### PR TITLE
Add secondary sort by start time for events on same day

### DIFF
--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -180,13 +180,20 @@ export function HarelineView({
   }, [events, view, timeFilter, scope, subscribedKennelIds, selectedRegions, selectedKennels, selectedDays]);
 
   // Sort: upcoming = ascending (nearest first), past = descending (most recent first)
+  // Secondary sort by startTime within the same day (events without time go last)
   const sortedEvents = useMemo(() => {
     const sorted = [...filteredEvents];
-    if (timeFilter === "upcoming") {
-      sorted.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-    } else {
-      sorted.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-    }
+    sorted.sort((a, b) => {
+      const dateA = new Date(a.date).getTime();
+      const dateB = new Date(b.date).getTime();
+      const dateDiff = timeFilter === "upcoming" ? dateA - dateB : dateB - dateA;
+      if (dateDiff !== 0) return dateDiff;
+      // Same date — sort by startTime ("HH:MM" string), nulls last
+      if (!a.startTime && !b.startTime) return 0;
+      if (!a.startTime) return 1;
+      if (!b.startTime) return -1;
+      return a.startTime.localeCompare(b.startTime);
+    });
     return sorted;
   }, [filteredEvents, timeFilter]);
 


### PR DESCRIPTION
## Summary
Enhanced the event sorting logic in HarelineView to include a secondary sort by start time when events fall on the same date. This ensures a more intuitive ordering where events are grouped by date and then ordered chronologically within each day.

## Key Changes
- Modified the `sortedEvents` sorting comparator to implement a two-level sort:
  - Primary: Sort by date (ascending for upcoming events, descending for past events)
  - Secondary: Sort by `startTime` string when dates are equal, with events lacking a start time placed last
- Updated the sort logic to handle null/undefined `startTime` values gracefully, ensuring events without times don't break the sort order

## Implementation Details
- The secondary sort uses `localeCompare()` for string-based time comparison, which correctly orders "HH:MM" formatted times lexicographically
- Events without a `startTime` are explicitly handled to appear after events with times on the same date
- The change maintains backward compatibility with the existing primary date-based sorting behavior

https://claude.ai/code/session_01GJfqAw4STHh5bWhsv167MS