### PR TITLE
Add "Refresh All" button to Manage Sources page

### DIFF
--- a/src/app/admin/sources/page.tsx
+++ b/src/app/admin/sources/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db";
 import { SourceTable } from "@/components/admin/SourceTable";
 import { SourceForm } from "@/components/admin/SourceForm";
+import { RefreshAllButton } from "@/components/admin/RefreshAllButton";
 import { Button } from "@/components/ui/button";
 
 export default async function AdminSourcesPage() {
@@ -43,10 +44,13 @@ export default async function AdminSourcesPage() {
     <div>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold">Manage Sources</h2>
-        <SourceForm
-          allKennels={allKennels}
-          trigger={<Button size="sm">Add Source</Button>}
-        />
+        <div className="flex items-center gap-2">
+          <RefreshAllButton />
+          <SourceForm
+            allKennels={allKennels}
+            trigger={<Button size="sm">Add Source</Button>}
+          />
+        </div>
       </div>
 
       <SourceTable sources={serialized} allKennels={allKennels} />

--- a/src/app/api/admin/scrape-all/route.ts
+++ b/src/app/api/admin/scrape-all/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { getAdminUser } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { scrapeSource } from "@/pipeline/scrape";
+
+export async function POST() {
+  const admin = await getAdminUser();
+  if (!admin) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 403 });
+  }
+
+  const sources = await prisma.source.findMany({
+    select: { id: true, name: true, scrapeDays: true },
+  });
+
+  // Scrape each source sequentially to avoid rate-limiting external APIs
+  const results = [];
+  for (const source of sources) {
+    try {
+      const result = await scrapeSource(source.id, { days: source.scrapeDays });
+      results.push({ sourceId: source.id, name: source.name, ...result });
+    } catch (err) {
+      results.push({
+        sourceId: source.id,
+        name: source.name,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const succeeded = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  return NextResponse.json({
+    success: failed === 0,
+    summary: { total: sources.length, succeeded, failed },
+    sources: results,
+  });
+}

--- a/src/components/admin/RefreshAllButton.tsx
+++ b/src/components/admin/RefreshAllButton.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+export function RefreshAllButton() {
+  const [isScraping, setIsScraping] = useState(false);
+  const router = useRouter();
+
+  async function handleRefreshAll() {
+    setIsScraping(true);
+    try {
+      const res = await fetch("/api/admin/scrape-all", { method: "POST" });
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error || "Refresh failed");
+      } else {
+        const { summary } = data;
+        toast.success(
+          `Refresh complete: ${summary.succeeded}/${summary.total} sources succeeded` +
+            (summary.failed > 0 ? `, ${summary.failed} failed` : ""),
+        );
+        if (summary.failed > 0) {
+          const failedNames = data.sources
+            .filter((s: { success: boolean }) => !s.success)
+            .map((s: { name: string }) => s.name)
+            .join(", ");
+          toast.error(`Failed: ${failedNames}`);
+        }
+      }
+      router.refresh();
+    } catch {
+      toast.error("Refresh request failed");
+    } finally {
+      setIsScraping(false);
+    }
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={isScraping}
+      onClick={handleRefreshAll}
+    >
+      {isScraping ? "Refreshing..." : "Refresh All"}
+    </Button>
+  );
+}


### PR DESCRIPTION
Adds a button next to "Add Source" that scrapes all sources sequentially, showing progress and a summary toast on completion.

- New API route POST /api/admin/scrape-all (admin-authed, scrapes all sources using each source's configured scrapeDays)
- New RefreshAllButton client component with loading state
- Wired into the sources page header

https://claude.ai/code/session_01GJfqAw4STHh5bWhsv167MS