### PR TITLE
Add expand/collapse to kennel detail event sections

### DIFF
--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -18,7 +18,8 @@ export async function generateMetadata({
 import { getOrCreateUser } from "@/lib/auth";
 import { Badge } from "@/components/ui/badge";
 import { SubscribeButton } from "@/components/kennels/SubscribeButton";
-import { EventCard, type HarelineEvent } from "@/components/hareline/EventCard";
+import type { HarelineEvent } from "@/components/hareline/EventCard";
+import { CollapsibleEventList } from "@/components/kennels/CollapsibleEventList";
 
 export default async function KennelDetailPage({
   params,
@@ -144,11 +145,7 @@ export default async function KennelDetailPage({
         {upcoming.length === 0 ? (
           <p className="text-sm text-muted-foreground">No upcoming events.</p>
         ) : (
-          <div className="space-y-3">
-            {upcoming.map((event) => (
-              <EventCard key={event.id} event={event} density="medium" />
-            ))}
-          </div>
+          <CollapsibleEventList events={upcoming} defaultLimit={4} label="upcoming" />
         )}
       </div>
 
@@ -156,16 +153,7 @@ export default async function KennelDetailPage({
       {past.length > 0 && (
         <div>
           <h2 className="mb-3 text-lg font-semibold">Past Events</h2>
-          <div className="space-y-3">
-            {past.slice(0, 10).map((event) => (
-              <EventCard key={event.id} event={event} density="medium" />
-            ))}
-            {past.length > 10 && (
-              <p className="text-sm text-muted-foreground">
-                And {past.length - 10} more past events.
-              </p>
-            )}
-          </div>
+          <CollapsibleEventList events={past} defaultLimit={10} label="past" />
         </div>
       )}
     </div>

--- a/src/components/kennels/CollapsibleEventList.tsx
+++ b/src/components/kennels/CollapsibleEventList.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { EventCard, type HarelineEvent } from "@/components/hareline/EventCard";
+import { Button } from "@/components/ui/button";
+
+interface CollapsibleEventListProps {
+  events: HarelineEvent[];
+  defaultLimit: number;
+  label: string; // e.g. "upcoming" or "past"
+}
+
+export function CollapsibleEventList({
+  events,
+  defaultLimit,
+  label,
+}: CollapsibleEventListProps) {
+  const [expanded, setExpanded] = useState(false);
+  const hasMore = events.length > defaultLimit;
+  const visible = expanded ? events : events.slice(0, defaultLimit);
+
+  return (
+    <div className="space-y-3">
+      {visible.map((event) => (
+        <EventCard key={event.id} event={event} density="medium" />
+      ))}
+      {hasMore && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-sm text-muted-foreground hover:text-foreground"
+          onClick={() => setExpanded(!expanded)}
+        >
+          {expanded
+            ? "Show less"
+            : `Show ${events.length - defaultLimit} more ${label} events`}
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Upcoming Events now shows only the first 4 with a "Show X more upcoming events" toggle. Past Events keeps its 10-event default but replaces the static "And X more" text with an interactive toggle button. Both collapse back with "Show less".

- New CollapsibleEventList client component (reusable)
- Kennel detail page wired to use it for both sections
- All data already fetched server-side, toggle is purely client-side

https://claude.ai/code/session_01GJfqAw4STHh5bWhsv167MS