### PR TITLE
Improve attendance form accessibility and mobile responsiveness

### DIFF
--- a/docs/misman-attendance-requirements.md
+++ b/docs/misman-attendance-requirements.md
@@ -232,6 +232,8 @@ The primary interface — designed for use at trail on a phone.
 - Quick-add: if the hasher isn't in the roster, create a new KennelHasher inline from the form
 - Per-hasher toggles: paid, hare, virgin, visitor
 - Visitor sub-fields: location and referral source (shown only when visitor or virgin is checked)
+- **Responsive row layout**: on mobile (<640px), attendee rows wrap into two lines — full name on the first line (no truncation), toggle switches on the second line. On larger screens, single-line layout with truncation.
+- **Accessible toggles**: $, H, V, Vis toggle switches have `title` tooltips and contextual `aria-label` attributes for screen readers
 - **Live view**: multiple mismans recording the same event see each other's additions in near real-time via polling (see [Concurrency](#10-concurrency))
 
 ### 2. Kennel Roster Management
@@ -597,3 +599,4 @@ await prisma.$transaction([
 | 31 | Verification participationLevel | haredThisTrail→HARE, else RUN; user can edit their Attendance record afterward |
 | 32 | Roster Group management | Site admin only for MVP; MISMAN self-service group requests deferred |
 | 33 | Group formation | Duplicate scan run when a kennel joins a group; merge candidates surfaced to admin |
+| 34 | Event dropdown scope on attendance page | Event selector on `/misman/[slug]/attendance` shows only events for the kennel in the URL, not all roster group kennels. Prevents confusion when managing a kennel that shares a roster group (e.g., NYCH3 page only shows NYCH3 events). Roster group scope is still used for roster/search — this change only affects the event dropdown. |

--- a/docs/misman-implementation-plan.md
+++ b/docs/misman-implementation-plan.md
@@ -99,6 +99,11 @@ No roadmap dependencies — this feature is independent of the unfinished source
 
 **Polling**: `useEffect` + `setInterval(4000)` calling `getEventAttendance`, silent on failure (mobile network tolerance)
 
+**UX Fixes (post-MVP polish):**
+- `AttendanceRow` — Responsive two-line layout on mobile (name on first line, toggles on second) to prevent name truncation
+- `AttendanceRow` — Tooltip (`title`) and `aria-label` attributes on $, H, V, Vis toggle switches for accessibility
+- `EventSelector` — Event dropdown filtered to current kennel only (not full roster group scope); keeps event selection focused when managing a specific kennel
+
 ---
 
 ### Sprint 8d: History + Hasher Detail + Roster Seeding ✅

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -220,7 +220,7 @@ See [misman-attendance-requirements.md](misman-attendance-requirements.md) for f
 - [x] **Side panel on desktop**: Day detail panel as sticky sidebar on large screens
 
 ### Remaining Polish
-- [ ] Mobile responsiveness pass
+- [x] Mobile responsiveness pass (attendance form: responsive row layout, name truncation fix)
 - [ ] Performance: pagination, React Query caching
 - [ ] Rate limiting on public API routes
 - [ ] Double-header handling (same kennel, same day, two events)

--- a/src/app/misman/[slug]/attendance/page.tsx
+++ b/src/app/misman/[slug]/attendance/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getMismanUser, getRosterKennelIds } from "@/lib/auth";
+import { getMismanUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { AttendanceForm } from "@/components/misman/AttendanceForm";
 
@@ -19,15 +19,13 @@ export default async function AttendancePage({ params }: Props) {
   const user = await getMismanUser(kennel.id);
   if (!user) notFound();
 
-  const rosterKennelIds = await getRosterKennelIds(kennel.id);
-
-  // Get events for the last year across roster scope
+  // Get events for the last year for this kennel
   const oneYearAgo = new Date();
   oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
 
   const events = await prisma.event.findMany({
     where: {
-      kennelId: { in: rosterKennelIds },
+      kennelId: kennel.id,
       date: { gte: oneYearAgo },
     },
     select: {

--- a/src/components/misman/AttendanceRow.tsx
+++ b/src/components/misman/AttendanceRow.tsx
@@ -52,9 +52,9 @@ export function AttendanceRow({
   return (
     <div className="rounded-lg border p-3 space-y-2">
       {/* Main row */}
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <button
-          className="flex-1 text-left text-sm font-medium truncate"
+          className="w-full sm:w-auto sm:flex-1 text-left text-sm font-medium sm:truncate"
           onClick={() => setExpanded(!expanded)}
         >
           {displayName}
@@ -67,48 +67,52 @@ export function AttendanceRow({
 
         {/* Quick toggles */}
         <div className="flex items-center gap-3 text-xs">
-          <label className="flex items-center gap-1 cursor-pointer">
+          <label className="flex items-center gap-1 cursor-pointer" title="Paid">
             <Switch
               checked={record.paid}
               onCheckedChange={(v) => onUpdate({ paid: v })}
               disabled={disabled}
               className="scale-75"
+              aria-label={`Mark ${displayName} as paid`}
             />
             <span className={record.paid ? "text-green-600 font-medium" : "text-muted-foreground"}>
               $
             </span>
           </label>
 
-          <label className="flex items-center gap-1 cursor-pointer">
+          <label className="flex items-center gap-1 cursor-pointer" title="Hare">
             <Switch
               checked={record.haredThisTrail}
               onCheckedChange={(v) => onUpdate({ haredThisTrail: v })}
               disabled={disabled}
               className="scale-75"
+              aria-label={`Mark ${displayName} as hare`}
             />
             <span className={record.haredThisTrail ? "text-orange-600 font-medium" : "text-muted-foreground"}>
               H
             </span>
           </label>
 
-          <label className="flex items-center gap-1 cursor-pointer">
+          <label className="flex items-center gap-1 cursor-pointer" title="Virgin">
             <Switch
               checked={record.isVirgin}
               onCheckedChange={(v) => onUpdate({ isVirgin: v })}
               disabled={disabled}
               className="scale-75"
+              aria-label={`Mark ${displayName} as virgin`}
             />
             <span className={record.isVirgin ? "text-pink-600 font-medium" : "text-muted-foreground"}>
               V
             </span>
           </label>
 
-          <label className="flex items-center gap-1 cursor-pointer">
+          <label className="flex items-center gap-1 cursor-pointer" title="Visitor">
             <Switch
               checked={record.isVisitor}
               onCheckedChange={(v) => onUpdate({ isVisitor: v })}
               disabled={disabled}
               className="scale-75"
+              aria-label={`Mark ${displayName} as visitor`}
             />
             <span className={record.isVisitor ? "text-blue-600 font-medium" : "text-muted-foreground"}>
               Vis


### PR DESCRIPTION
## Summary
This PR enhances the attendance form UI with better mobile responsiveness and accessibility features, and simplifies event filtering to be kennel-specific rather than roster-group-wide.

## Key Changes

### AttendanceRow Component
- **Responsive layout**: Changed main row to use `flex-wrap` with responsive width classes (`w-full sm:w-auto sm:flex-1`) so the attendee name displays on its own line on mobile without truncation, with toggle switches wrapping to a second line
- **Accessibility improvements**: Added `title` attributes (tooltips) and `aria-label` attributes to all four toggle switches ($, H, V, Vis) for better screen reader support and hover hints

### Event Filtering Scope
- **Simplified kennel scope**: Removed `getRosterKennelIds()` calls from both attendance pages (`/misman/[slug]/attendance` and `/misman/[slug]/attendance/[eventId]`)
- **Direct kennel matching**: Changed event queries to filter by `kennelId: kennel.id` instead of `kennelId: { in: rosterKennelIds }`, ensuring the event dropdown only shows events for the specific kennel being managed
- This prevents confusion when a kennel is part of a roster group — users now see only their kennel's events, not all group events

### Documentation
- Updated implementation plan and requirements docs to reflect the responsive layout and accessibility improvements
- Added decision note (item #34) explaining the event dropdown scope change and its rationale

## Implementation Details
- Mobile breakpoint uses Tailwind's `sm:` prefix (640px) to determine single vs. two-line layout
- Accessibility labels are contextual, including the hasher's display name for clarity
- Event filtering change is backward-compatible; roster group scope is still used for roster/search features

https://claude.ai/code/session_017f4SmezMtWE4C25TYRTtXZ