### PR TITLE
Refactor AttendanceRow to use data-driven expansion state

### DIFF
--- a/src/components/misman/AttendanceRow.tsx
+++ b/src/components/misman/AttendanceRow.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
@@ -45,25 +44,21 @@ export function AttendanceRow({
   onRemove,
   disabled,
 }: AttendanceRowProps) {
-  const [expanded, setExpanded] = useState(false);
   const displayName = record.hashName || record.nerdName || "Unknown";
-  const showVisitorFields = record.isVirgin || record.isVisitor;
+  const isExpanded = record.isVirgin || record.isVisitor;
 
   return (
-    <div className="rounded-lg border p-3 space-y-2">
+    <div className={`rounded-lg border p-3 space-y-2${isExpanded ? (record.isVisitor ? " border-l-2 border-l-blue-400" : " border-l-2 border-l-pink-400") : ""}`}>
       {/* Main row */}
       <div className="flex flex-wrap items-center gap-2">
-        <button
-          className="w-full sm:w-auto sm:flex-1 text-left text-sm font-medium sm:truncate"
-          onClick={() => setExpanded(!expanded)}
-        >
+        <span className="w-full sm:w-auto sm:flex-1 text-left text-sm font-medium sm:truncate">
           {displayName}
           {record.hashName && record.nerdName && (
             <span className="ml-1 text-muted-foreground font-normal">
               ({record.nerdName})
             </span>
           )}
-        </button>
+        </span>
 
         {/* Quick toggles */}
         <div className="flex items-center gap-3 text-xs">
@@ -133,7 +128,7 @@ export function AttendanceRow({
       </div>
 
       {/* Expanded visitor/referral fields */}
-      {expanded && showVisitorFields && (
+      {isExpanded && (
         <div className="pl-2 space-y-2 text-sm border-l-2 ml-1">
           {record.isVisitor && (
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
Refactored the `AttendanceRow` component to derive the expanded state from the record data instead of managing it with local component state. This simplifies the component logic and makes the expansion behavior data-driven.

## Key Changes
- Removed `useState` hook and local `expanded` state management
- Changed expansion logic to be based on `record.isVirgin` or `record.isVisitor` properties
- Renamed `showVisitorFields` to `isExpanded` to better reflect its dual purpose
- Converted the expandable button element to a non-interactive span since expansion is now automatic
- Added visual indicators (colored left borders) to distinguish between visitor (blue) and virgin (pink) records when expanded
- Simplified the conditional rendering of visitor/referral fields to only check `isExpanded`

## Implementation Details
- The expansion state is now determined by the data model rather than user interaction, making the component more predictable
- Visual feedback is provided through border styling that changes based on the record type
- The display name is no longer clickable, as the expanded state is automatically determined by the record properties

https://claude.ai/code/session_01DAQCjsMbUPrLsPwUa9ZcUa