### PR TITLE
Add smart suggestions, user linking, and verification for misman

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ calendar + personal logbook + kennel directory.
 ## Quick Commands
 - `npm run dev` — Start local dev server (http://localhost:3000)
 - `npm run build` — Production build
-- `npm test` — Run test suite (Vitest, 416 tests)
+- `npm test` — Run test suite (Vitest, 471 tests)
 - `npx prisma studio` — Visual database browser
 - `npx prisma db push` — Push schema changes to dev DB
 - `npx prisma migrate dev` — Create migration
@@ -84,12 +84,18 @@ calendar + personal logbook + kennel directory.
 - `src/app/admin/misman-requests/page.tsx` — Admin misman request approval (reuses misman server actions)
 - `src/components/admin/AlertCard.tsx` — Alert card with repair actions, context display, repair history
 - `src/app/misman/actions.ts` — Misman request/approve/reject server actions (used by both /misman and /admin)
-- `src/app/misman/[slug]/roster/actions.ts` — Roster CRUD + search (roster group scope)
-- `src/app/misman/[slug]/attendance/actions.ts` — Attendance recording, polling, quick-add
+- `src/app/misman/[slug]/roster/actions.ts` — Roster CRUD + search + user linking (roster group scope)
+- `src/app/misman/[slug]/attendance/actions.ts` — Attendance recording, polling, quick-add, smart suggestions
 - `src/app/misman/[slug]/history/actions.ts` — Attendance history, hasher detail, roster seeding from hares
+- `src/lib/misman/suggestions.ts` — Smart suggestion scoring algorithm (pure function: frequency/recency/streak)
+- `src/lib/misman/verification.ts` — Derived verification status (verified/misman-only/user-only/none)
 - `src/components/misman/KennelSwitcher.tsx` — Kennel dropdown switcher for misman layout (preserves active tab)
+- `src/components/misman/UserLinkSection.tsx` — User linking UI (suggest, dismiss, revoke) on hasher detail
+- `src/components/misman/SuggestionList.tsx` — Tap-to-add suggestion chips on attendance form
+- `src/components/misman/VerificationBadge.tsx` — Verification status badge (V/M/U) on attendance rows
+- `src/components/logbook/PendingConfirmations.tsx` — Pending misman confirmations on logbook page
 - `src/components/ui/alert-dialog.tsx` — Radix AlertDialog wrapper (confirmation dialogs)
-- `src/lib/fuzzy.ts` — Levenshtein-based fuzzy string matching for kennel tag resolution
+- `src/lib/fuzzy.ts` — Levenshtein-based fuzzy string matching for kennel tag resolution + pairwise name matching
 - `vercel.json` — Vercel Cron config (daily scrape at 6:00 AM UTC)
 - `vitest.config.ts` — Test runner config (globals, path aliases)
 - `src/test/factories.ts` — Shared test data builders
@@ -115,7 +121,7 @@ See `docs/roadmap.md` for implementation roadmap.
 ## Testing
 - **Framework:** Vitest with `globals: true` (no explicit imports needed)
 - **Config:** `vitest.config.ts` — path alias `@/` maps to `./src`
-- **Run:** `npm test` (416 tests across 24 files)
+- **Run:** `npm test` (471 tests across 30 files)
 - **Factories:** `src/test/factories.ts` — shared builders (`buildRawEvent`, `buildCalendarEvent`, `mockUser`)
 - **Mocking pattern:** `vi.mock("@/lib/db")` + `vi.mocked(prisma.model.method)` with `as never` for partial returns
 - **Exported helpers:** Pure functions in adapters/pipeline are exported for direct unit testing (additive-only, no behavior change)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 Living document tracking what's been built, what's next, and where we're headed.
 
-Last updated: 2026-02-14
+Last updated: 2026-02-15
 
 ---
 
@@ -156,7 +156,7 @@ Last updated: 2026-02-14
 - [ ] **Admin-editable participation levels**: Migrate enum to reference table for custom levels per community
 - [ ] **"Beez There" checkbox**: Optional flag on attendance (nice-to-have, deferred from Sprint 5)
 
-### Kennel Attendance Management (Misman Tool) — Sprints 8a-8d COMPLETE
+### Kennel Attendance Management (Misman Tool) — Sprints 8a-8e COMPLETE
 **Goal**: Replace kennel mismanagement's Google Sheet attendance tracking with a dedicated tool tied to HashTracks events.
 
 See [misman-attendance-requirements.md](misman-attendance-requirements.md) for full requirements and decisions log.
@@ -170,10 +170,12 @@ See [misman-implementation-plan.md](misman-implementation-plan.md) for detailed 
 - [x] **Per-attendance fields**: paid (boolean), hare (boolean), virgin (manual annotation), visitor (with location), referral source (dropdown)
 - [x] **Attendance history**: Per-event and per-hasher views with date filtering and pagination
 - [x] **UX polish**: Confirmation dialogs (AlertDialog) for destructive actions, kennel switcher dropdown, History links on dashboard, semantic toggle colors
-- [ ] **Smart suggestions**: Surface frequent/regular/recent attendees at top of form for fast population
-- [ ] **User linking**: Fuzzy-match suggestions for linking KennelHasher → site User, misman manually confirms
-- [ ] **Logbook sync**: Pending confirmations section on `/logbook` for linked users (suggest-and-confirm, no auto-sync)
+- [x] **Smart suggestions**: Weighted scoring (50% frequency + 30% recency + 20% streak) surfaces likely attendees as tap-to-add chips on attendance form
+- [x] **User linking**: Fuzzy-match (Levenshtein, ≥0.7 threshold) for linking KennelHasher → site User; suggest/confirm/dismiss/revoke workflow
+- [x] **Logbook sync**: Pending confirmations section on `/logbook` for linked users (confirm creates logbook entry with isVerified=true)
+- [x] **Verification badges**: Derived verification status (verified/misman-only/user-only) shown on hasher detail attendance rows
 - [ ] **CSV export**: Export attendance history to CSV
+- **Pending**: Sprint 8f — roster group admin UI, duplicate merge workflow
 - **Deferred**: Hash cash amounts, auto-detect virgins, hare→EventHare sync, cross-kennel directory, historical CSV import, notification system
 
 ### CSV Import (Bulk History)

--- a/src/app/logbook/page.tsx
+++ b/src/app/logbook/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getOrCreateUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { LogbookList } from "@/components/logbook/LogbookList";
+import { PendingConfirmations } from "@/components/logbook/PendingConfirmations";
 
 export const metadata: Metadata = {
   title: "My Logbook · HashTracks",
@@ -66,7 +67,8 @@ export default async function LogbookPage() {
         </Link>
       </div>
 
-      <div className="mt-6">
+      <div className="mt-6 space-y-6">
+        <PendingConfirmations />
         <LogbookList entries={entries} />
       </div>
     </div>

--- a/src/app/misman/[slug]/roster/page.tsx
+++ b/src/app/misman/[slug]/roster/page.tsx
@@ -27,6 +27,7 @@ export default async function RosterPage({ params }: Props) {
     include: {
       _count: { select: { attendances: true } },
       kennel: { select: { shortName: true } },
+      userLink: { select: { status: true } },
     },
     orderBy: [{ hashName: "asc" }, { nerdName: "asc" }],
   });
@@ -41,6 +42,7 @@ export default async function RosterPage({ params }: Props) {
     phone: h.phone,
     notes: h.notes,
     attendanceCount: h._count.attendances,
+    linkStatus: h.userLink?.status ?? null,
   }));
 
   const isSharedRoster = rosterKennelIds.length > 1;

--- a/src/components/logbook/PendingConfirmations.tsx
+++ b/src/components/logbook/PendingConfirmations.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useEffect, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import {
+  getPendingConfirmations,
+  confirmMismanAttendance,
+} from "@/app/logbook/actions";
+
+interface PendingRecord {
+  kennelAttendanceId: string;
+  eventId: string;
+  eventDate: string;
+  eventTitle: string | null;
+  runNumber: number | null;
+  kennelShortName: string;
+  haredThisTrail: boolean;
+}
+
+export function PendingConfirmations() {
+  const [pending, setPending] = useState<PendingRecord[]>([]);
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [loaded, setLoaded] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  useEffect(() => {
+    getPendingConfirmations().then((result) => {
+      if (result.data) setPending(result.data);
+      setLoaded(true);
+    });
+
+    // Restore dismissed IDs from localStorage
+    try {
+      const stored = localStorage.getItem("dismissed-misman-confirmations");
+      if (stored) setDismissed(new Set(JSON.parse(stored)));
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, []);
+
+  function handleConfirm(kennelAttendanceId: string) {
+    startTransition(async () => {
+      const result = await confirmMismanAttendance(kennelAttendanceId);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Added to your logbook");
+        setPending((prev) =>
+          prev.filter((p) => p.kennelAttendanceId !== kennelAttendanceId),
+        );
+        router.refresh();
+      }
+    });
+  }
+
+  function handleDismiss(kennelAttendanceId: string) {
+    const next = new Set(dismissed);
+    next.add(kennelAttendanceId);
+    setDismissed(next);
+    try {
+      localStorage.setItem(
+        "dismissed-misman-confirmations",
+        JSON.stringify([...next]),
+      );
+    } catch {
+      // Ignore localStorage errors
+    }
+  }
+
+  const visible = pending.filter((p) => !dismissed.has(p.kennelAttendanceId));
+
+  if (!loaded || visible.length === 0) return null;
+
+  function formatDate(iso: string) {
+    return new Date(iso).toLocaleDateString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      timeZone: "America/New_York",
+    });
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold">
+        Pending Confirmations ({visible.length})
+      </h3>
+      <p className="text-xs text-muted-foreground">
+        A misman recorded your attendance at these events. Confirm to add them
+        to your logbook.
+      </p>
+      <div className="space-y-2">
+        {visible.map((p) => (
+          <div
+            key={p.kennelAttendanceId}
+            className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 text-sm">
+                <Badge variant="outline" className="shrink-0 text-xs">
+                  {p.kennelShortName}
+                </Badge>
+                <span className="font-medium truncate">
+                  {p.runNumber ? `#${p.runNumber}` : ""}
+                  {p.runNumber && p.eventTitle ? " — " : ""}
+                  {p.eventTitle || (p.runNumber ? "" : "Untitled")}
+                </span>
+                {p.haredThisTrail && (
+                  <span className="text-xs text-orange-600 shrink-0">Hare</span>
+                )}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {formatDate(p.eventDate)}
+              </div>
+            </div>
+            <div className="flex gap-1 shrink-0">
+              <Button
+                size="sm"
+                variant="default"
+                className="h-7 text-xs"
+                onClick={() => handleConfirm(p.kennelAttendanceId)}
+                disabled={isPending}
+              >
+                Confirm
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs"
+                onClick={() => handleDismiss(p.kennelAttendanceId)}
+              >
+                Dismiss
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/misman/HasherDetail.tsx
+++ b/src/components/misman/HasherDetail.tsx
@@ -7,6 +7,9 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { deleteKennelHasher } from "@/app/misman/[slug]/roster/actions";
 import { HasherForm } from "./HasherForm";
+import { UserLinkSection } from "./UserLinkSection";
+import { VerificationBadge } from "./VerificationBadge";
+import type { VerificationStatus } from "@/lib/misman/verification";
 
 interface AttendanceEntry {
   id: string;
@@ -20,6 +23,7 @@ interface AttendanceEntry {
   isVirgin: boolean;
   isVisitor: boolean;
   createdAt: string;
+  verificationStatus?: VerificationStatus;
 }
 
 interface HasherData {
@@ -33,6 +37,7 @@ interface HasherData {
   notes: string | null;
   createdAt: string;
   userLink: {
+    id: string;
     status: string;
     userHashName: string | null;
     userEmail: string;
@@ -179,13 +184,18 @@ export function HasherDetail({ hasher, kennelSlug }: HasherDetailProps) {
         </div>
       )}
 
-      {/* Linked user info */}
-      {hasher.userLink && hasher.userLink.status === "CONFIRMED" && (
-        <div className="rounded-lg border p-3 text-sm">
-          <span className="text-muted-foreground">Linked to user:</span>{" "}
-          {hasher.userLink.userHashName || hasher.userLink.userEmail}
-        </div>
-      )}
+      {/* User linking */}
+      <UserLinkSection
+        kennelId={hasher.kennelId}
+        kennelHasherId={hasher.id}
+        userLink={hasher.userLink ? {
+          id: hasher.userLink.id,
+          status: hasher.userLink.status,
+          userHashName: hasher.userLink.userHashName,
+          userEmail: hasher.userLink.userEmail,
+        } : null}
+        hasherDisplayName={displayName}
+      />
 
       {/* Attendance history */}
       <div>
@@ -219,6 +229,9 @@ export function HasherDetail({ hasher, kennelSlug }: HasherDetailProps) {
                   </div>
                 </div>
                 <div className="flex gap-1 shrink-0">
+                  {a.verificationStatus && a.verificationStatus !== "none" && (
+                    <VerificationBadge status={a.verificationStatus} />
+                  )}
                   {a.paid && (
                     <span className="text-xs text-green-600" title="Paid">
                       $

--- a/src/components/misman/RosterTable.tsx
+++ b/src/components/misman/RosterTable.tsx
@@ -30,6 +30,7 @@ interface HasherRow {
   phone: string | null;
   notes: string | null;
   attendanceCount: number;
+  linkStatus?: string | null;
 }
 
 interface RosterTableProps {
@@ -183,14 +184,22 @@ export function RosterTable({
               sorted.map((h) => (
                 <tr key={h.id} className="border-b last:border-0">
                   <td className="px-3 py-2 font-medium">
-                    <Link
-                      href={`/misman/${kennelSlug}/roster/${h.id}`}
-                      className="hover:underline"
-                    >
-                      {h.hashName || (
-                        <span className="text-muted-foreground italic">—</span>
+                    <div className="flex items-center gap-1.5">
+                      <Link
+                        href={`/misman/${kennelSlug}/roster/${h.id}`}
+                        className="hover:underline"
+                      >
+                        {h.hashName || (
+                          <span className="text-muted-foreground italic">—</span>
+                        )}
+                      </Link>
+                      {h.linkStatus === "CONFIRMED" && (
+                        <span className="text-xs text-green-600" title="Linked to user">L</span>
                       )}
-                    </Link>
+                      {h.linkStatus === "SUGGESTED" && (
+                        <span className="text-xs text-yellow-600" title="Link pending">P</span>
+                      )}
+                    </div>
                   </td>
                   <td className="px-3 py-2 text-muted-foreground">
                     {h.nerdName || "—"}

--- a/src/components/misman/SuggestionList.tsx
+++ b/src/components/misman/SuggestionList.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+interface SuggestionItem {
+  kennelHasherId: string;
+  hashName: string | null;
+  nerdName: string | null;
+  score: number;
+}
+
+interface SuggestionListProps {
+  suggestions: SuggestionItem[];
+  attendedHasherIds: Set<string>;
+  onSelect: (hasherId: string) => void;
+  disabled?: boolean;
+}
+
+export function SuggestionList({
+  suggestions,
+  attendedHasherIds,
+  onSelect,
+  disabled,
+}: SuggestionListProps) {
+  const available = suggestions.filter(
+    (s) => !attendedHasherIds.has(s.kennelHasherId),
+  );
+
+  if (available.length === 0) return null;
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-muted-foreground">Suggestions</p>
+      <div className="flex flex-wrap gap-1.5">
+        {available.map((s) => (
+          <Button
+            key={s.kennelHasherId}
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => onSelect(s.kennelHasherId)}
+            disabled={disabled}
+          >
+            {s.hashName || s.nerdName}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/misman/UserLinkSection.tsx
+++ b/src/components/misman/UserLinkSection.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import {
+  suggestUserLinks,
+  createUserLink,
+  dismissUserLink,
+  revokeUserLink,
+} from "@/app/misman/[slug]/roster/actions";
+
+interface UserLinkData {
+  id: string;
+  status: string;
+  userHashName: string | null;
+  userEmail: string;
+}
+
+interface LinkSuggestion {
+  userId: string;
+  userHashName: string | null;
+  userEmail: string;
+  matchScore: number;
+  matchField: string;
+}
+
+interface UserLinkSectionProps {
+  kennelId: string;
+  kennelHasherId: string;
+  userLink: UserLinkData | null;
+  hasherDisplayName: string;
+}
+
+export function UserLinkSection({
+  kennelId,
+  kennelHasherId,
+  userLink,
+  hasherDisplayName,
+}: UserLinkSectionProps) {
+  const [suggestions, setSuggestions] = useState<LinkSuggestion[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function handleFindLinks() {
+    startTransition(async () => {
+      const result = await suggestUserLinks(kennelId);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      const matches = (result.data ?? []).filter(
+        (s) => s.kennelHasherId === kennelHasherId,
+      );
+      if (matches.length === 0) {
+        toast.info("No matching users found");
+      } else {
+        setSuggestions(matches);
+        setShowSuggestions(true);
+      }
+    });
+  }
+
+  function handleCreateLink(userId: string) {
+    startTransition(async () => {
+      const result = await createUserLink(kennelId, kennelHasherId, userId);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Link suggestion created");
+        setShowSuggestions(false);
+        router.refresh();
+      }
+    });
+  }
+
+  function handleDismiss() {
+    if (!userLink) return;
+    startTransition(async () => {
+      const result = await dismissUserLink(kennelId, userLink.id);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Link dismissed");
+        router.refresh();
+      }
+    });
+  }
+
+  function handleRevoke() {
+    if (!userLink) return;
+    startTransition(async () => {
+      const result = await revokeUserLink(kennelId, userLink.id);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Link revoked");
+        setShowRevokeConfirm(false);
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <h3 className="text-sm font-semibold">User Link</h3>
+
+      {/* No link */}
+      {(!userLink || userLink.status === "DISMISSED") && (
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-muted-foreground">
+            Not linked to a site user
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleFindLinks}
+            disabled={isPending}
+          >
+            {isPending ? "Searching..." : "Find Match"}
+          </Button>
+        </div>
+      )}
+
+      {/* Suggested */}
+      {userLink && userLink.status === "SUGGESTED" && (
+        <div className="flex items-center gap-3 flex-wrap">
+          <Badge variant="secondary">Pending</Badge>
+          <span className="text-sm">
+            Suggested link to{" "}
+            <strong>{userLink.userHashName || userLink.userEmail}</strong>
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-destructive"
+            onClick={handleDismiss}
+            disabled={isPending}
+          >
+            Dismiss
+          </Button>
+        </div>
+      )}
+
+      {/* Confirmed */}
+      {userLink && userLink.status === "CONFIRMED" && (
+        <div className="flex items-center gap-3 flex-wrap">
+          <Badge>Linked</Badge>
+          <span className="text-sm">
+            Linked to{" "}
+            <strong>{userLink.userHashName || userLink.userEmail}</strong>
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-destructive"
+            onClick={() => setShowRevokeConfirm(true)}
+            disabled={isPending}
+          >
+            Revoke
+          </Button>
+        </div>
+      )}
+
+      {/* Suggestions list */}
+      {showSuggestions && suggestions.length > 0 && (
+        <div className="space-y-2 border-t pt-3">
+          <p className="text-xs font-medium text-muted-foreground">
+            Matching users:
+          </p>
+          {suggestions.map((s) => (
+            <div
+              key={s.userId}
+              className="flex items-center justify-between gap-2 rounded border px-3 py-2 text-sm"
+            >
+              <div>
+                <span className="font-medium">
+                  {s.userHashName || s.userEmail}
+                </span>
+                <span className="text-xs text-muted-foreground ml-2">
+                  ({Math.round(s.matchScore * 100)}% match via {s.matchField})
+                </span>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => handleCreateLink(s.userId)}
+                disabled={isPending}
+              >
+                Link
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Revoke confirmation */}
+      <AlertDialog open={showRevokeConfirm} onOpenChange={setShowRevokeConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke user link?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will unlink <strong>{hasherDisplayName}</strong> from their
+              site account. Attendance records will be preserved, but the user
+              will no longer see pending confirmations from this roster entry.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRevoke}
+              disabled={isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isPending ? "Revoking..." : "Revoke Link"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/misman/VerificationBadge.tsx
+++ b/src/components/misman/VerificationBadge.tsx
@@ -1,0 +1,38 @@
+import type { VerificationStatus } from "@/lib/misman/verification";
+
+interface VerificationBadgeProps {
+  status: VerificationStatus;
+}
+
+const config: Record<
+  VerificationStatus,
+  { label: string; className: string; title: string } | null
+> = {
+  verified: {
+    label: "V",
+    className: "text-green-600",
+    title: "Verified — recorded by misman and user",
+  },
+  "misman-only": {
+    label: "M",
+    className: "text-yellow-600",
+    title: "Misman only — not yet confirmed by user",
+  },
+  "user-only": {
+    label: "U",
+    className: "text-blue-600",
+    title: "User only — not recorded by misman",
+  },
+  none: null,
+};
+
+export function VerificationBadge({ status }: VerificationBadgeProps) {
+  const cfg = config[status];
+  if (!cfg) return null;
+
+  return (
+    <span className={`text-xs font-medium ${cfg.className}`} title={cfg.title}>
+      {cfg.label}
+    </span>
+  );
+}

--- a/src/lib/fuzzy.test.ts
+++ b/src/lib/fuzzy.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyNameMatch, fuzzyMatch } from "./fuzzy";
+
+describe("fuzzyNameMatch", () => {
+  it("returns 1 for exact match", () => {
+    expect(fuzzyNameMatch("Mudflap", "Mudflap")).toBe(1);
+  });
+
+  it("returns 1 for case-insensitive match", () => {
+    expect(fuzzyNameMatch("Mudflap", "mudflap")).toBe(1);
+    expect(fuzzyNameMatch("MUDFLAP", "mudflap")).toBe(1);
+  });
+
+  it("returns 1 for match with whitespace differences", () => {
+    expect(fuzzyNameMatch("  Mudflap  ", "Mudflap")).toBe(1);
+  });
+
+  it("returns high score for close names", () => {
+    const score = fuzzyNameMatch("Mudflap", "Mudflep");
+    expect(score).toBeGreaterThan(0.8);
+  });
+
+  it("returns low score for very different names", () => {
+    const score = fuzzyNameMatch("Mudflap", "Zephyr");
+    expect(score).toBeLessThan(0.4);
+  });
+
+  it("returns 0 when either string is empty", () => {
+    expect(fuzzyNameMatch("", "Mudflap")).toBe(0);
+    expect(fuzzyNameMatch("Mudflap", "")).toBe(0);
+    expect(fuzzyNameMatch("", "")).toBe(0);
+  });
+
+  it("returns 0 for whitespace-only input", () => {
+    expect(fuzzyNameMatch("   ", "Mudflap")).toBe(0);
+    expect(fuzzyNameMatch("Mudflap", "   ")).toBe(0);
+  });
+});

--- a/src/lib/fuzzy.ts
+++ b/src/lib/fuzzy.ts
@@ -1,6 +1,7 @@
 /**
- * Simple fuzzy string matching for kennel tag resolution.
+ * Fuzzy string matching utilities.
  * Levenshtein distance + substring boost, no external deps.
+ * Used for kennel tag resolution and user-to-hasher name matching.
  */
 
 function levenshtein(a: string, b: string): number {
@@ -25,6 +26,19 @@ function levenshtein(a: string, b: string): number {
   }
 
   return dp[la][lb];
+}
+
+/**
+ * Compare two names for similarity. Returns 0–1 (1 = exact match).
+ * Case-insensitive, trims whitespace. Used for user-to-hasher matching.
+ */
+export function fuzzyNameMatch(a: string, b: string): number {
+  const na = a.toLowerCase().trim();
+  const nb = b.toLowerCase().trim();
+  if (!na || !nb) return 0;
+  if (na === nb) return 1;
+  const maxLen = Math.max(na.length, nb.length);
+  return 1 - levenshtein(na, nb) / maxLen;
 }
 
 export interface FuzzyCandidate {

--- a/src/lib/misman/suggestions.test.ts
+++ b/src/lib/misman/suggestions.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeSuggestionScores,
+  SUGGESTION_THRESHOLD,
+  MIN_EVENTS_FOR_SUGGESTIONS,
+  type SuggestionInput,
+  type KennelEvent,
+  type AttendanceRecord,
+} from "./suggestions";
+
+const KENNEL_ID = "kennel-1";
+const REF_DATE = new Date("2026-02-15T12:00:00Z");
+
+function daysAgo(n: number): Date {
+  return new Date(REF_DATE.getTime() - n * 24 * 60 * 60 * 1000);
+}
+
+function makeEvents(count: number, startDaysAgo = 7): KennelEvent[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `event-${i}`,
+    date: daysAgo(startDaysAgo + i * 7), // weekly events
+  }));
+}
+
+function makeInput(overrides: Partial<SuggestionInput> = {}): SuggestionInput {
+  const kennelEvents = overrides.kennelEvents ?? makeEvents(6);
+  const eventKennelMap = new Map<string, string>();
+  for (const e of kennelEvents) {
+    eventKennelMap.set(e.id, KENNEL_ID);
+  }
+  return {
+    kennelId: KENNEL_ID,
+    rosterKennelIds: [KENNEL_ID],
+    kennelEvents,
+    attendanceRecords: [],
+    rosterHasherIds: [],
+    eventKennelMap,
+    ...overrides,
+  };
+}
+
+describe("computeSuggestionScores", () => {
+  it("returns empty array when no events exist", () => {
+    const result = computeSuggestionScores(
+      makeInput({ kennelEvents: [] }),
+      REF_DATE,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when fewer than MIN_EVENTS kennel events", () => {
+    const result = computeSuggestionScores(
+      makeInput({ kennelEvents: makeEvents(MIN_EVENTS_FOR_SUGGESTIONS - 1) }),
+      REF_DATE,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when no hashers in roster", () => {
+    const result = computeSuggestionScores(
+      makeInput({ rosterHasherIds: [] }),
+      REF_DATE,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("scores a perfect regular near 1.0", () => {
+    const events = makeEvents(6);
+    const records: AttendanceRecord[] = events.map((e) => ({
+      kennelHasherId: "hasher-1",
+      eventId: e.id,
+      eventDate: e.date,
+    }));
+
+    const result = computeSuggestionScores(
+      makeInput({
+        kennelEvents: events,
+        attendanceRecords: records,
+        rosterHasherIds: ["hasher-1"],
+      }),
+      REF_DATE,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kennelHasherId).toBe("hasher-1");
+    // frequency=1.0, recency≈1.0, streak=1.0 → score ≈ 1.0
+    expect(result[0].score).toBeGreaterThan(0.9);
+  });
+
+  it("scores a one-time attendee from long ago low", () => {
+    const events = makeEvents(6);
+    const records: AttendanceRecord[] = [
+      {
+        kennelHasherId: "hasher-1",
+        eventId: events[5].id, // oldest event (~42 days ago)
+        eventDate: events[5].date,
+      },
+    ];
+
+    const result = computeSuggestionScores(
+      makeInput({
+        kennelEvents: events,
+        attendanceRecords: records,
+        rosterHasherIds: ["hasher-1"],
+      }),
+      REF_DATE,
+    );
+
+    // frequency=1/6≈0.167, recency depends on date, streak=0 (gap at most recent)
+    // Should be below threshold or very low
+    if (result.length > 0) {
+      expect(result[0].score).toBeLessThan(0.4);
+    }
+  });
+
+  it("frequency is scoped to this kennel only", () => {
+    const events = makeEvents(4);
+    const otherKennelEvent: KennelEvent = {
+      id: "other-event-1",
+      date: daysAgo(3),
+    };
+
+    const eventKennelMap = new Map<string, string>();
+    for (const e of events) eventKennelMap.set(e.id, KENNEL_ID);
+    eventKennelMap.set("other-event-1", "kennel-2");
+
+    // Hasher only attended the other kennel's event
+    const records: AttendanceRecord[] = [
+      {
+        kennelHasherId: "hasher-1",
+        eventId: "other-event-1",
+        eventDate: otherKennelEvent.date,
+      },
+    ];
+
+    const result = computeSuggestionScores(
+      makeInput({
+        rosterKennelIds: [KENNEL_ID, "kennel-2"],
+        kennelEvents: events,
+        attendanceRecords: records,
+        rosterHasherIds: ["hasher-1"],
+        eventKennelMap,
+      }),
+      REF_DATE,
+    );
+
+    // Frequency should be 0 (attended 0 events for this kennel)
+    // But recency > 0 (attended a roster group event recently)
+    if (result.length > 0) {
+      expect(result[0].frequency).toBe(0);
+      expect(result[0].recency).toBeGreaterThan(0);
+    }
+  });
+
+  it("recency considers roster group attendance", () => {
+    const events = makeEvents(4);
+    const eventKennelMap = new Map<string, string>();
+    for (const e of events) eventKennelMap.set(e.id, KENNEL_ID);
+    eventKennelMap.set("other-event", "kennel-2");
+
+    // Hasher attended this kennel's events AND a very recent other-kennel event
+    const records: AttendanceRecord[] = [
+      {
+        kennelHasherId: "hasher-1",
+        eventId: events[0].id,
+        eventDate: events[0].date,
+      },
+      {
+        kennelHasherId: "hasher-1",
+        eventId: "other-event",
+        eventDate: daysAgo(1), // very recent
+      },
+    ];
+
+    const result = computeSuggestionScores(
+      makeInput({
+        rosterKennelIds: [KENNEL_ID, "kennel-2"],
+        kennelEvents: events,
+        attendanceRecords: records,
+        rosterHasherIds: ["hasher-1"],
+        eventKennelMap,
+      }),
+      REF_DATE,
+    );
+
+    expect(result).toHaveLength(1);
+    // Recency should be very high (attended yesterday in roster group)
+    expect(result[0].recency).toBeGreaterThan(0.9);
+  });
+
+  it("streak resets after a gap", () => {
+    const events = makeEvents(6);
+    // Attended most recent 2, skipped 3rd, attended 4th
+    const records: AttendanceRecord[] = [
+      { kennelHasherId: "h1", eventId: events[0].id, eventDate: events[0].date },
+      { kennelHasherId: "h1", eventId: events[1].id, eventDate: events[1].date },
+      // gap at events[2]
+      { kennelHasherId: "h1", eventId: events[3].id, eventDate: events[3].date },
+    ];
+
+    const result = computeSuggestionScores(
+      makeInput({
+        kennelEvents: events,
+        attendanceRecords: records,
+        rosterHasherIds: ["h1"],
+      }),
+      REF_DATE,
+    );
+
+    expect(result).toHaveLength(1);
+    // Streak should be 2 (broke at the gap), normalized to 2/4 = 0.5
+    expect(result[0].streak).toBe(0.5);
+  });
+
+  it("streak caps at MAX_STREAK (4)", () => {
+    const events = makeEvents(6);
+    // Attended all 6 events
+    const records: AttendanceRecord[] = events.map((e) => ({
+      kennelHasherId: "h1",
+      eventId: e.id,
+      eventDate: e.date,
+    }));
+
+    const result = computeSuggestionScores(
+      makeInput({
+        kennelEvents: events,
+        attendanceRecords: records,
+        rosterHasherIds: ["h1"],
+      }),
+      REF_DATE,
+    );
+
+    expect(result).toHaveLength(1);
+    // Streak capped at 4, normalized to 4/4 = 1.0
+    expect(result[0].streak).toBe(1);
+  });
+
+  it("filters out hashers below the threshold", () => {
+    const events = makeEvents(10);
+    // hasher-1 attended every event; hasher-2 attended 0
+    const records: AttendanceRecord[] = events.map((e) => ({
+      kennelHasherId: "hasher-1",
+      eventId: e.id,
+      eventDate: e.date,
+    }));
+
+    const result = computeSuggestionScores(
+      makeInput({
+        kennelEvents: events,
+        attendanceRecords: records,
+        rosterHasherIds: ["hasher-1", "hasher-2"],
+      }),
+      REF_DATE,
+    );
+
+    // hasher-2 should be filtered out (score = 0)
+    expect(result).toHaveLength(1);
+    expect(result[0].kennelHasherId).toBe("hasher-1");
+  });
+
+  it("sorts by score descending", () => {
+    const events = makeEvents(6);
+    // hasher-1: attended all 6; hasher-2: attended 3 most recent
+    const records: AttendanceRecord[] = [
+      ...events.map((e) => ({
+        kennelHasherId: "h-regular" as string,
+        eventId: e.id,
+        eventDate: e.date,
+      })),
+      ...events.slice(0, 3).map((e) => ({
+        kennelHasherId: "h-occasional" as string,
+        eventId: e.id,
+        eventDate: e.date,
+      })),
+    ];
+
+    const result = computeSuggestionScores(
+      makeInput({
+        kennelEvents: events,
+        attendanceRecords: records,
+        rosterHasherIds: ["h-regular", "h-occasional"],
+      }),
+      REF_DATE,
+    );
+
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    expect(result[0].kennelHasherId).toBe("h-regular");
+    expect(result[0].score).toBeGreaterThan(result[1].score);
+  });
+
+  it("reference date parameter enables deterministic testing", () => {
+    const events = makeEvents(4);
+    const records: AttendanceRecord[] = events.map((e) => ({
+      kennelHasherId: "h1",
+      eventId: e.id,
+      eventDate: e.date,
+    }));
+    const input = makeInput({
+      kennelEvents: events,
+      attendanceRecords: records,
+      rosterHasherIds: ["h1"],
+    });
+
+    const result1 = computeSuggestionScores(input, REF_DATE);
+    const result2 = computeSuggestionScores(input, REF_DATE);
+
+    expect(result1).toEqual(result2);
+  });
+});

--- a/src/lib/misman/suggestions.ts
+++ b/src/lib/misman/suggestions.ts
@@ -1,0 +1,134 @@
+/**
+ * Smart suggestion scoring for attendance forms.
+ * Pure function — no DB or auth dependencies.
+ *
+ * Weights: 50% frequency (this kennel), 30% recency (roster group), 20% streak (this kennel).
+ * Returns hashers sorted by score descending, filtered above threshold.
+ */
+
+export const FREQUENCY_WEIGHT = 0.5;
+export const RECENCY_WEIGHT = 0.3;
+export const STREAK_WEIGHT = 0.2;
+export const SUGGESTION_THRESHOLD = 0.3;
+export const LOOKBACK_DAYS = 180;
+export const MIN_EVENTS_FOR_SUGGESTIONS = 3;
+export const MAX_STREAK = 4;
+
+export interface AttendanceRecord {
+  kennelHasherId: string;
+  eventId: string;
+  eventDate: Date;
+}
+
+export interface KennelEvent {
+  id: string;
+  date: Date;
+}
+
+export interface SuggestionInput {
+  /** The kennel being managed */
+  kennelId: string;
+  /** All kennel IDs in the roster group (includes kennelId) */
+  rosterKennelIds: string[];
+  /** Events for THIS kennel only (within lookback window) */
+  kennelEvents: KennelEvent[];
+  /** All attendance across the roster group (within lookback window) */
+  attendanceRecords: AttendanceRecord[];
+  /** All KennelHasher IDs in roster scope */
+  rosterHasherIds: string[];
+  /** Map of eventId → kennelId for scoping */
+  eventKennelMap: Map<string, string>;
+}
+
+export interface SuggestionScore {
+  kennelHasherId: string;
+  score: number;
+  frequency: number;
+  recency: number;
+  streak: number;
+}
+
+/**
+ * Compute suggestion scores for all roster hashers.
+ * @param input - Pre-fetched data scoped to lookback window
+ * @param referenceDate - For deterministic testing; defaults to now
+ */
+export function computeSuggestionScores(
+  input: SuggestionInput,
+  referenceDate: Date = new Date(),
+): SuggestionScore[] {
+  const { kennelId, kennelEvents, attendanceRecords, rosterHasherIds, eventKennelMap } = input;
+
+  // Not enough data to produce meaningful suggestions
+  if (kennelEvents.length < MIN_EVENTS_FOR_SUGGESTIONS) {
+    return [];
+  }
+
+  // Sort kennel events by date descending for streak calculation
+  const sortedKennelEvents = [...kennelEvents].sort(
+    (a, b) => b.date.getTime() - a.date.getTime(),
+  );
+  const kennelEventIds = new Set(kennelEvents.map((e) => e.id));
+
+  // Index attendance by hasher
+  const attendanceByHasher = new Map<string, AttendanceRecord[]>();
+  for (const record of attendanceRecords) {
+    const list = attendanceByHasher.get(record.kennelHasherId) ?? [];
+    list.push(record);
+    attendanceByHasher.set(record.kennelHasherId, list);
+  }
+
+  const refTime = referenceDate.getTime();
+  const lookbackMs = LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+
+  return rosterHasherIds
+    .map((hasherId) => {
+      const records = attendanceByHasher.get(hasherId) ?? [];
+
+      // --- Frequency: attendance at THIS kennel's events / total kennel events ---
+      const thisKennelCount = records.filter((r) =>
+        kennelEventIds.has(r.eventId),
+      ).length;
+      const frequency = thisKennelCount / kennelEvents.length;
+
+      // --- Recency: most recent attendance at ANY kennel in roster group ---
+      let recency = 0;
+      if (records.length > 0) {
+        const mostRecent = Math.max(...records.map((r) => r.eventDate.getTime()));
+        const daysSince = (refTime - mostRecent) / (24 * 60 * 60 * 1000);
+        recency = Math.max(0, 1 - daysSince / LOOKBACK_DAYS);
+      }
+
+      // --- Streak: consecutive THIS-kennel events attended (most recent first) ---
+      let streak = 0;
+      const hasherKennelEventIds = new Set(
+        records
+          .filter((r) => kennelEventIds.has(r.eventId))
+          .map((r) => r.eventId),
+      );
+      for (const event of sortedKennelEvents) {
+        if (hasherKennelEventIds.has(event.id)) {
+          streak++;
+          if (streak >= MAX_STREAK) break;
+        } else {
+          break;
+        }
+      }
+      const normalizedStreak = Math.min(1, streak / MAX_STREAK);
+
+      const score =
+        FREQUENCY_WEIGHT * frequency +
+        RECENCY_WEIGHT * recency +
+        STREAK_WEIGHT * normalizedStreak;
+
+      return {
+        kennelHasherId: hasherId,
+        score: Math.round(score * 1000) / 1000, // 3 decimal places
+        frequency: Math.round(frequency * 1000) / 1000,
+        recency: Math.round(recency * 1000) / 1000,
+        streak: normalizedStreak,
+      };
+    })
+    .filter((s) => s.score >= SUGGESTION_THRESHOLD)
+    .sort((a, b) => b.score - a.score);
+}

--- a/src/lib/misman/verification.test.ts
+++ b/src/lib/misman/verification.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveVerificationStatus,
+  computeVerificationStatuses,
+} from "./verification";
+
+describe("deriveVerificationStatus", () => {
+  it("returns 'verified' when both records exist", () => {
+    expect(
+      deriveVerificationStatus({
+        hasKennelAttendance: true,
+        hasUserAttendance: true,
+      }),
+    ).toBe("verified");
+  });
+
+  it("returns 'misman-only' when only misman recorded", () => {
+    expect(
+      deriveVerificationStatus({
+        hasKennelAttendance: true,
+        hasUserAttendance: false,
+      }),
+    ).toBe("misman-only");
+  });
+
+  it("returns 'user-only' when only user self-checked-in", () => {
+    expect(
+      deriveVerificationStatus({
+        hasKennelAttendance: false,
+        hasUserAttendance: true,
+      }),
+    ).toBe("user-only");
+  });
+
+  it("returns 'none' when neither record exists", () => {
+    expect(
+      deriveVerificationStatus({
+        hasKennelAttendance: false,
+        hasUserAttendance: false,
+      }),
+    ).toBe("none");
+  });
+});
+
+describe("computeVerificationStatuses", () => {
+  it("returns correct statuses for a set of events", () => {
+    const kennelIds = new Set(["e1", "e2"]);
+    const userIds = new Set(["e2", "e3"]);
+    const allIds = ["e1", "e2", "e3", "e4"];
+
+    const result = computeVerificationStatuses(kennelIds, userIds, allIds);
+
+    expect(result.get("e1")).toBe("misman-only");
+    expect(result.get("e2")).toBe("verified");
+    expect(result.get("e3")).toBe("user-only");
+    expect(result.get("e4")).toBe("none");
+  });
+
+  it("returns empty map for empty input", () => {
+    const result = computeVerificationStatuses(
+      new Set(),
+      new Set(),
+      [],
+    );
+    expect(result.size).toBe(0);
+  });
+});

--- a/src/lib/misman/verification.ts
+++ b/src/lib/misman/verification.ts
@@ -1,0 +1,51 @@
+/**
+ * Verification status derivation for attendance records.
+ * Pure function — no DB or auth dependencies.
+ *
+ * Compares misman-recorded (KennelAttendance) vs user self-checked-in (Attendance)
+ * records for linked users to determine verification status per event.
+ */
+
+export type VerificationStatus = "verified" | "misman-only" | "user-only" | "none";
+
+export interface VerificationInput {
+  /** Whether a KennelAttendance record exists (misman recorded) */
+  hasKennelAttendance: boolean;
+  /** Whether an Attendance record exists (user self-checked in) */
+  hasUserAttendance: boolean;
+}
+
+/**
+ * Derive verification status from the presence of both record types.
+ */
+export function deriveVerificationStatus(
+  input: VerificationInput,
+): VerificationStatus {
+  if (input.hasKennelAttendance && input.hasUserAttendance) return "verified";
+  if (input.hasKennelAttendance) return "misman-only";
+  if (input.hasUserAttendance) return "user-only";
+  return "none";
+}
+
+/**
+ * Compute verification statuses for a set of events.
+ * Given event IDs where either a KennelAttendance or Attendance exists,
+ * returns the derived status for each.
+ */
+export function computeVerificationStatuses(
+  kennelAttendanceEventIds: Set<string>,
+  userAttendanceEventIds: Set<string>,
+  allEventIds: string[],
+): Map<string, VerificationStatus> {
+  const result = new Map<string, VerificationStatus>();
+  for (const eventId of allEventIds) {
+    result.set(
+      eventId,
+      deriveVerificationStatus({
+        hasKennelAttendance: kennelAttendanceEventIds.has(eventId),
+        hasUserAttendance: userAttendanceEventIds.has(eventId),
+      }),
+    );
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Implements three interconnected features to improve the misman (attendance recording) workflow and connect it to user logbooks:

1. **Smart Suggestions** — Scoring algorithm to recommend hashers most likely to attend based on historical patterns
2. **User Linking** — Fuzzy-match KennelHashers to User accounts and create suggested links
3. **Verification Status** — Track whether attendance is recorded by misman, user, or both

## Key Changes

### Smart Suggestions (`src/lib/misman/suggestions.ts`)
- Pure function `computeSuggestionScores()` that weights three metrics:
  - **Frequency** (50%): attendance at this kennel's events
  - **Recency** (30%): most recent attendance across roster group
  - **Streak** (20%): consecutive recent events at this kennel (capped at 4)
- Filters results above 0.3 threshold; requires minimum 3 events of historical data
- Fully tested with 309 lines of test coverage

### User Linking (`src/app/misman/[slug]/roster/actions.ts`)
- `suggestUserLinks()` — Fuzzy-matches hasher names (hash/nerd) against User records in roster scope
- `createUserLink()` — Creates SUGGESTED link; prevents duplicate links in roster group
- `dismissUserLink()` / `revokeUserLink()` — Manage link lifecycle
- New `UserLinkSection` component for roster detail view with match display and confirmation UI

### Verification Status (`src/lib/misman/verification.ts`)
- `deriveVerificationStatus()` — Classifies attendance as:
  - **verified**: both misman and user records exist
  - **misman-only**: recorded by misman, not yet confirmed by user
  - **user-only**: self-checked in, not recorded by misman
  - **none**: no records
- `VerificationBadge` component displays status with tooltips (V/M/U badges)

### Pending Confirmations (Logbook Integration)
- `getPendingConfirmations()` — Fetches misman-recorded attendance for linked hashers that user hasn't confirmed
- `confirmMismanAttendance()` — Creates Attendance record from KennelAttendance, with participation level based on hare status
- `PendingConfirmations` component shows dismissible list on logbook page

### Attendance Form Enhancements
- `getSuggestions()` action fetches and enriches suggestion scores with hasher names
- `SuggestionList` component displays top suggestions as quick-add buttons
- Integrated into `AttendanceForm` for faster data entry

### Supporting Changes
- Extended `fuzzyNameMatch()` utility for cross-field matching (hash↔nerd name)
- Updated roster table to display link status
- Updated hasher detail page with verification badges and user link management
- 55 new tests across suggestions, user linking, and pending confirmations

## Implementation Details

- All scoring and verification logic is pure functions with no DB/auth dependencies, enabling deterministic testing
- User linking respects roster scope — prevents linking same user to multiple hashers in a group
- Fuzzy matching threshold set to 0.7 for user links; suggestions threshold 0.3
- Lookback window: 180 days for suggestions, 1 year for attendance history
- Dismissed links can be re-suggested; confirmed links require explicit revocation

https://claude.ai/code/session_019yCHvpUKg2UrN5JTLohav5