### PR TITLE
Sprint 8f: rosterGroupId migration, merge duplicates, roster groups a…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ calendar + personal logbook + kennel directory.
 ## Quick Commands
 - `npm run dev` — Start local dev server (http://localhost:3000)
 - `npm run build` — Production build
-- `npm test` — Run test suite (Vitest, 471 tests)
+- `npm test` — Run test suite (Vitest, 498 tests)
 - `npx prisma studio` — Visual database browser
 - `npx prisma db push` — Push schema changes to dev DB
 - `npx prisma migrate dev` — Create migration
@@ -64,7 +64,7 @@ calendar + personal logbook + kennel directory.
 - `prisma/seed.ts` — Launch kennel + alias data
 - `prisma.config.ts` — Prisma 7 config (datasource URL, seed command)
 - `src/lib/db.ts` — PrismaClient singleton (PrismaPg adapter + SSL)
-- `src/lib/auth.ts` — `getOrCreateUser()` + `getAdminUser()` (Clerk→DB sync + admin role check)
+- `src/lib/auth.ts` — `getOrCreateUser()` + `getAdminUser()` + `getMismanUser()` + `getRosterGroupId()` (Clerk→DB sync + admin/misman role checks)
 - `src/lib/format.ts` — Shared utilities: time formatting, region config/colors, participation levels
 - `src/lib/calendar.ts` — Google Calendar URL + .ics file generation (client-side)
 - `src/middleware.ts` — Clerk route protection (public vs authenticated routes)
@@ -84,7 +84,7 @@ calendar + personal logbook + kennel directory.
 - `src/app/admin/misman-requests/page.tsx` — Admin misman request approval (reuses misman server actions)
 - `src/components/admin/AlertCard.tsx` — Alert card with repair actions, context display, repair history
 - `src/app/misman/actions.ts` — Misman request/approve/reject server actions (used by both /misman and /admin)
-- `src/app/misman/[slug]/roster/actions.ts` — Roster CRUD + search + user linking (roster group scope)
+- `src/app/misman/[slug]/roster/actions.ts` — Roster CRUD + search + user linking + merge duplicates (roster group scope)
 - `src/app/misman/[slug]/attendance/actions.ts` — Attendance recording, polling, quick-add, smart suggestions
 - `src/app/misman/[slug]/history/actions.ts` — Attendance history, hasher detail, roster seeding from hares
 - `src/lib/misman/suggestions.ts` — Smart suggestion scoring algorithm (pure function: frequency/recency/streak)
@@ -93,7 +93,11 @@ calendar + personal logbook + kennel directory.
 - `src/components/misman/UserLinkSection.tsx` — User linking UI (suggest, dismiss, revoke) on hasher detail
 - `src/components/misman/SuggestionList.tsx` — Tap-to-add suggestion chips on attendance form
 - `src/components/misman/VerificationBadge.tsx` — Verification status badge (V/M/U) on attendance rows
+- `src/components/misman/DuplicateScanResults.tsx` — Scan for duplicate hashers + merge trigger
+- `src/components/misman/MergePreviewDialog.tsx` — Side-by-side merge preview with stats/conflicts
 - `src/components/logbook/PendingConfirmations.tsx` — Pending misman confirmations on logbook page
+- `src/components/admin/RosterGroupsAdmin.tsx` — Admin roster group management (shared/standalone display, rename, dissolve)
+- `src/app/admin/roster-groups/actions.ts` — Roster group CRUD (create, add/remove kennels, rename, dissolve)
 - `src/components/ui/alert-dialog.tsx` — Radix AlertDialog wrapper (confirmation dialogs)
 - `src/lib/fuzzy.ts` — Levenshtein-based fuzzy string matching for kennel tag resolution + pairwise name matching
 - `vercel.json` — Vercel Cron config (daily scrape at 6:00 AM UTC)
@@ -121,7 +125,7 @@ See `docs/roadmap.md` for implementation roadmap.
 ## Testing
 - **Framework:** Vitest with `globals: true` (no explicit imports needed)
 - **Config:** `vitest.config.ts` — path alias `@/` maps to `./src`
-- **Run:** `npm test` (471 tests across 30 files)
+- **Run:** `npm test` (498 tests across 30 files)
 - **Factories:** `src/test/factories.ts` — shared builders (`buildRawEvent`, `buildCalendarEvent`, `mockUser`)
 - **Mocking pattern:** `vi.mock("@/lib/db")` + `vi.mocked(prisma.model.method)` with `as never` for partial returns
 - **Exported helpers:** Pure functions in adapters/pipeline are exported for direct unit testing (additive-only, no behavior change)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -156,7 +156,7 @@ Last updated: 2026-02-15
 - [ ] **Admin-editable participation levels**: Migrate enum to reference table for custom levels per community
 - [ ] **"Beez There" checkbox**: Optional flag on attendance (nice-to-have, deferred from Sprint 5)
 
-### Kennel Attendance Management (Misman Tool) — Sprints 8a-8e COMPLETE
+### Kennel Attendance Management (Misman Tool) — Sprints 8a-8f COMPLETE
 **Goal**: Replace kennel mismanagement's Google Sheet attendance tracking with a dedicated tool tied to HashTracks events.
 
 See [misman-attendance-requirements.md](misman-attendance-requirements.md) for full requirements and decisions log.
@@ -174,8 +174,11 @@ See [misman-implementation-plan.md](misman-implementation-plan.md) for detailed 
 - [x] **User linking**: Fuzzy-match (Levenshtein, ≥0.7 threshold) for linking KennelHasher → site User; suggest/confirm/dismiss/revoke workflow
 - [x] **Logbook sync**: Pending confirmations section on `/logbook` for linked users (confirm creates logbook entry with isVerified=true)
 - [x] **Verification badges**: Derived verification status (verified/misman-only/user-only) shown on hasher detail attendance rows
+- [x] **rosterGroupId migration**: KennelHasher scoped by `rosterGroupId` instead of `kennelId`; `kennelId` nullable as metadata; `getRosterGroupId()` auth helper
+- [x] **Merge duplicates**: Pairwise fuzzy scan, preview with stats/conflicts, OR-merge attendance in transaction, mergeLog audit trail
+- [x] **Roster groups admin**: CRUD for roster groups at `/admin/roster-groups` (create, add/remove kennels, rename, dissolve)
+- [x] **Kennel deletion guard**: Block deletion when attendance records exist; cascade-delete misman records when safe
 - [ ] **CSV export**: Export attendance history to CSV
-- **Pending**: Sprint 8f — roster group admin UI, duplicate merge workflow
 - **Deferred**: Hash cash amounts, auto-detect virgins, hare→EventHare sync, cross-kennel directory, historical CSV import, notification system
 
 ### CSV Import (Bulk History)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -372,24 +372,28 @@ enum ReferralSource {
 // ── KENNEL ROSTER ──
 
 model KennelHasher {
-  id        String   @id @default(cuid())
-  kennelId  String
-  hashName  String?  // Public display name (primary identifier)
-  nerdName  String?  // Real name (private, visible to misman only)
-  email     String?  // Contact email (private, visible to misman only)
-  phone     String?  // Mobile phone (private, visible to misman only)
-  notes     String?  // Internal misman notes
+  id             String   @id @default(cuid())
+  rosterGroupId  String   // Primary scope — every hasher belongs to a RosterGroup
+  kennelId       String?  // "Created via" metadata — which kennel's misman added this entry
+  hashName       String?  // Public display name (primary identifier)
+  nerdName       String?  // Real name (private, visible to misman only)
+  email          String?  // Contact email (private, visible to misman only)
+  phone          String?  // Mobile phone (private, visible to misman only)
+  notes          String?  // Internal misman notes
+  mergeLog       Json?    // Audit trail for merge operations
 
-  kennel      Kennel              @relation(fields: [kennelId], references: [id])
+  rosterGroup RosterGroup         @relation(fields: [rosterGroupId], references: [id])
+  kennel      Kennel?             @relation(fields: [kennelId], references: [id])
   attendances KennelAttendance[]
   userLink    KennelHasherLink?
   createdAt   DateTime            @default(now())
   updatedAt   DateTime            @updatedAt
 
   // At least one of hashName or nerdName must be provided (enforced in app logic)
+  @@index([rosterGroupId])
+  @@index([rosterGroupId, hashName])
+  @@index([rosterGroupId, nerdName])
   @@index([kennelId])
-  @@index([kennelId, hashName])
-  @@index([kennelId, nerdName])
 }
 
 // ── USER ↔ KENNEL HASHER LINKING ──
@@ -461,10 +465,11 @@ model MismanRequest {
 // ── ROSTER GROUPS (Cross-Kennel Roster Sharing) ──
 
 model RosterGroup {
-  id      String              @id @default(cuid())
-  name    String              // "NYC Metro", "Philly Area"
-  kennels RosterGroupKennel[]
-  createdAt DateTime          @default(now())
+  id             String              @id @default(cuid())
+  name           String              // "NYC Metro", "Philly Area"
+  kennels        RosterGroupKennel[]
+  kennelHashers  KennelHasher[]
+  createdAt      DateTime            @default(now())
 }
 
 model RosterGroupKennel {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -49,6 +49,9 @@ export default async function AdminLayout({
           <TabsTrigger value="sources" asChild>
             <Link href="/admin/sources">Sources</Link>
           </TabsTrigger>
+          <TabsTrigger value="roster-groups" asChild>
+            <Link href="/admin/roster-groups">Roster Groups</Link>
+          </TabsTrigger>
           <TabsTrigger value="events" asChild>
             <Link href="/admin/events">Events</Link>
           </TabsTrigger>

--- a/src/app/admin/roster-groups/actions.test.ts
+++ b/src/app/admin/roster-groups/actions.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockAdmin = { id: "admin_1", email: "admin@test.com" };
+
+vi.mock("@/lib/auth", () => ({ getAdminUser: vi.fn() }));
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    rosterGroup: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    rosterGroupKennel: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    kennelHasher: {
+      updateMany: vi.fn(),
+      count: vi.fn(),
+    },
+    kennel: { findUnique: vi.fn() },
+  },
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { getAdminUser } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import {
+  getRosterGroups,
+  createRosterGroup,
+  addKennelToGroup,
+  removeKennelFromGroup,
+  renameRosterGroup,
+  deleteRosterGroup,
+} from "./actions";
+
+const mockAdminAuth = vi.mocked(getAdminUser);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAdminAuth.mockResolvedValue(mockAdmin as never);
+});
+
+describe("getRosterGroups", () => {
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await getRosterGroups()).toEqual({ error: "Not authorized" });
+  });
+
+  it("returns groups with kennels and hasher counts", async () => {
+    vi.mocked(prisma.rosterGroup.findMany).mockResolvedValueOnce([
+      {
+        id: "rg_1",
+        name: "NYC Metro",
+        kennels: [
+          { kennel: { id: "k1", shortName: "NYCH3", slug: "nych3" } },
+          { kennel: { id: "k2", shortName: "GGFM", slug: "ggfm" } },
+        ],
+        _count: { kennelHashers: 42 },
+      },
+    ] as never);
+
+    const result = await getRosterGroups();
+    expect(result.data).toHaveLength(1);
+    expect(result.data![0]).toEqual({
+      id: "rg_1",
+      name: "NYC Metro",
+      kennels: [
+        { id: "k1", shortName: "NYCH3", slug: "nych3" },
+        { id: "k2", shortName: "GGFM", slug: "ggfm" },
+      ],
+      hasherCount: 42,
+    });
+  });
+});
+
+describe("createRosterGroup", () => {
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await createRosterGroup("Test", ["k1", "k2"])).toEqual({
+      error: "Not authorized",
+    });
+  });
+
+  it("returns error when name is empty", async () => {
+    expect(await createRosterGroup("", ["k1", "k2"])).toEqual({
+      error: "Name is required",
+    });
+  });
+
+  it("returns error when fewer than 2 kennels", async () => {
+    expect(await createRosterGroup("Test", ["k1"])).toEqual({
+      error: "At least 2 kennels are required",
+    });
+  });
+
+  it("creates group and moves kennels", async () => {
+    vi.mocked(prisma.rosterGroup.create).mockResolvedValueOnce({
+      id: "rg_new",
+    } as never);
+
+    // Both kennels have existing standalone groups
+    vi.mocked(prisma.rosterGroupKennel.findUnique)
+      .mockResolvedValueOnce({ id: "rgk_1", groupId: "rg_old1" } as never)
+      .mockResolvedValueOnce({ id: "rgk_2", groupId: "rg_old2" } as never);
+    vi.mocked(prisma.rosterGroupKennel.delete).mockResolvedValue({} as never);
+    vi.mocked(prisma.kennelHasher.updateMany).mockResolvedValue({ count: 0 } as never);
+    vi.mocked(prisma.rosterGroupKennel.count)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+    vi.mocked(prisma.rosterGroup.delete).mockResolvedValue({} as never);
+    vi.mocked(prisma.rosterGroupKennel.create).mockResolvedValue({} as never);
+
+    const result = await createRosterGroup("NYC Metro", ["k1", "k2"]);
+    expect(result).toEqual({ success: true, groupId: "rg_new" });
+  });
+});
+
+describe("removeKennelFromGroup", () => {
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await removeKennelFromGroup("rg_1", "k1")).toEqual({
+      error: "Not authorized",
+    });
+  });
+
+  it("creates standalone group for removed kennel", async () => {
+    vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({
+      shortName: "NYCH3",
+    } as never);
+    vi.mocked(prisma.rosterGroup.create).mockResolvedValueOnce({
+      id: "rg_standalone",
+    } as never);
+    vi.mocked(prisma.rosterGroupKennel.update).mockResolvedValueOnce({} as never);
+    vi.mocked(prisma.kennelHasher.updateMany).mockResolvedValueOnce({ count: 5 } as never);
+
+    const result = await removeKennelFromGroup("rg_1", "k1");
+    expect(result).toEqual({ success: true });
+    expect(prisma.kennelHasher.updateMany).toHaveBeenCalledWith({
+      where: { rosterGroupId: "rg_1", kennelId: "k1" },
+      data: { rosterGroupId: "rg_standalone" },
+    });
+  });
+});
+
+describe("renameRosterGroup", () => {
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await renameRosterGroup("rg_1", "New Name")).toEqual({
+      error: "Not authorized",
+    });
+  });
+
+  it("returns error when name is empty", async () => {
+    expect(await renameRosterGroup("rg_1", "  ")).toEqual({
+      error: "Name is required",
+    });
+  });
+
+  it("renames successfully", async () => {
+    vi.mocked(prisma.rosterGroup.update).mockResolvedValueOnce({} as never);
+
+    const result = await renameRosterGroup("rg_1", "Philly Area");
+    expect(result).toEqual({ success: true });
+    expect(prisma.rosterGroup.update).toHaveBeenCalledWith({
+      where: { id: "rg_1" },
+      data: { name: "Philly Area" },
+    });
+  });
+});
+
+describe("deleteRosterGroup", () => {
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await deleteRosterGroup("rg_1")).toEqual({
+      error: "Not authorized",
+    });
+  });
+
+  it("returns error when group not found", async () => {
+    vi.mocked(prisma.rosterGroup.findUnique).mockResolvedValueOnce(null);
+    expect(await deleteRosterGroup("rg_bad")).toEqual({
+      error: "Roster group not found",
+    });
+  });
+
+  it("dissolves group into standalone groups", async () => {
+    vi.mocked(prisma.rosterGroup.findUnique).mockResolvedValueOnce({
+      id: "rg_1",
+      kennels: [
+        { id: "rgk_1", kennelId: "k1", kennel: { shortName: "NYCH3" } },
+        { id: "rgk_2", kennelId: "k2", kennel: { shortName: "GGFM" } },
+      ],
+    } as never);
+
+    vi.mocked(prisma.rosterGroup.create).mockResolvedValue({
+      id: "rg_standalone",
+    } as never);
+    vi.mocked(prisma.rosterGroupKennel.update).mockResolvedValue({} as never);
+    vi.mocked(prisma.kennelHasher.updateMany).mockResolvedValue({ count: 0 } as never);
+    vi.mocked(prisma.kennelHasher.count).mockResolvedValueOnce(0);
+    vi.mocked(prisma.rosterGroup.delete).mockResolvedValueOnce({} as never);
+
+    const result = await deleteRosterGroup("rg_1");
+    expect(result).toEqual({ success: true });
+    // Should create standalone groups for each kennel
+    expect(prisma.rosterGroup.create).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/admin/roster-groups/actions.ts
+++ b/src/app/admin/roster-groups/actions.ts
@@ -1,0 +1,252 @@
+"use server";
+
+import { getAdminUser } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+
+/**
+ * List all roster groups with their member kennels and hasher counts.
+ */
+export async function getRosterGroups() {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  const groups = await prisma.rosterGroup.findMany({
+    include: {
+      kennels: {
+        include: {
+          kennel: { select: { id: true, shortName: true, slug: true } },
+        },
+      },
+      _count: { select: { kennelHashers: true } },
+    },
+    orderBy: { name: "asc" },
+  });
+
+  return {
+    data: groups.map((g) => ({
+      id: g.id,
+      name: g.name,
+      kennels: g.kennels.map((k) => ({
+        id: k.kennel.id,
+        shortName: k.kennel.shortName,
+        slug: k.kennel.slug,
+      })),
+      hasherCount: g._count.kennelHashers,
+    })),
+  };
+}
+
+/**
+ * Create a new roster group with specified kennels.
+ * Moves kennels from their current standalone groups.
+ */
+export async function createRosterGroup(name: string, kennelIds: string[]) {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  if (!name.trim()) return { error: "Name is required" };
+  if (kennelIds.length < 2) return { error: "At least 2 kennels are required" };
+
+  // Create the group
+  const group = await prisma.rosterGroup.create({
+    data: { name: name.trim() },
+  });
+
+  // Move each kennel to the new group
+  for (const kennelId of kennelIds) {
+    // Remove from current group
+    const existing = await prisma.rosterGroupKennel.findUnique({
+      where: { kennelId },
+      select: { id: true, groupId: true },
+    });
+
+    if (existing) {
+      await prisma.rosterGroupKennel.delete({
+        where: { id: existing.id },
+      });
+
+      // Update hashers from old group to new group
+      await prisma.kennelHasher.updateMany({
+        where: { rosterGroupId: existing.groupId, kennelId },
+        data: { rosterGroupId: group.id },
+      });
+
+      // Clean up old group if empty
+      const remainingKennels = await prisma.rosterGroupKennel.count({
+        where: { groupId: existing.groupId },
+      });
+      if (remainingKennels === 0) {
+        // Move any orphaned hashers (no kennelId) to the new group
+        await prisma.kennelHasher.updateMany({
+          where: { rosterGroupId: existing.groupId },
+          data: { rosterGroupId: group.id },
+        });
+        await prisma.rosterGroup.delete({ where: { id: existing.groupId } });
+      }
+    }
+
+    // Add to new group
+    await prisma.rosterGroupKennel.create({
+      data: { groupId: group.id, kennelId },
+    });
+  }
+
+  revalidatePath("/admin/roster-groups");
+  return { success: true, groupId: group.id };
+}
+
+/**
+ * Add a kennel to an existing roster group.
+ */
+export async function addKennelToGroup(groupId: string, kennelId: string) {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  // Remove from current group
+  const existing = await prisma.rosterGroupKennel.findUnique({
+    where: { kennelId },
+    select: { id: true, groupId: true },
+  });
+
+  if (existing) {
+    await prisma.rosterGroupKennel.delete({ where: { id: existing.id } });
+
+    // Move hashers from old group
+    await prisma.kennelHasher.updateMany({
+      where: { rosterGroupId: existing.groupId, kennelId },
+      data: { rosterGroupId: groupId },
+    });
+
+    // Clean up old group if empty
+    const remainingKennels = await prisma.rosterGroupKennel.count({
+      where: { groupId: existing.groupId },
+    });
+    if (remainingKennels === 0) {
+      await prisma.kennelHasher.updateMany({
+        where: { rosterGroupId: existing.groupId },
+        data: { rosterGroupId: groupId },
+      });
+      await prisma.rosterGroup.delete({ where: { id: existing.groupId } });
+    }
+  }
+
+  // Add to target group
+  await prisma.rosterGroupKennel.create({
+    data: { groupId, kennelId },
+  });
+
+  revalidatePath("/admin/roster-groups");
+  return { success: true };
+}
+
+/**
+ * Remove a kennel from a group. Creates a new standalone group for it.
+ */
+export async function removeKennelFromGroup(groupId: string, kennelId: string) {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  // Create a new standalone group
+  const kennel = await prisma.kennel.findUnique({
+    where: { id: kennelId },
+    select: { shortName: true },
+  });
+  if (!kennel) return { error: "Kennel not found" };
+
+  const standaloneGroup = await prisma.rosterGroup.create({
+    data: { name: kennel.shortName },
+  });
+
+  // Move kennel to standalone group
+  await prisma.rosterGroupKennel.update({
+    where: { kennelId },
+    data: { groupId: standaloneGroup.id },
+  });
+
+  // Move hashers with this kennelId to the standalone group
+  await prisma.kennelHasher.updateMany({
+    where: { rosterGroupId: groupId, kennelId },
+    data: { rosterGroupId: standaloneGroup.id },
+  });
+
+  revalidatePath("/admin/roster-groups");
+  return { success: true };
+}
+
+/**
+ * Rename a roster group.
+ */
+export async function renameRosterGroup(groupId: string, name: string) {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  if (!name.trim()) return { error: "Name is required" };
+
+  await prisma.rosterGroup.update({
+    where: { id: groupId },
+    data: { name: name.trim() },
+  });
+
+  revalidatePath("/admin/roster-groups");
+  return { success: true };
+}
+
+/**
+ * Delete a roster group. Converts each member kennel to a standalone group.
+ */
+export async function deleteRosterGroup(groupId: string) {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  const group = await prisma.rosterGroup.findUnique({
+    where: { id: groupId },
+    include: {
+      kennels: {
+        include: { kennel: { select: { shortName: true } } },
+      },
+    },
+  });
+  if (!group) return { error: "Roster group not found" };
+
+  // Convert each kennel to a standalone group
+  for (const rgk of group.kennels) {
+    const standaloneGroup = await prisma.rosterGroup.create({
+      data: { name: rgk.kennel.shortName },
+    });
+
+    await prisma.rosterGroupKennel.update({
+      where: { id: rgk.id },
+      data: { groupId: standaloneGroup.id },
+    });
+
+    await prisma.kennelHasher.updateMany({
+      where: { rosterGroupId: groupId, kennelId: rgk.kennelId },
+      data: { rosterGroupId: standaloneGroup.id },
+    });
+  }
+
+  // Move orphaned hashers (no kennelId) — shouldn't exist but be safe
+  const orphanedCount = await prisma.kennelHasher.count({
+    where: { rosterGroupId: groupId },
+  });
+  if (orphanedCount > 0) {
+    // Assign to first kennel's standalone group as fallback
+    const firstStandaloneKennel = await prisma.rosterGroupKennel.findFirst({
+      where: { kennelId: { in: group.kennels.map((k) => k.kennelId) } },
+      select: { groupId: true },
+    });
+    if (firstStandaloneKennel) {
+      await prisma.kennelHasher.updateMany({
+        where: { rosterGroupId: groupId },
+        data: { rosterGroupId: firstStandaloneKennel.groupId },
+      });
+    }
+  }
+
+  // Delete the original group
+  await prisma.rosterGroup.delete({ where: { id: groupId } });
+
+  revalidatePath("/admin/roster-groups");
+  return { success: true };
+}

--- a/src/app/admin/roster-groups/page.tsx
+++ b/src/app/admin/roster-groups/page.tsx
@@ -1,0 +1,14 @@
+import { getAdminUser } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { RosterGroupsAdmin } from "@/components/admin/RosterGroupsAdmin";
+import { getRosterGroups } from "./actions";
+
+export default async function RosterGroupsPage() {
+  const admin = await getAdminUser();
+  if (!admin) redirect("/");
+
+  const result = await getRosterGroups();
+  if (result.error) return <p className="text-destructive">{result.error}</p>;
+
+  return <RosterGroupsAdmin groups={result.data ?? []} />;
+}

--- a/src/app/misman/[slug]/attendance/actions.test.ts
+++ b/src/app/misman/[slug]/attendance/actions.test.ts
@@ -4,6 +4,7 @@ const mockMisman = { id: "misman_1", email: "misman@test.com" };
 
 vi.mock("@/lib/auth", () => ({
   getMismanUser: vi.fn(),
+  getRosterGroupId: vi.fn(),
   getRosterKennelIds: vi.fn(),
 }));
 vi.mock("@/lib/db", () => ({
@@ -22,7 +23,7 @@ vi.mock("@/lib/db", () => ({
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-import { getMismanUser, getRosterKennelIds } from "@/lib/auth";
+import { getMismanUser, getRosterGroupId, getRosterKennelIds } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import {
   recordAttendance,
@@ -35,11 +36,13 @@ import {
 } from "./actions";
 
 const mockMismanAuth = vi.mocked(getMismanUser);
+const mockRosterGroupId = vi.mocked(getRosterGroupId);
 const mockRosterKennelIds = vi.mocked(getRosterKennelIds);
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockMismanAuth.mockResolvedValue(mockMisman as never);
+  mockRosterGroupId.mockResolvedValue("rg_1");
   mockRosterKennelIds.mockResolvedValue(["kennel_1"]);
 });
 
@@ -104,7 +107,7 @@ describe("recordAttendance", () => {
       date: new Date(),
     } as never);
     vi.mocked(prisma.kennelHasher.findUnique).mockResolvedValueOnce({
-      kennelId: "other_kennel",
+      rosterGroupId: "other_rg",
     } as never);
 
     expect(
@@ -119,7 +122,7 @@ describe("recordAttendance", () => {
       date: new Date(),
     } as never);
     vi.mocked(prisma.kennelHasher.findUnique).mockResolvedValueOnce({
-      kennelId: "kennel_1",
+      rosterGroupId: "rg_1",
     } as never);
     vi.mocked(prisma.kennelAttendance.upsert).mockResolvedValueOnce({} as never);
 
@@ -304,6 +307,7 @@ describe("quickAddHasher", () => {
 
     expect(prisma.kennelHasher.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
+        rosterGroupId: "rg_1",
         kennelId: "kennel_1",
         hashName: "Newbie",
       }),

--- a/src/app/misman/[slug]/roster/[hasherId]/page.tsx
+++ b/src/app/misman/[slug]/roster/[hasherId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getMismanUser, getRosterKennelIds } from "@/lib/auth";
+import { getMismanUser, getRosterGroupId } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { HasherDetail } from "@/components/misman/HasherDetail";
 import { deriveVerificationStatus, type VerificationStatus } from "@/lib/misman/verification";
@@ -20,7 +20,7 @@ export default async function HasherDetailPage({ params }: Props) {
   const user = await getMismanUser(kennel.id);
   if (!user) notFound();
 
-  const rosterKennelIds = await getRosterKennelIds(kennel.id);
+  const rosterGroupId = await getRosterGroupId(kennel.id);
 
   const hasher = await prisma.kennelHasher.findUnique({
     where: { id: hasherId },
@@ -49,7 +49,7 @@ export default async function HasherDetailPage({ params }: Props) {
   });
 
   if (!hasher) notFound();
-  if (!rosterKennelIds.includes(hasher.kennelId)) notFound();
+  if (hasher.rosterGroupId !== rosterGroupId) notFound();
 
   const totalRuns = hasher.attendances.length;
   const hareCount = hasher.attendances.filter((a) => a.haredThisTrail).length;
@@ -61,7 +61,7 @@ export default async function HasherDetailPage({ params }: Props) {
   const serialized = {
     id: hasher.id,
     kennelId: hasher.kennelId,
-    kennelShortName: hasher.kennel.shortName,
+    kennelShortName: hasher.kennel?.shortName ?? null,
     hashName: hasher.hashName,
     nerdName: hasher.nerdName,
     email: hasher.email,
@@ -117,5 +117,5 @@ export default async function HasherDetailPage({ params }: Props) {
     }
   }
 
-  return <HasherDetail hasher={serialized} kennelSlug={slug} />;
+  return <HasherDetail hasher={serialized} kennelId={kennel.id} kennelSlug={slug} />;
 }

--- a/src/components/admin/RosterGroupsAdmin.tsx
+++ b/src/components/admin/RosterGroupsAdmin.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import {
+  removeKennelFromGroup,
+  renameRosterGroup,
+  deleteRosterGroup,
+} from "@/app/admin/roster-groups/actions";
+
+interface RosterGroupData {
+  id: string;
+  name: string;
+  kennels: Array<{ id: string; shortName: string; slug: string }>;
+  hasherCount: number;
+}
+
+interface RosterGroupsAdminProps {
+  groups: RosterGroupData[];
+}
+
+export function RosterGroupsAdmin({ groups }: RosterGroupsAdminProps) {
+  const [deleteTarget, setDeleteTarget] = useState<RosterGroupData | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  // Separate shared groups (2+ kennels) from standalone (1 kennel)
+  const sharedGroups = groups.filter((g) => g.kennels.length > 1);
+  const standaloneGroups = groups.filter((g) => g.kennels.length <= 1);
+
+  function handleRemoveKennel(groupId: string, kennelId: string, kennelName: string) {
+    if (!confirm(`Remove ${kennelName} from this group? It will get its own standalone roster.`)) {
+      return;
+    }
+    startTransition(async () => {
+      const result = await removeKennelFromGroup(groupId, kennelId);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(`${kennelName} removed from group`);
+        router.refresh();
+      }
+    });
+  }
+
+  function handleRename(groupId: string, currentName: string) {
+    const newName = prompt("New group name:", currentName);
+    if (!newName || newName === currentName) return;
+    startTransition(async () => {
+      const result = await renameRosterGroup(groupId, newName);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Group renamed");
+        router.refresh();
+      }
+    });
+  }
+
+  function handleDelete() {
+    if (!deleteTarget) return;
+    startTransition(async () => {
+      const result = await deleteRosterGroup(deleteTarget.id);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Group dissolved — kennels are now standalone");
+        setDeleteTarget(null);
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Shared groups */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">
+          Shared Roster Groups ({sharedGroups.length})
+        </h2>
+        {sharedGroups.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No shared roster groups. Use the admin kennel merge to create one.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {sharedGroups.map((group) => (
+              <div key={group.id} className="rounded-lg border p-4 space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <h3 className="font-semibold">{group.name}</h3>
+                    <Badge variant="secondary">{group.hasherCount} hashers</Badge>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => handleRename(group.id, group.name)}
+                      disabled={isPending}
+                    >
+                      Rename
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive"
+                      onClick={() => setDeleteTarget(group)}
+                      disabled={isPending}
+                    >
+                      Dissolve
+                    </Button>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {group.kennels.map((k) => (
+                    <div
+                      key={k.id}
+                      className="flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm"
+                    >
+                      {k.shortName}
+                      {group.kennels.length > 2 && (
+                        <button
+                          className="ml-1 text-xs text-muted-foreground hover:text-destructive"
+                          onClick={() => handleRemoveKennel(group.id, k.id, k.shortName)}
+                          disabled={isPending}
+                          title="Remove from group"
+                        >
+                          x
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Standalone groups summary */}
+      <div>
+        <h2 className="text-lg font-semibold mb-2">
+          Standalone Kennels ({standaloneGroups.length})
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Kennels with their own individual roster. Each gets an auto-created
+          single-kennel roster group.
+        </p>
+      </div>
+
+      {/* Delete confirmation */}
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(v) => !v && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Dissolve Roster Group?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will convert each kennel in &ldquo;{deleteTarget?.name}&rdquo; to
+              its own standalone roster. Hashers tagged to each kennel will stay
+              with their kennel. This cannot be undone easily.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} disabled={isPending}>
+              {isPending ? "Dissolving..." : "Dissolve Group"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/misman/DuplicateScanResults.tsx
+++ b/src/components/misman/DuplicateScanResults.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import { scanDuplicates } from "@/app/misman/[slug]/roster/actions";
+import { MergePreviewDialog } from "./MergePreviewDialog";
+
+interface DuplicatePair {
+  hasherId1: string;
+  name1: string;
+  hasherId2: string;
+  name2: string;
+  score: number;
+  matchField: string;
+}
+
+interface DuplicateScanResultsProps {
+  kennelId: string;
+  kennelSlug: string;
+}
+
+export function DuplicateScanResults({
+  kennelId,
+  kennelSlug,
+}: DuplicateScanResultsProps) {
+  const [pairs, setPairs] = useState<DuplicatePair[] | null>(null);
+  const [scanning, startScan] = useTransition();
+  const [mergeTarget, setMergeTarget] = useState<DuplicatePair | null>(null);
+
+  function handleScan() {
+    startScan(async () => {
+      const result = await scanDuplicates(kennelId);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      setPairs(result.data ?? []);
+      if (result.data?.length === 0) {
+        toast.success("No duplicates found");
+      }
+    });
+  }
+
+  return (
+    <div>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={handleScan}
+        disabled={scanning}
+      >
+        {scanning ? "Scanning..." : "Scan for Duplicates"}
+      </Button>
+
+      {pairs !== null && pairs.length > 0 && (
+        <div className="mt-4 space-y-2">
+          <h3 className="text-sm font-semibold">
+            Potential Duplicates ({pairs.length})
+          </h3>
+          {pairs.map((pair, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between rounded-lg border px-3 py-2 text-sm"
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-medium">{pair.name1}</span>
+                <span className="text-muted-foreground">↔</span>
+                <span className="font-medium">{pair.name2}</span>
+                <Badge variant="secondary" className="text-xs">
+                  {Math.round(pair.score * 100)}%
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  ({pair.matchField})
+                </span>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setMergeTarget(pair)}
+              >
+                Merge
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {mergeTarget && (
+        <MergePreviewDialog
+          open={!!mergeTarget}
+          onClose={() => setMergeTarget(null)}
+          kennelId={kennelId}
+          kennelSlug={kennelSlug}
+          hasherId1={mergeTarget.hasherId1}
+          name1={mergeTarget.name1}
+          hasherId2={mergeTarget.hasherId2}
+          name2={mergeTarget.name2}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/misman/HasherDetail.tsx
+++ b/src/components/misman/HasherDetail.tsx
@@ -28,8 +28,8 @@ interface AttendanceEntry {
 
 interface HasherData {
   id: string;
-  kennelId: string;
-  kennelShortName: string;
+  kennelId: string | null;
+  kennelShortName: string | null;
   hashName: string | null;
   nerdName: string | null;
   email: string | null;
@@ -54,10 +54,11 @@ interface HasherData {
 
 interface HasherDetailProps {
   hasher: HasherData;
+  kennelId: string;
   kennelSlug: string;
 }
 
-export function HasherDetail({ hasher, kennelSlug }: HasherDetailProps) {
+export function HasherDetail({ hasher, kennelId, kennelSlug }: HasherDetailProps) {
   const [showEdit, setShowEdit] = useState(false);
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
@@ -103,7 +104,9 @@ export function HasherDetail({ hasher, kennelSlug }: HasherDetailProps) {
             <p className="text-muted-foreground">{hasher.nerdName}</p>
           )}
           <div className="mt-1 flex items-center gap-2">
-            <Badge variant="outline">{hasher.kennelShortName}</Badge>
+            {hasher.kennelShortName && (
+              <Badge variant="outline">{hasher.kennelShortName}</Badge>
+            )}
             {hasher.userLink && (
               <Badge
                 variant={
@@ -186,7 +189,7 @@ export function HasherDetail({ hasher, kennelSlug }: HasherDetailProps) {
 
       {/* User linking */}
       <UserLinkSection
-        kennelId={hasher.kennelId}
+        kennelId={kennelId}
         kennelHasherId={hasher.id}
         userLink={hasher.userLink ? {
           id: hasher.userLink.id,
@@ -268,7 +271,7 @@ export function HasherDetail({ hasher, kennelSlug }: HasherDetailProps) {
       <HasherForm
         open={showEdit}
         onClose={() => setShowEdit(false)}
-        kennelId={hasher.kennelId}
+        kennelId={kennelId}
         kennelSlug={kennelSlug}
         hasher={{
           id: hasher.id,

--- a/src/components/misman/MergePreviewDialog.tsx
+++ b/src/components/misman/MergePreviewDialog.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { previewMerge, executeMerge } from "@/app/misman/[slug]/roster/actions";
+
+interface MergePreviewDialogProps {
+  open: boolean;
+  onClose: () => void;
+  kennelId: string;
+  kennelSlug: string;
+  hasherId1: string;
+  name1: string;
+  hasherId2: string;
+  name2: string;
+}
+
+interface HasherPreview {
+  id: string;
+  hashName: string | null;
+  nerdName: string | null;
+  email: string | null;
+  phone: string | null;
+  notes: string | null;
+  attendanceCount: number;
+  hasLink: boolean;
+}
+
+interface PreviewData {
+  primary: HasherPreview;
+  secondaries: HasherPreview[];
+  totalAttendance: number;
+  overlapCount: number;
+  hasConflictingLinks: boolean;
+}
+
+export function MergePreviewDialog({
+  open,
+  onClose,
+  kennelId,
+  kennelSlug,
+  hasherId1,
+  name1,
+  hasherId2,
+  name2,
+}: MergePreviewDialogProps) {
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [primaryId, setPrimaryId] = useState(hasherId1);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const secondaryId = primaryId === hasherId1 ? hasherId2 : hasherId1;
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    previewMerge(kennelId, primaryId, [secondaryId]).then((result) => {
+      if (result.error) {
+        toast.error(result.error);
+        onClose();
+        return;
+      }
+      setPreview(result.data ?? null);
+      setLoading(false);
+    });
+  }, [open, kennelId, primaryId, secondaryId, onClose]);
+
+  function handleMerge() {
+    if (!preview) return;
+    const secondary = preview.secondaries[0];
+    startTransition(async () => {
+      const result = await executeMerge(kennelId, primaryId, [secondaryId], {
+        hashName: preview.primary.hashName ?? undefined,
+        nerdName: preview.primary.nerdName ?? secondary?.nerdName ?? undefined,
+        email: preview.primary.email ?? secondary?.email ?? undefined,
+        phone: preview.primary.phone ?? secondary?.phone ?? undefined,
+        notes: preview.primary.notes ?? secondary?.notes ?? undefined,
+      });
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(`Merged ${result.mergedCount} duplicate(s)`);
+        onClose();
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <AlertDialogContent className="max-w-lg">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Merge Preview</AlertDialogTitle>
+        </AlertDialogHeader>
+
+        {loading ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            Loading preview...
+          </div>
+        ) : preview ? (
+          <div className="space-y-4">
+            {/* Primary selector */}
+            <div className="text-sm">
+              <span className="text-muted-foreground">Keep as primary:</span>
+              <div className="mt-1 flex gap-2">
+                <Button
+                  size="sm"
+                  variant={primaryId === hasherId1 ? "default" : "outline"}
+                  onClick={() => setPrimaryId(hasherId1)}
+                >
+                  {name1}
+                </Button>
+                <Button
+                  size="sm"
+                  variant={primaryId === hasherId2 ? "default" : "outline"}
+                  onClick={() => setPrimaryId(hasherId2)}
+                >
+                  {name2}
+                </Button>
+              </div>
+            </div>
+
+            {/* Stats */}
+            <div className="rounded-lg border p-3 text-sm space-y-1">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Combined attendance:</span>
+                <span className="font-medium">{preview.totalAttendance} events</span>
+              </div>
+              {preview.overlapCount > 0 && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Overlapping events:</span>
+                  <span className="font-medium">{preview.overlapCount} (will OR-merge flags)</span>
+                </div>
+              )}
+            </div>
+
+            {/* Side-by-side comparison */}
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className="rounded-lg border p-2 space-y-1">
+                <div className="font-semibold flex items-center gap-1">
+                  Primary
+                  {preview.primary.hasLink && <Badge className="text-xs">Linked</Badge>}
+                </div>
+                <div>{preview.primary.hashName || "—"}</div>
+                <div className="text-muted-foreground text-xs">
+                  {preview.primary.nerdName || "—"}
+                </div>
+                <div className="text-muted-foreground text-xs">
+                  {preview.primary.email || "—"}
+                </div>
+                <div className="text-xs">{preview.primary.attendanceCount} runs</div>
+              </div>
+              {preview.secondaries.map((s) => (
+                <div key={s.id} className="rounded-lg border p-2 space-y-1">
+                  <div className="font-semibold flex items-center gap-1 text-destructive">
+                    Will be merged
+                    {s.hasLink && <Badge variant="secondary" className="text-xs">Linked</Badge>}
+                  </div>
+                  <div>{s.hashName || "—"}</div>
+                  <div className="text-muted-foreground text-xs">
+                    {s.nerdName || "—"}
+                  </div>
+                  <div className="text-muted-foreground text-xs">
+                    {s.email || "—"}
+                  </div>
+                  <div className="text-xs">{s.attendanceCount} runs</div>
+                </div>
+              ))}
+            </div>
+
+            {/* Conflict warning */}
+            {preview.hasConflictingLinks && (
+              <div className="rounded-lg border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+                These entries are linked to different users. Revoke one link before merging.
+              </div>
+            )}
+          </div>
+        ) : null}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <Button
+            onClick={handleMerge}
+            disabled={isPending || loading || preview?.hasConflictingLinks}
+            variant="destructive"
+          >
+            {isPending ? "Merging..." : "Confirm Merge"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/misman/RosterTable.tsx
+++ b/src/components/misman/RosterTable.tsx
@@ -22,8 +22,8 @@ import { HasherForm } from "./HasherForm";
 
 interface HasherRow {
   id: string;
-  kennelId: string;
-  kennelShortName: string;
+  kennelId: string | null;
+  kennelShortName: string | null;
   hashName: string | null;
   nerdName: string | null;
   email: string | null;
@@ -74,7 +74,7 @@ export function RosterTable({
     if (sortKey === "hashName") {
       cmp = (a.hashName ?? "").localeCompare(b.hashName ?? "");
     } else if (sortKey === "kennelShortName") {
-      cmp = a.kennelShortName.localeCompare(b.kennelShortName);
+      cmp = (a.kennelShortName ?? "").localeCompare(b.kennelShortName ?? "");
     } else if (sortKey === "attendanceCount") {
       cmp = a.attendanceCount - b.attendanceCount;
     }
@@ -207,7 +207,7 @@ export function RosterTable({
                   {isSharedRoster && (
                     <td className="px-3 py-2">
                       <Badge variant="outline" className="text-xs">
-                        {h.kennelShortName}
+                        {h.kennelShortName ?? "—"}
                       </Badge>
                     </td>
                   )}

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -15,6 +15,7 @@ import {
   getOrCreateUser,
   getAdminUser,
   getMismanUser,
+  getRosterGroupId,
   getRosterKennelIds,
 } from "./auth";
 
@@ -154,6 +155,25 @@ describe("getMismanUser", () => {
     mockUserKennelFind.mockResolvedValueOnce(null);
 
     expect(await getMismanUser("kennel_1")).toBeNull();
+  });
+});
+
+describe("getRosterGroupId", () => {
+  it("returns groupId for a kennel in a roster group", async () => {
+    mockRosterGroupKennelFind.mockResolvedValueOnce({
+      groupId: "rg_1",
+    } as never);
+
+    const result = await getRosterGroupId("kennel_1");
+    expect(result).toBe("rg_1");
+  });
+
+  it("throws when kennel has no roster group", async () => {
+    mockRosterGroupKennelFind.mockResolvedValueOnce(null);
+
+    await expect(getRosterGroupId("kennel_missing")).rejects.toThrow(
+      "Kennel kennel_missing has no RosterGroup",
+    );
   });
 });
 

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -64,12 +64,14 @@ export function buildKennelHasher(
 ): KennelHasher {
   return {
     id: "kh_1",
+    rosterGroupId: "rg_1",
     kennelId: "kennel_1",
     hashName: "Mudflap",
     nerdName: "John Doe",
     email: null,
     phone: null,
     notes: null,
+    mergeLog: null,
     createdAt: new Date("2026-01-01"),
     updatedAt: new Date("2026-01-01"),
     ...overrides,


### PR DESCRIPTION
…dmin

- Add rosterGroupId to KennelHasher (explicit roster group scoping); make kennelId nullable as metadata
- Add getRosterGroupId() auth helper; refactor all roster/attendance/history queries
- Add merge duplicates workflow: scan (fuzzy matching), preview (stats/conflicts), execute (OR-merge attendance, transfer links, mergeLog audit)
- Add admin roster groups CRUD at /admin/roster-groups (create, add/remove kennels, rename, dissolve)
- Add kennel deletion guard (block when attendance exists, cascade-delete misman records)
- 498 tests passing (28 new)

https://claude.ai/code/session_019yCHvpUKg2UrN5JTLohav5