### PR TITLE
Add misman invite links for secure team onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ calendar + personal logbook + kennel directory.
 - CRON_SECRET=            # Secret for Vercel Cron auth (set in Vercel dashboard)
 - GOOGLE_CALENDAR_API_KEY= # For Google Calendar + Sheets APIs
 - GITHUB_TOKEN=           # GitHub PAT with repo scope (for filing issues from alerts)
+- NEXT_PUBLIC_APP_URL=    # Base URL for invite links (e.g., https://hashtracks.com)
 
 ## Important Files
 - `prisma/schema.prisma` — Full data model (THE source of truth for types)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,8 @@ model User {
   kennelHasherLinks   KennelHasherLink[]
   mismanRequests      MismanRequest[]
   recordedAttendances KennelAttendance[] @relation("RecordedAttendances")
+  sentInvites         MismanInvite[]     @relation("SentInvites")
+  acceptedInvites     MismanInvite[]     @relation("AcceptedInvites")
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
 }
@@ -66,6 +68,7 @@ model Kennel {
   // Misman relations
   kennelHashers  KennelHasher[]
   mismanRequests MismanRequest[]
+  mismanInvites  MismanInvite[]
   rosterGroups   RosterGroupKennel[]
   createdAt   DateTime       @default(now())
   updatedAt   DateTime       @updatedAt
@@ -489,4 +492,35 @@ model RosterGroupKennel {
 
   @@unique([groupId, kennelId])
   @@unique([kennelId]) // A kennel can only be in one Roster Group
+}
+
+// ── MISMAN INVITES ──
+
+model MismanInvite {
+  id           String             @id @default(cuid())
+  kennelId     String
+  inviterId    String             // Misman user ID who created the invite
+  inviteeEmail String?            // Optional: email of intended recipient (for future email integration)
+  token        String             @unique // crypto.randomBytes(32), base64url-encoded
+  status       MismanInviteStatus @default(PENDING)
+  expiresAt    DateTime           // Computed at creation: now() + configured duration
+  acceptedBy   String?            // User ID who redeemed the invite
+  acceptedAt   DateTime?
+  revokedAt    DateTime?
+
+  kennel   Kennel @relation(fields: [kennelId], references: [id])
+  inviter  User   @relation("SentInvites", fields: [inviterId], references: [id])
+  acceptor User?  @relation("AcceptedInvites", fields: [acceptedBy], references: [id])
+
+  createdAt DateTime @default(now())
+
+  @@index([kennelId, status])
+  @@index([token])
+}
+
+enum MismanInviteStatus {
+  PENDING   // Link generated, not yet used
+  ACCEPTED  // Invitee redeemed it
+  EXPIRED   // Display-only — checked at read time, not actively written
+  REVOKED   // Inviter cancelled before use
 }

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,134 @@
+import { redirect, notFound } from "next/navigation";
+import { cookies } from "next/headers";
+import Link from "next/link";
+import { getOrCreateUser } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { INVITE_COOKIE_NAME } from "@/lib/invite";
+import { redeemMismanInvite } from "@/app/misman/invite/actions";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+interface Props {
+  params: Promise<{ token: string }>;
+}
+
+export default async function InvitePage({ params }: Props) {
+  const { token } = await params;
+
+  // Check auth
+  const user = await getOrCreateUser();
+
+  if (user) {
+    // Authenticated: attempt to redeem immediately
+    const result = await redeemMismanInvite(token);
+
+    // Clear the invite cookie if set
+    const cookieStore = await cookies();
+    cookieStore.delete(INVITE_COOKIE_NAME);
+
+    if (result.success) {
+      redirect(`/kennels/${result.kennelSlug}?invited=true`);
+    }
+
+    // Redemption failed — show error
+    return (
+      <div className="mx-auto max-w-md space-y-6 py-12">
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-6 text-center">
+          <h1 className="text-xl font-bold">Unable to accept invite</h1>
+          <p className="mt-2 text-muted-foreground">{result.error}</p>
+          <Button asChild className="mt-4" variant="outline">
+            <Link href="/hareline">Go to Hareline</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Unauthenticated: validate token and show landing page
+  const invite = await prisma.mismanInvite.findUnique({
+    where: { token },
+    include: {
+      kennel: { select: { shortName: true, fullName: true } },
+      inviter: { select: { hashName: true } },
+    },
+  });
+
+  if (!invite) notFound();
+
+  const isExpired = invite.expiresAt <= new Date();
+  const isUsed = invite.status === "ACCEPTED";
+  const isRevoked = invite.status === "REVOKED";
+
+  if (isUsed || isRevoked || isExpired) {
+    const message = isUsed
+      ? "This invite has already been used."
+      : isRevoked
+        ? "This invite was cancelled."
+        : "This invite has expired. Ask the inviter for a new link.";
+
+    return (
+      <div className="mx-auto max-w-md space-y-6 py-12">
+        <div className="rounded-lg border p-6 text-center">
+          <h1 className="text-xl font-bold">Invite unavailable</h1>
+          <p className="mt-2 text-muted-foreground">{message}</p>
+          <Button asChild className="mt-4" variant="outline">
+            <Link href="/">Go to HashTracks</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Valid invite — set cookie and show landing page
+  const cookieStore = await cookies();
+  cookieStore.set(INVITE_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 3600, // 1 hour
+    path: "/",
+  });
+
+  const expiresFormatted = invite.expiresAt.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+  const inviterName = invite.inviter.hashName || "A kennel member";
+  const encodedRedirect = encodeURIComponent(`/invite/${token}`);
+
+  return (
+    <div className="mx-auto max-w-md space-y-6 py-12">
+      <div className="rounded-lg border p-6 text-center space-y-4">
+        <Badge variant="secondary" className="text-sm">
+          Misman Invite
+        </Badge>
+        <h1 className="text-2xl font-bold">{invite.kennel.fullName}</h1>
+        <p className="text-muted-foreground">
+          {inviterName} invited you to manage{" "}
+          <span className="font-medium">{invite.kennel.shortName}</span> on
+          HashTracks.
+        </p>
+
+        <div className="flex flex-col gap-2 pt-2">
+          <Button asChild size="lg">
+            <Link href={`/sign-up?redirect_url=${encodedRedirect}`}>
+              Sign Up to Accept
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/sign-in?redirect_url=${encodedRedirect}`}>
+              Already have an account? Sign In
+            </Link>
+          </Button>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          This invite expires on {expiresFormatted}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { SubscribeButton } from "@/components/kennels/SubscribeButton";
 import { MismanAccessButton } from "@/components/kennels/MismanAccessButton";
 import type { HarelineEvent } from "@/components/hareline/EventCard";
 import { CollapsibleEventList } from "@/components/kennels/CollapsibleEventList";
+import { MismanManagementSection } from "@/components/kennels/MismanManagementSection";
 
 export default async function KennelDetailPage({
   params,
@@ -127,6 +128,14 @@ export default async function KennelDetailPage({
           isAuthenticated={!!user}
         />
       </div>
+
+      {/* Misman Management — visible only to mismans/admins */}
+      {(userRole === "MISMAN" || userRole === "ADMIN") && (
+        <MismanManagementSection
+          kennelId={kennel.id}
+          kennelShortName={kennel.shortName}
+        />
+      )}
 
       {kennel.description && (
         <p className="text-muted-foreground">{kennel.description}</p>

--- a/src/app/misman/invite/actions.test.ts
+++ b/src/app/misman/invite/actions.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockMisman = { id: "misman_1", email: "misman@test.com" };
+const mockUser = { id: "user_1", email: "user@test.com" };
+
+vi.mock("@/lib/auth", () => ({
+  getOrCreateUser: vi.fn(),
+  getMismanUser: vi.fn(),
+}));
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    mismanInvite: {
+      count: vi.fn(),
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    userKennel: {
+      upsert: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/invite", () => ({
+  generateInviteToken: vi.fn().mockReturnValue("test-token-abc123"),
+  computeExpiresAt: vi.fn().mockReturnValue(new Date("2026-02-22T12:00:00Z")),
+  MAX_PENDING_PER_KENNEL: 20,
+}));
+
+import { getOrCreateUser, getMismanUser } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import {
+  createMismanInvite,
+  revokeMismanInvite,
+  listMismanInvites,
+  redeemMismanInvite,
+  getKennelMismans,
+} from "./actions";
+
+const mockMismanAuth = vi.mocked(getMismanUser);
+const mockUserAuth = vi.mocked(getOrCreateUser);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMismanAuth.mockResolvedValue(mockMisman as never);
+  mockUserAuth.mockResolvedValue(mockUser as never);
+});
+
+describe("createMismanInvite", () => {
+  it("returns error when not authorized", async () => {
+    mockMismanAuth.mockResolvedValueOnce(null);
+    expect(await createMismanInvite("kennel_1")).toEqual({
+      error: "Not authorized",
+    });
+  });
+
+  it("returns error when max pending invites reached", async () => {
+    vi.mocked(prisma.mismanInvite.count).mockResolvedValueOnce(20);
+    expect(await createMismanInvite("kennel_1")).toEqual({
+      error: "Maximum of 20 pending invites per kennel",
+    });
+  });
+
+  it("creates invite with correct fields", async () => {
+    vi.mocked(prisma.mismanInvite.count).mockResolvedValueOnce(0);
+    vi.mocked(prisma.mismanInvite.create).mockResolvedValueOnce({
+      id: "mi_1",
+      token: "test-token-abc123",
+      expiresAt: new Date("2026-02-22T12:00:00Z"),
+      kennel: { slug: "nych3" },
+    } as never);
+
+    const result = await createMismanInvite("kennel_1", "invitee@test.com", 7);
+    expect(result.data).toBeDefined();
+    expect(result.data!.token).toBe("test-token-abc123");
+    expect(result.data!.inviteUrl).toContain("/invite/test-token-abc123");
+
+    expect(prisma.mismanInvite.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          kennelId: "kennel_1",
+          inviterId: "misman_1",
+          inviteeEmail: "invitee@test.com",
+          token: "test-token-abc123",
+        }),
+      }),
+    );
+  });
+
+  it("trims empty email to null", async () => {
+    vi.mocked(prisma.mismanInvite.count).mockResolvedValueOnce(0);
+    vi.mocked(prisma.mismanInvite.create).mockResolvedValueOnce({
+      id: "mi_1",
+      token: "test-token-abc123",
+      expiresAt: new Date("2026-02-22T12:00:00Z"),
+      kennel: { slug: "nych3" },
+    } as never);
+
+    await createMismanInvite("kennel_1", "  ");
+    expect(prisma.mismanInvite.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          inviteeEmail: null,
+        }),
+      }),
+    );
+  });
+});
+
+describe("revokeMismanInvite", () => {
+  it("returns error when invite not found", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce(null);
+    expect(await revokeMismanInvite("mi_missing")).toEqual({
+      error: "Invite not found",
+    });
+  });
+
+  it("returns error when not authorized for kennel", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce({
+      id: "mi_1",
+      kennelId: "kennel_1",
+      status: "PENDING",
+      expiresAt: new Date("2099-01-01"),
+      kennel: { slug: "nych3" },
+    } as never);
+    mockMismanAuth.mockResolvedValueOnce(null);
+
+    expect(await revokeMismanInvite("mi_1")).toEqual({
+      error: "Not authorized",
+    });
+  });
+
+  it("returns error when invite is not PENDING", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce({
+      id: "mi_1",
+      kennelId: "kennel_1",
+      status: "ACCEPTED",
+      expiresAt: new Date("2099-01-01"),
+      kennel: { slug: "nych3" },
+    } as never);
+
+    expect(await revokeMismanInvite("mi_1")).toEqual({
+      error: "Invite is not pending",
+    });
+  });
+
+  it("returns error when invite already expired", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce({
+      id: "mi_1",
+      kennelId: "kennel_1",
+      status: "PENDING",
+      expiresAt: new Date("2020-01-01"),
+      kennel: { slug: "nych3" },
+    } as never);
+
+    expect(await revokeMismanInvite("mi_1")).toEqual({
+      error: "Invite has already expired",
+    });
+  });
+
+  it("revokes successfully", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce({
+      id: "mi_1",
+      kennelId: "kennel_1",
+      status: "PENDING",
+      expiresAt: new Date("2099-01-01"),
+      kennel: { slug: "nych3" },
+    } as never);
+    vi.mocked(prisma.mismanInvite.update).mockResolvedValueOnce({} as never);
+
+    const result = await revokeMismanInvite("mi_1");
+    expect(result).toEqual({ success: true });
+    expect(prisma.mismanInvite.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "mi_1" },
+        data: expect.objectContaining({ status: "REVOKED" }),
+      }),
+    );
+  });
+});
+
+describe("listMismanInvites", () => {
+  it("returns error when not authorized", async () => {
+    mockMismanAuth.mockResolvedValueOnce(null);
+    expect(await listMismanInvites("kennel_1")).toEqual({
+      error: "Not authorized",
+    });
+  });
+
+  it("returns invites with effective expired status", async () => {
+    const pastDate = new Date("2020-01-01");
+    const futureDate = new Date("2099-01-01");
+
+    vi.mocked(prisma.mismanInvite.findMany).mockResolvedValueOnce([
+      {
+        id: "mi_1",
+        inviteeEmail: "a@test.com",
+        status: "PENDING",
+        expiresAt: pastDate,
+        createdAt: new Date("2026-02-01"),
+        acceptedAt: null,
+        revokedAt: null,
+        inviter: { hashName: "TrailBoss", email: "boss@test.com" },
+        acceptor: null,
+      },
+      {
+        id: "mi_2",
+        inviteeEmail: null,
+        status: "PENDING",
+        expiresAt: futureDate,
+        createdAt: new Date("2026-02-10"),
+        acceptedAt: null,
+        revokedAt: null,
+        inviter: { hashName: "TrailBoss", email: "boss@test.com" },
+        acceptor: null,
+      },
+    ] as never);
+
+    const result = await listMismanInvites("kennel_1");
+    expect(result.data).toHaveLength(2);
+    expect(result.data![0].status).toBe("EXPIRED"); // PENDING past expiry
+    expect(result.data![1].status).toBe("PENDING"); // Still valid
+  });
+});
+
+describe("redeemMismanInvite", () => {
+  it("returns error when not authenticated", async () => {
+    mockUserAuth.mockResolvedValueOnce(null);
+    expect(await redeemMismanInvite("some-token")).toEqual({
+      error: "Not authenticated",
+    });
+  });
+
+  it("returns error when token not found", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce(null);
+    expect(await redeemMismanInvite("bad-token")).toEqual({
+      error: "Invite not found",
+    });
+  });
+
+  it("returns error when invite expired", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce({
+      id: "mi_1",
+      kennelId: "kennel_1",
+      status: "PENDING",
+      expiresAt: new Date("2020-01-01"),
+      kennel: { slug: "nych3" },
+    } as never);
+
+    expect(await redeemMismanInvite("expired-token")).toEqual({
+      error: "This invite has expired",
+    });
+  });
+
+  it("returns error when invite already accepted", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce({
+      id: "mi_1",
+      kennelId: "kennel_1",
+      status: "ACCEPTED",
+      expiresAt: new Date("2099-01-01"),
+      kennel: { slug: "nych3" },
+    } as never);
+
+    expect(await redeemMismanInvite("used-token")).toEqual({
+      error: "This invite has already been used",
+    });
+  });
+
+  it("returns error when invite revoked", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce({
+      id: "mi_1",
+      kennelId: "kennel_1",
+      status: "REVOKED",
+      expiresAt: new Date("2099-01-01"),
+      kennel: { slug: "nych3" },
+    } as never);
+
+    expect(await redeemMismanInvite("revoked-token")).toEqual({
+      error: "This invite was cancelled",
+    });
+  });
+
+  it("upserts UserKennel and marks invite accepted on success", async () => {
+    vi.mocked(prisma.mismanInvite.findUnique).mockResolvedValueOnce({
+      id: "mi_1",
+      kennelId: "kennel_1",
+      status: "PENDING",
+      expiresAt: new Date("2099-01-01"),
+      kennel: { slug: "nych3" },
+    } as never);
+    vi.mocked(prisma.userKennel.upsert).mockResolvedValueOnce({} as never);
+    vi.mocked(prisma.mismanInvite.update).mockResolvedValueOnce({} as never);
+
+    const result = await redeemMismanInvite("valid-token");
+    expect(result).toEqual({ success: true, kennelSlug: "nych3" });
+
+    expect(prisma.userKennel.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId_kennelId: { userId: "user_1", kennelId: "kennel_1" } },
+        update: { role: "MISMAN" },
+        create: { userId: "user_1", kennelId: "kennel_1", role: "MISMAN" },
+      }),
+    );
+
+    expect(prisma.mismanInvite.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "mi_1" },
+        data: expect.objectContaining({
+          status: "ACCEPTED",
+          acceptedBy: "user_1",
+        }),
+      }),
+    );
+  });
+});
+
+describe("getKennelMismans", () => {
+  it("returns error when not authorized", async () => {
+    mockMismanAuth.mockResolvedValueOnce(null);
+    expect(await getKennelMismans("kennel_1")).toEqual({
+      error: "Not authorized",
+    });
+  });
+
+  it("returns misman and admin users", async () => {
+    vi.mocked(prisma.userKennel.findMany).mockResolvedValueOnce([
+      {
+        user: { id: "u1", hashName: "TrailBoss", email: "boss@test.com" },
+        role: "MISMAN",
+        createdAt: new Date("2026-01-01"),
+      },
+      {
+        user: { id: "u2", hashName: null, email: "admin@test.com" },
+        role: "ADMIN",
+        createdAt: new Date("2025-06-01"),
+      },
+    ] as never);
+
+    const result = await getKennelMismans("kennel_1");
+    expect(result.data).toHaveLength(2);
+    expect(result.data![0]).toEqual(
+      expect.objectContaining({
+        userId: "u1",
+        hashName: "TrailBoss",
+        role: "MISMAN",
+      }),
+    );
+    expect(result.data![1]).toEqual(
+      expect.objectContaining({
+        userId: "u2",
+        email: "admin@test.com",
+        role: "ADMIN",
+      }),
+    );
+  });
+});

--- a/src/app/misman/invite/actions.ts
+++ b/src/app/misman/invite/actions.ts
@@ -1,0 +1,217 @@
+"use server";
+
+import { getOrCreateUser, getMismanUser } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+import {
+  generateInviteToken,
+  computeExpiresAt,
+  MAX_PENDING_PER_KENNEL,
+} from "@/lib/invite";
+
+/**
+ * Create a new misman invite link for a kennel.
+ * Only existing mismans/admins of the kennel can create invites.
+ */
+export async function createMismanInvite(
+  kennelId: string,
+  inviteeEmail?: string,
+  expiryDays?: number,
+) {
+  const user = await getMismanUser(kennelId);
+  if (!user) return { error: "Not authorized" };
+
+  // Guard: max pending invites per kennel
+  const pendingCount = await prisma.mismanInvite.count({
+    where: {
+      kennelId,
+      status: "PENDING",
+      expiresAt: { gt: new Date() },
+    },
+  });
+
+  if (pendingCount >= MAX_PENDING_PER_KENNEL) {
+    return { error: `Maximum of ${MAX_PENDING_PER_KENNEL} pending invites per kennel` };
+  }
+
+  const token = generateInviteToken();
+  const expiresAt = computeExpiresAt(expiryDays);
+
+  const invite = await prisma.mismanInvite.create({
+    data: {
+      kennelId,
+      inviterId: user.id,
+      inviteeEmail: inviteeEmail?.trim() || null,
+      token,
+      expiresAt,
+    },
+    include: {
+      kennel: { select: { slug: true } },
+    },
+  });
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  const inviteUrl = `${baseUrl}/invite/${token}`;
+
+  revalidatePath(`/kennels/${invite.kennel.slug}`);
+
+  return {
+    data: {
+      id: invite.id,
+      token,
+      inviteUrl,
+      expiresAt: invite.expiresAt.toISOString(),
+    },
+  };
+}
+
+/**
+ * Revoke a pending invite. Only mismans of the kennel can revoke.
+ */
+export async function revokeMismanInvite(inviteId: string) {
+  const invite = await prisma.mismanInvite.findUnique({
+    where: { id: inviteId },
+    include: { kennel: { select: { slug: true } } },
+  });
+  if (!invite) return { error: "Invite not found" };
+
+  const user = await getMismanUser(invite.kennelId);
+  if (!user) return { error: "Not authorized" };
+
+  if (invite.status !== "PENDING") return { error: "Invite is not pending" };
+  if (invite.expiresAt <= new Date()) return { error: "Invite has already expired" };
+
+  await prisma.mismanInvite.update({
+    where: { id: inviteId },
+    data: {
+      status: "REVOKED",
+      revokedAt: new Date(),
+    },
+  });
+
+  revalidatePath(`/kennels/${invite.kennel.slug}`);
+  return { success: true };
+}
+
+/**
+ * List invites for a kennel with effective status.
+ * PENDING invites past expiresAt are displayed as expired.
+ */
+export async function listMismanInvites(kennelId: string) {
+  const user = await getMismanUser(kennelId);
+  if (!user) return { error: "Not authorized" };
+
+  const invites = await prisma.mismanInvite.findMany({
+    where: { kennelId },
+    include: {
+      inviter: { select: { hashName: true, email: true } },
+      acceptor: { select: { hashName: true, email: true } },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+  });
+
+  const now = new Date();
+
+  const data = invites.map((inv) => {
+    // Compute effective status: PENDING past expiry is "expired"
+    const effectiveStatus =
+      inv.status === "PENDING" && inv.expiresAt <= now ? "EXPIRED" : inv.status;
+
+    return {
+      id: inv.id,
+      inviteeEmail: inv.inviteeEmail,
+      status: effectiveStatus,
+      expiresAt: inv.expiresAt.toISOString(),
+      createdAt: inv.createdAt.toISOString(),
+      acceptedAt: inv.acceptedAt?.toISOString() ?? null,
+      revokedAt: inv.revokedAt?.toISOString() ?? null,
+      inviterName: inv.inviter.hashName || inv.inviter.email,
+      acceptorName: inv.acceptor
+        ? inv.acceptor.hashName || inv.acceptor.email
+        : null,
+    };
+  });
+
+  return { data };
+}
+
+/**
+ * Redeem an invite token. Grants MISMAN role to the authenticated user.
+ */
+export async function redeemMismanInvite(token: string) {
+  const user = await getOrCreateUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const invite = await prisma.mismanInvite.findUnique({
+    where: { token },
+    include: { kennel: { select: { slug: true } } },
+  });
+
+  if (!invite) return { error: "Invite not found" };
+  if (invite.status !== "PENDING") {
+    if (invite.status === "ACCEPTED") return { error: "This invite has already been used" };
+    if (invite.status === "REVOKED") return { error: "This invite was cancelled" };
+    return { error: "This invite is no longer valid" };
+  }
+  if (invite.expiresAt <= new Date()) {
+    return { error: "This invite has expired" };
+  }
+
+  // Upsert UserKennel with MISMAN role (same pattern as approveMismanRequest)
+  await prisma.userKennel.upsert({
+    where: {
+      userId_kennelId: { userId: user.id, kennelId: invite.kennelId },
+    },
+    update: { role: "MISMAN" },
+    create: {
+      userId: user.id,
+      kennelId: invite.kennelId,
+      role: "MISMAN",
+    },
+  });
+
+  // Mark invite as accepted
+  await prisma.mismanInvite.update({
+    where: { id: invite.id },
+    data: {
+      status: "ACCEPTED",
+      acceptedBy: user.id,
+      acceptedAt: new Date(),
+    },
+  });
+
+  revalidatePath("/misman");
+  revalidatePath(`/kennels/${invite.kennel.slug}`);
+
+  return { success: true, kennelSlug: invite.kennel.slug };
+}
+
+/**
+ * Get all users with MISMAN or ADMIN role for a kennel.
+ */
+export async function getKennelMismans(kennelId: string) {
+  const user = await getMismanUser(kennelId);
+  if (!user) return { error: "Not authorized" };
+
+  const members = await prisma.userKennel.findMany({
+    where: {
+      kennelId,
+      role: { in: ["MISMAN", "ADMIN"] },
+    },
+    include: {
+      user: { select: { id: true, hashName: true, email: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const data = members.map((m) => ({
+    userId: m.user.id,
+    hashName: m.user.hashName,
+    email: m.user.email,
+    role: m.role,
+    since: m.createdAt.toISOString(),
+  }));
+
+  return { data };
+}

--- a/src/components/kennels/MismanManagementSection.tsx
+++ b/src/components/kennels/MismanManagementSection.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useState, useTransition, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { Copy, UserPlus, X } from "lucide-react";
+import {
+  createMismanInvite,
+  revokeMismanInvite,
+  listMismanInvites,
+  getKennelMismans,
+} from "@/app/misman/invite/actions";
+
+interface MismanManagementSectionProps {
+  kennelId: string;
+  kennelShortName: string;
+}
+
+interface MismanMember {
+  userId: string;
+  hashName: string | null;
+  email: string;
+  role: string;
+  since: string;
+}
+
+interface InviteRecord {
+  id: string;
+  inviteeEmail: string | null;
+  status: string;
+  expiresAt: string;
+  createdAt: string;
+  acceptedAt: string | null;
+  revokedAt: string | null;
+  inviterName: string;
+  acceptorName: string | null;
+}
+
+export function MismanManagementSection({
+  kennelId,
+  kennelShortName,
+}: MismanManagementSectionProps) {
+  const [isPending, startTransition] = useTransition();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [inviteeEmail, setInviteeEmail] = useState("");
+  const [expiryDays, setExpiryDays] = useState(7);
+  const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
+
+  const [mismans, setMismans] = useState<MismanMember[]>([]);
+  const [invites, setInvites] = useState<InviteRecord[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    loadData();
+  }, [kennelId]);
+
+  function loadData() {
+    startTransition(async () => {
+      const [mismanResult, inviteResult] = await Promise.all([
+        getKennelMismans(kennelId),
+        listMismanInvites(kennelId),
+      ]);
+      if (mismanResult.data) setMismans(mismanResult.data);
+      if (inviteResult.data) setInvites(inviteResult.data);
+      setLoaded(true);
+    });
+  }
+
+  function handleGenerate() {
+    startTransition(async () => {
+      const result = await createMismanInvite(
+        kennelId,
+        inviteeEmail || undefined,
+        expiryDays,
+      );
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      if (result.data) {
+        setGeneratedUrl(result.data.inviteUrl);
+        toast.success("Invite link generated");
+        loadData();
+      }
+    });
+  }
+
+  function handleCopy() {
+    if (generatedUrl) {
+      navigator.clipboard.writeText(generatedUrl);
+      toast.success("Link copied to clipboard");
+    }
+  }
+
+  function handleRevoke(inviteId: string) {
+    startTransition(async () => {
+      const result = await revokeMismanInvite(inviteId);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Invite revoked");
+        loadData();
+      }
+    });
+  }
+
+  function handleCloseDialog() {
+    setDialogOpen(false);
+    setInviteeEmail("");
+    setGeneratedUrl(null);
+  }
+
+  if (!loaded) {
+    return (
+      <div className="rounded-lg border p-4">
+        <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+
+  const statusColor: Record<string, string> = {
+    PENDING: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    ACCEPTED: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    EXPIRED: "bg-muted text-muted-foreground",
+    REVOKED: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  };
+
+  return (
+    <div className="rounded-lg border p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold">Misman Team</h2>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setDialogOpen(true)}
+        >
+          <UserPlus className="h-3.5 w-3.5 mr-1" />
+          Invite
+        </Button>
+      </div>
+
+      {/* Team list */}
+      <div className="space-y-1">
+        {mismans.map((m) => (
+          <div key={m.userId} className="flex items-center justify-between text-sm">
+            <span>{m.hashName || m.email}</span>
+            <Badge variant="outline" className="text-xs">
+              {m.role}
+            </Badge>
+          </div>
+        ))}
+        {mismans.length === 0 && (
+          <p className="text-xs text-muted-foreground">No team members found.</p>
+        )}
+      </div>
+
+      {/* Invite list */}
+      {invites.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-xs font-medium text-muted-foreground">Invites</h3>
+          {invites.map((inv) => (
+            <div
+              key={inv.id}
+              className="flex items-center justify-between text-xs"
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-medium ${statusColor[inv.status] || ""}`}
+                >
+                  {inv.status}
+                </span>
+                <span className="text-muted-foreground">
+                  {inv.inviteeEmail || "No email"}
+                </span>
+                {inv.acceptorName && (
+                  <span className="text-muted-foreground">
+                    — {inv.acceptorName}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-1">
+                <span className="text-muted-foreground">
+                  {new Date(inv.createdAt).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+                {inv.status === "PENDING" && (
+                  <button
+                    onClick={() => handleRevoke(inv.id)}
+                    className="ml-1 rounded p-0.5 text-muted-foreground hover:text-destructive"
+                    disabled={isPending}
+                    title="Revoke invite"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Generate invite dialog */}
+      <Dialog open={dialogOpen} onOpenChange={handleCloseDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Invite Misman — {kennelShortName}</DialogTitle>
+          </DialogHeader>
+
+          {!generatedUrl ? (
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="invite-email">
+                  Email (optional — for your records)
+                </Label>
+                <Input
+                  id="invite-email"
+                  type="email"
+                  placeholder="invitee@example.com"
+                  value={inviteeEmail}
+                  onChange={(e) => setInviteeEmail(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="invite-expiry">Link expires in</Label>
+                <select
+                  id="invite-expiry"
+                  value={expiryDays}
+                  onChange={(e) => setExpiryDays(parseInt(e.target.value, 10))}
+                  className="mt-1 w-full rounded border px-3 py-2 text-sm"
+                >
+                  <option value={1}>1 day</option>
+                  <option value={3}>3 days</option>
+                  <option value={7}>7 days</option>
+                  <option value={14}>14 days</option>
+                  <option value={30}>30 days</option>
+                </select>
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={handleCloseDialog}
+                  disabled={isPending}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={handleGenerate} disabled={isPending}>
+                  {isPending ? "Generating..." : "Generate Link"}
+                </Button>
+              </DialogFooter>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Share this link with the person you want to invite:
+              </p>
+              <div className="flex gap-2">
+                <Input
+                  value={generatedUrl}
+                  readOnly
+                  className="font-mono text-xs"
+                />
+                <Button variant="outline" size="icon" onClick={handleCopy}>
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                This link is single-use and expires in {expiryDays} day{expiryDays !== 1 ? "s" : ""}.
+              </p>
+              <DialogFooter>
+                <Button onClick={handleCloseDialog}>Done</Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/lib/invite.test.ts
+++ b/src/lib/invite.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { generateInviteToken, computeExpiresAt } from "./invite";
+
+describe("generateInviteToken", () => {
+  it("returns a 43-character base64url string", () => {
+    const token = generateInviteToken();
+    // 32 bytes = 43 base64url characters (ceil(32*4/3) = 43, no padding)
+    expect(token).toHaveLength(43);
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("produces unique values on consecutive calls", () => {
+    const tokens = new Set(Array.from({ length: 10 }, () => generateInviteToken()));
+    expect(tokens.size).toBe(10);
+  });
+});
+
+describe("computeExpiresAt", () => {
+  it("returns a date N days from now", () => {
+    const before = Date.now();
+    const result = computeExpiresAt(7);
+    const after = Date.now();
+
+    const expectedMin = before + 7 * 24 * 60 * 60 * 1000;
+    const expectedMax = after + 7 * 24 * 60 * 60 * 1000;
+
+    expect(result.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(result.getTime()).toBeLessThanOrEqual(expectedMax);
+  });
+
+  it("defaults to 7 days", () => {
+    const before = Date.now();
+    const result = computeExpiresAt();
+    const expected = before + 7 * 24 * 60 * 60 * 1000;
+
+    // Within 1 second tolerance
+    expect(Math.abs(result.getTime() - expected)).toBeLessThan(1000);
+  });
+
+  it("handles 1-day expiry", () => {
+    const before = Date.now();
+    const result = computeExpiresAt(1);
+    const expected = before + 1 * 24 * 60 * 60 * 1000;
+
+    expect(Math.abs(result.getTime() - expected)).toBeLessThan(1000);
+  });
+});

--- a/src/lib/invite.ts
+++ b/src/lib/invite.ts
@@ -1,0 +1,27 @@
+/**
+ * Invite token utilities for misman invite links.
+ * Pure functions — no DB or auth dependencies.
+ */
+
+import { randomBytes } from "crypto";
+
+const INVITE_TOKEN_BYTES = 32; // 256 bits of randomness
+const DEFAULT_EXPIRY_DAYS = 7;
+
+/** Generate a cryptographically secure, URL-safe invite token. */
+export function generateInviteToken(): string {
+  return randomBytes(INVITE_TOKEN_BYTES).toString("base64url");
+}
+
+/** Compute an expiration date from now. */
+export function computeExpiresAt(days: number = DEFAULT_EXPIRY_DAYS): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+/** Cookie name for persisting invite token across auth redirect. */
+export const INVITE_COOKIE_NAME = "__ht_invite_token";
+
+/** Maximum pending (unexpired, unredeemed) invites per kennel. */
+export const MAX_PENDING_PER_KENNEL = 20;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,7 @@ const isPublicRoute = createRouteMatcher([
   "/api/cron(.*)",
   "/kennels(.*)",
   "/hareline(.*)",
+  "/invite(.*)",
 ]);
 
 export default clerkMiddleware(async (auth, request) => {

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -6,6 +6,7 @@ import type {
   MismanRequest,
   KennelHasherLink,
   EventHare,
+  MismanInvite,
 } from "@/generated/prisma/client";
 
 export function buildRawEvent(overrides?: Partial<RawEventData>): RawEventData {
@@ -144,6 +145,25 @@ export function buildEventHare(
     userId: null,
     role: "HARE",
     sourceType: "MISMAN_SYNC",
+    ...overrides,
+  };
+}
+
+export function buildMismanInvite(
+  overrides?: Partial<MismanInvite>,
+): MismanInvite {
+  return {
+    id: "mi_1",
+    kennelId: "kennel_1",
+    inviterId: "misman_1",
+    inviteeEmail: null,
+    token: "test-token-abc123",
+    status: "PENDING",
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    acceptedBy: null,
+    acceptedAt: null,
+    revokedAt: null,
+    createdAt: new Date("2026-01-01"),
     ...overrides,
   };
 }


### PR DESCRIPTION
Single-use, expiring invite links let existing mismans grant misman access to others via a shareable URL. Supports both existing users (instant redemption) and new users (cookie-persisted token across sign-up flow). Adds management section to kennel page showing team members and invite history.

New: MismanInvite model, token generation utility, 5 server actions (create/revoke/list/redeem/getKennelMismans), invite landing page, MismanManagementSection component. 577 tests passing.

https://claude.ai/code/session_01QtHMk8hdavLwA7BfBAm1p7