### PR TITLE
Add interactive sample event actions for kennel resolution

### DIFF
--- a/src/app/admin/sources/actions.ts
+++ b/src/app/admin/sources/actions.ts
@@ -3,6 +3,8 @@
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { revalidatePath } from "next/cache";
+import { resolveKennelTag, clearResolverCache } from "@/pipeline/kennel-resolver";
+import { scrapeSource } from "@/pipeline/scrape";
 
 export async function createSource(formData: FormData) {
   const admin = await getAdminUser();
@@ -112,5 +114,210 @@ export async function deleteSource(sourceId: string) {
   ]);
 
   revalidatePath("/admin/sources");
+  return { success: true };
+}
+
+/**
+ * Link a known kennel to a source (for SOURCE_KENNEL_MISMATCH).
+ * The kennelTag must already resolve to a kennel — this just creates the SourceKennel link.
+ */
+export async function linkKennelToSourceDirect(
+  sourceId: string,
+  kennelTag: string,
+) {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Unauthorized" };
+
+  clearResolverCache();
+  const { kennelId, matched } = await resolveKennelTag(kennelTag);
+  if (!matched || !kennelId) {
+    return { error: `Cannot resolve "${kennelTag}" to a kennel` };
+  }
+
+  // Check if link already exists
+  const existing = await prisma.sourceKennel.findUnique({
+    where: { sourceId_kennelId: { sourceId, kennelId } },
+  });
+  if (existing) {
+    return { error: "Kennel is already linked to this source" };
+  }
+
+  await prisma.sourceKennel.create({
+    data: { sourceId, kennelId },
+  });
+
+  // Auto-resolve any matching SOURCE_KENNEL_MISMATCH alert for this source
+  const matchingAlerts = await prisma.alert.findMany({
+    where: {
+      sourceId,
+      type: "SOURCE_KENNEL_MISMATCH",
+      status: { in: ["OPEN", "ACKNOWLEDGED"] },
+    },
+  });
+  for (const alert of matchingAlerts) {
+    const ctx = alert.context as { tags?: string[] } | null;
+    if (ctx?.tags?.includes(kennelTag)) {
+      await prisma.alert.update({
+        where: { id: alert.id },
+        data: { status: "RESOLVED", resolvedAt: new Date(), resolvedBy: admin.id },
+      });
+    }
+  }
+
+  // Re-scrape to pick up previously blocked events
+  clearResolverCache();
+  await scrapeSource(sourceId, { force: true });
+
+  revalidatePath("/admin/sources");
+  revalidatePath(`/admin/sources/${sourceId}`);
+  revalidatePath("/admin/alerts");
+  return { success: true };
+}
+
+/**
+ * Create an alias mapping an unmatched tag to an existing kennel (for UNMATCHED_TAG).
+ */
+export async function createAliasForSource(
+  sourceId: string,
+  tag: string,
+  kennelId: string,
+) {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Unauthorized" };
+
+  // Check alias doesn't already exist
+  const existing = await prisma.kennelAlias.findFirst({
+    where: { alias: { equals: tag, mode: "insensitive" } },
+  });
+  if (existing) return { error: `Alias "${tag}" already exists` };
+
+  await prisma.kennelAlias.create({
+    data: { kennelId, alias: tag },
+  });
+
+  // Auto-resolve any matching UNMATCHED_TAGS alert
+  const matchingAlerts = await prisma.alert.findMany({
+    where: {
+      sourceId,
+      type: "UNMATCHED_TAGS",
+      status: { in: ["OPEN", "ACKNOWLEDGED"] },
+    },
+  });
+  for (const alert of matchingAlerts) {
+    const ctx = alert.context as { tags?: string[] } | null;
+    if (ctx?.tags) {
+      clearResolverCache();
+      const remaining: string[] = [];
+      for (const t of ctx.tags) {
+        const result = await resolveKennelTag(t);
+        if (!result.matched) remaining.push(t);
+      }
+      if (remaining.length === 0) {
+        await prisma.alert.update({
+          where: { id: alert.id },
+          data: { status: "RESOLVED", resolvedAt: new Date(), resolvedBy: admin.id },
+        });
+      }
+    }
+  }
+
+  // Re-scrape to pick up previously skipped events
+  clearResolverCache();
+  await scrapeSource(sourceId, { force: true });
+
+  revalidatePath("/admin/sources");
+  revalidatePath(`/admin/sources/${sourceId}`);
+  revalidatePath("/admin/alerts");
+  revalidatePath("/admin/kennels");
+  return { success: true };
+}
+
+/**
+ * Create a new kennel from an unmatched tag (for UNMATCHED_TAG).
+ */
+export async function createKennelForSource(
+  sourceId: string,
+  tag: string,
+  kennelData: { shortName: string; fullName: string; region: string },
+) {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Unauthorized" };
+
+  const slug = kennelData.shortName
+    .toLowerCase()
+    .replace(/[()]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  const kennelCode = kennelData.shortName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  // Check uniqueness
+  const existingKennel = await prisma.kennel.findFirst({
+    where: {
+      OR: [
+        { kennelCode },
+        { slug },
+        { shortName: kennelData.shortName, region: kennelData.region || "Unknown" },
+      ],
+    },
+  });
+  if (existingKennel) return { error: `Kennel "${kennelData.shortName}" already exists` };
+
+  // Create kennel
+  const newKennel = await prisma.kennel.create({
+    data: {
+      kennelCode,
+      shortName: kennelData.shortName,
+      fullName: kennelData.fullName || kennelData.shortName,
+      slug,
+      region: kennelData.region || "Unknown",
+      aliases: {
+        create: tag !== kennelData.shortName ? [{ alias: tag }] : [],
+      },
+    },
+  });
+
+  // Link to source
+  await prisma.sourceKennel.create({
+    data: { sourceId, kennelId: newKennel.id },
+  });
+
+  // Auto-resolve any matching UNMATCHED_TAGS alert
+  const matchingAlerts = await prisma.alert.findMany({
+    where: {
+      sourceId,
+      type: "UNMATCHED_TAGS",
+      status: { in: ["OPEN", "ACKNOWLEDGED"] },
+    },
+  });
+  for (const alert of matchingAlerts) {
+    const ctx = alert.context as { tags?: string[] } | null;
+    if (ctx?.tags) {
+      clearResolverCache();
+      const remaining: string[] = [];
+      for (const t of ctx.tags) {
+        const result = await resolveKennelTag(t);
+        if (!result.matched) remaining.push(t);
+      }
+      if (remaining.length === 0) {
+        await prisma.alert.update({
+          where: { id: alert.id },
+          data: { status: "RESOLVED", resolvedAt: new Date(), resolvedBy: admin.id },
+        });
+      }
+    }
+  }
+
+  // Re-scrape to pick up previously skipped events
+  clearResolverCache();
+  await scrapeSource(sourceId, { force: true });
+
+  revalidatePath("/admin/sources");
+  revalidatePath(`/admin/sources/${sourceId}`);
+  revalidatePath("/admin/alerts");
+  revalidatePath("/admin/kennels");
   return { success: true };
 }

--- a/src/components/admin/SampleEventActions.tsx
+++ b/src/components/admin/SampleEventActions.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+import {
+  linkKennelToSourceDirect,
+  createAliasForSource,
+  createKennelForSource,
+} from "@/app/admin/sources/actions";
+
+interface KennelOption {
+  id: string;
+  shortName: string;
+  score?: number;
+}
+
+interface SampleEventActionsProps {
+  sourceId: string;
+  reason: string;
+  kennelTag: string;
+  allKennels: { id: string; shortName: string }[];
+  suggestions?: KennelOption[];
+}
+
+export function SampleEventActions({
+  sourceId,
+  reason,
+  kennelTag,
+  allKennels,
+  suggestions = [],
+}: SampleEventActionsProps) {
+  if (reason === "SOURCE_KENNEL_MISMATCH") {
+    return (
+      <LinkToSourceAction sourceId={sourceId} kennelTag={kennelTag} />
+    );
+  }
+
+  if (reason === "UNMATCHED_TAG") {
+    return (
+      <UnmatchedTagAction
+        sourceId={sourceId}
+        kennelTag={kennelTag}
+        allKennels={allKennels}
+        suggestions={suggestions}
+      />
+    );
+  }
+
+  return null;
+}
+
+function LinkToSourceAction({
+  sourceId,
+  kennelTag,
+}: {
+  sourceId: string;
+  kennelTag: string;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [resolved, setResolved] = useState(false);
+  const router = useRouter();
+
+  if (resolved) {
+    return (
+      <Badge variant="outline" className="text-xs border-green-300 text-green-700">
+        Linked
+      </Badge>
+    );
+  }
+
+  function handleLink() {
+    startTransition(async () => {
+      const result = await linkKennelToSourceDirect(sourceId, kennelTag);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(`Linked "${kennelTag}" to source`);
+        setResolved(true);
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      className="h-7 text-xs shrink-0"
+      disabled={isPending}
+      onClick={handleLink}
+    >
+      {isPending ? "Linking..." : "Link to Source"}
+    </Button>
+  );
+}
+
+function UnmatchedTagAction({
+  sourceId,
+  kennelTag,
+  allKennels,
+  suggestions,
+}: {
+  sourceId: string;
+  kennelTag: string;
+  allKennels: { id: string; shortName: string }[];
+  suggestions: KennelOption[];
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [mode, setMode] = useState<"pick" | "create">("pick");
+  const [selectedKennelId, setSelectedKennelId] = useState<string>("");
+  const [resolved, setResolved] = useState(false);
+  const router = useRouter();
+
+  // New kennel fields
+  const [newShortName, setNewShortName] = useState(kennelTag);
+  const [newFullName, setNewFullName] = useState("");
+  const [newRegion, setNewRegion] = useState("");
+
+  if (resolved) {
+    return (
+      <Badge variant="outline" className="text-xs border-green-300 text-green-700">
+        Mapped
+      </Badge>
+    );
+  }
+
+  function handleMapToKennel() {
+    if (!selectedKennelId) return;
+    startTransition(async () => {
+      const result = await createAliasForSource(sourceId, kennelTag, selectedKennelId);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(`Mapped "${kennelTag}" to kennel`);
+        setResolved(true);
+        router.refresh();
+      }
+    });
+  }
+
+  function handleCreateKennel() {
+    if (!newShortName.trim()) return;
+    startTransition(async () => {
+      const result = await createKennelForSource(sourceId, kennelTag, {
+        shortName: newShortName.trim(),
+        fullName: newFullName.trim(),
+        region: newRegion.trim(),
+      });
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(`Created kennel "${newShortName}" and mapped "${kennelTag}"`);
+        setResolved(true);
+        router.refresh();
+      }
+    });
+  }
+
+  if (mode === "pick") {
+    return (
+      <div className="mt-2 space-y-2 rounded-md border bg-muted/30 p-2">
+        {/* Quick suggestions */}
+        {suggestions.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {suggestions.slice(0, 5).map((s) => (
+              <Button
+                key={s.id}
+                size="sm"
+                variant={selectedKennelId === s.id ? "default" : "outline"}
+                className="h-6 text-[11px]"
+                onClick={() => setSelectedKennelId(s.id)}
+              >
+                {s.shortName}
+                <span className="ml-1 opacity-60">
+                  {Math.round((s.score ?? 0) * 100)}%
+                </span>
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {/* Full kennel selector + action */}
+        <div className="flex items-center gap-2">
+          <Select value={selectedKennelId} onValueChange={setSelectedKennelId}>
+            <SelectTrigger className="h-7 text-xs w-48">
+              <SelectValue placeholder="Select kennel..." />
+            </SelectTrigger>
+            <SelectContent>
+              {allKennels.map((k) => (
+                <SelectItem key={k.id} value={k.id} className="text-xs">
+                  {k.shortName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            size="sm"
+            className="h-7 text-xs"
+            disabled={!selectedKennelId || isPending}
+            onClick={handleMapToKennel}
+          >
+            {isPending ? "..." : "Map & Fix"}
+          </Button>
+        </div>
+
+        <button
+          className="text-[11px] text-primary hover:underline"
+          onClick={() => setMode("create")}
+        >
+          Create new kennel instead
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 space-y-2 rounded-md border bg-muted/30 p-2">
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <Label className="text-[10px]">Short Name</Label>
+          <Input
+            value={newShortName}
+            onChange={(e) => setNewShortName(e.target.value)}
+            className="h-7 text-xs"
+          />
+        </div>
+        <div>
+          <Label className="text-[10px]">Full Name</Label>
+          <Input
+            value={newFullName}
+            onChange={(e) => setNewFullName(e.target.value)}
+            className="h-7 text-xs"
+            placeholder="Optional"
+          />
+        </div>
+        <div>
+          <Label className="text-[10px]">Region</Label>
+          <Input
+            value={newRegion}
+            onChange={(e) => setNewRegion(e.target.value)}
+            className="h-7 text-xs"
+            placeholder="e.g. New York City, NY"
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          className="h-7 text-xs"
+          disabled={!newShortName.trim() || isPending}
+          onClick={handleCreateKennel}
+        >
+          {isPending ? "..." : "Create & Map"}
+        </Button>
+        <button
+          className="text-[11px] text-muted-foreground hover:underline"
+          onClick={() => setMode("pick")}
+        >
+          Back to existing kennels
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds interactive UI components and server actions to resolve sample event issues directly from the source detail page. Users can now link kennels to sources or create aliases/new kennels for unmatched tags without leaving the admin interface.

## Key Changes

- **New Component: `SampleEventActions`** (`src/components/admin/SampleEventActions.tsx`)
  - Renders context-specific actions based on sample event reason (SOURCE_KENNEL_MISMATCH or UNMATCHED_TAG)
  - `LinkToSourceAction`: One-click button to link an already-resolved kennel tag to a source
  - `UnmatchedTagAction`: Two-mode interface to either map an unmatched tag to an existing kennel or create a new kennel with optional full name and region
  - Displays fuzzy-matched kennel suggestions with match scores
  - Shows success badges after resolution

- **New Server Actions** (`src/app/admin/sources/actions.ts`)
  - `linkKennelToSourceDirect()`: Creates SourceKennel link and auto-resolves matching SOURCE_KENNEL_MISMATCH alerts
  - `createAliasForSource()`: Creates a KennelAlias mapping and auto-resolves UNMATCHED_TAGS alerts
  - `createKennelForSource()`: Creates a new kennel with slug/code generation and auto-resolves alerts
  - All actions trigger cache clearing, re-scraping with force flag, and path revalidation

- **Updated Source Detail Page** (`src/app/admin/sources/[sourceId]/page.tsx`)
  - Fetches kennel aliases for fuzzy matching
  - Computes fuzzy match suggestions for each unmatched tag in sample events
  - Replaces static suggested action badges with interactive `SampleEventActions` components
  - Passes suggestions and kennel data to enable intelligent recommendations

## Implementation Details

- Fuzzy matching uses existing `fuzzyMatch` utility to rank kennel candidates by similarity to unmatched tags
- Auto-resolution checks remaining unmatched tags after each action; only marks alerts resolved when all tags are matched
- Kennel slug/code generation sanitizes short names for URL-safe identifiers
- All mutations trigger `scrapeSource` with `force: true` to reprocess previously blocked/skipped events
- UI uses compact sizing (h-7, text-xs) to fit naturally in table rows

https://claude.ai/code/session_01Eq2yUTC2wnv9GR6ndJ5YHR