### PR TITLE
Fix sample events not populating on non-forced scrapes

### DIFF
--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -115,9 +115,15 @@ export async function scrapeSource(
         errorDetails: hasErrorDetails
           ? (combinedErrorDetails as unknown as Prisma.InputJsonValue)
           : undefined,
-        // Phase 2B: Store sample blocked/skipped events
-        sampleBlocked: mergeResult.sampleBlocked as unknown as Prisma.InputJsonValue | undefined,
-        sampleSkipped: mergeResult.sampleSkipped as unknown as Prisma.InputJsonValue | undefined,
+        // Phase 2B: Store sample blocked/skipped events (only if non-empty;
+        // storing empty arrays would cause the page query to match scrape logs
+        // with no actual samples, masking older logs that had real samples)
+        sampleBlocked: mergeResult.sampleBlocked?.length
+          ? (mergeResult.sampleBlocked as unknown as Prisma.InputJsonValue)
+          : undefined,
+        sampleSkipped: mergeResult.sampleSkipped?.length
+          ? (mergeResult.sampleSkipped as unknown as Prisma.InputJsonValue)
+          : undefined,
         // Phase 3A: Performance timing
         fetchDurationMs,
         mergeDurationMs,


### PR DESCRIPTION
Two bugs caused the "Sample Events from Recent Scrape" section to
inconsistently show data:

1. Fingerprint dedup prevented sample collection: On non-forced scrapes,
   previously-seen blocked/skipped events were fingerprint-deduped before
   reaching the kennel resolution and sample collection logic. Now, when
   a deduped RawEvent is unprocessed, we still resolve the kennel tag to
   capture samples for ongoing issues.

2. Empty arrays masked real samples: Empty [] arrays were stored in
   sampleBlocked/sampleSkipped fields, which the page query matched via
   `{ not: Prisma.AnyNull }`, overshadowing older scrape logs that had
   actual samples. Now only non-empty arrays are stored; empty arrays
   become undefined (null in DB) so the query skips them.

https://claude.ai/code/session_012PjxWyreW85G9czeBe2igp