### PR TITLE
Add past event attendance confirmation flow for logbook

### DIFF
--- a/src/app/logbook/page.tsx
+++ b/src/app/logbook/page.tsx
@@ -48,7 +48,11 @@ export default async function LogbookPage() {
   }));
 
   const confirmedCount = entries.filter((e) => e.attendance.status === "CONFIRMED").length;
-  const goingCount = entries.filter((e) => e.attendance.status === "INTENDING").length;
+  const now = new Date();
+  const todayUtcNoon = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0);
+  const goingCount = entries.filter(
+    (e) => e.attendance.status === "INTENDING" && new Date(e.event.date).getTime() > todayUtcNoon
+  ).length;
 
   return (
     <div>


### PR DESCRIPTION
## Summary
This PR implements a new attendance confirmation workflow for past events in the logbook. Events that have already occurred now display a "Confirm Attendance" button for users with "INTENDING" status, allowing them to confirm their attendance after the event date.

## Key Changes
- **Attendance status handling**: Split the "INTENDING" badge logic to differentiate between future events (editable "Going" badge) and past events (confirmable "Confirm Attendance" badge)
- **Past event detection**: Introduced a UTC noon boundary (`todayUtcNoon`) to consistently determine whether an event is in the past or future across the application
- **Server action integration**: Added `confirmAttendance` server action call with proper error handling and user feedback via toast notifications
- **UI/UX improvements**: 
  - Past "INTENDING" events now show an amber-colored "Confirm Attendance" badge instead of blue
  - Loading state displays "..." while confirmation is in progress
  - Success/error messages displayed via toast notifications
- **Stats update**: Modified the "going count" on the logbook page to only include future events with "INTENDING" status, excluding past events that need confirmation

## Implementation Details
- Used `useTransition` hook for optimistic UI updates during the confirmation request
- Implemented consistent date boundary logic (UTC noon) in both the component and page to ensure consistent behavior
- Added router refresh after successful confirmation to update the UI with the new attendance status

https://claude.ai/code/session_018S11r79U7Hu682wVWAizBp