### PR TITLE
Group kennels by region in roster admin dialogs

### DIFF
--- a/src/app/admin/roster-groups/actions.ts
+++ b/src/app/admin/roster-groups/actions.ts
@@ -15,7 +15,7 @@ export async function getRosterGroups() {
     include: {
       kennels: {
         include: {
-          kennel: { select: { id: true, shortName: true, slug: true } },
+          kennel: { select: { id: true, shortName: true, fullName: true, region: true, slug: true } },
         },
       },
       _count: { select: { kennelHashers: true } },
@@ -30,6 +30,8 @@ export async function getRosterGroups() {
       kennels: g.kennels.map((k) => ({
         id: k.kennel.id,
         shortName: k.kennel.shortName,
+        fullName: k.kennel.fullName,
+        region: k.kennel.region,
         slug: k.kennel.slug,
       })),
       hasherCount: g._count.kennelHashers,


### PR DESCRIPTION
## Summary
Enhanced the roster groups admin interface to organize kennels by region in both create and edit dialogs, improving usability when managing large numbers of kennels.

## Key Changes
- Added `groupByRegion()` utility function to organize kennels by their region with alphabetical sorting
- Imported and integrated `RegionBadge` component to visually display region information
- Updated `KennelOption` type to include `fullName` and `region` fields
- Modified kennel selection UI in both `CreateGroupDialog` and `EditGroupDialog` to:
  - Display kennels grouped by region with collapsible sections
  - Show full kennel names with short names in parentheses for better clarity
  - Increase max-height from 60 to 72 units for better visibility
  - Add visual indentation and spacing for grouped items
- Updated data fetching in `getRosterGroups()` action to include `fullName` and `region` fields from the database
- Ensured `allKennels` in edit dialog properly includes region and fullName data from both current group members and standalone kennels

## Implementation Details
- The `groupByRegion()` function handles generic types with `region` and `shortName` properties, making it reusable
- Region headers display with a badge and label for visual consistency
- Kennel list items now show both full and short names to help users identify kennels more easily
- The "(current)" indicator in the edit dialog is preserved to show which kennels are already in the group

https://claude.ai/code/session_011zGB8aTzMpdVSMjBnghjCL