### PR TITLE
Add SFH3 skipPatterns to seed and harden TH3 field parsing (with tests)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -826,6 +826,7 @@ async function main() {
           ["^26\\.2H3", "26.2H3"],
         ],
         defaultKennelTag: "SFH3",
+        skipPatterns: ["^Hand Pump", "^Workday"],
       },
       kennelCodes: ["sfh3", "gph3", "ebh3", "svh3", "fhac-u", "agnews", "barh3", "marinh3", "fch3", "sffmh3", "vmh3", "mwh3", "262h3"],
     },

--- a/src/adapters/html-scraper/chicago-th3.test.ts
+++ b/src/adapters/html-scraper/chicago-th3.test.ts
@@ -124,6 +124,22 @@ describe("parseBodyFields", () => {
     expect(result.hares).toBe("Only Runner");
     expect(result.location).toBeUndefined();
   });
+
+
+  it("does not stop location at bare label words inside values", () => {
+    const body = "WHERE: Meet at When Pigs Fly, near Hare & Hounds Pub  HARE: Solo Runner";
+    const result = parseBodyFields(body);
+    expect(result.location).toBe("Meet at When Pigs Fly, near Hare & Hounds Pub");
+    expect(result.hares).toBe("Solo Runner");
+  });
+
+  it("supports dash delimiters while preserving label words in values", () => {
+    const body = "WHERE - The When and Where Tavern HARE - Hare Trigger WHEN - 7:30 PM";
+    const result = parseBodyFields(body);
+    expect(result.location).toBe("The When and Where Tavern");
+    expect(result.hares).toBe("Hare Trigger");
+    expect(result.startTime).toBe("19:30");
+  });
 });
 
 const SAMPLE_HTML = `

--- a/src/adapters/html-scraper/chicago-th3.ts
+++ b/src/adapters/html-scraper/chicago-th3.ts
@@ -75,10 +75,11 @@ export function parseBodyFields(bodyText: string): {
   // Known labels as delimiters
   const labels = ["HARE", "HARES", "WHERE", "WHEN", "HASH CASH", "WALKER'?S TRAIL", "ON-?OUT"];
   const labelPattern = labels.join("|");
+  const fieldDelimiter = "\\s*[:\\-–—]\\s*";
 
   // Extract "WHERE" field → location
   const whereMatch = bodyText.match(
-    new RegExp(`WHERE[:\\s]+(.+?)(?=(?:${labelPattern})[:\\s]|$)`, "is"),
+    new RegExp(`WHERE${fieldDelimiter}(.+?)(?=(?:${labelPattern})${fieldDelimiter}|$)`, "is"),
   );
   if (whereMatch) {
     result.location = whereMatch[1].trim().replace(/\s+/g, " ");
@@ -86,7 +87,7 @@ export function parseBodyFields(bodyText: string): {
 
   // Extract "HARE" or "HARES" field
   const hareMatch = bodyText.match(
-    new RegExp(`HARES?[:\\s]+(.+?)(?=(?:${labelPattern})[:\\s]|$)`, "is"),
+    new RegExp(`HARES?${fieldDelimiter}(.+?)(?=(?:${labelPattern})${fieldDelimiter}|$)`, "is"),
   );
   if (hareMatch) {
     result.hares = hareMatch[1].trim().replace(/\s+/g, " ");
@@ -94,7 +95,7 @@ export function parseBodyFields(bodyText: string): {
 
   // Extract "HASH CASH" field
   const cashMatch = bodyText.match(
-    new RegExp(`HASH CASH[:\\s]+(.+?)(?=(?:${labelPattern})[:\\s]|$)`, "is"),
+    new RegExp(`HASH CASH${fieldDelimiter}(.+?)(?=(?:${labelPattern})${fieldDelimiter}|$)`, "is"),
   );
   if (cashMatch) {
     result.hashCash = cashMatch[1].trim().replace(/\s+/g, " ");
@@ -102,7 +103,7 @@ export function parseBodyFields(bodyText: string): {
 
   // Extract "WALKER'S TRAIL" field
   const walkerMatch = bodyText.match(
-    new RegExp(`WALKER'?S TRAIL[:\\s]+(.+?)(?=(?:${labelPattern})[:\\s]|$)`, "is"),
+    new RegExp(`WALKER'?S TRAIL${fieldDelimiter}(.+?)(?=(?:${labelPattern})${fieldDelimiter}|$)`, "is"),
   );
   if (walkerMatch) {
     result.walkersTrail = walkerMatch[1].trim().replace(/\s+/g, " ");
@@ -110,7 +111,7 @@ export function parseBodyFields(bodyText: string): {
 
   // Extract time from "WHEN" field
   const whenMatch = bodyText.match(
-    new RegExp(`WHEN[:\\s]+(.+?)(?=(?:${labelPattern})[:\\s]|$)`, "is"),
+    new RegExp(`WHEN${fieldDelimiter}(.+?)(?=(?:${labelPattern})${fieldDelimiter}|$)`, "is"),
   );
   if (whenMatch) {
     const whenText = whenMatch[1].trim();


### PR DESCRIPTION
### Motivation
- Ensure the SFH3 HTML source filters the same known non-run rows as the iCal source by adding missing `skipPatterns` to the seeded config.
- Prevent TH3 parser regexes from truncating field values when label words appear inside those values by requiring explicit delimiters.
- Add regression tests to lock in the corrected parsing behavior and support dash-delimited labels.

### Description
- Added `skipPatterns: ["^Hand Pump", "^Workday"]` to the `SFH3 MultiHash HTML Hareline` seed config in `prisma/seed.ts` so HTML seed parity matches iCal behavior.
- Introduced a `fieldDelimiter` pattern and updated TH3 field extractor regexes in `src/adapters/html-scraper/chicago-th3.ts` to require explicit delimiters (`:`, `-`, `–`, `—`) for `WHERE`, `HARE(S)`, `HASH CASH`, `WALKER'S TRAIL`, and `WHEN` fields.
- Fixed string escaping for the delimiter pattern so the runtime `RegExp` is constructed correctly in TypeScript.
- Added two regression tests to `src/adapters/html-scraper/chicago-th3.test.ts` that ensure label words inside values do not truncate fields and that dash-delimited labels parse correctly.

### Testing
- Ran the targeted test command `pnpm -s vitest run src/adapters/html-scraper/chicago-th3.test.ts src/adapters/html-scraper/sfh3.test.ts` and all tests passed.
- Both `chicago-th3` and `sfh3` test suites completed successfully with the new tests included.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997516f37d0832faf4143a72c8a2c80)