### PR TITLE
Phase 3: Test Config preview mode

### DIFF
--- a/src/components/admin/PreviewResults.tsx
+++ b/src/components/admin/PreviewResults.tsx
@@ -66,7 +66,7 @@ export function PreviewResults({ data }: PreviewResultsProps) {
             </thead>
             <tbody>
               {data.events.map((event, i) => (
-                <tr key={i} className="border-b last:border-0">
+                <tr key={`${event.date}-${event.kennelTag}-${i}`} className="border-b last:border-0">
                   <td className="whitespace-nowrap px-2 py-1">
                     {event.date}
                   </td>
@@ -127,7 +127,7 @@ export function PreviewResults({ data }: PreviewResultsProps) {
           {data.errors.length <= 3 ? (
             <ul className="list-inside list-disc text-xs text-destructive">
               {data.errors.map((err, i) => (
-                <li key={i}>{err}</li>
+                <li key={`${i}-${err.slice(0, 40)}`}>{err}</li>
               ))}
             </ul>
           ) : (
@@ -144,7 +144,7 @@ export function PreviewResults({ data }: PreviewResultsProps) {
               {showErrors && (
                 <ul className="list-inside list-disc text-xs text-destructive">
                   {data.errors.map((err, i) => (
-                    <li key={i}>{err}</li>
+                    <li key={`${i}-${err.slice(0, 40)}`}>{err}</li>
                   ))}
                 </ul>
               )}

--- a/src/components/admin/SourceForm.tsx
+++ b/src/components/admin/SourceForm.tsx
@@ -187,6 +187,12 @@ export function SourceForm({ source, allKennels, trigger }: SourceFormProps) {
     }
   }
 
+  function closeDialog() {
+    setOpen(false);
+    setPreviewData(null);
+    setPreviewError(null);
+  }
+
   function handlePreview() {
     if (!formRef.current) return;
     const fd = new FormData(formRef.current);
@@ -223,7 +229,7 @@ export function SourceForm({ source, allKennels, trigger }: SourceFormProps) {
         toast.error(result.error);
       } else {
         toast.success(source ? "Source updated" : "Source created");
-        setOpen(false);
+        closeDialog();
         if (!source) {
           setSelectedKennels([]);
           setConfigJson("");
@@ -241,11 +247,8 @@ export function SourceForm({ source, allKennels, trigger }: SourceFormProps) {
 
   return (
     <Dialog open={open} onOpenChange={(v) => {
-      setOpen(v);
-      if (!v) {
-        setPreviewData(null);
-        setPreviewError(null);
-      }
+      if (v) setOpen(true);
+      else closeDialog();
     }}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent
@@ -481,7 +484,7 @@ export function SourceForm({ source, allKennels, trigger }: SourceFormProps) {
             <Button
               type="button"
               variant="outline"
-              onClick={() => setOpen(false)}
+              onClick={() => closeDialog()}
             >
               Cancel
             </Button>


### PR DESCRIPTION
## Summary
- Adds a **Test Config** button to the admin source form that fetches events using the current URL/type/config **without any DB writes**
- Admins can iterate on adapter config (kennel patterns, skip patterns, etc.) and see live results before saving
- Resolves kennel tags read-only and shows which tags are matched (green) vs unmatched (amber)

## What's New

### `previewSourceConfig` server action (`preview-action.ts`)
- Builds a mock `Source` object from form values (no DB record needed)
- Calls `adapter.fetch()` → pure data fetch with no side effects
- Runs `computeFillRates()` for quality stats
- Resolves each unique kennel tag via `resolveKennelTag()` (read-only DB queries)
- Returns first 25 events + total count + fill rates + errors + unmatched tags

### `PreviewResults` component
- Summary bar: event count, unique kennel tags, unmatched/error badges
- Fill rate bar: title/location/hares/time/runNumber percentages
- Scrollable event table (max 25 rows, `max-h-[300px]`)
- Kennel tags color-coded: green badge = resolved, amber badge = unmatched
- Unmatched tags section with full list
- Collapsible error list (auto-collapsed when >3 errors)

### `SourceForm` wiring
- Separate `useTransition` for preview (doesn't block save button)
- Form ref for building FormData from current form state
- Preview state cleared when dialog closes
- Button disabled during preview or save operations

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 1117 tests pass (`npm test`) — 11 new preview action tests
- [ ] Edit existing source (e.g. BFM Calendar) → click Test Config → verify events appear with green kennel tags
- [ ] Edit SFH3 iCal → Test Config → verify 14 kennel patterns resolve
- [ ] Bad config (invalid regex) → Test Config → verify validation error shown
- [ ] New source with URL + type → Test Config → verify adapter fetches events
- [ ] Verify unmatched tags show amber + listed in summary
- [ ] Verify dialog scrolls cleanly with 25 rows of preview data

🤖 Generated with [Claude Code](https://claude.com/claude-code)