### PR TITLE
Move API key from URL params to request headers in Blogger API

### DIFF
--- a/src/adapters/blogger-api.test.ts
+++ b/src/adapters/blogger-api.test.ts
@@ -60,14 +60,21 @@ describe("fetchBloggerPosts", () => {
     expect(result.posts[1].title).toBe("Run #265");
     expect(result.fetchDurationMs).toBeDefined();
 
-    // Verify correct API URLs were called
+    // Verify correct API URLs were called (API key in header, not URL)
     const calls = vi.mocked(fetch).mock.calls;
     expect(calls[0][0]).toContain("/blogs/byurl");
     expect(calls[0][0]).toContain("url=http%3A%2F%2Fwww.example.com%2F");
-    expect(calls[0][0]).toContain("key=test-api-key");
+    expect(calls[0][0]).not.toContain("key=");
     expect(calls[1][0]).toContain("/blogs/12345/posts");
     expect(calls[1][0]).toContain("maxResults=25");
     expect(calls[1][0]).toContain("fetchBodies=true");
+    expect(calls[1][0]).not.toContain("key=");
+
+    // Verify API key is sent via header
+    const blogLookupInit = calls[0][1] as RequestInit;
+    expect(blogLookupInit.headers).toEqual({ "X-Goog-Api-Key": "test-api-key" });
+    const postsInit = calls[1][1] as RequestInit;
+    expect(postsInit.headers).toEqual({ "X-Goog-Api-Key": "test-api-key" });
   });
 
   it("passes custom maxResults", async () => {


### PR DESCRIPTION
## Summary
Refactored the Blogger API adapter to pass the API key via request headers instead of URL query parameters, improving security and following best practices for API authentication.

## Key Changes
- **Authentication method**: Moved API key from URL query parameters to the `X-Goog-Api-Key` header
  - Created `authHeaders` object with the API key header
  - Updated both blog lookup and posts fetch requests to use the header
  
- **URL parameter handling**: Refactored URL construction to use `URLSearchParams` for cleaner parameter management
  - Blog lookup URL now uses `URLSearchParams` instead of string concatenation
  - Posts URL now uses `URLSearchParams` instead of string concatenation
  - Removed API key from URL construction in both endpoints

- **Type safety improvements**: Enhanced TypeScript type annotations
  - Added explicit type assertions for API response objects (`as { id?: string }` and `as { items?: unknown[] }`)
  - Improved null-safety with optional chaining (`blogData?.id ?? ""`)
  - Refactored post mapping to use explicit type casting for better clarity

- **Test updates**: Updated test assertions to verify the new authentication approach
  - Verified API key is no longer in URL parameters
  - Added assertions to confirm API key is sent via request headers
  - Maintained existing URL parameter validation

## Implementation Details
The API key is now consistently passed via the `X-Goog-Api-Key` header for both the blog lookup and posts fetch operations, which is the recommended approach for Google APIs and reduces the risk of accidental key exposure in logs or browser history.

https://claude.ai/code/session_01VJXCYb4Ea5nojnwXUNLFwR