### PR TITLE
feat: robust timezone handling with user time preference toggle

### DIFF
--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -109,7 +109,8 @@ export function regionTimezone(region: string): string {
   // Case-insensitive partial match fallback (handles variants like "London, England")
   const lc = region.toLowerCase();
   for (const [key, cfg] of Object.entries(REGION_CONFIG)) {
-    if (lc.includes(key.toLowerCase()) || key.toLowerCase().includes(lc)) {
+    const keyLc = key.toLowerCase();
+    if (lc.includes(keyLc) || keyLc.includes(lc)) {
       return cfg.tz;
     }
   }


### PR DESCRIPTION
## Summary

Implements end-to-end improvements to how HashTracks handles event timezones and displays times to users.

## Changes

### New Features
- **Time preference toggle** in the site header — users can switch between **Event Local Time** and **My Local Time** (browser timezone)
- Preference is persisted to the database via a new `timeDisplayPref` column on the `User` model
- New `/api/user/preferences` API route to update the preference

### Bug Fixes
- **London events showing EST** — `regionTimezone()` now does case-insensitive partial matching, plus added UK region variants (`London, England`, `Barnes`, `Enfield`, etc.) so UK kennels no longer fall back to `America/New_York`
- **NASS 7AM instead of 2PM** — the fingerprint dedup in the merge pipeline now **refreshes `dateUtc` and `timezone`** on already-processed events each scrape, so stale timestamps (stored before this PR) are automatically backfilled
- Hydration mismatches fixed with `suppressHydrationWarning` on browser-timezone-dependent renders

### Pipeline Improvements
- `composeUtcStart()` in `src/lib/timezone.ts` — converts event local start time to absolute UTC using the event's IANA timezone
- `merge.ts` — region lookup cached to eliminate N+1 queries; `handleDuplicateFingerprint` replaces the old function to also refresh computed fields

### Schema
- Added `TimeDisplayPref` enum (`EVENT_LOCAL` | `USER_LOCAL`) to Prisma schema
- Added `timeDisplayPref` field to `User` model (default: `EVENT_LOCAL`)

## Testing
- All existing tests pass (`npm run test`)
- Local production build passes (`npm run build`)
- `prisma db push` applied to production database