### PR TITLE
feat: add misman access request from dashboard

### DIFF
--- a/src/app/misman/page.tsx
+++ b/src/app/misman/page.tsx
@@ -63,6 +63,12 @@ export default async function MismanPage() {
     orderBy: { createdAt: "desc" },
   });
 
+  // Fetch all kennels for the "request another kennel" picker
+  const allKennels = await prisma.kennel.findMany({
+    select: { id: true, shortName: true, fullName: true, region: true },
+    orderBy: { shortName: "asc" },
+  });
+
   const serializedKennels = mismanKennels.map((mk) => ({
     ...mk.kennel,
     role: mk.role,
@@ -78,6 +84,7 @@ export default async function MismanPage() {
 
   const serializedMyRequests = myPendingRequests.map((r) => ({
     id: r.id,
+    kennelId: r.kennelId,
     kennel: r.kennel,
     message: r.message,
     createdAt: r.createdAt.toISOString(),
@@ -112,6 +119,7 @@ export default async function MismanPage() {
       myPendingRequests={serializedMyRequests}
       myPendingRosterGroupRequests={serializedRosterGroupRequests}
       isSiteAdmin={isSiteAdmin}
+      allKennels={allKennels}
     />
   );
 }

--- a/src/components/misman/MismanDashboard.tsx
+++ b/src/components/misman/MismanDashboard.tsx
@@ -3,12 +3,21 @@
 import Link from "next/link";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { ChevronsUpDownIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import {
   Dialog,
   DialogContent,
@@ -17,10 +26,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { toast } from "sonner";
+import {
+  KennelOptionLabel,
+  type KennelOptionData,
+} from "@/components/kennels/KennelOptionLabel";
 import {
   approveMismanRequest,
   rejectMismanRequest,
+  requestMismanAccessFromDashboard,
   requestRosterGroup,
 } from "@/app/misman/actions";
 
@@ -43,6 +62,7 @@ interface PendingRequest {
 
 interface MyPendingRequest {
   id: string;
+  kennelId: string;
   kennel: { shortName: string; slug: string };
   message: string | null;
   createdAt: string;
@@ -62,6 +82,7 @@ interface MismanDashboardProps {
   myPendingRequests: MyPendingRequest[];
   myPendingRosterGroupRequests: MyPendingRosterGroupRequest[];
   isSiteAdmin: boolean;
+  allKennels: KennelOptionData[];
 }
 
 export function MismanDashboard({
@@ -70,6 +91,7 @@ export function MismanDashboard({
   myPendingRequests,
   myPendingRosterGroupRequests,
   isSiteAdmin,
+  allKennels,
 }: MismanDashboardProps) {
   const [showRosterGroupDialog, setShowRosterGroupDialog] = useState(false);
 
@@ -177,15 +199,15 @@ export function MismanDashboard({
           <p className="text-muted-foreground">
             You don&apos;t have misman access to any kennels yet.
           </p>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Visit a{" "}
-            <Link href="/kennels" className="text-primary hover:underline">
-              kennel&apos;s page
-            </Link>{" "}
-            to request misman access.
-          </p>
         </div>
       )}
+
+      {/* Request access to another kennel */}
+      <RequestAnotherKennelSection
+        allKennels={allKennels}
+        managedKennelIds={kennels.map((k) => k.id)}
+        pendingRequestKennelIds={myPendingRequests.map((r) => r.kennelId)}
+      />
 
       {/* Request Shared Roster dialog */}
       <RequestRosterGroupDialog
@@ -193,6 +215,124 @@ export function MismanDashboard({
         onClose={() => setShowRosterGroupDialog(false)}
         kennels={kennels}
       />
+    </div>
+  );
+}
+
+function RequestAnotherKennelSection({
+  allKennels,
+  managedKennelIds,
+  pendingRequestKennelIds,
+}: {
+  allKennels: KennelOptionData[];
+  managedKennelIds: string[];
+  pendingRequestKennelIds: string[];
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [selectedKennel, setSelectedKennel] = useState<KennelOptionData | null>(
+    null,
+  );
+  const [message, setMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const excludedIds = new Set([
+    ...managedKennelIds,
+    ...pendingRequestKennelIds,
+  ]);
+  const eligibleKennels = allKennels.filter((k) => !excludedIds.has(k.id));
+
+  if (eligibleKennels.length === 0) return null;
+
+  function handleSubmit() {
+    if (!selectedKennel) return;
+    startTransition(async () => {
+      const result = await requestMismanAccessFromDashboard(
+        selectedKennel.id,
+        message || undefined,
+      );
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(
+          `Misman access requested for ${selectedKennel.shortName}`,
+        );
+        setSelectedKennel(null);
+        setMessage("");
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-lg border border-dashed p-6 space-y-4">
+      <div>
+        <h3 className="font-semibold">Missing a kennel?</h3>
+        <p className="text-sm text-muted-foreground">
+          If you&apos;re the misman for another kennel, request access here.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              className="w-full max-w-sm justify-between font-normal"
+            >
+              {selectedKennel
+                ? selectedKennel.shortName
+                : "Search and select a kennel..."}
+              <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            className="w-[var(--radix-popover-trigger-width)] p-0"
+            align="start"
+          >
+            <Command>
+              <CommandInput placeholder="Search kennels..." />
+              <CommandList>
+                <CommandEmpty>No kennels found.</CommandEmpty>
+                <CommandGroup>
+                  {eligibleKennels.map((k) => (
+                    <CommandItem
+                      key={k.id}
+                      value={`${k.shortName} ${k.fullName} ${k.region}`}
+                      onSelect={() => {
+                        setSelectedKennel(k);
+                        setPickerOpen(false);
+                      }}
+                    >
+                      <KennelOptionLabel kennel={k} />
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        {selectedKennel && (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="dashboard-misman-message">
+                Message (optional)
+              </Label>
+              <Textarea
+                id="dashboard-misman-message"
+                placeholder="I'm the misman for this kennel..."
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                rows={2}
+              />
+            </div>
+            <Button onClick={handleSubmit} disabled={isPending} size="sm">
+              {isPending ? "Requesting..." : "Request Access"}
+            </Button>
+          </>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Adds a "Missing a kennel?" section to the misman dashboard so existing mismans can request access to additional kennels without navigating to each kennel's public page. Includes searchable kennel picker, optional message, and auto-subscribes the user if not already a member.

https://claude.ai/code/session_01THYKqnFw2DsUUVeRkXk98J