### PR TITLE
feat(meetup): pre-detect groupUrlname + MEETUP config validation

### DIFF
--- a/src/app/admin/sources/config-validation.test.ts
+++ b/src/app/admin/sources/config-validation.test.ts
@@ -7,6 +7,7 @@ describe("validateSourceConfig", () => {
       expect(validateSourceConfig("GOOGLE_CALENDAR", undefined)).toEqual([]);
       expect(validateSourceConfig("ICAL_FEED", null)).toEqual([]);
       expect(validateSourceConfig("HTML_SCRAPER", null)).toEqual([]);
+      expect(validateSourceConfig("RSS_FEED", null)).toEqual([]);
     });
 
     it("rejects null/undefined config for types that require it", () => {
@@ -251,6 +252,35 @@ describe("validateSourceConfig", () => {
         defaultKennelTag: "BFM",
       };
       expect(validateSourceConfig("GOOGLE_CALENDAR", config)).toEqual([]);
+    });
+  });
+
+  describe("MEETUP config validation", () => {
+    it("accepts valid MEETUP config", () => {
+      const config = { groupUrlname: "brooklyn-hash-house-harriers", kennelTag: "BrH3" };
+      expect(validateSourceConfig("MEETUP", config)).toEqual([]);
+    });
+
+    it("requires config object for MEETUP", () => {
+      expect(validateSourceConfig("MEETUP", null)).toContain("MEETUP requires a config object");
+    });
+
+    it("requires non-empty groupUrlname", () => {
+      const config = { groupUrlname: "", kennelTag: "BrH3" };
+      const errors = validateSourceConfig("MEETUP", config);
+      expect(errors.some((e) => e.includes("groupUrlname"))).toBe(true);
+    });
+
+    it("requires non-empty kennelTag", () => {
+      const config = { groupUrlname: "brooklyn-hash", kennelTag: "" };
+      const errors = validateSourceConfig("MEETUP", config);
+      expect(errors.some((e) => e.includes("kennelTag"))).toBe(true);
+    });
+
+    it("reports both errors when both fields are missing", () => {
+      const config = {};
+      const errors = validateSourceConfig("MEETUP", config);
+      expect(errors).toHaveLength(2);
     });
   });
 });

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -1,7 +1,7 @@
 import isSafeRegex from "safe-regex2";
 
 /** Types that require a non-empty config object */
-const TYPES_REQUIRING_CONFIG = new Set(["GOOGLE_SHEETS", "HASHREGO"]);
+const TYPES_REQUIRING_CONFIG = new Set(["GOOGLE_SHEETS", "HASHREGO", "MEETUP"]);
 
 /**
  * Validate source config based on type. Returns error messages or empty array.
@@ -94,6 +94,15 @@ export function validateSourceConfig(
       obj.kennelSlugs.some((s: unknown) => typeof s !== "string" || s.trim().length === 0)
     ) {
       errors.push("Hash Rego config requires at least one non-empty kennelSlug");
+    }
+  }
+
+  if (type === "MEETUP") {
+    if (!obj.groupUrlname || typeof obj.groupUrlname !== "string" || !obj.groupUrlname.trim()) {
+      errors.push("Meetup config requires a non-empty groupUrlname");
+    }
+    if (!obj.kennelTag || typeof obj.kennelTag !== "string" || !obj.kennelTag.trim()) {
+      errors.push("Meetup config requires a non-empty kennelTag");
     }
   }
 

--- a/src/components/admin/SourceForm.tsx
+++ b/src/components/admin/SourceForm.tsx
@@ -282,6 +282,13 @@ export function SourceForm({ source, allKennels, openAlertTags, geminiAvailable,
       setConfigObj(next);
       setConfigJson(JSON.stringify(next, null, 2));
     }
+
+    // For MEETUP: auto-populate groupUrlname into config
+    if (detected.type === "MEETUP" && detected.groupUrlname) {
+      const next = { ...(configObj ?? {}), groupUrlname: detected.groupUrlname };
+      setConfigObj(next);
+      setConfigJson(JSON.stringify(next, null, 2));
+    }
   }
 
   function handlePreview() {

--- a/src/components/admin/SourceOnboardingWizard.tsx
+++ b/src/components/admin/SourceOnboardingWizard.tsx
@@ -212,6 +212,12 @@ export function SourceOnboardingWizard({
         setConfigObj(next);
         setConfigJson(JSON.stringify(next, null, 2));
       }
+
+      if (detected.type === "MEETUP" && detected.groupUrlname) {
+        const next = { ...(configObj ?? {}), groupUrlname: detected.groupUrlname };
+        setConfigObj(next);
+        setConfigJson(JSON.stringify(next, null, 2));
+      }
     } else {
       setDetectedType(null);
     }

--- a/src/lib/source-detect.test.ts
+++ b/src/lib/source-detect.test.ts
@@ -63,6 +63,32 @@ describe("detectSourceType", () => {
     });
   });
 
+  describe("Meetup", () => {
+    it("detects meetup.com URL and extracts groupUrlname", () => {
+      const result = detectSourceType("https://www.meetup.com/brooklyn-hash-house-harriers/");
+      expect(result?.type).toBe("MEETUP");
+      expect(result?.groupUrlname).toBe("brooklyn-hash-house-harriers");
+    });
+
+    it("extracts groupUrlname without trailing slash", () => {
+      const result = detectSourceType("https://meetup.com/nyc-hash");
+      expect(result?.type).toBe("MEETUP");
+      expect(result?.groupUrlname).toBe("nyc-hash");
+    });
+
+    it("extracts groupUrlname from events sub-path", () => {
+      const result = detectSourceType("https://www.meetup.com/brooklyn-hash-house-harriers/events/");
+      expect(result?.type).toBe("MEETUP");
+      expect(result?.groupUrlname).toBe("brooklyn-hash-house-harriers");
+    });
+
+    it("returns undefined groupUrlname for bare meetup.com", () => {
+      const result = detectSourceType("https://meetup.com/");
+      expect(result?.type).toBe("MEETUP");
+      expect(result?.groupUrlname).toBeUndefined();
+    });
+  });
+
   describe("iCal feed", () => {
     it("detects .ics URL", () => {
       const result = detectSourceType("https://example.com/calendar/feed.ics");

--- a/src/lib/source-detect.ts
+++ b/src/lib/source-detect.ts
@@ -18,6 +18,11 @@ export type SourceDetectResult = {
    * Should be auto-populated into SheetsConfig.sheetId.
    */
   sheetId?: string;
+  /**
+   * For MEETUP: the group URL name extracted from the URL path.
+   * e.g. https://www.meetup.com/brooklyn-hash-house-harriers/ → "brooklyn-hash-house-harriers"
+   */
+  groupUrlname?: string;
 };
 
 /**
@@ -52,7 +57,9 @@ export function detectSourceType(rawUrl: string): SourceDetectResult | null {
 
   // Meetup.com
   if (url.hostname === "meetup.com" || url.hostname.endsWith(".meetup.com")) {
-    return { type: "MEETUP" };
+    const parts = url.pathname.split("/").filter(Boolean);
+    const groupUrlname = parts[0] ?? undefined;
+    return { type: "MEETUP", groupUrlname };
   }
 
   // iCal feed: .ics extension or ical/ics in query params, or webcal scheme


### PR DESCRIPTION
## Summary
- `source-detect.ts`: Meetup URL detection now extracts `groupUrlname` from the URL path (e.g. `https://www.meetup.com/brooklyn-hash-house-harriers/` → `groupUrlname: "brooklyn-hash-house-harriers"`)
- `SourceOnboardingWizard` + `SourceForm`: pre-populate `configObj.groupUrlname` when a Meetup URL is pasted — consistent with how `sheetId` is auto-filled for Google Sheets
- `config-validation.ts`: added `MEETUP` to `TYPES_REQUIRING_CONFIG`; validates `groupUrlname` and `kennelTag` are both non-empty strings
- 9 new tests: Meetup URL detection variants + MEETUP config validation

## Test plan
- [ ] Paste `https://www.meetup.com/brooklyn-hash-house-harriers/` into wizard URL field → advance to Config step → `groupUrlname` already populated in MeetupConfigPanel
- [ ] Try creating a MEETUP source without `groupUrlname` → validation error
- [ ] `npm test` passes (pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)