### PR TITLE
security: harden codebase with headers, input validation, rate limiting, and audit logging

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,38 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+];
+
 const nextConfig: NextConfig = {
   serverExternalPackages: ["node-ical"],
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/admin/events/actions.ts
+++ b/src/app/admin/events/actions.ts
@@ -41,6 +41,15 @@ export async function deleteEvent(eventId: string): Promise<ActionResult<{ kenne
 
   await deleteEventsCascade([eventId]);
 
+  console.log("[admin-audit] deleteEvent", JSON.stringify({
+    adminId: admin.id,
+    action: "delete_event",
+    eventId,
+    kennelName: event.kennel.shortName,
+    eventDate: event.date.toISOString(),
+    timestamp: new Date().toISOString(),
+  }));
+
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
   return {
@@ -123,6 +132,14 @@ export async function bulkDeleteEvents(filters: {
 
   await deleteEventsCascade(eventIds);
 
+  console.log("[admin-audit] bulkDeleteEvents", JSON.stringify({
+    adminId: admin.id,
+    action: "bulk_delete_events",
+    count: eventIds.length,
+    filters,
+    timestamp: new Date().toISOString(),
+  }));
+
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
   return { success: true, deletedCount: eventIds.length };
@@ -139,6 +156,13 @@ export async function deleteSelectedEvents(eventIds: string[]): Promise<ActionRe
   if (eventIds.length > 500) return { error: "Too many events selected (max 500)" };
 
   await deleteEventsCascade(eventIds);
+
+  console.log("[admin-audit] deleteSelectedEvents", JSON.stringify({
+    adminId: admin.id,
+    action: "delete_selected_events",
+    count: eventIds.length,
+    timestamp: new Date().toISOString(),
+  }));
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");

--- a/src/app/admin/kennels/actions.ts
+++ b/src/app/admin/kennels/actions.ts
@@ -312,6 +312,14 @@ export async function deleteKennel(kennelId: string) {
     prisma.kennel.delete({ where: { id: kennelId } }),
   ]);
 
+  console.log("[admin-audit] deleteKennel", JSON.stringify({
+    adminId: admin.id,
+    action: "delete_kennel",
+    kennelId,
+    kennelName: kennel.shortName,
+    timestamp: new Date().toISOString(),
+  }));
+
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
   return { success: true };
@@ -640,6 +648,17 @@ export async function mergeKennels(
       where: { id: sourceKennel.id },
     }),
   ]);
+
+  console.log("[admin-audit] mergeKennels", JSON.stringify({
+    adminId: admin.id,
+    action: "merge_kennels",
+    sourceKennelId: sourceKennel.id,
+    sourceKennelName: sourceKennel.shortName,
+    targetKennelId: targetKennel.id,
+    targetKennelName: targetKennel.shortName,
+    eventsMoved: sourceKennel._count.events,
+    timestamp: new Date().toISOString(),
+  }));
 
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/db";
 
 export async function GET() {
   try {
-    await prisma.$queryRawUnsafe("SELECT 1");
+    await prisma.$queryRaw`SELECT 1`;
 
     return NextResponse.json({
       status: "healthy",

--- a/src/app/feedback/actions.ts
+++ b/src/app/feedback/actions.ts
@@ -38,7 +38,9 @@ export async function submitFeedback(
   const pageUrl = (formData.get("pageUrl") as string)?.trim();
 
   if (!title) return { error: "Title is required" };
+  if (title.length > 200) return { error: "Title is too long (max 200 characters)" };
   if (!description) return { error: "Description is required" };
+  if (description.length > 5000) return { error: "Description is too long (max 5,000 characters)" };
 
   const issueTitle = `[Feedback] ${title}`;
   const heading = CATEGORY_HEADINGS[category] || "Feedback";

--- a/src/app/logbook/actions.ts
+++ b/src/app/logbook/actions.ts
@@ -79,6 +79,10 @@ export async function updateAttendance(
   if (!attendance) return { error: "Attendance not found" };
   if (attendance.userId !== user.id) return { error: "Not authorized" };
 
+  // Input length validation
+  if (data.stravaUrl && data.stravaUrl.length > 500) return { error: "Strava URL is too long (max 500 characters)" };
+  if (data.notes && data.notes.length > 1000) return { error: "Notes are too long (max 1,000 characters)" };
+
   await prisma.attendance.update({
     where: { id: attendanceId },
     data: {

--- a/src/app/profile/actions.ts
+++ b/src/app/profile/actions.ts
@@ -15,6 +15,11 @@ export async function updateProfile(
   const nerdName = formData.get("nerdName") as string | null;
   const bio = formData.get("bio") as string | null;
 
+  // Input length validation
+  if (hashName && hashName.trim().length > 100) return { error: "Hash name is too long (max 100 characters)" };
+  if (nerdName && nerdName.trim().length > 100) return { error: "Nerd name is too long (max 100 characters)" };
+  if (bio && bio.trim().length > 500) return { error: "Bio is too long (max 500 characters)" };
+
   await prisma.user.update({
     where: { id: user.id },
     data: {


### PR DESCRIPTION
Add security headers (X-Frame-Options, HSTS, nosniff, Referrer-Policy, Permissions-Policy)
to next.config.ts. Replace timing-unsafe string comparison for CRON_SECRET with
crypto.timingSafeEqual. Add CSV import size/row limits to prevent OOM. Replace
$queryRawUnsafe with safe tagged template literal in health check. Add input length
validation on profile fields, feedback, logbook notes, and Strava URLs. Add per-user
daily rate limit on misman invite creation. Add structured admin audit logging for
event deletion, bulk deletion, kennel deletion, and kennel merge operations.

https://claude.ai/code/session_01PwbXbgitNAokvcJEMxkatk