### PR TITLE
feat: add misman invite history, active mismans list, and revoke acce…

### DIFF
--- a/src/app/misman/invite/actions.ts
+++ b/src/app/misman/invite/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getOrCreateUser, getMismanUser, getAdminUser } from "@/lib/auth";
+import { getOrCreateUser, getMismanUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { revalidatePath } from "next/cache";
 import {
@@ -227,50 +227,6 @@ export async function getKennelMismans(kennelId: string) {
     role: m.role,
     since: m.createdAt.toISOString(),
   }));
-
-  return { data };
-}
-
-/**
- * List all misman invites across all kennels (admin-level view).
- * Computes effective status (PENDING past expiry → EXPIRED).
- */
-export async function listAllMismanInvites() {
-  const admin = await getAdminUser();
-  if (!admin) return { error: "Not authorized" };
-
-  const invites = await prisma.mismanInvite.findMany({
-    include: {
-      kennel: { select: { shortName: true, slug: true } },
-      inviter: { select: { hashName: true, email: true } },
-      acceptor: { select: { hashName: true, email: true } },
-    },
-    orderBy: { createdAt: "desc" },
-    take: 200,
-  });
-
-  const now = new Date();
-
-  const data = invites.map((inv) => {
-    const effectiveStatus =
-      inv.status === "PENDING" && inv.expiresAt <= now ? "EXPIRED" : inv.status;
-
-    return {
-      id: inv.id,
-      kennelShortName: inv.kennel.shortName,
-      kennelSlug: inv.kennel.slug,
-      inviteeEmail: inv.inviteeEmail,
-      status: effectiveStatus,
-      expiresAt: inv.expiresAt.toISOString(),
-      createdAt: inv.createdAt.toISOString(),
-      acceptedAt: inv.acceptedAt?.toISOString() ?? null,
-      revokedAt: inv.revokedAt?.toISOString() ?? null,
-      inviterName: inv.inviter.hashName || inv.inviter.email,
-      acceptorName: inv.acceptor
-        ? inv.acceptor.hashName || inv.acceptor.email
-        : null,
-    };
-  });
 
   return { data };
 }

--- a/src/components/admin/MismanRequestQueue.tsx
+++ b/src/components/admin/MismanRequestQueue.tsx
@@ -425,7 +425,7 @@ function ActiveMismanRowComponent({
         ? "Invite"
         : "Manual";
 
-  const sourceBadgeVariant =
+  const sourceBadgeVariant: "default" | "secondary" | "outline" =
     misman.grantSource === "request"
       ? "default"
       : misman.grantSource === "invite"
@@ -469,7 +469,7 @@ function ActiveMismanRowComponent({
         </Badge>
       </TableCell>
       <TableCell className="hidden sm:table-cell">
-        <Badge variant={sourceBadgeVariant as "default" | "secondary" | "outline"}>
+        <Badge variant={sourceBadgeVariant}>
           {sourceLabel}
         </Badge>
       </TableCell>


### PR DESCRIPTION
…ss to admin page

Restructures the admin misman requests page into a 3-tab layout:
- Pending Requests: existing approve/reject flow (filtered to pending only)
- Invite History: all MismanInvite records with status, inviter, acceptor, and revoke action
- Active Mismans: all users with MISMAN/ADMIN role, grant source (request/invite/manual), and revoke access

Adds revokeMismanAccess server action that downgrades MISMAN -> MEMBER. Auth: admins can revoke anyone, mismans can revoke users they personally invited.

https://claude.ai/code/session_01NJG5fMo5mwvr2oyWZY6W58