### PR TITLE
feat(wizard): Track C Phase 2 — AI config suggestion in Configure & Test step

### DIFF
--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -34,50 +34,42 @@ const adapters: Partial<Record<SourceType, () => SourceAdapter>> = {
   RSS_FEED: () => new RssAdapter(),
 };
 
-/** URL-based routing for HTML_SCRAPER sources with site-specific adapters */
-const htmlScrapersByUrl: [RegExp, () => SourceAdapter][] = [
-  [/benfranklinmob/i, () => new BFMAdapter()],
-  [/hashphilly/i, () => new HashPhillyAdapter()],
-  [/cityhash\.org/i, () => new CityHashAdapter()],
-  [/westlondonhash/i, () => new WestLondonHashAdapter()],
-  [/barnesh3\.com/i, () => new BarnesHashAdapter()],
-  [/och3\.org/i, () => new OCH3Adapter()],
-  [/londonhash\.org\/slah3/i, () => new SlashHashAdapter()],
-  [/londonhash\.org/i, () => new LondonHashAdapter()],
-  [/enfieldhash\.org/i, () => new EnfieldHashAdapter()],
-  [/chicagohash\.org/i, () => new ChicagoHashAdapter()],
-  [/chicagoth3\.com/i, () => new ChicagoTH3Adapter()],
-  [/sfh3\.com/i, () => new SFH3Adapter()],
-  [/ewh3\.com/i, () => new EWH3Adapter()],
-  [/dch4\.org/i, () => new DCH4Adapter()],
-  [/ofh3\.com/i, () => new OFH3Adapter()],
-  [/hangoverhash\.digitalpress/i, () => new HangoverAdapter()],
+/** Single source of truth for URL-routed HTML scrapers: pattern, adapter name, factory. */
+interface HtmlScraperEntry {
+  pattern: RegExp;
+  name: string;
+  factory: () => SourceAdapter;
+}
+
+const htmlScraperEntries: HtmlScraperEntry[] = [
+  { pattern: /benfranklinmob/i,          name: "BFMAdapter",          factory: () => new BFMAdapter() },
+  { pattern: /hashphilly/i,              name: "HashPhillyAdapter",   factory: () => new HashPhillyAdapter() },
+  { pattern: /cityhash\.org/i,           name: "CityHashAdapter",     factory: () => new CityHashAdapter() },
+  { pattern: /westlondonhash/i,          name: "WestLondonHashAdapter", factory: () => new WestLondonHashAdapter() },
+  { pattern: /barnesh3\.com/i,           name: "BarnesHashAdapter",   factory: () => new BarnesHashAdapter() },
+  { pattern: /och3\.org/i,              name: "OCH3Adapter",          factory: () => new OCH3Adapter() },
+  { pattern: /londonhash\.org\/slah3/i, name: "SlashHashAdapter",     factory: () => new SlashHashAdapter() },
+  { pattern: /londonhash\.org/i,        name: "LondonHashAdapter",    factory: () => new LondonHashAdapter() },
+  { pattern: /enfieldhash\.org/i,       name: "EnfieldHashAdapter",   factory: () => new EnfieldHashAdapter() },
+  { pattern: /chicagohash\.org/i,       name: "ChicagoHashAdapter",   factory: () => new ChicagoHashAdapter() },
+  { pattern: /chicagoth3\.com/i,        name: "ChicagoTH3Adapter",    factory: () => new ChicagoTH3Adapter() },
+  { pattern: /sfh3\.com/i,             name: "SFH3Adapter",           factory: () => new SFH3Adapter() },
+  { pattern: /ewh3\.com/i,             name: "EWH3Adapter",           factory: () => new EWH3Adapter() },
+  { pattern: /dch4\.org/i,             name: "DCH4Adapter",           factory: () => new DCH4Adapter() },
+  { pattern: /ofh3\.com/i,             name: "OFH3Adapter",           factory: () => new OFH3Adapter() },
+  { pattern: /hangoverhash\.digitalpress/i, name: "HangoverAdapter",  factory: () => new HangoverAdapter() },
 ];
 
+/** URL-based routing for HTML_SCRAPER — derived from htmlScraperEntries (single source of truth). */
+const htmlScrapersByUrl: [RegExp, () => SourceAdapter][] =
+  htmlScraperEntries.map(({ pattern, factory }) => [pattern, factory]);
+
 /**
- * Returns the adapter class name if the URL matches a known HTML scraper, else null.
+ * Returns the adapter class name if the URL matches a site-specific HTML scraper, else null.
  * Used by the AI config suggestion to detect whether a custom adapter already exists.
  */
 export function findHtmlAdapter(url: string): string | null {
-  const named: [RegExp, string][] = [
-    [/benfranklinmob/i, "BFMAdapter"],
-    [/hashphilly/i, "HashPhillyAdapter"],
-    [/cityhash\.org/i, "CityHashAdapter"],
-    [/westlondonhash/i, "WestLondonHashAdapter"],
-    [/barnesh3\.com/i, "BarnesHashAdapter"],
-    [/och3\.org/i, "OCH3Adapter"],
-    [/londonhash\.org\/slah3/i, "SlashHashAdapter"],
-    [/londonhash\.org/i, "LondonHashAdapter"],
-    [/enfieldhash\.org/i, "EnfieldHashAdapter"],
-    [/chicagohash\.org/i, "ChicagoHashAdapter"],
-    [/chicagoth3\.com/i, "ChicagoTH3Adapter"],
-    [/sfh3\.com/i, "SFH3Adapter"],
-    [/ewh3\.com/i, "EWH3Adapter"],
-    [/dch4\.org/i, "DCH4Adapter"],
-    [/ofh3\.com/i, "OFH3Adapter"],
-    [/hangoverhash\.digitalpress/i, "HangoverAdapter"],
-  ];
-  for (const [pattern, name] of named) {
+  for (const { pattern, name } of htmlScraperEntries) {
     if (pattern.test(url)) return name;
   }
   return null;

--- a/src/app/admin/sources/preview-action.ts
+++ b/src/app/admin/sources/preview-action.ts
@@ -3,6 +3,7 @@
 import { getAdminUser } from "@/lib/auth";
 import { getAdapter } from "@/adapters/registry";
 import { validateSourceConfig } from "./config-validation";
+import { validateFetchUrl } from "@/lib/url-validation";
 import { computeFillRates } from "@/pipeline/fill-rates";
 import {
   resolveKennelTag,
@@ -96,7 +97,7 @@ export async function previewSourceConfig(
   }
 
   if (type !== "GOOGLE_CALENDAR") {
-    const urlError = validatePreviewUrl(url);
+    const urlError = validateFetchUrl(url);
     if (urlError) return { error: urlError };
   }
 
@@ -168,44 +169,3 @@ export async function previewSourceConfig(
   };
 }
 
-/** Validate URL for SSRF protection: only http/https, no private IPs */
-export function validatePreviewUrl(url: string): string | null {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return "Invalid URL format";
-  }
-
-  if (!["http:", "https:"].includes(parsed.protocol)) {
-    return "Only http and https URLs are allowed";
-  }
-
-  const hostname = parsed.hostname;
-
-  // Block localhost and loopback
-  if (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "::1" ||
-    hostname === "0.0.0.0"
-  ) {
-    return "URLs pointing to localhost are not allowed";
-  }
-
-  // Block private IP ranges (10.x, 172.16-31.x, 192.168.x)
-  const ipv4Match = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
-  if (ipv4Match) {
-    const [, a, b] = ipv4Match.map(Number);
-    if (
-      a === 10 ||
-      (a === 172 && b >= 16 && b <= 31) ||
-      (a === 192 && b === 168) ||
-      a === 169 && b === 254 // link-local
-    ) {
-      return "URLs pointing to private IP addresses are not allowed";
-    }
-  }
-
-  return null;
-}

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -1,0 +1,46 @@
+/**
+ * SSRF protection utilities for server-side URL validation.
+ * Shared between preview-action.ts and suggest-source-config-action.ts.
+ */
+
+/** Validate URL for SSRF protection: only http/https, no private or loopback IPs. */
+export function validateFetchUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return "Invalid URL format";
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    return "Only http and https URLs are allowed";
+  }
+
+  const hostname = parsed.hostname;
+
+  // Block localhost and loopback
+  if (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "0.0.0.0"
+  ) {
+    return "URLs pointing to localhost are not allowed";
+  }
+
+  // Block private IP ranges (10.x, 172.16-31.x, 192.168.x, 169.254.x link-local)
+  const ipv4Match = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (ipv4Match) {
+    const [, a, b] = ipv4Match.map(Number);
+    if (
+      a === 10 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 169 && b === 254) // link-local
+    ) {
+      return "URLs pointing to private IP addresses are not allowed";
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- **AI-powered config suggestion** auto-runs when an admin enters the Configure & Test step with an empty config
- For HTML_SCRAPER sources: instantly checks if a named adapter exists (no Gemini call needed) — shows adapter name or "no adapter found" message
- For GOOGLE_SHEETS: defers to the existing column-detection button (skips AI)
- For all other types (GOOGLE_CALENDAR, ICAL_FEED, RSS_FEED, MEETUP, HASHREGO): fetches sample events via mock-Source pattern, then asks Gemini to suggest the complete adapter config + kennel tags

## New Files

### `src/app/admin/sources/suggest-source-config-action.ts`
Server action with full AI suggestion flow:
- Type-specific Gemini prompts: `defaultKennelTag` vs `kennelPatterns` for calendar/iCal, `kennelTag` for RSS/Meetup, `kennelSlugs` for Hash Rego
- DATA START/END injection guards in prompt
- `validateConfigShape()` strips ReDoS-unsafe regex patterns via `safe-regex2`
- Returns `ConfigSuggestion` with `suggestedConfig`, `suggestedKennelTags`, `explanation`, `confidence`, and `adapterNote`

## Modified Files

### `src/adapters/registry.ts`
- Added `findHtmlAdapter(url)` export — synchronous URL→adapter name lookup (no Gemini), used by the suggest action and available for future tooling

### `src/components/admin/ConfigureAndTest.tsx`
- Auto-triggers `suggestSourceConfig()` on mount when config is empty
- Shows pulsing "✨ Analyzing source…" banner while loading
- On success: explanation, confidence badge, optional adapter note, "Accept & Test" button
- Accept: populates config panel + auto-selects matching kennels + runs preview
- Uses `runPreviewWithConfig(overrideJson)` to avoid stale closure problem
- Silent on error (no banner shown — user just configures manually)

## Test Plan
- [ ] New Google Calendar URL with empty config → "Analyzing source…" banner → resolves to suggestion with explanation + confidence + Accept
- [ ] Click Accept → config panel populates → preview auto-runs
- [ ] `ewh3.com` HTML scraper URL → banner shows "Matched existing adapter: EWH3Adapter" immediately (no Gemini call)
- [ ] Unknown HTML URL → banner shows "No existing adapter matches" note
- [ ] Already-configured source → banner does NOT appear
- [ ] GOOGLE_SHEETS source → banner does NOT appear (deferred to column-detection button)
- [ ] `fnm exec --using=20 npm test` — 18 registry tests pass; no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)