### PR TITLE
Support multiple URL variants for Blogger blog discovery

### DIFF
--- a/src/adapters/blogger-api.ts
+++ b/src/adapters/blogger-api.ts
@@ -14,7 +14,7 @@
  *   2. Set GOOGLE_CALENDAR_API_KEY env var (same key used for Calendar/Sheets)
  */
 
-import { buildUrlVariantCandidates } from "./utils";
+import { buildUrlVariantCandidates } from "@/adapters/url-variants";
 
 const BLOGGER_API_BASE = "https://www.googleapis.com/blogger/v3";
 

--- a/src/adapters/url-variants.ts
+++ b/src/adapters/url-variants.ts
@@ -1,0 +1,45 @@
+/**
+ * URL variant helpers for hostname/protocol fallback probing.
+ *
+ * Keep this module dependency-light so adapters that only need URL manipulation
+ * do not pull in HTML parsing dependencies.
+ */
+
+/**
+ * Build canonical + fallback URL base variants for host/protocol edge-routing issues.
+ * Order: original, host variant (www/non-www), protocol variant (http/https), protocol+host variant.
+ */
+export function buildUrlVariantCandidates(baseUrl: string): string[] {
+  const normalizedBase = baseUrl.replace(/\/+$/, "");
+  const candidates = [normalizedBase];
+
+  try {
+    const parsed = new URL(normalizedBase);
+
+    const hostVariant = new URL(parsed.toString());
+    if (hostVariant.hostname.startsWith("www.")) {
+      hostVariant.hostname = hostVariant.hostname.slice(4);
+    } else {
+      hostVariant.hostname = `www.${hostVariant.hostname}`;
+    }
+    candidates.push(hostVariant.toString().replace(/\/+$/, ""));
+
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      const protocolVariant = new URL(parsed.toString());
+      protocolVariant.protocol = parsed.protocol === "https:" ? "http:" : "https:";
+      candidates.push(protocolVariant.toString().replace(/\/+$/, ""));
+
+      const protocolAndHostVariant = new URL(protocolVariant.toString());
+      if (protocolAndHostVariant.hostname.startsWith("www.")) {
+        protocolAndHostVariant.hostname = protocolAndHostVariant.hostname.slice(4);
+      } else {
+        protocolAndHostVariant.hostname = `www.${protocolAndHostVariant.hostname}`;
+      }
+      candidates.push(protocolAndHostVariant.toString().replace(/\/+$/, ""));
+    }
+  } catch {
+    // URL validation happens upstream.
+  }
+
+  return [...new Set(candidates)];
+}

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -4,6 +4,7 @@
 
 import * as cheerio from "cheerio";
 import he from "he";
+import { buildUrlVariantCandidates } from "@/adapters/url-variants";
 
 /**
  * Decode all HTML entities (named, hex, decimal) in a string.
@@ -147,44 +148,7 @@ export function validateSourceUrl(url: string): void {
   checkIPv6Private(bare);
 }
 
-/**
- * Build canonical + fallback URL base variants for host/protocol edge-routing issues.
- * Order: original, host variant (www/non-www), protocol variant (http/https), protocol+host variant.
- */
-export function buildUrlVariantCandidates(baseUrl: string): string[] {
-  const normalizedBase = baseUrl.replace(/\/+$/, "");
-  const candidates = [normalizedBase];
-
-  try {
-    const parsed = new URL(normalizedBase);
-
-    const hostVariant = new URL(parsed.toString());
-    if (hostVariant.hostname.startsWith("www.")) {
-      hostVariant.hostname = hostVariant.hostname.slice(4);
-    } else {
-      hostVariant.hostname = `www.${hostVariant.hostname}`;
-    }
-    candidates.push(hostVariant.toString().replace(/\/+$/, ""));
-
-    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-      const protocolVariant = new URL(parsed.toString());
-      protocolVariant.protocol = parsed.protocol === "https:" ? "http:" : "https:";
-      candidates.push(protocolVariant.toString().replace(/\/+$/, ""));
-
-      const protocolAndHostVariant = new URL(protocolVariant.toString());
-      if (protocolAndHostVariant.hostname.startsWith("www.")) {
-        protocolAndHostVariant.hostname = protocolAndHostVariant.hostname.slice(4);
-      } else {
-        protocolAndHostVariant.hostname = `www.${protocolAndHostVariant.hostname}`;
-      }
-      candidates.push(protocolAndHostVariant.toString().replace(/\/+$/, ""));
-    }
-  } catch {
-    // URL validation happens upstream.
-  }
-
-  return [...new Set(candidates)];
-}
+export { buildUrlVariantCandidates };
 
 /**
  * Parse a 12-hour time string into 24-hour "HH:MM" format.

--- a/src/adapters/wordpress-api.ts
+++ b/src/adapters/wordpress-api.ts
@@ -14,7 +14,7 @@
  */
 
 import he from "he";
-import { buildUrlVariantCandidates } from "./utils";
+import { buildUrlVariantCandidates } from "@/adapters/url-variants";
 
 /** A single post returned by the WordPress REST API */
 export interface WordPressPost {


### PR DESCRIPTION
## Summary
Enhanced the Blogger API adapter to try multiple URL variants when discovering blog IDs, improving reliability for blogs that may only be accessible via specific domain/protocol combinations.

## Key Changes
- **New utility function**: Created `buildUrlVariantCandidates()` in utils to generate URL variants by toggling www prefix and protocol (http/https), producing up to 4 candidates
- **Updated blog discovery**: Modified `discoverBlogId()` to use the new utility instead of only trying protocol toggling, now attempting all 4 URL variants before failing
- **Fixed URL encoding**: Removed trailing slashes from expected URLs in tests to match actual API behavior (e.g., `http%3A%2F%2Fwww.example.com` instead of `http%3A%2F%2Fwww.example.com%2F`)
- **Updated test coverage**: 
  - Expanded "404 on all variants" test to verify all 4 attempts
  - Clarified test descriptions to reflect www-toggling strategy
  - Added new "Enfield Hash scenario" test demonstrating discovery via non-www variant
- **Fixed seed data**: Corrected Enfield Hash House Harriers website URLs to use non-www variant (`https://enfieldhash.org`) which is the actual accessible domain

## Implementation Details
The URL variant strategy tries candidates in this order:
1. Original URL (as provided)
2. www-toggled variant (add/remove www prefix)
3. Protocol-toggled variant (switch http/https)
4. Both-toggled variant (www-toggle + protocol-toggle)

This approach handles edge cases like the Enfield Hash blog which is only accessible via the non-www domain, while maintaining backward compatibility with existing URLs.

https://claude.ai/code/session_01Hwk4GNhC1K1RWhsGN5KtKV