### PR TITLE
Fix seeded Source dedupe and extract URL-variant helper from heavy utils

### DIFF
--- a/src/adapters/blogger-api.ts
+++ b/src/adapters/blogger-api.ts
@@ -14,7 +14,7 @@
  *   2. Set GOOGLE_CALENDAR_API_KEY env var (same key used for Calendar/Sheets)
  */
 
-import { buildUrlVariantCandidates } from "./utils";
+import { buildUrlVariantCandidates } from "@/adapters/url-variants";
 
 const BLOGGER_API_BASE = "https://www.googleapis.com/blogger/v3";
 

--- a/src/adapters/url-variants.ts
+++ b/src/adapters/url-variants.ts
@@ -1,0 +1,45 @@
+/**
+ * URL variant helpers for hostname/protocol fallback probing.
+ *
+ * Keep this module dependency-light so adapters that only need URL manipulation
+ * do not pull in HTML parsing dependencies.
+ */
+
+/**
+ * Build canonical + fallback URL base variants for host/protocol edge-routing issues.
+ * Order: original, host variant (www/non-www), protocol variant (http/https), protocol+host variant.
+ */
+export function buildUrlVariantCandidates(baseUrl: string): string[] {
+  const normalizedBase = baseUrl.replace(/\/+$/, "");
+  const candidates = [normalizedBase];
+
+  try {
+    const parsed = new URL(normalizedBase);
+
+    const hostVariant = new URL(parsed.toString());
+    if (hostVariant.hostname.startsWith("www.")) {
+      hostVariant.hostname = hostVariant.hostname.slice(4);
+    } else {
+      hostVariant.hostname = `www.${hostVariant.hostname}`;
+    }
+    candidates.push(hostVariant.toString().replace(/\/+$/, ""));
+
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      const protocolVariant = new URL(parsed.toString());
+      protocolVariant.protocol = parsed.protocol === "https:" ? "http:" : "https:";
+      candidates.push(protocolVariant.toString().replace(/\/+$/, ""));
+
+      const protocolAndHostVariant = new URL(protocolVariant.toString());
+      if (protocolAndHostVariant.hostname.startsWith("www.")) {
+        protocolAndHostVariant.hostname = protocolAndHostVariant.hostname.slice(4);
+      } else {
+        protocolAndHostVariant.hostname = `www.${protocolAndHostVariant.hostname}`;
+      }
+      candidates.push(protocolAndHostVariant.toString().replace(/\/+$/, ""));
+    }
+  } catch {
+    // URL validation happens upstream.
+  }
+
+  return [...new Set(candidates)];
+}

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -4,6 +4,7 @@
 
 import * as cheerio from "cheerio";
 import he from "he";
+import { buildUrlVariantCandidates } from "@/adapters/url-variants";
 
 /**
  * Decode all HTML entities (named, hex, decimal) in a string.
@@ -147,44 +148,7 @@ export function validateSourceUrl(url: string): void {
   checkIPv6Private(bare);
 }
 
-/**
- * Build canonical + fallback URL base variants for host/protocol edge-routing issues.
- * Order: original, host variant (www/non-www), protocol variant (http/https), protocol+host variant.
- */
-export function buildUrlVariantCandidates(baseUrl: string): string[] {
-  const normalizedBase = baseUrl.replace(/\/+$/, "");
-  const candidates = [normalizedBase];
-
-  try {
-    const parsed = new URL(normalizedBase);
-
-    const hostVariant = new URL(parsed.toString());
-    if (hostVariant.hostname.startsWith("www.")) {
-      hostVariant.hostname = hostVariant.hostname.slice(4);
-    } else {
-      hostVariant.hostname = `www.${hostVariant.hostname}`;
-    }
-    candidates.push(hostVariant.toString().replace(/\/+$/, ""));
-
-    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-      const protocolVariant = new URL(parsed.toString());
-      protocolVariant.protocol = parsed.protocol === "https:" ? "http:" : "https:";
-      candidates.push(protocolVariant.toString().replace(/\/+$/, ""));
-
-      const protocolAndHostVariant = new URL(protocolVariant.toString());
-      if (protocolAndHostVariant.hostname.startsWith("www.")) {
-        protocolAndHostVariant.hostname = protocolAndHostVariant.hostname.slice(4);
-      } else {
-        protocolAndHostVariant.hostname = `www.${protocolAndHostVariant.hostname}`;
-      }
-      candidates.push(protocolAndHostVariant.toString().replace(/\/+$/, ""));
-    }
-  } catch {
-    // URL validation happens upstream.
-  }
-
-  return [...new Set(candidates)];
-}
+export { buildUrlVariantCandidates };
 
 /**
  * Parse a 12-hour time string into 24-hour "HH:MM" format.

--- a/src/adapters/wordpress-api.ts
+++ b/src/adapters/wordpress-api.ts
@@ -14,7 +14,7 @@
  */
 
 import he from "he";
-import { buildUrlVariantCandidates } from "./utils";
+import { buildUrlVariantCandidates } from "@/adapters/url-variants";
 
 /** A single post returned by the WordPress REST API */
 export interface WordPressPost {


### PR DESCRIPTION
### Motivation
- Prevent the seed script from creating duplicate `Source` rows when a seeded URL is edited by matching sources by `url` OR a stable identity (`{name, type}`).
- Avoid pulling heavy HTML-parsing deps (`cheerio`, `he`) into lightweight adapter code paths that only need URL manipulation to reduce bundle/cold-start cost.
- Reduce test duplication flagged by SonarCloud in the Blogger adapter tests.

### Description
- Updated `prisma/seed.ts` `upsertSources` to locate existing sources via `url` OR `{ name, type }`, prefer an exact URL match when present, update/create the chosen record, and deterministically disable any additional matched duplicates before linking kennels; added explanatory comments about the identity strategy.
- Extracted `buildUrlVariantCandidates()` into a new lightweight module `src/adapters/url-variants.ts` with no `cheerio`/`he` imports and updated adapters to import it via the `@/` path alias.
- Re-exported `buildUrlVariantCandidates` from `src/adapters/utils.ts` for backward compatibility while keeping parsing helpers that use `cheerio`/`he` local to `utils.ts`.
- Refactored `src/adapters/blogger-api.test.ts` to collapse two similar retry tests into a parameterized `it.each` table and added explicit assertions for the third fetch call (`/blogs/{id}/posts`) to reduce duplication and improve consistency.

### Testing
- Ran `npm test -- src/adapters/blogger-api.test.ts src/adapters/utils.test.ts` and the test suite passed (both files ran; total tests passed reported successfully).
- Ran `npm test -- src/adapters/blogger-api.test.ts` which passed (Blogger adapter tests all green).
- Ran linter via `npm run lint -- src/adapters/blogger-api.ts src/adapters/wordpress-api.ts src/adapters/url-variants.ts src/adapters/blogger-api.test.ts prisma/seed.ts` and fixed initial warnings, with the final lint run completing without reported problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9bdad2f4832fb38adfac449e721b)