### PR TITLE
fix: rewrite Enfield Hash adapter for new site structure

### DIFF
--- a/src/adapters/html-scraper/enfield-hash.test.ts
+++ b/src/adapters/html-scraper/enfield-hash.test.ts
@@ -1,11 +1,46 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { parseEnfieldDate, parseEnfieldBody } from "./enfield-hash";
-import { EnfieldHashAdapter } from "./enfield-hash";
-import * as bloggerApi from "../blogger-api";
+import {
+  parseEnfieldDate,
+  parseEnfieldBody,
+  inferYear,
+  EnfieldHashAdapter,
+} from "./enfield-hash";
 
-vi.mock("../blogger-api");
+describe("inferYear", () => {
+  it("returns current year when date is within 6 months", () => {
+    const now = new Date("2026-02-24T12:00:00Z");
+    expect(inferYear(3, 25, now)).toBe(2026); // March — 1 month ahead
+    expect(inferYear(1, 21, now)).toBe(2026); // January — 1 month ago
+  });
+
+  it("returns previous year when date is >6 months in the future", () => {
+    // Scraping in Feb 2026, see December → Dec 2026 would be ~10 months ahead → use 2025
+    const now = new Date("2026-02-24T12:00:00Z");
+    expect(inferYear(12, 17, now)).toBe(2025);
+    expect(inferYear(11, 15, now)).toBe(2025);
+  });
+
+  it("returns next year when date is >6 months in the past", () => {
+    // Scraping in Dec 2025, see January → Jan 2025 would be ~11 months ago → use 2026
+    const now = new Date("2025-12-15T12:00:00Z");
+    expect(inferYear(1, 21, now)).toBe(2026);
+    expect(inferYear(2, 18, now)).toBe(2026);
+  });
+
+  it("handles boundary months correctly", () => {
+    const now = new Date("2026-06-15T12:00:00Z");
+    // December is ~6 months away — should stay current year (just at boundary)
+    expect(inferYear(12, 15, now)).toBe(2026);
+    // January is ~5 months ago — should stay current year
+    expect(inferYear(1, 15, now)).toBe(2026);
+  });
+});
 
 describe("parseEnfieldDate", () => {
+  const now = new Date("2026-02-24T12:00:00Z");
+
+  // --- Formats with explicit year (backward compat) ---
+
   it("parses UK ordinal date", () => {
     expect(parseEnfieldDate("18th March 2026")).toBe("2026-03-18");
   });
@@ -39,9 +74,37 @@ describe("parseEnfieldDate", () => {
   it("returns null for empty string", () => {
     expect(parseEnfieldDate("")).toBeNull();
   });
+
+  // --- Year-less formats (new site) ---
+
+  it("parses year-less date with day name: 'Wed 25 February'", () => {
+    expect(parseEnfieldDate("Wed 25 February", now)).toBe("2026-02-25");
+  });
+
+  it("parses year-less date without day name: '25 February'", () => {
+    expect(parseEnfieldDate("25 February", now)).toBe("2026-02-25");
+  });
+
+  it("parses year-less date with ordinal: '17th December'", () => {
+    // December is >6 months ahead from Feb 2026 → infers 2025
+    expect(parseEnfieldDate("17th December", now)).toBe("2025-12-17");
+  });
+
+  it("parses year-less date embedded in title: 'Run 318 - Wed 25 February'", () => {
+    expect(parseEnfieldDate("Run 318 - Wed 25 February", now)).toBe("2026-02-25");
+  });
+
+  it("prefers explicit year over year inference", () => {
+    // If text has "25 February 2025" with explicit year, use it
+    expect(parseEnfieldDate("25 February 2025", now)).toBe("2025-02-25");
+  });
 });
 
 describe("parseEnfieldBody", () => {
+  const now = new Date("2026-02-24T12:00:00Z");
+
+  // --- Labeled field format (backward compat) ---
+
   it("parses labeled fields", () => {
     const text = "Date: Wednesday 18th March 2026\nPub: The King's Head\nStation: Enfield Chase\nHare: Speedy";
     const result = parseEnfieldBody(text);
@@ -109,9 +172,64 @@ describe("parseEnfieldBody", () => {
     const result = parseEnfieldBody(text);
     expect(result.hares).toBe("Where's Wally");
   });
+
+  // --- Unstructured prose format (new site) ---
+
+  it("extracts station from prose: 'P trail from Gordon Hill station'", () => {
+    const text = "Rose and Crown pub, Clay Hill, Enfield. P trail from Gordon Hill station. Bring a torch!";
+    const result = parseEnfieldBody(text, now);
+    expect(result.station).toBe("Gordon Hill");
+  });
+
+  it("extracts location from prose: 'running from The Wonder'", () => {
+    const text = "As is tradition, we will be running from The Wonder, with a mulled wine and mince pie stop";
+    const result = parseEnfieldBody(text, now);
+    expect(result.location).toBe("The Wonder");
+  });
+
+  it("handles year-less date in prose", () => {
+    const text = "RUN WILL BE ON 25 FEBRUARY";
+    const result = parseEnfieldBody(text, now);
+    expect(result.date).toBe("2026-02-25");
+  });
 });
 
-const SAMPLE_BLOGGER_HTML = `
+// --- New site HTML structure (current enfieldhash.org) ---
+
+const SAMPLE_NEW_SITE_HTML = `
+<html><body>
+<div class="content" id="content">
+  <div class="paragraph-box">
+    <h1>Run 318 - Wed 25 February</h1>
+    <p>CHANGE OF DATE TO THE FOURTH WEDNESDAY - RUN WILL BE ON 25 FEBRUARY</p>
+    <p>Pub details to follow nearer the time.</p>
+    <p>OnOn</p>
+  </div>
+  <div class="paragraph-box">
+    <h1>Run 317 - Wed 21 January</h1>
+    <p>Rose and Crown pub, Clay Hill, Enfield. P trail from Gordon Hill station. Bring a torch!</p>
+    <p>OnOn</p>
+  </div>
+  <div class="paragraph-box">
+    <h1>Run 316 - Wed 17 December</h1>
+    <p>Annual Christmas Fancy Dress Run</p>
+    <p>As is tradition, we will be running from The Wonder, with a mulled wine and mince pie stop</p>
+    <p>Meet at the pub for a 7:30pm start. You will need a TORCH and your FANCY DRESS. P trail from Gordon Hill station.</p>
+    <p>RSVP so our pastry chef and somellier can pepare.</p>
+    <p>OnOn</p>
+  </div>
+  <div class="paragraph-box">
+    <h1>Welcome to the Enfield Hash!</h1>
+    <p>We are a friendly running club.</p>
+    <p>OnOn</p>
+  </div>
+</div>
+</body></html>
+`;
+
+// --- Legacy Blogger HTML structure (backward compat) ---
+
+const SAMPLE_LEGACY_HTML = `
 <html><body>
 <div class="blog-posts">
   <div class="post-outer">
@@ -154,7 +272,7 @@ const SAMPLE_BLOGGER_HTML = `
 </body></html>
 `;
 
-describe("EnfieldHashAdapter.fetch (Blogger API path)", () => {
+describe("EnfieldHashAdapter.fetch (new site structure)", () => {
   let adapter: EnfieldHashAdapter;
 
   beforeEach(() => {
@@ -165,109 +283,105 @@ describe("EnfieldHashAdapter.fetch (Blogger API path)", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses Blogger API when available and parses events", async () => {
-    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
-      posts: [
-        {
-          title: "Enfield Hash Run #266 - March 2026",
-          content: "<p>Date: Wednesday 18th March 2026</p><p>Pub: The King's Head, Winchmore Hill</p><p>Station: Winchmore Hill (Overground)</p><p>Hare: Speedy</p>",
-          url: "http://www.enfieldhash.org/2026/03/run-266.html",
-          published: "2026-03-10T12:00:00Z",
-        },
-        {
-          title: "Enfield Hash Run #265 - February 2026",
-          content: "<p>Date: Wednesday 18th February 2026</p><p>Pub: The Salisbury Arms</p><p>Station: Edmonton Green</p><p>Hare: Muddy Boots</p>",
-          url: "http://www.enfieldhash.org/2026/02/run-265.html",
-          published: "2026-02-10T12:00:00Z",
-        },
-      ],
-      blogId: "12345",
-      fetchDurationMs: 150,
-    });
+  it("parses events from .paragraph-box containers", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(SAMPLE_NEW_SITE_HTML, { status: 200 }),
+    );
 
     const result = await adapter.fetch({
       id: "test",
-      url: "http://www.enfieldhash.org/",
+      url: "https://www.enfieldhash.org/",
     } as never);
 
-    expect(result.events).toHaveLength(2);
+    // 3 events (4th post "Welcome to the Enfield Hash!" has no date)
+    expect(result.events).toHaveLength(3);
+    expect(result.structureHash).toBeDefined();
 
     const first = result.events[0];
-    expect(first.date).toBe("2026-03-18");
     expect(first.kennelTag).toBe("EH3");
     expect(first.startTime).toBe("19:30");
-    expect(first.location).toBe("The King's Head, Winchmore Hill");
-    expect(first.hares).toBe("Speedy");
-    expect(first.description).toContain("Winchmore Hill");
-    expect(first.sourceUrl).toBe("http://www.enfieldhash.org/2026/03/run-266.html");
+    expect(first.title).toBe("Run 318 - Wed 25 February");
+    expect(first.sourceUrl).toBe("https://www.enfieldhash.org");
+    // Date includes inferred year
+    expect(first.date).toMatch(/^\d{4}-02-25$/);
 
     const second = result.events[1];
-    expect(second.date).toBe("2026-02-18");
-    expect(second.hares).toBe("Muddy Boots");
+    expect(second.title).toBe("Run 317 - Wed 21 January");
+    expect(second.date).toMatch(/^\d{4}-01-21$/);
+    expect(second.station).toBeUndefined(); // station goes to description
+    expect(second.description).toContain("Gordon Hill");
 
     expect(result.diagnosticContext).toMatchObject({
-      fetchMethod: "blogger-api",
-      blogId: "12345",
-      postsFound: 2,
-      eventsParsed: 2,
+      fetchMethod: "html-scrape",
+      postsFound: 4,
+      eventsParsed: 3,
     });
-
-    // structureHash is not set for Blogger API path
-    expect(result.structureHash).toBeUndefined();
   });
 
-  it("skips posts without dates via Blogger API", async () => {
-    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
-      posts: [
-        {
-          title: "Enfield Hash Run #266 - March 2026",
-          content: "<p>Date: Wednesday 18th March 2026</p><p>Hare: Speedy</p>",
-          url: "http://www.enfieldhash.org/2026/03/run-266.html",
-          published: "2026-03-10T12:00:00Z",
-        },
-        {
-          title: "Happy New Year!",
-          content: "<p>Wishing all hashers a happy new year!</p>",
-          url: "http://www.enfieldhash.org/2026/01/happy-new-year.html",
-          published: "2026-01-01T12:00:00Z",
-        },
-      ],
-      blogId: "12345",
-      fetchDurationMs: 100,
-    });
+  it("filters out 'OnOn' from body text", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(SAMPLE_NEW_SITE_HTML, { status: 200 }),
+    );
 
     const result = await adapter.fetch({
       id: "test",
-      url: "http://www.enfieldhash.org/",
+      url: "https://www.enfieldhash.org/",
     } as never);
 
-    expect(result.events).toHaveLength(1);
+    // No event should have "OnOn" in its description or title
+    for (const event of result.events) {
+      if (event.description) {
+        expect(event.description).not.toMatch(/on\s*on/i);
+      }
+    }
+  });
+
+  it("extracts run number into description", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(SAMPLE_NEW_SITE_HTML, { status: 200 }),
+    );
+
+    const result = await adapter.fetch({
+      id: "test",
+      url: "https://www.enfieldhash.org/",
+    } as never);
+
+    expect(result.events[0].description).toContain("Run #318");
+  });
+
+  it("skips posts without dates", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(SAMPLE_NEW_SITE_HTML, { status: 200 }),
+    );
+
+    const result = await adapter.fetch({
+      id: "test",
+      url: "https://www.enfieldhash.org/",
+    } as never);
+
+    // "Welcome to the Enfield Hash!" has no date → skipped
+    expect(result.events).toHaveLength(3);
     expect(result.diagnosticContext).toMatchObject({
-      postsFound: 2,
-      eventsParsed: 1,
+      postsFound: 4,
+      eventsParsed: 3,
     });
   });
 });
 
-describe("EnfieldHashAdapter.fetch (HTML fallback path)", () => {
+describe("EnfieldHashAdapter.fetch (legacy Blogger HTML fallback)", () => {
   let adapter: EnfieldHashAdapter;
 
   beforeEach(() => {
     adapter = new EnfieldHashAdapter();
-    // Make Blogger API return error to trigger HTML fallback
-    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValue({
-      posts: [],
-      error: { message: "Missing GOOGLE_CALENDAR_API_KEY environment variable" },
-    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("falls back to HTML scrape and parses events", async () => {
+  it("falls back to .post-outer selectors for legacy HTML", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(SAMPLE_BLOGGER_HTML, { status: 200 }),
+      new Response(SAMPLE_LEGACY_HTML, { status: 200 }),
     );
 
     const result = await adapter.fetch({
@@ -298,23 +412,17 @@ describe("EnfieldHashAdapter.fetch (HTML fallback path)", () => {
       eventsParsed: 2,
     });
   });
+});
 
-  it("skips posts without dates", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(SAMPLE_BLOGGER_HTML, { status: 200 }),
-    );
+describe("EnfieldHashAdapter.fetch (error handling)", () => {
+  let adapter: EnfieldHashAdapter;
 
-    const result = await adapter.fetch({
-      id: "test",
-      url: "http://www.enfieldhash.org/",
-    } as never);
+  beforeEach(() => {
+    adapter = new EnfieldHashAdapter();
+  });
 
-    // Third post ("Happy New Year") has no date and should be skipped
-    expect(result.events).toHaveLength(2);
-    expect(result.diagnosticContext).toMatchObject({
-      postsFound: 3,
-      eventsParsed: 2,
-    });
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("returns fetch error on network failure", async () => {
@@ -324,7 +432,7 @@ describe("EnfieldHashAdapter.fetch (HTML fallback path)", () => {
 
     const result = await adapter.fetch({
       id: "test",
-      url: "http://www.enfieldhash.org/",
+      url: "https://www.enfieldhash.org/",
     } as never);
 
     expect(result.events).toHaveLength(0);
@@ -339,30 +447,12 @@ describe("EnfieldHashAdapter.fetch (HTML fallback path)", () => {
 
     const result = await adapter.fetch({
       id: "test",
-      url: "http://www.enfieldhash.org/",
+      url: "https://www.enfieldhash.org/",
     } as never);
 
     expect(result.events).toHaveLength(0);
     expect(result.errorDetails?.fetch?.[0].status).toBe(403);
     expect(result.errorDetails?.fetch?.length).toBeGreaterThan(1);
-  });
-
-  it("includes Blogger API error in diagnostics when HTML also fails", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("Forbidden", { status: 403, statusText: "Forbidden" }),
-    );
-
-    const result = await adapter.fetch({
-      id: "test",
-      url: "http://www.enfieldhash.org/",
-    } as never);
-
-    expect(result.events).toHaveLength(0);
-    expect(result.errorDetails?.fetch?.[0].status).toBe(403);
-    // Blogger API error should be surfaced in diagnostic context
-    expect(result.diagnosticContext?.bloggerApiError).toBe(
-      "Missing GOOGLE_CALENDAR_API_KEY environment variable",
-    );
   });
 
   it("falls back across protocol/host variants on 403", async () => {
@@ -371,16 +461,15 @@ describe("EnfieldHashAdapter.fetch (HTML fallback path)", () => {
       new Response("Forbidden", { status: 403, statusText: "Forbidden" }),
     );
     fetchSpy.mockResolvedValueOnce(
-      new Response(SAMPLE_BLOGGER_HTML, { status: 200 }),
+      new Response(SAMPLE_NEW_SITE_HTML, { status: 200 }),
     );
 
     const result = await adapter.fetch({
       id: "test",
-      url: "http://www.enfieldhash.org/",
+      url: "https://www.enfieldhash.org/",
     } as never);
 
     expect(result.events.length).toBeGreaterThan(0);
     expect(fetchSpy).toHaveBeenCalledTimes(2);
-    expect(String(fetchSpy.mock.calls[1][0])).toContain("http://enfieldhash.org");
   });
 });


### PR DESCRIPTION
The Enfield Hash website migrated from Blogger/Blogspot to a custom
static HTML site, breaking the existing scraper. This commit:

- Removes Blogger API dependency (site no longer uses Blogger)
- Targets new .paragraph-box containers with h1 titles
- Adds year-less date parsing with smart ±6 month year inference
- Adds unstructured prose extraction (station, location fallbacks)
- Enhances fetch headers (Sec-Fetch-*, Sec-Ch-Ua) to help bypass 403
- Extracts run numbers from titles into event descriptions
- Filters out "OnOn" closing text from body paragraphs
- Retains legacy Blogger HTML selector fallback for safety
- Updates all 38 tests for new structure (all 1480 suite tests pass)

https://claude.ai/code/session_014YFNbAHt9KFza41jDg1upX