### PR TITLE
Fix EventCard header layout overflow on narrow screens

### DIFF
--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -175,8 +175,8 @@ export function EventCard({ event, density, onSelect, isSelected, attendance }: 
       >
         <div className="min-w-0 space-y-0.5">
           {/* Line 1: date · kennel · run# · time — all on one line */}
-          <div className="flex items-center gap-1.5 text-sm">
-            <span className="font-medium" suppressHydrationWarning>{displayDateStr}</span>
+          <div className="flex flex-nowrap items-center gap-1.5 overflow-hidden text-sm">
+            <span className="shrink-0 whitespace-nowrap font-medium" suppressHydrationWarning>{displayDateStr}</span>
             <span className="text-muted-foreground">·</span>
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
Fixed layout issues in the EventCard component's header row to prevent text overflow and ensure proper wrapping behavior on narrow screens.

## Key Changes
- Added `flex-nowrap` to the header container to prevent flex items from wrapping to multiple lines
- Added `overflow-hidden` to the container to clip any content that exceeds the available width
- Added `shrink-0` to the date span to prevent it from shrinking below its content width
- Added `whitespace-nowrap` to the date span to keep the date on a single line

## Implementation Details
These changes ensure that the date, kennel, run number, and time information in the EventCard header remain on a single line and are properly constrained within their container. The `shrink-0` class prevents the date from being compressed, while `whitespace-nowrap` ensures it doesn't break into multiple lines. The `overflow-hidden` on the parent container clips any overflow that might occur on very narrow viewports.

https://claude.ai/code/session_01THHZHvGeRzWYCaNcRcKMvs