### PR TITLE
Remove kennel aliases section from detail page

### DIFF
--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -36,7 +36,6 @@ export default async function KennelDetailPage({
   const kennel = await prisma.kennel.findUnique({
     where: { slug },
     include: {
-      aliases: { select: { alias: true }, orderBy: { alias: "asc" } },
       _count: { select: { members: true } },
     },
   });
@@ -169,22 +168,6 @@ export default async function KennelDetailPage({
           kennelId={kennel.id}
           kennelShortName={kennel.shortName}
         />
-      )}
-
-      {/* Aliases */}
-      {kennel.aliases.length > 0 && (
-        <div>
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Also known as
-          </h2>
-          <div className="mt-1 flex flex-wrap gap-1">
-            {kennel.aliases.map((a) => (
-              <Badge key={a.alias} variant="secondary">
-                {a.alias}
-              </Badge>
-            ))}
-          </div>
-        </div>
       )}
 
       {/* Upcoming Events */}


### PR DESCRIPTION
## Summary
Removed the kennel aliases feature from the kennel detail page, including both the database query and the UI rendering of aliases.

## Changes
- Removed `aliases` relation from the Prisma query in the kennel detail page
- Removed the "Also known as" section that displayed kennel aliases as badges
- Cleaned up the associated UI markup and styling

## Details
This change removes the display of alternative names (aliases) for kennels on their detail pages. The aliases data is no longer fetched from the database, and the corresponding UI component that rendered them as secondary badges has been deleted.

https://claude.ai/code/session_01UxSMwBfaWQUTY19Q9Uxb13