### PR TITLE
Replace Tooltip with InfoPopover component for event details

### DIFF
--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -41,7 +41,7 @@ import { EventTimeDisplay } from "@/components/hareline/EventTimeDisplay";
 import { SourcesDropdown } from "@/components/hareline/SourcesDropdown";
 import { getEventDayWeather } from "@/lib/weather";
 import { REGION_CENTROIDS } from "@/lib/geo";
-import { Info } from "lucide-react";
+import { InfoPopover } from "@/components/ui/info-popover";
 
 export default async function EventDetailPage({
   params,
@@ -143,14 +143,9 @@ export default async function EventDetailPage({
           >
             {event.kennel.fullName}
           </Link>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-3.5 w-3.5 cursor-help text-muted-foreground" />
-            </TooltipTrigger>
-            <TooltipContent>
-              Event details are pulled from public sources. Always confirm with your kennel.
-            </TooltipContent>
-          </Tooltip>
+          <InfoPopover title="Data source">
+            Event details are pulled from public sources. Always confirm with your kennel.
+          </InfoPopover>
           <Badge>{event.kennel.region}</Badge>
           {event.status === "CANCELLED" && (
             <Badge variant="destructive">Cancelled</Badge>


### PR DESCRIPTION
## Summary
Refactored the event details disclaimer UI to use a custom `InfoPopover` component instead of the generic `Tooltip` component from lucide-react, improving consistency and maintainability.

## Changes
- Replaced the `Info` icon import from lucide-react with `InfoPopover` component import
- Converted the Tooltip/TooltipTrigger/TooltipContent structure to a simpler `InfoPopover` component with `title` and children props
- Updated the disclaimer message about event data sources to use the new component structure
- Removed inline icon styling in favor of component-managed presentation

## Implementation Details
The new `InfoPopover` component provides a cleaner API for displaying informational popovers with a title and content, reducing boilerplate compared to the previous Tooltip implementation. This change maintains the same user-facing functionality while improving code readability and enabling consistent styling across similar UI patterns.

https://claude.ai/code/session_01XzZYtZiSp9BmsyZ52NymfA