### PR TITLE
Fix near-me filter by allowing geolocation in Permissions-Policy header

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,7 @@ const securityHeaders = [
   },
   {
     key: "Permissions-Policy",
-    value: "camera=(), microphone=(), geolocation=()",
+    value: "camera=(), microphone=(), geolocation=(self)",
   },
 ];
 


### PR DESCRIPTION
The Permissions-Policy header had geolocation=() which blocks the Geolocation API for all origins, preventing Chrome from ever showing the location permission prompt. Changed to geolocation=(self) to allow the page's own origin to request location.

https://claude.ai/code/session_01DhHCDnGuBicjanfaSab5aG