### PR TITLE
fix(deploy): add prisma db push to build script to sync database schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ calendar + personal logbook + kennel directory.
 
 ## Quick Commands
 - `npm run dev` — Start local dev server (http://localhost:3000)
-- `npm run build` — Production build
+- `npm run build` — Production build (runs `prisma db push --skip-generate` then `next build`)
 - `npm test` — Run test suite (Vitest, 69 test files)
 - `npx prisma studio` — Visual database browser
 - `npx prisma db push` — Push schema changes to dev DB

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma db push --skip-generate && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",


### PR DESCRIPTION
The STATIC_SCHEDULE enum value was in the Prisma schema but missing from the production database because the build pipeline only ran prisma generate (TypeScript types) without pushing schema changes to PostgreSQL. This caused a P2007 error when creating static schedule sources for Facebook-only kennels.

https://claude.ai/code/session_01B2guM8SxDscK5guXVJtBSF