### PR TITLE
fix: address PR #129 review feedback — type safety, idiomatic Next.js…

### DIFF
--- a/src/app/api/auth/strava/callback/route.ts
+++ b/src/app/api/auth/strava/callback/route.ts
@@ -13,12 +13,19 @@ const STATE_COOKIE = "strava_oauth_state";
 /**
  * GET /api/auth/strava/callback — Strava OAuth callback handler.
  *
- * 1. Validate CSRF state parameter against cookie
- * 2. Handle user denial (error=access_denied)
+ * @remarks
+ * This route uses `NextResponse.redirect()` instead of the standard
+ * `{ data, error?, meta? }` JSON envelope because it is an OAuth callback:
+ * the browser navigates here directly from Strava's authorization page, so
+ * the response must redirect the user back to the app UI. Returning JSON
+ * would leave the user stranded on a raw JSON page.
+ *
+ * 1. Handle user denial (error=access_denied)
+ * 2. Validate CSRF state parameter against cookie
  * 3. Exchange authorization code for tokens
  * 4. Check for duplicate athlete (one Strava account per HashTracks user)
  * 5. Upsert StravaConnection
- * 6. Redirect to profile page
+ * 6. Redirect to profile page with status query param
  */
 export async function GET(request: NextRequest) {
   const appUrl = getAppUrl();

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -11,6 +11,11 @@ import { Separator } from "@/components/ui/separator";
 import { getMyKennelLinks } from "./actions";
 import { getStravaConnection } from "@/app/strava/actions";
 
+/**
+ * Profile page — displays the user's hash identity, Strava connection,
+ * kennel connections, and subscribed kennels. Redirects to sign-in if
+ * the user is unauthenticated.
+ */
 export default async function ProfilePage() {
   const user = await getOrCreateUser();
   if (!user) redirect("/sign-in");


### PR DESCRIPTION
…, docstrings

- Narrow ERROR_MESSAGES type with `as const` + `keyof` union instead of Record<string, string> for compile-time key safety (CodeRabbit)
- Replace window.location.href URL cleanup with usePathname() hook for idiomatic Next.js pattern (Gemini Code Assist)
- Document OAuth callback redirect exemption from JSON envelope convention in JSDoc @remarks (CodeRabbit — intentional, redirects required for OAuth)
- Add JSDoc docstrings to StravaStatusToast, ERROR_MESSAGES, and ProfilePage to meet 80% docstring coverage threshold (pre-merge check)

https://claude.ai/code/session_01GzQh2dxjSUNvAjte9fwS7a