### PR TITLE
fix: skip SSRF URL validation for Google Calendar sources

### DIFF
--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -181,6 +181,18 @@ describe("scrapeSource", () => {
     expect(updateData.data.sampleSkipped).toBeUndefined();
   });
 
+  it("does not reject GOOGLE_CALENDAR sources with calendar-ID URLs", async () => {
+    const gcalSource = { id: "src_gcal", type: "GOOGLE_CALENDAR", url: "bostonhash@gmail.com" };
+    mockSourceFind.mockResolvedValueOnce(gcalSource as never);
+    mockGetAdapter.mockReturnValue({
+      type: "GOOGLE_CALENDAR",
+      fetch: vi.fn().mockResolvedValue({ events: [{ date: "2026-03-01", kennelTag: "BH3" }], errors: [] }),
+    } as never);
+
+    const result = await scrapeSource("src_gcal");
+    expect(result.success).toBe(true);
+  });
+
   it("stores non-empty sample arrays in ScrapeLog", async () => {
     const sampleBlocked = [{ reason: "SOURCE_KENNEL_MISMATCH", kennelTag: "OtherH3", event: {}, suggestedAction: "Link" }];
     const sampleSkipped = [{ reason: "UNMATCHED_TAG", kennelTag: "UnknownH3", event: {}, suggestedAction: "Create" }];

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -233,8 +233,13 @@ export async function scrapeSource(
   });
 
   try {
-    // SSRF prevention: validate source URL before any destructive operations
-    validateSourceUrl(source.url);
+    // SSRF prevention: validate source URL before any destructive operations.
+    // GOOGLE_CALENDAR stores a calendar ID (not a URL) — the adapter constructs
+    // the googleapis.com URL itself. STATIC_SCHEDULE and MANUAL have no fetch URL.
+    const urlBasedTypes = ["HTML_SCRAPER", "GOOGLE_SHEETS", "ICAL_FEED", "RSS_FEED", "JSON_API", "HASHREGO", "MEETUP"];
+    if (urlBasedTypes.includes(source.type)) {
+      validateSourceUrl(source.url);
+    }
 
     if (force) {
       await prisma.rawEvent.deleteMany({ where: { sourceId } });


### PR DESCRIPTION
GOOGLE_CALENDAR sources store a calendar ID (e.g. bostonhash@gmail.com)
in the url field, not a URL. The recent SSRF hardening commit added
validateSourceUrl() to the production scrape pipeline, which calls
new URL() and throws "Invalid URL" for non-URL calendar IDs.

The preview/test path already exempted GOOGLE_CALENDAR (preview-action.ts:99),
but the production path did not. This uses an allowlist of URL-based source
types so non-URL sources (GOOGLE_CALENDAR, STATIC_SCHEDULE, MANUAL) are
safely skipped.

https://claude.ai/code/session_013BvCdquHwcNgEGjevVp4nd