### PR TITLE
Add "Take Attendance" button on event detail page for misman members

### DIFF
--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
   });
   return { title: `${dateStr} · ${event.kennel.shortName} · HashTracks` };
 }
-import { getOrCreateUser } from "@/lib/auth";
+import { getOrCreateUser, getMismanUser } from "@/lib/auth";
 import { getStravaConnection } from "@/app/strava/actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -91,20 +91,15 @@ export default async function EventDetailPage({
     }
   }
 
-  const [confirmedCount, goingCount, stravaResult, mismanMembership] = await Promise.all([
+  const [confirmedCount, goingCount, stravaResult, mismanUser] = await Promise.all([
     prisma.attendance.count({ where: { eventId, status: "CONFIRMED" } }),
     prisma.attendance.count({ where: { eventId, status: "INTENDING" } }),
     user ? getStravaConnection() : Promise.resolve(null),
-    user
-      ? prisma.userKennel.findUnique({
-          where: { userId_kennelId: { userId: user.id, kennelId: event.kennelId } },
-          select: { role: true },
-        })
-      : Promise.resolve(null),
+    user ? getMismanUser(event.kennelId) : Promise.resolve(null),
   ]);
 
   const stravaConnected = stravaResult?.success ? stravaResult.connected : false;
-  const isMisman = mismanMembership?.role === "MISMAN" || mismanMembership?.role === "ADMIN";
+  const isMisman = !!mismanUser;
 
   // Fetch weather forecast for upcoming events (0–10 days out).
   // Compare at the calendar-day level (midnight UTC) to avoid off-by-one from UTC noon storage.


### PR DESCRIPTION
When a misman views an event for a kennel they manage, a primary "Take
Attendance" button now appears in the actions footer, deep-linking directly
to /misman/[slug]/attendance/[eventId]. The role check runs in parallel
with existing queries so there is no added latency.

https://claude.ai/code/session_01QG2cWMD5NkRCFPiScsix8b