### PR TITLE
feat: add ?force=true query param to cron dispatch endpoint

### DIFF
--- a/src/app/api/cron/dispatch/route.test.ts
+++ b/src/app/api/cron/dispatch/route.test.ts
@@ -16,8 +16,8 @@ vi.mock("@/pipeline/schedule");
 
 const APP_URL = "https://hashtracks.com";
 
-function makeRequest(): Request {
-  return new Request("https://example.com/api/cron/dispatch", {
+function makeRequest(queryString = ""): Request {
+  return new Request(`https://example.com/api/cron/dispatch${queryString}`, {
     method: "POST",
   });
 }
@@ -143,6 +143,35 @@ describe("POST /api/cron/dispatch", () => {
     expect(data.data.dispatched).toBe(3);
     expect(data.data.skipped).toBe(0);
     expect(data.data.success).toBe(true);
+    expect(data.data.force).toBe(false);
     expect(mockPublishJSON).toHaveBeenCalledTimes(3);
+  });
+
+  it("dispatches all sources when force=true, bypassing shouldScrape", async () => {
+    vi.mocked(prisma.source.findMany).mockResolvedValue(mockSources as never);
+    vi.mocked(shouldScrape).mockReturnValue(false);
+
+    const res = await POST(makeRequest("?force=true"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.data.force).toBe(true);
+    expect(data.data.dispatched).toBe(3);
+    expect(data.data.skipped).toBe(0);
+    expect(data.data.total).toBe(3);
+    expect(shouldScrape).not.toHaveBeenCalled();
+    expect(mockPublishJSON).toHaveBeenCalledTimes(3);
+  });
+
+  it("includes force=false in response when force param is absent", async () => {
+    vi.mocked(prisma.source.findMany).mockResolvedValue(mockSources as never);
+    vi.mocked(shouldScrape).mockReturnValue(false);
+
+    const res = await POST(makeRequest());
+    const data = await res.json();
+
+    expect(data.data.force).toBe(false);
+    expect(data.data.dispatched).toBe(0);
+    expect(shouldScrape).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/app/api/cron/dispatch/route.ts
+++ b/src/app/api/cron/dispatch/route.ts
@@ -7,12 +7,16 @@ import { shouldScrape } from "@/pipeline/schedule";
 /**
  * Fan-out dispatcher: queries all enabled sources, filters to those due for scraping,
  * and publishes a QStash message per source to `/api/cron/scrape/[sourceId]`.
+ * Supports `?force=true` query param to bypass schedule checks (all sources treated as due).
  */
 export async function POST(request: Request) {
   const auth = await verifyCronAuth(request);
   if (!auth.authenticated) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const url = new URL(request.url);
+  const force = url.searchParams.get("force") === "true";
 
   const appUrl =
     process.env.NEXT_PUBLIC_APP_URL ||
@@ -38,18 +42,23 @@ export async function POST(request: Request) {
   // Single-pass partitioning to avoid evaluating shouldScrape() twice per source
   const dueSources: typeof sources = [];
   const skippedSources: typeof sources = [];
-  for (const s of sources) {
-    (shouldScrape(s.scrapeFreq, s.lastScrapeAt) ? dueSources : skippedSources).push(s);
+  if (force) {
+    dueSources.push(...sources);
+  } else {
+    for (const s of sources) {
+      (shouldScrape(s.scrapeFreq, s.lastScrapeAt) ? dueSources : skippedSources).push(s);
+    }
   }
 
   console.log(
-    `[cron/dispatch] ${dueSources.length} due, ${skippedSources.length} skipped, auth=${auth.method}`,
+    `[cron/dispatch] ${dueSources.length} due, ${skippedSources.length} skipped, auth=${auth.method}${force ? ", force=true" : ""}`,
   );
 
   if (dueSources.length === 0) {
     return NextResponse.json({
       data: {
         success: true,
+        force,
         dispatched: 0,
         failed: 0,
         skipped: skippedSources.length,
@@ -88,6 +97,7 @@ export async function POST(request: Request) {
   return NextResponse.json({
     data: {
       success: failed === 0,
+      force,
       dispatched,
       failed,
       skipped: skippedSources.length,


### PR DESCRIPTION
Bypass shouldScrape() schedule check when force=true is passed, treating all enabled sources as due for scraping. Useful for manual testing and debugging via curl without waiting for schedule intervals.

https://claude.ai/code/session_01PaVEWE868fd5YjH8TzjycA