### PR TITLE
Upgrade Gemini model to gemini-2.5-flash-lite

### DIFF
--- a/src/lib/ai/gemini.test.ts
+++ b/src/lib/ai/gemini.test.ts
@@ -51,7 +51,7 @@ describe("callGemini", () => {
 
     await callGemini({ prompt: "test" });
     expect(capturedUrl).toContain("key=test-key");
-    expect(capturedUrl).toContain("gemini-2.0-flash");
+    expect(capturedUrl).toContain("gemini-2.5-flash-lite");
   });
 
   it("returns parsed text on success", async () => {

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -2,11 +2,11 @@
  * Gemini REST API client — thin wrapper for structured extraction.
  *
  * Uses the REST API directly (no SDK dependency) per PRD Appendix E.1.
- * Model: gemini-2.0-flash (fast, cheap — ideal for structured extraction).
+ * Model: gemini-2.5-flash-lite (fast, cheapest — ideal for structured extraction).
  * Temperature: 0.1 (deterministic for reproducible results).
  */
 
-const GEMINI_MODEL = "gemini-2.0-flash";
+const GEMINI_MODEL = "gemini-2.5-flash-lite";
 const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
 
 /** Simple in-memory response cache (survives within a single server instance). */

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -9,4 +9,4 @@ export function getGeminiClient(): GoogleGenAI | null {
   return _client;
 }
 
-export const GEMINI_MODEL = "gemini-2.0-flash";
+export const GEMINI_MODEL = "gemini-2.5-flash-lite";


### PR DESCRIPTION
## Summary
Updates the Gemini API client to use the newer `gemini-2.5-flash-lite` model instead of `gemini-2.0-flash`, providing improved performance at a lower cost for structured extraction tasks.

## Changes
- Updated `GEMINI_MODEL` constant from `gemini-2.0-flash` to `gemini-2.5-flash-lite` in both the main client (`src/lib/ai/gemini.ts`) and the exported constant (`src/lib/gemini.ts`)
- Updated documentation comment to reflect the model change and cost improvement ("cheapest" vs "cheap")
- Updated corresponding test assertion to verify the correct model is used in API requests

## Details
The model upgrade maintains the same configuration (temperature: 0.1 for deterministic results) while leveraging Google's latest flash model variant, which offers better cost efficiency for structured extraction use cases per the PRD requirements.

https://claude.ai/code/session_01Jx4eoCZQsxMCkdXkcsG8Dg