### PR TITLE
fix: migrate Meetup adapter from dead REST API to HTML scraping

### DIFF
--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MeetupAdapter } from "./adapter";
+import { MeetupAdapter, extractApolloEvents } from "./adapter";
 import type { Source } from "@/generated/prisma/client";
 
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
+vi.mock("../safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+
+import { safeFetch } from "../safe-fetch";
+const mockSafeFetch = vi.mocked(safeFetch);
 
 function makeSource(config: unknown): Source {
   return {
@@ -14,29 +18,78 @@ function makeSource(config: unknown): Source {
   } as unknown as Source;
 }
 
-const UPCOMING_EVENT = {
-  id: "evt-1",
-  name: "Trail #42 — Central Park",
-  status: "upcoming",
-  time: new Date("2026-03-15T18:00:00Z").getTime(),
-  local_date: "2026-03-15",
-  local_time: "18:00",
-  duration: 7200000,
-  description: "<p>Join us for a fun trail!</p>",
-  venue: { name: "Central Park Tavern", address_1: "100 W 67th St", city: "New York", state: "NY" },
-  link: "https://meetup.com/test-hash/events/evt-1",
+/** Build a minimal Apollo event object. */
+function buildApolloEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: "Event",
+    id: "313348941",
+    title: "Trail #42 — Central Park",
+    dateTime: "2026-03-15T18:00:00-05:00",
+    endTime: "2026-03-15T21:00:00-05:00",
+    status: "ACTIVE",
+    description: "<p>Join us for a fun trail!</p>",
+    eventUrl: "https://www.meetup.com/test-hash/events/313348941/",
+    venue: { __ref: "Venue:123" },
+    ...overrides,
+  };
+}
+
+const VENUE_ENTRY = {
+  __typename: "Venue",
+  name: "Central Park Tavern",
+  address: "100 W 67th St",
+  city: "New York",
+  state: "NY",
+  lat: 40.7749,
+  lng: -73.9754,
 };
 
-const PAST_EVENT = {
-  id: "evt-0",
-  name: "Trail #41",
-  status: "past",
-  time: new Date("2026-02-01T14:00:00Z").getTime(),
-  local_date: "2026-02-01",
-  local_time: "14:00",
-  venue: { name: "Some Bar", city: "Brooklyn" },
-  link: "https://meetup.com/test-hash/events/evt-0",
-};
+/** Wrap Apollo state entries into a realistic HTML page. */
+function buildMeetupHtml(
+  stateEntries: Record<string, unknown>,
+): string {
+  const json = JSON.stringify(stateEntries);
+  return `<!DOCTYPE html>
+<html><head><title>Meetup</title></head>
+<body>
+<script>window.__APOLLO_STATE__ = ${json};</script>
+<div id="app"></div>
+</body></html>`;
+}
+
+function mockHtmlResponse(html: string) {
+  mockSafeFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => html,
+  } as unknown as Response);
+}
+
+describe("extractApolloEvents", () => {
+  it("extracts events from Apollo state HTML", () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({ id: "1" }),
+      "Event:2": buildApolloEvent({ id: "2", title: "Second Run" }),
+      "Venue:123": VENUE_ENTRY,
+      ROOT_QUERY: { __typename: "Query" },
+    });
+    const { events } = extractApolloEvents(html);
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.id)).toContain("1");
+    expect(events.map((e) => e.id)).toContain("2");
+  });
+
+  it("returns empty array when no Apollo state found", () => {
+    const { events } = extractApolloEvents("<html><body>No state here</body></html>");
+    expect(events).toHaveLength(0);
+  });
+
+  it("returns empty array on malformed JSON", () => {
+    const html = '<script>window.__APOLLO_STATE__ = {broken json};</script>';
+    const { events } = extractApolloEvents(html);
+    expect(events).toHaveLength(0);
+  });
+});
 
 describe("MeetupAdapter", () => {
   beforeEach(() => {
@@ -56,37 +109,51 @@ describe("MeetupAdapter", () => {
     expect(result.errors[0]).toMatch(/groupUrlname/i);
   });
 
-  it("returns error on non-ok API response", async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+  it("returns error on non-ok HTTP response", async () => {
+    mockSafeFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    } as unknown as Response);
     const adapter = new MeetupAdapter();
     const result = await adapter.fetch(makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }));
     expect(result.events).toHaveLength(0);
     expect(result.errors[0]).toMatch(/404/);
   });
 
+  it("returns error on fetch failure", async () => {
+    mockSafeFetch.mockRejectedValue(new Error("Network error"));
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }));
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toMatch(/Network error/);
+  });
+
   it("parses events and assigns kennelTag", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => [UPCOMING_EVENT, PAST_EVENT],
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent(),
+      "Venue:123": VENUE_ENTRY,
     });
+    mockHtmlResponse(html);
+
     const adapter = new MeetupAdapter();
     const result = await adapter.fetch(
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
       { days: 365 },
     );
-    expect(result.errors).toHaveLength(0);
-    expect(result.events.length).toBe(2);
+    expect(result.events.length).toBe(1);
     expect(result.events[0].kennelTag).toBe("NYCH3");
     expect(result.events[0].title).toBe("Trail #42 — Central Park");
     expect(result.events[0].date).toBe("2026-03-15");
     expect(result.events[0].startTime).toBe("18:00");
   });
 
-  it("builds location from venue fields", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => [UPCOMING_EVENT],
+  it("builds location from venue ref", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent(),
+      "Venue:123": VENUE_ENTRY,
     });
+    mockHtmlResponse(html);
+
     const adapter = new MeetupAdapter();
     const result = await adapter.fetch(
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
@@ -95,11 +162,59 @@ describe("MeetupAdapter", () => {
     expect(result.events[0].location).toBe("Central Park Tavern, 100 W 67th St, New York, NY");
   });
 
-  it("strips HTML tags from description", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => [UPCOMING_EVENT],
+  it("extracts lat/lng from venue", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent(),
+      "Venue:123": VENUE_ENTRY,
     });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events[0].latitude).toBe(40.7749);
+    expect(result.events[0].longitude).toBe(-73.9754);
+  });
+
+  it("handles inline venue (no __ref)", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({
+        venue: { name: "Some Bar", city: "Brooklyn" },
+      }),
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events[0].location).toBe("Some Bar, Brooklyn");
+  });
+
+  it("handles null venue", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({ venue: null }),
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events[0].location).toBeUndefined();
+  });
+
+  it("strips HTML tags from description", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent(),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
     const adapter = new MeetupAdapter();
     const result = await adapter.fetch(
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
@@ -109,52 +224,103 @@ describe("MeetupAdapter", () => {
   });
 
   it("filters events outside the lookback window", async () => {
-    const futureTime = Date.now() + 200 * 24 * 60 * 60 * 1000;
-    const futureDate = new Date(futureTime);
-    const futureEvent = {
-      ...UPCOMING_EVENT,
-      id: "evt-future",
-      time: futureTime,
-      local_date: futureDate.toISOString().slice(0, 10),
-      local_time: "18:00",
-    };
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => [UPCOMING_EVENT, futureEvent],
+    const futureDate = new Date(Date.now() + 200 * 24 * 60 * 60 * 1000);
+    const futureIso = futureDate.toISOString().slice(0, 19) + "-05:00";
+
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent(),
+      "Event:2": buildApolloEvent({
+        id: "far-future",
+        title: "Far Future Run",
+        dateTime: futureIso,
+        eventUrl: "https://www.meetup.com/test-hash/events/far-future/",
+      }),
+      "Venue:123": VENUE_ENTRY,
     });
+    mockHtmlResponse(html);
+
     const adapter = new MeetupAdapter();
     const result = await adapter.fetch(
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
       { days: 90 },
     );
-    // futureEvent is >90 days out and should be excluded; UPCOMING_EVENT is within window
+    // far-future event is >90 days out and should be excluded
     expect(result.events).toHaveLength(1);
     expect(result.events[0].title).toBe("Trail #42 — Central Park");
   });
 
-  it("includes sourceUrl from event link", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => [UPCOMING_EVENT],
+  it("skips events without dateTime", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({ dateTime: undefined }),
+      "Event:2": buildApolloEvent({ id: "2", title: "Valid Run" }),
+      "Venue:123": VENUE_ENTRY,
     });
+    mockHtmlResponse(html);
+
     const adapter = new MeetupAdapter();
     const result = await adapter.fetch(
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
       { days: 365 },
     );
-    expect(result.events[0].sourceUrl).toBe(UPCOMING_EVENT.link);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].title).toBe("Valid Run");
+  });
+
+  it("includes sourceUrl from eventUrl", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent(),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events[0].sourceUrl).toBe("https://www.meetup.com/test-hash/events/313348941/");
   });
 
   it("populates diagnosticContext", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => [UPCOMING_EVENT],
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent(),
+      "Venue:123": VENUE_ENTRY,
     });
+    mockHtmlResponse(html);
+
     const adapter = new MeetupAdapter();
     const result = await adapter.fetch(
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
       { days: 365 },
     );
     expect(result.diagnosticContext?.groupUrlname).toBe("test-hash");
+    expect(result.diagnosticContext?.eventsFound).toBe(1);
+  });
+
+  it("reports error when no Apollo state found in HTML", async () => {
+    mockHtmlResponse("<html><body>No events here</body></html>");
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toMatch(/APOLLO_STATE/);
+  });
+
+  it("uses safeFetch with correct URL", async () => {
+    const html = buildMeetupHtml({ "Event:1": buildApolloEvent() });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    await adapter.fetch(
+      makeSource({ groupUrlname: "savannah-hash-house-harriers", kennelTag: "SavH3" }),
+      { days: 365 },
+    );
+    expect(mockSafeFetch).toHaveBeenCalledWith(
+      "https://www.meetup.com/savannah-hash-house-harriers/events/",
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
   });
 });

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -2,6 +2,7 @@ import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
 import { validateSourceConfig, stripHtmlTags, buildDateWindow } from "../utils";
+import { safeFetch } from "../safe-fetch";
 
 /** Source.config shape for Meetup sources. */
 export interface MeetupConfig {
@@ -11,37 +12,63 @@ export interface MeetupConfig {
   kennelTag: string;
 }
 
-interface MeetupEvent {
+/** Shape of an event entry in Meetup's __APOLLO_STATE__ JSON. */
+interface ApolloEvent {
+  __typename: string;
   id: string;
-  name: string;
-  status: string;
-  time: number;        // Unix ms timestamp — used only for window filtering
-  local_date: string;  // YYYY-MM-DD in the event's local timezone
-  local_time: string;  // HH:mm in the event's local timezone
-  duration?: number;
+  title?: string;
+  dateTime?: string;
+  endTime?: string;
+  status?: string;
   description?: string;
-  venue?: {
-    name?: string;
-    address_1?: string;
-    city?: string;
-    state?: string;
-  };
-  link: string;
+  eventUrl?: string;
+  venue?: { __ref?: string; name?: string; address?: string; city?: string; state?: string; lat?: number; lng?: number } | null;
 }
 
 /**
- * Meetup adapter — fetches events from a public Meetup.com group.
- *
- * Uses the Meetup v3 public API: GET /groups/{groupUrlname}/events
- * No API key required for public groups (rate-limited at ~200 req/hr).
- *
- * Config: { groupUrlname: string, kennelTag: string }
+ * Extract Event objects from Meetup's __APOLLO_STATE__ embedded JSON.
+ * Returns an empty array if the state isn't found or can't be parsed.
  */
-/** Build location string from a Meetup venue object. */
-function buildLocationFromVenue(venue: MeetupEvent["venue"]): string | undefined {
-  if (!venue) return undefined;
-  const parts = [venue.name, venue.address_1, venue.city, venue.state].filter(Boolean);
-  return parts.length > 0 ? parts.join(", ") : undefined;
+export function extractApolloEvents(html: string): { events: ApolloEvent[]; state: Record<string, Record<string, unknown>> } {
+  const match = /__APOLLO_STATE__\s*=\s*({[\s\S]+?});?\s*<\/script>/.exec(html);
+  if (!match) return { events: [], state: {} };
+
+  let state: Record<string, Record<string, unknown>>;
+  try {
+    state = JSON.parse(match[1]);
+  } catch {
+    return { events: [], state: {} };
+  }
+
+  const events: ApolloEvent[] = [];
+  for (const v of Object.values(state)) {
+    if (v != null && typeof v === "object" && (v as Record<string, unknown>).__typename === "Event") {
+      events.push(v as unknown as ApolloEvent);
+    }
+  }
+
+  return { events, state };
+}
+
+/**
+ * Resolve a venue from Apollo state — handles both inline objects and __ref lookups.
+ */
+function resolveVenue(
+  state: Record<string, Record<string, unknown>>,
+  venue: ApolloEvent["venue"],
+): { location?: string; latitude?: number; longitude?: number } {
+  if (!venue) return {};
+
+  // Resolve __ref if present
+  const resolved = venue.__ref ? (state[venue.__ref] as ApolloEvent["venue"]) : venue;
+  if (!resolved) return {};
+
+  const parts = [resolved.name, resolved.address, resolved.city, resolved.state].filter(Boolean);
+  return {
+    location: parts.length > 0 ? parts.join(", ") : undefined,
+    latitude: typeof resolved.lat === "number" ? resolved.lat : undefined,
+    longitude: typeof resolved.lng === "number" ? resolved.lng : undefined,
+  };
 }
 
 /** Strip HTML tags from Meetup description and truncate. */
@@ -50,20 +77,52 @@ function cleanMeetupDescription(desc: string | undefined): string | undefined {
   return stripHtmlTags(desc).slice(0, 2000) || undefined;
 }
 
-/** Build a RawEventData from a single Meetup event. */
-function buildRawEventFromMeetupEvent(ev: MeetupEvent, kennelTag: string): RawEventData {
+/**
+ * Extract local date and time from an ISO 8601 dateTime string.
+ * "2026-03-05T18:30:00-05:00" → { date: "2026-03-05", startTime: "18:30" }
+ * Uses the local portion of the string (not UTC conversion).
+ */
+function extractDateTime(dateTime: string): { date: string; startTime: string } {
   return {
-    date: ev.local_date,
-    kennelTag,
-    title: ev.name || undefined,
-    description: cleanMeetupDescription(ev.description),
-    location: buildLocationFromVenue(ev.venue),
-    startTime: ev.local_time,
-    sourceUrl: ev.link,
+    date: dateTime.slice(0, 10),
+    startTime: dateTime.slice(11, 16),
   };
 }
 
-/** Meetup.com public API adapter. Fetches upcoming and past events from a public Meetup group (no API key required). */
+/** Build a RawEventData from an Apollo event entry. */
+function buildRawEventFromApollo(
+  ev: ApolloEvent,
+  state: Record<string, Record<string, unknown>>,
+  kennelTag: string,
+): RawEventData {
+  const { date, startTime } = ev.dateTime
+    ? extractDateTime(ev.dateTime)
+    : { date: "", startTime: undefined };
+
+  const venueInfo = resolveVenue(state, ev.venue);
+
+  return {
+    date,
+    kennelTag,
+    title: ev.title || undefined,
+    description: cleanMeetupDescription(ev.description),
+    location: venueInfo.location,
+    latitude: venueInfo.latitude,
+    longitude: venueInfo.longitude,
+    startTime,
+    sourceUrl: ev.eventUrl || undefined,
+  };
+}
+
+/**
+ * Meetup.com HTML scraper adapter.
+ *
+ * Scrapes the public events page and extracts event data from the
+ * embedded __APOLLO_STATE__ JSON (the Meetup v3 REST API was shut down
+ * in Jan 2022 and the GraphQL API requires OAuth).
+ *
+ * Config: { groupUrlname: string, kennelTag: string }
+ */
 export class MeetupAdapter implements SourceAdapter {
   type = "MEETUP" as const;
 
@@ -88,35 +147,45 @@ export class MeetupAdapter implements SourceAdapter {
     const events: RawEventData[] = [];
     const errors: string[] = [];
 
-    const apiUrl = `https://api.meetup.com/${encodeURIComponent(config.groupUrlname)}/events?status=upcoming,past&page=100&only=id,name,status,time,local_date,local_time,duration,description,venue,link`;
+    const pageUrl = `https://www.meetup.com/${encodeURIComponent(config.groupUrlname)}/events/`;
 
-    let rawEvents: MeetupEvent[];
+    let html: string;
     try {
-      const res = await fetch(apiUrl, {
-        headers: { Accept: "application/json" },
+      const res = await safeFetch(pageUrl, {
+        headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
       });
 
       if (!res.ok) {
-        const message = `Meetup API error ${res.status} for group "${config.groupUrlname}"`;
+        const message = `Meetup page error ${res.status} for group "${config.groupUrlname}"`;
         return {
           events: [],
           errors: [message],
-          errorDetails: { fetch: [{ url: apiUrl, status: res.status, message }] },
+          errorDetails: { fetch: [{ url: pageUrl, status: res.status, message }] },
         };
       }
 
-      rawEvents = (await res.json()) as MeetupEvent[];
+      html = await res.text();
     } catch (err) {
       const message = `Failed to fetch Meetup events: ${err instanceof Error ? err.message : String(err)}`;
-      return { events: [], errors: [message], errorDetails: { fetch: [{ url: apiUrl, message }] } };
+      return { events: [], errors: [message], errorDetails: { fetch: [{ url: pageUrl, message }] } };
     }
 
-    for (const [i, ev] of rawEvents.entries()) {
+    const { events: apolloEvents, state } = extractApolloEvents(html);
+
+    if (apolloEvents.length === 0) {
+      const message = "No __APOLLO_STATE__ events found in page HTML";
+      errors.push(message);
+      errorDetails.parse = [{ row: 0, error: message }];
+    }
+
+    for (const [i, ev] of apolloEvents.entries()) {
       try {
-        const eventDate = new Date(ev.time);
+        if (!ev.dateTime) continue;
+
+        const eventDate = new Date(ev.dateTime);
         if (eventDate < minDate || eventDate > maxDate) continue;
 
-        events.push(buildRawEventFromMeetupEvent(ev, config.kennelTag));
+        events.push(buildRawEventFromApollo(ev, state, config.kennelTag));
       } catch (err) {
         const msg = `Failed to parse event "${ev.id}": ${err instanceof Error ? err.message : String(err)}`;
         errors.push(msg);
@@ -130,7 +199,7 @@ export class MeetupAdapter implements SourceAdapter {
       events,
       errors,
       errorDetails: hasErrorDetails ? errorDetails : undefined,
-      diagnosticContext: { groupUrlname: config.groupUrlname, eventsFound: rawEvents.length },
+      diagnosticContext: { groupUrlname: config.groupUrlname, eventsFound: apolloEvents.length },
     };
   }
 }

--- a/src/components/admin/config-panels/MeetupConfigPanel.tsx
+++ b/src/components/admin/config-panels/MeetupConfigPanel.tsx
@@ -56,13 +56,13 @@ export function MeetupConfigPanel({ config, onChange, allKennels }: MeetupConfig
         <p className="text-xs text-muted-foreground">
           Paste the full Meetup group URL or just the slug (e.g.{" "}
           <code className="rounded bg-muted px-1">brooklyn-hash-house-harriers</code>).
-          The group must be public — no API key required.
+          Scrapes the public events page — the group must be public.
         </p>
         {current.groupUrlname && (
           <p className="text-xs text-muted-foreground">
-            API URL:{" "}
+            Scrape URL:{" "}
             <code className="rounded bg-muted px-1">
-              api.meetup.com/{current.groupUrlname}/events
+              meetup.com/{current.groupUrlname}/events
             </code>
           </p>
         )}


### PR DESCRIPTION
## Summary

- The Meetup v3 REST API (`api.meetup.com`) was shut down Jan 31, 2022 — all fetches return 404
- Rewrites `MeetupAdapter` to scrape the public events page and extract data from the embedded `__APOLLO_STATE__` JSON (server-rendered Apollo cache)
- Resolves venue `__ref` lookups in Apollo state for location + lat/lng extraction
- Uses `safeFetch` for SSRF protection (old adapter used raw `fetch`)
- Updates config panel help text: "API URL" → "Scrape URL"

## Test plan

- [x] `npx vitest run src/adapters/meetup/` — 19 tests pass (extractApolloEvents unit tests, venue ref/inline/null, lat/lng, HTML stripping, date filtering, no-state error, safeFetch URL)
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 89/90 files pass (1 pre-existing flaky timeout in EventTable.test.ts)
- [ ] Test live scrape: create Meetup source for `savannah-hash-house-harriers` in admin UI and verify events load

🤖 Generated with [Claude Code](https://claude.com/claude-code)