### PR TITLE
fix: extract Meetup Apollo state from __NEXT_DATA__ script tag

### DIFF
--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -44,15 +44,17 @@ const VENUE_ENTRY = {
   lng: -73.9754,
 };
 
-/** Wrap Apollo state entries into a realistic HTML page. */
+/** Wrap Apollo state entries into a realistic __NEXT_DATA__ HTML page. */
 function buildMeetupHtml(
   stateEntries: Record<string, unknown>,
 ): string {
-  const json = JSON.stringify(stateEntries);
+  const nextData = JSON.stringify({
+    props: { pageProps: { __APOLLO_STATE__: stateEntries } },
+  });
   return `<!DOCTYPE html>
 <html><head><title>Meetup</title></head>
 <body>
-<script>window.__APOLLO_STATE__ = ${json};</script>
+<script id="__NEXT_DATA__" type="application/json">${nextData}</script>
 <div id="app"></div>
 </body></html>`;
 }
@@ -85,7 +87,7 @@ describe("extractApolloEvents", () => {
   });
 
   it("returns empty array on malformed JSON", () => {
-    const html = '<script>window.__APOLLO_STATE__ = {broken json};</script>';
+    const html = '<script id="__NEXT_DATA__" type="application/json">{broken json}</script>';
     const { events } = extractApolloEvents(html);
     expect(events).toHaveLength(0);
   });
@@ -306,7 +308,7 @@ describe("MeetupAdapter", () => {
       { days: 365 },
     );
     expect(result.events).toHaveLength(0);
-    expect(result.errors[0]).toMatch(/APOLLO_STATE/);
+    expect(result.errors[0]).toMatch(/NEXT_DATA/);
   });
 
   it("uses safeFetch with correct URL", async () => {

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -1,3 +1,4 @@
+import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
@@ -12,7 +13,7 @@ export interface MeetupConfig {
   kennelTag: string;
 }
 
-/** Shape of an event entry in Meetup's __APOLLO_STATE__ JSON. */
+/** Shape of an event entry in Meetup's __NEXT_DATA__ Apollo state. */
 interface ApolloEvent {
   __typename: string;
   id: string;
@@ -26,28 +27,30 @@ interface ApolloEvent {
 }
 
 /**
- * Extract Event objects from Meetup's __APOLLO_STATE__ embedded JSON.
+ * Extract Event objects from Meetup's __NEXT_DATA__ script tag (Apollo state).
  * Returns an empty array if the state isn't found or can't be parsed.
  */
 export function extractApolloEvents(html: string): { events: ApolloEvent[]; state: Record<string, Record<string, unknown>> } {
-  const match = /__APOLLO_STATE__\s*=\s*({[\s\S]+?});?\s*<\/script>/.exec(html);
-  if (!match) return { events: [], state: {} };
+  const $ = cheerio.load(html);
+  const scriptEl = $("#__NEXT_DATA__");
+  if (!scriptEl.length) return { events: [], state: {} };
 
-  let state: Record<string, Record<string, unknown>>;
   try {
-    state = JSON.parse(match[1]);
+    const nextData = JSON.parse(scriptEl.text());
+    const state: Record<string, Record<string, unknown>> = nextData?.props?.pageProps?.__APOLLO_STATE__;
+    if (!state || typeof state !== "object") return { events: [], state: {} };
+
+    const events: ApolloEvent[] = [];
+    for (const v of Object.values(state)) {
+      if (v != null && typeof v === "object" && (v as Record<string, unknown>).__typename === "Event") {
+        events.push(v as unknown as ApolloEvent);
+      }
+    }
+
+    return { events, state };
   } catch {
     return { events: [], state: {} };
   }
-
-  const events: ApolloEvent[] = [];
-  for (const v of Object.values(state)) {
-    if (v != null && typeof v === "object" && (v as Record<string, unknown>).__typename === "Event") {
-      events.push(v as unknown as ApolloEvent);
-    }
-  }
-
-  return { events, state };
 }
 
 /**
@@ -173,7 +176,7 @@ export class MeetupAdapter implements SourceAdapter {
     const { events: apolloEvents, state } = extractApolloEvents(html);
 
     if (apolloEvents.length === 0) {
-      const message = "No __APOLLO_STATE__ events found in page HTML";
+      const message = "No events found in __NEXT_DATA__ Apollo state";
       errors.push(message);
       errorDetails.parse = [{ row: 0, error: message }];
     }


### PR DESCRIPTION
## Summary
- **Fixes production Meetup scraper** — Apollo state is embedded inside `<script id="__NEXT_DATA__">` JSON, not as a `window.__APOLLO_STATE__` assignment
- Replaces regex extraction with Cheerio-based `#__NEXT_DATA__` parsing, navigating `props.pageProps.__APOLLO_STATE__`
- Updates all tests to use the correct `__NEXT_DATA__` HTML structure

## Test plan
- [x] `npx vitest run src/adapters/meetup/` — all 19 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] Verify live scrape in admin UI for savannah-hash-house-harriers

🤖 Generated with [Claude Code](https://claude.com/claude-code)