### PR TITLE
feat: Sprint C — kennel discovery + config-driven source onboarding

### DIFF
--- a/src/adapters/hashrego/kennel-api.ts
+++ b/src/adapters/hashrego/kennel-api.ts
@@ -4,6 +4,8 @@
  * GET /api/kennels/{slug} returns rich profile JSON (Django REST Framework).
  * Used by the discovery sync pipeline to enrich discovered kennels with
  * profile fields: website, email, year_started, trail info, payment info, etc.
+ *
+ * Rate limiting: 10 concurrent requests per batch, 500ms delay between batches.
  */
 
 export interface HashRegoKennelProfile {
@@ -31,8 +33,8 @@ export interface HashRegoKennelProfile {
 
 const BASE_URL = "https://hashrego.com";
 const USER_AGENT = "Mozilla/5.0 (compatible; HashTracks-Scraper)";
-const BATCH_SIZE = 5;
-const BATCH_DELAY_MS = 1000;
+const BATCH_SIZE = 10;
+const BATCH_DELAY_MS = 500;
 
 /** Fetch a single kennel profile from the Hash Rego API. Returns null on 404/error. */
 export async function fetchKennelProfile(
@@ -57,7 +59,7 @@ export async function fetchKennelProfile(
   }
 }
 
-/** Fetch profiles for a batch of slugs with rate limiting (~5/sec). */
+/** Fetch profiles for a batch of slugs with rate limiting (~20/sec). */
 export async function fetchKennelProfiles(
   slugs: string[],
 ): Promise<Map<string, HashRegoKennelProfile>> {

--- a/src/app/admin/discovery/page.tsx
+++ b/src/app/admin/discovery/page.tsx
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/db";
 import { DiscoveryTable } from "@/components/admin/DiscoveryTable";
 
 export const metadata = { title: "Kennel Discovery — HashTracks Admin" };
-export const maxDuration = 120;
+export const maxDuration = 300;
 
 export default async function DiscoveryPage() {
   const [discoveries, regions, statusCounts] = await Promise.all([

--- a/src/pipeline/kennel-discovery.ts
+++ b/src/pipeline/kennel-discovery.ts
@@ -84,20 +84,31 @@ export async function syncKennelDiscovery(): Promise<DiscoverySyncResult> {
     };
   }
 
-  // Step 2: Fetch API profiles + load DB data in parallel
-  const slugs = discovered.map((k) => k.slug);
-  const [profiles, existingKennels, existingAliases, existingDiscoveries] = await Promise.all([
-    fetchKennelProfiles(slugs),
+  // Step 2: Load existing discoveries to identify terminal slugs
+  const existingDiscoveries = await prisma.kennelDiscovery.findMany({
+    where: { externalSource: EXTERNAL_SOURCE },
+    select: { externalSlug: true, status: true },
+  });
+
+  const discoveryStatusMap = new Map(
+    existingDiscoveries.map((d) => [d.externalSlug, d.status]),
+  );
+
+  // Step 3: Split slugs — only fetch API profiles for non-terminal discoveries
+  const terminalStatuses = new Set(["ADDED", "LINKED", "DISMISSED"]);
+  const activeSlugs = discovered
+    .filter((k) => !terminalStatuses.has(discoveryStatusMap.get(k.slug) ?? ""))
+    .map((k) => k.slug);
+
+  // Step 4: Fetch API profiles (active only) + load kennels/aliases in parallel
+  const [profiles, existingKennels, existingAliases] = await Promise.all([
+    fetchKennelProfiles(activeSlugs),
     prisma.kennel.findMany({
       select: { id: true, shortName: true, fullName: true },
       where: { isHidden: false },
     }),
     prisma.kennelAlias.findMany({
       select: { kennelId: true, alias: true },
-    }),
-    prisma.kennelDiscovery.findMany({
-      where: { externalSource: EXTERNAL_SOURCE },
-      select: { externalSlug: true, status: true },
     }),
   ]);
   enriched = profiles.size;
@@ -116,10 +127,6 @@ export async function syncKennelDiscovery(): Promise<DiscoverySyncResult> {
     fullName: k.fullName,
     aliases: aliasMap.get(k.id),
   }));
-
-  const discoveryStatusMap = new Map(
-    existingDiscoveries.map((d) => [d.externalSlug, d.status]),
-  );
 
   // Step 5: Process each discovered kennel
   const syncTimestamp = new Date();


### PR DESCRIPTION
## Summary
- **Kennel Discovery pipeline**: Scrapes Hash Rego kennel directory (168+ kennels), enriches via API profiles, fuzzy-matches against existing DB kennels, upserts into `KennelDiscovery` model with admin review UI (add/link/dismiss)
- **Config-driven generic HTML scraper**: AI-assisted source onboarding wizard with CSS selector analysis (Gemini 2.0 Flash), preview/test flow, and `GenericHtmlAdapter`
- **Discovery sync timeout fix**: Skips API enrichment for terminal discoveries (ADDED/LINKED/DISMISSED), doubles batch concurrency (5→10, 500ms delay), bumps `maxDuration` to 300s

## Key changes
- New Prisma model: `KennelDiscovery` with status workflow (NEW → MATCHED → ADDED/LINKED/DISMISSED)
- New adapter: `GenericHtmlAdapter` — config-driven CSS selector scraping
- AI HTML analysis: Gemini-powered container detection, column mapping, few-shot learning from 7 adapter patterns
- Admin UI: Discovery table with bulk actions, match candidates, one-click add/link/dismiss
- Pipeline: 4-stage fuzzy matching (slug + name × shortName + fullName + aliases)
- Config validation with ReDoS safety (`safe-regex2`)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 96 test files, 1919 tests passing
- [ ] Vercel preview build succeeds
- [ ] "Sync Now" on `/admin/discovery` completes within timeout
- [ ] Discovery table shows ~168 kennels with match scores
- [ ] Add/Link/Dismiss actions work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)