### PR TITLE
feat: auto-link discovery kennels to Hash Rego event source

### DIFF
--- a/src/app/admin/discovery/actions.test.ts
+++ b/src/app/admin/discovery/actions.test.ts
@@ -183,6 +183,42 @@ describe("linkDiscoveryToKennel", () => {
       }),
     );
   });
+
+  it("preserves extra config keys during slug merge", async () => {
+    mockSourceFind.mockResolvedValue({
+      id: "src-hr",
+      config: { kennelSlugs: ["BFM"], baseUrl: "https://hashrego.com", retries: 3 },
+    } as never);
+
+    await linkDiscoveryToKennel("disc-1", "kennel-1");
+
+    expect(mockSourceUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          config: {
+            kennelSlugs: ["BFM", "NewH3"],
+            baseUrl: "https://hashrego.com",
+            retries: 3,
+          },
+        },
+      }),
+    );
+  });
+
+  it("treats array config as empty (does not corrupt data)", async () => {
+    mockSourceFind.mockResolvedValue({
+      id: "src-hr",
+      config: ["bad", "data"],
+    } as never);
+
+    await linkDiscoveryToKennel("disc-1", "kennel-1");
+
+    expect(mockSourceUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { config: { kennelSlugs: ["NewH3"] } },
+      }),
+    );
+  });
 });
 
 // ---- addKennelFromDiscovery ----
@@ -212,6 +248,19 @@ describe("addKennelFromDiscovery", () => {
     expect(mockSourceKennelCreate).toHaveBeenCalledWith({
       data: { sourceId: "src-hr", kennelId: "new-kennel-1" },
     });
+  });
+
+  it("succeeds even if source linking throws", async () => {
+    mockSourceFind.mockRejectedValue(new Error("DB timeout"));
+
+    const result = await addKennelFromDiscovery("disc-1", {
+      shortName: "NewH3",
+      fullName: "New Hash House Harriers",
+      regionId: "region-1",
+    });
+
+    // Kennel creation succeeded despite linking failure
+    expect(result).toEqual({ success: true, kennelId: "new-kennel-1" });
   });
 
   it("is a no-op for source linking if no HASHREGO source", async () => {

--- a/src/app/admin/discovery/actions.ts
+++ b/src/app/admin/discovery/actions.ts
@@ -45,7 +45,11 @@ async function linkKennelToHashRegoSource(
   if (!source) return;
 
   // Add slug to config.kennelSlugs (Set dedup prevents duplicates)
-  const config = (source.config as { kennelSlugs?: string[] } | null) ?? {};
+  const raw = source.config;
+  const config =
+    typeof raw === "object" && raw !== null && !Array.isArray(raw)
+      ? (raw as { kennelSlugs?: string[] })
+      : {};
   const slugs = new Set(config.kennelSlugs ?? []);
   if (!slugs.has(externalSlug)) {
     slugs.add(externalSlug);
@@ -232,7 +236,11 @@ export async function addKennelFromDiscovery(
 
   clearResolverCache();
 
-  await linkKennelToHashRegoSource(kennel.id, discovery.externalSlug);
+  try {
+    await linkKennelToHashRegoSource(kennel.id, discovery.externalSlug);
+  } catch (err) {
+    console.error("[discovery] Failed to link kennel to Hash Rego source:", err);
+  }
 
   revalidatePath("/admin/discovery");
   revalidatePath("/admin/kennels");


### PR DESCRIPTION
## Summary
- When an admin links, adds, or confirms a kennel discovery, automatically wire it to the Hash Rego event source by adding the slug to `Source.config.kennelSlugs` and creating a `SourceKennel` join record
- Without this, discovered kennels received metadata (website, schedule, etc.) but zero events in the hareline
- No UI or schema changes — linking is automatic; the next daily cron picks up new slugs

## Changes
- **`src/app/admin/discovery/actions.ts`**: Added `linkKennelToHashRegoSource()` helper called from `linkDiscoveryToKennel`, `addKennelFromDiscovery`, and `confirmMatch`. Also upgraded P2002 error handling to use `Prisma.PrismaClientKnownRequestError`.
- **`src/app/admin/discovery/actions.test.ts`** (new): 10 tests covering slug addition, SourceKennel creation, idempotency, null config, and no-op when no HASHREGO source exists.

## Test plan
- [x] All 97 test files pass (1953 tests)
- [ ] Link a discovery in admin UI → verify slug appears in Source config via Prisma Studio
- [ ] Confirm a MATCHED discovery → verify SourceKennel join record created
- [ ] Add kennel from discovery → verify both slug and SourceKennel wired up
- [ ] Run "Scrape Now" on Hash Rego source → verify events appear for newly linked kennel

🤖 Generated with [Claude Code](https://claude.com/claude-code)