### PR TITLE
refactor: make seed script additive (skip existing records)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -62,7 +62,8 @@ async function ensureKennelRecords(prisma: any, kennels: any[], toSlugFn: (s: st
       );
       const regionId = regionMap.get(kennel.region) ?? null;
       if (!regionId) {
-        console.warn(`  ⚠ No region found for "${kennel.region}" (kennel: ${kennel.shortName})`);
+        console.warn(`  ⚠ No region found for "${kennel.region}" (kennel: ${kennel.shortName}), skipping`);
+        continue;
       }
       record = await prisma.kennel.create({
         data: { kennelCode: kennel.kennelCode, shortName: kennel.shortName, slug, fullName: kennel.fullName, region: kennel.region, regionId, country: kennel.country ?? "USA", ...profileFields },
@@ -109,6 +110,7 @@ async function ensureSources(prisma: any, sources: any[], kennelRecords: Map<str
           { name: sourceData.name, type: sourceData.type },
         ],
       },
+      orderBy: { createdAt: "asc" },
     });
 
     let activeSource;


### PR DESCRIPTION
## Summary

- Changes seed functions from `upsert` to create-only (`ensure`) semantics — existing records are left untouched, preventing seed reruns from silently overwriting manual admin edits
- Renames `upsert*` → `ensure*` functions for clarity
- Removes source duplicate detection and auto-disable logic (no longer needed with additive-only approach)
- Adds per-function created-count logging for clearer seed output

## Context

Split out of PR #175 (hare extraction patterns) per code review feedback. The behavioral change from upsert→create-only deserves its own review since seed data updates will no longer propagate automatically.

**Trade-off:** After this change, updating seed data (e.g., fixing a kennel name or region assignment) requires either:
1. Manual DB update, or
2. Deleting the record and re-running seed

This is intentional — admin edits in the dashboard should take precedence over seed reruns.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 102 test files pass (2100 tests)
- [ ] Verify `npx prisma db seed` still creates new records on a fresh DB
- [ ] Verify re-running seed on an existing DB skips all records gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)