### PR TITLE
fix: restore EH3 + H4 adapters (SPA content URL, Ghost Content API)

### DIFF
--- a/docs/source-onboarding-playbook.md
+++ b/docs/source-onboarding-playbook.md
@@ -1,6 +1,6 @@
 # Source Onboarding Playbook
 
-How to add a new data source to HashTracks. This playbook captures patterns learned from onboarding 15 sources across 5 adapter types.
+How to add a new data source to HashTracks. This playbook captures patterns learned from onboarding 30 sources across 8 adapter types.
 
 ---
 
@@ -23,14 +23,14 @@ Source → Adapter.fetch() → RawEventData[] → fingerprint dedup → RawEvent
 
 ## What Varies Per Source (the adapter-specific work)
 
-| Concern | HTML Scraper | Google Calendar | Google Sheets | iCal Feed | Blogger API | Meetup | Hash Rego |
-|---------|-------------|----------------|--------------|-----------|-------------|--------|-----------|
-| Data access | HTTP GET + Cheerio parse | Calendar API v3 | Sheets API (tabs) + CSV export (data) | HTTP GET + node-ical parse | Blogger API v3 (blog ID discovery + posts endpoint) | Meetup public REST API | HTTP GET + Cheerio parse (index + detail pages) |
-| Auth needed | None | API key | API key (tab discovery only) | None | API key (same `GOOGLE_CALENDAR_API_KEY`) | None (public groups) | None |
-| Kennel tags | Regex patterns on event text | `config.kennelPatterns` (multi-kennel) or `config.defaultKennelTag` (single-kennel) or hardcoded SUMMARY regex (Boston) | Column-based rules from config JSON | `config.kennelPatterns` (regex on SUMMARY) or `config.defaultKennelTag` | Hardcoded per adapter (single-kennel Blogspot blogs) | `config.kennelTag` (single kennel, all events) | Per-event from Hash Rego data, filtered by `config.kennelSlugs` |
-| Date format | Site-specific (ordinals, DD/MM/YYYY, US dates) | ISO 8601 timestamps | Multi-format: M-D-YY, M/D/YYYY | ISO 8601 / DTSTART | API returns ISO 8601 `published`; post body parsed with site-specific logic | ISO 8601 (`local_date`) | Site-specific HTML parsing |
-| Routing | URL-based (`htmlScrapersByUrl` in registry) | Shared adapter (single class) | Shared adapter (config-driven) | Shared adapter (config-driven) | URL-based (reuses `htmlScrapersByUrl` routing, Blogger API is primary fetch with HTML fallback) | Shared adapter (config-driven) | Shared adapter (config-driven) |
-| Complexity | High (structural HTML, site-specific) | Medium (clean API) | Low (column mapping) | Low-Medium (config-driven, but iCal quirks) | Medium (shared `fetchBloggerPosts()` utility + site-specific body parsing) | Low (config-driven, AI-assisted) | Medium (index + detail page scraping) |
+| Concern | HTML Scraper | Google Calendar | Google Sheets | iCal Feed | Blogger API | Ghost Content API | Meetup | Hash Rego |
+|---------|-------------|----------------|--------------|-----------|-------------|-------------------|--------|-----------|
+| Data access | HTTP GET + Cheerio parse | Calendar API v3 | Sheets API (tabs) + CSV export (data) | HTTP GET + node-ical parse | Blogger API v3 (blog ID discovery + posts endpoint) | Ghost Content API (public key, JSON with full HTML) | Meetup public REST API | HTTP GET + Cheerio parse (index + detail pages) |
+| Auth needed | None | API key | API key (tab discovery only) | None | API key (same `GOOGLE_CALENDAR_API_KEY`) | None (public read-only key embedded in page) | None (public groups) | None |
+| Kennel tags | Regex patterns on event text | `config.kennelPatterns` (multi-kennel) or `config.defaultKennelTag` (single-kennel) or hardcoded SUMMARY regex (Boston) | Column-based rules from config JSON | `config.kennelPatterns` (regex on SUMMARY) or `config.defaultKennelTag` | Hardcoded per adapter (single-kennel Blogspot blogs) | Hardcoded per adapter (single-kennel Ghost blogs) | `config.kennelTag` (single kennel, all events) | Per-event from Hash Rego data, filtered by `config.kennelSlugs` |
+| Date format | Site-specific (ordinals, DD/MM/YYYY, US dates) | ISO 8601 timestamps | Multi-format: M-D-YY, M/D/YYYY | ISO 8601 / DTSTART | API returns ISO 8601 `published`; post body parsed with site-specific logic | API returns ISO 8601 `published_at`; post body HTML parsed for trail date | ISO 8601 (`local_date`) | Site-specific HTML parsing |
+| Routing | URL-based (`htmlScrapersByUrl` in registry) | Shared adapter (single class) | Shared adapter (config-driven) | Shared adapter (config-driven) | URL-based (reuses `htmlScrapersByUrl` routing, Blogger API is primary fetch with HTML fallback) | URL-based (reuses `htmlScrapersByUrl` routing, Ghost API is primary fetch with HTML fallback) | Shared adapter (config-driven) | Shared adapter (config-driven) |
+| Complexity | High (structural HTML, site-specific) | Medium (clean API) | Low (column mapping) | Low-Medium (config-driven, but iCal quirks) | Medium (shared `fetchBloggerPosts()` utility + site-specific body parsing) | Medium (Ghost API + trail section isolation + body parsing) | Low (config-driven, AI-assisted) | Medium (index + detail page scraping) |
 
 ---
 
@@ -336,21 +336,43 @@ git add . && git commit && git push
 - **Key lesson**: Use embedded HTML fixture strings in tests rather than fetching live sites — faster, deterministic, and captures known edge cases
 - **Key lesson**: Use `domhandler`'s `AnyNode` type (not `cheerio.AnyNode`) — Cheerio doesn't re-export it in all versions
 
-### Sources #13-14: Enfield Hash + OFH3 (Blogger API — Blogspot sites)
+### Source #13: OFH3 (Blogger API — Blogspot site)
 
 - **Type**: `HTML_SCRAPER` (internally uses Blogger API v3 with HTML scraping fallback)
-- **Coverage**: EH3 (enfieldhash.org — London), OFH3 (ofh3.com — DC/Frederick area)
-- **Adapters**:
-  - `src/adapters/html-scraper/enfield-hash.ts` — Monthly UK hash (3rd Wednesday, 7:30 PM), parses Date/Pub/Station/Hare labels
-  - `src/adapters/html-scraper/ofh3.ts` — Monthly US hash, parses Hares/When/Cost/Where/Trail Type/Shiggy/On-After labels
+- **Coverage**: OFH3 (ofh3.com — DC/Frederick area)
+- **Adapter**: `src/adapters/html-scraper/ofh3.ts` — Monthly US hash, parses Hares/When/Cost/Where/Trail Type/Shiggy/On-After labels
 - **Shared utility**: `src/adapters/blogger-api.ts` — `fetchBloggerPosts()` discovers blog ID, fetches posts via Blogger API v3
 - **Why Blogger API**: Google/Blogger blocks server-side requests from cloud provider IPs (Vercel, AWS, etc.) with HTTP 403 Forbidden. The Blogger API v3 authenticates via API key and bypasses this IP-based blocking.
-- **Fallback**: If the Blogger API is unavailable (missing API key, API not enabled), both adapters fall back to direct HTML scraping
+- **Fallback**: If the Blogger API is unavailable (missing API key, API not enabled), adapter falls back to direct HTML scraping
 - **Prerequisites**: Enable the Blogger API in GCP Console (https://console.cloud.google.com/apis/library/blogger.googleapis.com). Uses the same `GOOGLE_CALENDAR_API_KEY` — no new env var needed.
 - **Diagnostics**: `diagnosticContext.fetchMethod` indicates `"blogger-api"` or `"html-scrape"` to show which path was used
 - **Key lesson**: Blogger/Blogspot sites should always use the Blogger API v3 — direct HTML scraping will fail from cloud-hosted servers
 - **Key lesson**: The Blogger API returns post body as HTML in the `content` field, so existing Cheerio-based body parsers work unchanged — just load `post.content` instead of scraping the full page
 - **Key lesson**: Blog ID discovery (`/blogs/byurl`) needs to happen before posts can be fetched — build this into the shared utility, not per-adapter
+
+### Source #14: Enfield Hash (EH3) — SPA with static content file
+
+- **Type**: `HTML_SCRAPER` (direct HTML scraping with residential proxy)
+- **Coverage**: EH3 (enfieldhash.org — London)
+- **Adapter**: `src/adapters/html-scraper/enfield-hash.ts` — Monthly UK hash (3rd Wednesday, 7:30 PM), parses Date/Pub/Station/Hare labels + unstructured prose
+- **SPA workaround**: `enfieldhash.org` is a client-side SPA — the HTML shell has an empty `<div id="content">` and JavaScript loads content via `fetch("home.html")`. Cheerio can't execute JS, so the adapter fetches `home.html` directly. The content file has the same `.paragraph-box` + `<h1>` structure the parser expects.
+- **Residential proxy**: Required — the site's WAF blocks cloud provider IPs. Uses `USE_RESIDENTIAL_PROXY = true` with `safeFetch()`.
+- **URL variants**: `tryFetchWithUrlVariants()` tries www/non-www and http/https variants (shared `buildUrlVariantCandidates()` utility)
+- **Date handling**: Year-less dates ("Wed 25 February") use ±6 month inference via `inferYear()`; explicit years ("18th March 2026") trust chrono-node
+- **Key lesson**: SPA sites need content URL discovery — if a site loads content dynamically via `fetch()`, inspect the network requests to find the actual content URL and fetch it directly instead of the SPA shell
+- **Key lesson**: Not all hash sites are Blogger/Blogspot — verify the actual platform before assuming which API to use. EH3 is a custom SPA hosted on enfieldhash.org, NOT a Blogspot site.
+
+### Source #15: Hangover Hash (H4) — Ghost Content API
+
+- **Type**: `HTML_SCRAPER` (internally uses Ghost Content API with HTML scraping fallback)
+- **Coverage**: H4 (hangoverhash.digitalpress.blog — DC area, monthly)
+- **Adapter**: `src/adapters/html-scraper/hangover.ts` — Parses run number from title (`#214 - Trail Name`), Date/Hare/Location/HashCash/distances from body
+- **Ghost Content API**: DigitalPress is a Ghost CMS host. The Ghost Content API is publicly accessible with a read-only key embedded in every page response (in the `ghost-portal` script tag's `data-key` attribute). One API call (`/ghost/api/content/posts/`) returns structured JSON with full HTML per post, replacing 1 listing + N detail page fetches.
+- **Trail section isolation**: H4 posts contain two sections separated by `<hr>`: prelubes (events before the main trail) and the trail itself. `extractTrailSection(html)` strips everything before `<hr>` so `chronoParseDate` doesn't pick up prelube dates instead of the trail date.
+- **Date extraction**: Labeled `Date:` / `When:` fields → chrono-node fallback on trail section text → `published_at` from API as last resort
+- **HTML scraping fallback**: If the Ghost API returns 0 events (API unavailable, key rotated), falls back to the existing HTML scraping path
+- **Key lesson**: Ghost CMS sites expose a public Content API — look for `data-key` and `data-api` attributes on the portal script tag. The Content API returns structured JSON with full HTML, eliminating CSS selector fragility.
+- **Key lesson**: When a blog post contains multiple events (prelubes + main trail), isolate the relevant section before parsing to avoid extracting wrong dates/fields. Use structural markers like `<hr>` separators.
 
 ---
 
@@ -383,6 +405,9 @@ git add . && git commit && git push
 25. **Always add HTML scraping fallback for Blogger API sources** — If the API key is missing or the Blogger API isn't enabled, the adapter should fall back to direct HTML scraping. This ensures the scraper works in development environments without API keys (though it will still 403 from cloud IPs).
 26. **Meetup sources need zero code changes** — The MEETUP adapter is fully config-driven. The admin wizard auto-detects the source type from the URL, auto-populates `groupUrlname`, and uses AI to suggest the `kennelTag`. No API key required — Meetup's public REST API is unauthenticated for public groups.
 27. **AI config suggestion bootstraps Meetup onboarding** — The Meetup adapter requires both `groupUrlname` and `kennelTag` in config, but the AI suggestion flow extracts `groupUrlname` from the URL and uses it as a placeholder to fetch sample events. Gemini then analyzes event titles against known kennels to suggest the proper `kennelTag`. This solves the chicken-and-egg problem where config is needed to fetch, but fetching is needed to suggest config.
+28. **SPA sites need content URL discovery** — If a site loads content dynamically via JavaScript `fetch()`, Cheerio sees an empty container. Inspect the network requests (or the JS source) to find the actual content URL and fetch it directly. Example: `enfieldhash.org` loads `home.html` via SPA shell.
+29. **Ghost CMS sites expose a public Content API** — Look for `data-key` and `data-api` attributes on the `ghost-portal` script tag. The Content API (`/ghost/api/content/posts/`) returns structured JSON with full HTML per post, eliminating CSS selector fragility. The API key is read-only and safe to hardcode.
+30. **Multi-section blog posts need section isolation** — When a post contains multiple events (e.g., prelubes + main trail), isolate the relevant section before parsing to avoid extracting wrong dates/fields. Structural markers like `<hr>` separators are reliable delimiters.
 
 ---
 

--- a/src/adapters/html-scraper/enfield-hash.test.ts
+++ b/src/adapters/html-scraper/enfield-hash.test.ts
@@ -202,6 +202,45 @@ describe("parseEnfieldBody", () => {
   });
 });
 
+describe("EnfieldHashAdapter home.html URL construction", () => {
+  let adapter: EnfieldHashAdapter;
+
+  beforeEach(() => {
+    adapter = new EnfieldHashAdapter();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("<html><body></body></html>", { status: 200 }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("constructs home.html from trailing-slash base URL", async () => {
+    await adapter.fetch({ id: "test", url: "https://www.enfieldhash.org/" } as never);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("enfieldhash.org/home.html"),
+      expect.anything(),
+    );
+  });
+
+  it("constructs home.html from non-trailing-slash base URL", async () => {
+    await adapter.fetch({ id: "test", url: "https://www.enfieldhash.org" } as never);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("enfieldhash.org/home.html"),
+      expect.anything(),
+    );
+  });
+
+  it("uses default URL when source.url is empty", async () => {
+    await adapter.fetch({ id: "test", url: "" } as never);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("enfieldhash.org/home.html"),
+      expect.anything(),
+    );
+  });
+});
+
 // --- New site HTML structure (current enfieldhash.org) ---
 
 const SAMPLE_NEW_SITE_HTML = `
@@ -312,7 +351,8 @@ describe("EnfieldHashAdapter.fetch (new site structure)", () => {
     expect(first.kennelTag).toBe("EH3");
     expect(first.startTime).toBe("19:30");
     expect(first.title).toBe("Run 318 - Wed 25 February");
-    expect(first.sourceUrl).toBe("https://www.enfieldhash.org");
+    // SPA fix: fetches home.html, so sourceUrl is the home.html URL
+    expect(first.sourceUrl).toBe("https://www.enfieldhash.org/home.html");
     // Date includes inferred year
     expect(first.date).toMatch(/^\d{4}-02-25$/);
 

--- a/src/adapters/html-scraper/enfield-hash.ts
+++ b/src/adapters/html-scraper/enfield-hash.ts
@@ -215,7 +215,13 @@ export class EnfieldHashAdapter implements SourceAdapter {
     _options?: { days?: number },
   ): Promise<ScrapeResult> {
     const baseUrl = source.url || "https://www.enfieldhash.org/";
-    return this.fetchViaHtmlScrape(baseUrl);
+    // Site is a client-side SPA — the shell has an empty #content div.
+    // Content is loaded via fetch("home.html"), so we fetch that directly.
+    const contentUrl = new URL(
+      "home.html",
+      baseUrl.endsWith("/") ? baseUrl : baseUrl + "/",
+    ).toString();
+    return this.fetchViaHtmlScrape(contentUrl);
   }
 
   /** Try fetching HTML from URL variants with browser-like headers. */

--- a/src/adapters/html-scraper/hangover.test.ts
+++ b/src/adapters/html-scraper/hangover.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { parseHangoverTitle, parseHangoverDate, parseHangoverBody } from "./hangover";
-import { HangoverAdapter } from "./hangover";
+import {
+  parseHangoverTitle,
+  parseHangoverDate,
+  parseHangoverBody,
+  extractTrailSection,
+  HangoverAdapter,
+} from "./hangover";
 
 describe("parseHangoverTitle", () => {
   it("parses standard title", () => {
@@ -97,9 +102,267 @@ describe("parseHangoverBody", () => {
     expect(result.hares).toBeUndefined();
     expect(result.location).toBeUndefined();
   });
+
+  it("falls back to chrono-node for free-form dates without label", () => {
+    // New Ghost theme: dates appear as free-form text without Date:/When: prefix
+    const text = "Sunday, March 8th, 2026 Hare(s): Test Hare Trail Start: Some Park";
+    const result = parseHangoverBody(text);
+    expect(result.date).toBe("2026-03-08");
+    expect(result.hares).toBe("Test Hare");
+    expect(result.location).toBe("Some Park");
+  });
 });
 
-describe("HangoverAdapter integration", () => {
+describe("extractTrailSection", () => {
+  it("extracts text after <hr> separator", () => {
+    const html = `
+      <h2 id="prelubes-214">Prelubes</h2>
+      <p>Friday prelube at 6pm at Some Bar</p>
+      <hr>
+      <h2 id="h4-trail-214">H4 Trail #214</h2>
+      <p>Date: Sunday, February 15th, 2026</p>
+      <p>Hare(s): Test Hare</p>
+    `;
+    const result = extractTrailSection(html);
+    expect(result).toContain("Date: Sunday, February 15th, 2026");
+    expect(result).toContain("Test Hare");
+    expect(result).not.toContain("Friday prelube");
+  });
+
+  it("returns full text when no <hr> found", () => {
+    const html = `
+      <p>Date: Sunday, March 8th, 2026</p>
+      <p>Hare(s): Solo Hare</p>
+    `;
+    const result = extractTrailSection(html);
+    expect(result).toContain("Date: Sunday, March 8th, 2026");
+    expect(result).toContain("Solo Hare");
+  });
+
+  it("handles empty HTML", () => {
+    expect(extractTrailSection("")).toBe("");
+    expect(extractTrailSection("<p></p>")).toBe("");
+  });
+
+  it("strips prelube dates that would confuse chrono-node", () => {
+    const html = `
+      <h2>Prelubes</h2>
+      <p>Saturday, February 14th at 5pm at Bad Hare Brewing</p>
+      <hr>
+      <h2>H4 Trail</h2>
+      <p>Sunday, February 15th, 2026</p>
+      <p>Hare(s): Good Hare</p>
+    `;
+    const trailText = extractTrailSection(html);
+    // Should NOT contain the prelube date
+    expect(trailText).not.toContain("February 14th");
+    expect(trailText).toContain("February 15th");
+  });
+});
+
+describe("HangoverAdapter Ghost API integration", () => {
+  const GHOST_API_RESPONSE = {
+    posts: [
+      {
+        title: "#215 - The Spring Trail",
+        url: "https://hangoverhash.digitalpress.blog/215/",
+        html: `
+          <h2 id="prelubes-215">Prelubes</h2>
+          <p>Saturday, March 7th at 5pm at Prelube Bar</p>
+          <hr>
+          <h2 id="h4-trail-215">H4 Trail #215</h2>
+          <p>Date: Sunday, March 8th, 2026</p>
+          <p>Hare(s): Spring Runner and Trail Blazer</p>
+          <p>Trail Start: Rock Creek Park, 5200 Glover Rd NW, Washington, DC 20015</p>
+          <p>Hash Cash: $7.00 US</p>
+          <p>Trail Type: A to A</p>
+          <p>Pack Away at 10:15am</p>
+          <p>Eagle ~6.5 miles</p>
+          <p>Turkey ~4.2 miles</p>
+          <p>On-After: Pinstripes Georgetown</p>
+        `,
+        published_at: "2026-03-04T12:00:00.000Z",
+      },
+      {
+        title: "#214 - The Hungover Hearts Trail",
+        url: "https://hangoverhash.digitalpress.blog/214/",
+        html: `
+          <h2>H4 Trail #214</h2>
+          <p>Date: Sunday, February 15th, 2026</p>
+          <p>Hare(s): Just Rebekah and Grinding Nemo</p>
+          <p>Trail Start: Leesburg Town Hall Garage, 10 Loudoun St SW, Leesburg, VA 20175</p>
+          <p>Hash Cash: $7.00 US</p>
+        `,
+        published_at: "2026-02-10T12:00:00.000Z",
+      },
+      {
+        title: "About the Hangover Hash",
+        url: "https://hangoverhash.digitalpress.blog/about/",
+        html: "<p>We are a monthly hash in the DC area.</p>",
+        published_at: "2025-01-01T12:00:00.000Z",
+      },
+    ],
+  };
+
+  let adapter: HangoverAdapter;
+
+  beforeEach(() => {
+    adapter = new HangoverAdapter();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("parses events from Ghost Content API", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(GHOST_API_RESPONSE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }) as never,
+    );
+
+    const result = await adapter.fetch({
+      id: "test-h4",
+      url: "https://hangoverhash.digitalpress.blog/",
+    } as never);
+
+    expect(result.events).toHaveLength(2); // "About" skipped (no trail number)
+    expect(result.diagnosticContext).toMatchObject({
+      fetchMethod: "ghost-api",
+      postsFound: 3,
+      eventsParsed: 2,
+    });
+
+    // First event — has prelubes section (should be stripped)
+    expect(result.events[0]).toMatchObject({
+      date: "2026-03-08",
+      kennelTag: "H4",
+      runNumber: 215,
+      title: "The Spring Trail",
+      hares: "Spring Runner and Trail Blazer",
+      location: "Rock Creek Park, 5200 Glover Rd NW, Washington, DC 20015",
+      startTime: "10:15",
+      sourceUrl: "https://hangoverhash.digitalpress.blog/215/",
+    });
+    expect(result.events[0].description).toContain("Hash Cash: $7.00 US");
+
+    // Second event — no prelubes section
+    expect(result.events[1]).toMatchObject({
+      date: "2026-02-15",
+      kennelTag: "H4",
+      runNumber: 214,
+      title: "The Hungover Hearts Trail",
+      hares: "Just Rebekah and Grinding Nemo",
+    });
+  });
+
+  it("extracts correct trail date, not prelube date", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(GHOST_API_RESPONSE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }) as never,
+    );
+
+    const result = await adapter.fetch({
+      id: "test-h4",
+      url: "https://hangoverhash.digitalpress.blog/",
+    } as never);
+
+    // Trail date should be March 8, NOT the prelube date of March 7
+    expect(result.events[0].date).toBe("2026-03-08");
+  });
+
+  it("falls back to HTML scraping when Ghost API returns empty", async () => {
+    // Ghost API returns empty
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ posts: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }) as never,
+    );
+
+    // HTML fallback
+    const fallbackHtml = `
+<html><body>
+  <article class="gh-card">
+    <h2><a href="/214/">#214 - The Hungover Hearts Trail</a></h2>
+    <time datetime="2026-02-10">Feb 10, 2026</time>
+    <div class="gh-card-excerpt">
+      <p>Date: Sunday, February 15th, 2026</p>
+      <p>Hare(s): Just Rebekah</p>
+      <p>Trail Start: Leesburg</p>
+      <p>Hash Cash: $7.00</p>
+    </div>
+  </article>
+</body></html>`;
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(fallbackHtml, { status: 200 }) as never,
+    );
+
+    const result = await adapter.fetch({
+      id: "test-h4",
+      url: "https://hangoverhash.digitalpress.blog/",
+    } as never);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.diagnosticContext).toMatchObject({
+      fetchMethod: "html-scrape",
+    });
+    expect(result.events[0].date).toBe("2026-02-15");
+  });
+
+  it("falls back to HTML scraping when Ghost API errors", async () => {
+    // Ghost API 500 → 0 events → falls through to HTML scrape
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("Internal Server Error", { status: 500 }) as never,
+    );
+    // HTML scrape also fails (simulating total outage)
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("Server Error", { status: 500 }) as never,
+    );
+
+    const result = await adapter.fetch({
+      id: "test-h4",
+      url: "https://hangoverhash.digitalpress.blog/",
+    } as never);
+
+    // Both paths failed — should get HTML scrape result (the fallback path)
+    expect(result.events).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.diagnosticContext).toBeUndefined(); // HTML scrape error has no diagnosticContext
+    // Verify both API and HTML fetch were attempted
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses published_at as date fallback when body has no date", async () => {
+    const response = {
+      posts: [
+        {
+          title: "#216 - Mystery Trail",
+          url: "https://hangoverhash.digitalpress.blog/216/",
+          html: "<p>Hare(s): Unknown Hare</p><p>Trail Start: Somewhere</p>",
+          published_at: "2026-04-05T12:00:00.000Z",
+        },
+      ],
+    };
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }) as never,
+    );
+
+    const result = await adapter.fetch({
+      id: "test-h4",
+      url: "https://hangoverhash.digitalpress.blog/",
+    } as never);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].date).toBe("2026-04-05");
+  });
+});
+
+describe("HangoverAdapter HTML scraping (legacy)", () => {
   const SAMPLE_HTML = `
 <!DOCTYPE html>
 <html>
@@ -145,9 +408,13 @@ describe("HangoverAdapter integration", () => {
     vi.stubGlobal("fetch", vi.fn());
   });
 
-  it("parses trail posts from Ghost listing page", async () => {
+  it("parses trail posts from Ghost listing page via HTML fallback", async () => {
+    // Ghost API returns empty → falls back to HTML
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(SAMPLE_HTML, { status: 200 }) as never
+      new Response(JSON.stringify({ posts: [] }), { status: 200, headers: { "Content-Type": "application/json" } }) as never,
+    );
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(SAMPLE_HTML, { status: 200 }) as never,
     );
 
     const result = await adapter.fetch({
@@ -182,8 +449,14 @@ describe("HangoverAdapter integration", () => {
   });
 
   it("returns fetch error on HTTP failure", async () => {
+    // Ghost API fails
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response("Forbidden", { status: 403 }) as never
+      new Response("Forbidden", { status: 403 }) as never,
+    );
+    // API returns 0 events → falls through to HTML scrape
+    // HTML scrape also fails
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("Forbidden", { status: 403 }) as never,
     );
 
     const result = await adapter.fetch({
@@ -215,11 +488,17 @@ describe("HangoverAdapter integration", () => {
   </article>
 </body></html>`;
 
+    // Ghost API returns empty
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(html, { status: 200 }) as never
+      new Response(JSON.stringify({ posts: [] }), { status: 200, headers: { "Content-Type": "application/json" } }) as never,
     );
+    // HTML listing
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(detailHtml, { status: 200 }) as never
+      new Response(html, { status: 200 }) as never,
+    );
+    // Detail page fetch
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(detailHtml, { status: 200 }) as never,
     );
 
     const result = await adapter.fetch({
@@ -256,6 +535,10 @@ describe("HangoverAdapter integration", () => {
   </article>
 </body></html>`;
 
+    // Ghost API returns empty
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ posts: [] }), { status: 200, headers: { "Content-Type": "application/json" } }) as never,
+    );
     vi.mocked(fetch).mockResolvedValueOnce(new Response(listingHtml, { status: 200 }) as never);
     vi.mocked(fetch).mockResolvedValueOnce(new Response(detailHtml, { status: 200 }) as never);
 
@@ -272,6 +555,7 @@ describe("HangoverAdapter integration", () => {
       location: "The Pub, DC",
       sourceUrl: "https://hangoverhash.digitalpress.blog/211/",
     });
-    expect(fetch).toHaveBeenCalledTimes(2);
+    // API call + HTML listing + detail page
+    expect(fetch).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/adapters/html-scraper/hangover.ts
+++ b/src/adapters/html-scraper/hangover.ts
@@ -8,6 +8,13 @@ import { chronoParseDate, parse12HourTime } from "../utils";
 
 const DEFAULT_START_TIME = "10:15";
 
+/**
+ * Ghost Content API key — this is a public read-only key embedded in every page
+ * response of the DigitalPress site (in the ghost-portal script tag's data-key attribute).
+ * If it rotates, find the new one by inspecting the page source for `data-key="..."`.
+ */
+const GHOST_CONTENT_API_KEY = "970e3b5bd552591e25f0610a97";
+
 export function parseHangoverTitle(title: string): {
   runNumber?: number;
   trailName?: string;
@@ -32,6 +39,39 @@ export function parseHangoverDate(text: string): string | null {
 
 const parseTime = parse12HourTime;
 
+/**
+ * Extract the trail section from a Hangover H4 post's HTML body.
+ *
+ * H4 posts contain two sections separated by an `<hr>`:
+ *   1. Prelubes section (events before the main trail)
+ *   2. Trail section (the actual hash event details)
+ *
+ * We extract only the trail section to avoid prelube dates polluting
+ * the date extraction with chrono-node fallback.
+ *
+ * Exported for testing.
+ */
+export function extractTrailSection(html: string): string {
+  const $ = cheerio.load(html);
+  const hr = $("hr").first();
+
+  if (hr.length === 0) {
+    // No <hr> separator — return full text (older posts may not have prelubes)
+    return $.text().trim();
+  }
+
+  // Collect all text content after the <hr>
+  const parts: string[] = [];
+  let node = hr.get(0)?.nextSibling;
+  while (node) {
+    const text = $(node as AnyNode).text().trim();
+    if (text) parts.push(text);
+    node = node.nextSibling;
+  }
+
+  return parts.join("\n");
+}
+
 export function parseHangoverBody(text: string): {
   date?: string;
   hares?: string;
@@ -54,7 +94,13 @@ export function parseHangoverBody(text: string): {
     .trim();
 
   const dateMatch = normalized.match(/(?:^|\n)\s*(?:Date|When)\s*:\s*(.+?)(?=\n|$)/im);
-  const date = dateMatch ? parseHangoverDate(dateMatch[1].trim()) : undefined;
+  let date = dateMatch ? parseHangoverDate(dateMatch[1].trim()) : undefined;
+
+  // Fallback: use chrono-node on the full text when no Date:/When: label present.
+  // Safe when text has been pre-filtered via extractTrailSection (no prelube dates).
+  if (!date) {
+    date = chronoParseDate(text, "en-US") ?? undefined;
+  }
 
   const hareMatch = normalized.match(/(?:^|\n)\s*Hare(?:\(s\)|s)?\s*:\s*(.+?)(?=\n|$)/im);
   const locationMatch = normalized.match(/(?:^|\n)\s*(?:Trail Start|Start|Location|Where)\s*:\s*(.+?)(?=\n|$)/im);
@@ -154,6 +200,14 @@ function buildHangoverDescription(fields: ReturnType<typeof parseHangoverBody>):
   return descParts.length > 0 ? descParts.join(" | ") : undefined;
 }
 
+/** Ghost Content API post shape (subset of fields we request). */
+interface GhostPost {
+  title: string;
+  url: string;
+  html: string;
+  published_at: string;
+}
+
 export class HangoverAdapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
@@ -163,6 +217,104 @@ export class HangoverAdapter implements SourceAdapter {
   ): Promise<ScrapeResult> {
     const baseUrl = source.url || "https://hangoverhash.digitalpress.blog/";
 
+    // Try Ghost Content API first (structured JSON, no CSS selector fragility)
+    const apiResult = await this.fetchViaGhostApi(baseUrl);
+    if (apiResult.events.length > 0) return apiResult;
+
+    // Fallback to HTML scraping (for when API is unavailable or returns no posts)
+    return this.fetchViaHtmlScrape(baseUrl);
+  }
+
+  /** Fetch events via the Ghost Content API. */
+  private async fetchViaGhostApi(baseUrl: string): Promise<ScrapeResult> {
+    const events: RawEventData[] = [];
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    // Build API URL from the site's base URL
+    const apiBase = baseUrl.replace(/\/+$/, "");
+    const apiUrl = `${apiBase}/ghost/api/content/posts/?key=${GHOST_CONTENT_API_KEY}&limit=20&fields=title,url,html,published_at`;
+
+    const fetchStart = Date.now();
+    let posts: GhostPost[];
+    try {
+      const response = await safeFetch(apiUrl, {
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        return {
+          events: [],
+          errors: [`Ghost API HTTP ${response.status}`],
+          errorDetails: { fetch: [{ url: apiUrl, status: response.status, message: `HTTP ${response.status}` }] },
+          diagnosticContext: { fetchMethod: "ghost-api", apiStatus: response.status },
+        };
+      }
+      const data = await response.json() as { posts?: GhostPost[] };
+      posts = data.posts ?? [];
+    } catch (err) {
+      return {
+        events: [],
+        errors: [`Ghost API fetch failed: ${err}`],
+        errorDetails: { fetch: [{ url: apiUrl, message: `${err}` }] },
+        diagnosticContext: { fetchMethod: "ghost-api" },
+      };
+    }
+    const fetchDurationMs = Date.now() - fetchStart;
+
+    for (let i = 0; i < posts.length; i++) {
+      const post = posts[i];
+      const parsed = parseHangoverTitle(post.title);
+      if (!parsed) continue; // Non-trail post (e.g., "About", "Hash Markings Guide")
+
+      // Extract only the trail section (after <hr>) to avoid prelube dates
+      const trailText = extractTrailSection(post.html);
+      const bodyFields = parseHangoverBody(trailText);
+
+      // Use parsed date, fall back to API published_at
+      let eventDate = bodyFields.date;
+      if (!eventDate && post.published_at) {
+        const isoMatch = post.published_at.match(/^(\d{4}-\d{2}-\d{2})/);
+        eventDate = isoMatch?.[1];
+      }
+
+      if (!eventDate) {
+        errors.push(`No date for post: ${post.title}`);
+        continue;
+      }
+
+      const locationUrl = bodyFields.location
+        ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(bodyFields.location)}`
+        : undefined;
+
+      events.push({
+        date: eventDate,
+        kennelTag: "H4",
+        runNumber: parsed.runNumber,
+        title: parsed.trailName,
+        hares: bodyFields.hares,
+        location: bodyFields.location,
+        locationUrl,
+        startTime: bodyFields.startTime || DEFAULT_START_TIME,
+        sourceUrl: post.url,
+        description: buildHangoverDescription(bodyFields),
+      });
+    }
+
+    return {
+      events,
+      errors,
+      errorDetails: errors.length > 0 ? errorDetails : undefined,
+      diagnosticContext: {
+        fetchMethod: "ghost-api",
+        postsFound: posts.length,
+        eventsParsed: events.length,
+        fetchDurationMs,
+      },
+    };
+  }
+
+  /** Fetch events via HTML scraping (fallback path). */
+  private async fetchViaHtmlScrape(baseUrl: string): Promise<ScrapeResult> {
     const events: RawEventData[] = [];
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
@@ -241,6 +393,7 @@ export class HangoverAdapter implements SourceAdapter {
       structureHash,
       errorDetails: (errorDetails.fetch?.length ?? 0) > 0 ? errorDetails : undefined,
       diagnosticContext: {
+        fetchMethod: "html-scrape",
         articlesFound: articles.length,
         eventsParsed: events.length,
       },


### PR DESCRIPTION
## Summary

- **EH3 (Enfield Hash)**: Site redesigned as client-side SPA — Cheerio sees empty `#content` div. Fix: fetch `home.html` directly (the static content file loaded by the SPA shell). All existing parsing works unchanged.
- **H4 (Hangover Hash)**: Ghost CMS theme changed — listing cards lost excerpt/date, detail page dates lost `Date:` labels. Fix: switch to Ghost Content API as primary fetch method (structured JSON, one call replaces 1+N fetches). Added `extractTrailSection()` to isolate trail details from prelube dates via `<hr>` separator. HTML scraping kept as fallback.
- **Playbook**: Fixed EH3 entry (not Blogger), added H4 Ghost API docs, added 3 new lessons learned, updated source counts.

## Test plan

- [x] `npm test -- enfield-hash hangover` — 69 tests pass (43 EH3 + 26 H4)
- [x] Full suite: 102 files, 2144 tests pass
- [ ] Trigger manual scrape for EH3 from admin UI — verify events appear
- [ ] Trigger manual scrape for H4 from admin UI — verify events with correct dates (not prelube dates)
- [ ] Check diagnostic context shows `fetchMethod: "ghost-api"` for H4

🤖 Generated with [Claude Code](https://claude.com/claude-code)