### PR TITLE
Move geocoding to server action for admin authorization

### DIFF
--- a/src/app/admin/geocode-action.ts
+++ b/src/app/admin/geocode-action.ts
@@ -1,0 +1,12 @@
+"use server";
+
+import { getAdminUser } from "@/lib/auth";
+import { geocodeAddress } from "@/lib/geo";
+
+export async function geocodeAction(
+  address: string,
+): Promise<{ lat: number; lng: number } | null> {
+  const admin = await getAdminUser();
+  if (!admin) throw new Error("Unauthorized");
+  return geocodeAddress(address);
+}

--- a/src/components/admin/GeocodeButton.tsx
+++ b/src/components/admin/GeocodeButton.tsx
@@ -4,15 +4,15 @@ import { useState } from "react";
 import { Loader2, MapPin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import { geocodeAddress } from "@/lib/geo";
 
 interface GeocodeButtonProps {
   getAddress: () => string | null;
   latInputId: string;
   lngInputId: string;
+  geocode: (address: string) => Promise<{ lat: number; lng: number } | null>;
 }
 
-export function GeocodeButton({ getAddress, latInputId, lngInputId }: Readonly<GeocodeButtonProps>) {
+export function GeocodeButton({ getAddress, latInputId, lngInputId, geocode }: Readonly<GeocodeButtonProps>) {
   const [isGeocoding, setIsGeocoding] = useState(false);
 
   async function handleGeocode() {
@@ -20,7 +20,7 @@ export function GeocodeButton({ getAddress, latInputId, lngInputId }: Readonly<G
     if (!address) return;
     setIsGeocoding(true);
     try {
-      const result = await geocodeAddress(address);
+      const result = await geocode(address);
       if (result) {
         const latInput = document.getElementById(latInputId) as HTMLInputElement;
         const lngInput = document.getElementById(lngInputId) as HTMLInputElement;
@@ -47,7 +47,7 @@ export function GeocodeButton({ getAddress, latInputId, lngInputId }: Readonly<G
       {isGeocoding ? (
         <><Loader2 className="mr-1 h-3 w-3 animate-spin" />Geocoding...</>
       ) : (
-        <><MapPin className="mr-1 h-3 w-3" />Auto-fill from name</>
+        <><MapPin className="mr-1 h-3 w-3" />Geocode</>
       )}
     </Button>
   );

--- a/src/components/admin/KennelForm.tsx
+++ b/src/components/admin/KennelForm.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { generateAliases } from "@/lib/auto-aliases";
 import { GeocodeButton } from "./GeocodeButton";
+import { geocodeAction } from "@/app/admin/geocode-action";
 
 type KennelData = {
   id: string;
@@ -639,6 +640,7 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
                   }}
                   latInputId="latitude"
                   lngInputId="longitude"
+                  geocode={geocodeAction}
                 />
               </div>
               <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/admin/RegionFormDialog.tsx
+++ b/src/components/admin/RegionFormDialog.tsx
@@ -22,6 +22,7 @@ import { createRegion, updateRegion } from "@/app/admin/regions/actions";
 import { useRouter } from "next/navigation";
 import type { RegionRow } from "./RegionTable";
 import { GeocodeButton } from "./GeocodeButton";
+import { geocodeAction } from "@/app/admin/geocode-action";
 
 const COMMON_TIMEZONES = [
   "America/New_York",
@@ -206,6 +207,7 @@ export function RegionFormDialog({
                 }}
                 latInputId="centroidLat"
                 lngInputId="centroidLng"
+                geocode={geocodeAction}
               />
             </div>
             <div className="grid gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
Refactored the geocoding functionality to use a Next.js server action with admin authorization checks, improving security by ensuring only authenticated admins can perform geocoding operations.

## Key Changes
- Created new `geocodeAction` server action in `src/app/admin/geocode-action.ts` that:
  - Verifies the user is an admin before allowing geocoding
  - Wraps the existing `geocodeAddress` utility function
  - Throws an "Unauthorized" error if the user is not authenticated as an admin
  
- Updated `GeocodeButton` component to:
  - Accept a `geocode` function as a prop instead of directly importing `geocodeAddress`
  - Use the passed geocode function for address geocoding
  - Updated button label from "Auto-fill from name" to "Geocode" for clarity

- Updated form components to pass the server action:
  - `KennelForm.tsx` now imports and passes `geocodeAction` to `GeocodeButton`
  - `RegionFormDialog.tsx` now imports and passes `geocodeAction` to `GeocodeButton`

## Implementation Details
This change implements proper authorization at the server level rather than relying on client-side checks. The `GeocodeButton` component is now more flexible and testable by accepting the geocode function as a dependency, following the dependency injection pattern.

https://claude.ai/code/session_01A994dapvE5prmwk79DrN15