### PR TITLE
fix: use browser User-Agent in Meetup adapter to avoid bot detection

### DIFF
--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -155,7 +155,11 @@ export class MeetupAdapter implements SourceAdapter {
     let html: string;
     try {
       const res = await safeFetch(pageUrl, {
-        headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+        headers: {
+          "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "en-US,en;q=0.9",
+        },
       });
 
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- Meetup's bot detection was returning empty Apollo state when the adapter used a self-identifying `HashTracks-Scraper` User-Agent, causing "No events found" errors for Charleston Heretics and potentially all Meetup sources
- Updated to standard Chrome User-Agent with `Accept` and `Accept-Language` headers, matching the pattern used by other adapters (dch4, ewh3, ofh3, hangover)

## Test plan
- [x] `npm test -- src/adapters/meetup` — all 19 tests pass
- [ ] Trigger a scrape for Charleston Heretics Meetup and verify events are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)