### PR TITLE
Use server-only API key for geocoding operations

### DIFF
--- a/src/lib/geo.test.ts
+++ b/src/lib/geo.test.ts
@@ -147,14 +147,14 @@ describe("haversineDistance", () => {
 });
 
 describe("geocodeAddress", () => {
-  const originalEnv = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const originalEnv = process.env.GOOGLE_CALENDAR_API_KEY;
 
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = "test-api-key";
+    process.env.GOOGLE_CALENDAR_API_KEY = "test-api-key";
   });
 
   afterEach(() => {
-    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = originalEnv;
+    process.env.GOOGLE_CALENDAR_API_KEY = originalEnv;
     vi.restoreAllMocks();
   });
 
@@ -189,7 +189,7 @@ describe("geocodeAddress", () => {
   });
 
   it("returns null when API key is missing", async () => {
-    delete process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+    delete process.env.GOOGLE_CALENDAR_API_KEY;
     const result = await geocodeAddress("Some Address");
     expect(result).toBeNull();
   });
@@ -234,14 +234,14 @@ describe("geocodeAddress", () => {
 });
 
 describe("reverseGeocode", () => {
-  const originalEnv = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const originalEnv = process.env.GOOGLE_CALENDAR_API_KEY;
 
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = "test-api-key";
+    process.env.GOOGLE_CALENDAR_API_KEY = "test-api-key";
   });
 
   afterEach(() => {
-    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = originalEnv;
+    process.env.GOOGLE_CALENDAR_API_KEY = originalEnv;
     vi.restoreAllMocks();
   });
 
@@ -320,7 +320,7 @@ describe("reverseGeocode", () => {
   });
 
   it("returns null when API key is missing", async () => {
-    delete process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+    delete process.env.GOOGLE_CALENDAR_API_KEY;
     const result = await reverseGeocode(40, -74);
     expect(result).toBeNull();
   });

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -148,19 +148,22 @@ export function getEventCoordsFromRegionData(
   return null;
 }
 
+/** Hardcoded Google Geocoding API base — not user-controlled (SSRF-safe). */
+const GOOGLE_GEOCODE_BASE = "https://maps.googleapis.com/maps/api/geocode/json";
+
 /**
  * Geocode a text address using the Google Maps Geocoding API.
  * Returns the first result's coordinates, or null on failure.
- * Uses NEXT_PUBLIC_GOOGLE_MAPS_API_KEY (same key used by Static Maps).
+ * Uses GOOGLE_CALENDAR_API_KEY (server-only, no HTTP referrer restrictions).
  */
 export async function geocodeAddress(
   address: string,
 ): Promise<{ lat: number; lng: number } | null> {
-  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const apiKey = process.env.GOOGLE_CALENDAR_API_KEY;
   if (!apiKey || !address.trim()) return null;
 
   try {
-    const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${apiKey}`;
+    const url = `${GOOGLE_GEOCODE_BASE}?address=${encodeURIComponent(address)}&key=${apiKey}`;
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
     const res = await fetch(url, { signal: controller.signal });
@@ -168,7 +171,10 @@ export async function geocodeAddress(
     if (!res.ok) return null;
 
     const data = await res.json();
-    if (data.status !== "OK" || !data.results?.length) return null;
+    if (data.status !== "OK" || !data.results?.length) {
+      console.error(`Geocode failed for "${address}": ${data.status} ${data.error_message ?? ""}`);
+      return null;
+    }
 
     const { lat, lng } = data.results[0].geometry.location;
     if (typeof lat !== "number" || typeof lng !== "number") return null;
@@ -178,9 +184,6 @@ export async function geocodeAddress(
   }
 }
 
-/** Hardcoded Google Geocoding API base — not user-controlled (SSRF-safe). */
-const GOOGLE_GEOCODE_BASE = "https://maps.googleapis.com/maps/api/geocode/json";
-
 /**
  * Reverse geocode coordinates to a city string using the Google Maps Geocoding API.
  * Returns a display string like "Brooklyn, NY" or "London, England", or null on failure.
@@ -189,7 +192,7 @@ export async function reverseGeocode(
   lat: number,
   lng: number,
 ): Promise<string | null> {
-  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const apiKey = process.env.GOOGLE_CALENDAR_API_KEY;
   if (!apiKey) return null;
 
   try {


### PR DESCRIPTION
## Summary
Migrate geocoding functions to use a server-only API key (`GOOGLE_CALENDAR_API_KEY`) instead of the public-facing key (`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`). This improves security by removing HTTP referrer restrictions and prevents exposing the public key in client-side code.

## Key Changes
- **API Key Migration**: Updated `geocodeAddress()` and `reverseGeocode()` to use `GOOGLE_CALENDAR_API_KEY` environment variable instead of `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`
- **Code Organization**: Moved `GOOGLE_GEOCODE_BASE` constant definition before `geocodeAddress()` function for better logical flow
- **Enhanced Error Logging**: Added detailed error logging in `geocodeAddress()` to capture API status and error messages for debugging
- **Test Updates**: Updated all test cases to reference the new environment variable

## Implementation Details
- The hardcoded `GOOGLE_GEOCODE_BASE` URL remains SSRF-safe as it's not user-controlled
- Server-only API key eliminates the need for HTTP referrer restrictions, simplifying deployment configuration
- Error messages now include the geocoding status and API error details for better observability

https://claude.ai/code/session_01PUDtz47NzRoP9YiGMBxZC3