### PR TITLE
Fix HASHREGO kennel data sync: bidirectional slug↔SourceKennel auto-sync

### DIFF
--- a/src/app/admin/sources/[sourceId]/page.tsx
+++ b/src/app/admin/sources/[sourceId]/page.tsx
@@ -24,6 +24,7 @@ import { TroubleshootSection } from "@/components/admin/TroubleshootSection";
 import { TYPE_LABELS } from "@/components/admin/SourceTable";
 import { fuzzyMatch } from "@/lib/fuzzy";
 import { cn } from "@/lib/utils";
+import { getHashRegoSlugDrift } from "@/app/admin/sources/actions";
 
 /** Detect which scrape log IDs had structure hash changes. */
 function detectHashChanges(
@@ -392,6 +393,9 @@ export default async function SourceDetailPage({
 
   const hashChanges = detectHashChanges(structureHashHistory);
 
+  // Detect slug/link drift for HASHREGO sources (uses kennel resolver for alias resolution)
+  const slugDrift = await getHashRegoSlugDrift(source);
+
   const fuzzyCandidates = allKennels.map((k) => ({
     id: k.id,
     shortName: k.shortName,
@@ -490,38 +494,25 @@ export default async function SourceDetailPage({
       </div>
 
       {/* Slug/Link Drift Warning for HASHREGO sources */}
-      {source.type === "HASHREGO" && (() => {
-        const hrConfig = source.config as { kennelSlugs?: string[] } | null;
-        const slugs = (hrConfig?.kennelSlugs ?? []).map(s => s.toUpperCase());
-        const linkedShortNames = source.kennels.map(sk => sk.kennel.shortName.toUpperCase());
-        const slugsWithoutLink = slugs.filter(s => !linkedShortNames.includes(s));
-        const linksWithoutSlug = source.kennels
-          .filter(sk => !slugs.includes(sk.kennel.shortName.toUpperCase()))
-          .map(sk => sk.kennel.shortName);
-
-        if (slugsWithoutLink.length > 0 || linksWithoutSlug.length > 0) {
-          return (
-            <div className="rounded-md border border-yellow-500/50 bg-yellow-50 p-3 text-sm dark:bg-yellow-900/20">
-              <p className="font-medium text-yellow-800 dark:text-yellow-200">
-                Slug / Link Mismatch Detected
-              </p>
-              {slugsWithoutLink.length > 0 && (
-                <p className="mt-1 text-yellow-700 dark:text-yellow-300">
-                  Slugs without linked kennel (events will be blocked by guard):{" "}
-                  <span className="font-mono">{slugsWithoutLink.join(", ")}</span>
-                </p>
-              )}
-              {linksWithoutSlug.length > 0 && (
-                <p className="mt-1 text-yellow-700 dark:text-yellow-300">
-                  Linked kennels without slug (adapter won&apos;t fetch their events):{" "}
-                  <span className="font-mono">{linksWithoutSlug.join(", ")}</span>
-                </p>
-              )}
-            </div>
-          );
-        }
-        return null;
-      })()}
+      {(slugDrift.slugsWithoutLink.length > 0 || slugDrift.linksWithoutSlug.length > 0) && (
+        <div className="rounded-md border border-yellow-500/50 bg-yellow-50 p-3 text-sm dark:bg-yellow-900/20">
+          <p className="font-medium text-yellow-800 dark:text-yellow-200">
+            Slug / Link Mismatch Detected
+          </p>
+          {slugDrift.slugsWithoutLink.length > 0 && (
+            <p className="mt-1 text-yellow-700 dark:text-yellow-300">
+              Slugs without linked kennel (events will be blocked by guard):{" "}
+              <span className="font-mono">{slugDrift.slugsWithoutLink.join(", ")}</span>
+            </p>
+          )}
+          {slugDrift.linksWithoutSlug.length > 0 && (
+            <p className="mt-1 text-yellow-700 dark:text-yellow-300">
+              Linked kennels without slug (adapter won&apos;t fetch their events):{" "}
+              <span className="font-mono">{slugDrift.linksWithoutSlug.join(", ")}</span>
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Troubleshoot Config */}
       <TroubleshootSection

--- a/src/app/admin/sources/actions.test.ts
+++ b/src/app/admin/sources/actions.test.ts
@@ -11,7 +11,9 @@ vi.mock("@/lib/db", () => ({
     alert: { findMany: vi.fn(), update: vi.fn() },
     kennel: { findFirst: vi.fn() },
     kennelAlias: { findFirst: vi.fn() },
-    $transaction: vi.fn((arr: unknown[]) => Promise.all(arr)),
+    $transaction: vi.fn((arg: unknown) =>
+      typeof arg === "function" ? (arg as (tx: unknown) => Promise<unknown>)(prisma) : Promise.all(arg as unknown[]),
+    ),
   },
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
@@ -26,7 +28,7 @@ vi.mock("@/pipeline/scrape", () => ({
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { resolveKennelTag } from "@/pipeline/kennel-resolver";
-import { createSource, updateSource, deleteSource, linkKennelToSourceDirect } from "./actions";
+import { createSource, updateSource, deleteSource, linkKennelToSourceDirect, getHashRegoSlugDrift } from "./actions";
 
 const mockAdminAuth = vi.mocked(getAdminUser);
 const mockSourceCreate = vi.mocked(prisma.source.create);
@@ -225,5 +227,68 @@ describe("HASHREGO link-to-slug auto-sync", () => {
       (c) => (c[0] as { data: { config?: unknown } }).data.config !== undefined,
     );
     expect(configUpdateCalls).toHaveLength(0);
+  });
+});
+
+describe("getHashRegoSlugDrift", () => {
+  it("returns empty for non-HASHREGO sources", async () => {
+    const result = await getHashRegoSlugDrift({
+      type: "HTML_SCRAPER",
+      config: null,
+      kennels: [],
+    });
+    expect(result).toEqual({ slugsWithoutLink: [], linksWithoutSlug: [] });
+  });
+
+  it("detects slugs without linked kennel (using alias resolution)", async () => {
+    // "BFMH3" resolves to kennel k_bfm via alias, but k_bfm is not linked
+    mockResolveKennelTag.mockImplementation(async (tag: string) => {
+      if (tag === "BFMH3") return { kennelId: "k_bfm", matched: true };
+      return { kennelId: null, matched: false };
+    });
+
+    const result = await getHashRegoSlugDrift({
+      type: "HASHREGO",
+      config: { kennelSlugs: ["BFMH3"] },
+      kennels: [{ kennelId: "k_other", kennel: { shortName: "OTH3" } }],
+    });
+    expect(result.slugsWithoutLink).toEqual(["BFMH3"]);
+    expect(result.linksWithoutSlug).toEqual(["OTH3"]);
+  });
+
+  it("returns no drift when slugs resolve to linked kennels", async () => {
+    mockResolveKennelTag.mockImplementation(async (tag: string) => {
+      if (tag === "BFMH3") return { kennelId: "k_bfm", matched: true };
+      return { kennelId: null, matched: false };
+    });
+
+    const result = await getHashRegoSlugDrift({
+      type: "HASHREGO",
+      config: { kennelSlugs: ["BFMH3"] },
+      kennels: [{ kennelId: "k_bfm", kennel: { shortName: "BFM" } }],
+    });
+    expect(result.slugsWithoutLink).toEqual([]);
+    expect(result.linksWithoutSlug).toEqual([]);
+  });
+
+  it("detects unresolvable slugs as drift", async () => {
+    mockResolveKennelTag.mockResolvedValue({ kennelId: null, matched: false });
+
+    const result = await getHashRegoSlugDrift({
+      type: "HASHREGO",
+      config: { kennelSlugs: ["UNKNOWN"] },
+      kennels: [],
+    });
+    expect(result.slugsWithoutLink).toEqual(["UNKNOWN"]);
+  });
+
+  it("rejects malformed kennelSlugs (not an array)", async () => {
+    const result = await getHashRegoSlugDrift({
+      type: "HASHREGO",
+      config: { kennelSlugs: "not-an-array" },
+      kennels: [],
+    });
+    // isHashRegoConfig should reject this, returning empty
+    expect(result).toEqual({ slugsWithoutLink: [], linksWithoutSlug: [] });
   });
 });

--- a/src/app/admin/sources/actions.ts
+++ b/src/app/admin/sources/actions.ts
@@ -10,12 +10,21 @@ import { scrapeSource } from "@/pipeline/scrape";
 import { validateSourceConfig } from "./config-validation";
 import { buildKennelIdentifiers, createKennelRecord } from "@/lib/kennel-utils";
 
-/** Type guard: is this a HASHREGO source config with a kennelSlugs array? */
+/** Type guard: is this a HASHREGO source config with an optional kennelSlugs array?
+ *  When kennelSlugs is present, validates it is actually an array to guard against malformed JSON. */
 function isHashRegoConfig(
   config: unknown,
   type: string,
 ): config is { kennelSlugs?: string[] } {
-  return type === "HASHREGO" && !!config && typeof config === "object" && !Array.isArray(config);
+  if (type !== "HASHREGO" || !config || typeof config !== "object" || Array.isArray(config)) {
+    return false;
+  }
+  const obj = config as Record<string, unknown>;
+  // If kennelSlugs is present, it must be an array
+  if ("kennelSlugs" in obj && !Array.isArray(obj.kennelSlugs)) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -39,23 +48,47 @@ async function resolveHashRegoSlugsToKennelIds(
 }
 
 /**
+ * Combine form-selected kennel IDs with slug-resolved kennel IDs (HASHREGO auto-sync).
+ * Returns a deduplicated array of kennel IDs.
+ */
+async function getCombinedKennelIds(
+  kennelIdsStr: string,
+  config: unknown,
+  type: string,
+): Promise<string[]> {
+  const ids = kennelIdsStr
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+  const slugKennelIds = await resolveHashRegoSlugsToKennelIds(config, type);
+  const idSet = new Set(ids);
+  for (const kid of slugKennelIds) {
+    idSet.add(kid);
+  }
+  return Array.from(idSet);
+}
+
+/**
  * For a HASHREGO source, fetch its config and add `slug` to kennelSlugs if missing.
  * No-op for non-HASHREGO sources or if slug already exists.
+ * Uses a transaction to prevent TOCTOU races on the config read-modify-write.
  */
 async function syncHashRegoSlug(sourceId: string, slug: string): Promise<void> {
-  const source = await prisma.source.findUnique({
-    where: { id: sourceId },
-    select: { type: true, config: true },
-  });
-  if (!source || !isHashRegoConfig(source.config, source.type)) return;
+  await prisma.$transaction(async (tx) => {
+    const source = await tx.source.findUnique({
+      where: { id: sourceId },
+      select: { type: true, config: true },
+    });
+    if (!source || !isHashRegoConfig(source.config, source.type)) return;
 
-  const slugs = source.config.kennelSlugs ?? [];
-  const upperSlug = slug.toUpperCase();
-  if (slugs.some((s) => s.toUpperCase() === upperSlug)) return;
+    const slugs = source.config.kennelSlugs ?? [];
+    const upperSlug = slug.toUpperCase();
+    if (slugs.some((s) => s.toUpperCase() === upperSlug)) return;
 
-  await prisma.source.update({
-    where: { id: sourceId },
-    data: { config: { ...source.config, kennelSlugs: [...slugs, upperSlug] } as Prisma.InputJsonValue },
+    await tx.source.update({
+      where: { id: sourceId },
+      data: { config: { ...source.config, kennelSlugs: [...slugs, upperSlug] } as Prisma.InputJsonValue },
+    });
   });
 }
 
@@ -159,14 +192,7 @@ export async function createSource(formData: FormData) {
   });
 
   // Create SourceKennel links (auto-include slug-resolved kennels for HASHREGO)
-  const ids = kennelIds
-    .split(",")
-    .map((id) => id.trim())
-    .filter(Boolean);
-  const slugKennelIds = await resolveHashRegoSlugsToKennelIds(config, type);
-  for (const kid of slugKennelIds) {
-    if (!ids.includes(kid)) ids.push(kid);
-  }
+  const ids = await getCombinedKennelIds(kennelIds, config, type);
   for (const kennelId of ids) {
     await prisma.sourceKennel.create({
       data: { sourceId: source.id, kennelId },
@@ -196,16 +222,8 @@ export async function updateSource(sourceId: string, formData: FormData) {
     }
   }
 
-  const ids = kennelIds
-    .split(",")
-    .map((id) => id.trim())
-    .filter(Boolean);
-
   // Auto-include slug-resolved kennels for HASHREGO sources
-  const slugKennelIds = await resolveHashRegoSlugsToKennelIds(config, type);
-  for (const kid of slugKennelIds) {
-    if (!ids.includes(kid)) ids.push(kid);
-  }
+  const ids = await getCombinedKennelIds(kennelIds, config, type);
 
   await prisma.$transaction([
     prisma.sourceKennel.deleteMany({ where: { sourceId } }),
@@ -445,4 +463,47 @@ export async function createKennelForSource(
   revalidatePath("/admin/alerts");
   revalidatePath("/admin/kennels");
   return { success: true };
+}
+
+/**
+ * For HASHREGO sources, detect drift between config.kennelSlugs and SourceKennel links.
+ * Resolves each slug via the kennel resolver (handles alias resolution) rather than
+ * comparing slugs to shortNames directly (which would produce false positives).
+ */
+export async function getHashRegoSlugDrift(source: {
+  type: string;
+  config: unknown;
+  kennels: Array<{ kennelId: string; kennel: { shortName: string } }>;
+}): Promise<{ slugsWithoutLink: string[]; linksWithoutSlug: string[] }> {
+  const empty = { slugsWithoutLink: [], linksWithoutSlug: [] };
+  if (!isHashRegoConfig(source.config, source.type)) return empty;
+
+  const slugs = source.config.kennelSlugs ?? [];
+  if (slugs.length === 0 && source.kennels.length === 0) return empty;
+
+  const linkedKennelIds = new Set(source.kennels.map((sk) => sk.kennelId));
+
+  // Resolve each slug to a kennel ID (handles alias resolution, e.g. "BFMH3" → kennel "BFM")
+  clearResolverCache();
+  const slugToKennelId = new Map<string, string | null>();
+  for (const slug of slugs) {
+    const result = await resolveKennelTag(slug);
+    slugToKennelId.set(slug, result.matched ? result.kennelId : null);
+  }
+
+  // Slugs whose resolved kennel is not linked
+  const slugsWithoutLink = slugs.filter((slug) => {
+    const kennelId = slugToKennelId.get(slug);
+    return !kennelId || !linkedKennelIds.has(kennelId);
+  });
+
+  // Linked kennels whose ID doesn't appear in any slug resolution
+  const resolvedKennelIds = new Set(
+    Array.from(slugToKennelId.values()).filter((id): id is string => id != null),
+  );
+  const linksWithoutSlug = source.kennels
+    .filter((sk) => !resolvedKennelIds.has(sk.kennelId))
+    .map((sk) => sk.kennel.shortName);
+
+  return { slugsWithoutLink, linksWithoutSlug };
 }


### PR DESCRIPTION
The Hash Rego adapter requires both config.kennelSlugs (what to fetch) and
SourceKennel links (what to allow through the merge guard) to be in sync for
events to flow. These two lists could silently drift apart, causing events to
disappear when kennels were added or the source was edited.

Changes:
- updateSource/createSource: auto-resolve HASHREGO slugs to kennel IDs and
  include them in SourceKennel links so adding a slug guarantees the link
- linkKennelToSourceDirect/createKennelForSource: auto-add kennel shortName
  to HASHREGO config.kennelSlugs so linking a kennel also adds the slug
- Source detail page: show diagnostic warning when slugs and links are out
  of sync (slugs without links or links without slugs)
- Tests: 7 new test cases covering both sync directions

https://claude.ai/code/session_01SDh8PDvVBzJJicty2HXjDX