### PR TITLE
feat: add uncancel event admin action

### DIFF
--- a/src/app/admin/events/actions.ts
+++ b/src/app/admin/events/actions.ts
@@ -170,6 +170,44 @@ export async function deleteSelectedEvents(eventIds: string[]): Promise<ActionRe
 }
 
 /**
+ * Restore a cancelled event by setting status back to CONFIRMED.
+ */
+export async function uncancelEvent(eventId: string): Promise<ActionResult<{ kennelName: string; date: string }>> {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    include: { kennel: { select: { shortName: true } } },
+  });
+  if (!event) return { error: "Event not found" };
+  if (event.status !== "CANCELLED") return { error: "Event is not cancelled" };
+
+  await prisma.event.update({
+    where: { id: eventId },
+    data: { status: "CONFIRMED" },
+  });
+
+  console.log("[admin-audit] uncancelEvent", JSON.stringify({
+    adminId: admin.id,
+    action: "uncancel_event",
+    eventId,
+    kennelName: event.kennel.shortName,
+    eventDate: event.date.toISOString(),
+    timestamp: new Date().toISOString(),
+  }));
+
+  revalidatePath("/admin/events");
+  revalidatePath("/hareline");
+  revalidatePath(`/hareline/${eventId}`);
+  return {
+    success: true,
+    kennelName: event.kennel.shortName,
+    date: event.date.toISOString(),
+  };
+}
+
+/**
  * Build Prisma where clause from filters.
  * Returns null if no filters are provided (safety guard against accidental mass delete).
  */

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
   });
   return { title: `${dateStr} · ${event.kennel.shortName} · HashTracks` };
 }
-import { getOrCreateUser, getMismanUser } from "@/lib/auth";
+import { getOrCreateUser, getAdminUser, getMismanUser } from "@/lib/auth";
 import { getStravaConnection } from "@/app/strava/actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -43,6 +43,7 @@ import { SourcesDropdown } from "@/components/hareline/SourcesDropdown";
 import { getEventDayWeather } from "@/lib/weather";
 import { REGION_CENTROIDS } from "@/lib/geo";
 import { InfoPopover } from "@/components/ui/info-popover";
+import { RestoreEventButton } from "@/components/admin/RestoreEventButton";
 
 export default async function EventDetailPage({
   params,
@@ -91,15 +92,17 @@ export default async function EventDetailPage({
     }
   }
 
-  const [confirmedCount, goingCount, stravaResult, mismanUser] = await Promise.all([
+  const [confirmedCount, goingCount, stravaResult, mismanUser, adminUser] = await Promise.all([
     prisma.attendance.count({ where: { eventId, status: "CONFIRMED" } }),
     prisma.attendance.count({ where: { eventId, status: "INTENDING" } }),
     user ? getStravaConnection() : Promise.resolve(null),
     user ? getMismanUser(event.kennelId) : Promise.resolve(null),
+    event.status === "CANCELLED" ? getAdminUser() : Promise.resolve(null),
   ]);
 
   const stravaConnected = stravaResult?.success ? stravaResult.connected : false;
   const isMisman = !!mismanUser;
+  const isAdmin = !!adminUser;
 
   // Fetch weather forecast for upcoming events (0–10 days out).
   // Compare at the calendar-day level (midnight UTC) to avoid off-by-one from UTC noon storage.
@@ -334,6 +337,9 @@ export default async function EventDetailPage({
           </TooltipTrigger>
           <TooltipContent>{event.kennel.fullName}</TooltipContent>
         </Tooltip>
+        {isAdmin && event.status === "CANCELLED" && (
+          <RestoreEventButton eventId={event.id} />
+        )}
       </div>
     </div>
   );

--- a/src/components/admin/RestoreEventButton.tsx
+++ b/src/components/admin/RestoreEventButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { uncancelEvent } from "@/app/admin/events/actions";
+
+export function RestoreEventButton({ eventId }: { eventId: string }) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function handleRestore() {
+    startTransition(async () => {
+      const result = await uncancelEvent(eventId);
+      if ("error" in result) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success("Event restored");
+      router.refresh();
+    });
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleRestore}
+      disabled={isPending}
+    >
+      {isPending ? "Restoring…" : "Restore Event"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `uncancelEvent` server action to restore falsely cancelled events (sets status back to CONFIRMED with audit logging)
- Add "Restore Event" button on event detail page, visible only to admins when event is CANCELLED
- Conditionally call `getAdminUser()` only for cancelled events to avoid unnecessary Clerk API calls on every page load

## Context
Event `cmmgrfgwq000404jsrctbjbl8` (UH3) was falsely cancelled by the reconcile pipeline due to `startTime` inclusion in reconcile keys (fixed in `3ebacae`). There was no way to restore it — this PR adds that capability.

## Test plan
- [ ] Visit `/hareline/cmmgrfgwq000404jsrctbjbl8` as admin → see Cancelled badge + Restore Event button
- [ ] Click Restore → event status changes to CONFIRMED, button disappears
- [ ] Event reappears on kennel page and hareline
- [ ] Visit any non-cancelled event → no Restore button, no extra Clerk API call
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (106 files, 2265 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)