### PR TITLE
fix: preserve line breaks from block-level HTML tags

### DIFF
--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -190,7 +190,7 @@ describe("stripHtmlTags", () => {
     expect(stripHtmlTags("  <p>hello</p>  ")).toBe("hello");
   });
 
-  it("preserves block-level boundaries as newlines when brReplacement is \\n", () => {
+  it("preserves block-level boundaries as newlines when separator is \\n", () => {
     expect(stripHtmlTags("<p>line1</p><p>line2</p>", "\n")).toBe("line1\nline2");
     expect(stripHtmlTags("<div>a</div><div>b</div>", "\n")).toBe("a\nb");
     expect(stripHtmlTags("<ul><li>a</li><li>b</li></ul>", "\n")).toBe("a\nb");

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -30,7 +30,7 @@ export function stripHtmlTags(
 ): string {
   const withBr = text.replace(/<br\s*\/?>/gi, separator);
   // Insert replacement before closing block-level tags so paragraph boundaries survive .text()
-  const withBlocks = withBr.replace(/<\/(?:p|div|li|tr|blockquote|h[1-6])>/gi, separator);
+  const withBlocks = withBr.replace(/<\/(?:p|div|li|tr|blockquote|h[1-6])\s*>/gi, separator);
   const $ = cheerio.load(withBlocks);
   $("script, style").remove();
   return $.text()


### PR DESCRIPTION
## Summary
- `stripHtmlTags()` now converts closing block-level tags (`</div>`, `</p>`, `</li>`, `</tr>`, `</blockquote>`, `</h1>`–`</h6>`) to the separator character, just like `<br>` tags
- Fixes SHITH3 (and other sources) losing paragraph breaks when descriptions use `</div>` as separators
- Renamed parameter `brReplacement` → `separator` since it now controls both `<br>` and block-level tags
- Callers using default `" "` separator (hashnyc, Meetup, RSS) get spaces instead of silent removal — no regression

## Test plan
- [x] New tests for block-level tag preservation with `"\n"` separator (`<p>`, `<div>`, `<li>`, `<h1>`, `<blockquote>`)
- [x] New test for mixed `<br>` + block tags
- [x] New test with real SHITH3 `</div>`-separated content (exact string assertion)
- [x] Existing tests pass — default `" "` separator behavior unchanged
- [x] All 109 utils tests pass
- [ ] Manual: re-scrape SHITH3 source, verify event descriptions have line breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)