### PR TITLE
feat: misman landing page, about page, and route restructure

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { FadeInSection } from "@/components/home/HeroAnimations";
+
+export const metadata: Metadata = {
+  title: "About · HashTracks",
+  description:
+    "HashTracks is the Strava of hashing — aggregated harelines, personal logbooks, and kennel directories for the global hashing community.",
+};
+
+export default function AboutPage() {
+  return (
+    <div className="-mx-4 -mt-8">
+      <section className="px-4 py-16 sm:py-24">
+        <div className="mx-auto max-w-2xl">
+          <FadeInSection>
+            <h1 className="text-4xl font-extrabold tracking-tight sm:text-5xl">
+              About HashTracks
+            </h1>
+          </FadeInSection>
+
+          <FadeInSection delay={100}>
+            <div className="mt-8 space-y-6 text-base leading-relaxed text-muted-foreground">
+              <p>
+                HashTracks aggregates harelines from kennel websites, Google
+                Calendars, spreadsheets, and more into one searchable calendar.
+                No more checking five different sites to find your next run.
+              </p>
+              <p>
+                Beyond discovery, HashTracks gives every hasher a personal{" "}
+                <span className="font-medium text-foreground">logbook</span> to
+                track attendance, milestones, and streaks — and optionally link
+                Strava activities to each run.
+              </p>
+              <p>
+                For kennel organizers, our{" "}
+                <span className="font-medium text-foreground">
+                  Misman tools
+                </span>{" "}
+                replace the spreadsheet with a mobile-first attendance form,
+                smart suggestions, shared rosters, and full audit trails.
+              </p>
+              <p>
+                HashTracks is built by hashers, for hashers. We&apos;re a small
+                team and we&apos;re actively developing new features based on
+                community feedback.
+              </p>
+            </div>
+          </FadeInSection>
+
+          <FadeInSection delay={200}>
+            <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:gap-4">
+              <Link
+                href="/hareline"
+                className="group inline-flex h-11 items-center gap-2 rounded-full bg-foreground px-6 text-sm font-semibold text-background transition-all hover:gap-3 hover:bg-foreground/90"
+              >
+                Browse the Hareline
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+              </Link>
+              <Link
+                href="/for-misman"
+                className="inline-flex h-11 items-center gap-2 rounded-full border border-foreground/20 px-6 text-sm font-semibold transition-colors hover:border-foreground/40 hover:bg-foreground/[0.03]"
+              >
+                For Kennel Organizers
+              </Link>
+            </div>
+          </FadeInSection>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/for-misman/page.tsx
+++ b/src/app/for-misman/page.tsx
@@ -1,0 +1,157 @@
+import type { Metadata } from "next";
+import { currentUser } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/db";
+import {
+  AnimatedCounter,
+  FadeInSection,
+} from "@/components/home/HeroAnimations";
+import { MismanHero } from "@/components/misman/landing/MismanHero";
+import { FeatureShowcase } from "@/components/misman/landing/FeatureShowcase";
+import { HowItWorks } from "@/components/misman/landing/HowItWorks";
+import { MismanCTA, type CTAState } from "@/components/misman/landing/MismanCTA";
+import { ArrowRight, Lightbulb } from "lucide-react";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Misman — Attendance Tools for Kennel Organizers · HashTracks",
+  description:
+    "Mobile-first attendance recording, smart suggestions, roster management, and audit trails for hash kennel mismanagement.",
+};
+
+export default async function MismanAboutPage() {
+  // Run auth + stats in parallel (stats don't depend on auth)
+  const [clerkUser, [attendanceCount, mismanKennelCount, rosterCount]] =
+    await Promise.all([
+      currentUser(),
+      Promise.all([
+        prisma.kennelAttendance.count(),
+        prisma.userKennel
+          .groupBy({
+            by: ["kennelId"],
+            where: { role: { in: ["MISMAN", "ADMIN"] } },
+          })
+          .then((groups) => groups.length),
+        prisma.kennelHasher.count(),
+      ]),
+    ]);
+
+  // Determine CTA state (site admins get automatic misman access)
+  let ctaState: CTAState = "unauthenticated";
+  if (clerkUser) {
+    const metadata = clerkUser.publicMetadata as { role?: string } | null;
+    if (metadata?.role === "admin") {
+      ctaState = "misman";
+    } else {
+      const mismanRole = await prisma.userKennel.findFirst({
+        where: {
+          user: { clerkId: clerkUser.id },
+          role: { in: ["MISMAN", "ADMIN"] },
+        },
+      });
+      ctaState = mismanRole ? "misman" : "authenticated";
+    }
+  }
+
+  return (
+    <div className="-mx-4 -mt-8">
+      {/* ═══ HERO ═══ */}
+      <MismanHero ctaState={ctaState} />
+
+      {/* ═══ STATS BAR ═══ */}
+      <div className="border-y border-foreground/5 bg-foreground/[0.015]">
+        <div className="mx-auto flex max-w-lg flex-wrap items-center justify-center gap-8 py-8 sm:gap-12">
+          <FadeInSection>
+            <div className="text-center">
+              <div className="text-3xl font-bold tracking-tight sm:text-4xl">
+                <AnimatedCounter target={attendanceCount} />
+              </div>
+              <div className="mt-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Attendance Records
+              </div>
+            </div>
+          </FadeInSection>
+
+          <div className="h-8 w-px bg-foreground/10" aria-hidden="true" />
+
+          <FadeInSection delay={100}>
+            <div className="text-center">
+              <div className="text-3xl font-bold tracking-tight sm:text-4xl">
+                <AnimatedCounter target={mismanKennelCount} />
+              </div>
+              <div className="mt-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Active Kennels
+              </div>
+            </div>
+          </FadeInSection>
+
+          <div className="h-8 w-px bg-foreground/10" aria-hidden="true" />
+
+          <FadeInSection delay={200}>
+            <div className="text-center">
+              <div className="text-3xl font-bold tracking-tight sm:text-4xl">
+                <AnimatedCounter target={rosterCount} />
+              </div>
+              <div className="mt-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Hashers on Rosters
+              </div>
+            </div>
+          </FadeInSection>
+        </div>
+      </div>
+
+      {/* ═══ FEATURES ═══ */}
+      <FeatureShowcase />
+
+      {/* ═══ HOW IT WORKS ═══ */}
+      <HowItWorks />
+
+      {/* ═══ FEEDBACK CALLOUT ═══ */}
+      <section className="px-4 py-16 sm:py-20">
+        <div className="mx-auto max-w-2xl text-center">
+          <FadeInSection>
+            <div className="mb-5 inline-flex h-11 w-11 items-center justify-center rounded-xl bg-foreground/[0.05]">
+              <Lightbulb className="h-5 w-5 text-amber-400" />
+            </div>
+            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              Help us build this for you
+            </h2>
+            <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+              Misman is actively evolving. We&apos;re building this alongside
+              the kennel organizers who use it — your feedback shapes what comes
+              next. Tell us what&apos;s working, what&apos;s missing, and what
+              would make your life easier.
+            </p>
+            <Link
+              href={clerkUser ? "/misman" : "/sign-up"}
+              className="group mt-6 inline-flex items-center gap-1.5 text-sm font-semibold text-orange-500 transition-colors hover:text-orange-400"
+            >
+              Share your feedback
+              <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+            </Link>
+          </FadeInSection>
+        </div>
+      </section>
+
+      {/* ═══ FINAL CTA ═══ */}
+      <section className="border-t border-foreground/5 bg-foreground/[0.015] px-4 py-16 sm:py-20">
+        <div className="mx-auto max-w-2xl text-center">
+          <FadeInSection>
+            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              Ready to ditch the spreadsheet?
+            </h2>
+            <p className="mt-3 text-muted-foreground">
+              {ctaState === "misman"
+                ? "Your dashboard is waiting. Go manage your kennels."
+                : ctaState === "authenticated"
+                  ? "Request misman access for your kennel and start recording attendance today."
+                  : "Join HashTracks and start managing your kennel's attendance the easy way."}
+            </p>
+            <div className="mt-8">
+              <MismanCTA state={ctaState} variant="footer" />
+            </div>
+          </FadeInSection>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import {
   PulseDot,
   RegionTicker,
 } from "@/components/home/HeroAnimations";
-import { Calendar, BookOpen, Users, MapPin, ArrowRight, Beer, Zap, Globe } from "lucide-react";
+import { Calendar, BookOpen, Users, MapPin, ArrowRight, Beer, Zap, Globe, ClipboardList } from "lucide-react";
 
 export default async function HomePage() {
   const clerkUser = await currentUser();
@@ -421,6 +421,36 @@ export default async function HomePage() {
               </div>
             </FadeInSection>
           </div>
+        </div>
+      </section>
+
+      {/* ═══════════════════════════════════════════════
+          MISMAN TEASER
+       ═══════════════════════════════════════════════ */}
+      <section className="border-t border-foreground/5 bg-foreground/[0.015] px-4 py-16 sm:py-20">
+        <div className="mx-auto max-w-5xl">
+          <FadeInSection>
+            <div className="mx-auto max-w-2xl text-center">
+              <div className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-xl bg-orange-100 text-orange-700">
+                <ClipboardList className="h-5 w-5" />
+              </div>
+              <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
+                Run a kennel?
+              </h2>
+              <p className="mt-3 text-muted-foreground">
+                HashTracks Misman is a mobile-first attendance tool for kennel
+                organizers. Tap-to-add hashers, smart suggestions, shared rosters,
+                and full audit trails.
+              </p>
+              <Link
+                href="/for-misman"
+                className="group mt-5 inline-flex items-center gap-1.5 text-sm font-semibold text-orange-700 transition-colors hover:text-orange-800"
+              >
+                Learn more about extra features for Misman
+                <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+              </Link>
+            </div>
+          </FadeInSection>
         </div>
       </section>
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -34,6 +34,9 @@ export function Header() {
 
   const isActive = (href: string) => pathname === href || pathname.startsWith(`${href}/`);
 
+  const mismanHref = user ? "/misman" : "/for-misman";
+  const mismanActive = isActive("/misman") || isActive("/for-misman");
+
   return (
     <header className="sticky top-0 z-20 border-b bg-background/95 backdrop-blur-sm">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4">
@@ -52,14 +55,14 @@ export function Header() {
               {link.label}
             </Link>
           ))}
-          {user && (
-            <Link
-              href="/misman"
-              className={`text-sm font-medium transition-colors hover:text-foreground ${isActive("/misman") ? "text-foreground" : "text-muted-foreground"}`}
-            >
-              Misman
-            </Link>
-          )}
+          <Link
+            href={mismanHref}
+            className={`text-sm font-medium transition-colors hover:text-foreground ${
+              mismanActive ? "text-foreground" : "text-muted-foreground"
+            }`}
+          >
+            Misman
+          </Link>
           {isAdmin && (
             <Link
               href="/admin"
@@ -176,15 +179,15 @@ export function Header() {
               {link.label}
             </Link>
           ))}
-          {user && (
-            <Link
-              href="/misman"
-              className={`block py-2 text-sm font-medium ${isActive("/misman") ? "text-foreground" : "text-muted-foreground"}`}
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              Misman
-            </Link>
-          )}
+          <Link
+            href={mismanHref}
+            className={`block py-2 text-sm font-medium ${
+              mismanActive ? "text-foreground" : "text-muted-foreground"
+            }`}
+            onClick={() => setMobileMenuOpen(false)}
+          >
+            Misman
+          </Link>
           {isAdmin && (
             <Link
               href="/admin"

--- a/src/components/misman/landing/FeatureShowcase.tsx
+++ b/src/components/misman/landing/FeatureShowcase.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import {
+  UserPlus,
+  Sparkles,
+  Users,
+  Shield,
+  FileSpreadsheet,
+  Link2,
+  Check,
+  type LucideIcon,
+} from "lucide-react";
+import { FadeInSection } from "@/components/home/HeroAnimations";
+
+/* ── Feature visual illustrations (pure Tailwind, no images) ── */
+
+function ChipVisual() {
+  const names = [
+    { name: "Dances w/ Beer", checked: true },
+    { name: "Trail Blazer", checked: true },
+    { name: "Just John", checked: false },
+    { name: "Half Mind", checked: true },
+    { name: "Salty Dog", checked: false },
+  ];
+  return (
+    <div className="flex flex-wrap gap-2">
+      {names.map((n) => (
+        <span
+          key={n.name}
+          className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-all ${
+            n.checked
+              ? "border-orange-500/30 bg-orange-500/10 text-orange-300"
+              : "border-foreground/10 bg-foreground/[0.03] text-muted-foreground"
+          }`}
+        >
+          {n.checked && <Check className="h-3 w-3" />}
+          {n.name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ScoringVisual() {
+  const bars = [
+    { label: "Frequency", value: 85, color: "bg-emerald-500" },
+    { label: "Recency", value: 65, color: "bg-emerald-400" },
+    { label: "Streak", value: 100, color: "bg-emerald-300" },
+  ];
+  return (
+    <div className="space-y-3">
+      {bars.map((bar) => (
+        <div key={bar.label}>
+          <div className="mb-1 flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">{bar.label}</span>
+            <span className="font-mono text-foreground/60">{bar.value}%</span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-foreground/[0.06]">
+            <div
+              className={`h-full rounded-full ${bar.color}`}
+              style={{ width: `${bar.value}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RosterVisual() {
+  return (
+    <div className="flex items-center justify-center gap-4">
+      <div className="rounded-lg border border-blue-500/20 bg-blue-500/[0.06] px-3 py-2 text-xs font-semibold text-blue-300">
+        Brooklyn H3
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <div className="h-px w-8 border-t border-dashed border-foreground/20" />
+        <div className="rounded-md border border-foreground/10 bg-foreground/[0.04] px-2 py-1 text-[10px] text-muted-foreground">
+          Shared Roster
+        </div>
+        <div className="h-px w-8 border-t border-dashed border-foreground/20" />
+      </div>
+      <div className="rounded-lg border border-blue-500/20 bg-blue-500/[0.06] px-3 py-2 text-xs font-semibold text-blue-300">
+        NYC H3
+      </div>
+    </div>
+  );
+}
+
+function AuditVisual() {
+  const entries = [
+    { time: "2:41 PM", action: "Marked present", who: "Trail Blazer" },
+    { time: "2:38 PM", action: "Added to roster", who: "New Boot" },
+    { time: "2:35 PM", action: "Paid hash cash", who: "Half Mind" },
+  ];
+  return (
+    <div className="space-y-2">
+      {entries.map((e, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 rounded-lg border border-foreground/[0.06] bg-foreground/[0.02] px-3 py-2 text-xs"
+        >
+          <span className="shrink-0 font-mono text-muted-foreground/60">
+            {e.time}
+          </span>
+          <span className="text-muted-foreground">
+            {e.action}:{" "}
+            <span className="font-medium text-foreground/80">{e.who}</span>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ImportVisual() {
+  return (
+    <div className="flex items-center justify-center gap-3">
+      <div className="flex flex-col items-center gap-1">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-amber-500/20 bg-amber-500/[0.06]">
+          <FileSpreadsheet className="h-5 w-5 text-amber-400" />
+        </div>
+        <span className="text-[10px] text-muted-foreground">.csv</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <div className="h-px w-4 bg-foreground/20" />
+        <div className="h-0 w-0 border-y-[4px] border-l-[6px] border-y-transparent border-l-foreground/20" />
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-orange-500/20 bg-orange-500/[0.06] text-xs font-bold text-orange-400">
+          HT
+        </div>
+        <span className="text-[10px] text-muted-foreground">Roster</span>
+      </div>
+    </div>
+  );
+}
+
+function InviteVisual() {
+  const avatars = [
+    { cls: "bg-rose-500/20 text-rose-300", label: "GM" },
+    { cls: "bg-rose-400/20 text-rose-200", label: "RA" },
+    { cls: "bg-rose-300/20 text-rose-100", label: "HM" },
+  ];
+  return (
+    <div className="flex items-center justify-center -space-x-2">
+      {avatars.map((avatar) => (
+        <div
+          key={avatar.label}
+          className={`flex h-9 w-9 items-center justify-center rounded-full border-2 border-background text-xs font-bold ${avatar.cls}`}
+        >
+          {avatar.label}
+        </div>
+      ))}
+      <div className="flex h-9 w-9 items-center justify-center rounded-full border-2 border-dashed border-foreground/20 bg-foreground/[0.03] text-xs text-muted-foreground">
+        +
+      </div>
+    </div>
+  );
+}
+
+/* ── Feature data ── */
+
+interface Feature {
+  icon: LucideIcon;
+  accent: string;
+  iconBg: string;
+  heading: string;
+  description: string;
+  visual: React.ReactNode;
+}
+
+const features: Feature[] = [
+  {
+    icon: UserPlus,
+    accent: "text-orange-400",
+    iconBg: "bg-orange-500/10 border-orange-500/20",
+    heading: "One tap, one hasher",
+    description:
+      "No more typing hash names into a spreadsheet column. Tap a name chip to mark them attended — or search and add anyone from your roster instantly.",
+    visual: <ChipVisual />,
+  },
+  {
+    icon: Sparkles,
+    accent: "text-emerald-400",
+    iconBg: "bg-emerald-500/10 border-emerald-500/20",
+    heading: "It learns who shows up",
+    description:
+      "Frequency, recency, and streak scoring surfaces the hashers most likely to be at today's run. The more you use it, the smarter the suggestions get.",
+    visual: <ScoringVisual />,
+  },
+  {
+    icon: Users,
+    accent: "text-blue-400",
+    iconBg: "bg-blue-500/10 border-blue-500/20",
+    heading: "One roster, shared across your pack",
+    description:
+      "Manage hash names and nerd names in one place. Share a roster across related kennels so you never add the same person twice.",
+    visual: <RosterVisual />,
+  },
+  {
+    icon: Shield,
+    accent: "text-purple-400",
+    iconBg: "bg-purple-500/10 border-purple-500/20",
+    heading: "Every edit is tracked",
+    description:
+      "Full audit log for attendance changes. Know who recorded what, when. No more \"who deleted that row?\" mysteries.",
+    visual: <AuditVisual />,
+  },
+  {
+    icon: FileSpreadsheet,
+    accent: "text-amber-400",
+    iconBg: "bg-amber-500/10 border-amber-500/20",
+    heading: "Bring your history forward",
+    description:
+      "Import years of attendance data from your existing spreadsheets. Smart matching connects imported names to your roster automatically.",
+    visual: <ImportVisual />,
+  },
+  {
+    icon: Link2,
+    accent: "text-rose-400",
+    iconBg: "bg-rose-500/10 border-rose-500/20",
+    heading: "Invite your whole mismanagement",
+    description:
+      "Generate invite links to onboard your co-mismans. Everyone sees the same roster and attendance data.",
+    visual: <InviteVisual />,
+  },
+];
+
+/* ── Main component ── */
+
+export function FeatureShowcase() {
+  return (
+    <section id="features" className="px-4 py-16 sm:py-24">
+      <div className="mx-auto max-w-5xl">
+        <FadeInSection>
+          <h2 className="text-center text-2xl font-bold tracking-tight sm:text-3xl">
+            Everything you need at the hash
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-center text-muted-foreground">
+            Built for the circle, not the office. Pull it up on your phone and
+            you&apos;re good to go.
+          </p>
+        </FadeInSection>
+
+        <div className="mt-16 space-y-12 lg:space-y-20">
+          {features.map((feature, i) => {
+            const Icon = feature.icon;
+            const isReversed = i % 2 === 1;
+
+            return (
+              <FadeInSection key={feature.heading} delay={i * 60}>
+                <div
+                  className={`flex flex-col items-center gap-8 lg:flex-row lg:gap-16 ${
+                    isReversed ? "lg:flex-row-reverse" : ""
+                  }`}
+                >
+                  {/* Content side */}
+                  <div className="flex-1 text-center lg:text-left">
+                    <div className="relative inline-block">
+                      {/* Watermark number */}
+                      <span className="absolute -left-4 -top-6 select-none font-mono text-6xl font-bold text-foreground/[0.04] lg:-left-8 lg:-top-8 lg:text-8xl">
+                        {String(i + 1).padStart(2, "0")}
+                      </span>
+                      <div
+                        className={`relative inline-flex h-12 w-12 items-center justify-center rounded-xl border ${feature.iconBg}`}
+                      >
+                        <Icon className={`h-5 w-5 ${feature.accent}`} />
+                      </div>
+                    </div>
+                    <h3 className="mt-4 text-xl font-bold sm:text-2xl">
+                      {feature.heading}
+                    </h3>
+                    <p className="mt-3 max-w-md text-base leading-relaxed text-muted-foreground lg:max-w-none">
+                      {feature.description}
+                    </p>
+                  </div>
+
+                  {/* Visual side */}
+                  <div className="w-full max-w-sm flex-shrink-0 lg:w-[340px]">
+                    <div className="rounded-2xl border border-foreground/[0.07] bg-foreground/[0.02] p-6 shadow-sm">
+                      {feature.visual}
+                    </div>
+                  </div>
+                </div>
+              </FadeInSection>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/misman/landing/HowItWorks.tsx
+++ b/src/components/misman/landing/HowItWorks.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { FadeInSection } from "@/components/home/HeroAnimations";
+
+const steps = [
+  {
+    number: "1",
+    heading: "Request Access",
+    description:
+      "Tell us which kennel you manage. We'll verify and grant you misman access within a day.",
+  },
+  {
+    number: "2",
+    heading: "Set Up Your Roster",
+    description:
+      "Your roster builds organically as you take attendance, import from a spreadsheet, or seed from recent hares. Record hash names, nerd names, and internal notes.",
+  },
+  {
+    number: "3",
+    heading: "Record Attendance",
+    description:
+      "At the hash, pull up the form on your phone. Tap names, mark hash cash, done. Your regulars are suggested first.",
+  },
+];
+
+export function HowItWorks() {
+  return (
+    <section className="border-t border-foreground/5 bg-foreground/[0.015] px-4 py-16 sm:py-24">
+      <div className="mx-auto max-w-4xl">
+        <FadeInSection>
+          <h2 className="text-center text-2xl font-bold tracking-tight sm:text-3xl">
+            Up and running in minutes
+          </h2>
+          <p className="mx-auto mt-3 max-w-lg text-center text-muted-foreground">
+            No setup wizards, no training. If you can take attendance in a
+            spreadsheet, you can do it faster here.
+          </p>
+        </FadeInSection>
+
+        <div className="mt-14">
+          {/* Desktop: horizontal */}
+          <div className="hidden sm:flex sm:items-start sm:gap-4">
+            {steps.map((step, i) => (
+              <FadeInSection
+                key={step.number}
+                delay={i * 150}
+                className="flex flex-1 flex-col items-center text-center"
+              >
+                {/* Number + connector row */}
+                <div className="flex w-full items-center">
+                  {/* Left connector */}
+                  {i > 0 ? (
+                    <div className="h-px flex-1 border-t-2 border-dashed border-foreground/10" />
+                  ) : (
+                    <div className="flex-1" />
+                  )}
+
+                  {/* Circle */}
+                  <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border-2 border-orange-500/30 bg-orange-500/10">
+                    <span className="font-mono text-xl font-bold text-orange-500">
+                      {step.number}
+                    </span>
+                  </div>
+
+                  {/* Right connector */}
+                  {i < steps.length - 1 ? (
+                    <div className="h-px flex-1 border-t-2 border-dashed border-foreground/10" />
+                  ) : (
+                    <div className="flex-1" />
+                  )}
+                </div>
+
+                <h3 className="mt-5 text-lg font-bold">{step.heading}</h3>
+                <p className="mt-2 max-w-xs text-sm leading-relaxed text-muted-foreground">
+                  {step.description}
+                </p>
+              </FadeInSection>
+            ))}
+          </div>
+
+          {/* Mobile: vertical */}
+          <div className="flex flex-col gap-8 sm:hidden">
+            {steps.map((step, i) => (
+              <FadeInSection key={step.number} delay={i * 150}>
+                <div className="flex gap-4">
+                  {/* Number + vertical line */}
+                  <div className="flex flex-col items-center">
+                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border-2 border-orange-500/30 bg-orange-500/10">
+                      <span className="font-mono text-lg font-bold text-orange-500">
+                        {step.number}
+                      </span>
+                    </div>
+                    {i < steps.length - 1 && (
+                      <div className="mt-2 w-px flex-1 border-l-2 border-dashed border-foreground/10" />
+                    )}
+                  </div>
+
+                  {/* Content */}
+                  <div className="pb-2 pt-1">
+                    <h3 className="text-lg font-bold">{step.heading}</h3>
+                    <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                      {step.description}
+                    </p>
+                  </div>
+                </div>
+              </FadeInSection>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/misman/landing/MismanCTA.tsx
+++ b/src/components/misman/landing/MismanCTA.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+export type CTAState = "unauthenticated" | "authenticated" | "misman";
+
+interface MismanCTAProps {
+  state: CTAState;
+  variant?: "hero" | "footer";
+}
+
+const ctaConfig: Record<
+  CTAState,
+  {
+    href: string;
+    label: string;
+    secondary: { href: string; label: string } | null;
+  }
+> = {
+  misman: {
+    href: "/misman",
+    label: "Go to Dashboard",
+    secondary: null,
+  },
+  authenticated: {
+    href: "/misman",
+    label: "Request Access for Your Kennel",
+    secondary: { href: "/hareline", label: "Browse Events" },
+  },
+  unauthenticated: {
+    href: "/sign-up",
+    label: "Get Started \u2014 It\u2019s Free",
+    secondary: { href: "#features", label: "See What It Does" },
+  },
+};
+
+export function MismanCTA({ state, variant = "hero" }: MismanCTAProps) {
+  const isHero = variant === "hero";
+  const btnHeight = isHero ? "h-12 sm:h-14" : "h-12";
+  const btnPadding = isHero ? "px-8 sm:px-10" : "px-8";
+  const textSize = isHero ? "text-sm sm:text-base" : "text-sm";
+
+  const { href, label, secondary } = ctaConfig[state];
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+      <Link
+        href={href}
+        className={`group inline-flex ${btnHeight} items-center gap-2 rounded-full bg-orange-600 ${btnPadding} ${textSize} font-semibold text-white transition-all hover:gap-3 hover:bg-orange-700`}
+      >
+        {label}
+        <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+      </Link>
+      {secondary && (
+        <Link
+          href={secondary.href}
+          className={`inline-flex ${btnHeight} items-center gap-2 rounded-full border border-foreground/20 ${btnPadding} ${textSize} font-semibold transition-colors hover:border-foreground/40 hover:bg-foreground/[0.03]`}
+        >
+          {secondary.label}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/misman/landing/MismanHero.tsx
+++ b/src/components/misman/landing/MismanHero.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { ClipboardList } from "lucide-react";
+import { FadeInSection } from "@/components/home/HeroAnimations";
+import { MismanCTA, type CTAState } from "./MismanCTA";
+
+interface MismanHeroProps {
+  ctaState: CTAState;
+}
+
+export function MismanHero({ ctaState }: MismanHeroProps) {
+  return (
+    <section className="relative overflow-hidden px-4 pb-24 pt-12 sm:pb-32 sm:pt-20 lg:pb-36">
+      {/* Background texture — diagonal lines */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.03]"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' stroke='%23ffffff' stroke-width='1'%3E%3Cpath d='M0 40L40 0'/%3E%3C/g%3E%3C/svg%3E")`,
+        }}
+      />
+
+      {/* Gradient orbs */}
+      <div className="pointer-events-none absolute -top-40 right-1/4 h-96 w-96 rounded-full bg-orange-500/15 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-20 left-1/4 h-72 w-72 rounded-full bg-emerald-500/10 blur-3xl" />
+
+      {/* Diagonal bottom clip */}
+      <div
+        className="pointer-events-none absolute inset-0 hidden lg:block"
+        style={{
+          clipPath: "polygon(0 0, 100% 0, 100% 85%, 0 100%)",
+          background:
+            "linear-gradient(135deg, oklch(0.145 0.02 260 / 0.3), oklch(0.12 0.015 260 / 0.1))",
+        }}
+      />
+
+      <div className="relative mx-auto max-w-5xl text-center">
+        {/* Eyebrow */}
+        <FadeInSection>
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/[0.06] px-4 py-1.5">
+            <ClipboardList className="h-3.5 w-3.5 text-orange-400" />
+            <span className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-400/90">
+              For Kennel Mismanagement
+            </span>
+          </div>
+        </FadeInSection>
+
+        {/* Headline */}
+        <FadeInSection delay={100}>
+          <h1 className="mx-auto max-w-4xl text-4xl font-extrabold tracking-tight sm:text-6xl lg:text-7xl">
+            Stop counting heads
+            <br className="hidden sm:block" />{" "}
+            in a{" "}
+            <span className="text-foreground/40 line-through decoration-orange-500/60 decoration-4">
+              spreadsheet
+            </span>
+          </h1>
+        </FadeInSection>
+
+        {/* Replacement text with highlight */}
+        <FadeInSection delay={200}>
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-muted-foreground sm:text-xl">
+            HashTracks{" "}
+            <span className="relative inline-block">
+              <span className="relative z-10 font-semibold text-foreground">
+                Misman
+              </span>
+              <span
+                className="absolute -bottom-0.5 left-0 right-0 z-0 h-2.5 rounded-sm bg-orange-300/40 sm:h-3"
+                aria-hidden="true"
+              />
+            </span>{" "}
+            is a mobile-first attendance tool built for hash kennel organizers.
+            Tap names, track who&apos;s paid hash cash, manage your roster — all in one
+            place.
+          </p>
+        </FadeInSection>
+
+        {/* CTA */}
+        <FadeInSection delay={300}>
+          <div className="mt-10">
+            <MismanCTA state={ctaState} variant="hero" />
+          </div>
+        </FadeInSection>
+      </div>
+    </section>
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,8 @@ const isPublicRoute = createRouteMatcher([
   "/kennels(.*)",
   "/hareline(.*)",
   "/invite(.*)",
+  "/for-misman",
+  "/about",
 ]);
 
 export const proxy = clerkMiddleware(async (auth, request) => {


### PR DESCRIPTION
## Summary
- **Misman landing page** (`/for-misman`) — public product page for kennel organizers with hero, feature showcase (6 features with illustrative visuals), stats bar, how-it-works steps, feedback callout, and auth-aware CTAs
- **About page** (`/about`) — simple public About HashTracks page
- **Homepage misman teaser** — "Run a kennel?" section on `/` linking to the landing page
- **Header nav** — Misman link now visible to all users: signed-in → `/misman` dashboard, signed-out → `/for-misman` info page
- **Route restructure** — info pages at top-level (`/for-misman`, `/about`), dashboard stays at `/misman`

## Code quality (from /simplify review)
- Parallelized auth + stats queries in `/for-misman` page (~50-200ms faster)
- Fixed missing site-admin bypass in misman role check
- Collapsed 3 duplicate CTA return blocks into config-driven single render
- Replaced `findMany` + `.length` with `groupBy` for distinct kennel count
- Extracted Header misman link values to avoid duplication

## Test plan
- [ ] Visit `/for-misman` signed out — full page loads, "Get Started" CTA
- [ ] Visit `/for-misman` signed in (non-misman) — "Request Access" CTA
- [ ] Visit `/for-misman` signed in (misman/admin) — "Go to Dashboard" CTA
- [ ] Visit `/about` — about page loads
- [ ] Homepage — "Run a kennel?" section visible with link to `/for-misman`
- [ ] Header — Misman link visible for all users, correct destination per auth state
- [ ] Mobile responsive — all sections stack properly
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)