### PR TITLE
fix: prevent triage workflow race condition on auto-filed issues

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -7,7 +7,7 @@ on:
 # Prevent multiple triage runs for the same issue
 concurrency:
   group: triage-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   triage:

--- a/src/pipeline/auto-issue.test.ts
+++ b/src/pipeline/auto-issue.test.ts
@@ -37,7 +37,7 @@ function setupPassingGuards() {
   mockAlertFindMany.mockResolvedValueOnce([] as never); // isOnCooldown → pass
 }
 
-/** Mock fetch: no duplicate issues found, then successful issue creation. */
+/** Mock fetch: no duplicate issues found, then successful issue creation, then label addition. */
 function mockFetchForIssueCreation(opts?: { issueUrl?: string; issueNumber?: number }) {
   const fetchSpy = vi.spyOn(globalThis, "fetch");
   fetchSpy
@@ -51,6 +51,10 @@ function mockFetchForIssueCreation(opts?: { issueUrl?: string; issueNumber?: num
         html_url: opts?.issueUrl ?? "https://github.com/test/1",
         number: opts?.issueNumber ?? 1,
       }),
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
     } as Response);
   return fetchSpy;
 }
@@ -175,9 +179,9 @@ describe("buildIssueBody", () => {
     expect(title).toBe("[Alert] HTML structure changed — hashnyc.com");
   });
 
-  it("includes claude-fix label", () => {
+  it("includes base labels but not claude-fix (added separately)", () => {
     const { labels } = buildIssueBody(buildAlert());
-    expect(labels).toContain("claude-fix");
+    expect(labels).not.toContain("claude-fix");
     expect(labels).toContain("alert");
     expect(labels).toContain("alert:structure-change");
     expect(labels).toContain("severity:critical");
@@ -314,8 +318,8 @@ describe("autoFileIssuesForAlerts", () => {
     expect(result.filed).toBe(1);
     expect(result.skipped).toBe(0);
 
-    // Verify the issue creation fetch call
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // Verify fetch calls: dedup check, issue creation, claude-fix label
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
     const createCall = fetchSpy.mock.calls[1];
     expect(createCall[0]).toContain("/issues");
     expect((createCall[1] as RequestInit).method).toBe("POST");
@@ -456,9 +460,10 @@ describe("autoFileIssuesForAlerts", () => {
 
     await autoFileIssuesForAlerts("src_1", ["alert_1"]);
 
-    // Verify both API calls used the custom repo
+    // Verify all API calls used the custom repo
     expect((fetchSpy.mock.calls[0][0] as string)).toContain("other-org/other-repo");
     expect((fetchSpy.mock.calls[1][0] as string)).toContain("other-org/other-repo");
+    expect((fetchSpy.mock.calls[2][0] as string)).toContain("other-org/other-repo");
   });
 
   it("files issues for UNMATCHED_TAGS alerts (eligible type)", async () => {
@@ -475,7 +480,7 @@ describe("autoFileIssuesForAlerts", () => {
     const result = await autoFileIssuesForAlerts("src_1", ["alert_1"]);
     expect(result.filed).toBe(1);
     expect(result.skipped).toBe(0);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
   it("ignores cooldown entries older than the 48h window", async () => {
@@ -498,7 +503,92 @@ describe("autoFileIssuesForAlerts", () => {
     const result = await autoFileIssuesForAlerts("src_1", ["alert_1"]);
     expect(result.filed).toBe(1);
     expect(result.skipped).toBe(0);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ── split-label behavior ──
+
+describe("autoFileIssuesForAlerts split-label", () => {
+  it("creates issue without claude-fix in initial labels", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+
+    mockAlertFindMany.mockResolvedValueOnce([
+      buildAlert({ id: "alert_1", sourceId: "src_1" }),
+    ] as never);
+    setupPassingGuards();
+    const fetchSpy = mockFetchForIssueCreation();
+    mockAlertFindUnique.mockResolvedValueOnce({ repairLog: null } as never);
+    mockAlertUpdate.mockResolvedValueOnce({} as never);
+
+    await autoFileIssuesForAlerts("src_1", ["alert_1"]);
+
+    // Issue creation call should NOT include claude-fix in labels
+    const createBody = JSON.parse((fetchSpy.mock.calls[1][1] as RequestInit).body as string);
+    expect(createBody.labels).not.toContain("claude-fix");
+    expect(createBody.labels).toContain("alert");
+  });
+
+  it("adds claude-fix label in separate API call after issue creation", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+
+    mockAlertFindMany.mockResolvedValueOnce([
+      buildAlert({ id: "alert_1", sourceId: "src_1" }),
+    ] as never);
+    setupPassingGuards();
+    const fetchSpy = mockFetchForIssueCreation({ issueNumber: 42 });
+    mockAlertFindUnique.mockResolvedValueOnce({ repairLog: null } as never);
+    mockAlertUpdate.mockResolvedValueOnce({} as never);
+
+    await autoFileIssuesForAlerts("src_1", ["alert_1"]);
+
+    // Third fetch call should POST claude-fix label to the issue
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const labelCall = fetchSpy.mock.calls[2];
+    expect((labelCall[0] as string)).toContain("/issues/42/labels");
+    expect((labelCall[1] as RequestInit).method).toBe("POST");
+    const labelBody = JSON.parse((labelCall[1] as RequestInit).body as string);
+    expect(labelBody.labels).toEqual(["claude-fix"]);
+  });
+
+  it("still returns issue URL if claude-fix label addition fails", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+
+    mockAlertFindMany.mockResolvedValueOnce([
+      buildAlert({ id: "alert_1", sourceId: "src_1" }),
+    ] as never);
+    setupPassingGuards();
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as Response) // dedup
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ html_url: "https://github.com/test/99", number: 99 }),
+      } as Response) // create
+      .mockRejectedValueOnce(new Error("Network error")); // label add fails
+
+    mockAlertFindUnique.mockResolvedValueOnce({ repairLog: null } as never);
+    mockAlertUpdate.mockResolvedValueOnce({} as never);
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await autoFileIssuesForAlerts("src_1", ["alert_1"]);
+    expect(result.filed).toBe(1); // still counts as filed
+    expect(result.skipped).toBe(0);
+
+    // Repair log should still be written
+    expect(mockAlertUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          repairLog: expect.arrayContaining([
+            expect.objectContaining({ action: "auto_file_issue", result: "success" }),
+          ]),
+        }),
+      }),
+    );
+
+    consoleSpy.mockRestore();
   });
 });
 

--- a/src/pipeline/auto-issue.ts
+++ b/src/pipeline/auto-issue.ts
@@ -258,7 +258,9 @@ ${agentContext}
 
   const typeLabel = `alert:${alert.type.toLowerCase().replaceAll("_", "-")}`;
   const severityLabel = `severity:${alert.severity.toLowerCase()}`;
-  const labels = ["alert", typeLabel, severityLabel, "claude-fix"];
+  // claude-fix is added separately after issue creation to avoid a race condition
+  // where concurrent label events cancel the triage workflow run (cancel-in-progress).
+  const labels = ["alert", typeLabel, severityLabel];
 
   return { title: sanitizeMentions(title), body: sanitizeMentions(body), labels };
 }
@@ -363,17 +365,19 @@ async function fileGitHubIssue(
 
   const { title, body, labels } = buildIssueBody(alert);
 
+  const postHeaders = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+  };
+
   try {
     // SSRF-safe: URL is always api.github.com with repo from GITHUB_REPOSITORY env (set by GitHub Actions)
     const res = await fetch(
       `https://api.github.com/repos/${repo}/issues`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "Content-Type": "application/json",
-        },
+        headers: postHeaders,
         body: JSON.stringify({ title, body, labels }),
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       },
@@ -385,6 +389,23 @@ async function fileGitHubIssue(
     }
 
     const issue = (await res.json()) as { html_url: string; number: number };
+
+    // Add claude-fix label in a separate API call so the triage workflow
+    // receives exactly one matching labeled event (no concurrent cancellation).
+    try {
+      await fetch(
+        `https://api.github.com/repos/${repo}/issues/${issue.number}/labels`,
+        {
+          method: "POST",
+          headers: postHeaders,
+          body: JSON.stringify({ labels: ["claude-fix"] }),
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        },
+      );
+    } catch (err) {
+      // Non-fatal: issue was created, triage can be triggered manually
+      console.error(`[auto-issue] Failed to add claude-fix label to #${issue.number}:`, err);
+    }
 
     // Read-modify-write in a transaction to avoid race conditions
     await prisma.$transaction(async (tx) => {


### PR DESCRIPTION
## Summary
- **Split label application** in `auto-issue.ts`: create issue with base labels (`alert`, severity, alert-type), then add `claude-fix` in a separate API call so only one `labeled` event matches the triage workflow's `if` condition
- **Set `cancel-in-progress: false`** in `claude-issue-triage.yml` as belt-and-suspenders — queued runs with non-matching labels skip quickly without cancelling the valid run
- **3 new tests** for split-label behavior (label exclusion, separate API call, graceful failure)

## Context
Issue #217 was auto-filed by the self-healing pipeline but the triage workflow never ran. Root cause: GitHub fires a separate `labeled` event per label, and `cancel-in-progress: true` caused a later non-matching event to cancel the valid `claude-fix` run.

## Test plan
- [x] All 40 auto-issue tests pass (`npm test -- auto-issue`)
- [ ] After deploy, remove `claude-fix` from #217, re-add it, verify triage workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)