### PR TITLE
fix: transaction timeout in backfill-city-action

### DIFF
--- a/src/app/admin/events/backfill-city-action.ts
+++ b/src/app/admin/events/backfill-city-action.ts
@@ -82,16 +82,21 @@ export async function backfillEventCities(): Promise<{
   // Update events in batches (no transaction needed — each updateMany
   // targets a disjoint set of events with an idempotent value)
   const updateEntries = Array.from(coordToCity.entries());
-  for (let i = 0; i < updateEntries.length; i += BATCH_SIZE) {
-    await Promise.all(
-      updateEntries.slice(i, i + BATCH_SIZE).map(([key, city]) => {
-        const eventIds = coordToEventIds.get(key)!;
-        return prisma.event.updateMany({
-          where: { id: { in: eventIds } },
-          data: { locationCity: city },
-        });
-      }),
-    );
+  try {
+    for (let i = 0; i < updateEntries.length; i += BATCH_SIZE) {
+      await Promise.all(
+        updateEntries.slice(i, i + BATCH_SIZE).map(([key, city]) => {
+          const eventIds = coordToEventIds.get(key)!;
+          return prisma.event.updateMany({
+            where: { id: { in: eventIds } },
+            data: { locationCity: city },
+          });
+        }),
+      );
+    }
+  } catch (e) {
+    console.error("Failed to backfill event cities:", e);
+    return { error: "Database update failed during city backfill." };
   }
 
   revalidatePath("/hareline");


### PR DESCRIPTION
## Summary
- Replace `prisma.$transaction()` with batched `Promise.all()` in `backfillEventCities()` to fix P2028 transaction timeout errors
- Each `updateMany` targets a disjoint set of events with an idempotent value (`locationCity`), so no transaction is needed
- Reuses existing `BATCH_SIZE = 10` constant to bound concurrent DB queries and prevent connection pool exhaustion

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (109 files, 2362 tests)
- [ ] Manual: click "Backfill Cities" on `/admin/events`, verify it completes without timeout error

🤖 Generated with [Claude Code](https://claude.com/claude-code)