### PR TITLE
fix: hareline data quality — 9 fixes for location, titles, and adapters

### DIFF
--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -209,3 +209,13 @@ describe("extractHares", () => {
     ).toBeUndefined();
   });
 });
+
+// ── HTML entity decoding in titles ──
+
+describe("extractTitle — HTML entities", () => {
+  it("handles pre-decoded title (entities decoded before extractTitle)", () => {
+    // decodeEntities is applied to summary before extractTitle in buildRawEventFromGCalItem
+    // so extractTitle receives already-decoded text
+    expect(extractTitle("SHITH3: St. Patricshit's Day")).toBe("St. Patricshit's Day");
+  });
+});

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -233,19 +233,21 @@ function buildRawEventFromGCalItem(
 
   const { dateISO, startTime } = extractDateTimeFromGCalItem(item.start);
   if (!dateISO) return null;
+  const summary = decodeEntities(item.summary);
   const { rawDescription, description } = normalizeGCalDescription(item.description);
   const hares = rawDescription ? extractHares(rawDescription, compiledHarePatterns) : undefined;
-  const { kennelTag, useFullTitle } = resolveKennelTagFromSummary(item.summary, sourceConfig);
+  const { kennelTag, useFullTitle } = resolveKennelTagFromSummary(summary, sourceConfig);
+  const location = item.location ? decodeEntities(item.location) : undefined;
 
   return {
     date: dateISO,
     kennelTag,
-    runNumber: extractRunNumber(item.summary, rawDescription, compiledRunNumberPatterns),
-    title: useFullTitle ? item.summary : extractTitle(item.summary),
+    runNumber: extractRunNumber(summary, rawDescription, compiledRunNumberPatterns),
+    title: useFullTitle ? summary : extractTitle(summary),
     description,
     hares,
-    location: item.location,
-    locationUrl: item.location ? mapsUrl(item.location) : undefined,
+    location,
+    locationUrl: location ? mapsUrl(location) : undefined,
     startTime,
     sourceUrl: item.htmlLink,
   };
@@ -355,8 +357,18 @@ export class GoogleCalendarAdapter implements SourceAdapter {
 
     const hasErrorDetails = hasAnyErrors(errorDetails);
 
+    // Dedup events with identical date+kennelTag+startTime+title from the same calendar
+    // (upstream calendars sometimes contain duplicate entries)
+    const seen = new Set<string>();
+    const dedupedEvents = events.filter(e => {
+      const key = `${e.date}|${e.kennelTag}|${e.startTime ?? ""}|${e.title ?? ""}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
     return {
-      events,
+      events: dedupedEvents,
       errors,
       errorDetails: hasErrorDetails ? errorDetails : undefined,
       diagnosticContext: {

--- a/src/adapters/html-scraper/hangover.test.ts
+++ b/src/adapters/html-scraper/hangover.test.ts
@@ -559,3 +559,29 @@ describe("HangoverAdapter HTML scraping (legacy)", () => {
     expect(fetch).toHaveBeenCalledTimes(3);
   });
 });
+
+// ── Location address concatenation fix ──
+
+describe("parseHangoverBody — Cost/Directions boundary", () => {
+  it("stops location capture at Cost: label", () => {
+    const text = "Location: Hyattstown Fire Dept, 25801 Frederick Rd, Clarksburg, MD 20871\nCost: $20.00 for beer";
+    const result = parseHangoverBody(text);
+    expect(result.location).toBe("Hyattstown Fire Dept, 25801 Frederick Rd, Clarksburg, MD 20871");
+    expect(result.location).not.toContain("$20");
+  });
+
+  it("stops location capture at Directions: label", () => {
+    const text = "Location: The Pub, 123 Main St\nDirections: Take I-270 North";
+    const result = parseHangoverBody(text);
+    expect(result.location).toBe("The Pub, 123 Main St");
+    expect(result.location).not.toContain("270");
+  });
+});
+
+describe("extractTrailSection — br preservation", () => {
+  it("preserves <br> as newlines in trail section", () => {
+    const html = `<hr><p>Location: Venue Name<br>123 Street<br>City, MD 21701</p>`;
+    const result = extractTrailSection(html);
+    expect(result).toContain("Venue Name\n123 Street\nCity, MD 21701");
+  });
+});

--- a/src/adapters/html-scraper/hangover.ts
+++ b/src/adapters/html-scraper/hangover.ts
@@ -57,6 +57,8 @@ export function extractTrailSection(html: string): string {
 
   if (hr.length === 0) {
     // No <hr> separator — return full text (older posts may not have prelubes)
+    // Preserve <br> as newlines so multi-line addresses don't concatenate
+    $("br").replaceWith("\n");
     return $.text().trim();
   }
 
@@ -64,7 +66,10 @@ export function extractTrailSection(html: string): string {
   const parts: string[] = [];
   let node = hr.get(0)?.nextSibling;
   while (node) {
-    const text = $(node as AnyNode).text().trim();
+    const $node = $(node as AnyNode);
+    // Preserve <br> as newlines within each block so address lines don't concatenate
+    $node.find?.("br").replaceWith("\n");
+    const text = $node.text().trim();
     if (text) parts.push(text);
     node = node.nextSibling;
   }
@@ -86,7 +91,7 @@ export function parseHangoverBody(text: string): {
     .replace(/\r/g, "") // Normalize Windows newlines.
     .replace(/\s+/g, " ") // Collapse inconsistent spacing from extracted HTML text.
     // Put labeled fields on their own logical lines so downstream field regexes are reliable.
-    .replace(/\s+(Date|When|Hare(?:\(s\)|s)?|Trail Start|Start|Location|Where|Hash Cash|Trail Type|On[- ]?After|On On(?: Brunch)?)\s*:/gi, "\n$1: ")
+    .replace(/\s+(Date|When|Hare(?:\(s\)|s)?|Trail Start|Start|Location|Where|Hash Cash|Cost|Directions|Trail Type|On[- ]?After|On On(?: Brunch)?)\s*:/gi, "\n$1: ")
     // Normalize compact "Pack Away at" / "Hare Away at" variants into a line boundary.
     .replace(/\s+(Pack Away|Hares? Away)\s+at\s+/gi, "\n$1 at ")
     // Normalize distance labels so Eagle/Turkey/Penguin can be extracted independently.

--- a/src/adapters/html-scraper/london-hash.test.ts
+++ b/src/adapters/html-scraper/london-hash.test.ts
@@ -612,3 +612,28 @@ describe("LondonHashAdapter.fetch", () => {
     vi.restoreAllMocks();
   });
 });
+
+// ── Inline element concatenation fix ──
+
+describe("parseRunBlocks — inline element spacing", () => {
+  it("inserts space between adjacent span elements to prevent concatenation", () => {
+    const html = `
+      <html><body>
+      <div id="runListHolder">
+        <div class="runListDetails">
+          <div class="runlistRow">
+            <div class="runlistCat runlistNo"><a href="nextrun.php?run=2285">2285</a></div>
+            <div class="runlistDate">Saturday 22nd of February 2026<br />12 Noon</div>
+            <div class="runlistHare">Hared by <span>Not Out and Big In Japan</span><span>What Else</span></div>
+          </div>
+        </div>
+      </div>
+      </body></html>
+    `;
+    const blocks = parseRunBlocks(html);
+    expect(blocks).toHaveLength(1);
+    // Hare names should be separated by space, not concatenated
+    expect(blocks[0].text).toContain("Not Out and Big In Japan");
+    expect(blocks[0].text).not.toContain("JapanWhat");
+  });
+});

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -50,6 +50,8 @@ export function parseRunBlocks(html: string): RunBlock[] {
 
       // Replace <br> with newlines so date/time don't concatenate
       $block.find("br").replaceWith("\n");
+      // Insert space after inline elements to prevent "Name1Name2" concatenation
+      $block.find("span, a, strong, em, b, i").after(" ");
       const text = $block.text().trim();
 
       blocks.push({ runNumber, runId, text });

--- a/src/adapters/html-scraper/och3.test.ts
+++ b/src/adapters/html-scraper/och3.test.ts
@@ -392,4 +392,37 @@ describe("OCH3Adapter.fetch", () => {
 
     vi.restoreAllMocks();
   });
+
+  it("strips script and style elements from page content", async () => {
+    const htmlWithScripts = `
+      <html><body>
+      <script>var _gaq = _gaq || []; _gaq.push(['_setAccount', 'UA-7870337-1']);</script>
+      <style>.header { color: red; }</style>
+      <div class="wsite-section-wrap">
+        <script>document.write('injected');</script>
+        <p>Upcoming Runs:</p>
+        <p>1st March 2026 - Linda 'One in the Eye' Cooper - Outwood</p>
+      </div>
+      </body></html>
+    `;
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(htmlWithScripts, { status: 200 }))
+      .mockResolvedValueOnce(new Response("<html><body></body></html>", { status: 200 }));
+
+    const adapter = new OCH3Adapter();
+    const result = await adapter.fetch({
+      id: "test",
+      url: "http://www.och3.org.uk/upcoming-run-list.html",
+    } as never);
+
+    // Should parse the event without script content bleeding in
+    expect(result.events.length).toBeGreaterThanOrEqual(1);
+    const allText = result.events.map(e => `${e.title ?? ""} ${e.hares ?? ""} ${e.location ?? ""}`).join(" ");
+    expect(allText).not.toContain("_gaq");
+    expect(allText).not.toContain("document.write");
+    expect(allText).not.toContain("color: red");
+
+    vi.restoreAllMocks();
+  });
 });

--- a/src/adapters/html-scraper/och3.ts
+++ b/src/adapters/html-scraper/och3.ts
@@ -295,7 +295,11 @@ export class OCH3Adapter implements SourceAdapter {
     }
 
     // Parse run list using line-based strategy
-    const mainContent = runListResult.$("main, .main-content, #content, .wsite-section-wrap, body").first().text();
+    // Remove script/style/noscript elements first — Cheerio .text() includes their
+    // text content, which caused raw JS (Google Analytics, etc.) to bleed into event data
+    const $main = runListResult.$("main, .main-content, #content, .wsite-section-wrap, body").first();
+    $main.find("script, style, noscript").remove();
+    const mainContent = $main.text();
     const events = parseOCH3EntriesFromText(mainContent, runListUrl);
 
     // Attempt detail page enrichment

--- a/src/adapters/html-scraper/ofh3.test.ts
+++ b/src/adapters/html-scraper/ofh3.test.ts
@@ -353,3 +353,21 @@ describe("OFH3Adapter.fetch (HTML fallback path)", () => {
     expect(result.errors).toHaveLength(1);
   });
 });
+
+// ── Location address concatenation fix ──
+
+describe("parseOfh3Body — newline-delimited fields", () => {
+  it("stops location capture at next line (description doesn't bleed in)", () => {
+    const text = "Where: 6079 Spring Ridge Pkwy, Frederick, MD 21701\nSouth Side of Parking lot closest to the Subway.";
+    const result = parseOfh3Body(text);
+    expect(result.location).toBe("6079 Spring Ridge Pkwy, Frederick, MD 21701");
+    expect(result.location).not.toContain("South Side");
+  });
+
+  it("captures location when followed by another label", () => {
+    const text = "Where: Blue Heron Elementary\nTrail Type: A-A";
+    const result = parseOfh3Body(text);
+    expect(result.location).toBe("Blue Heron Elementary");
+    expect(result.trailType).toBe("A-A");
+  });
+});

--- a/src/adapters/html-scraper/ofh3.ts
+++ b/src/adapters/html-scraper/ofh3.ts
@@ -4,7 +4,7 @@ import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "..
 import { hasAnyErrors } from "../types";
 import { generateStructureHash } from "@/pipeline/structure-hash";
 import { fetchBloggerPosts } from "../blogger-api";
-import { chronoParseDate, decodeEntities, isPlaceholder } from "../utils";
+import { chronoParseDate, decodeEntities, isPlaceholder, stripHtmlTags } from "../utils";
 
 /**
  * Parse a date string from OFH3 content.
@@ -199,9 +199,9 @@ export class OFH3Adapter implements SourceAdapter {
     for (let i = 0; i < bloggerResult.posts.length; i++) {
       const post = bloggerResult.posts[i];
 
-      // Extract text from HTML content
-      const $ = cheerio.load(post.content);
-      const bodyText = $.text();
+      // Extract text from HTML content, preserving <br>/block boundaries as newlines
+      // so label-based field parsing can correctly delimit fields like "Where: address"
+      const bodyText = stripHtmlTags(post.content, "\n");
       const titleText = decodeEntities(post.title);
       const postUrl = post.url;
 

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -63,14 +63,18 @@ export { formatDate };
 
 // ── Display helpers ──
 
-/** Display title for events with missing or parenthetical titles. */
+/** Display title for events with missing, parenthetical, or kennel-name-only titles. */
 function getDisplayTitle(event: HarelineEvent): string {
   const title = event.title?.trim() ?? "";
-  if (!title || /^\(.*\)$/.test(title)) {
-    return event.runNumber
-      ? `${event.kennel.shortName} \u2014 Run #${event.runNumber}`
-      : event.kennel.shortName;
-  }
+  const fallback = event.runNumber
+    ? `${event.kennel.shortName} \u2014 Run #${event.runNumber}`
+    : event.kennel.shortName;
+  if (!title || /^\(.*\)$/.test(title)) return fallback;
+  // Suppress titles that just repeat the kennel name (e.g., "SPH3", "O2H3 Hash")
+  const norm = title.toLowerCase().replace(/\s+hash$/i, "").replace(/\s+h3$/i, "").trim();
+  const kennelNorm = event.kennel.shortName.toLowerCase().trim();
+  const fullNorm = (event.kennel.fullName ?? "").toLowerCase().trim();
+  if (norm === kennelNorm || (fullNorm && norm === fullNorm)) return fallback;
   return title;
 }
 
@@ -91,7 +95,11 @@ function buildAriaLabel(event: HarelineEvent, attendance?: AttendanceData | null
 function getLocationDisplay(event: HarelineEvent): string | null {
   const name = event.locationName?.replace(/https?:\/\/\S+/g, "").trim() || null;
   const city = event.locationCity;
-  if (name && city) return `${name}, ${city}`;
+  if (name && city) {
+    // Don't append city if it's already embedded in the location name
+    if (name.toLowerCase().includes(city.toLowerCase())) return name;
+    return `${name}, ${city}`;
+  }
   return city || name || null;
 }
 

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -434,3 +434,41 @@ describe("double-header support", () => {
   });
 });
 
+// ── sanitizeTitle ──
+
+import { sanitizeTitle } from "./merge";
+
+describe("sanitizeTitle", () => {
+  it("passes through normal titles", () => {
+    expect(sanitizeTitle("The Pre-Saint Patrick's Day Trail")).toBe("The Pre-Saint Patrick's Day Trail");
+  });
+
+  it("returns null for 'hares needed' admin text", () => {
+    expect(sanitizeTitle("Hares needed! Email the Hare Razor")).toBeNull();
+  });
+
+  it("returns null for 'Hare needed' singular", () => {
+    expect(sanitizeTitle("Hare needed for this week")).toBeNull();
+  });
+
+  it("returns null for 'Need a hare'", () => {
+    expect(sanitizeTitle("Need a hare")).toBeNull();
+  });
+
+  it("returns null for 'volunteer to hare'", () => {
+    expect(sanitizeTitle("Volunteer to hare this trail!")).toBeNull();
+  });
+
+  it("strips embedded email addresses", () => {
+    expect(sanitizeTitle("Trail Name <foo@bar.com> details")).toBe("Trail Name details");
+  });
+
+  it("returns null for undefined", () => {
+    expect(sanitizeTitle(undefined)).toBeNull();
+  });
+
+  it("returns null for empty/whitespace", () => {
+    expect(sanitizeTitle("  ")).toBeNull();
+  });
+});
+

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -227,6 +227,21 @@ function extractRawCoords(event: RawEventData): { latitude?: number; longitude?:
 }
 
 /**
+ * Sanitize event titles: strip admin placeholders, "hares needed" messages, and email addresses.
+ * Returns null for titles that are pure admin content, so the display layer falls back to kennel name.
+ */
+export function sanitizeTitle(title: string | undefined): string | null {
+  if (!title) return null;
+  const t = title.trim();
+  if (!t) return null;
+  // Filter out admin/meta content in titles
+  if (/hares?\s+needed|need\s+(?:a\s+)?hares?|looking\s+for\s+hares?|email\s+the\s+hare|volunteer\s+to\s+hare/i.test(t)) return null;
+  // Strip embedded email addresses
+  const cleaned = t.replace(/\s*<?[\w.+-]+@[\w.-]+>?\s*/g, " ").trim();
+  return cleaned || null;
+}
+
+/**
  * Resolve coordinates for a raw event: explicit coords → URL extraction → geocode fallback.
  * Optionally skips geocoding if the canonical event already has stored coords and
  * the location text hasn't changed.
@@ -357,7 +372,7 @@ async function upsertCanonicalEvent(
           runNumber: event.runNumber ?? existingEvent.runNumber,
           // Use ?? null for text fields: scraper always attempts these,
           // so undefined means "clear it" (not "I didn't try")
-          title: event.title ?? null,
+          title: sanitizeTitle(event.title),
           description: event.description ?? null,
           haresText: event.hares ?? null,
           locationName: event.location ?? null,
@@ -411,7 +426,7 @@ async function upsertCanonicalEvent(
         dateUtc,
         timezone,
         runNumber: event.runNumber,
-        title: event.title,
+        title: sanitizeTitle(event.title),
         description: event.description,
         haresText: event.hares,
         locationName: event.location,


### PR DESCRIPTION
## Summary

- **Location redundant city** (Fix 1): `getLocationDisplay()` now checks if `locationName` already contains `locationCity` before appending, fixing "El Paso, TX 79936, USA, El Paso, TX" → "El Paso, TX 79936, USA"
- **HTML entity decoding** (Fix 2): `decodeEntities()` applied to Google Calendar `summary` and `location` fields, fixing literal `&apos;` in titles like "St. Patricshit&apos;s Day"
- **Admin text in titles** (Fix 3): New `sanitizeTitle()` in merge pipeline strips "Hares needed!" placeholders and embedded email addresses from event titles
- **GCal adapter dedup** (Fix 4): Dedup pass at adapter level collapses duplicate upstream calendar entries (CFMH3/FCMH3)
- **Title redundancy suppression** (Fix 5): `getDisplayTitle()` detects and suppresses titles that just repeat the kennel name (e.g., "SPH3", "O2H3 Hash")
- **OCH3 script stripping** (Fix 6): Remove `<script>`, `<style>`, `<noscript>` elements before `.text()` extraction, preventing raw JS/CSS from bleeding into event data
- **LH3 hare concatenation** (Fix 7): Insert space after inline elements (`<span>`, `<a>`, etc.) to prevent "Name1Name2" concatenation
- **H4 location concatenation** (Fix 8): Preserve `<br>` as newlines in `extractTrailSection()` and add "Cost"/"Directions" to label boundary list in `parseHangoverBody()`
- **OFH3 location concatenation** (Fix 9): Replace `cheerio.load(content).text()` with `stripHtmlTags(content, "\n")` to preserve line boundaries between address and description

## Test plan

- [x] All 109 test files pass (2378 tests)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [ ] Browse /hareline after deploy — verify location strings, titles, and adapter output
- [ ] Trigger re-scrape of affected sources (SHITH3, EWH3, OCH3, LH3, H4, OFH3) via admin panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)