### PR TITLE
fix: hareline data quality round 2 — placeholder filtering, city dedup, title suppression

### DIFF
--- a/src/adapters/html-scraper/city-hash.test.ts
+++ b/src/adapters/html-scraper/city-hash.test.ts
@@ -137,6 +137,20 @@ describe("parseMakesweatEvent", () => {
     expect(event!.hares).toBe("TBC");
   });
 
+  it("skips TBC/TBD venue via isPlaceholder — location is undefined", () => {
+    const tbcHtml = `<div class="ms_event">
+      <div class="ms_eventtitle">City Hash R*n #1920 @ TBC</div>
+      <div class="ms_event_startdate">Tue 5th May 26</div>
+      <div class="ms_eventstart">7:00pm</div>
+      <div class="ms_eventdescription"></div>
+      <div class="ms_venue_name">TBC</div>
+    </div>`;
+    const $tbc = cheerio.load(tbcHtml);
+    const event = parseMakesweatEvent($tbc, $tbc(".ms_event").eq(0), "https://makesweat.com/cityhash#hashes");
+    expect(event).not.toBeNull();
+    expect(event!.location).toBeUndefined();
+  });
+
   it("extracts Makesweat ID from class attribute", () => {
     expect(extractMakesweatId(cards.eq(0))).toBe("12345");
   });

--- a/src/adapters/html-scraper/city-hash.ts
+++ b/src/adapters/html-scraper/city-hash.ts
@@ -10,6 +10,7 @@ import {
   chronoParseDate,
   parse12HourTime,
   fetchBrowserRenderedPage,
+  isPlaceholder,
 } from "../utils";
 
 /**
@@ -66,7 +67,7 @@ export function parseMakesweatEvent(
 
   // Build composite location: "Pub Name, Street Address, Postcode"
   let location: string | undefined;
-  if (venueName && venueName.toUpperCase() !== "TBA") {
+  if (venueName && !isPlaceholder(venueName)) {
     const parts = [venueName, venueAddress, venuePostcode].filter(Boolean);
     location = parts.join(", ");
   }

--- a/src/adapters/html-scraper/london-hash.test.ts
+++ b/src/adapters/html-scraper/london-hash.test.ts
@@ -114,6 +114,27 @@ describe("parseLocationFromBlock", () => {
     expect(result.location).toBeUndefined();
     expect(result.station).toBeUndefined();
   });
+
+  it("filters 'to be announced' from P-trail pattern", () => {
+    const result = parseLocationFromBlock(
+      "Follow the P trail from Sydenham station to be announced",
+    );
+    expect(result.location).toBeUndefined();
+    expect(result.station).toBe("Sydenham");
+  });
+
+  it("filters TBA location from P-trail pattern", () => {
+    const result = parseLocationFromBlock(
+      "Follow the P trail from Vauxhall to TBA",
+    );
+    expect(result.location).toBeUndefined();
+    expect(result.station).toBe("Vauxhall");
+  });
+
+  it("filters TBA from Start: pattern", () => {
+    const result = parseLocationFromBlock("Start: TBA");
+    expect(result.location).toBeUndefined();
+  });
 });
 
 describe("parseTimeFromBlock", () => {

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -7,7 +7,7 @@ import type {
   ErrorDetails,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { chronoParseDate, parse12HourTime, fetchHTMLPage } from "../utils";
+import { chronoParseDate, isPlaceholder, parse12HourTime, fetchHTMLPage } from "../utils";
 
 /** Max detail pages to fetch per scrape (only first N events). */
 const MAX_DETAIL_FETCHES = 3;
@@ -152,16 +152,21 @@ export function parseLocationFromBlock(text: string): { location?: string; stati
     /(?:Follow|P\s*trail)\s+(?:the\s+P\s+trail\s+)?from\s+(.+?)\s+(?:station\s+)?to\s+(.+?)(?:\n|$|\*)/i,
   );
   if (pTrailMatch) {
-    return {
-      station: pTrailMatch[1].trim(),
-      location: pTrailMatch[2].trim(),
-    };
+    const station = pTrailMatch[1].trim();
+    const loc = pTrailMatch[2].trim();
+    // Filter placeholder or announcement text (e.g., "to be announced")
+    if (isPlaceholder(loc) || /\bannounce/i.test(loc)) {
+      return { station };
+    }
+    return { station, location: loc };
   }
 
   // "Start: LOCATION" pattern
   const startMatch = text.match(/Start:\s*(.+?)(?:\n|$|\*)/i);
   if (startMatch) {
-    return { location: startMatch[1].trim() };
+    const loc = startMatch[1].trim();
+    if (isPlaceholder(loc)) return {};
+    return { location: loc };
   }
 
   return {};

--- a/src/adapters/html-scraper/och3.test.ts
+++ b/src/adapters/html-scraper/och3.test.ts
@@ -425,4 +425,36 @@ describe("OCH3Adapter.fetch", () => {
 
     vi.restoreAllMocks();
   });
+
+  it("strips nav, header, and footer elements from page content", async () => {
+    const htmlWithNav = `
+      <html><body>
+      <nav><ul><li>Home</li><li>Run List</li><li>About Us</li></ul></nav>
+      <header><h1>OCH3 Website</h1></header>
+      <div class="wsite-section-wrap">
+        <p>Upcoming Runs:</p>
+        <p>1st March 2026 - Linda 'One in the Eye' Cooper - Outwood</p>
+      </div>
+      <footer><p>Copyright 2026 OCH3</p></footer>
+      </body></html>
+    `;
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(htmlWithNav, { status: 200 }))
+      .mockResolvedValueOnce(new Response("<html><body></body></html>", { status: 200 }));
+
+    const adapter = new OCH3Adapter();
+    const result = await adapter.fetch({
+      id: "test",
+      url: "http://www.och3.org.uk/upcoming-run-list.html",
+    } as never);
+
+    expect(result.events.length).toBeGreaterThanOrEqual(1);
+    const allText = result.events.map(e => `${e.title ?? ""} ${e.hares ?? ""} ${e.location ?? ""}`).join(" ");
+    expect(allText).not.toContain("Run List");
+    expect(allText).not.toContain("About Us");
+    expect(allText).not.toContain("Copyright");
+
+    vi.restoreAllMocks();
+  });
 });

--- a/src/adapters/html-scraper/och3.ts
+++ b/src/adapters/html-scraper/och3.ts
@@ -298,7 +298,7 @@ export class OCH3Adapter implements SourceAdapter {
     // Remove script/style/noscript elements first — Cheerio .text() includes their
     // text content, which caused raw JS (Google Analytics, etc.) to bleed into event data
     const $main = runListResult.$("main, .main-content, #content, .wsite-section-wrap, body").first();
-    $main.find("script, style, noscript").remove();
+    $main.find("script, style, noscript, nav, header, footer, .nav, .navbar, .header, .footer, .menu, .navigation").remove();
     const mainContent = $main.text();
     const events = parseOCH3EntriesFromText(mainContent, runListUrl);
 

--- a/src/adapters/html-scraper/west-london-hash.test.ts
+++ b/src/adapters/html-scraper/west-london-hash.test.ts
@@ -69,6 +69,18 @@ describe("parseLocationFromHeading", () => {
   it("returns null when no location", () => {
     expect(parseLocationFromHeading("Run Number 2081 – 19 February 2026")).toBeNull();
   });
+
+  it("returns null for TBA placeholder", () => {
+    expect(parseLocationFromHeading("Run Number 2085 – 26 March 2026-TBA")).toBeNull();
+  });
+
+  it("returns null for 'Location TBA' placeholder", () => {
+    expect(parseLocationFromHeading("Run Number 2085 – 26 March 2026-Location TBA")).toBeNull();
+  });
+
+  it("returns null for TBD placeholder", () => {
+    expect(parseLocationFromHeading("Run Number 2085 – 26 March 2026-TBD")).toBeNull();
+  });
 });
 
 describe("extractPostcode", () => {

--- a/src/adapters/html-scraper/west-london-hash.ts
+++ b/src/adapters/html-scraper/west-london-hash.ts
@@ -10,7 +10,7 @@ import type {
 } from "../types";
 import { hasAnyErrors } from "../types";
 import { generateStructureHash } from "@/pipeline/structure-hash";
-import { chronoParseDate, extractUkPostcode, googleMapsSearchUrl, validateSourceUrl } from "../utils";
+import { chronoParseDate, extractUkPostcode, googleMapsSearchUrl, isPlaceholder, validateSourceUrl } from "../utils";
 import { safeFetch } from "../safe-fetch";
 
 /**
@@ -39,7 +39,12 @@ export function parseLocationFromHeading(heading: string): string | null {
   // Match year (20xx) immediately followed by a dash then location text (starts with letter)
   // Key: no whitespace between year and dash — "2026-Clapham" not "2081 – 19 Feb"
   const match = heading.match(/20\d{2}[-–—]([A-Za-z].+)$/);
-  return match ? match[1].trim() : null;
+  if (!match) return null;
+  const loc = match[1].trim();
+  // Filter placeholder values like "TBA" or "Location TBA"
+  const prefixStripped = loc.replace(/^Location\s+/i, "");
+  if (isPlaceholder(prefixStripped)) return null;
+  return loc;
 }
 
 /** @deprecated Use extractUkPostcode from ../utils instead */
@@ -96,8 +101,9 @@ export function parseRunItem(
     }
   });
 
-  // Build location: prefer venue address, fall back to heading location
-  const location = venueAddress || locationFromHeading || undefined;
+  // Build location: prefer venue address, fall back to heading location (filter placeholders)
+  const filteredVenue = venueAddress && !isPlaceholder(venueAddress) ? venueAddress : null;
+  const location = filteredVenue || locationFromHeading || undefined;
   const locationUrl = postcode ? mapsUrl(postcode) : (locationFromHeading ? mapsUrl(locationFromHeading) : undefined);
 
   // Build title

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -70,10 +70,16 @@ function getDisplayTitle(event: HarelineEvent): string {
     ? `${event.kennel.shortName} \u2014 Run #${event.runNumber}`
     : event.kennel.shortName;
   if (!title || /^\(.*\)$/.test(title)) return fallback;
-  // Suppress titles that just repeat the kennel name (e.g., "SPH3", "O2H3 Hash")
-  const norm = title.toLowerCase().replace(/\s+hash$/i, "").replace(/\s+h3$/i, "").trim();
+  // Suppress titles that just repeat the kennel name (e.g., "SPH3", "O2H3 Hash", "St Pete H3")
+  const norm = title.toLowerCase()
+    .replace(/\s+hash\s+house\s+harriers$/i, "")
+    .replace(/\s+hash$/i, "")
+    .replace(/\s+h3$/i, "")
+    .trim();
   const kennelNorm = event.kennel.shortName.toLowerCase().trim();
-  const fullNorm = (event.kennel.fullName ?? "").toLowerCase().trim();
+  const fullNorm = (event.kennel.fullName ?? "").toLowerCase()
+    .replace(/\s+hash\s+house\s+harriers$/i, "")
+    .trim();
   if (norm === kennelNorm || (fullNorm && norm === fullNorm)) return fallback;
   return title;
 }
@@ -97,7 +103,11 @@ function getLocationDisplay(event: HarelineEvent): string | null {
   const city = event.locationCity;
   if (name && city) {
     // Don't append city if it's already embedded in the location name
-    if (name.toLowerCase().includes(city.toLowerCase())) return name;
+    const nameLower = name.toLowerCase();
+    if (nameLower.includes(city.toLowerCase())) return name;
+    // Also check just the city name (before comma) — "Boston" in name vs "Boston, MA" as city
+    const cityName = city.split(",")[0].trim();
+    if (cityName && nameLower.includes(cityName.toLowerCase())) return name;
     return `${name}, ${city}`;
   }
   return city || name || null;

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -436,7 +436,7 @@ describe("double-header support", () => {
 
 // ── sanitizeTitle ──
 
-import { sanitizeTitle } from "./merge";
+import { sanitizeTitle, sanitizeLocation } from "./merge";
 
 describe("sanitizeTitle", () => {
   it("passes through normal titles", () => {
@@ -469,6 +469,42 @@ describe("sanitizeTitle", () => {
 
   it("returns null for empty/whitespace", () => {
     expect(sanitizeTitle("  ")).toBeNull();
+  });
+});
+
+// ── sanitizeLocation ──
+
+describe("sanitizeLocation", () => {
+  it("passes through normal locations", () => {
+    expect(sanitizeLocation("The Pub")).toBe("The Pub");
+  });
+
+  it("returns null for TBA", () => {
+    expect(sanitizeLocation("TBA")).toBeNull();
+  });
+
+  it("returns null for TBD", () => {
+    expect(sanitizeLocation("TBD")).toBeNull();
+  });
+
+  it("returns null for TBC", () => {
+    expect(sanitizeLocation("TBC")).toBeNull();
+  });
+
+  it("returns null for bare URLs", () => {
+    expect(sanitizeLocation("https://maps.google.com/some-place")).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(sanitizeLocation(undefined)).toBeNull();
+  });
+
+  it("returns null for empty/whitespace", () => {
+    expect(sanitizeLocation("  ")).toBeNull();
+  });
+
+  it("preserves location with embedded URL text", () => {
+    expect(sanitizeLocation("The Pub https://example.com")).toBe("The Pub https://example.com");
   });
 });
 

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -7,6 +7,7 @@ import { composeUtcStart } from "@/lib/timezone";
 import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag, clearResolverCache } from "./kennel-resolver";
 import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseGeocode } from "@/lib/geo";
+import { isPlaceholder } from "@/adapters/utils";
 
 /**
  * Create EventLink records for an event from externalLinks + alternate sourceUrls.
@@ -242,6 +243,20 @@ export function sanitizeTitle(title: string | undefined): string | null {
 }
 
 /**
+ * Sanitize location names: filter placeholders (TBA/TBD) and bare URLs.
+ * Returns null for locations that are not meaningful display text.
+ */
+export function sanitizeLocation(location: string | undefined): string | null {
+  if (!location) return null;
+  const t = location.trim();
+  if (!t) return null;
+  if (isPlaceholder(t)) return null;
+  // Strip bare URLs (not useful as location names)
+  if (/^https?:\/\/\S+$/.test(t)) return null;
+  return t;
+}
+
+/**
  * Resolve coordinates for a raw event: explicit coords → URL extraction → geocode fallback.
  * Optionally skips geocoding if the canonical event already has stored coords and
  * the location text hasn't changed.
@@ -375,7 +390,7 @@ async function upsertCanonicalEvent(
           title: sanitizeTitle(event.title),
           description: event.description ?? null,
           haresText: event.hares ?? null,
-          locationName: event.location ?? null,
+          locationName: sanitizeLocation(event.location),
           locationAddress: event.locationUrl ?? null,
           startTime: event.startTime ?? existingEvent.startTime,
           dateUtc,
@@ -429,7 +444,7 @@ async function upsertCanonicalEvent(
         title: sanitizeTitle(event.title),
         description: event.description,
         haresText: event.hares,
-        locationName: event.location,
+        locationName: sanitizeLocation(event.location),
         locationAddress: event.locationUrl,
         startTime: event.startTime,
         sourceUrl: event.sourceUrl,


### PR DESCRIPTION
## Summary

Follow-up to PR #227 addressing remaining data quality issues found in a second audit of ~650 hareline events (March–July 2026):

- **City dedup improvement** (EventCard.tsx): `getLocationDisplay()` now checks the city name before the comma (e.g., "Boston" from "Boston, MA") to prevent false duplicate city names
- **Title suppression enhancement** (EventCard.tsx): `getDisplayTitle()` now strips "Hash House Harriers" from fullName when comparing, so titles like "St Pete H3" match fullName "St Pete Hash House Harriers"
- **Location sanitization** (merge.ts): New `sanitizeLocation()` filters TBA/TBD placeholders and bare URLs from `locationName` at both write sites
- **WLH3 placeholder filtering** (west-london-hash.ts): `parseLocationFromHeading()` filters TBA/TBD/TBC and "Location TBA" patterns via `isPlaceholder()`
- **CityH3 placeholder broadening** (city-hash.ts): Replaced `venueName.toUpperCase() !== "TBA"` with `!isPlaceholder(venueName)` to catch TBC, TBD, etc.
- **LH3 location filtering** (london-hash.ts): `parseLocationFromBlock()` filters "to be announced" and placeholder text from P-trail regex matches
- **OCH3 nav stripping** (och3.ts): Extended element removal to include nav/header/footer, preventing navigation menu text from bleeding into event data

## Test plan

- [x] All 109 test files pass (2398 tests)
- [x] Type check passes (`npx tsc --noEmit`)
- [ ] Verify on /hareline: locations with partial city matches no longer show double city
- [ ] Verify "St Pete H3" and similar titles show kennel fallback
- [ ] Trigger re-scrape of WLH3, CityH3, LH3, OCH3 to pick up adapter fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)