### PR TITLE
perf: add parentEventId index to Event model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -318,6 +318,7 @@ model Event {
 
   @@index([date])
   @@index([kennelId, date])
+  @@index([parentEventId])
 }
 
 model EventLink {


### PR DESCRIPTION
## Summary
- Adds `@@index([parentEventId])` to the Event model in `prisma/schema.prisma`
- Multiple high-traffic queries filter on `parentEventId: null` (homepage, kennel page, admin page) — without this index, PostgreSQL falls back to row scanning after the `date` index narrows results
- Index already pushed to Railway DB via `prisma db push`

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx prisma db push` — index created
- [x] `npm test` — 109 files, 2451 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)