### PR TITLE
feat: fill VA gaps with Tidewater, Seven Hills + FUH3 source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ logbook + kennel directory.
 
 ## Important Files
 - `prisma/schema.prisma` — Full data model, 27 models + 20 enums (THE source of truth for types)
-- `prisma/seed.ts` — 186 kennels, 575 aliases, 105 sources, 92 regions (first-class model with hierarchy)
+- `prisma/seed.ts` — 188 kennels, 585 aliases, 108 sources, 93 regions (first-class model with hierarchy)
 - `prisma.config.ts` — Prisma 7 config (datasource URL, seed command)
 - `src/lib/db.ts` — PrismaClient singleton (PrismaPg adapter + SSL)
 - `src/lib/auth.ts` — `getOrCreateUser()` + `getAdminUser()` + `getMismanUser()` + `getRosterGroupId()` (Clerk→DB sync + admin/misman role checks)
@@ -246,7 +246,7 @@ logbook + kennel directory.
 - `infra/proxy-relay/` — NAS-deployed residential proxy (Cloudflare Tunnel + Node.js forwarder)
 - `docs/residential-proxy-spec.md` — Architecture and deployment guide for residential proxy
 
-## Active Sources (105)
+## Active Sources (108)
 
 ### NYC / NJ / Philly (8 sources)
 - **hashnyc.com** → HTML_SCRAPER → 11 NYC-area kennels
@@ -362,13 +362,16 @@ logbook + kennel directory.
 ### Delaware (1 source)
 - **Hockessin H3 Website** → HTML_SCRAPER → H4 (Wilmington)
 
-### Virginia (outside DC metro) (6 sources)
+### Virginia (outside DC metro) (9 sources)
 - **Richmond H3 Google Calendar** → GOOGLE_CALENDAR → RH3 (Richmond)
 - **Richmond H3 Meetup** → MEETUP → RH3 (Richmond)
 - **Fort Eustis H3 Google Calendar** → GOOGLE_CALENDAR → FEH3 (Hampton Roads)
 - **Fort Eustis H3 Meetup** → MEETUP → FEH3 (Hampton Roads)
 - **BDSM H3 Meetup** → MEETUP → BDSMH3 (Hampton Roads)
 - **cHARLOTtesville H3 Meetup** → MEETUP → CvilleH3 (Charlottesville)
+- **FUH3 Static Schedule** → STATIC_SCHEDULE → FUH3 (Fredericksburg)
+- **Tidewater H3 Static Schedule** → STATIC_SCHEDULE → TH3 (Hampton Roads)
+- **Seven Hills H3 Static Schedule** → STATIC_SCHEDULE → 7H4 (Lynchburg)
 
 ### North Carolina (6 sources)
 - **SWH3 Google Calendar** → GOOGLE_CALENDAR → SWH3 (Raleigh)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -86,7 +86,7 @@ async function ensureRegionRecords(prisma: any) {
     "Delaware": ["Wilmington, DE"],
     "Virginia": [
       "Northern Virginia", "Fredericksburg, VA", "Richmond, VA",
-      "Hampton Roads, VA", "Charlottesville, VA",
+      "Hampton Roads, VA", "Charlottesville, VA", "Lynchburg, VA",
     ],
     "North Carolina": [
       "Raleigh, NC", "Charlotte, NC", "Asheville, NC",
@@ -1142,6 +1142,28 @@ async function main() {
       description: "Biweekly hash in Charlottesville, known as 'the Harlots'.",
       latitude: 38.03, longitude: -78.48,
     },
+    // --- Hampton Roads (Tidewater) ---
+    {
+      kennelCode: "twh3", shortName: "TH3", fullName: "Tidewater Hash House Harriers", region: "Hampton Roads, VA",
+      facebookUrl: "https://www.facebook.com/groups/SEVAHHH",
+      scheduleDayOfWeek: "Sunday", scheduleFrequency: "Weekly", scheduleTime: "2:00 PM",
+      scheduleNotes: "Sundays year-round. Gather 1:30 PM, start 2:00 PM (spring/fall). Summer 3:30 PM, winter 1:00 PM. 11 sub-kennels run other days.",
+      hashCash: "$5", foundedYear: 1991,
+      description: "Hampton Roads' main hash kennel with 1,836+ trails and 11 sub-kennels across the Virginia Beach/Norfolk/Chesapeake area.",
+      latitude: 36.85, longitude: -76.13,
+    },
+    // --- Lynchburg ---
+    {
+      kennelCode: "7h4", shortName: "7H4", fullName: "Seven Hills Hash House Harriers", region: "Lynchburg, VA",
+      website: "https://sites.google.com/view/7h4/home",
+      facebookUrl: "https://www.facebook.com/groups/41511405734/",
+      contactEmail: "7h4hash@googlegroups.com",
+      scheduleDayOfWeek: "Wednesday", scheduleFrequency: "Weekly", scheduleTime: "6:30 PM",
+      scheduleNotes: "Wednesdays year-round. Also Sundays 3 PM in winter.",
+      hashCash: "$5", foundedYear: 1992,
+      description: "Weekly Wednesday evening hash in Lynchburg with 2,000+ trails since 1992.",
+      latitude: 37.41, longitude: -79.14,
+    },
     // ===== NORTH CAROLINA =====
     // --- Raleigh / Triangle ---
     {
@@ -1743,6 +1765,8 @@ async function main() {
     "feh3": ["FEH3", "Fort Eustis Hash", "Fort Eustis", "Ft Eustis Hash", "Fort Eustis HHH"],
     "bdsmh3": ["BDSMH3", "BDSM Hash", "Bad Decisions Hash", "Bad Decisions Start Monday"],
     "cvilleh3": ["CvilleH3", "Charlottesville Hash", "Harlots", "cHARLOTtesville Hash", "Cville Hash"],
+    "twh3": ["TH3", "Tidewater Hash", "Tidewater", "Tidewater HHH", "TH3 VA"],
+    "7h4": ["7H4", "Seven Hills Hash", "Seven Hills", "7 Hills Hash"],
     // North Carolina
     "swh3": ["SWH3", "Sir Walter's", "Sir Walters", "Sir Walter's Hash", "Sir Walters Hash"],
     "larrikins": ["Larrikins", "Carolina Larrikins", "CLH3", "Larrikins H3"],
@@ -2645,6 +2669,61 @@ async function main() {
       scrapeDays: 180,
       config: { groupUrlname: "meetup-group-xxcniptw", kennelTag: "CvilleH3" },
       kennelCodes: ["cvilleh3"],
+    },
+    // --- Fredericksburg (Static Schedule — kennel already exists, adding source) ---
+    {
+      name: "FUH3 Static Schedule",
+      url: "https://www.facebook.com/groups/fuh3va/",
+      type: "STATIC_SCHEDULE" as const,
+      trustLevel: 3,
+      scrapeFreq: "weekly",
+      scrapeDays: 90,
+      config: {
+        kennelTag: "FUH3",
+        rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA",
+        anchorDate: "2026-03-08",
+        startTime: "15:00",
+        defaultTitle: "FUH3 Biweekly Run",
+        defaultLocation: "Fredericksburg, VA",
+        defaultDescription: "Check the Facebook page at https://www.facebook.com/groups/fuh3va/ for updates on locations.",
+      },
+      kennelCodes: ["fuh3"],
+    },
+    // --- Tidewater (Static Schedule — main Sunday trail only) ---
+    {
+      name: "Tidewater H3 Static Schedule",
+      url: "https://www.facebook.com/groups/SEVAHHH",
+      type: "STATIC_SCHEDULE" as const,
+      trustLevel: 3,
+      scrapeFreq: "weekly",
+      scrapeDays: 90,
+      config: {
+        kennelTag: "TH3",
+        rrule: "FREQ=WEEKLY;BYDAY=SU",
+        startTime: "14:00",
+        defaultTitle: "Tidewater H3 Weekly Run",
+        defaultLocation: "Virginia Beach, VA",
+        defaultDescription: "Check the Facebook page at https://www.facebook.com/groups/SEVAHHH for updates on locations and times. Times vary seasonally.",
+      },
+      kennelCodes: ["twh3"],
+    },
+    // --- Lynchburg (Static Schedule — Wednesday only) ---
+    {
+      name: "Seven Hills H3 Static Schedule",
+      url: "https://www.facebook.com/groups/41511405734/",
+      type: "STATIC_SCHEDULE" as const,
+      trustLevel: 3,
+      scrapeFreq: "weekly",
+      scrapeDays: 90,
+      config: {
+        kennelTag: "7H4",
+        rrule: "FREQ=WEEKLY;BYDAY=WE",
+        startTime: "18:30",
+        defaultTitle: "Seven Hills H3 Weekly Run",
+        defaultLocation: "Lynchburg, VA",
+        defaultDescription: "Check the Facebook page at https://www.facebook.com/groups/41511405734/ for updates on locations.",
+      },
+      kennelCodes: ["7h4"],
     },
     // ===== NORTH CAROLINA =====
     // --- Raleigh / Triangle ---

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -494,6 +494,17 @@ export const REGION_SEED_DATA: RegionSeedRecord[] = [
     centroidLng: -78.48,
     aliases: ["Charlottesville"],
   },
+  {
+    name: "Lynchburg, VA",
+    country: "USA",
+    timezone: "America/New_York",
+    abbrev: "LYH",
+    colorClasses: "bg-pink-100 text-pink-700",
+    pinColor: "#ec4899",
+    centroidLat: 37.41,
+    centroidLng: -79.14,
+    aliases: ["Lynchburg"],
+  },
   // ── US Southeast ──
   {
     name: "Atlanta, GA",


### PR DESCRIPTION
## Summary
- **2 new kennels**: Tidewater H3 (Hampton Roads) + Seven Hills H3 (Lynchburg)
- **3 new sources**: All STATIC_SCHEDULE — FUH3 biweekly Saturday, Tidewater weekly Sunday, Seven Hills weekly Wednesday
- **1 new region**: Lynchburg, VA (METRO under Virginia)
- Completes Virginia coverage — all active VA kennels now have sources

## Notes
- FUH3 kennel already existed but had no source — this adds its biweekly Saturday schedule
- Tidewater has 11 sub-kennels but only the main Sunday trail is onboarded (sub-kennels can be added later)
- Seven Hills also runs Sundays in winter but the schedule is too vague for STATIC_SCHEDULE — Wednesday-only for now

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 115 files, 2615 tests pass
- [x] `npx prisma db seed` — 188 kennels, 115 sources, 95 regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)