### PR TITLE
fix: UX audit follow-up — maxZoom, group labels, card layout

### DIFF
--- a/src/components/hareline/ClusteredMarkers.tsx
+++ b/src/components/hareline/ClusteredMarkers.tsx
@@ -64,7 +64,7 @@ export function ClusteredMarkers({ events, selectedEventId, onSelectEvent, onNav
   useEffect(() => {
     if (!map) return;
     if (!clustererRef.current) {
-      clustererRef.current = new MarkerClusterer({ map });
+      clustererRef.current = new MarkerClusterer({ map, algorithmOptions: { maxZoom: 16 } });
     }
     return () => {
       clustererRef.current?.clearMarkers();

--- a/src/components/kennels/ClusteredKennelMarkers.tsx
+++ b/src/components/kennels/ClusteredKennelMarkers.tsx
@@ -34,7 +34,7 @@ export function ClusteredKennelMarkers({ pins, selectedPinId, onSelectPin }: Clu
   useEffect(() => {
     if (!map) return;
     if (!clustererRef.current) {
-      clustererRef.current = new MarkerClusterer({ map });
+      clustererRef.current = new MarkerClusterer({ map, algorithmOptions: { maxZoom: 16 } });
     }
     return () => {
       clustererRef.current?.clearMarkers();

--- a/src/components/kennels/KennelCard.tsx
+++ b/src/components/kennels/KennelCard.tsx
@@ -50,16 +50,19 @@ export function KennelCard({ kennel }: KennelCardProps) {
 
         {/* Schedule + founded */}
         {(schedule || kennel.foundedYear) && (
-          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+          <div className="mt-2 text-xs text-muted-foreground">
             {schedule && <span>{schedule}</span>}
+            {schedule && kennel.foundedYear && <span> · </span>}
             {kennel.foundedYear && <span>Est. {kennel.foundedYear}</span>}
           </div>
         )}
 
         {/* Description */}
-        <p className="mt-2 text-xs text-muted-foreground line-clamp-2">
-          {kennel.description || <span className="italic">No description yet</span>}
-        </p>
+        {kennel.description && (
+          <p className="mt-2 text-xs text-muted-foreground line-clamp-2">
+            {kennel.description}
+          </p>
+        )}
 
         {/* Spacer to push next run to bottom */}
         <div className="flex-1" />

--- a/src/components/kennels/KennelDirectory.tsx
+++ b/src/components/kennels/KennelDirectory.tsx
@@ -375,7 +375,10 @@ export function KennelDirectory({ kennels }: KennelDirectoryProps) {
           {groupKeys.map((group) => (
             <div key={group}>
               <h2 className="mb-3 text-lg font-semibold">
-                {group}{" "}
+                {group}
+                {group === "D.C. Metro" && (
+                  <span className="text-xs font-normal text-muted-foreground"> (MD · DC · VA · WV)</span>
+                )}{" "}
                 <span className="text-sm font-normal text-muted-foreground">
                   ({grouped[group].length})
                 </span>

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -1324,8 +1324,8 @@ const STATE_GROUP_MAP: Record<string, string> = {
   "Corpus Christi, TX": "Texas",
   "El Paso": "Texas",
   // Illinois / Chicagoland
-  "Chicago, IL": "Illinois",
-  "South Shore, IN": "Illinois",
+  "Chicago, IL": "Illinois + NW Indiana",
+  "South Shore, IN": "Illinois + NW Indiana",
   // California
   "San Francisco, CA": "California",
   "Oakland, CA": "California",


### PR DESCRIPTION
## Summary
Follow-up to PR #255 addressing remaining items from the UX re-audit.

- **Cap MarkerClusterer maxZoom at 16** on both maps — prevents tile rendering failure when clusters auto-zoom to street level (zoom 18+). Also eliminates the jarring green flash on rapid cluster expansion.
- **Rename "Illinois" → "Illinois + NW Indiana"** — DLH3 (South Shore, IN) was grouped under Illinois; now geographically accurate.
- **Add "(MD · DC · VA · WV)" scope note** to D.C. Metro group header — clarifies which states are included in the cross-state group.
- **Clean up card layout** — removed "No description yet" placeholder (added visual noise), consolidated "Est. XXXX" into schedule line with dot separator.

## Test plan
- [ ] `/kennels` map: click a cluster → zoom should cap at level 16, tiles render correctly
- [ ] `/kennels` grid: "Illinois + NW Indiana" group appears with DLH3
- [ ] `/kennels` grid: "D.C. Metro (MD · DC · VA · WV) (11)" header visible
- [ ] `/kennels` grid: cards without descriptions show schedule + Est. on one line, no placeholder
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)