### PR TITLE
fix: bypass Clerk middleware for cron routes to unblock QStash

### DIFF
--- a/scripts/setup-qstash-schedule.ts
+++ b/scripts/setup-qstash-schedule.ts
@@ -1,0 +1,55 @@
+/**
+ * One-time script to create a QStash schedule for hourly scrape dispatch.
+ *
+ * Usage:
+ *   eval "$(fnm env)" && fnm use 20 && npx tsx scripts/setup-qstash-schedule.ts
+ *
+ * Prerequisites:
+ *   - QSTASH_TOKEN in .env
+ */
+import "dotenv/config";
+import { Client } from "@upstash/qstash";
+
+const QSTASH_TOKEN = process.env.QSTASH_TOKEN;
+const DESTINATION = "https://hashtracks.xyz/api/cron/dispatch";
+const OLD_DESTINATION = "https://hashtracks.com/api/cron/dispatch";
+
+if (!QSTASH_TOKEN) {
+  console.error("ERROR: QSTASH_TOKEN is not set in .env");
+  process.exit(1);
+}
+
+const client = new Client({ token: QSTASH_TOKEN });
+
+async function main() {
+  const existing = await client.schedules.list();
+
+  // Clean up ALL existing schedules targeting either old or current destination
+  const toDelete = existing.filter(
+    (s) => s.destination === OLD_DESTINATION || s.destination === DESTINATION,
+  );
+  for (const s of toDelete) {
+    console.log(`Deleting schedule ${s.scheduleId} (${s.destination})`);
+    await client.schedules.delete(s.scheduleId);
+    console.log("  Deleted.");
+  }
+
+  console.log(`\nCreating hourly schedule -> ${DESTINATION}`);
+
+  const schedule = await client.schedules.create({
+    destination: DESTINATION,
+    cron: "0 * * * *",
+    retries: 3,
+  });
+
+  console.log("Schedule created successfully!");
+  console.log("  Schedule ID:", schedule.scheduleId);
+  console.log("  Cron: 0 * * * * (every hour)");
+  console.log("  Destination:", DESTINATION);
+  console.log("\nVerify at: https://console.upstash.com -> QStash -> Schedules");
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -15,6 +15,12 @@ const isPublicRoute = createRouteMatcher([
 ]);
 
 export const proxy = clerkMiddleware(async (auth, request) => {
+  // Cron routes use their own auth (QStash signature / CRON_SECRET) — skip Clerk
+  const pathname = new URL(request.url).pathname;
+  if (pathname.startsWith("/api/cron")) {
+    return;
+  }
+
   if (!isPublicRoute(request)) {
     await auth.protect();
   }


### PR DESCRIPTION
## Summary
- Clerk's `createRouteMatcher` was silently blocking external QStash POST requests to `/api/cron/dispatch` with 401, despite the route being listed as public in `isPublicRoute`
- Added explicit pathname bypass in `src/proxy.ts` before the `isPublicRoute` check — cron routes use their own auth (QStash signature / CRON_SECRET)
- Added `scripts/setup-qstash-schedule.ts` to create an hourly QStash schedule for the dispatch endpoint, completing the QStash migration Phase 3 that was never finished

## Test plan
- [ ] Verify CI passes (type check, lint, tests)
- [ ] After deploy, run `npx tsx scripts/setup-qstash-schedule.ts` to create the QStash schedule
- [ ] Check QStash dashboard for successful hourly deliveries to `/api/cron/dispatch`
- [ ] Verify `lastScrapeAt` on sources updates after the next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)