### PR TITLE
Adjust intersection observer threshold for fade-in animations

### DIFF
--- a/src/components/home/HeroAnimations.tsx
+++ b/src/components/home/HeroAnimations.tsx
@@ -59,7 +59,7 @@ export function FadeInSection({
           observer.disconnect();
         }
       },
-      { threshold: 0.15 }
+      { threshold: 0 }
     );
     if (ref.current) observer.observe(ref.current);
     return () => observer.disconnect();


### PR DESCRIPTION
## Summary
Updated the Intersection Observer threshold in the FadeInSection component to trigger animations earlier when elements enter the viewport.

## Changes
- Modified the `threshold` option in the Intersection Observer configuration from `0.15` to `0` in `HeroAnimations.tsx`

## Details
This change adjusts when the fade-in animation is triggered. With a threshold of `0`, the animation will now begin as soon as any part of the element enters the viewport, rather than waiting for 15% of the element to be visible. This provides a more responsive animation experience and ensures animations start immediately upon viewport entry.

https://claude.ai/code/session_01Uj6vtNNZavV2HF5eTqWpNP