### PR TITLE
Claude/fix kennels animation 4 uk9 h

### DIFF
--- a/src/components/home/HeroAnimations.tsx
+++ b/src/components/home/HeroAnimations.tsx
@@ -49,7 +49,7 @@ export function FadeInSection({
   delay?: number;
   className?: string;
 }) {
-  const { ref, visible } = useInView<HTMLDivElement>();
+  const { ref, visible } = useInView<HTMLDivElement>(0);
 
   return (
     <div

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 
 /** Fire-once IntersectionObserver hook. Returns `{ ref, visible }`. */
-export function useInView<T extends Element = HTMLDivElement>(threshold = 0) {
+export function useInView<T extends Element = HTMLDivElement>(threshold = 0.2) {
   const ref = useRef<T>(null);
   const [visible, setVisible] = useState(false);
   useEffect(() => {


### PR DESCRIPTION
Review summary:

All three agents found the same issue — changing useInView's default threshold from 0.2 to 0 silently affected 7 other consumers (logbook charts/stats) that relied on the old default for their animation timing.

Fixed: Restored the hook default to 0.2 and passed threshold=0 explicitly in FadeInSection. This keeps the kennels fix while preserving existing behavior for logbook components.

Other findings were non-issues (imports still needed by AnimatedCounter, JSDoc still accurate). The AnimatedCounter inline observer was noted as a potential future reuse opportunity but it has different enough logic (animation loop, hasAnimated guard, threshold: 0.3) that it's not worth forcing into useInView.