### PR TITLE
Rewrite SOH4 adapter: iCal → HTML page scraping

### DIFF
--- a/src/adapters/html-scraper/soh4.test.ts
+++ b/src/adapters/html-scraper/soh4.test.ts
@@ -148,6 +148,16 @@ describe("parseTrailPageHtml", () => {
     const result = parseTrailPageHtml(html);
     expect(result.hares).toBe("Solo Runner");
   });
+
+  it("extracts text from span-wrapped values", () => {
+    const html = `<div class="em-event-single">
+      <strong>Hares:</strong> <span>Wrapped Hare</span> </br>
+      <strong>Location:</strong> <em><a href="https://maps.app.goo.gl/test">Nested Link Park</a></em> </br>
+    </div>`;
+    const result = parseTrailPageHtml(html);
+    expect(result.hares).toBe("Wrapped Hare");
+    expect(result.location).toBe("Nested Link Park");
+  });
 });
 
 // ── parseRssItems ──

--- a/src/adapters/html-scraper/soh4.ts
+++ b/src/adapters/html-scraper/soh4.ts
@@ -62,9 +62,15 @@ export function parseTrailPageHtml(html: string): {
       if (node.type === "tag") {
         const tag = (node as Element).tagName?.toLowerCase();
         if (tag === "br" || tag === "strong") break;
+        // Extract text from any tag (a, span, em, etc.)
+        const $node = $(node);
+        text += $node.text().trim();
+        // Capture href from <a> tags (or nested <a> inside other tags)
         if (tag === "a") {
-          text += $(node).text().trim();
-          href = $(node).attr("href");
+          href = $node.attr("href");
+        } else {
+          const nestedLink = $node.find("a").last();
+          if (nestedLink.length) href = nestedLink.attr("href");
         }
       } else if (node.type === "text") {
         text += (node as Text).data || "";
@@ -268,8 +274,7 @@ export class SOH4Adapter implements SourceAdapter {
           let title: string | undefined = fields.title || rssTitle;
           // Clean up title — remove "Trail #NNN" prefix and site suffix
           if (title) {
-            title = title.replace(/^Trail\s*#?\d+\s*[-–:]\s*/i, "").trim();
-            title = decodeEntities(title) || undefined;
+            title = title.replace(/^Trail\s*#?\d+\s*[-–:]\s*/i, "").trim() || undefined;
           }
 
           // Build description with extra metadata


### PR DESCRIPTION
## Summary
- The SOH4 iCal export never contained structured fields (hares, location, start time) — the DESCRIPTION was only a creative narrative paragraph
- Rewrites Phase 2 from iCal fetching to HTML page scraping using Cheerio DOM walking
- Parses `<strong>Label:</strong>` patterns from raw HTML (no browser rendering needed)
- Extracts: hares, location + Google Maps URL, start time, hash cash, theme, on-after
- Handles SOH4's quirky "1:69PM (AKA 2:09 pm)" time format
- Detects TBD placeholders, strips boilerplate and Maps URLs from descriptions
- RSS feed phase unchanged (trail index discovery)

## Test plan
- [x] 17 SOH4-specific tests with HTML fixtures (complete trail, TBD trail, plain text location, AKA time, boilerplate stripping, empty HTML, singular "Hare:" label)
- [x] All 2729 tests pass (117 test files)
- [x] Type check clean
- [x] Lint clean (0 errors)
- [ ] After deploy: re-scrape SOH4, verify hares/location/startTime on hareline

🤖 Generated with [Claude Code](https://claude.com/claude-code)