### PR TITLE
Fix SOH4 date: scan h4 tags (date is in h4, not p)

### DIFF
--- a/src/adapters/html-scraper/soh4.test.ts
+++ b/src/adapters/html-scraper/soh4.test.ts
@@ -7,7 +7,7 @@ import { parseTrailPageHtml, parseRssItems, extractTrailNumber } from "./soh4";
 const COMPLETE_TRAIL_HTML = `<html><body>
 <div class="em-item em-item-single em-event em-event-single em-event-617">
   <h1>Trail #822: Spring Flours</h1>
-  <p>Saturday - March 21, 2026 - 2:09 pm</p>
+  <h4>Saturday - March 21, 2026 - 2:09 pm</h4>
   <p>March weather has been at times both warm enough to start us thinking
   spring flowers and STRAWBERRY(s) but then cold enough for snow's return to
   crush our spirits to ZERO. Cum to Geddes and encourage Mother Nature to bring
@@ -28,7 +28,7 @@ const COMPLETE_TRAIL_HTML = `<html><body>
 const TBD_TRAIL_HTML = `<html><body>
 <div class="em-item em-item-single em-event em-event-single em-event-620">
   <h1>Trail #825: TBD</h1>
-  <p>Monday - April 6, 2026 - 2:09 pm</p>
+  <h4>Monday - April 6, 2026 - 2:09 pm</h4>
   <p>Trail Details TBD</p>
   <p>
     <strong>Hares:</strong> TBD </br>
@@ -55,7 +55,7 @@ const PLAIN_LOCATION_HTML = `<html><body>
 const BOILERPLATE_HTML = `<html><body>
 <div class="em-item em-item-single em-event em-event-single em-event-619">
   <h1>Trail #824: Pink Full Moon</h1>
-  <p>Wednesday - April 1, 2026 - 6:09 pm</p>
+  <h4>Wednesday - April 1, 2026 - 6:09 pm</h4>
   <p>Come run with us under the full moon!</p>
   <p>https://maps.app.goo.gl/abc123</p>
   <p>Please include hash name and date of trail in description.</p>
@@ -164,7 +164,7 @@ describe("parseTrailPageHtml", () => {
   it("extracts correct date even with calendar widget and upcumming trails in container", () => {
     const html = `<div class="em-event-single">
       <h1>Trail #824: Pink Full Moon</h1>
-      <p>Wednesday - April 1, 2026 - 6:09 pm</p>
+      <h4>Wednesday - April 1, 2026 - 6:09 pm</h4>
       <p>Trail Details TBD</p>
       <p><strong>Hares:</strong> TBD </br></p>
       <p>Saturday - March 21, 2026: Trail #822: Spring Flours

--- a/src/adapters/html-scraper/soh4.ts
+++ b/src/adapters/html-scraper/soh4.ts
@@ -81,18 +81,19 @@ export function parseTrailPageHtml(html: string): {
     if (text) fields[key] = { text, href };
   });
 
-  // SOH4 date format in <p> tags: "DayOfWeek - Month DD, YYYY - H:MM pm"
+  // SOH4 date format: "DayOfWeek - Month DD, YYYY - H:MM pm"
   const DATE_LINE_RE = /(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\s*-\s*(\w+ \d{1,2},\s*\d{4})/i;
 
-  // Single pass over <p> elements to extract date and description.
+  // Single pass over headings and paragraphs to extract date and description.
+  // The date is in an <h4> tag (Cheerio parses it as heading, not paragraph).
   // The container includes a calendar widget and "Upcumming Trails" list with
   // other dates, so we target the specific SOH4 date format and stop before
   // labels, the trail list, or the calendar section.
   let date: string | undefined;
   const descParagraphs: string[] = [];
-  container.find("p").each((_i, el) => {
+  container.find("h1, h2, h3, h4, p").each((_i, el) => {
     const pText = decodeEntities($(el).text().replace(/\s+/g, " ").trim());
-    // Extract date from the first matching <p>
+    // Extract date from the first matching element
     const dateMatch = !date ? DATE_LINE_RE.exec(pText) : null;
     if (dateMatch) {
       date = chronoParseDate(dateMatch[1], "en-US") ?? undefined;


### PR DESCRIPTION
## Summary
The SOH4 date line renders as `<h4>Wednesday - April 1, 2026 - 6:09 pm</h4>` in Cheerio's DOM, but the code only scanned `container.find("p")`. This caused 18/19 events to fail with "No date in HTML or RSS title".

**Fix**: Scan `"h1, h2, h3, h4, p"` elements instead of just `"p"`.

## Test plan
- [x] 19 tests pass (fixtures updated to use `<h4>` matching real DOM)
- [x] Type check clean
- [ ] After deploy: re-scrape SOH4, verify all 19 events parse with correct dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)