### PR TITLE
fix: tighten Strava scoring — generic name detection, no-geo nameScore gate

### DIFF
--- a/src/app/strava/actions.ts
+++ b/src/app/strava/actions.ts
@@ -83,7 +83,12 @@ function findBestEventMatch<
       bestBreakdown = breakdown;
     }
   }
-  if (!bestEvent || !bestBreakdown || bestScore < threshold) return null;
+  if (!bestEvent || !bestBreakdown || bestScore <= threshold) return null;
+
+  // When no geo signal exists, require a meaningful name match to prevent
+  // short-string false positives (e.g., "NYC H3" vs "BARH3" = 0.333)
+  if (!bestBreakdown.hasGeoSignal && bestBreakdown.nameScore < 0.5) return null;
+
   return { event: bestEvent, score: bestScore, breakdown: bestBreakdown };
 }
 

--- a/src/lib/strava/match-score.test.ts
+++ b/src/lib/strava/match-score.test.ts
@@ -8,7 +8,7 @@ describe("scoreMatch", () => {
       null,
     );
     const lowMatch = scoreMatch(
-      { activityName: "Morning Run", stravaSportType: "Run", stravaTimeLocal: null },
+      { activityName: "Central Park Loop", stravaSportType: "Run", stravaTimeLocal: null },
       "Brooklyn H3",
       null,
     );
@@ -52,15 +52,45 @@ describe("scoreMatch", () => {
     expect(score.total).toBeGreaterThan(0);
   });
 
-  it("scores low for generic activity names (filtered by threshold in suggestions)", () => {
-    const score = scoreMatch(
+  it("zeros nameScore for generic activity names", () => {
+    const generic = scoreMatch(
       { activityName: "Morning Run", stravaSportType: "Run", stravaTimeLocal: null },
       "BH3",
       null,
     );
-    // Generic names still score (for findBestMatchIndex) but below suggestion threshold (2.0)
-    expect(score.total).toBeLessThan(2.0);
-    expect(score.total).toBeGreaterThan(0);
+    expect(generic.nameScore).toBe(0);
+
+    const afternoon = scoreMatch(
+      { activityName: "Afternoon Walk", stravaSportType: "Walk", stravaTimeLocal: null },
+      "NYCH3",
+      null,
+    );
+    expect(afternoon.nameScore).toBe(0);
+
+    // Non-generic name still scores normally
+    const specific = scoreMatch(
+      { activityName: "NYC H3", stravaSportType: "Run", stravaTimeLocal: null },
+      "NYCH3",
+      null,
+    );
+    expect(specific.nameScore).toBeGreaterThan(0);
+  });
+
+  it("includes hasGeoSignal in breakdown", () => {
+    const noGeo = scoreMatch(
+      { activityName: "Brooklyn H3", stravaSportType: "Run", stravaTimeLocal: null },
+      "Brooklyn H3",
+      null,
+    );
+    expect(noGeo.hasGeoSignal).toBe(false);
+
+    const withGeo = scoreMatch(
+      { activityName: "Brooklyn H3", stravaSportType: "Run", stravaTimeLocal: null, startLat: 40.7, startLng: -74.0 },
+      "Brooklyn H3",
+      null,
+      40.7, -74.0,
+    );
+    expect(withGeo.hasGeoSignal).toBe(true);
   });
 
   it("returns breakdown with geoKm when coords provided", () => {

--- a/src/lib/strava/match-score.ts
+++ b/src/lib/strava/match-score.ts
@@ -21,21 +21,15 @@ export interface ScoreBreakdown {
   nameScore: number;
   geoScore: number;
   geoKm: number | null; // actual distance in km, null if coords missing
+  hasGeoSignal: boolean; // true if either side had coordinates
   timeScore: number;
   sportBonus: number;
 }
 
 const RUN_TYPES = new Set(["Run", "TrailRun", "VirtualRun"]);
 
-/** Zero breakdown returned on early-exit (e.g. generic activity names). */
-const ZERO_BREAKDOWN: ScoreBreakdown = {
-  total: 0,
-  nameScore: 0,
-  geoScore: 0,
-  geoKm: null,
-  timeScore: 0,
-  sportBonus: 0,
-};
+/** Generic activity names that carry no kennel-identity signal. */
+const GENERIC_NAME = /^(morning|afternoon|evening|lunch|night|daily)?\s*(run|walk|ride|hike|workout|jog|yoga|swim)s?$/i;
 
 /**
  * Score a Strava activity against an event for match quality.
@@ -51,11 +45,10 @@ export function scoreMatch(
   eventLng?: number | null,
 ): ScoreBreakdown {
   // 1. Name match (0–1, weighted 3x)
-  const nameScore = fuzzyNameMatch(activity.activityName, kennelShortName);
-
-  // Low name scores get scored but won't pass the suggestion threshold (2.0).
-  // We still compute the full breakdown so findBestMatchIndex can rank by time/geo
-  // even when all candidates have generic names like "Afternoon Run".
+  // Generic names like "Afternoon Run" carry zero kennel-identity signal
+  const nameScore = GENERIC_NAME.test(activity.activityName.trim())
+    ? 0
+    : fuzzyNameMatch(activity.activityName, kennelShortName);
 
   // 2. Geo proximity (weighted 2x)
   // When activity has GPS but event doesn't, penalize to prevent cross-continent matches
@@ -94,7 +87,8 @@ export function scoreMatch(
   // Weighted combination: name×3 + geo×2 + time×1 + sport×0.2
   const total = nameScore * 3 + geoScore * 2 + timeScore + sportBonus;
 
-  return { total, nameScore, geoScore, geoKm, timeScore, sportBonus };
+  const hasGeoSignal = activityHasCoords || eventHasCoords;
+  return { total, nameScore, geoScore, geoKm, hasGeoSignal, timeScore, sportBonus };
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses cross-continent suggestion issue reported in PR #282 comment. Three specific fixes:

### 1. Generic activity name detection
Names like "Morning Run", "Afternoon Walk", "Run" now get `nameScore=0`. Pattern: `/^(morning|afternoon|evening|lunch|night|daily)?\s*(run|walk|ride|hike|workout|jog|yoga|swim)s?$/i`. These names carry zero kennel-identity signal.

### 2. No-geo nameScore gate
When neither Strava activity nor event has GPS coordinates, require `nameScore >= 0.5` to pass. This blocks short-string false positives:
- `fuzzy("NYC H3", "BARH3") = 0.333` → **blocked** (< 0.5)
- `fuzzy("Afternoon Run", "Dayton H4") = 0` → **blocked** (generic name)
- `fuzzy("NYC H3", "NYCH3") ≈ 0.8` → **allowed** (actual kennel match)

### 3. Threshold boundary fix
Changed `< threshold` to `<= threshold` so exactly 2.000 doesn't pass. Blocks the `fuzzy("Sav H3", "HVH3") = 0.500 → total = 2.000` edge case.

### Added `hasGeoSignal` to ScoreBreakdown
Boolean flag indicating whether either side had coordinates, for scoring transparency.

## Test plan
- [ ] TypeScript compiles clean, 101 tests pass
- [ ] "Afternoon Run" vs any kennel → nameScore=0, blocked
- [ ] "NYC H3" vs "BARH3" (no geo) → nameScore=0.333, blocked by 0.5 gate
- [ ] "NYC H3" vs "NYCH3" (no geo) → nameScore≈0.8, allowed
- [ ] "Sav H3" vs "HVH3" → total=2.0, blocked (threshold now exclusive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)