### PR TITLE
fix: require nameScore >= 0.6 when geo doesn't confirm proximity (#297)

### DIFF
--- a/src/app/strava/actions.ts
+++ b/src/app/strava/actions.ts
@@ -89,9 +89,11 @@ function findBestEventMatch<
   }
   if (!bestEvent || !bestBreakdown || bestScore <= threshold) return null;
 
-  // When no geo signal exists, require a meaningful name match to prevent
-  // short-string false positives (e.g., "NYC H3" vs "BARH3" = 0.333)
-  if (!bestBreakdown.hasGeoSignal && bestBreakdown.nameScore < 0.5) return null;
+  // When geo doesn't confirm proximity (score 0 or negative), require a
+  // strong name match. Blocks cross-geography false positives like
+  // "Sav H3" vs "HVH3" (0.5) and "NYC H3" vs "W3H3" (0.33) while
+  // allowing "NYC H3" vs "NYCH3" (0.83).
+  if (bestBreakdown.geoScore <= 0 && bestBreakdown.nameScore < 0.6) return null;
 
   return { event: bestEvent, score: bestScore, breakdown: bestBreakdown };
 }


### PR DESCRIPTION
## Summary

Fixes #297 — two remaining cross-geography false matches.

### The bug
"Sav H3" (Savannah, GA) was matching HVH3 (MA) and "NYC H3" (Manhattan) was matching W3H3 (WV). Both had GPS coords on both sides, but were hundreds of km apart. The nameScore gate (`nameScore >= 0.5 when !hasGeoSignal`) didn't fire because `hasGeoSignal=true` — coords existed, just far apart.

### The fix
Changed the gate condition from:
```
!hasGeoSignal && nameScore < 0.5
```
To:
```
geoScore <= 0 && nameScore < 0.6
```

This fires whenever geo **doesn't confirm proximity** (score 0 or negative) — regardless of whether coords exist. The 0.6 threshold was set based on verified fuzzy scores:

| Match | fuzzyNameMatch | Result |
|-------|---------------|--------|
| "Sav H3" vs "HVH3" | 0.500 | BLOCKED (< 0.6) |
| "NYC H3" vs "W3H3" | 0.333 | BLOCKED (< 0.6) |
| "NYC H3" vs "NYCH3" | 0.833 | ALLOWED (>= 0.6) |
| "BH3" vs "Boston H3" | 0.333 | BLOCKED without geo, ALLOWED with within-5km geo |

Closes #297

## Test plan
- [ ] TypeScript compiles clean
- [ ] All existing tests pass
- [ ] "Sav H3" vs HVH3 (Savannah→MA) no longer suggested
- [ ] "NYC H3" vs W3H3 (Manhattan→WV) no longer suggested
- [ ] "NYC H3" vs NYCH3 (valid same-city match) still works
- [ ] Matches with strong geo (Within 0-25km) still work regardless of name

🤖 Generated with [Claude Code](https://claude.com/claude-code)