### PR TITLE
fix: add Phoenix H3 Big Ass Calendar source to seed data

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1861,6 +1861,25 @@ export const SOURCES = [
       },
       kennelCodes: ["lbh-phx", "hump-d", "wrong-way", "fdtdd"],
     },
+    // --- Phoenix (HTML Scraper — Big Ass Calendar) ---
+    {
+      name: "Phoenix H3 Big Ass Calendar",
+      url: "https://www.phoenixhhh.org/?page_id=21",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 8,
+      scrapeFreq: "weekly",
+      scrapeDays: 365,
+      config: {
+        kennelPatterns: [
+          ["^LBH\\b|Lost Boobs", "LBH"],
+          ["Hump D", "Hump D"],
+          ["Wrong Way", "Wrong Way"],
+          ["Dusk.*Down|FDTDD", "FDTDD"],
+        ],
+        defaultKennelTag: "Wrong Way",
+      },
+      kennelCodes: ["lbh-phx", "hump-d", "wrong-way", "fdtdd"],
+    },
     // --- Tucson (Google Calendar — per-kennel) ---
     {
       name: "jHavelina H3 Google Calendar",


### PR DESCRIPTION
## Summary

The Phoenix H3 Big Ass Calendar HTML scraper adapter was merged in PR #307 but the source record in `prisma/seed-data/sources.ts` was not included in that commit. This adds the missing source entry so `npx prisma db seed` creates the source.

## What it adds

```
Phoenix H3 Big Ass Calendar
  type: HTML_SCRAPER
  url: https://www.phoenixhhh.org/?page_id=21
  trustLevel: 8
  scrapeDays: 365
  kennelCodes: lbh-phx, hump-d, wrong-way, fdtdd
```

## Test plan
- [ ] `npx prisma db seed` — should show `+ Created source: Phoenix H3 Big Ass Calendar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)