### PR TITLE
Split BFM/Philly H3 calendars + strip instruction text from titles

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -92,13 +92,12 @@ export const SOURCES = [
       config: {
         kennelPatterns: [
           ["BFM|Ben Franklin|BFMH3", "BFM"],
-          ["Philly Hash|hashphilly|Philly H3", "Philly H3"],
           ["Main Line", "Main Line H3"],
           ["TTH3", "TTH3"],
         ],
         defaultKennelTag: "BFM",
       },
-      kennelCodes: ["bfm", "philly-h3"],
+      kennelCodes: ["bfm"],
     },
     {
       name: "Philly H3 Google Calendar",
@@ -109,12 +108,11 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         kennelPatterns: [
-          ["BFM|Ben Franklin|BFMH3", "BFM"],
           ["Philly Hash|hashphilly|Philly H3", "Philly H3"],
         ],
         defaultKennelTag: "Philly H3",
       },
-      kennelCodes: ["bfm", "philly-h3"],
+      kennelCodes: ["philly-h3"],
     },
     {
       name: "BFM Website",

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -841,6 +841,14 @@ describe("sanitizeTitle", () => {
   it("collapses extra whitespace after date removal", () => {
     expect(sanitizeTitle("SOCO #13  3/20/26  Spring Equinox")).toBe("SOCO #13 Spring Equinox");
   });
+
+  it("strips parenthetical instruction text from title", () => {
+    expect(sanitizeTitle("Philly Hash (See: hashphilly.com for details)")).toBe("Philly Hash");
+  });
+
+  it("strips 'Visit' instruction variant", () => {
+    expect(sanitizeTitle("Weekly Run (Visit our website for info)")).toBe("Weekly Run");
+  });
 });
 
 // ── sanitizeHares ──

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -334,6 +334,8 @@ export function sanitizeTitle(title: string | undefined): string | null {
   cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
   // Strip embedded email addresses
   cleaned = cleaned.replace(/\s*<?[\w.+-]+@[\w.-]+>?\s*/g, " ").trim();
+  // Strip parenthetical instruction text (e.g., "(See: hashphilly.com for details)")
+  cleaned = cleaned.replace(/\s*\((?:See|Visit|Check|Go to)[:\s].+?\)/gi, "").trim();
   return cleaned || null;
 }
 


### PR DESCRIPTION
## Summary
BFM and Philly H3 shared two Google Calendar sources — each had `kennelPatterns` parsing events for BOTH kennels. This caused:
- BFM's stale "O'Neals" location showing on ~40 future recurring events
- Cross-kennel event attribution
- GCal's generic "Ben Franklin Mob H3" title overriding the HTML scraper's specific trail names during merge

**Fix:** Each calendar now serves only its own kennel. Removed cross-kennel patterns and kennel codes from both sources.

Also strips parenthetical instruction text from titles (e.g., "(See: hashphilly.com for details)").

## Audit issues addressed
| # | Issue | Fix |
|---|-------|-----|
| 1 | BFM stale O'Neals location | Calendar split eliminates cross-pollination |
| 2 | BFM generic title | Calendar split — website scraper title now wins merge |
| 3 | BFM hare names lost in merge | Calendar split — no competing GCal events |
| 6 | Duplicate series | Calendar split — only BFM events from BFM calendar |
| 7 | Philly instruction text | sanitizeTitle strips "(See: ... for details)" |

## Test plan
- [x] 726 merge tests pass (2 new instruction-text tests)
- [ ] After deploy + seed: re-scrape BFM and Philly H3
- [ ] Verify BFM future events show no "O'Neals" location
- [ ] Verify Philly H3 title shows "Philly Hash" not "(See: hashphilly.com...)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)