### PR TITLE
feat: add skipPatterns to Google Calendar adapter (closes #311)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -111,6 +111,7 @@ export const SOURCES = [
           ["Philly Hash|hashphilly|Philly H3", "Philly H3"],
         ],
         defaultKennelTag: "Philly H3",
+        skipPatterns: ["BFM|Ben Franklin|BFMH3"],
       },
       kennelCodes: ["philly-h3"],
     },

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -358,6 +358,52 @@ describe("buildRawEventFromGCalItem — all-day events", () => {
   });
 });
 
+// ── buildRawEventFromGCalItem — skipPatterns ──
+
+describe("buildRawEventFromGCalItem — skipPatterns", () => {
+  const baseItem = {
+    summary: "BFM Special Trail",
+    start: { dateTime: "2026-04-02T18:30:00-05:00" },
+    status: "confirmed" as const,
+  };
+
+  it("skips events matching a skipPattern", () => {
+    const skipPatterns = [/BFM|Ben Franklin/i];
+    const result = buildRawEventFromGCalItem(
+      baseItem,
+      { defaultKennelTag: "Philly H3" },
+      undefined,
+      undefined,
+      skipPatterns,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("does not skip events that don't match skipPatterns", () => {
+    const skipPatterns = [/BFM|Ben Franklin/i];
+    const result = buildRawEventFromGCalItem(
+      { ...baseItem, summary: "Philly Hash Weekly Run" },
+      { defaultKennelTag: "Philly H3" },
+      undefined,
+      undefined,
+      skipPatterns,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.kennelTag).toBe("Philly H3");
+  });
+
+  it("works with empty skipPatterns array", () => {
+    const result = buildRawEventFromGCalItem(
+      baseItem,
+      { defaultKennelTag: "TEST" },
+      undefined,
+      undefined,
+      [],
+    );
+    expect(result).not.toBeNull();
+  });
+});
+
 // ── extractTitleFromDescription ──
 
 describe("extractTitleFromDescription", () => {

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -164,6 +164,7 @@ const mapsUrl = googleMapsSearchUrl;
 interface CalendarSourceConfig {
   kennelPatterns?: [string, string][];  // [[regex, kennelTag], ...]
   defaultKennelTag?: string;            // fallback for unrecognized events
+  skipPatterns?: string[];              // regex strings — skip events whose summary matches
   harePatterns?: string[];              // regex strings to extract hares from descriptions
   runNumberPatterns?: string[];         // regex strings to extract run numbers from descriptions
   descriptionSuffix?: string;           // appended to every event description
@@ -263,6 +264,7 @@ export function buildRawEventFromGCalItem(
   sourceConfig: CalendarSourceConfig | null,
   compiledHarePatterns?: RegExp[],
   compiledRunNumberPatterns?: RegExp[],
+  compiledSkipPatterns?: RegExp[],
 ): RawEventData | null {
   if (item.status === "cancelled") return null;
   if (!item.summary) return null;
@@ -273,6 +275,13 @@ export function buildRawEventFromGCalItem(
   const { dateISO, startTime } = extractDateTimeFromGCalItem(item.start);
   if (!dateISO) return null;
   const summary = decodeEntities(item.summary);
+
+  // Skip events whose summary matches any configured skip pattern (e.g., cross-kennel posts)
+  if (compiledSkipPatterns?.length) {
+    for (const re of compiledSkipPatterns) {
+      if (re.test(summary)) return null;
+    }
+  }
   const { rawDescription, description } = normalizeGCalDescription(item.description);
   const hares = rawDescription ? extractHares(rawDescription, compiledHarePatterns) : undefined;
   const { kennelTag, useFullTitle } = resolveKennelTagFromSummary(summary, sourceConfig);
@@ -340,6 +349,9 @@ export class GoogleCalendarAdapter implements SourceAdapter {
     const compiledRunNumberPatterns = sourceConfig?.runNumberPatterns?.length
       ? compilePatterns(sourceConfig.runNumberPatterns)
       : undefined;
+    const compiledSkipPatterns = sourceConfig?.skipPatterns?.length
+      ? compilePatterns(sourceConfig.skipPatterns, "i")
+      : undefined;
 
     do {
       const url = new URL(
@@ -382,7 +394,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
 
       for (const item of items) {
         try {
-          const event = buildRawEventFromGCalItem(item, sourceConfig, compiledHarePatterns, compiledRunNumberPatterns);
+          const event = buildRawEventFromGCalItem(item, sourceConfig, compiledHarePatterns, compiledRunNumberPatterns, compiledSkipPatterns);
           if (event) events.push(event);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
Closes #311. The Google Calendar adapter had no mechanism to silently skip events by title pattern. BFM cross-posts on the Philly H3 calendar fell through to `defaultKennelTag: "Philly H3"` instead of being dropped.

**Changes:**
- Add `skipPatterns?: string[]` to `CalendarSourceConfig`
- Pre-compile once per scrape using `compilePatterns()` (same as harePatterns)
- Apply skip guard in `buildRawEventFromGCalItem()` before any parsing
- Add `skipPatterns: ["BFM|Ben Franklin|BFMH3"]` to Philly H3 GCal source config

Follows the same pattern as the iCal adapter's existing `skipPatterns` support.

## Test plan
- [x] 401 GCal adapter tests pass (3 new skipPatterns tests)
- [ ] After deploy + seed: re-scrape Philly H3 calendar
- [ ] Verify BFM cross-posts no longer appear as Philly H3 events

🤖 Generated with [Claude Code](https://claude.com/claude-code)