### PR TITLE
fix: resolve 3 RIH3 scraper bugs from first live scrape

### DIFF
--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -263,7 +263,7 @@ describe("parseHarelineRow", () => {
     expect(parseHarelineRow(["Mon April 6"], "", "", SOURCE_URL)).toBeNull();
   });
 
-  it("excludes Facebook and song links from description", () => {
+  it("preserves Facebook link as text with URL in description", () => {
     const cells = ["Mon April 21", "6:30 PM", "2043"];
     const result = parseHarelineRow(
       cells,
@@ -272,9 +272,60 @@ describe("parseHarelineRow", () => {
       SOURCE_URL,
     );
 
-    expect(result?.description).not.toContain("facebook");
+    expect(result?.description).toContain("facebook.com/groups");
+    expect(result?.description).toContain("See the RIH3 facebook Page");
     expect(result?.description).not.toContain("Song of the Week");
     expect(result?.description).toContain("monsoon slog");
+  });
+
+  it("strips song links from description", () => {
+    const cells = ["Mon April 21", "6:30 PM", "2043"];
+    const result = parseHarelineRow(
+      cells,
+      HARE_SINGLE,
+      DIRECTION_WITH_MAPS,
+      SOURCE_URL,
+    );
+
+    expect(result?.description).not.toContain("Santa Claus");
+    expect(result?.description).not.toContain("Song of the Week");
+  });
+
+  it("strips leading comma from description (Bug #3)", () => {
+    const directionWithComma = `
+<p>,</p>
+<h2>This Hash will bring tears to your eyes</h2>
+<br/><br/><br/>
+Basket says, "Check out the Receding Hareline..."
+<br/><br/>
+<p><a href="https://www.facebook.com/groups/120140164667510">See the RIH3 facebook Page</a></p>
+`;
+    const cells = ["Mon March 30", "6:30 PM", "2092"];
+    const result = parseHarelineRow(
+      cells,
+      HARE_SINGLE,
+      directionWithComma,
+      SOURCE_URL,
+    );
+
+    expect(result?.description).not.toMatch(/^[,\s]/);
+    expect(result?.description).toContain("Basket says");
+  });
+
+  it("resolves same-day date to current year, not next year (Bug #1)", () => {
+    // Simulate scrape running at 2:30 PM on March 23, 2026
+    const midDayRef = new Date(2026, 2, 23, 14, 30, 0);
+    const cells = ["Mon March 23", "6:30 PM", "2091"];
+    const result = parseHarelineRow(
+      cells,
+      HARE_SINGLE,
+      "",
+      SOURCE_URL,
+      midDayRef,
+    );
+
+    // Should still be 2026, NOT 2027
+    expect(result?.date).toBe("2026-03-23");
   });
 });
 

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -79,7 +79,15 @@ export function parseHarelineRow(
   // --- Date (year-less, e.g., "Mon March 23") ---
   const rawDate = cells[0]?.trim();
   if (!rawDate) return null;
-  const date = chronoParseDate(rawDate, "en-US", referenceDate, {
+  // Normalize reference to start-of-day to prevent forwardDate from advancing
+  // same-day events to next year (chrono parses year-less dates as midnight,
+  // which is "before" a mid-day reference → year drift)
+  let ref = referenceDate;
+  if (ref) {
+    ref = new Date(ref);
+    ref.setHours(0, 0, 0, 0);
+  }
+  const date = chronoParseDate(rawDate, "en-US", ref, {
     forwardDate: true,
   });
   if (!date) return null;
@@ -122,17 +130,23 @@ export function parseHarelineRow(
   const location =
     locationText && locationText.length > 3 ? locationText : undefined;
 
-  // Description: body text minus title, Facebook boilerplate, song links
+  // Description: body text minus title and song links; preserve Facebook link
   const descRoot = dir$("body").clone();
   descRoot.find("h2").remove();
   descRoot
-    .find(
-      'a[href*="facebook.com/groups"], a[href*="Songs/"], a[href$=".txt"], a[href$=".rtf"]',
-    )
+    .find('a[href*="Songs/"], a[href$=".txt"], a[href$=".rtf"]')
     .closest("p")
     .remove();
+  // Convert Facebook link to plain text with URL instead of removing it
+  descRoot.find('a[href*="facebook.com/groups"]').each((_, a) => {
+    const $a = dir$(a);
+    const href = $a.attr("href") ?? "";
+    const text = $a.text().trim();
+    $a.replaceWith(`${text} (${href})`);
+  });
   const description =
-    descRoot.text().replace(/\s+/g, " ").trim() || undefined;
+    descRoot.text().replace(/\s+/g, " ").trim().replace(/^[,\s]+/, "") ||
+    undefined;
 
   return {
     date,


### PR DESCRIPTION
## Summary
- **Year drift fix**: normalize referenceDate to midnight in `parseHarelineRow` so `forwardDate` doesn't advance same-day events to next year (e.g., "Mon March 23" scraped at 2:30 PM → 2027 instead of 2026)
- **Facebook link preservation**: convert the Facebook group link to plain text with URL instead of stripping it from descriptions
- **Leading comma fix**: strip stray leading punctuation from descriptions (Mar 30 directions cell has a literal comma before the H2)

## Test plan
- [x] 3 regression tests added covering each bug
- [x] 28/28 RIH3 adapter tests pass
- [x] Full test suite passes (2601/2601)
- [ ] Delete stale Mar 23 2026 + incorrect Mar 23 2027 events from DB, then re-scrape RIH3 source

🤖 Generated with [Claude Code](https://claude.com/claude-code)