### PR TITLE
fix: remove duplicate Michigan kennel entries in seed data

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1794,30 +1794,6 @@ export const KENNELS: KennelSeed[] = [
       description: "Greater Lansing biweekly Saturday hash. Trail #1042+ and counting.",
       latitude: 42.73, longitude: -84.56,
     },
-    // ===== MICHIGAN =====
-    {
-      kennelCode: "moa2h3", shortName: "MoA2H3", fullName: "Motown Ann Arbor Hash House Harriers", region: "Detroit, MI",
-      website: "https://moa2h3.org",
-      facebookUrl: "https://www.facebook.com/MOA2H3",
-      scheduleDayOfWeek: "Sunday", scheduleTime: "2:00 PM", scheduleFrequency: "Weekly",
-      description: "Metro Detroit and Ann Arbor's weekly Sunday hash. The largest kennel in Michigan.",
-      latitude: 42.33, longitude: -83.05,
-    },
-    {
-      kennelCode: "demon-h3", shortName: "DeMon", fullName: "DeMon Hash House Harriers", region: "Detroit, MI",
-      website: "https://demonh3.com",
-      scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
-      description: "Detroit's Monday evening hash.",
-      latitude: 42.33, longitude: -83.05,
-    },
-    {
-      kennelCode: "glh3", shortName: "GLH3", fullName: "Greater Lansing Hash House Harriers", region: "Lansing, MI",
-      website: "https://glh3.net",
-      scheduleDayOfWeek: "Saturday", scheduleTime: "3:00 PM", scheduleFrequency: "Biweekly",
-      hashCash: "$10",
-      description: "Greater Lansing biweekly Saturday hash. Trail #1042+ and counting.",
-      latitude: 42.73, longitude: -84.56,
-    },
     // ===== ARIZONA =====
     // Phoenix
     {


### PR DESCRIPTION
Michigan kennels (MoA2H3, DeMon, GLH3) were added twice — once from PR #315 and once from the UK PR's file copy. Removes the duplicate block so `npx prisma db seed` runs without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)