### PR TITLE
feat: replace Surf City H3 static schedule with Google Calendar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ logbook + kennel directory.
 ### SF Bay Area (3 sources)
 - **SFH3 MultiHash iCal Feed** → ICAL_FEED → 13 SF Bay Area kennels
 - **SFH3 MultiHash HTML Hareline** → HTML_SCRAPER → 13 SF Bay Area kennels (secondary)
-- **Surf City H3 Static Schedule** → STATIC_SCHEDULE → SCH3 (Santa Cruz)
+- **Surf City H3 Google Calendar** → GOOGLE_CALENDAR → SCH3 (Santa Cruz)
 
 ### Southern California (12 sources)
 - **LAH3 Google Calendar** → GOOGLE_CALENDAR → LAH3

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2034,23 +2034,15 @@ export const SOURCES = [
       kennelCodes: ["pedalfiles"],
     },
     // ===== CALIFORNIA =====
-    // --- Santa Cruz (Static Schedule) ---
+    // --- Santa Cruz (Google Calendar) ---
     {
-      name: "Surf City H3 Static Schedule",
-      url: "https://www.sch3.net",
-      type: "STATIC_SCHEDULE" as const,
-      trustLevel: 3,
-      scrapeFreq: "weekly",
+      name: "Surf City H3 Google Calendar",
+      url: "SCH3Calendar@gmail.com",
+      type: "GOOGLE_CALENDAR" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
       scrapeDays: 90,
-      config: {
-        kennelTag: "SCH3",
-        rrule: "FREQ=WEEKLY;BYDAY=TH",
-        startTime: "18:30",
-        timezone: "America/Los_Angeles",
-        defaultTitle: "SCH3 Weekly Thursday Hash",
-        defaultLocation: "Santa Cruz, CA — check Facebook for details",
-        defaultDescription: "Weekly Thursday evening hash in Santa Cruz.",
-      },
+      config: { defaultKennelTag: "SCH3" },
       kennelCodes: ["sch3-ca"],
     },
     // --- Los Angeles Area (Google Calendar) ---


### PR DESCRIPTION
Replace the SCH3 STATIC_SCHEDULE source (26 identical placeholder events) with a GOOGLE_CALENDAR source using `SCH3Calendar@gmail.com` found embedded on sch3.net.

The calendar should provide real event titles, locations, run numbers, and hares instead of generic "SCH3 Weekly Thursday Hash" placeholders.

Config: `defaultKennelTag: "SCH3"`, daily scrape, trustLevel 7.

## Test plan
- [ ] `npx prisma db seed` — creates new source
- [ ] Manual scrape — verify real event data appears
- [ ] Delete old static schedule source from admin after confirming

🤖 Generated with [Claude Code](https://claude.com/claude-code)