### PR TITLE
fix: HashRego scrape using 9 slugs instead of 108 (all-or-nothing guard)

### DIFF
--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -308,17 +308,15 @@ export async function scrapeSource(
     const adapter = getAdapter(source.type, source.url, source.config as Record<string, unknown> | null);
 
     // For HASHREGO, load SourceKennel externalSlugs and pass to adapter.
-    // Only use DB slugs when every linked kennel has been backfilled;
-    // otherwise fall back to config.kennelSlugs via undefined.
+    // Use all available DB slugs; fall back to config only when zero exist.
     let kennelSlugs: string[] | undefined;
     if (source.type === "HASHREGO") {
       const sks = await prisma.sourceKennel.findMany({
-        where: { sourceId },
+        where: { sourceId, externalSlug: { not: null } },
         select: { externalSlug: true },
       });
-      const dbSlugs = sks.flatMap((sk) => sk.externalSlug ? [sk.externalSlug] : []);
-      const hasMissingExternalSlugs = sks.some((sk) => !sk.externalSlug);
-      kennelSlugs = hasMissingExternalSlugs ? undefined : dbSlugs;
+      const dbSlugs = sks.map((sk) => sk.externalSlug!);
+      kennelSlugs = dbSlugs.length > 0 ? dbSlugs : undefined;
     }
 
     const fetchStart = Date.now();


### PR DESCRIPTION
## Summary
- The partial-migration guard in `scrape.ts` required **every** SourceKennel to have `externalSlug` before using DB slugs. With 99/108 rows null, it fell back to `config.kennelSlugs` (9 slugs), dropping events from ~10-22 to 3.
- Fix: use all available DB slugs; only fall back to config when zero exist.
- Backfill re-run populated 99 additional `externalSlug` values.

## Root Cause
```ts
// Before (broken): requires 100% coverage
const hasMissingExternalSlugs = sks.some((sk) => !sk.externalSlug);
kennelSlugs = hasMissingExternalSlugs ? undefined : dbSlugs;

// After (fixed): use what exists
kennelSlugs = dbSlugs.length > 0 ? dbSlugs : undefined;
```

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 120 files, 2959 tests passing
- [ ] Trigger manual HashRego scrape → expect `kennelSlugsSource: "sourceKennel"` with 100+ slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)