### PR TITLE
fix: Glasgow H3 custom adapter, EWH3 hare regex, Munich column mapping

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -309,18 +309,7 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 90,
-      config: {
-        containerSelector: "table:first-of-type",
-        rowSelector: "tr",
-        columns: {
-          runNumber: "td:nth-child(1)",
-          date: "td:nth-child(2)",
-          location: "td:nth-child(3)",
-          hares: "td:nth-child(4)",
-        },
-        defaultKennelTag: "Glasgow H3",
-        dateLocale: "en-GB",
-      },
+      config: {},
       kennelCodes: ["glasgowh3"],
     },
     {
@@ -2337,9 +2326,8 @@ export const SOURCES = [
       config: {
         sheetId: "anonymous",
         csvUrl: "https://docs.google.com/spreadsheets/d/e/2PACX-1vTtbizBGgic04azrTshlhcpRolA73yaiIijIFUSV0Gq7gU7KKchGWl0JRPHeIYspoq1PAx5XlyLTBfr/pub?output=csv&gid=2100367947",
-        columns: { runNumber: 0, date: 1, hares: 4, location: 5, description: 6 },
+        columns: { runNumber: 0, date: 1, hares: 4, location: 5, description: 6, title: 7 },
         kennelTagRules: { default: "MH3" },
-        defaultTitle: "MH3",
       },
       // Group column has MH3/MFMH3/MASS H3 but Sheets adapter can't route by column — all events tagged MH3
       kennelCodes: ["mh3-de"],

--- a/src/adapters/html-scraper/ewh3.test.ts
+++ b/src/adapters/html-scraper/ewh3.test.ts
@@ -126,6 +126,16 @@ describe("parseEwh3Body", () => {
     const text = "Hares: Roose Rips, Ha-Cum-On My Tatas, Ms. Nuttersworth\nWhere: Somewhere";
     expect(parseEwh3Body(text).hares).toBe("Roose Rips, Ha-Cum-On My Tatas, Ms. Nuttersworth");
   });
+
+  it("does not match 'Share:' as 'Hare:' — extracts actual hares after Bike Share line", () => {
+    const text = "Nearest Capital Bike Share: https://maps.app.goo.gl/abc123\nHares: Havana Lewinsky, Just Tommy, and Oh Hey! Not Gay\nTrail Details: stuff";
+    expect(parseEwh3Body(text).hares).toBe("Havana Lewinsky, Just Tommy, and Oh Hey! Not Gay");
+  });
+
+  it("extracts hares when Bike Share has non-URL value", () => {
+    const text = "Nearest Capital Bike Share: King St Metro North / Cameron St\nHares: Ha-Cum-On My Tatas & mystery hares\nTrail Details: stuff";
+    expect(parseEwh3Body(text).hares).toBe("Ha-Cum-On My Tatas & mystery hares");
+  });
 });
 
 const SAMPLE_HTML = `

--- a/src/adapters/html-scraper/ewh3.ts
+++ b/src/adapters/html-scraper/ewh3.ts
@@ -76,7 +76,7 @@ export function parseEwh3Body(text: string): {
   onAfter?: string;
   endMetro?: string;
 } {
-  const hareMatch = text.match(/Hares?:\s*(.+?)(?=(?:When|Where|Bring|Nearest|Trail Details|Miscellaneous|End Metro|On\s*After|Last Trains|Give Back):|\n|$)/i);
+  const hareMatch = text.match(/\bHares?:\s*(.+?)(?=(?:When|Where|Bring|Nearest|Trail Details|Miscellaneous|End Metro|On\s*After|Last Trains|Give Back):|\n|$)/i);
   const onAfterMatch = text.match(/On[- ]?After\*?:\s*(.+?)(?=\n|$)/i);
   const endMetroMatch = text.match(/End Metro:\s*(.+?)(?=\n|$)/i);
 
@@ -163,6 +163,8 @@ export class EWH3Adapter implements SourceAdapter {
 
     for (const post of wpResult.posts) {
       const $ = cheerio.load(post.content);
+      // Insert newlines at <p> boundaries so labels don't run together (e.g., "ThursdayHares:")
+      $("p, br").before("\n");
       const bodyText = $.text();
       const event = processPost(post.title, bodyText, post.url, baseUrl);
       if (event) events.push(event);
@@ -223,6 +225,8 @@ export class EWH3Adapter implements SourceAdapter {
       if (!titleText) continue;
 
       const contentEl = article.find(".entry-content, .post-content").first();
+      // Insert newlines at <p> boundaries so labels don't run together
+      contentEl.find("p, br").before("\n");
       const bodyText = contentEl.text() || "";
       const event = processPost(titleText, bodyText, postUrl, baseUrl);
       if (event) events.push(event);

--- a/src/adapters/html-scraper/glasgow-h3.test.ts
+++ b/src/adapters/html-scraper/glasgow-h3.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Source } from "@/generated/prisma/client";
+import { parseGlasgowRow, GlasgowH3Adapter } from "./glasgow-h3";
+
+vi.mock("@/adapters/safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+
+vi.mock("@/pipeline/structure-hash", () => ({
+  generateStructureHash: vi.fn(() => "mock-hash-glasgow"),
+}));
+
+const { safeFetch } = await import("@/adapters/safe-fetch");
+const mockedSafeFetch = vi.mocked(safeFetch);
+
+function mockFetchResponse(html: string) {
+  mockedSafeFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: () => Promise.resolve(html),
+    headers: new Headers({ "content-type": "text/html" }),
+  } as Response);
+}
+
+const sourceUrl = "https://glasgowh3.co.uk/hareline.php";
+
+describe("parseGlasgowRow", () => {
+  it("parses a standard Glasgow row", () => {
+    const cells = ["2206", "Monday 23 March", "Redhurst Hotel, Giffnock", "Audrey"];
+    const hrefs = ["run_request.php?id=1", undefined, undefined, undefined];
+    const event = parseGlasgowRow(cells, hrefs, sourceUrl);
+    expect(event).not.toBeNull();
+    expect(event!.date).toMatch(/^\d{4}-03-23$/);
+    expect(event!.runNumber).toBe(2206);
+    expect(event!.kennelTag).toBe("Glasgow H3");
+    expect(event!.location).toBe("Redhurst Hotel, Giffnock");
+    expect(event!.hares).toBe("Audrey");
+    expect(event!.startTime).toBe("19:00");
+    expect(event!.title).toBe("Glasgow H3 #2206");
+  });
+
+  it("extracts Google Maps locationUrl", () => {
+    const cells = ["2207", "Monday 30 March", "The Tavern, Hamilton", "Bob"];
+    const hrefs = [undefined, undefined, "https://maps.app.goo.gl/abc123", undefined];
+    const event = parseGlasgowRow(cells, hrefs, sourceUrl);
+    expect(event!.locationUrl).toBe("https://maps.app.goo.gl/abc123");
+  });
+
+  it("returns null for rows with fewer than 4 cells", () => {
+    expect(parseGlasgowRow(["2206", "Monday 23 March"], [], sourceUrl)).toBeNull();
+  });
+
+  it("returns null when date is empty", () => {
+    expect(parseGlasgowRow(["2206", "", "Somewhere", "Someone"], [], sourceUrl)).toBeNull();
+  });
+
+  it("filters TBD hares", () => {
+    const cells = ["2208", "Monday 6 April", "The Pub", "TBD"];
+    const event = parseGlasgowRow(cells, [], sourceUrl);
+    expect(event!.hares).toBeUndefined();
+  });
+});
+
+describe("GlasgowH3Adapter", () => {
+  let adapter: GlasgowH3Adapter;
+
+  beforeEach(() => {
+    adapter = new GlasgowH3Adapter();
+    vi.clearAllMocks();
+  });
+
+  it("returns only Glasgow events, not UK or International events", async () => {
+    const html = `<html><body>
+      <div class="row no-brd">
+        <table class="halloffame">
+          <tr><th>Run No</th><th>When</th><th>Where</th><th>Hare / Hares</th></tr>
+          <tr><td><a href="run_request.php?id=1">2206</a></td><td>Monday 23 March</td><td>Redhurst Hotel, Giffnock</td><td>Audrey</td></tr>
+          <tr></tr>
+          <tr><td><a href="run_request.php?id=2">2207</a></td><td>Monday 30 March</td><td><a href="https://maps.app.goo.gl/abc">The Tavern, Hamilton</a></td><td>Bob &amp; Alice</td></tr>
+        </table>
+      </div>
+      <div class="">
+        <table class="halloffame">
+          <tr><th>Date</th><th>Event</th><th>Venue</th></tr>
+          <tr><td>13 - 14 June 2026</td><td>Shetland Simmer Dim Weekend</td><td>Shetland</td></tr>
+          <tr><td>26 - 28 June 2026</td><td>BRAS H3 weekend</td><td>Palace Hotel Buxton</td></tr>
+        </table>
+      </div>
+      <div class="">
+        <table class="halloffame">
+          <tr><th>Date</th><th>Event</th><th>Venue</th></tr>
+          <tr><td>8-10 May 2026</td><td>Interhash 2026</td><td>Goa, India</td></tr>
+        </table>
+      </div>
+    </body></html>`;
+
+    mockFetchResponse(html);
+    const source = { id: "src-glasgow", url: sourceUrl, config: {} } as unknown as Source;
+    const result = await adapter.fetch(source, { days: 365 });
+
+    // CRITICAL: only Glasgow events, not UK or International
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0].runNumber).toBe(2206);
+    expect(result.events[0].location).toBe("Redhurst Hotel, Giffnock");
+    expect(result.events[1].runNumber).toBe(2207);
+    expect(result.events[1].locationUrl).toBe("https://maps.app.goo.gl/abc");
+    expect(result.events[1].hares).toBe("Bob & Alice");
+
+    // No 8-digit garbage run numbers
+    const badRuns = result.events.filter(e => e.runNumber && e.runNumber > 99999);
+    expect(badRuns).toHaveLength(0);
+  });
+
+  it("all events have default startTime 19:00", async () => {
+    const html = `<html><body>
+      <div class="row no-brd">
+        <table class="halloffame">
+          <tr><th>Run No</th><th>When</th><th>Where</th><th>Hare / Hares</th></tr>
+          <tr><td>2206</td><td>Monday 23 March</td><td>The Pub</td><td>Hare Name</td></tr>
+        </table>
+      </div>
+    </body></html>`;
+
+    mockFetchResponse(html);
+    const source = { id: "src-glasgow", url: sourceUrl, config: {} } as unknown as Source;
+    const result = await adapter.fetch(source, { days: 365 });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].startTime).toBe("19:00");
+  });
+});

--- a/src/adapters/html-scraper/glasgow-h3.ts
+++ b/src/adapters/html-scraper/glasgow-h3.ts
@@ -1,0 +1,170 @@
+/**
+ * Glasgow Hash House Harriers (Glasgow H3) HTML Scraper
+ *
+ * Scrapes glasgowh3.co.uk/hareline.php for upcoming runs.
+ * The page has THREE <table class="halloffame"> tables in separate parent divs:
+ *   1. Glasgow Hash Runs (inside div.row.no-brd) — the one we want
+ *   2. UK Events
+ *   3. International Events
+ *
+ * The generic adapter can't scope to just the first table, so we need
+ * a custom adapter that targets div.row.no-brd table.halloffame.
+ *
+ * Columns: Run No | When | Where | Hare / Hares
+ */
+
+import type { Source } from "@/generated/prisma/client";
+import type {
+  SourceAdapter,
+  RawEventData,
+  ScrapeResult,
+  ErrorDetails,
+} from "../types";
+import { hasAnyErrors } from "../types";
+import { chronoParseDate, fetchHTMLPage, buildDateWindow } from "../utils";
+
+/**
+ * Parse a single row from the Glasgow H3 hareline table.
+ * Columns: Run No | When | Where | Hare / Hares
+ * Exported for unit testing.
+ */
+export function parseGlasgowRow(
+  cells: string[],
+  hrefs: (string | undefined)[],
+  sourceUrl: string,
+): RawEventData | null {
+  if (cells.length < 4) return null;
+
+  // Column 0: Run number
+  const runDigits = cells[0]?.replace(/\D/g, "");
+  const runNumber = runDigits ? parseInt(runDigits, 10) || undefined : undefined;
+
+  // Column 1: Date — en-GB format like "Monday 23 March" (no year)
+  const dateText = cells[1]?.trim();
+  if (!dateText) return null;
+  const date = chronoParseDate(dateText, "en-GB", undefined, { forwardDate: true });
+  if (!date) return null;
+
+  // Column 2: Location
+  const location = cells[2]?.trim() || undefined;
+  const locationUrl = hrefs[2] || undefined;
+
+  // Column 3: Hares
+  const haresText = cells[3]?.trim();
+  const hares = haresText && !/^(?:tbd|tba|tbc)$/i.test(haresText) ? haresText : undefined;
+
+  // Build title from kennel + run number
+  const title = runNumber ? `Glasgow H3 #${runNumber}` : undefined;
+
+  return {
+    date,
+    kennelTag: "Glasgow H3",
+    title,
+    hares,
+    location,
+    locationUrl,
+    startTime: "19:00", // "All runs start at 7pm unless stated"
+    runNumber,
+    sourceUrl,
+  };
+}
+
+export class GlasgowH3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(
+    source: Source,
+    options?: { days?: number },
+  ): Promise<ScrapeResult> {
+    const sourceUrl = source.url || "https://glasgowh3.co.uk/hareline.php";
+
+    const page = await fetchHTMLPage(sourceUrl);
+    if (!page.ok) return page.result;
+    const { $, structureHash, fetchDurationMs } = page;
+
+    const events: RawEventData[] = [];
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+    const { minDate, maxDate } = buildDateWindow(options?.days);
+
+    // Target ONLY the Glasgow Hash Runs table — it's inside div.row.no-brd
+    let table = $("div.row.no-brd table.halloffame");
+    // Fallback: find h2 containing "Glasgow Hash Runs" and get the next table
+    if (!table.length) {
+      const h2 = $("h2").filter((_i, el) => $(el).text().includes("Glasgow Hash Runs"));
+      if (h2.length) {
+        table = h2.first().nextAll("table").first();
+      }
+    }
+
+    if (!table.length) {
+      const message = "Could not find Glasgow Hash Runs table";
+      return {
+        events: [],
+        errors: [message],
+        errorDetails: { parse: [{ row: 0, error: message }] },
+      };
+    }
+
+    const rows = table.find("tr");
+
+    rows.each((i, el) => {
+      const $row = $(el);
+      const tds = $row.find("td");
+      // Skip header rows (<th> elements) and empty separator rows
+      if ($row.find("th").length > 0 || tds.length < 4) return;
+
+      try {
+        const cells: string[] = [];
+        const hrefs: (string | undefined)[] = [];
+
+        tds.each((_j, td) => {
+          const $td = $(td);
+          cells.push($td.text().trim());
+          // For location cell (index 2), prefer Google Maps link
+          const allLinks = $td.find("a");
+          let href: string | undefined;
+          allLinks.each((_k, a) => {
+            const h = $(a).attr("href");
+            if (h && /maps\.(google|app\.goo\.gl)/i.test(h)) {
+              href = h;
+            }
+          });
+          if (!href) {
+            href = $td.find("a").first().attr("href") || undefined;
+          }
+          hrefs.push(href);
+        });
+
+        const event = parseGlasgowRow(cells, hrefs, sourceUrl);
+        if (event) {
+          const eventDate = new Date(event.date + "T12:00:00Z");
+          if (eventDate < minDate || eventDate > maxDate) return;
+          events.push(event);
+        }
+      } catch (err) {
+        errors.push(`Error parsing row ${i}: ${err}`);
+        (errorDetails.parse ??= []).push({
+          row: i,
+          section: "hareline",
+          error: String(err),
+          rawText: $row.text().trim().slice(0, 2000),
+        });
+      }
+    });
+
+    const hasErrors = hasAnyErrors(errorDetails);
+
+    return {
+      events,
+      errors,
+      structureHash,
+      errorDetails: hasErrors ? errorDetails : undefined,
+      diagnosticContext: {
+        rowsFound: rows.length,
+        eventsParsed: events.length,
+        fetchDurationMs,
+      },
+    };
+  }
+}

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -36,6 +36,7 @@ import { SWH3Adapter } from "./html-scraper/swh3";
 import { SDH3Adapter } from "./html-scraper/sdh3";
 import { PhoenixHHHAdapter } from "./html-scraper/phoenixhhh";
 import { EdinburghH3Adapter } from "./html-scraper/edinburgh-h3";
+import { GlasgowH3Adapter } from "./html-scraper/glasgow-h3";
 import { FrankfurtHashAdapter } from "./html-scraper/frankfurt-hash";
 import { GoogleCalendarAdapter } from "./google-calendar/adapter";
 import { GoogleSheetsAdapter } from "./google-sheets/adapter";
@@ -98,6 +99,7 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /sdh3\.com/i,            name: "SDH3Adapter",              factory: () => new SDH3Adapter() },
   { pattern: /phoenixhhh\.org/i,    name: "PhoenixHHHAdapter",        factory: () => new PhoenixHHHAdapter() },
   { pattern: /edinburghh3\.com/i,  name: "EdinburghH3Adapter",       factory: () => new EdinburghH3Adapter() },
+  { pattern: /glasgowh3\.co\.uk/i, name: "GlasgowH3Adapter",        factory: () => new GlasgowH3Adapter() },
   { pattern: /frankfurt-hash\.de/i, name: "FrankfurtHashAdapter",    factory: () => new FrankfurtHashAdapter() },
 ];
 


### PR DESCRIPTION
## Summary

Three fixes that weren't included in PR #344 (which was merged before these were pushed):

- **Glasgow H3 custom adapter**: The generic adapter with `table:first-of-type` still matched all 3 tables because each is in its own parent `<div>`. New `GlasgowH3Adapter` targets `$("div.row.no-brd table.halloffame")` — the only selector that uniquely identifies the Glasgow Hash Runs table. Parses en-GB dates with `forwardDate`, defaults to 19:00 start time, prefers Google Maps links for `locationUrl`.
- **EWH3 hare regex**: `/Hares?:/i` matched inside "Nearest Capital Bike **Share:**" because "hare" is a substring of "Share". Added `\b` word boundary + newline insertion at `<p>` boundaries before `.text()` extraction (Cheerio concatenates `<p>` tags without separators, producing `"ThursdayHares:"` where `\b` alone can't help since both adjacent chars are word characters).
- **Munich MH3 seed config**: Changed column mapping from `title: 6` (Notes column) to `description: 6, title: 7` per local testing.

## Test plan

- [x] 7/7 Glasgow H3 adapter tests pass (all new)
- [x] 22/22 EWH3 adapter tests pass (2 new)
- [ ] Re-scrape Glasgow, EWH3, Munich via admin panel after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)