### PR TITLE
fix: Glasgow forwardDate pushed recent past events to next year

### DIFF
--- a/src/adapters/html-scraper/glasgow-h3.test.ts
+++ b/src/adapters/html-scraper/glasgow-h3.test.ts
@@ -131,23 +131,29 @@ describe("GlasgowH3Adapter", () => {
   });
 
   it("includes recent past events — forwardDate does not push them to next year", async () => {
-    const html = `<html><body>
-      <div class="row no-brd">
-        <table class="halloffame">
-          <tr><th>Run No</th><th>When</th><th>Where</th><th>Hare / Hares</th></tr>
-          <tr><td>2206</td><td>Monday 23 March</td><td>Redhurst Hotel</td><td>Audrey</td></tr>
-          <tr><td>2207</td><td>Monday 30 March</td><td>Hamilton</td><td>Bob</td></tr>
-        </table>
-      </div>
-    </body></html>`;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T12:00:00Z"));
+    try {
+      const html = `<html><body>
+        <div class="row no-brd">
+          <table class="halloffame">
+            <tr><th>Run No</th><th>When</th><th>Where</th><th>Hare / Hares</th></tr>
+            <tr><td>2206</td><td>Monday 23 March</td><td>Redhurst Hotel</td><td>Audrey</td></tr>
+            <tr><td>2207</td><td>Monday 30 March</td><td>Hamilton</td><td>Bob</td></tr>
+          </table>
+        </div>
+      </body></html>`;
 
-    mockFetchResponse(html);
-    const source = { id: "src-glasgow", url: sourceUrl, config: {} } as unknown as Source;
-    const result = await adapter.fetch(source, { days: 90 });
+      mockFetchResponse(html);
+      const source = { id: "src-glasgow", url: sourceUrl, config: {} } as unknown as Source;
+      const result = await adapter.fetch(source, { days: 90 });
 
-    // Both events should be included — March 23 is within 90-day lookback
-    expect(result.events).toHaveLength(2);
-    expect(result.events.find(e => e.runNumber === 2206)).toBeDefined();
-    expect(result.events.find(e => e.runNumber === 2207)).toBeDefined();
+      // Both events should be included — March 23 is within 90-day lookback
+      expect(result.events).toHaveLength(2);
+      expect(result.events.find(e => e.runNumber === 2206)).toBeDefined();
+      expect(result.events.find(e => e.runNumber === 2207)).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/adapters/html-scraper/glasgow-h3.ts
+++ b/src/adapters/html-scraper/glasgow-h3.ts
@@ -48,8 +48,9 @@ export function parseGlasgowRow(
   // Year-rollover: dates without a year default to current year. If the parsed
   // date is >9 months in the past, it's likely next year (e.g., "6 January"
   // parsed in December should resolve to next January, not last January).
+  const YEAR_ROLLOVER_THRESHOLD_MS = 270 * 24 * 60 * 60 * 1000; // ~9 months
   const parsed = new Date(date + "T12:00:00Z");
-  if (parsed.getTime() < Date.now() - 270 * 24 * 60 * 60 * 1000) {
+  if (parsed.getTime() < Date.now() - YEAR_ROLLOVER_THRESHOLD_MS) {
     parsed.setUTCFullYear(parsed.getUTCFullYear() + 1);
     date = parsed.toISOString().slice(0, 10);
   }


### PR DESCRIPTION
## Summary

Fixes Glasgow H3 Run #2206 (March 23) being dropped after PR #346.

`chronoParseDate("Monday 23 March", "en-GB", undefined, { forwardDate: true })` resolved to 2027-03-23 instead of 2026-03-23 because March 23 is 3 days in the past and `forwardDate` pushes to the next future occurrence. The event then fell outside the 90-day date window and was silently filtered.

**Fix:** Remove `forwardDate: true`, parse with default (current year). Add year-rollover logic: if the parsed date is >9 months in the past, bump the year forward by 1. This correctly handles the December→January boundary (e.g., "Monday 6 January" parsed in December resolves to next January).

**Depends on:** PR #346 (Glasgow H3 custom adapter)

## Test plan

- [x] 8/8 Glasgow H3 adapter tests pass (1 new: recent past events not dropped)
- [ ] Re-scrape Glasgow source — verify Run #2206 appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)