### PR TITLE
fix: use kennel display name in default event titles

### DIFF
--- a/scripts/backfill-event-titles.ts
+++ b/scripts/backfill-event-titles.ts
@@ -1,0 +1,97 @@
+/**
+ * One-time backfill: rewrite default event titles that use raw kennelTag/kennelCode
+ * instead of the kennel's display name.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-event-titles.ts          # dry run (default)
+ *   npx tsx scripts/backfill-event-titles.ts --apply   # apply changes
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import pg from "pg";
+import { friendlyKennelName } from "../src/pipeline/merge";
+
+const dryRun = !process.argv.includes("--apply");
+
+async function main() {
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
+
+  const kennels = await prisma.kennel.findMany({
+    select: {
+      id: true,
+      kennelCode: true,
+      shortName: true,
+      fullName: true,
+      aliases: { select: { alias: true } },
+    },
+  });
+
+  let totalRewritten = 0;
+
+  for (const k of kennels) {
+    const friendly = friendlyKennelName(k.shortName, k.fullName);
+
+    // Collect all identifiers that could have been used as a default title prefix
+    const identifiers = new Set<string>();
+    identifiers.add(k.kennelCode);
+    identifiers.add(k.shortName.toLowerCase());
+    for (const a of k.aliases) {
+      identifiers.add(a.alias.toLowerCase());
+    }
+
+    for (const id of identifiers) {
+      // Skip if the identifier already produces the correct title
+      if (id === friendly) continue;
+
+      // Find events with bad default titles matching this identifier
+      const badEvents = await prisma.event.findMany({
+        where: {
+          kennelId: k.id,
+          OR: [
+            { title: `${id} Trail` },
+            { title: { startsWith: `${id} Trail #` } },
+          ],
+        },
+        select: { id: true, title: true, runNumber: true },
+      });
+
+      if (badEvents.length === 0) continue;
+
+      for (const ev of badEvents) {
+        const newTitle = ev.runNumber
+          ? `${friendly} Trail #${ev.runNumber}`
+          : `${friendly} Trail`;
+
+        if (dryRun) {
+          console.log(`  [dry] ${k.shortName}: "${ev.title}" → "${newTitle}"`);
+        } else {
+          await prisma.event.update({
+            where: { id: ev.id },
+            data: { title: newTitle },
+          });
+        }
+      }
+
+      console.log(`  ${k.shortName}: ${badEvents.length} events (was: "${id} Trail...")`);
+      totalRewritten += badEvents.length;
+    }
+  }
+
+  console.log(`\n${dryRun ? "Would rewrite" : "Rewrote"} ${totalRewritten} events total.`);
+  if (dryRun && totalRewritten > 0) {
+    console.log("Run with --apply to make changes.");
+  }
+
+  await prisma.$disconnect();
+  pool.end();
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -528,14 +528,18 @@ describe("empty event guard", () => {
     expect(mockRawEventCreate).not.toHaveBeenCalled();
   });
 
-  it("generates default title from kennelTag when title is missing", async () => {
+  it("generates default title using kennel display name (not raw tag)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({
+      shortName: "DUHHH", fullName: "DUHHH", region: "Dallas-Fort Worth, TX",
+      latitude: null, longitude: null, country: "US", regionRef: null,
+    } as never);
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
-        kennelTag: "DUHHH",
+        kennelTag: "duhhh",
         title: undefined,
         location: undefined,
         hares: undefined,
@@ -551,14 +555,45 @@ describe("empty event guard", () => {
     );
   });
 
+  it("uses friendlyKennelName for short kennel codes in default title", async () => {
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({
+      shortName: "H5", fullName: "Harrisburg-Hershey Hash House Harriers", region: "Harrisburg, PA",
+      latitude: null, longitude: null, country: "US", regionRef: null,
+    } as never);
+
+    const result = await processRawEvents("src_1", [
+      buildRawEvent({
+        kennelTag: "h5-hash",
+        title: undefined,
+        location: undefined,
+        hares: undefined,
+        runNumber: 314,
+      }),
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(mockEventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ title: "Harrisburg-Hershey H3 Trail #314" }),
+      }),
+    );
+  });
+
   it("includes run number in default title when available", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({
+      shortName: "Houston H3", fullName: "Houston Hash House Harriers", region: "Houston, TX",
+      latitude: null, longitude: null, country: "US", regionRef: null,
+    } as never);
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
-        kennelTag: "DH3",
+        kennelTag: "h4-tx",
         title: undefined,
         location: undefined,
         hares: undefined,
@@ -569,7 +604,7 @@ describe("empty event guard", () => {
     expect(result.created).toBe(1);
     expect(mockEventCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ title: "DH3 Trail #42" }),
+        data: expect.objectContaining({ title: "Houston H3 Trail #42" }),
       }),
     );
   });
@@ -738,7 +773,7 @@ describe("sanitizeLocationUrl", () => {
 
 // ── sanitizeTitle + sanitizeHares ──
 
-import { sanitizeTitle, sanitizeLocation, sanitizeHares } from "./merge";
+import { sanitizeTitle, sanitizeLocation, sanitizeHares, friendlyKennelName } from "./merge";
 
 describe("sanitizeTitle", () => {
   it("passes through normal titles", () => {
@@ -994,6 +1029,50 @@ describe("sanitizeHares", () => {
 
   it("passes through two-character hare name", () => {
     expect(sanitizeHares("Al")).toBe("Al");
+  });
+});
+
+// ── friendlyKennelName ──
+
+describe("friendlyKennelName", () => {
+  it("returns shortName when longer than 4 chars", () => {
+    expect(friendlyKennelName("Houston H3", "Houston Hash House Harriers")).toBe("Houston H3");
+  });
+
+  it("returns shortName when longer than 4 chars (SeaMon)", () => {
+    expect(friendlyKennelName("SeaMon", "Seattle Monday Hash House Harriers")).toBe("SeaMon");
+  });
+
+  it("expands short code using fullName with HHH suffix", () => {
+    expect(friendlyKennelName("H5", "Harrisburg-Hershey Hash House Harriers")).toBe("Harrisburg-Hershey H3");
+  });
+
+  it("expands short code (GAL)", () => {
+    expect(friendlyKennelName("GAL", "Galveston Hash House Harriers")).toBe("Galveston H3");
+  });
+
+  it("expands short code (OCH3)", () => {
+    expect(friendlyKennelName("OCH3", "Old Coulsdon Hash House Harriers")).toBe("Old Coulsdon H3");
+  });
+
+  it("returns fullName as-is when no HHH suffix", () => {
+    expect(friendlyKennelName("SFM", "South Fulton Mob")).toBe("South Fulton Mob");
+  });
+
+  it("returns fullName as-is when no HHH suffix (LBH)", () => {
+    expect(friendlyKennelName("LBH", "Love Bucket Hash")).toBe("Love Bucket Hash");
+  });
+
+  it("returns shortName when fullName equals shortName", () => {
+    expect(friendlyKennelName("H6", "H6")).toBe("H6");
+  });
+
+  it("returns shortName when fullName is null", () => {
+    expect(friendlyKennelName("H5", null)).toBe("H5");
+  });
+
+  it("returns shortName when stripping HHH leaves empty string", () => {
+    expect(friendlyKennelName("HHH", "Hash House Harriers")).toBe("HHH");
   });
 });
 

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -81,6 +81,20 @@ export function sanitizeHares(hares: string | undefined | null): string | null {
   return h || null;
 }
 
+/**
+ * Derive a user-friendly kennel name for default event titles.
+ * For short/cryptic codes (≤4 chars), derives a readable name from fullName.
+ * Strips "Hash House Harriers" suffix and appends "H3" when appropriate.
+ */
+export function friendlyKennelName(shortName: string, fullName: string | null): string {
+  if (shortName.length > 4) return shortName;
+  if (!fullName) return shortName;
+  const friendly = fullName.replace(/\s*Hash House Harriers?\s*$/i, "").trim();
+  if (!friendly || friendly === shortName) return shortName;
+  const hadHHH = /Hash House Harriers?/i.test(fullName);
+  return hadHHH ? `${friendly} H3` : friendly;
+}
+
 /** Compiled once — matches admin/meta content in event titles (split to keep regex complexity low). */
 const ADMIN_TITLE_PATTERNS = [
   /hares?\s+needed/i,
@@ -128,8 +142,8 @@ interface MergeContext {
   trustLevel: number;
   /** Kennel IDs linked to this source via SourceKennel (for the guard check). */
   linkedKennelIds: Set<string>;
-  /** Per-batch cache of kennelId → region + coords + country + region centroid to avoid N+1 queries. */
-  kennelCache: Map<string, { region: string; latitude: number | null; longitude: number | null; country: string; regionCentroidLat: number | null; regionCentroidLng: number | null }>;
+  /** Per-batch cache of kennelId → kennel data to avoid N+1 queries. */
+  kennelCache: Map<string, { shortName: string; fullName: string | null; region: string; latitude: number | null; longitude: number | null; country: string; regionCentroidLat: number | null; regionCentroidLng: number | null }>;
   /** Per-batch cache of short Maps URL → resolved full URL (avoids repeated HTTP calls). */
   shortUrlCache: Map<string, string | null>;
   /** Per-batch tracking: which canonical Event IDs have been matched for each kennel+date.
@@ -139,15 +153,17 @@ interface MergeContext {
   result: MergeResult;
 }
 
-/** Resolve kennel data (region + coords + country + region centroid), using the per-batch cache to avoid N+1 queries. */
-async function resolveKennelData(kennelId: string, ctx: MergeContext): Promise<{ region: string; latitude: number | null; longitude: number | null; country: string; regionCentroidLat: number | null; regionCentroidLng: number | null }> {
+/** Resolve kennel data (name + region + coords + country + region centroid), using the per-batch cache to avoid N+1 queries. */
+async function resolveKennelData(kennelId: string, ctx: MergeContext): Promise<{ shortName: string; fullName: string | null; region: string; latitude: number | null; longitude: number | null; country: string; regionCentroidLat: number | null; regionCentroidLng: number | null }> {
   let cached = ctx.kennelCache.get(kennelId);
   if (cached === undefined) {
     const kennel = await prisma.kennel.findUnique({
       where: { id: kennelId },
-      select: { region: true, latitude: true, longitude: true, country: true, regionRef: { select: { centroidLat: true, centroidLng: true } } },
+      select: { shortName: true, fullName: true, region: true, latitude: true, longitude: true, country: true, regionRef: { select: { centroidLat: true, centroidLng: true } } },
     });
     cached = {
+      shortName: kennel?.shortName ?? "",
+      fullName: kennel?.fullName ?? null,
       region: kennel?.region ?? "",
       latitude: kennel?.latitude ?? null,
       longitude: kennel?.longitude ?? null,
@@ -753,16 +769,9 @@ async function processNewRawEvent(
   // Decode HTML entities in text fields before any downstream processing
   sanitizeRawFields(event);
 
-  // Generate a default title when the adapter didn't provide one — ensures future
-  // placeholder events (e.g. DFW calendar) still pass the empty-event guard.
-  if (!sanitizeTitle(event.title) && event.kennelTag) {
-    event.title = event.runNumber
-      ? `${event.kennelTag} Trail #${event.runNumber}`
-      : `${event.kennelTag} Trail`;
-  }
-
-  // Validate the event has at least one meaningful display field before processing
-  const hasDisplayData = event.title || event.location || event.hares || event.runNumber;
+  // Validate the event has at least one meaningful display field before processing.
+  // kennelTag counts because we'll generate a default title from it after kennel resolution.
+  const hasDisplayData = event.title || event.location || event.hares || event.runNumber || event.kennelTag;
   if (!hasDisplayData) {
     ctx.result.eventErrors++;
     if (ctx.result.eventErrorMessages.length < 50) {
@@ -784,6 +793,16 @@ async function processNewRawEvent(
 
   const kennelId = await resolveAndGuardKennel(event, ctx);
   if (!kennelId) return null;
+
+  // Generate a default title using the kennel's display name (not the raw adapter tag).
+  // Must happen AFTER kennel resolution so we have access to shortName/fullName.
+  if (!sanitizeTitle(event.title) && kennelId) {
+    const kennelData = await resolveKennelData(kennelId, ctx);
+    const displayName = friendlyKennelName(kennelData.shortName, kennelData.fullName);
+    event.title = event.runNumber
+      ? `${displayName} Trail #${event.runNumber}`
+      : `${displayName} Trail`;
+  }
 
   const targetEventId = await upsertCanonicalEvent(event, kennelId, rawEvent.id, ctx);
 
@@ -857,7 +876,7 @@ export async function processRawEvents(
 
   clearResolverCache();
 
-  const kennelCache = new Map<string, { region: string; latitude: number | null; longitude: number | null; country: string; regionCentroidLat: number | null; regionCentroidLng: number | null }>();
+  const kennelCache = new Map<string, { shortName: string; fullName: string | null; region: string; latitude: number | null; longitude: number | null; country: string; regionCentroidLat: number | null; regionCentroidLng: number | null }>();
   const shortUrlCache = new Map<string, string | null>();
   const batchMatchedEvents = new Map<string, Set<string>>();
   const ctx: MergeContext = { sourceId, trustLevel, linkedKennelIds, kennelCache, shortUrlCache, batchMatchedEvents, result };


### PR DESCRIPTION
## Summary
- Default event titles were using raw adapter `kennelTag` (e.g., `h4-tx`, `cfh3`, `flour-city`) instead of the kennel's display name
- Added `friendlyKennelName()` helper that uses `shortName` for names >4 chars, and derives a readable name from `fullName` for short/cryptic codes (≤4 chars)
- Moved default title generation in merge pipeline to after kennel resolution, where `shortName`/`fullName` are available
- Backfill script already applied to production DB — **497 events rewritten across 27 kennels**

### Before → After examples
| Before | After |
|--------|-------|
| `h4-tx Trail #2555` | Houston H3 Trail #2555 |
| `h5-hash Trail #314` | Harrisburg-Hershey H3 Trail #314 |
| `cfh3 Trail #525` | Cape Fear H3 Trail #525 |
| `flour-city Trail` | Flour City H3 Trail |
| `seamon-h3 Trail #549` | SeaMon Trail #549 |
| `duhhh Trail #847` | DUHHH Trail #847 |
| `n2h3 Trail #773` | No Name H3 Trail #773 |
| `oh3 Trail` | Oregon H3 Trail |

## Test plan
- [x] 157 merge pipeline tests pass (10 new: friendlyKennelName + default title generation)
- [x] Backfill dry run verified all 497 events before applying
- [x] Backfill applied to production DB
- [ ] Verify new scrapes produce correct default titles (trigger re-scrape of affected source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)