### PR TITLE
Add "Updated X ago" timestamp to event detail page

### DIFF
--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -212,8 +212,10 @@ export default async function EventDetailPage({
           {event.status === "TENTATIVE" && (
             <Badge variant="outline">Tentative</Badge>
           )}
-          <span className="text-xs text-muted-foreground">·</span>
-          <span className={`text-xs ${Date.now() - event.updatedAt.getTime() > 7 * 86_400_000 ? "text-amber-500" : "text-muted-foreground"}`}>
+          {(event.status === "CANCELLED" || event.status === "TENTATIVE") && (
+            <span className="text-xs text-muted-foreground">·</span>
+          )}
+          <span className={`text-xs ${Date.now() - event.updatedAt.getTime() >= 7 * 86_400_000 ? "text-amber-500" : "text-muted-foreground"}`}>
             Updated {formatRelativeTime(event.updatedAt)}
           </span>
         </div>

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -287,6 +287,9 @@ describe("formatRelativeTime", () => {
   it("returns days for < 7 days ago", () => {
     expect(formatRelativeTime(new Date(NOW - 2 * 86_400_000))).toBe("2d ago");
   });
+  it("returns formatted date at exactly 7 days", () => {
+    expect(formatRelativeTime(new Date(NOW - 7 * 86_400_000))).toMatch(/Mar 20/);
+  });
   it("returns formatted date for >= 7 days ago", () => {
     expect(formatRelativeTime(new Date("2026-02-18T12:00:00Z"))).toMatch(/Feb 18/);
   });


### PR DESCRIPTION
Shows how fresh event data is by displaying the relative time since
the event record was last updated (via scrape/merge pipeline).

https://claude.ai/code/session_01Y2vGw6c7FVpBYP4Hz5gxbi