### PR TITLE
docs: roadmap update + FB user research reprioritization

### DIFF
--- a/docs/facebook-user-research.md
+++ b/docs/facebook-user-research.md
@@ -1,0 +1,92 @@
+# Hash House Harriers Facebook Group — User Research Report for HashTracks.xyz
+
+After thoroughly reviewing recent posts and comments in the Hash House Harriers Facebook group (16.6K members), here are the key findings organized by pain points and specific locations.
+
+---
+
+## COMMON PAIN POINTS
+
+### 1. "Where Is There a Hash?" — The #1 Problem
+The most frequent post type is tagged **"InSearchOf"** and follows a simple pattern: someone traveling or relocating asks the group if there's a hash in [location]. These posts generate massive engagement (up to 72 comments on the Texas post, 59 on the Florida post), which tells you two things: there's huge demand, and there's no single reliable tool that answers this question.
+
+**Key examples from the last few weeks alone:**
+- "Is there a hash in texas" (64 likes, 72 comments)
+- "Is there a South Florida H3 chapter group? (West Palm Beach/Miami)" (12 likes, 59 comments)
+- "Is there a hash near Charleston, SC this week?" (Yesterday)
+- "Any hashes near Biloxi, Mississippi?" (20 comments)
+- "I'm in Portland Maine. Is there a hash here?" (22 comments)
+
+### 2. Too Vague, Too Big — The Location Precision Problem
+When someone asks about a state or large region, the immediate response is always **"narrow it down."** Texas is the perfect case study: commenters pointed out that Texas is bigger than most of Europe and some cities have 5+ kennels, while other areas have none. One person estimated about 40 kennels in Texas alone. Responses repeatedly asked "What part?" and "How far are you willing to drive measured in hours?"
+
+**Your app opportunity:** Location-aware search with radius/drive-time filters. People don't just need "Texas kennels" — they need "kennels within 2 hours of San Antonio."
+
+### 3. Fragmented, Outdated Resources
+Three resources get shared repeatedly by the group admin and experienced hashers, but none is comprehensive:
+- **half-mind.com** (e.g., half-mind.com/regionalwebsite/p_list1.php?state=TX for Texas contacts, ?state=KY for Kentucky, ?state=FL for Florida)
+- **gotothehash.net** (genealogy.gotothehash.net for chapters by state)
+- **Individual Facebook group pages** (people share direct FB links to local kennel groups)
+
+The group admin Matthew Kleinosky manually pastes half-mind.com links in nearly every search thread. One community member (Pryvette SInohbawl) had to manually create a visual map of all Florida kennels because no existing tool showed them. This map was labeled "as of March 2026" and included both active and inactive kennels.
+
+### 4. Dead/Inactive Kennels
+Multiple comments reference kennels that "used to run" but are now inactive. Examples include Biloxi H3 ("used to run fairly frequently"), a hash in Davis called "DUHHH" that "died quickly," and "all kennels are dead" jokes about Texas. One commenter even said she kept inactive kennels on her Florida map "just in case they are restarted." There's no way to know if a kennel is active without asking around.
+
+### 5. Travel Hashing — The "Hash Tourist" Use Case
+A huge segment of this community are **travel hashers** (self-described as "travel whores") who visit kennels in new cities. Sarah Modlin's post about visiting Kentucky for a marathon and wanting to hash along the way (86 likes, 19 comments) and Monica Danger Wiggins looking for a hash in any new state reachable by cheap nonstop flight from Denver (23 comments) exemplify this. These users want to discover and plan hash visits while traveling.
+
+### 6. Timing and Scheduling Conflicts
+The Charleston post revealed a key issue: the local hash was cancelled because of a city bridge run event. Someone had to explain in real-time that hashers would be at the bridge run instead. Real-time event awareness and calendar integration would be extremely valuable.
+
+### 7. Asking About Individual Hashers, Not Just Kennels
+Some posts search for specific hashers by hash name (e.g., "Plastic Chaps My Ass" in Indiana) or look for any hashers in an area — not formal kennels. Julia Stewart in Tangier asked for "a hash (or hashers)" explicitly distinguishing between organized events and informal connections.
+
+### 8. International Discovery Is Even Harder
+Posts searching for hashes in Iceland/Reykjavik, Brazil (Belo Horizonte, Sao Paulo), Morocco (Tangier), and the inaugural KeflavikH3 in Iceland show that international discovery is even more challenging. One person asked about Belo Horizonte two years in a row because she couldn't find an answer.
+
+---
+
+## SPECIFIC LOCATIONS PEOPLE ARE SEARCHING FOR
+
+### United States
+| Location | Post Details |
+|---|---|
+| **Texas** (general, then Houston, San Antonio, Dallas, El Paso) | 72 comments, resources shared: AH3, NoDUH (North of Dallas Urban Hash), ~40 kennels statewide |
+| **South Florida** (West Palm Beach / Miami) | 59 comments; kennels identified: Miami (Pryvette SInohbawl), Wildcard (Fort Lauderdale), Palm Beach H3, Treasure Coast H3, Lakeland/Polk County H3, Lehigh Acres H3, ~16 kennels on the peninsula |
+| **Charleston, SC** | "This week?" — local hash cancelled for bridge run |
+| **Biloxi, Mississippi** | "Can't find any active kennels"; nearest: Gulf Coast H3 (Mobile), NOH3 & Vudu (New Orleans), Survivor H3 (Pensacola), Low Key H3 |
+| **Portland, Maine** | 22 comments |
+| **Kentucky** (Louisville, Lexington) | Kennels: Louisville H3, Cerberus Legion Full Moon H3 (Lexington), Horses Ass (Lexington) |
+| **Twin Falls, Idaho** | "Friend just moved there and needs community" |
+| **Banff / Spokane, WA** | 3 comments |
+| **Tulsa, Oklahoma** | "Weekend of the 18th?" |
+| **Denver area** (looking for any new state by nonstop flight) | Excluding Washington, Oregon — 23 comments |
+
+### International
+| Location | Post Details |
+|---|---|
+| **Reykjavik, Iceland** | 13 comments; also KeflavikH3 just formed as a new "renegade" kennel |
+| **Belo Horizonte, Brazil** | Asked twice (Oct 2023, Nov 2024) by the same person — still no answer |
+| **Sao Paulo, Brazil** | 9 comments |
+| **Tangier, Morocco** | Looking for hash or individual hashers |
+| **Karachi, Pakistan** | Active — Run 1165 posted March 28 |
+| **Yaoundé, Cameroon** | Active since 1986 |
+| **Sandakan (Malaysia) → Guangzhou, China** | Cross-border hashing |
+
+---
+
+## RECOMMENDATIONS FOR HASHTRACKS.XYZ
+
+Based on this research, the highest-value features to build would be:
+
+**1. Location-aware kennel finder** with radius/drive-time search — the single most requested thing in this group. Every "Is there a hash in [X]?" post is a user your app should capture.
+
+**2. Active vs. inactive kennel status** — People need to know if a kennel is still running, not just that it once existed. A last-verified or last-run-date indicator would solve a huge trust gap.
+
+**3. Traveler mode** — Let users input a trip itinerary or destination and surface kennels along the route or near the destination, with next-run dates. The "hash tourism" segment is passionate and well-connected.
+
+**4. Kennel aggregation** — Consolidate the fragmented info from half-mind.com, gotothehash.net, and individual Facebook pages into one searchable database. Right now the admin is manually copy-pasting these links.
+
+**5. Event calendar with real-time updates** — Show upcoming runs, cancellations, and special events (Red Dress, Green Dress, Interhash, campouts). The Charleston scheduling conflict demonstrates this need.
+
+**6. "No kennel here yet" flag with interest registration** — For locations like Belo Horizonte where someone asks repeatedly with no result, let users register interest so that when a kennel forms, they're notified. Also supports the "set your own trail" ethos that commenters suggest for areas without formal kennels.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,11 @@
 
 Living document tracking what's been built, what's next, and where we're headed.
 
-Last updated: 2026-03-23
+Last updated: 2026-03-29
 
 **Competitive context:** See [competitive-analysis.md](competitive-analysis.md) for detailed analysis of Harrier Central (the primary competitor), user pain points from their GitHub issues, and strategic positioning rationale behind these priorities.
+
+**User research:** See [facebook-user-research.md](facebook-user-research.md) for analysis of the 16.6K-member Hash House Harriers Facebook group. Key finding: the #1 post type is "Is there a hash in [location]?" — validating Discovery & Travel UX as the next highest-priority feature area.
 
 ---
 
@@ -18,7 +20,7 @@ Last updated: 2026-03-23
 - [x] Master-detail layout: event list + detail panel on desktop, full-page on mobile
 - [x] Admin UI: source management, manual scrape trigger, scrape logs, source health
 
-### Data Sources (174 live)
+### Data Sources (185 live)
 
 **NYC / NJ / Philly (8 sources)**
 - [x] **hashnyc.com** (HTML Scraper) — 11 NYC-area kennels
@@ -56,7 +58,7 @@ Last updated: 2026-03-23
 **SF Bay Area (3 sources)**
 - [x] **SFH3 MultiHash iCal Feed** (iCal Feed) — 13 SF Bay Area kennels
 - [x] **SFH3 MultiHash HTML Hareline** (HTML Scraper) — 13 SF Bay Area kennels (secondary enrichment)
-- [x] **Surf City H3 Static Schedule** (Static Schedule) — SCH3 (Santa Cruz)
+- [x] **Surf City H3 Google Calendar** (Google Calendar API) — SCH3 (Santa Cruz)
 
 **London / UK (7 sources)**
 - [x] **London Hash Run List** (HTML Scraper) — LH3
@@ -67,8 +69,31 @@ Last updated: 2026-03-23
 - [x] **SLASH Run List** (HTML Scraper) — SLH3 (South London)
 - [x] **Enfield Hash Blog** (HTML Scraper) — EH3
 
+**Scotland (2 sources)**
+- [x] **Glasgow H3 Hareline** (HTML Scraper, GenericHtml) — Glasgow H3
+- [x] **Edinburgh H3 Hareline** (HTML Scraper) — Edinburgh H3
+
+**Bristol (1 source)**
+- [x] **West of England Hash Run List** (HTML Scraper, GenericHtml) — Bristol H3, GREY, BOGS (3 kennels)
+
 **Ireland (1 source)**
 - [x] **Dublin H3 Website Hareline** (HTML Scraper) — DH3
+
+**Norfolk (1 source)**
+- [x] **Norfolk H3 Run List** (HTML Scraper, residential proxy) — Norfolk H3
+
+**Merseyside (1 source)**
+- [x] **Mersey Thirstdays Website** (HTML Scraper) — MTH3
+
+**Germany (4 sources)**
+- [x] **Berlin H3 iCal Feed** (iCal Feed) — BH3, BH3FM (2 Berlin kennels)
+- [x] **Stuttgart H3 Google Calendar** (Google Calendar API) — SH3, DST, FM, SUPER (4 Stuttgart kennels)
+- [x] **Munich H3 Hareline Sheet** (Google Sheets) — MH3 (Munich)
+- [x] **Frankfurt H3 Hareline** (HTML Scraper) — FH3, FFMH3, SHITS, DOM, Bike Hash (5 Frankfurt kennels)
+
+**Hawaii (2 sources)**
+- [x] **Aloha H3 Google Calendar** (Google Calendar API) — AH3, H5 (2 Honolulu kennels via kennelPatterns)
+- [x] **Honolulu H5 Google Calendar** (Google Calendar API) — H5
 
 **Florida (8 sources)**
 - [x] **Miami H3 Meetup** (Meetup) — MH3
@@ -269,6 +294,14 @@ See [misman-attendance-requirements.md](misman-attendance-requirements.md) and [
 - [x] Admin: kennel merge UI with fuzzy duplicate prevention
 - [x] Admin: slim source table, detail page tooltips
 - [x] **Navigation pattern decision:** Misman sub-tabs (Attendance/Roster/History) vs Alert pill-filters (Open/Resolved/All) use intentionally different patterns — sub-tabs switch between distinct content views while pill-filters narrow a single list by status. The divergence is justified and should be preserved.
+- [x] Map polish round 2: kennel popup redesign, default map view, region chips (PR #349)
+- [x] Map colocated popup enrichment with fullName, next-event, region badges (PR #353)
+- [x] "Search this area" on hareline map (PR #345)
+- [x] Kennel name disambiguation: title attrs, SourceTable region, seed warning (PR #343)
+- [x] Kennel routing resilience: source-scoped aliases + kennelCode migration (PR #348)
+- [x] "Updated X ago" timestamp on event detail page (PR #358)
+- [x] Attendance suggestion expand/collapse toggle (PR #359)
+- [x] Dark mode comprehensive polish (PR #356) + mobile dark mode toggle with ToggleGroup (PR #351)
 
 ### Kennel Page Redesign — COMPLETE
 - [x] 17 new nullable profile fields on Kennel model (schedule, social, details, flags)
@@ -384,6 +417,7 @@ See [config-driven-onboarding-plan.md](config-driven-onboarding-plan.md) for ful
 - [x] Series linking: multi-day events split into per-day records linked via parentEventId
 - [x] Event detail page + sidebar panel render EventLink buttons
 - [x] Seed: Hash Rego source with 7 kennel slugs (BFM, EWH3, WH4, GFH3, CH3, DCH4, DCFMH3)
+- [x] externalSlug backfill + KennelDiscovery fallback scoping fix (PR #364)
 
 ### Hareline UX Overhaul (PR #160) — COMPLETE
 - [x] Accessibility: skip nav, focus management, ARIA labels, keyboard-navigable EventCard
@@ -451,6 +485,8 @@ See [config-driven-onboarding-plan.md](config-driven-onboarding-plan.md) for ful
 - [x] Event city backfill from reverse geocoding coordinates
 - [x] `getLocationDisplay()` deduplicates city from location name
 - [x] Geocoding improvements: server-only API key, bulk coordinate resolution
+- [x] Three additional audit rounds (Mar 25-29): hare extraction from titles, Cape Fear CSS selector fix, GCal Maps URL location extraction, Meetup hare parsing, boilerplate filtering improvements
+- [x] Event reconciliation self-healing: auto-restore for false cancellations with diagnostics
 
 ### DB Seed Automation — COMPLETE
 - [x] Slug collision handling with `ensurePattern()` refactor (pre-check instead of P2002 retry)
@@ -486,6 +522,7 @@ See [config-driven-onboarding-plan.md](config-driven-onboarding-plan.md) for ful
 
 ### SEO Infrastructure — COMPLETE
 - [x] Open Graph images, sitemap.xml, JSON-LD structured data, social share buttons
+- [x] Open Graph metadata with branded OG image for hashtracks.xyz (PR #355)
 
 ### DMS Coordinate Parsing — COMPLETE
 - [x] Parse DMS coordinates (degrees/minutes/seconds) from location strings, strip from display text
@@ -494,10 +531,10 @@ See [config-driven-onboarding-plan.md](config-driven-onboarding-plan.md) for ful
 - [x] Admin event deletion now properly cascades to orphaned RawEvent records
 
 ### Current Stats
-- 261 kennels (with rich profiles), ~900 aliases, 174 sources, 93 regions (3 countries: US, UK, Ireland)
+- 290 kennels (with rich profiles), ~950 aliases, 185 sources, 137 regions (4 countries: US, UK, Ireland, Germany)
 - 9 live adapter types: STATIC_SCHEDULE, HTML_SCRAPER, GOOGLE_CALENDAR, MEETUP, ICAL_FEED, GOOGLE_SHEETS, HASHREGO, BLOGGER_API, RSS_ICAL
 - 27 models, 20 enums in Prisma schema
-- 119 test files, ~2,578 test cases
+- 128 test files
 
 ---
 
@@ -537,6 +574,12 @@ Regional research complete — see [kennel-research/](kennel-research/) for deta
 - [x] **Arizona** (7 kennels, 4 sources) — Phoenix, Tucson; iCal feed + Google Calendar
 - [x] **Virginia** (9 kennels, 9 sources) — Richmond, Hampton Roads, Charlottesville, Fredericksburg, Lynchburg; Google Calendar + Meetup + static schedules
 - [x] **North Carolina** (6 kennels, 6 sources) — Raleigh, Charlotte, Asheville, Wilmington NC, Fayetteville; Google Calendar + Meetup + HTML scraper
+- [x] **Scotland** (2 kennels, 2 sources) — Glasgow H3, Edinburgh H3; GenericHtml + HTML scraper
+- [x] **Bristol** (3 kennels, 1 source) — Bristol H3, GREY, BOGS; West of England Hash Run List (GenericHtml, 3 kennels from 1 source)
+- [x] **Norfolk** (1 kennel, 1 source) — Norfolk H3; HTML scraper with residential proxy
+- [x] **Merseyside** (1 kennel, 1 source) — Mersey Thirstdays (MTH3); HTML scraper
+- [x] **Germany** (12 kennels, 4 sources) — Berlin, Stuttgart, Munich, Frankfurt; iCal + Google Calendar + Google Sheets + HTML scraper
+- [x] **Hawaii** (2 kennels, 2 sources) — Honolulu; Google Calendar with kennelPatterns
 
 **Remaining opportunities:**
 - [ ] **Hash Rego kennel directory** — scrape `/kennels/` page for new kennel discovery + auto-onboarding
@@ -544,6 +587,15 @@ Regional research complete — see [kennel-research/](kennel-research/) for deta
 - [ ] **half-mind.com event listings** — evaluate as supplementary discovery data
 - [x] **Meetup.com sources** — 17+ live sources across 8 states; adapter supports zero-code onboarding via admin wizard
 - [ ] Continue refining kennel resolver patterns as new sources reveal new name variants
+
+**FB-identified demand (locations with zero current coverage):**
+The Hash House Harriers Facebook group (16.6K members) generates multiple "Is there a hash in [X]?" posts weekly with 20-72 comments each. These locations have the highest organic demand but no HashTracks coverage yet:
+- Mississippi (Biloxi area — 20 comments; nearest active: Gulf Coast H3 Mobile, NOH3 New Orleans)
+- Maine (Portland — 22 comments)
+- Kentucky (Louisville, Lexington — 3 known kennels: Louisville H3, Cerberus Legion Full Moon H3, Horses Ass)
+- Idaho (Twin Falls)
+- Oklahoma (Tulsa)
+- International: Iceland/Reykjavik (KeflavikH3 just formed), Brazil (Belo Horizonte asked twice with no answer, Sao Paulo), Morocco (Tangier)
 
 **Implementation notes:**
 - Follow [source-onboarding-playbook.md](source-onboarding-playbook.md) for each new source
@@ -568,26 +620,60 @@ See "Source Onboarding Wizard" in What's Built section above. The wizard support
 
 ---
 
-## Priority 2: Strava Integration
+## Priority 2: Discovery & Travel UX
 
-**Status: MVP COMPLETE** (PRs #126, #128)
+**Status: Foundation COMPLETE, key features remaining**
 
-**Strategic rationale:** Zero hashing platforms integrate with fitness tracking apps. Harrier Central, gotothehash.net, half-mind.com — none of them connect runs to GPS data. This feature bridges the gap between hashing and fitness tracking.
+**Strategic rationale:** The #1 post type in the 16.6K-member Hash House Harriers Facebook group is "Is there a hash in [location]?" — posts that generate 20-72 comments each, multiple times per week. Existing directories (half-mind.com, gotothehash.net) are manually maintained, frequently outdated, and can't answer "what's running near me this week?" HashTracks already has the data and map infrastructure to be the definitive answer — but needs stronger public-facing discovery UX.
 
-**See:** [competitive-analysis.md](competitive-analysis.md) — "What HashTracks Has That HC Doesn't"
+**See:** [facebook-user-research.md](facebook-user-research.md) — Pain Points #1 (Where Is There a Hash), #4 (Dead/Inactive Kennels), #5 (Travel Hashing)
 
-- [x] **Strava OAuth flow** — real redirect, refresh token storage, auto-refresh (`src/lib/strava/client.ts`)
-- [x] **Activity history fetch + server-side cache** — StravaActivity model, date string extraction (`src/lib/strava/sync.ts`)
-- [x] **Auto-suggest matches** — by date + region, privacy zone fallback to timezone
-- [x] **One-click attach** — normalize URL to `https://www.strava.com/activities/{id}`
-- [x] **Post-check-in prompt** — suggest linking activity after attendance check-in
-- [x] **Check-in nudge banner** — gentle reminder on logbook page (`StravaNudgeBanner.tsx`)
-- [x] **Rate limit handling** — 429 errors with user-friendly messaging
+### Already Built
+- [x] **Map tab on Hareline** — Google Maps JS (`@vis.gl/react-google-maps`), region-colored pins, click pin → EventDetailPanel, all filters apply, URL-persisted view state
+- [x] **Event detail map** — Google Maps Static API image on EventDetailPanel + standalone event page; coordinate extraction from Maps URLs in merge pipeline
+- [x] **Map toggle on Kennel Directory** — interactive map with kennel pins, color-coded by region, click → kennel page
+- [x] **"Near me" distance filtering** — browser geolocation + Haversine, 10/25/50/100/250 km options
+- [x] **"Search this area" on hareline map** — dynamic map-based event filtering (PR #345)
+- [x] **Map polish** — kennel popup redesign, colocated popup enrichment, default map view, region chips (PRs #349, #353)
 
-### Remaining Strava Work
-- [ ] **Out-of-town run discovery** — Strava activities in regions with no logged attendance → suggest logging
-- [ ] **Advanced matching** — distance/genre validation, multi-day event correlation
-- [ ] **Queue-based sync** — needed when scaling past ~50 concurrent users
+### Kennel Activity Status (New — high value, low effort)
+
+**Why:** Facebook group members repeatedly complain about dead kennels in existing directories. One member manually created a Florida kennel map marking active vs inactive kennels. half-mind.com lists kennels with no indication of whether they still run. This is a trust gap HashTracks can close automatically.
+
+- [ ] Auto-compute activity status from event data (`MAX(date) WHERE kennelId = X`)
+- [ ] Status tiers: **Active** (event in last 90 days), **Possibly Inactive** (90-365 days), **Inactive** (365+ days)
+- [ ] Display status badge on kennel directory cards and kennel profile pages
+- [ ] Filter: "Active only" toggle on kennel directory (default on)
+- [ ] Kennel-only records (no source) default to "Unknown" status
+
+**Implementation notes:**
+- Computed from Event table — no new model needed
+- Can be cached in a `lastEventDate` field on Kennel for performance (updated by merge pipeline)
+- Badge component similar to RegionBadge pattern
+- Filter integrates with existing KennelFilters component
+
+### Public Kennel Finder (New — SEO play)
+
+**Why:** Every "Is there a hash in [X]?" Facebook post is a potential user who would find HashTracks via Google instead — if we rank for "hash house harriers [city]" searches. Currently the hareline and kennel directory require understanding the app. A dedicated public finder page optimized for the exact query people ask would capture this traffic.
+
+- [ ] Public landing page at `/find` or `/discover` — no auth required
+- [ ] Map-centered UX with location search bar ("Find a hash near...")
+- [ ] SEO-optimized for "hash house harriers [city]" search queries
+- [ ] Shows: kennel name, next run date, distance, activity status
+- [ ] CTA: "See full schedule" → hareline filtered to that kennel
+
+### Travel Mode Search (Promoted from future enhancement)
+
+**Why:** "Hash tourism" is a passionate segment — the Facebook group has users searching for runs during marathons, business trips, and intentional "hash every state" projects. They need: destination + date range → matching events.
+
+- [ ] "Runs in [City/Region] between [Date A] and [Date B]"
+- [ ] Input: destination + date range → output: matching events with map
+- [ ] Pairs with Log Unlisted Run for runs found while traveling
+
+### "No Kennel Here" Interest Registration (Future)
+- [ ] Users register interest for locations with no coverage
+- [ ] When a kennel forms or is onboarded, notify interested users
+- [ ] Generates organic demand signal for source coverage prioritization (e.g., Belo Horizonte asked twice with no answer)
 
 ---
 
@@ -672,22 +758,27 @@ See "Source Onboarding Wizard" in What's Built section above. The wizard support
 
 ---
 
-## Priority 5: Map-Based Discovery
+## Priority 5: Strava Integration
 
-**Strategic rationale:** HC's #1 user testimonial is a traveling hasher who searched by radius and found a run. HC has invested years in map performance, distance filtering, and geo exploration. This is the killer feature HashTracks is missing for the traveling hasher persona. The good news: no PostGIS needed — Event model already has `latitude`, `longitude` fields and client-side distance calculation is sufficient for v1.
+**Status: MVP COMPLETE** (PRs #126, #128, #361)
 
-**See:** [competitive-analysis.md](competitive-analysis.md) — Theme: Discovery Quality
+**Strategic rationale:** Zero hashing platforms integrate with fitness tracking apps. Harrier Central, gotothehash.net, half-mind.com — none of them connect runs to GPS data. This feature bridges the gap between hashing and fitness tracking. MVP is complete — remaining work is optimization for scale.
 
-- [x] **Map tab on Hareline** — Google Maps JS (`@vis.gl/react-google-maps`), region-colored pins (filled = precise location, hollow = region centroid), click pin → EventDetailPanel, all filters apply, URL-persisted view state
-- [x] **Event detail map** — Google Maps Static API image on EventDetailPanel + standalone event page; clickable → opens Google Maps; coordinate extraction from `locationAddress` Google Maps URLs in merge pipeline
-- [x] **EventLocationMap text-address fallback** — Works without lat/lng; falls back to `locationName` text address for Google Maps Static API center/markers parameter (covers all hashnyc.com events and text-only sources)
-- [x] **Coordinate extraction from Maps URLs** — merge pipeline calls `extractCoordsFromMapsUrl()` on `locationAddress` (supports @lat,lng, ?q=, ll=, query= URL patterns), stores precise lat/lng on Event records
-- [x] **Map toggle on Kennel Directory** — interactive map with kennel pins, region-colored, click → kennel page (PR #178)
-- [x] **"Near me" distance filtering on Kennel Directory** — browser geolocation + Haversine, 10/25/50/100/250 km options (PR #178)
+**See:** [competitive-analysis.md](competitive-analysis.md) — "What HashTracks Has That HC Doesn't"
 
-- [ ] **Travel Mode search** (future enhancement)
-  - "Runs in [City/Region] between [Date A] and [Date B]"
-  - Pairs with Log Unlisted Run for runs found while traveling
+- [x] **Strava OAuth flow** — real redirect, refresh token storage, auto-refresh (`src/lib/strava/client.ts`)
+- [x] **Activity history fetch + server-side cache** — StravaActivity model, date string extraction (`src/lib/strava/sync.ts`)
+- [x] **Auto-suggest matches** — by date + region, privacy zone fallback to timezone
+- [x] **One-click attach** — normalize URL to `https://www.strava.com/activities/{id}`
+- [x] **Post-check-in prompt** — suggest linking activity after attendance check-in
+- [x] **Check-in nudge banner** — gentle reminder on logbook page (`StravaNudgeBanner.tsx`)
+- [x] **Rate limit handling** — 429 errors with user-friendly messaging
+- [x] **Pagination fix** — fixed Strava activity pagination + race condition in sync (PR #361)
+
+### Remaining Strava Work
+- [ ] **Out-of-town run discovery** — Strava activities in regions with no logged attendance → suggest logging
+- [ ] **Advanced matching** — distance/genre validation, multi-day event correlation
+- [ ] **Queue-based sync** — needed when scaling past ~50 concurrent users
 
 ---
 
@@ -983,18 +1074,18 @@ See "Source Onboarding Wizard" in What's Built section above. The wizard support
 
 ## Priority Summary
 
-| # | Feature | Strategic Driver | Effort | HC Gap Exploited |
-|---|---------|-----------------|--------|------------------|
-| 1 | **Expand Source Coverage** (admin wizard COMPLETE) | Widen primary moat | Ongoing (new sources via wizard) | Manual data entry |
-| 2 | **Strava Integration** (OAuth + auto-match) | Unique differentiator, no competitor has this | 2-3 sprints | Zero fitness integration |
-| 3 | **Misman Growth Lever** (milestone watch, landing page, real-world testing) | B2B adoption, replace Google Sheets | 1 sprint | Paid kennel admin with less capability |
-| 4 | **User Onboarding** (personal CSV import, log unlisted run, manual submission) | Reduce friction, serve traveling hashers | 1-2 sprints | Walled garden onboarding |
-| 5 | **Map-Based Discovery** (map tab, near-me, travel mode) | Traveling hasher killer feature | 1 sprint | App-only proximity search |
-| 6 | **PWA & Notifications** (web push, add-to-home-screen) | Retention, engagement loops | 1 sprint | Native app friction |
-| 7 | **Social Visibility** (who's going, event comments) | Engagement, coordination | Small per feature | RSVP visibility, Trail Chat |
-| 8 | **Data Portability** (CSV exports, payment links) | Trust, data ownership, lightweight Hash Cash | Small per feature | Excel export, Hash Cash |
-| 9 | **Additional Integrations** (iCal, RSS, event series, SEO) | Coverage depth, discoverability | Varies | Feature parity |
-| 10 | **Kennel Onboarding Scaling** (coverage dashboard, discovery, generic HTML) | Automate growth, eliminate manual bottleneck | 3 sprints | No competitor automates source onboarding |
+| # | Feature | Strategic Driver | Effort | FB Validated |
+|---|---------|-----------------|--------|--------------|
+| 1 | **Expand Source Coverage** (185 live, admin wizard) | Widen primary moat | Ongoing | "Is there a hash in [X]?" posts with 20-72 comments |
+| 2 | **Discovery & Travel UX** (activity status, public finder, travel mode) | Capture FB "where's a hash?" traffic | 1-2 sprints | #1 pain point: every search post is a missed user |
+| 3 | **Misman Growth Lever** (milestone watch, landing page, testing) | B2B adoption, replace Google Sheets | 1 sprint | Indirect: kennel organizers are power users |
+| 4 | **User Onboarding** (CSV import, log unlisted run, manual submission) | Reduce friction, serve traveling hashers | 1-2 sprints | Travel hashers need to log runs at unlisted kennels |
+| 5 | **Strava Integration** (MVP complete, optimization remaining) | Unique differentiator | Small | Not mentioned in FB group |
+| 6 | **PWA & Notifications** (web push, add-to-home-screen) | Retention, engagement loops | 1 sprint | Not directly validated |
+| 7 | **Social Visibility** (who's going, event comments) | Engagement, coordination | Small per feature | Charleston cancellation shows real-time need |
+| 8 | **Data Portability** (CSV exports, payment links) | Trust, data ownership | Small per feature | Not directly validated |
+| 9 | **Additional Integrations** (event series, calendar feeds, weather) | Coverage depth | Varies | Not directly validated |
+| 10 | **Kennel Onboarding Scaling** (discovery queue, generic HTML) | Automate growth | 1 sprint remaining | Scales answer to coverage gap demand |
 
 ---
 
@@ -1002,6 +1093,7 @@ See "Source Onboarding Wizard" in What's Built section above. The wizard support
 
 - [Source Onboarding Playbook](source-onboarding-playbook.md) — step-by-step guide for adding sources
 - [Competitive Analysis](competitive-analysis.md) — Harrier Central analysis and strategic positioning
+- [Facebook User Research](facebook-user-research.md) — HHH Facebook group (16.6K members) pain points and location demand analysis
 - [Kennel Page Redesign Spec](kennel-page-redesign-spec.md) — kennel profile enrichment and page redesign spec
 - [Kennel Research](kennel-research/) — regional research for DC, Chicago, SF Bay, London kennels
 - [Misman Attendance Requirements](misman-attendance-requirements.md) — kennel attendance management tool requirements and decisions


### PR DESCRIPTION
## Summary
- **Updated roadmap stats**: 290 kennels, 185 sources, 137 regions (4 countries)
- **Added recent completed work**: Scotland, Bristol, Norfolk, Merseyside, Germany, Hawaii sources; data quality audits; map polish; dark mode; Strava pagination fix; HashRego backfill
- **Reprioritized based on Facebook group research** (16.6K-member HHH group): Discovery & Travel UX elevated from P5 to P2; Strava (MVP complete) moved from P2 to P5
- **New features added to roadmap**: Kennel Activity Status, Public Kennel Finder, Travel Mode Search, Interest Registration
- **Saved FB user research** as `docs/facebook-user-research.md` — documents pain points, location demand, and recommendations

## Key Priority Change
The #1 post type in the HHH Facebook group is "Is there a hash in [location]?" with 20-72 comments per post. This validates Discovery & Travel UX as the next highest-priority feature area after source coverage expansion.

## Test plan
- [ ] Review roadmap for consistency (stats, priority numbering, no duplicates)
- [ ] Verify FB research doc accurately reflects the analysis
- [ ] Confirm new priority ordering aligns with strategic direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)