### PR TITLE
Fix Cape Fear year resolution via run-number monotonicity

### DIFF
--- a/src/adapters/html-scraper/generic.test.ts
+++ b/src/adapters/html-scraper/generic.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as cheerio from "cheerio";
-import { parseEventRow, GenericHtmlAdapter, isGenericHtmlConfig } from "./generic";
+import { parseEventRow, GenericHtmlAdapter, isGenericHtmlConfig, fixYearMonotonicity } from "./generic";
 import type { GenericHtmlConfig } from "./generic";
 import type { Source } from "@/generated/prisma/client";
 
@@ -481,46 +481,57 @@ describe("GenericHtmlAdapter", () => {
     expect(result.events.map(e => e.runNumber)).toEqual([514, 515, 516]);
   });
 
-  it("parses hyphenated M-D dates from Cape Fear hare line format", async () => {
-    const html = `<html><body>
-      <figure><table>
-        <tr><th>Trail #</th><th>Date</th><th>Hare(s)</th></tr>
-        <tr><td>514</td><td>3-7</td><td>Photo Spread</td></tr>
-        <tr><td>515</td><td>3-21</td><td>Mis-Man</td></tr>
-        <tr><td>516</td><td>4-4 EASTER WKND</td><td>TBD</td></tr>
-        <tr><td>517</td><td>4-18</td><td>Triple B</td></tr>
-        <tr><td>518</td><td>5-2</td><td>Plow Pants</td></tr>
-        <tr><td>519</td><td>10-31: 5th Saturday Social HALLOWEEN</td><td>TBD</td></tr>
-        <tr><td>520</td><td>7/24 – 7/26 PEG ISLAND</td><td>TBD</td></tr>
-      </table></figure>
-    </body></html>`;
-    const $ = cheerio.load(html);
-    mockFetchHTMLPage.mockResolvedValue({
-      ok: true, html, $, structureHash: "x", fetchDurationMs: 50,
-    });
+  it("parses hyphenated M-D dates and corrects year jumps (Cape Fear pattern)", async () => {
+    // Pin "today" to March 29, 2026 so forwardDate behavior is deterministic:
+    // 3-7 and 3-21 have passed → chrono pushes to 2027; 4-4+ are future → stay 2026
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 29, 12)));
 
-    const source = {
-      id: "cfh3-hyphen",
-      url: "https://capefearh3.com/hare-line/",
-      config: {
-        defaultKennelTag: "cfh3",
-        containerSelector: "figure:first-of-type table",
-        rowSelector: "tr",
-        columns: { runNumber: "td:nth-child(1)", date: "td:nth-child(2)", hares: "td:nth-child(3)" },
-        forwardDate: true,
-        stopWhenRunNumberDecreases: true,
-      },
-    } as unknown as Source;
+    try {
+      const html = `<html><body>
+        <figure><table>
+          <tr><th>Trail #</th><th>Date</th><th>Hare(s)</th></tr>
+          <tr><td>514</td><td>3-7</td><td>Photo Spread</td></tr>
+          <tr><td>515</td><td>3-21</td><td>Mis-Man</td></tr>
+          <tr><td>516</td><td>4-4 EASTER WKND</td><td>TBD</td></tr>
+          <tr><td>517</td><td>4-18</td><td>Triple B</td></tr>
+          <tr><td>518</td><td>5-2</td><td>Plow Pants</td></tr>
+          <tr><td>519</td><td>10-31: 5th Saturday Social HALLOWEEN</td><td>TBD</td></tr>
+          <tr><td>520</td><td>7/24 – 7/26 PEG ISLAND</td><td>TBD</td></tr>
+        </table></figure>
+      </body></html>`;
+      const $ = cheerio.load(html);
+      mockFetchHTMLPage.mockResolvedValue({
+        ok: true, html, $, structureHash: "x", fetchDurationMs: 50,
+      });
 
-    const result = await adapter.fetch(source);
-    // All 7 data rows should parse (header row has no <td>, so parseEventRow skips it)
-    expect(result.events).toHaveLength(7);
-    expect(result.events.map(e => e.runNumber)).toEqual([514, 515, 516, 517, 518, 519, 520]);
-    // Verify dates parsed correctly (year inferred via forwardDate)
-    const expectedMonthDays = ["03-07", "03-21", "04-04", "04-18", "05-02", "10-31", "07-24"];
-    expect(result.events.map(e => e.date?.substring(5))).toEqual(expectedMonthDays);
-    expect(result.events[0].hares).toBe("Photo Spread");
-    expect(result.events[2].hares).toBeUndefined();
+      const source = {
+        id: "cfh3-hyphen",
+        url: "https://capefearh3.com/hare-line/",
+        config: {
+          defaultKennelTag: "cfh3",
+          containerSelector: "figure:first-of-type table",
+          rowSelector: "tr",
+          columns: { runNumber: "td:nth-child(1)", date: "td:nth-child(2)", hares: "td:nth-child(3)" },
+          forwardDate: true,
+          maxPastDays: 14,
+          stopWhenRunNumberDecreases: true,
+        },
+      } as unknown as Source;
+
+      const result = await adapter.fetch(source);
+      // 3-7 is >14 days past after year correction → filtered by maxPastDays re-apply
+      // 3-21 is 8 days past → within maxPastDays window
+      expect(result.events.map(e => e.runNumber)).toEqual([515, 516, 517, 518, 519, 520]);
+      // All dates should be 2026 (year correction fixed 3-21 from 2027 → 2026)
+      expect(result.events.every(e => e.date!.startsWith("2026-"))).toBe(true);
+      const expectedMonthDays = ["03-21", "04-04", "04-18", "05-02", "10-31", "07-24"];
+      expect(result.events.map(e => e.date?.substring(5))).toEqual(expectedMonthDays);
+      expect(result.events[0].hares).toBe("Mis-Man");
+      expect(result.events[1].hares).toBeUndefined(); // TBD filtered
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns empty events when page has no matching rows", async () => {
@@ -539,5 +550,81 @@ describe("GenericHtmlAdapter", () => {
     const result = await adapter.fetch(source);
     expect(result.events).toHaveLength(0);
     expect(result.diagnosticContext?.rowsFound).toBe(0);
+  });
+});
+
+describe("fixYearMonotonicity", () => {
+  const makeEvent = (date: string, runNumber?: number) => ({
+    date,
+    kennelTag: "TEST",
+    sourceUrl: "https://example.com",
+    runNumber,
+  });
+
+  it("corrects year jumps when run numbers are ascending", () => {
+    const events = [
+      makeEvent("2027-03-07", 514),
+      makeEvent("2027-03-21", 515),
+      makeEvent("2026-04-04", 516),
+      makeEvent("2026-04-18", 517),
+    ];
+    const fixed = fixYearMonotonicity(events);
+    expect(fixed.map(e => e.date)).toEqual([
+      "2026-03-07",
+      "2026-03-21",
+      "2026-04-04",
+      "2026-04-18",
+    ]);
+  });
+
+  it("returns unchanged when dates are already monotonic", () => {
+    const events = [
+      makeEvent("2026-03-07", 514),
+      makeEvent("2026-04-04", 515),
+      makeEvent("2026-05-02", 516),
+    ];
+    const fixed = fixYearMonotonicity(events);
+    expect(fixed.map(e => e.date)).toEqual(["2026-03-07", "2026-04-04", "2026-05-02"]);
+  });
+
+  it("returns unchanged when events have no run numbers", () => {
+    const events = [
+      makeEvent("2027-03-07"),
+      makeEvent("2026-04-04"),
+    ];
+    const fixed = fixYearMonotonicity(events);
+    expect(fixed.map(e => e.date)).toEqual(["2027-03-07", "2026-04-04"]);
+  });
+
+  it("returns unchanged when run numbers are not ascending", () => {
+    const events = [
+      makeEvent("2027-03-07", 516),
+      makeEvent("2026-04-04", 514),
+    ];
+    const fixed = fixYearMonotonicity(events);
+    expect(fixed.map(e => e.date)).toEqual(["2027-03-07", "2026-04-04"]);
+  });
+
+  it("preserves legitimate Dec→Jan year boundary", () => {
+    const events = [
+      makeEvent("2026-12-05", 535),
+      makeEvent("2027-01-16", 536),
+    ];
+    const fixed = fixYearMonotonicity(events);
+    expect(fixed.map(e => e.date)).toEqual(["2026-12-05", "2027-01-16"]);
+  });
+
+  it("handles mixed events with and without run numbers", () => {
+    const events = [
+      makeEvent("2027-03-07", 514),
+      makeEvent("2026-03-15"),          // no run number
+      makeEvent("2026-04-04", 516),
+    ];
+    const fixed = fixYearMonotonicity(events);
+    // #514 compared to #516: 2027-03-07 > 2026-04-04 by >6mo → subtract year
+    expect(fixed[0].date).toBe("2026-03-07");
+    // Event without run number is unchanged
+    expect(fixed[1].date).toBe("2026-03-15");
+    expect(fixed[2].date).toBe("2026-04-04");
   });
 });

--- a/src/adapters/html-scraper/generic.ts
+++ b/src/adapters/html-scraper/generic.ts
@@ -104,6 +104,47 @@ const CTA_HARES_RE = /^(?:tbd|tba|tbc|n\/a|sign[\s\u00A0]*up!?|volunteer|needed|
 /** UK postcode pattern for location truncation. */
 const UK_POSTCODE_RE = /([A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2})/i;
 
+const SIX_MONTHS_MS = 6 * 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Fix year-resolution errors caused by `forwardDate: true` on year-less dates.
+ * Uses run-number ordering as a monotonicity constraint: if ascending run numbers
+ * have a backward date jump >6 months, the earlier date's year is decremented.
+ * Exported for unit testing.
+ */
+export function fixYearMonotonicity(events: RawEventData[]): RawEventData[] {
+  // Need at least 2 events with run numbers
+  const withRun = events.filter(e => e.runNumber != null && e.date);
+  if (withRun.length < 2) return events;
+
+  // Check run numbers are monotonically non-decreasing
+  for (let i = 1; i < withRun.length; i++) {
+    if (withRun[i].runNumber! < withRun[i - 1].runNumber!) return events;
+  }
+
+  // Build index of events with run numbers for backward walk
+  const runIndices = events
+    .map((e, i) => (e.runNumber != null && e.date ? i : -1))
+    .filter(i => i >= 0);
+
+  const result = events.map(e => ({ ...e }));
+
+  // Walk backward: trust last event, fix earlier ones
+  for (let ri = runIndices.length - 2; ri >= 0; ri--) {
+    const cur = runIndices[ri];
+    const next = runIndices[ri + 1];
+    const curDate = new Date(result[cur].date + "T12:00:00Z");
+    const nextDate = new Date(result[next].date + "T12:00:00Z");
+
+    if (curDate.getTime() - nextDate.getTime() > SIX_MONTHS_MS) {
+      curDate.setUTCFullYear(curDate.getUTCFullYear() - 1);
+      result[cur].date = curDate.toISOString().slice(0, 10);
+    }
+  }
+
+  return result;
+}
+
 /**
  * Parse a single row element into RawEventData using the column config.
  * Exported for unit testing.
@@ -208,7 +249,7 @@ export class GenericHtmlAdapter implements SourceAdapter {
     if (!page.ok) return page.result;
     const { $, structureHash, fetchDurationMs } = page;
 
-    const events: RawEventData[] = [];
+    let events: RawEventData[] = [];
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
 
@@ -257,6 +298,14 @@ export class GenericHtmlAdapter implements SourceAdapter {
         ];
       }
     });
+
+    // Fix year-resolution errors from forwardDate before returning
+    if (config.forwardDate) {
+      events = fixYearMonotonicity(events);
+      if (pastCutoff) {
+        events = events.filter(e => e.date >= pastCutoff);
+      }
+    }
 
     const hasErrors = hasAnyErrors(errorDetails);
 


### PR DESCRIPTION
## Summary
- **Bug**: `forwardDate: true` pushes past month-day combos to next year — CFH3 dates like "3-7" (March 7) resolve to 2027 instead of 2026 when that date has already passed
- **Fix**: Add `fixYearMonotonicity()` post-processing in the generic HTML scraper. Uses ascending run numbers as a chronological constraint: backward-walks from the last event (closest to today, most likely correct) and subtracts a year when a date jumps >6 months ahead of its successor
- **Bonus**: Re-applies `maxPastDays` filter after year correction, so corrected-to-past events (e.g., March 7 now correctly 2026 but >14 days ago) get filtered out

## Test plan
- [x] 6 unit tests for `fixYearMonotonicity`: year jump fix, already monotonic, no run numbers, non-ascending, Dec→Jan boundary, mixed run numbers
- [x] Updated CFH3 integration test with fake timers pinned to March 29, 2026 — verifies year correction + maxPastDays re-filtering
- [x] Full suite: 2923/2923 tests pass
- [ ] After deploy: verify CFH3 scrape assigns correct 2026 years to all events

## Depends on
- #371 (hyphenated M-D date normalization — already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)