### PR TITLE
refactor: simplify audit system — deduplicate, reuse, memoize

### DIFF
--- a/scripts/audit-data-quality.ts
+++ b/scripts/audit-data-quality.ts
@@ -1,9 +1,10 @@
 /**
  * Automated data quality audit — queries upcoming events for known bad patterns.
+ * Uses the same check functions as the API route, with a standalone DB connection.
  *
  * Usage:
  *   npx tsx scripts/audit-data-quality.ts              # dry run (print findings)
- *   npx tsx scripts/audit-data-quality.ts --post-issue  # create GitHub issue
+ *   npx tsx scripts/audit-data-quality.ts --post-issue  # create GitHub issue via gh CLI
  */
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
@@ -13,14 +14,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import {
-  checkHareQuality,
-  checkTitleQuality,
-  checkLocationQuality,
-  checkEventQuality,
-  checkDescriptionQuality,
-  type AuditFinding,
-} from "../src/pipeline/audit-checks";
+import type { AuditFinding } from "../src/pipeline/audit-checks";
+import { runChecks } from "../src/pipeline/audit-runner";
 import { formatIssueTitle, formatIssueBody } from "../src/pipeline/audit-format";
 
 const postIssue = process.argv.includes("--post-issue");
@@ -36,7 +31,7 @@ function postGitHubIssue(findings: AuditFinding[]): void {
     fs.writeFileSync(bodyFile, body);
     const result = spawnSync("gh", [
       "issue", "create",
-      "--repo", "johnrclem/hashtracks-web",
+      "--repo", process.env.GITHUB_REPOSITORY ?? "johnrclem/hashtracks-web",
       "--title", title,
       "--label", "audit",
       "--label", "claude-fix",
@@ -60,94 +55,52 @@ async function main() {
 
   console.log(postIssue ? "📋 AUDIT — will post GitHub issue\n" : "🔍 AUDIT — dry run\n");
 
-  // Query upcoming events (next 90 days) with kennel + source data
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - 7);
   const futureDate = new Date();
   futureDate.setDate(futureDate.getDate() + 90);
 
   const events = await prisma.event.findMany({
-    where: {
-      date: { gte: cutoffDate, lte: futureDate },
-      status: "CONFIRMED",
-    },
+    where: { date: { gte: cutoffDate, lte: futureDate }, status: "CONFIRMED" },
     select: {
-      id: true,
-      title: true,
-      haresText: true,
-      description: true,
-      locationName: true,
-      locationCity: true,
-      startTime: true,
-      runNumber: true,
-      date: true,
-      sourceUrl: true,
+      id: true, title: true, haresText: true, description: true,
+      locationName: true, locationCity: true, startTime: true,
+      runNumber: true, date: true, sourceUrl: true,
       kennel: { select: { shortName: true, kennelCode: true } },
       rawEvents: {
-        take: 1,
-        orderBy: [{ scrapedAt: "desc" }],
-        select: {
-          rawData: true,
-          source: { select: { type: true, scrapeDays: true } },
-        },
+        take: 1, orderBy: [{ scrapedAt: "desc" }],
+        select: { rawData: true, source: { select: { type: true, scrapeDays: true } } },
       },
     },
   });
 
   console.log(`Queried ${events.length} upcoming events\n`);
 
-  // Flatten for check functions
   const rows = events.map(e => ({
-    id: e.id,
-    kennelShortName: e.kennel.shortName,
-    kennelCode: e.kennel.kennelCode,
-    haresText: e.haresText,
-    title: e.title,
-    description: e.description,
-    locationName: e.locationName,
-    locationCity: e.locationCity,
-    startTime: e.startTime,
-    runNumber: e.runNumber,
-    date: e.date.toISOString().split("T")[0],
-    sourceUrl: e.sourceUrl,
+    id: e.id, kennelShortName: e.kennel.shortName, kennelCode: e.kennel.kennelCode,
+    haresText: e.haresText, title: e.title, description: e.description,
+    locationName: e.locationName, locationCity: e.locationCity,
+    startTime: e.startTime, runNumber: e.runNumber,
+    date: e.date.toISOString().split("T")[0], sourceUrl: e.sourceUrl,
     sourceType: e.rawEvents[0]?.source?.type ?? "UNKNOWN",
     scrapeDays: e.rawEvents[0]?.source?.scrapeDays ?? 90,
     rawDescription: (e.rawEvents[0]?.rawData as Record<string, unknown>)?.description as string | null ?? null,
   }));
 
-  // Run all checks — hare/title take single events, location/event/description take arrays
-  const findings: AuditFinding[] = [];
-  for (const row of rows) {
-    findings.push(...checkHareQuality(row), ...checkTitleQuality(row));
-  }
-  findings.push(
-    ...checkLocationQuality(rows),
-    ...checkEventQuality(rows),
-    ...checkDescriptionQuality(rows),
-  );
-
-  // Print summary
-  const byCategory = new Map<string, number>();
-  for (const f of findings) {
-    byCategory.set(f.category, (byCategory.get(f.category) ?? 0) + 1);
-  }
+  const { findings, summary } = runChecks(rows);
 
   if (findings.length === 0) {
     console.log("✅ No issues found!");
   } else {
     console.log(`Found ${findings.length} issues:`);
-    for (const [cat, count] of byCategory) {
+    for (const [cat, count] of Object.entries(summary)) {
       console.log(`  ${cat}: ${count}`);
     }
     console.log("");
-
     for (const f of findings) {
       console.log(`  [${f.severity}] ${f.kennelShortName}: ${f.rule} — "${f.currentValue.slice(0, 60)}"`);
     }
-
-    if (postIssue) {
-      postGitHubIssue(findings);
-    }
+    if (postIssue) postGitHubIssue(findings);
   }
 
   await prisma.$disconnect();

--- a/src/pipeline/audit-checks.ts
+++ b/src/pipeline/audit-checks.ts
@@ -60,6 +60,18 @@ export function finding(
   };
 }
 
+/** Memoized regex cache for kennelCode → Trail pattern (avoids recompiling per event). */
+const kennelCodePatternCache = new Map<string, RegExp>();
+function getKennelCodePattern(kennelCode: string): RegExp {
+  let pattern = kennelCodePatternCache.get(kennelCode);
+  if (!pattern) {
+    const escaped = kennelCode.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+    pattern = new RegExp(String.raw`^${escaped}\s+Trail`, "i");
+    kennelCodePatternCache.set(kennelCode, pattern);
+  }
+  return pattern;
+}
+
 const TITLE_CTA_PATTERN =
   /\b(?:wanna\s+hare|available\s+dates|check\s+out\s+our|sign\s*up)\b/i;
 const TITLE_SCHEDULE_PATTERNS = [
@@ -74,13 +86,8 @@ const TITLE_TIME_ONLY_PATTERN =
 
 const CTA_PATTERN =
   /^(?:tbd|tba|tbc|n\/a|sign[\s\u00A0]*up!?|volunteer|needed|required)$/i;
-const BOILERPLATE_MARKERS = [
-  "WHAT TIME",
-  "WHERE",
-  "HASH CASH",
-  "Location",
-  "Directions",
-];
+// Reuse the shared boilerplate regex from adapter utils
+import { HARE_BOILERPLATE_RE } from "@/adapters/utils";
 
 export function checkTitleQuality(event: AuditEventRow): AuditFinding[] {
   const { title, kennelCode, kennelShortName } = event;
@@ -91,12 +98,7 @@ export function checkTitleQuality(event: AuditEventRow): AuditFinding[] {
   }
 
   // 1. title-raw-kennel-code (error): title starts with `{kennelCode} Trail` but NOT with `{kennelShortName}`
-  // Dynamic regex is necessary here — kennelCode varies per event. Input is escaped.
-  const escapedCode = kennelCode.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-  const kennelCodeTrailPattern = new RegExp(
-    String.raw`^${escapedCode}\s+Trail`,
-    "i"
-  );
+  const kennelCodeTrailPattern = getKennelCodePattern(kennelCode);
   if (
     kennelCodeTrailPattern.test(title) &&
     !title.startsWith(kennelShortName)
@@ -397,7 +399,7 @@ export function checkHareQuality(event: AuditEventRow): AuditFinding[] {
   }
 
   // 6. hare-boilerplate-leak (warning): contains boilerplate markers
-  if (BOILERPLATE_MARKERS.some((marker) => haresText.includes(marker))) {
+  if (HARE_BOILERPLATE_RE.test(haresText)) {
     return [
       finding(event, {
         category: "hares",

--- a/src/pipeline/audit-issue.ts
+++ b/src/pipeline/audit-issue.ts
@@ -6,7 +6,11 @@ import type { AuditFinding } from "./audit-checks";
 import { formatIssueTitle, formatIssueBody } from "./audit-format";
 
 const FETCH_TIMEOUT_MS = 10_000;
-const REPO = "johnrclem/hashtracks-web";
+const DEFAULT_REPO = "johnrclem/hashtracks-web";
+
+function getRepo(): string {
+  return process.env.GITHUB_REPOSITORY ?? DEFAULT_REPO;
+}
 
 /**
  * File a GitHub issue with audit findings. Returns the issue URL on success, null on failure.
@@ -38,7 +42,7 @@ export async function fileAuditIssue(findings: AuditFinding[]): Promise<string |
 
   try {
     const res = await fetch(
-      `https://api.github.com/repos/${REPO}/issues`,
+      `https://api.github.com/repos/${getRepo()}/issues`,
       {
         method: "POST",
         headers,
@@ -61,7 +65,7 @@ export async function fileAuditIssue(findings: AuditFinding[]): Promise<string |
     // Add claude-fix label separately so triage workflow receives one labeled event
     try {
       await fetch(
-        `https://api.github.com/repos/${REPO}/issues/${issue.number}/labels`,
+        `https://api.github.com/repos/${getRepo()}/issues/${issue.number}/labels`,
         {
           method: "POST",
           headers,
@@ -85,7 +89,7 @@ export async function fileAuditIssue(findings: AuditFinding[]): Promise<string |
 async function checkExistingAuditIssue(token: string, date: string): Promise<string | null> {
   try {
     const res = await fetch(
-      `https://api.github.com/repos/${REPO}/issues?state=open&labels=audit&per_page=10`,
+      `https://api.github.com/repos/${getRepo()}/issues?state=open&labels=audit&per_page=10`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/src/pipeline/audit-runner.ts
+++ b/src/pipeline/audit-runner.ts
@@ -18,6 +18,26 @@ export interface AuditResult {
   summary: Record<string, number>;
 }
 
+/** Run all audit checks on pre-queried rows. Usable by both API route and standalone script. */
+export function runChecks(rows: Parameters<typeof checkHareQuality>[0][]): { findings: AuditFinding[]; summary: Record<string, number> } {
+  const findings: AuditFinding[] = [];
+  for (const row of rows) {
+    findings.push(...checkHareQuality(row), ...checkTitleQuality(row));
+  }
+  findings.push(
+    ...checkLocationQuality(rows),
+    ...checkEventQuality(rows),
+    ...checkDescriptionQuality(rows),
+  );
+
+  const summary: Record<string, number> = {};
+  for (const f of findings) {
+    summary[f.category] = (summary[f.category] ?? 0) + 1;
+  }
+
+  return { findings, summary };
+}
+
 export async function runAudit(): Promise<AuditResult> {
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - 7);
@@ -70,20 +90,5 @@ export async function runAudit(): Promise<AuditResult> {
     rawDescription: (e.rawEvents[0]?.rawData as Record<string, unknown>)?.description as string | null ?? null,
   }));
 
-  const findings: AuditFinding[] = [];
-  for (const row of rows) {
-    findings.push(...checkHareQuality(row), ...checkTitleQuality(row));
-  }
-  findings.push(
-    ...checkLocationQuality(rows),
-    ...checkEventQuality(rows),
-    ...checkDescriptionQuality(rows),
-  );
-
-  const summary: Record<string, number> = {};
-  for (const f of findings) {
-    summary[f.category] = (summary[f.category] ?? 0) + 1;
-  }
-
-  return { eventsScanned: events.length, findings, summary };
+  return { eventsScanned: events.length, ...runChecks(rows) };
 }


### PR DESCRIPTION
## Summary
Code review cleanup for the audit system. Net -36 lines.

- **Deduplicate check dispatch**: extracted `runChecks()` from audit-runner.ts — script now calls shared function instead of re-implementing the check loop
- **Reuse HARE_BOILERPLATE_RE**: replaced custom `BOILERPLATE_MARKERS` array with the shared regex from `adapters/utils.ts` (covers all markers + more)
- **Memoize regex compilation**: `checkTitleQuality` cached kennelCode patterns to avoid recompiling identical regex for events from the same kennel
- **Use GITHUB_REPOSITORY env var**: `audit-issue.ts` now reads `process.env.GITHUB_REPOSITORY` with fallback, matching the `auto-issue.ts` pattern

## Test plan
- [x] All 46 audit check tests pass
- [x] No new files — only modifications to existing audit files

🤖 Generated with [Claude Code](https://claude.com/claude-code)