### PR TITLE
fix: add GET handler for audit cron endpoint

### DIFF
--- a/src/app/api/cron/audit/route.ts
+++ b/src/app/api/cron/audit/route.ts
@@ -5,7 +5,7 @@ import { fileAuditIssue } from "@/pipeline/audit-issue";
 
 /**
  * Daily data quality audit endpoint.
- * Triggered by QStash (or manually with Bearer CRON_SECRET).
+ * Triggered by Vercel Cron (GET) or QStash (POST) or manually with Bearer CRON_SECRET.
  * Queries upcoming events for known bad patterns and files a GitHub issue if findings exist.
  */
 export async function POST(request: Request) {
@@ -44,4 +44,9 @@ export async function POST(request: Request) {
       { status: 500 },
     );
   }
+}
+
+/** Vercel Cron triggers GET requests. */
+export async function GET(request: Request) {
+  return POST(request);
 }


### PR DESCRIPTION
## Summary
Vercel Cron triggers GET requests, but `/api/cron/audit` only exported POST → 405 Method Not Allowed.

Added `GET` handler that delegates to `POST`, matching the existing pattern in `/api/cron/dispatch`.

## Test plan
- [ ] Trigger Vercel cron after deploy, verify 200 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)