### PR TITLE
fix: address 35 of 44 audit data quality issues

### DIFF
--- a/scripts/backfill-audit-fixes.ts
+++ b/scripts/backfill-audit-fixes.ts
@@ -15,7 +15,7 @@ import { sanitizeHares, sanitizeLocation, suppressRedundantCity } from "../src/p
 const dryRun = !process.argv.includes("--apply");
 
 async function main() {
-  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL, ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : undefined });
   const adapter = new PrismaPg(pool);
   const prisma = new PrismaClient({ adapter } as never);
 

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1344,7 +1344,15 @@ describe("suppressRedundantCity", () => {
   });
 
   it("suppresses city when locationName has state + zip and city differs", () => {
-    expect(suppressRedundantCity("Palm Beach County, FL 33414", "Wellington, FL")).toBeNull();
+    expect(suppressRedundantCity("1234 Main St, Palm Beach County, FL 33414", "Wellington, FL")).toBeNull();
+  });
+
+  it("preserves city when locationName has only street + state (no city segment)", () => {
+    expect(suppressRedundantCity("123 Main St, OH", "Akron, OH")).toBe("Akron, OH");
+  });
+
+  it("preserves city when locationName is county + state (2 segments)", () => {
+    expect(suppressRedundantCity("Palm Beach County, FL", "Wellington, FL")).toBe("Wellington, FL");
   });
 
   it("returns null when city is null", () => {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -139,7 +139,7 @@ async function createEventLinks(
 // ── Helper types for internal decomposition ──
 
 /** Cached kennel data shape used by the per-batch cache and resolveKennelData. */
-type KennelCacheEntry = {
+interface KennelCacheEntry {
   kennelCode: string;
   shortName: string;
   fullName: string | null;
@@ -149,7 +149,7 @@ type KennelCacheEntry = {
   country: string;
   regionCentroidLat: number | null;
   regionCentroidLng: number | null;
-};
+}
 
 /** Per-batch state threaded through all merge helper functions. */
 interface MergeContext {
@@ -525,6 +525,8 @@ export function sanitizeLocation(location: string | undefined): string | null {
 export function suppressRedundantCity(locationName: string | null, city: string | null): string | null {
   if (!city || !locationName) return city;
   if (!/,\s*[A-Z]{2}(?:\s+\d{5})?$/.test(locationName)) return city;
+  // Require at least 3 segments (e.g., "Street, City, ST") — fewer suggests incomplete address
+  if (locationName.split(",").length < 3) return city;
   const cityName = city.split(",")[0].trim();
   if (cityName && !locationName.includes(cityName)) return null;
   return city;
@@ -895,7 +897,7 @@ async function processNewRawEvent(
       : `${displayName} Trail`;
   } else {
     const displayName = friendlyKennelName(kennelData.shortName, kennelData.fullName);
-    if (displayName && displayName.toLowerCase() !== kennelData.kennelCode.toLowerCase()) {
+    if (displayName && kennelData.kennelCode && displayName.toLowerCase() !== kennelData.kennelCode.toLowerCase()) {
       const escaped = kennelData.kennelCode.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
       const codePattern = new RegExp(String.raw`^${escaped}(\s+Trail.*)`, "i");
       const match = sanitized.match(codePattern);


### PR DESCRIPTION
## Summary
Fixes code-level root causes for data quality issues found by the daily audit (#387).

- **Title raw kennel code (24 errors):** Merge pipeline now detects titles matching `{kennelCode} Trail` and replaces with friendly display name via `friendlyKennelName()`. Also fixes the regex to handle "Hash House Harriers and Harriettes" (Dayton H4).
- **Hare CTA text (8 warnings):** `sanitizeHares()` now filters "Sign up!" and "volunteer" placeholders.
- **Location region appended (3 warnings):** New `suppressRedundantCity()` skips setting `locationCity` when `locationName` already contains a complete address with state code and the reverse-geocoded city differs.

### Not addressed (9 remaining)
- 1 location-duplicate-segments — stale data, existing `deduplicateAddressPrefix()` handles new scrapes
- 3 event-improbable-time — source data issues (UTC times)
- 5 TBD hares — stale data, existing `isPlaceholder()` handles new scrapes

### Backfill scripts included (not yet run)
- `scripts/backfill-event-titles.ts` — rewrites 18 stale Munich H3 titles
- `scripts/backfill-audit-fixes.ts` — fixes 1,189 stale hares/location/city values

Closes #387

## Test plan
- [x] `friendlyKennelName()` handles "Harriers and Harriettes" suffix
- [x] `sanitizeHares()` filters "Sign up!", "volunteer"
- [x] `suppressRedundantCity()` suppresses mismatched city, passes matching city
- [x] Integration tests for default title generation still pass
- [x] Dry-run backfill scripts validated against production data
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npm run lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)