### PR TITLE
Onboard Netherlands: Amsterdam H3 + The Hague H3

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -343,5 +343,9 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "bmph3-be": ["BMPH3", "Brussels Manneke Piss", "Manneke Piss Hash", "BMP H3"],
     "bbmh3": ["BBMH3", "Brussels Blue Moon", "Blue Moon Hash", "Brussels Blue Moon H3"],
     "bruh3": ["BruH3", "Brussels Hash", "Brussels HHH", "Brussels Hash House Harriers", "BH3 Brussels"],
+
+    // ===== NETHERLANDS =====
+    "ah3-nl": ["AH3", "Amsterdam Hash", "Amsterdam HHH", "Amsterdam H3"],
+    "hagueh3": ["Hague H3", "The Hague Hash", "The Hague HHH", "Den Haag Hash", "HHH Den Haag"],
   };
 

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2243,5 +2243,27 @@ export const KENNELS: KennelSeed[] = [
       description: "Brussels' original Saturday hash, running weekly at 15:00 from different locations in and around Brussels since the 1980s.",
       latitude: 50.85, longitude: 4.35,
     },
+
+    // ── Netherlands: Amsterdam ──
+    {
+      kennelCode: "ah3-nl", shortName: "AH3", fullName: "Amsterdam Hash House Harriers", region: "Amsterdam", country: "Netherlands",
+      website: "https://ah3.nl",
+      scheduleDayOfWeek: "Sunday", scheduleTime: "2:45 PM", scheduleFrequency: "Weekly",
+      hashCash: "€5",
+      description: "Amsterdam's weekly hash, usually Sundays at 14:45. Trails through parks, streets, and hidden gems, 6-10 km. Annual Canal Hash on boats through UNESCO canals.",
+      latitude: 52.37, longitude: 4.90,
+    },
+
+    // ── Netherlands: The Hague ──
+    {
+      kennelCode: "hagueh3", shortName: "Hague H3", fullName: "The Hague Hash House Harriers", region: "The Hague", country: "Netherlands",
+      website: "https://haguehash.nl",
+      contactEmail: "mismanagement@haguehash.nl",
+      scheduleFrequency: "Weekly",
+      scheduleNotes: "Winter: Sunday 14:00, Summer: Wednesday 19:00",
+      hashCash: "€7",
+      description: "The Hague's weekly hash — Sundays at 14:00 in winter, Wednesdays at 19:00 in summer. Run fee includes beer and snacks.",
+      latitude: 52.08, longitude: 4.30,
+    },
   ];
 

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2572,5 +2572,28 @@ export const SOURCES = [
       },
       kennelCodes: ["bruh3"],
     },
+
+    // ===== NETHERLANDS =====
+    {
+      name: "Amsterdam H3 Website",
+      url: "https://ah3.nl/nextruns/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 365,
+      config: {
+        previousUrl: "https://ah3.nl/previous/",
+      },
+      kennelCodes: ["ah3-nl"],
+    },
+    {
+      name: "The Hague H3 Website",
+      url: "https://haguehash.nl/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 365,
+      kennelCodes: ["hagueh3"],
+    },
   ];
 

--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Source } from "@/generated/prisma/client";
+import {
+  parseEventBlock,
+  extractEvents,
+  htmlToText,
+  AH3Adapter,
+} from "./ah3";
+
+// Mock safeFetch (used by fetchHTMLPage)
+vi.mock("@/adapters/safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+
+// Mock structure-hash
+vi.mock("@/pipeline/structure-hash", () => ({
+  generateStructureHash: vi.fn(() => "mock-hash-ah3"),
+}));
+
+const { safeFetch } = await import("@/adapters/safe-fetch");
+const mockedSafeFetch = vi.mocked(safeFetch);
+
+const SOURCE_URL = "https://ah3.nl/nextruns/";
+const PREVIOUS_URL = "https://ah3.nl/previous/";
+
+function makeSource(overrides?: Partial<Source>): Source {
+  return {
+    id: "src-ah3",
+    name: "Amsterdam H3 Website",
+    url: SOURCE_URL,
+    type: "HTML_SCRAPER",
+    trustLevel: 7,
+    scrapeFreq: "daily",
+    scrapeDays: 365,
+    config: { previousUrl: PREVIOUS_URL },
+    isActive: true,
+    lastScrapeAt: null,
+    lastScrapeStatus: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastStructureHash: null,
+    ...overrides,
+  } as Source;
+}
+
+function mockFetchResponses(upcomingHtml: string, previousHtml: string) {
+  let callCount = 0;
+  mockedSafeFetch.mockImplementation(async () => {
+    callCount++;
+    const html = callCount === 1 ? upcomingHtml : previousHtml;
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: () => Promise.resolve(html),
+      headers: new Headers({ "content-type": "text/html" }),
+    } as Response;
+  });
+}
+
+// ── Unit tests: parseEventBlock ──
+
+describe("parseEventBlock", () => {
+  it("parses a full event block with title, run number, hares, date, location", () => {
+    const text = `The A to Birthday Run
+Run № 1476 by War 'n Piece & MiaB
+Saturday 04 April, 2026 at 14:45 hrs
+Haarlem Railway Station
+Stationsplein , Haarlem, 2011 LR, Noord-Holland Map`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.date).toBe("2026-04-04");
+    expect(event!.runNumber).toBe(1476);
+    expect(event!.hares).toBe("War 'n Piece & MiaB");
+    expect(event!.startTime).toBe("14:45");
+    expect(event!.location).toBe("Haarlem Railway Station");
+    expect(event!.locationStreet).toBe("Stationsplein , Haarlem, 2011 LR, Noord-Holland");
+    expect(event!.title).toBe("AH3 #1476 — The A to Birthday Run");
+    expect(event!.kennelTag).toBe("ah3-nl");
+  });
+
+  it("parses event with early start time", () => {
+    const text = `Do Not Eat Yellow Snow !
+Run № 1477 by Golden Showers
+Sunday 12 April, 2026 at 12:45 hrs
+Near Station Zuid
+Prinses Amaliaplein , Amsterdam, 1077 XS,`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.date).toBe("2026-04-12");
+    expect(event!.startTime).toBe("12:45");
+    expect(event!.runNumber).toBe(1477);
+    expect(event!.hares).toBe("Golden Showers");
+  });
+
+  it("handles event without hares (Click if you want to hare)", () => {
+    const text = `May The Third Be With You
+Run № 1480 Click if you want to hare this run
+Sunday 03 May, 2026 at 14:45 hrs
+somewhere`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.runNumber).toBe(1480);
+    expect(event!.hares).toBeUndefined();
+    expect(event!.location).toBeUndefined(); // "somewhere" should be stripped
+    expect(event!.date).toBe("2026-05-03");
+  });
+
+  it("returns null for blocks without a run number", () => {
+    const text = `Some random text
+without any run number or date.`;
+
+    expect(parseEventBlock(text, SOURCE_URL)).toBeNull();
+  });
+
+  it("returns null for blocks without a date", () => {
+    const text = `Run № 1476 by Someone
+No date here, just text.`;
+
+    expect(parseEventBlock(text, SOURCE_URL)).toBeNull();
+  });
+
+  it("parses title-less event (just run number)", () => {
+    const text = `Run № 1481 by Slippery Edge
+Sunday 10 May, 2026 at 14:45 hrs
+somewhere`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.title).toBe("AH3 #1481");
+    expect(event!.hares).toBe("Slippery Edge");
+  });
+});
+
+// ── Unit tests: extractEvents ──
+
+describe("extractEvents", () => {
+  it("splits text on ___good_to_know markers and parses each block", () => {
+    const text = `The A to Birthday Run
+Run № 1476 by War 'n Piece & MiaB
+Saturday 04 April, 2026 at 14:45 hrs
+Haarlem Railway Station
+
+___good_to_know
+Bag Drop – NO
+Hash Cash – €5
+
+Do Not Eat Yellow Snow !
+Run № 1477 by Golden Showers
+Sunday 12 April, 2026 at 12:45 hrs
+Near Station Zuid
+
+___good_to_know
+Bag Drop – Probably not`;
+
+    const { events, errors } = extractEvents(text, SOURCE_URL);
+    expect(errors).toHaveLength(0);
+    expect(events).toHaveLength(2);
+    expect(events[0].runNumber).toBe(1476);
+    expect(events[1].runNumber).toBe(1477);
+  });
+
+  it("skips blocks without run numbers", () => {
+    const text = `Some intro text about Amsterdam H3.
+___good_to_know
+Run № 1476 by War 'n Piece & MiaB
+Saturday 04 April, 2026 at 14:45 hrs
+Haarlem Railway Station
+___good_to_know
+More footer text`;
+
+    const { events } = extractEvents(text, SOURCE_URL);
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(1476);
+  });
+});
+
+// ── Unit tests: htmlToText ──
+
+describe("htmlToText", () => {
+  it("extracts text from .entry-content with br→newline conversion", async () => {
+    const $ = (await import("cheerio")).load(
+      `<div class="entry-content"><p>Run № <b>1476</b> by <b>War</b><br/>Saturday 04 April, 2026 at 14:45 hrs</p></div>`,
+    );
+    const text = htmlToText($);
+    expect(text).toContain("Run № 1476 by War");
+    expect(text).toContain("Saturday 04 April, 2026 at 14:45 hrs");
+  });
+
+  it("returns empty string when .entry-content is missing", async () => {
+    const $ = (await import("cheerio")).load(`<div>No entry content</div>`);
+    expect(htmlToText($)).toBe("");
+  });
+});
+
+// ── Integration tests: AH3Adapter.fetch ──
+
+describe("AH3Adapter", () => {
+  const adapter = new AH3Adapter();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches upcoming + previous pages and deduplicates by run number", async () => {
+    const upcomingHtml = `<html><body><div class="entry-content">
+<h1>Run A</h1>
+<p>Run № <b>1476</b> by <b>War &#039;n Piece</b><br/>
+<b>Saturday 04 April, 2026</b> at <b>14:45</b> hrs<br/>
+<b>Haarlem Station</b></p>
+<p>___good_to_know</p>
+</div></body></html>`;
+
+    const previousHtml = `<html><body><div class="entry-content">
+<h1>Run A Repeat</h1>
+<p>Run № <b>1476</b> by <b>War &#039;n Piece</b><br/>
+<b>Saturday 04 April, 2026</b> at <b>14:45</b> hrs<br/>
+<b>Haarlem Station</b></p>
+<p>___good_to_know</p>
+<h1>Run B</h1>
+<p>Run № <b>1475</b> by <b>Old Hare</b><br/>
+<b>Saturday 28 March, 2026</b> at <b>14:45</b> hrs<br/>
+<b>Central Station</b></p>
+<p>___good_to_know</p>
+</div></body></html>`;
+
+    mockFetchResponses(upcomingHtml, previousHtml);
+
+    const result = await adapter.fetch(makeSource());
+    expect(result.errors).toHaveLength(0);
+    // Run 1476 appears in both, should only appear once (from upcoming)
+    const run1476 = result.events.filter((e) => e.runNumber === 1476);
+    expect(run1476).toHaveLength(1);
+    // Run 1475 only in previous
+    const run1475 = result.events.filter((e) => e.runNumber === 1475);
+    expect(run1475).toHaveLength(1);
+  });
+
+  it("handles fetch failure on upcoming page", async () => {
+    mockedSafeFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: () => Promise.resolve(""),
+      headers: new Headers(),
+    } as Response);
+
+    const result = await adapter.fetch(makeSource());
+    expect(result.events).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("continues with upcoming events if previous page fails", async () => {
+    const upcomingHtml = `<html><body><div class="entry-content">
+<h1>Run A</h1>
+<p>Run № <b>1476</b> by <b>Hare</b><br/>
+<b>Saturday 04 April, 2026</b> at <b>14:45</b> hrs<br/>
+<b>Station</b></p>
+<p>___good_to_know</p>
+</div></body></html>`;
+
+    let callCount = 0;
+    mockedSafeFetch.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: () => Promise.resolve(upcomingHtml),
+          headers: new Headers(),
+        } as Response;
+      }
+      return {
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: () => Promise.resolve(""),
+        headers: new Headers(),
+      } as Response;
+    });
+
+    const result = await adapter.fetch(makeSource());
+    expect(result.events).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("Previous page fetch failed");
+  });
+});

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -1,0 +1,309 @@
+/**
+ * Amsterdam Hash House Harriers (AH3) Website Adapter
+ *
+ * Scrapes ah3.nl for hash events from two pages:
+ *   1. /nextruns/  — upcoming events
+ *   2. /previous/  — historical/past events
+ *
+ * Both pages use the same WordPress format: an `.entry-content` div with
+ * event blocks separated by `___good_to_know` markers. Each block contains:
+ *   - An event title (<h1>)
+ *   - Run number + hare(s) on a "Run № NNNN by Hare Name" line
+ *   - Date/time: "Saturday 04 April, 2026 at 14:45 hrs"
+ *   - Location: venue name (bold) followed by address line
+ *
+ * Blocks without hares that contain "Click if you want to hare this run"
+ * are still included (they have a date and run number), but hares will be
+ * undefined.
+ *
+ * Deduplication: upcoming events take priority over previous events
+ * when the same run number appears in both.
+ */
+
+import * as cheerio from "cheerio";
+import * as chrono from "chrono-node";
+import type { Source } from "@/generated/prisma/client";
+import type {
+  SourceAdapter,
+  RawEventData,
+  ScrapeResult,
+  ErrorDetails,
+  ParseError,
+} from "../types";
+import { hasAnyErrors } from "../types";
+import { fetchHTMLPage, buildDateWindow, decodeEntities } from "../utils";
+
+// ── Constants ──
+
+const KENNEL_TAG = "ah3-nl";
+
+// ── Regex patterns ──
+
+/** Match run number and optional hare(s): "Run № 1476 by War 'n Piece & MiaB" */
+const RUN_NUMBER_RE = /Run\s*[№#]\s*(\d{4,5})\s*(?:by\s+(.+))?/i;
+
+/** Match date + time: "Saturday 04 April, 2026 at 14:45 hrs" */
+const DATE_TIME_RE =
+  /(?:Sunday|Saturday|Monday|Tuesday|Wednesday|Thursday|Friday)\s+(\d{1,2}\s+\w+,?\s+\d{4})\s+at\s+(\d{1,2}):(\d{2})\s*hrs/i;
+
+/** Block separator: ___good_to_know */
+const BLOCK_SEPARATOR = "___good_to_know";
+
+// ── Exported helpers (for unit testing) ──
+
+/**
+ * Parse a single event block (text between ___good_to_know dividers) into RawEventData.
+ * Returns null if the block doesn't contain a valid run number + date.
+ */
+export function parseEventBlock(
+  text: string,
+  sourceUrl: string,
+): RawEventData | null {
+  // Extract run number and optional hares
+  const runMatch = RUN_NUMBER_RE.exec(text);
+  if (!runMatch) return null;
+  const runNumber = parseInt(runMatch[1], 10);
+
+  // Extract hares (if present and not just a "Click to hare" button)
+  let hares: string | undefined;
+  if (runMatch[2]) {
+    const hareTrimmed = runMatch[2].trim();
+    // Skip CTA-only "hare" text
+    if (!/Click if you want to hare/i.test(hareTrimmed)) {
+      hares = hareTrimmed;
+    }
+  }
+
+  // Extract date and time
+  const dtMatch = DATE_TIME_RE.exec(text);
+  if (!dtMatch) return null;
+
+  const dateStr = dtMatch[1]; // e.g., "04 April, 2026"
+  const hours = dtMatch[2];
+  const minutes = dtMatch[3];
+
+  // Parse the date portion with chrono
+  const parsed = chrono.en.parse(dateStr);
+  if (parsed.length === 0) return null;
+
+  const result = parsed[0].start;
+  const year = result.get("year");
+  const month = result.get("month");
+  const day = result.get("day");
+  if (year == null || month == null || day == null) return null;
+
+  const date = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  const startTime = `${hours.padStart(2, "0")}:${minutes}`;
+
+  // Extract title: look for text before "Run №" — typically the first line
+  const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+  let title: string | undefined;
+  for (const line of lines) {
+    // Skip empty and short lines
+    if (line.length < 2) continue;
+    // Stop at the run number line
+    if (/Run\s*[№#]\s*\d/i.test(line)) break;
+    // Use the first substantive line as the title
+    if (!title && line.length > 1 && !/^[_\-=]+$/.test(line)) {
+      title = line;
+    }
+  }
+
+  // Extract location: lines after the date line
+  let location: string | undefined;
+  let locationStreet: string | undefined;
+
+  const dateLineIdx = lines.findIndex((l) => DATE_TIME_RE.test(l));
+  if (dateLineIdx >= 0) {
+    // The line immediately after the date is the venue name
+    const venueLine = lines[dateLineIdx + 1];
+    if (venueLine && !/Map\s*$/.test(venueLine) && !/Let us know/.test(venueLine)) {
+      location = venueLine
+        .replace(/Map\s*$/, "")
+        .replace(/\s+$/, "")
+        .trim();
+      // Skip "somewhere" placeholder
+      if (/^somewhere$/i.test(location)) {
+        location = undefined;
+      }
+    }
+
+    // The line after venue might be a street address (contains comma + postal code)
+    const addressLine = lines[dateLineIdx + 2];
+    if (addressLine && /\d{4}\s*[A-Z]{2}/.test(addressLine)) {
+      locationStreet = addressLine
+        .replace(/Map\s*$/, "")
+        .replace(/\s+$/, "")
+        .trim();
+    }
+  }
+
+  // Build event title
+  const eventTitle = title
+    ? `AH3 #${runNumber} — ${title}`
+    : `AH3 #${runNumber}`;
+
+  return {
+    date,
+    kennelTag: KENNEL_TAG,
+    title: eventTitle,
+    runNumber,
+    hares,
+    location,
+    locationStreet,
+    startTime,
+    sourceUrl,
+  };
+}
+
+/**
+ * Extract all event blocks from page text.
+ * Splits on ___good_to_know markers plus <hr> separators, then parses each block.
+ */
+export function extractEvents(
+  pageText: string,
+  sourceUrl: string,
+): { events: RawEventData[]; errors: ParseError[] } {
+  const events: RawEventData[] = [];
+  const errors: ParseError[] = [];
+
+  // Split on ___good_to_know markers (which appear within blocks after the event data)
+  // and also on horizontal rule separators
+  const blocks = pageText.split(/___good_to_know/i);
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i].trim();
+    if (!block || block.length < 20) continue;
+
+    // A single block may contain content from the previous event's ___good_to_know
+    // section AND the next event's header. We need to find the run number line.
+    if (!RUN_NUMBER_RE.test(block)) continue;
+
+    try {
+      const event = parseEventBlock(block, sourceUrl);
+      if (event) events.push(event);
+    } catch (err) {
+      errors.push({
+        row: i,
+        error: String(err),
+        rawText: block.slice(0, 2000),
+      });
+    }
+  }
+
+  return { events, errors };
+}
+
+/**
+ * Convert raw HTML from AH3's .entry-content into line-separated text.
+ * Replaces <br>, <h1>, <hr>, and block-level tags with newlines.
+ */
+export function htmlToText($: cheerio.CheerioAPI): string {
+  const content = $(".entry-content");
+  if (content.length === 0) return "";
+
+  // Replace <br> with newlines
+  content.find("br").replaceWith("\n");
+  // Replace block-level tags with newlines for clean text extraction
+  content.find("h1").each(function () {
+    $(this).replaceWith("\n" + $(this).text() + "\n");
+  });
+
+  return decodeEntities(content.text());
+}
+
+// ── Adapter class ──
+
+export class AH3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(
+    source: Source,
+    _options?: { days?: number },
+  ): Promise<ScrapeResult> {
+    const upcomingUrl = source.url || "https://ah3.nl/nextruns/";
+    const config = (source.config ?? {}) as Record<string, unknown>;
+    const previousUrl =
+      (config.previousUrl as string) ??
+      upcomingUrl.replace(/nextruns\/?/, "previous/");
+
+    const allEvents: RawEventData[] = [];
+    const allErrors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+    const seenRunNumbers = new Set<number>();
+    let totalFetchMs = 0;
+
+    // ── 1. Fetch upcoming page ──
+    const upcoming = await fetchHTMLPage(upcomingUrl);
+    if (!upcoming.ok) return upcoming.result;
+
+    const structureHash = upcoming.structureHash;
+    totalFetchMs += upcoming.fetchDurationMs;
+
+    const upcomingText = htmlToText(upcoming.$);
+    const { events: upcomingEvents, errors: upcomingErrors } = extractEvents(
+      upcomingText,
+      upcomingUrl,
+    );
+
+    for (const ev of upcomingEvents) {
+      allEvents.push(ev);
+      if (ev.runNumber) seenRunNumbers.add(ev.runNumber);
+    }
+    if (upcomingErrors.length > 0) {
+      (errorDetails.parse ??= []).push(
+        ...upcomingErrors.map((e) => ({ ...e, section: "upcoming" })),
+      );
+    }
+
+    // ── 2. Fetch previous page ──
+    const previous = await fetchHTMLPage(previousUrl);
+    if (previous.ok) {
+      totalFetchMs += previous.fetchDurationMs;
+
+      const previousText = htmlToText(previous.$);
+      const { events: previousEvents, errors: previousErrors } = extractEvents(
+        previousText,
+        previousUrl,
+      );
+
+      // Deduplicate: upcoming events take priority
+      for (const ev of previousEvents) {
+        if (ev.runNumber && seenRunNumbers.has(ev.runNumber)) continue;
+        allEvents.push(ev);
+        if (ev.runNumber) seenRunNumbers.add(ev.runNumber);
+      }
+      if (previousErrors.length > 0) {
+        (errorDetails.parse ??= []).push(
+          ...previousErrors.map((e) => ({ ...e, section: "previous" })),
+        );
+      }
+    } else {
+      // Non-fatal: previous page failure shouldn't block upcoming events
+      allErrors.push(`Previous page fetch failed: ${previous.result.errors[0]}`);
+    }
+
+    // ── 3. Filter by date window ──
+    const { minDate, maxDate } = buildDateWindow(source.scrapeDays ?? 365);
+    const filtered = allEvents.filter((ev) => {
+      const d = new Date(ev.date + "T12:00:00Z");
+      return d >= minDate && d <= maxDate;
+    });
+
+    const hasErrors = hasAnyErrors(errorDetails);
+
+    return {
+      events: filtered,
+      errors: allErrors,
+      structureHash,
+      errorDetails: hasErrors ? errorDetails : undefined,
+      diagnosticContext: {
+        upcomingEvents: upcomingEvents.length,
+        previousEvents: allEvents.length - upcomingEvents.length,
+        totalBeforeFilter: allEvents.length,
+        totalAfterFilter: filtered.length,
+        fetchDurationMs: totalFetchMs,
+      },
+    };
+  }
+}

--- a/src/adapters/html-scraper/hague-h3.test.ts
+++ b/src/adapters/html-scraper/hague-h3.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as cheerio from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import {
+  parseEventBlock,
+  extractTextBlocks,
+  extractEvents,
+  HagueH3Adapter,
+} from "./hague-h3";
+
+// Mock safeFetch (used by fetchHTMLPage)
+vi.mock("@/adapters/safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+
+// Mock structure-hash
+vi.mock("@/pipeline/structure-hash", () => ({
+  generateStructureHash: vi.fn(() => "mock-hash-hague"),
+}));
+
+const { safeFetch } = await import("@/adapters/safe-fetch");
+const mockedSafeFetch = vi.mocked(safeFetch);
+
+const SOURCE_URL = "https://haguehash.nl/";
+
+function makeSource(overrides?: Partial<Source>): Source {
+  return {
+    id: "src-hague",
+    name: "The Hague H3 Website",
+    url: SOURCE_URL,
+    type: "HTML_SCRAPER",
+    trustLevel: 7,
+    scrapeFreq: "daily",
+    scrapeDays: 365,
+    config: {},
+    isActive: true,
+    lastScrapeAt: null,
+    lastScrapeStatus: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastStructureHash: null,
+    ...overrides,
+  } as Source;
+}
+
+// ── Unit tests: parseEventBlock ──
+
+describe("parseEventBlock", () => {
+  it("parses a standard event block", () => {
+    const text = `Run 2412
+When: Sunday, March 29
+Time: 14:00 hr
+Where: Parallelweg crossing Houtrustweg by Sportcity, The Hague
+Hares: Balls on a Dyke
+Cost: non-members EUR 7.00 for a single run (includes beer and snacks)`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.date).toBe("2026-03-29");
+    expect(event!.runNumber).toBe(2412);
+    expect(event!.hares).toBe("Balls on a Dyke");
+    expect(event!.startTime).toBe("14:00");
+    expect(event!.location).toBe("Parallelweg crossing Houtrustweg by Sportcity, The Hague");
+    expect(event!.kennelTag).toBe("hagueh3");
+    expect(event!.title).toBe("Hague H3 #2412");
+  });
+
+  it("parses event with parenthetical suffix in run number", () => {
+    const text = `Run 2411 (50+% run)
+When: Sunday, March 22
+Time: 14:00 hr
+Where: Station Voorburg under the viaduct
+Hare: XL`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.runNumber).toBe(2411);
+    expect(event!.hares).toBe("XL");
+  });
+
+  it("parses non-standard time with dot separator", () => {
+    const text = `Run 2410 (10.45 St Patrick's Day Run)
+When: Sunday, March 15
+Time: 10.45 hr (Different From Normal)
+Where: Stuyvesantplein Link
+Hares: RD aka Lazy`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.startTime).toBe("10:45");
+    expect(event!.location).toBe("Stuyvesantplein");
+  });
+
+  it("strips trailing Link from location", () => {
+    const text = `Run 2409
+When: Sunday, March 8
+Time: 14:00 hr
+Where: Rotterdamseweg near Vliet canal Link
+Hares: DW`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.location).toBe("Rotterdamseweg near Vliet canal");
+  });
+
+  it("parses Hare(s) variant", () => {
+    const text = `Run 2406 (Layer takes requests run)
+When: Sunday Februari 22th
+Hare(s): Layer (and maybe our hashflash FaD)
+Time: 14:00 hr
+Where: Wijndaelerweg by the entrance golf course Ockenburgh`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.hares).toBe("Layer (and maybe our hashflash FaD)");
+  });
+
+  it("parses event with title before run number", () => {
+    const text = `Windmill Poker Run
+When: Sunday February 15th
+Hare: Ironic Maiden
+Time: 14:00 hr
+Where: Zwembad Hillegersberg`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.title).toBe("Hague H3 — Windmill Poker Run");
+    expect(event!.runNumber).toBeUndefined();
+    expect(event!.hares).toBe("Ironic Maiden");
+    expect(event!.location).toBe("Zwembad Hillegersberg");
+  });
+
+  it("returns null if no When: line present", () => {
+    const text = `Run 2412
+No date info here
+Where: Some place`;
+
+    expect(parseEventBlock(text, SOURCE_URL)).toBeNull();
+  });
+
+  it("handles & in hare names", () => {
+    const text = `Run 2408
+When: Sunday, March 1
+Time: 14:00 hr
+Where: Station 't Loo
+Hares: DownDown & MyLady`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.hares).toBe("DownDown & MyLady");
+  });
+});
+
+// ── Unit tests: extractTextBlocks ──
+
+describe("extractTextBlocks", () => {
+  it("extracts text from WPBakery sections", () => {
+    const html = `<html><body>
+<section class="l-section"><div class="l-section-h"><div class="g-cols"><div class="vc_col-sm-12 wpb_column"><div class="vc_column-inner"><div class="wpb_wrapper"><div class="wpb_text_column"><div class="wpb_wrapper">
+<p>Run 2412<br/>When: Sunday, March 29<br/>Time: 14:00 hr<br/>Where: The Hague<br/>Hares: Test Hare</p>
+<p>OnOn</p>
+</div></div></div></div></div></div></div></section>
+<section class="l-section"><div class="l-section-h"><div class="g-cols"><div class="vc_col-sm-12 wpb_column"><div class="vc_column-inner"><div class="wpb_wrapper"><div class="wpb_text_column"><div class="wpb_wrapper">
+<p>Run 2411<br/>When: Sunday, March 22<br/>Time: 14:00 hr<br/>Where: Voorburg<br/>Hare: XL</p>
+<p>OnOn</p>
+</div></div></div></div></div></div></div></section>
+</body></html>`;
+
+    const $ = cheerio.load(html);
+    const blocks = extractTextBlocks($);
+    expect(blocks.length).toBeGreaterThanOrEqual(2);
+    expect(blocks[0]).toContain("Run 2412");
+    expect(blocks[1]).toContain("Run 2411");
+  });
+
+  it("skips short blocks", () => {
+    const html = `<html><body>
+<section class="l-section"><div class="l-section-h"><div class="g-cols"><div class="vc_col-sm-12 wpb_column"><div class="vc_column-inner"><div class="wpb_wrapper"><div class="wpb_text_column"><div class="wpb_wrapper">
+<p>Short</p>
+</div></div></div></div></div></div></div></section>
+</body></html>`;
+
+    const $ = cheerio.load(html);
+    const blocks = extractTextBlocks($);
+    expect(blocks).toHaveLength(0);
+  });
+});
+
+// ── Unit tests: extractEvents ──
+
+describe("extractEvents", () => {
+  it("parses multiple event blocks", () => {
+    const blocks = [
+      `Run 2412\nWhen: Sunday, March 29\nTime: 14:00 hr\nWhere: The Hague\nHares: Balls on a Dyke`,
+      `Run 2411 (50+% run)\nWhen: Sunday, March 22\nTime: 14:00 hr\nWhere: Station Voorburg\nHare: XL`,
+    ];
+
+    const { events, errors } = extractEvents(blocks, SOURCE_URL);
+    expect(errors).toHaveLength(0);
+    expect(events).toHaveLength(2);
+    expect(events[0].runNumber).toBe(2412);
+    expect(events[1].runNumber).toBe(2411);
+  });
+
+  it("skips blocks without When: lines", () => {
+    const blocks = [
+      `Some random footer text about beer`,
+      `Run 2412\nWhen: Sunday, March 29\nTime: 14:00 hr\nWhere: The Hague\nHares: Test`,
+    ];
+
+    const { events } = extractEvents(blocks, SOURCE_URL);
+    expect(events).toHaveLength(1);
+  });
+});
+
+// ── Integration tests: HagueH3Adapter.fetch ──
+
+describe("HagueH3Adapter", () => {
+  const adapter = new HagueH3Adapter();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches and parses events from WPBakery page", async () => {
+    const html = `<html><body>
+<section class="l-section"><div class="l-section-h"><div class="g-cols"><div class="vc_col-sm-12 wpb_column"><div class="vc_column-inner"><div class="wpb_wrapper"><div class="wpb_text_column"><div class="wpb_wrapper">
+<p>Run 2412<br/>When: Sunday, March 29<br/>Time: 14:00 hr<br/>Where: Parallelweg crossing Houtrustweg, The Hague<br/>Hares: Balls on a Dyke<br/>Cost: non-members EUR 7.00</p>
+<p>OnOn</p>
+</div></div></div></div></div></div></div></section>
+<section class="l-section"><div class="l-section-h"><div class="g-cols"><div class="vc_col-sm-12 wpb_column"><div class="vc_column-inner"><div class="wpb_wrapper"><div class="wpb_text_column"><div class="wpb_wrapper">
+<p>Run 2411 (50+% run)<br/>When: Sunday, March 22<br/>Time: 14:00 hr<br/>Where: Station Voorburg<br/>Hare: XL<br/>Cost: non-members EUR 7.00</p>
+<p>OnOn</p>
+</div></div></div></div></div></div></div></section>
+</body></html>`;
+
+    mockedSafeFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: () => Promise.resolve(html),
+      headers: new Headers({ "content-type": "text/html" }),
+    } as Response);
+
+    const result = await adapter.fetch(makeSource());
+    expect(result.errors).toHaveLength(0);
+    expect(result.events.length).toBeGreaterThanOrEqual(2);
+    expect(result.events[0].runNumber).toBe(2412);
+    expect(result.events[0].kennelTag).toBe("hagueh3");
+  });
+
+  it("handles fetch failure gracefully", async () => {
+    mockedSafeFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      statusText: "Service Unavailable",
+      text: () => Promise.resolve(""),
+      headers: new Headers(),
+    } as Response);
+
+    const result = await adapter.fetch(makeSource());
+    expect(result.events).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/adapters/html-scraper/hague-h3.ts
+++ b/src/adapters/html-scraper/hague-h3.ts
@@ -1,0 +1,264 @@
+/**
+ * The Hague Hash House Harriers (Hague H3) Website Adapter
+ *
+ * Scrapes haguehash.nl for hash events. The site uses WPBakery page builder
+ * with each event in a separate `<section>` containing a `.wpb_text_column
+ * .wpb_wrapper` div. Events are separated by "OnOn" markers.
+ *
+ * Event format (after br→newline conversion):
+ *   Run 2412
+ *   When: Sunday, March 29
+ *   Time: 14:00 hr
+ *   Where: Parallelweg crossing Houtrustweg by Sportcity, The Hague
+ *   Hares: Balls on a Dyke
+ *
+ * Some events have:
+ *   - Run number suffixes like "(50+% run)" or "(10.45 St Patrick's Day Run)"
+ *   - Title text before "Run NNNN" (e.g., "Windmill Poker Run")
+ *   - "Hare:" (singular) instead of "Hares:" (plural)
+ *   - "Hare(s):" variant
+ *   - Time with "." separator instead of ":" (e.g., "10.45 hr")
+ *   - <strong> tags around non-standard times
+ *   - "Link" text after location (Google Maps link)
+ *   - Missing run numbers (special events with just a title)
+ */
+
+import * as cheerio from "cheerio";
+import * as chrono from "chrono-node";
+import type { Source } from "@/generated/prisma/client";
+import type {
+  SourceAdapter,
+  RawEventData,
+  ScrapeResult,
+  ErrorDetails,
+  ParseError,
+} from "../types";
+import { hasAnyErrors } from "../types";
+import { fetchHTMLPage, buildDateWindow, decodeEntities } from "../utils";
+
+// ── Constants ──
+
+const KENNEL_TAG = "hagueh3";
+const DEFAULT_START_TIME = "14:00";
+
+// ── Regex patterns ──
+
+/** Match run number: "Run 2412" or "Run 2410 (50+% run)" */
+const RUN_NUMBER_RE = /Run\s+(\d{4})/;
+
+/** Match date line: "When: Sunday, March 29" or "When: Sunday Februari 22th" */
+const WHEN_RE = /When:\s*(.+)/i;
+
+/** Match time: "Time: 14:00 hr" or "Time: 10.45 hr (Different From Normal)" */
+const TIME_RE = /Time:\s*(?:<[^>]+>\s*)*(\d{1,2})[.:]\s*(\d{2})\s*hr/i;
+
+/** Match location: "Where: ..." — first line only */
+const WHERE_RE = /Where:\s*(.+)/i;
+
+/** Match hares: "Hares: ...", "Hare: ...", or "Hare(s): ..." */
+const HARES_RE = /Hare(?:s|\(s\))?:\s*(.+)/i;
+
+// ── Exported helpers (for unit testing) ──
+
+/**
+ * Extract text blocks from the WPBakery page structure.
+ * Each `.wpb_text_column .wpb_wrapper` in the main content area is one block.
+ */
+export function extractTextBlocks($: cheerio.CheerioAPI): string[] {
+  const blocks: string[] = [];
+
+  // WPBakery sections contain the event data
+  $("section.l-section .wpb_text_column .wpb_wrapper").each(function () {
+    const wrapper = $(this);
+    // Replace <br> with newlines for line-based parsing
+    wrapper.find("br").replaceWith("\n");
+    const text = decodeEntities(wrapper.text()).trim();
+    if (text.length > 10) {
+      blocks.push(text);
+    }
+  });
+
+  return blocks;
+}
+
+/**
+ * Parse a single text block into RawEventData.
+ * Returns null if the block doesn't contain a valid date.
+ */
+export function parseEventBlock(
+  text: string,
+  sourceUrl: string,
+): RawEventData | null {
+  // Extract date — required for all events
+  const whenMatch = WHEN_RE.exec(text);
+  if (!whenMatch) return null;
+
+  const rawDateStr = whenMatch[1].trim();
+  // Use chrono with en-GB for European date parsing, forwardDate=false since we want exact dates
+  const parsed = chrono.en.parse(rawDateStr);
+  if (parsed.length === 0) return null;
+
+  const result = parsed[0].start;
+  const year = result.get("year");
+  const month = result.get("month");
+  const day = result.get("day");
+  if (year == null || month == null || day == null) return null;
+
+  const date = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+
+  // Extract run number (optional — some special events don't have one)
+  let runNumber: number | undefined;
+  const runMatch = RUN_NUMBER_RE.exec(text);
+  if (runMatch) {
+    runNumber = parseInt(runMatch[1], 10);
+  }
+
+  // Extract time
+  let startTime = DEFAULT_START_TIME;
+  const timeMatch = TIME_RE.exec(text);
+  if (timeMatch) {
+    startTime = `${timeMatch[1].padStart(2, "0")}:${timeMatch[2]}`;
+  }
+
+  // Extract location — strip trailing "Link" text from Google Maps links
+  let location: string | undefined;
+  const whereMatch = WHERE_RE.exec(text);
+  if (whereMatch) {
+    location = whereMatch[1]
+      .trim()
+      .replace(/\s*Link\s*$/i, "")
+      .replace(/\s*https?:\/\/\S+/g, "")
+      .trim();
+    if (!location) location = undefined;
+  }
+
+  // Extract hares
+  let hares: string | undefined;
+  const haresMatch = HARES_RE.exec(text);
+  if (haresMatch) {
+    hares = haresMatch[1].trim();
+    // Truncate at "Cost:" or "Inquiries?" that may follow on the same line
+    hares = hares
+      .replace(/\s*Cost:.*$/i, "")
+      .replace(/\s*Inquiries\?.*$/i, "")
+      .trim();
+    if (!hares) hares = undefined;
+  }
+
+  // Extract title: look for text before "Run NNNN" that isn't just whitespace
+  let title: string | undefined;
+  const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+  for (const line of lines) {
+    if (RUN_NUMBER_RE.test(line) || /^When:/i.test(line)) break;
+    // Use the first substantive line as the title
+    if (line.length > 2 && !/^OnOn/i.test(line)) {
+      title = line;
+      break;
+    }
+  }
+
+  // Build event title
+  let eventTitle: string;
+  if (title && runNumber) {
+    eventTitle = `Hague H3 #${runNumber} — ${title}`;
+  } else if (title) {
+    eventTitle = `Hague H3 — ${title}`;
+  } else if (runNumber) {
+    eventTitle = `Hague H3 #${runNumber}`;
+  } else {
+    return null; // No run number and no title — skip
+  }
+
+  return {
+    date,
+    kennelTag: KENNEL_TAG,
+    title: eventTitle,
+    runNumber,
+    hares,
+    location,
+    startTime,
+    sourceUrl,
+  };
+}
+
+/**
+ * Extract all events from the page's text blocks.
+ */
+export function extractEvents(
+  blocks: string[],
+  sourceUrl: string,
+): { events: RawEventData[]; errors: ParseError[] } {
+  const events: RawEventData[] = [];
+  const errors: ParseError[] = [];
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+
+    // Skip blocks that don't look like event data
+    if (!WHEN_RE.test(block)) continue;
+
+    try {
+      const event = parseEventBlock(block, sourceUrl);
+      if (event) events.push(event);
+    } catch (err) {
+      errors.push({
+        row: i,
+        error: String(err),
+        rawText: block.slice(0, 2000),
+      });
+    }
+  }
+
+  return { events, errors };
+}
+
+// ── Adapter class ──
+
+export class HagueH3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(
+    source: Source,
+    _options?: { days?: number },
+  ): Promise<ScrapeResult> {
+    const sourceUrl = source.url || "https://haguehash.nl/";
+    const allErrors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    // ── Fetch page ──
+    const page = await fetchHTMLPage(sourceUrl);
+    if (!page.ok) return page.result;
+
+    // ── Extract text blocks from WPBakery sections ──
+    const blocks = extractTextBlocks(page.$);
+
+    // ── Parse events ──
+    const { events, errors: parseErrors } = extractEvents(blocks, sourceUrl);
+
+    if (parseErrors.length > 0) {
+      (errorDetails.parse ??= []).push(...parseErrors);
+    }
+
+    // ── Filter by date window ──
+    const { minDate, maxDate } = buildDateWindow(source.scrapeDays ?? 365);
+    const filtered = events.filter((ev) => {
+      const d = new Date(ev.date + "T12:00:00Z");
+      return d >= minDate && d <= maxDate;
+    });
+
+    const hasErrors = hasAnyErrors(errorDetails);
+
+    return {
+      events: filtered,
+      errors: allErrors,
+      structureHash: page.structureHash,
+      errorDetails: hasErrors ? errorDetails : undefined,
+      diagnosticContext: {
+        totalBlocks: blocks.length,
+        totalEvents: events.length,
+        totalAfterFilter: filtered.length,
+        fetchDurationMs: page.fetchDurationMs,
+      },
+    };
+  }
+}

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -43,6 +43,8 @@ import { GlasgowH3Adapter } from "./html-scraper/glasgow-h3";
 import { FrankfurtHashAdapter } from "./html-scraper/frankfurt-hash";
 import { CapeFearH3Adapter } from "./html-scraper/cape-fear-h3";
 import { BruH3Adapter } from "./html-scraper/bruh3";
+import { AH3Adapter } from "./html-scraper/ah3";
+import { HagueH3Adapter } from "./html-scraper/hague-h3";
 import { F3H3Adapter } from "./html-scraper/f3h3";
 import { SumoH3Adapter } from "./html-scraper/sumo-h3";
 import { YokoYokoH3Adapter } from "./html-scraper/yoko-yoko-h3";
@@ -119,6 +121,8 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /frankfurt-hash\.de/i, name: "FrankfurtHashAdapter",    factory: () => new FrankfurtHashAdapter() },
   { pattern: /capefearh3\.com/i,   name: "CapeFearH3Adapter",      factory: () => new CapeFearH3Adapter() },
   { pattern: /bruh3\.eu/i,          name: "BruH3Adapter",            factory: () => new BruH3Adapter() },
+  { pattern: /ah3\.nl/i,            name: "AH3Adapter",              factory: () => new AH3Adapter() },
+  { pattern: /haguehash\.nl/i,      name: "HagueH3Adapter",          factory: () => new HagueH3Adapter() },
   { pattern: /f3h3\.net/i,         name: "F3H3Adapter",            factory: () => new F3H3Adapter() },
   { pattern: /sumoh3\.gotothehash/i, name: "SumoH3Adapter",        factory: () => new SumoH3Adapter() },
   { pattern: /y2h3\.net/i,          name: "YokoYokoH3Adapter",     factory: () => new YokoYokoH3Adapter() },

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -1636,6 +1636,41 @@ export const REGION_SEED_DATA: RegionSeedRecord[] = [
     centroidLng: 4.35,
     aliases: ["Brussels, Belgium", "Bruxelles"],
   },
+  // ── Netherlands ──
+  {
+    name: "Netherlands",
+    country: "Netherlands",
+    level: "COUNTRY",
+    timezone: "Europe/Amsterdam",
+    abbrev: "NL",
+    colorClasses: "bg-orange-200 text-orange-800",
+    pinColor: "#ea580c",
+    centroidLat: 52.13,
+    centroidLng: 5.29,
+    aliases: ["NL", "Holland", "Nederland"],
+  },
+  {
+    name: "Amsterdam",
+    country: "Netherlands",
+    timezone: "Europe/Amsterdam",
+    abbrev: "AMS",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#f97316",
+    centroidLat: 52.37,
+    centroidLng: 4.90,
+    aliases: ["Amsterdam, Netherlands"],
+  },
+  {
+    name: "The Hague",
+    country: "Netherlands",
+    timezone: "Europe/Amsterdam",
+    abbrev: "DH",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#f97316",
+    centroidLat: 52.08,
+    centroidLng: 4.30,
+    aliases: ["The Hague, Netherlands", "Den Haag"],
+  },
 ];
 
 // ── Sync fallback map (built from REGION_SEED_DATA at module load) ──
@@ -1827,6 +1862,7 @@ export function inferCountry(name: string): string {
   if (/\b(germany|berlin|munich|münchen|muenchen|hamburg|stuttgart|frankfurt)\b/.test(lower)) return "Germany";
   if (/\b(japan|tokyo|osaka)\b/.test(lower)) return "Japan";
   if (/\b(belgium|brussels|bruxelles|antwerp|ghent)\b/.test(lower)) return "Belgium";
+  if (/\b(netherlands|amsterdam|rotterdam|den haag|the hague|holland)\b/.test(lower)) return "Netherlands";
   return "USA";
 }
 
@@ -1990,6 +2026,9 @@ const STATE_GROUP_MAP: Record<string, string> = {
   "Okinawa": "Japan",
   // Belgium
   "Brussels": "Belgium",
+  // Netherlands
+  "Amsterdam": "Netherlands",
+  "The Hague": "Netherlands",
 };
 
 /** Get the state/country group for a region name (for kennel directory grouping). */


### PR DESCRIPTION
## Summary
First Dutch coverage on HashTracks — 2 kennels, 2 HTML scraper sources, 20 events verified against live data.

| Kennel | Source Type | Events | Notes |
|--------|------------|--------|-------|
| Amsterdam H3 (AH3) | HTML_SCRAPER | 11 | ah3.nl/nextruns/ + /previous/, weekly Sunday |
| The Hague H3 | HTML_SCRAPER | 9 | haguehash.nl, weekly (seasonal day switch) |

Chose website scrapers over Harrier Central API — the websites have significantly richer data (real hare names, specific locations with addresses) vs HC's mostly placeholder data ("somewhere", "!?").

### New files
- `src/adapters/html-scraper/ah3.ts` + `ah3.test.ts` — 13 tests
- `src/adapters/html-scraper/hague-h3.ts` + `hague-h3.test.ts` — 14 tests

### Modified files
- `src/lib/region.ts` — Netherlands country + Amsterdam + The Hague metros
- `prisma/seed-data/kennels.ts` — 2 kennels
- `prisma/seed-data/aliases.ts` — aliases for both
- `prisma/seed-data/sources.ts` — 2 HTML_SCRAPER sources
- `src/adapters/registry.ts` — `ah3.nl` + `haguehash.nl` patterns

## Test plan
- [x] 27 adapter unit tests pass
- [x] Live verification: AH3 — 11 events (hares, locations, run numbers)
- [x] Live verification: Hague H3 — 9 events (hares, detailed locations)
- [x] Lint passes (0 errors)
- [ ] `npx prisma db seed` — add seed data
- [ ] Manual scrape via admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)