### PR TITLE
fix: MTH3 phantom event + year marker off-by-one

### DIFF
--- a/src/adapters/html-scraper/mersey-thirstdays.test.ts
+++ b/src/adapters/html-scraper/mersey-thirstdays.test.ts
@@ -104,6 +104,11 @@ describe("MerseyThirstdaysAdapter", () => {
     it("returns null for block with no date", () => {
       expect(parseMerseyNextRunBlock("Some random text without dates")).toBeNull();
     });
+
+    it("returns null for instruction header with bare time", () => {
+      const block = "Instructions: meet at the On Inn location at 7pm (unless stated otherwise)";
+      expect(parseMerseyNextRunBlock(block)).toBeNull();
+    });
   });
 
   describe("parseMerseyNextRuns", () => {
@@ -126,20 +131,34 @@ describe("MerseyThirstdaysAdapter", () => {
       expect(runs[1].runNumber).toBe(600);
     });
 
+    it("skips instruction header before first dash separator", () => {
+      const text = [
+        "Instructions: meet at the On Inn location at 7pm (unless stated otherwise)",
+        "-------------------------------------------------",
+        "2nd April",
+        "Run 598",
+        "Hare: FCUK",
+      ].join("\n");
+
+      const runs = parseMerseyNextRuns(text);
+      expect(runs.length).toBe(1);
+      expect(runs[0].runNumber).toBe(598);
+    });
+
     it("returns empty for text with no dash separators and no dates", () => {
       expect(parseMerseyNextRuns("Just some random text")).toEqual([]);
     });
   });
 
   describe("splitByYearMarkers", () => {
-    it("splits text by year markers", () => {
+    it("splits text by footer-style year markers", () => {
       const text = [
         "597 19th March Hare 10 Seconds. Ring O' Bells, West Kirby",
         "596 5th March Hares Wigan Pier. The Royal Alfred",
-        " ▲  2025  ▲",
+        " ▲  2026  ▲",
         "590 11th December Hare PJ. The Bouverie, Chester",
         "589 27th November Hare FCUK. The George, Liverpool",
-        " ▲  2024  ▲",
+        " ▲  2025  ▲",
         "546 7 March Hare ET, The Aigburth Arms, Liverpool",
       ].join("\n");
 
@@ -148,20 +167,26 @@ describe("MerseyThirstdaysAdapter", () => {
       expect(sections.has(2025)).toBe(true);
       expect(sections.has(2024)).toBe(true);
 
-      // Entries before first ▲ 2025 ▲ belong to 2026
+      // Entries before ▲ 2026 ▲ belong to 2026 (footer-style)
       const y2026 = sections.get(2026)!;
       expect(y2026.length).toBe(2);
       expect(y2026[0]).toContain("597");
 
+      // Entries between ▲ 2026 ▲ and ▲ 2025 ▲ belong to 2025
       const y2025 = sections.get(2025)!;
       expect(y2025.length).toBe(2);
       expect(y2025[0]).toContain("590");
+
+      // Entries after ▲ 2025 ▲ belong to 2024
+      const y2024 = sections.get(2024)!;
+      expect(y2024.length).toBe(1);
+      expect(y2024[0]).toContain("546");
     });
 
     it("handles variable whitespace in markers", () => {
       const text = [
         "100 1st Jan Hare Test. Pub, City",
-        "▲ 2024 ▲",
+        "▲ 2025 ▲",
         "99 15 Dec Hare Test2. Pub2, City2",
       ].join("\n");
 
@@ -337,7 +362,7 @@ describe("MerseyThirstdaysAdapter", () => {
       const mockPastHtml = `<html><body>
         <div class="n module-type-text diyfeLiveArea">
           <div>600 16th April Hare Snoozeanne. The Augustus John, Liverpool</div>
-          <div>▲  2025  ▲</div>
+          <div>▲  2026  ▲</div>
           <div>580 11 December Hare FCUK. The Bouverie, Chester</div>
         </div>
       </body></html>`;

--- a/src/adapters/html-scraper/mersey-thirstdays.ts
+++ b/src/adapters/html-scraper/mersey-thirstdays.ts
@@ -185,6 +185,11 @@ export function parseMerseyNextRunBlock(block: string): ParsedMerseyRun | null {
   }
   if (descParts.length > 0) result.description = descParts.join(". ");
 
+  // Require at least one event-identifying field beyond a bare date.
+  // Blocks with only an implied date (e.g., from "7pm" in instruction text)
+  // are not real events.
+  if (!result.runNumber && !result.hares && !result.location) return null;
+
   return result;
 }
 
@@ -222,15 +227,14 @@ export function splitByYearMarkers(text: string): Map<number, string[]> {
   const parts = text.split(/▲\s*(\d{4})\s*▲/);
   // parts: [before_first_marker, year1, section1_text, year2, section2_text, ...]
 
-  // Runs before the first ▲ marker belong to the year AFTER that marker.
-  // E.g., text before ▲ 2025 ▲ is 2026 runs. This assumes the site never
-  // adds a ▲ CURRENT_YEAR ▲ header at the top — if they do, the +1 logic
-  // would mis-date the first section. The page has been stable since 2006.
+  // Year markers are footer-style: ▲ YYYY ▲ marks the END of year YYYY.
+  // Content before ▲ YYYY ▲ belongs to year YYYY.
+  // Content after ▲ YYYY ▲ belongs to year YYYY - 1.
   let currentYear: number | null = null;
   if (parts.length >= 2) {
     currentYear = parseInt(parts[1], 10);
     if (parts[0].trim()) {
-      sections.set(currentYear + 1, splitIntoRunLines(parts[0]));
+      sections.set(currentYear, splitIntoRunLines(parts[0]));
     }
   }
 
@@ -239,7 +243,7 @@ export function splitByYearMarkers(text: string): Map<number, string[]> {
     const year = parseInt(parts[i], 10);
     const sectionText = parts[i + 1] || "";
     if (!isNaN(year) && sectionText.trim()) {
-      sections.set(year, splitIntoRunLines(sectionText));
+      sections.set(year - 1, splitIntoRunLines(sectionText));
     }
   }
 


### PR DESCRIPTION
## Summary
- **Phantom event:** The instruction header ("meet at 7pm") before the first dash separator on the next-runs page was interpreted by chrono-node as today's date, creating a new phantom event on every scrape. Fixed by requiring at least one event field (runNumber, hares, or location) beyond a bare date.
- **Year offset:** Year markers (`▲ YYYY ▲`) are footer-style on the live site — `▲ 2026 ▲` marks the *end* of 2026 runs. The code treated them as headers, shifting every year section +1. This caused all 2025 past runs to appear as 2026 future events, inflating the upcoming count from ~8 to 34. Fixed year assignment: before marker → year YYYY, after marker → year YYYY-1.
- Test fixtures updated to match live site marker convention; added tests for instruction header rejection.

## Test plan
- [x] `npm test -- mersey-thirstdays` — 26 tests pass
- [x] Lint clean, no new type errors
- [ ] Live verification: confirm ~8 upcoming events (not 34), no phantom date-of-scrape event
- [ ] Verify run #573 (Apr 10) resolves to 2025, not 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)