### PR TITLE
fix: NOH3 all-day events + Voodoo JSON control characters

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2645,6 +2645,7 @@ export const SOURCES = [
       config: {
         calendarId: "nolahash@gmail.com",
         defaultKennelTag: "noh3",
+        includeAllDayEvents: true,
       },
       kennelCodes: ["noh3"],
     },

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -292,6 +292,7 @@ interface CalendarSourceConfig {
   runNumberPatterns?: string[];         // regex strings to extract run numbers from descriptions
   titleHarePattern?: string;            // regex to extract hare names from summary when description has none
   descriptionSuffix?: string;           // appended to every event description
+  includeAllDayEvents?: boolean;        // if true, don't skip all-day events (some calendars use them for real runs)
 }
 
 /**
@@ -394,8 +395,8 @@ export function buildRawEventFromGCalItem(
   if (item.status === "cancelled") return null;
   if (!item.summary) return null;
   if (!item.start?.dateTime && !item.start?.date) return null;
-  // Skip all-day events — travel blocks, holidays, multi-day markers, not trail runs
-  if (item.start?.date && !item.start?.dateTime) return null;
+  // Skip all-day events unless config opts in (some calendars use all-day for real runs)
+  if (item.start?.date && !item.start?.dateTime && !sourceConfig?.includeAllDayEvents) return null;
 
   const { dateISO, startTime } = extractDateTimeFromGCalItem(item.start);
   if (!dateISO) return null;

--- a/src/adapters/wordpress-api.ts
+++ b/src/adapters/wordpress-api.ts
@@ -70,7 +70,11 @@ export async function fetchWordPressPosts(
       });
 
       if (response.ok) {
-        const data = (await response.json()) as {
+        // Some WordPress sites embed control characters in post content
+        // (e.g., Voodoo H3). Strip them before JSON.parse to avoid SyntaxError.
+        const raw = await response.text();
+        const sanitized = raw.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
+        const data = JSON.parse(sanitized) as {
           title?: { rendered?: string };
           content?: { rendered?: string };
           link?: string;


### PR DESCRIPTION
## Summary
Two production bugs found after scraping the new Louisiana sources:

### 1. NOH3 all-day events skipped
NOH3 (New Orleans) uses all-day Google Calendar events for actual hash runs, but the GCal adapter skips all-day events by default (usually holidays/travel blocks). Past events that happened to have specific times were scraped fine, but future events — all in all-day format — were silently dropped.

**Fix:** Added `includeAllDayEvents: boolean` config option to `CalendarSourceConfig`. Default is `false` (existing behavior preserved). NOH3 source config opts in with `includeAllDayEvents: true`.

### 2. Voodoo WordPress JSON parse error
Voodoo H3's WordPress REST API returns JSON containing control characters (bytes 0x00-0x1f) in post content, causing `JSON.parse` to throw `SyntaxError: Bad control character`.

**Fix:** `fetchWordPressPosts()` now reads raw text first, strips control characters, then parses JSON. Affects all WordPress API sources but is a no-op for clean JSON.

## Test plan
- [x] 148 GCal adapter tests pass (default skip-allday behavior preserved)
- [x] 13 WordPress API tests pass
- [x] 31 Voodoo adapter tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)