### PR TITLE
fix: swap Voodoo H3 from WordPress scraper to Google Calendar

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2650,12 +2650,16 @@ export const SOURCES = [
       kennelCodes: ["noh3"],
     },
     {
-      name: "Voodoo H3 Website",
-      url: "https://www.voodoohash.com/",
-      type: "HTML_SCRAPER" as const,
+      name: "Voodoo H3 Google Calendar",
+      url: "voodoohash@gmail.com",
+      type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 365,
+      config: {
+        calendarId: "voodoohash@gmail.com",
+        defaultKennelTag: "voodoo-h3",
+      },
       kennelCodes: ["voodoo-h3"],
     },
 


### PR DESCRIPTION
## Summary
Voodoo H3 has a Google Calendar (`voodoohash@gmail.com`) with richer data than the WordPress API — dateTime format, run numbers and hare names in summaries. Swaps the source from HTML_SCRAPER to GOOGLE_CALENDAR. Config-only change.

## Test plan
- [x] Calendar verified: 5+ events with run numbers, hares, dateTime format
- [ ] `npx prisma db seed` to update source record

🤖 Generated with [Claude Code](https://claude.com/claude-code)