### PR TITLE
Fix map markers lost on filter toggle + URL persistence

### DIFF
--- a/src/components/hareline/ClusteredMarkers.tsx
+++ b/src/components/hareline/ClusteredMarkers.tsx
@@ -212,7 +212,7 @@ export function ClusteredMarkers({
     const currentMarkers = Array.from(markersRef.current.values());
     clusterer.clearMarkers(true); // noDraw — suppress intermediate render
     clusterer.addMarkers(currentMarkers); // single render pass
-  }, [groups]);
+  }, [groups, map]);
 
   // Stable per-group ref callback factory — avoids new function identity on every render.
   // Reads from groupDataRef so the reverse lookup always has the latest data even if

--- a/src/components/kennels/ClusteredKennelMarkers.tsx
+++ b/src/components/kennels/ClusteredKennelMarkers.tsx
@@ -133,7 +133,7 @@ export function ClusteredKennelMarkers({ pins, selectedPinId, onSelectPin, onSho
     const currentMarkers = Array.from(markersRef.current.values());
     clusterer.clearMarkers(true); // noDraw — suppress intermediate render
     clusterer.addMarkers(currentMarkers); // single render pass
-  }, [pinGroups]);
+  }, [pinGroups, map]);
 
   // Stable per-group ref callback factory — avoids new function identity on every render.
   // Reads from groupDataRef so the reverse lookup always has the latest data even if


### PR DESCRIPTION
## Summary

- **Map markers vanish on Active Only toggle** — When toggling Active Only OFF, 209 active kennel markers disappeared from the map. Root cause: `MarkerClusterer` lost markers when coordinate group keys shifted during bulk pin changes. Ref callbacks only fire for new/unmounted components; existing markers with stable keys were never re-added.
- **Batch re-sync with noDraw optimization** — Added `useEffect` on both `ClusteredKennelMarkers` and hareline `ClusteredMarkers` that does `clearMarkers(true) + addMarkers()` after React processes ref callbacks. Individual ref callback add/remove now use `noDraw: true` so the batch effect is the sole render trigger (1 cluster recalculation per change instead of N+2).
- **`active=false` URL persistence** — Boolean `false` was serialized as `""` which was dropped as a default. Now serializes as `"false"` so the Active Only OFF state survives page refresh.
- **`clearAllFilters` consistency** — Changed `active: null` to `active: true` to match the state reset.

## Test plan

- [ ] `/kennels` map view → toggle Active Only OFF → all 256 kennels visible (not just 47)
- [ ] Toggle Active Only back ON → returns to ~209
- [ ] URL shows `active=false` when toggle is OFF
- [ ] Page refresh with `?active=false` → toggle remains OFF
- [ ] `/hareline` map view → filter changes don't lose markers
- [ ] Clear all filters → active resets to ON, URL clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)