### PR TITLE
Fix map markers lost on Active Only toggle

### DIFF
--- a/src/components/hareline/ClusteredMarkers.tsx
+++ b/src/components/hareline/ClusteredMarkers.tsx
@@ -203,6 +203,13 @@ export function ClusteredMarkers({
     };
   }, [map, handleClusterClick]);
 
+  // Safety-net render after coordinate groups change. Ref callbacks handle
+  // incremental add/remove, but the clusterer may not re-render after all
+  // changes settle (e.g. AdvancedMarker elements mount asynchronously).
+  useEffect(() => {
+    clustererRef.current?.render();
+  }, [groups, map]);
+
   // Stable per-group ref callback factory — avoids new function identity on every render.
   // Reads from groupDataRef so the reverse lookup always has the latest data even if
   // the callback fires after a re-render (fixes stale closure).

--- a/src/components/kennels/ClusteredKennelMarkers.tsx
+++ b/src/components/kennels/ClusteredKennelMarkers.tsx
@@ -122,6 +122,14 @@ export function ClusteredKennelMarkers({ pins, selectedPinId, onSelectPin, onSho
     };
   }, [map, handleClusterClick]);
 
+  // Safety-net render after pin groups change. Ref callbacks handle incremental
+  // add/remove, but the clusterer may not re-render after all changes settle
+  // (e.g. AdvancedMarker elements mount asynchronously). This forces one final
+  // cluster recalculation without clearing — markers stay registered.
+  useEffect(() => {
+    clustererRef.current?.render();
+  }, [pinGroups, map]);
+
   // Stable per-group ref callback factory — avoids new function identity on every render.
   // Reads from groupDataRef so the reverse lookup always has the latest data even if
   // the callback fires after a re-render (fixes stale closure).

--- a/src/components/kennels/KennelDirectory.tsx
+++ b/src/components/kennels/KennelDirectory.tsx
@@ -91,7 +91,7 @@ export function KennelDirectory({ kennels }: KennelDirectoryProps) {
         if (val == null) {
           str = "";
         } else if (typeof val === "boolean") {
-          str = val ? "true" : "";
+          str = val ? "true" : "false";
         } else if (typeof val === "number") {
           str = String(val);
         } else if (Array.isArray(val)) {
@@ -181,7 +181,7 @@ export function KennelDirectory({ kennels }: KennelDirectoryProps) {
     setShowActiveOnlyState(true);
     setNearMeDistanceState(null);
     setMapBounds(null);
-    syncUrl({ q: "", regions: [], days: [], freq: "", upcoming: false, active: null, distance: null });
+    syncUrl({ q: "", regions: [], days: [], freq: "", upcoming: false, active: true, distance: null });
   }
 
   // Compute distances for each kennel (when geolocation is available)


### PR DESCRIPTION
## Summary

- **Map markers vanish on Active Only toggle** — Toggling Active Only OFF caused 209 active kennel markers to disappear from the map (only ~47 inactive ones remained). The count text correctly showed "256 kennels" and grid view was fine — only the map broke.
- **Root cause:** `MarkerClusterer` didn't re-render after `AdvancedMarker` ref callbacks fired asynchronously during bulk pin updates
- **Fix:** Add `clusterer.render()` safety-net `useEffect` on pin group changes — forces one final cluster recalculation without clearing marker registrations. Applied to both kennel and hareline map components.
- **URL persistence:** `active=false` was never written to the URL (boolean `false` serialized as `""` and was dropped). Now serializes as `"false"`.
- **clearAllFilters:** Fixed `active: null` → `active: true` to match state reset.

## Test plan

- [ ] `/kennels` map view, Active Only ON → ~209 kennels with clusters
- [ ] Toggle Active Only OFF → **256 kennels** with clusters (active + inactive)
- [ ] Toggle back ON → returns to ~209
- [ ] URL shows `active=false` when toggle is OFF
- [ ] Page refresh with `?active=false` → toggle stays OFF
- [ ] `/hareline` map → filter changes don't lose markers
- [ ] Clear all filters → resets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)