### PR TITLE
Fix map markers lost on single↔multi pin transitions

### DIFF
--- a/src/components/hareline/ClusteredMarkers.tsx
+++ b/src/components/hareline/ClusteredMarkers.tsx
@@ -107,8 +107,6 @@ export function ClusteredMarkers({
   const refCallbacksRef = useRef<Map<string, (marker: Marker | null) => void>>(new Map());
   // Reverse lookup: marker element → events at that marker's coordinate group
   const markerToEventsRef = useRef<Map<Marker, EventWithCoords[]>>(new Map());
-  // Track event count per group to detect single↔multi transitions that require ref invalidation
-  const refEventCountsRef = useRef<Map<string, number>>(new Map());
 
   // Stable ref for the onShowColocated callback so the cluster click handler can access it
   const onShowColocatedRef = useRef(onShowColocated);
@@ -202,7 +200,6 @@ export function ClusteredMarkers({
       markers.clear();
       refCallbacks.clear();
       markerToEvents.clear();
-      refEventCountsRef.current.clear();
     };
   }, [map, handleClusterClick]);
 
@@ -221,19 +218,13 @@ export function ClusteredMarkers({
   // Reads from groupDataRef so the reverse lookup always has the latest data even if
   // the callback fires after a re-render (fixes stale closure).
   const getRefCallback = useCallback((groupKey: string) => {
-    // Detect single↔multi transitions. When AdvancedMarker switches between
-    // single-event and multi-event content, the underlying marker element may be
-    // replaced. Invalidate the cached callback so React re-fires the ref.
     const latestEvents = groupDataRef.current.get(groupKey) ?? [];
-    const prevCount = refEventCountsRef.current.get(groupKey) ?? 0;
-    const newCount = latestEvents.length;
-    const compositionChanged = (prevCount <= 1) !== (newCount <= 1);
-    refEventCountsRef.current.set(groupKey, newCount);
-    if (compositionChanged) {
-      refCallbacksRef.current.delete(groupKey);
-    }
+    // Composite cache key includes single/multi state. When a group crosses
+    // the boundary, the key changes → new callback identity → React re-fires ref.
+    const isMulti = latestEvents.length > 1;
+    const cacheKey = `${groupKey}-${isMulti}`;
 
-    let cb = refCallbacksRef.current.get(groupKey);
+    let cb = refCallbacksRef.current.get(cacheKey);
     if (cb) {
       // Existing callback — eagerly update the marker→events mapping with latest data
       const existingMarker = markersRef.current.get(groupKey);
@@ -263,7 +254,7 @@ export function ClusteredMarkers({
           markerToEventsRef.current.delete(prev);
         }
       };
-      refCallbacksRef.current.set(groupKey, cb);
+      refCallbacksRef.current.set(cacheKey, cb);
     }
     return cb;
   }, []);

--- a/src/components/kennels/ClusteredKennelMarkers.tsx
+++ b/src/components/kennels/ClusteredKennelMarkers.tsx
@@ -45,8 +45,6 @@ export function ClusteredKennelMarkers({ pins, selectedPinId, onSelectPin, onSho
   const refCallbacksRef = useRef<Map<string, (marker: google.maps.marker.AdvancedMarkerElement | null) => void>>(new Map());
   // Maps marker elements to their pin groups for cluster click handling
   const markerToPinsRef = useRef<Map<google.maps.marker.AdvancedMarkerElement, KennelPin[]>>(new Map());
-  // Track pin count per group to detect single↔multi transitions that require ref invalidation
-  const refPinCountsRef = useRef<Map<string, number>>(new Map());
 
   // Stable refs for callbacks so the cluster click handler can access them without re-creating
   const onShowColocatedRef = useRef(onShowColocated);
@@ -121,7 +119,6 @@ export function ClusteredKennelMarkers({ pins, selectedPinId, onSelectPin, onSho
       markers.clear();
       refCallbacks.clear();
       markerToPins.clear();
-      refPinCountsRef.current.clear();
     };
   }, [map, handleClusterClick]);
 
@@ -140,20 +137,15 @@ export function ClusteredKennelMarkers({ pins, selectedPinId, onSelectPin, onSho
   // Reads from groupDataRef so the reverse lookup always has the latest data even if
   // the callback fires after a re-render (fixes stale closure).
   const getRefCallback = useCallback((groupKey: string) => {
-    // Detect single↔multi transitions. When AdvancedMarker switches between
-    // single-pin and multi-pin content, the underlying marker element may be
-    // replaced. Invalidate the cached callback so React re-fires the ref with
-    // the new element, allowing the clusterer to track it.
     const latestPins = groupDataRef.current.get(groupKey) ?? [];
-    const prevCount = refPinCountsRef.current.get(groupKey) ?? 0;
-    const newCount = latestPins.length;
-    const compositionChanged = (prevCount <= 1) !== (newCount <= 1);
-    refPinCountsRef.current.set(groupKey, newCount);
-    if (compositionChanged) {
-      refCallbacksRef.current.delete(groupKey);
-    }
+    // Use a composite cache key that includes the single/multi state.
+    // When a group crosses the single↔multi boundary, the cache key changes,
+    // producing a new callback identity. React sees the new ref and fires
+    // null (cleanup) then the new marker element — no render-phase side effects.
+    const isMulti = latestPins.length > 1;
+    const cacheKey = `${groupKey}-${isMulti}`;
 
-    let cb = refCallbacksRef.current.get(groupKey);
+    let cb = refCallbacksRef.current.get(cacheKey);
     if (cb) {
       // Existing callback — eagerly update the marker→pins mapping with latest data
       const existingMarker = markersRef.current.get(groupKey);
@@ -183,7 +175,7 @@ export function ClusteredKennelMarkers({ pins, selectedPinId, onSelectPin, onSho
           markerToPinsRef.current.delete(prev);
         }
       };
-      refCallbacksRef.current.set(groupKey, cb);
+      refCallbacksRef.current.set(cacheKey, cb);
     }
     return cb;
   }, []);


### PR DESCRIPTION
## Summary

When toggling Active Only OFF on the kennel map, 209 active markers vanish and only ~47 inactive ones remain. The count correctly shows 256 but the map loses markers.

**Root cause:** When an inactive kennel joins a coordinate group that had a single active kennel, the group transitions from single-pin to multi-pin rendering. The `AdvancedMarker` component replaces the underlying marker element, but the cached ref callback has the same function identity so React never re-fires it. The old (invisible) marker stays registered in the clusterer; the new marker is on the map but unregistered.

**Fix:** Track pin/event count per coordinate group. When a group crosses the single↔multi boundary, invalidate the cached ref callback so `getRefCallback` returns a new function identity. React then fires the cleanup (removing the old marker) and registers the new one.

## Test plan

- [ ] `/kennels` map → Active Only ON → ~209 kennels with clusters
- [ ] Toggle Active Only OFF → **all 256 kennels** with proper clustering
- [ ] Toggle back ON → returns to ~209
- [ ] Rapid toggling — no ghost markers or missing clusters
- [ ] `/hareline` map → filter changes preserve all markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)