### PR TITLE
fix: Hash Rego kennel-page fallback for missing events

### DIFF
--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -9,6 +9,12 @@ import {
 } from "./parser";
 import { HashRegoAdapter } from "./adapter";
 
+vi.mock("@/lib/browser-render", () => ({
+  browserRender: vi.fn(),
+}));
+
+import { browserRender } from "@/lib/browser-render";
+
 // ── parseHashRegoDate ──
 
 describe("parseHashRegoDate", () => {
@@ -190,18 +196,18 @@ const KENNEL_PAGE_HTML = `
   </thead>
   <tbody>
     <tr>
-      <td>06/27 12:30 PM</td>
-      <td>Hash Weekend</td>
-      <td><a href="/events/nych3-5-boro-pub-crawl-2026">5-boro Pub Crawl</a></td>
-      <td>$0</td>
-      <td>1</td>
+      <td class="ng-binding">06/27 4:30 PM</td>
+      <td class="text-center ng-binding"></td>
+      <td class="text-center"><a href="//hashrego.com/events/nych3-5-boro-pub-crawl-2026" class="ng-binding">5-boro Pub Crawl</a></td>
+      <td class="text-center ng-binding">$0</td>
+      <td class="text-center"><a href="//hashrego.com/events/nych3-5-boro-pub-crawl-2026/cumming" class="ng-binding">1</a></td>
     </tr>
     <tr>
-      <td>09/15 07:00 PM</td>
-      <td>Trail</td>
-      <td><a href="/events/nych3-run-42">NYCH3 Run #42</a></td>
-      <td>$10</td>
-      <td>5</td>
+      <td class="ng-binding">09/15 07:00 PM</td>
+      <td class="text-center ng-binding">Trail</td>
+      <td class="text-center"><a href="//hashrego.com/events/nych3-run-42" class="ng-binding">NYCH3 Run #42</a></td>
+      <td class="text-center ng-binding">$10</td>
+      <td class="text-center"><a href="//hashrego.com/events/nych3-run-42/cumming" class="ng-binding">5</a></td>
     </tr>
   </tbody>
 </table>
@@ -230,25 +236,55 @@ describe("parseKennelEventsPage", () => {
 
   it("extracts time from date cell", () => {
     const entries = parseKennelEventsPage(KENNEL_PAGE_HTML, "NYCH3", 2026);
-    expect(entries[0].startTime).toBe("12:30 PM");
+    expect(entries[0].startTime).toBe("4:30 PM");
   });
 
   it("extracts type and cost", () => {
     const entries = parseKennelEventsPage(KENNEL_PAGE_HTML, "NYCH3", 2026);
-    expect(entries[0].type).toBe("Hash Weekend");
+    expect(entries[0].type).toBe(""); // empty on live site for this event
     expect(entries[0].cost).toBe("$0");
+    expect(entries[1].type).toBe("Trail");
+    expect(entries[1].cost).toBe("$10");
   });
 
   it("returns empty array for empty table", () => {
-    const html = `<html><body><table class="table table-striped"><tbody></tbody></table></body></html>`;
+    const html = `<html><body><table class="table table-striped"><thead><tr><th>Start Date</th></tr></thead><tbody></tbody></table></body></html>`;
     expect(parseKennelEventsPage(html, "NYCH3", 2026)).toHaveLength(0);
   });
 
   it("skips rows without event links", () => {
-    const html = `<html><body><table class="table table-striped"><tbody>
+    const html = `<html><body><table class="table table-striped"><thead><tr><th>Start Date</th></tr></thead><tbody>
       <tr><td>06/27</td><td>Trail</td><td>No link here</td><td>$0</td><td>0</td></tr>
     </tbody></table></body></html>`;
     expect(parseKennelEventsPage(html, "NYCH3", 2026)).toHaveLength(0);
+  });
+
+  it("infers next year for Jan events when scraping in December", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-12-15T12:00:00Z"));
+    const html = `<html><body><table class="table table-striped ng-scope">
+      <thead><tr><th>Start Date</th><th>Type</th><th>Event Name</th><th>Cost</th><th>Cumming</th></tr></thead>
+      <tbody><tr>
+        <td>01/10 07:00 PM</td><td>Trail</td>
+        <td><a href="//hashrego.com/events/test-jan">Jan Event</a></td><td>$5</td><td>0</td>
+      </tr></tbody></table></body></html>`;
+    const entries = parseKennelEventsPage(html, "TEST");
+    expect(entries[0].startDate).toBe("01/10/27");
+    vi.useRealTimers();
+  });
+
+  it("infers previous year for Dec events when scraping in January", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-01-05T12:00:00Z"));
+    const html = `<html><body><table class="table table-striped ng-scope">
+      <thead><tr><th>Start Date</th><th>Type</th><th>Event Name</th><th>Cost</th><th>Cumming</th></tr></thead>
+      <tbody><tr>
+        <td>12/28 07:00 PM</td><td>Trail</td>
+        <td><a href="//hashrego.com/events/test-dec">Dec Event</a></td><td>$5</td><td>0</td>
+      </tr></tbody></table></body></html>`;
+    const entries = parseKennelEventsPage(html, "TEST");
+    expect(entries[0].startDate).toBe("12/28/26");
+    vi.useRealTimers();
   });
 });
 
@@ -472,6 +508,7 @@ function buildSource(configOverrides?: { kennelSlugs?: string[] }) {
 describe("HashRegoAdapter", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.mocked(browserRender).mockReset();
     // Freeze time to before all fixture dates so they fall within the forward window
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T12:00:00Z"));
@@ -557,6 +594,8 @@ describe("HashRegoAdapter", () => {
   it("includes diagnostic context with slug source", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     fetchSpy.mockResolvedValueOnce(new Response(INDEX_HTML, { status: 200 }));
+    // NONEXISTENT is not in global index — browserRender will be called for kennel page
+    vi.mocked(browserRender).mockRejectedValueOnce(new Error("not found"));
 
     const adapter = new HashRegoAdapter();
     const source = buildSource();
@@ -579,20 +618,20 @@ describe("HashRegoAdapter", () => {
       <meta property="og:description" content="A fun event" />
     </head><body><a href="/kennels/NYCH3/">NYCH3</a></body></html>`;
 
-    let callCount = 0;
-    fetchSpy.mockImplementation(async () => {
-      callCount++;
-      if (callCount === 1) return new Response(INDEX_HTML, { status: 200 });
-      if (callCount === 2) return new Response(KENNEL_PAGE_HTML, { status: 200 });
-      return new Response(detailHtml, { status: 200 });
-    });
+    // Global index (no NYCH3)
+    fetchSpy.mockImplementation(async () => new Response(detailHtml, { status: 200 }));
+    fetchSpy.mockResolvedValueOnce(new Response(INDEX_HTML, { status: 200 }));
+
+    // browserRender returns the kennel page HTML
+    vi.mocked(browserRender).mockResolvedValueOnce(KENNEL_PAGE_HTML);
 
     const adapter = new HashRegoAdapter();
     const source = buildSource();
     const result = await adapter.fetch(source, { days: 365, kennelSlugs: ["NYCH3"] });
 
-    // Should have fetched: index + kennel page + detail pages
-    expect(fetchSpy.mock.calls[1][0]).toBe("https://hashrego.com/kennels/NYCH3/events");
+    expect(browserRender).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://hashrego.com/kennels/NYCH3/events" }),
+    );
     expect(result.diagnosticContext?.kennelPagesChecked).toEqual(["NYCH3"]);
     expect((result.diagnosticContext?.kennelPageEventsFound as number)).toBeGreaterThan(0);
     expect(result.events.length).toBeGreaterThan(0);
@@ -611,16 +650,16 @@ describe("HashRegoAdapter", () => {
     const source = buildSource();
     const result = await adapter.fetch(source, { days: 36500, kennelSlugs: ["EWH3"] });
 
-    // Should NOT have fetched a kennel page
-    expect(fetchSpy.mock.calls.every((c) => !String(c[0]).includes("/kennels/"))).toBe(true);
+    // Should NOT have called browserRender (slug is in global index)
+    expect(browserRender).not.toHaveBeenCalled();
     expect(result.diagnosticContext?.kennelPagesChecked).toEqual([]);
   });
 
-  it("handles kennel page fetch failure gracefully", async () => {
+  it("handles kennel page render failure gracefully", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
     fetchSpy.mockResolvedValueOnce(new Response(INDEX_HTML, { status: 200 }));
-    fetchSpy.mockResolvedValueOnce(new Response("Not Found", { status: 404 }));
+    vi.mocked(browserRender).mockRejectedValueOnce(new Error("Render timeout"));
 
     const adapter = new HashRegoAdapter();
     const source = buildSource();
@@ -629,19 +668,19 @@ describe("HashRegoAdapter", () => {
     expect(result.diagnosticContext?.kennelPagesChecked).toEqual(["NYCH3"]);
     expect(result.diagnosticContext?.kennelPageEventsFound).toBe(0);
     expect(result.events).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("Kennel page error");
   });
 
   it("filters events by days window", async () => {
     vi.setSystemTime(new Date("2026-02-15T12:00:00Z"));
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    let callCount = 0;
-    fetchSpy.mockImplementation(async () => {
-      callCount++;
-      if (callCount === 1) return new Response(INDEX_HTML, { status: 200 });
-      // All subsequent calls: kennel pages + detail pages get empty HTML
-      return new Response("<html><body></body></html>", { status: 200 });
-    });
+    fetchSpy
+      .mockResolvedValueOnce(new Response(INDEX_HTML, { status: 200 }))
+      // Detail page fetch for the 1 matching entry (EWH3)
+      .mockResolvedValueOnce(new Response("<html><body></body></html>", { status: 200 }));
+    // No kennel page fallback needed: all 4 slugs appear in global index (just outside date window)
 
     const adapter = new HashRegoAdapter();
     const source = buildSource();
@@ -650,7 +689,8 @@ describe("HashRegoAdapter", () => {
     // CH3 12/12/25 ✗ (way before), RANDOMH3 03/01/26 ✗ (after Feb 25)
     const result = await adapter.fetch(source, { days: 10, kennelSlugs: ["EWH3", "BFMH3", "CH3", "RANDOMH3"] });
 
-    // matchingEntries: 1 from global (EWH3) + 0 from kennel pages (empty HTML)
+    // matchingEntries: 1 from global (EWH3) — no kennel page fallback since all slugs exist in index
     expect(result.diagnosticContext?.matchingEntries).toBe(1);
+    expect(browserRender).not.toHaveBeenCalled();
   });
 });

--- a/src/adapters/hashrego/adapter.ts
+++ b/src/adapters/hashrego/adapter.ts
@@ -2,6 +2,7 @@ import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
 import { safeFetch } from "../safe-fetch";
+import { browserRender } from "@/lib/browser-render";
 import { generateStructureHash } from "@/pipeline/structure-hash";
 import {
   parseEventsIndex,
@@ -93,7 +94,8 @@ export class HashRegoAdapter implements SourceAdapter {
     const kennelPagesChecked: string[] = [];
     let kennelPageEventsFound = 0;
     const existingSlugs = new Set(matchingEntries.map((e) => e.slug));
-    const currentYear = now.getFullYear();
+    const currentYear = now.getUTCFullYear();
+    let kennelPageFetchErrors = 0;
 
     for (let i = 0; i < missingSlugs.length; i++) {
       if (i > 0) {
@@ -101,18 +103,14 @@ export class HashRegoAdapter implements SourceAdapter {
       }
       const slug = missingSlugs[i];
       kennelPagesChecked.push(slug);
+      const kennelUrl = `https://hashrego.com/kennels/${slug}/events`;
       try {
-        const kennelUrl = `https://hashrego.com/kennels/${slug}/events`;
-        const res = await safeFetch(kennelUrl, {
-          headers: { "User-Agent": USER_AGENT },
+        // Kennel pages are Angular SPAs — need browser rendering to get the table
+        const html = await browserRender({
+          url: kennelUrl,
+          waitFor: "table.table-striped tbody tr",
+          timeout: 15000,
         });
-        if (!res.ok) {
-          (errorDetails.fetch ??= []).push(
-            { url: kennelUrl, status: res.status, message: `Kennel page HTTP ${res.status}` },
-          );
-          continue;
-        }
-        const html = await res.text();
         const kennelEntries = parseKennelEventsPage(html, slug, currentYear);
 
         const filtered = kennelEntries.filter((e) =>
@@ -125,9 +123,12 @@ export class HashRegoAdapter implements SourceAdapter {
         }
         kennelPageEventsFound += filtered.length;
       } catch (err) {
+        const msg = `Kennel page error for ${slug}: ${err}`;
+        errors.push(msg);
         (errorDetails.fetch ??= []).push(
-          { url: `https://hashrego.com/kennels/${slug}/events`, message: `Kennel page error: ${err}` },
+          { url: kennelUrl, message: msg },
         );
+        kennelPageFetchErrors++;
       }
     }
 
@@ -157,7 +158,8 @@ export class HashRegoAdapter implements SourceAdapter {
     const unmappedKennelSlugs = allIndexSlugs.filter((s) => !kennelSlugs.has(s));
 
     // Approximate fallback count from detail page errors (each error triggers createFromIndex)
-    const indexOnlyFallbacks = (errorDetails.fetch?.length ?? 0) + (errorDetails.parse?.length ?? 0);
+    // Exclude kennel page fetch errors since those don't produce createFromIndex fallbacks
+    const indexOnlyFallbacks = (errorDetails.fetch?.length ?? 0) - kennelPageFetchErrors + (errorDetails.parse?.length ?? 0);
 
     return {
       events,

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -408,27 +408,42 @@ function cleanDescription(text: string): string | undefined {
 export function parseKennelEventsPage(html: string, kennelSlug: string, referenceYear?: number): IndexEntry[] {
   const $ = cheerio.load(html);
   const entries: IndexEntry[] = [];
-  const year = referenceYear ?? new Date().getFullYear();
+  const year = referenceYear ?? new Date().getUTCFullYear();
+  const currentMonth = new Date().getUTCMonth() + 1;
 
-  $("table.table-striped tbody tr").each((_i, row) => {
+  // Target the events table specifically — verify header contains "Start Date"
+  const table = $("table.table-striped").filter((_i, el) =>
+    $(el).find("thead th").first().text().trim().toLowerCase().includes("start date"),
+  ).first();
+
+  table.find("tbody tr").each((_i, row) => {
     const cells = $(row).find("td");
     if (cells.length < 5) return;
 
     // Col 0: Start Date — "MM/DD HH:MM AM/PM" (no year on kennel pages)
     const dateText = $(cells[0]).text().trim();
     const dateMatch = dateText.match(/^(\d{1,2}\/\d{1,2})\s*(.*)/);
-    // Append reference year so dates work with parseHashRegoDate (expects MM/DD/YY)
-    const rawDate = dateMatch ? dateMatch[1] : dateText;
-    const startDate = dateMatch ? `${rawDate}/${String(year).slice(-2)}` : rawDate;
-    const startTime = dateMatch?.[2]?.trim() || "";
+    if (!dateMatch) return;
+
+    // Infer year: if scraping in late months (Oct–Dec) and event is in early months (Jan–Mar),
+    // assume next year. If scraping in early months (Jan–Mar) and event is in late months (Oct–Dec),
+    // assume previous year.
+    const eventMonth = parseInt(dateMatch[1].split("/")[0], 10);
+    let inferredYear = year;
+    if (currentMonth >= 10 && eventMonth <= 3) inferredYear = year + 1;
+    else if (currentMonth <= 3 && eventMonth >= 10) inferredYear = year - 1;
+
+    const rawDate = dateMatch[1];
+    const startDate = `${rawDate}/${String(inferredYear).slice(-2)}`;
+    const startTime = dateMatch[2]?.trim() || "";
 
     // Col 1: Type
     const type = $(cells[1]).text().trim();
 
-    // Col 2: Event Name with link to /events/{slug}
+    // Col 2: Event Name with link to /events/{slug} or //hashrego.com/events/{slug}
     const eventLink = $(cells[2]).find("a");
     const href = eventLink.attr("href") || "";
-    const slugMatch = href.match(/^\/events\/([^/]+)/);
+    const slugMatch = href.match(/(?:^\/|\/\/hashrego\.com\/)events\/([^/]+)/);
     if (!slugMatch) return;
     const slug = slugMatch[1];
     const title = eventLink.text().trim();


### PR DESCRIPTION
## Summary
- Events like the NYCH3 5-boro Pub Crawl only appear on kennel-specific pages (`hashrego.com/kennels/{SLUG}/events`), not the global events index — the adapter now falls back to kennel pages for configured slugs absent from the global index
- Added `parseKennelEventsPage()` parser for the kennel page's different 5-column table structure (no Host Kennel column, MM/DD dates without year)
- Kennel page results are date-filtered, deduped, and merged into the existing detail-page fetch pipeline with diagnostics (`kennelPagesChecked`, `kennelPageEventsFound`)

## Test plan
- [x] 8 new parser tests for `parseKennelEventsPage` (slug extraction, date/year handling, type/cost, empty table, missing links)
- [x] 3 new adapter integration tests (fallback triggers on missing slug, skips when slug in global index, graceful fetch failure)
- [x] All 85 hashrego tests pass
- [x] TypeScript type check clean (only pre-existing Prisma generated types errors)
- [x] Lint clean (0 errors)
- [ ] Live verification against `hashrego.com/kennels/NYCH3/events` to confirm 5-boro Pub Crawl discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)