### PR TITLE
[codex] Restore sitemap metadata routes

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://hashtracks.xyz";
+
   return {
     rules: [
       {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,61 +1,39 @@
 import type { MetadataRoute } from "next";
 import { prisma } from "@/lib/db";
-import { regionNameToSlug } from "@/lib/region";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://hashtracks.xyz";
 
-  // Core pages
   const staticPages: MetadataRoute.Sitemap = [
     { url: baseUrl, changeFrequency: "daily", priority: 1.0 },
     { url: `${baseUrl}/kennels`, changeFrequency: "daily", priority: 0.9 },
     { url: `${baseUrl}/hareline`, changeFrequency: "daily", priority: 0.9 },
+    { url: `${baseUrl}/about`, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${baseUrl}/for-misman`, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${baseUrl}/suggest`, changeFrequency: "monthly", priority: 0.5 },
   ];
 
-  // Kennel detail pages
   const kennels = await prisma.kennel.findMany({
     where: { isHidden: false },
     select: { slug: true, lastEventDate: true, updatedAt: true },
   });
 
   const now = new Date();
-  const ACTIVE_DAYS = 90;
+  const activeDays = 90;
 
-  const kennelPages: MetadataRoute.Sitemap = kennels.map((k) => {
-    const daysSinceEvent = k.lastEventDate
-      ? Math.floor((now.getTime() - k.lastEventDate.getTime()) / (1000 * 60 * 60 * 24))
-      : Infinity;
-    const isActive = daysSinceEvent < ACTIVE_DAYS;
+  const kennelPages: MetadataRoute.Sitemap = kennels.map((kennel) => {
+    const daysSinceEvent = kennel.lastEventDate
+      ? Math.floor((now.getTime() - kennel.lastEventDate.getTime()) / (1000 * 60 * 60 * 24))
+      : Number.POSITIVE_INFINITY;
+    const isActive = daysSinceEvent < activeDays;
 
     return {
-      url: `${baseUrl}/kennels/${k.slug}`,
-      lastModified: k.updatedAt,
+      url: `${baseUrl}/kennels/${kennel.slug}`,
+      lastModified: kennel.updatedAt,
       changeFrequency: isActive ? "weekly" : "monthly",
       priority: isActive ? 0.8 : 0.5,
     };
   });
 
-  // Region landing pages — only regions that have at least 1 kennel
-  const regionsWithKennels = await prisma.kennel.groupBy({
-    by: ["region"],
-    where: { isHidden: false },
-    _count: true,
-  });
-
-  // Deduplicate and filter to regions with valid landing page slugs
-  const seenSlugs = new Set<string>();
-  const regionPages: MetadataRoute.Sitemap = [];
-  for (const r of regionsWithKennels) {
-    const slug = regionNameToSlug(r.region);
-    if (slug && !seenSlugs.has(slug)) {
-      seenSlugs.add(slug);
-      regionPages.push({
-        url: `${baseUrl}/kennels/region/${slug}`,
-        changeFrequency: "weekly",
-        priority: 0.7,
-      });
-    }
-  }
-
-  return [...staticPages, ...kennelPages, ...regionPages];
+  return [...staticPages, ...kennelPages];
 }


### PR DESCRIPTION
## Summary
This PR restores the Next metadata routes for `sitemap.xml` and `robots.txt` on top of `admin-ui-redesign`.

## Root Cause
`admin-ui-redesign` removed `src/app/sitemap.ts` and `src/app/robots.ts`, so production requests to `/sitemap.xml` fell through to the Next.js 404 page and returned HTML instead of XML.

## Changes
- restore `src/app/sitemap.ts`
- restore `src/app/robots.ts`
- update the sitemap entries to reflect the current route structure and stop emitting the removed `/kennels/region/*` URLs

## Impact
Search engines will be able to discover `https://www.hashtracks.xyz/sitemap.xml` again after this branch is merged and deployed.

## Validation
- verified the live production URL returned an HTML 404 before the fix
- linted the restored sitemap and robots files in the local workspace