### PR TITLE
[codex] Allow sitemap and robots through proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,8 @@ const isPublicRoute = createRouteMatcher([
   "/",
   "/sign-in(.*)",
   "/sign-up(.*)",
+  "/sitemap.xml",
+  "/robots.txt",
   "/api/health(.*)",
   "/api/cron(.*)",
   "/api/auth/strava(.*)",


### PR DESCRIPTION
## Summary
This PR allows the sitemap and robots metadata routes to bypass Clerk protection.

## Root Cause
Production was already running the restored `src/app/sitemap.ts` and `src/app/robots.ts`, but requests to `/sitemap.xml` were still returning the Next.js 404 page because `src/proxy.ts` treated those URLs as protected routes.

## Changes
- add `/sitemap.xml` to the public route matcher
- add `/robots.txt` to the public route matcher

## Impact
Unauthenticated requests from search engines and browsers can reach the metadata routes directly, so `https://www.hashtracks.xyz/sitemap.xml` and `https://www.hashtracks.xyz/robots.txt` should resolve correctly after deploy.

## Validation
- confirmed live production responses included `x-clerk-auth-reason: protect-rewrite`
- linted `src/proxy.ts` after the change