### PR TITLE
[codex] Encode sitemap slugs

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -28,7 +28,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const isActive = daysSinceEvent < activeDays;
 
     return {
-      url: `${baseUrl}/kennels/${kennel.slug}`,
+      url: `${baseUrl}/kennels/${encodeURIComponent(kennel.slug)}`,
       lastModified: kennel.updatedAt,
       changeFrequency: isActive ? "weekly" : "monthly",
       priority: isActive ? 0.8 : 0.5,


### PR DESCRIPTION
## Summary
This PR URL-encodes kennel slugs before adding them to sitemap URLs.

## Root Cause
After the sitemap route and proxy fixes were deployed, the live sitemap still contained invalid XML for kennel slugs that include reserved characters. The failing production entry was `t&ah3`, which rendered as a raw `&` inside `<loc>` and caused XML parsers to fail with `EntityRef: expecting ';'`.

## Changes
- wrap the kennel slug with `encodeURIComponent(...)` when building sitemap URLs

## Impact
Sitemap entries remain valid XML even when kennel slugs contain characters like `&`.

## Validation
- inspected the live sitemap and confirmed the bad entry at line 262
- linted `src/app/sitemap.ts` after the change