### PR TITLE
[codex] Canonicalize site host for metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { getOrCreateUser } from "@/lib/auth";
 import { clerkAppearance } from "@/lib/clerk-appearance";
 import { buildWebSiteJsonLd, safeJsonLd } from "@/lib/seo";
+import { getCanonicalSiteUrl } from "@/lib/site-url";
 import { TimePreferenceProvider } from "@/components/providers/time-preference-provider";
 import { UnitsPreferenceProvider } from "@/components/providers/units-preference-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
@@ -38,7 +39,7 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://hashtracks.xyz"),
+  metadataBase: new URL(getCanonicalSiteUrl()),
   title: "HashTracks",
   description: "Discover runs, track attendance, view stats — the hareline you never knew you needed.",
   openGraph: {
@@ -59,7 +60,7 @@ export default async function RootLayout({
 }>) {
   const user = await getOrCreateUser();
   const timeDisplayPref = user?.timeDisplayPref ?? "EVENT_LOCAL";
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://hashtracks.xyz";
+  const baseUrl = getCanonicalSiteUrl();
   const websiteJsonLd = buildWebSiteJsonLd(baseUrl);
 
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from "next";
+import { getCanonicalSiteUrl } from "@/lib/site-url";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://hashtracks.xyz";
+  const baseUrl = getCanonicalSiteUrl();
 
   return {
     rules: [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,9 @@
 import type { MetadataRoute } from "next";
 import { prisma } from "@/lib/db";
+import { getCanonicalSiteUrl } from "@/lib/site-url";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://hashtracks.xyz";
+  const baseUrl = getCanonicalSiteUrl();
 
   const staticPages: MetadataRoute.Sitemap = [
     { url: baseUrl, changeFrequency: "daily", priority: 1.0 },

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,0 +1,17 @@
+const DEFAULT_SITE_URL = "https://www.hashtracks.xyz";
+
+export function getCanonicalSiteUrl(): string {
+  const rawUrl = process.env.NEXT_PUBLIC_APP_URL || DEFAULT_SITE_URL;
+
+  try {
+    const url = new URL(rawUrl);
+
+    if (url.hostname === "hashtracks.xyz") {
+      url.hostname = "www.hashtracks.xyz";
+    }
+
+    return url.origin;
+  } catch {
+    return DEFAULT_SITE_URL;
+  }
+}


### PR DESCRIPTION
## Summary
This PR normalizes the site host to `https://www.hashtracks.xyz` for sitemap, robots, and metadata URLs.

## Root Cause
The live sitemap was being served from `https://www.hashtracks.xyz/sitemap.xml`, but its `<loc>` entries and related metadata were still generated from a non-`www` base URL. That mismatch can confuse crawlers and third-party validators, especially because `https://hashtracks.xyz/sitemap.xml` responds with a redirect instead of the XML payload.

## Changes
- add a small `getCanonicalSiteUrl()` helper
- normalize `hashtracks.xyz` to `www.hashtracks.xyz`
- use the canonical host for sitemap generation
- use the canonical host for `robots.txt`
- use the canonical host for `metadataBase` and website JSON-LD

## Impact
Search engines and validators will see a single consistent host across the served sitemap URL, the `robots.txt` sitemap reference, sitemap `<loc>` entries, and site metadata.

## Validation
- confirmed the live `www` sitemap returns `application/xml`
- confirmed the non-`www` sitemap URL returns a `307` redirect with `text/plain`
- linted the updated files