### PR TITLE
[codex] Fix sitemap lastmod format

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -30,7 +30,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     return {
       url: `${baseUrl}/kennels/${encodeURIComponent(kennel.slug)}`,
-      lastModified: kennel.updatedAt,
+      lastModified: kennel.updatedAt.toISOString().split("T")[0],
       changeFrequency: isActive ? "weekly" : "monthly",
       priority: isActive ? 0.8 : 0.5,
     };


### PR DESCRIPTION
## Summary
This PR changes sitemap `lastmod` values to use a date-only format.

## Root Cause
The live sitemap was emitting timestamps like `2026-03-08T18:38:43.349Z`. While that format is ISO-like, some sitemap validators and crawler tooling reject fractional seconds and report each entry as an invalid `lastmod` value.

## Changes
- change sitemap `lastModified` values from full timestamps to `YYYY-MM-DD`

## Impact
Sitemap consumers should accept the `lastmod` field consistently across all entries.

## Validation
- confirmed the live sitemap was returning millisecond timestamps before the change
- linted `src/app/sitemap.ts` after the update