### PR TITLE
fix: skip location-region-appended for venue-name-only locations

### DIFF
--- a/src/pipeline/audit-checks.test.ts
+++ b/src/pipeline/audit-checks.test.ts
@@ -323,9 +323,18 @@ describe("checkLocationQuality", () => {
     expect(findings).toHaveLength(0);
   });
 
-  it("flags location-region-appended when location has no state abbreviation and city differs", () => {
+  it("skips location-region-appended for venue-name-only locations (city context is desirable)", () => {
     const event = makeEvent({
       locationName: "The Rusty Bucket",
+      locationCity: "Akron, OH",
+    });
+    const findings = checkLocationQuality([event]);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("flags location-region-appended for structured address with mismatched city", () => {
+    const event = makeEvent({
+      locationName: "123 Main St, Hartville",
       locationCity: "Akron, OH",
     });
     const findings = checkLocationQuality([event]);

--- a/src/pipeline/audit-checks.ts
+++ b/src/pipeline/audit-checks.ts
@@ -206,12 +206,14 @@ function normalizeSegment(s: string): string {
 /** Matches getLocationDisplay() state-abbreviation guard exactly — keeps audit in sync with display logic. */
 const STATE_GUARD_RE = /, [A-Za-z]{2}(?:\s+\d{5}(?:-\d{4})?)?\s*$/;
 
-/** Check if a location has a region city appended that doesn't match the address city. */
+/** Check if a location has a mismatched region city appended to a structured address. */
 function checkRegionAppended(event: LocationEventRow, locationName: string, locationCity: string | null): AuditFinding | null {
   if (!locationCity) return null;
-  // Skip when location ends with state abbreviation — getLocationDisplay() already guards against
-  // appending city in this case, so the display is correct even if locationCity differs
+  // Skip when location ends with state abbreviation — getLocationDisplay() already guards this
   if (STATE_GUARD_RE.test(locationName)) return null;
+  // Skip venue-name-only locations (no comma = no structured address parts).
+  // Appending city context to "Marina Green" → "Marina Green, San Francisco, CA" is desirable.
+  if (!locationName.includes(",")) return null;
   const cityName = locationCity.split(",")[0].trim();
   if (locationName.includes(cityName)) return null;
   return finding(event, {


### PR DESCRIPTION
## Summary
Today's audit found 136 location findings — all false positives for venue-name-only locations like "Marina Green", "DMV", "Western Massachusetts" where city appending is actually desirable.

**Before:** "Marina Green" flagged because "San Francisco" not in location name
**After:** Skip locations without commas — these are venue names, not structured addresses. City context ("Marina Green, San Francisco, CA") is helpful, not a bug.

Only flag structured addresses (contain comma) with mismatched cities, e.g., "123 Main St, Hartville" + "Akron, OH".

## Test plan
- [x] 48 audit check tests pass (1 updated, 1 new)
- [ ] Tomorrow's audit should not flag venue-name-only locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)