### PR TITLE
fix: exclude sitemap.xml and robots.txt from Clerk middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -32,7 +32,7 @@ export const proxy = clerkMiddleware(async (auth, request) => {
 export const config = {
   matcher: [
     // Skip Next.js internals and static files
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|xml|txt)).*)",
     // Always run for API routes
     "/(api|trpc)(.*)",
   ],


### PR DESCRIPTION
## Summary
- Adds `xml` and `txt` to the Clerk middleware matcher's extension exclusion list in `src/proxy.ts`
- This prevents Clerk middleware from running on `/sitemap.xml` and `/robots.txt`, removing `X-Clerk-Auth-*` headers from responses
- Fixes Google Search Console "Couldn't fetch" error for the sitemap

## Test plan
- [ ] `npm run build` passes
- [ ] Fetch `/sitemap.xml` — verify no `X-Clerk-Auth-Status` header in response
- [ ] Fetch `/robots.txt` — verify no `X-Clerk-Auth-Status` header in response
- [ ] Resubmit sitemap in Google Search Console after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)