### PR TITLE
chore(sentry): drop duplicate deprecated disableLogger

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -63,7 +63,6 @@ export default withSentryConfig(nextConfig, {
 
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
-  disableLogger: true,
 
   // For all available options, see:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/


### PR DESCRIPTION
## Summary
Follow-up to #468 — drops a duplicate top-level `disableLogger: true` in `next.config.ts` that I accidentally left behind when reverting the wizard's hardcoded values to env vars.

The equivalent setting is already configured via the non-deprecated `webpack.treeshake.removeDebugLogging: true`. The top-level form is marked `@deprecated` in `@sentry/nextjs@10.47` (`node_modules/@sentry/nextjs/build/types/config/types.d.ts:505`).

## Test plan
- [ ] CI passes (typecheck, lint, tests) — single-line deletion of an optional deprecated field

🤖 Generated with [Claude Code](https://claude.com/claude-code)