### PR TITLE
feat: backfill Maine kennels into seed + research skill DB check

### DIFF
--- a/.claude/commands/research-region.md
+++ b/.claude/commands/research-region.md
@@ -8,9 +8,38 @@ Discover kennels, identify the best data source for each, and write a research f
 
 ## Stage 1: Check Existing Coverage
 
+Check BOTH seed data AND the live production database. Seed files alone are not authoritative — kennels can be added directly via the admin UI and exist only in the DB until backfilled. Skipping this check has caused duplicate research passes on already-onboarded kennels.
+
 ```bash
+# 1. Seed data
 grep -i "REGION_KEYWORDS" prisma/seed-data/kennels.ts prisma/seed-data/aliases.ts
 ```
+
+```bash
+# 2. Live DB — any kennel attached to a region whose name matches the target
+set -a; source .env.local 2>/dev/null || source .env; set +a
+cat > /tmp/check-region.ts <<'EOF'
+import { PrismaClient } from './src/generated/prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
+async function main(){
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false }});
+  const p = new PrismaClient({ adapter: new PrismaPg(pool) });
+  // Replace REGION_KEYWORDS with all relevant terms (state name, abbrev, major cities)
+  const terms = ["REGION_KEYWORDS"];
+  const regions = await p.region.findMany({ where: { OR: terms.map(t => ({ name: { contains: t, mode: "insensitive" as const }})) }});
+  for (const r of regions) {
+    const ks = await p.kennel.findMany({ where: { regionId: r.id }, select:{kennelCode:true, shortName:true, fullName:true}});
+    console.log(`${r.name} (${r.level}): ${ks.length} kennels`, ks.map(k=>k.kennelCode).join(", "));
+  }
+  await p.$disconnect();
+}
+main();
+EOF
+npx tsx /tmp/check-region.ts && rm /tmp/check-region.ts
+```
+
+Any kennel returned here is already onboarded and MUST NOT be re-researched. If any DB kennel is missing from seed files, flag it — that's a backfill candidate (the seed files should be the source of truth).
 
 ## Stage 2: Aggregator-First Discovery
 

--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -391,6 +391,10 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "gch3": ["GCH3", "Gulf Coast", "Gulf Coast H3", "Gulf Coast Hash", "Gulf Coast HHH"],
     "wsh3": ["WSH3", "Wandering Soul", "Wandering Soul H3", "Wandering Soul Hash", "Wandering Soul HHH"],
 
+    // ===== MAINE =====
+    "pormeh3": ["PorMEH3", "PorMe H3", "PorMe Hash", "Portland Maine Hash", "Portland Maine H3", "Portland ME H3"],
+    "knightvillian": ["Knightvillian H3", "Knightvillain", "Knightvillain H3", "KV", "KV H3", "Knightvillian Hash", "Knightville H3"],
+
     // ===== CANADA =====
     // Quebec
     "mh3-ca": ["MH3", "Montreal Hash", "Montreal HHH", "Montreal H3", "MHHH"],

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2609,5 +2609,25 @@ export const KENNELS: KennelSeed[] = [
       description: "Birmingham, Alabama hash kennel. Best known for hosting the annual SOEX (Southern Excursion) hash campout.",
       latitude: 33.52, longitude: -86.81,
     },
+
+    // ── Maine: Portland ──
+    {
+      kennelCode: "pormeh3", shortName: "PorMEH3", fullName: "Portland Maine Hash House Harriers",
+      region: "Portland, ME",
+      scheduleDayOfWeek: "Saturday",
+      scheduleFrequency: "Biweekly",
+      scheduleNotes: "Saturday trails — usually around noon, sometimes later. Check the calendar, show up thirsty.",
+      description: "Portland, Maine's flagship hash. Beer, trail, and a whole lot of bad decisions along the rocky coast.",
+      latitude: 43.66, longitude: -70.26,
+    },
+    {
+      kennelCode: "knightvillian", shortName: "Knightvillian", fullName: "Knightvillian Hash House Harriers",
+      region: "Portland, ME",
+      scheduleDayOfWeek: "Thursday",
+      scheduleFrequency: "Weekly",
+      scheduleNotes: "Thursdays at 6:30 PM. Rain, shine, or nor'easter.",
+      description: "Portland's weekly Thursday-night hash out of the Knightville neighborhood in South Portland. If the night's long enough and the beer's cold enough, the name starts looking like 'Knightvillain' — and nobody's arguing.",
+      latitude: 43.64, longitude: -70.24,
+    },
   ];
 

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2948,5 +2948,26 @@ export const SOURCES = [
       },
       kennelCodes: ["gch3"],
     },
+
+    // ===== MAINE =====
+    // Aggregator calendar for both Portland, ME kennels. Events titled
+    // "Knightvillain"/"KV" route to knightvillian; everything else defaults to pormeh3.
+    {
+      name: "PorMe H3 Google Calendar",
+      url: "pormeh3hashcash@gmail.com",
+      type: "GOOGLE_CALENDAR" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 365,
+      config: {
+        calendarId: "pormeh3hashcash@gmail.com",
+        defaultKennelTag: "pormeh3",
+        kennelPatterns: [
+          ["Knightvillain", "knightvillian"],
+          ["KV", "knightvillian"],
+        ],
+      },
+      kennelCodes: ["pormeh3", "knightvillian"],
+    },
   ];
 


### PR DESCRIPTION
## Summary
Both Maine kennels (PorMEH3 + Knightvillian) were already live in the production DB, added via admin UI, but missing from \`prisma/seed-data/*.ts\`. The next \`npx prisma db seed\` run would leave them dangling. This PR backfills seed + makes the research skill query the DB so admin-added kennels aren't re-researched.

## Changes
- **kennels.ts**: add \`pormeh3\` and \`knightvillian\` (both region \`Portland, ME\`) with day/frequency/notes/coords; light-and-hashy descriptions
- **Reparent pormeh3**: was attached to the state-level \`Maine\` region in DB; seed upsert moves it to the \`Portland, ME\` metro
- **aliases.ts**: standard variants, including the common \`Knightvillain\` misspelling
- **sources.ts**: add \`PorMe H3 Google Calendar\` (\`pormeh3hashcash@gmail.com\`) with \`kennelPatterns\` routing \`Knightvillain\`/\`KV\` events to knightvillian and defaulting to pormeh3
- **defaultKennelTag fix**: \`PorMEH3\` → \`pormeh3\` (lowercase kennelCode per convention)
- **/research-region skill**: Stage 1 now queries the live production DB in addition to grepping seed files, so admin-added kennels no longer trigger duplicate research passes

## Live verification
- \`pormeh3hashcash@gmail.com\` → 10+ events ✓ (HEALTHY in DB, scraping every 6h)
- Sample events: PorMEH3 #897 Sweater Late Than Never (Sat), Knightvillain H3 #478 Hamm's and Eggs (Thu 6:30pm)

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Lint clean (no new errors)
- [ ] Post-merge: \`npx prisma db seed\` to sync DB (reparents pormeh3, fixes defaultKennelTag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)