### PR TITLE
fix: address PR #479 review feedback (Maine backfill)

### DIFF
--- a/.claude/commands/research-region.md
+++ b/.claude/commands/research-region.md
@@ -16,27 +16,29 @@ grep -i "REGION_KEYWORDS" prisma/seed-data/kennels.ts prisma/seed-data/aliases.t
 ```
 
 ```bash
-# 2. Live DB — any kennel attached to a region whose name matches the target
+# 2. Live DB — any kennel attached to a region whose name matches the target.
+# NOTE: script must live in the project root so @/ path aliases and the
+# generated Prisma client resolve correctly.
 set -a; source .env.local 2>/dev/null || source .env; set +a
-cat > /tmp/check-region.ts <<'EOF'
-import { PrismaClient } from './src/generated/prisma/client';
-import { PrismaPg } from '@prisma/adapter-pg';
-import { Pool } from 'pg';
-async function main(){
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false }});
+cat > check-region-tmp.ts <<'EOF'
+import { PrismaClient } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+async function main() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
   const p = new PrismaClient({ adapter: new PrismaPg(pool) });
   // Replace REGION_KEYWORDS with all relevant terms (state name, abbrev, major cities)
   const terms = ["REGION_KEYWORDS"];
-  const regions = await p.region.findMany({ where: { OR: terms.map(t => ({ name: { contains: t, mode: "insensitive" as const }})) }});
+  const regions = await p.region.findMany({ where: { OR: terms.map((t) => ({ name: { contains: t, mode: "insensitive" as const } })) } });
   for (const r of regions) {
-    const ks = await p.kennel.findMany({ where: { regionId: r.id }, select:{kennelCode:true, shortName:true, fullName:true}});
-    console.log(`${r.name} (${r.level}): ${ks.length} kennels`, ks.map(k=>k.kennelCode).join(", "));
+    const ks = await p.kennel.findMany({ where: { regionId: r.id }, select: { kennelCode: true, shortName: true, fullName: true } });
+    console.log(`${r.name} (${r.level}): ${ks.length} kennels`, ks.map((k) => k.kennelCode).join(", "));
   }
   await p.$disconnect();
 }
 main();
 EOF
-npx tsx /tmp/check-region.ts && rm /tmp/check-region.ts
+npx tsx check-region-tmp.ts; rm -f check-region-tmp.ts
 ```
 
 Any kennel returned here is already onboarded and MUST NOT be re-researched. If any DB kennel is missing from seed files, flag it — that's a backfill candidate (the seed files should be the source of truth).

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2957,14 +2957,17 @@ export const SOURCES = [
       url: "pormeh3hashcash@gmail.com",
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
-      scrapeFreq: "daily",
+      scrapeFreq: "every_6h",
       scrapeDays: 365,
       config: {
         calendarId: "pormeh3hashcash@gmail.com",
         defaultKennelTag: "pormeh3",
         kennelPatterns: [
-          ["Knightvillain", "knightvillian"],
-          ["KV", "knightvillian"],
+          // Handles both spellings: correct "Knightvillian" (ian) and common misspelling "Knightvillain" (ain)
+          ["Knightvill(ian|ain)", "knightvillian"],
+          // Matches "KV", "KV484", "KV 478" but NOT "KVR", "Kevin", etc.
+          // (\bKV not followed by another letter)
+          ["\\bKV(?![A-Za-z])", "knightvillian"],
         ],
       },
       kennelCodes: ["pormeh3", "knightvillian"],


### PR DESCRIPTION
Follow-up to #479. Three bugs flagged unanimously by Gemini, CodeRabbit, and Claude — all addressed before running seed.

## Fixes

### 1. `/research-region` script path (runtime breakage)
The DB-check snippet wrote to \`/tmp/check-region.ts\` with a relative \`./src/...\` import — resolved to \`/tmp/src/...\` which doesn't exist. Now writes \`check-region-tmp.ts\` in the project root and uses the \`@/\` path alias so tsconfig resolution works.

### 2. PorMe \`kennelPatterns\` (silent misattribution)
- \`"Knightvillain"\` (a-i-n) only matched the misspelling. Correctly-spelled \`Knightvillian\` (i-a-n) events were falling through to the \`pormeh3\` default. Now \`Knightvill(ian|ain)\` catches both.
- \`"KV"\` was a bare substring match — would match \"Kevin\", \"KVR\", etc. Now \`\\\\bKV(?![A-Za-z])\` — matches \"KV\", \"KV484\", \"KV 478\" but rejects \"Kevin\"/\"KVR\"/\"AKV\".

### 3. \`scrapeFreq\` mismatch
Seed said \`"daily"\` but prod DB is \`"every_6h"\`. Next \`prisma db seed\` would have downgraded scrape cadence. Fixed.

## Live verification
Tested the regex against **all 50 upcoming events** from \`pormeh3hashcash@gmail.com\`:

| Kennel | Count |
|---|---|
| knightvillian | 25 |
| pormeh3 | 25 |

Zero misattribution. Edge cases verified: \`KV484 – Booze-Your-Own-Adventure\` → knightvillian ✓, \`Kevin's Birthday Trail\` → pormeh3 ✓, \`KVR trail\` → pormeh3 ✓.

## Test plan
- [x] Regex smoke test against 50 live calendar events
- [x] Type check clean
- [ ] Post-merge: run \`npx prisma db seed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)