### PR TITLE
docs: New Hampshire kennel research (zero shippable)

### DIFF
--- a/docs/kennel-research/new-hampshire-research.md
+++ b/docs/kennel-research/new-hampshire-research.md
@@ -1,7 +1,7 @@
 # New Hampshire Kennel Research
 
 **Researched:** 2026-04-07
-**Result:** 0 kennels shippable (all Facebook-only, dead aggregator sites)
+**Result:** 0 kennels shippable (all Facebook-only, dead kennel websites)
 
 ## Existing Coverage
 None. DB probe for regions containing Hampshire / NH / Concord / Seacoast / Enfield returned zero NH matches.


### PR DESCRIPTION
Closing out the Eastern Time Zone sweep. NH has 4 candidate kennels per half-mind.com but every single one is Facebook-only with a dead website. Every structured-source check came back negative.

## Findings

| Kennel | City | Outcome |
|---|---|---|
| Concord H3 | Concord | concordh3.com DEAD, FB only |
| Seacoast H3 | Seacoast | seacoasth3.com DEAD, FB only |
| The New HashMpire H3 | Statewide | newhashmpire.com DEAD, FB only |
| Upper Valley H3 | Enfield | No site ever, FB only |

## Checks performed (all negative)
- **12 Google Calendar ID variants** (concordh3@, seacoasth3@, seacoasth3hashcash@, newhashmpire@, uppervalleyh3@, uvh3@, nhh3@, nhh3hashcash@, ch3nh@, concordnh@, concordhhh@, hashmpire@) → all HTTP 404
- **HashRego /events** live index → 0 NH slug matches
- **Dead domain check** → all 3 → HTTP 000
- **Meetup** → no results
- **Harrier Central** → no NH kennels
- **DB existing-coverage probe** → no NH regions/kennels

## Result
**0 kennels shippable.** Documented in \`docs/kennel-research/new-hampshire-research.md\`. No seed data changes. Defer until a kennel adopts a scrapeable source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)