### PR TITLE
chore(readme): refresh stale counts, trim sprint changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ A community platform where hashers discover upcoming runs, track attendance, and
 ## Tech Stack
 
 - **Framework:** Next.js 16 (App Router), React 19, TypeScript strict
-- **Database:** PostgreSQL (Railway) via Prisma 7
+- **Database:** PostgreSQL (Railway) via Prisma 7 with versioned migrations
 - **Auth:** Clerk (Google OAuth + email/password)
 - **UI:** Tailwind CSS v4 + shadcn/ui
-- **Analytics:** PostHog (event tracking, privacy-first), Sentry (error tracking), Vercel Speed Insights
-- **Testing:** Vitest (129 test files, 3200+ tests)
-- **Deployment:** Vercel (auto-deploy from `main`, daily cron scrapes)
+- **Jobs:** Vercel Cron triggers QStash fan-out for per-source scrape jobs
+- **NAS infra:** Self-hosted Playwright browser-render + residential proxy (Synology + Tailscale) for JS-rendered and WAF-blocked sources
+- **AI:** Gemini 2.0 Flash for parse recovery, column detection, and source research
+- **Analytics:** PostHog (privacy-first), Sentry error tracking, Vercel Speed Insights
+- **Testing:** Vitest (163 test files, 3900+ tests)
+- **Deployment:** Vercel (auto-deploy from `main`, `prisma migrate deploy` on build)
 
 ## Local Development
 
@@ -43,15 +46,17 @@ Open [http://localhost:3000](http://localhost:3000).
 |---------|-------------|
 | `npm run dev` | Start dev server |
 | `npm run build` | Production build |
-| `npm test` | Run test suite (109 test files) |
+| `npm test` | Run test suite |
 | `npx prisma studio` | Visual database browser |
-| `npx prisma db push` | Push schema changes to DB |
+| `npx prisma db push` | Push schema changes to **local dev** DB only (prod uses versioned migrations) |
+| `npx prisma migrate dev --name <change>` | Author a new versioned migration for a schema change |
+| `npx prisma migrate deploy` | Apply pending migrations (runs automatically in Vercel build) |
 | `npx prisma db seed` | Seed kennels, aliases, and sources |
 
 ## Features
 
 ### Hareline (Event Calendar)
-- Aggregated event list, calendar, and **map** views from 150+ data sources
+- Aggregated event list, calendar, and **map** views from 155+ data sources
 - Filters: time scope (upcoming/past), region, kennel, day of week (apply across all views)
 - Master-detail layout with side panel on desktop
 - Region-colored badges, calendar export (Google Calendar + .ics)
@@ -64,7 +69,7 @@ Open [http://localhost:3000](http://localhost:3000).
 - Stats dashboard: per-kennel, per-region breakdowns with milestone markers
 
 ### Kennel Directory
-- Browse and search 190+ kennels across 97 regions (US, UK, Ireland, Germany)
+- Browse and search 193+ kennels across 97 regions (US, UK, Ireland, Germany, Japan)
 - Rich kennel profiles: schedule, social links, hash cash, dog-friendly/walkers-welcome flags
 - Filters: region, run day, frequency, has upcoming, country
 - Sort: A–Z (grouped by region) or Recently Active
@@ -82,9 +87,9 @@ Open [http://localhost:3000](http://localhost:3000).
 - Logbook sync: pending confirmations link misman records to user logbook entries
 
 ### Source Engine
-- 7 source types: HTML Scraper, Google Calendar, Google Sheets, iCal Feed, Hash Rego, Meetup, Static Schedule (RRULE-based); HTML Scraper includes implementation variants: browser-rendered (Wix/SPA), WordPress REST API, Blogger API, and generic config-driven CSS selector scraping
-- 150+ live sources feeding 190+ kennels across 25+ regions (US coast-to-coast, UK, Ireland, Germany)
-- Automated daily scrapes via Vercel Cron
+- Adapter types: HTML Scraper, Google Calendar, Google Sheets, iCal Feed, Hash Rego, Meetup, Harrier Central, Static Schedule (RRULE-based). HTML Scraper has implementation variants: Cheerio, browser-rendered (Wix/SPA), WordPress REST API, Blogger API, and a generic config-driven CSS selector scraper.
+- **155+ live sources feeding 193+ kennels across 25+ regions** (US coast-to-coast, UK, Ireland, Germany, Japan). See [`.claude/rules/active-sources.md`](.claude/rules/active-sources.md) for the full per-region breakdown.
+- Scrape dispatch: Vercel Cron fires a fan-out job → QStash publishes one message per due source → per-source endpoints run the adapter and merge results
 - Merge pipeline with fingerprint dedup, trust levels, and kennel alias resolution
 - Event reconciliation: detects and cancels stale events when sources change
 - AI recovery layer: Gemini-powered parse error fallback with confidence tracking
@@ -92,7 +97,7 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ### Source Health Monitoring
 - Rolling-window health analysis (event counts, field fill rates, structure fingerprints)
-- 6 alert types: event count anomaly, field fill drop, structure change, scrape failure, consecutive failures, unmatched tags
+- Alert types: event count anomaly, field fill drop, structure change, scrape failure, consecutive failures, unmatched tags, source-kennel mismatch, excessive cancellations
 - AI-assisted alert classification and repair suggestions
 - Self-healing alert actions: one-click re-scrape, unmatched tag resolver with fuzzy matching, GitHub issue creation
 - Self-healing automation loop: critical alerts auto-create GitHub issues → Claude AI triages with confidence scoring → high-confidence issues trigger auto-fix PRs → CI validates → human reviews
@@ -102,12 +107,13 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ### Admin Tools
 - Source onboarding wizard: multi-phase guided setup with source type auto-detection, config panels, and live preview
+- Source research pipeline: AI-powered URL discovery, classification, and proposal workflow
 - Source coverage dashboard: kennel-to-source mapping matrix
 - Config validation with ReDoS safety and per-adapter field enforcement
 - Source management: scrape triggers, lookback configuration, structured scrape logs
 - Kennel CRUD with auto-alias on rename, duplicate detection, kennel merge tool
 - Alert dashboard with acknowledge/snooze/resolve workflow and repair history
-- **Analytics dashboard:** community health, user engagement, and operational metrics with recharts
+- Analytics dashboard: community health, user engagement, and operational metrics with recharts
 - Misman request queue with approve/reject and invite link generation
 - Roster group management: create, rename, dissolve, approve requests
 - CI enforcement: type checking, linting, and tests required on all PRs via GitHub Actions
@@ -122,91 +128,11 @@ Open [http://localhost:3000](http://localhost:3000).
 - Temperature units toggle: °F / °C (localStorage-persisted, defaults to °F)
 - Header dropdowns for quick switching; event cards and detail pages respect both preferences
 
-## Data Sources (150+)
-
-| Region | Sources | Kennels |
-|--------|---------|---------|
-| NYC / NJ / Philly | 8 sources (hashnyc.com, Summit Sheets, Calendars, websites, Hash Rego) | 17 kennels |
-| Massachusetts | 4 sources (Boston Calendar, static schedules, Northboro browser-rendered) | 11 kennels |
-| Chicago | 3 sources (Chicagoland Calendar, CH3 + TH3 websites) | 11 kennels |
-| DC / DMV | 10 sources (Calendars, iCal feeds, WordPress blogs, Sheets) | 19 kennels |
-| SF Bay Area | 3 sources (SFH3 iCal + HTML, Surf City Calendar) | 13 kennels |
-| Southern California | 12 sources (Google Calendars, SDH3 hareline) | 20+ kennels |
-| Washington | 8 sources (WA Hash Calendar, Sheets for 6 kennels) | 12 kennels |
-| Colorado | 5 sources (Denver, Boulder, Ft Collins, CO Springs Calendars) | 8 kennels |
-| Texas | 10 sources (Austin, Houston, DFW Calendars, Brass Monkey blog) | 10+ kennels |
-| London / UK + Scotland | 9 sources (HTML scrapers, GenericHtml) | 12 kennels |
-| Germany | 4 sources (Berlin iCal, Stuttgart + Munich Calendars, Frankfurt scraper) | 12 kennels |
-| Ireland | 1 source (Dublin H3 website) | 1 kennel |
-| Florida | 8 sources (Meetup, Calendars, WCFH3 scraper, static schedules) | 29 kennels |
-| Georgia | 11 sources (Meetup, Atlanta Hash Board, static schedules) | 20 kennels |
-| South Carolina | 10 sources (Meetup, static schedules) | 10 kennels |
-| Virginia | 9 sources (Calendars, Meetup, static schedules) | 9 kennels |
-| North Carolina | 6 sources (Calendars, Meetup, website) | 6 kennels |
-| Upstate New York | 6 sources (Calendars, Meetup, HTML scrapers) | 6 kennels |
-| Pennsylvania | 6 sources (Calendars, iCal feeds) | 6 kennels |
-| New England | 5 sources (Meetup, websites, static schedule) | 5 kennels |
-| Other (AZ, HI, MN, MI, DE) | 10+ sources | 15+ kennels |
-
 ## Documentation
 
-- [`docs/roadmap.md`](docs/roadmap.md) — Implementation roadmap and what's next
-- [`docs/source-onboarding-playbook.md`](docs/source-onboarding-playbook.md) — How to add new data sources
-- [`docs/misman-attendance-requirements.md`](docs/misman-attendance-requirements.md) — Misman tool requirements
-- [`docs/config-driven-onboarding-plan.md`](docs/config-driven-onboarding-plan.md) — Source onboarding wizard design
-- [`docs/test-coverage-analysis.md`](docs/test-coverage-analysis.md) — Test coverage gap analysis
-- [`docs/self-healing-automation-plan.md`](docs/self-healing-automation-plan.md) — Self-healing automation architecture
-- [`CLAUDE.md`](CLAUDE.md) — AI assistant context (architecture, conventions, file map)
+- [`CLAUDE.md`](CLAUDE.md) — AI assistant context: architecture, conventions, file map, active sources
+- [`docs/`](docs/) — Roadmap, source-onboarding playbook, misman requirements, self-healing automation, residential-proxy spec, and regional kennel research
 
 ## Project Status
 
-**Sprints 1-10 complete.** See [`docs/roadmap.md`](docs/roadmap.md) for the full roadmap.
-
-### Completed
-- **Sprint 1:** Scaffold — Prisma 7, Clerk auth, seeded DB, Vercel deployment
-- **Sprint 2:** Kennel directory — browse, search, subscribe, profiles, admin tools
-- **Sprint 3:** Source engine — adapter framework, hashnyc.com scraper, merge pipeline
-- **Sprint 4:** Hareline — event list & calendar views, filters, event detail pages
-- **Post-sprint polish:** Tooltips, AM/PM times, filter URL persistence, Google Calendar adapter (Boston), Google Sheets adapter (Summit H3)
-- **Sprint 5:** The Logbook — attendance tracking, check-in, stats, milestones
-- **Sprint 6:** UX polish — loading skeletons, calendar export, dynamic titles, region badges
-- **Sprint 7:** Per-source scrape windows, "I'm Going" RSVP
-- **Source monitoring:** Health analysis, structural fingerprinting, admin alerts, self-healing actions
-- **Scrape logging:** Structured errors across all adapters, performance timing, diagnostic context
-- **Sprints 8a-8f:** Misman tool — schema, dashboard, attendance form, roster, history, roster groups, duplicate merge
-- **Sprint 9:** Audit log, hare sync, CSV import, invite links, attendance UX polish
-- **Admin polish:** Kennel merge UI, roster group admin, invite from admin page
-- **Kennel identity:** Permanent kennelCode field, source-scoped resolver, duplicate merges
-- **EventLink + Hash Rego:** EventLink model, Hash Rego adapter, multi-day event splitting
-- **Source expansion:** 29 sources across 6 regions — DC/DMV, Chicago, SF Bay, London adapters
-- **Refactoring:** Shared adapter utilities, function decomposition, ActionResult types
-- **Hasher-kennel linking:** Profile invites, user-side visibility, misman activity awareness
-- **Source onboarding wizard:** Multi-phase admin UI for config-driven source creation with live preview
-- **AI recovery layer:** Gemini-powered parse error fallback, column auto-detection, kennel pattern suggestions
-- **Event reconciliation:** Stale event detection and cancellation when sources change
-- **Meetup adapter:** Meetup.com public API adapter — 5 live sources (Miami, Savannah, VT, CT, Charleston)
-- **Static Schedule adapter:** RRULE-based event generation for Facebook-only kennels — 26 live sources
-- **BFM + Philly H3 scrapers:** benfranklinmob.com and hashphilly.com HTML adapters
-- **User feedback:** In-app dialog auto-filing GitHub issues with category labels
-- **Timezone preferences:** User-selectable timezone display with header dropdown
-- **Analytics:** PostHog (client + server event tracking, privacy-first, `/ingest` reverse proxy), Sentry error tracking, Vercel Speed Insights, admin analytics dashboard at `/admin/analytics`
-- **Config validation:** Server-side validation with ReDoS protection for all source types
-- **Map-based discovery (PR #95):** Interactive Map tab on Hareline with Google Maps JS, region-colored pins, EventLocationMap static image, coordinate extraction from Maps URLs
-- **Weather forecast + units toggle (PR #97):** Google Weather API forecast on upcoming events, °F/°C toggle, text-address fallback
-- **Self-healing automation:** CI gate, auto-issue filing from alerts, Claude AI triage + auto-fix workflows
-- **Design refresh:** Homepage redesign (PR #205), EventCard redesign (PR #219), Kennel profile pages (PR #210), Logbook visualizations (PR #211), Nav & Chrome overhaul (PRs #214-226)
-- **SHITH3 website adapter:** PHP REST API scraper for richer event data (hares, locations, distances)
-- **Kennel scaling:** Florida (29 kennels, 8 sources), Georgia (20 kennels, 11 sources), South Carolina (10 kennels, 10 sources), New England + Dublin expansion
-- **Double-header support:** Multiple events per kennel per day with `allowDoubleHeaders` flag
-- **Hidden kennels:** Admin hide/unhide kennels from public directory
-- **Rolling weeks calendar:** Week-based calendar navigation with time filter
-- **Data quality hardening:** Location cleanup, venue dedup, placeholder filtering, event city backfill from coordinates
-- **DB seed automation:** Slug collision handling, `ensurePattern()` refactor
-- **Dublin H3 adapter:** First Ireland-based kennel (HTML scraper)
-- **Massive source expansion:** 150+ sources across 25+ regions — Southern CA, Washington, Colorado, Texas, Virginia, North Carolina, Upstate NY, Pennsylvania, Germany, Scotland, Arizona, Hawaii, Minnesota, Michigan, Delaware
-- **Strava integration:** OAuth connect, activity sync, match suggestions, privacy zone handling
-- **Near Me filter:** Geolocation-based distance filtering on hareline and kennel directory
-- **Kennel map view:** Interactive Google Maps with region-colored pins and aggregate markers
-- **Source research pipeline:** AI-powered URL discovery, classification, and proposal workflow
-- **GenericHtml adapter:** Config-driven CSS selector scraping with AI-assisted setup
-- **Open Graph + social sharing:** Metadata, og:image, Twitter cards
+Active development. See [`docs/roadmap.md`](docs/roadmap.md) for what's next.


### PR DESCRIPTION
## Summary
Fresh-eyes pass on README.md after noticing it had stale test counts and a growing sprint changelog.

**Stale numbers fixed:**
- Test suite: 129 → 163 files, 3200+ → 3900+ tests (and removed a second "109 test files" that had drifted separately in the commands table)
- Sources: 150+ → 155+, kennels: 190+ → 193+
- Regions now list Japan (Tokyo HC, Kyoto, Osaka, KFMH3)
- Source Engine adapter list now includes HARRIER_CENTRAL

**Structural cleanup:**
- Deleted the per-region "Data Sources" table — it was drifting with every onboarding PR and duplicates `.claude/rules/active-sources.md`. Replaced with a single pointer line.
- Deleted the "Project Status → Completed" section (~50 bullets of historical sprint work). git log and `docs/roadmap.md` cover this better.
- README goes from **215 → 138 lines** (~36% shorter) with no information loss.

**Added:**
- NAS infra (Playwright browser render + residential proxy via Tailscale) and Gemini AI to Tech Stack — these were notable omissions
- QStash fan-out wording under Source Engine (previously just "Vercel Cron")
- Versioned migrations noted in Tech Stack + Deployment bullets + Key Commands (per #477/#480)

## Test plan
- [x] Render preview on GitHub PR (markdown-only change, no code)
- [ ] Spot-check that all links still resolve (`CLAUDE.md`, `docs/`, `.claude/rules/active-sources.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)