### PR TITLE
docs: Kentucky kennel research (zero shippable)

### DIFF
--- a/docs/kennel-research/kentucky-research.md
+++ b/docs/kennel-research/kentucky-research.md
@@ -32,7 +32,7 @@ None. DB probe for regions matching Kentucky / KY / Louisville / Lexington / Bow
 - [x] HashRego `/events` live index grep — 0 KY slug matches
 - [x] Meetup — Louisville group 404
 - [x] Harrier Central — no KY kennels
-- [x] Chrome probe of all 4 alive-kennel websites (`lexingtonhah3.org`, `louisvillehashers.com`, `hellhoundh3.com`, `lickingvalleyh3.com`) — 2 live, 2 dead
+- [x] Chrome probe of all 4 discovered websites (lexingtonhah3.org, louisvillehashers.com, hellhoundh3.com, lickingvalleyh3.com) — 2 live, 2 dead
 - [x] Extracted HAH3 calendar ID from iframe, verified empty via Calendar API
 - [x] Louisville WordPress REST API probed — `/wp/v2/posts` has 1 post from 2021, `/wp/v2/pages` has only "Mismanagement" + "Regional Kennels"
 - [x] 15 Google Calendar ID variants tried across all 4 alive kennels — all HTTP 404 or 0 events


### PR DESCRIPTION
9 Kentucky kennels enumerated, 5 dead, 4 alive — but every single alive candidate lacks a scrapeable source.

## Findings

| Kennel | Outcome |
|---|---|
| **Horse's Ass H3** (Lexington) | Website live, GCal iframe found (`g2drd8u3nmknj0rubhv5d8eois@group.calendar.google.com`) — but **calendar is empty**. Site says "Follow the tweet on and on to the next Hash info." |
| **Louisville H3** | WordPress site live, no calendar embed, only a Meetup link — and the Meetup group returns "Group not found." |
| **Hellhound H3** (Lexington) | Domain DEAD (NXDOMAIN). 2022 Wayback snapshot had no calendar either. |
| **Lexington Lunatics H3** | No website ever listed. |
| Beaver Creek / Bluegrass / Four Roses FMH3 / Ft Knox Hors Hunt / Licking Valley | All Dead per half-mind |

## Checks performed
- DB existing-coverage probe — zero
- HashRego \`/events\` live index — 0 KY slug matches
- 15 Google Calendar ID variants across 4 alive kennels — all 404 or empty
- All 4 alive-kennel websites probed via Chrome (2 live, 2 NXDOMAIN)
- Louisville WP REST API probed (2 pages, no events/schedule)
- Hellhound Wayback 2022 snapshot — no calendar historically either

## Closest miss
Horse's Ass H3 (Lexington) has the right scaffolding — an embedded Google Calendar on their website — but it's unmaintained. Calendar ID captured in the research doc so we can re-enable instantly if they resume using it.

## Result
**0 kennels shippable.** Documented in \`docs/kennel-research/kentucky-research.md\`. No seed data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)