### PR TITLE
docs: Mississippi research (0 shippable) + chrome-verify-kennels skill

### DIFF
--- a/.claude/commands/chrome-verify-kennels.md
+++ b/.claude/commands/chrome-verify-kennels.md
@@ -1,0 +1,104 @@
+Generate a Claude-in-Chrome verification prompt for deferred kennels in: $ARGUMENTS
+
+Claude-in-Chrome (the browser-based Claude with full web search + Facebook page reading) is very good at re-checking kennels we've marked as "no scrapeable source" — it can find activity status, dead-domain successors, private-vs-public FB groups, and incidental mentions on aggregator pages. This skill produces a single self-contained prompt the user can paste into a fresh Chrome session.
+
+## When to use
+- After a regional research pass that produced deferred kennels
+- When the user asks to "double check" or "verify" kennels we've already declared unshippable
+- Before a deep-dive backfill where we need confidence the kennel is genuinely sourceless
+
+## Inputs ($ARGUMENTS)
+- A region name (e.g. `Mississippi`) → look up `docs/kennel-research/{region}-research.md` and extract every Skip/Deferred kennel
+- OR an explicit kennel list (e.g. `Biloxi H3, Jackson H3, OUCH3`) → use as-is
+- OR `recent` → scan the last 5 research docs for any deferred kennels
+
+## Steps
+
+### 1. Gather context
+For each kennel to verify, collect from the research doc (or by asking the user):
+- Kennel name + any abbreviations
+- City + state
+- Half-mind status + schedule (if known)
+- Listed website (and whether it's dead/repurposed/live)
+- What we already tried (GCal variants, HashRego slug, Harrier Central probe, WP REST, etc.)
+- Any known FB / IG / hashrego presence
+
+### 2. Generate the prompt
+
+Output a single Markdown block the user can copy-paste. **Structure (MUST include all sections):**
+
+```
+I'm helping verify hash kennel data for HashTracks (a Hash House Harriers event aggregator). I need your help re-checking {N} kennels in {REGION} that came back as "no scrapeable source" in an automated research pass. Before you start, please skim these two docs from the project so you understand what counts as a usable source and the discovery patterns we use:
+
+- **Research methodology & discovery checklist:** https://github.com/johnrclem/hashtracks-web/blob/main/docs/regional-research-prompt.md
+- **Source onboarding playbook (adapter types & priority):** https://github.com/johnrclem/hashtracks-web/blob/main/docs/source-onboarding-playbook.md
+
+The TL;DR of what counts as a "good source" (in priority order):
+1. Google Calendar with a public ID
+2. Meetup group with active events
+3. iCal feed (`.ics` or `webcal://`)
+4. Harrier Central API (`hashruns.org`) — already checked
+5. WordPress site exposing The Events Calendar plugin (`/wp-json/tribe/events/v1/events`)
+6. WordPress REST API for posts/pages
+7. Any HTML page with structured event listings (table, list, JSON-in-script)
+8. STATIC_SCHEDULE with a known recurrence + anchor date
+
+Facebook-only / Instagram-only kennels are **not** usable — the merge pipeline can't ingest FB events, and per project policy we don't add directory-style entries.
+
+## The {N} kennels to re-check
+
+{FOR EACH KENNEL:}
+**{N}. {Kennel name} ({abbrev if any}) — {City}, {State}**
+- Half-mind says: {status} {schedule}
+- Listed website: {url} ({dead/repurposed/live status})
+- {Any other known facts: founded year, founder, sister kennels, etc.}
+- **Things to try in Chrome:**
+  - {Specific search queries for this kennel}
+  - {Specific FB / IG / archive.org checks}
+  - {Specific domain variants worth probing}
+  - {Whether they may show up on a regional aggregator we already onboarded}
+
+## What I already tried (don't repeat)
+
+- **Google Calendar ID variants:** {comma-separated list of every @gmail.com / @group.calendar.google.com ID we probed and got 0 events for}
+- **HashRego /events index:** {kennel slugs probed} → 0 hits
+- **Harrier Central API:** {cities probed} → 0 hits
+- **WordPress REST API endpoints:** {if any tried}
+- **Domain DNS:** {dead domains confirmed}
+
+## What I need back
+
+For each of the {N} kennels, please report one of:
+- **A working source** — type (calendar/iCal/Meetup/WordPress/etc.) plus the canonical URL or ID. **Verify it actually contains upcoming events** before reporting it.
+- **A current website** even if it has no calendar yet — note the platform (WordPress, Wix, Squarespace, etc.) and whether they post any structured schedule.
+- **Active but Facebook/Instagram-only** — confirm the kennel is alive (date of most recent post), note follower count, and flag whether the FB group is private or public.
+- **Confirmed dormant or dead** — note what you found (e.g. "FB page hasn't posted since 2023", "no website found in search").
+
+Skip Facebook, Instagram, WhatsApp, Discord, and email-only contacts as **sources** — but DO report on them as activity evidence.
+```
+
+### 3. Save the prompt to a file
+
+Write to `docs/kennel-research/chrome-verification/{region}-{YYYY-MM-DD}.md` so the user can re-paste later and so we have a record.
+
+### 4. Tell the user what to do next
+
+Print:
+> Prompt saved to `docs/kennel-research/chrome-verification/{region}-{YYYY-MM-DD}.md`. Paste it into a fresh Claude-in-Chrome session. When you have results, share them back and I'll update the research doc + capture activity status + flag any newly discovered sources.
+
+## After Chrome results come back
+When the user shares Chrome's findings:
+1. Update the relevant `docs/kennel-research/{region}-research.md` with:
+   - Activity status per kennel (active / dormant / dead)
+   - Last-seen evidence (FB post date, club registry, etc.)
+   - Any corrections to kennel names / abbreviations / IDs
+   - Newly discovered sources (rare but worth a re-ship if any)
+2. If any kennel has a real source surfaced, propose a ship plan (gated on user approval per `feedback_research_review_gate.md`).
+3. If all kennels are confirmed sourceless, commit the doc update so we don't re-research the same kennels next sweep.
+
+## Key principles
+- **Single self-contained prompt** — Chrome session has no shared state with our tools
+- **Always include the GitHub links** to the playbook + research-prompt docs
+- **Always list what we already tried** so Chrome doesn't waste effort
+- **Always specify the desired output shape** so results map cleanly back into our research docs
+- **Save the prompt** for traceability — future re-checks should reference past verification rounds

--- a/docs/kennel-research/chrome-verification/mississippi-2026-04-08.md
+++ b/docs/kennel-research/chrome-verification/mississippi-2026-04-08.md
@@ -1,0 +1,77 @@
+# Mississippi Chrome Verification — 2026-04-08
+
+Re-checked the 3 deferred Mississippi kennels via Claude in Chrome to confirm the automated research pass didn't miss anything.
+
+## Result
+**All 3 confirmed sourceless.** Chrome found additional context (activity status, kennel codes, FB group privacy, dead-domain successors) but no usable structured data sources.
+
+## Per-kennel findings
+
+| Kennel | Activity Status | Best Non-FB Presence | Notes |
+|---|---|---|---|
+| **Biloxi H3** | **Dormant** — last FB post 2023-09-11 | HashRego slug `biloxih3` (old campout events only) | 18+ months inactive on FB; biloxih3.com archive.org has only 2 captures from 2008 |
+| **Jackson H3 (JXNH3)** | **Likely active** — members RSVP'd to DallasH3 Texas Interhash 2026 | Dead Google Sites: `sites.google.com/site/queencityhash` (404) | Private FB group "Jackson, Mississippi (MS) Hash House Harriers (JXNH3)", 325 members. Revived 2018 by "Spelunk My Abyss". Schedule: monthly Saturday 14:00 |
+| **OUCH3** | **Active** — confirmed via 35th-birthday-run announcement on RunOxford FB group, 2026-01-19 | Dead phpwebhosting site (`ouch3.phpwebhosting.com`) | Private FB group, 363 members. ouch3.com domain repurposed by The Local Voice newspaper. Founded 1991-01-19. Contact `naturehumphries@gmail.com` |
+
+## Newly captured facts (not in original research doc)
+- **Jackson H3 actually goes by JXNH3** — the abbreviation we should use if we ever ship them
+- **OUCH3's last verified activity is 2026-01-19** (their 35th birthday run) — most active of the three
+- **Biloxi H3's email is `biloxih3@gmail.com`** — confirms the GCal variant we tried, no surprise hit
+- **All three FB groups are private** — even FB-event scraping wouldn't work without membership
+
+## STATIC_SCHEDULE candidates (if policy ever changes)
+None of these have structured data, but if the "no FB-only kennels" rule were ever relaxed, these would be the order:
+1. **OUCH3** — Last Saturday + 1st Sunday at 1:00 PM (actively running, well-documented schedule)
+2. **JXNH3** — Monthly Saturday at 2:00 PM (likely active, less verified)
+3. **Biloxi H3** — Skip until they show signs of life (18+ months dormant)
+
+## Chrome prompt used
+The full prompt that produced these findings is captured below for reference.
+
+---
+
+I'm helping verify hash kennel data for HashTracks (a Hash House Harriers event aggregator). I need your help re-checking 3 Mississippi kennels that came back as "no scrapeable sources" in an automated research pass. Before you start, please skim these two docs from the project so you understand what counts as a usable source and the discovery patterns we use:
+
+- **Research methodology & discovery checklist:** https://github.com/johnrclem/hashtracks-web/blob/main/docs/regional-research-prompt.md
+- **Source onboarding playbook (adapter types & priority):** https://github.com/johnrclem/hashtracks-web/blob/main/docs/source-onboarding-playbook.md
+
+The TL;DR of what counts as a "good source" (in priority order):
+1. Google Calendar with a public ID
+2. Meetup group with active events
+3. iCal feed (`.ics` or `webcal://`)
+4. Harrier Central API (`hashruns.org`) — already checked, no MS hits
+5. WordPress site exposing The Events Calendar plugin (`/wp-json/tribe/events/v1/events`)
+6. WordPress REST API for posts/pages
+7. Any HTML page with structured event listings (table, list, JSON-in-script)
+8. STATIC_SCHEDULE with a known recurrence + anchor date
+
+Facebook-only / Instagram-only kennels are **not** usable — the merge pipeline can't ingest FB events, and per project policy we don't add directory-style entries.
+
+## The 3 kennels to re-check
+
+**1. Biloxi H3 — Biloxi, MS**
+- Half-mind says alive, "Variable Saturday 1:00 PM"
+- Their own statement: *"Biloxi H3 isn't dead, we've just been lost on trail!"*
+- `biloxih3.com` returns NXDOMAIN
+- Things to try: archive.org for biloxih3.com, search `"Biloxi H3" hash`, FB page check, see if they appear on the Gulf Coast H3 (Mobile, AL) calendar `gch3hash@gmail.com`
+
+**2. Jackson H3 — Jackson, MS (sometimes "Magnolia H3")**
+- Half-mind says alive, "Monthly Saturday 2:00 PM year-round"
+- Facebook only per half-mind
+- Things to try: search FB for Jackson Hash House Harriers, check pinned posts for calendar/website links, search `"Jackson MS H3" calendar`
+
+**3. OUCH3 — Oxford University-Community Hash House Harriers, Oxford, MS**
+- Half-mind lists `ouch3.com` but the domain has been **repurposed** to "The Local Voice — Roundabout Oxford & Ole Miss" newspaper
+- Half-mind says alive, "Last Saturday and 1st Sunday at 1:00 PM"
+- Things to try: `oxfordhash.com` / `oxfordh3.com` / `olemissh3.com`, FB search for "Oxford University Community H3", Ole Miss club registry
+
+## Google Calendar ID variants I already tried (all returned 0 events)
+`biloxih3@gmail.com`, `biloxih3hashcash@gmail.com`, `biloxihash@gmail.com`, `jacksonh3@gmail.com`, `jacksonh3hashcash@gmail.com`, `jacksonmsh3@gmail.com`, `magnoliah3@gmail.com`, `ouch3@gmail.com`, `ouch3hashcash@gmail.com`, `oxfordh3@gmail.com`, `oxfordh3ms@gmail.com`
+
+## What I need back
+For each kennel, report one of:
+- A working source (verify upcoming events exist)
+- A current website (note platform)
+- Confirmed dead
+
+Skip Facebook, Instagram, WhatsApp, Discord, and email-only contacts.

--- a/docs/kennel-research/mississippi-research.md
+++ b/docs/kennel-research/mississippi-research.md
@@ -1,0 +1,49 @@
+# Mississippi Kennel Research
+
+**Researched:** 2026-04-08
+**Chrome-verified:** 2026-04-08 (see `chrome-verification/mississippi-2026-04-08.md`)
+**Result:** 0 shippable kennels — all 3 alive kennels confirmed Facebook-only
+
+## Existing Coverage
+None.
+
+## Aggregator Sources Found
+- **Harrier Central:** Probed 9 MS cities (Jackson, Biloxi, Gulfport, Hattiesburg, Tupelo, Oxford, Starkville, Meridian, Vicksburg) — zero hits
+- **HashRego /events live index:** zero MS slug matches
+- **half-mind.com MS list:** 3 kennels enumerated
+
+## Candidate Kennels
+
+| # | Kennel | Code | City | half-mind | Activity | Website | Verdict |
+|---|--------|------|------|-----------|----------|---------|---------|
+| 1 | **Biloxi H3** | (would be `biloxih3`) | Biloxi | Alive, Variable Sat 13:00 | **Dormant** — last FB post 2023-09-11 | biloxih3.com DEAD (NXDOMAIN since ~2008) | Skip — 18+ months FB-inactive |
+| 2 | **Jackson H3** | `jxnh3` | Jackson | Alive, monthly Sat 14:00 | Likely active (members at national events) | None — old Google Sites at `queencityhash` is 404 | Skip — private FB group only (325 members) |
+| 3 | **OUCH3** (Oxford University-Community H3) | `ouch3` | Oxford | Alive, last Sat + 1st Sun 13:00 | **Active** — confirmed via 35th-birthday-run announcement 2026-01-19 | `ouch3.com` repurposed as The Local Voice newspaper; phpwebhosting site dead | Skip — private FB group only (363 members) |
+
+## Checks Performed
+- [x] DB existing-coverage probe — 0 MS regions/kennels
+- [x] half-mind.com MS list — 3 candidates enumerated
+- [x] HashRego `/events` live index grep — 0 MS slugs
+- [x] Harrier Central API — 9 cities probed, 0 hits
+- [x] curl probe of biloxih3.com → NXDOMAIN
+- [x] curl probe of ouch3.com → 200 OK but content is The Local Voice newspaper (domain repurposed)
+- [x] Chrome probe of biloxih3.com → confirmed NXDOMAIN
+- [x] WordPress REST API probe of ouch3.com → it's not the kennel's site
+- [x] 11 Google Calendar ID variants tried — all 0 items
+- [x] Claude-in-Chrome second-pass verification — confirmed all 3 sourceless, captured FB activity status, JXNH3 abbreviation, founder names, last-seen evidence
+
+## Lessons Learned
+- **Three small Southern states in a row with 0 shippable kennels** (KY, MS, plus NH earlier). The pattern: small kennels with dedicated members but no tech infrastructure beyond FB groups. This is the long tail.
+- **Chrome verification surfaced facts the automated pass missed** — JXNH3 abbreviation, OUCH3's exact most-recent run date, FB group membership counts. Worth the extra step on every "0 shippable" research outcome.
+- **Domain repurposing is a real risk** — `ouch3.com` is now a local newspaper. The half-mind URL is years stale. When a domain returns 200 but the content isn't a hash kennel, the kennel is effectively website-less.
+
+## STATIC_SCHEDULE candidates (deferred)
+None of these have structured data, but if the "no FB-only kennels" rule were ever relaxed and we accepted STATIC_SCHEDULE entries for actively-running FB-only kennels, the order would be:
+1. **OUCH3** — Last Saturday + 1st Sunday at 1:00 PM (most recently verified active, well-defined recurrence)
+2. **JXNH3** — Monthly Saturday at 2:00 PM (less verified)
+3. **Biloxi H3** — defer further until they show signs of life
+
+## Defer Until
+- Biloxi H3 resumes posting on FB or builds a website
+- Jackson H3 (JXNH3) goes public with their group or adopts a calendar
+- OUCH3 builds a new website or adopts a Google Calendar — they're actively running and most likely to onboard if asked directly


### PR DESCRIPTION
## Summary
Two things in one docs-only PR:

### 1. Mississippi research — 0 shippable kennels
3 alive kennels per half-mind, all confirmed sourceless via two-pass research:

| Kennel | Code | Activity | Verdict |
|---|---|---|---|
| **Biloxi H3** | — | **Dormant** (last FB post 2023-09-11) | Skip |
| **Jackson H3** | \`JXNH3\` | Likely active, private FB group only | Skip |
| **OUCH3** | \`ouch3\` | **Active** (35th-birthday run 2026-01-19), private FB group only | Skip |

OUCH3 was particularly tricky — \`ouch3.com\` returns 200 OK but the domain was repurposed by The Local Voice newspaper, so the kennel effectively has no website.

### 2. New skill: \`chrome-verify-kennels\`
Formalizes a pattern that just paid off. Claude-in-Chrome verification surfaced facts the automated pass missed (activity status, JXNH3 abbreviation, dead-domain successors) but confirmed the original "no source" verdict. Worth running on every 0-shippable research outcome.

The skill generates a self-contained Chrome prompt with:
- GitHub links to \`docs/regional-research-prompt.md\` and \`docs/source-onboarding-playbook.md\`
- Source priority TL;DR
- Per-kennel context (city, half-mind status, listed website status)
- List of GCal variants / HashRego slugs / HC cities already tried
- Required output shape so results map cleanly back into research docs

Prompts get saved to \`docs/kennel-research/chrome-verification/{region}-{date}.md\` for traceability. The MS verification is captured as the first record under that path.

## Files changed
- \`.claude/commands/chrome-verify-kennels.md\` — new skill
- \`docs/kennel-research/mississippi-research.md\` — research doc
- \`docs/kennel-research/chrome-verification/mississippi-2026-04-08.md\` — first verification record

## No code, no seed changes, no ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)