### PR TITLE
fix: raise SFH3 detail-page enrichment cap 30→200

### DIFF
--- a/src/adapters/html-scraper/sfh3-detail-enrichment.ts
+++ b/src/adapters/html-scraper/sfh3-detail-enrichment.ts
@@ -18,10 +18,19 @@ import { safeFetch } from "../safe-fetch";
 // RawEvents that all pass sfh3NeedsEnrichment() — a lower cap permanently starves
 // events beyond the window (the Aug 15 `26.2H3 Run #7` event, #492/#493, was
 // stuck because the first 30 by date were always the earliest upcoming ones).
-// Batched 5-parallel, 200 fetches ≈ 40 batches ≈ ~12s added to a scrape under
-// the 120s maxDuration ceiling.
+//
+// Wall-time budget under the 120s scrape maxDuration:
+//   200 fetches ÷ BATCH_SIZE 10 = 20 batches
+//   Per-batch latency on a healthy origin is ~300-500ms; under sustained slow
+//   conditions (1-2s/batch) we still finish in 20-40s, leaving room for the
+//   .ics fetch + merge pipeline. Enrichment failures are non-fatal so the
+//   scrape degrades gracefully if sfh3.com gets slower.
+//
+// TODO(future): make sfh3NeedsEnrichment() consult the stored DB RawEvent so
+// already-enriched events skip the fetch entirely. That would drop steady-state
+// cost from ~140 fetches/scrape to ~0 and let us shrink BATCH_SIZE back down.
 const MAX_ENRICH_PER_SCRAPE = 200;
-const BATCH_SIZE = 5;
+const BATCH_SIZE = 10;
 
 export interface SFH3Detail {
   title?: string;


### PR DESCRIPTION
## Problem

After PRs #514 + #516 landed, the canonical 26.2H3 Run #7 event (#492/#493) still had the stale title and no Comment. Root cause: the iCal SUMMARY never carries \`Run #N\`, so \`sfh3NeedsEnrichment()\` flags every fresh iCal scrape of every SFH3 event as enrichable. With \`MAX_ENRICH_PER_SCRAPE = 30\` and a sort-by-date-ascending ordering, only the earliest 30 upcoming events were ever fetched. Events 4+ months out (like Aug 15) sat past position 30 indefinitely — re-running the scrape always enriched the same 30.

## Fix

Raise the cap to 200, which comfortably covers SFH3's full upcoming window (~110-140 events across 13 kennels). The batched 5-parallel fetch pattern means +170 fetches ≈ 40 batches ≈ ~12s added to a scrape, well under the 120s \`maxDuration\` ceiling.

## Verification

- \`npx vitest run src/adapters/html-scraper/sfh3 src/adapters/ical\` → 99/99 ✅
- \`npx tsc --noEmit\` ✅
- After merge + Vercel deploy: trigger the SFH3 iCal scrape manually, confirm \`26.2H3 Run #7\` (event \`cmmtcm722002g04jppn2mei1v\`) gets the enriched title + \`Comment:\` in description, then #492/#493 auto-close via the post-merge verify-fixes workflow.

## Why not fingerprint-skip

A nicer fix would check the stored DB RawEvent before enriching, so each event is fetched exactly once. But SFH3 tops out at ~150 events and the fetches are fast + parallel — raising the cap is one line and handles the backlog in a single scrape, whereas fingerprint-skip is a structural refactor across the enrichment path. We can revisit if enrichment cost ever matters.

## Test plan

- [x] Existing tests still pass
- [ ] After merge: manual scrape trigger enriches #492/#493 event, verify-fixes workflow auto-closes both