### PR TITLE
fix(seletar-h3): sort hare names for stable fingerprint

### DIFF
--- a/src/adapters/html-scraper/seletar-h3.ts
+++ b/src/adapters/html-scraper/seletar-h3.ts
@@ -165,7 +165,10 @@ export function groupSeletarRows(rows: SeletarRow[]): GroupSeletarRowsResult {
       kennelTag: KENNEL_TAG,
       runNumber,
       title,
-      hares: hareNames.length > 0 ? hareNames.join(", ") : undefined,
+      // Sort alphabetically so the fingerprint is stable — the API returns
+      // hare rows in nondeterministic order, which would otherwise cause
+      // re-scrapes and the one-shot backfill to insert duplicate RawEvents.
+      hares: hareNames.length > 0 ? [...hareNames].sort((a, b) => a.localeCompare(b)).join(", ") : undefined,
       location: head.hl_runsite?.trim() || undefined,
       latitude,
       longitude,


### PR DESCRIPTION
## Summary
- HashController.php returns hare rows in nondeterministic order, so the RawEvent fingerprint changed on every re-scrape
- First re-run of the historical backfill inserted 74 duplicate RawEvents because of this
- Sort hare names alphabetically before joining so the fingerprint is stable

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/adapters/html-scraper/seletar-h3.test.ts` passes (11/11)
- [ ] After merge: re-run `BACKFILL_APPLY=1 npx tsx scripts/backfill-seletar-h3-history.ts` — expect 0 new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)