### PR TITLE
docs(audit): add kennelCode lookup hint to chrome daily prompt

### DIFF
--- a/docs/audit-chrome-prompt.md
+++ b/docs/audit-chrome-prompt.md
@@ -95,6 +95,8 @@ Open that URL (it's a small markdown document, not a set of instructions) and tr
 For each issue found, try to file it as a GitHub issue:
 
 **Option 1 (preferred):** Navigate to this URL with the title, body, and labels filled in. `title` and `body` MUST be URL-encoded (use `encodeURIComponent`) — raw newlines, `&`, or `#` will break the query string. The labels list MUST include `audit:chrome-event` for stream attribution and `kennel:<kennelCode>` (the kennel's HashTracks code, lowercase, hyphenated) for kennel attribution. The dashboard's "Findings by stream" panel reads these labels — without them the issue lands in the `UNKNOWN` bucket.
+
+**Finding the kennelCode:** it is the last URL segment on the kennel's HashTracks page — e.g. `agnews` for `https://www.hashtracks.xyz/kennels/agnews`, `ah3-hi` for `https://www.hashtracks.xyz/kennels/ah3-hi`. If the URL is ambiguous (e.g. two kennels share the "AH3" shortName), open the kennel page and verify the slug in the address bar before filing — do not guess.
 ```text
 https://github.com/johnrclem/hashtracks-web/issues/new?labels=audit,alert,audit:chrome-event,kennel:{KENNEL_CODE}&title={URL-ENCODED TITLE}&body={URL-ENCODED BODY}
 ```


### PR DESCRIPTION
## Summary

Closes #590.

Operators filing issues via the chrome daily hareline prompt had no instructions for where to find the `kennelCode` that goes into the `kennel:<code>` label. That led to guessed codes, omitted labels, or ambiguous shortName collisions (e.g. AH3 → Aloha vs Amsterdam) across the recent audit rounds.

## Change

One-paragraph addition to the Option 1 filing section in \`docs/audit-chrome-prompt.md\`:

> **Finding the kennelCode:** it is the last URL segment on the kennel's HashTracks page — e.g. \`agnews\` for \`https://www.hashtracks.xyz/kennels/agnews\`, \`ah3-hi\` for \`https://www.hashtracks.xyz/kennels/ah3-hi\`. If the URL is ambiguous (e.g. two kennels share the "AH3" shortName), open the kennel page and verify the slug in the address bar before filing — do not guess.

## Test plan

- [ ] Dashboard's "Copy daily prompt" button reads this doc at request time, so the next render picks up the new text with no deploy required
- [ ] Next chrome audit run should land all new issues with correct `kennel:<code>` labels

Pure docs — skipping \`/simplify\` and adversarial review.