### PR TITLE
Make MATCHED a semi-terminal discovery status (fix slug degradation)

### DIFF
--- a/src/pipeline/kennel-discovery.test.ts
+++ b/src/pipeline/kennel-discovery.test.ts
@@ -202,9 +202,15 @@ describe("syncKennelDiscovery", () => {
     const result = await syncKennelDiscovery();
 
     // Takes the updateTerminalDiscovery path — profile data refreshed,
-    // but no re-scoring, no SourceKennel deletion, no SourceKennel upsert.
+    // no re-scoring, no SourceKennel deletion.
     expect(prisma.sourceKennel.deleteMany).not.toHaveBeenCalled();
-    expect(prisma.sourceKennel.upsert).not.toHaveBeenCalled();
+    // Self-healing: the SourceKennel link is re-ensured via upsert (no-op
+    // when the row already exists, creates it if manually removed).
+    expect(prisma.sourceKennel.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { sourceId_kennelId: { sourceId: "src-hashrego", kennelId: "k1" } },
+      }),
+    );
     // Discovery record updated with fresh profile data via the terminal path
     expect(prisma.kennelDiscovery.update).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/pipeline/kennel-discovery.test.ts
+++ b/src/pipeline/kennel-discovery.test.ts
@@ -184,47 +184,37 @@ describe("syncKennelDiscovery", () => {
     expect(prisma.kennelAlias.create).not.toHaveBeenCalled();
   });
 
-  it("downgrade: previously MATCHED that now re-scores below threshold deletes stale SourceKennel", async () => {
-    // Previous state: MATCHED → k1
+  it("MATCHED is semi-terminal: subsequent sync updates profile but preserves SourceKennel", async () => {
+    // A previously MATCHED discovery must NOT be re-scored on subsequent
+    // syncs. Fuzzy scores fluctuate near the 0.95 threshold, causing
+    // MATCHED↔NEW flip-flops that delete and recreate SourceKennel rows
+    // every cycle (the root cause of the Apr 8–10 slug degradation).
     vi.mocked(prisma.kennelDiscovery.findMany).mockResolvedValue([
       { externalSlug: "EWH3", status: "MATCHED", matchedKennelId: "k1" },
     ] as never);
-    // Current scrape: same slug, but candidate pool is empty so no match
     vi.mocked(parseKennelDirectory).mockReturnValue([
-      buildDiscovered({ slug: "EWH3", name: "Nothing matches this" }),
+      buildDiscovered({ slug: "EWH3", name: "Everyday Is Wednesday H3" }),
     ]);
+    // Even with an empty candidate pool (which would fail re-scoring),
+    // the MATCHED discovery must not be re-scored or have its link deleted.
     vi.mocked(prisma.kennel.findMany).mockResolvedValue([] as never);
 
-    await syncKennelDiscovery();
+    const result = await syncKennelDiscovery();
 
-    expect(prisma.sourceKennel.deleteMany).toHaveBeenCalledWith({
-      where: { sourceId: "src-hashrego", kennelId: "k1" },
-    });
+    // Takes the updateTerminalDiscovery path — profile data refreshed,
+    // but no re-scoring, no SourceKennel deletion, no SourceKennel upsert.
+    expect(prisma.sourceKennel.deleteMany).not.toHaveBeenCalled();
     expect(prisma.sourceKennel.upsert).not.toHaveBeenCalled();
-  });
-
-  it("retarget: previously MATCHED to k1 now MATCHED to k2 deletes k1 and upserts k2", async () => {
-    vi.mocked(prisma.kennelDiscovery.findMany).mockResolvedValue([
-      { externalSlug: "EWH3", status: "MATCHED", matchedKennelId: "k1" },
-    ] as never);
-    vi.mocked(parseKennelDirectory).mockReturnValue([
-      buildDiscovered({ slug: "EWH3", name: "Everyday Is Wednesday H3", latitude: 38.9, longitude: -77.04 }),
-    ]);
-    // Candidate is k2, not k1
-    vi.mocked(prisma.kennel.findMany).mockResolvedValue([
-      { id: "k2", shortName: "EWH3", fullName: "Everyday Is Wednesday H3", country: "USA", regionRef: { centroidLat: 38.9, centroidLng: -77.04 } },
-    ] as never);
-
-    await syncKennelDiscovery();
-
-    expect(prisma.sourceKennel.deleteMany).toHaveBeenCalledWith({
-      where: { sourceId: "src-hashrego", kennelId: "k1" },
-    });
-    expect(prisma.sourceKennel.upsert).toHaveBeenCalledWith(
+    // Discovery record updated with fresh profile data via the terminal path
+    expect(prisma.kennelDiscovery.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { sourceId_kennelId: { sourceId: "src-hashrego", kennelId: "k2" } },
+        where: {
+          externalSource_externalSlug: { externalSource: "HASHREGO", externalSlug: "EWH3" },
+        },
+        data: expect.objectContaining({ lastSeenAt: expect.any(Date) }),
       }),
     );
+    expect(result.updated).toBe(1);
   });
 
   it("LINKED preserved: previously LINKED discovery is never touched by sync", async () => {

--- a/src/pipeline/kennel-discovery.ts
+++ b/src/pipeline/kennel-discovery.ts
@@ -303,8 +303,15 @@ export async function syncKennelDiscovery(): Promise<DiscoverySyncResult> {
       const profile = profiles.get(kennel.slug);
       const prev = discoveryPrevMap.get(kennel.slug);
       const existingStatus = prev?.status;
+      // MATCHED is semi-terminal: once a discovery auto-matches above 0.95
+      // and creates a SourceKennel link, subsequent syncs must NOT re-score
+      // it. Fuzzy scores naturally fluctuate near the threshold as the
+      // candidate pool evolves, causing MATCHED↔NEW flip-flops that delete
+      // and recreate SourceKennel rows every cycle. Only explicit admin
+      // actions (dismiss, confirm, unlink) should change the state.
       const isTerminal = existingStatus === "ADDED" ||
-        existingStatus === "LINKED" || existingStatus === "DISMISSED";
+        existingStatus === "LINKED" || existingStatus === "DISMISSED" ||
+        existingStatus === "MATCHED";
 
       const schedule = profile
         ? buildScheduleString(profile.trail_frequency, profile.trail_day) || kennel.schedule
@@ -355,28 +362,6 @@ export async function syncKennelDiscovery(): Promise<DiscoverySyncResult> {
       } else {
         newKennels++;
         if (match.status === "MATCHED") autoMatched++;
-      }
-
-      // Clean up stale SourceKennel rows when an auto-match is downgraded
-      // (re-scored below threshold) or retargeted to a different kennel. We
-      // only clean up rows whose *previous* status was MATCHED — LINKED /
-      // ADDED are admin-confirmed and never get clobbered by sync. The
-      // isTerminal early-return above already skips those from this branch,
-      // but this predicate makes the invariant explicit.
-      const wasAutoLinked = prev?.status === "MATCHED" && prev.matchedKennelId !== null;
-      const newMatchedId = match.status === "MATCHED" ? match.matchedKennelId : null;
-      if (
-        hashRegoSourceId &&
-        wasAutoLinked &&
-        prev!.matchedKennelId !== newMatchedId
-      ) {
-        try {
-          await prisma.sourceKennel.deleteMany({
-            where: { sourceId: hashRegoSourceId, kennelId: prev!.matchedKennelId! },
-          });
-        } catch (err) {
-          errors.push(`Error clearing stale link for ${kennel.slug}: ${err}`);
-        }
       }
 
       if (match.status === "MATCHED" && match.matchedKennelId) {

--- a/src/pipeline/kennel-discovery.ts
+++ b/src/pipeline/kennel-discovery.ts
@@ -225,25 +225,29 @@ export async function syncKennelDiscovery(): Promise<DiscoverySyncResult> {
     };
   }
 
-  // Step 2: Load existing discoveries to identify terminal slugs. We also
-  // track the previous matchedKennelId so auto-match downgrades/retargets
-  // can delete the stale SourceKennel row below.
+  // Step 2: Load existing discoveries to identify terminal slugs (ADDED,
+  // LINKED, DISMISSED, MATCHED) which skip re-scoring. matchedKennelId is
+  // needed for the MATCHED self-healing guard (re-link if SourceKennel row
+  // was manually removed).
   const existingDiscoveries = await prisma.kennelDiscovery.findMany({
     where: { externalSource: EXTERNAL_SOURCE },
     select: { externalSlug: true, status: true, matchedKennelId: true },
   });
 
   const discoveryPrevMap = new Map(
-    existingDiscoveries.map((d) => [
-      d.externalSlug,
-      { status: d.status, matchedKennelId: d.matchedKennelId },
-    ]),
+    existingDiscoveries.map((d) => [d.externalSlug, d.status]),
+  );
+  // Separate lookup for MATCHED discoveries that may need SourceKennel re-link.
+  const matchedKennelIds = new Map(
+    existingDiscoveries
+      .filter((d) => d.status === "MATCHED" && d.matchedKennelId)
+      .map((d) => [d.externalSlug, d.matchedKennelId!]),
   );
 
   // Step 3: Split slugs — only fetch API profiles for non-terminal discoveries
   const terminalStatuses = new Set(["ADDED", "LINKED", "DISMISSED"]);
   const activeSlugs = discovered
-    .filter((k) => !terminalStatuses.has(discoveryPrevMap.get(k.slug)?.status ?? ""))
+    .filter((k) => !terminalStatuses.has(discoveryPrevMap.get(k.slug) ?? ""))
     .map((k) => k.slug);
 
   // Step 4: Fetch API profiles (active only) + load kennels/aliases in parallel
@@ -301,8 +305,7 @@ export async function syncKennelDiscovery(): Promise<DiscoverySyncResult> {
   for (const kennel of discovered) {
     try {
       const profile = profiles.get(kennel.slug);
-      const prev = discoveryPrevMap.get(kennel.slug);
-      const existingStatus = prev?.status;
+      const existingStatus = discoveryPrevMap.get(kennel.slug);
       // MATCHED is semi-terminal: once a discovery auto-matches above 0.95
       // and creates a SourceKennel link, subsequent syncs must NOT re-score
       // it. Fuzzy scores naturally fluctuate near the threshold as the
@@ -320,6 +323,23 @@ export async function syncKennelDiscovery(): Promise<DiscoverySyncResult> {
 
       if (isTerminal) {
         await updateTerminalDiscovery(kennel, profile, schedule, profileData, syncTimestamp);
+        // Self-healing: if a MATCHED discovery's SourceKennel row was
+        // manually removed (or the initial match happened when the HASHREGO
+        // source didn't exist), re-create it. The upsert is a no-op when the
+        // row already exists, so this is safe to call unconditionally.
+        const matchedKennelId = matchedKennelIds.get(kennel.slug);
+        if (existingStatus === "MATCHED" && matchedKennelId && hashRegoSourceId) {
+          try {
+            await linkDiscoveryKennelToHashRego(
+              matchedKennelId,
+              kennel.slug,
+              hashRegoSourceId,
+              { createAlias: false },
+            );
+          } catch (err) {
+            errors.push(`Error re-linking ${kennel.slug}: ${err}`);
+          }
+        }
         updated++;
         continue;
       }


### PR DESCRIPTION
## Summary

- After the PR #554 backfill restored 205 SourceKennel rows for the HASHREGO source, the count dropped back to ~12 within a day — twice (Apr 8→9 and again after PR #593 merge).
- Root cause: `syncKennelDiscovery` re-evaluated MATCHED discoveries on every run. Fuzzy scores fluctuate near the 0.95 threshold, flipping MATCHED↔NEW and triggering the downgrade cleanup block which deleted the SourceKennel row each cycle. 193 of 205 rows cycled this way.
- Fix: add MATCHED to the `isTerminal` set so subsequent syncs skip re-scoring and take the `updateTerminalDiscovery` path (refreshes profile data without touching match state). Only explicit admin actions can change status. Remove the now-dead downgrade cleanup block.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (pre-existing warnings only)
- [x] `npm test` — 4305 passing. Replaced downgrade/retarget tests with a "MATCHED is semi-terminal" test asserting no re-scoring + no SourceKennel deletion + profile still refreshed.
- [ ] Re-run backfill: `BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-hashrego-source-kennels.ts --apply`. Confirm SourceKennel count returns to ~205.
- [ ] Run `/admin/discovery → Sync Now` twice in a row. Confirm SourceKennel count stays at ~205 after both runs.
- [ ] Trigger a HASHREGO scrape and confirm `kennelSlugsConfigured.length ≈ 205`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)