### PR TITLE
fix(audit): Philly/Oregon skip + Lion City hares + Amsterdam adapter rewrite + AH3 profile

### DIFF
--- a/prisma/manual-sql/2026-04-10-ah3-nl-profile.sql
+++ b/prisma/manual-sql/2026-04-10-ah3-nl-profile.sql
@@ -1,0 +1,32 @@
+-- Amsterdam H3 kennel profile enrichment (#564).
+-- Adds Facebook group URL and logo URL from ah3.nl.
+-- Uses COALESCE so admin-curated values are not overwritten.
+
+UPDATE "Kennel"
+SET "facebookUrl" = COALESCE("facebookUrl", 'https://www.facebook.com/groups/AmsterdamH3'),
+    "logoUrl" = COALESCE("logoUrl", 'https://ah3.nl/wp-content/uploads/2022/03/cropped-Amsterdam-original-192x192.png'),
+    "updatedAt" = NOW()
+WHERE "kennelCode" = 'ah3-nl'
+  AND (
+    NULLIF(BTRIM("facebookUrl"), '') IS NULL
+    OR NULLIF(BTRIM("logoUrl"), '') IS NULL
+  );
+
+DO $$
+DECLARE
+  stored_fb text;
+  stored_logo text;
+BEGIN
+  SELECT "facebookUrl", "logoUrl"
+    INTO stored_fb, stored_logo
+  FROM "Kennel" WHERE "kennelCode" = 'ah3-nl';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ah3-nl kennel row not found';
+  END IF;
+  IF NULLIF(BTRIM(stored_fb), '') IS NULL THEN
+    RAISE EXCEPTION 'ah3-nl facebookUrl is still null/empty after update';
+  END IF;
+  IF NULLIF(BTRIM(stored_logo), '') IS NULL THEN
+    RAISE EXCEPTION 'ah3-nl logoUrl is still null/empty after update';
+  END IF;
+END $$;

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2378,6 +2378,8 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "ah3-nl", shortName: "AH3", fullName: "Amsterdam Hash House Harriers", region: "Amsterdam", country: "Netherlands",
       website: "https://ah3.nl",
+      facebookUrl: "https://www.facebook.com/groups/AmsterdamH3",
+      logoUrl: "https://ah3.nl/wp-content/uploads/2022/03/cropped-Amsterdam-original-192x192.png",
       scheduleDayOfWeek: "Sunday", scheduleTime: "2:45 PM", scheduleFrequency: "Weekly",
       hashCash: "€5",
       description: "Amsterdam's weekly hash, usually Sundays at 14:45. Trails through parks, streets, and hidden gems, 6-10 km. Annual Canal Hash on boats through UNESCO canals.",

--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import {
-  parseEventBlock,
-  extractEvents,
-  htmlToText,
+  parseEventSection,
+  extractEventsFromDOM,
   AH3Adapter,
 } from "./ah3";
 
@@ -58,174 +58,164 @@ function mockFetchResponses(upcomingHtml: string, previousHtml: string) {
   });
 }
 
-// ── Unit tests: parseEventBlock ──
+// Real HTML fixture — mirrors the structure of ah3.nl/nextruns/
+const FIXTURE_HTML = `<html><body><div class="entry-content">
+<style>mark { background-color: lightgrey; color: black; }</style>
+<hr class="wp-block-separator"/>
+<div style='text-align:center'><font size=5><b>
+<p id=1477>Do Not Eat Yellow Snow !</b></font></p>
+<p>Run № <b> 1477 </b>by <b>  Golden Showers  </b><br/>
+<b>Sunday 12 April, 2026</b> at <b>12:45</b> hrs<br/>
+<b>Near Station Lelylaan</b><br/>
+9M5R+65, Amsterdam, 1077 XS, <a href="https://maps.google.com"><button>Map</button></a></p>
+<div style='line-height:30px'>
+<p>An early run at 13:00 hrs. Golden Showers is our hare and he has to rush to the airport.</p>
+<p><i>Logistics: Bag Drop and Beer will be on Corelis Lelylaan.</i></p>
+<small>___good_to_know<br/>
+Bag Drop – Yes<br/>
+BeerMeister – Slippery Edge<br/>
+Hash Cash – €5<br/>
+On After – We discuss before/during/after the run/circle<br/>
+</small></div>
+</div>
+<hr class="wp-block-separator"/>
+<div style='text-align:center'><font size=5><b>
+<p id=1478>Tulip Hash</b></font></p>
+<p>Run № <b> 1478 </b>by <b>  Cumming Home  </b><br/>
+<b>Saturday 18 April, 2026</b> at <b>14:45</b> hrs<br/>
+<b>somewhere</b></p>
+<div style='line-height:30px'>
+<p>Cumming Home makes us find tulips everywhere from a completely virginal run site.</p>
+<small>___good_to_know<br/>
+Bag Drop – Yes<br/>
+Hash Cash – €5<br/>
+On After – BBQ probably<br/>
+</small></div>
+</div>
+<hr class="wp-block-separator"/>
+<div style='text-align:center'><font size=5><b>
+<p id=1479>NOT The KoningsDag Run</b></font></p>
+<p>Run № <b> 1479 </b>by <b>  Hard Drive, Pink Panter  </b><br/>
+<b>Sunday 26 April, 2026</b> at <b>14:45</b> hrs<br/>
+<b>Hard Drive&#8217;s Shenanigans &#038; Mischief Center</b><br/>
+Brouwersgracht 72-2, Amsterdam, 1013 GX, <a href="#"><button>Map</button></a></p>
+<div style='line-height:30px'>
+<p>The World looks a lot better through orange glasses.</p>
+</div>
+</div>
+<hr class="wp-block-separator"/>
+</div></body></html>`;
 
-describe("parseEventBlock", () => {
-  it("parses a full event block with title, run number, hares, date, location", () => {
-    const text = `The A to Birthday Run
-Run № 1476 by War 'n Piece & MiaB
-Saturday 04 April, 2026 at 14:45 hrs
-Haarlem Railway Station
-Stationsplein , Haarlem, 2011 LR, Noord-Holland Map`;
+// ── Unit tests: parseEventSection ──
 
-    const event = parseEventBlock(text, SOURCE_URL);
+describe("parseEventSection — DOM-based event parsing", () => {
+  const $ = cheerio.load(FIXTURE_HTML);
+  const content = $(".entry-content");
+  const hrs = content.find("hr").toArray();
+
+  function getSection(idx: number) {
+    const sectionNodes: import("domhandler").AnyNode[] = [];
+    let node: import("domhandler").AnyNode | null = (hrs[idx] as import("domhandler").Element).nextSibling;
+    const nextHr = idx + 1 < hrs.length ? hrs[idx + 1] : null;
+    while (node && node !== nextHr) {
+      sectionNodes.push(node);
+      node = node.nextSibling;
+    }
+    return $(sectionNodes);
+  }
+
+  it("extracts title from <p id=NNNN> (not from the previous block's good_to_know text) (#559)", () => {
+    const event = parseEventSection(getSection(0), $, SOURCE_URL);
     expect(event).not.toBeNull();
-    expect(event!.date).toBe("2026-04-04");
-    expect(event!.runNumber).toBe(1476);
-    expect(event!.hares).toBe("War 'n Piece & MiaB");
-    expect(event!.startTime).toBe("14:45");
-    expect(event!.location).toBe("Haarlem Railway Station");
-    expect(event!.locationStreet).toBe("Stationsplein , Haarlem, 2011 LR, Noord-Holland");
-    expect(event!.title).toBe("AH3 #1476 — The A to Birthday Run");
-    expect(event!.kennelTag).toBe("ah3-nl");
-  });
-
-  it("parses event with early start time", () => {
-    const text = `Do Not Eat Yellow Snow !
-Run № 1477 by Golden Showers
-Sunday 12 April, 2026 at 12:45 hrs
-Near Station Zuid
-Prinses Amaliaplein , Amsterdam, 1077 XS,`;
-
-    const event = parseEventBlock(text, SOURCE_URL);
-    expect(event).not.toBeNull();
-    expect(event!.date).toBe("2026-04-12");
-    expect(event!.startTime).toBe("12:45");
-    expect(event!.runNumber).toBe(1477);
-    expect(event!.hares).toBe("Golden Showers");
-  });
-
-  it("handles event without hares (Click if you want to hare)", () => {
-    const text = `May The Third Be With You
-Run № 1480 Click if you want to hare this run
-Sunday 03 May, 2026 at 14:45 hrs
-somewhere`;
-
-    const event = parseEventBlock(text, SOURCE_URL);
-    expect(event).not.toBeNull();
-    expect(event!.runNumber).toBe(1480);
-    expect(event!.hares).toBeUndefined();
-    expect(event!.location).toBeUndefined(); // "somewhere" should be stripped
-    expect(event!.date).toBe("2026-05-03");
-  });
-
-  it("returns null for blocks without a run number", () => {
-    const text = `Some random text
-without any run number or date.`;
-
-    expect(parseEventBlock(text, SOURCE_URL)).toBeNull();
-  });
-
-  it("returns null for blocks without a date", () => {
-    const text = `Run № 1476 by Someone
-No date here, just text.`;
-
-    expect(parseEventBlock(text, SOURCE_URL)).toBeNull();
-  });
-
-  it("skips leftover good_to_know instructions and picks correct title", () => {
-    const text = `Bag Drop – NO ( but lockers inside the station )
-The A to Birthday Run
-Run № 1476 by War 'n Piece & MiaB
-Saturday 04 April, 2026 at 14:45 hrs
-Haarlem Railway Station`;
-
-    const event = parseEventBlock(text, SOURCE_URL);
-    expect(event).not.toBeNull();
-    expect(event!.title).toBe("AH3 #1476 — The A to Birthday Run");
+    expect(event!.title).toBe("AH3 #1477 — Do Not Eat Yellow Snow !");
+    expect(event!.title).not.toContain("On After");
     expect(event!.title).not.toContain("Bag Drop");
   });
 
-  it("parses title-less event (just run number)", () => {
-    const text = `Run № 1481 by Slippery Edge
-Sunday 10 May, 2026 at 14:45 hrs
-somewhere`;
+  it("extracts run number, hares, date/time, location", () => {
+    const event = parseEventSection(getSection(0), $, SOURCE_URL);
+    expect(event!.runNumber).toBe(1477);
+    expect(event!.hares).toBe("Golden Showers");
+    expect(event!.date).toBe("2026-04-12");
+    expect(event!.startTime).toBe("12:45");
+    expect(event!.location).toBe("Near Station Lelylaan");
+    expect(event!.kennelTag).toBe("ah3-nl");
+  });
 
-    const event = parseEventBlock(text, SOURCE_URL);
-    expect(event).not.toBeNull();
-    expect(event!.title).toBe("AH3 #1481");
-    expect(event!.hares).toBe("Slippery Edge");
+  it("extracts description text between header and ___good_to_know (#563)", () => {
+    const event = parseEventSection(getSection(0), $, SOURCE_URL);
+    expect(event!.description).toContain("Golden Showers is our hare");
+    // Description includes the logistics paragraph (it's body text, not metadata)
+    expect(event!.description).toContain("Logistics");
+    // But the ___good_to_know metadata block is excluded
+    expect(event!.description).not.toContain("___good_to_know");
+    expect(event!.description).not.toContain("BeerMeister");
+    // "Bag Drop – Yes" is metadata; "Bag Drop and Beer" is description — both
+    // contain "Bag Drop" but only the metadata line should be excluded
+    expect(event!.description).not.toContain("Bag Drop – Yes");
+  });
+
+  it("strips 'somewhere' placeholder from location", () => {
+    const event = parseEventSection(getSection(1), $, SOURCE_URL);
+    expect(event!.location).toBeUndefined();
+  });
+
+  it("parses the second event correctly (after the first block's good_to_know)", () => {
+    const event = parseEventSection(getSection(1), $, SOURCE_URL);
+    expect(event!.title).toBe("AH3 #1478 — Tulip Hash");
+    expect(event!.runNumber).toBe(1478);
+    expect(event!.hares).toBe("Cumming Home");
+    expect(event!.date).toBe("2026-04-18");
+    expect(event!.description).toContain("tulips everywhere");
+  });
+
+  it("extracts street address with postal code", () => {
+    const event = parseEventSection(getSection(2), $, SOURCE_URL);
+    expect(event!.location).toContain("Shenanigans");
+    expect(event!.locationStreet).toContain("Brouwersgracht 72-2");
+    expect(event!.locationStreet).toContain("1013 GX");
   });
 });
 
-// ── Unit tests: extractEvents ──
+// ── extractEventsFromDOM ──
 
-describe("extractEvents", () => {
-  it("splits text on ___good_to_know markers and parses each block", () => {
-    const text = `The A to Birthday Run
-Run № 1476 by War 'n Piece & MiaB
-Saturday 04 April, 2026 at 14:45 hrs
-Haarlem Railway Station
-
-___good_to_know
-Bag Drop – NO
-Hash Cash – €5
-
-Do Not Eat Yellow Snow !
-Run № 1477 by Golden Showers
-Sunday 12 April, 2026 at 12:45 hrs
-Near Station Zuid
-
-___good_to_know
-Bag Drop – Probably not`;
-
-    const { events, errors } = extractEvents(text, SOURCE_URL);
+describe("extractEventsFromDOM", () => {
+  it("finds all 3 events in the fixture", () => {
+    const $ = cheerio.load(FIXTURE_HTML);
+    const { events, errors } = extractEventsFromDOM($, SOURCE_URL);
     expect(errors).toHaveLength(0);
-    expect(events).toHaveLength(2);
-    expect(events[0].runNumber).toBe(1476);
-    expect(events[1].runNumber).toBe(1477);
+    expect(events).toHaveLength(3);
+    expect(events.map((e) => e.runNumber)).toEqual([1477, 1478, 1479]);
   });
 
-  it("skips blocks without run numbers", () => {
-    const text = `Some intro text about Amsterdam H3.
-___good_to_know
-Run № 1476 by War 'n Piece & MiaB
-Saturday 04 April, 2026 at 14:45 hrs
-Haarlem Railway Station
-___good_to_know
-More footer text`;
-
-    const { events } = extractEvents(text, SOURCE_URL);
-    expect(events).toHaveLength(1);
-    expect(events[0].runNumber).toBe(1476);
+  it("returns empty when .entry-content is missing", () => {
+    const $ = cheerio.load("<html><body>No content</body></html>");
+    const { events } = extractEventsFromDOM($, SOURCE_URL);
+    expect(events).toHaveLength(0);
   });
 });
 
-// ── Unit tests: htmlToText ──
+// ── Special event without Run № line ──
 
-describe("htmlToText", () => {
-  it("extracts text from .entry-content with br→newline conversion", async () => {
-    const $ = (await import("cheerio")).load(
-      `<div class="entry-content"><p>Run № <b>1476</b> by <b>War</b><br/>Saturday 04 April, 2026 at 14:45 hrs</p></div>`,
-    );
-    const text = htmlToText($);
-    expect(text).toContain("Run № 1476 by War");
-    expect(text).toContain("Saturday 04 April, 2026 at 14:45 hrs");
-  });
+describe("special events without Run №", () => {
+  const SPECIAL_HTML = `<html><body><div class="entry-content">
+<hr/>
+<p id="1">A Very Special FILTH Bicycle Hash</p>
+<p><b>Saturday 29 August, 2026</b> at <b>12:00</b> hrs<br/>
+<b>Central Station</b></p>
+<p>Bring your bicycle for an adventure.</p>
+<hr/>
+</div></body></html>`;
 
-  it("returns empty string when .entry-content is missing", async () => {
-    const $ = (await import("cheerio")).load(`<div>No entry content</div>`);
-    expect(htmlToText($)).toBe("");
-  });
-
-  it("strips <style> tags so CSS rules don't appear as text", async () => {
-    const $ = (await import("cheerio")).load(
-      `<div class="entry-content"><style>mark { background-color: lightgrey; color: black; }</style><p>The A to Birthday Run</p></div>`,
-    );
-    const text = htmlToText($);
-    expect(text).not.toContain("background-color");
-    expect(text).not.toContain("mark {");
-    expect(text).toContain("The A to Birthday Run");
-  });
-
-  it("strips CSS rules that leak outside <style> tags (malformed HTML)", async () => {
-    const $ = (await import("cheerio")).load(
-      `<div class="entry-content">mark { background-color: lightgrey; color: black; }<p>The A to Birthday Run</p></div>`,
-    );
-    const text = htmlToText($);
-    expect(text).not.toContain("background-color");
-    expect(text).not.toContain("mark {");
-    expect(text).toContain("The A to Birthday Run");
+  it("parses events without Run № using the <p id> title and skips placeholder IDs", () => {
+    const $ = cheerio.load(SPECIAL_HTML);
+    const { events } = extractEventsFromDOM($, SOURCE_URL);
+    expect(events).toHaveLength(1);
+    // id="1" is a placeholder — runNumber should be undefined
+    expect(events[0].runNumber).toBeUndefined();
+    expect(events[0].title).toBe("A Very Special FILTH Bicycle Hash");
+    expect(events[0].date).toBe("2026-08-29");
+    expect(events[0].description).toContain("Bring your bicycle");
   });
 });
 
@@ -239,34 +229,28 @@ describe("AH3Adapter", () => {
   });
 
   it("fetches upcoming + previous pages and deduplicates by run number", async () => {
-    const upcomingHtml = `<html><body><div class="entry-content">
-<h1>Run A</h1>
-<p>Run № <b>1476</b> by <b>War &#039;n Piece</b><br/>
-<b>Saturday 04 April, 2026</b> at <b>14:45</b> hrs<br/>
-<b>Haarlem Station</b></p>
-<p>___good_to_know</p>
-</div></body></html>`;
-
+    const upcomingHtml = FIXTURE_HTML;
     const previousHtml = `<html><body><div class="entry-content">
-<h1>Run A Repeat</h1>
-<p>Run № <b>1476</b> by <b>War &#039;n Piece</b><br/>
-<b>Saturday 04 April, 2026</b> at <b>14:45</b> hrs<br/>
-<b>Haarlem Station</b></p>
-<p>___good_to_know</p>
-<h1>Run B</h1>
+<hr/>
+<p id=1477>Do Not Eat Yellow Snow !</p>
+<p>Run № <b>1477</b> by <b>Golden Showers</b><br/>
+<b>Sunday 12 April, 2026</b> at <b>12:45</b> hrs<br/>
+<b>Station</b></p>
+<hr/>
+<p id=1475>Old Run</p>
 <p>Run № <b>1475</b> by <b>Old Hare</b><br/>
 <b>Saturday 28 March, 2026</b> at <b>14:45</b> hrs<br/>
 <b>Central Station</b></p>
-<p>___good_to_know</p>
+<hr/>
 </div></body></html>`;
 
     mockFetchResponses(upcomingHtml, previousHtml);
 
     const result = await adapter.fetch(makeSource());
     expect(result.errors).toHaveLength(0);
-    // Run 1476 appears in both, should only appear once (from upcoming)
-    const run1476 = result.events.filter((e) => e.runNumber === 1476);
-    expect(run1476).toHaveLength(1);
+    // Run 1477 appears in both, should only appear once (from upcoming)
+    const run1477 = result.events.filter((e) => e.runNumber === 1477);
+    expect(run1477).toHaveLength(1);
     // Run 1475 only in previous
     const run1475 = result.events.filter((e) => e.runNumber === 1475);
     expect(run1475).toHaveLength(1);
@@ -287,14 +271,6 @@ describe("AH3Adapter", () => {
   });
 
   it("continues with upcoming events if previous page fails", async () => {
-    const upcomingHtml = `<html><body><div class="entry-content">
-<h1>Run A</h1>
-<p>Run № <b>1476</b> by <b>Hare</b><br/>
-<b>Saturday 04 April, 2026</b> at <b>14:45</b> hrs<br/>
-<b>Station</b></p>
-<p>___good_to_know</p>
-</div></body></html>`;
-
     let callCount = 0;
     mockedSafeFetch.mockImplementation(async () => {
       callCount++;
@@ -303,7 +279,7 @@ describe("AH3Adapter", () => {
           ok: true,
           status: 200,
           statusText: "OK",
-          text: () => Promise.resolve(upcomingHtml),
+          text: () => Promise.resolve(FIXTURE_HTML),
           headers: new Headers(),
         } as Response;
       }
@@ -317,7 +293,7 @@ describe("AH3Adapter", () => {
     });
 
     const result = await adapter.fetch(makeSource());
-    expect(result.events).toHaveLength(1);
+    expect(result.events).toHaveLength(3);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("Previous page fetch failed");
   });

--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -113,10 +113,15 @@ describe("parseEventSection — DOM-based event parsing", () => {
   const content = $(".entry-content");
   const hrs = content.find("hr").toArray();
 
+  /** Walk sibling nodes between hrs[idx] and hrs[idx+1] (or end of content).
+   *  Uses .at() for the index lookup so eslint-plugin-security doesn't flag
+   *  the dynamic access as an object-injection sink. */
   function getSection(idx: number) {
+    const hr = hrs.at(idx);
+    if (!hr) throw new Error(`No <hr> at index ${idx}`);
+    const nextHr = hrs.at(idx + 1) ?? null;
     const sectionNodes: import("domhandler").AnyNode[] = [];
-    let node: import("domhandler").AnyNode | null = (hrs[idx] as import("domhandler").Element).nextSibling;
-    const nextHr = idx + 1 < hrs.length ? hrs[idx + 1] : null;
+    let node: import("domhandler").AnyNode | null = (hr as import("domhandler").Element).nextSibling;
     while (node && node !== nextHr) {
       sectionNodes.push(node);
       node = node.nextSibling;

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -5,22 +5,24 @@
  *   1. /nextruns/  — upcoming events
  *   2. /previous/  — historical/past events
  *
- * Both pages use the same WordPress format: an `.entry-content` div with
- * event blocks separated by `___good_to_know` markers. Each block contains:
- *   - An event title (<h1>)
- *   - Run number + hare(s) on a "Run № NNNN by Hare Name" line
- *   - Date/time: "Saturday 04 April, 2026 at 14:45 hrs"
- *   - Location: venue name (bold) followed by address line
+ * DOM-based parsing: each event sits between consecutive `<hr>` elements
+ * inside `.entry-content`. Within each section:
+ *   - `<p id="NNNN">Title</p>` carries the event title (id is usually the
+ *     run number but can be a placeholder like "1" for special events)
+ *   - "Run № NNNN by Hare Name" line carries the authoritative run number
+ *     and optional hare(s). Not every event has this line (special events
+ *     like pub crawls omit it).
+ *   - "Saturday 04 April, 2026 at 14:45 hrs" line — date + time
+ *   - Bold venue name followed by an address line — location
+ *   - Free-text paragraphs between the header and `___good_to_know` — description
  *
- * Blocks without hares that contain "Click if you want to hare this run"
- * are still included (they have a date and run number), but hares will be
- * undefined.
- *
- * Deduplication: upcoming events take priority over previous events
- * when the same run number appears in both.
+ * Deduplication: upcoming events take priority over previous events when
+ * the same run number appears in both.
  */
 
 import * as cheerio from "cheerio";
+import type { Cheerio } from "cheerio";
+import type { AnyNode, Element } from "domhandler";
 import * as chrono from "chrono-node";
 import type { Source } from "@/generated/prisma/client";
 import type {
@@ -31,7 +33,7 @@ import type {
   ParseError,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { fetchHTMLPage, decodeEntities, filterEventsByWindow } from "../utils";
+import { fetchHTMLPage, decodeEntities, stripHtmlTags, filterEventsByWindow } from "../utils";
 
 // ── Constants ──
 
@@ -46,46 +48,75 @@ const RUN_NUMBER_RE = /Run\s*[№#]\s*(\d{4,5})\s*(?:by\s+(.+))?/i;
 const DATE_TIME_RE =
   /(?:Sunday|Saturday|Monday|Tuesday|Wednesday|Thursday|Friday)\s+(\d{1,2}\s+\w+,?\s+\d{4})\s+at\s+(\d{1,2}):(\d{2})\s*hrs/i;
 
-/** Block separator: ___good_to_know */
-const BLOCK_SEPARATOR = "___good_to_know";
+/** Block metadata marker — everything after this is structured metadata
+ *  (Bag Drop, BeerMeister, Hash Cash, On After) not event description. */
+const GOOD_TO_KNOW_RE = /___good_to_know/i;
 
 // ── Exported helpers (for unit testing) ──
 
 /**
- * Parse a single event block (text between ___good_to_know dividers) into RawEventData.
- * Returns null if the block doesn't contain a valid run number + date.
+ * Parse a single `<hr>`-delimited section of the .entry-content into
+ * RawEventData. Returns null if the section lacks a valid date. Uses the
+ * `<p[id]>` element for the title and the `id` attribute as a fallback
+ * run number when the "Run №" line is absent.
  */
-export function parseEventBlock(
-  text: string,
+export function parseEventSection(
+  $section: Cheerio<AnyNode>,
+  $: cheerio.CheerioAPI,
   sourceUrl: string,
 ): RawEventData | null {
-  // Extract run number and optional hares
-  const runMatch = RUN_NUMBER_RE.exec(text);
-  if (!runMatch) return null;
-  const runNumber = parseInt(runMatch[1], 10);
+  // ── Title from <p id="NNNN"> ──
+  // find() only matches descendants; filter() matches the top-level nodes
+  // themselves. We need both: the real HTML wraps events in a <div> (so
+  // find works), but test fixtures may have <p id> as a direct sibling
+  // (so filter is the fallback).
+  let titleP = $section.find("p[id]").first();
+  if (titleP.length === 0) titleP = $section.filter("p[id]").first();
+  const title = titleP.length > 0
+    ? decodeEntities(titleP.text()).trim()
+    : undefined;
+  const pId = titleP.length > 0 ? titleP.attr("id") : undefined;
 
-  // Extract hares (if present and not just a "Click to hare" button)
+  // ── Convert section HTML to text with block-boundary newlines ──
+  // $section is a cheerio collection of sibling nodes (text + elements).
+  // .html() only returns the first node's innerHTML; we need the full
+  // outer HTML of every node in the collection.
+  const sectionHtml = $section.toArray().map((n) => $.html(n)).join("");
+  const text = stripHtmlTags(sectionHtml, "\n").replaceAll("\u00a0", " ");
+
+  // ── Run number + hares from "Run №" line ──
+  const runMatch = RUN_NUMBER_RE.exec(text);
+  let runNumber: number | undefined;
   let hares: string | undefined;
-  if (runMatch[2]) {
-    const hareTrimmed = runMatch[2].trim();
-    // Skip CTA-only "hare" text
-    if (!/Click if you want to hare/i.test(hareTrimmed)) {
-      hares = hareTrimmed;
+  if (runMatch) {
+    runNumber = parseInt(runMatch[1], 10);
+    if (runMatch[2]) {
+      const hareTrimmed = runMatch[2].trim();
+      if (!/Click if you want to hare/i.test(hareTrimmed)) {
+        hares = hareTrimmed;
+      }
     }
   }
 
-  // Extract date and time
+  // Fallback: use the <p id="NNNN"> id as run number when Run № is absent
+  // (special events). Skip placeholder ids like "1".
+  if (runNumber == null && pId) {
+    const parsed = parseInt(pId, 10);
+    if (Number.isFinite(parsed) && parsed >= 100) {
+      runNumber = parsed;
+    }
+  }
+
+  // ── Date + time ──
   const dtMatch = DATE_TIME_RE.exec(text);
   if (!dtMatch) return null;
 
-  const dateStr = dtMatch[1]; // e.g., "04 April, 2026"
+  const dateStr = dtMatch[1];
   const hours = dtMatch[2];
   const minutes = dtMatch[3];
 
-  // Parse the date portion with chrono
   const parsed = chrono.en.parse(dateStr);
   if (parsed.length === 0) return null;
-
   const result = parsed[0].start;
   const year = result.get("year");
   const month = result.get("month");
@@ -95,51 +126,77 @@ export function parseEventBlock(
   const date = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
   const startTime = `${hours.padStart(2, "0")}:${minutes}`;
 
-  // Title is the line immediately before "Run №" — searching backwards avoids
-  // picking up leftover good_to_know instruction text from the previous block.
+  // ── Location: first bold text after the date line ──
   const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
-  let title: string | undefined;
-  const runLineIdx = lines.findIndex((l) => RUN_NUMBER_RE.test(l));
-  if (runLineIdx > 0) {
-    const candidate = lines[runLineIdx - 1];
-    if (candidate.length > 1 && !/^[_\-=]+$/.test(candidate)) {
-      title = candidate;
-    }
-  }
-
-  // Extract location: lines after the date line
   let location: string | undefined;
   let locationStreet: string | undefined;
 
   const dateLineIdx = lines.findIndex((l) => DATE_TIME_RE.test(l));
   if (dateLineIdx >= 0) {
-    // The line immediately after the date is the venue name
     const venueLine = lines[dateLineIdx + 1];
     if (venueLine && !/Map\s*$/.test(venueLine) && !/Let us know/.test(venueLine)) {
       location = venueLine
         .replace(/Map\s*$/, "")
-        .replace(/\s+$/, "")
         .trim();
-      // Skip "somewhere" placeholder
       if (/^somewhere$/i.test(location)) {
         location = undefined;
       }
     }
-
-    // The line after venue might be a street address (contains comma + postal code)
     const addressLine = lines[dateLineIdx + 2];
     if (addressLine && /\d{4}\s*[A-Z]{2}/.test(addressLine)) {
       locationStreet = addressLine
         .replace(/Map\s*$/, "")
-        .replace(/\s+$/, "")
         .trim();
     }
   }
 
-  // Build event title
+  // ── Description: text between the event header and ___good_to_know ──
+  // Start scanning from dateLineIdx + 1 (after the date line) and filter
+  // out structural lines (venue, address, WhatsApp, buttons, images).
+  // Description is whatever free-text paragraphs remain before the
+  // ___good_to_know marker. The +3 hard-coded offset from the prior
+  // version was too aggressive — it skipped the description start when
+  // the address line was absent.
+  let description: string | undefined;
+  const goodToKnowIdx = lines.findIndex((l) => GOOD_TO_KNOW_RE.test(l));
+  const descStartIdx = dateLineIdx >= 0 ? dateLineIdx + 1 : -1;
+  if (descStartIdx > 0) {
+    const descEndIdx = goodToKnowIdx > descStartIdx ? goodToKnowIdx : lines.length;
+    const descLines = lines.slice(descStartIdx, descEndIdx).filter((l) => {
+      // Skip venue name (already captured as location)
+      if (location && l === location) return false;
+      // Skip address line (already captured as locationStreet)
+      if (/^\d{4}\s*[A-Z]{2}/.test(l)) return false;
+      if (locationStreet && l.includes(locationStreet)) return false;
+      // Skip plus-codes (e.g. "9M5R+65, Amsterdam, 1077 XS")
+      if (/^[A-Z0-9]{4}\+[A-Z0-9]+/.test(l)) return false;
+      // Skip non-description noise
+      if (/^Let us know/i.test(l)) return false;
+      if (/^WhatsApp$/i.test(l)) return false;
+      if (/^RSVP$/i.test(l)) return false;
+      if (/^Map$/i.test(l)) return false;
+      if (/^Contact\b/i.test(l)) return false;
+      if (/^somewhere$/i.test(l)) return false;
+      if (/^–\s*$/.test(l)) return false;
+      if (l.length < 3) return false;
+      return true;
+    });
+    const descText = descLines.join("\n").trim();
+    if (descText.length > 5) {
+      description = descText;
+    }
+  }
+
+  // ── Build event title ──
   const eventTitle = title
-    ? `AH3 #${runNumber} — ${title}`
-    : `AH3 #${runNumber}`;
+    ? runNumber
+      ? `AH3 #${runNumber} — ${title}`
+      : title
+    : runNumber
+      ? `AH3 #${runNumber}`
+      : undefined;
+
+  if (!eventTitle) return null;
 
   return {
     date,
@@ -150,70 +207,58 @@ export function parseEventBlock(
     location,
     locationStreet,
     startTime,
+    description,
     sourceUrl,
   };
 }
 
 /**
- * Extract all event blocks from page text.
- * Splits on ___good_to_know markers plus <hr> separators, then parses each block.
+ * Extract all events from a page's DOM by splitting on `<hr>` elements.
+ * Each `<hr>` marks the boundary between events in the .entry-content.
  */
-export function extractEvents(
-  pageText: string,
+export function extractEventsFromDOM(
+  $: cheerio.CheerioAPI,
   sourceUrl: string,
 ): { events: RawEventData[]; errors: ParseError[] } {
   const events: RawEventData[] = [];
   const errors: ParseError[] = [];
+  const content = $(".entry-content");
+  if (content.length === 0) return { events, errors };
 
-  // Split on ___good_to_know markers (which appear within blocks after the event data)
-  // and also on horizontal rule separators
-  const blocks = pageText.split(/___good_to_know/i);
+  // Remove <style> blocks that leak CSS rules into .text()
+  content.find("style").remove();
 
-  for (let i = 0; i < blocks.length; i++) {
-    const block = blocks[i].trim();
-    if (!block || block.length < 20) continue;
+  // Split content into sections by <hr>. We wrap each section's content
+  // between consecutive <hr> elements into a virtual container for parsing.
+  const hrs = content.find("hr").toArray();
+  if (hrs.length === 0) return { events, errors };
 
-    // A single block may contain content from the previous event's ___good_to_know
-    // section AND the next event's header. We need to find the run number line.
-    if (!RUN_NUMBER_RE.test(block)) continue;
-
+  for (let i = 0; i < hrs.length; i++) {
     try {
-      const event = parseEventBlock(block, sourceUrl);
+      // Collect all sibling nodes between this <hr> and the next (or end)
+      const sectionNodes: AnyNode[] = [];
+      let node: AnyNode | null = (hrs[i] as Element).nextSibling;
+      const nextHr = i + 1 < hrs.length ? hrs[i + 1] : null;
+      while (node && node !== nextHr) {
+        sectionNodes.push(node);
+        node = node.nextSibling;
+      }
+      if (sectionNodes.length === 0) continue;
+
+      // Wrap in a cheerio object for querying
+      const $section = $(sectionNodes);
+      const event = parseEventSection($section, $, sourceUrl);
       if (event) events.push(event);
     } catch (err) {
       errors.push({
         row: i,
         error: String(err),
-        rawText: block.slice(0, 2000),
+        rawText: `Section ${i} after <hr>`,
       });
     }
   }
 
   return { events, errors };
-}
-
-/**
- * Convert raw HTML from AH3's .entry-content into line-separated text.
- * Replaces <br>, <h1>, <hr>, and block-level tags with newlines.
- */
-export function htmlToText($: cheerio.CheerioAPI): string {
-  const content = $(".entry-content");
-  if (content.length === 0) return "";
-
-  content.find("style").remove();
-
-  // Replace <br> with newlines
-  content.find("br").replaceWith("\n");
-  // Replace block-level tags with newlines for clean text extraction
-  content.find("h1").each(function () {
-    $(this).replaceWith("\n" + $(this).text() + "\n");
-  });
-
-  let text = decodeEntities(content.text());
-  // Strip leaked CSS rules (e.g. "mark { background-color: lightgrey; color: black; }")
-  // that may survive style-tag removal due to malformed HTML
-  text = text.replace(/[a-z-]+\s*\{[^{}]*:[^{}]*\}/gi, "");
-  return text;
 }
 
 // ── Adapter class ──
@@ -226,7 +271,6 @@ export class AH3Adapter implements SourceAdapter {
     options?: { days?: number },
   ): Promise<ScrapeResult> {
     const upcomingUrl = source.url || "https://ah3.nl/nextruns/";
-    // Honor source.scrapeDays via options.days (default 365)
     const days = options?.days ?? source.scrapeDays ?? 365;
     const config = (source.config ?? {}) as Record<string, unknown>;
     const previousUrl =
@@ -246,9 +290,8 @@ export class AH3Adapter implements SourceAdapter {
     const structureHash = upcoming.structureHash;
     totalFetchMs += upcoming.fetchDurationMs;
 
-    const upcomingText = htmlToText(upcoming.$);
-    const { events: upcomingEvents, errors: upcomingErrors } = extractEvents(
-      upcomingText,
+    const { events: upcomingEvents, errors: upcomingErrors } = extractEventsFromDOM(
+      upcoming.$,
       upcomingUrl,
     );
 
@@ -267,13 +310,11 @@ export class AH3Adapter implements SourceAdapter {
     if (previous.ok) {
       totalFetchMs += previous.fetchDurationMs;
 
-      const previousText = htmlToText(previous.$);
-      const { events: previousEvents, errors: previousErrors } = extractEvents(
-        previousText,
+      const { events: previousEvents, errors: previousErrors } = extractEventsFromDOM(
+        previous.$,
         previousUrl,
       );
 
-      // Deduplicate: upcoming events take priority
       for (const ev of previousEvents) {
         if (ev.runNumber && seenRunNumbers.has(ev.runNumber)) continue;
         allEvents.push(ev);
@@ -285,7 +326,6 @@ export class AH3Adapter implements SourceAdapter {
         );
       }
     } else {
-      // Non-fatal: previous page failure shouldn't block upcoming events
       allErrors.push(`Previous page fetch failed: ${previous.result.errors[0]}`);
     }
 

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -39,6 +39,10 @@ import { fetchHTMLPage, decodeEntities, stripHtmlTags, filterEventsByWindow } fr
 
 const KENNEL_TAG = "ah3-nl";
 
+/** IDs below this threshold on `<p id="N">` elements are WordPress
+ *  placeholders (e.g. id="1" for special events), not real run numbers. */
+const MIN_VALID_RUN_NUMBER = 100;
+
 // ── Regex patterns ──
 
 /** Match run number and optional hare(s): "Run № 1476 by War 'n Piece & MiaB" */
@@ -102,7 +106,7 @@ export function parseEventSection(
   // (special events). Skip placeholder ids like "1".
   if (runNumber == null && pId) {
     const parsed = parseInt(pId, 10);
-    if (Number.isFinite(parsed) && parsed >= 100) {
+    if (Number.isFinite(parsed) && parsed >= MIN_VALID_RUN_NUMBER) {
       runNumber = parsed;
     }
   }
@@ -250,10 +254,16 @@ export function extractEventsFromDOM(
       const event = parseEventSection($section, $, sourceUrl);
       if (event) events.push(event);
     } catch (err) {
+      // Include the section's outer HTML in the error so the AI parse-recovery
+      // pipeline can attempt re-extraction from the raw source material.
+      const nextNode = (hrs[i] as Element | undefined)?.nextSibling;
+      const sectionSnippet = nextNode
+        ? ($.html(nextNode as AnyNode)?.slice(0, 2000) ?? "")
+        : "";
       errors.push({
         row: i,
         error: String(err),
-        rawText: `Section ${i} after <hr>`,
+        rawText: sectionSnippet || `Section ${i} after <hr>`,
       });
     }
   }


### PR DESCRIPTION
## Summary

Audit batch closing 10 issues across 4 kennels:

### #582 + #584 — Philly H3 + Oregon H3 shared-calendar cross-kennel skip
Anchored \`skipPatterns\` filter BFM and N2H3 events from shared Google Calendars. Both sister kennels have dedicated sources at trust 8, so skipping avoids cross-kennel duplicates without losing data. \`jsonb_set\` prod SQL preserves admin-UI drift. 6 regression tests verify both drop and mixed-title preservation.

### #583 — Lion City H3 hares extraction
Root-cause fix: replaced cheerio \`\$("body").text()\` (which flattens \`<p>\` boundaries) with \`stripHtmlTags(html, "\\n")\` so the existing newline-terminated hares regex stops at paragraph boundaries. Same pattern as ewh3.ts + calgary-h3-scribe.ts.

### #559, #560, #561, #563, #564 — Amsterdam H3 (ah3-nl) adapter rewrite + profile
Complete rewrite of the Amsterdam adapter from text-splitting to DOM-based parsing:
- **#559**: Title now extracted from \`<p id="NNNN">\` DOM elements — no more "On After" leaking from the previous event's metadata
- **#561**: 20 events extracted (was 10) — special events without "Run №" lines now captured via \`<p id>\` fallback
- **#563**: Description extracted from paragraph text between the header block and \`___good_to_know\`
- **#560**: Adapter now extracts "Near Station Lelylaan" correctly (was "Near Station Zuid" due to text boundary flattening)
- **#564**: Facebook group URL + 192×192 logo added to kennel profile

### #566, #567 — closed as non-code findings
- **#566**: Schema gap (PRD decision) — bag drop, beermeister, on-after fields have no HashTracks home yet
- **#567**: Source coverage gap (research) — Harrier Central slug for Amsterdam needs discovery

### #565, #585 — deferred
- **#565**: Historical backfill — \`/previous/\` page uses a different HTML layout than \`/nextruns/\`; needs a separate parser
- **#585**: Calgary description-dropped — needs investigation before a fix (comment posted with concrete data-gathering steps)

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 4251 passing
- [x] Prod SQL applied for skipPatterns (Philly + Oregon) + verified idempotent
- [x] Prod SQL applied for AH3 profile (logo + Facebook) + verified idempotent
- [x] Re-scrape: Philly H3 → BFM events CANCELLED; Oregon H3 → NNH3 #769 CANCELLED
- [x] Lion City re-scrape → haresText clean on #2194
- [x] Live verification against ah3.nl/nextruns/ → 20 events, correct titles + descriptions

Closes #559, #560, #561, #563, #564, #566, #567, #582, #583, #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)