### PR TITLE
Allow unauthenticated users to open sign-in modal from feedback button

### DIFF
--- a/src/components/feedback/FeedbackDialog.tsx
+++ b/src/components/feedback/FeedbackDialog.tsx
@@ -26,8 +26,15 @@ import { Button } from "@/components/ui/button";
 
 const triggerClass = "text-foreground/80 transition-colors hover:text-foreground";
 
+/**
+ * Footer/menu trigger for submitting user feedback.
+ *
+ * Renders for all visitors. Signed-out users get a sign-in modal on click;
+ * signed-in users get the feedback form dialog. While Clerk is still loading
+ * auth state we render nothing to avoid flashing the wrong trigger.
+ */
 export function FeedbackDialog() {
-  const { user } = useUser();
+  const { isLoaded, isSignedIn } = useUser();
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
@@ -48,10 +55,13 @@ export function FeedbackDialog() {
     }
   }, [state]);
 
-  if (!user) {
+  // Wait for Clerk so signed-in users never briefly see the sign-in CTA
+  if (!isLoaded) return null;
+
+  if (!isSignedIn) {
     return (
       <SignInButton mode="modal">
-        <button className={triggerClass}>Send Feedback</button>
+        <button type="button" className={triggerClass}>Send Feedback</button>
       </SignInButton>
     );
   }
@@ -59,7 +69,7 @@ export function FeedbackDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <button className={triggerClass}>Send Feedback</button>
+        <button type="button" className={triggerClass}>Send Feedback</button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>

--- a/src/components/feedback/FeedbackDialog.tsx
+++ b/src/components/feedback/FeedbackDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useActionState, useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
-import { useUser } from "@clerk/nextjs";
+import { useUser, SignInButton } from "@clerk/nextjs";
 import { submitFeedback } from "@/app/feedback/actions";
 import { toast } from "sonner";
 import {
@@ -46,8 +46,16 @@ export function FeedbackDialog() {
     }
   }, [state]);
 
-  // Don't render for signed-out users
-  if (!user) return null;
+  // Signed-out users see a button that opens the Clerk sign-in modal
+  if (!user) {
+    return (
+      <SignInButton mode="modal">
+        <button className="text-foreground/80 transition-colors hover:text-foreground">
+          Send Feedback
+        </button>
+      </SignInButton>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/src/components/feedback/FeedbackDialog.tsx
+++ b/src/components/feedback/FeedbackDialog.tsx
@@ -24,6 +24,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 
+const triggerClass = "text-foreground/80 transition-colors hover:text-foreground";
+
 export function FeedbackDialog() {
   const { user } = useUser();
   const pathname = usePathname();
@@ -46,13 +48,10 @@ export function FeedbackDialog() {
     }
   }, [state]);
 
-  // Signed-out users see a button that opens the Clerk sign-in modal
   if (!user) {
     return (
       <SignInButton mode="modal">
-        <button className="text-foreground/80 transition-colors hover:text-foreground">
-          Send Feedback
-        </button>
+        <button className={triggerClass}>Send Feedback</button>
       </SignInButton>
     );
   }
@@ -60,9 +59,7 @@ export function FeedbackDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <button className="text-foreground/80 transition-colors hover:text-foreground">
-          Send Feedback
-        </button>
+        <button className={triggerClass}>Send Feedback</button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>


### PR DESCRIPTION
## Summary
Updated the feedback dialog to allow unauthenticated users to access the feedback feature by presenting a sign-in modal, rather than hiding the feedback button entirely for signed-out users.

## Key Changes
- Imported `SignInButton` from `@clerk/nextjs` to enable authentication flow
- Extracted the button styling into a reusable `triggerClass` constant to maintain consistency across both authenticated and unauthenticated states
- Modified the unauthenticated user handling to render a `SignInButton` wrapper around the feedback button instead of returning `null`
- Updated the authenticated user's dialog trigger to use the extracted `triggerClass` constant

## Implementation Details
- The feedback button now appears for all users, but unauthenticated users will see a sign-in modal when clicked
- The button styling remains consistent between both states using the shared `triggerClass` constant
- Sign-in uses modal mode to keep users on the current page during authentication

https://claude.ai/code/session_01XMt8osrUHcWanDbABho39y