### PR TITLE
feat(admin): kennel create/delete syncs GitHub label

### DIFF
--- a/src/app/admin/kennels/actions.ts
+++ b/src/app/admin/kennels/actions.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache";
 import { fuzzyMatch } from "@/lib/fuzzy";
 import { toSlug, toKennelCode } from "@/lib/kennel-utils";
 import { generateAliases } from "@/lib/auto-aliases";
+import { ensureKennelLabel, deleteKennelLabel } from "@/pipeline/kennel-label-sync";
 
 function extractProfileFields(formData: FormData) {
   const result: Record<string, string | number | boolean | null> = {};
@@ -199,6 +200,17 @@ export async function createKennel(formData: FormData, force: boolean = false) {
     },
   });
 
+  // Fast-path canonicalize the `kennel:<code>` GitHub label so audit issues
+  // filed before the next daily sync get correct color/description. Failures
+  // are non-fatal — the daily cron reconciles drift.
+  const labelOutcome = await ensureKennelLabel(kennelCode, shortName);
+  if (!labelOutcome.ok) {
+    console.warn("[createKennel] label sync failed", {
+      kennelCode,
+      error: labelOutcome.error,
+    });
+  }
+
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
   return { success: true };
@@ -355,6 +367,16 @@ export async function deleteKennel(kennelId: string) {
     prisma.sourceKennel.deleteMany({ where: { kennelId } }),
     prisma.kennel.delete({ where: { id: kennelId } }),
   ]);
+
+  // Clean up orphaned `kennel:<code>` GitHub label. Non-fatal — an orphan
+  // label is cosmetic only.
+  const delOutcome = await deleteKennelLabel(kennel.kennelCode);
+  if (!delOutcome.ok) {
+    console.warn("[deleteKennel] label cleanup failed", {
+      kennelCode: kennel.kennelCode,
+      error: delOutcome.error,
+    });
+  }
 
   console.log("[admin-audit] deleteKennel", JSON.stringify({
     adminId: admin.id,

--- a/src/pipeline/kennel-label-sync.test.ts
+++ b/src/pipeline/kennel-label-sync.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   planKennelLabelSync,
+  ensureKennelLabel,
+  deleteKennelLabel,
   type GitHubLabel,
 } from "./kennel-label-sync";
 
@@ -128,5 +130,171 @@ describe("planKennelLabelSync", () => {
     if (agnewsUpdate && agnewsUpdate.kind === "update") {
       expect(agnewsUpdate.description).toBe("Audit kennel attribution — Agnews");
     }
+  });
+});
+
+// ── Per-kennel lifecycle hooks ──
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function emptyResponse(status: number): Response {
+  return new Response(null, { status });
+}
+
+describe("ensureKennelLabel", () => {
+  const ORIGINAL_TOKEN = process.env.GITHUB_TOKEN;
+  let fetchMock: FetchMock;
+
+  beforeEach(() => {
+    process.env.GITHUB_TOKEN = "test-token";
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env.GITHUB_TOKEN = ORIGINAL_TOKEN;
+  });
+
+  it("creates the label when GitHub returns 404", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(404, { message: "Not Found" }))
+      .mockResolvedValueOnce(jsonResponse(201, { name: "kennel:agnews" }));
+    const outcome = await ensureKennelLabel("agnews", "Agnews");
+    expect(outcome).toEqual({ ok: true, action: "created" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, postCall] = fetchMock.mock.calls;
+    expect(postCall[1].method).toBe("POST");
+    const body = JSON.parse(postCall[1].body as string);
+    expect(body).toEqual({
+      name: "kennel:agnews",
+      color: "d0e8ff",
+      description: "Audit kennel attribution — Agnews",
+    });
+  });
+
+  it("patches a drifted canonical label (description stale)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          name: "kennel:agnews",
+          color: "d0e8ff",
+          description: "Audit kennel attribution — OldName",
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { name: "kennel:agnews" }));
+    const outcome = await ensureKennelLabel("agnews", "Agnews");
+    expect(outcome).toEqual({ ok: true, action: "updated" });
+    const [, patchCall] = fetchMock.mock.calls;
+    expect(patchCall[1].method).toBe("PATCH");
+  });
+
+  it("skips when the label is already canonical", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, {
+        name: "kennel:agnews",
+        color: "d0e8ff",
+        description: "Audit kennel attribution — Agnews",
+      }),
+    );
+    const outcome = await ensureKennelLabel("agnews", "Agnews");
+    expect(outcome).toEqual({ ok: true, action: "skipped" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves externally owned labels alone", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, {
+        name: "kennel:agnews",
+        color: "ff0000",
+        description: "Triage queue — blocker",
+      }),
+    );
+    const outcome = await ensureKennelLabel("agnews", "Agnews");
+    expect(outcome).toEqual({ ok: true, action: "external" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns invalid without hitting the network for bad kennelCodes", async () => {
+    const outcome = await ensureKennelLabel("Bad Code!", "Bad");
+    expect(outcome).toEqual({ ok: true, action: "invalid" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns missing-token when GITHUB_TOKEN is unset", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const outcome = await ensureKennelLabel("agnews", "Agnews");
+    expect(outcome).toEqual({ ok: true, action: "missing-token" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("captures errors from failed GETs without throwing", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(500, { message: "boom" }));
+    const outcome = await ensureKennelLabel("agnews", "Agnews");
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.action).toBe("error");
+      expect(outcome.error).toMatch(/500/);
+    }
+  });
+});
+
+describe("deleteKennelLabel", () => {
+  const ORIGINAL_TOKEN = process.env.GITHUB_TOKEN;
+  let fetchMock: FetchMock;
+
+  beforeEach(() => {
+    process.env.GITHUB_TOKEN = "test-token";
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env.GITHUB_TOKEN = ORIGINAL_TOKEN;
+  });
+
+  it("returns deleted on 204", async () => {
+    fetchMock.mockResolvedValueOnce(emptyResponse(204));
+    const outcome = await deleteKennelLabel("agnews");
+    expect(outcome).toEqual({ ok: true, action: "deleted" });
+    const [[, init]] = fetchMock.mock.calls;
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("treats 404 as idempotent absent", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(404, { message: "Not Found" }));
+    const outcome = await deleteKennelLabel("agnews");
+    expect(outcome).toEqual({ ok: true, action: "absent" });
+  });
+
+  it("captures 500 errors without throwing", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(500, { message: "boom" }));
+    const outcome = await deleteKennelLabel("agnews");
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.action).toBe("error");
+      expect(outcome.error).toMatch(/500/);
+    }
+  });
+
+  it("returns invalid for bad kennelCodes without touching the network", async () => {
+    const outcome = await deleteKennelLabel("Bad!");
+    expect(outcome).toEqual({ ok: true, action: "invalid" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns missing-token when GITHUB_TOKEN is unset", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const outcome = await deleteKennelLabel("agnews");
+    expect(outcome).toEqual({ ok: true, action: "missing-token" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/pipeline/kennel-label-sync.ts
+++ b/src/pipeline/kennel-label-sync.ts
@@ -26,6 +26,22 @@ import {
   type StreamLabelName,
 } from "@/lib/audit-labels";
 
+/** Outcome of a per-kennel label lifecycle call. Never throws to callers. */
+export type KennelLabelOutcome =
+  | {
+      ok: true;
+      action:
+        | "created"
+        | "updated"
+        | "skipped"
+        | "external"
+        | "deleted"
+        | "absent"
+        | "invalid"
+        | "missing-token";
+    }
+  | { ok: false; action: "error"; error: string };
+
 const FETCH_TIMEOUT_MS = 15_000;
 const PAGE_SIZE = 100;
 const MAX_PAGES = 20;
@@ -82,7 +98,6 @@ function isOwnedLabel(label: GitHubLabel, ownershipPrefix: string): boolean {
   return desc.startsWith(ownershipPrefix);
 }
 
-/** Single diff that handles both kennel and stream labels. */
 function diffLabel(
   canonical: CanonicalLabel,
   existing: GitHubLabel | undefined,
@@ -140,6 +155,19 @@ export async function fetchAllLabels(token: string): Promise<GitHubLabel[]> {
   return out;
 }
 
+/** Build the canonical label spec for a single kennel. */
+function buildKennelCanonical(
+  kennelCode: string,
+  shortName: string | null,
+): CanonicalLabel {
+  return {
+    name: kennelLabel(kennelCode),
+    color: KENNEL_LABEL_COLOR,
+    description: `${KENNEL_DESCRIPTION_PREFIX} — ${shortName ?? kennelCode}`,
+    ownershipPrefix: KENNEL_DESCRIPTION_PREFIX,
+  };
+}
+
 /** Build the canonical label list for every kennel + every audit stream. */
 function buildCanonicalLabels(
   kennels: ReadonlyArray<{ kennelCode: string; shortName: string | null }>,
@@ -151,12 +179,7 @@ function buildCanonicalLabels(
       invalid.push(k.kennelCode);
       continue;
     }
-    canonical.push({
-      name: kennelLabel(k.kennelCode),
-      color: KENNEL_LABEL_COLOR,
-      description: `${KENNEL_DESCRIPTION_PREFIX} — ${k.shortName ?? k.kennelCode}`,
-      ownershipPrefix: KENNEL_DESCRIPTION_PREFIX,
-    });
+    canonical.push(buildKennelCanonical(k.kennelCode, k.shortName));
   }
   for (const [name, meta] of Object.entries(STREAM_LABEL_META) as Array<
     [StreamLabelName, { color: string; description: string }]
@@ -315,4 +338,135 @@ export async function syncKennelLabels(opts: { apply: boolean }): Promise<SyncLa
   );
 
   return plan;
+}
+
+// ── Per-kennel lifecycle hooks (create/delete fast path) ──
+//
+// These wrap a single label GET/POST/PATCH/DELETE so the admin kennel CRUD
+// actions can eagerly canonicalize (or clean up) a label without waiting for
+// the nightly full sync. They never throw — the daily cron is authoritative
+// and will reconcile any drift.
+
+/** GET a single label by name. 404 returns null. Throws on other failures. */
+export async function fetchLabel(
+  token: string,
+  name: string,
+): Promise<GitHubLabel | null> {
+  const repo = getValidatedRepo();
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/labels/${encodeURIComponent(name)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    },
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`GET /labels/${name} ${res.status}: ${await res.text()}`);
+  }
+  return (await res.json()) as GitHubLabel;
+}
+
+/** DELETE a label by name. 204 and 404 both succeed. */
+async function deleteLabel(
+  token: string,
+  name: string,
+): Promise<"deleted" | "absent"> {
+  assertSafeLabelName(name);
+  const repo = getValidatedRepo();
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/labels/${encodeURIComponent(name)}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    },
+  );
+  if (res.status === 404) return "absent";
+  if (!res.ok) {
+    throw new Error(`DELETE /labels/${name} ${res.status}: ${await res.text()}`);
+  }
+  return "deleted";
+}
+
+/**
+ * Ensure the canonical `kennel:<code>` label exists for a newly created
+ * kennel. Never throws — returns a structured outcome so the caller can log.
+ */
+export async function ensureKennelLabel(
+  kennelCode: string,
+  shortName: string | null,
+): Promise<KennelLabelOutcome> {
+  if (!isValidKennelCode(kennelCode)) {
+    return { ok: true, action: "invalid" };
+  }
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return { ok: true, action: "missing-token" };
+  }
+  const canonical = buildKennelCanonical(kennelCode, shortName);
+  try {
+    const existing = await fetchLabel(token, canonical.name);
+    const action = diffLabel(canonical, existing ?? undefined);
+    if (action.kind === "create") {
+      await writeLabel(
+        "POST",
+        token,
+        canonical.name,
+        canonical.color,
+        canonical.description,
+      );
+      return { ok: true, action: "created" };
+    }
+    if (action.kind === "update") {
+      await writeLabel(
+        "PATCH",
+        token,
+        canonical.name,
+        canonical.color,
+        canonical.description,
+      );
+      return { ok: true, action: "updated" };
+    }
+    if (action.kind === "external") {
+      console.warn(
+        `[ensureKennelLabel] ${canonical.name} externally owned, leaving alone:`,
+        action.description,
+      );
+      return { ok: true, action: "external" };
+    }
+    return { ok: true, action: "skipped" };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, action: "error", error: message };
+  }
+}
+
+/**
+ * Delete the `kennel:<code>` label for a deleted kennel. Never throws —
+ * returns a structured outcome so the caller can log.
+ */
+export async function deleteKennelLabel(
+  kennelCode: string,
+): Promise<KennelLabelOutcome> {
+  if (!isValidKennelCode(kennelCode)) {
+    return { ok: true, action: "invalid" };
+  }
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return { ok: true, action: "missing-token" };
+  }
+  try {
+    const result = await deleteLabel(token, kennelLabel(kennelCode));
+    return { ok: true, action: result };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, action: "error", error: message };
+  }
 }


### PR DESCRIPTION
## Overview
Add fast-path GitHub label synchronization for kennel CRUD operations so labels are canonicalized immediately rather than waiting for the nightly sync.

## Changes

### New Functions
- `ensureKennelLabel()` - Create or update `kennel:<code>` label when a kennel is created
- `deleteKennelLabel()` - Delete the `kennel:<code>` label when a kennel is deleted
- `fetchLabel()` - Get a single label by name from GitHub API
- `buildKennelCanonical()` - Extract common label spec building logic

### Updates
- **actions.ts**: Call `ensureKennelLabel()` after kennel creation and `deleteKennelLabel()` after deletion
- **kennel-label-sync.ts**: Refactor label building and add per-kennel lifecycle hooks
- **kennel-label-sync.test.ts**: Comprehensive test coverage for new lifecycle functions

### Design
- Never throws - failures are non-fatal since the daily cron reconciles drift
- Returns structured outcomes for logging and observability
- Validates kennel codes and respects externally-owned labels
- Handles missing `GITHUB_TOKEN` gracefully

Closes #587, #588