### PR TITLE
feat(audit): Amsterdam H3 /previous/ gallery parser (#565)

### DIFF
--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -4,6 +4,8 @@ import type { Source } from "@/generated/prisma/client";
 import {
   parseEventSection,
   extractEventsFromDOM,
+  extractEventsFromGallery,
+  parseGalleryDate,
   AH3Adapter,
 } from "./ah3";
 
@@ -197,6 +199,81 @@ describe("extractEventsFromDOM", () => {
     const $ = cheerio.load("<html><body>No content</body></html>");
     const { events } = extractEventsFromDOM($, SOURCE_URL);
     expect(events).toHaveLength(0);
+  });
+});
+
+// ── Gallery parser (/previous/ page) ──
+
+describe("parseGalleryDate", () => {
+  it("parses 'Saturday, Apr 4th, 2026 2:45PM'", () => {
+    const result = parseGalleryDate("Saturday, Apr 4th, 2026 2:45PM");
+    expect(result).toEqual({ date: "2026-04-04", startTime: "14:45" });
+  });
+
+  it("parses 'Sunday, Mar 8th, 2026 2:45PM'", () => {
+    const result = parseGalleryDate("Sunday, Mar 8th, 2026 2:45PM");
+    expect(result).toEqual({ date: "2026-03-08", startTime: "14:45" });
+  });
+
+  it("handles 1st/2nd/3rd ordinals", () => {
+    expect(parseGalleryDate("Saturday, Jun 1st, 2025 2:45PM")?.date).toBe("2025-06-01");
+    expect(parseGalleryDate("Sunday, Aug 2nd, 2025 2:45PM")?.date).toBe("2025-08-02");
+    expect(parseGalleryDate("Saturday, May 3rd, 2025 2:45PM")?.date).toBe("2025-05-03");
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseGalleryDate("")).toBeNull();
+  });
+});
+
+describe("extractEventsFromGallery", () => {
+  const GALLERY_HTML = `<html><body><div class="entry-content">
+<div class="harrier-gallery-grid">
+<a class="harrier-gallery-tile-link" href="/rundetail?publiceventid=abc">
+  <div class="harrier-gallery-tile">
+    <div class="harrier-gallery-image"><img alt="The A to Birthday Run"></div>
+    <h3>The A to Birthday Run</h3>
+    <p><strong>Date:</strong> Saturday, Apr 4th, 2026 2:45PM</p>
+    <p><strong>Location:</strong> Haarlem Railway Station</p>
+    <p><strong>Hares:</strong> War 'n Piece &amp; MiaB</p>
+    <p><strong>Description:</strong><br>&lt;b&gt;Saturday&lt;/b&gt; Birthday run from Haarlem.</p>
+  </div>
+</a>
+<a class="harrier-gallery-tile-link" href="/rundetail?publiceventid=def">
+  <div class="harrier-gallery-tile">
+    <h3>No Run</h3>
+    <p><strong>Date:</strong> Sunday, May 5th, 2024 2:45PM</p>
+  </div>
+</a>
+</div>
+</div></body></html>`;
+
+  it("extracts events from gallery tiles with all fields", () => {
+    const $ = cheerio.load(GALLERY_HTML);
+    const { events, errors } = extractEventsFromGallery($, PREVIOUS_URL);
+    expect(errors).toHaveLength(0);
+    expect(events).toHaveLength(2);
+
+    expect(events[0].title).toBe("The A to Birthday Run");
+    expect(events[0].date).toBe("2026-04-04");
+    expect(events[0].startTime).toBe("14:45");
+    expect(events[0].location).toBe("Haarlem Railway Station");
+    expect(events[0].hares).toBe("War 'n Piece & MiaB");
+    expect(events[0].description).toContain("Birthday run from Haarlem");
+    expect(events[0].description).not.toContain("<b>");
+    expect(events[0].kennelTag).toBe("ah3-nl");
+    // sourceUrl should come from the tile's per-event href, not the listing page
+    expect(events[0].sourceUrl).toContain("publiceventid=abc");
+  });
+
+  it("handles tiles with minimal fields (no location, hares, description)", () => {
+    const $ = cheerio.load(GALLERY_HTML);
+    const { events } = extractEventsFromGallery($, PREVIOUS_URL);
+    expect(events[1].title).toBe("No Run");
+    expect(events[1].date).toBe("2024-05-05");
+    expect(events[1].hares).toBeUndefined();
+    expect(events[1].location).toBeUndefined();
+    expect(events[1].description).toBeUndefined();
   });
 });
 

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -33,7 +33,7 @@ import type {
   ParseError,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { fetchHTMLPage, decodeEntities, stripHtmlTags, filterEventsByWindow, chronoParseDate, parse12HourTime } from "../utils";
+import { fetchHTMLPage, decodeEntities, stripHtmlTags, filterEventsByWindow, chronoParseDate, parse12HourTime, normalizeHaresField } from "../utils";
 
 // ── Constants ──
 
@@ -277,7 +277,7 @@ export function extractEventsFromDOM(
  * Strips ordinal suffixes then delegates to chronoParseDate + parse12HourTime.
  */
 export function parseGalleryDate(text: string): { date: string; startTime?: string } | null {
-  const cleaned = text.replace(/(\d+)(?:st|nd|rd|th)\b/gi, "$1");
+  const cleaned = text.replace(/(\d+)(?:st|nd|rd|th)/gi, "$1");
   const date = chronoParseDate(cleaned);
   if (!date) return null;
   return { date, startTime: parse12HourTime(cleaned) };
@@ -319,7 +319,7 @@ export function extractEventsFromGallery(
         if (!label) return;
         // Get text after the <strong> — clone the <p>, remove the <strong>, take remaining text
         const $p = $(this).clone();
-        $p.find("strong").remove();
+        $p.find("strong").first().remove();
         const value = decodeEntities($p.text()).trim();
         if (value) fields.set(label, value);
       });
@@ -343,7 +343,7 @@ export function extractEventsFromGallery(
       }
 
       const location = fields.get("location") || undefined;
-      const hares = fields.get("hares") || undefined;
+      const hares = normalizeHaresField(fields.get("hares"));
       const descRaw = fields.get("description") || undefined;
       const description = descRaw
         ? stripHtmlTags(decodeEntities(descRaw)).trim() || undefined

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -33,7 +33,7 @@ import type {
   ParseError,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { fetchHTMLPage, decodeEntities, stripHtmlTags, filterEventsByWindow } from "../utils";
+import { fetchHTMLPage, decodeEntities, stripHtmlTags, filterEventsByWindow, chronoParseDate, parse12HourTime } from "../utils";
 
 // ── Constants ──
 
@@ -271,6 +271,102 @@ export function extractEventsFromDOM(
   return { events, errors };
 }
 
+/**
+ * Parse a date from the /previous/ gallery tile format:
+ *   "Saturday, Apr 4th, 2026 2:45PM"
+ * Strips ordinal suffixes then delegates to chronoParseDate + parse12HourTime.
+ */
+export function parseGalleryDate(text: string): { date: string; startTime?: string } | null {
+  const cleaned = text.replace(/(\d+)(?:st|nd|rd|th)\b/gi, "$1");
+  const date = chronoParseDate(cleaned);
+  if (!date) return null;
+  return { date, startTime: parse12HourTime(cleaned) };
+}
+
+/**
+ * Extract events from the /previous/ page's Harrier Central gallery grid.
+ * Each event is an `<a class="harrier-gallery-tile-link">` with structured
+ * `<p><strong>Label:</strong> Value</p>` fields inside.
+ */
+export function extractEventsFromGallery(
+  $: cheerio.CheerioAPI,
+  sourceUrl: string,
+): { events: RawEventData[]; errors: ParseError[] } {
+  const events: RawEventData[] = [];
+  const errors: ParseError[] = [];
+
+  $(".harrier-gallery-tile-link").each(function (i) {
+    try {
+      const $tile = $(this);
+
+      // Per-event detail URL — preserves same-day event identity for
+      // reconciliation and merge disambiguation. The tile's href is a
+      // relative /rundetail?... path with a publiceventid query param.
+      const tileHref = $tile.attr("href");
+      const eventSourceUrl = tileHref
+        ? new URL(tileHref, "https://ah3.nl").href
+        : sourceUrl;
+
+      // Title from <h3> or image alt
+      const title = $tile.find("h3").first().text().trim()
+        || $tile.find("img").first().attr("alt")?.trim()
+        || undefined;
+
+      // Parse labeled fields from <p><strong>Label:</strong> text</p>
+      const fields = new Map<string, string>();
+      $tile.find("p").each(function () {
+        const label = $(this).find("strong").first().text().replace(/:$/, "").trim().toLowerCase();
+        if (!label) return;
+        // Get text after the <strong> — clone the <p>, remove the <strong>, take remaining text
+        const $p = $(this).clone();
+        $p.find("strong").remove();
+        const value = decodeEntities($p.text()).trim();
+        if (value) fields.set(label, value);
+      });
+
+      // Treat missing required fields as structured parse errors instead of
+      // silent drops — a silent drop from a successful scrape can drive
+      // reconciliation to cancel canonical events it didn't see.
+      if (!title) {
+        errors.push({ row: i, error: "Missing title", rawText: $tile.text().slice(0, 500) });
+        return;
+      }
+      const dateText = fields.get("date");
+      if (!dateText) {
+        errors.push({ row: i, error: `Missing date for "${title}"`, rawText: $tile.text().slice(0, 500) });
+        return;
+      }
+      const dateParsed = parseGalleryDate(dateText);
+      if (!dateParsed) {
+        errors.push({ row: i, error: `Unparseable date: "${dateText}"`, rawText: $tile.text().slice(0, 500) });
+        return;
+      }
+
+      const location = fields.get("location") || undefined;
+      const hares = fields.get("hares") || undefined;
+      const descRaw = fields.get("description") || undefined;
+      const description = descRaw
+        ? stripHtmlTags(decodeEntities(descRaw)).trim() || undefined
+        : undefined;
+
+      events.push({
+        date: dateParsed.date,
+        kennelTag: KENNEL_TAG,
+        title,
+        hares,
+        location,
+        description,
+        startTime: dateParsed.startTime,
+        sourceUrl: eventSourceUrl,
+      });
+    } catch (err) {
+      errors.push({ row: i, error: String(err), rawText: $(this).text().slice(0, 500) });
+    }
+  });
+
+  return { events, errors };
+}
+
 // ── Adapter class ──
 
 export class AH3Adapter implements SourceAdapter {
@@ -316,14 +412,17 @@ export class AH3Adapter implements SourceAdapter {
     }
 
     // ── 2. Fetch previous page ──
+    // The /previous/ page uses a Harrier Central gallery grid (not <hr> sections),
+    // so we use the gallery parser instead of the DOM-based <hr> splitter.
     const previous = await fetchHTMLPage(previousUrl);
     if (previous.ok) {
       totalFetchMs += previous.fetchDurationMs;
 
-      const { events: previousEvents, errors: previousErrors } = extractEventsFromDOM(
-        previous.$,
-        previousUrl,
-      );
+      // Detect which parser to use: gallery grid vs <hr> sections
+      const hasGallery = previous.$(".harrier-gallery-tile-link").length > 0;
+      const { events: previousEvents, errors: previousErrors } = hasGallery
+        ? extractEventsFromGallery(previous.$, previousUrl)
+        : extractEventsFromDOM(previous.$, previousUrl);
 
       for (const ev of previousEvents) {
         if (ev.runNumber && seenRunNumbers.has(ev.runNumber)) continue;


### PR DESCRIPTION
## Summary

Closes #565.

The /previous/ page at ah3.nl uses a Harrier Central gallery grid (63 \`<a class=\"harrier-gallery-tile-link\">\` tiles) instead of the \`<hr>\`-separated sections used by /nextruns/. Each tile has structured HTML:

\`\`\`html
<h3>Title</h3>
<p><strong>Date:</strong> Saturday, Apr 4th, 2026 2:45PM</p>
<p><strong>Location:</strong> Haarlem Railway Station</p>
<p><strong>Hares:</strong> War 'n Piece & MiaB</p>
<p><strong>Description:</strong> ...</p>
\`\`\`

New \`extractEventsFromGallery()\` parser handles ordinal dates (1st/2nd/3rd/4th), AM/PM conversion, double-encoded HTML entities in descriptions, and minimal tiles. The adapter's \`fetch()\` auto-detects which parser to use.

## /simplify finding applied

\`parseGalleryDate\` was reimplementing \`chronoParseDate\` + \`parse12HourTime\` from \`src/adapters/utils.ts\`. Collapsed to 3 lines: strip ordinals → delegate to the existing helpers.

## Codex adversarial findings applied

- **[high]** Gallery events all reused the listing page URL as \`sourceUrl\`, collapsing same-day event identity. Fixed: each tile's per-event \`<a href>\` (which includes a \`publiceventid\`) is resolved to an absolute URL and used as \`sourceUrl\`.
- **[medium]** Missing title/date silently dropped tiles instead of emitting parse errors. Fixed: missing required fields now emit structured parse errors with the tile's raw text, so the health pipeline can flag template drift before reconciliation cancels events.

## Verified against live ah3.nl/previous/

- 63 events parsed, 0 errors
- Date range: Apr 2024 → Apr 2026
- All fields populated where available
- Per-event \`sourceUrl\` confirmed for every tile

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 18/18 ah3 adapter tests passing (6 new: gallery date parsing + gallery extraction)
- [ ] Post-merge: trigger re-scrape to ingest the 63 historical events

🤖 Generated with [Claude Code](https://claude.com/claude-code)