### PR TITLE
fix(audit): Larryville cross-kennel skip + London H3 hares table boundary

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3050,6 +3050,10 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "lh3-ks",
+        // Drop KCH3 events that leak into this calendar. KCH3 has its own
+        // source via HashRego (trust 8). Anchored so joint titles stay put.
+        // Closes #608.
+        skipPatterns: ["^KCH3\\b"],
       },
       kennelCodes: ["lh3-ks"],
     },

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -53,6 +53,9 @@ export function parseRunBlocks(html: string): RunBlock[] {
 
       // Replace <br> with newlines so date/time don't concatenate
       $block.find("br").replaceWith("\n");
+      // Insert newlines at table-cell boundaries so "Who" row value doesn't
+      // run into the "What Else" row label in .text() output. Closes #609.
+      $block.find("td, th").before("\n");
       // Insert space after inline elements to prevent "Name1Name2" concatenation
       $block.find("span, a, strong, em, b, i").after(" ");
       const text = $block.text().trim();


### PR DESCRIPTION
## Summary

Two quick audit fixes using patterns established in prior PRs:

### #608 — Larryville H3 cross-kennel duplicate
KCH3 Red Dress Run appearing under Larryville H3. Added anchored \`skipPattern: ["^KCH3\\b"]\` to the source config + applied to prod via \`jsonb_set\`. KCH3 has its own HashRego source at trust 8. Same pattern as Philly (#582) and Oregon (#584).

### #609 — London H3 hares "Sir HumpalotWhat Else"
Source page uses a table layout where the "Who" (hares) and "What Else" (travel info) rows run together in \`.text()\` output because cheerio flattens \`<td>\` boundaries. Fix: \`$block.find("td, th").before("\\n")\` so the hare regex terminates at the cell edge. Same class of fix as Lion City (#583, \`<p>\` boundaries) and Amsterdam (#559, \`<hr>\` sections).

### #611 — C2H3 semantic title (closed as source data)
The Google Calendar SUMMARY is literally the kennel's tagline — not an extraction bug.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 4351 passing
- [x] Larryville skipPatterns applied to prod via jsonb_set
- [ ] Post-merge: re-scrape Larryville (KCH3 event should be cancelled) + London H3 (hares should be clean)

Closes #608, closes #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)