### PR TITLE
fix(audit): Augusta + Asheville batch (11 issues)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1500,7 +1500,10 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "augh3", shortName: "AUGH3", fullName: "Augusta Underground Hash House Harriers", region: "Augusta, GA",
-      scheduleDayOfWeek: "Saturday", scheduleFrequency: "Biweekly",
+      facebookUrl: "https://www.facebook.com/augustaundergroundH3",
+      contactEmail: "fuzzyundergroundh3@gmail.com",
+      hashCash: "$5",
+      scheduleDayOfWeek: "Saturday", scheduleTime: "2:00 PM", scheduleFrequency: "Biweekly",
       description: "Alternate Saturday runs in the Augusta area.",
     },
     // --- Macon ---

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1062,6 +1062,7 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "avlh3", shortName: "Asheville H3", fullName: "Asheville Hash House Harriers", region: "Asheville, NC",
       website: "https://avlh3.wordpress.com/",
       facebookUrl: "https://www.facebook.com/groups/avlh3/",
+      logoUrl: "https://avlh3.wordpress.com/wp-content/uploads/2019/08/avlh3-logo.jpg",
       contactEmail: "avlh3.mm@gmail.com",
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Weekly", scheduleTime: "2:00 PM",
       hashCash: "$8", foundedYear: 2008,

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1259,7 +1259,7 @@ export const SOURCES = [
     },
     {
       name: "AUGH3 Static Schedule",
-      url: "https://www.facebook.com/groups/augustaundergroundhash",
+      url: "https://www.facebook.com/augustaundergroundH3",
       type: "STATIC_SCHEDULE" as const,
       trustLevel: 3,
       scrapeFreq: "weekly",

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -298,7 +298,7 @@ export function extractTimeFromDescription(description: string): string | undefi
 
 /** Default hare extraction patterns for Google Calendar descriptions. */
 const DEFAULT_HARE_PATTERNS = [
-  /(?:^|\n)[ \t]*Hare(?:\s*&\s*Co-Hares?)?\(?s?\)?:[ \t]*(.+)/im,  // Hare:, Hares:, Hare(s):, Hare & Co-Hares:
+  /(?:^|\n)[ \t]*H{1,3}are(?:\s*&\s*Co-Hares?)?\(?s?\)?:[ \t]*(.+)/im,  // Hare:, Hares:, HHHares: (Asheville's "HHH" = Hash House Harriers convention)
   /(?:^|\n)[ \t]*Who\s*\(?(?:hares?)?\)?:[ \t]*(.+)/im,  // Who:, WHO (hares):, Who(hare):
   /(?:^|\n)[ \t]*Hare[ \t]+([A-Z*].+)/im,  // "Hare C*ck Swap" (no colon, name starts uppercase/special)
 ];


### PR DESCRIPTION
## Summary

Augusta Underground (#645–#648) + Asheville H3 (#619–#626) audit fixes. Adelaide was already merged in PR #650.

### Augusta Underground H3
- **#645**: Fixed broken source URL (dead FB group → active FB page)
- **#646**: Profile enrichment (hash cash \$5, email, Facebook, schedule time)
- **#647**: Closed — STATIC_SCHEDULE placeholders are by design
- **#648**: Closed — no stable logo URL available (Facebook CDN only)

### Asheville H3
- **#623**: Broadened shared \`DEFAULT_HARE_PATTERNS\` from \`Hare\` → \`H{1,3}are\` so Asheville's "HHHARES:" convention (triple-H = Hash House Harriers) is matched
- **#620**: Logo URL from WordPress site
- **#619**: Missing event was scrape timing — now present
- **#621/#624/#625/#626**: Closed as schema gaps, source coverage, or already-populated
- **#622**: Historical backfill commented — will trigger wide-window scrape post-merge

All profile SQL already applied to prod. 4351 tests passing.

Closes #619, #620, #621, #623, #624, #625, #626, #645, #646, #647, #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)