### PR TITLE
feat: Thailand Phase 1a — 4 kennels (Cha-Am + BSSH3 + Chiang Rai + Bangkok Harriettes)

### DIFF
--- a/docs/kennel-research/thailand-research.md
+++ b/docs/kennel-research/thailand-research.md
@@ -1,0 +1,373 @@
+# Thailand Kennel Research
+
+**Researched:** 2026-04-08
+
+## Why Thailand matters
+
+Thailand is one of the **densest hashing scenes in Asia** and one of the oldest outside the founding countries. Bangkok H3 was founded on **11 June 1977** -- just 15 years after Singapore's Father Hash (HHHS, 1962) and 39 years after Mother Hash (KL, 1938). The genealogy project lists **34 active kennels** across the country, making Thailand comparable to the entire US East Coast in hashing density.
+
+Bangkok alone has **7+ weekly/regular kennels** covering Monday through Sunday. A Bangkok-based hasher can run every day of the week with a different kennel. Pattaya (100 km southeast) has a massive expat scene with 5+ kennels. Chiang Mai has 4-5 active kennels. Phuket has 4+ including specialty hashes. Smaller scenes exist in Hua Hin/Cha-Am, Koh Samui, Chiang Rai, Songkhla, Korat, and Ubon.
+
+The Thai hashing scene is almost entirely **expat-driven** with English as the primary language for all kennel communications and websites. Run numbers in the 2000s+ reflect decades of continuous weekly activity (e.g., Bangkok Monday H3 is at run #2207, Bangkok Harriettes at #2259, Phuket H3 at #2061).
+
+Thailand is NOT a city-state -- it needs **country + metro-level regions**: Thailand (country), Bangkok, Pattaya, Chiang Mai, Phuket, plus potential Hua Hin and Koh Samui metros.
+
+## Existing Coverage
+
+**None.** Thailand has zero kennels in `prisma/seed-data/kennels.ts`, zero in the production DB. No `Thailand` region exists in `src/lib/region.ts`.
+
+## Aggregator Sources Found
+
+| Aggregator | Coverage | Usable? |
+|---|---|---|
+| **Harrier Central API** (`hashruns.org`) | **0 Thai kennels** -- API does not cover Thailand | No |
+| **HashRego** (`hashrego.com/events`) | **0 Thai events** in live index | No |
+| **Meetup** | **1 group found**: "Bangkok Weekend Walk and Run Adventure Group" (BSSH3, 767 members, monthly Saturday). `bangkok-hash` group returns 404 (deleted). | Yes (1 kennel) |
+| **Half-Mind.com** | USA/Americas only. Does not track Asia. | No |
+| **hashhouseharriers.nl** | Europe only | No |
+| **genealogy.gotothehash.net** (`?r=chapters/list&country=Thailand`) | **62 kennel records** (34 active, 28 inactive). Extremely rich: aliases, founding dates, founders, parent hash lineage, runner type, schedules. | Metadata only |
+| **china.hash.cn** / **hashchina.wordpress.com** | Thailand not covered (China/HK/Macau only) | No |
+| **gotothehash.net** | Main site defunct | No |
+| **goHash.App** | No Thai kennels found (Malaysia/SG focus) | No |
+| **bangkokhash.com** | **Bangkok hub site** -- lists 10 Bangkok-area kennels with links. Hosts Thursday Hash, Full Moon Hash, and Siam Sunday subpages (all Joomla CMS). | Hub/metadata |
+| **chiangmaihhh.com** | **Chiang Mai hub** -- WordPress aggregator covering 4-5 CM kennels with hareline pages. Site currently returning ECONNREFUSED. | Hub (down) |
+| **bangkokmondayhhh.com/HashLinks.html** | **Thai kennel directory** -- comprehensive link list covering Bangkok, Pattaya, Phuket, Chiang Mai, Hua Hin, Songkhla. | Metadata only |
+
+## New Kennels Discovered
+
+### Bangkok (10 kennels)
+
+| # | Kennel | Day | Status | Tier | Best Source | Source URL/Notes | Founded |
+|---|--------|-----|--------|------|-------------|------------------|---------|
+| 1 | **Bangkok Monday H3** | Mon | ACTIVE | Tier 2 | HTML_SCRAPER | `bangkokmondayhhh.com` -- custom HTML site. Hareline table with run #2207+, dates through Jul 2026. Columns: Run#, Date, Hare, Location. Has Google Maps links per run. No calendar/iCal. | 8 Mar 1982 |
+| 2 | **Bangkok H3 (BH3)** | Sat | ACTIVE | Tier 2 (Wix SPA) | HTML_SCRAPER (browser-render) | `bangkokhhh.org` -- Wix SPA. Men only. Founded 1977 -- oldest Thai kennel. Needs headless browser. Parent of most Thai kennels. | 11 Jun 1977 |
+| 3 | **Bangkok Harriettes** | Wed | ACTIVE | Tier 1 | WordPress.com Public API | `bangkokharriettes.wordpress.com` -- WP.com hosted. **API confirmed working** (`public-api.wordpress.com/rest/v1.1/sites/bangkokharriettes.wordpress.com/posts/`). Only 3 posts (Hareline, Welcome, Next Run) but Hareline post contains full schedule. Run #2259. Mixed. | 17 Mar 1982 |
+| 4 | **Bangkok Thursday H3** | Thu | ACTIVE | Tier 2 | HTML_SCRAPER | `bangkokhash.com/thursday/` -- Joomla CMS. Run #518. Starts 6:30 PM near BTS/MRT stations. Skips full moon weeks. Run fee 50 baht. Flashlights required. | 19 Jul 2012 |
+| 5 | **Bangkok Full Moon H3** | Full Moon Fri | ACTIVE | Tier 2 | HTML_SCRAPER | `bangkokhash.com/fullmoon/` -- Joomla CMS. Run #255. Monthly on Friday nearest full moon, 6:30 PM. Run fee 60 baht. Near BTS/MRT. | 31 May 2004 |
+| 6 | **Siam Sunday H3** | 2nd/4th Sun | ACTIVE | Tier 2 | HTML_SCRAPER | `bangkokhash.com/siamsunday/` -- Joomla CMS. Run #653. Biweekly Sunday at 4:30 PM. Active committee, detailed run descriptions. | 14 Dec 1997 |
+| 7 | **Bangkok Sabai Saturday H3 (BSSH3)** | Monthly Sat | ACTIVE | Tier 1 | MEETUP | `meetup.com/bangkok-weekend-walk-run-adventure-group/` -- 767 members. Monthly Saturday at 2:45 PM near On Nut BTS. Also has own website `bangkoksaturdayhash.com` (JS-heavy, content not extractable). | Recent (est. ~2023) |
+| 8 | **Bangkok HH Bikers (BHHB)** | Monthly | ACTIVE | Tier 3 | STATIC_SCHEDULE | `bangkokbikehash.org` -- Monthly mountain bike hash, 40-50km rides. Weekend overnight trips. Facebook-primary. Founded 1992. Run #400+. | 30 Jun 1992 |
+| 9 | **Bangkok Bush H3** | By exception | ACTIVE | Skip | -- | `bangkokbushhash.com` -- Wix SPA. 3-4 times per year. Too infrequent for regular scraping. | Unknown |
+| 10 | **Bangkok Leap Day H3** | Quadrennial | ACTIVE | Skip | -- | Only runs Feb 29. Inaugural run 2024. Novelty kennel. | 29 Feb 2024 |
+
+### Pattaya (5 kennels)
+
+| # | Kennel | Day | Status | Tier | Best Source | Source URL/Notes | Founded |
+|---|--------|-----|--------|------|-------------|------------------|---------|
+| 11 | **Pattaya H3** | Mon | ACTIVE | Tier 2 | HTML_SCRAPER | `pattayah3.com` -- PHP-based site. Run #2145+. Weekly Monday, bus departs 3:00 PM from Buffalo Bar. Male 400 baht, female 150 baht. Has hasher directory, run stats, comprehensive archive. | 7 Jan 1984 |
+| 12 | **Pattaya Jungle H3** | Sat biweekly | ACTIVE | Tier 1 | WordPress REST API | `pattayajungle.com` -- WordPress. **wp-json API confirmed working.** Run #562+. Biweekly Saturday. Rich event calendar with special events. Some spam posts mixed in. | 11 May 2003 |
+| 13 | **Pattaya Monkey H3** | Sat bimonthly | ACTIVE | Tier 2 | HTML_SCRAPER | `pattayamonkeyh3.com` -- WordPress but wp-json returns 404 (API disabled). Bimonthly Saturday with occasional outstations. | 4 Oct 2005 |
+| 14 | **Pattaya Dirt Road H3** | By invitation | ACTIVE | Skip | -- | Men only, by invitation. No regular public schedule. | 30 Jun 1984 |
+| 15 | **Pattaya Jungle Irregular Lunar H3** | Irregular | ACTIVE | Skip | -- | Irregular, by occasion. Too infrequent. | 26 May 2005 |
+
+### Chiang Mai (5 kennels)
+
+| # | Kennel | Day | Status | Tier | Best Source | Source URL/Notes | Founded |
+|---|--------|-----|--------|------|-------------|------------------|---------|
+| 16 | **Chiang Mai H3 (CH3)** | Mon | ACTIVE | Tier 2 | HTML_SCRAPER | `chiangmaihhh.com/chhh/` -- WordPress aggregator site (currently ECONNREFUSED). Men only. Monday 4:30 PM, bus from McDonald's Thapae Gate. Oldest CM kennel. | 25 May 1981 |
+| 17 | **Chiang Mai Gentlemen's H3 (CGH3)** | Mon | ACTIVE | Tier 2 | HTML_SCRAPER | `chiangmaihhh.com` subpage -- WordPress. Men only. Monday 4:30 PM, bus from Loi Kroh Soi 3. BYO hash. Founded 2020 as spinoff of CH3. | 26 Oct 2020 |
+| 18 | **Chiang Mai Happy H3 (CH4)** | Thu | ACTIVE | Tier 2 | HTML_SCRAPER | `chiangmaihhh.com` subpage -- WordPress. Mixed. Thursday 4:30 PM, bus from McDonald's Thapae Gate. | 22 May 2004 |
+| 19 | **Chiang Mai Saturday H3 (CSH3)** | Sat | ACTIVE | Tier 2 | HTML_SCRAPER | `chiangmaihhh.com/csh3/` -- WordPress. Mixed. Saturday 4:30 PM, bus from McDonald's Thapae Gate. | 16 Apr 1991 |
+| 20 | **Chiang Mai Bunny H3 (CBH3)** | Last Tue monthly | ACTIVE | Tier 2 | HTML_SCRAPER | `chiangmaihhh.com/cbh3-hareline/` -- WordPress. Women only. Last Tuesday of month. | 24 Nov 2001 |
+
+### Phuket (4 kennels)
+
+| # | Kennel | Day | Status | Tier | Best Source | Source URL/Notes | Founded |
+|---|--------|-----|--------|------|-------------|------------------|---------|
+| 21 | **Phuket H3** | Sat | ACTIVE | Tier 2 | HTML_SCRAPER | `phuket-hhh.com` -- PHP site. Run #2061. Weekly Saturday 4:00 PM. Mixed. 40th anniversary Jun 2026. Has hareline, run stats. Also `phuketh3.com` (40th anniversary registration site). | 14 Jun 1986 |
+| 22 | **Phuket Tin Men H3** | 1st Wed monthly | ACTIVE | Tier 3 | STATIC_SCHEDULE | Men only. First Wednesday monthly. Part of Phuket H3 family. No dedicated website. | 21 May 1990 |
+| 23 | **Iron Pussy H3** | 2nd Wed monthly | ACTIVE | Tier 3 | STATIC_SCHEDULE | Women only. Second Wednesday monthly. Part of Phuket H3 family. | 31 Dec 2003 |
+| 24 | **Phuket Mountain Bike H3** | Monthly Sun | ACTIVE | Tier 3 | STATIC_SCHEDULE | Monthly Sunday bike hash. | 25 Jun 2005 |
+
+### Hua Hin / Cha-Am (3 kennels)
+
+| # | Kennel | Day | Status | Tier | Best Source | Source URL/Notes | Founded |
+|---|--------|-----|--------|------|-------------|------------------|---------|
+| 25 | **Hua Hin H3 / Cha-Am H3** | Alt Sat | ACTIVE | Tier 1 | WordPress REST API | `cah3.net` -- WordPress. **wp-json API confirmed working.** Run #534. Alternate Saturdays between Hua Hin and Cha-Am locations. 100 baht adults / 50 baht kids. Also `h2h3-cah3.weebly.com` (secondary Weebly site). | H2H3: 8 Jul 2000 / CAH3: 13 Aug 2005 |
+| 26 | **Hua Hin Full Moon H3** | Monthly | ACTIVE | Tier 2 | HTML_SCRAPER | `h2fm.site.pro` -- simple site. Monthly run nearest full moon, 5:00 PM. Run #42. 200 baht drinkers / 100 baht non-drinkers. Instagram: @hua_hin_full_moon_hash. | 1 Jun 2022 |
+
+### Koh Samui (1 kennel)
+
+| # | Kennel | Day | Status | Tier | Best Source | Source URL/Notes | Founded |
+|---|--------|-----|--------|------|-------------|------------------|---------|
+| 27 | **Koh Samui H3** | Sat | ACTIVE | Tier 2 | HTML_SCRAPER | `kohsamuihhh.com` -- WordPress (wp-json 404). Registration 3:30 PM, start 4:00 PM. Rotating island locations with GPS coords. | 15 Feb 1997 |
+
+### Chiang Rai (1 kennel)
+
+| # | Kennel | Day | Status | Tier | Best Source | Source URL/Notes | Founded |
+|---|--------|-----|--------|------|-------------|------------------|---------|
+| 28 | **Chiang Rai H3** | 3rd Sat monthly | ACTIVE | Tier 1 | Blogger API | `chiangraihhh.blogspot.com` -- Blogspot. Run #220. Monthly 3rd Saturday 3:00 PM. 100 baht. Active blog with run reports 2007-present. Aliases: "S2ATO - Start Slowly And Taper Off". | 15 Nov 2003 |
+
+### Other Thai Regions (5 kennels)
+
+| # | Kennel | Day | Status | Tier | Best Source | Source URL/Notes | Founded |
+|---|--------|-----|--------|------|-------------|------------------|---------|
+| 29 | **Songkhla H3** | Sat | DORMANT? | Tier 3 | STATIC_SCHEDULE | `songkhlah3.blogspot.com` -- blog closed Jan 2021. Run #2050 was Dec 2020. Saturday 4:30 PM. Moved to Facebook-only. Founded 1981 -- very old kennel. May still be active via FB. | 26 Oct 1981 |
+| 30 | **Korat H3** | Unknown | ACTIVE | Skip | -- | No website found. Genealogy lists as active. Nakhon Ratchasima. Founded 2008. | 1 Jun 2008 |
+| 31 | **Ubon H3** | 1st Sat monthly | ACTIVE | Skip | -- | No website found. First Saturday monthly. | 2 Aug 2008 |
+| 32 | **Hatyai H3** | Unknown | ACTIVE | Skip | -- | No website found. Hat Yai, southern Thailand near Malaysia. | 5 Nov 2000 |
+| 33 | **Nonthaburi H3** | Fri monthly | ACTIVE | Skip | -- | No website found. Men only, by invitation. Bangkok suburb. Monthly Friday. | 28 Feb 2001 |
+| 34 | **Lanna Bush H3** | ~5x/year | ACTIVE | Skip | -- | Northern Thailand bush hash. Men only, by invitation. Too infrequent. | 18 Sep 2011 |
+
+### Additional Bangkok kennels (from bangkokhash.com)
+
+| Kennel | Notes | Status |
+|--------|-------|--------|
+| **Bangkok Angkaan Horny Hares H3** | Listed on bangkokhash.com but no website or details found. "Angkaan" = Tuesday in Thai. Possibly a Tuesday hash. | Unknown -- needs verification |
+| **Thinking Drinking H3** | Event hash only -- runs as prelube to major events. Not a regular kennel. | Skip (event hash) |
+
+### Inactive / Skipped Kennels (28 from genealogy)
+
+| Kennel | Last Activity | Reason for Skip |
+|--------|--------------|-----------------|
+| **Bangkok HH Horrors** | Inactive | Children's hash, no longer active |
+| **Ban Chang Bar Crawlers H3** | Inactive since 2009 | Pattaya spinoff, dead |
+| **Banglamung Bottom Feeders H3** | Inactive | Pattaya spinoff, dead |
+| **Chiang Mai Diamond H3** | Inactive since 2013 | CM spinoff, dead |
+| **Chiang Mai Underground Male H3 (CUM H3)** | Inactive | CM spinoff, dead |
+| **Hatyai Full Moon H3** | Inactive | Hat Yai spinoff, dead |
+| **Hatyai Sunday H3** | Inactive | Hat Yai spinoff, dead |
+| **Hua Cha Pedalars H3** | Inactive | Hua Hin bike hash, dead |
+| **Hua Hin Bush H3** | Inactive since 2022 | Very short-lived |
+| **Hua Hin Monday H3** | Inactive | Hua Hin spinoff, dead |
+| **Isaan H3** | Inactive since 1998 | Northeast Thailand, dead |
+| **Kamala Koba H3** | Inactive | Phuket spinoff, dead |
+| **Khon Kaen H3** | Inactive since 1980 | Very early kennel, long dead |
+| **Korat Knights H3** | Inactive since 2009 | Korat spinoff, dead |
+| **Lampang H3** | Inactive since 1981 | Northern Thailand, long dead |
+| **Pattaya Bush H3** | Inactive since 2000 | Pattaya spinoff, dead |
+| **Pattaya Dirt Bike H3** | Inactive since 1991 | Pattaya bike hash, dead |
+| **Pattaya FM H3** | Inactive since 1989 | Pattaya full moon, dead |
+| **Phitsanuloke-1 H3** | Inactive since 1983 | Central Thailand, dead |
+| **Phitsanuloke-2 H3** | Inactive since 1985 | Central Thailand, dead |
+| **Phuket Island Southern H3 (PISH3)** | Inactive since 2003 | Phuket spinoff, dead |
+| **Phuket Marauders H3** | Inactive since 1988 | Phuket spinoff, dead |
+| **Phuket Pooying Picnic H3** | Potentially active | Listed inactive in genealogy BUT Phuket main site lists "Pooying" runs (Run #414, Apr 12 2026). **May need reclassification.** |
+| **Pooying H3** | Inactive since 1990 | Phuket women's hash, dead |
+| **Sadao H3** | Inactive since 2003 | Southern Thailand, dead |
+| **Ubon Ratchathani H3** | Inactive since 1966 | Vietnam War era, long dead (RAAF personnel) |
+| **Udorn Friday Outback H3** | Inactive since 2000 | Northeast Thailand, dead |
+| **Udorn Saturday H3** | Inactive since 1999 | Northeast Thailand, dead |
+
+**Note on Phuket Pooying:** The genealogy lists this as inactive, but `phuket-hhh.com` shows "Phuket Pooying Picnic Hash Run #414" on April 12, 2026. This appears to be a **revived or still-active sub-hash** under the Phuket H3 umbrella. Should be included as a Phuket kennel if verified.
+
+## Collision Check Results
+
+Checked every proposed kennelCode against `prisma/seed-data/kennels.ts` + `prisma/seed-data/aliases.ts`:
+
+| Proposed Code | Status | Resolution |
+|---|---|---|
+| `bmh3-th` | Needed -- `bmh3` TAKEN (Bushman H3, Chicago + Brass Monkey, Houston) | **Use `bmh3-th` for Bangkok Monday H3** |
+| `bkh3` | FREE | **Use for Bangkok H3 (BH3)** -- avoids `bh3` collision (Buffalo, Boulder) |
+| `bkharriettes` | FREE | **Use for Bangkok Harriettes** |
+| `bth3-bk` | Needed -- `bth3` collision-prone | **Use for Bangkok Thursday H3** |
+| `bkfmh3` | FREE | **Use for Bangkok Full Moon H3** -- avoids `bfmh3` collision (Ben Franklin Mob alias) |
+| `ssh3-th` | Needed -- `ssh3` collision (South Sound H3, WA) | **Use `ssh3-th` for Siam Sunday H3** |
+| `bssh3` | FREE | **Use for Bangkok Sabai Saturday H3** |
+| `bhhb` | FREE | **Use for Bangkok HH Bikers** |
+| `pth3` | FREE | **Use for Pattaya H3** |
+| `pjh3` | FREE | **Use for Pattaya Jungle H3** |
+| `pmh3-pt` | Needed -- `pmh3` collision-prone | **Use for Pattaya Monkey H3** |
+| `cmh3` | FREE but collision-prone | **Use `cmh3-th` for Chiang Mai H3** (avoids future collision) |
+| `cgh3` | FREE | **Use for Chiang Mai Gentlemen's H3** |
+| `ch4-cm` | Needed -- `ch4` collision-prone | **Use for Chiang Mai Happy H3 (CH4)** |
+| `csh3-cm` | Needed -- `csh3` free but ambiguous | **Use for Chiang Mai Saturday H3** |
+| `cbh3` | FREE | **Use for Chiang Mai Bunny H3** |
+| `phuketh3` | FREE | **Use for Phuket H3** |
+| `phtm` | FREE | **Use for Phuket Tin Men H3** |
+| `ironpussy` | FREE | **Use for Iron Pussy H3** |
+| `phmbh3` | FREE | **Use for Phuket Mountain Bike H3** |
+| `h2h3` | FREE | **Use for Hua Hin H3** |
+| `cah3` | FREE | **Use for Cha-Am H3** (or combined with H2H3) |
+| `h2fmh3` | FREE | **Use for Hua Hin Full Moon H3** |
+| `ksh3` | FREE | **Use for Koh Samui H3** |
+| `crh3-th` | Needed -- `crh3` collision-prone | **Use for Chiang Rai H3** |
+| `songkhlah3` | FREE | **Use for Songkhla H3** |
+
+## Recommended Ship List (Phase 1)
+
+**Priority: 15 active kennels with verifiable web sources across 5 metro areas.**
+
+### Tier 1 -- Config-only or existing adapter pattern (4 kennels)
+
+| Kennel | Adapter | Notes |
+|--------|---------|-------|
+| **Bangkok Harriettes** (Wed) | WordPress.com Public API | API confirmed working. Only 3 posts but Hareline post has full schedule. Same pattern as Cape Fear adapter. Run #2259. |
+| **Pattaya Jungle H3** (Sat biweekly) | WordPress REST API | wp-json API confirmed. Run #562+. Some spam posts -- needs title/category filtering. |
+| **Cha-Am H3** (Alt Sat) | WordPress REST API | wp-json API confirmed. Run posts with rich location data + GPS coords. Run #534. Also covers Hua Hin H3. |
+| **BSSH3** (Monthly Sat) | MEETUP | `groupUrlname: "bangkok-weekend-walk-run-adventure-group"`. 767 members. Monthly Saturday at On Nut BTS. |
+
+### Tier 1.5 -- Existing adapter pattern, needs verification (1 kennel)
+
+| Kennel | Adapter | Notes |
+|--------|---------|-------|
+| **Chiang Rai H3** (3rd Sat monthly) | Blogger API | Blogspot blog with 17+ years of posts. Needs Blogger blog ID discovery. Run #220. |
+
+### Tier 2 -- Needs adapter code (7 kennels)
+
+| Kennel | Adapter | Notes |
+|--------|---------|-------|
+| **Bangkok Monday H3** (Mon) | HTML_SCRAPER | Custom HTML hareline table. Clean format: Run#, Date, Hare, Location + Google Maps links. 6+ months of future runs. Simple Cheerio scraper. |
+| **Bangkok Thursday H3** (Thu) | HTML_SCRAPER | Joomla CMS at `bangkokhash.com/thursday/`. Run #518. Structured run details. |
+| **Bangkok Full Moon H3** (Full Moon Fri) | HTML_SCRAPER | Joomla CMS at `bangkokhash.com/fullmoon/`. Run #255. |
+| **Siam Sunday H3** (2nd/4th Sun) | HTML_SCRAPER | Joomla CMS at `bangkokhash.com/siamsunday/`. Run #653. |
+| **Pattaya H3** (Mon) | HTML_SCRAPER | PHP site at `pattayah3.com`. Run #2145+. Comprehensive database system. |
+| **Phuket H3** (Sat) | HTML_SCRAPER | PHP site at `phuket-hhh.com`. Run #2061. Hareline + run stats. |
+| **Bangkok H3 (BH3)** (Sat) | HTML_SCRAPER (browser-render) | Wix SPA at `bangkokhhh.org`. Men only. Needs headless browser. Oldest Thai kennel (1977). |
+
+### Tier 3 -- Static schedule / Facebook-only (3 kennels)
+
+| Kennel | Adapter | Notes |
+|--------|---------|-------|
+| **Phuket Tin Men H3** (1st Wed) | STATIC_SCHEDULE | Men only. `FREQ=MONTHLY;BYDAY=1WE`. Part of Phuket family. |
+| **Iron Pussy H3** (2nd Wed) | STATIC_SCHEDULE | Women only. `FREQ=MONTHLY;BYDAY=2WE`. Part of Phuket family. |
+| **Bangkok HH Bikers** (Monthly) | STATIC_SCHEDULE | Monthly weekend bike hash. `FREQ=MONTHLY;BYDAY=1SA` (approx). Facebook-primary. |
+
+### Phase 2 / Deferred
+
+| Kennel | Reason |
+|--------|--------|
+| **Chiang Mai H3** (Mon) | chiangmaihhh.com currently ECONNREFUSED. Defer until site recovers. Could share adapter with CGH3/CH4/CSH3. |
+| **Chiang Mai Gentlemen's H3** (Mon) | Same site, same issue. |
+| **Chiang Mai Happy H3 (CH4)** (Thu) | Same site, same issue. |
+| **Chiang Mai Saturday H3** (Sat) | Same site, same issue. |
+| **Chiang Mai Bunny H3** (Last Tue) | Same site, same issue. |
+| **Koh Samui H3** (Sat) | WordPress but API disabled. Needs HTML scraper for "Next Run" page. Lower priority. |
+| **Pattaya Monkey H3** (Bimonthly Sat) | WordPress but API disabled. Lower frequency. |
+| **Hua Hin Full Moon H3** (Monthly) | Simple site.pro page. Low priority. |
+| **Songkhla H3** (Sat) | Blog closed 2021. May be FB-only now. Needs Facebook verification. |
+| **Phuket Mountain Bike H3** (Monthly Sun) | Low frequency bike hash. |
+| **Hua Hin H3** (Alt Sat with CAH3) | Already covered by CAH3 source -- same kennel pair alternates Saturdays. Model as single combined source with two kennelCodes. |
+
+## Shared Adapter Opportunities
+
+1. **Bangkok Joomla trio** -- Bangkok Thursday H3, Full Moon H3, and Siam Sunday H3 all run on the same Joomla CMS at `bangkokhash.com` with the same URL pattern (`/thursday/`, `/fullmoon/`, `/siamsunday/`). A single adapter with URL-based routing could handle all three. The page structure appears consistent across subdomains.
+
+2. **WordPress REST API** -- Pattaya Jungle H3 and Cha-Am H3 both have confirmed wp-json APIs. Both follow standard WordPress post patterns with run details in post content. Could use the existing WordPress API utility (`fetchWordPressPosts`).
+
+3. **WordPress.com Public API** -- Bangkok Harriettes uses wordpress.com hosting. Same pattern as Cape Fear and N2TH3 (Hong Kong). Uses `fetchWordPressComPage()`.
+
+4. **Chiang Mai WordPress aggregator** -- When chiangmaihhh.com comes back online, ALL 5 Chiang Mai kennels could potentially be scraped from a single WordPress site with kennel-tag routing based on post categories/URL patterns (CGH3, CH3, CH4, CSH3, CBH3).
+
+5. **Blogger API** -- Chiang Rai H3 uses Blogspot, same pattern as Enfield Hash (EH3) and OFH3. Uses `fetchBloggerPosts()`.
+
+## Region Updates Needed
+
+Thailand needs a **COUNTRY-level region** plus metro subdivisions:
+
+```typescript
+// In src/lib/region.ts REGION_SEED_DATA:
+{
+  name: "Thailand",
+  country: "Thailand",
+  level: "COUNTRY",
+  timezone: "Asia/Bangkok",
+  abbrev: "TH",
+  colorClasses: "bg-amber-100 text-amber-700",
+  pinColor: "#d97706",
+  centroidLat: 13.75,
+  centroidLng: 100.50,
+},
+{
+  name: "Bangkok",
+  country: "Thailand",
+  level: "METRO",
+  timezone: "Asia/Bangkok",
+  abbrev: "BKK",
+  colorClasses: "bg-amber-100 text-amber-700",
+  pinColor: "#d97706",
+  centroidLat: 13.76,
+  centroidLng: 100.50,
+  aliases: ["Bangkok, Thailand", "Krung Thep"],
+},
+{
+  name: "Pattaya",
+  country: "Thailand",
+  level: "METRO",
+  timezone: "Asia/Bangkok",
+  abbrev: "PTY",
+  colorClasses: "bg-amber-100 text-amber-700",
+  pinColor: "#d97706",
+  centroidLat: 12.93,
+  centroidLng: 100.88,
+  aliases: ["Pattaya, Thailand", "Chonburi"],
+},
+{
+  name: "Chiang Mai",
+  country: "Thailand",
+  level: "METRO",
+  timezone: "Asia/Bangkok",
+  abbrev: "CNX",
+  colorClasses: "bg-amber-100 text-amber-700",
+  pinColor: "#d97706",
+  centroidLat: 18.79,
+  centroidLng: 98.98,
+  aliases: ["Chiang Mai, Thailand"],
+},
+{
+  name: "Phuket",
+  country: "Thailand",
+  level: "METRO",
+  timezone: "Asia/Bangkok",
+  abbrev: "HKT",
+  colorClasses: "bg-amber-100 text-amber-700",
+  pinColor: "#d97706",
+  centroidLat: 7.88,
+  centroidLng: 98.39,
+  aliases: ["Phuket, Thailand"],
+},
+{
+  name: "Hua Hin",
+  country: "Thailand",
+  level: "METRO",
+  timezone: "Asia/Bangkok",
+  abbrev: "HHN",
+  colorClasses: "bg-amber-100 text-amber-700",
+  pinColor: "#d97706",
+  centroidLat: 12.57,
+  centroidLng: 99.96,
+  aliases: ["Hua Hin, Thailand", "Cha-Am"],
+},
+
+// In COUNTRY_GROUP_MAP (prisma/seed.ts):
+// "Thailand": ["Bangkok", "Pattaya", "Chiang Mai", "Phuket", "Hua Hin"],
+```
+
+Additional metros (Koh Samui, Chiang Rai, Songkhla) can be added in Phase 2 as more kennels are onboarded.
+
+## Open Questions
+
+1. **chiangmaihhh.com status** -- The aggregator WordPress site for all 5 Chiang Mai kennels is returning ECONNREFUSED. Is this temporary downtime or permanent? If the site recovers, all 5 CM kennels could be Tier 1/2 via a single WordPress source. If dead, individual Facebook groups become the fallback. This blocks Phase 1 for Chiang Mai.
+
+2. **Bangkok H3 (bangkokhhh.org) Wix rendering** -- The Saturday men's hash is the oldest Thai kennel (1977) and a high-priority target. It's on Wix, which requires browser-render. Will the NAS headless browser service extract usable hareline data?
+
+3. **Phuket Pooying classification** -- Genealogy lists "Phuket Pooying Picnic H3" as inactive, but Phuket H3's site shows active runs (Run #414, Apr 2026). Is this a revived kennel or a sub-hash of Phuket H3? If active, it should be added (monthly Sunday, family-friendly).
+
+4. **Bangkok Angkaan Horny Hares** -- Listed on bangkokhash.com but no website, schedule details, or web presence found. "Angkaan" = Tuesday in Thai, suggesting it fills the missing Tuesday slot. Needs Facebook verification.
+
+5. **Songkhla H3 activity** -- Blog closed 2021 but kennel founded 1981 with 2050+ runs. Almost certainly still active via Facebook. Worth a STATIC_SCHEDULE with Saturday 4:30 PM if confirmed.
+
+6. **Hua Hin H3 vs Cha-Am H3 modeling** -- These two kennels alternate Saturdays (H2H3 one week, CAH3 the next). The WordPress API at cah3.net covers both. Model as one source with two kennelCodes and `kennelPatterns`, or as two separate kennels sharing a source?
+
+7. **Pattaya H3 scraping complexity** -- pattayah3.com has a PHP database backend with hasher directories, run stats, and comprehensive archives. The hareline data may require navigating dynamic PHP pages. Need to inspect the hareline page structure.
+
+8. **Bangkok Joomla scraping** -- The three kennels on bangkokhash.com all use Joomla CMS. Joomla may have a REST API (similar to WordPress wp-json) that could simplify scraping. Worth checking `/api/` or `/index.php?option=com_content&format=json`.
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| Total kennels discovered | 62 (genealogy) / 34 active |
+| Active kennels with web presence | 28 |
+| Included in research (active + web) | 28 |
+| Tier 1 (config-only / existing adapter) | 4 (Harriettes WP.com, PJH3 WP REST, CAH3 WP REST, BSSH3 Meetup) |
+| Tier 1.5 (existing adapter, needs verification) | 1 (Chiang Rai Blogger) |
+| Tier 2 (needs adapter code) | 12 (BKK Monday, BKK Thursday, BKK FM, Siam Sunday, BH3 Wix, Pattaya H3, Phuket H3, 5x CM if site recovers) |
+| Tier 3 (static schedule) | 3 (Phuket Tin Men, Iron Pussy, BKK Bikers) |
+| Skip (by-invitation / too infrequent / no source) | 8 |
+| Inactive (genealogy) | 28 |
+| Phase 1 recommended | 15 kennels (4 Tier 1 + 1 Tier 1.5 + 7 Tier 2 + 3 Tier 3) |
+| Phase 2 deferred | 10 kennels (5x CM pending site recovery + KS, PM, HFMH3, Songkhla, Phuket MBH3) |
+| New adapter code needed | ~4-5 adapters (BKK Monday HTML, BKK Joomla trio, Pattaya H3 PHP, Phuket H3 PHP, BH3 Wix) |
+| Zero-code sources | 5 (Harriettes WP.com, PJH3 WP REST, CAH3 WP REST, BSSH3 Meetup, Chiang Rai Blogger) |
+| New regions needed | 6 (Thailand country + 5 metros) |

--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -472,5 +472,10 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "hkfh3": ["HKFH3", "HK Full House", "Full House H3", "Hong Kong Full House Hash"],
     "fch3-hk": ["Free China H3", "Free China Hash", "FCH3 HK", "Free China HHH"],
     "hebe-h3": ["Hebe H3", "Hebe Hash", "Hebe HHH", "Hebe Haven Hash"],
+    // Thailand
+    "bssh3": ["BSSH3", "Bangkok Sabai Saturday", "Bangkok Saturday Hash", "Bangkok Weekend Walk Run"],
+    "cah3": ["Cha-Am H3", "Cha-Am Hash", "ChaAm H3", "CAH3", "Cha-Am HHH"],
+    "crh3": ["Chiang Rai H3", "Chiang Rai Hash", "CRH3", "Chiang Rai HHH"],
+    "bkk-harriettes": ["BKK Harriettes", "Bangkok Harriettes", "Bangkok Harriettes H3", "Bangkok Harriets"],
   };
 

--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -474,7 +474,7 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "hebe-h3": ["Hebe H3", "Hebe Hash", "Hebe HHH", "Hebe Haven Hash"],
     // Thailand
     "bssh3": ["BSSH3", "Bangkok Sabai Saturday", "Bangkok Saturday Hash", "Bangkok Weekend Walk Run"],
-    "cah3": ["Cha-Am H3", "Cha-Am Hash", "ChaAm H3", "CAH3", "Cha-Am HHH"],
+    "cah3": ["Cha-Am H3", "Cha-Am Hash", "ChaAm H3", "CAH3", "Cha-Am HHH", "H2H3", "Hua Hin H3", "Hua Hin Hash", "Hua Hin HHH", "H2H3-CAH3"],
     "crh3": ["Chiang Rai H3", "Chiang Rai Hash", "CRH3", "Chiang Rai HHH"],
     "bkk-harriettes": ["BKK Harriettes", "Bangkok Harriettes", "Bangkok Harriettes H3", "Bangkok Harriets"],
   };

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3109,7 +3109,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
       scheduleNotes: "Monthly Saturday runs. Trail details posted on Meetup (Bangkok Weekend Walk Run Adventure Group).",
       description: "Bangkok's Saturday hash, running monthly trails around the city. Active Meetup group with 768+ members.",
-      latitude: 13.76, longitude: 100.50,
+      latitude: 13.76, longitude: 100.5,
     },
     {
       kennelCode: "cah3", shortName: "Cha-Am H3", fullName: "Cha-Am Hash House Harriers",
@@ -3118,7 +3118,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
       scheduleNotes: "Monthly Saturday runs in the Hua Hin / Cha-Am area. Run announcements on cah3.net with run number, date, hares, and location.",
       description: "Cha-Am's monthly hash in the Hua Hin/Prachuap Khiri Khan coastal region. Each run is a WordPress blog post with full details.",
-      latitude: 12.80, longitude: 99.97,
+      latitude: 12.8, longitude: 99.97,
     },
     {
       kennelCode: "crh3", shortName: "Chiang Rai H3", fullName: "Chiang Rai Hash House Harriers",
@@ -3136,7 +3136,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleDayOfWeek: "Wednesday", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Wednesday runs. Blog has only 3 posts (they reuse/overwrite a single 'Next Run' post with updated details).",
       description: "Bangkok's women's hash, running weekly Wednesday trails. One of the longest-running Harriettes chapters in Southeast Asia.",
-      latitude: 13.76, longitude: 100.50,
+      latitude: 13.76, longitude: 100.5,
     },
   ];
 

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3112,12 +3112,12 @@ export const KENNELS: KennelSeed[] = [
       latitude: 13.76, longitude: 100.5,
     },
     {
-      kennelCode: "cah3", shortName: "Cha-Am H3", fullName: "Cha-Am Hash House Harriers",
+      kennelCode: "cah3", shortName: "H2H3 / Cha-Am H3", fullName: "Hua Hin H3 & Cha-Am Hash House Harriers",
       region: "Hua Hin", country: "Thailand",
       website: "https://cah3.net",
-      scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
-      scheduleNotes: "Monthly Saturday runs in the Hua Hin / Cha-Am area. Run announcements on cah3.net with run number, date, hares, and location.",
-      description: "Cha-Am's monthly hash in the Hua Hin/Prachuap Khiri Khan coastal region. Each run is a WordPress blog post with full details.",
+      scheduleDayOfWeek: "Saturday", scheduleFrequency: "Biweekly",
+      scheduleNotes: "Alternating Saturdays between Hua Hin (H2H3, founded 8 Jul 2000) and Cha-Am (CAH3, founded 13 Aug 2005). cah3.net WordPress covers both kennels as one combined feed. 100 baht adults / 50 baht kids.",
+      description: "Combined Hua Hin and Cha-Am hash kennel — two sister organizations that alternate Saturdays in Thailand's Prachuap Khiri Khan coastal region. Modeled as one kennel because the WordPress source at cah3.net publishes both without distinguishing titles. Split into separate kennels requires Chrome-verified title-pattern analysis.",
       latitude: 12.8, longitude: 99.97,
     },
     {

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3100,5 +3100,43 @@ export const KENNELS: KennelSeed[] = [
       description: "Hong Kong's Sai Kung-area hash, founded in 2019. Monthly Saturday afternoon trails in the scenic eastern New Territories.",
       latitude: 22.3813, longitude: 114.2707,
     },
+
+    // ── Thailand ──
+    {
+      kennelCode: "bssh3", shortName: "BSSH3", fullName: "Bangkok Sabai Saturday Hash House Harriers",
+      region: "Bangkok", country: "Thailand",
+      website: "https://bangkoksaturdayhash.com",
+      scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
+      scheduleNotes: "Monthly Saturday runs. Trail details posted on Meetup (Bangkok Weekend Walk Run Adventure Group).",
+      description: "Bangkok's Saturday hash, running monthly trails around the city. Active Meetup group with 768+ members.",
+      latitude: 13.76, longitude: 100.50,
+    },
+    {
+      kennelCode: "cah3", shortName: "Cha-Am H3", fullName: "Cha-Am Hash House Harriers",
+      region: "Hua Hin", country: "Thailand",
+      website: "https://cah3.net",
+      scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
+      scheduleNotes: "Monthly Saturday runs in the Hua Hin / Cha-Am area. Run announcements on cah3.net with run number, date, hares, and location.",
+      description: "Cha-Am's monthly hash in the Hua Hin/Prachuap Khiri Khan coastal region. Each run is a WordPress blog post with full details.",
+      latitude: 12.80, longitude: 99.97,
+    },
+    {
+      kennelCode: "crh3", shortName: "Chiang Rai H3", fullName: "Chiang Rai Hash House Harriers",
+      region: "Chiang Rai", country: "Thailand",
+      website: "https://chiangraihhh.blogspot.com",
+      scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
+      scheduleNotes: "Monthly 3rd Saturday runs. Trail announcements on chiangraihhh.blogspot.com with run number and details.",
+      description: "Chiang Rai's monthly hash in northern Thailand. Blog posts chronicle each run with emojis, freeform details, and run number in titles like 'CRH3#220'.",
+      latitude: 19.91, longitude: 99.83,
+    },
+    {
+      kennelCode: "bkk-harriettes", shortName: "BKK Harriettes", fullName: "Bangkok Harriettes Hash House Harriers",
+      region: "Bangkok", country: "Thailand",
+      website: "https://bangkokharriettes.wordpress.com",
+      scheduleDayOfWeek: "Wednesday", scheduleFrequency: "Weekly",
+      scheduleNotes: "Weekly Wednesday runs. Blog has only 3 posts (they reuse/overwrite a single 'Next Run' post with updated details).",
+      description: "Bangkok's women's hash, running weekly Wednesday trails. One of the longest-running Harriettes chapters in Southeast Asia.",
+      latitude: 13.76, longitude: 100.50,
+    },
   ];
 

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3722,5 +3722,55 @@ export const SOURCES = [
       },
       kennelCodes: ["hebe-h3"],
     },
+
+    // ── Thailand ──
+    // --- BSSH3 (Meetup) ---
+    {
+      name: "BSSH3 Meetup",
+      url: "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/",
+      type: "MEETUP" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 90,
+      config: {
+        groupUrlname: "bangkok-weekend-walk-run-adventure-group",
+        kennelTag: "bssh3",
+      },
+      kennelCodes: ["bssh3"],
+    },
+    // --- Cha-Am H3 (WordPress REST API) ---
+    {
+      name: "Cha-Am H3 Website",
+      url: "https://cah3.net",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 365,
+      config: {},
+      kennelCodes: ["cah3"],
+    },
+    // --- Chiang Rai H3 (Blogger API) ---
+    {
+      name: "Chiang Rai H3 Blog",
+      url: "https://chiangraihhh.blogspot.com",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 365,
+      config: {},
+      kennelCodes: ["crh3"],
+    },
+    // --- Bangkok Harriettes (WordPress.com Public API) ---
+    {
+      name: "Bangkok Harriettes Blog",
+      url: "https://bangkokharriettes.wordpress.com",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 5,
+      scrapeFreq: "daily",
+      scrapeDays: 90,
+      enabled: false,
+      config: {},
+      kennelCodes: ["bkk-harriettes"],
+    },
   ];
 

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3768,7 +3768,6 @@ export const SOURCES = [
       trustLevel: 5,
       scrapeFreq: "daily",
       scrapeDays: 90,
-      enabled: false,
       config: {},
       kennelCodes: ["bkk-harriettes"],
     },

--- a/src/adapters/html-scraper/bkk-harriettes.test.ts
+++ b/src/adapters/html-scraper/bkk-harriettes.test.ts
@@ -1,0 +1,86 @@
+import { parseBkkHarriettesPost } from "./bkk-harriettes";
+import type { WordPressComPage } from "../wordpress-api";
+
+function makePage(overrides: Partial<WordPressComPage> = {}): WordPressComPage {
+  return {
+    ID: 1,
+    title: "Next Run",
+    content: "",
+    URL: "https://bangkokharriettes.wordpress.com/next-run/",
+    date: "2000-01-01T00:00:00", // always hardcoded to 2000
+    modified: "2026-04-01T00:00:00", // last updated with current run details
+    type: "post",
+    slug: "next-run",
+    ...overrides,
+  };
+}
+
+describe("parseBkkHarriettesPost", () => {
+  it("parses the real 'Run no. NNNN on DAY DATE at TIME' format", () => {
+    const post = makePage({
+      content: `
+<div style="border: solid 3px magenta;border-radius: 25px;width: 97%;text-align: left;margin-left: auto;margin-right: auto;padding-left: 20px;padding-top: 20px"><strong>Run no. 2259 on Wednesday 15 April at 17:30</strong><br />
+<strong>Hare:-</strong> Hazukashii<br />
+<strong>Location:- </strong>TBA
+</div>`,
+    });
+    const event = parseBkkHarriettesPost(post);
+    expect(event).not.toBeNull();
+    expect(event?.date).toBe("2026-04-15");
+    expect(event?.kennelTag).toBe("bkk-harriettes");
+    expect(event?.runNumber).toBe(2259);
+    expect(event?.hares).toBe("Hazukashii");
+    // TBA should be excluded
+    expect(event?.location).toBeUndefined();
+    expect(event?.startTime).toBe("17:30");
+  });
+
+  it("parses with a real location (not TBA)", () => {
+    const post = makePage({
+      content: `
+<div><strong>Run no. 2258 on Wednesday 9 April at 17:30</strong><br />
+<strong>Hare:-</strong> Jelly Bean<br />
+<strong>Location:- </strong>Benchasiri Park, Sukhumvit Soi 22
+</div>`,
+    });
+    const event = parseBkkHarriettesPost(post);
+    expect(event).not.toBeNull();
+    expect(event?.location).toBe("Benchasiri Park, Sukhumvit Soi 22");
+    expect(event?.hares).toBe("Jelly Bean");
+  });
+
+  it("returns null when no date can be extracted", () => {
+    const post = makePage({
+      content: "<p>Coming soon...</p>",
+    });
+    const event = parseBkkHarriettesPost(post);
+    expect(event).toBeNull();
+  });
+
+  it("uses default start time when no time in run line", () => {
+    const post = makePage({
+      content: `
+<div><strong>Run no. 2260 on Wednesday 22 April</strong><br />
+<strong>Hare:-</strong> Speedy
+</div>`,
+    });
+    const event = parseBkkHarriettesPost(post);
+    expect(event).not.toBeNull();
+    expect(event?.startTime).toBe("17:30");
+  });
+
+  it("falls back to labeled Date field format", () => {
+    const post = makePage({
+      content: `
+<p><strong>Run Number:</strong> 2150</p>
+<p><strong>Date:</strong> Wednesday 9th April 2025</p>
+<p><strong>Time:</strong> 5:30 PM</p>
+<p><strong>Hare:</strong> Jelly Bean</p>
+<p><strong>Location:</strong> Benchasiri Park</p>
+`,
+    });
+    const event = parseBkkHarriettesPost(post);
+    expect(event).not.toBeNull();
+    expect(event?.date).toBe("2025-04-09");
+  });
+});

--- a/src/adapters/html-scraper/bkk-harriettes.ts
+++ b/src/adapters/html-scraper/bkk-harriettes.ts
@@ -6,9 +6,16 @@ import { fetchWordPressComPosts, type WordPressComPage } from "../wordpress-api"
 import {
   applyDateWindow,
   chronoParseDate,
+  decodeEntities,
   normalizeHaresField,
   parse12HourTime,
 } from "../utils";
+
+/** Parse ISO string as UTC for chrono reference date anchoring. */
+function utcRef(iso: string | undefined): Date | undefined {
+  if (!iso) return undefined;
+  return new Date(iso.endsWith("Z") ? iso : `${iso}Z`);
+}
 
 /**
  * Bangkok Harriettes Hash House Harriers adapter.
@@ -52,10 +59,16 @@ export function parseBkkHarriettesPost(
   post: WordPressComPage,
 ): RawEventData | null {
   const $ = cheerio.load(post.content);
-  const bodyText = $("body").text().trim();
+  const bodyText = decodeEntities($("body").text().trim());
+
+  // Hoist UTC-normalized refDate once — Bangkok Harriettes hardcode
+  // publish dates to 2000-01-01, so use post.modified (reflects when
+  // the "Next Run" post was last updated). UTC normalization avoids
+  // timezone-dependent year shifts around midnight.
+  const refDate = utcRef(post.modified) ?? utcRef(post.date);
 
   // Pattern 1: "Run no. NNNN on Wednesday 15 April at 17:30"
-  const runLineMatch = /Run\s*no\.?\s*(\d+)\s+on\s+(.+?)(?:\s+at\s+(\d{1,2}:\d{2}))?\s*$/im.exec(bodyText);
+  const runLineMatch = /Run\s*no\.?\s*(\d+)\s+on\s+(.+?)(?:\s+at\s+(\d{1,2}:\d{2}))?[.,]?\s*$/im.exec(bodyText);
 
   let date: string | null = null;
   let runNumber: number | undefined;
@@ -64,56 +77,50 @@ export function parseBkkHarriettesPost(
   if (runLineMatch) {
     runNumber = Number.parseInt(runLineMatch[1], 10);
     const dateStr = runLineMatch[2].trim();
-    // Anchor yearless dates to the post's modified timestamp (NOT the
-    // publish date — Bangkok Harriettes hardcode publish dates to
-    // 2000-01-01 because they reuse posts). The modified timestamp
-    // reflects when the "Next Run" post was last updated with new
-    // run details, giving chrono the correct year context.
-    const refDate = post.modified ? new Date(post.modified) : post.date ? new Date(post.date) : undefined;
     date = chronoParseDate(dateStr, "en-GB", refDate, { forwardDate: true });
     if (runLineMatch[3]) {
       const parsed = parse12HourTime(runLineMatch[3]);
       if (parsed) startTime = parsed;
-      else startTime = runLineMatch[3]; // already HH:MM
+      else if (/^\d{1,2}:\d{2}$/.test(runLineMatch[3].trim())) startTime = runLineMatch[3].trim();
     }
   }
 
   // Pattern 2: labeled "Date:" field (fallback for alternate format)
   if (!date) {
-    const dateMatch = /(?:^|\b)Date\s*[:\-]+\s*(.+?)(?:\n|$)/im.exec(bodyText);
+    const dateMatch = /(?:^|\b)Date\s*[:-]+\s*(.+?)(?:\n|$)/im.exec(bodyText);
     if (dateMatch) {
-      const refDate = post.modified ? new Date(post.modified) : post.date ? new Date(post.date) : undefined;
       date = chronoParseDate(dateMatch[1], "en-GB", refDate, { forwardDate: true });
     }
   }
 
   // Pattern 3: labeled "Run Number:" field (fallback)
   if (!runNumber) {
-    const numMatch = /Run\s*(?:Number|No|#)\s*[:\-]+\s*(\d+)/i.exec(bodyText);
+    const numMatch = /Run\s*(?:Number|No|#)\s*[:-]+\s*(\d+)/i.exec(bodyText);
     if (numMatch) runNumber = Number.parseInt(numMatch[1], 10);
   }
 
-  // Fallback: scan full body for any date
+  // Fallback: scan full body for any date — still anchor to refDate
   if (!date) {
-    date = chronoParseDate(bodyText, "en-GB");
+    date = chronoParseDate(bodyText, "en-GB", refDate, { forwardDate: true });
   }
   if (!date) return null;
 
   // Extract labeled fields: "Hare:-" and "Location:-"
-  const hareMatch = /Hares?\s*[:\-]+\s*(.+?)(?=\n|Location|$)/i.exec(bodyText);
+  const hareMatch = /Hares?\s*[:-]+\s*(.+?)(?=\n|Location|$)/i.exec(bodyText);
   const hares = hareMatch?.[1].trim() || undefined;
 
-  const locationMatch = /Location\s*[:\-]+\s*(.+?)(?=\n|Hare|$)/i.exec(bodyText);
+  const locationMatch = /Location\s*[:-]+\s*(.+?)(?=\n|Hare|$)/i.exec(bodyText);
   const locationRaw = locationMatch?.[1].trim() || undefined;
-  // Skip TBA/TBD locations
   const location = locationRaw && !/^tba|^tbd/i.test(locationRaw) ? locationRaw : undefined;
 
   // Time from labeled field (fallback if not in run line)
   if (startTime === DEFAULT_START_TIME) {
-    const timeMatch = /Time\s*[:\-]+\s*(.+?)(?:\n|$)/i.exec(bodyText);
+    const timeMatch = /Time\s*[:-]+\s*(.+?)(?:\n|$)/i.exec(bodyText);
     if (timeMatch) {
-      const parsed = parse12HourTime(timeMatch[1].replace(/\./g, ""));
+      const timeStr = timeMatch[1].replaceAll(".", "").trim();
+      const parsed = parse12HourTime(timeStr);
       if (parsed) startTime = parsed;
+      else if (/^\d{1,2}:\d{2}$/.test(timeStr)) startTime = timeStr;
     }
   }
 

--- a/src/adapters/html-scraper/bkk-harriettes.ts
+++ b/src/adapters/html-scraper/bkk-harriettes.ts
@@ -1,0 +1,195 @@
+import * as cheerio from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
+import { hasAnyErrors } from "../types";
+import { fetchWordPressComPosts, type WordPressComPage } from "../wordpress-api";
+import {
+  applyDateWindow,
+  chronoParseDate,
+  normalizeHaresField,
+  parse12HourTime,
+} from "../utils";
+
+/**
+ * Bangkok Harriettes Hash House Harriers adapter.
+ *
+ * bangkokharriettes.wordpress.com is a WordPress.com hosted blog. Unlike most
+ * hash blogs where each post is a separate run, Bangkok Harriettes reuses only
+ * 3 posts total — they overwrite a single "Next Run" post with updated details.
+ * As a result:
+ *   - Post publish dates (2000-01-01) are meaningless
+ *   - The real date must be parsed from the post body
+ *   - Only the most recent body content matters
+ *
+ * Body fields (in `<strong>` labeled format):
+ *   Run Number: <N>
+ *   Date: <date>
+ *   Time: <time>
+ *   Hare: <names>
+ *   Location: <place>
+ *
+ * Weekly Wednesday runs.
+ */
+
+const SITE_DOMAIN = "bangkokharriettes.wordpress.com";
+const KENNEL_TAG = "bkk-harriettes";
+const DEFAULT_START_TIME = "17:30"; // typical Wednesday afternoon
+
+/**
+ * Parse a Bangkok Harriettes post into RawEventData.
+ *
+ * The blog has only 3 posts that get reused. The "Next Run" post body is:
+ *   `<strong>Run no. 2259 on Wednesday 15 April at 17:30</strong><br />
+ *    <strong>Hare:-</strong> Hazukashii<br />
+ *    <strong>Location:- </strong>TBA`
+ *
+ * The "Run no. NNNN on DAY DATE at TIME" line embeds run#, date, and time.
+ * Hare and Location use `:-` as separator.
+ *
+ * Exported for unit testing.
+ */
+export function parseBkkHarriettesPost(
+  post: WordPressComPage,
+): RawEventData | null {
+  const $ = cheerio.load(post.content);
+  const bodyText = $("body").text().trim();
+
+  // Pattern 1: "Run no. NNNN on Wednesday 15 April at 17:30"
+  const runLineMatch = /Run\s*no\.?\s*(\d+)\s+on\s+(.+?)(?:\s+at\s+(\d{1,2}:\d{2}))?\s*$/im.exec(bodyText);
+
+  let date: string | null = null;
+  let runNumber: number | undefined;
+  let startTime = DEFAULT_START_TIME;
+
+  if (runLineMatch) {
+    runNumber = Number.parseInt(runLineMatch[1], 10);
+    const dateStr = runLineMatch[2].trim();
+    // Anchor yearless dates to the post's modified timestamp (NOT the
+    // publish date — Bangkok Harriettes hardcode publish dates to
+    // 2000-01-01 because they reuse posts). The modified timestamp
+    // reflects when the "Next Run" post was last updated with new
+    // run details, giving chrono the correct year context.
+    const refDate = post.modified ? new Date(post.modified) : post.date ? new Date(post.date) : undefined;
+    date = chronoParseDate(dateStr, "en-GB", refDate, { forwardDate: true });
+    if (runLineMatch[3]) {
+      const parsed = parse12HourTime(runLineMatch[3]);
+      if (parsed) startTime = parsed;
+      else startTime = runLineMatch[3]; // already HH:MM
+    }
+  }
+
+  // Pattern 2: labeled "Date:" field (fallback for alternate format)
+  if (!date) {
+    const dateMatch = /(?:^|\b)Date\s*[:\-]+\s*(.+?)(?:\n|$)/im.exec(bodyText);
+    if (dateMatch) {
+      const refDate = post.modified ? new Date(post.modified) : post.date ? new Date(post.date) : undefined;
+      date = chronoParseDate(dateMatch[1], "en-GB", refDate, { forwardDate: true });
+    }
+  }
+
+  // Pattern 3: labeled "Run Number:" field (fallback)
+  if (!runNumber) {
+    const numMatch = /Run\s*(?:Number|No|#)\s*[:\-]+\s*(\d+)/i.exec(bodyText);
+    if (numMatch) runNumber = Number.parseInt(numMatch[1], 10);
+  }
+
+  // Fallback: scan full body for any date
+  if (!date) {
+    date = chronoParseDate(bodyText, "en-GB");
+  }
+  if (!date) return null;
+
+  // Extract labeled fields: "Hare:-" and "Location:-"
+  const hareMatch = /Hares?\s*[:\-]+\s*(.+?)(?=\n|Location|$)/i.exec(bodyText);
+  const hares = hareMatch?.[1].trim() || undefined;
+
+  const locationMatch = /Location\s*[:\-]+\s*(.+?)(?=\n|Hare|$)/i.exec(bodyText);
+  const locationRaw = locationMatch?.[1].trim() || undefined;
+  // Skip TBA/TBD locations
+  const location = locationRaw && !/^tba|^tbd/i.test(locationRaw) ? locationRaw : undefined;
+
+  // Time from labeled field (fallback if not in run line)
+  if (startTime === DEFAULT_START_TIME) {
+    const timeMatch = /Time\s*[:\-]+\s*(.+?)(?:\n|$)/i.exec(bodyText);
+    if (timeMatch) {
+      const parsed = parse12HourTime(timeMatch[1].replace(/\./g, ""));
+      if (parsed) startTime = parsed;
+    }
+  }
+
+  return {
+    date,
+    kennelTag: KENNEL_TAG,
+    runNumber,
+    hares: normalizeHaresField(hares),
+    location,
+    startTime,
+    sourceUrl: post.URL,
+  };
+}
+
+export class BkkHarriettesAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(
+    source: Source,
+    options?: { days?: number },
+  ): Promise<ScrapeResult> {
+    const fetchStart = Date.now();
+
+    // Bangkok Harriettes only maintain ~3 reused posts (they overwrite a
+    // single "Next Run" post instead of creating new ones). Filter to only
+    // posts whose title/content contains "Run" to skip the static hareline
+    // and info pages that would create stale duplicate events.
+    const { posts: allPosts, error } = await fetchWordPressComPosts(
+      SITE_DOMAIN,
+      { number: 5, search: "Run" },
+    );
+    const posts = allPosts.filter((p) => /run\s*(?:no|#|number)?\s*\.?\s*\d/i.test(p.title + " " + p.content));
+
+    if (error) {
+      const errorDetails: ErrorDetails = {
+        fetch: [{ url: `public-api.wordpress.com/.../sites/${SITE_DOMAIN}/posts/`, message: error.message, status: error.status }],
+      };
+      return { events: [], errors: [error.message], errorDetails };
+    }
+
+    const events: RawEventData[] = [];
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    for (const post of posts) {
+      try {
+        const event = parseBkkHarriettesPost(post);
+        if (event) {
+          events.push(event);
+        }
+      } catch (err) {
+        errors.push(`Error parsing post "${post.title}": ${err}`);
+        errorDetails.parse = [
+          ...(errorDetails.parse ?? []),
+          { row: post.ID, error: String(err), rawText: post.title.slice(0, 200) },
+        ];
+      }
+    }
+
+    const fetchDurationMs = Date.now() - fetchStart;
+
+    const days = options?.days ?? source.scrapeDays ?? 90;
+    return applyDateWindow(
+      {
+        events,
+        errors,
+        errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+        diagnosticContext: {
+          fetchMethod: "wordpress-com-api",
+          postsFound: allPosts.length,
+          postsFetched: posts.length,
+          eventsParsed: events.length,
+          fetchDurationMs,
+        },
+      },
+      days,
+    );
+  }
+}

--- a/src/adapters/html-scraper/cah3.test.ts
+++ b/src/adapters/html-scraper/cah3.test.ts
@@ -1,0 +1,117 @@
+import { parseCah3Title, parseCah3Body, parseCah3Post } from "./cah3";
+
+describe("parseCah3Title", () => {
+  it("parses run number and date from a typical title", () => {
+    const result = parseCah3Title(
+      "Run 533 Saturday 8th March 2025",
+      "2025-03-01T00:00:00",
+    );
+    expect(result.runNumber).toBe(533);
+    expect(result.date).toBe("2025-03-08");
+  });
+
+  it("parses colon-separated title", () => {
+    const result = parseCah3Title(
+      "Run 534: Songkran Outstation APR 10 & 11",
+      "2025-04-01T00:00:00",
+    );
+    expect(result.runNumber).toBe(534);
+    // Should at least get the first date
+    expect(result.date).toBe("2025-04-10");
+  });
+
+  it("parses title with month name and year", () => {
+    const result = parseCah3Title(
+      "Run 532 Saturday February 8 2025",
+      "2025-01-15T00:00:00",
+    );
+    expect(result.runNumber).toBe(532);
+    expect(result.date).toBe("2025-02-08");
+  });
+
+  it("returns undefined date when no date in title", () => {
+    const result = parseCah3Title(
+      "Run 530 Special Event",
+      "2025-01-01T00:00:00",
+    );
+    expect(result.runNumber).toBe(530);
+    expect(result.date).toBeUndefined();
+  });
+});
+
+describe("parseCah3Body", () => {
+  it("extracts labeled fields from body HTML", () => {
+    const body = `
+<p>Hare: Rusty Nail</p>
+<p>Location: Cha-Am Beach Park</p>
+<p>Time: 4:00 PM</p>
+`;
+    const result = parseCah3Body(body);
+    expect(result.hares).toBe("Rusty Nail");
+    expect(result.location).toBe("Cha-Am Beach Park");
+    expect(result.startTime).toBe("16:00");
+  });
+
+  it("returns undefined for missing fields", () => {
+    const body = "<p>Just some random post content</p>";
+    const result = parseCah3Body(body);
+    expect(result.hares).toBeUndefined();
+    expect(result.location).toBeUndefined();
+    expect(result.startTime).toBeUndefined();
+  });
+});
+
+describe("parseCah3Post", () => {
+  it("parses a complete post", () => {
+    const result = parseCah3Post({
+      title: "Run 533 Saturday 8th March 2025",
+      content: "<p>Hare: Rusty Nail</p><p>Location: Cha-Am Beach</p>",
+      url: "https://cah3.net/?p=123",
+      date: "2025-03-01T00:00:00",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.event.date).toBe("2025-03-08");
+      expect(result.event.kennelTag).toBe("cah3");
+      expect(result.event.runNumber).toBe(533);
+      expect(result.event.hares).toBe("Rusty Nail");
+      expect(result.event.location).toBe("Cha-Am Beach");
+      expect(result.event.sourceUrl).toBe("https://cah3.net/?p=123");
+    }
+  });
+
+  it("filters non-run posts", () => {
+    const result = parseCah3Post({
+      title: "Welcome to Cha-Am H3",
+      content: "<p>About us</p>",
+      url: "https://cah3.net/?p=1",
+      date: "2025-01-01T00:00:00",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not-run-post");
+  });
+
+  it("returns no-date when title and body both lack a parseable date", () => {
+    const result = parseCah3Post({
+      title: "Run 533: Saurkrap's Cat Sanctuary Run",
+      content: "<p>Some directions without a date</p>",
+      url: "https://cah3.net/?p=456",
+      date: "2026-03-16T12:40:57",
+    });
+    // Do NOT fall back to the WordPress publish date — it's the
+    // announcement date and may be days before the actual Saturday run.
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("no-date");
+  });
+
+  it("uses default start time when body has no time", () => {
+    const result = parseCah3Post({
+      title: "Run 533 Saturday 8th March 2025",
+      content: "<p>Hare: Rusty Nail</p>",
+      url: "https://cah3.net/?p=123",
+      date: "2025-03-01T00:00:00",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.event.startTime).toBe("16:00");
+  });
+});

--- a/src/adapters/html-scraper/cah3.ts
+++ b/src/adapters/html-scraper/cah3.ts
@@ -11,6 +11,12 @@ import {
   stripHtmlTags,
 } from "../utils";
 
+/** Parse ISO string as UTC for chrono reference date anchoring. */
+function utcRef(iso: string | undefined): Date | undefined {
+  if (!iso) return undefined;
+  return new Date(iso.endsWith("Z") ? iso : `${iso}Z`);
+}
+
 /**
  * Cha-Am Hash House Harriers (CAH3) adapter.
  *
@@ -50,7 +56,7 @@ export function parseCah3Title(title: string, publishDateIso: string): {
   const stripped = decoded.replace(/^Run\s*#?\s*\d+\s*[:\-–]?\s*/i, "").trim();
 
   // Parse date from the remaining title text using the publish date as reference
-  const refDate = new Date(publishDateIso);
+  const refDate = utcRef(publishDateIso);
   const date = chronoParseDate(stripped, "en-GB", refDate, { forwardDate: true })
     ?? chronoParseDate(decoded, "en-GB", refDate, { forwardDate: true });
 
@@ -71,7 +77,7 @@ export function parseCah3Body(bodyHtml: string): {
   startTime?: string;
   date?: string;
 } {
-  const text = stripHtmlTags(bodyHtml, "\n");
+  const text = decodeEntities(stripHtmlTags(bodyHtml, "\n"));
   const labels = "(?:Hares?|Location|Time|Date|Start|Run\\s*Site|On\\s*After|Meeting\\s*Point)";
   const stop = `(?=\\n|${labels}\\s*:|$)`;
 
@@ -89,7 +95,9 @@ export function parseCah3Body(bodyHtml: string): {
   let startTime: string | undefined;
   if (timeRaw) {
     const normalized = timeRaw.replace(/a\.m\./gi, "am").replace(/p\.m\./gi, "pm");
-    startTime = parse12HourTime(normalized);
+    const parsed = parse12HourTime(normalized);
+    if (parsed) startTime = parsed;
+    else if (/^\d{1,2}:\d{2}$/.test(normalized.trim())) startTime = normalized.trim();
   }
 
   const dateRaw = grab("Date");
@@ -115,10 +123,10 @@ export type ParseCah3PostResult =
  * Parse a single CAH3 WordPress post into RawEventData.
  *
  * CAH3 posts often don't have a date in the title (e.g. "Run 533: Saurkrap's
- * Cat Sanctuary Run") or body. The WordPress publish date IS the run
- * announcement date and is typically within a few days of the actual run.
- * When no date can be parsed from title or body, we fall back to the post's
- * publish date.
+ * Cat Sanctuary Run") or body. When no date can be parsed from title or body,
+ * the post is skipped (returns `no-date`) rather than using the WordPress
+ * publish date, which is the announcement date and may be several days
+ * before the actual Saturday run.
  *
  * Exported for unit testing.
  */
@@ -139,7 +147,7 @@ export function parseCah3Post(post: Cah3PostInput): ParseCah3PostResult {
   if (!date) return { ok: false, reason: "no-date", title: rawTitle };
 
   // Try to extract a Google Maps link from the body as locationUrl
-  const mapsMatch = /href="(https?:\/\/(?:maps\.app\.goo\.gl|(?:www\.)?google\.com\/maps)[^"]+)"/i.exec(post.content);
+  const mapsMatch = /href=["']?(https?:\/\/(?:maps\.app\.goo\.gl|(?:www\.)?google\.com\/maps)[^"'\s>]+)/i.exec(post.content);
   const locationUrl = mapsMatch?.[1];
 
   return {

--- a/src/adapters/html-scraper/cah3.ts
+++ b/src/adapters/html-scraper/cah3.ts
@@ -1,0 +1,224 @@
+import type { Source } from "@/generated/prisma/client";
+import type { ErrorDetails, RawEventData, ScrapeResult, SourceAdapter } from "../types";
+import { hasAnyErrors } from "../types";
+import { fetchWordPressPosts } from "../wordpress-api";
+import {
+  applyDateWindow,
+  chronoParseDate,
+  decodeEntities,
+  normalizeHaresField,
+  parse12HourTime,
+  stripHtmlTags,
+} from "../utils";
+
+/**
+ * Cha-Am Hash House Harriers (CAH3) adapter.
+ *
+ * cah3.net is a self-hosted WordPress site that publishes one blog post per
+ * monthly run. Post titles follow patterns like:
+ *   "Run 534: Songkran Outstation APR 10 & 11"
+ *   "Run 533 Saturday 8th March 2025"
+ *   "Run 532 Saturday February 8 2025"
+ *
+ * The body typically contains labeled fields:
+ *   Hare: <name>
+ *   Location: <place>
+ *   Time: <time>
+ *
+ * Monthly Saturday runs in the Hua Hin / Cha-Am area.
+ */
+
+const KENNEL_TAG = "cah3";
+const DEFAULT_START_TIME = "16:00"; // typical Saturday afternoon hash
+const TITLE_RUN_RE = /Run\s*#?\s*(\d+)/i;
+
+/**
+ * Parse a CAH3 post title for date and run number.
+ * Exported for unit testing.
+ */
+export function parseCah3Title(title: string, publishDateIso: string): {
+  runNumber?: number;
+  date?: string;
+  title?: string;
+} {
+  const decoded = decodeEntities(title);
+
+  const runMatch = TITLE_RUN_RE.exec(decoded);
+  const runNumber = runMatch ? Number.parseInt(runMatch[1], 10) : undefined;
+
+  // Strip "Run NNN:" prefix to get the descriptive part
+  const stripped = decoded.replace(/^Run\s*#?\s*\d+\s*[:\-–]?\s*/i, "").trim();
+
+  // Parse date from the remaining title text using the publish date as reference
+  const refDate = new Date(publishDateIso);
+  const date = chronoParseDate(stripped, "en-GB", refDate, { forwardDate: true })
+    ?? chronoParseDate(decoded, "en-GB", refDate, { forwardDate: true });
+
+  return {
+    runNumber,
+    date: date ?? undefined,
+    title: stripped || undefined,
+  };
+}
+
+/**
+ * Extract labeled fields from a CAH3 post body.
+ * Exported for unit testing.
+ */
+export function parseCah3Body(bodyHtml: string): {
+  hares?: string;
+  location?: string;
+  startTime?: string;
+  date?: string;
+} {
+  const text = stripHtmlTags(bodyHtml, "\n");
+  const labels = "(?:Hares?|Location|Time|Date|Start|Run\\s*Site|On\\s*After|Meeting\\s*Point)";
+  const stop = `(?=\\n|${labels}\\s*:|$)`;
+
+  const grab = (label: string): string | undefined => {
+    const re = new RegExp(`${label}\\s*:\\s*(.+?)${stop}`, "i");
+    const m = re.exec(text);
+    if (!m) return undefined;
+    const value = m[1].trim().replace(/\s+/g, " ");
+    return value || undefined;
+  };
+
+  const hares = grab("Hares?");
+  const location = grab("Location") ?? grab("Run\\s*Site") ?? grab("Meeting\\s*Point");
+  const timeRaw = grab("Time") ?? grab("Start");
+  let startTime: string | undefined;
+  if (timeRaw) {
+    const normalized = timeRaw.replace(/a\.m\./gi, "am").replace(/p\.m\./gi, "pm");
+    startTime = parse12HourTime(normalized);
+  }
+
+  const dateRaw = grab("Date");
+  const date = dateRaw ? chronoParseDate(dateRaw, "en-GB") ?? undefined : undefined;
+
+  return { hares, location, startTime, date };
+}
+
+/** A minimal WordPress post shape for parsePost. */
+export interface Cah3PostInput {
+  title: string;
+  content: string;
+  url: string;
+  date: string;
+}
+
+/** Result of parsing a CAH3 post. */
+export type ParseCah3PostResult =
+  | { ok: true; event: RawEventData }
+  | { ok: false; reason: "not-run-post" | "no-date"; title: string };
+
+/**
+ * Parse a single CAH3 WordPress post into RawEventData.
+ *
+ * CAH3 posts often don't have a date in the title (e.g. "Run 533: Saurkrap's
+ * Cat Sanctuary Run") or body. The WordPress publish date IS the run
+ * announcement date and is typically within a few days of the actual run.
+ * When no date can be parsed from title or body, we fall back to the post's
+ * publish date.
+ *
+ * Exported for unit testing.
+ */
+export function parseCah3Post(post: Cah3PostInput): ParseCah3PostResult {
+  const rawTitle = post.title;
+  if (!TITLE_RUN_RE.test(rawTitle)) {
+    return { ok: false, reason: "not-run-post", title: rawTitle };
+  }
+
+  const titleFields = parseCah3Title(rawTitle, post.date);
+  const body = parseCah3Body(post.content);
+
+  // Try title date, then body date. Do NOT fall back to the WordPress
+  // publish date — it's the announcement date and may be several days
+  // before the actual Saturday run, which would emit events on the
+  // wrong day and break calendar accuracy + fingerprint dedup.
+  const date = body.date ?? titleFields.date;
+  if (!date) return { ok: false, reason: "no-date", title: rawTitle };
+
+  // Try to extract a Google Maps link from the body as locationUrl
+  const mapsMatch = /href="(https?:\/\/(?:maps\.app\.goo\.gl|(?:www\.)?google\.com\/maps)[^"]+)"/i.exec(post.content);
+  const locationUrl = mapsMatch?.[1];
+
+  return {
+    ok: true,
+    event: {
+      date,
+      kennelTag: KENNEL_TAG,
+      runNumber: titleFields.runNumber,
+      title: titleFields.title,
+      hares: normalizeHaresField(body.hares),
+      location: body.location,
+      locationUrl,
+      startTime: body.startTime ?? DEFAULT_START_TIME,
+      sourceUrl: post.url,
+    },
+  };
+}
+
+export class Cah3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(
+    source: Source,
+    options?: { days?: number },
+  ): Promise<ScrapeResult> {
+    const baseUrl = source.url || "https://cah3.net";
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    const wpResult = await fetchWordPressPosts(baseUrl, 20);
+    if (wpResult.error || wpResult.posts.length === 0) {
+      const message = wpResult.error?.message ?? "CAH3 WordPress API returned no posts";
+      errorDetails.fetch = [
+        { url: baseUrl, message, status: wpResult.error?.status },
+      ];
+      return { events: [], errors: [message], errorDetails };
+    }
+
+    const events: RawEventData[] = [];
+    for (let i = 0; i < wpResult.posts.length; i++) {
+      const post = wpResult.posts[i];
+      const result = parseCah3Post({
+        title: post.title,
+        content: post.content,
+        url: post.url,
+        date: post.date,
+      });
+      if (result.ok) {
+        events.push(result.event);
+        continue;
+      }
+      if (result.reason === "not-run-post") continue;
+      errors.push(`CAH3 post "${result.title.slice(0, 80)}" has no parseable date`);
+      errorDetails.parse = [
+        ...(errorDetails.parse ?? []),
+        {
+          row: i,
+          section: "post",
+          field: "date",
+          error: "No parseable date in title or body",
+          rawText: `Title: ${result.title}`.slice(0, 500),
+        },
+      ];
+    }
+
+    const days = options?.days ?? source.scrapeDays ?? 365;
+    return applyDateWindow(
+      {
+        events,
+        errors,
+        errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+        diagnosticContext: {
+          fetchMethod: "wordpress-api",
+          postsFound: wpResult.posts.length,
+          eventsParsed: events.length,
+          fetchDurationMs: wpResult.fetchDurationMs,
+        },
+      },
+      days,
+    );
+  }
+}

--- a/src/adapters/html-scraper/crh3.test.ts
+++ b/src/adapters/html-scraper/crh3.test.ts
@@ -1,0 +1,92 @@
+import { parseCrh3Title, parseCrh3Body, parseCrh3Post } from "./crh3";
+
+describe("parseCrh3Title", () => {
+  it("parses run number and date from title with date", () => {
+    const result = parseCrh3Title(
+      "CRH3 #218 Saturday 15th February 2025",
+      "2025-02-01T00:00:00",
+    );
+    expect(result.runNumber).toBe(218);
+    expect(result.date).toBe("2025-02-15");
+  });
+
+  it("parses run number from compact title (no date)", () => {
+    const result = parseCrh3Title(
+      "CRH3#220",
+      "2025-04-01T00:00:00",
+    );
+    expect(result.runNumber).toBe(220);
+    // No date parseable from title alone
+    expect(result.date).toBeUndefined();
+  });
+
+  it("parses run number from title with event name", () => {
+    const result = parseCrh3Title(
+      "CRH3#217 HAPPY NEW YEAR RUN",
+      "2025-01-01T00:00:00",
+    );
+    expect(result.runNumber).toBe(217);
+  });
+});
+
+describe("parseCrh3Body", () => {
+  it("extracts hare and location from labeled body text", () => {
+    const body = `
+<p>Hare: Iron Chef</p>
+<p>Location: Mae Fah Luang Garden</p>
+<p>Time to assemble: 3:30 PM</p>
+`;
+    const result = parseCrh3Body(body, "2025-02-01T00:00:00");
+    expect(result.hares).toBe("Iron Chef");
+    expect(result.location).toBe("Mae Fah Luang Garden");
+  });
+
+  it("returns undefined for freeform text without labels", () => {
+    const body = "<p>Come join us for a great hash!</p>";
+    const result = parseCrh3Body(body, "2025-02-01T00:00:00");
+    expect(result.hares).toBeUndefined();
+    expect(result.location).toBeUndefined();
+  });
+});
+
+describe("parseCrh3Post", () => {
+  it("parses a complete post with date in title", () => {
+    const result = parseCrh3Post({
+      title: "CRH3 #218 Saturday 15th February 2025",
+      content: "<p>Hare: Iron Chef</p><p>Location: Mae Fah Luang</p>",
+      url: "https://chiangraihhh.blogspot.com/2025/02/crh3-218.html",
+      published: "2025-02-01T00:00:00",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.event.date).toBe("2025-02-15");
+      expect(result.event.kennelTag).toBe("crh3");
+      expect(result.event.runNumber).toBe(218);
+      expect(result.event.hares).toBe("Iron Chef");
+      expect(result.event.location).toBe("Mae Fah Luang");
+      expect(result.event.startTime).toBe("15:00");
+    }
+  });
+
+  it("filters non-run posts", () => {
+    const result = parseCrh3Post({
+      title: "Happy Birthday to our GM!",
+      content: "<p>Cheers!</p>",
+      url: "https://chiangraihhh.blogspot.com/2025/01/happy.html",
+      published: "2025-01-01T00:00:00",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not-run-post");
+  });
+
+  it("returns no-date when no date can be parsed", () => {
+    const result = parseCrh3Post({
+      title: "CRH3#220",
+      content: "<p>Details to follow...</p>",
+      url: "https://chiangraihhh.blogspot.com/2025/04/crh3-220.html",
+      published: "2025-04-01T00:00:00",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("no-date");
+  });
+});

--- a/src/adapters/html-scraper/crh3.ts
+++ b/src/adapters/html-scraper/crh3.ts
@@ -1,0 +1,206 @@
+import type { Source } from "@/generated/prisma/client";
+import type { ErrorDetails, RawEventData, ScrapeResult, SourceAdapter } from "../types";
+import { hasAnyErrors } from "../types";
+import { fetchBloggerPosts } from "../blogger-api";
+import {
+  applyDateWindow,
+  chronoParseDate,
+  decodeEntities,
+  normalizeHaresField,
+  stripHtmlTags,
+} from "../utils";
+
+/**
+ * Chiang Rai Hash House Harriers (CRH3) adapter.
+ *
+ * chiangraihhh.blogspot.com is a Blogger-hosted blog with 364+ posts.
+ * Run announcements have titles matching patterns like:
+ *   "CRH3#220"
+ *   "CRH3 #218 Saturday 15th February 2025"
+ *   "CRH3#217 HAPPY NEW YEAR RUN"
+ *
+ * Posts are freeform with emojis and variable formatting. The body often
+ * contains date, location, and hare info in plain text. Monthly 3rd Saturday.
+ */
+
+const KENNEL_TAG = "crh3";
+const DEFAULT_START_TIME = "15:00"; // 3rd Saturday monthly, 3:00 PM start per Chrome research
+/** Matches CRH3 run posts with or without a run number. */
+const RUN_TITLE_RE = /CRH3\s*#?\s*\d*/i;
+/** Extracts the run number if present. */
+const RUN_NUMBER_RE = /CRH3\s*#?\s*(\d+)/i;
+
+/**
+ * Parse a CRH3 post title for run number and optional date.
+ * Exported for unit testing.
+ */
+export function parseCrh3Title(title: string, publishDateIso: string): {
+  runNumber?: number;
+  date?: string;
+} {
+  const decoded = decodeEntities(title);
+  const runMatch = RUN_NUMBER_RE.exec(decoded);
+  const runNumber = runMatch ? Number.parseInt(runMatch[1], 10) : undefined;
+
+  // Strip "CRH3#NNN" or "CRH3" prefix and try to parse remaining text as a date
+  const stripped = decoded.replace(/CRH3\s*#?\s*\d*\s*/i, "").trim();
+  const refDate = new Date(publishDateIso);
+  const date = chronoParseDate(stripped, "en-GB", refDate, { forwardDate: true })
+    ?? chronoParseDate(decoded, "en-GB", refDate, { forwardDate: true });
+
+  return { runNumber, date: date ?? undefined };
+}
+
+/**
+ * Extract fields from a CRH3 post body. The body is freeform text with
+ * emoji separators. We look for date, hare, and location patterns.
+ * Exported for unit testing.
+ */
+export function parseCrh3Body(bodyHtml: string, publishDateIso: string): {
+  date?: string;
+  hares?: string;
+  location?: string;
+} {
+  const text = stripHtmlTags(bodyHtml, "\n")
+    // Strip emoji characters that might interfere with regex
+    .replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu, " ");
+
+  // Use newline-delimited text with label-anchored regexes that stop at
+  // the next known label or newline to avoid greedy over-matching.
+  const labels = "(?:Hares?|GM|Grand Master|Location|Run\\s*Site|Start|Meeting|Time|Date|On\\s*After)";
+  const stop = `(?=\\n|${labels}\\s*[=:]|$)`;
+
+  const grab = (label: string): string | undefined => {
+    const re = new RegExp(`(?:${label})\\s*[=:]\\s*(.+?)${stop}`, "i");
+    const m = re.exec(text);
+    if (!m) return undefined;
+    const value = m[1].trim().replace(/\s+/g, " ");
+    return value || undefined;
+  };
+
+  const hares = grab("Hares?|GM|Grand Master");
+  const location = grab("Location|Run\\s*Site|Meeting");
+
+  // Try to find a date in the body
+  const refDate = new Date(publishDateIso);
+  const date = chronoParseDate(text, "en-GB", refDate, { forwardDate: true }) ?? undefined;
+
+  return { date, hares, location };
+}
+
+/** A minimal Blogger post shape for parsePost. */
+export interface Crh3PostInput {
+  title: string;
+  content: string;
+  url: string;
+  published: string;
+}
+
+/** Result of parsing a CRH3 post. */
+export type ParseCrh3PostResult =
+  | { ok: true; event: RawEventData }
+  | { ok: false; reason: "not-run-post" | "no-date"; title: string };
+
+/**
+ * Parse a single CRH3 Blogger post into RawEventData.
+ * Exported for unit testing.
+ */
+export function parseCrh3Post(post: Crh3PostInput): ParseCrh3PostResult {
+  const rawTitle = post.title;
+  if (!RUN_TITLE_RE.test(rawTitle)) {
+    return { ok: false, reason: "not-run-post", title: rawTitle };
+  }
+
+  const titleFields = parseCrh3Title(rawTitle, post.published);
+  const body = parseCrh3Body(post.content, post.published);
+
+  const date = titleFields.date ?? body.date;
+  if (!date) return { ok: false, reason: "no-date", title: rawTitle };
+
+  return {
+    ok: true,
+    event: {
+      date,
+      kennelTag: KENNEL_TAG,
+      runNumber: titleFields.runNumber,
+      hares: normalizeHaresField(body.hares),
+      location: body.location,
+      startTime: DEFAULT_START_TIME,
+      sourceUrl: post.url,
+    },
+  };
+}
+
+export class Crh3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(
+    source: Source,
+    options?: { days?: number },
+  ): Promise<ScrapeResult> {
+    const baseUrl = source.url || "https://chiangraihhh.blogspot.com";
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    const bloggerResult = await fetchBloggerPosts(baseUrl);
+    if (bloggerResult.error) {
+      errorDetails.fetch = [
+        {
+          url: baseUrl,
+          message: bloggerResult.error.message,
+          status: bloggerResult.error.status,
+        },
+      ];
+      return { events: [], errors: [bloggerResult.error.message], errorDetails };
+    }
+
+    const events: RawEventData[] = [];
+    let filteredOut = 0;
+    for (let i = 0; i < bloggerResult.posts.length; i++) {
+      const post = bloggerResult.posts[i];
+      const result = parseCrh3Post({
+        title: post.title,
+        content: post.content,
+        url: post.url,
+        published: post.published,
+      });
+      if (result.ok) {
+        events.push(result.event);
+        continue;
+      }
+      if (result.reason === "not-run-post") {
+        filteredOut++;
+        continue;
+      }
+      errors.push(`CRH3 post "${result.title.slice(0, 80)}" has no parseable date`);
+      errorDetails.parse = [
+        ...(errorDetails.parse ?? []),
+        {
+          row: i,
+          section: "post",
+          field: "date",
+          error: "No parseable date",
+          rawText: `Title: ${result.title}`.slice(0, 500),
+        },
+      ];
+    }
+
+    const days = options?.days ?? source.scrapeDays ?? 365;
+    return applyDateWindow(
+      {
+        events,
+        errors,
+        errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+        diagnosticContext: {
+          fetchMethod: "blogger-api",
+          blogId: bloggerResult.blogId,
+          postsFound: bloggerResult.posts.length,
+          postsFilteredOut: filteredOut,
+          eventsParsed: events.length,
+          fetchDurationMs: bloggerResult.fetchDurationMs,
+        },
+      },
+      days,
+    );
+  }
+}

--- a/src/adapters/html-scraper/crh3.ts
+++ b/src/adapters/html-scraper/crh3.ts
@@ -23,10 +23,16 @@ import {
  * contains date, location, and hare info in plain text. Monthly 3rd Saturday.
  */
 
+/** Parse ISO string as UTC for chrono reference date anchoring. */
+function utcRef(iso: string | undefined): Date | undefined {
+  if (!iso) return undefined;
+  return new Date(iso.endsWith("Z") ? iso : iso + "Z");
+}
+
 const KENNEL_TAG = "crh3";
 const DEFAULT_START_TIME = "15:00"; // 3rd Saturday monthly, 3:00 PM start per Chrome research
-/** Matches CRH3 run posts with or without a run number. */
-const RUN_TITLE_RE = /CRH3\s*#?\s*\d*/i;
+/** Matches CRH3 run posts — requires at least one digit to avoid matching run reports. */
+const RUN_TITLE_RE = /CRH3\s*#?\s*\d+/i;
 /** Extracts the run number if present. */
 const RUN_NUMBER_RE = /CRH3\s*#?\s*(\d+)/i;
 
@@ -44,7 +50,7 @@ export function parseCrh3Title(title: string, publishDateIso: string): {
 
   // Strip "CRH3#NNN" or "CRH3" prefix and try to parse remaining text as a date
   const stripped = decoded.replace(/CRH3\s*#?\s*\d*\s*/i, "").trim();
-  const refDate = new Date(publishDateIso);
+  const refDate = utcRef(publishDateIso);
   const date = chronoParseDate(stripped, "en-GB", refDate, { forwardDate: true })
     ?? chronoParseDate(decoded, "en-GB", refDate, { forwardDate: true });
 
@@ -61,7 +67,7 @@ export function parseCrh3Body(bodyHtml: string, publishDateIso: string): {
   hares?: string;
   location?: string;
 } {
-  const text = stripHtmlTags(bodyHtml, "\n")
+  const text = decodeEntities(stripHtmlTags(bodyHtml, "\n"))
     // Strip emoji characters that might interfere with regex
     .replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu, " ");
 
@@ -82,7 +88,7 @@ export function parseCrh3Body(bodyHtml: string, publishDateIso: string): {
   const location = grab("Location|Run\\s*Site|Meeting");
 
   // Try to find a date in the body
-  const refDate = new Date(publishDateIso);
+  const refDate = utcRef(publishDateIso);
   const date = chronoParseDate(text, "en-GB", refDate, { forwardDate: true }) ?? undefined;
 
   return { date, hares, location };

--- a/src/adapters/html-scraper/crh3.ts
+++ b/src/adapters/html-scraper/crh3.ts
@@ -162,6 +162,12 @@ export class Crh3Adapter implements SourceAdapter {
 
     const events: RawEventData[] = [];
     let filteredOut = 0;
+    // Dedupe by (date, runNumber) — Blogger returns newest-first, so the
+    // first post per run# is the most recent (announcement). Later posts
+    // with the same run# are typically run reports/recaps and must NOT
+    // create additional events.
+    const seenRuns = new Set<string>();
+    let duplicatesSkipped = 0;
     for (let i = 0; i < bloggerResult.posts.length; i++) {
       const post = bloggerResult.posts[i];
       const result = parseCrh3Post({
@@ -171,6 +177,12 @@ export class Crh3Adapter implements SourceAdapter {
         published: post.published,
       });
       if (result.ok) {
+        const dedupKey = `${result.event.date}|${result.event.runNumber ?? ""}`;
+        if (seenRuns.has(dedupKey)) {
+          duplicatesSkipped++;
+          continue;
+        }
+        seenRuns.add(dedupKey);
         events.push(result.event);
         continue;
       }
@@ -202,6 +214,7 @@ export class Crh3Adapter implements SourceAdapter {
           blogId: bloggerResult.blogId,
           postsFound: bloggerResult.posts.length,
           postsFilteredOut: filteredOut,
+          duplicatesSkipped,
           eventsParsed: events.length,
           fetchDurationMs: bloggerResult.fetchDurationMs,
         },

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -82,6 +82,9 @@ import { SydneyThirstyH3Adapter } from "./html-scraper/sydney-thirsty-h3";
 import { N2TH3Adapter } from "./html-scraper/n2th3";
 import { LswH3Adapter } from "./html-scraper/lsw-h3";
 import { LadiesH4HkAdapter } from "./html-scraper/ladies-h4-hk";
+import { Cah3Adapter } from "./html-scraper/cah3";
+import { Crh3Adapter } from "./html-scraper/crh3";
+import { BkkHarriettesAdapter } from "./html-scraper/bkk-harriettes";
 import { GoogleCalendarAdapter } from "./google-calendar/adapter";
 import { GoogleSheetsAdapter } from "./google-sheets/adapter";
 import { ICalAdapter } from "./ical/adapter";
@@ -196,6 +199,10 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /n2th3\.org|n2th3\.wordpress/i, name: "N2TH3Adapter", factory: () => new N2TH3Adapter() },
   { pattern: /datadesignfactory\.com\/lsw/i, name: "LswH3Adapter", factory: () => new LswH3Adapter() },
   { pattern: /hkladiesh4\.wixsite/i, name: "LadiesH4HkAdapter", factory: () => new LadiesH4HkAdapter() },
+  // ── Thailand (Phase 1a) ──
+  { pattern: /cah3\.net/i, name: "Cah3Adapter", factory: () => new Cah3Adapter() },
+  { pattern: /chiangraihhh\.blogspot/i, name: "Crh3Adapter", factory: () => new Crh3Adapter() },
+  { pattern: /bangkokharriettes\.wordpress/i, name: "BkkHarriettesAdapter", factory: () => new BkkHarriettesAdapter() },
 ];
 
 /** URL-based routing for HTML_SCRAPER — derived from htmlScraperEntries (single source of truth). */

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -3056,6 +3056,8 @@ const STATE_GROUP_MAP: Record<string, string> = {
   "Phuket": "Thailand",
   "Hua Hin": "Thailand",
   "Chiang Rai": "Thailand",
+  "Koh Samui": "Thailand",
+  "Krabi": "Thailand",
   // Belgium
   "Brussels": "Belgium",
   // Louisiana
@@ -3249,6 +3251,8 @@ const COUNTRY_GROUP_MAP: Record<string, string> = {
   "Phuket": "Thailand",
   "Hua Hin": "Thailand",
   "Chiang Rai": "Thailand",
+  "Koh Samui": "Thailand",
+  "Krabi": "Thailand",
   "Hong Kong": "Hong Kong",
   // Malaysia — state groups (per feedback_country_group_map memory: both
   // state names AND metro names need explicit entries).

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -2250,6 +2250,85 @@ export const REGION_SEED_DATA: RegionSeedRecord[] = [
     centroidLng: 103.82,
     aliases: ["SG", "Republic of Singapore"],
   },
+  // ── Thailand ──
+  {
+    name: "Thailand",
+    country: "Thailand",
+    level: "COUNTRY",
+    timezone: "Asia/Bangkok",
+    abbrev: "TH",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#ea580c",
+    centroidLat: 15.87,
+    centroidLng: 100.99,
+    aliases: ["TH", "Kingdom of Thailand"],
+  },
+  {
+    name: "Bangkok",
+    country: "Thailand",
+    timezone: "Asia/Bangkok",
+    abbrev: "BKK",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#ea580c",
+    centroidLat: 13.76,
+    centroidLng: 100.50,
+    aliases: ["Bangkok, Thailand", "Bangkok, TH"],
+  },
+  {
+    name: "Pattaya",
+    country: "Thailand",
+    timezone: "Asia/Bangkok",
+    abbrev: "PYA",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#ea580c",
+    centroidLat: 12.93,
+    centroidLng: 100.88,
+    aliases: ["Pattaya, Thailand", "Pattaya, TH"],
+  },
+  {
+    name: "Chiang Mai",
+    country: "Thailand",
+    timezone: "Asia/Bangkok",
+    abbrev: "CNX",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#ea580c",
+    centroidLat: 18.79,
+    centroidLng: 98.98,
+    aliases: ["Chiang Mai, Thailand", "Chiang Mai, TH"],
+  },
+  {
+    name: "Phuket",
+    country: "Thailand",
+    timezone: "Asia/Bangkok",
+    abbrev: "HKT",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#ea580c",
+    centroidLat: 7.88,
+    centroidLng: 98.39,
+    aliases: ["Phuket, Thailand", "Phuket, TH"],
+  },
+  {
+    name: "Hua Hin",
+    country: "Thailand",
+    timezone: "Asia/Bangkok",
+    abbrev: "HHN",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#ea580c",
+    centroidLat: 12.57,
+    centroidLng: 99.96,
+    aliases: ["Hua Hin, Thailand", "Hua Hin, TH"],
+  },
+  {
+    name: "Chiang Rai",
+    country: "Thailand",
+    timezone: "Asia/Bangkok",
+    abbrev: "CEI",
+    colorClasses: "bg-orange-100 text-orange-700",
+    pinColor: "#ea580c",
+    centroidLat: 19.91,
+    centroidLng: 99.83,
+    aliases: ["Chiang Rai, Thailand", "Chiang Rai, TH"],
+  },
   // ── Hong Kong ──
   {
     name: "Hong Kong",
@@ -2806,6 +2885,7 @@ export function inferCountry(name: string): string {
   if (/\b(sweden|stockholm|göteborg|gothenburg|malmö)\b/.test(lower)) return "Sweden";
   if (/\b(norway|oslo|bergen|stavanger)\b/.test(lower)) return "Norway";
   if (/\b(singapore)\b/.test(lower)) return "Singapore";
+  if (/\b(thailand|bangkok|pattaya|chiang mai|chiang rai|phuket|hua hin|samui|krabi)\b/.test(lower)) return "Thailand";
   if (/\b(hong kong|kowloon|lantau|new territories|wan\s?chai|sai kung|sek kong)\b/.test(lower)) return "Hong Kong";
   if (/\b(malaysia|kuala lumpur|\bkl\b|petaling|penang|pulau pinang|george town|selangor|johor|sabah|sarawak|melaka|malacca|ipoh|kuching|kota kinabalu|miri|kelana jaya|butterworth|kluang)\b/.test(lower)) return "Malaysia";
   return "USA";
@@ -2969,6 +3049,13 @@ const STATE_GROUP_MAP: Record<string, string> = {
   "Tokyo": "Japan",
   "Kansai": "Japan",
   "Okinawa": "Japan",
+  // Thailand
+  "Bangkok": "Thailand",
+  "Pattaya": "Thailand",
+  "Chiang Mai": "Thailand",
+  "Phuket": "Thailand",
+  "Hua Hin": "Thailand",
+  "Chiang Rai": "Thailand",
   // Belgium
   "Brussels": "Belgium",
   // Louisiana
@@ -3155,6 +3242,13 @@ const COUNTRY_GROUP_MAP: Record<string, string> = {
   "Sweden": "Sweden",
   "Norway": "Norway",
   "Singapore": "Singapore",
+  "Thailand": "Thailand",
+  "Bangkok": "Thailand",
+  "Pattaya": "Thailand",
+  "Chiang Mai": "Thailand",
+  "Phuket": "Thailand",
+  "Hua Hin": "Thailand",
+  "Chiang Rai": "Thailand",
   "Hong Kong": "Hong Kong",
   // Malaysia — state groups (per feedback_country_group_map memory: both
   // state names AND metro names need explicit entries).
@@ -3233,6 +3327,7 @@ const COUNTRY_CODE_TO_NAME: Record<string, string> = {
   AU: "Australia",
   CA: "Canada",
   SG: "Singapore",
+  TH: "Thailand",
   HK: "Hong Kong",
   MY: "Malaysia",
 };


### PR DESCRIPTION
## Summary
First Thailand ship. 4 kennels using existing adapter patterns (WordPress REST, Meetup, Blogger, WordPress.com).

| # | Kennel | City | Source | Verified |
|---|--------|------|--------|----------|
| 1 | **Cha-Am H3** | Hua Hin | WordPress REST API | ✅ unit tests |
| 2 | **BSSH3** (Bangkok Sabai Saturday) | Bangkok | MEETUP | config-only |
| 3 | **Chiang Rai H3** | Chiang Rai | Blogger API | ✅ unit tests |
| 4 | **Bangkok Harriettes** | Bangkok | WordPress.com API | ✅ unit tests |

## Thailand region
- Thailand COUNTRY + 6 metros (Bangkok, Pattaya, Chiang Mai, Phuket, Hua Hin, Chiang Rai)
- \`inferCountry()\` extended with Thai city names
- Metros parent directly to Thailand (no state level)

## Codex review fixes (4 corrections)
- Bangkok Harriettes: filter to "Run" posts only + anchor chrono to \`post.modified\` (site hardcodes \`post.date\` to 2000-01-01)
- Cha-Am: removed WP publish-date fallback (announcement ≠ run date)
- Chiang Rai: start time 16:00 → 15:00 per research

## Phase 1b preview
15 more Thai kennels ready: bangkokhash.com Joomla hub (3), phuket-hhh.com shared hareline (4), chiangmaihhh.com (7), Bangkok H3 Wix, Pattaya H3 PHP, Bangkok Bikers Rails.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] 23 new adapter tests pass
- [x] /simplify — unused imports cleaned
- [x] /codex:adversarial-review — 4 data-quality bugs caught and fixed
- [ ] Post-merge: \`npx prisma db seed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)