### PR TITLE
fix(audit): Calgary description-dropped + merge pipeline null-field enrichment

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3237,13 +3237,11 @@ export const SOURCES = [
       name: "Calgary H3 Scribe",
       url: "https://scribe.onon.org/",
       type: "HTML_SCRAPER" as const,
-      // Raised from 7 → 8 so the Scribe's description + hares fields can
-      // update canonical events created by the Home adapter (also trust 8).
-      // The Home adapter creates events first but has no description/hares;
-      // the Scribe provides them as enrichment. At trust 7 the merge
-      // pipeline's `trustLevel >= existingEvent.trustLevel` gate blocked
-      // the update, leaving description permanently null. Closes #585.
-      trustLevel: 8,
+      // Trust 7 (below the Home adapter's 8): the merge pipeline's null-field
+      // enrichment path lets the Scribe fill description + hares on canonical
+      // events created by the Home adapter without being able to overwrite
+      // the Home's title, location, or other non-null fields. Closes #585.
+      trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 90,
       kennelCodes: ["ch3-ab"],

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3237,7 +3237,13 @@ export const SOURCES = [
       name: "Calgary H3 Scribe",
       url: "https://scribe.onon.org/",
       type: "HTML_SCRAPER" as const,
-      trustLevel: 7,
+      // Raised from 7 → 8 so the Scribe's description + hares fields can
+      // update canonical events created by the Home adapter (also trust 8).
+      // The Home adapter creates events first but has no description/hares;
+      // the Scribe provides them as enrichment. At trust 7 the merge
+      // pipeline's `trustLevel >= existingEvent.trustLevel` gate blocked
+      // the update, leaving description permanently null. Closes #585.
+      trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,
       kennelCodes: ["ch3-ab"],

--- a/scripts/data/avlh3-meetup-history-batch-1.json
+++ b/scripts/data/avlh3-meetup-history-batch-1.json
@@ -224,14 +224,6 @@
 "attendees": 19
 },
 {
-"title": "AVLH3 #830: Squirt Gun's \"Adult Diaper Trail\" (POSTPONED until August 23, please RSVP on new event)",
-"date": "2025-06-14",
-"startTime": "14:00",
-"location": "Asheville, NC, US",
-"url": "https://www.meetup.com/avlh3-on-on/events/308836198/",
-"attendees": 2
-},
-{
 "title": "AVLH3 #829 - Trails JUST FOR LOVE 💕",
 "date": "2025-06-07",
 "startTime": "14:00",
@@ -254,14 +246,6 @@
 "location": "Asheville, NC, US",
 "url": "https://www.meetup.com/avlh3-on-on/events/307645402/",
 "attendees": 22
-},
-{
-"title": "AVLH3 #8?? - **NEEDS A HARE**",
-"date": "2025-05-10",
-"startTime": "14:00",
-"location": "Asheville, NC, US",
-"url": "https://www.meetup.com/avlh3-on-on/events/307645401/",
-"attendees": null
 },
 {
 "title": "AVLH3 #826A: Riveter's Rosie's Run (Beer stop hash!)",
@@ -438,14 +422,6 @@
 "location": "Asheville, NC, US",
 "url": "https://www.meetup.com/avlh3-on-on/events/303827698/",
 "attendees": 12
-},
-{
-"title": "AVLH3 #807 - POSTPONED!!!",
-"date": "2024-09-28",
-"startTime": "14:00",
-"location": "Asheville, NC, US",
-"url": "https://www.meetup.com/avlh3-on-on/events/303636891/",
-"attendees": 2
 },
 {
 "title": "AVLH3 #806 - Trail by Half Cocked and Rosie",

--- a/scripts/data/avlh3-meetup-history-batch-2.json
+++ b/scripts/data/avlh3-meetup-history-batch-2.json
@@ -1,41 +1,306 @@
 [
-{"title":"AVLH3 #799 - Run, Rabbit, Run: #2","date":"2024-07-27","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/302296262/","attendees":11},
-{"title":"AVLH3 #798 -Just Noah and Bearly go for a run","date":"2024-07-20","startTime":"14:00","location":"Roger farmer park, 71 Deaverview R,, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/301879873/","attendees":11},
-{"title":"AVLH3 #797  Run, Rabbit, Run!","date":"2024-07-13","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/301837065/","attendees":13},
-{"title":"AVLH3 #796–Sicilian & Kotex. Redemption-Stupid TShirt Run","date":"2024-07-06","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/301316834/","attendees":10},
-{"title":"AVLH3 #795 -  High Jacked Hash!","date":"2024-06-29","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/301316833/","attendees":14},
-{"title":"Hashathon 2024 - Asheville, NC","date":"2024-06-21","startTime":"18:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/300023849/","attendees":24},
-{"title":"AVLH3 #794 - Pre-lube: Body Glide's Trail","date":"2024-06-15","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/301316830/","attendees":9},
-{"title":"AVLH3 #793 - Shitty Titties Hares Some Shit!","date":"2024-06-08","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/301316827/","attendees":17},
-{"title":"AVLH3 #792 - memorial weekend Trail!!!!","date":"2024-05-25","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/300820052/","attendees":7},
-{"title":"AVLH3 #791 - Riveter's Rosie's Last Trail in Asheville!","date":"2024-05-18","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/300820047/","attendees":18},
-{"title":"AVLH3 #790 - Stinky Mink's Trail","date":"2024-05-11","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/300453953/","attendees":10},
-{"title":"AVLH3 #789 - Lube Job's Kennel Farewell!","date":"2024-05-04","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/300453943/","attendees":22},
-{"title":"AVLH3 #788 - Stitch and VCR's Earth Day hash🌎","date":"2024-04-20","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/300028449/","attendees":14},
-{"title":"AVLH3 #787 - Family cums first and mystery hare(it's time for a hare-olina patch","date":"2024-04-13","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/300028438/","attendees":14},
-{"title":"AVLH3 #786 Part C - Run","date":"2024-03-31","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/299709393/","attendees":15},
-{"title":"AVLH3 #786 Part B - Easter","date":"2024-03-31","startTime":"10:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/299709371/","attendees":3},
-{"title":"AVLH3 #786 Part A - Purim Party!","date":"2024-03-23","startTime":"18:30","location":"21 Battery Park Ave, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/299709349/","attendees":6},
-{"title":"AVLH3 #785 - Needs a Hare *claimed*","date":"2024-03-16","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/299037089/","attendees":18},
-{"title":"AVLH3 #784 Red Dress 2024!","date":"2024-03-09","startTime":"13:00","location":"Martin Luther King Jr Park, 50 Martin Luther King Junior Drive, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/298583753/","attendees":36},
-{"title":"AVLH3 #783 - Onesie Hash! 🐣🐥","date":"2024-03-03","startTime":"14:00","location":"Biltmore Estate, 1 Approach Rd, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/299037067/","attendees":18},
-{"title":"AVLH3 #782 - The Day of the Dude Hash","date":"2024-03-02","startTime":"14:00","location":"Martin Luther King Park, 50 Martin Luther King Jr Dr, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/299037047/","attendees":17},
-{"title":"AVLH3 #781 - A totally not last minute trail","date":"2024-02-24","startTime":"14:00","location":"Weaverville Center, 60 Lakeshore Dr., weaverville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/299286956/","attendees":7},
-{"title":"Moonshine H3 #110 - Snow Moon","date":"2024-02-23","startTime":"19:30","location":"The Oysterhouse brewing company, 625 Haywood rd, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/298179811/","attendees":8},
-{"title":"AVLH3 #780 - Butts and Just Emily","date":"2024-02-17","startTime":"13:30","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/297583165/","attendees":12},
-{"title":"AVLH3 #779 - MardiGras WEEKEND AND PARADE! 2/11","date":"2024-02-10","startTime":"13:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/298179701/","attendees":14},
-{"title":"AVLH3 #778 - Road Trip: Greenville SC h3 Super Bowl Hash!","date":"2024-02-10","startTime":"13:00","location":"Greenville, SC, US","url":"https://www.meetup.com/avlh3-on-on/events/298583776/","attendees":5},
-{"title":"Moonshine H3 #109 - HOWL Moon","date":"2024-01-26","startTime":"19:30","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/298179764/","attendees":8},
-{"title":"AVLH3 #777 Lucky Hash by Realtree","date":"2024-01-27","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/297583141/","attendees":11},
-{"title":"AVLH3 #776 - FREE Hash Appreciation Trail! New Year's Day Hash!","date":"2024-01-01","startTime":"13:00","location":"Hominy Creek River Park, 280 Hominy Creek Road, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/297583110/","attendees":32},
-{"title":"Moonshine H3 #108 - Cold Moon","date":"2023-12-22","startTime":"19:30","location":"Archetype Brewing - West, 174 Broadway St., Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/297583093/","attendees":7},
-{"title":"AVLH3 #775 - Sicilian's Grinch Hash!","date":"2023-12-16","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/297583069/","attendees":12},
-{"title":"AVLH3 #774 - Squirt Gun's kids hash!","date":"2023-12-09","startTime":"10:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/297583024/","attendees":12},
-{"title":"AVLH3 #773 - 12 down downs of Christmas","date":"2023-12-02","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/297582999/","attendees":14},
-{"title":"Moonshine H3 #107 - Beaver Moon","date":"2023-11-25","startTime":"19:30","location":"The Odditorium, 1045 Haywood Road, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296780001/","attendees":8},
-{"title":"AVLH3 #772 - Pre-Lube trail by Body Glide","date":"2023-11-18","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296779989/","attendees":18},
-{"title":"AVLH3 #771 - Mismanagement's Hash Appreciation Trail!!","date":"2023-11-11","startTime":"14:00","location":"Carrier Park, 220 Amboy Road, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296779975/","attendees":33},
-{"title":"AVLH3 #770 - VCR, Stitch and Jack's Kids Hash!","date":"2023-10-28","startTime":"10:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296779962/","attendees":16},
-{"title":"Moonshine H3 #106 - Hunters Moon","date":"2023-10-27","startTime":"19:30","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296779950/","attendees":14},
-{"title":"AVLH3 #769 - Spooky Noodler Trail 🎃👻","date":"2023-10-21","startTime":"18:30","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296779941/","attendees":14}
+{
+"title": "AVLH3 #799 - Run, Rabbit, Run: #2",
+"date": "2024-07-27",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/302296262/",
+"attendees": 11
+},
+{
+"title": "AVLH3 #798 -Just Noah and Bearly go for a run",
+"date": "2024-07-20",
+"startTime": "14:00",
+"location": "Roger farmer park, 71 Deaverview R,, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/301879873/",
+"attendees": 11
+},
+{
+"title": "AVLH3 #797  Run, Rabbit, Run!",
+"date": "2024-07-13",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/301837065/",
+"attendees": 13
+},
+{
+"title": "AVLH3 #796–Sicilian & Kotex. Redemption-Stupid TShirt Run",
+"date": "2024-07-06",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/301316834/",
+"attendees": 10
+},
+{
+"title": "AVLH3 #795 -  High Jacked Hash!",
+"date": "2024-06-29",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/301316833/",
+"attendees": 14
+},
+{
+"title": "Hashathon 2024 - Asheville, NC",
+"date": "2024-06-21",
+"startTime": "18:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/300023849/",
+"attendees": 24
+},
+{
+"title": "AVLH3 #794 - Pre-lube: Body Glide's Trail",
+"date": "2024-06-15",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/301316830/",
+"attendees": 9
+},
+{
+"title": "AVLH3 #793 - Shitty Titties Hares Some Shit!",
+"date": "2024-06-08",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/301316827/",
+"attendees": 17
+},
+{
+"title": "AVLH3 #792 - memorial weekend Trail!!!!",
+"date": "2024-05-25",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/300820052/",
+"attendees": 7
+},
+{
+"title": "AVLH3 #791 - Riveter's Rosie's Last Trail in Asheville!",
+"date": "2024-05-18",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/300820047/",
+"attendees": 18
+},
+{
+"title": "AVLH3 #790 - Stinky Mink's Trail",
+"date": "2024-05-11",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/300453953/",
+"attendees": 10
+},
+{
+"title": "AVLH3 #789 - Lube Job's Kennel Farewell!",
+"date": "2024-05-04",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/300453943/",
+"attendees": 22
+},
+{
+"title": "AVLH3 #788 - Stitch and VCR's Earth Day hash🌎",
+"date": "2024-04-20",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/300028449/",
+"attendees": 14
+},
+{
+"title": "AVLH3 #787 - Family cums first and mystery hare(it's time for a hare-olina patch",
+"date": "2024-04-13",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/300028438/",
+"attendees": 14
+},
+{
+"title": "AVLH3 #786 Part C - Run",
+"date": "2024-03-31",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/299709393/",
+"attendees": 15
+},
+{
+"title": "AVLH3 #786 Part B - Easter",
+"date": "2024-03-31",
+"startTime": "10:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/299709371/",
+"attendees": 3
+},
+{
+"title": "AVLH3 #786 Part A - Purim Party!",
+"date": "2024-03-23",
+"startTime": "18:30",
+"location": "21 Battery Park Ave, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/299709349/",
+"attendees": 6
+},
+{
+"title": "AVLH3 #784 Red Dress 2024!",
+"date": "2024-03-09",
+"startTime": "13:00",
+"location": "Martin Luther King Jr Park, 50 Martin Luther King Junior Drive, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/298583753/",
+"attendees": 36
+},
+{
+"title": "AVLH3 #783 - Onesie Hash! 🐣🐥",
+"date": "2024-03-03",
+"startTime": "14:00",
+"location": "Biltmore Estate, 1 Approach Rd, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/299037067/",
+"attendees": 18
+},
+{
+"title": "AVLH3 #782 - The Day of the Dude Hash",
+"date": "2024-03-02",
+"startTime": "14:00",
+"location": "Martin Luther King Park, 50 Martin Luther King Jr Dr, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/299037047/",
+"attendees": 17
+},
+{
+"title": "AVLH3 #781 - A totally not last minute trail",
+"date": "2024-02-24",
+"startTime": "14:00",
+"location": "Weaverville Center, 60 Lakeshore Dr., weaverville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/299286956/",
+"attendees": 7
+},
+{
+"title": "Moonshine H3 #110 - Snow Moon",
+"date": "2024-02-23",
+"startTime": "19:30",
+"location": "The Oysterhouse brewing company, 625 Haywood rd, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/298179811/",
+"attendees": 8
+},
+{
+"title": "AVLH3 #780 - Butts and Just Emily",
+"date": "2024-02-17",
+"startTime": "13:30",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/297583165/",
+"attendees": 12
+},
+{
+"title": "AVLH3 #779 - MardiGras WEEKEND AND PARADE! 2/11",
+"date": "2024-02-10",
+"startTime": "13:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/298179701/",
+"attendees": 14
+},
+{
+"title": "AVLH3 #778 - Road Trip: Greenville SC h3 Super Bowl Hash!",
+"date": "2024-02-10",
+"startTime": "13:00",
+"location": "Greenville, SC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/298583776/",
+"attendees": 5
+},
+{
+"title": "Moonshine H3 #109 - HOWL Moon",
+"date": "2024-01-26",
+"startTime": "19:30",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/298179764/",
+"attendees": 8
+},
+{
+"title": "AVLH3 #777 Lucky Hash by Realtree",
+"date": "2024-01-27",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/297583141/",
+"attendees": 11
+},
+{
+"title": "AVLH3 #776 - FREE Hash Appreciation Trail! New Year's Day Hash!",
+"date": "2024-01-01",
+"startTime": "13:00",
+"location": "Hominy Creek River Park, 280 Hominy Creek Road, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/297583110/",
+"attendees": 32
+},
+{
+"title": "Moonshine H3 #108 - Cold Moon",
+"date": "2023-12-22",
+"startTime": "19:30",
+"location": "Archetype Brewing - West, 174 Broadway St., Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/297583093/",
+"attendees": 7
+},
+{
+"title": "AVLH3 #775 - Sicilian's Grinch Hash!",
+"date": "2023-12-16",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/297583069/",
+"attendees": 12
+},
+{
+"title": "AVLH3 #774 - Squirt Gun's kids hash!",
+"date": "2023-12-09",
+"startTime": "10:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/297583024/",
+"attendees": 12
+},
+{
+"title": "AVLH3 #773 - 12 down downs of Christmas",
+"date": "2023-12-02",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/297582999/",
+"attendees": 14
+},
+{
+"title": "Moonshine H3 #107 - Beaver Moon",
+"date": "2023-11-25",
+"startTime": "19:30",
+"location": "The Odditorium, 1045 Haywood Road, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296780001/",
+"attendees": 8
+},
+{
+"title": "AVLH3 #772 - Pre-Lube trail by Body Glide",
+"date": "2023-11-18",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296779989/",
+"attendees": 18
+},
+{
+"title": "AVLH3 #771 - Mismanagement's Hash Appreciation Trail!!",
+"date": "2023-11-11",
+"startTime": "14:00",
+"location": "Carrier Park, 220 Amboy Road, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296779975/",
+"attendees": 33
+},
+{
+"title": "AVLH3 #770 - VCR, Stitch and Jack's Kids Hash!",
+"date": "2023-10-28",
+"startTime": "10:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296779962/",
+"attendees": 16
+},
+{
+"title": "Moonshine H3 #106 - Hunters Moon",
+"date": "2023-10-27",
+"startTime": "19:30",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296779950/",
+"attendees": 14
+},
+{
+"title": "AVLH3 #769 - Spooky Noodler Trail 🎃👻",
+"date": "2023-10-21",
+"startTime": "18:30",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296779941/",
+"attendees": 14
+}
 ]

--- a/scripts/data/avlh3-meetup-history-batch-3.json
+++ b/scripts/data/avlh3-meetup-history-batch-3.json
@@ -1,52 +1,394 @@
 [
-{"title":"AVLH3 #765 - \"His name is Jack\" Hash 🎶🎵🎶","date":"2023-10-14","startTime":"14:00","location":"2582 Riceville Rd, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296151065/","attendees":11},
-{"title":"AVLH3 #765 - Cocky and Bearly Cum N U","date":"2023-10-07","startTime":"14:00","location":"Casa de Cocky, 4 Moody Ave,, Candler, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296151056/","attendees":4},
-{"title":"Moonshine H3 #105 - Harvest Moon - Spaghetti","date":"2023-09-29","startTime":"19:30","location":"Family dollar Parking Lot, 609 Haywood Road, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294575022/","attendees":5},
-{"title":"AVLH3 #764 - The one before the moon","date":"2023-09-29","startTime":"18:00","location":"Family Dollar Parking Lot, 609 Haywood Road, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/296151049/","attendees":5},
-{"title":"AVLH3 #763 - Spaghetti Shenanigans","date":"2023-09-23","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/295677297/","attendees":9},
-{"title":"AVLH3 #762 - Bobby and Squirt run it into the ground (get it? Get it??)","date":"2023-09-16","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/295512019/","attendees":7},
-{"title":"AVLH3 #761 - Blue Dress Weekend!","date":"2023-09-10","startTime":"13:00","location":"Highland Brewing Company, 12 Old Charlotte Highway, Suite 200, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294575137/","attendees":24},
-{"title":"AVLH3 #761 - Blue Dress Pre-Lube!","date":"2023-09-09","startTime":"17:00","location":"Rabbit Rabbit, 75 S French Broad Ave, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/295677252/","attendees":11},
-{"title":"AVLH3 #760 - HS and JtR's \"Stinky Mink\" Trail","date":"2023-09-02","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/295195282/","attendees":10},
-{"title":"TURBO'S OLYMPDICKS #759 - Trail & Games","date":"2023-08-26","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294575105/","attendees":11},
-{"title":"Moonshine H3 #103 - Sturgeon Moon - Cocky","date":"2023-08-25","startTime":"19:30","location":"Highland Brewing Company, 12 Old Charlotte Highway, Suite 200, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294575068/","attendees":6},
-{"title":"AVLH3 #758 - ART Crawl Pub Hash by OHB!","date":"2023-08-19","startTime":"15:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294575095/","attendees":13},
-{"title":"AVLH3 #757 - PF's Rogue Degenerate Tour","date":"2023-08-12","startTime":"14:00","location":"One Stop - Concert Stage, 29 1/2 Banks Avenue, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294575086/","attendees":14},
-{"title":"AVLH3 #756 - Midsommar Hash","date":"2023-08-05","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294575078/","attendees":13},
-{"title":"Moonshine H3 #102 - Buck Moon - Spaghetti","date":"2023-07-28","startTime":"19:30","location":"Fleetwood's, 496 Haywood Road, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150797/","attendees":10},
-{"title":"AVLH3 #755 - Merica! F*ck Yeah!!","date":"2023-07-29","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150832/","attendees":15},
-{"title":"AVLH3 #754 - pre-lube trail by Log Flume","date":"2023-07-22","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150813/","attendees":15},
-{"title":"AVLH3 #753 - Le Tour Stage 4","date":"2023-07-15","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150807/","attendees":6},
-{"title":"AVLH3 #752 - Le Tour Stage 3","date":"2023-07-08","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150800/","attendees":10},
-{"title":"AVLH3 #751 - Le Tour Avl h3 Stage 2","date":"2023-07-04","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150789/","attendees":17},
-{"title":"AVLH3 #750 - Le Tour de AVL H3 Stage 1","date":"2023-07-02","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150785/","attendees":9},
-{"title":"Moonshine H3 #101 - Strawberry Moon","date":"2023-06-30","startTime":"19:30","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/293751027/","attendees":13},
-{"title":"AVLH3 #749 - Hashathon pre-lube & naming!","date":"2023-07-01","startTime":"13:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150777/","attendees":11},
-{"title":"Hashathon 2023 - Asheville, NC!","date":"2023-06-30","startTime":"18:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/291735430/","attendees":20},
-{"title":"AVLH3 #747- Spaghetti gets the r*ns","date":"2023-07-01","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/294150781/","attendees":15},
-{"title":"AVLH3 #746 Just Bobby's Midlife Crisis the Musical","date":"2023-06-24","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/293437289/","attendees":8},
-{"title":"The Ending of an Era #745","date":"2023-06-17","startTime":"14:00","location":"19 Russell St, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/293013176/","attendees":17},
-{"title":"AVLH3 Trail #744 - The Grape Escape","date":"2023-06-10","startTime":"13:00","location":"French Broad River Park, 508 Riverview Dr., Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292711472/","attendees":15},
-{"title":"AVLH3 #743 - 💦Birthday Broad Float💦","date":"2023-06-04","startTime":"13:00","location":"Asheville Adventure Company, 521 Amboy Road,, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292711467/","attendees":23},
-{"title":"Moonshine H3 #100 - Flower Moon","date":"2023-05-26","startTime":"19:30","location":"Highland Brewing Company, 12 Old Charlotte Highway, Suite 200, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292506456/","attendees":17},
-{"title":"AVLH3 #742 - Memorial Weekend Shenanigans!","date":"2023-05-27","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292506477/","attendees":16},
-{"title":"AVLH3 #741 - A Stitch in Time...Saves the trail?","date":"2023-05-20","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292505625/","attendees":18},
-{"title":"AVLH3 #740 - Sicilian's Preakness Day Hash 🏇!","date":"2023-05-20","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292506442/","attendees":5},
-{"title":"AVLH3 #739 - Cocky's May the Fourth Prelube Trail","date":"2023-05-06","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292506435/","attendees":18},
-{"title":"AVLH3 #738 - Party Foul's Jurassic Hash!","date":"2023-04-29","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292506429/","attendees":7},
-{"title":"Moonshine H3 #99 - Pink Moon","date":"2023-04-28","startTime":"19:30","location":"Archetype Brewing - West, 174 Broadway St., Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292506424/","attendees":8},
-{"title":"AVLH3 #737 - hashers not trashers trail (pt 2!)","date":"2023-04-22","startTime":"10:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292506416/","attendees":12},
-{"title":"AVLH3 #736 ⚠️ POSTPONED ⚠️ Hashers Not Trashers Trail","date":"2023-04-15","startTime":"10:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/292506405/","attendees":3},
-{"title":"AVLH3 #735 - Easter Egg Run! 🥚🐇🐣","date":"2023-04-08","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/291735448/","attendees":12},
-{"title":"Moonshine H3 #98 - Worm Moon","date":"2023-03-31","startTime":"19:30","location":"Fleetwood's, 496 Haywood Road, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/291735442/","attendees":8},
-{"title":"AVLH3 #734 - Hare: Turbo Lover's March MadHash!","date":"2023-03-25","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/291735438/","attendees":17},
-{"title":"AVLH3 #733 - Red Dress 2023!! ❤️","date":"2023-03-11","startTime":"13:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/290939506/","attendees":26},
-{"title":"AVLH3 #732 - Hares: Bobby and Half Cocked (and Half Cocked)","date":"2023-03-04","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/291735435/","attendees":14},
-{"title":"Moonshine H3 #97 - Snow Moon","date":"2023-02-24","startTime":"19:30","location":"Upcountry Brewing, 1042 Haywood Road, Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/290704416/","attendees":7},
-{"title":"AVLH3 #731 - Onesie Run!","date":"2023-02-25","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/290704419/","attendees":19},
-{"title":"AVLH3 Mardi Gras Parade and Party! ⚜️🟢🟡🟣💃🕺🎷🎶","date":"2023-02-25","startTime":"11:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/291093654/","attendees":14},
-{"title":"AVLH3 #730 - Just Bobby and High Strung","date":"2023-02-19","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/290939444/","attendees":16},
-{"title":"AVLH3 #729 - Just Emily and Spaghetti and Lube Job!","date":"2023-02-19","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/290704413/","attendees":4},
-{"title":"AVLH3 #729 - Just Emily and Spaghetti's SUPER BOWL 🏈 HASH !","date":"2023-02-12","startTime":"15:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/290704410/","attendees":13},
-{"title":"AVLH3 #728 - FREE Hash Appreciation Trail by Mismanagement!","date":"2023-02-19","startTime":"14:00","location":"Asheville, NC, US","url":"https://www.meetup.com/avlh3-on-on/events/290704402/","attendees":18}
+{
+"title": "AVLH3 #765 - \"His name is Jack\" Hash 🎶🎵🎶",
+"date": "2023-10-14",
+"startTime": "14:00",
+"location": "2582 Riceville Rd, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296151065/",
+"attendees": 11
+},
+{
+"title": "AVLH3 #765 - Cocky and Bearly Cum N U",
+"date": "2023-10-07",
+"startTime": "14:00",
+"location": "Casa de Cocky, 4 Moody Ave,, Candler, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296151056/",
+"attendees": 4
+},
+{
+"title": "Moonshine H3 #105 - Harvest Moon - Spaghetti",
+"date": "2023-09-29",
+"startTime": "19:30",
+"location": "Family dollar Parking Lot, 609 Haywood Road, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294575022/",
+"attendees": 5
+},
+{
+"title": "AVLH3 #764 - The one before the moon",
+"date": "2023-09-29",
+"startTime": "18:00",
+"location": "Family Dollar Parking Lot, 609 Haywood Road, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/296151049/",
+"attendees": 5
+},
+{
+"title": "AVLH3 #763 - Spaghetti Shenanigans",
+"date": "2023-09-23",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/295677297/",
+"attendees": 9
+},
+{
+"title": "AVLH3 #762 - Bobby and Squirt run it into the ground (get it? Get it??)",
+"date": "2023-09-16",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/295512019/",
+"attendees": 7
+},
+{
+"title": "AVLH3 #761 - Blue Dress Weekend!",
+"date": "2023-09-10",
+"startTime": "13:00",
+"location": "Highland Brewing Company, 12 Old Charlotte Highway, Suite 200, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294575137/",
+"attendees": 24
+},
+{
+"title": "AVLH3 #761 - Blue Dress Pre-Lube!",
+"date": "2023-09-09",
+"startTime": "17:00",
+"location": "Rabbit Rabbit, 75 S French Broad Ave, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/295677252/",
+"attendees": 11
+},
+{
+"title": "AVLH3 #760 - HS and JtR's \"Stinky Mink\" Trail",
+"date": "2023-09-02",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/295195282/",
+"attendees": 10
+},
+{
+"title": "TURBO'S OLYMPDICKS #759 - Trail & Games",
+"date": "2023-08-26",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294575105/",
+"attendees": 11
+},
+{
+"title": "Moonshine H3 #103 - Sturgeon Moon - Cocky",
+"date": "2023-08-25",
+"startTime": "19:30",
+"location": "Highland Brewing Company, 12 Old Charlotte Highway, Suite 200, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294575068/",
+"attendees": 6
+},
+{
+"title": "AVLH3 #758 - ART Crawl Pub Hash by OHB!",
+"date": "2023-08-19",
+"startTime": "15:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294575095/",
+"attendees": 13
+},
+{
+"title": "AVLH3 #757 - PF's Rogue Degenerate Tour",
+"date": "2023-08-12",
+"startTime": "14:00",
+"location": "One Stop - Concert Stage, 29 1/2 Banks Avenue, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294575086/",
+"attendees": 14
+},
+{
+"title": "AVLH3 #756 - Midsommar Hash",
+"date": "2023-08-05",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294575078/",
+"attendees": 13
+},
+{
+"title": "Moonshine H3 #102 - Buck Moon - Spaghetti",
+"date": "2023-07-28",
+"startTime": "19:30",
+"location": "Fleetwood's, 496 Haywood Road, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150797/",
+"attendees": 10
+},
+{
+"title": "AVLH3 #755 - Merica! F*ck Yeah!!",
+"date": "2023-07-29",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150832/",
+"attendees": 15
+},
+{
+"title": "AVLH3 #754 - pre-lube trail by Log Flume",
+"date": "2023-07-22",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150813/",
+"attendees": 15
+},
+{
+"title": "AVLH3 #753 - Le Tour Stage 4",
+"date": "2023-07-15",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150807/",
+"attendees": 6
+},
+{
+"title": "AVLH3 #752 - Le Tour Stage 3",
+"date": "2023-07-08",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150800/",
+"attendees": 10
+},
+{
+"title": "AVLH3 #751 - Le Tour Avl h3 Stage 2",
+"date": "2023-07-04",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150789/",
+"attendees": 17
+},
+{
+"title": "AVLH3 #750 - Le Tour de AVL H3 Stage 1",
+"date": "2023-07-02",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150785/",
+"attendees": 9
+},
+{
+"title": "Moonshine H3 #101 - Strawberry Moon",
+"date": "2023-06-30",
+"startTime": "19:30",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/293751027/",
+"attendees": 13
+},
+{
+"title": "AVLH3 #749 - Hashathon pre-lube & naming!",
+"date": "2023-07-01",
+"startTime": "13:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150777/",
+"attendees": 11
+},
+{
+"title": "Hashathon 2023 - Asheville, NC!",
+"date": "2023-06-30",
+"startTime": "18:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/291735430/",
+"attendees": 20
+},
+{
+"title": "AVLH3 #747- Spaghetti gets the r*ns",
+"date": "2023-07-01",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/294150781/",
+"attendees": 15
+},
+{
+"title": "AVLH3 #746 Just Bobby's Midlife Crisis the Musical",
+"date": "2023-06-24",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/293437289/",
+"attendees": 8
+},
+{
+"title": "The Ending of an Era #745",
+"date": "2023-06-17",
+"startTime": "14:00",
+"location": "19 Russell St, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/293013176/",
+"attendees": 17
+},
+{
+"title": "AVLH3 Trail #744 - The Grape Escape",
+"date": "2023-06-10",
+"startTime": "13:00",
+"location": "French Broad River Park, 508 Riverview Dr., Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292711472/",
+"attendees": 15
+},
+{
+"title": "AVLH3 #743 - 💦Birthday Broad Float💦",
+"date": "2023-06-04",
+"startTime": "13:00",
+"location": "Asheville Adventure Company, 521 Amboy Road,, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292711467/",
+"attendees": 23
+},
+{
+"title": "Moonshine H3 #100 - Flower Moon",
+"date": "2023-05-26",
+"startTime": "19:30",
+"location": "Highland Brewing Company, 12 Old Charlotte Highway, Suite 200, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292506456/",
+"attendees": 17
+},
+{
+"title": "AVLH3 #742 - Memorial Weekend Shenanigans!",
+"date": "2023-05-27",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292506477/",
+"attendees": 16
+},
+{
+"title": "AVLH3 #741 - A Stitch in Time...Saves the trail?",
+"date": "2023-05-20",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292505625/",
+"attendees": 18
+},
+{
+"title": "AVLH3 #740 - Sicilian's Preakness Day Hash 🏇!",
+"date": "2023-05-20",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292506442/",
+"attendees": 5
+},
+{
+"title": "AVLH3 #739 - Cocky's May the Fourth Prelube Trail",
+"date": "2023-05-06",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292506435/",
+"attendees": 18
+},
+{
+"title": "AVLH3 #738 - Party Foul's Jurassic Hash!",
+"date": "2023-04-29",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292506429/",
+"attendees": 7
+},
+{
+"title": "Moonshine H3 #99 - Pink Moon",
+"date": "2023-04-28",
+"startTime": "19:30",
+"location": "Archetype Brewing - West, 174 Broadway St., Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292506424/",
+"attendees": 8
+},
+{
+"title": "AVLH3 #737 - hashers not trashers trail (pt 2!)",
+"date": "2023-04-22",
+"startTime": "10:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/292506416/",
+"attendees": 12
+},
+{
+"title": "AVLH3 #735 - Easter Egg Run! 🥚🐇🐣",
+"date": "2023-04-08",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/291735448/",
+"attendees": 12
+},
+{
+"title": "Moonshine H3 #98 - Worm Moon",
+"date": "2023-03-31",
+"startTime": "19:30",
+"location": "Fleetwood's, 496 Haywood Road, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/291735442/",
+"attendees": 8
+},
+{
+"title": "AVLH3 #734 - Hare: Turbo Lover's March MadHash!",
+"date": "2023-03-25",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/291735438/",
+"attendees": 17
+},
+{
+"title": "AVLH3 #733 - Red Dress 2023!! ❤️",
+"date": "2023-03-11",
+"startTime": "13:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/290939506/",
+"attendees": 26
+},
+{
+"title": "AVLH3 #732 - Hares: Bobby and Half Cocked (and Half Cocked)",
+"date": "2023-03-04",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/291735435/",
+"attendees": 14
+},
+{
+"title": "Moonshine H3 #97 - Snow Moon",
+"date": "2023-02-24",
+"startTime": "19:30",
+"location": "Upcountry Brewing, 1042 Haywood Road, Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/290704416/",
+"attendees": 7
+},
+{
+"title": "AVLH3 #731 - Onesie Run!",
+"date": "2023-02-25",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/290704419/",
+"attendees": 19
+},
+{
+"title": "AVLH3 Mardi Gras Parade and Party! ⚜️🟢🟡🟣💃🕺🎷🎶",
+"date": "2023-02-25",
+"startTime": "11:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/291093654/",
+"attendees": 14
+},
+{
+"title": "AVLH3 #730 - Just Bobby and High Strung",
+"date": "2023-02-19",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/290939444/",
+"attendees": 16
+},
+{
+"title": "AVLH3 #729 - Just Emily and Spaghetti and Lube Job!",
+"date": "2023-02-19",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/290704413/",
+"attendees": 4
+},
+{
+"title": "AVLH3 #729 - Just Emily and Spaghetti's SUPER BOWL 🏈 HASH !",
+"date": "2023-02-12",
+"startTime": "15:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/290704410/",
+"attendees": 13
+},
+{
+"title": "AVLH3 #728 - FREE Hash Appreciation Trail by Mismanagement!",
+"date": "2023-02-19",
+"startTime": "14:00",
+"location": "Asheville, NC, US",
+"url": "https://www.meetup.com/avlh3-on-on/events/290704402/",
+"attendees": 18
+}
 ]

--- a/scripts/import-meetup-history.ts
+++ b/scripts/import-meetup-history.ts
@@ -44,6 +44,13 @@ function extractRunNumber(title: string): number | undefined {
   return Number.isFinite(num) && num >= 1 ? num : undefined;
 }
 
+/** Skip titles that are clearly not real completed events. */
+const SKIP_TITLE_RE = /\bPOSTPONED\b|\bCANCEL(?:L?ED)\b|\bNEEDS?\s+(?:A\s+)?HARE\b/i;
+
+function isPlaceholderEvent(title: string): boolean {
+  return SKIP_TITLE_RE.test(title);
+}
+
 /** Parse CLI arguments for --kennel and --source. */
 function parseArgs(): { kennelCode: string; sourceName: string } {
   const args = process.argv.slice(2);
@@ -76,36 +83,43 @@ async function readStdin(): Promise<string> {
  * fragile global-regex approach that could corrupt data containing "] ["
  * inside string values.
  */
-function parseJsonArrays(raw: string): MeetupHistoryRow[] {
+interface ParseResult {
+  rows: MeetupHistoryRow[];
+  /** True when at least one chunk failed to parse. */
+  hadParseErrors: boolean;
+}
+
+function parseJsonArrays(raw: string): ParseResult {
   const trimmed = raw.trim();
 
   // Fast path: single file, single array
   try {
     const parsed = JSON.parse(trimmed);
-    if (Array.isArray(parsed)) return parsed;
+    if (Array.isArray(parsed)) return { rows: parsed, hadParseErrors: false };
   } catch {
     // Fall through to multi-array parsing
   }
 
   // Multi-file: split on "]<whitespace>[" boundary, re-bracket each chunk
-  const allRows: MeetupHistoryRow[] = [];
+  const rows: MeetupHistoryRow[] = [];
+  let hadParseErrors = false;
   const chunks = trimmed.split(/\]\s*\[/);
   for (let i = 0; i < chunks.length; i++) {
     let chunk = chunks[i];
-    // Re-add the brackets stripped by the split
     if (i === 0) chunk = chunk + "]";
     else if (i === chunks.length - 1) chunk = "[" + chunk;
     else chunk = "[" + chunk + "]";
 
     try {
       const parsed = JSON.parse(chunk);
-      if (Array.isArray(parsed)) allRows.push(...parsed);
+      if (Array.isArray(parsed)) rows.push(...parsed);
     } catch (err) {
-      console.warn(`[chunk ${i}] Failed to parse: ${(err as Error).message}`);
-      console.warn(`  First 100 chars: ${chunk.slice(0, 100)}`);
+      hadParseErrors = true;
+      console.error(`[chunk ${i}] Failed to parse: ${(err as Error).message}`);
+      console.error(`  First 100 chars: ${chunk.slice(0, 100)}`);
     }
   }
-  return allRows;
+  return { rows, hadParseErrors };
 }
 
 async function main() {
@@ -120,20 +134,29 @@ async function main() {
     process.exit(1);
   }
 
-  const allRows = parseJsonArrays(raw);
+  const { rows: allRows, hadParseErrors } = parseJsonArrays(raw);
   if (allRows.length === 0) {
     console.error("Parsed 0 rows from stdin — input may be malformed.");
     process.exit(1);
   }
+  if (hadParseErrors && apply) {
+    console.error("Aborting: at least one JSON chunk failed to parse. Fix the input before applying.");
+    process.exit(1);
+  }
 
-  console.log(`Parsed ${allRows.length} rows from stdin.`);
+  console.log(`Parsed ${allRows.length} rows from stdin.${hadParseErrors ? " (WARNING: some chunks failed — dry run only)" : ""}`);
 
-  // Convert to RawEventData
+  // Convert to RawEventData, filtering out placeholders/cancelled events
   const events: RawEventData[] = [];
   let skipped = 0;
+  let skippedPlaceholder = 0;
   for (const row of allRows) {
     if (!row.date || !row.title) { skipped++; continue; }
     if (!/^\d{4}-\d{2}-\d{2}$/.test(row.date)) { skipped++; continue; }
+    if (isPlaceholderEvent(row.title)) {
+      skippedPlaceholder++;
+      continue;
+    }
 
     events.push({
       date: row.date,
@@ -156,7 +179,7 @@ async function main() {
     unique.push(event);
   }
 
-  console.log(`Valid: ${events.length}, unique: ${unique.length}, skipped: ${skipped}`);
+  console.log(`Valid: ${events.length}, unique: ${unique.length}, skipped: ${skipped}, placeholders filtered: ${skippedPlaceholder}`);
   if (unique.length === 0) { console.log("Nothing to import."); return; }
 
   // Sort by date for readable output

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -112,14 +112,20 @@ describe("processRawEvents", () => {
     mockEventUpdate.mockResolvedValue({ id: "evt_1" } as never);
 
     const result = await processRawEvents("src_1", [buildRawEvent()]);
-    // The enrichment path should have called update for NULL-field filling,
-    // but NOT for the full-update branch (which requires trust >= 8).
-    expect(result.updated).toBe(2); // RawEvent link + enrichment
-    // The update should only contain the enrichment fields, not title/runNumber/etc.
+    // updated is 1 (the matched-event counter at line 850). The enrichment
+    // path fires an update call but doesn't double-count.
+    expect(result.updated).toBe(1);
+    // The enrichment update should contain description/hares/location/startTime
+    // but NOT title, runNumber, or other full-update-only fields.
     const enrichCall = mockEventUpdate.mock.calls.find(
       (call: unknown[]) => (call[0] as { data?: { description?: string } })?.data?.description,
     );
     expect(enrichCall).toBeDefined();
+    const enrichData = (enrichCall![0] as { data: Record<string, unknown> }).data;
+    expect(enrichData).toHaveProperty("description");
+    expect(enrichData).not.toHaveProperty("title");
+    expect(enrichData).not.toHaveProperty("runNumber");
+    expect(enrichData).not.toHaveProperty("trustLevel");
   });
 
   it("tracks unmatched kennel tags", async () => {

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -104,13 +104,22 @@ describe("processRawEvents", () => {
     expect(mockEventUpdate).toHaveBeenCalled();
   });
 
-  it("does not update when trust level is lower", async () => {
+  it("does not full-update when trust level is lower, but enriches NULL fields", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
+    // Existing event has trust 8; source trust is 5. All user-facing fields
+    // are null/undefined so the lower-trust enrichment path fills them.
     mockEventFindMany.mockResolvedValueOnce([{ id: "evt_1", trustLevel: 8 }] as never);
+    mockEventUpdate.mockResolvedValue({ id: "evt_1" } as never);
 
     const result = await processRawEvents("src_1", [buildRawEvent()]);
-    expect(result.updated).toBe(1);
-    expect(mockEventUpdate).not.toHaveBeenCalled();
+    // The enrichment path should have called update for NULL-field filling,
+    // but NOT for the full-update branch (which requires trust >= 8).
+    expect(result.updated).toBe(2); // RawEvent link + enrichment
+    // The update should only contain the enrichment fields, not title/runNumber/etc.
+    const enrichCall = mockEventUpdate.mock.calls.find(
+      (call: unknown[]) => (call[0] as { data?: { description?: string } })?.data?.description,
+    );
+    expect(enrichCall).toBeDefined();
   });
 
   it("tracks unmatched kennel tags", async () => {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -721,7 +721,8 @@ async function upsertCanonicalEvent(
       });
     }
 
-    // Update only if our source trust level >= existing
+    // Update only if our source trust level >= existing; lower-trust
+    // sources get the null-field enrichment path in the else branch.
     if (ctx.trustLevel >= existingEvent.trustLevel) {
       const coords = await resolveCoords(event, {
         latitude: existingEvent.latitude,
@@ -804,31 +805,33 @@ async function upsertCanonicalEvent(
       });
     }
 
-    // Lower-trust enrichment: when a source's trust is below the canonical
-    // event's, it can still fill NULL fields. This lets enrichment-only
-    // sources (e.g. a scribe/write-up page) provide description, hares,
-    // location, or start time that the primary source doesn't carry, without
-    // being able to overwrite fields the primary source already set.
-    if (ctx.trustLevel < existingEvent.trustLevel) {
+    // Lower-trust enrichment: fill NULL fields without overwriting non-null
+    // data set by the higher-trust primary source. Sanitizers that return
+    // null (e.g. placeholder "TBD" values) are excluded from the payload so
+    // we don't write null over null and trigger a redundant DB round-trip.
+    // dateUtc is intentionally NOT updated here — it stays at noon UTC by
+    // design (CLAUDE.md Appendix F.4); startTime is a display-only string.
+    else {
       const enrichData: Record<string, unknown> = {};
-      if (!existingEvent.description && event.description !== undefined && event.description) {
+      if (!existingEvent.description && event.description) {
         enrichData.description = event.description;
       }
-      if (!existingEvent.haresText && event.hares !== undefined && event.hares) {
-        enrichData.haresText = sanitizeHares(event.hares);
+      if (!existingEvent.haresText && event.hares) {
+        const sanitized = sanitizeHares(event.hares);
+        if (sanitized) enrichData.haresText = sanitized;
       }
-      if (!existingEvent.locationName && event.location !== undefined && event.location) {
-        enrichData.locationName = sanitizeLocation(event.location);
+      if (!existingEvent.locationName && event.location) {
+        const sanitized = sanitizeLocation(event.location);
+        if (sanitized) enrichData.locationName = sanitized;
       }
-      if (!existingEvent.startTime && event.startTime !== undefined && event.startTime) {
+      if (!existingEvent.startTime && event.startTime) {
         enrichData.startTime = event.startTime;
       }
       if (Object.keys(enrichData).length > 0) {
         await prisma.event.update({
           where: { id: existingEvent.id },
-          data: { ...enrichData, updatedAt: new Date() },
+          data: enrichData,
         });
-        ctx.result.updated++;
       }
     }
 

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -804,6 +804,34 @@ async function upsertCanonicalEvent(
       });
     }
 
+    // Lower-trust enrichment: when a source's trust is below the canonical
+    // event's, it can still fill NULL fields. This lets enrichment-only
+    // sources (e.g. a scribe/write-up page) provide description, hares,
+    // location, or start time that the primary source doesn't carry, without
+    // being able to overwrite fields the primary source already set.
+    if (ctx.trustLevel < existingEvent.trustLevel) {
+      const enrichData: Record<string, unknown> = {};
+      if (!existingEvent.description && event.description !== undefined && event.description) {
+        enrichData.description = event.description;
+      }
+      if (!existingEvent.haresText && event.hares !== undefined && event.hares) {
+        enrichData.haresText = sanitizeHares(event.hares);
+      }
+      if (!existingEvent.locationName && event.location !== undefined && event.location) {
+        enrichData.locationName = sanitizeLocation(event.location);
+      }
+      if (!existingEvent.startTime && event.startTime !== undefined && event.startTime) {
+        enrichData.startTime = event.startTime;
+      }
+      if (Object.keys(enrichData).length > 0) {
+        await prisma.event.update({
+          where: { id: existingEvent.id },
+          data: { ...enrichData, updatedAt: new Date() },
+        });
+        ctx.result.updated++;
+      }
+    }
+
     // If this source provides a different sourceUrl, create an EventLink for it
     if (event.sourceUrl && existingEvent.sourceUrl && event.sourceUrl !== existingEvent.sourceUrl) {
       await prisma.eventLink.upsert({


### PR DESCRIPTION
## Summary

Closes #585 — the longest-running audit issue (filed Apr 9, re-fired daily).

### Root cause
Calgary H3 has two sources: Home (trust 8, creates events with title + location but no description/hares) and Scribe (trust 7, has description + hares). The merge pipeline's trust gate at \`merge.ts:725\` blocked all updates from the lower-trust Scribe, leaving description permanently null.

### Fix: null-field enrichment path in the merge pipeline

Instead of raising the Scribe's trust (which would let it overwrite ALL fields — a data-integrity regression caught by codex), added a **null-field enrichment path** in the else branch of the trust gate:

\`\`\`
if (trustLevel >= existing.trustLevel) {
  // Full update (existing behavior)
} else {
  // Lower-trust enrichment: fill only NULL fields
  // description, haresText, locationName, startTime
}
\`\`\`

This benefits **all source pairs** where a lower-trust enrichment source provides fields the primary source doesn't — not just Calgary.

### Codex adversarial review — 3 findings addressed

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | high | Trust-8 Scribe overwrites everything | Reverted to trust 7 + added null-field enrichment path |
| 2 | high | POSTPONED/NEEDS HARE events imported as real history | Added skip filter + scrubbed batch files (5 rows removed) |
| 3 | medium | Partial JSON parse continues in apply mode | \`hadParseErrors\` flag aborts apply-mode before processRawEvents |

### Also in this PR (from earlier commits)
- B2BH3 profile enrichment (#652–#654)
- RDH3 titleHarePattern (#661)
- Asheville Meetup historical import tooling + 201 events backfilled
- Chrome prompt for Meetup scraping

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] 4351 tests passing (merge test updated for enrichment behavior)
- [x] Calgary Scribe reverted to trust 7 on prod
- [x] Calgary event \`cmng9kc6t000m04l55b8fzttn\` already has description from prior one-shot SQL

Closes #585, #652, #653, #654, #655, #656, #657, #661, #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)