### PR TITLE
fix(audit): B3H4 + BAH3 profiles, source fix, and wide-window scrapes

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -130,6 +130,8 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "bobbh3", shortName: "B3H4", fullName: "Boston Ballbuster Hardcore Hash House Harriers", region: "Boston, MA",
+      website: "https://bostonhash.com/about/kennels",
+      instagramHandle: "@bostonh3",
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
     },
     { kennelCode: "beantown", shortName: "Beantown", fullName: "Beantown City Hash House Harriers", region: "Boston, MA" },
@@ -378,8 +380,11 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "bah3", shortName: "BAH3", fullName: "Baltimore Annapolis Hash House Harriers", region: "Baltimore, MD",
       website: "https://www.bah3.org",
+      logoUrl: "https://lh3.googleusercontent.com/sitesv/APaQ0SSucYaZkcO7GC7BlT8OXRH9YojrWGQqsXTQ0euCA3FIaQisokS_NqUzdXzeCozPE4ERZwS2xTQtpo4ofzFVYJh62L6agOS8aj261HbtJYpS4ng_ekpjln9XrFZBfWypgM-LEynRgLqSSlhP6XesBg_MS9q1hk0lkTiOunVD6A-dsngliBNQh8CzqdM=w16383",
+      contactEmail: "bahhh.gm@gmail.com",
+      foundedYear: 1994,
       scheduleDayOfWeek: "Sunday", scheduleTime: "3:00 PM", scheduleFrequency: "Weekly",
-      description: "Weekly Sunday 3 PM hash in the Baltimore/Annapolis area.",
+      description: "Weekly Sunday 3 PM hash in the Baltimore/Annapolis area. Annapolis hash created 1986, Baltimore 1990, merged as BAH3 in 1994.",
     },
     {
       kennelCode: "mvh3", shortName: "MVH3", fullName: "Mount Vernon Hash House Harriers", region: "Washington, DC",


### PR DESCRIPTION
## Summary

B3H4 (#666–#672) and BAH3 (#674–#679) — 13 issues resolved.

### B3H4 (Boston Ballbuster)
- **#666**: Cleared misattributed BH3 run #2745 from a joint event (direct prod SQL fix)
- **#667 + #669**: Instagram handle + website link added to seed + prod
- **#668/#670/#671/#672**: Closed as schema gap, source limitation, or no-action

### BAH3 (Baltimore/Annapolis)
- **#675**: Disabled broken iCal feed (bah3.org migrated to Google Sites)
- **#674 + #677**: Widened GCal scrapeDays 90 → 365, triggered days=3000 scrape → **34 new events** created
- **#676**: Profile enrichment: foundedYear 1994, contactEmail, logoUrl, enriched description
- **#678/#679**: Closed as schema gap + source coverage observation

New audit workflow memory: always trigger wide-window scrapes for GCal-backed kennels (API-backed = safe, free history).

Closes #666, #667, #668, #669, #670, #671, #672, #674, #675, #676, #677, #678, #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)