### PR TITLE
fix(audit): BruH3 title/location + Edinburgh hares + Hangover location extraction

### DIFF
--- a/src/adapters/html-scraper/bruh3.ts
+++ b/src/adapters/html-scraper/bruh3.ts
@@ -36,8 +36,13 @@ const DEFAULT_START_TIME = "15:00";
 
 // ── Regex patterns ──
 
-/** Match run number: "Hash 2339" or "Hash 2339:" */
+/** Match run number + optional date + optional event name:
+ *  "Hash 2341:     11.04.26     Wood Anemone Hash" */
 const HASH_NUMBER_RE = /Hash\s+(\d{3,4})/i;
+/** Match event name on the same line as the Hash number + date:
+ *  "Hash 2341:     11.04.26     Wood Anemone Hash"
+ *  Uses [ \t]+ (horizontal whitespace only) so it doesn't jump to the next line. */
+const HASH_TITLE_RE = /Hash\s+\d{3,4}:?[ \t]+\d{2}\.\d{2}\.\d{2}[ \t]+([^\n]+)/i;
 
 /** Match European date: DD.MM.YY */
 const DATE_RE = /(\d{2})\.(\d{2})\.(\d{2})/;
@@ -105,14 +110,26 @@ export function parseEventBlock(
   const hareMatch = HARE_RE.exec(text);
   const hares = hareMatch ? hareMatch[1].trim() : undefined;
 
-  // Extract location
+  // Extract event name from the first line (after date): "Hash 2341: 11.04.26 Wood Anemone Hash"
+  const titleMatch = HASH_TITLE_RE.exec(text);
+  const eventName = titleMatch ? titleMatch[1].trim() : undefined;
+
+  // Extract location — strip trailing ": lat, lng" GPS coordinates that
+  // leave a dangling colon on the place name (e.g. "Kortenberg: 50.868, 4.562")
   const locMatch = LOCATION_RE.exec(text);
-  const location = locMatch ? locMatch[1].trim() : undefined;
+  let location = locMatch ? locMatch[1].trim() : undefined;
+  if (location) {
+    location = location.replace(/:\s*-?\d+\.\d+\s*,\s*-?\d+\.\d+\s*$/, "").trim();
+  }
+
+  const title = eventName
+    ? `BruH3 #${runNumber} — ${eventName}`
+    : `BruH3 #${runNumber}`;
 
   return {
     date,
     kennelTag: KENNEL_TAG,
-    title: `BruH3 #${runNumber}`,
+    title,
     runNumber,
     hares,
     location,

--- a/src/adapters/html-scraper/edinburgh-h3.test.ts
+++ b/src/adapters/html-scraper/edinburgh-h3.test.ts
@@ -106,6 +106,26 @@ ON INN The Oxford Bar`;
       expect(run!.onInn).toBe("The Oxford Bar");
     });
 
+    it("does not let ON INN prose overwrite real hare names (#659)", () => {
+      // The ON INN section can contain "Hare will provide soup..." which
+      // matches /^Hares?/ but is prose, not the hare field. The first-match
+      // guard ensures the real "Hares Ankle Grinder & Flying Boats" sticks
+      // and the later prose line is ignored.
+      const block = `Run No. 2305
+Date 12th April 2026
+Hares Ankle Grinder & Flying Boats
+Venue Meldon Hills car park
+Time 11:00
+ON INN: An informal affair at Dean Cottage
+Hare will provide soup, sandwiches, beer and bubbles.`;
+
+      const run = parseRunBlock(block);
+
+      expect(run).not.toBeNull();
+      expect(run!.hares).toBe("Ankle Grinder & Flying Boats");
+      expect(run!.hares).not.toContain("soup");
+    });
+
     it("returns null for empty text", () => {
       expect(parseRunBlock("")).toBeNull();
       expect(parseRunBlock("   \n  \n  ")).toBeNull();

--- a/src/adapters/html-scraper/edinburgh-h3.ts
+++ b/src/adapters/html-scraper/edinburgh-h3.ts
@@ -65,12 +65,16 @@ export function parseRunBlock(block: string): ParsedRun | null {
       continue;
     }
 
-    // Hares Name & Name
-    const haresMatch = /^Hares?\s+(.+)/i.exec(line);
-    if (haresMatch) {
-      const hares = stripPlaceholder(haresMatch[1]);
-      if (hares) result.hares = hares;
-      continue;
+    // Hares Name & Name — only take the FIRST match. The ON INN section
+    // can contain "Hare will provide soup..." which also matches /^Hare/
+    // and would overwrite the real hare names. Closes #659.
+    if (!result.hares) {
+      const haresMatch = /^Hares?\s+(.+)/i.exec(line);
+      if (haresMatch) {
+        const hares = stripPlaceholder(haresMatch[1]);
+        if (hares) result.hares = hares;
+        continue;
+      }
     }
 
     // Venue Location text (postcode)

--- a/src/adapters/html-scraper/hangover.ts
+++ b/src/adapters/html-scraper/hangover.ts
@@ -108,7 +108,7 @@ export function parseHangoverBody(text: string): {
     .replace(/\r/g, "") // Normalize Windows newlines.
     .replace(/\s+/g, " ") // Collapse inconsistent spacing from extracted HTML text.
     // Put labeled fields on their own logical lines so downstream field regexes are reliable.
-    .replace(/\s+(Date|When|Hare(?:\(s\)|s)?|Trail Start|Start|Location|Where|Hash Cash|Cost|Directions|Trail Type|On[- ]?After|On On(?: Brunch)?)\s*:/gi, "\n$1: ")
+    .replace(/\s+(Date|When|Hare(?:\(s\)|s)?|Trail Start|Start|Location|Where|Hash Cash|Cost|Directions|Trail (?:Type|Length)|On[- ]?After|On On(?: Brunch)?|Metro Accessibility|D.Erections|Parking|Shiggy Rating|Dog Friendly|Stroller Friendly)\s*:/gi, "\n$1: ")
     // Normalize compact "Pack Away at" / "Hare Away at" variants into a line boundary.
     .replace(/\s+(Pack Away|Hares? Away)\s+at\s+/gi, "\n$1 at ")
     // Normalize distance labels so Eagle/Turkey/Penguin can be extracted independently.


### PR DESCRIPTION
## Summary

Three adapter extraction bugs, oldest first:

### #630 BruH3 — title + trailing colon
1. **Title**: "Hash 2341: 11.04.26 Wood Anemone Hash" now extracts the event name from the first line → "BruH3 #2341 — Wood Anemone Hash" instead of the bare default. Regex uses horizontal-whitespace-only anchor (\`[ \\t]+\`) to avoid jumping to the next line.
2. **Location**: strips trailing \`: lat, lng\` GPS coordinates so "Kortenberg:" becomes "Kortenberg".

### #659 Edinburgh H3 — hares overwritten by ON INN
The ON INN section contains "Hare will provide soup..." which matched \`/^Hares?/\` and overwrote the real hare names ("Ankle Grinder & Flying Boats"). Fix: only set hares on the FIRST match (\`if (!result.hares)\`).

### #660 Hangover H3 — location captures full metadata
The line-break normalization regex didn't include Hangover's DigitalPress field labels (Metro Accessibility, Parking, Trail Length, Shiggy Rating, Dog Friendly, Stroller Friendly, D'Erections). Without line breaks, the location regex captured the entire metadata block as one string. Added the missing labels.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] 79 adapter tests passing (29 BruH3 + 15 Edinburgh + 35 Hangover)
- [x] Full suite: 4406 passing
- [ ] Post-merge: re-scrape all three to verify prod data

Closes #630, #659, #660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)