### PR TITLE
fix(audit): BARH3 + MH3 placeholder + B3H4 profile

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -517,9 +517,11 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "barh3", shortName: "BARH3", fullName: "Bay Area Rabble Hash", region: "San Francisco, CA",
       twitterHandle: "@BARH3",
-      scheduleDayOfWeek: "Wednesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Bar-to-bar live hare hash starting at various BART stations",
-      description: "Weekly Wednesday evening bar-to-bar live hare hash. Starts at BART stations across the Bay Area.",
+      hashCash: "Free",
+      foundedYear: 2009,
+      scheduleDayOfWeek: "Wednesday", scheduleTime: "6:30 PM", scheduleFrequency: "Biweekly",
+      scheduleNotes: "Bar-to-bar live hare hash starting at various BART stations.",
+      description: "Biweekly Wednesday evening bar-to-bar live hare hash. Starts at BART stations across the Bay Area. Free hash cash.",
     },
     {
       kennelCode: "marinh3", shortName: "MarinH3", fullName: "Marin Hash House Harriers", region: "Marin County, CA",

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -512,7 +512,7 @@ export function stripNonEnglishCountry(location: string): string {
 // ---------------------------------------------------------------------------
 
 const PLACEHOLDER_RE =
-  /^(?:tbd|tba|tbc|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3})$/i;
+  /^(?:tbd|tba|tbc|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3}|hares?\s+needed\b.*|needs?\s+(?:a\s+)?hares?\b.*)$/i;
 
 /**
  * Field labels that frequently appear next to a colon in event descriptions

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -512,7 +512,7 @@ export function stripNonEnglishCountry(location: string): string {
 // ---------------------------------------------------------------------------
 
 const PLACEHOLDER_RE =
-  /^(?:tbd|tba|tbc|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3}|hares?\s+needed\b.*|needs?\s+(?:a\s+)?hares?\b.*)$/i;
+  /^(?:tbd|tba|tbc|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3}|hares?\s+needed\b[\s\S]*|needs?\s+(?:a\s+)?hares?\b[\s\S]*)$/i;
 
 /**
  * Field labels that frequently appear next to a colon in event descriptions


### PR DESCRIPTION
## Summary

### BARH3 (#682–#687)
- **#685**: Profile enrichment (foundedYear 2009, hashCash "Free", Biweekly)
- **#682/#683/#684/#686/#687**: Closed as source limitations (HTML returns 0, iCal limited window, retroactive posting, schema gap)

### MH3 (#629)
- Broadened \`PLACEHOLDER_RE\` to catch "hares needed..." and "needs a hare..." sentence patterns
- Source spreadsheet has descriptive notes in the Hared by column — now filtered as placeholders

### B3H4 (#667, #669)
- Instagram handle + website link in seed

### BMH3 (#615)
- Multi-line hare extraction is a known limitation of \`extractHares()\` — filed #690 as a well-documented enhancement

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] 4407 tests passing
- [x] All profile data applied to prod

Closes #615, #629, #682, #683, #684, #685, #686, #687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)