### PR TITLE
feat(admin): deep-dive kennel selector — pick any kennel from the queue

### DIFF
--- a/src/components/admin/AuditDashboard.tsx
+++ b/src/components/admin/AuditDashboard.tsx
@@ -328,61 +328,10 @@ export function AuditDashboard({
           color="bg-purple-500/10 text-purple-500"
         />
         <DeepDiveCard
-          next={deepDiveQueue[0] ?? null}
+          queue={deepDiveQueue}
           coverage={deepDiveCoverage}
           onCompleted={() => router.refresh()}
         />
-        {deepDiveQueue.length > 1 && (
-          <div className="rounded-xl border border-border/50 bg-card overflow-hidden">
-            <div className="px-5 py-3 border-b border-border/50">
-              <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Next up
-              </h3>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border/30">
-                    <th className="px-5 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Kennel
-                    </th>
-                    <th className="px-5 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Region
-                    </th>
-                    <th className="px-5 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Last Dived
-                    </th>
-                    <th className="px-5 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Sources
-                    </th>
-                    <th className="px-5 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Events 90d
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border/30">
-                  {deepDiveQueue.slice(1, 11).map(k => (
-                    <tr key={k.kennelCode} className="hover:bg-accent/30 transition-colors">
-                      <td className="px-5 py-2.5 font-medium">{k.shortName}</td>
-                      <td className="px-5 py-2.5 text-muted-foreground">{k.region}</td>
-                      <td className="px-5 py-2.5 text-muted-foreground tabular-nums text-xs">
-                        {k.lastDeepDiveAt
-                          ? new Date(k.lastDeepDiveAt).toISOString().split("T")[0]
-                          : "never"}
-                      </td>
-                      <td className="px-5 py-2.5 text-right tabular-nums font-mono text-xs">
-                        {k.sources.length}
-                      </td>
-                      <td className="px-5 py-2.5 text-right tabular-nums font-mono text-xs">
-                        {k.eventCount90d}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
       </section>
 
       {/* ── Suppressions ───────────────────────────────────────── */}
@@ -796,18 +745,21 @@ function CopyHarelinePromptButton({ prompt }: Readonly<{ prompt: string }>) {
 // ── Deep Dive Card ──────────────────────────────────────────────────
 
 function DeepDiveCard({
-  next,
+  queue,
   coverage,
   onCompleted,
 }: {
-  next: DeepDiveCandidate | null;
+  queue: DeepDiveCandidate[];
   coverage: DeepDiveCoverage;
   onCompleted: () => void;
 }) {
+  const [selectedCode, setSelectedCode] = useState(queue[0]?.kennelCode ?? "");
   const [completeOpen, setCompleteOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  if (!next) {
+  const currentKennel = queue.find((k) => k.kennelCode === selectedCode) ?? queue[0];
+
+  if (!currentKennel || queue.length === 0) {
     return (
       <div className="rounded-xl border border-border/50 bg-card p-6 text-center">
         <Telescope className="mx-auto mb-2 h-8 w-8 text-muted-foreground" />
@@ -818,9 +770,6 @@ function DeepDiveCard({
     );
   }
 
-  // Capture the narrowed reference so the closure doesn't need a non-null assertion
-  const currentKennel = next;
-
   function handleCopy() {
     void navigator.clipboard.writeText(buildDeepDivePrompt(currentKennel));
     setCopied(true);
@@ -830,26 +779,40 @@ function DeepDiveCard({
   const lastDived =
     currentKennel.lastDeepDiveAt === null
       ? "never"
-      : new Date(currentKennel.lastDeepDiveAt).toISOString().split("T")[0];
+      : (currentKennel.lastDeepDiveAt instanceof Date
+          ? currentKennel.lastDeepDiveAt
+          : new Date(currentKennel.lastDeepDiveAt)
+        ).toISOString().split("T")[0];
 
   return (
     <>
+      {/* ── Selected kennel card ── */}
       <div className="rounded-xl border border-border/50 bg-card p-5">
         <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-              Today&apos;s target
+          <div className="min-w-0 flex-1">
+            <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-1.5">
+              Deep dive target
             </div>
-            <div className="mt-1 text-xl font-bold tracking-tight">
-              {next.shortName}
-            </div>
-            <div className="mt-1 text-xs text-muted-foreground">
-              {next.region} · {next.sources.length} source
-              {next.sources.length === 1 ? "" : "s"} · {next.eventCount90d} events in last
-              90d · last dived {lastDived}
+            <Select value={selectedCode} onValueChange={(v) => { setSelectedCode(v); setCopied(false); }}>
+              <SelectTrigger className="h-9 w-full max-w-sm text-base font-semibold">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {queue.map((k) => (
+                  <SelectItem key={k.kennelCode} value={k.kennelCode}>
+                    <span className="font-medium">{k.shortName}</span>
+                    <span className="ml-2 text-xs text-muted-foreground">{k.region}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <div className="mt-2 text-xs text-muted-foreground">
+              {currentKennel.region} · {currentKennel.sources.length} source
+              {currentKennel.sources.length === 1 ? "" : "s"} · {currentKennel.eventCount90d} events
+              in last 90d · last dived {lastDived}
             </div>
           </div>
-          <div className="flex shrink-0 gap-2">
+          <div className="flex shrink-0 gap-2 pt-6">
             <Button variant="outline" size="sm" onClick={handleCopy}>
               {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
               {copied ? "Copied" : "Copy prompt"}
@@ -873,10 +836,72 @@ function DeepDiveCard({
           )}
         </div>
       </div>
+
+      {/* ── Queue table (clickable rows select the kennel above) ── */}
+      {queue.length > 1 && (
+        <div className="rounded-xl border border-border/50 bg-card overflow-hidden">
+          <div className="px-5 py-3 border-b border-border/50">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Queue
+            </h3>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border/30">
+                  <th className="px-5 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Kennel
+                  </th>
+                  <th className="px-5 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Region
+                  </th>
+                  <th className="px-5 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Last Dived
+                  </th>
+                  <th className="px-5 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Sources
+                  </th>
+                  <th className="px-5 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Events 90d
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/30">
+                {queue.slice(0, 15).map((k) => (
+                  <tr
+                    key={k.kennelCode}
+                    className={`cursor-pointer transition-colors ${
+                      k.kennelCode === selectedCode
+                        ? "bg-accent/50 border-l-2 border-l-purple-500"
+                        : "hover:bg-accent/30"
+                    }`}
+                    onClick={() => { setSelectedCode(k.kennelCode); setCopied(false); }}
+                  >
+                    <td className="px-5 py-2.5 font-medium">{k.shortName}</td>
+                    <td className="px-5 py-2.5 text-muted-foreground">{k.region}</td>
+                    <td className="px-5 py-2.5 text-muted-foreground tabular-nums text-xs">
+                      {k.lastDeepDiveAt
+                        ? new Date(k.lastDeepDiveAt).toISOString().split("T")[0]
+                        : "never"}
+                    </td>
+                    <td className="px-5 py-2.5 text-right tabular-nums font-mono text-xs">
+                      {k.sources.length}
+                    </td>
+                    <td className="px-5 py-2.5 text-right tabular-nums font-mono text-xs">
+                      {k.eventCount90d}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
       <DeepDiveCompleteDialog
         open={completeOpen}
         onOpenChange={setCompleteOpen}
-        kennel={next}
+        kennel={currentKennel}
         onCompleted={() => {
           setCompleteOpen(false);
           onCompleted();

--- a/src/components/admin/AuditDashboard.tsx
+++ b/src/components/admin/AuditDashboard.tsx
@@ -757,6 +757,12 @@ function DeepDiveCard({
   const [completeOpen, setCompleteOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
+  useEffect(() => {
+    if (queue.some((k) => k.kennelCode === selectedCode)) return;
+    setSelectedCode(queue[0]?.kennelCode ?? "");
+    setCopied(false);
+  }, [queue, selectedCode]);
+
   const currentKennel = queue.find((k) => k.kennelCode === selectedCode) ?? queue[0];
 
   if (!currentKennel || queue.length === 0) {
@@ -779,10 +785,7 @@ function DeepDiveCard({
   const lastDived =
     currentKennel.lastDeepDiveAt === null
       ? "never"
-      : (currentKennel.lastDeepDiveAt instanceof Date
-          ? currentKennel.lastDeepDiveAt
-          : new Date(currentKennel.lastDeepDiveAt)
-        ).toISOString().split("T")[0];
+      : new Date(currentKennel.lastDeepDiveAt).toISOString().split("T")[0];
 
   return (
     <>
@@ -812,7 +815,7 @@ function DeepDiveCard({
               in last 90d · last dived {lastDived}
             </div>
           </div>
-          <div className="flex shrink-0 gap-2 pt-6">
+          <div className="flex shrink-0 items-center gap-2 self-center">
             <Button variant="outline" size="sm" onClick={handleCopy}>
               {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
               {copied ? "Copied" : "Copy prompt"}
@@ -867,15 +870,24 @@ function DeepDiveCard({
                 </tr>
               </thead>
               <tbody className="divide-y divide-border/30">
-                {queue.slice(0, 15).map((k) => (
+                {queue.map((k) => (
                   <tr
                     key={k.kennelCode}
-                    className={`cursor-pointer transition-colors ${
+                    role="button"
+                    tabIndex={0}
+                    className={`cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 ${
                       k.kennelCode === selectedCode
                         ? "bg-accent/50 border-l-2 border-l-purple-500"
                         : "hover:bg-accent/30"
                     }`}
                     onClick={() => { setSelectedCode(k.kennelCode); setCopied(false); }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelectedCode(k.kennelCode);
+                        setCopied(false);
+                      }
+                    }}
                   >
                     <td className="px-5 py-2.5 font-medium">{k.shortName}</td>
                     <td className="px-5 py-2.5 text-muted-foreground">{k.region}</td>
@@ -926,6 +938,13 @@ function DeepDiveCompleteDialog({
   const [summary, setSummary] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!open) return;
+    setFindingsCount(0);
+    setSummary("");
+    setError(null);
+  }, [open, kennel.kennelCode]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();


### PR DESCRIPTION
## Problem

The deep-dive card on \`/admin/audit\` was hardcoded to show only the top-of-queue kennel. When a new never-dived kennel was added mid-audit, it jumped to the top (never-dived = first priority) and displaced the kennel the operator was actively auditing. The operator couldn't copy the prompt for or mark complete the original kennel.

## Fix

Replaced the static "Today's target" display with a **shadcn Select dropdown** showing all queue candidates (up to 15). The selected kennel flows into both:
- **"Copy prompt"** → generates the deep-dive prompt for the selected kennel
- **"Mark complete"** → records the dive for the selected kennel

The queue table below is now **clickable** — clicking a row selects that kennel in the dropdown above, with a purple left-border highlight on the active row.

## Changes

- \`DeepDiveCard\` props: \`next: DeepDiveCandidate | null\` → \`queue: DeepDiveCandidate[]\`
- \`selectedCode\` state tracks the active kennel, initialized to the top of the queue
- Queue table renders all items (was \`slice(1)\`), clickable with selection highlight
- Selection change clears the "Copied" toast so it doesn't persist across kennels

## No backend changes

\`recordDeepDive()\` and \`buildDeepDivePrompt()\` already accept any kennel — only the UI was the bottleneck.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` ✓ Compiled
- [ ] Manual: Select dropdown shows all queue kennels with top pre-selected
- [ ] Manual: Click queue table row → dropdown updates
- [ ] Manual: "Copy prompt" and "Mark complete" use the selected kennel

🤖 Generated with [Claude Code](https://claude.com/claude-code)