### PR TITLE
Backfill full AVL Meetup archive and document the workflow

### DIFF
--- a/docs/meetup-historical-backfill.md
+++ b/docs/meetup-historical-backfill.md
@@ -1,0 +1,73 @@
+# Meetup Historical Backfill
+
+Use this workflow to backfill older events from any Meetup-backed kennel page into HashTracks.
+
+## What worked for AVL H3
+
+- Source page: `https://www.meetup.com/AVLH3-On-On/events/?type=past`
+- Previously captured through: `2022-06-17`
+- Additional archive discovered by automated scrolling: `2021-06-25` back to `2008-09-13`
+- End-of-archive condition:
+  Repeated bottom-scrolls stopped increasing the number of parsed event cards for 10 consecutive rounds. The oldest visible event remained `2008-09-13`, so that was treated as saturation for the session.
+
+## Reusable scraper
+
+The repo now includes [scrape-meetup-history.mjs](/Users/johnclem/.codex/worktrees/f085/hashtracks-web/scripts/scrape-meetup-history.mjs), a Playwright-based extractor that:
+
+- opens a Meetup `?type=past` page
+- scrolls to the bottom until the archive stops growing
+- parses visible event cards into the JSON format expected by `import-meetup-history.ts`
+- filters to rows older than a cutoff date
+- optionally writes numbered batch files
+
+It intentionally does not depend on a local Playwright install. Run it with a temporary package install:
+
+```bash
+npx -y -p playwright node scripts/scrape-meetup-history.mjs \
+  --url "https://www.meetup.com/AVLH3-On-On/events/?type=past" \
+  --before-date 2021-06-26 \
+  --out /tmp/avlh3-older.json \
+  --batch-prefix "scripts/data/avlh3-meetup-history-batch-" \
+  --batch-start 6
+```
+
+## Recommended workflow for another kennel
+
+1. Identify the kennel's Meetup past-events page.
+   Example: `https://www.meetup.com/<group>/events/?type=past`
+2. Identify the last already-imported event date.
+   Use the newest already-backfilled historical event as the cutoff.
+3. Run the scraper with `--before-date` set to the day after the older archive should begin.
+   Example: if the last captured event is `2021-06-25`, pass `--before-date 2021-06-26`.
+4. Review the generated JSON.
+   Spot-check oldest and newest rows, a few URLs, and any obviously placeholder events.
+5. Dry-run the importer.
+
+```bash
+cat scripts/data/<prefix>*.json | npx tsx scripts/import-meetup-history.ts --kennel <code> --source "<source name>"
+```
+
+6. If the dry-run looks good, apply it.
+
+```bash
+cat scripts/data/<prefix>*.json | BACKFILL_APPLY=1 npx tsx scripts/import-meetup-history.ts --kennel <code> --source "<source name>"
+```
+
+## Notes
+
+- Meetup card order is newest to oldest. The scraper writes batch files in that same continuation-friendly order.
+- The importer already deduplicates by fingerprint, so reruns and overlapping batches are safe.
+- Card data is limited to what the list page shows.
+  Hares usually require a second pass against event detail pages.
+- Placeholder and cancelled titles can appear in the archive.
+  The importer already filters common non-event placeholders.
+- Some rows have weak locations like `Asheville, NC, US` or `Location not specified yet`.
+  That is expected from Meetup’s card view.
+- Very old archives may stop before the kennel’s true first run if Meetup no longer exposes older cards.
+
+## AVL H3 outcome
+
+- New continuation batches created: `scripts/data/avlh3-meetup-history-batch-6.json` through `scripts/data/avlh3-meetup-history-batch-21.json`
+- Oldest reachable Meetup card in this session: `2008-09-13`
+- Combined dry-run status after batches `1..21`:
+  Run the importer locally to confirm against your active database before applying, since dry-run/apply depend on your Prisma target being available.

--- a/docs/meetup-historical-backfill.md
+++ b/docs/meetup-historical-backfill.md
@@ -12,7 +12,7 @@ Use this workflow to backfill older events from any Meetup-backed kennel page in
 
 ## Reusable scraper
 
-The repo now includes [scrape-meetup-history.mjs](/Users/johnclem/.codex/worktrees/f085/hashtracks-web/scripts/scrape-meetup-history.mjs), a Playwright-based extractor that:
+The repo now includes [scrape-meetup-history.mjs](../scripts/scrape-meetup-history.mjs), a Playwright-based extractor that:
 
 - opens a Meetup `?type=past` page
 - scrolls to the bottom until the archive stops growing

--- a/scripts/backfill-meetup-history.ts
+++ b/scripts/backfill-meetup-history.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env -S npx tsx
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { SOURCES } from "../prisma/seed-data/sources";
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const includeExisting = args.includes("--include-existing");
+const onlyArg = args.find((arg) => arg.startsWith("--only="));
+const only = onlyArg ? new Set(onlyArg.slice("--only=".length).split(",").map((item) => item.trim()).filter(Boolean)) : null;
+const today = new Date().toISOString().slice(0, 10);
+
+const meetupSources = SOURCES.filter((source) => source.type === "MEETUP");
+const summary: Array<{ source: string; kennel: string; status: "ok" | "skipped" | "failed"; detail: string }> = [];
+
+function run(cmd: string, cmdArgs: string[], extraEnv: Record<string, string> = {}) {
+  const result = spawnSync(cmd, cmdArgs, {
+    cwd: process.cwd(),
+    stdio: "inherit",
+    env: { ...process.env, ...extraEnv },
+  });
+  if (result.status !== 0) {
+    throw new Error(`${cmd} ${cmdArgs.join(" ")} failed with exit code ${result.status ?? "unknown"}`);
+  }
+}
+
+function sh(command: string, env: Record<string, string> = {}) {
+  run("zsh", ["-lc", command], env);
+}
+
+function batchFilesFor(prefix: string) {
+  const dir = path.dirname(prefix);
+  const base = path.basename(prefix);
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter((name) => name.startsWith(base) && name.endsWith(".json"))
+    .sort((a, b) => {
+      const aNum = Number(a.match(/(\d+)\.json$/)?.[1] ?? 0);
+      const bNum = Number(b.match(/(\d+)\.json$/)?.[1] ?? 0);
+      return aNum - bNum;
+    })
+    .map((name) => path.join(dir, name));
+}
+
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+for (const source of meetupSources) {
+  const config = (source.config ?? {}) as { kennelTag?: string };
+  const defaultKennel = config.kennelTag;
+  const url = source.url;
+
+  if (typeof defaultKennel !== "string" || !defaultKennel) {
+    console.log(`Skipping ${source.name}: missing config.kennelTag`);
+    summary.push({ source: source.name, kennel: "?", status: "skipped", detail: "missing config.kennelTag" });
+    continue;
+  }
+  if (typeof url !== "string" || !url.includes("meetup.com")) {
+    console.log(`Skipping ${source.name}: missing Meetup URL`);
+    summary.push({ source: source.name, kennel: defaultKennel, status: "skipped", detail: "missing Meetup URL" });
+    continue;
+  }
+  if (only && !only.has(defaultKennel) && !only.has(source.name)) continue;
+
+  const batchPrefix = `scripts/data/${defaultKennel}-meetup-history-batch-`;
+  const existing = batchFilesFor(batchPrefix);
+  if (existing.length > 0 && !includeExisting) {
+    console.log(`Skipping ${source.name}: found ${existing.length} existing batch files`);
+    summary.push({ source: source.name, kennel: defaultKennel, status: "skipped", detail: `found ${existing.length} existing batch files` });
+    continue;
+  }
+
+  try {
+    console.log(`\n=== ${source.name} (${defaultKennel}) ===`);
+    sh(
+      [
+        "npx -y -p playwright -c",
+        shellQuote(
+          [
+            "node scripts/scrape-meetup-history.mjs",
+            "--url", `${url.replace(/\/$/, "")}/events/?type=past`,
+            "--before-date", today,
+          "--batch-prefix", batchPrefix,
+          "--batch-start", "1",
+          "--wait-ms", "750",
+          "--stable-rounds", "12",
+          "--max-rounds", "300",
+        ].join(" "),
+      ),
+    ].join(" "),
+    );
+
+    const files = batchFilesFor(batchPrefix);
+    if (files.length === 0) {
+      console.log(`No batch files written for ${source.name}; skipping import`);
+      summary.push({ source: source.name, kennel: defaultKennel, status: "skipped", detail: "no batch files written" });
+      continue;
+    }
+
+    const sourceName = shellQuote(source.name);
+    const importCmd =
+      `cat ${batchPrefix}*.json | npx tsx scripts/import-meetup-history.ts --source ${sourceName}`;
+    sh(importCmd);
+
+    if (apply) {
+      sh(importCmd, { BACKFILL_APPLY: "1" });
+    }
+    summary.push({ source: source.name, kennel: defaultKennel, status: "ok", detail: `batches=${files.length}${apply ? ", applied" : ", dry-run only"}` });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`FAILED ${source.name}: ${message}`);
+    summary.push({ source: source.name, kennel: defaultKennel, status: "failed", detail: message });
+  }
+}
+
+console.log("\n=== Summary ===");
+for (const item of summary) {
+  console.log(`${item.status.toUpperCase()}\t${item.kennel}\t${item.source}\t${item.detail}`);
+}

--- a/scripts/data/avlh3-meetup-history-batch-10.json
+++ b/scripts/data/avlh3-meetup-history-batch-10.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 #503 - We're freeeeeeeee!",
+    "date": "2018-09-01",
+    "startTime": "14:00",
+    "location": "Buffalo Wild Wings, 4 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/253799594/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #502 - NFN Monica's Divorce Party!",
+    "date": "2018-08-25",
+    "startTime": "14:00",
+    "location": "Jackson Park, 810 Glover St, Hendersonville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/253798888/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #501 - Into the Woods",
+    "date": "2018-08-18",
+    "startTime": "14:00",
+    "location": "Bent Creek Ledford Parking area, Wesley Branch Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/253726555/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #500 - 10th Annual Blue Dress Run and Trail 500 Celebration!",
+    "date": "2018-08-11",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251550952/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #499 - Sometimes hashers need a Babysitter",
+    "date": "2018-08-04",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/252230505/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #498 - A quickie with Brownie",
+    "date": "2018-07-28",
+    "startTime": "12:00",
+    "location": "Semi Abandoned Church, 930 swannanoa river rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/252230489/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #497 - Kids Hash!",
+    "date": "2018-07-22",
+    "startTime": "14:00",
+    "location": "Parking Lot, 100 Schenck Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/252604127/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #496 - RIP H3 invasion!",
+    "date": "2018-07-21",
+    "startTime": "14:00",
+    "location": "Parking Lot off Charlotte Street, 77 Charlotte Street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251550916/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #495 - A Ben Franklin 69 Trail",
+    "date": "2018-07-14",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/252230452/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #494 - Le Tour de Hash (Stage 6) FINALE - 4th Anual 4th of July Hash Camp!",
+    "date": "2018-07-07",
+    "startTime": "14:00",
+    "location": "Potchentokus Manor, 286 Flat Creek Rd, Fairview, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251534747/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #493 - Le Tour de Hash - North (Stage 5)",
+    "date": "2018-07-05",
+    "startTime": "18:00",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251534697/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #492 - Le Tour de Hash - South (Stage 4)",
+    "date": "2018-07-04",
+    "startTime": "14:00",
+    "location": "Parking Lot, 100 Schenck Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251534676/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #491 - Le Tour de Hash - Downtown (Stage 3)",
+    "date": "2018-07-03",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251534659/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #490 - Le Tour de Hash - West (Stage 2)",
+    "date": "2018-07-01",
+    "startTime": "14:00",
+    "location": "West Asheville Park, 198 Vermont Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251534607/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #489 - Le Tour de Hash - Central (Stage 1)",
+    "date": "2018-06-30",
+    "startTime": "14:00",
+    "location": "Summit Crossfit, 21 A McArthur Lane, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251534493/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #488 - Lazy brunch trail",
+    "date": "2018-06-23",
+    "startTime": "12:00",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251550639/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #487 - The White Dress Run of Lady & Tugs!",
+    "date": "2018-06-17",
+    "startTime": "18:30",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251601189/",
+    "attendees": 23
+  },
+  {
+    "title": "AVLH3 #486 - Warm, Wet and Shiggy",
+    "date": "2018-06-16",
+    "startTime": "14:00",
+    "location": "Shitty Parking, 1983 Riverside Dr, Woodfin, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251550566/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #485 - Wino Ducks",
+    "date": "2018-06-09",
+    "startTime": "14:00",
+    "location": "Parking Lot near Ichiban, 13 Garfield St, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251518549/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #484 -Sneek A Peak Trail",
+    "date": "2018-06-02",
+    "startTime": "14:00",
+    "location": "Summit Crossfit, 21 A McArthur Lane, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/251195335/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #483 - AVLH3's 9th An(nu)al Memorial Day Trail And Cookout",
+    "date": "2018-05-26",
+    "startTime": "14:00",
+    "location": "Rise Above Bakery, 1207 Charlotte Hwy, Fairview, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/249683954/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #482 - Armed Forces/Camo Hash",
+    "date": "2018-05-19",
+    "startTime": "15:00",
+    "location": "Bent Creek, Explorer LooP Parking, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/249349460/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #481 - Yo mama so... queasy",
+    "date": "2018-05-12",
+    "startTime": "14:00",
+    "location": "Bull Mountain Parking Area, 139 Bull Mountain Road, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/250305093/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #480 - Stinko de Mayo",
+    "date": "2018-05-05",
+    "startTime": "14:00",
+    "location": "Haw Creek Park, 38 Avon Rd, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/250305071/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #479 - Current mood: furious and horny",
+    "date": "2018-04-28",
+    "startTime": "14:00",
+    "location": "A House, 1 Spears Avenue, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/250045313/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #478 - International gEARTH Day",
+    "date": "2018-04-21",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/249925648/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #477 - The Lumberjack Trail",
+    "date": "2018-04-15",
+    "startTime": "14:00",
+    "location": "Richmond Hill Park, 280 Richmond Hill Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/249349163/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #476 - A Sunday Birthday Trail",
+    "date": "2018-04-08",
+    "startTime": "14:00",
+    "location": "Titties House, 20 Dorchester Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/249353455/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #475 - Better Late Than Never Trail",
+    "date": "2018-03-24",
+    "startTime": "14:00",
+    "location": "Hare's House, 105 Arco Road, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/249042642/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #474 - St. Paddy's Day Hash! and potential naming for NFHN Matt.",
+    "date": "2018-03-17",
+    "startTime": "14:00",
+    "location": "Parking lot behind Dr. Daves Automotive., 1022 Haywood Rd, Asheville, NC 28806, ASHEVILLE, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/248467543/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #473 - Run Lesbitch Over the Hill Birthday Bash",
+    "date": "2018-03-10",
+    "startTime": "14:00",
+    "location": "Jean Webb River Park, 30 Riverside Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/247062673/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #472 - Hashers of Walfart",
+    "date": "2018-03-03",
+    "startTime": "14:00",
+    "location": "Walmart Supercenter, 1636 Hendersonville Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/248258191/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #471 - Red Dress “The Hangover” Trail",
+    "date": "2018-02-25",
+    "startTime": "11:30",
+    "location": "Ingles Market, 780 Hendersonville Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/246518129/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #470 - 10th Annual Red Dress Run!",
+    "date": "2018-02-24",
+    "startTime": "13:00",
+    "location": "Hi-Wire Brewing - Big Top, 2A Huntsman Place, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/246517324/",
+    "attendees": 31
+  },
+  {
+    "title": "AVLH3 #469 - AVLH3's 10th Analversary/Pre-Red Dress Trail!",
+    "date": "2018-02-23",
+    "startTime": "18:30",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/246518013/",
+    "attendees": 26
+  },
+  {
+    "title": "AVLH3 #468 - Hashy Valentine’s Day",
+    "date": "2018-02-17",
+    "startTime": "14:00",
+    "location": "Bull Mountain Parking Area, 139 Bull Mountain Road, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/247063551/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #467 - Mardi Crawl 2018",
+    "date": "2018-02-11",
+    "startTime": "13:00",
+    "location": "Mountainside park behind Asheville Toursit-McCormick Field, 30 Buchanan Place (off of Hunt Hill Place), Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/247356889/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #466 - Beads and Brews-Mardi Gras Hash and NFHN Joe's first hare.",
+    "date": "2018-02-10",
+    "startTime": "14:00",
+    "location": "West Asheville Park, 198 Vermont Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/247063547/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #465 - Pre Superbowl Hash",
+    "date": "2018-02-03",
+    "startTime": "14:00",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/247063539/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #464 - Take 2!",
+    "date": "2018-01-27",
+    "startTime": "14:00",
+    "location": "Parking Lot off Charlotte Street, 77 Charlotte Street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/247063475/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #463 - Looking for signs of Spring",
+    "date": "2018-01-20",
+    "startTime": "14:00",
+    "location": "Abandoned gas station, 429-401 Broadway St, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/246843764/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 Trail #462 - Old New Year's Eve",
+    "date": "2018-01-13",
+    "startTime": "13:00",
+    "location": "Parking Lot off Charlotte Street, 77 Charlotte Street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/246676569/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #461 - Tutu Loo NFN!",
+    "date": "2018-01-06",
+    "startTime": "18:00",
+    "location": "Fleetwood's, 476 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/245644205/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #460/MH3 #34 - AVLH3's Annual Formal/MH3's Wolf Moon trail",
+    "date": "2018-01-01",
+    "startTime": "18:00",
+    "location": "Barley's Taproom, 42 Biltmore Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/245828727/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #459 - Christmas Day BBQ and Bourbon",
+    "date": "2017-12-25",
+    "startTime": "15:00",
+    "location": "Professional Ball Handler's Place, 16 Stockbridge Place, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/246042008/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #458 - 26 And Zorro's 3rd Anal Solstice Onesie Trail",
+    "date": "2017-12-21",
+    "startTime": "18:30",
+    "location": "26 and Zorro's, 19 Russell St, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/245340746/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #457 - NFN Kristen’s first haring!",
+    "date": "2017-12-17",
+    "startTime": "12:00",
+    "location": "Parking lot on Virginia Ave, 22 Virginia Ave, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/245230482/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #457 - Two birthdays, one trail",
+    "date": "2017-12-09",
+    "startTime": "14:00",
+    "location": "Oskar Blues Reeb Ranch, 315 Shoals Falls Rd., Brevard, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/245064572/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #456 - AVLH3's Holiday Hash!",
+    "date": "2017-12-02",
+    "startTime": "14:00",
+    "location": "Mountainside park behind Asheville Toursit-McCormick Field, 30 Buchanan Place (off of Hunt Hill Place), Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/244750920/",
+    "attendees": 33
+  },
+  {
+    "title": "AVLH3 #455 - Turkey Weekend/Black Friday/Possible Double Naming",
+    "date": "2017-11-25",
+    "startTime": "14:00",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/245147317/",
+    "attendees": 22
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-11.json
+++ b/scripts/data/avlh3-meetup-history-batch-11.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 #454 - 7th Annual MANNA Foodbank Hash",
+    "date": "2017-11-18",
+    "startTime": "14:00",
+    "location": "Blue Sky Cafe, 3987 Hendersonville Road, Fletcher, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/244406349/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3 #453 - Tutu-loo NFHN",
+    "date": "2017-11-12",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/244753349/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #453 - The Big Bad Bus",
+    "date": "2017-11-11",
+    "startTime": "14:00",
+    "location": "Abandoned Parking Lot, 1500 Tunnel Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/244836718/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #452 - The Adventures of Zorro and Princess",
+    "date": "2017-11-04",
+    "startTime": "14:00",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/244696683/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #451 - Hashoween!",
+    "date": "2017-10-28",
+    "startTime": "18:00",
+    "location": "Babysitters Hizzy, 12 Highland st, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/243870450/",
+    "attendees": 28
+  },
+  {
+    "title": "Open MM meeting & drinking practice!",
+    "date": "2017-10-26",
+    "startTime": "18:00",
+    "location": "Wedge At Foundation, 5 Foundy Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/243870683/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #450 - Trail Four FIDDY!",
+    "date": "2017-10-21",
+    "startTime": "14:00",
+    "location": "Corner of Cumberland and Starnes Avenues, 51 Cumberland Avenue (closest address I could find), Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/244179533/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #449 - Saturday downtown trail",
+    "date": "2017-10-14",
+    "startTime": "15:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/244025576/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #448 - Booze and Brunch... and maybe some running",
+    "date": "2017-10-08",
+    "startTime": "12:00",
+    "location": "Sir Tugs, \"Lady\" Guenevere And, 374 Old County Home Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/243901169/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #447 - The White Dress Run of Fffffaklava & NFN Charrie!!",
+    "date": "2017-10-01",
+    "startTime": "14:00",
+    "location": "J and S Cafeteria, 800 Fairview Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/243418426/",
+    "attendees": 36
+  },
+  {
+    "title": "AVLH3 #446 - Put on my Booze Suede Shoes and I.....Stumbled Again....",
+    "date": "2017-09-23",
+    "startTime": "12:00",
+    "location": "Hi-Wire Brewing, 2 Huntsman Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/243451820/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #445 - Hashshit Brewery Tour",
+    "date": "2017-09-16",
+    "startTime": "14:00",
+    "location": "Bens Tune Up, 195 Hillard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/243019959/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 Hash appreciation and new MM announcements!",
+    "date": "2017-09-10",
+    "startTime": "11:00",
+    "location": "House, 19 Russell Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/243085054/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #444 - Hashshit gave me Crags!",
+    "date": "2017-09-09",
+    "startTime": "14:00",
+    "location": "Craggy Pinnacle Parking Lot, 3641 Blue Ridge Pkwy, Barnardsville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/243019860/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #443 - Hobo Hash",
+    "date": "2017-09-04",
+    "startTime": "14:00",
+    "location": "West Asheville Park, 198 Vermont Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/241895206/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #442 - Welcome to HASHeville!",
+    "date": "2017-09-02",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/242697369/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #441 - Labor Day Weekend Kickoff!",
+    "date": "2017-09-01",
+    "startTime": "18:00",
+    "location": "McCauley Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/242698113/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #440 - Hashshitin' & River fArts",
+    "date": "2017-08-26",
+    "startTime": "12:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/242697319/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #439 - Back To School Hash 3",
+    "date": "2017-08-25",
+    "startTime": "18:00",
+    "location": "iwanna, 22 Garfield St #100, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/242697736/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #438 - Lube the Boob on the Tube 69",
+    "date": "2017-08-19",
+    "startTime": "13:00",
+    "location": "Hominy Creek Park, 194 Hominy Creek Rd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/239654977/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #437 - Bent over for the Hashshit!",
+    "date": "2017-08-16",
+    "startTime": "18:00",
+    "location": "Bent Creek Ledford Parking area, 479E, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/242537808/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #436 - Hashshit Kick-off at Sierra Nevada!",
+    "date": "2017-08-15",
+    "startTime": "18:00",
+    "location": "Sierra Nevada Brewery, 100 Sierra Nevada Way, Fletcher, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/242537632/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #435 - 9th Anal Blue Dress Run!",
+    "date": "2017-08-12",
+    "startTime": "13:00",
+    "location": "Summit Crossfit, 21 A McArthur Lane, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/240919627/",
+    "attendees": 29
+  },
+  {
+    "title": "AVLH3 #434 - Sweet Dirty South",
+    "date": "2017-08-05",
+    "startTime": "14:00",
+    "location": "Sweeten Creek Brewing, 1127 Sweeten Creek Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/241956823/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #433 - Professional Ball Handler's B-Day Hash",
+    "date": "2017-07-29",
+    "startTime": "14:00",
+    "location": "Folk Art Center, 382 Blue Ridge Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/241794626/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #432 - The Old School East Syeed Hash!",
+    "date": "2017-07-15",
+    "startTime": "14:00",
+    "location": "JtR and Precious Trail Cranium, 2582 Riceville Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/239857323/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #431 - 50/150",
+    "date": "2017-07-08",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/240936670/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #430 - Eagles Soarin' Firework Explodin' True 'Murican Campout Experience",
+    "date": "2017-07-01",
+    "startTime": "14:00",
+    "location": "Potchentokus Manor, 286 Flat Creek Road, Fairview, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/240363020/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #429 - Deep Fry hash",
+    "date": "2017-06-24",
+    "startTime": "14:00",
+    "location": "Catrock Cabin, 80 Fenner Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/240447731/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #428 - Who's Your Daddy?",
+    "date": "2017-06-17",
+    "startTime": "14:00",
+    "location": "Gravel Lot, 28 Meadow Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/240747655/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #427 - Madre and Admiral",
+    "date": "2017-06-10",
+    "startTime": "14:00",
+    "location": "Reed Creek Greenway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/239617025/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #426 - Couldn't think of a name for this trail. So let's call it Harold!",
+    "date": "2017-06-03",
+    "startTime": "14:00",
+    "location": "HHGreg, 80 S Tunnel Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/239692218/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #425 - AVLH3's 8th An(nu)al Memorial Day Trail",
+    "date": "2017-05-27",
+    "startTime": "14:00",
+    "location": "Wash Creek Horse Camp, National Forest Road, Horse Shoe, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237793523/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #424 - Cruisin' through the Alleys!",
+    "date": "2017-05-20",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/239692104/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #423 - Yo Mama",
+    "date": "2017-05-13",
+    "startTime": "14:00",
+    "location": "South Buncombe Library/Skyland, 260 Overlook Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/238719268/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #422 - Cinco de Mayo...only 364 more days!!!",
+    "date": "2017-05-06",
+    "startTime": "12:00",
+    "location": "West Asheville Park, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/239128833/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #421 - Ball Smasher is Leaving Us",
+    "date": "2017-04-22",
+    "startTime": "14:00",
+    "location": "Ingles Supermark, 550 NC-9, Black Mountain, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/238441045/",
+    "attendees": 35
+  },
+  {
+    "title": "AVLH3 #420 - Safety Meeting",
+    "date": "2017-04-20",
+    "startTime": "16:15",
+    "location": "Richmond Hill Park, 280 Richmond Hill Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237793583/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #419 - NFN Shane's 2nd Cumming",
+    "date": "2017-04-16",
+    "startTime": "12:00",
+    "location": "NFHN Heather's House, 39 McDade Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/238718157/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #418 - Because trail numbers are important!",
+    "date": "2017-04-13",
+    "startTime": "18:30",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/239108246/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #418 - A trail",
+    "date": "2017-04-09",
+    "startTime": "12:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/238718074/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #417 - Brews in Brevard with NFN Mallory!",
+    "date": "2017-04-08",
+    "startTime": "14:00",
+    "location": "Oskar Blues Brewery, 342 Mountain Industrial Drive, Brevard, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237676696/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #416 - Hillman Beer Soft Opening Trail!",
+    "date": "2017-04-06",
+    "startTime": "18:00",
+    "location": "Hillman Beer, 8 Sweeten Creek Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/238717943/",
+    "attendees": 26
+  },
+  {
+    "title": "AVLH3 #415 - Insert Rinse Repeat & Surf N Turd's White Dress Run!",
+    "date": "2017-04-01",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/238588053/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #414 - A Blast from the Past -&- LTdH FINALE",
+    "date": "2017-03-25",
+    "startTime": "14:00",
+    "location": "Martin Luther King Park, 50 Martin Luther King Jr Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237497324/",
+    "attendees": 29
+  },
+  {
+    "title": "AVLH3 #413 - Le Tour de Hash (Stage 5)",
+    "date": "2017-03-24",
+    "startTime": "18:30",
+    "location": "Reynolds Villages, Senator Reynolds Road and North Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237999996/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #412 - Le Tour de Hash (Stage 4)",
+    "date": "2017-03-22",
+    "startTime": "18:30",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237999989/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #411 - Le Tour de Hash (Stage 3)",
+    "date": "2017-03-21",
+    "startTime": "18:30",
+    "location": "Folk Art Center, 382 Blue Ridge Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237999973/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #410 - Le Tour de Hash (Stage 2)",
+    "date": "2017-03-20",
+    "startTime": "18:30",
+    "location": "Hominy Creek Trail Parking Lot, 422 Sand Hill Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237999953/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #409 - Le Tour de Hash (Stage 1)",
+    "date": "2017-03-18",
+    "startTime": "14:00",
+    "location": "Biltmore Park Parking Lot, 100 Schenck Pkwy, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237999774/",
+    "attendees": 14
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-12.json
+++ b/scripts/data/avlh3-meetup-history-batch-12.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 #408 - ST. PATS--National Banan-ahhh Porn: the Running of the Gingers",
+    "date": "2017-03-17",
+    "startTime": "18:30",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237793507/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #407 - F&$% It, Let's Hash",
+    "date": "2017-03-11",
+    "startTime": "15:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/238001072/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #406 - Hash of Shame",
+    "date": "2017-03-04",
+    "startTime": "14:00",
+    "location": "Corner of Cumberland and Starnes Avenues, 51 Cumberland Avenue (closest address I could find), Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/238001049/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #405 - Mardi Crawl",
+    "date": "2017-02-26",
+    "startTime": "12:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237793482/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #404 - Brown Townin'",
+    "date": "2017-02-25",
+    "startTime": "14:00",
+    "location": "Parking along Roberts Road, 5 Roberts Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237793400/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #403 - 9th Anniversary Trail",
+    "date": "2017-02-23",
+    "startTime": "18:30",
+    "location": "sav-more parking lot, 842 merrimon ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237498529/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #402 - Not Ashamed to Hare",
+    "date": "2017-02-18",
+    "startTime": "14:00",
+    "location": "Carrier Park, 199 Amboy Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237497302/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #401 - Red Dress Hangover Trail",
+    "date": "2017-02-12",
+    "startTime": "11:00",
+    "location": "West Asheville Park, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236792193/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #400 - 9th ANNUAL RED DRESS RUN!!!",
+    "date": "2017-02-11",
+    "startTime": "13:00",
+    "location": "New Mountain, 38 N French Board, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234837320/",
+    "attendees": 48
+  },
+  {
+    "title": "Moonshine H3 Trail #23 - Snow Moon/Pre-Red Dress Trail!",
+    "date": "2017-02-10",
+    "startTime": "19:00",
+    "location": "Parking Lot, 167 Craven Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236792171/",
+    "attendees": 30
+  },
+  {
+    "title": "AVLH3 #399 - The Toilet Bowl Hash",
+    "date": "2017-02-05",
+    "startTime": "11:00",
+    "location": "Creekside Taphouse, 20 Beverly Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237411002/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #398 - A couple of NFHN hares join a Family",
+    "date": "2017-01-29",
+    "startTime": "13:00",
+    "location": "The Montford Park Players, 92 Gay St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/237135852/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #397 - La Cucaracha Trail",
+    "date": "2017-01-21",
+    "startTime": "14:00",
+    "location": "Las Cazuelas Mexican Restaurant, 502 W State St, Black Mountain, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236137690/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3's Drinking Practice / Open MisManageme­nt Meeting / Red Dress Planning",
+    "date": "2017-01-19",
+    "startTime": "19:00",
+    "location": "Buffalo Nickel, 747 Haywood Road West, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236828073/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #396 - Sunday Funday Joint Run with Kittens H3",
+    "date": "2017-01-15",
+    "startTime": "11:00",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236792881/",
+    "attendees": 27
+  },
+  {
+    "title": "AVLH3 #395 - Hide Your Kids, Hide Your Wife...",
+    "date": "2017-01-14",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236716140/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #394 - Who Wants a Snow Job?",
+    "date": "2017-01-07",
+    "startTime": "14:00",
+    "location": "Hares House, 19 Russell St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236685098/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #393 - Annual Formal",
+    "date": "2016-12-30",
+    "startTime": "18:30",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236138011/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #392 - Getting Smashed on Jack",
+    "date": "2016-12-28",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236343959/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #391 - Ho Ho Ho!",
+    "date": "2016-12-24",
+    "startTime": "12:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236307986/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #390 - The Darkest and Longest 2 - A Hashiversary",
+    "date": "2016-12-21",
+    "startTime": "18:00",
+    "location": "Parking lot at the top of the hill, 122 Lyman St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236074057/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #389 - Kotex and Cockodile",
+    "date": "2016-12-17",
+    "startTime": "14:00",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/236072543/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #388 - Jingle my Bells Holiday Hash",
+    "date": "2016-12-10",
+    "startTime": "13:30",
+    "location": "Near Asheville Municipal Golf Course, 16 Stockbridge Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/235871677/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #387 - Annual Ugly Sweater Hash",
+    "date": "2016-12-03",
+    "startTime": "14:00",
+    "location": "iwanna, 22 Garfield St #100, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234472018/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #386 - Make Her Wet",
+    "date": "2016-11-28",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/235870729/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #385 - After Thanksgiving - THE CLEANSING",
+    "date": "2016-11-26",
+    "startTime": "14:00",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/235807633/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #384 - 6th Annual MANNA Foodbank Hash",
+    "date": "2016-11-20",
+    "startTime": "14:00",
+    "location": "Bottom of the hill on Schenck Pkwy at tennis courts, 100 Schenck Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234349723/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #383 - Red, White, and Blues Trail",
+    "date": "2016-11-12",
+    "startTime": "14:00",
+    "location": "Dirt Parking Lot, 420 Azalea Road East, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/235094170/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #382 - A \"Brief\" Trail...",
+    "date": "2016-11-05",
+    "startTime": "14:00",
+    "location": "Asheville Visitor Center, 36 Montford Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234599383/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3's Drinking Practice/MisManagement Meeting",
+    "date": "2016-11-04",
+    "startTime": "19:00",
+    "location": "Barley's Taproom, 42 Biltmore Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234829574/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #381 - 8th Anal Hash - O - Weenie Event!",
+    "date": "2016-10-29",
+    "startTime": "16:00",
+    "location": "West Asheville Park, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234830128/",
+    "attendees": 23
+  },
+  {
+    "title": "AVLH3 #380 - Lonely Island Trail",
+    "date": "2016-10-22",
+    "startTime": "14:00",
+    "location": "Martin Luther King Park, 50 Martin Luther King Jr Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234274281/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #379 - A Trail, Laid with Love",
+    "date": "2016-10-15",
+    "startTime": "14:00",
+    "location": "North Mills River Campground, 5289 N Mills River Road, Mills River, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234351838/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #378 - We're all getting tramp stamps",
+    "date": "2016-10-09",
+    "startTime": "15:00",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234601368/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #377 - FREE Craft Beer!",
+    "date": "2016-10-08",
+    "startTime": "14:00",
+    "location": "Eastwood Village Apartments, 9 Olde Eastwood Village Blvd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234276257/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #376 - The Saturday Strut, the Hash to Support Exposed @$$",
+    "date": "2016-10-01",
+    "startTime": "16:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234389977/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #375 - Get Bent Creeked",
+    "date": "2016-09-24",
+    "startTime": "14:00",
+    "location": "Bent Creek Ledford Parking area, 479E, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232288530/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #374 - Talk Like a Pirate Day",
+    "date": "2016-09-19",
+    "startTime": "18:30",
+    "location": "Bens Tune Up, 195 Hillard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234209116/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #374 - The Brown Eye",
+    "date": "2016-09-17",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/234052597/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #373 - NFN Amy's 1st Haring",
+    "date": "2016-09-14",
+    "startTime": "18:30",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/233744088/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3's Hashy Brunch Erections",
+    "date": "2016-09-11",
+    "startTime": "11:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231327721/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #372 - Cougar and Stonz Cumsumate their Marriage",
+    "date": "2016-09-10",
+    "startTime": "16:00",
+    "location": "Admiral and Madre's New Casa, 13 Beaver Point Park, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232254279/",
+    "attendees": 29
+  },
+  {
+    "title": "AVLH3 #371 - A Farewell to our Unicorn",
+    "date": "2016-09-04",
+    "startTime": "14:00",
+    "location": "2 Flycatcher Way, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232278035/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #370 - Back To School Hash!!!",
+    "date": "2016-09-01",
+    "startTime": "18:00",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232926905/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #370 - Cum^2",
+    "date": "2016-08-27",
+    "startTime": "16:00",
+    "location": "Buffalo Wild Wings, 4 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/233514638/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #369 - AVLH3's Anal Blue Dress Hash",
+    "date": "2016-08-20",
+    "startTime": "14:00",
+    "location": "Parking lot at the top of the hill, 122 Lyman St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231327526/",
+    "attendees": 33
+  },
+  {
+    "title": "AVLH3 #368 - Fournicorn's Bday Hash",
+    "date": "2016-08-15",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232278157/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #367 - Consummation Sunday",
+    "date": "2016-08-14",
+    "startTime": "14:00",
+    "location": "Parking lot behind Curves, 16 Regent Park Blvd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/233013839/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #366 - The Big Bad Bus Trail",
+    "date": "2016-08-07",
+    "startTime": "14:00",
+    "location": "198 Vermont St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232949209/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #365 - Admiral and Madre's White Dress!",
+    "date": "2016-08-06",
+    "startTime": "14:00",
+    "location": "The Wedge, 125B Roberts Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/230498467/",
+    "attendees": 39
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-13.json
+++ b/scripts/data/avlh3-meetup-history-batch-13.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 #364 - The Numbers Game",
+    "date": "2016-08-04",
+    "startTime": "18:30",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/233042224/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #363 - If you are here, just what are you really missing?",
+    "date": "2016-07-30",
+    "startTime": "16:00",
+    "location": "Catrock Cabin, 80 Fenner Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232894970/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #362 - Jump On-On Tramps",
+    "date": "2016-07-27",
+    "startTime": "18:30",
+    "location": "15 Walden Drive, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232232356/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #361 - Franken Bone",
+    "date": "2016-07-23",
+    "startTime": "14:00",
+    "location": "Bent Creek Rice Pinnacle Parking Area, 63 Rice pinnacle rd, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232307458/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #360 - Pokemon Go Hash",
+    "date": "2016-07-17",
+    "startTime": "16:00",
+    "location": "Unnamed Grassy Area in Montford, 31 Cumberland Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232642929/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #359 - Le Tour de Hash - The River (Stage 6: THE FINALE)",
+    "date": "2016-07-16",
+    "startTime": "14:00",
+    "location": "Parking lot under Haywood Road, 45 Riverside Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231004721/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #358 - Le Tour de Hash - Downtown (Stage 5)",
+    "date": "2016-07-14",
+    "startTime": "18:30",
+    "location": "Martin Luther King Park, 50 Martin Luther King Jr Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231004686/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #357 - Le Tour de Hash - South (Stage 4)",
+    "date": "2016-07-13",
+    "startTime": "18:30",
+    "location": "Walmart Supercenter, 1636 Hendersonville Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231004669/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #356 - Le Tour de Hash - West (Stage 3)",
+    "date": "2016-07-12",
+    "startTime": "18:30",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231004638/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #355 - Le Tour de Hash - North (Stage 2)",
+    "date": "2016-07-10",
+    "startTime": "14:00",
+    "location": "MAHEC Family Health Center, 118 W. T. Weaver Blvd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231004485/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #354 - Le Tour de Hash - East (Stage 1)",
+    "date": "2016-07-09",
+    "startTime": "14:00",
+    "location": "East Asheville Library, 902 Tunnel Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/232026487/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #353 - 'MURICA!",
+    "date": "2016-07-02",
+    "startTime": "14:00",
+    "location": "Potchentokus Manor, 286 Flat Creek Road, Fairview, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231533063/",
+    "attendees": 40
+  },
+  {
+    "title": "AVLH3 #352 - Helter Skelter Why Must We Swelter",
+    "date": "2016-06-25",
+    "startTime": "14:00",
+    "location": "https://goo.gl/maps/gV7mdxaCGbv, 1 4th Ave, Hendersonville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/230437893/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #351 - Enka Stinka Candler Shmandler",
+    "date": "2016-06-18",
+    "startTime": "14:00",
+    "location": "Parking lot at top of Buncombe County Sports Complex, 154 Sand Hill School Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231584049/",
+    "attendees": 8
+  },
+  {
+    "title": "NC/SC Intercourse 2016",
+    "date": "2016-06-17",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227340929/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #350 - The 1st Haring of NFHN Sage & NFHN Jonathan",
+    "date": "2016-06-11",
+    "startTime": "14:00",
+    "location": "Bent Creek - Rice Pinnacle Parking Area, 64 Rice Pinnacle Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231656215/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #349 - Early Bird Gets The Beer",
+    "date": "2016-06-04",
+    "startTime": "11:30",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231593024/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #348 - AVLH3's 7th Anal Memorial Day Trail",
+    "date": "2016-05-28",
+    "startTime": "13:00",
+    "location": "White Pines South Group Campground, National Forest Road, Pisgah Forest, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/230133909/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3's 7th Anal Memorial Weekend Campout Extravaganza!",
+    "date": "2016-05-27",
+    "startTime": "16:00",
+    "location": "White Pines South Group Campground, National Forest Road, Pisgah Forest, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/229639199/",
+    "attendees": 26
+  },
+  {
+    "title": "INVASION TRAIL: UHHH's Little Black Dress Hash",
+    "date": "2016-05-21",
+    "startTime": "14:00",
+    "location": "UHHH Trail, 109 Fountain Brook Lane, Fountain Inn, SC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/231276395/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #347 - Hogwarts Hash (VCR's Birthday Hash!)",
+    "date": "2016-05-20",
+    "startTime": "18:30",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/228900966/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #347 - The Ides of May",
+    "date": "2016-05-14",
+    "startTime": "14:00",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/230675991/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #346 - Front Running Dicks",
+    "date": "2016-05-12",
+    "startTime": "18:30",
+    "location": "Parking lot under Haywood Road, 45 Riverside Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/230794361/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #345 - Bridesmaid Dash and Groomsmen Trash",
+    "date": "2016-05-07",
+    "startTime": "12:00",
+    "location": "Starting location, 930 swannanoa river rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/229839422/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #344 - Cinco de Mayo & Drinko!",
+    "date": "2016-05-05",
+    "startTime": "18:30",
+    "location": "The Altamont Brewing Company, 1042 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227680470/",
+    "attendees": 30
+  },
+  {
+    "title": "AVLH3 #343 - Kessel R*n",
+    "date": "2016-05-04",
+    "startTime": "18:30",
+    "location": "Parking lot in Biltmore Village, 33 Garfield Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/230516215/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3's Hash Appreciation Brunch",
+    "date": "2016-05-01",
+    "startTime": "12:00",
+    "location": "Admiral and Madre's New Casa, 13 Beaver Point Park, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/230134301/",
+    "attendees": 31
+  },
+  {
+    "title": "AVLH3 #342 - Mario Kart Hash",
+    "date": "2016-04-30",
+    "startTime": "13:00",
+    "location": "Bell Forest Apartments, 300 Long Shoals Rd, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/229228999/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #341 - HoneyMOON Hash",
+    "date": "2016-04-24",
+    "startTime": "12:00",
+    "location": "Sierra Nevada Brewery, 100 Sierra Nevada Way, Fletcher, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/230496985/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #340 - Princess & Cum Pi's White Dress Run!",
+    "date": "2016-04-23",
+    "startTime": "14:00",
+    "location": "North Mills River Campground, 5289 N Mills River Road, Mills River, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/228626984/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3 #339 - Hoover's Housewarming",
+    "date": "2016-04-16",
+    "startTime": "10:00",
+    "location": "Casa de Hoover, 14 Briarcliff Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/229785386/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #338 - Lady And Tugs's Anal 80's Bday Hash!!!",
+    "date": "2016-04-09",
+    "startTime": "14:00",
+    "location": "Hominy Creek Park, 194 Hominy Creek Rd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/228636241/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #337 - NFN Eliza Beth's 1st Haring!",
+    "date": "2016-04-05",
+    "startTime": "18:30",
+    "location": "Richmond Hill Park, 280 Richmond Hill Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/228124384/",
+    "attendees": 34
+  },
+  {
+    "title": "AVLH3 336 - April Fool NFN Eugene's 1st Haring!!!",
+    "date": "2016-04-02",
+    "startTime": "14:00",
+    "location": "Weaver Park, 200 Murdock Ave., (Off Merrimon Ave.), Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/229461238/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #335 - Jesus Saves Hash",
+    "date": "2016-03-26",
+    "startTime": "14:00",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227480653/",
+    "attendees": 23
+  },
+  {
+    "title": "AVLH3 #334 - Hottie Tottie Hash",
+    "date": "2016-03-19",
+    "startTime": "14:00",
+    "location": "Fresh Market, 944 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/228098542/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #333 - Annual St Paddy's Day Hash!",
+    "date": "2016-03-17",
+    "startTime": "18:30",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227680324/",
+    "attendees": 29
+  },
+  {
+    "title": "AVLH3 #332 - NFN Matt's 1st haring",
+    "date": "2016-03-16",
+    "startTime": "18:30",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/229234096/",
+    "attendees": 12
+  },
+  {
+    "title": "AVL H3 #331 - The BVVVVVVVVVVVVVVVVVVVC Hash",
+    "date": "2016-03-12",
+    "startTime": "14:00",
+    "location": "Parking Lot on Virginia Avenue (you should know where this is by now), 690 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225736482/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #330 - March on ya Wanks!",
+    "date": "2016-03-05",
+    "startTime": "13:00",
+    "location": "2 Flycatcher Way, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/229033222/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #329 - First Quadrennial Leap Day Hash!",
+    "date": "2016-02-29",
+    "startTime": "18:30",
+    "location": "Parking Lot at the Top of Lyman St (Zorro's office), 122 Lyman St., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/228882646/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #328 - Annual Red Dress Hash",
+    "date": "2016-02-27",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226715790/",
+    "attendees": 59
+  },
+  {
+    "title": "Red Dress PreParty West AVL Bar Crawl!!!",
+    "date": "2016-02-26",
+    "startTime": "19:00",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/229094513/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #327 - Asheville H3's 8th Anniversary",
+    "date": "2016-02-23",
+    "startTime": "18:00",
+    "location": "West Asheville Presbyterian, 690 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227725296/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 Invades UHHH's Red Dress Hash!",
+    "date": "2016-02-20",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227419468/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #326 - VD for all the wankers!",
+    "date": "2016-02-13",
+    "startTime": "14:00",
+    "location": "Stevens Lee Rec Center, 30 G W Carver Avenue Asheville, NC 28801, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226749845/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #325 - Sexy Cums in a Pair",
+    "date": "2016-02-11",
+    "startTime": "18:30",
+    "location": "Hi-Wire Brewing, 2 Huntsman Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/228108036/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #324 - Oh when the HASHERS go marching in: AVLH3 Does Mardi Gras",
+    "date": "2016-02-07",
+    "startTime": "13:00",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227904929/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #323 - Wounded Warrior Charity Hash",
+    "date": "2016-02-06",
+    "startTime": "14:00",
+    "location": "Asheville Mall, 3 South Tunnel Rd, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226945947/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #322 - Stayshoe",
+    "date": "2016-01-30",
+    "startTime": "14:00",
+    "location": "Parking lot, 17 Garfield Street, Asheville, NC, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227725232/",
+    "attendees": 15
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-14.json
+++ b/scripts/data/avlh3-meetup-history-batch-14.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Knuckle Dragging, Two Planken, Drunken good time.... In Snow Shoe",
+    "date": "2016-01-29",
+    "startTime": "08:00",
+    "location": "Snow Shoe Mt., West Ridge 119, Snow Shoe, WV, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226918994/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #321 - Most Raceist Trail Ever and NFN Chris's 1st haring",
+    "date": "2016-01-16",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226749887/",
+    "attendees": 35
+  },
+  {
+    "title": "AVLH3 #320 - Helen Keller's a Perfect 10",
+    "date": "2016-01-09",
+    "startTime": "14:00",
+    "location": "Behind the Root Bar, 1410 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227553935/",
+    "attendees": 9
+  },
+  {
+    "title": "AVL Invades Sopih3's 200th!!!",
+    "date": "2016-01-09",
+    "startTime": "14:00",
+    "location": "Railhouse Brewery, 105 E South St, Aberdeen, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227341237/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #319 - New Year's Hangover-Over Hash",
+    "date": "2016-01-03",
+    "startTime": "14:00",
+    "location": "Parking Lot, 16 Regent Park Blvd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227783328/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #318 - Annual Formal",
+    "date": "2016-01-01",
+    "startTime": "17:30",
+    "location": "The Bier Garden, 46 Haywood Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226715761/",
+    "attendees": 41
+  },
+  {
+    "title": "AVLH3 #317 - Adios 2015!",
+    "date": "2015-12-26",
+    "startTime": "14:00",
+    "location": "Carmike 10 at River Hills, 121 River Hills Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227533526/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #316 - The Darkest and Longest....",
+    "date": "2015-12-21",
+    "startTime": "18:30",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/227291016/",
+    "attendees": 27
+  },
+  {
+    "title": "AVLH3 #315 - The Wind Between My Cheeks",
+    "date": "2015-12-19",
+    "startTime": "14:00",
+    "location": "Buffalo Wild Wings, 4 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226629459/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #314 - The Maccabeetoff Hanukkah Hash",
+    "date": "2015-12-13",
+    "startTime": "14:00",
+    "location": "M's School Of Art, 302 Davis St, Hendersonville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226945689/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #313 - Annual Ugly Sweater Hash",
+    "date": "2015-12-12",
+    "startTime": "13:00",
+    "location": "Weaver Park, 200 Murdock Ave., (Off Merrimon Ave.), Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225547090/",
+    "attendees": 27
+  },
+  {
+    "title": "AVLH3 #312 - Nurse Hoover's Birthday Hash!",
+    "date": "2015-12-09",
+    "startTime": "18:00",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226749797/",
+    "attendees": 30
+  },
+  {
+    "title": "UHHH Green Dress Run",
+    "date": "2015-12-06",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226750047/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #311 - Taint's Revenge",
+    "date": "2015-12-05",
+    "startTime": "12:00",
+    "location": "Taint Tantra's Residence, 154 Castlerock Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225547001/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #310 - Spanksgiving",
+    "date": "2015-11-28",
+    "startTime": "14:00",
+    "location": "Ingles, 780 hendersonville road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225560221/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #309 - Annual MANNA Food Bank Hash",
+    "date": "2015-11-21",
+    "startTime": "14:00",
+    "location": "iwanna, 22 Garfield St #100, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225368638/",
+    "attendees": 26
+  },
+  {
+    "title": "AVLH3 #308 - Kaitlyn's 1st haring",
+    "date": "2015-11-20",
+    "startTime": "18:00",
+    "location": "Brownies shit hole, 7 waters rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225856103/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #308 - Houdini's Birthday!",
+    "date": "2015-11-19",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226885759/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #307 - Does a bear sh*t in the woods?",
+    "date": "2015-11-14",
+    "startTime": "16:00",
+    "location": "Brian's Mountain Home, 43 Sonnet Lane, 28804, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225208742/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #306 - Around the World: A Relay-Hare Hash",
+    "date": "2015-11-13",
+    "startTime": "18:30",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225213100/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #305 - NFN Cassandra's first hare!",
+    "date": "2015-11-12",
+    "startTime": "18:00",
+    "location": "MAHEC Family Health Center, 118 W. T. Weaver Blvd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/226536615/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #304 - The Mud Beneath My Sneaks (and NFN Damien's first hare!)",
+    "date": "2015-11-07",
+    "startTime": "14:00",
+    "location": "McCormick Field, 30 Buchanan Place, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224378876/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #303 - Friday Mash Up",
+    "date": "2015-11-06",
+    "startTime": "19:00",
+    "location": "Wedge Brewery, 125b Roberts St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225559054/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #302 - Annual Hashoween Pub Crawl",
+    "date": "2015-10-31",
+    "startTime": "19:00",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224137481/",
+    "attendees": 47
+  },
+  {
+    "title": "Case of the Mondays hash",
+    "date": "2015-10-26",
+    "startTime": "18:30",
+    "location": "TGI Fridays, 115 Hendersonville Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224703742/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3's 300TH TRAIL",
+    "date": "2015-10-24",
+    "startTime": "13:00",
+    "location": "McCormick Field, 30 Buchanan Place, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224378958/",
+    "attendees": 46
+  },
+  {
+    "title": "AVLH3 #299 - The $2.99 Hash!",
+    "date": "2015-10-17",
+    "startTime": "14:00",
+    "location": "J&S Cafeteria, 800 Fairview Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224378891/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #298: AVLH3 Invades the Asheville Zombie Walk!",
+    "date": "2015-10-11",
+    "startTime": "16:00",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/225286789/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #297 - The Great Hash Beer Taste Test",
+    "date": "2015-10-03",
+    "startTime": "14:00",
+    "location": "West Ashville Presbyterian, 22 Virginia Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221738770/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #296 - Mount My Python and the Happy Trail Hash",
+    "date": "2015-09-26",
+    "startTime": "15:00",
+    "location": "\"Lady\" Guinevere, Sir Tugs and The Knights Of The Round Table, 374 Old County Home Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/223494630/",
+    "attendees": 32
+  },
+  {
+    "title": "AVLH3 #295 - Kotex and NFN Jay, NFN Adam and Fournicorn.",
+    "date": "2015-09-19",
+    "startTime": "14:00",
+    "location": "Folk Art Center, Milepost 382 Blue Ridge Pkwy Asheville, NC 28805, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224378793/",
+    "attendees": 11
+  },
+  {
+    "title": "ERECTIONS AND HASH APPRECIATION NIGHT",
+    "date": "2015-09-18",
+    "startTime": "19:30",
+    "location": "Admiral and Madre Place, 60 mildred ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224135094/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #294 - NFHN Eric's First Haring & Possible Naming",
+    "date": "2015-09-12",
+    "startTime": "14:00",
+    "location": "Eric's Neighbor, 19 Old Run Road, Fairview, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/223362712/",
+    "attendees": 16
+  },
+  {
+    "title": "THE GREAT AMERICAN WANKER WHISKEY TASTING",
+    "date": "2015-09-05",
+    "startTime": "14:00",
+    "location": "Our place, 60 Mildred Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221838784/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3# 293 - Log and NFN Christine's Fun Friday",
+    "date": "2015-08-28",
+    "startTime": "18:30",
+    "location": "Mahec Family Health Center: Ray Lisa MD, 118 W. T. Weaver Boulevard, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224573098/",
+    "attendees": 26
+  },
+  {
+    "title": "AVLH3 #292 - NFHN Emily",
+    "date": "2015-08-22",
+    "startTime": "15:00",
+    "location": "George's stor-mor, 550 Swannanoa River Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224009949/",
+    "attendees": 22
+  },
+  {
+    "title": "#291: Back 2 School Hash",
+    "date": "2015-08-19",
+    "startTime": "18:30",
+    "location": "Aston Park, 336 Hilliard Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224673989/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 Trail #291 - Case of the Mondays Hash",
+    "date": "2015-08-17",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224232376/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 Trail #290 - Rough on the Right's Analversary",
+    "date": "2015-08-15",
+    "startTime": "14:00",
+    "location": "Bent Creek Ledford Parking area, 479E, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222817948/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3 Trail #289 - NFN Kasha's SECOND Haring (And Possible Naming)",
+    "date": "2015-08-08",
+    "startTime": "14:00",
+    "location": "Azalea Park, Azalea Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/223044797/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 Trail #288 - Wine down down down down Wednesday",
+    "date": "2015-08-05",
+    "startTime": "18:30",
+    "location": "Bear Creek Apartments, 110 Bear Creek Ln, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224233032/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #287 - Sober Up Sunday",
+    "date": "2015-08-02",
+    "startTime": "14:00",
+    "location": "creekside taphouse, 8 beverly rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224184940/",
+    "attendees": 7
+  },
+  {
+    "title": "Get into the Moonshine while Mommy and Daddy are away",
+    "date": "2015-08-01",
+    "startTime": "21:30",
+    "location": "Ingles, 1141 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224309745/",
+    "attendees": 4
+  },
+  {
+    "title": "SloshBall at Greenville",
+    "date": "2015-07-31",
+    "startTime": "17:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221418716/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #285 - Pee Pee Trail",
+    "date": "2015-07-27",
+    "startTime": "18:00",
+    "location": "Blue Ridge Parkway Visitors Center, 195 Hemphill Knob Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/224054162/",
+    "attendees": 11
+  },
+  {
+    "title": "Annual BLUE DRESS RUN!!!",
+    "date": "2015-07-25",
+    "startTime": "14:00",
+    "location": "West Asheville Park, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221686367/",
+    "attendees": 33
+  },
+  {
+    "title": "AVLH3 #283: Naming of NFN Faye!!!",
+    "date": "2015-07-18",
+    "startTime": "13:00",
+    "location": "Jean Webb Park, 30 Riverside Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222860128/",
+    "attendees": 30
+  },
+  {
+    "title": "AVLH3 #282 - Roller Derby Hash",
+    "date": "2015-07-11",
+    "startTime": "14:00",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222572677/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #281 - Princess' 100th Hare!",
+    "date": "2015-07-04",
+    "startTime": "14:00",
+    "location": "Potchentokus Manor, 286 Flat Creek Road, Fairview, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222638117/",
+    "attendees": 32
+  },
+  {
+    "title": "AVLH3 #280 - Mon-day Trail! Mon-day Trail! Excellent!!!",
+    "date": "2015-06-29",
+    "startTime": "18:30",
+    "location": "West Ashville Presbyterian, 22 Virginia Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/223506285/",
+    "attendees": 13
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-15.json
+++ b/scripts/data/avlh3-meetup-history-batch-15.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Doggie style hash: proceeds go to Charlie's Angel Dog Rescue",
+    "date": "2015-06-27",
+    "startTime": "14:00",
+    "location": "Carrier Park, 220 Amboy Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221773528/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #278 - Princess' 99th",
+    "date": "2015-06-24",
+    "startTime": "18:30",
+    "location": "Parking lot in Biltmore Village, 33 Garfield Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222802323/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #277 - Le Tour de Hash - SOUTH (Stage 6: THE FINALE)",
+    "date": "2015-06-20",
+    "startTime": "14:00",
+    "location": "Glen Bridge River Park, 77 Pinner Road, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221798163/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #276 - Le Tour de Hash - North (Stage 5)",
+    "date": "2015-06-19",
+    "startTime": "18:30",
+    "location": "Brian's House, 43 Sonnet Lane, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221798157/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #275 - Le Tour de Hash - West (Stage 4)",
+    "date": "2015-06-17",
+    "startTime": "18:30",
+    "location": "West Asheville Park, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221798149/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #274 - Le Tour de Hash - East (Stage 3)",
+    "date": "2015-06-16",
+    "startTime": "18:30",
+    "location": "Highland Brewing Company, 12 Old Charlotte Highway, Suite H, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221798140/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #273 - Le Tour de Hash - Downtown (Stage 2)",
+    "date": "2015-06-15",
+    "startTime": "18:30",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221798130/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #272 - Le Tour de Hash - River Arts (Stage 1)",
+    "date": "2015-06-13",
+    "startTime": "14:00",
+    "location": "Westgate Shopping Center, 50 Westgate Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221798118/",
+    "attendees": 15
+  },
+  {
+    "title": "F&*€ing Fairview",
+    "date": "2015-06-06",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222595921/",
+    "attendees": 1
+  },
+  {
+    "title": "NFHN Zach's Fairview Naming!",
+    "date": "2015-06-06",
+    "startTime": "14:00",
+    "location": "Potchentokus Manor, 286 Flat Creek Road, Fairview, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222573512/",
+    "attendees": 22
+  },
+  {
+    "title": "Welcome Home CumLord!!",
+    "date": "2015-05-26",
+    "startTime": "18:00",
+    "location": "Corner of Cumberland and Starnes Avenues, 51 Cumberland Avenue (closest address I could find), Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222769974/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3's 6th Annual Memorial Saturday Trail!!!",
+    "date": "2015-05-23",
+    "startTime": "14:00",
+    "location": "White Pines South Group Campground, National Forest Road, Pisgah Forest, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221392591/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #268 - Ya, Mon-Day Trail!",
+    "date": "2015-05-18",
+    "startTime": "18:30",
+    "location": "J and S Cafeteria, 800 Fairview Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222454066/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #266: Burlesque/Lingerie Run to benefit A Dry Dome for Ellen's Bald Head",
+    "date": "2015-05-16",
+    "startTime": "14:00",
+    "location": "Mahec Family Health Center: Ray Lisa MD, 118 W. T. Weaver Boulevard, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221506966/",
+    "attendees": 12
+  },
+  {
+    "title": "Trinity is Dirty and Thirty",
+    "date": "2015-05-09",
+    "startTime": "15:00",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221117427/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #265 - NIMBY",
+    "date": "2015-05-07",
+    "startTime": "18:30",
+    "location": "Berrington Village Apartments, 1 Overton Way, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221694010/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #264 - Cinco de Mayo Hash",
+    "date": "2015-05-05",
+    "startTime": "19:00",
+    "location": "Casa de Trinity, 21 Balsam Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222178640/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #263 - The Kessel Run",
+    "date": "2015-05-04",
+    "startTime": "18:30",
+    "location": "The park across from St. Mary's Episcopal, 70 Gertrude Place, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221722173/",
+    "attendees": 11
+  },
+  {
+    "title": "Charlotte Red Dress",
+    "date": "2015-05-02",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221479741/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #262 - Mayday Mayday!!!",
+    "date": "2015-05-01",
+    "startTime": "18:00",
+    "location": "Empty Parking Lot at corner of Shelburne and Hominy Creek, 30 shelburne road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/222120636/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #261 - Shuck my balls Hash:",
+    "date": "2015-04-29",
+    "startTime": "18:00",
+    "location": "Walton Street Park, 570 Walton Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221749441/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #260 - Oh Brother Hand Job",
+    "date": "2015-04-25",
+    "startTime": "14:00",
+    "location": "Hand Job and Oh Brother's House, 54 Scott Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220898834/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #259 - Hump Mother Earth Day",
+    "date": "2015-04-22",
+    "startTime": "18:30",
+    "location": "Walton Street Park, 570 Walton Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221323334/",
+    "attendees": 9
+  },
+  {
+    "title": "Lady Furlezbo Bonobo's 80's Birthday Hash",
+    "date": "2015-04-18",
+    "startTime": "15:00",
+    "location": "Aston Park, 336 Hilliard Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220817609/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #257 - Grill Out in Candler Forest HASHRUN!",
+    "date": "2015-04-11",
+    "startTime": "14:00",
+    "location": "Pisgah National Forest, 2211 Pisgah Hwy, Candler, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220898906/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #256 - 96/269",
+    "date": "2015-04-06",
+    "startTime": "18:00",
+    "location": "Westgate Shopping Center, 50 Westgate Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221554564/",
+    "attendees": 7
+  },
+  {
+    "title": "Beer, Boxes, & Braut’s",
+    "date": "2015-04-05",
+    "startTime": "14:00",
+    "location": "U-Haul, 387 Swannanoa River Rd, 28805, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/221554680/",
+    "attendees": 1
+  },
+  {
+    "title": "First Full mOOn Hash of 2015 and Naughty Easter Egg Hunt",
+    "date": "2015-04-04",
+    "startTime": "18:00",
+    "location": "Parking Lot BEHIND the car wash, across from the Church - Where we met up for Hobo Hash, 650 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220647684/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #255 - Wanker Fools Hash",
+    "date": "2015-04-01",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220745442/",
+    "attendees": 3
+  },
+  {
+    "title": "Geriatric Hash & NFN Marybeth's naming!",
+    "date": "2015-03-28",
+    "startTime": "14:00",
+    "location": "Lake Julian, 406 Overlook Extension, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220721660/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3 #253 - Cum Pi Show You Good Time",
+    "date": "2015-03-25",
+    "startTime": "18:30",
+    "location": "Parking lot, 39 Banks Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220937413/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #252 - Pooping Princess Trail",
+    "date": "2015-03-23",
+    "startTime": "18:30",
+    "location": "Folk Art Center, 382 Blue Ridge Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220930753/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #251 - Spring has Sprung",
+    "date": "2015-03-21",
+    "startTime": "15:00",
+    "location": "Blocked Road, 30 Goodman Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220757577/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #250 - St. Patty's Day Hash",
+    "date": "2015-03-17",
+    "startTime": "18:30",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220757504/",
+    "attendees": 25
+  },
+  {
+    "title": "AVLH3 #249 PI DAY and NFHN Jason's Naming",
+    "date": "2015-03-14",
+    "startTime": "14:00",
+    "location": "Asheville Pizza & Brewing Co, 675 Merrimon Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220691510/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #248 - Hash to the Future!!!",
+    "date": "2015-03-07",
+    "startTime": "14:00",
+    "location": "Dr Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220502309/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #247 - Farewell February",
+    "date": "2015-02-28",
+    "startTime": "14:00",
+    "location": "Ascot Point Village, 22 Ascot Point Circle, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220326546/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #246 - Asheville H3's 7th GLOW Anniversary",
+    "date": "2015-02-23",
+    "startTime": "18:30",
+    "location": "West Asheville Park, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219903023/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3's 7th Annual Red Dress Run!!!",
+    "date": "2015-02-21",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/201964382/",
+    "attendees": 44
+  },
+  {
+    "title": "HotDog-Tugs Anti-VDay Adventure",
+    "date": "2015-02-14",
+    "startTime": "16:00",
+    "location": "Asheville Pizza & Brewing Co, 675 Merrimon Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220436095/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #243 - Friday the 13th",
+    "date": "2015-02-13",
+    "startTime": "18:30",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220093852/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #242 - Namings Are Such Fun...",
+    "date": "2015-02-11",
+    "startTime": "18:00",
+    "location": "Empty Parking Lot, 83 Charlotte Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220140798/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 invades CHARLOTTE! Joint run with CH3, MOSH3 and SMUSHHH!!!",
+    "date": "2015-02-07",
+    "startTime": "11:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219698062/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #240 - MS Charity Hash",
+    "date": "2015-02-06",
+    "startTime": "18:30",
+    "location": "Parking lot, 39 Banks Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/220260761/",
+    "attendees": 13
+  },
+  {
+    "title": "Samantha's Naming",
+    "date": "2015-01-31",
+    "startTime": "17:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219877741/",
+    "attendees": 9
+  },
+  {
+    "title": "Ski trip: snowshoe ski resort",
+    "date": "2015-01-30",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/218853344/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3's Frankin Spankin good time!",
+    "date": "2015-01-24",
+    "startTime": "15:00",
+    "location": "Lake Julian, 406 Overlook Extension, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219616600/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #237 - Huckelberry Wood",
+    "date": "2015-01-17",
+    "startTime": "14:00",
+    "location": "Woodberry Apartments, 10 Alexander Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219668990/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3 #236 - NFN Stephs Naming & Princess' 75th Haring",
+    "date": "2015-01-10",
+    "startTime": "14:00",
+    "location": "Parking lot, 39 Banks Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219384517/",
+    "attendees": 17
+  },
+  {
+    "title": "Hashy Happy Hour",
+    "date": "2015-01-09",
+    "startTime": "17:00",
+    "location": "Altamont Brewing Co, 1042 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219697395/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-16.json
+++ b/scripts/data/avlh3-meetup-history-batch-16.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3's First Annual Formal",
+    "date": "2015-01-03",
+    "startTime": "17:00",
+    "location": "The Bier Garden, 46 Haywood Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/214555812/",
+    "attendees": 31
+  },
+  {
+    "title": "Festivus, A Hash for the Rest of Us",
+    "date": "2014-12-27",
+    "startTime": "14:00",
+    "location": "Kmart Asheville, 980 Brevard Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219220741/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 # 233: Ba Hum Bug Hash",
+    "date": "2014-12-20",
+    "startTime": "14:00",
+    "location": "Ben's Tune-Up, 195 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/219195251/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 Ugly Christmas Sweater HASH and the naming of just Krista",
+    "date": "2014-12-13",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/217224992/",
+    "attendees": 37
+  },
+  {
+    "title": "AVLH3 \"Catch Brownie if you can Hash\"",
+    "date": "2014-12-06",
+    "startTime": "13:00",
+    "location": "Asheville Technologies Parking Lot, 40 N. Merrimon Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/218946043/",
+    "attendees": 9
+  },
+  {
+    "title": "Let's Name Barbara, Eh?! NFN Barbara's Naming, Part Deux",
+    "date": "2014-12-03",
+    "startTime": "18:00",
+    "location": "Asheville Pizza & Brewing Co, 675 Merrimon Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/218873576/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3's #229 - Post Gobbleyptic Hash",
+    "date": "2014-11-29",
+    "startTime": "13:00",
+    "location": "Bent Creek Ledford Parking area, 479E, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/218892877/",
+    "attendees": 10
+  },
+  {
+    "title": "Beersgiving hash",
+    "date": "2014-11-26",
+    "startTime": "18:30",
+    "location": "Aston Park, 336 Hilliard Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/218852994/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #227 - MANNA Food Bank Hash",
+    "date": "2014-11-22",
+    "startTime": "13:00",
+    "location": "Walmart Supercenter, 1636 Hendersonville Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/210851042/",
+    "attendees": 25
+  },
+  {
+    "title": "Throw a name on the Barbie",
+    "date": "2014-11-20",
+    "startTime": "18:00",
+    "location": "Mahec Family Health Center: Ray Lisa MD, 118 W. T. Weaver Boulevard, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/218723291/",
+    "attendees": 8
+  },
+  {
+    "title": "Hasharoke",
+    "date": "2014-11-14",
+    "startTime": "18:30",
+    "location": "Near subway, 4 Long Shoals Rd, Ste A, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/213137882/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #224 Ashton's Naming",
+    "date": "2014-11-09",
+    "startTime": "15:00",
+    "location": "Ascot Point Village, 22 Ascot Point Circle, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/217221452/",
+    "attendees": 19
+  },
+  {
+    "title": "Movember Mustache Hash",
+    "date": "2014-11-02",
+    "startTime": "14:00",
+    "location": "Asheville Tourists - McCormick Field, 30 Buchanan Pl., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/205379332/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3's 6th Annual Hash-o-ween-er Hash",
+    "date": "2014-10-25",
+    "startTime": "15:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/202091142/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 Trail #222",
+    "date": "2014-10-22",
+    "startTime": "18:00",
+    "location": "Asheville Pizza & Brewing Co, 675 Merrimon Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/214746562/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #221 - Get Bent Creek Hash",
+    "date": "2014-10-17",
+    "startTime": "18:00",
+    "location": "Bent Creek Ledford Parking area, 479E, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/210851582/",
+    "attendees": 4
+  },
+  {
+    "title": "Wednesday Wet Willy Wanker's Hillbilly Hash..",
+    "date": "2014-10-15",
+    "startTime": "17:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/210260762/",
+    "attendees": 11
+  },
+  {
+    "title": "Asheville H3 invades the Asheville Zombie Walk!!",
+    "date": "2014-10-12",
+    "startTime": "17:00",
+    "location": "Asheville Pizza and Brewing Co., 77 Coxe Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/210993112/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #218 - Topsy Turvy Tash",
+    "date": "2014-10-11",
+    "startTime": "14:00",
+    "location": "Appalachian Vinter, 745 Biltmore Avenue Suite 121, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/210232152/",
+    "attendees": 7
+  },
+  {
+    "title": "Log Flume's BIRTHDAY Hump Day Hash!!!!",
+    "date": "2014-10-08",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/209195512/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #216 - Turn the Paige...... into a named Wanker.",
+    "date": "2014-10-04",
+    "startTime": "15:00",
+    "location": "Kmart, 1001 Patton Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/210233282/",
+    "attendees": 14
+  },
+  {
+    "title": "MOSH3 Invasion!",
+    "date": "2014-09-28",
+    "startTime": "14:00",
+    "location": "Hash Start, 23 Asheland Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/203127132/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3# 214: Lube the Boob on the Tube",
+    "date": "2014-09-27",
+    "startTime": "11:30",
+    "location": "Wedge Brewing Co, 125B Roberts St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/203495262/",
+    "attendees": 22
+  },
+  {
+    "title": "Hash #213: Super Sh*tty Tuesday",
+    "date": "2014-09-23",
+    "startTime": "18:00",
+    "location": "Asheville Tourists - McCormick Field, 30 Buchanan Pl., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/206247992/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #212: FIRST LEG of the CAROLINA HOBO HASH!!!",
+    "date": "2014-09-18",
+    "startTime": "18:30",
+    "location": "West Asheville Presbyterian, 690 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/206249612/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #211: Wankers on Wednesday",
+    "date": "2014-09-17",
+    "startTime": "18:30",
+    "location": "French Broad River Park, 508 Riverview Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/207341012/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #210 - Namings of NFHN Gene & NFHN Bryan",
+    "date": "2014-09-13",
+    "startTime": "14:00",
+    "location": "First Bank, 79 Woodfin Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/199999772/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #209 - 69th Hare",
+    "date": "2014-09-06",
+    "startTime": "14:00",
+    "location": "Hi-Wire Brewing, 197 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/200560132/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #208 - ALS Ice Bucket Challenge Trail",
+    "date": "2014-09-02",
+    "startTime": "18:00",
+    "location": "Wild Wings Cafe, 64 Long Shoals Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/202428582/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #207 - NFHN Jeremy",
+    "date": "2014-08-30",
+    "startTime": "14:00",
+    "location": "Mahec Family Health Center: Ray Lisa MD, 118 W. T. Weaver Boulevard, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/203245052/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #206 - NFHN Kyle",
+    "date": "2014-08-24",
+    "startTime": "14:00",
+    "location": "Gavel parking lot off of greenway, 300 Broadway Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/201962802/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #205 - Spanks-Flume Hump Day Hash",
+    "date": "2014-08-20",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/201802532/",
+    "attendees": 5
+  },
+  {
+    "title": "MisManagement Meeting",
+    "date": "2014-08-18",
+    "startTime": "18:00",
+    "location": "Ben's Tune-Up, 195 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/200933352/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #204 - White Dress",
+    "date": "2014-08-17",
+    "startTime": "14:00",
+    "location": "Altamont Brewing Co, 1042 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/198241312/",
+    "attendees": 17
+  },
+  {
+    "title": "SLOSHBALL! Rep Team AVLH3 against GH3, UHHH, MOSH3, SMUSHHH, CLTH3, & COLAH3",
+    "date": "2014-08-16",
+    "startTime": "13:00",
+    "location": "Rubber Commando's Place, 308 Keeler Bridge Road, Marietta, SC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/188003992/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #203 - Erections",
+    "date": "2014-08-13",
+    "startTime": "18:30",
+    "location": "Wedge Brewery, 151 Roberts St, Ground floor of the Wedge Gallery, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/198765822/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #202 - The Haunted Hash",
+    "date": "2014-08-09",
+    "startTime": "15:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/196102902/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3's 200TH TRAIL!!!!",
+    "date": "2014-08-02",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/187104742/",
+    "attendees": 3
+  },
+  {
+    "title": "Pooping on the Parkway",
+    "date": "2014-07-30",
+    "startTime": "18:30",
+    "location": "Folk Art Center, 382 Blue Ridge Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/196787662/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #200 - BLUE DRESS & 6TH YEAR ANNIVERSARY HASH!!!",
+    "date": "2014-07-27",
+    "startTime": "13:30",
+    "location": "Ben's Tune-Up, 195 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/187322542/",
+    "attendees": 33
+  },
+  {
+    "title": "AVLH3 #199 - 199 Red Balloons",
+    "date": "2014-07-23",
+    "startTime": "18:30",
+    "location": "Parking Lot (Across from Asheville Brewing Company), 76 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/195843332/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #198 - Blind Leading the Monkey Hash",
+    "date": "2014-07-19",
+    "startTime": "15:00",
+    "location": "Mysterious Place, 39 Banks Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/194132482/",
+    "attendees": 5
+  },
+  {
+    "title": "Asheville invades Columbia for a FLASH!",
+    "date": "2014-07-19",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/186618442/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #???",
+    "date": "2014-07-17",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/192622662/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #197 - Le Tour de Hash (FINALE!!!)",
+    "date": "2014-07-12",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/187101042/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #196 - Le Tour de Hash (Stage 4)",
+    "date": "2014-07-10",
+    "startTime": "18:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/187100882/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #195 - Le Tour de Hash (Stage 3)",
+    "date": "2014-07-09",
+    "startTime": "18:00",
+    "location": "Buffalo Wild Wings Grill & Bar, 4 Tunnel Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/187100702/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #194 - Le Tour de Hash (Stage 2)",
+    "date": "2014-07-07",
+    "startTime": "18:00",
+    "location": "Hazel Robinson Amphitheatre, 100 Gay St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/187100492/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #193 - Le Tour de Hash (Stage 1)",
+    "date": "2014-07-06",
+    "startTime": "13:00",
+    "location": "The Wedge, 125B Roberts Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/187099462/",
+    "attendees": 14
+  },
+  {
+    "title": "Drinking Practice",
+    "date": "2014-06-29",
+    "startTime": "13:00",
+    "location": "Oyster House, 625 Haywood Rd, Asheville, NC, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/191446912/",
+    "attendees": 2
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-17.json
+++ b/scripts/data/avlh3-meetup-history-batch-17.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Wedgies in the River Farts District",
+    "date": "2014-06-25",
+    "startTime": "18:30",
+    "location": "Wedge Brewery, 151 Roberts St, Ground floor of the Wedge Gallery, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/189481112/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #192 - Mount Me Momma",
+    "date": "2014-06-14",
+    "startTime": "15:00",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/183457532/",
+    "attendees": 16
+  },
+  {
+    "title": "FREE BEER FOR ALL THE HASHERS!!",
+    "date": "2014-06-11",
+    "startTime": "18:30",
+    "location": "Cherry Street Parking Lot, Flint St & Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/186565442/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3's 5th Annual Memorial Saturday Trail!!!",
+    "date": "2014-05-24",
+    "startTime": "13:00",
+    "location": "White Pines South Group Campground, National Forest Road, Pisgah Forest, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/179069372/",
+    "attendees": 6
+  },
+  {
+    "title": "Hump Day Hash",
+    "date": "2014-05-14",
+    "startTime": "18:30",
+    "location": "Mahec Family Health Center: Ray Lisa MD, 118 W. T. Weaver Boulevard, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/181550562/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #188 - Spring Has Sprung Hash!",
+    "date": "2014-04-26",
+    "startTime": "14:00",
+    "location": "French Broad River Park, 508 Riverview Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/176218972/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #187",
+    "date": "2014-04-19",
+    "startTime": "14:00",
+    "location": "West Asheville Park, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/172632262/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #186 - Tax Day Tuesday",
+    "date": "2014-04-15",
+    "startTime": "18:00",
+    "location": "Ascot Point Village, 22 Ascot Point Circle, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/176219822/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #185 - Shiggy Sunday!!!",
+    "date": "2014-04-13",
+    "startTime": "13:00",
+    "location": "Bent Creek Ledford Parking area, 479E, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/175499832/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #184 - Thirsty Thursday",
+    "date": "2014-04-10",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/175499662/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #183 Haywood Jablomey Trail",
+    "date": "2014-03-15",
+    "startTime": "14:00",
+    "location": "Lake Junaluska Conference and Retreat Center, 91 North Lakeshore Drive, Lake Junaluska, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/166537292/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3's 6th Annual RED DRESS RUN!",
+    "date": "2014-02-22",
+    "startTime": "13:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/156816942/",
+    "attendees": 46
+  },
+  {
+    "title": "Two-fer Tuesday",
+    "date": "2014-02-18",
+    "startTime": "17:30",
+    "location": "Mahec Family Health Center: Ray Lisa MD, 118 W. T. Weaver Boulevard, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/164227562/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #180 - Thirsty Thursday",
+    "date": "2014-02-06",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/164213852/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #179 - Hashlympics",
+    "date": "2014-02-01",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/160590572/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #178 - Stop! Frankintime!",
+    "date": "2014-01-25",
+    "startTime": "14:00",
+    "location": "Hi-Wire Brewing, 197 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/159664102/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #177 - Beer Pimpin' Ain't Easy",
+    "date": "2014-01-18",
+    "startTime": "14:00",
+    "location": "Lower Parking Lot on Bulldog Drive, Bulldog Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/159663912/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #176 - Hunk Day Hash",
+    "date": "2014-01-08",
+    "startTime": "18:30",
+    "location": "Parking Lot (Across from Asheville Brewing Company), 76 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/157894512/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #??? - Who wants a Wedgie?",
+    "date": "2013-12-28",
+    "startTime": "12:00",
+    "location": "Wedge Brewing Co, 125B Roberts St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/155971992/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #174 - 12/12 Hash!",
+    "date": "2013-12-12",
+    "startTime": "18:00",
+    "location": "barcade, 130 College Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/154045552/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #173 - Ugly Sweater + Manna Food Bank Hash",
+    "date": "2013-12-07",
+    "startTime": "12:00",
+    "location": "Buncombe County Health Department, 35 Woodfin Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/139847152/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #172 - Spankin' Good Time",
+    "date": "2013-11-16",
+    "startTime": "14:00",
+    "location": "Old Fort Road Community Center, 807 Old Fort Road, Fairview, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/148630812/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #171 - Ukrainian Trail",
+    "date": "2013-11-09",
+    "startTime": "14:00",
+    "location": "Bent Creek ~ Rice Pinnacle Parking Area, 35.496612, -82.615854, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/147869872/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3's Annual Hash-O-Ween Event!",
+    "date": "2013-10-25",
+    "startTime": "18:00",
+    "location": "Mahec Family Health Center: Ray Lisa MD, 118 W. T. Weaver Boulevard, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/139840732/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #169 - Thor's Day Out",
+    "date": "2013-10-19",
+    "startTime": "15:00",
+    "location": "Bent Creek Ledford Parking area, 479E, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/144329602/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #168 - Discovery of America Hash",
+    "date": "2013-10-14",
+    "startTime": "18:00",
+    "location": "barcade, 130 College Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/144333232/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #167 - Princess' Ejaculate Conception Hash",
+    "date": "2013-09-28",
+    "startTime": "13:00",
+    "location": "Tods Tasties and To-Go's, 102 Montford Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/139847422/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #166 - West Asheville Hump Day Hash",
+    "date": "2013-09-18",
+    "startTime": "19:00",
+    "location": "Cum Lord's, 191 Cumberland Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/139849972/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #165 - AVLH3 Pub Crawl",
+    "date": "2013-09-14",
+    "startTime": "15:00",
+    "location": "Hi-Wire Brewing, 197 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/138381302/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #164 - Princess' 50th Hare",
+    "date": "2013-09-07",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/129579662/",
+    "attendees": 7
+  },
+  {
+    "title": "Need Hare(s)",
+    "date": "2013-08-31",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/133545772/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #163 - A Frankin' Spankin' B-DAY!",
+    "date": "2013-08-27",
+    "startTime": "18:30",
+    "location": "Stevens Lee Rec Center, 30 G W Carver Avenue Asheville, NC 28801, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/133226722/",
+    "attendees": 4
+  },
+  {
+    "title": "Need Hare(s)",
+    "date": "2013-08-17",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/133545532/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #162 - Deuce-Lo-Co Hash",
+    "date": "2013-08-10",
+    "startTime": "14:00",
+    "location": "Black Forest Restaurant, 2155 Hendersonville Rd., Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/129578302/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #161 - Humppopotamus",
+    "date": "2013-08-07",
+    "startTime": "19:00",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/131179142/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #160 - Hump Hash",
+    "date": "2013-07-31",
+    "startTime": "19:00",
+    "location": "Brixx Pizza, 0 Town Square Blvd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/131177922/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3's 5th Annual Bele Chere Hash",
+    "date": "2013-07-27",
+    "startTime": "12:00",
+    "location": "Hazel Robinson Amphitheatre, 100 Gay St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/128602582/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #158 - Le Tour de Hash (Downtown Finale Stage)",
+    "date": "2013-07-20",
+    "startTime": "14:00",
+    "location": "Hi-Wire Brewing, 197 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/124126372/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #157 - Le Tour de Hash (East Stage)",
+    "date": "2013-07-18",
+    "startTime": "18:30",
+    "location": "Highland Brewing Company, 12 Old Charlotte Highway, Suite H, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/124126182/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #156 - Le Tour de Hash (North Stage)",
+    "date": "2013-07-17",
+    "startTime": "18:00",
+    "location": "Asheville Pizza & Brewing Co, 675 Merrimon Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/124125872/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #155 - Le Tour de Hash (South Stage)",
+    "date": "2013-07-15",
+    "startTime": "18:00",
+    "location": "Brixx Pizza, 0 Town Square Blvd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/124125402/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #154 - Admiral's B-DAY! (Le Tour de Hash (West Stage))",
+    "date": "2013-07-13",
+    "startTime": "13:00",
+    "location": "The Wedge, 125B Roberts Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/124124312/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #153 - AMERICA!!! HASH YEAH!!!",
+    "date": "2013-07-07",
+    "startTime": "14:00",
+    "location": "Parking Lot in Arden, 320 Rockwood Road, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/127623272/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #151 - Rootin' Tootin' Trail",
+    "date": "2013-06-22",
+    "startTime": "14:00",
+    "location": "Root Bar #1, 1410 Tunnel Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/118563272/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #151 - JTR + OB3 +1",
+    "date": "2013-06-15",
+    "startTime": "14:00",
+    "location": "The Cantina Biltmore, 10 Biltmore Plaza, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/118536672/",
+    "attendees": 12
+  },
+  {
+    "title": "Pig Roast (no hash) Social Event",
+    "date": "2013-05-25",
+    "startTime": "12:00",
+    "location": "Wooden Eye's House, 615 Lake Drive, Piney Flats, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/117274112/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #149 - Smokey the ON-ON Bear!",
+    "date": "2013-05-19",
+    "startTime": "14:00",
+    "location": "5279 N Mills River Rd, Mills River, No, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/118167872/",
+    "attendees": 3
+  },
+  {
+    "title": "Ramble Run 5k/12k Road and Trail Race",
+    "date": "2013-05-11",
+    "startTime": "08:00",
+    "location": "Biltmore Park Town Square, 1 Town Square Boulevard, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/118145042/",
+    "attendees": null
+  },
+  {
+    "title": "AVLH3 #148 - NFN Scott's Birthday Hash!",
+    "date": "2013-05-10",
+    "startTime": "18:00",
+    "location": "Jet Set Designs, 915 Haywood Road, Asheville, NC 28806, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/117724172/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #147 - Beantown Charity Hash",
+    "date": "2013-04-28",
+    "startTime": "14:00",
+    "location": "creekside taphouse, 8 beverly rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/114785312/",
+    "attendees": 7
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-18.json
+++ b/scripts/data/avlh3-meetup-history-batch-18.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 #146 - Sunday Funday!",
+    "date": "2013-04-21",
+    "startTime": "14:00",
+    "location": "Immedion, 100 Technology Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/113292162/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #145 - Coltmore 45 Hash!",
+    "date": "2013-04-13",
+    "startTime": "13:00",
+    "location": "Hominy Valley Park, 25 Twin Lakes Drive, Candler, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/113289412/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #144 - New Beer's Eve Hash",
+    "date": "2013-04-06",
+    "startTime": "14:00",
+    "location": "J&S Cafeteria, 800 Fairview Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/112466872/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #143 - Fletcher Up Hash!",
+    "date": "2013-03-23",
+    "startTime": "13:00",
+    "location": "Fletcher Community Park, 85 Howard Gap Road, Fletcher, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/108708942/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #142 - St. Patrick's Day Hash",
+    "date": "2013-03-17",
+    "startTime": "14:00",
+    "location": "Parking Lot (Across from Asheville Brewing Company), 76 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/107094792/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #141 - 31313 Hash",
+    "date": "2013-03-13",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/107090812/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #140 - Daylight Saving Eve Hash",
+    "date": "2013-03-09",
+    "startTime": "13:00",
+    "location": "Walmart Supercenter, 1636 Hendersonville Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/107085802/",
+    "attendees": 5
+  },
+  {
+    "title": "MisManagement Meeting",
+    "date": "2013-02-07",
+    "startTime": "18:00",
+    "location": "Thirsty Monk, 92 Patton Ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/103160442/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #138 - The Frozen Nips Hash",
+    "date": "2013-01-26",
+    "startTime": "13:00",
+    "location": "NFHN Nate and Cindy's Place, 300 Long Shoals Road, Building 1, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/97931522/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3# 137 - Beer Can Appreciation Day",
+    "date": "2013-01-24",
+    "startTime": "18:00",
+    "location": "ARCADE, 130 College Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/99318222/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #136 - To Lay or Pre-Lay?",
+    "date": "2013-01-19",
+    "startTime": "14:00",
+    "location": "Charles D. Owen Park, 875 Warren Wilson Road, Swannanoa, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/99305672/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #135 - ON-2013-ON!!!",
+    "date": "2013-01-12",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/97932372/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #134 - First Day After the End of the World Hash",
+    "date": "2012-12-22",
+    "startTime": "13:00",
+    "location": "Church Parking Lot, 25 Forsythe Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/95914102/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #133 - Hairy Crispins Trail",
+    "date": "2012-12-18",
+    "startTime": "18:00",
+    "location": "Malvern Hills Pool, 75 Rumbough Pl., Asheville, NC 28806, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/94323472/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #132 - Ugly Sweater Hash",
+    "date": "2012-12-08",
+    "startTime": "14:00",
+    "location": "The Wedge, 125B Roberts Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/93481482/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #131 - Cans for Your Manna",
+    "date": "2012-12-01",
+    "startTime": "14:00",
+    "location": "Atlanta Bread Company, 633 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/85889382/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #131",
+    "date": "2012-11-17",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/91096742/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #130 - The Great Moustache Hash (benefiting Movember)!",
+    "date": "2012-11-10",
+    "startTime": "13:00",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/86202532/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #129 - Hashoween!",
+    "date": "2012-10-26",
+    "startTime": "18:30",
+    "location": "30 G W Carver Ave, Asheville, No, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/83833902/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #128 - Just F*&$in' Oslo's Birthday Hash-O-RAMA!!",
+    "date": "2012-10-21",
+    "startTime": "13:15",
+    "location": "Pink Beds / Pisgah Forest, 276 North, Brevard, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/87728592/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3's Le Tour de Hash - Downtown Finale",
+    "date": "2012-10-11",
+    "startTime": "18:00",
+    "location": "barcade, 130 College Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/83838892/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3's Le Tour de Hash - South Asheville Stage!",
+    "date": "2012-10-08",
+    "startTime": "18:00",
+    "location": "Brixx Pizza, 0 Town Square Blvd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/83895922/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3's Le Tour de Hash - East Asheville Stage!",
+    "date": "2012-10-07",
+    "startTime": "14:00",
+    "location": "Ingles Market, 29 Tunnel Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/83895372/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3's Le Tour de Hash - North Asheville Stage!",
+    "date": "2012-10-05",
+    "startTime": "18:00",
+    "location": "Charlotte Street Grill & Pub, 157 Charlotte St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/83895032/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3's Le Tour de Hash - West Asheville Stage!",
+    "date": "2012-10-04",
+    "startTime": "18:00",
+    "location": "The Asheville Public (TAP), 175 Clingman Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/83894292/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #122 - Princess' Ejaculate Conception (birthday) Hash!",
+    "date": "2012-09-29",
+    "startTime": "14:00",
+    "location": "Biltmore Park Pool, 1067 Columbine Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/83828692/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #122 - Goodbye to Summer Hash",
+    "date": "2012-09-22",
+    "startTime": "14:00",
+    "location": "Biltmore Park, 90 Schenck Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/81705872/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #120 - Weekday Trail! Weekday Trail! Excellent!",
+    "date": "2012-09-06",
+    "startTime": "18:00",
+    "location": "The Asheville Public (TAP), 175 Clingman Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/80250752/",
+    "attendees": 9
+  },
+  {
+    "title": "Spanks is Sexy and You Know it Hash",
+    "date": "2012-08-18",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/63362652/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #119: 4th Annual Bele Chere BLUE DRESS RUN!!",
+    "date": "2012-07-28",
+    "startTime": "13:30",
+    "location": "Stevens Lee Rec Center, 30 G W Carver Avenue Asheville, NC 28801, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/58254202/",
+    "attendees": 44
+  },
+  {
+    "title": "AVLH3 #:?? Let's Get Lost in Black Mountain with Helen Keller",
+    "date": "2012-07-21",
+    "startTime": "15:00",
+    "location": "Bi lo, 205 North Carolina 9, Black Mountain, NC, Black Mountain, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/72988712/",
+    "attendees": 14
+  },
+  {
+    "title": "MM Meeting",
+    "date": "2012-07-11",
+    "startTime": "18:00",
+    "location": "Thirsty Monk, 92 Patton Ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/72050842/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 - MisManagement Meeting",
+    "date": "2012-06-18",
+    "startTime": "18:00",
+    "location": "Thirsty Monk, 92 Patton Ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/69542602/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #117 - Special Hash",
+    "date": "2012-06-17",
+    "startTime": "14:00",
+    "location": "Richmond Hill Park, Richmond Hill Park Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/66217002/",
+    "attendees": 9
+  },
+  {
+    "title": "Run Beerfoot",
+    "date": "2012-05-26",
+    "startTime": "14:00",
+    "location": "Asheville Motor Speedway at Carrier Park, 500 Amboy Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/63941372/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 Trail# 115 - Triple Crown Whores Race (Part I)",
+    "date": "2012-05-19",
+    "startTime": "15:00",
+    "location": "Ingles, 1141 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/62387462/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 Mismanagement Meeting!",
+    "date": "2012-05-17",
+    "startTime": "18:00",
+    "location": "Thirsty Monk, 92 Patton Ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/63950622/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 Trail #114",
+    "date": "2012-05-12",
+    "startTime": "15:00",
+    "location": "Bent Creek Parking Lot off of Wesley Branch Road, Wesley Branch Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/62387332/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3#?? Twofer Tuesday",
+    "date": "2012-04-17",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/57976802/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 - Lucky Number 113!",
+    "date": "2012-04-14",
+    "startTime": "15:00",
+    "location": "Empty Parking Lot at corner of Shelburne and Hominy Creek, 30 shelburne road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/58092812/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #112 - Gorillaz' Easter Scrabble",
+    "date": "2012-04-07",
+    "startTime": "15:00",
+    "location": "Parking Lot behind Dealership off of Biltmore Ave, Frederick Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/53919572/",
+    "attendees": 7
+  },
+  {
+    "title": "#111: Erections & Mount Hee's going away Hash",
+    "date": "2012-03-31",
+    "startTime": "14:00",
+    "location": "Gravel parking Lot next to the Exxon., 11120 Us 23 Hwy, Mars Hill, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/56213302/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3# 110: Trapped in a Parking Dick",
+    "date": "2012-03-24",
+    "startTime": "15:30",
+    "location": "Barnes & Noble, 33 Town Square Boulevard, Suite 100, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/53919832/",
+    "attendees": 7
+  },
+  {
+    "title": "Official Travel Hash to CLT's GREEN DRESS RUN",
+    "date": "2012-03-16",
+    "startTime": "18:30",
+    "location": "Casa De Spanks & Shortbus, 101 Brevard Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/55983392/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 Trail #109, 13 Rebels Run",
+    "date": "2012-03-14",
+    "startTime": "18:15",
+    "location": "French Broad Brewery, 101 Fairview Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/52913182/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #108 Wood? Who said wood? I'll take some of that!",
+    "date": "2012-03-10",
+    "startTime": "15:00",
+    "location": "502 Emmas Grove Road, CALL EAT-A IF YOU GET LOST: 828-280-4422, Fletcher, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/53919702/",
+    "attendees": 7
+  },
+  {
+    "title": "Tricities H3 (Johnson City, TN) - Red Dress Run",
+    "date": "2012-03-03",
+    "startTime": "14:00",
+    "location": "Mellow Mushroom, 2929 N Roan Street, Johnson City, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/52656112/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #107 -The Hills have Thighs **New Date**",
+    "date": "2012-02-25",
+    "startTime": "14:00",
+    "location": "West Asheville Presbyterian, 690 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/47340652/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #106 - No Ex-Girlfriends Allowed.",
+    "date": "2012-02-18",
+    "startTime": "14:00",
+    "location": "Cum Lord's, 191 Cumberland Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/50422142/",
+    "attendees": 4
+  },
+  {
+    "title": "2012 RED DRESS RUN!!",
+    "date": "2012-02-11",
+    "startTime": "13:00",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/44110882/",
+    "attendees": 58
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-19.json
+++ b/scripts/data/avlh3-meetup-history-batch-19.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 #104 - Hump Day Hash!",
+    "date": "2012-02-08",
+    "startTime": "18:00",
+    "location": "ARCADE, 130 College Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/50880302/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 Trail #103 - Menage A Trois Hash",
+    "date": "2012-02-04",
+    "startTime": "14:00",
+    "location": "Kathryn and Emily's Place, 346 Montford Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/47501472/",
+    "attendees": 7
+  },
+  {
+    "title": "Red Dress Mismanagement Meeting",
+    "date": "2012-02-02",
+    "startTime": "18:00",
+    "location": "Thirsty Monk, 92 Patton Ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/50399332/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #102 - Charlie and Shiggy Factory",
+    "date": "2012-01-28",
+    "startTime": "15:00",
+    "location": "Bent Creek Ledford Parking area, 479E, Asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/48921502/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #101 - Tuesday! Part Deux!",
+    "date": "2012-01-24",
+    "startTime": "18:00",
+    "location": "ARCADE, 130 College Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/48927542/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #100: Our first WHITE DRESS RUN!",
+    "date": "2012-01-21",
+    "startTime": "13:00",
+    "location": "CVS / Ingles parking lot, 225 Charlotte Hwy., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/44111292/",
+    "attendees": 26
+  },
+  {
+    "title": "AVLH3 Trail #99",
+    "date": "2012-01-15",
+    "startTime": "13:30",
+    "location": "Buncombe County Sports Complex, 58 Apac Circle, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/44920872/",
+    "attendees": 11
+  },
+  {
+    "title": "#98: Not Another West Asheville Hash",
+    "date": "2012-01-11",
+    "startTime": "18:00",
+    "location": "West Asheville Presbyterian, 690 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/44913352/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #97 - Resolutions Hash",
+    "date": "2012-01-07",
+    "startTime": "15:00",
+    "location": "Harris Teeter, 1378 Hendersonville Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/44907562/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #96 - Tuesday",
+    "date": "2012-01-03",
+    "startTime": "18:00",
+    "location": "ARCADE, 130 College Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/44902512/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3#95 Festivus Hash!",
+    "date": "2011-12-23",
+    "startTime": "18:30",
+    "location": "Southern Appalchian Brewery, 822 Locust Street, Hendersonville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/38573032/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 Trail #93: The Blind and The Beautiful",
+    "date": "2011-12-10",
+    "startTime": "14:00",
+    "location": "Warren Wilson College, 701 Warren Wilson Rd, Swannanoa, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/42783562/",
+    "attendees": 8
+  },
+  {
+    "title": "Mismangement Meeting",
+    "date": "2011-12-09",
+    "startTime": "19:00",
+    "location": "Thirsty Monk, 92 Patton Ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/42906742/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #94: The Great Mustache Hash (Benefiting Movember)",
+    "date": "2011-11-19",
+    "startTime": "15:00",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/39805572/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #93 - Return of the prodigal son",
+    "date": "2011-11-05",
+    "startTime": "13:30",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/39568022/",
+    "attendees": 1
+  },
+  {
+    "title": "saturday",
+    "date": "2011-10-29",
+    "startTime": "13:30",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/38925692/",
+    "attendees": null
+  },
+  {
+    "title": "Trail #92, Humpday Hash",
+    "date": "2011-10-26",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/38639182/",
+    "attendees": 2
+  },
+  {
+    "title": "1st Anal ZOMBIE HASH!",
+    "date": "2011-10-22",
+    "startTime": "16:00",
+    "location": "Biltmore Square Mall, 800 Brevard Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/37136802/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #90",
+    "date": "2011-10-04",
+    "startTime": "18:30",
+    "location": "Moose Cafe - Asheville, 570 Brevard Rd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/33908682/",
+    "attendees": 5
+  },
+  {
+    "title": "NC/SC Planning Meeting",
+    "date": "2011-08-25",
+    "startTime": "19:00",
+    "location": "Westville Pub, 777 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/29857261/",
+    "attendees": 3
+  },
+  {
+    "title": "3rd Annual Slip-n-Slide Hash",
+    "date": "2011-08-20",
+    "startTime": "14:00",
+    "location": "R2DoMe's house, 1412 Ridgecrest Rd, Johnson City, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/29168551/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #89 -- Slacker's stroll",
+    "date": "2011-08-14",
+    "startTime": "14:00",
+    "location": "Oakley Plaza, I-240 & Fairview Ave (US 74), Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/26866161/",
+    "attendees": 3
+  },
+  {
+    "title": "TRIH3: Johnson City Hash",
+    "date": "2011-08-06",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/26866691/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3# 87 - First Full mOOn Hash (and Spanks' Birthday Hash)",
+    "date": "2011-07-15",
+    "startTime": "20:00",
+    "location": "Ingles Market, 669 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/22552811/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3# 86 - Huck Finn Goes to Summer School",
+    "date": "2011-06-18",
+    "startTime": "15:00",
+    "location": "Charles D. Owen Park, 875 Warren Wilson Road, Swannanoa, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/21232731/",
+    "attendees": 6
+  },
+  {
+    "title": "Asheville H3 Travel Hash to Upstate H3 for DTDD's Memorial Hash",
+    "date": "2011-05-14",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/17243695/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 # 84 - Get-Away-With-It-Saturday",
+    "date": "2011-04-23",
+    "startTime": "14:00",
+    "location": "The Wedge, 125B Roberts Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/17284456/",
+    "attendees": 3
+  },
+  {
+    "title": "TRIH3 Crosses and Camo Hash",
+    "date": "2011-04-16",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/16581795/",
+    "attendees": 3
+  },
+  {
+    "title": "2nd Annual TRIH3 Green Dress",
+    "date": "2011-03-19",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15942106/",
+    "attendees": 3
+  },
+  {
+    "title": "AVL H3 Trail #81 \"Super Bowl Prelube Hash\"",
+    "date": "2011-02-06",
+    "startTime": "13:00",
+    "location": "Charles Bell Elementary, 90 Maple Springs Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/16427407/",
+    "attendees": 3
+  },
+  {
+    "title": "Dr. Cranium (Head) to the End's Graduation Run!! (TriCity/AVL H3s) Trail # ??",
+    "date": "2010-12-19",
+    "startTime": "14:00",
+    "location": "Jack's Grill, 1805 North Roan Street, Johnson City, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15630074/",
+    "attendees": 5
+  },
+  {
+    "title": "AVL H3 \"Tacky Sweater Pub Crawl\" Trail #79",
+    "date": "2010-12-11",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15658991/",
+    "attendees": 7
+  },
+  {
+    "title": "RDR Beer Summit",
+    "date": "2010-12-09",
+    "startTime": "18:30",
+    "location": "Brixx Pizza, 0 Town Square Blvd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15619968/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 # 78 - Asheville Alleyways and Oddities.",
+    "date": "2010-11-27",
+    "startTime": "14:00",
+    "location": "Park Place office bldg., 70 Woodfin place, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15460946/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 # 77 - Pre pre lube",
+    "date": "2010-11-26",
+    "startTime": "19:00",
+    "location": "The Wedge, 125B Roberts Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15460955/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 # 76 - What a set of cans!",
+    "date": "2010-11-20",
+    "startTime": "14:00",
+    "location": "Ingles Weaverville, 140 Weaver Blvd, Weaverville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15253165/",
+    "attendees": 12
+  },
+  {
+    "title": "AVL H3 Trail #75 Vetaran's Hash Day Hash...? (1 PM)",
+    "date": "2010-11-13",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15397971/",
+    "attendees": 9
+  },
+  {
+    "title": "Chili Challenge Run",
+    "date": "2010-11-07",
+    "startTime": "13:00",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15079481/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #74: Tit Bit Nipply",
+    "date": "2010-11-06",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15228907/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #73 - Halloweenie Hash",
+    "date": "2010-10-29",
+    "startTime": "18:30",
+    "location": "Asheville Radiology, 534 Biltmore Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14993517/",
+    "attendees": 18
+  },
+  {
+    "title": "TRIH3 Pink Dress to support Breast Cancer cure and research.",
+    "date": "2010-10-24",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15079495/",
+    "attendees": 2
+  },
+  {
+    "title": "\"69 days 'til New Years\" Hash...AVL H3 Trail #72",
+    "date": "2010-10-23",
+    "startTime": "15:00",
+    "location": "Martin Monuments, 104 Charlotte Hwy, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14719545/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 # 71 - Hump Day Hash",
+    "date": "2010-10-20",
+    "startTime": "18:00",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15090126/",
+    "attendees": 9
+  },
+  {
+    "title": "TRIH3 That 70's Hash and Pub Crawl",
+    "date": "2010-10-16",
+    "startTime": "17:00",
+    "location": "Old Brody's Restaurant, 603 West Walnut, Johnson City, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/15079401/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail # 70: Cliffs Hanger",
+    "date": "2010-10-09",
+    "startTime": "14:00",
+    "location": "Hash Co, 172 Vista Blvd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14851282/",
+    "attendees": 4
+  },
+  {
+    "title": "AVL H3 Trail #69 Celebration of Inebriation!!",
+    "date": "2010-10-02",
+    "startTime": "14:00",
+    "location": "Camp NFN, 910 Jordan Branch Rd, Mars Hill, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14355640/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3 # 68 - Technology on Trail",
+    "date": "2010-09-25",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14627878/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 # 67 - The Boy with the Arab Strap-on",
+    "date": "2010-09-15",
+    "startTime": "18:00",
+    "location": "West Gate Shopping Center, 66 Westgate Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14717073/",
+    "attendees": 15
+  },
+  {
+    "title": "TRIH3 / AVLH3 (#66) \"Back to Basics\" hash/swim/gril",
+    "date": "2010-08-28",
+    "startTime": "15:00",
+    "location": "Erwin Fishery Park, Fishery Park Road, Erwin, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14468358/",
+    "attendees": 3
+  },
+  {
+    "title": "White Trash Float Hash (Trail #65) 2PM (not 3PM)",
+    "date": "2010-08-21",
+    "startTime": "14:00",
+    "location": "Kayak Depot, 2010 Riverside Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/13923799/",
+    "attendees": 8
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-20.json
+++ b/scripts/data/avlh3-meetup-history-batch-20.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 Trail # 64 - Magical Wonderland.",
+    "date": "2010-08-07",
+    "startTime": "14:00",
+    "location": "Fellowship Freewill Baptist Church, 184 New Haw Creek Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14177388/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 # 63 - The Princess and the Pee",
+    "date": "2010-07-31",
+    "startTime": "15:00",
+    "location": "McCormick Field, McCormick Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/14223102/",
+    "attendees": 5
+  },
+  {
+    "title": "Bele Chere Blue Dress Run (AVLH# #62)",
+    "date": "2010-07-24",
+    "startTime": "15:00",
+    "location": "Asheville Brewing Company, 77 Coxe Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/13923727/",
+    "attendees": 32
+  },
+  {
+    "title": "Midsummer Night's Hash (w/ AVL H3)",
+    "date": "2010-06-25",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/13838794/",
+    "attendees": 9
+  },
+  {
+    "title": "Wednesday, 16 June AVL H3 (likely trail #57)",
+    "date": "2010-06-16",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/13699473/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 2nd Anal Memorial Day Campout Weekend",
+    "date": "2010-05-28",
+    "startTime": "16:00",
+    "location": "Hot Springs Campground, 35.893419,-82.824301, Hot Springs, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12069867/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 Trail #56 (Dark and Wet)",
+    "date": "2010-05-15",
+    "startTime": "15:00",
+    "location": "Wedge Brewery, 151 Roberts St, Ground floor of the Wedge Gallery, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/13186415/",
+    "attendees": 12
+  },
+  {
+    "title": "Short Road trip to Ocho de Mayo w/ TRIH3",
+    "date": "2010-05-08",
+    "startTime": "14:00",
+    "location": "Teague Farm, 125 Brice Teague Rd, Unicoi, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/13219460/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 trail # 54: The Sweetness and Light Spring Run",
+    "date": "2010-05-01",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/13274499/",
+    "attendees": 5
+  },
+  {
+    "title": "AVL H3 Trail #53, April 10th, 2010 at 3PM",
+    "date": "2010-04-10",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12799837/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 Trail #51: Radioactive Erection (and elections!)",
+    "date": "2010-04-03",
+    "startTime": "14:00",
+    "location": "The Wedge, 125B Roberts Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12989225/",
+    "attendees": 9
+  },
+  {
+    "title": "***New starting location for St Patty's Trail*****",
+    "date": "2010-03-13",
+    "startTime": "14:00",
+    "location": "Poor Richards, 825 West Walnut Street, Johnson City, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12664951/",
+    "attendees": 9
+  },
+  {
+    "title": "Emergency Pick-Up Hash.....las minute",
+    "date": "2010-02-27",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12723478/",
+    "attendees": 1
+  },
+  {
+    "title": "\"Freeze Yer Hash Off\" Hash, AVL H3 Trail #49 FRIDAY at 6:30PM",
+    "date": "2010-01-29",
+    "startTime": "18:30",
+    "location": "Charlotte Street Grill & Pub, 157 Charlotte St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12421939/",
+    "attendees": 1
+  },
+  {
+    "title": "AVL H3 Trail #48 (Wednesday!!!)",
+    "date": "2010-01-27",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12421903/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 trail #47: Rocky Road (New Years special with fireworks!)",
+    "date": "2010-01-16",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12299065/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 trail #46 Battle of Bear Valley",
+    "date": "2010-01-09",
+    "startTime": "14:00",
+    "location": "Wedge Brewery, 151 Roberts St, Ground floor of the Wedge Gallery, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/12127750/",
+    "attendees": 10
+  },
+  {
+    "title": "AVL H3 #45 HASHMASH HASH!!!!!",
+    "date": "2009-12-19",
+    "startTime": "14:00",
+    "location": "West Gate Shopping Center, 66 Westgate Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11972896/",
+    "attendees": 8
+  },
+  {
+    "title": "AVL H3 #44",
+    "date": "2009-12-12",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11972889/",
+    "attendees": 5
+  },
+  {
+    "title": "AVL H3 #43",
+    "date": "2009-12-05",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11972876/",
+    "attendees": 6
+  },
+  {
+    "title": "Hashgivings Hash! AVL H3 Trail #42 at 2PM",
+    "date": "2009-11-28",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11931338/",
+    "attendees": 3
+  },
+  {
+    "title": "The Hasher in the Rye (AVLH3 # 41)",
+    "date": "2009-11-21",
+    "startTime": "14:00",
+    "location": "East Asheville Home Depot, 795 Fairview rd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11803131/",
+    "attendees": 4
+  },
+  {
+    "title": "Halloweenie Hash!! The AVL H3's 40th trail (please RSVP)",
+    "date": "2009-10-30",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11606877/",
+    "attendees": 19
+  },
+  {
+    "title": "R2's Half Centry Black Tie Hash and Bash",
+    "date": "2009-10-17",
+    "startTime": "15:00",
+    "location": "Walmart Paring lot, 437 Swannanoa River Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11151856/",
+    "attendees": 13
+  },
+  {
+    "title": "Oktoberfest Lube & Trail",
+    "date": "2009-10-10",
+    "startTime": "13:00",
+    "location": "Downtown Oktoberfest, Wall Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10341930/",
+    "attendees": 5
+  },
+  {
+    "title": "AVL H3 Trail #38 on Saturday, 3 Oct",
+    "date": "2009-10-03",
+    "startTime": "15:00",
+    "location": "Carson Creek Apartments, 1680 Hendersonville Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11327625/",
+    "attendees": 5
+  },
+  {
+    "title": "AVL H3 Trail #37",
+    "date": "2009-09-26",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11453191/",
+    "attendees": 5
+  },
+  {
+    "title": "Hobo Hash!!!",
+    "date": "2009-09-04",
+    "startTime": "19:00",
+    "location": "Camp Hobo, 158 Old Marshall Hwy, French Broad, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11070151/",
+    "attendees": 9
+  },
+  {
+    "title": "AVL H3 #35 Rumble in the Jungle",
+    "date": "2009-08-29",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11163322/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #34--Operation Dragon",
+    "date": "2009-08-15",
+    "startTime": "13:00",
+    "location": "Grainger Parking Lot, 834 Riverside Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11082081/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #33",
+    "date": "2009-08-12",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11038637/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #32 , The Michael Jordan of Trails",
+    "date": "2009-08-08",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/11031556/",
+    "attendees": 1
+  },
+  {
+    "title": "1 Aug 2009 AVL H3",
+    "date": "2009-08-01",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10825616/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 Weekday Dirty Thirty Trail",
+    "date": "2009-07-29",
+    "startTime": "18:00",
+    "location": "West Gate Shopping Center, 66 Westgate Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10964504/",
+    "attendees": 4
+  },
+  {
+    "title": "Road Hash in Tennessee",
+    "date": "2009-07-11",
+    "startTime": "15:00",
+    "location": "BP Station, 3211 S Roan St, Johnson City, TN, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10733981/",
+    "attendees": 4
+  },
+  {
+    "title": "Tubing In The Shenandoah, T.I.T.S.",
+    "date": "2009-07-02",
+    "startTime": "18:00",
+    "location": "Country Place Camp, 100 Fort Liscomb Road, Luray, VA, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10774937/",
+    "attendees": null
+  },
+  {
+    "title": "Week Day Hash [FINALLY!]",
+    "date": "2009-06-30",
+    "startTime": "18:00",
+    "location": "Food Lion Skate Park, 3 Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10730693/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 Trail #27; South Side",
+    "date": "2009-06-27",
+    "startTime": "15:00",
+    "location": "REI Rear Lot, 31 Schenck Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10712252/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 Trail #26 ---///--->",
+    "date": "2009-06-20",
+    "startTime": "15:00",
+    "location": "UNCA Admissions BLDG, 1 University Hts, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10680145/",
+    "attendees": 2
+  },
+  {
+    "title": "AVL H3 Trail #25",
+    "date": "2009-06-13",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10607543/",
+    "attendees": 1
+  },
+  {
+    "title": "NC/SC Interhash",
+    "date": "2009-06-12",
+    "startTime": "16:00",
+    "location": "Interhash, 6148 Lisbon Rd, Mountville, SC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/9745060/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 Trail #24",
+    "date": "2009-06-06",
+    "startTime": "15:00",
+    "location": "Ingles Market, 669 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10367652/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 Trail #23 \"Home Brew Hash\"",
+    "date": "2009-05-30",
+    "startTime": "15:00",
+    "location": "Empty Lot, Near Blockbuster, Hendersonville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10334740/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 Memorial Day Campout Weekend! (Fri-Sun) UPDATE",
+    "date": "2009-05-22",
+    "startTime": "15:00",
+    "location": "Nolichucky Gorge Campground, Jones Branch Road, Erwin, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/9745056/",
+    "attendees": 15
+  },
+  {
+    "title": "Dos de Mayo Trail [May 2]",
+    "date": "2009-05-02",
+    "startTime": "16:00",
+    "location": "Shell Station, 112 Monticello, Weaverville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10273820/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 Trail #19 ---///--->",
+    "date": "2009-04-25",
+    "startTime": "15:00",
+    "location": "Richmond Hill Park (not the inn!) parking lot, by the kiosk, NC-1345/Richmond Hill Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10220457/",
+    "attendees": 3
+  },
+  {
+    "title": "Asheville H3 Trail #18, Saturday Apr 18 at 3pm",
+    "date": "2009-04-18",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10168867/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 Trail #18 ---///---> (TODAY)",
+    "date": "2009-04-11",
+    "startTime": "15:00",
+    "location": "Rice Pinnacle Lot, Bent Creek, 2 miles up, Wesley Branch Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/10163098/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 Trail #16",
+    "date": "2009-03-22",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/9869392/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 Trail #15 ---///---> Beware The Ides Of March!!!",
+    "date": "2009-03-14",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/9744770/",
+    "attendees": 11
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-21.json
+++ b/scripts/data/avlh3-meetup-history-batch-21.json
@@ -1,0 +1,50 @@
+[
+  {
+    "title": "Asheville H3 Trail #14",
+    "date": "2009-03-07",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/9844841/",
+    "attendees": 10
+  },
+  {
+    "title": "2009 Asheville H3 Red Dress Run",
+    "date": "2009-02-07",
+    "startTime": "14:00",
+    "location": "Ed Boudreaux's, 48 Biltmore Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/9621732/",
+    "attendees": 25
+  },
+  {
+    "title": "Asheville H3 Trail #11",
+    "date": "2009-01-10",
+    "startTime": "15:00",
+    "location": "East Village Grille, 1177 Tunnel Rd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/9420337/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 Trail #9, Pearl Necklace Harbour",
+    "date": "2008-12-07",
+    "startTime": "15:30",
+    "location": "Mac-D's, 35 Hendersonville Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/9212238/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 hash run",
+    "date": "2008-09-20",
+    "startTime": "18:00",
+    "location": "Ingles, 1141 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/8761599/",
+    "attendees": 6
+  },
+  {
+    "title": "Road Hash",
+    "date": "2008-09-13",
+    "startTime": "17:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/8713328/",
+    "attendees": 7
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-5.json
+++ b/scripts/data/avlh3-meetup-history-batch-5.json
@@ -1,0 +1,474 @@
+[
+  {
+    "title": "AVLH3 #653 - Cum and get Shanghai'ed!!",
+    "date": "2021-06-26",
+    "startTime": "14:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278180835/",
+    "attendees": 30
+  },
+  {
+    "title": "AVLH3 #654 - 'MURICA!",
+    "date": "2021-07-03",
+    "startTime": "13:30",
+    "location": "105 blue mountain road, 105 Blue Mountain road, Fairview, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278341673/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #655 - Trinity & Titties",
+    "date": "2021-07-11",
+    "startTime": "14:00",
+    "location": "AB Tech, Enka branch, 1459 Sand Hill Rd, Candler, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278826396/",
+    "attendees": 33
+  },
+  {
+    "title": "AVLH3 #656 - OLYMPDICKS",
+    "date": "2021-07-17",
+    "startTime": "14:00",
+    "location": "Just Kate’s House, 539 Caribou Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278937951/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #657 - National Tequila Day, hurrah!!",
+    "date": "2021-07-24",
+    "startTime": "14:00",
+    "location": "Veterans Park, 10 Veterans Park Dr, Black Mountain, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278180854/",
+    "attendees": 12
+  },
+  {
+    "title": "Moonshine H3 #78 - Buck It. (Moon)",
+    "date": "2021-07-25",
+    "startTime": "20:30",
+    "location": "749 Fairview Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/279597162/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #658 - Le Tour de Hash - Stage 1",
+    "date": "2021-07-31",
+    "startTime": "14:00",
+    "location": "Dr. Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/279797047/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #659 - Le Tour de Hash - Stage 2",
+    "date": "2021-08-03",
+    "startTime": "18:00",
+    "location": "Walgreens, 841 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/279797056/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #660 - Le Tour de Hash - Stage 3",
+    "date": "2021-08-04",
+    "startTime": "18:00",
+    "location": "Parking lot next to Subway, 766 Biltmore Ave, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/279797070/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #661 - Le Tour de Hash - Stage 4",
+    "date": "2021-08-08",
+    "startTime": "14:00",
+    "location": "105 Arco Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/279797075/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #662 - Impromptu Crawl, Y'all!",
+    "date": "2021-08-14",
+    "startTime": "14:00",
+    "location": "Hi-Wire Brewing - South Slope, 197 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280008311/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #663 - VCR 13.brew and 10kan",
+    "date": "2021-08-21",
+    "startTime": "13:00",
+    "location": "Jackson Park, 810 Glover St, Hendersonville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280008322/",
+    "attendees": 5
+  },
+  {
+    "title": "Moonshine H3 #79 - Red Moon",
+    "date": "2021-08-27",
+    "startTime": "19:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280226420/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #664 - An Ice Cream Social with Cherry Pie and Cum on Moses",
+    "date": "2021-08-28",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280008330/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #665 - VCR's chase the case",
+    "date": "2021-09-04",
+    "startTime": "14:00",
+    "location": "Martin Luther King Park, 50 Martin Luther King Jr Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280008335/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #666 - 13th Annual Blue Dress Run!",
+    "date": "2021-09-11",
+    "startTime": "13:00",
+    "location": "96 Cherry St N, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/279658281/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #667 - Hash Like a Pirate!",
+    "date": "2021-09-18",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280662908/",
+    "attendees": 6
+  },
+  {
+    "title": "Moonshine H3 #80 - Harvest Moon",
+    "date": "2021-09-22",
+    "startTime": "18:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280663160/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #668 - Dead? Who said dead?!",
+    "date": "2021-09-25",
+    "startTime": "14:00",
+    "location": "Weaver Park, 200 Murdock Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280662931/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #669 - 2nd Anal BEER MILE!",
+    "date": "2021-10-02",
+    "startTime": "12:00",
+    "location": "Hesta fiesta, 537 Appeldoorn Cir, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280662951/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #670 - Needs a hare!",
+    "date": "2021-10-09",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280662972/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #670 - An Asheville-lutely Gourd-eous Hash!",
+    "date": "2021-10-16",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280662984/",
+    "attendees": 25
+  },
+  {
+    "title": "Moonshine H3 #81 - Blood Moon",
+    "date": "2021-10-21",
+    "startTime": "18:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280663185/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #671 - A Furious and Pornographic Hash",
+    "date": "2021-10-23",
+    "startTime": "14:00",
+    "location": "323 Depot St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280663299/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #672 - ☠️🎃HASHOWEEN🎃☠️",
+    "date": "2021-10-30",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/280872896/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #673 - Panic & No Homo",
+    "date": "2021-11-06",
+    "startTime": "14:00",
+    "location": "Sierra Nevada Brewery, 111 Westfeldt Rd, Mills River, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/281209289/",
+    "attendees": 11
+  },
+  {
+    "title": "--|||--> UHHH RDR",
+    "date": "2021-11-13",
+    "startTime": "13:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/281209304/",
+    "attendees": 2
+  },
+  {
+    "title": "Moonshine H3 #82 - Frosty Moon",
+    "date": "2021-11-19",
+    "startTime": "17:00",
+    "location": "Haw Creek Park, 38 Avon Rd, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/281209361/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #674 - 11th Annual MANNA Foodbank Hash",
+    "date": "2021-11-20",
+    "startTime": "14:00",
+    "location": "Wild Wing Cafe, 65 Long Shoals Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/281209312/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #675 - Trot off Your Turkey/NAMING TRAIL - NFHN BONNIE",
+    "date": "2021-11-27",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/281209319/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3 #676 - Ugly Sweater!",
+    "date": "2021-12-04",
+    "startTime": "14:00",
+    "location": "West Asheville Park - Gassaway Field, 198 Vermont Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/281940996/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #677 - The White Dress Run of National & NFN Susan!",
+    "date": "2021-12-12",
+    "startTime": "13:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/281941005/",
+    "attendees": 36
+  },
+  {
+    "title": "Moonshine H3 #83 - Cold Moon & Annual Onesie/Solstice Trail!",
+    "date": "2021-12-21",
+    "startTime": "18:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/281941018/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #678 - **covid caught us*** CANCELLED Annual Formal!",
+    "date": "2022-01-01",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/282428649/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #678 - Breaking out of quarantine.",
+    "date": "2022-01-08",
+    "startTime": "14:00",
+    "location": "19 Russell St. Asheville, 19 Russell St., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/282428699/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #679 snow dance",
+    "date": "2022-01-15",
+    "startTime": "14:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/282428716/",
+    "attendees": 7
+  },
+  {
+    "title": "Moonshine H3 #84 - Wolf Moon/Betty’s Belated Birthday",
+    "date": "2022-01-18",
+    "startTime": "18:00",
+    "location": "Titties House, 20 Dorchester Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/282428679/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #680 - Cougar and Stonz",
+    "date": "2022-01-22",
+    "startTime": "14:00",
+    "location": "101 Patton Mountain Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/282428734/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #682 - Just Larry’s Naming Trail",
+    "date": "2022-02-05",
+    "startTime": "13:00",
+    "location": "Start, 63 Zillicoa Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/283030858/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #683 - Goat hash",
+    "date": "2022-02-12",
+    "startTime": "14:00",
+    "location": "the goat house, 76 Overlook Dr., Leicester, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/283030862/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #684 - 🍒 🥧 National Cherry Pie Day! 🍒 🥧",
+    "date": "2022-02-19",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/283606983/",
+    "attendees": 9
+  },
+  {
+    "title": "Moonshine H3 #85 - Snow Moon - 2/22/22 tu tutu tutuuuuu",
+    "date": "2022-02-22",
+    "startTime": "18:30",
+    "location": "Titties House, 20 Dorchester Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/282056092/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #685 - Mardi Gras Hash!",
+    "date": "2022-02-27",
+    "startTime": "12:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/282819448/",
+    "attendees": 30
+  },
+  {
+    "title": "AVLH3 #??? - Needs a hare!",
+    "date": "2022-03-05",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/283628486/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #686 - Titties",
+    "date": "2022-03-10",
+    "startTime": "18:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/283119455/",
+    "attendees": 10
+  },
+  {
+    "title": "Moonshine H3 #86 - Crow Moon/St Paddy’s observed",
+    "date": "2022-03-18",
+    "startTime": "19:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/283628514/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #??? - Needs a hare!",
+    "date": "2022-03-26",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/283628493/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #687 - Family & Lefty",
+    "date": "2022-04-02",
+    "startTime": "14:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/284380648/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #688 -",
+    "date": "2022-04-10",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/284380657/",
+    "attendees": 31
+  },
+  {
+    "title": "AVLH3 #689/ Moonshine H3 #87 - Pink Moon Periods are forever",
+    "date": "2022-04-16",
+    "startTime": "19:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/284380163/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #690 - National Slay a Dragon Day!",
+    "date": "2022-04-23",
+    "startTime": "14:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/284380662/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #691 - MYSTERY HARE TRAIL",
+    "date": "2022-04-29",
+    "startTime": "19:00",
+    "location": "Food Lion Skate Park, 3 Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/284380672/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #692 - It’s a mother f*in’ Mother’s Day Trail!!",
+    "date": "2022-05-08",
+    "startTime": "14:00",
+    "location": "Ichiban Japanese Restaurant, 2 Hendersonville Road # East, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/285058382/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #693/Moonshine H3 #88 - Flower Power/Just Whitney Naming Trail",
+    "date": "2022-05-14",
+    "startTime": "16:00",
+    "location": "65 Gashes Creek Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/285058292/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #694 - Towel Day Hash",
+    "date": "2022-05-21",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/285058430/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #695 - Spaghetti & Bible Belt",
+    "date": "2022-05-28",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/285058477/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #696 - Spaghetti",
+    "date": "2022-06-04",
+    "startTime": "18:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/285636269/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #697 - WHAT THE FLOAT, AVL?!",
+    "date": "2022-06-11",
+    "startTime": "11:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/285636369/",
+    "attendees": 33
+  },
+  {
+    "title": "Moonshine H3 #88 - Strawberry Moon",
+    "date": "2022-06-14",
+    "startTime": "20:30",
+    "location": "Weaver Park, 200 Murdock Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/285636363/",
+    "attendees": 13
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-6.json
+++ b/scripts/data/avlh3-meetup-history-batch-6.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Moonshine H3 #77 - Strawberry Moon",
+    "date": "2021-06-25",
+    "startTime": "20:30",
+    "location": "Weaver Park, 200 Murdock Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/279019805/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #652 - Return of the Fournicorn!",
+    "date": "2021-06-19",
+    "startTime": "13:30",
+    "location": "Papas and Beer, 17 Tunnel Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278547645/",
+    "attendees": 14
+  },
+  {
+    "title": "#651 Bar Crawl!! We've been baptized in beer and we're here to testify!",
+    "date": "2021-06-12",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278547612/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #650 - 26 & Zorro save the day!",
+    "date": "2021-06-05",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278547591/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #649 - VCR & Kotex",
+    "date": "2021-05-29",
+    "startTime": "14:00",
+    "location": "8 Beverly Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278180898/",
+    "attendees": 16
+  },
+  {
+    "title": "Moonshine H3 #76 - Flour Moon",
+    "date": "2021-05-26",
+    "startTime": "20:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277958116/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #648 - If you lay it, they will cum",
+    "date": "2021-05-22",
+    "startTime": "14:00",
+    "location": "Hare’s House, 105 Arco Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/278180875/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #647 - Kotex Kessel Run like it’s 1999",
+    "date": "2021-05-15",
+    "startTime": "14:00",
+    "location": "Here, 39 Garfield St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277754911/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #646 - NFN Hilary's first haring!",
+    "date": "2021-05-08",
+    "startTime": "14:00",
+    "location": "2578 Riceville Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277754939/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #645 - May the thirst, I mean first trail",
+    "date": "2021-05-01",
+    "startTime": "14:00",
+    "location": "Buffalo Wild Wings, 4 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277754935/",
+    "attendees": 10
+  },
+  {
+    "title": "Moonshine H3 #75 - Pink Moon",
+    "date": "2021-04-26",
+    "startTime": "19:00",
+    "location": "Fuddruckers, 130 Charlotte Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277754967/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #644 - Spring-a Dingaling",
+    "date": "2021-04-25",
+    "startTime": "14:00",
+    "location": "Grove Park- Sunset, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277694585/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #643 - blah blah blah",
+    "date": "2021-04-17",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277608694/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #642 - 13th Annual Red Dress Run!",
+    "date": "2021-04-10",
+    "startTime": "13:00",
+    "location": "1314 Parkwood Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276911504/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #641 - BK Invasion - Better Beer Hash",
+    "date": "2021-04-03",
+    "startTime": "14:00",
+    "location": "Mile High Moses’ Yard, 81 Mt Claire ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277282456/",
+    "attendees": 14
+  },
+  {
+    "title": "Moonshine H3 #74 - Crow Moon",
+    "date": "2021-03-30",
+    "startTime": "17:00",
+    "location": "Cherry Street North, Cherry St N, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277247481/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #640 - It's Spring-a-ling, ya ding-a-ling!",
+    "date": "2021-03-28",
+    "startTime": "14:00",
+    "location": "801 Fairview Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/277086142/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #639 - Green Dress Run ST PATRICK'S DAY!!",
+    "date": "2021-03-20",
+    "startTime": "14:00",
+    "location": "Ingles Markets, 225 Charlotte Hwy, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276655210/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #638 - Family, Lefty, NFN Jeff",
+    "date": "2021-03-13",
+    "startTime": "14:00",
+    "location": "Blue Ridge Parkway Folk Art Center, Milepost 382 Blue Ridge Parkway, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276655026/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #637 - Quickie",
+    "date": "2021-03-07",
+    "startTime": "12:00",
+    "location": "Top of John B. Lewis Park, 520 Azalea Road East, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276605976/",
+    "attendees": 3
+  },
+  {
+    "title": "Upstate H3 Vacunt Memorial Hash",
+    "date": "2021-03-06",
+    "startTime": "12:00",
+    "location": "Greer, SC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276605911/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #636 - IN THE STICKS",
+    "date": "2021-03-04",
+    "startTime": "18:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276643947/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #635 - Moonshine H3 Invasion!",
+    "date": "2021-02-27",
+    "startTime": "16:30",
+    "location": "Weaver Park, 200 Murdock Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276501539/",
+    "attendees": 20
+  },
+  {
+    "title": "Moonshine H3 #73 - Snow Moon",
+    "date": "2021-02-27",
+    "startTime": "16:30",
+    "location": "Weaver Park, 200 Murdock Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276147696/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #634 - AVLH3's Lucky #13 Analversary (observed)!",
+    "date": "2021-02-20",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276147646/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #633 - Spaghetti’s Soggy VD trail",
+    "date": "2021-02-14",
+    "startTime": "14:30",
+    "location": "795 Fairview Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276147624/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #632 - National & Flipper Super Saturday(UPDATED) Hash",
+    "date": "2021-02-06",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276147600/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #631 - A Shitty Zorro Trail",
+    "date": "2021-01-30",
+    "startTime": "14:00",
+    "location": "162 Craven St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/276054222/",
+    "attendees": 11
+  },
+  {
+    "title": "Moonshine H3 #72 - Wolf Moon",
+    "date": "2021-01-28",
+    "startTime": "18:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/275682814/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #630 - If you can't see or hear a trail, can it still be sh*tty?",
+    "date": "2021-01-23",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/274924094/",
+    "attendees": 23
+  },
+  {
+    "title": "AVLH3 #629 - Annual Formal -- Wreck the Dress Edition",
+    "date": "2021-01-16",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/275411439/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #628 - 6*Pi",
+    "date": "2021-01-10",
+    "startTime": "14:00",
+    "location": "Haw Creek Park, 40 Avon Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/275411431/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #627 - Backdoors, Alleys, Kitchens and Dumpsters revisited",
+    "date": "2021-01-02",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/275411410/",
+    "attendees": 16
+  },
+  {
+    "title": "Moonshine H3 #71 - Cold Moon",
+    "date": "2020-12-30",
+    "startTime": "18:30",
+    "location": "The Scarlet Bee, 853 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/275411361/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #626 - Silver Balls",
+    "date": "2020-12-27",
+    "startTime": "14:00",
+    "location": "Azalea Roadside, 402 Azalea Road East, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/274948308/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #625 - 26 And Zorro's 6th Anal Solstice Onesie Trail",
+    "date": "2020-12-20",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273705093/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #624 - Ugly Sweater Hash! 12/12!",
+    "date": "2020-12-12",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/274942998/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #623 - The Caroling Choir Practice Hash!!",
+    "date": "2020-12-06",
+    "startTime": "11:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/274942952/",
+    "attendees": 5
+  },
+  {
+    "title": "Moonshine H3 #70 - Beaver Moon",
+    "date": "2020-11-30",
+    "startTime": "18:30",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/274374680/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #622 - Lefty & Family",
+    "date": "2020-11-28",
+    "startTime": "14:00",
+    "location": "Up Country Brewing Co., 1042 Haywood Rd, 28806, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/274491371/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #621 - ⭐️TURBOTASTIC TUTU TRAIL⭐️",
+    "date": "2020-11-21",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273705059/",
+    "attendees": 24
+  },
+  {
+    "title": "AVLH3 #620 - 10th Annual MANNA Foodbank Hash",
+    "date": "2020-11-14",
+    "startTime": "14:00",
+    "location": "Wild Wing Cafe, 65 Long Shoals Rd, Arden, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273706202/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #619 - Family-Friendly Scavenger Hunt + Games + Awesome Funday Trail!",
+    "date": "2020-11-07",
+    "startTime": "14:00",
+    "location": "105 Arco Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/274374462/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #618 - Hashoween!",
+    "date": "2020-10-31",
+    "startTime": "16:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273349103/",
+    "attendees": 28
+  },
+  {
+    "title": "Moonshine H3 #69 - BLUE MOON Zombie Trail",
+    "date": "2020-10-30",
+    "startTime": "20:00",
+    "location": "Buffalo Wild Wings, 4 Tunnel Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273704981/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #617 - Princess's 200th Hare!!",
+    "date": "2020-10-24",
+    "startTime": "13:30",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273704341/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #616 - Let’s try this again... DEAD TRAIL!",
+    "date": "2020-10-18",
+    "startTime": "12:00",
+    "location": "Creekside Taphouse, 8 Beverly road , asheville, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/274018180/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #616 - Dead trail TBD",
+    "date": "2020-10-17",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273704290/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #615 - Ten Things I Like About Brews",
+    "date": "2020-10-10",
+    "startTime": "14:00",
+    "location": "Hesta fiesta, 537 Appeldoorn Cir, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273704254/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #614 - 1st Annual Beer Mile",
+    "date": "2020-10-03",
+    "startTime": "16:00",
+    "location": "Hesta fiesta, 537 Appeldoorn Cir, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273646131/",
+    "attendees": 17
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-7.json
+++ b/scripts/data/avlh3-meetup-history-batch-7.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Moonshine H3 #68 - Blood Moon",
+    "date": "2020-10-01",
+    "startTime": "19:00",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273591944/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #613 -- The Labyrinth",
+    "date": "2020-09-27",
+    "startTime": "14:00",
+    "location": "Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/273438416/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #612 - Like a Duck on a June Bug",
+    "date": "2020-09-19",
+    "startTime": "14:00",
+    "location": "Ledford Branch Trailhead, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272838133/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #611 - Trail",
+    "date": "2020-09-12",
+    "startTime": "14:00",
+    "location": "West Asheville Parks and Recreation Pavilion, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272838069/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #610 - Cum Pi's 69th Hare",
+    "date": "2020-09-05",
+    "startTime": "14:00",
+    "location": "Haw Creek Park, 38 Avon Rd, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272838051/",
+    "attendees": 16
+  },
+  {
+    "title": "Moonshine H3 #67 - Harvest Moon",
+    "date": "2020-09-02",
+    "startTime": "12:00",
+    "location": "Weaver Park, 200 Murdock Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272753670/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #609 - Saturday trail",
+    "date": "2020-08-29",
+    "startTime": "14:00",
+    "location": "Upcountry Brewing Company, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272753656/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #608-B - 12th Annual Blue Dress Run!",
+    "date": "2020-08-22",
+    "startTime": "14:00",
+    "location": "Martin Luther King Jr Park, 50 Martin Luther King Jr Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272633725/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #608-A - 12th Annual Blue Dress Run!",
+    "date": "2020-08-22",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272633709/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #607 - Holly Gee Willikers",
+    "date": "2020-08-15",
+    "startTime": "14:00",
+    "location": "Papa's & Beer Mexican Restaurant, 1000 Brevard Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272549057/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #606 - NoAss Trail",
+    "date": "2020-08-08",
+    "startTime": "14:00",
+    "location": "99 Gracelyn Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272344020/",
+    "attendees": 16
+  },
+  {
+    "title": "MH3 #66 - Red Moon",
+    "date": "2020-08-04",
+    "startTime": "12:00",
+    "location": "Martin Luther King Jr Park, 50 Martin Luther King Jr Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272328407/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #605 - A snowballs chance in August",
+    "date": "2020-08-01",
+    "startTime": "14:00",
+    "location": "UpCountry Brewing Company, 1042 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272218609/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #604 - Backdoors, Kitchens and Dumpsters",
+    "date": "2020-07-25",
+    "startTime": "12:00",
+    "location": "1030 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/272059667/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #603 - Dead Bride Trail",
+    "date": "2020-07-18",
+    "startTime": "12:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271909205/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #602 - Deja Poo",
+    "date": "2020-07-11",
+    "startTime": "14:00",
+    "location": "Parking lot next to Subway, 766 Biltmore Ave, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271840420/",
+    "attendees": 3
+  },
+  {
+    "title": "Moonshine H3 #65 - Buck Moon.",
+    "date": "2020-07-05",
+    "startTime": "21:00",
+    "location": "·",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271602457/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #601 - 'Murica!",
+    "date": "2020-07-04",
+    "startTime": "14:00",
+    "location": "Parking lot next to Subway, 766 Biltmore Ave, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271602353/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #600 - The Hot & Wet Hash!",
+    "date": "2020-06-27",
+    "startTime": "13:00",
+    "location": "Mills River Park, 124 Town Center Dr, Mills River, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271142185/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #599 - Schlongest Day of the Year",
+    "date": "2020-06-20",
+    "startTime": "14:00",
+    "location": "Church In Motion!, 930 Swannanoa River Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271142178/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #598 - The Sky is the Limit!",
+    "date": "2020-06-13",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271142172/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #597 - confirmed",
+    "date": "2020-06-06",
+    "startTime": "14:00",
+    "location": "Parking lot behind Dr. Daves Automotive., 1022 Haywood Rd, Asheville, NC 28806, ASHEVILLE, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271081436/",
+    "attendees": 9
+  },
+  {
+    "title": "Moonshine H3 #64 - Strawberry Moon",
+    "date": "2020-06-05",
+    "startTime": "12:00",
+    "location": "Fuddruckers, 130 Charlotte St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/271081279/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #596 - Schooooool's out..for..summer!",
+    "date": "2020-05-30",
+    "startTime": "12:00",
+    "location": "State Employees’ Credit Union, 701 Broadway St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/270944006/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #595 - HARES Act",
+    "date": "2020-05-23",
+    "startTime": "12:00",
+    "location": "Ichiban, 2 Hendersonville Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/270778782/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #594 - Tongue Punch My Fart Box, Social-Distantly",
+    "date": "2020-05-16",
+    "startTime": "12:00",
+    "location": "Asheville Pizza and Brewing Co, 675 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/270661232/",
+    "attendees": 6
+  },
+  {
+    "title": "Moonshine H3 #63 - Flour Moon (virtual)",
+    "date": "2020-05-07",
+    "startTime": "21:00",
+    "location": "·",
+    "url": "https://www.meetup.com/avlh3-on-on/events/270432497/",
+    "attendees": 4
+  },
+  {
+    "title": "Virtually AVLH3 #3 - Most Hash-tacular Scavenger Hunt Competition That Ever Was!",
+    "date": "2020-05-02",
+    "startTime": "20:30",
+    "location": "·",
+    "url": "https://www.meetup.com/avlh3-on-on/events/270286082/",
+    "attendees": 13
+  },
+  {
+    "title": "Virtually AVLH3 #2 - Beer Yoga",
+    "date": "2020-04-25",
+    "startTime": "19:30",
+    "location": "·",
+    "url": "https://www.meetup.com/avlh3-on-on/events/270187925/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #5?? - The White Dress Run of Dick and Rebound!",
+    "date": "2020-04-25",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265403951/",
+    "attendees": 14
+  },
+  {
+    "title": "Virtually AVLH3 #1 - Lip Sync and Karaoke your Covid Off",
+    "date": "2020-04-18",
+    "startTime": "19:00",
+    "location": "·",
+    "url": "https://www.meetup.com/avlh3-on-on/events/270000479/",
+    "attendees": 12
+  },
+  {
+    "title": "Moonshine H3 #62 - Pink Moon (virtual)",
+    "date": "2020-04-08",
+    "startTime": "21:00",
+    "location": "·",
+    "url": "https://www.meetup.com/avlh3-on-on/events/269902404/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 Drinking Practice",
+    "date": "2020-03-19",
+    "startTime": "19:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267906108/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 trails on hold for 2 weeks",
+    "date": "2020-03-17",
+    "startTime": "10:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/269478902/",
+    "attendees": 2
+  },
+  {
+    "title": "AVLH3 #593 - ** Update** St. Paddy's Hash!",
+    "date": "2020-03-14",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026781/",
+    "attendees": 25
+  },
+  {
+    "title": "Moonshine H3 #61 - Crow Moon",
+    "date": "2020-03-09",
+    "startTime": "19:30",
+    "location": "Hummingbird Park, Cumberland Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026849/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #592 - BVC (Biltmore Village Crawl)",
+    "date": "2020-03-07",
+    "startTime": "14:00",
+    "location": "El Chapala Mexican Restaurant, 777 Biltmore Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026714/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #591 - Leap year trail!",
+    "date": "2020-02-29",
+    "startTime": "14:00",
+    "location": "Lake Louis, 192 lake shore dr, Weaverville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026616/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #590 - Trinity & Ladyland hare a trail!",
+    "date": "2020-02-24",
+    "startTime": "18:30",
+    "location": "French Broad River Park, 508 Riverview Dr., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268846824/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #589 - RDR Sunday Hangover Trail/AVLH3's 12th Analversary!",
+    "date": "2020-02-23",
+    "startTime": "10:00",
+    "location": "West Asheville Park - Gassaway Field, 198 Vermont Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267512023/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 #588 - AVLH3's 12th Annual Red Dress Run!",
+    "date": "2020-02-22",
+    "startTime": "13:00",
+    "location": "Off The Wagon Dueling Piano Bar Asheville, 22 North Market Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/266881199/",
+    "attendees": 40
+  },
+  {
+    "title": "AVLH3 #587 - Friday night pre-RDR trail!",
+    "date": "2020-02-21",
+    "startTime": "18:30",
+    "location": "Depot Street Parking Lot, 404 Depot St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267511994/",
+    "attendees": 36
+  },
+  {
+    "title": "AVLH3 Red Dress Pre-Lube!!!",
+    "date": "2020-02-20",
+    "startTime": "19:30",
+    "location": "Fairview Tavern, 831 Old Fairview Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267906106/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #586 - Spaghetti with a Chance of Sh*tty Trail",
+    "date": "2020-02-15",
+    "startTime": "14:00",
+    "location": "Weaver Park, 200 Murdock Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026457/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #585 - Brownie hares a magical unicorn rainbow trail",
+    "date": "2020-02-09",
+    "startTime": "14:00",
+    "location": "Neo Burrito, 4 S tunnel rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026448/",
+    "attendees": 9
+  },
+  {
+    "title": "Moonshine H3 #60 - Snow Moon",
+    "date": "2020-02-06",
+    "startTime": "18:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026811/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #584 - Groundhog Day 2020",
+    "date": "2020-02-02",
+    "startTime": "14:00",
+    "location": "Parking lot behind Dr. Daves Automotive., 1022 Haywood Rd, Asheville, NC 28806, ASHEVILLE, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026435/",
+    "attendees": 21
+  },
+  {
+    "title": "AVLH3 #583 - Brrrrrrrr...",
+    "date": "2020-01-26",
+    "startTime": "14:00",
+    "location": "105 Arco Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/268026424/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #582 - NFHN Tee",
+    "date": "2020-01-18",
+    "startTime": "14:00",
+    "location": "Murphy-Oakley Park, 715 Fairview Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267499721/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 Drinking Practice and Sing-A-Long",
+    "date": "2020-01-16",
+    "startTime": "19:30",
+    "location": "AMF Bowling, 491 Kenilworth Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267906083/",
+    "attendees": 3
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-8.json
+++ b/scripts/data/avlh3-meetup-history-batch-8.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 #581 - Pitter Patter NFHN Dustin Gets Ater!",
+    "date": "2020-01-11",
+    "startTime": "14:00",
+    "location": "167 Craven St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267473362/",
+    "attendees": 13
+  },
+  {
+    "title": "Moonshine H3 #59 - Wolf Moon",
+    "date": "2020-01-10",
+    "startTime": "18:30",
+    "location": "Applebee's, 1655 Hendersonville Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267511950/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3's Polar Plunge",
+    "date": "2020-01-04",
+    "startTime": "09:00",
+    "location": "Riverside Tiki Bar & Grill, 3147 Memorial Highway, Lake Lure, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267510774/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #580 - Annual AVLH3 Formal",
+    "date": "2020-01-04",
+    "startTime": "18:00",
+    "location": "DSSOLVR, 63 N Lexington Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267271546/",
+    "attendees": 29
+  },
+  {
+    "title": "AVLH3 #579 - RU Ready?...sǝɯoɔʎɐʍsᴉɥʇunɟƃuᴉɥʇǝɯos",
+    "date": "2019-12-28",
+    "startTime": "14:00",
+    "location": "Martin Luther King Jr Park, 50 Martin Luther King Junior Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265476427/",
+    "attendees": 30
+  },
+  {
+    "title": "AVLH3 #578 - 26 And Zorro's 5th Anal Solstice Onesie Trail",
+    "date": "2019-12-21",
+    "startTime": "14:00",
+    "location": "West Asheville Park, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265476399/",
+    "attendees": 22
+  },
+  {
+    "title": "AVLH3 Drinking Practice",
+    "date": "2019-12-19",
+    "startTime": "19:30",
+    "location": "Antidote at Chemist Spirits, 151 Coxe Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/267224873/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #577 - Ugly Sweater Hash",
+    "date": "2019-12-14",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265501345/",
+    "attendees": 28
+  },
+  {
+    "title": "Moonshine H3 #58 - Cold Moon/hot cocoa day",
+    "date": "2019-12-12",
+    "startTime": "18:30",
+    "location": "Neo Burrito, 4 South Tunnel Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/266881140/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #576 - details pended",
+    "date": "2019-12-07",
+    "startTime": "14:00",
+    "location": "AMF Bowling, 491 Kenilworth Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265501284/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #575 - Runnin' Redneck",
+    "date": "2019-11-30",
+    "startTime": "14:00",
+    "location": "Jackson Park, 810 Glover St, Hendersonville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265492880/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #574 - 9th Annual MANNA Foodbank Hash",
+    "date": "2019-11-23",
+    "startTime": "14:00",
+    "location": "Biltmore Park Pool, 1067 Columbine Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265476347/",
+    "attendees": 27
+  },
+  {
+    "title": "AVLH3 Drinking Practice",
+    "date": "2019-11-21",
+    "startTime": "19:30",
+    "location": "Sweeten Creek Brewing, 1127 Sweeten Creek Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/266581421/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #573 - Death to All But Metal",
+    "date": "2019-11-17",
+    "startTime": "13:30",
+    "location": "Parking Lot Between Premier FCU & HomeSource, 172 Charlotte St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265290171/",
+    "attendees": 18
+  },
+  {
+    "title": "Moonshine H3 #57 - Beaver Moon",
+    "date": "2019-11-10",
+    "startTime": "19:00",
+    "location": "Olde London Road English Pub, 270 Depot St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265614156/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #572 - Furious likes it long and hard..",
+    "date": "2019-11-09",
+    "startTime": "14:00",
+    "location": "81 Charlotte St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265494880/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #571 - Pumpkin Destruction Day",
+    "date": "2019-11-02",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265493630/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #570 - Hashoween!",
+    "date": "2019-10-31",
+    "startTime": "18:00",
+    "location": "Westville Pub / All Sevens Brewing, 777 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265476294/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #569 - Halloweeny!",
+    "date": "2019-10-27",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265476265/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #568 - “Flaming Balls with Reports\"",
+    "date": "2019-10-20",
+    "startTime": "14:00",
+    "location": "609 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265476185/",
+    "attendees": 6
+  },
+  {
+    "title": "Moonshine H3 #56 - Blood Moon",
+    "date": "2019-10-13",
+    "startTime": "18:30",
+    "location": "125 Bleachery Blvd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265119049/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #567 - Outlandos d'Hash",
+    "date": "2019-10-06",
+    "startTime": "14:00",
+    "location": "Smokey Park Supper Club, 350 Riverside Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265119014/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #566 - something enticing",
+    "date": "2019-09-28",
+    "startTime": "14:00",
+    "location": "105 Arco Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/265118962/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #565 - BEER & BOOBS & LEDERHOSEN! (This trail has been updated).",
+    "date": "2019-09-22",
+    "startTime": "13:00",
+    "location": "Dr. Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/263805115/",
+    "attendees": 7
+  },
+  {
+    "title": "Moonshine H3 #55 - Harvest Moon",
+    "date": "2019-09-14",
+    "startTime": "20:30",
+    "location": "6 Bryson St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/264157316/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 Erections and Hash Appreciation!",
+    "date": "2019-09-08",
+    "startTime": "16:00",
+    "location": "Family Dollar, 609 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/264406386/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #564 - South Slope bar crawl!",
+    "date": "2019-09-07",
+    "startTime": "14:00",
+    "location": "Ben's Tune Up, 195 Hilliard Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/264157260/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #563 - 11th Annual Blue Dress Run!",
+    "date": "2019-08-31",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/262397791/",
+    "attendees": 19
+  },
+  {
+    "title": "AVLH3 #562 - Searching the Beaver for a Little Man in a Boat",
+    "date": "2019-08-25",
+    "startTime": "14:00",
+    "location": "1056 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/263676973/",
+    "attendees": 10
+  },
+  {
+    "title": "AVLH3 #561 - Why us?",
+    "date": "2019-08-17",
+    "startTime": "14:00",
+    "location": "Semi Abandoned Church, 930 swannanoa river rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/263734073/",
+    "attendees": 6
+  },
+  {
+    "title": "Moonshine H3 #54 - Red Moon",
+    "date": "2019-08-14",
+    "startTime": "19:30",
+    "location": "425 Broadway St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/263749743/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #560 - Who's got two thumbs and a half cup of flour?",
+    "date": "2019-08-10",
+    "startTime": "14:00",
+    "location": "Parking Lot, 118 WT Weaver Blvd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/263734046/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #559 pt 2.... Babysitter teaches beer drinking",
+    "date": "2019-08-04",
+    "startTime": "14:00",
+    "location": "Martin Luther King Jr Park, 50 Martin Luther King Junior Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/263704966/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #559 - Don’t Leaf me now!",
+    "date": "2019-08-03",
+    "startTime": "14:00",
+    "location": "Martin Luther King Jr Park, 50 Martin Luther King Junior Drive, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/263285822/",
+    "attendees": 1
+  },
+  {
+    "title": "AVLH3 #558 - Sunday trail",
+    "date": "2019-07-28",
+    "startTime": "14:00",
+    "location": "Parking lot behind Dr. Daves Automotive., 1022 Haywood Rd, Asheville, NC 28806, ASHEVILLE, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/263285811/",
+    "attendees": 10
+  },
+  {
+    "title": "Moonshine H3 #53 - Buck Moon",
+    "date": "2019-07-20",
+    "startTime": "20:30",
+    "location": "Family Dollar, 609 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/262001720/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #557 - I say I say I say I see you haring trail!",
+    "date": "2019-07-13",
+    "startTime": "14:00",
+    "location": "Buncombe County Sports Park, 58 Apac Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/262669122/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #556 - 5th Annual 'Murica Hash (+ camp-out)!",
+    "date": "2019-07-06",
+    "startTime": "14:00",
+    "location": "Potchentokus Manor, 286 Flat Creek Rd, Fairview, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/261205253/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #555 - 4th of July Bar Crawl!",
+    "date": "2019-07-04",
+    "startTime": "15:00",
+    "location": "Burial Beer Company, 40 Collier Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/262734583/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #554 - Why'd the wanker cross the road",
+    "date": "2019-06-29",
+    "startTime": "14:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/262001810/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #553 - Dumber than Summer",
+    "date": "2019-06-22",
+    "startTime": "14:00",
+    "location": "Happiest Place in Asheville, 105 Arco Road, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/262002039/",
+    "attendees": 3
+  },
+  {
+    "title": "Moonshine H3 #52 - Strawberry Moon",
+    "date": "2019-06-17",
+    "startTime": "20:30",
+    "location": "Cherry Street North, Cherry St N, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/262001609/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #552 - Gender reveal hash for Nurse Hoover & VCR",
+    "date": "2019-06-16",
+    "startTime": "14:00",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/261187183/",
+    "attendees": 27
+  },
+  {
+    "title": "AVLH3 #551 - Wednesday Bar Crawl Trail",
+    "date": "2019-06-12",
+    "startTime": "18:30",
+    "location": "Burial Beer Company, 40 Collier Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/262082009/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #550 - Le Tour de Hash - FINALE (Stage 6)",
+    "date": "2019-06-08",
+    "startTime": "14:00",
+    "location": "Cherry Street North, Cherry St N, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260868426/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #549 - Le Tour de Hash - North (Stage 5)",
+    "date": "2019-06-06",
+    "startTime": "18:00",
+    "location": "Madre/Admiral's House, 13 Beaver Point Park, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260868405/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #548 - Le Tour de Hash - West (Stage 4)",
+    "date": "2019-06-05",
+    "startTime": "18:00",
+    "location": "West Asheville Park - Gassaway Field, 198 Vermont Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260868390/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #547 - Le Tour de Hash - River Arts (Stage 3)",
+    "date": "2019-06-03",
+    "startTime": "18:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260868380/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #546 - Le Tour de Hash - South (Stage 2)",
+    "date": "2019-06-02",
+    "startTime": "14:00",
+    "location": "100 Schenck Pkwy, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260868342/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #545 - Le Tour de Hash - East (Stage 1)",
+    "date": "2019-06-01",
+    "startTime": "14:00",
+    "location": "Potchentokus Manor, 286 Flat Creek Rd, Fairview, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260868300/",
+    "attendees": 16
+  }
+]

--- a/scripts/data/avlh3-meetup-history-batch-9.json
+++ b/scripts/data/avlh3-meetup-history-batch-9.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "AVLH3 #544 - Memorial Day Hash",
+    "date": "2019-05-27",
+    "startTime": "14:00",
+    "location": "Folk arts center, Blue ridge Parkway, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/261204327/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #543 - Armed Forces Day/Camo Hash",
+    "date": "2019-05-19",
+    "startTime": "12:00",
+    "location": "Bent Creek Rice Pinnacle Parking Area, 63 Rice Pinnacle Rd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260618134/",
+    "attendees": 14
+  },
+  {
+    "title": "Moonshine H3 #51 - Flower Moon",
+    "date": "2019-05-18",
+    "startTime": "20:00",
+    "location": "71 Cherry St N, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/261011500/",
+    "attendees": 8
+  },
+  {
+    "title": "AVLH3 #542 - Soaking Wet Mother(‘s Day) Hash",
+    "date": "2019-05-12",
+    "startTime": "13:00",
+    "location": "Village Wayside Bar & Grill, 30 Lodge Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260727881/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #541 - May the 4th Be With You",
+    "date": "2019-05-04",
+    "startTime": "14:00",
+    "location": "asheville eye gravel lot, 5 medical park dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260252041/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #540 - Sunday with Squeezy",
+    "date": "2019-04-28",
+    "startTime": "11:30",
+    "location": "West Asheville Parks and Recreation Pavilion, 11 Vermont Ave., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260727846/",
+    "attendees": 5
+  },
+  {
+    "title": "AVLH3 #539 - BEER-ster",
+    "date": "2019-04-21",
+    "startTime": "14:00",
+    "location": "Martin Luther King Jr Park, 50 Martin Luther King Jr Dr, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260618164/",
+    "attendees": 6
+  },
+  {
+    "title": "Moonshine H3 #50 - Pink Moon of the Dead!",
+    "date": "2019-04-18",
+    "startTime": "21:00",
+    "location": "Asheville Pizza and Brewing Co, 675 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260448531/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #538 - Ingenuity of event horizon camouflage...",
+    "date": "2019-04-13",
+    "startTime": "17:00",
+    "location": "Dr. Dave's Automotive, 1022 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260522549/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #537 - The Grim Reaper Trail: 40th birthday celebration of impending doom",
+    "date": "2019-04-07",
+    "startTime": "12:00",
+    "location": "Parking Lot, 167 Craven Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/259895978/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #536 - Titties' Tutu Birthday Hash!",
+    "date": "2019-04-05",
+    "startTime": "18:30",
+    "location": "Family Dollar, 609 Haywood Rd, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/260189699/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #535 - Just another Sunday trail!",
+    "date": "2019-03-31",
+    "startTime": "14:00",
+    "location": "Parking lot behind Dr. Daves Automotive., 1022 Haywood Rd, Asheville, NC 28806, ASHEVILLE, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/259895881/",
+    "attendees": 12
+  },
+  {
+    "title": "AVLH3 #534 - Spring has sprung!",
+    "date": "2019-03-24",
+    "startTime": "14:00",
+    "location": "The Montford Park Players, 92 Gay St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/259895668/",
+    "attendees": 12
+  },
+  {
+    "title": "Moonshine H3 #49 - Crow Moon",
+    "date": "2019-03-22",
+    "startTime": "19:30",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/259531528/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #533 - St. Paddy's Day Irish-U were a beer hash!",
+    "date": "2019-03-17",
+    "startTime": "13:00",
+    "location": "French Broad Brewery, 101 Fairview Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/259530909/",
+    "attendees": 30
+  },
+  {
+    "title": "AVLH3 #532 - Spring forward!",
+    "date": "2019-03-10",
+    "startTime": "14:00",
+    "location": "848 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/259468461/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #531 - Mardi Gras Trail",
+    "date": "2019-03-03",
+    "startTime": "11:00",
+    "location": "30 Buchanan place, Asheville, 28801, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/258749316/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #530 - RDR Sunday Hangover Trail!",
+    "date": "2019-02-24",
+    "startTime": "12:00",
+    "location": "Family Dollar Parking Lot, 609 Haywood Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257343831/",
+    "attendees": 28
+  },
+  {
+    "title": "AVLH3 #529 - AVLH3's 11th Annual Red Dress Run!",
+    "date": "2019-02-23",
+    "startTime": "13:00",
+    "location": "Off The Wagon Dueling Piano Bar Asheville, 22 North Market Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257343786/",
+    "attendees": 32
+  },
+  {
+    "title": "Moonshine H3 #48 - Snow Moon/Friday night pre-RDR trail!",
+    "date": "2019-02-22",
+    "startTime": "18:30",
+    "location": "167 Craven St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257343720/",
+    "attendees": 41
+  },
+  {
+    "title": "AVLH3 #528 - NFHN Nikki’s first haring!",
+    "date": "2019-02-16",
+    "startTime": "14:00",
+    "location": "Gravel Lot, 1979 Riverside Dr, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/258409519/",
+    "attendees": 17
+  },
+  {
+    "title": "AVLH3 #527 - Stayshoe",
+    "date": "2019-02-10",
+    "startTime": "14:00",
+    "location": "Walgreens, 841 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/258409814/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #526 - Snowshoe",
+    "date": "2019-02-08",
+    "startTime": "19:00",
+    "location": "Snowshoe, WV, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/258770509/",
+    "attendees": 3
+  },
+  {
+    "title": "AVLH3 #525 - Groundhog Day!!!",
+    "date": "2019-02-02",
+    "startTime": "14:00",
+    "location": "80 Fenner Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/258354895/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #524 - Green Eggs and Hamms!",
+    "date": "2019-01-26",
+    "startTime": "14:00",
+    "location": "Schenck Parkway Lot, 100 Schenck Parkway, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/258354812/",
+    "attendees": 13
+  },
+  {
+    "title": "Moonshine H3 #47 - Super Blood Wolf Eclipse Buzz Lightyear Hashy Birthday Moon",
+    "date": "2019-01-20",
+    "startTime": "17:30",
+    "location": "Weaver Park, 200 Murdock Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257863790/",
+    "attendees": 11
+  },
+  {
+    "title": "AVLH3 #523 - NFN Megan's first haring!",
+    "date": "2019-01-19",
+    "startTime": "14:00",
+    "location": "NC Outward Bound School, 2582 Riceville Rd., Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257863741/",
+    "attendees": 9
+  },
+  {
+    "title": "AVLH3 #522 - Make your dream come true day!",
+    "date": "2019-01-13",
+    "startTime": "13:30",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257863724/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #521 - AVLH3's Annual Formal",
+    "date": "2019-01-05",
+    "startTime": "18:00",
+    "location": "Aloft Asheville Downtown, 51 Biltmore Avenue, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257268687/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #520 - Goodbye, 2018!",
+    "date": "2018-12-29",
+    "startTime": "14:00",
+    "location": "Memorial Stadium, 32 Buchanan Pl, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257221148/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #519 - 26 And Zorro's 4th Anal Solstice Onesie Trail",
+    "date": "2018-12-21",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/256558638/",
+    "attendees": 18
+  },
+  {
+    "title": "Moonshine H3 #46 - Cold Moon",
+    "date": "2018-12-19",
+    "startTime": "18:30",
+    "location": "Free Lot On Cherry Street, 88ish Cherry St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/257221062/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #518 - Ugly Sweater Hash",
+    "date": "2018-12-15",
+    "startTime": "14:00",
+    "location": "Craven Street Parking Lot, 167 Craven Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/256223069/",
+    "attendees": 23
+  },
+  {
+    "title": "AVLH3 #517 - Highly Suggestive Shitshow",
+    "date": "2018-12-08",
+    "startTime": "14:00",
+    "location": "Asheville Folk Art Center, 382 Blue Ridge Pkwy, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/256222888/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #516 - A long time ago in a galaxy far, far away",
+    "date": "2018-12-01",
+    "startTime": "14:00",
+    "location": "walgreens side lot, 841 merrimon ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/256343957/",
+    "attendees": 6
+  },
+  {
+    "title": "Moonshine H3 #45 - Frosty Moon",
+    "date": "2018-11-25",
+    "startTime": "18:00",
+    "location": "Cherry Street Free Lot, 98 cherry street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/255935464/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 #515 - 8th Annual MANNA Foodbank Hash",
+    "date": "2018-11-17",
+    "startTime": "14:00",
+    "location": "Summit Crossfit, 21 A McArthur Lane, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/255391976/",
+    "attendees": 18
+  },
+  {
+    "title": "AVLH3 #514 - Hills, thrills, and chills",
+    "date": "2018-11-10",
+    "startTime": "14:00",
+    "location": "spare subway parking lot, 766 biltmore ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/255934204/",
+    "attendees": 6
+  },
+  {
+    "title": "AVLH3 #513 - Leaf Peeper trail.",
+    "date": "2018-11-04",
+    "startTime": "14:00",
+    "location": "Weaver Park Tennis Courts, 437 Merrimon Ave, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/255934098/",
+    "attendees": 7
+  },
+  {
+    "title": "AVLH3 #512 - Hashoween!",
+    "date": "2018-10-31",
+    "startTime": "18:00",
+    "location": "Brew Pump, 760 Haywood Road, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/255392222/",
+    "attendees": 14
+  },
+  {
+    "title": "AVLH3 #511 - The Most Golden of Showers",
+    "date": "2018-10-28",
+    "startTime": "12:00",
+    "location": "Behind Fresh Market, 58 Osborne Rd, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/254862301/",
+    "attendees": 10
+  },
+  {
+    "title": "Moonshine H3 #44 - Blood Moon",
+    "date": "2018-10-24",
+    "startTime": "19:30",
+    "location": "HomeSource, 172 Charlotte St, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/255392566/",
+    "attendees": 16
+  },
+  {
+    "title": "AVLH3 #510 - Crafting, Crapping, & Carving",
+    "date": "2018-10-21",
+    "startTime": "14:00",
+    "location": "Burleson Road Parking Lot, 3 Burleson Road, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/255338516/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #509 - Day of Failure - The Sweeten Creek Shuffle",
+    "date": "2018-10-13",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/avlh3-on-on/events/255338478/",
+    "attendees": 4
+  },
+  {
+    "title": "AVLH3 #508 - White dress for VCR and Nurse getting hitched",
+    "date": "2018-10-06",
+    "startTime": "14:00",
+    "location": "Cherry St. Parking Lot, 71 Cherry Street, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/254108679/",
+    "attendees": 33
+  },
+  {
+    "title": "AVLH3 #507 - Stop! Brunchie Time!",
+    "date": "2018-09-30",
+    "startTime": "11:00",
+    "location": "Parking Lot off Charlotte Street, 77 Charlotte Street, Asheville, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/254379592/",
+    "attendees": 20
+  },
+  {
+    "title": "AVLH3 #506 - Luau Hula Hash",
+    "date": "2018-09-22",
+    "startTime": "14:00",
+    "location": "Beverly Hills Municipal Golf Course, Asheville, 16 Stockbridge Pl, Walkers Tropical Paradise, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/252375152/",
+    "attendees": 26
+  },
+  {
+    "title": "AVLH3 #505 - NFN Sydney's first haring!",
+    "date": "2018-09-15",
+    "startTime": "14:00",
+    "location": "spare subway parking lot, 766 biltmore ave, asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/254379515/",
+    "attendees": 13
+  },
+  {
+    "title": "AVLH3 Erections and Hash Appreciation Brunch!",
+    "date": "2018-09-09",
+    "startTime": "11:00",
+    "location": "Princess & Cum Pi’s House, 105 Arco Road, Asheville, NC, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/253948922/",
+    "attendees": 15
+  },
+  {
+    "title": "AVLH3 #504 - NFN Brandt's first haring!",
+    "date": "2018-09-08",
+    "startTime": "14:00",
+    "location": "Parking lot behind Dr. Daves Automotive., 1022 Haywood Rd, Asheville, NC 28806, ASHEVILLE, nc, US",
+    "url": "https://www.meetup.com/avlh3-on-on/events/254379461/",
+    "attendees": 8
+  }
+]

--- a/scripts/data/bdsmh3-meetup-history-batch-1.json
+++ b/scripts/data/bdsmh3-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "BDSMH3 Trail",
+    "date": "2022-12-19",
+    "startTime": "18:00",
+    "location": "start, 1030 independence Blvd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/290425713/",
+    "attendees": 3
+  },
+  {
+    "title": "CB2H2 MEMORIAL DAY BASH COOKOUT",
+    "date": "2021-05-31",
+    "startTime": "12:30",
+    "location": "824 W 47th St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/278447538/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail #2449: Granny & Panda",
+    "date": "2021-05-29",
+    "startTime": "15:00",
+    "location": "The Marquis, 100 Gristmill Plz, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/278448166/",
+    "attendees": 1
+  },
+  {
+    "title": "Trash Pickup H3 Beach Day Edition",
+    "date": "2021-05-29",
+    "startTime": "10:30",
+    "location": "4717 Shore Dr, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/278447823/",
+    "attendees": 1
+  },
+  {
+    "title": "Panda's Birthday Trail",
+    "date": "2021-05-23",
+    "startTime": "12:00",
+    "location": "13028 Carrollton Blvd, Carrollton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/278094341/",
+    "attendees": 2
+  },
+  {
+    "title": "FEH3 Trail #2448",
+    "date": "2021-05-15",
+    "startTime": "15:00",
+    "location": "Berkeley Middle School, 1118 Ironbound Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/278146521/",
+    "attendees": 1
+  },
+  {
+    "title": "HOBO H3 (#866)",
+    "date": "2021-05-09",
+    "startTime": "15:00",
+    "location": "508 Shoreside Wy, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/278051560/",
+    "attendees": 1
+  },
+  {
+    "title": "T3H3",
+    "date": "2021-05-04",
+    "startTime": "18:00",
+    "location": "Starbucks, 179 W Ocean View Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277985629/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail #2447: NFN Doug & Nine Second Swallow, May Day Toga Trail",
+    "date": "2021-05-01",
+    "startTime": "15:00",
+    "location": "217 Bulifants Blvd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277881587/",
+    "attendees": 1
+  },
+  {
+    "title": "Fullmoon H3",
+    "date": "2021-04-30",
+    "startTime": "18:30",
+    "location": "212 Seabridge Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277881541/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater H3",
+    "date": "2021-04-29",
+    "startTime": "18:00",
+    "location": "Coleman Place Elementary, 2445 Palmyra St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277881496/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3",
+    "date": "2021-04-22",
+    "startTime": "18:00",
+    "location": "Harbor Park LRT Station Park & Ride, 190 Park Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277739868/",
+    "attendees": 1
+  },
+  {
+    "title": "TUESDAY! TUESDAY! TUESDAY! 4/20 Trail",
+    "date": "2021-04-20",
+    "startTime": "18:00",
+    "location": "1610 Coliseum Dr, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277528511/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail #2446 - Blackout Lesbian",
+    "date": "2021-04-17",
+    "startTime": "15:00",
+    "location": "1118 Ironbound Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277528563/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3",
+    "date": "2021-04-15",
+    "startTime": "18:00",
+    "location": "1920 Centerville Turnpike, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277585296/",
+    "attendees": 1
+  },
+  {
+    "title": "CB2H2 Brunch Bash",
+    "date": "2021-04-03",
+    "startTime": "09:30",
+    "location": "824 W 47th St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277301887/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail #2445 Easter Trail",
+    "date": "2021-04-03",
+    "startTime": "15:00",
+    "location": "LF Palmer Elementary School, 100 Palmer Ln, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/277301751/",
+    "attendees": 1
+  },
+  {
+    "title": "T3H3's 1014th Trail",
+    "date": "2020-11-24",
+    "startTime": "18:00",
+    "location": "3575 Bridge Rd, Suffolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/274789425/",
+    "attendees": 1
+  },
+  {
+    "title": "TUESDAY! TUESDAY! TUESDAY! T3H3 Trail # 1013",
+    "date": "2020-11-10",
+    "startTime": "18:00",
+    "location": "280 Libby St, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/274491916/",
+    "attendees": 2
+  },
+  {
+    "title": "FEH3 Trail# 2433 - Zombie Hash",
+    "date": "2020-10-17",
+    "startTime": "15:00",
+    "location": "81 Patch Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/273902047/",
+    "attendees": 2
+  },
+  {
+    "title": "TUESDAY's 1011th Trail",
+    "date": "2020-10-13",
+    "startTime": "18:00",
+    "location": "823 Maury Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/273901892/",
+    "attendees": 1
+  },
+  {
+    "title": "HOBO 2.0 Trail #850 2.0 IS BACK !! and WE GOT TOETAGS FOR REACHING 850 TRAILS!!",
+    "date": "2020-10-08",
+    "startTime": "18:00",
+    "location": "4001 Llewellyn Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/273804269/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail# 2431 - NFN Carl & PNA",
+    "date": "2020-09-19",
+    "startTime": "15:00",
+    "location": "Yorktown Middle School, 11201 George Washington Memorial Hwy, Yorktown, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/273346895/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3 Trail",
+    "date": "2020-07-16",
+    "startTime": "18:00",
+    "location": "2521 Peritan Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/271961619/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #845",
+    "date": "2020-07-05",
+    "startTime": "12:00",
+    "location": "824 W 47th St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/271550874/",
+    "attendees": 1
+  },
+  {
+    "title": "1003rd Tuesday Tuesday Tuesday Trail",
+    "date": "2020-06-30",
+    "startTime": "18:00",
+    "location": "102 East St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/271550846/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail #2425",
+    "date": "2020-06-27",
+    "startTime": "15:00",
+    "location": "5424 Discovery Park Blvd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/271550814/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail #2424",
+    "date": "2020-06-13",
+    "startTime": "15:00",
+    "location": "Yorktown French Memorial, Yorktown, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/271250950/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3 Trail #1515",
+    "date": "2020-06-11",
+    "startTime": "18:00",
+    "location": "3461 Plainsman Trail, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/271234217/",
+    "attendees": 1
+  },
+  {
+    "title": "1000th Tuesday Tuesday Tuesday Trail",
+    "date": "2020-06-09",
+    "startTime": "18:00",
+    "location": "1060 Cascade Blvd, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/271166220/",
+    "attendees": 2
+  },
+  {
+    "title": "999th Tuesday Tuesday Tuesday Trail",
+    "date": "2020-06-02",
+    "startTime": "18:00",
+    "location": "1901 E Ocean View Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/271034102/",
+    "attendees": 1
+  },
+  {
+    "title": "998th Tuesday Tuesday Tuesday Trail",
+    "date": "2020-05-26",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/270882085/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #842",
+    "date": "2020-05-24",
+    "startTime": "14:00",
+    "location": "3981 Twin Pines Rd, Portsmouth, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/270747806/",
+    "attendees": 1
+  },
+  {
+    "title": "997th Tuesday Tuesday Tuesday Trail",
+    "date": "2020-05-19",
+    "startTime": "18:00",
+    "location": "827 W 47th St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/270747532/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #840",
+    "date": "2020-04-26",
+    "startTime": "14:00",
+    "location": "4720 Clifford St, Portsmouth, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/270224158/",
+    "attendees": 4
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #839",
+    "date": "2020-04-12",
+    "startTime": "14:00",
+    "location": "1590 Corporate Landing Pkwy, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269931208/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #838",
+    "date": "2020-03-26",
+    "startTime": "18:00",
+    "location": "3690 Marlin Bay Dr, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269627085/",
+    "attendees": 2
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #986",
+    "date": "2020-03-24",
+    "startTime": "18:00",
+    "location": "1240 Homestead Dr, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269627011/",
+    "attendees": 1
+  },
+  {
+    "title": "TH3 20th Green Dress Run 2020",
+    "date": "2020-03-21",
+    "startTime": "12:30",
+    "location": "1083 37th St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268544740/",
+    "attendees": null
+  },
+  {
+    "title": "Tidewater Fullmoon H3 trail",
+    "date": "2020-03-20",
+    "startTime": "18:30",
+    "location": "3791 Karlin Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269402993/",
+    "attendees": 2
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #985",
+    "date": "2020-03-17",
+    "startTime": "18:00",
+    "location": "701 N Battlefield Blvd, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269480071/",
+    "attendees": 1
+  },
+  {
+    "title": "CB2H2 PRESENTS A Bash Hash @ Ocean VIEW",
+    "date": "2020-03-14",
+    "startTime": "12:30",
+    "location": "127 Howe St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269403064/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #837",
+    "date": "2020-03-12",
+    "startTime": "18:00",
+    "location": "Lakewood Park, 1612 Willow Wood Dr, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269380210/",
+    "attendees": 1
+  },
+  {
+    "title": "2417 - KISS & NFN Joe",
+    "date": "2020-03-07",
+    "startTime": "15:00",
+    "location": "14550 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268711948/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #983",
+    "date": "2020-03-03",
+    "startTime": "18:00",
+    "location": "6400 Newport Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269163434/",
+    "attendees": 1
+  },
+  {
+    "title": "One City Marathon Beer Stop",
+    "date": "2020-03-01",
+    "startTime": "07:00",
+    "location": "Hilton Village Goldsmith, 10347 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269067642/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3 Trail",
+    "date": "2020-03-01",
+    "startTime": "13:00",
+    "location": "1070 University Blvd, Portsmouth, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268958304/",
+    "attendees": 2
+  },
+  {
+    "title": "F Breast Cancer",
+    "date": "2020-02-29",
+    "startTime": "15:00",
+    "location": "Billsburg Brewery, 2054 Jamestown Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269067572/",
+    "attendees": 1
+  },
+  {
+    "title": "Leap Day Hash",
+    "date": "2020-02-29",
+    "startTime": "14:00",
+    "location": "old food lion, 1581 General Booth Blvd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268547441/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #836",
+    "date": "2020-02-27",
+    "startTime": "18:00",
+    "location": "1100 Volvo Pkwy, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/269012011/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/bdsmh3-meetup-history-batch-2.json
+++ b/scripts/data/bdsmh3-meetup-history-batch-2.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #982",
+    "date": "2020-02-25",
+    "startTime": "18:00",
+    "location": "3501 Holland Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268958252/",
+    "attendees": 1
+  },
+  {
+    "title": "2416 - Clits 'n Chips, & Cow Poke",
+    "date": "2020-02-22",
+    "startTime": "15:00",
+    "location": "Warhill High School, 4615 Opportunity Way, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268711924/",
+    "attendees": 2
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #981",
+    "date": "2020-02-18",
+    "startTime": "18:00",
+    "location": "4356 Holland Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268804840/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3 Trail",
+    "date": "2020-02-16",
+    "startTime": "13:00",
+    "location": "Ghent Elementary School, 200 Shirley Avenue, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268749087/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #835",
+    "date": "2020-02-13",
+    "startTime": "18:00",
+    "location": "2059 Tarrallton Dr, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268607018/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #980",
+    "date": "2020-02-11",
+    "startTime": "18:00",
+    "location": "1070 37th St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268606846/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3 Trail #150? TH3 LOVE RUN",
+    "date": "2020-02-09",
+    "startTime": "13:00",
+    "location": "3500 Granby St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268544704/",
+    "attendees": 3
+  },
+  {
+    "title": "FEH3's 4th ANAL Red Dress Run",
+    "date": "2020-02-08",
+    "startTime": "15:00",
+    "location": "Stillwater Tavern, 555 Settlers Landing Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268426407/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidywater Trash Pickup",
+    "date": "2020-02-08",
+    "startTime": "10:30",
+    "location": "4625 Shore Dr, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268328282/",
+    "attendees": 4
+  },
+  {
+    "title": "Virginia Beach Full Moon H3",
+    "date": "2020-02-07",
+    "startTime": "18:30",
+    "location": "2875 Sabre St, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268544622/",
+    "attendees": 1
+  },
+  {
+    "title": "2020 SUPER BOWL TRAIL & POT LUCK GATHERING",
+    "date": "2020-02-02",
+    "startTime": "13:00",
+    "location": "Shadow's, 4888 Euclid Rd., Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268307600/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #834",
+    "date": "2020-01-30",
+    "startTime": "18:00",
+    "location": "2809 S Lynnhaven Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268328210/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater Hash House Harriers 2020 AGM!",
+    "date": "2020-01-26",
+    "startTime": "13:00",
+    "location": "Red Bones Raw Bar Seafood Grille, 445 N Battlefield Blvd, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268112985/",
+    "attendees": 4
+  },
+  {
+    "title": "2414 - A.N.A.L.",
+    "date": "2020-01-25",
+    "startTime": "15:00",
+    "location": "65 W Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267962469/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #978",
+    "date": "2020-01-21",
+    "startTime": "18:00",
+    "location": "823 Maury Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268094233/",
+    "attendees": 2
+  },
+  {
+    "title": "TH3 Trail - This is gettin Syriaous",
+    "date": "2020-01-19",
+    "startTime": "13:00",
+    "location": "Burlington coat factory, 880 S Military Hwy, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/268016761/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #833",
+    "date": "2020-01-16",
+    "startTime": "18:00",
+    "location": "5235 Learning Cir, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267962517/",
+    "attendees": 2
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #977",
+    "date": "2020-01-14",
+    "startTime": "18:00",
+    "location": "Restaurant Depot, 5112 Virginia Beach Blvd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267907249/",
+    "attendees": 2
+  },
+  {
+    "title": "FEH3 Trail# 2413",
+    "date": "2020-01-11",
+    "startTime": "15:00",
+    "location": "275 Menchville Rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267593967/",
+    "attendees": 3
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #976",
+    "date": "2020-01-07",
+    "startTime": "18:00",
+    "location": "416 W 24th St, Norfolk, VA 23517, 416 W 24th Street, norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267705954/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater H3 Trail #1501 maybe 1502",
+    "date": "2020-01-05",
+    "startTime": "13:00",
+    "location": "3333 Virginia Beach Blvd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267661803/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #832",
+    "date": "2020-01-02",
+    "startTime": "18:00",
+    "location": "1741 Corporate Landing Pkwy, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267580934/",
+    "attendees": 2
+  },
+  {
+    "title": "FEH3's New Year's Day Hangover Trail",
+    "date": "2020-01-01",
+    "startTime": "10:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267537796/",
+    "attendees": 1
+  },
+  {
+    "title": "T3H3 The Great Gatsby New Years Eve Party 2020",
+    "date": "2019-12-31",
+    "startTime": "20:30",
+    "location": "1860 Laskin Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266975718/",
+    "attendees": 3
+  },
+  {
+    "title": "8th Day of Hanukkah!!",
+    "date": "2019-12-29",
+    "startTime": "13:00",
+    "location": "4797 Indian River Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267426559/",
+    "attendees": 2
+  },
+  {
+    "title": "HANUKKAH DAY 7 Shots in the Day!! Oy Vey",
+    "date": "2019-12-28",
+    "startTime": "15:00",
+    "location": "81 Patch Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267426531/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail# 2412",
+    "date": "2019-12-28",
+    "startTime": "15:00",
+    "location": "Fort Monroe, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266974258/",
+    "attendees": 1
+  },
+  {
+    "title": "FRIDAY DAY 6",
+    "date": "2019-12-27",
+    "startTime": "18:00",
+    "location": "Wasserhund Brewing Company, 1805 Laskin Road, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267426491/",
+    "attendees": 2
+  },
+  {
+    "title": "THURSDAY HANUKKAH HASH DAY 5",
+    "date": "2019-12-26",
+    "startTime": "18:00",
+    "location": "4356 Holland Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267426470/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater Fullmoon H3 & Ugly Sweater & White Elephant Gift Exchange!",
+    "date": "2019-12-20",
+    "startTime": "19:00",
+    "location": "2617 Eastwood Ave, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267304023/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #829",
+    "date": "2019-12-19",
+    "startTime": "18:00",
+    "location": "200 50th St, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/267303979/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidywater Trash Pickup",
+    "date": "2019-12-07",
+    "startTime": "11:00",
+    "location": "4625 Shore Dr, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266973567/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #828",
+    "date": "2019-12-05",
+    "startTime": "18:00",
+    "location": "1151 Azalea Garden Rd, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266973462/",
+    "attendees": 2
+  },
+  {
+    "title": "2019 Turkey Bowl",
+    "date": "2019-11-30",
+    "startTime": "23:30",
+    "location": "8100 Tidewater Dr, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266118456/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #827",
+    "date": "2019-11-28",
+    "startTime": "18:00",
+    "location": "1551 Premium Outlets Blvd, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266728332/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #970",
+    "date": "2019-11-26",
+    "startTime": "18:00",
+    "location": "3636 Virginia Beach Blvd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266728265/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #967",
+    "date": "2019-11-12",
+    "startTime": "18:00",
+    "location": "1220 Fordham Dr, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266409045/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3 Trail #1495",
+    "date": "2019-11-10",
+    "startTime": "13:00",
+    "location": "2411 Bainbridge Blvd, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266211214/",
+    "attendees": 2
+  },
+  {
+    "title": "FEH3 Turns 48 - Bar Crawl/Hashit Across America Move",
+    "date": "2019-11-09",
+    "startTime": "15:00",
+    "location": "Oozlefinch Beers & Blending, 81 Patch Rd, Fort Monroe, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266210742/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #825",
+    "date": "2019-11-07",
+    "startTime": "18:00",
+    "location": "415 N Military Hwy, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266210538/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #966",
+    "date": "2019-11-05",
+    "startTime": "18:00",
+    "location": "748 Independence Blvd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266210491/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3 Trail #1494",
+    "date": "2019-11-03",
+    "startTime": "13:00",
+    "location": "2476 Nimmo Pkwy, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266107657/",
+    "attendees": 2
+  },
+  {
+    "title": "2408 - BBQ's Birthday Trail",
+    "date": "2019-11-02",
+    "startTime": "15:00",
+    "location": "846 Chapin Wood Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266052936/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #824",
+    "date": "2019-10-31",
+    "startTime": "18:00",
+    "location": "127 Howe St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266052704/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #965",
+    "date": "2019-10-29",
+    "startTime": "18:00",
+    "location": "215 W York St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/266052604/",
+    "attendees": 1
+  },
+  {
+    "title": "TH3 26th Anal Halloweenie Pub Crawl \"TH3 Corpse' Bride\" 2019",
+    "date": "2019-10-26",
+    "startTime": "19:00",
+    "location": "Bayside Bar & Grill, 2973 Shore Dr Ste 106, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265153336/",
+    "attendees": 3
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #823",
+    "date": "2019-10-24",
+    "startTime": "18:00",
+    "location": "3698 Marlin Bay Dr, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265878848/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #965",
+    "date": "2019-10-22",
+    "startTime": "18:00",
+    "location": "1070 37th St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265878133/",
+    "attendees": 1
+  },
+  {
+    "title": "2407 - Whirled Peas Through Beer",
+    "date": "2019-10-19",
+    "startTime": "15:00",
+    "location": "Jamestown High School, 3751 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265532849/",
+    "attendees": 2
+  },
+  {
+    "title": "ZOMBIE Hash 2019",
+    "date": "2019-10-18",
+    "startTime": "18:00",
+    "location": "2000 Rokeby Ave, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264819854/",
+    "attendees": 2
+  }
+]

--- a/scripts/data/bdsmh3-meetup-history-batch-3.json
+++ b/scripts/data/bdsmh3-meetup-history-batch-3.json
@@ -1,0 +1,386 @@
+[
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #964 World Peace Through Beer #2",
+    "date": "2019-10-15",
+    "startTime": "18:00",
+    "location": "1716 Grey Friars Chase, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265692015/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #821",
+    "date": "2019-10-10",
+    "startTime": "18:00",
+    "location": "Picnic Oak Avenue, Picnic Oak Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265532734/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #963 T3H3 presents \"COCKTOBERFEST\"",
+    "date": "2019-10-08",
+    "startTime": "18:00",
+    "location": "143 East St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265508386/",
+    "attendees": 2
+  },
+  {
+    "title": "TideWater H3 Trail #1490 Sunday! Funday! Runday!",
+    "date": "2019-10-06",
+    "startTime": "13:00",
+    "location": "Start, 1164 Millers In Suite A, Virginia Beach, va, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265406389/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail #2406 - PNA's Beer Mile",
+    "date": "2019-10-05",
+    "startTime": "15:00",
+    "location": "Briarfield Park, 1560 Briarfield Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265406441/",
+    "attendees": 2
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #962",
+    "date": "2019-10-01",
+    "startTime": "18:00",
+    "location": "823 Maury Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265317909/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater HOBO H3 Trail #820",
+    "date": "2019-09-29",
+    "startTime": "15:00",
+    "location": "Greenbrier Park, 1009 Greenbrier Pkwy, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265183128/",
+    "attendees": 1
+  },
+  {
+    "title": "ClamH3 5th Annual Co-Ed Purple Dress Run 2019",
+    "date": "2019-09-28",
+    "startTime": "12:00",
+    "location": "701 Town Center Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264925181/",
+    "attendees": 2
+  },
+  {
+    "title": "Tidewater H3 Trail #1488",
+    "date": "2019-09-26",
+    "startTime": "18:00",
+    "location": "All About Scrapbooks, 701 Battlefield Blvd N, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/265182651/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail# 2405",
+    "date": "2019-09-21",
+    "startTime": "15:00",
+    "location": "432 Industrial Park Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264753752/",
+    "attendees": 3
+  },
+  {
+    "title": "The 9er trail of 2019",
+    "date": "2019-09-19",
+    "startTime": "18:00",
+    "location": "1075 Norview Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264991690/",
+    "attendees": 1
+  },
+  {
+    "title": "Tuesday Tuesday Tuesday Trail #960",
+    "date": "2019-09-17",
+    "startTime": "18:00",
+    "location": "All Around Pizzas and Deli, 3501 Holland Rd, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264924527/",
+    "attendees": 1
+  },
+  {
+    "title": "HOBO H3 Trail #819",
+    "date": "2019-09-15",
+    "startTime": "15:00",
+    "location": "1900 Paramont Ave, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264753813/",
+    "attendees": 1
+  },
+  {
+    "title": "FULL MOON! Friday the 13th! Muhahaha! Tombstone Paint Night!",
+    "date": "2019-09-13",
+    "startTime": "18:00",
+    "location": "410 Virginian Dr, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264781542/",
+    "attendees": 1
+  },
+  {
+    "title": "Tidewater H3 Trail #1486",
+    "date": "2019-09-12",
+    "startTime": "18:00",
+    "location": "6101 N Military Hwy, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264753691/",
+    "attendees": 2
+  },
+  {
+    "title": "FEH3's Trail# 2404 - Lube - The day after Dorian",
+    "date": "2019-09-07",
+    "startTime": "15:00",
+    "location": "County Grill & Smokehouse, 26 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/264548852/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 TRAIL #2401 CumLine's Farewell Trail",
+    "date": "2019-07-27",
+    "startTime": "15:00",
+    "location": "Huntington Park, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/263490799/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail# 2397",
+    "date": "2019-06-01",
+    "startTime": "15:00",
+    "location": "Capstan Bar Brewing Company, 2036 Exploration Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/261865389/",
+    "attendees": 1
+  },
+  {
+    "title": "CB2H2 Bash in Ghent",
+    "date": "2019-05-19",
+    "startTime": "10:00",
+    "location": "1020 Spotswood Ave, Norfolk, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/261485800/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Trail# 2396",
+    "date": "2019-05-18",
+    "startTime": "15:00",
+    "location": "Williamsburg, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/261486408/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 2395 - May the fourth be with you",
+    "date": "2019-05-04",
+    "startTime": "15:00",
+    "location": "Richneck Elementary Public School, 205 Tyner Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/261136075/",
+    "attendees": 1
+  },
+  {
+    "title": "Renegade Wednesday Trail",
+    "date": "2019-02-06",
+    "startTime": "17:45",
+    "location": "County Grill & Smokehouse, 26 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/258700169/",
+    "attendees": 5
+  },
+  {
+    "title": "2388 - FEH3 RED DRESS RUN",
+    "date": "2019-01-26",
+    "startTime": "15:00",
+    "location": "Hilton Tavern Brewing Co., 10184 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/258394440/",
+    "attendees": 3
+  },
+  {
+    "title": "Bad Decisions Start Monday H3 Trail Number #28 - Hampton",
+    "date": "2019-01-14",
+    "startTime": "18:00",
+    "location": "County Grill & Smokehouse, 26 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/257730907/",
+    "attendees": 5
+  },
+  {
+    "title": "New Year's Day Hangover Trail",
+    "date": "2019-01-01",
+    "startTime": "10:00",
+    "location": "Hampton Roads Convention Center, 1610 Coliseum Dr, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/257626881/",
+    "attendees": 1
+  },
+  {
+    "title": "County Grill Social - Hampton",
+    "date": "2018-12-19",
+    "startTime": "18:00",
+    "location": "County Grill & Smokehouse, 23 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/257201064/",
+    "attendees": 2
+  },
+  {
+    "title": "Tradition's Brewery Social Run!",
+    "date": "2018-12-19",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/257138155/",
+    "attendees": 3
+  },
+  {
+    "title": "County Grill Social - Hampton",
+    "date": "2018-12-12",
+    "startTime": "18:00",
+    "location": "County Grill & Smokehouse, 23 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/257018010/",
+    "attendees": 1
+  },
+  {
+    "title": "Tradition's Brewery Social Run!",
+    "date": "2018-12-12",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256206627/",
+    "attendees": 1
+  },
+  {
+    "title": "County Grill Social - Hampton",
+    "date": "2018-12-05",
+    "startTime": "18:00",
+    "location": "County Grill & Smokehouse, 23 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256823476/",
+    "attendees": 1
+  },
+  {
+    "title": "Tradition's Brewery Social Run!",
+    "date": "2018-12-05",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256206616/",
+    "attendees": 1
+  },
+  {
+    "title": "County Grill Social - Hampton",
+    "date": "2018-11-28",
+    "startTime": "18:00",
+    "location": "County Grill & Smokehouse, 23 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256635286/",
+    "attendees": 2
+  },
+  {
+    "title": "Tradition's Brewery Social Run!",
+    "date": "2018-11-28",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256206607/",
+    "attendees": 1
+  },
+  {
+    "title": "County Grill Social - Hampton",
+    "date": "2018-11-21",
+    "startTime": "18:00",
+    "location": "County Grill & Smokehouse, 23 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256454587/",
+    "attendees": 1
+  },
+  {
+    "title": "Tradition's Brewery Social Run!",
+    "date": "2018-11-21",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256206598/",
+    "attendees": 1
+  },
+  {
+    "title": "County Grill Social - Hampton",
+    "date": "2018-11-14",
+    "startTime": "18:00",
+    "location": "County Grill & Smokehouse, 23 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256244637/",
+    "attendees": 1
+  },
+  {
+    "title": "Bad Decisions Start Monday H3 Trail Number #27 - NoNo GoGo - Virginia Beach",
+    "date": "2018-11-12",
+    "startTime": "18:00",
+    "location": "Parking Lot behind Kirklands, 1725 Laskin Rd, Virginia Beach, va, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256277007/",
+    "attendees": 1
+  },
+  {
+    "title": "Tradition's Brewery Social Run! Trivia after!",
+    "date": "2018-11-07",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/256050090/",
+    "attendees": 1
+  },
+  {
+    "title": "Bad Decisions Start Monday H3 Trail Number #26 - Hampton",
+    "date": "2018-11-05",
+    "startTime": "18:00",
+    "location": "lube's home, 2314 Shell Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/255863106/",
+    "attendees": 3
+  },
+  {
+    "title": "Tradition's Brewery Social Run! Trivia after!",
+    "date": "2018-10-31",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/255843547/",
+    "attendees": 1
+  },
+  {
+    "title": "Tradition's Brewery Social Run! Trivia after!",
+    "date": "2018-10-24",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/255651100/",
+    "attendees": 1
+  },
+  {
+    "title": "Tradition's Brewery Social Run! Trivia after!",
+    "date": "2018-10-17",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/255464718/",
+    "attendees": 1
+  },
+  {
+    "title": "Tradition's Brewery Social Run! Trivia after!",
+    "date": "2018-10-10",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/255277645/",
+    "attendees": 3
+  },
+  {
+    "title": "Fat boy trail from Lube's new Homestead",
+    "date": "2018-10-08",
+    "startTime": "18:00",
+    "location": "lube's home, 2314 Shell Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/255366747/",
+    "attendees": 1
+  },
+  {
+    "title": "Tradition's Brewery Social Run! Trivia after!",
+    "date": "2018-10-03",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/254819552/",
+    "attendees": 3
+  },
+  {
+    "title": "Tradition's Brewery Social Run! Trivia after!",
+    "date": "2018-09-26",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/254819547/",
+    "attendees": 1
+  },
+  {
+    "title": "Bad Decisions Start Monday H3 Trail Number #24 -Back in the Saddle-Newport News",
+    "date": "2018-09-24",
+    "startTime": "18:00",
+    "location": "Parking lot behind Denbigh Pharmacy, 13349 Warwick Blvd, Newport News, va, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/254788780/",
+    "attendees": 2
+  },
+  {
+    "title": "Tradition's Brewery Social Run! Trivia after!",
+    "date": "2018-09-19",
+    "startTime": "17:45",
+    "location": "Tradition Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/bdsm-hash-house-harriers/events/254819129/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/bssh3-meetup-history-batch-1.json
+++ b/scripts/data/bssh3-meetup-history-batch-1.json
@@ -1,0 +1,146 @@
+[
+  {
+    "title": "The 20th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2026-03-28",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/313781935/",
+    "attendees": 15
+  },
+  {
+    "title": "The 19th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2026-03-14",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/313619555/",
+    "attendees": 13
+  },
+  {
+    "title": "The 18th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2026-01-31",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/312264054/",
+    "attendees": 27
+  },
+  {
+    "title": "The 17th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-12-20",
+    "startTime": "15:00",
+    "location": "Sam Yot Mrt, Sam Yot, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/312457941/",
+    "attendees": 5
+  },
+  {
+    "title": "The 16th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-11-29",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/312092660/",
+    "attendees": 17
+  },
+  {
+    "title": "The 15th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-10-25",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/311148127/",
+    "attendees": 30
+  },
+  {
+    "title": "The 14th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-09-20",
+    "startTime": "14:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/310796458/",
+    "attendees": 9
+  },
+  {
+    "title": "The 13th Bangkok Weekend Trail Walk & Run (BSSH3) - 1 Year Anniversary",
+    "date": "2025-08-30",
+    "startTime": "13:00",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/309700113/",
+    "attendees": 31
+  },
+  {
+    "title": "The 12th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-06-14",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/307600299/",
+    "attendees": 20
+  },
+  {
+    "title": "The 9th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-04-26",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/307178564/",
+    "attendees": 7
+  },
+  {
+    "title": "The 8th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-03-29",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/306065339/",
+    "attendees": 20
+  },
+  {
+    "title": "The 7th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-03-01",
+    "startTime": "13:45",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/306065329/",
+    "attendees": 18
+  },
+  {
+    "title": "The 6th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2025-01-25",
+    "startTime": "14:00",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/305496970/",
+    "attendees": 18
+  },
+  {
+    "title": "The 5th Bangkok Weekend Trail Walk & Run (BSSH3) - City Special",
+    "date": "2024-12-07",
+    "startTime": "16:30",
+    "location": "Leelabar, 274 276 Boriphat Rd, Ban Bat, Pom Prap Sattru Phai, 10100, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/304452511/",
+    "attendees": 28
+  },
+  {
+    "title": "The 4th Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2024-11-30",
+    "startTime": "14:00",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/304358075/",
+    "attendees": 33
+  },
+  {
+    "title": "The 3rd Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2024-10-26",
+    "startTime": "13:30",
+    "location": "CHARM Bistro Bangkok, Sukhumvit 50, Phra Khanong, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/303972408/",
+    "attendees": 19
+  },
+  {
+    "title": "The 2nd Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2024-09-28",
+    "startTime": "14:45",
+    "location": "OM GANESH INDIAN RESTAURANT, 12/3 Sukhumvit 50 Aly, Phra Khanong, Khlong Toei, Bangkok 10260, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/303171520/",
+    "attendees": 51
+  },
+  {
+    "title": "The Inaugural Bangkok Weekend Trail Walk & Run (BSSH3)",
+    "date": "2024-08-31",
+    "startTime": "14:45",
+    "location": "OM GANESH INDIAN RESTAURANT, 12/3 Sukhumvit 50 Aly, Phra Khanong, Khlong Toei, Bangkok 10260, Bangkok, TH",
+    "url": "https://www.meetup.com/bangkok-weekend-walk-run-adventure-group/events/302960090/",
+    "attendees": 18
+  }
+]

--- a/scripts/data/ch3-nc-meetup-history-batch-1.json
+++ b/scripts/data/ch3-nc-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Charlotte H3 Trail #1238 - Just Alex gets nameD!",
+    "date": "2026-04-04",
+    "startTime": "14:00",
+    "location": "410 E 35th Street Parking Lot, 410 E 35th Street410 E 35th St, Charlotte, NC 28205, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/313507710/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte H3 Trail #1237 - Ides of St Paddy's Day Past",
+    "date": "2026-03-21",
+    "startTime": "14:00",
+    "location": "Robert L Smith Park, 1604 Little Rock Road, Charlotte 28214, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/313507671/",
+    "attendees": 3
+  },
+  {
+    "title": "March MMm DP",
+    "date": "2026-03-10",
+    "startTime": "18:30",
+    "location": "Lucky Lou's Tavern, 5124 Park Rd., Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/313115067/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte H3 Trail #1236 - A Mystery Trail!",
+    "date": "2026-03-07",
+    "startTime": "14:00",
+    "location": "Hornets Nest Park, 6301 Beatties Ford Road, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/312975558/",
+    "attendees": 5
+  },
+  {
+    "title": "Charlotte H3 Trail #1235 - An East Charlotte Snow Melt Trail!",
+    "date": "2026-02-07",
+    "startTime": "14:00",
+    "location": "Plaza, 4545 The Plaza, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/312736345/",
+    "attendees": 6
+  },
+  {
+    "title": "February MMm DP",
+    "date": "2026-02-03",
+    "startTime": "18:00",
+    "location": "Steamers Sports Pub, 1513 Pierson Dr, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/313115045/",
+    "attendees": 1
+  },
+  {
+    "title": "Charlotte H3 Drinking Practice & Erections (& Soup Cook off)",
+    "date": "2026-01-24",
+    "startTime": "14:00",
+    "location": "Park Road Pub, 10403 Park Road Suite H, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/312736334/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte H3 Trail #1235 - Erections (Elections) & SOUP Cook off",
+    "date": "2026-01-10",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/311796266/",
+    "attendees": 5
+  },
+  {
+    "title": "Charlotte H3 Trail #1234 - Santa Scavenger Hunt",
+    "date": "2025-12-20",
+    "startTime": "14:00",
+    "location": "Parking Lot, 705 W. 4th St, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/311795975/",
+    "attendees": 1
+  },
+  {
+    "title": "Charlotte H3 Trail #1233 - White Elephant & Toys for Twats",
+    "date": "2025-12-06",
+    "startTime": "14:00",
+    "location": "Park Road Pub, 10403 Park Road Suite H, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/311795915/",
+    "attendees": 5
+  },
+  {
+    "title": "Charlotte H3 Trail #1232 - Sip & Craft Friendsgiving!",
+    "date": "2025-11-22",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/311347011/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte H3 Trail #1231 - Veterans Day!",
+    "date": "2025-11-15",
+    "startTime": "13:00",
+    "location": "Kirk Farm Park, 210 E Mallard Creek Church Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/311347005/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte H3 Trail #1230 - Chasing the Goose!",
+    "date": "2025-11-08",
+    "startTime": "14:00",
+    "location": "S Church St, Charlotte, No, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/311346975/",
+    "attendees": 3
+  },
+  {
+    "title": "Rat Flashes Hash! A CH3 & CLTH3 Hash Event!",
+    "date": "2025-11-01",
+    "startTime": "12:00",
+    "location": "Ghost Tattoo Studios, 3216 South Blvd #204, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/311795955/",
+    "attendees": 1
+  },
+  {
+    "title": "Charlotte H3 Thirsty Thursday @ TBD",
+    "date": "2025-10-30",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310652367/",
+    "attendees": 1
+  },
+  {
+    "title": "Charlotte H3 Thirsty Thursday @ TBD",
+    "date": "2025-10-23",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/311346900/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte H3 Trail #1229 - Pink Dress",
+    "date": "2025-10-11",
+    "startTime": "06:30",
+    "location": "Symphony Park, 4400 Sharon Road, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310652764/",
+    "attendees": 5
+  },
+  {
+    "title": "Charlotte H3 Trail #1229 - A White Trash Birthday!",
+    "date": "2025-10-04",
+    "startTime": "14:00",
+    "location": "Cavendish Brewing Company, 207 N Chester St, Gastonia, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310652558/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte H3 Thirsty Thursday @ TBD",
+    "date": "2025-10-02",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310652354/",
+    "attendees": 1
+  },
+  {
+    "title": "Charlotte H3 Trail #1228 - Hash der Deutsche Einheit",
+    "date": "2025-09-27",
+    "startTime": "14:00",
+    "location": "Camp North End, 1774 Statesville Ave, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310652410/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte H3 Trail #1227 - Yellow Dress",
+    "date": "2025-09-20",
+    "startTime": "14:00",
+    "location": "19 Church St S Parking, 19 Church St S,, Concord, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310652401/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte H3 Thirsty Thursday @ McHale's Pub",
+    "date": "2025-09-18",
+    "startTime": "18:30",
+    "location": "McHale's Pub, 3112 N Davidson St, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310652344/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte H3 Thirsty Thursday @ McHale's Pub",
+    "date": "2025-09-04",
+    "startTime": "18:30",
+    "location": "McHale's Pub, 3112 N Davidson St, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310652301/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte H3 Trail #1226 - A Hot Ho Trail!",
+    "date": "2025-08-30",
+    "startTime": "14:00",
+    "location": "Reid Park, 3215 Amay James Ave,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310349050/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte H3 Thirsty Thursday @ Armored Cow!",
+    "date": "2025-08-21",
+    "startTime": "18:30",
+    "location": "Armored Cow Brewing Co, 8821 JW Clay Blvd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310346363/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte H3 Trail #1225 - Proud Pride Moms Hash",
+    "date": "2025-08-16",
+    "startTime": "12:00",
+    "location": "South Church Street Parking Garage, 206 S Church St, Charlotte, NC 28202, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310109905/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte H3 Thirsty Thursday @ Lucky Lou's!",
+    "date": "2025-08-07",
+    "startTime": "18:30",
+    "location": "Lucky Lou's Tavern, 5124 Park Road, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310110469/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte H3 Trail # 1224 - Street hits the Charlotte Streets!",
+    "date": "2025-08-02",
+    "startTime": "14:00",
+    "location": "Northridge Middle School, 7601 The Plaza, Charlotte, NC, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310108828/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte H3 Thirsty Thursday @ T Street Tavern",
+    "date": "2025-07-24",
+    "startTime": "18:30",
+    "location": "Thomas Street Tavern, 1228 Thomas Street, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/310110254/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte House Harriers - Trail #1222 - Juluau: Everyone Gets Leid!",
+    "date": "2025-07-05",
+    "startTime": "14:00",
+    "location": "Harrisburg Road Sports Comlex, 8045 Harrisburg Rd., Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/308793732/",
+    "attendees": 5
+  },
+  {
+    "title": "CH3 2025 Family Reunion Campout 2",
+    "date": "2025-06-27",
+    "startTime": "08:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/307745107/",
+    "attendees": 6
+  },
+  {
+    "title": "Whiskey Wednesday with Charlotte House Harries @ Sidelines",
+    "date": "2025-06-25",
+    "startTime": "18:30",
+    "location": "Sidelines Sports Bar & Billiards, 4544 South Blvd, Suite C, Charlotte, nc, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/308315030/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte House Harriers Trail #1219 - Theme: Sip & Craft (Summer Addition!)",
+    "date": "2025-06-21",
+    "startTime": "14:00",
+    "location": "McDowell Nature Preserve, 15222 York Rd,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/308313778/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte House Harriers Trail #1218 - 🌈 Gaudy, Prismatic, & Flashy 🌈",
+    "date": "2025-06-14",
+    "startTime": "14:00",
+    "location": "Neighborhood Coffee Roasters, 3646 Central Ave, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/308313669/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday with Charlotte House Harries @ Pineville Tavern",
+    "date": "2025-06-12",
+    "startTime": "18:30",
+    "location": "Pineville Tavern, 314 N Polk St, Pineville, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/308314372/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte House Harriers #1217 - Butterfly 🦋 Awareness Day Trail",
+    "date": "2025-06-07",
+    "startTime": "14:00",
+    "location": "Reedy Creek Nature Preserve and Park, 2900 Rocky River Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/308238918/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday with Charlotte House Harries @ Carmella’s on South Tryon",
+    "date": "2025-05-29",
+    "startTime": "18:30",
+    "location": "Carmella's Pizza, 8124 South Tryon Street, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/307793688/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte House Harriers - Trail #1216 - Thrifty Trail",
+    "date": "2025-05-24",
+    "startTime": "13:00",
+    "location": "Bargain Hunters, 7020 Albemarle Road, 28227,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/307793835/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday with Charlotte House Harries @ Park Road Pub",
+    "date": "2025-05-15",
+    "startTime": "18:30",
+    "location": "Park Road Pub, 10403 Park Road Suite H, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/307793228/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte House Harriers - Trail# 1215",
+    "date": "2025-05-10",
+    "startTime": "14:00",
+    "location": "Sugar creek station, 4020 Raleigh St, ,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/307571878/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte House Harriers!!! Trail # 1214 Just Another Saturday",
+    "date": "2025-04-26",
+    "startTime": "14:00",
+    "location": "Ballantyne Parks, 11611 N Community House Rd, 11611 N Community House Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/307327058/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte House Harriers, Trail # 1212 - A Hancock House Warming",
+    "date": "2025-04-12",
+    "startTime": "14:00",
+    "location": "Druid Hills Park, 8363 Poinsett St.,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306915329/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte House Harriers!!! Trail # 1211 Sip and Craft……",
+    "date": "2025-03-29",
+    "startTime": "14:00",
+    "location": "McDowell Nature Preserve @ Lake Wylie, 15222 York Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306915196/",
+    "attendees": 2
+  },
+  {
+    "title": "Thirsty Thursday with the Charlotte House Harriers!!!",
+    "date": "2025-03-27",
+    "startTime": "18:30",
+    "location": "Goldies, 3601 South Blvd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306780849/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte House Harriers, Trail #1210, The Ides (ish) of St Paddy's Day themed",
+    "date": "2025-03-22",
+    "startTime": "14:00",
+    "location": "Rosedale Dog Park, 9705 Rosewood Meadow Ln, Huntersville, NC 28078,, Huntersville, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306560787/",
+    "attendees": 6
+  },
+  {
+    "title": "Thirsty Thursday with Charlotte House Harries @ Lucky Lou’s",
+    "date": "2025-03-20",
+    "startTime": "18:30",
+    "location": "Lucky Lou's Tavern, 5124 Park Road, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306780261/",
+    "attendees": 1
+  },
+  {
+    "title": "Thirsty Thursday with Charlotte House Harries @ The Common Market",
+    "date": "2025-03-06",
+    "startTime": "18:30",
+    "location": "The Common Market, 235 W Tremount Ave,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306370185/",
+    "attendees": 4
+  },
+  {
+    "title": "Charlotte House Harriers, Trail #1209, Carnival / Mardi Gras themed",
+    "date": "2025-03-01",
+    "startTime": "14:00",
+    "location": "Pasta & Provisions on Park, 4700 Park Road, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306124707/",
+    "attendees": 3
+  },
+  {
+    "title": "Thirsty Thursday with Charlotte House Harries @ Hattie's Tap and Tavern",
+    "date": "2025-02-20",
+    "startTime": "19:00",
+    "location": "Hattie's Tap & Tavern, 2918 The Plaza, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306209709/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte House Harriers, Trail #1208, We have a Hashiversary!!!",
+    "date": "2025-02-15",
+    "startTime": "14:00",
+    "location": "Park Denistry, 11940 Carolina Place Parkway,, Pineville, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/306124581/",
+    "attendees": 2
+  }
+]

--- a/scripts/data/ch3-nc-meetup-history-batch-2.json
+++ b/scripts/data/ch3-nc-meetup-history-batch-2.json
@@ -1,0 +1,290 @@
+[
+  {
+    "title": "Thirsty Thursday with the Charlotte House Harriers!!!!",
+    "date": "2025-02-06",
+    "startTime": "19:00",
+    "location": "Snug Harbor, 1228 Gordon St, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/305971043/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte House Harriers, Trail #1207 Wholly Roll",
+    "date": "2025-02-01",
+    "startTime": "14:00",
+    "location": "1712 J N Pease Pl, Charlotte, NC 28262-4506, United States, 1712 J N Pease Pl, ,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/305872359/",
+    "attendees": 5
+  },
+  {
+    "title": "Charlotte Hash Harriers Trail #1206 - A Trash Trail!!",
+    "date": "2025-01-25",
+    "startTime": "14:00",
+    "location": "Elizabeth Park, 101 N Kings Drive,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/305626729/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte Hash Harriers Trail #1205 - Noda Trek",
+    "date": "2025-01-18",
+    "startTime": "14:00",
+    "location": "Alexander Park, 910 N Alexander Street ,, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/305626684/",
+    "attendees": 3
+  },
+  {
+    "title": "Thirsty Thursday with the Charlotte House Harriers!!!",
+    "date": "2025-01-16",
+    "startTime": "18:30",
+    "location": "Flying Saucer, 9605 N. Tryon St., Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/305499542/",
+    "attendees": 1
+  },
+  {
+    "title": "Thirsty Thursday with Charlotte House Harriers!!!",
+    "date": "2025-01-09",
+    "startTime": "18:30",
+    "location": "Park Road Pub, 10403 Park Road Suite H, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/305458129/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail #1204 Elections & Chili Cook Off!",
+    "date": "2025-01-04",
+    "startTime": "14:00",
+    "location": "Former Rite Aid, 15225 John H Delaney Drive, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/305302396/",
+    "attendees": null
+  },
+  {
+    "title": "Trail #1203 Santa Scavenger Hunt",
+    "date": "2024-12-21",
+    "startTime": "14:00",
+    "location": "Parking Lot, 705 W. 4th St, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/303628501/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail #1202 Toys for Twats",
+    "date": "2024-12-07",
+    "startTime": "14:00",
+    "location": "Park Road Pub, 10403 Park Road Suite H, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/303628470/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #1201 Turkey Trot",
+    "date": "2024-11-23",
+    "startTime": "14:00",
+    "location": "Trail 1201, 2734 Rozzelles Ferry Road, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/303628436/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #1200 Disaster Relief Trail",
+    "date": "2024-11-09",
+    "startTime": "13:00",
+    "location": "Park Road Pub (Alley), 10403 Park Rd H, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/303628431/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #1199 Mrs. Roper Pub Crawl",
+    "date": "2024-11-02",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/303628430/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #1198",
+    "date": "2024-10-26",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/303628408/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #1197 Pink Dress!",
+    "date": "2024-10-05",
+    "startTime": "07:00",
+    "location": "Pink Dress Start, 705 W. 4th St, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/303628403/",
+    "attendees": 1
+  },
+  {
+    "title": "Midget's and Dingle's First Rodeo (Trail #1195)",
+    "date": "2024-08-31",
+    "startTime": "14:00",
+    "location": "Trail start, 7025 Northwinds Dr NW, Concord, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/303084627/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #1194 Oh and the hares",
+    "date": "2024-08-17",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/302689272/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #1193 Dingle acquires an out of town hare",
+    "date": "2024-08-03",
+    "startTime": "13:00",
+    "location": "GGDB, 5024 Aster View Lane, Apt E, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/302514285/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail 1192 Running of the Bulls Hash",
+    "date": "2024-07-20",
+    "startTime": "14:00",
+    "location": "Park Road Pub (Alley), 10403 Park Rd H, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/302280657/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail 1191 \"Fourth of Juluau (aka Everyone get's Lei'd)\"",
+    "date": "2024-07-06",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/301734081/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #1190",
+    "date": "2024-06-22",
+    "startTime": "14:00",
+    "location": "13515 Ballantyne Corporate Pl, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/301703279/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail # 1188",
+    "date": "2024-05-25",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/301127488/",
+    "attendees": 4
+  },
+  {
+    "title": "\"This is Screamer's Fault\" - A Squeaky trail",
+    "date": "2024-05-11",
+    "startTime": "14:00",
+    "location": "6994 Old Lawyers Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/300870641/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte H3 Trail #1186 FORT MILL BABAAAAYYYY!!!!",
+    "date": "2024-04-27",
+    "startTime": "14:00",
+    "location": "205 N White St, Fort Mill, SC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/300448452/",
+    "attendees": 2
+  },
+  {
+    "title": "Charlotte H3 Trail #1185 Punchy is Going for the Patch!",
+    "date": "2024-04-13",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/300019455/",
+    "attendees": 5
+  },
+  {
+    "title": "CH3 Trail #1184 Over the Hill - Shocker Turns 40!",
+    "date": "2024-03-30",
+    "startTime": "14:00",
+    "location": "9724 Industrial Dr, Pineville, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/299640197/",
+    "attendees": 2
+  },
+  {
+    "title": "CH3 Trail #1183 Green Dress Run!",
+    "date": "2024-03-16",
+    "startTime": "14:00",
+    "location": "12206 Copper Way, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/299640089/",
+    "attendees": 11
+  },
+  {
+    "title": "CH3 Trail #1182 Packin a Hot U's And Just Cici's Suessical Trail",
+    "date": "2024-03-02",
+    "startTime": "14:00",
+    "location": "Kirk Farm Fields Park, 210 E Mallard Creek Church Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/299475026/",
+    "attendees": 3
+  },
+  {
+    "title": "SUN H3 / Charlotte H3 Trail #1181",
+    "date": "2024-02-24",
+    "startTime": "16:30",
+    "location": "943 W Sugar Creek Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/299141536/",
+    "attendees": 3
+  },
+  {
+    "title": "Charlotte H3 Trail #1180",
+    "date": "2024-02-17",
+    "startTime": "14:00",
+    "location": "7501 E Independence Blvd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/299046430/",
+    "attendees": 5
+  },
+  {
+    "title": "CLTH3 Trail #1178 No Nip and Dingle's Excellent Adventure",
+    "date": "2024-01-20",
+    "startTime": "14:00",
+    "location": "Lucky Lou's Tavern, 5124 Park Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/298577959/",
+    "attendees": 7
+  },
+  {
+    "title": "CH3 Trail #1174 - Just Caitlin get a name",
+    "date": "2023-12-02",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/297224939/",
+    "attendees": 10
+  },
+  {
+    "title": "Thanksgiving Turkey Trail - CH3 Trail #1173",
+    "date": "2023-11-25",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/297224892/",
+    "attendees": 9
+  },
+  {
+    "title": "CH3 Trail #1172 Veterans Day Trail / Charlene Gets a name!",
+    "date": "2023-11-11",
+    "startTime": "14:00",
+    "location": "10325 Pineshadow Dr, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/297224712/",
+    "attendees": 4
+  },
+  {
+    "title": "Southeastern Degenerates Mrs. Roper Pub Crawl",
+    "date": "2023-10-07",
+    "startTime": "14:00",
+    "location": "125 Scaleybark Rd, Charlotte, NC, US",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/296519608/",
+    "attendees": 1
+  },
+  {
+    "title": "Blue Ball!",
+    "date": "2022-11-12",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/289518431/",
+    "attendees": 3
+  },
+  {
+    "title": "CHARLOTTE PINK DRESS!",
+    "date": "2022-10-08",
+    "startTime": "07:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlotte-hash-house-harriers/events/288825561/",
+    "attendees": 3
+  }
+]

--- a/scripts/data/chh3-meetup-history-batch-1.json
+++ b/scripts/data/chh3-meetup-history-batch-1.json
@@ -1,0 +1,154 @@
+[
+  {
+    "title": "CHH3 Trail #682 - Turkeys n Tutus",
+    "date": "2025-11-22",
+    "startTime": "14:00",
+    "location": "PETCO, 975 Savannah Hwy, Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/312117043/",
+    "attendees": 4
+  },
+  {
+    "title": "CHH3 Trail #681 - Hashoween",
+    "date": "2025-11-08",
+    "startTime": "14:00",
+    "location": "Container Bar, 2130 Mt. Pleasant Street,, Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/311862401/",
+    "attendees": 4
+  },
+  {
+    "title": "World Peace Thru Beer",
+    "date": "2025-10-25",
+    "startTime": "14:00",
+    "location": "Rebel Taqueria, 1809 Reynolds Ave, North Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/311660625/",
+    "attendees": 3
+  },
+  {
+    "title": "Heretics White Dress Run",
+    "date": "2025-09-27",
+    "startTime": "14:00",
+    "location": "Cannon Park, 131 Rutledge Avenue, Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/311174958/",
+    "attendees": 7
+  },
+  {
+    "title": "Heretics Trail 675- Sip and Stroll",
+    "date": "2025-07-26",
+    "startTime": "16:00",
+    "location": "A Members House, 1305 Waxwing Way, Hanahan, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/310093809/",
+    "attendees": 2
+  },
+  {
+    "title": "Heretics Trail #670 Once Upon a Hash",
+    "date": "2025-05-24",
+    "startTime": "14:00",
+    "location": "Across the Street from LoLa, 1072 Empire Ave, North Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/307962983/",
+    "attendees": 1
+  },
+  {
+    "title": "Charleston Heretics H3 Trail 666- Mark of the Hares",
+    "date": "2025-03-22",
+    "startTime": "14:00",
+    "location": "Horse Lot Park, 2 Chisholm St, Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/306780135/",
+    "attendees": 2
+  },
+  {
+    "title": "Charleston Heretics H3 Trail #664 The Golden GILFs Pub Run and Snail Trail",
+    "date": "2025-02-22",
+    "startTime": "14:00",
+    "location": "Gadsdenboro Park, 303 Concord Street, Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/306234297/",
+    "attendees": 1
+  },
+  {
+    "title": "CHH3 Trail #663 - Circle Jerk",
+    "date": "2025-02-08",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlestonheretics/events/306057932/",
+    "attendees": 3
+  },
+  {
+    "title": "CHH3 Trail #662 - Choose your own adventure exploration",
+    "date": "2025-01-25",
+    "startTime": "14:00",
+    "location": "Park Circle, 4800 Park Cir, North Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/305598526/",
+    "attendees": 13
+  },
+  {
+    "title": "CHH3 Trail #661 - Nature's Calling",
+    "date": "2025-01-11",
+    "startTime": "14:00",
+    "location": "Dungannon Plantation Heritage Preserve/Wildlife Management Area, Hollywood, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/305426744/",
+    "attendees": 4
+  },
+  {
+    "title": "CHH3 Trail #658 - Combined event with Grand Strand",
+    "date": "2024-11-16",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlestonheretics/events/304576489/",
+    "attendees": 1
+  },
+  {
+    "title": "ROGUE DP - Super Duper Beaver Full Moon DP",
+    "date": "2024-11-15",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlestonheretics/events/304548468/",
+    "attendees": 1
+  },
+  {
+    "title": "White Dress Run weekend",
+    "date": "2024-11-09",
+    "startTime": "16:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlestonheretics/events/304019665/",
+    "attendees": 5
+  },
+  {
+    "title": "World Peace Through Beer",
+    "date": "2024-10-26",
+    "startTime": "14:00",
+    "location": "125 Fairchild Street, Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/304181137/",
+    "attendees": 3
+  },
+  {
+    "title": "CHH3 Trail # 654 - Everyone Sucks Trail",
+    "date": "2024-10-12",
+    "startTime": "16:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlestonheretics/events/303942646/",
+    "attendees": 2
+  },
+  {
+    "title": "Taco Tuesday! (DP)",
+    "date": "2024-10-08",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlestonheretics/events/303847335/",
+    "attendees": 2
+  },
+  {
+    "title": "CHH3 Trail# 649",
+    "date": "2024-07-27",
+    "startTime": "16:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/charlestonheretics/events/302391875/",
+    "attendees": 1
+  },
+  {
+    "title": "CHH3 Trail #648 - Fullish Moon Trail",
+    "date": "2024-07-23",
+    "startTime": "18:30",
+    "location": "Charleston City Marina, 17 Lockwood Dr., Charleston, SC, US",
+    "url": "https://www.meetup.com/charlestonheretics/events/302299108/",
+    "attendees": 3
+  }
+]

--- a/scripts/data/cleh4-meetup-history-batch-1.json
+++ b/scripts/data/cleh4-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "CH4 Trail #8-something and some: Airshow Hash!",
+    "date": "2024-08-31",
+    "startTime": "14:00",
+    "location": "Lopresti Union Club Bar, 2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/302868011/",
+    "attendees": 12
+  },
+  {
+    "title": "Christmas Story Hash! Trail #839",
+    "date": "2023-12-16",
+    "startTime": "14:00",
+    "location": "Rowley Inn, 1104 Rowley Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/296651295/",
+    "attendees": 19
+  },
+  {
+    "title": "CH4 Trail #8-something or other: Airshow Hash!",
+    "date": "2023-09-02",
+    "startTime": "14:00",
+    "location": "2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/295468242/",
+    "attendees": 11
+  },
+  {
+    "title": "CH4's 5th Saturday with Rubber City",
+    "date": "2023-07-29",
+    "startTime": "15:00",
+    "location": "Edgewater Beach House, 7600 Cleveland Memorial Shoreway, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/293822496/",
+    "attendees": 12
+  },
+  {
+    "title": "CH4 Trail #869-ish: Xmas Story Hash!",
+    "date": "2022-12-17",
+    "startTime": "14:00",
+    "location": "Clark Bar, 1201 Clark Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/289052081/",
+    "attendees": 21
+  },
+  {
+    "title": "CH4 Trail #8-something or other: Airshow Hash!",
+    "date": "2022-09-03",
+    "startTime": "14:00",
+    "location": "2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/287618507/",
+    "attendees": 11
+  },
+  {
+    "title": "5th Saturday of July - Trail # 832 Joint Trail with Rubber City H3",
+    "date": "2022-07-30",
+    "startTime": "14:00",
+    "location": "Whiskey Island Still & Eatery, 2800 Whiskey Island Dr, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/286674756/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 Trail 831 - Visiting Hare",
+    "date": "2022-06-18",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/286607338/",
+    "attendees": 8
+  },
+  {
+    "title": "CH4 Trail #800-something: Xmas Story Hash!",
+    "date": "2021-12-18",
+    "startTime": "13:00",
+    "location": "Clark Bar, 1201 Clark Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/281546486/",
+    "attendees": 21
+  },
+  {
+    "title": "CH4 Trail #8-something: Airshow Hash!",
+    "date": "2021-09-04",
+    "startTime": "14:00",
+    "location": "2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/280335696/",
+    "attendees": 15
+  },
+  {
+    "title": "5th Saturday CAkronLand Trail - Halloween",
+    "date": "2020-10-31",
+    "startTime": "14:00",
+    "location": "1000 Old Mill Rd, Aurora, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/273914874/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #827: Cleveland comes to Akron....again",
+    "date": "2020-10-03",
+    "startTime": "14:00",
+    "location": "1267 Murray Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/273582915/",
+    "attendees": 11
+  },
+  {
+    "title": "CH4 Trail #826: Spike's Goodbye Hash",
+    "date": "2020-09-05",
+    "startTime": "14:00",
+    "location": "2316 Mulberry Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/272550899/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 Trail #825: Airshow Hash!",
+    "date": "2020-08-29",
+    "startTime": "14:00",
+    "location": "2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/272550422/",
+    "attendees": 9
+  },
+  {
+    "title": "CH4 Trail #824: A Frolic in the Wood",
+    "date": "2020-07-18",
+    "startTime": "14:00",
+    "location": "Euclid Creek Upper Highland Picinic Area, Euclid, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/271679894/",
+    "attendees": 5
+  },
+  {
+    "title": "CH4 Trail #823: Coming to you live from Akron!",
+    "date": "2020-06-20",
+    "startTime": "14:30",
+    "location": "499 Memorial Pkwy, Akron, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/271338627/",
+    "attendees": 5
+  },
+  {
+    "title": "TIMES CHANGED!! CHECK AGAIN BEFORE DRIVING!! CH4 Trail #822: A taste of Tremont",
+    "date": "2020-06-06",
+    "startTime": "15:00",
+    "location": "The Treehouse, 820 College Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/271036435/",
+    "attendees": 16
+  },
+  {
+    "title": "CH4 Trail #820: Groundhog's Day Hash",
+    "date": "2020-02-01",
+    "startTime": "15:00",
+    "location": "Mulberry's, 2316 Mulberry Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/267756611/",
+    "attendees": 7
+  },
+  {
+    "title": "CH4 Trail #819: XMAS STO-errr New Year Hash?",
+    "date": "2020-01-04",
+    "startTime": "14:00",
+    "location": "Prosperity Social Club, 1109 Starkweather Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/267119698/",
+    "attendees": 13
+  },
+  {
+    "title": "CH4 Trail #818",
+    "date": "2019-12-07",
+    "startTime": "14:00",
+    "location": "4611 Derbyshire Dr, North Randall, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/266999154/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #817: Short but Sweet",
+    "date": "2019-10-19",
+    "startTime": "14:00",
+    "location": "McCarthy's Downtown, 1231 Main Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/265683519/",
+    "attendees": 1
+  },
+  {
+    "title": "CH4 Trail #816",
+    "date": "2019-10-05",
+    "startTime": "14:00",
+    "location": "Ugly Broad Tavern, 3908 Denison Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/265309295/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 Trail #814: Fun in the Sun",
+    "date": "2019-09-07",
+    "startTime": "14:00",
+    "location": "Terrestrial Brewing Company, 7524 Father Frascati, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/264548821/",
+    "attendees": 4
+  },
+  {
+    "title": "Cleveland Air Show Hash: SSBB",
+    "date": "2019-08-31",
+    "startTime": "14:00",
+    "location": "Lopresti Union Club Bar & Restaurant, 2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/264196110/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 Trail #812: Backslider",
+    "date": "2019-08-17",
+    "startTime": "15:00",
+    "location": "Tavern Of Little Italy, 12117 Mayfield Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/263997652/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 Trail #811",
+    "date": "2019-07-20",
+    "startTime": "14:00",
+    "location": "Ugly Broad Tavern, 3908 Denison Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/262988140/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 Trail #810",
+    "date": "2019-07-06",
+    "startTime": "14:00",
+    "location": "Mullen's of Letterfrack, 17014 Madison Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/262617277/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #809",
+    "date": "2019-06-15",
+    "startTime": "14:00",
+    "location": "Five O'Clock Lounge, 11904 Detroit Avenue, Lakewood, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/262266237/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 Trail #809",
+    "date": "2019-06-12",
+    "startTime": "14:00",
+    "location": "Five O'Clock Lounge, 11904 Detroit Avenue, Lakewood, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/262260506/",
+    "attendees": 1
+  },
+  {
+    "title": "CH4 Trail #808: Watch You’re F*cking Mouth",
+    "date": "2019-06-01",
+    "startTime": "14:00",
+    "location": "HWD, 4893 Fairlawn Rd, Lyndhurst, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/261860968/",
+    "attendees": 1
+  },
+  {
+    "title": "CH4 Trail #807",
+    "date": "2019-05-18",
+    "startTime": "15:00",
+    "location": "The River Tavern, 3511-1 Lost Nation Rd, Willoughby, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/261484718/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 Trail #806",
+    "date": "2019-05-04",
+    "startTime": "15:00",
+    "location": "Thirsty Dog East Bank, 1085 Old River Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/261062015/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 Trail #805",
+    "date": "2019-04-20",
+    "startTime": "14:00",
+    "location": "Hoopples, 1930 Columbus Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/260671978/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 Trail #804",
+    "date": "2019-04-06",
+    "startTime": "14:00",
+    "location": "Ugly Broad Tavern, 3908 Denison Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/260361990/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #803",
+    "date": "2019-03-16",
+    "startTime": "14:00",
+    "location": "2316 Mulberry Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/259718952/",
+    "attendees": 5
+  },
+  {
+    "title": "CH4 Trail #802",
+    "date": "2019-03-02",
+    "startTime": "14:00",
+    "location": "9829 Lake Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/259307980/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 Trail #801",
+    "date": "2019-02-16",
+    "startTime": "15:00",
+    "location": "The 1899 Pub, 38228 Glenn Ave, Willoughby, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/258958581/",
+    "attendees": 5
+  },
+  {
+    "title": "CH4 Trail #800",
+    "date": "2019-02-02",
+    "startTime": "15:00",
+    "location": "Granite City Food & Brewery Eagan, 24519 Cedar Rd, Cleveland, Oh, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420681/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #799",
+    "date": "2019-01-19",
+    "startTime": "14:00",
+    "location": "Mulberry's, 2316 Mulberry Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420657/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #798",
+    "date": "2019-01-05",
+    "startTime": "15:00",
+    "location": "The Flying Monkey Pub, Tremont Ohio, 819 Jefferson Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420609/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 Trail #797 - 5th Saturday",
+    "date": "2018-12-29",
+    "startTime": "15:00",
+    "location": "Winking Lizard Tavern, 1615 Main Street, Peninsula, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420529/",
+    "attendees": 4
+  },
+  {
+    "title": "Burning Stunt Liver",
+    "date": "2018-12-23",
+    "startTime": "11:00",
+    "location": "Muni Lot, 1535 S Marginal Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/257324903/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 Trail #796 - Christmas Story Hash",
+    "date": "2018-12-15",
+    "startTime": "14:00",
+    "location": "Hooples, 1930 Columbus Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420466/",
+    "attendees": 7
+  },
+  {
+    "title": "CH4 Trail #795",
+    "date": "2018-12-01",
+    "startTime": "14:00",
+    "location": "TBD, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420407/",
+    "attendees": 1
+  },
+  {
+    "title": "CH4 Trail #794",
+    "date": "2018-11-17",
+    "startTime": "15:00",
+    "location": "Mulberry's, 2316 Mulberry Street, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420369/",
+    "attendees": 1
+  },
+  {
+    "title": "CH4 Trail #793",
+    "date": "2018-11-03",
+    "startTime": "15:00",
+    "location": "The 1899 Pub, 38228 Glenn Ave, Willoughby, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420355/",
+    "attendees": 2
+  },
+  {
+    "title": "Burning Liver Trail/6 Hashes in 6 Days",
+    "date": "2018-10-23",
+    "startTime": "18:00",
+    "location": "Mulberry's, 2316 Mulberry Street, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/255717995/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 Trail #792",
+    "date": "2018-10-20",
+    "startTime": "15:00",
+    "location": "The 1899 Pub, 38228 Glenn Ave, Willoughby, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420331/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #791",
+    "date": "2018-10-06",
+    "startTime": "15:00",
+    "location": "Mulberry's, 2316 Mulberry Street, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420319/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 Trail #790/ Rubber City - 5th Saturday Joint Trail",
+    "date": "2018-09-29",
+    "startTime": "15:00",
+    "location": "Jimmy Bigg's Grill, 1927 State Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420278/",
+    "attendees": 6
+  }
+]

--- a/scripts/data/cleh4-meetup-history-batch-2.json
+++ b/scripts/data/cleh4-meetup-history-batch-2.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "CH4 Trail #789",
+    "date": "2018-09-15",
+    "startTime": "15:00",
+    "location": "Tavern Of Little Italy, 12117 Mayfield Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420185/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 Trail #787 - Air Show Hash",
+    "date": "2018-09-01",
+    "startTime": "15:00",
+    "location": "Lopresti Union Club Bar, 2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251420110/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #787",
+    "date": "2018-08-18",
+    "startTime": "15:00",
+    "location": "TBD, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251419994/",
+    "attendees": 1
+  },
+  {
+    "title": "CH4 Trail #786",
+    "date": "2018-08-04",
+    "startTime": "14:00",
+    "location": "Hoopples, 1930 Columbus Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251419840/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #785",
+    "date": "2018-07-21",
+    "startTime": "15:00",
+    "location": "Terrestrial Brewing Company, 7524 Father Frascati, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251419698/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #784 - Let's Monkey Around Hash",
+    "date": "2018-07-07",
+    "startTime": "14:00",
+    "location": "The Monkey Bar and Grill, 5517 Memphis Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251419601/",
+    "attendees": 7
+  },
+  {
+    "title": "CH4 Trail #783 - 3rd Saturday Trail",
+    "date": "2018-06-30",
+    "startTime": "15:00",
+    "location": "Brandywine Falls Parking Lot, 6863 Stanford Rd, Northfield, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251419429/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 Trail #782 - The CH4 Historic Running/Walking Tour",
+    "date": "2018-06-16",
+    "startTime": "15:00",
+    "location": "Little Bar and Grill, 614 Frankfort Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/250992582/",
+    "attendees": 7
+  },
+  {
+    "title": "CH4 Trail #781 - PG Trail",
+    "date": "2018-06-02",
+    "startTime": "15:00",
+    "location": "DePompeis, 811 Broadway Ave., Bedford, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/251301584/",
+    "attendees": 1
+  },
+  {
+    "title": "Cleveland H4 Trail #780",
+    "date": "2018-05-19",
+    "startTime": "15:00",
+    "location": "Flannery's Pub, 323 Prospect Avenue East, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/250914084/",
+    "attendees": 3
+  },
+  {
+    "title": "Cleveland H4 Hash #779 - Mayo",
+    "date": "2018-05-05",
+    "startTime": "14:00",
+    "location": "Parkview Niteclub, 1261 W.58th Street, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/250337847/",
+    "attendees": 3
+  },
+  {
+    "title": "Cleveland H4 Hash #778",
+    "date": "2018-04-21",
+    "startTime": "14:00",
+    "location": "Around the Corner Saloon & Cafe, 18616 Detroit Ave, Lakewood, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/249743083/",
+    "attendees": 4
+  },
+  {
+    "title": "Cleveland H4 Hash #776 - St. Paddy’s Day",
+    "date": "2018-03-17",
+    "startTime": "14:00",
+    "location": "Flat Iron Cafe, 1114 Center St, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/247887104/",
+    "attendees": 4
+  },
+  {
+    "title": "Cleveland H4 Hash #775 - Comic-Con",
+    "date": "2018-03-03",
+    "startTime": "14:00",
+    "location": "Hoopples, 1930 Columbus Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/247886964/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #744 - Magic!",
+    "date": "2018-02-17",
+    "startTime": "14:00",
+    "location": "The Flying Monkey Pub, 819 Jefferson Avenue, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/247834734/",
+    "attendees": 2
+  },
+  {
+    "title": "Cleveland H4 Hash #773",
+    "date": "2018-02-03",
+    "startTime": "14:00",
+    "location": "Mulberry's, 2316 Mulberry Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/247345767/",
+    "attendees": 4
+  },
+  {
+    "title": "33rd Analversary Hash #772",
+    "date": "2018-01-27",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/246946646/",
+    "attendees": 8
+  },
+  {
+    "title": "Cleveland H4 Hash #771",
+    "date": "2018-01-20",
+    "startTime": "14:00",
+    "location": "The 1899 Pub, 38228 Glenn Ave, Willoughby, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/246900265/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #770 - Perfect Season Hash (2 Prelubes)",
+    "date": "2018-01-06",
+    "startTime": "11:15",
+    "location": "Map Room, 1281 W 9th St, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/246516859/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 Trail #769 - The Christmas Story Hash",
+    "date": "2017-12-16",
+    "startTime": "14:00",
+    "location": "Hoopples, 1930 Columbus Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/245898315/",
+    "attendees": 9
+  },
+  {
+    "title": "CH4 #768 - Lifestyles of Dead Golfers Hash",
+    "date": "2017-12-02",
+    "startTime": "14:00",
+    "location": "Just Jay's House, 3549 Lytle Road, Shaker Heights, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/245442608/",
+    "attendees": 5
+  },
+  {
+    "title": "CH4 #766 - St. Peter's Basilica Consecration Remembrance Hash",
+    "date": "2017-11-18",
+    "startTime": "14:00",
+    "location": "Hoopples, 1930 Columbus Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/245105325/",
+    "attendees": 5
+  },
+  {
+    "title": "Burning Liver #2 - Revival/6 Hashes in 6 Days Kickoff!",
+    "date": "2017-10-24",
+    "startTime": "18:00",
+    "location": "Mulberry's, 2316 Mulberry Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/244356527/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 #765 - Hashing on the Westside",
+    "date": "2017-10-21",
+    "startTime": "14:00",
+    "location": "Five O'Clock Lounge, 11904 Detroit Avenue, Lakewood, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/244346310/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 #764 - ooOOOOooweeEEE Hash!",
+    "date": "2017-10-07",
+    "startTime": "15:00",
+    "location": "McCarthy’s Downtown, 1231 Main Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/243951769/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 / RCH3 #69ish - Yay FRIENDSHIP Hash",
+    "date": "2017-09-30",
+    "startTime": "15:00",
+    "location": "Lock 29 Overflow Parking Lot, 1787-1799 Mill St W, Peninsula, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/243717049/",
+    "attendees": 1
+  },
+  {
+    "title": "CH4 #763 - Hitler's Wet Dream BDAY HASH",
+    "date": "2017-09-16",
+    "startTime": "15:00",
+    "location": "HWD's Place, 4893 Fairlawn Rd, Lyndhurst, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/243212901/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 #782 - Boy are Poles FUN!",
+    "date": "2017-09-02",
+    "startTime": "15:00",
+    "location": "Payne Cafe, 3528 Payne Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/242964067/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 #781 - Always go Ass First",
+    "date": "2017-08-19",
+    "startTime": "15:00",
+    "location": "McCarthy’s Downtown, 1231 Main Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/242473755/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 #780 - Live Long",
+    "date": "2017-08-05",
+    "startTime": "15:00",
+    "location": "Buffalo Wild Wings, 26200 Harvard Road, Warrensville Heights, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/242093889/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 #759 - The Buddy System Trail",
+    "date": "2017-07-15",
+    "startTime": "15:00",
+    "location": "Indian Point Park, 12951 Seeley Rd, Painesville, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/241512724/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 #758 - What a C*nt's On Out!",
+    "date": "2017-07-01",
+    "startTime": "15:00",
+    "location": "Wildwood Park & Marina, 16975 Wildwood Dr., Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/240973346/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 #757 - Hot Tub Milk Machine's Hashy Birthday Trail",
+    "date": "2017-06-17",
+    "startTime": "15:00",
+    "location": "HWD & HTMM Mansion, 4893 Fairlawn Rd, Lyndhurst, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/240814190/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 #756 - Something Smells in the East Hash",
+    "date": "2017-06-03",
+    "startTime": "15:00",
+    "location": "New Heights Grill, 2206 Lee Road, Cleveland Heights, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/240460696/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 #755 - Remembrance Hash",
+    "date": "2017-05-20",
+    "startTime": "15:00",
+    "location": "Hoopples, 1930 Columbus Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/240011298/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 #754 - Ill Take some Shiggy Please Hash!",
+    "date": "2017-05-06",
+    "startTime": "15:00",
+    "location": "Meadows Picnic Area Brecksville Reservation, Cuyahoga Valley National Park, Brecksville, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/239702932/",
+    "attendees": 2
+  },
+  {
+    "title": "CH4 / RCH3 #69 - Good Old Fashioned Hootenanny Hash!",
+    "date": "2017-04-29",
+    "startTime": "15:00",
+    "location": "winking lizard, 1615 Main St, Peninsula, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/239428599/",
+    "attendees": 3
+  },
+  {
+    "title": "CH4 #752 - Easter Hash!",
+    "date": "2017-04-15",
+    "startTime": "14:00",
+    "location": "HWD & HTMM Mansion, 4893 Fairlawn Rd, Lyndhurst, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/238980571/",
+    "attendees": 8
+  },
+  {
+    "title": "CH4 #751 - Apral Fawls Hash",
+    "date": "2017-04-01",
+    "startTime": "15:00",
+    "location": "O'Reilly's Irish Pub, 13914 Cedar Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/238771116/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 #750 - St. Patrick's Day Hangover Hash",
+    "date": "2017-03-18",
+    "startTime": "14:00",
+    "location": "Flat Iron Cafe, 1114 Center St, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/238264754/",
+    "attendees": 4
+  },
+  {
+    "title": "CH4 #749 - What is that, poop?",
+    "date": "2017-03-04",
+    "startTime": "14:00",
+    "location": "2nd II None, 650 S Green, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/238053793/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 #748 - Assotope LIVES",
+    "date": "2017-02-18",
+    "startTime": "14:00",
+    "location": "Stadium Grill, 8330 Tyler Blvd, Mentor, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/237677314/",
+    "attendees": 5
+  },
+  {
+    "title": "CH4 #747",
+    "date": "2017-02-04",
+    "startTime": "14:00",
+    "location": "Market Garden Brewery, 1947 W 25th Street, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/237312140/",
+    "attendees": 6
+  },
+  {
+    "title": "CH4 #746",
+    "date": "2017-01-21",
+    "startTime": "14:00",
+    "location": "Brick and Barrel, 1844 Columbus Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/237031531/",
+    "attendees": 2
+  },
+  {
+    "title": "Burning Liver Full Moon #2",
+    "date": "2017-01-19",
+    "startTime": "20:00",
+    "location": "Chuck's Place, 3830 St. Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/237031500/",
+    "attendees": 1
+  },
+  {
+    "title": "Just Mike's Virgin Lay and CH4 AGM! #746",
+    "date": "2017-01-07",
+    "startTime": "14:00",
+    "location": "Painini's Bar And Grill, 1825 Coventry Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/236658075/",
+    "attendees": 3
+  },
+  {
+    "title": "NYE Hash #745",
+    "date": "2016-12-31",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/232810252/",
+    "attendees": 2
+  },
+  {
+    "title": "Third Saturday Hash #744",
+    "date": "2016-12-17",
+    "startTime": "14:00",
+    "location": "Harbor Inn, 1219 Main Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557681/",
+    "attendees": 4
+  },
+  {
+    "title": "First Saturday Hash #743",
+    "date": "2016-12-03",
+    "startTime": "14:00",
+    "location": "Rowley Inn, 1104 Rowley Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557670/",
+    "attendees": 9
+  },
+  {
+    "title": "Third Saturday Hash #742",
+    "date": "2016-11-19",
+    "startTime": "14:00",
+    "location": "ABC Tavern Up-Town, 11434 Uptown Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557659/",
+    "attendees": 3
+  }
+]

--- a/scripts/data/cleh4-meetup-history-batch-3.json
+++ b/scripts/data/cleh4-meetup-history-batch-3.json
@@ -1,0 +1,250 @@
+[
+  {
+    "title": "First Saturday Hash #741",
+    "date": "2016-11-05",
+    "startTime": "15:00",
+    "location": "Around the Corner, 18616 Detroit Ave, Lakewood, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557652/",
+    "attendees": 5
+  },
+  {
+    "title": "Halloween Hash #740",
+    "date": "2016-10-29",
+    "startTime": "15:00",
+    "location": "Two Bucks, 1637 Golden Gate Plaza, Mayfield Heights, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/232810139/",
+    "attendees": 3
+  },
+  {
+    "title": "Kyle \"Tranny Bait\" Hamblin Memorial Has",
+    "date": "2016-10-15",
+    "startTime": "15:00",
+    "location": "101 Bottles of Beer on the Wall, 115 N Willow St, Kent, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557648/",
+    "attendees": 2
+  },
+  {
+    "title": "1'st An*l Cle Sausage Fest #738",
+    "date": "2016-10-01",
+    "startTime": "15:00",
+    "location": "The Happy Dog, 5801 Detroit Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557640/",
+    "attendees": 9
+  },
+  {
+    "title": "Weekday Hash #737.5",
+    "date": "2016-09-22",
+    "startTime": "18:00",
+    "location": "Maple Lanes, 6918 St Clair Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/234286452/",
+    "attendees": 3
+  },
+  {
+    "title": "HWD Birthday Hash #737",
+    "date": "2016-09-17",
+    "startTime": "15:00",
+    "location": "The Hitler Estate, 4893 Fairlawn Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557624/",
+    "attendees": 7
+  },
+  {
+    "title": "Air Show Hash #736",
+    "date": "2016-09-03",
+    "startTime": "14:00",
+    "location": "Lopresti Union Club Bar, 2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557619/",
+    "attendees": 7
+  },
+  {
+    "title": "Third Saturday Hash #735",
+    "date": "2016-08-20",
+    "startTime": "15:00",
+    "location": "Sokolowski's University Inn, 1201 University Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557611/",
+    "attendees": 3
+  },
+  {
+    "title": "First Saturday Hash #734",
+    "date": "2016-08-06",
+    "startTime": "15:00",
+    "location": "Dante's Tap House & Restaurant, 13007 Chippewa Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557604/",
+    "attendees": 5
+  },
+  {
+    "title": "Fifth Saturday Hash #733",
+    "date": "2016-07-30",
+    "startTime": "15:00",
+    "location": "Black Forest, 4368 Mayfield Rd, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/232809707/",
+    "attendees": 8
+  },
+  {
+    "title": "Third Saturday Hash",
+    "date": "2016-07-16",
+    "startTime": "15:00",
+    "location": "Clark Bar, 1201 Clark Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557596/",
+    "attendees": 9
+  },
+  {
+    "title": "First Saturday Hash",
+    "date": "2016-07-02",
+    "startTime": "15:00",
+    "location": "DePompeis, 811 Broadway Ave., Bedford, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557587/",
+    "attendees": 3
+  },
+  {
+    "title": "Eerie Analversary 2016",
+    "date": "2016-07-01",
+    "startTime": "15:00",
+    "location": "Brushwood Folklore Center, 8881 Bailey Hill Rd, Sherman, NY, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/232228544/",
+    "attendees": 4
+  },
+  {
+    "title": "Third Saturday Hash",
+    "date": "2016-06-18",
+    "startTime": "15:00",
+    "location": "The Monkey Bar and Grill, 5517 Memphis Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557572/",
+    "attendees": 7
+  },
+  {
+    "title": "First Saturday Hash",
+    "date": "2016-06-04",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557558/",
+    "attendees": 8
+  },
+  {
+    "title": "Third Saturday Hash",
+    "date": "2016-05-21",
+    "startTime": "15:00",
+    "location": "West End Tavern, 18514 Detroit Ave, Lakewood, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557552/",
+    "attendees": 5
+  },
+  {
+    "title": "First Saturday Hash",
+    "date": "2016-05-07",
+    "startTime": "15:00",
+    "location": "Parkview Niteclub, 1261 W.58th Street, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557542/",
+    "attendees": 4
+  },
+  {
+    "title": "5th Saturday Hash with Akron",
+    "date": "2016-04-30",
+    "startTime": "15:00",
+    "location": "Latchaw House, 4893 Fairlawn Rd., Lyndhurst, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/228711994/",
+    "attendees": 5
+  },
+  {
+    "title": "Third Saturday Hash #725",
+    "date": "2016-04-16",
+    "startTime": "15:00",
+    "location": "Around the Corner Saloon & Cafe, 18616 Detroit Ave, Lakewood, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557533/",
+    "attendees": 13
+  },
+  {
+    "title": "First Saturday Tu-Tu Hash #724",
+    "date": "2016-04-02",
+    "startTime": "15:00",
+    "location": "Mulberry's, 2316 Mulberry Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557524/",
+    "attendees": 8
+  },
+  {
+    "title": "Third Saturday Hash #723",
+    "date": "2016-03-19",
+    "startTime": "15:00",
+    "location": "The Tree House, 820 College Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557502/",
+    "attendees": 8
+  },
+  {
+    "title": "First Saturday Hash #722",
+    "date": "2016-03-05",
+    "startTime": "14:00",
+    "location": "Becky's, 1762 E 18th St, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557494/",
+    "attendees": 12
+  },
+  {
+    "title": "Pinchy's Beerthday Hash (Eerie Hash)",
+    "date": "2016-02-20",
+    "startTime": "14:00",
+    "location": "Al-be-ON-ON Estate, 10160 Rt 6N, Albion, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/228711895/",
+    "attendees": 4
+  },
+  {
+    "title": "Third Saturday Hash #721",
+    "date": "2016-02-20",
+    "startTime": "14:00",
+    "location": "Muldoon's Saloon & Eatery, 1020 East 185th Street, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557325/",
+    "attendees": 1
+  },
+  {
+    "title": "First Saturday Hash",
+    "date": "2016-02-06",
+    "startTime": "14:00",
+    "location": "Parkview Tavern, 1261 West 58th St., Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557355/",
+    "attendees": 10
+  },
+  {
+    "title": "Fifth Saturday Hash with Akron",
+    "date": "2016-01-30",
+    "startTime": "14:00",
+    "location": "winking lizard, 1615 Main St, Peninsula, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557744/",
+    "attendees": 4
+  },
+  {
+    "title": "Third Saturday Hash - AGM Meeting",
+    "date": "2016-01-16",
+    "startTime": "14:00",
+    "location": "McCarthy’s Downtown, 1231 Main Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557207/",
+    "attendees": 4
+  },
+  {
+    "title": "First Saturday Hash/AGM",
+    "date": "2016-01-02",
+    "startTime": "14:00",
+    "location": "Sully's Side Street Saloon, 23108 Felch St, Warrensville Heights, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/227557148/",
+    "attendees": 2
+  },
+  {
+    "title": "Third Saturday Hash",
+    "date": "2015-12-19",
+    "startTime": "14:00",
+    "location": "Bier Markt, 1948 W 25th St, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/226842398/",
+    "attendees": 3
+  },
+  {
+    "title": "First Saturday Hash",
+    "date": "2015-12-05",
+    "startTime": "14:00",
+    "location": "Rowley Inn, 1104 Rowley Ave, Cleveland, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/226842157/",
+    "attendees": 8
+  },
+  {
+    "title": "Third Saturday Hash",
+    "date": "2015-11-21",
+    "startTime": "14:00",
+    "location": "Coventry Panini's Grill, 1825 Coventry Road, Cleveland Heights, OH, US",
+    "url": "https://www.meetup.com/cleveland-hash-house-harriers-and-harriettes/events/226841921/",
+    "attendees": 4
+  }
+]

--- a/scripts/data/ctrh3-meetup-history-batch-1.json
+++ b/scripts/data/ctrh3-meetup-history-batch-1.json
@@ -1,0 +1,170 @@
+[
+  {
+    "title": "CTrH3 Trail #2207",
+    "date": "2025-11-23",
+    "startTime": "13:00",
+    "location": "Trail, 3829 golfview road,, Hope mills, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/312020563/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2206",
+    "date": "2025-11-16",
+    "startTime": "13:00",
+    "location": "Trail, 4108 Raeford road,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/312020545/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2205 YELLOW DRESS RUN",
+    "date": "2025-11-09",
+    "startTime": "13:00",
+    "location": "Trail Location, 235 Person Street,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/311889163/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2204",
+    "date": "2025-11-02",
+    "startTime": "13:00",
+    "location": "Trail Location, 3501 N Main St,, Hope mills, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/311706042/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2203 HALLOWEEN COSTUME PUB CRAWL!!!",
+    "date": "2025-10-26",
+    "startTime": "13:00",
+    "location": "Trail Location, 455 Williams street,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/311689052/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2201 PURPLE DRESS",
+    "date": "2025-10-12",
+    "startTime": "13:00",
+    "location": "Trail, 2709 Breezewood Ave,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/311448072/",
+    "attendees": 5
+  },
+  {
+    "title": "CTrH3 Trail #2198",
+    "date": "2025-09-26",
+    "startTime": "13:00",
+    "location": "Trail Location, 235 Person Street,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/311228481/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2198 STREET CLEAN TRAIL",
+    "date": "2025-09-21",
+    "startTime": "13:00",
+    "location": "35.1340786, -78.8781643, 35.1340786, -78.8781643,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/311103492/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2197",
+    "date": "2025-09-14",
+    "startTime": "13:00",
+    "location": "Trail Location, 3625 Golfview Rd,, Hope mills, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/310979011/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2196",
+    "date": "2025-09-07",
+    "startTime": "13:00",
+    "location": "Park in the lot that is marked in the picture, 1214 N Bragg Blvd,, Spring Lake, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/310821193/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2195",
+    "date": "2025-08-31",
+    "startTime": "14:00",
+    "location": "Event Location, 35.0822630, -78.8687820,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/310764469/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2194 PUB CRAWL!",
+    "date": "2025-08-24",
+    "startTime": "13:00",
+    "location": "Rowan Park, 725 West Rowan Street, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/310582908/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #2193",
+    "date": "2025-08-17",
+    "startTime": "13:00",
+    "location": "Trail Location, 3501 N Main St,, Hope mills, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/310509545/",
+    "attendees": 4
+  },
+  {
+    "title": "CTrH3 Trail #2192",
+    "date": "2025-08-10",
+    "startTime": "13:00",
+    "location": "Trail Start, 290 riverdell drive,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/308310363/",
+    "attendees": 4
+  },
+  {
+    "title": "CTRH3 Trail #2191",
+    "date": "2025-08-03",
+    "startTime": "13:00",
+    "location": "El Salvador Restaurant, 155 Bonanza Drive, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/310284151/",
+    "attendees": 4
+  },
+  {
+    "title": "CTRH3 Trail #2190",
+    "date": "2025-07-27",
+    "startTime": "13:00",
+    "location": "Trail Location, 2421 Wilmington Hwy,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/308933343/",
+    "attendees": 5
+  },
+  {
+    "title": "CTRH3 Trail#2189",
+    "date": "2025-07-20",
+    "startTime": "13:00",
+    "location": "3644 Golfview Rd, Hope Mills, NC 28348, USA, 3644 Golfview Rd, Hope Mills, NC 28348, USA,, Hope mills, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/309998288/",
+    "attendees": 4
+  },
+  {
+    "title": "CTRH3 Trail# 2188",
+    "date": "2025-07-13",
+    "startTime": "14:00",
+    "location": "Trail Location, 235 Person Street,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/308933394/",
+    "attendees": 5
+  },
+  {
+    "title": "CTRH3 Trail #2187 PUB CRAWL",
+    "date": "2025-07-06",
+    "startTime": "13:00",
+    "location": "Parking Lot, 700 Pershing St,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/308840134/",
+    "attendees": 4
+  },
+  {
+    "title": "Carolina Trash Trail #2186",
+    "date": "2025-06-29",
+    "startTime": "13:00",
+    "location": "Carver Creek State Park Sandhills Access, 995 McCloskey Rd, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/308599063/",
+    "attendees": 3
+  },
+  {
+    "title": "Trash Trail #2185",
+    "date": "2025-06-22",
+    "startTime": "13:00",
+    "location": "Trash Trail #2185, 1500 Colonial Park Dr,, Fayetteville, NC, US",
+    "url": "https://www.meetup.com/fayetteville-running-training-meetup-group/events/308570851/",
+    "attendees": 5
+  }
+]

--- a/scripts/data/cvilleh3-meetup-history-batch-1.json
+++ b/scripts/data/cvilleh3-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "cHHH Family Trail #676 Easter Egg Hunt",
+    "date": "2025-04-20",
+    "startTime": "13:00",
+    "location": "Forest Lakes South parking lot, 1650 Ashwood Blvd, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/306798796/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #675 Let’s get Jalap-in in this shit!",
+    "date": "2025-04-17",
+    "startTime": "18:00",
+    "location": "Washington Park, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/306798767/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #674: Can’t talk with my mouth full of Whoreos",
+    "date": "2025-04-03",
+    "startTime": "18:00",
+    "location": "Ix Art Park, 936 2nd St, SE, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/306798753/",
+    "attendees": 3
+  },
+  {
+    "title": "cHHH Trail #673",
+    "date": "2025-03-20",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/306798697/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #666 - The Trail of the Beast",
+    "date": "2025-01-02",
+    "startTime": "18:00",
+    "location": "Washington Park, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/305186373/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #665 - Boozy Xmas Lights Walk",
+    "date": "2024-12-27",
+    "startTime": "17:45",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/305183182/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #664 - Twas the Hash Before Xmas",
+    "date": "2024-12-19",
+    "startTime": "17:45",
+    "location": "Virginia Department of Forestry, 900 Natural Resources Drive, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/305168330/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #661 - Just Jack’s Naming Trail",
+    "date": "2024-11-21",
+    "startTime": "17:45",
+    "location": "Riverside North, 1770 Timberwood Blvd, Ste 110, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/304410678/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #660",
+    "date": "2024-11-17",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/304410706/",
+    "attendees": 3
+  },
+  {
+    "title": "cHHH Trail #659",
+    "date": "2024-11-07",
+    "startTime": "18:00",
+    "location": "cHHH #659, 1530 Insurance Lane, CHARLOTTESVILLE, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/304410650/",
+    "attendees": 3
+  },
+  {
+    "title": "cHHH Trail #657 Full Moon Hash",
+    "date": "2024-10-17",
+    "startTime": "18:15",
+    "location": "JBird Supply, 969 Second St SE,, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/303990679/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #656",
+    "date": "2024-09-19",
+    "startTime": "18:30",
+    "location": "cHHH Trail #656, 399 Hillsdale Dr, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/303513890/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Family Trail #653",
+    "date": "2024-08-18",
+    "startTime": "13:00",
+    "location": "AZALEA PARK, 304 Old Lynchburg Road, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/302811924/",
+    "attendees": 5
+  },
+  {
+    "title": "cHHH Trail #652",
+    "date": "2024-08-15",
+    "startTime": "18:30",
+    "location": "Urology Clinic cHHH #652, 155 Riverbend Drive, CHARLOTTESVILLE, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/302748530/",
+    "attendees": 3
+  },
+  {
+    "title": "cHHH Trail #651",
+    "date": "2024-08-01",
+    "startTime": "18:30",
+    "location": "Wegmans, 100 Wegmans Way, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/302542631/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #650",
+    "date": "2024-07-25",
+    "startTime": "18:30",
+    "location": "cHHH Trail #650, 540 Belvedere Boulevard ,, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/302438410/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #649 Sunday Family Friendly Trail",
+    "date": "2024-07-21",
+    "startTime": "13:00",
+    "location": "North Fork Research Park, 994 Research Park Boulevard, Charlottesville, VA 22911, CHARLOTTESVILLE, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/302336374/",
+    "attendees": 2
+  },
+  {
+    "title": "cHHH Trail #648 - Return of the Harlots",
+    "date": "2024-07-11",
+    "startTime": "18:30",
+    "location": "Riverview Park, 1999 Chesapeake Street, Charlottesville, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/301966477/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail # 284 - Jingle Balls",
+    "date": "2023-12-30",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/295598843/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail # 283 - Needs a Hare",
+    "date": "2023-12-16",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/295598781/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail # 282 - Krampus Run",
+    "date": "2023-12-02",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/295598714/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail # 281 - World Peace Through Beer",
+    "date": "2023-11-18",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/295598397/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail # 280 - lets annoy the neighbors",
+    "date": "2023-11-04",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/295598382/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #279 - Shiggy, no Shiggy Quest trail",
+    "date": "2023-10-21",
+    "startTime": "15:00",
+    "location": "Alum Spring Park, 1 Greenbrier Dr., Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294937084/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #278 - Honeymoon Trail",
+    "date": "2023-10-07",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294937078/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail # 277",
+    "date": "2023-09-23",
+    "startTime": "15:00",
+    "location": "Culpeper, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294937025/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #276 - Doe... A Deer",
+    "date": "2023-09-09",
+    "startTime": "15:00",
+    "location": "9300 Onyx Ct, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294937006/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #275 - Blue Moon Trail",
+    "date": "2023-08-26",
+    "startTime": "18:00",
+    "location": "Dumfries Park and Ride, Dumfries Rd, Triangle, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294936988/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #274 - Staying Alive trail",
+    "date": "2023-08-12",
+    "startTime": "15:00",
+    "location": "The Home Depot, 5771 Plank Rd, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294936883/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #273 - Member only Campout and River Float",
+    "date": "2023-07-28",
+    "startTime": "13:00",
+    "location": "Springfield, WV, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294708083/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #272 - Sweating to History",
+    "date": "2023-07-15",
+    "startTime": "15:00",
+    "location": "Chancellorsville Battlefield Visitor Center, 9001 Plank Rd, Spotsylvania Courthouse, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294416006/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #271 Vines, Vines and more Vines",
+    "date": "2023-07-01",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/294125964/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #270 - 1st Annual Purple Dress Run for Alzheimer's",
+    "date": "2023-06-17",
+    "startTime": "15:00",
+    "location": "City Dock Park, 207 Sophia St, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/293536517/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #269 - FU leg of TDH",
+    "date": "2023-06-10",
+    "startTime": "16:00",
+    "location": "Juggins Road Connector, Juggins Rd Connector, Virginia, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/292469787/",
+    "attendees": 1
+  },
+  {
+    "title": "The Seasoned, the New and the Curious!",
+    "date": "2023-06-03",
+    "startTime": "15:00",
+    "location": "Strangeways Brewing Fredericksburg, 350 Lansdowne Rd, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/293788641/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #268 - Grape Te-quila run",
+    "date": "2023-05-20",
+    "startTime": "15:00",
+    "location": "Gordon W. Shelton Boulevard, Gordon W. Shelton Blvd, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/291577844/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #267 - Oh no, not again!!",
+    "date": "2023-05-06",
+    "startTime": "15:00",
+    "location": "South Commuter Lot, Stafford, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/291577828/",
+    "attendees": 1
+  },
+  {
+    "title": "Jawshank Redemption Memorial Trail",
+    "date": "2023-04-29",
+    "startTime": "13:01",
+    "location": "Locust Shade Park, 4701 Locust Shade Dr, Triangle, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/293084644/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #266 - Be your inner furry animal",
+    "date": "2023-04-22",
+    "startTime": "15:00",
+    "location": "1601 Kenmore Ave, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/291577790/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #265 - Giving Back to the Community Trash Pickup Trail",
+    "date": "2023-04-08",
+    "startTime": "15:00",
+    "location": "50 Foreston Woods Dr #109, Stafford, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/291577692/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #264 - National Peacock Day",
+    "date": "2023-03-25",
+    "startTime": "15:00",
+    "location": "7530 Smith Station Rd, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/291577776/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #263 - Annual Green Dress Bar Crawl",
+    "date": "2023-03-11",
+    "startTime": "15:00",
+    "location": "400 Prince Edward St, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/291577493/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail # 262 - Tanks Trail",
+    "date": "2023-02-25",
+    "startTime": "15:00",
+    "location": "The Home Depot, 1201 Gateway Blvd, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/291577436/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #259",
+    "date": "2023-01-14",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/290859804/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #258 - Fancy Dress Balls",
+    "date": "2022-12-31",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832656/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #257 - Jingle Balls",
+    "date": "2022-12-17",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832640/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #256",
+    "date": "2022-12-03",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832635/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #255 - Turkey Trot",
+    "date": "2022-11-19",
+    "startTime": "15:00",
+    "location": "Target, 25 S Gateway Dr, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832630/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #254 - World Peace Through Beer",
+    "date": "2022-11-05",
+    "startTime": "15:00",
+    "location": "8110 River Stone Dr, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832623/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #253",
+    "date": "2022-10-22",
+    "startTime": "15:00",
+    "location": "Publix Super Market at Embrey Mill Town Center, 1640 Publix Wy, Stafford, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832618/",
+    "attendees": 2
+  }
+]

--- a/scripts/data/cvilleh3-meetup-history-batch-2.json
+++ b/scripts/data/cvilleh3-meetup-history-batch-2.json
@@ -1,0 +1,138 @@
+[
+  {
+    "title": "Trail #252",
+    "date": "2022-10-08",
+    "startTime": "15:00",
+    "location": "Maltese Brewing Company, 11047 Pierson Dr B, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832616/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #251",
+    "date": "2022-09-24",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832611/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #250",
+    "date": "2022-09-10",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832603/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #249",
+    "date": "2022-08-27",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832595/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #248",
+    "date": "2022-08-13",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832588/",
+    "attendees": 1
+  },
+  {
+    "title": "DP and Happi",
+    "date": "2022-08-06",
+    "startTime": "19:00",
+    "location": "Brocks Riverside Grill, 503 Sophia St, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/287661179/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #247",
+    "date": "2022-07-30",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831989/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #246",
+    "date": "2022-07-16",
+    "startTime": "15:00",
+    "location": "Rick's On The River, 6338 Riverview Drive, King George, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831984/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #245",
+    "date": "2022-07-02",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284832562/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #245",
+    "date": "2022-07-02",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831973/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #243",
+    "date": "2022-06-10",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831968/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #242 TOGA! TOGA!",
+    "date": "2022-06-04",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831965/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #241",
+    "date": "2022-05-21",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831957/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #240",
+    "date": "2022-05-07",
+    "startTime": "15:00",
+    "location": "Old Mill Park, 2201 Caroline St, Fredericksburg, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831953/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #239",
+    "date": "2022-04-23",
+    "startTime": "15:00",
+    "location": "11210 Catharpin Rd Spotsylvania VA 22553, 11210 Catharpin Rd, Spotsylvania, VA, US",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831946/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #238",
+    "date": "2022-04-09",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831939/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail #237",
+    "date": "2022-03-26",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-xxcniptw/events/284831843/",
+    "attendees": 2
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-1.json
+++ b/scripts/data/feh3-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Hash # 2576, hare Cow Poke",
+    "date": "2026-04-11",
+    "startTime": "15:00",
+    "location": "The Kensington School, 3435 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/314213266/",
+    "attendees": 5
+  },
+  {
+    "title": "Hash # 2574",
+    "date": "2026-03-28",
+    "startTime": "15:00",
+    "location": "Behind Riverside Internal Medicine, 11008 Warwick Blvd #1300, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/313960357/",
+    "attendees": 5
+  },
+  {
+    "title": "Hash # 2574",
+    "date": "2026-03-14",
+    "startTime": "15:00",
+    "location": "Deer Park, 11523 Jefferson Ave., Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/313758619/",
+    "attendees": 8
+  },
+  {
+    "title": "2026 One City Marathon Beer Stop",
+    "date": "2026-03-01",
+    "startTime": "07:00",
+    "location": "Indulge Bakery and Bistro, 10359 Warwick Blvd Hilton Village, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/313498997/",
+    "attendees": 4
+  },
+  {
+    "title": "Hash # 2573",
+    "date": "2026-02-28",
+    "startTime": "15:00",
+    "location": "Fort Fun, 9285 Warwick Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/313556941/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail # 2572 Hare : This is Sharda",
+    "date": "2026-02-14",
+    "startTime": "15:00",
+    "location": "St. George Brewery, 204 Challenger Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/312701564/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail # 2571 - AGM - Hare : BBQ",
+    "date": "2026-01-31",
+    "startTime": "15:00",
+    "location": "BBQ, 846 Chapin Wood Dr,, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/312701556/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #2570 Hare: nfn Grace",
+    "date": "2026-01-17",
+    "startTime": "15:00",
+    "location": "Jamestown Settlement Parking Lot, 2206 Colonial Pkwy Parking, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/312701547/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail # 2569. Hare: Chips & Clits",
+    "date": "2026-01-03",
+    "startTime": "15:00",
+    "location": "Covenant Wealth, 351 McLaws Cir, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/312691829/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail # 2568. Hare: Cow Poke. Solstice Spam Hash",
+    "date": "2025-12-20",
+    "startTime": "15:00",
+    "location": "Powhatan Creek Park and Blueway, 1831 Jamestown Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/311708055/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail # 2567 Hare : BBQ",
+    "date": "2025-12-06",
+    "startTime": "15:00",
+    "location": "11801 Canon Blvd, Newport News, Vi, US",
+    "url": "https://www.meetup.com/feh3-hash/events/311708052/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail # 2566. Where's My Mom",
+    "date": "2025-11-22",
+    "startTime": "15:00",
+    "location": "https://www.google.com/maps/@37.1711092,-76.5134668,760m/data=!3m1!1e3, The empty parking lot across from the NN AirRC club road, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/311630419/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail # 2565. Hare: Cow Poke",
+    "date": "2025-11-08",
+    "startTime": "15:00",
+    "location": "Jamestown Settlement Parking Lot, 2206 Colonial Pkwy Parking, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/311630386/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail # 2564. Hare: Shitty Orgy Daycare and Kibbles & Vomit",
+    "date": "2025-10-25",
+    "startTime": "13:30",
+    "location": "Hunter B. Andrews PK-8, 3120 Victoria Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/311630369/",
+    "attendees": 9
+  },
+  {
+    "title": "Trail # 2563. Hares: Clits & 9ss, Scotch-toberfest",
+    "date": "2025-10-11",
+    "startTime": "15:00",
+    "location": "Clit's home, 127 Ruth Lane, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/311077617/",
+    "attendees": 9
+  },
+  {
+    "title": "Trail # 2562 Hares: Soerst Rump, Just Malloy, & Radioactive Cum Swallower",
+    "date": "2025-09-27",
+    "startTime": "15:00",
+    "location": "New Quarter Park, 1000 Lakeshead Drive, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/308851455/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail # 2561 Hare : TTT & Your Mom",
+    "date": "2025-09-13",
+    "startTime": "15:00",
+    "location": "1700 Brewing, 11838 Canon Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/308851447/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail # 2560 Hare : This Is SHARDA",
+    "date": "2025-08-30",
+    "startTime": "15:00",
+    "location": "Trail #2560, 6376 Richmond Road,, Lightfoot, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/308851425/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail # 2559 ABCDEFG & Your Mom (b-day)",
+    "date": "2025-08-16",
+    "startTime": "15:00",
+    "location": "Newport News Park Discovery Center, 901 Constitution Way, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/308851387/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail # 2558 Red Dress",
+    "date": "2025-08-02",
+    "startTime": "15:00",
+    "location": "Craft 60 Taphouse & Grill, 14346 Warwick Blvd Ste 348, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/308851359/",
+    "attendees": 14
+  },
+  {
+    "title": "Trail # 2557 Hare : TTT (b-day)",
+    "date": "2025-07-19",
+    "startTime": "15:00",
+    "location": "Trail #2557 start, 2224 Andrews Blvd,, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/308851120/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #2556 Hare : Your Mom",
+    "date": "2025-07-05",
+    "startTime": "15:00",
+    "location": "The Vanguard, 504 N. King St., Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/308850004/",
+    "attendees": 4
+  },
+  {
+    "title": "BBQ's back pocket treat",
+    "date": "2025-06-21",
+    "startTime": "15:00",
+    "location": "Grafton Middle School, 405 Grafton Drive, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/307501148/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #2554 ~ Rainbow Dress",
+    "date": "2025-06-07",
+    "startTime": "12:00",
+    "location": "Woodland Skateboard Park, 9 Woodland Rd.,, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/307501185/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #2553 Hare: Can't Talk with My Mouth Full",
+    "date": "2025-05-24",
+    "startTime": "15:00",
+    "location": "Food Lion Parking lot, 10880 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/307501174/",
+    "attendees": 11
+  },
+  {
+    "title": "Hare: Salty Sharda trail",
+    "date": "2025-05-10",
+    "startTime": "15:00",
+    "location": "Robinson-Bruton Park, 221 Benns Road, Newport News, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/307501170/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail #2551 3rd Annual Chips Williamsburg Brewery Bike Bash with GED (co-hare)",
+    "date": "2025-04-26",
+    "startTime": "10:30",
+    "location": "Frothy Moon Brewhouse, 1826 Jamestown Rd,, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/306515131/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail 2550, hare: Over the Shoulder Boulder Holder",
+    "date": "2025-04-12",
+    "startTime": "15:00",
+    "location": "Carrabba's Italian Grill, 2500 Richmond Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/306652583/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #2549 Hares: Whoredor, D-Cell, & Fisty",
+    "date": "2025-03-29",
+    "startTime": "15:00",
+    "location": "Vacant Lot, 401 Oriana Road, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/306343063/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail 2548, hares: Your Mom & TTT",
+    "date": "2025-03-15",
+    "startTime": "15:00",
+    "location": "Air Power Park, 413 W. Mercury Boulevard, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/306331999/",
+    "attendees": 4
+  },
+  {
+    "title": "2025 One City Marathon Beer Stop",
+    "date": "2025-03-02",
+    "startTime": "07:30",
+    "location": "Indulge Bakery and Bistro, 10359 Warwick Blvd Hilton Village, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/306445854/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail 2547, hare: Whoreos",
+    "date": "2025-03-01",
+    "startTime": "15:00",
+    "location": "York High School 9300 George Washington Memorial Hwy Yorktown Va 23692, 9300 George Washington Memorial Hwy, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/306308212/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail 2546, Buck-a-Fuffalo & Lichtenschtabbed",
+    "date": "2025-02-15",
+    "startTime": "15:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/305448185/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail 2545, AGM Hare: BBQ",
+    "date": "2025-02-01",
+    "startTime": "15:00",
+    "location": "Craft 60 Ale House, 13361 Warwick Blvd Unit 2, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/305448180/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail 2544, Hare: Who's Your Mom & Family",
+    "date": "2025-01-18",
+    "startTime": "15:00",
+    "location": "Hampton Coliseum, 1000 Coliseum Dr, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/305448172/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail # 2543",
+    "date": "2025-01-04",
+    "startTime": "15:00",
+    "location": "Woodland Skateboard Park, 9 Woodland Rd.,, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/305060765/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail # 2542, hare: Granny's Ugly Sweater or Onezie Lights Trail",
+    "date": "2024-12-21",
+    "startTime": "17:00",
+    "location": "Bethel Manor Elementary School, 1797 First Street,, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/304497140/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail # 2541, hare: Cow Poke",
+    "date": "2024-12-07",
+    "startTime": "15:00",
+    "location": "Matoaka Elementary School, 4101 Brick Bat Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/304471368/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail # 2540, hare: BBQ",
+    "date": "2024-11-23",
+    "startTime": "15:00",
+    "location": "Woodside High School, 13450 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/303081994/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail # 2539, Hares: Where's My Mom & Whoreo",
+    "date": "2024-11-09",
+    "startTime": "15:00",
+    "location": "FERGUSON CENTER FOR THE ARTS, 1 Avenue of the Arts, NEWPORT NEWS, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/303956837/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail # 2538, Halloween. hare: Your Mom",
+    "date": "2024-10-26",
+    "startTime": "15:00",
+    "location": "Fort Fun, Fort Fun Circle, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/303719388/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail # 2537, World Peace. Hares: Fuck Dem Kids & Bike-urious",
+    "date": "2024-10-12",
+    "startTime": "15:00",
+    "location": "Marshall Early Learning Center, 743 24th St, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/303719334/",
+    "attendees": 10
+  },
+  {
+    "title": "Trail # 2536, Hare: Clean Up Crew",
+    "date": "2024-09-28",
+    "startTime": "15:00",
+    "location": "Beachlake Park, Longmeadow Dr.,, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/303081906/",
+    "attendees": 9
+  },
+  {
+    "title": "Trail # 2535, Hare: Bra",
+    "date": "2024-09-14",
+    "startTime": "15:00",
+    "location": "Abandoned mini golf, 1989 Richmond Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/303081867/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail # 2534, Hare: Hello Pity",
+    "date": "2024-08-31",
+    "startTime": "15:00",
+    "location": "Chickahominy Riverfront Park, 1350 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/302714780/",
+    "attendees": 4
+  },
+  {
+    "title": "WTF Trifukta Labor Day Weekend Campout",
+    "date": "2024-08-30",
+    "startTime": "13:00",
+    "location": "Chickahominy Riverfront Park, 1350 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/300379543/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail # 2533, hare: Cow Poke",
+    "date": "2024-08-17",
+    "startTime": "15:00",
+    "location": "Jamestown High School Parking lot behind the school, 3751 John Tyler Highway, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/302714817/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #2532, Where's My Mom",
+    "date": "2024-08-03",
+    "startTime": "15:00",
+    "location": "Dog Park, 2110 chartwell dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/302496593/",
+    "attendees": 9
+  },
+  {
+    "title": "Trail #2531 (C & C)² Tri-Fuc-Ta",
+    "date": "2024-07-20",
+    "startTime": "14:00",
+    "location": "Jamestown Settlement, 2110 Jamestown Road, Route 31 South, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/302120114/",
+    "attendees": 12
+  },
+  {
+    "title": "Trail #2530",
+    "date": "2024-07-06",
+    "startTime": "15:00",
+    "location": "Mt. Vernon Elementary School, 310 Mt Vernon Drive, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/301927879/",
+    "attendees": 5
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-10.json
+++ b/scripts/data/feh3-meetup-history-batch-10.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Try a tuesday hash with Hampton H3",
+    "date": "2012-10-09",
+    "startTime": "18:00",
+    "location": "Darling Stadium, 4111 Victoria Boulevard, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/85466372/",
+    "attendees": 2
+  },
+  {
+    "title": "run with the feh3 hash",
+    "date": "2012-10-06",
+    "startTime": "15:00",
+    "location": "Bass Pro Shops, 1972 Power Plant Parkway, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/85458122/",
+    "attendees": 3
+  },
+  {
+    "title": "Hash w/ feh3 then carpool to the Richmond hash.....dont be scared",
+    "date": "2012-09-29",
+    "startTime": "13:00",
+    "location": "Movie Tavern at High Street, 1430 Richmond Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/83356992/",
+    "attendees": 5
+  },
+  {
+    "title": "hash with FEH3",
+    "date": "2012-09-22",
+    "startTime": "15:00",
+    "location": "Harwoods Mill Park, 368 Oriana Road, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/82648352/",
+    "attendees": 5
+  },
+  {
+    "title": "show some support for the Tuesday hash house harriers",
+    "date": "2012-09-18",
+    "startTime": "18:00",
+    "location": "Booker T Washington Middle School, 3700 Chestnut Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/82399942/",
+    "attendees": 1
+  },
+  {
+    "title": "hash with FEH3",
+    "date": "2012-09-15",
+    "startTime": "15:00",
+    "location": "Lee Hall Elementary School, 17346 Warwick Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/82220482/",
+    "attendees": 5
+  },
+  {
+    "title": "try a tuesday hash",
+    "date": "2012-09-11",
+    "startTime": "18:30",
+    "location": "Save-A-Lot, 1933 East Pembroke Avenue, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/81590422/",
+    "attendees": 2
+  },
+  {
+    "title": "run with feh3",
+    "date": "2012-09-08",
+    "startTime": "15:00",
+    "location": "The White Oaks Lodge, 3533 Kecoughtan Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/81220122/",
+    "attendees": 5
+  },
+  {
+    "title": "Hash in your birthday suit",
+    "date": "2012-09-01",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/79446722/",
+    "attendees": 9
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-08-25",
+    "startTime": "15:00",
+    "location": "Parking lot, 100 Exploration Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/79234942/",
+    "attendees": 3
+  },
+  {
+    "title": "BEER MILE / SPAM RUN",
+    "date": "2012-08-18",
+    "startTime": "12:00",
+    "location": "Rey Azteca, 10530 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/77773182/",
+    "attendees": 9
+  },
+  {
+    "title": "hash at noon w feh3",
+    "date": "2012-08-11",
+    "startTime": "12:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/76901462/",
+    "attendees": 3
+  },
+  {
+    "title": "hash with FEH3",
+    "date": "2012-08-04",
+    "startTime": "15:00",
+    "location": "Food Lion, 10880 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/76173382/",
+    "attendees": 1
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-07-28",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/74854092/",
+    "attendees": 6
+  },
+  {
+    "title": "hash with FEH3",
+    "date": "2012-07-21",
+    "startTime": "15:00",
+    "location": "Warwick High School Parking Lot, 51 Copeland Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/73757462/",
+    "attendees": 4
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-07-14",
+    "startTime": "15:00",
+    "location": "Hooters, 12640 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/73119982/",
+    "attendees": 4
+  },
+  {
+    "title": "Say goodbye to shiny diver Mr. Pasty white is heading back to alaska",
+    "date": "2012-07-07",
+    "startTime": "15:00",
+    "location": "Woodside High School, 13450 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/72243262/",
+    "attendees": null
+  },
+  {
+    "title": "FEH3 goes F.A.R.T ing with the Richmond Hash",
+    "date": "2012-06-30",
+    "startTime": "08:30",
+    "location": "Food Lion, 5601 Richmond Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/70862372/",
+    "attendees": 3
+  },
+  {
+    "title": "hash with FEH3",
+    "date": "2012-06-23",
+    "startTime": "15:00",
+    "location": "JM Dozier Middle School, 432 Industrial Park Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/70046552/",
+    "attendees": 3
+  },
+  {
+    "title": "Day 8 the end of pussocalypse...saran wrap hash",
+    "date": "2012-06-16",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/68977892/",
+    "attendees": 4
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-06-09",
+    "startTime": "15:00",
+    "location": "Food Lion, 4047 W Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/67752252/",
+    "attendees": 1
+  },
+  {
+    "title": "Hash with Ft Useless",
+    "date": "2012-05-26",
+    "startTime": "15:00",
+    "location": "Deer Park, 11523 Jefferson Ave., Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/66011952/",
+    "attendees": 2
+  },
+  {
+    "title": "celebrate Fairy Beary Birthday",
+    "date": "2012-05-19",
+    "startTime": "15:00",
+    "location": "Wells Fargo, 2 Victory Blvd, Puquoson, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/65180272/",
+    "attendees": 4
+  },
+  {
+    "title": "BITCH BE COOL",
+    "date": "2012-05-12",
+    "startTime": "15:00",
+    "location": "McIntosh Elementary, 185 Richneck Rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/64304622/",
+    "attendees": 3
+  },
+  {
+    "title": "CINCO DE TOGA FEH3 Hash and POOL Party",
+    "date": "2012-05-05",
+    "startTime": "15:00",
+    "location": "R.O. Nelson Elementary School, 826 Moyer Road, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/63092512/",
+    "attendees": 4
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-04-28",
+    "startTime": "15:00",
+    "location": "Warwick High School Parking Lot, 51 Copeland Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/62291642/",
+    "attendees": 1
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-04-21",
+    "startTime": "15:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/61095982/",
+    "attendees": 2
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-04-14",
+    "startTime": "15:00",
+    "location": "Harwoods Mill Park, 368 Oriana Road, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/60162172/",
+    "attendees": 2
+  },
+  {
+    "title": "support one of FEH3 newest harrietts!",
+    "date": "2012-03-31",
+    "startTime": "15:00",
+    "location": "Parking Lot, 20 Enterprise Parkway, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/58242542/",
+    "attendees": 5
+  },
+  {
+    "title": "Hash with fort useless",
+    "date": "2012-03-24",
+    "startTime": "15:00",
+    "location": "Briarfield Park Tennis Courts, 1540 Briarfield Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/57358112/",
+    "attendees": 4
+  },
+  {
+    "title": "THE RETURN OF THE MIMOSA H3",
+    "date": "2012-03-17",
+    "startTime": "10:00",
+    "location": "Food Lion, 10880 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/56467152/",
+    "attendees": 1
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-03-03",
+    "startTime": "15:00",
+    "location": "Big Lots, 2330 West Mercury Blvd # C, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/54535592/",
+    "attendees": 2
+  },
+  {
+    "title": "watch NFN ANTHONY LAY HIS FIRST TRAIL",
+    "date": "2012-02-25",
+    "startTime": "15:00",
+    "location": "Berkley Middle, 1118 Ironbound Rd, williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/53495472/",
+    "attendees": 1
+  },
+  {
+    "title": "Hash in the burg",
+    "date": "2012-02-18",
+    "startTime": "15:00",
+    "location": "Movie Tavern at High Street, 1430 Richmond Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/52587512/",
+    "attendees": 1
+  },
+  {
+    "title": "ALL YOU NEED IS LOVE",
+    "date": "2012-02-11",
+    "startTime": "15:00",
+    "location": "Union First Market Bank, 603 Pilot House Drive, Suite 100, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/51239962/",
+    "attendees": 3
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-02-04",
+    "startTime": "15:00",
+    "location": "York High School, 9300 George Washington Memorial Highway, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/50876272/",
+    "attendees": 1
+  },
+  {
+    "title": "join us this saturday at the FEH3 hash",
+    "date": "2012-01-28",
+    "startTime": "15:00",
+    "location": "Hampton High School, 1491 West Queen Street, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/49709242/",
+    "attendees": 2
+  },
+  {
+    "title": "One is the loneliest number that you'll ever do.........so why not pick four?",
+    "date": "2012-01-21",
+    "startTime": "15:00",
+    "location": "Richneck Elementary School, 205 Tyner Drive, Newport News, Vi, US",
+    "url": "https://www.meetup.com/feh3-hash/events/48632142/",
+    "attendees": 3
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-01-07",
+    "startTime": "15:00",
+    "location": "Food Lion, 1164 Big Bethel Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/46773512/",
+    "attendees": 2
+  },
+  {
+    "title": "Naughty or Nice Hash",
+    "date": "2011-12-17",
+    "startTime": "15:00",
+    "location": "Brentwood Shopping Center, 10530 Jefferson Ave, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/44311642/",
+    "attendees": 3
+  },
+  {
+    "title": "HASHY HOLIDAYS Christmas Light hash",
+    "date": "2011-12-10",
+    "startTime": "17:30",
+    "location": "600 Concord Dr, Hampton, Vi, US",
+    "url": "https://www.meetup.com/feh3-hash/events/42693752/",
+    "attendees": 3
+  },
+  {
+    "title": "hash 5, thats right 5, not sure? THE ANSWER IS 5",
+    "date": "2011-12-03",
+    "startTime": "15:00",
+    "location": "William Mason Cooper Elementary School, 200 Marcella Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/42691782/",
+    "attendees": 4
+  },
+  {
+    "title": "Trott your Turkey gutt off with the FEH3 hash",
+    "date": "2011-11-26",
+    "startTime": "15:00",
+    "location": "York High School, 9300 George Washington Memorial Highway, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/42179732/",
+    "attendees": 2
+  },
+  {
+    "title": "Support the FEH3 hash",
+    "date": "2011-11-19",
+    "startTime": "15:00",
+    "location": "Hampton Sentara walking trail, 300 Butler Farm Road, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/41192212/",
+    "attendees": 2
+  },
+  {
+    "title": "HASH IN THE WOODS",
+    "date": "2011-11-12",
+    "startTime": "15:00",
+    "location": "Harwoods Mill Park, 368 Oriana Road, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/40281662/",
+    "attendees": 2
+  },
+  {
+    "title": "CELEBRATE 40 YEARS OF HASHING",
+    "date": "2011-11-05",
+    "startTime": "12:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/38792902/",
+    "attendees": 4
+  },
+  {
+    "title": "MIMOSAS H3",
+    "date": "2011-10-29",
+    "startTime": "11:30",
+    "location": "Piggy and Gophers House, 772 Wilderness Way, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/38792382/",
+    "attendees": 2
+  },
+  {
+    "title": "HASH SOUTHSIDE PIRATE STYLE TO JOIN TIDEWATER HASHERS",
+    "date": "2011-10-08",
+    "startTime": "10:30",
+    "location": "The Home Depot - Virginia Beach, 2324 Elson Green Avenue, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/36090832/",
+    "attendees": 1
+  },
+  {
+    "title": "Hedgie's Friday Night Birthday Hash",
+    "date": "2011-09-30",
+    "startTime": "18:30",
+    "location": "Piggy and Gophers House, 772 Wilderness Way, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/35004622/",
+    "attendees": 3
+  },
+  {
+    "title": "THE RETURN OF THE SCHWINN!",
+    "date": "2011-09-24",
+    "startTime": "15:00",
+    "location": "Hooters, 12640 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/34684512/",
+    "attendees": 4
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-11.json
+++ b/scripts/data/feh3-meetup-history-batch-11.json
@@ -1,0 +1,74 @@
+[
+  {
+    "title": "get in the shiggy with feh3",
+    "date": "2011-09-17",
+    "startTime": "15:00",
+    "location": "Harwoods Mill Park, 370 Oriana Road, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/33830842/",
+    "attendees": 2
+  },
+  {
+    "title": "BLOODY MARY BRUNCH HASH",
+    "date": "2011-09-11",
+    "startTime": "10:00",
+    "location": "County Grill, 1215-a Geo. Wash. Mem. Hwy., Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/32770512/",
+    "attendees": 1
+  },
+  {
+    "title": "TU TU YOUR WAY TO THE TERRIBLE TWO HASH",
+    "date": "2011-09-03",
+    "startTime": "15:00",
+    "location": "Denbigh High School, 259 Denbigh Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/32017092/",
+    "attendees": 1
+  },
+  {
+    "title": "Celebrate 2100!!! Running of the FEH3.....",
+    "date": "2011-08-20",
+    "startTime": "15:00",
+    "location": "Rey Azteca, 10530 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/29331361/",
+    "attendees": 6
+  },
+  {
+    "title": "Run/walk with FEH3 this lovely saturday",
+    "date": "2011-08-13",
+    "startTime": "13:00",
+    "location": "JM Dozier Middle School, 432 Industrial Park Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/29123311/",
+    "attendees": 3
+  },
+  {
+    "title": "REDNECK WEDDING SHOTGUN HASH",
+    "date": "2011-07-16",
+    "startTime": "15:00",
+    "location": "Brittingham-Midtown Community Center, 570 McLawhorne Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/24747671/",
+    "attendees": 7
+  },
+  {
+    "title": "Get off your a$$ and come join FEH3 for trail this saturday!!!!!!!!!!!!!",
+    "date": "2011-06-25",
+    "startTime": "15:30",
+    "location": "Rey Azteca, 10530 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/23298261/",
+    "attendees": 4
+  },
+  {
+    "title": "Join FEH3 this Saturday",
+    "date": "2011-06-18",
+    "startTime": "13:00",
+    "location": "Darling Stadium, 4111 Victoria Boulevard, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/22436151/",
+    "attendees": 3
+  },
+  {
+    "title": "Hash at the Campgrounds",
+    "date": "2011-06-04",
+    "startTime": "15:00",
+    "location": "Big Bear Family Campground, 7651 Whispering Pines Trail, Windsor, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/20146261/",
+    "attendees": 5
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-2.json
+++ b/scripts/data/feh3-meetup-history-batch-2.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Trail #2529 HARE : Where's My Mom",
+    "date": "2024-06-22",
+    "startTime": "15:00",
+    "location": "Huntington beach, Riverpark Rd, Newport News, VA 23607, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/301761034/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #2528, THIS IS SHARDA Rainbow trail",
+    "date": "2024-06-08",
+    "startTime": "15:00",
+    "location": "Rainbow r*n, 300 E Mellen Street,, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/300427814/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail #2527, hare: Cowpoke",
+    "date": "2024-05-25",
+    "startTime": "15:00",
+    "location": "Chickahominy Riverfront Park, 1350 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/300335054/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail #2526: Rolling D-Cell trail",
+    "date": "2024-05-11",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/300335021/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail #2525 Clits & Chips or Chips & Clits' Analual Bike Brewery Bash",
+    "date": "2024-04-27",
+    "startTime": "10:00",
+    "location": "Frothy Moon Brewhouse, 1826 Jamestown Rd,, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/299200497/",
+    "attendees": 8
+  },
+  {
+    "title": "Drinking practice & open Misman meeting",
+    "date": "2024-04-22",
+    "startTime": "17:00",
+    "location": "Juan's Mexican Cafe and Cantina, 561 Bland Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/300527704/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #2524: Blue Dress Invasion",
+    "date": "2024-04-13",
+    "startTime": "14:00",
+    "location": "STYRON PARK at PORT WARWICK, 3100 STYRON SQUARE, NEWPORT NEWS, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/299200808/",
+    "attendees": 9
+  },
+  {
+    "title": "Trail #2523 - NFN Sarh & Chips 'n Clits or Clits 'n Chips",
+    "date": "2024-03-30",
+    "startTime": "13:00",
+    "location": "Chickahominy Riverfront Park, 1350 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/299200795/",
+    "attendees": 9
+  },
+  {
+    "title": "Trail #2522 - Nine Second Swallow",
+    "date": "2024-03-16",
+    "startTime": "15:00",
+    "location": "Old Point National Bank, 4139 Ironbound Rd Williamsburg, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/299200772/",
+    "attendees": 6
+  },
+  {
+    "title": "One City Marathon Beer Stop",
+    "date": "2024-03-03",
+    "startTime": "07:30",
+    "location": "Indulge Bakery and Bistro, 10359 Warwick Blvd Hilton Village, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/298577837/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail # 2521 Over the Shoulder Boulder Holder",
+    "date": "2024-03-02",
+    "startTime": "15:00",
+    "location": "Daddyo's Tavern, 7500 Richmond Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/298577862/",
+    "attendees": 6
+  },
+  {
+    "title": "FEH3 Trail # 2518 Hare : Where's My Mom",
+    "date": "2024-01-20",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/298351649/",
+    "attendees": 8
+  },
+  {
+    "title": "FEH3 Trail # 2517. New Year, New Hare, New Territory",
+    "date": "2024-01-06",
+    "startTime": "15:00",
+    "location": "Lois Hornsby Middle School, 850 Jolly Pond Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/297031009/",
+    "attendees": 6
+  },
+  {
+    "title": "FEH3 Trail # 2516. 9SS Festivus Trail",
+    "date": "2023-12-23",
+    "startTime": "17:00",
+    "location": "Phillips Elementary School, 703 Lemaster Ave, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/297030989/",
+    "attendees": 9
+  },
+  {
+    "title": "FEH3 Trail # 2515. Cow Poke is hare",
+    "date": "2023-12-09",
+    "startTime": "15:00",
+    "location": "Jamestown High School, 3751 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/297030973/",
+    "attendees": 5
+  },
+  {
+    "title": "FEH3 Trail # 2514. Pre-Lube to Turkey Bowl",
+    "date": "2023-11-25",
+    "startTime": "09:00",
+    "location": "Glazed Doughnuts, 24 Wine St., Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/297030944/",
+    "attendees": 9
+  },
+  {
+    "title": "FEH3 Trail # 2513. hares: BBQ + 9SS",
+    "date": "2023-11-11",
+    "startTime": "15:00",
+    "location": "Richneck Elementary School, 205 Tyner Drive, Newport News, Vi, US",
+    "url": "https://www.meetup.com/feh3-hash/events/296515947/",
+    "attendees": 11
+  },
+  {
+    "title": "Virginia Interhash 2023",
+    "date": "2023-11-03",
+    "startTime": "15:00",
+    "location": "2132 Shipping Ln, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/292113473/",
+    "attendees": 3
+  },
+  {
+    "title": "FEH3 Trail # 2512. Hare: Rolling in the Deep",
+    "date": "2023-10-28",
+    "startTime": "15:00",
+    "location": "Soulful Journey, LLC, 11010 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/295897229/",
+    "attendees": 8
+  },
+  {
+    "title": "FEH3 Trail # 2511 - Over the shoulder boulder holder",
+    "date": "2023-10-14",
+    "startTime": "15:00",
+    "location": "Williamsburg Alewerks Brewery, 189 Ewell Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/295897211/",
+    "attendees": 5
+  },
+  {
+    "title": "FEH3 Trail # 2510. Hare: Where's My Mom?",
+    "date": "2023-09-30",
+    "startTime": "15:00",
+    "location": "Christopher Newport University, 1 Avenue of the Arts, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/295870099/",
+    "attendees": 11
+  },
+  {
+    "title": "FEH3 Trail # 2509. Hares: 9SS + Bra",
+    "date": "2023-09-16",
+    "startTime": "15:00",
+    "location": "Trail Start 2509, 522 Surrender Rd,, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/295870080/",
+    "attendees": 8
+  },
+  {
+    "title": "FEH3 Trail # 2508. Cow Poke Haring a Minimalist Hash.",
+    "date": "2023-09-02",
+    "startTime": "15:00",
+    "location": "Clara Byrd Baker Elementary, 3131 Ironbound Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/295653604/",
+    "attendees": 8
+  },
+  {
+    "title": "FART",
+    "date": "2023-07-04",
+    "startTime": "10:00",
+    "location": "Pony Pasture Parking, 7300 Riverside Dr, Richmond, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/293794828/",
+    "attendees": 8
+  },
+  {
+    "title": "FEH3 Trail # 2501, 2nd An*l Bike Brewery Marathon",
+    "date": "2023-05-27",
+    "startTime": "10:30",
+    "location": "2206 Colonial Pkwy Parking, 2206 Colonial Nat'l Historical Pkwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/291104138/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail # 2500, hares: ANAL et.al.",
+    "date": "2023-05-13",
+    "startTime": "14:00",
+    "location": "119 Bypass Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/291104128/",
+    "attendees": 18
+  },
+  {
+    "title": "FEH3 Trail # 2498, Hare: Hermie",
+    "date": "2023-04-15",
+    "startTime": "15:00",
+    "location": "College Creek Beach, Colonial Nat'l Historical Pkwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/291095116/",
+    "attendees": 12
+  },
+  {
+    "title": "FEH3 Trail # 2497, April Fool's Day, Hare: Rolling in the Deep",
+    "date": "2023-04-01",
+    "startTime": "15:00",
+    "location": "AMC Hampton 24, 1 Town Center Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/291095109/",
+    "attendees": 12
+  },
+  {
+    "title": "FEH3 Trail # 2496, My PNA",
+    "date": "2023-03-18",
+    "startTime": "12:00",
+    "location": "Grafton Middle School, 405 Grafton Drive, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/291095075/",
+    "attendees": 12
+  },
+  {
+    "title": "FEH3 One City Marathon Beer Stop",
+    "date": "2023-03-05",
+    "startTime": "07:30",
+    "location": "Whatever Media Photography Studio, 10349A Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/291795828/",
+    "attendees": 5
+  },
+  {
+    "title": "Misman Meeting & Drinking Practice",
+    "date": "2023-03-01",
+    "startTime": "18:15",
+    "location": "Tradition Brewing Company, 700 Thimble Shoals Blvd #100, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/291808702/",
+    "attendees": 6
+  },
+  {
+    "title": "Beach Day",
+    "date": "2022-08-27",
+    "startTime": "10:00",
+    "location": "College Creek Beach, Colonial Nat'l Historical Pkwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/288012608/",
+    "attendees": 5
+  },
+  {
+    "title": "FEH3 trail #2479 Super Soaker",
+    "date": "2022-07-23",
+    "startTime": "15:00",
+    "location": "Huntington Park Beach/Fort Fun, 361 Hornet Cir, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/286486243/",
+    "attendees": 8
+  },
+  {
+    "title": "FEH3 trail # 2478: NEW START LOCATION",
+    "date": "2022-07-09",
+    "startTime": "15:00",
+    "location": "3751 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/286486213/",
+    "attendees": 11
+  },
+  {
+    "title": "FEH3 trail #2477-Rainbow Dress Run",
+    "date": "2022-06-25",
+    "startTime": "15:00",
+    "location": "Bryan Elementary school, 1021 N Mallory St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/285777227/",
+    "attendees": 21
+  },
+  {
+    "title": "FEH3 trail #2476 - My PNA",
+    "date": "2022-06-11",
+    "startTime": "15:00",
+    "location": "Harwoods Mill Park, 368 Oriana Road, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/285777219/",
+    "attendees": 10
+  },
+  {
+    "title": "FEH3 trail # 2475 - Over the Shoulder Boulder Holder",
+    "date": "2022-05-28",
+    "startTime": "15:00",
+    "location": "Jamestown Settlement, 2110 Jamestown Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/285777199/",
+    "attendees": 9
+  },
+  {
+    "title": "WTF presents: M.U.D. the Forth be with U",
+    "date": "2022-05-04",
+    "startTime": "17:00",
+    "location": "Casa de M.U.D., 127 B Wickre St ,, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/285593132/",
+    "attendees": 6
+  },
+  {
+    "title": "FEH3 trail#2473 Chip and Clits Bike Bash",
+    "date": "2022-04-30",
+    "startTime": "10:00",
+    "location": "Jamestown Settlement, 2110 Jamestown Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/284718331/",
+    "attendees": 11
+  },
+  {
+    "title": "FEH3 trail #2472 9 second blackout inaugural trail",
+    "date": "2022-04-16",
+    "startTime": "15:00",
+    "location": "5424 Discovery Park Blvd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/284717971/",
+    "attendees": 11
+  },
+  {
+    "title": "WTF (C + C)² trail #11",
+    "date": "2022-04-13",
+    "startTime": "17:30",
+    "location": "RF Wilkinson YMCA, 301 Sentara Ct, Willamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/285216065/",
+    "attendees": 4
+  },
+  {
+    "title": "FEH3 Trail#2471 HermphroditesOnUnicycles",
+    "date": "2022-04-02",
+    "startTime": "15:00",
+    "location": "Old Point National Bank, 4139 Ironbound Rd Williamsburg, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/284135908/",
+    "attendees": 12
+  },
+  {
+    "title": "WTF St. Patty's Day Shenanigans",
+    "date": "2022-03-17",
+    "startTime": "17:00",
+    "location": "CrossWalk Community Church, 7575 Richmond Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/284667979/",
+    "attendees": 5
+  },
+  {
+    "title": "One City Marathon Beer Stop",
+    "date": "2022-03-06",
+    "startTime": "07:00",
+    "location": "10345 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/284186438/",
+    "attendees": 7
+  },
+  {
+    "title": "FEH3 Trail# 2469 - The Fast & Bike-urious",
+    "date": "2022-03-05",
+    "startTime": "15:00",
+    "location": "Net Center at New Market Mall, 5200 Mercury Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/283499556/",
+    "attendees": 13
+  },
+  {
+    "title": "FEH3 Trail# 2468 - Red Dress Run",
+    "date": "2022-02-19",
+    "startTime": "15:00",
+    "location": "11801 Canon Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/283499552/",
+    "attendees": 16
+  },
+  {
+    "title": "FEH3 Trail# 2467 - NFN Nick & Blackout",
+    "date": "2022-02-05",
+    "startTime": "15:00",
+    "location": "NFN Nick's, 110 Clemwood Pkwy, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/283147515/",
+    "attendees": 12
+  },
+  {
+    "title": "WTF last minute trail & travel hasher in town",
+    "date": "2022-02-01",
+    "startTime": "17:00",
+    "location": "Warhill Sports Complex, 5700 Warhill Trail, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/283541817/",
+    "attendees": 9
+  },
+  {
+    "title": "FEH3 Trail# 2466 - Downward Dog Shit",
+    "date": "2022-01-22",
+    "startTime": "14:00",
+    "location": "455 Merrimac Trail, Williamsburg, VA 23185, 455 Merrimac Trail, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/282637352/",
+    "attendees": 16
+  },
+  {
+    "title": "NORTH SIDE TUESDAY H3 Trail!",
+    "date": "2021-11-09",
+    "startTime": "18:00",
+    "location": "Oozlefinch Beers & Blending, 81 Patch Rd, Fort Monroe, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/281926771/",
+    "attendees": 5
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-3.json
+++ b/scripts/data/feh3-meetup-history-batch-3.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Drinking Practice / Misman Meeting",
+    "date": "2021-10-06",
+    "startTime": "18:00",
+    "location": "136 Ruth Ln, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/281216160/",
+    "attendees": 7
+  },
+  {
+    "title": "Adult Field Day & Campout By WTF",
+    "date": "2021-09-11",
+    "startTime": "11:00",
+    "location": "136 Ruth Ln, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/279331551/",
+    "attendees": 13
+  },
+  {
+    "title": "WTF another FART? - Float Around Richmond in a Tube.",
+    "date": "2021-08-29",
+    "startTime": "10:00",
+    "location": "Huguenot Flatwater - James River Park System, 8600 Southampton Rd, Richmond, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/279528669/",
+    "attendees": 15
+  },
+  {
+    "title": "FART - Float Around Richmond in a Tube.",
+    "date": "2021-07-03",
+    "startTime": "11:00",
+    "location": "Huguenot Flatwater - James River Park System, 8600 Southampton Rd, Richmond, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/278648833/",
+    "attendees": 9
+  },
+  {
+    "title": "Impromptu WTF (Williamsburg Trail for Families) hash",
+    "date": "2021-06-30",
+    "startTime": "17:30",
+    "location": "Jamestown High School, 3751 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/279175136/",
+    "attendees": 3
+  },
+  {
+    "title": "Panda's Birthday Trail",
+    "date": "2021-05-23",
+    "startTime": "12:00",
+    "location": "13028 Carrollton Blvd, Carrollton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/278145336/",
+    "attendees": 10
+  },
+  {
+    "title": "FEH3 Trail #2448: As long as my pussy gets wet & NFN Jennifer",
+    "date": "2021-05-15",
+    "startTime": "15:00",
+    "location": "Berkeley Middle School, 1118 Ironbound Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/277353021/",
+    "attendees": 18
+  },
+  {
+    "title": "Tims not so 50 Boston 50 mile run",
+    "date": "2021-04-19",
+    "startTime": "08:30",
+    "location": "The Boat House at rockettes landing, 4708 E Old Main St, Richmond, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/277387009/",
+    "attendees": 6
+  },
+  {
+    "title": "Open Misman Meeting",
+    "date": "2021-03-24",
+    "startTime": "17:30",
+    "location": "Cow Poke's Place, 3522 Mott Ln, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/277066792/",
+    "attendees": 10
+  },
+  {
+    "title": "FEH3 Trail #2444 - NFN Morgan and Chips 'n Clits (Clits 'n Chips)",
+    "date": "2021-03-20",
+    "startTime": "15:00",
+    "location": "Grafton High School, 403 Grafton Dr, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/275408957/",
+    "attendees": 12
+  },
+  {
+    "title": "FEH3 Trail #2442 - 4th Annual Red Dress Run",
+    "date": "2021-02-20",
+    "startTime": "15:00",
+    "location": "Cinema Cafe, 1044 Von Schilling Dr, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/275408921/",
+    "attendees": 26
+  },
+  {
+    "title": "FEH3 Trail #2441 - Cardboard Robot Hash",
+    "date": "2021-02-06",
+    "startTime": "15:00",
+    "location": "555 Settlers Landing Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/275408868/",
+    "attendees": 17
+  },
+  {
+    "title": "FEH3 trail# 2435 - Tesla & NFN Topher",
+    "date": "2020-11-14",
+    "startTime": "15:00",
+    "location": "E Mart, 13276 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/273375212/",
+    "attendees": 2
+  },
+  {
+    "title": "FEH3 Trail# 2433 - Zombie Hash",
+    "date": "2020-10-17",
+    "startTime": "15:00",
+    "location": "Oozlefinch Beers & Blending, 81 Patch Rd, Fort Monroe, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/272472196/",
+    "attendees": 47
+  },
+  {
+    "title": "FEH3 Trail# 2432 - Farewell to Tea Time",
+    "date": "2020-10-03",
+    "startTime": "15:00",
+    "location": "Yorktown Elementary School, 131 Siege Ln, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/272472185/",
+    "attendees": 21
+  },
+  {
+    "title": "FEH3 Trail# 2431 - NFN Carl & PNA",
+    "date": "2020-09-19",
+    "startTime": "15:00",
+    "location": "Yorktown Middle School, 11201 George Washington Memorial Hwy, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/271942336/",
+    "attendees": 16
+  },
+  {
+    "title": "FEH3 trail# 2430 - ANAL BBQ TRAIL",
+    "date": "2020-09-05",
+    "startTime": "15:00",
+    "location": "E Mart, 13276 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/271942303/",
+    "attendees": 20
+  },
+  {
+    "title": "FEH3 Trail# 2429 - Blackout Lesbian",
+    "date": "2020-08-22",
+    "startTime": "15:00",
+    "location": "Samuel P. Langley Elementary School, 16 Rockwell Drive, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/271605453/",
+    "attendees": 20
+  },
+  {
+    "title": "FEH3 Trail# 2428 - KISS & NFN Jordon",
+    "date": "2020-08-08",
+    "startTime": "15:00",
+    "location": "Denbigh Baptist Christian School Gymnasium, 13010 Mitchell Point Road, Newport News, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/271605488/",
+    "attendees": 16
+  },
+  {
+    "title": "2427 - Back Nine",
+    "date": "2020-07-25",
+    "startTime": "15:00",
+    "location": "Peninsula Fine Arts Center, 101 Museum Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/270987037/",
+    "attendees": 19
+  },
+  {
+    "title": "Richmond float - tentative",
+    "date": "2020-07-04",
+    "startTime": "13:00",
+    "location": "Byrd Park Pump House, 1708 Pump House Dr, Richmond, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/271506825/",
+    "attendees": 6
+  },
+  {
+    "title": "2425 - Drunk Neighbor's Birthday Trail",
+    "date": "2020-06-27",
+    "startTime": "15:00",
+    "location": "5424 Discovery Park Blvd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/271172061/",
+    "attendees": 46
+  },
+  {
+    "title": "2424 - NFN Nicole & NFN Alec & Seventeen",
+    "date": "2020-06-13",
+    "startTime": "15:00",
+    "location": "Yorktown French Memorial, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/270000997/",
+    "attendees": 28
+  },
+  {
+    "title": "15+ Mile Ruck",
+    "date": "2020-06-06",
+    "startTime": "09:00",
+    "location": "Jamestown Settlement, 2110 Jamestown Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/270884009/",
+    "attendees": 4
+  },
+  {
+    "title": "2423 - Vanilla Is a Flavor Too",
+    "date": "2020-05-30",
+    "startTime": "15:00",
+    "location": "Alewerks, 189-B Ewell Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/270000985/",
+    "attendees": 17
+  },
+  {
+    "title": "2422 - The Tit Wanker Trail",
+    "date": "2020-05-16",
+    "startTime": "15:00",
+    "location": "100 Ponsonby Dr, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/269964808/",
+    "attendees": 19
+  },
+  {
+    "title": "2421 - NFN Dru - Another social distancing trail",
+    "date": "2020-05-02",
+    "startTime": "15:00",
+    "location": "13450 Woodside Ln, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/269870739/",
+    "attendees": 13
+  },
+  {
+    "title": "2420 - Cow Poke",
+    "date": "2020-04-18",
+    "startTime": "15:00",
+    "location": "3751 John Tyler Hwy, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/266462194/",
+    "attendees": 14
+  },
+  {
+    "title": "2419 - BBQ & ANAL",
+    "date": "2020-04-04",
+    "startTime": "15:00",
+    "location": "1 Towne Centre Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/266462188/",
+    "attendees": 13
+  },
+  {
+    "title": "Cancelled!!! TH3's Green Dress Run",
+    "date": "2020-03-21",
+    "startTime": "12:00",
+    "location": "37th & Zen, 1083 37th St, Norfolk, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/266462181/",
+    "attendees": 9
+  },
+  {
+    "title": "2417 - KISS & NFN Joe",
+    "date": "2020-03-07",
+    "startTime": "15:00",
+    "location": "14550 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/266462174/",
+    "attendees": 12
+  },
+  {
+    "title": "One City Marathon Beer Stop",
+    "date": "2020-03-01",
+    "startTime": "07:00",
+    "location": "Warwick Boulevard & Main Street, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/269046470/",
+    "attendees": 2
+  },
+  {
+    "title": "F Breast Cancer",
+    "date": "2020-02-29",
+    "startTime": "15:00",
+    "location": "Billsburg Brewery, 2054 Jamestown Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/268909736/",
+    "attendees": 4
+  },
+  {
+    "title": "2416 - Clits 'n Chips, & Cow Poke",
+    "date": "2020-02-22",
+    "startTime": "15:00",
+    "location": "Warhill High School, 4615 Opportunity Way, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/266462170/",
+    "attendees": 4
+  },
+  {
+    "title": "Virginia Beer Company, noon today, Hash it across America",
+    "date": "2020-01-12",
+    "startTime": "12:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/267853802/",
+    "attendees": 1
+  },
+  {
+    "title": "FEH3 Turns 48 - Bar Crawl/Hashit Across America Move",
+    "date": "2019-11-09",
+    "startTime": "15:00",
+    "location": "Oozlefinch Beers & Blending, 81 Patch Rd, Fort Monroe, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/266019062/",
+    "attendees": 10
+  },
+  {
+    "title": "4th Quarter Drinking Practice",
+    "date": "2019-09-10",
+    "startTime": "18:30",
+    "location": "Whole Foods Market, 12090 Jefferson Ave Ste 100, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/264698444/",
+    "attendees": 3
+  },
+  {
+    "title": "FEH3 Trail #2403 - Dead Elvis",
+    "date": "2019-08-24",
+    "startTime": "13:00",
+    "location": "Casa de Cavity Search, 1936 Lancing Crest Lane, Chesapeake, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/263866053/",
+    "attendees": 5
+  },
+  {
+    "title": "Moving Hash",
+    "date": "2019-08-11",
+    "startTime": "10:00",
+    "location": "958 Edgewater Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/263853365/",
+    "attendees": 2
+  },
+  {
+    "title": "2402 - BBQ & NFN Micheal",
+    "date": "2019-08-10",
+    "startTime": "15:00",
+    "location": "Tabb Elementary School, 3711 Big Bethel Rd, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/261285076/",
+    "attendees": 4
+  },
+  {
+    "title": "2401 - Cum Line & Anal",
+    "date": "2019-07-27",
+    "startTime": "15:00",
+    "location": "Huntington Park, Mercury Blvd & Riverpark Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/261285024/",
+    "attendees": 12
+  },
+  {
+    "title": "PNA Site Clean Up for 2400th/SPAM event",
+    "date": "2019-06-22",
+    "startTime": "10:00",
+    "location": "600 Brittain Ln, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/261286453/",
+    "attendees": 4
+  },
+  {
+    "title": "Carpool To RH3 Green Dress",
+    "date": "2019-03-09",
+    "startTime": "10:00",
+    "location": "PNA's Place, 702 Ida St, Hampton, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/255828586/",
+    "attendees": 1
+  },
+  {
+    "title": "One City Marathon & Half Beer Stop",
+    "date": "2019-03-03",
+    "startTime": "07:00",
+    "location": "Warwick Boulevard, Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/259168787/",
+    "attendees": 3
+  },
+  {
+    "title": "2390 - Cow Poke",
+    "date": "2019-02-23",
+    "startTime": "15:00",
+    "location": "200 Arthur Way, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/255828479/",
+    "attendees": 5
+  },
+  {
+    "title": "Drinking Practice!",
+    "date": "2019-02-12",
+    "startTime": "18:00",
+    "location": "Mellow Mushroom Newport News, 12090 Jefferson Ave Suite 1500, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/258727604/",
+    "attendees": 5
+  },
+  {
+    "title": "Renegade Wednesday Trail",
+    "date": "2019-02-06",
+    "startTime": "17:45",
+    "location": "County Grill & Smokehouse, 26 E Mercury Blvd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/258700237/",
+    "attendees": 3
+  },
+  {
+    "title": "2383 - Maryland Mauler",
+    "date": "2018-11-17",
+    "startTime": "15:00",
+    "location": "York County General District Court, 300 Ballard St, Yorktown, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/252901983/",
+    "attendees": 6
+  },
+  {
+    "title": "2382 - Build Your Own Superhero - Costume Trail",
+    "date": "2018-10-20",
+    "startTime": "15:00",
+    "location": "Family Dollar, 461 Merrimac Trail, Williamsburg, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/249903498/",
+    "attendees": 5
+  },
+  {
+    "title": "Wanking Man Campout",
+    "date": "2018-10-05",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/249903332/",
+    "attendees": 9
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-4.json
+++ b/scripts/data/feh3-meetup-history-batch-4.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "2380 - Whirled Peas Through Beer",
+    "date": "2018-09-22",
+    "startTime": "15:00",
+    "location": "Buckroe Beach Park, 100 South 1st Street, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247333303/",
+    "attendees": 9
+  },
+  {
+    "title": "2379, Beer Mile, hared by KISS",
+    "date": "2018-09-08",
+    "startTime": "15:00",
+    "location": "JM Dozier Middle School, 432 Industrial Park Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247333364/",
+    "attendees": 11
+  },
+  {
+    "title": "2378 - Super Soaker Battle Hash & HemoGoblin's Bday Trail",
+    "date": "2018-08-25",
+    "startTime": "15:00",
+    "location": "Trail #2378 Start Location, 1909 Commerce Dr, Hampton, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/250011541/",
+    "attendees": 14
+  },
+  {
+    "title": "2377 - A.N.A.L. - Snare Me If You Can",
+    "date": "2018-08-11",
+    "startTime": "15:00",
+    "location": "Newport Crossings Shopping Center, 467 Oriana Road, Newport News, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/249836718/",
+    "attendees": 11
+  },
+  {
+    "title": "2376 - The SPAM Run, Straight from the Can",
+    "date": "2018-07-28",
+    "startTime": "14:00",
+    "location": "Bird Farm, 900 Brittain Ln, Hampton, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247333252/",
+    "attendees": 11
+  },
+  {
+    "title": "23rd Gentleman's Quarterly H3 & CB2H2",
+    "date": "2018-07-21",
+    "startTime": "14:00",
+    "location": "PNA's Place, 702 Ida St, Hampton, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/251264073/",
+    "attendees": 6
+  },
+  {
+    "title": "Drinking Practice",
+    "date": "2018-07-17",
+    "startTime": "18:00",
+    "location": "Jose Tequilas, 615 Thimble Shoals Blvd, Newport News, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/252712798/",
+    "attendees": 4
+  },
+  {
+    "title": "2375 - Rolling of the Bulls",
+    "date": "2018-07-14",
+    "startTime": "14:00",
+    "location": "Settlers Landing, 555 Settlers Landing Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247392199/",
+    "attendees": 12
+  },
+  {
+    "title": "Running of Bulls??, Hampton",
+    "date": "2018-07-07",
+    "startTime": "11:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/247360308/",
+    "attendees": 1
+  },
+  {
+    "title": "2374 - Neighbor's B-Day Trail #8 - Reclaim the base",
+    "date": "2018-06-30",
+    "startTime": "15:00",
+    "location": "Liberty at Harbour View, 7025 Harbour View Blvd, Suffolk, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247333200/",
+    "attendees": 9
+  },
+  {
+    "title": "STFU H3 - Neighbor's B-Day Trail #3",
+    "date": "2018-06-25",
+    "startTime": "18:15",
+    "location": "Discovery Park, 5416 Discovery Park Blvd, Williamsburg, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/251913759/",
+    "attendees": 4
+  },
+  {
+    "title": "Wanking Man 1.69 - Neighbor B-Day Trail #1",
+    "date": "2018-06-23",
+    "startTime": "15:00",
+    "location": "Donkey's Stable, 14221 Cooks Mill Rd, Lanexa, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/251913608/",
+    "attendees": 4
+  },
+  {
+    "title": "2373, Cum Line & Cow Poke, School's Out",
+    "date": "2018-06-16",
+    "startTime": "15:00",
+    "location": "Kohl's, 551 Bland Blvd, Newport News, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247333130/",
+    "attendees": 13
+  },
+  {
+    "title": "BDSM H3 Trail #17 - Northside",
+    "date": "2018-06-04",
+    "startTime": "18:00",
+    "location": "Robinson & Benns Park, Benns rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/251234895/",
+    "attendees": 2
+  },
+  {
+    "title": "2372 - The Battle of Yorktown",
+    "date": "2018-06-02",
+    "startTime": "15:00",
+    "location": "York High School, 9300 George Washington Memorial Highway, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247392085/",
+    "attendees": 10
+  },
+  {
+    "title": "2372, contact Cow Poke if you want to hare",
+    "date": "2018-06-02",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/247333477/",
+    "attendees": 1
+  },
+  {
+    "title": "2371: Taint, GIISM, & Clean Up Crew",
+    "date": "2018-05-19",
+    "startTime": "15:00",
+    "location": "Turn Key Real Estate, LLC, 1124 Big Bethel Road, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247333460/",
+    "attendees": 16
+  },
+  {
+    "title": "Bar Golf w/ Cum Line",
+    "date": "2018-05-12",
+    "startTime": "16:30",
+    "location": "Shaka's, 2014 Atlantic Ave., Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247333430/",
+    "attendees": 1
+  },
+  {
+    "title": "2370 - Cinco de Mayo",
+    "date": "2018-05-05",
+    "startTime": "15:00",
+    "location": "Bethel High School, 1067 Big Bethel Road, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247332181/",
+    "attendees": 11
+  },
+  {
+    "title": "2369 - Pearl Necklace Trail",
+    "date": "2018-04-21",
+    "startTime": "15:00",
+    "location": "Mary Passage Middle School, 400 Atkinson Way, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/244938360/",
+    "attendees": 2
+  },
+  {
+    "title": "Drinking Practice - Misman Meeting",
+    "date": "2018-04-17",
+    "startTime": "18:30",
+    "location": "Schooners Grill, 12567 Warwick Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/249606540/",
+    "attendees": 4
+  },
+  {
+    "title": "2368 - Tunnel Trail",
+    "date": "2018-04-07",
+    "startTime": "15:00",
+    "location": "Kmart, 401 Oriana Road, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247330961/",
+    "attendees": 9
+  },
+  {
+    "title": "Brew Day for GQ",
+    "date": "2018-03-31",
+    "startTime": "15:00",
+    "location": "PNA's Place, 702 Ida St, Hampton, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/249187648/",
+    "attendees": 3
+  },
+  {
+    "title": "2367, FEH3 Invades the 22nd GQ in Tidewater",
+    "date": "2018-03-24",
+    "startTime": "14:00",
+    "location": "St. Nicholas Catholic Church, 712 Little Neck Rd, Virginia Beach, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247331511/",
+    "attendees": 1
+  },
+  {
+    "title": "The Beer Mile-ish",
+    "date": "2018-03-18",
+    "startTime": "11:30",
+    "location": "Beach Garden Park, 2854 Kilbourne Court, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/248510635/",
+    "attendees": 3
+  },
+  {
+    "title": "2366 - Butt Light Goes to Hampton",
+    "date": "2018-03-10",
+    "startTime": "15:00",
+    "location": "Grandview Natural Preserve, State Park Drive, Hampton, Vi, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247331344/",
+    "attendees": 8
+  },
+  {
+    "title": "2365 - Second Anal FEH3 Red Dress Run",
+    "date": "2018-02-24",
+    "startTime": "15:00",
+    "location": "Traditions Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/244601146/",
+    "attendees": 15
+  },
+  {
+    "title": "BDSM Monday Hampton Trail",
+    "date": "2018-02-19",
+    "startTime": "18:00",
+    "location": "Briarfield, 404 E Street, Hampton, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247816324/",
+    "attendees": 2
+  },
+  {
+    "title": "2364 - NFN Bag of Dicks & Water Closet Wanker!",
+    "date": "2018-02-10",
+    "startTime": "15:00",
+    "location": "Machen Elementary, 20 Sacramento Drive, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/244790992/",
+    "attendees": 5
+  },
+  {
+    "title": "Drinking Practice - Misman Meeting",
+    "date": "2018-01-30",
+    "startTime": "18:00",
+    "location": "BJ's Restaurant & Brewhouse, 12090 Jefferson Ave Ste 1400, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/247087692/",
+    "attendees": 4
+  },
+  {
+    "title": "Froggie, Menage, Brown Towel, & Captain Bangeroo",
+    "date": "2018-01-27",
+    "startTime": "15:00",
+    "location": "BC Charles Elementary School, 701 Menchville Rd,, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/244790736/",
+    "attendees": 14
+  },
+  {
+    "title": "Peninsula Hash, Highspeed Cockbumper & CumLine",
+    "date": "2018-01-16",
+    "startTime": "18:00",
+    "location": "Sears, 100 Newmarket Dr North, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/246834208/",
+    "attendees": 3
+  },
+  {
+    "title": "Hared by Whoredor & Cum Line",
+    "date": "2018-01-13",
+    "startTime": "15:00",
+    "location": "*Newport Crossings Shopping Center, 467 Oriana Road, Newport News, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/244673982/",
+    "attendees": 14
+  },
+  {
+    "title": "Sparkle Dress hared by PNA & Froggie",
+    "date": "2017-12-30",
+    "startTime": "15:00",
+    "location": "Coventry Elementary School, 200 Owen Davis Boulevard, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243635298/",
+    "attendees": 12
+  },
+  {
+    "title": "STFUH3 Trail Number #55 - Northside",
+    "date": "2017-12-18",
+    "startTime": "18:00",
+    "location": "George Phenix School, 1061 Big Bethel Rd, Hampton, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/245945604/",
+    "attendees": 2
+  },
+  {
+    "title": "JINGLE BALLS, hared My PNA",
+    "date": "2017-12-16",
+    "startTime": "15:00",
+    "location": "City Center Start, 724 Thimble Shoals Blvd, Newport News, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243635294/",
+    "attendees": 8
+  },
+  {
+    "title": "Family Hash, NEW location with awning, kids free",
+    "date": "2017-12-09",
+    "startTime": "15:00",
+    "location": "Machen Elementary, 20 Sacramento Drive, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/244790583/",
+    "attendees": 3
+  },
+  {
+    "title": "Hares: Clean Up Crew & NFN Hunter",
+    "date": "2017-12-02",
+    "startTime": "15:00",
+    "location": "OSC, 250 Nat Turner Blvd., Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243635290/",
+    "attendees": 9
+  },
+  {
+    "title": "STFU Peninsula Hash",
+    "date": "2017-11-27",
+    "startTime": "19:00",
+    "location": "Next to Tennis Courts, 404 E Street, Hampton, va, US",
+    "url": "https://www.meetup.com/feh3-hash/events/245416199/",
+    "attendees": 1
+  },
+  {
+    "title": "Wanking Man",
+    "date": "2017-11-25",
+    "startTime": "10:00",
+    "location": "Donkey Stable, Lanexa, actually New Kent, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243629117/",
+    "attendees": 8
+  },
+  {
+    "title": "Hare: Reach Around, somewhere in Yorktown",
+    "date": "2017-11-18",
+    "startTime": "15:00",
+    "location": "Reach Around Hound's House, 100 Chestnut Court, yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243635280/",
+    "attendees": 6
+  },
+  {
+    "title": "Spam hash, hared by SPAM",
+    "date": "2017-11-04",
+    "startTime": "15:00",
+    "location": "SPAM's Can, 902 Abingdon Court, Newport News, VA, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243635265/",
+    "attendees": 12
+  },
+  {
+    "title": "WHIRLED PEAS",
+    "date": "2017-10-21",
+    "startTime": "15:00",
+    "location": "Traditions Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243635251/",
+    "attendees": 6
+  },
+  {
+    "title": "Slap & Semen's Wedding Hash",
+    "date": "2017-10-15",
+    "startTime": "11:00",
+    "location": "Slap & Semen's place, 4716 Deliverance Dr, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243948614/",
+    "attendees": 6
+  },
+  {
+    "title": "Hares: Whoredor and Cumline",
+    "date": "2017-10-07",
+    "startTime": "15:00",
+    "location": "R. O. Nelson Elementary School, 826 Moyer Road, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240530408/",
+    "attendees": 7
+  },
+  {
+    "title": "Tuesday, Tuesday, Tuesday HASH will be on the Peninsula (SPAM is haring)",
+    "date": "2017-10-03",
+    "startTime": "18:00",
+    "location": "Oozlelefinch Brewery, 81 Patch Road, Fort Monroe, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243707340/",
+    "attendees": 5
+  },
+  {
+    "title": "Help Tesla move & Hash",
+    "date": "2017-09-30",
+    "startTime": "11:00",
+    "location": "Tesla's abode, 106 Great Glen, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/243615859/",
+    "attendees": 6
+  },
+  {
+    "title": "HARE: SPAM",
+    "date": "2017-09-23",
+    "startTime": "15:00",
+    "location": "York High School, 9300 George Washington Memorial Highway, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240530396/",
+    "attendees": 8
+  },
+  {
+    "title": "Hare: Cow Poke",
+    "date": "2017-09-09",
+    "startTime": "15:00",
+    "location": "Kiln Creek Elementary School, 1501 Kiln Creek Pkwy, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240085057/",
+    "attendees": 5
+  },
+  {
+    "title": "Family, Dog, & Stroller Friendly Hash. Hare: Cow Poke",
+    "date": "2017-09-02",
+    "startTime": "15:00",
+    "location": "Traditions Brewery, 700 Thimble Shoals Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/242784954/",
+    "attendees": 3
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-5.json
+++ b/scripts/data/feh3-meetup-history-batch-5.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Drinking Practice at Port Warwick Concert, BYOB",
+    "date": "2017-08-30",
+    "startTime": "18:00",
+    "location": "Port Warwick, 3100 William Styron Square N, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/242875322/",
+    "attendees": 1
+  },
+  {
+    "title": "Hares: Kiss & PNA. Bring your squirt guns and water bombs.",
+    "date": "2017-08-26",
+    "startTime": "15:00",
+    "location": "Menchville High School, 275 Menchville Rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240530284/",
+    "attendees": 8
+  },
+  {
+    "title": "Hares: KISS and My PNA, on Peninsula, not a FEH3 event",
+    "date": "2017-08-22",
+    "startTime": "18:00",
+    "location": "Woodland Golf Course, 9. Woodland Dr, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/242029626/",
+    "attendees": 3
+  },
+  {
+    "title": "Hare: SPAM AGAIN",
+    "date": "2017-08-12",
+    "startTime": "15:00",
+    "location": "Grafton High School, 403 Grafton Dr., York County, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240530361/",
+    "attendees": 5
+  },
+  {
+    "title": "Full Moon & Toga. Hares: KISS & My PNA. Not a FEH3 event.",
+    "date": "2017-08-11",
+    "startTime": "18:45",
+    "location": "Norfolk Public Library: Mary D Pretlow Anchor Branch, 111 West Ocean View Avenue, Norfolk, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/242168317/",
+    "attendees": 5
+  },
+  {
+    "title": "Family Hash, hare: My PNA",
+    "date": "2017-08-05",
+    "startTime": "15:00",
+    "location": "37.054974, -76.489917, 100 Museum Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240085230/",
+    "attendees": 5
+  },
+  {
+    "title": "Dirty Dick, Suck it for Stars, NFN Freedom (naming)",
+    "date": "2017-07-29",
+    "startTime": "15:00",
+    "location": "back right corner, 11008 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240195716/",
+    "attendees": 7
+  },
+  {
+    "title": "hare: Cow Poke, down-downs @ Stillwater, not a FEH3 event",
+    "date": "2017-07-25",
+    "startTime": "18:00",
+    "location": "Hampton High School, 1491 West Queen Street, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/241329091/",
+    "attendees": 5
+  },
+  {
+    "title": "Penis Needs Attachment",
+    "date": "2017-07-15",
+    "startTime": "15:00",
+    "location": "37.058420, -76.329467, near the ABC Store, 227 Fox Hill Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240530341/",
+    "attendees": 8
+  },
+  {
+    "title": "FEH3 Rolling of the Bulls",
+    "date": "2017-07-08",
+    "startTime": "14:00",
+    "location": "Hampton City Hall parking lot, 301 Eaton St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/239213718/",
+    "attendees": 4
+  },
+  {
+    "title": "SPAM haring",
+    "date": "2017-07-01",
+    "startTime": "15:00",
+    "location": "Lee Hall Elementary, 17346 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/239190785/",
+    "attendees": 6
+  },
+  {
+    "title": "Cum Line & ANAL",
+    "date": "2017-06-28",
+    "startTime": "17:30",
+    "location": "Suite Life, 112 C Suite Life Circle, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/241106255/",
+    "attendees": 3
+  },
+  {
+    "title": "Reach Around Hound",
+    "date": "2017-06-17",
+    "startTime": "15:00",
+    "location": "Grafton-Bethel Elementary School, 410 Lakeside Drive, Grafton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/238824772/",
+    "attendees": 11
+  },
+  {
+    "title": "Cow Poke, T3H3",
+    "date": "2017-06-13",
+    "startTime": "18:00",
+    "location": "Boo Williams Sportsplex, 5 Armistead Pointe Parkway, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240232495/",
+    "attendees": 3
+  },
+  {
+    "title": "Family Hash, Cow Poke",
+    "date": "2017-06-10",
+    "startTime": "15:00",
+    "location": "Kiln Creek Elementary School, 1501 Kiln Creek Pkwy, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/240084904/",
+    "attendees": 6
+  },
+  {
+    "title": "DRUNK NIEGHBOR and NFN JOANNA",
+    "date": "2017-06-03",
+    "startTime": "15:00",
+    "location": "Oozlefinch Brewery, 81 Patch Road, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/239514660/",
+    "attendees": 9
+  },
+  {
+    "title": "FEH3 #2341! Invades POHO",
+    "date": "2017-05-20",
+    "startTime": "14:00",
+    "location": "Castleburg Brewery and Taproom, 1626 Ownby Lane, Richmond, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/239514658/",
+    "attendees": 3
+  },
+  {
+    "title": "Family Hash- CLAM Mother's Day Hash (southside)",
+    "date": "2017-05-13",
+    "startTime": "10:30",
+    "location": "Chesapeake Arboretum, 624 Oak Grove Rd, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/239427079/",
+    "attendees": 3
+  },
+  {
+    "title": "FEH3 2340: CowPoke's Search For The Golden Nectar",
+    "date": "2017-05-06",
+    "startTime": "15:00",
+    "location": "Kiln Creek Elementary School, 1501 Kiln Creek Pkwy, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/238605934/",
+    "attendees": 5
+  },
+  {
+    "title": "HASH WITH T3H3! Cause TUESDAY IS A HASHING DAY!!!",
+    "date": "2017-05-02",
+    "startTime": "18:00",
+    "location": "HOMO'S HOTEL MOTEL, 18 Laurel Dr, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/239652155/",
+    "attendees": 5
+  },
+  {
+    "title": "FEH3's 2339: POHO's Earth Day Trail",
+    "date": "2017-04-22",
+    "startTime": "14:00",
+    "location": "Kiwanis Municipal Park, 125 Longhill Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/237168618/",
+    "attendees": 11
+  },
+  {
+    "title": "836th Tuesday Tuesday Tuesday H3 Trail",
+    "date": "2017-04-18",
+    "startTime": "18:00",
+    "location": "Bryan Elementary school, 1021 N Mallory St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/239188144/",
+    "attendees": 4
+  },
+  {
+    "title": "FEH3's 2338: CowPoke's Cow Tipping Awareness Trail",
+    "date": "2017-04-08",
+    "startTime": "15:00",
+    "location": "State Farm Poquoson, 400 City Hall Ave, Poquoson, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/238054284/",
+    "attendees": 10
+  },
+  {
+    "title": "#2337 The Clean Up Crew: Kunk Edition",
+    "date": "2017-03-25",
+    "startTime": "15:00",
+    "location": "Hiddenwood Elementary School, 501 Blount Point Rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/236344189/",
+    "attendees": 11
+  },
+  {
+    "title": "Tuesday! Tuesday!",
+    "date": "2017-03-21",
+    "startTime": "18:00",
+    "location": "plaza roller rink, 1924 E. Pembroke ave., Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/238564359/",
+    "attendees": 2
+  },
+  {
+    "title": "#2336: SPAM's Wilderness Exploration Trail",
+    "date": "2017-03-11",
+    "startTime": "15:00",
+    "location": "SPAM's Place, 902 Abingdon Court, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/236262875/",
+    "attendees": 8
+  },
+  {
+    "title": "Family Hash Bash #4: Arts, Family, And Friends",
+    "date": "2017-03-04",
+    "startTime": "15:00",
+    "location": "Cinema Cafe, 1044 Von Schilling Dr, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/238043246/",
+    "attendees": 8
+  },
+  {
+    "title": "Party GRAS TRAIL IN VIRGINIA BEACH",
+    "date": "2017-02-25",
+    "startTime": "11:30",
+    "location": "Bridge Center, 4966 Euclid Rd Suite 101, VIRGINIA BEACH, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/234746332/",
+    "attendees": 5
+  },
+  {
+    "title": "HASH WITH TUESDAY TUESDAY IN HAMPTON!!",
+    "date": "2017-02-21",
+    "startTime": "18:00",
+    "location": "The Dead Rise on Fort Monroe, 100 McNair Dr, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/237835532/",
+    "attendees": 1
+  },
+  {
+    "title": "Family HASH",
+    "date": "2017-02-19",
+    "startTime": "15:00",
+    "location": "TBA- earth, in the general area of Virginia, 101 earthling lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/237829409/",
+    "attendees": 1
+  },
+  {
+    "title": "PBR NIGHT!",
+    "date": "2017-02-18",
+    "startTime": "20:00",
+    "location": "TAPPS, 1976 POWER PLANT PKWY, HAMPTON, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/237633813/",
+    "attendees": 1
+  },
+  {
+    "title": "Banana Clit's Birthday trail #2334",
+    "date": "2017-02-11",
+    "startTime": "15:00",
+    "location": "Poquoson Municipal Pool, 16 Municipal Dr, Poquoson, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/236191286/",
+    "attendees": 6
+  },
+  {
+    "title": "Hash-a-tit for Humanity Blue Dress Run",
+    "date": "2017-02-04",
+    "startTime": "15:00",
+    "location": "Hi Richmond Hostel, 7 N 2nd St, Richmond, VA, Richmond, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/236873878/",
+    "attendees": 3
+  },
+  {
+    "title": "T3H3 - Penzinsula Side Trail",
+    "date": "2017-01-31",
+    "startTime": "18:00",
+    "location": "TBA- earth, in the general area of Virginia, 101 earthling lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/236625706/",
+    "attendees": 7
+  },
+  {
+    "title": "#2333 First Anal Deep freeze- Red Dress Hash",
+    "date": "2017-01-28",
+    "startTime": "14:00",
+    "location": "Bull Island Brewing Company, 758 Settlers Landing Rd, Hampton, Virginia 23669, hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232884143/",
+    "attendees": 21
+  },
+  {
+    "title": "FEH3 #2332: SPAM's Scintillating Scavenger Steeplechase",
+    "date": "2017-01-14",
+    "startTime": "15:00",
+    "location": "Grafton High School, 401 Grafton Dr, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/233102513/",
+    "attendees": 16
+  },
+  {
+    "title": "Free Family Hash Bash!!!!",
+    "date": "2017-01-07",
+    "startTime": "13:00",
+    "location": "AMF Bowling Center, 4200 George Washington Mem Hwy, Grafton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/236517071/",
+    "attendees": 6
+  },
+  {
+    "title": "#2331 MY P.N.A. NEW YEAR'S TRAIL",
+    "date": "2016-12-31",
+    "startTime": "13:00",
+    "location": "Dark Lord Start, 300 Butler farm rd, Newport news, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/234528799/",
+    "attendees": 14
+  },
+  {
+    "title": "#2330 FrogG4y! Lights Shooting Star trail",
+    "date": "2016-12-17",
+    "startTime": "18:00",
+    "location": "Kraft Elementary School, 600 Concord Drive, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232848258/",
+    "attendees": 11
+  },
+  {
+    "title": "December Family Hash Bash with Cowpoke",
+    "date": "2016-12-10",
+    "startTime": "14:00",
+    "location": "101 Village Ave, Yorktown 23693, 101 Village Ave, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/236059012/",
+    "attendees": 4
+  },
+  {
+    "title": "FEH3 Arts N Tesla Trail: Season 1 Episode 1",
+    "date": "2016-12-03",
+    "startTime": "14:00",
+    "location": "Griffin - Yeates Center, 1490 Government Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/233986773/",
+    "attendees": 11
+  },
+  {
+    "title": "\"Timmay's­ Fantasy Trail to End All Trails\" Trail #2328",
+    "date": "2016-11-19",
+    "startTime": "15:00",
+    "location": "Froggy's pad, 305 Boyd Circle, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232679962/",
+    "attendees": 13
+  },
+  {
+    "title": "Friday Game And Prelube",
+    "date": "2016-11-18",
+    "startTime": "20:02",
+    "location": "Froggy's pad, 305 Boyd Circle, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/235633216/",
+    "attendees": 3
+  },
+  {
+    "title": "INFORMAL FAMILY HASH",
+    "date": "2016-11-12",
+    "startTime": "15:00",
+    "location": "Kiln Creek Park, 2901 Kiln Creek Pkwy, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/235414485/",
+    "attendees": 10
+  },
+  {
+    "title": "FEH3's Interracial Racest TRAIL #2327",
+    "date": "2016-11-05",
+    "startTime": "13:00",
+    "location": "Merrimack Elementary School, 2113 Woodmansee Dr., Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/233689598/",
+    "attendees": 11
+  },
+  {
+    "title": "Arrested Bucks! - World Peace Through Beer Week",
+    "date": "2016-10-25",
+    "startTime": "18:30",
+    "location": "Brentwood Shopping Center, 10530 Jefferson Ave, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/234255141/",
+    "attendees": 7
+  },
+  {
+    "title": "# 2326 A dark Cow Rises!! -Cowpoke and NFN Dark Lord hare",
+    "date": "2016-10-22",
+    "startTime": "15:00",
+    "location": "Booker T Washington Middle School, 3700 Chestnut Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/234746258/",
+    "attendees": 11
+  },
+  {
+    "title": "SpamALot: Donkeys Epic Journey",
+    "date": "2016-10-08",
+    "startTime": "14:00",
+    "location": "Donkey's Lair, 740 Old Fort Eustis Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/233134731/",
+    "attendees": 10
+  },
+  {
+    "title": "Oozlefinch Brewery Run",
+    "date": "2016-10-02",
+    "startTime": "15:00",
+    "location": "Oozlefinch Brewery, 81 Patch Road, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/234553322/",
+    "attendees": null
+  },
+  {
+    "title": "Hunt For GLAZED DEZNUTS T3H3",
+    "date": "2016-09-27",
+    "startTime": "18:00",
+    "location": "Glazed Doughnuts, 24 Wine St., Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/234422426/",
+    "attendees": 5
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-6.json
+++ b/scripts/data/feh3-meetup-history-batch-6.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Cherry shaft Trail",
+    "date": "2016-09-24",
+    "startTime": "15:00",
+    "location": "5452 Olde Towne Road Williamsburg, 23188, 5452 Olde Towne Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232848091/",
+    "attendees": 13
+  },
+  {
+    "title": "Important Notes!! Read If You're Haring. Copied With Permission By TIMMAY",
+    "date": "2016-09-21",
+    "startTime": "06:00",
+    "location": "Earth, 123 You Need To Know This, Aroostook County, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/234268874/",
+    "attendees": 1
+  },
+  {
+    "title": "Back to Hash Bash!- Family hash",
+    "date": "2016-09-10",
+    "startTime": "14:00",
+    "location": "Harwoods Mill Park, 368 Oriana Road, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232745758/",
+    "attendees": 23
+  },
+  {
+    "title": "Cards Against Humanity at Froggy's pad",
+    "date": "2016-09-09",
+    "startTime": "20:30",
+    "location": "Froggy's pad, 305 Boyd Circle, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/233972353/",
+    "attendees": 4
+  },
+  {
+    "title": "Va BeachTrash Pick-up",
+    "date": "2016-08-27",
+    "startTime": "10:30",
+    "location": "Parking lot, 4625 Shore Drive, Va beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/233533299/",
+    "attendees": 1
+  },
+  {
+    "title": "#2322 Running Of FEH3... TUTU HASH",
+    "date": "2016-08-27",
+    "startTime": "15:00",
+    "location": "Casa de Kiss, 963 Lacon Dr., Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232544642/",
+    "attendees": 7
+  },
+  {
+    "title": "Drinking Practice at O'Hermans",
+    "date": "2016-08-26",
+    "startTime": "19:30",
+    "location": "O'herman's, 16912 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/233527009/",
+    "attendees": 5
+  },
+  {
+    "title": "800Th Tuesday Tuesday Tuesday TRAIL- Froggy Guts Trail",
+    "date": "2016-08-16",
+    "startTime": "18:00",
+    "location": "St. George Brewery, 204 Challenger Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/233373015/",
+    "attendees": 3
+  },
+  {
+    "title": "NFNs Posse & COWPOKING TRAIL!",
+    "date": "2016-08-13",
+    "startTime": "15:00",
+    "location": "Kiln Creek Elementary School, 1501 Kiln Creek Pkwy, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232619645/",
+    "attendees": 8
+  },
+  {
+    "title": "Quarterly Mismanagement Meeting! Cum one, Cum all.",
+    "date": "2016-08-03",
+    "startTime": "19:00",
+    "location": "Mellow Mushroom, 12090 Jefferson Ave, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232899672/",
+    "attendees": 6
+  },
+  {
+    "title": "COWPOKE trail",
+    "date": "2016-07-30",
+    "startTime": "15:00",
+    "location": "Old Kroger now building a church, 101 Village Ave, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/231620134/",
+    "attendees": 9
+  },
+  {
+    "title": "Spontaneous BILLIARDS at O'Herman's In NN",
+    "date": "2016-07-27",
+    "startTime": "20:00",
+    "location": "O'herman's, 16912 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232928577/",
+    "attendees": 4
+  },
+  {
+    "title": "Archer Hash #2219",
+    "date": "2016-07-16",
+    "startTime": "15:00",
+    "location": "Oliver Greenwood Elementary School, 13460 Woodside Ln, Newport News, VA 23608, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/231592131/",
+    "attendees": 19
+  },
+  {
+    "title": "FEH3 ROLLING OF THE BULLS #2218",
+    "date": "2016-07-09",
+    "startTime": "14:00",
+    "location": "Hampton City Hall parking lot, 301 Eaton St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/231287072/",
+    "attendees": 7
+  },
+  {
+    "title": "Tuesday Tueday Tuesday Hash, on the northside",
+    "date": "2016-07-05",
+    "startTime": "18:00",
+    "location": "Stillwater Tavern, 50 Old Hampton Lane, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232381398/",
+    "attendees": 6
+  },
+  {
+    "title": "Drink Neighbors Trail #4 SNOWCONES",
+    "date": "2016-06-27",
+    "startTime": "18:30",
+    "location": "Parking Deck At 1400 Middle St. Williamsburg VA, 1400 Middle St, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/232183585/",
+    "attendees": 9
+  },
+  {
+    "title": "Drunk Neighbor's German Invasion #2017",
+    "date": "2016-06-25",
+    "startTime": "15:00",
+    "location": "Behind Riverside Supply, 1300 Old Denbigh Blvd, Newport News, VA, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/231707024/",
+    "attendees": 14
+  },
+  {
+    "title": "Drink Neighbor's 9 days of trail- trail info!! Starts Friday June 24th",
+    "date": "2016-06-24",
+    "startTime": "19:15",
+    "location": "June 24th trail address, 550 First Colonial Rd, Va beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/231863936/",
+    "attendees": 6
+  },
+  {
+    "title": "Freedom TRAIL #2016",
+    "date": "2016-06-04",
+    "startTime": "15:00",
+    "location": "Casa de Kiss, 963 Lacon Dr., Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229814430/",
+    "attendees": 12
+  },
+  {
+    "title": "Raise a glass to those that are missing and those that are missed",
+    "date": "2016-05-21",
+    "startTime": "07:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/229814415/",
+    "attendees": 4
+  },
+  {
+    "title": "TUESDAY! TUESDAY! TUESDAY",
+    "date": "2016-05-10",
+    "startTime": "18:00",
+    "location": "Briarfield Tennis Couts, 1590 Briarfield Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/230965444/",
+    "attendees": 4
+  },
+  {
+    "title": "Froggy Style and DSBCRVT (aka The Long One)",
+    "date": "2016-05-07",
+    "startTime": "15:00",
+    "location": "BC Charles Elementary School, 701 Menchville Rd,, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229814384/",
+    "attendees": 3
+  },
+  {
+    "title": "G.R.I.T.S VS GLITTER GIRL BEER MILE! #2013",
+    "date": "2016-04-23",
+    "startTime": "15:00",
+    "location": "Berkley Middle, 1118 Ironbound Rd, williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229814363/",
+    "attendees": 3
+  },
+  {
+    "title": "T3H3- Ft. Monroe Trail",
+    "date": "2016-04-12",
+    "startTime": "18:00",
+    "location": "Gazabo at Ft. Monroe, Ft. Monroe, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/230268187/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #2012",
+    "date": "2016-04-09",
+    "startTime": "15:30",
+    "location": "Matthew Whaley Elem School, 301 Scotland St, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229548759/",
+    "attendees": 6
+  },
+  {
+    "title": "Frog Hunt Hash-FEH3 #2011",
+    "date": "2016-03-26",
+    "startTime": "13:00",
+    "location": "Froggy's home, 305 boyd circle, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229712953/",
+    "attendees": 6
+  },
+  {
+    "title": "FEH3 TRAIL #2310.",
+    "date": "2016-03-12",
+    "startTime": "15:00",
+    "location": "JM Dozier Middle School, 432 Industrial Park Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229209671/",
+    "attendees": 26
+  },
+  {
+    "title": "777th TUESDAY TUESDAY TUESDAY is coming to Hampton",
+    "date": "2016-03-08",
+    "startTime": "18:00",
+    "location": "Booker T Washington Middle School, 3700 Chestnut Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229228198/",
+    "attendees": 6
+  },
+  {
+    "title": "CLAM HASH HO, HO, HO, YO Trail (ladies only) Hampton",
+    "date": "2016-03-05",
+    "startTime": "12:00",
+    "location": "La Bodega Hampton, 22 Wine St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229117296/",
+    "attendees": 2
+  },
+  {
+    "title": "Leap Year Hash- Va Beach",
+    "date": "2016-02-29",
+    "startTime": "17:00",
+    "location": "food lion parking lot, 5020 Ferrell Pkwy, VB, 23464, Va beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/229100320/",
+    "attendees": 3
+  },
+  {
+    "title": "DONKEY DICKS TRAIL OF BEERS #2309",
+    "date": "2016-02-27",
+    "startTime": "15:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/228728894/",
+    "attendees": 27
+  },
+  {
+    "title": "Who wants to hare this wonderful Saturday? E-mail me!",
+    "date": "2016-02-20",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/227839926/",
+    "attendees": null
+  },
+  {
+    "title": "FEH3 Trail #2308",
+    "date": "2016-02-13",
+    "startTime": "15:00",
+    "location": "Old Kroger now building a church, 101 Village Ave, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/228153053/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #2307",
+    "date": "2016-01-30",
+    "startTime": "15:00",
+    "location": "Liver Institute Of Virginia, 12720 McManus Blvd, Newport news, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/228088334/",
+    "attendees": 7
+  },
+  {
+    "title": "FEH3 TRAIL #2306",
+    "date": "2016-01-16",
+    "startTime": "15:00",
+    "location": "Parking Garage, 1 University Place, Newport News, UM, US",
+    "url": "https://www.meetup.com/feh3-hash/events/227230096/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail #2305Happy NEW BEER",
+    "date": "2016-01-02",
+    "startTime": "15:00",
+    "location": "Kiln Creek Elementary School, 1501 Kiln Creek Pkwy, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/226950605/",
+    "attendees": 5
+  },
+  {
+    "title": "Annual Xmas Light Run #2304",
+    "date": "2015-12-19",
+    "startTime": "17:00",
+    "location": "Kraft Elementary School, 600 Concord Drive, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/226198355/",
+    "attendees": 13
+  },
+  {
+    "title": "HASH WITH TUESDAY TUESDAY TUESDAY",
+    "date": "2015-12-08",
+    "startTime": "18:00",
+    "location": "Farm Fresh, 608 E Mercury Blvd, hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/227209590/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail #2303",
+    "date": "2015-12-05",
+    "startTime": "15:00",
+    "location": "Parking Lot Behind Fresh Market, 5239 Monticello Ave, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/226950197/",
+    "attendees": 6
+  },
+  {
+    "title": "Lumber Jacks And Indian Girls#2302",
+    "date": "2015-11-21",
+    "startTime": "15:00",
+    "location": "Virginia Peninsula Association of Realtors, 1001 N Campus Parkway, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/226624165/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail #2301",
+    "date": "2015-11-07",
+    "startTime": "13:45",
+    "location": "Kmart parking lot, 118 Waller Mill Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/225558441/",
+    "attendees": 4
+  },
+  {
+    "title": "Peninsula Road Runners Beer Mile",
+    "date": "2015-11-01",
+    "startTime": "13:00",
+    "location": "Grafton High School Track, 403 Grafton Dr, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/226378660/",
+    "attendees": 1
+  },
+  {
+    "title": "Who wants to hare this wonderful Saturday? E-mail me!",
+    "date": "2015-10-31",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/225558438/",
+    "attendees": null
+  },
+  {
+    "title": "2300th running of the FEH3 hash! Whirrled Peas Through Beer",
+    "date": "2015-10-23",
+    "startTime": "18:45",
+    "location": "Sloppy's House, 175 East Ave, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/225558437/",
+    "attendees": 13
+  },
+  {
+    "title": "FEH3 TRAIL #2299",
+    "date": "2015-10-10",
+    "startTime": "15:00",
+    "location": "Lee Hall Elementary School, 17346 Warwick Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/225139596/",
+    "attendees": 5
+  },
+  {
+    "title": "FEH3 TRAIL #2298",
+    "date": "2015-09-26",
+    "startTime": "15:00",
+    "location": "Yorktown Parking Garage across from Water Street Grille, 323 Water St, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/225139589/",
+    "attendees": 12
+  },
+  {
+    "title": "FEH3 Trail #2297",
+    "date": "2015-09-12",
+    "startTime": "15:00",
+    "location": "Parking lot near RITA'S ICE CREAM, 220 Monticello Ave, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/225139486/",
+    "attendees": 5
+  },
+  {
+    "title": "Who wants to hare this wonderful Saturday? E-mail me!",
+    "date": "2015-09-05",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/224996244/",
+    "attendees": 2
+  },
+  {
+    "title": "Let There Be A Hash",
+    "date": "2015-08-29",
+    "startTime": "15:00",
+    "location": "Movie Tavern, 1430 High Street, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/221555049/",
+    "attendees": 4
+  },
+  {
+    "title": "Who wants to hare this wonderful Saturday? E-mail me!",
+    "date": "2015-08-22",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/221555046/",
+    "attendees": null
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-7.json
+++ b/scripts/data/feh3-meetup-history-batch-7.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Hash this Saturday",
+    "date": "2015-08-15",
+    "startTime": "15:00",
+    "location": "Kmart parking lot, 118 Waller Mill Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/224339877/",
+    "attendees": 4
+  },
+  {
+    "title": "Who wants to hare this wonderful Saturday? E-mail me!",
+    "date": "2015-08-01",
+    "startTime": "15:00",
+    "location": "Kohls, 100 Gristmill Plz, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/224109815/",
+    "attendees": 1
+  },
+  {
+    "title": "COWPOKE TO THE RESCUE",
+    "date": "2015-07-18",
+    "startTime": "15:00",
+    "location": "Kiln Creek Elementary School, 1501 Kiln Creek Pkwy, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/223876336/",
+    "attendees": 2
+  },
+  {
+    "title": "Hash with the ROLLING OF THE BULLS #2292",
+    "date": "2015-07-11",
+    "startTime": "15:30",
+    "location": "Hampton City Hall parking lot, 301 Eaton St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/223224504/",
+    "attendees": 4
+  },
+  {
+    "title": "Feh3 Trail #2291",
+    "date": "2015-06-20",
+    "startTime": "15:00",
+    "location": "Kiln Creek Elementary School, 1501 Kiln Creek Pkwy, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/222697128/",
+    "attendees": 4
+  },
+  {
+    "title": "FEH3 trail #2290",
+    "date": "2015-06-06",
+    "startTime": "15:00",
+    "location": "Hooters, 12640 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/222217751/",
+    "attendees": 4
+  },
+  {
+    "title": "Enjoy your Holiday Weekend",
+    "date": "2015-05-23",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/222276334/",
+    "attendees": 1
+  },
+  {
+    "title": "Feh3 #2289 Day 1 of Brown Towel's Seven Days of Shiggy",
+    "date": "2015-05-16",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/221475544/",
+    "attendees": 16
+  },
+  {
+    "title": "Feh3 #2288",
+    "date": "2015-05-09",
+    "startTime": "15:00",
+    "location": "Warehouse, 781 Industrial park dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/221464239/",
+    "attendees": 3
+  },
+  {
+    "title": "FEH3 trail #2287 fart jar strikes again",
+    "date": "2015-04-25",
+    "startTime": "15:00",
+    "location": "Venture Net Inc Parking Lot, 11822 Cannon Blvd #B, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/221464235/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail! Trail! Trail! Late announcement but there will be a trail",
+    "date": "2015-04-11",
+    "startTime": "15:00",
+    "location": "Sloppy's House, 175 East Ave, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/221016679/",
+    "attendees": 1
+  },
+  {
+    "title": "Fart Jar Hares (April Fools Edition)",
+    "date": "2015-03-28",
+    "startTime": "15:00",
+    "location": "Warwick High School Parking Lot, 51 Copeland Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/221372180/",
+    "attendees": 2
+  },
+  {
+    "title": "Playing with RH3 travel hash to the GRD",
+    "date": "2015-03-14",
+    "startTime": "13:00",
+    "location": "CARPOOL OR DRIVE YOUR BUTTS TO RICHMOND VA, 69 go to their web for info, Richmond, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/220522337/",
+    "attendees": 3
+  },
+  {
+    "title": "Who wants to hare this wonderful Saturday? E-mail me!",
+    "date": "2015-03-07",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/219694249/",
+    "attendees": null
+  },
+  {
+    "title": "Port Warwick Pub Crawl",
+    "date": "2015-02-28",
+    "startTime": "15:00",
+    "location": "In the parking lot near, 410 Flannery O'Conner St, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/210359392/",
+    "attendees": 3
+  },
+  {
+    "title": "Who wants to hare this wonderful Saturday? E-mail me!",
+    "date": "2015-02-21",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/218827850/",
+    "attendees": null
+  },
+  {
+    "title": "Trail #2282 Love stinks, be my hashy valentine",
+    "date": "2015-02-14",
+    "startTime": "15:00",
+    "location": "Harwoods Mill Park, 368 Oriana Road, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/218827848/",
+    "attendees": 4
+  },
+  {
+    "title": "The Return of the Donkey Fluffer! ( trail #2281)",
+    "date": "2015-01-31",
+    "startTime": "15:00",
+    "location": "MHS, 275 Menchville Rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/218827840/",
+    "attendees": 20
+  },
+  {
+    "title": "Say Goodbye To PI-ho",
+    "date": "2015-01-24",
+    "startTime": "14:00",
+    "location": "Swing Funky House, 102 Hutton Ct, Grandy, NC, US",
+    "url": "https://www.meetup.com/feh3-hash/events/219971087/",
+    "attendees": 3
+  },
+  {
+    "title": "Come Out This Saturday For A Hash And Golden Nectar",
+    "date": "2015-01-17",
+    "startTime": "15:00",
+    "location": "Darling Stadium, 4111 Victoria Boulevard, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/210359342/",
+    "attendees": 7
+  },
+  {
+    "title": "FEH3 Hangover hash",
+    "date": "2015-01-01",
+    "startTime": "12:00",
+    "location": "Kiln Creek Park, 2901 Kiln Creek Pkwy, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344212/",
+    "attendees": 1
+  },
+  {
+    "title": "Hash with FEH3 this Saturday",
+    "date": "2014-12-27",
+    "startTime": "15:00",
+    "location": "Kiln Creek Elementary School, 1501 Kiln Creek Pkwy, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344202/",
+    "attendees": 4
+  },
+  {
+    "title": "Christmas Light Run",
+    "date": "2014-12-19",
+    "startTime": "18:45",
+    "location": "Kraft Elementary School, 600 Concord Drive, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/210359272/",
+    "attendees": 3
+  },
+  {
+    "title": "The Daisy Chain Hash",
+    "date": "2014-12-13",
+    "startTime": "15:00",
+    "location": "Sedgefield Elementary School, 804 Main St, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344182/",
+    "attendees": 1
+  },
+  {
+    "title": "Better Late Than Never",
+    "date": "2014-12-06",
+    "startTime": "15:00",
+    "location": "York High School 9300 George Washington Memorial Hwy Yorktown Va 23692, 9300 George Washington Memorial Hwy, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344172/",
+    "attendees": 3
+  },
+  {
+    "title": "Trot Your Turkey Off!",
+    "date": "2014-11-29",
+    "startTime": "11:00",
+    "location": "Lee Hall Elementary, 17346 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344152/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail! What do we want? A cure for tourettes? When do we want it? C@nt",
+    "date": "2014-11-22",
+    "startTime": "15:00",
+    "location": "Warwick High School Parking Lot, 51 Copeland Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344102/",
+    "attendees": 4
+  },
+  {
+    "title": "RSR is hare-ing",
+    "date": "2014-11-15",
+    "startTime": "15:00",
+    "location": "MHS, 275 Menchville Rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344092/",
+    "attendees": 4
+  },
+  {
+    "title": "HASHING WITH THE OBXH3",
+    "date": "2014-11-08",
+    "startTime": "15:00",
+    "location": "Jockey's Ridge State Park, 300 W Carolista Dr, Nags Head, NC, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344072/",
+    "attendees": 1
+  },
+  {
+    "title": "#2271 SUNDAY HASH AND SUPPORT YOUR LOCAL BREWERY!",
+    "date": "2014-11-02",
+    "startTime": "13:00",
+    "location": "Kmart parking lot, 118 Waller Mill Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344032/",
+    "attendees": 3
+  },
+  {
+    "title": "#2270 Whirrled Peas Thru shitty beer .",
+    "date": "2014-10-25",
+    "startTime": "10:00",
+    "location": "Sedgefield Elementary School, 804 Main St, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197344012/",
+    "attendees": null
+  },
+  {
+    "title": "#2269",
+    "date": "2014-10-18",
+    "startTime": "15:00",
+    "location": "Food Lion, 10880 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197343972/",
+    "attendees": 1
+  },
+  {
+    "title": "#2268 Be a friend and Hare.",
+    "date": "2014-10-11",
+    "startTime": "15:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/196257472/",
+    "attendees": 4
+  },
+  {
+    "title": "NFN Brian Presents \"The Yellow Stream\"",
+    "date": "2014-10-04",
+    "startTime": "16:00",
+    "location": "Ivy Farms Park, 55 Ivy Farms Rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/197343912/",
+    "attendees": 6
+  },
+  {
+    "title": "Mimosa Hash/Bacon Festival",
+    "date": "2014-09-27",
+    "startTime": "10:00",
+    "location": "Food Lion Parking lot, 10880 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/208913452/",
+    "attendees": 3
+  },
+  {
+    "title": "Our friends down in Tidewater are hosting VA Interhash this year down in Chesape",
+    "date": "2014-09-26",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/195409292/",
+    "attendees": 4
+  },
+  {
+    "title": "#2265 White Dress Sparkle Party Hash",
+    "date": "2014-09-20",
+    "startTime": "14:00",
+    "location": "Beach Garden Park, 2854 Kilbourne Court, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/195409762/",
+    "attendees": 6
+  },
+  {
+    "title": "#2264 Better late than.......",
+    "date": "2014-09-13",
+    "startTime": "15:00",
+    "location": "Movie Tavern at High Street, 1430 Richmond Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/195409632/",
+    "attendees": 2
+  },
+  {
+    "title": "Shiggy gets me all wet!",
+    "date": "2014-09-06",
+    "startTime": "15:00",
+    "location": "Warwick High School Parking Lot, 51 Copeland Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/195409532/",
+    "attendees": 5
+  },
+  {
+    "title": "#2262 Pool Party Blow Out",
+    "date": "2014-08-30",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/195409442/",
+    "attendees": 1
+  },
+  {
+    "title": "#2261 Off Road Luggage Hash",
+    "date": "2014-08-23",
+    "startTime": "15:00",
+    "location": "Newport News Library, 110 Main Streetz, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/192336402/",
+    "attendees": 9
+  },
+  {
+    "title": "#2260. Time for shiggyfest",
+    "date": "2014-08-15",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/192305962/",
+    "attendees": 2
+  },
+  {
+    "title": "W#2259. The night before Shiggy Fest..",
+    "date": "2014-08-09",
+    "startTime": "15:00",
+    "location": "Fast's, 838 Sharpley Ave, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/185183452/",
+    "attendees": 7
+  },
+  {
+    "title": "#2258 If this is your first hash.. you have to...",
+    "date": "2014-08-02",
+    "startTime": "15:00",
+    "location": "'NIA', 300 Exploration Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/185183022/",
+    "attendees": 5
+  },
+  {
+    "title": "#2257 Hope you're good at Frogger!",
+    "date": "2014-07-26",
+    "startTime": "15:00",
+    "location": "Parking lot next to Blush Bridal Consignment Boutique, 185 Herman Melville Ave, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/185182872/",
+    "attendees": 6
+  },
+  {
+    "title": "#2256 July's POOL PARTY BBQ HASH",
+    "date": "2014-07-19",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179113302/",
+    "attendees": 7
+  },
+  {
+    "title": "#2255 Rolling of the bulls hash",
+    "date": "2014-07-12",
+    "startTime": "15:00",
+    "location": "Hampton City Hall parking lot, 301 Eaton St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179113252/",
+    "attendees": 3
+  },
+  {
+    "title": "#2254 if you are NOT going to T.I.T.S can u hare this one for us?",
+    "date": "2014-07-05",
+    "startTime": "11:00",
+    "location": "Movie Tavern at High Street, 1430 Richmond Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179113182/",
+    "attendees": 3
+  },
+  {
+    "title": "#2253 Lotion's Sarong (Soo wrong, Soo long!) Hash and POOL PARTY",
+    "date": "2014-06-28",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179113072/",
+    "attendees": 15
+  },
+  {
+    "title": "#2252 What we do on trail stays on trail.....",
+    "date": "2014-06-21",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/179113002/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-8.json
+++ b/scripts/data/feh3-meetup-history-batch-8.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "#2251 We're doing this trail at a special time.Take note it starts at NOON!",
+    "date": "2014-06-14",
+    "startTime": "12:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179112942/",
+    "attendees": 3
+  },
+  {
+    "title": "#2250 it's Saturday and pick-up hare day",
+    "date": "2014-06-07",
+    "startTime": "15:00",
+    "location": "Hardwood's Mill Park, 798 Oriana Rd, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179112812/",
+    "attendees": 2
+  },
+  {
+    "title": "#2249 PIRATE VS. NINJAS- worst pirate in the world",
+    "date": "2014-05-31",
+    "startTime": "15:00",
+    "location": "Darling Stadium, 4111 Victoria Boulevard, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179112742/",
+    "attendees": 8
+  },
+  {
+    "title": "#2248 Arresting the Seamen",
+    "date": "2014-05-24",
+    "startTime": "15:00",
+    "location": "McIntosh Elementary, 185 Richneck Rd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179112602/",
+    "attendees": 5
+  },
+  {
+    "title": "13th Annual Virginia Beer Festival In partnership with Virginia Arts Festival",
+    "date": "2014-05-18",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/183255792/",
+    "attendees": null
+  },
+  {
+    "title": "#2247 The \"gimpy\" 90 Second Easy Snatch",
+    "date": "2014-05-17",
+    "startTime": "15:00",
+    "location": "Denbigh Community Center, 15198 Warwick Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/179112532/",
+    "attendees": 5
+  },
+  {
+    "title": "#2246 hares: The Fast and Bike-urious and Momma's Little Bag Blower",
+    "date": "2014-05-10",
+    "startTime": "15:00",
+    "location": "Yates Elementary School, 73 Maxwell Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/177592022/",
+    "attendees": 10
+  },
+  {
+    "title": "#2245 The hares evading the pack this wk are: The Fast & Bike-urious and NFN DB",
+    "date": "2014-05-03",
+    "startTime": "15:00",
+    "location": "Tabb High School, 4431 Big Bethel Road, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/177591812/",
+    "attendees": 4
+  },
+  {
+    "title": "#2244 Goobily gook to be presented to the kennel by NFNCarl",
+    "date": "2014-04-26",
+    "startTime": "15:00",
+    "location": "Lee Hall Elementary School, 17346 Warwick Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/177591602/",
+    "attendees": 14
+  },
+  {
+    "title": "Lions and tigers and bears OH MY!!!",
+    "date": "2014-04-19",
+    "startTime": "15:00",
+    "location": "Big Bethel Park, 123 Saunders Road, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/171735982/",
+    "attendees": 5
+  },
+  {
+    "title": "Hash with FEH3",
+    "date": "2014-04-12",
+    "startTime": "15:00",
+    "location": "Budget Inn, 800 Capitol Landing Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/171735652/",
+    "attendees": 4
+  },
+  {
+    "title": "Saturday is a hashing day",
+    "date": "2014-04-05",
+    "startTime": "15:00",
+    "location": "Hardwood's Mill Park, 798 Oriana Rd, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/171735412/",
+    "attendees": 3
+  },
+  {
+    "title": "a Damn Fine Shitty Trail",
+    "date": "2014-03-29",
+    "startTime": "15:00",
+    "location": "Warwick High School Parking Lot, 51 Copeland Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/171735222/",
+    "attendees": 4
+  },
+  {
+    "title": "Join FEH3 this saturday",
+    "date": "2014-03-22",
+    "startTime": "15:00",
+    "location": "Sloppy's House, 175 East Ave, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/171735122/",
+    "attendees": 2
+  },
+  {
+    "title": "Come Hash With FEH3",
+    "date": "2014-03-15",
+    "startTime": "15:00",
+    "location": "Kiln Creek Park, 2901 Kiln Creek Pkwy, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/168808382/",
+    "attendees": 2
+  },
+  {
+    "title": "We have a start location!",
+    "date": "2014-03-08",
+    "startTime": "15:00",
+    "location": "Hardwood's Mill Park, 798 Oriana Rd, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/168808162/",
+    "attendees": 4
+  },
+  {
+    "title": "hash with feh3 this Saturday!",
+    "date": "2014-03-01",
+    "startTime": "15:00",
+    "location": "Kmart parking lot, 118 Waller Mill Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/168808012/",
+    "attendees": 1
+  },
+  {
+    "title": "hash with FEH3 this Saturday!",
+    "date": "2014-02-22",
+    "startTime": "15:00",
+    "location": "JM Dozier Middle School, 432 Industrial Park Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/167619942/",
+    "attendees": 2
+  },
+  {
+    "title": "HAsh with FEH3 this Saturday!",
+    "date": "2014-02-15",
+    "startTime": "15:00",
+    "location": "Lee Hall Elementary School, 17346 Warwick Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/166332762/",
+    "attendees": 2
+  },
+  {
+    "title": "This Sh*t is BANANA",
+    "date": "2014-02-08",
+    "startTime": "15:00",
+    "location": "Harris Teeter, 1470 Quarterpath Rd, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/161158362/",
+    "attendees": 6
+  },
+  {
+    "title": "Come join feh3 this Saturday",
+    "date": "2014-02-01",
+    "startTime": "15:00",
+    "location": "Sears, 100 Newmarket Dr North, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/161158142/",
+    "attendees": 9
+  },
+  {
+    "title": "Tacky tourist hash",
+    "date": "2014-01-25",
+    "startTime": "12:00",
+    "location": "Matthew Whaley Elem School, 301 Scotland St, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/161157942/",
+    "attendees": 7
+  },
+  {
+    "title": "late announcement!",
+    "date": "2014-01-18",
+    "startTime": "15:00",
+    "location": "York High School, 9300 George Washington Memorial Highway, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/161157702/",
+    "attendees": 3
+  },
+  {
+    "title": "Hash with FEH3 this Saturday!",
+    "date": "2014-01-11",
+    "startTime": "15:00",
+    "location": "Hooters, 12640 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/159859732/",
+    "attendees": 5
+  },
+  {
+    "title": "Donkey Show (Donkey Fluffers 52nd Birthday Hash)",
+    "date": "2014-01-04",
+    "startTime": "15:30",
+    "location": "Casa de EZ Pass, 1037 Oldwood Street, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/156861892/",
+    "attendees": 11
+  },
+  {
+    "title": "Clear out the 2013 Hangover and Ring in the New Year (before the games start)",
+    "date": "2014-01-01",
+    "startTime": "12:00",
+    "location": "Union First Market Bank, 603 Pilot House Drive, Suite 100, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/157803872/",
+    "attendees": 7
+  },
+  {
+    "title": "Banana has stepped up to hare in Williamsburg.",
+    "date": "2013-12-28",
+    "startTime": "15:00",
+    "location": "Parking lot behind Big lots, 208 Monticello Ave, williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/153698872/",
+    "attendees": 5
+  },
+  {
+    "title": "ANNUAL PENNY BEERS AT THE OAKS",
+    "date": "2013-12-25",
+    "startTime": "17:00",
+    "location": "The White Oaks Lodge, 3533 Kecoughtan Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/153698672/",
+    "attendees": 8
+  },
+  {
+    "title": "Holiday hash light run",
+    "date": "2013-12-21",
+    "startTime": "17:30",
+    "location": "Kraft Elementary School, 600 Concord Drive, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/153698192/",
+    "attendees": 12
+  },
+  {
+    "title": "Come on out to Spiderman's Naughty or Nice trail.",
+    "date": "2013-12-14",
+    "startTime": "15:00",
+    "location": "Tower Ln, Yorktown, Vi, US",
+    "url": "https://www.meetup.com/feh3-hash/events/153697782/",
+    "attendees": 4
+  },
+  {
+    "title": "Pick this date to hare",
+    "date": "2013-12-07",
+    "startTime": "15:00",
+    "location": "Hardwood's Mill Park, 798 Oriana Rd, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/153695222/",
+    "attendees": 4
+  },
+  {
+    "title": "TURKEY BOWL in tidewater area hosted by feh3",
+    "date": "2013-11-30",
+    "startTime": "14:00",
+    "location": "Beach Garden Park, Beach Garden Park, Virginia Beach, Virginia 23451, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/149383322/",
+    "attendees": 8
+  },
+  {
+    "title": "Hash with feh3",
+    "date": "2013-11-23",
+    "startTime": "15:00",
+    "location": "Kiln Creek Park, 2901 Kiln Creek Pkwy, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/152064012/",
+    "attendees": 5
+  },
+  {
+    "title": "need a hare",
+    "date": "2013-11-23",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/149383212/",
+    "attendees": 1
+  },
+  {
+    "title": "join us for the hash",
+    "date": "2013-11-16",
+    "startTime": "15:00",
+    "location": "Wells Fargo, 600 Thimble Shoals Boulevard #100, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/149383082/",
+    "attendees": 3
+  },
+  {
+    "title": "Hashing in the burg",
+    "date": "2013-11-09",
+    "startTime": "15:00",
+    "location": "Parking lot Behind Opus 9, 5143 Main St, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/149382982/",
+    "attendees": 2
+  },
+  {
+    "title": "Donkey Fluffer has stepped up to hare.",
+    "date": "2013-11-02",
+    "startTime": "14:00",
+    "location": "Riverwalk Restaurant, 323 Water St, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/148244812/",
+    "attendees": 5
+  },
+  {
+    "title": "early hash",
+    "date": "2013-10-26",
+    "startTime": "12:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/147507772/",
+    "attendees": 2
+  },
+  {
+    "title": "Whirrled Peas Thru Beer",
+    "date": "2013-10-19",
+    "startTime": "15:00",
+    "location": "Rey Azteca, 10530 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/140127802/",
+    "attendees": 17
+  },
+  {
+    "title": "Hash in portsmouth",
+    "date": "2013-10-12",
+    "startTime": "15:00",
+    "location": "Churchland High School, 4301 Cedar Lane, Portsmouth, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/144819722/",
+    "attendees": 4
+  },
+  {
+    "title": "Hash with FEH3 this Saturday!",
+    "date": "2013-10-05",
+    "startTime": "15:00",
+    "location": "Hampton Sentara walking trail, 300 Butler Farm Road, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/143815292/",
+    "attendees": 3
+  },
+  {
+    "title": "Early hash and hallo-scream",
+    "date": "2013-09-28",
+    "startTime": "23:30",
+    "location": "James River Community Center, 8901 Pocahontas Trail, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/139945812/",
+    "attendees": 3
+  },
+  {
+    "title": "Pirates Pack the Park hash",
+    "date": "2013-09-21",
+    "startTime": "12:30",
+    "location": "Food Lion Parking lot, 10880 Warwick Blvd, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/141125292/",
+    "attendees": 4
+  },
+  {
+    "title": "PICK THIS HASH TO HARE",
+    "date": "2013-09-21",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/139945442/",
+    "attendees": 1
+  },
+  {
+    "title": "Hash with the oldest continous hash in the US",
+    "date": "2013-09-14",
+    "startTime": "15:00",
+    "location": "JM Dozier Middle School, 432 Industrial Park Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/139945252/",
+    "attendees": 4
+  },
+  {
+    "title": "BANANORAMA!!!!",
+    "date": "2013-09-07",
+    "startTime": "15:00",
+    "location": "NEAR, 1470 Quarterpath rd, williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/138856062/",
+    "attendees": 4
+  },
+  {
+    "title": "snare me if you dare",
+    "date": "2013-08-31",
+    "startTime": "15:00",
+    "location": "Rey Azteca, 10530 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/137450102/",
+    "attendees": 4
+  },
+  {
+    "title": "Invade the Dead Elvis hash",
+    "date": "2013-08-24",
+    "startTime": "14:30",
+    "location": "Red Bones Raw Bar Seafood Grill, 445 North Battlefield Boulevard, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/136171852/",
+    "attendees": 12
+  },
+  {
+    "title": "2200th Running and Campout LINGERIE SHIGGY FEST",
+    "date": "2013-08-16",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/feh3-hash/events/126047772/",
+    "attendees": 20
+  },
+  {
+    "title": "hash with feh3",
+    "date": "2013-08-10",
+    "startTime": "15:00",
+    "location": "Big Lots, 4318 George Washington Memorial Hwy, Grafton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/133417222/",
+    "attendees": 5
+  }
+]

--- a/scripts/data/feh3-meetup-history-batch-9.json
+++ b/scripts/data/feh3-meetup-history-batch-9.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Hashing With Sloppy",
+    "date": "2013-08-03",
+    "startTime": "15:00",
+    "location": "Sloppy's House, 175 East Ave, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/132648272/",
+    "attendees": 4
+  },
+  {
+    "title": "lost in transhiggy",
+    "date": "2013-07-27",
+    "startTime": "15:00",
+    "location": "Warwick High School Parking Lot, 51 Copeland Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/129122262/",
+    "attendees": 4
+  },
+  {
+    "title": "FUN with Inflateables Hash and Pool Party",
+    "date": "2013-07-20",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/128581002/",
+    "attendees": 12
+  },
+  {
+    "title": "Run with the bulls and va dominion derby girls",
+    "date": "2013-07-13",
+    "startTime": "14:30",
+    "location": "Hampton City Hall parking lot, 301 Eaton St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/128742162/",
+    "attendees": 6
+  },
+  {
+    "title": "Hashing on the South side!!",
+    "date": "2013-07-06",
+    "startTime": "15:00",
+    "location": "EZ PASS HOUSE, 1037 Oldwood St, Chesapeake, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/126045072/",
+    "attendees": 8
+  },
+  {
+    "title": "Hashing In the burg!",
+    "date": "2013-06-29",
+    "startTime": "15:00",
+    "location": "See special instructions below, 3401 Monticello Ave, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/124900902/",
+    "attendees": 8
+  },
+  {
+    "title": "Hash with FEH3",
+    "date": "2013-06-22",
+    "startTime": "15:00",
+    "location": "Denbigh High School, 259 Denbigh Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/124900522/",
+    "attendees": 6
+  },
+  {
+    "title": "Better late than ............( I wont go there)",
+    "date": "2013-06-15",
+    "startTime": "15:00",
+    "location": "TowneBank, Branch Office, 1030 Loftis Boulevard #100, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/124697632/",
+    "attendees": 7
+  },
+  {
+    "title": "Come play Frogger",
+    "date": "2013-06-08",
+    "startTime": "15:00",
+    "location": "Newmarket South Shopping Center, Hampton, VA, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/123071882/",
+    "attendees": 1
+  },
+  {
+    "title": "ARRRGGGGHHHHHHH.....",
+    "date": "2013-06-01",
+    "startTime": "15:00",
+    "location": "Darling Stadium, 4111 Victoria Boulevard, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/121894462/",
+    "attendees": 5
+  },
+  {
+    "title": "Gator's Bday hash and pool party SUPER SOAKER HASH",
+    "date": "2013-05-25",
+    "startTime": "15:00",
+    "location": "Kiss's House, 963 lacon Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/114308152/",
+    "attendees": 24
+  },
+  {
+    "title": "the fast and bicurious!",
+    "date": "2013-05-18",
+    "startTime": "15:00",
+    "location": "AMC Hampton 24, 1 Town Center Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/114307422/",
+    "attendees": 4
+  },
+  {
+    "title": "S%@#^% F#^%$^&# C&#%&$# MOOOOO",
+    "date": "2013-05-11",
+    "startTime": "15:00",
+    "location": "Midtown Community Center, 570 McLawhorne Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/114307272/",
+    "attendees": 6
+  },
+  {
+    "title": "NFN Mike and Donkey Fluffer",
+    "date": "2013-05-04",
+    "startTime": "15:00",
+    "location": "Hooters, 12640 Jefferson Avenue, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/114307062/",
+    "attendees": 8
+  },
+  {
+    "title": "Pirate hash southside.....",
+    "date": "2013-04-27",
+    "startTime": "12:00",
+    "location": "Flagship Inn, 512 Atlantic Avenue, Virginia Beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/106802052/",
+    "attendees": 15
+  },
+  {
+    "title": "MVH3 Invasion",
+    "date": "2013-04-20",
+    "startTime": "11:00",
+    "location": "Freedom Park, 5537 Centerville Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/112896512/",
+    "attendees": 6
+  },
+  {
+    "title": "Beers a springin'",
+    "date": "2013-04-13",
+    "startTime": "15:00",
+    "location": "Budget Inn, 800 Capitol Landing Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/112896722/",
+    "attendees": 5
+  },
+  {
+    "title": "Join feh3 in the lovely town of williamsburg",
+    "date": "2013-04-06",
+    "startTime": "15:00",
+    "location": "Movie Tavern at High Street, 1430 Richmond Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/112898012/",
+    "attendees": 7
+  },
+  {
+    "title": "join th3 for thier Zombie and or feh3 sat for the hangover hash",
+    "date": "2013-03-30",
+    "startTime": "11:00",
+    "location": "KOA Virginia Beach Campground, 1420 General Booth Blvd, 23451, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/106800582/",
+    "attendees": 8
+  },
+  {
+    "title": "we need hares",
+    "date": "2013-03-23",
+    "startTime": "15:00",
+    "location": "York High School, 9300 George Washington Memorial Highway, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/106800972/",
+    "attendees": 3
+  },
+  {
+    "title": "EARLY HASH WITH FEH3",
+    "date": "2013-03-16",
+    "startTime": "10:00",
+    "location": "AMC Hampton 24, 1 Town Center Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/105605472/",
+    "attendees": 1
+  },
+  {
+    "title": "Come join us in the burg for a dustballs trail",
+    "date": "2013-03-09",
+    "startTime": "15:00",
+    "location": "Freedom Park, 5537 Centerville Road, Williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/105603462/",
+    "attendees": 11
+  },
+  {
+    "title": "Spidey the bday boy trail",
+    "date": "2013-03-02",
+    "startTime": "15:00",
+    "location": "Riverwalk Restaurant, 323 Water St, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/103041452/",
+    "attendees": 7
+  },
+  {
+    "title": "hash with FEH3",
+    "date": "2013-02-23",
+    "startTime": "15:00",
+    "location": "Deer Park, 11541 Jefferson Ave, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/100742802/",
+    "attendees": 4
+  },
+  {
+    "title": "Hash with the oldest continous hash in the US",
+    "date": "2013-02-09",
+    "startTime": "15:00",
+    "location": "Parking lot behind Big lots, 208 Monticello Ave, williamsburg, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/100720952/",
+    "attendees": 12
+  },
+  {
+    "title": "hash with feh3",
+    "date": "2013-02-02",
+    "startTime": "15:00",
+    "location": "Churchland High School, 4301 Cedar Lane, Portsmouth, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/100720242/",
+    "attendees": 6
+  },
+  {
+    "title": "50 Shades of Piggy",
+    "date": "2013-01-26",
+    "startTime": "15:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/98477052/",
+    "attendees": 15
+  },
+  {
+    "title": "hash on a tuesday",
+    "date": "2013-01-22",
+    "startTime": "18:30",
+    "location": "Hampton City Hall parking lot, 301 Eaton St, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/100722892/",
+    "attendees": 1
+  },
+  {
+    "title": "SAY GOOD BYE TO FAIRY BEARY AND RAD :( :( :(",
+    "date": "2013-01-18",
+    "startTime": "18:30",
+    "location": "Sloppy's House, 175 East Ave, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/98834402/",
+    "attendees": 4
+  },
+  {
+    "title": "Hash with feh3",
+    "date": "2013-01-12",
+    "startTime": "15:00",
+    "location": "parking lot, 2020 Exploration Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/98476422/",
+    "attendees": 3
+  },
+  {
+    "title": "Tuesday the best hash in the tidewater area",
+    "date": "2013-01-08",
+    "startTime": "18:15",
+    "location": "Woodland Skate Park, Woodland AVE, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/98475802/",
+    "attendees": 1
+  },
+  {
+    "title": "hash with feh3",
+    "date": "2013-01-05",
+    "startTime": "15:00",
+    "location": "Riverdale Plaza Shopping Center, 1044 W. Mercury Blvd., Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/97687102/",
+    "attendees": 8
+  },
+  {
+    "title": "New Years Hangover hash feh3 and the Hampton \"best hash in the Tidewater Area\"",
+    "date": "2013-01-01",
+    "startTime": "12:00",
+    "location": "Union First Market Bank, 603 Pilot House Drive, Suite 100, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/96563322/",
+    "attendees": 6
+  },
+  {
+    "title": "Annual Penny Beers and FEH3/Tuesday hash gathering!",
+    "date": "2012-12-25",
+    "startTime": "17:00",
+    "location": "The White Oaks Lodge, 3533 Kecoughtan Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/96199822/",
+    "attendees": 15
+  },
+  {
+    "title": "Annual Christmas light hash Naughty or Nice",
+    "date": "2012-12-22",
+    "startTime": "17:00",
+    "location": "Christopher C. Kraft Elementary School, Hampton, VA, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/91231922/",
+    "attendees": 9
+  },
+  {
+    "title": "hash with ft eustis",
+    "date": "2012-12-15",
+    "startTime": "15:00",
+    "location": "JM Dozier Middle School, 432 Industrial Park Drive, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/95374432/",
+    "attendees": 3
+  },
+  {
+    "title": "hash with feh3",
+    "date": "2012-12-08",
+    "startTime": "15:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/94061392/",
+    "attendees": 3
+  },
+  {
+    "title": "lets try this again.....",
+    "date": "2012-12-01",
+    "startTime": "15:00",
+    "location": "Sears, 100 Newmarket Dr North, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/93253172/",
+    "attendees": 1
+  },
+  {
+    "title": "trot your turkey gut off",
+    "date": "2012-11-24",
+    "startTime": "11:00",
+    "location": "Sears, 100 Newmarket Dr North, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/91715012/",
+    "attendees": 3
+  },
+  {
+    "title": "Try a tuesday hash with Hampton H3",
+    "date": "2012-11-20",
+    "startTime": "18:00",
+    "location": "Hampton High School, 1491 West Queen Street, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/91714122/",
+    "attendees": 1
+  },
+  {
+    "title": "Hash with Ft Eustis",
+    "date": "2012-11-17",
+    "startTime": "15:00",
+    "location": "National Institute of Aerospace (NIA), 100 Exploration Way, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/91712712/",
+    "attendees": 2
+  },
+  {
+    "title": "hash southside with the tuesday hash",
+    "date": "2012-11-13",
+    "startTime": "18:00",
+    "location": "Football Field, 1300 Baker Rd, virginia beach, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/90354732/",
+    "attendees": null
+  },
+  {
+    "title": "cowboy and aliens hash",
+    "date": "2012-11-10",
+    "startTime": "15:00",
+    "location": "Wells Fargo, 600 Thimble Shoals Boulevard #100, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/90354242/",
+    "attendees": 4
+  },
+  {
+    "title": "tuesday tuesday 600th hash",
+    "date": "2012-11-06",
+    "startTime": "18:00",
+    "location": "Hampton Sentara walking trail, 300 Butler Farm Road, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/90146322/",
+    "attendees": 5
+  },
+  {
+    "title": "hash this saturday with feh3",
+    "date": "2012-11-03",
+    "startTime": "15:00",
+    "location": "Brittingham-Midtown Community Center, 570 McLawhorne Dr, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/89260782/",
+    "attendees": 4
+  },
+  {
+    "title": "An early saturday hash",
+    "date": "2012-10-27",
+    "startTime": "11:30",
+    "location": "Riverwalk Restaurant, 323 Water St, Yorktown, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/87128472/",
+    "attendees": 5
+  },
+  {
+    "title": "WPTB with the Hampton hashers",
+    "date": "2012-10-23",
+    "startTime": "18:00",
+    "location": "Buckroe Beach, 213 Buckroe Avenue, Hampton, VA, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/87956012/",
+    "attendees": 1
+  },
+  {
+    "title": "whirrled peas thru beer",
+    "date": "2012-10-20",
+    "startTime": "15:00",
+    "location": "Oliver C. Greenwood Elementary School, 13460 Woodside Lane, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/86424302/",
+    "attendees": 7
+  },
+  {
+    "title": "Try a tuesday hash",
+    "date": "2012-10-16",
+    "startTime": "18:00",
+    "location": "The White Oaks Lodge, 3533 Kecoughtan Rd, Hampton, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/86421792/",
+    "attendees": 2
+  },
+  {
+    "title": "try a hash run with FEH3",
+    "date": "2012-10-13",
+    "startTime": "15:00",
+    "location": "Suntrust bank, 729 Thimble Shoals Boulevard, Newport News, VA, US",
+    "url": "https://www.meetup.com/feh3-hash/events/86420842/",
+    "attendees": 3
+  }
+]

--- a/scripts/data/hogtownh3-meetup-history-batch-1.json
+++ b/scripts/data/hogtownh3-meetup-history-batch-1.json
@@ -1,0 +1,370 @@
+[
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3",
+    "date": "2026-04-11",
+    "startTime": "17:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/314042674/",
+    "attendees": 4
+  },
+  {
+    "title": "Thursday evening run/walk and beer with HH3",
+    "date": "2026-04-02",
+    "startTime": "19:00",
+    "location": "Toronto Style Bar & Grill, 1546 Bloor St W, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313727928/",
+    "attendees": 4
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3",
+    "date": "2026-03-28",
+    "startTime": "17:00",
+    "location": "Captain Jack, 2 Wheeler Avenue, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313621138/",
+    "attendees": 8
+  },
+  {
+    "title": "Friday evening walk and beer with HH3",
+    "date": "2026-03-20",
+    "startTime": "19:00",
+    "location": "Christie Pits Pub, 814 Bloor Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313621055/",
+    "attendees": 6
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3",
+    "date": "2026-03-14",
+    "startTime": "17:00",
+    "location": "Rumble Pontiac, 197 1/2 Baldwin St, Toronto, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313621016/",
+    "attendees": 6
+  },
+  {
+    "title": "Thursday evening run/walk and beer with HH3",
+    "date": "2026-03-05",
+    "startTime": "19:00",
+    "location": "Paupers Pub, 561 Bloor street west M5S 1Y5, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313429991/",
+    "attendees": 7
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer and hot sauce tasting!",
+    "date": "2026-02-28",
+    "startTime": "17:00",
+    "location": "Rainhard Brewing Co., 100 Symes Road, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313175242/",
+    "attendees": 6
+  },
+  {
+    "title": "Friday evening walk and beer with HH3",
+    "date": "2026-02-20",
+    "startTime": "19:00",
+    "location": "Bistro 422, 422 College Street, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313174618/",
+    "attendees": 7
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3",
+    "date": "2026-02-14",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313174598/",
+    "attendees": 4
+  },
+  {
+    "title": "Valentines Hash",
+    "date": "2026-02-11",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/313298880/",
+    "attendees": 1
+  },
+  {
+    "title": "Thursday evening run/walk and beer with HH3",
+    "date": "2026-02-05",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/312857548/",
+    "attendees": 5
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3",
+    "date": "2026-01-31",
+    "startTime": "15:00",
+    "location": "Great Lakes Brewpub, 11 Lower Jarvis St Units 5-8, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/312685111/",
+    "attendees": 5
+  },
+  {
+    "title": "Friday evening walk and beer with HH3",
+    "date": "2026-01-23",
+    "startTime": "19:00",
+    "location": "Rainhard Brewing Co., 100 Symes Road, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/312685133/",
+    "attendees": 4
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer and HH3 annual re-gift party",
+    "date": "2026-01-17",
+    "startTime": "17:00",
+    "location": "Rainhard Brewing Co., 100 Symes Road, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/312685364/",
+    "attendees": 6
+  },
+  {
+    "title": "Thursday evening run/walk and beer with HH3",
+    "date": "2026-01-08",
+    "startTime": "19:00",
+    "location": "The Old Sod, 2936 Bloor Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/312685064/",
+    "attendees": 4
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3",
+    "date": "2025-12-20",
+    "startTime": "15:00",
+    "location": "The Burdock, 1184 Bloor Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/311960732/",
+    "attendees": 8
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3 - Annual General Meeting",
+    "date": "2025-12-06",
+    "startTime": "17:00",
+    "location": "Christie Pits Pub, 814 Bloor Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/311960450/",
+    "attendees": 8
+  },
+  {
+    "title": "Thursday evening run/walk and beer with HH3",
+    "date": "2025-11-27",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/311274335/",
+    "attendees": 8
+  },
+  {
+    "title": "Saturday evening run/walk and beer with HH3",
+    "date": "2025-11-22",
+    "startTime": "15:00",
+    "location": "Firkin on the Bay, 68 Marine Parade Dr, Etobicoke, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/311274316/",
+    "attendees": 10
+  },
+  {
+    "title": "Friday evening walk and beer with HH3",
+    "date": "2025-11-07",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/311274308/",
+    "attendees": 1
+  },
+  {
+    "title": "Thursday evening run/walk and beer with HH3",
+    "date": "2025-10-30",
+    "startTime": "19:00",
+    "location": "Jenny's Bar, 2383 Dundas Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310843680/",
+    "attendees": 4
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3 - Field trip to Vaughan!",
+    "date": "2025-10-25",
+    "startTime": "15:00",
+    "location": "The Mills TapHouse + Grill, 9100 Jane St Unit 44,45, Vaughan, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310843648/",
+    "attendees": 6
+  },
+  {
+    "title": "Friday evening walk and beer with HH3",
+    "date": "2025-10-17",
+    "startTime": "19:00",
+    "location": "Imperial Pub, 54 Dundas St. E., Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310843670/",
+    "attendees": 6
+  },
+  {
+    "title": "Saturday afternoon run/walk and beer with HH3",
+    "date": "2025-10-11",
+    "startTime": "15:00",
+    "location": "The Bull, A Firkin Pub, 1835 Yonge Street, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310843696/",
+    "attendees": 5
+  },
+  {
+    "title": "Thursday evening run/walk and beer with HH3",
+    "date": "2025-10-02",
+    "startTime": "19:00",
+    "location": "Black Swan Pub, 154 Danforth Avenue, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310843604/",
+    "attendees": 6
+  },
+  {
+    "title": "HH3's Pink Dress Run to Support Breast Cancer Research",
+    "date": "2025-09-27",
+    "startTime": "13:00",
+    "location": "Annex Social, 1078 Bathurst St, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/311090420/",
+    "attendees": 4
+  },
+  {
+    "title": "Friday evening walk and beer with HH3",
+    "date": "2025-09-19",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310765897/",
+    "attendees": 1
+  },
+  {
+    "title": "Saturday evening run/walk and beer with HH3",
+    "date": "2025-09-13",
+    "startTime": "17:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310843557/",
+    "attendees": 2
+  },
+  {
+    "title": "Thursday evening run/walk and beer with HH3",
+    "date": "2025-09-04",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310765768/",
+    "attendees": 2
+  },
+  {
+    "title": "Saturday evening run/walk and beer with HH3",
+    "date": "2025-08-30",
+    "startTime": "17:00",
+    "location": "Victory Cafe, 440 Bloor St W, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310706467/",
+    "attendees": 3
+  },
+  {
+    "title": "Friday evening run/walk and beer with HH3",
+    "date": "2025-08-29",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310706732/",
+    "attendees": 2
+  },
+  {
+    "title": "National IPA Day",
+    "date": "2025-08-07",
+    "startTime": "19:00",
+    "location": "A Dark Horse Pub, 2401 Bloor St. West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310387000/",
+    "attendees": 1
+  },
+  {
+    "title": "TWAT Run",
+    "date": "2025-07-22",
+    "startTime": "19:00",
+    "location": "Pour Boy Pub, 666 Manning Avenue, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/310097083/",
+    "attendees": 1
+  },
+  {
+    "title": "Music Festival Hash",
+    "date": "2025-06-07",
+    "startTime": "17:00",
+    "location": "Christie Pits Pub, 814 Bloor Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/308229781/",
+    "attendees": 6
+  },
+  {
+    "title": "Yorkville Summer Hash",
+    "date": "2025-05-27",
+    "startTime": "19:00",
+    "location": "The Pilot, 22 Cumberland Street, Toronto, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/308070955/",
+    "attendees": 3
+  },
+  {
+    "title": "National Scavenger Hunt Day",
+    "date": "2025-05-24",
+    "startTime": "17:00",
+    "location": "Black Swan Pub, 154 Danforth Avenue, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/307796504/",
+    "attendees": 1
+  },
+  {
+    "title": "Back To The Lake Hash",
+    "date": "2025-05-15",
+    "startTime": "19:00",
+    "location": "The Grand Trunk, 1718 Queen Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/307796455/",
+    "attendees": 2
+  },
+  {
+    "title": "National Clean Up Your Room Day Hash",
+    "date": "2025-05-10",
+    "startTime": "17:00",
+    "location": "A Dark Horse Pub, 2401 Bloor St. West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/307665464/",
+    "attendees": 2
+  },
+  {
+    "title": "Royal Wedding Run",
+    "date": "2025-04-29",
+    "startTime": "19:00",
+    "location": "Duke of York, 39 Prince Arthur Ave, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/307537642/",
+    "attendees": 2
+  },
+  {
+    "title": "St. George's Day Trail",
+    "date": "2025-04-26",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/307414568/",
+    "attendees": 2
+  },
+  {
+    "title": "Ides of April",
+    "date": "2025-04-17",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/307335290/",
+    "attendees": 3
+  },
+  {
+    "title": "MWF & Half Wit's Karaoke Birthday Trail",
+    "date": "2025-04-12",
+    "startTime": "17:00",
+    "location": "Rainhard Brewing Co., 100 Symes Road, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/307224579/",
+    "attendees": 2
+  },
+  {
+    "title": "April Fool's Hash",
+    "date": "2025-04-01",
+    "startTime": "19:00",
+    "location": "The Old Sod, 2936 Bloor Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/307043380/",
+    "attendees": 3
+  },
+  {
+    "title": "Buzz's Birthday Hash: Part Duh",
+    "date": "2025-03-20",
+    "startTime": "19:00",
+    "location": "Christie Pits Pub, 814 Bloor Street West, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/306777756/",
+    "attendees": 3
+  },
+  {
+    "title": "Buzz's Birthday Run: Part One",
+    "date": "2025-03-15",
+    "startTime": "17:00",
+    "location": "The Embassy, 223 Augusta Ave., Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/306621096/",
+    "attendees": 10
+  },
+  {
+    "title": "Pandemic Anniversary Run",
+    "date": "2025-03-11",
+    "startTime": "19:00",
+    "location": "Jane Subway Station, Jane St. & BLoor St. W, Toronto, ON, CA",
+    "url": "https://www.meetup.com/meetup-group-pyrddkbc/events/306621017/",
+    "attendees": 6
+  }
+]

--- a/scripts/data/hvh3-ny-meetup-history-batch-1.json
+++ b/scripts/data/hvh3-ny-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "#63 Back from the Dead Trail!",
+    "date": "2024-11-02",
+    "startTime": "12:00",
+    "location": "Keegan Ales, 20 Saint James St, Kingston, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/304017011/",
+    "attendees": 6
+  },
+  {
+    "title": "#62 HVH3 Halloween 2023 Hilarity Hash!",
+    "date": "2023-10-28",
+    "startTime": "12:00",
+    "location": "Dongan Square Park, Dongan Pl, Poughkeepsie, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/296677247/",
+    "attendees": 15
+  },
+  {
+    "title": "Pegging Who??? Pegging Sue Rogue Trail",
+    "date": "2023-06-08",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/293861312/",
+    "attendees": 2
+  },
+  {
+    "title": "Hash #61 in Hyde Park, NY",
+    "date": "2022-04-16",
+    "startTime": "13:00",
+    "location": "Hyde Park Florist & Gifts, 4204 Albany Post Rd, Hyde Park, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/284616537/",
+    "attendees": 6
+  },
+  {
+    "title": "#60 Halloween hash",
+    "date": "2021-10-23",
+    "startTime": "13:00",
+    "location": "Parking Lot at 41.226457, -74.025318 on Turkey Hollow Road, 11 Turkey Hollow Road, Stony Point, ny, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/280708805/",
+    "attendees": 4
+  },
+  {
+    "title": "Hash # 59 at West Point Museum",
+    "date": "2021-09-11",
+    "startTime": "11:00",
+    "location": "West Point Museum, 2110 New South Post Rd, West Point, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/280609603/",
+    "attendees": 5
+  },
+  {
+    "title": "HVH3 Hash #59- Creamsicle Day Hash!",
+    "date": "2021-08-28",
+    "startTime": "14:00",
+    "location": "Parking lot behind Hanaford Super Market, 3650 Us Highway 9w, Highland, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/279603815/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail #58- Summer Solstice Hash",
+    "date": "2021-06-19",
+    "startTime": "14:00",
+    "location": "21 Burgers & Wings, 2026 NY-9D, Wappingers Falls, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/278502547/",
+    "attendees": 3
+  },
+  {
+    "title": "2021 (K)Northeastern Unofficial Run for Drunks - KNURD XVII",
+    "date": "2021-06-04",
+    "startTime": "15:00",
+    "location": "2015 Alexander Rd, Galway, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/277411182/",
+    "attendees": 3
+  },
+  {
+    "title": "HVH3 # 57 Pigs-in-a-Blanket-Day Hash",
+    "date": "2021-04-24",
+    "startTime": "13:30",
+    "location": "Tuxedo, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/277410957/",
+    "attendees": 4
+  },
+  {
+    "title": "HVH3 Trail #56 in Cold Spring, NY",
+    "date": "2021-03-27",
+    "startTime": "13:00",
+    "location": "Cold Spring, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/276724951/",
+    "attendees": 3
+  },
+  {
+    "title": "HVH3 Trail #55 - NOSE-Halve Mein Interhash",
+    "date": "2021-02-27",
+    "startTime": "13:00",
+    "location": "Mary Harriman Park, Harriman, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/276107072/",
+    "attendees": 8
+  },
+  {
+    "title": "HVH3 Trail #54 in Beacon, NY",
+    "date": "2021-01-23",
+    "startTime": "12:30",
+    "location": "Jean Van Pelt Park, Washington Ave, Fishkill, ny, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/275286118/",
+    "attendees": 4
+  },
+  {
+    "title": "HVH3 Trail #53 - Welcome back, D-Cell!",
+    "date": "2020-12-19",
+    "startTime": "12:00",
+    "location": "Veterans Memorial Park, Warwick, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/274650711/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #52- Peggin' Sue's New Paltz Hash",
+    "date": "2020-11-14",
+    "startTime": "13:00",
+    "location": "New Paltz, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/273983663/",
+    "attendees": 3
+  },
+  {
+    "title": "#51 Leap Day Hash",
+    "date": "2020-02-29",
+    "startTime": "14:00",
+    "location": "120 Channingville Rd, Wappingers Falls, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/268542151/",
+    "attendees": 8
+  },
+  {
+    "title": "Hash #50- Bon Voyage, Furry Canoe!",
+    "date": "2019-10-12",
+    "startTime": "13:30",
+    "location": "21 Burgers & Wings, 2026 NY-9D, Wappingers Falls, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/265361713/",
+    "attendees": 5
+  },
+  {
+    "title": "HVH3 Trail #49: Tu-Tu Hash",
+    "date": "2019-09-28",
+    "startTime": "14:00",
+    "location": "274 County Rd 10, Cold Spring, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/264875058/",
+    "attendees": 3
+  },
+  {
+    "title": "Summer Hash Practice: Hike-Drink-Swim-Float!",
+    "date": "2019-08-17",
+    "startTime": "12:30",
+    "location": "White Pond Multiple Use Area, Carmel Hamlet, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/263649614/",
+    "attendees": 3
+  },
+  {
+    "title": "HASH PRACTICE: Stony Kill Falls (no running)",
+    "date": "2019-06-15",
+    "startTime": "13:00",
+    "location": "Stony Kill Falls, Shaft 2A Rd, Kerhonkson, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/262130461/",
+    "attendees": 4
+  },
+  {
+    "title": "#48 Memorial Day Weekend Hash in Beacon, NY",
+    "date": "2019-05-25",
+    "startTime": "13:30",
+    "location": "Two Way Brewing Company, 18 W Main St, Beacon, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/260427414/",
+    "attendees": 3
+  },
+  {
+    "title": "Drinking Practice!",
+    "date": "2019-05-11",
+    "startTime": "18:00",
+    "location": "18 W Main St, Beacon, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/260427587/",
+    "attendees": 5
+  },
+  {
+    "title": "KAYAK Drinking Practice!",
+    "date": "2019-05-04",
+    "startTime": "14:00",
+    "location": "Pleasant Valley Recreation, 1558 Main St, Pleasant Valley, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/261115441/",
+    "attendees": 2
+  },
+  {
+    "title": "Hash # 47 in East Fishkill/Hopewell Junction, NY",
+    "date": "2019-04-21",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/260427294/",
+    "attendees": 3
+  },
+  {
+    "title": "Drinking Practice",
+    "date": "2019-04-12",
+    "startTime": "18:00",
+    "location": "Fishkill, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/260511657/",
+    "attendees": 4
+  },
+  {
+    "title": "#46 Beer Mine Valentine",
+    "date": "2019-02-16",
+    "startTime": "13:00",
+    "location": "214 Gardnertown Rd, Newburgh, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/258135547/",
+    "attendees": 3
+  },
+  {
+    "title": "Drinking Practice",
+    "date": "2019-01-25",
+    "startTime": "19:00",
+    "location": "King's Court Brewing Company, 40 Cannon St #1, Poughkeepsie, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/258116862/",
+    "attendees": 7
+  },
+  {
+    "title": "Adults Only Roller Skating with HVH3",
+    "date": "2019-01-16",
+    "startTime": "19:00",
+    "location": "Hyde Park Roller Magic, 4178 Albany Post Rd Suite #666, Hyde Park, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/258117000/",
+    "attendees": 4
+  },
+  {
+    "title": "HVH3 Trail #45",
+    "date": "2019-01-12",
+    "startTime": "12:30",
+    "location": "Johnson-Iorio Memorial Park, 281 Haviland Rd, Highland, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/257590403/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail #44 Hashy Trashmas!",
+    "date": "2018-12-22",
+    "startTime": "12:30",
+    "location": "Parking lot behind Hyde Park Florist and Gifts, 4204 Albany Post Rd, Hyde Park, ny, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/256156071/",
+    "attendees": 4
+  },
+  {
+    "title": "Drinking Practice",
+    "date": "2018-12-07",
+    "startTime": "19:00",
+    "location": "Sloop Brewery @ the Factory, 755 East Drive, Suite 106, Hopewell Junction, ny, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/256768354/",
+    "attendees": 8
+  },
+  {
+    "title": "#43 Spooky Turkey Hash!",
+    "date": "2018-11-24",
+    "startTime": "13:00",
+    "location": "Parking Lot at 41.226457, -74.025318 on Turkey Hollow Road, 11 Turkey Hollow Road, Stony Point, ny, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/255345737/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail #42: Hudson Valley H3 and C.U.N.T Joint Hash!",
+    "date": "2018-07-14",
+    "startTime": "14:30",
+    "location": "Emmett Mahoney's Irish Pub & Steak House, 35 Main Street, Poughkeepsie, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/251890898/",
+    "attendees": 4
+  },
+  {
+    "title": "HVH3 Trail #41- Fahnestock State Park",
+    "date": "2018-05-26",
+    "startTime": "14:00",
+    "location": "Dennytown AT Parking, 291-295 Dennytown Rd, Putnam Valley, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/248687724/",
+    "attendees": 11
+  },
+  {
+    "title": "HVH3 Trail #40- Newburgh, NY",
+    "date": "2018-04-14",
+    "startTime": "14:00",
+    "location": "Cronomer Hill Park, 214 Gardnertown Rd, Newburgh, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/248687657/",
+    "attendees": 5
+  },
+  {
+    "title": "HVH3 Trail #39- Happy Goatday Hash",
+    "date": "2018-03-24",
+    "startTime": "14:00",
+    "location": "Oaktree Gardens Apartments, 120 Channingville Rd, Apt 4B, Wappingers Falls, ny, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/248687506/",
+    "attendees": 6
+  },
+  {
+    "title": "#38 Jingle Balls Hash",
+    "date": "2017-12-17",
+    "startTime": "12:00",
+    "location": "Nardone Soccer Complex, 149 Upper Grand St, Highland, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/245118879/",
+    "attendees": 5
+  },
+  {
+    "title": "#37 Turkey Hash",
+    "date": "2017-11-25",
+    "startTime": "12:30",
+    "location": "James Baird State Park, 14 Maintenance Lane, Pleasant Valley, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/245118680/",
+    "attendees": 3
+  },
+  {
+    "title": "HVH3 Roadtrip to Ithaca's Halloweenie Hash",
+    "date": "2017-10-28",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/244402979/",
+    "attendees": 2
+  },
+  {
+    "title": "Hash #36 - Hashtober!",
+    "date": "2017-10-21",
+    "startTime": "13:00",
+    "location": "Madam Brett Park, Beacon, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/243693847/",
+    "attendees": 5
+  },
+  {
+    "title": "Holy Mattress Monkey Hash!",
+    "date": "2017-09-03",
+    "startTime": "12:30",
+    "location": "Maple Knoll Lodge at Bowdoin Park, 130 Sheafe Road, Wappingers Falls, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/240581569/",
+    "attendees": 7
+  },
+  {
+    "title": "HVH3 Hash #34",
+    "date": "2017-08-12",
+    "startTime": "13:30",
+    "location": "Kingston Point Rotary Park, Delaware Avenue, Kingston, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/240581292/",
+    "attendees": 7
+  },
+  {
+    "title": "HVH3 Hash #33- Highland NY",
+    "date": "2017-07-15",
+    "startTime": "14:00",
+    "location": "Parking lot behind Hanaford Super Market, 3650 Us Highway 9w, Highland, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/241451332/",
+    "attendees": 4
+  },
+  {
+    "title": "HVH3 Hash # 32 in Hopewell Junction, NY",
+    "date": "2017-06-24",
+    "startTime": "14:00",
+    "location": "Hopewell Recreation, Hopewell Junction, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/240578204/",
+    "attendees": 2
+  },
+  {
+    "title": "HVH3 Trail #31 Dyslexia Hash",
+    "date": "2017-05-20",
+    "startTime": "14:00",
+    "location": "Parking Lot on Brewers Lane, 41.685641, -73.903267, Poughkeepsie, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/239517387/",
+    "attendees": 4
+  },
+  {
+    "title": "HVH3 Trail #30 on April 29",
+    "date": "2017-04-29",
+    "startTime": "13:00",
+    "location": "Starr Park, Traver Lane, Rhinebeck, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/238786282/",
+    "attendees": 2
+  },
+  {
+    "title": "Beer Stop for the Breakneck Marathon hosted by HVH3",
+    "date": "2017-04-15",
+    "startTime": "06:00",
+    "location": "Breakneck Parking 41°26'19.9\"N 73°58'24.5\"W, 3001 Bear Mountain-Beacon Hwy, Cold Spring, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/238722550/",
+    "attendees": 3
+  },
+  {
+    "title": "HVH3 Hash #29 Goat Fucker's Birthday Hash!",
+    "date": "2017-03-18",
+    "startTime": "13:00",
+    "location": "2 Way Brewing Company, 18 West Main Street, Beacon, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/237830869/",
+    "attendees": 7
+  },
+  {
+    "title": "Road Trip to New Haven Hash House Harriers: NOT Hashmat 2",
+    "date": "2017-03-11",
+    "startTime": "10:00",
+    "location": "Long Wharf Drive Parking Lot, 351 Long Wharf Dr, New Haven, CT, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/238087673/",
+    "attendees": 2
+  },
+  {
+    "title": "Hash #28 Presidents' Day Hash",
+    "date": "2017-02-18",
+    "startTime": "13:00",
+    "location": "Blue Collar Brewery, 40 Cottage St, Poughkeepsie, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/237523188/",
+    "attendees": 5
+  }
+]

--- a/scripts/data/hvh3-ny-meetup-history-batch-2.json
+++ b/scripts/data/hvh3-ny-meetup-history-batch-2.json
@@ -1,0 +1,114 @@
+[
+  {
+    "title": "Holly Jolly Jingle Hash 2016",
+    "date": "2016-12-17",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/235355199/",
+    "attendees": 2
+  },
+  {
+    "title": "Hash #26 Election Day Hangover Hash in Hyde Park, NY",
+    "date": "2016-11-12",
+    "startTime": "13:00",
+    "location": "Empty parking lot next to Feeds Plus, 4290 Albany Post Rd, Hyde Park, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/234575220/",
+    "attendees": 5
+  },
+  {
+    "title": "Road Trip to Halve Mein/Utica>0 HHH Halloween Hash!",
+    "date": "2016-10-29",
+    "startTime": "10:00",
+    "location": "Center Street Pub, 308 Union St, Schenectady, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/234940483/",
+    "attendees": 4
+  },
+  {
+    "title": "#25 Hashtoberfest 2016",
+    "date": "2016-10-01",
+    "startTime": "13:30",
+    "location": "Snug Harbor Bar and Grill, 38 Main Street, New Paltz, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/234399988/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #24 Father's Day Hash- New Paltz, NY",
+    "date": "2016-06-19",
+    "startTime": "13:30",
+    "location": "Gilded Otter, 3 Main Street, New Paltz, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/231516405/",
+    "attendees": 5
+  },
+  {
+    "title": "Hash #23 Wappingers Vision Quest Hash",
+    "date": "2016-05-21",
+    "startTime": "13:00",
+    "location": "Oak Tree Gardens, 120 Channingville Road, Wappingers Falls, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/230230959/",
+    "attendees": 7
+  },
+  {
+    "title": "Tax Day Hash",
+    "date": "2016-04-15",
+    "startTime": "18:00",
+    "location": "Parking Area, 68 Mt Rutsen Rd, Rhinebeck, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/229245028/",
+    "attendees": 5
+  },
+  {
+    "title": "HVH3 St. Patty's Hangover Hash!",
+    "date": "2016-03-18",
+    "startTime": "17:30",
+    "location": "Keegan Ales, 20 Saint James St, Kingston, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/229244972/",
+    "attendees": 7
+  },
+  {
+    "title": "Ivy League InterHash in Utica, NY (March 4-6)",
+    "date": "2016-03-04",
+    "startTime": "19:00",
+    "location": "Raddison Hotel, 200 Genesee St, Utica, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/228998038/",
+    "attendees": 2
+  },
+  {
+    "title": "Hash #20",
+    "date": "2016-01-30",
+    "startTime": "14:00",
+    "location": "Ulster BOCES on Route 32, 175 NY-32, New Paltz, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/228308462/",
+    "attendees": 2
+  },
+  {
+    "title": "(#19) Bad Santa Hash and Poughkeepsie Santacon!",
+    "date": "2015-12-19",
+    "startTime": "13:00",
+    "location": "Blue Collar Brewery, 40 Cottage St, Poughkeepsie, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/226175130/",
+    "attendees": 5
+  },
+  {
+    "title": "#18 Day of the Dead",
+    "date": "2015-11-01",
+    "startTime": "15:00",
+    "location": "Snug Harbor Bar and Grill, 38 Main Street, New Paltz, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/225791258/",
+    "attendees": 4
+  },
+  {
+    "title": "#17 HashtoberFest",
+    "date": "2015-10-04",
+    "startTime": "13:15",
+    "location": "Hannaford, Rte 9W, Highland, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/225394579/",
+    "attendees": 11
+  },
+  {
+    "title": "Let's go hashing!",
+    "date": "2015-09-14",
+    "startTime": "17:30",
+    "location": "Highland Middle School, 71 Main St, Highland, NY, US",
+    "url": "https://www.meetup.com/hudson-valley-hash-house-harriers/events/225297520/",
+    "attendees": 5
+  }
+]

--- a/scripts/data/mel-new-moon-meetup-history-batch-1.json
+++ b/scripts/data/mel-new-moon-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Bike hash ride #132",
+    "date": "2026-03-22",
+    "startTime": "12:00",
+    "location": "Moorabbin Station, Moorabbin, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/313580232/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne New Moon #174- Maggot & Dripping Wet @ Docklands",
+    "date": "2026-03-14",
+    "startTime": "15:00",
+    "location": "Urban Alley Brewery, 12 Star Circus, Docklands, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/312891079/",
+    "attendees": 6
+  },
+  {
+    "title": "Bike hash ride #132",
+    "date": "2026-02-22",
+    "startTime": "12:00",
+    "location": "SANDRINGHAM STATION/on Sandringham, Station st, Sandringham,Vic 3191, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/313186163/",
+    "attendees": 4
+  },
+  {
+    "title": "Melbourne New Moon #173- Quick Lay @ The King of Tonga",
+    "date": "2026-02-21",
+    "startTime": "15:00",
+    "location": "King of Tonga, 164A Tennyson Street, Elwood VIC 3184, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/312890139/",
+    "attendees": 4
+  },
+  {
+    "title": "Ride #130 New Year, Old Favourites",
+    "date": "2026-01-18",
+    "startTime": "12:00",
+    "location": "Kaiju Beer & Pizza, 27 Hume st, Huntingdale, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/312675951/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne New Moon #172- Skinny Tool @ The Metropolitan Melbourne",
+    "date": "2026-01-10",
+    "startTime": "15:00",
+    "location": "The Metropolitan Hotel, 263 William Street, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/312718878/",
+    "attendees": 1
+  },
+  {
+    "title": "Full Moon Run No. 303",
+    "date": "2026-01-04",
+    "startTime": "16:00",
+    "location": "Werribee Gorge, werribee gorge, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/312647658/",
+    "attendees": 1
+  },
+  {
+    "title": "Bike Hash Ride #129 - Ho Ho Hashy Home Trail",
+    "date": "2025-12-21",
+    "startTime": "12:00",
+    "location": "Whitlam Place, corner of Moor and Napier Sts, Fitzroy, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/312205970/",
+    "attendees": 3
+  },
+  {
+    "title": "Melbourne New Moon #171- Skinny Tool @ Yarraville",
+    "date": "2025-11-22",
+    "startTime": "15:00",
+    "location": "Railway Hotel, 35 Anderson St, Yarraville VIC 3013, Yarraville, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306310844/",
+    "attendees": 5
+  },
+  {
+    "title": "Bike Hash Ride #128 Lester's laneway adventures",
+    "date": "2025-11-16",
+    "startTime": "12:00",
+    "location": "Post Office Hotel Pub & Dining Hall, 229-231 Sydney Rd, Coburg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/311685052/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne New Moon #170- Pog does Williamstown",
+    "date": "2025-10-25",
+    "startTime": "15:00",
+    "location": "The Rifle Club, 121 Victoria Street Williamstown, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306310837/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #127 Thorn again",
+    "date": "2025-09-21",
+    "startTime": "12:00",
+    "location": "Welcome to Thornbury, 520 High St, Northcote 3070, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/310629254/",
+    "attendees": 3
+  },
+  {
+    "title": "Melbourne New Moon #169- CBCo Brewing & Big Earle's Roadhouse BBQ",
+    "date": "2025-09-20",
+    "startTime": "15:00",
+    "location": "CBCo Brewing, 89 Bertie St, Port Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306310832/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.83",
+    "date": "2025-09-12",
+    "startTime": "18:00",
+    "location": "Transport Bar Fed Square, Fed Square, In the \"sunroom\" parallel to Swanston Street, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/310966826/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #126",
+    "date": "2025-08-24",
+    "startTime": "12:00",
+    "location": "Kaiju Beer & Pizza, 27 Hume st, Huntingdale, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/310187134/",
+    "attendees": 3
+  },
+  {
+    "title": "Melbourne New Moon #168- Spotswood",
+    "date": "2025-08-23",
+    "startTime": "15:00",
+    "location": "Spottiswoode Hotel, 62 Hudsons Road, Spotswood, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306310820/",
+    "attendees": 3
+  },
+  {
+    "title": "New Moon #167 @Brunswick",
+    "date": "2025-07-26",
+    "startTime": "15:00",
+    "location": "The Foreigner Brewing Company, Factory 12, 102 Henkel St, Brunswick, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306310813/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #125 Moonshine in Moonee",
+    "date": "2025-07-20",
+    "startTime": "11:30",
+    "location": "Junction Club, 740 Mount Alexander Road, Moonee Ponds, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/308767091/",
+    "attendees": 4
+  },
+  {
+    "title": "Delinquents HHH No.82",
+    "date": "2025-07-11",
+    "startTime": "18:00",
+    "location": "Transport Bar Fed Square, Fed Square, In the \"sunroom\" parallel to Swanston Street, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/309155458/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #124 Hashy Solstice",
+    "date": "2025-06-22",
+    "startTime": "12:00",
+    "location": "Brewmanity, 50 Tope Street, South Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/308124212/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 296",
+    "date": "2025-06-15",
+    "startTime": "15:00",
+    "location": "The Cross, Memorial Cross Loop Road, Mt Macedon, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/308350250/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne New Moon #166- The College Lawn Hotel",
+    "date": "2025-06-14",
+    "startTime": "15:00",
+    "location": "College Lawn Hotel, 36 Greville Street, Prahran, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306310801/",
+    "attendees": 3
+  },
+  {
+    "title": "Delinquents HHH No.81",
+    "date": "2025-06-13",
+    "startTime": "18:00",
+    "location": "Transport Bar Fed Square, Fed Square, In the \"sunroom\" parallel to Swanston Street, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/308350186/",
+    "attendees": 4
+  },
+  {
+    "title": "Bike Hash Ride #123...Easy as",
+    "date": "2025-05-25",
+    "startTime": "12:00",
+    "location": "Goldy's Tavern, 66 Gold Street, Collingwood VIC 3066, Collingwood, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/307578479/",
+    "attendees": 3
+  },
+  {
+    "title": "Melbourne New Moon #165- Hardimans Hotel Kensington",
+    "date": "2025-05-24",
+    "startTime": "15:00",
+    "location": "Hardiman's Hotel, 521 Macaulay Road, Kensington, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306310783/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.80",
+    "date": "2025-05-09",
+    "startTime": "18:00",
+    "location": "Mail Exchange Hotel, 688 Bourke Street , (almost corner Spencer St), Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/307711686/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #122 The Phantom hares again",
+    "date": "2025-04-27",
+    "startTime": "12:00",
+    "location": "Caulfield Station, Station Street, Caulfield, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/307080913/",
+    "attendees": 3
+  },
+  {
+    "title": "Melbourne New Moon #164",
+    "date": "2025-04-26",
+    "startTime": "15:00",
+    "location": "Racecourse Hotel, 895 Dandenong Road, Malvern East, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306310759/",
+    "attendees": 7
+  },
+  {
+    "title": "Delinquents HHH No.79",
+    "date": "2025-04-11",
+    "startTime": "18:00",
+    "location": "Jekyll & Hyde Bar, Acland st, St Kilda, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/307156883/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne New Moon #163- Williamstown",
+    "date": "2025-03-29",
+    "startTime": "15:00",
+    "location": "Pelican's Landing, 1 Syme Street, Williamstown, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306272252/",
+    "attendees": 2
+  },
+  {
+    "title": "Ride #121 Putting the bone into Mentone",
+    "date": "2025-03-22",
+    "startTime": "12:00",
+    "location": "Mentone Railway Station, Corner Balcombe Road and Mentone Parade, Mentone, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305806943/",
+    "attendees": 2
+  },
+  {
+    "title": "Delinquents HHH No.79",
+    "date": "2025-03-14",
+    "startTime": "18:00",
+    "location": "Jekyll & Hyde Bar, Acland st, St Kilda, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306340134/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #120 Captain's (s)log",
+    "date": "2025-02-23",
+    "startTime": "12:00",
+    "location": "The Keys, Unit 1/188 Plenty Rd, Preston, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305806829/",
+    "attendees": 6
+  },
+  {
+    "title": "Melbourne New Moon #162- Red Dress Run",
+    "date": "2025-02-22",
+    "startTime": "15:00",
+    "location": "Flagstaff Gardens, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/306178203/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.78",
+    "date": "2025-02-14",
+    "startTime": "18:00",
+    "location": "The Union Hotel, 90 Chapel Street, Windsor, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305807151/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run #161",
+    "date": "2025-01-26",
+    "startTime": "12:00",
+    "location": "Eastern Lions Soccer Club, Sixth Avenue, Burwood, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305326222/",
+    "attendees": 2
+  },
+  {
+    "title": "Bike hash #119 Drop into Franga",
+    "date": "2025-01-18",
+    "startTime": "12:00",
+    "location": "Carrum Surf Life Saving Club, 15 Old Post Office Lane, Carrum, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305624265/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.",
+    "date": "2025-01-10",
+    "startTime": "18:00",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305195050/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run #160",
+    "date": "2024-12-28",
+    "startTime": "15:00",
+    "location": "Exford Hotel, 199 Russell St (Cnr Russell & Lt Bourke), Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305178309/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 290",
+    "date": "2024-12-15",
+    "startTime": "16:00",
+    "location": "Wattle park Surrey hills 60 k3, Wattle Park in Surrey Hills, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305044793/",
+    "attendees": 1
+  },
+  {
+    "title": "12 Pubs of Christmas",
+    "date": "2024-12-14",
+    "startTime": "14:00",
+    "location": "Bridge Road Brewers, 137-141 Nicholson St, Brunswick East, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/305044768/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No. 77",
+    "date": "2024-12-13",
+    "startTime": "18:00",
+    "location": "Transport Bar Fed Square, Fed Square, In the \"sunroom\" parallel to Swanston Street, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/304722265/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #118 Half-arsed Lazy Hashmas",
+    "date": "2024-12-08",
+    "startTime": "11:00",
+    "location": "Mayors Park near Collingwood Leisure Centre, Hoddle Street, Clifton Hill, 3068, Hoddle Street, Clifton Hill, 3068, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/304608322/",
+    "attendees": 2
+  },
+  {
+    "title": "Ride #117 Make a racket",
+    "date": "2024-11-24",
+    "startTime": "12:00",
+    "location": "Melbourne Park, Victoria, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/304213871/",
+    "attendees": 5
+  },
+  {
+    "title": "AGM Beer Run from Bendigo",
+    "date": "2024-11-23",
+    "startTime": "15:00",
+    "location": "Brougham Arms, 148-150 Williamson St, Bendigo, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303029236/",
+    "attendees": 3
+  },
+  {
+    "title": "Delinquents HHH No.",
+    "date": "2024-11-08",
+    "startTime": "18:00",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/304091741/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.",
+    "date": "2024-11-08",
+    "startTime": "18:00",
+    "location": "College Lawn Hotel, 36 Greville Street, Prahran, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/304091740/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Beer Run #158",
+    "date": "2024-10-26",
+    "startTime": "15:00",
+    "location": "Pier 35 Bar & Grill, 263-329 Lorimer Street, Port Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303635074/",
+    "attendees": 3
+  },
+  {
+    "title": "Bike Hash #116 Sunshine ride",
+    "date": "2024-10-20",
+    "startTime": "10:10",
+    "location": "St Albans Railway Station, Main Rd / St Albans Rd, St Albans, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303951499/",
+    "attendees": 6
+  },
+  {
+    "title": "Full Moon Run No. 288",
+    "date": "2024-10-20",
+    "startTime": "15:00",
+    "location": "Finns Reserve, corner Union Street, Templestowe Lower, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303753864/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/mel-new-moon-meetup-history-batch-2.json
+++ b/scripts/data/mel-new-moon-meetup-history-batch-2.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Delinquents HHH No.76",
+    "date": "2024-10-11",
+    "startTime": "18:00",
+    "location": "College Lawn Hotel, 36 Greville Street, Prahran, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303753953/",
+    "attendees": 4
+  },
+  {
+    "title": "Bike Hash ride #115 - Into the Woods with Lester",
+    "date": "2024-09-29",
+    "startTime": "12:00",
+    "location": "The Woodlands Hotel, 84 Sydney Rd, Coburg, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303208800/",
+    "attendees": 4
+  },
+  {
+    "title": "New Moon Beer Run 157",
+    "date": "2024-09-21",
+    "startTime": "15:00",
+    "location": "Urban Alley Brewery, 12 Star Circus, Docklands, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303029211/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 287",
+    "date": "2024-09-15",
+    "startTime": "15:00",
+    "location": "Tony Clarke Recreation Reserve, Waterfalls Road, Macedon Ranges Shire, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303364790/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.75",
+    "date": "2024-09-13",
+    "startTime": "18:00",
+    "location": "Transport Bar Fed Square, Fed Square, In the \"sunroom\" parallel to Swanston Street, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/303016424/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Beer Run #156",
+    "date": "2024-08-31",
+    "startTime": "15:00",
+    "location": "Wheat, Wine & Whiskey, 284 Smith Street,, Collingwood, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/302683697/",
+    "attendees": 4
+  },
+  {
+    "title": "Bike Hash Ride #114 [not so] Wild West",
+    "date": "2024-08-18",
+    "startTime": "12:00",
+    "location": "St Albans Railway Station, Main Rd / St Albans Rd, St Albans, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/302626112/",
+    "attendees": 2
+  },
+  {
+    "title": "Delinquents HHH No. 74",
+    "date": "2024-08-09",
+    "startTime": "18:00",
+    "location": "Transport Bar Fed Square, Fed Square, In the \"sunroom\" parallel to Swanston Street, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/302348100/",
+    "attendees": 3
+  },
+  {
+    "title": "New Moon Hash Beer Run 155",
+    "date": "2024-08-03",
+    "startTime": "15:00",
+    "location": "Gales Brewery, 28 Gale St, Brunswick East, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/302227360/",
+    "attendees": 3
+  },
+  {
+    "title": "Full Moon Run No. 285",
+    "date": "2024-07-21",
+    "startTime": "15:00",
+    "location": "Churchill National Park, Churchill Park Drive, Rowville, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/302264811/",
+    "attendees": 1
+  },
+  {
+    "title": "Saturday Xmas in July",
+    "date": "2024-07-13",
+    "startTime": "12:00",
+    "location": "PMOW, 11 Bishop st, Kingsville, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/301951290/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.",
+    "date": "2024-07-12",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/301793979/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Hash Beer Run 154",
+    "date": "2024-07-06",
+    "startTime": "15:00",
+    "location": "Whitehart Bar, 22 Whitehart Lane, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/301829965/",
+    "attendees": 2
+  },
+  {
+    "title": "Full Moon Run No. 284",
+    "date": "2024-06-23",
+    "startTime": "15:00",
+    "location": "Bullengarook Recreation Reserve, 683 Bacchus Marsh Road, Bullengarook, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/301794949/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.73",
+    "date": "2024-06-14",
+    "startTime": "18:00",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/301235161/",
+    "attendees": 4
+  },
+  {
+    "title": "Ride #112 Pascoe Vale",
+    "date": "2024-06-09",
+    "startTime": "11:30",
+    "location": "Pascoe Vale Hotel, 12 Railway Parade, Pascoe Vale, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300690043/",
+    "attendees": 3
+  },
+  {
+    "title": "New Moon Hash Beer Run 153",
+    "date": "2024-06-08",
+    "startTime": "15:00",
+    "location": "BrewDog Pentridge, 1 Champ St, Coburg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300363461/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 281",
+    "date": "2024-05-26",
+    "startTime": "15:00",
+    "location": "Greenvale Recreation Reserve, 85 Section Rd, Greenvale, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300876935/",
+    "attendees": 3
+  },
+  {
+    "title": "Ride #111 Retreat!",
+    "date": "2024-05-19",
+    "startTime": "12:00",
+    "location": "Retreat Hotel, 226 Nicholson St, Abbotsford, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300690033/",
+    "attendees": 4
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-05-15",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/301051658/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.72",
+    "date": "2024-05-10",
+    "startTime": "18:00",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300531480/",
+    "attendees": 2
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-05-08",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300914916/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run 152",
+    "date": "2024-05-04",
+    "startTime": "15:00",
+    "location": "College Lawn Hotel, 36 Greville St, Prahran, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300363339/",
+    "attendees": 4
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-05-01",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300773212/",
+    "attendees": 1
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-04-24",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300626409/",
+    "attendees": 1
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-04-17",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300483631/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No. 71",
+    "date": "2024-04-12",
+    "startTime": "18:00",
+    "location": "Hotel Railway Brunswick, 291 Albert St, Brunswick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299129922/",
+    "attendees": 2
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-04-10",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300341868/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run No. 151",
+    "date": "2024-04-06",
+    "startTime": "15:00",
+    "location": "The Tessie Pearl Hotel, 31 Dukes Walk, South Wharf, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/300006417/",
+    "attendees": 1
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-04-03",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299786855/",
+    "attendees": 1
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-03-27",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299649751/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH #70",
+    "date": "2024-03-22",
+    "startTime": "17:30",
+    "location": "Fitzroy Town Hall Hotel, 166 Johnston Street,, Fitzroy, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299809432/",
+    "attendees": 5
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-03-20",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299502479/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #109 - Way out smelly West - St Paddy’s Day ride!",
+    "date": "2024-03-17",
+    "startTime": "12:00",
+    "location": "Altona RSL, 31 Sargood St, Altona, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299330314/",
+    "attendees": 2
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-03-13",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299352821/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.",
+    "date": "2024-03-08",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299671998/",
+    "attendees": 1
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-03-06",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299211052/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run No. 150 (Interhash Prelube Run)",
+    "date": "2024-03-02",
+    "startTime": "15:00",
+    "location": "The Metropolitan Hotel, 265 William St, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299437534/",
+    "attendees": 7
+  },
+  {
+    "title": "Full Moon Run No. 281",
+    "date": "2024-02-25",
+    "startTime": "16:00",
+    "location": "Queens Park Road, Queens Park Rd, Highton, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298009791/",
+    "attendees": 3
+  },
+  {
+    "title": "Ride #108 Braeside Boondoggle",
+    "date": "2024-02-18",
+    "startTime": "12:00",
+    "location": "Mordialloc Station/Albert St, Mordialloc, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298751229/",
+    "attendees": 1
+  },
+  {
+    "title": "City Hash Run#54",
+    "date": "2024-02-15",
+    "startTime": "18:30",
+    "location": "13 Mitford St, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/299051460/",
+    "attendees": 2
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-02-14",
+    "startTime": "18:30",
+    "location": "13 Mitford St, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298773205/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run No. 149 - Annual Red Dress Run",
+    "date": "2024-02-10",
+    "startTime": "15:00",
+    "location": "Flagstaff Gardens Playground, A'Beckett St, West Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298709030/",
+    "attendees": 5
+  },
+  {
+    "title": "Delinquents HHH No.69",
+    "date": "2024-02-09",
+    "startTime": "18:00",
+    "location": "Metro Cellar Door, 1/92 Railway St South, Altona, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298902550/",
+    "attendees": 2
+  },
+  {
+    "title": "Every Wednesday @ 6:30pm from tbd",
+    "date": "2024-02-07",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298858124/",
+    "attendees": 1
+  },
+  {
+    "title": "City Hash Run#53",
+    "date": "2024-02-01",
+    "startTime": "18:30",
+    "location": "Union Hotel, 109 Union St, Brunswick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298707334/",
+    "attendees": 5
+  },
+  {
+    "title": "31 of January @ 6:30pm. Picnic area behind the royal tennis centre Sandringham",
+    "date": "2024-01-31",
+    "startTime": "18:30",
+    "location": "13 Mitford St, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298773502/",
+    "attendees": 1
+  },
+  {
+    "title": "24 of January @ 6:30pm from 13 Mitford St St kilda",
+    "date": "2024-01-24",
+    "startTime": "18:30",
+    "location": "13 Mitford St, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298708984/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #107 Silly in Willy",
+    "date": "2024-01-21",
+    "startTime": "12:00",
+    "location": "Stags Head Hotel, 39 Cecil St, Williamstown, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298160912/",
+    "attendees": 5
+  },
+  {
+    "title": "Full Moon Run No. 281",
+    "date": "2024-01-21",
+    "startTime": "16:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293879013/",
+    "attendees": 3
+  }
+]

--- a/scripts/data/mel-new-moon-meetup-history-batch-3.json
+++ b/scripts/data/mel-new-moon-meetup-history-batch-3.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Aussie Beer Mile",
+    "date": "2024-01-20",
+    "startTime": "15:00",
+    "location": "George Knott Reserve, Heidelberg Rd, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298297549/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne City Hash Run#52",
+    "date": "2024-01-18",
+    "startTime": "18:30",
+    "location": "Goldy's! Tavern, 66A Gold St, Collingwood, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298454319/",
+    "attendees": 5
+  },
+  {
+    "title": "New Moon Run No. 148",
+    "date": "2024-01-13",
+    "startTime": "15:00",
+    "location": "13 Mitford St, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298009639/",
+    "attendees": 9
+  },
+  {
+    "title": "Delinquents HHH No.",
+    "date": "2024-01-12",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/298480850/",
+    "attendees": 1
+  },
+  {
+    "title": "City Hash from CBD (2nd Anniversary Run # 51)",
+    "date": "2024-01-04",
+    "startTime": "18:30",
+    "location": "Batman Park, 32 Rebecca Walk, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/297828230/",
+    "attendees": 6
+  },
+  {
+    "title": "Full Moon Run No. 278",
+    "date": "2023-12-24",
+    "startTime": "16:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714866/",
+    "attendees": 1
+  },
+  {
+    "title": "City Hash from South Melbourne (Run#50)",
+    "date": "2023-12-21",
+    "startTime": "18:30",
+    "location": "Rising Sun Hotel, 2 Raglan St, South Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/297828155/",
+    "attendees": 3
+  },
+  {
+    "title": "Ride #106 Trashy Hashy Christmas",
+    "date": "2023-12-17",
+    "startTime": "12:00",
+    "location": "Local Brewing Co. Taproom, 3 Hilton St, Clifton Hill, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/297574842/",
+    "attendees": 5
+  },
+  {
+    "title": "New Moon Run No. 147 (X'mas Special)",
+    "date": "2023-12-16",
+    "startTime": "14:30",
+    "location": "Co-conspirators Brewpub, 377 Victoria St, Brunswick, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/295167102/",
+    "attendees": 6
+  },
+  {
+    "title": "12 Pubs of Chrismas",
+    "date": "2023-12-09",
+    "startTime": "13:00",
+    "location": "The Fox Hotel, 351 Wellington St, Collingwood, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/296979427/",
+    "attendees": 5
+  },
+  {
+    "title": "Delinquents HHH No.68",
+    "date": "2023-12-08",
+    "startTime": "18:00",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/297811414/",
+    "attendees": 2
+  },
+  {
+    "title": "City Hash from Flagstaff (Run 48)",
+    "date": "2023-12-07",
+    "startTime": "18:30",
+    "location": "Flagstaff Gardens, 309-311 William St, West Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/297652685/",
+    "attendees": 2
+  },
+  {
+    "title": "Full Moon Run No. 279",
+    "date": "2023-11-26",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293879021/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #105. Ah Sole! is the hare",
+    "date": "2023-11-19",
+    "startTime": "12:00",
+    "location": "Tallboy and Moose, 270 Raglan St, Preston, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/297169748/",
+    "attendees": 4
+  },
+  {
+    "title": "New Moon Run No. 146",
+    "date": "2023-11-18",
+    "startTime": "15:00",
+    "location": "The Tessie Pearl Hotel, 31 Dukes Walk, South Wharf, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714942/",
+    "attendees": 4
+  },
+  {
+    "title": "Delinquents HHH No.67",
+    "date": "2023-11-10",
+    "startTime": "18:00",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/297155454/",
+    "attendees": 1
+  },
+  {
+    "title": "Ingest the Best of the West at our Behest. Ride #104",
+    "date": "2023-10-29",
+    "startTime": "12:00",
+    "location": "Mona Castle Hotel, 45-53 Austin St, Seddon, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/296597161/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 278",
+    "date": "2023-10-29",
+    "startTime": "16:00",
+    "location": "Hobbs Road, Hobbs Rd, Gisborne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714978/",
+    "attendees": 2
+  },
+  {
+    "title": "Delinquents HHH No.66",
+    "date": "2023-10-20",
+    "startTime": "18:00",
+    "location": "The Sherlock Holmes, 415 Collins St, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294715099/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run No. 145",
+    "date": "2023-10-14",
+    "startTime": "15:00",
+    "location": "The Mint, 318 William St, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714937/",
+    "attendees": 6
+  },
+  {
+    "title": "Full Moon Run No. 277",
+    "date": "2023-10-08",
+    "startTime": "16:00",
+    "location": "Werribee Gorge State Park, 204 Myers Rd, Pentland Hills, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714858/",
+    "attendees": 2
+  },
+  {
+    "title": "Ride #103 What Kiwi did next",
+    "date": "2023-09-24",
+    "startTime": "12:00",
+    "location": "Deeds Brewing, 4 Paran Pl, Glen Iris, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/295993958/",
+    "attendees": 4
+  },
+  {
+    "title": "City Hash Run#43 (Race The Tram)",
+    "date": "2023-09-23",
+    "startTime": "15:00",
+    "location": "Urban Alley Brewery, 12 Star Circus, Docklands, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/295123915/",
+    "attendees": 2
+  },
+  {
+    "title": "New Moon Run No. 144",
+    "date": "2023-09-23",
+    "startTime": "15:00",
+    "location": "Urban Alley Brewery, 12 Star Circus, Docklands, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714960/",
+    "attendees": 2
+  },
+  {
+    "title": "City Hash Run#42",
+    "date": "2023-09-21",
+    "startTime": "18:30",
+    "location": "Goat House, 272 Glen Huntly Rd, Elsternwick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/295123892/",
+    "attendees": 3
+  },
+  {
+    "title": "Delinquents HHH No.65",
+    "date": "2023-09-08",
+    "startTime": "18:00",
+    "location": "The Tessie Pearl Hotel, 31 Dukes Walk, South Wharf, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714920/",
+    "attendees": 4
+  },
+  {
+    "title": "City Hash Run#41",
+    "date": "2023-09-07",
+    "startTime": "18:30",
+    "location": "The Central Club Hotel, 293 Swan St, Richmond, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/295123874/",
+    "attendees": 1
+  },
+  {
+    "title": "Full Moon Run No. 276",
+    "date": "2023-09-03",
+    "startTime": "15:00",
+    "location": "Lysterfield Park, Horswood Rd, Lysterfield, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714849/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #102 Poison Ivy plays naughts and crosses",
+    "date": "2023-08-20",
+    "startTime": "12:00",
+    "location": "The Woodlands Hotel, 84-88 Sydney Rd, Coburg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/295109029/",
+    "attendees": 3
+  },
+  {
+    "title": "New Moon Run No. 143",
+    "date": "2023-08-19",
+    "startTime": "15:00",
+    "location": "The Mitre Tavern, 5 Bank Pl, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293878959/",
+    "attendees": 7
+  },
+  {
+    "title": "City Hash Run#40",
+    "date": "2023-08-17",
+    "startTime": "18:30",
+    "location": "Westside Ale Works, 36 Alfred St, South Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/295123862/",
+    "attendees": 2
+  },
+  {
+    "title": "Delinquents HHH No.64",
+    "date": "2023-08-11",
+    "startTime": "17:30",
+    "location": "Hippo Bottle & Bar, 290 Smith St, Collingwood, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294714888/",
+    "attendees": 6
+  },
+  {
+    "title": "Full Moon Run No. 275",
+    "date": "2023-08-06",
+    "startTime": "15:00",
+    "location": "Churchill National Park, Army Track, Lysterfield South, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293879004/",
+    "attendees": 3
+  },
+  {
+    "title": "City Hash Run#39",
+    "date": "2023-08-03",
+    "startTime": "18:30",
+    "location": "All Nations Hotel, 64 Lennox St, Richmond, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/295123852/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.63",
+    "date": "2023-07-28",
+    "startTime": "17:30",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294388843/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne Bike Hash Ride #101 - AGM Handing over the big wheel",
+    "date": "2023-07-23",
+    "startTime": "12:00",
+    "location": "BrewDog Pentridge, 1 Champ St, Coburg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/294363400/",
+    "attendees": 10
+  },
+  {
+    "title": "New Moon Run No. 142",
+    "date": "2023-07-15",
+    "startTime": "15:00",
+    "location": "Goat House, 272 Glen Huntly Rd, Elsternwick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293878938/",
+    "attendees": 2
+  },
+  {
+    "title": "Full Moon Run No. 274",
+    "date": "2023-07-02",
+    "startTime": "15:00",
+    "location": "Long Forest Nature Conservation Reserve, Long Forest Rd, Merrimu, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293878980/",
+    "attendees": 3
+  },
+  {
+    "title": "New Moon Run No. 141 (Jock's Farewell Run)",
+    "date": "2023-06-24",
+    "startTime": "15:00",
+    "location": "Railway Hotel, 35 Anderson Street, Yarraville, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293878906/",
+    "attendees": 5
+  },
+  {
+    "title": "Melbourne City Hash#36 (Run & Beer)",
+    "date": "2023-06-15",
+    "startTime": "18:30",
+    "location": "The Cross - St Kilda, 14 Fitzroy St, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293949237/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne Bike Hash Ride#100 - It's our 100th ride!",
+    "date": "2023-06-10",
+    "startTime": "09:30",
+    "location": "The Red Hill Caterers Cafe, 1008 Mornington-Flinders Road, Red Hill VIC 3937, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290346199/",
+    "attendees": 6
+  },
+  {
+    "title": "Delinquents HHH No.62 + add on a birthday",
+    "date": "2023-06-09",
+    "startTime": "18:00",
+    "location": "Bartronica, 335 Flinders Ln, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610446/",
+    "attendees": 2
+  },
+  {
+    "title": "Full Moon Run No. 273",
+    "date": "2023-06-04",
+    "startTime": "15:00",
+    "location": "Mount Macedon Memorial Cross, Mount Macedon, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610411/",
+    "attendees": 4
+  },
+  {
+    "title": "Melbourne City Hash # 35 (Run & Beer)",
+    "date": "2023-06-01",
+    "startTime": "18:30",
+    "location": "Local Brewing Co. Taproom, 3 Hilton St, Clifton Hill, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293690951/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne Bike Hash Ride#99 - Cooch and E&B are hares",
+    "date": "2023-05-21",
+    "startTime": "12:00",
+    "location": "Ramblers Ale Works, 96 Riversdale Rd, Hawthorn, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290346165/",
+    "attendees": 6
+  },
+  {
+    "title": "New Moon Run No. 140",
+    "date": "2023-05-20",
+    "startTime": "15:00",
+    "location": "Exford Hotel, 199 Russell St (Cnr Russell & Lt Bourke), Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610257/",
+    "attendees": 3
+  },
+  {
+    "title": "Delinquents HHH No.61",
+    "date": "2023-05-12",
+    "startTime": "17:30",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610438/",
+    "attendees": 1
+  },
+  {
+    "title": "Full Moon Run No. 272",
+    "date": "2023-05-07",
+    "startTime": "15:00",
+    "location": "Currawong Bush Park, Reynolds Rd, Doncaster East, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610397/",
+    "attendees": 2
+  },
+  {
+    "title": "Melbourne City Hash#33 (Run & Beer)",
+    "date": "2023-05-04",
+    "startTime": "18:30",
+    "location": "Doutta Galla Hotel, 339 Racecourse Road Flemington, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/293229296/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run No. 139",
+    "date": "2023-04-22",
+    "startTime": "15:00",
+    "location": "The Stolberg, 197 Plenty Rd, Preston, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290947071/",
+    "attendees": 4
+  }
+]

--- a/scripts/data/mel-new-moon-meetup-history-batch-4.json
+++ b/scripts/data/mel-new-moon-meetup-history-batch-4.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Melbourne City Hash Run#32",
+    "date": "2023-04-20",
+    "startTime": "19:00",
+    "location": "Prince Alfred Hotel, 355 Bay Street, Port Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/292314609/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne Bike Hash Ride #98 - Happy Hour(s) in Bike(Car)negie",
+    "date": "2023-04-16",
+    "startTime": "12:00",
+    "location": "Carnegie Station, Carnegie, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290346107/",
+    "attendees": 7
+  },
+  {
+    "title": "Delinquents HHH No.60",
+    "date": "2023-04-14",
+    "startTime": "17:30",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610427/",
+    "attendees": 2
+  },
+  {
+    "title": "Melbourne City Hash Run#31",
+    "date": "2023-04-06",
+    "startTime": "18:45",
+    "location": "Union Club Hotel, 164 Gore St, Fitzroy, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/292314567/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 271",
+    "date": "2023-04-02",
+    "startTime": "15:00",
+    "location": "O'Briens Crossing, Obriens Rd, Lerderderg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610339/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run No: 138",
+    "date": "2023-03-18",
+    "startTime": "15:00",
+    "location": "Kaiju!, 27 Hume St, Huntingdale, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/291712541/",
+    "attendees": 5
+  },
+  {
+    "title": "Melbourne Bike Hash Ride #97 - Things are Crook in Karkarook",
+    "date": "2023-03-12",
+    "startTime": "12:00",
+    "location": "Highett Station, Highett, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290346098/",
+    "attendees": 6
+  },
+  {
+    "title": "Delinquents HHH No.59",
+    "date": "2023-03-10",
+    "startTime": "17:30",
+    "location": "The Provincial Hotel, 299 Brunswick St, Fitzroy, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610421/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 270",
+    "date": "2023-03-05",
+    "startTime": "16:00",
+    "location": "Kurth Kiln picnic area, Thornton Walk, Yellingbo, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610338/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne Bike Hash Ride #96 - Woodend",
+    "date": "2023-02-19",
+    "startTime": "12:00",
+    "location": "Woodend, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290346077/",
+    "attendees": 8
+  },
+  {
+    "title": "T-shirt Order for New Moon Hash",
+    "date": "2023-02-18",
+    "startTime": "15:00",
+    "location": "Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/291696780/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run No. 137",
+    "date": "2023-02-18",
+    "startTime": "15:00",
+    "location": "The Duke of Wellington, 146 Flinders Street, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610265/",
+    "attendees": 4
+  },
+  {
+    "title": "Delinquents HHH No.58",
+    "date": "2023-02-10",
+    "startTime": "18:00",
+    "location": "The Cheeky Pint, 231 Barkly St, Footscray, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610311/",
+    "attendees": 2
+  },
+  {
+    "title": "Full Moon Run No. 269",
+    "date": "2023-02-05",
+    "startTime": "16:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610335/",
+    "attendees": 2
+  },
+  {
+    "title": "Beer Run#27 (Melbourne City Hash House Harriers)",
+    "date": "2023-02-02",
+    "startTime": "18:45",
+    "location": "Hotel Spencer Bar & Grill, 475 Spencer St, West Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/291125562/",
+    "attendees": 1
+  },
+  {
+    "title": "New Moon Run No. 136",
+    "date": "2023-01-21",
+    "startTime": "15:00",
+    "location": "The Cheeky Pint, 231 Barkly St, Footscray, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610201/",
+    "attendees": 7
+  },
+  {
+    "title": "Beer Run# 26 from Melbourne City Hash",
+    "date": "2023-01-19",
+    "startTime": "18:45",
+    "location": "THE ANGRY DOG, 405 Spencer St, West Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290799204/",
+    "attendees": 2
+  },
+  {
+    "title": "Melbourne Bike Hash #95 - Werribee hash",
+    "date": "2023-01-15",
+    "startTime": "12:00",
+    "location": "The Park Hotel, 12 Watton St, Werribee, VIC 3030, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/288680938/",
+    "attendees": 10
+  },
+  {
+    "title": "Delinquents HHH No.57",
+    "date": "2023-01-13",
+    "startTime": "18:00",
+    "location": "Hotel Esplanade, 11 The Esplanade, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290508593/",
+    "attendees": 2
+  },
+  {
+    "title": "Full Moon Run No. 268",
+    "date": "2023-01-08",
+    "startTime": "16:00",
+    "location": "Nobelius Siding Packing Shed, LOT 1 Crichton Rd, Emerald, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290610111/",
+    "attendees": 2
+  },
+  {
+    "title": "Melbourne City Hash 1st Anniversary Run",
+    "date": "2023-01-05",
+    "startTime": "18:40",
+    "location": "Batman Park, 2A Spencer St, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/290396695/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne Bike Hash #94 - Red Dress Tide",
+    "date": "2022-12-18",
+    "startTime": "11:30",
+    "location": "The Keys, 188 Plenty Rd, Preston, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/288680529/",
+    "attendees": 11
+  },
+  {
+    "title": "MNH3 Run#135 - Six Pubs of X'mas Crawl Run",
+    "date": "2022-12-17",
+    "startTime": "15:00",
+    "location": "Fixation Brewing Co - the incubator, 414 Smith St, Collingwood, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/289284807/",
+    "attendees": 13
+  },
+  {
+    "title": "Full Moon Run No. 267",
+    "date": "2022-12-11",
+    "startTime": "16:00",
+    "location": "Days Picnic Ground, Mount Macedon, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371671/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.56",
+    "date": "2022-12-09",
+    "startTime": "18:00",
+    "location": "North Port Hotel, 146 Evans St, Port Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/288640769/",
+    "attendees": 5
+  },
+  {
+    "title": "MNH3 Run No. 134",
+    "date": "2022-11-26",
+    "startTime": "15:00",
+    "location": "Flagstaff Gardens, 309-311 William St, West Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371853/",
+    "attendees": 6
+  },
+  {
+    "title": "Melbourne Bike Hash #93 - Ballarat ride",
+    "date": "2022-11-20",
+    "startTime": "11:30",
+    "location": "The North Star Hotel, 302 Lydiard St N, Soldiers Hill, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/288680509/",
+    "attendees": 5
+  },
+  {
+    "title": "Delinquents HHH No.55",
+    "date": "2022-11-11",
+    "startTime": "17:30",
+    "location": "The Provincial Hotel, 299 Brunswick St, Fitzroy, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/289269671/",
+    "attendees": 8
+  },
+  {
+    "title": "Full Moon Run No. 266",
+    "date": "2022-11-06",
+    "startTime": "16:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371659/",
+    "attendees": 1
+  },
+  {
+    "title": "Run No. 133 - Homecoming",
+    "date": "2022-10-29",
+    "startTime": "15:00",
+    "location": "Exford Hotel, 199 Russell St, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371848/",
+    "attendees": 3
+  },
+  {
+    "title": "Delinquents HHH No.54",
+    "date": "2022-10-14",
+    "startTime": "17:30",
+    "location": "The Moat, 176 Little Lonsdale St, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/287128661/",
+    "attendees": 2
+  },
+  {
+    "title": "Melbourne Bike Hash #92",
+    "date": "2022-10-09",
+    "startTime": "12:00",
+    "location": "clare castle, 354 Graham St Port Melbourne,, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/288133670/",
+    "attendees": 10
+  },
+  {
+    "title": "Full Moon Run No. 265",
+    "date": "2022-10-09",
+    "startTime": "15:00",
+    "location": "Maroondah Reservoir Park, Maroondah Hwy, Healesville, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371651/",
+    "attendees": 3
+  },
+  {
+    "title": "Run No. 132 and AGPU",
+    "date": "2022-10-01",
+    "startTime": "15:00",
+    "location": "Rising Sun Hotel Richmond, 395 Swan St, Richmond, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371837/",
+    "attendees": 12
+  },
+  {
+    "title": "Melbourne Bike Hash #91",
+    "date": "2022-09-17",
+    "startTime": "12:00",
+    "location": "Benchwarmer, 345 Victoria Street, West Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/288133904/",
+    "attendees": 13
+  },
+  {
+    "title": "Full Moon Run No. 264",
+    "date": "2022-09-11",
+    "startTime": "15:00",
+    "location": "Ferndale Park, Back Creek Reserve, Glen Iris, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371643/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.53",
+    "date": "2022-09-09",
+    "startTime": "18:00",
+    "location": "the wood samaritan, 140 Lygon St, Brunswick East, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/287118440/",
+    "attendees": 6
+  },
+  {
+    "title": "Melbourne Bike Hash #90 - The Phantom Trail",
+    "date": "2022-08-21",
+    "startTime": "11:30",
+    "location": "Huntingdale Station, Huntingdale and Haughtin Rds, Oakleigh, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/287281623/",
+    "attendees": 8
+  },
+  {
+    "title": "Run No. 131",
+    "date": "2022-08-20",
+    "startTime": "15:00",
+    "location": "Stags Head Hotel, 39 Cecil St, Williamstown, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371827/",
+    "attendees": 2
+  },
+  {
+    "title": "Full Moon Run No. 263",
+    "date": "2022-08-14",
+    "startTime": "15:00",
+    "location": "Lower Stony Creek Reservoir, Staughton Vale, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371634/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.52",
+    "date": "2022-08-12",
+    "startTime": "18:00",
+    "location": "Hotel Esplanade, 11 The Esplanade, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/287118413/",
+    "attendees": 1
+  },
+  {
+    "title": "Run No. 130",
+    "date": "2022-07-30",
+    "startTime": "15:00",
+    "location": "Temperance Hotel, 426 Chapel St, South Yarra, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371818/",
+    "attendees": 2
+  },
+  {
+    "title": "Melbourne Bike Hash - Ride #89 Xmas in July 2022",
+    "date": "2022-07-17",
+    "startTime": "10:30",
+    "location": "German Café /Café Hahn, 79 Paisley St, Footscray, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/285323987/",
+    "attendees": 6
+  },
+  {
+    "title": "Full Moon Run No. 262",
+    "date": "2022-07-17",
+    "startTime": "15:00",
+    "location": "Nobelius Heritage Park, 3 Crichton Rd, Emerald, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371611/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH - Addon's farewell to Stuckon",
+    "date": "2022-07-08",
+    "startTime": "18:00",
+    "location": "13 Mitford St, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/287008669/",
+    "attendees": 1
+  },
+  {
+    "title": "Run No. 129",
+    "date": "2022-06-25",
+    "startTime": "15:00",
+    "location": "The Woodlands Hotel, 84-88 Sydney Rd, Coburg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/286651117/",
+    "attendees": 2
+  },
+  {
+    "title": "Run No. 129",
+    "date": "2022-06-25",
+    "startTime": "15:00",
+    "location": "The Woodlands Hotel, 84-88 Sydney Rd, Coburg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371799/",
+    "attendees": 3
+  },
+  {
+    "title": "Full Moon Run No. 261",
+    "date": "2022-06-19",
+    "startTime": "15:00",
+    "location": "Falcon's Lookout, Werribee Gorge State Park, Ironbark Road, Ingliston, al, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371394/",
+    "attendees": 4
+  },
+  {
+    "title": "Delinquents HHH No.51",
+    "date": "2022-06-17",
+    "startTime": "17:30",
+    "location": "Chuckle Park Bar, 322 Little Collins St, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/285562845/",
+    "attendees": 1
+  },
+  {
+    "title": "Bike Ride #88 - Two Fat Ladies hash",
+    "date": "2022-06-12",
+    "startTime": "11:45",
+    "location": "Randazzo Park, Brunswick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/284648668/",
+    "attendees": 6
+  }
+]

--- a/scripts/data/mel-new-moon-meetup-history-batch-5.json
+++ b/scripts/data/mel-new-moon-meetup-history-batch-5.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Run No. 128",
+    "date": "2022-05-28",
+    "startTime": "15:00",
+    "location": "Westside Ale Works, 36 Alfred St, South Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371788/",
+    "attendees": 6
+  },
+  {
+    "title": "Full Moon Run No. 260",
+    "date": "2022-05-14",
+    "startTime": "13:30",
+    "location": "Dammans Road, Dammans Rd, Warburton, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371247/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.50",
+    "date": "2022-05-13",
+    "startTime": "18:00",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/285034250/",
+    "attendees": 3
+  },
+  {
+    "title": "Run No. 127",
+    "date": "2022-04-30",
+    "startTime": "15:00",
+    "location": "Royal Standard Hotel, 333 William St, West Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371724/",
+    "attendees": 12
+  },
+  {
+    "title": "Melbourne Bike Hash - Ride #87 - Complete Mismanagement (AGM)",
+    "date": "2022-04-10",
+    "startTime": "12:00",
+    "location": "The Woodlands Hotel, 84-88 Sydney Rd, Coburg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/284648351/",
+    "attendees": 10
+  },
+  {
+    "title": "Full Moon Run No. 259",
+    "date": "2022-04-10",
+    "startTime": "15:00",
+    "location": "One Tree Hill Picnic Ground, Lord Somers Rd, Tremont, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371060/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.49",
+    "date": "2022-04-08",
+    "startTime": "18:00",
+    "location": "Union Club Hotel, 164 Gore St, Fitzroy, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/285034197/",
+    "attendees": 2
+  },
+  {
+    "title": "Run No. 126",
+    "date": "2022-04-02",
+    "startTime": "15:00",
+    "location": "THE HOF DOWNTOWN, 737 Bourke Street Docklands 3008, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/284458464/",
+    "attendees": 5
+  },
+  {
+    "title": "Full Moon Run No. 258",
+    "date": "2022-03-20",
+    "startTime": "16:00",
+    "location": "Kurth Kiln Regional Park, Gembrook, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283370825/",
+    "attendees": 1
+  },
+  {
+    "title": "Ride #86 - You're 86ed!",
+    "date": "2022-03-13",
+    "startTime": "12:00",
+    "location": "Tallboy and Moose, 270 Raglan St, Preston, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/282765593/",
+    "attendees": 8
+  },
+  {
+    "title": "Delinquents HHH No.48",
+    "date": "2022-03-11",
+    "startTime": "18:00",
+    "location": "Retreat Hotel, 280 Sydney Rd, Brunswick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/284112170/",
+    "attendees": 3
+  },
+  {
+    "title": "Run No. 125",
+    "date": "2022-03-05",
+    "startTime": "15:00",
+    "location": "Yarraville Club, 135 Stephen St, Yarraville, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371710/",
+    "attendees": 5
+  },
+  {
+    "title": "Full Moon Run No. 257",
+    "date": "2022-02-20",
+    "startTime": "16:00",
+    "location": "Sapling Gully Picnic Area, Aeroplane Rd, Glenmore, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283370336/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne Bike Hash ride #85 - Pythagorarse's Triangle",
+    "date": "2022-02-13",
+    "startTime": "12:00",
+    "location": "Mordialloc Railway Station, Historic Water Tower Albert Street Mordialloc, Melbourne, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283168974/",
+    "attendees": 9
+  },
+  {
+    "title": "Delinquents HHH No. 47",
+    "date": "2022-02-11",
+    "startTime": "17:30",
+    "location": "Fixation Brewing Co - the incubator, 414 Smith St, Collingwood, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283738585/",
+    "attendees": 6
+  },
+  {
+    "title": "Run No. 124",
+    "date": "2022-02-05",
+    "startTime": "15:00",
+    "location": "13 Mitford St, St Kilda, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283371701/",
+    "attendees": 12
+  },
+  {
+    "title": "Full Moon Run No. 256",
+    "date": "2022-01-16",
+    "startTime": "16:00",
+    "location": "Churchill Park, Churchill Park Drive, Lysterfield South, al, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/283167559/",
+    "attendees": 1
+  },
+  {
+    "title": "Delinquents HHH No.46",
+    "date": "2022-01-14",
+    "startTime": "17:30",
+    "location": "Transport Hotel, Federation Square, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/282987853/",
+    "attendees": 2
+  },
+  {
+    "title": "Melbourne bike hash ride #84- Happy despotic new year. Polpot is the hare",
+    "date": "2022-01-09",
+    "startTime": "12:00",
+    "location": "Moorabbin Train Station, Moorabbin, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/282106528/",
+    "attendees": 7
+  },
+  {
+    "title": "Run No. 123",
+    "date": "2022-01-08",
+    "startTime": "15:00",
+    "location": "Racecourse Hotel, 895 Princes Hwy Service Rd, Malvern East, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/282619934/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 255",
+    "date": "2021-12-19",
+    "startTime": "16:00",
+    "location": "24 Glasgow Rd, Kilsyth, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/281562868/",
+    "attendees": 1
+  },
+  {
+    "title": "Melbourne Bike Hash Ride #83 - Xmas hash",
+    "date": "2021-12-12",
+    "startTime": "11:00",
+    "location": "Bayswater railway station, Station Street, Bayswater, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/281880078/",
+    "attendees": 10
+  },
+  {
+    "title": "Delinquents HHH No.45",
+    "date": "2021-12-10",
+    "startTime": "17:30",
+    "location": "El Camino Cantina Fitzroy, 222 Brunswick St, Fitzroy, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734879/",
+    "attendees": 5
+  },
+  {
+    "title": "Run No. 122",
+    "date": "2021-12-04",
+    "startTime": "15:00",
+    "location": "Moon Dog OG, 17 Duke St, Abbotsford, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734766/",
+    "attendees": 10
+  },
+  {
+    "title": "Full Moon Run No. 254",
+    "date": "2021-11-21",
+    "startTime": "16:00",
+    "location": "Dammans Road, Dammans Rd, Warburton, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/281562858/",
+    "attendees": 3
+  },
+  {
+    "title": "Delinquents HHH No.44",
+    "date": "2021-11-19",
+    "startTime": "18:00",
+    "location": "Common Man, 39 Dukes Walk, South Wharf, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734858/",
+    "attendees": 3
+  },
+  {
+    "title": "Melbourne Bike Hash Ride #82 - LCM is at it again",
+    "date": "2021-11-14",
+    "startTime": "12:00",
+    "location": "Inner North Brewing Company, 10A Russell St, Brunswick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/281328693/",
+    "attendees": 18
+  },
+  {
+    "title": "Run No. 121",
+    "date": "2021-11-13",
+    "startTime": "15:30",
+    "location": "The Cornish Arms Hotel, 163A Sydney Rd, Brunswick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/281562751/",
+    "attendees": 5
+  },
+  {
+    "title": "Run No. 120",
+    "date": "2021-10-30",
+    "startTime": "15:00",
+    "location": "Beaton Reserve, Yarraville, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734756/",
+    "attendees": 8
+  },
+  {
+    "title": "Full Moon Run No. 253",
+    "date": "2021-10-24",
+    "startTime": "16:00",
+    "location": "Braeside Park - Red Gum Picnic Area, Braeside, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/281562714/",
+    "attendees": 3
+  },
+  {
+    "title": "Delinquents HHH No.43",
+    "date": "2021-10-08",
+    "startTime": "17:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734807/",
+    "attendees": 1
+  },
+  {
+    "title": "Run No. 121",
+    "date": "2021-10-02",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734741/",
+    "attendees": 1
+  },
+  {
+    "title": "Bike hash #80 - Polpot is the hare",
+    "date": "2021-09-12",
+    "startTime": "12:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/278255611/",
+    "attendees": 2
+  },
+  {
+    "title": "Delinquents HHH No.42",
+    "date": "2021-09-10",
+    "startTime": "17:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734799/",
+    "attendees": 1
+  },
+  {
+    "title": "Run No. 120",
+    "date": "2021-09-04",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734718/",
+    "attendees": 3
+  },
+  {
+    "title": "Bike hash #79 - Lester TCM is the hare",
+    "date": "2021-08-22",
+    "startTime": "12:00",
+    "location": "Inner North Brewing Company, 10A Russell St, Brunswick, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/278255569/",
+    "attendees": 13
+  },
+  {
+    "title": "Virtual hash 6.2 - Bailie Bitches Beers Bikes & Bridges",
+    "date": "2021-08-15",
+    "startTime": "17:00",
+    "location": null,
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/280069232/",
+    "attendees": 5
+  },
+  {
+    "title": "Delinquents HHH No. 41",
+    "date": "2021-08-13",
+    "startTime": "17:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734780/",
+    "attendees": 1
+  },
+  {
+    "title": "Run No. 119",
+    "date": "2021-08-07",
+    "startTime": "15:00",
+    "location": "Moon Dog OG, 17 Duke St, Abbotsford, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/279734706/",
+    "attendees": 12
+  },
+  {
+    "title": "Delinquents HHH No.41 - LOCKDOWNED",
+    "date": "2021-07-16",
+    "startTime": "18:00",
+    "location": "Bridie O'Reilly’s, 462 Chapel St, South Yarra, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/276827060/",
+    "attendees": 3
+  },
+  {
+    "title": "Run No. 118",
+    "date": "2021-07-10",
+    "startTime": "15:00",
+    "location": "The Grandview Hotel Fairfield, 429 Heidelberg Rd, Fairfield, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/276827013/",
+    "attendees": 9
+  },
+  {
+    "title": "Delinquents HHH No.40 - rescheduled",
+    "date": "2021-06-18",
+    "startTime": "17:30",
+    "location": "Stags Head Hotel, 39 Cecil St, Williamstown, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/275310980/",
+    "attendees": 10
+  },
+  {
+    "title": "Bike Hash #78 - Dirty Laundry Ride",
+    "date": "2021-06-13",
+    "startTime": "12:00",
+    "location": "Back Alley Sally's, 4 Yewers Street, Footscray, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/278255532/",
+    "attendees": 13
+  },
+  {
+    "title": "Run No. 117",
+    "date": "2021-06-12",
+    "startTime": "15:00",
+    "location": "Royal Standard Hotel, 333 William St, West Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/275310703/",
+    "attendees": 10
+  },
+  {
+    "title": "Full Moon Run No. 252 - Cancelled due to lockdown",
+    "date": "2021-05-30",
+    "startTime": "11:00",
+    "location": "Doongalla Forest Road, Doongalla Forest Rd, Mount Dandenong, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/277659668/",
+    "attendees": 1
+  },
+  {
+    "title": "Bike Hash #77 - Not Over the Hill",
+    "date": "2021-05-16",
+    "startTime": "12:00",
+    "location": "Clifton Hill, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/277850536/",
+    "attendees": 13
+  },
+  {
+    "title": "Run No. 116",
+    "date": "2021-05-15",
+    "startTime": "15:00",
+    "location": "Future Mountain, 703 Plenty Road, Reservoir, Reservoir, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/275310693/",
+    "attendees": 15
+  },
+  {
+    "title": "Full Moon Run No. 251",
+    "date": "2021-05-02",
+    "startTime": "15:00",
+    "location": "Currawong Bush Park, Reynolds Rd, Doncaster East, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/277659658/",
+    "attendees": 5
+  },
+  {
+    "title": "Bike Hash #76 - Sistas are Doin it",
+    "date": "2021-04-17",
+    "startTime": "13:30",
+    "location": "Post Office Hotel Pub & Dining Hall, 229-231 Sydney Rd, Coburg, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/274448693/",
+    "attendees": 14
+  },
+  {
+    "title": "Delinquents HHH No.39",
+    "date": "2021-04-16",
+    "startTime": "18:30",
+    "location": "Exford Hotel, 199 Russell St, Melbourne, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/275310890/",
+    "attendees": 4
+  }
+]

--- a/scripts/data/mel-new-moon-meetup-history-batch-6.json
+++ b/scripts/data/mel-new-moon-meetup-history-batch-6.json
@@ -1,0 +1,82 @@
+[
+  {
+    "title": "Run No. 115",
+    "date": "2021-04-10",
+    "startTime": "15:00",
+    "location": "Urban Alley Brewery, 12 Star Circus, Docklands, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/275310687/",
+    "attendees": 3
+  },
+  {
+    "title": "Full Moon Run No. 250",
+    "date": "2021-03-28",
+    "startTime": "16:00",
+    "location": "Mortimer Picnic Ground, Triangle Rd, Gembrook, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/276021657/",
+    "attendees": 2
+  },
+  {
+    "title": "Bike Hash#75 - Coochie Coo in Castlemaine",
+    "date": "2021-03-27",
+    "startTime": "09:00",
+    "location": "Castlemaine, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/274448617/",
+    "attendees": 12
+  },
+  {
+    "title": "Delinquents HHH No.38",
+    "date": "2021-03-19",
+    "startTime": "18:30",
+    "location": "Platform 28, 82 Village St, Docklands, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/275310781/",
+    "attendees": 3
+  },
+  {
+    "title": "Run No. 108 - Geelong Cruise Run",
+    "date": "2021-03-13",
+    "startTime": "10:45",
+    "location": "Port Phillip Ferries Docklands Terminal, 131 Harbour Esplanade, Docklands, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/276555064/",
+    "attendees": 4
+  },
+  {
+    "title": "Full Moon Run No. 249",
+    "date": "2021-02-28",
+    "startTime": "16:00",
+    "location": "Stanley Park, Mount Macedon, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/276021646/",
+    "attendees": 1
+  },
+  {
+    "title": "Bike hash #74 - Brendover is the hare.",
+    "date": "2021-02-28",
+    "startTime": "12:00",
+    "location": "Bodriggy Brewing Company, 245 Johnston St, Abbotsford, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/274448573/",
+    "attendees": 15
+  },
+  {
+    "title": "Run No. 114 - rescheduled from last week",
+    "date": "2021-02-20",
+    "startTime": "15:00",
+    "location": "Beaton Reserve, Yarraville, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/276416630/",
+    "attendees": 4
+  },
+  {
+    "title": "Delinquents HHH No.37",
+    "date": "2021-02-19",
+    "startTime": "18:30",
+    "location": "Terminus Hotel Abbotsford, 605 Victoria St, Abbotsford, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/275310400/",
+    "attendees": 5
+  },
+  {
+    "title": "Run No. 114",
+    "date": "2021-02-13",
+    "startTime": "15:00",
+    "location": "Beaton Reserve, Yarraville, VI, AU",
+    "url": "https://www.meetup.com/melbourne-new-moon-running-group/events/268211835/",
+    "attendees": 8
+  }
+]

--- a/scripts/data/mia-h3-meetup-history-batch-1.json
+++ b/scripts/data/mia-h3-meetup-history-batch-1.json
@@ -1,0 +1,210 @@
+[
+  {
+    "title": "MIAMI H3 #1042 CALLE OCHO Decompression HASH",
+    "date": "2026-03-19",
+    "startTime": "18:30",
+    "location": "The Dead Flamingo, 1728 SW 8 street, miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/313839496/",
+    "attendees": 2
+  },
+  {
+    "title": "WILDCARD H3 NEW YEARS EVE HASH AND PUB CRAWL",
+    "date": "2024-12-31",
+    "startTime": "20:00",
+    "location": "Tarpon river Brewing, 280 SW 6th Street,, Fort Lauderdale, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/305298515/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash #969 MisMan Meeting & Drinking Practice",
+    "date": "2024-10-24",
+    "startTime": "19:00",
+    "location": "Magic 13 Brewing Co, 340 NE 61 Street,, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/302839897/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash DRINKING PRACTICE 957",
+    "date": "2024-08-01",
+    "startTime": "19:30",
+    "location": "Gramps in Wynwood, 176 NW 24th St, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/301749157/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash Trail 951 DRINKING PRACTICE",
+    "date": "2024-06-20",
+    "startTime": "19:30",
+    "location": "Jacalito Taqueria Mexicana, 3622 West Flagler Street, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/301307810/",
+    "attendees": 1
+  },
+  {
+    "title": "South Florida TRIRAIL TRIFUCTA (a Miami Hash House Harriers sponsored event)",
+    "date": "2024-04-20",
+    "startTime": "07:50",
+    "location": "Miami Airport Tri-Rail Station, 3797 Northwest 21st Street, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/300417224/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash Trail 942 FINAL STOP OF THE TRIRAIL TRIFUCTA!!!",
+    "date": "2024-04-20",
+    "startTime": "15:30",
+    "location": "American Car Parks, 49 NW 2nd St,, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/299773495/",
+    "attendees": 1
+  },
+  {
+    "title": "KING MANGO STRUT 2024",
+    "date": "2024-01-07",
+    "startTime": "11:00",
+    "location": "End of Royal Road in Coconut Grove, End of Royal Road,, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/298266425/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash Trail 925 Annual Christmas Lights Hash",
+    "date": "2023-12-21",
+    "startTime": "18:30",
+    "location": "Evio's Pizza and Grill, 12600 Biscayne Blvd, North Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/297649336/",
+    "attendees": 1
+  },
+  {
+    "title": "Q-TIP'S MICKEY MOUSE DAY AND COOKOUT",
+    "date": "2023-11-18",
+    "startTime": "12:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/297415794/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #919b HOMECOMING WEEKEND Tailgate and Cookout",
+    "date": "2023-11-11",
+    "startTime": "14:00",
+    "location": "Crandon Park, 6747 Crandon Boulevard, Key Biscayne, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/297226495/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash Trail #885 DANCE RASH GUEST HARE",
+    "date": "2023-03-16",
+    "startTime": "18:30",
+    "location": "The Wharf Miami, 114 SW North River Dr, Miami, FL 33130, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/292164717/",
+    "attendees": 1
+  },
+  {
+    "title": "KING MANGO STRUT hash and parade",
+    "date": "2023-01-08",
+    "startTime": "11:00",
+    "location": "Royal Road and Old Main Hwy, Miami, FL 33133, The west end of Royal Road on the east side of Old Main Hwy, miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/290637840/",
+    "attendees": 1
+  },
+  {
+    "title": "2022 MIAMI BEER MILE",
+    "date": "2022-08-06",
+    "startTime": "08:00",
+    "location": "Crandon Park, 6747 Crandon Blvd, Key Biscayne, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/287583376/",
+    "attendees": 1
+  },
+  {
+    "title": "SOUTH FLORIDA TRI-RAIL TRIFUCTA",
+    "date": "2022-04-23",
+    "startTime": "09:30",
+    "location": "Boynton Beach TriRail station, 2800 High Ridge Rd, Boynton Beach, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/285425806/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami H3 Calle Ocho Festival Hash (VEINTE Y SEIS)",
+    "date": "2022-03-13",
+    "startTime": "14:00",
+    "location": "1401 SW 17th Terrace, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/284449596/",
+    "attendees": 1
+  },
+  {
+    "title": "2022 MIAMI H3 / SOFLO RED DRESS RUN",
+    "date": "2022-02-12",
+    "startTime": "19:00",
+    "location": "Miami Beach Parking Garage, 640 17th St, Miami Beach, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/283643158/",
+    "attendees": 1
+  },
+  {
+    "title": "Wankers Away Weekend in Miami",
+    "date": "2021-11-06",
+    "startTime": "18:00",
+    "location": "Burger King, 5721 NW 7th Street, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/281837206/",
+    "attendees": 1
+  },
+  {
+    "title": "SUNDAY FUNDAY #2",
+    "date": "2021-08-01",
+    "startTime": "15:00",
+    "location": "Roberto Clemente Park, 101 NW 34th St, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/279762507/",
+    "attendees": 1
+  },
+  {
+    "title": "SOUTH FLORIDA TRI-RAIL TRIFUC*TA 2021",
+    "date": "2021-04-03",
+    "startTime": "10:00",
+    "location": "203 S Tamarind Ave, West Palm Beach, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/277242672/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash E-TRAIL #2 (in lieu of Trail #730)",
+    "date": "2020-03-26",
+    "startTime": "19:00",
+    "location": null,
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/269010019/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash GREEN DRESS RUN",
+    "date": "2020-03-21",
+    "startTime": "18:30",
+    "location": "3500 Pan American Dr Parking, 3500 Pan American Dr, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/269315984/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash Trail #703",
+    "date": "2019-09-19",
+    "startTime": "18:30",
+    "location": "Phillips Park, 90 Menores Ave, Coral Gables, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/264937009/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash Trail #702",
+    "date": "2019-09-12",
+    "startTime": "18:30",
+    "location": "Burger King, 2801 SW 27th Ave, Miami, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/264773551/",
+    "attendees": 1
+  },
+  {
+    "title": "Miami Hash Trail #692",
+    "date": "2019-07-04",
+    "startTime": "18:30",
+    "location": "The Money Pit, 1401 SW 17th Terrace, Miami, IN, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/262851997/",
+    "attendees": 3
+  },
+  {
+    "title": "Miami Hash Trail #685",
+    "date": "2019-05-16",
+    "startTime": "18:30",
+    "location": "La Esquina Caribena, 13290 NW 43rd Ave, Opa-locka, FL, US",
+    "url": "https://www.meetup.com/miami-hash-house-harriers/events/261474926/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/narwhal-h3-meetup-history-batch-1.json
+++ b/scripts/data/narwhal-h3-meetup-history-batch-1.json
@@ -1,0 +1,258 @@
+[
+  {
+    "title": "Moving to a new website site - Last day in Meetup is March 10th",
+    "date": "2026-03-09",
+    "startTime": "07:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/313638944/",
+    "attendees": 1
+  },
+  {
+    "title": "Narwhalversary #7",
+    "date": "2025-09-21",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/311028231/",
+    "attendees": 1
+  },
+  {
+    "title": "Nawhal Trail #61: Just the Tip!",
+    "date": "2025-08-17",
+    "startTime": "13:00",
+    "location": "Pequot woods, 289 Sandy Hollow Rd,, Mystic, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/310496084/",
+    "attendees": 3
+  },
+  {
+    "title": "Narwhal Conception Day Drinking Practice!",
+    "date": "2023-04-28",
+    "startTime": "17:00",
+    "location": "Outer Light Brewing Company, 266 Bridge St, Groton, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/293126659/",
+    "attendees": 2
+  },
+  {
+    "title": "Narwhal Trail 51#: Did We Miss St. Patrick's Day?",
+    "date": "2023-03-19",
+    "startTime": "13:00",
+    "location": "Ring's End, 28 Hope St, Niantic, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/292117799/",
+    "attendees": 1
+  },
+  {
+    "title": "5/5 Cupid is a Pr*ck: Narwhal/Boner Trail",
+    "date": "2023-02-19",
+    "startTime": "12:30",
+    "location": "13 Deborah Ln, Farmington, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/291291763/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #49 - THE MOST EPIC JANUARY 2023 TRAIL EVER!!!!",
+    "date": "2023-01-15",
+    "startTime": "12:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/290700654/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #48 Trail Treasure X-change!",
+    "date": "2022-12-18",
+    "startTime": "12:00",
+    "location": "90 Poheganut Dr, Groton, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/289893227/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #47 - Partial Montano liver fuck off",
+    "date": "2022-11-20",
+    "startTime": "12:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/289856844/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #46: Devilish Narwhals",
+    "date": "2022-10-30",
+    "startTime": "13:00",
+    "location": "Devil's Hopyard State Park, 366 Hopyard Rd, East Haddam, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/289298058/",
+    "attendees": 1
+  },
+  {
+    "title": "Narwhal Trail! REGRETS!",
+    "date": "2022-09-18",
+    "startTime": "13:00",
+    "location": "120r Bloomingdale Rd, Quaker Hill, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/288312399/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #44: F*ck The Bluffs, Eat The Rich!",
+    "date": "2022-07-31",
+    "startTime": "13:00",
+    "location": "Esker Point Beach, 900 Groton Long Point Rd, Groton, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/287016061/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail# 42 - Dad bod trail",
+    "date": "2022-06-19",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/286123893/",
+    "attendees": 1
+  },
+  {
+    "title": "May Trail!",
+    "date": "2022-05-01",
+    "startTime": "13:00",
+    "location": "The Divine Wine Emporium, 275 W Main St, Niantic, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/285461980/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #40 Risky Business",
+    "date": "2022-04-03",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/284912466/",
+    "attendees": 1
+  },
+  {
+    "title": "New Year... New Shit Shows ???",
+    "date": "2022-03-06",
+    "startTime": "13:00",
+    "location": "Mohegan Park Road, Mohegan Park Rd, Norwich, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/283404222/",
+    "attendees": 3
+  },
+  {
+    "title": "Anti-Valentines #3 of 5",
+    "date": "2022-02-13",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/283776775/",
+    "attendees": 3
+  },
+  {
+    "title": "Spooktober Surprise!(AKA F*ck I’m Awkward, Here’s Trail)",
+    "date": "2021-10-30",
+    "startTime": "17:15",
+    "location": "Behind Davids Cafe, 134 RT 12, Preston, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/281344977/",
+    "attendees": 3
+  },
+  {
+    "title": "Narwhalvesary #3 Trail",
+    "date": "2021-09-19",
+    "startTime": "12:00",
+    "location": null,
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/280058706/",
+    "attendees": 1
+  },
+  {
+    "title": "Narwhal #31 Bring out your green dead liver Trail",
+    "date": "2021-03-28",
+    "startTime": "13:00",
+    "location": "Bates Woods Park, 80 Chester St, New London, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/277202118/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #20",
+    "date": "2020-04-05",
+    "startTime": "13:00",
+    "location": "Waterford, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/269335879/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #19: Let The Sun Shine Trail",
+    "date": "2020-03-08",
+    "startTime": "13:00",
+    "location": "New London, 27 Water St, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/268952150/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #17 - The Roaring 20s Strike Again",
+    "date": "2020-01-12",
+    "startTime": "13:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/267397615/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #16: The Pod Gives Back",
+    "date": "2019-12-16",
+    "startTime": "12:00",
+    "location": "Capstan Avenue, Capstan Ave, Groton, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/267205313/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #15: Gimpceañera Trail",
+    "date": "2019-11-03",
+    "startTime": "13:00",
+    "location": "Peace Sanctuary, River Rd, Mystic, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/265886273/",
+    "attendees": 6
+  },
+  {
+    "title": "Spooktober Spectacular",
+    "date": "2019-10-06",
+    "startTime": "12:00",
+    "location": "Park & Ride, CT-12, Preston, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/265353622/",
+    "attendees": 4
+  },
+  {
+    "title": "WANKERS AWAY! 1st Narwhalversary!!!",
+    "date": "2019-09-15",
+    "startTime": "13:00",
+    "location": "Connecticut College Fitness Center, New London, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/263179364/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #12: Baby Bye Bye Bye",
+    "date": "2019-08-18",
+    "startTime": "13:00",
+    "location": "Niantic Lumber Co., 28 Hope Street, Niantic, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/263093390/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #11: Taco's Trail in Ham-my-Asset",
+    "date": "2019-07-07",
+    "startTime": "12:00",
+    "location": "Hammonasset Beach State Park, 1288 Boston Post Rd, Madison, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/262814829/",
+    "attendees": 1
+  },
+  {
+    "title": "Trail #10 Mystery Meat trail",
+    "date": "2019-06-23",
+    "startTime": "13:00",
+    "location": "155 Ingham Hill Rd, Old Saybrook, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/262178904/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #8 Narwhals & Waterfalls",
+    "date": "2019-04-07",
+    "startTime": "13:00",
+    "location": "277 CT-207, North Franklin, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/260412333/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #7: Narwhal Green Dress!",
+    "date": "2019-03-17",
+    "startTime": "13:00",
+    "location": "Rocky Neck State Park, 228 W Main St, Niantic, CT, US",
+    "url": "https://www.meetup.com/meetup-group-cwrnpwpc/events/259693863/",
+    "attendees": 3
+  }
+]

--- a/scripts/data/rch3-meetup-history-batch-1.json
+++ b/scripts/data/rch3-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Good Friday Pub Crawl",
+    "date": "2026-04-03",
+    "startTime": "13:00",
+    "location": "Kevin O'Bryan's, 1761 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/312501308/",
+    "attendees": 8
+  },
+  {
+    "title": "9 Annual SKASH Holiday Valley Ski Resort NY",
+    "date": "2026-02-07",
+    "startTime": "13:00",
+    "location": "Holiday Valley Ski Resort, 6557 Holiday Valley Road, Ellicottville, NY, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/312501146/",
+    "attendees": 7
+  },
+  {
+    "title": "2nd Saturday of Month - Akron Brewery Trail",
+    "date": "2025-11-08",
+    "startTime": "15:00",
+    "location": "Johnny J's Pub & Grille, Springfield, 2891 E Waterloo Rd, akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/304523232/",
+    "attendees": 15
+  },
+  {
+    "title": "Haunted Houses and Drinking Practice",
+    "date": "2025-10-24",
+    "startTime": "18:30",
+    "location": "Hide-A-Way, 4021 Mahoning Rd NE, Canton, OH 44705, Canton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/310908564/",
+    "attendees": 2
+  },
+  {
+    "title": "5th Saturday of the Month",
+    "date": "2025-08-30",
+    "startTime": "15:00",
+    "location": "Becky's, 1762 E 18th St, Cleveland, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/304524046/",
+    "attendees": 6
+  },
+  {
+    "title": "RCH3 Eerie Invasion!",
+    "date": "2025-05-17",
+    "startTime": "14:00",
+    "location": "Lombardo’s Tavern, 915 W 21st St, Erie, PA, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/307549751/",
+    "attendees": 7
+  },
+  {
+    "title": "Good Friday Pub Crawl",
+    "date": "2025-04-18",
+    "startTime": "13:00",
+    "location": "Kevin O'Bryan's, 1761 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/304524564/",
+    "attendees": 10
+  },
+  {
+    "title": "2nd Saturday of Month",
+    "date": "2025-04-12",
+    "startTime": "15:00",
+    "location": "La Mexicana Cantina & Grill Tallmadge, 76 West Ave, Tallmadge, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/304523085/",
+    "attendees": 8
+  },
+  {
+    "title": "Ohio InterHash Weekend 8.16-8.18",
+    "date": "2024-08-16",
+    "startTime": "19:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/300590323/",
+    "attendees": 17
+  },
+  {
+    "title": "Blossom Independence Day Celebration",
+    "date": "2024-07-03",
+    "startTime": "17:30",
+    "location": "Blossom Music Center, 1145 W Steels Corners Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/298153832/",
+    "attendees": 7
+  },
+  {
+    "title": "3 minutes of darkness / Total Solar Eclipse",
+    "date": "2024-04-08",
+    "startTime": "12:30",
+    "location": "Tuscarawas Shelter - Firestone Metro Park, 2620 Harrington Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/296256083/",
+    "attendees": 22
+  },
+  {
+    "title": "Good Friday Pub Crawl",
+    "date": "2024-03-29",
+    "startTime": "13:00",
+    "location": "Kevin O'Bryan's, 1761 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/298155232/",
+    "attendees": 7
+  },
+  {
+    "title": "12 Pubs of Christmas",
+    "date": "2023-12-23",
+    "startTime": "15:00",
+    "location": "EuroGyro, 444 E Exchange St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/290217470/",
+    "attendees": 6
+  },
+  {
+    "title": "Halloween Family Trail",
+    "date": "2023-10-28",
+    "startTime": "13:00",
+    "location": "Tuscarawas Shelter - Firestone Metro Park, 2620 Harrington Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/295864220/",
+    "attendees": 18
+  },
+  {
+    "title": "5th Saturday of July Trail with Cleveland H4",
+    "date": "2023-07-29",
+    "startTime": "15:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/294682189/",
+    "attendees": 11
+  },
+  {
+    "title": "Independence Day",
+    "date": "2023-07-04",
+    "startTime": "18:00",
+    "location": "Blossom Music Center, 1145 W Steels Corners Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/290217675/",
+    "attendees": 18
+  },
+  {
+    "title": "Good Friday Pub Crawl",
+    "date": "2023-04-07",
+    "startTime": "13:00",
+    "location": "Kevin O'Bryan's, 1761 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/290217599/",
+    "attendees": 8
+  },
+  {
+    "title": "** Holiday Party **",
+    "date": "2022-12-10",
+    "startTime": "15:00",
+    "location": "Tip'em Up Tavern, 1854 Newton St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/285022402/",
+    "attendees": 15
+  },
+  {
+    "title": "Fall Thursdays (Hashtobeer) Trail #618",
+    "date": "2022-10-27",
+    "startTime": "18:30",
+    "location": "Kevin O'Bryan's, 1761 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/285036092/",
+    "attendees": 8
+  },
+  {
+    "title": "Fall Thursdays (Hashtobeer) Trail #615",
+    "date": "2022-10-13",
+    "startTime": "18:30",
+    "location": "Akronym Brewing, 58 E Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/285036084/",
+    "attendees": 8
+  },
+  {
+    "title": "Summer Solstice Celebration",
+    "date": "2022-06-21",
+    "startTime": "19:00",
+    "location": "Baxter's, 205 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/285022551/",
+    "attendees": 11
+  },
+  {
+    "title": "Deadline to REGO for HASHCUMMING 2022 is in one week",
+    "date": "2022-02-12",
+    "startTime": "19:00",
+    "location": "1581 Main St, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/283681164/",
+    "attendees": 2
+  },
+  {
+    "title": "Boxing Day * 12 Beers of Christmas - Trail # 570",
+    "date": "2021-12-26",
+    "startTime": "12:00",
+    "location": "Missing Mountain Brewing Co., 2811 Front St, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/280579355/",
+    "attendees": 9
+  },
+  {
+    "title": "Winter Solstice Celebration",
+    "date": "2021-12-20",
+    "startTime": "18:30",
+    "location": "Ignite Brewing Company, 600 W Tuscarawas Ave, Barberton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/282703544/",
+    "attendees": 5
+  },
+  {
+    "title": "** Holiday Party ** Trail #568",
+    "date": "2021-12-11",
+    "startTime": "15:00",
+    "location": "Tip'em Up Tavern, 1854 Newton St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/280579162/",
+    "attendees": 10
+  },
+  {
+    "title": "Trail# 560 Fall Thursdays (Hashtobeer)",
+    "date": "2021-10-28",
+    "startTime": "18:30",
+    "location": "390 N Arlington St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/280579261/",
+    "attendees": 9
+  },
+  {
+    "title": "Trail# 558 Fall Thursdays (Hashtobeer)",
+    "date": "2021-10-21",
+    "startTime": "18:30",
+    "location": "The Getaway Pub, 1462 N Portage Path, Akron, oh, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/280579238/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail# 557 Fall Thursdays (Hashtobeer)",
+    "date": "2021-10-14",
+    "startTime": "18:30",
+    "location": "Akronym Brewing, 58 E Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/280579210/",
+    "attendees": 10
+  },
+  {
+    "title": "First Thursday ZOOM due to COVID-19",
+    "date": "2021-01-07",
+    "startTime": "18:30",
+    "location": null,
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/275591181/",
+    "attendees": 4
+  },
+  {
+    "title": "RCH3 Black Friday ZOOM Pub Crawl",
+    "date": "2020-11-27",
+    "startTime": "13:00",
+    "location": null,
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/274734286/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail# 519 Fall Thursdays (Hashtobeer)",
+    "date": "2020-10-29",
+    "startTime": "18:30",
+    "location": "The Getaway Pub, 1462 N Portage Path, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/273272020/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail# 517 Fall Thursdays (Hashtobeer)",
+    "date": "2020-10-22",
+    "startTime": "18:30",
+    "location": "Akronym Brewing, 58 E Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/273271997/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail # 514 Fall Thursdays (Hashtober)",
+    "date": "2020-10-08",
+    "startTime": "18:30",
+    "location": "Hop Tree Brewing, 1297 Hudson Gate Dr, Hudson, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/273271729/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail #512 PIRATE HASH",
+    "date": "2020-09-26",
+    "startTime": "14:30",
+    "location": "Towpath Cabinn, 4462 Erie Ave NW, Massillon, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/270884334/",
+    "attendees": 24
+  },
+  {
+    "title": "Trail #499.69 Luxury Trail",
+    "date": "2020-07-02",
+    "startTime": "18:00",
+    "location": "Casa De Mr. Sniff, 77 E Catawba Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/271526853/",
+    "attendees": 7
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2020-01-25",
+    "startTime": "14:00",
+    "location": "Thirsty Dog Tap Room, 587 Grant St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/268153184/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail# 485 - Laser Tag",
+    "date": "2020-01-16",
+    "startTime": "18:00",
+    "location": "Winking Lizard Copley, 79 Springside Dr, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/267517629/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail# 484 - AGM",
+    "date": "2020-01-11",
+    "startTime": "19:00",
+    "location": "Stonehedge Entertainment, 580 E Cuyahoga Falls Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/267517593/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 483 - First 2020 Trail",
+    "date": "2020-01-02",
+    "startTime": "18:00",
+    "location": "Ray's Pub, 801 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/267516261/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #482 - Holiday Party",
+    "date": "2019-12-28",
+    "startTime": "14:00",
+    "location": "Tip'em Up Tavern, 1854 Newton St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244272/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail# 481 - Year end luxury trail",
+    "date": "2019-12-19",
+    "startTime": "18:00",
+    "location": "1267 Murray Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261493073/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail #480",
+    "date": "2019-12-14",
+    "startTime": "14:00",
+    "location": "Tugboats Pub At Meadowlake Golf, 1211 39th St NE, Canton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244260/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 479",
+    "date": "2019-12-05",
+    "startTime": "18:00",
+    "location": "Missing Falls Brewery, 540 S Main St suite 112, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261493067/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail# 478 - Joint Cleveland Trail",
+    "date": "2019-11-30",
+    "startTime": "14:00",
+    "location": "#Woody's Bar, 376 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244242/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail# 477 - Second Saturday",
+    "date": "2019-11-23",
+    "startTime": "14:00",
+    "location": "Cliffside Key Club, 2118 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244229/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 476",
+    "date": "2019-11-21",
+    "startTime": "18:00",
+    "location": "Hoppin' Frog Brewery, 1680 E Waterloo Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261493060/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail #475 - First Saturday",
+    "date": "2019-11-09",
+    "startTime": "14:00",
+    "location": "King Sportsman, 1402 W Waterloo Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244214/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail# 474",
+    "date": "2019-11-07",
+    "startTime": "18:00",
+    "location": "Larry's Main Entrance, 1964 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261493052/",
+    "attendees": 4
+  },
+  {
+    "title": "Anal Pink Dress/Boobie Hash",
+    "date": "2019-10-25",
+    "startTime": "19:00",
+    "location": "Quality Inn Akron - Fairlawn, 70 Rothrock Loop, Montrose, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261245281/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 472",
+    "date": "2019-10-17",
+    "startTime": "18:00",
+    "location": "Ray's Pub, 801 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261493038/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/rch3-meetup-history-batch-2.json
+++ b/scripts/data/rch3-meetup-history-batch-2.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Trail# 471 - All Shiggy",
+    "date": "2019-10-12",
+    "startTime": "14:00",
+    "location": "Winking Lizard Peninsula, 1615 Main St, Peninsula, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244194/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 470",
+    "date": "2019-10-03",
+    "startTime": "18:00",
+    "location": "Bailey Road Tavern, 2920 Bailey Rd #2240, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261493030/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #469 - Pirate Hash",
+    "date": "2019-09-28",
+    "startTime": "13:00",
+    "location": "Anarchy Acres, 2381 Center Rd, New Franklin, oh, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244184/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail# 468",
+    "date": "2019-09-19",
+    "startTime": "18:00",
+    "location": "Thirsty Dog Brewing Co. Tap House, 587 Grant St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261493017/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail #467 - A VIRGIN LAY",
+    "date": "2019-09-14",
+    "startTime": "14:00",
+    "location": "Buckeye Tavern, 1931 Bailey Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244168/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail# 466",
+    "date": "2019-09-05",
+    "startTime": "18:00",
+    "location": "The Getaway Pub, 1462 N Portage Path, Akron, oh, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261439896/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 465 - Air Show Hash",
+    "date": "2019-08-31",
+    "startTime": "14:00",
+    "location": "Lopresti Union Club Bar & Restaurant, 2549 St Clair Ave NE, Cleveland, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244139/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 464 - PRIDE!",
+    "date": "2019-08-24",
+    "startTime": "14:00",
+    "location": "Arnie’s Public House, 1682 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244128/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 463 - Full Moon",
+    "date": "2019-08-15",
+    "startTime": "18:00",
+    "location": "R. Shea Brewing - Merriman Valley, 1662 Merriman Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261439871/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail #462 - First Saturday",
+    "date": "2019-08-10",
+    "startTime": "14:00",
+    "location": "Fire & Ice, 1941 Triplett Blvd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244115/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 461",
+    "date": "2019-08-01",
+    "startTime": "18:00",
+    "location": "Kevin O'Bryan's, 1761 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261439860/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail# 460 - Picnic Bash",
+    "date": "2019-07-27",
+    "startTime": "14:00",
+    "location": "Market District Supermarket, 2687 State Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244100/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail# 459",
+    "date": "2019-07-18",
+    "startTime": "18:00",
+    "location": "Akronym Brewing, 58 E Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261439831/",
+    "attendees": 3
+  },
+  {
+    "title": "Trail# 458 - Wedding Celebration",
+    "date": "2019-07-13",
+    "startTime": "18:00",
+    "location": "Anarchy Acres, 2381 Center Rd, New Franklin, oh, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261244067/",
+    "attendees": 2
+  },
+  {
+    "title": "Trail# 457 - Independence Day!",
+    "date": "2019-07-04",
+    "startTime": "18:00",
+    "location": "Barley House, 222 S Main St #1B, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/261439782/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail# 456 Joint Cleveland Trail",
+    "date": "2019-06-29",
+    "startTime": "14:00",
+    "location": "Amici Italian Restaurant & Bar, 13000 Royalton Rd, North Royalton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/262477457/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail# 455",
+    "date": "2019-06-22",
+    "startTime": "14:00",
+    "location": "Noisy Oyster Pub, 1375 N Portage Path, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239348/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 454",
+    "date": "2019-06-20",
+    "startTime": "18:00",
+    "location": "Missing Falls Brewery, 540 S Main St suite 112, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258238908/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail# 453 - Annal! - Quinceañera",
+    "date": "2019-06-08",
+    "startTime": "14:00",
+    "location": "Rays In Highland Square, 801 West Market Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239342/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 452 - Rubber Ducks Game",
+    "date": "2019-06-06",
+    "startTime": "17:30",
+    "location": "The Game Grill + Bar, 300 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258238895/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 451 - Second Saturday",
+    "date": "2019-05-25",
+    "startTime": "14:00",
+    "location": "Frank's Place On Market, 549 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239323/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 450",
+    "date": "2019-05-16",
+    "startTime": "18:00",
+    "location": "Rockne's Restaurants, 2914 W Market St, Fairlawn, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258238863/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail# 449 - KSU Memorial Hash",
+    "date": "2019-05-11",
+    "startTime": "14:00",
+    "location": "La Terraza Mexican Bar & Grill, 1888 OH-59, Kent, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239316/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 448",
+    "date": "2019-05-02",
+    "startTime": "18:00",
+    "location": "Dante's Gameday Grille, 1019 N Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258238831/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail# 447 - Reerection",
+    "date": "2019-04-27",
+    "startTime": "14:00",
+    "location": "Fire & Ice, 1941 Triplett Blvd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239306/",
+    "attendees": 7
+  },
+  {
+    "title": "Good Friday Pub Crawl",
+    "date": "2019-04-19",
+    "startTime": "13:00",
+    "location": "Kevin O'Bryan's, 1761 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239293/",
+    "attendees": 4
+  },
+  {
+    "title": "Trail# 446",
+    "date": "2019-04-18",
+    "startTime": "18:00",
+    "location": "Kevin O'Bryan's, 1761 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258238807/",
+    "attendees": 5
+  },
+  {
+    "title": "Trail# 445",
+    "date": "2019-04-13",
+    "startTime": "14:00",
+    "location": "Jimmy Bigg's Grill, 1927 State Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239273/",
+    "attendees": 8
+  },
+  {
+    "title": "Trail# 444",
+    "date": "2019-04-04",
+    "startTime": "18:00",
+    "location": "Larry's Main Entrance, 1964 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258238800/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 443 - Joint Cleveland Hash - READ DETAILS",
+    "date": "2019-03-30",
+    "startTime": "14:00",
+    "location": "Winking Lizard Peninsula, 1615 Main St, Peninsula, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239248/",
+    "attendees": 11
+  },
+  {
+    "title": "Trail# 442 - Green Dress",
+    "date": "2019-03-23",
+    "startTime": "14:00",
+    "location": "Tear-Ez, 360 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258238980/",
+    "attendees": 8
+  },
+  {
+    "title": "Hash# 441 - Second Thursday Hash",
+    "date": "2019-03-21",
+    "startTime": "18:00",
+    "location": "Jimmy Bigg's Grill, 1927 State Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258193470/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 440 - Toga Hash",
+    "date": "2019-03-09",
+    "startTime": "14:00",
+    "location": "EuroGyro, 107 S Depeyster St, Kent, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258239018/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail# 439 - Glow Stick Run",
+    "date": "2019-03-07",
+    "startTime": "18:00",
+    "location": "Schrop Intermediate School, 2215 Pickle Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258193440/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 438 - 2nd Saturday",
+    "date": "2019-02-23",
+    "startTime": "14:00",
+    "location": "#Woody's Bar, 376 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258193457/",
+    "attendees": 9
+  },
+  {
+    "title": "Trail# 437",
+    "date": "2019-02-21",
+    "startTime": "18:00",
+    "location": "69 Taps, 370 Paul Williams St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258193393/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail# 436 - Skash",
+    "date": "2019-02-09",
+    "startTime": "08:00",
+    "location": "Ellicottville, NY, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258193419/",
+    "attendees": 6
+  },
+  {
+    "title": "Hash# 435 - Leisure Birthday Trail",
+    "date": "2019-02-07",
+    "startTime": "18:00",
+    "location": "Tonix Bar LLC, 3090 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258238661/",
+    "attendees": 6
+  },
+  {
+    "title": "Trail #434 - Sledding!",
+    "date": "2019-01-26",
+    "startTime": "14:30",
+    "location": "1061 Cuyahoga St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258190658/",
+    "attendees": 7
+  },
+  {
+    "title": "Trail #433 - Laser Tag",
+    "date": "2019-01-17",
+    "startTime": "18:00",
+    "location": "Winking Lizard Copley, 79 Springside Dr, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/258080652/",
+    "attendees": 6
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2018-12-22",
+    "startTime": "14:00",
+    "location": "EuroGyro, 444 E Exchange St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/250595203/",
+    "attendees": 1
+  },
+  {
+    "title": "Joint Hash with Cleveland",
+    "date": "2018-06-30",
+    "startTime": "15:00",
+    "location": "Brandywine Falls Parking Lot, 6863 Stanford Rd, Northfield, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/252188721/",
+    "attendees": 3
+  },
+  {
+    "title": "First Thursday Hash",
+    "date": "2018-05-03",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/250135054/",
+    "attendees": 1
+  },
+  {
+    "title": "CINCO DE DRINKO! First Thursday Hash",
+    "date": "2018-05-03",
+    "startTime": "18:00",
+    "location": "Tres Potrillos, 115 Montrose W Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/249383706/",
+    "attendees": 10
+  },
+  {
+    "title": "CALLING ALL VIRGINS! 4th Saturday Trail",
+    "date": "2018-04-28",
+    "startTime": "15:00",
+    "location": "69 taps, 370 Paul Williams St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/249383698/",
+    "attendees": 8
+  },
+  {
+    "title": "Third Thursday Hash",
+    "date": "2018-04-19",
+    "startTime": "18:00",
+    "location": "Tonix, 3090 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/248307972/",
+    "attendees": 3
+  },
+  {
+    "title": "Third Thursday Hash",
+    "date": "2018-04-19",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/248307706/",
+    "attendees": 1
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2018-04-14",
+    "startTime": "15:00",
+    "location": "Casa de STD, 1267 Murray Ave, Akron, oh, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/249383683/",
+    "attendees": 4
+  },
+  {
+    "title": "First Thursday Hash",
+    "date": "2018-04-12",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/248307491/",
+    "attendees": 1
+  },
+  {
+    "title": "First Thursday Hash",
+    "date": "2018-04-05",
+    "startTime": "18:00",
+    "location": "Annabell's Bar and Lounge, 784 West Market Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/248307777/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/rch3-meetup-history-batch-3.json
+++ b/scripts/data/rch3-meetup-history-batch-3.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "Third Thursday Hash",
+    "date": "2018-03-29",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/248307417/",
+    "attendees": 1
+  },
+  {
+    "title": "4th Saturday Hash--ANNUAL GREEN DRESS RUN",
+    "date": "2018-03-24",
+    "startTime": "15:00",
+    "location": "Tear Ez, 360 S. Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/248578309/",
+    "attendees": 6
+  },
+  {
+    "title": "Third Thursday Hash",
+    "date": "2018-03-15",
+    "startTime": "18:00",
+    "location": "Tip'em Up Tavern, 1854 Newton St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/248307397/",
+    "attendees": 2
+  },
+  {
+    "title": "2nd Saturday Hash--ANNUAL TOGA HASH",
+    "date": "2018-03-10",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/248308546/",
+    "attendees": 9
+  },
+  {
+    "title": "First Thursday Hash",
+    "date": "2018-03-01",
+    "startTime": "18:00",
+    "location": "Schrop Elementary School, 2215 Pickle Road, Akron, oh, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/247748904/",
+    "attendees": 3
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2018-02-24",
+    "startTime": "14:00",
+    "location": "Red Fox Bar & Grill, 1767 State Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/247748992/",
+    "attendees": 2
+  },
+  {
+    "title": "Third Thursday Hash",
+    "date": "2018-02-15",
+    "startTime": "18:00",
+    "location": "Ray's Place, 25 Ghent Rd, Fairlawn, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/247748600/",
+    "attendees": 6
+  },
+  {
+    "title": "Third Thursday Hash",
+    "date": "2018-01-18",
+    "startTime": "18:00",
+    "location": "Nickelby's Lounge, 1947 W Market St, Akron, oh, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/246887988/",
+    "attendees": 2
+  },
+  {
+    "title": "5th Saturday-Joint Hash with Cleveland Hashers",
+    "date": "2017-12-30",
+    "startTime": "14:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236755140/",
+    "attendees": 1
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2017-12-23",
+    "startTime": "14:00",
+    "location": "Chestnut Beer Garden, 503 Chestnut blvd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236755078/",
+    "attendees": 3
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-12-21",
+    "startTime": "18:00",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236755070/",
+    "attendees": 3
+  },
+  {
+    "title": "2nd Saturday Hash-Annual Holiday Hash",
+    "date": "2017-12-09",
+    "startTime": "14:00",
+    "location": "Tip'em Up Tavern, 1854 Newton St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236755024/",
+    "attendees": 5
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-12-07",
+    "startTime": "18:00",
+    "location": "Tonix, 3090 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236755016/",
+    "attendees": 6
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2017-11-25",
+    "startTime": "16:00",
+    "location": "Tear Ez, 360 S. Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754974/",
+    "attendees": 9
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-11-16",
+    "startTime": "18:00",
+    "location": "Thursdays, 306 E Exchange St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754968/",
+    "attendees": 8
+  },
+  {
+    "title": "2nd Saturday Hash-Veteran's Day Hash",
+    "date": "2017-11-11",
+    "startTime": "14:00",
+    "location": "VFW, 618 West Tuscarawas Ave., Barberton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754926/",
+    "attendees": 4
+  },
+  {
+    "title": "1st Thirsty Thursday-Moved to Friday for Visitors Hash",
+    "date": "2017-11-03",
+    "startTime": "18:00",
+    "location": "Lynn’s Bar, 334 E Cuyahoga Falls Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754911/",
+    "attendees": 7
+  },
+  {
+    "title": "Annual Pink Dress Booby Hash",
+    "date": "2017-10-27",
+    "startTime": "19:00",
+    "location": "Econo Lodge, 2677 Gilchrist Road, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754892/",
+    "attendees": 15
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-10-19",
+    "startTime": "18:00",
+    "location": "Frank's Place On Market, 549 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754799/",
+    "attendees": 7
+  },
+  {
+    "title": "2nd Saturday Hash-Annual All Shiggy Hash",
+    "date": "2017-10-14",
+    "startTime": "15:00",
+    "location": "Winking Lizard, 1615 Main Street, Peninsula, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754727/",
+    "attendees": 8
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-10-05",
+    "startTime": "18:00",
+    "location": "Ray's Place, 25 Ghent Rd, Fairlawn, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754711/",
+    "attendees": 6
+  },
+  {
+    "title": "5th Saturday-Joint Hash with Cleveland Hashers",
+    "date": "2017-09-30",
+    "startTime": "15:00",
+    "location": "Lock 29 Overflow Parking Lot, 1787-1799 Mill St W, Peninsula, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754674/",
+    "attendees": 2
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2017-09-23",
+    "startTime": "15:00",
+    "location": "The Brooklands Cafe, 371 The Brooklands, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754640/",
+    "attendees": 6
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-09-21",
+    "startTime": "18:00",
+    "location": "Annunciation Greek Orthodox Church, 129 South Union Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754633/",
+    "attendees": 5
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2017-09-09",
+    "startTime": "15:00",
+    "location": "Tiny 2 (Kacey's), 1199 Triplett Blvd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/237193526/",
+    "attendees": 7
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-09-07",
+    "startTime": "18:00",
+    "location": "R. Shea Brewing, 1662 Merriman Rd., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754608/",
+    "attendees": 7
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2017-08-26",
+    "startTime": "15:00",
+    "location": "Casa de Jagger Snatch, 803 Colonial Blvd NE, Canton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754571/",
+    "attendees": 8
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-08-17",
+    "startTime": "18:00",
+    "location": "Annabell's Bar and Lounge, 784 West Market Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754529/",
+    "attendees": 7
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2017-08-12",
+    "startTime": "15:00",
+    "location": "Kepner's Tavern, 88 North Main St., Hudson, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/237193488/",
+    "attendees": 10
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-08-03",
+    "startTime": "18:00",
+    "location": "Barley House, 222 South Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754461/",
+    "attendees": 6
+  },
+  {
+    "title": "5th Saturday-Joint Hash with Cleveland Hashers",
+    "date": "2017-07-29",
+    "startTime": "15:00",
+    "location": "Zodiac Bar, 1955 Triplett blvd, akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754384/",
+    "attendees": 5
+  },
+  {
+    "title": "4th Saturday Hash-Summer Picnic Bash",
+    "date": "2017-07-22",
+    "startTime": "14:00",
+    "location": "Casa de Shorthairs, 491 Wyoga Lake, Stow, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754334/",
+    "attendees": 9
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-07-20",
+    "startTime": "18:00",
+    "location": "Casa de Bitches, 604 Mardon, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754321/",
+    "attendees": 8
+  },
+  {
+    "title": "2nd Saturday Hash-Running of the Bullshitters",
+    "date": "2017-07-08",
+    "startTime": "15:00",
+    "location": "Chestnut Beer Garden, 503 Chestnut blvd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754277/",
+    "attendees": 6
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-07-06",
+    "startTime": "18:00",
+    "location": "Ozzys Nottingham Pub, 1390 Brittain Rd, akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754266/",
+    "attendees": 5
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2017-06-24",
+    "startTime": "15:00",
+    "location": "Theo's, 1600 Massillon Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754258/",
+    "attendees": 7
+  },
+  {
+    "title": "Third Thirsty Thursday Hash-Rubber Ducks Game",
+    "date": "2017-06-15",
+    "startTime": "18:00",
+    "location": "Barley House, 222 S Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754228/",
+    "attendees": 9
+  },
+  {
+    "title": "Lucky 13th Lace & Lingerie Analversary Campout",
+    "date": "2017-06-09",
+    "startTime": "16:00",
+    "location": "Anarchy Acres, 2381 Center Rd, Clinton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754183/",
+    "attendees": 10
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-06-01",
+    "startTime": "18:00",
+    "location": "Tip'em Up Tavern, 1854 Newton St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236754013/",
+    "attendees": 5
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2017-05-27",
+    "startTime": "15:00",
+    "location": "Tear Ez, 360 S. Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753991/",
+    "attendees": 4
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-05-18",
+    "startTime": "18:00",
+    "location": "Just Casey's Crib, 1267 Murray Ave, akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753970/",
+    "attendees": 6
+  },
+  {
+    "title": "2nd Saturday Hash-KSU Memorial Hash",
+    "date": "2017-05-13",
+    "startTime": "15:00",
+    "location": "The Pub, 401 Franklin Ave, Kent, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753945/",
+    "attendees": 3
+  },
+  {
+    "title": "1st Thirsty Thursday Hash-Cinco de Mayo",
+    "date": "2017-05-04",
+    "startTime": "18:00",
+    "location": "Akron Rubber Ducks, Canal Park; 300 South Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753930/",
+    "attendees": 2
+  },
+  {
+    "title": "5th Saturday-Joint Hash with Cleveland Hashers",
+    "date": "2017-04-29",
+    "startTime": "15:00",
+    "location": "Winking Lizard, 1645 main st, penninsula, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753901/",
+    "attendees": 9
+  },
+  {
+    "title": "4th Saturday Hash-Re-Erection Hash",
+    "date": "2017-04-22",
+    "startTime": "15:00",
+    "location": "Paramount Pub & Grill, 491 E Waterloo Rd., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753873/",
+    "attendees": 5
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-04-20",
+    "startTime": "18:00",
+    "location": "Anarchy Acres, 2381 Center Rd, New Franklin, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753839/",
+    "attendees": 6
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2017-04-08",
+    "startTime": "15:00",
+    "location": "B.G. Bree's, 451 N Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236755448/",
+    "attendees": 13
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-04-06",
+    "startTime": "18:00",
+    "location": "Getaway, 1462 N Portage Path, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753815/",
+    "attendees": 10
+  },
+  {
+    "title": "4th Saturday Hash-Annual Green Dress Hash",
+    "date": "2017-03-25",
+    "startTime": "15:00",
+    "location": "Tear Ez, 360 S. Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753742/",
+    "attendees": 7
+  },
+  {
+    "title": "Third Thirsty Thursday Hash-Tranny Bait's Memorial Hash",
+    "date": "2017-03-16",
+    "startTime": "18:00",
+    "location": "Ray's Place, 25 Ghent Rd, Fairlawn, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753617/",
+    "attendees": 7
+  }
+]

--- a/scripts/data/rch3-meetup-history-batch-4.json
+++ b/scripts/data/rch3-meetup-history-batch-4.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "2nd Saturday Hash-Annual Toga Hash",
+    "date": "2017-03-11",
+    "startTime": "14:00",
+    "location": "Euro Gyro, 107 S. Depeyster Street, Kent, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753600/",
+    "attendees": 6
+  },
+  {
+    "title": "Tuesday Song Practice",
+    "date": "2017-03-07",
+    "startTime": "19:00",
+    "location": "Scratch's House, 77 East Catawba Ave., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/238144071/",
+    "attendees": 6
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-03-02",
+    "startTime": "18:00",
+    "location": "69 Taps, 370 Paul Williams St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753545/",
+    "attendees": 5
+  },
+  {
+    "title": "4th Saturday Hash - Mardi Gras",
+    "date": "2017-02-25",
+    "startTime": "14:00",
+    "location": "R. Shea Brewing, 1662 Merriman Rd., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/237726836/",
+    "attendees": 5
+  },
+  {
+    "title": "Third Thirsty Thursday Laser Tag Hash",
+    "date": "2017-02-16",
+    "startTime": "18:00",
+    "location": "Winking Lizard, 79 Springside Drive, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753487/",
+    "attendees": 7
+  },
+  {
+    "title": "Tuesday Song Practice",
+    "date": "2017-02-14",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/237588178/",
+    "attendees": 1
+  },
+  {
+    "title": "2nd Saturday Hash-Ski Hash, Holiday Valley",
+    "date": "2017-02-11",
+    "startTime": "23:30",
+    "location": "Tannenbaum Lodge, Holiday Valley, Ellicottville, NY, 6787 Holiday Valley Rd., Ellicottvilley, NY, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753454/",
+    "attendees": 4
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2017-02-02",
+    "startTime": "18:00",
+    "location": "Jedd Park, 2275 Pickle Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236753427/",
+    "attendees": 6
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2017-01-19",
+    "startTime": "18:00",
+    "location": "Jilly's Music Room, 111 N Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236755240/",
+    "attendees": 6
+  },
+  {
+    "title": "2nd Saturday Hash-Annual General Mismanagement",
+    "date": "2017-01-14",
+    "startTime": "14:00",
+    "location": "Stonehedge, 580 E Cuyahoga Falls Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236696559/",
+    "attendees": 7
+  },
+  {
+    "title": "NYE Clue Hash",
+    "date": "2016-12-31",
+    "startTime": "14:00",
+    "location": "Kevin O'Bryan's, 1761 South Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/236491939/",
+    "attendees": 8
+  },
+  {
+    "title": "Ugly Sweater Hash",
+    "date": "2016-12-24",
+    "startTime": "14:00",
+    "location": "Tear Ez, 360 S. Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/235764141/",
+    "attendees": 4
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2016-12-15",
+    "startTime": "18:00",
+    "location": "Kepner's Tavern, 88 North Main St., Hudson, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/235764132/",
+    "attendees": 6
+  },
+  {
+    "title": "Annual Holiday Hash",
+    "date": "2016-12-10",
+    "startTime": "14:00",
+    "location": "Tip'em Up Tavern, 1854 Newton St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/235556102/",
+    "attendees": 8
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2016-12-01",
+    "startTime": "18:00",
+    "location": "Ray's, 816 W. Market Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/235556112/",
+    "attendees": 8
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2016-11-17",
+    "startTime": "18:00",
+    "location": "Tonix Bar, 3090 South Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/235396943/",
+    "attendees": 9
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2016-11-12",
+    "startTime": "15:00",
+    "location": "Zephyr, 106 West Main Street, Kent, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/235401988/",
+    "attendees": 5
+  },
+  {
+    "title": "Bonfire of Badassery V",
+    "date": "2016-11-04",
+    "startTime": "19:00",
+    "location": "I'm Not The Savior's House, 2381 Center Rd., Clinton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/235068492/",
+    "attendees": 13
+  },
+  {
+    "title": "Annual Pink Dress Booby Hash",
+    "date": "2016-10-28",
+    "startTime": "18:30",
+    "location": "Super 8 Motel, 5161 Montville Drive, Medina, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/235068444/",
+    "attendees": 5
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2016-10-22",
+    "startTime": "15:00",
+    "location": "Rancheros taqueria, 286 E Cuyahoga Falls Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/234373263/",
+    "attendees": 13
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2016-10-08",
+    "startTime": "15:00",
+    "location": "Winking Lizard, 1615 Main Street, Peninsula, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/234171329/",
+    "attendees": 8
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2016-10-06",
+    "startTime": "18:00",
+    "location": "Ohio Brewing Company, 804 W Market St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/233814280/",
+    "attendees": 7
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2016-09-24",
+    "startTime": "15:00",
+    "location": "I'm Not The Savior's House, 2381 Center Rd., Clinton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/233548701/",
+    "attendees": 6
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2016-09-01",
+    "startTime": "18:00",
+    "location": "On Tap, Portage Lakes, 562 Portage Lakes Drive, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/233158967/",
+    "attendees": 11
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2016-08-18",
+    "startTime": "18:00",
+    "location": "Paramount Pub & Grill, 491 E Waterloo Rd., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/232481581/",
+    "attendees": 7
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2016-08-13",
+    "startTime": "15:00",
+    "location": "Winking Lizard, 1615 Main Street, Peninsula, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/232911095/",
+    "attendees": 5
+  },
+  {
+    "title": "4th Saturday Summer Birthday Picnic Hash",
+    "date": "2016-07-23",
+    "startTime": "15:00",
+    "location": "Casa de Shorthairs, 491 Wyoga Lake, Stow, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/229623883/",
+    "attendees": 9
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2016-07-21",
+    "startTime": "18:00",
+    "location": "The Upper Deck, 357 W Turkeyfoot Lake Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/232296244/",
+    "attendees": 10
+  },
+  {
+    "title": "2nd Saturday Running of the Bullshitters Hash",
+    "date": "2016-07-09",
+    "startTime": "15:00",
+    "location": "Chestnut Beer Garden, 503 Chestnut Blvd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/229623773/",
+    "attendees": 10
+  },
+  {
+    "title": "2016 Ohio Interhash Campout Weekend",
+    "date": "2016-06-03",
+    "startTime": "12:00",
+    "location": "Private Property, 2381 Center Road, Clinton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/229623649/",
+    "attendees": 13
+  },
+  {
+    "title": "2nd Saturday KSU Memorial Hash",
+    "date": "2016-05-14",
+    "startTime": "15:00",
+    "location": "101 Bottles of Beer on the Wall, 115 N Willow St, Kent, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/229622073/",
+    "attendees": 10
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2016-05-05",
+    "startTime": "18:00",
+    "location": "Barley House, 222 South Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/227411079/",
+    "attendees": 15
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2016-04-23",
+    "startTime": "15:00",
+    "location": "Manny's Pub, 394 Brown Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/229622043/",
+    "attendees": 11
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2016-04-21",
+    "startTime": "18:00",
+    "location": "Mr. Spocks Lounge, 2012 S. Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/230249761/",
+    "attendees": 15
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2016-04-09",
+    "startTime": "15:00",
+    "location": "The Canal Boat, 119 S. Canal Street, Canal Fulton, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/228958558/",
+    "attendees": 5
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2016-04-07",
+    "startTime": "18:00",
+    "location": "69 taps, 370 Paul Williams St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/228958554/",
+    "attendees": 4
+  },
+  {
+    "title": "4th Saturday Hash--Annual Green Dress Run",
+    "date": "2016-03-26",
+    "startTime": "15:00",
+    "location": "The Elks, 2555 State Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/228958548/",
+    "attendees": 8
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2016-03-17",
+    "startTime": "18:00",
+    "location": "69 taps, 370 Paul Williams St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/228511873/",
+    "attendees": 5
+  },
+  {
+    "title": "2nd Saturday Hash-- Annual Toga Hash",
+    "date": "2016-03-12",
+    "startTime": "15:00",
+    "location": "Euro Gyro, 107 S. Depeyster Street, Kent, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/228511861/",
+    "attendees": 7
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2016-03-03",
+    "startTime": "18:00",
+    "location": "The Paramount, 491 Waterloo Rd., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/228511833/",
+    "attendees": 5
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2016-02-27",
+    "startTime": "14:00",
+    "location": "R J's Pub, 4195 Massillon Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/228408259/",
+    "attendees": 7
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2016-02-18",
+    "startTime": "18:00",
+    "location": "Ray's, 816 W. Market Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/226919314/",
+    "attendees": 8
+  },
+  {
+    "title": "2nd Saturday Karoke Valentines Hash",
+    "date": "2016-02-13",
+    "startTime": "14:00",
+    "location": "The Elks, 2555 State Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/226919312/",
+    "attendees": 7
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2016-02-04",
+    "startTime": "18:00",
+    "location": "Jilly's Music Room, 111 N Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/226919308/",
+    "attendees": 8
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2016-01-23",
+    "startTime": "15:00",
+    "location": "On Tap, Portage Lakes, 562 Portage Lakes Drive, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/226919295/",
+    "attendees": 9
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2016-01-21",
+    "startTime": "18:00",
+    "location": "Annabelle's, 784 W. Market Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/226919278/",
+    "attendees": 7
+  },
+  {
+    "title": "2nd Saturday Hash - AGM (Annual General Mismanagement)",
+    "date": "2016-01-09",
+    "startTime": "14:00",
+    "location": "Stonehedge, 580 E Cuyahoga Falls Ave, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/226919302/",
+    "attendees": 9
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2016-01-07",
+    "startTime": "18:00",
+    "location": "Frank's Place On Market, 549 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/226919273/",
+    "attendees": 7
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2015-12-26",
+    "startTime": "14:00",
+    "location": "River City Bar & Grill, 2621 Bailey Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022810/",
+    "attendees": 6
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2015-12-17",
+    "startTime": "18:00",
+    "location": "69 taps, 370 Paul Williams St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223020608/",
+    "attendees": 10
+  }
+]

--- a/scripts/data/rch3-meetup-history-batch-5.json
+++ b/scripts/data/rch3-meetup-history-batch-5.json
@@ -1,0 +1,218 @@
+[
+  {
+    "title": "Holiday Hash - 2nd Saturday Hash",
+    "date": "2015-12-12",
+    "startTime": "14:00",
+    "location": "Tip'em Up Tavern, 1854 Newton St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022212/",
+    "attendees": 8
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2015-12-03",
+    "startTime": "18:00",
+    "location": "Brubaker's Pub, 357 S.Main St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223021564/",
+    "attendees": 7
+  },
+  {
+    "title": "4th Saturday Thanksgiving Hash",
+    "date": "2015-11-28",
+    "startTime": "14:00",
+    "location": "Varsity O's, 1895 Triplett Blvd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022767/",
+    "attendees": 7
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2015-11-19",
+    "startTime": "18:00",
+    "location": "Brubaker's Pub, 357 S.Main St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223020544/",
+    "attendees": 5
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2015-11-14",
+    "startTime": "14:00",
+    "location": "Harvey Wallbangers, 1915 Brown Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022147/",
+    "attendees": 4
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2015-11-05",
+    "startTime": "18:00",
+    "location": "Jilly's Music Room, 111 N Main St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223021509/",
+    "attendees": 7
+  },
+  {
+    "title": "Pink Dress Booby Hash",
+    "date": "2015-10-30",
+    "startTime": "18:00",
+    "location": "Super 8 Motel, 5161 Montville Drive, Medina, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223023189/",
+    "attendees": 15
+  },
+  {
+    "title": "4th Saturday Halloween Hash",
+    "date": "2015-10-24",
+    "startTime": "15:00",
+    "location": "Tear Ez, 360 S. Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022712/",
+    "attendees": 12
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2015-10-15",
+    "startTime": "18:00",
+    "location": "Brubaker's Pub, 357 S.Main St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223020092/",
+    "attendees": 10
+  },
+  {
+    "title": "All Shiggy - 2nd Saturday Hash",
+    "date": "2015-10-10",
+    "startTime": "14:00",
+    "location": "Winking Lizard, 1615 Main Street, Peninsula, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022109/",
+    "attendees": 9
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2015-10-01",
+    "startTime": "18:00",
+    "location": "BW-3's, 456 E. Exchange Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223021479/",
+    "attendees": 10
+  },
+  {
+    "title": "Pirate Hash!! 4th Saturday Hash",
+    "date": "2015-09-26",
+    "startTime": "13:30",
+    "location": "BW-3s, 235 Lincoln Way W, Massillon, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022636/",
+    "attendees": 7
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2015-09-17",
+    "startTime": "18:00",
+    "location": "Hoppin Frog, 1680 E. Waterloo Rd, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223020441/",
+    "attendees": 7
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2015-09-12",
+    "startTime": "15:00",
+    "location": "Harvey Wallbangers, 1915 Brown Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022061/",
+    "attendees": 7
+  },
+  {
+    "title": "1st Thirsty Thursday Baseball Hash",
+    "date": "2015-09-03",
+    "startTime": "18:00",
+    "location": "69 taps, 370 Paul Williams St., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223021455/",
+    "attendees": 9
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2015-08-22",
+    "startTime": "15:00",
+    "location": "River City Bar & Grill, 2621 Bailey Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223129668/",
+    "attendees": 9
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2015-08-20",
+    "startTime": "18:00",
+    "location": "Buffalo Wild Wings, 456 E. Exchange Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223020336/",
+    "attendees": 8
+  },
+  {
+    "title": "2nd Saturday Hash",
+    "date": "2015-08-08",
+    "startTime": "15:00",
+    "location": "Zephyr, 106 West Main Street, Kent, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223021769/",
+    "attendees": 5
+  },
+  {
+    "title": "1st Thirsty Thursday Hash",
+    "date": "2015-08-06",
+    "startTime": "18:00",
+    "location": "EuroGyro in WEST AKRON, 77 Westgate Ctr., Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223021397/",
+    "attendees": 10
+  },
+  {
+    "title": "Summer Birthday Picnic Bash - 4th Saturday Hash",
+    "date": "2015-07-25",
+    "startTime": "14:00",
+    "location": "Shorthairs' Estate, 491 Wyoga Lake Blve, Stow, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022400/",
+    "attendees": 6
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2015-07-16",
+    "startTime": "18:00",
+    "location": "Arnie's Standing Room Only, 1682 W Market St, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223020037/",
+    "attendees": 3
+  },
+  {
+    "title": "Guam Goodbye 2nd Saturday Hash",
+    "date": "2015-07-11",
+    "startTime": "15:00",
+    "location": "Care & Beaver, 6861 Ballish Rd, Medina, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223021927/",
+    "attendees": 7
+  },
+  {
+    "title": "Blossom Music Center Hash",
+    "date": "2015-07-02",
+    "startTime": "18:00",
+    "location": "Blossom Music Center, 1145 W Steels Corners Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223021367/",
+    "attendees": 4
+  },
+  {
+    "title": "4th Saturday Hash",
+    "date": "2015-06-27",
+    "startTime": "15:00",
+    "location": "Ray's Place Fairlawn, 25 Ghent Rd, Fairlawn, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223022298/",
+    "attendees": 6
+  },
+  {
+    "title": "Third Thirsty Thursday Hash",
+    "date": "2015-06-18",
+    "startTime": "18:00",
+    "location": "The Boulevard Tavern, 435 Chestnut Blvd., Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223020197/",
+    "attendees": 7
+  },
+  {
+    "title": "The Rubber City's 11th Anniversary and Goodbye to Priority Male",
+    "date": "2015-06-13",
+    "startTime": "15:00",
+    "location": "Jimmy Bigg's Grill, 1927 State Rd, Cuyahoga Falls, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/223019783/",
+    "attendees": 12
+  },
+  {
+    "title": "Hash - Drink beer and exercise",
+    "date": "2015-06-04",
+    "startTime": "18:00",
+    "location": "Mr. Spocks Lounge, 2012 S. Main Street, Akron, OH, US",
+    "url": "https://www.meetup.com/rubber-city-hash-house-harriers-and-harriettes/events/222975689/",
+    "attendees": 1
+  }
+]

--- a/scripts/data/savh3-meetup-history-batch-1.json
+++ b/scripts/data/savh3-meetup-history-batch-1.json
@@ -1,0 +1,402 @@
+[
+  {
+    "title": "SAVH3 Trail #1328",
+    "date": "2026-04-11",
+    "startTime": "14:00",
+    "location": "Tubby's Tank House, 2909 River Drive, Thunderbolt, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313899799/",
+    "attendees": 6
+  },
+  {
+    "title": "Drinking Practice at Over Yonder!",
+    "date": "2026-04-06",
+    "startTime": "18:00",
+    "location": "Moodrights, 2424 Abercorn St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313874572/",
+    "attendees": 3
+  },
+  {
+    "title": "SAV H3 Trail # 1327",
+    "date": "2026-04-04",
+    "startTime": "14:00",
+    "location": "Bonita Boutique, 485 Jimmy Deloach Parkway,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313795654/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Hop Atomica",
+    "date": "2026-04-02",
+    "startTime": "18:30",
+    "location": "Hop Atomica, 535 E. 39th St., Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313992240/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail #1326",
+    "date": "2026-03-28",
+    "startTime": "11:30",
+    "location": "Bowles C Ford Park, Cloverdale Dr, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313698258/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Hey’s and Mary!",
+    "date": "2026-03-26",
+    "startTime": "18:30",
+    "location": "The Wormhole, 2307 Bull Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313674375/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail #1325!",
+    "date": "2026-03-21",
+    "startTime": "14:00",
+    "location": "TBD, One of the squares, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313590990/",
+    "attendees": 7
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Lone Wolf Lounge!",
+    "date": "2026-03-19",
+    "startTime": "18:30",
+    "location": "Lone Wolf Lounge, 2429 Lincoln Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313565396/",
+    "attendees": 4
+  },
+  {
+    "title": "SAVH3 Trail #1324!",
+    "date": "2026-03-14",
+    "startTime": "14:00",
+    "location": "TBD, One of the squares, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313480174/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Blueberry Hill!",
+    "date": "2026-03-12",
+    "startTime": "18:30",
+    "location": "Blueberry Hill Bar, 1550 Dean Forest Rd ste C,, Garden City, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313453760/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail #1323",
+    "date": "2026-03-07",
+    "startTime": "14:00",
+    "location": "Blackshear Park, 820 Wheaton St ,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313372521/",
+    "attendees": 6
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Tacos and Tequila!",
+    "date": "2026-03-05",
+    "startTime": "18:30",
+    "location": "Tacos+Tequila, 1611 Habersham St ,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313348941/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail #1321",
+    "date": "2026-02-21",
+    "startTime": "14:00",
+    "location": "TBD, One of the squares, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313162048/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Moodright’s!",
+    "date": "2026-02-19",
+    "startTime": "18:30",
+    "location": "Moodright’s, 2424 Abercorn St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313135692/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1320",
+    "date": "2026-02-14",
+    "startTime": "14:00",
+    "location": "TBD, One of the squares, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313053847/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at TAB!",
+    "date": "2026-02-12",
+    "startTime": "18:30",
+    "location": "Totally Awesome Bar, 107B Whitaker St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/313028305/",
+    "attendees": 5
+  },
+  {
+    "title": "SAVH3 Trail # 1219 - Chicken Chase!",
+    "date": "2026-02-07",
+    "startTime": "14:00",
+    "location": "Congress Street Social Club, 411 W Congress st, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312947084/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Norwood Tavern!",
+    "date": "2026-02-05",
+    "startTime": "18:30",
+    "location": "Norwood Tavern, 2130 Norwood Ave, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312921663/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1318 - BLT!",
+    "date": "2026-01-31",
+    "startTime": "15:00",
+    "location": "Sexton Pub & Provisions, 9 w 43rd st,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312835669/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2026-01-29",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312810593/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1317",
+    "date": "2026-01-24",
+    "startTime": "15:00",
+    "location": "Liberty Street Community Center, 1401 Mills B Ln Blvd,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312717775/",
+    "attendees": 6
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!l at White Whale!",
+    "date": "2026-01-22",
+    "startTime": "18:30",
+    "location": "White Whale, 1207 Bull Street,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312975915/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Sexton!",
+    "date": "2026-01-15",
+    "startTime": "18:30",
+    "location": "Sexton Pub & Provisions, 9 w 43rd st,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312590090/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail #1316",
+    "date": "2026-01-10",
+    "startTime": "14:00",
+    "location": null,
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312529053/",
+    "attendees": 6
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Over Yonder!",
+    "date": "2026-01-08",
+    "startTime": "18:30",
+    "location": "Moodright’s, 2424 Abercorn St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312506988/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail #1315",
+    "date": "2026-01-03",
+    "startTime": "14:00",
+    "location": "Progressive Recreation Center, 5321 Ogeechee Road, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312435164/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2026-01-01",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312412748/",
+    "attendees": 3
+  },
+  {
+    "title": "Savannah H3 Trail # 1314!",
+    "date": "2025-12-27",
+    "startTime": "14:00",
+    "location": "Congress Street Social Club, 411 W Congress st, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312343536/",
+    "attendees": 13
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2025-12-25",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312320517/",
+    "attendees": 12
+  },
+  {
+    "title": "SAVH3 Trail # 1313",
+    "date": "2025-12-20",
+    "startTime": "17:30",
+    "location": "Solomon Tract Trail, EMD Blvd,, Port Wentworth, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312241461/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Rachael’s!",
+    "date": "2025-12-18",
+    "startTime": "18:30",
+    "location": "Rachael's 1190, 1190 King George Boulevard, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312215143/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail 1312 -JINGLE BALLS!",
+    "date": "2025-12-13",
+    "startTime": "14:15",
+    "location": "Pinkie Masters, 318 Drayton St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312142999/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Wormhole!",
+    "date": "2025-12-11",
+    "startTime": "18:30",
+    "location": "The Wormhole, 2307 Bull Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312118614/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1311",
+    "date": "2025-12-06",
+    "startTime": "14:00",
+    "location": null,
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312038104/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Aqua Vitae!",
+    "date": "2025-12-04",
+    "startTime": "18:30",
+    "location": "Aqua Vitae, 719 E 65th St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/312013602/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail 1310",
+    "date": "2025-11-22",
+    "startTime": "14:00",
+    "location": null,
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311828580/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at the Legion!",
+    "date": "2025-11-20",
+    "startTime": "18:30",
+    "location": "American Legion, 1108 Bull Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311801915/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1309!",
+    "date": "2025-11-15",
+    "startTime": "14:00",
+    "location": "UGA Marine Education Center and Aquarium, 30 Ocean Science Circle, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311719454/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Wormhole!",
+    "date": "2025-11-13",
+    "startTime": "18:30",
+    "location": "The Wormhole, 2307 Bull Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311696049/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1308",
+    "date": "2025-11-08",
+    "startTime": "14:00",
+    "location": "Rincon Trail, 203 Georgia Ave,, Rincon, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311614347/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Hawthorn Minibar and Lounge!",
+    "date": "2025-11-06",
+    "startTime": "18:30",
+    "location": "Hawthorn Minibar and Lounge, 524 ML King Jr Blvd,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311589513/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1307",
+    "date": "2025-11-01",
+    "startTime": "14:00",
+    "location": null,
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311508733/",
+    "attendees": 4
+  },
+  {
+    "title": "Drinking Practice at Dayumm’s!",
+    "date": "2025-10-31",
+    "startTime": "18:30",
+    "location": "Location not specified yet",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311481594/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1306 - Hashoween!",
+    "date": "2025-10-25",
+    "startTime": "14:00",
+    "location": null,
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311395087/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2025-10-23",
+    "startTime": "18:30",
+    "location": "World of Beer, 112 West Broughton Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311366788/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1305",
+    "date": "2025-10-18",
+    "startTime": "14:00",
+    "location": null,
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311274951/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Bowl and Brew!",
+    "date": "2025-10-16",
+    "startTime": "18:30",
+    "location": "Broughton Street Bowl and Brew, 129 e broughton st,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311245990/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1304",
+    "date": "2025-10-11",
+    "startTime": "14:00",
+    "location": "Red Roof Inn Yemassee, 138 Frampton Dr,, Yemassee, SC, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311156656/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Social Club!",
+    "date": "2025-10-09",
+    "startTime": "18:30",
+    "location": "Congress Street Social Club, 411 West Congress Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311130183/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1303",
+    "date": "2025-10-04",
+    "startTime": "14:00",
+    "location": "Mother Matilda Beasley Park, 500 E. Broad Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311041556/",
+    "attendees": 4
+  }
+]

--- a/scripts/data/savh3-meetup-history-batch-2.json
+++ b/scripts/data/savh3-meetup-history-batch-2.json
@@ -1,0 +1,162 @@
+[
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Jerry’s!",
+    "date": "2025-10-02",
+    "startTime": "18:30",
+    "location": "Jerry's Lounge, Jerry's Lounge 1209 E Montgomery Cross Rd, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/311013223/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1302",
+    "date": "2025-09-27",
+    "startTime": "14:00",
+    "location": "Bunny’s House, 2103 New Mexico St,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310924957/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Midtown Sports!",
+    "date": "2025-09-25",
+    "startTime": "18:30",
+    "location": "Midtown Sportsbar, Habersham Village, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310896254/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1301 - Groupie Turns 32! 😱",
+    "date": "2025-09-20",
+    "startTime": "15:30",
+    "location": "Forsyth Park, Drayton St & W Gaston Street, Savannah, ga, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310801486/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Rachael’s!",
+    "date": "2025-09-18",
+    "startTime": "18:30",
+    "location": "Rachael's 1190, 1190 King George Boulevard, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310772938/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1300!",
+    "date": "2025-09-13",
+    "startTime": "13:00",
+    "location": null,
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310683876/",
+    "attendees": 8
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Dub’s!",
+    "date": "2025-09-11",
+    "startTime": "18:30",
+    "location": "Dubs, 225 W River Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310657210/",
+    "attendees": 3
+  },
+  {
+    "title": "SAVH3 Trail # 1299",
+    "date": "2025-09-06",
+    "startTime": "13:00",
+    "location": "Lone Wolf Lounge, 2429 Lincoln Street, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310571065/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at Coach’s!",
+    "date": "2025-09-04",
+    "startTime": "18:30",
+    "location": "Coach's Corner, 3016 East Victory Drive, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310543348/",
+    "attendees": 3
+  },
+  {
+    "title": "Saturday Trail!",
+    "date": "2025-08-30",
+    "startTime": "14:00",
+    "location": "Rice Creek Community Center, 1 Miller Park Circle ,, Port Wentworth, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310458520/",
+    "attendees": 6
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice at B&D Burgers!",
+    "date": "2025-08-28",
+    "startTime": "18:30",
+    "location": "B&D Burgers - Pooler, 238 Pooler Pkwy #G, Pooler, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310431451/",
+    "attendees": 4
+  },
+  {
+    "title": "SAVH3 Trail # 1297",
+    "date": "2025-08-23",
+    "startTime": "14:00",
+    "location": "Lake Mayer Park, 1850 E. Montgomery Crossroad, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310344738/",
+    "attendees": 6
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2025-08-21",
+    "startTime": "18:30",
+    "location": "The Rail Pub, 405 W Congress St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310601060/",
+    "attendees": 1
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2025-08-21",
+    "startTime": "18:30",
+    "location": "The Rail Pub, 405 W Congress St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310316833/",
+    "attendees": 3
+  },
+  {
+    "title": "Saturday Trail!",
+    "date": "2025-08-16",
+    "startTime": "14:00",
+    "location": "Trail, 32°03'32.4\"N 81°09'20.8\"W,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310216712/",
+    "attendees": 5
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2025-08-14",
+    "startTime": "18:30",
+    "location": "Treylor Park Pizza Party, 1201 Habersham St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310180810/",
+    "attendees": 7
+  },
+  {
+    "title": "Saturday Trail!",
+    "date": "2025-08-09",
+    "startTime": "14:00",
+    "location": "Moodrights, 2424 Abercorn St, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310068472/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2025-08-07",
+    "startTime": "18:30",
+    "location": "Blueberry Hill Bar, 1550 Dean Forest Rd ste C,, Garden City, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310023928/",
+    "attendees": 3
+  },
+  {
+    "title": "Saturday Trail!",
+    "date": "2025-08-02",
+    "startTime": "14:00",
+    "location": null,
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310219020/",
+    "attendees": 4
+  },
+  {
+    "title": "Thirsty Thursday / Drinking Practice!",
+    "date": "2025-07-31",
+    "startTime": "18:30",
+    "location": "The black rabbit, 1215 Barnard St,, Savannah, GA, US",
+    "url": "https://www.meetup.com/savannah-hash-house-harriers/events/310182889/",
+    "attendees": 3
+  }
+]

--- a/scripts/import-meetup-history.ts
+++ b/scripts/import-meetup-history.ts
@@ -25,6 +25,7 @@ import { prisma } from "@/lib/db";
 import { processRawEvents } from "@/pipeline/merge";
 import { generateFingerprint } from "@/pipeline/fingerprint";
 import type { RawEventData } from "@/adapters/types";
+import { SOURCES } from "@/../prisma/seed-data/sources";
 
 /** Shape of a single event row from the Chrome scrape JSON output. */
 interface MeetupHistoryRow {
@@ -34,6 +35,14 @@ interface MeetupHistoryRow {
   location?: string | null;
   url?: string | null;
   attendees?: number | null;
+}
+
+function todayIsoDate(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 /** Extract run number from a Meetup event title (e.g. "#850" or "Run #850"). */
@@ -52,19 +61,78 @@ function isPlaceholderEvent(title: string): boolean {
 }
 
 /** Parse CLI arguments for --kennel and --source. */
-function parseArgs(): { kennelCode: string; sourceName: string } {
+function parseArgs(): { kennelCode?: string; sourceName: string } {
   const args = process.argv.slice(2);
-  let kennelCode = "";
+  let kennelCode: string | undefined;
   let sourceName = "";
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--kennel" && args[i + 1]) kennelCode = args[++i];
     if (args[i] === "--source" && args[i + 1]) sourceName = args[++i];
   }
-  if (!kennelCode || !sourceName) {
-    console.error("Usage: ... | npx tsx scripts/import-meetup-history.ts --kennel <code> --source <name>");
+  if (!sourceName) {
+    console.error("Usage: ... | npx tsx scripts/import-meetup-history.ts --source <name> [--kennel <code>]");
     process.exit(1);
   }
   return { kennelCode, sourceName };
+}
+
+interface MeetupRoutingConfig {
+  kennelTag: string;
+  kennelPatterns?: [string, string][];
+}
+
+function compileKennelPatterns(
+  patterns?: [string, string][],
+): [RegExp, string][] | undefined {
+  if (!patterns) return undefined;
+  const compiled: [RegExp, string][] = [];
+  for (const [pattern, tag] of patterns) {
+    try {
+      compiled.push([new RegExp(pattern, "i"), tag]);
+    } catch (err) {
+      console.warn(`Skipping malformed kennel pattern "${pattern}": ${(err as Error).message}`);
+    }
+  }
+  return compiled.length > 0 ? compiled : undefined;
+}
+
+function resolveKennelTag(
+  title: string,
+  fallbackKennelTag: string,
+  compiledPatterns?: [RegExp, string][],
+): string {
+  if (!compiledPatterns) return fallbackKennelTag;
+  for (const [re, tag] of compiledPatterns) {
+    if (re.test(title)) return tag;
+  }
+  return fallbackKennelTag;
+}
+
+async function loadMeetupRoutingConfig(sourceName: string): Promise<MeetupRoutingConfig> {
+  const dbSource = await prisma.source.findFirst({
+    where: { name: sourceName },
+    select: { config: true, type: true },
+  });
+  if (dbSource?.type === "MEETUP" && dbSource.config && typeof dbSource.config === "object") {
+    const cfg = dbSource.config as Record<string, unknown>;
+    if (typeof cfg.kennelTag === "string" && cfg.kennelTag.trim()) {
+      return {
+        kennelTag: cfg.kennelTag,
+        kennelPatterns: Array.isArray(cfg.kennelPatterns) ? cfg.kennelPatterns as [string, string][] : undefined,
+      };
+    }
+  }
+
+  const seededSource = SOURCES.find((source) => source.name === sourceName && source.type === "MEETUP");
+  const seededConfig = seededSource?.config as Record<string, unknown> | undefined;
+  if (seededConfig && typeof seededConfig.kennelTag === "string" && seededConfig.kennelTag.trim()) {
+    return {
+      kennelTag: seededConfig.kennelTag,
+      kennelPatterns: Array.isArray(seededConfig.kennelPatterns) ? seededConfig.kennelPatterns as [string, string][] : undefined,
+    };
+  }
+
+  throw new Error(`Meetup source "${sourceName}" is missing a usable kennelTag config`);
 }
 
 /** Read all of stdin into a string. */
@@ -123,9 +191,19 @@ function parseJsonArrays(raw: string): ParseResult {
 }
 
 async function main() {
-  const { kennelCode, sourceName } = parseArgs();
+  const { kennelCode: kennelOverride, sourceName } = parseArgs();
   const apply = process.env.BACKFILL_APPLY === "1";
-  console.log(`Import Meetup history: kennel=${kennelCode} source="${sourceName}"`);
+  const today = todayIsoDate();
+  const routingConfig = await loadMeetupRoutingConfig(sourceName);
+  const defaultKennelCode = kennelOverride ?? routingConfig.kennelTag;
+  const compiledPatterns = compileKennelPatterns(routingConfig.kennelPatterns);
+
+  console.log(`Import Meetup history: kennel=${defaultKennelCode} source="${sourceName}"`);
+  if (kennelOverride) {
+    console.log(`Routing override: forcing kennel=${kennelOverride}`);
+  } else if (compiledPatterns) {
+    console.log(`Routing mode: default kennel=${defaultKennelCode} with ${compiledPatterns.length} kennelPatterns`);
+  }
   console.log(`Mode: ${apply ? "APPLY" : "DRY RUN"}\n`);
 
   const raw = await readStdin();
@@ -150,9 +228,14 @@ async function main() {
   const events: RawEventData[] = [];
   let skipped = 0;
   let skippedPlaceholder = 0;
+  let skippedFuture = 0;
   for (const row of allRows) {
     if (!row.date || !row.title) { skipped++; continue; }
     if (!/^\d{4}-\d{2}-\d{2}$/.test(row.date)) { skipped++; continue; }
+    if (row.date > today) {
+      skippedFuture++;
+      continue;
+    }
     if (isPlaceholderEvent(row.title)) {
       skippedPlaceholder++;
       continue;
@@ -160,7 +243,9 @@ async function main() {
 
     events.push({
       date: row.date,
-      kennelTag: kennelCode,
+      kennelTag: kennelOverride
+        ? kennelOverride
+        : resolveKennelTag(row.title, defaultKennelCode, compiledPatterns),
       title: row.title,
       runNumber: extractRunNumber(row.title),
       startTime: row.startTime || undefined,
@@ -179,7 +264,7 @@ async function main() {
     unique.push(event);
   }
 
-  console.log(`Valid: ${events.length}, unique: ${unique.length}, skipped: ${skipped}, placeholders filtered: ${skippedPlaceholder}`);
+  console.log(`Valid: ${events.length}, unique: ${unique.length}, skipped: ${skipped}, future filtered: ${skippedFuture}, placeholders filtered: ${skippedPlaceholder}`);
   if (unique.length === 0) { console.log("Nothing to import."); return; }
 
   // Sort by date for readable output

--- a/scripts/scrape-meetup-history.mjs
+++ b/scripts/scrape-meetup-history.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const { chromium } = await import("playwright");
+
+const CURRENT_YEAR = new Date().getUTCFullYear();
+const MONTHS = {
+  Jan: 1,
+  Feb: 2,
+  Mar: 3,
+  Apr: 4,
+  May: 5,
+  Jun: 6,
+  Jul: 7,
+  Aug: 8,
+  Sep: 9,
+  Oct: 10,
+  Nov: 11,
+  Dec: 12,
+};
+
+function parseArgs(argv) {
+  const args = {
+    stableRounds: 10,
+    chunkSize: 50,
+    maxRounds: 150,
+    waitMs: 2500,
+    width: 1440,
+    height: 2200,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    if (arg === "--url" && next) args.url = next;
+    if (arg === "--before-date" && next) args.beforeDate = next;
+    if (arg === "--out" && next) args.out = next;
+    if (arg === "--batch-prefix" && next) args.batchPrefix = next;
+    if (arg === "--batch-start" && next) args.batchStart = Number(next);
+    if (arg === "--chunk-size" && next) args.chunkSize = Number(next);
+    if (arg === "--stable-rounds" && next) args.stableRounds = Number(next);
+    if (arg === "--max-rounds" && next) args.maxRounds = Number(next);
+    if (arg === "--wait-ms" && next) args.waitMs = Number(next);
+  }
+
+  if (!args.url || !args.beforeDate) {
+    console.error(
+      "Usage: node scripts/scrape-meetup-history.mjs --url <meetup-past-events-url> --before-date <YYYY-MM-DD> [--out file.json] [--batch-prefix prefix] [--batch-start N]",
+    );
+    process.exit(1);
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(args.beforeDate)) {
+    console.error(`Invalid --before-date: ${args.beforeDate}`);
+    process.exit(1);
+  }
+
+  if (args.batchPrefix && !Number.isInteger(args.batchStart)) {
+    console.error("--batch-start is required when --batch-prefix is provided");
+    process.exit(1);
+  }
+
+  return args;
+}
+
+function parseCardText(text, url) {
+  const rawLines = text.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (rawLines.length < 2) return null;
+
+  const lines = [...rawLines];
+  if (/^(Cancelled|Canceled)$/i.test(lines[0])) lines.shift();
+
+  const title = (lines.shift() ?? "").replace(/\s+/g, " ").trim();
+  const dateLine = lines.shift() ?? "";
+  const match = dateLine.match(
+    /^[A-Za-z]{3},\s+([A-Za-z]{3})\s+(\d{1,2})(?:,\s+(\d{4}))?\s+·\s+(\d{1,2}:\d{2})\s+([AP]M)/,
+  );
+  if (!match) return null;
+
+  const year = match[3] ? Number(match[3]) : CURRENT_YEAR;
+  const month = MONTHS[match[1]];
+  const day = Number(match[2]);
+  let [hour, minute] = match[4].split(":").map(Number);
+  const ampm = match[5];
+  if (ampm === "PM" && hour !== 12) hour += 12;
+  if (ampm === "AM" && hour === 12) hour = 0;
+
+  let location = null;
+  if (
+    lines[0] &&
+    !/^\d+ attendees?$/i.test(lines[0]) &&
+    !/^by\s+/i.test(lines[0])
+  ) {
+    const normalized = lines[0].replace(/\s+/g, " ").trim();
+    if (normalized !== "·") location = normalized;
+  }
+
+  let attendees = null;
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const attendeeMatch = lines[i].match(/^(\d+) attendees?$/i);
+    if (attendeeMatch) {
+      attendees = Number(attendeeMatch[1]);
+      break;
+    }
+  }
+
+  return {
+    title,
+    date: `${year.toString().padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+    startTime: `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`,
+    location,
+    url: url.replace(/\?.*/, ""),
+    attendees,
+  };
+}
+
+async function collectRows(page, beforeDate, waitMs, maxRounds, stableRounds) {
+  let lastCount = 0;
+  let stable = 0;
+  let parsed = [];
+
+  for (let round = 0; round < maxRounds; round += 1) {
+    await page.evaluate(() => {
+      window.scrollTo(0, document.scrollingElement.scrollHeight);
+    });
+    await page.waitForTimeout(waitMs);
+
+    const items = await page.evaluate(() => {
+      return [...document.querySelectorAll('a[href*="/events/"]')]
+        .filter((anchor) => /\/events\/\d+/.test(anchor.href))
+        .map((anchor) => ({ href: anchor.href, text: anchor.innerText.trim() }))
+        .filter((item) => item.text);
+    });
+
+    const next = [];
+    const seen = new Set();
+    for (const item of items) {
+      const row = parseCardText(item.text, item.href);
+      if (!row || seen.has(row.url)) continue;
+      seen.add(row.url);
+      next.push(row);
+    }
+
+    next.sort((a, b) => a.date.localeCompare(b.date) || a.url.localeCompare(b.url));
+    parsed = next;
+
+    const olderCount = parsed.filter((row) => row.date < beforeDate).length;
+    console.log(
+      `round=${round} total=${parsed.length} older=${olderCount} oldest=${parsed[0]?.date ?? "n/a"}`,
+    );
+
+    if (parsed.length === lastCount) stable += 1;
+    else stable = 0;
+    lastCount = parsed.length;
+
+    if (stable >= stableRounds) break;
+  }
+
+  return parsed.filter((row) => row.date < beforeDate);
+}
+
+function writeJson(filePath, rows) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(rows, null, 2) + "\n");
+}
+
+function writeBatches(prefix, start, rows, chunkSize) {
+  const descending = [...rows].sort((a, b) => b.date.localeCompare(a.date) || b.url.localeCompare(a.url));
+  const written = [];
+
+  for (let i = 0; i < descending.length; i += chunkSize) {
+    const chunk = descending.slice(i, i + chunkSize);
+    const batchNumber = start + written.length;
+    const filePath = `${prefix}${batchNumber}.json`;
+    writeJson(filePath, chunk);
+    written.push({
+      filePath,
+      count: chunk.length,
+      newest: chunk[0]?.date ?? null,
+      oldest: chunk.at(-1)?.date ?? null,
+    });
+  }
+
+  return written;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+const browser = await chromium.launch({ headless: true });
+try {
+  const page = await browser.newPage({
+    viewport: { width: args.width, height: args.height },
+  });
+  page.setDefaultTimeout(45_000);
+
+  await page.goto(args.url, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(5_000);
+
+  const rows = await collectRows(
+    page,
+    args.beforeDate,
+    args.waitMs,
+    args.maxRounds,
+    args.stableRounds,
+  );
+
+  if (args.out) {
+    writeJson(args.out, rows);
+    console.log(`wrote ${rows.length} rows to ${args.out}`);
+  }
+
+  if (args.batchPrefix) {
+    const batches = writeBatches(args.batchPrefix, args.batchStart, rows, args.chunkSize);
+    for (const batch of batches) {
+      console.log(
+        `batch ${path.basename(batch.filePath)} count=${batch.count} newest=${batch.newest} oldest=${batch.oldest}`,
+      );
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        rows: rows.length,
+        oldest: rows[0] ?? null,
+        newest: rows.at(-1) ?? null,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await browser.close();
+}

--- a/scripts/scrape-meetup-history.mjs
+++ b/scripts/scrape-meetup-history.mjs
@@ -66,7 +66,39 @@ function parseArgs(argv) {
   return args;
 }
 
-function parseCardText(text, url) {
+function extractDateParts(dateLine) {
+  const match = dateLine.match(
+    /^[A-Za-z]{3},\s+([A-Za-z]{3})\s+(\d{1,2})(?:,\s+(\d{4}))?\s+·\s+(\d{1,2}:\d{2})\s+([AP]M)/,
+  );
+  if (!match) return null;
+
+  return {
+    month: MONTHS[match[1]],
+    day: Number(match[2]),
+    year: match[3] ? Number(match[3]) : null,
+    time: match[4],
+    ampm: match[5],
+  };
+}
+
+function normalizeLocation(rawLocation) {
+  const collapsed = rawLocation.replace(/\s+/g, " ").trim();
+  if (!collapsed || collapsed === "·") return null;
+
+  const withoutMapsUrl = collapsed.replace(
+    /^https?:\/\/(?:(?:goo\.gl\/maps|maps\.app\.goo\.gl|maps\.google\.com|www\.google\.com\/maps)[^\s,]*)\s*,?\s*/i,
+    "",
+  ).trim();
+
+  const uppercasedState = withoutMapsUrl.replace(
+    /,\s*([a-z]{2})\s*,\s*([a-z]{2}|[A-Z]{2})$/i,
+    (_, state, country) => `, ${state.toUpperCase()}, ${country.toUpperCase()}`,
+  );
+
+  return uppercasedState || null;
+}
+
+function parseCardText(text, url, fallbackYear = CURRENT_YEAR) {
   const rawLines = text.split("\n").map((line) => line.trim()).filter(Boolean);
   if (rawLines.length < 2) return null;
 
@@ -75,16 +107,14 @@ function parseCardText(text, url) {
 
   const title = (lines.shift() ?? "").replace(/\s+/g, " ").trim();
   const dateLine = lines.shift() ?? "";
-  const match = dateLine.match(
-    /^[A-Za-z]{3},\s+([A-Za-z]{3})\s+(\d{1,2})(?:,\s+(\d{4}))?\s+·\s+(\d{1,2}:\d{2})\s+([AP]M)/,
-  );
-  if (!match) return null;
+  const dateParts = extractDateParts(dateLine);
+  if (!dateParts) return null;
 
-  const year = match[3] ? Number(match[3]) : CURRENT_YEAR;
-  const month = MONTHS[match[1]];
-  const day = Number(match[2]);
-  let [hour, minute] = match[4].split(":").map(Number);
-  const ampm = match[5];
+  const year = dateParts.year ?? fallbackYear;
+  const month = dateParts.month;
+  const day = dateParts.day;
+  let [hour, minute] = dateParts.time.split(":").map(Number);
+  const ampm = dateParts.ampm;
   if (ampm === "PM" && hour !== 12) hour += 12;
   if (ampm === "AM" && hour === 12) hour = 0;
 
@@ -94,8 +124,7 @@ function parseCardText(text, url) {
     !/^\d+ attendees?$/i.test(lines[0]) &&
     !/^by\s+/i.test(lines[0])
   ) {
-    const normalized = lines[0].replace(/\s+/g, " ").trim();
-    if (normalized !== "·") location = normalized;
+    location = normalizeLocation(lines[0]);
   }
 
   let attendees = null;
@@ -137,8 +166,22 @@ async function collectRows(page, beforeDate, waitMs, maxRounds, stableRounds) {
 
     const next = [];
     const seen = new Set();
+    let inferredYear = CURRENT_YEAR;
+    let previousMonth = null;
     for (const item of items) {
-      const row = parseCardText(item.text, item.href);
+      const rawLines = item.text.split("\n").map((line) => line.trim()).filter(Boolean);
+      const dateLineIndex = /^(Cancelled|Canceled)$/i.test(rawLines[0]) ? 2 : 1;
+      const dateParts = extractDateParts(rawLines[dateLineIndex] ?? "");
+      if (!dateParts) continue;
+
+      if (dateParts.year != null) {
+        inferredYear = dateParts.year;
+      } else if (previousMonth != null && dateParts.month > previousMonth) {
+        inferredYear -= 1;
+      }
+      previousMonth = dateParts.month;
+
+      const row = parseCardText(item.text, item.href, inferredYear);
       if (!row || seen.has(row.url)) continue;
       seen.add(row.url);
       next.push(row);
@@ -197,7 +240,8 @@ try {
   page.setDefaultTimeout(45_000);
 
   await page.goto(args.url, { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(5_000);
+  await page.waitForSelector('a[href*="/events/"]', { timeout: 15_000 });
+  await page.waitForTimeout(1_500);
 
   const rows = await collectRows(
     page,


### PR DESCRIPTION
## Summary
- add AVL H3 Meetup historical backfill batches 5 through 21
- capture the full reachable Meetup archive from 2008-09-13 through 2021-06-25
- add a reusable Playwright scraper for Meetup past-events archive backfills
- document the end-to-end backfill workflow for other Meetup-backed kennels

## What I verified
- Meetup archive scrolling saturated with the oldest reachable AVL H3 card at 2008-09-13
- importer dry-run succeeds across batches 1 through 21
- dry-run result: 1011 parsed rows, 1005 valid unique rows, 6 placeholders filtered
- combined date range: 2008-09-13 to 2026-04-04

## Notes
- I could not run the apply step in this worktree because the local Prisma target is unavailable here: `Database 'johnclem' does not exist on the database server`
- the new scraper and docs are intended to make the same process repeatable for other Meetup-based groups
