### PR TITLE
fix: resolve /kennels/ah3 slug collision + kennel profile corrections

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,12 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["node-ical"],
+  async redirects() {
+    return [
+      // Disambiguate /kennels/ah3 slug collision between Aloha H3 (HI) and Amsterdam H3 (NL)
+      { source: "/kennels/ah3", destination: "/kennels/ah3-hi", permanent: true },
+    ];
+  },
   async headers() {
     return [
       {

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4,6 +4,7 @@ export interface KennelSeed {
   fullName: string;
   region: string;
   country?: string;
+  slug?: string;
   website?: string;
   scheduleDayOfWeek?: string;
   scheduleTime?: string;
@@ -134,7 +135,7 @@ export const KENNELS: KennelSeed[] = [
       instagramHandle: "@bostonh3",
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
     },
-    { kennelCode: "beantown", shortName: "Beantown", fullName: "Beantown City Hash House Harriers", region: "Boston, MA" },
+    { kennelCode: "beantown", shortName: "Beantown", fullName: "Beantown City Hash House Harriers", region: "Boston, MA", hashCash: "$5", contactEmail: "HashCash@beantown.cityhash.org" },
     {
       kennelCode: "bos-moon", shortName: "Boston Moon", fullName: "Boston Moon Hash House Harriers", region: "Boston, MA",
       scheduleFrequency: "Full Moon",
@@ -1435,10 +1436,10 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "ah4", shortName: "Atlanta H4", fullName: "Atlanta Hash House Harriers & Harriettes", region: "Atlanta, GA",
       website: "https://board.atlantahash.com",
-      facebookUrl: "https://www.facebook.com/groups/atlantahash",
       scheduleDayOfWeek: "Saturday", scheduleTime: "1:00 PM", scheduleFrequency: "Weekly",
       hashCash: "$10", foundedYear: 1978,
-      description: "Atlanta's original hash. Weekly Saturday runs since 1978.",
+      contactEmail: "info@atlantahash.com",
+      description: "Atlanta's original hash. Weekly Saturday runs.",
     },
     {
       kennelCode: "ph3-atl", shortName: "Pinelake H3", fullName: "Pinelake Hash House Harriers", region: "Atlanta, GA",
@@ -1996,7 +1997,7 @@ export const KENNELS: KennelSeed[] = [
     },
     // ===== HAWAII =====
     {
-      kennelCode: "ah3-hi", shortName: "AH3", fullName: "Aloha Hash House Harriers", region: "Honolulu, HI",
+      kennelCode: "ah3-hi", shortName: "AH3", fullName: "Aloha Hash House Harriers", region: "Honolulu, HI", slug: "ah3-hi",
       website: "https://alohah3.com",
       facebookUrl: "https://www.facebook.com/AlohaH3/",
       logoUrl: "https://alohah3.com/wp-content/uploads/2023/10/FB-Link-Sharing-Photo-homepage.png",
@@ -2398,7 +2399,7 @@ export const KENNELS: KennelSeed[] = [
 
     // ── Netherlands: Amsterdam ──
     {
-      kennelCode: "ah3-nl", shortName: "AH3", fullName: "Amsterdam Hash House Harriers", region: "Amsterdam", country: "Netherlands",
+      kennelCode: "ah3-nl", shortName: "AH3", fullName: "Amsterdam Hash House Harriers", region: "Amsterdam", country: "Netherlands", slug: "ah3-nl",
       website: "https://ah3.nl",
       facebookUrl: "https://www.facebook.com/groups/AmsterdamH3",
       logoUrl: "https://ah3.nl/wp-content/uploads/2022/03/cropped-Amsterdam-original-192x192.png",
@@ -2477,10 +2478,12 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "bch3", shortName: "BCH3", fullName: "Brew City Hash House Harriers", region: "Milwaukee, WI",
       website: "https://www.brewcityh3.com",
-      facebookUrl: "https://www.facebook.com/brewcityh3",
-      scheduleDayOfWeek: "Thursday", scheduleFrequency: "Biweekly",
+      facebookUrl: "https://www.facebook.com/groups/BrewCityH3/",
+      scheduleDayOfWeek: "Friday", scheduleFrequency: "Weekly",
       hashCash: "$7-8",
-      description: "Milwaukee's biweekly Thursday evening hash. Trail #359+.",
+      contactEmail: "Fido@BrewCityH3.com",
+      logoUrl: "https://static.wixstatic.com/media/5b98c7_0b8ba7cdd4114a479765ea7e0d64d4ea~mv2.png/v1/fill/w_657,h_534,al_c/5b98c7_0b8ba7cdd4114a479765ea7e0d64d4ea~mv2.png",
+      description: "Milwaukee's weekly Friday evening hash. Trail #359+.",
       latitude: 43.04, longitude: -87.91,
     },
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -236,8 +236,13 @@ async function ensureKennelRecords(prisma: any, kennels: KennelSeed[], toSlugFn:
           continue;
         }
         // Pre-check slug candidates to find an available one (avoids P2002 errors)
-        const slugCandidates = [toSlugFn(kennel.shortName), toSlugFn(kennel.kennelCode)];
-        for (let n = 2; slugCandidates.length < 10; n++) slugCandidates.push(`${toSlugFn(kennel.kennelCode)}-${n}`);
+        // Explicit slug in seed data takes priority; otherwise derive from shortName/kennelCode
+        const slugCandidates = kennel.slug
+          ? [kennel.slug]
+          : [toSlugFn(kennel.shortName), toSlugFn(kennel.kennelCode)];
+        if (!kennel.slug) {
+          for (let n = 2; slugCandidates.length < 10; n++) slugCandidates.push(`${toSlugFn(kennel.kennelCode)}-${n}`);
+        }
         let chosenSlug: string | null = null;
         for (const slug of slugCandidates) {
           const taken = await prisma.kennel.findUnique({ where: { slug }, select: { kennelCode: true, shortName: true } });
@@ -291,6 +296,10 @@ async function ensureKennelRecords(prisma: any, kennels: KennelSeed[], toSlugFn:
           if (record[k] === null || record[k] === undefined) {
             updates[k] = v;
           }
+        }
+        // Explicit slug override: update slug if seed specifies a different one
+        if (kennel.slug && record.slug !== kennel.slug) {
+          updates.slug = kennel.slug;
         }
         if (Object.keys(updates).length > 0) {
           record = await prisma.kennel.update({

--- a/scripts/fix-kennel-data-2026-04.ts
+++ b/scripts/fix-kennel-data-2026-04.ts
@@ -1,0 +1,50 @@
+/**
+ * One-shot data correction script for April 2026 kennel audit findings.
+ *
+ * Fixes wrong-value fields that the seed's "fill missing" path cannot correct
+ * because the DB already has stale values set.
+ *
+ * Addresses: #694, #692, #635
+ *
+ * Run: npx tsx scripts/fix-kennel-data-2026-04.ts
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const pool = createScriptPool();
+const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+async function main() {
+  // BCH3: fix schedule (Thursday biweekly → Friday weekly) and dead Facebook link
+  const bch3 = await prisma.kennel.update({
+    where: { kennelCode: "bch3" },
+    data: {
+      scheduleDayOfWeek: "Friday",
+      scheduleFrequency: "Weekly",
+      facebookUrl: "https://www.facebook.com/groups/BrewCityH3/",
+      description: "Milwaukee's weekly Friday evening hash. Trail #359+.",
+    },
+    select: { kennelCode: true, scheduleDayOfWeek: true, scheduleFrequency: true, facebookUrl: true },
+  });
+  console.log("Updated BCH3:", bch3);
+
+  // Atlanta H4: remove dead Facebook link and clean description
+  const ah4 = await prisma.kennel.update({
+    where: { kennelCode: "ah4" },
+    data: {
+      facebookUrl: null,
+      description: "Atlanta's original hash. Weekly Saturday runs.",
+    },
+    select: { kennelCode: true, facebookUrl: true, description: true },
+  });
+  console.log("Updated AH4:", ah4);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => Promise.all([prisma.$disconnect(), pool.end()]));


### PR DESCRIPTION
## Summary

- **#586** Slug collision `/kennels/ah3` — adds explicit `slug: "ah3-hi"` / `slug: "ah3-nl"` to Aloha H3 and Amsterdam H3 seed entries; seed.ts now supports explicit slug overrides and will rename Aloha H3's slug on next run; adds permanent redirect `/kennels/ah3` → `/kennels/ah3-hi` in `next.config.ts`
- **BCH3** (#694, #692, #693, #695) — fixes schedule to Friday/Weekly, updates Facebook to active group URL, adds `contactEmail` and `logoUrl`
- **Beantown** (#701) — adds `hashCash: "$5"` and `contactEmail`
- **Atlanta H4** (#636, #635, #640) — adds `contactEmail`, removes dead Facebook link, cleans description; keeping `hashCash: "$10"` (confirmed by event data) and `foundedYear: 1978` (disputed but unverifiable)

## Post-merge steps (run from main after deploy)

```bash
# Apply seed (fills missing fields + renames Aloha H3 slug ah3 → ah3-hi)
npm run prisma -- db seed

# Overwrite stale BCH3 and AH4 values already in DB
npx tsx scripts/fix-kennel-data-2026-04.ts
```

## Test plan

- [ ] CI passes (tsc + lint + tests)
- [ ] Run `npm run prisma -- db seed` — confirm "Updated kennel: AH3 (slug)", BCH3/Beantown/AH4 field fills
- [ ] Run `npx tsx scripts/fix-kennel-data-2026-04.ts` — confirm BCH3 and AH4 overwrites
- [ ] Verify `/kennels/ah3` redirects to `/kennels/ah3-hi`
- [ ] Verify `/kennels/ah3-hi` and `/kennels/ah3-nl` resolve correctly

Closes #586, #694, #692, #693, #695, #701, #636, #635, #640, #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)