### PR TITLE
fix(adapters): hare boilerplate + location parsing fixes (#712, #715–#719)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -128,6 +128,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "boh3", shortName: "Boston H3", fullName: "Boston Hash House Harriers", region: "Boston, MA",
       scheduleDayOfWeek: "Sunday", scheduleTime: "2:30 PM", scheduleFrequency: "Weekly",
+      logoUrl: "https://www.bostonhash.com/images/hash-logo.jpg",
     },
     {
       kennelCode: "bobbh3", shortName: "B3H4", fullName: "Boston Ballbuster Hardcore Hash House Harriers", region: "Boston, MA",

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -122,7 +122,7 @@ const TITLE_PURE_TIME_RE = /^\d{1,2}:\d{2}\s*[ap]m$/i;
 const TITLE_SCHEDULE_LINE_RE = /:\s*\d{1,2}:\d{2}\s*(?:am|pm)/i;
 
 // Pre-compiled regexes for extractLocationFromDescription
-const LOCATION_LABEL_RE = /(?:^|\n)\s*(?:WHERE|Location|Start\s+Address|Address|Meet(?:ing)?\s*(?:spot|point|at)?)\s*:\s*(.+)/im;
+const LOCATION_LABEL_RE = /(?:^|\n)\s*(?:WHERE|Location|On[\s-]Start|Start\s+Address|Address|Meet(?:ing)?\s*(?:spot|point|at)?)\s*:\s*(.+)/im;
 // Fallback: bare label (no colon) with value on subsequent line, optionally after a URL line
 const LOCATION_BARE_LABEL_RE = /(?:^|\n)\s*(?:WHERE|LOCATION)\s*\n(?:\s*https?:\/\/\S+\s*\n)?\s*(.+)/im;
 // Secondary fallback: "Start:" as location label (lower priority — often contains time, not location)
@@ -280,6 +280,7 @@ export function extractLocationFromDescription(description: string): string | un
 
   if (location.length < 3) return undefined;
   if (isPlaceholder(location)) return undefined;
+  if (isNonAddressText(location)) return undefined;
   if (LOCATION_TIME_ONLY_RE.test(location)) return undefined;
 
   return location;
@@ -357,7 +358,7 @@ export function extractHares(description: string, customPatterns?: string[] | Re
 const mapsUrl = googleMapsSearchUrl;
 
 /** Instruction phrases that indicate a GCal location field contains directions, not an address. */
-const NON_ADDRESS_RE = /^(?:use the|check the|see the|see description|click|follow the|refer to|details in|when:|why:|hare:|what:|who:|cost:)/i;
+const NON_ADDRESS_RE = /^(?:use the|check the|see the|see description|click|follow the|refer to|details in|when:|why:|hare:|what:|who:|cost:)|\bstart\s+location\s*$/i;
 
 /** Returns true if text starts with instruction phrasing rather than an address. */
 function isNonAddressText(text: string): boolean {

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -358,11 +358,14 @@ export function extractHares(description: string, customPatterns?: string[] | Re
 const mapsUrl = googleMapsSearchUrl;
 
 /** Instruction phrases that indicate a GCal location field contains directions, not an address. */
-const NON_ADDRESS_RE = /^(?:use the|check the|see the|see description|click|follow the|refer to|details in|when:|why:|hare:|what:|who:|cost:)|\bstart\s+location\s*$/i;
+const NON_ADDRESS_RE = /^(?:use the|check the|see the|see description|click|follow the|refer to|details in|when:|why:|hare:|what:|who:|cost:)/i;
+/** Suffix phrase indicating the field is a placeholder like "DST start location". */
+const NON_ADDRESS_SUFFIX_RE = /\bstart\s+location\s*$/i;
 
 /** Returns true if text starts with instruction phrasing rather than an address. */
 function isNonAddressText(text: string): boolean {
-  return NON_ADDRESS_RE.test(text.trim());
+  const t = text.trim();
+  return NON_ADDRESS_RE.test(t) || NON_ADDRESS_SUFFIX_RE.test(t);
 }
 
 /** Config shape for Google Calendar sources */

--- a/src/adapters/html-scraper/bangkokhash.test.ts
+++ b/src/adapters/html-scraper/bangkokhash.test.ts
@@ -53,6 +53,18 @@ describe("parseNextRunArticle", () => {
     expect(event!.locationUrl).toBe("https://maps.app.goo.gl/LF88EQZtSPZkdt826");
   });
 
+  it("falls back to Station when Run Site starts with 'Google Map:'", () => {
+    const html = `
+<div class="item-content">
+  <p><strong>Date</strong>: 16-Apr-2026<br>
+  <strong>Station</strong>: BTS Chong Nonsi<br>
+  <strong>Run Site</strong>: Google Map: https://maps.app.goo.gl/HHfhEm6<br>
+  <strong>Hare</strong>: Jessticles</p>
+</div>`;
+    const event = parseNextRunArticle(html, "bth3", "18:30", "https://www.bangkokhash.com/thursday/index.php");
+    expect(event!.location).toBe("BTS Chong Nonsi");
+  });
+
   it("returns null for empty article", () => {
     const event = parseNextRunArticle("<div></div>", "bth3", "18:30", "https://example.com");
     expect(event).toBeNull();
@@ -113,5 +125,15 @@ describe("parseHarelineApiHtml", () => {
   it("handles empty hareline", () => {
     const events = parseHarelineApiHtml("", "bth3", "bfmh3", "18:30", "https://example.com");
     expect(events).toEqual([]);
+  });
+
+  it("filters 'On On' boilerplate from hare field", () => {
+    const html = `
+<div style='padding: 0px;'>
+  <div style='font-weight: bold; background: #b3d9ff;'>01-May-2026 <span>Friday</span></div>
+  <div style='font-size: 10pt;'><label style='width: 100px;'>Run #101</label>On On Q</div>
+</div>`;
+    const events = parseHarelineApiHtml(html, "bfmh3", null, "18:30", "https://example.com");
+    expect(events[0].hares).toBeUndefined();
   });
 });

--- a/src/adapters/html-scraper/bangkokhash.ts
+++ b/src/adapters/html-scraper/bangkokhash.ts
@@ -8,6 +8,7 @@ import {
   chronoParseDate,
   decodeEntities,
   fetchHTMLPage,
+  HARE_BOILERPLATE_RE,
   normalizeHaresField,
   stripHtmlTags,
 } from "../utils";
@@ -103,7 +104,10 @@ export function parseNextRunArticle(
   const titleMatch = /Run\s*#?\s*(\d+)/i.exec(text);
   const runNumber = titleMatch ? Number.parseInt(titleMatch[1], 10) : undefined;
 
-  const locationCandidate = locationRaw ?? runSite ?? station ?? restaurant ?? undefined;
+  // Strip "Google Map:" prefix from runSite — when the kennel uses that as the label it's not
+  // a useful venue name. Fall back to station (BTS stop etc.) when runSite is just a map label.
+  const runSiteClean = runSite && !/^Google\s*Map/i.test(runSite) ? runSite : undefined;
+  const locationCandidate = locationRaw ?? runSiteClean ?? station ?? restaurant ?? undefined;
   // Filter out empty/placeholder values
   const location = locationCandidate && locationCandidate.length > 1 ? locationCandidate : undefined;
   const locationUrl = googleMap && /^https?:\/\//.test(googleMap) ? googleMap : undefined;
@@ -184,7 +188,7 @@ export function parseHarelineApiHtml(
     let hares: string | undefined;
     if (runMatch) {
       const afterRun = infoText.slice(runMatch.index + runMatch[0].length).trim();
-      if (afterRun && !/^$/.test(afterRun)) {
+      if (afterRun && !HARE_BOILERPLATE_RE.test(afterRun)) {
         hares = normalizeHaresField(afterRun);
       }
     }

--- a/src/adapters/html-scraper/city-hash.ts
+++ b/src/adapters/html-scraper/city-hash.ts
@@ -10,6 +10,7 @@ import {
   chronoParseDate,
   parse12HourTime,
   fetchBrowserRenderedPage,
+  HARE_BOILERPLATE_RE,
   isPlaceholder,
 } from "../utils";
 
@@ -54,7 +55,8 @@ export function parseMakesweatEvent(
   if (descText) {
     const hareMatch = descText.match(/Hares?\s*[-–—]\s*(.+?)(?:\n|$)/i);
     if (hareMatch) {
-      hares = hareMatch[1].trim();
+      const raw = hareMatch[1].trim();
+      hares = HARE_BOILERPLATE_RE.test(raw) ? undefined : raw;
     }
   }
 

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -485,7 +485,7 @@ export async function fetchHTMLPage(url: string): Promise<FetchHTMLResult> {
  * The pipeline's sanitizeHares() is the authoritative safety net; adapter-level
  * usage is best-effort early cleanup.
  */
-export const HARE_BOILERPLATE_RE = /\s*\b(?:WHAT TIME|WHAT TO WEAR|WHERE|Location|HASH CASH|Cost|Price|Length|Distance|Directions|Trail Type|Trail is|Start|Meet at|Registration|WHAT IS THE COST|On-On|On On|Question|Call\s|Lost\?)[:\s].*|\s*\(\d{3}\)\s*\d{3}.*/i;
+export const HARE_BOILERPLATE_RE = /\s*\b(?:WHAT TIME|WHAT TO WEAR|WHERE|Location|HASH CASH|Cost|Price|Length|Distance|Directions|Trail Type|Trail is|Start|Meet at|Registration|WHAT IS THE COST|On-On|On On|Hares?\s+Needed|Question|Call\s|Lost\?)[:\s].*|\s*\(\d{3}\)\s*\d{3}.*/i;
 
 // ---------------------------------------------------------------------------
 // Non-English country name normalization


### PR DESCRIPTION
## Summary

- **bangkokhash.ts** — prefer station name over raw `Run Site: Google Map:` label for BTH3 location (#717); filter `On On` hash closing phrases from BFMH3 hareline hare extraction (#719)
- **google-calendar/adapter.ts** — add `On-Start:` as a location label (DST Stuttgart uses this in descriptions, #715); extend `NON_ADDRESS_RE` to reject `<kennel> start location` boilerplate; apply `isNonAddressText` guard inside `extractLocationFromDescription` to prevent label-like text leaking through the description fallback path (#716)
- **city-hash.ts** — discard CTA hare text ("Hare Needed! Please contact ...") via `HARE_BOILERPLATE_RE` (#718)
- **utils.ts** — add `Hares? Needed` to `HARE_BOILERPLATE_RE`
- **seed** — add Boston H3 `logoUrl` (#712)

## Closed via DB operations (not code changes)
- #692 #693 #694 #695 — BCH3 profile (seed + fix script from PR #710 applied)
- #701 — Beantown hash cash (seed applied)
- #664 — AVLH3 backfill (PR #709 already merged)
- #642 #641 #640 — AH4 (source down; won't-fix)
- #702 #703 #696 #697 — Schema gaps / unstable logos (won't-fix)

## Test plan

- [x] `npm test` — 199 files, 4419 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] New test cases added for bangkokhash: "Google Map:" station fallback and "On On" hare boilerplate filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)