### PR TITLE
fix(hareline): auto-switch to All Kennels scope when region filter is active

### DIFF
--- a/src/components/hareline/HarelineView.test.ts
+++ b/src/components/hareline/HarelineView.test.ts
@@ -1,0 +1,36 @@
+import { computeInitialScope } from "./HarelineView";
+
+describe("computeInitialScope", () => {
+  test("explicit scope=my wins even with regions present", () => {
+    expect(computeInitialScope("my", "Boston, MA", "all")).toBe("my");
+  });
+
+  test("explicit scope=all wins", () => {
+    expect(computeInitialScope("all", null, "my")).toBe("all");
+  });
+
+  test("regions present with no explicit scope → always returns all", () => {
+    expect(computeInitialScope(null, "Boston, MA", "my")).toBe("all");
+  });
+
+  test("pipe-separated multi-region with no explicit scope → all", () => {
+    expect(computeInitialScope(null, "Boston, MA|NYC", "my")).toBe("all");
+  });
+
+  test("no regions and no explicit scope → uses defaultScope (my)", () => {
+    expect(computeInitialScope(null, null, "my")).toBe("my");
+  });
+
+  test("no regions and no explicit scope → uses defaultScope (all)", () => {
+    expect(computeInitialScope(null, null, "all")).toBe("all");
+  });
+
+  test("empty string regions → uses defaultScope", () => {
+    expect(computeInitialScope(null, "", "my")).toBe("my");
+  });
+
+  test("invalid scope param is ignored → falls through to region check", () => {
+    // 'mine' is not a valid scope value, so falls through to region check
+    expect(computeInitialScope("mine", "Boston, MA", "my")).toBe("all");
+  });
+});

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -303,6 +303,12 @@ export function HarelineView({
         ...overrides,
       };
 
+      // When regions are active, the effective default scope is "all" (see computeInitialScope).
+      // We must persist an explicit scope=my to the URL so a page refresh doesn't
+      // re-promote it back to "all".
+      const effectiveRegions = state.regions as string[];
+      const effectiveDefaultScope = effectiveRegions.length > 0 ? "all" : defaultScope;
+
       for (const [key, val] of Object.entries(state)) {
         const str = Array.isArray(val) ? val.join("|") : val;
         // Only add non-default values to keep URL clean
@@ -310,7 +316,7 @@ export function HarelineView({
           (key === "time" && str === getDefaultTimeFilter(currentView)) ||
           (key === "view" && str === "list") ||
           (key === "density" && str === "medium") ||
-          (key === "scope" && str === defaultScope) ||
+          (key === "scope" && str === effectiveDefaultScope) ||
           str === "";
         if (!isDefault) {
           params.set(key, str);

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -186,7 +186,6 @@ function getDefaultTimeFilter(v: ViewMode): TimeFilter {
 type ViewMode = "list" | "calendar" | "map";
 
 /**
- * Determines the initial scope for the hareline.
  * When a region filter is pre-applied (from the URL), default to "all" so the
  * user sees every kennel in that region, not just ones they're subscribed to.
  * An explicit ?scope= param always wins.
@@ -230,11 +229,12 @@ export function HarelineView({
     return getDefaultTimeFilter(initialView);
   });
 
-  const initialRegions = parseList(searchParams.get("regions"));
   const [scope, setScopeState] = useState<"my" | "all">(
     computeInitialScope(searchParams.get("scope"), searchParams.get("regions"), defaultScope),
   );
-  const [selectedRegions, setSelectedRegionsState] = useState<string[]>(initialRegions);
+  const [selectedRegions, setSelectedRegionsState] = useState<string[]>(
+    parseList(searchParams.get("regions")),
+  );
   const [selectedKennels, setSelectedKennelsState] = useState<string[]>(
     parseList(searchParams.get("kennels")),
   );

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -497,7 +497,6 @@ export function HarelineView({
         syncUrl({ regions: [region] });
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [syncUrl, scope],
   );
 

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -185,6 +185,22 @@ function getDefaultTimeFilter(v: ViewMode): TimeFilter {
 
 type ViewMode = "list" | "calendar" | "map";
 
+/**
+ * Determines the initial scope for the hareline.
+ * When a region filter is pre-applied (from the URL), default to "all" so the
+ * user sees every kennel in that region, not just ones they're subscribed to.
+ * An explicit ?scope= param always wins.
+ */
+export function computeInitialScope(
+  scopeParam: string | null,
+  regionsParam: string | null,
+  defaultScope: "my" | "all",
+): "my" | "all" {
+  if (scopeParam === "my" || scopeParam === "all") return scopeParam;
+  if (regionsParam && regionsParam.length > 0) return "all";
+  return defaultScope;
+}
+
 export function HarelineView({
   events,
   subscribedKennelIds,
@@ -214,12 +230,11 @@ export function HarelineView({
     return getDefaultTimeFilter(initialView);
   });
 
+  const initialRegions = parseList(searchParams.get("regions"));
   const [scope, setScopeState] = useState<"my" | "all">(
-    (searchParams.get("scope") as "my" | "all") || defaultScope,
+    computeInitialScope(searchParams.get("scope"), searchParams.get("regions"), defaultScope),
   );
-  const [selectedRegions, setSelectedRegionsState] = useState<string[]>(
-    parseList(searchParams.get("regions")),
-  );
+  const [selectedRegions, setSelectedRegionsState] = useState<string[]>(initialRegions);
   const [selectedKennels, setSelectedKennelsState] = useState<string[]>(
     parseList(searchParams.get("kennels")),
   );

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -359,7 +359,12 @@ export function HarelineView({
     setSelectedRegionsState(v);
     setPrefApplied(null);
     resetListState();
-    syncUrl({ regions: v });
+    if (v.length > 0 && scope === "my") {
+      setScopeState("all");
+      syncUrl({ regions: v, scope: "all" });
+    } else {
+      syncUrl({ regions: v });
+    }
   }
   function setSelectedKennels(v: string[]) {
     setSelectedKennelsState(v);
@@ -485,10 +490,15 @@ export function HarelineView({
     (region: string) => {
       setSelectedRegionsState([region]);
       resetListState();
-      syncUrl({ regions: [region] });
+      if (scope === "my") {
+        setScopeState("all");
+        syncUrl({ regions: [region], scope: "all" });
+      } else {
+        syncUrl({ regions: [region] });
+      }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [syncUrl],
+    [syncUrl, scope],
   );
 
   // Track when a stored preference was auto-applied (for return-visitor banner)


### PR DESCRIPTION
## Summary

- When a user lands on `/hareline?regions=Boston%2C+MA`, the scope now defaults to **All Kennels** instead of My Kennels, so events from all kennels in that region are visible (not just subscribed ones)
- When a user interactively selects a region while in My Kennels scope, the scope auto-switches to All Kennels
- An explicit `?scope=my` URL param always overrides this behavior

## Root Cause

The hareline defaulted to `"my"` scope for authenticated users with subscriptions, regardless of any `regions` param. A user navigating to a region-filtered URL would silently see only their subscribed kennels — missing events like the Pink Taco Trotters run that prompted this fix.

## Changes

- `computeInitialScope()` — new exported pure function that returns `"all"` when `regionsParam` is present and no explicit `scope` param overrides it
- `setSelectedRegions` / `handleRegionFilter` — both auto-switch scope to `"all"` when a region is selected while scope is `"my"`
- 8 unit tests covering all branches of `computeInitialScope`

## Test Plan

- [ ] `GET /hareline?regions=Boston%2C+MA` — scope defaults to All Kennels, Pink Taco Trotters events visible
- [ ] `GET /hareline?scope=my&regions=Boston%2C+MA` — explicit `scope=my` is respected, My Kennels shown
- [ ] Navigate to `/hareline` in My Kennels scope → select a region → scope auto-switches to All Kennels
- [ ] `npm test` passes (200/200 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)