### PR TITLE
fix(adapters): City H3 CTA hare filter + Harrier Central GCal description boilerplate

### DIFF
--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -12,6 +12,7 @@ import {
   extractLocationFromDescription,
   extractTimeFromDescription,
   buildRawEventFromGCalItem,
+  normalizeGCalDescription,
 } from "./adapter";
 import type { RawEventData } from "../types";
 
@@ -1773,5 +1774,39 @@ describe("applyInlineHarelineBackfill (#498)", () => {
       makeEvent({ date: "2026-09-01" }), // empty too
     ];
     expect(applyInlineHarelineBackfill(events, pattern, { now })).toBe(0);
+  });
+});
+
+// ── normalizeGCalDescription ──
+
+describe("normalizeGCalDescription", () => {
+  it("strips Harrier Central boilerplate prefix from GCal-synced descriptions (#724)", () => {
+    const raw = "Morgantown H3\nLocation: WVU Coliseum\nDescription: In case yall don't know, I'm conquering a marathon in each state!";
+    const result = normalizeGCalDescription(raw);
+    expect(result.description).toBe("In case yall don't know, I'm conquering a marathon in each state!");
+    expect(result.description).not.toContain("Morgantown H3");
+    expect(result.description).not.toContain("Location:");
+    expect(result.description).not.toContain("Description:");
+  });
+
+  it("strips HC boilerplate when description spans multiple lines", () => {
+    const raw = "Tokyo H3\nLocation: Waseda Station\nDescription: Meet at the west exit.\nBring cash.";
+    const result = normalizeGCalDescription(raw);
+    expect(result.description).toBe("Meet at the west exit.\nBring cash.");
+    expect(result.description).not.toContain("Tokyo H3");
+  });
+
+  it("does not alter normal GCal descriptions without HC boilerplate", () => {
+    const raw = "A beautiful trail through the park\nHare: Indiana Bones\nWhere: Central Park";
+    const result = normalizeGCalDescription(raw);
+    expect(result.description).toContain("A beautiful trail through the park");
+    expect(result.description).toContain("Hare: Indiana Bones");
+  });
+
+  it("does not strip when Location: appears mid-description (not in HC header position)", () => {
+    const raw = "Trail notes\nLocation: Central Park — meet at the fountain\nBring water";
+    const result = normalizeGCalDescription(raw);
+    // No "Description:" label after Location:, so it is NOT the HC boilerplate pattern
+    expect(result.description).toContain("Trail notes");
   });
 });

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -443,11 +443,14 @@ function extractDateTimeFromGCalItem(start: { dateTime?: string; date?: string }
 }
 
 /** Strip HTML from description, preserving newlines, and truncate. */
-function normalizeGCalDescription(rawDesc: string | undefined): { rawDescription: string | undefined; description: string | undefined } {
+export function normalizeGCalDescription(rawDesc: string | undefined): { rawDescription: string | undefined; description: string | undefined } {
   if (!rawDesc) return { rawDescription: undefined, description: undefined };
   let rawDescription = stripHtmlTags(decodeEntities(rawDesc), "\n");
   // Strip mailto: link artifacts: "text (mailto:email)" → "text"
   rawDescription = rawDescription.replace(/\s*\(mailto:[^)]+\)/g, "");
+  // Strip Harrier Central auto-generated header from GCal-synced events:
+  // "{KennelName}\nLocation: {venue}\nDescription: {actual text}" → "{actual text}"
+  rawDescription = rawDescription.replace(/^[^\n]*\nLocation:[^\n]*\nDescription:\s*/i, "");
   const description = rawDescription
     ? rawDescription.replace(/[ \t]+/g, " ").trim().substring(0, 2000) || undefined
     : undefined;

--- a/src/adapters/html-scraper/city-hash.test.ts
+++ b/src/adapters/html-scraper/city-hash.test.ts
@@ -151,6 +151,22 @@ describe("parseMakesweatEvent", () => {
     expect(event!.location).toBeUndefined();
   });
 
+  it("filters CTA hare text as undefined (#726)", () => {
+    // Source description: "Hare Needed! Please contact Full Load" — the "Hare" prefix
+    // with dash separator is how Makesweat formats the field, producing a CTA as the value
+    const ctaHtml = `<div class="ms_event makesweatevent-99999">
+      <div class="ms_eventtitle">City Hash R*n #1920 @ TBA</div>
+      <div class="ms_event_startdate">Tue 21st Apr 26</div>
+      <div class="ms_eventstart">7:00pm</div>
+      <div class="ms_eventdescription">Hare - Hare Needed! Please contact Full Load
+Pub - TBA</div>
+      <div class="ms_venue_name">TBA</div>
+    </div>`;
+    const $cta = cheerio.load(ctaHtml);
+    const event = parseMakesweatEvent($cta, $cta(".ms_event").eq(0), "https://makesweat.com/cityhash#hashes");
+    expect(event?.hares).toBeUndefined();
+  });
+
   it("extracts Makesweat ID from class attribute", () => {
     expect(extractMakesweatId(cards.eq(0))).toBe("12345");
   });

--- a/src/adapters/html-scraper/city-hash.ts
+++ b/src/adapters/html-scraper/city-hash.ts
@@ -56,7 +56,10 @@ export function parseMakesweatEvent(
     const hareMatch = descText.match(/Hares?\s*[-–—]\s*(.+?)(?:\n|$)/i);
     if (hareMatch) {
       const raw = hareMatch[1].trim();
-      hares = HARE_BOILERPLATE_RE.test(raw) ? undefined : raw;
+      const isCta = HARE_BOILERPLATE_RE.test(raw)
+        || /^(?:hare\s+)?needed\b/i.test(raw)
+        || /^please\s+contact\b/i.test(raw);
+      hares = isCta ? undefined : raw;
     }
   }
 


### PR DESCRIPTION
## Fixes

- **#726** City H3 (`city-hash.ts`): `parseMakesweatEvent()` was storing CTA text like \"Hare Needed! Please contact Full Load\" as the hare name. Added guard that filters text matching `^(?:hare\s+)?needed\b` or `^please\s+contact\b` patterns as `undefined`.

- **#724** Google Calendar (`adapter.ts`): GCal descriptions for kennels that sync from Harrier Central include a structured header block (`{KennelName}\nLocation: {venue}\nDescription: {actual text}`). `normalizeGCalDescription()` now strips this prefix before storing the description.

## Test plan
- [ ] `npx vitest run src/adapters/html-scraper/city-hash.test.ts` — 19 tests pass
- [ ] `npx vitest run src/adapters/google-calendar/adapter.test.ts` — 210 tests pass
- [ ] Full suite: `npx tsc --noEmit && npm run lint && npm test` — 200 files, 4436 tests pass
- [ ] Closes #726, #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)