### PR TITLE
fix(logbook): allow RSVP for same-day future events

### DIFF
--- a/src/app/logbook/actions.test.ts
+++ b/src/app/logbook/actions.test.ts
@@ -187,10 +187,12 @@ describe("rsvp", () => {
     expect(result).toEqual({ error: "Can only RSVP to future events" });
   });
 
-  it("returns error for today's event (use check-in instead)", async () => {
+  it("allows RSVP for today's event (same-day future event)", async () => {
     mockEventFind.mockResolvedValueOnce({ id: "evt_1", date: utcNoonDate(0) } as never);
+    mockAttFind.mockResolvedValueOnce(null);
+    mockAttCreate.mockResolvedValueOnce({ id: "att_1" } as never);
     const result = await rsvp("evt_1");
-    expect(result).toEqual({ error: "Can only RSVP to future events" });
+    expect(result).toEqual({ success: true, attendanceId: "att_1", toggled: "on" });
   });
 
   it("creates INTENDING attendance for future event", async () => {

--- a/src/app/logbook/actions.test.ts
+++ b/src/app/logbook/actions.test.ts
@@ -184,7 +184,7 @@ describe("rsvp", () => {
   it("returns error for past events", async () => {
     mockEventFind.mockResolvedValueOnce({ id: "evt_1", date: utcNoonDate(-1) } as never);
     const result = await rsvp("evt_1");
-    expect(result).toEqual({ error: "Can only RSVP to future events" });
+    expect(result).toEqual({ error: "Can only RSVP to today's or future events" });
   });
 
   it("allows RSVP for today's event (same-day future event)", async () => {

--- a/src/app/logbook/actions.ts
+++ b/src/app/logbook/actions.ts
@@ -136,9 +136,9 @@ export async function rsvp(eventId: string) {
   });
   if (!event) return { error: "Event not found" };
 
-  // Validate event is in the future — today's events can be checked in, not RSVP'd
+  // Validate event is today or in the future
   const todayUtcNoon = getTodayUtcNoon();
-  if (event.date.getTime() <= todayUtcNoon) {
+  if (event.date.getTime() < todayUtcNoon) {
     return { error: "Can only RSVP to future events" };
   }
 

--- a/src/app/logbook/actions.ts
+++ b/src/app/logbook/actions.ts
@@ -139,7 +139,7 @@ export async function rsvp(eventId: string) {
   // Validate event is today or in the future
   const todayUtcNoon = getTodayUtcNoon();
   if (event.date.getTime() < todayUtcNoon) {
-    return { error: "Can only RSVP to future events" };
+    return { error: "Can only RSVP to today's or future events" };
   }
 
   // Toggle: if already INTENDING, remove it

--- a/src/app/logbook/page.tsx
+++ b/src/app/logbook/page.tsx
@@ -79,7 +79,7 @@ export default async function LogbookPage() {
   ).size;
   const todayUtcNoon = getTodayUtcNoon();
   const goingCount = entries.filter(
-    (e) => e.attendance.status === "INTENDING" && new Date(e.event.date).getTime() > todayUtcNoon
+    (e) => e.attendance.status === "INTENDING" && new Date(e.event.date).getTime() >= todayUtcNoon
   ).length;
 
   const description = `${confirmedCount} ${confirmedCount === 1 ? "run" : "runs"} logged${

--- a/src/components/logbook/LogbookList.tsx
+++ b/src/components/logbook/LogbookList.tsx
@@ -89,10 +89,10 @@ export function filterLogbookEntries(
   });
 }
 
-/** Check whether a logbook entry represents a future RSVP. */
+/** Check whether a logbook entry represents an upcoming RSVP (today or future). */
 function isUpcomingEntry(entry: LogbookEntry, todayUtcNoon: number): boolean {
   return entry.attendance.status === "INTENDING"
-    && new Date(entry.event.date).getTime() > todayUtcNoon;
+    && new Date(entry.event.date).getTime() >= todayUtcNoon;
 }
 
 /** Derive a status label for accessibility (screen reader row summary). */


### PR DESCRIPTION
## Summary

- Events are stored as UTC noon regardless of actual start time
- The RSVP guard used `<=` when comparing `event.date.getTime()` against `todayUtcNoon`, so same-day events (date == todayUtcNoon) were incorrectly rejected
- A 6:30 PM event on today's date would return "Can only RSVP to future events" at 10 AM ET

## Root Cause

`src/app/logbook/actions.ts` line 141:
```ts
// Before (broken)
if (event.date.getTime() <= todayUtcNoon) {

// After (fixed)
if (event.date.getTime() < todayUtcNoon) {
```

Using `<=` means `today == todayUtcNoon` evaluates true and blocks the RSVP. Changing to `<` means only strictly-past events (yesterday and earlier) are blocked — same-day events pass through.

The mirror check-in guard already uses `>` (not `>=`) at line 30, so this brings RSVP into alignment with that pattern.

## Test Plan

- [x] Updated the test that was asserting the wrong behavior ("today's event → error") — it now correctly expects RSVP success for today's events
- [x] All 4436 tests pass (`200 test files passed`)
- [x] Reproduces the exact scenario from the bug report: same-day future event RSVP now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)