### PR TITLE
fix(filters): region names with commas break URL filter on page refresh

### DIFF
--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -19,7 +19,7 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
 import { EventCard, type HarelineEvent } from "./EventCard";
-import { getDayOfWeek, formatDateLong, parseList } from "@/lib/format";
+import { getDayOfWeek, formatDateLong, parseList, parseRegionParam } from "@/lib/format";
 import { FilterBar } from "@/components/shared/FilterBar";
 import { resolveCountryName } from "@/lib/region";
 import { EmptyState } from "./EmptyState";
@@ -233,7 +233,7 @@ export function HarelineView({
     computeInitialScope(searchParams.get("scope"), searchParams.get("regions"), defaultScope),
   );
   const [selectedRegions, setSelectedRegionsState] = useState<string[]>(
-    parseList(searchParams.get("regions")),
+    parseRegionParam(searchParams.get("regions")),
   );
   const [selectedKennels, setSelectedKennelsState] = useState<string[]>(
     parseList(searchParams.get("kennels")),

--- a/src/components/kennels/KennelDirectory.tsx
+++ b/src/components/kennels/KennelDirectory.tsx
@@ -16,7 +16,7 @@ import { groupRegionsByState, expandRegionSelections, regionAbbrev, resolveCount
 import { LocationPrompt } from "@/components/hareline/LocationPrompt";
 import { RegionQuickChips } from "@/components/hareline/RegionQuickChips";
 import { getLocationPref, resolveLocationDefault, clearLocationPref } from "@/lib/location-pref";
-import { parseList } from "@/lib/format";
+import { parseList, parseRegionParam } from "@/lib/format";
 import { getActivityStatus } from "@/lib/activity-status";
 
 const KennelMapView = dynamic(() => import("./KennelMapView"), {
@@ -40,7 +40,7 @@ export function KennelDirectory({ kennels }: KennelDirectoryProps) {
   // Initialize state from URL params
   const [search, setSearchState] = useState(searchParams.get("q") ?? "");
   const [selectedRegions, setSelectedRegionsState] = useState<string[]>(
-    parseList(searchParams.get("regions")),
+    parseRegionParam(searchParams.get("regions")),
   );
   const [selectedDays, setSelectedDaysState] = useState<string[]>(
     parseList(searchParams.get("days")),

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -307,11 +307,17 @@ describe("parseList", () => {
   it("returns [] for empty string", () => {
     expect(parseList("")).toEqual([]);
   });
+  it("returns [] for whitespace-only string", () => {
+    expect(parseList("   ")).toEqual([]);
+  });
   it("returns single plain value", () => {
     expect(parseList("Mon")).toEqual(["Mon"]);
   });
   it("splits pipe-delimited plain values", () => {
     expect(parseList("Mon|Tue")).toEqual(["Mon", "Tue"]);
+  });
+  it("trims whitespace around pipe-delimited segments", () => {
+    expect(parseList("Mon | Tue")).toEqual(["Mon", "Tue"]);
   });
   it("splits comma-delimited values (legacy days/kennels backward compat)", () => {
     expect(parseList("Mon,Tue")).toEqual(["Mon", "Tue"]);
@@ -325,11 +331,17 @@ describe("parseRegionParam", () => {
   it("returns [] for empty string", () => {
     expect(parseRegionParam("")).toEqual([]);
   });
+  it("returns [] for whitespace-only string", () => {
+    expect(parseRegionParam("   ")).toEqual([]);
+  });
   it("returns single region name with comma intact", () => {
     expect(parseRegionParam("Boston, MA")).toEqual(["Boston, MA"]);
   });
   it("splits pipe-delimited region names containing commas", () => {
     expect(parseRegionParam("Boston, MA|Cambridge, MA")).toEqual(["Boston, MA", "Cambridge, MA"]);
+  });
+  it("trims whitespace around pipe-delimited region segments", () => {
+    expect(parseRegionParam("Boston, MA | NYC")).toEqual(["Boston, MA", "NYC"]);
   });
   it("returns single plain value", () => {
     expect(parseRegionParam("NYC")).toEqual(["NYC"]);

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -17,6 +17,8 @@ import {
   stripMarkdown,
   stripUrlsFromText,
   formatRelativeTime,
+  parseList,
+  parseRegionParam,
 } from "./format";
 
 describe("formatTime", () => {
@@ -295,5 +297,41 @@ describe("formatRelativeTime", () => {
   });
   it("accepts ISO string input", () => {
     expect(formatRelativeTime(new Date(NOW - 10 * 60_000).toISOString())).toBe("10m ago");
+  });
+});
+
+describe("parseList", () => {
+  it("returns [] for null", () => {
+    expect(parseList(null)).toEqual([]);
+  });
+  it("returns [] for empty string", () => {
+    expect(parseList("")).toEqual([]);
+  });
+  it("returns single plain value", () => {
+    expect(parseList("Mon")).toEqual(["Mon"]);
+  });
+  it("splits pipe-delimited plain values", () => {
+    expect(parseList("Mon|Tue")).toEqual(["Mon", "Tue"]);
+  });
+  it("splits comma-delimited values (legacy days/kennels backward compat)", () => {
+    expect(parseList("Mon,Tue")).toEqual(["Mon", "Tue"]);
+  });
+});
+
+describe("parseRegionParam", () => {
+  it("returns [] for null", () => {
+    expect(parseRegionParam(null)).toEqual([]);
+  });
+  it("returns [] for empty string", () => {
+    expect(parseRegionParam("")).toEqual([]);
+  });
+  it("returns single region name with comma intact", () => {
+    expect(parseRegionParam("Boston, MA")).toEqual(["Boston, MA"]);
+  });
+  it("splits pipe-delimited region names containing commas", () => {
+    expect(parseRegionParam("Boston, MA|Cambridge, MA")).toEqual(["Boston, MA", "Cambridge, MA"]);
+  });
+  it("returns single plain value", () => {
+    expect(parseRegionParam("NYC")).toEqual(["NYC"]);
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -109,10 +109,11 @@ export function toggleArrayItem<T>(array: T[], value: T): T[] {
  * Do NOT use this for region params — use parseRegionParam instead.
  */
 export function parseList(value: string | null): string[] {
-  if (!value) return [];
-  if (value.includes("|")) return value.split("|").filter(Boolean);
-  if (value.includes(",")) return value.split(",").map(s => s.trim()).filter(Boolean);
-  return [value];
+  const trimmed = value?.trim();
+  if (!trimmed) return [];
+  if (trimmed.includes("|")) return trimmed.split("|").map(s => s.trim()).filter(Boolean);
+  if (trimmed.includes(",")) return trimmed.split(",").map(s => s.trim()).filter(Boolean);
+  return [trimmed];
 }
 
 /**
@@ -120,9 +121,10 @@ export function parseList(value: string | null): string[] {
  * contain commas (e.g. "Boston, MA"). Pipe is the only multi-value delimiter.
  */
 export function parseRegionParam(value: string | null): string[] {
-  if (!value) return [];
-  if (value.includes("|")) return value.split("|").filter(Boolean);
-  return [value];
+  const trimmed = value?.trim();
+  if (!trimmed) return [];
+  if (trimmed.includes("|")) return trimmed.split("|").map(s => s.trim()).filter(Boolean);
+  return [trimmed];
 }
 
 /**

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -103,25 +103,33 @@ export function toggleArrayItem<T>(array: T[], value: T): T[] {
 // ── URL param helpers (shared by KennelDirectory + HarelineView) ──
 
 /**
- * Parse a pipe-separated URL param into an array of non-empty strings.
- * Uses `|` as the delimiter because region names can contain commas
- * (e.g. "Houston, TX") which broke the old comma-delimited format.
+ * Parse a pipe-or-comma-separated URL param into an array of non-empty strings.
+ * Pipe is the current format; comma is accepted for backward compat with legacy
+ * bookmarked URLs for params whose values never contain commas (e.g. days, kennels).
+ * Do NOT use this for region params — use parseRegionParam instead.
  */
 export function parseList(value: string | null): string[] {
   if (!value) return [];
-  // Pipe is the primary delimiter (new format)
   if (value.includes("|")) return value.split("|").filter(Boolean);
-  // Comma fallback for legacy URLs (days, kennels — values don't contain commas)
   if (value.includes(",")) return value.split(",").map(s => s.trim()).filter(Boolean);
-  // Single value
-  return [value].filter(Boolean);
+  return [value];
+}
+
+/**
+ * Parse a region URL param without splitting on commas, since region names
+ * contain commas (e.g. "Boston, MA"). Pipe is the only multi-value delimiter.
+ */
+export function parseRegionParam(value: string | null): string[] {
+  if (!value) return [];
+  if (value.includes("|")) return value.split("|").filter(Boolean);
+  return [value];
 }
 
 /**
  * Parse region URL param with backward compat — resolves old name strings to slugs.
  */
 export function parseRegionList(value: string | null): string[] {
-  const raw = parseList(value);
+  const raw = parseRegionParam(value);
   return raw.map((v) => regionNameToSlug(v) ?? v);
 }
 


### PR DESCRIPTION
## Summary

- Selecting a region like "Boston, MA" and refreshing the page caused 0 results — the URL param `?regions=Boston%2C+MA` was parsed by a comma-splitting fallback in `parseList()`, producing two phantom filters `["Boston", "MA"]` instead of one
- Introduces `parseRegionParam()` in `src/lib/format.ts`: pipe-only parsing (no comma split), used for all `regions` URL params
- `parseList()` retains its comma fallback for backward compat with legacy bookmarked `?days=Mon,Tue` / `?kennels=A,B` URLs
- `parseRegionList()` updated to call `parseRegionParam` so the slug-resolution path is also safe

## Changes

- **`src/lib/format.ts`** — add `parseRegionParam()`, update `parseRegionList()` to use it, clean up JSDoc
- **`src/components/hareline/HarelineView.tsx`** — swap `parseList` → `parseRegionParam` for `regions` param init
- **`src/components/kennels/KennelDirectory.tsx`** — same swap
- **`src/lib/format.test.ts`** — add `parseList` and `parseRegionParam` test suites (83 tests passing)

## Test Plan

- [ ] Select "Boston, MA" in the region filter on `/hareline` — verify events load correctly
- [ ] Refresh the page — verify "Boston, MA" chip still shows and events still load (was broken before)
- [ ] Select multiple regions including comma-names (e.g. "Boston, MA" + "Cambridge, MA") — verify both chips persist after refresh
- [ ] Verify legacy day filter URLs like `?days=Mon,Tue` still parse correctly (backward compat)
- [ ] `npm test` — 83 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)