### PR TITLE
fix: audit rules, geo guard, wide re-scrape, HC link rot

### DIFF
--- a/scripts/clear-hc-sourceurls.ts
+++ b/scripts/clear-hc-sourceurls.ts
@@ -1,0 +1,66 @@
+/**
+ * One-shot backfill: null out Event.sourceUrl where it points at the broken
+ * hashruns.org Flutter UI. HARRIER_CENTRAL events used to emit
+ * `https://www.hashruns.org/#/event/<uuid>` URLs; the API still serves the
+ * UUIDs but the Flutter page no longer resolves them (#706, #725).
+ *
+ * The adapter has already been changed to stop emitting these URLs for new
+ * events — this script clears the existing rows. Merge.ts preserves existing
+ * sourceUrl ahead of new adapter output, so without this script the broken
+ * URLs would persist for already-ingested events.
+ *
+ * Usage:
+ *   npx tsx scripts/clear-hc-sourceurls.ts           # dry run (default)
+ *   npx tsx scripts/clear-hc-sourceurls.ts --apply   # apply changes
+ *
+ * Load env before running (tsx does not auto-load .env):
+ *   set -a && source .env && set +a
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const dryRun = !process.argv.includes("--apply");
+
+async function main() {
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
+
+  const affected = await prisma.event.findMany({
+    where: { sourceUrl: { contains: "hashruns.org" } },
+    select: { id: true, sourceUrl: true, kennel: { select: { shortName: true } } },
+  });
+
+  console.log(`Found ${affected.length} Event(s) with hashruns.org sourceUrl.`);
+  if (affected.length === 0) {
+    await pool.end();
+    return;
+  }
+
+  for (const e of affected.slice(0, 10)) {
+    console.log(`  ${e.id}  ${e.kennel.shortName}  ${e.sourceUrl}`);
+  }
+  if (affected.length > 10) console.log(`  … and ${affected.length - 10} more`);
+
+  if (dryRun) {
+    console.log("\n(dry run) re-run with --apply to null these URLs.");
+    await pool.end();
+    return;
+  }
+
+  const res = await prisma.event.updateMany({
+    where: { sourceUrl: { contains: "hashruns.org" } },
+    data: { sourceUrl: null },
+  });
+  console.log(`\n✅ Nulled sourceUrl on ${res.count} Event(s).`);
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/clear-hc-sourceurls.ts
+++ b/scripts/clear-hc-sourceurls.ts
@@ -31,7 +31,7 @@ async function main() {
   console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
 
   const affected = await prisma.event.findMany({
-    where: { sourceUrl: { contains: "hashruns.org" } },
+    where: { sourceUrl: { contains: "hashruns.org/#/event/" } },
     select: { id: true, sourceUrl: true, kennel: { select: { shortName: true } } },
   });
 
@@ -53,7 +53,7 @@ async function main() {
   }
 
   const res = await prisma.event.updateMany({
-    where: { sourceUrl: { contains: "hashruns.org" } },
+    where: { sourceUrl: { contains: "hashruns.org/#/event/" } },
     data: { sourceUrl: null },
   });
   console.log(`\n✅ Nulled sourceUrl on ${res.count} Event(s).`);

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -103,7 +103,9 @@ describe("HarrierCentralAdapter", () => {
       expect(evt.location).toBe("Yamanote, Tozai lines. Waseda exit");
       expect(evt.latitude).toBeCloseTo(35.713, 2);
       expect(evt.longitude).toBeCloseTo(139.704, 2);
-      expect(evt.sourceUrl).toContain(hcEvent.publicEventId);
+      // sourceUrl is intentionally omitted — hashruns.org/#/event/... links
+      // no longer resolve in the Flutter UI (#706, #725).
+      expect(evt.sourceUrl).toBeUndefined();
     });
 
     it("skips invisible events", async () => {

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -159,6 +159,11 @@ export class HarrierCentralAdapter implements SourceAdapter {
         hares = undefined;
       }
 
+      // Intentionally no sourceUrl: the hashruns.org Flutter UI can no longer
+      // resolve `https://www.hashruns.org/#/event/${publicEventId}` links
+      // (#706, #725). The REST API still serves the UUIDs so scrapes succeed,
+      // but the user-facing detail page is dead. Event detail pages fall back
+      // to the kennel website / other EventLinks when sourceUrl is null.
       const raw: RawEventData = {
         date: dateStr,
         kennelTag,
@@ -169,7 +174,6 @@ export class HarrierCentralAdapter implements SourceAdapter {
         location,
         latitude: hcEvent.syncLat != null ? hcEvent.syncLat : undefined,
         longitude: hcEvent.syncLong != null ? hcEvent.syncLong : undefined,
-        sourceUrl: `https://www.hashruns.org/#/event/${hcEvent.publicEventId}`,
       };
 
       events.push(raw);

--- a/src/adapters/html-scraper/new-tokyo-katch.test.ts
+++ b/src/adapters/html-scraper/new-tokyo-katch.test.ts
@@ -2,6 +2,7 @@ import {
   parseNtkDate,
   parseNtkRow,
   buildColumnMap,
+  overseasCountryOverride,
   NewTokyoKatchAdapter,
 } from "./new-tokyo-katch";
 import type { Source } from "@/generated/prisma/client";
@@ -161,6 +162,55 @@ describe("NewTokyoKatchAdapter", () => {
       const run = parseNtkRow(cells, columnMap);
       expect(run).not.toBeNull();
       expect(run!.hares).toBe("Hash Master");
+    });
+  });
+
+  describe("overseasCountryOverride", () => {
+    it("returns '' (no-bias sentinel) for REMARK containing 'Overseas' (#741)", () => {
+      expect(overseasCountryOverride("Annual Overseas Run")).toBe("");
+      expect(overseasCountryOverride("OVERSEAS trip")).toBe("");
+    });
+
+    it("returns undefined for domestic REMARK", () => {
+      expect(overseasCountryOverride("Bring rain gear")).toBeUndefined();
+      expect(overseasCountryOverride("Cherry blossom run")).toBeUndefined();
+    });
+
+    it("returns undefined for empty or missing remark", () => {
+      expect(overseasCountryOverride(undefined)).toBeUndefined();
+      expect(overseasCountryOverride("")).toBeUndefined();
+    });
+  });
+
+  describe("overseas row propagates countryOverride", () => {
+    it("emits countryOverride='' in RawEventData for an overseas row", async () => {
+      const mockHtml = `<!DOCTYPE html><html><body>
+        <table>
+          <thead>
+            <tr><th>DATE</th><th>RUN</th><th>VENUE</th><th>LINE</th><th>HARE</th><th>SWEEP</th><th>REMARK</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>17-Apr-2026</td><td>70</td><td>Taoyuan</td><td>TBC</td><td>TBC</td><td>TBC</td><td>Annual Overseas Run</td>
+            </tr>
+            <tr>
+              <td>24-Apr-2026</td><td>71</td><td>Shibuya</td><td>Ginza Line</td><td>Sushi Roll</td><td></td><td>Bring rain gear</td>
+            </tr>
+          </tbody>
+        </table>
+      </body></html>`;
+      const { browserRender } = await import("@/lib/browser-render");
+      vi.mocked(browserRender).mockResolvedValue(mockHtml);
+      const adapter = new NewTokyoKatchAdapter();
+      const result = await adapter.fetch({
+        id: "test",
+        url: "https://newtokyohash.wixsite.com/newtokyokatchhash/hareline",
+        config: {},
+      } as unknown as Source, { days: 365 });
+      const overseas = result.events.find((e) => e.runNumber === 70);
+      const domestic = result.events.find((e) => e.runNumber === 71);
+      expect(overseas?.countryOverride).toBe("");
+      expect(domestic?.countryOverride).toBeUndefined();
     });
   });
 

--- a/src/adapters/html-scraper/new-tokyo-katch.test.ts
+++ b/src/adapters/html-scraper/new-tokyo-katch.test.ts
@@ -176,6 +176,11 @@ describe("NewTokyoKatchAdapter", () => {
       expect(overseasCountryOverride("Cherry blossom run")).toBeUndefined();
     });
 
+    it("matches 'overseas' only as a whole word", () => {
+      // Word-boundary anchors avoid matching 'overseasoned' or similar substrings.
+      expect(overseasCountryOverride("overseasoned")).toBeUndefined();
+    });
+
     it("returns undefined for empty or missing remark", () => {
       expect(overseasCountryOverride(undefined)).toBeUndefined();
       expect(overseasCountryOverride("")).toBeUndefined();

--- a/src/adapters/html-scraper/new-tokyo-katch.ts
+++ b/src/adapters/html-scraper/new-tokyo-katch.ts
@@ -185,6 +185,17 @@ function extractTableRows($: CheerioAPI): { headers: string[]; rows: string[][] 
 // Event building
 // ---------------------------------------------------------------------------
 
+/**
+ * Detect a REMARK column value that signals this is an overseas trip — NTKH4
+ * runs an annual "Overseas Run" outside Japan. Returning an empty string tells
+ * the merge pipeline to drop the kennel's country bias entirely, so a venue
+ * like "Taoyuan" resolves to Taiwan instead of a Tokyo neighborhood. Issue #741.
+ */
+export function overseasCountryOverride(remark: string | undefined): string | undefined {
+  if (!remark) return undefined;
+  return /overseas/i.test(remark) ? "" : undefined;
+}
+
 function buildRawEvent(parsed: ParsedNtkRun, sourceUrl: string): RawEventData {
   const title = parsed.runNumber
     ? `${DISPLAY_NAME} #${parsed.runNumber}`
@@ -193,6 +204,8 @@ function buildRawEvent(parsed: ParsedNtkRun, sourceUrl: string): RawEventData {
   const descParts: string[] = [];
   if (parsed.line) descParts.push(`Line: ${parsed.line}`);
   if (parsed.remark) descParts.push(`Remark: ${parsed.remark}`);
+
+  const countryOverride = overseasCountryOverride(parsed.remark);
 
   return {
     date: parsed.date,
@@ -203,6 +216,7 @@ function buildRawEvent(parsed: ParsedNtkRun, sourceUrl: string): RawEventData {
     location: parsed.location,
     sourceUrl,
     description: descParts.length > 0 ? descParts.join("\n") : undefined,
+    ...(countryOverride !== undefined ? { countryOverride } : {}),
   };
 }
 

--- a/src/adapters/html-scraper/new-tokyo-katch.ts
+++ b/src/adapters/html-scraper/new-tokyo-katch.ts
@@ -193,7 +193,7 @@ function extractTableRows($: CheerioAPI): { headers: string[]; rows: string[][] 
  */
 export function overseasCountryOverride(remark: string | undefined): string | undefined {
   if (!remark) return undefined;
-  return /overseas/i.test(remark) ? "" : undefined;
+  return /\boverseas\b/i.test(remark) ? "" : undefined;
 }
 
 function buildRawEvent(parsed: ParsedNtkRun, sourceUrl: string): RawEventData {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -19,6 +19,15 @@ export interface RawEventData {
   sourceUrl?: string;
   externalLinks?: { url: string; label: string }[]; // Additional links (creates EventLink records)
   seriesId?: string; // Groups multi-day events (e.g., Hash Rego event slug)
+  /**
+   * ISO-2 country code override used for geocoding region bias.
+   * Set by adapters when a single event runs outside the kennel's home country
+   * (e.g. an annual "overseas" trip). The merge pipeline prefers this over
+   * the kennel's country when resolving coordinates. Empty string is a sentinel
+   * meaning "no bias" — use it when the destination country is unknown but we
+   * want Google to search globally instead of snapping to the kennel's country.
+   */
+  countryOverride?: string;
 }
 
 /** Structured parse error with row-level context (Phase 2A) */

--- a/src/app/admin/alerts/actions.test.ts
+++ b/src/app/admin/alerts/actions.test.ts
@@ -294,7 +294,7 @@ describe("rescrapeFromAlert", () => {
       created: 3,
       updated: 2,
     });
-    expect(mockScrape).toHaveBeenCalledWith("src_1", { force: false });
+    expect(mockScrape).toHaveBeenCalledWith("src_1", { force: false, days: undefined });
 
     const updateCall = mockAlertUpdate.mock.calls[0][0];
     const repairLog = updateCall.data.repairLog as unknown[];
@@ -316,7 +316,42 @@ describe("rescrapeFromAlert", () => {
 
     await rescrapeFromAlert("alert_1", true);
 
-    expect(mockScrape).toHaveBeenCalledWith("src_1", { force: true });
+    expect(mockScrape).toHaveBeenCalledWith("src_1", { force: true, days: undefined });
+  });
+
+  it("passes a custom days window through to scrapeSource (#700)", async () => {
+    mockAlertFind.mockResolvedValueOnce(baseAlert() as never);
+    mockScrape.mockResolvedValueOnce({
+      success: true,
+      eventsFound: 5,
+      created: 1,
+      updated: 0,
+      errors: [],
+    } as never);
+    mockAlertUpdate.mockResolvedValueOnce({} as never);
+
+    await rescrapeFromAlert("alert_1", false, 365);
+
+    expect(mockScrape).toHaveBeenCalledWith("src_1", { force: false, days: 365 });
+    const updateCall = mockAlertUpdate.mock.calls[0][0];
+    const entry = (updateCall.data.repairLog as Record<string, unknown>[])[0];
+    expect((entry.details as Record<string, unknown>).days).toBe(365);
+  });
+
+  it("clamps the days window to [1, 1825]", async () => {
+    mockAlertFind.mockResolvedValueOnce(baseAlert() as never);
+    mockScrape.mockResolvedValueOnce({
+      success: true,
+      eventsFound: 0,
+      created: 0,
+      updated: 0,
+      errors: [],
+    } as never);
+    mockAlertUpdate.mockResolvedValueOnce({} as never);
+
+    await rescrapeFromAlert("alert_1", false, 9999);
+
+    expect(mockScrape).toHaveBeenCalledWith("src_1", { force: false, days: 1825 });
   });
 });
 

--- a/src/app/admin/alerts/actions.test.ts
+++ b/src/app/admin/alerts/actions.test.ts
@@ -353,6 +353,22 @@ describe("rescrapeFromAlert", () => {
 
     expect(mockScrape).toHaveBeenCalledWith("src_1", { force: false, days: 1825 });
   });
+
+  it("rejects non-finite days (NaN, Infinity) and falls back to default", async () => {
+    mockAlertFind.mockResolvedValueOnce(baseAlert() as never);
+    mockScrape.mockResolvedValueOnce({
+      success: true,
+      eventsFound: 0,
+      created: 0,
+      updated: 0,
+      errors: [],
+    } as never);
+    mockAlertUpdate.mockResolvedValueOnce({} as never);
+
+    await rescrapeFromAlert("alert_1", false, Number.NaN);
+
+    expect(mockScrape).toHaveBeenCalledWith("src_1", { force: false, days: undefined });
+  });
 });
 
 // ── createAliasFromAlert ──

--- a/src/app/admin/alerts/actions.ts
+++ b/src/app/admin/alerts/actions.ts
@@ -190,7 +190,8 @@ export async function rescrapeFromAlert(alertId: string, force = false, days?: n
   if (!admin) return { error: "Unauthorized" };
 
   // Clamp days to the same range the cron endpoint enforces — 1..1825.
-  const clampedDays = days != null
+  // Reject NaN/Infinity up front so a non-finite value can't poison buildDateWindow().
+  const clampedDays = days != null && Number.isFinite(days)
     ? Math.max(1, Math.min(1825, Math.floor(days)))
     : undefined;
 

--- a/src/app/admin/alerts/actions.ts
+++ b/src/app/admin/alerts/actions.ts
@@ -185,14 +185,19 @@ export async function resolveAllForSource(sourceId: string) {
 
 // ── Repair Actions ──
 
-export async function rescrapeFromAlert(alertId: string, force = false) {
+export async function rescrapeFromAlert(alertId: string, force = false, days?: number) {
   const admin = await getAdminUser();
   if (!admin) return { error: "Unauthorized" };
+
+  // Clamp days to the same range the cron endpoint enforces — 1..1825.
+  const clampedDays = days != null
+    ? Math.max(1, Math.min(1825, Math.floor(days)))
+    : undefined;
 
   const alert = await prisma.alert.findUnique({ where: { id: alertId } });
   if (!alert) return { error: "Alert not found" };
 
-  const result = await scrapeSource(alert.sourceId, { force });
+  const result = await scrapeSource(alert.sourceId, { force, days: clampedDays });
 
   await prisma.alert.update({
     where: { id: alertId },
@@ -200,7 +205,12 @@ export async function rescrapeFromAlert(alertId: string, force = false) {
       repairLog: appendRepairLog(alert.repairLog,
         buildRepairEntry(
           "rescrape", admin.id,
-          { forced: force, eventsFound: result.eventsFound, created: result.created },
+          {
+            forced: force,
+            eventsFound: result.eventsFound,
+            created: result.created,
+            ...(clampedDays != null ? { days: clampedDays } : {}),
+          },
           result.success ? "success" : "error",
           result.errors.length > 0 ? result.errors.slice(0, 3).join("; ") : undefined,
         ),

--- a/src/components/admin/AlertCard.tsx
+++ b/src/components/admin/AlertCard.tsx
@@ -146,14 +146,15 @@ export function AlertCard({ alert, allKennels, suggestions }: AlertCardProps) {
     });
   }
 
-  function handleRescrape() {
+  function handleRescrape(days?: number) {
     startTransition(async () => {
-      const result = await rescrapeFromAlert(alert.id);
+      const result = await rescrapeFromAlert(alert.id, false, days);
       if ("error" in result) {
         toast.error(result.error);
       } else {
+        const windowLabel = days ? ` (${days}d window)` : "";
         toast.success(
-          `Re-scraped: ${result.eventsFound} found, ${result.created} created, ${result.updated} updated`,
+          `Re-scraped${windowLabel}: ${result.eventsFound} found, ${result.created} created, ${result.updated} updated`,
         );
       }
       router.refresh();
@@ -295,12 +296,26 @@ export function AlertCard({ alert, allKennels, suggestions }: AlertCardProps) {
                 variant="outline"
                 className="h-7 text-xs"
                 disabled={isPending}
-                onClick={handleRescrape}
+                onClick={() => handleRescrape()}
               >
                 {isPending ? "..." : "Re-scrape"}
               </Button>
             </TooltipTrigger>
             <TooltipContent>Try fetching this source again — good first step for transient errors</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs"
+                disabled={isPending}
+                onClick={() => handleRescrape(365)}
+              >
+                {isPending ? "..." : "Wide re-scrape (365d)"}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Force a 365-day window scrape — catches events the default window missed</TooltipContent>
           </Tooltip>
           {alert.status === "OPEN" && (
             <Tooltip>

--- a/src/pipeline/audit-checks.test.ts
+++ b/src/pipeline/audit-checks.test.ts
@@ -171,6 +171,22 @@ describe("checkHareQuality", () => {
     expect(findings[0].rule).toBe("hare-phone-number");
   });
 
+  it("flags hare-phone-number for bare 10-digit run (unseparated, #742)", () => {
+    const event = makeEvent({
+      haresText: "Any Cock'll Do Me, 2406185563 CALL for same day service",
+    });
+    const findings = checkHareQuality(event);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("hare-phone-number");
+  });
+
+  it("does not flag hare-phone-number for shorter digit runs", () => {
+    // 9 digits bounded by non-digits — below the 10-digit phone threshold
+    const event = makeEvent({ haresText: "Runner #123456789" });
+    const findings = checkHareQuality(event);
+    expect(findings).toHaveLength(0);
+  });
+
   it("flags hare-boilerplate-leak when haresText contains 'WHAT TIME'", () => {
     const event = makeEvent({
       haresText: "WHAT TIME: 6:30 PM WHERE: Central Park",
@@ -257,6 +273,22 @@ describe("checkTitleQuality", () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].rule).toBe("title-cta-text");
     expect(findings[0].severity).toBe("warning");
+  });
+
+  it("flags title-cta-text for 'Hare wanted' recruitment prefix (#740)", () => {
+    const event = makeEvent({
+      title: "SH3 #880 Hare wanted - get in touch with Anni Tua",
+    });
+    const findings = checkTitleQuality(event);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("title-cta-text");
+  });
+
+  it("flags title-cta-text for 'Hares needed' wording", () => {
+    const event = makeEvent({ title: "Spring Trail — hares needed!" });
+    const findings = checkTitleQuality(event);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("title-cta-text");
   });
 
   it("flags title-schedule-description as warning for schedule language", () => {
@@ -367,6 +399,34 @@ describe("checkLocationQuality", () => {
     expect(findings).toHaveLength(0);
   });
 
+  it("flags location-phone-number for separated phone in locationName (#743)", () => {
+    const event = makeEvent({
+      locationName: "Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)",
+    });
+    const findings = checkLocationQuality([event]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("location-phone-number");
+    expect(findings[0].severity).toBe("warning");
+    expect(findings[0].category).toBe("location");
+    expect(findings[0].field).toBe("locationName");
+  });
+
+  it("flags location-phone-number for bare 10-digit run in locationName", () => {
+    const event = makeEvent({
+      locationName: "Private home, call 9193326661 for address",
+    });
+    const findings = checkLocationQuality([event]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("location-phone-number");
+  });
+
+  it("does not flag location-phone-number for street numbers or ZIP codes", () => {
+    const event = makeEvent({
+      locationName: "15001 Health Center Dr, Bowie, MD 20716",
+    });
+    const findings = checkLocationQuality([event]);
+    expect(findings).toHaveLength(0);
+  });
 });
 
 describe("checkEventQuality", () => {

--- a/src/pipeline/audit-checks.test.ts
+++ b/src/pipeline/audit-checks.test.ts
@@ -187,6 +187,14 @@ describe("checkHareQuality", () => {
     expect(findings).toHaveLength(0);
   });
 
+  it("does not flag hare-phone-number inside a longer digit run", () => {
+    // Both branches anchored with (?<!\d)/(?!\d) so a formatted phone wedged
+    // inside a longer digit run (e.g., a tracking code) doesn't false-positive.
+    const event = makeEvent({ haresText: "ID9202-555-12345" });
+    const findings = checkHareQuality(event);
+    expect(findings).toHaveLength(0);
+  });
+
   it("flags hare-boilerplate-leak when haresText contains 'WHAT TIME'", () => {
     const event = makeEvent({
       haresText: "WHAT TIME: 6:30 PM WHERE: Central Park",

--- a/src/pipeline/audit-checks.ts
+++ b/src/pipeline/audit-checks.ts
@@ -118,7 +118,7 @@ const TITLE_TIME_ONLY_PATTERN =
  * boundaries to avoid matching inside longer numeric strings.
  */
 const PHONE_NUMBER_RE =
-  /(?:\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}|(?<!\d)\d{10}(?!\d))/;
+  /(?:(?<!\d)\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}(?!\d)|(?<!\d)\d{10}(?!\d))/;
 
 const CTA_PATTERN =
   /^(?:tbd|tba|tbc|n\/a|sign[\s\u00A0]*up!?|volunteer|needed|required)$/i;

--- a/src/pipeline/audit-checks.ts
+++ b/src/pipeline/audit-checks.ts
@@ -50,6 +50,7 @@ export const KNOWN_AUDIT_RULES = [
   "title-time-only",
   "location-url",
   "location-duplicate-segments",
+  "location-phone-number",
   "event-improbable-time",
   "description-dropped",
 ] as const;
@@ -110,6 +111,15 @@ const TITLE_HTML_ENTITIES_PATTERN =
 const TITLE_TIME_ONLY_PATTERN =
   /^(?:\d{1,2}(?::\d{2})?\s*(?:am|pm)|\d{1,2}:\d{2})$/i;
 
+/**
+ * Phone-number detector for haresText and locationName. Catches both the
+ * classic separated form `(415) 555-1212` / `415.555.1212` / `415-555-1212`
+ * and the unseparated 10-digit run `4155551212`. Anchored with non-digit
+ * boundaries to avoid matching inside longer numeric strings.
+ */
+const PHONE_NUMBER_RE =
+  /(?:\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}|(?<!\d)\d{10}(?!\d))/;
+
 const CTA_PATTERN =
   /^(?:tbd|tba|tbc|n\/a|sign[\s\u00A0]*up!?|volunteer|needed|required)$/i;
 /**
@@ -151,8 +161,13 @@ export function checkTitleQuality(event: AuditEventRow): AuditFinding[] {
     ];
   }
 
-  // 2. title-cta-text (warning)
-  if (TITLE_CTA_PATTERN.test(title)) {
+  // 2. title-cta-text (warning). Covers explicit CTA phrases in TITLE_CTA_PATTERN
+  // ("sign up", "wanna hare", etc.) plus the shared CTA_EMBEDDED_PATTERNS list
+  // ("hare wanted/needed/required/volunteer…") reused from the hare check.
+  const titleCtaHit =
+    TITLE_CTA_PATTERN.test(title) ||
+    CTA_EMBEDDED_PATTERNS.some((re) => re.test(title));
+  if (titleCtaHit) {
     return [
       finding(event, {
         category: "title",
@@ -280,6 +295,22 @@ export function checkLocationQuality(events: LocationEventRow[]): AuditFinding[]
       }
     }
 
+    // 3. location-phone-number: locationName contains a phone number
+    // (separated or bare 10-digit run). Venues named with contact CTAs
+    // like "Casa De Assover (text 919-332-2615 for address)" degrade
+    // geocoding precision and should move the contact to the description.
+    if (PHONE_NUMBER_RE.test(locationName)) {
+      findings.push(
+        finding(event, {
+          category: "location",
+          field: "locationName",
+          currentValue: locationName,
+          rule: "location-phone-number",
+          severity: "warning",
+        })
+      );
+      continue;
+    }
   }
 
   return findings;
@@ -404,8 +435,8 @@ export function checkHareQuality(event: AuditEventRow): AuditFinding[] {
     ];
   }
 
-  // 5. hare-phone-number (warning): contains phone pattern
-  if (/\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}/.test(haresText)) {
+  // 5. hare-phone-number (warning): contains phone pattern (separated or bare 10-digit run)
+  if (PHONE_NUMBER_RE.test(haresText)) {
     return [
       finding(event, {
         category: "hares",

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -20,6 +20,24 @@ function countryToRegionBias(country?: string | null): string | undefined {
 }
 
 /**
+ * Resolve the region bias Google Geocoding should use for an event. Prefers the
+ * per-event `countryOverride` when the adapter set one (e.g. an annual overseas
+ * trip leaving the kennel's home country). An empty-string override means "no
+ * bias" — intentionally skip the kennel's default.
+ */
+function resolveRegionBias(
+  event: RawEventData,
+  kennelCountry: string | null | undefined,
+): string | undefined {
+  if (event.countryOverride !== undefined) {
+    return event.countryOverride === ""
+      ? undefined
+      : countryToRegionBias(event.countryOverride);
+  }
+  return countryToRegionBias(kennelCountry);
+}
+
+/**
  * Sanitize raw event fields: decode HTML entities in text fields.
  * Applied at the top of processNewRawEvent() so all downstream sanitizers receive clean text.
  */
@@ -623,10 +641,13 @@ async function resolveCoords(
     const geocoded = await geocodeAddress(event.location, regionBias ? { regionBias } : undefined);
     if (geocoded) {
       // Validate geocoded result against kennel coords or region centroid (if available)
-      // Skip geocode if result is >200km from reference point — likely wrong city/state
+      // Skip geocode if result is >200km from reference point — likely wrong city/state.
+      // Adapters set `countryOverride` on per-event overseas trips (e.g. NTKH4 annual
+      // Taoyuan run) to opt out of the kennel-proximity check, which would otherwise
+      // reject the correct far-away pin.
       const valLat = kennelCoords?.latitude ?? kennelCoords?.regionCentroidLat;
       const valLng = kennelCoords?.longitude ?? kennelCoords?.regionCentroidLng;
-      if (valLat != null && valLng != null) {
+      if (valLat != null && valLng != null && event.countryOverride === undefined) {
         const dist = haversineDistance(geocoded.lat, geocoded.lng, valLat, valLng);
         if (dist > 200) {
           console.warn(`Geocode validation: "${event.location}" resolved ${dist.toFixed(0)}km from kennel — skipping`);
@@ -728,7 +749,7 @@ async function upsertCanonicalEvent(
         latitude: existingEvent.latitude,
         longitude: existingEvent.longitude,
         locationAddress: existingEvent.locationAddress,
-      }, ctx.shortUrlCache, kennelData, countryToRegionBias(kennelData.country));
+      }, ctx.shortUrlCache, kennelData, resolveRegionBias(event, kennelData.country));
 
       const locName = coords.normalizedLocation ?? sanitizeLocation(event.location);
 
@@ -854,7 +875,7 @@ async function upsertCanonicalEvent(
     if (shouldRestore) ctx.result.restored++;
   } else {
     // Create new canonical Event
-    const coords = await resolveCoords(event, undefined, ctx.shortUrlCache, kennelData, countryToRegionBias(kennelData.country));
+    const coords = await resolveCoords(event, undefined, ctx.shortUrlCache, kennelData, resolveRegionBias(event, kennelData.country));
     // Reverse-geocode city when coords are available (suppress when address already has state).
     // Canonical-location sources skip this entirely — see shouldSkipReverseGeocode.
     const locName = coords.normalizedLocation ?? sanitizeLocation(event.location);


### PR DESCRIPTION
## Summary

Four-commit fix bundle closing eight open issues in independent areas. Ordered A → C → D → HC per original plan.

**Issues closed:** #740 · #742 · #743 · #727 · #741 · #700 · #706 · #725

### Commits

1. **`feat(audit)`** — extends the audit rule pack with a unified `PHONE_NUMBER_RE` that catches both formatted (`919-332-2615`) and unseparated (`2406185563`) phone numbers in hares and locations, and reuses `CTA_EMBEDDED_PATTERNS` in the title rule to catch "Hare wanted" titles. Closes #740, #742, #743. #727 was investigated live — BFMH3 rule is firing correctly on source-side boilerplate, so closing as not-a-bug.

2. **`fix(geo)`** — adds `RawEventData.countryOverride` for annual overseas kennel trips (e.g. NTKH4's Taoyuan run). Empty-string sentinel means "no bias"; any override opts the event out of the 200km kennel-proximity guard in `resolveCoords`. NTKH4 adapter sets the override when REMARK contains `\boverseas\b`. Closes #741.

3. **`feat(admin)`** — extends `rescrapeFromAlert` with a clamped `days` parameter and adds a "Wide re-scrape (365d)" button next to the default rescrape button on `AlertCard`. Makes it one click to force a 365-day window when the default misses an event (like Beantown #275 did). Post-merge: trigger the wide rescrape for the Boston GCal source to import the missing run. Closes #700.

4. **`fix(harrier-central)`** — stops the HC adapter from emitting `https://www.hashruns.org/#/event/<uuid>` URLs. The Flutter UI no longer resolves these, leaving dead links in the event detail page. The REST API still serves the UUIDs so scraping is unaffected. Includes `scripts/clear-hc-sourceurls.ts` (dry-run-by-default) to null already-ingested broken URLs — since `merge.ts` preserves existing `sourceUrl`, the adapter change alone doesn't clear old rows. Run against prod post-merge. Closes #706, #725.

5. **`fix(review)`** — pre-PR adversarial review caught three tightening opportunities: NaN guard on `days`, `\boverseas\b` word boundaries, backfill scoped to exact `/#/event/` path.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (23 pre-existing warnings unchanged)
- [x] `npm test` — 4465 passing (added 10 new tests across the four areas)
- [x] `/simplify` — nothing to simplify
- [x] `/codex:adversarial-review` — 3 medium findings addressed in commit 5, 2 low findings left as intentional
- [x] NTKH4 live-verified against `newtokyohash.wixsite.com/newtokyokatchhash/hareline` — Apr 17 2026 Run #70 confirmed as "Annual Overseas Run" to Taoyuan

## Post-merge steps

- [ ] Trigger wide-window rescrape on Boston Hash GCal source via new admin button → verify Beantown #275 appears (#700)
- [ ] Run `npx tsx scripts/clear-hc-sourceurls.ts --apply` against prod → verify Tokyo H3 + Singapore Sunday H3 event detail pages no longer show broken hashruns.org links (#706, #725)

Closes #740, #742, #743, #727, #741, #700, #706, #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)