### PR TITLE
feat(berlin-h3): cost extraction, hares enrichment, kennel profile backfill

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -15,6 +15,7 @@ export interface KennelSeed {
   instagramHandle?: string;
   twitterHandle?: string;
   discordUrl?: string;
+  mailingListUrl?: string;
   contactEmail?: string;
   foundedYear?: number;
   description?: string;
@@ -865,7 +866,11 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "bh3fm", shortName: "Berlin Full Moon", fullName: "Berlin Full Moon Hash House Harriers", region: "Berlin", country: "Germany",
       website: "https://www.berlin-h3.eu",
       scheduleFrequency: "Monthly", scheduleNotes: "Full moon evening",
-      description: "Berlin monthly full moon hash.",
+      hashCash: "€5", foundedYear: 1979,
+      facebookUrl: "https://de-de.facebook.com/BerlinHashHouseHarriers/",
+      mailingListUrl: "https://list.berlin-h3.eu/subscription/form",
+      logoUrl: "https://www.berlin-h3.eu/wp-content/uploads/2020/05/bh3Logo.png",
+      description: "Berlin's monthly full moon hash. A drinking club with a running problem — since 1979.",
       latitude: 52.52, longitude: 13.41,
     },
     // Stuttgart

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -445,6 +445,7 @@ export const SOURCES = [
       config: {
         kennelPatterns: [["Full Moon Run", "bh3fm"]],
         defaultKennelTag: "berlinh3",
+        enrichBerlinH3Details: true,
       },
       kennelCodes: ["berlinh3", "bh3fm"],
     },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -28,7 +28,7 @@ function toSlug(shortName: string): string {
 const PROFILE_FIELDS = new Set([
   "website", "scheduleDayOfWeek", "scheduleTime", "scheduleFrequency",
   "scheduleNotes", "hashCash", "facebookUrl", "instagramHandle",
-  "twitterHandle", "discordUrl", "contactEmail", "foundedYear", "description",
+  "twitterHandle", "discordUrl", "mailingListUrl", "contactEmail", "foundedYear", "description",
   "logoUrl", "latitude", "longitude",
 ]);
 

--- a/scripts/fix-kennel-data-bh3fm-2026-04.ts
+++ b/scripts/fix-kennel-data-bh3fm-2026-04.ts
@@ -1,0 +1,51 @@
+/**
+ * One-shot data correction script for the Berlin Full Moon (bh3fm) kennel.
+ *
+ * Adds profile fields from audit issues #745 (logo), #746 (facebook + mailing
+ * list), and #747 (founded year + richer description). The seed's
+ * "fill missing" path skips these because some of them may already be non-null
+ * (description) in prod — this script updates them directly to the seed's
+ * canonical values.
+ *
+ * Run after the PR merges:
+ *   npx tsx scripts/fix-kennel-data-bh3fm-2026-04.ts
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const pool = createScriptPool();
+const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+async function main() {
+  const bh3fm = await prisma.kennel.update({
+    where: { kennelCode: "bh3fm" },
+    data: {
+      hashCash: "€5",
+      foundedYear: 1979,
+      facebookUrl: "https://de-de.facebook.com/BerlinHashHouseHarriers/",
+      mailingListUrl: "https://list.berlin-h3.eu/subscription/form",
+      logoUrl: "https://www.berlin-h3.eu/wp-content/uploads/2020/05/bh3Logo.png",
+      description:
+        "Berlin's monthly full moon hash. A drinking club with a running problem — since 1979.",
+    },
+    select: {
+      kennelCode: true,
+      hashCash: true,
+      foundedYear: true,
+      facebookUrl: true,
+      mailingListUrl: true,
+      logoUrl: true,
+      description: true,
+    },
+  });
+  console.log("Updated BH3FM:", bh3fm);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => Promise.all([prisma.$disconnect(), pool.end()]));

--- a/src/adapters/html-scraper/berlin-h3-detail-enrichment.test.ts
+++ b/src/adapters/html-scraper/berlin-h3-detail-enrichment.test.ts
@@ -29,6 +29,15 @@ describe("parseBerlinH3DetailPage", () => {
     expect(parseBerlinH3DetailPage(html).hares).toBe("Captain Hash");
   });
 
+  it("handles separator outside the <strong> tag", () => {
+    // Some wp-event-manager templates render the separator after the closing
+    // </strong>, leaving a leading space in the remainder after the label slice.
+    const html = `
+      <p class="wpem-additional-info-block-title"><strong>Hares</strong> - Symphomaniac</p>
+    `;
+    expect(parseBerlinH3DetailPage(html).hares).toBe("Symphomaniac");
+  });
+
   it("ignores unrelated additional-info paragraphs", () => {
     const html = `
       <p class="wpem-additional-info-block-title"><strong>Cost -</strong> 5 EUR</p>
@@ -140,6 +149,22 @@ describe("enrichBerlinH3Events", () => {
       buildEvent({ sourceUrl: "https://www.berlin-h3.eu/" }),
       buildEvent({ sourceUrl: "https://www.berlin-h3.eu/wp-admin/" }),
       buildEvent({ sourceUrl: "https://www.berlin-h3.eu/wp-content/uploads/logo.png" }),
+    ];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects post_type=event_listing query form without a `p` id", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const events = [
+      buildEvent({
+        // Valid-looking post_type but no event id — not an event detail page.
+        sourceUrl: "https://www.berlin-h3.eu/?post_type=event_listing",
+      }),
     ];
 
     const result = await enrichBerlinH3Events(events, { now });

--- a/src/adapters/html-scraper/berlin-h3-detail-enrichment.test.ts
+++ b/src/adapters/html-scraper/berlin-h3-detail-enrichment.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from "vitest";
+import type { RawEventData } from "../types";
+import {
+  parseBerlinH3DetailPage,
+  enrichBerlinH3Events,
+} from "./berlin-h3-detail-enrichment";
+
+describe("parseBerlinH3DetailPage", () => {
+  it("extracts Hares from the wp-event-manager additional-info block", () => {
+    const html = `
+      <html><body>
+        <p class="wpem-additional-info-block-title"><strong>Hares -</strong> Symphomaniac</p>
+      </body></html>
+    `;
+    expect(parseBerlinH3DetailPage(html).hares).toBe("Symphomaniac");
+  });
+
+  it("handles 'Hare(s) -' label variant", () => {
+    const html = `
+      <p class="wpem-additional-info-block-title"><strong>Hare(s) -</strong> Alpha &amp; Omega</p>
+    `;
+    expect(parseBerlinH3DetailPage(html).hares).toBe("Alpha & Omega");
+  });
+
+  it("handles a trailing colon instead of dash", () => {
+    const html = `
+      <p class="wpem-additional-info-block-title"><strong>Hares:</strong> Captain Hash</p>
+    `;
+    expect(parseBerlinH3DetailPage(html).hares).toBe("Captain Hash");
+  });
+
+  it("ignores unrelated additional-info paragraphs", () => {
+    const html = `
+      <p class="wpem-additional-info-block-title"><strong>Cost -</strong> 5 EUR</p>
+      <p class="wpem-additional-info-block-title"><strong>On On On -</strong> Some Pub</p>
+    `;
+    expect(parseBerlinH3DetailPage(html).hares).toBeUndefined();
+  });
+
+  it("returns undefined for pages without additional-info blocks", () => {
+    const html = `<html><body><h1>Full Moon Run 149</h1></body></html>`;
+    expect(parseBerlinH3DetailPage(html).hares).toBeUndefined();
+  });
+
+  it("skips overly long values (noise guard)", () => {
+    const longValue = "x".repeat(300);
+    const html = `
+      <p class="wpem-additional-info-block-title"><strong>Hares -</strong> ${longValue}</p>
+    `;
+    expect(parseBerlinH3DetailPage(html).hares).toBeUndefined();
+  });
+});
+
+describe("enrichBerlinH3Events", () => {
+  const now = new Date("2026-04-01T00:00:00Z");
+
+  function buildEvent(overrides: Partial<RawEventData>): RawEventData {
+    return {
+      date: "2026-04-03",
+      kennelTag: "bh3fm",
+      sourceUrl: "https://www.berlin-h3.eu/event/full-moon-run-148/",
+      ...overrides,
+    };
+  }
+
+  it("fetches the detail page and sets hares in place", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        `<p class="wpem-additional-info-block-title"><strong>Hares -</strong> Symphomaniac</p>`,
+        { status: 200 },
+      ),
+    );
+    const events = [buildEvent({})];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(1);
+    expect(result.failures).toHaveLength(0);
+    expect(events[0].hares).toBe("Symphomaniac");
+    vi.restoreAllMocks();
+  });
+
+  it("skips events whose sourceUrl is not a Berlin H3 permalink", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const events = [
+      buildEvent({
+        sourceUrl: "https://www.sfh3.com/runs/1",
+      }),
+    ];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(events[0].hares).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+
+  it("skips events that already have hares (steady state → no fetch)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const events = [buildEvent({ hares: "Already Set" })];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it("skips past events (outside the upcoming window)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const events = [buildEvent({ date: "2025-01-01" })];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it("records HTTP failures without throwing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Not Found", { status: 404 }),
+    );
+    const events = [buildEvent({})];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(0);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].url).toBe(events[0].sourceUrl);
+    expect(result.failures[0].message).toContain("HTTP 404");
+    expect(events[0].hares).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects same-origin non-event URLs (homepage, uploads, admin)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const events = [
+      buildEvent({ sourceUrl: "https://www.berlin-h3.eu/" }),
+      buildEvent({ sourceUrl: "https://www.berlin-h3.eu/wp-admin/" }),
+      buildEvent({ sourceUrl: "https://www.berlin-h3.eu/wp-content/uploads/logo.png" }),
+    ];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it("accepts the post_type=event_listing query form", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        `<p class="wpem-additional-info-block-title"><strong>Hares -</strong> Symphomaniac</p>`,
+        { status: 200 },
+      ),
+    );
+    const events = [
+      buildEvent({
+        sourceUrl: "https://www.berlin-h3.eu/?post_type=event_listing&p=1119",
+      }),
+    ];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(1);
+    expect(events[0].hares).toBe("Symphomaniac");
+    vi.restoreAllMocks();
+  });
+
+  it("includes events exactly 24h in the past (cutoff boundary)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        `<p class="wpem-additional-info-block-title"><strong>Hares -</strong> Boundary</p>`,
+        { status: 200 },
+      ),
+    );
+    // now = 2026-04-01T00:00:00Z → cutoff date = 2026-03-31 (today − 24h)
+    const events = [buildEvent({ date: "2026-03-31" })];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(1);
+    expect(events[0].hares).toBe("Boundary");
+    vi.restoreAllMocks();
+  });
+
+  it("excludes events older than the 24h buffer", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // now = 2026-04-01T00:00:00Z, cutoff = 2026-03-31 → 2026-03-30 is excluded
+    const events = [buildEvent({ date: "2026-03-30" })];
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(result.enriched).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it("caps fetch count at MAX_ENRICH_PER_SCRAPE (100) and leaves overflow untouched", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () =>
+        new Response(
+          `<p class="wpem-additional-info-block-title"><strong>Hares -</strong> Capped</p>`,
+          { status: 200 },
+        ),
+      );
+    const events = Array.from({ length: 101 }, (_, i) =>
+      buildEvent({
+        // Stagger dates so sort order is deterministic: event #0 is earliest, #100 is latest.
+        date: `2026-04-${String(3 + Math.floor(i / 10)).padStart(2, "0")}`,
+        sourceUrl: `https://www.berlin-h3.eu/event/run-${i}/`,
+      }),
+    );
+
+    const result = await enrichBerlinH3Events(events, { now });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(100);
+    expect(result.enriched).toBe(100);
+    // The latest-dated event (last after sort) is the one dropped by the cap.
+    expect(events[100].hares).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+});

--- a/src/adapters/html-scraper/berlin-h3-detail-enrichment.ts
+++ b/src/adapters/html-scraper/berlin-h3-detail-enrichment.ts
@@ -1,0 +1,128 @@
+import * as cheerio from "cheerio";
+import type { RawEventData } from "../types";
+import { decodeEntities, stripHtmlTags } from "../utils";
+import { safeFetch } from "../safe-fetch";
+
+/**
+ * Berlin H3 run detail-page enrichment.
+ *
+ * The .ics DESCRIPTION published by wordpress-hash-event-api only carries a
+ * few free-text lines ("Hash Cash: 5€"), with no structured Hares. The
+ * wp-event-manager event page (e.g. /event/full-moon-run-148/) exposes the
+ * hares as a labeled "Additional Details" block:
+ *
+ *   <p class="wpem-additional-info-block-title">
+ *     <strong>Hares -</strong> Symphomaniac
+ *   </p>
+ *
+ * This module fetches that page for each upcoming event that hasn't already
+ * picked up hares from the ICS description, and sets RawEventData.hares in
+ * place. Mirrors the SFH3 detail-enrichment pattern.
+ */
+
+const MAX_ENRICH_PER_SCRAPE = 100;
+const BATCH_SIZE = 5;
+
+export interface BerlinH3Detail {
+  hares?: string;
+}
+
+export interface BerlinH3EnrichFailure {
+  url: string;
+  message: string;
+}
+
+type EnrichableEvent = RawEventData & { sourceUrl: string };
+
+/** True if the URL is a Berlin H3 event permalink (either query or pretty form). */
+function isBerlinEventUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    if (host !== "berlin-h3.eu" && host !== "www.berlin-h3.eu") return false;
+    if (parsed.pathname.startsWith("/event/")) return true;
+    if (parsed.pathname === "/" && parsed.searchParams.get("post_type") === "event_listing") return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse a Berlin H3 event detail page. Returns the Hares value if present.
+ * Handles label variants like "Hares -", "Hares -", "Hare(s) -".
+ */
+export function parseBerlinH3DetailPage(html: string): BerlinH3Detail {
+  const $ = cheerio.load(html);
+
+  let hares: string | undefined;
+  $("p.wpem-additional-info-block-title").each((_i, el) => {
+    if (hares) return;
+    const $p = $(el);
+    const labelText = $p.find("strong").first().text().trim();
+    // Match "Hares -", "Hare -", "Hare(s) -" (trailing dash/colon optional, case-insensitive)
+    if (!/^hares?(?:\(s\))?\s*[-:]?\s*$/i.test(labelText)) return;
+    // Grab the paragraph text, subtract the strong label to get the value.
+    const fullText = decodeEntities(stripHtmlTags($p.html() ?? ""))
+      .replace(/\s+/g, " ")
+      .trim();
+    const value = fullText.slice(labelText.length).replace(/^[-:]\s*/, "").trim();
+    if (value && value.length < 200) hares = value;
+  });
+
+  return { hares };
+}
+
+/** Fetch one detail page; throws on non-2xx so Promise.allSettled records it. */
+async function fetchBerlinDetailPage(event: EnrichableEvent): Promise<{ html: string; event: EnrichableEvent }> {
+  const response = await safeFetch(event.sourceUrl, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${event.sourceUrl}`);
+  }
+  return { html: await response.text(), event };
+}
+
+/**
+ * Fetch the event detail page for upcoming Berlin H3 events missing hares,
+ * and update them in place. Best-effort, capped at MAX_ENRICH_PER_SCRAPE.
+ */
+export async function enrichBerlinH3Events(
+  events: RawEventData[],
+  options: { now?: Date } = {},
+): Promise<{ enriched: number; failures: BerlinH3EnrichFailure[] }> {
+  const isEnrichable = (e: RawEventData): e is EnrichableEvent =>
+    !!e.sourceUrl && !e.hares && isBerlinEventUrl(e.sourceUrl);
+
+  const referenceTime = options.now?.getTime() ?? Date.now();
+  const todayIso = new Date(referenceTime - 86_400_000).toISOString().split("T")[0];
+  const toEnrich = events
+    .filter((e) => e.date >= todayIso)
+    .filter(isEnrichable)
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .slice(0, MAX_ENRICH_PER_SCRAPE);
+  if (toEnrich.length === 0) return { enriched: 0, failures: [] };
+
+  const failures: BerlinH3EnrichFailure[] = [];
+  let enriched = 0;
+
+  for (let b = 0; b < toEnrich.length; b += BATCH_SIZE) {
+    const batch = toEnrich.slice(b, b + BATCH_SIZE);
+    const results = await Promise.allSettled(batch.map(fetchBerlinDetailPage));
+    for (const [i, result] of results.entries()) {
+      if (result.status === "rejected") {
+        failures.push({ url: batch[i].sourceUrl, message: String(result.reason) });
+        continue;
+      }
+      const { html, event } = result.value;
+      const { hares } = parseBerlinH3DetailPage(html);
+      if (hares && !event.hares) {
+        event.hares = hares;
+        enriched++;
+      }
+    }
+  }
+
+  return { enriched, failures };
+}

--- a/src/adapters/html-scraper/berlin-h3-detail-enrichment.ts
+++ b/src/adapters/html-scraper/berlin-h3-detail-enrichment.ts
@@ -41,7 +41,16 @@ function isBerlinEventUrl(url: string): boolean {
     const host = parsed.hostname.toLowerCase();
     if (host !== "berlin-h3.eu" && host !== "www.berlin-h3.eu") return false;
     if (parsed.pathname.startsWith("/event/")) return true;
-    if (parsed.pathname === "/" && parsed.searchParams.get("post_type") === "event_listing") return true;
+    // The query-string permalink form is `?post_type=event_listing&p=<id>` — both
+    // params must be present. `post_type` alone would match arbitrary WordPress
+    // taxonomy URLs that can't be parsed as event pages.
+    if (
+      parsed.pathname === "/" &&
+      parsed.searchParams.get("post_type") === "event_listing" &&
+      parsed.searchParams.has("p")
+    ) {
+      return true;
+    }
     return false;
   } catch {
     return false;
@@ -63,10 +72,13 @@ export function parseBerlinH3DetailPage(html: string): BerlinH3Detail {
     // Match "Hares -", "Hare -", "Hare(s) -" (trailing dash/colon optional, case-insensitive)
     if (!/^hares?(?:\(s\))?\s*[-:]?\s*$/i.test(labelText)) return;
     // Grab the paragraph text, subtract the strong label to get the value.
+    // Allow optional whitespace before the separator: the separator may sit
+    // inside the <strong> (e.g. "Hares -") OR after it (e.g. "Hares</strong> -"),
+    // which leaves a leading space in the remainder after slicing.
     const fullText = decodeEntities(stripHtmlTags($p.html() ?? ""))
       .replace(/\s+/g, " ")
       .trim();
-    const value = fullText.slice(labelText.length).replace(/^[-:]\s*/, "").trim();
+    const value = fullText.slice(labelText.length).replace(/^\s*[-:]\s*/, "").trim();
     if (value && value.length < 200) hares = value;
   });
 
@@ -96,9 +108,12 @@ export async function enrichBerlinH3Events(
     !!e.sourceUrl && !e.hares && isBerlinEventUrl(e.sourceUrl);
 
   const referenceTime = options.now?.getTime() ?? Date.now();
-  const todayIso = new Date(referenceTime - 86_400_000).toISOString().split("T")[0];
+  // Cutoff is one day behind `now` so events from the past 24h are still
+  // eligible for enrichment (a.k.a. "run was last night, detail page may
+  // now list the hares"). Keep separate from `todayIso` semantics.
+  const cutoffIso = new Date(referenceTime - 86_400_000).toISOString().split("T")[0];
   const toEnrich = events
-    .filter((e) => e.date >= todayIso)
+    .filter((e) => e.date >= cutoffIso)
     .filter(isEnrichable)
     .sort((a, b) => a.date.localeCompare(b.date))
     .slice(0, MAX_ENRICH_PER_SCRAPE);

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { ICalAdapter, parseICalSummary, extractHaresFromDescription, extractRunNumberFromDescription, extractLocationFromDescription, extractMapsUrlFromDescription, paramValue } from "./adapter";
+import { ICalAdapter, parseICalSummary, extractHaresFromDescription, extractRunNumberFromDescription, extractLocationFromDescription, extractCostFromDescription, extractMapsUrlFromDescription, paramValue } from "./adapter";
 import type { Source } from "@/generated/prisma/client";
 import type { ParameterValue } from "node-ical";
 
@@ -331,6 +331,36 @@ describe("extractLocationFromDescription", () => {
   it("handles multiline description with location in the middle", () => {
     const desc = String.raw`Hare: Captain Hash\n\nWhere: Fells Point\n\nBring $5`;
     expect(extractLocationFromDescription(desc)).toBe("Fells Point");
+  });
+});
+
+describe("extractCostFromDescription", () => {
+  it("extracts 'Hash Cash: 5€' (wordpress-hash-event-api format)", () => {
+    expect(extractCostFromDescription("Hash Cash: 5€")).toBe("5€");
+  });
+
+  it("extracts from multi-line description with ICS newlines", () => {
+    const desc = String.raw`Bring a torch\n\nHash Cash: 5€\n\nOn On On: Pub`;
+    expect(extractCostFromDescription(desc)).toBe("5€");
+  });
+
+  it("handles dollar-sign costs", () => {
+    expect(extractCostFromDescription("Hash Cash: $7")).toBe("$7");
+  });
+
+  it("returns undefined when no cost pattern", () => {
+    expect(extractCostFromDescription("Hares: Symphomaniac")).toBeUndefined();
+  });
+
+  it("allows custom patterns to replace defaults", () => {
+    expect(
+      extractCostFromDescription("Cost: £4", [/Cost:\s*(.+)/i]),
+    ).toBe("£4");
+  });
+
+  it("drops matches exceeding maxLength (100 chars)", () => {
+    const longValue = "a".repeat(150);
+    expect(extractCostFromDescription(`Hash Cash: ${longValue}`)).toBeUndefined();
   });
 });
 
@@ -734,6 +764,114 @@ END:VCALENDAR`;
     expect(result.events[0].location).not.toBe("None");
     expect(result.events[0].location).toBe("S Julius Leber Brücke");
     expect(result.events[0].date).toBe("2026-04-03");
+  });
+
+  it("populates cost from 'Hash Cash:' in description (Berlin H3 format)", async () => {
+    const icsWithCost = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:com.test.bh3-1
+DTSTART;TZID=Europe/Berlin:20260321T145000
+DTEND;TZID=Europe/Berlin:20260321T174500
+SUMMARY:Berlin H3 Run 2329
+DESCRIPTION:Hash Cash: 5€\\nOn On On: The Pub
+LOCATION:S Schönhauser Allee
+DTSTAMP:20260201T000000Z
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(icsWithCost, { status: 200 }),
+    );
+
+    const source = buildMockSource({
+      config: {
+        kennelPatterns: [["Full Moon Run", "bh3fm"]],
+        defaultKennelTag: "berlinh3",
+      },
+    });
+    const result = await adapter.fetch(source, { days: 9999 });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].cost).toBe("5€");
+    expect(result.events[0].kennelTag).toBe("berlinh3");
+  });
+
+  it("enriches Berlin H3 events with Hares from wp-event-manager detail page", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-01T00:00:00Z"));
+    const icsBerlin = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:com.test.bh3fm-enrich
+DTSTART;TZID=Europe/Berlin:20260403T184500
+DTEND;TZID=Europe/Berlin:20260403T214500
+SUMMARY:Full Moon Run 148
+DESCRIPTION:Hash Cash: 5€
+LOCATION:None
+URL:https://www.berlin-h3.eu/event/full-moon-run-148/
+DTSTAMP:20260201T000000Z
+END:VEVENT
+END:VCALENDAR`;
+
+    const detailHtml = `<html><body>
+      <p class="wpem-additional-info-block-title"><strong>Hares -</strong> Symphomaniac</p>
+      <p class="wpem-additional-info-block-title"><strong>Cost -</strong> 5 EUR</p>
+    </body></html>`;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/event/full-moon-run-148")) {
+        return new Response(detailHtml, { status: 200 });
+      }
+      return new Response(icsBerlin, { status: 200 });
+    });
+
+    const source = buildMockSource({
+      config: {
+        kennelPatterns: [["Full Moon Run", "bh3fm"]],
+        defaultKennelTag: "berlinh3",
+        enrichBerlinH3Details: true,
+      },
+    });
+    const result = await adapter.fetch(source, { days: 9999 });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].kennelTag).toBe("bh3fm");
+    expect(result.events[0].hares).toBe("Symphomaniac");
+    expect(result.events[0].cost).toBe("5€");
+    expect(result.diagnosticContext!.enrichmentEnriched).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it("skips Berlin H3 enrichment when flag is off", async () => {
+    const icsBerlin = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:com.test.bh3fm-off
+DTSTART;TZID=Europe/Berlin:20260403T184500
+SUMMARY:Full Moon Run 148
+URL:https://www.berlin-h3.eu/event/full-moon-run-148/
+DTSTAMP:20260201T000000Z
+END:VEVENT
+END:VCALENDAR`;
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(icsBerlin, { status: 200 }),
+    );
+
+    const source = buildMockSource({
+      config: {
+        kennelPatterns: [["Full Moon Run", "bh3fm"]],
+        defaultKennelTag: "berlinh3",
+      },
+    });
+    await adapter.fetch(source, { days: 9999 });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("enriches SFH3 events: preserves descriptive titles, appends Comment when enrichSFH3Details=true", async () => {

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -4,6 +4,7 @@ import { hasAnyErrors } from "../types";
 import { googleMapsSearchUrl, compilePatterns, appendDescriptionSuffix, isPlaceholder } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { enrichSFH3Events } from "../html-scraper/sfh3-detail-enrichment";
+import { enrichBerlinH3Events } from "../html-scraper/berlin-h3-detail-enrichment";
 import { sync as icalSync } from "node-ical";
 import type { VEvent, ParameterValue, DateWithTimeZone } from "node-ical";
 
@@ -15,9 +16,11 @@ export interface ICalSourceConfig {
   harePatterns?: string[];             // regex strings to extract hares from descriptions
   runNumberPatterns?: string[];        // regex strings to extract run numbers from descriptions
   locationPatterns?: string[];         // regex strings to extract location from descriptions (overrides default LOCATION_PATTERNS)
+  costPatterns?: string[];             // regex strings to extract cost from descriptions (e.g. wordpress-hash-event-api "Hash Cash: 5€")
   titleHarePattern?: string;           // regex to extract hare names from SUMMARY when description has none
   descriptionSuffix?: string;          // static text appended to every event description
   enrichSFH3Details?: boolean;         // fetch sfh3.com/runs/{id} detail pages for canonical title + Comment field
+  enrichBerlinH3Details?: boolean;     // fetch berlin-h3.eu event pages for Hares field from wp-event-manager
 }
 
 /**
@@ -87,6 +90,9 @@ const LOCATION_PATTERNS = [
   /(?:^|\n)\s*Where:\s*([^\n]+)/im,
   /(?:^|\n)\s*Location:\s*([^\n]+)/im,
   /(?:^|\n)\s*Start(?:ing)?\s*(?:Location)?:\s*([^\n]+)/im,
+];
+const COST_PATTERNS = [
+  /(?:^|\n)\s*Hash\s*Cash:\s*([^\n]+)/im,
 ];
 const MAPS_URL_PATTERN =
   /https?:\/\/(?:www\.)?(?:google\.com\/maps|maps\.google\.com|goo\.gl\/maps)\S*/i;
@@ -165,6 +171,17 @@ export function extractLocationFromDescription(description: string, customPatter
   return extractFieldFromDescription(description, customPatterns ?? LOCATION_PATTERNS, {
     maxLength: 300,
     stripUrls: true,
+  });
+}
+
+/**
+ * Extract a cost/hash-cash value from an iCal DESCRIPTION field.
+ * Accepts pre-compiled RegExp[] for custom patterns; falls back to default COST_PATTERNS.
+ * Short maxLength (100) guards against picking up multi-line paragraphs.
+ */
+export function extractCostFromDescription(description: string, customPatterns?: RegExp[]): string | undefined {
+  return extractFieldFromDescription(description, customPatterns ?? COST_PATTERNS, {
+    maxLength: 100,
   });
 }
 
@@ -342,6 +359,7 @@ function buildRawEventFromVEvent(
   compiledRunNumberPatterns?: RegExp[],
   compiledTitleHarePattern?: RegExp,
   compiledLocationPatterns?: RegExp[],
+  compiledCostPatterns?: RegExp[],
 ): RawEventData | null {
   if (vevent.status === "CANCELLED") return null;
 
@@ -388,6 +406,8 @@ function buildRawEventFromVEvent(
     runNumber = extractRunNumberFromDescription(description, compiledRunNumberPatterns);
   }
 
+  const cost = description ? extractCostFromDescription(description, compiledCostPatterns) : undefined;
+
   return {
     date: dateStr,
     kennelTag: parsed.kennelTag,
@@ -399,6 +419,7 @@ function buildRawEventFromVEvent(
     locationUrl,
     startTime,
     endTime,
+    cost,
     sourceUrl: paramValue(vevent.url) ?? undefined,
   };
 }
@@ -462,6 +483,9 @@ export class ICalAdapter implements SourceAdapter {
     const compiledLocationPatterns = config?.locationPatterns?.length
       ? compilePatterns(config.locationPatterns)
       : undefined;
+    const compiledCostPatterns = config?.costPatterns?.length
+      ? compilePatterns(config.costPatterns)
+      : undefined;
     const compiledTitleHarePattern = config?.titleHarePattern
       ? compilePatterns([config.titleHarePattern], "i")[0]
       : undefined;
@@ -500,7 +524,7 @@ export class ICalAdapter implements SourceAdapter {
           continue;
         }
 
-        const event = buildRawEventFromVEvent(vevent, config, compiledHarePatterns, compiledRunNumberPatterns, compiledTitleHarePattern, compiledLocationPatterns);
+        const event = buildRawEventFromVEvent(vevent, config, compiledHarePatterns, compiledRunNumberPatterns, compiledTitleHarePattern, compiledLocationPatterns, compiledCostPatterns);
         if (event) events.push(event);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -541,6 +565,21 @@ export class ICalAdapter implements SourceAdapter {
         // Single summary line in `errors` — per-fetch details live in errorDetails.fetch
         // and the count is in diagnosticContext.enrichmentFailures.
         errors.push(`enrichment: ${enrichResult.failures.length} detail-page fetch(es) failed`);
+      }
+    }
+
+    // Berlin H3 enrichment: the .ics DESCRIPTION lacks structured Hares — the
+    // wp-event-manager event page has them as <strong>Hares -</strong> {name}.
+    if (config?.enrichBerlinH3Details) {
+      const enrichResult = await enrichBerlinH3Events(events, { now: new Date(fetchStart) });
+      enrichmentEnriched = (enrichmentEnriched ?? 0) + enrichResult.enriched;
+      enrichmentFailures = (enrichmentFailures ?? 0) + enrichResult.failures.length;
+      if (enrichResult.failures.length > 0) {
+        errorDetails.fetch ??= [];
+        for (const failure of enrichResult.failures) {
+          errorDetails.fetch.push({ url: failure.url, message: failure.message });
+        }
+        errors.push(`berlin-h3 enrichment: ${enrichResult.failures.length} detail-page fetch(es) failed`);
       }
     }
 

--- a/src/app/admin/sources/config-validation.test.ts
+++ b/src/app/admin/sources/config-validation.test.ts
@@ -250,6 +250,40 @@ describe("validateSourceConfig", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // costPatterns validation
+  // ---------------------------------------------------------------------------
+
+  describe("costPatterns validation", () => {
+    it("accepts valid costPatterns", () => {
+      const config = {
+        costPatterns: [String.raw`(?:^|\n)\s*Hash\s*Cash:\s*([^\n]+)`],
+        defaultKennelTag: "berlinh3",
+      };
+      expect(validateSourceConfig("ICAL_FEED", config)).toEqual([]);
+    });
+
+    it("rejects non-array costPatterns", () => {
+      const errors = validateSourceConfig("ICAL_FEED", {
+        costPatterns: "not an array",
+      });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("must be an array");
+    });
+
+    it.each([
+      [["[broken("], "invalid regex"],
+      [[123], "must be a string"],
+      [["(x+x+)+y"], "catastrophic backtracking"],
+    ])("rejects invalid cost pattern: %s", (patterns, expectedMsg) => {
+      const errors = validateSourceConfig("ICAL_FEED", {
+        costPatterns: patterns,
+      });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain(expectedMsg);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // GOOGLE_SHEETS required fields
   // ---------------------------------------------------------------------------
 

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -224,6 +224,7 @@ export function validateSourceConfig(
   validatePatternArray(obj, "harePatterns", errors);
   validatePatternArray(obj, "runNumberPatterns", errors);
   validatePatternArray(obj, "locationPatterns", errors);
+  validatePatternArray(obj, "costPatterns", errors);
 
   // Single-pattern validation (titleHarePattern is a string, not an array)
   if ("titleHarePattern" in obj && obj.titleHarePattern !== undefined) {


### PR DESCRIPTION
## Summary
- Closes #744, #745, #746, #747, #748 (Berlin Full Moon / BH3FM audit)
- iCal adapter now extracts Hash Cash from DESCRIPTION (default `COST_PATTERNS`), validated via ReDoS-safe config validator
- New detail-page enrichment fetches wp-event-manager event pages for structured Hares (modeled on SFH3 enrichment, gated via `enrichBerlinH3Details: true` on the source config)
- Seed updates + one-shot `prisma.kennel.update` script for BH3FM profile fields (logo, FB, mailing list, founded year, €5 hash cash, richer description). The seed's fill-missing path won't overwrite existing non-null values in prod, so the script is required post-merge.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` (0 errors)
- [x] `npm test` — 4480 tests pass (adds 25 new tests: 16 Berlin enrichment + 6 cost extraction + 3 adapter integration; costPatterns validation suite)
- [x] Adversarial review run; all findings addressed (stricter event-URL gate, 24h cutoff boundary tests, MAX_ENRICH_PER_SCRAPE cap test, costPatterns added to validator)
- [x] Live-verified against `https://www.berlin-h3.eu/events.ics` — 8 events, all extract `cost: '5€'`, 0 enrichment failures (upstream hasn't published Hares yet for upcoming runs — expected)
- [ ] After merge + deploy: run `npx tsx scripts/fix-kennel-data-bh3fm-2026-04.ts` against prod to apply profile fields, then re-dispatch the Berlin source scrape
- [ ] Close #744–#748 once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)