### PR TITLE
fix(travel): Undo re-saves + suppress revision badges on no-coverage

### DIFF
--- a/src/components/travel/TripSummary.test.ts
+++ b/src/components/travel/TripSummary.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "vitest";
+
+// Placeholder for interaction coverage. The undo/restore flow logic lives
+// in TripSummary's handleRemove handler; the server action paths are
+// covered by actions.test.ts (restoreTravelSearch success/error branches).
+// What's missing is the React-rendering side: that clicking Undo fires the
+// server action, updates savedId on success, dismisses the success toast,
+// and shows an error toast on failure. Pending Travel-Mode RTL setup.
+describe("TripSummary", () => {
+  it.todo("restores savedId and captures analytics when Undo succeeds");
+  it.todo("dismisses the success toast and shows error when Undo fails");
+  it.todo("dismisses the success toast and shows error on network failure");
+  it.todo("does not update state if user navigated away during Undo");
+  it.todo("suppresses radiusSnapped badge when noCoverage is true");
+  it.todo("suppresses broaderExpanded badge when noCoverage is true");
+});

--- a/src/components/travel/TripSummary.tsx
+++ b/src/components/travel/TripSummary.tsx
@@ -189,13 +189,25 @@ export function TripSummary({
             // to no-op silently. Going straight to the action keeps the
             // control path obvious and the restore deterministic.
             onClick: async () => {
-              const undo = await restoreTravelSearch(archivedId);
-              if ("success" in undo && undo.success) {
-                setSavedId(archivedId);
-              } else {
-                toast.error("Couldn't undo — save the trip again to preserve it.", {
-                  description: "error" in undo ? undo.error : undefined,
-                });
+              const toastId = undoToastIdRef.current;
+              try {
+                const undo = await restoreTravelSearch(archivedId);
+                // Guard: user navigated to a different search while the
+                // restore was in flight — don't clobber the new trip's state.
+                if (undoToastIdRef.current !== toastId) return;
+                if (toastId != null) toast.dismiss(toastId);
+                if ("success" in undo && undo.success) {
+                  setSavedId(archivedId);
+                  capture("travel_saved_search_restored", {});
+                } else {
+                  toast.error("Couldn't undo — save the trip again to preserve it.", {
+                    description: "error" in undo ? undo.error : undefined,
+                  });
+                }
+              } catch {
+                if (undoToastIdRef.current !== toastId) return;
+                if (toastId != null) toast.dismiss(toastId);
+                toast.error("Couldn't undo — save the trip again to preserve it.");
               }
             },
           },

--- a/src/components/travel/TripSummary.tsx
+++ b/src/components/travel/TripSummary.tsx
@@ -103,10 +103,12 @@ export function TripSummary({
   const days = daysBetween(startDate, endDate);
   const totalCount = confirmedCount + likelyCount + possibleCount;
   // broaderExpanded wins visually over radiusSnapped when both fire.
+  // Suppressed on no_coverage: the EmptyStates copy takes over and a
+  // revision badge would misleadingly imply we found something out there.
   const radiusSnapped =
-    requestedRadiusKm != null && requestedRadiusKm !== radiusKm;
+    !noCoverage && requestedRadiusKm != null && requestedRadiusKm !== radiusKm;
   const broaderExpanded =
-    effectiveRadiusKm != null && effectiveRadiusKm > radiusKm;
+    !noCoverage && effectiveRadiusKm != null && effectiveRadiusKm > radiusKm;
   const radiusToShow = effectiveRadiusKm ?? radiusKm;
   const showProjectionGapHint =
     confirmedCount > 0 && likelyCount === 0 && possibleCount === 0;
@@ -179,17 +181,22 @@ export function TripSummary({
         undoToastIdRef.current = toast.success("Removed from saved trips", {
           action: {
             label: "Undo",
-            onClick: () => {
-              startMutation(async () => {
-                const undo = await restoreTravelSearch(archivedId);
-                if ("success" in undo && undo.success) {
-                  setSavedId(archivedId);
-                } else {
-                  toast.error("Couldn't undo — save the trip again to preserve it.", {
-                    description: "error" in undo ? undo.error : undefined,
-                  });
-                }
-              });
+            // Direct async (no startMutation wrapper): Sonner's action
+            // button renders through its own portal, so the click is a
+            // native DOM event rather than a React synthetic event. Async
+            // transitions kicked off from that boundary don't schedule
+            // reliably — the QA symptom was the server action appearing
+            // to no-op silently. Going straight to the action keeps the
+            // control path obvious and the restore deterministic.
+            onClick: async () => {
+              const undo = await restoreTravelSearch(archivedId);
+              if ("success" in undo && undo.success) {
+                setSavedId(archivedId);
+              } else {
+                toast.error("Couldn't undo — save the trip again to preserve it.", {
+                  description: "error" in undo ? undo.error : undefined,
+                });
+              }
             },
           },
         });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -193,6 +193,7 @@ interface AnalyticsEventMap {
   travel_saved_search_viewed: TravelSavedSearchViewedProps;
   travel_saved_search_updated: Record<string, never>;
   travel_saved_search_removed: Record<string, never>;
+  travel_saved_search_restored: Record<string, never>;
   travel_possible_section_expanded: Record<string, never>;
   travel_share_clicked: TravelShareClickedProps;
   travel_calendar_exported: TravelCalendarExportedProps;


### PR DESCRIPTION
## Summary

Two findings from the re-test of PR #767 that surfaced after merge.

### P2 — Undo doesn't re-save (regression of advertised behavior)

QA repro: click `Saved` to unsave → sonner toast `Removed from saved trips · Undo` → click Undo → toast dismisses, but the trip is still archived in the DB. The restore server action never fired.

**Root cause:** the Undo `onClick` wrapped `restoreTravelSearch` in `startMutation(async () => { ... })`. Sonner's action button renders through a portal, so the click event is a native DOM event rather than a React synthetic event. Async state updates inside a `useTransition` callback launched from that boundary didn't schedule reliably — the server action appeared to no-op silently.

**Fix:** make the onClick directly async; call `restoreTravelSearch` + `setSavedId` without the `useTransition` wrapper. The UX-level indirection from `isMutating` didn't apply to the Undo path anyway (`SavedBadge` isn't visible while `savedId` is null during the Undo window).

### P3 — Revision badges fire on no-coverage empty state

QA repro: Ushuaia search (no kennels at 50 km, no kennels at the 150 km broader-fallback either) rendered `◆ Routing revised · 50 km → 150 km` alongside the `We haven't mapped any hashes here — yet` empty state. The badge falsely implies the expansion found something.

**Fix:** gate `radiusSnapped` and `broaderExpanded` derivations on `!noCoverage`. When there's nothing to show, the EmptyStates copy owns the page and any revision signal becomes misleading noise.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` no new warnings (pre-existing react-hooks warning from 8fec5ce untouched)
- [x] 195 travel tests still passing
- [ ] Preview browser — Undo path:
  - [ ] Save a trip → click Saved → Undo in the toast → chip flips back to Saved, reload confirms DB row restored with original id
- [ ] Preview browser — no-coverage badge:
  - [ ] Ushuaia search → empty state renders without any ◆/◇ revision badge and no strikethrough in the meta line

🤖 Generated with [Claude Code](https://claude.com/claude-code)