### PR TITLE
fix(gcal): enable includeAllDayEvents for EWH3 calendar

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -226,6 +226,7 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "ewh3",
+        includeAllDayEvents: true,
       },
       kennelCodes: ["ewh3"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -227,6 +227,8 @@ export const SOURCES = [
       config: {
         defaultKennelTag: "ewh3",
         includeAllDayEvents: true,
+        defaultTitle: "EWH3 Trail",
+        defaultStartTime: "18:45",
       },
       kennelCodes: ["ewh3"],
     },


### PR DESCRIPTION
## Summary
- EWH3's GCal is 100% all-day placeholders (hashname + "Location TBD"); detailed trail data comes from the EWH3 WordPress secondary source via merge.
- Adding `includeAllDayEvents: true` lets real placeholders through so the CTA filter (PR #782) can drop recruitment entries, WP enriches near-term trails, and hashers see long-tail calendar coverage.
- Also unblocks reconciliation of 115 stale "Hares needed!" canonical events currently stuck at CONFIRMED (the adapter was returning empty, so the reconciler couldn't tell they were missing vs source-down).

## Context
Surfaced during post-merge verification of #782. Live check:
- Before: EWH3 adapter returned 0 events (all-day guard dropped everything)
- After: 75 events, 0 CTA titles leaking past the filter

## Test plan
- [ ] Next scrape populates EWH3 hareline with non-CTA placeholders
- [ ] 115 stale "Hares needed!" canonical events flip to CANCELLED via reconciler
- [ ] Merge pipeline enriches near-term placeholders from EWH3 WordPress source

🤖 Generated with [Claude Code](https://claude.com/claude-code)