### PR TITLE
fix(adapters): Chrome daily hareline audit Round 2 — 7 parser-bug fixes

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2384,6 +2384,10 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "dh4",
+        // #800: calendar emits legacy "DH3 #N" titles despite the kennel
+        // having been recoded to dh4. Adapter substitutes this fallback when
+        // the summary is a bare {kennel-code} #N pattern.
+        defaultTitle: "Dayton H4 Trail",
       },
       kennelCodes: ["dh4"],
     },
@@ -4035,6 +4039,12 @@ export const SOURCES = [
         // null default — unmatched events are skipped rather than
         // silently misrouted to wasatch-h3
         defaultKennelTag: null,
+        // #796: Wasatch titles arrive as bare "wasatch #1144" — substitute a
+        // readable trail name when the adapter matches the kennel-code-only
+        // pattern. Per-kennel keys so lds/slosh/slut keep pattern routing.
+        defaultTitles: {
+          "wasatch-h3": "Wasatch H3 Trail",
+        },
       },
       kennelCodes: ["wasatch-h3", "lds-h3", "slosh-h3", "slut-h3"],
     },

--- a/scripts/verify-round2-autoheal.ts
+++ b/scripts/verify-round2-autoheal.ts
@@ -1,0 +1,59 @@
+/**
+ * Quick check: do the PR #805 fixes auto-heal issues #799, #803, #804?
+ * Runs each adapter in-memory against its production URL and greps for the
+ * reported-bad substring in the relevant field of the sample event.
+ *
+ *   #799 Pedal Files — title should NOT end with " -" or " - tbd"
+ *   #803 BAH3        — hares should NOT contain "2406185563" (phone)
+ *   #804 SWH3        — locationName should NOT contain "text ... for address"
+ */
+import "dotenv/config";
+import { prisma } from "../src/lib/db";
+import { getAdapter } from "../src/adapters/registry";
+
+async function runOne(sourceName: string) {
+  const source = await prisma.source.findFirst({ where: { name: sourceName } });
+  if (!source) throw new Error(`source not found: ${sourceName}`);
+  const adapter = getAdapter(source.type);
+  const result = await adapter.fetch(source, { days: 180 });
+  return { source, events: result.events, errors: result.errors };
+}
+
+function sample(events: { title?: string; hares?: string; location?: string; sourceUrl?: string; runNumber?: number }[], pred: (e: { title?: string; hares?: string; location?: string }) => boolean) {
+  return events.filter(pred).slice(0, 3);
+}
+
+async function main() {
+  // #799 Pedal Files
+  console.log("\n=== #799 Pedal Files ===");
+  const pedal = await runOne("Pedal Files Bash Google Calendar");
+  console.log(`events=${pedal.events.length} errors=${pedal.errors.length}`);
+  const dashArtifacts = sample(pedal.events, e => !!e.title && /\s-\s*(?:tbd)?\s*$/i.test(e.title));
+  console.log(`trailing-dash titles:`, dashArtifacts.length, dashArtifacts.map(e => e.title));
+
+  // #803 BAH3 — calendar is the Baltimore/Annapolis Hash, phone "2406185563"
+  console.log("\n=== #803 BAH3 ===");
+  const bah3 = await runOne("BAH3 iCal Feed");
+  console.log(`events=${bah3.events.length} errors=${bah3.errors.length}`);
+  const phoneHares = sample(bah3.events, e => !!e.hares && /\b2406185563\b/.test(e.hares));
+  console.log(`phone-in-hares:`, phoneHares.length, phoneHares.map(e => ({ hares: e.hares, runNumber: e.runNumber })));
+  const allHares = bah3.events.filter(e => !!e.hares).slice(0, 5);
+  console.log(`sample hares:`, allHares.map(e => e.hares));
+
+  // #804 SWH3
+  console.log("\n=== #804 SWH3 ===");
+  const swh3 = await runOne("SWH3 Google Calendar");
+  console.log(`events=${swh3.events.length} errors=${swh3.errors.length}`);
+  const ctaLocs = sample(swh3.events, e => !!e.location && /\btext\b.*\bfor\s+address\b/i.test(e.location));
+  console.log(`cta-locations:`, ctaLocs.length, ctaLocs.map(e => e.location));
+  const sampleLocs = swh3.events.filter(e => !!e.location).slice(0, 5);
+  console.log(`sample locations:`, sampleLocs.map(e => e.location));
+
+  await prisma.$disconnect();
+}
+
+main().catch(async err => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/verify-round2-autoheal.ts
+++ b/scripts/verify-round2-autoheal.ts
@@ -24,12 +24,15 @@ function sample(events: { title?: string; hares?: string; location?: string; sou
 }
 
 async function main() {
+  let failed = false;
+
   // #799 Pedal Files
   console.log("\n=== #799 Pedal Files ===");
   const pedal = await runOne("Pedal Files Bash Google Calendar");
   console.log(`events=${pedal.events.length} errors=${pedal.errors.length}`);
   const dashArtifacts = sample(pedal.events, e => !!e.title && /\s-\s*(?:tbd)?\s*$/i.test(e.title));
   console.log(`trailing-dash titles:`, dashArtifacts.length, dashArtifacts.map(e => e.title));
+  failed ||= dashArtifacts.length > 0;
 
   // #803 BAH3 — calendar is the Baltimore/Annapolis Hash, phone "2406185563"
   console.log("\n=== #803 BAH3 ===");
@@ -37,6 +40,7 @@ async function main() {
   console.log(`events=${bah3.events.length} errors=${bah3.errors.length}`);
   const phoneHares = sample(bah3.events, e => !!e.hares && /\b2406185563\b/.test(e.hares));
   console.log(`phone-in-hares:`, phoneHares.length, phoneHares.map(e => ({ hares: e.hares, runNumber: e.runNumber })));
+  failed ||= phoneHares.length > 0;
   const allHares = bah3.events.filter(e => !!e.hares).slice(0, 5);
   console.log(`sample hares:`, allHares.map(e => e.hares));
 
@@ -46,10 +50,12 @@ async function main() {
   console.log(`events=${swh3.events.length} errors=${swh3.errors.length}`);
   const ctaLocs = sample(swh3.events, e => !!e.location && /\btext\b.*\bfor\s+address\b/i.test(e.location));
   console.log(`cta-locations:`, ctaLocs.length, ctaLocs.map(e => e.location));
+  failed ||= ctaLocs.length > 0;
   const sampleLocs = swh3.events.filter(e => !!e.location).slice(0, 5);
   console.log(`sample locations:`, sampleLocs.map(e => e.location));
 
   await prisma.$disconnect();
+  if (failed) process.exit(1);
 }
 
 main().catch(async err => {

--- a/scripts/verify-round2-fixes.ts
+++ b/scripts/verify-round2-fixes.ts
@@ -29,7 +29,10 @@ async function runOne(
   return { events: result.events, errors: result.errors };
 }
 
+let hasFailures = false;
+
 function print(label: string, pass: boolean, detail: string) {
+  hasFailures ||= !pass;
   const icon = pass ? "OK" : "FAIL";
   console.log(`[${icon}] ${label} — ${detail}`);
 }
@@ -108,6 +111,7 @@ async function main() {
   }
 
   await prisma.$disconnect();
+  if (hasFailures) process.exit(1);
 }
 
 main().catch(async err => {

--- a/scripts/verify-round2-fixes.ts
+++ b/scripts/verify-round2-fixes.ts
@@ -1,0 +1,116 @@
+/**
+ * Live verification for Round 2 fixes (issues #796–#802).
+ * Runs each affected adapter against its production URL and asserts the
+ * previously-reported defect is gone in the sample events.
+ */
+import "dotenv/config";
+import { prisma } from "../src/lib/db";
+import { getAdapter } from "../src/adapters/registry";
+import type { RawEventData } from "../src/adapters/types";
+
+type Event = RawEventData;
+
+async function runOne(
+  sourceName: string,
+  days = 180,
+  configOverride?: (cfg: Record<string, unknown>) => Record<string, unknown>,
+): Promise<{ events: Event[]; errors: string[] }> {
+  const source = await prisma.source.findFirst({ where: { name: sourceName } });
+  if (!source) throw new Error(`source not found: ${sourceName}`);
+  const patched = configOverride
+    ? { ...source, config: configOverride((source.config ?? {}) as Record<string, unknown>) as never }
+    : source;
+  const adapter = getAdapter(
+    source.type,
+    patched.url ?? undefined,
+    (patched.config ?? undefined) as Record<string, unknown> | undefined,
+  );
+  const result = await adapter.fetch(patched, { days });
+  return { events: result.events, errors: result.errors };
+}
+
+function print(label: string, pass: boolean, detail: string) {
+  const icon = pass ? "OK" : "FAIL";
+  console.log(`[${icon}] ${label} — ${detail}`);
+}
+
+async function main() {
+  // #799 Pedal Files — no trailing "- tbd"/" -" in titles
+  {
+    const { events } = await runOne("Pedal Files Bash Google Calendar");
+    const bad = events.filter(e => e.title && /\s[-–—]\s*(?:tbd|tba|tbc)?\s*$/i.test(e.title));
+    print("#799 Pedal Files trailing-dash titles", bad.length === 0,
+      `events=${events.length} bad=${bad.length} ${bad.slice(0, 3).map(e => e.title).join(" | ")}`);
+  }
+
+  // #796 Whoreman (Wasatch) — titles no longer "wasatch #N".
+  // Seed adds `defaultTitles.wasatch-h3`; inject it here so we can verify
+  // the adapter logic against live calendar data pre-seed-deploy.
+  {
+    const { events } = await runOne(
+      "Whoreman H3 Calendar",
+      180,
+      cfg => ({ ...cfg, defaultTitles: { ...(cfg.defaultTitles as Record<string, string> | undefined), "wasatch-h3": "Wasatch H3 Trail" } }),
+    );
+    const wasatch = events.filter(e => e.kennelTag === "wasatch-h3");
+    const bad = wasatch.filter(e => /^wasatch\s*#?\d+$/i.test(e.title ?? ""));
+    const healed = wasatch.filter(e => /^Wasatch H3 Trail #\d+$/.test(e.title ?? ""));
+    print("#796 Wasatch bare-code titles", bad.length === 0 && healed.length > 0,
+      `wasatch=${wasatch.length} bad=${bad.length} healed=${healed.length} sample=${wasatch.slice(0, 3).map(e => e.title).join(" | ")}`);
+  }
+
+  // #800 Dayton DH4 — titles no longer "DH3 #N". Seed adds `defaultTitle`;
+  // inject for live verify pre-seed-deploy.
+  {
+    const { events } = await runOne(
+      "DH4 Google Calendar",
+      180,
+      cfg => ({ ...cfg, defaultTitle: "Dayton H4 Trail" }),
+    );
+    const bad = events.filter(e => /^dh3\s*#?\d+$/i.test(e.title ?? ""));
+    const healed = events.filter(e => /^Dayton H4 Trail #\d+$/.test(e.title ?? ""));
+    print("#800 Dayton DH3-prefix titles", bad.length === 0 && healed.length > 0,
+      `events=${events.length} bad=${bad.length} healed=${healed.length} sample=${events.slice(0, 5).map(e => e.title).join(" | ")}`);
+  }
+
+  // #798 ABQ — no email-CTA locations
+  {
+    const { events } = await runOne("ABQ H3 Google Calendar");
+    const bad = events.filter(e => e.location && (/inquire.*@/i.test(e.location) || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e.location.trim())));
+    print("#798 ABQ email-CTA locations", bad.length === 0,
+      `events=${events.length} bad=${bad.length} sample-locs=${events.filter(e => e.location).slice(0, 3).map(e => e.location).join(" | ")}`);
+  }
+
+  // #801 Reading H3 — at least some events now have locations extracted
+  {
+    const { events } = await runOne("Reading H3 Localendar");
+    const withLoc = events.filter(e => e.location);
+    print("#801 Reading H3 location fill", withLoc.length > 0,
+      `events=${events.length} with-location=${withLoc.length} sample=${withLoc.slice(0, 3).map(e => e.location).join(" | ")}`);
+  }
+
+  // #797 Hockessin — title is "Hockessin H3 Trail #N", hares populated separately
+  {
+    const { events } = await runOne("Hockessin H3 Website");
+    const malformed = events.filter(e => !e.title || !/^Hockessin H3 Trail #\d+$/.test(e.title));
+    const withHares = events.filter(e => e.hares);
+    print("#797 Hockessin title normalization", malformed.length === 0,
+      `events=${events.length} malformed=${malformed.length} with-hares=${withHares.length} sample=${events.slice(0, 3).map(e => `${e.title} / hares=${e.hares ?? "—"}`).join(" | ")}`);
+  }
+
+  // #802 Bangkok Full Moon — Hares field does not contain "On On" boilerplate
+  {
+    const { events } = await runOne("Bangkok Full Moon Hash");
+    const bad = events.filter(e => e.hares && /^\s*on\s+on\b/i.test(e.hares));
+    print("#802 BFMH3 'On On' in hares", bad.length === 0,
+      `events=${events.length} bad=${bad.length} sample-hares=${events.filter(e => e.hares).slice(0, 3).map(e => e.hares).join(" | ")}`);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async err => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/verify-round2-fixes.ts
+++ b/scripts/verify-round2-fixes.ts
@@ -94,8 +94,9 @@ async function main() {
     const { events } = await runOne("Hockessin H3 Website");
     const malformed = events.filter(e => !e.title || !/^Hockessin H3 Trail #\d+$/.test(e.title));
     const withHares = events.filter(e => e.hares);
+    const sample = events.slice(0, 3).map(e => `${e.title} / hares=${e.hares ?? "—"}`).join(" | ");
     print("#797 Hockessin title normalization", malformed.length === 0,
-      `events=${events.length} malformed=${malformed.length} with-hares=${withHares.length} sample=${events.slice(0, 3).map(e => `${e.title} / hares=${e.hares ?? "—"}`).join(" | ")}`);
+      `events=${events.length} malformed=${malformed.length} with-hares=${withHares.length} sample=${sample}`);
   }
 
   // #802 Bangkok Full Moon — Hares field does not contain "On On" boilerplate

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -1996,106 +1996,33 @@ describe("buildRawEventFromGCalItem — trailing dash + defaultTitle (#756 Moooo
 });
 
 describe("buildRawEventFromGCalItem — audit Round 2 (#796 #798 #799 #800)", () => {
-  it("strips trailing '- tbd' placeholder then applies defaultTitle (#799 Pedal Files)", () => {
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({ summary: "Bash - tbd" }),
-      {
-        kennelPatterns: [["Bash", "pedal-files"]],
-        defaultTitle: "Bash",
-      },
-    );
-    expect(result?.title).toBe("Bash");
+  const pedal = { kennelPatterns: [["Bash", "pedal-files"]] as [string, string][], defaultTitle: "Bash" };
+  const wasatch = { kennelPatterns: [["wasatch", "wasatch-h3"]] as [string, string][], defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" } };
+  const dayton = { kennelPatterns: [["DH[34]", "dh4"]] as [string, string][], defaultTitle: "Dayton H4 Trail" };
+  const april = { kennelPatterns: [["April", "wasatch-h3"]] as [string, string][], defaultTitle: "Wasatch H3 Trail" };
+  const numeric = { kennelPatterns: [["1144", "wasatch-h3"]] as [string, string][], defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" } };
+
+  it.each([
+    ["strips trailing '- tbd' placeholder then applies defaultTitle (#799 Pedal Files)", "Bash - tbd", pedal, "Bash"],
+    ["strips trailing '- TBA' placeholder too (#799)", "Bash - TBA", pedal, "Bash"],
+    ["strips trailing '- TBC' placeholder too (#799)", "Bash - TBC", pedal, "Bash"],
+    ["substitutes defaultTitle for bare '{kennelCode} #N' (#796 Wasatch)", "wasatch #1144", wasatch, "Wasatch H3 Trail #1144"],
+    ["substitutes defaultTitle for '{kennelCode}#N' no-space variant (#800 Dayton)", "DH3#1663", dayton, "Dayton H4 Trail #1663"],
+    ["substitutes defaultTitle for '{kennelCode} #N' with space (#800 Dayton)", "DH3 #1663", dayton, "Dayton H4 Trail #1663"],
+    ["leaves multi-word titles alone even with defaultTitle set (#796 guard)", "April Hash", april, "April Hash"],
+    ["leaves already-canonical 'DefaultTitle #N' titles unchanged (#796 guard)", "Wasatch H3 Trail #1144", wasatch, "Wasatch H3 Trail #1144"],
+    ["leaves bare-number-only titles alone (#796 guard — no letter prefix)", "1144", numeric, "1144"],
+  ] as const)("%s", (_name, summary, config, expected) => {
+    const result = buildRawEventFromGCalItem(testGCalEvent({ summary }), config);
+    expect(result?.title).toBe(expected);
   });
 
-  it("strips trailing '- TBA' / '- TBC' placeholder too (#799)", () => {
+  it.each([
+    ["drops location when it's an 'inquire for location' email CTA (#798 ABQ)", "Inquire for location: abqh3misman@gmail.com"],
+    ["drops location when it's a bare email address (#798)", "abqh3misman@gmail.com"],
+  ])("%s", (_name, location) => {
     const result = buildRawEventFromGCalItem(
-      testGCalEvent({ summary: "Bash - TBA" }),
-      {
-        kennelPatterns: [["Bash", "pedal-files"]],
-        defaultTitle: "Bash",
-      },
-    );
-    expect(result?.title).toBe("Bash");
-  });
-
-  it("substitutes defaultTitle for bare '{kennelCode} #N' (#796 Wasatch)", () => {
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({ summary: "wasatch #1144" }),
-      {
-        kennelPatterns: [["wasatch", "wasatch-h3"]],
-        defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" },
-      },
-    );
-    expect(result?.title).toBe("Wasatch H3 Trail #1144");
-  });
-
-  it("substitutes defaultTitle for '{kennelCode}#N' no-space variant (#800 Dayton)", () => {
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({ summary: "DH3 #1663" }),
-      {
-        kennelPatterns: [["DH[34]", "dh4"]],
-        defaultTitle: "Dayton H4 Trail",
-      },
-    );
-    expect(result?.title).toBe("Dayton H4 Trail #1663");
-  });
-
-  it("leaves multi-word titles alone even with defaultTitle set (#796 guard)", () => {
-    // "April Hash" should not be treated as "{kennelCode} #N" just because
-    // a defaultTitle happens to be configured.
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({ summary: "April Hash" }),
-      {
-        kennelPatterns: [["April", "wasatch-h3"]],
-        defaultTitle: "Wasatch H3 Trail",
-      },
-    );
-    expect(result?.title).toBe("April Hash");
-  });
-
-  it("leaves already-canonical 'DefaultTitle #N' titles unchanged (#796 guard)", () => {
-    // The bare-kennel rewrite must NOT fire when the title is already in the
-    // canonical '{defaultTitle} #N' shape — otherwise we'd churn fingerprints.
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({ summary: "Wasatch H3 Trail #1144" }),
-      {
-        kennelPatterns: [["wasatch", "wasatch-h3"]],
-        defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" },
-      },
-    );
-    expect(result?.title).toBe("Wasatch H3 Trail #1144");
-  });
-
-  it("leaves bare-number-only titles alone (#796 guard — no letter prefix)", () => {
-    // "1144" alone has no kennel prefix; must not be rewritten to
-    // "Wasatch H3 Trail #1144" out of thin air.
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({ summary: "1144" }),
-      {
-        kennelPatterns: [["1144", "wasatch-h3"]],
-        defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" },
-      },
-    );
-    expect(result?.title).toBe("1144");
-  });
-
-  it("drops location when it's an 'inquire for location' email CTA (#798 ABQ)", () => {
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({
-        summary: "ABQ Hash #42",
-        location: "Inquire for location: abqh3misman@gmail.com",
-      }),
-      { defaultKennelTag: "abq-h3" },
-    );
-    expect(result?.location).toBeUndefined();
-  });
-
-  it("drops location when it's a bare email address (#798)", () => {
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({
-        summary: "ABQ Hash #43",
-        location: "abqh3misman@gmail.com",
-      }),
+      testGCalEvent({ summary: "ABQ Hash #42", location }),
       { defaultKennelTag: "abq-h3" },
     );
     expect(result?.location).toBeUndefined();

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -1995,6 +1995,113 @@ describe("buildRawEventFromGCalItem — trailing dash + defaultTitle (#756 Moooo
   });
 });
 
+describe("buildRawEventFromGCalItem — audit Round 2 (#796 #798 #799 #800)", () => {
+  it("strips trailing '- tbd' placeholder then applies defaultTitle (#799 Pedal Files)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "Bash - tbd" }),
+      {
+        kennelPatterns: [["Bash", "pedal-files"]],
+        defaultTitle: "Bash",
+      },
+    );
+    expect(result?.title).toBe("Bash");
+  });
+
+  it("strips trailing '- TBA' / '- TBC' placeholder too (#799)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "Bash - TBA" }),
+      {
+        kennelPatterns: [["Bash", "pedal-files"]],
+        defaultTitle: "Bash",
+      },
+    );
+    expect(result?.title).toBe("Bash");
+  });
+
+  it("substitutes defaultTitle for bare '{kennelCode} #N' (#796 Wasatch)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "wasatch #1144" }),
+      {
+        kennelPatterns: [["wasatch", "wasatch-h3"]],
+        defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" },
+      },
+    );
+    expect(result?.title).toBe("Wasatch H3 Trail #1144");
+  });
+
+  it("substitutes defaultTitle for '{kennelCode}#N' no-space variant (#800 Dayton)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "DH3 #1663" }),
+      {
+        kennelPatterns: [["DH[34]", "dh4"]],
+        defaultTitle: "Dayton H4 Trail",
+      },
+    );
+    expect(result?.title).toBe("Dayton H4 Trail #1663");
+  });
+
+  it("leaves multi-word titles alone even with defaultTitle set (#796 guard)", () => {
+    // "April Hash" should not be treated as "{kennelCode} #N" just because
+    // a defaultTitle happens to be configured.
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "April Hash" }),
+      {
+        kennelPatterns: [["April", "wasatch-h3"]],
+        defaultTitle: "Wasatch H3 Trail",
+      },
+    );
+    expect(result?.title).toBe("April Hash");
+  });
+
+  it("leaves already-canonical 'DefaultTitle #N' titles unchanged (#796 guard)", () => {
+    // The bare-kennel rewrite must NOT fire when the title is already in the
+    // canonical '{defaultTitle} #N' shape — otherwise we'd churn fingerprints.
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "Wasatch H3 Trail #1144" }),
+      {
+        kennelPatterns: [["wasatch", "wasatch-h3"]],
+        defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" },
+      },
+    );
+    expect(result?.title).toBe("Wasatch H3 Trail #1144");
+  });
+
+  it("leaves bare-number-only titles alone (#796 guard — no letter prefix)", () => {
+    // "1144" alone has no kennel prefix; must not be rewritten to
+    // "Wasatch H3 Trail #1144" out of thin air.
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "1144" }),
+      {
+        kennelPatterns: [["1144", "wasatch-h3"]],
+        defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" },
+      },
+    );
+    expect(result?.title).toBe("1144");
+  });
+
+  it("drops location when it's an 'inquire for location' email CTA (#798 ABQ)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "ABQ Hash #42",
+        location: "Inquire for location: abqh3misman@gmail.com",
+      }),
+      { defaultKennelTag: "abq-h3" },
+    );
+    expect(result?.location).toBeUndefined();
+  });
+
+  it("drops location when it's a bare email address (#798)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "ABQ Hash #43",
+        location: "abqh3misman@gmail.com",
+      }),
+      { defaultKennelTag: "abq-h3" },
+    );
+    expect(result?.location).toBeUndefined();
+  });
+});
+
 describe("buildRawEventFromGCalItem — strictKennelRouting (#753 WA Hash)", () => {
   // `defaultKennelTag` is set alongside strict routing to prove the strict flag
   // actually short-circuits the fallback, not merely that no fallback exists.

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -699,7 +699,7 @@ export function buildRawEventFromGCalItem(
   // #799 Pedal Files: trailing "- tbd" / "- tba" placeholder after a delimiter
   // ("Bash - tbd" → "Bash"). Runs *after* w/ extraction so we don't consume the
   // " - TBA" tail of "Title w/ TBD - TBA" before the pattern can strip it.
-  title = title.replace(/\s*[-–—]\s*(?:tbd|tba|tbc)\s*$/i, "").trim();
+  title = title.replace(/\s*[-–—]\s*(?:tbd|tba|tbc)\.?\s*$/i, "").trim();
 
   // Trailing "(Hare Name)" parenthetical (common in Boston/many kennels).
   // When hares are already set from description, the parenthetical is left in the title

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -770,11 +770,9 @@ export function buildRawEventFromGCalItem(
     const prefix = bareKennelRunMatch?.[1];
     const prefixMatchesKennel = !!prefix && (
       titleMatchesKennelTag(prefix, kennelTag)
-      || !!sourceConfig?.kennelPatterns?.some(([pattern, tag]) => {
-        if (tag !== kennelTag) return false;
-        try { return new RegExp(`^(?:${pattern})$`, "i").test(prefix); }
-        catch { return false; }
-      })
+      || (sourceConfig?.kennelPatterns
+        ? matchConfigPatterns(prefix, sourceConfig.kennelPatterns) === kennelTag
+        : false)
     );
     if (bareKennelRunMatch && prefixMatchesKennel) {
       title = `${fallback} #${bareKennelRunMatch[2]}`;

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -2,7 +2,7 @@ import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
 import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, HARE_BOILERPLATE_RE, EVENT_FIELD_LABEL_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, stripNonEnglishCountry } from "../utils";
-import { PHONE_NUMBER_RE } from "@/pipeline/audit-checks";
+import { PHONE_NUMBER_RE, LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 
 // Kennel patterns derived from actual Boston Hash Calendar event data.
 // Longer/more-specific patterns first to avoid false matches.
@@ -129,6 +129,10 @@ const TITLE_SCHEDULE_LINE_RE = /:\s*\d{1,2}:\d{2}\s*(?:am|pm)/i;
 // suffixes like "(text for details)" that creep in via Google Calendar.
 const PHONE_TRAILING_RE = new RegExp(String.raw`\s*(?:${PHONE_NUMBER_RE.source})\s*$`);
 const LOCATION_TRAILING_CTA_RE = /\s*\((?:text|call|contact|ping)[^)]*\)\s*$/i;
+// #798 ABQ: bare-email fallback for locationName (e.g. "abqh3misman@gmail.com"
+// on its own). The broader "Inquire for location: …@…" form is shared with
+// the audit-checks rule and imported above.
+const LOCATION_BARE_EMAIL_RE = /^\s*\S+@\S+\.\S+\s*$/;
 
 // Pre-compiled regexes for extractLocationFromDescription.
 // #742: hash-vernacular labels (De'erections, Direcshits, Where to gather) are synonyms for "Location".
@@ -621,6 +625,10 @@ export function buildRawEventFromGCalItem(
       .replace(PHONE_TRAILING_RE, "")
       .trim() || undefined;
   }
+  // #798: drop email-CTA-as-location values outright — no address to preserve.
+  if (location && (LOCATION_EMAIL_CTA_RE.test(location) || LOCATION_BARE_EMAIL_RE.test(location))) {
+    location = undefined;
+  }
   if (location && (isPlaceholder(location) || isNonAddressText(location))) location = undefined;
   if (!location && rawDescription) {
     location = extractLocationFromDescription(rawDescription);
@@ -688,6 +696,11 @@ export function buildRawEventFromGCalItem(
     }
   }
 
+  // #799 Pedal Files: trailing "- tbd" / "- tba" placeholder after a delimiter
+  // ("Bash - tbd" → "Bash"). Runs *after* w/ extraction so we don't consume the
+  // " - TBA" tail of "Title w/ TBD - TBA" before the pattern can strip it.
+  title = title.replace(/\s*[-–—]\s*(?:tbd|tba|tbc)\s*$/i, "").trim();
+
   // Trailing "(Hare Name)" parenthetical (common in Boston/many kennels).
   // When hares are already set from description, the parenthetical is left in the title
   // since it may be a subtitle rather than a hare name.
@@ -746,8 +759,16 @@ export function buildRawEventFromGCalItem(
   // defaultTitle fallback runs last, after all branches that may reset title to kennelTag.
   // Also fires when title collapsed to empty after trailing-dash strip (#756).
   const fallback = sourceConfig?.defaultTitles?.[kennelTag] ?? sourceConfig?.defaultTitle;
-  if ((!title || titleMatchesKennelTag(title, kennelTag)) && fallback) {
-    title = fallback;
+  if (fallback) {
+    // #796 #800: titles like "wasatch #1144" or "DH3 #1663" are raw kennel-code
+    // + run-number pairs, not real event names. Substitute the configured
+    // default and preserve the run number so users see a readable trail name.
+    const bareKennelRunMatch = /^[A-Za-z][A-Za-z0-9-]{0,19}\s*#?\s*(\d+)$/.exec(title);
+    if (bareKennelRunMatch) {
+      title = `${fallback} #${bareKennelRunMatch[1]}`;
+    } else if (!title || titleMatchesKennelTag(title, kennelTag)) {
+      title = fallback;
+    }
   }
 
   // Start time: prefer dateTime-derived time, then description extraction,

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -763,9 +763,21 @@ export function buildRawEventFromGCalItem(
     // #796 #800: titles like "wasatch #1144" or "DH3 #1663" are raw kennel-code
     // + run-number pairs, not real event names. Substitute the configured
     // default and preserve the run number so users see a readable trail name.
-    const bareKennelRunMatch = /^[A-Za-z][A-Za-z0-9-]{0,19}\s*#?\s*(\d+)$/.exec(title);
-    if (bareKennelRunMatch) {
-      title = `${fallback} #${bareKennelRunMatch[1]}`;
+    // Guard: require the prefix to match either the resolved kennelTag or one
+    // of the configured kennelPatterns — otherwise legit titles like
+    // "Picnic 2026" get rewritten to "{defaultTitle} #2026".
+    const bareKennelRunMatch = /^([A-Za-z][A-Za-z0-9-]{0,19})\s*#?\s*(\d+)$/.exec(title);
+    const prefix = bareKennelRunMatch?.[1];
+    const prefixMatchesKennel = !!prefix && (
+      titleMatchesKennelTag(prefix, kennelTag)
+      || !!sourceConfig?.kennelPatterns?.some(([pattern, tag]) => {
+        if (tag !== kennelTag) return false;
+        try { return new RegExp(`^(?:${pattern})$`, "i").test(prefix); }
+        catch { return false; }
+      })
+    );
+    if (bareKennelRunMatch && prefixMatchesKennel) {
+      title = `${fallback} #${bareKennelRunMatch[2]}`;
     } else if (!title || titleMatchesKennelTag(title, kennelTag)) {
       title = fallback;
     }

--- a/src/adapters/html-scraper/bangkokhash.test.ts
+++ b/src/adapters/html-scraper/bangkokhash.test.ts
@@ -69,6 +69,22 @@ describe("parseNextRunArticle", () => {
     const event = parseNextRunArticle("<div></div>", "bth3", "18:30", "https://example.com");
     expect(event).toBeNull();
   });
+
+  it("filters boilerplate 'On On Q' out of Hares field (#802 BFMH3)", () => {
+    // From BFMH3 (Bangkok Full Moon) next-run article — the labeled
+    // `Hares:` row carries "On On Q" filler instead of a real name.
+    const html = `
+<div class="item-content">
+  <p><strong>Date</strong>: 22-Apr-2026<br>
+  <strong>Start Time</strong>: 18:30<br>
+  <strong>Hares</strong>: On On Q<br>
+  <strong>Station</strong>: BTS Asok<br>
+  <strong>Run Site</strong>: Lumpini Park</p>
+</div>`;
+    const event = parseNextRunArticle(html, "bfmh3", "18:30", "https://www.bangkokhash.com/fullmoon/index.php");
+    expect(event).not.toBeNull();
+    expect(event!.hares).toBeUndefined();
+  });
 });
 
 describe("parseHarelineApiHtml", () => {

--- a/src/adapters/html-scraper/bangkokhash.ts
+++ b/src/adapters/html-scraper/bangkokhash.ts
@@ -93,7 +93,11 @@ export function parseNextRunArticle(
     ? startTimeRaw
     : defaultTime;
 
-  const hare = grab("Hares?");
+  // #802: the labeled `Hares:` field sometimes carries filler like "On On Q"
+  // instead of a real name. Mirror the API-path boilerplate guard so we don't
+  // ship "On On Q" as a hare name.
+  const hareRaw = grab("Hares?");
+  const hare = hareRaw && !HARE_BOILERPLATE_RE.test(hareRaw) ? hareRaw : undefined;
   const station = grab("Station");
   const runSite = grab("Run\\s*Site");
   const restaurant = grab("Restaurant");

--- a/src/adapters/html-scraper/hockessin.test.ts
+++ b/src/adapters/html-scraper/hockessin.test.ts
@@ -3,7 +3,8 @@ import { parseHockessinEvent } from "./hockessin";
 
 describe("HockessinAdapter", () => {
   describe("parseHockessinEvent", () => {
-    it("parses a standard event with title, date, time, and location", () => {
+    it("parses a standard event with title, date, time, hares, and location", () => {
+      // #797: post-colon header text is the hare name, not the event title.
       const header = "Hash #1656: Green Dress Hash";
       const detail = "SATURDAY, March 14, 2026, 3:00pm, (Prelube at 2:30PM, pack off 3:15), 404 New London Road, Newark, DE";
 
@@ -11,7 +12,8 @@ describe("HockessinAdapter", () => {
 
       expect(event).not.toBeNull();
       expect(event!.runNumber).toBe(1656);
-      expect(event!.title).toBe("Green Dress Hash");
+      expect(event!.title).toBe("Hockessin H3 Trail #1656");
+      expect(event!.hares).toBe("Green Dress Hash");
       expect(event!.date).toBe("2026-03-14");
       expect(event!.startTime).toBe("15:00");
       expect(event!.kennelTag).toBe("hockessin");
@@ -28,10 +30,37 @@ describe("HockessinAdapter", () => {
 
       expect(event).not.toBeNull();
       expect(event!.runNumber).toBe(1650);
-      expect(event!.title).toBe("January Thaw");
+      expect(event!.title).toBe("Hockessin H3 Trail #1650");
+      expect(event!.hares).toBe("January Thaw");
       expect(event!.date).toBe("2026-01-10");
       expect(event!.startTime).toBe("15:00");
       expect(event!.location).toContain("123 Main Street");
+    });
+
+    it("live-format fixture from #797: '715 Art Lane, Newark, DE'", () => {
+      // Verbatim from hockessinhash.org on 2026-04-19.
+      const header = "Hash #1661: Asshopper";
+      const detail = "SATURDAY, April 18, 2026, 3:00pm,  715 Art Lane, Newark, DE";
+
+      const event = parseHockessinEvent(header, detail, "https://www.hockessinhash.org/");
+
+      expect(event).not.toBeNull();
+      expect(event!.runNumber).toBe(1661);
+      expect(event!.title).toBe("Hockessin H3 Trail #1661");
+      expect(event!.hares).toBe("Asshopper");
+      expect(event!.date).toBe("2026-04-18");
+      expect(event!.startTime).toBe("15:00");
+      expect(event!.location).toBe("715 Art Lane, Newark, DE");
+    });
+
+    it("rejects TBA/TBD placeholder locations", () => {
+      const header = "Hash #1670: Placeholder Event";
+      const detail = "SATURDAY, July 4, 2026, 3:00pm, TBA";
+
+      const event = parseHockessinEvent(header, detail, "https://www.hockessinhash.org/");
+
+      expect(event).not.toBeNull();
+      expect(event!.location).toBeUndefined();
     });
 
     it("returns null for non-matching header", () => {
@@ -84,14 +113,17 @@ describe("HockessinAdapter", () => {
       expect(event!.runNumber).toBe(999);
     });
 
-    it("uses title from header and falls back for missing title", () => {
+    it("emits empty hares when the header has no post-colon text", () => {
+      // Title is always synthesized from the run number (#797); a missing
+      // post-colon segment just leaves hares undefined.
       const header = "Hash #1700: ";
       const detail = "SATURDAY, May 2, 2026, 3:00pm, Test Location";
 
       const event = parseHockessinEvent(header, detail, "https://www.hockessinhash.org/");
 
       expect(event).not.toBeNull();
-      expect(event!.title).toBe("Hockessin #1700");
+      expect(event!.title).toBe("Hockessin H3 Trail #1700");
+      expect(event!.hares).toBeUndefined();
     });
   });
 });

--- a/src/adapters/html-scraper/hockessin.ts
+++ b/src/adapters/html-scraper/hockessin.ts
@@ -28,11 +28,12 @@ export function parseHockessinEvent(
   detailText: string,
   sourceUrl: string,
 ): RawEventData | null {
-  const headerMatch = /Hash\s*#(\d+)\s*:\s*(.+)/i.exec(headerText);
+  // Optional post-colon group so "Hash #1700:" (no trailing whitespace) still parses.
+  const headerMatch = /Hash\s*#(\d+)(?:\s*:\s*(.*))?/i.exec(headerText);
   if (!headerMatch) return null;
 
   const runNumber = Number.parseInt(headerMatch[1], 10);
-  const hares = headerMatch[2].trim() || undefined;
+  const hares = headerMatch[2]?.trim() || undefined;
 
   const cleaned = detailText.replace(/\s+/g, " ").trim();
   if (!cleaned) return null;

--- a/src/adapters/html-scraper/hockessin.ts
+++ b/src/adapters/html-scraper/hockessin.ts
@@ -14,10 +14,12 @@ import { fetchHTMLPage, parse12HourTime, chronoParseDate } from "../utils";
  *
  * The site uses 90s-era HTML with `<font>` and `<b>` tags, no CSS classes.
  * Each event has:
- *   <font color="..."><b>Hash #1656: Green Dress Hash</b></font> <br>
- *   SATURDAY, March 14, 2026, 3:00pm, (Prelube at 2:30PM, pack off 3:15), 404 New London Road, Newark, DE <br>
+ *   <font color="..."><b>Hash #1661: Asshopper</b></font> <br>
+ *   SATURDAY, April 18, 2026, 3:00pm, 715 Art Lane, Newark, DE <br>
  *
- * @param headerText - The text from the <b> tag (e.g., "Hash #1656: Green Dress Hash")
+ * The post-colon header text is the hare name(s) — NOT the event title (#797).
+ *
+ * @param headerText - The text from the <b> tag (e.g., "Hash #1661: Asshopper")
  * @param detailText - The raw text node after the header (date, time, location info)
  * @param sourceUrl  - Source URL for fallback
  */
@@ -26,45 +28,40 @@ export function parseHockessinEvent(
   detailText: string,
   sourceUrl: string,
 ): RawEventData | null {
-  // Extract run number and title from header
   const headerMatch = /Hash\s*#(\d+)\s*:\s*(.+)/i.exec(headerText);
   if (!headerMatch) return null;
 
   const runNumber = Number.parseInt(headerMatch[1], 10);
-  const title = headerMatch[2].trim();
+  const hares = headerMatch[2].trim() || undefined;
 
-  // Clean up detail text — remove leading/trailing whitespace and BRs
   const cleaned = detailText.replace(/\s+/g, " ").trim();
   if (!cleaned) return null;
 
-  // Parse date using chrono (handles "SATURDAY, March 14, 2026" etc.)
   const date = chronoParseDate(cleaned, "en-US", undefined, { forwardDate: true });
   if (!date) return null;
 
-  // Extract time — find the first HH:MM am/pm pattern
   const startTime = parse12HourTime(cleaned);
 
-  // Extract location — everything after the time in the detail string
-  let location: string | undefined;
-
-  // Remove parenthetical notes like "(Prelube at 2:30PM, pack off 3:15)"
+  // Strip parenthetical notes like "(Prelube at 2:30PM, pack off 3:15)" before
+  // locating the post-time address segment.
   const withoutParens = cleaned.replace(/\([^)]*\)/g, "");
+  const timeMatch = /\d{1,2}:\d{2}\s*(?:am|pm)/i.exec(withoutParens);
 
-  // Find the time to locate where the location details start
-  const timeRegex = /(\d{1,2}:\d{2}\s*(?:am|pm))/i;
-  const timeMatch = timeRegex.exec(withoutParens);
-
+  let location: string | undefined;
   if (timeMatch) {
-    const locationPart = withoutParens.substring(timeMatch.index + timeMatch[0].length);
-    location = locationPart.replace(/^,?\s*/, "").trim();
-    if (!location) location = undefined;
+    const after = withoutParens.substring(timeMatch.index + timeMatch[0].length).replace(/^,?\s*/, "").trim();
+    // Reject placeholders like "TBA" / "TBD" so the kennel centroid fallback wins.
+    if (after && !/^(?:tba|tbd|tbc)\.?$/i.test(after)) {
+      location = after;
+    }
   }
 
   return {
     date,
     kennelTag: "hockessin",
     runNumber: !Number.isNaN(runNumber) ? runNumber : undefined,
-    title: title || `Hockessin #${runNumber}`,
+    title: `Hockessin H3 Trail #${runNumber}`,
+    hares,
     location,
     startTime,
     sourceUrl,

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { ICalAdapter, parseICalSummary, extractHaresFromDescription, extractRunNumberFromDescription, extractLocationFromDescription, extractCostFromDescription, extractMapsUrlFromDescription, paramValue } from "./adapter";
+import { ICalAdapter, parseICalSummary, extractHaresFromDescription, extractRunNumberFromDescription, extractLocationFromDescription, extractOnOnVenueFromDescription, extractCostFromDescription, extractMapsUrlFromDescription, paramValue } from "./adapter";
 import type { Source } from "@/generated/prisma/client";
 import type { ParameterValue } from "node-ical";
 
@@ -331,6 +331,44 @@ describe("extractLocationFromDescription", () => {
   it("handles multiline description with location in the middle", () => {
     const desc = String.raw`Hare: Captain Hash\n\nWhere: Fells Point\n\nBring $5`;
     expect(extractLocationFromDescription(desc)).toBe("Fells Point");
+  });
+});
+
+describe("extractOnOnVenueFromDescription (#801 Reading H3)", () => {
+  it("captures venue after 'On On: {time} …' before 'Hares:'", () => {
+    // Fixture from Reading H3 Localendar feed (#801 issue body).
+    const desc = "Run #1234 On On: 6:15p Lower Access lot at Monocacy Hill Hares: Cowboy";
+    expect(extractOnOnVenueFromDescription(desc)).toBe("Lower Access lot at Monocacy Hill");
+  });
+
+  it("handles ICS-escaped commas and semicolons", () => {
+    const desc = String.raw`Run #1234 On On: 6:15pm 404 New London Road\, Newark\, DE Hares: Cowboy`;
+    expect(extractOnOnVenueFromDescription(desc)).toBe("404 New London Road, Newark, DE");
+  });
+
+  it("stops at 'Hash Cash:' sibling label", () => {
+    const desc = String.raw`On On: Main Park Hash Cash: $5`;
+    expect(extractOnOnVenueFromDescription(desc)).toBe("Main Park");
+  });
+
+  it("returns undefined when no 'On On:' label", () => {
+    expect(extractOnOnVenueFromDescription("Hares: Cowboy")).toBeUndefined();
+  });
+
+  it("rejects captures that are just a time fragment", () => {
+    const desc = "On On: 6:15p";
+    expect(extractOnOnVenueFromDescription(desc)).toBeUndefined();
+  });
+
+  it("rejects captures shorter than 3 chars", () => {
+    const desc = "On On: X";
+    expect(extractOnOnVenueFromDescription(desc)).toBeUndefined();
+  });
+
+  it("stops at 'Hares:' even when no whitespace precedes it", () => {
+    // Guards against typo'd feeds where 'Hares:' is adjacent to the venue.
+    const desc = "On On: Lower Access lotHares: Cowboy";
+    expect(extractOnOnVenueFromDescription(desc)).toBe("Lower Access lot");
   });
 });
 

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -370,6 +370,17 @@ describe("extractOnOnVenueFromDescription (#801 Reading H3)", () => {
     const desc = "On On: Lower Access lotHares: Cowboy";
     expect(extractOnOnVenueFromDescription(desc)).toBe("Lower Access lot");
   });
+
+  it("ignores 'On On On:' after-run shorthand", () => {
+    // "On On On:" names the *after-run* pub, not the trail start — skip it.
+    const desc = "Hares: Cowboy On On On: Cozy Car";
+    expect(extractOnOnVenueFromDescription(desc)).toBeUndefined();
+  });
+
+  it("strips 24-hour leading time too", () => {
+    const desc = "On On: 18:30 Main Park Hares: Cowboy";
+    expect(extractOnOnVenueFromDescription(desc)).toBe("Main Park");
+  });
 });
 
 describe("extractCostFromDescription", () => {

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -174,6 +174,29 @@ export function extractLocationFromDescription(description: string, customPatter
   });
 }
 
+// #801 Reading H3 format: "...On On: 6:15p Lower Access lot at Monocacy Hill Hares: ..."
+// Captures everything after "On On:" up to " Hares:" / " Hash Cash:" / newline / end,
+// then strips a leading time token if present.
+const ON_ON_VENUE_RE = /On[-\s]?On\s*:\s*([^\n]+?)(?=\s*Hares?:|\s*Hash\s*Cash:|\n|$)/i;
+const LEADING_TIME_RE = /^\d{1,2}(?::\d{2})?\s*[ap]\.?m?\.?\s+/i;
+
+/**
+ * Fallback for iCal DESCRIPTION bodies that embed the venue inline via
+ * "On On: {time} {venue} Hares: ..." — common in Localendar-hosted feeds
+ * (Reading H3 #801).
+ */
+export function extractOnOnVenueFromDescription(description: string): string | undefined {
+  const normalized = normalizeIcsDescription(description);
+  const match = ON_ON_VENUE_RE.exec(normalized);
+  if (!match) return undefined;
+  let venue = match[1].replace(LEADING_TIME_RE, "").trim();
+  venue = venue.replaceAll("\\;", ";").replaceAll("\\,", ",");
+  if (venue.length < 3 || venue.length > 300) return undefined;
+  // Reject captures that are nothing but a time or a stray punctuation fragment.
+  if (LEADING_TIME_RE.test(venue + " ")) return undefined;
+  return venue;
+}
+
 /**
  * Extract a cost/hash-cash value from an iCal DESCRIPTION field.
  * Accepts pre-compiled RegExp[] for custom patterns; falls back to default COST_PATTERNS.
@@ -395,7 +418,8 @@ function buildRawEventFromVEvent(
   }
 
   if (!location && description) {
-    location = extractLocationFromDescription(description, compiledLocationPatterns);
+    location = extractLocationFromDescription(description, compiledLocationPatterns)
+      ?? extractOnOnVenueFromDescription(description);
   }
 
   const locationUrl = resolveLocationUrl(vevent.geo, location, description);

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -180,7 +180,11 @@ export function extractLocationFromDescription(description: string, customPatter
 //   2. Slice to the first sibling label (Hares:/Hash Cash:) or newline.
 const ON_ON_LABEL_RE = /On[-\s]?On\s*:\s*/i;
 const ON_ON_TERMINATOR_RE = /\s*Hares?:|\s*Hash\s*Cash:|\n/i;
-const LEADING_TIME_RE = /^\d{1,2}(?::\d{2})?\s*[ap]\.?m?\.?\s+/i;
+// Guards against "On On On: Cozy Car" (after-run shorthand) false-positive.
+const PRECEDING_ON_RE = /\bOn[-\s]$/i;
+// Accepts 12-hour ("6:15p", "6:15 pm") and 24-hour ("18:30") leading times.
+const LEADING_TIME_RE = /^(?:\d{1,2}(?::\d{2})?\s*[ap]\.?m?\.?|\d{1,2}:\d{2})\s+/i;
+const TIME_ONLY_RE = /^(?:\d{1,2}(?::\d{2})?\s*[ap]\.?m?\.?|\d{1,2}:\d{2})$/i;
 
 /**
  * Fallback for iCal DESCRIPTION bodies that embed the venue inline via
@@ -191,6 +195,11 @@ export function extractOnOnVenueFromDescription(description: string): string | u
   const normalized = normalizeIcsDescription(description);
   const labelMatch = ON_ON_LABEL_RE.exec(normalized);
   if (!labelMatch) return undefined;
+  // Reject after-run "On On On:" shorthand — the leading "On " makes the
+  // trailing "On On:" match the label even though it's not the start-point.
+  if (labelMatch.index > 0 && PRECEDING_ON_RE.test(normalized.slice(0, labelMatch.index))) {
+    return undefined;
+  }
   const afterLabel = normalized.slice(labelMatch.index + labelMatch[0].length);
   const termMatch = ON_ON_TERMINATOR_RE.exec(afterLabel);
   const rawVenue = termMatch ? afterLabel.slice(0, termMatch.index) : afterLabel;
@@ -198,7 +207,7 @@ export function extractOnOnVenueFromDescription(description: string): string | u
   venue = venue.replaceAll(String.raw`\;`, ";").replaceAll(String.raw`\,`, ",");
   if (venue.length < 3 || venue.length > 300) return undefined;
   // Reject captures that are nothing but a time or a stray punctuation fragment.
-  if (LEADING_TIME_RE.test(venue + " ")) return undefined;
+  if (TIME_ONLY_RE.test(venue)) return undefined;
   return venue;
 }
 

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -175,9 +175,11 @@ export function extractLocationFromDescription(description: string, customPatter
 }
 
 // #801 Reading H3 format: "...On On: 6:15p Lower Access lot at Monocacy Hill Hares: ..."
-// Captures everything after "On On:" up to " Hares:" / " Hash Cash:" / newline / end,
-// then strips a leading time token if present.
-const ON_ON_VENUE_RE = /On[-\s]?On\s*:\s*([^\n]+?)(?=\s*Hares?:|\s*Hash\s*Cash:|\n|$)/i;
+// Two-pass extraction (single regex trips SonarCloud complexity cap):
+//   1. Find the 'On On:' label.
+//   2. Slice to the first sibling label (Hares:/Hash Cash:) or newline.
+const ON_ON_LABEL_RE = /On[-\s]?On\s*:\s*/i;
+const ON_ON_TERMINATOR_RE = /\s*Hares?:|\s*Hash\s*Cash:|\n/i;
 const LEADING_TIME_RE = /^\d{1,2}(?::\d{2})?\s*[ap]\.?m?\.?\s+/i;
 
 /**
@@ -187,10 +189,13 @@ const LEADING_TIME_RE = /^\d{1,2}(?::\d{2})?\s*[ap]\.?m?\.?\s+/i;
  */
 export function extractOnOnVenueFromDescription(description: string): string | undefined {
   const normalized = normalizeIcsDescription(description);
-  const match = ON_ON_VENUE_RE.exec(normalized);
-  if (!match) return undefined;
-  let venue = match[1].replace(LEADING_TIME_RE, "").trim();
-  venue = venue.replaceAll("\\;", ";").replaceAll("\\,", ",");
+  const labelMatch = ON_ON_LABEL_RE.exec(normalized);
+  if (!labelMatch) return undefined;
+  const afterLabel = normalized.slice(labelMatch.index + labelMatch[0].length);
+  const termMatch = ON_ON_TERMINATOR_RE.exec(afterLabel);
+  const rawVenue = termMatch ? afterLabel.slice(0, termMatch.index) : afterLabel;
+  let venue = rawVenue.replace(LEADING_TIME_RE, "").trim();
+  venue = venue.replaceAll(String.raw`\;`, ";").replaceAll(String.raw`\,`, ",");
   if (venue.length < 3 || venue.length > 300) return undefined;
   // Reject captures that are nothing but a time or a stray punctuation fragment.
   if (LEADING_TIME_RE.test(venue + " ")) return undefined;

--- a/src/pipeline/audit-checks.test.ts
+++ b/src/pipeline/audit-checks.test.ts
@@ -407,52 +407,24 @@ describe("checkLocationQuality", () => {
     expect(findings).toHaveLength(0);
   });
 
-  it("flags location-phone-number for separated phone in locationName (#743)", () => {
-    const event = makeEvent({
-      locationName: "Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)",
-    });
-    const findings = checkLocationQuality([event]);
+  it.each([
+    ["location-phone-number for separated phone in locationName (#743)", "Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)", "location-phone-number"],
+    ["location-phone-number for bare 10-digit run in locationName", "Private home, call 9193326661 for address", "location-phone-number"],
+    ["location-email-cta for 'Inquire for location: …@…' (#798 ABQ)", "Inquire for location: abqh3misman@gmail.com", "location-email-cta"],
+  ])("flags %s", (_name, locationName, rule) => {
+    const findings = checkLocationQuality([makeEvent({ locationName })]);
     expect(findings).toHaveLength(1);
-    expect(findings[0].rule).toBe("location-phone-number");
+    expect(findings[0].rule).toBe(rule);
     expect(findings[0].severity).toBe("warning");
     expect(findings[0].category).toBe("location");
     expect(findings[0].field).toBe("locationName");
   });
 
-  it("flags location-phone-number for bare 10-digit run in locationName", () => {
-    const event = makeEvent({
-      locationName: "Private home, call 9193326661 for address",
-    });
-    const findings = checkLocationQuality([event]);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].rule).toBe("location-phone-number");
-  });
-
-  it("does not flag location-phone-number for street numbers or ZIP codes", () => {
-    const event = makeEvent({
-      locationName: "15001 Health Center Dr, Bowie, MD 20716",
-    });
-    const findings = checkLocationQuality([event]);
-    expect(findings).toHaveLength(0);
-  });
-
-  it("flags location-email-cta for 'Inquire for location: …@…' (#798 ABQ)", () => {
-    const event = makeEvent({
-      locationName: "Inquire for location: abqh3misman@gmail.com",
-    });
-    const findings = checkLocationQuality([event]);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].rule).toBe("location-email-cta");
-    expect(findings[0].severity).toBe("warning");
-    expect(findings[0].category).toBe("location");
-    expect(findings[0].field).toBe("locationName");
-  });
-
-  it("does not flag real address that happens to contain an @-like token", () => {
-    const event = makeEvent({
-      locationName: "Apt @ 123 Main Street, Newark, DE",
-    });
-    const findings = checkLocationQuality([event]);
+  it.each([
+    ["street numbers or ZIP codes (location-phone-number)", "15001 Health Center Dr, Bowie, MD 20716"],
+    ["real address that happens to contain an @-like token", "Apt @ 123 Main Street, Newark, DE"],
+  ])("does not flag %s", (_name, locationName) => {
+    const findings = checkLocationQuality([makeEvent({ locationName })]);
     expect(findings).toHaveLength(0);
   });
 });

--- a/src/pipeline/audit-checks.test.ts
+++ b/src/pipeline/audit-checks.test.ts
@@ -435,6 +435,26 @@ describe("checkLocationQuality", () => {
     const findings = checkLocationQuality([event]);
     expect(findings).toHaveLength(0);
   });
+
+  it("flags location-email-cta for 'Inquire for location: …@…' (#798 ABQ)", () => {
+    const event = makeEvent({
+      locationName: "Inquire for location: abqh3misman@gmail.com",
+    });
+    const findings = checkLocationQuality([event]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("location-email-cta");
+    expect(findings[0].severity).toBe("warning");
+    expect(findings[0].category).toBe("location");
+    expect(findings[0].field).toBe("locationName");
+  });
+
+  it("does not flag real address that happens to contain an @-like token", () => {
+    const event = makeEvent({
+      locationName: "Apt @ 123 Main Street, Newark, DE",
+    });
+    const findings = checkLocationQuality([event]);
+    expect(findings).toHaveLength(0);
+  });
 });
 
 describe("checkEventQuality", () => {

--- a/src/pipeline/audit-checks.ts
+++ b/src/pipeline/audit-checks.ts
@@ -51,6 +51,7 @@ export const KNOWN_AUDIT_RULES = [
   "location-url",
   "location-duplicate-segments",
   "location-phone-number",
+  "location-email-cta",
   "event-improbable-time",
   "description-dropped",
 ] as const;
@@ -119,6 +120,14 @@ const TITLE_TIME_ONLY_PATTERN =
  */
 export const PHONE_NUMBER_RE =
   /(?:(?<!\d)\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}(?!\d)|(?<!\d)\d{10}(?!\d))/;
+
+/**
+ * Email-CTA-as-location detector (#798 ABQ H3). Flags locationName values
+ * like "Inquire for location: abqh3misman@gmail.com" — no geocodable address
+ * in the field, same failure mode as a phone CTA.
+ */
+export const LOCATION_EMAIL_CTA_RE =
+  /^\s*(?:inquire|email|contact|ping|message|msg|dm)\b.*?\S+@\S+\.\S+.*$/i;
 
 const CTA_PATTERN =
   /^(?:tbd|tba|tbc|n\/a|sign[\s\u00A0]*up!?|volunteer|needed|required)$/i;
@@ -294,6 +303,22 @@ export function checkLocationQuality(events: LocationEventRow[]): AuditFinding[]
           field: "locationName",
           currentValue: locationName,
           rule: "location-phone-number",
+          severity: "warning",
+        })
+      );
+      continue;
+    }
+
+    // 4. location-email-cta: locationName is an email-based "inquire for
+    // location" CTA (#798 ABQ H3). Same downside as the phone variant —
+    // no geocodable address in the field.
+    if (LOCATION_EMAIL_CTA_RE.test(locationName)) {
+      findings.push(
+        finding(event, {
+          category: "location",
+          field: "locationName",
+          currentValue: locationName,
+          rule: "location-email-cta",
           severity: "warning",
         })
       );


### PR DESCRIPTION
## Summary
- Round 2 of the audit-fix cycle: 7 fresh code fixes across 4 adapters + 1 new audit rule, addressing issues #796–#802 filed by the 2026-04-18 daily alert pipeline after PR #805 merged.
- One mega-PR with 5 per-area commits + scripts. All diffs run against the live production URLs via `scripts/verify-round2-fixes.ts`.

## Fixes

| Issue | Kennel/Source | Defect | Change |
|---|---|---|---|
| [#796](https://github.com/johnrclem/hashtracks-web/issues/796) | Wasatch H3 (Whoreman calendar) | Title `"wasatch #1144"` — lowercase kennel code passed through verbatim | GCal adapter: substitute `defaultTitles[kennelTag]` when title matches `{slug} #N`; seed adds per-kennel `defaultTitles` on Whoreman source |
| [#797](https://github.com/johnrclem/hashtracks-web/issues/797) | Hockessin H3 | Hare name scraped as event title; street address missing | Rewrote line parser: post-colon header → hares (not title); title always `Hockessin H3 Trail #N`; trailing segment → locationName |
| [#798](https://github.com/johnrclem/hashtracks-web/issues/798) | ABQ H3 | `location = "Inquire for location: abqh3misman@gmail.com"` | GCal adapter strips email-CTA strings + bare-email values; new `location-email-cta` audit rule with shared regex |
| [#799](https://github.com/johnrclem/hashtracks-web/issues/799) | Pedal Files Bash | Titles end in trailing `" - tbd"` / `" -"` placeholders | GCal adapter: broader placeholder-tail strip (`tbd`/`tba`/`tbc`) placed AFTER w/-extraction so `Hash Run w/ TBD - TBA` still extracts correctly |
| [#800](https://github.com/johnrclem/hashtracks-web/issues/800) | Dayton H4 (DH4 calendar) | Title `"DH3 #1663"` — legacy kennel abbrev | Same bare-kennel-code heal path as #796; seed adds `defaultTitle: "Dayton H4 Trail"` on DH4 source |
| [#801](https://github.com/johnrclem/hashtracks-web/issues/801) | Reading H3 (Localendar) | Empty `LOCATION`; venue embedded in `DESCRIPTION` via `"On On: {time} {venue}"` | iCal adapter: exported `extractOnOnVenueFromDescription()` fallback runs after standard LOCATION_PATTERNS |
| [#802](https://github.com/johnrclem/hashtracks-web/issues/802) | BFMH3 (Bangkok Full Moon) | `hares = "On On Q"` boilerplate captured as hare name | bangkokhash article-page path now applies `HARE_BOILERPLATE_RE` before assignment (mirrors API-path filter) |

## Auto-heal verify + close (no code change)
- [#799](https://github.com/johnrclem/hashtracks-web/issues/799) — also covered by live-verify; closed via `Fixes:` footer
- [#803](https://github.com/johnrclem/hashtracks-web/issues/803) BAH3 phone in hares — PR #805's `PHONE_NUMBER_RE` upgrade handles this (will post closing comment)
- [#804](https://github.com/johnrclem/hashtracks-web/issues/804) SWH3 CTA in location — PR #805's CTA-strip handles this (will post closing comment)

## Quality gates
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (12 pre-existing warnings, 0 errors)
- `npm test` — 4837 tests pass
- `/codex:adversarial-review` — applied 2 findings: tightened iCal `Hares:`/`Hash Cash:` adjacency + added negative test cases for bare-kennel rewrite
- Live verify (`scripts/verify-round2-fixes.ts`) — all 7 fixes assert clean against production URLs (Whoreman, DH4, Pedal Files, ABQ, Reading, Hockessin, BFMH3)

## Test plan
- [x] Unit tests with fixtures per adapter change
- [x] Live verify against production URLs (configOverride injects seed changes pre-deploy)
- [x] Negative test coverage: `Wasatch H3 Trail #1144` unchanged; bare `1144` not rewritten; multi-word titles untouched
- [ ] Post-merge: watch alert pipeline for 24h via `claude-post-merge.yml`

Fixes: #796 #797 #798 #799 #800 #801 #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)