### PR TITLE
fix: audit round 4 — label-aware parsers + multi-label block walkers

### DIFF
--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -2233,7 +2233,7 @@ describe("buildRawEventFromGCalItem — coord-only item.location (#779 BMPH3)", 
     expect(event!.location).toBe("Rue de la Gare, 1332 Genval");
   });
 
-  it("rejects out-of-range coord strings (keeps text field intact)", () => {
+  it("discards out-of-range coord strings (description fallback takes over)", () => {
     const item = {
       summary: "BMPH3 Trail",
       description: "Hares: Tester",

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -11,6 +11,7 @@ import {
   applyInlineHarelineBackfill,
   extractLocationFromDescription,
   extractTimeFromDescription,
+  extractCostFromDescription,
   buildRawEventFromGCalItem,
   normalizeGCalDescription,
 } from "./adapter";
@@ -2166,5 +2167,114 @@ describe("extractLocationFromDescription — hash-vernacular labels (#742)", () 
     ["Where to gather", "Where to gather: 123 Main St"],
   ])("extracts location from %s label", (_label, desc) => {
     expect(extractLocationFromDescription(desc)).toBe("123 Main St");
+  });
+});
+
+// ── Audit Round 3 — #774 BJH3 cost + WHO ARE THE HARES + #779 BMPH3 coord-only location ──
+
+describe("extractCostFromDescription (#774)", () => {
+  it.each([
+    ["bare integer gets $ prefix", "Hash Cash: 5", "$5"],
+    ["WHAT IS THE COST template variant", "WHAT IS THE COST: $7", "$7"],
+    ["Cost: Free passes through", "Cost: Free", "Free"],
+    ["decimal bare number", "Price: 10.50", "$10.50"],
+    ["already prefixed $ kept verbatim", "Hash Cash: $10 cash", "$10 cash"],
+    ["non-USD currency preserved", "Cost: €10", "€10"],
+  ])("%s", (_label, desc, expected) => {
+    expect(extractCostFromDescription(desc)).toBe(expected);
+  });
+
+  it("returns undefined when no cost label present", () => {
+    expect(extractCostFromDescription("Hares: Slick Willy\nLocation: 123 Main")).toBeUndefined();
+  });
+
+  it("returns undefined for placeholder values", () => {
+    expect(extractCostFromDescription("Hash Cash: TBD")).toBeUndefined();
+  });
+
+  it("truncates at embedded next-field label (HTML-collapsed)", () => {
+    // When HTML stripping collapses fields onto one line, EVENT_FIELD_LABEL_RE
+    // truncates at the next recognized label so the value doesn't leak.
+    expect(extractCostFromDescription("Hash Cash: $5 When: 6pm")).toBe("$5");
+  });
+});
+
+describe("extractHares — WHO ARE THE HARES template (#774 BJH3)", () => {
+  it("captures hare name from WHO ARE THE HARES: label", () => {
+    expect(extractHares("WHO ARE THE HARES: Leeroy")).toBe("Leeroy");
+  });
+
+  it("captures multiple hares from WHO ARE THE HARES: label", () => {
+    expect(extractHares("WHO ARE THE HARES: Leeroy & Jenkins")).toBe(
+      "Leeroy & Jenkins",
+    );
+  });
+
+  it("matches case-insensitively", () => {
+    expect(extractHares("Who Are The Hares: Leeroy")).toBe("Leeroy");
+  });
+});
+
+describe("buildRawEventFromGCalItem — coord-only item.location (#779 BMPH3)", () => {
+  it("clears coord-only location and populates lat/lng from item.location", () => {
+    const item = {
+      summary: "BMPH3 Trail",
+      description: "Start: Rue de la Gare, 1332 Genval\nHares: Tester",
+      location: "50.7234, 4.5123",
+      start: { dateTime: "2026-04-05T14:00:00+02:00" },
+      status: "confirmed",
+    };
+    const config = { defaultKennelTag: "bmph3-be" };
+    const event = buildRawEventFromGCalItem(item, config);
+    expect(event).not.toBeNull();
+    expect(event!.latitude).toBe(50.7234);
+    expect(event!.longitude).toBe(4.5123);
+    // Coord-only text cleared → description fallback surfaces the real address
+    expect(event!.location).toBe("Rue de la Gare, 1332 Genval");
+  });
+
+  it("rejects out-of-range coord strings (keeps text field intact)", () => {
+    const item = {
+      summary: "BMPH3 Trail",
+      description: "Hares: Tester",
+      location: "999.0, 4.5123",
+      start: { dateTime: "2026-04-05T14:00:00+02:00" },
+      status: "confirmed",
+    };
+    const config = { defaultKennelTag: "bmph3-be" };
+    const event = buildRawEventFromGCalItem(item, config);
+    expect(event).not.toBeNull();
+    expect(event!.latitude).toBeUndefined();
+    expect(event!.longitude).toBeUndefined();
+  });
+
+  it("leaves real address item.location alone", () => {
+    const item = {
+      summary: "Trail",
+      description: "Hares: Tester",
+      location: "123 Main St, Philadelphia, PA",
+      start: { dateTime: "2026-04-05T14:00:00-04:00" },
+      status: "confirmed",
+    };
+    const config = { defaultKennelTag: "bmph3-be" };
+    const event = buildRawEventFromGCalItem(item, config);
+    expect(event).not.toBeNull();
+    expect(event!.latitude).toBeUndefined();
+    expect(event!.longitude).toBeUndefined();
+    expect(event!.location).toBe("123 Main St, Philadelphia, PA");
+  });
+
+  it("populates cost from description when label present", () => {
+    const item = {
+      summary: "BJ Invasion",
+      description: "WHO ARE THE HARES: Leeroy\nHash Cash: 5",
+      start: { dateTime: "2026-04-05T14:00:00-04:00" },
+      status: "confirmed",
+    };
+    const config = { defaultKennelTag: "bjh3" };
+    const event = buildRawEventFromGCalItem(item, config);
+    expect(event).not.toBeNull();
+    expect(event!.cost).toBe("$5");
+    expect(event!.hares).toBe("Leeroy");
   });
 });

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, HARE_BOILERPLATE_RE, EVENT_FIELD_LABEL_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, stripNonEnglishCountry } from "../utils";
+import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, HARE_BOILERPLATE_RE, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, stripNonEnglishCountry } from "../utils";
 import { PHONE_NUMBER_RE, LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 
 // Kennel patterns derived from actual Boston Hash Calendar event data.
@@ -354,7 +354,7 @@ export function extractCostFromDescription(description: string): string | undefi
   const match = COST_LABEL_RE.exec(description);
   if (!match?.[1]) return undefined;
   let value = match[1].trim();
-  value = value.replace(EVENT_FIELD_LABEL_RE, "").trim();
+  value = value.replace(EVENT_FIELD_LABEL_RE, "").replace(EVENT_FIELD_LABEL_UPPERCASE_RE, "").trim();
   if (!value || isPlaceholder(value)) return undefined;
   if (/^\d+(?:\.\d{1,2})?$/.test(value)) return `$${value}`;
   return value;
@@ -405,7 +405,7 @@ export function extractHares(description: string, customPatterns?: string[] | Re
         for (let i = startIdx; i < continuation.length && added < MAX_CONTINUATION_LINES; i++) {
           const line = continuation[i].trim();
           if (!line) break;
-          if (EVENT_FIELD_LABEL_RE.test(line)) break;
+          if (EVENT_FIELD_LABEL_RE.test(line) || EVENT_FIELD_LABEL_UPPERCASE_RE.test(line)) break;
           if (HARE_BOILERPLATE_RE.test(line)) break;
           if (/^https?:\/\//i.test(line)) break;
           // Reject obviously non-name lines: colons (unrecognized field labels),
@@ -426,7 +426,7 @@ export function extractHares(description: string, customPatterns?: string[] | Re
       // Truncate at next embedded field label when HTML stripping collapsed fields
       // (e.g., "AmazonWhat: A beautiful trail …" → "Amazon"). The \b word boundary
       // in EVENT_FIELD_LABEL_RE prevents matching tokens inside other words.
-      hares = hares.replace(EVENT_FIELD_LABEL_RE, "").trim();
+      hares = hares.replace(EVENT_FIELD_LABEL_RE, "").replace(EVENT_FIELD_LABEL_UPPERCASE_RE, "").trim();
       // Strip trailing US phone numbers — both formatted ("(555) 123-4567",
       // "719-360-3805") and bare 10-digit runs ("2406185563" — see #742).
       hares = hares.replace(PHONE_TRAILING_RE, "").trim();

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -133,6 +133,11 @@ const LOCATION_TRAILING_CTA_RE = /\s*\((?:text|call|contact|ping)[^)]*\)\s*$/i;
 // on its own). The broader "Inquire for location: …@…" form is shared with
 // the audit-checks rule and imported above.
 const LOCATION_BARE_EMAIL_RE = /^\s*\S+@\S+\.\S+\s*$/;
+// Some GCal sources put "lat, lng" in item.location and the readable venue in
+// the description. Coord-only values are discarded so description extraction
+// surfaces the address; parsed coords flow to the pipeline as structured
+// lat/lng.
+const LOCATION_COORDS_ONLY_RE = /^\s*(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)\s*$/;
 
 // Pre-compiled regexes for extractLocationFromDescription.
 // #742: hash-vernacular labels (De'erections, Direcshits, Where to gather) are synonyms for "Location".
@@ -330,9 +335,30 @@ export function extractTimeFromDescription(description: string): string | undefi
 /** Default hare extraction patterns for Google Calendar descriptions. */
 const DEFAULT_HARE_PATTERNS = [
   /(?:^|\n)[ \t]*H{1,3}are(?:\s*&\s*Co-Hares?)?\(?s?\)?:[ \t]*(.*)/im,  // Hare:, Hares:, HHHares: (Asheville's "HHH" = Hash House Harriers convention)
+  // "WHO ARE THE HARES:" template variant — must match before the generic
+  // "Who:" pattern so the full label prefix is consumed.
+  /(?:^|\n)[ \t]*WHO\s+ARE\s+THE\s+HARES?\s*:[ \t]*(.*)/im,
   /(?:^|\n)[ \t]*Who\s*\(?(?:hares?)?\)?:[ \t]*(.*)/im,  // Who:, WHO (hares):, Who(hare):
   /(?:^|\n)[ \t]*Hare[ \t]+([A-Z*].+)/im,  // "Hare C*ck Swap" (no colon, name starts uppercase/special)
 ];
+
+const COST_LABEL_RE =
+  /(?:^|\n)[ \t]*(?:Hash\s+Cash|WHAT\s+IS\s+THE\s+COST|Cost|Price)\s*:[ \t]*([^\n]+)/im;
+
+/**
+ * Extract a cost value from a calendar description. Bare integers get a `$`
+ * prefix to match the HashRego/OFH3 normalized format; values that already
+ * carry a currency symbol, unit, or word ("Free") pass through verbatim.
+ */
+export function extractCostFromDescription(description: string): string | undefined {
+  const match = COST_LABEL_RE.exec(description);
+  if (!match?.[1]) return undefined;
+  let value = match[1].trim();
+  value = value.replace(EVENT_FIELD_LABEL_RE, "").trim();
+  if (!value || isPlaceholder(value)) return undefined;
+  if (/^\d+(?:\.\d{1,2})?$/.test(value)) return `$${value}`;
+  return value;
+}
 
 /**
  * Extract hare names from the event description.
@@ -628,6 +654,26 @@ export function buildRawEventFromGCalItem(
   // raw GCal location field. Trailing only — a bare "1 800 ..." in the middle
   // of a street fragment would otherwise be shredded.
   let location = item.location ? stripNonEnglishCountry(decodeEntities(item.location).trim()) : undefined;
+  let latitude: number | undefined;
+  let longitude: number | undefined;
+  if (location) {
+    const coordsMatch = LOCATION_COORDS_ONLY_RE.exec(location);
+    if (coordsMatch) {
+      const lat = Number.parseFloat(coordsMatch[1]);
+      const lng = Number.parseFloat(coordsMatch[2]);
+      if (
+        Number.isFinite(lat) &&
+        Number.isFinite(lng) &&
+        Math.abs(lat) <= 90 &&
+        Math.abs(lng) <= 180 &&
+        (lat !== 0 || lng !== 0)
+      ) {
+        latitude = lat;
+        longitude = lng;
+      }
+      location = undefined;
+    }
+  }
   // Skip phone/CTA strip when the field is a bare URL — Maps place IDs end in digit runs
   // that PHONE_TRAILING_RE would mangle.
   if (location && !/^https?:\/\//i.test(location)) {
@@ -824,6 +870,7 @@ export function buildRawEventFromGCalItem(
   // Any URL as location (Maps or otherwise) gets routed to locationUrl for geocoding,
   // not stored as display location. resolveCoords handles URL → address resolution.
   const locationIsUrl = location && /^https?:\/\//i.test(location);
+  const cost = rawDescription ? extractCostFromDescription(rawDescription) : undefined;
   return {
     date: dateISO,
     kennelTag,
@@ -833,9 +880,12 @@ export function buildRawEventFromGCalItem(
     hares,
     location: locationIsUrl ? undefined : location,
     locationUrl: location ? (locationIsUrl ? location : mapsUrl(location)) : undefined,
+    latitude,
+    longitude,
     startTime: resolvedStartTime,
     // endTime is HH:MM only, so cross-date end timestamps (overnight runs) are dropped.
     endTime: endParts && endParts.dateISO === dateISO ? endParts.startTime : undefined,
+    cost,
     sourceUrl: item.htmlLink,
   };
 }

--- a/src/adapters/html-scraper/adelaide-h3.test.ts
+++ b/src/adapters/html-scraper/adelaide-h3.test.ts
@@ -82,6 +82,20 @@ describe("adelaide-h3 parseAdelaideDetail (#705)", () => {
     expect(d.description).toBeUndefined();
     expect(d.locationUrl).toBeUndefined();
   });
+
+  it("drops placeholder TBA venue/street + stale map URL (#705 polish)", () => {
+    // Source leaves "TBA" in both spans when a location hasn't been set. The
+    // associated `maplink` href is a bare `?q=TBA` — useless to the pipeline.
+    const tbaContent = `<a href='http://maps.google.com/?q=TBA' class='maplink'>View Map</a>
+<div class='location'>
+<span>TBA</span>
+<span>TBA</span>
+</div>`;
+    const d = parseAdelaideDetail(tbaContent);
+    expect(d.location).toBeUndefined();
+    expect(d.locationStreet).toBeUndefined();
+    expect(d.locationUrl).toBeUndefined();
+  });
 });
 
 describe("adelaide-h3 adelaideWallClockToUnix", () => {

--- a/src/adapters/html-scraper/adelaide-h3.ts
+++ b/src/adapters/html-scraper/adelaide-h3.ts
@@ -112,7 +112,7 @@ interface AdelaideEventDetail {
 function isPlaceholderMapQuery(href: string): boolean {
   const q = /[?&]q=([^&#]*)/.exec(href);
   if (!q?.[1]) return false;
-  return isPlaceholder(decodeURIComponent(q[1].replace(/\+/g, " ")));
+  return isPlaceholder(decodeURIComponent(q[1].replaceAll("+", " ")));
 }
 
 /**

--- a/src/adapters/html-scraper/adelaide-h3.ts
+++ b/src/adapters/html-scraper/adelaide-h3.ts
@@ -105,6 +105,17 @@ interface AdelaideEventDetail {
 }
 
 /**
+ * Check whether a maps URL's `?q=` parameter is a placeholder like `TBA`/`TBD`.
+ * Uses a lenient regex (not `new URL`) because the source sometimes emits
+ * unescaped `+` in the query and we only need the raw token.
+ */
+function isPlaceholderMapQuery(href: string): boolean {
+  const q = /[?&]q=([^&#]*)/.exec(href);
+  if (!q?.[1]) return false;
+  return isPlaceholder(decodeURIComponent(q[1].replace(/\+/g, " ")));
+}
+
+/**
  * Parse the HTML content returned by `action=get_event`.
  * Shape: `.description`, `.location > span:nth-child(1|2)`, `a.maplink[href]`.
  * Exported for unit testing.
@@ -120,8 +131,9 @@ export function parseAdelaideDetail(contentHtml: string): AdelaideEventDetail {
   // "TBA" as a location or build a junk `?q=TBA` Maps URL.
   const locationClean = venue && !isPlaceholder(venue) ? venue : undefined;
   const streetClean = address && !isPlaceholder(address) ? address : undefined;
-  const mapClean =
-    mapHref && !locationClean && !streetClean ? undefined : mapHref || undefined;
+  // Map URL is independent of venue/street: only suppress when the map's own
+  // `?q=` query is a placeholder (e.g. `?q=TBA`).
+  const mapClean = mapHref && isPlaceholderMapQuery(mapHref) ? undefined : mapHref || undefined;
   return {
     location: locationClean,
     locationStreet: streetClean,

--- a/src/adapters/html-scraper/adelaide-h3.ts
+++ b/src/adapters/html-scraper/adelaide-h3.ts
@@ -116,11 +116,17 @@ export function parseAdelaideDetail(contentHtml: string): AdelaideEventDetail {
   const address = spans.eq(1).text().trim();
   const description = $(".description").first().text().trim();
   const mapHref = $("a.maplink").first().attr("href")?.trim();
+  // Drop placeholder venue/street ("TBA", "TBD") so the pipeline doesn't store
+  // "TBA" as a location or build a junk `?q=TBA` Maps URL.
+  const locationClean = venue && !isPlaceholder(venue) ? venue : undefined;
+  const streetClean = address && !isPlaceholder(address) ? address : undefined;
+  const mapClean =
+    mapHref && !locationClean && !streetClean ? undefined : mapHref || undefined;
   return {
-    location: venue || undefined,
-    locationStreet: address || undefined,
+    location: locationClean,
+    locationStreet: streetClean,
     description: description || undefined,
-    locationUrl: mapHref || undefined,
+    locationUrl: mapClean,
   };
 }
 

--- a/src/adapters/html-scraper/bfm.test.ts
+++ b/src/adapters/html-scraper/bfm.test.ts
@@ -181,6 +181,40 @@ describe("BFMAdapter.fetch", () => {
     expect(result).toContain("New? Come join us");
   });
 
+  it("#763: parses 'Upcumming Hashes' with collapsed whitespace between entries", async () => {
+    // Live benfranklinmob.com renders entries as text like:
+    //   "Upcumming Hashes: April 30th – EnergeticMay 7th – Just Mike..."
+    // with the header using the pun spelling and entries joined without newlines.
+    const html = `
+      <html><body>
+      <h2>Trail #1157: Test Trail</h2>
+      <p>When: Thursday, 4/23 at 7:00 PM gather</p>
+      <p>Where: Cherry Street Tavern</p>
+      <p>Hares: 60k9</p>
+      <p>Upcumming Hashes: April 30th – EnergeticMay 7th – Just Mike (Virgin Lay!) and Where's My D?May 14th – Bananass</p>
+      </body></html>
+    `;
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(html, { status: 200 }))
+      .mockResolvedValueOnce(new Response("<html><body></body></html>", { status: 200 }));
+
+    const adapter = new BFMAdapter();
+    const result = await adapter.fetch({
+      id: "test",
+      url: "https://benfranklinmob.com",
+    } as never);
+
+    const upcoming = result.events.filter((e) => !e.runNumber);
+    const apr30 = upcoming.find((e) => e.date === "2026-04-30");
+    const may7 = upcoming.find((e) => e.date === "2026-05-07");
+    const may14 = upcoming.find((e) => e.date === "2026-05-14");
+
+    expect(apr30?.hares).toBe("Energetic");
+    expect(may7?.hares).toBe("Just Mike (Virgin Lay!) and Where's My D?");
+    expect(may14?.hares).toBe("Bananass");
+  });
+
   it("returns error on HTTP error status", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response("Forbidden", { status: 403, statusText: "Forbidden" }),

--- a/src/adapters/html-scraper/bfm.ts
+++ b/src/adapters/html-scraper/bfm.ts
@@ -175,7 +175,7 @@ function scrapeUpcomingHares(
   // month spelling ("May", "Jan.", "September", "Sept") without a 12-way
   // alternation (keeps SonarCloud regex complexity under budget).
   const ENTRY_ANCHOR =
-    /(?=[A-Z][a-z]{2,}\.?\s+\d{1,2}(?:st|nd|rd|th)?\s*[–—-])/g;
+    /(?=[A-Z][a-z]{2,}\.?\s+\d{1,2}[a-z]{0,2}\s*[–—-])/g;
   const segments = sectionText
     .split(ENTRY_ANCHOR)
     .map((s) => s.trim())

--- a/src/adapters/html-scraper/bfm.ts
+++ b/src/adapters/html-scraper/bfm.ts
@@ -159,7 +159,9 @@ function scrapeUpcomingHares(
   baseUrl: string,
 ): RawEventData[] {
   const events: RawEventData[] = [];
-  const headerMatch = /Upcoming\s+Ha(?:re|sh)s?[:\s]*/i.exec(bodyText);
+  // Site uses "Upcumming Hashes:" (intentional pun) — accept standard and
+  // pun spellings: Upcoming / Upcomming / Upcumming.
+  const headerMatch = /Upc[uo]m{1,2}ing\s+Ha(?:re|sh)s?[:\s]*/i.exec(bodyText);
   if (!headerMatch) return events;
   const sectionStart = headerMatch.index + headerMatch[0].length;
   const specialIdx = bodyText.slice(sectionStart).search(/Special\s+Events|Mayor/i);
@@ -167,14 +169,22 @@ function scrapeUpcomingHares(
     ? bodyText.slice(sectionStart, sectionStart + specialIdx)
     : bodyText.slice(sectionStart);
 
-  const lines = sectionText.split("\n").filter((l) => l.trim());
-  for (const line of lines) {
-    const lineMatch = /^([^–—-]+?)\s*[–—-]\s*(.+)$/.exec(line);
+  // Split on month-day lookahead. No `\b` anchor — entries sometimes run
+  // together ("...EnergeticMay 7th – ...") with no word boundary present.
+  const ENTRY_ANCHOR =
+    /(?=(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+\d{1,2}(?:st|nd|rd|th)?\s*[–—-])/g;
+  const segments = sectionText
+    .split(ENTRY_ANCHOR)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  for (const segment of segments) {
+    const lineMatch = /^([^–—-]+?)\s*[–—-]\s*([^\n]+)/.exec(segment);
     if (!lineMatch) continue;
 
     const datePart = lineMatch[1].trim();
     const harePart = lineMatch[2].trim();
-    if (/could be you/i.test(harePart)) continue;
+    if (!harePart || /could be you/i.test(harePart)) continue;
 
     const dateStr = parseBfmDate(datePart, currentYear);
     if (!dateStr) continue;

--- a/src/adapters/html-scraper/bfm.ts
+++ b/src/adapters/html-scraper/bfm.ts
@@ -171,8 +171,10 @@ function scrapeUpcomingHares(
 
   // Split on month-day lookahead. No `\b` anchor — entries sometimes run
   // together ("...EnergeticMay 7th – ...") with no word boundary present.
+  // Match 3-letter month prefix + optional suffix so "May", "Jan", "Jan.",
+  // "September", "Sept" all hit with a single alternation set.
   const ENTRY_ANCHOR =
-    /(?=(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+\d{1,2}(?:st|nd|rd|th)?\s*[–—-])/g;
+    /(?=(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2}(?:st|nd|rd|th)?\s*[–—-])/g;
   const segments = sectionText
     .split(ENTRY_ANCHOR)
     .map((s) => s.trim())

--- a/src/adapters/html-scraper/bfm.ts
+++ b/src/adapters/html-scraper/bfm.ts
@@ -171,10 +171,11 @@ function scrapeUpcomingHares(
 
   // Split on month-day lookahead. No `\b` anchor — entries sometimes run
   // together ("...EnergeticMay 7th – ...") with no word boundary present.
-  // Match 3-letter month prefix + optional suffix so "May", "Jan", "Jan.",
-  // "September", "Sept" all hit with a single alternation set.
+  // Shape-based match: capitalized word ≥3 chars + day + dash. Covers every
+  // month spelling ("May", "Jan.", "September", "Sept") without a 12-way
+  // alternation (keeps SonarCloud regex complexity under budget).
   const ENTRY_ANCHOR =
-    /(?=(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2}(?:st|nd|rd|th)?\s*[–—-])/g;
+    /(?=[A-Z][a-z]{2,}\.?\s+\d{1,2}(?:st|nd|rd|th)?\s*[–—-])/g;
   const segments = sectionText
     .split(ENTRY_ANCHOR)
     .map((s) => s.trim())

--- a/src/adapters/html-scraper/n2th3.test.ts
+++ b/src/adapters/html-scraper/n2th3.test.ts
@@ -122,6 +122,29 @@ describe("parseN2th3Post", () => {
     expect(result?.location).toBe("Fanling");
   });
 
+  it("#723: splits multiple labels sharing one <p> block", () => {
+    // Live N2TH3 posts often collapse Hares + Location into one paragraph
+    // separated only by <br>. The fix must pick each label's own value and
+    // not leak the next label's text into the prior field.
+    const post = buildPost({
+      title: "Run announcement 2276 &#8211; 15th April 2026 &#8211; Fanling",
+      content: `
+        <p><strong>Hares:</strong> <br>Golden Balls   <br><br><strong>Location: </strong><br>Fanling Recreation Ground</p>
+        <p><strong>Map:</strong> <a href="https://maps.app.goo.gl/Ub3s32Scit81gjnM8">link</a></p>
+        <p><strong>Hare says:</strong> Come along!</p>
+      `,
+      date: "2026-04-14T10:00:00+08:00",
+    });
+    const result = parseN2th3Post(post);
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Golden Balls");
+    expect(result!.location).toBe("Fanling Recreation Ground");
+    expect(result!.locationUrl).toBe(
+      "https://maps.app.goo.gl/Ub3s32Scit81gjnM8",
+    );
+    expect(result!.description).toBe("Come along!");
+  });
+
   it("handles map URL as plain text (no anchor tag)", () => {
     const post = buildPost({
       content: `

--- a/src/adapters/html-scraper/n2th3.ts
+++ b/src/adapters/html-scraper/n2th3.ts
@@ -11,32 +11,45 @@ const DEFAULT_START_TIME = "19:00";
 
 /**
  * Extract a labeled field value from post body HTML.
- * Looks for `<strong>Label:</strong> Value` patterns in `<p>` elements.
- * Returns the text after the label, trimmed.
+ *
+ * N2TH3 posts often collapse multiple labels into a single `<p>` separated
+ * by `<br>`, e.g.:
+ *   <p><strong>Hares:</strong><br>Golden Balls
+ *      <br><br><strong>Location:</strong><br>Fanling Recreation Ground</p>
+ *
+ * Walking `<p>.text()` after the first `<strong>` leaks the next label's
+ * value into this one. Instead, iterate `<strong>` tags and collect sibling
+ * nodes *until the next `<strong>`* so each label gets exactly its own value.
  */
-function extractLabeledField($: cheerio.CheerioAPI, label: RegExp): { text: string; href?: string } | null {
-  const paragraphs = $("p").toArray();
-  for (const p of paragraphs) {
-    const $p = $(p);
-    const strong = $p.find("strong").first();
-    if (!strong.length) continue;
-
-    const strongText = strong.text().trim().replace(/:?\s*$/, "");
+function extractLabeledField(
+  $: cheerio.CheerioAPI,
+  label: RegExp,
+): { text: string; href?: string } | null {
+  const strongs = $("p strong").toArray();
+  for (const strong of strongs) {
+    const strongText = $(strong).text().trim().replace(/:?\s*$/, "");
     if (!label.test(strongText)) continue;
 
-    // Get text after the strong tag — could be in same <p> or the strong itself
-    // Clone the paragraph, remove the strong, get remaining text
-    const fullText = $p.text().trim();
-    const labelText = strong.text().trim();
-    const afterLabel = fullText.slice(fullText.indexOf(labelText) + labelText.length).replace(/^[:\s]+/, "").trim();
-
-    if (!afterLabel) continue;
-
-    // Check for a link in the same paragraph
-    const link = $p.find("a").first();
-    const href = link.length ? link.attr("href") : undefined;
-
-    return { text: afterLabel, href };
+    let text = "";
+    let href: string | undefined;
+    let node: typeof strong.nextSibling = strong.nextSibling;
+    while (node) {
+      if (node.type === "tag") {
+        const tagName = (node as { name: string }).name;
+        if (tagName === "strong") break;
+        if (!href) {
+          // Check direct tag first, then nested descendants (e.g. <span><a/></span>)
+          const directHref = tagName === "a" ? $(node).attr("href") : undefined;
+          href = directHref || $(node).find("a").first().attr("href") || undefined;
+        }
+        text += $(node).text();
+      } else if (node.type === "text") {
+        text += (node as { data?: string }).data ?? "";
+      }
+      node = node.nextSibling;
+    }
+    const trimmed = text.replace(/^[:\s]+/, "").replace(/\s+/g, " ").trim();
+    if (trimmed) return { text: trimmed, href };
   }
   return null;
 }

--- a/src/adapters/html-scraper/n2th3.ts
+++ b/src/adapters/html-scraper/n2th3.ts
@@ -35,11 +35,17 @@ function collectSiblingValue(
   while (node) {
     if (node.type === "tag") {
       if (node.name === "strong") break;
-      if (!href) {
-        const directHref = node.name === "a" ? $(node as never).attr("href") : undefined;
-        href = directHref || $(node as never).find("a").first().attr("href") || undefined;
+      if (node.name === "br") {
+        // `<br>` has empty .text(); add an explicit space so adjacent values
+        // don't concatenate (e.g. line-break between location and map URL).
+        text += " ";
+      } else {
+        if (!href) {
+          const directHref = node.name === "a" ? $(node as never).attr("href") : undefined;
+          href = directHref || $(node as never).find("a").first().attr("href") || undefined;
+        }
+        text += $(node as never).text();
       }
-      text += $(node as never).text();
     } else if (node.type === "text") {
       text += node.data ?? "";
     }
@@ -59,7 +65,9 @@ function extractLabeledField(
 
     const { text, href } = collectSiblingValue($, strong);
     const trimmed = text.replace(/^[:\s]+/, "").replaceAll(/\s+/g, " ").trim();
-    if (trimmed) return { text: trimmed, href };
+    // Return href-only fields too: an icon/image-only map link has empty
+    // visible text but a valid href we want to preserve.
+    if (trimmed || href) return { text: trimmed, href };
   }
   return null;
 }

--- a/src/adapters/html-scraper/n2th3.ts
+++ b/src/adapters/html-scraper/n2th3.ts
@@ -21,6 +21,23 @@ const DEFAULT_START_TIME = "19:00";
  * value into this one. Instead, iterate `<strong>` tags and collect sibling
  * nodes *until the next `<strong>`* so each label gets exactly its own value.
  */
+type SibNode = { type?: string; nextSibling: unknown; name?: string; data?: string };
+
+/** Find the first `<a>` href reachable from a tag node (direct or nested). */
+function firstHref($: cheerio.CheerioAPI, node: SibNode): string | undefined {
+  const direct = node.name === "a" ? $(node as never).attr("href") : undefined;
+  return direct || $(node as never).find("a").first().attr("href") || undefined;
+}
+
+/**
+ * Visible text contributed by a sibling tag. `<br>` has empty `.text()`, so
+ * emit an explicit space to keep adjacent values (e.g. location + map URL)
+ * from concatenating across line breaks.
+ */
+function tagText($: cheerio.CheerioAPI, node: SibNode): string {
+  return node.name === "br" ? " " : $(node as never).text();
+}
+
 /**
  * Walk sibling nodes after `startNode` until the next `<strong>` tag,
  * accumulating text content and the first `<a>` href found (direct or nested).
@@ -31,21 +48,12 @@ function collectSiblingValue(
 ): { text: string; href?: string } {
   let text = "";
   let href: string | undefined;
-  let node = startNode.nextSibling as { type?: string; nextSibling: unknown; name?: string; data?: string } | null;
+  let node = startNode.nextSibling as SibNode | null;
   while (node) {
     if (node.type === "tag") {
       if (node.name === "strong") break;
-      if (node.name === "br") {
-        // `<br>` has empty .text(); add an explicit space so adjacent values
-        // don't concatenate (e.g. line-break between location and map URL).
-        text += " ";
-      } else {
-        if (!href) {
-          const directHref = node.name === "a" ? $(node as never).attr("href") : undefined;
-          href = directHref || $(node as never).find("a").first().attr("href") || undefined;
-        }
-        text += $(node as never).text();
-      }
+      if (!href) href = firstHref($, node);
+      text += tagText($, node);
     } else if (node.type === "text") {
       text += node.data ?? "";
     }

--- a/src/adapters/html-scraper/n2th3.ts
+++ b/src/adapters/html-scraper/n2th3.ts
@@ -21,6 +21,33 @@ const DEFAULT_START_TIME = "19:00";
  * value into this one. Instead, iterate `<strong>` tags and collect sibling
  * nodes *until the next `<strong>`* so each label gets exactly its own value.
  */
+/**
+ * Walk sibling nodes after `startNode` until the next `<strong>` tag,
+ * accumulating text content and the first `<a>` href found (direct or nested).
+ */
+function collectSiblingValue(
+  $: cheerio.CheerioAPI,
+  startNode: { nextSibling: unknown },
+): { text: string; href?: string } {
+  let text = "";
+  let href: string | undefined;
+  let node = startNode.nextSibling as { type?: string; nextSibling: unknown; name?: string; data?: string } | null;
+  while (node) {
+    if (node.type === "tag") {
+      if (node.name === "strong") break;
+      if (!href) {
+        const directHref = node.name === "a" ? $(node as never).attr("href") : undefined;
+        href = directHref || $(node as never).find("a").first().attr("href") || undefined;
+      }
+      text += $(node as never).text();
+    } else if (node.type === "text") {
+      text += node.data ?? "";
+    }
+    node = node.nextSibling as typeof node;
+  }
+  return { text, href };
+}
+
 function extractLabeledField(
   $: cheerio.CheerioAPI,
   label: RegExp,
@@ -30,25 +57,8 @@ function extractLabeledField(
     const strongText = $(strong).text().trim().replace(/:?\s*$/, "");
     if (!label.test(strongText)) continue;
 
-    let text = "";
-    let href: string | undefined;
-    let node: typeof strong.nextSibling = strong.nextSibling;
-    while (node) {
-      if (node.type === "tag") {
-        const tagName = (node as { name: string }).name;
-        if (tagName === "strong") break;
-        if (!href) {
-          // Check direct tag first, then nested descendants (e.g. <span><a/></span>)
-          const directHref = tagName === "a" ? $(node).attr("href") : undefined;
-          href = directHref || $(node).find("a").first().attr("href") || undefined;
-        }
-        text += $(node).text();
-      } else if (node.type === "text") {
-        text += (node as { data?: string }).data ?? "";
-      }
-      node = node.nextSibling;
-    }
-    const trimmed = text.replace(/^[:\s]+/, "").replace(/\s+/g, " ").trim();
+    const { text, href } = collectSiblingValue($, strong);
+    const trimmed = text.replace(/^[:\s]+/, "").replaceAll(/\s+/g, " ").trim();
     if (trimmed) return { text: trimmed, href };
   }
   return null;

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -536,10 +536,14 @@ const PLACEHOLDER_RE =
  * insensitive regex). A `\b` word-boundary doesn't help here because "AmazonWhat" has
  * no word break — both characters are word chars.
  *
+ * Uppercase variants (WHAT, WHERE, WHO…) are listed explicitly rather than using
+ * /i so we catch all-caps BJH3/BMPH3-style labels without triggering the
+ * "Somewhere:" regression.
+ *
  * Single source of truth used by both google-calendar and html-scraper adapters.
  */
 export const EVENT_FIELD_LABEL_RE =
-  /(?:What|Where|When|Why|How|Time|Start|Location|Hash\s*Cash|Cost|Price|Registration|On[\s-]After|Directions|Pack\s*Meet|Circle|Chalk\s*Talk)\s*:.*$/i;
+  /(?:What|Where|When|Why|How|Who|Time|Start|Location|Hash\s*Cash|Cost|Price|Registration|On[\s-]After|Directions|Pack\s*Meet|Circle|Chalk\s*Talk|WHAT|WHERE|WHEN|WHY|HOW|WHO|TIME|START|LOCATION|HASH\s*CASH|COST|PRICE)\s*:.*$/;
 
 /**
  * Check if a value is a common placeholder (TBD, TBA, TBC, N/A, ?, ??, needed, required).

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -536,14 +536,17 @@ const PLACEHOLDER_RE =
  * insensitive regex). A `\b` word-boundary doesn't help here because "AmazonWhat" has
  * no word break — both characters are word chars.
  *
- * Uppercase variants (WHAT, WHERE, WHO…) are listed explicitly rather than using
- * /i so we catch all-caps BJH3/BMPH3-style labels without triggering the
- * "Somewhere:" regression.
+ * All-caps variants live in {@link EVENT_FIELD_LABEL_UPPERCASE_RE} so each regex stays
+ * under SonarCloud's complexity budget and callers can apply both passes.
  *
  * Single source of truth used by both google-calendar and html-scraper adapters.
  */
 export const EVENT_FIELD_LABEL_RE =
-  /(?:What|Where|When|Why|How|Who|Time|Start|Location|Hash\s*Cash|Cost|Price|Registration|On[\s-]After|Directions|Pack\s*Meet|Circle|Chalk\s*Talk|WHAT|WHERE|WHEN|WHY|HOW|WHO|TIME|START|LOCATION|HASH\s*CASH|COST|PRICE)\s*:.*$/;
+  /(?:What|Where|When|Why|How|Time|Start|Location|Hash\s*Cash|Cost|Price|Registration|On[\s-]After|Directions|Pack\s*Meet|Circle|Chalk\s*Talk)\s*:.*$/;
+
+/** All-caps counterpart of {@link EVENT_FIELD_LABEL_RE} for BJH3/BMPH3-style descriptions. */
+export const EVENT_FIELD_LABEL_UPPERCASE_RE =
+  /(?:WHAT|WHERE|WHEN|WHY|HOW|WHO|TIME|START|LOCATION|HASH\s*CASH|COST|PRICE)\s*:.*$/;
 
 /**
  * Check if a value is a common placeholder (TBD, TBA, TBC, N/A, ?, ??, needed, required).

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -539,7 +539,7 @@ const PLACEHOLDER_RE =
  * Single source of truth used by both google-calendar and html-scraper adapters.
  */
 export const EVENT_FIELD_LABEL_RE =
-  /(?:What|Where|When|Why|How|Time|Start|Location|Hash\s*Cash|Cost|Price|Registration|On[\s-]After|Directions|Pack\s*Meet|Circle|Chalk\s*Talk)\s*:.*$/;
+  /(?:What|Where|When|Why|How|Time|Start|Location|Hash\s*Cash|Cost|Price|Registration|On[\s-]After|Directions|Pack\s*Meet|Circle|Chalk\s*Talk)\s*:.*$/i;
 
 /**
  * Check if a value is a common placeholder (TBD, TBA, TBC, N/A, ?, ??, needed, required).


### PR DESCRIPTION
## Summary

Chrome Daily Hareline audit round 4 — five adapter parser bug fixes across four files, plus one shared utility improvement. All changes gated by existing tests; no behavior changes for sources that already parsed correctly.

## Changes

- **`src/adapters/google-calendar/adapter.ts`** — Add `WHO ARE THE HARES:` label pattern, `COST_LABEL_RE` + `extractCostFromDescription` export. Extract `(lat, lng)` pairs out of `item.location` into `latitude`/`longitude` (rejects Null Island). Covers #774 (BJH3), #778 (BMPH3 label-line), #779 (BMPH3 coord-only location).
- **`src/adapters/utils.ts`** — `EVENT_FIELD_LABEL_RE` now case-insensitive so uppercase sibling labels (\`WHEN:\`, \`HASH CASH:\`) stop leaking into adjacent values during mid-value truncation.
- **`src/adapters/html-scraper/adelaide-h3.ts`** — Filter placeholder venue/street through \`isPlaceholder()\`. Covers #705 (TBA stored verbatim as locationName + junk \`?q=TBA\` Maps URL).
- **`src/adapters/html-scraper/n2th3.ts`** — Rewrote \`extractLabeledField\` as a sibling-node walker. N2TH3 posts collapse multiple labels into one \`<p>\` separated by \`<br>\`; the old \`p.text()\`-after-strong approach leaked the next label's value into the current one. Covers #723.
- **`src/adapters/html-scraper/bfm.ts`** — Match \`Upcumming Hashes\` pun + split entries on month-name lookahead (no word-boundary anchor since \"Energetic\"+\"May\" run together). Covers #762, #763.

## Auto-heal (already fixed by PR #805, not in this diff)

#727, #760 — BFMH3 \`hares = 'On On Q'\`. \`HARE_BOILERPLATE_RE\` covers \"On On\" per PR #805 diagnostic. Legacy DB rows are stale pre-fix data; closing on merge.

## Deferred

#775 — will scope in follow-up.

## Adversarial review

Caught three issues pre-push:
1. n2th3 walker missed nested \`<a>\` tags (e.g. \`<span><a/></span>\`) — fixed to scan descendants within sibling window.
2. \`COST_LABEL_RE\` leaked uppercase adjacent fields — fixed via \`/i\` flag on shared regex.
3. Coord validation accepted (0,0) — fixed with explicit Null Island rejection.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` 4886 pass (added regression coverage per fix)
- [x] \`npm run lint\` 0 errors
- [ ] Live verify on merge: BJH3 / BMPH3 GCal, Adelaide H3, N2TH3, BFM

Fixes: #774 #778 #779 #705 #723 #727 #760 #762 #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)