### PR TITLE
fix(seed): source identity is (name,type), not (url,type) (#817, #789)

### DIFF
--- a/prisma/seed-data/sources.test.ts
+++ b/prisma/seed-data/sources.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { SOURCES } from "./sources";
 
 describe("SOURCES seed data invariants (#817 regression guard)", () => {

--- a/prisma/seed-data/sources.test.ts
+++ b/prisma/seed-data/sources.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { SOURCES } from "./sources";
+
+describe("SOURCES seed data invariants (#817 regression guard)", () => {
+  it("every (name, type) pair is unique", () => {
+    // prisma/seed.ts:363 looks up existing sources by (name, type) as the
+    // identity key. Collisions there would collapse two seed rows into one
+    // DB row — the exact bug that hit HARRIER_CENTRAL in #817 when the key
+    // was (url, type).
+    const seen = new Map<string, number>();
+    const dupes: string[] = [];
+    for (const s of SOURCES) {
+      const key = `${s.name}::${s.type}`;
+      const count = (seen.get(key) ?? 0) + 1;
+      seen.set(key, count);
+      if (count === 2) dupes.push(key);
+    }
+    expect(dupes).toEqual([]);
+  });
+
+  it("HARRIER_CENTRAL sources stay distinct even though they share a base URL", () => {
+    const hc = SOURCES.filter((s) => s.type === "HARRIER_CENTRAL");
+    // Three live sources today (Tokyo H3, Morgantown H3, Singapore Sunday H3).
+    // The count guard catches a regression where a seed edit accidentally
+    // drops one.
+    expect(hc.length).toBeGreaterThanOrEqual(3);
+
+    // They intentionally share a base URL (config-driven REST API).
+    const urls = new Set(hc.map((s) => s.url));
+    expect(urls.size).toBe(1);
+
+    // But the discriminator lives in `config` — either cityNames or
+    // kennelUniqueShortName must be present and distinct per row.
+    const discriminators = hc.map((s) => {
+      const cfg = (s.config ?? {}) as { cityNames?: string; kennelUniqueShortName?: string };
+      return cfg.cityNames ?? cfg.kennelUniqueShortName ?? "";
+    });
+    expect(discriminators.every((d) => d.length > 0)).toBe(true);
+    expect(new Set(discriminators).size).toBe(discriminators.length);
+  });
+});

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -56,13 +56,7 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "every_6h",
       scrapeDays: 365,
-      // Shared Boston-area calendar. Patterns were previously hardcoded in
-      // google-calendar/adapter.ts (BOSTON_KENNEL_PATTERNS); moving them into
-      // source config lets us extend without touching adapter code. Order
-      // matters — matchConfigPatterns returns the first match (adapter.ts:506),
-      // so more specific patterns come first. See #789.
-      //   - "Bos\s*Moo[mn]" catches the observed "Boston Moom" typo
-      //   - "\bTaco\b" catches "Taco Marathon" variants without "Pink"
+      // Shared Boston-area calendar — order matters, first match wins.
       config: {
         kennelPatterns: [
           ["Boston Ball\\s*Buster|\\bBall\\s*Buster\\b|BoBBH3|B3H4|BBH3", "bobbh3"],

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -56,6 +56,23 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "every_6h",
       scrapeDays: 365,
+      // Shared Boston-area calendar. Patterns were previously hardcoded in
+      // google-calendar/adapter.ts (BOSTON_KENNEL_PATTERNS); moving them into
+      // source config lets us extend without touching adapter code. Order
+      // matters — matchConfigPatterns returns the first match (adapter.ts:506),
+      // so more specific patterns come first. See #789.
+      //   - "Bos\s*Moo[mn]" catches the observed "Boston Moom" typo
+      //   - "\bTaco\b" catches "Taco Marathon" variants without "Pink"
+      config: {
+        kennelPatterns: [
+          ["Boston Ball\\s*Buster|\\bBall\\s*Buster\\b|BoBBH3|B3H4|BBH3", "bobbh3"],
+          ["Beantown", "beantown"],
+          ["Pink Taco|PT2H3|\\bTaco\\b", "pink-taco"],
+          ["Boston Moo[mn]|Full Moon|\\bMoo[mn]\\b", "bos-moon"],
+          ["Boston H3|Boston Hash|BoH3|BH3", "boh3"],
+        ],
+        defaultKennelTag: "boh3",
+      },
       kennelCodes: ["boh3", "bobbh3", "beantown", "bos-moon", "pink-taco"],
     },
     {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -349,24 +349,21 @@ async function ensureSources(prisma: any, sources: any[], kennelRecords: Map<str
   // any DB rows that were removed from SOURCES (e.g. retired dead-upstream sources).
   // Soft-disable (not delete) preserves RawEvents / ScrapeLogs for audit; operators
   // can manually delete stale rows after confirming nothing depends on them.
-  // Caveat: renaming a seed entry (same type, new name) will make the old row
-  // appear stale for one reconciliation pass, even though the name gets updated
-  // via the url/name OR-match above. Operators can safely skip reconcile during
-  // rename seeds, or rename via a two-step: alias first, then seed.
+  // Renames are a two-step: alias first, then seed — the identity key is
+  // (name, type), not url, because config-driven adapters (HARRIER_CENTRAL,
+  // MEETUP, some GOOGLE_CALENDAR aggregators) legitimately share a URL across
+  // multiple sources that differ only in their `config`. Matching by url here
+  // collapsed the 3 HARRIER_CENTRAL sources into a single DB row — see #817.
   const seededKeys = new Set<string>(
     sources.map((s) => `${s.name}::${s.type}`),
   );
   for (const source of sources) {
     const { kennelCodes, kennelSlugMap, ...sourceData } = source;
 
-    // Check if source already exists by URL or name+type
+    // Identity is (name, type). Url is synced below via the scalar-field loop
+    // if it changes on an existing row.
     const existingSource = await prisma.source.findFirst({
-      where: {
-        OR: [
-          { url: sourceData.url, type: sourceData.type },
-          { name: sourceData.name, type: sourceData.type },
-        ],
-      },
+      where: { name: sourceData.name, type: sourceData.type },
       orderBy: { createdAt: "asc" },
     });
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -345,23 +345,18 @@ async function ensureAliases(prisma: any, kennelAliases: Record<string, string[]
 async function ensureSources(prisma: any, sources: any[], kennelRecords: Map<string, { id: string }>) {
   console.log("Seeding sources...");
   let created = 0;
-  // Track which (name+type) pairs are still in the seed so we can soft-disable
-  // any DB rows that were removed from SOURCES (e.g. retired dead-upstream sources).
-  // Soft-disable (not delete) preserves RawEvents / ScrapeLogs for audit; operators
-  // can manually delete stale rows after confirming nothing depends on them.
-  // Renames are a two-step: alias first, then seed — the identity key is
-  // (name, type), not url, because config-driven adapters (HARRIER_CENTRAL,
-  // MEETUP, some GOOGLE_CALENDAR aggregators) legitimately share a URL across
-  // multiple sources that differ only in their `config`. Matching by url here
-  // collapsed the 3 HARRIER_CENTRAL sources into a single DB row — see #817.
+  // Identity is (name, type), not url — config-driven adapters
+  // (HARRIER_CENTRAL, MEETUP, some GOOGLE_CALENDAR aggregators) legitimately
+  // share a url across multiple sources. Matching by url collapsed all three
+  // HARRIER_CENTRAL sources into a single DB row (#817). Renames are a
+  // two-step: alias first, then seed. Sources dropped from SOURCES are
+  // soft-disabled (not deleted) below so their RawEvents / ScrapeLogs survive.
   const seededKeys = new Set<string>(
     sources.map((s) => `${s.name}::${s.type}`),
   );
   for (const source of sources) {
     const { kennelCodes, kennelSlugMap, ...sourceData } = source;
 
-    // Identity is (name, type). Url is synced below via the scalar-field loop
-    // if it changes on an existing row.
     const existingSource = await prisma.source.findFirst({
       where: { name: sourceData.name, type: sourceData.type },
       orderBy: { createdAt: "asc" },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -357,10 +357,17 @@ async function ensureSources(prisma: any, sources: any[], kennelRecords: Map<str
   for (const source of sources) {
     const { kennelCodes, kennelSlugMap, ...sourceData } = source;
 
-    const existingSource = await prisma.source.findFirst({
+    const matchingSources = await prisma.source.findMany({
       where: { name: sourceData.name, type: sourceData.type },
       orderBy: { createdAt: "asc" },
+      take: 2,
     });
+    if (matchingSources.length > 1) {
+      throw new Error(
+        `Duplicate Source rows for identity ${sourceData.name}::${sourceData.type} — seed cannot disambiguate. Resolve in DB before re-seeding.`,
+      );
+    }
+    const existingSource = matchingSources[0] ?? null;
 
     let activeSource;
     try {

--- a/scripts/split-harrier-central-sources.ts
+++ b/scripts/split-harrier-central-sources.ts
@@ -5,6 +5,10 @@
  * links. Leaves existing RawEvents on the surviving row — next scrape
  * repopulates the new rows.
  *
+ * Convergent across partial failures: the plan is driven by missing
+ * `(Source, SourceKennel)` pairs, not just missing Source rows, and each
+ * per-source apply runs in a transaction. Safe to rerun after any crash.
+ *
  * Usage:
  *   set -a && source .env && set +a
  *   npx tsx scripts/split-harrier-central-sources.ts            # dry run
@@ -20,10 +24,19 @@ const dryRun = !process.argv.includes("--apply");
 
 type SeedSource = (typeof SOURCES)[number];
 
-interface PlannedCreate {
-  name: string;
-  kennelCodes: readonly string[];
+interface PlannedSource {
   seed: SeedSource;
+  /** Existing Source row (if the previous apply partially succeeded), else null. */
+  existing: { id: string; name: string } | null;
+  /** kennelCodes from the seed that still need SourceKennel links to this source. */
+  missingKennelCodes: string[];
+}
+
+interface OrphanLink {
+  sourceId: string;
+  sourceName: string;
+  kennelId: string;
+  kennelCode: string;
 }
 
 async function main() {
@@ -31,102 +44,139 @@ async function main() {
   const adapter = new PrismaPg(pool);
   const prisma = new PrismaClient({ adapter } as never);
 
-  console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
+  try {
+    console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
 
-  const hcSeeds = SOURCES.filter((s) => s.type === "HARRIER_CENTRAL");
-  console.log(`Found ${hcSeeds.length} HARRIER_CENTRAL source(s) in seed data:`);
-  for (const s of hcSeeds) console.log(`  • ${s.name}`);
-  console.log();
+    const hcSeeds = SOURCES.filter((s) => s.type === "HARRIER_CENTRAL");
+    console.log(`Found ${hcSeeds.length} HARRIER_CENTRAL source(s) in seed data:`);
+    for (const s of hcSeeds) console.log(`  • ${s.name}`);
+    console.log();
 
-  const hcRows = await prisma.source.findMany({
-    where: { type: "HARRIER_CENTRAL" },
-    select: { id: true, name: true, url: true, config: true },
-  });
-  console.log(`Found ${hcRows.length} HARRIER_CENTRAL Source row(s) in DB:`);
-  for (const r of hcRows) console.log(`  • ${r.id}  ${r.name}`);
-  console.log();
+    const hcRows = await prisma.source.findMany({
+      where: { type: "HARRIER_CENTRAL" },
+      select: { id: true, name: true },
+    });
+    console.log(`Found ${hcRows.length} HARRIER_CENTRAL Source row(s) in DB:`);
+    for (const r of hcRows) console.log(`  • ${r.id}  ${r.name}`);
+    console.log();
 
-  const byName = new Map(hcRows.map((r) => [r.name, r]));
-  const toCreate: PlannedCreate[] = [];
-  for (const seed of hcSeeds) {
-    if (byName.has(seed.name)) continue;
-    toCreate.push({ name: seed.name, kennelCodes: seed.kennelCodes, seed });
-  }
+    const byName = new Map(hcRows.map((r) => [r.name, r]));
 
-  if (toCreate.length === 0 && hcRows.length === hcSeeds.length) {
-    console.log("✅ DB already in the correct shape — nothing to do.");
-    await pool.end();
-    return;
-  }
+    // Preload all kennels referenced by HC seeds, plus all SourceKennel rows on
+    // HC sources — drives the plan + idempotency check with O(1) lookups.
+    const allCodes = Array.from(new Set(hcSeeds.flatMap((s) => s.kennelCodes)));
+    const kennels = await prisma.kennel.findMany({
+      where: { kennelCode: { in: allCodes } },
+      select: { id: true, kennelCode: true },
+    });
+    const kennelsByCode = new Map(kennels.map((k) => [k.kennelCode, k]));
+    const missingKennelRecords = allCodes.filter((c) => !kennelsByCode.has(c));
+    if (missingKennelRecords.length > 0) {
+      console.error(`❌ Missing kennels in DB for kennelCodes: ${missingKennelRecords.join(", ")}`);
+      console.error("   Seed kennels first, then re-run this script.");
+      process.exit(1);
+    }
 
-  console.log(`Plan: create ${toCreate.length} missing Source row(s)\n`);
-  for (const c of toCreate) {
-    console.log(`  + Create Source: ${c.name}`);
-    console.log(`      kennelCodes to re-parent: ${c.kennelCodes.join(", ")}`);
-  }
-  console.log();
+    const existingLinks = await prisma.sourceKennel.findMany({
+      where: { source: { type: "HARRIER_CENTRAL" } },
+      select: { sourceId: true, kennelId: true },
+    });
+    const linkKey = (sourceId: string, kennelId: string) => `${sourceId}:${kennelId}`;
+    const existingLinkSet = new Set(existingLinks.map((l) => linkKey(l.sourceId, l.kennelId)));
 
-  // Look up kennels we'll need to re-link.
-  const allCodes = Array.from(new Set(toCreate.flatMap((c) => c.kennelCodes)));
-  const kennels = await prisma.kennel.findMany({
-    where: { kennelCode: { in: allCodes } },
-    select: { id: true, kennelCode: true, shortName: true },
-  });
-  const kennelsByCode = new Map(kennels.map((k) => [k.kennelCode, k]));
-  const missingCodes = allCodes.filter((c) => !kennelsByCode.has(c));
-  if (missingCodes.length > 0) {
-    console.error(`❌ Missing kennels in DB for kennelCodes: ${missingCodes.join(", ")}`);
-    console.error("   Seed kennels first, then re-run this script.");
-    await pool.end();
-    process.exit(1);
-  }
+    // Plan: for each seed, what's missing? A seed is done iff its Source row
+    // exists AND all its kennelCodes are linked to it.
+    const plan: PlannedSource[] = hcSeeds.map((seed) => {
+      const existing = byName.get(seed.name) ?? null;
+      const missingKennelCodes = existing
+        ? seed.kennelCodes.filter((code) => {
+            const kennel = kennelsByCode.get(code)!;
+            return !existingLinkSet.has(linkKey(existing.id, kennel.id));
+          })
+        : [...seed.kennelCodes];
+      return { seed, existing, missingKennelCodes };
+    });
 
-  if (dryRun) {
-    console.log("(dry run) re-run with --apply to create sources + re-link SourceKennel rows.");
-    await pool.end();
-    return;
-  }
-
-  for (const c of toCreate) {
-    const seed = c.seed as SeedSource & { kennelSlugMap?: Record<string, string> };
-    const { kennelCodes: _kc, kennelSlugMap: _ksm, ...data } = seed;
-    const newSource = await prisma.source.create({ data });
-    console.log(`  ✓ Created Source ${newSource.id}  ${newSource.name}`);
-
-    for (const code of c.kennelCodes) {
-      const kennel = kennelsByCode.get(code)!;
-      const existingLinks = await prisma.sourceKennel.findMany({
-        where: { kennelId: kennel.id, source: { type: "HARRIER_CENTRAL" } },
-      });
-      const toNew = existingLinks.find((l) => l.sourceId !== newSource.id);
-      if (toNew) {
-        // Re-parent the existing link. Use upsert via delete+create because
-        // @@unique([sourceId, kennelId]) could collide with an existing
-        // link to the new source.
-        const alreadyLinked = await prisma.sourceKennel.findUnique({
-          where: { sourceId_kennelId: { sourceId: newSource.id, kennelId: kennel.id } },
-        });
-        if (alreadyLinked) {
-          await prisma.sourceKennel.delete({ where: { id: toNew.id } });
-          console.log(`    ~ Dropped dup SourceKennel for ${code} (kept ${alreadyLinked.id})`);
-        } else {
-          await prisma.sourceKennel.update({
-            where: { id: toNew.id },
-            data: { sourceId: newSource.id },
-          });
-          console.log(`    → Re-parented SourceKennel for ${code} → ${newSource.id}`);
-        }
-      } else {
-        await prisma.sourceKennel.create({
-          data: { sourceId: newSource.id, kennelId: kennel.id },
-        });
-        console.log(`    + Created SourceKennel for ${code} → ${newSource.id}`);
+    // Orphan links = SourceKennel rows on an existing HC source that link to
+    // a kennel NOT in that source's seed kennelCodes. These are residue from
+    // the collapse and must be removed so the collapsed source no longer
+    // claims ownership over kennels that now belong to a new source row.
+    const seedByName = new Map(hcSeeds.map((s) => [s.name, s]));
+    const kennelIdToCode = new Map(kennels.map((k) => [k.id, k.kennelCode]));
+    const orphans: OrphanLink[] = [];
+    for (const link of existingLinks) {
+      const row = hcRows.find((r) => r.id === link.sourceId);
+      if (!row) continue;
+      const seed = seedByName.get(row.name);
+      const kennelCode = kennelIdToCode.get(link.kennelId);
+      if (!seed || !kennelCode) continue;
+      if (!seed.kennelCodes.includes(kennelCode)) {
+        orphans.push({ sourceId: link.sourceId, sourceName: row.name, kennelId: link.kennelId, kennelCode });
       }
     }
-  }
 
-  console.log("\n✅ Done. Trigger a fresh scrape of each HC source to repopulate RawEvents.");
-  await pool.end();
+    const workItems = plan.filter((p) => !p.existing || p.missingKennelCodes.length > 0);
+    if (workItems.length === 0 && orphans.length === 0) {
+      console.log("✅ DB already in the correct shape — nothing to do.");
+      return;
+    }
+
+    console.log(`Plan:\n`);
+    for (const p of workItems) {
+      if (!p.existing) {
+        console.log(`  + Create Source: ${p.seed.name}`);
+        console.log(`      Link kennels: ${p.missingKennelCodes.join(", ")}`);
+      } else {
+        console.log(`  ~ Source ${p.seed.name} exists (${p.existing.id}) — add missing links`);
+        console.log(`      Link kennels: ${p.missingKennelCodes.join(", ")}`);
+      }
+    }
+    for (const o of orphans) {
+      console.log(`  - Delete orphan SourceKennel: ${o.sourceName} ⇢ ${o.kennelCode}`);
+    }
+    console.log();
+
+    if (dryRun) {
+      console.log("(dry run) re-run with --apply to execute.");
+      return;
+    }
+
+    await prisma.$transaction(async (tx) => {
+      for (const p of workItems) {
+        let sourceId: string;
+        if (p.existing) {
+          sourceId = p.existing.id;
+        } else {
+          const seed = p.seed as SeedSource & { kennelSlugMap?: Record<string, string> };
+          const { kennelCodes: _kc, kennelSlugMap: _ksm, ...data } = seed;
+          const created = await tx.source.create({ data });
+          sourceId = created.id;
+          console.log(`  ✓ Created Source ${created.id}  ${created.name}`);
+        }
+
+        for (const code of p.missingKennelCodes) {
+          const kennel = kennelsByCode.get(code)!;
+          await tx.sourceKennel.upsert({
+            where: { sourceId_kennelId: { sourceId, kennelId: kennel.id } },
+            create: { sourceId, kennelId: kennel.id },
+            update: {},
+          });
+          console.log(`    + Linked ${code} → ${sourceId}`);
+        }
+      }
+
+      for (const o of orphans) {
+        await tx.sourceKennel.delete({
+          where: { sourceId_kennelId: { sourceId: o.sourceId, kennelId: o.kennelId } },
+        });
+        console.log(`    - Deleted orphan ${o.sourceName} ⇢ ${o.kennelCode}`);
+      }
+    });
+
+    console.log("\n✅ Done. Trigger a fresh scrape of each HC source to repopulate RawEvents.");
+  } finally {
+    await pool.end();
+  }
 }
 
 main().catch((err) => {

--- a/scripts/split-harrier-central-sources.ts
+++ b/scripts/split-harrier-central-sources.ts
@@ -52,17 +52,22 @@ async function main() {
     for (const s of hcSeeds) console.log(`  • ${s.name}`);
     console.log();
 
-    const hcRows = await prisma.source.findMany({
-      where: { type: "HARRIER_CENTRAL" },
-      select: { id: true, name: true },
-    });
+    const [hcRows, existingLinks] = await Promise.all([
+      prisma.source.findMany({
+        where: { type: "HARRIER_CENTRAL" },
+        select: { id: true, name: true },
+      }),
+      prisma.sourceKennel.findMany({
+        where: { source: { type: "HARRIER_CENTRAL" } },
+        select: { sourceId: true, kennelId: true },
+      }),
+    ]);
     console.log(`Found ${hcRows.length} HARRIER_CENTRAL Source row(s) in DB:`);
     for (const r of hcRows) console.log(`  • ${r.id}  ${r.name}`);
     console.log();
 
-    // Since this repair enforces (name, type) as identity, bail out loudly if
-    // the prod table already violates that invariant — operating on an
-    // arbitrarily-chosen row would move links non-deterministically.
+    // This repair assumes (name, type) is the identity — bail out before
+    // mutating anything if the DB already violates that.
     const byName = new Map<string, { id: string; name: string }>();
     const dupeNames: string[] = [];
     for (const row of hcRows) {
@@ -70,19 +75,11 @@ async function main() {
       else byName.set(row.name, row);
     }
     if (dupeNames.length > 0) {
-      console.error(`❌ Duplicate HARRIER_CENTRAL Source rows with same name: ${Array.from(new Set(dupeNames)).join(", ")}`);
-      console.error("   Resolve manually in DB (pick which row to keep) before running this script.");
-      process.exit(1);
+      throw new Error(
+        `Duplicate HARRIER_CENTRAL Source rows with same name: ${Array.from(new Set(dupeNames)).join(", ")}. Resolve manually in DB before re-running.`,
+      );
     }
 
-    const existingLinks = await prisma.sourceKennel.findMany({
-      where: { source: { type: "HARRIER_CENTRAL" } },
-      select: { sourceId: true, kennelId: true },
-    });
-
-    // Load kennels referenced by HC seeds AND by existing SourceKennel links.
-    // The link-side load ensures orphan detection can see links that point at
-    // kennels no longer in any current seed (residue from the collapse).
     const allSeedCodes = Array.from(new Set(hcSeeds.flatMap((s) => s.kennelCodes)));
     const linkedKennelIds = Array.from(new Set(existingLinks.map((l) => l.kennelId)));
     const kennels = await prisma.kennel.findMany({
@@ -97,15 +94,13 @@ async function main() {
     const kennelsByCode = new Map(kennels.map((k) => [k.kennelCode, k]));
     const missingSeedKennels = allSeedCodes.filter((c) => !kennelsByCode.has(c));
     if (missingSeedKennels.length > 0) {
-      console.error(`❌ Missing kennels in DB for kennelCodes: ${missingSeedKennels.join(", ")}`);
-      console.error("   Seed kennels first, then re-run this script.");
-      process.exit(1);
+      throw new Error(
+        `Missing kennels in DB for kennelCodes: ${missingSeedKennels.join(", ")}. Seed kennels first, then re-run.`,
+      );
     }
     const linkKey = (sourceId: string, kennelId: string) => `${sourceId}:${kennelId}`;
     const existingLinkSet = new Set(existingLinks.map((l) => linkKey(l.sourceId, l.kennelId)));
 
-    // Plan: for each seed, what's missing? A seed is done iff its Source row
-    // exists AND all its kennelCodes are linked to it.
     const plan: PlannedSource[] = hcSeeds.map((seed) => {
       const existing = byName.get(seed.name) ?? null;
       const missingKennelCodes = existing
@@ -117,25 +112,26 @@ async function main() {
       return { seed, existing, missingKennelCodes };
     });
 
-    // Orphan links = SourceKennel rows on an existing HC source that link to
-    // a kennel NOT in that source's seed kennelCodes. These are residue from
-    // the collapse and must be removed so the collapsed source no longer
-    // claims ownership over kennels that now belong to a new source row.
-    // Also treated as orphans: links on HC source rows that have no matching
-    // seed by name at all (the collapsed row whose seed has been superseded
-    // by distinct per-city rows).
+    // An existing SourceKennel link is an orphan when its source row has no
+    // matching seed (collapsed legacy row) OR when it points at a kennel
+    // outside its seed's kennelCodes (residue from the collapse). Both must
+    // be removed so ownership shifts cleanly to the new per-city rows.
     const seedByName = new Map(hcSeeds.map((s) => [s.name, s]));
     const rowsById = new Map(hcRows.map((r) => [r.id, r]));
     const kennelIdToCode = new Map(kennels.map((k) => [k.id, k.kennelCode]));
     const orphans: OrphanLink[] = [];
     for (const link of existingLinks) {
       const row = rowsById.get(link.sourceId);
-      if (!row) continue; // defensive — FK should guarantee this
-      const kennelCode = kennelIdToCode.get(link.kennelId) ?? "<unknown>";
+      if (!row) continue;
+      const kennelCode = kennelIdToCode.get(link.kennelId);
+      if (!kennelCode) {
+        // Every link.kennelId is in `linkedKennelIds` which drives the
+        // kennels query, so a miss here means the kennel row was deleted
+        // between the two queries — fail rather than risk a bogus orphan
+        // delete on a real kennel.
+        throw new Error(`Kennel ${link.kennelId} disappeared between queries (link from source ${link.sourceId})`);
+      }
       const seed = seedByName.get(row.name);
-      // If the source row has no matching seed, every link on it is orphaned
-      // (collapsed row whose name doesn't match any current seed).
-      // Otherwise, only links to kennels outside its kennelCodes are orphans.
       const isOrphan = !seed || !seed.kennelCodes.includes(kennelCode);
       if (isOrphan) {
         orphans.push({ sourceId: link.sourceId, sourceName: row.name, kennelId: link.kennelId, kennelCode });

--- a/scripts/split-harrier-central-sources.ts
+++ b/scripts/split-harrier-central-sources.ts
@@ -60,20 +60,18 @@ async function main() {
     for (const r of hcRows) console.log(`  • ${r.id}  ${r.name}`);
     console.log();
 
-    const byName = new Map(hcRows.map((r) => [r.name, r]));
-
-    // Preload all kennels referenced by HC seeds, plus all SourceKennel rows on
-    // HC sources — drives the plan + idempotency check with O(1) lookups.
-    const allCodes = Array.from(new Set(hcSeeds.flatMap((s) => s.kennelCodes)));
-    const kennels = await prisma.kennel.findMany({
-      where: { kennelCode: { in: allCodes } },
-      select: { id: true, kennelCode: true },
-    });
-    const kennelsByCode = new Map(kennels.map((k) => [k.kennelCode, k]));
-    const missingKennelRecords = allCodes.filter((c) => !kennelsByCode.has(c));
-    if (missingKennelRecords.length > 0) {
-      console.error(`❌ Missing kennels in DB for kennelCodes: ${missingKennelRecords.join(", ")}`);
-      console.error("   Seed kennels first, then re-run this script.");
+    // Since this repair enforces (name, type) as identity, bail out loudly if
+    // the prod table already violates that invariant — operating on an
+    // arbitrarily-chosen row would move links non-deterministically.
+    const byName = new Map<string, { id: string; name: string }>();
+    const dupeNames: string[] = [];
+    for (const row of hcRows) {
+      if (byName.has(row.name)) dupeNames.push(row.name);
+      else byName.set(row.name, row);
+    }
+    if (dupeNames.length > 0) {
+      console.error(`❌ Duplicate HARRIER_CENTRAL Source rows with same name: ${Array.from(new Set(dupeNames)).join(", ")}`);
+      console.error("   Resolve manually in DB (pick which row to keep) before running this script.");
       process.exit(1);
     }
 
@@ -81,6 +79,28 @@ async function main() {
       where: { source: { type: "HARRIER_CENTRAL" } },
       select: { sourceId: true, kennelId: true },
     });
+
+    // Load kennels referenced by HC seeds AND by existing SourceKennel links.
+    // The link-side load ensures orphan detection can see links that point at
+    // kennels no longer in any current seed (residue from the collapse).
+    const allSeedCodes = Array.from(new Set(hcSeeds.flatMap((s) => s.kennelCodes)));
+    const linkedKennelIds = Array.from(new Set(existingLinks.map((l) => l.kennelId)));
+    const kennels = await prisma.kennel.findMany({
+      where: {
+        OR: [
+          { kennelCode: { in: allSeedCodes } },
+          { id: { in: linkedKennelIds } },
+        ],
+      },
+      select: { id: true, kennelCode: true },
+    });
+    const kennelsByCode = new Map(kennels.map((k) => [k.kennelCode, k]));
+    const missingSeedKennels = allSeedCodes.filter((c) => !kennelsByCode.has(c));
+    if (missingSeedKennels.length > 0) {
+      console.error(`❌ Missing kennels in DB for kennelCodes: ${missingSeedKennels.join(", ")}`);
+      console.error("   Seed kennels first, then re-run this script.");
+      process.exit(1);
+    }
     const linkKey = (sourceId: string, kennelId: string) => `${sourceId}:${kennelId}`;
     const existingLinkSet = new Set(existingLinks.map((l) => linkKey(l.sourceId, l.kennelId)));
 
@@ -101,16 +121,23 @@ async function main() {
     // a kennel NOT in that source's seed kennelCodes. These are residue from
     // the collapse and must be removed so the collapsed source no longer
     // claims ownership over kennels that now belong to a new source row.
+    // Also treated as orphans: links on HC source rows that have no matching
+    // seed by name at all (the collapsed row whose seed has been superseded
+    // by distinct per-city rows).
     const seedByName = new Map(hcSeeds.map((s) => [s.name, s]));
+    const rowsById = new Map(hcRows.map((r) => [r.id, r]));
     const kennelIdToCode = new Map(kennels.map((k) => [k.id, k.kennelCode]));
     const orphans: OrphanLink[] = [];
     for (const link of existingLinks) {
-      const row = hcRows.find((r) => r.id === link.sourceId);
-      if (!row) continue;
+      const row = rowsById.get(link.sourceId);
+      if (!row) continue; // defensive — FK should guarantee this
+      const kennelCode = kennelIdToCode.get(link.kennelId) ?? "<unknown>";
       const seed = seedByName.get(row.name);
-      const kennelCode = kennelIdToCode.get(link.kennelId);
-      if (!seed || !kennelCode) continue;
-      if (!seed.kennelCodes.includes(kennelCode)) {
+      // If the source row has no matching seed, every link on it is orphaned
+      // (collapsed row whose name doesn't match any current seed).
+      // Otherwise, only links to kennels outside its kennelCodes are orphans.
+      const isOrphan = !seed || !seed.kennelCodes.includes(kennelCode);
+      if (isOrphan) {
         orphans.push({ sourceId: link.sourceId, sourceName: row.name, kennelId: link.kennelId, kennelCode });
       }
     }

--- a/scripts/split-harrier-central-sources.ts
+++ b/scripts/split-harrier-central-sources.ts
@@ -1,29 +1,14 @@
 /**
- * One-shot fix for #817: the 3 HARRIER_CENTRAL sources (Tokyo H3, Morgantown
- * H3, Singapore Sunday H3) were collapsed into a single Source row by the
- * `(url, type)` branch of the seed's findFirst at prisma/seed.ts:363-371. All
- * 3 share the identical base API URL, so each subsequent seed run overwrote
- * the previous row's name + config. The surviving row depends on seed order;
- * the issue observed it as "Singapore Sunday H3 Harrier Central".
- *
- * The seed fix (restrict identity to `(name, type)`) prevents recurrence but
- * cannot heal the already-merged prod row. This script does the data repair:
- *
- *   1. Find every Source with type=HARRIER_CENTRAL.
- *   2. For each seed entry NOT yet represented in the DB, create the missing
- *      row (copying name, url, config, etc. from the seed definition).
- *   3. Re-parent SourceKennel rows: `tokyo-h3` → Tokyo source,
- *      `mh3-wv` → Morgantown source, `sh3-sg` → Singapore source.
- *   4. Leave existing RawEvents on the surviving row untouched — they were
- *      scraped while the config was SH3-SG, so they belong with the SG source.
- *      Tokyo + Morgantown will pick up fresh RawEvents on the next scrape.
+ * One-shot prod repair for #817: splits a Source row that collapsed multiple
+ * HARRIER_CENTRAL seed entries into one (via the old `(url, type)` seed
+ * identity) back into one row per seed entry, and re-parents SourceKennel
+ * links. Leaves existing RawEvents on the surviving row — next scrape
+ * repopulates the new rows.
  *
  * Usage:
- *   npx tsx scripts/split-harrier-central-sources.ts           # dry run
- *   npx tsx scripts/split-harrier-central-sources.ts --apply   # apply
- *
- * Load env first (tsx does not auto-load .env):
  *   set -a && source .env && set +a
+ *   npx tsx scripts/split-harrier-central-sources.ts            # dry run
+ *   npx tsx scripts/split-harrier-central-sources.ts --apply    # apply
  */
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
@@ -103,8 +88,9 @@ async function main() {
   }
 
   for (const c of toCreate) {
-    const { kennelCodes: _kc, kennelSlugMap: _ksm, ...data } = c.seed as unknown as Record<string, unknown>;
-    const newSource = await prisma.source.create({ data: data as never });
+    const seed = c.seed as SeedSource & { kennelSlugMap?: Record<string, string> };
+    const { kennelCodes: _kc, kennelSlugMap: _ksm, ...data } = seed;
+    const newSource = await prisma.source.create({ data });
     console.log(`  ✓ Created Source ${newSource.id}  ${newSource.name}`);
 
     for (const code of c.kennelCodes) {

--- a/scripts/split-harrier-central-sources.ts
+++ b/scripts/split-harrier-central-sources.ts
@@ -1,0 +1,149 @@
+/**
+ * One-shot fix for #817: the 3 HARRIER_CENTRAL sources (Tokyo H3, Morgantown
+ * H3, Singapore Sunday H3) were collapsed into a single Source row by the
+ * `(url, type)` branch of the seed's findFirst at prisma/seed.ts:363-371. All
+ * 3 share the identical base API URL, so each subsequent seed run overwrote
+ * the previous row's name + config. The surviving row depends on seed order;
+ * the issue observed it as "Singapore Sunday H3 Harrier Central".
+ *
+ * The seed fix (restrict identity to `(name, type)`) prevents recurrence but
+ * cannot heal the already-merged prod row. This script does the data repair:
+ *
+ *   1. Find every Source with type=HARRIER_CENTRAL.
+ *   2. For each seed entry NOT yet represented in the DB, create the missing
+ *      row (copying name, url, config, etc. from the seed definition).
+ *   3. Re-parent SourceKennel rows: `tokyo-h3` → Tokyo source,
+ *      `mh3-wv` → Morgantown source, `sh3-sg` → Singapore source.
+ *   4. Leave existing RawEvents on the surviving row untouched — they were
+ *      scraped while the config was SH3-SG, so they belong with the SG source.
+ *      Tokyo + Morgantown will pick up fresh RawEvents on the next scrape.
+ *
+ * Usage:
+ *   npx tsx scripts/split-harrier-central-sources.ts           # dry run
+ *   npx tsx scripts/split-harrier-central-sources.ts --apply   # apply
+ *
+ * Load env first (tsx does not auto-load .env):
+ *   set -a && source .env && set +a
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+import { SOURCES } from "@/../prisma/seed-data/sources";
+
+const dryRun = !process.argv.includes("--apply");
+
+type SeedSource = (typeof SOURCES)[number];
+
+interface PlannedCreate {
+  name: string;
+  kennelCodes: readonly string[];
+  seed: SeedSource;
+}
+
+async function main() {
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
+
+  const hcSeeds = SOURCES.filter((s) => s.type === "HARRIER_CENTRAL");
+  console.log(`Found ${hcSeeds.length} HARRIER_CENTRAL source(s) in seed data:`);
+  for (const s of hcSeeds) console.log(`  • ${s.name}`);
+  console.log();
+
+  const hcRows = await prisma.source.findMany({
+    where: { type: "HARRIER_CENTRAL" },
+    select: { id: true, name: true, url: true, config: true },
+  });
+  console.log(`Found ${hcRows.length} HARRIER_CENTRAL Source row(s) in DB:`);
+  for (const r of hcRows) console.log(`  • ${r.id}  ${r.name}`);
+  console.log();
+
+  const byName = new Map(hcRows.map((r) => [r.name, r]));
+  const toCreate: PlannedCreate[] = [];
+  for (const seed of hcSeeds) {
+    if (byName.has(seed.name)) continue;
+    toCreate.push({ name: seed.name, kennelCodes: seed.kennelCodes, seed });
+  }
+
+  if (toCreate.length === 0 && hcRows.length === hcSeeds.length) {
+    console.log("✅ DB already in the correct shape — nothing to do.");
+    await pool.end();
+    return;
+  }
+
+  console.log(`Plan: create ${toCreate.length} missing Source row(s)\n`);
+  for (const c of toCreate) {
+    console.log(`  + Create Source: ${c.name}`);
+    console.log(`      kennelCodes to re-parent: ${c.kennelCodes.join(", ")}`);
+  }
+  console.log();
+
+  // Look up kennels we'll need to re-link.
+  const allCodes = Array.from(new Set(toCreate.flatMap((c) => c.kennelCodes)));
+  const kennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: allCodes } },
+    select: { id: true, kennelCode: true, shortName: true },
+  });
+  const kennelsByCode = new Map(kennels.map((k) => [k.kennelCode, k]));
+  const missingCodes = allCodes.filter((c) => !kennelsByCode.has(c));
+  if (missingCodes.length > 0) {
+    console.error(`❌ Missing kennels in DB for kennelCodes: ${missingCodes.join(", ")}`);
+    console.error("   Seed kennels first, then re-run this script.");
+    await pool.end();
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    console.log("(dry run) re-run with --apply to create sources + re-link SourceKennel rows.");
+    await pool.end();
+    return;
+  }
+
+  for (const c of toCreate) {
+    const { kennelCodes: _kc, kennelSlugMap: _ksm, ...data } = c.seed as unknown as Record<string, unknown>;
+    const newSource = await prisma.source.create({ data: data as never });
+    console.log(`  ✓ Created Source ${newSource.id}  ${newSource.name}`);
+
+    for (const code of c.kennelCodes) {
+      const kennel = kennelsByCode.get(code)!;
+      const existingLinks = await prisma.sourceKennel.findMany({
+        where: { kennelId: kennel.id, source: { type: "HARRIER_CENTRAL" } },
+      });
+      const toNew = existingLinks.find((l) => l.sourceId !== newSource.id);
+      if (toNew) {
+        // Re-parent the existing link. Use upsert via delete+create because
+        // @@unique([sourceId, kennelId]) could collide with an existing
+        // link to the new source.
+        const alreadyLinked = await prisma.sourceKennel.findUnique({
+          where: { sourceId_kennelId: { sourceId: newSource.id, kennelId: kennel.id } },
+        });
+        if (alreadyLinked) {
+          await prisma.sourceKennel.delete({ where: { id: toNew.id } });
+          console.log(`    ~ Dropped dup SourceKennel for ${code} (kept ${alreadyLinked.id})`);
+        } else {
+          await prisma.sourceKennel.update({
+            where: { id: toNew.id },
+            data: { sourceId: newSource.id },
+          });
+          console.log(`    → Re-parented SourceKennel for ${code} → ${newSource.id}`);
+        }
+      } else {
+        await prisma.sourceKennel.create({
+          data: { sourceId: newSource.id, kennelId: kennel.id },
+        });
+        console.log(`    + Created SourceKennel for ${code} → ${newSource.id}`);
+      }
+    }
+  }
+
+  console.log("\n✅ Done. Trigger a fresh scrape of each HC source to repopulate RawEvents.");
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -66,25 +66,13 @@ describe("extractKennelTag", () => {
 });
 
 // ── Boston Hash Calendar multi-kennel routing via seed config (#789) ──
-//
-// The Boston source config lives in prisma/seed-data/sources.ts. These
-// patterns are mirrored here so a copy-paste drift between seed and test
-// gets caught. If you edit either side, update both. Order matters —
-// matchConfigPatterns returns the first hit (adapter.ts:506).
 
-const BOSTON_SEED_KENNEL_PATTERNS: [string, string][] = [
-  ["Boston Ball\\s*Buster|\\bBall\\s*Buster\\b|BoBBH3|B3H4|BBH3", "bobbh3"],
-  ["Beantown", "beantown"],
-  ["Pink Taco|PT2H3|\\bTaco\\b", "pink-taco"],
-  ["Boston Moo[mn]|Full Moon|\\bMoo[mn]\\b", "bos-moon"],
-  ["Boston H3|Boston Hash|BoH3|BH3", "boh3"],
-];
+import { SOURCES } from "../../../prisma/seed-data/sources";
 
 describe("Boston Hash Calendar multi-kennel routing (#789)", () => {
-  const config = {
-    kennelPatterns: BOSTON_SEED_KENNEL_PATTERNS,
-    defaultKennelTag: "boh3",
-  };
+  const bostonSource = SOURCES.find((s) => s.name === "Boston Hash Calendar");
+  if (!bostonSource?.config) throw new Error("Boston Hash Calendar seed config missing");
+  const config = bostonSource.config as { kennelPatterns: [string, string][]; defaultKennelTag: string };
 
   it("routes 'Boston Moom' typo to bos-moon (failure mode A from the issue)", () => {
     const result = buildRawEventFromGCalItem(

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -74,52 +74,20 @@ describe("Boston Hash Calendar multi-kennel routing (#789)", () => {
   if (!bostonSource?.config) throw new Error("Boston Hash Calendar seed config missing");
   const config = bostonSource.config as { kennelPatterns: [string, string][]; defaultKennelTag: string };
 
-  it("routes 'Boston Moom' typo to bos-moon (failure mode A from the issue)", () => {
+  it.each([
+    // [summary, expected kennelTag, description]
+    ["Boston Moom", "bos-moon", "failure mode A: 'Boston Moom' typo (not 'Boston Moon')"],
+    ["Taco Marathon Pre-Pre-Pre-Prelube", "pink-taco", "failure mode A: 'Taco' without 'Pink' prefix"],
+    ["Moon Marathon Pre-Pre Lube", "bos-moon", "failure mode A: 'Moon' as solo token"],
+    ["Beantown #276", "beantown", "failure mode B: Beantown no longer dropped"],
+    ["BH3 #2781", "boh3", "plain Boston H3 run"],
+    ["AGM Planning Meeting", "boh3", "defaultKennelTag fallback for unmatched titles"],
+  ])("routes %j → %s (%s)", (summary, expectedTag) => {
     const result = buildRawEventFromGCalItem(
-      { summary: "Boston Moom", start: { dateTime: "2026-03-20T19:00:00-04:00" }, status: "confirmed" },
+      { summary, start: { dateTime: "2026-04-15T19:00:00-04:00" }, status: "confirmed" },
       config,
     );
-    expect(result?.kennelTag).toBe("bos-moon");
-  });
-
-  it("routes 'Taco Marathon Pre-Pre-Pre-Prelube' to pink-taco (failure mode A)", () => {
-    const result = buildRawEventFromGCalItem(
-      { summary: "Taco Marathon Pre-Pre-Pre-Prelube", start: { dateTime: "2026-04-14T19:00:00-04:00" }, status: "confirmed" },
-      config,
-    );
-    expect(result?.kennelTag).toBe("pink-taco");
-  });
-
-  it("routes 'Moon Marathon Pre-Pre Lube' to bos-moon (failure mode A)", () => {
-    const result = buildRawEventFromGCalItem(
-      { summary: "Moon Marathon Pre-Pre Lube", start: { dateTime: "2026-04-16T19:00:00-04:00" }, status: "confirmed" },
-      config,
-    );
-    expect(result?.kennelTag).toBe("bos-moon");
-  });
-
-  it("routes 'Beantown #276' to beantown (failure mode B — no longer dropped)", () => {
-    const result = buildRawEventFromGCalItem(
-      { summary: "Beantown #276", start: { dateTime: "2026-04-01T19:00:00-04:00" }, status: "confirmed" },
-      config,
-    );
-    expect(result?.kennelTag).toBe("beantown");
-  });
-
-  it("routes a plain Boston H3 run to boh3", () => {
-    const result = buildRawEventFromGCalItem(
-      { summary: "BH3 #2781", start: { dateTime: "2026-03-22T14:00:00-04:00" }, status: "confirmed" },
-      config,
-    );
-    expect(result?.kennelTag).toBe("boh3");
-  });
-
-  it("falls back to boh3 for unmatched titles (socials, meetings)", () => {
-    const result = buildRawEventFromGCalItem(
-      { summary: "AGM Planning Meeting", start: { dateTime: "2026-05-01T19:00:00-04:00" }, status: "confirmed" },
-      config,
-    );
-    expect(result?.kennelTag).toBe("boh3");
+    expect(result?.kennelTag).toBe(expectedTag);
   });
 });
 

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -65,6 +65,76 @@ describe("extractKennelTag", () => {
   });
 });
 
+// ── Boston Hash Calendar multi-kennel routing via seed config (#789) ──
+//
+// The Boston source config lives in prisma/seed-data/sources.ts. These
+// patterns are mirrored here so a copy-paste drift between seed and test
+// gets caught. If you edit either side, update both. Order matters —
+// matchConfigPatterns returns the first hit (adapter.ts:506).
+
+const BOSTON_SEED_KENNEL_PATTERNS: [string, string][] = [
+  ["Boston Ball\\s*Buster|\\bBall\\s*Buster\\b|BoBBH3|B3H4|BBH3", "bobbh3"],
+  ["Beantown", "beantown"],
+  ["Pink Taco|PT2H3|\\bTaco\\b", "pink-taco"],
+  ["Boston Moo[mn]|Full Moon|\\bMoo[mn]\\b", "bos-moon"],
+  ["Boston H3|Boston Hash|BoH3|BH3", "boh3"],
+];
+
+describe("Boston Hash Calendar multi-kennel routing (#789)", () => {
+  const config = {
+    kennelPatterns: BOSTON_SEED_KENNEL_PATTERNS,
+    defaultKennelTag: "boh3",
+  };
+
+  it("routes 'Boston Moom' typo to bos-moon (failure mode A from the issue)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Boston Moom", start: { dateTime: "2026-03-20T19:00:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTag).toBe("bos-moon");
+  });
+
+  it("routes 'Taco Marathon Pre-Pre-Pre-Prelube' to pink-taco (failure mode A)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Taco Marathon Pre-Pre-Pre-Prelube", start: { dateTime: "2026-04-14T19:00:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTag).toBe("pink-taco");
+  });
+
+  it("routes 'Moon Marathon Pre-Pre Lube' to bos-moon (failure mode A)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Moon Marathon Pre-Pre Lube", start: { dateTime: "2026-04-16T19:00:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTag).toBe("bos-moon");
+  });
+
+  it("routes 'Beantown #276' to beantown (failure mode B — no longer dropped)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Beantown #276", start: { dateTime: "2026-04-01T19:00:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTag).toBe("beantown");
+  });
+
+  it("routes a plain Boston H3 run to boh3", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "BH3 #2781", start: { dateTime: "2026-03-22T14:00:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTag).toBe("boh3");
+  });
+
+  it("falls back to boh3 for unmatched titles (socials, meetings)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "AGM Planning Meeting", start: { dateTime: "2026-05-01T19:00:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTag).toBe("boh3");
+  });
+});
+
 // ── extractRunNumber ──
 
 describe("extractRunNumber", () => {


### PR DESCRIPTION
Two source-attribution bugs shared a root cause: records that legitimately
share a URL (config-driven REST APIs, shared calendars) were being
collapsed or cross-attributed because seed and adapter logic keyed off
the wrong identifier.

#817 — The 3 HARRIER_CENTRAL sources (Tokyo H3, Morgantown H3, Singapore
Sunday H3) share the base API URL https://harriercentralpublicapi.../;
prisma/seed.ts matched existing records by `(url, type)` first, so each
subsequent seed run UPDATED the prior row's name + config instead of
inserting a new one. Prod collapsed to a single row named "Singapore
Sunday H3 Harrier Central" with all 3 kennels linked to it. Narrow the
identity check to `(name, type)` only — url is still synced via the
existing scalar-field loop further down. Adds a seed-data invariant test
to guard against re-collapse.

#789 — The bostonhash@gmail.com Google Calendar feeds 5+ Boston-area
kennels (Boston H3, Boston Moon, Beantown, Pink Taco Trotters, Boston
Ball Buster), but pattern matching lived hardcoded in
google-calendar/adapter.ts and didn't cover observed title variants like
"Boston Moom" typo or "Taco Marathon" (no "Pink" prefix). Migrate those
patterns into source config (matching Philly, Chicago, BFM, Princeton,
etc.) and extend them to cover the failing cases. Adds adapter tests for
each failure mode from the issue body.

Also adds scripts/split-harrier-central-sources.ts — a dry-run-by-default
one-shot script that splits the collapsed prod HC row into 3 distinct
rows and re-parents SourceKennel links. Must be run manually against
prod before the next HC scrape cycle so Tokyo/Morgantown events attribute
correctly.

https://claude.ai/code/session_01V7m1qsjsrqvy5GhTXBkSjG