### PR TITLE
fix(db): enforce (name, type) as Source identity at the DB layer

### DIFF
--- a/prisma/migrations/20260420203030_source_name_type_unique/migration.sql
+++ b/prisma/migrations/20260420203030_source_name_type_unique/migration.sql
@@ -1,0 +1,6 @@
+-- Enforce (name, type) as Source identity at the DB layer.
+-- prisma/seed.ts::ensureSources already upserts by (name, type) in app code;
+-- this index makes the invariant impossible to violate via admin creation,
+-- manual SQL, or future seed edits that collide on (name, type).
+-- See #817 for the HARRIER_CENTRAL collapse that motivated this guard.
+CREATE UNIQUE INDEX "Source_name_type_key" ON "Source"("name", "type");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -205,6 +205,10 @@ model Source {
   eventLinks    EventLink[]
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
+
+  // (name, type) is the seed upsert identity — see prisma/seed.ts ensureSources
+  // and #817 for the HARRIER_CENTRAL collapse that motivated this constraint.
+  @@unique([name, type])
 }
 
 enum SourceType {

--- a/src/app/admin/research/actions.ts
+++ b/src/app/admin/research/actions.ts
@@ -12,6 +12,7 @@ import { analyzeUrlForProposal, refineAnalysis } from "@/pipeline/html-analysis"
 import { regionSlug, inferCountry, buildAbbrev } from "@/lib/region";
 import { clearResolverCache } from "@/pipeline/kennel-resolver";
 import { createKennelFromDiscovery } from "@/app/admin/shared/kennel-creation";
+import { nameTypeConflictError } from "@/app/admin/shared/source-errors";
 
 /**
  * Trigger research for a region.
@@ -270,15 +271,8 @@ export async function approveProposal(
     revalidatePath("/admin/sources");
     return { success: true, sourceId };
   } catch (err) {
-    if (
-      err instanceof Prisma.PrismaClientKnownRequestError &&
-      err.code === "P2002" &&
-      Array.isArray(err.meta?.target) &&
-      (err.meta.target as string[]).includes("name") &&
-      (err.meta.target as string[]).includes("type")
-    ) {
-      return { error: "A source with that name and type already exists." };
-    }
+    const msg = nameTypeConflictError(err);
+    if (msg) return { error: msg };
     return { error: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/app/admin/research/actions.ts
+++ b/src/app/admin/research/actions.ts
@@ -270,6 +270,15 @@ export async function approveProposal(
     revalidatePath("/admin/sources");
     return { success: true, sourceId };
   } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002" &&
+      Array.isArray(err.meta?.target) &&
+      (err.meta.target as string[]).includes("name") &&
+      (err.meta.target as string[]).includes("type")
+    ) {
+      return { error: "A source with that name and type already exists." };
+    }
     return { error: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/app/admin/shared/source-errors.ts
+++ b/src/app/admin/shared/source-errors.ts
@@ -1,0 +1,19 @@
+import { Prisma } from "@/generated/prisma/client";
+
+/**
+ * Friendly message when a Source write violates the `(name, type)` unique
+ * constraint. The DB enforces seed upsert identity — see prisma/schema.prisma
+ * Source and #817.
+ */
+export function nameTypeConflictError(err: unknown): string | null {
+  if (
+    err instanceof Prisma.PrismaClientKnownRequestError &&
+    err.code === "P2002" &&
+    Array.isArray(err.meta?.target) &&
+    (err.meta.target as string[]).includes("name") &&
+    (err.meta.target as string[]).includes("type")
+  ) {
+    return "A source with that name and type already exists.";
+  }
+  return null;
+}

--- a/src/app/admin/sources/actions.ts
+++ b/src/app/admin/sources/actions.ts
@@ -10,6 +10,23 @@ import { scrapeSource } from "@/pipeline/scrape";
 import { validateSourceConfig } from "./config-validation";
 import { buildKennelIdentifiers, createKennelRecord } from "@/lib/kennel-utils";
 
+/**
+ * Friendly message when a write violates the `(name, type)` unique constraint.
+ * The DB enforces seed upsert identity — see prisma/schema.prisma Source and #817.
+ */
+function nameTypeConflictError(err: unknown): string | null {
+  if (
+    err instanceof Prisma.PrismaClientKnownRequestError &&
+    err.code === "P2002" &&
+    Array.isArray(err.meta?.target) &&
+    (err.meta.target as string[]).includes("name") &&
+    (err.meta.target as string[]).includes("type")
+  ) {
+    return "A source with that name and type already exists.";
+  }
+  return null;
+}
+
 /** Parse and validate config JSON from form input. Returns the parsed value or an error. */
 function parseConfigJson(
   configRaw: string,
@@ -97,17 +114,24 @@ export async function createSource(formData: FormData) {
     }
   }
 
-  const source = await prisma.source.create({
-    data: {
-      name,
-      url,
-      type: type as SourceType,
-      trustLevel,
-      scrapeFreq,
-      scrapeDays: isNaN(scrapeDays) ? 90 : scrapeDays,
-      ...(config !== undefined ? { config } : {}),
-    },
-  });
+  let source;
+  try {
+    source = await prisma.source.create({
+      data: {
+        name,
+        url,
+        type: type as SourceType,
+        trustLevel,
+        scrapeFreq,
+        scrapeDays: isNaN(scrapeDays) ? 90 : scrapeDays,
+        ...(config !== undefined ? { config } : {}),
+      },
+    });
+  } catch (err) {
+    const msg = nameTypeConflictError(err);
+    if (msg) return { error: msg };
+    throw err;
+  }
 
   // Create SourceKennel links
   const ids = kennelIds.split(",").map(id => id.trim()).filter(Boolean);
@@ -142,24 +166,30 @@ export async function updateSource(sourceId: string, formData: FormData) {
 
   const ids = kennelIds.split(",").map(id => id.trim()).filter(Boolean);
 
-  await prisma.$transaction([
-    prisma.sourceKennel.deleteMany({ where: { sourceId } }),
-    prisma.source.update({
-      where: { id: sourceId },
-      data: {
-        name,
-        url,
-        type: type as SourceType,
-        trustLevel,
-        scrapeFreq,
-        scrapeDays: isNaN(scrapeDays) ? 90 : scrapeDays,
-        config,
-        kennels: {
-          create: ids.map((kennelId) => ({ kennelId })),
+  try {
+    await prisma.$transaction([
+      prisma.sourceKennel.deleteMany({ where: { sourceId } }),
+      prisma.source.update({
+        where: { id: sourceId },
+        data: {
+          name,
+          url,
+          type: type as SourceType,
+          trustLevel,
+          scrapeFreq,
+          scrapeDays: isNaN(scrapeDays) ? 90 : scrapeDays,
+          config,
+          kennels: {
+            create: ids.map((kennelId) => ({ kennelId })),
+          },
         },
-      },
-    }),
-  ]);
+      }),
+    ]);
+  } catch (err) {
+    const msg = nameTypeConflictError(err);
+    if (msg) return { error: msg };
+    throw err;
+  }
 
   revalidatePath("/admin/sources");
   return { success: true };

--- a/src/app/admin/sources/actions.ts
+++ b/src/app/admin/sources/actions.ts
@@ -9,23 +9,7 @@ import { resolveKennelTag, clearResolverCache } from "@/pipeline/kennel-resolver
 import { scrapeSource } from "@/pipeline/scrape";
 import { validateSourceConfig } from "./config-validation";
 import { buildKennelIdentifiers, createKennelRecord } from "@/lib/kennel-utils";
-
-/**
- * Friendly message when a write violates the `(name, type)` unique constraint.
- * The DB enforces seed upsert identity — see prisma/schema.prisma Source and #817.
- */
-function nameTypeConflictError(err: unknown): string | null {
-  if (
-    err instanceof Prisma.PrismaClientKnownRequestError &&
-    err.code === "P2002" &&
-    Array.isArray(err.meta?.target) &&
-    (err.meta.target as string[]).includes("name") &&
-    (err.meta.target as string[]).includes("type")
-  ) {
-    return "A source with that name and type already exists.";
-  }
-  return null;
-}
+import { nameTypeConflictError } from "@/app/admin/shared/source-errors";
 
 /** Parse and validate config JSON from form input. Returns the parsed value or an error. */
 function parseConfigJson(
@@ -114,31 +98,31 @@ export async function createSource(formData: FormData) {
     }
   }
 
-  let source;
+  const ids = kennelIds.split(",").map(id => id.trim()).filter(Boolean);
+
   try {
-    source = await prisma.source.create({
-      data: {
-        name,
-        url,
-        type: type as SourceType,
-        trustLevel,
-        scrapeFreq,
-        scrapeDays: isNaN(scrapeDays) ? 90 : scrapeDays,
-        ...(config !== undefined ? { config } : {}),
-      },
+    await prisma.$transaction(async (tx) => {
+      const source = await tx.source.create({
+        data: {
+          name,
+          url,
+          type: type as SourceType,
+          trustLevel,
+          scrapeFreq,
+          scrapeDays: isNaN(scrapeDays) ? 90 : scrapeDays,
+          ...(config !== undefined ? { config } : {}),
+        },
+      });
+      for (const kennelId of ids) {
+        await tx.sourceKennel.create({
+          data: { sourceId: source.id, kennelId },
+        });
+      }
     });
   } catch (err) {
     const msg = nameTypeConflictError(err);
     if (msg) return { error: msg };
     throw err;
-  }
-
-  // Create SourceKennel links
-  const ids = kennelIds.split(",").map(id => id.trim()).filter(Boolean);
-  for (const kennelId of ids) {
-    await prisma.sourceKennel.create({
-      data: { sourceId: source.id, kennelId },
-    });
   }
 
   revalidatePath("/admin/sources");


### PR DESCRIPTION
## Summary

Follow-up to #822. That PR fixed the [#817](https://github.com/johnrclem/hashtracks-web/issues/817) HARRIER_CENTRAL source collapse at the seed-upsert layer by keying on `(name, type)` instead of `(url, type)`. This PR closes the same gap at the DB layer so admin-created sources, manual SQL, or future seed edits can't silently reintroduce the duplicate.

- Add `@@unique([name, type])` on the `Source` model.
- Migration is a single `CREATE UNIQUE INDEX`; ran a prod audit before authoring and confirmed zero existing `(name, type)` duplicates on Railway.
- Translate `P2002` on the new constraint into a friendly validation message in the admin write paths (`createSource`, `updateSource`, `approveProposal`) so users see _"A source with that name and type already exists."_ instead of a raw Prisma exception.

## Why this + the seed fix

The seed-side fix in #822 is sufficient to prevent _seed_ runs from collapsing sources — but it leaves admin-created sources unprotected. If an admin inadvertently types an existing `(name, type)` pair, the DB will accept it today. With this index, the DB rejects it and the admin UI surfaces a clean error.

## Rollout risk

`migrate deploy` runs the `CREATE UNIQUE INDEX` in a transaction. If an admin creates a colliding source between the prod audit and the index build, the deploy transaction will fail cleanly and roll back. Risk window is seconds; if it triggers we retry after resolving the collision. `CONCURRENTLY` can't be used inside a migration transaction.

## Verification

- Prod `(name, type)` audit: 0 duplicates
- Local DB audit: 0 duplicates
- Migration applies on local DB + a fresh shadow DB (full `prisma/migrations/` replay)
- `npx tsc --noEmit` clean
- `npm run lint` — 0 errors (pre-existing warnings unchanged)
- `npm test` — 211 files, 4894 tests passing
- Codex adversarial review — 2 findings, both addressed (race window documented above; P2002 handling added to admin paths)

## Test plan

- [ ] CI green (type check + lint + tests)
- [ ] Preview deploy succeeds (Vercel runs `prisma migrate deploy`)
- [ ] Admin UX: create a source with a duplicate `(name, type)` — should show friendly error, not Prisma internals

🤖 Generated with [Claude Code](https://claude.com/claude-code)