### PR TITLE
fix(audit): CGH3 Hare. prefix + RIH3 title/location + BFMH3 hare boilerplate

### DIFF
--- a/src/adapters/html-scraper/chiangmai-hhh.test.ts
+++ b/src/adapters/html-scraper/chiangmai-hhh.test.ts
@@ -52,6 +52,16 @@ describe("parseChiangMaiLine", () => {
     expect(event!.hares).toBe("Emma Royde");
   });
 
+  it("strips CGH3 'Hare.' label prefix (#814)", () => {
+    const event = parseChiangMaiLine(
+      "Monday 20 April \u2013 CGH3 Run #256 \u2013 Hare. HRA",
+      "cgh3",
+      SOURCE_URL,
+    );
+    expect(event).not.toBeNull();
+    expect(event!.hares).toBe("HRA");
+  });
+
   it("parses CBH3 format: 'Sunday 26 April – CBH3 – Run # 281 – Misfortune and Bare Bum'", () => {
     const event = parseChiangMaiLine(
       "Sunday 26 April \u2013 CBH3 \u2013 Run # 281 \u2013 Misfortune and Bare Bum",

--- a/src/adapters/html-scraper/chiangmai-hhh.ts
+++ b/src/adapters/html-scraper/chiangmai-hhh.ts
@@ -70,10 +70,15 @@ export function parseChiangMaiLine(
   const runNumberRaw = Number.parseInt(runMatch[1], 10);
   const runNumber = Number.isNaN(runNumberRaw) ? undefined : runNumberRaw;
 
-  // Extract hare name: everything after the last " – " or after the run number
+  // Extract hare name: everything after the last " – " or after the run number.
+  // CGH3 pages prefix the name with a "Hare." label (e.g. "Hare. HRA") — strip
+  // it so only the name survives. #814.
   let hares: string | undefined;
   const afterRun = cleaned.slice(runMatch.index + runMatch[0].length);
-  const harePart = afterRun.replace(/^\s*[-–—]\s*/, "").trim();
+  const harePart = afterRun
+    .replace(/^\s*[-–—]\s*/, "")
+    .replace(/^Hares?\s*[.:]\s*/i, "")
+    .trim();
   if (harePart && !/^HARE NEEDED$/i.test(harePart) && !/^\?+$/.test(harePart)) {
     hares = normalizeHaresField(harePart);
   }

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -336,6 +336,37 @@ Basket says, "Check out the Receding Hareline..."
     expect(result?.description).toContain("Basket says");
   });
 
+  it("truncates long prose bleed from h2 to first segment (#816)", () => {
+    // Real-world: h2 has the run name followed by <br/> and a long sentence
+    // of prose. The joined text exceeds 80 chars, so we keep only the first
+    // segment ("The 420 Hash") as the title.
+    const dirHtml = `
+      <h2><strong>The 420 Hash<br/>It's been a while since Cracker Jackoff and Blue Job Lips Laid Flour for the RIH3</strong></h2>
+      <a href="https://www.google.com/maps/place/Quonset+Point">
+        <font>Park Here for a smokin' good time</font>
+      </a>
+    `;
+    const cells = ["Mon April 20", "6:30 PM", "2095"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.title).toBe("The 420 Hash");
+  });
+
+  it("rejects lowercase location phrases (#816)", () => {
+    // "Park Here for a smokin' good time" — "Park Here " prefix is stripped,
+    // leaving "for a smokin' good time" which starts lowercase and is not a
+    // real venue name.
+    const dirHtml = `
+      <h2>The 420 Hash</h2>
+      <a href="https://www.google.com/maps/place/Quonset+Point">
+        <font>Park Here for a smokin' good time</font>
+      </a>
+    `;
+    const cells = ["Mon April 20", "6:30 PM", "2095"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBeUndefined();
+    expect(result?.locationUrl).toContain("google.com/maps");
+  });
+
   it("resolves same-day date to current year, not next year (Bug #1)", () => {
     // Simulate scrape running at 2:30 PM on March 23, 2026
     const midDayRef = new Date(2026, 2, 23, 14, 30, 0);

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
 import { parseHarelineRow, extractHares, RIH3Adapter } from "./rih3";
 
@@ -155,6 +155,17 @@ describe("extractHares", () => {
 });
 
 describe("parseHarelineRow", () => {
+  // Pin system time so year-less dates like "Mon April 21" resolve to 2026
+  // regardless of when the test runs (chrono's forwardDate would otherwise
+  // push them to next year once "today" has passed them).
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 0, 15, 12)));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("parses standard event with all fields", () => {
     const cells = ["Mon April 21", "6:30 PM", "2043"];
     // Fixed reference date so year inference is deterministic regardless
@@ -432,6 +443,11 @@ describe("RIH3Adapter", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 0, 15, 12)));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("has correct type", () => {

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -367,6 +367,33 @@ Basket says, "Check out the Receding Hareline..."
     expect(result?.locationUrl).toContain("google.com/maps");
   });
 
+  it("preserves Title-Case venue names starting with 'On'/'In' (#824 review)", () => {
+    // PROSE_LEAD_RE must be case-sensitive so Title-Case venues survive.
+    const dirHtml = `
+      <h2>Pub Run</h2>
+      <a href="https://www.google.com/maps/place/On+Tap+Sports+Bar">
+        <font>On Tap Sports Bar</font>
+      </a>
+    `;
+    const cells = ["Mon April 20", "6:30 PM", "2096"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBe("On Tap Sports Bar");
+  });
+
+  it("normalizes source newlines inside <h2> so formatting wraps don't fake segments (#824 review)", () => {
+    // Source HTML has an actual CRLF inside the <h2> between tags — without
+    // normalization, stripHtmlTags would treat it as a segment boundary and
+    // truncate to "The 420".
+    const dirHtml = `
+      <h2><strong>The 420
+Hash</strong></h2>
+      <a href="https://www.google.com/maps/place/Quonset+Point">Quonset Point</a>
+    `;
+    const cells = ["Mon April 20", "6:30 PM", "2097"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.title).toBe("The 420 Hash");
+  });
+
   it("resolves same-day date to current year, not next year (Bug #1)", () => {
     // Simulate scrape running at 2:30 PM on March 23, 2026
     const midDayRef = new Date(2026, 2, 23, 14, 30, 0);

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -31,9 +31,11 @@ import {
 
 const DAY_PREFIX_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\.?\s+/i;
 
-/** Reject a locationText that starts with a preposition/conjunction — those
- *  are sentence fragments bleeding through the strip cascade, not venues. #816. */
-const PROSE_LEAD_RE = /^(?:for|in|on|to|with|and|but|so|of|it['’]s|we['’]?re)\b/i;
+/** Reject a locationText that starts with a lowercase preposition/conjunction —
+ *  those are sentence fragments bleeding through the strip cascade, not venues.
+ *  Case-sensitive to preserve Title-Case venues like "On Tap Sports Bar" or
+ *  "In-N-Out Burger". #816. */
+const PROSE_LEAD_RE = /^(?:for|in|on|to|at|with|from|near|and|but|so|of|it['’]s|we['’]?re)\b/;
 
 /** Max h2 length before we assume prose has bled into the title and keep
  *  only the first <br>-delimited segment. Motivated by rih3 #2095. #816. */
@@ -124,7 +126,9 @@ export function parseHarelineRow(
   // Title from <h2>. If h2 has multiple <br>-separated segments and the full
   // joined text runs long (prose bleed from unstructured authoring), fall back
   // to the first segment only. #816.
-  const h2Html = dir$("h2").first().html() ?? "";
+  // Normalize raw CRLF/LF in the HTML source to spaces so formatting line
+  // wraps don't get mistaken for <br>-delimited segments. CodeRabbit PR #824.
+  const h2Html = (dir$("h2").first().html() ?? "").replace(/\r?\n/g, " ");
   const h2Segments = stripHtmlTags(h2Html, "\n")
     .split("\n")
     .map((s) => s.trim())

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -26,9 +26,18 @@ import {
   chronoParseDate,
   parse12HourTime,
   isPlaceholder,
+  stripHtmlTags,
 } from "../utils";
 
 const DAY_PREFIX_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\.?\s+/i;
+
+/** Reject a locationText that starts with a preposition/conjunction — those
+ *  are sentence fragments bleeding through the strip cascade, not venues. #816. */
+const PROSE_LEAD_RE = /^(?:for|in|on|to|with|and|but|so|of|it['’]s|we['’]?re)\b/i;
+
+/** Max h2 length before we assume prose has bled into the title and keep
+ *  only the first <br>-delimited segment. Motivated by rih3 #2095. #816. */
+const MAX_H2_TITLE_LEN = 80;
 
 /** Days to backdate the chrono reference so `forwardDate: true` doesn't push
  *  recent year-less dates (e.g., "March 23") into the next year when scraping
@@ -112,13 +121,19 @@ export function parseHarelineRow(
   // --- Directions cell: title, location, description ---
   const dir$ = cheerio.load(directionHtml);
 
-  // Title from <h2>
-  dir$("h2").find("br").replaceWith(" ");
-  const h2Text = dir$("h2")
-    .first()
-    .text()
-    .trim()
-    .replace(/\s+/g, " ");
+  // Title from <h2>. If h2 has multiple <br>-separated segments and the full
+  // joined text runs long (prose bleed from unstructured authoring), fall back
+  // to the first segment only. #816.
+  const h2Html = dir$("h2").first().html() ?? "";
+  const h2Segments = stripHtmlTags(h2Html, "\n")
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const h2Joined = h2Segments.join(" ");
+  const h2Text =
+    h2Joined.length > MAX_H2_TITLE_LEN && h2Segments[0]
+      ? h2Segments[0]
+      : h2Joined;
   const title =
     h2Text ||
     (runNumber ? `RIH3 #${runNumber}` : "RIH3 Monday Trail");
@@ -139,7 +154,9 @@ export function parseHarelineRow(
       .trim()
     : undefined;
   const location =
-    locationText && locationText.length > 3 ? locationText : undefined;
+    locationText && locationText.length > 3 && !PROSE_LEAD_RE.test(locationText)
+      ? locationText
+      : undefined;
 
   // Description: body text minus title and song links; preserve Facebook link
   const descRoot = dir$("body").clone();

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1227,6 +1227,15 @@ describe("sanitizeHares", () => {
     expect(sanitizeHares("Captain Hash On-On: The Pub")).toBe("Captain Hash");
   });
 
+  it("returns null when the whole value is boilerplate (#819)", () => {
+    // Stale "On On Q" canonical value was surviving because the old impl only
+    // truncated when the marker was mid-string (idx > 0), leaving idx===0 as
+    // a pass-through. See bangkokhash hare-boilerplate-leak audit.
+    expect(sanitizeHares("On On Q")).toBeNull();
+    expect(sanitizeHares("On-On The Pub")).toBeNull();
+    expect(sanitizeHares("On On: 6:30 at The Pub")).toBeNull();
+  });
+
   // Fix 2: URL rejection
   it("rejects bare URL as hare value", () => {
     expect(sanitizeHares("https://maps.app.goo.gl/cqc9yN889CTN23vLA")).toBeNull();

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -82,10 +82,14 @@ export function sanitizeHares(hares: string | undefined | null): string | null {
   // Truncate at trailing logistics clauses (e.g., ", we are still taking applications...")
   h = h.replace(/,\s*(?:and we |we |still |also |please |but )\b.*/i, "").trim();
 
-  // Truncate at boilerplate markers (description text leaked into hares)
+  // Truncate at boilerplate markers (description text leaked into hares).
+  // If the whole value matches (idx === 0), drop it entirely — e.g. "On On Q"
+  // #819 — rather than storing an empty string that would pass through merge.
   const boilerplateIdx = h.search(HARE_BOILERPLATE_RE);
+  if (boilerplateIdx === 0) return null;
   if (boilerplateIdx > 0) {
     h = h.slice(0, boilerplateIdx).trim();
+    if (!h) return null;
   }
 
   // Cap at 200 chars with smart truncation at last delimiter


### PR DESCRIPTION
## Summary

Three audit-triggered fixes to canonical event extraction:

- **#814 CGH3 Chiang Mai** — strip the "Hare." label prefix from the hare name in `parseChiangMaiLine` (Chiang Mai CGH3 hareline page format: `"Monday 20 April – CGH3 Run #256 – Hare. HRA"`).
- **#816 Rhode Island H3** — two bugs on run #2095:
  - **Title** was prose-bled ("The 420 Hash It's been a while since…"). Split h2 on `<br>` via shared `stripHtmlTags` util; keep only the first segment when joined length exceeds 80 chars.
  - **locationName** was "for a smokin' good time" because the strip cascade consumed "Park Here " off "Park Here for a smokin' good time". Reject locationText starting with a preposition/conjunction via new `PROSE_LEAD_RE` guard.
- **#819 BFMH3 hare boilerplate** — stale `haresText` like "On On Q" (whole string = boilerplate) survived `sanitizeHares` because it only truncated mid-string. Return `null` when `boilerplateIdx === 0` or post-slice value is empty — this lets `scripts/backfill-audit-fixes.ts` retroactively clear stale canonical values on re-merge.

Stale-only audit issues #815/#818/#820 already have adapter fixes in place (google-calendar adapter trailing-dash strip + `LOCATION_EMAIL_CTA_RE` + `PHONE_TRAILING_RE`) — they only need the backfill script run against prod.

## Live verification

- `rih3.com/hareline.html` — run #2095 now extracts `title="The 420 Hash"`, `location=undefined`. 8 upcoming events parse cleanly, no errors.
- `chiangmaihhh.com/cgh3-hareline/` — run #256 now extracts `hares="HRA"` (was `"Hare. HRA"`).

## Test plan

- [x] New unit tests cover all three fixes (5 new assertions)
- [x] Existing RIH3 tests still pass — location still extracts "dog park" / "dog park at Melville Park, Portsmouth, RI" for the legit cases
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 4898 passed
- [x] Live verified against production URLs
- [ ] **After merge:** run `scripts/backfill-audit-fixes.ts` against prod to clear stale #815/#818/#819/#820 canonical values

Closes #814, #816, #819. Enables backfill-only cleanup of #815, #818, #820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)