### PR TITLE
fix(reconcile): skip past-side for upcoming-only sources (GH #849)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3496,6 +3496,9 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 180,
+      config: {
+        upcomingOnly: true,
+      },
       kennelCodes: ["sh3-au"],
     },
     {

--- a/scripts/restore-reconcile-false-cancellations.ts
+++ b/scripts/restore-reconcile-false-cancellations.ts
@@ -1,0 +1,133 @@
+/**
+ * One-shot restoration for events falsely cancelled by `reconcileStaleEvents`
+ * on upcoming-only sources (GH #849).
+ *
+ * Before the reconcile upcoming-only fix, sources that only publish future runs
+ * (e.g. sh3.link) saw every past run drop off the page and get flipped to
+ * CANCELLED by reconcile. This script flips vetted rows back to CONFIRMED.
+ *
+ * Two-phase workflow (intentional — per review feedback, we never bulk-update
+ * the full dry-run cohort without an operator reviewing each row first):
+ *
+ *   1. Dry run — enumerate candidate CANCELLED events that still have RawEvents
+ *      from the supplied sources. Human reviews the list.
+ *   2. Apply — re-run with `EVENT_IDS=<csv>` AND `RESTORE_APPLY=1`. Only the
+ *      explicit ids are flipped, and only after we re-verify each is still
+ *      CANCELLED and still in the candidate cohort.
+ *
+ * Usage:
+ *   # default: Sydney H3, dry run
+ *   npx tsx scripts/restore-reconcile-false-cancellations.ts
+ *
+ *   # apply, restricted to reviewed ids
+ *   EVENT_IDS=evt_abc,evt_def RESTORE_APPLY=1 \
+ *     npx tsx scripts/restore-reconcile-false-cancellations.ts
+ *
+ *   # other upcoming-only sources
+ *   SOURCE_IDS=cmn...,cmx... npx tsx scripts/restore-reconcile-false-cancellations.ts
+ */
+
+import "dotenv/config";
+import { EventStatus, PrismaClient } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { createScriptPool } from "./lib/db-pool";
+
+const DEFAULT_SOURCE_IDS = ["cmnt77pfl001mjjhn5zmwl9v8"]; // Sydney H3
+const LOOKBACK_DAYS = 365;
+
+async function main() {
+  const apply = process.env.RESTORE_APPLY === "1";
+  const sourceIds = (process.env.SOURCE_IDS ?? DEFAULT_SOURCE_IDS.join(","))
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const reviewedIds = (process.env.EVENT_IDS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  console.log(`Mode: ${apply ? "APPLY (will update DB)" : "DRY RUN (no writes)"}`);
+  console.log(`Source IDs: ${sourceIds.join(", ")}`);
+  if (reviewedIds.length > 0) {
+    console.log(`Reviewed EVENT_IDS: ${reviewedIds.join(", ")}`);
+  }
+
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+  try {
+    const now = new Date();
+    const lookbackFloor = new Date(now.getTime() - LOOKBACK_DAYS * 86_400_000);
+
+    const events = await prisma.event.findMany({
+      where: {
+        status: EventStatus.CANCELLED,
+        date: { gte: lookbackFloor, lt: now },
+        rawEvents: { some: { sourceId: { in: sourceIds } } },
+      },
+      select: {
+        id: true,
+        date: true,
+        kennel: { select: { shortName: true, kennelCode: true } },
+      },
+      orderBy: { date: "asc" },
+    });
+
+    console.log(`\nFound ${events.length} past CANCELLED events with RawEvents from these sources:\n`);
+    for (const ev of events) {
+      const dateStr = ev.date.toISOString().split("T")[0];
+      console.log(`  ${dateStr}  ${ev.kennel.kennelCode.padEnd(20)} (${ev.kennel.shortName})  [${ev.id}]`);
+    }
+
+    if (!apply) {
+      console.log(
+        "\nDry run complete. To restore, re-run with RESTORE_APPLY=1 and " +
+          "EVENT_IDS=<csv of ids from the list above>.\n" +
+          "\n⚠️  WARNING: this cohort includes ANY past CANCELLED event that still has a\n" +
+          "    RawEvent from the selected source(s). A row in this list could have been\n" +
+          "    legitimately cancelled (hare called it off) and still appear here, since\n" +
+          "    upcoming-only sources drop runs the same way whether they happen or get\n" +
+          "    cancelled. Cross-check each id against the GH issue, attendance records,\n" +
+          "    or kennel communications before including it in EVENT_IDS.",
+      );
+      return;
+    }
+
+    if (reviewedIds.length === 0) {
+      console.error(
+        "\nRefusing to apply without EVENT_IDS. Provide a reviewed subset of ids " +
+          "(e.g. EVENT_IDS=evt_abc,evt_def) so we don't bulk-update the full cohort.",
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const candidateIds = new Set(events.map((e) => e.id));
+    const toRestore = reviewedIds.filter((id) => candidateIds.has(id));
+    const skipped = reviewedIds.filter((id) => !candidateIds.has(id));
+    if (skipped.length > 0) {
+      console.warn(
+        `\nSkipping ${skipped.length} id(s) not in current candidate cohort ` +
+          `(already restored, outside lookback, or no RawEvent from these sources): ${skipped.join(", ")}`,
+      );
+    }
+
+    if (toRestore.length === 0) {
+      console.log("Nothing to restore after filtering. Exiting.");
+      return;
+    }
+
+    const updated = await prisma.event.updateMany({
+      where: { id: { in: toRestore }, status: EventStatus.CANCELLED },
+      data: { status: EventStatus.CONFIRMED },
+    });
+    console.log(`\nDone. Restored ${updated.count} Event(s) to CONFIRMED.`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/pipeline/reconcile.test.ts
+++ b/src/pipeline/reconcile.test.ts
@@ -367,6 +367,44 @@ describe("reconcileStaleEvents", () => {
     expect(result.totalLinkedKennels).toBe(2);
   });
 
+  it("preserves the days-wide past window by default", async () => {
+    vi.useFakeTimers();
+    try {
+      const now = new Date("2026-04-21T12:00:00Z");
+      vi.setSystemTime(now);
+      mockEventFindMany.mockResolvedValueOnce([] as never);
+
+      await reconcileStaleEvents("src_1", [buildRawEvent()], 90);
+
+      const call = mockEventFindMany.mock.calls[0][0] as {
+        where: { date: { gte: Date; lte: Date } };
+      };
+      expect(call.where.date.gte).toEqual(new Date(now.getTime() - 90 * 86_400_000));
+      expect(call.where.date.lte).toEqual(new Date(now.getTime() + 90 * 86_400_000));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restricts the past side to now when upcomingOnly is true", async () => {
+    vi.useFakeTimers();
+    try {
+      const now = new Date("2026-04-21T12:00:00Z");
+      vi.setSystemTime(now);
+      mockEventFindMany.mockResolvedValueOnce([] as never);
+
+      await reconcileStaleEvents("src_1", [buildRawEvent()], 90, undefined, true);
+
+      const call = mockEventFindMany.mock.calls[0][0] as {
+        where: { date: { gte: Date; lte: Date } };
+      };
+      expect(call.where.date.gte).toEqual(now);
+      expect(call.where.date.lte).toEqual(new Date(now.getTime() + 90 * 86_400_000));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("returns empty result when scrapedKennelIds has no overlap with linked kennels", async () => {
     mockSourceKennelFind.mockResolvedValueOnce([
       { kennelId: "kennel_1" },

--- a/src/pipeline/reconcile.ts
+++ b/src/pipeline/reconcile.ts
@@ -34,6 +34,7 @@ export async function reconcileStaleEvents(
   scrapedEvents: RawEventData[],
   days: number,
   scrapedKennelIds?: string[],
+  upcomingOnly?: boolean,
 ): Promise<ReconcileResult> {
   const emptyResult: ReconcileResult = {
     cancelled: 0, cancelledEventIds: [],
@@ -80,9 +81,13 @@ export async function reconcileStaleEvents(
     return { ...emptyResult, totalLinkedKennels: allLinkedKennelIds.length };
   }
 
-  // Compute the scrape time window (same as adapter)
+  // Upcoming-only sources (e.g. sh3.link) drop runs the moment they happen —
+  // a past-dated event missing from a scrape is not a cancellation signal, so
+  // restrict the reconcile window to future dates for those sources.
   const now = new Date();
-  const timeMin = new Date(now.getTime() - days * 86_400_000);
+  const timeMin = upcomingOnly
+    ? now
+    : new Date(now.getTime() - days * 86_400_000);
   const timeMax = new Date(now.getTime() + days * 86_400_000);
 
   // Find CONFIRMED events in the window for this source's kennels

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -421,7 +421,15 @@ export async function scrapeSource(
       kennelPageErrors === 0 &&
       !kennelPagesIncomplete
     ) {
-      const reconciled = await reconcileStaleEvents(sourceId, scrapeResult.events, days, scrapedKennelIds);
+      const upcomingOnly =
+        (source.config as Record<string, unknown> | null)?.upcomingOnly === true;
+      const reconciled = await reconcileStaleEvents(
+        sourceId,
+        scrapeResult.events,
+        days,
+        scrapedKennelIds,
+        upcomingOnly,
+      );
       const { cancelledEventIds: _, ...reconDiag } = reconciled;
       cancelledCount = reconciled.cancelled;
       reconcileContext = reconDiag;


### PR DESCRIPTION
## Summary

- Adds an `upcomingOnly` flag in `Source.config`; when set, `reconcileStaleEvents` restricts its candidate window to `[now, now+days]` so absence of a past event is not treated as a cancellation signal
- Flips Sydney H3 (`sh3-au`) to `upcomingOnly: true` — the motivating source from GH #849, active weekly kennel (founded 1967, Latest Run #3,072) whose past runs were being silently cancelled
- Adds a one-shot restoration script (`scripts/restore-reconcile-false-cancellations.ts`) to fix the backlog of falsely cancelled Events

## Why this shape

Codex's first pass flagged that a global 24h past-grace changes semantics for all 184 sources. A per-source flag is the right scope: upcoming-only sources are a distinct adapter class (sh3.link, Hockessin, Burlington, WCFH, etc.), and other source types (Google Calendar, iCal, Meetup) are unaffected.

The restoration script is deliberately two-phase: dry-run lists the candidate cohort, apply requires an explicit `EVENT_IDS=<csv>` env var after operator review. The cohort can include legitimately cancelled runs — upcoming-only sources drop past runs and cancelled runs the same way — so the script surfaces an operator warning and never bulk-updates the full dry-run list.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint` (no new warnings)
- [x] `npm test` — 4918 passed, 2 skipped, 22 todo
- [x] New tests in `src/pipeline/reconcile.test.ts`:
  - `preserves the days-wide past window by default` — asserts existing behavior is unchanged when `upcomingOnly` is not set
  - `restricts the past side to now when upcomingOnly is true` — asserts `date.gte === now` for the Prisma query
- [ ] Post-merge: run `scripts/restore-reconcile-false-cancellations.ts` in dry-run against prod, review cohort, apply reviewed subset
- [ ] Post-merge: trigger a Sydney H3 scrape from admin and verify `cancelled: 0` in `SourceScrapeLog`

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)