### PR TITLE
fix(seed): flag 9 upcoming-only HTML_SCRAPER sources (GH #849 sweep)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -399,7 +399,7 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 90,
-      config: {},
+      config: { upcomingOnly: true },
       kennelCodes: ["norfolkh3"],
     },
     // ===== UK — LIVERPOOL =====

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -298,6 +298,7 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 90,
+      config: { upcomingOnly: true },
       kennelCodes: ["wlh3"],
     },
     {
@@ -307,6 +308,7 @@ export const SOURCES = [
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,
+      config: { upcomingOnly: true },
       kennelCodes: ["lh3"],
     },
     {
@@ -325,6 +327,7 @@ export const SOURCES = [
       trustLevel: 6,
       scrapeFreq: "daily",
       scrapeDays: 90,
+      config: { upcomingOnly: true },
       kennelCodes: ["och3"],
     },
     {
@@ -374,6 +377,7 @@ export const SOURCES = [
         },
         defaultKennelTag: "glasgowh3",
         dateLocale: "en-GB",
+        upcomingOnly: true,
       },
       kennelCodes: ["glasgowh3"],
     },
@@ -384,7 +388,7 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 90,
-      config: {},
+      config: { upcomingOnly: true },
       kennelCodes: ["edinburghh3"],
     },
     // ===== UK — NORFOLK =====
@@ -776,7 +780,7 @@ export const SOURCES = [
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 180,
-      config: { defaultKennelTag: "ih3" },
+      config: { defaultKennelTag: "ih3", upcomingOnly: true },
       kennelCodes: ["ih3"],
     },
     // --- Buffalo (Google Calendar) ---
@@ -882,7 +886,7 @@ export const SOURCES = [
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,
-      config: { defaultKennelTag: "hockessin" },
+      config: { defaultKennelTag: "hockessin", upcomingOnly: true },
       kennelCodes: ["hockessin"],
     },
     // ===== VIRGINIA (outside DC metro) =====
@@ -1085,7 +1089,7 @@ export const SOURCES = [
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 180,
-      config: { defaultKennelTag: "cfh3" },
+      config: { defaultKennelTag: "cfh3", upcomingOnly: true },
       kennelCodes: ["cfh3"],
     },
     // --- Fayetteville (Meetup) ---
@@ -1665,6 +1669,7 @@ export const SOURCES = [
       trustLevel: 6,
       scrapeFreq: "daily",
       scrapeDays: 365,
+      config: { upcomingOnly: true },
       kennelCodes: ["burlyh3"],
     },
     // ===== RHODE ISLAND =====


### PR DESCRIPTION
## Summary

Propagates the `upcomingOnly: true` source-config flag shipped in [#855](https://github.com/johnrclem/hashtracks-web/pull/855) (Sydney H3) to the other HTML_SCRAPER sources whose adapters never fetch a past/previous/history URL. Without the flag, `reconcileStaleEvents` sees past-dated runs drop off the upcoming page and flips them to CANCELLED, producing weekly `EXCESSIVE_CANCELLATIONS` alerts and wiping past-run lists from kennel pages.

**Flagged (9):** Hockessin, Burlington, Cape Fear, London Hash, West London, OCH3, Edinburgh, Glasgow, IH3.

**Deliberately not flagged:** Bull Moon (`recedingHarelineUrl` fetched), Amsterdam (`previousUrl` fetched), Big Hump (`includeHistory: true`), Mersey Thirstdays (`pastRunsUrl` fetched).

I verified each flagged adapter has no `/past`, `/previous`, `/history`, or `/archive` fetch path.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint` (no new warnings)
- [x] `npm test` (4918 pass, 2 skip, 22 todo)
- [ ] After merge: run `npx prisma db seed` against prod to push the new config
- [ ] After config is live, restore 41 falsely-cancelled past events via `scripts/restore-reconcile-false-cancellations.ts` (IDs already enumerated, pending operator go-ahead)
- [ ] Watch next scrape log for each source — `cancelled: 0` expected despite past runs missing from the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)