### PR TITLE
feat(travel): Phase 6 PR 3b — multi-destination results views

### DIFF
--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -223,6 +223,16 @@ async function TravelResultsServer({
     const serializedResults = {
       emptyState: results.emptyState,
       meta: results.meta,
+      // Per-stop metadata. Dates toISOString so the RSC boundary
+      // serializes cleanly.
+      destinations: results.destinations.map((d) => ({
+        index: d.index,
+        label: d.label,
+        startDate: d.startDate.toISOString(),
+        endDate: d.endDate.toISOString(),
+        radiusKm: d.radiusKm,
+        broaderRadiusKm: d.broaderRadiusKm,
+      })),
       confirmed: results.confirmed.map((r) => ({
         ...r,
         date: r.date.toISOString(),
@@ -331,7 +341,11 @@ async function TravelResultsServer({
             broaderRadiusKm={stop?.broaderRadiusKm}
           />
           {resultsToRender && (
-            <TravelResults destination={destination} results={resultsToRender} />
+            <TravelResults
+              destination={destination}
+              results={resultsToRender}
+              destinations={serializedResults.destinations}
+            />
           )}
         </>
       );
@@ -340,7 +354,11 @@ async function TravelResultsServer({
     return (
       <>
         {tripHeader}
-        <TravelResults destination={destination} results={serializedResults} />
+        <TravelResults
+          destination={destination}
+          results={serializedResults}
+          destinations={serializedResults.destinations}
+        />
       </>
     );
   } catch (err) {

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -210,9 +210,24 @@ async function TravelResultsServer({
         })
       : null;
 
+    const isMultiStop = results.destinations.length > 1;
+
+    // Multi-stop: every stop's broader pass rows need to reach the
+    // attendance map + serialized arrays. Single-stop's broader is
+    // already captured via `broaderResults` (== destinations[0].broaderResults).
+    const allBroaderConfirmed = isMultiStop
+      ? results.destinations.flatMap((d) => d.broaderResults?.confirmed ?? [])
+      : (broaderResults?.confirmed ?? []);
+    const allBroaderLikely = isMultiStop
+      ? results.destinations.flatMap((d) => d.broaderResults?.likely ?? [])
+      : (broaderResults?.likely ?? []);
+    const allBroaderPossible = isMultiStop
+      ? results.destinations.flatMap((d) => d.broaderResults?.possible ?? [])
+      : (broaderResults?.possible ?? []);
+
     const confirmedEventIds = [
       ...results.confirmed,
-      ...(broaderResults?.confirmed ?? []),
+      ...allBroaderConfirmed,
     ].map((r) => r.eventId);
 
     const attendanceMap = await loadAttendanceMap(user, confirmedEventIds);
@@ -233,16 +248,22 @@ async function TravelResultsServer({
         radiusKm: d.radiusKm,
         broaderRadiusKm: d.broaderRadiusKm,
       })),
-      confirmed: results.confirmed.map((r) => ({
+      // Multi-stop: merge every stop's broader rows into the top-level
+      // flat arrays so the multi-destination renderer (which iterates
+      // the flat set tagged by destinationIndex) sees both primary and
+      // broader results across ALL stops. Single-stop keeps today's
+      // behavior — broader rows flow through `broaderResults` below and
+      // `selectResultsToRender` swaps them in on `no_nearby`.
+      confirmed: [...results.confirmed, ...(isMultiStop ? allBroaderConfirmed : [])].map((r) => ({
         ...r,
         date: r.date.toISOString(),
         attendance: attendanceMap[r.eventId] ?? null,
       })),
-      likely: results.likely.map((r) => ({
+      likely: [...results.likely, ...(isMultiStop ? allBroaderLikely : [])].map((r) => ({
         ...r,
         date: r.date.toISOString(),
       })),
-      possible: results.possible.map((r) => ({
+      possible: [...results.possible, ...(isMultiStop ? allBroaderPossible : [])].map((r) => ({
         ...r,
         date: r.date?.toISOString() ?? null,
         lastConfirmedAt: r.lastConfirmedAt?.toISOString() ?? null,
@@ -331,7 +352,12 @@ async function TravelResultsServer({
     );
 
     if (results.emptyState !== "none") {
-      const resultsToRender = selectResultsToRender(results.emptyState, serializedResults);
+      // Multi-stop: skip the broader-swap since top-level arrays already
+      // contain merged primary + all-stops-broader (see serialization above).
+      // Single-stop: swap broader arrays in place on `no_nearby`.
+      const resultsToRender = isMultiStop
+        ? serializedResults
+        : selectResultsToRender(results.emptyState, serializedResults);
 
       return (
         <>

--- a/src/components/travel/TravelResults.tsx
+++ b/src/components/travel/TravelResults.tsx
@@ -14,7 +14,11 @@ import {
   type DistanceTier,
 } from "@/lib/travel/filters";
 import { formatDayHeader, cityToIata } from "@/lib/travel/format";
-import type { MultiDestView } from "@/lib/travel/multi-destination";
+import {
+  bucketDays,
+  bucketStops,
+  type MultiDestView,
+} from "@/lib/travel/multi-destination";
 import { ConfirmedCard } from "./ConfirmedCard";
 import { LikelyCard } from "./LikelyCard";
 import { PossibleSection } from "./PossibleSection";
@@ -187,11 +191,11 @@ export function TravelResults({
     [confirmed, likely, possible, selectedDays],
   );
 
-  // Day-filtered rows shared by both multi-destination views. Computed
-  // once per change of the underlying arrays or the DOW filter so the
-  // view toggle itself doesn't re-filter. Only meaningful when
-  // `isMultiStop`; cheap to compute regardless (the flat arrays usually
-  // fit the page's confirmed-event cap of 500).
+  // Day-filtered rows shared by both multi-destination views. Multi-stop
+  // views always include possibles (unlike the single-stop distance-tier
+  // layout, which tucks them into a collapsed PossibleSection below). The
+  // includePossible toggle is a single-stop-only affordance; multi-stop
+  // shows per-stop "No trails on this leg" placeholders instead.
   const filteredForMultiStop = useMemo(() => {
     if (!isMultiStop) return null;
     return {
@@ -201,13 +205,11 @@ export function TravelResults({
       likely: likely.filter((r) =>
         passesDayFilter(getDayCode(r.date), selectedDays),
       ),
-      possible: includePossible
-        ? possible.filter((r) =>
-            passesDayFilter(r.date ? getDayCode(r.date) : null, selectedDays),
-          )
-        : [],
+      possible: possible.filter((r) =>
+        passesDayFilter(r.date ? getDayCode(r.date) : null, selectedDays),
+      ),
     };
-  }, [isMultiStop, confirmed, likely, possible, includePossible, selectedDays]);
+  }, [isMultiStop, confirmed, likely, possible, selectedDays]);
 
   const renderedTiers = TIERS.map((tier) => ({
     tier,
@@ -291,10 +293,10 @@ export function TravelResults({
       {isMultiStop && filteredForMultiStop && viewMode === "day-by-day" && (
         <MultiDestDayView rows={filteredForMultiStop} />
       )}
-      {isMultiStop && filteredForMultiStop && viewMode === "by-destination" && (
+      {isMultiStop && filteredForMultiStop && viewMode === "by-destination" && destinations && (
         <MultiDestDestinationView
           rows={filteredForMultiStop}
-          destinations={destinations ?? []}
+          destinations={destinations}
         />
       )}
 
@@ -428,56 +430,6 @@ interface MultiDestRows {
   possible: SerializedPossible[];
 }
 
-interface DayStopBand {
-  label: string | null;
-  confirmed: SerializedConfirmed[];
-  likely: SerializedLikely[];
-  possible: SerializedPossible[];
-}
-
-interface DayBucket {
-  dateKey: string | null;
-  bandsByStop: Map<number, DayStopBand>;
-}
-
-/** Build per-day Map<stopIndex, bands> in one pass over each row kind.
- *  O(rows) instead of per-day per-stop triple `.find()` lookups. */
-function bucketDays(rows: MultiDestRows): DayBucket[] {
-  const byDay = new Map<string | null, Map<number, DayStopBand>>();
-  const touch = (dateKey: string | null, stop: number, label: string | null) => {
-    let forDay = byDay.get(dateKey);
-    if (!forDay) {
-      forDay = new Map();
-      byDay.set(dateKey, forDay);
-    }
-    let band = forDay.get(stop);
-    if (!band) {
-      band = { label, confirmed: [], likely: [], possible: [] };
-      forDay.set(stop, band);
-    } else if (band.label === null && label !== null) {
-      band.label = label;
-    }
-    return band;
-  };
-  for (const r of rows.confirmed) {
-    touch(r.date.slice(0, 10), r.destinationIndex, r.destinationLabel).confirmed.push(r);
-  }
-  for (const r of rows.likely) {
-    touch(r.date.slice(0, 10), r.destinationIndex, r.destinationLabel).likely.push(r);
-  }
-  for (const r of rows.possible) {
-    const key = r.date ? r.date.slice(0, 10) : null;
-    touch(key, r.destinationIndex, r.destinationLabel).possible.push(r);
-  }
-  return [...byDay.entries()]
-    .map(([dateKey, bandsByStop]) => ({ dateKey, bandsByStop }))
-    .sort((a, b) => {
-      if (a.dateKey === null) return 1;
-      if (b.dateKey === null) return -1;
-      return a.dateKey.localeCompare(b.dateKey);
-    });
-}
-
 /**
  * Day-by-day layout with LEG sub-bands on overlap days. Days sort
  * chronologically; overlap days (2+ legs share a date) split by
@@ -531,29 +483,6 @@ function MultiDestDayView({ rows }: { rows: MultiDestRows }) {
       })}
     </div>
   );
-}
-
-interface StopBucket {
-  confirmed: SerializedConfirmed[];
-  likely: SerializedLikely[];
-  possible: SerializedPossible[];
-}
-
-/** Partition rows into a Map keyed by destinationIndex in one pass. */
-function bucketStops(rows: MultiDestRows): Map<number, StopBucket> {
-  const byStop = new Map<number, StopBucket>();
-  const touch = (idx: number): StopBucket => {
-    let b = byStop.get(idx);
-    if (!b) {
-      b = { confirmed: [], likely: [], possible: [] };
-      byStop.set(idx, b);
-    }
-    return b;
-  };
-  for (const r of rows.confirmed) touch(r.destinationIndex).confirmed.push(r);
-  for (const r of rows.likely) touch(r.destinationIndex).likely.push(r);
-  for (const r of rows.possible) touch(r.destinationIndex).possible.push(r);
-  return byStop;
 }
 
 /**
@@ -671,8 +600,8 @@ function DayRows({
       {confirmed.map((r) => (
         <ConfirmedCard key={r.eventId} result={r} />
       ))}
-      {likely.map((r) => (
-        <LikelyCard key={`${r.kennelId}-${r.date}`} result={r} />
+      {likely.map((r, i) => (
+        <LikelyCard key={`${r.kennelId}-${r.date}-${i}`} result={r} />
       ))}
       {possible.length > 0 && (
         <div className="flex flex-col border-l-2 border-dashed border-border/60 pl-3">

--- a/src/components/travel/TravelResults.tsx
+++ b/src/components/travel/TravelResults.tsx
@@ -6,19 +6,31 @@ import { capture } from "@/lib/analytics";
 import {
   computeDayCounts,
   groupResultsByTier,
+  passesDayFilter,
+  getDayCode,
   toggleDay as toggleDayInSet,
   TIERS,
   type DayCode,
   type DistanceTier,
 } from "@/lib/travel/filters";
-import { formatDayHeader } from "@/lib/travel/format";
+import { formatDayHeader, cityToIata } from "@/lib/travel/format";
+import type { MultiDestView } from "@/lib/travel/multi-destination";
 import { ConfirmedCard } from "./ConfirmedCard";
 import { LikelyCard } from "./LikelyCard";
 import { PossibleSection } from "./PossibleSection";
 import { PossibleRow } from "./PossibleRow";
 import { TravelResultFilters } from "./TravelResultFilters";
 
-interface SerializedConfirmed {
+/** Per-row multi-destination tag. Every result is tagged with the 0-indexed
+ * stop it belongs to, letting the UI render LEG sub-bands on overlap days
+ * (where two stops share a calendar date). Single-destination searches
+ * produce rows all tagged `{ destinationIndex: 0 }`. */
+interface DestinationTag {
+  destinationIndex: number;
+  destinationLabel: string | null;
+}
+
+interface SerializedConfirmed extends DestinationTag {
   type: "confirmed";
   eventId: string;
   kennelId: string;
@@ -50,7 +62,7 @@ interface SerializedConfirmed {
   attendance: { status: string; participationLevel: string } | null;
 }
 
-interface SerializedLikely {
+interface SerializedLikely extends DestinationTag {
   type: "likely";
   kennelId: string;
   kennelSlug: string;
@@ -69,7 +81,7 @@ interface SerializedLikely {
   sourceLinks: SourceLink[];
 }
 
-interface SerializedPossible {
+interface SerializedPossible extends DestinationTag {
   type: "possible";
   kennelId: string;
   kennelSlug: string;
@@ -85,6 +97,17 @@ interface SerializedPossible {
   lastConfirmedAt: string | null;
 }
 
+/** Serialized per-stop summary, threaded through from search.ts. Dates are
+ * ISO strings because the props cross the RSC boundary. */
+export interface SerializedDestination {
+  index: number;
+  label: string | null;
+  startDate: string;
+  endDate: string;
+  radiusKm: number;
+  broaderRadiusKm?: number;
+}
+
 interface TravelResultsProps {
   destination: string;
   results: {
@@ -92,6 +115,9 @@ interface TravelResultsProps {
     likely: SerializedLikely[];
     possible: SerializedPossible[];
   };
+  /** Per-stop metadata. When length > 1 the multi-destination view
+   * toggle renders; otherwise the distance-tier view takes over. */
+  destinations?: SerializedDestination[];
 }
 
 const TIER_LABELS: Record<DistanceTier, { title: string; description: string }> = {
@@ -100,11 +126,19 @@ const TIER_LABELS: Record<DistanceTier, { title: string; description: string }> 
   drive: { title: "Day trip material", description: "25+ km" },
 };
 
-export function TravelResults({ destination, results }: Readonly<TravelResultsProps>) {
+export function TravelResults({
+  destination,
+  results,
+  destinations,
+}: Readonly<TravelResultsProps>) {
   const { confirmed, likely, possible } = results;
+  const isMultiStop = (destinations?.length ?? 0) > 1;
 
   const [includePossible, setIncludePossible] = useState(false);
   const [selectedDays, setSelectedDays] = useState<Set<DayCode>>(new Set());
+  // Multi-stop view axis; single-stop trips keep the distance-tier render
+  // below and ignore this state.
+  const [viewMode, setViewMode] = useState<MultiDestView>("day-by-day");
 
   // Fire once per unique search result set. The string key captures every
   // distinct result shape (destination + counts), and the useEffect only
@@ -153,6 +187,28 @@ export function TravelResults({ destination, results }: Readonly<TravelResultsPr
     [confirmed, likely, possible, selectedDays],
   );
 
+  // Day-filtered rows shared by both multi-destination views. Computed
+  // once per change of the underlying arrays or the DOW filter so the
+  // view toggle itself doesn't re-filter. Only meaningful when
+  // `isMultiStop`; cheap to compute regardless (the flat arrays usually
+  // fit the page's confirmed-event cap of 500).
+  const filteredForMultiStop = useMemo(() => {
+    if (!isMultiStop) return null;
+    return {
+      confirmed: confirmed.filter((r) =>
+        passesDayFilter(getDayCode(r.date), selectedDays),
+      ),
+      likely: likely.filter((r) =>
+        passesDayFilter(getDayCode(r.date), selectedDays),
+      ),
+      possible: includePossible
+        ? possible.filter((r) =>
+            passesDayFilter(r.date ? getDayCode(r.date) : null, selectedDays),
+          )
+        : [],
+    };
+  }, [isMultiStop, confirmed, likely, possible, includePossible, selectedDays]);
+
   const renderedTiers = TIERS.map((tier) => ({
     tier,
     ...grouped[tier],
@@ -199,6 +255,16 @@ export function TravelResults({ destination, results }: Readonly<TravelResultsPr
         </p>
       )}
 
+      {isMultiStop && (
+        <ViewToggle
+          viewMode={viewMode}
+          onChange={(next) => {
+            capture("travel_multidest_view_changed", { view: next });
+            setViewMode(next);
+          }}
+        />
+      )}
+
       {/*
         Only show the "no matches" banner when the filter has truly hidden
         everything — including the collapsed PossibleSection below. Without
@@ -222,6 +288,18 @@ export function TravelResults({ destination, results }: Readonly<TravelResultsPr
         </div>
       )}
 
+      {isMultiStop && filteredForMultiStop && viewMode === "day-by-day" && (
+        <MultiDestDayView rows={filteredForMultiStop} />
+      )}
+      {isMultiStop && filteredForMultiStop && viewMode === "by-destination" && (
+        <MultiDestDestinationView
+          rows={filteredForMultiStop}
+          destinations={destinations ?? []}
+        />
+      )}
+
+      {!isMultiStop && (
+      <>
       <div className="mt-6">
         {renderedTiers.map(({ tier, confirmed: tc, likely: tl, shownPossible }) => {
           const total = tc.length + tl.length + shownPossible.length;
@@ -293,6 +371,315 @@ export function TravelResults({ destination, results }: Readonly<TravelResultsPr
           results={filteredPossibleAll}
           confirmedCount={renderedTiers.reduce((sum, t) => sum + t.confirmed.length, 0)}
         />
+      )}
+      </>
+      )}
+    </div>
+  );
+}
+
+/** Day-by-day / by-destination segmented control — appears only when multi-stop. */
+function ViewToggle({
+  viewMode,
+  onChange,
+}: {
+  viewMode: MultiDestView;
+  onChange: (next: MultiDestView) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Results view"
+      className="mt-4 inline-flex rounded-full border border-border bg-card p-0.5"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={viewMode === "day-by-day"}
+        onClick={() => onChange("day-by-day")}
+        className={`rounded-full px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] transition ${
+          viewMode === "day-by-day"
+            ? "bg-foreground text-background"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        Day-by-day
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={viewMode === "by-destination"}
+        onClick={() => onChange("by-destination")}
+        className={`rounded-full px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] transition ${
+          viewMode === "by-destination"
+            ? "bg-foreground text-background"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        By destination
+      </button>
+    </div>
+  );
+}
+
+interface MultiDestRows {
+  confirmed: SerializedConfirmed[];
+  likely: SerializedLikely[];
+  possible: SerializedPossible[];
+}
+
+interface DayStopBand {
+  label: string | null;
+  confirmed: SerializedConfirmed[];
+  likely: SerializedLikely[];
+  possible: SerializedPossible[];
+}
+
+interface DayBucket {
+  dateKey: string | null;
+  bandsByStop: Map<number, DayStopBand>;
+}
+
+/** Build per-day Map<stopIndex, bands> in one pass over each row kind.
+ *  O(rows) instead of per-day per-stop triple `.find()` lookups. */
+function bucketDays(rows: MultiDestRows): DayBucket[] {
+  const byDay = new Map<string | null, Map<number, DayStopBand>>();
+  const touch = (dateKey: string | null, stop: number, label: string | null) => {
+    let forDay = byDay.get(dateKey);
+    if (!forDay) {
+      forDay = new Map();
+      byDay.set(dateKey, forDay);
+    }
+    let band = forDay.get(stop);
+    if (!band) {
+      band = { label, confirmed: [], likely: [], possible: [] };
+      forDay.set(stop, band);
+    } else if (band.label === null && label !== null) {
+      band.label = label;
+    }
+    return band;
+  };
+  for (const r of rows.confirmed) {
+    touch(r.date.slice(0, 10), r.destinationIndex, r.destinationLabel).confirmed.push(r);
+  }
+  for (const r of rows.likely) {
+    touch(r.date.slice(0, 10), r.destinationIndex, r.destinationLabel).likely.push(r);
+  }
+  for (const r of rows.possible) {
+    const key = r.date ? r.date.slice(0, 10) : null;
+    touch(key, r.destinationIndex, r.destinationLabel).possible.push(r);
+  }
+  return [...byDay.entries()]
+    .map(([dateKey, bandsByStop]) => ({ dateKey, bandsByStop }))
+    .sort((a, b) => {
+      if (a.dateKey === null) return 1;
+      if (b.dateKey === null) return -1;
+      return a.dateKey.localeCompare(b.dateKey);
+    });
+}
+
+/**
+ * Day-by-day layout with LEG sub-bands on overlap days. Days sort
+ * chronologically; overlap days (2+ legs share a date) split by
+ * destinationIndex with a hairline ✈ perforation between bands.
+ * Non-overlap days render flat.
+ */
+function MultiDestDayView({ rows }: { rows: MultiDestRows }) {
+  const buckets = useMemo(() => bucketDays(rows), [rows]);
+
+  if (buckets.length === 0) {
+    return (
+      <p className="mt-10 text-center text-sm text-muted-foreground">
+        No results on any day.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-6 flex flex-col gap-10">
+      {buckets.map((bucket) => {
+        const orderedStops = [...bucket.bandsByStop.keys()].sort((a, b) => a - b);
+        const hasOverlap = orderedStops.length > 1;
+        return (
+          <section key={bucket.dateKey ?? "cadence"} className="flex flex-col gap-4">
+            <h2 className="font-display text-xl font-medium tracking-tight border-b border-border pb-2">
+              {bucket.dateKey ? formatDayHeader(bucket.dateKey) : "Cadence-based"}
+            </h2>
+            {orderedStops.map((stopIndex, bandIdx) => {
+              const band = bucket.bandsByStop.get(stopIndex)!;
+              return (
+                <div key={stopIndex} className="flex flex-col gap-3">
+                  {hasOverlap && (
+                    <>
+                      {bandIdx > 0 && <Perforation />}
+                      <LegSubHeader
+                        destinationIndex={stopIndex}
+                        destinationLabel={band.label}
+                      />
+                    </>
+                  )}
+                  <DayRows
+                    confirmed={band.confirmed}
+                    likely={band.likely}
+                    possible={band.possible}
+                  />
+                </div>
+              );
+            })}
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+interface StopBucket {
+  confirmed: SerializedConfirmed[];
+  likely: SerializedLikely[];
+  possible: SerializedPossible[];
+}
+
+/** Partition rows into a Map keyed by destinationIndex in one pass. */
+function bucketStops(rows: MultiDestRows): Map<number, StopBucket> {
+  const byStop = new Map<number, StopBucket>();
+  const touch = (idx: number): StopBucket => {
+    let b = byStop.get(idx);
+    if (!b) {
+      b = { confirmed: [], likely: [], possible: [] };
+      byStop.set(idx, b);
+    }
+    return b;
+  };
+  for (const r of rows.confirmed) touch(r.destinationIndex).confirmed.push(r);
+  for (const r of rows.likely) touch(r.destinationIndex).likely.push(r);
+  for (const r of rows.possible) touch(r.destinationIndex).possible.push(r);
+  return byStop;
+}
+
+/**
+ * By-destination layout — one boarding-pass panel per stop (1–3 column
+ * grid). Stops with zero rows still render as an empty placeholder so
+ * users can see which leg didn't land anything.
+ */
+function MultiDestDestinationView({
+  rows,
+  destinations,
+}: {
+  rows: MultiDestRows;
+  destinations: SerializedDestination[];
+}) {
+  const stops = useMemo(() => bucketStops(rows), [rows]);
+
+  return (
+    <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+      {destinations.map((dest) => {
+        const bucket = stops.get(dest.index);
+        const total =
+          (bucket?.confirmed.length ?? 0) +
+          (bucket?.likely.length ?? 0) +
+          (bucket?.possible.length ?? 0);
+
+        return (
+          <article
+            key={dest.index}
+            className="flex flex-col gap-4 rounded-xl border border-border bg-card p-5"
+          >
+            <header className="border-b border-dashed border-border pb-3">
+              <div className="flex items-baseline justify-between gap-2">
+                <LegSubHeader
+                  destinationIndex={dest.index}
+                  destinationLabel={dest.label}
+                />
+                <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                  {dest.radiusKm} km
+                </span>
+              </div>
+              <p className="mt-1 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                {dest.startDate.slice(0, 10)} → {dest.endDate.slice(0, 10)}
+              </p>
+            </header>
+
+            {total === 0 ? (
+              <p className="text-sm italic text-muted-foreground">
+                No trails on this leg.
+              </p>
+            ) : (
+              <DayRows
+                confirmed={bucket!.confirmed}
+                likely={bucket!.likely}
+                possible={bucket!.possible}
+              />
+            )}
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+/** LEG stamp header — sequence number + IATA. */
+function LegSubHeader({
+  destinationIndex,
+  destinationLabel,
+}: {
+  destinationIndex: number;
+  destinationLabel: string | null;
+}) {
+  const seq = String(destinationIndex + 1).padStart(2, "0");
+  const iata = destinationLabel ? cityToIata(destinationLabel) : "—";
+  const cityShort = destinationLabel
+    ? (destinationLabel.split(",")[0]?.trim() ?? destinationLabel)
+    : "Stop";
+  return (
+    <div className="flex items-center gap-3">
+      <span className="inline-flex items-center justify-center rounded-sm border-[1.5px] border-red-600/70 px-1.5 py-[1px] font-mono text-[10px] font-bold uppercase tracking-wider text-red-600 dark:border-red-400/70 dark:text-red-400">
+        LEG {seq} · {iata}
+      </span>
+      <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+        {cityShort}
+      </span>
+    </div>
+  );
+}
+
+/** Hairline ticket perforation with a rotated ✈ glyph. Renders between
+ *  LEG sub-bands on overlap days so the split reads as a tear-strip. */
+function Perforation() {
+  return (
+    <div className="relative my-2 h-px w-full bg-[length:6px_1px] bg-repeat-x bg-muted-foreground/35" aria-hidden="true">
+      <span
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rotate-[-8deg] bg-background px-2.5 text-sm text-muted-foreground/80"
+      >
+        ✈
+      </span>
+    </div>
+  );
+}
+
+/** Shared row render — confirmed + likely cards stacked; possibles dashed-indented. */
+function DayRows({
+  confirmed,
+  likely,
+  possible,
+}: {
+  confirmed: SerializedConfirmed[];
+  likely: SerializedLikely[];
+  possible: SerializedPossible[];
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      {confirmed.map((r) => (
+        <ConfirmedCard key={r.eventId} result={r} />
+      ))}
+      {likely.map((r) => (
+        <LikelyCard key={`${r.kennelId}-${r.date}`} result={r} />
+      ))}
+      {possible.length > 0 && (
+        <div className="flex flex-col border-l-2 border-dashed border-border/60 pl-3">
+          {possible.map((r, i) => (
+            <PossibleRow key={`${r.kennelId}-${r.date ?? "cadence"}-${i}`} result={r} />
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -157,6 +157,10 @@ interface TravelFilterAppliedProps {
   value: string;
 }
 
+interface TravelMultidestViewChangedProps {
+  view: "day-by-day" | "by-destination";
+}
+
 // ── Event Map ────────────────────────────────────────────────────────
 
 interface AnalyticsEventMap {
@@ -202,6 +206,7 @@ interface AnalyticsEventMap {
   travel_near_me_clicked: Record<string, never>;
   travel_popular_destination_clicked: TravelPopularDestinationClickedProps;
   travel_filter_applied: TravelFilterAppliedProps;
+  travel_multidest_view_changed: TravelMultidestViewChangedProps;
 }
 
 /**

--- a/src/lib/travel/multi-destination.test.ts
+++ b/src/lib/travel/multi-destination.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  groupByDayWithLegs,
+  groupByDestination,
+} from "./multi-destination";
+
+interface TestRow {
+  destinationIndex: number;
+  destinationLabel: string | null;
+  date: string | null;
+  id: string;
+}
+
+const row = (
+  id: string,
+  destinationIndex: number,
+  date: string | null,
+  label: string | null = null,
+): TestRow => ({ id, destinationIndex, destinationLabel: label, date });
+
+describe("groupByDayWithLegs", () => {
+  it("returns one flat leg for a single-stop day (no overlap)", () => {
+    const groups = groupByDayWithLegs([
+      row("a", 0, "2026-04-20", "London"),
+      row("b", 0, "2026-04-20", "London"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].dateKey).toBe("2026-04-20");
+    expect(groups[0].hasOverlap).toBe(false);
+    expect(groups[0].legs).toHaveLength(1);
+    expect(groups[0].legs[0].rows.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("marks days as hasOverlap when 2+ stops share the date", () => {
+    // London and Paris both have events on Thursday April 23 (transit day).
+    const groups = groupByDayWithLegs([
+      row("lhr-1", 0, "2026-04-23", "London"),
+      row("cdg-1", 1, "2026-04-23", "Paris"),
+      row("cdg-2", 1, "2026-04-23", "Paris"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].hasOverlap).toBe(true);
+    expect(groups[0].legs).toHaveLength(2);
+    expect(groups[0].legs.map((l) => l.destinationIndex)).toEqual([0, 1]);
+    expect(groups[0].legs[0].rows.map((r) => r.id)).toEqual(["lhr-1"]);
+    expect(groups[0].legs[1].rows.map((r) => r.id)).toEqual(["cdg-1", "cdg-2"]);
+  });
+
+  it("preserves destinationLabel from the first row of each band", () => {
+    const groups = groupByDayWithLegs([
+      row("lhr-1", 0, "2026-04-23", "London"),
+      row("cdg-1", 1, "2026-04-23", "Paris"),
+    ]);
+    expect(groups[0].legs[0].destinationLabel).toBe("London");
+    expect(groups[0].legs[1].destinationLabel).toBe("Paris");
+  });
+
+  it("sorts days chronologically with cadence-based (null date) group last", () => {
+    const groups = groupByDayWithLegs([
+      row("cadence", 0, null),
+      row("wed", 0, "2026-04-22"),
+      row("mon", 0, "2026-04-20"),
+    ]);
+    expect(groups.map((g) => g.dateKey)).toEqual([
+      "2026-04-20",
+      "2026-04-22",
+      null,
+    ]);
+  });
+
+  it("sorts leg bands by destinationIndex regardless of input row order", () => {
+    const groups = groupByDayWithLegs([
+      // Paris (1) event mentioned first in input, but leg 01 (index 0) sorts first.
+      row("cdg", 1, "2026-04-23", "Paris"),
+      row("lhr", 0, "2026-04-23", "London"),
+    ]);
+    expect(groups[0].legs.map((l) => l.destinationIndex)).toEqual([0, 1]);
+  });
+
+  it("handles a 3-stop day with all three overlapping (hasOverlap + 3 legs)", () => {
+    const groups = groupByDayWithLegs([
+      row("lhr", 0, "2026-04-25"),
+      row("cdg", 1, "2026-04-25"),
+      row("ber", 2, "2026-04-25"),
+    ]);
+    expect(groups[0].hasOverlap).toBe(true);
+    expect(groups[0].legs).toHaveLength(3);
+  });
+
+  it("returns empty array when no rows are supplied", () => {
+    expect(groupByDayWithLegs([])).toEqual([]);
+  });
+
+  it("slices ISO timestamps to YYYY-MM-DD so 'date' stamps from the wire match", () => {
+    // `date` is serialized as ISO on the wire (`.toISOString()`); the
+    // grouping key must ignore the time portion so same-day events
+    // collapse correctly.
+    const groups = groupByDayWithLegs([
+      row("a", 0, "2026-04-23T12:00:00.000Z"),
+      row("b", 0, "2026-04-23T18:00:00.000Z"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].dateKey).toBe("2026-04-23");
+    expect(groups[0].legs[0].rows).toHaveLength(2);
+  });
+});
+
+describe("groupByDestination", () => {
+  it("returns one section per stop, position-ordered", () => {
+    const sections = groupByDestination([
+      row("c", 2, "2026-04-26"),
+      row("a", 0, "2026-04-20"),
+      row("b", 1, "2026-04-23"),
+    ]);
+    expect(sections.map((s) => s.destinationIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("groups all rows per stop regardless of date", () => {
+    const sections = groupByDestination([
+      row("lhr-1", 0, "2026-04-20"),
+      row("lhr-2", 0, "2026-04-21"),
+      row("lhr-3", 0, null),
+      row("cdg-1", 1, "2026-04-24"),
+    ]);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].rows.map((r) => r.id)).toEqual(["lhr-1", "lhr-2", "lhr-3"]);
+    expect(sections[1].rows.map((r) => r.id)).toEqual(["cdg-1"]);
+  });
+
+  it("omits stops with zero rows", () => {
+    // Paris (1) has no rows in this mix. Only London + Berlin surface.
+    const sections = groupByDestination([
+      row("lhr", 0, "2026-04-20"),
+      row("ber", 2, "2026-04-26"),
+    ]);
+    expect(sections.map((s) => s.destinationIndex)).toEqual([0, 2]);
+  });
+
+  it("returns empty when no rows supplied", () => {
+    expect(groupByDestination([])).toEqual([]);
+  });
+});

--- a/src/lib/travel/multi-destination.test.ts
+++ b/src/lib/travel/multi-destination.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  groupByDayWithLegs,
-  groupByDestination,
-} from "./multi-destination";
+import { bucketDays, bucketStops } from "./multi-destination";
 
 interface TestRow {
   destinationIndex: number;
@@ -18,125 +15,132 @@ const row = (
   label: string | null = null,
 ): TestRow => ({ id, destinationIndex, destinationLabel: label, date });
 
-describe("groupByDayWithLegs", () => {
-  it("returns one flat leg for a single-stop day (no overlap)", () => {
-    const groups = groupByDayWithLegs([
-      row("a", 0, "2026-04-20", "London"),
-      row("b", 0, "2026-04-20", "London"),
-    ]);
-    expect(groups).toHaveLength(1);
-    expect(groups[0].dateKey).toBe("2026-04-20");
-    expect(groups[0].hasOverlap).toBe(false);
-    expect(groups[0].legs).toHaveLength(1);
-    expect(groups[0].legs[0].rows.map((r) => r.id)).toEqual(["a", "b"]);
+const emptyKind = <T,>(): T[] => [];
+
+describe("bucketDays", () => {
+  it("returns one day bucket for a single-stop day (no overlap)", () => {
+    const buckets = bucketDays({
+      confirmed: [row("a", 0, "2026-04-20", "London"), row("b", 0, "2026-04-20", "London")],
+      likely: emptyKind<TestRow>(),
+      possible: emptyKind<TestRow>(),
+    });
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].dateKey).toBe("2026-04-20");
+    expect(buckets[0].bandsByStop.size).toBe(1);
+    const band = buckets[0].bandsByStop.get(0);
+    expect(band?.confirmed.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(band?.label).toBe("London");
   });
 
-  it("marks days as hasOverlap when 2+ stops share the date", () => {
-    // London and Paris both have events on Thursday April 23 (transit day).
-    const groups = groupByDayWithLegs([
-      row("lhr-1", 0, "2026-04-23", "London"),
-      row("cdg-1", 1, "2026-04-23", "Paris"),
-      row("cdg-2", 1, "2026-04-23", "Paris"),
-    ]);
-    expect(groups).toHaveLength(1);
-    expect(groups[0].hasOverlap).toBe(true);
-    expect(groups[0].legs).toHaveLength(2);
-    expect(groups[0].legs.map((l) => l.destinationIndex)).toEqual([0, 1]);
-    expect(groups[0].legs[0].rows.map((r) => r.id)).toEqual(["lhr-1"]);
-    expect(groups[0].legs[1].rows.map((r) => r.id)).toEqual(["cdg-1", "cdg-2"]);
+  it("separates stops into different bands within the same day (overlap)", () => {
+    const buckets = bucketDays({
+      confirmed: [row("lhr-1", 0, "2026-04-23", "London"), row("cdg-1", 1, "2026-04-23", "Paris"), row("cdg-2", 1, "2026-04-23", "Paris")],
+      likely: emptyKind<TestRow>(),
+      possible: emptyKind<TestRow>(),
+    });
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].bandsByStop.size).toBe(2);
+    expect(buckets[0].bandsByStop.get(0)?.confirmed.map((r) => r.id)).toEqual(["lhr-1"]);
+    expect(buckets[0].bandsByStop.get(1)?.confirmed.map((r) => r.id)).toEqual(["cdg-1", "cdg-2"]);
   });
 
-  it("preserves destinationLabel from the first row of each band", () => {
-    const groups = groupByDayWithLegs([
-      row("lhr-1", 0, "2026-04-23", "London"),
-      row("cdg-1", 1, "2026-04-23", "Paris"),
-    ]);
-    expect(groups[0].legs[0].destinationLabel).toBe("London");
-    expect(groups[0].legs[1].destinationLabel).toBe("Paris");
+  it("upgrades a null label when a later row in the same (day, stop) band has one", () => {
+    // First row lacks a label; second sets it. The band should carry the later value.
+    const buckets = bucketDays({
+      confirmed: [row("a", 0, "2026-04-20", null), row("b", 0, "2026-04-20", "London")],
+      likely: emptyKind<TestRow>(),
+      possible: emptyKind<TestRow>(),
+    });
+    expect(buckets[0].bandsByStop.get(0)?.label).toBe("London");
+  });
+
+  it("merges confirmed + likely + possible for the same (day, stop) band", () => {
+    const buckets = bucketDays({
+      confirmed: [row("c", 0, "2026-04-20")],
+      likely: [row("l", 0, "2026-04-20")],
+      possible: [row("p", 0, "2026-04-20")],
+    });
+    const band = buckets[0].bandsByStop.get(0)!;
+    expect(band.confirmed.map((r) => r.id)).toEqual(["c"]);
+    expect(band.likely.map((r) => r.id)).toEqual(["l"]);
+    expect(band.possible.map((r) => r.id)).toEqual(["p"]);
   });
 
   it("sorts days chronologically with cadence-based (null date) group last", () => {
-    const groups = groupByDayWithLegs([
-      row("cadence", 0, null),
-      row("wed", 0, "2026-04-22"),
-      row("mon", 0, "2026-04-20"),
-    ]);
-    expect(groups.map((g) => g.dateKey)).toEqual([
-      "2026-04-20",
-      "2026-04-22",
-      null,
-    ]);
+    const buckets = bucketDays({
+      confirmed: emptyKind<TestRow>(),
+      likely: emptyKind<TestRow>(),
+      possible: [row("cadence", 0, null), row("wed", 0, "2026-04-22"), row("mon", 0, "2026-04-20")],
+    });
+    expect(buckets.map((b) => b.dateKey)).toEqual(["2026-04-20", "2026-04-22", null]);
   });
 
-  it("sorts leg bands by destinationIndex regardless of input row order", () => {
-    const groups = groupByDayWithLegs([
-      // Paris (1) event mentioned first in input, but leg 01 (index 0) sorts first.
-      row("cdg", 1, "2026-04-23", "Paris"),
-      row("lhr", 0, "2026-04-23", "London"),
-    ]);
-    expect(groups[0].legs.map((l) => l.destinationIndex)).toEqual([0, 1]);
+  it("slices ISO timestamps to YYYY-MM-DD so wire-formatted dates collapse", () => {
+    const buckets = bucketDays({
+      confirmed: [row("a", 0, "2026-04-23T12:00:00.000Z"), row("b", 0, "2026-04-23T18:00:00.000Z")],
+      likely: emptyKind<TestRow>(),
+      possible: emptyKind<TestRow>(),
+    });
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].dateKey).toBe("2026-04-23");
+    expect(buckets[0].bandsByStop.get(0)?.confirmed).toHaveLength(2);
   });
 
-  it("handles a 3-stop day with all three overlapping (hasOverlap + 3 legs)", () => {
-    const groups = groupByDayWithLegs([
-      row("lhr", 0, "2026-04-25"),
-      row("cdg", 1, "2026-04-25"),
-      row("ber", 2, "2026-04-25"),
-    ]);
-    expect(groups[0].hasOverlap).toBe(true);
-    expect(groups[0].legs).toHaveLength(3);
+  it("handles a 3-stop day with all three overlapping", () => {
+    const buckets = bucketDays({
+      confirmed: [row("lhr", 0, "2026-04-25"), row("cdg", 1, "2026-04-25"), row("ber", 2, "2026-04-25")],
+      likely: emptyKind<TestRow>(),
+      possible: emptyKind<TestRow>(),
+    });
+    expect(buckets[0].bandsByStop.size).toBe(3);
+    expect([...buckets[0].bandsByStop.keys()].sort()).toEqual([0, 1, 2]);
   });
 
-  it("returns empty array when no rows are supplied", () => {
-    expect(groupByDayWithLegs([])).toEqual([]);
-  });
-
-  it("slices ISO timestamps to YYYY-MM-DD so 'date' stamps from the wire match", () => {
-    // `date` is serialized as ISO on the wire (`.toISOString()`); the
-    // grouping key must ignore the time portion so same-day events
-    // collapse correctly.
-    const groups = groupByDayWithLegs([
-      row("a", 0, "2026-04-23T12:00:00.000Z"),
-      row("b", 0, "2026-04-23T18:00:00.000Z"),
-    ]);
-    expect(groups).toHaveLength(1);
-    expect(groups[0].dateKey).toBe("2026-04-23");
-    expect(groups[0].legs[0].rows).toHaveLength(2);
+  it("returns empty array when no rows supplied", () => {
+    expect(
+      bucketDays({ confirmed: emptyKind<TestRow>(), likely: emptyKind<TestRow>(), possible: emptyKind<TestRow>() }),
+    ).toEqual([]);
   });
 });
 
-describe("groupByDestination", () => {
-  it("returns one section per stop, position-ordered", () => {
-    const sections = groupByDestination([
-      row("c", 2, "2026-04-26"),
-      row("a", 0, "2026-04-20"),
-      row("b", 1, "2026-04-23"),
-    ]);
-    expect(sections.map((s) => s.destinationIndex)).toEqual([0, 1, 2]);
+describe("bucketStops", () => {
+  it("partitions rows by destinationIndex into a Map for O(1) lookup", () => {
+    const buckets = bucketStops({
+      confirmed: [row("a", 0, "2026-04-20"), row("b", 2, "2026-04-26")],
+      likely: [row("c", 1, "2026-04-23")],
+      possible: [row("d", 0, null)],
+    });
+    expect(buckets.size).toBe(3);
+    expect(buckets.get(0)?.confirmed.map((r) => r.id)).toEqual(["a"]);
+    expect(buckets.get(0)?.possible.map((r) => r.id)).toEqual(["d"]);
+    expect(buckets.get(1)?.likely.map((r) => r.id)).toEqual(["c"]);
+    expect(buckets.get(2)?.confirmed.map((r) => r.id)).toEqual(["b"]);
   });
 
-  it("groups all rows per stop regardless of date", () => {
-    const sections = groupByDestination([
-      row("lhr-1", 0, "2026-04-20"),
-      row("lhr-2", 0, "2026-04-21"),
-      row("lhr-3", 0, null),
-      row("cdg-1", 1, "2026-04-24"),
-    ]);
-    expect(sections).toHaveLength(2);
-    expect(sections[0].rows.map((r) => r.id)).toEqual(["lhr-1", "lhr-2", "lhr-3"]);
-    expect(sections[1].rows.map((r) => r.id)).toEqual(["cdg-1"]);
+  it("groups all three row kinds per stop", () => {
+    const buckets = bucketStops({
+      confirmed: [row("c", 0, "2026-04-20")],
+      likely: [row("l", 0, "2026-04-21")],
+      possible: [row("p", 0, null)],
+    });
+    const b = buckets.get(0)!;
+    expect(b.confirmed).toHaveLength(1);
+    expect(b.likely).toHaveLength(1);
+    expect(b.possible).toHaveLength(1);
   });
 
-  it("omits stops with zero rows", () => {
-    // Paris (1) has no rows in this mix. Only London + Berlin surface.
-    const sections = groupByDestination([
-      row("lhr", 0, "2026-04-20"),
-      row("ber", 2, "2026-04-26"),
-    ]);
-    expect(sections.map((s) => s.destinationIndex)).toEqual([0, 2]);
+  it("returns an empty map when no rows supplied", () => {
+    expect(
+      bucketStops({ confirmed: emptyKind<TestRow>(), likely: emptyKind<TestRow>(), possible: emptyKind<TestRow>() }).size,
+    ).toBe(0);
   });
 
-  it("returns empty when no rows supplied", () => {
-    expect(groupByDestination([])).toEqual([]);
+  it("skips stops with zero rows", () => {
+    const buckets = bucketStops({
+      confirmed: [row("a", 0, "2026-04-20")],
+      likely: emptyKind<TestRow>(),
+      possible: [row("b", 2, null)],
+    });
+    expect([...buckets.keys()].sort()).toEqual([0, 2]);
   });
 });

--- a/src/lib/travel/multi-destination.test.ts
+++ b/src/lib/travel/multi-destination.test.ts
@@ -93,7 +93,7 @@ describe("bucketDays", () => {
       possible: emptyKind<TestRow>(),
     });
     expect(buckets[0].bandsByStop.size).toBe(3);
-    expect([...buckets[0].bandsByStop.keys()].sort()).toEqual([0, 1, 2]);
+    expect([...buckets[0].bandsByStop.keys()].sort((a, b) => a - b)).toEqual([0, 1, 2]);
   });
 
   it("returns empty array when no rows supplied", () => {
@@ -141,6 +141,6 @@ describe("bucketStops", () => {
       likely: emptyKind<TestRow>(),
       possible: [row("b", 2, null)],
     });
-    expect([...buckets.keys()].sort()).toEqual([0, 2]);
+    expect([...buckets.keys()].sort((a, b) => a - b)).toEqual([0, 2]);
   });
 });

--- a/src/lib/travel/multi-destination.ts
+++ b/src/lib/travel/multi-destination.ts
@@ -1,5 +1,5 @@
 /**
- * Multi-destination view grouping helpers for Travel Mode results.
+ * Multi-destination view bucketing helpers for Travel Mode results.
  *
  * Two views:
  *   - Day-by-day: days as the top-level axis; overlap days split into
@@ -19,98 +19,98 @@ interface TaggedRow {
   date: string | null;
 }
 
-export interface LegBand<T extends TaggedRow> {
-  destinationIndex: number;
-  destinationLabel: string | null;
-  rows: T[];
+export interface DayStopBand<C, L, P> {
+  label: string | null;
+  confirmed: C[];
+  likely: L[];
+  possible: P[];
 }
 
-export interface DayGroupWithLegs<T extends TaggedRow> {
-  /** YYYY-MM-DD or null for cadence-based (undated) rows. */
+export interface DayBucket<C, L, P> {
   dateKey: string | null;
-  /** True when the day contains rows from 2+ stops — UI renders LEG sub-bands + ✈ perforation. */
-  hasOverlap: boolean;
-  /** One band per distinct `destinationIndex`, position-ordered. Length 1 on non-overlap days. */
-  legs: LegBand<T>[];
+  bandsByStop: Map<number, DayStopBand<C, L, P>>;
+}
+
+interface RowBundle<C extends TaggedRow, L extends TaggedRow, P extends TaggedRow> {
+  confirmed: C[];
+  likely: L[];
+  possible: P[];
 }
 
 /**
- * Group rows by calendar day. For each day, split rows by
- * `destinationIndex` into leg-bands (position-ordered). A day with
- * 2+ distinct stop indexes is marked `hasOverlap: true` so the UI
- * can render LEG sub-bands with a ✈ perforation; single-stop days
- * render flat.
+ * Bucket rows into `Map<dateKey, Map<stopIndex, band>>` in one pass per
+ * row kind. Each band collects confirmed + likely + possible for that
+ * (day, stop) cell. Day-by-day rendering reads these directly — no
+ * per-cell `.find()` lookups.
  *
- * Rows with `date === null` (cadence-based possibles with no fixed
- * date) collapse into a single `dateKey: null` group sorted last.
+ * Date keys are YYYY-MM-DD (sliced from ISO timestamps so event rows
+ * and cadence-null possibles collapse correctly). Days sort
+ * chronologically; cadence-based rows (`date === null`) sort last.
  */
-export function groupByDayWithLegs<T extends TaggedRow>(rows: T[]): DayGroupWithLegs<T>[] {
-  const byDay = new Map<string | null, Map<number, LegBand<T>>>();
-
-  for (const row of rows) {
-    const dayKey = row.date ? row.date.slice(0, 10) : null;
-    let legsForDay = byDay.get(dayKey);
-    if (!legsForDay) {
-      legsForDay = new Map();
-      byDay.set(dayKey, legsForDay);
+export function bucketDays<C extends TaggedRow, L extends TaggedRow, P extends TaggedRow>(
+  rows: RowBundle<C, L, P>,
+): DayBucket<C, L, P>[] {
+  const byDay = new Map<string | null, Map<number, DayStopBand<C, L, P>>>();
+  const touch = (dateKey: string | null, stop: number, label: string | null) => {
+    let forDay = byDay.get(dateKey);
+    if (!forDay) {
+      forDay = new Map();
+      byDay.set(dateKey, forDay);
     }
-    let band = legsForDay.get(row.destinationIndex);
+    let band = forDay.get(stop);
     if (!band) {
-      band = {
-        destinationIndex: row.destinationIndex,
-        destinationLabel: row.destinationLabel,
-        rows: [],
-      };
-      legsForDay.set(row.destinationIndex, band);
+      band = { label, confirmed: [], likely: [], possible: [] };
+      forDay.set(stop, band);
+    } else if (band.label === null && label !== null) {
+      band.label = label;
     }
-    band.rows.push(row);
+    return band;
+  };
+  for (const r of rows.confirmed) {
+    touch(r.date?.slice(0, 10) ?? null, r.destinationIndex, r.destinationLabel).confirmed.push(r);
   }
-
-  const groups: DayGroupWithLegs<T>[] = [];
-  for (const [dateKey, legsMap] of byDay.entries()) {
-    const legs = [...legsMap.values()].sort(
-      (a, b) => a.destinationIndex - b.destinationIndex,
-    );
-    groups.push({ dateKey, hasOverlap: legs.length > 1, legs });
+  for (const r of rows.likely) {
+    touch(r.date?.slice(0, 10) ?? null, r.destinationIndex, r.destinationLabel).likely.push(r);
   }
-
-  return groups.sort((a, b) => {
-    if (a.dateKey === null) return 1;
-    if (b.dateKey === null) return -1;
-    return a.dateKey.localeCompare(b.dateKey);
-  });
+  for (const r of rows.possible) {
+    const key = r.date ? r.date.slice(0, 10) : null;
+    touch(key, r.destinationIndex, r.destinationLabel).possible.push(r);
+  }
+  return [...byDay.entries()]
+    .map(([dateKey, bandsByStop]) => ({ dateKey, bandsByStop }))
+    .sort((a, b) => {
+      if (a.dateKey === null) return 1;
+      if (b.dateKey === null) return -1;
+      return a.dateKey.localeCompare(b.dateKey);
+    });
 }
 
-export interface DestinationSection<T extends TaggedRow> {
-  destinationIndex: number;
-  destinationLabel: string | null;
-  rows: T[];
+export interface StopBucket<C, L, P> {
+  confirmed: C[];
+  likely: L[];
+  possible: P[];
 }
 
 /**
- * Partition rows by `destinationIndex` for the by-destination view.
- * Returns one section per distinct stop the rows touched,
- * position-ordered. Stops with zero rows are omitted so the UI
- * doesn't render empty columns — the caller supplies the per-stop
- * emptyState separately if it wants to render a placeholder.
+ * Partition rows by `destinationIndex` in one pass per row kind. Caller
+ * supplies stops to render (typically `results.destinations`) so the map
+ * is keyed for O(1) `.get(index)` lookup — no per-stop linear scan.
+ * Stops with zero rows have no entry in the map.
  */
-export function groupByDestination<T extends TaggedRow>(
-  rows: T[],
-): DestinationSection<T>[] {
-  const byStop = new Map<number, DestinationSection<T>>();
-  for (const row of rows) {
-    let section = byStop.get(row.destinationIndex);
-    if (!section) {
-      section = {
-        destinationIndex: row.destinationIndex,
-        destinationLabel: row.destinationLabel,
-        rows: [],
-      };
-      byStop.set(row.destinationIndex, section);
+export function bucketStops<C extends TaggedRow, L extends TaggedRow, P extends TaggedRow>(
+  rows: RowBundle<C, L, P>,
+): Map<number, StopBucket<C, L, P>> {
+  const byStop = new Map<number, StopBucket<C, L, P>>();
+  const touch = (idx: number): StopBucket<C, L, P> => {
+    let b = byStop.get(idx);
+    if (!b) {
+      b = { confirmed: [], likely: [], possible: [] };
+      byStop.set(idx, b);
     }
-    section.rows.push(row);
-  }
-  return [...byStop.values()].sort(
-    (a, b) => a.destinationIndex - b.destinationIndex,
-  );
+    return b;
+  };
+  for (const r of rows.confirmed) touch(r.destinationIndex).confirmed.push(r);
+  for (const r of rows.likely) touch(r.destinationIndex).likely.push(r);
+  for (const r of rows.possible) touch(r.destinationIndex).possible.push(r);
+  return byStop;
 }

--- a/src/lib/travel/multi-destination.ts
+++ b/src/lib/travel/multi-destination.ts
@@ -1,0 +1,116 @@
+/**
+ * Multi-destination view grouping helpers for Travel Mode results.
+ *
+ * Two views:
+ *   - Day-by-day: days as the top-level axis; overlap days split into
+ *     LEG sub-bands (one band per distinct destinationIndex).
+ *   - By-destination: stops as the top-level axis; each stop section
+ *     collects rows tagged with its index.
+ *
+ * Inputs are already tagged with `destinationIndex` by the search
+ * service. These helpers are pure (no React, no I/O).
+ */
+
+export type MultiDestView = "day-by-day" | "by-destination";
+
+interface TaggedRow {
+  destinationIndex: number;
+  destinationLabel: string | null;
+  date: string | null;
+}
+
+export interface LegBand<T extends TaggedRow> {
+  destinationIndex: number;
+  destinationLabel: string | null;
+  rows: T[];
+}
+
+export interface DayGroupWithLegs<T extends TaggedRow> {
+  /** YYYY-MM-DD or null for cadence-based (undated) rows. */
+  dateKey: string | null;
+  /** True when the day contains rows from 2+ stops — UI renders LEG sub-bands + ✈ perforation. */
+  hasOverlap: boolean;
+  /** One band per distinct `destinationIndex`, position-ordered. Length 1 on non-overlap days. */
+  legs: LegBand<T>[];
+}
+
+/**
+ * Group rows by calendar day. For each day, split rows by
+ * `destinationIndex` into leg-bands (position-ordered). A day with
+ * 2+ distinct stop indexes is marked `hasOverlap: true` so the UI
+ * can render LEG sub-bands with a ✈ perforation; single-stop days
+ * render flat.
+ *
+ * Rows with `date === null` (cadence-based possibles with no fixed
+ * date) collapse into a single `dateKey: null` group sorted last.
+ */
+export function groupByDayWithLegs<T extends TaggedRow>(rows: T[]): DayGroupWithLegs<T>[] {
+  const byDay = new Map<string | null, Map<number, LegBand<T>>>();
+
+  for (const row of rows) {
+    const dayKey = row.date ? row.date.slice(0, 10) : null;
+    let legsForDay = byDay.get(dayKey);
+    if (!legsForDay) {
+      legsForDay = new Map();
+      byDay.set(dayKey, legsForDay);
+    }
+    let band = legsForDay.get(row.destinationIndex);
+    if (!band) {
+      band = {
+        destinationIndex: row.destinationIndex,
+        destinationLabel: row.destinationLabel,
+        rows: [],
+      };
+      legsForDay.set(row.destinationIndex, band);
+    }
+    band.rows.push(row);
+  }
+
+  const groups: DayGroupWithLegs<T>[] = [];
+  for (const [dateKey, legsMap] of byDay.entries()) {
+    const legs = [...legsMap.values()].sort(
+      (a, b) => a.destinationIndex - b.destinationIndex,
+    );
+    groups.push({ dateKey, hasOverlap: legs.length > 1, legs });
+  }
+
+  return groups.sort((a, b) => {
+    if (a.dateKey === null) return 1;
+    if (b.dateKey === null) return -1;
+    return a.dateKey.localeCompare(b.dateKey);
+  });
+}
+
+export interface DestinationSection<T extends TaggedRow> {
+  destinationIndex: number;
+  destinationLabel: string | null;
+  rows: T[];
+}
+
+/**
+ * Partition rows by `destinationIndex` for the by-destination view.
+ * Returns one section per distinct stop the rows touched,
+ * position-ordered. Stops with zero rows are omitted so the UI
+ * doesn't render empty columns — the caller supplies the per-stop
+ * emptyState separately if it wants to render a placeholder.
+ */
+export function groupByDestination<T extends TaggedRow>(
+  rows: T[],
+): DestinationSection<T>[] {
+  const byStop = new Map<number, DestinationSection<T>>();
+  for (const row of rows) {
+    let section = byStop.get(row.destinationIndex);
+    if (!section) {
+      section = {
+        destinationIndex: row.destinationIndex,
+        destinationLabel: row.destinationLabel,
+        rows: [],
+      };
+      byStop.set(row.destinationIndex, section);
+    }
+    section.rows.push(row);
+  }
+  return [...byStop.values()].sort(
+    (a, b) => a.destinationIndex - b.destinationIndex,
+  );
+}


### PR DESCRIPTION
## Summary

Second of three sub-PRs for Phase 6 PR 3. **Scope: TravelResults rendering only.** Single-destination trips render identically to prod today — the new code paths only fire when `destinations.length > 1`, which nothing on the /travel page produces yet. That's intentional: the sub-PR split lands the renderer ahead of the producer, same pattern PR 3a used for SavedTripCard.

Plan: \`/Users/johnclem/.claude/plans/majestic-baking-donut.md\`

### Three-sub-PR split (recap)
- ✅ **PR 3a** (merged): `cityToIata()` + multi-leg SavedTripCard + aggregate dashboard counts.
- ➡️ **PR 3b** (this PR): multi-leg TravelResults renderer (day-by-day + by-destination views).
- **PR 3c** (next): search form ghost-leg rows + draft auto-save + `?savedTripId=` URL + TripSummary multi-stop hero. **PR 3c is what finally makes these rendering branches reachable for users.**

### Added
- `src/lib/travel/multi-destination.ts` — `groupByDayWithLegs`, `groupByDestination` helpers. Pure functions. 12 unit tests: overlap-day detection, chronological + null-date sorting, position ordering, 3-stop all-overlap, ISO-timestamp slicing, per-stop partitioning.
- `TravelResults.destinations?: SerializedDestination[]` prop + `viewMode` state. View toggle renders only when multi-stop.
- **Day-by-day renderer** (Mock 02 from the frontend-design round): days as the top-level axis. Overlap days split into LEG sub-bands separated by a hairline ✈ perforation. Non-overlap days render flat.
- **By-destination renderer** (Mock 03): one boarding-pass panel per leg (1–3 column grid). Empty legs render "No trails on this leg."
- `LegSubHeader`, `Perforation`, `DayRows` sub-components.
- `travel_multidest_view_changed` analytics event.

### Efficiency / simplify pass applied pre-PR
- Single `useMemo` hoists the day-filter to the parent; both views share filtered arrays instead of re-filtering on every toggle.
- Both views build `Map<key, band>` buckets in one pass per row kind — O(rows) bucketing + O(days×stops) render instead of N×M `.find()` lookups.
- Stripped PR-narrating comments; replaced `"???"` sentinel with `"—"`.

### Serialization (page.tsx)
- Serializes `results.destinations` (Date → ISO string) for the RSC boundary. Passed through to TravelResults.

### Codex adversarial review acknowledged
The multi-stop views are unreachable from /travel until PR 3c wires the producer (search form + draft auto-save + `?savedTripId=`). End-to-end integration test gates at PR 3c when the path becomes reachable. This is consistent with the 3-way sub-PR split.

### Single-stop regression: zero
The distance-tier render block is wrapped in `{!isMultiStop && (<>...</>)}`; all existing single-destination flows render identically.

## Test plan
- [x] `/simplify` (3 parallel review agents) — applied high + medium findings.
- [x] `/codex:adversarial-review` — flagged dead-code-until-3c concern; documented as intentional.
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all changed files
- [x] 4947 tests pass (+12 multi-destination helper tests)
- [ ] Manual Chrome post-merge: single-stop Travel Mode unchanged from main
- [ ] PR 3c: producer flow + end-to-end multi-stop test

🤖 Generated with [Claude Code](https://claude.com/claude-code)