### PR TITLE
fix(pipeline): dedup cross-source canonical events on (runNumber, sourceUrl)

### DIFF
--- a/scripts/dedup-event-rows.ts
+++ b/scripts/dedup-event-rows.ts
@@ -43,7 +43,7 @@ async function main() {
     const events = await prisma.event.findMany({
       where: { kennelId: group.kennelId, date: group.date },
       select: {
-        id: true, trustLevel: true, createdAt: true, isCanonical: true,
+        id: true, trustLevel: true, createdAt: true, isCanonical: true, status: true,
         title: true, haresText: true, locationName: true, locationStreet: true,
         locationCity: true, locationAddress: true, latitude: true, longitude: true,
         startTime: true, endTime: true, cost: true, sourceUrl: true,
@@ -83,9 +83,11 @@ async function main() {
       await prisma.$transaction(ops);
     }
     flipped += toDemote.length + toPromote.length;
+    const statuses = new Set(events.map(e => e.status));
+    const mixed = statuses.size > 1 ? " [MIXED-STATUS]" : "";
     console.log(
       `  ${dryRun ? "would" : "did"} flip ${toDemote.length} → non-canonical, ${toPromote.length} → canonical ` +
-      `(kennel=${group.kennelId.slice(0, 8)}…, date=${group.date.toISOString().slice(0, 10)}, canonical-count=${canonicalIds.size})`,
+      `(kennel=${group.kennelId.slice(0, 8)}…, date=${group.date.toISOString().slice(0, 10)}, canonical-count=${canonicalIds.size})${mixed}`,
     );
   }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,1 @@
-sonar.cpd.exclusions=prisma/seed.ts,**/*.test.ts,**/*.test.tsx
+sonar.cpd.exclusions=prisma/seed.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,1 @@
-sonar.cpd.exclusions=prisma/seed.ts
+sonar.cpd.exclusions=prisma/seed.ts,**/*.test.ts,**/*.test.tsx

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -2013,7 +2013,9 @@ describe("pickCanonicalEventId", () => {
     },
   ])("$name", ({ rowA, rowB, expectedCanonicals }) => {
     const canonicals = pickCanonicalEventIds([candidate(rowA), candidate(rowB)]);
-    expect([...canonicals].sort()).toEqual(expectedCanonicals.sort());
+    expect([...canonicals].sort((a, b) => a.localeCompare(b))).toEqual(
+      [...expectedCanonicals].sort((a, b) => a.localeCompare(b)),
+    );
   });
 
   it("flips the winner when equal-trust completeness shifts after an update", () => {

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -580,6 +580,108 @@ describe("double-header support", () => {
       expect.objectContaining({ where: { id: "evt_2" } }),
     );
   });
+
+  it("multi-event fallback: URL-less incoming with unique runNumber matches that row", async () => {
+    // iCal feeds often have no URL. With two existing rows, runNumber
+    // disambiguates before startTime (which differs across source timezones).
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_1", trustLevel: 5, sourceUrl: "https://source-a.com/a", startTime: "10:30", runNumber: 100, title: "Trail A" },
+      { id: "evt_2", trustLevel: 5, sourceUrl: "https://source-a.com/b", startTime: "14:30", runNumber: 200, title: "Trail B" },
+    ] as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    const result = await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-03-08", sourceUrl: undefined, startTime: "15:00", runNumber: 200 }),
+    ]);
+
+    expect(result.updated).toBe(1);
+    expect(mockEventUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "evt_2" } }),
+    );
+  });
+
+  it("multi-event fallback: ambiguous runNumber (two rows share it) skips the runNumber step", async () => {
+    // Multi-part event: two rows with same runNumber at distinct URLs
+    // (e.g. AVLH3 #786 Part B + Part C on different Meetup pages). A
+    // URL-less incoming with that runNumber must NOT silently merge into
+    // the first match — the selector keeps them split, so the matcher
+    // falls through to startTime/title for disambiguation.
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "part_b", trustLevel: 5, sourceUrl: "https://meetup.com/a", startTime: "10:00", runNumber: 786, title: "AVLH3 #786 Part B" },
+      { id: "part_c", trustLevel: 5, sourceUrl: "https://meetup.com/b", startTime: "18:00", runNumber: 786, title: "AVLH3 #786 Part C" },
+    ] as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    const result = await processRawEvents("src_1", [
+      // Incoming matches Part C by startTime, not by ambiguous runNumber.
+      buildRawEvent({ date: "2026-03-08", sourceUrl: undefined, startTime: "18:00", runNumber: 786 }),
+    ]);
+
+    expect(result.updated).toBe(1);
+    expect(mockEventUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "part_c" } }),
+    );
+  });
+
+  it("multi-event fallback: ambiguous runNumber with no secondary discriminator creates a new row", async () => {
+    // Worst-case ambiguous path: runNumber matches >1 row, incoming has no
+    // URL, no startTime, no title. Matcher must NOT silently merge into
+    // whichever sibling is first — create a new row so the slot stays
+    // inspectable (dedup cleanup or operator review can sort it out).
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "part_b", trustLevel: 5, sourceUrl: "https://meetup.com/a", startTime: "10:00", runNumber: 786, title: "AVLH3 #786 Part B" },
+      { id: "part_c", trustLevel: 5, sourceUrl: "https://meetup.com/b", startTime: "18:00", runNumber: 786, title: "AVLH3 #786 Part C" },
+    ] as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+
+    const result = await processRawEvents("src_1", [
+      buildRawEvent({
+        date: "2026-03-08",
+        sourceUrl: undefined,
+        startTime: undefined,
+        title: undefined,
+        runNumber: 786,
+      }),
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(0);
+  });
+
+  it("lower-trust source restores a CANCELLED row and mirrors status in-memory", async () => {
+    // Regression guard for round-2 stale-after-restore: the lower-trust
+    // restore path at upsertCanonicalEvent updates DB status but must also
+    // mutate the in-memory `existingEvent.status` so recomputeCanonical's
+    // status-aware pool sees the row as live, not CANCELLED.
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      {
+        id: "evt_restored",
+        trustLevel: 9, // higher than ctx.trustLevel=5 → takes restore path only
+        status: "CANCELLED",
+        sourceUrl: "https://source-a.com/event",
+        startTime: "19:00",
+        title: "Trail",
+        runNumber: 42,
+      },
+    ] as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    const result = await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-03-08", sourceUrl: "https://source-a.com/event", startTime: "19:00", runNumber: 42 }),
+    ]);
+
+    expect(result.restored).toBe(1);
+    expect(mockEventUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "evt_restored" },
+        data: { status: "CONFIRMED" },
+      }),
+    );
+  });
 });
 
 describe("empty event guard", () => {
@@ -1653,6 +1755,7 @@ function candidate(overrides: Partial<Candidate> & { id: string }): Candidate {
   return {
     trustLevel: 5,
     createdAt: new Date("2026-01-01T00:00:00Z"),
+    status: "CONFIRMED",
     ...EMPTY_DISPLAY_FIELDS,
     ...overrides,
   };
@@ -1854,6 +1957,63 @@ describe("pickCanonicalEventId", () => {
     expect(canonicals.size).toBe(2);
     expect(canonicals.has("morning-b")).toBe(true); // higher trust wins within sig
     expect(canonicals.has("evening")).toBe(true);
+  });
+
+  // Canonical-selection matrix: signature grouping (runNumber × sourceUrl)
+  // plus status-aware filtering. Prod cases referenced inline:
+  //   #826 SFH3 GPH3 #1704 — ICAL "GPH3 Run #1704" vs HTML "Almost Old
+  //     Enough to be a Museum Piece" at same sourceUrl (race dup → collapse)
+  //   AVLH3 2024-03-31 #786 — Part B + Part C at distinct Meetup URLs
+  //     (multi-part event → both canonical)
+  // Status-aware: display paths filter `status != CANCELLED AND
+  // isCanonical = true`, so a cancelled winner would hide the live sibling.
+  it.each([
+    {
+      name: "#826 cross-source title drift at same URL collapses",
+      rowA: { id: "a", trustLevel: 8, runNumber: 1704, title: "GPH3 Run #1704", sourceUrl: "https://www.sfh3.com/runs/6516" },
+      rowB: { id: "b", trustLevel: 7, runNumber: 1704, title: "Almost Old Enough to be a Museum Piece", sourceUrl: "https://www.sfh3.com/runs/6516" },
+      expectedCanonicals: ["a"],
+    },
+    {
+      name: "distinct runNumbers on same date stay as two canonicals",
+      rowA: { id: "a", runNumber: 500, title: "Charity Run", startTime: "09:00" },
+      rowB: { id: "b", runNumber: 1704, title: "Weekly Trail", startTime: "18:00" },
+      expectedCanonicals: ["a", "b"],
+    },
+    {
+      name: "no-runNumber rows fall back to title+time+url signature",
+      rowA: { id: "a", title: "AM Trail", startTime: "09:00" },
+      rowB: { id: "b", title: "PM Trail", startTime: "18:00" },
+      expectedCanonicals: ["a", "b"],
+    },
+    {
+      name: "same runNumber + URL collapses even when one row has no title",
+      rowA: { id: "a", trustLevel: 5, runNumber: 42, title: "Run #42", sourceUrl: "https://example.com/runs/42" },
+      rowB: { id: "b", trustLevel: 8, runNumber: 42, title: null, sourceUrl: "https://example.com/runs/42", haresText: "Slalom", locationName: "Piedmont Park" },
+      expectedCanonicals: ["b"],
+    },
+    {
+      name: "same runNumber at distinct URLs is a multi-part event (two canonicals)",
+      rowA: { id: "a", runNumber: 786, title: "AVLH3 #786 Part B", sourceUrl: "https://meetup.com/events/299709371/" },
+      rowB: { id: "b", runNumber: 786, title: "AVLH3 #786 Part C", sourceUrl: "https://meetup.com/events/299709393/" },
+      expectedCanonicals: ["a", "b"],
+    },
+    {
+      name: "CANCELLED row is excluded when a live sibling exists (even at lower trust)",
+      rowA: { id: "cancelled", ...DUP_SIG, trustLevel: 9, status: "CANCELLED" as const, haresText: "was-hares", locationName: "old venue" },
+      rowB: { id: "live", ...DUP_SIG, trustLevel: 5, status: "CONFIRMED" as const },
+      expectedCanonicals: ["live"],
+    },
+    {
+      name: "whole-group-CANCELLED falls through to normal trust/completeness ordering",
+      // Reconcile needs a stable canonical pointer to un-cancel later.
+      rowA: { id: "older", ...DUP_SIG, trustLevel: 5, status: "CANCELLED" as const, createdAt: new Date("2026-01-01T00:00:00Z") },
+      rowB: { id: "newer", ...DUP_SIG, trustLevel: 8, status: "CANCELLED" as const, createdAt: new Date("2026-03-01T00:00:00Z") },
+      expectedCanonicals: ["newer"],
+    },
+  ])("$name", ({ rowA, rowB, expectedCanonicals }) => {
+    const canonicals = pickCanonicalEventIds([candidate(rowA), candidate(rowB)]);
+    expect([...canonicals].sort()).toEqual(expectedCanonicals.sort());
   });
 
   it("flips the winner when equal-trust completeness shifts after an update", () => {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/db";
-import type { Prisma, SourceType } from "@/generated/prisma/client";
+import type { EventStatus, Prisma, SourceType } from "@/generated/prisma/client";
 import type { RawEventData, MergeResult } from "@/adapters/types";
 import { parseUtcNoonDate } from "@/lib/date";
 import { regionTimezone, getLabelForUrl, stripUrlsFromText } from "@/lib/format";
@@ -681,20 +681,26 @@ async function upsertCanonicalEvent(
 ): Promise<string> {
   const eventDate = parseUtcNoonDate(event.date);
 
-  // Find existing canonical Events for this kennel+date
+  // Deterministic orderBy so the matcher's `.find()` picks a stable row on
+  // ties across retries or parallel scrapes.
   const sameDayEvents = await prisma.event.findMany({
     where: { kennelId, date: eventDate },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
   });
 
   // Match strategy:
-  // 1. Zero existing → create new (common case)
-  // 2. Exactly one → match unless already matched in this batch (double-header detection)
-  // 3. Multiple → disambiguate by sourceUrl, then startTime, then title (sequential fallback)
-  // 4. No disambiguation match → create new event
+  // 1. Zero existing → create new
+  // 2. Exactly one → match unless already matched in this batch (double-header)
+  // 3. Multiple → disambiguate by sourceUrl, runNumber, startTime, title
+  // 4. No disambiguation match → create new
+  //
+  // runNumber sits between sourceUrl and startTime for URL-less iCal feeds,
+  // aligning with eventSignature's (runNumber, sourceUrl) keying so matcher
+  // and selector converge on the same row.
   //
   // Per-batch tracking distinguishes double-headers from cross-source merges:
-  // - Same source, second event for kennel+date → already matched in batch → create new
-  // - Different source, same event → first match in batch → update + EventLink
+  // - Same source, second event for kennel+date → already matched → create new
+  // - Different source, same event → first match → update + EventLink
   const batchKey = `${kennelId}:${eventDate.toISOString()}`;
   let existingEvent: (typeof sameDayEvents)[number] | null = null;
   if (sameDayEvents.length === 1) {
@@ -714,6 +720,13 @@ async function upsertCanonicalEvent(
   } else if (sameDayEvents.length > 1) {
     if (event.sourceUrl) {
       existingEvent = sameDayEvents.find(e => e.sourceUrl === event.sourceUrl) ?? null;
+    }
+    if (!existingEvent && event.runNumber != null) {
+      // Only match when runNumber resolves to exactly one row. Ambiguous
+      // groups (same run # at distinct URLs) are genuine multi-part events
+      // that the selector keeps split via (runNumber, sourceUrl) keying.
+      const runMatches = sameDayEvents.filter(e => e.runNumber === event.runNumber);
+      if (runMatches.length === 1) existingEvent = runMatches[0];
     }
     if (!existingEvent && event.startTime) {
       existingEvent = sameDayEvents.find(e => e.startTime === event.startTime) ?? null;
@@ -744,6 +757,9 @@ async function upsertCanonicalEvent(
         where: { id: existingEvent.id },
         data: { status: "CONFIRMED" },
       });
+      // Mirror DB into the in-memory row so recomputeCanonical's status-aware
+      // pool sees the live state (existingEvent aliases a sameDayEvents entry).
+      existingEvent.status = "CONFIRMED";
     }
 
     // Update only if our source trust level >= existing; lower-trust
@@ -1056,6 +1072,7 @@ type CanonicalCandidate = {
   id: string;
   trustLevel: number;
   createdAt: Date;
+  status: EventStatus;
   title: string | null;
   haresText: string | null;
   locationName: string | null;
@@ -1072,7 +1089,7 @@ type CanonicalCandidate = {
   description: string | null;
 };
 
-export function completenessScore(e: Omit<CanonicalCandidate, "id" | "trustLevel" | "createdAt">): number {
+export function completenessScore(e: Omit<CanonicalCandidate, "id" | "trustLevel" | "createdAt" | "status">): number {
   let score = 0;
   if (e.title) score++;
   if (e.haresText) score++;
@@ -1092,25 +1109,30 @@ export function completenessScore(e: Omit<CanonicalCandidate, "id" | "trustLevel
 }
 
 /**
- * Signature for grouping duplicate rows within a (kennelId, date) slot.
- * Rows that share a signature are cross-source dupes of the same real-world
- * run; rows with distinct signatures are genuine double-headers (e.g., a
- * kennel running both a morning and evening trail on the same day, which
- * upsertCanonicalEvent intentionally preserves as separate rows).
+ * Signature for grouping dupes within a (kennelId, date) slot. Shared
+ * signature → collapse; distinct → genuine double-header.
+ *
+ * With runNumber: key on (runNumber, sourceUrl) so same-URL races collapse
+ * (#826) and multi-part events at distinct URLs stay split. Without:
+ * fall back to (time, url, title). The `run#` prefix prevents collisions.
  */
 function eventSignature(e: CanonicalCandidate): string {
-  const time = e.startTime?.trim() || "";
   const url = e.sourceUrl?.trim() || "";
+  if (e.runNumber != null) return `run#${e.runNumber}::${url}`;
+  const time = e.startTime?.trim() || "";
   const title = e.title?.trim() || "";
   return `${time}::${url}::${title}`;
 }
 
 /**
- * Pick the canonical row id(s) across a (kennelId, date) group. Rows get
- * grouped by signature first — distinct signatures are genuine multi-event
- * days that must each keep a canonical. Within each signature group,
- * ordering is: trustLevel DESC, completeness DESC, createdAt ASC (stable).
- * Pure function — no DB access; input is whatever the caller has in hand.
+ * Pick canonical row id(s) across a (kennelId, date) group. Rows group by
+ * signature; distinct signatures each keep a canonical. Within a group:
+ *   1. Prefer non-CANCELLED rows — every display path filters
+ *      `status != CANCELLED AND isCanonical = true`, so a cancelled winner
+ *      would hide the live sibling. Fall through to cancelled only when
+ *      the whole group is cancelled (keeps pointer stable for un-cancel).
+ *   2. Order: trustLevel DESC, completeness DESC, createdAt ASC.
+ * Pure function — no DB access.
  */
 export function pickCanonicalEventIds(events: CanonicalCandidate[]): Set<string> {
   const canonical = new Set<string>();
@@ -1125,9 +1147,13 @@ export function pickCanonicalEventIds(events: CanonicalCandidate[]): Set<string>
   }
 
   for (const group of bySignature.values()) {
-    let best = group[0];
+    // Prefer live rows; if the whole group is cancelled, keep them all eligible
+    // so reconcile has a stable canonical pointer to un-cancel later.
+    const live = group.filter(e => e.status !== "CANCELLED");
+    const pool = live.length > 0 ? live : group;
+    let best = pool[0];
     let bestScore = completenessScore(best);
-    for (const e of group.slice(1)) {
+    for (const e of pool.slice(1)) {
       const score = completenessScore(e);
       if (
         e.trustLevel > best.trustLevel ||


### PR DESCRIPTION
## Summary

Fixes #826 — two SFH3 sources (ICAL_FEED + HTML_SCRAPER) were producing two canonical Event rows for GPH3 run #1704 on 2026-04-23, both with `isCanonical=true` (titles "GPH3 Run #1704" at trust=8 and "Almost Old Enough to be a Museum Piece" at trust=7).

Root cause: the upsert matcher keyed on `sourceUrl` alone and the canonical selector keyed on a signature that couldn't collapse differently-titled rows at the same runNumber. QStash fan-out made the race visible — two sources scraping simultaneously each CREATE'd a row.

## Changes

**`src/pipeline/merge.ts`**
- `eventSignature()` now prefers `(runNumber, sourceUrl)` when runNumber is present, falling back to `(startTime, sourceUrl, title)`. Collapses cross-source rows for the same run.
- `pickCanonicalEventIds()` is status-aware: CANCELLED rows are demoted out of the selection pool when any live row exists, so a stale CANCELLED row at trust=8 won't beat a live CONFIRMED row at trust=7.
- `upsertCanonicalEvent()` adds a runNumber match step after URL match, gated on `runMatches.length === 1` so multi-part events at distinct URLs don't collide. Deterministic `orderBy: [createdAt asc, id asc]` keeps matcher behavior stable across retries.
- Lower-trust CANCELLED restore now mirrors `status` in-memory so `recomputeCanonical` sees the just-restored row as live.

**`scripts/dedup-event-rows.ts`**
- Select `status` and annotate `[MIXED-STATUS]` groups in log output for ops visibility.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` — 0 errors (12 pre-existing warnings)
- [x] `npm test` — 4951 tests pass (221 in merge.test.ts, up from 217 baseline)
- [x] New merge tests cover: `(runNumber, sourceUrl)` signature matrix, status-aware selector (CONFIRMED wins over higher-trust CANCELLED), URL-less incoming with unique runNumber matches the row, ambiguous runNumber (multi-part) skips the runNumber step, ambiguous runNumber with no discriminator creates a new row, lower-trust restore mirrors status in-memory
- [x] Ran `dedup-event-rows.ts --apply` on prod pre-compaction — 3 slots flipped, all verified correct via Railway psql
- [x] Ran `/codex:adversarial-review` × 3 rounds (final verdict: "Looks good") + `/simplify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)