### PR TITLE
feat(travel): Phase 6 PR 3c.1 — draft server actions + ?savedTripId= render path

### DIFF
--- a/src/app/travel/actions.test.ts
+++ b/src/app/travel/actions.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/lib/db", () => {
     findFirst: vi.fn(),
     findMany: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
   };
   const travelDestination = {
     deleteMany: vi.fn(),
@@ -54,6 +55,8 @@ import {
   updateTravelSearch,
   deleteTravelSearch,
   restoreTravelSearch,
+  saveDraftSearch,
+  updateDraftSearch,
   findExistingSavedSearch,
   listSavedSearches,
   viewTravelSearch,
@@ -784,6 +787,162 @@ describe("resolveDestinationTimezone", () => {
       expect("error" in result && result.error).toBe("Time Zone API not configured");
     } finally {
       if (originalKey) process.env.GOOGLE_CALENDAR_API_KEY = originalKey;
+    }
+  });
+});
+
+describe("saveDraftSearch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates a DRAFT TravelSearch + destinations", async () => {
+    vi.mocked(prisma.travelSearch.create).mockResolvedValue({
+      id: "draft-1",
+      userId: "user-1",
+      name: "Atlanta, GA · Apr 14–21",
+      status: "DRAFT",
+      lastViewedAt: null,
+      itinerarySignature: "sig-abc",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    vi.mocked(prisma.travelDestination.createMany).mockResolvedValue({ count: 1 } as never);
+
+    const result = await saveDraftSearch(validParams);
+
+    expect("success" in result).toBe(true);
+    expect("id" in result && result.id).toBe("draft-1");
+
+    expect(prisma.travelSearch.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-1",
+          status: "DRAFT",
+          itinerarySignature: expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it("does NOT dedup — two drafts with the same itinerary coexist", async () => {
+    vi.mocked(prisma.travelSearch.create)
+      .mockResolvedValueOnce({ id: "draft-a" } as never)
+      .mockResolvedValueOnce({ id: "draft-b" } as never);
+    vi.mocked(prisma.travelDestination.createMany).mockResolvedValue({ count: 1 } as never);
+
+    const first = await saveDraftSearch(validParams);
+    const second = await saveDraftSearch(validParams);
+
+    expect("id" in first && first.id).toBe("draft-a");
+    expect("id" in second && second.id).toBe("draft-b");
+    expect(prisma.travelSearch.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid params (>3 stops, out-of-range radius, etc.)", async () => {
+    const result = await saveDraftSearch({
+      destinations: [validParams, validParams, validParams, validParams],
+    });
+    expect("error" in result && result.error).toMatch(/at most/i);
+  });
+
+  it("requires authentication", async () => {
+    vi.mocked(getOrCreateUser).mockResolvedValueOnce(null as never);
+    const result = await saveDraftSearch(validParams);
+    expect("error" in result && result.error).toBe("Not authenticated");
+  });
+
+  it("writes DRAFT child rows — not ACTIVE — to preserve the parent/child status invariant", async () => {
+    vi.mocked(prisma.travelSearch.create).mockResolvedValue({ id: "draft-2" } as never);
+    vi.mocked(prisma.travelDestination.createMany).mockResolvedValue({ count: 1 } as never);
+
+    await saveDraftSearch(validParams);
+
+    const createCall = vi.mocked(prisma.travelDestination.createMany).mock.calls[0][0];
+    const rows = (createCall as { data: Array<{ status: string }> }).data;
+    for (const row of rows) {
+      expect(row.status).toBe("DRAFT");
+    }
+  });
+});
+
+describe("updateDraftSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: composite where-clause matches (row exists, owned, still DRAFT).
+    vi.mocked(prisma.travelSearch.updateMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(prisma.travelDestination.deleteMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(prisma.travelDestination.createMany).mockResolvedValue({ count: 2 } as never);
+  });
+
+  it("updateMany payload never includes status — stays DRAFT", async () => {
+    const result = await updateDraftSearch("draft-1", {
+      destinations: [validParams, validParams],
+    });
+
+    expect("id" in result && result.id).toBe("draft-1");
+    const call = vi.mocked(prisma.travelSearch.updateMany).mock.calls[0][0];
+    expect(call.data).not.toHaveProperty("status");
+    // The where clause enforces the tx-scoped guard.
+    expect(call.where).toMatchObject({ id: "draft-1", userId: "user-1", status: "DRAFT" });
+  });
+
+  it("refuses to mutate non-DRAFT trips", async () => {
+    // Guard didn't match. Post-hoc read shows the row is ACTIVE.
+    vi.mocked(prisma.travelSearch.updateMany).mockResolvedValue({ count: 0 } as never);
+    vi.mocked(prisma.travelSearch.findUnique).mockResolvedValue({
+      userId: "user-1",
+      status: "ACTIVE",
+    } as never);
+
+    const result = await updateDraftSearch("active-1", validParams);
+    expect("error" in result && result.error).toBe("Search is not a draft");
+    expect(prisma.travelDestination.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("refuses to mutate another user's draft", async () => {
+    vi.mocked(prisma.travelSearch.updateMany).mockResolvedValue({ count: 0 } as never);
+    vi.mocked(prisma.travelSearch.findUnique).mockResolvedValue({
+      userId: "someone-else",
+      status: "DRAFT",
+    } as never);
+
+    const result = await updateDraftSearch("draft-1", validParams);
+    expect("error" in result && result.error).toBe("Not authorized");
+  });
+
+  it("returns Draft not found when id doesn't exist", async () => {
+    vi.mocked(prisma.travelSearch.updateMany).mockResolvedValue({ count: 0 } as never);
+    vi.mocked(prisma.travelSearch.findUnique).mockResolvedValue(null as never);
+
+    const result = await updateDraftSearch("ghost", validParams);
+    expect("error" in result && result.error).toBe("Draft not found");
+  });
+
+  it("rolls back when a concurrent archive races between the initial guard and the final recheck", async () => {
+    // First updateMany (initial guard) passes. The delete+create run.
+    // Then the final updateMany (tail recheck) returns count=0 — the
+    // parent was archived mid-flight. Expected: the whole tx throws,
+    // surfaces as Search is not a draft.
+    vi.mocked(prisma.travelSearch.updateMany)
+      .mockResolvedValueOnce({ count: 1 } as never)  // initial guard OK
+      .mockResolvedValueOnce({ count: 0 } as never); // tail recheck fails
+    vi.mocked(prisma.travelSearch.findUnique).mockResolvedValue({
+      userId: "user-1",
+      status: "ARCHIVED",
+    } as never);
+
+    const result = await updateDraftSearch("draft-1", validParams);
+    expect("error" in result && result.error).toBe("Search is not a draft");
+  });
+
+  it("writes DRAFT child rows on successful update (preserves parent/child invariant)", async () => {
+    vi.mocked(prisma.travelSearch.updateMany).mockResolvedValue({ count: 1 } as never);
+
+    await updateDraftSearch("draft-1", validParams);
+
+    const createCall = vi.mocked(prisma.travelDestination.createMany).mock.calls[0][0];
+    const rows = (createCall as { data: Array<{ status: string }> }).data;
+    for (const row of rows) {
+      expect(row.status).toBe("DRAFT");
     }
   });
 });

--- a/src/app/travel/actions.ts
+++ b/src/app/travel/actions.ts
@@ -391,6 +391,121 @@ export async function restoreTravelSearch(
 }
 
 // ============================================================================
+// saveDraftSearch / updateDraftSearch
+// ============================================================================
+
+/**
+ * Create a DRAFT TravelSearch. Drafts are exempt from the ACTIVE
+ * dedup partial-unique (the index filters `WHERE status='ACTIVE'`)
+ * so two drafts with the same itinerary can coexist. Signature is
+ * populated so a later promotion to ACTIVE reuses the shared dedup.
+ */
+export async function saveDraftSearch(
+  params: SaveTravelSearchParams,
+): Promise<ActionResult<{ id: string }>> {
+  const user = await getOrCreateUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const stops = normalizeDestinations(params);
+  const validation = validateSearchParams(stops);
+  if (validation) return { error: validation };
+
+  const signature = computeItinerarySignature(stops);
+  const name = formatItineraryName(stops);
+
+  const search = await prisma.$transaction(async (tx) => {
+    const created = await tx.travelSearch.create({
+      data: {
+        userId: user.id,
+        name,
+        status: TravelSearchStatus.DRAFT,
+        itinerarySignature: signature,
+      },
+    });
+    await tx.travelDestination.createMany({
+      data: stops.map((stop, i) =>
+        buildDestinationData(created.id, user.id, stop, i, TravelSearchStatus.DRAFT),
+      ),
+    });
+    return created;
+  });
+
+  return { success: true, id: search.id };
+}
+
+/**
+ * Mutate an existing DRAFT in-place. Fails if the id is not the
+ * caller's own draft. An ACTIVE trip mutates via `updateTravelSearch`
+ * instead, which enforces the partial-unique dedup.
+ */
+export async function updateDraftSearch(
+  id: string,
+  params: SaveTravelSearchParams,
+): Promise<ActionResult<{ id: string }>> {
+  const user = await getOrCreateUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const stops = normalizeDestinations(params);
+  const validation = validateSearchParams(stops);
+  if (validation) return { error: validation };
+
+  const signature = computeItinerarySignature(stops);
+  const name = formatItineraryName(stops);
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Tx-scoped ownership + status guard. `updateMany` with a composite
+      // where atomically asserts "still DRAFT, still owned by this user".
+      const guarded = await tx.travelSearch.updateMany({
+        where: { id, userId: user.id, status: TravelSearchStatus.DRAFT },
+        data: { name, itinerarySignature: signature },
+      });
+      if (guarded.count === 0) {
+        throw new DraftGuardError();
+      }
+      await tx.travelDestination.deleteMany({
+        where: { travelSearchId: id, userId: user.id },
+      });
+      await tx.travelDestination.createMany({
+        data: stops.map((stop, i) =>
+          buildDestinationData(id, user.id, stop, i, TravelSearchStatus.DRAFT),
+        ),
+      });
+      // Re-assert at the tail of the tx. A concurrent deleteTravelSearch
+      // could archive the parent between the initial guard and this
+      // createMany — without the recheck we'd end up with an ARCHIVED
+      // parent holding freshly-created DRAFT children.
+      const stillDraft = await tx.travelSearch.updateMany({
+        where: { id, userId: user.id, status: TravelSearchStatus.DRAFT },
+        data: { updatedAt: new Date() },
+      });
+      if (stillDraft.count === 0) {
+        throw new DraftGuardError();
+      }
+    });
+  } catch (err) {
+    if (err instanceof DraftGuardError) {
+      const row = await prisma.travelSearch.findUnique({
+        where: { id },
+        select: { userId: true, status: true },
+      });
+      if (!row) return { error: "Draft not found" };
+      if (row.userId !== user.id) return { error: "Not authorized" };
+      return { error: "Search is not a draft" };
+    }
+    throw err;
+  }
+
+  return { success: true, id };
+}
+
+/** Sentinel thrown from inside the updateDraftSearch tx when the
+ *  composite where-clause didn't match. Lets the caller disambiguate
+ *  the three distinct failure modes (missing / not-owner / not-draft)
+ *  via a single post-hoc read outside the tx. */
+class DraftGuardError extends Error {}
+
+// ============================================================================
 // listSavedSearches
 // ============================================================================
 
@@ -790,12 +905,18 @@ function buildDestinationData(
   userId: string,
   stop: SaveDestinationParams,
   position: number,
+  // Child status must mirror the parent's status: DRAFT parent → DRAFT
+  // children, ACTIVE parent → ACTIVE children. Codex flagged the prior
+  // hardcoded ACTIVE as a shortcut that let DRAFT parents hold ACTIVE
+  // children, breaking the parent/child invariant the rest of the
+  // reader path (and the partial-unique dedup) relies on.
+  status: TravelSearchStatus = TravelSearchStatus.ACTIVE,
 ) {
   return {
     travelSearchId,
     userId,
     position,
-    status: TravelSearchStatus.ACTIVE,
+    status,
     label: stop.label,
     placeId: stop.placeId ?? null,
     latitude: stop.latitude,

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -531,21 +531,40 @@ async function SavedTripPage({
     );
   }
 
+  const isMultiStop = search.destinations.length > 1;
+  // Mirror TravelResultsServer's branch: when the primary radius came
+  // back empty (no_nearby), `selectResultsToRender` swaps in the broader
+  // arrays so single-stop saved trips still render meaningful results.
+  // Multi-stop saved trips already have broader merged into the flat
+  // arrays by `serializeTravelResults({ mergeBroader: true })`, so the
+  // swap is a no-op and we pass serializedResults through.
+  const resultsToRender = isMultiStop
+    ? serializedResults
+    : selectResultsToRender(serializedResults.emptyState, serializedResults);
+
   return (
     <div className="mx-auto max-w-6xl px-4 py-6">
       <header className="mb-6 border-b border-border pb-4">
         <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-red-600 dark:text-red-400">
-          ◆ Itinerary · {search.destinations.length} legs
+          ◆ Itinerary · {search.destinations.length} leg{search.destinations.length !== 1 ? "s" : ""}
         </p>
         <h1 className="mt-1 font-display text-3xl font-medium tracking-tight">
           {search.name ?? "Trip"}
         </h1>
       </header>
-      <TravelResults
-        destination={search.name ?? ""}
-        results={serializedResults}
-        destinations={serializedResults.destinations}
-      />
+      {serializedResults.emptyState !== "none" && (
+        <EmptyStates
+          variant={serializedResults.emptyState}
+          broaderRadiusKm={serializedResults.destinations[0]?.broaderRadiusKm}
+        />
+      )}
+      {resultsToRender && (
+        <TravelResults
+          destination={search.name ?? ""}
+          results={resultsToRender}
+          destinations={serializedResults.destinations}
+        />
+      )}
     </div>
   );
 }
@@ -573,5 +592,7 @@ async function buildSavedTripResults(args: {
     args.user,
     allConfirmed.map((r) => r.eventId),
   );
-  return serializeTravelResults(results, attendanceMap, { mergeBroader: true });
+  return serializeTravelResults(results, attendanceMap, {
+    mergeBroader: args.destinations.length > 1,
+  });
 }

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -2,10 +2,17 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/db";
+import { TravelSearchStatus } from "@/generated/prisma/client";
 import { getOrCreateUser } from "@/lib/auth";
 import { executeTravelSearch } from "@/lib/travel/search";
 import { findExistingSavedSearch } from "@/app/travel/actions";
 import { MAX_RADIUS_KM, snapRadiusToTier } from "@/lib/travel/limits";
+import { utcYmd } from "@/lib/travel/url";
+import {
+  serializeTravelResults,
+  type AttendanceMap,
+  type SerializedTravelResults,
+} from "@/lib/travel/serialize";
 import { TravelSearchForm } from "@/components/travel/TravelSearchForm";
 import { TravelResults } from "@/components/travel/TravelResults";
 import { TravelResultsSkeleton } from "@/components/travel/TravelResultsSkeleton";
@@ -53,6 +60,11 @@ export async function generateMetadata({
 
 export default async function TravelPage({ searchParams }: TravelPageProps) {
   const params = await searchParams;
+
+  const savedTripId = getParam(params, "savedTripId");
+  if (savedTripId) {
+    return <SavedTripPage savedTripId={savedTripId} filterParams={params} />;
+  }
 
   const lat = getParam(params, "lat");
   const lng = getParam(params, "lng");
@@ -212,81 +224,26 @@ async function TravelResultsServer({
 
     const isMultiStop = results.destinations.length > 1;
 
-    // Multi-stop: every stop's broader pass rows need to reach the
-    // attendance map + serialized arrays. Single-stop's broader is
-    // already captured via `broaderResults` (== destinations[0].broaderResults).
-    const allBroaderConfirmed = isMultiStop
-      ? results.destinations.flatMap((d) => d.broaderResults?.confirmed ?? [])
-      : (broaderResults?.confirmed ?? []);
-    const allBroaderLikely = isMultiStop
-      ? results.destinations.flatMap((d) => d.broaderResults?.likely ?? [])
-      : (broaderResults?.likely ?? []);
-    const allBroaderPossible = isMultiStop
-      ? results.destinations.flatMap((d) => d.broaderResults?.possible ?? [])
-      : (broaderResults?.possible ?? []);
+    // Build the attendance map from every eventId the renderer might show —
+    // multi-stop surfaces all stops' broader via the merged arrays;
+    // single-stop uses destinations[0].broaderResults only.
+    const eventIds = isMultiStop
+      ? [
+          ...results.confirmed.map((r) => r.eventId),
+          ...results.destinations.flatMap((d) =>
+            (d.broaderResults?.confirmed ?? []).map((r) => r.eventId),
+          ),
+        ]
+      : [
+          ...results.confirmed.map((r) => r.eventId),
+          ...(broaderResults?.confirmed ?? []).map((r) => r.eventId),
+        ];
 
-    const confirmedEventIds = [
-      ...results.confirmed,
-      ...allBroaderConfirmed,
-    ].map((r) => r.eventId);
+    const attendanceMap = await loadAttendanceMap(user, eventIds);
 
-    const attendanceMap = await loadAttendanceMap(user, confirmedEventIds);
-
-    // Serialize Date objects for client components. Explicit field list
-    // (rather than `...results`) so the multi-destination `destinations`
-    // array's Date fields don't silently cross the RSC boundary unserialized.
-    const serializedResults = {
-      emptyState: results.emptyState,
-      meta: results.meta,
-      // Per-stop metadata. Dates toISOString so the RSC boundary
-      // serializes cleanly.
-      destinations: results.destinations.map((d) => ({
-        index: d.index,
-        label: d.label,
-        startDate: d.startDate.toISOString(),
-        endDate: d.endDate.toISOString(),
-        radiusKm: d.radiusKm,
-        broaderRadiusKm: d.broaderRadiusKm,
-      })),
-      // Multi-stop: merge every stop's broader rows into the top-level
-      // flat arrays so the multi-destination renderer (which iterates
-      // the flat set tagged by destinationIndex) sees both primary and
-      // broader results across ALL stops. Single-stop keeps today's
-      // behavior — broader rows flow through `broaderResults` below and
-      // `selectResultsToRender` swaps them in on `no_nearby`.
-      confirmed: [...results.confirmed, ...(isMultiStop ? allBroaderConfirmed : [])].map((r) => ({
-        ...r,
-        date: r.date.toISOString(),
-        attendance: attendanceMap[r.eventId] ?? null,
-      })),
-      likely: [...results.likely, ...(isMultiStop ? allBroaderLikely : [])].map((r) => ({
-        ...r,
-        date: r.date.toISOString(),
-      })),
-      possible: [...results.possible, ...(isMultiStop ? allBroaderPossible : [])].map((r) => ({
-        ...r,
-        date: r.date?.toISOString() ?? null,
-        lastConfirmedAt: r.lastConfirmedAt?.toISOString() ?? null,
-      })),
-      broaderResults: broaderResults
-        ? {
-            confirmed: broaderResults.confirmed.map((r) => ({
-              ...r,
-              date: r.date.toISOString(),
-              attendance: attendanceMap[r.eventId] ?? null,
-            })),
-            likely: broaderResults.likely.map((r) => ({
-              ...r,
-              date: r.date.toISOString(),
-            })),
-            possible: broaderResults.possible.map((r) => ({
-              ...r,
-              date: r.date?.toISOString() ?? null,
-              lastConfirmedAt: r.lastConfirmedAt?.toISOString() ?? null,
-            })),
-          }
-        : undefined,
-    };
+    const serializedResults = serializeTravelResults(results, attendanceMap, {
+      mergeBroader: isMultiStop,
+    });
 
     // Events exposed to TripSummary for Export Calendar .ics generation.
     // Use broaderResults when the primary radius came up empty — mirrors
@@ -496,4 +453,125 @@ function selectResultsToRender<T extends {
     };
   }
   return null;
+}
+
+/**
+ * Server component for `/travel?savedTripId=<id>`. Fetches the saved
+ * trip (DRAFT or ACTIVE), runs executeTravelSearch across all its
+ * destinations, and renders the multi-stop TravelResults branch. Only
+ * the owner can access — ownership is enforced server-side, and
+ * non-owners see a 404-style empty state.
+ *
+ * This is the URL-authoritative entry point for multi-stop trips
+ * (sharing + bookmarking round-trip cleanly). Single-stop trips
+ * continue to use the stateless `?q=&lat=&lng=&from=&to=&r=` shape.
+ */
+async function SavedTripPage({
+  savedTripId,
+  filterParams,
+}: {
+  savedTripId: string;
+  filterParams: SearchParamsRecord;
+}) {
+  const user = await getOrCreateUser().catch(() => null);
+  if (!user) {
+    return <EmptyStates variant="error" />;
+  }
+
+  const search = await prisma.travelSearch.findUnique({
+    where: { id: savedTripId },
+    include: {
+      // Destinations carry the same status as their parent (invariant
+      // enforced at save/update time). We've already rejected ARCHIVED
+      // parents above, so any surviving destinations are DRAFT or ACTIVE
+      // and belong to the rendered trip.
+      destinations: { orderBy: { position: "asc" } },
+    },
+  });
+
+  // Ownership check + reject ARCHIVED; DRAFT and ACTIVE both resolve.
+  if (
+    !search ||
+    search.userId !== user.id ||
+    search.status === TravelSearchStatus.ARCHIVED ||
+    search.destinations.length === 0
+  ) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <EmptyStates variant="error" />
+      </div>
+    );
+  }
+
+  const { confidenceFilter, distanceFilter } = parseFilterParams(filterParams);
+  const destinations = search.destinations.map((d) => ({
+    latitude: d.latitude,
+    longitude: d.longitude,
+    radiusKm: d.radiusKm,
+    startDate: utcYmd(d.startDate),
+    endDate: utcYmd(d.endDate),
+    timezone: d.timezone ?? undefined,
+    label: d.label,
+  }));
+
+  let serializedResults: SerializedTravelResults;
+  try {
+    serializedResults = await buildSavedTripResults({
+      user,
+      destinations,
+      filters: { confidence: confidenceFilter, distanceTier: distanceFilter },
+    });
+  } catch (err) {
+    console.error("[travel] SavedTripPage threw", err);
+    Sentry.captureException(err);
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <EmptyStates variant="error" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6">
+      <header className="mb-6 border-b border-border pb-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-red-600 dark:text-red-400">
+          ◆ Itinerary · {search.destinations.length} legs
+        </p>
+        <h1 className="mt-1 font-display text-3xl font-medium tracking-tight">
+          {search.name ?? "Trip"}
+        </h1>
+      </header>
+      <TravelResults
+        destination={search.name ?? ""}
+        results={serializedResults}
+        destinations={serializedResults.destinations}
+      />
+    </div>
+  );
+}
+
+/**
+ * Extracted so the `SavedTripPage` render path stays outside the
+ * try/catch — `react-hooks/error-boundaries` forbids constructing
+ * JSX inside the catch path because it bypasses the route-level
+ * error boundary.
+ */
+async function buildSavedTripResults(args: {
+  user: Awaited<ReturnType<typeof getOrCreateUser>>;
+  destinations: Parameters<typeof executeTravelSearch>[1]["destinations"];
+  filters: Parameters<typeof executeTravelSearch>[1]["filters"];
+}): Promise<SerializedTravelResults> {
+  const results = await executeTravelSearch(prisma, {
+    destinations: args.destinations,
+    filters: args.filters,
+  });
+  const allConfirmed = [
+    ...results.confirmed,
+    ...results.destinations.flatMap((d) => d.broaderResults?.confirmed ?? []),
+  ];
+  const attendanceMap: AttendanceMap = await loadAttendanceMap(
+    args.user,
+    allConfirmed.map((r) => r.eventId),
+  );
+  return serializeTravelResults(results, attendanceMap, { mergeBroader: true });
 }

--- a/src/components/travel/TravelResults.tsx
+++ b/src/components/travel/TravelResults.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { SourceLink } from "@/lib/travel/search";
 import { capture } from "@/lib/analytics";
 import {
   computeDayCounts,
@@ -24,93 +23,13 @@ import { LikelyCard } from "./LikelyCard";
 import { PossibleSection } from "./PossibleSection";
 import { PossibleRow } from "./PossibleRow";
 import { TravelResultFilters } from "./TravelResultFilters";
-
-/** Per-row multi-destination tag. Every result is tagged with the 0-indexed
- * stop it belongs to, letting the UI render LEG sub-bands on overlap days
- * (where two stops share a calendar date). Single-destination searches
- * produce rows all tagged `{ destinationIndex: 0 }`. */
-interface DestinationTag {
-  destinationIndex: number;
-  destinationLabel: string | null;
-}
-
-interface SerializedConfirmed extends DestinationTag {
-  type: "confirmed";
-  eventId: string;
-  kennelId: string;
-  kennelSlug: string;
-  kennelName: string;
-  kennelFullName: string;
-  kennelRegion: string;
-  kennelPinColor: string | null;
-  date: string;
-  startTime: string | null;
-  title: string | null;
-  runNumber: number | null;
-  haresText: string | null;
-  locationName: string | null;
-  locationStreet: string | null;
-  locationCity: string | null;
-  timezone: string | null;
-  sourceUrl: string | null;
-  distanceKm: number;
-  distanceTier: "nearby" | "area" | "drive";
-  sourceLinks: SourceLink[];
-  weather: {
-    highTempC: number;
-    lowTempC: number;
-    condition: string;
-    conditionType: string;
-    precipProbability: number;
-  } | null;
-  attendance: { status: string; participationLevel: string } | null;
-}
-
-interface SerializedLikely extends DestinationTag {
-  type: "likely";
-  kennelId: string;
-  kennelSlug: string;
-  kennelName: string;
-  kennelFullName: string;
-  kennelRegion: string;
-  kennelPinColor: string | null;
-  date: string;
-  startTime: string | null;
-  confidence: "high" | "medium";
-  distanceKm: number;
-  distanceTier: "nearby" | "area" | "drive";
-  explanation: string;
-  evidenceWindow: string;
-  evidenceTimeline: { weeks: boolean[]; totalEvents: number };
-  sourceLinks: SourceLink[];
-}
-
-interface SerializedPossible extends DestinationTag {
-  type: "possible";
-  kennelId: string;
-  kennelSlug: string;
-  kennelName: string;
-  kennelFullName: string;
-  kennelRegion: string;
-  date: string | null;
-  confidence: "low";
-  distanceKm: number;
-  distanceTier: "nearby" | "area" | "drive";
-  explanation: string;
-  sourceLinks: SourceLink[];
-  lastConfirmedAt: string | null;
-}
-
-/** Serialized per-stop summary, threaded through from search.ts. Dates are
- * ISO strings because the props cross the RSC boundary. */
-export interface SerializedDestination {
-  index: number;
-  label: string | null;
-  startDate: string;
-  endDate: string;
-  radiusKm: number;
-  broaderRadiusKm?: number;
-}
+import type {
+  SerializedConfirmed,
+  SerializedLikely,
+  SerializedPossible,
+  SerializedDestination,
+} from "@/lib/travel/serialize";
+export type { SerializedDestination };
 
 interface TravelResultsProps {
   destination: string;

--- a/src/lib/travel/serialize.ts
+++ b/src/lib/travel/serialize.ts
@@ -1,0 +1,148 @@
+/**
+ * Serialize an `executeTravelSearch` result set for the RSC→client
+ * boundary. Dates become ISO strings; confirmed rows get their
+ * attendance record merged in.
+ *
+ * Two modes:
+ *   - `mergeBroader: true` — multi-stop. Every stop's broader-pass rows
+ *     append to the flat confirmed/likely/possible arrays. No top-level
+ *     `broaderResults` key (each row already carries its destinationIndex).
+ *   - `mergeBroader: false` — single-stop. Flat arrays hold primary only;
+ *     `broaderResults` carries destinations[0]'s broader so the existing
+ *     `selectResultsToRender` swap on `no_nearby` works unchanged.
+ */
+
+import type { executeTravelSearch } from "./search";
+
+type SearchResults = Awaited<ReturnType<typeof executeTravelSearch>>;
+type ConfirmedRow = SearchResults["confirmed"][number];
+type LikelyRow = SearchResults["likely"][number];
+type PossibleRow = SearchResults["possible"][number];
+
+export type AttendanceEntry = { status: string; participationLevel: string };
+export type AttendanceMap = Record<string, AttendanceEntry>;
+
+export interface SerializedDestination {
+  index: number;
+  label: string | null;
+  startDate: string;
+  endDate: string;
+  radiusKm: number;
+  broaderRadiusKm?: number;
+}
+
+export interface SerializedConfirmed extends Omit<ConfirmedRow, "date"> {
+  date: string;
+  attendance: AttendanceEntry | null;
+}
+
+export interface SerializedLikely extends Omit<LikelyRow, "date"> {
+  date: string;
+}
+
+export interface SerializedPossible
+  extends Omit<PossibleRow, "date" | "lastConfirmedAt"> {
+  date: string | null;
+  lastConfirmedAt: string | null;
+}
+
+export interface SerializedTravelResults {
+  emptyState: SearchResults["emptyState"];
+  meta: SearchResults["meta"];
+  destinations: SerializedDestination[];
+  confirmed: SerializedConfirmed[];
+  likely: SerializedLikely[];
+  possible: SerializedPossible[];
+  broaderResults?: {
+    confirmed: SerializedConfirmed[];
+    likely: SerializedLikely[];
+    possible: SerializedPossible[];
+  };
+}
+
+function serializeConfirmed(
+  r: ConfirmedRow,
+  attendanceMap: AttendanceMap,
+): SerializedConfirmed {
+  return {
+    ...r,
+    date: r.date.toISOString(),
+    attendance: attendanceMap[r.eventId] ?? null,
+  };
+}
+
+function serializeLikely(r: LikelyRow): SerializedLikely {
+  return { ...r, date: r.date.toISOString() };
+}
+
+function serializePossible(r: PossibleRow): SerializedPossible {
+  return {
+    ...r,
+    date: r.date?.toISOString() ?? null,
+    lastConfirmedAt: r.lastConfirmedAt?.toISOString() ?? null,
+  };
+}
+
+function serializeDestinations(
+  destinations: SearchResults["destinations"],
+): SerializedDestination[] {
+  return destinations.map((d) => ({
+    index: d.index,
+    label: d.label,
+    startDate: d.startDate.toISOString(),
+    endDate: d.endDate.toISOString(),
+    radiusKm: d.radiusKm,
+    broaderRadiusKm: d.broaderRadiusKm,
+  }));
+}
+
+export function serializeTravelResults(
+  results: SearchResults,
+  attendanceMap: AttendanceMap,
+  { mergeBroader }: { mergeBroader: boolean },
+): SerializedTravelResults {
+  if (mergeBroader) {
+    // Multi-stop: flatten all stops' broader rows into the primary arrays.
+    const allBroaderConfirmed = results.destinations.flatMap(
+      (d) => d.broaderResults?.confirmed ?? [],
+    );
+    const allBroaderLikely = results.destinations.flatMap(
+      (d) => d.broaderResults?.likely ?? [],
+    );
+    const allBroaderPossible = results.destinations.flatMap(
+      (d) => d.broaderResults?.possible ?? [],
+    );
+    return {
+      emptyState: results.emptyState,
+      meta: results.meta,
+      destinations: serializeDestinations(results.destinations),
+      confirmed: [...results.confirmed, ...allBroaderConfirmed].map((r) =>
+        serializeConfirmed(r, attendanceMap),
+      ),
+      likely: [...results.likely, ...allBroaderLikely].map(serializeLikely),
+      possible: [...results.possible, ...allBroaderPossible].map(serializePossible),
+    };
+  }
+
+  // Single-stop: primary-only flat arrays; destination[0]'s broader goes
+  // into its own `broaderResults` key so the selectResultsToRender swap
+  // on `no_nearby` keeps working as it does on main today.
+  const stopBroader = results.destinations[0]?.broaderResults;
+  return {
+    emptyState: results.emptyState,
+    meta: results.meta,
+    destinations: serializeDestinations(results.destinations),
+    confirmed: results.confirmed.map((r) => serializeConfirmed(r, attendanceMap)),
+    likely: results.likely.map(serializeLikely),
+    possible: results.possible.map(serializePossible),
+    broaderResults: stopBroader
+      ? {
+          confirmed: stopBroader.confirmed.map((r) =>
+            serializeConfirmed(r, attendanceMap),
+          ),
+          likely: stopBroader.likely.map(serializeLikely),
+          possible: stopBroader.possible.map(serializePossible),
+        }
+      : undefined,
+  };
+}


### PR DESCRIPTION
## Summary

First of three sub-PRs for Phase 6 PR 3. **Scope: server-action plumbing + the `/travel?savedTripId=<id>` render surface.** The form (ghost-leg rows + draft auto-save) ships in PR 3c.2; TripSummary multi-stop hero ships in PR 3c.3.

Plan: `/Users/johnclem/.claude/plans/majestic-baking-donut.md`

### PR 3 sub-split recap
- ✅ **PR 3a** (merged): `cityToIata()` + multi-leg SavedTripCard
- ✅ **PR 3b** (merged): TravelResults day-by-day + by-destination views
- ➡️ **PR 3c.1** (this PR): draft server actions + `?savedTripId=` URL path
- **PR 3c.2**: search form ghost-leg rows + draft auto-save client-side
- **PR 3c.3**: TripSummary multi-stop hero

### Server actions
- `saveDraftSearch(params)` — creates a DRAFT TravelSearch with DRAFT child destinations. Drafts are exempt from the ACTIVE dedup partial-unique.
- `updateDraftSearch(id, params)` — mutates an existing DRAFT in-place. Tx-scoped `updateMany` composite-where guard + tail-end recheck to catch concurrent archives.

### Page surface
- `/travel?savedTripId=<id>` resolves to the trip's destinations and runs `executeTravelSearch` across the full itinerary. Both DRAFT and ACTIVE parents render; ARCHIVED returns an error empty state. Ownership enforced server-side.

### Plumbing (from /simplify pre-PR)
- New `@/lib/travel/serialize` module. `serializeTravelResults(results, attendanceMap, { mergeBroader })` replaces ~90 LOC of duplicated serialization that previously lived inline in `TravelResultsServer` and `buildSavedTripResults`. Types (`SerializedConfirmed`/`Likely`/`Possible`/`Destination`/`TravelResults`) derived from `executeTravelSearch`'s actual return type — the `unknown[]` + double-cast antipattern is gone.
- `TravelResults` imports its row types from the shared module (single source of truth).

### Invariants locked (from /codex:adversarial-review pre-PR)
- `buildDestinationData` takes a `status` parameter (default ACTIVE). `saveDraftSearch` / `updateDraftSearch` pass `DRAFT` so child rows mirror parent status — the parent/child invariant the reader path relies on.
- `updateDraftSearch` runs two guarded `updateMany` calls bracketing the destination rewrite (initial guard + tail recheck). A concurrent `deleteTravelSearch` archiving the parent between them rolls the tx back instead of leaving ARCHIVED-parent + DRAFT-children.
- `SavedTripPage` drops `destinations.where.status` — the invariant makes the filter redundant.

## Test plan
- [x] `/simplify` (3 parallel review agents) — high/medium findings applied
- [x] `/codex:adversarial-review` — 2 findings applied (parent/child invariant, archive race)
- [x] 66 actions tests pass (+11 new); 4968 total
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] Manual post-merge: create a DRAFT trip via Prisma studio, hit `/travel?savedTripId=<id>`, verify multi-stop render
- [ ] PR 3c.2: form + draft auto-save
- [ ] PR 3c.3: TripSummary multi-stop hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)