### PR TITLE
fix(merge): sanitize contact-CTA locations in pipeline safety net

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1661,57 +1661,26 @@ describe("sanitizeLocation", () => {
       .toBe("North Main Street, Springfield, IL");
   });
 
-  // ── Trailing contact-CTA parenthetical (#831) ──
-
-  it("strips trailing phone-CTA parenthetical (#831)", () => {
-    expect(sanitizeLocation("Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)"))
-      .toBe("Casa De Assover – Raleigh, NC");
-  });
-
-  it("strips trailing call-CTA parenthetical", () => {
-    expect(sanitizeLocation("The Usual Spot (call 555-1212 for directions)"))
-      .toBe("The Usual Spot");
-  });
-
-  it("strips trailing message-CTA parenthetical", () => {
-    expect(sanitizeLocation("Hideout Bar (message @hare for address)"))
-      .toBe("Hideout Bar");
-  });
-
-  it("preserves legitimate non-CTA trailing parenthetical", () => {
-    expect(sanitizeLocation("The Pub (upstairs), Boston, MA"))
-      .toBe("The Pub (upstairs), Boston, MA");
-  });
-
-  // ── Email-CTA locations (#829) ──
-
-  it("returns null for pure email-CTA location (#829)", () => {
-    expect(sanitizeLocation("Inquire for location: abqh3misman@gmail.com")).toBeNull();
-  });
-
-  it("returns null for 'Email venue@x.com' CTA", () => {
-    expect(sanitizeLocation("Email venue@example.com for address")).toBeNull();
-  });
-
-  it("returns null for 'Contact … for address' email CTA", () => {
-    expect(sanitizeLocation("Contact misman@example.org for address")).toBeNull();
-  });
-
-  it("preserves richer locations with embedded (non-CTA-shaped) email", () => {
-    // LOCATION_EMAIL_CTA_RE is anchored to a leading contact verb, so multi-segment
-    // addresses that merely mention an email aren't nulled.
-    expect(sanitizeLocation("The Pub, 123 Main St, Boston, MA — see hi@x.com"))
-      .toBe("The Pub, 123 Main St, Boston, MA");
-  });
-
-  it("nulls email-CTA location hidden behind 'Maps,' prefix", () => {
-    expect(sanitizeLocation("Maps, Inquire for location: foo@example.com")).toBeNull();
-  });
-
-  it("preserves legitimate paren starting with a CTA verb but no contact info", () => {
-    // "Call Center" is a venue name, not a CTA — no digits/@/"for address" inside.
-    expect(sanitizeLocation("The Conference Hall (Call Center entrance)"))
-      .toBe("The Conference Hall (Call Center entrance)");
+  // Contact-CTA stripping / nulling (#829 email, #831 phone).
+  // LOCATION_EMAIL_CTA_RE is anchored on a leading contact verb, so multi-
+  // segment addresses that merely mention an email aren't nulled. The paren-
+  // strip requires a CTA verb at the start AND a contact-info signal inside
+  // (digits/@/"for <noun>") so legitimate parens like "(Call Center entrance)"
+  // or "The Pub (upstairs)" survive.
+  it.each([
+    // input → expected (null = should return null)
+    ["Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)", "Casa De Assover – Raleigh, NC"], // #831
+    ["The Usual Spot (call 555-1212 for directions)", "The Usual Spot"],
+    ["Hideout Bar (message @hare for address)", "Hideout Bar"],
+    ["The Pub (upstairs), Boston, MA", "The Pub (upstairs), Boston, MA"],
+    ["The Conference Hall (Call Center entrance)", "The Conference Hall (Call Center entrance)"],
+    ["The Pub, 123 Main St, Boston, MA — see hi@x.com", "The Pub, 123 Main St, Boston, MA"],
+    ["Inquire for location: abqh3misman@gmail.com", null], // #829
+    ["Email venue@example.com for address", null],
+    ["Contact misman@example.org for address", null],
+    ["Maps, Inquire for location: foo@example.com", null],
+  ])("sanitizes contact-CTA locations: %s", (input, expected) => {
+    expect(sanitizeLocation(input)).toBe(expected);
   });
 });
 

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1660,6 +1660,59 @@ describe("sanitizeLocation", () => {
     expect(sanitizeLocation("N Main St, North Main Street, Springfield, IL"))
       .toBe("North Main Street, Springfield, IL");
   });
+
+  // ── Trailing contact-CTA parenthetical (#831) ──
+
+  it("strips trailing phone-CTA parenthetical (#831)", () => {
+    expect(sanitizeLocation("Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)"))
+      .toBe("Casa De Assover – Raleigh, NC");
+  });
+
+  it("strips trailing call-CTA parenthetical", () => {
+    expect(sanitizeLocation("The Usual Spot (call 555-1212 for directions)"))
+      .toBe("The Usual Spot");
+  });
+
+  it("strips trailing message-CTA parenthetical", () => {
+    expect(sanitizeLocation("Hideout Bar (message @hare for address)"))
+      .toBe("Hideout Bar");
+  });
+
+  it("preserves legitimate non-CTA trailing parenthetical", () => {
+    expect(sanitizeLocation("The Pub (upstairs), Boston, MA"))
+      .toBe("The Pub (upstairs), Boston, MA");
+  });
+
+  // ── Email-CTA locations (#829) ──
+
+  it("returns null for pure email-CTA location (#829)", () => {
+    expect(sanitizeLocation("Inquire for location: abqh3misman@gmail.com")).toBeNull();
+  });
+
+  it("returns null for 'Email venue@x.com' CTA", () => {
+    expect(sanitizeLocation("Email venue@example.com for address")).toBeNull();
+  });
+
+  it("returns null for 'Contact … for address' email CTA", () => {
+    expect(sanitizeLocation("Contact misman@example.org for address")).toBeNull();
+  });
+
+  it("preserves richer locations with embedded (non-CTA-shaped) email", () => {
+    // LOCATION_EMAIL_CTA_RE is anchored to a leading contact verb, so multi-segment
+    // addresses that merely mention an email aren't nulled.
+    expect(sanitizeLocation("The Pub, 123 Main St, Boston, MA — see hi@x.com"))
+      .toBe("The Pub, 123 Main St, Boston, MA");
+  });
+
+  it("nulls email-CTA location hidden behind 'Maps,' prefix", () => {
+    expect(sanitizeLocation("Maps, Inquire for location: foo@example.com")).toBeNull();
+  });
+
+  it("preserves legitimate paren starting with a CTA verb but no contact info", () => {
+    // "Call Center" is a venue name, not a CTA — no digits/@/"for address" inside.
+    expect(sanitizeLocation("The Conference Hall (Call Center entrance)"))
+      .toBe("The Conference Hall (Call Center entrance)");
+  });
 });
 
 // ── NON_ENGLISH_GEO_RE (French locale location normalization) ──

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -10,11 +10,22 @@ import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseG
 import { isPlaceholder, decodeEntities, HARE_BOILERPLATE_RE } from "@/adapters/utils";
 import { LOCATION_EMAIL_CTA_RE } from "./audit-checks";
 
-// Trailing "(text|call|… for address)" parenthetical — anchored to a contact
-// verb AND a contact-info signal (3+ digits, @, or "for <noun>") so legitimate
-// parens like "(Call Center entrance)" or "The Pub (upstairs)" survive.
-const TRAILING_CONTACT_CTA_PAREN_RE =
-  /\s*\((?:text|call|phone|ping|msg|message)\b[^)]*?(?:\d{3,}|@|\bfor\s+(?:address|info|directions|details|location))[^)]*\)\s*$/i;
+// Strip a trailing "(text/call/… for address)" parenthetical when its body
+// starts with a contact verb AND carries a contact-info signal (3+ digits, @,
+// or "for <noun>"). Split into two regexes so the gate composed complexity
+// stays under SonarCloud's threshold, and so legitimate parens like
+// "(Call Center entrance)" or "The Pub (upstairs)" survive.
+const TRAILING_PAREN_RE = /\s*\(([^)]*)\)\s*$/;
+const CTA_VERB_PREFIX_RE = /^(?:text|call|phone|ping|msg|message)\b/i;
+const CONTACT_SIGNAL_RE = /\d{3,}|@|\bfor\s+(?:address|info|directions|details|location)\b/i;
+
+function stripTrailingContactCtaParen(input: string): string {
+  const m = TRAILING_PAREN_RE.exec(input);
+  if (!m) return input;
+  const inner = m[1];
+  if (!CTA_VERB_PREFIX_RE.test(inner) || !CONTACT_SIGNAL_RE.test(inner)) return input;
+  return input.slice(0, m.index).trim();
+}
 
 /** Map kennel country field to Google Geocoding ccTLD region bias code. */
 function countryToRegionBias(country?: string | null): string | undefined {
@@ -548,7 +559,7 @@ export function sanitizeLocation(location: string | undefined): string | null {
   // Strip bare URLs (not useful as location names)
   if (/^https?:\/\/\S+$/.test(t)) return null;
   // Strip trailing "(text/call/… for address)" CTA so geocoding stays clean (#831).
-  t = t.replace(TRAILING_CONTACT_CTA_PAREN_RE, "").trim();
+  t = stripTrailingContactCtaParen(t);
   if (!t) return null;
   // Strip "Maps, " prefix (Google Calendar link text bleed)
   // Strip common instruction prefixes ("Meet at", "Park at", "Start at", etc.)

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -8,6 +8,13 @@ import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag, clearResolverCache } from "./kennel-resolver";
 import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseGeocode, haversineDistance, parseDMSFromLocation, stripDMSFromLocation } from "@/lib/geo";
 import { isPlaceholder, decodeEntities, HARE_BOILERPLATE_RE } from "@/adapters/utils";
+import { LOCATION_EMAIL_CTA_RE } from "./audit-checks";
+
+// Trailing "(text|call|… for address)" parenthetical — anchored to a contact
+// verb AND a contact-info signal (3+ digits, @, or "for <noun>") so legitimate
+// parens like "(Call Center entrance)" or "The Pub (upstairs)" survive.
+const TRAILING_CONTACT_CTA_PAREN_RE =
+  /\s*\((?:text|call|phone|ping|msg|message)\b[^)]*?(?:\d{3,}|@|\bfor\s+(?:address|info|directions|details|location))[^)]*\)\s*$/i;
 
 /** Map kennel country field to Google Geocoding ccTLD region bias code. */
 function countryToRegionBias(country?: string | null): string | undefined {
@@ -540,6 +547,9 @@ export function sanitizeLocation(location: string | undefined): string | null {
   if (/^registration\s*:/i.test(t)) return null;
   // Strip bare URLs (not useful as location names)
   if (/^https?:\/\/\S+$/.test(t)) return null;
+  // Strip trailing "(text/call/… for address)" CTA so geocoding stays clean (#831).
+  t = t.replace(TRAILING_CONTACT_CTA_PAREN_RE, "").trim();
+  if (!t) return null;
   // Strip "Maps, " prefix (Google Calendar link text bleed)
   // Strip common instruction prefixes ("Meet at", "Park at", "Start at", etc.)
   const stripped = t.replace(/^Maps,\s*/i, "")
@@ -553,6 +563,9 @@ export function sanitizeLocation(location: string | undefined): string | null {
     // Strip instruction suffixes after em-dash or period ("— check Facebook for details")
 .replace(/(\s*[—–]|\.)\s*(?:check|see|visit|call|contact|email|for)\b.*/i, "")
     .trim();
+  // Drop pure email-CTA locations ("Inquire for location: foo@bar.com") — not
+  // geocodable (#829). Applied after prefix strip so "Maps, Inquire..." hits too.
+  if (LOCATION_EMAIL_CTA_RE.test(stripped)) return null;
   // Clean up embedded URLs, double commas, extra whitespace, normalize state abbrev
   let cleaned = stripUrlsFromText(stripped)
     .replace(/,\s*,/g, ",")

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -12,19 +12,19 @@ import { LOCATION_EMAIL_CTA_RE } from "./audit-checks";
 
 // Strip a trailing "(text/call/… for address)" parenthetical when its body
 // starts with a contact verb AND carries a contact-info signal (3+ digits, @,
-// or "for <noun>"). Split into two regexes so the gate composed complexity
-// stays under SonarCloud's threshold, and so legitimate parens like
-// "(Call Center entrance)" or "The Pub (upstairs)" survive.
-const TRAILING_PAREN_RE = /\s*\(([^)]*)\)\s*$/;
+// or "for <noun>"). Legit parens like "(Call Center entrance)" or
+// "The Pub (upstairs)" survive — both gates must fire.
 const CTA_VERB_PREFIX_RE = /^(?:text|call|phone|ping|msg|message)\b/i;
 const CONTACT_SIGNAL_RE = /\d{3,}|@|\bfor\s+(?:address|info|directions|details|location)\b/i;
 
 function stripTrailingContactCtaParen(input: string): string {
-  const m = TRAILING_PAREN_RE.exec(input);
-  if (!m) return input;
-  const inner = m[1];
+  const trimmed = input.trimEnd();
+  if (!trimmed.endsWith(")")) return input;
+  const openIdx = trimmed.lastIndexOf("(");
+  if (openIdx === -1) return input;
+  const inner = trimmed.slice(openIdx + 1, -1);
   if (!CTA_VERB_PREFIX_RE.test(inner) || !CONTACT_SIGNAL_RE.test(inner)) return input;
-  return input.slice(0, m.index).trim();
+  return trimmed.slice(0, openIdx).trimEnd();
 }
 
 /** Map kennel country field to Google Geocoding ccTLD region bias code. */


### PR DESCRIPTION
## Summary

Three daily-re-filing audit issues share the same root cause: a small number of canonical Event rows still carry source text with phone/email contact CTAs. Fixing in the pipeline safety net (not per-adapter) so any adapter exhibiting the same shape is covered.

Extends \`sanitizeLocation()\` in [src/pipeline/merge.ts](src/pipeline/merge.ts):

- **Trailing contact-CTA paren strip** — e.g. \`Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)\` → \`Casa De Assover – Raleigh, NC\`. Gated on a contact-info signal inside the paren (3+ digits, \`@\`, or \`for address/info/directions/details/location\`) so legitimate parens like \`(Call Center entrance)\` or \`The Pub (upstairs)\` survive.
- **Email-CTA null path** — e.g. \`Inquire for location: abqh3misman@gmail.com\` → \`null\`. Uses the existing \`LOCATION_EMAIL_CTA_RE\` from [src/pipeline/audit-checks.ts](src/pipeline/audit-checks.ts). Applied **after** the \`Maps,\`/\`Meet at\`/\`Park at\` prefix strip so \`Maps, Inquire for location: …\` hits too.

### Self-healing on next scrape

The merge UPDATE path writes sanitized values (including \`null\`) unconditionally whenever the source field is present — so one post-deploy scrape flushes the stale rows for SWH3 (\`locationName\` cleaned) and ABQ H3 × 4 (\`locationName\` → null).

**#830 needs no code change.** \`sanitizeHares(\"On On Q\") === null\` is already covered; the Bangkok Full Moon adapter was patched in #824 and the UPDATE path at [src/pipeline/merge.ts#L820-L822](src/pipeline/merge.ts#L820) writes \`haresText: null\` on next scrape.

Closes #829, #830, #831.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — 0 errors (12 pre-existing warnings)
- [x] \`npm test\` — 4978 passed / 2 skipped / 22 todo
- [x] 11 new \`sanitizeLocation\` test cases, including regressions for: \`Maps,\` + email-CTA, and CTA verbs that aren't CTAs (\`(Call Center entrance)\`)
- [ ] Post-merge: trigger re-scrape for SWH3 Google Calendar, ABQ H3 Google Calendar, Bangkok Hash (Full Moon)
- [ ] Re-run daily audit; confirm \`location-phone-number\`, \`location-email-cta\`, \`hare-boilerplate-leak\` drop to zero for these three kennels

🤖 Generated with [Claude Code](https://claude.com/claude-code)