### PR TITLE
feat(travel): Phase 6 PR 3c.2 — ghost-leg form + draft auto-save

### DIFF
--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -77,11 +77,16 @@ export default async function TravelPage({ searchParams }: TravelPageProps) {
   const hasSearchParams =
     lat != null && lng != null && from != null && to != null;
 
+  // Auth status drives the multi-leg ghost-row gate: anonymous users
+  // see a sign-in prompt instead of the expand-into-new-leg interaction.
+  // Cached by Next.js so duplicate calls in TravelResultsServer are free.
+  const isAuthenticated = (await safeGetUser()) != null;
+
   // No search params → show landing state with hero + popular destinations
   if (!hasSearchParams) {
     return (
       <>
-        <TravelHero />
+        <TravelHero isAuthenticated={isAuthenticated} />
         <PopularDestinations />
       </>
     );
@@ -123,6 +128,7 @@ export default async function TravelPage({ searchParams }: TravelPageProps) {
       {/* Compact search form for editing */}
       <TravelSearchForm
         variant="compact"
+        isAuthenticated={isAuthenticated}
         initialValues={{
           destination: q ?? "",
           latitude,

--- a/src/components/travel/SavedTripCard.tsx
+++ b/src/components/travel/SavedTripCard.tsx
@@ -18,7 +18,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
   formatDateCompact,
-  daysBetween,
+  formatNights,
   cityToIata,
   formatLegDateRange,
 } from "@/lib/travel/format";
@@ -85,7 +85,6 @@ export function SavedTripCard({
   // Trip-level window spans from earliest leg start to latest leg end.
   const tripStartStr = utcYmd(firstLeg.startDate);
   const tripEndStr = utcYmd(lastLeg.endDate);
-  const totalNights = daysBetween(tripStartStr, tripEndStr);
 
   // Multi-stop trips route through `?savedTripId=` (PR 3c); single-stop
   // keeps the stateless URL shape. For PR 3a the stateless URL still
@@ -142,9 +141,7 @@ export function SavedTripCard({
               <span>→</span>
               <span>{formatDateCompact(tripEndStr, { withWeekday: true })}</span>
               <span>·</span>
-              <span>
-                {totalNights} night{totalNights !== 1 ? "s" : ""}
-              </span>
+              <span>{formatNights(tripStartStr, tripEndStr)}</span>
               {isMultiStop && (
                 <>
                   <span>·</span>

--- a/src/components/travel/TravelHero.tsx
+++ b/src/components/travel/TravelHero.tsx
@@ -4,11 +4,15 @@ import { useEffect, useRef } from "react";
 import { TravelSearchForm } from "./TravelSearchForm";
 import { NearMeShortcut } from "./NearMeShortcut";
 
+interface TravelHeroProps {
+  isAuthenticated?: boolean;
+}
+
 /**
  * Landing hero for /travel with no search params.
  * Client component for staggered word reveal animation + scroll parallax.
  */
-export function TravelHero() {
+export function TravelHero({ isAuthenticated = false }: Readonly<TravelHeroProps>) {
   const backdropRef = useRef<HTMLDivElement>(null);
 
   // Scroll parallax via direct DOM mutation — avoids re-rendering the
@@ -152,7 +156,7 @@ export function TravelHero() {
             animationDelay: "600ms",
           }}
         >
-          <TravelSearchForm variant="hero" />
+          <TravelSearchForm variant="hero" isAuthenticated={isAuthenticated} />
         </div>
 
         <NearMeShortcut />

--- a/src/components/travel/TravelSearchForm.tsx
+++ b/src/components/travel/TravelSearchForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useState, useTransition } from "react";
+import { memo, useCallback, useId, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { MapPin, Calendar, Compass, Search, Pencil, Plus, X, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -28,16 +28,6 @@ interface TravelSearchFormProps {
   isAuthenticated?: boolean;
 }
 
-/** Stable per-leg id for the React key. Array index keys would reuse
- *  component instances across remove-leg operations, which would drift
- *  DestinationInput's local autocomplete state onto the wrong leg. */
-function newLegId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  return `leg-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
 const RADIUS_META: Record<(typeof RADIUS_TIERS)[number], { label: string; description: string }> = {
   10: { label: "Close", description: "~6 mi" },
   25: { label: "Metro", description: "~15 mi" },
@@ -59,9 +49,9 @@ interface LegState {
   coordsResolved: boolean;
 }
 
-function makeEmptyLeg(): LegState {
+function makeEmptyLeg(id: string): LegState {
   return {
-    id: newLegId(),
+    id,
     destination: "",
     latitude: 0,
     longitude: 0,
@@ -74,11 +64,12 @@ function makeEmptyLeg(): LegState {
 }
 
 function makeLegFromInitial(
+  id: string,
   initial: TravelSearchFormProps["initialValues"],
 ): LegState {
-  if (!initial) return makeEmptyLeg();
+  if (!initial) return makeEmptyLeg(id);
   return {
-    id: newLegId(),
+    id,
     destination: initial.destination,
     latitude: initial.latitude,
     longitude: initial.longitude,
@@ -86,8 +77,9 @@ function makeLegFromInitial(
     startDate: initial.startDate,
     endDate: initial.endDate,
     radiusKm: snapRadiusToTier(initial.radiusKm),
-    coordsResolved:
-      initial.latitude !== undefined && initial.longitude !== undefined,
+    // Types mark latitude/longitude as required numbers; any LegState we
+    // build from initialValues is coord-resolved by construction.
+    coordsResolved: true,
   };
 }
 
@@ -120,7 +112,22 @@ export function TravelSearchForm({
 }: Readonly<TravelSearchFormProps>) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const [legs, setLegs] = useState<LegState[]>(() => [makeLegFromInitial(initialValues)]);
+  // Deterministic per-leg ids. useId() is stable across SSR/hydration
+  // and the counter ref increments only on the client after mount, so
+  // the initial leg's key matches on both sides and subsequent adds
+  // produce unique, collision-free keys without crypto/randomness.
+  const baseLegId = useId();
+  // Counter starts at 1 because the initial leg (built below via
+  // lazy-init useState) always owns `${baseLegId}-leg-0`. Kept
+  // deterministic across SSR/hydration — no randomness, no Date.now.
+  const legCounter = useRef(1);
+  const makeLegId = useCallback(
+    () => `${baseLegId}-leg-${legCounter.current++}`,
+    [baseLegId],
+  );
+  const [legs, setLegs] = useState<LegState[]>(() => [
+    makeLegFromInitial(`${baseLegId}-leg-0`, initialValues),
+  ]);
   const [isExpanded, setIsExpanded] = useState(variant === "hero");
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
@@ -175,41 +182,30 @@ export function TravelSearchForm({
       return;
     }
     setSubmitError(null);
-    // Compute the new legs array synchronously — setLegs's functional
-    // updater runs synchronously so the captured `computed` is safe to
-    // read after. The initial [] is just a type anchor.
-    let computed: LegState[] = [];
-    setLegs((prev) => {
-      if (prev.length >= MAX_STOPS_PER_TRIP) {
-        computed = prev;
-        return prev;
-      }
-      const next = makeEmptyLeg();
-      const prevLeg = prev[prev.length - 1];
-      if (prevLeg?.endDate) next.startDate = prevLeg.endDate;
-      capture("travel_leg_added", { legCount: prev.length + 1 });
-      computed = [...prev, next];
-      return computed;
-    });
-    if (computed.length > 0 && computed.every(legReadyToSubmit)) {
-      await persistDraft(computed);
+    // Compute `nextLegs` in a stable closure over the current `legs`
+    // value, not inside the setLegs updater. React strict-mode invokes
+    // functional updaters twice; side effects (capture, persistDraft)
+    // must not piggyback on the updater body.
+    if (legs.length >= MAX_STOPS_PER_TRIP) return;
+    const next = makeEmptyLeg(makeLegId());
+    const prevLeg = legs.at(-1);
+    if (prevLeg?.endDate) next.startDate = prevLeg.endDate;
+    const nextLegs = [...legs, next];
+    setLegs(nextLegs);
+    capture("travel_leg_added", { legCount: nextLegs.length });
+    if (nextLegs.every(legReadyToSubmit)) {
+      await persistDraft(nextLegs);
     }
-  }, [isAuthenticated, persistDraft]);
+  }, [isAuthenticated, legs, makeLegId, persistDraft]);
 
   const removeLeg = useCallback(async (index: number) => {
-    let computed: LegState[] = [];
-    setLegs((prev) => {
-      if (prev.length <= 1) {
-        computed = prev;
-        return prev;
-      }
-      capture("travel_leg_removed", { legCount: prev.length - 1 });
-      computed = prev.filter((_, i) => i !== index);
-      return computed;
-    });
-    if (computed.length > 1 && draftId && computed.every(legReadyToSubmit)) {
+    if (legs.length <= 1) return;
+    const nextLegs = legs.filter((_, i) => i !== index);
+    setLegs(nextLegs);
+    capture("travel_leg_removed", { legCount: nextLegs.length });
+    if (nextLegs.length > 1 && draftId && nextLegs.every(legReadyToSubmit)) {
       const result = await updateDraftSearch(draftId, {
-        destinations: computed.map(legToDestParams),
+        destinations: nextLegs.map(legToDestParams),
       });
       if ("error" in result) {
         setSubmitError(result.error ?? "Could not update draft");
@@ -218,7 +214,7 @@ export function TravelSearchForm({
     // If remove leaves 1 leg, the draft is orphaned; cron GC sweeps
     // drafts older than a week. Not worth deleting eagerly — the user
     // might re-add another leg.
-  }, [draftId]);
+  }, [draftId, legs]);
 
   const canSubmit = legs.every(legReadyToSubmit);
 
@@ -250,17 +246,18 @@ export function TravelSearchForm({
       setHasAttemptedSubmit(true);
       return;
     }
+    const lastLeg = legs.at(-1)!;
     capture("travel_search_submitted", {
       destination: legs[0].destination,
       radiusKm: legs[0].radiusKm,
-      dateRangeDays: daysBetween(legs[0].startDate, legs[legs.length - 1].endDate),
+      dateRangeDays: daysBetween(legs[0].startDate, lastLeg.endDate),
       legCount: legs.length,
     });
-    startTransition(() => {
+    startTransition(async () => {
       if (legs.length === 1) {
         submitSingleLeg(legs[0]);
       } else {
-        void submitMultiLeg();
+        await submitMultiLeg();
       }
     });
   }, [canSubmit, legs, submitMultiLeg, submitSingleLeg]);
@@ -303,7 +300,6 @@ export function TravelSearchForm({
             <SignInToAddLegRow
               nextIndex={legs.length + 1}
               legs={legs}
-              variant={variant}
             />
           )
         )}
@@ -361,7 +357,7 @@ export function TravelSearchForm({
   );
 }
 
-function SubmitBarSummary({ legs }: { legs: LegState[] }) {
+function SubmitBarSummary({ legs }: Readonly<{ legs: LegState[] }>) {
   if (legs.length === 1) {
     const leg = legs[0];
     if (!leg.startDate || !leg.endDate) return <>Ready when you are</>;
@@ -372,7 +368,7 @@ function SubmitBarSummary({ legs }: { legs: LegState[] }) {
     );
   }
   const firstStart = legs[0].startDate;
-  const lastEnd = legs[legs.length - 1].endDate;
+  const lastEnd = legs.at(-1)!.endDate;
   if (!firstStart || !lastEnd) return <>{legs.length} legs · pending dates</>;
   return (
     <>
@@ -406,7 +402,7 @@ const LegRow = memo(function LegRow({
   showRequiredStamps,
   updateLeg,
   removeLeg,
-}: LegRowProps) {
+}: Readonly<LegRowProps>) {
   const legLabel = `LEG ${String(legIndex + 1).padStart(2, "0")}`;
   const destInvalid = showRequiredStamps && (!leg.destination || !leg.coordsResolved);
   const datesInvalid = showRequiredStamps && !legDatesValid(leg);
@@ -495,7 +491,7 @@ const LegRow = memo(function LegRow({
             />
             {leg.timezone && (
               <p className="mt-1 text-xs text-muted-foreground">
-                {leg.destination.split(",").slice(-1)[0]?.trim()} · {leg.timezone.split("/").pop()?.replaceAll("_", " ")}
+                {leg.destination.split(",").at(-1)?.trim()} · {leg.timezone.split("/").at(-1)?.replaceAll("_", " ")}
               </p>
             )}
           </fieldset>
@@ -552,7 +548,7 @@ const LegRow = memo(function LegRow({
   );
 });
 
-function RadiusPicker({ value, onChange }: { value: number; onChange: (v: number) => void }) {
+function RadiusPicker({ value, onChange }: Readonly<{ value: number; onChange: (v: number) => void }>) {
   return (
     <div className="flex flex-wrap gap-1.5">
       {RADIUS_OPTIONS.map((opt) => (
@@ -586,10 +582,10 @@ function RadiusPicker({ value, onChange }: { value: number; onChange: (v: number
 function GhostLegRow({
   nextIndex,
   onClick,
-}: {
+}: Readonly<{
   nextIndex: number;
-  onClick: () => void | Promise<void>;
-}) {
+  onClick: () => Promise<void>;
+}>) {
   return (
     <button
       type="button"
@@ -622,12 +618,10 @@ function GhostLegRow({
 function SignInToAddLegRow({
   nextIndex,
   legs,
-  variant,
-}: {
+}: Readonly<{
   nextIndex: number;
   legs: LegState[];
-  variant: "hero" | "compact";
-}) {
+}>) {
   // Preserve the in-progress leg-1 params so the user lands back on
   // /travel with the same destination after signing in. Multi-leg
   // continuation post-signin happens via the form — not via URL —
@@ -646,12 +640,18 @@ function SignInToAddLegRow({
     if (leg.timezone) p.set("tz", leg.timezone);
     return `/travel?${p.toString()}`;
   })();
-  const signInHref = `/sign-in?redirect_url=${encodeURIComponent(returnTo)}`;
+  // SECURITY: only allow same-origin redirects (path-relative URLs).
+  // An attacker-crafted full URL in returnTo would redirect the user
+  // to an arbitrary host after sign-in (open-redirect → phishing).
+  const safeReturnTo = returnTo.startsWith("/") && !returnTo.startsWith("//")
+    ? returnTo
+    : "/travel";
+  const signInHref = `/sign-in?redirect_url=${encodeURIComponent(safeReturnTo)}`;
 
   return (
     <a
       href={signInHref}
-      onClick={() => capture("travel_auth_prompt_shown", {})}
+      onClick={() => capture("travel_auth_prompt_clicked", {})}
       className={`
         group flex w-full items-center gap-4 rounded-xl border-[1.5px]
         border-dashed border-muted-foreground/40 bg-card/40 p-5 text-left
@@ -659,7 +659,6 @@ function SignInToAddLegRow({
         hover:border-muted-foreground/70 hover:bg-card
       `}
       aria-label={`Sign in to add leg ${nextIndex}`}
-      data-variant={variant}
     >
       <BoardingStamp label={`LEG ${String(nextIndex).padStart(2, "0")}`} variant="ghost" />
       <span className="flex items-center gap-2 font-mono text-[12px] uppercase tracking-[0.18em] text-muted-foreground/70 group-hover:text-foreground">
@@ -673,10 +672,10 @@ function SignInToAddLegRow({
   );
 }
 
-function CompactPill({ legs, onExpand }: { legs: LegState[]; onExpand: () => void }) {
+function CompactPill({ legs, onExpand }: Readonly<{ legs: LegState[]; onExpand: () => void }>) {
   const isMulti = legs.length > 1;
   const firstStart = legs[0].startDate;
-  const lastEnd = legs[legs.length - 1].endDate;
+  const lastEnd = legs.at(-1)!.endDate;
   const summary =
     firstStart && lastEnd
       ? `${formatDateCompact(firstStart, { withWeekday: true })} → ${formatDateCompact(lastEnd, { withWeekday: true })}`
@@ -684,6 +683,7 @@ function CompactPill({ legs, onExpand }: { legs: LegState[]; onExpand: () => voi
 
   return (
     <button
+      type="button"
       onClick={onExpand}
       className="
         flex w-full items-center gap-3 rounded-full border border-border
@@ -725,11 +725,11 @@ type BoardingStampVariant = "leg" | "ghost" | "required";
 function BoardingStamp({
   label,
   variant,
-}: {
+}: Readonly<{
   label: string;
   variant: BoardingStampVariant;
-}) {
-  const baseClasses = "inline-flex items-center justify-center rounded-sm border-[1.5px] px-1.5 py-[1px] font-mono text-[10px] font-bold uppercase tracking-wider";
+}>) {
+  const baseClasses = "inline-flex -rotate-[1.5deg] items-center justify-center rounded-sm border-[1.5px] px-1.5 py-[1px] font-mono text-[10px] font-bold uppercase tracking-wider";
   const variantClasses: Record<BoardingStampVariant, string> = {
     leg: "border-red-600/70 text-red-600 dark:border-red-400/70 dark:text-red-400",
     ghost: "border-dashed border-muted-foreground/50 text-muted-foreground",
@@ -740,7 +740,6 @@ function BoardingStamp({
       role={variant === "required" ? "status" : undefined}
       aria-live={variant === "required" ? "polite" : undefined}
       className={`${baseClasses} ${variantClasses[variant]}`}
-      style={{ transform: "rotate(-1.5deg)" }}
     >
       {label}
     </span>

--- a/src/components/travel/TravelSearchForm.tsx
+++ b/src/components/travel/TravelSearchForm.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState, useCallback, useTransition } from "react";
+import { memo, useCallback, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { MapPin, Calendar, Compass, Search, Pencil } from "lucide-react";
+import { MapPin, Calendar, Compass, Search, Pencil, Plus, X, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { formatDateCompact, daysBetween } from "@/lib/travel/format";
-import { RADIUS_TIERS, snapRadiusToTier } from "@/lib/travel/limits";
+import { formatDateCompact, formatNights, daysBetween } from "@/lib/travel/format";
+import { RADIUS_TIERS, snapRadiusToTier, MAX_STOPS_PER_TRIP } from "@/lib/travel/limits";
 import { capture } from "@/lib/analytics";
 import { resolveRefCode } from "@/lib/travel/iata";
+import { saveDraftSearch, updateDraftSearch } from "@/app/travel/actions";
 import { DestinationInput } from "./DestinationInput";
 
 interface TravelSearchFormProps {
@@ -21,6 +22,20 @@ interface TravelSearchFormProps {
     radiusKm: number;
     timezone?: string;
   };
+  /** Multi-leg adds require auth (drafts persist server-side). When
+   *  `false`, the ghost-leg row renders as a sign-in gate instead of
+   *  expanding. Single-leg flow stays anonymous. */
+  isAuthenticated?: boolean;
+}
+
+/** Stable per-leg id for the React key. Array index keys would reuse
+ *  component instances across remove-leg operations, which would drift
+ *  DestinationInput's local autocomplete state onto the wrong leg. */
+function newLegId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `leg-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 const RADIUS_META: Record<(typeof RADIUS_TIERS)[number], { label: string; description: string }> = {
@@ -31,287 +46,311 @@ const RADIUS_META: Record<(typeof RADIUS_TIERS)[number], { label: string; descri
 };
 const RADIUS_OPTIONS = RADIUS_TIERS.map((value) => ({ value, ...RADIUS_META[value] }));
 
-export function TravelSearchForm({ variant, initialValues }: Readonly<TravelSearchFormProps>) {
+interface LegState {
+  id: string;
+  destination: string;
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  startDate: string;
+  endDate: string;
+  radiusKm: number;
+  /** DestinationInput reported resolved coords — (0, 0) is a valid equatorial destination so this is not just `latitude !== 0`. */
+  coordsResolved: boolean;
+}
+
+function makeEmptyLeg(): LegState {
+  return {
+    id: newLegId(),
+    destination: "",
+    latitude: 0,
+    longitude: 0,
+    timezone: "",
+    startDate: "",
+    endDate: "",
+    radiusKm: 50,
+    coordsResolved: false,
+  };
+}
+
+function makeLegFromInitial(
+  initial: TravelSearchFormProps["initialValues"],
+): LegState {
+  if (!initial) return makeEmptyLeg();
+  return {
+    id: newLegId(),
+    destination: initial.destination,
+    latitude: initial.latitude,
+    longitude: initial.longitude,
+    timezone: initial.timezone ?? "",
+    startDate: initial.startDate,
+    endDate: initial.endDate,
+    radiusKm: snapRadiusToTier(initial.radiusKm),
+    coordsResolved:
+      initial.latitude !== undefined && initial.longitude !== undefined,
+  };
+}
+
+/** Convert a LegState into the SaveDestinationParams shape the
+ *  server action accepts. */
+function legToDestParams(leg: LegState) {
+  return {
+    label: leg.destination,
+    latitude: leg.latitude,
+    longitude: leg.longitude,
+    radiusKm: leg.radiusKm,
+    startDate: leg.startDate,
+    endDate: leg.endDate,
+    timezone: leg.timezone || undefined,
+  };
+}
+
+function legDatesValid(leg: LegState): boolean {
+  return Boolean(leg.startDate && leg.endDate && leg.startDate <= leg.endDate);
+}
+
+function legReadyToSubmit(leg: LegState): boolean {
+  return Boolean(leg.destination && leg.coordsResolved && legDatesValid(leg));
+}
+
+export function TravelSearchForm({
+  variant,
+  initialValues,
+  isAuthenticated = false,
+}: Readonly<TravelSearchFormProps>) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-
-  const [destination, setDestination] = useState(initialValues?.destination ?? "");
-  const [latitude, setLatitude] = useState(initialValues?.latitude ?? 0);
-  const [longitude, setLongitude] = useState(initialValues?.longitude ?? 0);
-  const [startDate, setStartDate] = useState(initialValues?.startDate ?? "");
-  const [endDate, setEndDate] = useState(initialValues?.endDate ?? "");
-  const [radiusKm, setRadiusKm] = useState(
-    snapRadiusToTier(initialValues?.radiusKm ?? 50),
-  );
-  const [timezone, setTimezone] = useState(initialValues?.timezone ?? "");
+  const [legs, setLegs] = useState<LegState[]>(() => [makeLegFromInitial(initialValues)]);
   const [isExpanded, setIsExpanded] = useState(variant === "hero");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
+  /**
+   * Multi-leg itineraries persist as DRAFT TravelSearches so the URL
+   * can stay `?savedTripId=<id>` (plan: stateless multi-leg URLs were
+   * rejected as fragile). Once we've created a draft on the first
+   * leg-2 add, subsequent edits `updateDraftSearch` the same row —
+   * this prevents duplicate draft accretion on re-submit / retry.
+   */
+  const [draftId, setDraftId] = useState<string | null>(null);
 
-  // Tracks whether DestinationInput has reported a resolved coordinate
-  // pair. Distinct from `latitude !== 0` because (0, 0) is a valid coord
-  // — equatorial Atlantic destinations exist. Flips true when
-  // DestinationInput.onChange fires; resets when the user clears.
-  const [coordsResolved, setCoordsResolved] = useState(
-    initialValues?.latitude !== undefined && initialValues?.longitude !== undefined,
+  const updateLeg = useCallback((index: number, patch: Partial<LegState>) => {
+    setLegs((prev) => prev.map((leg, i) => (i === index ? { ...leg, ...patch } : leg)));
+  }, []);
+
+  /**
+   * Create or update the draft so the URL can route through
+   * `?savedTripId=<id>`. Idempotent on resubmit: once we have a
+   * draftId, repeat calls update-in-place instead of inserting new
+   * rows (Codex #868 flagged unbounded draft creation).
+   */
+  const persistDraft = useCallback(
+    async (nextLegs: LegState[]): Promise<string | null> => {
+      const destinations = nextLegs.map(legToDestParams);
+      if (draftId) {
+        const result = await updateDraftSearch(draftId, { destinations });
+        if ("error" in result) {
+          setSubmitError(result.error ?? "Could not update trip draft");
+          return null;
+        }
+        return result.id;
+      }
+      const result = await saveDraftSearch({ destinations });
+      if ("error" in result) {
+        setSubmitError(result.error ?? "Could not save trip draft");
+        return null;
+      }
+      setDraftId(result.id);
+      return result.id;
+    },
+    [draftId],
   );
 
-  // Per-field invalid flags — drive the REQUIRED rubber stamps. Flipped
-  // true on attempted-submit-while-empty; cleared the moment the user
-  // provides that field. Starts false so landing form is pristine.
-  const [destInvalid, setDestInvalid] = useState(false);
-  const [datesInvalid, setDatesInvalid] = useState(false);
+  const addLeg = useCallback(async () => {
+    // Multi-leg adds require auth — drafts live server-side. Anonymous
+    // users hitting the ghost row see the SignInToAddLegRow instead,
+    // so this callback should never fire anonymously. Defensive guard
+    // preserves the invariant if a future refactor exposes the path.
+    if (!isAuthenticated) {
+      setSubmitError("Sign in to plan multi-city trips");
+      return;
+    }
+    setSubmitError(null);
+    // Compute the new legs array synchronously — setLegs's functional
+    // updater runs synchronously so the captured `computed` is safe to
+    // read after. The initial [] is just a type anchor.
+    let computed: LegState[] = [];
+    setLegs((prev) => {
+      if (prev.length >= MAX_STOPS_PER_TRIP) {
+        computed = prev;
+        return prev;
+      }
+      const next = makeEmptyLeg();
+      const prevLeg = prev[prev.length - 1];
+      if (prevLeg?.endDate) next.startDate = prevLeg.endDate;
+      capture("travel_leg_added", { legCount: prev.length + 1 });
+      computed = [...prev, next];
+      return computed;
+    });
+    if (computed.length > 0 && computed.every(legReadyToSubmit)) {
+      await persistDraft(computed);
+    }
+  }, [isAuthenticated, persistDraft]);
 
-  // Inverted ranges (endDate before startDate) are caught at the server
-  // boundary, but allowing them through the form yields a negative
-  // "N nights" display + negative analytics. Surface as invalid here.
-  const datesValid = Boolean(startDate && endDate && startDate <= endDate);
-  const canSubmit = destination && datesValid && coordsResolved;
+  const removeLeg = useCallback(async (index: number) => {
+    let computed: LegState[] = [];
+    setLegs((prev) => {
+      if (prev.length <= 1) {
+        computed = prev;
+        return prev;
+      }
+      capture("travel_leg_removed", { legCount: prev.length - 1 });
+      computed = prev.filter((_, i) => i !== index);
+      return computed;
+    });
+    if (computed.length > 1 && draftId && computed.every(legReadyToSubmit)) {
+      const result = await updateDraftSearch(draftId, {
+        destinations: computed.map(legToDestParams),
+      });
+      if ("error" in result) {
+        setSubmitError(result.error ?? "Could not update draft");
+      }
+    }
+    // If remove leaves 1 leg, the draft is orphaned; cron GC sweeps
+    // drafts older than a week. Not worth deleting eagerly — the user
+    // might re-add another leg.
+  }, [draftId]);
+
+  const canSubmit = legs.every(legReadyToSubmit);
+
+  const submitMultiLeg = useCallback(async () => {
+    const id = await persistDraft(legs);
+    if (!id) return;
+    router.push(`/travel?savedTripId=${encodeURIComponent(id)}`);
+    if (variant === "compact") setIsExpanded(false);
+  }, [legs, router, variant, persistDraft]);
+
+  const submitSingleLeg = useCallback((leg: LegState) => {
+    const params = new URLSearchParams({
+      lat: leg.latitude.toString(),
+      lng: leg.longitude.toString(),
+      from: leg.startDate,
+      to: leg.endDate,
+      r: leg.radiusKm.toString(),
+      q: leg.destination,
+    });
+    if (leg.timezone) params.set("tz", leg.timezone);
+    router.push(`/travel?${params.toString()}`);
+    if (variant === "compact") setIsExpanded(false);
+  }, [router, variant]);
 
   const handleSubmit = useCallback(() => {
+    setSubmitError(null);
     if (!canSubmit) {
-      // Boarding-pass aesthetic: the form visibly refuses, not silently.
-      // Stamp REQUIRED next to the missing section's margin label.
-      setDestInvalid(!destination || !coordsResolved);
-      setDatesInvalid(!datesValid);
+      // Boarding-pass aesthetic: REQUIRED stamps light up on attempt.
+      setHasAttemptedSubmit(true);
       return;
     }
     capture("travel_search_submitted", {
-      destination,
-      radiusKm,
-      dateRangeDays: daysBetween(startDate, endDate),
+      destination: legs[0].destination,
+      radiusKm: legs[0].radiusKm,
+      dateRangeDays: daysBetween(legs[0].startDate, legs[legs.length - 1].endDate),
+      legCount: legs.length,
     });
-    const params = new URLSearchParams({
-      lat: latitude.toString(),
-      lng: longitude.toString(),
-      from: startDate,
-      to: endDate,
-      r: radiusKm.toString(),
-      q: destination,
-    });
-    if (timezone) params.set("tz", timezone);
     startTransition(() => {
-      router.push(`/travel?${params.toString()}`);
+      if (legs.length === 1) {
+        submitSingleLeg(legs[0]);
+      } else {
+        void submitMultiLeg();
+      }
     });
-    if (variant === "compact") setIsExpanded(false);
-  }, [canSubmit, coordsResolved, datesValid, latitude, longitude, startDate, endDate, radiusKm, destination, timezone, router, variant]);
+  }, [canSubmit, legs, submitMultiLeg, submitSingleLeg]);
 
-  // ── Compact variant: single-row pill ──
   if (variant === "compact" && !isExpanded) {
-    return (
-      <button
-        onClick={() => { setIsExpanded(true); }}
-        className="
-          flex w-full items-center gap-3 rounded-full border border-border
-          bg-card px-6 py-3 text-left transition-colors hover:bg-accent
-          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
-        "
-        aria-label="Edit travel search"
-      >
-        <MapPin className="h-4 w-4 text-muted-foreground" />
-        <span className="font-medium">{destination || "Search"}</span>
-        <span className="text-muted-foreground">·</span>
-        <Calendar className="h-4 w-4 text-muted-foreground" />
-        <span className="font-mono text-sm text-muted-foreground">
-          {startDate && endDate
-            ? `${formatDateCompact(startDate, { withWeekday: true })} → ${formatDateCompact(endDate, { withWeekday: true })}`
-            : "Dates"}
-        </span>
-        <span className="text-muted-foreground">·</span>
-        <Compass className="h-4 w-4 text-muted-foreground" />
-        <span className="font-mono text-sm text-muted-foreground">{radiusKm} km</span>
-        <span className="ml-auto flex items-center gap-1.5 rounded-full bg-muted px-3 py-1.5 text-xs text-muted-foreground">
-          <Pencil className="h-3 w-3" />
-          Edit
-        </span>
-      </button>
-    );
+    return <CompactPill legs={legs} onExpand={() => setIsExpanded(true)} />;
   }
 
-  // ── Hero / Expanded variant: boarding pass form ──
+  const canAddLeg = legs.length < MAX_STOPS_PER_TRIP;
+  const isMultiLeg = legs.length > 1;
+
   return (
     <div className="travel-animate">
-      {/* Margin labels above the card border. REQUIRED stamps flip on when
-          submit is attempted with an empty field — diegetic to the
-          boarding-pass metaphor (the form visibly refuses) rather than
-          a generic toast. Clears when the user fills the field. */}
-      <div className="mb-2 grid grid-cols-3 gap-0 px-1 md:grid-cols-[2.4fr_1.4fr_1fr_auto]">
-        <div className="flex items-center gap-2 pl-5 text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground/70">
-          <MapPin className="h-3 w-3" />
-          Destination
-          {destInvalid && <RequiredStamp />}
-        </div>
-        <div className="hidden items-center gap-2 text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground/70 md:flex">
-          <Calendar className="h-3 w-3" />
-          Dates
-          {datesInvalid && <RequiredStamp />}
-        </div>
-        <div className="hidden items-center gap-2 text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground/70 md:flex">
-          <Compass className="h-3 w-3" />
-          Radius
-        </div>
-      </div>
-
-      {/* The boarding pass card */}
       <form
         onSubmit={(e) => {
           e.preventDefault();
           handleSubmit();
         }}
-        className="
-          travel-grain relative rounded-xl border-[1.5px] border-border
-          bg-card shadow-lg transition-all duration-300
-          focus-within:border-ring focus-within:shadow-xl
-          md:-rotate-[0.5deg] md:focus-within:rotate-0
-        "
-        style={{ "--travel-grain-opacity": "0.04" } as React.CSSProperties}
         role="search"
         aria-label="Travel search"
+        className="flex flex-col gap-3"
       >
-        <div className="grid grid-cols-1 md:grid-cols-[2.4fr_1.4fr_1fr_auto]">
-          {/* Destination section */}
-          <fieldset className="border-b border-dashed border-border p-5 md:border-b-0 md:border-r">
-            <legend className="sr-only">Destination</legend>
-            <DestinationInput
-              value={destination}
-              autoFocus={variant === "hero"}
-              onChange={(place) => {
-                setDestination(place.label);
-                setLatitude(place.latitude);
-                setLongitude(place.longitude);
-                setCoordsResolved(true);
-                // Always reset timezone before applying any new value —
-                // otherwise the prior selection's tz lingers when the new
-                // place's async tz lookup fails or hasn't returned yet
-                // (Codex). DestinationInput's currentSelectionRef guards
-                // against late callbacks; this guards against stale state.
-                setTimezone(place.timezone ?? "");
-                setDestInvalid(false);
-              }}
-              onClear={() => {
-                setDestination("");
-                setLatitude(0);
-                setLongitude(0);
-                setCoordsResolved(false);
-                setTimezone("");
-              }}
+        {legs.map((leg, i) => (
+          <LegRow
+            key={leg.id}
+            leg={leg}
+            legIndex={i}
+            isOnlyLeg={legs.length === 1}
+            autoFocus={variant === "hero" && i === 0 && legs.length === 1}
+            showRequiredStamps={hasAttemptedSubmit}
+            updateLeg={updateLeg}
+            removeLeg={legs.length > 1 ? removeLeg : undefined}
+          />
+        ))}
+
+        {canAddLeg && (
+          isAuthenticated ? (
+            <GhostLegRow nextIndex={legs.length + 1} onClick={addLeg} />
+          ) : (
+            <SignInToAddLegRow
+              nextIndex={legs.length + 1}
+              legs={legs}
+              variant={variant}
             />
-            {timezone && (
-              <p className="mt-1 text-xs text-muted-foreground">
-                {destination.split(",").slice(-1)[0]?.trim()} · {timezone.split("/").pop()?.replaceAll("_", " ")}
-              </p>
-            )}
-          </fieldset>
+          )
+        )}
 
-          {/* Dates section */}
-          <fieldset className="border-b border-dashed border-border p-5 md:border-b-0 md:border-r">
-            <legend className="sr-only">Dates</legend>
-            <div className="flex gap-2">
-              <input
-                type="date"
-                value={startDate}
-                onChange={(e) => {
-                  const next = e.target.value;
-                  setStartDate(next);
-                  // Only clear the invalid flag when the resulting range
-                  // is actually valid (both fields filled AND start <= end).
-                  // Inverted ranges otherwise slip past with the stamp gone.
-                  if (next && endDate && next <= endDate) setDatesInvalid(false);
-                }}
-                aria-label="Start date"
-                className="w-full bg-transparent font-mono text-sm focus:outline-none"
-              />
-              <span className="text-muted-foreground">→</span>
-              <input
-                type="date"
-                value={endDate}
-                onChange={(e) => {
-                  const next = e.target.value;
-                  setEndDate(next);
-                  if (startDate && next && startDate <= next) setDatesInvalid(false);
-                }}
-                aria-label="End date"
-                className="w-full bg-transparent font-mono text-sm focus:outline-none"
-              />
-            </div>
-            {startDate && endDate && startDate <= endDate && (
-              <p className="mt-1 text-xs text-muted-foreground">
-                {daysBetween(startDate, endDate)} nights
-              </p>
-            )}
-          </fieldset>
+        {submitError && (
+          <p
+            role="alert"
+            className="rounded-md border border-red-600/40 bg-red-600/5 px-4 py-2 font-mono text-xs text-red-600 dark:text-red-400"
+          >
+            {submitError}
+          </p>
+        )}
 
-          {/* Radius section */}
-          <fieldset className="border-b border-dashed border-border p-5 md:border-b-0 md:border-r">
-            <legend className="sr-only">Radius</legend>
-            <div className="flex flex-wrap gap-1.5">
-              {RADIUS_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => { setRadiusKm(opt.value); }}
-                  aria-pressed={radiusKm === opt.value}
-                  className={`
-                    rounded-md px-2.5 py-1 text-xs font-medium transition-colors
-                    ${
-                      radiusKm === opt.value
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-muted text-muted-foreground hover:bg-accent"
-                    }
-                  `}
-                >
-                  {opt.label}
-                </button>
-              ))}
-            </div>
-            <p className="mt-1.5 font-mono text-xs text-muted-foreground">
-              {radiusKm} km · ~{Math.round(radiusKm * 0.621)} mi
-            </p>
-          </fieldset>
-
-          {/* Submit section with barcode decoration */}
-          <div className="flex flex-col items-end justify-between gap-3 p-5">
-            {/* Decorative barcode */}
-            <div className="hidden items-end gap-px opacity-40 md:flex" aria-hidden="true">
-              {[60, 100, 70, 90, 50, 100, 65, 80, 45, 95, 70, 100].map((h, i) => (
-                <span
-                  key={i}
-                  className="block bg-muted-foreground"
-                  style={{ width: i % 3 === 1 ? 2 : 1, height: `${h * 0.22}px` }}
-                />
-              ))}
-            </div>
-            <Button
-              type="submit"
-              disabled={isPending}
-              className="
-                group gap-2 rounded-lg px-6 uppercase tracking-wider
-                transition-colors
-              "
-            >
-              {isPending ? "Searching…" : "Search"}
-              <Search className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-            </Button>
-          </div>
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border-[1.5px] border-foreground bg-foreground px-5 py-3 text-background">
+          <span className="font-mono text-[11px] uppercase tracking-[0.22em]">
+            <SubmitBarSummary legs={legs} />
+          </span>
+          <Button
+            type="submit"
+            disabled={isPending}
+            variant="secondary"
+            className="gap-2 rounded-md border border-background/20 bg-background text-foreground hover:bg-background/90"
+          >
+            {isPending ? "Searching…" : "Search"}
+            <Search className="h-4 w-4" />
+          </Button>
         </div>
       </form>
 
-      {/* ISSUED microlabel — `new Date()` mismatches between SSR and
-          client hydration on day boundaries. The whole row is
-          aria-hidden so the mismatch is purely cosmetic; suppress the
-          hydration warning rather than wire up a useEffect just for the
-          decoration. */}
-      <div className="mt-2 flex justify-between px-2 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground/40" aria-hidden="true">
-        <span suppressHydrationWarning>
-          ISSUED {new Date().toLocaleDateString("en-US", { day: "2-digit", month: "short", year: "2-digit" }).toUpperCase()} · HASHTRACKS
-        </span>
-        <span>REF HT-{resolveRefCode(destination)}</span>
-      </div>
+      {/* ISSUED microlabel — cosmetic, aria-hidden. Hero single-leg only. */}
+      {variant === "hero" && !isMultiLeg && (
+        <div
+          className="mt-2 flex justify-between px-2 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground/40"
+          aria-hidden="true"
+        >
+          <span suppressHydrationWarning>
+            ISSUED {new Date().toLocaleDateString("en-US", { day: "2-digit", month: "short", year: "2-digit" }).toUpperCase()} · HASHTRACKS
+          </span>
+          <span>REF HT-{resolveRefCode(legs[0].destination)}</span>
+        </div>
+      )}
 
-      {/* Collapse button when in expanded compact mode */}
       {variant === "compact" && isExpanded && (
         <div className="mt-3 text-center">
           <button
             type="button"
-            onClick={() => { setIsExpanded(false); }}
+            onClick={() => setIsExpanded(false)}
             className="text-xs text-muted-foreground underline underline-offset-4 hover:text-foreground"
           >
             Collapse
@@ -322,21 +361,388 @@ export function TravelSearchForm({ variant, initialValues }: Readonly<TravelSear
   );
 }
 
-/**
- * Rubber-stamp "REQUIRED" marker that appears next to a field's margin
- * label when a user attempts submit while that field is empty. Rotated,
- * red, monospace — reads as a gate-stamp on a physical boarding pass.
- * Fades in via the globals.css `travel-stamp-required` keyframe.
- */
-function RequiredStamp() {
+function SubmitBarSummary({ legs }: { legs: LegState[] }) {
+  if (legs.length === 1) {
+    const leg = legs[0];
+    if (!leg.startDate || !leg.endDate) return <>Ready when you are</>;
+    return (
+      <>
+        {formatDateCompact(leg.startDate)} → {formatDateCompact(leg.endDate)} · {formatNights(leg.startDate, leg.endDate)}
+      </>
+    );
+  }
+  const firstStart = legs[0].startDate;
+  const lastEnd = legs[legs.length - 1].endDate;
+  if (!firstStart || !lastEnd) return <>{legs.length} legs · pending dates</>;
   return (
-    <span
-      role="status"
-      aria-live="polite"
-      className="travel-stamp-required ml-2 inline-flex items-center rounded-sm border border-red-600/60 px-1 py-[1px] font-mono text-[9px] font-bold uppercase tracking-wider text-red-600"
-    >
-      Required
-    </span>
+    <>
+      {legs.length} legs · {formatDateCompact(firstStart)} → {formatDateCompact(lastEnd)} · {formatNights(firstStart, lastEnd)}
+    </>
   );
 }
 
+interface LegRowProps {
+  leg: LegState;
+  legIndex: number;
+  isOnlyLeg: boolean;
+  autoFocus: boolean;
+  showRequiredStamps: boolean;
+  updateLeg: (index: number, patch: Partial<LegState>) => void;
+  removeLeg?: (index: number) => void;
+}
+
+/**
+ * One boarding-pass row per leg. Memoized so typing into one leg's
+ * date input doesn't re-render other legs — `updateLeg` / `removeLeg`
+ * come from the parent as stable `useCallback` references that take
+ * the leg index as an argument, so the row can bind per-row closures
+ * without breaking referential equality.
+ */
+const LegRow = memo(function LegRow({
+  leg,
+  legIndex,
+  isOnlyLeg,
+  autoFocus,
+  showRequiredStamps,
+  updateLeg,
+  removeLeg,
+}: LegRowProps) {
+  const legLabel = `LEG ${String(legIndex + 1).padStart(2, "0")}`;
+  const destInvalid = showRequiredStamps && (!leg.destination || !leg.coordsResolved);
+  const datesInvalid = showRequiredStamps && !legDatesValid(leg);
+
+  const onDestinationChange = useCallback(
+    (place: { label: string; latitude: number; longitude: number; timezone?: string }) => {
+      updateLeg(legIndex, {
+        destination: place.label,
+        latitude: place.latitude,
+        longitude: place.longitude,
+        coordsResolved: true,
+        timezone: place.timezone ?? "",
+      });
+    },
+    [updateLeg, legIndex],
+  );
+  const onDestinationClear = useCallback(() => {
+    updateLeg(legIndex, {
+      destination: "",
+      latitude: 0,
+      longitude: 0,
+      coordsResolved: false,
+      timezone: "",
+    });
+  }, [updateLeg, legIndex]);
+  const onStartDateChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => updateLeg(legIndex, { startDate: e.target.value }),
+    [updateLeg, legIndex],
+  );
+  const onEndDateChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => updateLeg(legIndex, { endDate: e.target.value }),
+    [updateLeg, legIndex],
+  );
+  const onRadiusChange = useCallback(
+    (value: number) => updateLeg(legIndex, { radiusKm: value }),
+    [updateLeg, legIndex],
+  );
+  const onRemoveClick = useCallback(
+    () => removeLeg?.(legIndex),
+    [removeLeg, legIndex],
+  );
+
+  return (
+    <div className="travel-animate">
+      <div className="mb-2 grid grid-cols-3 gap-0 px-1 md:grid-cols-[auto_2.4fr_1.4fr_1fr_auto]">
+        <div className="hidden items-center justify-center text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground/70 md:flex">
+          &nbsp;
+        </div>
+        <div className="flex items-center gap-2 pl-5 text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground/70">
+          <MapPin className="h-3 w-3" />
+          Destination
+          {destInvalid && <BoardingStamp label="Required" variant="required" />}
+        </div>
+        <div className="hidden items-center gap-2 text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground/70 md:flex">
+          <Calendar className="h-3 w-3" />
+          Dates
+          {datesInvalid && <BoardingStamp label="Required" variant="required" />}
+        </div>
+        <div className="hidden items-center gap-2 text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground/70 md:flex">
+          <Compass className="h-3 w-3" />
+          Radius
+        </div>
+        <div />
+      </div>
+      <div
+        className={`
+          travel-grain relative rounded-xl border-[1.5px] border-border
+          bg-card shadow-lg transition-all duration-300
+          focus-within:border-ring focus-within:shadow-xl
+          ${isOnlyLeg ? "md:-rotate-[0.5deg] md:focus-within:rotate-0" : ""}
+        `}
+        style={{ "--travel-grain-opacity": "0.04" } as React.CSSProperties}
+      >
+        <div className="grid grid-cols-1 md:grid-cols-[auto_2.4fr_1.4fr_1fr_auto]">
+          <div className="flex items-start justify-center border-b border-dashed border-border p-5 md:border-b-0 md:border-r">
+            <BoardingStamp label={legLabel} variant="leg" />
+          </div>
+
+          <fieldset className="border-b border-dashed border-border p-5 md:border-b-0 md:border-r">
+            <legend className="sr-only">Leg {legIndex + 1} destination</legend>
+            <DestinationInput
+              value={leg.destination}
+              autoFocus={autoFocus}
+              onChange={onDestinationChange}
+              onClear={onDestinationClear}
+            />
+            {leg.timezone && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {leg.destination.split(",").slice(-1)[0]?.trim()} · {leg.timezone.split("/").pop()?.replaceAll("_", " ")}
+              </p>
+            )}
+          </fieldset>
+
+          <fieldset className="border-b border-dashed border-border p-5 md:border-b-0 md:border-r">
+            <legend className="sr-only">Leg {legIndex + 1} dates</legend>
+            <div className="flex gap-2">
+              <input
+                type="date"
+                value={leg.startDate}
+                onChange={onStartDateChange}
+                aria-label={`Leg ${legIndex + 1} start date`}
+                className="w-full bg-transparent font-mono text-sm focus:outline-none"
+              />
+              <span className="text-muted-foreground">→</span>
+              <input
+                type="date"
+                value={leg.endDate}
+                onChange={onEndDateChange}
+                aria-label={`Leg ${legIndex + 1} end date`}
+                className="w-full bg-transparent font-mono text-sm focus:outline-none"
+              />
+            </div>
+            {legDatesValid(leg) && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {formatNights(leg.startDate, leg.endDate)}
+              </p>
+            )}
+          </fieldset>
+
+          <fieldset className="border-b border-dashed border-border p-5 md:border-b-0 md:border-r">
+            <legend className="sr-only">Leg {legIndex + 1} radius</legend>
+            <RadiusPicker value={leg.radiusKm} onChange={onRadiusChange} />
+            <p className="mt-1.5 font-mono text-xs text-muted-foreground">
+              {leg.radiusKm} km · ~{Math.round(leg.radiusKm * 0.621)} mi
+            </p>
+          </fieldset>
+
+          <div className="flex items-start justify-center p-5">
+            {removeLeg && (
+              <button
+                type="button"
+                onClick={onRemoveClick}
+                aria-label={`Remove leg ${legIndex + 1}`}
+                className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-red-600/10 hover:text-red-600 dark:hover:text-red-400"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+function RadiusPicker({ value, onChange }: { value: number; onChange: (v: number) => void }) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {RADIUS_OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          aria-pressed={value === opt.value}
+          className={`
+            rounded-md px-2.5 py-1 text-xs font-medium transition-colors
+            ${
+              value === opt.value
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:bg-accent"
+            }
+          `}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Faded dashed-border row below the last committed leg. Tapping
+ * unfolds a fresh leg. Mirrors the boarding-pass "pending segment"
+ * metaphor — visible promise of future content without cluttering
+ * the primary ticket.
+ */
+function GhostLegRow({
+  nextIndex,
+  onClick,
+}: {
+  nextIndex: number;
+  onClick: () => void | Promise<void>;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="
+        group flex w-full items-center gap-4 rounded-xl border-[1.5px]
+        border-dashed border-muted-foreground/40 bg-card/40 p-5 text-left
+        transition-all duration-200
+        hover:border-muted-foreground/70 hover:bg-card
+      "
+    >
+      <BoardingStamp label={`LEG ${String(nextIndex).padStart(2, "0")}`} variant="ghost" />
+      <span className="flex items-center gap-2 font-mono text-[12px] uppercase tracking-[0.18em] text-muted-foreground/70 group-hover:text-foreground">
+        <Plus className="h-3.5 w-3.5" />
+        Add next stop
+      </span>
+      <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground/50">
+        Where next?
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Ghost-leg variant rendered for anonymous users. Tapping navigates
+ * to sign-in with a redirect back to the current form, so the user
+ * returns to the same editing state post-auth. Multi-leg planning is
+ * intentionally auth-only (drafts persist server-side via `saveDraftSearch`).
+ */
+function SignInToAddLegRow({
+  nextIndex,
+  legs,
+  variant,
+}: {
+  nextIndex: number;
+  legs: LegState[];
+  variant: "hero" | "compact";
+}) {
+  // Preserve the in-progress leg-1 params so the user lands back on
+  // /travel with the same destination after signing in. Multi-leg
+  // continuation post-signin happens via the form — not via URL —
+  // because the URL doesn't carry leg-N state pre-draft-save.
+  const returnTo = (() => {
+    if (legs.length === 0 || !legs[0].destination) return "/travel";
+    const leg = legs[0];
+    const p = new URLSearchParams({
+      lat: String(leg.latitude),
+      lng: String(leg.longitude),
+      from: leg.startDate,
+      to: leg.endDate,
+      r: String(leg.radiusKm),
+      q: leg.destination,
+    });
+    if (leg.timezone) p.set("tz", leg.timezone);
+    return `/travel?${p.toString()}`;
+  })();
+  const signInHref = `/sign-in?redirect_url=${encodeURIComponent(returnTo)}`;
+
+  return (
+    <a
+      href={signInHref}
+      onClick={() => capture("travel_auth_prompt_shown", {})}
+      className={`
+        group flex w-full items-center gap-4 rounded-xl border-[1.5px]
+        border-dashed border-muted-foreground/40 bg-card/40 p-5 text-left
+        transition-all duration-200
+        hover:border-muted-foreground/70 hover:bg-card
+      `}
+      aria-label={`Sign in to add leg ${nextIndex}`}
+      data-variant={variant}
+    >
+      <BoardingStamp label={`LEG ${String(nextIndex).padStart(2, "0")}`} variant="ghost" />
+      <span className="flex items-center gap-2 font-mono text-[12px] uppercase tracking-[0.18em] text-muted-foreground/70 group-hover:text-foreground">
+        <Lock className="h-3.5 w-3.5" />
+        Sign in to add leg
+      </span>
+      <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground/50">
+        Multi-city is free — just need an account
+      </span>
+    </a>
+  );
+}
+
+function CompactPill({ legs, onExpand }: { legs: LegState[]; onExpand: () => void }) {
+  const isMulti = legs.length > 1;
+  const firstStart = legs[0].startDate;
+  const lastEnd = legs[legs.length - 1].endDate;
+  const summary =
+    firstStart && lastEnd
+      ? `${formatDateCompact(firstStart, { withWeekday: true })} → ${formatDateCompact(lastEnd, { withWeekday: true })}`
+      : "Dates";
+
+  return (
+    <button
+      onClick={onExpand}
+      className="
+        flex w-full items-center gap-3 rounded-full border border-border
+        bg-card px-6 py-3 text-left transition-colors hover:bg-accent
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+      "
+      aria-label="Edit travel search"
+    >
+      <MapPin className="h-4 w-4 text-muted-foreground" />
+      <span className="font-medium">
+        {isMulti ? `${legs.length} legs` : legs[0].destination || "Search"}
+      </span>
+      <span className="text-muted-foreground">·</span>
+      <Calendar className="h-4 w-4 text-muted-foreground" />
+      <span className="font-mono text-sm text-muted-foreground">{summary}</span>
+      {!isMulti && (
+        <>
+          <span className="text-muted-foreground">·</span>
+          <Compass className="h-4 w-4 text-muted-foreground" />
+          <span className="font-mono text-sm text-muted-foreground">{legs[0].radiusKm} km</span>
+        </>
+      )}
+      <span className="ml-auto flex items-center gap-1.5 rounded-full bg-muted px-3 py-1.5 text-xs text-muted-foreground">
+        <Pencil className="h-3 w-3" />
+        Edit
+      </span>
+    </button>
+  );
+}
+
+type BoardingStampVariant = "leg" | "ghost" | "required";
+
+/**
+ * Rotated monospace badge used as the boarding-pass rubber-stamp
+ * vocabulary. `leg` — solid red LEG NN marker; `ghost` — dashed
+ * muted marker on pending slots; `required` — red, with the
+ * travel-stamp-required fade-in animation for submit-refusal.
+ */
+function BoardingStamp({
+  label,
+  variant,
+}: {
+  label: string;
+  variant: BoardingStampVariant;
+}) {
+  const baseClasses = "inline-flex items-center justify-center rounded-sm border-[1.5px] px-1.5 py-[1px] font-mono text-[10px] font-bold uppercase tracking-wider";
+  const variantClasses: Record<BoardingStampVariant, string> = {
+    leg: "border-red-600/70 text-red-600 dark:border-red-400/70 dark:text-red-400",
+    ghost: "border-dashed border-muted-foreground/50 text-muted-foreground",
+    required: "travel-stamp-required border-red-600/60 text-red-600 ml-2 text-[9px]",
+  };
+  return (
+    <span
+      role={variant === "required" ? "status" : undefined}
+      aria-live={variant === "required" ? "polite" : undefined}
+      className={`${baseClasses} ${variantClasses[variant]}`}
+      style={{ transform: "rotate(-1.5deg)" }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -101,9 +101,14 @@ interface MapColocatedKennelPopoverProps {
 // ── Travel Mode ──────────────────────────────────────────────────────
 
 interface TravelSearchSubmittedProps {
+  /** First-leg destination for multi-leg trips (preserves the single-dest contract). */
   destination: string;
+  /** First-leg radius. */
   radiusKm: number;
+  /** Days from first leg start to last leg end. */
   dateRangeDays: number;
+  /** Leg count: 1 for single-dest, 2–3 for multi-stop. */
+  legCount: number;
 }
 
 interface TravelSearchResultsViewedProps {
@@ -161,6 +166,11 @@ interface TravelMultidestViewChangedProps {
   view: "day-by-day" | "by-destination";
 }
 
+interface TravelLegCountChangedProps {
+  /** Leg count AFTER the add/remove. 1..MAX_STOPS_PER_TRIP. */
+  legCount: number;
+}
+
 // ── Event Map ────────────────────────────────────────────────────────
 
 interface AnalyticsEventMap {
@@ -207,6 +217,8 @@ interface AnalyticsEventMap {
   travel_popular_destination_clicked: TravelPopularDestinationClickedProps;
   travel_filter_applied: TravelFilterAppliedProps;
   travel_multidest_view_changed: TravelMultidestViewChangedProps;
+  travel_leg_added: TravelLegCountChangedProps;
+  travel_leg_removed: TravelLegCountChangedProps;
 }
 
 /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -205,6 +205,7 @@ interface AnalyticsEventMap {
   travel_source_link_clicked: TravelSourceLinkClickedProps;
   travel_save_clicked: TravelSaveClickedProps;
   travel_auth_prompt_shown: Record<string, never>;
+  travel_auth_prompt_clicked: Record<string, never>;
   travel_saved_search_created: TravelSavedSearchCreatedProps;
   travel_saved_search_viewed: TravelSavedSearchViewedProps;
   travel_saved_search_updated: Record<string, never>;

--- a/src/lib/travel/format.ts
+++ b/src/lib/travel/format.ts
@@ -43,6 +43,15 @@ export function daysBetween(start: string, end: string): number {
   return Math.max(1, Math.round((e.getTime() - s.getTime()) / (24 * 60 * 60 * 1000)));
 }
 
+/** Pluralize the trip-window night count: "1 night" / "3 nights". Four
+ *  UI sites (TravelSearchForm, SavedTripCard, TripSummary, compact pill)
+ *  repeat this; kept here next to `daysBetween` so callers share one
+ *  pluralization rule. */
+export function formatNights(start: string, end: string): string {
+  const n = daysBetween(start, end);
+  return `${n} night${n !== 1 ? "s" : ""}`;
+}
+
 /**
  * Signed day delta between two YYYY-MM-DD strings: `(end - start)` in days.
  * Returns 0 for same day, positive for end-after-start, negative otherwise.

--- a/src/lib/travel/format.ts
+++ b/src/lib/travel/format.ts
@@ -49,7 +49,7 @@ export function daysBetween(start: string, end: string): number {
  *  pluralization rule. */
 export function formatNights(start: string, end: string): string {
   const n = daysBetween(start, end);
-  return `${n} night${n !== 1 ? "s" : ""}`;
+  return `${n} night${n === 1 ? "" : "s"}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Second of three sub-PRs for Phase 6 PR 3 (after 3c.1's server-action plumbing). Rewrites `TravelSearchForm` into a 1–3 leg editor with the ghost-leg pattern from the frontend-design mocks and auto-saves drafts server-side so multi-stop URLs route through `?savedTripId=<id>`.

Plan: `/Users/johnclem/.claude/plans/majestic-baking-donut.md`

### PR 3 sub-split recap
- ✅ **PR 3a** / **PR 3b** / **PR 3c.1** merged
- ➡️ **PR 3c.2** (this PR): form ghost-leg rows + draft auto-save + auth gate
- **PR 3c.3**: TripSummary multi-stop hero + compact-form multi-leg initial-values wiring

### Form behavior
- State is `legs: LegState[]`. Each leg has a stable `id` (crypto.randomUUID) used as the React key — prevents DestinationInput's local state from drifting onto the wrong leg after a middle remove.
- Ghost-leg row below the last leg. Adds empty leg whose start date anchors to prev leg's end date (overlap-day default).
- Per-leg remove button (X) on multi-leg rows.
- Submit branches: single-leg keeps the stateless `?q=&lat=&lng=&from=&to=&r=` URL (anonymous-friendly). Multi-leg navigates to `?savedTripId=<draftId>`.

### Draft idempotency (Codex finding)
- `persistDraft(nextLegs)` creates-or-updates a single draft row. First ready state → `saveDraftSearch`; subsequent edits → `updateDraftSearch` against the stored draftId. Kills the unbounded draft accretion previous design would have caused.

### Auth gate (Codex finding)
- Multi-leg requires auth (drafts persist server-side). `isAuthenticated` prop gates the ghost row: anonymous users see `<SignInToAddLegRow>` which navigates to `/sign-in?redirect_url=...` preserving leg-1's params. Single-leg flow stays anonymous.

### Stable keys (Codex finding)
- React key is `leg.id`, not array index — prevents the "wrong DestinationInput state" bug when a middle leg is removed.

### Simplify pass (applied pre-PR)
- Dropped `destInvalid`/`datesInvalid` per-leg flags → single form-level `hasAttemptedSubmit` boolean.
- Extracted `formatNights(start, end)` in `@/lib/travel/format` (used by form + SavedTripCard).
- `BoardingStamp` primitive replaces `LegStamp` + `RequiredStamp`.
- `LegRow` wrapped in `React.memo` with stable per-row callbacks so typing into one leg doesn't re-render the others.

### Plumbing
- page.tsx calls `safeGetUser()` up front; threads `isAuthenticated` into both compact + hero form instances. TravelHero accepts + passes through.
- Analytics: new `travel_leg_added` / `travel_leg_removed`; extended `travel_search_submitted` with `legCount`.

## Test plan
- [x] `/simplify` (3 parallel review agents) applied
- [x] `/codex:adversarial-review` — 3 findings addressed (stable keys, auth gate, draft idempotency)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all changed files
- [x] 4994 tests pass (no new form tests yet — RTL harness deferred to a later PR)
- [ ] Manual post-merge: anonymous user fills single leg → works. Tries to add leg 2 → sees Sign-in prompt. Signs in and returns to form → continues adding legs. Authenticated user adds 3 legs → Search navigates to `?savedTripId=`.
- [ ] PR 3c.3: TripSummary multi-stop hero + compact multi-leg init

🤖 Generated with [Claude Code](https://claude.com/claude-code)