### PR TITLE
fix(merge): collapse cross-source URL-less/URL-bearing runNumber races

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -2148,6 +2148,40 @@ describe("pickCanonicalEventId", () => {
     expect(canonicals.has("url-bearing")).toBe(true);
   });
 
+  it("#866 URL-less internally conflicted times + URL-bearing blank-time peer blocks collapse", () => {
+    // Codex review regression: URL-less group has {09:00, 18:00}, URL-bearing
+    // peer has null startTime. A blank peer cannot disambiguate which of the
+    // two URL-less rows it matches, so collapse must be blocked.
+    const urlLessMorning = candidate({
+      id: "url-less-morning",
+      runNumber: 99,
+      title: "Run #99",
+      startTime: "09:00",
+      sourceUrl: null,
+    });
+    const urlLessEvening = candidate({
+      id: "url-less-evening",
+      runNumber: 99,
+      title: "Run #99",
+      startTime: "18:00",
+      sourceUrl: null,
+    });
+    const urlBearingBlank = candidate({
+      id: "url-bearing-blank",
+      runNumber: 99,
+      title: "Run #99",
+      startTime: null,
+      sourceUrl: "https://example.com/99",
+    });
+    const canonicals = pickCanonicalEventIds([
+      urlLessMorning,
+      urlLessEvening,
+      urlBearingBlank,
+    ]);
+    expect(canonicals.size).toBe(2);
+    expect(canonicals.has("url-bearing-blank")).toBe(true);
+  });
+
   it("#866 ambiguous URL-less + two URL-bearing peers preserves all groups", () => {
     // Conservative fallback: if the URL-less row could belong to either of
     // two URL-bearing multi-part rows, don't guess — keep all three

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -2033,11 +2033,152 @@ describe("pickCanonicalEventId", () => {
       rowB: { id: "newer", ...DUP_SIG, trustLevel: 8, status: "CANCELLED" as const, createdAt: new Date("2026-03-01T00:00:00Z") },
       expectedCanonicals: ["newer"],
     },
+    {
+      // #866 cross-source race path: one source emits (runNumber, no URL),
+      // another emits (runNumber, URL). Pre-fix their signatures differ
+      // (`run#N::` vs `run#N::<url>`) and both survive as canonical.
+      name: "#866 URL-less + URL-bearing at same runNumber + compatible startTime collapses",
+      rowA: { id: "url-less", trustLevel: 5, runNumber: 1704, title: "Run #1704", startTime: "14:00", sourceUrl: null },
+      rowB: { id: "url-bearing", trustLevel: 5, runNumber: 1704, title: "Run #1704", startTime: "14:00", sourceUrl: "https://example.com/1704", haresText: "hares", locationName: "park" },
+      expectedCanonicals: ["url-bearing"],
+    },
+    {
+      name: "#866 collapse works when both sides have null startTime",
+      rowA: { id: "url-less", trustLevel: 5, runNumber: 42, title: "Run #42", sourceUrl: null },
+      rowB: { id: "url-bearing", trustLevel: 7, runNumber: 42, title: "Run #42", sourceUrl: "https://example.com/42" },
+      expectedCanonicals: ["url-bearing"],
+    },
+    {
+      // Safety: if the URL-less row claims a different time than the
+      // URL-bearing row, treat them as separate events (e.g. someone typo'd
+      // the runNumber into a different trail).
+      name: "#866 conflicting startTimes keep both canonicals",
+      rowA: { id: "url-less", trustLevel: 5, runNumber: 1704, title: "Run #1704", startTime: "09:00", sourceUrl: null },
+      rowB: { id: "url-bearing", trustLevel: 5, runNumber: 1704, title: "Run #1704", startTime: "18:00", sourceUrl: "https://example.com/1704" },
+      expectedCanonicals: ["url-less", "url-bearing"],
+    },
+    {
+      // AVLH3 multi-part preservation: two URL-bearing rows for the same
+      // runNumber at distinct URLs must still produce two canonicals
+      // because neither is URL-less (no race to collapse).
+      name: "AVLH3 multi-part still splits when neither side is URL-less",
+      rowA: { id: "a", runNumber: 786, title: "AVLH3 #786 Part B", sourceUrl: "https://meetup.com/events/299709371/" },
+      rowB: { id: "b", runNumber: 786, title: "AVLH3 #786 Part C", sourceUrl: "https://meetup.com/events/299709393/" },
+      expectedCanonicals: ["a", "b"],
+    },
   ])("$name", ({ rowA, rowB, expectedCanonicals }) => {
     const canonicals = pickCanonicalEventIds([candidate(rowA), candidate(rowB)]);
     expect([...canonicals].sort((a, b) => a.localeCompare(b))).toEqual(
       [...expectedCanonicals].sort((a, b) => a.localeCompare(b)),
     );
+  });
+
+  it("#866 two URL-less rows + one URL-bearing row collapse into one canonical", () => {
+    // The URL-less signature group buckets BOTH null-URL rows together
+    // (signature ignores startTime when runNumber is set). The helper must
+    // inspect every row's startTime, not just [0], or input order decides
+    // whether collapse happens.
+    const urlLessA = candidate({
+      id: "url-less-a",
+      runNumber: 1704,
+      title: "Run #1704",
+      startTime: null,
+      sourceUrl: null,
+    });
+    const urlLessB = candidate({
+      id: "url-less-b",
+      runNumber: 1704,
+      title: "Run #1704",
+      startTime: "14:00",
+      sourceUrl: null,
+    });
+    const urlBearing = candidate({
+      id: "url-bearing",
+      trustLevel: 8,
+      runNumber: 1704,
+      title: "Run #1704",
+      startTime: "14:00",
+      sourceUrl: "https://example.com/1704",
+    });
+    // Order should not matter: run both permutations.
+    for (const rows of [
+      [urlLessA, urlLessB, urlBearing],
+      [urlLessB, urlLessA, urlBearing],
+      [urlBearing, urlLessA, urlLessB],
+    ]) {
+      const canonicals = pickCanonicalEventIds(rows);
+      expect(canonicals.size).toBe(1);
+      expect(canonicals.has("url-bearing")).toBe(true);
+    }
+  });
+
+  it("#866 URL-less group with conflicting internal time blocks collapse", () => {
+    // If the URL-less group contains rows with two different concrete times,
+    // it can't be the same event as a single-time URL-bearing peer. Safety:
+    // keep both groups canonical rather than silently merging.
+    const urlLessMorning = candidate({
+      id: "url-less-morning",
+      runNumber: 42,
+      title: "Run #42",
+      startTime: "09:00",
+      sourceUrl: null,
+    });
+    const urlLessEvening = candidate({
+      id: "url-less-evening",
+      runNumber: 42,
+      title: "Run #42",
+      startTime: "18:00",
+      sourceUrl: null,
+    });
+    const urlBearing = candidate({
+      id: "url-bearing",
+      runNumber: 42,
+      title: "Run #42",
+      startTime: "18:00",
+      sourceUrl: "https://example.com/42",
+    });
+    const canonicals = pickCanonicalEventIds([
+      urlLessMorning,
+      urlLessEvening,
+      urlBearing,
+    ]);
+    // URL-less group stays (it's one signature group, one canonical winner
+    // by trust/completeness), URL-bearing stays — two canonicals total.
+    expect(canonicals.size).toBe(2);
+    expect(canonicals.has("url-bearing")).toBe(true);
+  });
+
+  it("#866 ambiguous URL-less + two URL-bearing peers preserves all groups", () => {
+    // Conservative fallback: if the URL-less row could belong to either of
+    // two URL-bearing multi-part rows, don't guess — keep all three
+    // canonicals. Reproducing #866 for this rare topology beats silently
+    // collapsing a genuine multi-part event.
+    const urlLess = candidate({
+      id: "url-less",
+      runNumber: 786,
+      title: "AVLH3 #786",
+      startTime: null,
+      sourceUrl: null,
+    });
+    const partB = candidate({
+      id: "part-b",
+      runNumber: 786,
+      title: "AVLH3 #786 Part B",
+      startTime: null,
+      sourceUrl: "https://meetup.com/events/299709371/",
+    });
+    const partC = candidate({
+      id: "part-c",
+      runNumber: 786,
+      title: "AVLH3 #786 Part C",
+      startTime: null,
+      sourceUrl: "https://meetup.com/events/299709393/",
+    });
+    const canonicals = pickCanonicalEventIds([urlLess, partB, partC]);
+    expect(canonicals.size).toBe(3);
+    expect(canonicals.has("url-less")).toBe(true);
+    expect(canonicals.has("part-b")).toBe(true);
+    expect(canonicals.has("part-c")).toBe(true);
   });
 
   it("flips the winner when equal-trust completeness shifts after an update", () => {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1149,6 +1149,72 @@ function eventSignature(e: CanonicalCandidate): string {
 }
 
 /**
+ * Collapse signature groups that share a runNumber when one group is
+ * URL-bearing and the other is URL-less, provided startTimes don't conflict.
+ *
+ * Covers the cross-source race path (#866): one source emits
+ * `(runNumber, no URL)` and another emits `(runNumber, URL)`. They produce
+ * distinct signatures (`run#N::` vs `run#N::<url>`) but are the same event.
+ *
+ * Preserves multi-part events: two URL-bearing groups with the same
+ * runNumber at distinct URLs (AVLH3 #786 Part B/C) stay split because
+ * neither is URL-less.
+ *
+ * Ambiguous cases — a URL-less group with two or more compatible URL-bearing
+ * peers — are left alone. Collapsing would incorrectly merge genuine
+ * multi-part events; reproducing #866 for that rare topology is safer.
+ *
+ * Compatibility is computed over every row in each group, not just the first:
+ * `eventSignature` ignores startTime when runNumber is set, so one URL-less
+ * group can contain rows with differing times. Collapse only when the two
+ * groups' non-blank startTime sets are either empty or equal.
+ */
+function collapseRunNumberRaces(groups: CanonicalCandidate[][]): CanonicalCandidate[][] {
+  const nonBlankTimes = (group: CanonicalCandidate[]): Set<string> => {
+    const set = new Set<string>();
+    for (const row of group) {
+      const t = row.startTime?.trim();
+      if (t) set.add(t);
+    }
+    return set;
+  };
+  const timesCompatible = (a: Set<string>, b: Set<string>): boolean => {
+    if (a.size === 0 || b.size === 0) return true;
+    if (a.size !== b.size) return false;
+    for (const t of a) if (!b.has(t)) return false;
+    return true;
+  };
+  const isUrlLess = (group: CanonicalCandidate[]): boolean =>
+    // Signature buckets by trimmed URL, so every row in a group shares the
+    // same URL presence — `[0]` is a safe proxy for the whole group here.
+    (group[0].sourceUrl?.trim() || "") === "";
+
+  const absorbed = new Set<number>();
+  for (let i = 0; i < groups.length; i++) {
+    if (absorbed.has(i)) continue;
+    const urlLess = groups[i];
+    const rep = urlLess[0];
+    if (rep.runNumber == null) continue;
+    if (!isUrlLess(urlLess)) continue;
+    const urlLessTimes = nonBlankTimes(urlLess);
+    const peers: number[] = [];
+    for (let j = 0; j < groups.length; j++) {
+      if (j === i || absorbed.has(j)) continue;
+      const peer = groups[j];
+      if (peer[0].runNumber !== rep.runNumber) continue;
+      if (isUrlLess(peer)) continue;
+      if (!timesCompatible(urlLessTimes, nonBlankTimes(peer))) continue;
+      peers.push(j);
+    }
+    if (peers.length === 1) {
+      groups[peers[0]].push(...urlLess);
+      absorbed.add(i);
+    }
+  }
+  return groups.filter((_, i) => !absorbed.has(i));
+}
+
+/**
  * Pick canonical row id(s) across a (kennelId, date) group. Rows group by
  * signature; distinct signatures each keep a canonical. Within a group:
  *   1. Prefer non-CANCELLED rows — every display path filters
@@ -1170,7 +1236,9 @@ export function pickCanonicalEventIds(events: CanonicalCandidate[]): Set<string>
     bySignature.set(sig, group);
   }
 
-  for (const group of bySignature.values()) {
+  const mergedGroups = collapseRunNumberRaces(Array.from(bySignature.values()));
+
+  for (const group of mergedGroups) {
     // Prefer live rows; if the whole group is cancelled, keep them all eligible
     // so reconcile has a stable canonical pointer to un-cancel later.
     const live = group.filter(e => e.status !== "CANCELLED");

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1179,7 +1179,12 @@ function collapseRunNumberRaces(groups: CanonicalCandidate[][]): CanonicalCandid
     return set;
   };
   const timesCompatible = (a: Set<string>, b: Set<string>): boolean => {
-    if (a.size === 0 || b.size === 0) return true;
+    // A blank peer (size 0) can't disambiguate an internally time-conflicted
+    // group — if `a` has {09:00, 18:00} and `b` is all-null, collapsing
+    // would silently fold two distinct events into one. Only allow the
+    // empty-side shortcut when the other side has at most one concrete time.
+    if (a.size === 0) return b.size <= 1;
+    if (b.size === 0) return a.size <= 1;
     if (a.size !== b.size) return false;
     for (const t of a) if (!b.has(t)) return false;
     return true;
@@ -1207,10 +1212,20 @@ function collapseRunNumberRaces(groups: CanonicalCandidate[][]): CanonicalCandid
       peers.push(j);
     }
     if (peers.length === 1) {
-      groups[peers[0]].push(...urlLess);
+      // Replace the peer with a new concatenated array so we don't mutate
+      // the bucket still referenced by the outer signature map — easier to
+      // reason about even though nothing downstream reads it.
+      groups[peers[0]] = [...groups[peers[0]], ...urlLess];
       absorbed.add(i);
     }
   }
+  // Footgun: `pickCanonicalEventIds` picks the winner by trustLevel then
+  // completeness. If a URL-less source has strictly higher trustLevel than
+  // the URL-bearing peer it gets absorbed into, the URL-less row wins
+  // canonical and `Event.sourceUrl` will be null despite a URL-bearing
+  // sibling existing in the group. No source combination produces this
+  // today (URL-bearing sources are trusted ≥ URL-less), but watch for it
+  // if trust levels are rebalanced.
   return groups.filter((_, i) => !absorbed.has(i));
 }
 


### PR DESCRIPTION
## Summary

Closes #866.

- Adds `collapseRunNumberRaces()` in `src/pipeline/merge.ts`: after signature grouping and before canonical selection, absorb a URL-less signature group into its URL-bearing peer when they share a runNumber and startTimes don't conflict.
- Preserves multi-part events (AVLH3 #786 Part B/C) — collapse only fires when one side is URL-less; two URL-bearing groups stay split.
- Conservative fallback: ambiguous topologies (URL-less + 2+ compatible URL-bearing peers) leave all groups canonical.

## Why

Two scrape sources fan out concurrently via QStash. If one emits `sourceUrl` populated and the other doesn't, `eventSignature()` produces `run#N::` vs `run#N::<url>` and both survive — the exact #826 symptom this issue is following up on. The PR #865 upsert matcher only handles the sequential case; this closes the concurrent-create race by letting the post-group reconcile pass in `pickCanonicalEventIds` self-heal on the next scrape.

## Implementation notes

- Compatibility is checked over every row's startTime in each group, not just the representative — signature ignores startTime when runNumber is set, so one URL-less group can contain rows with different times. Required to keep behavior stable against input order.
- Chose option 2 from the issue (post-create reconcile pass) over option 1 (URL-agnostic signature) because option 1 risks collapsing genuine multi-part events.
- Pure logic change in a pure function — no schema or migration needed.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 errors)
- [x] `npm test` — 5009 pass, 238 in `merge.test.ts`
- [x] New regression cases cover: URL-less + URL-bearing collapse (matching + blank startTimes), conflicting startTimes stay split, multi-row URL-less group order-independence (3 permutations), internal time conflict blocks collapse, AVLH3 multi-part preservation, ambiguous three-group topology
- [ ] Post-merge: watch for a drop in same-runNumber canonical dupes surfaced by future reconcile audits

🤖 Generated with [Claude Code](https://claude.com/claude-code)