### PR TITLE
feat(health): promote reconcile-suppression to RECONCILE_SUPPRESSED alert

### DIFF
--- a/prisma/migrations/20260422140239_add_reconcile_suppressed_alert_type/migration.sql
+++ b/prisma/migrations/20260422140239_add_reconcile_suppressed_alert_type/migration.sql
@@ -1,0 +1,4 @@
+-- AlterEnum
+-- IF NOT EXISTS keeps deploy idempotent when the enum value is already present
+-- (e.g. hand-applied on a staging DB or a partially-replayed history).
+ALTER TYPE "AlertType" ADD VALUE IF NOT EXISTS 'RECONCILE_SUPPRESSED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -473,6 +473,7 @@ enum AlertType {
   UNMATCHED_TAGS // New unmatched kennel tags appeared
   SOURCE_KENNEL_MISMATCH // Resolved kennel not linked to source
   EXCESSIVE_CANCELLATIONS // Too many events cancelled in one scrape
+  RECONCILE_SUPPRESSED // Reconcile skipped stale-event cancellation for kennel(s) due to unparseable dates
 }
 
 enum AlertSeverity {

--- a/src/pipeline/auto-issue.ts
+++ b/src/pipeline/auto-issue.ts
@@ -26,6 +26,7 @@ const AUTO_FILE_ALERT_TYPES = new Set([
   "STRUCTURE_CHANGE",
   "FIELD_FILL_DROP",
   "UNMATCHED_TAGS",
+  "RECONCILE_SUPPRESSED",
 ]);
 
 /** Severities eligible for automatic issue filing. */
@@ -111,6 +112,9 @@ export function buildRelevantFiles(alertType: string, sourceType: string, source
     case "SOURCE_KENNEL_MISMATCH":
       files.push("src/pipeline/merge.ts", "src/pipeline/kennel-resolver.ts", "prisma/seed.ts");
       break;
+    case "RECONCILE_SUPPRESSED":
+      files.push("src/pipeline/reconcile.ts", "src/lib/date.ts");
+      break;
   }
 
   return [...new Set(files)]; // deduplicate
@@ -148,6 +152,11 @@ function buildContextSection(alertType: string, ctx: Record<string, unknown> | n
       const blockedList = (Array.isArray(ctx.tags) ? ctx.tags : []).map((t: string) => "- `" + t + "`").join("\n");
       return `### Blocked Tags\n${blockedList}\n\nThese tags resolved to valid kennels but those kennels are not linked to this source via SourceKennel.`;
     }
+    case "RECONCILE_SUPPRESSED": {
+      const kennels = Array.isArray(ctx.kennelsSuppressed) ? ctx.kennelsSuppressed : [];
+      const kennelList = kennels.map((k: string) => "- `" + k + "`").join("\n");
+      return `### Suppressed Kennels\n${kennelList}\n\nReconciliation skipped stale-event cancellation for these kennel IDs because the adapter emitted unparseable dates. Stale CONFIRMED events will not be cancelled until dates parse cleanly again.`;
+    }
     default:
       return "";
   }
@@ -181,6 +190,8 @@ function buildSuggestedApproach(alertType: string, ctx: Record<string, unknown> 
       return "Check source URL accessibility. Review error messages for network, auth, or parsing failures.";
     case "SOURCE_KENNEL_MISMATCH":
       return "Add the SourceKennel link if the source legitimately provides events for that kennel, or update the adapter to produce the correct tag.";
+    case "RECONCILE_SUPPRESSED":
+      return "Inspect adapter output for the listed kennels — the date field is failing `toIsoDateString`. Typical causes: unexpected date formats, timezone-only strings, or missing dates. Fix the parser so every emitted row has a valid UTC date.";
     default:
       return "Investigate the alert context and relevant files.";
   }

--- a/src/pipeline/health.test.ts
+++ b/src/pipeline/health.test.ts
@@ -4,6 +4,7 @@ vi.mock("@/lib/db", () => ({
   prisma: {
     scrapeLog: { findMany: vi.fn() },
     alert: { findMany: vi.fn(), update: vi.fn() },
+    kennel: { findMany: vi.fn() },
   },
 }));
 
@@ -11,6 +12,7 @@ import { prisma } from "@/lib/db";
 import { analyzeHealth, autoResolveCleared } from "./health";
 
 const mockScrapeLogFind = vi.mocked(prisma.scrapeLog.findMany);
+const mockKennelFindMany = vi.mocked(prisma.kennel.findMany);
 
 const baseFillRates = { title: 100, location: 80, hares: 50, startTime: 90, runNumber: 70 };
 
@@ -43,6 +45,9 @@ beforeEach(() => {
   mockScrapeLogFind
     .mockResolvedValueOnce(baselineEntries as never)  // recentSuccessful
     .mockResolvedValueOnce([] as never);               // recentAll
+  // Default: no kennel lookups needed; tests that exercise RECONCILE_SUPPRESSED
+  // override this with their own mockResolvedValueOnce.
+  mockKennelFindMany.mockResolvedValue([] as never);
 });
 
 describe("analyzeHealth", () => {
@@ -88,6 +93,9 @@ describe("analyzeHealth", () => {
     expect(result.checkedTypes).toContain("STRUCTURE_CHANGE");
     expect(result.checkedTypes).toContain("UNMATCHED_TAGS");
     expect(result.checkedTypes).toContain("SOURCE_KENNEL_MISMATCH");
+    // RECONCILE_SUPPRESSED is only checked when reconcile actually ran —
+    // see the dedicated describe block below for gated behavior.
+    expect(result.checkedTypes).not.toContain("RECONCILE_SUPPRESSED");
   });
 
   it("omits trend check types from checkedTypes when no baseline", async () => {
@@ -176,6 +184,106 @@ describe("SOURCE_KENNEL_MISMATCH alerts", () => {
     const alert = result.alerts.find(a => a.type === "SOURCE_KENNEL_MISMATCH");
     expect(alert!.title).toContain("1 kennel tag blocked");
     expect(alert!.title).not.toContain("tags");
+  });
+});
+
+describe("RECONCILE_SUPPRESSED alerts", () => {
+  it("does not check or alert when reconcile did not run", async () => {
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      reconcileSuppressedKennels: ["knl_1"],
+      // reconcileEvaluated omitted — simulates scrape where reconcile was skipped
+    }));
+    expect(result.alerts.find((a) => a.type === "RECONCILE_SUPPRESSED")).toBeUndefined();
+    expect(result.checkedTypes).not.toContain("RECONCILE_SUPPRESSED");
+    expect(mockKennelFindMany).not.toHaveBeenCalled();
+  });
+
+  it("registers check but skips alert when reconcile ran with no suppression", async () => {
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      reconcileEvaluated: true,
+      reconcileSuppressedKennels: [],
+    }));
+    expect(result.alerts.find((a) => a.type === "RECONCILE_SUPPRESSED")).toBeUndefined();
+    expect(result.checkedTypes).toContain("RECONCILE_SUPPRESSED");
+    expect(mockKennelFindMany).not.toHaveBeenCalled();
+  });
+
+  it("registers check but skips alert when reconcile ran with undefined suppression", async () => {
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      reconcileEvaluated: true,
+    }));
+    expect(result.alerts.find((a) => a.type === "RECONCILE_SUPPRESSED")).toBeUndefined();
+    expect(result.checkedTypes).toContain("RECONCILE_SUPPRESSED");
+    expect(mockKennelFindMany).not.toHaveBeenCalled();
+  });
+
+  it("generates one WARNING alert with resolved shortNames and kennelsSuppressed context", async () => {
+    mockKennelFindMany.mockReset();
+    mockKennelFindMany.mockResolvedValueOnce([
+      { id: "knl_1", shortName: "NYCH3" },
+      { id: "knl_2", shortName: "BFM" },
+    ] as never);
+
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      reconcileEvaluated: true,
+      reconcileSuppressedKennels: ["knl_1", "knl_2"],
+    }));
+
+    const alert = result.alerts.find((a) => a.type === "RECONCILE_SUPPRESSED");
+    expect(alert).toBeDefined();
+    expect(alert!.severity).toBe("WARNING");
+    expect(alert!.title).toContain("2 kennels");
+    expect(alert!.details).toContain("NYCH3");
+    expect(alert!.details).toContain("BFM");
+    expect((alert!.context!.kennelsSuppressed as string[])).toEqual(["knl_1", "knl_2"]);
+    expect(result.healthStatus).toBe("DEGRADED");
+  });
+
+  it("uses singular grammar for one suppressed kennel", async () => {
+    mockKennelFindMany.mockReset();
+    mockKennelFindMany.mockResolvedValueOnce([
+      { id: "knl_1", shortName: "NYCH3" },
+    ] as never);
+
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      reconcileEvaluated: true,
+      reconcileSuppressedKennels: ["knl_1"],
+    }));
+
+    const alert = result.alerts.find((a) => a.type === "RECONCILE_SUPPRESSED");
+    expect(alert!.title).toContain("1 kennel");
+    expect(alert!.title).not.toMatch(/\bkennels\b/);
+  });
+
+  it("falls back to raw kennel ID when shortName lookup misses", async () => {
+    mockKennelFindMany.mockReset();
+    mockKennelFindMany.mockResolvedValueOnce([] as never);
+
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      reconcileEvaluated: true,
+      reconcileSuppressedKennels: ["knl_orphan"],
+    }));
+
+    const alert = result.alerts.find((a) => a.type === "RECONCILE_SUPPRESSED");
+    expect(alert).toBeDefined();
+    expect(alert!.details).toContain("knl_orphan");
+    expect((alert!.context!.kennelsSuppressed as string[])).toEqual(["knl_orphan"]);
+  });
+
+  it("falls back to raw IDs without rejecting when kennel lookup throws", async () => {
+    mockKennelFindMany.mockReset();
+    mockKennelFindMany.mockRejectedValueOnce(new Error("transient DB error") as never);
+
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      reconcileEvaluated: true,
+      reconcileSuppressedKennels: ["knl_1", "knl_2"],
+    }));
+
+    const alert = result.alerts.find((a) => a.type === "RECONCILE_SUPPRESSED");
+    expect(alert).toBeDefined();
+    expect(alert!.details).toContain("knl_1");
+    expect(alert!.details).toContain("knl_2");
+    expect((alert!.context!.kennelsSuppressed as string[])).toEqual(["knl_1", "knl_2"]);
   });
 });
 

--- a/src/pipeline/health.ts
+++ b/src/pipeline/health.ts
@@ -40,6 +40,10 @@ interface AnalyzeInput {
   aiRecovery?: AiRecoveryContext;
   /** Number of events cancelled by reconciliation on this scrape. */
   cancelledCount?: number;
+  /** Whether reconciliation ran this scrape. Gates `RECONCILE_SUPPRESSED` from `checkedTypes` so a skipped reconcile doesn't false-resolve a prior open alert. */
+  reconcileEvaluated?: boolean;
+  /** Kennel IDs whose stale-event cancellation was suppressed because the adapter emitted unparseable dates. */
+  reconcileSuppressedKennels?: string[];
 }
 
 /** Type alias for the shape of recent scrape log rows used across checks. */
@@ -294,6 +298,40 @@ function checkExcessiveCancellations(
   };
 }
 
+/** Alert when reconciliation suppressed stale-event cancellation due to unparseable dates. */
+async function checkReconcileSuppressed(
+  input: AnalyzeInput,
+): Promise<AlertCandidate | null> {
+  const kennelIds = input.reconcileSuppressedKennels ?? [];
+  if (kennelIds.length === 0) return null;
+
+  // ShortName enrichment is best-effort — a lookup failure must not fail the scrape.
+  let shortNameById = new Map<string, string>();
+  try {
+    const kennels = await prisma.kennel.findMany({
+      where: { id: { in: kennelIds } },
+      select: { id: true, shortName: true },
+    });
+    shortNameById = new Map(kennels.map((k) => [k.id, k.shortName]));
+  } catch (err) {
+    console.warn(
+      `[health] RECONCILE_SUPPRESSED shortName lookup failed; falling back to raw IDs: ${String(err)}`,
+    );
+  }
+  const labels = kennelIds.map((id) => shortNameById.get(id) ?? id);
+  const suffix = kennelIds.length === 1 ? "" : "s";
+
+  return {
+    type: "RECONCILE_SUPPRESSED",
+    severity: "WARNING",
+    title: `Reconcile suppressed for ${kennelIds.length} kennel${suffix}`,
+    details:
+      `Stale-event cancellation skipped for ${labels.join(", ")} because the adapter emitted unparseable dates. ` +
+      "Stale CONFIRMED events in these kennels will remain until the adapter returns valid dates — investigate the source/adapter parse path.",
+    context: { kennelsSuppressed: kennelIds },
+  };
+}
+
 /** Alert if events resolved to valid kennels that are not linked to this source via SourceKennel. */
 function checkSourceKennelMismatches(
   input: AnalyzeInput,
@@ -389,6 +427,14 @@ export async function analyzeHealth(
   checkedTypes.add("EXCESSIVE_CANCELLATIONS");
   const cancellationAlert = checkExcessiveCancellations(input, recentSuccessful);
   if (cancellationAlert) alerts.push(cancellationAlert);
+
+  // 9. Reconcile suppressed. Gate on reconcileEvaluated so a skipped reconcile
+  // (scrape failed, partial coverage, etc.) doesn't false-resolve a prior alert.
+  if (input.reconcileEvaluated) {
+    checkedTypes.add("RECONCILE_SUPPRESSED");
+    const reconcileAlert = await checkReconcileSuppressed(input);
+    if (reconcileAlert) alerts.push(reconcileAlert);
+  }
 
   // Determine overall health status
   let healthStatus: SourceHealth;

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -410,6 +410,8 @@ export async function scrapeSource(
     // Reconcile stale events (scope to scraped kennels for partial-scrape adapters)
     let cancelledCount = 0;
     let reconcileContext: Record<string, unknown> | undefined;
+    let reconcileEvaluated = false;
+    let reconcileSuppressedKennels: string[] = [];
     const rawKennelPageErrors = scrapeResult.diagnosticContext?.kennelPageFetchErrors;
     const kennelPageErrors = typeof rawKennelPageErrors === "number" && Number.isFinite(rawKennelPageErrors) ? rawKennelPageErrors : 0;
     const kennelPagesStopReason = scrapeResult.diagnosticContext?.kennelPagesStopReason;
@@ -430,6 +432,7 @@ export async function scrapeSource(
         scrapedKennelIds,
         upcomingOnly,
       );
+      reconcileEvaluated = true;
       const { cancelledEventIds: _, ...reconDiag } = reconciled;
       cancelledCount = reconciled.cancelled;
       reconcileContext = reconDiag;
@@ -440,14 +443,13 @@ export async function scrapeSource(
           `Scope: ${reconciled.kennelsInScope}/${reconciled.totalLinkedKennels} kennels.`,
         );
       }
-      // Suppression disables stale-event cleanup for the listed kennels. Surface
-      // at scrape level (not just per-row in reconcile) — the operational symptom
-      // is quiet failure, so relying on high-cancellation noise won't catch it.
-      if (reconciled.kennelsSuppressedForBadDate.length > 0) {
-        console.warn(
-          `[scrape] Reconcile cancellations suppressed for ${reconciled.kennelsSuppressedForBadDate.length} kennel(s) ` +
+      // Operator-facing signal is the RECONCILE_SUPPRESSED health alert; log is a triage breadcrumb.
+      reconcileSuppressedKennels = reconciled.kennelsSuppressedForBadDate;
+      if (reconcileSuppressedKennels.length > 0) {
+        console.info(
+          `[scrape] Reconcile cancellations suppressed for ${reconcileSuppressedKennels.length} kennel(s) ` +
           `in source "${source.name}" (${sourceId}) due to unparseable dates: ` +
-          `${reconciled.kennelsSuppressedForBadDate.join(", ")}. ` +
+          `${reconcileSuppressedKennels.join(", ")}. ` +
           `Stale CONFIRMED events in these kennels will not be cancelled until the adapter emits valid dates.`,
         );
       }
@@ -479,6 +481,8 @@ export async function scrapeSource(
         ? { attempted: aiRecovery.attempted, succeeded: aiRecovery.succeeded, failed: aiRecovery.failed }
         : undefined,
       cancelledCount,
+      reconcileEvaluated,
+      reconcileSuppressedKennels,
     });
 
     // Run IndexNow ping after the response is sent, so the serverless function


### PR DESCRIPTION
## Summary

- Promote \`reconcile.kennelsSuppressedForBadDate\` from a buried \`console.warn\` to a first-class \`RECONCILE_SUPPRESSED\` health alert so the self-healing pipeline auto-files a GitHub issue.
- Add idempotent additive migration for the new \`AlertType\` enum value.
- Best-effort kennel shortName enrichment with graceful fallback to raw IDs; gate on \`reconcileEvaluated\` so a skipped reconcile doesn't false-resolve prior open alerts via \`autoResolveCleared\`.

## Changes

- \`prisma/schema.prisma\` + new migration — \`ADD VALUE IF NOT EXISTS 'RECONCILE_SUPPRESSED'\`.
- \`src/pipeline/health.ts\` — \`AnalyzeInput\` gains \`reconcileEvaluated\` + \`reconcileSuppressedKennels\`; new \`checkReconcileSuppressed\` helper; registered in \`analyzeHealth\` behind the evaluated gate.
- \`src/pipeline/scrape.ts\` — threads reconcile results through to \`runHealthAndAlerts\`; demotes \`console.warn\` → \`console.info\`.
- \`src/pipeline/auto-issue.ts\` — adds \`RECONCILE_SUPPRESSED\` to \`AUTO_FILE_ALERT_TYPES\` with relevant files, context rendering, and suggested approach.
- \`src/pipeline/health.test.ts\` — 7 new cases (gate, empty/undefined suppression, singular/plural grammar, shortName resolution, findMany failure fallback).

Closes #870

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run src/pipeline/health.test.ts src/pipeline/auto-issue.test.ts\` — 68 tests pass
- [x] Codex adversarial-review pass (HIGH false-resolve bug, MED findMany reject, MED non-idempotent migration — all fixed)
- [x] /simplify pass
- [ ] Post-merge: Vercel \`prisma migrate deploy\` applies enum migration cleanly
- [ ] Post-merge: trigger a bad-date adapter scrape, confirm AlertCard renders \`RECONCILE_SUPPRESSED\` with \`kennelsSuppressed\` context

🤖 Generated with [Claude Code](https://claude.com/claude-code)