### PR TITLE
feat(travel): nightly GC for abandoned draft trips

### DIFF
--- a/src/app/api/cron/travel-draft-gc/route.ts
+++ b/src/app/api/cron/travel-draft-gc/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { verifyCronAuth } from "@/lib/cron-auth";
+import { runTravelDraftGc, DRAFT_GC_AGE_DAYS } from "@/pipeline/travel-draft-gc";
+
+/**
+ * Daily GC for orphan TravelSearch DRAFT rows.
+ *
+ * Drafts are created by the ghost-leg auto-save flow (see
+ * src/components/travel/TravelSearchForm.tsx:persistDraft). When a user
+ * abandons mid-flow the row stays behind — it's invisible from
+ * /travel/saved but still occupies dedup-index slots and bloats the
+ * table over time. This cron sweeps drafts older than
+ * DRAFT_GC_AGE_DAYS.
+ *
+ * Triggered by Vercel Cron (GET) or QStash (POST) or manually with
+ * Bearer CRON_SECRET.
+ */
+export async function POST(request: Request) {
+  const auth = await verifyCronAuth(request);
+  if (!auth.authenticated) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runTravelDraftGc();
+    console.log(
+      `[travel-draft-gc] deleted ${result.deleted} drafts older than ${result.olderThan.toISOString()}`,
+    );
+    return NextResponse.json({
+      data: {
+        deleted: result.deleted,
+        olderThan: result.olderThan.toISOString(),
+        ageDays: DRAFT_GC_AGE_DAYS,
+      },
+    });
+  } catch (err) {
+    console.error("[travel-draft-gc] failed:", err);
+    return NextResponse.json(
+      { data: null, error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}
+
+/** Vercel Cron triggers GET requests. */
+export async function GET(request: Request) {
+  return POST(request);
+}

--- a/src/app/api/cron/travel-draft-gc/route.ts
+++ b/src/app/api/cron/travel-draft-gc/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { verifyCronAuth } from "@/lib/cron-auth";
 import { runTravelDraftGc, DRAFT_GC_AGE_DAYS } from "@/pipeline/travel-draft-gc";
 
@@ -35,6 +36,7 @@ export async function POST(request: Request) {
     });
   } catch (err) {
     console.error("[travel-draft-gc] failed:", err);
+    Sentry.captureException(err);
     return NextResponse.json(
       { data: null, error: err instanceof Error ? err.message : "Unknown error" },
       { status: 500 },

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -509,6 +509,25 @@ async function SavedTripPage({
     );
   }
 
+  // Heartbeat: DRAFT trips are bookmarkable (the URL resolves them
+  // even without explicit Save), so the draft-GC cron must see real
+  // activity when the user reopens one. Bump `updatedAt` on read so
+  // the 7-day TTL in runTravelDraftGc only fires on truly abandoned
+  // drafts. updateMany is ownership+status-scoped; a concurrent
+  // DRAFT→ACTIVE transition inside saveTravelSearch's tx will skip
+  // this no-op. Fire-and-forget — a timestamp update failure is
+  // non-fatal and the GC will retry tomorrow.
+  if (search.status === TravelSearchStatus.DRAFT) {
+    void prisma.travelSearch
+      .updateMany({
+        where: { id: search.id, userId: user.id, status: TravelSearchStatus.DRAFT },
+        data: { updatedAt: new Date() },
+      })
+      .catch((err) => {
+        console.error("[travel] draft heartbeat failed", err);
+      });
+  }
+
   const { confidenceFilter, distanceFilter } = parseFilterParams(filterParams);
   const destinations = search.destinations.map((d) => ({
     latitude: d.latitude,

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -515,17 +515,28 @@ async function SavedTripPage({
   // the 7-day TTL in runTravelDraftGc only fires on truly abandoned
   // drafts. updateMany is ownership+status-scoped; a concurrent
   // DRAFT→ACTIVE transition inside saveTravelSearch's tx will skip
-  // this no-op. Fire-and-forget — a timestamp update failure is
-  // non-fatal and the GC will retry tomorrow.
-  if (search.status === TravelSearchStatus.DRAFT) {
-    void prisma.travelSearch
-      .updateMany({
+  // this no-op.
+  //
+  // Awaited (not fire-and-forget): serverless invocations can end
+  // before a background promise settles, which would leave
+  // `updatedAt` stale and risk a GC-driven data loss on the next
+  // cron run. Bounded throttle: skip when updatedAt was refreshed
+  // within the last 24h, so frequent page reloads don't hammer the
+  // DB (the 7-day TTL has plenty of headroom for a daily refresh).
+  const HEARTBEAT_THROTTLE_MS = 24 * 60 * 60 * 1000;
+  if (
+    search.status === TravelSearchStatus.DRAFT &&
+    Date.now() - search.updatedAt.getTime() > HEARTBEAT_THROTTLE_MS
+  ) {
+    try {
+      await prisma.travelSearch.updateMany({
         where: { id: search.id, userId: user.id, status: TravelSearchStatus.DRAFT },
         data: { updatedAt: new Date() },
-      })
-      .catch((err) => {
-        console.error("[travel] draft heartbeat failed", err);
       });
+    } catch (err) {
+      console.error("[travel] draft heartbeat failed", err);
+      Sentry.captureException(err);
+    }
   }
 
   const { confidenceFilter, distanceFilter } = parseFilterParams(filterParams);

--- a/src/pipeline/travel-draft-gc.test.ts
+++ b/src/pipeline/travel-draft-gc.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prisma } from "@/lib/db";
+import { TravelSearchStatus } from "@/generated/prisma/client";
+import { runTravelDraftGc, DRAFT_GC_AGE_DAYS } from "./travel-draft-gc";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    travelSearch: {
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+describe("runTravelDraftGc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes DRAFT rows updated before the cutoff", async () => {
+    vi.mocked(prisma.travelSearch.deleteMany).mockResolvedValue({ count: 4 } as never);
+    const now = new Date("2026-05-01T00:00:00Z");
+    const result = await runTravelDraftGc(now);
+
+    expect(result.deleted).toBe(4);
+    // Cutoff is now − DRAFT_GC_AGE_DAYS days.
+    expect(result.olderThan).toEqual(
+      new Date("2026-04-24T00:00:00Z"),
+    );
+    expect(prisma.travelSearch.deleteMany).toHaveBeenCalledWith({
+      where: {
+        status: TravelSearchStatus.DRAFT,
+        updatedAt: { lt: result.olderThan },
+      },
+    });
+  });
+
+  it("scopes strictly to status DRAFT so ACTIVE/ARCHIVED trips can't be caught mid-transition", async () => {
+    vi.mocked(prisma.travelSearch.deleteMany).mockResolvedValue({ count: 0 } as never);
+    await runTravelDraftGc();
+
+    const where = vi.mocked(prisma.travelSearch.deleteMany).mock.calls[0][0]!.where!;
+    expect(where.status).toBe(TravelSearchStatus.DRAFT);
+  });
+
+  it(`uses ${DRAFT_GC_AGE_DAYS} days as the age threshold`, async () => {
+    vi.mocked(prisma.travelSearch.deleteMany).mockResolvedValue({ count: 0 } as never);
+    const now = new Date("2026-05-10T12:00:00Z");
+    const { olderThan } = await runTravelDraftGc(now);
+    const diffMs = now.getTime() - olderThan.getTime();
+    expect(diffMs).toBe(DRAFT_GC_AGE_DAYS * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/pipeline/travel-draft-gc.ts
+++ b/src/pipeline/travel-draft-gc.ts
@@ -1,0 +1,53 @@
+import { prisma } from "@/lib/db";
+import { TravelSearchStatus } from "@/generated/prisma/client";
+
+/**
+ * Drafts older than this are swept. Mid-flow abandonment (user adds a
+ * leg 2 in the search form, then navigates away without saving) creates
+ * a DRAFT TravelSearch row that is invisible from /travel/saved but
+ * still counts against the partial-unique dedup index and accumulates
+ * forever without GC.
+ *
+ * A week is chosen to leave plenty of headroom for the "I'll finish
+ * this tomorrow" flow while still keeping the backlog bounded. Delete,
+ * not archive — DRAFT rows have no user-facing history value and
+ * ARCHIVED semantics is reserved for trips the user explicitly saved
+ * then removed.
+ *
+ * The GC is read-path-aware: SavedTripPage in src/app/travel/page.tsx
+ * bumps `updatedAt` whenever a DRAFT is reopened. That heartbeat means
+ * the predicate below only catches drafts that are genuinely
+ * abandoned — a bookmarked or revisited draft resets its 7-day clock
+ * on each page load. If that heartbeat is ever removed, this GC
+ * becomes a data-loss path for bookmarked drafts; keep them in sync.
+ */
+export const DRAFT_GC_AGE_DAYS = 7;
+
+export interface TravelDraftGcResult {
+  deleted: number;
+  olderThan: Date;
+}
+
+/**
+ * Delete DRAFT TravelSearch rows whose `updatedAt` is older than
+ * `DRAFT_GC_AGE_DAYS`. TravelDestination rows cascade via the
+ * compound FK (prisma/schema.prisma: TravelDestination.travelSearch
+ * onDelete: Cascade).
+ *
+ * Returns the count of deleted parents. Safe to run concurrently
+ * with save/update flows — the WHERE clause scopes strictly to
+ * status='DRAFT', so an ACTIVE or ARCHIVED trip can never be caught
+ * mid-transition.
+ */
+export async function runTravelDraftGc(
+  now: Date = new Date(),
+): Promise<TravelDraftGcResult> {
+  const olderThan = new Date(now.getTime() - DRAFT_GC_AGE_DAYS * 24 * 60 * 60 * 1000);
+  const { count } = await prisma.travelSearch.deleteMany({
+    where: {
+      status: TravelSearchStatus.DRAFT,
+      updatedAt: { lt: olderThan },
+    },
+  });
+  return { deleted: count, olderThan };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,10 @@
     {
       "path": "/api/cron/sync-audit-issues",
       "schedule": "30 12 * * *"
+    },
+    {
+      "path": "/api/cron/travel-draft-gc",
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- New daily cron (`0 3 * * *` UTC) deletes `TravelSearch` rows with `status='DRAFT' AND updatedAt < now - 7d`. TravelDestination rows cascade via the compound FK.
- Ghost-leg auto-save creates DRAFT rows whenever a user expands to leg 2; abandonment leaves orphans that hold slots in the partial-unique dedup index and accumulate forever without GC.
- **Read-path heartbeat**: SavedTripPage bumps `updatedAt` on DRAFT reopen, so bookmarked or revisited drafts reset their 7-day clock and only truly abandoned drafts get swept. (Without this, the GC becomes a data-loss path for user-addressable DRAFT URLs.)

Completes deferred item #7 from the Phase 6 out-of-scope list.

## Pre-PR review loop
- `/simplify` pass: "No changes needed. Ship it." — flagged route boilerplate duplication with `audit/route.ts` as out of scope for this PR.
- `/codex:adversarial-review`: flagged high-severity data loss on bookmarked drafts; fixed via heartbeat before ship.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npx vitest run` — 5035 passed (3 new)
- [ ] Manual: create a draft (add leg 2), confirm it's reachable at `?savedTripId=...`, confirm `updatedAt` bumps on each page load
- [ ] Manual: trigger `/api/cron/travel-draft-gc` with `Authorization: Bearer $CRON_SECRET` — returns `{ deleted, olderThan, ageDays: 7 }`
- [ ] Manual: verify vercel.json cron entry deploys with the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)