### PR TITLE
fix(audit): self-heal stale sanitizer drift before daily scan

### DIFF
--- a/src/app/api/cron/audit/route.ts
+++ b/src/app/api/cron/audit/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { verifyCronAuth } from "@/lib/cron-auth";
-import { runAudit, persistAuditLog, updateAuditLogIssuesFiled } from "@/pipeline/audit-runner";
+import {
+  runAudit,
+  persistAuditLog,
+  updateAuditLogIssuesFiled,
+  selfHealSanitizers,
+} from "@/pipeline/audit-runner";
 import { fileAuditIssues } from "@/pipeline/audit-issue";
 import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
 
@@ -23,6 +28,21 @@ export async function POST(request: Request) {
       if (backfilled > 0) console.log(`[audit] lastEventDate backfill: ${backfilled} kennels updated`);
     } catch (err) {
       console.error("[audit] lastEventDate backfill failed:", err instanceof Error ? err.message : err);
+    }
+
+    // Re-apply merge sanitizers to any stale rows in the audit window before
+    // scanning, so the audit doesn't re-file issues for values the sanitizers
+    // already know how to clean. Non-blocking; failures logged but don't block
+    // the audit.
+    try {
+      const heal = await selfHealSanitizers();
+      if (heal.locationHealed + heal.haresHealed > 0) {
+        console.log(
+          `[audit] self-heal: ${heal.locationHealed} locations, ${heal.haresHealed} hares (scanned ${heal.scanned})`,
+        );
+      }
+    } catch (err) {
+      console.error("[audit] self-heal failed:", err instanceof Error ? err.message : err);
     }
 
     const result = await runAudit();

--- a/src/pipeline/audit-runner.ts
+++ b/src/pipeline/audit-runner.ts
@@ -97,6 +97,19 @@ export function computeSummary(findings: AuditFinding[]): Record<string, number>
   return summary;
 }
 
+/**
+ * The date window audited each run: rows whose `date` falls between
+ * 7 days before now and 90 days after. Shared between `selfHealSanitizers()`
+ * and `runAudit()` so the pre-pass heals exactly what the scan will inspect.
+ */
+export function getAuditWindow(): { cutoffDate: Date; futureDate: Date } {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - 7);
+  const futureDate = new Date();
+  futureDate.setDate(futureDate.getDate() + 90);
+  return { cutoffDate, futureDate };
+}
+
 export interface SelfHealResult {
   scanned: number;
   locationHealed: number;
@@ -118,10 +131,7 @@ export interface SelfHealResult {
  * `runAudit()` so the scan sees a clean slate.
  */
 export async function selfHealSanitizers(): Promise<SelfHealResult> {
-  const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - 7);
-  const futureDate = new Date();
-  futureDate.setDate(futureDate.getDate() + 90);
+  const { cutoffDate, futureDate } = getAuditWindow();
 
   const events = await prisma.event.findMany({
     where: {
@@ -181,10 +191,7 @@ export function runChecks(rows: AuditEventRow[]): AuditFinding[] {
 }
 
 export async function runAudit(): Promise<AuditResult> {
-  const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - 7);
-  const futureDate = new Date();
-  futureDate.setDate(futureDate.getDate() + 90);
+  const { cutoffDate, futureDate } = getAuditWindow();
 
   const events = await prisma.event.findMany({
     where: {

--- a/src/pipeline/audit-runner.ts
+++ b/src/pipeline/audit-runner.ts
@@ -13,6 +13,7 @@ import {
   type AuditEventRow,
   type AuditFinding,
 } from "./audit-checks";
+import { sanitizeHares, sanitizeLocation } from "./merge";
 
 /** A group of related findings (same kennel + same rule). */
 export interface AuditGroup {
@@ -94,6 +95,75 @@ export function computeSummary(findings: AuditFinding[]): Record<string, number>
     summary[f.category] = (summary[f.category] ?? 0) + 1;
   }
   return summary;
+}
+
+export interface SelfHealResult {
+  scanned: number;
+  locationHealed: number;
+  haresHealed: number;
+}
+
+/**
+ * Reconcile stale Event rows against the current merge sanitizers.
+ *
+ * The merge UPDATE path only rewrites `locationName`/`haresText` when the
+ * adapter re-emits `event.location`/`event.hares` on a scrape. Rows whose
+ * source field has since been removed (e.g. a Calendar owner moved a CTA into
+ * the description) can't be reached that way, so stale pre-sanitizer values
+ * persist and the daily audit re-files an issue for each of them.
+ *
+ * This pass re-applies `sanitizeLocation`/`sanitizeHares` across the same
+ * window the audit is about to scan, writing only when the sanitizer output
+ * differs from the stored value. Intended to run immediately before
+ * `runAudit()` so the scan sees a clean slate.
+ */
+export async function selfHealSanitizers(): Promise<SelfHealResult> {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - 7);
+  const futureDate = new Date();
+  futureDate.setDate(futureDate.getDate() + 90);
+
+  const events = await prisma.event.findMany({
+    where: {
+      date: { gte: cutoffDate, lte: futureDate },
+      status: "CONFIRMED",
+      OR: [{ locationName: { not: null } }, { haresText: { not: null } }],
+    },
+    select: { id: true, locationName: true, haresText: true },
+  });
+
+  let locationHealed = 0;
+  let haresHealed = 0;
+
+  for (const e of events) {
+    const newLocation = e.locationName !== null ? sanitizeLocation(e.locationName) : e.locationName;
+    const newHares = e.haresText !== null ? sanitizeHares(e.haresText) : e.haresText;
+    const healLocation = newLocation !== e.locationName;
+    const healHares = newHares !== e.haresText;
+    if (!healLocation && !healHares) continue;
+
+    // Guard against concurrent merge writes: only heal if the field still
+    // holds the value we just read. If a scrape rewrote it in the interim,
+    // updateMany returns count=0 and we skip the stat bump.
+    const where: { id: string; locationName?: string | null; haresText?: string | null } = { id: e.id };
+    const data: { locationName?: string | null; haresText?: string | null } = {};
+    if (healLocation) {
+      where.locationName = e.locationName;
+      data.locationName = newLocation;
+    }
+    if (healHares) {
+      where.haresText = e.haresText;
+      data.haresText = newHares;
+    }
+
+    const { count } = await prisma.event.updateMany({ where, data });
+    if (count > 0) {
+      if (healLocation) locationHealed++;
+      if (healHares) haresHealed++;
+    }
+  }
+
+  return { scanned: events.length, locationHealed, haresHealed };
 }
 
 /** Run all audit checks on pre-queried rows. Returns raw findings (no grouping — caller groups after filtering). */

--- a/src/pipeline/audit-self-heal.test.ts
+++ b/src/pipeline/audit-self-heal.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    event: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/db";
+import { selfHealSanitizers } from "./audit-runner";
+import { sanitizeHares, sanitizeLocation } from "./merge";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(prisma.event.updateMany).mockResolvedValue({ count: 1 } as never);
+});
+
+describe("merge sanitizers — regression coverage for recurring audit rules", () => {
+  it("sanitizeLocation strips trailing contact-CTA paren (location-phone-number, SWH3 #910)", () => {
+    expect(
+      sanitizeLocation("Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)"),
+    ).toBe("Casa De Assover – Raleigh, NC");
+  });
+
+  it("sanitizeLocation nulls email-CTA locations (location-email-cta, ABQ H3 #908)", () => {
+    expect(sanitizeLocation("Inquire for location: abqh3misman@gmail.com")).toBeNull();
+  });
+
+  it("sanitizeHares nulls 'On On Q' boilerplate (hare-boilerplate-leak, BFMH3 #909)", () => {
+    expect(sanitizeHares("On On Q")).toBeNull();
+  });
+});
+
+describe("selfHealSanitizers", () => {
+  it("updates locationName when the sanitizer output differs", async () => {
+    const original = "Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)";
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      { id: "evt-swh3", locationName: original, haresText: null },
+    ] as never);
+
+    const result = await selfHealSanitizers();
+
+    expect(prisma.event.updateMany).toHaveBeenCalledWith({
+      where: { id: "evt-swh3", locationName: original },
+      data: { locationName: "Casa De Assover – Raleigh, NC" },
+    });
+    expect(result).toEqual({ scanned: 1, locationHealed: 1, haresHealed: 0 });
+  });
+
+  it("writes null when sanitizeLocation rejects the whole value (email CTA)", async () => {
+    const original = "Inquire for location: abqh3misman@gmail.com";
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      { id: "evt-abq", locationName: original, haresText: null },
+    ] as never);
+
+    const result = await selfHealSanitizers();
+
+    expect(prisma.event.updateMany).toHaveBeenCalledWith({
+      where: { id: "evt-abq", locationName: original },
+      data: { locationName: null },
+    });
+    expect(result.locationHealed).toBe(1);
+  });
+
+  it("writes null when sanitizeHares rejects boilerplate ('On On Q')", async () => {
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      { id: "evt-bfmh3", locationName: null, haresText: "On On Q" },
+    ] as never);
+
+    const result = await selfHealSanitizers();
+
+    expect(prisma.event.updateMany).toHaveBeenCalledWith({
+      where: { id: "evt-bfmh3", haresText: "On On Q" },
+      data: { haresText: null },
+    });
+    expect(result).toEqual({ scanned: 1, locationHealed: 0, haresHealed: 1 });
+  });
+
+  it("does not issue an update when sanitizer output matches current value", async () => {
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      {
+        id: "evt-clean",
+        locationName: "Central Park, New York, NY",
+        haresText: "Assover, Slippery Pete",
+      },
+    ] as never);
+
+    const result = await selfHealSanitizers();
+
+    expect(prisma.event.updateMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 1, locationHealed: 0, haresHealed: 0 });
+  });
+
+  it("heals empty-string values that slip past the non-null filter", async () => {
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      { id: "evt-empty", locationName: "", haresText: null },
+    ] as never);
+
+    const result = await selfHealSanitizers();
+
+    // sanitizeLocation("") returns null; the empty-string branch must run
+    expect(prisma.event.updateMany).toHaveBeenCalledWith({
+      where: { id: "evt-empty", locationName: "" },
+      data: { locationName: null },
+    });
+    expect(result.locationHealed).toBe(1);
+  });
+
+  it("skips the stat bump when a concurrent write made updateMany a no-op", async () => {
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      { id: "evt-raced", locationName: "Inquire for location: x@y.com", haresText: null },
+    ] as never);
+    vi.mocked(prisma.event.updateMany).mockResolvedValueOnce({ count: 0 } as never);
+
+    const result = await selfHealSanitizers();
+
+    expect(prisma.event.updateMany).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ scanned: 1, locationHealed: 0, haresHealed: 0 });
+  });
+
+  it("batches both field updates into a single write when both need healing", async () => {
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      {
+        id: "evt-both",
+        locationName: "Inquire for location: test@example.com",
+        haresText: "On On Q",
+      },
+    ] as never);
+
+    const result = await selfHealSanitizers();
+
+    expect(prisma.event.updateMany).toHaveBeenCalledTimes(1);
+    expect(prisma.event.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "evt-both",
+        locationName: "Inquire for location: test@example.com",
+        haresText: "On On Q",
+      },
+      data: { locationName: null, haresText: null },
+    });
+    expect(result).toEqual({ scanned: 1, locationHealed: 1, haresHealed: 1 });
+  });
+
+  it("queries the 7-back / 90-forward window with CONFIRMED filter and non-null OR", async () => {
+    vi.mocked(prisma.event.findMany).mockResolvedValue([] as never);
+
+    await selfHealSanitizers();
+
+    const arg = vi.mocked(prisma.event.findMany).mock.calls[0][0]!;
+    const where = arg.where as {
+      date: { gte: Date; lte: Date };
+      status: string;
+      OR: { locationName?: { not: null }; haresText?: { not: null } }[];
+    };
+
+    expect(where.status).toBe("CONFIRMED");
+    expect(where.OR).toEqual([
+      { locationName: { not: null } },
+      { haresText: { not: null } },
+    ]);
+
+    const now = Date.now();
+    const gte = where.date.gte.getTime();
+    const lte = where.date.lte.getTime();
+    const oneDay = 24 * 60 * 60 * 1000;
+    // ~7 days back (tolerate clock skew between setup and assertion)
+    expect(now - gte).toBeGreaterThan(6 * oneDay);
+    expect(now - gte).toBeLessThan(8 * oneDay);
+    // ~90 days forward
+    expect(lte - now).toBeGreaterThan(89 * oneDay);
+    expect(lte - now).toBeLessThan(91 * oneDay);
+  });
+});


### PR DESCRIPTION
## Summary

The daily audit cron re-files the same three extraction-rule violations every day (9 open issues total) even though PR #869's merge sanitizers already handle all the offending values:

| Rule | Stale value | Source kennel |
|---|---|---|
| `location-phone-number` | `Casa De Assover – Raleigh, NC (text Assover at 919-332-2615 for address)` | SWH3 (Google Calendar) |
| `location-email-cta` | `Inquire for location: abqh3misman@gmail.com` (×4) | ABQ H3 (Google Calendar) |
| `hare-boilerplate-leak` | `On On Q` | BFMH3 (HTML scraper) |

**Root cause:** merge's UPDATE path only rewrites `locationName`/`haresText` when the adapter re-emits `event.location`/`event.hares` on a scrape. Rows whose source field has since been removed or moved (e.g. a Calendar owner relocated the CTA into the description) can't be reached, so pre-sanitizer values persist and the daily audit re-detects them.

**Fix:** add `selfHealSanitizers()` as a non-blocking pre-pass in the audit cron, re-applying `sanitizeLocation`/`sanitizeHares` across the same 7-back / 90-forward / CONFIRMED window the audit is about to scan. Writes via `updateMany` guarded on the original field value so a concurrent merge write isn't clobbered (count=0 no-ops are skipped).

No adapter or merge changes — those are correct and already cover all three values.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (no new warnings)
- [x] `npm test` — 5066 passed (11 new in `audit-self-heal.test.ts`)
- [x] Regression tests for all 3 exact stale values
- [x] Tests cover: no-op on clean rows, guarded concurrent-update no-op, empty-string branch, batched dual-field update, window/filter shape
- [ ] Post-merge: watch Vercel logs for first `/api/cron/audit` invocation at 12:00 UTC; expect `[audit] self-heal: ≥5 locations, ≥1 hares (scanned N)` and all 9 issues auto-close via the `Closes` keywords above

Closes #818
Closes #819
Closes #820
Closes #876
Closes #877
Closes #878
Closes #908
Closes #909
Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)