### PR TITLE
feat(bssh3): backfill runs #10–#11 (Ko Samet outstation)

### DIFF
--- a/scripts/backfill-bssh3-ko-samet.ts
+++ b/scripts/backfill-bssh3-ko-samet.ts
@@ -1,0 +1,141 @@
+/**
+ * One-shot historical backfill for Bangkok Sabai Saturday Hash (BSSH3).
+ *
+ * Runs 10 and 11 (Ko Samet outstation weekend, May 30–31 2025) are missing
+ * from HashTracks because BSSH3's only source is Meetup and the kennel never
+ * posted these two outstation runs on Meetup. Per issue #915, recommendation
+ * is a one-shot RawEvent insert — widening the Meetup scrape window can't
+ * surface events that never lived on Meetup.
+ *
+ * Binding these RawEvents to the existing "BSSH3 Meetup" source preserves
+ * kennel provenance; the merge pipeline resolves the canonical Event via
+ * `kennelTag`, not source identity. The Meetup adapter scrapes 90 days
+ * forward only, so it cannot race these past rows.
+ *
+ * Partition (per `.claude/rules/adapter-patterns.md`):
+ *   - Adapter handles dates >= CURDATE()
+ *   - This script handles dates < CURDATE() (these events are May 2025)
+ * Always re-runnable: fingerprint-based dedup against existing RawEvents.
+ *
+ * Usage:
+ *   1. Dry run first:  npx tsx scripts/backfill-bssh3-ko-samet.ts
+ *   2. Execute:        BACKFILL_APPLY=1 npx tsx scripts/backfill-bssh3-ko-samet.ts
+ */
+
+import "dotenv/config";
+import { PrismaClient, type Prisma } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { createScriptPool } from "./lib/db-pool";
+import { generateFingerprint } from "@/pipeline/fingerprint";
+import type { RawEventData } from "@/adapters/types";
+
+const KENNEL_CODE = "bssh3";
+const SOURCE_NAME = "BSSH3 Meetup";
+const KENNEL_TIMEZONE = "Asia/Bangkok";
+const DEFAULT_START_TIME = "13:45"; // BSSH3's standard meet time
+
+/**
+ * Verbatim from https://bangkoksaturdayhash.com/past-events (issue #915):
+ *   "Run 10 - 30 May 25 (Ko Samet)"
+ *   "Run 11 - 31 May 25 (Ko Samet)"
+ * Canonical titles aren't displayed on the past-events page; we use the
+ * short-form title shown verbatim on the source.
+ */
+const KO_SAMET_EVENTS: RawEventData[] = [
+  {
+    date: "2025-05-30",
+    kennelTag: KENNEL_CODE,
+    runNumber: 10,
+    title: "Run 10 - Ko Samet",
+    location: "Ko Samet",
+    startTime: DEFAULT_START_TIME,
+  },
+  {
+    date: "2025-05-31",
+    kennelTag: KENNEL_CODE,
+    runNumber: 11,
+    title: "Run 11 - Ko Samet",
+    location: "Ko Samet",
+    startTime: DEFAULT_START_TIME,
+  },
+];
+
+async function main() {
+  const apply = process.env.BACKFILL_APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
+
+  // en-CA emits ISO YYYY-MM-DD; compare against RawEventData.date (also ISO).
+  const today = new Intl.DateTimeFormat("en-CA", { timeZone: KENNEL_TIMEZONE }).format(new Date());
+  const allEvents = KO_SAMET_EVENTS.filter((e) => {
+    if (e.date >= today) {
+      console.log(`Skipping ${e.title}: date ${e.date} >= today ${today} (adapter territory)`);
+      return false;
+    }
+    return true;
+  });
+
+  console.log(`\nEvents to insert: ${allEvents.length}`);
+  for (const e of allEvents) {
+    console.log(`  #${e.runNumber} ${e.date} | ${e.title} | loc=${e.location} | start=${e.startTime}`);
+  }
+
+  if (!apply) {
+    console.log("\nDry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
+    return;
+  }
+
+  if (allEvents.length === 0) {
+    console.log("No events to insert. Exiting.");
+    return;
+  }
+
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+  try {
+    const sources = await prisma.source.findMany({
+      where: { name: SOURCE_NAME },
+      select: { id: true },
+    });
+    if (sources.length === 0) throw new Error(`Source "${SOURCE_NAME}" not found in DB. Run prisma db seed first.`);
+    if (sources.length > 1) throw new Error(`Multiple sources named "${SOURCE_NAME}" found (${sources.length}). Aborting to avoid writing to the wrong one.`);
+    const source = sources[0];
+
+    const withFingerprints = allEvents.map((event) => ({
+      event,
+      fingerprint: generateFingerprint(event),
+    }));
+    const fingerprintList = withFingerprints.map((x) => x.fingerprint);
+    const existingRows = await prisma.rawEvent.findMany({
+      where: { sourceId: source.id, fingerprint: { in: fingerprintList } },
+      select: { fingerprint: true },
+    });
+    const existingSet = new Set(existingRows.map((r) => r.fingerprint));
+    const toInsert = withFingerprints.filter(({ fingerprint }) => !existingSet.has(fingerprint));
+    console.log(`\nPre-existing rows: ${existingSet.size}. New rows to insert: ${toInsert.length}.`);
+
+    if (toInsert.length === 0) {
+      console.log("Nothing new to insert. Exiting.");
+      return;
+    }
+
+    await prisma.rawEvent.createMany({
+      data: toInsert.map(({ event, fingerprint }) => ({
+        sourceId: source.id,
+        rawData: event as unknown as Prisma.InputJsonValue,
+        fingerprint,
+        processed: false,
+      })),
+    });
+
+    console.log(`\nDone. Inserted ${toInsert.length} new RawEvents for source "${SOURCE_NAME}".`);
+    console.log("Trigger a scrape of this source from the admin UI to merge the new RawEvents into canonical Events.");
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-bssh3-ko-samet.ts
+++ b/scripts/backfill-bssh3-ko-samet.ts
@@ -23,10 +23,7 @@
  */
 
 import "dotenv/config";
-import { PrismaClient, type Prisma } from "@/generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { createScriptPool } from "./lib/db-pool";
-import { generateFingerprint } from "@/pipeline/fingerprint";
+import { insertRawEventsForSource } from "./lib/backfill-runner";
 import type { RawEventData } from "@/adapters/types";
 
 const KENNEL_CODE = "bssh3";
@@ -89,50 +86,16 @@ async function main() {
     return;
   }
 
-  const pool = createScriptPool();
-  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
-  try {
-    const sources = await prisma.source.findMany({
-      where: { name: SOURCE_NAME },
-      select: { id: true },
-    });
-    if (sources.length === 0) throw new Error(`Source "${SOURCE_NAME}" not found in DB. Run prisma db seed first.`);
-    if (sources.length > 1) throw new Error(`Multiple sources named "${SOURCE_NAME}" found (${sources.length}). Aborting to avoid writing to the wrong one.`);
-    const source = sources[0];
+  const { preExisting, inserted } = await insertRawEventsForSource(SOURCE_NAME, allEvents);
+  console.log(`\nPre-existing rows: ${preExisting}. New rows to insert: ${inserted}.`);
 
-    const withFingerprints = allEvents.map((event) => ({
-      event,
-      fingerprint: generateFingerprint(event),
-    }));
-    const fingerprintList = withFingerprints.map((x) => x.fingerprint);
-    const existingRows = await prisma.rawEvent.findMany({
-      where: { sourceId: source.id, fingerprint: { in: fingerprintList } },
-      select: { fingerprint: true },
-    });
-    const existingSet = new Set(existingRows.map((r) => r.fingerprint));
-    const toInsert = withFingerprints.filter(({ fingerprint }) => !existingSet.has(fingerprint));
-    console.log(`\nPre-existing rows: ${existingSet.size}. New rows to insert: ${toInsert.length}.`);
-
-    if (toInsert.length === 0) {
-      console.log("Nothing new to insert. Exiting.");
-      return;
-    }
-
-    await prisma.rawEvent.createMany({
-      data: toInsert.map(({ event, fingerprint }) => ({
-        sourceId: source.id,
-        rawData: event as unknown as Prisma.InputJsonValue,
-        fingerprint,
-        processed: false,
-      })),
-    });
-
-    console.log(`\nDone. Inserted ${toInsert.length} new RawEvents for source "${SOURCE_NAME}".`);
-    console.log("Trigger a scrape of this source from the admin UI to merge the new RawEvents into canonical Events.");
-  } finally {
-    await prisma.$disconnect();
-    await pool.end();
+  if (inserted === 0) {
+    console.log("Nothing new to insert. Exiting.");
+    return;
   }
+
+  console.log(`\nDone. Inserted ${inserted} new RawEvents for source "${SOURCE_NAME}".`);
+  console.log("Trigger a scrape of this source from the admin UI to merge the new RawEvents into canonical Events.");
 }
 
 main().catch((err) => {

--- a/scripts/lib/backfill-runner.ts
+++ b/scripts/lib/backfill-runner.ts
@@ -1,0 +1,70 @@
+import { PrismaClient, type Prisma } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { createScriptPool } from "./db-pool";
+import { generateFingerprint } from "@/pipeline/fingerprint";
+import type { RawEventData } from "@/adapters/types";
+
+export interface InsertRawEventsResult {
+  preExisting: number;
+  inserted: number;
+}
+
+/**
+ * Shared apply-phase for one-shot backfill scripts: looks up the source by
+ * name, dedupes against existing RawEvent fingerprints, and batch-inserts the
+ * remainder. Callers handle CLI flags, date partitioning, and reporting.
+ *
+ * Every backfill has to own pool/prisma lifecycle + source lookup + dedup
+ * identically; diverging copies accumulate and fail SonarCloud duplication
+ * gates on every new script.
+ */
+export async function insertRawEventsForSource(
+  sourceName: string,
+  events: RawEventData[],
+): Promise<InsertRawEventsResult> {
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+  try {
+    const sources = await prisma.source.findMany({
+      where: { name: sourceName },
+      select: { id: true },
+    });
+    if (sources.length === 0) {
+      throw new Error(`Source "${sourceName}" not found in DB. Run prisma db seed first.`);
+    }
+    if (sources.length > 1) {
+      throw new Error(
+        `Multiple sources named "${sourceName}" found (${sources.length}). Aborting to avoid writing to the wrong one.`,
+      );
+    }
+    const source = sources[0];
+
+    const withFingerprints = events.map((event) => ({
+      event,
+      fingerprint: generateFingerprint(event),
+    }));
+    const fingerprintList = withFingerprints.map((x) => x.fingerprint);
+    const existingRows = await prisma.rawEvent.findMany({
+      where: { sourceId: source.id, fingerprint: { in: fingerprintList } },
+      select: { fingerprint: true },
+    });
+    const existingSet = new Set(existingRows.map((r) => r.fingerprint));
+    const toInsert = withFingerprints.filter(({ fingerprint }) => !existingSet.has(fingerprint));
+
+    if (toInsert.length > 0) {
+      await prisma.rawEvent.createMany({
+        data: toInsert.map(({ event, fingerprint }) => ({
+          sourceId: source.id,
+          rawData: event as unknown as Prisma.InputJsonValue,
+          fingerprint,
+          processed: false,
+        })),
+      });
+    }
+
+    return { preExisting: existingSet.size, inserted: toInsert.length };
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}


### PR DESCRIPTION
## Summary

- One-shot backfill script [scripts/backfill-bssh3-ko-samet.ts](scripts/backfill-bssh3-ko-samet.ts) that inserts the two Ko Samet outstation runs (May 30–31 2025) as RawEvents.
- These events never appeared on Meetup — BSSH3's only configured source — because the kennel ran them off-platform. Widening the Meetup scrape window is not the right fix; a one-shot RawEvent insert is.

## Why this pattern

- Rows bind to the existing `"BSSH3 Meetup"` source for kennel provenance. The merge pipeline resolves the canonical Event via `kennelTag`, not source identity.
- Strict partition: events are dated 2025-05, well before today; Meetup's forward-only scrape window cannot race.
- Fingerprint-based dedup via `generateFingerprint` — re-runs are no-ops (verified against local `hashtracks_dev`).

## Dry-run output

```
Mode: DRY RUN (no writes)

Events to insert: 2
  #10 2025-05-30 | Run 10 - Ko Samet | loc=Ko Samet | start=13:45
  #11 2025-05-31 | Run 11 - Ko Samet | loc=Ko Samet | start=13:45
```

## Local verification

- `BACKFILL_APPLY=1` against `hashtracks_dev` inserted 2 RawEvents
- Re-run: `Pre-existing rows: 2. New rows to insert: 0.` ✓ idempotent
- `npx tsc --noEmit` clean
- `npm run lint` — no new warnings
- `npm test` — 213 test files pass, 5055 tests pass

## Test plan

- [ ] Merge this PR
- [ ] Locally, run `BACKFILL_APPLY=1 npx tsx scripts/backfill-bssh3-ko-samet.ts` against prod Railway DB
- [ ] Trigger a scrape of "BSSH3 Meetup" via admin UI to merge the new RawEvents into canonical Events
- [ ] Verify runs #10 and #11 appear at https://www.hashtracks.xyz/kennels/bssh3

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)