### PR TITLE
fix(merge): restore CANCELLED events without startTime (#874)

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -682,6 +682,36 @@ describe("double-header support", () => {
       }),
     );
   });
+
+  it("restores a CANCELLED row via refreshExistingEvent even when scraped row has no startTime (#874)", async () => {
+    // Dublin Nash Hash regression: the hareline row "3–5 July 2026" has no
+    // time, so composeUtcStart returns null. Without this fix, the early
+    // return in refreshExistingEvent bypassed the CANCELLED→CONFIRMED restore
+    // for processed=true fingerprint matches, leaving the event cancelled
+    // indefinitely once it had been cancelled by a prior reconcile cycle.
+    mockRawEventFind.mockResolvedValueOnce({
+      id: "raw_existing",
+      processed: true,
+      eventId: "evt_cancelled",
+    } as never);
+    vi.mocked(prisma.event.findUnique).mockResolvedValueOnce({
+      trustLevel: 5,
+      dateUtc: null,
+      timezone: "Europe/Dublin",
+      status: "CANCELLED",
+    } as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    const result = await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-07-03", startTime: undefined }),
+    ]);
+
+    expect(result.restored).toBe(1);
+    expect(mockEventUpdate).toHaveBeenCalledWith({
+      where: { id: "evt_cancelled" },
+      data: { status: "CONFIRMED" },
+    });
+  });
 });
 
 describe("empty event guard", () => {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -289,30 +289,32 @@ async function refreshExistingEvent(
   const timezone = regionTimezone(region);
   const eventDate = parseUtcNoonDate(event.date);
   const composedUtc = composeUtcStart(eventDate, event.startTime, timezone);
-  // No start time → can't update dateUtc/timezone; upsertCanonicalEvent handles restores for these
-  if (!composedUtc) return;
 
   const existingEvent = await prisma.event.findUnique({
     where: { id: existingEventId },
     select: { trustLevel: true, dateUtc: true, timezone: true, status: true },
   });
+  // Auto-restore cancelled events when source still returns them. Runs even
+  // when we can't compose a dateUtc (scraped row has no startTime) — otherwise
+  // processed=true duplicates for rows without startTime stay CANCELLED forever
+  // because upsertCanonicalEvent's restore path is unreachable here. (#874)
+  const shouldRestore = existingEvent?.status === "CANCELLED";
   const isHigherOrEqualTrust = !existingEvent || ctx.trustLevel >= existingEvent.trustLevel;
   const isAlreadyCurrent =
+    !!composedUtc &&
     existingEvent?.dateUtc?.getTime() === composedUtc.getTime() &&
     existingEvent?.timezone === timezone;
-  // Auto-restore cancelled events when source still returns them
-  const shouldRestore = existingEvent?.status === "CANCELLED";
-  const needsUpdate = (isHigherOrEqualTrust && !isAlreadyCurrent) || shouldRestore;
-  if (needsUpdate) {
-    await prisma.event.update({
-      where: { id: existingEventId },
-      data: {
-        ...(isHigherOrEqualTrust && !isAlreadyCurrent ? { dateUtc: composedUtc, timezone } : {}),
-        ...(shouldRestore ? { status: "CONFIRMED" as const } : {}),
-      },
-    });
-    if (shouldRestore) ctx.result.restored++;
-  }
+  const shouldRefreshDateUtc = !!composedUtc && isHigherOrEqualTrust && !isAlreadyCurrent;
+  if (!shouldRestore && !shouldRefreshDateUtc) return;
+
+  await prisma.event.update({
+    where: { id: existingEventId },
+    data: {
+      ...(shouldRefreshDateUtc ? { dateUtc: composedUtc, timezone } : {}),
+      ...(shouldRestore ? { status: "CONFIRMED" as const } : {}),
+    },
+  });
+  if (shouldRestore) ctx.result.restored++;
 }
 
 /**


### PR DESCRIPTION
## Summary

Dublin Nash Hash (issue #874) stayed CANCELLED even after the adapter started returning it again. Root cause is in `refreshExistingEvent` in `src/pipeline/merge.ts`: when a processed=true fingerprint matches, the function early-returned if `composeUtcStart()` returned null — which happens whenever the scraped row has no `startTime`. That early return sat *before* the CANCELLED→CONFIRMED restore check, so the restore never ran.

Dublin's hareline renders "3–5 July 2026" with no time, so every scrape hit the early-return path. Once a prior reconcile cycle cancelled the event, no subsequent scrape could bring it back — `upsertCanonicalEvent`'s restore branch is unreachable once the RawEvent is marked processed.

## Fix

- Move `prisma.event.findUnique` above the composedUtc guard.
- Compute `shouldRestore` and `shouldRefreshDateUtc` independently; only skip the update when both are false.
- Only include `dateUtc`/`timezone` in the update payload when we actually have a composed time.

Net behaviour: a scraped row with no startTime now restores a CANCELLED canonical without touching its existing dateUtc/timezone.

## Test plan

- [x] New regression test in `src/pipeline/merge.test.ts` exercises the refreshExistingEvent restore path with `startTime: undefined` — asserts `result.restored === 1` and the update payload is exactly `{ status: "CONFIRMED" }` (no dateUtc clobber).
- [x] All 240 merge tests pass locally.
- [x] `npx tsc --noEmit` + `npm run lint` clean.
- [ ] Post-merge: trigger Dublin Hash scrape from admin UI; confirm the Nash Hash event flips CONFIRMED.

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)