### PR TITLE
fix(adapters+merge): bundle of 7 extraction fixes

### DIFF
--- a/scripts/cleanup-lsw-stale-descriptions.ts
+++ b/scripts/cleanup-lsw-stale-descriptions.ts
@@ -1,0 +1,126 @@
+/**
+ * One-shot cleanup for #873: the LSW adapter previously mis-mapped the
+ * DESCRIPTION source column (which actually holds an HK district name) to
+ * `description` instead of `locationName`. The adapter fix stops new events
+ * from getting the wrong shape, but existing events need a repair pass.
+ *
+ * Provenance guard: we only touch rows where Event.description EXACTLY matches
+ * the `description` field of a legacy LSW RawEvent (the old mis-mapped adapter
+ * wrote the district name into `description`) linked to that same Event. That
+ * proves the text came from the old LSW mis-mapping, not from another source
+ * or manual edit, and avoids wiping legitimate descriptions.
+ *
+ * Repair logic (per-matched event):
+ *   - If Event.locationName is empty, move description → locationName.
+ *   - If Event.locationName is already set (e.g. re-scraped post-fix), just
+ *     clear description so the stale district name stops showing as a second
+ *     copy.
+ *
+ * ORDERING CONSTRAINT: run this BEFORE any force re-scrape of the LSW source.
+ * `scrapeSource(..., { force: true })` deletes all prior RawEvents for a
+ * source, which is what carries the legacy provenance. Once those are gone
+ * this script can no longer repair already-corrupted rows.
+ *
+ * Runs in dry-run mode by default — pass `--apply` to actually write.
+ *   npm run tsx scripts/cleanup-lsw-stale-descriptions.ts           # preview
+ *   npm run tsx scripts/cleanup-lsw-stale-descriptions.ts -- --apply
+ */
+import "dotenv/config";
+import { prisma } from "../src/lib/db";
+
+const APPLY = process.argv.includes("--apply");
+
+async function main() {
+  const kennel = await prisma.kennel.findFirst({ where: { kennelCode: "lsw-h3" } });
+  if (!kennel) {
+    console.error("LSW kennel not found — aborting.");
+    process.exit(1);
+  }
+
+  // Scope by URL to the one legacy LSW adapter that mis-mapped the column.
+  // Filtering by kennelId alone would include any future sources linked to the
+  // kennel (e.g. a Meetup feed) whose RawEvent.rawData.description might
+  // coincidentally match an Event description contributed elsewhere.
+  const LEGACY_LSW_URL = "https://www.datadesignfactory.com/lsw/hareline.htm";
+  const lswSources = await prisma.source.findMany({
+    where: {
+      url: LEGACY_LSW_URL,
+      kennels: { some: { kennelId: kennel.id } },
+    },
+    select: { id: true, name: true },
+  });
+  if (lswSources.length === 0) {
+    console.error(`No source matching ${LEGACY_LSW_URL} linked to LSW kennel — aborting.`);
+    process.exit(1);
+  }
+
+  // Pull LSW-contributed RawEvents with a linked Event + non-null description.
+  const rawEvents = await prisma.rawEvent.findMany({
+    where: {
+      sourceId: { in: lswSources.map((s) => s.id) },
+      eventId: { not: null },
+      event: { kennelId: kennel.id, description: { not: null } },
+    },
+    select: {
+      rawData: true,
+      event: { select: { id: true, description: true, locationName: true } },
+    },
+  });
+
+  console.log(
+    `Scanning ${rawEvents.length} LSW RawEvents linked to Events with populated description.`,
+  );
+
+  let moved = 0;
+  let cleared = 0;
+  let skipped = 0;
+  for (const re of rawEvents) {
+    if (!re.event) continue;
+    const raw = re.rawData as { description?: unknown } | null;
+    // Provenance guard: only act when a LEGACY LSW RawEvent snapshot (the old
+    // mis-mapped adapter wrote the district name into `description`) matches
+    // the Event's current description. Post-fix snapshots carry the text in
+    // `location` — we deliberately don't treat that as provenance because a
+    // coincidental description from another source or manual edit might match,
+    // and `description: null` is irreversible. If a row has no legacy snapshot,
+    // we leave it alone.
+    const rawDescription = typeof raw?.description === "string" ? raw.description : null;
+    if (rawDescription === null || re.event.description !== rawDescription) {
+      skipped++;
+      continue;
+    }
+
+    if (!re.event.locationName) {
+      console.log(`  MOVE   ${re.event.id}: description="${re.event.description}" → locationName`);
+      if (APPLY) {
+        await prisma.event.update({
+          where: { id: re.event.id },
+          data: { locationName: re.event.description, description: null },
+        });
+      }
+      moved++;
+    } else {
+      console.log(`  CLEAR  ${re.event.id}: locationName already "${re.event.locationName}", dropping stale description`);
+      if (APPLY) {
+        await prisma.event.update({
+          where: { id: re.event.id },
+          data: { description: null },
+        });
+      }
+      cleared++;
+    }
+  }
+
+  const action = APPLY ? "Updated" : "Would update";
+  console.log(
+    `\n${action} ${moved} rows (description→locationName), ${cleared} rows (clear duplicate). Skipped ${skipped} non-provenance-match.`,
+  );
+  if (!APPLY) console.log("Dry-run only. Re-run with --apply to write changes.");
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/verify-round2-autoheal.ts
+++ b/scripts/verify-round2-autoheal.ts
@@ -19,7 +19,7 @@ async function runOne(sourceName: string) {
   return { source, events: result.events, errors: result.errors };
 }
 
-function sample(events: { title?: string; hares?: string; location?: string; sourceUrl?: string; runNumber?: number }[], pred: (e: { title?: string; hares?: string; location?: string }) => boolean) {
+function sample(events: { title?: string; hares?: string; location?: string; sourceUrl?: string; runNumber?: number | null }[], pred: (e: { title?: string; hares?: string; location?: string }) => boolean) {
   return events.filter(pred).slice(0, 3);
 }
 

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -240,13 +240,30 @@ describe("HarrierCentralAdapter", () => {
       expect(result.events[0].date).toBe("2026-04-15");
     });
 
-    it("preserves zero-value lat/lng and eventNumber", async () => {
+    it("preserves zero-value lat/lng (equator is valid) but drops runNumber=0 (#892)", async () => {
+      // eventNumber=0 is how HC flags social / "drinking practice" events that
+      // aren't part of the numbered run series. Storing it as runNumber=0 shows
+      // "#0" on the event card (Morgantown H3's "Hillbilly Drinking Practice"
+      // regression). Coordinates at 0,0 are genuinely the equator — keep them.
+      // Adapter emits `null` (not undefined) so the merge UPDATE path actively
+      // clears any stale runNumber stored before the fix shipped.
       mockApiResponse([buildHCEvent({ syncLat: 0, syncLong: 0, eventNumber: 0 })]);
       const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
       expect(result.events).toHaveLength(1);
       expect(result.events[0].latitude).toBe(0);
       expect(result.events[0].longitude).toBe(0);
-      expect(result.events[0].runNumber).toBe(0);
+      expect(result.events[0].runNumber).toBeNull();
+    });
+
+    it("preserves existing runNumber when eventNumber is absent/invalid (#892)", async () => {
+      // Only the explicit 0 sentinel clears; a negative or missing value
+      // must pass through as `undefined` so the merge UPDATE path leaves
+      // any existing canonical runNumber untouched. Otherwise a partial HC
+      // payload would silently wipe good data on re-scrape.
+      mockApiResponse([buildHCEvent({ eventNumber: -1 })]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].runNumber).toBeUndefined();
     });
 
     it("includes diagnosticContext in result", async () => {

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { HarrierCentralAdapter } from "./adapter";
+import { HarrierCentralAdapter, composeHcLocation } from "./adapter";
 import type { HCEvent } from "./adapter";
 import { generateAccessToken, PUBLIC_HASHER_ID } from "./token";
 import type { Source } from "@/generated/prisma/client";
@@ -52,6 +52,46 @@ function mockApiResponse(events: HCEvent[]) {
     json: async () => [events],
   } as never);
 }
+
+describe("composeHcLocation", () => {
+  it("returns undefined when both fields are missing or TBA", () => {
+    expect(composeHcLocation(undefined, undefined)).toBeUndefined();
+    expect(composeHcLocation("TBA", "TBA")).toBeUndefined();
+    expect(composeHcLocation("", "")).toBeUndefined();
+  });
+
+  it("treats padded/case-variant TBA as missing (prevents merge UPDATE from clearing good location)", () => {
+    // Without trimming-before-sentinel, " TBA " survives as a defined string
+    // and the merge path would overwrite existing canonical locationName with
+    // sanitizeLocation("TBA") = null on an equal-trust re-scrape.
+    expect(composeHcLocation(" TBA ", " TBA ")).toBeUndefined();
+    expect(composeHcLocation("tba", "TBA\n")).toBeUndefined();
+  });
+
+  it("returns place alone when resolvable is bare coordinates", () => {
+    expect(composeHcLocation("Waseda exit", "35.713, 139.704")).toBe("Waseda exit");
+  });
+
+  it("returns address alone when it already contains the place name", () => {
+    expect(
+      composeHcLocation("Morgantown", "227 Spruce Street, Morgantown, WV"),
+    ).toBe("227 Spruce Street, Morgantown, WV");
+  });
+
+  it("composes 'place, address' when both are distinct", () => {
+    expect(
+      composeHcLocation("Apothecary Ale House", "227 Spruce Street, Morgantown, WV"),
+    ).toBe("Apothecary Ale House, 227 Spruce Street, Morgantown, WV");
+  });
+
+  it("preserves venue when its name is a substring of an address token (not a full segment)", () => {
+    // "Iron Horse" appears inside "Iron Horse Tavern Road" but is NOT a complete
+    // comma segment — venue should be preserved, not silently dropped.
+    expect(
+      composeHcLocation("Iron Horse", "Iron Horse Tavern Road, Morgantown, WV"),
+    ).toBe("Iron Horse, Iron Horse Tavern Road, Morgantown, WV");
+  });
+});
 
 describe("generateAccessToken", () => {
   it("produces a 64-char hex string", () => {
@@ -264,6 +304,50 @@ describe("HarrierCentralAdapter", () => {
       const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
       expect(result.events).toHaveLength(1);
       expect(result.events[0].runNumber).toBeUndefined();
+    });
+
+    it("composes locationName with street address when resolvableLocation is a real address (#907)", async () => {
+      // Morgantown MH3-US actual payload: locationOneLineDesc is the venue
+      // name, resolvableLocation is the full USPS-shaped address. Prefer the
+      // composed "{venue}, {address}" form so the event card shows street-level
+      // context, not just "Apothecary Ale House and Cafe".
+      mockApiResponse([
+        buildHCEvent({
+          locationOneLineDesc: "Apothecary Ale House and Cafe",
+          resolvableLocation: "227 Spruce Street, Morgantown, 26505-7511, WV, United States",
+        }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "mh3-wv" }));
+      expect(result.events[0].location).toBe(
+        "Apothecary Ale House and Cafe, 227 Spruce Street, Morgantown, 26505-7511, WV, United States",
+      );
+    });
+
+    it("falls back to locationOneLineDesc when resolvableLocation is bare coordinates", async () => {
+      // Tokyo H3 payload: HC couldn't geocode the meeting point so
+      // resolvableLocation is a lat/lng pair, which is useless as user-facing
+      // text. Use the one-line description alone.
+      mockApiResponse([
+        buildHCEvent({
+          locationOneLineDesc: "Yamanote, Tozai lines. Waseda exit",
+          resolvableLocation: "35.713482463621920, 139.704315846472870",
+        }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
+      expect(result.events[0].location).toBe("Yamanote, Tozai lines. Waseda exit");
+    });
+
+    it("returns full address alone when locationOneLineDesc duplicates it", async () => {
+      mockApiResponse([
+        buildHCEvent({
+          locationOneLineDesc: "227 Spruce Street, Morgantown",
+          resolvableLocation: "227 Spruce Street, Morgantown, 26505-7511, WV, United States",
+        }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "mh3-wv" }));
+      expect(result.events[0].location).toBe(
+        "227 Spruce Street, Morgantown, 26505-7511, WV, United States",
+      );
     });
 
     it("includes diagnosticContext in result", async () => {

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -143,10 +143,8 @@ export class HarrierCentralAdapter implements SourceAdapter {
       const timeMatch = hcEvent.eventStartDatetime.match(/T(\d{2}:\d{2})/);
       const startTime = timeMatch ? timeMatch[1] : undefined;
 
-      let hares = hcEvent.hares && hcEvent.hares !== "TBA" ? hcEvent.hares : undefined;
-      const location = hcEvent.locationOneLineDesc && hcEvent.locationOneLineDesc !== "TBA"
-        ? hcEvent.locationOneLineDesc
-        : undefined;
+      let hares = stripTba(hcEvent.hares);
+      const location = composeHcLocation(hcEvent.locationOneLineDesc, hcEvent.resolvableLocation);
 
       // Data-entry safety net: when a kennel user pastes the same text into
       // both the hare and location slots (observed on Tokyo H3 #2578, where
@@ -168,17 +166,11 @@ export class HarrierCentralAdapter implements SourceAdapter {
         date: dateStr,
         kennelTag,
         title: hcEvent.eventName || undefined,
-        // Socials / "drinking practices" come back as eventNumber=0 (the API
-        // types it as a number). ONLY the explicit 0 sentinel clears via null
-        // — absent/invalid values pass through as undefined so the merge UPDATE
-        // path preserves any existing runNumber instead of silently wiping it
-        // on a partial HC payload (#892).
-        runNumber:
-          hcEvent.eventNumber === 0
-            ? null
-            : hcEvent.eventNumber > 0
-              ? hcEvent.eventNumber
-              : undefined,
+        // Socials / "drinking practices" come back as eventNumber=0. Map that
+        // sentinel to null (explicit clear) and positive values to the number;
+        // anything else stays undefined so the merge UPDATE path preserves an
+        // existing runNumber on partial HC payloads (#892).
+        runNumber: normalizeHcEventNumber(hcEvent.eventNumber),
         startTime,
         hares,
         location,
@@ -200,6 +192,70 @@ export class HarrierCentralAdapter implements SourceAdapter {
       },
     };
   }
+}
+
+/**
+ * Trim input and drop padded/case-variant "TBA" placeholders. Must run BEFORE
+ * any merge-path comparison so " TBA ", "tba\n", etc. don't survive as a
+ * defined string and overwrite a valid existing value via the UPDATE path.
+ */
+function stripTba(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && !/^tba$/i.test(trimmed) ? trimmed : undefined;
+}
+
+/**
+ * Map HC eventNumber to RawEvent.runNumber tri-state:
+ *   0        → null      (explicit clear: social / drinking practice)
+ *   positive → number    (normal run)
+ *   other    → undefined (preserve existing value through merge)
+ */
+function normalizeHcEventNumber(n: number | undefined | null): number | null | undefined {
+  if (n === 0) return null;
+  if (typeof n === "number" && n > 0) return n;
+  return undefined;
+}
+
+/**
+ * Compose a location string from HC's two location fields.
+ *
+ * `locationOneLineDesc` is typically the venue/place name ("Iron Horse Tavern").
+ * `resolvableLocation` is the full street address when set
+ * ("140 High Street, Morgantown, 26505-5413, WV, United States"), but for
+ * kennels without a geocoded venue it's either a bare coordinate pair
+ * ("35.713..., 139.704...") or a duplicate of the place name.
+ *
+ * Prefer "{place}, {full address}" when both fields carry real, distinct data
+ * so hashers get street-level context in addition to the venue name (#907).
+ */
+export function composeHcLocation(
+  placeName: string | undefined,
+  resolvable: string | undefined,
+): string | undefined {
+  const place = stripTba(placeName);
+  const full = stripTba(resolvable);
+
+  // resolvableLocation is a bare coordinate pair for venues Harrier Central
+  // couldn't geocode — not useful as user-facing text.
+  const coordsOnly = /^-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?$/;
+  const addressShaped = full && !coordsOnly.test(full) ? full : undefined;
+
+  if (!place && !addressShaped) return undefined;
+  if (!addressShaped) return place;
+  if (!place) return addressShaped;
+  if (place === addressShaped) return place;
+  // Drop place when it duplicates the address — either as a complete comma
+  // segment (e.g. place "Morgantown" inside "...Morgantown, WV") or as a
+  // leading prefix of the address (e.g. place "227 Spruce Street, Morgantown"
+  // inside the same fully-formed address). Avoids substring false positives
+  // like place "Iron Horse" being dropped because "Iron Horse Tavern Road"
+  // appears in the street segment.
+  const placeLc = place.toLowerCase();
+  const addressLc = addressShaped.toLowerCase();
+  const segments = addressLc.split(",").map((s) => s.trim());
+  if (segments.includes(placeLc)) return addressShaped;
+  if (addressLc.startsWith(`${placeLc},`)) return addressShaped;
+  return `${place}, ${addressShaped}`;
 }
 
 /** Resolve kennel tag from HC event using pre-compiled config patterns */

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -168,7 +168,17 @@ export class HarrierCentralAdapter implements SourceAdapter {
         date: dateStr,
         kennelTag,
         title: hcEvent.eventName || undefined,
-        runNumber: hcEvent.eventNumber != null ? hcEvent.eventNumber : undefined,
+        // Socials / "drinking practices" come back as eventNumber=0 (the API
+        // types it as a number). ONLY the explicit 0 sentinel clears via null
+        // — absent/invalid values pass through as undefined so the merge UPDATE
+        // path preserves any existing runNumber instead of silently wiping it
+        // on a partial HC payload (#892).
+        runNumber:
+          hcEvent.eventNumber === 0
+            ? null
+            : hcEvent.eventNumber > 0
+              ? hcEvent.eventNumber
+              : undefined,
         startTime,
         hares,
         location,

--- a/src/adapters/html-scraper/brew-city-h3.ts
+++ b/src/adapters/html-scraper/brew-city-h3.ts
@@ -268,10 +268,11 @@ export class BrewCityH3Adapter implements SourceAdapter {
     const seenKeys = new Set<string>();
     const dedupedEvents: RawEventData[] = [];
     for (const event of windowFiltered) {
-      if (event.runNumber !== undefined && seenRuns.has(event.runNumber)) continue;
+      const runNum = event.runNumber ?? undefined;
+      if (runNum !== undefined && seenRuns.has(runNum)) continue;
       const titleKey = `${event.date}|${event.title}`;
-      if (event.runNumber === undefined && seenKeys.has(titleKey)) continue;
-      if (event.runNumber !== undefined) seenRuns.add(event.runNumber);
+      if (runNum === undefined && seenKeys.has(titleKey)) continue;
+      if (runNum !== undefined) seenRuns.add(runNum);
       seenKeys.add(titleKey);
       dedupedEvents.push(event);
     }

--- a/src/adapters/html-scraper/burlington-hash.test.ts
+++ b/src/adapters/html-scraper/burlington-hash.test.ts
@@ -184,6 +184,73 @@ describe("parseCalendarLink", () => {
     expect(result?.title).toBe("BurlyH3 #853");
   });
 
+  it("extracts cost and description from Wix <br>-separated details payload (#887)", () => {
+    // Live Girth Day #850 payload (Wix uses <br> between labeled fields and
+    // before the free-form prose). URL-encoded: "<br>" → %3Cbr%3E, "$" → %24.
+    const details =
+      "%3Cb%3EHares%3A%3C%2Fb%3E+20+Gallons+of+Piss+%26+Redtail+Swallows" +
+      "%3Cbr%3E%3Cb%3ELength%3A+%3C%2Fb%3E2.69" +
+      "%3Cbr%3E%3Cb%3EShiggy+Scale%3A+%3C%2Fb%3E4" +
+      "%3Cbr%3E%3Cb%3ECost%3A%3C%2Fb%3E+%246.90" +
+      "%3Cbr%3E%3Cbr%3ESince+it%27s+Earth+day%2C+we%27re+honoring+the+planet+by+stuffing+as+many+hashers+as+we+can+into+Mother+Nature%27s+sweet+Sunny+Hollow.";
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23850%3A+Girth+Day" +
+      "&dates=20260422T223000Z/20260422T233000Z" +
+      `&details=${details}`;
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.runNumber).toBe(850);
+    expect(result?.hares).toBe("20 Gallons of Piss & Redtail Swallows");
+    expect(result?.cost).toBe("$6.90");
+    expect(result?.description).toContain("Earth day");
+    expect(result?.description).toContain("Sunny Hollow");
+  });
+
+  it("leaves cost undefined when the details payload has no 'Cost:' marker (#887)", () => {
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23860%3A+No+Cost+Listed" +
+      "&dates=20260701T223000Z/20260701T233000Z" +
+      "&details=Hares%3A+Mystery";
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.cost).toBeUndefined();
+  });
+
+  it("leaves description undefined when details payload has only labeled fields (#887)", () => {
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23861%3A+Labels+Only" +
+      "&dates=20260708T223000Z/20260708T233000Z" +
+      "&details=%3Cb%3EHares%3A%3C%2Fb%3E+X%3Cbr%3E%3Cb%3ECost%3A%3C%2Fb%3E+%246.90";
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.cost).toBe("$6.90");
+    expect(result?.description).toBeUndefined();
+  });
+
+  it("preserves hares value containing internal <br> breaks (no field-marker truncation)", () => {
+    // Defensive: if a Wix author injects a <br> inside the Hares value (e.g.
+    // multi-line co-hare list), the parser must not truncate at the break.
+    // Hares should keep going until the next labeled-field marker.
+    const details =
+      "%3Cb%3EHares%3A%3C%2Fb%3E+Alice%3Cbr%3E%26+Bob%3Cbr%3E%26+Carol" +
+      "%3Cbr%3E%3Cb%3ECost%3A%3C%2Fb%3E+%245.00";
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23862%3A+Multi-line+Hares" +
+      "&dates=20260715T223000Z/20260715T233000Z" +
+      `&details=${details}`;
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+
+    expect(result?.hares).toContain("Alice");
+    expect(result?.hares).toContain("Bob");
+    expect(result?.hares).toContain("Carol");
+    expect(result?.cost).toBe("$5.00");
+    // The continuation lines must NOT leak into description.
+    expect(result?.description).toBeUndefined();
+  });
+
   it("strips 'Length:' and 'Shiggy Scale:' trail metadata from hares field (#825)", () => {
     // BurlyH3 concatenates trail metadata inline with hares. Source-of-truth
     // content: "Hares: 20 Gallons of Piss & Redtail SwallowsLength: TBDShiggy Scale: 4"

--- a/src/adapters/html-scraper/burlington-hash.test.ts
+++ b/src/adapters/html-scraper/burlington-hash.test.ts
@@ -145,6 +145,45 @@ describe("parseCalendarLink", () => {
     expect(result?.hares).toBe("Penis Colada");
   });
 
+  it("extracts run number when title uses 'ft.' instead of ':' (#889)", () => {
+    // Source-observed title: "BTVH3 #851 ft. Not Just the Tip and Skidmark"
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23851+ft.+Not+Just+the+Tip+and+Skidmark" +
+      "&dates=20260429T223000Z/20260429T233000Z" +
+      "&details=Hares%3A+Skidmark";
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.runNumber).toBe(851);
+    // Preserve the "ft." prefix verbatim — reporter prefers this over
+    // stripping since it's a meaningful crediting convention.
+    expect(result?.title).toBe("ft. Not Just the Tip and Skidmark");
+  });
+
+  it("extracts run number when title uses 'feat.' instead of ':' (#889)", () => {
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23852+feat.+Mystery+Guest" +
+      "&dates=20260506T223000Z/20260506T233000Z" +
+      "&details=Hares%3A+Mystery";
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.runNumber).toBe(852);
+    expect(result?.title).toBe("feat. Mystery Guest");
+  });
+
+  it("extracts run number from bare '#NNN' title with no subtitle (#889)", () => {
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23853" +
+      "&dates=20260513T223000Z/20260513T233000Z" +
+      "&details=Hares%3A+TBD";
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.runNumber).toBe(853);
+    expect(result?.title).toBe("BurlyH3 #853");
+  });
+
   it("strips 'Length:' and 'Shiggy Scale:' trail metadata from hares field (#825)", () => {
     // BurlyH3 concatenates trail metadata inline with hares. Source-of-truth
     // content: "Hares: 20 Gallons of Piss & Redtail SwallowsLength: TBDShiggy Scale: 4"

--- a/src/adapters/html-scraper/burlington-hash.ts
+++ b/src/adapters/html-scraper/burlington-hash.ts
@@ -90,24 +90,36 @@ export function parseCalendarLink(
     }
   }
 
-  // Parse details — strip HTML and extract hares
-  const detailText = cheerio.load(details).text().trim();
-  let hares: string | undefined;
-  const haresMatch = /Hares?:\s*(.+?)(?=Location:|Cost:|HASH CASH|On-On|On On|\n|$)/i.exec(detailText);
-  if (haresMatch) {
-    hares = haresMatch[1].trim();
-    // #825: BurlyH3 inlines "Length: TBD" and "Shiggy Scale: 4" directly after
-    // the hares list with no separator (e.g. "...SwallowsLength: TBDShiggy..."),
-    // so HARE_BOILERPLATE_RE's \b word boundary can't catch them. Truncate at
-    // the first marker via indexOf (avoids a new S5852-flagged regex line).
-    const lower = hares.toLowerCase();
-    let cutIdx = -1;
-    for (const marker of ["length:", "shiggy scale:", "shiggyscale:"]) {
-      const idx = lower.indexOf(marker);
-      if (idx >= 0 && (cutIdx === -1 || idx < cutIdx)) cutIdx = idx;
-    }
-    if (cutIdx >= 0) hares = hares.slice(0, cutIdx);
-    hares = hares.replace(HARE_BOILERPLATE_RE, "").trim();
+  // Parse details — strip HTML, then extract labeled fields and free-form prose.
+  // The live Wix payload uses `<br>` between labeled fields and before the
+  // free-form prose; convert those to `\n` purely so cheerio.text() preserves
+  // visual breaks. Field extraction relies on known label markers (not `\n`)
+  // as terminators, so an internal break inside a value doesn't truncate it.
+  const detailsWithBreaks = details.replace(/<br\s*\/?>/gi, "\n");
+  const detailText = cheerio.load(detailsWithBreaks).text().trim();
+
+  // Hares: slice from after "Hares:" to the next known field marker,
+  // paragraph break, or EOF. #825 inlines "Length:"/"Shiggy Scale:" with no
+  // whitespace so they're terminators alongside Location:/Cost:/HASH CASH/
+  // On-On. Using indexOf-based slicing (not a single regex with alternation
+  // in a lookahead) avoids catastrophic backtracking on long payloads.
+  const hares = extractHares(detailText);
+
+  // #887: extract cost (always formatted as "$X.XX" — Burly is USD-only).
+  let cost: string | undefined;
+  const costMatch = /Cost:\s*\$?([0-9]+(?:\.[0-9]{1,2})?)/i.exec(detailText);
+  if (costMatch) cost = `$${costMatch[1]}`;
+
+  // #887: extract free-form description. Wix puts `<br><br>` (a blank line
+  // after `<br>→\n` conversion) before the prose paragraph that follows the
+  // labeled fields. Anchoring on that paragraph break avoids treating any
+  // single-break continuation of a labeled value as the start of description.
+  // Newlines are preserved so the UI can render paragraph structure.
+  let description: string | undefined;
+  const paragraphBreak = detailText.search(/\n[\t ]*\n/);
+  if (paragraphBreak >= 0) {
+    const descText = detailText.slice(paragraphBreak).replace(/^\s+/, "").trim();
+    if (descText.length >= 10) description = descText;
   }
 
   return {
@@ -116,10 +128,25 @@ export function parseCalendarLink(
     runNumber,
     title,
     hares,
+    cost,
+    description,
     location: location.trim() || undefined,
     startTime,
     sourceUrl,
   };
+}
+
+const HARES_LABEL_RE = /Hares?:\s*/i;
+const HARES_TERMINATORS_RE = /Length\s*:|Shiggy\s*Scale\s*:|Location\s*:|Cost\s*:|HASH\s*CASH|On[\s-]*On|\n[\t ]*\n/i;
+
+function extractHares(detailText: string): string | undefined {
+  const labelMatch = HARES_LABEL_RE.exec(detailText);
+  if (!labelMatch) return undefined;
+  const rest = detailText.slice(labelMatch.index + labelMatch[0].length);
+  const termMatch = HARES_TERMINATORS_RE.exec(rest);
+  const value = termMatch ? rest.slice(0, termMatch.index) : rest;
+  const cleaned = value.replace(HARE_BOILERPLATE_RE, "").trim();
+  return cleaned || undefined;
 }
 
 /**

--- a/src/adapters/html-scraper/burlington-hash.ts
+++ b/src/adapters/html-scraper/burlington-hash.ts
@@ -70,13 +70,24 @@ export function parseCalendarLink(
   const min = String(localDate.getMinutes()).padStart(2, "0");
   const startTime = `${hh}:${min}`;
 
-  // Parse title and run number: "BTVH3 #846: Season Premier"
+  // Parse title and run number. Three accepted forms (#889):
+  //   "BTVH3 #846: Season Premier"       → title "Season Premier"
+  //   "BTVH3 #851 ft. Not Just the Tip"  → title "ft. Not Just the Tip" (prefix kept)
+  //   "BTVH3 #852"                        → title "BurlyH3 #852"
   let title = text.trim();
   let runNumber: number | undefined;
-  const runMatch = /(?:BTVH3|BurlyH3|Burlington)\s*#(\d+)\s*[:\-–]\s*(.*)/i.exec(title);
-  if (runMatch) {
-    runNumber = parseInt(runMatch[1], 10);
-    title = runMatch[2].trim() || `BurlyH3 #${runNumber}`;
+  const colonMatch = /(?:BTVH3|BurlyH3|Burlington)\s*#(\d+)\s*[:\-–]\s*(.*)/i.exec(title);
+  if (colonMatch) {
+    runNumber = parseInt(colonMatch[1], 10);
+    title = colonMatch[2].trim() || `BurlyH3 #${runNumber}`;
+  } else {
+    const altMatch = /(?:BTVH3|BurlyH3|Burlington)\s*#(\d+)(?:\s+(ft\.|feat\.)\s+(.+)|\s*$)/i.exec(title);
+    if (altMatch) {
+      runNumber = parseInt(altMatch[1], 10);
+      const featSep = altMatch[2];
+      const rest = altMatch[3];
+      title = featSep ? `${featSep} ${rest}`.trim() : `BurlyH3 #${runNumber}`;
+    }
   }
 
   // Parse details — strip HTML and extract hares

--- a/src/adapters/html-scraper/dublin-hash.test.ts
+++ b/src/adapters/html-scraper/dublin-hash.test.ts
@@ -60,6 +60,16 @@ describe("stripTruncatedPostalFragment", () => {
       "51 Bar, Haddington Rd, Dublin, D02",
     );
   });
+  it("strips fragment followed by trailing nbsp (#905)", () => {
+    expect(
+      stripTruncatedPostalFragment("51 Bar, Haddington Rd, Dublin, D\u00A0"),
+    ).toBe("51 Bar, Haddington Rd, Dublin");
+  });
+  it("normalizes interior nbsp to space before stripping (#905)", () => {
+    expect(
+      stripTruncatedPostalFragment("Dublin,\u00A0D"),
+    ).toBe("Dublin");
+  });
   it("returns undefined for empty input", () => {
     expect(stripTruncatedPostalFragment(undefined)).toBeUndefined();
     expect(stripTruncatedPostalFragment("")).toBeUndefined();

--- a/src/adapters/html-scraper/dublin-hash.ts
+++ b/src/adapters/html-scraper/dublin-hash.ts
@@ -21,11 +21,18 @@ import type {
 import { hasAnyErrors } from "../types";
 import { chronoParseDate, fetchHTMLPage, buildDateWindow } from "../utils";
 
-/** Strip a trailing 1–2 letter postal-code fragment after a comma (e.g. "Dublin, D" → "Dublin"). */
+/**
+ * Strip a trailing 1–2 letter postal-code fragment after a comma
+ * (e.g. "Dublin, D" → "Dublin"). #905: also normalize nbsp → space so a
+ * trailing `, D\u00A0` (source row wrapping after "Dublin, ") is recognized
+ * by the regex's `$` anchor. Multi-digit suffixes like "D02" are real
+ * Eircodes and intentionally preserved.
+ */
 export function stripTruncatedPostalFragment(value: string | undefined): string | undefined {
   if (!value) return undefined;
-  const trimmed = value.replace(/,\s*[A-Z]{1,2}$/i, "").trim();
-  return trimmed || undefined;
+  const normalized = value.replace(/\u00A0/g, " ").trim();
+  const stripped = normalized.replace(/,\s*[A-Z]{1,2}$/i, "").trim();
+  return stripped || undefined;
 }
 
 /**

--- a/src/adapters/html-scraper/lsw-h3.test.ts
+++ b/src/adapters/html-scraper/lsw-h3.test.ts
@@ -27,8 +27,8 @@ describe("parseLswDate", () => {
 describe("parseLswRow", () => {
   const sourceUrl = "https://www.datadesignfactory.com/lsw/hareline.htm";
 
-  it("parses a complete row", () => {
-    const cells = ["09 Apr 25", "2402", "Indy and Inflatable", "Night Run"];
+  it("parses a complete row, mapping DESCRIPTION column to location (#873)", () => {
+    const cells = ["09 Apr 25", "2402", "Indy and Inflatable", "Chai Wan"];
     const result = parseLswRow(cells, sourceUrl);
 
     expect(result).not.toBeNull();
@@ -36,18 +36,23 @@ describe("parseLswRow", () => {
     expect(result!.kennelTag).toBe("lsw-h3");
     expect(result!.runNumber).toBe(2402);
     expect(result!.hares).toBe("Indy and Inflatable");
-    expect(result!.description).toBe("Night Run");
+    // Source calls this column "DESCRIPTION" but it always holds an HK
+    // district name — map to location, not description.
+    expect(result!.location).toBe("Chai Wan");
+    // Do NOT emit description: null — that would wipe descriptions contributed
+    // by other sources / manual edits on every scrape. Field is simply absent.
+    expect(result!.description).toBeUndefined();
     expect(result!.startTime).toBe("18:30");
     expect(result!.sourceUrl).toBe(sourceUrl);
   });
 
   it("handles missing hares", () => {
-    const cells = ["16 Apr 25", "2403", "", "Mystery Run"];
+    const cells = ["16 Apr 25", "2403", "", "Shek O"];
     const result = parseLswRow(cells, sourceUrl);
 
     expect(result).not.toBeNull();
     expect(result!.hares).toBeUndefined();
-    expect(result!.description).toBe("Mystery Run");
+    expect(result!.location).toBe("Shek O");
   });
 
   it("handles placeholder hares", () => {
@@ -58,11 +63,12 @@ describe("parseLswRow", () => {
     expect(result!.hares).toBeUndefined();
   });
 
-  it("handles missing description", () => {
+  it("handles missing location cell", () => {
     const cells = ["23 Apr 25", "2404", "Hash Flash"];
     const result = parseLswRow(cells, sourceUrl);
 
     expect(result).not.toBeNull();
+    expect(result!.location).toBeUndefined();
     expect(result!.description).toBeUndefined();
   });
 

--- a/src/adapters/html-scraper/lsw-h3.ts
+++ b/src/adapters/html-scraper/lsw-h3.ts
@@ -40,7 +40,9 @@ export function parseLswDate(text: string): string | null {
 
 /**
  * Parse a single LSW hareline table row into RawEventData.
- * Expected columns: DATE, RUN NO., HARES, DESCRIPTION
+ * Expected columns: DATE, RUN NO., HARES, DESCRIPTION (source calls it
+ * "DESCRIPTION" but the content is always an HK district name —
+ * "Chai Wan", "Shek O" — so map it to `location`, not `description`).
  *
  * Exported for unit testing.
  */
@@ -50,7 +52,7 @@ export function parseLswRow(
 ): RawEventData | null {
   if (cells.length < 2) return null;
 
-  const [dateCell, runNoCell, haresCell, descCell] = cells;
+  const [dateCell, runNoCell, haresCell, locationCell] = cells;
   const date = parseLswDate(dateCell ?? "");
   if (!date) return null;
 
@@ -60,15 +62,20 @@ export function parseLswRow(
   const hares = haresCell?.trim();
   const validHares = hares && !isPlaceholder(hares) ? hares : undefined;
 
-  const description = descCell?.trim() || undefined;
+  const location = locationCell?.trim() || undefined;
 
   return {
     date,
     kennelTag: KENNEL_TAG,
     runNumber: runNumber && runNumber > 0 ? runNumber : undefined,
-    title: runNumber ? `LSW Run #${runNumber}` : description || undefined,
+    title: runNumber ? `LSW Run #${runNumber}` : location || undefined,
     hares: validHares,
-    description,
+    location,
+    // Do NOT emit description: null here — the merge UPDATE path treats that
+    // as an authoritative clear and would wipe descriptions contributed by
+    // other sources or manual edits on every scrape. Stale rows from the
+    // previous mis-mapping get cleaned up via a one-shot admin cleanup, not
+    // by silently nuking the column forever (#873).
     startTime: DEFAULT_START_TIME,
     sourceUrl,
   };

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -6,7 +6,7 @@ export interface RawEventData {
   kennelTag: string; // Kennel identifier — use kennelCode (e.g. "nych3", "bfm") for stable resolution
   runNumber?: number | null; // null = explicit clear signal (e.g. HC eventNumber=0 for socials)
   title?: string;
-  description?: string;
+  description?: string | null; // null = explicit clear signal (see merge.ts UPDATE path)
   hares?: string;
   location?: string;
   locationStreet?: string; // Full street address (multi-line address blocks)

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -4,7 +4,7 @@ import type { SourceType, Source } from "@/generated/prisma/client";
 export interface RawEventData {
   date: string; // YYYY-MM-DD
   kennelTag: string; // Kennel identifier — use kennelCode (e.g. "nych3", "bfm") for stable resolution
-  runNumber?: number;
+  runNumber?: number | null; // null = explicit clear signal (e.g. HC eventNumber=0 for socials)
   title?: string;
   description?: string;
   hares?: string;

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -573,11 +573,11 @@ export function stripPlaceholder(value: string | undefined | null): string | und
  * Returns the original description if no suffix is provided.
  */
 export function appendDescriptionSuffix(
-  description: string | undefined,
+  description: string | null | undefined,
   suffix: string | undefined,
 ): string | undefined {
   const trimmedSuffix = suffix?.trim();
-  if (!trimmedSuffix) return description;
+  if (!trimmedSuffix) return description ?? undefined;
   return description ? `${description}\n\n${trimmedSuffix}` : trimmedSuffix;
 }
 

--- a/src/app/admin/sources/preview-action.ts
+++ b/src/app/admin/sources/preview-action.ts
@@ -159,7 +159,7 @@ export async function previewSourceConfig(
       kennelTag: e.kennelTag === UNKNOWN_KENNEL_SENTINEL ? UNTAGGED_KENNEL_DISPLAY : e.kennelTag,
       title: e.title,
       description: e.description?.substring(0, 500) || undefined,
-      runNumber: e.runNumber,
+      runNumber: e.runNumber ?? undefined,
       location: e.location,
       hares: e.hares,
       startTime: e.startTime ?? undefined,

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -225,6 +225,39 @@ describe("processRawEvents", () => {
     );
   });
 
+  it("clears existing runNumber when adapter emits null (HC social re-scrape #892)", async () => {
+    // Existing canonical event was previously stored with runNumber=2100 (a
+    // social that wrongly inherited a numbered-run value before #892). HC
+    // adapter now emits runNumber=null for eventNumber<=0; merge UPDATE must
+    // overwrite, not preserve, so the user-visible "#0/#2100" regression goes
+    // away on next scrape — not just for newly-created events.
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_social", trustLevel: 5, runNumber: 2100 },
+    ] as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    await processRawEvents("src_1", [buildRawEvent({ runNumber: null })]);
+
+    const updateCall = mockEventUpdate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(updateCall.data.runNumber).toBeNull();
+  });
+
+  it("preserves existing runNumber when adapter omits the field (undefined)", async () => {
+    // Symmetric guard: many adapters never emit runNumber. They must not
+    // accidentally clear an existing value.
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_existing", trustLevel: 5, runNumber: 1234 },
+    ] as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    await processRawEvents("src_1", [buildRawEvent({ runNumber: undefined })]);
+
+    const updateCall = mockEventUpdate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(updateCall.data).not.toHaveProperty("runNumber");
+  });
+
   it("preserves existing locationCity for HARRIER_CENTRAL sources on update (#471)", async () => {
     // On UPDATE we never touch locationCity for canonical-location sources. If a non-HC
     // source previously populated city for this canonical event (cross-source merge),

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1776,6 +1776,73 @@ describe("suppressRedundantCity", () => {
   it("returns city when locationName is null", () => {
     expect(suppressRedundantCity(null, "Akron, OH")).toBe("Akron, OH");
   });
+
+  it("suppresses neighborhood for full US address ending in country (#906)", () => {
+    // N2H3 case: full address with zip + USA suffix shouldn't get a
+    // reverse-geocoded neighborhood ("Marlene Village") appended.
+    expect(
+      suppressRedundantCity(
+        "Greek Village, 301 NW Murray Blvd, Portland, OR 97229, USA",
+        "Marlene Village, OR",
+      ),
+    ).toBeNull();
+  });
+
+  it("preserves city when full US address contains the city (#906)", () => {
+    expect(
+      suppressRedundantCity(
+        "Greek Village, 301 NW Murray Blvd, Portland, OR 97229, USA",
+        "Portland, OR",
+      ),
+    ).toBe("Portland, OR");
+  });
+
+  it("preserves city for international address with no zip (#906)", () => {
+    expect(
+      suppressRedundantCity(
+        "Marina Green, San Francisco, California",
+        "San Francisco, CA",
+      ),
+    ).toBe("San Francisco, CA");
+  });
+
+  it("suppresses neighborhood for Google-formatted US address with ZIP before state (#906)", () => {
+    // Google Maps & Harrier Central both emit "...ZIP, ST, United States".
+    // Note: HARRIER_CENTRAL itself is in shouldSkipReverseGeocode so this path
+    // isn't reached for HC events today, but other sources emit the same shape.
+    expect(
+      suppressRedundantCity(
+        "Apothecary Ale House, 227 Spruce Street, Morgantown, 26505-7511, WV, United States",
+        "Marlene Village, WV",
+      ),
+    ).toBeNull();
+  });
+
+  it("preserves city when ZIP-before-state US address contains the city (#906)", () => {
+    expect(
+      suppressRedundantCity(
+        "Apothecary Ale House, 227 Spruce Street, Morgantown, 26505-7511, WV, United States",
+        "Morgantown, WV",
+      ),
+    ).toBe("Morgantown, WV");
+  });
+
+  it("preserves city for international address with 5-digit postal code (#906)", () => {
+    // German 5-digit postal code shouldn't trigger US zip suppression.
+    expect(
+      suppressRedundantCity(
+        "Hofbräuhaus, Platzl 9, 80331 München, Germany",
+        "Munich",
+      ),
+    ).toBe("Munich");
+    // French 5-digit postal code.
+    expect(
+      suppressRedundantCity(
+        "Tour Eiffel, 5 Avenue Anatole France, 75007 Paris, France",
+        "Paris",
+      ),
+    ).toBe("Paris");
+  });
 });
 
 // ============================================================================

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -840,7 +840,11 @@ async function upsertCanonicalEvent(
         where: { id: existingEvent.id },
         data: {
           ...(shouldRestore ? { status: "CONFIRMED" as const } : {}),
-          runNumber: event.runNumber ?? existingEvent.runNumber,
+          // Tri-state: undefined = preserve existing, null = explicit clear
+          // (e.g. HC eventNumber=0 socials), number = overwrite (#892).
+          ...(event.runNumber !== undefined
+            ? { runNumber: event.runNumber }
+            : {}),
           title: (() => {
             const nextTitle = sanitizeTitle(event.title) ?? existingEvent.title;
             return nextTitle ? rewriteStaleDefaultTitle(nextTitle, kennelData.kennelCode, kennelData.shortName, kennelData.fullName) : nextTitle;

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -606,11 +606,28 @@ export function sanitizeLocation(location: string | undefined): string | null {
 
 /**
  * Suppress reverse-geocoded locationCity when locationName already contains a full
- * address with state code and the city doesn't match (avoids "Hartville, OH, Akron, OH").
+ * US address and the city doesn't match (avoids "Hartville, OH, Akron, OH").
+ *
+ * Three US-specific patterns trigger the city/locationName comparison:
+ *   1. `…, ST` or `…, ST 12345`            (short-form trailing state code)
+ *   2. `ST 12345` anywhere in the string   (#906: catches `…, ST 12345, USA`
+ *      where Google's reverse geocoder returns a neighborhood like
+ *      "Marlene Village, OR" that shouldn't be appended to a fully-qualified
+ *      address.)
+ *   3. `12345, ST` anywhere in the string  (#906 + #907: Harrier Central and
+ *      Google Maps emit addresses like `…, 26505-7511, WV, United States`
+ *      with ZIP before state.)
+ *
+ * All three require a 2-letter US state code adjacent to a 5-digit ZIP —
+ * a bare 5-digit number is not enough, so international addresses with
+ * 5-digit postal codes (e.g. "80331 München, Germany") are left alone.
  */
 export function suppressRedundantCity(locationName: string | null, city: string | null): string | null {
   if (!city || !locationName) return city;
-  if (!/,\s*[A-Z]{2}(?:\s+\d{5})?$/.test(locationName)) return city;
+  const stateSuffix = /,\s*[A-Z]{2}(?:\s+\d{5})?$/.test(locationName);
+  const hasStateZip = /\b[A-Z]{2}\s+\d{5}(?:-\d{4})?\b/.test(locationName);
+  const hasZipState = /\b\d{5}(?:-\d{4})?,\s*[A-Z]{2}\b/.test(locationName);
+  if (!stateSuffix && !hasStateZip && !hasZipState) return city;
   // Require at least 3 segments (e.g., "Street, City, ST") — fewer suggests incomplete address
   if (locationName.split(",").length < 3) return city;
   const cityName = city.split(",")[0].trim();


### PR DESCRIPTION
## Summary

Daily audit round — 7 extraction bugs across 4 adapters + the merge pipeline. One commit per issue, each with a regression test and live-verified against production per `.claude/rules/live-verification.md`.

| Issue | Commit | Fix |
|---|---|---|
| #892 | `fix(harrier-central)` | `eventNumber === 0` (social / drinking practice) maps to `runNumber: null` explicit clear; non-numeric falls through as `undefined` to preserve existing value on partial payloads |
| #907 | `fix(harrier-central)` | Compose `locationName` from `locationOneLineDesc` + `resolvableLocation`, de-duplicating repeated segments/prefixes. Coordinate-only `resolvableLocation` is dropped as non-text |
| #873 | `fix(lsw-h3)` | LSW hareline's "DESCRIPTION" column is an HK district name — now emitted as `location`, not `description`. One-shot admin cleanup script included for stale rows |
| #889 | `fix(burlington-hash)` | Extract run number when title uses `ft.`/`feat.` separator or is bare `BTVH3 #NNN` |
| #887 | `fix(burlington-hash)` | Extract `cost` and `description` from the Wix `details=` HTML (previously only hares were pulled out) |
| #905 | `fix(dublin-hash)` | Normalize `\u00A0` (nbsp) before stripping `, D<postcode>` fragment so trailing ", D" / ", D4" don't survive |
| #906 | `fix(merge)` | Widen `suppressRedundantCity` to catch Google-formatted US addresses (`...ZIP, ST, United States`); preserve existing `runNumber` on undefined while clearing on explicit null |

## Follow-ups (out of scope, noted in PR body only)

- **HC `locationCity` one-shot repair:** existing HC events still carry reverse-geocoded neighborhood text. The merge guard prevents further regressions; a one-shot DB update can clear stale values.
- **LSW cleanup ordering:** `scripts/cleanup-lsw-stale-descriptions.ts` must run BEFORE any force re-scrape of the LSW source — noted in the script header.
- **BurlyH3 hash-cash mismatch:** kennel profile shows `$6` but trails charge `$6.90` — kennel-level one-shot update.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (pre-existing warnings only)
- [x] `npm test` — 5100 passed, 2 skipped, 25 todo (7 new regression tests added)
- [x] Live-verified per adapter per `.claude/rules/live-verification.md`

Closes #907, #892, #906, #905, #889, #887, #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)