### PR TITLE
feat(sources): enable Malaysia Phase 1 (PH3, KLFMH3, KLJHHH)

### DIFF
--- a/.claude/rules/active-sources.md
+++ b/.claude/rules/active-sources.md
@@ -218,9 +218,9 @@ globs:
 
 ## Malaysia (7 sources — Phase 1: KL + Penang founder pack)
 - **Mother Hash Website** -> HTML_SCRAPER (Google Sites, labeled-field parse) -> motherh3 (weekly Monday 18:00, **1938 — first hash kennel in the world**)
-- **Petaling H3 Hareline** -> HTML_SCRAPER (Yii GridView, shared adapter) -> ph3-my (weekly Saturday, 1977, 1160+ runs) — **gated `enabled:false` pending live verify post-merge**
-- **KL Full Moon H3 Hareline** -> HTML_SCRAPER (Yii GridView, shared adapter) -> klfmh3 (monthly full moon, 1992) — **gated `enabled:false` pending live verify post-merge**
-- **KL Junior H3 Website** -> HTML_SCRAPER (WordPress REST API, body regex) -> kljhhh (monthly 1st Sunday, 1982) — **gated `enabled:false` pending live verify post-merge**
+- **Petaling H3 Hareline** -> HTML_SCRAPER (Yii GridView, shared adapter) -> ph3-my (weekly Saturday, 1977, 1160+ runs)
+- **KL Full Moon H3 Hareline** -> HTML_SCRAPER (Yii GridView, shared adapter) -> klfmh3 (monthly full moon, 1992)
+- **KL Junior H3 Website** -> HTML_SCRAPER (WordPress REST API, body regex) -> kljhhh (monthly 1st Sunday, 1982)
 - **Penang H3 Hareline** -> HTML_SCRAPER (goHash.app SSR, shared adapter) -> penangh3 (weekly Monday 17:30, 1965 — 3rd-oldest kennel ever)
 - **HHH Penang Hareline** -> HTML_SCRAPER (goHash.app SSR, shared adapter) -> hhhpenang (weekly Thursday 17:30, 1972)
 - **Kelana Jaya Harimau Blog** -> HTML_SCRAPER (Blogger API with Run#: title filter + dedup) -> kj-harimau (weekly Tuesday 18:00, 1996)

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3028,15 +3028,10 @@ export const SOURCES = [
     },
 
     // 2. Petaling H3 — Yii Framework hareline, 1,160+ runs back to 2003
-    // DISABLED pending live verification: Malaysia-hosted origin was
-    // unreachable during the build window so the adapter was only
-    // exercised against captured HTML. Manually flip enabled=true after
-    // confirming the first scrape post-merge returns valid events.
     {
       name: "Petaling H3 Hareline",
       url: "https://ph3.org/index.php?r=site/hareline",
       type: "HTML_SCRAPER" as const,
-      enabled: false,
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 180,
@@ -3048,12 +3043,10 @@ export const SOURCES = [
     },
 
     // 3. KL Full Moon H3 — Yii Framework hareline (same shape as PH3)
-    // DISABLED pending live verification (same Malaysia origin outage).
     {
       name: "KL Full Moon H3 Hareline",
       url: "https://klfullmoonhash.com/index.php?r=site/hareline",
       type: "HTML_SCRAPER" as const,
-      enabled: false,
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 365,
@@ -3065,12 +3058,10 @@ export const SOURCES = [
     },
 
     // 4. KL Junior H3 — self-hosted WordPress REST API
-    // DISABLED pending live verification (same Malaysia origin outage).
     {
       name: "KL Junior H3 Website",
       url: "https://www.kljhhh.org",
       type: "HTML_SCRAPER" as const,
-      enabled: false,
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 365,


### PR DESCRIPTION
## Summary

- Live-verified all 3 Malaysia Phase 1 sources against production URLs and flipped `enabled: false` → default (enabled) in `prisma/seed-data/sources.ts`.
- Drops the stale "DISABLED pending live verification" comment blocks and the gating callout in `.claude/rules/active-sources.md`.

## Live verification results (today)

Ran each adapter end-to-end against the live origin:

| Source | URL | Events | Upcoming | Date range |
|---|---|---|---|---|
| Petaling H3 | `ph3.org/index.php?r=site/hareline` | 39 | 17 | 2025-11-22 → 2026-08-15 |
| KL Full Moon H3 | `klfullmoonhash.com/index.php?r=site/hareline` | 21 | 9 | 2025-05-11 → 2026-12-20 |
| KL Junior H3 | `www.kljhhh.org` | 20 | 8 | 2025-05-04 → 2026-12-06 |

Sample event from Petaling H3:
```
date: '2025-11-22', kennelTag: 'ph3-my', startTime: '16:00',
runNumber: 2459, hares: 'John Lavelle'
```

All three return valid `date` (UTC noon), `kennelTag`, and `HH:MM` `startTime`.

## Why this is safe

- Adapters and tests already shipped with the original PR; this only flips an `enabled` flag on existing seed rows.
- Origin reachability was the original blocker — confirmed today (HTTP 200 from all 3 hosts in <4s).
- Source-kennel mappings, fingerprint dedup, and the merge pipeline have not changed.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (13 pre-existing warnings)
- [x] `npm test` — 5073 passed
- [x] Live-fetch each adapter, confirm event counts + sample event
- [ ] After merge: confirm first scheduled scrape produces RawEvents in prod for each source

🤖 Generated with [Claude Code](https://claude.com/claude-code)