### PR TITLE
refactor(travel): dedupe confirmed-event projection + city-name split

### DIFF
--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -17,6 +17,7 @@ import { TravelSearchForm } from "@/components/travel/TravelSearchForm";
 import { TravelResults } from "@/components/travel/TravelResults";
 import { TravelResultsSkeleton } from "@/components/travel/TravelResultsSkeleton";
 import { TripSummary } from "@/components/travel/TripSummary";
+import { toExportableConfirmedEvent } from "@/lib/travel/export";
 import { EmptyStates } from "@/components/travel/EmptyStates";
 import { TravelHero } from "@/components/travel/TravelHero";
 import { PopularDestinations } from "@/components/travel/PopularDestinations";
@@ -279,17 +280,7 @@ async function TravelResultsServer({
       confirmedCount: exportableConfirmed.length,
       likelyCount: results.likely.length + (broaderResults?.likely.length ?? 0),
       possibleCount: results.possible.length + (broaderResults?.possible.length ?? 0),
-      confirmedEvents: exportableConfirmed.map((r) => ({
-        date: r.date,
-        startTime: r.startTime,
-        timezone: r.timezone,
-        title: r.title,
-        runNumber: r.runNumber,
-        haresText: r.haresText,
-        locationName: r.locationName,
-        sourceUrl: r.sourceUrl,
-        kennelName: r.kennelName,
-      })),
+      confirmedEvents: exportableConfirmed.map(toExportableConfirmedEvent),
     };
 
     // Auto-save only fires for authenticated users returning from the
@@ -639,17 +630,7 @@ async function SavedTripPage({
     possibleCount: serializedResults.possible.length,
     noCoverage: serializedResults.emptyState === "no_coverage",
     horizonTier: serializedResults.meta.horizonTier,
-    confirmedEvents: exportableConfirmed.map((r) => ({
-      date: r.date,
-      startTime: r.startTime,
-      timezone: r.timezone,
-      title: r.title,
-      runNumber: r.runNumber,
-      haresText: r.haresText,
-      locationName: r.locationName,
-      sourceUrl: r.sourceUrl,
-      kennelName: r.kennelName,
-    })),
+    confirmedEvents: exportableConfirmed.map(toExportableConfirmedEvent),
     legs: isMultiStop ? heroLegs : undefined,
   };
 

--- a/src/components/travel/SavedTripCard.tsx
+++ b/src/components/travel/SavedTripCard.tsx
@@ -20,6 +20,7 @@ import {
   formatDateCompact,
   formatNights,
   cityToIata,
+  extractCityName,
   formatLegDateRange,
 } from "@/lib/travel/format";
 import { buildTravelSearchUrl, utcYmd } from "@/lib/travel/url";
@@ -250,7 +251,7 @@ export function SavedTripCard({
                     <div className="rounded-md border border-border/60 bg-muted/30 px-4 py-3">
                       <div className="font-display text-base font-medium tracking-tight text-foreground">
                         {isMultiStop
-                          ? destinations.map((d) => d.label.split(",")[0]?.trim() ?? d.label).join(" → ")
+                          ? destinations.map((d) => extractCityName(d.label)).join(" → ")
                           : firstLeg.label}
                       </div>
                       <div className="mt-1 font-mono text-xs uppercase tracking-wider text-muted-foreground">
@@ -297,10 +298,7 @@ export function SavedTripCard({
  */
 function MultiStopHeader({ destinations }: { destinations: SavedTripLeg[] }) {
   const iataCodes = destinations.map((d) => cityToIata(d.label));
-  const cityNames = destinations.map((d) => {
-    const first = d.label.split(",")[0]?.trim() ?? d.label;
-    return first.toUpperCase();
-  });
+  const cityNames = destinations.map((d) => extractCityName(d.label).toUpperCase());
 
   return (
     <div className="min-w-0">

--- a/src/components/travel/TravelResults.tsx
+++ b/src/components/travel/TravelResults.tsx
@@ -12,7 +12,7 @@ import {
   type DayCode,
   type DistanceTier,
 } from "@/lib/travel/filters";
-import { formatDayHeader, cityToIata } from "@/lib/travel/format";
+import { formatDayHeader, cityToIata, extractCityName } from "@/lib/travel/format";
 import {
   bucketDays,
   bucketStops,
@@ -475,9 +475,7 @@ function LegSubHeader({
 }) {
   const seq = String(destinationIndex + 1).padStart(2, "0");
   const iata = destinationLabel ? cityToIata(destinationLabel) : "—";
-  const cityShort = destinationLabel
-    ? (destinationLabel.split(",")[0]?.trim() ?? destinationLabel)
-    : "Stop";
+  const cityShort = destinationLabel ? extractCityName(destinationLabel) : "Stop";
   return (
     <div className="flex items-center gap-3">
       <span className="inline-flex items-center justify-center rounded-sm border-[1.5px] border-red-600/70 px-1.5 py-[1px] font-mono text-[10px] font-bold uppercase tracking-wider text-red-600 dark:border-red-400/70 dark:text-red-400">

--- a/src/components/travel/TripSummary.tsx
+++ b/src/components/travel/TripSummary.tsx
@@ -16,10 +16,22 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { formatDateCompact, daysBetween, cityToIata } from "@/lib/travel/format";
+import {
+  formatDateCompact,
+  daysBetween,
+  cityToIata,
+  extractCityName,
+} from "@/lib/travel/format";
 import { buildMultiEventIcs } from "@/lib/calendar";
 import { capture } from "@/lib/analytics";
 import { stashSaveIntent } from "@/lib/travel/save-intent";
+import type { ExportableConfirmedEvent } from "@/lib/travel/export";
+
+// Re-export so existing consumers that imported `ExportableConfirmedEvent`
+// from TripSummary keep working. The canonical definition + projection
+// helper now live at `@/lib/travel/export` so server components can
+// use them without crossing the `"use client"` boundary.
+export type { ExportableConfirmedEvent } from "@/lib/travel/export";
 import { sanitizeRedirectPath } from "@/lib/travel/url";
 import {
   deleteTravelSearch,
@@ -27,18 +39,6 @@ import {
   saveTravelSearch,
 } from "@/app/travel/actions";
 
-/** Minimal shape required to build a VEVENT from a confirmed search result. */
-export interface ExportableConfirmedEvent {
-  date: string;
-  startTime: string | null;
-  timezone: string | null;
-  title: string | null;
-  runNumber: number | null;
-  haresText: string | null;
-  locationName: string | null;
-  sourceUrl: string | null;
-  kennelName: string;
-}
 
 /** Per-leg shape used when rendering the multi-stop ITINERARY hero. */
 export interface TripSummaryLeg {
@@ -507,10 +507,7 @@ function SavedBadge({
  */
 function ItineraryHero({ legs }: Readonly<{ legs: TripSummaryLeg[] }>) {
   const iataCodes = legs.map((leg) => cityToIata(leg.label));
-  const cityNames = legs.map((leg) => {
-    const first = leg.label.split(",")[0]?.trim() ?? leg.label;
-    return first.toUpperCase();
-  });
+  const cityNames = legs.map((leg) => extractCityName(leg.label).toUpperCase());
   const firstStart = legs[0].startDate;
   const lastEnd = legs.at(-1)!.endDate;
   const totalDays = daysBetween(firstStart, lastEnd);

--- a/src/lib/travel/export.ts
+++ b/src/lib/travel/export.ts
@@ -1,0 +1,60 @@
+import type { SerializedConfirmed } from "./serialize";
+
+/** Minimal shape required to build a VEVENT from a confirmed search result. */
+export interface ExportableConfirmedEvent {
+  date: string;
+  startTime: string | null;
+  timezone: string | null;
+  title: string | null;
+  runNumber: number | null;
+  haresText: string | null;
+  locationName: string | null;
+  sourceUrl: string | null;
+  kennelName: string;
+}
+
+/**
+ * Project a serialized confirmed search result to the minimal
+ * `ExportableConfirmedEvent` shape the ICS builder needs. Both
+ * /travel entry points (TravelResultsServer + SavedTripPage) use
+ * this so the projection stays in one place and the interface above
+ * remains the source of truth for which fields the exporter depends
+ * on.
+ *
+ * Lives in a plain (non-`"use client"`) module so server components
+ * — `src/app/travel/page.tsx` — can import it without crossing an
+ * RSC boundary. The client-side `TripSummary` re-exports
+ * `ExportableConfirmedEvent` for backward compatibility with the
+ * external consumer shape.
+ *
+ * The param is typed as a `Pick` of `SerializedConfirmed` (not an
+ * inline shape) so adding a field to `ExportableConfirmedEvent`
+ * surfaces a compile error at the projection and forces the call
+ * sites to opt in explicitly.
+ */
+export function toExportableConfirmedEvent(
+  r: Pick<
+    SerializedConfirmed,
+    | "date"
+    | "startTime"
+    | "timezone"
+    | "title"
+    | "runNumber"
+    | "haresText"
+    | "locationName"
+    | "sourceUrl"
+    | "kennelName"
+  >,
+): ExportableConfirmedEvent {
+  return {
+    date: r.date,
+    startTime: r.startTime,
+    timezone: r.timezone,
+    title: r.title,
+    runNumber: r.runNumber,
+    haresText: r.haresText,
+    locationName: r.locationName,
+    sourceUrl: r.sourceUrl,
+    kennelName: r.kennelName,
+  };
+}

--- a/src/lib/travel/format.ts
+++ b/src/lib/travel/format.ts
@@ -280,6 +280,20 @@ const CITY_IATA: Record<string, string> = {
  * are stripped before the consonant fallback, so "São Paulo" → "SPL"
  * (instead of, say, "PLO") after the accented S survives the lowercasing.
  */
+/**
+ * Extract the display city name from a destination label (e.g.
+ * "London, UK" → "London", "San Francisco, CA, USA" → "San Francisco").
+ * Uses the first comma-separated segment, trimmed. Falls back to the
+ * full label when no comma is present (e.g. "Near me").
+ *
+ * Matches the split convention used by `cityToIata` below, so the pair
+ * (code + city subhead) renders in lockstep across SavedTripCard's
+ * MultiStopHeader and TripSummary's ItineraryHero.
+ */
+export function extractCityName(label: string): string {
+  return label.split(",")[0]?.trim() ?? label;
+}
+
 export function cityToIata(label: string): string {
   const firstSegment = label.split(",")[0]?.trim().toLowerCase() ?? "";
   const hit = CITY_IATA[firstSegment];

--- a/src/lib/travel/format.ts
+++ b/src/lib/travel/format.ts
@@ -291,7 +291,10 @@ const CITY_IATA: Record<string, string> = {
  * MultiStopHeader and TripSummary's ItineraryHero.
  */
 export function extractCityName(label: string): string {
-  return label.split(",")[0]?.trim() ?? label;
+  // `String.prototype.split` always returns at least one element, so
+  // the `[0]` access is non-nullable — no optional-chain or fallback
+  // needed.
+  return label.split(",")[0].trim();
 }
 
 export function cityToIata(label: string): string {


### PR DESCRIPTION
## Summary
Two small cleanups flagged by prior review loops (gemini #935 and codex #880):

1. **`toExportableConfirmedEvent`** — 9-line projection from `SerializedConfirmed` to `ExportableConfirmedEvent` was duplicated byte-for-byte across `TravelResultsServer` and `SavedTripPage`. New helper at `@/lib/travel/export.ts` alongside the canonical type. TripSummary re-exports the type for its existing public surface. Param typed as `Pick<SerializedConfirmed, …>` so future fields force call-site opt-in.
2. **`extractCityName`** — `label.split(",")[0]?.trim() ?? label` was repeated at 4 sites (`ItineraryHero`, `MultiStopHeader`, SavedTripCard delete dialog, `DestinationBoardingStamp` in TravelResults). New helper in `@/lib/travel/format` alongside `cityToIata`.

## Pre-PR review loop
- **`/simplify`**: flagged inline param type (should anchor to `SerializedConfirmed`) and a missed 4th city-split site — both applied.
- **`/codex:adversarial-review`** caught a real RSC boundary hazard: my first draft put `toExportableConfirmedEvent` in `TripSummary.tsx` (`"use client"`), which server `page.tsx` then imported. `tsc` accepted it but `next build` would reject at the client-reference serialization step. **Fixed before push** by lifting the helper into the plain `@/lib/travel/export.ts` module. `npx next build` now passes clean.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npx vitest run` — 5074 passed (baseline)
- [x] `npx next build` — `/travel` + `/travel/saved` routes compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)