### PR TITLE
perf(hareline): cache event list + tag-invalidate on mutations

### DIFF
--- a/src/app/admin/events/actions.test.ts
+++ b/src/app/admin/events/actions.test.ts
@@ -24,7 +24,11 @@ vi.mock("@/lib/db", () => ({
     ),
   },
 }));
-vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  unstable_cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+}));
 
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";

--- a/src/app/admin/events/actions.ts
+++ b/src/app/admin/events/actions.ts
@@ -3,7 +3,8 @@
 import { prisma } from "@/lib/db";
 import { getAdminUser } from "@/lib/auth";
 import type { ActionResult } from "@/lib/actions";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
 
 const DELETE_BATCH_SIZE = 100;
 
@@ -78,6 +79,7 @@ export async function deleteEvent(eventId: string): Promise<ActionResult<{ kenne
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return {
     success: true,
     kennelName: event.kennel.shortName,
@@ -175,6 +177,7 @@ export async function bulkDeleteEvents(filters: {
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true, deletedCount };
 }
 
@@ -205,6 +208,7 @@ export async function deleteSelectedEvents(eventIds: string[]): Promise<ActionRe
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true, deletedCount };
 }
 
@@ -238,6 +242,7 @@ export async function uncancelEvent(eventId: string): Promise<ActionResult<{ ken
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   revalidatePath(`/hareline/${eventId}`);
   return {
     success: true,

--- a/src/app/admin/events/actions.ts
+++ b/src/app/admin/events/actions.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/db";
 import { getAdminUser } from "@/lib/auth";
 import type { ActionResult } from "@/lib/actions";
 import { revalidatePath, revalidateTag } from "next/cache";
-import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
+import { HARELINE_EVENTS_TAG } from "@/lib/cache-tags";
 
 const DELETE_BATCH_SIZE = 100;
 
@@ -79,7 +79,7 @@ export async function deleteEvent(eventId: string): Promise<ActionResult<{ kenne
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return {
     success: true,
     kennelName: event.kennel.shortName,
@@ -177,7 +177,7 @@ export async function bulkDeleteEvents(filters: {
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true, deletedCount };
 }
 
@@ -208,7 +208,7 @@ export async function deleteSelectedEvents(eventIds: string[]): Promise<ActionRe
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true, deletedCount };
 }
 
@@ -242,7 +242,7 @@ export async function uncancelEvent(eventId: string): Promise<ActionResult<{ ken
 
   revalidatePath("/admin/events");
   revalidatePath("/hareline");
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   revalidatePath(`/hareline/${eventId}`);
   return {
     success: true,

--- a/src/app/admin/events/backfill-city-action.ts
+++ b/src/app/admin/events/backfill-city-action.ts
@@ -3,7 +3,8 @@
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { reverseGeocode } from "@/lib/geo";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
 
 interface BackfillCityResult {
   total: number;
@@ -101,6 +102,7 @@ export async function backfillEventCities(): Promise<{
 
   revalidatePath("/hareline");
   revalidatePath("/admin/events");
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
 
   return {
     result: {

--- a/src/app/admin/events/backfill-city-action.ts
+++ b/src/app/admin/events/backfill-city-action.ts
@@ -4,7 +4,7 @@ import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { reverseGeocode } from "@/lib/geo";
 import { revalidatePath, revalidateTag } from "next/cache";
-import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
+import { HARELINE_EVENTS_TAG } from "@/lib/cache-tags";
 
 interface BackfillCityResult {
   total: number;
@@ -81,7 +81,11 @@ export async function backfillEventCities(): Promise<{
   }
 
   // Update events in batches (no transaction needed — each updateMany
-  // targets a disjoint set of events with an idempotent value)
+  // targets a disjoint set of events with an idempotent value).
+  // Earlier batches may have already written `locationCity` rows by the
+  // time a later batch throws, so the `finally` always runs the
+  // invalidations — otherwise the Hareline cache would keep serving the
+  // pre-backfill city values until the 3600s fallback window expired.
   const updateEntries = Array.from(coordToCity.entries());
   try {
     for (let i = 0; i < updateEntries.length; i += BATCH_SIZE) {
@@ -98,11 +102,11 @@ export async function backfillEventCities(): Promise<{
   } catch (e) {
     console.error("Failed to backfill event cities:", e);
     return { error: "Database update failed during city backfill." };
+  } finally {
+    revalidatePath("/hareline");
+    revalidatePath("/admin/events");
+    revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   }
-
-  revalidatePath("/hareline");
-  revalidatePath("/admin/events");
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
 
   return {
     result: {

--- a/src/app/admin/kennels/actions.test.ts
+++ b/src/app/admin/kennels/actions.test.ts
@@ -19,7 +19,11 @@ vi.mock("@/lib/db", () => ({
     $transaction: vi.fn((arr: unknown[]) => Promise.all(arr)),
   },
 }));
-vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  unstable_cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+}));
 
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";

--- a/src/app/admin/kennels/actions.ts
+++ b/src/app/admin/kennels/actions.ts
@@ -2,7 +2,8 @@
 
 import { getAdminUser, getRosterGroupId } from "@/lib/auth";
 import { prisma } from "@/lib/db";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
 import { fuzzyMatch } from "@/lib/fuzzy";
 import { toSlug, toKennelCode } from "@/lib/kennel-utils";
 import { generateAliases } from "@/lib/auto-aliases";
@@ -311,6 +312,11 @@ export async function updateKennel(kennelId: string, formData: FormData) {
 
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
+  // Kennel display fields (shortName/fullName/slug/region/country) are
+  // denormalized into the cached Hareline event list via a nested
+  // `kennel` select, so any mutation here can leave stale labels/routes
+  // in the cache until TTL.
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true };
 }
 
@@ -388,6 +394,7 @@ export async function deleteKennel(kennelId: string) {
 
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true };
 }
 
@@ -708,6 +715,9 @@ export async function mergeKennels(
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
   revalidatePath(`/kennels/${targetKennel.slug}`);
+  // Merge reassigns events to the target kennel, so their cached kennel
+  // display fields (shortName/slug/region) go stale until tag bust.
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true };
 }
 
@@ -744,6 +754,10 @@ export async function toggleKennelVisibility(kennelId: string) {
   revalidatePath(`/kennels/${kennel.slug}`);
   revalidatePath("/hareline");
   revalidatePath("/misman");
+  // Hareline's cached event list filters on `kennel.isHidden`; without a
+  // tag bust the cache would continue to include (or exclude) this kennel's
+  // events until the 3600s revalidate window expired.
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true, isHidden: newValue };
 }
 

--- a/src/app/admin/kennels/actions.ts
+++ b/src/app/admin/kennels/actions.ts
@@ -3,7 +3,7 @@
 import { getAdminUser, getRosterGroupId } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { revalidatePath, revalidateTag } from "next/cache";
-import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
+import { HARELINE_EVENTS_TAG } from "@/lib/cache-tags";
 import { fuzzyMatch } from "@/lib/fuzzy";
 import { toSlug, toKennelCode } from "@/lib/kennel-utils";
 import { generateAliases } from "@/lib/auto-aliases";
@@ -316,7 +316,7 @@ export async function updateKennel(kennelId: string, formData: FormData) {
   // denormalized into the cached Hareline event list via a nested
   // `kennel` select, so any mutation here can leave stale labels/routes
   // in the cache until TTL.
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true };
 }
 
@@ -394,7 +394,7 @@ export async function deleteKennel(kennelId: string) {
 
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true };
 }
 
@@ -717,7 +717,7 @@ export async function mergeKennels(
   revalidatePath(`/kennels/${targetKennel.slug}`);
   // Merge reassigns events to the target kennel, so their cached kennel
   // display fields (shortName/slug/region) go stale until tag bust.
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true };
 }
 
@@ -757,7 +757,7 @@ export async function toggleKennelVisibility(kennelId: string) {
   // Hareline's cached event list filters on `kennel.isHidden`; without a
   // tag bust the cache would continue to include (or exclude) this kennel's
   // events until the 3600s revalidate window expired.
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true, isHidden: newValue };
 }
 

--- a/src/app/admin/regions/actions.ts
+++ b/src/app/admin/regions/actions.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/db";
 import { callGemini } from "@/lib/ai/gemini";
 import { regionSlug } from "@/lib/region";
 import { revalidatePath, revalidateTag } from "next/cache";
-import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
+import { HARELINE_EVENTS_TAG } from "@/lib/cache-tags";
 
 export async function getRegionsWithKennels() {
   const admin = await getAdminUser();
@@ -191,7 +191,7 @@ async function updateRegionWithRename(
   revalidatePath("/admin/kennels");
   // Denormalized `region` string on each kennel just changed; the Hareline
   // cache stores it per event, so bust the tag.
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true };
 }
 
@@ -305,7 +305,7 @@ export async function mergeRegions(
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
   // Merge reassigns kennels' denormalized `region` string.
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true };
 }
 
@@ -345,7 +345,7 @@ export async function reassignKennels(kennelIds: string[], targetRegionId: strin
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
   // Reassignment changes kennels' denormalized `region` string.
-  revalidateTag(HARELINE_EVENTS_TAG, "max");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true };
 }
 

--- a/src/app/admin/regions/actions.ts
+++ b/src/app/admin/regions/actions.ts
@@ -4,7 +4,8 @@ import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { callGemini } from "@/lib/ai/gemini";
 import { regionSlug } from "@/lib/region";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
 
 export async function getRegionsWithKennels() {
   const admin = await getAdminUser();
@@ -188,6 +189,9 @@ async function updateRegionWithRename(
 
   revalidatePath("/admin/regions");
   revalidatePath("/admin/kennels");
+  // Denormalized `region` string on each kennel just changed; the Hareline
+  // cache stores it per event, so bust the tag.
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true };
 }
 
@@ -300,6 +304,8 @@ export async function mergeRegions(
   revalidatePath("/admin/regions");
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
+  // Merge reassigns kennels' denormalized `region` string.
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true };
 }
 
@@ -338,6 +344,8 @@ export async function reassignKennels(kennelIds: string[], targetRegionId: strin
   revalidatePath("/admin/regions");
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
+  // Reassignment changes kennels' denormalized `region` string.
+  revalidateTag(HARELINE_EVENTS_TAG, "max");
   return { success: true };
 }
 

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -19,13 +19,10 @@
 import { unstable_cache } from "next/cache";
 import { prisma } from "@/lib/db";
 import { DISPLAY_EVENT_WHERE } from "@/lib/event-filters";
-
-/**
- * Shared invalidation tag. Import from here (rather than inlining the
- * string literal at every call site) so the merge pipeline + admin
- * mutation actions stay in sync with the cache wrapper below.
- */
-export const HARELINE_EVENTS_TAG = "hareline:events";
+// Tag constant lives in a plain module — a `"use server"` file can only
+// export async functions, so any non-function export (even a string)
+// makes Next strip all exports and fail the build at import sites.
+import { HARELINE_EVENTS_TAG } from "@/lib/cache-tags";
 
 /** Matches the slim shape rendered by EventCard's list view. */
 export interface HarelineListEvent {

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -7,12 +7,25 @@
  *   both the initial server render (page.tsx) and lazy client tab-switches
  *   (HarelineView), so the two paths always use the same date boundaries,
  *   ordering, and serialization.
+ *   Delegates to an `unstable_cache`-wrapped inner so anonymous traffic
+ *   is served from the function's in-region cache. The public shape
+ *   (`HarelineListEvent`) keeps `dateUtc` as `Date` — the cache internally
+ *   round-trips via ISO string (JSON-safe) and we rehydrate at the boundary
+ *   so consumers don't need to know it was cached.
  * - getEventDetail: heavy fields (description, source URL, full address,
  *   eventLinks) fetched on detail-panel expand. Keeps the list payload slim.
  */
 
+import { unstable_cache } from "next/cache";
 import { prisma } from "@/lib/db";
 import { DISPLAY_EVENT_WHERE } from "@/lib/event-filters";
+
+/**
+ * Shared invalidation tag. Import from here (rather than inlining the
+ * string literal at every call site) so the merge pipeline + admin
+ * mutation actions stay in sync with the cache wrapper below.
+ */
+export const HARELINE_EVENTS_TAG = "hareline:events";
 
 /** Matches the slim shape rendered by EventCard's list view. */
 export interface HarelineListEvent {
@@ -49,8 +62,103 @@ export type TimeMode = "upcoming" | "past";
 const PAST_EVENTS_LIMIT = 200;
 
 /**
- * Fetch the slim event list for a time mode.
+ * Cache-shape twin of `HarelineListEvent` with `dateUtc` serialized to ISO
+ * string. `unstable_cache` JSON-serializes its return value; keeping this
+ * twin explicit means the boundary conversion is visible at the call site.
+ */
+interface CachedHarelineEvent extends Omit<HarelineListEvent, "dateUtc"> {
+  dateUtc: string | null;
+}
+
+/**
+ * Cached inner: pure function of `(mode, todayDateStr)`.
  *
+ * Cache key parts, chosen so hit/miss behavior matches user intent:
+ *  - `mode` — upcoming vs past keep separate entries (different ORDER BY
+ *    + separate `take:` budget).
+ *  - `todayDateStr` — `YYYY-MM-DD` UTC date, so the key naturally rotates
+ *    at UTC midnight without a live timer. **Must not include raw `nowMs`**
+ *    or the key would churn every request.
+ *
+ * No region scoping at the cache/query layer: region filtering is
+ * client-side only. Attempting server-side region scoping via URL param
+ * introduced two classes of bugs — (1) the client uses `history.replaceState`
+ * for region chip changes so a user widening their selection past the
+ * original URL scope would stay frozen on the server-scoped subset,
+ * and (2) seed-derived region expansion misses metros that admins create
+ * at runtime via `src/app/admin/regions/actions.ts`. Keeping the cache
+ * key coarse maximizes hit rate and sidesteps both issues.
+ *
+ * `revalidate: 3600` is a belt-and-suspenders fallback. Tag invalidation
+ * from `scrapeSource` / admin mutations is the primary freshness mechanism
+ * (see `HARELINE_EVENTS_TAG` consumers). 1-hour max staleness in the
+ * absence of scrape activity is acceptable for a community event calendar.
+ */
+const fetchSlimEventsCached = unstable_cache(
+  async (
+    mode: TimeMode,
+    todayDateStr: string,
+  ): Promise<CachedHarelineEvent[]> => {
+    // Reconstruct UTC boundary from the date string so the cached function
+    // is a pure function of its args. (No reading Date.now() here —
+    // that would invalidate the cache contract.)
+    const startOfTodayUtc = new Date(`${todayDateStr}T00:00:00.000Z`);
+    const yesterdayUtc = new Date(startOfTodayUtc.getTime() - 24 * 60 * 60 * 1000);
+    const isPast = mode === "past";
+
+    const where = {
+      ...DISPLAY_EVENT_WHERE,
+      date: isPast ? { lt: yesterdayUtc } : { gte: yesterdayUtc },
+    };
+
+    const events = await prisma.event.findMany({
+      where,
+      select: {
+        id: true,
+        date: true,
+        dateUtc: true,
+        timezone: true,
+        kennelId: true,
+        runNumber: true,
+        title: true,
+        haresText: true,
+        startTime: true,
+        locationName: true,
+        locationCity: true,
+        status: true,
+        latitude: true,
+        longitude: true,
+        kennel: {
+          select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },
+        },
+      },
+      orderBy: { date: isPast ? "desc" : "asc" },
+      ...(isPast ? { take: PAST_EVENTS_LIMIT } : {}),
+    });
+
+    return events.map((e) => ({
+      id: e.id,
+      date: e.date.toISOString(),
+      dateUtc: e.dateUtc ? e.dateUtc.toISOString() : null,
+      timezone: e.timezone,
+      kennelId: e.kennelId,
+      kennel: e.kennel,
+      runNumber: e.runNumber,
+      title: e.title,
+      haresText: e.haresText,
+      startTime: e.startTime,
+      locationName: e.locationName,
+      locationCity: e.locationCity,
+      status: e.status,
+      latitude: e.latitude ?? null,
+      longitude: e.longitude ?? null,
+    }));
+  },
+  ["hareline:events"],
+  { tags: [HARELINE_EVENTS_TAG], revalidate: 3600 },
+);
+
+/**
  * Events are stored at UTC noon. The single boundary used for both modes is
  * `yesterday 00:00 UTC`: upcoming is `>= yesterdayUtc` (catches noon-UTC runs
  * that haven't happened yet in any Western-Hemisphere timezone), past is
@@ -60,11 +168,8 @@ const PAST_EVENTS_LIMIT = 200;
  * hide against `take: PAST_EVENTS_LIMIT`.
  *
  * `nowMs` lets the initial-render path in `page.tsx` share a single clock
- * with the `serverNowMs` prop passed to the client — otherwise an HTTP
- * request that straddles UTC midnight could have the server compute its
- * boundary off one day and the client hydrate off the next. Omit for the
- * lazy client-driven tab switch, which recomputes fresh boundaries each
- * call.
+ * with the `serverNowMs` prop passed to the client. Omit for the lazy
+ * client-driven tab switch, which recomputes fresh boundaries each call.
  *
  * Uses `select` (not `include`) so heavy fields (description, sourceUrl,
  * locationStreet, locationAddress, eventLinks) never leave Postgres — they
@@ -74,55 +179,18 @@ export async function loadEventsForTimeMode(
   mode: TimeMode,
   nowMs?: number,
 ): Promise<HarelineListEvent[]> {
-  const now = new Date(nowMs ?? Date.now());
-  const startOfTodayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  const yesterdayUtc = new Date(startOfTodayUtc.getTime() - 24 * 60 * 60 * 1000);
-  const isPast = mode === "past";
+  // YYYY-MM-DD in UTC — the cache key that rotates at UTC midnight.
+  const todayDateStr = new Date(nowMs ?? Date.now()).toISOString().slice(0, 10);
 
-  const events = await prisma.event.findMany({
-    where: {
-      ...DISPLAY_EVENT_WHERE,
-      date: isPast ? { lt: yesterdayUtc } : { gte: yesterdayUtc },
-    },
-    select: {
-      id: true,
-      date: true,
-      dateUtc: true,
-      timezone: true,
-      kennelId: true,
-      runNumber: true,
-      title: true,
-      haresText: true,
-      startTime: true,
-      locationName: true,
-      locationCity: true,
-      status: true,
-      latitude: true,
-      longitude: true,
-      kennel: {
-        select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },
-      },
-    },
-    orderBy: { date: isPast ? "desc" : "asc" },
-    ...(isPast ? { take: PAST_EVENTS_LIMIT } : {}),
-  });
+  const cached = await fetchSlimEventsCached(mode, todayDateStr);
 
-  return events.map((e) => ({
-    id: e.id,
-    date: e.date.toISOString(),
-    dateUtc: e.dateUtc,
-    timezone: e.timezone,
-    kennelId: e.kennelId,
-    kennel: e.kennel,
-    runNumber: e.runNumber,
-    title: e.title,
-    haresText: e.haresText,
-    startTime: e.startTime,
-    locationName: e.locationName,
-    locationCity: e.locationCity,
-    status: e.status,
-    latitude: e.latitude ?? null,
-    longitude: e.longitude ?? null,
+  // Rehydrate `dateUtc` from ISO string back to `Date` at the cache
+  // boundary. Keeps `HarelineListEvent` stable across the project so
+  // EventCard/EventDetailPanel/CalendarView/kennel page don't need to
+  // learn about the cache shape.
+  return cached.map((e) => ({
+    ...e,
+    dateUtc: e.dateUtc ? new Date(e.dateUtc) : null,
   }));
 }
 

--- a/src/app/hareline/page.tsx
+++ b/src/app/hareline/page.tsx
@@ -66,7 +66,9 @@ export default async function HarelinePage({
  * `?time=past` is in the URL, the server fetches past events up front
  * instead of shipping upcoming and relying on the client to swap.
  */
-async function HarelineData({ initialTimeMode }: Readonly<{ initialTimeMode: TimeMode }>) {
+async function HarelineData({
+  initialTimeMode,
+}: Readonly<{ initialTimeMode: TimeMode }>) {
   // Capture `now` before awaiting and thread it into `loadEventsForTimeMode`
   // so the server query boundary, the `serverNowMs` prop, and the client's
   // hydrated bucket split all derive from the same instant. Without a shared

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared `unstable_cache` / `revalidateTag` tag constants.
+ *
+ * Kept in a plain module (no `"use server"`) so it can be imported from
+ * both the cache wrapper and any mutation site — a server-action module
+ * may only export async functions, so the tag constant can't live next
+ * to `loadEventsForTimeMode`.
+ */
+
+/** Invalidates the cached Hareline event list (see `src/app/hareline/actions.ts`). */
+export const HARELINE_EVENTS_TAG = "hareline:events";

--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -43,7 +43,7 @@ vi.mock("./health", () => ({
   autoResolveCleared: vi.fn(() => Promise.resolve(0)),
 }));
 
-// Mock next/cache so the `revalidateTag(HARELINE_EVENTS_TAG, "max")` call at
+// Mock next/cache so the `revalidateTag(HARELINE_EVENTS_TAG)` call at
 // the tail of the happy-path scrape doesn't throw outside a request context.
 vi.mock("next/cache", () => ({
   revalidateTag: vi.fn(),

--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -40,6 +40,14 @@ vi.mock("./health", () => ({
     alerts: [],
   })),
   persistAlerts: vi.fn(() => Promise.resolve()),
+  autoResolveCleared: vi.fn(() => Promise.resolve(0)),
+}));
+
+// Mock next/cache so the `revalidateTag(HARELINE_EVENTS_TAG, "max")` call at
+// the tail of the happy-path scrape doesn't throw outside a request context.
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+  unstable_cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
 }));
 
 import { prisma } from "@/lib/db";

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -16,7 +16,7 @@ import { after } from "next/server";
 import { revalidateTag } from "next/cache";
 import { pingIndexNow } from "@/lib/indexnow";
 import { getCanonicalSiteUrl } from "@/lib/site-url";
-import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
+import { HARELINE_EVENTS_TAG } from "@/lib/cache-tags";
 
 /** Result returned by `scrapeSource()` summarizing the full scrape-merge-reconcile cycle. */
 export interface ScrapeSourceResult {
@@ -499,14 +499,10 @@ export async function scrapeSource(
     // from Postgres. Conditional on something actually changing: a scrape
     // that found zero new/updated/cancelled events has no effect on what
     // /hareline would display, so there's no reason to burn a warm cache.
-    // Single tag — all (mode, date, regionsKey) entries are invalidated at
-    // once. Cheap because the cache is small and naturally re-warms on the
-    // next visit.
+    // Single tag — all (mode, date) entries are invalidated at once. Cheap
+    // because the cache is small and naturally re-warms on the next visit.
     if (mergeResult.created + mergeResult.updated + cancelledCount + mergeResult.restored > 0) {
-      // `"max"` profile = immediate expiration (purge now). Next 16 made the
-      // second arg required — scrapeSource runs in route handlers, not
-      // server actions, so we can't use `updateTag` here.
-      revalidateTag(HARELINE_EVENTS_TAG, "max");
+      revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
     }
 
     return {

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -13,8 +13,10 @@ import { verifyResolvedAutoFixes } from "./verify-fixes";
 import { attemptAiRecovery, isAiRecoveryAvailable } from "@/lib/ai/parse-recovery";
 import { validateSourceUrl } from "@/adapters/utils";
 import { after } from "next/server";
+import { revalidateTag } from "next/cache";
 import { pingIndexNow } from "@/lib/indexnow";
 import { getCanonicalSiteUrl } from "@/lib/site-url";
+import { HARELINE_EVENTS_TAG } from "@/app/hareline/actions";
 
 /** Result returned by `scrapeSource()` summarizing the full scrape-merge-reconcile cycle. */
 export interface ScrapeSourceResult {
@@ -491,6 +493,20 @@ export async function scrapeSource(
       const baseUrl = getCanonicalSiteUrl();
       const urls = mergeResult.createdEventIds.map((id) => `${baseUrl}/hareline/${id}`);
       after(() => pingIndexNow(urls));
+    }
+
+    // Bust the Hareline `unstable_cache` entries so the next request re-pulls
+    // from Postgres. Conditional on something actually changing: a scrape
+    // that found zero new/updated/cancelled events has no effect on what
+    // /hareline would display, so there's no reason to burn a warm cache.
+    // Single tag — all (mode, date, regionsKey) entries are invalidated at
+    // once. Cheap because the cache is small and naturally re-warms on the
+    // next visit.
+    if (mergeResult.created + mergeResult.updated + cancelledCount + mergeResult.restored > 0) {
+      // `"max"` profile = immediate expiration (purge now). Next 16 made the
+      // second arg required — scrapeSource runs in route handlers, not
+      // server actions, so we can't use `updateTag` here.
+      revalidateTag(HARELINE_EVENTS_TAG, "max");
     }
 
     return {


### PR DESCRIPTION
## Summary

- Wrap the slim `/hareline` event list query with `unstable_cache` so anonymous traffic is served from the function's in-region cache instead of hitting Railway on every request.
- Cache key is `(mode, YYYY-MM-DD UTC date)` — rotates at UTC midnight naturally, no live timer.
- `revalidateTag(HARELINE_EVENTS_TAG, "max")` on every mutation that can change what appears on the Hareline page:
  - `scrapeSource()` after merge + reconcile, gated on non-zero delta
  - Admin event mutations (delete, bulk delete, uncancel, backfill city)
  - Admin kennel mutations (update, delete, merge, toggleVisibility) — cache stores denormalized kennel fields per event
  - Admin region mutations (rename, merge, reassign kennels) — `kennel.region` is denormalized
- `revalidate: 3600` fallback for the "scrape silently failed to invalidate" edge case.

## What got dropped

Phase 2b (server-side region scoping for `?regions=` deep links) was explored and reverted after adversarial review surfaced two separate failure modes:

1. **Client/server scope divergence.** `HarelineView.syncUrl()` uses `history.replaceState` for region-chip changes, so Next.js never re-runs the server component. A user who lands on `?regions=state:CA` and then widens their selection would stay frozen on the CA-scoped subset — the client can only filter that subset further, never fetch newly eligible events.
2. **Seed-vs-DB drift.** `expandRegionSelections()` uses `REGION_SEED_DATA` for state/country → metro expansion. Admins create, rename, and reassign regions at runtime via `src/app/admin/regions/actions.ts`, so the seed snapshot misses live metros. `state:CA` deep links would underfetch whenever a California metro was admin-created.

The primary Phase 2 win (cache hits on the DB query + freshness via tag invalidation) is preserved. The dropped optimization was just a share-link payload shrink — modest gain, not worth the correctness risk.

## Correctness

- `dateUtc` serializes to ISO string inside the cache (JSON-safe) and rehydrates to `Date` at the `loadEventsForTimeMode` boundary so consumers (`HarelineView`, `EventCard`, detail panel) see a stable `HarelineListEvent` shape.
- Invalidation coverage expanded beyond the two sites Codex flagged (`toggleKennelVisibility`, `updateKennel`) to include every mutation that touches denormalized fields in the cache: `deleteKennel`, `mergeKennels`, `updateRegionWithRename`, `mergeRegions`, `reassignKennels`.
- `scrape.ts` tag-bust is gated on `created + updated + cancelled + restored > 0` — avoids burning the cache on no-op scrapes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (13 pre-existing warnings in unrelated `travel/*` files)
- [x] `npm test` — 214/214 test files, 5101/5101 tests pass
- [ ] Manual: anonymous `/hareline` — second request noticeably faster than first
- [ ] Manual: trigger a scrape via admin → reload `/hareline` — newly scraped events visible
- [ ] Manual: delete an event via `/admin/events` → `/hareline` drops it immediately
- [ ] Manual: hide a kennel via `/admin/kennels` → its events disappear from `/hareline` without a 1-hour lag
- [ ] Post-deploy: Vercel Speed Insights p50 TTFB drop on `/hareline` for anonymous traffic after cache warm-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)