### PR TITLE
feat(bmh3): backfill historical runs #1-#423 from Blogger archive

### DIFF
--- a/scripts/backfill-bmh3-history.ts
+++ b/scripts/backfill-bmh3-history.ts
@@ -38,7 +38,6 @@ const KENNEL_TIMEZONE = "America/Chicago";
 const BLOGGER_API_BASE = "https://www.googleapis.com/blogger/v3";
 const PAGE_SIZE = 100;
 const FETCH_TIMEOUT_MS = 30_000;
-const BLOG_ID_RE = /^\d+$/;
 
 interface PostsPage {
   items?: BloggerPost[];
@@ -97,12 +96,15 @@ async function discoverBlogId(apiKey: string): Promise<string> {
   );
   if (!res.ok) throw new Error(`Blogger byurl failed: HTTP ${res.status}`);
   const data = (await res.json()) as { id?: string };
-  // Validate to neutralize SSRF: the ID is interpolated into a URL path on
-  // subsequent calls, so reject anything that isn't a numeric Blogger ID.
-  if (!data.id || !BLOG_ID_RE.test(data.id)) {
+  // Sanitize before interpolating into downstream Blogger API paths: parse
+  // strictly as a positive integer; the round-trip equality check rejects
+  // leading zeros, whitespace, and trailing junk that parseInt would accept.
+  if (!data.id) throw new Error("Blogger byurl returned no blog ID");
+  const numericId = Number.parseInt(data.id, 10);
+  if (!Number.isFinite(numericId) || numericId <= 0 || String(numericId) !== data.id) {
     throw new Error("Blogger byurl returned an invalid blog ID");
   }
-  return data.id;
+  return String(numericId);
 }
 
 // Broader than the live adapter regex: tolerates "BRASS MONKEY H3 RUN # 118"

--- a/scripts/backfill-bmh3-history.ts
+++ b/scripts/backfill-bmh3-history.ts
@@ -1,0 +1,290 @@
+/**
+ * One-shot historical backfill for Brass Monkey H3 (BMH3, Houston).
+ *
+ * The live BrassMonkeyAdapter uses the Blogger API but honors
+ * source.scrapeDays (default 180), so runs older than ~6 months are dropped
+ * before they reach RawEvents. The blog has ~453 posts going back to the
+ * kennel's founding in Feb 2010 — this script paginates through the full
+ * archive, parses each trail post via the adapter's exported helpers, and
+ * inserts past-dated RawEvents.
+ *
+ * Partition: live adapter owns `date >= CURDATE()` (via scrapeDays window),
+ * this script owns `date < CURDATE()`. `insertRawEventsForSource`
+ * fingerprint-dedupes, so the script is safely re-runnable.
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-bmh3-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-bmh3-history.ts
+ *   Env:       GOOGLE_CALENDAR_API_KEY (required, same as live adapter)
+ */
+
+import "dotenv/config";
+import { insertRawEventsForSource } from "./lib/backfill-runner";
+import { parseBrassMonkeyBody } from "@/adapters/html-scraper/brass-monkey";
+import {
+  chronoParseDate,
+  decodeEntities,
+  googleMapsSearchUrl,
+  isPlaceholder,
+  parse12HourTime,
+  stripHtmlTags,
+} from "@/adapters/utils";
+import { todayInTimezone } from "@/lib/timezone";
+import type { RawEventData } from "@/adapters/types";
+import type { BloggerPost } from "@/adapters/blogger-api";
+
+const SOURCE_NAME = "Brass Monkey H3 Blog";
+const BLOG_URL = "https://teambrassmonkey.blogspot.com/";
+const KENNEL_TIMEZONE = "America/Chicago";
+const BLOGGER_API_BASE = "https://www.googleapis.com/blogger/v3";
+const PAGE_SIZE = 100;
+
+interface PostsPage {
+  items?: BloggerPost[];
+  nextPageToken?: string;
+}
+
+async function fetchAllPosts(blogId: string, apiKey: string): Promise<BloggerPost[]> {
+  const all: BloggerPost[] = [];
+  let pageToken: string | undefined;
+  let page = 0;
+  const seenTokens = new Set<string>();
+
+  do {
+    const params = new URLSearchParams({
+      maxResults: String(PAGE_SIZE),
+      fetchBodies: "true",
+      fields: "nextPageToken,items(title,content,url,published)",
+    });
+    if (pageToken) params.set("pageToken", pageToken);
+
+    const res = await fetch(`${BLOGGER_API_BASE}/blogs/${blogId}/posts?${params.toString()}`, {
+      headers: { "X-Goog-Api-Key": apiKey },
+    });
+    if (!res.ok) {
+      throw new Error(`Blogger posts fetch failed (page ${page + 1}): HTTP ${res.status}`);
+    }
+    const data = (await res.json()) as PostsPage;
+    const items = data.items ?? [];
+    all.push(...items);
+    page++;
+    console.log(`  Page ${page}: +${items.length} posts (running total: ${all.length})`);
+    const nextToken = data.nextPageToken;
+    if (nextToken && seenTokens.has(nextToken)) {
+      throw new Error(`Blogger pagination returned a repeated pageToken at page ${page}`);
+    }
+    if (nextToken) seenTokens.add(nextToken);
+    pageToken = nextToken;
+  } while (pageToken);
+
+  return all;
+}
+
+async function discoverBlogId(apiKey: string): Promise<string> {
+  const params = new URLSearchParams({ url: BLOG_URL });
+  const res = await fetch(`${BLOGGER_API_BASE}/blogs/byurl?${params.toString()}`, {
+    headers: { "X-Goog-Api-Key": apiKey },
+  });
+  if (!res.ok) throw new Error(`Blogger byurl failed: HTTP ${res.status}`);
+  const data = (await res.json()) as { id?: string };
+  if (!data.id) throw new Error("Blogger byurl returned no blog ID");
+  return data.id;
+}
+
+// Broader than the live adapter regex: tolerates "BRASS MONKEY H3 RUN # 118"
+// and "BMH3 R*N # 181" formats used in 2010–2019. Requires a BMH3/Brass Monkey
+// marker AND a #NNN token within 80 chars to avoid false positives from
+// non-trail posts (e.g. "we need hares in May and beyond").
+const TRAIL_TITLE_RE = /(?:\bbrass\s+monkey\b|\bbmh3\b)[^#]{0,80}#\s*(\d+)\b/i;
+const NUMERIC_DATE_IN_TITLE_RE = /(\d{1,2}\/\d{1,2}\/\d{2,4})/;
+// Meta-posts that reference a run # but aren't the trail announcement itself
+// (e.g. travel itinerary for the kennel's founding run). Kept narrow — words
+// like "photos"/"recap"/"video" can appear inside legitimate trail titles, so
+// we only match tokens that specifically indicate a supplementary post.
+const META_POST_TITLE_RE = /^(?:itinerary\b|.*\bitinerary\s+for\b)/i;
+
+function parseBackfillTitle(rawTitle: string): {
+  runNumber?: number;
+  title?: string;
+  date?: string;
+} {
+  const title = rawTitle.trim();
+  if (META_POST_TITLE_RE.test(title)) return {};
+  const runMatch = TRAIL_TITLE_RE.exec(title);
+  if (!runMatch) return {};
+  const runNumber = parseInt(runMatch[1], 10);
+
+  // Everything after the "#NNN" token — that's the trail name / date.
+  const tailStart = runMatch.index + runMatch[0].length;
+  const tail = title.slice(tailStart);
+
+  // Extract numeric date if present (new-style posts embed it).
+  const dateMatch = NUMERIC_DATE_IN_TITLE_RE.exec(tail);
+  const date = dateMatch ? chronoParseDate(dateMatch[1], "en-US") : undefined;
+
+  let cleaned = tail;
+  if (dateMatch && date) cleaned = cleaned.replace(dateMatch[0], "");
+  cleaned = cleaned.replace(/^[\s:–—-]+|[\s:–—-]+$/g, "").trim();
+
+  return {
+    runNumber,
+    title: cleaned || undefined,
+    date: date ?? undefined,
+  };
+}
+
+// Old-format body fields (2010–2016 posts). Labels are space-separated:
+//   "When : Saturday, August 16th, at 4:00pm!"
+//   "Where : Backwoods Saloon 230 Lexington Conroe, TX 77385"
+//   "Hares : Mighty Mighty Small Mouth & EZ Chair"
+// Year is often omitted — resolved via chrono with publish-date as reference.
+const WHEN_LABEL_RE = /When\s*:\s*(.+?)(?=\n|Where\s*:|Hares?\s*:|$)/i;
+const WHERE_LABEL_RE = /Where\s*:\s*(.+?)(?=\n|Hares?\s*:|Why\s*:|Bring\s*:|$)/i;
+
+// Trail dates should fall within ~6 months of publish (typical lead time is a
+// few weeks, but occasional anniversary/roadtrip announcements post earlier).
+// Dates further than this are almost certainly typo years in stale boilerplate.
+const PLAUSIBLE_MIN_DAYS = -30;
+const PLAUSIBLE_MAX_DAYS = 180;
+
+function withinPlausibleWindow(parsedDate: string, publishDate: Date): boolean {
+  const publishMs = publishDate.getTime();
+  const parsedMs = new Date(`${parsedDate}T12:00:00Z`).getTime();
+  const diffDays = (parsedMs - publishMs) / 86_400_000;
+  return diffDays >= PLAUSIBLE_MIN_DAYS && diffDays <= PLAUSIBLE_MAX_DAYS;
+}
+
+/**
+ * Parse a date string that may contain a stale boilerplate year.
+ *
+ * Old BMH3 posts sometimes left a stale year in place (e.g. "Saturday January
+ * 8th, 2010" on a run published 2011-01-05 for a Jan 8 2011 trail). First
+ * trust any explicit year; if the resulting date falls outside the plausible
+ * publish-to-trail window, re-parse with the year stripped so chrono infers
+ * from the publish date. Returns undefined if neither parse is plausible.
+ */
+function parseFallbackDate(whenText: string, publishDate: Date): string | undefined {
+  const parsed = chronoParseDate(whenText, "en-US", publishDate);
+  if (parsed && withinPlausibleWindow(parsed, publishDate)) return parsed;
+  const stripped = whenText.replace(/,?\s*\b(19|20)\d{2}\b/g, "").trim();
+  if (!stripped) return undefined;
+  const reparsed = chronoParseDate(stripped, "en-US", publishDate);
+  if (reparsed && withinPlausibleWindow(reparsed, publishDate)) return reparsed;
+  return undefined;
+}
+
+function parseBackfillBody(
+  bodyText: string,
+  publishedIso: string,
+): { date?: string; startTime?: string; location?: string; hares?: string } {
+  const strict = parseBrassMonkeyBody(bodyText);
+  if (strict.date && strict.location && strict.hares) return strict;
+
+  const whenMatch = WHEN_LABEL_RE.exec(bodyText);
+  const whenText = whenMatch ? whenMatch[1].trim() : "";
+  const publishDate = new Date(publishedIso);
+  const date = strict.date ?? (whenText ? parseFallbackDate(whenText, publishDate) : undefined);
+
+  const whereMatch = WHERE_LABEL_RE.exec(bodyText);
+  const location = strict.location ?? (whereMatch ? whereMatch[1].trim() : undefined);
+
+  const startTime = strict.startTime ?? (whenText ? parse12HourTime(whenText) : undefined);
+
+  return { date, startTime, location, hares: strict.hares };
+}
+
+type SkipReason = "no-run-number" | "no-date";
+
+function postToRawEvent(post: BloggerPost): RawEventData | SkipReason {
+  const titleFields = parseBackfillTitle(decodeEntities(post.title));
+  if (titleFields.runNumber == null) return "no-run-number";
+
+  const bodyText = stripHtmlTags(post.content, "\n");
+  const bodyFields = parseBackfillBody(bodyText, post.published);
+
+  // Title MM/DD/YYYY is explicit and authoritative; body dates can be freeform
+  // prose with stale boilerplate years.
+  const date = titleFields.date ?? bodyFields.date;
+  if (!date) return "no-date";
+
+  const location = bodyFields.location && !isPlaceholder(bodyFields.location)
+    ? bodyFields.location
+    : undefined;
+
+  return {
+    date,
+    kennelTag: "bmh3-tx",
+    runNumber: titleFields.runNumber,
+    title: titleFields.title,
+    hares: bodyFields.hares,
+    location,
+    locationUrl: location ? googleMapsSearchUrl(location) : undefined,
+    startTime: bodyFields.startTime,
+    sourceUrl: post.url,
+  };
+}
+
+async function main() {
+  const apply = process.env.BACKFILL_APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
+
+  const apiKey = process.env.GOOGLE_CALENDAR_API_KEY;
+  if (!apiKey) throw new Error("Missing GOOGLE_CALENDAR_API_KEY");
+
+  console.log("\n[1/3] Discovering blog ID + fetching all posts...");
+  const blogId = await discoverBlogId(apiKey);
+  console.log(`  Blog ID: ${blogId}`);
+  const posts = await fetchAllPosts(blogId, apiKey);
+  console.log(`  Fetched ${posts.length} total posts`);
+
+  console.log("\n[2/3] Parsing posts into RawEvents...");
+  const parsed: RawEventData[] = [];
+  let skippedNoRun = 0;
+  let skippedNoDate = 0;
+  for (const post of posts) {
+    const result = postToRawEvent(post);
+    if (result === "no-run-number") skippedNoRun++;
+    else if (result === "no-date") skippedNoDate++;
+    else parsed.push(result);
+  }
+  console.log(`  Parsed: ${parsed.length}. Skipped: ${skippedNoRun} no-run-number, ${skippedNoDate} no-date.`);
+
+  const today = todayInTimezone(KENNEL_TIMEZONE);
+  const past = parsed.filter((e) => e.date < today);
+  const futureOrToday = parsed.length - past.length;
+  console.log(`  Partition: ${past.length} past rows, ${futureOrToday} skipped (date >= ${today})`);
+
+  const sorted = [...past].sort((a, b) => a.date.localeCompare(b.date));
+  if (sorted.length > 0) {
+    console.log(`\nDate range: ${sorted[0].date} → ${sorted[sorted.length - 1].date}`);
+    const sampleIdx = [0, Math.floor(sorted.length / 2), sorted.length - 1];
+    console.log("Samples (oldest, middle, newest):");
+    for (const i of sampleIdx) {
+      const e = sorted[i];
+      console.log(
+        `  #${e.runNumber ?? "?"} ${e.date} | title=${e.title ?? "—"} | hares=${e.hares ?? "—"} | loc=${e.location ?? "—"} | start=${e.startTime ?? "—"}`,
+      );
+    }
+  }
+
+  if (!apply) {
+    console.log("\n[3/3] Dry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
+    return;
+  }
+  if (past.length === 0) {
+    console.log("\nNo events to insert. Exiting.");
+    return;
+  }
+
+  console.log("\n[3/3] Writing to DB...");
+  const { preExisting, inserted } = await insertRawEventsForSource(SOURCE_NAME, past);
+  console.log(`  Pre-existing: ${preExisting}. Inserted: ${inserted}.`);
+  if (inserted > 0) {
+    console.log(`\nDone. Trigger a scrape of "${SOURCE_NAME}" from the admin UI to merge the new RawEvents.`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-bmh3-history.ts
+++ b/scripts/backfill-bmh3-history.ts
@@ -36,6 +36,7 @@ const SOURCE_NAME = "Brass Monkey H3 Blog";
 const BLOG_URL = "https://teambrassmonkey.blogspot.com/";
 const KENNEL_TIMEZONE = "America/Chicago";
 const BLOGGER_API_BASE = "https://www.googleapis.com/blogger/v3";
+const BLOGGER_API_ORIGIN = "https://www.googleapis.com";
 const PAGE_SIZE = 100;
 const FETCH_TIMEOUT_MS = 30_000;
 
@@ -44,7 +45,20 @@ interface PostsPage {
   nextPageToken?: string;
 }
 
-async function fetchWithTimeout(url: string, apiKey: string): Promise<Response> {
+/**
+ * Build + fetch a Blogger API URL, asserting the resolved origin matches the
+ * trusted host. The origin check defeats SSRF even if a downstream value
+ * (e.g. blogId) somehow smuggles a host change through URL parsing.
+ */
+async function fetchBloggerEndpoint(
+  path: string,
+  params: URLSearchParams,
+  apiKey: string,
+): Promise<Response> {
+  const url = new URL(`${BLOGGER_API_BASE}/${path}?${params.toString()}`);
+  if (url.origin !== BLOGGER_API_ORIGIN) {
+    throw new Error(`Refusing to fetch non-Blogger origin: ${url.origin}`);
+  }
   return fetch(url, {
     headers: { "X-Goog-Api-Key": apiKey },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -65,8 +79,9 @@ async function fetchAllPosts(blogId: string, apiKey: string): Promise<BloggerPos
     });
     if (pageToken) params.set("pageToken", pageToken);
 
-    const res = await fetchWithTimeout(
-      `${BLOGGER_API_BASE}/blogs/${blogId}/posts?${params.toString()}`,
+    const res = await fetchBloggerEndpoint(
+      `blogs/${blogId}/posts`,
+      params,
       apiKey,
     );
     if (!res.ok) {
@@ -76,7 +91,7 @@ async function fetchAllPosts(blogId: string, apiKey: string): Promise<BloggerPos
     const items = data.items ?? [];
     all.push(...items);
     page++;
-    console.log(`  Page ${page}: +${items.length} posts (total: ${all.length})`);
+    console.log(`  Page ${page} fetched`);
     const nextToken = data.nextPageToken;
     if (nextToken && seenTokens.has(nextToken)) {
       throw new Error(`Blogger pagination returned a repeated pageToken at page ${page}`);
@@ -90,10 +105,7 @@ async function fetchAllPosts(blogId: string, apiKey: string): Promise<BloggerPos
 
 async function discoverBlogId(apiKey: string): Promise<string> {
   const params = new URLSearchParams({ url: BLOG_URL });
-  const res = await fetchWithTimeout(
-    `${BLOGGER_API_BASE}/blogs/byurl?${params.toString()}`,
-    apiKey,
-  );
+  const res = await fetchBloggerEndpoint("blogs/byurl", params, apiKey);
   if (!res.ok) throw new Error(`Blogger byurl failed: HTTP ${res.status}`);
   const data = (await res.json()) as { id?: string };
   // Sanitize before interpolating into downstream Blogger API paths: parse

--- a/scripts/backfill-bmh3-history.ts
+++ b/scripts/backfill-bmh3-history.ts
@@ -19,7 +19,7 @@
  */
 
 import "dotenv/config";
-import { insertRawEventsForSource } from "./lib/backfill-runner";
+import { reportAndApplyBackfill } from "./lib/backfill-runner";
 import { parseBrassMonkeyBody } from "@/adapters/html-scraper/brass-monkey";
 import {
   chronoParseDate,
@@ -29,7 +29,6 @@ import {
   parse12HourTime,
   stripHtmlTags,
 } from "@/adapters/utils";
-import { todayInTimezone } from "@/lib/timezone";
 import type { RawEventData } from "@/adapters/types";
 import type { BloggerPost } from "@/adapters/blogger-api";
 
@@ -38,10 +37,19 @@ const BLOG_URL = "https://teambrassmonkey.blogspot.com/";
 const KENNEL_TIMEZONE = "America/Chicago";
 const BLOGGER_API_BASE = "https://www.googleapis.com/blogger/v3";
 const PAGE_SIZE = 100;
+const FETCH_TIMEOUT_MS = 30_000;
+const BLOG_ID_RE = /^\d+$/;
 
 interface PostsPage {
   items?: BloggerPost[];
   nextPageToken?: string;
+}
+
+async function fetchWithTimeout(url: string, apiKey: string): Promise<Response> {
+  return fetch(url, {
+    headers: { "X-Goog-Api-Key": apiKey },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
 }
 
 async function fetchAllPosts(blogId: string, apiKey: string): Promise<BloggerPost[]> {
@@ -58,9 +66,10 @@ async function fetchAllPosts(blogId: string, apiKey: string): Promise<BloggerPos
     });
     if (pageToken) params.set("pageToken", pageToken);
 
-    const res = await fetch(`${BLOGGER_API_BASE}/blogs/${blogId}/posts?${params.toString()}`, {
-      headers: { "X-Goog-Api-Key": apiKey },
-    });
+    const res = await fetchWithTimeout(
+      `${BLOGGER_API_BASE}/blogs/${blogId}/posts?${params.toString()}`,
+      apiKey,
+    );
     if (!res.ok) {
       throw new Error(`Blogger posts fetch failed (page ${page + 1}): HTTP ${res.status}`);
     }
@@ -68,7 +77,7 @@ async function fetchAllPosts(blogId: string, apiKey: string): Promise<BloggerPos
     const items = data.items ?? [];
     all.push(...items);
     page++;
-    console.log(`  Page ${page}: +${items.length} posts (running total: ${all.length})`);
+    console.log(`  Page ${page}: +${items.length} posts (total: ${all.length})`);
     const nextToken = data.nextPageToken;
     if (nextToken && seenTokens.has(nextToken)) {
       throw new Error(`Blogger pagination returned a repeated pageToken at page ${page}`);
@@ -82,12 +91,17 @@ async function fetchAllPosts(blogId: string, apiKey: string): Promise<BloggerPos
 
 async function discoverBlogId(apiKey: string): Promise<string> {
   const params = new URLSearchParams({ url: BLOG_URL });
-  const res = await fetch(`${BLOGGER_API_BASE}/blogs/byurl?${params.toString()}`, {
-    headers: { "X-Goog-Api-Key": apiKey },
-  });
+  const res = await fetchWithTimeout(
+    `${BLOGGER_API_BASE}/blogs/byurl?${params.toString()}`,
+    apiKey,
+  );
   if (!res.ok) throw new Error(`Blogger byurl failed: HTTP ${res.status}`);
   const data = (await res.json()) as { id?: string };
-  if (!data.id) throw new Error("Blogger byurl returned no blog ID");
+  // Validate to neutralize SSRF: the ID is interpolated into a URL path on
+  // subsequent calls, so reject anything that isn't a numeric Blogger ID.
+  if (!data.id || !BLOG_ID_RE.test(data.id)) {
+    throw new Error("Blogger byurl returned an invalid blog ID");
+  }
   return data.id;
 }
 
@@ -112,7 +126,7 @@ function parseBackfillTitle(rawTitle: string): {
   if (META_POST_TITLE_RE.test(title)) return {};
   const runMatch = TRAIL_TITLE_RE.exec(title);
   if (!runMatch) return {};
-  const runNumber = parseInt(runMatch[1], 10);
+  const runNumber = Number.parseInt(runMatch[1], 10);
 
   // Everything after the "#NNN" token — that's the trail name / date.
   const tailStart = runMatch.index + runMatch[0].length;
@@ -123,8 +137,10 @@ function parseBackfillTitle(rawTitle: string): {
   const date = dateMatch ? chronoParseDate(dateMatch[1], "en-US") : undefined;
 
   let cleaned = tail;
-  if (dateMatch && date) cleaned = cleaned.replace(dateMatch[0], "");
-  cleaned = cleaned.replace(/^[\s:–—-]+|[\s:–—-]+$/g, "").trim();
+  if (dateMatch && date) cleaned = cleaned.replaceAll(dateMatch[0], "");
+  // Strip leading/trailing separators (colons, dashes, em/en dashes, whitespace)
+  // — two anchored passes, no alternation, to avoid super-linear backtracking.
+  cleaned = cleaned.replaceAll(/^[\s:–—-]+/g, "").replaceAll(/[\s:–—-]+$/g, "").trim();
 
   return {
     runNumber,
@@ -133,13 +149,38 @@ function parseBackfillTitle(rawTitle: string): {
   };
 }
 
-// Old-format body fields (2010–2016 posts). Labels are space-separated:
+// Old-format body fields (2010–2016 posts). Labels typically appear on their
+// own lines with the value either on the same line or the following line:
 //   "When : Saturday, August 16th, at 4:00pm!"
 //   "Where : Backwoods Saloon 230 Lexington Conroe, TX 77385"
 //   "Hares : Mighty Mighty Small Mouth & EZ Chair"
 // Year is often omitted — resolved via chrono with publish-date as reference.
-const WHEN_LABEL_RE = /When\s*:\s*(.+?)(?=\n|Where\s*:|Hares?\s*:|$)/i;
-const WHERE_LABEL_RE = /Where\s*:\s*(.+?)(?=\n|Hares?\s*:|Why\s*:|Bring\s*:|$)/i;
+const LABEL_LINE_RE = /^\s*([A-Za-z]+)\s*:\s?(.*)$/;
+
+/**
+ * Find a labelled value in a body split into lines. The value may share the
+ * label's line, or span the next non-empty line(s) until the next label.
+ * Linear scan, no super-linear regex backtracking.
+ */
+function findLabelValue(bodyLines: string[], label: RegExp): string | undefined {
+  for (let i = 0; i < bodyLines.length; i++) {
+    const m = LABEL_LINE_RE.exec(bodyLines[i]);
+    if (!m || !label.test(m[1])) continue;
+    const inline = m[2].trim();
+    if (inline) return inline;
+    for (let j = i + 1; j < bodyLines.length; j++) {
+      const next = bodyLines[j].trim();
+      if (!next) continue;
+      if (LABEL_LINE_RE.test(bodyLines[j])) return undefined;
+      return next;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+const WHEN_LABEL = /^when$/i;
+const WHERE_LABEL = /^where$/i;
 
 // Trail dates should fall within ~6 months of publish (typical lead time is a
 // few weeks, but occasional anniversary/roadtrip announcements post earlier).
@@ -166,7 +207,8 @@ function withinPlausibleWindow(parsedDate: string, publishDate: Date): boolean {
 function parseFallbackDate(whenText: string, publishDate: Date): string | undefined {
   const parsed = chronoParseDate(whenText, "en-US", publishDate);
   if (parsed && withinPlausibleWindow(parsed, publishDate)) return parsed;
-  const stripped = whenText.replace(/,?\s*\b(19|20)\d{2}\b/g, "").trim();
+  // Bound `\s*` to avoid super-linear backtracking on pathological whitespace.
+  const stripped = whenText.replaceAll(/,?\s{0,4}\b(?:19|20)\d{2}\b/g, "").trim();
   if (!stripped) return undefined;
   const reparsed = chronoParseDate(stripped, "en-US", publishDate);
   if (reparsed && withinPlausibleWindow(reparsed, publishDate)) return reparsed;
@@ -180,13 +222,12 @@ function parseBackfillBody(
   const strict = parseBrassMonkeyBody(bodyText);
   if (strict.date && strict.location && strict.hares) return strict;
 
-  const whenMatch = WHEN_LABEL_RE.exec(bodyText);
-  const whenText = whenMatch ? whenMatch[1].trim() : "";
+  const lines = bodyText.split("\n");
+  const whenText = findLabelValue(lines, WHEN_LABEL) ?? "";
   const publishDate = new Date(publishedIso);
   const date = strict.date ?? (whenText ? parseFallbackDate(whenText, publishDate) : undefined);
 
-  const whereMatch = WHERE_LABEL_RE.exec(bodyText);
-  const location = strict.location ?? (whereMatch ? whereMatch[1].trim() : undefined);
+  const location = strict.location ?? findLabelValue(lines, WHERE_LABEL);
 
   const startTime = strict.startTime ?? (whenText ? parse12HourTime(whenText) : undefined);
 
@@ -233,7 +274,6 @@ async function main() {
 
   console.log("\n[1/3] Discovering blog ID + fetching all posts...");
   const blogId = await discoverBlogId(apiKey);
-  console.log(`  Blog ID: ${blogId}`);
   const posts = await fetchAllPosts(blogId, apiKey);
   console.log(`  Fetched ${posts.length} total posts`);
 
@@ -249,39 +289,13 @@ async function main() {
   }
   console.log(`  Parsed: ${parsed.length}. Skipped: ${skippedNoRun} no-run-number, ${skippedNoDate} no-date.`);
 
-  const today = todayInTimezone(KENNEL_TIMEZONE);
-  const past = parsed.filter((e) => e.date < today);
-  const futureOrToday = parsed.length - past.length;
-  console.log(`  Partition: ${past.length} past rows, ${futureOrToday} skipped (date >= ${today})`);
-
-  const sorted = [...past].sort((a, b) => a.date.localeCompare(b.date));
-  if (sorted.length > 0) {
-    console.log(`\nDate range: ${sorted[0].date} → ${sorted[sorted.length - 1].date}`);
-    const sampleIdx = [0, Math.floor(sorted.length / 2), sorted.length - 1];
-    console.log("Samples (oldest, middle, newest):");
-    for (const i of sampleIdx) {
-      const e = sorted[i];
-      console.log(
-        `  #${e.runNumber ?? "?"} ${e.date} | title=${e.title ?? "—"} | hares=${e.hares ?? "—"} | loc=${e.location ?? "—"} | start=${e.startTime ?? "—"}`,
-      );
-    }
-  }
-
-  if (!apply) {
-    console.log("\n[3/3] Dry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
-    return;
-  }
-  if (past.length === 0) {
-    console.log("\nNo events to insert. Exiting.");
-    return;
-  }
-
-  console.log("\n[3/3] Writing to DB...");
-  const { preExisting, inserted } = await insertRawEventsForSource(SOURCE_NAME, past);
-  console.log(`  Pre-existing: ${preExisting}. Inserted: ${inserted}.`);
-  if (inserted > 0) {
-    console.log(`\nDone. Trigger a scrape of "${SOURCE_NAME}" from the admin UI to merge the new RawEvents.`);
-  }
+  console.log("\n[3/3] Reporting + applying...");
+  await reportAndApplyBackfill({
+    apply,
+    sourceName: SOURCE_NAME,
+    events: parsed,
+    kennelTimezone: KENNEL_TIMEZONE,
+  });
 }
 
 main().catch((err) => {

--- a/scripts/backfill-bssh3-ko-samet.ts
+++ b/scripts/backfill-bssh3-ko-samet.ts
@@ -12,18 +12,13 @@
  * `kennelTag`, not source identity. The Meetup adapter scrapes 90 days
  * forward only, so it cannot race these past rows.
  *
- * Partition (per `.claude/rules/adapter-patterns.md`):
- *   - Adapter handles dates >= CURDATE()
- *   - This script handles dates < CURDATE() (these events are May 2025)
- * Always re-runnable: fingerprint-based dedup against existing RawEvents.
- *
  * Usage:
  *   1. Dry run first:  npx tsx scripts/backfill-bssh3-ko-samet.ts
  *   2. Execute:        BACKFILL_APPLY=1 npx tsx scripts/backfill-bssh3-ko-samet.ts
  */
 
 import "dotenv/config";
-import { insertRawEventsForSource } from "./lib/backfill-runner";
+import { reportAndApplyBackfill } from "./lib/backfill-runner";
 import type { RawEventData } from "@/adapters/types";
 
 const KENNEL_CODE = "bssh3";
@@ -61,41 +56,12 @@ async function main() {
   const apply = process.env.BACKFILL_APPLY === "1";
   console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
 
-  // en-CA emits ISO YYYY-MM-DD; compare against RawEventData.date (also ISO).
-  const today = new Intl.DateTimeFormat("en-CA", { timeZone: KENNEL_TIMEZONE }).format(new Date());
-  const allEvents = KO_SAMET_EVENTS.filter((e) => {
-    if (e.date >= today) {
-      console.log(`Skipping ${e.title}: date ${e.date} >= today ${today} (adapter territory)`);
-      return false;
-    }
-    return true;
+  await reportAndApplyBackfill({
+    apply,
+    sourceName: SOURCE_NAME,
+    events: KO_SAMET_EVENTS,
+    kennelTimezone: KENNEL_TIMEZONE,
   });
-
-  console.log(`\nEvents to insert: ${allEvents.length}`);
-  for (const e of allEvents) {
-    console.log(`  #${e.runNumber} ${e.date} | ${e.title} | loc=${e.location} | start=${e.startTime}`);
-  }
-
-  if (!apply) {
-    console.log("\nDry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
-    return;
-  }
-
-  if (allEvents.length === 0) {
-    console.log("No events to insert. Exiting.");
-    return;
-  }
-
-  const { preExisting, inserted } = await insertRawEventsForSource(SOURCE_NAME, allEvents);
-  console.log(`\nPre-existing rows: ${preExisting}. New rows to insert: ${inserted}.`);
-
-  if (inserted === 0) {
-    console.log("Nothing new to insert. Exiting.");
-    return;
-  }
-
-  console.log(`\nDone. Inserted ${inserted} new RawEvents for source "${SOURCE_NAME}".`);
-  console.log("Trigger a scrape of this source from the admin UI to merge the new RawEvents into canonical Events.");
 }
 
 main().catch((err) => {

--- a/scripts/lib/backfill-runner.ts
+++ b/scripts/lib/backfill-runner.ts
@@ -2,11 +2,67 @@ import { PrismaClient, type Prisma } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { createScriptPool } from "./db-pool";
 import { generateFingerprint } from "@/pipeline/fingerprint";
+import { todayInTimezone } from "@/lib/timezone";
 import type { RawEventData } from "@/adapters/types";
 
 export interface InsertRawEventsResult {
   preExisting: number;
   inserted: number;
+}
+
+export interface BackfillReportOptions {
+  apply: boolean;
+  sourceName: string;
+  events: RawEventData[];
+  kennelTimezone: string;
+}
+
+/**
+ * Shared report + apply phase for one-shot backfill scripts. Splits parsed
+ * events into past (date < today-in-kennel-timezone) and skipped, prints a
+ * partition summary plus three sample rows, and either short-circuits in dry
+ * run mode or hands the past slice off to `insertRawEventsForSource`.
+ *
+ * Centralised here because every backfill repeats the same partition/report/
+ * apply block verbatim, which trips SonarCloud's duplication gate.
+ */
+export async function reportAndApplyBackfill(
+  options: BackfillReportOptions,
+): Promise<void> {
+  const { apply, sourceName, events, kennelTimezone } = options;
+  const today = todayInTimezone(kennelTimezone);
+  const past = events.filter((e) => e.date < today);
+  const skipped = events.length - past.length;
+  console.log(`  Partition: ${past.length} past rows, ${skipped} skipped (date >= ${today})`);
+
+  past.sort((a, b) => a.date.localeCompare(b.date));
+  if (past.length > 0) {
+    console.log(`\nDate range: ${past[0].date} → ${past.at(-1)!.date}`);
+    const sampleIdx = [0, Math.floor(past.length / 2), past.length - 1];
+    console.log("Samples (oldest, middle, newest):");
+    for (const i of sampleIdx) {
+      const e = past[i];
+      console.log(
+        `  #${e.runNumber ?? "?"} ${e.date} | title=${e.title ?? "—"} | hares=${e.hares ?? "—"} | loc=${e.location ?? "—"} | start=${e.startTime ?? "—"}`,
+      );
+    }
+  }
+
+  if (!apply) {
+    console.log("\nDry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
+    return;
+  }
+  if (past.length === 0) {
+    console.log("\nNo events to insert. Exiting.");
+    return;
+  }
+
+  console.log("\nWriting to DB...");
+  const { preExisting, inserted } = await insertRawEventsForSource(sourceName, past);
+  console.log(`  Pre-existing: ${preExisting}. Inserted: ${inserted}.`);
+  if (inserted > 0) {
+    console.log(`\nDone. Trigger a scrape of "${sourceName}" from the admin UI to merge the new RawEvents.`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- New one-shot script `scripts/backfill-bmh3-history.ts` paginates the full teambrassmonkey.blogspot.com archive (453 posts, ~16 years) and inserts past-dated RawEvents for Brass Monkey H3 (Houston). The live adapter's 180-day scrape window drops everything older.
- Reuses the adapter's exported `parseBrassMonkeyBody`; adds broader title/body fallbacks for the 2010-2019 "BRASS MONKEY H3 RUN # NNN" format plus a publish-date plausibility window (`-30d..+180d`) that guards against stale boilerplate years chrono would otherwise trust (e.g. #25 body literally says "January 8th, 2010" on a 2011 trail).
- Strict date partition: live adapter owns `date >= CURDATE()` (America/Chicago), script owns `date < CURDATE()`. `insertRawEventsForSource` fingerprint-dedupes, so re-runs are safe.

## Dry-run output

```
Fetched 453 total posts
Parsed: 351. Skipped: 96 no-run-number, 6 no-date.
Partition: 350 past rows, 1 skipped (date >= 2026-04-24)
Date range: 2010-02-06 → 2026-04-11
Samples (oldest, middle, newest):
  #1 2010-02-06 | title=— | hares=— | loc=— | start=—
  #224 2018-08-25 | title=The 2nd Anal Flock You Hash | hares=Dumbsterbaitor | loc=Northwood Pines Park | start=15:00
  #423 2026-04-11 | title=3rd Anal Tax Day trail hared by Ivanna and Indiana | hares=Ivanna Hairy Buttchug | loc=WG Jones State Forest Trail Head | start=14:30
```

96 non-trail posts (travel recaps, hare-call blurbs) correctly skipped via META_POST_TITLE_RE and the "requires #NNN within 80 chars" gate. 6 no-date skips are early posts with no parseable When field.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — no new warnings (13 pre-existing, unrelated)
- [x] Dry run reports 351 parsed / 350 past
- [ ] After merge: run `BACKFILL_APPLY=1 npx tsx scripts/backfill-bmh3-history.ts` against prod Railway DB
- [ ] Trigger merge scrape of "Brass Monkey H3 Blog" from admin UI
- [ ] Verify on hashtracks.com/kennels/bmh3-tx that historical runs appear

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)