### PR TITLE
fix(frankfurt-hash): strip 'Hare: <name>' suffix from FH3 titles (#961)

### DIFF
--- a/src/adapters/html-scraper/frankfurt-hash.test.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.test.ts
@@ -169,6 +169,13 @@ describe("stripHareSuffix (#961)", () => {
     // accidental over-eager regexes if someone tightens the pattern later.
     expect(stripHareSuffix("FH3-Hare: X")).toBe("FH3-Hare: X");
   });
+
+  it("strips trailing ' Hare - <name>' (dash separator, archive form)", () => {
+    // Live FH3 archive title (e.g. "FH3 Run #1639: Hare - Wankula") — the
+    // run-# colon is left intact, only the trailing "Hare - …" is removed.
+    expect(stripHareSuffix("FH3 Run #1639: Hare - Wankula")).toBe("FH3 Run #1639:");
+    expect(stripHareSuffix("FH3 Run #1636: Hare - The Blacks")).toBe("FH3 Run #1636:");
+  });
 });
 
 // ── parseJEMEvent tests ──
@@ -429,6 +436,30 @@ describe("parseJEMEvent", () => {
     expect(event!.runNumber).toBe(2119);
     expect(event!.hares).toBe("Whore Durve");
     expect(event!.kennelTag).toBe("FH3");
+  });
+
+  it("strips ' Hare - <name>' suffix and extracts hares (archive dash form, #961)", () => {
+    // Live FH3 archive entry: "FH3 Run #1639: Hare - Wankula" — both
+    // stripHareSuffix and extractHaresFromText must accept the dash form,
+    // otherwise the title strips but the hare is lost.
+    const html = `<li class="jem-event">
+      <time itemprop="startDate" content="2018-06-15T19:00"></time>
+      <div class="jem-event-title">
+        <h4 title="Title: FH3 Run #1639: Hare - Wankula">
+          <a href="/index.php/coming-runs/event/695:Hare%20-%20Wankula">FH3 Run #1639: Hare - Wankula</a>
+        </h4>
+      </div>
+      <div class="jem-event-venue"><a href="/venues/1">Frankfurt</a></div>
+    </li>`;
+    const $ = cheerio.load(html);
+    const $li = $("li.jem-event").first();
+
+    const event = parseJEMEvent($li, $, compiled, defaultTag, baseUrl);
+
+    expect(event).not.toBeNull();
+    expect(event!.title).toBe("FH3 Run #1639:");
+    expect(event!.runNumber).toBe(1639);
+    expect(event!.hares).toBe("Wankula");
   });
 });
 

--- a/src/adapters/html-scraper/frankfurt-hash.test.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.test.ts
@@ -3,6 +3,7 @@ import type { Source } from "@/generated/prisma/client";
 import {
   parseJEMEvent,
   parseJEMEventList,
+  stripHareSuffix,
   FrankfurtHashAdapter,
 } from "./frankfurt-hash";
 import * as cheerio from "cheerio";
@@ -134,6 +135,41 @@ const ARCHIVE_HTML = `<html><body>
   </li>
 </ul>
 </body></html>`;
+
+// ── stripHareSuffix tests ──
+
+describe("stripHareSuffix (#961)", () => {
+  it("strips trailing ' Hare: <name>' from FH3-style titles", () => {
+    // Live FH3 list-page title (2026-04-25) — hare name appended after run #
+    expect(stripHareSuffix("FH3 Run #2119 Hare: Whore Durve")).toBe("FH3 Run #2119");
+  });
+
+  it("strips trailing ' Hares: <names>' (plural)", () => {
+    expect(stripHareSuffix("FH3 Run #2120 Hares: Foo, Bar")).toBe("FH3 Run #2120");
+  });
+
+  it("is case-insensitive on the Hare(s) keyword", () => {
+    expect(stripHareSuffix("FH3 Run #2121 hare: alice")).toBe("FH3 Run #2121");
+    expect(stripHareSuffix("FH3 Run #2122 HARES: bob")).toBe("FH3 Run #2122");
+  });
+
+  it("passes through titles with no Hare suffix unchanged", () => {
+    expect(stripHareSuffix("Frankfurt Hash House Harriers #2114")).toBe("Frankfurt Hash House Harriers #2114");
+    expect(stripHareSuffix("FM Run 500 Full Moon Edition")).toBe("FM Run 500 Full Moon Edition");
+  });
+
+  it("returns the original title when stripping would empty it (defensive)", () => {
+    // A malformed title that's *only* "Hare: X" should not collapse to "" —
+    // RawEventData.title is required to be present for the merge to succeed.
+    expect(stripHareSuffix("Hare: Solo")).toBe("Hare: Solo");
+  });
+
+  it("does not strip 'Hare' when not preceded by whitespace (no-op safety)", () => {
+    // "FH3-Hare: X" (no whitespace before Hare) should not match. Catches
+    // accidental over-eager regexes if someone tightens the pattern later.
+    expect(stripHareSuffix("FH3-Hare: X")).toBe("FH3-Hare: X");
+  });
+});
 
 // ── parseJEMEvent tests ──
 
@@ -367,6 +403,32 @@ describe("parseJEMEvent", () => {
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-03-29");
     expect(event!.startTime).toBeUndefined();
+  });
+
+  it("strips ' Hare: <name>' suffix from title and still extracts hares from the same <li> (#961)", () => {
+    // Live-page-shaped HTML for FH3 Run #2119: title text contains the hare
+    // name appended after the run number. extractHaresFromText() picks up the
+    // "Hare:" pattern from the same <li> HTML, so stripping the title doesn't
+    // lose the hare.
+    const html = `<li class="jem-event">
+      <time itemprop="startDate" content="2026-04-26T14:30"></time>
+      <div class="jem-event-title">
+        <h4 title="Title: FH3 Run #2119 Hare: Whore Durve">
+          <a href="/index.php/coming-runs/event/1315:fh3-run-2119-hare-whore-durve">FH3 Run #2119 Hare: Whore Durve</a>
+        </h4>
+      </div>
+      <div class="jem-event-venue"><a href="/venues/123">Flörsheim Bahnhof</a></div>
+    </li>`;
+    const $ = cheerio.load(html);
+    const $li = $("li.jem-event").first();
+
+    const event = parseJEMEvent($li, $, compiled, defaultTag, baseUrl);
+
+    expect(event).not.toBeNull();
+    expect(event!.title).toBe("FH3 Run #2119");
+    expect(event!.runNumber).toBe(2119);
+    expect(event!.hares).toBe("Whore Durve");
+    expect(event!.kennelTag).toBe("FH3");
   });
 });
 

--- a/src/adapters/html-scraper/frankfurt-hash.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.ts
@@ -62,7 +62,7 @@ function matchKennelTag(title: string, compiled: [RegExp, string][], defaultTag:
  * See #961.
  */
 export function stripHareSuffix(title: string): string {
-  const stripped = title.replace(/\s+Hares?\s*[:\-]\s*.+$/i, "").trim();
+  const stripped = title.replace(/\s+Hares?\s*[:-]\s*.+$/i, "").trim();
   return stripped || title;
 }
 
@@ -158,8 +158,11 @@ export function extractHaresFromText(text: string): string | undefined {
   const cleaned = looksLikeHtml
     ? stripHtmlTags(text, "\n")
     : decodeEntities(text).trim();
-  // Match "Hares: <names>" or "Hare: <names>" up to newline/sentence/line break or "by".
-  const m = /\bHares?\s*:\s*([^\n.|]+?)(?=\s*(?:[.|\n]|\bby\b|$))/i.exec(cleaned);
+  // Match "Hares: <names>", "Hare: <names>", or "Hare - <names>" up to
+  // newline/sentence/line break or "by". FH3 archive titles use both colon
+  // and dash as the hare separator (e.g. "FH3 Run #1639: Hare - Wankula"),
+  // so we accept either — kept in sync with stripHareSuffix(). See #961.
+  const m = /\bHares?\s*[:-]\s*([^\n.|]+?)(?=\s*(?:[.|\n]|\bby\b|$))/i.exec(cleaned);
   if (!m) return undefined;
   const value = m[1].trim();
   return value || undefined;

--- a/src/adapters/html-scraper/frankfurt-hash.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.ts
@@ -52,6 +52,20 @@ function matchKennelTag(title: string, compiled: [RegExp, string][], defaultTag:
   return defaultTag;
 }
 
+/**
+ * Strip a trailing " Hare(s): <name>" suffix from a title. The Frankfurt
+ * JEM list page appends hare names to event titles (e.g.
+ * "FH3 Run #2119 Hare: Whore Durve"), but the hare name is also extracted
+ * into RawEventData.hares from the same `<li>` HTML — keeping it in the
+ * title is pure duplication. Returns the original title if stripping
+ * would leave nothing (defensive: a malformed bare "Hare: X" passes through).
+ * See #961.
+ */
+export function stripHareSuffix(title: string): string {
+  const stripped = title.replace(/\s+Hares?\s*[:\-]\s*.+$/i, "").trim();
+  return stripped || title;
+}
+
 // ── Exported helpers (for unit testing) ──
 
 /**
@@ -80,8 +94,13 @@ export function parseJEMEvent(
 
   // Extract title from .jem-event-title h4 a
   const titleLink = $li.find(".jem-event-title h4 a").first();
-  const title = decodeEntities(titleLink.text()).trim();
-  if (!title) return null;
+  const rawTitle = decodeEntities(titleLink.text()).trim();
+  if (!rawTitle) return null;
+  // Strip trailing " Hare(s): <name>" — Frankfurt's JEM template appends
+  // hare names to the event title (e.g. "FH3 Run #2119 Hare: Whore Durve"),
+  // but hares are extracted separately into RawEventData.hares below.
+  // See #961.
+  const title = stripHareSuffix(rawTitle);
 
   // Extract sourceUrl from href
   const href = titleLink.attr("href");


### PR DESCRIPTION
## Summary

Frankfurt's JEM list page appends hare names to event titles (`"FH3 Run #2119 Hare: Whore Durve"`). The hare name is *also* extracted separately into `RawEventData.hares`, so keeping it in the title duplicates the hare name on every event card.

`stripHareSuffix()` removes the trailing `\sHares?[:\-]\s.+$` from titles. Defensive guards:
- Requires whitespace before `Hare` (won't strip `"FH3-Hare:..."` URL-slug styles)
- Falls back to the original title when stripping would empty it (so a malformed bare `"Hare: X"` title doesn't break the merge — `RawEventData.title` must be non-empty)

Generic across all kennels routed through this adapter: FH3, FFMH3, SHITS, DOM, Bike Hash.

## Live verification

Ran the adapter against `frankfurt-hash.de` on 2026-04-26 (17 events, 0 errors):

| Field | Before | After |
|---|---|---|
| #2119 title | `"FH3 Run #2119 Hare: Whore Durve"` | `"FH3 Run #2119"` ✓ |
| #2119 hares | `"Whore Durve"` | `"Whore Durve"` ✓ (still extracted) |
| #2119 runNumber | `2119` | `2119` ✓ |
| #2119 kennelTag | `fh3` | `fh3` ✓ |

## Test plan

- [x] Unit tests for `stripHareSuffix` (singular/plural, case-insensitive, no-op, defensive empty fallback, no-whitespace-prefix)
- [x] Integration test for `parseJEMEvent` confirming title strip + hares extraction both succeed
- [x] `npx vitest run src/adapters/html-scraper/frankfurt-hash` — 27 / 27 pass
- [x] `npx tsc --noEmit` clean
- [x] Live re-fetch against frankfurt-hash.de

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)