### PR TITLE
fix(meetup): hares dash-form fallback (#953) + filter CANCELLED events (#917)

### DIFF
--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo } from "./adapter";
+import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription } from "./adapter";
 import type { Source } from "@/generated/prisma/client";
 
 vi.mock("../safe-fetch", () => ({
@@ -352,6 +352,41 @@ describe("MeetupAdapter", () => {
     const result = await adapter.fetch(makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }));
     expect(result.events).toHaveLength(0);
     expect(result.errors[0]).toMatch(/Network error/);
+  });
+
+  it("filters out cancelled events (#917 Charlotte H3 #1235)", async () => {
+    // Charlotte H3 Trail #1235 (Jan 10) was cancelled on Meetup with
+    // status="CANCELLED", then re-held on Feb 7 with the same trail
+    // number but a new title. The adapter must not surface the cancelled
+    // version as a normal past run, otherwise users see two #1235 cards
+    // and no cancellation indicator on the first.
+    const html = buildMeetupHtml({
+      "Event:cancelled": buildApolloEvent({
+        id: "1235-cancelled",
+        title: "Charlotte H3 Trail #1235 - Erections (Elections) & SOUP Cook off",
+        dateTime: "2026-01-10T14:00:00-05:00",
+        status: "CANCELLED",
+      }),
+      "Event:active": buildApolloEvent({
+        id: "1235-active",
+        title: "Charlotte H3 Trail #1235 - An East Charlotte Snow Melt Trail!",
+        dateTime: "2026-02-07T14:00:00-05:00",
+        status: "ACTIVE",
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "charlotte-hash-house-harriers", kennelTag: "ch3-nc" }),
+      { days: 365 },
+    );
+
+    // Cancelled event should be skipped; only the active one survives.
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].title).toMatch(/Snow Melt/);
+    expect(result.diagnosticContext?.cancelledSkipped).toBe(1);
   });
 
   it("parses events and assigns kennelTag", async () => {
@@ -1084,5 +1119,88 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     };
     const event = buildRawEventFromApollo(ev as never, emptyState, "rch3");
     expect(event.hares).toBeUndefined();
+  });
+});
+
+describe("extractHaresFromMeetupDescription (#953 CHH3 dash separator)", () => {
+  it("captures 'Hares - X and Y' (plural, dash, ASCII hyphen)", () => {
+    expect(extractHaresFromMeetupDescription("Hares - FAW and Just Jim\n\nGo see the rail yards"))
+      .toBe("FAW and Just Jim");
+  });
+
+  it("captures 'Hare - X' (singular)", () => {
+    expect(extractHaresFromMeetupDescription("Hare - She Shooters She Scores (Again) with Just Dave"))
+      .toBe("She Shooters She Scores (Again) with Just Dave");
+  });
+
+  it("is case-insensitive", () => {
+    expect(extractHaresFromMeetupDescription("hares - alice")).toBe("alice");
+    expect(extractHaresFromMeetupDescription("HARE - bob")).toBe("bob");
+  });
+
+  it("handles en-dash and em-dash", () => {
+    expect(extractHaresFromMeetupDescription("Hares – Alice")).toBe("Alice");
+    expect(extractHaresFromMeetupDescription("Hare — Bob")).toBe("Bob");
+  });
+
+  it("only scans the first 5 non-empty description lines", () => {
+    // Filler lines are non-empty so they consume the budget; the Hares line
+    // beyond position 5 is ignored.
+    const desc = [
+      "Filler 1", "Filler 2", "Filler 3", "Filler 4", "Filler 5", "Filler 6",
+      "Hares - Late Liner",
+    ].join("\n");
+    expect(extractHaresFromMeetupDescription(desc)).toBeUndefined();
+  });
+
+  it("truncates trailing boilerplate field labels (HASH CASH)", () => {
+    // When HTML stripping collapses several fields onto one line,
+    // HARE_BOILERPLATE_RE caps the hare names at the first known label.
+    expect(extractHaresFromMeetupDescription("Hares - FAW and Just Jim HASH CASH: $5"))
+      .toBe("FAW and Just Jim");
+  });
+
+  it("returns undefined when no Hare(s) line is present", () => {
+    expect(extractHaresFromMeetupDescription("2pm Show 2:30pm Go\n$5 Hash Cash"))
+      .toBeUndefined();
+  });
+
+  it("returns undefined for an empty/missing description", () => {
+    expect(extractHaresFromMeetupDescription(undefined)).toBeUndefined();
+    expect(extractHaresFromMeetupDescription("")).toBeUndefined();
+  });
+
+  it("does not match colon form (handled by extractHaresFromDescription)", () => {
+    // Colon form is the google-calendar helper's job; the dash-fallback
+    // should leave it alone so we don't accidentally double-match.
+    expect(extractHaresFromMeetupDescription("Hares: Just Josh")).toBeUndefined();
+  });
+});
+
+describe("buildRawEventFromApollo — CHH3 dash-form fallback (#953)", () => {
+  const emptyState = {};
+
+  it("falls back to dash-form regex when colon-form returns undefined", () => {
+    const ev = {
+      __typename: "Event",
+      id: "999",
+      title: "Heretics Trail - The Kennel Gets Railed",
+      dateTime: "2026-04-25T14:00:00-04:00",
+      description: "Hares - FAW and Just Jim\n\nGo see the magnificent rail yards.",
+    };
+    const event = buildRawEventFromApollo(ev as never, emptyState, "chh3");
+    expect(event.hares).toBe("FAW and Just Jim");
+  });
+
+  it("prefers colon-form match when present (no fallback fired)", () => {
+    const ev = {
+      __typename: "Event",
+      id: "1000",
+      title: "Heretics Trail - Love Sucks",
+      dateTime: "2026-02-14T14:00:00-04:00",
+      description: "Hares: Just Josh\n2pm Show 2:30pm Go",
+    };
+    const event = buildRawEventFromApollo(ev as never, emptyState, "chh3");
+    expect(event.hares).toBe("Just Josh");
   });
 });

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -2,7 +2,7 @@ import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { validateSourceConfig, stripHtmlTags, buildDateWindow } from "../utils";
+import { validateSourceConfig, stripHtmlTags, buildDateWindow, HARE_BOILERPLATE_RE } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { extractHares as extractHaresFromDescription } from "../google-calendar/adapter";
 
@@ -287,6 +287,33 @@ function compileKennelPatterns(
   return compiled.length > 0 ? compiled : undefined;
 }
 
+/**
+ * Meetup-style hare-line fallback: scan the first few description lines for
+ * `Hare(s)` followed by a dash separator. Charleston Heretics (CHH3)
+ * consistently writes `Hares - FAW and Just Jim` / `Hare - X` / `Hares X and Y`,
+ * but the imported `extractHaresFromDescription` (google-calendar) only matches
+ * the colon form. We match the dash variant locally so we don't reach into
+ * WS1's google-calendar adapter to extend its pattern set.
+ *
+ * Truncates the captured names at the first boilerplate field label
+ * (`HARE_BOILERPLATE_RE`) so trailing description text like "Show/Go: 2:00"
+ * doesn't leak into the hares field. See #953.
+ */
+export function extractHaresFromMeetupDescription(
+  description: string | undefined,
+): string | undefined {
+  if (!description) return undefined;
+  const lines = description.split("\n").map((l) => l.trim()).filter(Boolean);
+  for (const line of lines.slice(0, 5)) {
+    // Dash separator: ASCII hyphen, en-dash, or em-dash (kennel users mix).
+    const m = /^Hares?\s*[-–—]\s*(.+?)\s*$/i.exec(line);
+    if (!m) continue;
+    const names = m[1].replace(HARE_BOILERPLATE_RE, "").trim();
+    if (names) return names;
+  }
+  return undefined;
+}
+
 /** Build a RawEventData from an Apollo event entry. */
 export function buildRawEventFromApollo(
   ev: ApolloEvent,
@@ -321,7 +348,12 @@ export function buildRawEventFromApollo(
   const descForHares = ev.description
     ? stripHtmlTags(ev.description, "\n").replace(/\*{1,2}|#{1,3}\s*/g, "")
     : undefined;
-  const hares = descForHares ? extractHaresFromDescription(descForHares) : undefined;
+  // Try the colon-form helper first (matches DEFAULT_HARE_PATTERNS in
+  // google-calendar/adapter.ts). Fall back to the Meetup-local dash-separator
+  // pattern for kennels like CHH3 that always write "Hares - X". See #953.
+  const hares =
+    (descForHares ? extractHaresFromDescription(descForHares) : undefined)
+    ?? extractHaresFromMeetupDescription(descForHares);
   const cleanedDesc = cleanMeetupDescription(ev.description);
 
   return {
@@ -500,9 +532,22 @@ export class MeetupAdapter implements SourceAdapter {
     }
 
     const compiledPatterns = compileKennelPatterns(config.kennelPatterns);
+    let cancelledSkipped = 0;
     for (const [i, ev] of allApolloEvents.entries()) {
       try {
         if (!ev.dateTime) continue;
+        // Drop cancelled events at ingest. Meetup's Apollo payload exposes
+        // `status: "CANCELLED"` for trails that were called off (e.g.
+        // Charlotte H3 #1235, Jan 10 — weather cancellation, re-held later
+        // as a different trail with the same number). Without this filter
+        // they show on HashTracks as normal past runs with no cancellation
+        // indicator; the reconcile pipeline transitions any pre-existing
+        // CONFIRMED row to CANCELLED on the next scrape because the event
+        // is no longer in the active set. See #917.
+        if (ev.status === "CANCELLED") {
+          cancelledSkipped++;
+          continue;
+        }
         events.push(buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns));
       } catch (err) {
         const msg = `Failed to parse event "${ev.id}": ${err instanceof Error ? err.message : String(err)}`;
@@ -524,6 +569,7 @@ export class MeetupAdapter implements SourceAdapter {
         pastEventsFound: pastEvents.length,
         pastEventsIngested: allApolloEvents.filter((ev) => pastOnlyIds.has(ev.id)).length,
         eventsAfterDedup: allApolloEvents.length,
+        cancelledSkipped,
         detailPagesFetched,
         detailPagesEnriched,
       },


### PR DESCRIPTION
## Summary

Two distinct MEETUP adapter bugs from the chrome-kennel audit, bundled into one PR because both touch the same `buildRawEventFromApollo` / scrape-loop path.

### #953 — CHH3 hares fallback (dash separator)

Charleston Heretics consistently writes \`Hares - FAW and Just Jim\` / \`Hare - X\` in their description body, but the imported \`extractHaresFromDescription\` (google-calendar) only matches the colon form. New \`extractHaresFromMeetupDescription\` is a Meetup-local fallback that scans the first 5 non-empty lines for the dash variant (ASCII hyphen, en-dash, em-dash). Truncates trailing field labels via \`HARE_BOILERPLATE_RE\`.

Why a Meetup-local helper instead of extending the gcal pattern set: \`src/adapters/google-calendar/**\` is owned by the parallel WS1 GCal overhaul session.

### #917 — Charlotte H3 cancelled events

The Apollo payload exposes \`ev.status\` (line 81), but the scrape loop never read it. Cancelled events (Charlotte H3 #1235 Jan 10 — weather cancellation, re-held Feb 7 with a new theme) showed up as normal past runs. Filter \`ev.status === \"CANCELLED\"\` at the loop site; reconcile transitions pre-existing CONFIRMED rows to CANCELLED on next scrape. \`cancelledSkipped\` added to diagnosticContext.

### #856 BIBH3 — investigated, wontfix

Live Meetup payload now reads \`\"BIBH3 Trail #249 - NEED A HARE\"\` (themed, hare-recruitment placeholder set by the kennel). The HashTracks DB row showing just \`\"BIBH3 Trail\"\` is stale from before the source was updated; next daily scrape will refresh. Per planning gate, closing #856 separately as wontfix with that explanation.

## Live verification

**CHH3** (\`charlestonheretics\`, 2026-04-26):
| Event | Before | After |
|---|---|---|
| Apr 25 \"The Kennel Gets Railed\" | hares=— | \`FAW and Just Jim\` ✓ |
| Mar 14 \"Saintly Pat Me Day\" | hares=— | \`She Shooters She Scores (Again) with Just Dave\` ✓ |
| Feb 28 \"Beer Mile\" | hares=— | \`She Shooters She Scores with Screw My Face …\` ✓ |
| Feb 14 \"Love Sucks\" (control, colon form) | \`Just Josh\` | \`Just Josh\` ✓ unchanged |

**Charlotte H3** (\`charlotte-hash-house-harriers\`, 2026-04-26):
- \`cancelledSkipped: 1\` (the Jan 10 #1235)
- Only the Feb 7 #1235 (\"Snow Melt Trail\") reaches RawEvents
- 14 active events ingested, 0 errors

## Test plan

- [x] `extractHaresFromMeetupDescription` unit tests: dash/colon/case/em-dash, line-budget cap, boilerplate truncation, control-no-match
- [x] `buildRawEventFromApollo` integration tests: dash fallback fires, colon-form preferred when present
- [x] CANCELLED filter integration test asserting 1 cancelled + 1 active → 1 RawEvent + diagnosticContext.cancelledSkipped=1
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/adapters/meetup/` clean
- [x] `npx vitest run src/adapters/meetup` — 91 / 91 pass
- [x] Live re-fetch against both production sources

Closes #953
Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)