### PR TITLE
fix(city-h3, merge): clear stale haresText when source flips to CTA placeholder (#963, #949)

### DIFF
--- a/src/adapters/html-scraper/city-hash.test.ts
+++ b/src/adapters/html-scraper/city-hash.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
 import * as cheerio from "cheerio";
 import { parseMakesweatEvent, extractMakesweatId } from "./city-hash";
 import { CityHashAdapter } from "./city-hash";
@@ -188,6 +189,27 @@ Pub - TBA</div>
     const $cta = cheerio.load(ctaHtml);
     const event = parseMakesweatEvent($cta, $cta(".ms_event").eq(0), "https://makesweat.com/cityhash#hashes");
     expect(event?.hares).toBe("We need a Hare, Contact Full Load!");
+  });
+
+  it("does not collapse a matched-but-trim-empty hare value to undefined (#949)", () => {
+    // Regression guard for the `|| undefined` footgun removed in this PR.
+    // The merge UPDATE branch only writes `haresText` when
+    // `event.hares !== undefined`. If the regex matches a label like
+    // "Hare - " but `(.+?)` captures only whitespace-equivalent characters
+    // that `trim()` strips, the adapter must still emit an empty string —
+    // NOT `undefined` — so merge can call `sanitizeHares("")` (returns null)
+    // and clear any stale value. Returning `undefined` would skip the write
+    // entirely and "69 Virgins to Paradise" would persist forever (#949).
+    //
+    // We test the property by reading the source: the assignment is
+    // `hares = hareMatch[1].trim();` — bare trim, no `|| undefined`.
+    // This sentinel test fails if a future maintainer reintroduces the
+    // collapse pattern.
+    const src = readFileSync(
+      new URL("./city-hash.ts", import.meta.url),
+      "utf8",
+    );
+    expect(src).not.toMatch(/hareMatch\[1\]\.trim\(\)\s*\|\|\s*undefined/);
   });
 
   it("extracts Makesweat ID from class attribute", () => {

--- a/src/adapters/html-scraper/city-hash.test.ts
+++ b/src/adapters/html-scraper/city-hash.test.ts
@@ -151,9 +151,15 @@ describe("parseMakesweatEvent", () => {
     expect(event!.location).toBeUndefined();
   });
 
-  it("filters CTA hare text as undefined (#726)", () => {
-    // Source description: "Hare Needed! Please contact Full Load" — the "Hare" prefix
-    // with dash separator is how Makesweat formats the field, producing a CTA as the value
+  it("passes CTA hare text through verbatim (sanitizeHares clears it; #726, #949, #963)", () => {
+    // Source description: "Hare Needed! Please contact Full Load" — the "Hare"
+    // prefix with dash separator is how Makesweat formats the field. The
+    // adapter no longer null-filters CTAs in-place — it passes raw text
+    // through so the merge pipeline's sanitizeHares can recognize the CTA
+    // and write `haresText: null`, which clears stale values on existing
+    // canonical events. Returning undefined here would leave the merge
+    // UPDATE branch as a no-op for hares, so a stale "69 Virgins to
+    // Paradise" (#949) would persist forever.
     const ctaHtml = `<div class="ms_event makesweatevent-99999">
       <div class="ms_eventtitle">City Hash R*n #1920 @ TBA</div>
       <div class="ms_event_startdate">Tue 21st Apr 26</div>
@@ -164,7 +170,24 @@ Pub - TBA</div>
     </div>`;
     const $cta = cheerio.load(ctaHtml);
     const event = parseMakesweatEvent($cta, $cta(".ms_event").eq(0), "https://makesweat.com/cityhash#hashes");
-    expect(event?.hares).toBeUndefined();
+    // Raw passthrough — sanitization happens downstream.
+    expect(event?.hares).toBe("Hare Needed! Please contact Full Load");
+  });
+
+  it("passes 'We need a Hare, Contact Full Load!' through verbatim (#963)", () => {
+    // Live #1920 reproduction (Makesweat 2026-04-26). Adapter must emit the
+    // raw string so sanitizeHares can clear stale data on UPDATE.
+    const ctaHtml = `<div class="ms_event makesweatevent-99999">
+      <div class="ms_eventtitle">City Hash R*n #1920 @ TBA</div>
+      <div class="ms_event_startdate">Tue 5th May 26</div>
+      <div class="ms_eventstart">7:00pm</div>
+      <div class="ms_eventdescription">Hare - We need a Hare, Contact Full Load!
+Pub - TBA</div>
+      <div class="ms_venue_name">TBA</div>
+    </div>`;
+    const $cta = cheerio.load(ctaHtml);
+    const event = parseMakesweatEvent($cta, $cta(".ms_event").eq(0), "https://makesweat.com/cityhash#hashes");
+    expect(event?.hares).toBe("We need a Hare, Contact Full Load!");
   });
 
   it("extracts Makesweat ID from class attribute", () => {

--- a/src/adapters/html-scraper/city-hash.ts
+++ b/src/adapters/html-scraper/city-hash.ts
@@ -61,7 +61,11 @@ export function parseMakesweatEvent(
   if (descText) {
     const hareMatch = descText.match(/Hares?\s*[-–—]\s*(.+?)(?:\n|$)/i);
     if (hareMatch) {
-      hares = hareMatch[1].trim() || undefined;
+      // Empty string (not undefined) signals "field present but empty" so the
+      // merge UPDATE path fires and sanitizeHares("") returns null, clearing
+      // any stale value. Returning undefined would skip the haresText write
+      // entirely and leave stale data forever. See #949.
+      hares = hareMatch[1].trim();
     }
   }
 

--- a/src/adapters/html-scraper/city-hash.ts
+++ b/src/adapters/html-scraper/city-hash.ts
@@ -10,7 +10,6 @@ import {
   chronoParseDate,
   parse12HourTime,
   fetchBrowserRenderedPage,
-  HARE_BOILERPLATE_RE,
   isPlaceholder,
 } from "../utils";
 
@@ -49,17 +48,20 @@ export function parseMakesweatEvent(
   const timeText = $event.find(".ms_eventstart").first().text().trim();
   const startTime = timeText ? parse12HourTime(timeText) : "19:00";
 
-  // Hares from .ms_eventdescription — match "Hare(s) - Name"
+  // Hares from .ms_eventdescription — match "Hare(s) - Name". CTA-shaped values
+  // ("We need a Hare, Contact Full Load!", "Hare needed", etc.) flow through to
+  // the merge pipeline's sanitizeHares which uses CTA_EMBEDDED_PATTERNS to
+  // recognize them and write `haresText: null`. This is the only path that
+  // CLEARS a stale haresText on an existing canonical event — returning
+  // `undefined` here would leave the merge UPDATE branch as a no-op for the
+  // hares field, so a value like "69 Virgins to Paradise" (#949) would persist
+  // forever even after the source switched to a placeholder. See #963.
   let hares: string | undefined;
   const descText = $event.find(".ms_eventdescription").first().text().trim();
   if (descText) {
     const hareMatch = descText.match(/Hares?\s*[-–—]\s*(.+?)(?:\n|$)/i);
     if (hareMatch) {
-      const raw = hareMatch[1].trim();
-      const isCta = HARE_BOILERPLATE_RE.test(raw)
-        || /^(?:hare\s+)?needed\b/i.test(raw)
-        || /^please\s+contact\b/i.test(raw);
-      hares = isCta ? undefined : raw;
+      hares = hareMatch[1].trim() || undefined;
     }
   }
 

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1331,6 +1331,26 @@ describe("sanitizeHares", () => {
     expect(sanitizeHares("Needed")).toBeNull();
   });
 
+  it("returns null for sentence-shaped CTAs (#963)", () => {
+    // Live City H3 #1920 case: the source description starts "Hare - We need
+    // a Hare, Contact Full Load!" and the adapter passes the value through
+    // verbatim. sanitizeHares must catch the embedded "need a Hare" phrase
+    // (via CTA_EMBEDDED_PATTERNS) and return null so the merge UPDATE path
+    // writes haresText: null and clears any stale "real" hare value (#949).
+    expect(sanitizeHares("We need a Hare, Contact Full Load!")).toBeNull();
+    expect(sanitizeHares("Need a hare for this trail")).toBeNull();
+    expect(sanitizeHares("Hare needed — please volunteer")).toBeNull();
+    expect(sanitizeHares("Looking for a hare")).toBeNull();
+  });
+
+  it("does NOT clear legitimate hare names that contain the word 'need' (no false positives)", () => {
+    // Defensive: a hare name like "Need For Speed" or "Needled" should not
+    // be misclassified as a CTA. CTA_EMBEDDED_PATTERNS requires "need" to
+    // be followed by "(a) hare(s)", so these pass through.
+    expect(sanitizeHares("Need For Speed")).toBe("Need For Speed");
+    expect(sanitizeHares("Needled")).toBe("Needled");
+  });
+
   it("truncates at boilerplate marker 'WHAT TIME'", () => {
     expect(sanitizeHares("Captain Hash WHAT TIME: 6:30 PM")).toBe("Captain Hash");
   });

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -7,7 +7,7 @@ import { composeUtcStart } from "@/lib/timezone";
 import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag, clearResolverCache } from "./kennel-resolver";
 import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseGeocode, haversineDistance, parseDMSFromLocation, stripDMSFromLocation } from "@/lib/geo";
-import { isPlaceholder, decodeEntities, HARE_BOILERPLATE_RE } from "@/adapters/utils";
+import { isPlaceholder, decodeEntities, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "@/adapters/utils";
 import { LOCATION_EMAIL_CTA_RE } from "./audit-checks";
 
 // Strip a trailing "(text/call/… for address)" parenthetical when its body
@@ -85,8 +85,13 @@ export function sanitizeHares(hares: string | undefined | null): string | null {
   if (!h) return null;
   if (isPlaceholder(h)) return null;
 
-  // Filter CTA/volunteer placeholders that aren't real hare names
+  // Filter CTA/volunteer placeholders that aren't real hare names — sentence-shaped
+  // CTAs (e.g. "We need a Hare, Contact Full Load!" — Makesweat City H3 #1920)
+  // get caught here so adapters don't need to special-case per-source. See #963.
   if (/^(?:sign[\s\u00A0]*up!?|volunteer)$/i.test(h)) return null;
+  for (const re of CTA_EMBEDDED_PATTERNS) {
+    if (re.test(h)) return null;
+  }
 
   // Reject bare URLs (e.g., Google Maps links extracted as hare names)
   if (/^https?:\/\//i.test(h)) return null;


### PR DESCRIPTION
## Summary

Three Makesweat City H3 audit findings; **#948 resolved by re-scrape**, **#963 + #949 require code**.

### #948 — already resolved (no code change)

Live adapter run against `https://makesweat.com/cityhash#hashes` (2026-04-26): **11 events emitted**, 0 errors. \`cardsFound=22\` (Makesweat duplicates each card in the DOM), \`eventsDeduped=11\` (Set keyed on Makesweat event ID). The 2-of-11 audit report was a transient browser-render issue or pre-fix snapshot.

### #963 + #949 — CTA in hares + stale haresText

Makesweat's \`Hare - …\` field can hold a CTA placeholder (\"We need a Hare, Contact Full Load!\"). The previous adapter detected the CTA and returned \`hares=undefined\`, but **undefined leaves the merge UPDATE branch as a no-op for haresText** — so a stale \"real\" hare value (e.g. \"69 Virgins to Paradise\" on #1920) persisted forever even after the source switched.

**Two-layer fix:**

1. **\`city-hash.ts\`**: Pass the raw extracted hares text through verbatim. No in-adapter null filter.
2. **\`merge.ts\` \`sanitizeHares\`**: Loop \`CTA_EMBEDDED_PATTERNS\` (the existing util used by the audit-time CTA detector) and return null on any match — including the \"We need a Hare\" / \"need a hare\" / \"looking for a hare\" / \"Hare(s) needed/wanted/required/volunteer\" sentence-shaped CTAs that \`PLACEHOLDER_RE\` missed because they don't anchor at the string start.
3. **null from sanitizeHares writes \`haresText=null\` on the UPDATE path → clears stale row.**

**Defensive**: legitimate hare names containing \"need\" (\"Need For Speed\", \"Needled\") are not false-positives — \`CTA_EMBEDDED_PATTERNS\` requires \"need\" be followed by \"(a) hare(s)\".

## Live verification

\`https://makesweat.com/cityhash\` 2026-04-26: 11 events, 0 errors.

| Event | raw extraction | sanitizeHares output |
|---|---|---|
| #1919 | \`FLAR\` | \`FLAR\` |
| **#1920** | \`We need a Hare, Contact Full Load!\` | **null** 🧹 |
| #1921 | \`Salty Rim / Neeps & Titties\` | \`Salty Rim / Neeps & Titties\` |
| **#1922** | \`We need a Hare, Contact Full Load!\` | **null** 🧹 |
| **#1923** | \`We need a Hare, Contact Full Load!\` | **null** 🧹 |
| #1924–1929 | various real names | passed through ✓ |

Stale rows on existing canonical events (#1920, #1922, #1923) get cleared on the next merge UPDATE.

## Test plan

- [x] Updated city-hash.ts CTA test to assert raw passthrough (responsibility split: adapter extracts, pipeline sanitizes)
- [x] New city-hash.ts test for live #1920 \"We need a Hare\" string
- [x] New \`sanitizeHares\` tests in merge.test.ts: 4 CTA forms + 2 false-positive guards (\"Need For Speed\", \"Needled\")
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint src/adapters/html-scraper/city-hash.ts src/pipeline/merge.ts\` clean
- [x] Full \`npx vitest run\` — 5114 / 5114 pass
- [x] Live re-fetch against production Makesweat

Closes #948
Closes #949
Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)