### PR TITLE
fix(bch3, browser-render): pass timezoneId to Playwright so Wix renders local dates (#960)

### DIFF
--- a/infra/browser-render/server.js
+++ b/infra/browser-render/server.js
@@ -177,18 +177,23 @@ const server = http.createServer(async (req, res) => {
 
     // Validate timezoneId — Playwright accepts any IANA timezone identifier.
     // Cap length to keep the surface small; defer full validation to Playwright
-    // which throws a clear error on unknown zones.
+    // which throws a clear error on unknown zones. Any non-undefined value that
+    // fails length OR charset checks returns 400 (no silent fallback to UTC).
     let safeTimezoneId;
-    if (typeof timezoneId === "string" && timezoneId.length > 0 && timezoneId.length <= 64) {
-      // Allow only the IANA charset: letters, digits, /, _, -, +
-      if (/^[A-Za-z0-9/_+\-]+$/.test(timezoneId)) {
-        safeTimezoneId = timezoneId;
-      } else {
+    if (timezoneId !== undefined) {
+      if (
+        typeof timezoneId !== "string" ||
+        timezoneId.length === 0 ||
+        timezoneId.length > 64 ||
+        // Allow only the IANA charset: letters, digits, /, _, -, +
+        !/^[A-Za-z0-9/_+\-]+$/.test(timezoneId)
+      ) {
         busy = false;
         return jsonResponse(res, 400, {
           error: `Invalid timezoneId: ${timezoneId}`,
         });
       }
+      safeTimezoneId = timezoneId;
     }
 
     // SSRF check
@@ -229,16 +234,15 @@ const server = http.createServer(async (req, res) => {
     );
 
     const b = await getBrowser();
-    // When timezoneId is supplied, create a dedicated context so JS calendars
-    // (Wix, Google Sites) format dates in the kennel's local zone rather than
-    // the server's UTC default. Without it, BCH3 events authored as
-    // "Thursday 8 PM CDT" rendered as "Friday 12 AM" (rounded UTC). See #960.
-    if (safeTimezoneId) {
-      context = await b.newContext({ timezoneId: safeTimezoneId });
-      page = await context.newPage();
-    } else {
-      page = await b.newPage();
-    }
+    // Always create an explicit context so cleanup is uniform across the
+    // timezone and no-timezone paths. When timezoneId is supplied, the context
+    // makes JS calendars (Wix, Google Sites) format dates in the kennel's
+    // local zone rather than the server's UTC default. Without it, BCH3 events
+    // authored as "Thursday 8 PM CDT" rendered as "Friday 12 AM" (rounded
+    // UTC). See #960.
+    const contextOpts = safeTimezoneId ? { timezoneId: safeTimezoneId } : {};
+    context = await b.newContext(contextOpts);
+    page = await context.newPage();
 
     // Use domcontentloaded instead of networkidle — Wix/SPA sites have
     // continuous background requests that prevent networkidle from firing.

--- a/infra/browser-render/server.js
+++ b/infra/browser-render/server.js
@@ -155,6 +155,7 @@ const server = http.createServer(async (req, res) => {
 
   busy = true;
   let page = null;
+  let context = null;
 
   try {
     const rawBody = await readBody(req);
@@ -166,12 +167,28 @@ const server = http.createServer(async (req, res) => {
       return jsonResponse(res, 400, { error: "Invalid JSON body" });
     }
 
-    const { url, waitFor, selector, frameUrl, timeout } = parsed;
+    const { url, waitFor, selector, frameUrl, timeout, timezoneId } = parsed;
     if (!url || typeof url !== "string") {
       busy = false;
       return jsonResponse(res, 400, {
         error: "Missing or invalid 'url' field",
       });
+    }
+
+    // Validate timezoneId — Playwright accepts any IANA timezone identifier.
+    // Cap length to keep the surface small; defer full validation to Playwright
+    // which throws a clear error on unknown zones.
+    let safeTimezoneId;
+    if (typeof timezoneId === "string" && timezoneId.length > 0 && timezoneId.length <= 64) {
+      // Allow only the IANA charset: letters, digits, /, _, -, +
+      if (/^[A-Za-z0-9/_+\-]+$/.test(timezoneId)) {
+        safeTimezoneId = timezoneId;
+      } else {
+        busy = false;
+        return jsonResponse(res, 400, {
+          error: `Invalid timezoneId: ${timezoneId}`,
+        });
+      }
     }
 
     // SSRF check
@@ -208,11 +225,20 @@ const server = http.createServer(async (req, res) => {
 
     const renderStart = Date.now();
     console.log(
-      `[${new Date().toISOString()}] Rendering ${url} (waitFor: ${waitForSelector}, timeout: ${pageTimeout}ms)`,
+      `[${new Date().toISOString()}] Rendering ${url} (waitFor: ${waitForSelector}, timeout: ${pageTimeout}ms${safeTimezoneId ? `, tz: ${safeTimezoneId}` : ""})`,
     );
 
     const b = await getBrowser();
-    page = await b.newPage();
+    // When timezoneId is supplied, create a dedicated context so JS calendars
+    // (Wix, Google Sites) format dates in the kennel's local zone rather than
+    // the server's UTC default. Without it, BCH3 events authored as
+    // "Thursday 8 PM CDT" rendered as "Friday 12 AM" (rounded UTC). See #960.
+    if (safeTimezoneId) {
+      context = await b.newContext({ timezoneId: safeTimezoneId });
+      page = await context.newPage();
+    } else {
+      page = await b.newPage();
+    }
 
     // Use domcontentloaded instead of networkidle — Wix/SPA sites have
     // continuous background requests that prevent networkidle from firing.
@@ -248,6 +274,7 @@ const server = http.createServer(async (req, res) => {
         const frameCount = allFrames.length;
         await page.close();
         page = null;
+        if (context) { await context.close(); context = null; }
         busy = false;
         return jsonResponse(res, 422, {
           error: `No child frame matching "${frameUrl}" found (${frameCount} frames total)`,
@@ -287,6 +314,7 @@ const server = http.createServer(async (req, res) => {
       if (!element) {
         await page.close();
         page = null;
+        if (context) { await context.close(); context = null; }
         busy = false;
         return jsonResponse(res, 422, {
           error: `Selector "${selector}" not found on page`,
@@ -299,6 +327,10 @@ const server = http.createServer(async (req, res) => {
 
     await page.close();
     page = null;
+    if (context) {
+      await context.close();
+      context = null;
+    }
 
     // Size check
     const htmlBytes = Buffer.byteLength(html, "utf-8");
@@ -325,6 +357,11 @@ const server = http.createServer(async (req, res) => {
     if (page) {
       try {
         await page.close();
+      } catch {}
+    }
+    if (context) {
+      try {
+        await context.close();
       } catch {}
     }
     jsonResponse(res, 502, { error: "Render failed", detail: err.message });

--- a/src/adapters/html-scraper/brew-city-h3.test.ts
+++ b/src/adapters/html-scraper/brew-city-h3.test.ts
@@ -69,6 +69,16 @@ describe("parseDateTime", () => {
     expect(result.date).toBeNull();
     expect(result.startTime).toBeUndefined();
   });
+
+  it("parses Thursday 8 PM (post-#960 timezone fix expected input)", () => {
+    // After the browser-render service is given timezoneId="America/Chicago",
+    // Wix renders BCH3 events as "Thursday, April 30, 2026 AT 8 PM" (the
+    // kennel's authored local time). Without the timezone hint, the same
+    // event rendered as "Friday, May 1, 2026 AT 12 AM" — see #960.
+    const result = parseDateTime("Thursday, April 30, 2026 AT 8 PM");
+    expect(result.date).toBe("2026-04-30");
+    expect(result.startTime).toBe("20:00");
+  });
 });
 
 describe("parseTitle", () => {

--- a/src/adapters/html-scraper/brew-city-h3.test.ts
+++ b/src/adapters/html-scraper/brew-city-h3.test.ts
@@ -185,6 +185,13 @@ describe("BrewCityH3Adapter", () => {
     const result = await adapter.fetch(makeSource());
     expect(result.events.length).toBeGreaterThanOrEqual(2);
 
+    // Verify the adapter forwards timezoneId so the NAS browser-render service
+    // creates a Playwright context in BCH3's local zone (#960). Without this,
+    // Wix renders 8 PM CDT events as 12 AM UTC and parseDateTime drops them.
+    expect(mockedBrowserRender).toHaveBeenCalledWith(
+      expect.objectContaining({ timezoneId: "America/Chicago" }),
+    );
+
     // First event: BCH3 Trail #359
     const trail359 = result.events.find(e => e.runNumber === 359);
     expect(trail359).toBeDefined();

--- a/src/adapters/html-scraper/brew-city-h3.ts
+++ b/src/adapters/html-scraper/brew-city-h3.ts
@@ -147,9 +147,17 @@ export class BrewCityH3Adapter implements SourceAdapter {
   ): Promise<ScrapeResult> {
     const calendarUrl = source.url || "https://www.brewcityh3.com/calendar";
 
+    // BCH3 is Wisconsin (Milwaukee) — America/Chicago. Wix renders calendar
+    // dates client-side via Intl.DateTimeFormat, so the rendering browser's
+    // timezone determines what string we see. Without this, Playwright's UTC
+    // default produced "Friday, May 1, AT 12 AM" for what the kennel
+    // authored as "Thursday, April 30, AT 8 PM CDT" — the date label was
+    // rounded forward across midnight UTC and the time degenerated to the
+    // 12 AM placeholder branch. See #960.
     const page = await fetchBrowserRenderedPage(calendarUrl, {
       waitFor: '[role="listitem"]',
       timeout: 20000,
+      timezoneId: "America/Chicago",
     });
 
     if (!page.ok) return page.result;

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -622,7 +622,16 @@ Text: "${text.slice(0, 500)}"`;
  */
 export async function fetchBrowserRenderedPage(
   url: string,
-  options?: { waitFor?: string; selector?: string; frameUrl?: string; timeout?: number },
+  options?: {
+    waitFor?: string;
+    selector?: string;
+    frameUrl?: string;
+    timeout?: number;
+    /** IANA timezone for the rendering context. See `RenderOptions.timezoneId`
+     *  in `@/lib/browser-render`. Required for Wix/JS-rendered calendars whose
+     *  date strings are formatted client-side and depend on viewer locale (#960). */
+    timezoneId?: string;
+  },
 ): Promise<FetchHTMLResult> {
   const fetchStart = Date.now();
   try {

--- a/src/lib/browser-render.ts
+++ b/src/lib/browser-render.ts
@@ -20,6 +20,13 @@ export interface RenderOptions {
   frameUrl?: string;
   /** Max wait in ms (default: 15000, capped at 30000 server-side) */
   timeout?: number;
+  /** IANA timezone (e.g. "America/Chicago") for the rendering browser context.
+   *  Wix and other JS-rendered calendars use the browser's timezone via
+   *  Intl.DateTimeFormat to format event dates. Without this, Playwright's
+   *  default UTC context yields viewer-local dates that are off by hours
+   *  for kennels in non-UTC zones (#960 BCH3 — Thu 8pm CDT shown as Fri
+   *  12am UTC). Default: undefined → server uses UTC (current behavior). */
+  timezoneId?: string;
 }
 
 /**
@@ -68,6 +75,7 @@ export async function browserRender(options: RenderOptions): Promise<string> {
         selector: options.selector,
         frameUrl: options.frameUrl,
         timeout: options.timeout,
+        timezoneId: options.timezoneId,
       }),
       signal: AbortSignal.timeout(fetchTimeoutMs), // 30s render timeout + 15s tunnel buffer
     });


### PR DESCRIPTION
## Summary

Wix calendars render event dates client-side via \`Intl.DateTimeFormat\`, so the rendering browser's timezone determines the displayed string. The NAS browser-render service ran Playwright in its default UTC context — BCH3's CDT-authored events (\`Thursday, April 30, 2026 AT 8 PM\`) rendered for the scraper as \`Friday, May 1, 2026 AT 12 AM\`: the date label rounded forward across midnight UTC, and the time degenerated to the existing 12-AM-placeholder branch. Real users in CDT see the kennel's intended Thursday 8 PM; the scraper saw Friday midnight.

## Changes

- **\`src/lib/browser-render.ts\`**: add \`timezoneId?: string\` to \`RenderOptions\`, forward to NAS request body.
- **\`src/adapters/utils.ts\`**: \`fetchBrowserRenderedPage\` accepts \`timezoneId\`, passes through.
- **\`infra/browser-render/server.js\`**: accept \`timezoneId\` in body, validate IANA charset (letters/digits/_/+/-//), create a dedicated browser context with that zone when supplied. **Backward compatible** — without timezoneId, server falls back to default UTC context (existing behavior). Added cleanup of the new context in early-return + catch paths so it doesn't leak.
- **\`src/adapters/html-scraper/brew-city-h3.ts\`**: passes \`timezoneId: \"America/Chicago\"\`.

The hook is generic — other Wix-rendered calendars (Northboro H3, Samurai H3, etc.) can opt in by passing their own kennel timezone.

## Deployment dependency

Requires \`infra/browser-render/server.js\` to be deployed to the NAS:

\`\`\`
scp -O infra/browser-render/server.js nas-tailscale:/volume1/docker/browser-render/
ssh nas-tailscale \"cd /volume1/docker/proxy-relay && \\
  /volume1/@appstore/ContainerManager/usr/bin/docker compose up -d --build browser-render\"
\`\`\`

Until the NAS is updated, the adapter passes \`timezoneId\`, the server ignores the new field, and behavior is unchanged from current production.

## Test plan

- [x] Unit test: \`parseDateTime(\"Thursday, April 30, 2026 AT 8 PM\")\` → \`{ date: \"2026-04-30\", startTime: \"20:00\" }\`
- [x] Existing tests still pass: 12-AM-placeholder, AM, PM, 12 PM matrix
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run src/adapters/html-scraper/brew-city-h3 src/lib\` — 891 / 891 pass
- [ ] Live verification deferred until NAS deploy: re-fetch BCH3 and assert dates land on Thursdays with 20:00 startTime

Closes #960 (after NAS deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)