### PR TITLE
fix(merge): rewrite alias-prefixed stale event titles, not just kennelCode (#884)

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1521,6 +1521,67 @@ describe("rewriteStaleDefaultTitle", () => {
     expect(rewriteStaleDefaultTitle("Something Else", "kwh3", "Key West H3", null))
       .toBe("Something Else");
   });
+
+  // ── alias rewriting (#884 Bristol H3 — "BRIS Trail" stale prefix) ──
+
+  it("rewrites alias-prefixed stale titles to display name (#884)", () => {
+    // Bristol H3's source page emits the kennel code "BRIS" in column 1.
+    // Old DB rows landed with title "BRIS Trail" before the kennel was renamed
+    // to shortName="Bristol H3". The kennelCode rewrite alone wouldn't match
+    // because "bristolh3" isn't a prefix of "BRIS Trail" — but "BRIS" is in
+    // the alias list, so the rewrite catches it.
+    expect(
+      rewriteStaleDefaultTitle("BRIS Trail", "bristolh3", "Bristol H3", "Bristol Hash House Harriers", ["Bristol Hash", "BH3", "Bristol HHH", "BRIS"]),
+    ).toBe("Bristol H3 Trail");
+  });
+
+  it("rewrites alias-prefixed title with run number suffix", () => {
+    expect(
+      rewriteStaleDefaultTitle("BRIS Trail #1357", "bristolh3", "Bristol H3", "Bristol Hash House Harriers", ["BRIS"]),
+    ).toBe("Bristol H3 Trail #1357");
+  });
+
+  it("prefers longer alias matches over shorter (no partial-prefix collision)", () => {
+    // "Bristol HHH" (longer) and "Bristol" (hypothetical shorter) — must match
+    // the longer one first so the suffix " HHH Trail" doesn't survive.
+    expect(
+      rewriteStaleDefaultTitle("Bristol HHH Trail", "bristolh3", "Bristol H3", "Bristol Hash House Harriers", ["Bristol", "Bristol HHH"]),
+    ).toBe("Bristol H3 Trail");
+  });
+
+  it("skips aliases that equal the current display name (no-op rewrite)", () => {
+    // "Bristol H3" alias would just rebuild the same string — should be filtered.
+    expect(
+      rewriteStaleDefaultTitle("Bristol H3 Trail", "bristolh3", "Bristol H3", "Bristol Hash House Harriers", ["Bristol H3", "BRIS"]),
+    ).toBe("Bristol H3 Trail");
+  });
+
+  it("does not rewrite when no alias or kennelCode prefix matches", () => {
+    expect(
+      rewriteStaleDefaultTitle("The Posset Cup", "bristolh3", "Bristol H3", "Bristol Hash House Harriers", ["BRIS"]),
+    ).toBe("The Posset Cup");
+  });
+
+  it("rewrites when only aliases are stale (kennelCode === displayName)", () => {
+    // For kennels where kennelCode = displayName, the old behavior returned
+    // immediately without rewriting any aliases. The fix lets aliases
+    // continue to drive rewrites.
+    expect(
+      rewriteStaleDefaultTitle("OldName Trail", "currentname", "currentname", "Current Name H3", ["OldName"]),
+    ).toBe("currentname Trail");
+  });
+
+  it("ignores empty/whitespace aliases", () => {
+    expect(
+      rewriteStaleDefaultTitle("BRIS Trail", "bristolh3", "Bristol H3", "Bristol Hash House Harriers", ["", "  ", "BRIS"]),
+    ).toBe("Bristol H3 Trail");
+  });
+
+  it("aliases parameter is optional (back-compat with existing callers)", () => {
+    // Existing call sites that don't pass aliases must keep working.
+    expect(rewriteStaleDefaultTitle("kwh3 Trail #42", "kwh3", "Key West H3", "Key West Hash House Harriers"))
+      .toBe("Key West H3 Trail #42");
+  });
 });
 
 // ── sanitizeLocation ──

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1582,6 +1582,28 @@ describe("rewriteStaleDefaultTitle", () => {
     expect(rewriteStaleDefaultTitle("kwh3 Trail #42", "kwh3", "Key West H3", "Key West Hash House Harriers"))
       .toBe("Key West H3 Trail #42");
   });
+
+  it("sorts equal-length aliases deterministically (insertion order independent)", () => {
+    // Two equal-length aliases ("AAA" and "BBB", both length 3). The internal
+    // sort uses length desc then localeCompare, so the compiled regex (and
+    // its cache key) must be identical regardless of which order callers
+    // pass the aliases in. We assert stable rewrite behavior on both inputs
+    // for both orderings — if the tiebreaker were missing, the Set's
+    // insertion order would leak into the regex alternation order. While
+    // the resulting regex is functionally equivalent under simple prefix
+    // matching, the cache key would diverge and fragment the cache.
+    const display = "Foo H3";
+    const long = "Foo Hash House Harriers";
+    const order1 = rewriteStaleDefaultTitle("AAA Trail #1", "fooh3", display, long, ["AAA", "BBB"]);
+    const order2 = rewriteStaleDefaultTitle("AAA Trail #1", "fooh3", display, long, ["BBB", "AAA"]);
+    expect(order1).toBe("Foo H3 Trail #1");
+    expect(order2).toBe(order1);
+
+    const order3 = rewriteStaleDefaultTitle("BBB Trail #2", "fooh3", display, long, ["AAA", "BBB"]);
+    const order4 = rewriteStaleDefaultTitle("BBB Trail #2", "fooh3", display, long, ["BBB", "AAA"]);
+    expect(order3).toBe("Foo H3 Trail #2");
+    expect(order4).toBe(order3);
+  });
 });
 
 // ── sanitizeLocation ──

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -138,26 +138,61 @@ export function friendlyKennelName(shortName: string, fullName: string | null): 
   return hadHHH ? `${friendly} H3` : friendly;
 }
 
-/** Cache of kennelCode → compiled Trail pattern for rewriteStaleDefaultTitle. */
+/** Cache of cache-key → compiled Trail pattern for rewriteStaleDefaultTitle.
+ *  Cache key includes both kennelCode and the sorted alias list so renames or
+ *  alias additions invalidate the cached pattern naturally. */
 const staleTrailPatternCache = new Map<string, RegExp>();
 
 /**
- * Rewrite stale default titles that use a raw kennelCode instead of the current
- * display name. Returns the corrected title or the original if no rewrite needed.
+ * Rewrite stale default titles that use a raw kennelCode (or a known alias)
+ * instead of the current display name. Returns the corrected title or the
+ * original if no rewrite needed.
+ *
+ * Examples:
+ *   - "BRIS Trail" → "Bristol H3 Trail"      (alias "BRIS" rewrites; #884)
+ *   - "bristolh3 Trail #42" → "Bristol H3 Trail #42"  (kennelCode rewrites)
+ *   - "Bristol H3 Trail" → "Bristol H3 Trail" (already current; no-op)
+ *   - "The Posset Cup" → "The Posset Cup"     (real title; no match, unchanged)
+ *
+ * Aliases that ARE the current display name (case-insensitive) are skipped to
+ * avoid no-op rewrites that just rebuild the same string.
  */
 export function rewriteStaleDefaultTitle(
   title: string,
   kennelCode: string,
   shortName: string,
   fullName: string | null,
+  aliases: string[] = [],
 ): string {
   const displayName = friendlyKennelName(shortName, fullName);
-  if (!displayName || displayName.toLowerCase() === kennelCode.toLowerCase()) return title;
-  let pattern = staleTrailPatternCache.get(kennelCode);
+  if (!displayName) return title;
+  const displayLc = displayName.toLowerCase();
+
+  // Build the set of stale prefixes: kennelCode plus any alias that isn't the
+  // current display name. Skip empty/whitespace aliases.
+  const stalePrefixes = new Set<string>();
+  if (kennelCode && kennelCode.toLowerCase() !== displayLc) {
+    stalePrefixes.add(kennelCode);
+  }
+  for (const alias of aliases) {
+    const trimmed = alias.trim();
+    if (trimmed && trimmed.toLowerCase() !== displayLc) {
+      stalePrefixes.add(trimmed);
+    }
+  }
+  if (stalePrefixes.size === 0) return title;
+
+  // Sort by length desc so longer aliases match first (e.g. "Bristol HHH"
+  // before "Bristol"), avoiding partial-prefix collisions.
+  const sortedPrefixes = [...stalePrefixes].sort((a, b) => b.length - a.length);
+  const cacheKey = `${kennelCode}|${sortedPrefixes.join("|")}`;
+  let pattern = staleTrailPatternCache.get(cacheKey);
   if (!pattern) {
-    const escaped = kennelCode.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-    pattern = new RegExp(String.raw`^${escaped}(\s+Trail.*)`, "i");
-    staleTrailPatternCache.set(kennelCode, pattern);
+    const escaped = sortedPrefixes
+      .map((p) => p.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`))
+      .join("|");
+    pattern = new RegExp(String.raw`^(?:${escaped})(\s+Trail.*)`, "i");
+    staleTrailPatternCache.set(cacheKey, pattern);
   }
   const match = title.match(pattern);
   return match ? `${displayName}${match[1]}` : title;
@@ -214,6 +249,11 @@ interface KennelCacheEntry {
   country: string;
   regionCentroidLat: number | null;
   regionCentroidLng: number | null;
+  /** All known aliases for this kennel — used by rewriteStaleDefaultTitle to
+   *  catch alias-prefixed stale titles like "BRIS Trail" → "Bristol H3 Trail"
+   *  on kennels whose displayed shortName has changed since the row was
+   *  scraped. See #884. */
+  aliases: string[];
 }
 
 /** Source types whose location field is canonical and should not be enriched with a
@@ -249,7 +289,12 @@ async function resolveKennelData(kennelId: string, ctx: MergeContext): Promise<K
   if (cached === undefined) {
     const kennel = await prisma.kennel.findUnique({
       where: { id: kennelId },
-      select: { kennelCode: true, shortName: true, fullName: true, region: true, latitude: true, longitude: true, country: true, regionRef: { select: { centroidLat: true, centroidLng: true } } },
+      select: {
+        kennelCode: true, shortName: true, fullName: true, region: true,
+        latitude: true, longitude: true, country: true,
+        regionRef: { select: { centroidLat: true, centroidLng: true } },
+        aliases: { select: { alias: true } },
+      },
     });
     cached = {
       kennelCode: kennel?.kennelCode ?? "",
@@ -261,6 +306,7 @@ async function resolveKennelData(kennelId: string, ctx: MergeContext): Promise<K
       country: kennel?.country ?? "",
       regionCentroidLat: kennel?.regionRef?.centroidLat ?? null,
       regionCentroidLng: kennel?.regionRef?.centroidLng ?? null,
+      aliases: kennel?.aliases?.map((a) => a.alias) ?? [],
     };
     ctx.kennelCache.set(kennelId, cached);
   }
@@ -847,7 +893,7 @@ async function upsertCanonicalEvent(
             : {}),
           title: (() => {
             const nextTitle = sanitizeTitle(event.title) ?? existingEvent.title;
-            return nextTitle ? rewriteStaleDefaultTitle(nextTitle, kennelData.kennelCode, kennelData.shortName, kennelData.fullName) : nextTitle;
+            return nextTitle ? rewriteStaleDefaultTitle(nextTitle, kennelData.kennelCode, kennelData.shortName, kennelData.fullName, kennelData.aliases) : nextTitle;
           })(),
           // Preserve existing fields when source doesn't provide them (undefined)
           ...(event.description !== undefined
@@ -1091,7 +1137,7 @@ async function processNewRawEvent(
       ? `${displayName} Trail #${event.runNumber}`
       : `${displayName} Trail`;
   } else {
-    event.title = rewriteStaleDefaultTitle(sanitized, kennelData.kennelCode, kennelData.shortName, kennelData.fullName);
+    event.title = rewriteStaleDefaultTitle(sanitized, kennelData.kennelCode, kennelData.shortName, kennelData.fullName, kennelData.aliases);
   }
 
   const targetEventId = await upsertCanonicalEvent(event, kennelId, rawEvent.id, ctx);

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -183,8 +183,13 @@ export function rewriteStaleDefaultTitle(
   if (stalePrefixes.size === 0) return title;
 
   // Sort by length desc so longer aliases match first (e.g. "Bristol HHH"
-  // before "Bristol"), avoiding partial-prefix collisions.
-  const sortedPrefixes = [...stalePrefixes].sort((a, b) => b.length - a.length);
+  // before "Bristol"), avoiding partial-prefix collisions. Tiebreak with
+  // localeCompare so equal-length aliases produce a deterministic cache key
+  // regardless of Set insertion order (which depends on alias-add order
+  // upstream and would otherwise fragment the regex cache across batches).
+  const sortedPrefixes = [...stalePrefixes].sort(
+    (a, b) => b.length - a.length || a.localeCompare(b),
+  );
   const cacheKey = `${kennelCode}|${sortedPrefixes.join("|")}`;
   let pattern = staleTrailPatternCache.get(cacheKey);
   if (!pattern) {


### PR DESCRIPTION
## Summary

Bristol H3's source page (\`allprint.php\`) emits the kennel code \`BRIS\` in column 1. Old DB rows landed with title \`BRIS Trail\` before the kennel was renamed to \`shortName=\"Bristol H3\"\`. The existing \`rewriteStaleDefaultTitle\` only matched titles prefixed with the current kennelCode (\`bristolh3\`), so \`BRIS Trail\` titles persisted forever even though \`BRIS\` is in the kennel's alias list.

Three of nine current Bristol upcoming events show \`BRIS Trail\` instead of the consistent \`Bristol H3 Trail\` used elsewhere on the same kennel page.

## Changes

- **\`rewriteStaleDefaultTitle\`**: add optional \`aliases?: string[]\` (defaults to []). Build the regex alternation from \`{kennelCode, ...aliases}\`, sorted by length desc so longer aliases match first (\`Bristol HHH\` before \`Bristol\`), filtering out aliases equal to the current displayName (avoids no-op rewrites).
- **\`KennelCacheEntry\`**: extend with \`aliases: string[]\`. \`resolveKennelData\` pulls them from the existing per-batch Prisma query via \`aliases: { select: { alias: true } }\` join — single round-trip, cached for the batch (no N+1).
- Update both call sites (UPDATE + CREATE branches) to pass \`kennelData.aliases\`.

Generic across all kennels — fixes Bristol's \`BRIS Trail\` stale rows plus any other kennel whose source emits an alias prefix.

## Test plan

- [x] 7 new \`rewriteStaleDefaultTitle\` tests cover: alias rewrite, run-number suffix preservation, longer-alias-first preference, no-op skip when alias equals displayName, no-match passthrough, kennelCode-equals-displayName + aliases-still-rewrite case, empty/whitespace alias filtering, optional-aliases back-compat
- [x] All 256 \`merge.test.ts\` pass (was 248 + 8 new)
- [x] Full suite: 5164 / 5191 pass (rest skipped)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint src/pipeline/merge.ts\` clean
- [ ] Live verification deferred — the next Bristol scrape will rewrite the 3 stale rows in production

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)