### PR TITLE
fix(google-sheets): drop lowercase single-token "city shorthand" venue values (#893)

### DIFF
--- a/src/adapters/google-sheets/adapter.test.ts
+++ b/src/adapters/google-sheets/adapter.test.ts
@@ -209,6 +209,40 @@ describe("buildEventFromSheetRow", () => {
     expect(event!.title).toBe("Real Title");
   });
 
+  it("drops all-lowercase single-token city shorthands like 'sheperdstown' (#893)", () => {
+    // W3H3 sheet row 17 (run #359) has "sheperdstown" in column D — a typo'd
+    // city name used as a venue placeholder. Without this fix the geocoder
+    // appends the resolved city → "sheperdstown, Shepherdstown, WV" double-render.
+    const row = ["359", "3/11/26", "Alice", "sheperdstown", "Trail Title"];
+    const event = buildEventFromSheetRow(row, baseConfig, "https://example.com", "2026-03-11");
+    expect(event).not.toBeNull();
+    expect(event!.location).toBeUndefined();
+    // locationUrl is gated on location, so it also drops.
+    expect(event!.locationUrl).toBeUndefined();
+  });
+
+  it("preserves capitalized one-word venue names (no false-positive on 'Subway')", () => {
+    // Capitalized one-word values could be real venues — the heuristic
+    // intentionally skips them. Capitalized city shorthands like
+    // "Charlestown" would still pass through to the geocoder; that's
+    // a downstream redundancy-suppression concern, out of scope here.
+    const row = ["359", "3/11/26", "Alice", "Subway", "Trail Title"];
+    const event = buildEventFromSheetRow(row, baseConfig, "https://example.com", "2026-03-11");
+    expect(event!.location).toBe("Subway");
+  });
+
+  it("preserves multi-word lowercase venue names (heuristic only fires on single-token)", () => {
+    const row = ["359", "3/11/26", "Alice", "the old star", "Trail Title"];
+    const event = buildEventFromSheetRow(row, baseConfig, "https://example.com", "2026-03-11");
+    expect(event!.location).toBe("the old star");
+  });
+
+  it("preserves real venue names with apostrophes/hyphens but spaces", () => {
+    const row = ["359", "3/11/26", "Alice", "Joe's Tavern", "Trail Title"];
+    const event = buildEventFromSheetRow(row, baseConfig, "https://example.com", "2026-03-11");
+    expect(event!.location).toBe("Joe's Tavern");
+  });
+
   it("applies defaultTitle with run number when title is placeholder", () => {
     const config = { ...baseConfig, defaultTitle: "Wild & Wonderful Wednesday Trail" };
     const row = ["42", "3/11/26", "Alice", "Park", "TBD"];

--- a/src/adapters/google-sheets/adapter.ts
+++ b/src/adapters/google-sheets/adapter.ts
@@ -7,6 +7,30 @@ import { safeFetch } from "../safe-fetch";
 /** Titles starting with these verbs are instructions/notes, not event names. */
 const INSTRUCTION_TITLE_RE = /^(?:bring|check|don['\u2019]t|remember|note|pack|wear)\b/i;
 
+/**
+ * Detects all-lowercase single-token values that look like city/area
+ * shorthands typed into a venue column. Some kennels (W3H3) use the same
+ * sheet column for both real venue names and city hints; the city-hint
+ * rows are usually short, lowercase, and unpunctuated (e.g. "sheperdstown",
+ * "harpers", "brunswick").
+ *
+ * Treating these as venue names produces double-rendered locations like
+ * "sheperdstown, Shepherdstown, WV" once the geocoder appends the resolved
+ * city. Returning the value as-is to the merge pipeline still leaves the
+ * geocoder with enough context to find the right place using the kennel's
+ * region bias (#893). Capitalized one-word values like "Charlestown" are
+ * intentionally NOT caught \u2014 they could be real venues (e.g. "Subway",
+ * "Roxy") and need a different signal (geocoded-city equality) handled
+ * downstream.
+ */
+function isCityShorthand(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 30) return false;
+  // Single token, all lowercase letters/apostrophes/hyphens, no whitespace
+  // or punctuation. Allows common typo'd or shorthanded city names.
+  return /^[a-z][a-z'-]+$/.test(trimmed);
+}
+
 /** Config stored in Source.config JSON for Google Sheets sources */
 export interface GoogleSheetsConfig {
   sheetId: string;
@@ -281,7 +305,13 @@ export function buildEventFromSheetRow(
 
   // Strip placeholder values (TBD, TBA, N/A, etc.)
   const hares = stripPlaceholder(row[config.columns.hares]);
-  const location = stripPlaceholder(row[config.columns.location]);
+  let location = stripPlaceholder(row[config.columns.location]);
+  // Drop all-lowercase single-token "city shorthand" values (e.g. "sheperdstown")
+  // that aren't real venue names. The merge pipeline still has the kennel's
+  // region/country bias for geocoding. See #893.
+  if (location && isCityShorthand(location)) {
+    location = undefined;
+  }
   let title = config.columns.title != null ? stripPlaceholder(row[config.columns.title]) : undefined;
 
   if (title && INSTRUCTION_TITLE_RE.test(title)) {

--- a/src/adapters/google-sheets/adapter.ts
+++ b/src/adapters/google-sheets/adapter.ts
@@ -16,12 +16,14 @@ const INSTRUCTION_TITLE_RE = /^(?:bring|check|don['\u2019]t|remember|note|pack|w
  *
  * Treating these as venue names produces double-rendered locations like
  * "sheperdstown, Shepherdstown, WV" once the geocoder appends the resolved
- * city. Returning the value as-is to the merge pipeline still leaves the
- * geocoder with enough context to find the right place using the kennel's
- * region bias (#893). Capitalized one-word values like "Charlestown" are
- * intentionally NOT caught \u2014 they could be real venues (e.g. "Subway",
- * "Roxy") and need a different signal (geocoded-city equality) handled
- * downstream.
+ * city. Dropping the value here (caller sets `location = undefined` when
+ * this returns `true`) leaves the geocoder with the kennel's region bias
+ * still pointing it at the right place — without the typo'd shorthand
+ * lingering in user-facing text (#893).
+ *
+ * Capitalized one-word values like "Charlestown" are intentionally NOT
+ * caught \u2014 they could be real venues (e.g. "Subway", "Roxy") and need
+ * a different signal (geocoded-city equality) handled downstream.
  */
 function isCityShorthand(value: string): boolean {
   const trimmed = value.trim();


### PR DESCRIPTION
## Summary

W3H3's hareline sheet (column D) is used by the kennel for both real venue names (\`The Old Star\`) and city/area hints (\`sheperdstown\`, \`harpers\`, \`brunswick\`). When the city-hint rows hit the geocoder, the resolved city gets appended to the displayed locationName, producing double-rendered strings like \`\"sheperdstown, Shepherdstown, WV\"\` — the typo'd shorthand next to the correctly-resolved city.

**Adapter-level fix**: drop column-D values that look like city shorthands — defined narrowly as **all-lowercase single tokens** (letters, apostrophes, hyphens; no whitespace; ≤ 30 chars). The merge pipeline still has the kennel's region/country bias for geocoding, so the right pin still drops on the map.

## Conservative scope

- **Capitalized one-word values** like \`Subway\` or \`Charlestown\` pass through unchanged. They could be real venues. Capitalized city shorthands are a separate downstream redundancy-suppression concern — out of scope here.
- **Multi-word lowercase** like \`the old star\` passes through.
- **Apostrophe'd venue** like \`Joe's Tavern\` passes through.

## Test plan

- [x] Drops \`sheperdstown\` + suppresses locationUrl when shorthand detected
- [x] Preserves \`Subway\`, \`the old star\`, \`Joe's Tavern\`
- [x] 58 / 58 \`google-sheets\` tests pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint src/adapters/google-sheets/adapter.ts\` clean
- [ ] Live verification deferred — next W3H3 scrape will overwrite stale row #359 via the merge UPDATE path (\`event.location !== undefined\` for the column entry, \`undefined\` after this fix → writes \`locationName: null\`)

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)