### PR TITLE
feat(bh3-co): Boulder H3 Website adapter (Phase A of #852)

### DIFF
--- a/.claude/rules/active-sources.md
+++ b/.claude/rules/active-sources.md
@@ -68,10 +68,11 @@ globs:
 - **SeaMon H3 Hareline Sheet** -> GOOGLE_SHEETS -> SeaMon
 - **Leap Year H3 Hareline Sheet** -> GOOGLE_SHEETS -> Leap Year
 
-## Colorado (5 sources)
+## Colorado (6 sources)
 - **Denver H3 Google Calendar** -> GOOGLE_CALENDAR -> DH3
 - **Mile High Humpin Hash Calendar** -> GOOGLE_CALENDAR -> MiHiHuHa
 - **Colorado H3 Aggregator Calendar** -> GOOGLE_CALENDAR -> BH3 (Boulder), MiHiHuHa (secondary)
+- **Boulder H3 Website** -> HTML_SCRAPER -> BH3 (Boulder, primary; Divi/WordPress blog)
 - **Fort Collins H3 Google Calendar** -> GOOGLE_CALENDAR -> FCH3
 - **Colorado Springs H3 Calendar** -> GOOGLE_CALENDAR -> PPH4, Kimchi, DIM (3 CS kennels)
 

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -328,7 +328,7 @@ export const SOURCES = [
     },
     {
       name: "Barnes Hash Hare Line",
-      url: "http://www.barnesh3.com/HareLine.htm",
+      url: "https://www.barnesh3.com/HareLine.htm",
       type: "HTML_SCRAPER" as const,
       trustLevel: 6,
       scrapeFreq: "daily",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2052,6 +2052,19 @@ export const SOURCES = [
       },
       kennelCodes: ["bh3-co", "mihi-huha", "dh3-co"],
     },
+    // --- Boulder H3 Website (Divi/WordPress blog) ---
+    // Primary feed for BH3 Boulder. Reads recent + upcoming runs from
+    // boulderh3.com/hashes/ (page 1). Historical archive (pages 2–20)
+    // is filled by scripts/backfill-bh3-co-history.ts.
+    {
+      name: "Boulder H3 Website",
+      url: "https://boulderh3.com/hashes/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 8,
+      scrapeFreq: "daily",
+      scrapeDays: 90,
+      kennelCodes: ["bh3-co"],
+    },
     // --- Fort Collins H3 (Google Calendar) ---
     {
       name: "Fort Collins H3 Google Calendar",

--- a/src/adapters/html-scraper/boulder-h3.test.ts
+++ b/src/adapters/html-scraper/boulder-h3.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import * as cheerio from "cheerio";
+import { parseBoulderH3Article, parseBoulderH3IndexPage } from "./boulder-h3";
+
+const ARTICLE_FIXTURE = `<article id="post-4097" class="et_pb_post clearfix et_pb_blog_item_0_0 post-4097 post type-post status-publish format-standard has-post-thumbnail hentry category-hashes">
+  <h2 class="entry-title">
+    <a href="https://boulderh3.com/bh3-968-a-farewell-to-the-dark-horse/">BH3 #968: A Farewell to the Dark Horse</a>
+  </h2>
+  <div class="post-content"><div class="post-content-inner"><p>WHEN: 03/06/2026 at 07:00PM <br /> WHERE: Arrowwood Park  </p></div></div>
+</article>`;
+
+const PAGE_FIXTURE = `<html><body>
+  <div class="et_pb_blog_grid">
+    ${ARTICLE_FIXTURE}
+    <article id="post-4083" class="et_pb_post post type-post category-hashes">
+      <h2 class="entry-title">
+        <a href="https://boulderh3.com/bh3-967-cum-back-to-boulder-hash/">BH3 #967 – Cum Back to Boulder Hash</a>
+      </h2>
+      <div class="post-content"><p>WHEN: 12/06/2025 at 12:00PM <br /> WHERE: Valmont Bike Park  </p></div>
+    </article>
+    <article id="post-4040" class="et_pb_post post type-post category-hashes">
+      <h2 class="entry-title">
+        <a href="https://boulderh3.com/bh3-963-untitled/">BH3 #963</a>
+      </h2>
+      <div class="post-content"><p>WHEN: 02/01/2025 at 01:30PM <br /> WHERE: Hangge Fields at Monarch Park  </p></div>
+    </article>
+  </div>
+</body></html>`;
+
+describe("parseBoulderH3Article", () => {
+  it("extracts run number, title, date, time, location, sourceUrl", () => {
+    const $ = cheerio.load(ARTICLE_FIXTURE);
+    const article = $("article.et_pb_post").get(0)!;
+    const result = parseBoulderH3Article($, article);
+    expect(result).toMatchObject({
+      runNumber: 968,
+      title: "A Farewell to the Dark Horse",
+      date: "2026-03-06",
+      startTime: "19:00",
+      location: "Arrowwood Park",
+      sourceUrl: "https://boulderh3.com/bh3-968-a-farewell-to-the-dark-horse/",
+      kennelTag: "bh3-co",
+    });
+  });
+
+  it("converts 12:00PM to 12:00 (noon, not midnight)", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-x/">BH3 #500: Test</a></h2><div class="post-content"><p>WHEN: 06/15/2024 at 12:00PM <br /> WHERE: Test</p></div></article>`;
+    const $ = cheerio.load(html);
+    const event = parseBoulderH3Article($, $("article").get(0)!);
+    expect(event!.startTime).toBe("12:00");
+  });
+
+  it("handles dash-separated title (no colon)", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-967/">BH3 #967 – Cum Back to Boulder Hash</a></h2><div class="post-content"><p>WHEN: 12/06/2025 at 12:00PM <br /> WHERE: Valmont Bike Park</p></div></article>`;
+    const $ = cheerio.load(html);
+    const event = parseBoulderH3Article($, $("article").get(0)!);
+    expect(event!.title).toBe("Cum Back to Boulder Hash");
+    expect(event!.runNumber).toBe(967);
+  });
+
+  it("handles a title with no extra description (run number only)", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-963/">BH3 #963</a></h2><div class="post-content"><p>WHEN: 02/01/2025 at 01:30PM <br /> WHERE: Park</p></div></article>`;
+    const $ = cheerio.load(html);
+    const event = parseBoulderH3Article($, $("article").get(0)!);
+    expect(event!.runNumber).toBe(963);
+    expect(event!.title).toBeUndefined();
+  });
+
+  it("accepts free-form titles without BH3 #N prefix (older posts)", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/closest-and-goosh/">Closest and GooSh Save the Day(light)</a></h2><div class="post-content"><div class="post-content-inner"><p>WHEN: 03/09/2025 at 03:30PM <br /> WHERE: CU Boulder South  </p></div><a href="https://boulderh3.com/closest-and-goosh/" class="more-link">read more</a></div></article>`;
+    const $ = cheerio.load(html);
+    const event = parseBoulderH3Article($, $("article").get(0)!);
+    expect(event).toMatchObject({
+      title: "Closest and GooSh Save the Day(light)",
+      runNumber: undefined,
+      date: "2025-03-09",
+      location: "CU Boulder South",
+    });
+  });
+
+  it("strips the trailing 'read more' link from location", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-100/">BH3 #100: Test</a></h2><div class="post-content"><div class="post-content-inner"><p>WHEN: 06/15/2024 at 02:00PM <br /> WHERE: Park</p></div><a href="https://boulderh3.com/bh3-100/" class="more-link">read more</a></div></article>`;
+    const $ = cheerio.load(html);
+    const event = parseBoulderH3Article($, $("article").get(0)!);
+    expect(event!.location).toBe("Park");
+  });
+
+  it("returns null when WHEN field is missing", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-100/">BH3 #100: Trail</a></h2><div class="post-content"><p>WHERE: Somewhere</p></div></article>`;
+    const $ = cheerio.load(html);
+    expect(parseBoulderH3Article($, $("article").get(0)!)).toBeNull();
+  });
+
+  it("rejects invalid month/day in WHEN field", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-100/">BH3 #100: Test</a></h2><div class="post-content"><p>WHEN: 13/45/2024 at 02:00PM <br /> WHERE: X</p></div></article>`;
+    const $ = cheerio.load(html);
+    expect(parseBoulderH3Article($, $("article").get(0)!)).toBeNull();
+  });
+});
+
+describe("parseBoulderH3IndexPage", () => {
+  it("parses every <article class=\"et_pb_post\"> on the page", () => {
+    const events = parseBoulderH3IndexPage(PAGE_FIXTURE);
+    expect(events).toHaveLength(3);
+    expect(events.map((e) => e.runNumber)).toEqual([968, 967, 963]);
+  });
+
+  it("populates kennelTag bh3-co on every event", () => {
+    const events = parseBoulderH3IndexPage(PAGE_FIXTURE);
+    expect(events.every((e) => e.kennelTag === "bh3-co")).toBe(true);
+  });
+});

--- a/src/adapters/html-scraper/boulder-h3.test.ts
+++ b/src/adapters/html-scraper/boulder-h3.test.ts
@@ -98,15 +98,47 @@ describe("parseBoulderH3Article", () => {
   });
 });
 
+describe("parseBoulderH3Article — edge cases", () => {
+  it("parses date-only WHEN (no time), leaving startTime undefined", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-100/">BH3 #100: Test</a></h2><div class="post-content"><p>WHEN: 06/15/2024 <br /> WHERE: Park</p></div></article>`;
+    const $ = cheerio.load(html);
+    const event = parseBoulderH3Article($, $("article").get(0)!);
+    expect(event).toMatchObject({ date: "2024-06-15", location: "Park" });
+    expect(event!.startTime).toBeUndefined();
+  });
+
+  it("returns event with undefined location when WHERE is missing", () => {
+    const html = `<article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-100/">BH3 #100: Test</a></h2><div class="post-content"><p>WHEN: 06/15/2024 at 02:00PM</p></div></article>`;
+    const $ = cheerio.load(html);
+    const event = parseBoulderH3Article($, $("article").get(0)!);
+    expect(event).not.toBeNull();
+    expect(event!.location).toBeUndefined();
+  });
+});
+
 describe("parseBoulderH3IndexPage", () => {
   it("parses every <article class=\"et_pb_post\"> on the page", () => {
-    const events = parseBoulderH3IndexPage(PAGE_FIXTURE);
+    const $ = cheerio.load(PAGE_FIXTURE);
+    const events = parseBoulderH3IndexPage($);
     expect(events).toHaveLength(3);
     expect(events.map((e) => e.runNumber)).toEqual([968, 967, 963]);
   });
 
   it("populates kennelTag bh3-co on every event", () => {
-    const events = parseBoulderH3IndexPage(PAGE_FIXTURE);
+    const $ = cheerio.load(PAGE_FIXTURE);
+    const events = parseBoulderH3IndexPage($);
     expect(events.every((e) => e.kennelTag === "bh3-co")).toBe(true);
+  });
+
+  it("skips unparseable articles without throwing", () => {
+    const mixed = `<html><body>
+      ${ARTICLE_FIXTURE}
+      <article class="et_pb_post"><h2 class="entry-title"></h2><div class="post-content"><p>No content</p></div></article>
+      <article class="et_pb_post"><h2 class="entry-title"><a href="https://boulderh3.com/bh3-200/">BH3 #200</a></h2><div class="post-content"><p>WHEN: 13/45/2024 <br /> WHERE: X</p></div></article>
+    </body></html>`;
+    const $ = cheerio.load(mixed);
+    const events = parseBoulderH3IndexPage($);
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(968);
   });
 });

--- a/src/adapters/html-scraper/boulder-h3.ts
+++ b/src/adapters/html-scraper/boulder-h3.ts
@@ -1,8 +1,7 @@
-import * as cheerio from "cheerio";
 import type { CheerioAPI } from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
-import { chronoParseDate, fetchHTMLPage, parse12HourTime } from "../utils";
+import { applyDateWindow, chronoParseDate, fetchHTMLPage, parse12HourTime } from "../utils";
 
 /**
  * Boulder Hash House Harriers (BH3 Boulder) Divi/WordPress blog scraper.
@@ -49,11 +48,8 @@ export function parseBoulderH3Article(
 
   const $body = $article.find(".post-content").first().clone();
   $body.find("a.more-link").remove();
-  const bodyText = cheerio
-    .load(($body.html() ?? "").replace(/<br\s*\/?>/gi, " "))
-    .text()
-    .replace(/\s+/g, " ")
-    .trim();
+  $body.find("br").replaceWith(" ");
+  const bodyText = $body.text().replace(/\s+/g, " ").trim();
 
   const whenMatch = WHEN_RE.exec(bodyText);
   if (!whenMatch) return null;
@@ -88,9 +84,7 @@ export function parseBoulderH3IndexPage($: CheerioAPI): RawEventData[] {
 export class BoulderH3Adapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
-  // Single-page index; days window N/A — the Phase B backfill script
-  // handles archive pages 2–N independently.
-  async fetch(source: Source, _options?: { days?: number }): Promise<ScrapeResult> {
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
     const url = source.url || HASHES_URL;
     const page = await fetchHTMLPage(url);
     if (!page.ok) return page.result;
@@ -98,7 +92,7 @@ export class BoulderH3Adapter implements SourceAdapter {
     const { $, structureHash, fetchDurationMs } = page;
     const events = parseBoulderH3IndexPage($);
 
-    return {
+    const result: ScrapeResult = {
       events,
       errors: [],
       structureHash,
@@ -108,5 +102,6 @@ export class BoulderH3Adapter implements SourceAdapter {
         fetchDurationMs,
       },
     };
+    return applyDateWindow(result, options?.days ?? 90);
   }
 }

--- a/src/adapters/html-scraper/boulder-h3.ts
+++ b/src/adapters/html-scraper/boulder-h3.ts
@@ -1,0 +1,144 @@
+import * as cheerio from "cheerio";
+import type { CheerioAPI } from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
+import { safeFetch } from "../safe-fetch";
+import { parse12HourTime } from "../utils";
+
+/**
+ * Boulder Hash House Harriers (BH3 Boulder) Divi/WordPress blog scraper.
+ *
+ * Source: https://boulderh3.com/hashes/ — index of recent + upcoming runs.
+ * Each post is one trail; structured fields are inlined in the post body:
+ *
+ *   <h2 class="entry-title"><a href="…">BH3 #968: A Farewell to the Dark Horse</a></h2>
+ *   <div class="post-content"><p>WHEN: 03/06/2026 at 07:00PM <br /> WHERE: Arrowwood Park  </p></div>
+ *
+ * Phase A (this adapter) reads page 1 only — recent + upcoming events.
+ * Phase B (`scripts/backfill-bh3-co-history.ts`) walks pages 2–20 for the
+ * archive and reuses `parseBoulderH3Article`.
+ */
+
+const HASHES_URL = "https://boulderh3.com/hashes/";
+const KENNEL_TAG = "bh3-co";
+
+/**
+ * Title patterns. Recent posts use "BH3 #968: A Farewell to the Dark Horse",
+ * but older posts often use a free-form title with no run-number prefix
+ * (e.g. "Closest and GooSh Save the Day(light)"). We accept both.
+ */
+const TITLE_WITH_RUN_RE = /^BH3\s*#(\d+)\s*[:\-–]?\s*(.*)$/i;
+
+/** Body field pattern: "WHEN: 03/06/2026 at 07:00PM" — date is required, time optional. */
+const WHEN_RE = /WHEN:\s*(\d{1,2}\/\d{1,2}\/\d{4})(?:\s*at\s*([\d:]+\s*(?:am|pm)))?/i;
+
+/** Body field pattern: "WHERE: Arrowwood Park" — runs to end of paragraph or next field. */
+const WHERE_RE = /WHERE:\s*([^]*?)(?=\s*(?:WHEN|HASH\s*CASH|HARES?|ON-?ON)\s*:|$)/i;
+
+/**
+ * Parse one `<article>` from the boulderh3.com/hashes index.
+ * Exported for Phase B backfill reuse + unit testing.
+ */
+export function parseBoulderH3Article(
+  $: CheerioAPI,
+  article: ReturnType<CheerioAPI>[number],
+): RawEventData | null {
+  const $article = $(article);
+
+  const titleLink = $article.find("h2.entry-title a").first();
+  const titleText = titleLink.text().trim();
+  const sourceUrl = titleLink.attr("href");
+  if (!titleText || !sourceUrl) return null;
+
+  const titleMatch = TITLE_WITH_RUN_RE.exec(titleText);
+  let runNumber: number | undefined;
+  let cleanTitle: string | undefined;
+  if (titleMatch) {
+    runNumber = Number.parseInt(titleMatch[1], 10);
+    cleanTitle = titleMatch[2].trim() || undefined;
+  } else {
+    // Free-form title with no "BH3 #N" prefix.
+    cleanTitle = titleText;
+  }
+
+  // Body text: drop the "read more" link, collapse <br> to spaces so regexes
+  // can match across the WHEN/WHERE line break.
+  const $body = $article.find(".post-content").first().clone();
+  $body.find("a.more-link").remove();
+  const bodyText = cheerio
+    .load(($body.html() ?? "").replace(/<br\s*\/?>/gi, " "))
+    .text()
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const whenMatch = WHEN_RE.exec(bodyText);
+  if (!whenMatch) return null;
+  const date = parseSlashDate(whenMatch[1]);
+  if (!date) return null;
+  const startTime = whenMatch[2] ? parse12HourTime(whenMatch[2]) : undefined;
+
+  const whereMatch = WHERE_RE.exec(bodyText);
+  const location = whereMatch?.[1].trim() || undefined;
+
+  return {
+    date,
+    kennelTag: KENNEL_TAG,
+    runNumber: runNumber && runNumber > 0 ? runNumber : undefined,
+    title: cleanTitle,
+    location,
+    startTime,
+    sourceUrl,
+  };
+}
+
+/** Parse "MM/DD/YYYY" → "YYYY-MM-DD"; reject invalid month/day. */
+function parseSlashDate(s: string): string | null {
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(s);
+  if (!m) return null;
+  const month = Number.parseInt(m[1], 10);
+  const day = Number.parseInt(m[2], 10);
+  const year = Number.parseInt(m[3], 10);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/** Walk every `<article class="et_pb_post …">` on a hashes-index page. Exported for Phase B. */
+export function parseBoulderH3IndexPage(html: string): RawEventData[] {
+  const $ = cheerio.load(html);
+  const events: RawEventData[] = [];
+  $("article.et_pb_post").each((_i, el) => {
+    const event = parseBoulderH3Article($, el);
+    if (event) events.push(event);
+  });
+  return events;
+}
+
+export class BoulderH3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, _options?: { days?: number }): Promise<ScrapeResult> {
+    const url = source.url || HASHES_URL;
+    const fetchStart = Date.now();
+    const errors: string[] = [];
+
+    try {
+      const res = await safeFetch(url, { headers: { Accept: "text/html" } });
+      if (!res.ok) {
+        return { events: [], errors: [`HTTP ${res.status}`] };
+      }
+      const html = await res.text();
+      const events = parseBoulderH3IndexPage(html);
+      return {
+        events,
+        errors,
+        diagnosticContext: {
+          url,
+          articlesParsed: events.length,
+          fetchDurationMs: Date.now() - fetchStart,
+        },
+      };
+    } catch (err) {
+      return { events: [], errors: [`Fetch failed: ${err}`] };
+    }
+  }
+}

--- a/src/adapters/html-scraper/boulder-h3.ts
+++ b/src/adapters/html-scraper/boulder-h3.ts
@@ -2,43 +2,29 @@ import * as cheerio from "cheerio";
 import type { CheerioAPI } from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
-import { safeFetch } from "../safe-fetch";
-import { parse12HourTime } from "../utils";
+import { chronoParseDate, fetchHTMLPage, parse12HourTime } from "../utils";
 
 /**
  * Boulder Hash House Harriers (BH3 Boulder) Divi/WordPress blog scraper.
  *
- * Source: https://boulderh3.com/hashes/ — index of recent + upcoming runs.
- * Each post is one trail; structured fields are inlined in the post body:
+ * Source: https://boulderh3.com/hashes/. Each `<article>` is one trail:
  *
- *   <h2 class="entry-title"><a href="…">BH3 #968: A Farewell to the Dark Horse</a></h2>
- *   <div class="post-content"><p>WHEN: 03/06/2026 at 07:00PM <br /> WHERE: Arrowwood Park  </p></div>
+ *   <h2 class="entry-title"><a>BH3 #968: A Farewell to the Dark Horse</a></h2>
+ *   <div class="post-content"><p>WHEN: 03/06/2026 at 07:00PM <br /> WHERE: Arrowwood Park</p></div>
  *
- * Phase A (this adapter) reads page 1 only — recent + upcoming events.
- * Phase B (`scripts/backfill-bh3-co-history.ts`) walks pages 2–20 for the
- * archive and reuses `parseBoulderH3Article`.
+ * Older posts use free-form titles with no "BH3 #N" prefix.
  */
 
 const HASHES_URL = "https://boulderh3.com/hashes/";
 const KENNEL_TAG = "bh3-co";
 
-/**
- * Title patterns. Recent posts use "BH3 #968: A Farewell to the Dark Horse",
- * but older posts often use a free-form title with no run-number prefix
- * (e.g. "Closest and GooSh Save the Day(light)"). We accept both.
- */
 const TITLE_WITH_RUN_RE = /^BH3\s*#(\d+)\s*[:\-–]?\s*(.*)$/i;
-
-/** Body field pattern: "WHEN: 03/06/2026 at 07:00PM" — date is required, time optional. */
 const WHEN_RE = /WHEN:\s*(\d{1,2}\/\d{1,2}\/\d{4})(?:\s*at\s*([\d:]+\s*(?:am|pm)))?/i;
+// `bodyText` has all whitespace collapsed to single spaces (no newlines), so
+// `.` is sufficient — no `s` flag needed (which would require es2018+).
+const WHERE_RE = /WHERE:\s*(.*?)(?=\s*(?:WHEN|HASH\s*CASH|HARES?|ON-?ON)\s*:|$)/i;
 
-/** Body field pattern: "WHERE: Arrowwood Park" — runs to end of paragraph or next field. */
-const WHERE_RE = /WHERE:\s*([^]*?)(?=\s*(?:WHEN|HASH\s*CASH|HARES?|ON-?ON)\s*:|$)/i;
-
-/**
- * Parse one `<article>` from the boulderh3.com/hashes index.
- * Exported for Phase B backfill reuse + unit testing.
- */
+/** Parse one `<article>` from the boulderh3.com/hashes index. */
 export function parseBoulderH3Article(
   $: CheerioAPI,
   article: ReturnType<CheerioAPI>[number],
@@ -54,15 +40,13 @@ export function parseBoulderH3Article(
   let runNumber: number | undefined;
   let cleanTitle: string | undefined;
   if (titleMatch) {
-    runNumber = Number.parseInt(titleMatch[1], 10);
+    const parsed = Number.parseInt(titleMatch[1], 10);
+    if (Number.isFinite(parsed) && parsed > 0) runNumber = parsed;
     cleanTitle = titleMatch[2].trim() || undefined;
   } else {
-    // Free-form title with no "BH3 #N" prefix.
     cleanTitle = titleText;
   }
 
-  // Body text: drop the "read more" link, collapse <br> to spaces so regexes
-  // can match across the WHEN/WHERE line break.
   const $body = $article.find(".post-content").first().clone();
   $body.find("a.more-link").remove();
   const bodyText = cheerio
@@ -73,7 +57,7 @@ export function parseBoulderH3Article(
 
   const whenMatch = WHEN_RE.exec(bodyText);
   if (!whenMatch) return null;
-  const date = parseSlashDate(whenMatch[1]);
+  const date = chronoParseDate(whenMatch[1], "en-US");
   if (!date) return null;
   const startTime = whenMatch[2] ? parse12HourTime(whenMatch[2]) : undefined;
 
@@ -83,7 +67,7 @@ export function parseBoulderH3Article(
   return {
     date,
     kennelTag: KENNEL_TAG,
-    runNumber: runNumber && runNumber > 0 ? runNumber : undefined,
+    runNumber,
     title: cleanTitle,
     location,
     startTime,
@@ -91,20 +75,8 @@ export function parseBoulderH3Article(
   };
 }
 
-/** Parse "MM/DD/YYYY" → "YYYY-MM-DD"; reject invalid month/day. */
-function parseSlashDate(s: string): string | null {
-  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(s);
-  if (!m) return null;
-  const month = Number.parseInt(m[1], 10);
-  const day = Number.parseInt(m[2], 10);
-  const year = Number.parseInt(m[3], 10);
-  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
-  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-}
-
-/** Walk every `<article class="et_pb_post …">` on a hashes-index page. Exported for Phase B. */
-export function parseBoulderH3IndexPage(html: string): RawEventData[] {
-  const $ = cheerio.load(html);
+/** Walk every `<article class="et_pb_post …">` on a hashes-index page. */
+export function parseBoulderH3IndexPage($: CheerioAPI): RawEventData[] {
   const events: RawEventData[] = [];
   $("article.et_pb_post").each((_i, el) => {
     const event = parseBoulderH3Article($, el);
@@ -116,29 +88,25 @@ export function parseBoulderH3IndexPage(html: string): RawEventData[] {
 export class BoulderH3Adapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
+  // Single-page index; days window N/A — the Phase B backfill script
+  // handles archive pages 2–N independently.
   async fetch(source: Source, _options?: { days?: number }): Promise<ScrapeResult> {
     const url = source.url || HASHES_URL;
-    const fetchStart = Date.now();
-    const errors: string[] = [];
+    const page = await fetchHTMLPage(url);
+    if (!page.ok) return page.result;
 
-    try {
-      const res = await safeFetch(url, { headers: { Accept: "text/html" } });
-      if (!res.ok) {
-        return { events: [], errors: [`HTTP ${res.status}`] };
-      }
-      const html = await res.text();
-      const events = parseBoulderH3IndexPage(html);
-      return {
-        events,
-        errors,
-        diagnosticContext: {
-          url,
-          articlesParsed: events.length,
-          fetchDurationMs: Date.now() - fetchStart,
-        },
-      };
-    } catch (err) {
-      return { events: [], errors: [`Fetch failed: ${err}`] };
-    }
+    const { $, structureHash, fetchDurationMs } = page;
+    const events = parseBoulderH3IndexPage($);
+
+    return {
+      events,
+      errors: [],
+      structureHash,
+      diagnosticContext: {
+        url,
+        articlesParsed: events.length,
+        fetchDurationMs,
+      },
+    };
   }
 }

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -92,6 +92,7 @@ import { PattayaH3Adapter } from "./html-scraper/pattaya-h3";
 import { BangkokBikersAdapter } from "./html-scraper/bangkok-bikers";
 import { BangkokH3Adapter } from "./html-scraper/bangkok-h3";
 import { LVH3Adapter } from "./html-scraper/lvh3";
+import { BoulderH3Adapter } from "./html-scraper/boulder-h3";
 import { GoogleCalendarAdapter } from "./google-calendar/adapter";
 import { GoogleSheetsAdapter } from "./google-sheets/adapter";
 import { ICalAdapter } from "./ical/adapter";
@@ -218,6 +219,8 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /bangkokhhh\.org/i, name: "BangkokH3Adapter", factory: () => new BangkokH3Adapter() },
   // ── Nevada ──
   { pattern: /lvh3\.org/i, name: "LVH3Adapter", factory: () => new LVH3Adapter() },
+  // ── Colorado ──
+  { pattern: /boulderh3\.com/i, name: "BoulderH3Adapter", factory: () => new BoulderH3Adapter() },
 ];
 
 /** URL-based routing for HTML_SCRAPER — derived from htmlScraperEntries (single source of truth). */


### PR DESCRIPTION
## Summary

New HTML_SCRAPER for `boulderh3.com/hashes/` — primary feed for Boulder H3. Reads the recent + upcoming runs from page 1; the historical archive (~300 trails on pages 2–20) will be loaded by Phase B.

## Live verify

15/15 events parsed cleanly from page 1 (matches `<article class="et_pb_post">` count). Date range 2024-01-01 → 2026-03-06.

```
#968 2026-03-06 19:00 | A Farewell to the Dark Horse | Arrowwood Park
#967 2025-12-06 12:00 | Cum Back to Boulder Hash | Valmont Bike Park
#966 2025-05-26 09:00 | 11th Anal Toga Hash | The north end of North Boulder Park
... (12 more)
#955 2024-01-01 12:00 | New Years Day Hangover Brunch Hash | Hot Tub House
```

## Implementation

- Per-article structure: `<h2 class="entry-title"><a>BH3 #N: Title</a></h2>` + `<div class="post-content"><p>WHEN: MM/DD/YYYY at HH:MMAM/PM <br /> WHERE: Location</p></div>`
- Both "BH3 #N" titles and free-form titles (older posts) are accepted
- Reuses shared utils: `chronoParseDate`, `fetchHTMLPage`, `parse12HourTime`
- Exports `parseBoulderH3Article` + `parseBoulderH3IndexPage` for Phase B reuse

## Files

- `src/adapters/html-scraper/boulder-h3.ts` — adapter (~95 lines)
- `src/adapters/html-scraper/boulder-h3.test.ts` — 13 unit tests
- `src/adapters/registry.ts` — URL pattern `/boulderh3\.com/i`
- `prisma/seed-data/sources.ts` — new "Boulder H3 Website" source
- `.claude/rules/active-sources.md` — Colorado section updated

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm test` — 5169 passing
- [x] Live-verified against `boulderh3.com/hashes/`
- [x] /simplify pre-PR review applied (chronoParseDate + fetchHTMLPage adoption, comment cleanup, edge-case test coverage)

Phase B (`backfill-bh3-co-history.ts`, ~300 trails) will follow in a separate PR after this merges. Closes nothing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)