### PR TITLE
feat(bh3-co): historical backfill (Phase B of #852)

### DIFF
--- a/scripts/backfill-bh3-co-history.ts
+++ b/scripts/backfill-bh3-co-history.ts
@@ -1,0 +1,101 @@
+/**
+ * One-shot historical backfill for Boulder H3 (BH3 Boulder).
+ *
+ * Walks `/hashes/` pages 1–N of boulderh3.com and feeds every article
+ * through the merge pipeline. Phase A's adapter only ingests page 1
+ * within a 90-day window — the archive (~300 trails back to early
+ * 2010s) lives on pages 2–20 and would never reach canonical Events
+ * without this script.
+ *
+ * Reuses Phase A's exported parser (`parseBoulderH3IndexPage`), so the
+ * backfill stays in sync with the live adapter on field extraction.
+ *
+ * Re-runnable: `reportAndApplyBackfill` routes through `processRawEvents`,
+ * which dedupes by fingerprint on every row.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-bh3-co-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-bh3-co-history.ts
+ *   Env:      BACKFILL_ALLOW_SELF_SIGNED_CERT=1 (Railway proxy)
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import { reportAndApplyBackfill } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { parseBoulderH3IndexPage } from "@/adapters/html-scraper/boulder-h3";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Boulder H3 Website";
+const KENNEL_TIMEZONE = "America/Denver";
+const BASE_URL = "https://boulderh3.com/hashes/";
+const MAX_PAGES = 30; // Safety cap; current archive is 20 pages.
+
+async function fetchPage(page: number): Promise<string | null> {
+  const url = page === 1 ? BASE_URL : `${BASE_URL}page/${page}/`;
+  const res = await safeFetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)",
+      Accept: "text/html",
+    },
+  });
+  if (!res.ok) {
+    console.warn(`  Page ${page}: HTTP ${res.status}, stopping`);
+    return null;
+  }
+  return res.text();
+}
+
+async function fetchAllArchive(): Promise<RawEventData[]> {
+  const all: RawEventData[] = [];
+  let emptyStreak = 0;
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const html = await fetchPage(page);
+    if (!html) break;
+    const $ = cheerio.load(html);
+    const articleCount = $("article.et_pb_post").length;
+    const events = parseBoulderH3IndexPage($);
+    if (articleCount > 0 && events.length === 0) {
+      // Older archive posts use free-form prose ("When: Saturday, April 25th
+      // @ 2:30") rather than the structured "WHEN: MM/DD/YYYY" the parser
+      // expects. Logged for visibility; cleanup is out of scope for this
+      // phase — would need Gemini-assisted parsing like the CFH3 archive.
+      console.log(`  Page ${page}: ${articleCount} articles, 0 parsed (older free-form format — skipped)`);
+    } else {
+      console.log(`  Page ${page}: parsed ${events.length}/${articleCount} articles`);
+    }
+    if (articleCount === 0) {
+      emptyStreak++;
+      if (emptyStreak >= 2) {
+        console.log("  Two consecutive empty pages — assuming end of archive.");
+        break;
+      }
+    } else {
+      emptyStreak = 0;
+      all.push(...events);
+    }
+  }
+  return all;
+}
+
+async function main() {
+  const apply = process.env.BACKFILL_APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
+
+  console.log("\n[1/2] Walking boulderh3.com/hashes/ archive...");
+  const events = await fetchAllArchive();
+  console.log(`  Total articles parsed: ${events.length}`);
+
+  console.log("\n[2/2] Reporting + applying...");
+  await reportAndApplyBackfill({
+    apply,
+    sourceName: SOURCE_NAME,
+    events,
+    kennelTimezone: KENNEL_TIMEZONE,
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/boulder-h3.ts
+++ b/src/adapters/html-scraper/boulder-h3.ts
@@ -17,7 +17,10 @@ import { applyDateWindow, chronoParseDate, fetchHTMLPage, parse12HourTime } from
 const HASHES_URL = "https://boulderh3.com/hashes/";
 const KENNEL_TAG = "bh3-co";
 
-const TITLE_WITH_RUN_RE = /^BH3\s*#(\d+)\s*[:\-–]?\s*(.*)$/i;
+// Strip the optional `[BH3]` / `[Boulder H3]` prefix some older posts use,
+// then accept "BH3 #N" or "BH3 # N" with optional whitespace around `#`.
+const TITLE_PREFIX_RE = /^\[?\s*(?:Boulder\s+)?BH3\s*\]?\s*/i;
+const TITLE_WITH_RUN_RE = /^BH3\s*#\s*(\d+)\s*[:\-–]?\s*(.*)$/i;
 const WHEN_RE = /WHEN:\s*(\d{1,2}\/\d{1,2}\/\d{4})(?:\s*at\s*([\d:]+\s*(?:am|pm)))?/i;
 // `bodyText` has all whitespace collapsed to single spaces (no newlines), so
 // `.` is sufficient — no `s` flag needed (which would require es2018+).
@@ -35,7 +38,8 @@ export function parseBoulderH3Article(
   const sourceUrl = titleLink.attr("href");
   if (!titleText || !sourceUrl) return null;
 
-  const titleMatch = TITLE_WITH_RUN_RE.exec(titleText);
+  const normalizedTitle = titleText.replace(TITLE_PREFIX_RE, "BH3 ").trim();
+  const titleMatch = TITLE_WITH_RUN_RE.exec(normalizedTitle);
   let runNumber: number | undefined;
   let cleanTitle: string | undefined;
   if (titleMatch) {


### PR DESCRIPTION
## Summary

Phase B of #852 — walks `boulderh3.com/hashes/` pages 1–N and routes the archive through the shared merge pipeline. Captures **191 trails from 2015-10-31 → 2026-03-06** covering BH3 #735–#968.

## Out of scope

The pre-2015 archive (~117 articles on pages 14–20) uses a free-form prose format:

> "When: Saturday, April 25th @ 2:30"
> "What: A hash When: Saturday 20 Jun @ 1800 (that's 5:69 pm or 5:00 pm Beano Time)"

vs. the structured format the parser handles:

> "WHEN: 04/25/2015 at 02:30PM <br /> WHERE: …"

Capturing the older archive needs per-post year inference and Gemini-style cleanup (like the CFH3 backfill). Logged + skipped intentionally with a clear "older free-form format — skipped" message. Will follow up separately.

## Adapter tweaks (also help the live Phase A scraper)

- Strip leading `[BH3]` / `[Boulder H3]` brackets from titles
- Allow whitespace between `#` and number (`"BH3 # 748: …"`)

## Dry run output

```
[1/2] Walking boulderh3.com/hashes/ archive...
  Page 1: parsed 15/15 articles
  ...
  Page 13: parsed 14/15 articles
  Page 14: 15 articles, 0 parsed (older free-form format — skipped)
  ...
  Page 20: 12 articles, 0 parsed (older free-form format — skipped)
  Page 21: parsed 0/0 articles
  Page 22: parsed 0/0 articles
  Two consecutive empty pages — assuming end of archive.
  Total articles parsed: 191

[2/2] Reporting + applying...
  Partition: 191 past rows, 0 skipped (date >= 2026-04-26)

Date range: 2015-10-31 → 2026-03-06
Samples (oldest, middle, newest):
  #? 2015-10-31 | title=Tricks Treats and Sexy Man Meats | ...
  #? 2018-10-06 | title=The Devil's Triangle: A Drinking Game Hash! | ...
  #968 2026-03-06 | title=A Farewell to the Dark Horse | ...
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` — 5219 passing (Phase A's 13 boulder-h3 tests still green)
- [x] Live verify: 191 articles parsed across 13 pages from `boulderh3.com/hashes/`
- [x] /simplify review applied — verdict: ship as-is

After merge: I'll run `BACKFILL_APPLY=1` against prod to insert the 191 historical RawEvents (and merge into canonical Events in the same pass via the shared pipeline).

Closes #852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)