### PR TITLE
refactor(travel): per-card polish — runNumber dedup + PossibleRow link

### DIFF
--- a/src/components/travel/ConfirmedCard.tsx
+++ b/src/components/travel/ConfirmedCard.tsx
@@ -185,7 +185,12 @@ export function ConfirmedCard({ result }: ConfirmedCardProps) {
             {result.kennelRegion && (
               <RegionBadge region={result.kennelRegion} size="sm" />
             )}
-            {result.runNumber && (
+            {/* Suppress when the headline already names the run (e.g.
+                "London Hash Run #2832"). Many adapters bake the run
+                number into the title, so showing it again as a pill is
+                visual noise. The pill stays for sources whose titles
+                use a different pattern (or none at all). */}
+            {result.runNumber && !headline.includes(`#${result.runNumber}`) && (
               <span className="flex-shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/50">
                 #{result.runNumber}
               </span>

--- a/src/components/travel/PossibleRow.tsx
+++ b/src/components/travel/PossibleRow.tsx
@@ -1,9 +1,11 @@
 import { ExternalLink } from "lucide-react";
+import Link from "next/link";
 import { KennelNameTooltip } from "@/components/shared/KennelNameTooltip";
 import { formatDistanceShort, formatDateCompact } from "@/lib/travel/format";
 
 export interface PossibleRowData {
   kennelId: string;
+  kennelSlug: string;
   kennelName: string;
   kennelFullName: string;
   distanceKm: number;
@@ -29,12 +31,25 @@ export function PossibleRow({ result }: { result: PossibleRowData }) {
     <div className="border-b border-border/60 py-3 last:border-b-0">
       <div className="text-sm font-medium text-muted-foreground">
         <KennelNameTooltip fullName={result.kennelFullName}>
-          <span
-            title={result.kennelFullName || undefined}
-            className={result.kennelFullName ? "cursor-help" : undefined}
-          >
-            {result.kennelName}
-          </span>
+          {result.kennelSlug ? (
+            <Link
+              href={`/kennels/${result.kennelSlug}`}
+              title={result.kennelFullName || undefined}
+              className="hover:text-foreground hover:underline"
+            >
+              {result.kennelName}
+            </Link>
+          ) : (
+            // Defensive: search.ts:648 falls back to "" when the kennel
+            // record can't be resolved. Linking to /kennels/ would 404,
+            // so render an inert span — strictly better than a broken link.
+            <span
+              title={result.kennelFullName || undefined}
+              className={result.kennelFullName ? "cursor-help" : undefined}
+            >
+              {result.kennelName}
+            </span>
+          )}
         </KennelNameTooltip>
       </div>
       <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground/70">


### PR DESCRIPTION
## Summary
Two surgical polish items, both **grounded by live UI verification** on production hashtracks.xyz (Chrome MCP) rather than JSX-scout-only:

1. **ConfirmedCard runNumber pill** — titles like "London Hash Run #2832" already include the run number, so the standalone `#2832` font-mono pill in row 2 was visual noise. Now suppressed when `headline.includes(\`#${runNumber}\`)`. Pill stays for sources whose title doesn't bake one in (no real-world cases observed in prod, but the fallback path also produces `#`-containing strings via `getDisplayTitle`).
2. **PossibleRow kennel name** — was a non-clickable `<span title=… cursor-help>`, while sibling ConfirmedCard / LikelyCard render it as a Next `<Link href="/kennels/${slug}">`. PossibleRow now matches. Added `kennelSlug` to `PossibleRowData` and an empty-slug guard that falls back to the original inert span (search.ts:648 can resolve to `""`).

## Pre-PR review loop
- **`/simplify`** flagged the empty-slug 404 risk — guard added before push.
- **`/codex:adversarial-review`** approved, no material findings. Suggested follow-up: small component tests for the two new branches (deferred — RTL harness for travel components still pending across the project).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npx vitest run` — 5111 passed (baseline)
- [x] **Live verification on production**: ConfirmedCard duplication and PossibleRow non-link both reproduced via Chrome MCP DOM inspection on `/travel?q=London`
- [ ] Manual Chrome on Vercel preview: confirm pill no longer renders + PossibleRow kennel-name navigates to kennel page

🤖 Generated with [Claude Code](https://claude.com/claude-code)