### PR TITLE
feat(static-schedule): BYMONTH support for seasonal kennels

### DIFF
--- a/src/adapters/static-schedule/adapter.test.ts
+++ b/src/adapters/static-schedule/adapter.test.ts
@@ -14,6 +14,8 @@ import type { Source } from "@/generated/prisma/client";
 const WEEKLY_SAT = "FREQ=WEEKLY;BYDAY=SA";
 const BIWEEKLY_SAT = "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA";
 const MONTHLY_2ND_SAT = "FREQ=MONTHLY;BYDAY=2SA";
+const NOSE_SUMMER = "FREQ=WEEKLY;BYDAY=TH;BYMONTH=5,6,7,8,9,10";
+const NOSE_WINTER = "FREQ=WEEKLY;BYDAY=WE;BYMONTH=1,2,3,4,11,12";
 const DEFAULT_URL = "https://www.facebook.com/groups/rumsonh3/";
 
 function makeSource(config: Record<string, unknown>, url = DEFAULT_URL): Source {
@@ -100,6 +102,28 @@ describe("parseRRule", () => {
     expect(rule.byDay).toEqual({ day: 6 });
   });
 
+  it("parses BYMONTH list (NOSE summer)", () => {
+    const rule = parseRRule(NOSE_SUMMER);
+    expect(rule.freq).toBe("WEEKLY");
+    expect(rule.byDay).toEqual({ day: 4 });
+    expect(rule.byMonth).toEqual([5, 6, 7, 8, 9, 10]);
+  });
+
+  it("dedupes and sorts BYMONTH values", () => {
+    const rule = parseRRule("FREQ=WEEKLY;BYDAY=TH;BYMONTH=10,5,5,6,9,7,8");
+    expect(rule.byMonth).toEqual([5, 6, 7, 8, 9, 10]);
+  });
+
+  it("tolerates whitespace inside BYMONTH list", () => {
+    const rule = parseRRule("FREQ=WEEKLY;BYDAY=TH;BYMONTH=5, 6 , 7");
+    expect(rule.byMonth).toEqual([5, 6, 7]);
+  });
+
+  it("leaves byMonth undefined when BYMONTH is absent", () => {
+    const rule = parseRRule(WEEKLY_SAT);
+    expect(rule.byMonth).toBeUndefined();
+  });
+
   it.each([
     ["BYDAY=SA", "missing FREQ"],
     ["FREQ=WEEKLY;BYDAY=XX", "Unknown day"],
@@ -111,6 +135,11 @@ describe("parseRRule", () => {
     ["FREQ=DAILY;BYDAY=SA", "Unsupported FREQ"],
     ["FREQ=YEARLY;BYDAY=SA", "Unsupported FREQ"],
     ["FREQ=WEEKLY", "WEEKLY RRULE requires BYDAY"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=0", "Invalid BYMONTH"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=13", "Invalid BYMONTH"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=foo", "Invalid BYMONTH"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=5.5", "Invalid BYMONTH"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=,", "Invalid BYMONTH"],
   ])("throws on invalid input: %s", (rrule, expectedError) => {
     expect(() => parseRRule(rrule)).toThrow(expectedError);
   });
@@ -191,6 +220,51 @@ describe("generateOccurrences", () => {
     const rule = parseRRule(WEEKLY_SAT);
     const dates = generateOccurrences(rule, utcDate(2026, 0, 5), utcDate(2026, 0, 9, 23, 59, 59));
     expect(dates).toEqual([]);
+  });
+
+  it("filters to BYMONTH months for NOSE summer (May-Oct Thursdays)", () => {
+    const rule = parseRRule(NOSE_SUMMER);
+    const dates = generateOccurrences(rule, utcDate(2026, 0, 1), utcDate(2026, 11, 31, 23, 59, 59));
+
+    expect(dates.length).toBeGreaterThan(0);
+    expect(dates[0]).toBe("2026-05-07"); // first Thursday of May 2026
+    expect(dates[dates.length - 1]).toBe("2026-10-29"); // last Thursday of October 2026
+    for (const d of dates) {
+      const date = new Date(d + "T12:00:00Z");
+      expect(date.getUTCDay()).toBe(4); // Thursday
+      const month = date.getUTCMonth() + 1;
+      expect(month).toBeGreaterThanOrEqual(5);
+      expect(month).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("filters to BYMONTH months for NOSE winter (Nov-Apr Wednesdays)", () => {
+    const rule = parseRRule(NOSE_WINTER);
+    const dates = generateOccurrences(rule, utcDate(2026, 0, 1), utcDate(2026, 11, 31, 23, 59, 59));
+
+    expect(dates.length).toBeGreaterThan(0);
+    for (const d of dates) {
+      const date = new Date(d + "T12:00:00Z");
+      expect(date.getUTCDay()).toBe(3); // Wednesday
+      const month = date.getUTCMonth() + 1;
+      expect([1, 2, 3, 4, 11, 12]).toContain(month);
+    }
+  });
+
+  it("emits unchanged output when BYMONTH is absent (non-breaking)", () => {
+    const rule = parseRRule(WEEKLY_SAT);
+    const dates = generateOccurrences(rule, utcDate(2026, 0, 1), utcDate(2026, 11, 31, 23, 59, 59));
+
+    const monthsCovered = new Set(dates.map((d) => Number.parseInt(d.slice(5, 7), 10)));
+    for (let m = 1; m <= 12; m++) {
+      expect(monthsCovered.has(m)).toBe(true);
+    }
+  });
+
+  it("supports BYMONTH on monthly rules (annual occurrence pattern)", () => {
+    const rule = parseRRule("FREQ=MONTHLY;BYMONTHDAY=15;BYMONTH=6");
+    const dates = generateOccurrences(rule, utcDate(2026, 0, 1), utcDate(2027, 11, 31, 23, 59, 59));
+    expect(dates).toEqual(["2026-06-15", "2027-06-15"]);
   });
 });
 
@@ -338,6 +412,21 @@ describe("StaticScheduleAdapter", () => {
       expect(date.getUTCDay()).toBe(6);
       expect(date.getUTCDate()).toBeGreaterThanOrEqual(8);
       expect(date.getUTCDate()).toBeLessThanOrEqual(14);
+    }
+  });
+
+  it("filters fetched events to BYMONTH months", async () => {
+    const result = await adapter.fetch(
+      makeSource({ kennelTag: "NOSEH3", rrule: NOSE_SUMMER }),
+      { days: 365 },
+    );
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.events.length).toBeGreaterThan(0);
+    for (const event of result.events) {
+      const month = Number.parseInt(event.date.slice(5, 7), 10);
+      expect([5, 6, 7, 8, 9, 10]).toContain(month);
+      expect(new Date(event.date + "T12:00:00Z").getUTCDay()).toBe(4); // Thursday
     }
   });
 

--- a/src/adapters/static-schedule/adapter.test.ts
+++ b/src/adapters/static-schedule/adapter.test.ts
@@ -237,7 +237,7 @@ describe("generateOccurrences", () => {
 
     expect(dates.length).toBeGreaterThan(0);
     expect(dates[0]).toBe("2026-05-07"); // first Thursday of May 2026
-    expect(dates[dates.length - 1]).toBe("2026-10-29"); // last Thursday of October 2026
+    expect(dates.at(-1)).toBe("2026-10-29"); // last Thursday of October 2026
     for (const d of dates) {
       const date = new Date(d + "T12:00:00Z");
       expect(date.getUTCDay()).toBe(4); // Thursday
@@ -436,6 +436,49 @@ describe("StaticScheduleAdapter", () => {
       const month = Number.parseInt(event.date.slice(5, 7), 10);
       expect([5, 6, 7, 8, 9, 10]).toContain(month);
       expect(new Date(event.date + "T12:00:00Z").getUTCDay()).toBe(4); // Thursday
+    }
+  });
+
+  it("treats off-season as success (no error) when window misses every BYMONTH month", async () => {
+    // Single-month June rule scraped in mid-December: 90-day window spans
+    // mid-Sep → mid-Mar, never touching June. Should return 0 events with NO
+    // error so the alert pipeline doesn't fire 6+ months of false alarms.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-12-15T12:00:00Z"));
+    try {
+      const result = await adapter.fetch(
+        makeSource({ kennelTag: "TestKennel", rrule: "FREQ=MONTHLY;BYMONTHDAY=15;BYMONTH=6" }),
+      );
+      expect(result.errors).toHaveLength(0);
+      expect(result.events).toHaveLength(0);
+      expect(result.diagnosticContext?.note).toMatch(/off-season/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still alerts when window overlaps a BYMONTH month but generates 0 events", async () => {
+    // Window crosses June, but BYMONTHDAY=31 in June clamps to June 30 — wait,
+    // that still emits. Use BYDAY=2SA;BYMONTH=6 in a window that contains June
+    // and ensure the day-2-Saturday-of-June logic emits at least one event.
+    // To force a true 0-with-overlap, use an invalid pairing: monthly nth weekday
+    // that resolves outside the month — which the existing nthWeekdayOfMonth
+    // returns null for. But simpler: use a 1-day window starting today that
+    // overlaps a BYMONTH month but lands on a non-target weekday.
+    vi.useFakeTimers();
+    // Set "today" to Mon 2026-06-15 (June, in BYMONTH=6) and use a 0-day window:
+    // window = [today-0, today+0] = exactly today. Rule wants Saturdays in June.
+    // Today is Monday → 0 events, but window IS in June → real misconfig signal.
+    vi.setSystemTime(new Date("2026-06-15T12:00:00Z"));
+    try {
+      const result = await adapter.fetch(
+        makeSource({ kennelTag: "TestKennel", rrule: "FREQ=WEEKLY;BYDAY=SA;BYMONTH=6" }),
+        { days: 0 },
+      );
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toMatch(/0 events/);
+    } finally {
+      vi.useRealTimers();
     }
   });
 

--- a/src/adapters/static-schedule/adapter.test.ts
+++ b/src/adapters/static-schedule/adapter.test.ts
@@ -124,6 +124,11 @@ describe("parseRRule", () => {
     expect(rule.byMonth).toBeUndefined();
   });
 
+  it("accepts RFC 5545 1*2DIGIT month forms (leading zero)", () => {
+    const rule = parseRRule("FREQ=WEEKLY;BYDAY=TH;BYMONTH=05,06,07,08,09,10");
+    expect(rule.byMonth).toEqual([5, 6, 7, 8, 9, 10]);
+  });
+
   it.each([
     ["BYDAY=SA", "missing FREQ"],
     ["FREQ=WEEKLY;BYDAY=XX", "Unknown day"],
@@ -140,6 +145,10 @@ describe("parseRRule", () => {
     ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=foo", "Invalid BYMONTH"],
     ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=5.5", "Invalid BYMONTH"],
     ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=,", "Invalid BYMONTH"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=5,,6", "Invalid BYMONTH"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=5,", "Invalid BYMONTH"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=,5", "Invalid BYMONTH"],
+    ["FREQ=WEEKLY;BYDAY=TH;BYMONTH=005", "Invalid BYMONTH"],
   ])("throws on invalid input: %s", (rrule, expectedError) => {
     expect(() => parseRRule(rrule)).toThrow(expectedError);
   });

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -81,14 +81,19 @@ function parseByMonthDay(parts: Record<string, string>): number | undefined {
  */
 function parseByMonth(parts: Record<string, string>): number[] | undefined {
   if (!parts.BYMONTH) return undefined;
-  const tokens = parts.BYMONTH.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
-  if (tokens.length === 0) {
+  const tokens = parts.BYMONTH.split(",").map((t) => t.trim());
+  if (tokens.length === 0 || tokens.some((t) => t.length === 0)) {
     throw new Error(`Invalid BYMONTH: ${parts.BYMONTH} (must be a comma-separated list of months 1-12)`);
   }
   const months = new Set<number>();
+  // RFC 5545 §3.3.10: monthnum = 1*2DIGIT — accept "5" and "05" but reject
+  // "005", "5.5", "5abc". Range check after parse handles "13", "99".
   for (const token of tokens) {
+    if (!/^\d{1,2}$/.test(token)) {
+      throw new Error(`Invalid BYMONTH: ${parts.BYMONTH} (each value must be an integer 1-12)`);
+    }
     const month = Number.parseInt(token, 10);
-    if (!Number.isFinite(month) || String(month) !== token || month < 1 || month > 12) {
+    if (month < 1 || month > 12) {
       throw new Error(`Invalid BYMONTH: ${parts.BYMONTH} (each value must be an integer 1-12)`);
     }
     months.add(month);

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -75,17 +75,41 @@ function parseByMonthDay(parts: Record<string, string>): number | undefined {
 }
 
 /**
+ * Parse BYMONTH from RRULE parts. Comma-separated list of month numbers (1-12)
+ * per RFC 5545 §3.3.10. Returns a deduplicated, sorted list, or undefined if not present.
+ * @throws {Error} If the list is empty or contains values outside 1-12.
+ */
+function parseByMonth(parts: Record<string, string>): number[] | undefined {
+  if (!parts.BYMONTH) return undefined;
+  const tokens = parts.BYMONTH.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
+  if (tokens.length === 0) {
+    throw new Error(`Invalid BYMONTH: ${parts.BYMONTH} (must be a comma-separated list of months 1-12)`);
+  }
+  const months = new Set<number>();
+  for (const token of tokens) {
+    const month = Number.parseInt(token, 10);
+    if (!Number.isFinite(month) || String(month) !== token || month < 1 || month > 12) {
+      throw new Error(`Invalid BYMONTH: ${parts.BYMONTH} (each value must be an integer 1-12)`);
+    }
+    months.add(month);
+  }
+  return [...months].sort((a, b) => a - b);
+}
+
+/**
  * Parse an RRULE string into structured parts.
- * Supports: FREQ (WEEKLY|MONTHLY), BYDAY (with optional nth prefix), INTERVAL, BYMONTHDAY.
+ * Supports: FREQ (WEEKLY|MONTHLY), BYDAY (with optional nth prefix), INTERVAL, BYMONTHDAY,
+ * BYMONTH (comma-separated list of months 1-12, RFC 5545 §3.3.10).
  * Whitespace around semicolons and equals signs is trimmed.
  *
- * @throws {Error} On missing FREQ, unsupported FREQ, invalid INTERVAL/BYMONTHDAY/BYDAY values.
+ * @throws {Error} On missing FREQ, unsupported FREQ, invalid INTERVAL/BYMONTHDAY/BYMONTH/BYDAY values.
  */
 export function parseRRule(rrule: string): {
   freq: string;
   interval: number;
   byDay?: { day: number; nth?: number };
   byMonthDay?: number;
+  byMonth?: number[];
 } {
   const parts: Record<string, string> = {};
   for (const segment of rrule.split(";")) {
@@ -105,12 +129,13 @@ export function parseRRule(rrule: string): {
   const interval = parseInterval(parts);
   const byDay = parseByDay(parts);
   const byMonthDay = parseByMonthDay(parts);
+  const byMonth = parseByMonth(parts);
 
   if (freq === "WEEKLY" && !byDay) {
     throw new Error("WEEKLY RRULE requires BYDAY");
   }
 
-  return { freq, interval, byDay, byMonthDay };
+  return { freq, interval, byDay, byMonthDay, byMonth };
 }
 
 /**
@@ -262,21 +287,26 @@ export function generateOccurrences(
   windowEnd: Date,
   anchorDate?: string,
 ): string[] {
+  let dates: string[] = [];
   if (rule.freq === "WEEKLY" && rule.byDay) {
-    return generateWeeklyDates(rule.byDay.day, rule.interval, windowStart, windowEnd, anchorDate);
-  }
-  if (rule.freq === "MONTHLY") {
+    dates = generateWeeklyDates(rule.byDay.day, rule.interval, windowStart, windowEnd, anchorDate);
+  } else if (rule.freq === "MONTHLY") {
     if (rule.byDay?.nth !== undefined) {
-      return generateMonthlyNthWeekdayDates(rule.byDay.day, rule.byDay.nth, rule.interval, windowStart, windowEnd);
-    }
-    if (rule.byMonthDay) {
-      return generateMonthlyByMonthDayDates(rule.byMonthDay, rule.interval, windowStart, windowEnd);
-    }
-    if (rule.byDay) {
-      return generateMonthlyByWeekdayDates(rule.byDay.day, rule.interval, windowStart, windowEnd);
+      dates = generateMonthlyNthWeekdayDates(rule.byDay.day, rule.byDay.nth, rule.interval, windowStart, windowEnd);
+    } else if (rule.byMonthDay) {
+      dates = generateMonthlyByMonthDayDates(rule.byMonthDay, rule.interval, windowStart, windowEnd);
+    } else if (rule.byDay) {
+      dates = generateMonthlyByWeekdayDates(rule.byDay.day, rule.interval, windowStart, windowEnd);
     }
   }
-  return [];
+
+  if (rule.byMonth && rule.byMonth.length > 0) {
+    const allowed = new Set(rule.byMonth);
+    // YYYY-MM-DD → month is chars 5-6 (1-indexed slice), parse as 1-12.
+    dates = dates.filter((d) => allowed.has(Number.parseInt(d.slice(5, 7), 10)));
+  }
+
+  return dates;
 }
 
 /** Find the nth weekday of a given month. Supports negative nth (-1 = last). */

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -340,6 +340,29 @@ function nthWeekdayOfMonth(
   }
 }
 
+/**
+ * Check whether [windowStart, windowEnd] overlaps any (year, month) pair whose
+ * 1-indexed month is in `months`. Used to distinguish a seasonal rule's
+ * legitimate off-season (no overlap) from an actual misconfiguration (overlap
+ * but still no occurrences).
+ */
+function windowOverlapsAnyMonth(windowStart: Date, windowEnd: Date, months: number[]): boolean {
+  const allowed = new Set(months);
+  let year = windowStart.getUTCFullYear();
+  let month = windowStart.getUTCMonth(); // 0-indexed
+  const endYear = windowEnd.getUTCFullYear();
+  const endMonth = windowEnd.getUTCMonth();
+  while (year < endYear || (year === endYear && month <= endMonth)) {
+    if (allowed.has(month + 1)) return true;
+    month++;
+    if (month > 11) {
+      month = 0;
+      year++;
+    }
+  }
+  return false;
+}
+
 /** Format a UTC date as YYYY-MM-DD. */
 function formatDateUTC(d: Date): string {
   const y = d.getUTCFullYear();
@@ -402,6 +425,25 @@ export class StaticScheduleAdapter implements SourceAdapter {
     const occurrences = generateOccurrences(rule, windowStart, windowEnd, config.anchorDate);
 
     if (occurrences.length === 0) {
+      // Off-season for a seasonal rule is expected, not a misconfiguration.
+      // Only alert when the window actually overlaps an active month.
+      const seasonalOffSeason =
+        rule.byMonth !== undefined && rule.byMonth.length > 0 &&
+        !windowOverlapsAnyMonth(windowStart, windowEnd, rule.byMonth);
+      if (seasonalOffSeason) {
+        return {
+          events: [],
+          errors: [],
+          diagnosticContext: {
+            rrule: config.rrule,
+            occurrencesGenerated: 0,
+            windowDays: days,
+            windowStart: windowStart.toISOString(),
+            windowEnd: windowEnd.toISOString(),
+            note: "off-season: window does not overlap any BYMONTH month",
+          },
+        };
+      }
       const message = `RRULE "${config.rrule}" generated 0 events in ${days}-day window — check schedule configuration`;
       return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
     }


### PR DESCRIPTION
## Summary

- Adds RFC 5545 [§3.3.10 BYMONTH](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10) parsing to the STATIC_SCHEDULE adapter.
- New `parseByMonth()` helper accepts a comma-separated list of month numbers (1–12), trims whitespace per token, dedupes, and sorts. Throws on empty list, non-integers, decimals, or values outside 1–12.
- `generateOccurrences()` now post-filters dates by the BYMONTH set after the FREQ/BYDAY/BYMONTHDAY generators run. Absent BYMONTH → existing behavior (non-breaking).

## Grammar

```
BYMONTH=<1..12>(,<1..12>)*
```

Examples:

- `FREQ=WEEKLY;BYDAY=TH;BYMONTH=5,6,7,8,9,10` — Thursdays, May–October only
- `FREQ=WEEKLY;BYDAY=WE;BYMONTH=1,2,3,4,11,12` — Wednesdays, Nov–April only
- `FREQ=MONTHLY;BYMONTHDAY=15;BYMONTH=6` — June 15th every year

Whitespace inside the list is tolerated (`5, 6, 7`); values are deduped and sorted; out-of-range or non-integer entries throw at parse time.

## Why

NOSE Hash (North Of Seventy Eight, NJ) runs Thursdays May–Oct and Wednesdays Nov–Apr. Without BYMONTH, the only ways to encode this were either two RRULEs that emit wrong-day events year-round, or deferring to a custom adapter. RFC 5545 BYMONTH expresses it cleanly. Likely useful for other Northern-Hemisphere kennels with summer evening / winter weekend-day shifts.

NOSE Hash seed entries are deferred to a follow-up PR to avoid colliding with the in-flight WS3 seed sweep.

## Test plan

- [x] Existing 5233 tests still pass (non-breaking).
- [x] `parseRRule` handles BYMONTH list, dedup+sort, whitespace tolerance, and absence (returns `undefined`).
- [x] `parseRRule` throws on `BYMONTH=0`, `=13`, `=foo`, `=5.5`, `=,`.
- [x] `generateOccurrences` for NOSE summer/winter rules emits only the right weekday in the right months over a 1-year window.
- [x] `generateOccurrences` without BYMONTH still covers all 12 months (regression guard).
- [x] `StaticScheduleAdapter.fetch()` filters live results to BYMONTH months.
- [x] BYMONTH on a MONTHLY+BYMONTHDAY rule produces the expected annual-occurrence pattern.
- [x] `npx tsc --noEmit`, `npm run lint`, `npx vitest run` all clean.

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)