### PR TITLE
fix(utils): pre-parse 'D MMM YY' before chrono — fixes Ladies H4 sawtooth date bug

### DIFF
--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -651,6 +651,15 @@ describe("chronoParseDate", () => {
     // Fast-path rejects; chrono fallback returns null too because Xyz isn't a month
     expect(chronoParseDate("5 Xyz 26", "en-GB")).toBeNull();
   });
+
+  it("does not fast-path 3-digit year tokens (year-226 AD would be absurd)", () => {
+    // The fast-path regex requires exactly 2 OR 4 digits, so "5 May 226"
+    // falls through to chrono. chrono parses the "5 May" prefix and infers
+    // a sensible current-year date, NOT a literal "226-05-05" the old
+    // permissive `\d{2,4}` quantifier would have produced.
+    const result = chronoParseDate("5 May 226", "en-GB");
+    expect(result).toMatch(/^20\d{2}-05-05$/);
+  });
 });
 
 describe("extractAddressWithAi", () => {

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -602,6 +602,55 @@ describe("chronoParseDate", () => {
     // Chrono natively parses M-D-YY; the negative lookahead must not interfere
     expect(chronoParseDate("3-7-26", "en-US")).toBe("2026-03-07");
   });
+
+  // ── "D[D] MMM YY[YY]" fast-path (chrono-node bug workaround) ──
+  // chrono mis-parses single-digit-day variants of this format: "5 May 26"
+  // becomes 2026-05-26 (interpreting the year fragment as the day) instead of
+  // 2026-05-05. We pre-parse the unambiguous DDMonYY shape before chrono.
+  // Bug surfaced in Ladies H4 HK where rows like "5 May 26" / "2 Jun 26" /
+  // "7 Jul 26" all landed on the 26th of their month.
+
+  it("parses single-digit-day '5 May 26' as 2026-05-05 (not chrono's 2026-05-26)", () => {
+    expect(chronoParseDate("5 May 26", "en-GB")).toBe("2026-05-05");
+  });
+
+  it("parses single-digit-day '2 Jun 26' as 2026-06-02", () => {
+    expect(chronoParseDate("2 Jun 26", "en-GB")).toBe("2026-06-02");
+  });
+
+  it("parses single-digit-day '7 Jul 26' as 2026-07-07", () => {
+    expect(chronoParseDate("7 Jul 26", "en-GB")).toBe("2026-07-07");
+  });
+
+  it("still parses two-digit-day '28 Apr 26' as 2026-04-28", () => {
+    expect(chronoParseDate("28 Apr 26", "en-GB")).toBe("2026-04-28");
+  });
+
+  it("parses hyphenated D-Mon-YY '5-May-26' as 2026-05-05", () => {
+    expect(chronoParseDate("5-May-26", "en-GB")).toBe("2026-05-05");
+  });
+
+  it("parses 4-digit year 'D MMM YYYY': '5 May 2026'", () => {
+    expect(chronoParseDate("5 May 2026", "en-GB")).toBe("2026-05-05");
+  });
+
+  it("parses 2-digit year boundary 49 → 2049", () => {
+    expect(chronoParseDate("5 May 49", "en-GB")).toBe("2049-05-05");
+  });
+
+  it("parses 2-digit year boundary 50 → 1950", () => {
+    expect(chronoParseDate("5 May 50", "en-GB")).toBe("1950-05-05");
+  });
+
+  it("rejects impossible D MMM YY '31 Apr 26'", () => {
+    // Apr has 30 days — fast-path returns null and chrono fallback also rejects
+    expect(chronoParseDate("31 Apr 26", "en-GB")).toBeNull();
+  });
+
+  it("rejects unknown month abbreviation 'D Xyz YY'", () => {
+    // Fast-path rejects; chrono fallback returns null too because Xyz isn't a month
+    expect(chronoParseDate("5 Xyz 26", "en-GB")).toBeNull();
+  });
 });
 
 describe("extractAddressWithAi", () => {

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -394,12 +394,6 @@ export type DateLocale = "en-US" | "en-GB";
  * @param options - Optional parsing options (forwardDate: prefer next future occurrence)
  * @returns "YYYY-MM-DD" string, or null if parsing fails
  */
-/** 3-letter month abbreviation → 1-based month number. */
-const MONTH_ABBREV_TO_NUMBER: Record<string, number> = {
-  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
-  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
-};
-
 /**
  * Pre-parse the unambiguous "D[D] MMM YY[YY]" format (e.g. "5 May 26",
  * "28-Apr-2026") before falling through to chrono-node. chrono mis-parses
@@ -412,17 +406,18 @@ const MONTH_ABBREV_TO_NUMBER: Record<string, number> = {
  * Returns "YYYY-MM-DD" on a clean match, or null if the pattern doesn't fit.
  */
 function parseDmyAbbrevDate(text: string): string | null {
-  const match = /^\s*(\d{1,2})[\s-]+([A-Za-z]{3})[\s-]+(\d{2,4})\s*$/.exec(text);
+  // Year quantifier is exactly 2 OR exactly 4 digits — `\d{4}|\d{2}`
+  // (alternation, not `\d{2,4}`) so we don't accidentally match 3-digit years.
+  const match = /^\s*(\d{1,2})[\s-]+([A-Za-z]{3})[\s-]+(\d{4}|\d{2})\s*$/.exec(text);
   if (!match) return null;
   const day = Number.parseInt(match[1], 10);
-  const month = MONTH_ABBREV_TO_NUMBER[match[2].toLowerCase()];
+  const month = MONTHS[match[2].toLowerCase()];
   if (!month) return null;
   let year = Number.parseInt(match[3], 10);
   if (year < 100) year += year < 50 ? 2000 : 1900;
-  // Validate the day fits in the month (rejects e.g. "31 Apr 26").
+  // Date round-trip catches invalid days (e.g. "31 Apr 26" → null).
   const d = new Date(Date.UTC(year, month - 1, day));
   if (d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return null;
-  if (day < 1 || day > 31) return null;
   return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }
 

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -394,12 +394,51 @@ export type DateLocale = "en-US" | "en-GB";
  * @param options - Optional parsing options (forwardDate: prefer next future occurrence)
  * @returns "YYYY-MM-DD" string, or null if parsing fails
  */
+/** 3-letter month abbreviation → 1-based month number. */
+const MONTH_ABBREV_TO_NUMBER: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+
+/**
+ * Pre-parse the unambiguous "D[D] MMM YY[YY]" format (e.g. "5 May 26",
+ * "28-Apr-2026") before falling through to chrono-node. chrono mis-parses
+ * single-digit-day variants of this pattern: it reads "5 May 26" as
+ * 2026-05-26 (interpreting the year fragment as the day) instead of
+ * 2026-05-05. This format is fully deterministic when the components are
+ * separated and the month is a recognized 3-letter abbreviation, so
+ * handling it explicitly is both safer and faster than the chrono path.
+ *
+ * Returns "YYYY-MM-DD" on a clean match, or null if the pattern doesn't fit.
+ */
+function parseDmyAbbrevDate(text: string): string | null {
+  const match = /^\s*(\d{1,2})[\s-]+([A-Za-z]{3})[\s-]+(\d{2,4})\s*$/.exec(text);
+  if (!match) return null;
+  const day = Number.parseInt(match[1], 10);
+  const month = MONTH_ABBREV_TO_NUMBER[match[2].toLowerCase()];
+  if (!month) return null;
+  let year = Number.parseInt(match[3], 10);
+  if (year < 100) year += year < 50 ? 2000 : 1900;
+  // Validate the day fits in the month (rejects e.g. "31 Apr 26").
+  const d = new Date(Date.UTC(year, month - 1, day));
+  if (d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return null;
+  if (day < 1 || day > 31) return null;
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
 export function chronoParseDate(
   text: string,
   locale: DateLocale = "en-US",
   referenceDate?: Date,
   options?: { forwardDate?: boolean },
 ): string | null {
+  // Fast-path: "D[D] MMM YY[YY]" with space or hyphen separators. Bypasses
+  // a chrono-node bug where "5 May 26" becomes 2026-05-26 instead of
+  // 2026-05-05. Affects Ladies H4 HK and any other adapter feeding this
+  // format. See unit tests in utils.test.ts.
+  const dmyResult = parseDmyAbbrevDate(text);
+  if (dmyResult) return dmyResult;
+
   // Normalize hyphenated M-D dates (e.g., "3-7", "10-31: HALLOWEEN") → "M/D"
   // before parsing. Chrono can't parse "3-7" but handles "3/7" natively.
   // Negative lookahead excludes M-D-YY patterns (e.g., "3-7-26").


### PR DESCRIPTION
## Summary

Follow-up to PR #1057. chrono-node mis-parses single-digit-day variants of the unambiguous "D MMM YY" date format: `5 May 26` returns `2026-05-26` (interpreting the year fragment as the day) instead of `2026-05-05`. The bug surfaced in **Ladies H4 HK** where the first run of every month landed on the 26th.

## Reproduction (confirmed via live source)

Before the fix:

```
#2864 → 2026-04-28 ✓ (28 Apr 26)
#2865 → 2026-05-26 ✗ (5 May 26  — should be 2026-05-05)
#2866 → 2026-05-12 ✓ (12 May 26)
#2867 → 2026-05-19 ✓ (19 May 26)
#2868 → 2026-05-26 ✓ (26 May 26)
#2869 → 2026-06-26 ✗ (2 Jun 26  — should be 2026-06-02)
#2870 → 2026-06-26 ✗ (9 Jun 26  — should be 2026-06-09)
...
```

After the fix (live-verified):

```
#2864 → 2026-04-28 ✓
#2865 → 2026-05-05 ✓
#2866 → 2026-05-12 ✓
#2867 → 2026-05-19 ✓
#2868 → 2026-05-26 ✓
#2869 → 2026-06-02 ✓
#2870 → 2026-06-09 ✓
#2871 → 2026-06-16 ✓
... (all 18 events sequential weekly Tuesdays)
```

## Fix

Added `parseDmyAbbrevDate()` fast-path in `chronoParseDate()` that handles `D[D]( |-)MMM( |-)YY[YY]` with explicit month-abbrev recognition and day-fits-in-month validation. Bypasses chrono entirely when the pattern matches; falls through to chrono for everything else.

The fast-path is gated by an exact full-string regex match, so generic free-text dates ("Saturday 21st of February 2026", "March 14, 2026") continue to flow through chrono unchanged.

## Affected adapters

- **Ladies H4 HK** (lh4-hk) — primary motivation, confirmed fixed
- Any other adapter that calls `chronoParseDate()` with `D MMM YY`-shaped cells gets the fix automatically. Likely candidates: Barnes Hash, other UK-format kennels.

## Test plan

- [x] 10 new unit tests in `src/adapters/utils.test.ts` covering: single-digit days, two-digit days, hyphenated separators, 4-digit years, 2-digit-year boundaries (49→2049, 50→1950), impossible dates (`31 Apr 26`), unknown months
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors
- [x] `npm test` 5303 pass / 2 skip / 25 todo (was 5293 → +10 new)
- [x] Live-verified Ladies H4 source: all 18 events now in correct weekly-Tuesday sequence
- [ ] Post-merge: confirm next scrape cycle re-fingerprints the corrected dates and the Ladies H4 hareline shows accurate weekly Tuesdays

🤖 Generated with [Claude Code](https://claude.com/claude-code)