### PR TITLE
fix(gcal): recover RECURRENCE-ID overrides + sweep CUNTh/DeMon metadata

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1868,8 +1868,12 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "cunth3-wa", shortName: "CUNTh", fullName: "C.U.N.Th Hash House Harriers", region: "Seattle, WA",
       website: "https://wh3.org",
+      facebookUrl: "https://www.facebook.com/share/g/T7Ccn7uC2zUwekBj/",
+      contactEmail: "cnthh3@gmail.com",
+      logoUrl: "https://wh3.org/img/icons/CUNTHH3.png",
       scheduleDayOfWeek: "Thursday", scheduleFrequency: "Biweekly",
       scheduleNotes: "Twice monthly Thursday. Transit-friendly, light shiggy.",
+      hashCash: "$7", foundedYear: 2022,
       description: "Seattle-area transit-friendly hash with light shiggy. Runs twice monthly on Thursdays.",
       latitude: 47.61, longitude: -122.33,
     },
@@ -2028,7 +2032,10 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "demon-h3", shortName: "DeMon", fullName: "DeMon Hash House Harriers", region: "Detroit, MI",
       website: "https://demonh3.com",
+      contactEmail: "demonhashhouseharriers@gmail.com",
+      logoUrl: "https://demonh3.com/DeMon_files/demon_logo.png",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
+      hashCash: "$5", foundedYear: 2025,
       description: "Detroit's Monday evening hash — 'Detroit's Monday Kennel'.",
       latitude: 42.33, longitude: -83.05,
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2056,6 +2056,11 @@ export const SOURCES = [
         ],
         defaultKennelTag: "sh3-wa",
         strictKennelRouting: true,
+        // CUNTh stores many of its trail events as all-day RECURRENCE-ID overrides
+        // (DTSTART;VALUE=DATE). Without this opt-in, those events are dropped by
+        // the all-day filter (#1021). strictKennelRouting bounds the blast radius —
+        // anything not matching kennelPatterns is still discarded.
+        includeAllDayEvents: true,
       },
       kennelCodes: ["sh3-wa", "psh3", "nbh3-wa", "rch3-wa", "seamon-h3", "th3-wa", "ssh3-wa", "cunth3-wa", "taint-h3", "giggity-h3", "seh3-wa", "hswtf-h3", "leapyear-h3"],
     },

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -2565,46 +2565,49 @@ describe("GoogleCalendarAdapter — RRULE future-horizon cap (#939)", () => {
 
 // ── #1021 / #1024 RECURRENCE-ID override recovery via secondary call ──
 
+const RECOVERY_ADAPTER = new GoogleCalendarAdapter();
+
+function makeRecoverySource(config: object) {
+  return {
+    id: "test-source",
+    url: "test@calendar.google.com",
+    type: "GOOGLE_CALENDAR" as const,
+    config,
+    scrapeDays: 90,
+  } as unknown as Parameters<typeof RECOVERY_ADAPTER.fetch>[0];
+}
+
+// Build a fetch spy that returns different bodies for the primary
+// (singleEvents=true) and secondary (singleEvents=false) calls. Both can
+// be primed with multi-page responses via { items, nextPageToken }.
+function mockTwoCalls(
+  primary: object | (() => Response | Promise<Response>),
+  secondary: object | (() => Response | Promise<Response>) | "throw" | "500",
+) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = new URL(input as string);
+    const isSingle = url.searchParams.get("singleEvents") === "true";
+    const handler = isSingle ? primary : secondary;
+    if (handler === "throw") throw new Error("network down");
+    if (handler === "500") return new Response("server error", { status: 500 });
+    if (typeof handler === "function") return await handler();
+    return new Response(JSON.stringify(handler), { status: 200 });
+  });
+}
+
+async function withApiKey(fn: () => Promise<void>): Promise<void> {
+  const original = process.env.GOOGLE_CALENDAR_API_KEY;
+  process.env.GOOGLE_CALENDAR_API_KEY = "test-key";
+  try { await fn(); }
+  finally {
+    if (original === undefined) delete process.env.GOOGLE_CALENDAR_API_KEY;
+    else process.env.GOOGLE_CALENDAR_API_KEY = original;
+  }
+}
+
 describe("GoogleCalendarAdapter — RECURRENCE-ID override recovery (#1021/#1024)", () => {
-  const adapter = new GoogleCalendarAdapter();
-
-  function makeSource(config: object = { defaultKennelTag: "test" }) {
-    return {
-      id: "test-source",
-      url: "test@calendar.google.com",
-      type: "GOOGLE_CALENDAR" as const,
-      config,
-      scrapeDays: 90,
-    } as unknown as Parameters<typeof adapter.fetch>[0];
-  }
-
-  // Build a fetch spy that returns different bodies for the primary
-  // (singleEvents=true) and secondary (singleEvents=false) calls. Both can
-  // be primed with multi-page responses via { items, nextPageToken }.
-  function mockTwoCalls(
-    primary: object | (() => Response | Promise<Response>),
-    secondary: object | (() => Response | Promise<Response>) | "throw" | "500",
-  ) {
-    return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = new URL(input as string);
-      const isSingle = url.searchParams.get("singleEvents") === "true";
-      const handler = isSingle ? primary : secondary;
-      if (handler === "throw") throw new Error("network down");
-      if (handler === "500") return new Response("server error", { status: 500 });
-      if (typeof handler === "function") return await handler();
-      return new Response(JSON.stringify(handler), { status: 200 });
-    });
-  }
-
-  async function withApiKey(fn: () => Promise<void>): Promise<void> {
-    const original = process.env.GOOGLE_CALENDAR_API_KEY;
-    process.env.GOOGLE_CALENDAR_API_KEY = "test-key";
-    try { await fn(); }
-    finally {
-      if (original === undefined) delete process.env.GOOGLE_CALENDAR_API_KEY;
-      else process.env.GOOGLE_CALENDAR_API_KEY = original;
-    }
-  }
+  const adapter = RECOVERY_ADAPTER;
+  const makeSource = makeRecoverySource;
 
   // ── Fixture A: timed RRULE master + timed override (DeMon shape) ──
   it("dedups across calls when primary singleEvents=true returns the override (DeMon shape)", async () => {
@@ -2756,7 +2759,7 @@ describe("GoogleCalendarAdapter — RECURRENCE-ID override recovery (#1021/#1024
           { days: 1500 },
         );
         expect(res.events).toHaveLength(3);
-        expect(res.events.map(e => e.date).sort()).toEqual(["2024-08-01", "2024-09-15", "2024-10-30"]);
+        expect(res.events.map(e => e.date).sort((a, b) => a.localeCompare(b))).toEqual(["2024-08-01", "2024-09-15", "2024-10-30"]);
         expect(res.diagnosticContext?.exceptionsRecovered).toBe(3);
       } finally {
         fetchSpy.mockRestore();
@@ -2793,7 +2796,7 @@ describe("GoogleCalendarAdapter — RECURRENCE-ID override recovery (#1021/#1024
       try {
         const res = await adapter.fetch(makeSource({ defaultKennelTag: "demon-h3" }), { days: 90 });
         expect(res.events).toHaveLength(2);
-        const dates = res.events.map(e => e.date).sort();
+        const dates = res.events.map(e => e.date).sort((a, b) => a.localeCompare(b));
         expect(dates).toEqual(["2025-12-15", "2025-12-22"]);
       } finally {
         fetchSpy.mockRestore();

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -2562,3 +2562,358 @@ describe("GoogleCalendarAdapter — RRULE future-horizon cap (#939)", () => {
     expect(timeMax - after).toBeGreaterThanOrEqual(364 * 86_400_000);
   });
 });
+
+// ── #1021 / #1024 RECURRENCE-ID override recovery via secondary call ──
+
+describe("GoogleCalendarAdapter — RECURRENCE-ID override recovery (#1021/#1024)", () => {
+  const adapter = new GoogleCalendarAdapter();
+
+  function makeSource(config: object = { defaultKennelTag: "test" }) {
+    return {
+      id: "test-source",
+      url: "test@calendar.google.com",
+      type: "GOOGLE_CALENDAR" as const,
+      config,
+      scrapeDays: 90,
+    } as unknown as Parameters<typeof adapter.fetch>[0];
+  }
+
+  // Build a fetch spy that returns different bodies for the primary
+  // (singleEvents=true) and secondary (singleEvents=false) calls. Both can
+  // be primed with multi-page responses via { items, nextPageToken }.
+  function mockTwoCalls(
+    primary: object | (() => Response | Promise<Response>),
+    secondary: object | (() => Response | Promise<Response>) | "throw" | "500",
+  ) {
+    return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input as string);
+      const isSingle = url.searchParams.get("singleEvents") === "true";
+      const handler = isSingle ? primary : secondary;
+      if (handler === "throw") throw new Error("network down");
+      if (handler === "500") return new Response("server error", { status: 500 });
+      if (typeof handler === "function") return await handler();
+      return new Response(JSON.stringify(handler), { status: 200 });
+    });
+  }
+
+  async function withApiKey(fn: () => Promise<void>): Promise<void> {
+    const original = process.env.GOOGLE_CALENDAR_API_KEY;
+    process.env.GOOGLE_CALENDAR_API_KEY = "test-key";
+    try { await fn(); }
+    finally {
+      if (original === undefined) delete process.env.GOOGLE_CALENDAR_API_KEY;
+      else process.env.GOOGLE_CALENDAR_API_KEY = original;
+    }
+  }
+
+  // ── Fixture A: timed RRULE master + timed override (DeMon shape) ──
+  it("dedups across calls when primary singleEvents=true returns the override (DeMon shape)", async () => {
+    await withApiKey(async () => {
+      const masterId = "5mr7g9g41rjp3s3a1oj3khbu98";
+      const overrideId = `${masterId}_20251215T233000Z`;
+      const overrideItem = {
+        id: overrideId,
+        iCalUID: `${masterId}@google.com`,
+        recurringEventId: masterId,
+        originalStartTime: { dateTime: "2025-12-15T18:30:00-05:00", timeZone: "America/Detroit" },
+        summary: "DeMon H3 #5 - Bah Humbug",
+        description: "WHO (hares): Just Jordi\nHash cash: $5",
+        start: { dateTime: "2025-12-15T18:30:00-05:00", timeZone: "America/Detroit" },
+        end: { dateTime: "2025-12-15T20:30:00-05:00" },
+        status: "confirmed",
+      };
+      const masterItem = {
+        id: masterId,
+        iCalUID: `${masterId}@google.com`,
+        summary: "DeMon H3 Trail",
+        start: { dateTime: "2025-11-17T18:30:00-05:00", timeZone: "America/Detroit" },
+        recurrence: ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+        status: "confirmed",
+      };
+      const fetchSpy = mockTwoCalls(
+        { items: [overrideItem] },
+        { items: [masterItem, overrideItem] },
+      );
+      try {
+        const res = await adapter.fetch(makeSource({ defaultKennelTag: "demon-h3" }), { days: 90 });
+        expect(res.events).toHaveLength(1);
+        expect(res.events[0].kennelTag).toBe("demon-h3");
+        expect(res.events[0].date).toBe("2025-12-15");
+        expect(res.events[0].startTime).toBe("18:30");
+        expect(res.events[0].title).toBe("DeMon H3 #5 - Bah Humbug");
+        expect(res.diagnosticContext?.exceptionsRecovered).toBeUndefined();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  // ── Fixture B: all-day override on RRULE master, CUNTh shape (includeAllDayEvents opt-in required) ──
+  it("admits all-day override exceptions when includeAllDayEvents is set (CUNTh shape)", async () => {
+    await withApiKey(async () => {
+      const masterId = "6msrbmsmup1kjdt44qh905ijv9";
+      const overrideId = `${masterId}_20251023`;
+      const item = {
+        id: overrideId,
+        iCalUID: `${masterId}@google.com`,
+        recurringEventId: masterId,
+        originalStartTime: { date: "2025-10-23" },
+        summary: "CUNTh H3 #91",
+        description: "CUNth #91 - Two Sleeps to the Black Parade\nHash cash: $7",
+        start: { date: "2025-10-23" },
+        end: { date: "2025-10-24" },
+        status: "confirmed",
+      };
+      const fetchSpy = mockTwoCalls(
+        { items: [item] },
+        { items: [] },
+      );
+      try {
+        const res = await adapter.fetch(
+          makeSource({
+            kennelPatterns: [["CUNTh", "cunth3-wa"]],
+            strictKennelRouting: true,
+            includeAllDayEvents: true,
+          }),
+          { days: 90 },
+        );
+        expect(res.events).toHaveLength(1);
+        expect(res.events[0].kennelTag).toBe("cunth3-wa");
+        expect(res.events[0].date).toBe("2025-10-23");
+        expect(res.events[0].startTime).toBeUndefined();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  // ── Regression guard: non-override all-day RRULE instances must still drop without opt-in ──
+  it("does NOT admit ordinary all-day RRULE instances when includeAllDayEvents is unset", async () => {
+    await withApiKey(async () => {
+      // Materialized RRULE instance: has recurringEventId + originalStartTime,
+      // but is NOT an explicit author-edited override. Without includeAllDayEvents,
+      // these should still be dropped — otherwise sources accidentally ingest
+      // every all-day daily/weekly recurring event (holidays, OOO, etc.).
+      const masterId = "ordinary-rrule-master";
+      const expandedInstance = {
+        id: `${masterId}_20260201`,
+        iCalUID: `${masterId}@google.com`,
+        recurringEventId: masterId,
+        originalStartTime: { date: "2026-02-01" },
+        summary: "Daily standup",
+        start: { date: "2026-02-01" },
+        end: { date: "2026-02-02" },
+        status: "confirmed",
+      };
+      const fetchSpy = mockTwoCalls(
+        { items: [expandedInstance] },
+        { items: [] },
+      );
+      try {
+        const res = await adapter.fetch(makeSource({ defaultKennelTag: "test" }), { days: 90 });
+        expect(res.events).toHaveLength(0);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  // ── Fixture C: epoch RECURRENCE-ID on non-RRULE master ──
+  it("recovers orphan exceptions when primary returns nothing (epoch RECURRENCE-ID)", async () => {
+    await withApiKey(async () => {
+      const masterId = "abc123orphanmaster";
+      const epochOriginal = { dateTime: "1969-12-31T16:00:00-08:00" };
+      const epochOverride = (suffix: string, summary: string, date: string) => ({
+        id: `${masterId}_${suffix}`,
+        iCalUID: `${masterId}@google.com`,
+        recurringEventId: masterId,
+        originalStartTime: epochOriginal,
+        summary,
+        start: { date },
+        end: { date: new Date(new Date(date).getTime() + 86_400_000).toISOString().split("T")[0] },
+        status: "confirmed",
+      });
+      const overrides = [
+        epochOverride("a", "CUNTh H3 #62", "2024-08-01"),
+        epochOverride("b", "CUNTh H3 #65", "2024-09-15"),
+        epochOverride("c", "CUNTh H3 #68", "2024-10-30"),
+      ];
+      const orphanMaster = {
+        id: masterId,
+        iCalUID: `${masterId}@google.com`,
+        summary: "CUNTh placeholder",
+        start: { date: "2024-01-01" },
+        // No RRULE — singleEvents=true won't expand or surface the overrides.
+        status: "confirmed",
+      };
+      const fetchSpy = mockTwoCalls(
+        { items: [] },
+        { items: [orphanMaster, ...overrides] },
+      );
+      try {
+        const res = await adapter.fetch(
+          makeSource({ kennelPatterns: [["CUNTh", "cunth3-wa"]], strictKennelRouting: true, includeAllDayEvents: true }),
+          { days: 1500 },
+        );
+        expect(res.events).toHaveLength(3);
+        expect(res.events.map(e => e.date).sort()).toEqual(["2024-08-01", "2024-09-15", "2024-10-30"]);
+        expect(res.diagnosticContext?.exceptionsRecovered).toBe(3);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  // ── Fixture D: cross-call dedup correctness (id-first key) ──
+  it("id-first dedup eliminates double-counting when primary and secondary both return the same id", async () => {
+    await withApiKey(async () => {
+      const sharedId = "shared-event-id-xyz";
+      const item = {
+        id: sharedId,
+        iCalUID: `${sharedId}@google.com`,
+        recurringEventId: "master-rrule",
+        originalStartTime: { dateTime: "2025-12-15T18:30:00-05:00" },
+        summary: "DeMon H3 #5",
+        start: { dateTime: "2025-12-15T18:30:00-05:00" },
+        status: "confirmed",
+      };
+      const otherException = {
+        id: "another-exception-id",
+        iCalUID: `${sharedId}@google.com`,
+        recurringEventId: "master-rrule",
+        originalStartTime: { dateTime: "2025-12-22T18:30:00-05:00" },
+        summary: "DeMon H3 #6",
+        start: { dateTime: "2025-12-22T18:30:00-05:00" },
+        status: "confirmed",
+      };
+      const fetchSpy = mockTwoCalls(
+        { items: [item] },
+        { items: [item, otherException] },
+      );
+      try {
+        const res = await adapter.fetch(makeSource({ defaultKennelTag: "demon-h3" }), { days: 90 });
+        expect(res.events).toHaveLength(2);
+        const dates = res.events.map(e => e.date).sort();
+        expect(dates).toEqual(["2025-12-15", "2025-12-22"]);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  // ── Fixture E: secondary call failure preserves primary results ──
+  it("secondary-call HTTP 500 logs the error but does not break primary results", async () => {
+    await withApiKey(async () => {
+      const items = Array.from({ length: 3 }, (_, i) => ({
+        id: `id-${i}`,
+        summary: `Trail ${i + 1}`,
+        start: { dateTime: `2026-01-${(i + 10).toString().padStart(2, "0")}T18:30:00-05:00` },
+        status: "confirmed",
+      }));
+      const fetchSpy = mockTwoCalls({ items }, "500");
+      try {
+        const res = await adapter.fetch(makeSource({ defaultKennelTag: "test" }), { days: 90 });
+        expect(res.events).toHaveLength(3);
+        expect(res.errors.some(e => e.includes("500"))).toBe(true);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  it("secondary-call thrown error logs but does not break primary results", async () => {
+    await withApiKey(async () => {
+      const items = [{
+        id: "id-1",
+        summary: "Solo Trail",
+        start: { dateTime: "2026-01-15T18:30:00-05:00" },
+        status: "confirmed",
+      }];
+      const fetchSpy = mockTwoCalls({ items }, "throw");
+      try {
+        const res = await adapter.fetch(makeSource({ defaultKennelTag: "test" }), { days: 90 });
+        expect(res.events).toHaveLength(1);
+        expect(res.errors.some(e => e.toLowerCase().includes("exception-recovery"))).toBe(true);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  // ── Fixture F: start vs originalStartTime divergence (moved override) ──
+  it("uses start (not originalStartTime) for the user-visible date when an override is moved", async () => {
+    await withApiKey(async () => {
+      const masterId = "moved-master";
+      const item = {
+        id: `${masterId}_moved`,
+        iCalUID: `${masterId}@google.com`,
+        recurringEventId: masterId,
+        // Original recurrence slot was 2025-12-15 18:30
+        originalStartTime: { dateTime: "2025-12-15T18:30:00-05:00", timeZone: "America/Detroit" },
+        // But the trail was moved to 2025-12-16 19:00
+        start: { dateTime: "2025-12-16T19:00:00-05:00", timeZone: "America/Detroit" },
+        summary: "Moved Trail",
+        status: "confirmed",
+      };
+      const fetchSpy = mockTwoCalls({ items: [item] }, { items: [] });
+      try {
+        const res = await adapter.fetch(makeSource({ defaultKennelTag: "test" }), { days: 90 });
+        expect(res.events).toHaveLength(1);
+        expect(res.events[0].date).toBe("2025-12-16");
+        expect(res.events[0].startTime).toBe("19:00");
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  // ── Fixture G: inline-hareline backfill still works after recovery ──
+  it("recovered exceptions can serve as inline-hareline backfill donors", async () => {
+    await withApiKey(async () => {
+      const futureDate = new Date(Date.now() + 7 * 86_400_000);
+      const futureIso = futureDate.toISOString().split("T")[0];
+      const m1 = futureDate.getMonth() + 1;
+      const d1 = futureDate.getDate();
+      const futureDate2 = new Date(futureDate.getTime() + 14 * 86_400_000);
+      const futureIso2 = futureDate2.toISOString().split("T")[0];
+      const m2real = futureDate2.getMonth() + 1;
+      const d2real = futureDate2.getDate();
+
+      const donor = {
+        id: "donor-recovered",
+        iCalUID: "rrule-master@google.com",
+        recurringEventId: "rrule-master",
+        originalStartTime: { dateTime: `${futureIso}T18:30:00-05:00` },
+        summary: "Recovered Donor",
+        description: `Hareline:\nMon ${m1}/${d1}: Alice\nMon ${m2real}/${d2real}: Bob`,
+        start: { dateTime: `${futureIso}T18:30:00-05:00`, timeZone: "America/Detroit" },
+        status: "confirmed",
+      };
+      const recipient = {
+        id: "recipient-primary",
+        summary: "Recipient #2",
+        start: { dateTime: `${futureIso2}T18:30:00-05:00`, timeZone: "America/Detroit" },
+        status: "confirmed",
+      };
+      // Donor is recovered via secondary; recipient comes through primary.
+      const fetchSpy = mockTwoCalls(
+        { items: [recipient] },
+        { items: [donor] },
+      );
+      try {
+        const res = await adapter.fetch(
+          makeSource({
+            defaultKennelTag: "test",
+            inlineHarelinePattern: { kennelTag: "test", blockHeader: "Hareline:" },
+          }),
+          { days: 90 },
+        );
+        expect(res.events).toHaveLength(2);
+        const recipientEvent = res.events.find(e => e.date === futureIso2);
+        expect(recipientEvent?.hares).toBe("Bob");
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -546,6 +546,23 @@ function matchConfigPatterns(summary: string, patterns: [string, string][]): str
 
 /** Subset of the Google Calendar API v3 event shape */
 interface GCalEvent {
+  /** Stable per-instance event id; same id appears in `singleEvents=true` and `singleEvents=false` responses. */
+  id?: string;
+  /** iCalendar UID — stable across cross-calendar copies; shared by master + all RECURRENCE-ID overrides. */
+  iCalUID?: string;
+  /**
+   * Set on materialized RRULE instances and on RECURRENCE-ID override exceptions.
+   * Points to the master event's id. Combined with `originalStartTime`, signals
+   * "this item is an exception" — see issue #1021.
+   */
+  recurringEventId?: string;
+  /**
+   * The original recurrence-slot start time (RECURRENCE-ID equivalent). Present
+   * on materialized instances and overrides; absent on standalone events. The
+   * adapter only reads its presence, not its value — `start` is always used for
+   * the user-visible event time.
+   */
+  originalStartTime?: { dateTime?: string; date?: string; timeZone?: string };
   summary?: string;
   description?: string;
   location?: string;
@@ -637,11 +654,21 @@ export function buildRawEventFromGCalItem(
   compiledRunNumberPatterns?: RegExp[],
   compiledSkipPatterns?: RegExp[],
   compiledTitleHarePattern?: RegExp,
+  // Optional id-tracking map. The adapter populates this so the cross-call
+  // dedup at the end of `fetch` can use stable GCal ids without changing the
+  // public RawEventData shape.
+  gcalIdMap?: WeakMap<RawEventData, string>,
 ): RawEventData | null {
   if (item.status === "cancelled") return null;
   if (!item.summary) return null;
   if (!item.start?.dateTime && !item.start?.date) return null;
-  // Skip all-day events unless config opts in (some calendars use all-day for real runs)
+  // Skip all-day events unless config opts in (some calendars use all-day for real runs).
+  // Sources with all-day overrides (e.g. CUNTh on WA Hash) must set
+  // `includeAllDayEvents: true` to admit them — including those recovered via the
+  // secondary singleEvents=false call. We deliberately don't carve out
+  // `recurringEventId` here: that field is also set on materialized RRULE instances,
+  // so a carve-out would silently ingest unwanted all-day recurring instances on
+  // sources that never opted in.
   if (item.start?.date && !item.start?.dateTime && !sourceConfig?.includeAllDayEvents) return null;
 
   const { dateISO, startTime } = extractDateTimeFromGCalItem(item.start);
@@ -913,7 +940,7 @@ export function buildRawEventFromGCalItem(
   // not stored as display location. resolveCoords handles URL → address resolution.
   const locationIsUrl = location && /^https?:\/\//i.test(location);
   const cost = rawDescription ? extractCostFromDescription(rawDescription) : undefined;
-  return {
+  const event: RawEventData = {
     date: dateISO,
     kennelTag,
     runNumber: extractRunNumber(summary, rawDescription, compiledRunNumberPatterns),
@@ -930,6 +957,8 @@ export function buildRawEventFromGCalItem(
     cost,
     sourceUrl: item.htmlLink,
   };
+  if (gcalIdMap && item.id) gcalIdMap.set(event, item.id);
+  return event;
 }
 
 /** Build diagnostic context for a parse error on a GCal item. */
@@ -972,7 +1001,6 @@ export class GoogleCalendarAdapter implements SourceAdapter {
     const events: RawEventData[] = [];
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
-    let pageToken: string | undefined;
     let totalItemsReturned = 0;
     let pagesProcessed = 0;
     const compiledHarePatterns = sourceConfig?.harePatterns?.length
@@ -987,18 +1015,144 @@ export class GoogleCalendarAdapter implements SourceAdapter {
     const compiledTitleHarePattern = sourceConfig?.titleHarePattern
       ? compilePatterns([sourceConfig.titleHarePattern], "i")[0]
       : undefined;
+    const gcalIdMap = new WeakMap<RawEventData, string>();
 
+    const buildEvents = (items: GCalEvent[], filter?: (item: GCalEvent) => boolean): void => {
+      let eventIndex = 0;
+      for (const item of items) {
+        if (filter && !filter(item)) {
+          eventIndex++;
+          continue;
+        }
+        try {
+          const event = buildRawEventFromGCalItem(
+            item, sourceConfig,
+            compiledHarePatterns, compiledRunNumberPatterns,
+            compiledSkipPatterns, compiledTitleHarePattern,
+            gcalIdMap,
+          );
+          if (event) events.push(event);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          errors.push(`Event parse error (${item.summary ?? "unknown"}): ${message}`);
+          errorDetails.parse = [...(errorDetails.parse ?? []), {
+            row: eventIndex,
+            section: "calendar_events",
+            error: message,
+            rawText: buildGCalDiagnosticContext(item),
+            partialData: { kennelTag: item.summary ?? "unknown", date: item.start?.dateTime ?? item.start?.date },
+          }];
+        }
+        eventIndex++;
+      }
+    };
+
+    const primary = await this.#fetchAllPages(
+      calendarId, apiKey,
+      { timeMin, timeMax, singleEvents: "true", orderBy: "startTime", maxResults: "250", hl: "en" },
+      errors, errorDetails,
+    );
+    pagesProcessed += primary.pagesProcessed;
+    totalItemsReturned += primary.items.length;
+    buildEvents(primary.items);
+
+    // Secondary call recovers RECURRENCE-ID exceptions that the primary call
+    // can't surface — e.g. orphan overrides on non-recurring masters with the
+    // epoch RECURRENCE-ID 19691231T160000 pattern (#1021).
+    // NB: orderBy=startTime is incompatible with singleEvents=false (API 400).
+    let exceptionsRecovered = 0;
+    try {
+      const secondary = await this.#fetchAllPages(
+        calendarId, apiKey,
+        { timeMin, timeMax, singleEvents: "false", maxResults: "250", hl: "en" },
+        errors, errorDetails,
+      );
+      pagesProcessed += secondary.pagesProcessed;
+      const primaryIds = new Set<string>();
+      for (const e of events) {
+        const id = gcalIdMap.get(e);
+        if (id) primaryIds.add(id);
+      }
+      const before = events.length;
+      buildEvents(secondary.items, (item) => {
+        if (!item.recurringEventId || !item.originalStartTime) return false;
+        if (item.id && primaryIds.has(item.id)) return false;
+        return true;
+      });
+      exceptionsRecovered = events.length - before;
+    } catch (err) {
+      // Never let the exception-recovery call break primary results — log and continue.
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(`Exception-recovery call failed: ${message}`);
+      errorDetails.fetch = [...(errorDetails.fetch ?? []), { status: 0, message: `Exception-recovery call failed: ${message}` }];
+    }
+
+    // Some calendars (e.g. Chicagoland's 4X2H4 routing) only populate the
+    // soonest-upcoming event's description; its hareline block carries the
+    // future dates → hare mappings used to back-fill the rest.
+    const backfillCount = applyInlineHarelineBackfill(
+      events,
+      sourceConfig?.inlineHarelinePattern,
+      { now },
+    );
+
+    const hasErrorDetails = hasAnyErrors(errorDetails);
+
+    // Dedup id-first when GCal returned a stable id; legacy composite-key
+    // fallback covers synthetic test fixtures and pre-id callers.
+    const seen = new Set<string>();
+    const dedupedEvents = events.filter(e => {
+      const id = gcalIdMap.get(e);
+      const key = id
+        ? `id:${id}`
+        : `legacy:${e.date}|${e.kennelTag}|${e.startTime ?? ""}|${e.title ?? ""}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    return {
+      events: dedupedEvents,
+      errors,
+      errorDetails: hasErrorDetails ? errorDetails : undefined,
+      diagnosticContext: {
+        calendarId: decodeURIComponent(calendarId),
+        pagesProcessed,
+        itemsReturned: totalItemsReturned,
+        ...(backfillCount > 0 && { inlineHarelineBackfilled: backfillCount }),
+        ...(exceptionsRecovered > 0 && { exceptionsRecovered }),
+      },
+    };
+  }
+
+  /**
+   * Paginated GET against `events.list`. Both primary (`singleEvents=true`)
+   * and secondary (`singleEvents=false`) calls funnel through here so they
+   * share fetch / error / page-token plumbing identically.
+   *
+   * Error handling: HTTP errors and JSON `data.error` responses are appended to
+   * the passed-in `errors` and `errorDetails.fetch` arrays and the page loop
+   * breaks — the method returns whatever items were collected so far. Only
+   * transport-level exceptions (DNS failure, abort, network down) propagate
+   * out of `fetch()`/`resp.json()`; callers wrap those in try/catch when they
+   * care (e.g. the secondary call must not break primary results).
+   */
+  async #fetchAllPages(
+    calendarId: string,
+    apiKey: string,
+    params: Record<string, string>,
+    errors: string[],
+    errorDetails: ErrorDetails,
+  ): Promise<{ items: GCalEvent[]; pagesProcessed: number }> {
+    const items: GCalEvent[] = [];
+    let pagesProcessed = 0;
+    let pageToken: string | undefined;
     do {
       const url = new URL(
         `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`,
       );
       url.searchParams.set("key", apiKey);
-      url.searchParams.set("timeMin", timeMin);
-      url.searchParams.set("timeMax", timeMax);
-      url.searchParams.set("singleEvents", "true");
-      url.searchParams.set("orderBy", "startTime");
-      url.searchParams.set("maxResults", "250");
-      url.searchParams.set("hl", "en");
+      for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
       if (pageToken) url.searchParams.set("pageToken", pageToken);
 
       const resp = await fetch(url.toString(), {
@@ -1023,63 +1177,11 @@ export class GoogleCalendarAdapter implements SourceAdapter {
       }
 
       pagesProcessed++;
-      const items = data.items ?? [];
-      totalItemsReturned += items.length;
-      let eventIndex = 0;
-
-      for (const item of items) {
-        try {
-          const event = buildRawEventFromGCalItem(item, sourceConfig, compiledHarePatterns, compiledRunNumberPatterns, compiledSkipPatterns, compiledTitleHarePattern);
-          if (event) events.push(event);
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          errors.push(`Event parse error (${item.summary ?? "unknown"}): ${message}`);
-          errorDetails.parse = [...(errorDetails.parse ?? []), {
-            row: eventIndex,
-            section: "calendar_events",
-            error: message,
-            rawText: buildGCalDiagnosticContext(item),
-            partialData: { kennelTag: item.summary ?? "unknown", date: item.start?.dateTime ?? item.start?.date },
-          }];
-        }
-        eventIndex++;
-      }
-
+      const pageItems = data.items ?? [];
+      items.push(...pageItems);
       pageToken = data.nextPageToken;
     } while (pageToken);
-
-    // Some calendars (e.g. Chicagoland's 4X2H4 routing) only populate the
-    // soonest-upcoming event's description; its hareline block carries the
-    // future dates → hare mappings used to back-fill the rest.
-    const backfillCount = applyInlineHarelineBackfill(
-      events,
-      sourceConfig?.inlineHarelinePattern,
-      { now },
-    );
-
-    const hasErrorDetails = hasAnyErrors(errorDetails);
-
-    // Dedup events with identical date+kennelTag+startTime+title from the same calendar
-    // (upstream calendars sometimes contain duplicate entries)
-    const seen = new Set<string>();
-    const dedupedEvents = events.filter(e => {
-      const key = `${e.date}|${e.kennelTag}|${e.startTime ?? ""}|${e.title ?? ""}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
-
-    return {
-      events: dedupedEvents,
-      errors,
-      errorDetails: hasErrorDetails ? errorDetails : undefined,
-      diagnosticContext: {
-        calendarId: decodeURIComponent(calendarId),
-        pagesProcessed,
-        itemsReturned: totalItemsReturned,
-        ...(backfillCount > 0 && { inlineHarelineBackfilled: backfillCount }),
-      },
-    };
+    return { items, pagesProcessed };
   }
 }
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1068,11 +1068,9 @@ export class GoogleCalendarAdapter implements SourceAdapter {
         errors, errorDetails,
       );
       pagesProcessed += secondary.pagesProcessed;
-      const primaryIds = new Set<string>();
-      for (const e of events) {
-        const id = gcalIdMap.get(e);
-        if (id) primaryIds.add(id);
-      }
+      const primaryIds = new Set(
+        events.map(e => gcalIdMap.get(e)).filter((id): id is string => !!id),
+      );
       const before = events.length;
       buildEvents(secondary.items, (item) => {
         if (!item.recurringEventId || !item.originalStartTime) return false;


### PR DESCRIPTION
## Summary

- The Google Calendar adapter calls `singleEvents=true`, which expands RRULE-based recurrences but silently drops orphan RECURRENCE-ID exceptions on non-recurring masters (the epoch `19691231T160000` pattern Google uses when a user adds overrides to a non-recurring event). CUNTh has 24+ of these.
- CUNTh's all-day overrides (`DTSTART;VALUE=DATE`) were also being filtered without an opt-in.
- Two affected kennels:
  - **CUNTh** (Seattle, on shared WA Hash calendar): 47 of 91 source events invisible on HashTracks
  - **DeMon** (Detroit): missing #1–#5 (Nov 17 – Dec 15, 2025) due to scrape-window + reconciliation interaction

### What changed
1. Adds `id` / `iCalUID` / `recurringEventId` / `originalStartTime` to `GCalEvent` interface.
2. Refactors pagination into private `#fetchAllPages` helper.
3. Adds a secondary `singleEvents=false` API call wrapped in `try/catch` so it can never break primary results. Filters to override exceptions only (`recurringEventId` + `originalStartTime`, status != cancelled, id not already in primary set).
4. Plumbs GCal `id` via a transient `WeakMap<RawEventData, string>` (no public `RawEventData` shape change) into the dedup.
5. Replaces dedup with id-first key (`id:X`) and a legacy composite-key fallback for synthetic test fixtures.
6. Sets `includeAllDayEvents: true` on the WA Hash source for CUNTh's all-day overrides — `strictKennelRouting: true` was already set, so non-CUNTh noise stays bounded.
7. Sweeps CUNTh + DeMon profile metadata: foundedYear, hashCash, facebookUrl, contactEmail, logoUrl.

## Live verification (days=1500)

- **DeMon H3**: 26/26 numbered runs (#1–#26) recovered. Was 21 before fix. Issue [#1024](https://github.com/johnrclem/hashtracks-web/issues/1024) target met.
- **CUNTh**: 22 of 24 previously-missing runs recovered (40, 62, 64, 65, 66, 67, 68, 70, 72, 73, 75, 76, 77, 78, 79, 80, 89, 90, 91, 92, 93, 95, 97, 101 → recovered 62, 64, 65, 67, 68, 70, 72, 73, 75, 76, 77, 78, 79, 80, 89, 90, 91, 92, 93, 95, 97, 101). #40 and #66 still missing — likely structural quirks unrelated to RECURRENCE-ID handling, can be triaged separately.
- 109 total CUNTh events visible (was 43); date range 2022-03-24 → 2027-04-22.

## Tests

- 8 new unit fixtures added covering: timed RRULE master + override (DeMon), all-day override on RRULE master with `includeAllDayEvents` opt-in, epoch RECURRENCE-ID on non-RRULE master, cross-call dedup, secondary-call HTTP 500 + thrown error, `start` vs `originalStartTime` divergence, inline-hareline backfill ordering, **regression guard** that ordinary all-day RRULE instances still drop without `includeAllDayEvents`.
- All 5302 unit tests pass; lint + typecheck clean for changed files.

## Reviews run

- Adversarial review (Codex) — flagged that an early `recurringEventId`-only carve-out on the all-day filter would admit ordinary all-day RRULE instances on sources that didn't opt in. Fixed by making `includeAllDayEvents` the sole opt-in path for both primary and secondary calls; added regression test.
- Simplify pass — trimmed redundant WHAT-comments, extracted `epochOverride` helper to deduplicate fixture C.

## Post-merge follow-up

Trigger admin wide-window scrape (`days=1500`) for both sources to backfill historical events. The merge pipeline's reconcile window expands with the scrape's `days`, so a wide-window scrape is safe — it won't cancel existing events.

## Test plan
- [x] `npx tsc --noEmit` clean for changed files
- [x] `npm run lint` clean for changed files
- [x] `npm test` — 5302 passed
- [x] Live verify against DeMon calendar (26 runs visible)
- [x] Live verify against WA Hash calendar (CUNTh 22/24 missing runs recovered)
- [ ] After merge: admin wide-window scrape on both sources; verify DeMon #1–#5 and CUNTh #40-#101 historical runs appear on kennel pages

Closes #1021
Closes #1022
Closes #1024
Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)