### PR TITLE
fix(chiangmai): hare-as-title bug + harden post-merge housekeeping

### DIFF
--- a/scripts/backfill-chiangmai-titles.ts
+++ b/scripts/backfill-chiangmai-titles.ts
@@ -1,0 +1,74 @@
+/**
+ * One-time backfill for #1058 fallout: Chiang Mai HHH events whose title was
+ * incorrectly set to the hare name. The adapter no longer emits `title`, but
+ * the merge update path preserves existing values, so already-persisted bad
+ * titles need to be rewritten by hand.
+ *
+ * Heuristic: kennel ∈ Chiang Mai 5 AND title === haresText.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-chiangmai-titles.ts          # dry run (default)
+ *   npx tsx scripts/backfill-chiangmai-titles.ts --apply   # apply changes
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { friendlyKennelName } from "../src/pipeline/merge";
+import { createScriptPool } from "./lib/db-pool";
+
+const CHIANG_MAI_KENNEL_CODES = ["ch3-cm", "ch4-cm", "cgh3", "csh3", "cbh3-cm"];
+const dryRun = !process.argv.includes("--apply");
+
+async function main() {
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
+
+  const kennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: CHIANG_MAI_KENNEL_CODES } },
+    select: { id: true, kennelCode: true, shortName: true, fullName: true },
+  });
+
+  let totalRewritten = 0;
+
+  for (const k of kennels) {
+    const display = friendlyKennelName(k.shortName, k.fullName);
+
+    const events = await prisma.event.findMany({
+      where: {
+        kennelId: k.id,
+        title: { not: null },
+        haresText: { not: null },
+      },
+      select: { id: true, title: true, haresText: true, runNumber: true },
+    });
+
+    const stale = events.filter((e) => e.title !== null && e.title === e.haresText);
+    if (stale.length === 0) {
+      console.log(`${k.kennelCode}: nothing to do (${events.length} events checked)`);
+      continue;
+    }
+
+    console.log(`\n${k.kennelCode} (${display}): ${stale.length} event(s) to rewrite`);
+    for (const e of stale) {
+      const next = e.runNumber ? `${display} Trail #${e.runNumber}` : `${display} Trail`;
+      console.log(`  ${e.id}: "${e.title}" → "${next}"`);
+      if (!dryRun) {
+        await prisma.event.update({ where: { id: e.id }, data: { title: next } });
+      }
+      totalRewritten++;
+    }
+  }
+
+  console.log(`\n${dryRun ? "Would rewrite" : "Rewrote"} ${totalRewritten} event title(s).`);
+  if (dryRun) console.log("Run with --apply to commit changes.");
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/verify-chiangmai-adapters.ts
+++ b/scripts/verify-chiangmai-adapters.ts
@@ -1,0 +1,51 @@
+import "dotenv/config";
+import { ChiangMaiHHHAdapter } from "@/adapters/html-scraper/chiangmai-hhh";
+import type { Source } from "@/generated/prisma/client";
+
+const KENNELS = [
+  { harelineKey: "ch3", path: "/ch3-hareline/" },
+  { harelineKey: "ch4", path: "/ch4-hareline/" },
+  { harelineKey: "cgh3", path: "/cgh3-hareline/" },
+  { harelineKey: "csh3", path: "/csh3-hareline/" },
+  { harelineKey: "cbh3", path: "/cbh3-hareline/" },
+] as const;
+
+async function main() {
+  const adapter = new ChiangMaiHHHAdapter();
+  let totalEvents = 0;
+  let titleSetCount = 0;
+
+  for (const { harelineKey, path } of KENNELS) {
+    const source = {
+      id: `verify-${harelineKey}`,
+      url: `http://www.chiangmaihhh.com${path}`,
+      config: { harelineKey },
+      scrapeDays: 365,
+    } as unknown as Source;
+
+    process.stdout.write(`\n=== ${harelineKey.toUpperCase()} (${path}) ===\n`);
+    const result = await adapter.fetch(source, { days: 365 });
+    if (result.errors?.length) {
+      process.stdout.write(`  errors: ${JSON.stringify(result.errors)}\n`);
+    }
+    process.stdout.write(`  events: ${result.events.length}\n`);
+    if (result.events.length > 0) {
+      const sample = result.events[0];
+      process.stdout.write(`  sample: ${JSON.stringify(sample)}\n`);
+    }
+    totalEvents += result.events.length;
+    for (const e of result.events) {
+      if (e.title !== undefined) titleSetCount++;
+    }
+  }
+
+  process.stdout.write(
+    `\n=== Summary: ${totalEvents} events across 5 kennels, ${titleSetCount} with title set (expect 0) ===\n`,
+  );
+  if (titleSetCount > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/chiangmai-hhh.test.ts
+++ b/src/adapters/html-scraper/chiangmai-hhh.test.ts
@@ -156,23 +156,19 @@ describe("parseChiangMaiLine", () => {
     expect(event!.hares).toContain("Anal Vice");
   });
 
-  describe("title preservation", () => {
+  describe("title is left unset (#1058)", () => {
+    // Per #1058, the adapter must not put hare names into `title` \u2014 they
+    // belong in `haresText` only. Leaving `title` undefined lets merge.ts
+    // synthesize a "{kennel.displayName} Trail #{N}" default, the same
+    // pattern used by every other hareline adapter.
     it.each([
-      ["CSH3 em-dash", "Saturday May 9 \u2013 CSH3 \u2013 Run #1811 \u2013 Stumbling Dyke", "csh3", "Stumbling Dyke"],
-      ["CH4 em-dash with '&' joiner", "Thursday 30 April \u2013 CH4 Run # 1102 \u2013 Bushy Tail & co-hare BUF", "ch4-cm", "Bushy Tail & co-hare BUF"],
-      ["CBH3 em-dash hare list", "Sunday 26 April \u2013 CBH3 \u2013 Run # 281 \u2013 Misfortune and Bare Bum", "cbh3-cm", "Misfortune and Bare Bum"],
-      ["CH3 whitespace form", "Monday 27th April CH3  Run # 1635 Dyke Converter", "ch3-cm", "Dyke Converter"],
-    ])("preserves title from %s", (_label, line, tag, expected) => {
+      ["CSH3 em-dash", "Saturday May 9 \u2013 CSH3 \u2013 Run #1811 \u2013 Stumbling Dyke", "csh3"],
+      ["CH4 em-dash with '&' joiner", "Thursday 30 April \u2013 CH4 Run # 1102 \u2013 Bushy Tail & co-hare BUF", "ch4-cm"],
+      ["CBH3 em-dash hare list", "Sunday 26 April \u2013 CBH3 \u2013 Run # 281 \u2013 Misfortune and Bare Bum", "cbh3-cm"],
+      ["CH3 whitespace form", "Monday 27th April CH3  Run # 1635 Dyke Converter", "ch3-cm"],
+      ["HARE NEEDED row", "Monday 18 May \u2013 CGH3 Run #258 \u2013 HARE NEEDED", "cgh3"],
+    ])("leaves title undefined for %s", (_label, line, tag) => {
       const event = parseChiangMaiLine(line, tag, SOURCE_URL);
-      expect(event!.title).toBe(expected);
-    });
-
-    it("HARE NEEDED rows leave title undefined so merge synthesizes a default", () => {
-      const event = parseChiangMaiLine(
-        "Monday 18 May \u2013 CGH3 Run #258 \u2013 HARE NEEDED",
-        "cgh3",
-        SOURCE_URL,
-      );
       expect(event!.title).toBeUndefined();
     });
   });

--- a/src/adapters/html-scraper/chiangmai-hhh.ts
+++ b/src/adapters/html-scraper/chiangmai-hhh.ts
@@ -70,13 +70,13 @@ export function parseChiangMaiLine(
   const runNumberRaw = Number.parseInt(runMatch[1], 10);
   const runNumber = Number.isNaN(runNumberRaw) ? undefined : runNumberRaw;
 
-  // The text after the run number is both the hare list (normalized) and the
-  // event title (verbatim — populating it stops merge.ts from synthesizing
-  // a default "{kennel.fullName} Trail #{N}" string).
-  // CGH3 pages prefix the name with a "Hare." label (e.g. "Hare. HRA") — strip
-  // it so only the name survives.
+  // Text after the run number is the hare list. CGH3 pages prefix the name
+  // with a "Hare." label (e.g. "Hare. HRA") — strip it so only the name
+  // survives. We deliberately leave `title` undefined so merge.ts synthesizes
+  // a "{kennel.displayName} Trail #{N}" default — putting the hare name into
+  // `title` (the previous behavior) caused #1058: hare names showed up as
+  // event titles in Hareline cards.
   let hares: string | undefined;
-  let title: string | undefined;
   const afterRun = cleaned.slice(runMatch.index + runMatch[0].length);
   const harePart = afterRun
     .replace(/^\s*[-–—]\s*/, "")
@@ -84,7 +84,6 @@ export function parseChiangMaiLine(
     .trim();
   if (harePart && !/^HARE NEEDED$/i.test(harePart) && !/^\?+$/.test(harePart)) {
     hares = normalizeHaresField(harePart);
-    title = harePart;
   }
 
   const beforeRun = cleaned.slice(0, runMatch.index).trim();
@@ -115,7 +114,6 @@ export function parseChiangMaiLine(
     kennelTag,
     runNumber,
     hares,
-    title,
     sourceUrl,
   };
 }

--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/db", () => ({
   prisma: {
@@ -43,11 +43,15 @@ vi.mock("./health", () => ({
   autoResolveCleared: vi.fn(() => Promise.resolve(0)),
 }));
 
-// Mock next/cache so the `revalidateTag(HARELINE_EVENTS_TAG)` call at
-// the tail of the happy-path scrape doesn't throw outside a request context.
+// Mock next/cache + next/server so the post-merge `revalidateTag(...)` and
+// `after(...)` calls at the tail of the happy-path scrape don't throw
+// outside a request context.
 vi.mock("next/cache", () => ({
   revalidateTag: vi.fn(),
   unstable_cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+}));
+vi.mock("next/server", () => ({
+  after: vi.fn(() => {}),
 }));
 
 import { prisma } from "@/lib/db";
@@ -55,6 +59,8 @@ import { getAdapter } from "@/adapters/registry";
 import { processRawEvents } from "./merge";
 import { analyzeHealth } from "./health";
 import { scrapeSource } from "./scrape";
+import { revalidateTag } from "next/cache";
+import { after } from "next/server";
 
 const mockSourceFind = vi.mocked(prisma.source.findUnique);
 const mockSourceUpdate = vi.mocked(prisma.source.update);
@@ -251,5 +257,47 @@ describe("scrapeSource", () => {
     const updateData = mockLogUpdate.mock.calls[0][0] as { data: Record<string, unknown> };
     expect(updateData.data.sampleBlocked).toEqual(sampleBlocked);
     expect(updateData.data.sampleSkipped).toEqual(sampleSkipped);
+  });
+
+  // Regression for #1053-1056. Both `after()` and `revalidateTag()` need a
+  // Next.js request scope. When something (Vercel cold-start race, library
+  // wrapping a Promise chain, etc.) breaks AsyncLocalStorage tracking they
+  // throw, and we used to bubble that into the outer catch and mark the
+  // entire scrape FAILED — even though merge had already persisted the
+  // events. Now they're best-effort.
+  describe("post-merge housekeeping resilience", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    afterEach(() => {
+      consoleErrorSpy.mockClear();
+    });
+
+    it("does not mark scrape FAILED when revalidateTag throws", async () => {
+      vi.mocked(revalidateTag).mockImplementationOnce(() => {
+        throw new Error("Invariant: static generation store missing in revalidateTag hareline:events");
+      });
+
+      const result = await scrapeSource("src_1");
+      expect(result.success).toBe(true);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("post-merge revalidateTag"),
+      );
+    });
+
+    it("does not mark scrape FAILED when after() throws", async () => {
+      mockProcessRaw.mockResolvedValueOnce({
+        ...fakeMergeResult,
+        createdEventIds: ["evt_1"],
+      });
+      vi.mocked(after).mockImplementationOnce(() => {
+        throw new Error("`after` was called outside a request scope");
+      });
+
+      const result = await scrapeSource("src_1");
+      expect(result.success).toBe(true);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("post-merge IndexNow ping"),
+      );
+    });
   });
 });

--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -281,6 +281,7 @@ describe("scrapeSource", () => {
       expect(result.success).toBe(true);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("post-merge revalidateTag"),
+        expect.any(Error),
       );
     });
 
@@ -297,6 +298,7 @@ describe("scrapeSource", () => {
       expect(result.success).toBe(true);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("post-merge IndexNow ping"),
+        expect.any(Error),
       );
     });
   });

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -492,8 +492,7 @@ export async function scrapeSource(
     // here must not roll back an already-persisted scrape. The Hareline
     // cache has a natural TTL and other mutation paths also invalidate it.
     const logHousekeepingError = (op: string, err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[scrape] post-merge ${op} failed for ${sourceId}: ${msg}`);
+      console.error(`[scrape] post-merge ${op} failed for ${sourceId}:`, err);
     };
 
     // IndexNow ping deferred via `after()` so it runs post-response.

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -488,22 +488,32 @@ export async function scrapeSource(
       reconcileSuppressedKennels,
     });
 
-    // Run IndexNow ping after the response is sent, so the serverless function
-    // doesn't get killed mid-request. No-op when key is unset or non-prod.
+    // Post-merge housekeeping is best-effort: a Next.js request-scope error
+    // here must not roll back an already-persisted scrape. The Hareline
+    // cache has a natural TTL and other mutation paths also invalidate it.
+    const logHousekeepingError = (op: string, err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[scrape] post-merge ${op} failed for ${sourceId}: ${msg}`);
+    };
+
+    // IndexNow ping deferred via `after()` so it runs post-response.
     if (mergeResult.createdEventIds.length > 0) {
-      const baseUrl = getCanonicalSiteUrl();
-      const urls = mergeResult.createdEventIds.map((id) => `${baseUrl}/hareline/${id}`);
-      after(() => pingIndexNow(urls));
+      try {
+        const baseUrl = getCanonicalSiteUrl();
+        const urls = mergeResult.createdEventIds.map((id) => `${baseUrl}/hareline/${id}`);
+        after(() => pingIndexNow(urls));
+      } catch (err) {
+        logHousekeepingError("IndexNow ping", err);
+      }
     }
 
-    // Bust the Hareline `unstable_cache` entries so the next request re-pulls
-    // from Postgres. Conditional on something actually changing: a scrape
-    // that found zero new/updated/cancelled events has no effect on what
-    // /hareline would display, so there's no reason to burn a warm cache.
-    // Single tag — all (mode, date) entries are invalidated at once. Cheap
-    // because the cache is small and naturally re-warms on the next visit.
+    // Bust the Hareline `unstable_cache` only when something actually changed.
     if (mergeResult.created + mergeResult.updated + cancelledCount + mergeResult.restored > 0) {
-      revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
+      try {
+        revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
+      } catch (err) {
+        logHousekeepingError(`revalidateTag(${HARELINE_EVENTS_TAG})`, err);
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary

- **#1058 (hare-as-title bug):** `parseChiangMaiLine` no longer sets `title = harePart`. Adapter leaves `title` undefined and merge.ts synthesizes "Chiang Mai H3 Trail #N" the same way it does for every other adapter. Hares stay in `haresText` where they belong.
- **38-event backfill applied to prod:** new `scripts/backfill-chiangmai-titles.ts` rewrote the already-persisted bad titles (idempotent — second dry-run reports zero remaining).
- **#1053-1056 (4 transient SCRAPE_FAILURE alerts):** wrapped the post-merge `after()` + `revalidateTag()` in try/catch with `logHousekeepingError`. Both calls require a Next.js request scope; a transient AsyncLocalStorage hiccup (Vercel cold-start race) used to bubble into the outer catch and mark the scrape FAILED — even though merge had already persisted events. Now it logs and degrades to the cache TTL.

## Why two fixes in one PR

Same cluster of issues (all 5 reference `chiangmai-hhh.ts`). #1053-1056 turned out to be a pipeline regression in `scrape.ts` introduced 2 days earlier (commit `250461eb`), not an adapter problem — the curl'd live HTML is unchanged. Fixing only the adapter would not have closed those alerts.

## Trade-off on the cache hardening

`revalidateTag` failure now degrades to the Hareline `unstable_cache`'s 3600s TTL instead of failing the scrape. Codex flagged this as a freshness risk; the prior behavior was strictly worse — the same failure mode prevented invalidation **and** emitted a noisy false alert **and** mis-recorded the scrapeLog as FAILED. The 1% transient-failure window now degrades gracefully instead of cascading.

## Test plan

- [x] Live verify all 5 Chiang Mai hareline pages — 77 events parsed, 0 with title set (`scripts/verify-chiangmai-adapters.ts`)
- [x] Backfill applied to prod — 38 events rewritten across CH3/CH4/CGH3/CSH3/CBH3
- [x] Re-run backfill in dry mode — 0 events to rewrite (idempotent)
- [x] Two new regression tests in `scrape.test.ts` cover both throwing paths
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (13 pre-existing warnings unrelated)
- [x] `npm test` — 5295/5295 pass

Closes #1053
Closes #1054
Closes #1055
Closes #1056
Closes #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)