### PR TITLE
fix(eh3): logo, hash cash, untitled-run title, special events

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2667,6 +2667,8 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "eh3-ab", shortName: "EH3", fullName: "Edmonton Hash House Harriers", region: "Edmonton, AB", country: "Canada",
       website: "https://www.eh3.org",
+      logoUrl: "https://www.eh3.org/wp-content/uploads/2017/08/EH3_icon.jpg",
+      hashCash: "$5",
       scheduleFrequency: "Weekly",
       scheduleNotes: "Monday 6:30pm (Apr-Sep), Saturday 2:00pm (Oct-Mar)",
       foundedYear: 1991,

--- a/src/adapters/html-scraper/eh3-edmonton.test.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.test.ts
@@ -84,7 +84,7 @@ describe("parseEh3EventBlock", () => {
       expect(result!.description).toContain("Hash Hold: Cherry Poppins");
     });
 
-    it("parses header without title", () => {
+    it("emits 'EH3 Run #NNNN' title for untitled numbered runs (#1044)", () => {
       const lines = [
         "EH3 Run # 1847 Monday April 20",
         "Hares: Very Saggy Testicles and Inky Dinky",
@@ -92,7 +92,7 @@ describe("parseEh3EventBlock", () => {
       const result = parseEh3EventBlock(lines, "eh3-ab", "18:30");
       expect(result).not.toBeNull();
       expect(result!.runNumber).toBe(1847);
-      expect(result!.title).toBeUndefined();
+      expect(result!.title).toBe("EH3 Run #1847");
       expect(result!.hares).toBe("Very Saggy Testicles and Inky Dinky");
     });
 
@@ -245,10 +245,51 @@ describe("parseEh3EventBlock", () => {
     });
   });
 
-  it("returns null for non-matching header", () => {
-    const lines = ["AGPU (Annual General Piss Up) SATURDAY AUGUST 29"];
-    const result = parseEh3EventBlock(lines, "eh3-ab", "18:30");
-    expect(result).toBeNull();
+  describe("EH3 special events without run number (#1045)", () => {
+    it("parses 'AGPU' header with caps day-of-week", () => {
+      const lines = ["AGPU (Annual General Piss Up)  SATURDAY AUGUST 29"];
+      const result = parseEh3EventBlock(lines, "eh3-ab", "18:30");
+      expect(result).not.toBeNull();
+      expect(result!.runNumber).toBeUndefined();
+      expect(result!.title).toBe("AGPU (Annual General Piss Up)");
+      expect(result!.date).toMatch(/^\d{4}-08-29$/);
+    });
+
+    it("parses 'Special Event' header with date range", () => {
+      const lines = [
+        "Special Event: Hash in Grande Cache – May 22-24 – detrails to come",
+      ];
+      const result = parseEh3EventBlock(lines, "eh3-ab", "18:30");
+      expect(result).not.toBeNull();
+      expect(result!.runNumber).toBeUndefined();
+      expect(result!.title).toBe("Special Event: Hash in Grande Cache");
+      expect(result!.date).toMatch(/^\d{4}-05-22$/);
+    });
+
+    it("returns null when no date is parseable", () => {
+      const lines = ["Random unrelated paragraph with no date or run header"];
+      const result = parseEh3EventBlock(lines, "eh3-ab", "18:30");
+      expect(result).toBeNull();
+    });
+
+    it("returns null for vague intro prose (no certain day)", () => {
+      const lines = [
+        "Unless otherwise posted, runs from April through September are held Mondays at 6:30 pm and runs from October through March are held Saturdays at 2:00 pm.",
+      ];
+      const result = parseEh3EventBlock(lines, "eh3-ab", "18:30");
+      expect(result).toBeNull();
+    });
+
+    it("returns null for incidental dated prose without a special-event marker", () => {
+      // A stray sentence with a certain date but no "Special Event:" prefix
+      // or ALL-CAPS day-of-week must not be ingested as a phantom event.
+      expect(parseEh3EventBlock(["Updated April 2, 2026"], "eh3-ab", "18:30")).toBeNull();
+      expect(parseEh3EventBlock(
+        ["Email the hares by April 15 to claim a date."],
+        "eh3-ab",
+        "18:30",
+      )).toBeNull();
+    });
   });
 });
 

--- a/src/adapters/html-scraper/eh3-edmonton.test.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.test.ts
@@ -280,6 +280,15 @@ describe("parseEh3EventBlock", () => {
       expect(result).toBeNull();
     });
 
+    it("returns event with undefined title when date is at start of header (no prefix)", () => {
+      const lines = ["SATURDAY AUGUST 29 – Special Event"];
+      const result = parseEh3EventBlock(lines, "eh3-ab", "18:30");
+      expect(result).not.toBeNull();
+      expect(result!.runNumber).toBeUndefined();
+      expect(result!.title).toBeUndefined();
+      expect(result!.date).toMatch(/^\d{4}-08-29$/);
+    });
+
     it("returns null for incidental dated prose without a special-event marker", () => {
       // A stray sentence with a certain date but no "Special Event:" prefix
       // or ALL-CAPS day-of-week must not be ingested as a phantom event.

--- a/src/adapters/html-scraper/eh3-edmonton.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.ts
@@ -61,6 +61,19 @@ function eh3StartTimeFromDay(dayOfWeek: string): string {
   return /saturday/i.test(dayOfWeek) ? "14:00" : "18:30";
 }
 
+/**
+ * EH3-specific special-event header detector — a guard for the chrono-based
+ * fallback in `parseEh3EventBlock`. The page marks special events with either
+ * a "Special Event:" prefix or an ALL-CAPS day-of-week (regular numbered runs
+ * use mixed-case "Monday"/"Saturday"). Without this guard, incidental dated
+ * prose like "Updated April 2, 2026" would be ingested as a phantom event.
+ */
+function isSpecialEventHeader(headerLine: string): boolean {
+  if (/^special event\b/i.test(headerLine)) return true;
+  // All-caps day-of-week (no /i flag) — distinguishes "SATURDAY" from "Saturday".
+  return /\b(?:MONDAY|TUESDAY|WEDNESDAY|THURSDAY|FRIDAY|SATURDAY|SUNDAY)\b/.test(headerLine);
+}
+
 /** Extract labeled field value from a line, e.g., "Hares: Foo and Bar" → "Foo and Bar" */
 function extractField(line: string, ...labels: string[]): string | undefined {
   for (const label of labels) {
@@ -120,6 +133,30 @@ export function parseEh3EventBlock(
         headerDate = parseDate(datePart) ?? undefined;
         matched = true;
         break;
+      }
+    }
+
+    // Fallback for special events without an "EH3 Run #" prefix (e.g.
+    // "Special Event: Hash in Grande Cache – May 22-24", "AGPU SATURDAY
+    // AUGUST 29"). Constrained by `isSpecialEventHeader` and a chrono
+    // isCertain check so incidental dated prose ("Updated April 2, 2026",
+    // "April through September") isn't ingested as a phantom event.
+    if (!matched && isSpecialEventHeader(headerLine)) {
+      const results = chrono.en.parse(headerLine, { instant: new Date() }, { forwardDate: true });
+      if (results.length > 0) {
+        const r = results[0];
+        const parsed = r.start;
+        if (parsed.isCertain("day") && parsed.isCertain("month")) {
+          const year = parsed.get("year");
+          const month = parsed.get("month");
+          const day = parsed.get("day");
+          if (year != null && month != null && day != null) {
+            headerDate = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+            const before = headerLine.substring(0, r.index).trim().replace(/[\s–—\-:]+$/, "").trim();
+            title = before || headerLine;
+            matched = true;
+          }
+        }
       }
     }
   } else if (kennelTag === "efmh3") {
@@ -239,6 +276,14 @@ export function parseEh3EventBlock(
     if (dayMatch) {
       startTime = eh3StartTimeFromDay(dayMatch[0]);
     }
+  }
+
+  // Emit an explicit title for untitled numbered runs to suppress the
+  // downstream merge fallback ("{friendlyKennelName} Trail #N"), which for
+  // EH3 expands to the unwanted "Edmonton H3 Trail #N". The source page
+  // itself labels these runs "EH3 Run #N".
+  if (kennelTag === "eh3-ab" && runNumber !== undefined && !title) {
+    title = `EH3 Run #${runNumber}`;
   }
 
   return {

--- a/src/adapters/html-scraper/eh3-edmonton.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.ts
@@ -153,7 +153,10 @@ export function parseEh3EventBlock(
           if (year != null && month != null && day != null) {
             headerDate = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
             const before = headerLine.substring(0, r.index).trim().replace(/[\s–—\-:]+$/, "").trim();
-            title = before || headerLine;
+            // If the date sits at the very start of the line, there's no
+            // prefix to use as a title — leave undefined so we don't end up
+            // with "SATURDAY AUGUST 29" or similar.
+            title = before || undefined;
             matched = true;
           }
         }


### PR DESCRIPTION
## Summary

Quick Win bundle from the chrome-kennel audit on Edmonton H3 (`eh3-ab`):

- **Profile metadata** (#1042, #1043): adds `logoUrl` and `hashCash: "$5"` to the EH3-AB seed block.
- **#1044** — adapter emits an explicit `"EH3 Run #N"` title for untitled numbered runs, suppressing the downstream merge fallback `"Edmonton H3 Trail #N"` (which doesn't match the source's own naming). `friendlyKennelName("EH3", "Edmonton Hash House Harriers")` expands to `"Edmonton H3"`, hence the unwanted placeholder; doing this in the adapter avoids touching shared merge code.
- **#1045** — adapter captures special events without run numbers via a guarded chrono fallback. Guard requires a `"Special Event:"` prefix or an ALL-CAPS day-of-week (regular runs use mixed-case `Monday`/`Saturday`) **and** chrono's `isCertain` for month + day, so incidental dated prose like `"Updated April 2, 2026"` or `"April through September"` doesn't get ingested as phantom events.

Out of scope: #1046 (schema gap for On-On / Scribe / hare notes) — requires Prisma schema work.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors
- [x] `npm test` — 5,297 tests pass (29 in `eh3-edmonton.test.ts`)
- [x] Live verification against `https://www.eh3.org/wp-json/wp/v2/pages/423`:
  - 18 events parsed (was 16 — `Grande Cache` + `AGPU` now included)
  - Untitled runs (`#1849`, `#1850`, `#1858`, …) render as `"EH3 Run #N"`
  - Real source titles preserved (`#1854` → `"D-Day Run"`, `#1856` → `"The Dick Run"`)
  - Vague intro prose (`"Unless otherwise posted, runs from April through September…"`) correctly dropped
- [x] `/codex:adversarial-review` (caught the original too-permissive fallback; tightened with `isSpecialEventHeader` guard)
- [x] `/simplify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)