### PR TITLE
fix(google-calendar): match run numbers when summary has whitespace after #

### DIFF
--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -185,6 +185,20 @@ describe("extractRunNumber", () => {
       ]),
     ).toBe(259);
   });
+
+  it("extracts from summary with space after hash (CUNTh-WA #40, #66)", () => {
+    expect(extractRunNumber("Cunth # 40: the perfect birthday")).toBe(40);
+    expect(extractRunNumber("CUNTh # 66 - Winner Winner Dildo Dinner")).toBe(66);
+  });
+
+  it("extracts from summary with multiple spaces after hash (El Paso H3)", () => {
+    expect(extractRunNumber("Hash#  2713")).toBe(2713);
+    expect(extractRunNumber("Christmas Lights Hash#  2713")).toBe(2713);
+  });
+
+  it("does not match qualifier text without a # (e.g. 'CUNTh 66ish')", () => {
+    expect(extractRunNumber("CUNTh 66ish Hiidea's Bday")).toBeUndefined();
+  });
 });
 
 // ── extractTitle ──

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -35,8 +35,8 @@ export function extractRunNumber(
   description?: string,
   customPatterns?: string[] | RegExp[],
 ): number | undefined {
-  // 1. Check summary first (e.g., "Beantown #255: ...", "BH3: ... #2781")
-  const summaryMatch = /#(\d+)/.exec(summary);
+  // 1. Check summary first (e.g., "Beantown #255: ...", "BH3: ... #2781", "Cunth # 40: ...")
+  const summaryMatch = /#\s*(\d+)/.exec(summary);
   if (summaryMatch) return Number.parseInt(summaryMatch[1], 10);
 
   if (!description) return undefined;


### PR DESCRIPTION
## Summary

- Recovers the last 2 missing CUNTh-WA runs (#40, #66) flagged in #1021. Their `Event` rows have always been in the DB — they had `runNumber = NULL` because the summary regex required digits to immediately follow `#`.
- Same gap affects ~597 other events (El Paso H3 `Hash#  2716`, etc.). Next scheduled scrape per source backfills `runNumber` organically.
- 1-character regex change in `extractRunNumber`: `/#(\d+)/` → `/#\s*(\d+)/`.

## Diagnostic evidence

- iCal feed (live) — both VEVENTs present, CONFIRMED:
  - `SUMMARY:Cunth # 40: the perfect birthday` (DTSTART 2023-07-27, between #39+#41)
  - `SUMMARY:CUNTh # 66 - Winner Winner Dildo Dinner` (DTSTART 2024-10-24, between #65+#67)
- Production DB — both rows exist (`Event.runNumber=NULL`); `RawEvent` rows fingerprinted, `eventId` linked.
- Wider impact query: `SELECT COUNT(*) FROM "Event" WHERE "runNumber" IS NULL AND title ~* '#\s+\d'` → **597 rows**.

## Risk

`\s*` is a single bounded character class — no nested quantifiers, no ReDoS surface. The pre-existing regex already matches `#5` in any text (e.g. `Apt #5 Trail`); this only adds the whitespace-tolerant variant of the same class. Downstream merge logic (`src/pipeline/merge.ts:873`) rejects fuzzy matches when runNumbers differ, so a false positive would just keep events split rather than corrupting canonical rows.

## Post-merge backfill

After Vercel deploys, the next scheduled WA Hash Calendar scrape (every 6h) re-processes RawEvents through the merge pipeline and writes `runNumber` to existing canonical Events. Admin can also force immediate backfill via `POST /api/admin/sources/<id>/scrape?days=1500&force=true`. Same applies to El Paso H3 + the other ~595 affected events — one re-scrape per source fills them in.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` (0 errors, pre-existing warnings only)
- [x] `npm test` — 5358 pass, 1 pre-existing flaky failure unrelated to this change (also fails on clean main: `recovered exceptions can serve as inline-hareline backfill donors`, date-math-dependent)
- [x] 3 new test cases in `extractRunNumber` describe block — all pass
- [x] /codex:adversarial-review run; finding evaluated and accepted (false-positive class unchanged from pre-existing regex)
- [x] /simplify run

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)