### PR TITLE
fix(seed): dump full conflict context on Source upsert failure

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -373,6 +373,7 @@ async function ensureSources(prisma: any, sources: any[], kennelRecords: Map<str
     const existingSource = matchingSources[0] ?? null;
 
     let activeSource;
+    let updates: Record<string, unknown> | null = null;
     try {
       if (!existingSource) {
         activeSource = await prisma.source.create({ data: sourceData });
@@ -381,7 +382,7 @@ async function ensureSources(prisma: any, sources: any[], kennelRecords: Map<str
       } else {
         activeSource = existingSource;
         // Sync mutable fields (config, name, trustLevel) so seed changes get applied
-        const updates: Record<string, unknown> = {};
+        updates = {};
         if (sourceData.trustLevel && sourceData.trustLevel > (existingSource.trustLevel ?? 0)) {
           updates.trustLevel = sourceData.trustLevel;
         }
@@ -409,9 +410,48 @@ async function ensureSources(prisma: any, sources: any[], kennelRecords: Map<str
       await linkKennelsToSource(prisma, activeSource.id, kennelCodes, kennelRecords, kennelSlugMap);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
+      const code = e != null && typeof e === "object" && "code" in e ? (e as { code: unknown }).code : undefined;
       const meta = e != null && typeof e === "object" && "meta" in e ? (e as { meta: unknown }).meta : undefined;
       console.error(`  ✗ FAILED to seed source "${sourceData.name}" (${sourceData.type}): ${msg}`);
+      if (code) console.error(`    Prisma code: ${code}`);
       if (meta) console.error(`    Prisma meta:`, JSON.stringify(meta));
+      console.error(`    Seed row:`, stableStringify(sourceData));
+      console.error(
+        `    Matched DB row:`,
+        existingSource
+          ? stableStringify({
+              id: existingSource.id,
+              name: existingSource.name,
+              type: existingSource.type,
+              url: existingSource.url,
+              enabled: existingSource.enabled,
+            })
+          : "<none — create-path failure>",
+      );
+      if (updates && Object.keys(updates).length > 0) {
+        console.error(`    Update payload:`, stableStringify(updates));
+      }
+      if (code === "P2002") {
+        try {
+          const conflicts = await prisma.source.findMany({
+            where: {
+              OR: [
+                { name: sourceData.name, type: sourceData.type },
+                ...(sourceData.url ? [{ url: sourceData.url }] : []),
+              ],
+            },
+            select: { id: true, name: true, type: true, url: true, enabled: true },
+            take: 10,
+          });
+          console.error(`    Rows colliding on (name,type) or url:`);
+          for (const row of conflicts) {
+            console.error(`      - ${stableStringify(row)}`);
+          }
+        } catch (lookupErr) {
+          const lookupMsg = lookupErr instanceof Error ? lookupErr.message : String(lookupErr);
+          console.error(`    (conflict lookup failed: ${lookupMsg})`);
+        }
+      }
       throw e;
     }
   }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -415,16 +415,21 @@ async function ensureSources(prisma: any, sources: any[], kennelRecords: Map<str
       console.error(`  ✗ FAILED to seed source "${sourceData.name}" (${sourceData.type}): ${msg}`);
       if (code) console.error(`    Prisma code: ${code}`);
       if (meta) console.error(`    Prisma meta:`, JSON.stringify(meta));
-      console.error(`    Seed row:`, stableStringify(sourceData));
+      // Log the full seed entry (including kennelCodes / kennelSlugMap) so failures inside
+      // linkKennelsToSource still record the association context that caused them.
+      console.error(`    Seed row:`, stableStringify(source));
+      // Prefer the just-created row when the create path succeeded but linkKennelsToSource
+      // then failed — existingSource is still null in that window.
+      const dbRow = activeSource ?? existingSource;
       console.error(
         `    Matched DB row:`,
-        existingSource
+        dbRow
           ? stableStringify({
-              id: existingSource.id,
-              name: existingSource.name,
-              type: existingSource.type,
-              url: existingSource.url,
-              enabled: existingSource.enabled,
+              id: dbRow.id,
+              name: dbRow.name,
+              type: dbRow.type,
+              url: dbRow.url,
+              enabled: dbRow.enabled,
             })
           : "<none — create-path failure>",
       );


### PR DESCRIPTION
## Summary

- Expands the catch block in `prisma/seed.ts::ensureSources()` so that any error — especially P2002 on the `(name, type)` unique — now prints the seed row, the matched DB row, the planned `updates` payload, and (on P2002) every Source row that collides on `(name, type)` or shares the seed URL. The conflict lookup is wrapped in its own try/catch so a transient DB issue during diagnostics can't shadow the original error.
- No schema changes, no behavior change on the happy path. Catch logs only — `throw e` is preserved so the seed still aborts on failure.

## Why

Prompted by a reported P2002 on `"Tokyo H3 Harrier Central"`. Read-only investigation surfaced what the prior catch made impossible to confirm:

- The only `Source` unique besides `id` is `@@unique([name, type])` (`prisma/schema.prisma:188-212`, migration `20260420203030_source_name_type_unique`). There is **no** unique on `url` — the original hand-off's "URL collision" hypothesis is structurally impossible.
- The current prod row for Tokyo H3 is field-for-field identical to the seed entry (name, type, url, trustLevel, scrapeFreq, scrapeDays, config). Exactly one matching `(name, type)` row exists in prod — no duplicates, case variants, or whitespace drift.
- Walking the `ensureSources` update path against this state yields `updates = {}`, the update is skipped entirely, and `linkKennelsToSource` no-ops on the existing `SourceKennel` row.

So either the failing run hit a transient duplicate that's since been cleaned up, or the truncated `UniqueConstraintViolation` message attributed the failure to the wrong source. The previous catch block (`e.message` + bare `e.meta`) couldn't disambiguate. **No data resolution was needed for this PR** — running `npx prisma db seed` end-to-end against prod after this change succeeded with 287 sources checked, 8 created, 0 errors.

The richer diagnostics are the durable fix the original hand-off explicitly flagged as step 5: the next on-call sees `id`/`name`/`url`/`enabled` for every conflicting row and can resolve in seconds instead of guessing.

## Notes / out of scope

- The prod DB has a `Singapore Sunday H3 Harrier Central` Source row that's in the worktree's `seed-data/sources.ts` but not in the user's `admin-ui-redesign` working copy. The reconciler at `seed.ts:425-445` would log it as stale; harmless because `SEED_RECONCILE_DISABLE` defaults off. Out of scope.
- Skipped two reviewer suggestions on intent: (1) static-importing `Prisma.PrismaClientKnownRequestError` for typed instanceof — `seed.ts:268` already uses the duck-typed `"code" in e` pattern, so the new catch matches local convention; (2) redacting `config` in logs — verified 0 hits for `apiKey/secret/token/password/credential` across all 230 seed config blocks (configs in this codebase contain CSS selectors, calendar IDs, kennel patterns; secrets live in env vars).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (14 pre-existing warnings, none touch `prisma/seed.ts`)
- [x] `npm test prisma/seed-data` — 2/2 pass
- [x] `npx prisma db seed` against Railway prod — exit 0, "Seed complete!", 287 sources checked, 0 errors
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)