### PR TITLE
feat(types): RawEventData.kennelTag → kennelTags: string[] (step 3 of #1023)

### DIFF
--- a/scripts/backfill-bh3-co-pre2015-history.ts
+++ b/scripts/backfill-bh3-co-pre2015-history.ts
@@ -243,7 +243,7 @@ function cleanedToRawEvent(row: CleanedRow): RawEventData | null {
       : undefined;
   return {
     date: row.date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber: row.runNumber && row.runNumber > 0 ? row.runNumber : undefined,
     title: row.title,
     hares: row.hares,

--- a/scripts/backfill-bmh3-history.ts
+++ b/scripts/backfill-bmh3-history.ts
@@ -268,7 +268,7 @@ function postToRawEvent(post: BloggerPost): RawEventData | SkipReason {
 
   return {
     date,
-    kennelTag: "bmh3-tx",
+    kennelTags: ["bmh3-tx"],
     runNumber: titleFields.runNumber,
     title: titleFields.title,
     hares: bodyFields.hares,

--- a/scripts/backfill-bssh3-ko-samet.ts
+++ b/scripts/backfill-bssh3-ko-samet.ts
@@ -36,7 +36,7 @@ const DEFAULT_START_TIME = "13:45"; // BSSH3's standard meet time
 const KO_SAMET_EVENTS: RawEventData[] = [
   {
     date: "2025-05-30",
-    kennelTag: KENNEL_CODE,
+    kennelTags: [KENNEL_CODE],
     runNumber: 10,
     title: "Run 10 - Ko Samet",
     location: "Ko Samet",
@@ -44,7 +44,7 @@ const KO_SAMET_EVENTS: RawEventData[] = [
   },
   {
     date: "2025-05-31",
-    kennelTag: KENNEL_CODE,
+    kennelTags: [KENNEL_CODE],
     runNumber: 11,
     title: "Run 11 - Ko Samet",
     location: "Ko Samet",

--- a/scripts/backfill-cch3-history.ts
+++ b/scripts/backfill-cch3-history.ts
@@ -134,7 +134,7 @@ function buildEvent(vevent: VEvent, titleHareRegex: RegExp): RawEventData | null
 
   return {
     date: dateStr,
-    kennelTag: parsed.kennelTag,
+    kennelTags: [parsed.kennelTag],
     runNumber: parsed.runNumber,
     title: parsed.title ?? summary,
     description: description?.substring(0, 2000) || undefined,

--- a/scripts/backfill-cch3-or-inaugural.ts
+++ b/scripts/backfill-cch3-or-inaugural.ts
@@ -34,7 +34,7 @@ const KENNEL_TIMEZONE = "America/Los_Angeles";
 const INAUGURAL_RUN: RawEventData[] = [
   {
     date: "2025-07-12",
-    kennelTag: "cch3-or",
+    kennelTags: ["cch3-or"],
     runNumber: 1,
     title: "Cherry City H3 #1 / OH3 # 1340",
     location: "Keizer Rapids Park, 1900 Chemawa Rd N, Keizer, OR 97303, USA",

--- a/scripts/backfill-cfh3-history.ts
+++ b/scripts/backfill-cfh3-history.ts
@@ -172,7 +172,7 @@ function cleanedToRawEvent(row: CleanedRow): RawEventData | null {
   const notes = row.notes && !/omit\s+hares/i.test(row.notes) ? row.notes : undefined;
   return {
     date: row.date,
-    kennelTag: "cfh3",
+    kennelTags: ["cfh3"],
     runNumber: row.runNumber && row.runNumber > 0 ? row.runNumber : undefined,
     title: row.title,
     hares: row.hares,

--- a/scripts/backfill-chain-gang-trail-40.ts
+++ b/scripts/backfill-chain-gang-trail-40.ts
@@ -40,7 +40,7 @@ const SOURCE_NAME = "Richmond H3 Meetup";
 const TRAIL_40: RawEventData[] = [
   {
     date: "2026-04-25",
-    kennelTag: "chain-gang-hhh",
+    kennelTags: ["chain-gang-hhh"],
     runNumber: 40,
     title: "ANNUAL GENERAL MEEING: Chain Gang Hash House Harriers Trail #40",
     startTime: "13:00",

--- a/scripts/backfill-meetup-history.ts
+++ b/scripts/backfill-meetup-history.ts
@@ -54,8 +54,8 @@ for (const source of meetupSources) {
   const url = source.url;
 
   if (typeof defaultKennel !== "string" || !defaultKennel) {
-    console.log(`Skipping ${source.name}: missing config.kennelTag`);
-    summary.push({ source: source.name, kennel: "?", status: "skipped", detail: "missing config.kennelTag" });
+    console.log(`Skipping ${source.name}: missing config.kennelTags[0]`);
+    summary.push({ source: source.name, kennel: "?", status: "skipped", detail: "missing config.kennelTags[0]" });
     continue;
   }
   if (typeof url !== "string" || !url.includes("meetup.com")) {

--- a/scripts/import-meetup-history.ts
+++ b/scripts/import-meetup-history.ts
@@ -243,9 +243,11 @@ async function main() {
 
     events.push({
       date: row.date,
-      kennelTag: kennelOverride
-        ? kennelOverride
-        : resolveKennelTag(row.title, defaultKennelCode, compiledPatterns),
+      kennelTags: [
+        kennelOverride
+          ? kennelOverride
+          : resolveKennelTag(row.title, defaultKennelCode, compiledPatterns),
+      ],
       title: row.title,
       runNumber: extractRunNumber(row.title),
       startTime: row.startTime || undefined,

--- a/scripts/import-meetup-history.ts
+++ b/scripts/import-meetup-history.ts
@@ -244,9 +244,7 @@ async function main() {
     events.push({
       date: row.date,
       kennelTags: [
-        kennelOverride
-          ? kennelOverride
-          : resolveKennelTag(row.title, defaultKennelCode, compiledPatterns),
+        kennelOverride ?? resolveKennelTag(row.title, defaultKennelCode, compiledPatterns),
       ],
       title: row.title,
       runNumber: extractRunNumber(row.title),

--- a/scripts/lib/gcal-backfill.ts
+++ b/scripts/lib/gcal-backfill.ts
@@ -36,14 +36,14 @@ function logEventSamples(events: readonly RawEventData[]): void {
   console.log("\nFirst 3:");
   for (const e of events.slice(0, 3)) {
     console.log(
-      `  ${e.date} #${e.runNumber ?? "?"} ${e.kennelTag} | ${e.title ?? "—"} | hares=${e.hares ?? "—"}`,
+      `  ${e.date} #${e.runNumber ?? "?"} ${e.kennelTags[0]} | ${e.title ?? "—"} | hares=${e.hares ?? "—"}`,
     );
   }
   if (events.length > 3) {
     console.log("Last 3:");
     for (const e of events.slice(-3)) {
       console.log(
-        `  ${e.date} #${e.runNumber ?? "?"} ${e.kennelTag} | ${e.title ?? "—"} | hares=${e.hares ?? "—"}`,
+        `  ${e.date} #${e.runNumber ?? "?"} ${e.kennelTags[0]} | ${e.title ?? "—"} | hares=${e.hares ?? "—"}`,
       );
     }
   }
@@ -83,7 +83,7 @@ export async function backfillGCalSource(params: GCalBackfillParams): Promise<vo
     // Tally per-kennel for visibility on multi-kennel calendars.
     const byKennel = new Map<string, number>();
     for (const ev of historical) {
-      byKennel.set(ev.kennelTag, (byKennel.get(ev.kennelTag) ?? 0) + 1);
+      byKennel.set(ev.kennelTags[0], (byKennel.get(ev.kennelTags[0]) ?? 0) + 1);
     }
     if (byKennel.size > 0) {
       console.log("  Per-kennel:");

--- a/scripts/lib/sfh3-backfill.ts
+++ b/scripts/lib/sfh3-backfill.ts
@@ -142,7 +142,7 @@ async function fetchPeriodRows(
       : url;
     events.push({
       date,
-      kennelTag: kennelCode,
+      kennelTags: [kennelCode],
       runNumber: row.runNumber,
       title: row.title || undefined,
       hares: row.hare,

--- a/scripts/merge-orphan-rawevents.ts
+++ b/scripts/merge-orphan-rawevents.ts
@@ -63,11 +63,17 @@ async function main() {
     // Guard against malformed legacy rows: rawData is `Json` in the schema,
     // so a missing/non-string `date` would throw on `localeCompare`. Skip
     // dirty rows (with a warning) so dry-run survives.
+    //
+    // Also normalize legacy `kennelTag: string` payloads (pre-#1023 step 3)
+    // into the new `kennelTags: string[]` shape — old RawEvents persisted
+    // before step 3 deployed still have the bare string, and merge.ts now
+    // dereferences `event.kennelTags[0]` unconditionally.
     const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+    type LegacyOrCurrent = Partial<RawEventData> & { kennelTag?: string };
     const mergeable: { id: string; event: RawEventData }[] = [];
     let skippedMalformed = 0;
     for (const o of orphans) {
-      const raw = o.rawData as unknown as Partial<RawEventData> | null;
+      const raw = o.rawData as unknown as LegacyOrCurrent | null;
       if (!raw || typeof raw.date !== "string" || !ISO_DATE_RE.test(raw.date)) {
         skippedMalformed++;
         if (skippedMalformed <= 5) {
@@ -75,7 +81,15 @@ async function main() {
         }
         continue;
       }
-      mergeable.push({ id: o.id, event: raw as RawEventData });
+      const kennelTags = raw.kennelTags ?? (raw.kennelTag ? [raw.kennelTag] : undefined);
+      if (!kennelTags || kennelTags.length === 0) {
+        skippedMalformed++;
+        if (skippedMalformed <= 5) {
+          console.warn(`  Skipping malformed orphan ${o.id}: missing kennelTag/kennelTags`);
+        }
+        continue;
+      }
+      mergeable.push({ id: o.id, event: { ...raw, kennelTags } as RawEventData });
     }
     if (skippedMalformed > 5) {
       console.warn(`  …${skippedMalformed - 5} more malformed orphans skipped`);

--- a/scripts/scrape-hashnyc-hares.ts
+++ b/scripts/scrape-hashnyc-hares.ts
@@ -138,7 +138,7 @@ function parseRowsFromHtml(
 
       events.push({
         date: dateStr,
-        kennelTag: parsed.kennelTag,
+        kennelTags: [parsed.kennelTag],
         runNumber: parsed.runNumber,
         title: parsed.title,
         description: parsed.description,
@@ -438,7 +438,7 @@ async function main() {
     if (!event.hares) continue;
     eventsWithHares++;
 
-    const kennel = event.kennelTag;
+    const kennel = event.kennelTags[0];
     if (!namesByKennel.has(kennel)) namesByKennel.set(kennel, []);
 
     const names = splitHareNames(event.hares);

--- a/scripts/verify-hashrego-step2b.ts
+++ b/scripts/verify-hashrego-step2b.ts
@@ -83,7 +83,7 @@ async function main() {
   if (sample) {
     console.log("\nSample event:");
     console.log(`  date:      ${sample.date}`);
-    console.log(`  kennelTag: ${sample.kennelTag}`);
+    console.log(`  kennelTag: ${sample.kennelTags[0]}`);
     console.log(`  title:     ${sample.title}`);
     console.log(`  startTime: ${sample.startTime}`);
   }
@@ -103,7 +103,7 @@ async function main() {
     pageEventsFound > 0 &&
     sample !== undefined &&
     !!sample.date &&
-    !!sample.kennelTag;
+    !!sample.kennelTags[0];
   function check(pass: boolean, detail?: string): string {
     const icon = pass ? "✅" : "❌";
     return detail ? `${icon} ${detail}` : icon;
@@ -114,7 +114,7 @@ async function main() {
   console.log(`top-level errors empty:          ${check(result.errors.length === 0)}`);
   console.log(`kennelPagesChecked > 10:         ${check(checked > 10, `(${checked})`)}`);
   console.log(`kennelPageEventsFound > 0:       ${check(pageEventsFound > 0)}`);
-  console.log(`sample has date + kennelTag:     ${check(!!sample?.date && !!sample?.kennelTag)}`);
+  console.log(`sample has date + kennelTag:     ${check(!!sample?.date && !!sample?.kennelTags[0])}`);
   console.log(`\n  (kennelPageFetchErrors: ${pageFetchErrors} — per-slug not_found is expected if the DB has drifted from the live API; check errorDetails.fetch[] for kinds)`);
 
   await pool.end();

--- a/scripts/verify-round2-fixes.ts
+++ b/scripts/verify-round2-fixes.ts
@@ -55,7 +55,7 @@ async function main() {
       180,
       cfg => ({ ...cfg, defaultTitles: { ...(cfg.defaultTitles as Record<string, string> | undefined), "wasatch-h3": "Wasatch H3 Trail" } }),
     );
-    const wasatch = events.filter(e => e.kennelTag === "wasatch-h3");
+    const wasatch = events.filter(e => e.kennelTags[0] === "wasatch-h3");
     const bad = wasatch.filter(e => /^wasatch\s*#?\d+$/i.test(e.title ?? ""));
     const healed = wasatch.filter(e => /^Wasatch H3 Trail #\d+$/.test(e.title ?? ""));
     print("#796 Wasatch bare-code titles", bad.length === 0 && healed.length > 0,

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -46,7 +46,7 @@ describe("Boston Hash Calendar multi-kennel routing (#789)", () => {
       { summary, start: { dateTime: "2026-04-15T19:00:00-04:00" }, status: "confirmed" },
       config,
     );
-    expect(result?.kennelTag).toBe(expectedTag);
+    expect(result?.kennelTags[0]).toBe(expectedTag);
   });
 
   it("unmatched titles pass summary through as kennelTag (distinct UNMATCHED_TAGS alerts, #789)", () => {
@@ -54,7 +54,7 @@ describe("Boston Hash Calendar multi-kennel routing (#789)", () => {
       { summary: "AGM Planning Meeting", start: { dateTime: "2026-04-15T19:00:00-04:00" }, status: "confirmed" },
       config,
     );
-    expect(result?.kennelTag).toBe("AGM Planning Meeting");
+    expect(result?.kennelTags[0]).toBe("AGM Planning Meeting");
   });
 });
 
@@ -78,7 +78,7 @@ describe("Colorado H3 Aggregator multi-kennel routing (#850)", () => {
       { summary, start: { dateTime: "2026-04-15T19:00:00-06:00" }, status: "confirmed" },
       config,
     );
-    expect(result?.kennelTag).toBe(expectedTag);
+    expect(result?.kennelTags[0]).toBe(expectedTag);
   });
 
   it.each([
@@ -91,7 +91,7 @@ describe("Colorado H3 Aggregator multi-kennel routing (#850)", () => {
       { summary, start: { dateTime: "2026-04-15T19:00:00-06:00" }, status: "confirmed" },
       config,
     );
-    expect(result?.kennelTag).toBe(summary);
+    expect(result?.kennelTags[0]).toBe(summary);
   });
 });
 
@@ -103,7 +103,7 @@ describe("resolveKennelTagFromSummary with no config", () => {
       { summary: "Some Random Event", start: { dateTime: "2026-04-15T19:00:00-04:00" }, status: "confirmed" },
       null,
     );
-    expect(result?.kennelTag).toBe("Some Random Event");
+    expect(result?.kennelTags[0]).toBe("Some Random Event");
   });
 });
 
@@ -972,7 +972,7 @@ describe("buildRawEventFromGCalItem — skipPatterns", () => {
       skipPatterns,
     );
     expect(result).not.toBeNull();
-    expect(result!.kennelTag).toBe("philly-h3");
+    expect(result!.kennelTags[0]).toBe("philly-h3");
   });
 
   it("works with empty skipPatterns array", () => {
@@ -1024,7 +1024,7 @@ describe("buildRawEventFromGCalItem — skipPatterns", () => {
         PHILLY_SKIP,
       );
       expect(result).not.toBeNull();
-      expect(result!.kennelTag).toBe("philly-h3");
+      expect(result!.kennelTags[0]).toBe("philly-h3");
     });
 
     it("drops a pure N2H3-titled event from the Oregon calendar", () => {
@@ -1058,7 +1058,7 @@ describe("buildRawEventFromGCalItem — skipPatterns", () => {
         OREGON_SKIP,
       );
       expect(result).not.toBeNull();
-      expect(result!.kennelTag).toBe("oh3");
+      expect(result!.kennelTags[0]).toBe("oh3");
     });
   });
 });
@@ -1928,7 +1928,7 @@ describe("applyInlineHarelineBackfill (#498)", () => {
   function makeEvent(overrides: Partial<RawEventData>): RawEventData {
     return {
       date: "2026-04-07",
-      kennelTag: "4x2h4",
+      kennelTags: ["4x2h4"],
       title: "4x2 H4 No. 124",
       ...overrides,
     };
@@ -1964,7 +1964,7 @@ describe("applyInlineHarelineBackfill (#498)", () => {
   it("ignores events for other kennels", () => {
     const events = [
       makeEvent({ date: "2026-04-07", hares: "Lifa", description: donorDescription }),
-      makeEvent({ date: "2026-05-05", kennelTag: "ch3" }),
+      makeEvent({ date: "2026-05-05", kennelTags: ["ch3"] }),
     ];
     applyInlineHarelineBackfill(events, pattern, { now });
     expect(events[1].hares).toBeUndefined();
@@ -2206,7 +2206,7 @@ describe("buildRawEventFromGCalItem — strictKennelRouting (#753 WA Hash)", () 
       testGCalEvent({ summary: "Seattle H3 #500" }),
       config,
     );
-    expect(result?.kennelTag).toBe("seattle-h3");
+    expect(result?.kennelTags[0]).toBe("seattle-h3");
   });
 
   it("falls back to defaultKennelTag when strictKennelRouting is not set", () => {
@@ -2217,7 +2217,7 @@ describe("buildRawEventFromGCalItem — strictKennelRouting (#753 WA Hash)", () 
         defaultKennelTag: "wa-hash",
       },
     );
-    expect(result?.kennelTag).toBe("wa-hash");
+    expect(result?.kennelTags[0]).toBe("wa-hash");
   });
 });
 
@@ -2394,7 +2394,7 @@ describe("Chicagoland Hash Calendar routing (#938)", () => {
       { summary, start: { dateTime: "2026-04-15T19:00:00-05:00" }, status: "confirmed" },
       config,
     );
-    expect(result?.kennelTag).toBe(expectedTag);
+    expect(result?.kennelTags[0]).toBe(expectedTag);
   });
 
   it("drops C2B3H4 placeholder 'HARE NEEDED' events (CTA filter)", () => {
@@ -2414,7 +2414,7 @@ describe("Chicagoland Hash Calendar routing (#938)", () => {
       { summary: "Hash Ball 2026", start: { dateTime: "2026-12-31T19:00:00-05:00" }, status: "confirmed" },
       config,
     );
-    expect(result?.kennelTag).toBe("ch3");
+    expect(result?.kennelTags[0]).toBe("ch3");
   });
 });
 
@@ -2440,7 +2440,7 @@ describe("Oregon Hashing Calendar routing (#991)", () => {
       { summary, start: { dateTime: "2026-07-12T19:00:00-07:00" }, status: "confirmed" },
       config,
     );
-    expect(result?.kennelTag).toBe(expectedTag);
+    expect(result?.kennelTags[0]).toBe(expectedTag);
   });
 });
 
@@ -2654,7 +2654,7 @@ describe("GoogleCalendarAdapter — RECURRENCE-ID override recovery (#1021/#1024
       try {
         const res = await adapter.fetch(makeSource({ defaultKennelTag: "demon-h3" }), { days: 90 });
         expect(res.events).toHaveLength(1);
-        expect(res.events[0].kennelTag).toBe("demon-h3");
+        expect(res.events[0].kennelTags[0]).toBe("demon-h3");
         expect(res.events[0].date).toBe("2025-12-15");
         expect(res.events[0].startTime).toBe("18:30");
         expect(res.events[0].title).toBe("DeMon H3 #5 - Bah Humbug");
@@ -2695,7 +2695,7 @@ describe("GoogleCalendarAdapter — RECURRENCE-ID override recovery (#1021/#1024
           { days: 90 },
         );
         expect(res.events).toHaveLength(1);
-        expect(res.events[0].kennelTag).toBe("cunth3-wa");
+        expect(res.events[0].kennelTags[0]).toBe("cunth3-wa");
         expect(res.events[0].date).toBe("2025-10-23");
         expect(res.events[0].startTime).toBeUndefined();
       } finally {

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -942,7 +942,7 @@ export function buildRawEventFromGCalItem(
   const cost = rawDescription ? extractCostFromDescription(rawDescription) : undefined;
   const event: RawEventData = {
     date: dateISO,
-    kennelTag,
+    kennelTags: [kennelTag],
     runNumber: extractRunNumber(summary, rawDescription, compiledRunNumberPatterns),
     title,
     description: appendDescriptionSuffix(description, sourceConfig?.descriptionSuffix),
@@ -1040,7 +1040,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
             section: "calendar_events",
             error: message,
             rawText: buildGCalDiagnosticContext(item),
-            partialData: { kennelTag: item.summary ?? "unknown", date: item.start?.dateTime ?? item.start?.date },
+            partialData: { kennelTags: [item.summary ?? "unknown"], date: item.start?.dateTime ?? item.start?.date },
           }];
         }
         eventIndex++;
@@ -1103,7 +1103,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
       const id = gcalIdMap.get(e);
       const key = id
         ? `id:${id}`
-        : `legacy:${e.date}|${e.kennelTag}|${e.startTime ?? ""}|${e.title ?? ""}`;
+        : `legacy:${e.date}|${e.kennelTags[0]}|${e.startTime ?? ""}|${e.title ?? ""}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;
@@ -1215,7 +1215,7 @@ export function applyInlineHarelineBackfill(
   const todayIso = new Date(referenceTime - 86_400_000).toISOString().split("T")[0];
   const donor = events
     .filter((e) =>
-      e.kennelTag === targetKennel
+      e.kennelTags[0] === targetKennel
       && e.date >= todayIso
       && !!e.description?.includes(blockHeader),
     )
@@ -1229,7 +1229,7 @@ export function applyInlineHarelineBackfill(
 
   let backfilled = 0;
   for (const event of events) {
-    if (event.kennelTag !== targetKennel) continue;
+    if (event.kennelTags[0] !== targetKennel) continue;
     if (event.hares) continue;
     const hares = absoluteMap[event.date];
     if (hares) {

--- a/src/adapters/google-sheets/adapter.test.ts
+++ b/src/adapters/google-sheets/adapter.test.ts
@@ -479,7 +479,7 @@ describe("GoogleSheetsAdapter.fetch — skipRows", () => {
     const result = await adapter.fetch(source);
 
     expect(result.events.length).toBe(1);
-    expect(result.events[0].kennelTag).toBe("TestH3");
+    expect(result.events[0].kennelTags[0]).toBe("TestH3");
     expect(result.events[0].runNumber).toBe(100);
     expect(result.events[0].title).toBe("Fun Run");
   });
@@ -583,7 +583,7 @@ describe("GoogleSheetsAdapter.fetch — csvUrl", () => {
 
     expect(result.events.length).toBe(1);
     expect(result.events[0].title).toBe("Pub Crawl");
-    expect(result.events[0].kennelTag).toBe("TestH3");
+    expect(result.events[0].kennelTags[0]).toBe("TestH3");
 
     // Verify it fetched from the csvUrl directly
     const fetchedUrl = mockedSafeFetch.mock.calls[0][0] as string;

--- a/src/adapters/google-sheets/adapter.ts
+++ b/src/adapters/google-sheets/adapter.ts
@@ -399,7 +399,7 @@ export function buildEventFromSheetRow(
 
   return {
     date: dateStr,
-    kennelTag: resolved.kennelTag,
+    kennelTags: [resolved.kennelTag],
     runNumber: resolved.runNumber,
     title,
     description,

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -162,7 +162,7 @@ describe("HarrierCentralAdapter", () => {
       const evt = result.events[0];
       expect(evt.date).toBe("2026-04-27");
       expect(evt.startTime).toBe("19:15");
-      expect(evt.kennelTag).toBe("tokyo-h3");
+      expect(evt.kennelTags[0]).toBe("tokyo-h3");
       expect(evt.title).toBe("Takadanobanba");
       expect(evt.runNumber).toBe(2577);
       expect(evt.hares).toBe("Khuming Rouge");
@@ -235,15 +235,15 @@ describe("HarrierCentralAdapter", () => {
 
       const result = await adapter.fetch(source);
       expect(result.events).toHaveLength(2);
-      expect(result.events[0].kennelTag).toBe("seamon-h3");
-      expect(result.events[1].kennelTag).toBe("psh3");
+      expect(result.events[0].kennelTags[0]).toBe("seamon-h3");
+      expect(result.events[1].kennelTags[0]).toBe("psh3");
     });
 
     it("falls back to kennelUniqueShortName when no config patterns match", async () => {
       mockApiResponse([buildHCEvent()]);
       const result = await adapter.fetch(makeSource({}));
       expect(result.events).toHaveLength(1);
-      expect(result.events[0].kennelTag).toBe("TH3");
+      expect(result.events[0].kennelTags[0]).toBe("TH3");
     });
 
     it("handles API errors gracefully", async () => {

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -176,8 +176,7 @@ export class HarrierCentralAdapter implements SourceAdapter {
       // to the kennel website / other EventLinks when sourceUrl is null.
       const raw: RawEventData = {
         date: dateStr,
-        kennelTag,
-        title: hcEvent.eventName || undefined,
+        kennelTags: [kennelTag],        title: hcEvent.eventName || undefined,
         // Socials / "drinking practices" come back as eventNumber=0. Map that
         // sentinel to null (explicit clear) and positive values to the number;
         // anything else stays undefined so the merge UPDATE path preserves an

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -692,7 +692,7 @@ describe("splitToRawEvents", () => {
     const events = splitToRawEvents(parsed, "bfmh3-agm-2026");
     expect(events).toHaveLength(1);
     expect(events[0].date).toBe("2026-02-05");
-    expect(events[0].kennelTag).toBe("BFMH3");
+    expect(events[0].kennelTags[0]).toBe("BFMH3");
     expect(events[0].sourceUrl).toBe("https://hashrego.com/events/bfmh3-agm-2026");
     expect(events[0].externalLinks).toEqual([
       { url: "https://hashrego.com/events/bfmh3-agm-2026", label: "Hash Rego" },
@@ -842,7 +842,7 @@ describe("HashRegoAdapter", () => {
     const result = await adapter.fetch(source, { days: 36500, kennelSlugs: ["EWH3"] });
 
     expect(result.events.length).toBeGreaterThan(0);
-    expect(result.events[0].kennelTag).toBe("EWH3");
+    expect(result.events[0].kennelTags[0]).toBe("EWH3");
     expect(result.events[0].date).toBe("2026-02-19");
     expect(result.errors.length).toBeGreaterThan(0);
   });

--- a/src/adapters/hashrego/adapter.ts
+++ b/src/adapters/hashrego/adapter.ts
@@ -292,7 +292,7 @@ async function fetchAndParseDetail(
       error: msg,
       rawText: `Slug: ${entry.slug}\nTitle: ${entry.title ?? "unknown"}\nDate: ${entry.startDate ?? "unknown"}`.slice(0, 2000),
       partialData: {
-        kennelTag: entry.kennelSlug,
+        kennelTags: [entry.kennelSlug],
         sourceUrl: eventDetailUrl(entry.slug),
       },
     });
@@ -425,7 +425,7 @@ async function fetchAndConvertKennelEvents(
         section: slug,
         error: message,
         rawText: safeApiRowSample(row ?? {}),
-        partialData: { kennelTag: slug, sourceUrl },
+        partialData: { kennelTags: [slug], sourceUrl },
       });
     }
   });
@@ -447,7 +447,7 @@ function createFromIndex(entry: IndexEntry): RawEventData[] {
   return [
     {
       date,
-      kennelTag: entry.kennelSlug,
+      kennelTags: [entry.kennelSlug],
       title: entry.title,
       startTime: time || undefined,
       sourceUrl: hashRegoUrl,

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -276,7 +276,7 @@ export function splitToRawEvents(
     return [
       {
         date,
-        kennelTag: parsed.hostKennelName || parsed.kennelSlug,
+        kennelTags: [parsed.hostKennelName || parsed.kennelSlug],
         title: parsed.title,
         description: parsed.description,
         hares: parsed.hares,
@@ -296,7 +296,7 @@ export function splitToRawEvents(
       i === 0 ? "Day 1" : i === parsed.dates.length - 1 ? `Day ${i + 1}` : `Day ${i + 1}`;
     return {
       date,
-      kennelTag: parsed.hostKennelName || parsed.kennelSlug,
+      kennelTags: [parsed.hostKennelName || parsed.kennelSlug],
       title: `${parsed.title} (${dayLabel})`,
       description: parsed.description,
       hares: parsed.hares,

--- a/src/adapters/html-scraper/adelaide-h3.test.ts
+++ b/src/adapters/html-scraper/adelaide-h3.test.ts
@@ -19,7 +19,7 @@ describe("adelaide-h3 parseAdelaideEvent", () => {
     expect(e!.runNumber).toBe(2645);
     expect(e!.date).toBe("2026-04-13");
     expect(e!.startTime).toBe("19:00");
-    expect(e!.kennelTag).toBe("ah3-au");
+    expect(e!.kennelTags[0]).toBe("ah3-au");
     expect(e!.hares).toBe("Crunchy Crack and Unstoppable");
   });
 

--- a/src/adapters/html-scraper/adelaide-h3.ts
+++ b/src/adapters/html-scraper/adelaide-h3.ts
@@ -88,7 +88,7 @@ export function parseAdelaideEvent(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     title,
     runNumber,
     hares,

--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -146,7 +146,7 @@ describe("parseEventSection — DOM-based event parsing", () => {
     expect(event!.date).toBe("2026-04-12");
     expect(event!.startTime).toBe("12:45");
     expect(event!.location).toBe("Near Station Lelylaan");
-    expect(event!.kennelTag).toBe("ah3-nl");
+    expect(event!.kennelTags[0]).toBe("ah3-nl");
   });
 
   it("extracts description text between header and ___good_to_know (#563)", () => {
@@ -261,7 +261,7 @@ describe("extractEventsFromGallery", () => {
     expect(events[0].hares).toBe("War 'n Piece & MiaB");
     expect(events[0].description).toContain("Birthday run from Haarlem");
     expect(events[0].description).not.toContain("<b>");
-    expect(events[0].kennelTag).toBe("ah3-nl");
+    expect(events[0].kennelTags[0]).toBe("ah3-nl");
     // sourceUrl should come from the tile's per-event href, not the listing page
     expect(events[0].sourceUrl).toContain("publiceventid=abc");
   });

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -204,7 +204,7 @@ export function parseEventSection(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     title: eventTitle,
     runNumber,
     hares,
@@ -351,7 +351,7 @@ export function extractEventsFromGallery(
 
       events.push({
         date: dateParsed.date,
-        kennelTag: KENNEL_TAG,
+        kennelTags: [KENNEL_TAG],
         title,
         hares,
         location,

--- a/src/adapters/html-scraper/atlanta-hash-board.test.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.test.ts
@@ -226,8 +226,8 @@ describe("AtlantaHashBoardAdapter", () => {
       url: "https://board.atlantahash.com",
       config: {
         forums: {
-          "2": { kennelTag: "ah4", hashDay: "Saturday" },
-          "8": { kennelTag: "mlh4", hashDay: "Monday" },
+          "2": { kennelTags: ["ah4"], hashDay: "Saturday" },
+          "8": { kennelTags: ["mlh4"], hashDay: "Monday" },
         },
       },
     } as never;
@@ -265,7 +265,7 @@ describe("AtlantaHashBoardAdapter", () => {
       url: "https://board.atlantahash.com",
       config: {
         forums: {
-          "2": { kennelTag: "ah4", hashDay: "Saturday" },
+          "2": { kennelTags: ["ah4"], hashDay: "Saturday" },
         },
       },
     } as never;

--- a/src/adapters/html-scraper/atlanta-hash-board.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.ts
@@ -262,7 +262,7 @@ function processForumEntries(
 
       events.push({
         date,
-        kennelTag: forumConfig.kennelTag,
+        kennelTags: [forumConfig.kennelTag],
         runNumber: fields.runNumber ?? titleRunNumber,
         title: titleName,
         hares: fields.hares,

--- a/src/adapters/html-scraper/bangkok-bikers.ts
+++ b/src/adapters/html-scraper/bangkok-bikers.ts
@@ -58,7 +58,7 @@ export function parseBikersNextRide(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     hares: normalizeHaresField(hares),
     location: location || undefined,
@@ -106,7 +106,7 @@ export class BangkokBikersAdapter implements SourceAdapter {
 
         events.push({
           date: dateMatch,
-          kennelTag: KENNEL_TAG,
+          kennelTags: [KENNEL_TAG],
           runNumber: runMatch ? Number.parseInt(runMatch[1], 10) : undefined,
           hares: normalizeHaresField(hareMatch?.[1]?.trim()),
           sourceUrl: baseUrl,

--- a/src/adapters/html-scraper/bangkok-h3.ts
+++ b/src/adapters/html-scraper/bangkok-h3.ts
@@ -57,7 +57,7 @@ export class BangkokH3Adapter implements SourceAdapter {
 
       events.push({
         date,
-        kennelTag: KENNEL_TAG,
+        kennelTags: [KENNEL_TAG],
         runNumber: runMatch ? Number.parseInt(runMatch[1], 10) : undefined,
         hares: normalizeHaresField(hareMatch?.[1]?.trim()),
         location: locationMatch?.[1]?.trim() || undefined,

--- a/src/adapters/html-scraper/bangkokhash.test.ts
+++ b/src/adapters/html-scraper/bangkokhash.test.ts
@@ -33,7 +33,7 @@ describe("parseNextRunArticle", () => {
     const event = parseNextRunArticle(NEXT_RUN_HTML, "bth3", "18:30", "https://www.bangkokhash.com/thursday/index.php");
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-04-16");
-    expect(event!.kennelTag).toBe("bth3");
+    expect(event!.kennelTags[0]).toBe("bth3");
     expect(event!.runNumber).toBe(519);
     expect(event!.startTime).toBe("18:30");
     expect(event!.hares).toBe("Jessticles");
@@ -45,7 +45,7 @@ describe("parseNextRunArticle", () => {
     const event = parseNextRunArticle(SIAM_SUNDAY_HTML, "s2h3", "16:30", "https://www.bangkokhash.com/siamsunday/index.php");
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-04-12");
-    expect(event!.kennelTag).toBe("s2h3");
+    expect(event!.kennelTags[0]).toBe("s2h3");
     expect(event!.runNumber).toBe(653);
     expect(event!.startTime).toBe("16:30");
     expect(event!.hares).toBe("Horny Viking");
@@ -131,7 +131,7 @@ describe("parseNextRunArticle", () => {
     const event = parseNextRunArticle(html, "bfmh3", "18:30", "https://www.bangkokhash.com/fullmoon/index.php/run-archives-bfmh3/157-run-254");
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-04-03");
-    expect(event!.kennelTag).toBe("bfmh3");
+    expect(event!.kennelTags[0]).toBe("bfmh3");
     expect(event!.hares).toBe("Patpom");
     expect(event!.location).toBe("BTS Asok");
     expect(event!.locationUrl).toBe("https://maps.app.goo.gl/v5yucg6jKmXALUf59");
@@ -213,7 +213,7 @@ describe("parseHarelineApiHtml", () => {
 
     // First entry: BTH3
     expect(events[0].date).toBe("2026-04-16");
-    expect(events[0].kennelTag).toBe("bth3");
+    expect(events[0].kennelTags[0]).toBe("bth3");
     expect(events[0].runNumber).toBe(519);
     expect(events[0].hares).toBe("Jessticles");
 
@@ -225,7 +225,7 @@ describe("parseHarelineApiHtml", () => {
 
   it("routes Fullmoon entries to bfmh3 tag", () => {
     const events = parseHarelineApiHtml(HARELINE_HTML, "bth3", "bfmh3", "18:30", "https://www.bangkokhash.com/thursday/index.php");
-    const fullmoon = events.find((e) => e.kennelTag === "bfmh3");
+    const fullmoon = events.find((e) => e.kennelTags[0] === "bfmh3");
     expect(fullmoon).toBeDefined();
     expect(fullmoon!.date).toBe("2026-05-01");
     expect(fullmoon!.runNumber).toBe(255);
@@ -234,7 +234,7 @@ describe("parseHarelineApiHtml", () => {
 
   it("does not route Fullmoon when fullmoonTag is null", () => {
     const events = parseHarelineApiHtml(HARELINE_HTML, "s2h3", null, "16:30", "https://www.bangkokhash.com/siamsunday/index.php");
-    const fullmoon = events.find((e) => e.kennelTag === "bfmh3");
+    const fullmoon = events.find((e) => e.kennelTags[0] === "bfmh3");
     expect(fullmoon).toBeUndefined();
   });
 

--- a/src/adapters/html-scraper/bangkokhash.ts
+++ b/src/adapters/html-scraper/bangkokhash.ts
@@ -147,7 +147,7 @@ export function parseNextRunArticle(
 
   return {
     date,
-    kennelTag,
+    kennelTags: [kennelTag],
     runNumber,
     hares: normalizeHaresField(hare),
     location: location || undefined,
@@ -206,7 +206,7 @@ export function parseHarelineApiHtml(
     if (fullmoonMatch) {
       events.push({
         date,
-        kennelTag: fullmoonTag ?? kennelTag,
+        kennelTags: [fullmoonTag ?? kennelTag],
         runNumber: Number.parseInt(fullmoonMatch[1], 10),
         startTime: "18:30",
         sourceUrl,
@@ -228,7 +228,7 @@ export function parseHarelineApiHtml(
 
     events.push({
       date,
-      kennelTag,
+      kennelTags: [kennelTag],
       runNumber,
       hares,
       startTime: defaultTime,
@@ -300,9 +300,9 @@ export class BangkokHashAdapter implements SourceAdapter {
         const apiEvents = parseHarelineApiHtml(harelineHtml, kennelTag, fullmoonTag, defaultTime, baseUrl);
 
         // Deduplicate: prefer the article's next-run event (richer data) over API data
-        const existingDates = new Set(events.map((e) => `${e.date}|${e.kennelTag}`));
+        const existingDates = new Set(events.map((e) => `${e.date}|${e.kennelTags[0]}`));
         for (const apiEvent of apiEvents) {
-          const key = `${apiEvent.date}|${apiEvent.kennelTag}`;
+          const key = `${apiEvent.date}|${apiEvent.kennelTags[0]}`;
           if (!existingDates.has(key)) {
             events.push(apiEvent);
             existingDates.add(key);

--- a/src/adapters/html-scraper/barnes-hash.test.ts
+++ b/src/adapters/html-scraper/barnes-hash.test.ts
@@ -97,7 +97,7 @@ describe("parseBarnesRow", () => {
     const event = parseBarnesRow(cells);
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-02-19");
-    expect(event!.kennelTag).toBe("barnesh3");
+    expect(event!.kennelTags[0]).toBe("barnesh3");
     expect(event!.runNumber).toBe(2104);
     expect(event!.hares).toBe("Speedy & Flasher");
     expect(event!.location).toBe("The Sun Inn, Richmond TW9 1TH");
@@ -141,7 +141,7 @@ describe("parseBarnesRow", () => {
   it("sets BarnesH3 as kennel tag", () => {
     const cells = ["2107  12th March 2026", "Hare Name", "The Fox SW19 3AA"];
     const event = parseBarnesRow(cells);
-    expect(event!.kennelTag).toBe("barnesh3");
+    expect(event!.kennelTags[0]).toBe("barnesh3");
   });
 });
 
@@ -191,7 +191,7 @@ describe("BarnesHashAdapter.fetch", () => {
 
     const first = result.events[0];
     expect(first.date).toBe("2026-02-19");
-    expect(first.kennelTag).toBe("barnesh3");
+    expect(first.kennelTags[0]).toBe("barnesh3");
     expect(first.startTime).toBe("19:30");
 
     vi.restoreAllMocks();

--- a/src/adapters/html-scraper/barnes-hash.ts
+++ b/src/adapters/html-scraper/barnes-hash.ts
@@ -100,7 +100,7 @@ export function parseBarnesRow(cells: string[], sourceUrl = "http://www.barnesh3
 
   return {
     date,
-    kennelTag: "barnesh3",
+    kennelTags: ["barnesh3"],
     runNumber: runNumber ?? undefined,
     title: runNumber ? `Barnes Hash Run #${runNumber}` : undefined,
     hares,

--- a/src/adapters/html-scraper/berlin-h3-detail-enrichment.test.ts
+++ b/src/adapters/html-scraper/berlin-h3-detail-enrichment.test.ts
@@ -66,7 +66,7 @@ describe("enrichBerlinH3Events", () => {
   function buildEvent(overrides: Partial<RawEventData>): RawEventData {
     return {
       date: "2026-04-03",
-      kennelTag: "bh3fm",
+      kennelTags: ["bh3fm"],
       sourceUrl: "https://www.berlin-h3.eu/event/full-moon-run-148/",
       ...overrides,
     };

--- a/src/adapters/html-scraper/bfh3.ts
+++ b/src/adapters/html-scraper/bfh3.ts
@@ -91,7 +91,7 @@ export class Bfh3Adapter implements SourceAdapter {
       events.push({
         date,
         startTime,
-        kennelTag: KENNEL_TAG,
+        kennelTags: [KENNEL_TAG],
         sourceUrl: url,
       });
     }

--- a/src/adapters/html-scraper/bfm.test.ts
+++ b/src/adapters/html-scraper/bfm.test.ts
@@ -67,7 +67,7 @@ describe("BFMAdapter.fetch", () => {
 
     const current = result.events.find((e) => e.runNumber === 1500);
     expect(current).toBeDefined();
-    expect(current!.kennelTag).toBe("bfm");
+    expect(current!.kennelTags[0]).toBe("bfm");
     expect(current!.hares).toBe("Mudflap and Shiggy Pop");
     expect(current!.location).toBe("Central Bar, 123 Main St");
     expect(current!.startTime).toBe("19:00");

--- a/src/adapters/html-scraper/bfm.ts
+++ b/src/adapters/html-scraper/bfm.ts
@@ -93,7 +93,7 @@ function scrapeCurrentTrail(
   const trailMatch = /Trail\s*#(\d+)\s*:?\s*([^\n]+?)(?:\n|$)/i.exec(bodyText);
   if (!trailMatch) {
     errors.push("No current trail found on page");
-    parseErrors.push({ row: 0, section: "current_trail", error: "No current trail found on page", rawText: bodyText.slice(0, 2000), partialData: { kennelTag: "bfm" } });
+    parseErrors.push({ row: 0, section: "current_trail", error: "No current trail found on page", rawText: bodyText.slice(0, 2000), partialData: { kennelTags: ["bfm" ]} });
     return { events, errors, parseErrors };
   }
 
@@ -113,7 +113,7 @@ function scrapeCurrentTrail(
 
   if (!dateStr) {
     errors.push("Could not parse date from current trail");
-    parseErrors.push({ row: 0, section: "current_trail", field: "date", error: "Could not parse date from current trail", rawText: bodyText.slice(0, 2000), partialData: { kennelTag: "bfm" } });
+    parseErrors.push({ row: 0, section: "current_trail", field: "date", error: "Could not parse date from current trail", rawText: bodyText.slice(0, 2000), partialData: { kennelTags: ["bfm" ]} });
     return { events, errors, parseErrors };
   }
 
@@ -138,7 +138,7 @@ function scrapeCurrentTrail(
 
   events.push({
     date: dateStr,
-    kennelTag: "bfm",
+    kennelTags: ["bfm"],
     runNumber,
     title: trailName,
     hares,
@@ -194,7 +194,7 @@ function scrapeUpcomingHares(
 
     events.push({
       date: dateStr,
-      kennelTag: "bfm",
+      kennelTags: ["bfm"],
       title: undefined,
       hares: harePart,
       sourceUrl: baseUrl,
@@ -237,7 +237,7 @@ async function scrapeSpecialEvents(
 
       events.push({
         date: dateStr,
-        kennelTag: "bfm",
+        kennelTags: ["bfm"],
         title,
         sourceUrl: specialUrl,
       });

--- a/src/adapters/html-scraper/big-hump.test.ts
+++ b/src/adapters/html-scraper/big-hump.test.ts
@@ -321,7 +321,7 @@ describe("parseHistoryCard", () => {
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-03-25");
     expect(event!.runNumber).toBe(1989);
-    expect(event!.kennelTag).toBe("bh4");
+    expect(event!.kennelTags[0]).toBe("bh4");
     expect(event!.title).toContain("Whiney The Beer Bitch");
     expect(event!.location).toBe("Ladue");
     // Attendance hares override title hares
@@ -565,7 +565,7 @@ describe("BigHumpAdapter", () => {
     expect(result.events).toHaveLength(2);
     expect(result.events[0].date).toBe("2026-04-01");
     expect(result.events[0].runNumber).toBe(1991);
-    expect(result.events[0].kennelTag).toBe("bh4");
+    expect(result.events[0].kennelTags[0]).toBe("bh4");
     expect(result.events[0].startTime).toBe("18:45");
     expect((result.diagnosticContext as Record<string, unknown>).includeHistory).toBe(false);
     // Should not have fetched history pages
@@ -746,7 +746,7 @@ describe.skip("BigHumpAdapter live", () => {
 
     const sample = result.events[0];
     expect(sample.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    expect(sample.kennelTag).toBe("bh4");
+    expect(sample.kennelTags[0]).toBe("bh4");
     expect(sample.runNumber).toBeGreaterThan(0);
   });
 
@@ -762,7 +762,7 @@ describe.skip("BigHumpAdapter live", () => {
 
     const sample = events[0];
     expect(sample.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    expect(sample.kennelTag).toBe("bh4");
+    expect(sample.kennelTags[0]).toBe("bh4");
     expect(sample.runNumber).toBeGreaterThan(0);
     expect(sample.sourceUrl).toContain("runinfo.php?num=");
   });

--- a/src/adapters/html-scraper/big-hump.ts
+++ b/src/adapters/html-scraper/big-hump.ts
@@ -290,7 +290,7 @@ export function parseHistoryCard(
 
   const event: RawEventData = {
     date,
-    kennelTag: "bh4",
+    kennelTags: ["bh4"],
     runNumber,
     title,
     hares,
@@ -497,7 +497,7 @@ export class BigHumpAdapter implements SourceAdapter {
 
           harelineEvents.push({
             date,
-            kennelTag: "bh4",
+            kennelTags: ["bh4"],
             runNumber,
             title,
             hares,

--- a/src/adapters/html-scraper/bkk-harriettes.test.ts
+++ b/src/adapters/html-scraper/bkk-harriettes.test.ts
@@ -27,7 +27,7 @@ describe("parseBkkHarriettesPost", () => {
     const event = parseBkkHarriettesPost(post);
     expect(event).not.toBeNull();
     expect(event?.date).toBe("2026-04-15");
-    expect(event?.kennelTag).toBe("bkk-harriettes");
+    expect(event?.kennelTags[0]).toBe("bkk-harriettes");
     expect(event?.runNumber).toBe(2259);
     expect(event?.hares).toBe("Hazukashii");
     // TBA should be excluded

--- a/src/adapters/html-scraper/bkk-harriettes.ts
+++ b/src/adapters/html-scraper/bkk-harriettes.ts
@@ -121,7 +121,7 @@ export function parseBkkHarriettesPost(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     hares: normalizeHaresField(hares),
     location,

--- a/src/adapters/html-scraper/boulder-h3.test.ts
+++ b/src/adapters/html-scraper/boulder-h3.test.ts
@@ -39,7 +39,7 @@ describe("parseBoulderH3Article", () => {
       startTime: "19:00",
       location: "Arrowwood Park",
       sourceUrl: "https://boulderh3.com/bh3-968-a-farewell-to-the-dark-horse/",
-      kennelTag: "bh3-co",
+      kennelTags: ["bh3-co"],
     });
   });
 
@@ -127,7 +127,7 @@ describe("parseBoulderH3IndexPage", () => {
   it("populates kennelTag bh3-co on every event", () => {
     const $ = cheerio.load(PAGE_FIXTURE);
     const events = parseBoulderH3IndexPage($);
-    expect(events.every((e) => e.kennelTag === "bh3-co")).toBe(true);
+    expect(events.every((e) => e.kennelTags[0] === "bh3-co")).toBe(true);
   });
 
   it("skips unparseable articles without throwing", () => {

--- a/src/adapters/html-scraper/boulder-h3.ts
+++ b/src/adapters/html-scraper/boulder-h3.ts
@@ -66,7 +66,7 @@ export function parseBoulderH3Article(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     title: cleanTitle,
     location,

--- a/src/adapters/html-scraper/brass-monkey.test.ts
+++ b/src/adapters/html-scraper/brass-monkey.test.ts
@@ -175,7 +175,7 @@ describe("BrassMonkeyAdapter.fetch (Blogger API path)", () => {
 
     expect(result.events[0]).toMatchObject({
       date: "2026-03-14",
-      kennelTag: "bmh3-tx",
+      kennelTags: ["bmh3-tx"],
       runNumber: 421,
       title: "Just Short of A Brass Monkey Mile?",
       hares: "Lucky Stiff",
@@ -186,7 +186,7 @@ describe("BrassMonkeyAdapter.fetch (Blogger API path)", () => {
 
     expect(result.events[1]).toMatchObject({
       date: "2026-02-28",
-      kennelTag: "bmh3-tx",
+      kennelTags: ["bmh3-tx"],
       runNumber: 420,
       title: "Blaze It Trail",
       hares: "Hot Mess & Cold Feet",
@@ -231,7 +231,7 @@ describe("BrassMonkeyAdapter.fetch (Blogger API path)", () => {
     } as never);
 
     expect(result.events).toHaveLength(1);
-    expect(result.events[0].kennelTag).toBe("bmh3-tx");
+    expect(result.events[0].kennelTags[0]).toBe("bmh3-tx");
     expect(result.diagnosticContext).toMatchObject({
       fetchMethod: "html-scrape",
     });

--- a/src/adapters/html-scraper/brass-monkey.ts
+++ b/src/adapters/html-scraper/brass-monkey.ts
@@ -147,7 +147,7 @@ function processPost(
         error: dateError,
         rawText: `Title: ${titleText}\n\n${bodyText}`.slice(0, 2000),
         partialData: {
-          kennelTag: "bmh3-tx",
+          kennelTags: ["bmh3-tx"],
           title: titleFields.title,
           runNumber: titleFields.runNumber,
           hares: bodyFields.hares,
@@ -169,7 +169,7 @@ function processPost(
 
   return {
     date: eventDate,
-    kennelTag: "bmh3-tx",
+    kennelTags: ["bmh3-tx"],
     runNumber: titleFields.runNumber,
     title: titleFields.title,
     hares: bodyFields.hares,

--- a/src/adapters/html-scraper/brew-city-h3.test.ts
+++ b/src/adapters/html-scraper/brew-city-h3.test.ts
@@ -196,7 +196,7 @@ describe("BrewCityH3Adapter", () => {
     const trail359 = result.events.find(e => e.runNumber === 359);
     expect(trail359).toBeDefined();
     expect(trail359!.date).toBe("2026-04-03");
-    expect(trail359!.kennelTag).toBe("bch3");
+    expect(trail359!.kennelTags[0]).toBe("bch3");
     expect(trail359!.title).toBe("🌕 Moonlit Easter Egg Hunt Hash III");
     expect(trail359!.hares).toBe("Amber Alert");
     // "Location:" header wins over On-Out abbreviated value (#698)

--- a/src/adapters/html-scraper/brew-city-h3.ts
+++ b/src/adapters/html-scraper/brew-city-h3.ts
@@ -242,7 +242,7 @@ export class BrewCityH3Adapter implements SourceAdapter {
 
         const event: RawEventData = {
           date,
-          kennelTag: "bch3",
+          kennelTags: ["bch3"],
           title,
           runNumber,
           hares: details.hares,

--- a/src/adapters/html-scraper/bruh3.test.ts
+++ b/src/adapters/html-scraper/bruh3.test.ts
@@ -126,7 +126,7 @@ Public transport: De Lijn buses R75 from Etterbeek
 
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-03-28");
-    expect(event!.kennelTag).toBe("bruh3");
+    expect(event!.kennelTags[0]).toBe("bruh3");
     expect(event!.runNumber).toBe(2339);
     expect(event!.title).toBe("BruH3 #2339");
     expect(event!.hares).toBe("John & Alison");
@@ -260,7 +260,7 @@ April 25 - Julian O.
     expect(events).toHaveLength(3);
     expect(events[0].date).toBe("2026-04-11");
     expect(events[0].hares).toBe("Ed");
-    expect(events[0].kennelTag).toBe("bruh3");
+    expect(events[0].kennelTags[0]).toBe("bruh3");
     expect(events[0].startTime).toBe("15:00");
 
     expect(events[1].date).toBe("2026-04-18");

--- a/src/adapters/html-scraper/bruh3.ts
+++ b/src/adapters/html-scraper/bruh3.ts
@@ -138,7 +138,7 @@ export function parseEventBlock(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     title,
     runNumber,
     hares,
@@ -203,7 +203,7 @@ export function parseFutureDates(
 
     events.push({
       date,
-      kennelTag: KENNEL_TAG,
+      kennelTags: [KENNEL_TAG],
       title: `BruH3 — ${dateStr}`,
       hares: isReserved ? undefined : hare,
       startTime: DEFAULT_START_TIME,

--- a/src/adapters/html-scraper/bull-moon.test.ts
+++ b/src/adapters/html-scraper/bull-moon.test.ts
@@ -273,17 +273,17 @@ describe("BullMoonAdapter", () => {
       expect(t3Run!.date).toBe("2026-04-02");
       expect(t3Run!.startTime).toBe("18:45");
       expect(t3Run!.title).toBe("T3 #201");
-      expect(t3Run!.kennelTag).toBe("bullmoon");
+      expect(t3Run!.kennelTags[0]).toBe("bullmoon");
 
       const bmRun = result.events.find((e) => e.runNumber === 124);
       expect(bmRun).toBeDefined();
       expect(bmRun!.startTime).toBe("12:00");
       expect(bmRun!.title).toBe("Bull Moon #124");
-      expect(bmRun!.kennelTag).toBe("bullmoon");
+      expect(bmRun!.kennelTags[0]).toBe("bullmoon");
 
       const social = result.events.find((e) => !e.runNumber);
       expect(social).toBeDefined();
-      expect(social!.kennelTag).toBe("bullmoon");
+      expect(social!.kennelTags[0]).toBe("bullmoon");
     });
 
     it("verifies browserRender is called with frameUrl option", async () => {

--- a/src/adapters/html-scraper/bull-moon.ts
+++ b/src/adapters/html-scraper/bull-moon.ts
@@ -278,7 +278,7 @@ function buildRawEvent(parsed: ParsedBullMoonRun, sourceUrl: string): RawEventDa
 
   return {
     date: parsed.date!,
-    kennelTag: KENNEL_CODE,
+    kennelTags: [KENNEL_CODE],
     runNumber: parsed.runNumber,
     title,
     hares: parsed.hares,

--- a/src/adapters/html-scraper/burlington-hash.test.ts
+++ b/src/adapters/html-scraper/burlington-hash.test.ts
@@ -50,7 +50,7 @@ describe("parseCalendarLink", () => {
 
     expect(result).toMatchObject({
       date: "2026-04-01",
-      kennelTag: "burlyh3",
+      kennelTags: ["burlyh3"],
       runNumber: 846,
       title: "Season Premier",
       hares: "Trailblazer & MapQuest",
@@ -70,7 +70,7 @@ describe("parseCalendarLink", () => {
     const result = parseCalendarLink(href, SOURCE_URL);
 
     expect(result).toMatchObject({
-      kennelTag: "burlyh3",
+      kennelTags: ["burlyh3"],
       runNumber: 847,
       title: "Mud Season Hash",
       hares: "Muddy Buddy",
@@ -89,7 +89,7 @@ describe("parseCalendarLink", () => {
     const result = parseCalendarLink(href, SOURCE_URL);
 
     expect(result).toMatchObject({
-      kennelTag: "burlyh3",
+      kennelTags: ["burlyh3"],
       title: "Annual Invihash 2026",
       location: "Waterfront Park",
     });
@@ -296,12 +296,12 @@ describe("BurlingtonHashAdapter", () => {
 
     expect(result.events).toHaveLength(2);
     expect(result.events[0]).toMatchObject({
-      kennelTag: "burlyh3",
+      kennelTags: ["burlyh3"],
       runNumber: 846,
       title: "Season Premier",
     });
     expect(result.events[1]).toMatchObject({
-      kennelTag: "burlyh3",
+      kennelTags: ["burlyh3"],
       runNumber: 847,
       title: "Mud Run",
     });

--- a/src/adapters/html-scraper/burlington-hash.ts
+++ b/src/adapters/html-scraper/burlington-hash.ts
@@ -124,7 +124,7 @@ export function parseCalendarLink(
 
   return {
     date,
-    kennelTag: "burlyh3",
+    kennelTags: ["burlyh3"],
     runNumber,
     title,
     hares,

--- a/src/adapters/html-scraper/cah3.test.ts
+++ b/src/adapters/html-scraper/cah3.test.ts
@@ -86,7 +86,7 @@ describe("parseCah3Post", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.event.date).toBe("2025-03-08");
-      expect(result.event.kennelTag).toBe("cah3");
+      expect(result.event.kennelTags[0]).toBe("cah3");
       expect(result.event.runNumber).toBe(533);
       expect(result.event.hares).toBe("Rusty Nail");
       expect(result.event.location).toBe("Cha-Am Beach");

--- a/src/adapters/html-scraper/cah3.ts
+++ b/src/adapters/html-scraper/cah3.ts
@@ -150,7 +150,7 @@ export function parseCah3Post(post: Cah3PostInput): ParseCah3PostResult {
     ok: true,
     event: {
       date,
-      kennelTag: KENNEL_TAG,
+      kennelTags: [KENNEL_TAG],
       runNumber: titleFields.runNumber,
       title: titleFields.title,
       hares: normalizeHaresField(body.hares),

--- a/src/adapters/html-scraper/calgary-h3-home.test.ts
+++ b/src/adapters/html-scraper/calgary-h3-home.test.ts
@@ -119,7 +119,7 @@ describe("CalgaryH3HomeAdapter", () => {
     expect(run2455.date).toBe("2026-04-02");
     expect(run2455.startTime).toBe("19:00");
     expect(run2455.location).toBe("Kensington Pub");
-    expect(run2455.kennelTag).toBe("ch3-ab");
+    expect(run2455.kennelTags[0]).toBe("ch3-ab");
     expect(run2455.sourceUrl).toBe("https://home.onon.org/events/2455/");
 
     const badThursday = result.events[1];

--- a/src/adapters/html-scraper/calgary-h3-home.ts
+++ b/src/adapters/html-scraper/calgary-h3-home.ts
@@ -12,7 +12,7 @@
  * Note: Events Manager loads events via AJAX, so this adapter uses
  * fetchBrowserRenderedPage() to get the fully rendered HTML.
  *
- * kennelTag: "ch3-ab"
+ * kennelTags: ["ch3-ab"]
  */
 
 import type { Source } from "@/generated/prisma/client";
@@ -120,7 +120,7 @@ export class CalgaryH3HomeAdapter implements SourceAdapter {
 
         events.push({
           date: dateStr,
-          kennelTag: KENNEL_TAG,
+          kennelTags: [KENNEL_TAG],
           runNumber,
           title: title || undefined,
           location,

--- a/src/adapters/html-scraper/calgary-h3-scribe.test.ts
+++ b/src/adapters/html-scraper/calgary-h3-scribe.test.ts
@@ -134,7 +134,7 @@ Attendance: 35
     );
     expect(result).not.toBeNull();
     expect(result!.date).toBe("2026-03-29");
-    expect(result!.kennelTag).toBe("ch3-ab");
+    expect(result!.kennelTags[0]).toBe("ch3-ab");
     expect(result!.runNumber).toBe(2453);
     expect(result!.title).toBe("A Hot Slippy Thong in the Cheeks");
     expect(result!.hares).toBe("Boner and Chips");
@@ -204,7 +204,7 @@ Attendance: 35</p>`,
     const result = await adapter.fetch(mockSource);
     expect(result.events).toHaveLength(2);
     expect(result.events[0].runNumber).toBe(2453);
-    expect(result.events[0].kennelTag).toBe("ch3-ab");
+    expect(result.events[0].kennelTags[0]).toBe("ch3-ab");
     expect(result.events[1].runNumber).toBe(2452);
     expect(result.errors).toHaveLength(0);
   });

--- a/src/adapters/html-scraper/calgary-h3-scribe.ts
+++ b/src/adapters/html-scraper/calgary-h3-scribe.ts
@@ -8,7 +8,7 @@
  * Post title format: "Run 2453 – A Hot Slippy Thong in the Cheeks"
  * Post body contains labeled fields: Hares:, Location:, RA:, Attendance:
  *
- * kennelTag: "ch3-ab"
+ * kennelTags: ["ch3-ab"]
  */
 
 import * as cheerio from "cheerio";
@@ -104,7 +104,7 @@ export function processScribePost(
 
   return {
     date: dateStr,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber: parsed.runNumber,
     title: parsed.trailName,
     hares: body.hares,

--- a/src/adapters/html-scraper/cape-fear-h3.test.ts
+++ b/src/adapters/html-scraper/cape-fear-h3.test.ts
@@ -128,7 +128,7 @@ describe("parseCfh3Post", () => {
   it("sets kennelTag to cfh3", () => {
     const $ = cheerio.load(POST_HTML_MIS_MAN);
     const result = parseCfh3Post($, "2026-03-17T18:40:42-04:00");
-    expect(result!.kennelTag).toBe("cfh3");
+    expect(result!.kennelTags[0]).toBe("cfh3");
   });
 
   it("parses posts with the colon inside the <strong> tag (#903 regression)", () => {
@@ -158,7 +158,7 @@ describe("parseHarelineRow", () => {
       date: "2026-03-07",
       runNumber: 514,
       hares: "Photo Spread",
-      kennelTag: "cfh3",
+      kennelTags: ["cfh3"],
     });
   });
 

--- a/src/adapters/html-scraper/cape-fear-h3.ts
+++ b/src/adapters/html-scraper/cape-fear-h3.ts
@@ -111,7 +111,7 @@ export function parseCfh3Post(
 
   return {
     date,
-    kennelTag: "cfh3",
+    kennelTags: ["cfh3"],
     hares: haresField?.text || undefined,
     location,
     locationUrl,
@@ -164,7 +164,7 @@ export function parseHarelineRow(
 
   return {
     date,
-    kennelTag: "cfh3",
+    kennelTags: ["cfh3"],
     runNumber: runNumber && runNumber > 0 ? runNumber : undefined,
     title,
     hares: isPlaceholderHares ? undefined : hares,

--- a/src/adapters/html-scraper/ch4-dk.test.ts
+++ b/src/adapters/html-scraper/ch4-dk.test.ts
@@ -214,7 +214,7 @@ describe("Ch4DkAdapter.fetch", () => {
     const run367 = result.events.find((e) => e.runNumber === 367);
     expect(run367).toMatchObject({
       date: "2026-04-03",
-      kennelTag: "ch4-dk",
+      kennelTags: ["ch4-dk"],
       runNumber: 367,
       title: "CH4 #367",
       startTime: "20:00",

--- a/src/adapters/html-scraper/ch4-dk.ts
+++ b/src/adapters/html-scraper/ch4-dk.ts
@@ -313,7 +313,7 @@ export class Ch4DkAdapter implements SourceAdapter {
 
         events.push({
           date: dt.date,
-          kennelTag: "ch4-dk",
+          kennelTags: ["ch4-dk"],
           runNumber,
           title: runNumber === undefined ? undefined : `CH4 #${runNumber}`,
           startTime: dt.startTime,

--- a/src/adapters/html-scraper/chiangmai-hhh.test.ts
+++ b/src/adapters/html-scraper/chiangmai-hhh.test.ts
@@ -17,7 +17,7 @@ describe("parseChiangMaiLine", () => {
     );
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-04-06");
-    expect(event!.kennelTag).toBe("ch3-cm");
+    expect(event!.kennelTags[0]).toBe("ch3-cm");
     expect(event!.runNumber).toBe(1631);
     expect(event!.hares).toBe("Suckit");
   });

--- a/src/adapters/html-scraper/chiangmai-hhh.ts
+++ b/src/adapters/html-scraper/chiangmai-hhh.ts
@@ -111,8 +111,7 @@ export function parseChiangMaiLine(
 
   return {
     date,
-    kennelTag,
-    runNumber,
+    kennelTags: [kennelTag],    runNumber,
     hares,
     sourceUrl,
   };

--- a/src/adapters/html-scraper/chicago-hash.test.ts
+++ b/src/adapters/html-scraper/chicago-hash.test.ts
@@ -224,7 +224,7 @@ describe("parseArticle", () => {
     const event = parseArticle($, articles.eq(0), "https://chicagohash.org/");
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-02-15");
-    expect(event!.kennelTag).toBe("ch3");
+    expect(event!.kennelTags[0]).toBe("ch3");
     expect(event!.runNumber).toBe(2580);
     expect(event!.title).toBe("CH3 #2580");
     expect(event!.hares).toBe("Speedy McFast");

--- a/src/adapters/html-scraper/chicago-hash.ts
+++ b/src/adapters/html-scraper/chicago-hash.ts
@@ -154,7 +154,7 @@ export function parseArticle(
 
   return {
     date,
-    kennelTag: "ch3",
+    kennelTags: ["ch3"],
     runNumber,
     title: titleText,
     hares: fields.hares,

--- a/src/adapters/html-scraper/chicago-th3.test.ts
+++ b/src/adapters/html-scraper/chicago-th3.test.ts
@@ -212,7 +212,7 @@ describe("parseArticle", () => {
     const event = parseArticle($, articles.eq(0), "https://chicagoth3.com/");
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2024-10-03");
-    expect(event!.kennelTag).toBe("th3");
+    expect(event!.kennelTags[0]).toBe("th3");
     expect(event!.runNumber).toBe(1060);
     expect(event!.title).toBe("TH3 #1060 – October 3, 2024");
     expect(event!.hares).toBe("Trail Blazer");

--- a/src/adapters/html-scraper/chicago-th3.ts
+++ b/src/adapters/html-scraper/chicago-th3.ts
@@ -136,7 +136,7 @@ export function parseArticle(
 
   return {
     date,
-    kennelTag: "th3",
+    kennelTags: ["th3"],
     runNumber,
     title: titleText,
     hares: fields.hares,

--- a/src/adapters/html-scraper/choo-choo-h3.ts
+++ b/src/adapters/html-scraper/choo-choo-h3.ts
@@ -51,7 +51,7 @@ export class ChooChooH3Adapter implements SourceAdapter {
         // All-day events carry a meaningless 00:00 from the API; omit so the
         // canonical record doesn't show "midnight".
         startTime: e.allDay ? undefined : e.startTime,
-        kennelTag: KENNEL_TAG,
+        kennelTags: [KENNEL_TAG],
         title: e.title,
         description: e.description,
         location: e.location || e.venue,

--- a/src/adapters/html-scraper/city-hash.test.ts
+++ b/src/adapters/html-scraper/city-hash.test.ts
@@ -109,7 +109,7 @@ describe("parseMakesweatEvent", () => {
     const event = parseMakesweatEvent($, cards.eq(0), "https://makesweat.com/cityhash#hashes");
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-03-10");
-    expect(event!.kennelTag).toBe("cityh3");
+    expect(event!.kennelTags[0]).toBe("cityh3");
     expect(event!.runNumber).toBe(1912);
     expect(event!.title).toBe("City Hash Run #1912 - International Women's Day");
     expect(event!.hares).toBe("Sort Yourself Out");

--- a/src/adapters/html-scraper/city-hash.ts
+++ b/src/adapters/html-scraper/city-hash.ts
@@ -131,7 +131,7 @@ export function parseMakesweatEvent(
 
   return {
     date,
-    kennelTag: "cityh3",
+    kennelTags: ["cityh3"],
     runNumber,
     title,
     hares,

--- a/src/adapters/html-scraper/crh3.test.ts
+++ b/src/adapters/html-scraper/crh3.test.ts
@@ -75,7 +75,7 @@ describe("parseCrh3Post", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.event.date).toBe("2025-02-15");
-      expect(result.event.kennelTag).toBe("crh3");
+      expect(result.event.kennelTags[0]).toBe("crh3");
       expect(result.event.runNumber).toBe(218);
       expect(result.event.hares).toBe("Iron Chef");
       expect(result.event.location).toBe("Mae Fah Luang");

--- a/src/adapters/html-scraper/crh3.ts
+++ b/src/adapters/html-scraper/crh3.ts
@@ -122,7 +122,7 @@ export function parseCrh3Post(post: Crh3PostInput): ParseCrh3PostResult {
     ok: true,
     event: {
       date,
-      kennelTag: KENNEL_TAG,
+      kennelTags: [KENNEL_TAG],
       runNumber: titleFields.runNumber,
       hares: normalizeHaresField(body.hares),
       location: body.location,

--- a/src/adapters/html-scraper/dch4.test.ts
+++ b/src/adapters/html-scraper/dch4.test.ts
@@ -170,7 +170,7 @@ describe("DCH4Adapter (WordPress API path)", () => {
     expect(result.events).toHaveLength(1);
     expect(result.events[0]).toMatchObject({
       date: "2026-02-14",
-      kennelTag: "dch4",
+      kennelTags: ["dch4"],
       runNumber: 2299,
       hares: "Blinded by the Spooge",
       location: "Twinbrook Metro Station (1600 Chapman Ave. Rockville, MD)",
@@ -250,7 +250,7 @@ describe("DCH4Adapter (HTML fallback path)", () => {
 
     expect(result.events[0]).toMatchObject({
       date: "2026-02-14",
-      kennelTag: "dch4",
+      kennelTags: ["dch4"],
       runNumber: 2299,
       hares: "Blinded by the Spooge",
       location: "Twinbrook Metro Station (1600 Chapman Ave. Rockville, MD)",
@@ -260,7 +260,7 @@ describe("DCH4Adapter (HTML fallback path)", () => {
 
     expect(result.events[1]).toMatchObject({
       date: "2026-02-07",
-      kennelTag: "dch4",
+      kennelTags: ["dch4"],
       runNumber: 2298,
       hares: "Spike and Big in Japan",
       startTime: "14:00",

--- a/src/adapters/html-scraper/dch4.ts
+++ b/src/adapters/html-scraper/dch4.ts
@@ -120,7 +120,7 @@ function processPost(
 
   return {
     date: parsed.date,
-    kennelTag: "dch4",
+    kennelTags: ["dch4"],
     runNumber: parsed.runNumber,
     title: parsed.theme || `DCH4 Trail #${parsed.runNumber}`,
     hares: bodyFields.hares,

--- a/src/adapters/html-scraper/dfw-hash.test.ts
+++ b/src/adapters/html-scraper/dfw-hash.test.ts
@@ -114,25 +114,25 @@ describe("extractDFWEvents", () => {
     expect(events.length).toBeGreaterThanOrEqual(4);
 
     // Check first DUHHH event (Wed March 2)
-    const duhhh = events.find((e) => e.event.kennelTag === "duhhh" && e.event.date === "2026-03-02");
+    const duhhh = events.find((e) => e.event.kennelTags[0] === "duhhh" && e.event.date === "2026-03-02");
     expect(duhhh).toBeDefined();
     expect(duhhh!.event.hares).toBe("Hare Name");
     expect(duhhh!.detailUrl).toContain("event.php");
 
     // Check Dallas H3 event (Sat March 5)
-    const dh3 = events.find((e) => e.event.kennelTag === "dh3-tx");
+    const dh3 = events.find((e) => e.event.kennelTags[0] === "dh3-tx");
     expect(dh3).toBeDefined();
     expect(dh3!.event.date).toBe("2026-03-05");
     expect(dh3!.event.hares).toBe("Dallas Hare");
 
     // Check NODUHHH event (Mon March 7)
-    const noduhhh = events.find((e) => e.event.kennelTag === "noduhhh");
+    const noduhhh = events.find((e) => e.event.kennelTags[0] === "noduhhh");
     expect(noduhhh).toBeDefined();
     expect(noduhhh!.event.date).toBe("2026-03-07");
     expect(noduhhh!.event.hares).toBeUndefined(); // no <em> tag
 
     // Check FWH3 event (Sat March 12)
-    const fwh3 = events.find((e) => e.event.kennelTag === "fwh3");
+    const fwh3 = events.find((e) => e.event.kennelTags[0] === "fwh3");
     expect(fwh3).toBeDefined();
     expect(fwh3!.event.date).toBe("2026-03-12");
     expect(fwh3!.event.hares).toBe("FW Hare");
@@ -183,7 +183,7 @@ describe("extractDFWEvents", () => {
     `;
     const $ = cheerio.load(html);
     const { events } = extractDFWEvents($, 2026, 2, "http://test.com");
-    const evt = events.find((e) => e.event.kennelTag === "duhhh");
+    const evt = events.find((e) => e.event.kennelTags[0] === "duhhh");
     expect(evt).toBeDefined();
     expect(evt!.event.title).toBe("Bubblecum Strikes Again");
     expect(evt!.event.hares).toBe("Bubblecum");
@@ -219,7 +219,7 @@ describe("extractDFWEvents", () => {
     `;
     const $ = cheerio.load(html);
     const { events } = extractDFWEvents($, 2026, 3, "http://test.com"); // April 2026
-    const yak = events.find((e) => e.event.kennelTag === "yakh3");
+    const yak = events.find((e) => e.event.kennelTags[0] === "yakh3");
     expect(yak).toBeDefined();
     expect(yak!.event.date).toBe("2026-04-19");
     expect(yak!.event.title).toBe("Yak Season Opener");
@@ -250,7 +250,7 @@ describe("day-number extraction with holiday prefixes (Issue #2)", () => {
     `;
     const $ = cheerio.load(html);
     const { events } = extractDFWEvents($, 2026, 2, "http://test.com"); // March 2026
-    const fwh3 = events.find((e) => e.event.kennelTag === "fwh3");
+    const fwh3 = events.find((e) => e.event.kennelTags[0] === "fwh3");
     expect(fwh3).toBeDefined();
     expect(fwh3!.event.date).toBe("2026-03-21");
     expect(fwh3!.event.hares).toBe("Whitney MutchaFuckin Houston");
@@ -279,7 +279,7 @@ describe("day-number extraction with holiday prefixes (Issue #2)", () => {
     `;
     const $ = cheerio.load(html);
     const { events } = extractDFWEvents($, 2026, 3, "http://test.com"); // April 2026
-    const noduhhh = events.find((e) => e.event.kennelTag === "noduhhh");
+    const noduhhh = events.find((e) => e.event.kennelTags[0] === "noduhhh");
     expect(noduhhh).toBeDefined();
     expect(noduhhh!.event.date).toBe("2026-04-20");
   });
@@ -307,7 +307,7 @@ describe("day-number extraction with holiday prefixes (Issue #2)", () => {
     `;
     const $ = cheerio.load(html);
     const { events } = extractDFWEvents($, 2026, 3, "http://test.com"); // April 2026
-    const duhhh = events.find((e) => e.event.kennelTag === "duhhh");
+    const duhhh = events.find((e) => e.event.kennelTags[0] === "duhhh");
     expect(duhhh).toBeDefined();
     expect(duhhh!.event.date).toBe("2026-04-01");
     expect(duhhh!.event.title).toBe("Conjoined with the Full Moon!");
@@ -337,7 +337,7 @@ describe("day-number extraction with holiday prefixes (Issue #2)", () => {
     `;
     const $ = cheerio.load(html);
     const { events } = extractDFWEvents($, 2026, 3, "http://test.com"); // April 2026
-    const dh3 = events.find((e) => e.event.kennelTag === "dh3-tx");
+    const dh3 = events.find((e) => e.event.kennelTags[0] === "dh3-tx");
     expect(dh3).toBeDefined();
     expect(dh3!.event.date).toBe("2026-04-05");
     expect(dh3!.event.title).toBe("Easter Trail");

--- a/src/adapters/html-scraper/dfw-hash.ts
+++ b/src/adapters/html-scraper/dfw-hash.ts
@@ -218,8 +218,7 @@ export function extractDFWEvents(
 
         const event: RawEventData = {
           date: dateStr,
-          kennelTag,
-          sourceUrl,
+          kennelTags: [kennelTag],          sourceUrl,
           ...(title && { title }),
           ...(hares && { hares }),
         };

--- a/src/adapters/html-scraper/dublin-hash.test.ts
+++ b/src/adapters/html-scraper/dublin-hash.test.ts
@@ -120,7 +120,7 @@ describe("DublinHashAdapter", () => {
       expect(event).not.toBeNull();
       expect(event!.date).toBe("2026-03-16");
       expect(event!.startTime).toBe("19:30");
-      expect(event!.kennelTag).toBe("dh3");
+      expect(event!.kennelTags[0]).toBe("dh3");
       expect(event!.title).toBe("Dublin H3 #1668");
       expect(event!.runNumber).toBe(1668);
       expect(event!.location).toBe("Dalkey DART Station");
@@ -154,7 +154,7 @@ describe("DublinHashAdapter", () => {
 
       expect(event).not.toBeNull();
       expect(event!.date).toBe("2026-03-23");
-      expect(event!.kennelTag).toBe("dh3");
+      expect(event!.kennelTags[0]).toBe("dh3");
       expect(event!.title).toBe("I ♥ Monday #410");
       expect(event!.runNumber).toBe(410);
       expect(event!.location).toBe("Strand House, Fairview");

--- a/src/adapters/html-scraper/dublin-hash.ts
+++ b/src/adapters/html-scraper/dublin-hash.ts
@@ -99,7 +99,7 @@ export function parseHarelineRow(
 
   return {
     date,
-    kennelTag: "dh3",
+    kennelTags: ["dh3"],
     title,
     hares,
     location,

--- a/src/adapters/html-scraper/edinburgh-h3.ts
+++ b/src/adapters/html-scraper/edinburgh-h3.ts
@@ -208,7 +208,7 @@ export class EdinburghH3Adapter implements SourceAdapter {
 
         events.push({
           date: run.date,
-          kennelTag: "Edinburgh H3",
+          kennelTags: ["Edinburgh H3"],
           runNumber: run.runNumber,
           title,
           hares: run.hares,

--- a/src/adapters/html-scraper/eh3-edmonton.test.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.test.ts
@@ -346,7 +346,7 @@ describe("Eh3EdmontonAdapter", () => {
 
     const firstEvent = result.events.find((e) => e.runNumber === 1845);
     expect(firstEvent).toBeDefined();
-    expect(firstEvent!.kennelTag).toBe("eh3-ab");
+    expect(firstEvent!.kennelTags[0]).toBe("eh3-ab");
     expect(firstEvent!.title).toBe("Test Run");
     expect(firstEvent!.hares).toBe("Spring Loaded and Soggy Bottom");
     expect(firstEvent!.date).toMatch(/^\d{4}-04-06$/);

--- a/src/adapters/html-scraper/eh3-edmonton.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.ts
@@ -406,8 +406,7 @@ export class Eh3EdmontonAdapter implements SourceAdapter {
 
             const event: RawEventData = {
               date: parsed.date,
-              kennelTag,
-              runNumber: parsed.runNumber,
+              kennelTags: [kennelTag],              runNumber: parsed.runNumber,
               title: parsed.title,
               hares: parsed.hares,
               location: parsed.location,

--- a/src/adapters/html-scraper/enfield-hash.test.ts
+++ b/src/adapters/html-scraper/enfield-hash.test.ts
@@ -394,7 +394,7 @@ describe("EnfieldHashAdapter.fetch (new site structure)", () => {
     expect(result.structureHash).toBeDefined();
 
     const first = result.events[0];
-    expect(first.kennelTag).toBe("eh3");
+    expect(first.kennelTags[0]).toBe("eh3");
     expect(first.startTime).toBe("19:30");
     expect(first.title).toBe("Run 318 - Wed 25 February");
     // SPA fix: fetches home.html, so sourceUrl is the home.html URL
@@ -510,7 +510,7 @@ describe("EnfieldHashAdapter.fetch (legacy Blogger HTML fallback)", () => {
 
     const first = result.events[0];
     expect(first.date).toBe("2026-03-18");
-    expect(first.kennelTag).toBe("eh3");
+    expect(first.kennelTags[0]).toBe("eh3");
     expect(first.startTime).toBe("19:30");
     expect(first.location).toBe("The King's Head, Winchmore Hill, Enfield");
     expect(first.hares).toBe("Speedy");

--- a/src/adapters/html-scraper/enfield-hash.ts
+++ b/src/adapters/html-scraper/enfield-hash.ts
@@ -197,7 +197,7 @@ function processPost(
           field: "date",
           error: `No date found in post: ${titleText || "(untitled)"}`,
           rawText: `Title: ${titleText}\n\n${bodyText}`.slice(0, 2000),
-          partialData: { kennelTag: "eh3", title: titleText || undefined },
+          partialData: { kennelTags: ["eh3"], title: titleText || undefined },
         },
       ];
     }
@@ -212,7 +212,7 @@ function processPost(
 
   return {
     date,
-    kennelTag: "eh3",
+    kennelTags: ["eh3"],
     title: titleText || undefined,
     hares: bodyFields.hares,
     location: bodyFields.location,

--- a/src/adapters/html-scraper/ewh3.test.ts
+++ b/src/adapters/html-scraper/ewh3.test.ts
@@ -212,7 +212,7 @@ describe("EWH3Adapter (WordPress API path)", () => {
     expect(result.events).toHaveLength(1);
     expect(result.events[0]).toMatchObject({
       date: "2026-02-19",
-      kennelTag: "ewh3",
+      kennelTags: ["ewh3"],
       runNumber: 1506,
       title: "Huaynaputina's Revenge",
       hares: "Mongo & Lo Ho",
@@ -295,7 +295,7 @@ describe("EWH3Adapter (HTML fallback path)", () => {
     // First event
     expect(result.events[0]).toMatchObject({
       date: "2026-02-19",
-      kennelTag: "ewh3",
+      kennelTags: ["ewh3"],
       runNumber: 1506,
       title: "Huaynaputina's Revenge",
       hares: "Mongo & Lo Ho",
@@ -307,7 +307,7 @@ describe("EWH3Adapter (HTML fallback path)", () => {
     // Second event
     expect(result.events[1]).toMatchObject({
       date: "2026-02-12",
-      kennelTag: "ewh3",
+      kennelTags: ["ewh3"],
       runNumber: 1505,
       title: "Roose Rips Fukov Farewell Trail",
       hares: "Roose Rips, Ha-Cum-On My Tatas",

--- a/src/adapters/html-scraper/ewh3.ts
+++ b/src/adapters/html-scraper/ewh3.ts
@@ -115,7 +115,7 @@ function processPost(
 
   return {
     date: parsed.date,
-    kennelTag: "ewh3",
+    kennelTags: ["ewh3"],
     runNumber: parsed.runNumber ? Math.floor(parsed.runNumber) : undefined,
     title: parsed.trailName,
     hares: bodyFields.hares,

--- a/src/adapters/html-scraper/f3h3.test.ts
+++ b/src/adapters/html-scraper/f3h3.test.ts
@@ -89,7 +89,7 @@ describe("F3H3Adapter", () => {
 
       expect(result).toMatchObject({
         date: "2026-04-10",
-        kennelTag: "f3h3",
+        kennelTags: ["f3h3"],
         title: "F3H3 #1058",
         runNumber: 1058,
         hares: "Mismanagement",

--- a/src/adapters/html-scraper/f3h3.ts
+++ b/src/adapters/html-scraper/f3h3.ts
@@ -90,7 +90,7 @@ export function parseHarelineRow(
 
   return {
     date,
-    kennelTag: "f3h3",
+    kennelTags: ["f3h3"],
     title,
     runNumber,
     hares,

--- a/src/adapters/html-scraper/frankfurt-hash.test.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.test.ts
@@ -209,7 +209,7 @@ describe("parseJEMEvent", () => {
     expect(event!.title).toBe("Frankfurt Hash House Harriers #2114");
     expect(event!.location).toBe("Golfclub Rheinblick");
     expect(event!.runNumber).toBe(2114);
-    expect(event!.kennelTag).toBe("FH3"); // default, no pattern match
+    expect(event!.kennelTags[0]).toBe("FH3"); // default, no pattern match
     expect(event!.sourceUrl).toBe("https://frankfurt-hash.de/coming-runs/event/1234:fh3-run-2114");
   });
 
@@ -280,7 +280,7 @@ describe("parseJEMEvent", () => {
     const event = parseJEMEvent($li, $, compiled, defaultTag, baseUrl);
 
     expect(event).not.toBeNull();
-    expect(event!.kennelTag).toBe("FFMH3");
+    expect(event!.kennelTags[0]).toBe("FFMH3");
     expect(event!.startTime).toBe("19:00");
   });
 
@@ -298,7 +298,7 @@ describe("parseJEMEvent", () => {
     const event = parseJEMEvent($li, $, compiled, defaultTag, baseUrl);
 
     expect(event).not.toBeNull();
-    expect(event!.kennelTag).toBe("SHITS");
+    expect(event!.kennelTags[0]).toBe("SHITS");
   });
 
   it("matches DOM pattern for DOM Run events", () => {
@@ -315,7 +315,7 @@ describe("parseJEMEvent", () => {
     const event = parseJEMEvent($li, $, compiled, defaultTag, baseUrl);
 
     expect(event).not.toBeNull();
-    expect(event!.kennelTag).toBe("DOM");
+    expect(event!.kennelTags[0]).toBe("DOM");
     expect(event!.runNumber).toBe(42);
   });
 
@@ -333,7 +333,7 @@ describe("parseJEMEvent", () => {
     const event = parseJEMEvent($li, $, compiled, defaultTag, baseUrl);
 
     expect(event).not.toBeNull();
-    expect(event!.kennelTag).toBe("Bike Hash");
+    expect(event!.kennelTags[0]).toBe("Bike Hash");
   });
 
   it("extracts 'Run NNN' style run numbers", () => {
@@ -435,7 +435,7 @@ describe("parseJEMEvent", () => {
     expect(event!.title).toBe("FH3 Run #2119");
     expect(event!.runNumber).toBe(2119);
     expect(event!.hares).toBe("Whore Durve");
-    expect(event!.kennelTag).toBe("FH3");
+    expect(event!.kennelTags[0]).toBe("FH3");
   });
 
   it("strips ' Hare - <name>' suffix and extracts hares (archive dash form, #961)", () => {
@@ -477,11 +477,11 @@ describe("parseJEMEventList", () => {
     const events = parseJEMEventList(UPCOMING_HTML, compiled, "FH3", "https://frankfurt-hash.de");
 
     expect(events).toHaveLength(5);
-    expect(events[0].kennelTag).toBe("FH3");
-    expect(events[1].kennelTag).toBe("FFMH3");
-    expect(events[2].kennelTag).toBe("SHITS");
-    expect(events[3].kennelTag).toBe("DOM");
-    expect(events[4].kennelTag).toBe("Bike Hash");
+    expect(events[0].kennelTags[0]).toBe("FH3");
+    expect(events[1].kennelTags[0]).toBe("FFMH3");
+    expect(events[2].kennelTags[0]).toBe("SHITS");
+    expect(events[3].kennelTags[0]).toBe("DOM");
+    expect(events[4].kennelTags[0]).toBe("Bike Hash");
   });
 
   it("extracts venues correctly including HTML entities", () => {

--- a/src/adapters/html-scraper/frankfurt-hash.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.ts
@@ -129,8 +129,7 @@ export function parseJEMEvent(
 
   return {
     date: datePart,
-    kennelTag,
-    runNumber,
+    kennelTags: [kennelTag],    runNumber,
     title,
     location,
     startTime,

--- a/src/adapters/html-scraper/generic.test.ts
+++ b/src/adapters/html-scraper/generic.test.ts
@@ -88,7 +88,7 @@ describe("parseEventRow", () => {
     const event = parseEventRow($, $(rows[0]), BASE_CONFIG, "https://example.com");
     expect(event).toEqual({
       date: "2026-03-15",
-      kennelTag: "DFWH3",
+      kennelTags: ["DFWH3"],
       title: undefined,
       hares: "Salty Dog & Beer Me",
       location: "The Rusty Bucket",
@@ -117,7 +117,7 @@ describe("parseEventRow", () => {
 
   it("uses defaultKennelTag when no kennelTag column configured", () => {
     const event = parseEventRow($, $(rows[0]), BASE_CONFIG, "https://example.com");
-    expect(event?.kennelTag).toBe("DFWH3");
+    expect(event?.kennelTags[0]).toBe("DFWH3");
   });
 
   it("parses en-GB dates correctly", () => {
@@ -556,7 +556,7 @@ describe("GenericHtmlAdapter", () => {
 describe("fixYearMonotonicity", () => {
   const makeEvent = (date: string, runNumber?: number) => ({
     date,
-    kennelTag: "TEST",
+    kennelTags: ["TEST"],
     sourceUrl: "https://example.com",
     runNumber,
   });

--- a/src/adapters/html-scraper/generic.ts
+++ b/src/adapters/html-scraper/generic.ts
@@ -178,8 +178,7 @@ export function parseEventRow(
 
   return {
     date,
-    kennelTag,
-    title,
+    kennelTags: [kennelTag],    title,
     hares,
     location,
     locationUrl,

--- a/src/adapters/html-scraper/glasgow-h3.test.ts
+++ b/src/adapters/html-scraper/glasgow-h3.test.ts
@@ -33,7 +33,7 @@ describe("parseGlasgowRow", () => {
     expect(event).not.toBeNull();
     expect(event!.date).toMatch(/^\d{4}-03-23$/);
     expect(event!.runNumber).toBe(2206);
-    expect(event!.kennelTag).toBe("Glasgow H3");
+    expect(event!.kennelTags[0]).toBe("Glasgow H3");
     expect(event!.location).toBe("Redhurst Hotel, Giffnock");
     expect(event!.hares).toBe("Audrey");
     expect(event!.startTime).toBe("19:00");

--- a/src/adapters/html-scraper/glasgow-h3.ts
+++ b/src/adapters/html-scraper/glasgow-h3.ts
@@ -83,7 +83,7 @@ export function parseGlasgowRow(
 
   return {
     date,
-    kennelTag: "Glasgow H3",
+    kennelTags: ["Glasgow H3"],
     title,
     hares,
     location,

--- a/src/adapters/html-scraper/gohash.test.ts
+++ b/src/adapters/html-scraper/gohash.test.ts
@@ -55,7 +55,7 @@ describe("parseGoHashRun", () => {
     expect(event?.location).toBe("Kali Corner");
     expect(event?.locationUrl).toBe("https://maps.app.goo.gl/6sYjGXsrKKKJzsp68");
     expect(event?.startTime).toBe("17:30");
-    expect(event?.kennelTag).toBe("penangh3");
+    expect(event?.kennelTags[0]).toBe("penangh3");
     // Deduped: locationUrl removed from externalLinks
     expect(event?.externalLinks).toEqual([
       { url: "https://waze.com/ul/xyz", label: "Waze" },

--- a/src/adapters/html-scraper/gohash.ts
+++ b/src/adapters/html-scraper/gohash.ts
@@ -29,7 +29,7 @@ import { applyDateWindow, fetchHTMLPage, normalizeHaresField, validateSourceConf
  *
  * **Config shape** (`source.config`):
  * ```ts
- * { kennelTag: "penangh3", startTime?: "17:30", harelinePath?: "/hareline/upcoming" }
+ * { kennelTags: ["penangh3"], startTime?: "17:30", harelinePath?: "/hareline/upcoming" }
  * ```
  * If `harelinePath` is omitted the adapter defaults to `/hareline/upcoming`
  * appended to `source.url`.
@@ -175,7 +175,7 @@ export function parseGoHashRun(
 
   return {
     date: rawDate,
-    kennelTag: config.kennelTag,
+    kennelTags: [config.kennelTag],
     runNumber: Number.isFinite(run.run_number) ? (run.run_number as number) : undefined,
     title,
     hares,

--- a/src/adapters/html-scraper/gold-coast-h3.test.ts
+++ b/src/adapters/html-scraper/gold-coast-h3.test.ts
@@ -21,7 +21,7 @@ describe("gold-coast-h3 parseGoldCoastRow", () => {
     expect(e).not.toBeNull();
     expect(e!.date).toBe("2026-04-13");
     expect(e!.runNumber).toBe(2500);
-    expect(e!.kennelTag).toBe("gch3-au");
+    expect(e!.kennelTags[0]).toBe("gch3-au");
     expect(e!.hares).toBe("Hierarchy");
     expect(e!.title).toBe("Special Event");
   });

--- a/src/adapters/html-scraper/gold-coast-h3.ts
+++ b/src/adapters/html-scraper/gold-coast-h3.ts
@@ -63,7 +63,7 @@ export function parseGoldCoastRow(
   const themeRaw = cells[3].trim();
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     hares: hareRaw || undefined,
     title: themeRaw || undefined,

--- a/src/adapters/html-scraper/hague-h3.test.ts
+++ b/src/adapters/html-scraper/hague-h3.test.ts
@@ -61,7 +61,7 @@ Cost: non-members EUR 7.00 for a single run (includes beer and snacks)`;
     expect(event!.hares).toBe("Balls on a Dyke");
     expect(event!.startTime).toBe("14:00");
     expect(event!.location).toBe("Parallelweg crossing Houtrustweg by Sportcity, The Hague");
-    expect(event!.kennelTag).toBe("hagueh3");
+    expect(event!.kennelTags[0]).toBe("hagueh3");
     expect(event!.title).toBe("Hague H3 #2412");
   });
 
@@ -246,7 +246,7 @@ describe("HagueH3Adapter", () => {
     expect(result.errors).toHaveLength(0);
     expect(result.events.length).toBeGreaterThanOrEqual(2);
     expect(result.events[0].runNumber).toBe(2412);
-    expect(result.events[0].kennelTag).toBe("hagueh3");
+    expect(result.events[0].kennelTags[0]).toBe("hagueh3");
   });
 
   it("handles fetch failure gracefully", async () => {

--- a/src/adapters/html-scraper/hague-h3.ts
+++ b/src/adapters/html-scraper/hague-h3.ts
@@ -171,7 +171,7 @@ export function parseEventBlock(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     title: eventTitle,
     runNumber,
     hares,

--- a/src/adapters/html-scraper/halvemein.test.ts
+++ b/src/adapters/html-scraper/halvemein.test.ts
@@ -83,7 +83,7 @@ describe("parseHalveMeinRow", () => {
     expect(result!.startTime).toBe("18:00");
     expect(result!.location).toBe("Crossroads Brewing, Athens, NY");
     expect(result!.hares).toBe("Hashy McHashface");
-    expect(result!.kennelTag).toBe("halvemein");
+    expect(result!.kennelTags[0]).toBe("halvemein");
     expect(result!.title).toBe("HMHHH #825");
   });
 

--- a/src/adapters/html-scraper/halvemein.ts
+++ b/src/adapters/html-scraper/halvemein.ts
@@ -146,7 +146,7 @@ export function parseHalveMeinRow(
 
   return {
     date,
-    kennelTag: "halvemein",
+    kennelTags: ["halvemein"],
     runNumber,
     title,
     hares,

--- a/src/adapters/html-scraper/hangover.test.ts
+++ b/src/adapters/html-scraper/hangover.test.ts
@@ -234,7 +234,7 @@ describe("HangoverAdapter Ghost API integration", () => {
     // First event — has prelubes section (should be stripped)
     expect(result.events[0]).toMatchObject({
       date: "2026-03-08",
-      kennelTag: "h4",
+      kennelTags: ["h4"],
       runNumber: 215,
       title: "The Spring Trail",
       hares: "Spring Runner and Trail Blazer",
@@ -247,7 +247,7 @@ describe("HangoverAdapter Ghost API integration", () => {
     // Second event — no prelubes section
     expect(result.events[1]).toMatchObject({
       date: "2026-02-15",
-      kennelTag: "h4",
+      kennelTags: ["h4"],
       runNumber: 214,
       title: "The Hungover Hearts Trail",
       hares: "Just Rebekah and Grinding Nemo",
@@ -428,7 +428,7 @@ describe("HangoverAdapter HTML scraping (legacy)", () => {
     // First event
     expect(result.events[0]).toMatchObject({
       date: "2026-02-15",
-      kennelTag: "h4",
+      kennelTags: ["h4"],
       runNumber: 214,
       title: "The Hungover Hearts Trail",
       hares: "Just Rebekah and Grinding Nemo",
@@ -441,7 +441,7 @@ describe("HangoverAdapter HTML scraping (legacy)", () => {
     // Second event
     expect(result.events[1]).toMatchObject({
       date: "2026-01-11",
-      kennelTag: "h4",
+      kennelTags: ["h4"],
       runNumber: 213,
       title: "Need Wood",
       hares: "TestHare1 and TestHare2",
@@ -695,7 +695,7 @@ describe("HangoverAdapter Ghost API — post #212 trail-before-hr", () => {
     expect(result.events).toHaveLength(1);
     expect(result.events[0]).toMatchObject({
       date: "2026-01-01",
-      kennelTag: "h4",
+      kennelTags: ["h4"],
       runNumber: 212,
       title: "The Hangover H3 New Years 2026 Trail",
       hares: "Straight in the Navy",

--- a/src/adapters/html-scraper/hangover.ts
+++ b/src/adapters/html-scraper/hangover.ts
@@ -316,7 +316,7 @@ export class HangoverAdapter implements SourceAdapter {
 
       events.push({
         date: eventDate,
-        kennelTag: "h4",
+        kennelTags: ["h4"],
         runNumber: parsed.runNumber,
         title: parsed.trailName,
         hares: bodyFields.hares,
@@ -403,7 +403,7 @@ export class HangoverAdapter implements SourceAdapter {
 
       events.push({
         date: eventDate,
-        kennelTag: "h4",
+        kennelTags: ["h4"],
         runNumber: parsed.runNumber,
         title: parsed.trailName,
         hares: bodyFields.hares,

--- a/src/adapters/html-scraper/hash-horrors.test.ts
+++ b/src/adapters/html-scraper/hash-horrors.test.ts
@@ -57,7 +57,7 @@ describe("parseHashHorrorsHareline", () => {
   it("tags every event with kennelTag 'hhhorrors' and default startTime", () => {
     const text = "2026 1016 – May 17 – Wade Family";
     const events = parseHashHorrorsHareline(text).events;
-    expect(events[0].kennelTag).toBe("hhhorrors");
+    expect(events[0].kennelTags[0]).toBe("hhhorrors");
     expect(events[0].startTime).toBe("16:30");
   });
 

--- a/src/adapters/html-scraper/hash-horrors.ts
+++ b/src/adapters/html-scraper/hash-horrors.ts
@@ -142,7 +142,7 @@ export function parseHashHorrorsHareline(text: string): ParseHarelineResult {
       events.push({
         date,
         startTime: DEFAULT_START_TIME,
-        kennelTag: KENNEL_TAG,
+        kennelTags: [KENNEL_TAG],
         runNumber: parsed.runNumber,
         title: `Hash Horrors ${parsed.runNumber}`,
         hares: parsed.hares,

--- a/src/adapters/html-scraper/hashnyc.test.ts
+++ b/src/adapters/html-scraper/hashnyc.test.ts
@@ -453,7 +453,7 @@ describe("parseRows", () => {
 
     const result = parseRows($, rows, "https://hashnyc.com", true, "future_hashes");
     expect(result.events.length).toBe(1);
-    expect(result.events[0].kennelTag).toBe("nych3");
+    expect(result.events[0].kennelTags[0]).toBe("nych3");
   });
 
   it("defaults section to past_hashes for non-future rows", () => {
@@ -520,7 +520,7 @@ describe("HashNYCAdapter deduplication", () => {
     const result = await adapter.fetch({ url: "https://hashnyc.com" } as never);
 
     // Should be deduplicated: only 1 event, not 2
-    const nychEvents = result.events.filter(e => e.kennelTag === "nych3" && e.date === "2026-06-20");
+    const nychEvents = result.events.filter(e => e.kennelTags[0] === "nych3" && e.date === "2026-06-20");
     expect(nychEvents.length).toBe(1);
     // Future table entry should win (later overwrites)
     expect(nychEvents[0].hares).toBe("Updated Hare");

--- a/src/adapters/html-scraper/hashnyc.ts
+++ b/src/adapters/html-scraper/hashnyc.ts
@@ -521,7 +521,7 @@ export function parseRows(
 
       events.push({
         date: dateStr,
-        kennelTag: parsed.kennelTag,
+        kennelTags: [parsed.kennelTag],
         runNumber: parsed.runNumber,
         title: parsed.title,
         description: parsed.description,
@@ -627,7 +627,7 @@ export class HashNYCAdapter implements SourceAdapter {
     // Later entry (future table) overwrites earlier (past table) since it's more current.
     const deduped = new Map<string, RawEventData>();
     for (const event of allEvents) {
-      const key = `${event.kennelTag}:${event.date}:${event.runNumber ?? ""}:${event.startTime ?? ""}`;
+      const key = `${event.kennelTags[0]}:${event.date}:${event.runNumber ?? ""}:${event.startTime ?? ""}`;
       deduped.set(key, event);
     }
     const dedupedEvents = Array.from(deduped.values());

--- a/src/adapters/html-scraper/hashphilly.test.ts
+++ b/src/adapters/html-scraper/hashphilly.test.ts
@@ -66,7 +66,7 @@ describe("HashPhillyAdapter.fetch", () => {
     expect(result.errors).toHaveLength(0);
 
     const event = result.events[0];
-    expect(event.kennelTag).toBe("philly-h3");
+    expect(event.kennelTags[0]).toBe("philly-h3");
     expect(event.date).toBe("2026-02-14");
     expect(event.runNumber).toBe(1234);
     expect(event.startTime).toBe("15:00");

--- a/src/adapters/html-scraper/hashphilly.ts
+++ b/src/adapters/html-scraper/hashphilly.ts
@@ -49,14 +49,14 @@ export class HashPhillyAdapter implements SourceAdapter {
     const locationMatch = bodyText.match(/Location:\s*(.+?)(?:\n|$)/i);
 
     if (!dateMatch) {
-      errorDetails.parse = [{ row: 0, section: "main", field: "date", error: "No date found on page", rawText: bodyText.slice(0, 2000), partialData: { kennelTag: "philly-h3" } }];
+      errorDetails.parse = [{ row: 0, section: "main", field: "date", error: "No date found on page", rawText: bodyText.slice(0, 2000), partialData: { kennelTags: ["philly-h3" ]} }];
       return { events: [], errors: ["No date found on page"], structureHash, errorDetails };
     }
 
     const dateStr = parsePhillyDate(dateMatch[1].trim());
     if (!dateStr) {
       const message = `Could not parse date: "${dateMatch[1].trim()}"`;
-      errorDetails.parse = [{ row: 0, section: "main", field: "date", error: message, rawText: bodyText.slice(0, 2000), partialData: { kennelTag: "philly-h3" } }];
+      errorDetails.parse = [{ row: 0, section: "main", field: "date", error: message, rawText: bodyText.slice(0, 2000), partialData: { kennelTags: ["philly-h3" ]} }];
       return { events: [], errors: [message], structureHash, errorDetails };
     }
 
@@ -74,7 +74,7 @@ export class HashPhillyAdapter implements SourceAdapter {
 
     events.push({
       date: dateStr,
-      kennelTag: "philly-h3",
+      kennelTags: ["philly-h3"],
       runNumber,
       location,
       locationUrl: location ? mapsUrl(location) : undefined,

--- a/src/adapters/html-scraper/hayama-4h.test.ts
+++ b/src/adapters/html-scraper/hayama-4h.test.ts
@@ -47,7 +47,7 @@ describe("parseSectionText", () => {
 
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-03-29");
-    expect(event!.kennelTag).toBe("hayama-4h");
+    expect(event!.kennelTags[0]).toBe("hayama-4h");
     expect(event!.runNumber).toBe(204);
     expect(event!.location).toBe("Mejiroyamashita(目白山下)");
     expect(event!.hares).toBe("Super Spreader");

--- a/src/adapters/html-scraper/hayama-4h.ts
+++ b/src/adapters/html-scraper/hayama-4h.ts
@@ -71,7 +71,7 @@ export function parseSectionText(
 
   return {
     date,
-    kennelTag: "hayama-4h",
+    kennelTags: ["hayama-4h"],
     title,
     runNumber,
     hares: hares || undefined,

--- a/src/adapters/html-scraper/hkh3.test.ts
+++ b/src/adapters/html-scraper/hkh3.test.ts
@@ -52,7 +52,7 @@ describe("parseHkh3Homepage", () => {
     expect(event!.location).toBe("Hollywood Park Road");
     expect(event!.locationUrl).toBe("https://maps.app.goo.gl/gxCPV8ZLegCWebTX8?g_st=ac");
     expect(event!.startTime).toBe("18:00");
-    expect(event!.kennelTag).toBe("hkh3");
+    expect(event!.kennelTags[0]).toBe("hkh3");
     expect(event!.title).toBe("HK H3 Run #2969");
     expect(event!.date).toBe("2026-04-27");
   });

--- a/src/adapters/html-scraper/hkh3.ts
+++ b/src/adapters/html-scraper/hkh3.ts
@@ -156,7 +156,7 @@ export function parseHkh3Homepage(
 
   return {
     date: nextMondayOnOrAfter(today),
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber: Number.isFinite(runNumber) ? runNumber : undefined,
     title: runNumber ? `HK H3 Run #${runNumber}` : "HK H3 Weekly Run",
     location,

--- a/src/adapters/html-scraper/hockessin.test.ts
+++ b/src/adapters/html-scraper/hockessin.test.ts
@@ -16,7 +16,7 @@ describe("HockessinAdapter", () => {
       expect(event!.hares).toBe("Green Dress Hash");
       expect(event!.date).toBe("2026-03-14");
       expect(event!.startTime).toBe("15:00");
-      expect(event!.kennelTag).toBe("hockessin");
+      expect(event!.kennelTags[0]).toBe("hockessin");
       expect(event!.location).toContain("404 New London Road");
       expect(event!.location).toContain("Newark");
       expect(event!.location).toContain("DE");

--- a/src/adapters/html-scraper/hockessin.ts
+++ b/src/adapters/html-scraper/hockessin.ts
@@ -59,7 +59,7 @@ export function parseHockessinEvent(
 
   return {
     date,
-    kennelTag: "hockessin",
+    kennelTags: ["hockessin"],
     runNumber: !Number.isNaN(runNumber) ? runNumber : undefined,
     title: `Hockessin H3 Trail #${runNumber}`,
     hares,

--- a/src/adapters/html-scraper/indyh3.test.ts
+++ b/src/adapters/html-scraper/indyh3.test.ts
@@ -60,7 +60,7 @@ describe("parseIndyCard", () => {
     expect(event).toMatchObject({
       date: "2026-04-10",
       startTime: "17:00",
-      kennelTag: "indyh3",
+      kennelTags: ["indyh3"],
       runNumber: 1119,
       title: "IndyScent Prom - Spy vs Spy 2026 - Initial Contact",
       sourceUrl: "https://indyhhh.com/hashes/hash-1119-indy-prom-pre-lube/",
@@ -77,7 +77,7 @@ describe("parseIndyCard", () => {
       "indyh3",
       "https://indyhhh.com",
     );
-    expect(event?.kennelTag).toBe("thicch3");
+    expect(event?.kennelTags[0]).toBe("thicch3");
     expect(event?.runNumber).toBe(1122);
     expect(event?.hares).toBe("Shaggy");
   });

--- a/src/adapters/html-scraper/indyh3.ts
+++ b/src/adapters/html-scraper/indyh3.ts
@@ -130,8 +130,7 @@ export function parseIndyCard(
 
   return {
     date,
-    kennelTag,
-    runNumber,
+    kennelTags: [kennelTag],    runNumber,
     title,
     hares,
     location,

--- a/src/adapters/html-scraper/ithaca-h3.test.ts
+++ b/src/adapters/html-scraper/ithaca-h3.test.ts
@@ -66,7 +66,7 @@ describe("parseIH3Block", () => {
     expect(result).not.toBeNull();
     expect(result!.runNumber).toBe(1119);
     expect(result!.date).toBe("2026-03-15");
-    expect(result!.kennelTag).toBe("ih3");
+    expect(result!.kennelTags[0]).toBe("ih3");
     expect(result!.title).toBe("IH3 #1119");
     expect(result!.hares).toBe("Flesh Flaps & Spike");
     expect(result!.startTime).toBe("14:00");

--- a/src/adapters/html-scraper/ithaca-h3.ts
+++ b/src/adapters/html-scraper/ithaca-h3.ts
@@ -134,7 +134,7 @@ export function parseIH3Block(
 
   return {
     date,
-    kennelTag: "ih3",
+    kennelTags: ["ih3"],
     runNumber: !isNaN(runNumber) ? runNumber : undefined,
     title: `IH3 #${runNumber}`,
     hares,

--- a/src/adapters/html-scraper/kampong-h3.ts
+++ b/src/adapters/html-scraper/kampong-h3.ts
@@ -99,7 +99,7 @@ function buildEventFromPageText(pageText: string, sourceUrl: string): {
   const event: RawEventData = {
     date: fields.date,
     startTime: fields.startTime,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber: fields.runNumber,
     title: fields.runNumber
       ? `Kampong H3 Run ${fields.runNumber}`

--- a/src/adapters/html-scraper/kch3.test.ts
+++ b/src/adapters/html-scraper/kch3.test.ts
@@ -120,7 +120,7 @@ describe("processKCH3Post", () => {
 
     expect(result).not.toBeNull();
     expect(result!.date).toBe("2026-03-21");
-    expect(result!.kennelTag).toBe("kch3");
+    expect(result!.kennelTags[0]).toBe("kch3");
     expect(result!.title).toBe("SHHHHHHH Trail");
     expect(result!.hares).toBe("Shhhhhhhh");
     expect(result!.startTime).toBe("14:00");
@@ -183,7 +183,7 @@ describe("KCH3Adapter", () => {
     const result = await adapter.fetch(mockSource);
     expect(result.events).toHaveLength(1);
     expect(result.events[0].date).toBe("2026-03-21");
-    expect(result.events[0].kennelTag).toBe("kch3");
+    expect(result.events[0].kennelTags[0]).toBe("kch3");
     expect(result.events[0].hares).toBe("Shhhhhhhh");
   });
 

--- a/src/adapters/html-scraper/kch3.ts
+++ b/src/adapters/html-scraper/kch3.ts
@@ -111,8 +111,7 @@ export function processKCH3Post(
 
   return {
     date: dateStr,
-    kennelTag,
-    title: trailName,
+    kennelTags: [kennelTag],    title: trailName,
     hares: body.hares,
     location: body.location,
     startTime,

--- a/src/adapters/html-scraper/kj-harimau.ts
+++ b/src/adapters/html-scraper/kj-harimau.ts
@@ -230,7 +230,7 @@ export class KjHarimauAdapter implements SourceAdapter {
 
       events.push({
         date,
-        kennelTag: KENNEL_TAG,
+        kennelTags: [KENNEL_TAG],
         runNumber,
         hares,
         location,

--- a/src/adapters/html-scraper/klj-h3.ts
+++ b/src/adapters/html-scraper/klj-h3.ts
@@ -181,7 +181,7 @@ export function parseKljPost(post: KljPostInput): ParseKljPostResult {
     ok: true,
     event: {
       date,
-      kennelTag: KENNEL_TAG,
+      kennelTags: [KENNEL_TAG],
       runNumber,
       title,
       hares: normalizeHaresField(mergedHares),

--- a/src/adapters/html-scraper/ladies-h4-hk.test.ts
+++ b/src/adapters/html-scraper/ladies-h4-hk.test.ts
@@ -10,7 +10,7 @@ describe("parseLadiesH4Row", () => {
 
     expect(result).not.toBeNull();
     expect(result!.date).toBe("2025-04-08");
-    expect(result!.kennelTag).toBe("lh4-hk");
+    expect(result!.kennelTags[0]).toBe("lh4-hk");
     expect(result!.runNumber).toBe(1234);
     expect(result!.hares).toBe("Speedy & Dizzy");
     expect(result!.location).toBe("Wan Chai Park");

--- a/src/adapters/html-scraper/ladies-h4-hk.ts
+++ b/src/adapters/html-scraper/ladies-h4-hk.ts
@@ -39,7 +39,7 @@ export function parseLadiesH4Row(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber: runNumber && runNumber > 0 ? runNumber : undefined,
     title: runNumber ? `Ladies H4 Run #${runNumber}` : "Ladies H4 Run",
     hares: validHares,

--- a/src/adapters/html-scraper/larrikins.test.ts
+++ b/src/adapters/html-scraper/larrikins.test.ts
@@ -21,7 +21,7 @@ describe("larrikins parseLarrikinsRow", () => {
     expect(e).not.toBeNull();
     expect(e!.date).toBe("2026-04-21");
     expect(e!.runNumber).toBe(2492);
-    expect(e!.kennelTag).toBe("larrikins-au");
+    expect(e!.kennelTags[0]).toBe("larrikins-au");
     expect(e!.hares).toBe("Bejesus");
   });
 

--- a/src/adapters/html-scraper/larrikins.ts
+++ b/src/adapters/html-scraper/larrikins.ts
@@ -60,7 +60,7 @@ export function parseLarrikinsRow(
   const hares = hareCell.trim() || undefined;
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     hares,
     sourceUrl,

--- a/src/adapters/html-scraper/lion-city-h3.test.ts
+++ b/src/adapters/html-scraper/lion-city-h3.test.ts
@@ -89,7 +89,7 @@ Map – On On: A bar</p>`;
     expect(event).toMatchObject({
       date: "2026-04-03",
       startTime: "18:00",
-      kennelTag: "lch3",
+      kennelTags: ["lch3"],
       runNumber: 2193,
       title: "Hash Run #2193",
       hares: "Lap Dog",

--- a/src/adapters/html-scraper/lion-city-h3.ts
+++ b/src/adapters/html-scraper/lion-city-h3.ts
@@ -140,7 +140,7 @@ export function buildLionCityEvent(
   return {
     date: parsedBody.date,
     startTime: parsedBody.startTime,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber: parsedTitle.runNumber,
     title: parsedTitle.title,
     description,

--- a/src/adapters/html-scraper/london-hash.test.ts
+++ b/src/adapters/html-scraper/london-hash.test.ts
@@ -432,7 +432,7 @@ describe("parseLH3DetailPage", () => {
 describe("mergeLH3DetailIntoEvent", () => {
   const baseEvent: RawEventData = {
     date: "2026-03-14",
-    kennelTag: "lh3",
+    kennelTags: ["lh3"],
     runNumber: 2823,
     title: "London Hash Run #2823",
     hares: "Run List Hare",
@@ -466,7 +466,7 @@ describe("mergeLH3DetailIntoEvent", () => {
     expect(merged.description).toContain("Distance: 113 meters from Finchley Road station as the Skylark flies");
     // Preserved base fields
     expect(merged.date).toBe("2026-03-14");
-    expect(merged.kennelTag).toBe("lh3");
+    expect(merged.kennelTags[0]).toBe("lh3");
     expect(merged.startTime).toBe("12:00");
   });
 
@@ -524,7 +524,7 @@ describe("LondonHashAdapter.fetch", () => {
     const first = result.events.find((e) => e.runNumber === 2820);
     expect(first).toBeDefined();
     expect(first!.date).toBe("2026-02-21");
-    expect(first!.kennelTag).toBe("lh3");
+    expect(first!.kennelTags[0]).toBe("lh3");
     expect(first!.hares).toBe("Tuna Melt and Opee");
     expect(first!.location).toBe("The Dolphin");
     expect(first!.startTime).toBe("12:00");

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -407,7 +407,7 @@ export class LondonHashAdapter implements SourceAdapter {
 
         events.push({
           date,
-          kennelTag: "lh3",
+          kennelTags: ["lh3"],
           runNumber: block.runNumber,
           title: `London Hash Run #${block.runNumber}`,
           hares: hares ?? undefined,

--- a/src/adapters/html-scraper/lsw-h3.test.ts
+++ b/src/adapters/html-scraper/lsw-h3.test.ts
@@ -33,7 +33,7 @@ describe("parseLswRow", () => {
 
     expect(result).not.toBeNull();
     expect(result!.date).toBe("2025-04-09");
-    expect(result!.kennelTag).toBe("lsw-h3");
+    expect(result!.kennelTags[0]).toBe("lsw-h3");
     expect(result!.runNumber).toBe(2402);
     expect(result!.hares).toBe("Indy and Inflatable");
     // Source calls this column "DESCRIPTION" but it always holds an HK

--- a/src/adapters/html-scraper/lsw-h3.ts
+++ b/src/adapters/html-scraper/lsw-h3.ts
@@ -66,7 +66,7 @@ export function parseLswRow(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber: runNumber && runNumber > 0 ? runNumber : undefined,
     title: runNumber ? `LSW Run #${runNumber}` : location || undefined,
     hares: validHares,

--- a/src/adapters/html-scraper/lvh3.ts
+++ b/src/adapters/html-scraper/lvh3.ts
@@ -100,8 +100,7 @@ export function buildLvh3RawEvent(
   return {
     date: e.date,
     startTime: e.allDay ? undefined : e.startTime,
-    kennelTag,
-    title: e.title,
+    kennelTags: [kennelTag],    title: e.title,
     runNumber: extractLvRunNumber(e.title ?? ""),
     description: e.description,
     location:

--- a/src/adapters/html-scraper/mersey-thirstdays.test.ts
+++ b/src/adapters/html-scraper/mersey-thirstdays.test.ts
@@ -344,7 +344,7 @@ describe("MerseyThirstdaysAdapter", () => {
       expect(run600!.date).toBe("2026-04-16");
       expect(run600!.hares).toBe("Snoozeanne");
       expect(run600!.location).toContain("Augustus John");
-      expect(run600!.kennelTag).toBe("MTH3");
+      expect(run600!.kennelTags[0]).toBe("MTH3");
       expect(run600!.startTime).toBe("19:00");
     });
 

--- a/src/adapters/html-scraper/mersey-thirstdays.ts
+++ b/src/adapters/html-scraper/mersey-thirstdays.ts
@@ -444,7 +444,7 @@ export class MerseyThirstdaysAdapter implements SourceAdapter {
 
           events.push({
             date: run.date,
-            kennelTag: KENNEL_TAG,
+            kennelTags: [KENNEL_TAG],
             runNumber: run.runNumber,
             title,
             hares: run.hares,
@@ -511,7 +511,7 @@ export class MerseyThirstdaysAdapter implements SourceAdapter {
 
                 events.push({
                   date: run.date,
-                  kennelTag: KENNEL_TAG,
+                  kennelTags: [KENNEL_TAG],
                   runNumber: run.runNumber,
                   title,
                   hares: run.hares,

--- a/src/adapters/html-scraper/mother-hash.test.ts
+++ b/src/adapters/html-scraper/mother-hash.test.ts
@@ -104,7 +104,7 @@ describe("parseMotherHashBlock", () => {
       url: "https://waze.com/ul/hw282wz7gv",
       label: "Waze",
     });
-    expect(event?.kennelTag).toBe("motherh3");
+    expect(event?.kennelTags[0]).toBe("motherh3");
     expect(event?.sourceUrl).toBe("https://www.motherhash.org");
   });
 

--- a/src/adapters/html-scraper/mother-hash.ts
+++ b/src/adapters/html-scraper/mother-hash.ts
@@ -161,7 +161,7 @@ export function parseMotherHashBlock(block: string, sourceUrl: string): RawEvent
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     hares,
     location,

--- a/src/adapters/html-scraper/n2th3.test.ts
+++ b/src/adapters/html-scraper/n2th3.test.ts
@@ -28,7 +28,7 @@ describe("parseN2th3Post", () => {
     const result = parseN2th3Post(buildPost());
     expect(result).not.toBeNull();
     expect(result!.date).toBe("2026-04-09");
-    expect(result!.kennelTag).toBe("n2th3");
+    expect(result!.kennelTags[0]).toBe("n2th3");
     expect(result!.runNumber).toBe(2226);
     expect(result!.hares).toBe("Imbiblio");
     expect(result!.startTime).toBe("19:00");

--- a/src/adapters/html-scraper/n2th3.ts
+++ b/src/adapters/html-scraper/n2th3.ts
@@ -162,7 +162,7 @@ export function parseN2th3Post(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     title: runNumber ? `N2TH3 Run #${runNumber}` : title,
     hares,

--- a/src/adapters/html-scraper/new-tokyo-katch.test.ts
+++ b/src/adapters/html-scraper/new-tokyo-katch.test.ts
@@ -272,13 +272,13 @@ describe("NewTokyoKatchAdapter", () => {
       expect(run456).toBeDefined();
       expect(run456!.date).toBe("2026-01-31");
       expect(run456!.title).toBe("New Tokyo Katch #456");
-      expect(run456!.kennelTag).toBe("new-tokyo-katch");
+      expect(run456!.kennelTags[0]).toBe("new-tokyo-katch");
       expect(run456!.hares).toBe("Tokyo Runner; Sweep: Noodle King");
 
       const run457 = result.events.find((e) => e.runNumber === 457);
       expect(run457).toBeDefined();
       expect(run457!.date).toBe("2026-04-17");
-      expect(run457!.kennelTag).toBe("new-tokyo-katch");
+      expect(run457!.kennelTags[0]).toBe("new-tokyo-katch");
     });
 
     it("verifies browserRender is called with frameUrl option", async () => {

--- a/src/adapters/html-scraper/new-tokyo-katch.ts
+++ b/src/adapters/html-scraper/new-tokyo-katch.ts
@@ -209,7 +209,7 @@ function buildRawEvent(parsed: ParsedNtkRun, sourceUrl: string): RawEventData {
 
   return {
     date: parsed.date,
-    kennelTag: KENNEL_CODE,
+    kennelTags: [KENNEL_CODE],
     runNumber: parsed.runNumber,
     title,
     hares: parsed.hares,

--- a/src/adapters/html-scraper/norfolk-h3.test.ts
+++ b/src/adapters/html-scraper/norfolk-h3.test.ts
@@ -336,7 +336,7 @@ describe("NorfolkH3Adapter", () => {
       expect(run2139!.location).toContain("Crown Inn");
       expect(run2139!.location).toContain("NR28 0AH");
       expect(run2139!.hares).toBe("Woolly and Bagpuss");
-      expect(run2139!.kennelTag).toBe("Norfolk H3");
+      expect(run2139!.kennelTags[0]).toBe("Norfolk H3");
 
       // Second event: Run #2144 (Wednesday evening)
       const run2144 = result.events.find((e) => e.runNumber === 2144);

--- a/src/adapters/html-scraper/norfolk-h3.ts
+++ b/src/adapters/html-scraper/norfolk-h3.ts
@@ -360,7 +360,7 @@ export class NorfolkH3Adapter implements SourceAdapter {
 
         events.push({
           date: parsed.date,
-          kennelTag: KENNEL_TAG,
+          kennelTags: [KENNEL_TAG],
           runNumber: parsed.runNumber,
           title,
           hares: parsed.hares,

--- a/src/adapters/html-scraper/northboro-hash.test.ts
+++ b/src/adapters/html-scraper/northboro-hash.test.ts
@@ -66,7 +66,7 @@ describe("parseTrailBlock", () => {
     );
     expect(result).toEqual({
       date: "2026-02-15",
-      kennelTag: "nbh3",
+      kennelTags: ["nbh3"],
       runNumber: 237,
       title: "NbH3 Trail #237",
       hares: undefined,
@@ -83,7 +83,7 @@ describe("parseTrailBlock", () => {
     );
     expect(result).toEqual({
       date: "2026-01-01",
-      kennelTag: "nbh3",
+      kennelTags: ["nbh3"],
       runNumber: 236,
       title: "Hangover Trail",
       hares: "Scrumples",
@@ -100,7 +100,7 @@ describe("parseTrailBlock", () => {
     );
     expect(result).toEqual({
       date: "2026-03-14",
-      kennelTag: "nbh3",
+      kennelTags: ["nbh3"],
       runNumber: 238,
       title: "Pi Day Hash",
       hares: "Alice, Bob",
@@ -121,7 +121,7 @@ describe("parseTrailBlock", () => {
     );
     expect(result).toEqual({
       date: "2026-04-18",
-      kennelTag: "nbh3",
+      kennelTags: ["nbh3"],
       runNumber: 239,
       title: "NbH3 Trail #239",
       hares: "HashName",
@@ -138,7 +138,7 @@ describe("parseTrailBlock", () => {
     );
     expect(result).toEqual({
       date: "2026-05-16",
-      kennelTag: "nbh3",
+      kennelTags: ["nbh3"],
       runNumber: 240,
       title: "NbH3 Trail #240",
       hares: undefined,
@@ -270,13 +270,13 @@ describe("NorthboroHashAdapter", () => {
     expect(result.events).toHaveLength(2);
     expect(result.events[0]).toMatchObject({
       date: "2026-02-15",
-      kennelTag: "nbh3",
+      kennelTags: ["nbh3"],
       runNumber: 237,
       title: "Winter Hash",
     });
     expect(result.events[1]).toMatchObject({
       date: "2026-03-14",
-      kennelTag: "nbh3",
+      kennelTags: ["nbh3"],
       runNumber: 238,
       title: "Pi Day Hash",
     });
@@ -305,7 +305,7 @@ describe("NorthboroHashAdapter", () => {
     const december = result.events.find((e) => e.runNumber === 235);
     expect(december).toMatchObject({
       date: "2025-12-20",
-      kennelTag: "nbh3",
+      kennelTags: ["nbh3"],
       runNumber: 235,
       title: "Holiday Hash",
       hares: "Santa",

--- a/src/adapters/html-scraper/northboro-hash.ts
+++ b/src/adapters/html-scraper/northboro-hash.ts
@@ -157,7 +157,7 @@ export function parseTrailBlock(
 
   return {
     date,
-    kennelTag: "nbh3",
+    kennelTags: ["nbh3"],
     runNumber,
     title: title || `NbH3 Trail #${runNumber}`,
     hares,

--- a/src/adapters/html-scraper/och3.test.ts
+++ b/src/adapters/html-scraper/och3.test.ts
@@ -215,7 +215,7 @@ describe("parseDetailPage", () => {
 describe("mergeDetailIntoEvent", () => {
   const baseEvent: RawEventData = {
     date: "2026-03-09",
-    kennelTag: "och3",
+    kennelTags: ["och3"],
     title: "Anna 'Fish n Chips' Cooper",
     startTime: "19:30",
     sourceUrl: "http://www.och3.org.uk/upcoming-run-list.html",
@@ -244,7 +244,7 @@ describe("mergeDetailIntoEvent", () => {
     expect(merged.description).toBe("On Inn: The Bush, Dorking");
     expect(merged.sourceUrl).toBe("http://www.och3.org.uk/next-run-details.html");
     // Original fields preserved
-    expect(merged.kennelTag).toBe("och3");
+    expect(merged.kennelTags[0]).toBe("och3");
     // Title cleared because it matched the hare name (run-list sets hare as title for OCH3)
     expect(merged.title).toBeUndefined();
   });

--- a/src/adapters/html-scraper/och3.ts
+++ b/src/adapters/html-scraper/och3.ts
@@ -269,7 +269,7 @@ export function parseEventsPage(html: string, baseUrl: string): RawEventData[] {
 
     events.push({
       date,
-      kennelTag: "och3",
+      kennelTags: ["och3"],
       title,
       location,
       description: description || undefined,
@@ -332,7 +332,7 @@ function parseRunEntry(
   return {
     entry: {
       date,
-      kennelTag: "och3",
+      kennelTags: ["och3"],
       title,
       location,
       startTime: getStartTimeForDay(extractDayOfWeek(section) ?? inferDayFromDate(date)),
@@ -430,7 +430,7 @@ export class OCH3Adapter implements SourceAdapter {
           const dayOfWeek = inferDayFromDate(detail.date!);
           events.unshift({
             date: detail.date!,
-            kennelTag: "och3",
+            kennelTags: ["och3"],
             startTime: detail.startTime ?? getStartTimeForDay(dayOfWeek),
             location: detail.location,
             hares: detail.hares,

--- a/src/adapters/html-scraper/ofh3.test.ts
+++ b/src/adapters/html-scraper/ofh3.test.ts
@@ -256,7 +256,7 @@ describe("OFH3Adapter.fetch (Blogger API path)", () => {
 
     expect(result.events[0]).toMatchObject({
       date: "2026-03-14",
-      kennelTag: "ofh3",
+      kennelTags: ["ofh3"],
       title: "Are you feelin' lucky?",
       hares: "Herpicles",
       location: "Blue Heron Elementary School",
@@ -268,7 +268,7 @@ describe("OFH3Adapter.fetch (Blogger API path)", () => {
     // TBA location should be excluded
     expect(result.events[1]).toMatchObject({
       date: "2026-02-08",
-      kennelTag: "ofh3",
+      kennelTags: ["ofh3"],
     });
     expect(result.events[1].location).toBeUndefined();
 
@@ -339,7 +339,7 @@ describe("OFH3Adapter.fetch (HTML fallback path)", () => {
     // First event (March)
     expect(result.events[0]).toMatchObject({
       date: "2026-03-14",
-      kennelTag: "ofh3",
+      kennelTags: ["ofh3"],
       title: "Are you feelin' lucky?",
       hares: "Herpicles",
       location: "Blue Heron Elementary School",
@@ -352,7 +352,7 @@ describe("OFH3Adapter.fetch (HTML fallback path)", () => {
     // Second event (February) — TBA location should be excluded
     expect(result.events[1]).toMatchObject({
       date: "2026-02-08",
-      kennelTag: "ofh3",
+      kennelTags: ["ofh3"],
       title: "Ready to shake off the snow?",
       hares: "Livin' Lolita Loca & Special Ed Forces",
       startTime: "11:00",

--- a/src/adapters/html-scraper/ofh3.ts
+++ b/src/adapters/html-scraper/ofh3.ts
@@ -141,7 +141,7 @@ function processPost(
         error: dateError,
         rawText: `Title: ${titleText}\n\n${bodyText}`.slice(0, 2000),
         partialData: {
-          kennelTag: "ofh3",
+          kennelTags: ["ofh3"],
           title: titleText || undefined,
           hares: bodyFields.hares,
           location: bodyFields.location,
@@ -163,7 +163,7 @@ function processPost(
 
   return {
     date: eventDate,
-    kennelTag: "ofh3",
+    kennelTags: ["ofh3"],
     title: cleanedTitle || undefined,
     hares: bodyFields.hares,
     location: bodyFields.location && !isPlaceholder(bodyFields.location) ? bodyFields.location : undefined,

--- a/src/adapters/html-scraper/oh3-ottawa.test.ts
+++ b/src/adapters/html-scraper/oh3-ottawa.test.ts
@@ -98,7 +98,7 @@ Hash Cash:                   $5`;
 
   it("sets kennelTag to oh3-ca", () => {
     const result = parseDetailedBlock(fullBlock);
-    expect(result!.kennelTag).toBe("oh3-ca");
+    expect(result!.kennelTags[0]).toBe("oh3-ca");
   });
 
   it("returns null when no R*n pattern found", () => {
@@ -162,7 +162,7 @@ describe("parsePlanningLine", () => {
     expect(result!.runNumber).toBe(2210);
     expect(result!.date).toBe("2026-05-18");
     expect(result!.hares).toBe("Alkasleezer");
-    expect(result!.kennelTag).toBe("oh3-ca");
+    expect(result!.kennelTags[0]).toBe("oh3-ca");
     expect(result!.startTime).toBe("18:45");
   });
 
@@ -247,7 +247,7 @@ describe("Oh3OttawaAdapter", () => {
     expect(run2203).toBeDefined();
     expect(run2203!.date).toBe("2026-03-30");
     expect(run2203!.hares).toBe("Didgeri-Do-Me");
-    expect(run2203!.kennelTag).toBe("oh3-ca");
+    expect(run2203!.kennelTags[0]).toBe("oh3-ca");
 
     const run2204 = result.events.find((e) => e.runNumber === 2204);
     expect(run2204).toBeDefined();

--- a/src/adapters/html-scraper/oh3-ottawa.ts
+++ b/src/adapters/html-scraper/oh3-ottawa.ts
@@ -10,7 +10,7 @@
  * 2. Planning-ahead section with one-line-per-event future runs:
  *    2208    Monday, 4 May    2026    NEED A HARE
  *
- * kennelTag: "oh3-ca"
+ * kennelTags: ["oh3-ca"]
  */
 
 import type { Source } from "@/generated/prisma/client";
@@ -80,7 +80,7 @@ export function parseDetailedBlock(text: string): RawEventData | null {
 
   return {
     date: dateStr,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     title,
     hares: stripPlaceholder(haresMatch?.[1]),
@@ -136,7 +136,7 @@ export function parsePlanningLine(text: string): RawEventData | null {
 
   return {
     date: dateStr,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     title,
     hares,

--- a/src/adapters/html-scraper/pattaya-h3.test.ts
+++ b/src/adapters/html-scraper/pattaya-h3.test.ts
@@ -10,7 +10,7 @@ describe("parsePattayaRow", () => {
 
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-04-13");
-    expect(event!.kennelTag).toBe("pattaya-h3");
+    expect(event!.kennelTags[0]).toBe("pattaya-h3");
     expect(event!.runNumber).toBe(2146);
     expect(event!.hares).toContain("Lady Squeeze My Tube");
     expect(event!.hares).toContain("Many Drinks");

--- a/src/adapters/html-scraper/pattaya-h3.ts
+++ b/src/adapters/html-scraper/pattaya-h3.ts
@@ -92,7 +92,7 @@ export function parsePattayaRow(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     title,
     hares,

--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -214,7 +214,7 @@ describe("kennel pattern matching", () => {
     const compiled = makeCompiledPatterns(DEFAULT_CONFIG);
     const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
 
-    expect(event!.kennelTag).toBe("LBH");
+    expect(event!.kennelTags[0]).toBe("LBH");
   });
 
   it("uses defaultKennelTag when no title available for pattern matching", () => {
@@ -224,7 +224,7 @@ describe("kennel pattern matching", () => {
     const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
 
     // No title means no pattern match — falls back to defaultKennelTag
-    expect(event!.kennelTag).toBe("Wrong Way");
+    expect(event!.kennelTags[0]).toBe("Wrong Way");
   });
 
   it("matches Wrong Way from img alt", () => {
@@ -233,7 +233,7 @@ describe("kennel pattern matching", () => {
     const compiled = makeCompiledPatterns(DEFAULT_CONFIG);
     const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
 
-    expect(event!.kennelTag).toBe("Wrong Way");
+    expect(event!.kennelTags[0]).toBe("Wrong Way");
   });
 
   it("matches FDTDD from title", () => {
@@ -242,7 +242,7 @@ describe("kennel pattern matching", () => {
     const compiled = makeCompiledPatterns(DEFAULT_CONFIG);
     const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
 
-    expect(event!.kennelTag).toBe("FDTDD");
+    expect(event!.kennelTags[0]).toBe("FDTDD");
   });
 
   it("falls back to defaultKennelTag for unrecognized events", () => {
@@ -255,7 +255,7 @@ describe("kennel pattern matching", () => {
     const compiled = makeCompiledPatterns(DEFAULT_CONFIG);
     const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
 
-    expect(event!.kennelTag).toBe("Wrong Way");
+    expect(event!.kennelTags[0]).toBe("Wrong Way");
   });
 });
 

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -137,8 +137,7 @@ export function parseEventFromItem(
 
   return {
     date,
-    kennelTag,
-    title,
+    kennelTags: [kennelTag],    title,
     description,
     hares,
     location,
@@ -293,7 +292,7 @@ export class PhoenixHHHAdapter implements SourceAdapter {
           // Re-resolve kennel tag now that we have the real title
           for (const [pattern, tag] of compiledPatterns) {
             if (pattern.test(result.value)) {
-              batch[j].kennelTag = tag;
+              batch[j].kennelTags[0] = tag;
               break;
             }
           }

--- a/src/adapters/html-scraper/phuket-hhh.test.ts
+++ b/src/adapters/html-scraper/phuket-hhh.test.ts
@@ -41,7 +41,7 @@ describe("parsePhuketRow", () => {
     const event = parsePhuketRow(cells, "saturday", DEFAULT_KENNEL_MAP, sourceUrl);
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-04-18");
-    expect(event!.kennelTag).toBe("phhh");
+    expect(event!.kennelTags[0]).toBe("phhh");
     expect(event!.runNumber).toBe(2062);
     expect(event!.startTime).toBe("16:00");
     expect(event!.hares).toContain("B.C.");
@@ -58,7 +58,7 @@ describe("parsePhuketRow", () => {
     ];
     const event = parsePhuketRow(cells, "pooying", DEFAULT_KENNEL_MAP, sourceUrl);
     expect(event).not.toBeNull();
-    expect(event!.kennelTag).toBe("phuket-pooying");
+    expect(event!.kennelTags[0]).toBe("phuket-pooying");
     expect(event!.runNumber).toBe(414);
     expect(event!.startTime).toBe("15:00");
   });
@@ -73,7 +73,7 @@ describe("parsePhuketRow", () => {
     ];
     const event = parsePhuketRow(cells, "tinmen", DEFAULT_KENNEL_MAP, sourceUrl);
     expect(event).not.toBeNull();
-    expect(event!.kennelTag).toBe("phuket-tinmen");
+    expect(event!.kennelTags[0]).toBe("phuket-tinmen");
     expect(event!.date).toBe("2026-05-06");
   });
 
@@ -87,7 +87,7 @@ describe("parsePhuketRow", () => {
     ];
     const event = parsePhuketRow(cells, "ironpussy", DEFAULT_KENNEL_MAP, sourceUrl);
     expect(event).not.toBeNull();
-    expect(event!.kennelTag).toBe("iron-pussy");
+    expect(event!.kennelTags[0]).toBe("iron-pussy");
   });
 
   it("skips unknown kennel class", () => {

--- a/src/adapters/html-scraper/phuket-hhh.ts
+++ b/src/adapters/html-scraper/phuket-hhh.ts
@@ -106,8 +106,7 @@ export function parsePhuketRow(
 
   return {
     date,
-    kennelTag,
-    runNumber,
+    kennelTags: [kennelTag],    runNumber,
     hares: haresRaw ? normalizeHaresField(haresRaw) : undefined,
     location,
     startTime: startTime ?? undefined,
@@ -184,7 +183,7 @@ export class PhuketHHHAdapter implements SourceAdapter {
           fetchMethod: "fetchHTMLPage",
           rowsFound: rowsParsed,
           eventsParsed: events.length,
-          kennelsFound: [...new Set(events.map((e) => e.kennelTag))],
+          kennelsFound: [...new Set(events.map((e) => e.kennelTags[0]))],
           fetchDurationMs,
         },
       },

--- a/src/adapters/html-scraper/renegade-h3.ts
+++ b/src/adapters/html-scraper/renegade-h3.ts
@@ -169,7 +169,7 @@ export class RenegadeH3Adapter implements SourceAdapter {
 
         const event: RawEventData = {
           date: header.date,
-          kennelTag: "renh3",
+          kennelTags: ["renh3"],
           runNumber: header.runNumber,
           title: header.title,
           hares: details.hares,

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -181,7 +181,7 @@ describe("parseHarelineRow", () => {
 
     expect(result).toMatchObject({
       date: "2026-04-21",
-      kennelTag: "rih3",
+      kennelTags: ["rih3"],
       runNumber: 2043,
       startTime: "18:30",
       hares: "tongue in rEar, ProbonoR",
@@ -496,7 +496,7 @@ describe("RIH3Adapter", () => {
     expect(result.events).toHaveLength(2);
     expect(result.events[0]).toMatchObject({
       date: "2026-04-21",
-      kennelTag: "rih3",
+      kennelTags: ["rih3"],
       runNumber: 2043,
       hares: "Rusty",
       title: "Spring Trail",

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -182,7 +182,7 @@ export function parseHarelineRow(
 
   return {
     date,
-    kennelTag: "rih3",
+    kennelTags: ["rih3"],
     title,
     runNumber,
     hares,

--- a/src/adapters/html-scraper/samurai-h3.test.ts
+++ b/src/adapters/html-scraper/samurai-h3.test.ts
@@ -222,13 +222,13 @@ describe("SamuraiH3Adapter", () => {
       expect(run123!.date).toBe("2026-03-28");
       expect(run123!.startTime).toBe("14:00");
       expect(run123!.title).toBe("Samurai H3 #123");
-      expect(run123!.kennelTag).toBe("samurai-h3");
+      expect(run123!.kennelTags[0]).toBe("samurai-h3");
       expect(run123!.hares).toBe("Hashimoto; Sweep: Sake Bomb");
 
       const run124 = result.events.find((e) => e.runNumber === 124);
       expect(run124).toBeDefined();
       expect(run124!.date).toBe("2026-04-04");
-      expect(run124!.kennelTag).toBe("samurai-h3");
+      expect(run124!.kennelTags[0]).toBe("samurai-h3");
     });
 
     it("verifies browserRender is called with frameUrl option", async () => {

--- a/src/adapters/html-scraper/samurai-h3.ts
+++ b/src/adapters/html-scraper/samurai-h3.ts
@@ -205,7 +205,7 @@ function buildRawEvent(parsed: ParsedSamuraiRun, sourceUrl: string): RawEventDat
 
   return {
     date: parsed.date,
-    kennelTag: KENNEL_CODE,
+    kennelTags: [KENNEL_CODE],
     runNumber: parsed.runNumber,
     title,
     hares: parsed.hares,

--- a/src/adapters/html-scraper/sdh3.test.ts
+++ b/src/adapters/html-scraper/sdh3.test.ts
@@ -297,12 +297,12 @@ describe("parseHarelineEvents", () => {
 
   it("parses a dt with all fields", () => {
     const events = parseHarelineEvents(HARELINE_HTML, config);
-    const sdh3Event = events.find((e) => e.kennelTag === "sdh3");
+    const sdh3Event = events.find((e) => e.kennelTags[0] === "sdh3");
 
     expect(sdh3Event).toBeDefined();
     expect(sdh3Event).toMatchObject({
       date: "2026-03-20",
-      kennelTag: "sdh3",
+      kennelTags: ["sdh3"],
       startTime: "18:00",
       hares: "Trail Blazer & Lost Cause",
       location: "123 Main St, San Diego, CA",
@@ -317,12 +317,12 @@ describe("parseHarelineEvents", () => {
 
   it("parses a dt with minimal fields", () => {
     const events = parseHarelineEvents(HARELINE_HTML, config);
-    const irh3Event = events.find((e) => e.kennelTag === "irh3-sd");
+    const irh3Event = events.find((e) => e.kennelTags[0] === "irh3-sd");
 
     expect(irh3Event).toBeDefined();
     expect(irh3Event).toMatchObject({
       date: "2026-03-21",
-      kennelTag: "irh3-sd",
+      kennelTags: ["irh3-sd"],
       startTime: "15:00",
       hares: "Iron Mike",
     });
@@ -352,7 +352,7 @@ describe("parseHarelineEvents", () => {
 
   it("extracts kennel code from CSS class", () => {
     const events = parseHarelineEvents(HARELINE_HTML, config);
-    const tags = events.map((e) => e.kennelTag);
+    const tags = events.map((e) => e.kennelTags[0]);
     expect(tags).toContain("sdh3");
     expect(tags).toContain("irh3-sd");
   });
@@ -361,16 +361,16 @@ describe("parseHarelineEvents", () => {
     const events = parseHarelineEvents(HARELINE_HTML, config);
     // "UNKN" is not in the config, so it should be skipped
     expect(events).toHaveLength(2);
-    expect(events.every((e) => e.kennelTag !== "UNKN")).toBe(true);
+    expect(events.every((e) => e.kennelTags[0] !== "UNKN")).toBe(true);
   });
 
   it("extracts sourceUrl from the float-right span event link", () => {
     const events = parseHarelineEvents(HARELINE_HTML, config);
-    const sdh3Event = events.find((e) => e.kennelTag === "sdh3");
+    const sdh3Event = events.find((e) => e.kennelTags[0] === "sdh3");
     expect(sdh3Event?.sourceUrl).toBe(
       "https://sdh3.com/e/event-20260320180000.shtml",
     );
-    const irh3Event = events.find((e) => e.kennelTag === "irh3-sd");
+    const irh3Event = events.find((e) => e.kennelTags[0] === "irh3-sd");
     expect(irh3Event?.sourceUrl).toBe(
       "https://sdh3.com/e/event-20260321150000.shtml",
     );
@@ -404,12 +404,12 @@ describe("parseHistoryEvents", () => {
 
   it("parses an li entry with kennel in parentheses", () => {
     const events = parseHistoryEvents(HISTORY_HTML, config);
-    const sdEvent = events.find((e) => e.kennelTag === "sdh3");
+    const sdEvent = events.find((e) => e.kennelTags[0] === "sdh3");
 
     expect(sdEvent).toBeDefined();
     expect(sdEvent).toMatchObject({
       date: "2006-12-03",
-      kennelTag: "sdh3",
+      kennelTags: ["sdh3"],
       startTime: "18:30",
       title: "The Cold Moon",
       sourceUrl: "https://sdh3.com/e/event-20061203183000.shtml",
@@ -418,12 +418,12 @@ describe("parseHistoryEvents", () => {
 
   it("maps kennel name via kennelNameMap", () => {
     const events = parseHistoryEvents(HISTORY_HTML, config);
-    const irEvent = events.find((e) => e.kennelTag === "irh3-sd");
+    const irEvent = events.find((e) => e.kennelTags[0] === "irh3-sd");
 
     expect(irEvent).toBeDefined();
     expect(irEvent).toMatchObject({
       date: "2007-01-05",
-      kennelTag: "irh3-sd",
+      kennelTags: ["irh3-sd"],
       title: "New Year Hash",
     });
   });
@@ -444,7 +444,7 @@ describe("parseHistoryEvents", () => {
 
   it("constructs sourceUrl from link href", () => {
     const events = parseHistoryEvents(HISTORY_HTML, config);
-    const sdEvent = events.find((e) => e.kennelTag === "sdh3");
+    const sdEvent = events.find((e) => e.kennelTags[0] === "sdh3");
     expect(sdEvent?.sourceUrl).toBe(
       "https://sdh3.com/e/event-20061203183000.shtml",
     );
@@ -582,7 +582,7 @@ describe("SDH3Adapter", () => {
 
     // Find the SDH3 event on 2006-12-03 — hareline should win with richer data
     const overlapEvents = result.events.filter(
-      (e) => e.date === "2006-12-03" && e.kennelTag === "sdh3",
+      (e) => e.date === "2006-12-03" && e.kennelTags[0] === "sdh3",
     );
     expect(overlapEvents).toHaveLength(1);
     expect(overlapEvents[0].hares).toBe("Special Hare");

--- a/src/adapters/html-scraper/sdh3.ts
+++ b/src/adapters/html-scraper/sdh3.ts
@@ -289,8 +289,7 @@ export function parseHarelineEvents(
 
     events.push({
       date: parsed.date,
-      kennelTag,
-      startTime: parsed.startTime,
+      kennelTags: [kennelTag],      startTime: parsed.startTime,
       title,
       hares,
       location,
@@ -345,8 +344,7 @@ export function parseHistoryEvents(
 
     events.push({
       date: entry.date,
-      kennelTag,
-      startTime: entry.startTime,
+      kennelTags: [kennelTag],      startTime: entry.startTime,
       title: entry.title,
       sourceUrl: entry.sourceUrl,
     });
@@ -552,10 +550,10 @@ export class SDH3Adapter implements SourceAdapter {
     // ── Step 3: Combine and dedup ──
     // Hareline events win when both pages have the same date+kennel
     const harelineKeys = new Set(
-      harelineEvents.map((e) => `${e.date}|${e.kennelTag}`),
+      harelineEvents.map((e) => `${e.date}|${e.kennelTags[0]}`),
     );
     const dedupedHistory = historyEvents.filter(
-      (e) => !harelineKeys.has(`${e.date}|${e.kennelTag}`),
+      (e) => !harelineKeys.has(`${e.date}|${e.kennelTags[0]}`),
     );
 
     const allEvents = [...harelineEvents, ...dedupedHistory];

--- a/src/adapters/html-scraper/seletar-h3.test.ts
+++ b/src/adapters/html-scraper/seletar-h3.test.ts
@@ -33,7 +33,7 @@ describe("groupSeletarRows", () => {
     expect(events[0]).toMatchObject({
       runNumber: 2374,
       date: "2026-04-14",
-      kennelTag: "seletar-h3",
+      kennelTags: ["seletar-h3"],
       startTime: "18:00",
       hares: "Perut Besar, Skinny",
       location: "Bukit Gombak",

--- a/src/adapters/html-scraper/seletar-h3.ts
+++ b/src/adapters/html-scraper/seletar-h3.ts
@@ -187,7 +187,7 @@ export function groupSeletarRows(rows: SeletarRow[]): GroupSeletarRowsResult {
     events.push({
       date: head.hl_datetime,
       startTime: DEFAULT_START_TIME,
-      kennelTag: KENNEL_TAG,
+      kennelTags: [KENNEL_TAG],
       runNumber,
       title,
       // Sort alphabetically so the fingerprint is stable — the API returns

--- a/src/adapters/html-scraper/seven-hills-h3.test.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.test.ts
@@ -101,7 +101,7 @@ describe("SevenHillsH3Adapter.fetch", () => {
     const result = await adapter.fetch(source);
     expect(result.events).toHaveLength(1);
     expect(result.events[0]).toMatchObject({
-      kennelTag: "7h4",
+      kennelTags: ["7h4"],
       runNumber: 2005,
       title: "Peter CottonTrail",
       hares: "Frodo & Snatch",

--- a/src/adapters/html-scraper/seven-hills-h3.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.ts
@@ -147,7 +147,7 @@ export class SevenHillsH3Adapter implements SourceAdapter {
     } else {
       events.push({
         date: parsed.date,
-        kennelTag: "7h4",
+        kennelTags: ["7h4"],
         runNumber: parsed.runNumber,
         title: parsed.title,
         hares: parsed.hares,

--- a/src/adapters/html-scraper/sfh3-detail-enrichment.ts
+++ b/src/adapters/html-scraper/sfh3-detail-enrichment.ts
@@ -126,7 +126,7 @@ function sfh3NeedsEnrichment(event: RawEventData): boolean {
   const descHasComment = !!event.description && /\bComment\s*:/i.test(event.description);
   // Skip the fetch entirely when both sides are already good — the detail
   // page can't improve on a descriptive hareline title + an existing Comment.
-  if (descHasComment && !isGenericSFH3Title(event.title, event.kennelTag)) return false;
+  if (descHasComment && !isGenericSFH3Title(event.title, event.kennelTags[0])) return false;
   return true;
 }
 
@@ -142,7 +142,7 @@ function applyDetailToEvent(event: EnrichableEvent, detail: SFH3Detail): boolean
   if (
     detail.title
     && detail.title !== event.title
-    && isGenericSFH3Title(event.title, event.kennelTag)
+    && isGenericSFH3Title(event.title, event.kennelTags[0])
   ) {
     event.title = detail.title;
     touched = true;

--- a/src/adapters/html-scraper/sfh3.test.ts
+++ b/src/adapters/html-scraper/sfh3.test.ts
@@ -307,7 +307,7 @@ describe("SFH3Adapter.fetch", () => {
     // Verify first event (SFH3)
     const sfh3Event = result.events[0];
     expect(sfh3Event.date).toBe("2026-03-03");
-    expect(sfh3Event.kennelTag).toBe("sfh3");
+    expect(sfh3Event.kennelTags[0]).toBe("sfh3");
     expect(sfh3Event.runNumber).toBe(2302);
     expect(sfh3Event.title).toBe("A Very Heated Rivalry");
     expect(sfh3Event.hares).toBe("Trail Blazer");
@@ -317,12 +317,12 @@ describe("SFH3Adapter.fetch", () => {
 
     // Verify second event (GPH3)
     const gph3Event = result.events[1];
-    expect(gph3Event.kennelTag).toBe("gph3");
+    expect(gph3Event.kennelTags[0]).toBe("gph3");
     expect(gph3Event.runNumber).toBe(1700);
 
     // Verify Marin H3 event (kennel pattern with space)
     const marinEvent = result.events[4];
-    expect(marinEvent.kennelTag).toBe("marinh3");
+    expect(marinEvent.kennelTags[0]).toBe("marinh3");
     expect(marinEvent.runNumber).toBe(292);
 
     vi.restoreAllMocks();
@@ -377,8 +377,8 @@ describe("SFH3Adapter.fetch", () => {
     } as never);
 
     expect(result.events).toHaveLength(2);
-    expect(result.events[0].kennelTag).toBe("sfh3");
-    expect(result.events[1].kennelTag).toBe("gph3");
+    expect(result.events[0].kennelTags[0]).toBe("sfh3");
+    expect(result.events[1].kennelTags[0]).toBe("gph3");
     expect(result.diagnosticContext).toMatchObject({
       rowsFound: 4,
       eventsParsed: 2,
@@ -430,7 +430,7 @@ describe("SFH3Adapter.fetch", () => {
     } as never);
 
     expect(result.events).toHaveLength(1);
-    expect(result.events[0].kennelTag).toBe("SFH3");
+    expect(result.events[0].kennelTags[0]).toBe("SFH3");
     expect(result.diagnosticContext).toMatchObject({
       rowsFound: 2,
       eventsParsed: 1,
@@ -465,7 +465,7 @@ describe("SFH3Adapter.fetch", () => {
 
     // Without skipPatterns, the row is emitted (falls back to defaultKennelTag)
     expect(result.events).toHaveLength(1);
-    expect(result.events[0].kennelTag).toBe("sfh3");
+    expect(result.events[0].kennelTags[0]).toBe("sfh3");
     expect(result.diagnosticContext).toMatchObject({ skippedPattern: 0 });
 
     vi.restoreAllMocks();
@@ -495,7 +495,7 @@ describe("SFH3Adapter.fetch", () => {
     } as never);
 
     expect(result.events).toHaveLength(1);
-    expect(result.events[0].kennelTag).toBe("sfh3");
+    expect(result.events[0].kennelTags[0]).toBe("sfh3");
 
     vi.restoreAllMocks();
   });
@@ -688,7 +688,7 @@ describe("isGenericSFH3Title", () => {
   it("does not classify `Campout #5` or other descriptive `{word} #N` titles as generic (Codex PR #557 review)", () => {
     // Without the kennelTag anchor, the earlier heuristic classified any
     // "{single-word} #N" shape as generic. The fix ties the check to the
-    // event's own kennelTag: only titles that literally begin with the tag
+    // event's own kennelTags: [only titles that literally begin with the tag]
     // are candidates for override. "Campout" is a descriptive noun, not
     // the Agnews kennel slug, so its title must survive enrichment.
     expect(isGenericSFH3Title("Campout #5", "agnews")).toBe(false);
@@ -729,7 +729,7 @@ describe("enrichSFH3Events — preserves descriptive titles (#545)", () => {
   function buildEvent(overrides: Partial<RawEventData>): RawEventData {
     return {
       date: "2026-04-09",
-      kennelTag: "agnews",
+      kennelTags: ["agnews"],
       sourceUrl: "https://www.sfh3.com/runs/6495",
       ...overrides,
     };
@@ -760,7 +760,7 @@ describe("enrichSFH3Events — preserves descriptive titles (#545)", () => {
     const events = [
       buildEvent({
         date: "2026-08-15",
-        kennelTag: "262h3",
+        kennelTags: ["262h3"],
         title: "26.2H3 #7",
         runNumber: 7,
         sourceUrl: "https://www.sfh3.com/runs/6478",

--- a/src/adapters/html-scraper/sfh3.ts
+++ b/src/adapters/html-scraper/sfh3.ts
@@ -259,8 +259,7 @@ export class SFH3Adapter implements SourceAdapter {
 
         events.push({
           date,
-          kennelTag,
-          runNumber,
+          kennelTags: [kennelTag],          runNumber,
           title: parsed.title ?? row.title,
           hares: row.hare,
           location: row.locationText,

--- a/src/adapters/html-scraper/sh3-au.test.ts
+++ b/src/adapters/html-scraper/sh3-au.test.ts
@@ -12,7 +12,7 @@ describe("sh3-au parseSh3Paragraph", () => {
     expect(e).not.toBeNull();
     expect(e!.runNumber).toBe(3069);
     expect(e!.date).toBe("2026-04-07");
-    expect(e!.kennelTag).toBe("sh3-au");
+    expect(e!.kennelTags[0]).toBe("sh3-au");
     expect(e!.hares).toBe("Harriettes");
     expect(e!.location).toBe("Carpark 87 Winbourne Rd, Brookvale");
     expect(e!.description).toBe("Brookvale Hotel");

--- a/src/adapters/html-scraper/sh3-au.ts
+++ b/src/adapters/html-scraper/sh3-au.ts
@@ -93,7 +93,7 @@ export function parseSh3Paragraph(
 
   return {
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     hares: hares || undefined,
     location: start,

--- a/src/adapters/html-scraper/shith3.test.ts
+++ b/src/adapters/html-scraper/shith3.test.ts
@@ -144,7 +144,7 @@ describe("buildEventFromDetail", () => {
   it("maps all fields correctly", () => {
     const event = buildEventFromDetail(baseDetail, baseListing);
     expect(event.date).toBe("2026-03-03");
-    expect(event.kennelTag).toBe("shith3");
+    expect(event.kennelTags[0]).toBe("shith3");
     expect(event.runNumber).toBe(1196);
     expect(event.title).toBe("Peek a Boob. Hide n Seek!");
     expect(event.hares).toBe("Fingrrrrrrrrrr");
@@ -219,7 +219,7 @@ describe("buildEventFromListing", () => {
     });
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-03-03");
-    expect(event!.kennelTag).toBe("shith3");
+    expect(event!.kennelTags[0]).toBe("shith3");
     expect(event!.runNumber).toBe(1196);
     expect(event!.title).toBe("Peek a Boob");
     expect(event!.startTime).toBe("19:00");

--- a/src/adapters/html-scraper/shith3.ts
+++ b/src/adapters/html-scraper/shith3.ts
@@ -125,7 +125,7 @@ export function buildEventFromDetail(detail: DetailItem, listing: ListingItem): 
 
   return {
     date,
-    kennelTag: "shith3",
+    kennelTags: ["shith3"],
     runNumber: runNumber && !isNaN(runNumber) ? runNumber : undefined,
     title: decodeEntities(detail.TITLE || "") || parseListingTitle(listing.title).trailName,
     hares,
@@ -148,7 +148,7 @@ export function buildEventFromListing(listing: ListingItem): RawEventData | null
 
   return {
     date,
-    kennelTag: "shith3",
+    kennelTags: ["shith3"],
     runNumber: parsed.runNumber,
     title: parsed.trailName,
     startTime: extractStartTime(listing.start),

--- a/src/adapters/html-scraper/slash-hash.test.ts
+++ b/src/adapters/html-scraper/slash-hash.test.ts
@@ -60,7 +60,7 @@ describe("parseSlashRow", () => {
     const event = parseSlashRow(cells);
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-03-14");
-    expect(event!.kennelTag).toBe("slh3");
+    expect(event!.kennelTags[0]).toBe("slh3");
     expect(event!.runNumber).toBe(320);
     expect(event!.startTime).toBe("12:00");
     expect(event!.location).toBe("The Pub, Brixton");
@@ -96,7 +96,7 @@ describe("parseSlashRow", () => {
   it("always uses SLH3 kennel tag", () => {
     const cells = ["323", "Sat", "13th June 2026", "12 Noon", "Venue", "Hare"];
     const event = parseSlashRow(cells);
-    expect(event!.kennelTag).toBe("slh3");
+    expect(event!.kennelTags[0]).toBe("slh3");
   });
 });
 
@@ -130,7 +130,7 @@ describe("SlashHashAdapter.fetch", () => {
 
     const first = result.events[0];
     expect(first.date).toBe("2026-03-14");
-    expect(first.kennelTag).toBe("slh3");
+    expect(first.kennelTags[0]).toBe("slh3");
     expect(first.runNumber).toBe(320);
     expect(first.startTime).toBe("12:00");
     expect(first.location).toBe("The Duke, Brixton");

--- a/src/adapters/html-scraper/slash-hash.ts
+++ b/src/adapters/html-scraper/slash-hash.ts
@@ -115,7 +115,7 @@ export function parseSlashRow(cells: string[]): RawEventData | null {
 
   return {
     date,
-    kennelTag: "slh3",
+    kennelTags: ["slh3"],
     runNumber,
     title: runNumber ? `SLASH Run #${runNumber}` : undefined,
     hares,

--- a/src/adapters/html-scraper/soh4.ts
+++ b/src/adapters/html-scraper/soh4.ts
@@ -294,7 +294,7 @@ export class SOH4Adapter implements SourceAdapter {
 
           const event: RawEventData = {
             date,
-            kennelTag: "soh4",
+            kennelTags: ["soh4"],
             runNumber: trailNumber,
             title: title || (trailNumber ? `SOH4 Trail #${trailNumber}` : "SOH4 Trail"),
             description: descParts.length > 0 ? descParts.join("\n") : undefined,

--- a/src/adapters/html-scraper/stlh3.test.ts
+++ b/src/adapters/html-scraper/stlh3.test.ts
@@ -195,7 +195,7 @@ describe("StlH3Adapter", () => {
 
     expect(result.events).toHaveLength(1);
     expect(result.events[0].date).toBe("2026-03-29");
-    expect(result.events[0].kennelTag).toBe("stlh3");
+    expect(result.events[0].kennelTags[0]).toBe("stlh3");
     expect(result.events[0].startTime).toBe("17:00");
     expect(result.events[0].location).toBe(
       "Fenton Bar and Grill 1025 Dougherty Ferry Rd",

--- a/src/adapters/html-scraper/stlh3.ts
+++ b/src/adapters/html-scraper/stlh3.ts
@@ -267,7 +267,7 @@ export class StlH3Adapter implements SourceAdapter {
 
         events.push({
           date,
-          kennelTag: "stlh3",
+          kennelTags: ["stlh3"],
           title: cleanPostTitle(post.title),
           location,
           startTime,

--- a/src/adapters/html-scraper/sumo-h3.test.ts
+++ b/src/adapters/html-scraper/sumo-h3.test.ts
@@ -97,7 +97,7 @@ describe("SumoH3Adapter", () => {
 
       expect(result).toMatchObject({
         date: "2026-04-05",
-        kennelTag: "sumo-h3",
+        kennelTags: ["sumo-h3"],
         title: "Sumo H3 #1038",
         runNumber: 1038,
         hares: "Khuming Rouge",

--- a/src/adapters/html-scraper/sumo-h3.ts
+++ b/src/adapters/html-scraper/sumo-h3.ts
@@ -94,7 +94,7 @@ export function parseHarelineRow(
 
   return {
     date,
-    kennelTag: "sumo-h3",
+    kennelTags: ["sumo-h3"],
     title,
     runNumber,
     hares,

--- a/src/adapters/html-scraper/swh3.ts
+++ b/src/adapters/html-scraper/swh3.ts
@@ -213,7 +213,7 @@ function processPost(
 
   return {
     date,
-    kennelTag: "swh3",
+    kennelTags: ["swh3"],
     runNumber: titleFields.runNumber,
     title: bodyFields.trailName || titleText,
     hares: bodyFields.hares,

--- a/src/adapters/html-scraper/sydney-thirsty-h3.test.ts
+++ b/src/adapters/html-scraper/sydney-thirsty-h3.test.ts
@@ -41,7 +41,7 @@ describe("sydney-thirsty-h3 parseThirstyBlock", () => {
     expect(e.startTime).toBe("18:30");
     expect(e.location).toBe("Redfern Park, Redfern");
     expect(e.locationUrl).toBe("https://maps.app.goo.gl/x");
-    expect(e.kennelTag).toBe("sth3-au");
+    expect(e.kennelTags[0]).toBe("sth3-au");
   });
 
   it("tolerates missing location/map fields", () => {

--- a/src/adapters/html-scraper/sydney-thirsty-h3.ts
+++ b/src/adapters/html-scraper/sydney-thirsty-h3.ts
@@ -149,7 +149,7 @@ export function parseThirstyBlock(
 
   return runNumbers.map((runNumber) => ({
     date,
-    kennelTag: KENNEL_TAG,
+    kennelTags: [KENNEL_TAG],
     runNumber,
     location,
     locationUrl,

--- a/src/adapters/html-scraper/true-trail-h3.test.ts
+++ b/src/adapters/html-scraper/true-trail-h3.test.ts
@@ -150,7 +150,7 @@ describe("TrueTrailH3Adapter", () => {
     // First detailed event: #170
     const ev170 = result.events.find((e) => e.runNumber === 170);
     expect(ev170).toBeDefined();
-    expect(ev170!.kennelTag).toBe("tth3-ab");
+    expect(ev170!.kennelTags[0]).toBe("tth3-ab");
     expect(ev170!.title).toBe("Get Green\u2019d Up Hash");
     expect(ev170!.date).toBe("2026-03-26");
     expect(ev170!.hares).toBe("Peppermint Meatrod, Tinder Tits");

--- a/src/adapters/html-scraper/true-trail-h3.ts
+++ b/src/adapters/html-scraper/true-trail-h3.ts
@@ -169,7 +169,7 @@ export class TrueTrailH3Adapter implements SourceAdapter {
           row: hIdx,
           field: "date",
           error: `No date found for event #${heading.runNumber}`,
-          partialData: { kennelTag: KENNEL_TAG, runNumber: heading.runNumber, title: heading.title },
+          partialData: { kennelTags: [KENNEL_TAG], runNumber: heading.runNumber, title: heading.title },
         });
         continue;
       }
@@ -186,7 +186,7 @@ export class TrueTrailH3Adapter implements SourceAdapter {
 
       events.push({
         date,
-        kennelTag: KENNEL_TAG,
+        kennelTags: [KENNEL_TAG],
         runNumber: heading.runNumber,
         title: heading.title,
         hares,

--- a/src/adapters/html-scraper/voodoo-h3.test.ts
+++ b/src/adapters/html-scraper/voodoo-h3.test.ts
@@ -175,7 +175,7 @@ On-After: JB's Fuel Dock.
     const result = processVoodooPost(title, body, "https://www.voodoohash.com/2026/03/29/trail-1035/");
     expect(result).not.toBeNull();
     expect(result!.date).toBe("2026-04-02");
-    expect(result!.kennelTag).toBe("voodoo-h3");
+    expect(result!.kennelTags[0]).toBe("voodoo-h3");
     expect(result!.runNumber).toBe(1035);
     expect(result!.title).toBe("The Egg-Stra Dirty Spring Scramble");
     expect(result!.hares).toBe("Steven with a D and Surprise Co Hare.");
@@ -263,7 +263,7 @@ Hare &amp; Co-Hares: Steven with a D</p>`,
     const result = await adapter.fetch(mockSource);
     expect(result.events).toHaveLength(1);
     expect(result.events[0].date).toBe("2026-04-02");
-    expect(result.events[0].kennelTag).toBe("voodoo-h3");
+    expect(result.events[0].kennelTags[0]).toBe("voodoo-h3");
     expect(result.events[0].runNumber).toBe(1035);
     expect(result.events[0].startTime).toBe("18:30");
     expect(result.errors).toHaveLength(0);

--- a/src/adapters/html-scraper/voodoo-h3.ts
+++ b/src/adapters/html-scraper/voodoo-h3.ts
@@ -116,7 +116,7 @@ export function processVoodooPost(
 
   return {
     date: dateStr,
-    kennelTag: "voodoo-h3",
+    kennelTags: ["voodoo-h3"],
     runNumber: parsed.runNumber,
     title: parsed.trailName,
     hares: body.hares,

--- a/src/adapters/html-scraper/wcfh-calendar.test.ts
+++ b/src/adapters/html-scraper/wcfh-calendar.test.ts
@@ -205,15 +205,15 @@ describe("WCFHCalendarAdapter.fetch", () => {
     } as never);
 
     // First event is Feb 22 CH3 (circus-h3)
-    const feb22 = result.events.find(e => e.date === "2026-02-22" && e.kennelTag === "circus-h3");
+    const feb22 = result.events.find(e => e.date === "2026-02-22" && e.kennelTags[0] === "circus-h3");
     expect(feb22).toBeDefined();
     expect(feb22!.sourceUrl).toBe("https://www.jollyrogerh3.com/WCFH_Calendar.htm");
 
     // March events
-    const mar1 = result.events.find(e => e.date === "2026-03-01" && e.kennelTag === "b2b-h3");
+    const mar1 = result.events.find(e => e.date === "2026-03-01" && e.kennelTags[0] === "b2b-h3");
     expect(mar1).toBeDefined();
 
-    const mar8 = result.events.find(e => e.date === "2026-03-08" && e.kennelTag === "circus-h3");
+    const mar8 = result.events.find(e => e.date === "2026-03-08" && e.kennelTags[0] === "circus-h3");
     expect(mar8).toBeDefined();
 
     vi.restoreAllMocks();
@@ -233,7 +233,7 @@ describe("WCFHCalendarAdapter.fetch", () => {
     // Apr 5 has both CH3 (circus-h3) and B2BH3 (b2b-h3)
     const apr5Events = result.events.filter(e => e.date === "2026-04-05");
     expect(apr5Events).toHaveLength(2);
-    expect(apr5Events.map(e => e.kennelTag).sort()).toEqual(["b2b-h3", "circus-h3"]);
+    expect(apr5Events.map(e => e.kennelTags[0]).sort()).toEqual(["b2b-h3", "circus-h3"]);
 
     vi.restoreAllMocks();
   });
@@ -270,7 +270,7 @@ describe("WCFHCalendarAdapter.fetch", () => {
 
     const knownTags = new Set(["barf-h3", "b2b-h3", "jrh3", "lh3-fl", "sbh3", "lush", "nsah3", "circus-h3", "sph3-fl", "tth3-fl", "tbh3-fl"]);
     for (const event of result.events) {
-      expect(knownTags.has(event.kennelTag)).toBe(true);
+      expect(knownTags.has(event.kennelTags[0])).toBe(true);
     }
 
     vi.restoreAllMocks();
@@ -288,27 +288,27 @@ describe("WCFHCalendarAdapter.fetch", () => {
     } as never);
 
     // TTH3 should use the display abbreviation, not the kennelCode "tth3-fl"
-    const tth3 = result.events.find(e => e.kennelTag === "tth3-fl");
+    const tth3 = result.events.find(e => e.kennelTags[0] === "tth3-fl");
     expect(tth3).toBeDefined();
     expect(tth3!.title).toBe("TTH3 Trail");
 
     // CH3 → circus-h3 should produce "CH3 Trail"
-    const ch3 = result.events.find(e => e.kennelTag === "circus-h3");
+    const ch3 = result.events.find(e => e.kennelTags[0] === "circus-h3");
     expect(ch3).toBeDefined();
     expect(ch3!.title).toBe("CH3 Trail");
 
     // SPH3 → sph3-fl should produce "SPH3 Trail"
-    const sph3 = result.events.find(e => e.kennelTag === "sph3-fl");
+    const sph3 = result.events.find(e => e.kennelTags[0] === "sph3-fl");
     expect(sph3).toBeDefined();
     expect(sph3!.title).toBe("SPH3 Trail");
 
     // B2BH3 → b2b-h3 should produce "B2BH3 Trail"
-    const b2b = result.events.find(e => e.kennelTag === "b2b-h3");
+    const b2b = result.events.find(e => e.kennelTags[0] === "b2b-h3");
     expect(b2b).toBeDefined();
     expect(b2b!.title).toBe("B2BH3 Trail");
 
     // TBH3 → tbh3-fl should produce "TBH3 Trail"
-    const tbh3 = result.events.find(e => e.kennelTag === "tbh3-fl");
+    const tbh3 = result.events.find(e => e.kennelTags[0] === "tbh3-fl");
     expect(tbh3).toBeDefined();
     expect(tbh3!.title).toBe("TBH3 Trail");
 

--- a/src/adapters/html-scraper/wcfh-calendar.ts
+++ b/src/adapters/html-scraper/wcfh-calendar.ts
@@ -166,7 +166,7 @@ export class WCFHCalendarAdapter implements SourceAdapter {
           for (const tag of kennelTags) {
             events.push({
               date: dateStr,
-              kennelTag: tag,
+              kennelTags: [tag],
               title: `${WCFH_CODE_TO_ABBREV[tag] ?? tag} Trail`,
               sourceUrl,
             });

--- a/src/adapters/html-scraper/west-london-hash.test.ts
+++ b/src/adapters/html-scraper/west-london-hash.test.ts
@@ -123,7 +123,7 @@ describe("parseRunItem", () => {
     const event = parseRunItem($, items.eq(0), "https://westlondonhash.com/runs/");
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-02-19");
-    expect(event!.kennelTag).toBe("wlh3");
+    expect(event!.kennelTags[0]).toBe("wlh3");
     expect(event!.runNumber).toBe(2081);
     expect(event!.hares).toBe("Alice and Bobo");
     expect(event!.location).toContain("Roundhouse");

--- a/src/adapters/html-scraper/west-london-hash.ts
+++ b/src/adapters/html-scraper/west-london-hash.ts
@@ -121,7 +121,7 @@ export function parseRunItem(
 
   const event: RawEventData & { _longParagraph?: string } = {
     date,
-    kennelTag: "wlh3",
+    kennelTags: ["wlh3"],
     runNumber: runNumber ?? undefined,
     title,
     hares,

--- a/src/adapters/html-scraper/yii-hareline.test.ts
+++ b/src/adapters/html-scraper/yii-hareline.test.ts
@@ -64,7 +64,7 @@ describe("parseYiiHarelineRow", () => {
     expect(event?.hares).toBe("Raymond Lai");
     expect(event?.location).toBe("Pantai Remis (Remis Beach)");
     expect(event?.startTime).toBe("16:00");
-    expect(event?.kennelTag).toBe("ph3-my");
+    expect(event?.kennelTags[0]).toBe("ph3-my");
   });
 
   it("extracts title from Occasion column", () => {

--- a/src/adapters/html-scraper/yii-hareline.ts
+++ b/src/adapters/html-scraper/yii-hareline.ts
@@ -26,7 +26,7 @@ import {
  * **Config shape** (`source.config`):
  * ```ts
  * {
- *   kennelTag: "ph3-my",              // kennelCode — used for all events
+ *   kennelTags: ["ph3-my"],              // kennelCode — used for all events
  *   startTime: "16:00",               // default HH:MM for all runs (kennel meets)
  *   columnMap?: {                     // 0-indexed column positions; defaults below
  *     runNumber: 0,
@@ -147,7 +147,7 @@ export function parseYiiHarelineRow(
 
   return {
     date,
-    kennelTag: config.kennelTag,
+    kennelTags: [config.kennelTag],
     runNumber,
     hares,
     location,

--- a/src/adapters/html-scraper/yoko-yoko-h3.test.ts
+++ b/src/adapters/html-scraper/yoko-yoko-h3.test.ts
@@ -224,7 +224,7 @@ describe("parseEventCell", () => {
     const event = parseEventCell(CELL_ST_PATRICKS, "https://y2h3.net/");
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-03-20");
-    expect(event!.kennelTag).toBe("yoko-yoko-h3");
+    expect(event!.kennelTags[0]).toBe("yoko-yoko-h3");
     expect(event!.title).toBe("Yoko Yoko Hash, St. Patrick's Hash");
     expect(event!.startTime).toBe("19:00");
     expect(event!.hares).toBe("Gerbil Stuffer");

--- a/src/adapters/html-scraper/yoko-yoko-h3.ts
+++ b/src/adapters/html-scraper/yoko-yoko-h3.ts
@@ -162,7 +162,7 @@ export function parseEventCell(
 
   return {
     date,
-    kennelTag: "yoko-yoko-h3",
+    kennelTags: ["yoko-yoko-h3"],
     title,
     runNumber,
     hares,

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -498,7 +498,7 @@ describe("ICalAdapter", () => {
     // Should skip Hand Pump Workday (skipPatterns), cancelled Agnews, and filter by date range
     // With days=9999, all non-skipped, non-cancelled events should be included
     // SFH3 #2300
-    const sfh3 = result.events.find((e) => e.kennelTag === "SFH3" && e.runNumber === 2300);
+    const sfh3 = result.events.find((e) => e.kennelTags[0] === "SFH3" && e.runNumber === 2300);
     expect(sfh3).toBeDefined();
     expect(sfh3!.title).toBe("Test Trail");
     expect(sfh3!.date).toBe("2026-03-01");
@@ -510,20 +510,20 @@ describe("ICalAdapter", () => {
     expect(sfh3!.sourceUrl).toBe("https://www.sfh3.com/runs/1");
 
     // GPH3 #1700
-    const gph3 = result.events.find((e) => e.kennelTag === "GPH3");
+    const gph3 = result.events.find((e) => e.kennelTags[0] === "GPH3");
     expect(gph3).toBeDefined();
     expect(gph3!.runNumber).toBe(1700);
     expect(gph3!.location).toBe("Alamo Square");
 
     // FHAC-U: BAWC 5 (no run number, has title)
-    const fhacu = result.events.find((e) => e.kennelTag === "FHAC-U");
+    const fhacu = result.events.find((e) => e.kennelTags[0] === "FHAC-U");
     expect(fhacu).toBeDefined();
     expect(fhacu!.title).toBe("BAWC 5");
     expect(fhacu!.runNumber).toBeUndefined();
     expect(fhacu!.hares).toBe("Alpha & Omega");
 
     // Marin H3 #290
-    const marin = result.events.find((e) => e.kennelTag === "MARINH3");
+    const marin = result.events.find((e) => e.kennelTags[0] === "MARINH3");
     expect(marin).toBeDefined();
     expect(marin!.runNumber).toBe(290);
     expect(marin!.startTime).toBe("14:00");
@@ -535,13 +535,13 @@ describe("ICalAdapter", () => {
     expect(handpump).toBeUndefined();
 
     // Cancelled Agnews should be skipped
-    const agnews = result.events.find((e) => e.kennelTag === "AGNEWS");
+    const agnews = result.events.find((e) => e.kennelTags[0] === "AGNEWS");
     expect(agnews).toBeUndefined();
 
     // Bay 2 Blackout (all-day event) should use defaultKennelTag
     const b2b = result.events.find((e) => e.title?.includes("Bay 2 Blackout"));
     expect(b2b).toBeDefined();
-    expect(b2b!.kennelTag).toBe("SFH3");
+    expect(b2b!.kennelTags[0]).toBe("SFH3");
     expect(b2b!.date).toBe("2026-06-20");
     expect(b2b!.startTime).toBeUndefined();
 
@@ -764,7 +764,7 @@ END:VCALENDAR`;
 
     expect(result.events).toHaveLength(1);
     expect(result.events[0].hares).toBe("Captain Hash");
-    expect(result.events[0].kennelTag).toBe("CCH3");
+    expect(result.events[0].kennelTags[0]).toBe("CCH3");
   });
 
   it("suppresses endTime when DTEND is on a different calendar day (overnight run)", async () => {
@@ -858,7 +858,7 @@ END:VCALENDAR`;
 
     expect(result.events).toHaveLength(1);
     expect(result.events[0].cost).toBe("5€");
-    expect(result.events[0].kennelTag).toBe("berlinh3");
+    expect(result.events[0].kennelTags[0]).toBe("berlinh3");
   });
 
   it("enriches Berlin H3 events with Hares from wp-event-manager detail page", async () => {
@@ -902,7 +902,7 @@ END:VCALENDAR`;
     const result = await adapter.fetch(source, { days: 9999 });
 
     expect(result.events).toHaveLength(1);
-    expect(result.events[0].kennelTag).toBe("bh3fm");
+    expect(result.events[0].kennelTags[0]).toBe("bh3fm");
     expect(result.events[0].hares).toBe("Symphomaniac");
     expect(result.events[0].cost).toBe("5€");
     expect(result.diagnosticContext!.enrichmentEnriched).toBe(1);
@@ -1009,7 +1009,7 @@ END:VCALENDAR`;
     // Without patterns, all events get UNKNOWN tag
     expect(result.events.length).toBeGreaterThan(0);
     result.events.forEach((e) => {
-      expect(e.kennelTag).toBe("UNKNOWN");
+      expect(e.kennelTags[0]).toBe("UNKNOWN");
     });
   });
 });

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -448,7 +448,7 @@ function buildRawEventFromVEvent(
 
   return {
     date: dateStr,
-    kennelTag: parsed.kennelTag,
+    kennelTags: [parsed.kennelTag],
     runNumber,
     title: parsed.title ?? summary,
     description: appendDescriptionSuffix(description?.substring(0, 2000) || undefined, config?.descriptionSuffix),
@@ -574,7 +574,7 @@ export class ICalAdapter implements SourceAdapter {
           error: message,
           rawText: diag.rawText,
           partialData: {
-            kennelTag: diag.summary,
+            kennelTags: [diag.summary],
             date: vevent.start ? formatDate(vevent.start) : undefined,
           },
         });

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -402,7 +402,7 @@ describe("MeetupAdapter", () => {
       { days: 365 },
     );
     expect(result.events.length).toBe(1);
-    expect(result.events[0].kennelTag).toBe("NYCH3");
+    expect(result.events[0].kennelTags[0]).toBe("NYCH3");
     expect(result.events[0].title).toBe("Trail #42 — Central Park");
     expect(result.events[0].date).toBe("2026-03-15");
     expect(result.events[0].startTime).toBe("18:00");
@@ -1059,7 +1059,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     };
     const patterns: [RegExp, string][] = [[/^BIBH3/i, "bibh3"], [/^TMFMH3/i, "tmfmh3"]];
     const event = buildRawEventFromApollo(ev as never, emptyState, "rvah3", patterns);
-    expect(event.kennelTag).toBe("bibh3");
+    expect(event.kennelTags[0]).toBe("bibh3");
   });
 
   it("routes Chain Gang event correctly", () => {
@@ -1071,7 +1071,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     };
     const patterns: [RegExp, string][] = [[/^BIBH3/i, "bibh3"], [/^Chain Gang/i, "chain-gang-hhh"]];
     const event = buildRawEventFromApollo(ev as never, emptyState, "rvah3", patterns);
-    expect(event.kennelTag).toBe("chain-gang-hhh");
+    expect(event.kennelTags[0]).toBe("chain-gang-hhh");
   });
 
   it("routes prefixed Chain Gang AGM title with word-boundary pattern (#992)", () => {
@@ -1090,7 +1090,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       [/\bChain Gang\b/i, "chain-gang-hhh"],
     ];
     const event = buildRawEventFromApollo(ev as never, emptyState, "rvah3", patterns);
-    expect(event.kennelTag).toBe("chain-gang-hhh");
+    expect(event.kennelTags[0]).toBe("chain-gang-hhh");
   });
 
   it("routes Belle Isle alt-name to bibh3 with word-boundary pattern (#992)", () => {
@@ -1105,7 +1105,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       [/\bChain Gang\b/i, "chain-gang-hhh"],
     ];
     const event = buildRawEventFromApollo(ev as never, emptyState, "rvah3", patterns);
-    expect(event.kennelTag).toBe("bibh3");
+    expect(event.kennelTags[0]).toBe("bibh3");
   });
 
   it("falls back to default kennelTag when no pattern matches", () => {
@@ -1117,7 +1117,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     };
     const patterns: [RegExp, string][] = [[/^BIBH3/i, "bibh3"], [/^TMFMH3/i, "tmfmh3"]];
     const event = buildRawEventFromApollo(ev as never, emptyState, "rvah3", patterns);
-    expect(event.kennelTag).toBe("rvah3");
+    expect(event.kennelTags[0]).toBe("rvah3");
   });
 
   it("uses default kennelTag when no patterns provided", () => {
@@ -1128,7 +1128,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       dateTime: "2026-04-08T18:30:00-04:00",
     };
     const event = buildRawEventFromApollo(ev as never, emptyState, "rvah3");
-    expect(event.kennelTag).toBe("rvah3");
+    expect(event.kennelTags[0]).toBe("rvah3");
   });
 
   it("extracts hares from description (HARE: pattern)", () => {

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -358,7 +358,7 @@ export function buildRawEventFromApollo(
 
   return {
     date,
-    kennelTag: resolvedKennelTag,
+    kennelTags: [resolvedKennelTag],
     title: ev.title || undefined,
     description: cleanedDesc,
     hares,

--- a/src/adapters/rss/adapter.test.ts
+++ b/src/adapters/rss/adapter.test.ts
@@ -111,7 +111,7 @@ describe("RssAdapter", () => {
       expect(result.events).toHaveLength(1);
 
       const ev = result.events[0];
-      expect(ev.kennelTag).toBe("TestH3");
+      expect(ev.kennelTags[0]).toBe("TestH3");
       expect(ev.title).toBe("Trail #42 — Central Park");
       expect(ev.sourceUrl).toBe("https://example.com/trail-42");
       // date is YYYY-MM-DD

--- a/src/adapters/rss/adapter.ts
+++ b/src/adapters/rss/adapter.ts
@@ -99,7 +99,7 @@ export class RssAdapter implements SourceAdapter {
 
         events.push({
           date: parsed.dateStr,
-          kennelTag: config.kennelTag,
+          kennelTags: [config.kennelTag],
           title: item.title?.trim() || undefined,
           description: extractDescription(item),
           sourceUrl: item.link?.trim() || undefined,

--- a/src/adapters/static-schedule/adapter.test.ts
+++ b/src/adapters/static-schedule/adapter.test.ts
@@ -46,10 +46,10 @@ function utcDate(y: number, m: number, d: number, h = 0, min = 0, s = 0): Date {
   return new Date(Date.UTC(y, m, d, h, min, s));
 }
 
-/** Assert that every event has the given property value. */
+/** Assert that every event has the given property value (deep equality for arrays/objects). */
 function expectAllEvents(events: RawEventData[], prop: keyof RawEventData, value: unknown): void {
   for (const event of events) {
-    expect(event[prop]).toBe(value);
+    expect(event[prop]).toEqual(value);
   }
 }
 
@@ -335,7 +335,7 @@ describe("StaticScheduleAdapter", () => {
     });
 
     it("assigns kennelTag to all events", () => {
-      expectAllEvents(result.events, "kennelTag", "Rumson");
+      expectAllEvents(result.events, "kennelTags", ["Rumson"]);
     });
 
     it("omits startTime when not configured", () => {

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -454,7 +454,7 @@ export class StaticScheduleAdapter implements SourceAdapter {
 
     const events: RawEventData[] = occurrences.map((date) => ({
       date,
-      kennelTag: config.kennelTag,
+      kennelTags: [config.kennelTag],
       title: config.defaultTitle,
       description: config.defaultDescription,
       location: config.defaultLocation,

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -3,7 +3,13 @@ import type { SourceType, Source } from "@/generated/prisma/client";
 /** Raw event data extracted from a source before kennel resolution or deduplication */
 export interface RawEventData {
   date: string; // YYYY-MM-DD
-  kennelTag: string; // Kennel identifier — use kennelCode (e.g. "nych3", "bfm") for stable resolution
+  /**
+   * Kennel identifiers — use kennelCode (e.g. "nych3", "bfm") for stable
+   * resolution. Always at least one entry; multi-kennel co-hosted events
+   * (#1023) emit multiple. The first resolved tag becomes the primary
+   * EventKennel; the rest become co-host secondaries.
+   */
+  kennelTags: string[];
   runNumber?: number | null; // null = explicit clear signal (e.g. HC eventNumber=0 for socials)
   title?: string;
   description?: string | null; // null = explicit clear signal (see merge.ts UPDATE path)

--- a/src/app/admin/sources/preview-action.test.ts
+++ b/src/app/admin/sources/preview-action.test.ts
@@ -112,7 +112,7 @@ describe("previewSourceConfig", () => {
     const mockEvents = [
       {
         date: "2026-03-01",
-        kennelTag: "NYCH3",
+        kennelTags: ["NYCH3"],
         title: "Run #2000",
         location: "Central Park",
         hares: "John",
@@ -121,7 +121,7 @@ describe("previewSourceConfig", () => {
       },
       {
         date: "2026-03-08",
-        kennelTag: "EWH3",
+        kennelTags: ["EWH3"],
         title: "Trail Run",
         location: null,
         hares: null,
@@ -163,7 +163,7 @@ describe("previewSourceConfig", () => {
   it("caps preview events at 25", async () => {
     const mockEvents = Array.from({ length: 40 }, (_, i) => ({
       date: `2026-03-${String(i + 1).padStart(2, "0")}`,
-      kennelTag: "NYCH3",
+      kennelTags: ["NYCH3"],
       title: `Run #${i}`,
     }));
     const mockAdapter = {
@@ -238,7 +238,7 @@ describe("previewSourceConfig", () => {
   it("clears resolver cache before resolving tags", async () => {
     const mockAdapter = {
       fetch: vi.fn().mockResolvedValue({
-        events: [{ date: "2026-03-01", kennelTag: "TestH3" }],
+        events: [{ date: "2026-03-01", kennelTags: ["TestH3"] }],
         errors: [],
       }),
     };
@@ -359,9 +359,9 @@ describe("previewSourceConfig", () => {
 
   it("deduplicates kennel tags before resolving", async () => {
     const mockEvents = [
-      { date: "2026-03-01", kennelTag: "NYCH3" },
-      { date: "2026-03-08", kennelTag: "NYCH3" },
-      { date: "2026-03-15", kennelTag: "NYCH3" },
+      { date: "2026-03-01", kennelTags: ["NYCH3"] },
+      { date: "2026-03-08", kennelTags: ["NYCH3"] },
+      { date: "2026-03-15", kennelTags: ["NYCH3"] },
     ];
     const mockAdapter = {
       fetch: vi.fn().mockResolvedValue({ events: mockEvents, errors: [] }),

--- a/src/app/admin/sources/preview-action.ts
+++ b/src/app/admin/sources/preview-action.ts
@@ -68,10 +68,12 @@ function parsePreviewConfig(
 
 /** Resolve all unique kennel tags and return resolution map + unmatched list. */
 async function resolvePreviewTags(
-  events: Array<{ kennelTag: string }>,
+  events: Array<{ kennelTags: string[] }>,
 ): Promise<{ tagResolution: Map<string, { matched: boolean; kennelId: string | null }>; unmatchedTags: string[] }> {
   clearResolverCache();
-  const uniqueTags = [...new Set(events.map((e) => e.kennelTag))];
+  // Use the primary tag for preview-time resolution; co-host secondaries are
+  // a step-4 concern and don't affect preview UX.
+  const uniqueTags = [...new Set(events.map((e) => e.kennelTags[0]))];
   const tagResults = await Promise.all(
     uniqueTags.map(async (tag) => {
       const { matched, kennelId } = await resolveKennelTag(tag);
@@ -156,15 +158,15 @@ export async function previewSourceConfig(
     .slice(0, MAX_PREVIEW_EVENTS)
     .map((e) => ({
       date: e.date,
-      kennelTag: e.kennelTag === UNKNOWN_KENNEL_SENTINEL ? UNTAGGED_KENNEL_DISPLAY : e.kennelTag,
+      kennelTag: e.kennelTags[0] === UNKNOWN_KENNEL_SENTINEL ? UNTAGGED_KENNEL_DISPLAY : e.kennelTags[0],
       title: e.title,
       description: e.description?.substring(0, 500) || undefined,
       runNumber: e.runNumber ?? undefined,
       location: e.location,
       hares: e.hares,
       startTime: e.startTime ?? undefined,
-      resolved: tagResolution.get(e.kennelTag)?.matched ?? false,
-      resolvedKennelId: tagResolution.get(e.kennelTag)?.kennelId ?? undefined,
+      resolved: tagResolution.get(e.kennelTags[0])?.matched ?? false,
+      resolvedKennelId: tagResolution.get(e.kennelTags[0])?.kennelId ?? undefined,
     }));
 
   return {

--- a/src/app/admin/sources/suggest-source-config-action.test.ts
+++ b/src/app/admin/sources/suggest-source-config-action.test.ts
@@ -39,7 +39,7 @@ describe("extractMeetupGroupUrlname", () => {
 function makeSampleEvents(kennelTag: string, count = 3): RawEventData[] {
   return Array.from({ length: count }, (_, i) => ({
     date: `2026-03-${String(i + 1).padStart(2, "0")}`,
-    kennelTag,
+    kennelTags: [kennelTag],
     title: `Trail #${i + 1} — Test Run`,
   }));
 }

--- a/src/app/admin/sources/suggest-source-config-action.ts
+++ b/src/app/admin/sources/suggest-source-config-action.ts
@@ -251,17 +251,17 @@ export async function buildGeminiSuggestion(
 
   // Replace sentinel __unknown__ tags with UNTAGGED_KENNEL_DISPLAY so Gemini derives kennels from titles
   const cleanEvents = events.map(e =>
-    e.kennelTag === UNKNOWN_KENNEL_SENTINEL ? { ...e, kennelTag: UNTAGGED_KENNEL_DISPLAY } : e
+    e.kennelTags[0] === UNKNOWN_KENNEL_SENTINEL ? { ...e, kennelTag: UNTAGGED_KENNEL_DISPLAY } : e
   );
 
   const sampleLines = cleanEvents
     .slice(0, MAX_SAMPLE_EVENTS)
-    .map((e) => `${e.date}: [${e.kennelTag}] ${e.title ?? "(no title)"}`)
+    .map((e) => `${e.date}: [${e.kennelTags[0]}] ${e.title ?? "(no title)"}`)
     .join("\n");
 
   const tagCounts = new Map<string, number>();
   for (const e of cleanEvents) {
-    tagCounts.set(e.kennelTag, (tagCounts.get(e.kennelTag) ?? 0) + 1);
+    tagCounts.set(e.kennelTags[0], (tagCounts.get(e.kennelTags[0]) ?? 0) + 1);
   }
   const tagSummary = [...tagCounts.entries()]
     .sort((a, b) => b[1] - a[1])

--- a/src/lib/ai/parse-recovery.test.ts
+++ b/src/lib/ai/parse-recovery.test.ts
@@ -73,7 +73,7 @@ describe("attemptAiRecovery", () => {
         field: "date",
         error: "No date found in post: March Trail 3.14.26",
         rawText: "Title: March Trail 3.14.26\n\nHares: Just John\nWhen: 3.14.26\nWhere: Blue Heron Elementary",
-        partialData: { kennelTag: "OFH3" },
+        partialData: { kennelTags: ["OFH3" ]},
       },
     ];
 
@@ -83,7 +83,7 @@ describe("attemptAiRecovery", () => {
     expect(result.failed).toBe(0);
     expect(result.results).toHaveLength(1);
     expect(result.results[0].recovered.date).toBe("2026-03-14");
-    expect(result.results[0].recovered.kennelTag).toBe("OFH3");
+    expect(result.results[0].recovered.kennelTags[0]).toBe("OFH3");
     expect(result.results[0].recovered.hares).toBe("Just John");
     expect(result.results[0].recovered.location).toBe("Blue Heron Elementary");
     expect(result.results[0].confidence).toBe("high");
@@ -109,14 +109,14 @@ describe("attemptAiRecovery", () => {
         section: "NYCH3",
         error: "bad start_time",
         rawText: "Some raw text",
-        partialData: { kennelTag: "NYCH3" },
+        partialData: { kennelTags: ["NYCH3" ]},
       },
       {
         row: 0,
         section: "BFMH3",
         error: "bad start_time",
         rawText: "Some raw text",
-        partialData: { kennelTag: "BFMH3" },
+        partialData: { kennelTags: ["BFMH3" ]},
       },
     ];
 
@@ -125,7 +125,7 @@ describe("attemptAiRecovery", () => {
     const result = await attemptAiRecovery(errors, "WRONG_KENNEL");
     expect(result.succeeded).toBe(2);
     const tags = result.results
-      .map((r) => r.recovered.kennelTag)
+      .map((r) => r.recovered.kennelTags[0])
       .sort((a, b) => a.localeCompare(b));
     expect(tags).toEqual(["BFMH3", "NYCH3"]);
   });
@@ -149,7 +149,7 @@ describe("attemptAiRecovery", () => {
         error: "bad start_time",
         rawText: "Some raw text",
         partialData: {
-          kennelTag: "NYCH3",
+          kennelTags: ["NYCH3"],
           sourceUrl: "https://hashrego.com/events/nych3-pub-crawl-2026",
         },
       },
@@ -180,7 +180,7 @@ describe("attemptAiRecovery", () => {
         error: "No date",
         rawText: "Some raw text with date 3.14.26",
         partialData: {
-          kennelTag: "OFH3",
+          kennelTags: ["OFH3"],
           hares: "Deterministic Hare", // This should take priority over AI
         },
       },
@@ -334,7 +334,7 @@ describe("attemptAiRecovery", () => {
         field: "date",
         error: "Could not parse date from post: March Trail",
         rawText: "When: 3.14.26\nWhere: School",
-        partialData: { kennelTag: "OFH3", title: "March Trail" },
+        partialData: { kennelTags: ["OFH3"], title: "March Trail" },
       },
     ];
 
@@ -357,7 +357,7 @@ describe("attemptAiRecovery", () => {
     ];
 
     const result = await attemptAiRecovery(errors, "TestH3");
-    expect(result.results[0].recovered.kennelTag).toBe("TestH3");
+    expect(result.results[0].recovered.kennelTags[0]).toBe("TestH3");
   });
 
   it("tracks duration across all recovery attempts", async () => {

--- a/src/lib/ai/parse-recovery.ts
+++ b/src/lib/ai/parse-recovery.ts
@@ -48,7 +48,7 @@ function buildExtractionPrompt(parseError: ParseError): string {
   if (parseError.partialData) {
     const partial = parseError.partialData;
     const known: string[] = [];
-    if (partial.kennelTag) known.push(`kennelTag: "${partial.kennelTag}"`);
+    if (partial.kennelTags?.[0]) known.push(`kennelTag: "${partial.kennelTags[0]}"`);
     if (partial.date) known.push(`date: "${partial.date}"`);
     if (partial.title) known.push(`title: "${partial.title}"`);
     if (known.length > 0) {
@@ -161,12 +161,12 @@ async function recoverSingleError(
   if (!parsed) return null;
 
   // Merge: partialData (deterministic) + AI-extracted fields. Prefer the
-  // per-error kennelTag over the scrape-wide default so multi-kennel sources
-  // (HASHREGO, SFH3, Phoenix, etc.) don't recover events under the wrong
-  // kennel — `kennelTag` arg is a fallback for adapters that haven't started
-  // populating partialData.kennelTag yet.
+  // per-error primary tag (kennelTags[0]) over the scrape-wide default so
+  // multi-kennel sources (HASHREGO, SFH3, Phoenix, etc.) don't recover
+  // events under the wrong kennel — `kennelTag` arg is a fallback for
+  // adapters that haven't started populating partialData.kennelTags yet.
   const merged: RawEventData = {
-    kennelTag: parseError.partialData?.kennelTag ?? kennelTag,
+    kennelTags: [parseError.partialData?.kennelTags?.[0] ?? kennelTag],
     date: parseError.partialData?.date ?? parsed.event.date ?? "",
     title: parseError.partialData?.title ?? parsed.event.title,
     hares: parseError.partialData?.hares ?? parsed.event.hares,

--- a/src/pipeline/fingerprint.test.ts
+++ b/src/pipeline/fingerprint.test.ts
@@ -20,8 +20,8 @@ describe("generateFingerprint", () => {
   });
 
   it("different kennel tags produce different fingerprints", () => {
-    const a = generateFingerprint(buildRawEvent({ kennelTag: "NYCH3" }));
-    const b = generateFingerprint(buildRawEvent({ kennelTag: "BrH3" }));
+    const a = generateFingerprint(buildRawEvent({ kennelTags: ["NYCH3" ]}));
+    const b = generateFingerprint(buildRawEvent({ kennelTags: ["BrH3" ]}));
     expect(a).not.toBe(b);
   });
 

--- a/src/pipeline/fingerprint.ts
+++ b/src/pipeline/fingerprint.ts
@@ -4,11 +4,21 @@ import type { RawEventData } from "@/adapters/types";
 /**
  * Generate a deterministic fingerprint for a raw event.
  * Used to detect unchanged events and skip re-processing.
+ *
+ * `kennelTags` is sorted before joining — adapters that emit multi-kennel
+ * tags from set-typed sources (e.g. Hash Rego API) can return them in
+ * non-deterministic order, and an unsorted join would produce a fresh
+ * fingerprint on every scrape and break idempotency
+ * (memory: feedback_fingerprint_stability — Seletar PR #541, 74 dups).
+ *
+ * Single-tag events fingerprint identically to pre-#1023 (single-element
+ * sorted-join is the same string as the bare tag).
  */
 export function generateFingerprint(data: RawEventData): string {
+  const sortedTags = [...data.kennelTags].sort((a, b) => a.localeCompare(b));
   const input = [
     data.date,
-    data.kennelTag,
+    sortedTags.join(","),
     data.runNumber?.toString() ?? "",
     data.title ?? "",
     data.location ?? "",

--- a/src/pipeline/fingerprint.ts
+++ b/src/pipeline/fingerprint.ts
@@ -15,7 +15,10 @@ import type { RawEventData } from "@/adapters/types";
  * sorted-join is the same string as the bare tag).
  */
 export function generateFingerprint(data: RawEventData): string {
-  const sortedTags = [...data.kennelTags].sort((a, b) => a.localeCompare(b));
+  // Dedupe before sorting so an adapter that accidentally emits a duplicate
+  // tag (`["A", "B", "A"]`) fingerprints the same as the canonical set
+  // (`["A", "B"]`) — preserves idempotency across set-typed sources.
+  const sortedTags = [...new Set(data.kennelTags)].sort((a, b) => a.localeCompare(b));
   const input = [
     data.date,
     sortedTags.join(","),

--- a/src/pipeline/kennel-resolver.ts
+++ b/src/pipeline/kennel-resolver.ts
@@ -112,6 +112,20 @@ async function resolveViaPatternMapping(
 }
 
 /**
+ * Resolve an array of raw kennel tags to ResolveResults (#1023). Per-tag
+ * results preserve order — `kennelTags[0]` becomes the primary kennel for
+ * the event, the rest become EventKennel co-host rows. Unmatched tags
+ * surface as `{ kennelId: null, matched: false }` so the caller can decide
+ * to skip the event or alert.
+ */
+export async function resolveKennelTags(
+  tags: string[],
+  sourceId?: string,
+): Promise<ResolveResult[]> {
+  return Promise.all(tags.map((tag) => resolveKennelTag(tag, sourceId)));
+}
+
+/**
  * Resolve a raw kennel tag to a Kennel ID.
  *
  * Pipeline:

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -19,10 +19,18 @@ vi.mock("./fingerprint", () => ({
   generateFingerprint: vi.fn(() => "fp_abc123"),
 }));
 
-vi.mock("./kennel-resolver", () => ({
-  resolveKennelTag: vi.fn(),
-  clearResolverCache: vi.fn(),
-}));
+vi.mock("./kennel-resolver", () => {
+  const resolveKennelTag = vi.fn();
+  return {
+    resolveKennelTag,
+    // Route through the mocked single-tag resolver so per-test
+    // mockResolve.mockImplementation() drives both code paths.
+    resolveKennelTags: vi.fn(async (tags: string[], sourceId?: string) =>
+      Promise.all(tags.map((t) => resolveKennelTag(t, sourceId))),
+    ),
+    clearResolverCache: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/geo", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/geo")>();

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/db", () => ({
     sourceKennel: { findMany: vi.fn() },
     rawEvent: { findFirst: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn() },
     event: { findUnique: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
-    eventKennel: { create: vi.fn() },
+    eventKennel: { create: vi.fn(), upsert: vi.fn() },
     eventLink: { upsert: vi.fn() },
     kennel: { findUnique: vi.fn() },
     $executeRaw: vi.fn().mockResolvedValue(0),
@@ -132,6 +132,67 @@ describe("processRawEvents", () => {
     });
   });
 
+  describe("secondary co-host EventKennel writes (#1023 step 3)", () => {
+    // The current adapter codemod emits `kennelTags: [singleTag]` everywhere
+    // — multi-tag emission is gated to step 4's `matchConfigPatterns`
+    // arrayification. These tests synthesize multi-tag input directly via
+    // buildRawEvent to lock in the secondary-write behavior NOW so step 4
+    // doesn't have to be the first real exercise of the path.
+    beforeEach(() => {
+      vi.mocked(prisma.eventKennel.upsert).mockResolvedValue({} as never);
+    });
+
+    it("writes secondary EventKennel rows for each additional resolved tag", async () => {
+      mockRawEventFind.mockResolvedValueOnce(null);
+      mockEventFindMany.mockResolvedValueOnce([] as never);
+      mockEventCreate.mockResolvedValueOnce({ id: "evt_co", kennelId: "kennel_1" } as never);
+      // Primary "primary" → kennel_1; secondary "co-host" → kennel_2
+      mockResolve.mockReset();
+      mockResolve.mockImplementation(async (tag: string) => {
+        if (tag === "co-host") return { kennelId: "kennel_2", matched: true };
+        return { kennelId: "kennel_1", matched: true };
+      });
+
+      await processRawEvents("src_1", [buildRawEvent({ kennelTags: ["primary", "co-host"] })]);
+
+      expect(vi.mocked(prisma.eventKennel.upsert)).toHaveBeenCalledWith({
+        where: { eventId_kennelId: { eventId: "evt_co", kennelId: "kennel_2" } },
+        create: { eventId: "evt_co", kennelId: "kennel_2", isPrimary: false },
+        update: {},
+      });
+    });
+
+    it("skips a secondary tag that resolves to the primary kennel (no duplicate)", async () => {
+      mockRawEventFind.mockResolvedValueOnce(null);
+      mockEventFindMany.mockResolvedValueOnce([] as never);
+      mockEventCreate.mockResolvedValueOnce({ id: "evt_dup", kennelId: "kennel_1" } as never);
+      // Both tags resolve to the same kennel_1 — secondary upsert must NOT fire.
+      mockResolve.mockResolvedValue({ kennelId: "kennel_1", matched: true });
+
+      await processRawEvents("src_1", [buildRawEvent({ kennelTags: ["alias-a", "alias-b"] })]);
+
+      expect(vi.mocked(prisma.eventKennel.upsert)).not.toHaveBeenCalled();
+    });
+
+    it("skips an unresolved secondary tag without failing the event", async () => {
+      mockRawEventFind.mockResolvedValueOnce(null);
+      mockEventFindMany.mockResolvedValueOnce([] as never);
+      mockEventCreate.mockResolvedValueOnce({ id: "evt_unmatched", kennelId: "kennel_1" } as never);
+      mockResolve.mockReset();
+      mockResolve.mockImplementation(async (tag: string) => {
+        if (tag === "unknown") return { kennelId: null, matched: false };
+        return { kennelId: "kennel_1", matched: true };
+      });
+
+      const result = await processRawEvents("src_1", [
+        buildRawEvent({ kennelTags: ["primary", "unknown"] }),
+      ]);
+
+      expect(result.created).toBe(1);
+      expect(vi.mocked(prisma.eventKennel.upsert)).not.toHaveBeenCalled();
+    });
+  });
+
   it("updates existing event when trust level is >=", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([{ id: "evt_1", trustLevel: 5 }] as never);
@@ -170,7 +231,7 @@ describe("processRawEvents", () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockResolve.mockResolvedValueOnce({ kennelId: null, matched: false });
 
-    const result = await processRawEvents("src_1", [buildRawEvent({ kennelTag: "UNKNOWN" })]);
+    const result = await processRawEvents("src_1", [buildRawEvent({ kennelTags: ["UNKNOWN" ]})]);
     expect(result.unmatched).toEqual(["UNKNOWN"]);
   });
 
@@ -179,8 +240,8 @@ describe("processRawEvents", () => {
     mockResolve.mockResolvedValue({ kennelId: null, matched: false });
 
     const result = await processRawEvents("src_1", [
-      buildRawEvent({ kennelTag: "UNKNOWN" }),
-      buildRawEvent({ kennelTag: "UNKNOWN" }),
+      buildRawEvent({ kennelTags: ["UNKNOWN" ]}),
+      buildRawEvent({ kennelTags: ["UNKNOWN" ]}),
     ]);
     expect(result.unmatched).toEqual(["UNKNOWN"]);
   });
@@ -245,7 +306,7 @@ describe("processRawEvents", () => {
     mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
 
     await processRawEvents("src_1", [
-      buildRawEvent({ location: "Sobu line, West exit", kennelTag: "tokyo-h3" }),
+      buildRawEvent({ location: "Sobu line, West exit", kennelTags: ["tokyo-h3" ]}),
     ]);
 
     expect(mockEventCreate).toHaveBeenCalledWith(
@@ -300,7 +361,7 @@ describe("processRawEvents", () => {
     mockEventUpdate.mockResolvedValueOnce({} as never);
 
     await processRawEvents("src_1", [
-      buildRawEvent({ location: "Sobu line, West exit", kennelTag: "tokyo-h3" }),
+      buildRawEvent({ location: "Sobu line, West exit", kennelTags: ["tokyo-h3" ]}),
     ]);
 
     const updateCall = mockEventUpdate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
@@ -315,7 +376,7 @@ describe("source-kennel guard", () => {
     mockResolve.mockResolvedValueOnce({ kennelId: "kennel_other", matched: true });
     // Source is only linked to kennel_1 (default mock)
 
-    const result = await processRawEvents("src_1", [buildRawEvent({ kennelTag: "OtherH3" })]);
+    const result = await processRawEvents("src_1", [buildRawEvent({ kennelTags: ["OtherH3" ]})]);
     expect(result.blocked).toBe(1);
     expect(result.blockedTags).toEqual(["OtherH3"]);
     expect(result.created).toBe(0);
@@ -339,8 +400,8 @@ describe("source-kennel guard", () => {
     mockFingerprint.mockReturnValueOnce("fp_1").mockReturnValueOnce("fp_2");
 
     const result = await processRawEvents("src_1", [
-      buildRawEvent({ kennelTag: "OtherH3" }),
-      buildRawEvent({ kennelTag: "OtherH3" }),
+      buildRawEvent({ kennelTags: ["OtherH3" ]}),
+      buildRawEvent({ kennelTags: ["OtherH3" ]}),
     ]);
     expect(result.blocked).toBe(2);
     expect(result.blockedTags).toEqual(["OtherH3"]);
@@ -367,7 +428,7 @@ describe("mergeErrorDetails", () => {
     mockFingerprint.mockReturnValueOnce("fp_error_event").mockReturnValueOnce("fp_error_event");
 
     const result = await processRawEvents("src_1", [
-      buildRawEvent({ date: "2026-03-01", kennelTag: "TestH3" }),
+      buildRawEvent({ date: "2026-03-01", kennelTags: ["TestH3" ]}),
     ]);
 
     expect(result.eventErrors).toBe(1);
@@ -394,8 +455,8 @@ describe("mergeErrorDetails", () => {
     mockFingerprint.mockReturnValueOnce("fp_1").mockReturnValueOnce("fp_2");
 
     const result = await processRawEvents("src_1", [
-      buildRawEvent({ kennelTag: "UnknownH3", date: "2026-03-01" }),
-      buildRawEvent({ kennelTag: "UnknownH3", date: "2026-03-02" }),
+      buildRawEvent({ kennelTags: ["UnknownH3"], date: "2026-03-01" }),
+      buildRawEvent({ kennelTags: ["UnknownH3"], date: "2026-03-02" }),
     ]);
 
     expect(result.sampleSkipped!.length).toBe(2);
@@ -410,7 +471,7 @@ describe("mergeErrorDetails", () => {
     vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({ shortName: "OtherH3" } as never);
 
     const result = await processRawEvents("src_1", [
-      buildRawEvent({ kennelTag: "OtherH3" }),
+      buildRawEvent({ kennelTags: ["OtherH3" ]}),
     ]);
 
     expect(result.sampleBlocked!.length).toBe(1);
@@ -425,7 +486,7 @@ describe("mergeErrorDetails", () => {
     mockResolve.mockResolvedValueOnce({ kennelId: null, matched: false });
 
     const result = await processRawEvents("src_1", [
-      buildRawEvent({ kennelTag: "UnknownH3", date: "2026-03-01" }),
+      buildRawEvent({ kennelTags: ["UnknownH3"], date: "2026-03-01" }),
     ]);
 
     // Event is re-processed but fails kennel resolution
@@ -439,7 +500,7 @@ describe("mergeErrorDetails", () => {
     vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({ shortName: "OtherH3" } as never);
 
     const result = await processRawEvents("src_1", [
-      buildRawEvent({ kennelTag: "OtherH3", date: "2026-03-01" }),
+      buildRawEvent({ kennelTags: ["OtherH3"], date: "2026-03-01" }),
     ]);
 
     // Event is re-processed but blocked by source-kennel guard — counts as blocked
@@ -451,7 +512,7 @@ describe("mergeErrorDetails", () => {
     mockRawEventFind.mockResolvedValueOnce({ id: "raw_existing", processed: true } as never);
 
     const result = await processRawEvents("src_1", [
-      buildRawEvent({ kennelTag: "NYCH3", date: "2026-03-01" }),
+      buildRawEvent({ kennelTags: ["NYCH3"], date: "2026-03-01" }),
     ]);
 
     expect(result.skipped).toBe(1);
@@ -783,7 +844,7 @@ describe("empty event guard", () => {
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
-        kennelTag: "",
+        kennelTags: [""],
         title: undefined,
         location: undefined,
         hares: undefined,
@@ -808,7 +869,7 @@ describe("empty event guard", () => {
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
-        kennelTag: "duhhh",
+        kennelTags: ["duhhh"],
         title: undefined,
         location: undefined,
         hares: undefined,
@@ -835,7 +896,7 @@ describe("empty event guard", () => {
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
-        kennelTag: "h5-hash",
+        kennelTags: ["h5-hash"],
         title: undefined,
         location: undefined,
         hares: undefined,
@@ -862,7 +923,7 @@ describe("empty event guard", () => {
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
-        kennelTag: "h4-tx",
+        kennelTags: ["h4-tx"],
         title: undefined,
         location: undefined,
         hares: undefined,
@@ -885,7 +946,7 @@ describe("empty event guard", () => {
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
-        kennelTag: "NYCH3",
+        kennelTags: ["NYCH3"],
         title: "Valentine's Day Trail",
         location: undefined,
         hares: undefined,

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -5,7 +5,7 @@ import { parseUtcNoonDate } from "@/lib/date";
 import { regionTimezone, getLabelForUrl, stripUrlsFromText, timeToMinutes } from "@/lib/format";
 import { composeUtcStart } from "@/lib/timezone";
 import { generateFingerprint } from "./fingerprint";
-import { resolveKennelTag, clearResolverCache } from "./kennel-resolver";
+import { resolveKennelTag, resolveKennelTags, clearResolverCache } from "./kennel-resolver";
 import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseGeocode, haversineDistance, parseDMSFromLocation, stripDMSFromLocation } from "@/lib/geo";
 import { isPlaceholder, decodeEntities, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "@/adapters/utils";
 import { LOCATION_EMAIL_CTA_RE } from "./audit-checks";
@@ -1210,16 +1210,28 @@ async function upsertCanonicalEvent(
   // step 4's `matchConfigPatterns` arrayification). Upsert is safe across
   // re-scrapes; we never delete co-host rows so a tag dropping from a
   // future scrape doesn't reverse a real co-host relationship.
+  //
+  // The `update: {}` no-op is intentional: if a kennel was previously the
+  // primary on this event (isPrimary=true), a fresh scrape that lists it
+  // as a co-host should NOT demote it. Demotion only happens via the admin
+  // kennel-merge path in `app/admin/kennels/actions.ts`.
   if (event.kennelTags.length > 1) {
-    for (const tag of event.kennelTags.slice(1)) {
-      const { kennelId: coHostId, matched: coHostMatched } = await resolveKennelTag(tag, ctx.sourceId);
-      if (!coHostMatched || !coHostId || coHostId === kennelId) continue;
-      await prisma.eventKennel.upsert({
-        where: { eventId_kennelId: { eventId: targetEventId, kennelId: coHostId } },
-        create: { eventId: targetEventId, kennelId: coHostId, isPrimary: false },
-        update: {},
-      });
+    const secondaryTags = [...new Set(event.kennelTags.slice(1))];
+    const resolved = await resolveKennelTags(secondaryTags, ctx.sourceId);
+    const coHostIds = new Set<string>();
+    for (const r of resolved) {
+      if (!r.matched || !r.kennelId || r.kennelId === kennelId) continue;
+      coHostIds.add(r.kennelId);
     }
+    await Promise.all(
+      [...coHostIds].map((coHostId) =>
+        prisma.eventKennel.upsert({
+          where: { eventId_kennelId: { eventId: targetEventId, kennelId: coHostId } },
+          create: { eventId: targetEventId, kennelId: coHostId, isPrimary: false },
+          update: {},
+        }),
+      ),
+    );
   }
 
   // Record this match in the per-batch tracker

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -340,7 +340,7 @@ async function refreshExistingEvent(
   event: RawEventData,
   ctx: MergeContext,
 ): Promise<void> {
-  const { kennelId, matched } = await resolveKennelTag(event.kennelTag, ctx.sourceId);
+  const { kennelId, matched } = await resolveKennelTag(event.kennelTags[0], ctx.sourceId);
   if (!matched || !kennelId || !ctx.linkedKennelIds.has(kennelId)) return;
 
   const region = await resolveRegion(kennelId, ctx);
@@ -387,15 +387,15 @@ async function collectSkippedAndBlockedSamples(
   if (!needSkippedSamples && !needBlockedSamples) return;
 
   const { kennelId: resolvedId, matched: resolvedMatch } =
-    await resolveKennelTag(event.kennelTag, ctx.sourceId);
+    await resolveKennelTag(event.kennelTags[0], ctx.sourceId);
 
   if (!resolvedMatch || !resolvedId) {
     if (needSkippedSamples) {
       ctx.result.sampleSkipped?.push({
         reason: "UNMATCHED_TAG",
-        kennelTag: event.kennelTag,
+        kennelTag: event.kennelTags[0],
         event,
-        suggestedAction: `Create kennel or alias for "${event.kennelTag}"`,
+        suggestedAction: `Create kennel or alias for "${event.kennelTags[0]}"`,
       });
     }
   } else if (!ctx.linkedKennelIds.has(resolvedId)) {
@@ -403,7 +403,7 @@ async function collectSkippedAndBlockedSamples(
       const kennel = await prisma.kennel.findUnique({ where: { id: resolvedId }, select: { shortName: true } });
       ctx.result.sampleBlocked?.push({
         reason: "SOURCE_KENNEL_MISMATCH",
-        kennelTag: event.kennelTag,
+        kennelTag: event.kennelTags[0],
         event,
         suggestedAction: `Link ${kennel?.shortName ?? resolvedId} to this source`,
       });
@@ -460,19 +460,19 @@ async function resolveAndGuardKennel(
   event: RawEventData,
   ctx: MergeContext,
 ): Promise<string | null> {
-  const { kennelId, matched } = await resolveKennelTag(event.kennelTag, ctx.sourceId);
+  const { kennelId, matched } = await resolveKennelTag(event.kennelTags[0], ctx.sourceId);
 
   if (!matched || !kennelId) {
     // Flag for review — leave unprocessed
-    if (!ctx.result.unmatched.includes(event.kennelTag)) {
-      ctx.result.unmatched.push(event.kennelTag);
+    if (!ctx.result.unmatched.includes(event.kennelTags[0])) {
+      ctx.result.unmatched.push(event.kennelTags[0]);
     }
     if (ctx.result.sampleSkipped && ctx.result.sampleSkipped.length < 3) {
       ctx.result.sampleSkipped.push({
         reason: "UNMATCHED_TAG",
-        kennelTag: event.kennelTag,
+        kennelTag: event.kennelTags[0],
         event,
-        suggestedAction: `Create kennel or alias for "${event.kennelTag}"`,
+        suggestedAction: `Create kennel or alias for "${event.kennelTags[0]}"`,
       });
     }
     return null;
@@ -481,8 +481,8 @@ async function resolveAndGuardKennel(
   // Guard: block events for kennels not linked to this source
   if (!ctx.linkedKennelIds.has(kennelId)) {
     ctx.result.blocked++;
-    if (!ctx.result.blockedTags.includes(event.kennelTag)) {
-      ctx.result.blockedTags.push(event.kennelTag);
+    if (!ctx.result.blockedTags.includes(event.kennelTags[0])) {
+      ctx.result.blockedTags.push(event.kennelTags[0]);
     }
     if (ctx.result.sampleBlocked && ctx.result.sampleBlocked.length < 3) {
       const kennel = await prisma.kennel.findUnique({
@@ -491,7 +491,7 @@ async function resolveAndGuardKennel(
       });
       ctx.result.sampleBlocked.push({
         reason: "SOURCE_KENNEL_MISMATCH",
-        kennelTag: event.kennelTag,
+        kennelTag: event.kennelTags[0],
         event,
         suggestedAction: `Link ${kennel?.shortName ?? kennelId} to this source`,
       });
@@ -1204,6 +1204,24 @@ async function upsertCanonicalEvent(
     ctx.result.createdEventIds.push(newEvent.id);
   }
 
+  // #1023 step 3: write co-host EventKennel rows for any additional kennel
+  // tags beyond the primary. No-op for single-tag events (every adapter
+  // currently emits a 1-element array; multi-tag emission opts in via
+  // step 4's `matchConfigPatterns` arrayification). Upsert is safe across
+  // re-scrapes; we never delete co-host rows so a tag dropping from a
+  // future scrape doesn't reverse a real co-host relationship.
+  if (event.kennelTags.length > 1) {
+    for (const tag of event.kennelTags.slice(1)) {
+      const { kennelId: coHostId, matched: coHostMatched } = await resolveKennelTag(tag, ctx.sourceId);
+      if (!coHostMatched || !coHostId || coHostId === kennelId) continue;
+      await prisma.eventKennel.upsert({
+        where: { eventId_kennelId: { eventId: targetEventId, kennelId: coHostId } },
+        create: { eventId: targetEventId, kennelId: coHostId, isPrimary: false },
+        update: {},
+      });
+    }
+  }
+
   // Record this match in the per-batch tracker
   const matched = ctx.batchMatchedEvents.get(batchKey) ?? new Set<string>();
   matched.add(targetEventId);
@@ -1283,12 +1301,12 @@ async function processNewRawEvent(
 
   // Validate the event has at least one meaningful display field before processing.
   // kennelTag counts because we'll generate a default title from it after kennel resolution.
-  const hasDisplayData = event.title || event.location || event.hares || event.runNumber || event.kennelTag;
+  const hasDisplayData = event.title || event.location || event.hares || event.runNumber || event.kennelTags[0];
   if (!hasDisplayData) {
     ctx.result.eventErrors++;
     if (ctx.result.eventErrorMessages.length < 50) {
       ctx.result.eventErrorMessages.push(
-        `${event.date}/${event.kennelTag}: Skipping empty event (no title, location, hares, or run number)`,
+        `${event.date}/${event.kennelTags[0]}: Skipping empty event (no title, location, hares, or run number)`,
       );
     }
     return null;
@@ -1311,7 +1329,7 @@ async function processNewRawEvent(
   const kennelData = await resolveKennelData(kennelId, ctx);
   const sanitized = sanitizeTitle(event.title);
   if (!sanitized) {
-    const displayName = friendlyKennelName(kennelData.shortName, kennelData.fullName) || event.kennelTag;
+    const displayName = friendlyKennelName(kennelData.shortName, kennelData.fullName) || event.kennelTags[0];
     event.title = event.runNumber
       ? `${displayName} Trail #${event.runNumber}`
       : `${displayName} Trail`;
@@ -1605,7 +1623,7 @@ function recordMergeError(
   result: MergeResult,
 ): void {
   const reason = err instanceof Error ? err.message : String(err);
-  const msg = `${event.date}/${event.kennelTag}: ${reason}`;
+  const msg = `${event.date}/${event.kennelTags[0]}: ${reason}`;
   console.error(`Merge error: ${msg}`);
   result.eventErrors++;
   if (result.eventErrorMessages.length < 50) {

--- a/src/pipeline/reconcile.test.ts
+++ b/src/pipeline/reconcile.test.ts
@@ -57,7 +57,7 @@ beforeEach(() => {
 describe("reconcileStaleEvents", () => {
   it("cancels sole-source events not in current scrape", async () => {
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
     ];
 
     // DB has two events for kennel_1, but scrape only returned one date
@@ -81,7 +81,7 @@ describe("reconcileStaleEvents", () => {
 
   it("preserves multi-source events when one source removes them", async () => {
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
     ];
 
     mockEventFindMany.mockResolvedValueOnce([
@@ -101,8 +101,8 @@ describe("reconcileStaleEvents", () => {
 
   it("does not cancel events that match scraped dates", async () => {
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
-      buildRawEvent({ date: "2026-02-21", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
+      buildRawEvent({ date: "2026-02-21", kennelTags: ["BoBBH3" ]}),
     ];
 
     mockEventFindMany.mockResolvedValueOnce([
@@ -141,8 +141,8 @@ describe("reconcileStaleEvents", () => {
       .mockResolvedValueOnce({ kennelId: "kennel_1", matched: true });
 
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "Unknown" }),
-      buildRawEvent({ date: "2026-02-21", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["Unknown" ]}),
+      buildRawEvent({ date: "2026-02-21", kennelTags: ["BoBBH3" ]}),
     ];
 
     // DB has both dates
@@ -172,8 +172,8 @@ describe("reconcileStaleEvents", () => {
       .mockResolvedValueOnce({ kennelId: "kennel_2", matched: true });
 
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoH3" ]}),
     ];
 
     // DB has events for both kennels, plus an extra for kennel_2
@@ -202,7 +202,7 @@ describe("reconcileStaleEvents", () => {
     const scrapedEvents = [
       buildRawEvent({
         date: "2026-02-14",
-        kennelTag: "BoBBH3",
+        kennelTags: ["BoBBH3"],
         sourceUrl: "https://example.com/past/detail?id=123",
       }),
     ];
@@ -234,7 +234,7 @@ describe("reconcileStaleEvents", () => {
     const scrapedEvents = [
       buildRawEvent({
         date: "2026-03-08",
-        kennelTag: "BoH3",
+        kennelTags: ["BoH3"],
         sourceUrl: "https://example.com/trail-a",
       }),
     ];
@@ -269,7 +269,7 @@ describe("reconcileStaleEvents", () => {
     const scrapedEvents = [
       buildRawEvent({
         date: "2026-03-08",
-        kennelTag: "BoH3",
+        kennelTags: ["BoH3"],
         sourceUrl: undefined,
         startTime: undefined,
         title: undefined,
@@ -301,7 +301,7 @@ describe("reconcileStaleEvents", () => {
         // Cast through unknown because the type says YYYY-MM-DD — this is the
         // adapter-bug scenario we're protecting against.
         date: "2026-02-14T15:00:00Z" as unknown as string,
-        kennelTag: "BoBBH3",
+        kennelTags: ["BoBBH3"],
       }),
     ];
 
@@ -324,7 +324,7 @@ describe("reconcileStaleEvents", () => {
     const scrapedEvents = [
       buildRawEvent({
         date: "2026-2-14 15:00:00" as unknown as string,
-        kennelTag: "BoBBH3",
+        kennelTags: ["BoBBH3"],
       }),
     ];
 
@@ -348,7 +348,7 @@ describe("reconcileStaleEvents", () => {
     const scrapedEvents = [
       buildRawEvent({
         date: "2026-02-14T23:30:00-05:00" as unknown as string,
-        kennelTag: "BoBBH3",
+        kennelTags: ["BoBBH3"],
       }),
     ];
 
@@ -376,7 +376,7 @@ describe("reconcileStaleEvents", () => {
         // Sole scraped row for kennel_1; date is garbage. Without the safeguard,
         // any canonical of kennel_1 would look orphaned and get cancelled.
         date: "not-a-date" as unknown as string,
-        kennelTag: "BoBBH3",
+        kennelTags: ["BoBBH3"],
       }),
     ];
 
@@ -411,11 +411,11 @@ describe("reconcileStaleEvents", () => {
     const scrapedEvents = [
       buildRawEvent({
         date: "not-a-date" as unknown as string,
-        kennelTag: "BoBBH3",
+        kennelTags: ["BoBBH3"],
       }),
       buildRawEvent({
         date: "2026-02-14",
-        kennelTag: "Kennel2",
+        kennelTags: ["Kennel2"],
       }),
     ];
 
@@ -457,13 +457,13 @@ describe("reconcileStaleEvents", () => {
     const scrapedEvents = [
       buildRawEvent({
         date: "2026-03-08",
-        kennelTag: "BoH3",
+        kennelTags: ["BoH3"],
         sourceUrl: "https://example.com/trail-a",
         startTime: "10:30",
       }),
       buildRawEvent({
         date: "2026-03-08",
-        kennelTag: "BoH3",
+        kennelTags: ["BoH3"],
         // URL drifted from trail-b to a per-event detail page
         sourceUrl: "https://example.com/detail?id=999",
         startTime: "14:30",
@@ -499,8 +499,8 @@ describe("reconcileStaleEvents", () => {
 
   it("does not cancel same-day events when both present in scrape", async () => {
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-03-08", kennelTag: "BoH3", sourceUrl: "https://example.com/trail-a" }),
-      buildRawEvent({ date: "2026-03-08", kennelTag: "BoH3", sourceUrl: "https://example.com/trail-b" }),
+      buildRawEvent({ date: "2026-03-08", kennelTags: ["BoH3"], sourceUrl: "https://example.com/trail-a" }),
+      buildRawEvent({ date: "2026-03-08", kennelTags: ["BoH3"], sourceUrl: "https://example.com/trail-b" }),
     ];
 
     mockEventFindMany.mockResolvedValueOnce([
@@ -524,7 +524,7 @@ describe("reconcileStaleEvents", () => {
     mockResolve.mockResolvedValueOnce({ kennelId: "kennel_1", matched: true });
 
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
     ];
 
     // DB returns events for both kennels in the window (scoped to kennel_1 only)
@@ -557,7 +557,7 @@ describe("reconcileStaleEvents", () => {
 
   it("cancels multiple orphaned events in one batch", async () => {
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
     ];
 
     mockEventFindMany.mockResolvedValueOnce([
@@ -589,7 +589,7 @@ describe("reconcileStaleEvents", () => {
     mockResolve.mockResolvedValue({ kennelId: "kennel_1", matched: true });
 
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
     ];
 
     // DB has events for both kennels — kennel_2's event would be orphaned
@@ -622,7 +622,7 @@ describe("reconcileStaleEvents", () => {
     mockResolve.mockResolvedValue({ kennelId: "kennel_1", matched: true });
 
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
     ];
 
     mockEventFindMany.mockResolvedValueOnce([] as never);
@@ -648,7 +648,7 @@ describe("reconcileStaleEvents", () => {
     mockResolve.mockResolvedValue({ kennelId: "kennel_1", matched: true });
 
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
     ];
 
     mockEventFindMany.mockResolvedValueOnce([] as never);
@@ -675,7 +675,7 @@ describe("reconcileStaleEvents", () => {
     mockResolve.mockResolvedValue({ kennelId: "kennel_1", matched: true });
 
     const scrapedEvents = [
-      buildRawEvent({ date: "2026-02-14", kennelTag: "BoBBH3" }),
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),
     ];
 
     mockEventFindMany.mockResolvedValueOnce([

--- a/src/pipeline/reconcile.ts
+++ b/src/pipeline/reconcile.ts
@@ -56,7 +56,7 @@ export async function reconcileStaleEvents(
   // (kennelId, date) slot below. Slot membership drives the orphan decision
   // after we query canonical candidates from the DB.
   const resolutions = await Promise.all(
-    scrapedEvents.map((event) => resolveKennelTag(event.kennelTag, sourceId)),
+    scrapedEvents.map((event) => resolveKennelTag(event.kennelTags[0], sourceId)),
   );
   // When a scraped row has an unparseable date we suppress the whole kennel,
   // not just the row: dropping the row would leave its canonical orphaned and

--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -86,7 +86,7 @@ beforeEach(() => {
   mockSourceUpdate.mockResolvedValue({} as never);
   mockGetAdapter.mockReturnValue({
     type: "HTML_SCRAPER",
-    fetch: vi.fn().mockResolvedValue({ events: [{ date: "2026-02-14", kennelTag: "NYCH3" }], errors: [] }),
+    fetch: vi.fn().mockResolvedValue({ events: [{ date: "2026-02-14", kennelTags: ["NYCH3"] }], errors: [] }),
   } as never);
   mockProcessRaw.mockResolvedValue(fakeMergeResult);
   mockRawEventDeleteMany.mockResolvedValue({} as never);
@@ -209,7 +209,7 @@ describe("scrapeSource", () => {
     mockSourceFind.mockResolvedValueOnce(gcalSource as never);
     mockGetAdapter.mockReturnValue({
       type: "GOOGLE_CALENDAR",
-      fetch: vi.fn().mockResolvedValue({ events: [{ date: "2026-03-01", kennelTag: "BH3" }], errors: [] }),
+      fetch: vi.fn().mockResolvedValue({ events: [{ date: "2026-03-01", kennelTags: ["BH3"] }], errors: [] }),
     } as never);
 
     const result = await scrapeSource("src_gcal");

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -65,8 +65,8 @@ async function runAiRecovery(
     return undefined;
   }
 
-  const defaultKennelTag = scrapeResult.events[0]?.kennelTag
-    ?? parseErrors[0]?.partialData?.kennelTag
+  const defaultKennelTag = scrapeResult.events[0]?.kennelTags?.[0]
+    ?? parseErrors[0]?.partialData?.kennelTags?.[0]
     ?? sourceName;
 
   const aiRecovery = await attemptAiRecovery(recoverableErrors, defaultKennelTag);

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -14,7 +14,7 @@ import type {
 export function buildRawEvent(overrides?: Partial<RawEventData>): RawEventData {
   return {
     date: "2026-02-14",
-    kennelTag: "NYCH3",
+    kennelTags: ["NYCH3"],
     runNumber: 2100,
     title: "Valentine's Day Trail",
     description: "A lovely trail",


### PR DESCRIPTION
## Summary

Third implementation step of the multi-kennel co-hosted events spec ([docs/multi-kennel-events-spec.md](docs/multi-kennel-events-spec.md)). Step 1 ([#1092](https://github.com/johnrclem/hashtracks-web/pull/1092)) added the EventKennel join table; step 2 ([#1099](https://github.com/johnrclem/hashtracks-web/pull/1099)) made every Event-write dual-write the primary EventKennel row. This step converts the adapter interface to multi-tag and lays the groundwork for step 4's opt-in multi-kennel pattern emission.

229 files changed (~120 are mechanical adapter codemods).

### What lands

**Foundational changes:**
- `src/adapters/types.ts` — `RawEventData.kennelTag: string` → `kennelTags: string[]`. EventSample.kennelTag stays as a string (diagnostic display, populated from `kennelTags[0]`).
- `src/pipeline/fingerprint.ts` — sort + comma-join kennelTags before hashing. Required to keep fingerprints stable for set-typed sources (memory: `feedback_fingerprint_stability`). Single-tag events hash identically to pre-#1023.
- `src/pipeline/kennel-resolver.ts` — added `resolveKennelTags(tags, sourceId)` wrapper. Single-tag `resolveKennelTag` preserved.
- `src/pipeline/merge.ts` — every `event.kennelTag` access → `event.kennelTags[0]`. After event create/match, a new loop iterates `kennelTags.slice(1)`, resolves each, and upserts EventKennel rows with `isPrimary=false`. Skips unresolved tags and tags resolving to the same kennel as primary. **No-op for current single-tag adapters**; activates when step 4 enables array-typed kennelPatterns.

**Codemod across ~120 files** (adapters, scripts, tests):
- `kennelTag: <expr>` in RawEventData literals → `kennelTags: [<expr>]`
- `event.kennelTag` reads → `event.kennelTags[0]`
- Internal config types preserved (BangkokHashConfig, MeetupConfig, GoHashConfig, YiiHarelineConfig, StaticScheduleConfig, GoogleSheetsConfig helpers, inlineHarelinePattern). Source-config schema is unchanged in this step — adapters wrap `[config.kennelTag]` when emitting RawEventData.

### Codex adversarial review caught + fixed

- **IMPORTANT** — `scripts/merge-orphan-rawevents.ts` now normalizes legacy `rawData.kennelTag` → `kennelTags: [kennelTag]` so orphan rows persisted before this PR ships don't crash on `event.kennelTags[0]` dereference.
- **IMPORTANT** — Added 3 unit tests for the new secondary co-host write loop (synthetic multi-tag input via `buildRawEvent`): re-point, primary-collapse-skip, unresolved-tag-skip. Locks behavior NOW so step 4 isn't the first real exercise.
- **NIT** — scrape.test.ts mock fixtures updated to new shape.
- **NIT** — parse-recovery.ts comment updated.

### Local verification (hashtracks_dev, 34,205 events)

- **5,382 unit tests pass**; `tsc --noEmit` clean
- Lint shows 14 pre-existing warnings unrelated to this diff
- `scripts/live-verify-dual-write.ts`: dual-write + composite PK + partial unique index all still pass
- `scripts/verify-event-kennel-backfill.ts`: 4 invariants all hold

### Production safety

- Per-event cost in scrape hot path: same as pre-step-3 (still one Prisma nested-create round-trip; secondary loop is dormant for single-tag adapters)
- Fingerprint backward compat: single-tag events fingerprint to byte-identical strings vs pre-step-3 — no RawEvent churn
- Migration script normalizes legacy persisted JSON

### What's NOT in this PR

- `matchConfigPatterns` arrayification + multi-tag pattern emission — step 4
- Display-layer migration (~200 sites) + authorization path updates — step 5
- `Event.kennelId` removal — step 7

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 5,382 pass, 0 new failures
- [x] `scripts/verify-event-kennel-backfill.ts` still passes (no step 1 regression)
- [x] `scripts/live-verify-dual-write.ts` still passes (no step 2 regression)
- [x] 3 new unit tests cover the secondary co-host write path
- [ ] Vercel preview deploys cleanly
- [ ] Post-merge: monitor scrape error rates for ~24h to confirm no per-event regression in the merge pipeline

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)