### PR TITLE
feat(patterns): opt-in multi-kennel kennelPatterns + Oregon Calendar (step 4 of #1023)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1884,10 +1884,14 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         calendarId: "cae3r4u2uhucmmi9rvq5eu6obg@group.calendar.google.com",
-        // Anchor OH3 to start-of-title so co-host titles like
-        // "Cherry City H3 #1 / OH3 # 1340" no longer match the OH3 pattern
-        // mid-string and get correctly routed to cch3-or. Closes #991.
+        // Multi-kennel pattern (#1023 step 4): titles mentioning BOTH Cherry
+        // City and OH3 (e.g. "Cherry City H3 #1 / OH3 # 1340" — the inaugural
+        // joint trail surfaced in #991) emit both kennels as co-hosts so the
+        // event lands on both kennel pages. The array form takes precedence
+        // over the single-tag patterns below per spec §2 D15, so single-kennel
+        // titles still route correctly.
         kennelPatterns: [
+          ["(?:Cherry City.*OH3)|(?:OH3.*Cherry City)", ["cch3-or", "oh3"]],
           ["^OH3\\b|OH3 Full Moon", "oh3"],
           ["TGIF|Friday.*Pubcrawl", "tgif"],
           ["Cherry City|Cherry Cherry City", "cch3-or"],

--- a/scripts/live-verify-multi-kennel-pattern.ts
+++ b/scripts/live-verify-multi-kennel-pattern.ts
@@ -1,0 +1,128 @@
+/**
+ * Live verification (#1023 step 4): exercise the full multi-kennel path
+ * against hashtracks_dev — Oregon Calendar config + Cherry City/OH3 title
+ * → resolveKennelTagFromSummary → buildRawEventFromGCalItem emits
+ * `kennelTags: ["cch3-or", "oh3"]` → processRawEvents creates an Event
+ * with the primary EventKennel (cch3-or) + a secondary co-host (oh3).
+ *
+ * Idempotent — cleans up the synthetic event at the end.
+ *
+ * Run: `npx tsx scripts/live-verify-multi-kennel-pattern.ts`
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { matchKennelPatterns, type KennelPattern } from "@/adapters/kennel-patterns";
+import { processRawEvents } from "@/pipeline/merge";
+
+const PROBE_TITLE = "PROBE: Cherry City H3 #1 / OH3 # 1340 (multi-kennel test)";
+
+async function main() {
+  // 1. Verify the helper produces the expected multi-kennel result for the
+  //    Oregon Calendar pattern shape.
+  const oregonPatterns: KennelPattern[] = [
+    ["(?:Cherry City.*OH3)|(?:OH3.*Cherry City)", ["cch3-or", "oh3"]],
+    ["^OH3\\b|OH3 Full Moon", "oh3"],
+    ["TGIF|Friday.*Pubcrawl", "tgif"],
+    ["Cherry City|Cherry Cherry City", "cch3-or"],
+  ];
+  const tags = matchKennelPatterns(PROBE_TITLE, oregonPatterns);
+  if (tags.length !== 2 || tags[0] !== "cch3-or" || tags[1] !== "oh3") {
+    throw new Error(`Helper returned wrong tags: ${JSON.stringify(tags)}`);
+  }
+  console.log(`Helper output: ${JSON.stringify(tags)} ✓`);
+
+  // 2. Find the cch3-or kennel + an existing source linked to both kennels.
+  const cch3 = await prisma.kennel.findFirst({ where: { kennelCode: "cch3-or" }, select: { id: true } });
+  const oh3 = await prisma.kennel.findFirst({ where: { kennelCode: "oh3" }, select: { id: true } });
+  if (!cch3 || !oh3) throw new Error("cch3-or or oh3 kennel missing from hashtracks_dev — bail");
+
+  const source = await prisma.source.findFirst({
+    where: { name: "Oregon Hashing Calendar" },
+    select: { id: true },
+  });
+  if (!source) throw new Error("Oregon Hashing Calendar source missing from hashtracks_dev — bail");
+
+  // Make sure both kennels are linked to the source (they should be).
+  await prisma.sourceKennel.upsert({
+    where: { sourceId_kennelId: { sourceId: source.id, kennelId: cch3.id } },
+    create: { sourceId: source.id, kennelId: cch3.id },
+    update: {},
+  });
+  await prisma.sourceKennel.upsert({
+    where: { sourceId_kennelId: { sourceId: source.id, kennelId: oh3.id } },
+    create: { sourceId: source.id, kennelId: oh3.id },
+    update: {},
+  });
+
+  // 3. Cleanup any prior probe state.
+  const stale = await prisma.event.findMany({ where: { title: PROBE_TITLE }, select: { id: true } });
+  for (const e of stale) {
+    await prisma.eventKennel.deleteMany({ where: { eventId: e.id } });
+    await prisma.rawEvent.deleteMany({ where: { eventId: e.id } });
+    await prisma.event.delete({ where: { id: e.id } });
+  }
+
+  // 4. Push a synthetic RawEventData through processRawEvents.
+  const result = await processRawEvents(source.id, [
+    {
+      date: "2099-07-12",
+      kennelTags: tags,
+      title: PROBE_TITLE,
+      runNumber: 1340,
+      sourceUrl: "https://example.com/probe",
+    },
+  ]);
+
+  if (result.created !== 1) {
+    throw new Error(`Expected created=1, got ${result.created}: ${JSON.stringify(result)}`);
+  }
+  console.log("processRawEvents created 1 event ✓");
+
+  // 5. Verify the resulting Event has both kennels as EventKennel rows.
+  const event = await prisma.event.findFirst({
+    where: { title: PROBE_TITLE },
+    include: { eventKennels: { select: { kennelId: true, isPrimary: true } } },
+  });
+  if (!event) throw new Error("Expected Event row not found");
+
+  const eks = event.eventKennels;
+  console.log(`Event ${event.id} has ${eks.length} EventKennel rows`);
+
+  const primaryRow = eks.find((r) => r.isPrimary);
+  const coHostRows = eks.filter((r) => !r.isPrimary);
+
+  if (!primaryRow) throw new Error("No primary EventKennel row");
+  if (primaryRow.kennelId !== cch3.id) {
+    throw new Error(`Primary kennel is ${primaryRow.kennelId}, expected cch3-or (${cch3.id})`);
+  }
+  console.log("Primary EventKennel = cch3-or ✓");
+
+  if (coHostRows.length !== 1) {
+    throw new Error(`Expected 1 co-host row, got ${coHostRows.length}`);
+  }
+  if (coHostRows[0].kennelId !== oh3.id) {
+    throw new Error(`Co-host kennel is ${coHostRows[0].kennelId}, expected oh3 (${oh3.id})`);
+  }
+  console.log("Co-host EventKennel = oh3 (isPrimary=false) ✓");
+
+  if (event.kennelId !== cch3.id) {
+    throw new Error(`Denorm Event.kennelId = ${event.kennelId}, expected cch3-or`);
+  }
+  console.log("Denorm Event.kennelId = cch3-or ✓");
+
+  // 6. Cleanup.
+  await prisma.eventKennel.deleteMany({ where: { eventId: event.id } });
+  await prisma.rawEvent.deleteMany({ where: { eventId: event.id } });
+  await prisma.event.delete({ where: { id: event.id } });
+  console.log("Cleanup OK");
+
+  console.log("\nMulti-kennel pattern end-to-end ✓");
+}
+
+main()
+  .catch((err) => {
+    console.error("\nMulti-kennel verification failed:");
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/live-verify-multi-kennel-pattern.ts
+++ b/scripts/live-verify-multi-kennel-pattern.ts
@@ -15,13 +15,28 @@ import { matchKennelPatterns, type KennelPattern } from "@/adapters/kennel-patte
 import { processRawEvents } from "@/pipeline/merge";
 
 const PROBE_TITLE = "PROBE: Cherry City H3 #1 / OH3 # 1340 (multi-kennel test)";
+const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "0.0.0.0", "host.docker.internal", "postgres", "db"]);
+
+/** Refuse to run against any DATABASE_URL whose host isn't on the local-safe
+ *  allowlist. Mirrors `scripts/safe-prisma.mjs`. Belt-and-suspenders so a
+ *  mispointed DATABASE_URL can't turn a smoke-test into a prod write. */
+function assertLocalDb(): void {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL not set");
+  const host = new URL(url.replace(/^postgresql:/, "http:")).hostname;
+  if (!LOCAL_DB_HOSTS.has(host)) {
+    throw new Error(`Refusing to run live verification against non-local host ${host}. Set DATABASE_URL to hashtracks_dev.`);
+  }
+}
 
 async function main() {
+  assertLocalDb();
+
   // 1. Verify the helper produces the expected multi-kennel result for the
-  //    Oregon Calendar pattern shape.
+  //    Oregon Calendar pattern shape. String.raw avoids escaping the `\b`.
   const oregonPatterns: KennelPattern[] = [
     ["(?:Cherry City.*OH3)|(?:OH3.*Cherry City)", ["cch3-or", "oh3"]],
-    ["^OH3\\b|OH3 Full Moon", "oh3"],
+    [String.raw`^OH3\b|OH3 Full Moon`, "oh3"],
     ["TGIF|Friday.*Pubcrawl", "tgif"],
     ["Cherry City|Cherry Cherry City", "cch3-or"],
   ];
@@ -42,17 +57,21 @@ async function main() {
   });
   if (!source) throw new Error("Oregon Hashing Calendar source missing from hashtracks_dev — bail");
 
-  // Make sure both kennels are linked to the source (they should be).
-  await prisma.sourceKennel.upsert({
-    where: { sourceId_kennelId: { sourceId: source.id, kennelId: cch3.id } },
-    create: { sourceId: source.id, kennelId: cch3.id },
-    update: {},
-  });
-  await prisma.sourceKennel.upsert({
-    where: { sourceId_kennelId: { sourceId: source.id, kennelId: oh3.id } },
-    create: { sourceId: source.id, kennelId: oh3.id },
-    update: {},
-  });
+  // Track newly-created links so finally{} can revert them on failure
+  // (we don't want a panicked smoke-test to leave a SourceKennel row that
+  // would re-authorize this source for ingestion later).
+  const createdLinks: Array<{ sourceId: string; kennelId: string }> = [];
+  const ensureLinked = async (kennelId: string) => {
+    const existing = await prisma.sourceKennel.findUnique({
+      where: { sourceId_kennelId: { sourceId: source.id, kennelId } },
+    });
+    if (!existing) {
+      await prisma.sourceKennel.create({ data: { sourceId: source.id, kennelId } });
+      createdLinks.push({ sourceId: source.id, kennelId });
+    }
+  };
+  await ensureLinked(cch3.id);
+  await ensureLinked(oh3.id);
 
   // 3. Cleanup any prior probe state.
   const stale = await prisma.event.findMany({ where: { title: PROBE_TITLE }, select: { id: true } });
@@ -62,59 +81,71 @@ async function main() {
     await prisma.event.delete({ where: { id: e.id } });
   }
 
-  // 4. Push a synthetic RawEventData through processRawEvents.
-  const result = await processRawEvents(source.id, [
-    {
-      date: "2099-07-12",
-      kennelTags: tags,
-      title: PROBE_TITLE,
-      runNumber: 1340,
-      sourceUrl: "https://example.com/probe",
-    },
-  ]);
+  let createdEventId: string | null = null;
+  try {
+    // 4. Push a synthetic RawEventData through processRawEvents.
+    const result = await processRawEvents(source.id, [
+      {
+        date: "2099-07-12",
+        kennelTags: tags,
+        title: PROBE_TITLE,
+        runNumber: 1340,
+        sourceUrl: "https://example.com/probe",
+      },
+    ]);
 
-  if (result.created !== 1) {
-    throw new Error(`Expected created=1, got ${result.created}: ${JSON.stringify(result)}`);
+    if (result.created !== 1) {
+      throw new Error(`Expected created=1, got ${result.created}: ${JSON.stringify(result)}`);
+    }
+    console.log("processRawEvents created 1 event ✓");
+
+    // 5. Verify the resulting Event has both kennels as EventKennel rows.
+    const event = await prisma.event.findFirst({
+      where: { title: PROBE_TITLE },
+      include: { eventKennels: { select: { kennelId: true, isPrimary: true } } },
+    });
+    if (!event) throw new Error("Expected Event row not found");
+    createdEventId = event.id;
+
+    const eks = event.eventKennels;
+    console.log(`Event ${event.id} has ${eks.length} EventKennel rows`);
+
+    const primaryRow = eks.find((r) => r.isPrimary);
+    const coHostRows = eks.filter((r) => !r.isPrimary);
+
+    if (!primaryRow) throw new Error("No primary EventKennel row");
+    if (primaryRow.kennelId !== cch3.id) {
+      throw new Error(`Primary kennel is ${primaryRow.kennelId}, expected cch3-or (${cch3.id})`);
+    }
+    console.log("Primary EventKennel = cch3-or ✓");
+
+    if (coHostRows.length !== 1) {
+      throw new Error(`Expected 1 co-host row, got ${coHostRows.length}`);
+    }
+    if (coHostRows[0].kennelId !== oh3.id) {
+      throw new Error(`Co-host kennel is ${coHostRows[0].kennelId}, expected oh3 (${oh3.id})`);
+    }
+    console.log("Co-host EventKennel = oh3 (isPrimary=false) ✓");
+
+    if (event.kennelId !== cch3.id) {
+      throw new Error(`Denorm Event.kennelId = ${event.kennelId}, expected cch3-or`);
+    }
+    console.log("Denorm Event.kennelId = cch3-or ✓");
+  } finally {
+    // Cleanup runs unconditionally so a failed assertion can't leave the
+    // synthetic event or the (re-)created SourceKennel links behind.
+    if (createdEventId) {
+      await prisma.eventKennel.deleteMany({ where: { eventId: createdEventId } });
+      await prisma.rawEvent.deleteMany({ where: { eventId: createdEventId } });
+      await prisma.event.delete({ where: { id: createdEventId } }).catch(() => {});
+    }
+    for (const link of createdLinks) {
+      await prisma.sourceKennel.delete({
+        where: { sourceId_kennelId: link },
+      }).catch(() => {});
+    }
+    console.log("Cleanup OK");
   }
-  console.log("processRawEvents created 1 event ✓");
-
-  // 5. Verify the resulting Event has both kennels as EventKennel rows.
-  const event = await prisma.event.findFirst({
-    where: { title: PROBE_TITLE },
-    include: { eventKennels: { select: { kennelId: true, isPrimary: true } } },
-  });
-  if (!event) throw new Error("Expected Event row not found");
-
-  const eks = event.eventKennels;
-  console.log(`Event ${event.id} has ${eks.length} EventKennel rows`);
-
-  const primaryRow = eks.find((r) => r.isPrimary);
-  const coHostRows = eks.filter((r) => !r.isPrimary);
-
-  if (!primaryRow) throw new Error("No primary EventKennel row");
-  if (primaryRow.kennelId !== cch3.id) {
-    throw new Error(`Primary kennel is ${primaryRow.kennelId}, expected cch3-or (${cch3.id})`);
-  }
-  console.log("Primary EventKennel = cch3-or ✓");
-
-  if (coHostRows.length !== 1) {
-    throw new Error(`Expected 1 co-host row, got ${coHostRows.length}`);
-  }
-  if (coHostRows[0].kennelId !== oh3.id) {
-    throw new Error(`Co-host kennel is ${coHostRows[0].kennelId}, expected oh3 (${oh3.id})`);
-  }
-  console.log("Co-host EventKennel = oh3 (isPrimary=false) ✓");
-
-  if (event.kennelId !== cch3.id) {
-    throw new Error(`Denorm Event.kennelId = ${event.kennelId}, expected cch3-or`);
-  }
-  console.log("Denorm Event.kennelId = cch3-or ✓");
-
-  // 6. Cleanup.
-  await prisma.eventKennel.deleteMany({ where: { eventId: event.id } });
-  await prisma.rawEvent.deleteMany({ where: { eventId: event.id } });
-  await prisma.event.delete({ where: { id: event.id } });
-  console.log("Cleanup OK");
 
   console.log("\nMulti-kennel pattern end-to-end ✓");
 }

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -95,6 +95,52 @@ describe("Colorado H3 Aggregator multi-kennel routing (#850)", () => {
   });
 });
 
+// ── Oregon Hashing Calendar multi-kennel co-host pattern (#1023 step 4 / #991) ──
+
+describe("Oregon Hashing Calendar multi-kennel routing (#1023 step 4)", () => {
+  const oregonSource = SOURCES.find((s) => s.name === "Oregon Hashing Calendar");
+  if (!oregonSource?.config) throw new Error("Oregon Hashing Calendar seed config missing");
+  const config = oregonSource.config as { kennelPatterns: [string, string | string[]][]; defaultKennelTag: string };
+
+  it("emits BOTH kennels when title mentions Cherry City + OH3 (the joint inaugural — #991)", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Cherry City H3 #1 / OH3 # 1340",
+        start: { dateTime: "2025-07-12T18:30:00-07:00" },
+        status: "confirmed",
+      },
+      config,
+    );
+    // Multi-kennel pattern fires before the single-tag patterns and
+    // returns both as co-hosts.
+    expect(result?.kennelTags).toEqual(["cch3-or", "oh3"]);
+  });
+
+  it("emits a single tag for OH3-only titles (single-tag pattern still wins)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "OH3 #1342: Wednesday Trail", start: { dateTime: "2025-07-23T18:30:00-07:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual(["oh3"]);
+  });
+
+  it("emits a single tag for Cherry City-only titles", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Cherry City H3 #2", start: { dateTime: "2025-08-10T18:30:00-07:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual(["cch3-or"]);
+  });
+
+  it("emits a single tag for TGIF-only titles", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "TGIF Pubcrawl", start: { dateTime: "2025-08-15T18:30:00-07:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual(["tgif"]);
+  });
+});
+
 // ── GCal adapter with no config returns empty tag (no Boston fallback) ──
 
 describe("resolveKennelTagFromSummary with no config", () => {

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -681,10 +681,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         description: "MAP: https://maps.app.goo.gl/bPryrj1CNfrg6kxQ7\nA to B, Dog Friendly",
         location: "12017 Amherst Dr, Austin, TX 78759, USA",
       }),
-      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` },
-      undefined, undefined, undefined,
-      titleHareRE,
-    );
+      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePattern: titleHareRE });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Baba Gagush & Crusty Beaver");
     expect(result!.title).toBe("AH3 #2269");
@@ -701,10 +698,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         summary: "AH3 #1833 - Manoa Valley District Park - International Dicklomat",
         start: { dateTime: "2026-04-18T14:00:00-10:00" },
       }),
-      { defaultKennelTag: "ah3-hi", titleHarePattern: String.raw`^AH3\s*#\d+.*-\s+(.+)$` },
-      undefined, undefined, undefined,
-      suffixRE,
-    );
+      { defaultKennelTag: "ah3-hi", titleHarePattern: String.raw`^AH3\s*#\d+.*-\s+(.+)$` }, { compiledTitleHarePattern: suffixRE });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("International Dicklomat");
     expect(result!.title).toBe("AH3 #1833 - Manoa Valley District Park");
@@ -718,10 +712,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         summary: "AH3 #1828 - **EARLY START** - Kailua District Park - Green Machine",
         start: { dateTime: "2026-03-14T10:00:00-10:00" },
       }),
-      { defaultKennelTag: "ah3-hi", titleHarePattern: String.raw`^AH3\s*#\d+.*-\s+(.+)$` },
-      undefined, undefined, undefined,
-      suffixRE,
-    );
+      { defaultKennelTag: "ah3-hi", titleHarePattern: String.raw`^AH3\s*#\d+.*-\s+(.+)$` }, { compiledTitleHarePattern: suffixRE });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Green Machine");
     expect(result!.title).toBe("AH3 #1828 - **EARLY START** - Kailua District Park");
@@ -737,10 +728,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         summary: "Alice AH3 #2269 - Event with Alice",
         start: { dateTime: "2026-04-18T14:00:00-05:00" },
       }),
-      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` },
-      undefined, undefined, undefined,
-      prefixRE,
-    );
+      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePattern: prefixRE });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Alice");
     // Title should strip from the front, not the back
@@ -757,10 +745,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         summary: "SH3 #880 Hare: Kiss Me- Degerloch",
         start: { dateTime: "2026-04-19T12:00:00+02:00" },
       }),
-      { defaultKennelTag: "sh3-de", titleHarePattern: String.raw`Hare:\s+(.+?)(?=-\s+\S)` },
-      undefined, undefined, undefined,
-      midRE,
-    );
+      { defaultKennelTag: "sh3-de", titleHarePattern: String.raw`Hare:\s+(.+?)(?=-\s+\S)` }, { compiledTitleHarePattern: midRE });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Kiss Me");
     expect(result!.title).toBe("SH3 #880 - Degerloch");
@@ -778,10 +763,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
       {
         defaultKennelTag: "sh3-de",
         titleHarePattern: String.raw`Hare:?\s+(.+?)(?:(?=[-\u2013\u2014]\s*\S)|\s*$)`,
-      },
-      undefined, undefined, undefined,
-      pattern,
-    );
+      }, { compiledTitleHarePattern: pattern });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Kiss Me");
     expect(result!.title).toBe("SH3 #881 — Degerloch");
@@ -801,10 +783,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
       {
         defaultKennelTag: "ah3-hi",
         titleHarePattern: String.raw`Hare:\s+(.+?)(?:\s*$)`,
-      },
-      undefined, undefined, undefined,
-      pattern,
-    );
+      }, { compiledTitleHarePattern: pattern });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("AH3");
     expect(result!.title).toBe("AH3 #880");
@@ -817,10 +796,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         start: { dateTime: "2026-04-05T14:00:00-05:00" },
         description: "Hare: Actual Hare Name\nDetails here",
       }),
-      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` },
-      undefined, undefined, undefined,
-      titleHareRE,
-    );
+      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePattern: titleHareRE });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Actual Hare Name");
     // Title should NOT be stripped when hares came from description
@@ -1000,11 +976,7 @@ describe("buildRawEventFromGCalItem — skipPatterns", () => {
     const skipPatterns = [/BFM|Ben Franklin/i];
     const result = buildRawEventFromGCalItem(
       baseItem,
-      { defaultKennelTag: "philly-h3" },
-      undefined,
-      undefined,
-      skipPatterns,
-    );
+      { defaultKennelTag: "philly-h3" }, { compiledSkipPatterns: skipPatterns });
     expect(result).toBeNull();
   });
 
@@ -1012,11 +984,7 @@ describe("buildRawEventFromGCalItem — skipPatterns", () => {
     const skipPatterns = [/BFM|Ben Franklin/i];
     const result = buildRawEventFromGCalItem(
       { ...baseItem, summary: "Philly Hash Weekly Run" },
-      { defaultKennelTag: "philly-h3" },
-      undefined,
-      undefined,
-      skipPatterns,
-    );
+      { defaultKennelTag: "philly-h3" }, { compiledSkipPatterns: skipPatterns });
     expect(result).not.toBeNull();
     expect(result!.kennelTags[0]).toBe("philly-h3");
   });
@@ -1025,9 +993,7 @@ describe("buildRawEventFromGCalItem — skipPatterns", () => {
     const result = buildRawEventFromGCalItem(
       baseItem,
       { defaultKennelTag: "TEST" },
-      undefined,
-      undefined,
-      [],
+      { compiledSkipPatterns: [] },
     );
     expect(result).not.toBeNull();
   });
@@ -1042,33 +1008,21 @@ describe("buildRawEventFromGCalItem — skipPatterns", () => {
     it("drops a pure BFM-titled event from the Philly calendar", () => {
       const result = buildRawEventFromGCalItem(
         { ...baseItem, summary: "Ben Franklin Mob H3" },
-        { defaultKennelTag: "philly-h3" },
-        undefined,
-        undefined,
-        PHILLY_SKIP,
-      );
+        { defaultKennelTag: "philly-h3" }, { compiledSkipPatterns: PHILLY_SKIP });
       expect(result).toBeNull();
     });
 
     it("drops a 'BFM #123' prefixed event from the Philly calendar", () => {
       const result = buildRawEventFromGCalItem(
         { ...baseItem, summary: "BFM #1234: Trail Name" },
-        { defaultKennelTag: "philly-h3" },
-        undefined,
-        undefined,
-        PHILLY_SKIP,
-      );
+        { defaultKennelTag: "philly-h3" }, { compiledSkipPatterns: PHILLY_SKIP });
       expect(result).toBeNull();
     });
 
     it("KEEPS a mixed-title joint event under Philly H3 (co-host, not BFM-only)", () => {
       const result = buildRawEventFromGCalItem(
         { ...baseItem, summary: "Philly H3 & BFM joint co-host trail" },
-        { defaultKennelTag: "philly-h3" },
-        undefined,
-        undefined,
-        PHILLY_SKIP,
-      );
+        { defaultKennelTag: "philly-h3" }, { compiledSkipPatterns: PHILLY_SKIP });
       expect(result).not.toBeNull();
       expect(result!.kennelTags[0]).toBe("philly-h3");
     });
@@ -1076,33 +1030,21 @@ describe("buildRawEventFromGCalItem — skipPatterns", () => {
     it("drops a pure N2H3-titled event from the Oregon calendar", () => {
       const result = buildRawEventFromGCalItem(
         { ...baseItem, summary: "N2H3 #769 The Matzo Ball Hash!" },
-        { defaultKennelTag: "oh3" },
-        undefined,
-        undefined,
-        OREGON_SKIP,
-      );
+        { defaultKennelTag: "oh3" }, { compiledSkipPatterns: OREGON_SKIP });
       expect(result).toBeNull();
     });
 
     it("drops an NNH3-prefixed event from the Oregon calendar", () => {
       const result = buildRawEventFromGCalItem(
         { ...baseItem, summary: "NNH3 #769 The Matzo Ball Hash!" },
-        { defaultKennelTag: "oh3" },
-        undefined,
-        undefined,
-        OREGON_SKIP,
-      );
+        { defaultKennelTag: "oh3" }, { compiledSkipPatterns: OREGON_SKIP });
       expect(result).toBeNull();
     });
 
     it("KEEPS an OH3 event whose description mentions N2H3 (e.g. meetup reference)", () => {
       const result = buildRawEventFromGCalItem(
         { ...baseItem, summary: "OH3 #1500 — meet at the No Name H3 bar" },
-        { defaultKennelTag: "oh3" },
-        undefined,
-        undefined,
-        OREGON_SKIP,
-      );
+        { defaultKennelTag: "oh3" }, { compiledSkipPatterns: OREGON_SKIP });
       expect(result).not.toBeNull();
       expect(result!.kennelTags[0]).toBe("oh3");
     });
@@ -1792,7 +1734,7 @@ describe("buildRawEventFromGCalItem — 4X2H4 stale-default title fix (#496/#497
   it("extracts the run number from the description via runNumberPatterns", () => {
     // Caller (the adapter) pre-compiles patterns once per scrape and threads them in.
     const compiledRunNumberPatterns = [/What:\s*4x2\s*H4\s*No\.?\s*(\d+)/i];
-    const event = buildRawEventFromGCalItem(item, config, undefined, compiledRunNumberPatterns);
+    const event = buildRawEventFromGCalItem(item, config, { compiledRunNumberPatterns });
     expect(event!.runNumber).toBe(124);
   });
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -2,7 +2,7 @@ import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
 import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, HARE_BOILERPLATE_RE, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry } from "../utils";
-import { matchKennelPatterns, type KennelPattern } from "../kennel-patterns";
+import { matchKennelPatterns, matchCompiledKennelPatterns, compileKennelPatterns, type KennelPattern, type CompiledKennelPattern } from "../kennel-patterns";
 import { PHONE_NUMBER_RE, LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 
 /**
@@ -537,12 +537,17 @@ interface CalendarSourceConfig {
 }
 
 /**
- * Match event summary against config-driven kennel patterns.
- * Returns resolved kennel tags per the spec §2 D15 precedence rules
- * (see `src/adapters/kennel-patterns.ts`). Always returns an array;
- * empty when nothing matched.
+ * Match event summary against kennel patterns. Prefers pre-compiled patterns
+ * (the hot path during a scrape) and falls back to compile-per-call for
+ * direct test invocations. Always returns an array; see
+ * `src/adapters/kennel-patterns.ts` for precedence rules.
  */
-function matchConfigPatterns(summary: string, patterns: KennelPattern[]): string[] {
+function matchConfigPatterns(
+  summary: string,
+  patterns: KennelPattern[],
+  compiled?: CompiledKennelPattern[],
+): string[] {
+  if (compiled) return matchCompiledKennelPatterns(summary, compiled);
   return matchKennelPatterns(summary, patterns);
 }
 
@@ -628,9 +633,10 @@ export function normalizeGCalDescription(rawDesc: string | undefined): { rawDesc
 function resolveKennelTagFromSummary(
   summary: string,
   sourceConfig: CalendarSourceConfig | null,
+  compiledKennelPatterns?: CompiledKennelPattern[],
 ): { kennelTags: string[]; useFullTitle: boolean } | null {
   if (sourceConfig?.kennelPatterns) {
-    const matched = matchConfigPatterns(summary, sourceConfig.kennelPatterns);
+    const matched = matchConfigPatterns(summary, sourceConfig.kennelPatterns, compiledKennelPatterns);
     if (matched.length > 0) return { kennelTags: matched, useFullTitle: true };
     if (sourceConfig.strictKennelRouting) return null;
     return { kennelTags: [sourceConfig.defaultKennelTag ?? summary], useFullTitle: true };
@@ -660,6 +666,9 @@ export function buildRawEventFromGCalItem(
   // dedup at the end of `fetch` can use stable GCal ids without changing the
   // public RawEventData shape.
   gcalIdMap?: WeakMap<RawEventData, string>,
+  // Pre-compiled kennelPatterns. Optional for direct test invocations; the
+  // production fetch loop passes this so we don't re-compile every event.
+  compiledKennelPatterns?: CompiledKennelPattern[],
 ): RawEventData | null {
   if (item.status === "cancelled") return null;
   if (!item.summary) return null;
@@ -707,7 +716,7 @@ export function buildRawEventFromGCalItem(
       haresFromTitle = !!hares;
     }
   }
-  const resolved = resolveKennelTagFromSummary(summary, sourceConfig);
+  const resolved = resolveKennelTagFromSummary(summary, sourceConfig, compiledKennelPatterns);
   if (!resolved) return null;
   const { kennelTags, useFullTitle } = resolved;
   // The first resolved tag is the primary kennel for routing/title fallback
@@ -911,7 +920,7 @@ export function buildRawEventFromGCalItem(
     const prefixMatchesKennel = !!prefix && (
       titleMatchesKennelTag(prefix, kennelTag)
       || (sourceConfig?.kennelPatterns
-        ? matchConfigPatterns(prefix, sourceConfig.kennelPatterns).includes(kennelTag)
+        ? matchConfigPatterns(prefix, sourceConfig.kennelPatterns, compiledKennelPatterns).includes(kennelTag)
         : false)
     );
     if (bareKennelRunMatch && prefixMatchesKennel) {
@@ -1023,6 +1032,9 @@ export class GoogleCalendarAdapter implements SourceAdapter {
     const compiledTitleHarePattern = sourceConfig?.titleHarePattern
       ? compilePatterns([sourceConfig.titleHarePattern], "i")[0]
       : undefined;
+    const compiledKennelPatterns = sourceConfig?.kennelPatterns?.length
+      ? compileKennelPatterns(sourceConfig.kennelPatterns)
+      : undefined;
     const gcalIdMap = new WeakMap<RawEventData, string>();
 
     const buildEvents = (items: GCalEvent[], filter?: (item: GCalEvent) => boolean): void => {
@@ -1037,7 +1049,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
             item, sourceConfig,
             compiledHarePatterns, compiledRunNumberPatterns,
             compiledSkipPatterns, compiledTitleHarePattern,
-            gcalIdMap,
+            gcalIdMap, compiledKennelPatterns,
           );
           if (event) events.push(event);
         } catch (err) {

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -654,22 +654,38 @@ function parseCalendarSourceConfig(config: unknown): CalendarSourceConfig | null
     : null;
 }
 
+/** Optional pre-compiled patterns + tracking map plumbed through the
+ *  fetch loop. Bundled into one options object to keep
+ *  buildRawEventFromGCalItem within the function-arity limit. Direct
+ *  test invocations can omit this entirely. */
+export interface BuildRawEventFromGCalItemOptions {
+  compiledHarePatterns?: RegExp[];
+  compiledRunNumberPatterns?: RegExp[];
+  compiledSkipPatterns?: RegExp[];
+  compiledTitleHarePattern?: RegExp;
+  /** Pre-compiled kennelPatterns. Production fetch path passes this so
+   *  we don't re-compile every event; tests can omit. */
+  compiledKennelPatterns?: CompiledKennelPattern[];
+  /** id-tracking map; the adapter populates this so the cross-call
+   *  dedup at the end of `fetch` can use stable GCal ids without
+   *  changing the public RawEventData shape. */
+  gcalIdMap?: WeakMap<RawEventData, string>;
+}
+
 /** Build a RawEventData from a single Google Calendar event item. Returns null if the item should be skipped. */
 export function buildRawEventFromGCalItem(
   item: GCalEvent,
   sourceConfig: CalendarSourceConfig | null,
-  compiledHarePatterns?: RegExp[],
-  compiledRunNumberPatterns?: RegExp[],
-  compiledSkipPatterns?: RegExp[],
-  compiledTitleHarePattern?: RegExp,
-  // Optional id-tracking map. The adapter populates this so the cross-call
-  // dedup at the end of `fetch` can use stable GCal ids without changing the
-  // public RawEventData shape.
-  gcalIdMap?: WeakMap<RawEventData, string>,
-  // Pre-compiled kennelPatterns. Optional for direct test invocations; the
-  // production fetch loop passes this so we don't re-compile every event.
-  compiledKennelPatterns?: CompiledKennelPattern[],
+  options: BuildRawEventFromGCalItemOptions = {},
 ): RawEventData | null {
+  const {
+    compiledHarePatterns,
+    compiledRunNumberPatterns,
+    compiledSkipPatterns,
+    compiledTitleHarePattern,
+    compiledKennelPatterns,
+    gcalIdMap,
+  } = options;
   if (item.status === "cancelled") return null;
   if (!item.summary) return null;
   if (!item.start?.dateTime && !item.start?.date) return null;
@@ -1045,12 +1061,14 @@ export class GoogleCalendarAdapter implements SourceAdapter {
           continue;
         }
         try {
-          const event = buildRawEventFromGCalItem(
-            item, sourceConfig,
-            compiledHarePatterns, compiledRunNumberPatterns,
-            compiledSkipPatterns, compiledTitleHarePattern,
-            gcalIdMap, compiledKennelPatterns,
-          );
+          const event = buildRawEventFromGCalItem(item, sourceConfig, {
+            compiledHarePatterns,
+            compiledRunNumberPatterns,
+            compiledSkipPatterns,
+            compiledTitleHarePattern,
+            compiledKennelPatterns,
+            gcalIdMap,
+          });
           if (event) events.push(event);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -2,6 +2,7 @@ import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
 import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, HARE_BOILERPLATE_RE, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry } from "../utils";
+import { matchKennelPatterns, type KennelPattern } from "../kennel-patterns";
 import { PHONE_NUMBER_RE, LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 
 /**
@@ -490,7 +491,13 @@ function isNonAddressText(text: string): boolean {
 
 /** Config shape for Google Calendar sources */
 interface CalendarSourceConfig {
-  kennelPatterns?: [string, string][];  // [[regex, kennelTag], ...]
+  /**
+   * Per-event kennel routing. Each entry is `[regex, kennelTag | kennelTag[]]`.
+   * Single-tag (string) entries preserve legacy first-match-wins behavior.
+   * Array entries declare a true multi-kennel co-host (#1023 step 4); see
+   * `src/adapters/kennel-patterns.ts` for the full precedence rules.
+   */
+  kennelPatterns?: KennelPattern[];
   defaultKennelTag?: string;            // fallback for unrecognized events
   /**
    * When true on a multi-kennel calendar (one with `kennelPatterns`), a summary
@@ -531,17 +538,12 @@ interface CalendarSourceConfig {
 
 /**
  * Match event summary against config-driven kennel patterns.
- * Returns the kennel tag for the first matching pattern, or null.
+ * Returns resolved kennel tags per the spec §2 D15 precedence rules
+ * (see `src/adapters/kennel-patterns.ts`). Always returns an array;
+ * empty when nothing matched.
  */
-function matchConfigPatterns(summary: string, patterns: [string, string][]): string | null {
-  for (const [regex, tag] of patterns) {
-    try {
-      if (new RegExp(regex, "i").test(summary)) return tag;
-    } catch {
-      // Skip malformed patterns from source config
-    }
-  }
-  return null;
+function matchConfigPatterns(summary: string, patterns: KennelPattern[]): string[] {
+  return matchKennelPatterns(summary, patterns);
 }
 
 /** Subset of the Google Calendar API v3 event shape */
@@ -626,17 +628,17 @@ export function normalizeGCalDescription(rawDesc: string | undefined): { rawDesc
 function resolveKennelTagFromSummary(
   summary: string,
   sourceConfig: CalendarSourceConfig | null,
-): { kennelTag: string; useFullTitle: boolean } | null {
+): { kennelTags: string[]; useFullTitle: boolean } | null {
   if (sourceConfig?.kennelPatterns) {
     const matched = matchConfigPatterns(summary, sourceConfig.kennelPatterns);
-    if (matched) return { kennelTag: matched, useFullTitle: true };
+    if (matched.length > 0) return { kennelTags: matched, useFullTitle: true };
     if (sourceConfig.strictKennelRouting) return null;
-    return { kennelTag: sourceConfig.defaultKennelTag ?? summary, useFullTitle: true };
+    return { kennelTags: [sourceConfig.defaultKennelTag ?? summary], useFullTitle: true };
   }
   if (sourceConfig?.defaultKennelTag) {
-    return { kennelTag: sourceConfig.defaultKennelTag, useFullTitle: true };
+    return { kennelTags: [sourceConfig.defaultKennelTag], useFullTitle: true };
   }
-  return { kennelTag: summary, useFullTitle: true };
+  return { kennelTags: [summary], useFullTitle: true };
 }
 
 /** Parse source.config into CalendarSourceConfig or null. */
@@ -707,7 +709,11 @@ export function buildRawEventFromGCalItem(
   }
   const resolved = resolveKennelTagFromSummary(summary, sourceConfig);
   if (!resolved) return null;
-  const { kennelTag, useFullTitle } = resolved;
+  const { kennelTags, useFullTitle } = resolved;
+  // The first resolved tag is the primary kennel for routing/title fallback
+  // logic below. Co-host secondaries (#1023) ride along in `kennelTags` and
+  // are written to EventKennel rows by the merge pipeline.
+  const kennelTag = kennelTags[0];
   // Location: prefer item.location (unless placeholder or instruction text), fall back to description extraction.
   // #743: strip trailing phone numbers and contact-CTA parentheticals from the
   // raw GCal location field. Trailing only — a bare "1 800 ..." in the middle
@@ -905,7 +911,7 @@ export function buildRawEventFromGCalItem(
     const prefixMatchesKennel = !!prefix && (
       titleMatchesKennelTag(prefix, kennelTag)
       || (sourceConfig?.kennelPatterns
-        ? matchConfigPatterns(prefix, sourceConfig.kennelPatterns) === kennelTag
+        ? matchConfigPatterns(prefix, sourceConfig.kennelPatterns).includes(kennelTag)
         : false)
     );
     if (bareKennelRunMatch && prefixMatchesKennel) {
@@ -942,7 +948,9 @@ export function buildRawEventFromGCalItem(
   const cost = rawDescription ? extractCostFromDescription(rawDescription) : undefined;
   const event: RawEventData = {
     date: dateISO,
-    kennelTags: [kennelTag],
+    // Pass the full multi-kennel set (#1023): for single-tag patterns this
+    // is `[primary]`; for array patterns it's the union of all matched kennels.
+    kennelTags,
     runNumber: extractRunNumber(summary, rawDescription, compiledRunNumberPatterns),
     title,
     description: appendDescriptionSuffix(description, sourceConfig?.descriptionSuffix),

--- a/src/adapters/kennel-patterns.test.ts
+++ b/src/adapters/kennel-patterns.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { matchKennelPatterns, type KennelPattern } from "./kennel-patterns";
+
+describe("matchKennelPatterns (#1023 step 4)", () => {
+  describe("legacy string-only configs (no behavior change)", () => {
+    it("returns [firstMatch] for first matching string pattern", () => {
+      const patterns: KennelPattern[] = [
+        ["^Cherry City", "cch3-or"],
+        ["^OH3", "oh3"],
+      ];
+      expect(matchKennelPatterns("OH3 #1340", patterns)).toEqual(["oh3"]);
+    });
+
+    it("preserves first-match-wins ordering for overlapping single-tag patterns", () => {
+      // Mirrors the C2B3H4-vs-CH3 case in prisma/seed-data/sources.ts:296-299:
+      // a more specific kennel must come before a generic one.
+      const patterns: KennelPattern[] = [
+        ["C2B3H4", "c2b3h4"],
+        ["CH3", "ch3"],
+      ];
+      // Both patterns match this title; the first wins.
+      expect(matchKennelPatterns("C2B3H4 Special Run", patterns)).toEqual(["c2b3h4"]);
+      // Only the second matches this title.
+      expect(matchKennelPatterns("CH3 Tuesday", patterns)).toEqual(["ch3"]);
+    });
+
+    it("returns [] when no pattern matches", () => {
+      const patterns: KennelPattern[] = [["foo", "x"]];
+      expect(matchKennelPatterns("bar baz", patterns)).toEqual([]);
+    });
+
+    it("is case-insensitive", () => {
+      expect(matchKennelPatterns("oh3", [["^OH3", "oh3"]])).toEqual(["oh3"]);
+    });
+
+    it("skips malformed regex strings without throwing", () => {
+      const patterns: KennelPattern[] = [
+        ["[invalid(", "broken"],
+        ["valid", "good"],
+      ];
+      expect(matchKennelPatterns("valid input", patterns)).toEqual(["good"]);
+    });
+
+    it("returns [] for empty patterns", () => {
+      expect(matchKennelPatterns("anything", [])).toEqual([]);
+    });
+  });
+
+  describe("multi-kennel array patterns", () => {
+    it("returns the array contents when a single array pattern matches", () => {
+      const patterns: KennelPattern[] = [
+        ["Cherry City.*OH3|OH3.*Cherry City", ["cch3-or", "oh3"]],
+      ];
+      expect(matchKennelPatterns("Cherry City H3 #1 / OH3 # 1340", patterns))
+        .toEqual(["cch3-or", "oh3"]);
+    });
+
+    it("unions multiple matching array patterns deduplicated", () => {
+      const patterns: KennelPattern[] = [
+        ["Cherry City", ["cch3-or"]],
+        ["OH3", ["oh3", "cch3-or"]],
+      ];
+      // Both match; union = first-seen order
+      expect(matchKennelPatterns("Cherry City + OH3 trail", patterns))
+        .toEqual(["cch3-or", "oh3"]);
+    });
+  });
+
+  describe("mixed string + array patterns (precedence)", () => {
+    it("array match takes precedence — string match captured but discarded", () => {
+      const patterns: KennelPattern[] = [
+        ["^OH3", "oh3"], // string pattern matches first
+        ["Cherry City|OH3", ["cch3-or", "oh3"]], // array pattern matches too
+      ];
+      // String "oh3" was captured first, but array fires → array wins
+      expect(matchKennelPatterns("OH3 #1340", patterns))
+        .toEqual(["cch3-or", "oh3"]);
+    });
+
+    it("string match returns only when no array pattern fires", () => {
+      const patterns: KennelPattern[] = [
+        ["Cherry City.*OH3", ["cch3-or", "oh3"]], // array — doesn't match
+        ["^OH3", "oh3"], // string — matches
+      ];
+      expect(matchKennelPatterns("OH3 standalone", patterns)).toEqual(["oh3"]);
+    });
+
+    it("string match after an array match is ignored entirely", () => {
+      const patterns: KennelPattern[] = [
+        ["A", ["a-multi"]], // array fires
+        ["foo", "single-tag"], // string also fires — but array already won
+      ];
+      expect(matchKennelPatterns("A foo bar", patterns)).toEqual(["a-multi"]);
+    });
+  });
+});

--- a/src/adapters/kennel-patterns.test.ts
+++ b/src/adapters/kennel-patterns.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { matchKennelPatterns, type KennelPattern } from "./kennel-patterns";
 
 describe("matchKennelPatterns (#1023 step 4)", () => {

--- a/src/adapters/kennel-patterns.ts
+++ b/src/adapters/kennel-patterns.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared kennelPatterns config grammar + matcher (#1023 step 4).
+ *
+ * A pattern entry is a tuple of `[regexString, kennelTagOrTags]`. The tag
+ * value may be:
+ *   - a `string` — single-kennel routing, preserves the legacy first-match
+ *     behavior so existing single-tag configs are unaffected.
+ *   - a `string[]` — declares the regex legitimately tags multiple kennels
+ *     (a true co-host). Multi-kennel emission is opt-in per pattern; an
+ *     adapter author has to consciously promote a pattern to array form.
+ *
+ * Precedence (spec §2 D15):
+ *   1. If any array-typed pattern matches anywhere in the list, return the
+ *      union of all array values from matched entries (deduplicated, in
+ *      first-seen order).
+ *   2. Otherwise return `[firstStringMatch]` for the first matching string
+ *      pattern (legacy behavior preserved for string-only configs).
+ *   3. Otherwise return `[]`.
+ *
+ * Once any array pattern matches, subsequent string matches are advisory
+ * only — they do NOT contribute to the result. This keeps the routing
+ * deterministic when a source author intentionally promotes one pattern
+ * to array form.
+ */
+
+export type KennelPatternValue = string | string[];
+
+/**
+ * One kennelPatterns entry: regex string + tag value. Stored as a tuple in
+ * source.config so the order is preserved through JSON round-trips.
+ */
+export type KennelPattern = readonly [string, KennelPatternValue];
+
+/**
+ * Match `text` against the configured patterns and return the resolved
+ * kennel tags per the precedence rules above. Always returns an array;
+ * empty when nothing matched.
+ *
+ * Malformed regex strings from source config are skipped silently.
+ */
+export function matchKennelPatterns(
+  text: string,
+  patterns: readonly KennelPattern[],
+): string[] {
+  let arrayMatches: string[] | null = null;
+  let firstStringMatch: string | null = null;
+
+  for (const [regex, value] of patterns) {
+    let matched: boolean;
+    try {
+      matched = new RegExp(regex, "i").test(text);
+    } catch {
+      continue;
+    }
+    if (!matched) continue;
+
+    if (Array.isArray(value)) {
+      arrayMatches ??= [];
+      for (const tag of value) {
+        if (!arrayMatches.includes(tag)) arrayMatches.push(tag);
+      }
+    } else if (firstStringMatch === null && arrayMatches === null) {
+      firstStringMatch = value;
+    }
+  }
+
+  if (arrayMatches !== null) return arrayMatches;
+  if (firstStringMatch !== null) return [firstStringMatch];
+  return [];
+}

--- a/src/adapters/kennel-patterns.ts
+++ b/src/adapters/kennel-patterns.ts
@@ -40,8 +40,14 @@ export type KennelPattern = readonly [string, KennelPatternValue];
  */
 export type CompiledKennelPattern = readonly [RegExp, KennelPatternValue];
 
+import { compilePatterns } from "./utils";
+
 /**
  * Compile a list of source-config kennel patterns into runtime form.
+ * Delegates regex construction to `compilePatterns` (the canonical site
+ * for `new RegExp(...)` in the adapter layer — patterns are pre-validated
+ * via safe-regex2 in `config-validation.ts` before reaching here).
+ *
  * Malformed regex strings are dropped (with `console.warn`) so a single
  * bad config entry doesn't kill the whole scrape.
  */
@@ -49,14 +55,12 @@ export function compileKennelPatterns(
   patterns: readonly KennelPattern[],
 ): CompiledKennelPattern[] {
   const compiled: CompiledKennelPattern[] = [];
-  for (const [regex, value] of patterns) {
-    try {
-      // nosemgrep: detect-non-literal-regexp — patterns are pre-validated via safe-regex2 in config-validation.ts
-      compiled.push([new RegExp(regex, "i"), value]); // NOSONAR
-    } catch (err) {
-      console.warn(
-        `[kennel-patterns] Skipping malformed regex ${JSON.stringify(regex)}: ${(err as Error).message}`,
-      );
+  for (const [regexStr, value] of patterns) {
+    const [regex] = compilePatterns([regexStr], "i");
+    if (regex) {
+      compiled.push([regex, value]);
+    } else {
+      console.warn(`[kennel-patterns] Skipping malformed regex ${JSON.stringify(regexStr)}`);
     }
   }
   return compiled;

--- a/src/adapters/kennel-patterns.ts
+++ b/src/adapters/kennel-patterns.ts
@@ -51,7 +51,8 @@ export function compileKennelPatterns(
   const compiled: CompiledKennelPattern[] = [];
   for (const [regex, value] of patterns) {
     try {
-      compiled.push([new RegExp(regex, "i"), value]);
+      // nosemgrep: detect-non-literal-regexp — patterns are pre-validated via safe-regex2 in config-validation.ts
+      compiled.push([new RegExp(regex, "i"), value]); // NOSONAR
     } catch (err) {
       console.warn(
         `[kennel-patterns] Skipping malformed regex ${JSON.stringify(regex)}: ${(err as Error).message}`,

--- a/src/adapters/kennel-patterns.ts
+++ b/src/adapters/kennel-patterns.ts
@@ -32,39 +32,79 @@ export type KennelPatternValue = string | string[];
 export type KennelPattern = readonly [string, KennelPatternValue];
 
 /**
- * Match `text` against the configured patterns and return the resolved
- * kennel tags per the precedence rules above. Always returns an array;
- * empty when nothing matched.
- *
- * Malformed regex strings from source config are skipped silently.
+ * Pre-compiled form of `KennelPattern`. Adapters that match the same
+ * patterns against many events per scrape should compile once via
+ * `compileKennelPatterns()` and pass the result to
+ * `matchCompiledKennelPatterns()` to avoid `new RegExp(...)` overhead per
+ * event.
+ */
+export type CompiledKennelPattern = readonly [RegExp, KennelPatternValue];
+
+/**
+ * Compile a list of source-config kennel patterns into runtime form.
+ * Malformed regex strings are dropped (with `console.warn`) so a single
+ * bad config entry doesn't kill the whole scrape.
+ */
+export function compileKennelPatterns(
+  patterns: readonly KennelPattern[],
+): CompiledKennelPattern[] {
+  const compiled: CompiledKennelPattern[] = [];
+  for (const [regex, value] of patterns) {
+    try {
+      compiled.push([new RegExp(regex, "i"), value]);
+    } catch (err) {
+      console.warn(
+        `[kennel-patterns] Skipping malformed regex ${JSON.stringify(regex)}: ${(err as Error).message}`,
+      );
+    }
+  }
+  return compiled;
+}
+
+/** Update accumulator state for a single matched pattern (extracted to keep
+ *  the matcher's cognitive complexity below SonarCloud's threshold). */
+function applyMatch(
+  value: KennelPatternValue,
+  acc: { arrayMatches: string[] | null; firstStringMatch: string | null },
+): void {
+  if (Array.isArray(value)) {
+    acc.arrayMatches ??= [];
+    for (const tag of value) {
+      if (!acc.arrayMatches.includes(tag)) acc.arrayMatches.push(tag);
+    }
+  } else if (acc.firstStringMatch === null && acc.arrayMatches === null) {
+    acc.firstStringMatch = value;
+  }
+}
+
+/**
+ * Match `text` against pre-compiled kennel patterns. Always returns an
+ * array; empty when nothing matched. See module docstring for precedence.
+ */
+export function matchCompiledKennelPatterns(
+  text: string,
+  compiled: readonly CompiledKennelPattern[],
+): string[] {
+  const acc: { arrayMatches: string[] | null; firstStringMatch: string | null } = {
+    arrayMatches: null,
+    firstStringMatch: null,
+  };
+  for (const [regex, value] of compiled) {
+    if (regex.test(text)) applyMatch(value, acc);
+  }
+  if (acc.arrayMatches !== null) return acc.arrayMatches;
+  if (acc.firstStringMatch !== null) return [acc.firstStringMatch];
+  return [];
+}
+
+/**
+ * Convenience: compile + match in one call. Use only for one-off matches
+ * (tests, scripts). Hot paths should compile once per scrape via
+ * `compileKennelPatterns()` and reuse `matchCompiledKennelPatterns()`.
  */
 export function matchKennelPatterns(
   text: string,
   patterns: readonly KennelPattern[],
 ): string[] {
-  let arrayMatches: string[] | null = null;
-  let firstStringMatch: string | null = null;
-
-  for (const [regex, value] of patterns) {
-    let matched: boolean;
-    try {
-      matched = new RegExp(regex, "i").test(text);
-    } catch {
-      continue;
-    }
-    if (!matched) continue;
-
-    if (Array.isArray(value)) {
-      arrayMatches ??= [];
-      for (const tag of value) {
-        if (!arrayMatches.includes(tag)) arrayMatches.push(tag);
-      }
-    } else if (firstStringMatch === null && arrayMatches === null) {
-      firstStringMatch = value;
-    }
-  }
-
-  if (arrayMatches !== null) return arrayMatches;
-  if (firstStringMatch !== null) return [firstStringMatch];
-  return [];
+  return matchCompiledKennelPatterns(text, compileKennelPatterns(patterns));
 }

--- a/src/app/admin/sources/config-validation.test.ts
+++ b/src/app/admin/sources/config-validation.test.ts
@@ -83,11 +83,11 @@ describe("validateSourceConfig", () => {
         kennelPatterns: [["only one"]],
       });
       expect(errors).toHaveLength(1);
-      expect(errors[0]).toContain("[regex, tag] pair");
+      expect(errors[0]).toContain("must be a [regex, tag");
     });
 
     it.each([
-      [[[123, "TAG"]], "must be strings"],
+      [[[123, "TAG"]], "regex must be a string"],
       [[["^EWH3", "  "]], "cannot be empty"],
       [[["[invalid(", "TAG"]], "invalid regex"],
       [[["(a+)+$", "TAG"]], "catastrophic backtracking"],
@@ -97,6 +97,36 @@ describe("validateSourceConfig", () => {
       });
       expect(errors).toHaveLength(1);
       expect(errors[0]).toContain(expectedMsg);
+    });
+
+    // #1023 step 4: multi-kennel array tag values — gated by source type
+    it("accepts a multi-kennel array tag pattern for GOOGLE_CALENDAR (migrated to matchKennelPatterns)", () => {
+      const errors = validateSourceConfig("GOOGLE_CALENDAR", {
+        kennelPatterns: [["Cherry City.*OH3", ["cch3-or", "oh3"]]],
+      });
+      expect(errors).toEqual([]);
+    });
+
+    it.each(["MEETUP", "ICAL_FEED", "HTML_SCRAPER", "RSS_FEED"])(
+      "rejects a multi-kennel array tag pattern for non-migrated source type %s",
+      (type) => {
+        const errors = validateSourceConfig(type, {
+          kennelPatterns: [["X", ["a", "b"]]],
+        });
+        expect(errors.some((e) => e.includes("multi-kennel array tags are not supported"))).toBe(true);
+      },
+    );
+
+    it.each([
+      [[[".*", []]], "multi-kennel tag array cannot be empty"],
+      [[[".*", ["valid", ""]]], "each multi-kennel tag must be a non-empty string"],
+      [[[".*", ["valid", 123]]], "each multi-kennel tag must be a non-empty string"],
+      [[[".*", 42]], "tag must be a string or string[]"],
+    ])("rejects invalid multi-kennel tag value: %s", (patterns, expectedMsg) => {
+      const errors = validateSourceConfig("GOOGLE_CALENDAR", {
+        kennelPatterns: patterns,
+      });
+      expect(errors.some((e) => e.includes(expectedMsg))).toBe(true);
     });
 
     it("collects multiple errors", () => {

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -47,6 +47,45 @@ function validateRegex(
  */
 const TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS = new Set(["GOOGLE_CALENDAR"]);
 
+/** Per-entry tag-value validation for `validateKennelPatterns`. Extracted to
+ *  keep the parent function's cognitive complexity below SonarCloud's
+ *  threshold. Returns true when the value is well-formed enough to fall
+ *  through to regex validation; false on hard rejection. */
+function validateKennelPatternTagValue(
+  i: number,
+  tagValue: unknown,
+  type: string,
+  errors: string[],
+): boolean {
+  const allowMultiKennel = TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS.has(type);
+  if (typeof tagValue === "string") {
+    if (!tagValue.trim()) {
+      errors.push(`kennelPatterns[${i}]: kennel tag cannot be empty`);
+    }
+    return true;
+  }
+  if (Array.isArray(tagValue)) {
+    if (!allowMultiKennel) {
+      errors.push(
+        `kennelPatterns[${i}]: multi-kennel array tags are not supported for source type ${type} ` +
+          `— migrate the adapter to matchKennelPatterns first (#1023). Allowed: ${[...TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS].join(", ")}.`,
+      );
+      return false;
+    }
+    if (tagValue.length === 0) {
+      errors.push(`kennelPatterns[${i}]: multi-kennel tag array cannot be empty`);
+    }
+    for (const [j, tag] of tagValue.entries()) {
+      if (typeof tag !== "string" || !tag.trim()) {
+        errors.push(`kennelPatterns[${i}][${j}]: each multi-kennel tag must be a non-empty string`);
+      }
+    }
+    return true;
+  }
+  errors.push(`kennelPatterns[${i}]: tag must be a string${allowMultiKennel ? " or string[]" : ""}`);
+  return false;
+}
+
 /** Validate kennelPatterns: each entry is [regex, tag] or [regex, tag[]] (#1023 step 4). */
 function validateKennelPatterns(type: string, obj: Record<string, unknown>, errors: string[]): void {
   if (!("kennelPatterns" in obj) || obj.kennelPatterns === undefined) return;
@@ -55,7 +94,6 @@ function validateKennelPatterns(type: string, obj: Record<string, unknown>, erro
     errors.push("kennelPatterns must be an array of [regex, tag] pairs");
     return;
   }
-  const allowMultiKennel = TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS.has(type);
   for (const [i, pair] of obj.kennelPatterns.entries()) {
     if (!Array.isArray(pair) || pair.length !== 2) {
       errors.push(`kennelPatterns[${i}]: must be a [regex, tag] pair`);
@@ -66,29 +104,7 @@ function validateKennelPatterns(type: string, obj: Record<string, unknown>, erro
       errors.push(`kennelPatterns[${i}]: regex must be a string`);
       continue;
     }
-    if (typeof tagValue === "string") {
-      if (!tagValue.trim()) {
-        errors.push(`kennelPatterns[${i}]: kennel tag cannot be empty`);
-      }
-    } else if (Array.isArray(tagValue)) {
-      if (!allowMultiKennel) {
-        errors.push(
-          `kennelPatterns[${i}]: multi-kennel array tags are not supported for source type ${type} ` +
-            `— migrate the adapter to matchKennelPatterns first (#1023). Allowed: ${[...TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS].join(", ")}.`,
-        );
-        continue;
-      }
-      if (tagValue.length === 0) {
-        errors.push(`kennelPatterns[${i}]: multi-kennel tag array cannot be empty`);
-      }
-      for (const [j, tag] of tagValue.entries()) {
-        if (typeof tag !== "string" || !tag.trim()) {
-          errors.push(`kennelPatterns[${i}][${j}]: each multi-kennel tag must be a non-empty string`);
-        }
-      }
-    } else {
-      errors.push(`kennelPatterns[${i}]: tag must be a string${allowMultiKennel ? " or string[]" : ""}`);
-    }
+    if (!validateKennelPatternTagValue(i, tagValue, type, errors)) continue;
     validateRegex(pattern, `kennelPatterns[${i}]`, errors);
   }
 }

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -36,26 +36,58 @@ function validateRegex(
   }
 }
 
-/** Validate kennelPatterns array: each entry must be a [regex, tag] pair. */
-function validateKennelPatterns(obj: Record<string, unknown>, errors: string[]): void {
+/**
+ * Source types whose adapters consume the multi-kennel array tag form
+ * via the central `matchKennelPatterns` helper (#1023 step 4). Every other
+ * adapter is still string-only and would silently emit malformed kennelTags
+ * if given an array value, so the validator gates the broader grammar to
+ * just these types.
+ *
+ * Add to this set when migrating an adapter to `matchKennelPatterns`.
+ */
+const TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS = new Set(["GOOGLE_CALENDAR"]);
+
+/** Validate kennelPatterns: each entry is [regex, tag] or [regex, tag[]] (#1023 step 4). */
+function validateKennelPatterns(type: string, obj: Record<string, unknown>, errors: string[]): void {
   if (!("kennelPatterns" in obj) || obj.kennelPatterns === undefined) return;
 
   if (!Array.isArray(obj.kennelPatterns)) {
     errors.push("kennelPatterns must be an array of [regex, tag] pairs");
     return;
   }
+  const allowMultiKennel = TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS.has(type);
   for (const [i, pair] of obj.kennelPatterns.entries()) {
     if (!Array.isArray(pair) || pair.length !== 2) {
       errors.push(`kennelPatterns[${i}]: must be a [regex, tag] pair`);
       continue;
     }
-    const [pattern, tag] = pair;
-    if (typeof pattern !== "string" || typeof tag !== "string") {
-      errors.push(`kennelPatterns[${i}]: both regex and tag must be strings`);
+    const [pattern, tagValue] = pair;
+    if (typeof pattern !== "string") {
+      errors.push(`kennelPatterns[${i}]: regex must be a string`);
       continue;
     }
-    if (!tag.trim()) {
-      errors.push(`kennelPatterns[${i}]: kennel tag cannot be empty`);
+    if (typeof tagValue === "string") {
+      if (!tagValue.trim()) {
+        errors.push(`kennelPatterns[${i}]: kennel tag cannot be empty`);
+      }
+    } else if (Array.isArray(tagValue)) {
+      if (!allowMultiKennel) {
+        errors.push(
+          `kennelPatterns[${i}]: multi-kennel array tags are not supported for source type ${type} ` +
+            `— migrate the adapter to matchKennelPatterns first (#1023). Allowed: ${[...TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS].join(", ")}.`,
+        );
+        continue;
+      }
+      if (tagValue.length === 0) {
+        errors.push(`kennelPatterns[${i}]: multi-kennel tag array cannot be empty`);
+      }
+      for (const [j, tag] of tagValue.entries()) {
+        if (typeof tag !== "string" || !tag.trim()) {
+          errors.push(`kennelPatterns[${i}][${j}]: each multi-kennel tag must be a non-empty string`);
+        }
+      }
+    } else {
+      errors.push(`kennelPatterns[${i}]: tag must be a string${allowMultiKennel ? " or string[]" : ""}`);
     }
     validateRegex(pattern, `kennelPatterns[${i}]`, errors);
   }
@@ -219,7 +251,7 @@ export function validateSourceConfig(
   const obj = config as Record<string, unknown>;
 
   // Common pattern validation
-  validateKennelPatterns(obj, errors);
+  validateKennelPatterns(type, obj, errors);
   validatePatternArray(obj, "skipPatterns", errors);
   validatePatternArray(obj, "harePatterns", errors);
   validatePatternArray(obj, "runNumberPatterns", errors);

--- a/src/app/admin/sources/suggest-source-config-action.ts
+++ b/src/app/admin/sources/suggest-source-config-action.ts
@@ -470,7 +470,7 @@ function validateConfigShape(raw: unknown, type: string): Record<string, unknown
   const obj = { ...(raw as Record<string, unknown>) };
 
   if (Array.isArray(obj.kennelPatterns)) {
-    obj.kennelPatterns = (obj.kennelPatterns as unknown[]).filter(isValidPatternEntry);
+    obj.kennelPatterns = (obj.kennelPatterns as unknown[]).filter((e) => isValidPatternEntry(e, type));
   }
 
   if (Array.isArray(obj.skipPatterns)) {
@@ -490,11 +490,29 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 
-/** Returns true if entry is a valid [pattern, tag] pair with a safe regex. */
-function isValidPatternEntry(entry: unknown): boolean {
+// Mirror config-validation's gate: only adapter types that consume the
+// central matchKennelPatterns helper accept array-valued tags. Adding a
+// type here without migrating the adapter risks silent malformed kennelTags.
+const TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS = new Set(["GOOGLE_CALENDAR"]);
+
+/**
+ * Returns true if entry is a valid `[pattern, tag | tag[]]` pair with a
+ * safe regex. Multi-kennel arrays (#1023 step 4) are only allowed for
+ * source types whose adapter has been migrated to handle them.
+ */
+function isValidPatternEntry(entry: unknown, type?: string): boolean {
   if (!Array.isArray(entry) || entry.length !== 2) return false;
-  const [pattern, tag] = entry;
-  if (typeof pattern !== "string" || typeof tag !== "string") return false;
+  const [pattern, tagValue] = entry;
+  if (typeof pattern !== "string") return false;
+  if (typeof tagValue === "string") {
+    if (!tagValue.trim()) return false;
+  } else if (Array.isArray(tagValue)) {
+    if (type !== undefined && !TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS.has(type)) return false;
+    if (tagValue.length === 0) return false;
+    if (!tagValue.every((t) => typeof t === "string" && t.trim().length > 0)) return false;
+  } else {
+    return false;
+  }
   return isSafeRegexString(pattern);
 }
 


### PR DESCRIPTION
## Summary

Fourth implementation step of the multi-kennel co-hosted events spec ([docs/multi-kennel-events-spec.md](docs/multi-kennel-events-spec.md)). Steps 1–3 merged via [#1092](https://github.com/johnrclem/hashtracks-web/pull/1092), [#1099](https://github.com/johnrclem/hashtracks-web/pull/1099), and [#1105](https://github.com/johnrclem/hashtracks-web/pull/1105). This step adds the spec D15 precedence algorithm and ships **Oregon Hashing Calendar's Cherry City + OH3 co-host as the first real multi-kennel pattern** — the structural fix for the [#991](https://github.com/johnrclem/hashtracks-web/issues/991) joint-trail case.

### What lands

**`src/adapters/kennel-patterns.ts` (new):**
- `KennelPattern = readonly [string, string | string[]]`
- `matchKennelPatterns(text, patterns): string[]` — implements spec §2 D15 precedence: array-typed values always win once one matches; string-only configs preserve legacy first-match-wins.

**`src/adapters/google-calendar/adapter.ts`:**
- `kennelPatterns` widened to `KennelPattern[]`, matcher delegates to the helper.
- `resolveKennelTagFromSummary` returns `kennelTags: string[]`. Caller extracts `kennelTags[0]` as primary; the full array flows into RawEventData so the merge pipeline's secondary co-host loop ([#1099](https://github.com/johnrclem/hashtracks-web/pull/1099) step 3) writes EventKennel rows for the rest.

**`prisma/seed-data/sources.ts` — Oregon Hashing Calendar:**
```ts
kennelPatterns: [
  ["(?:Cherry City.*OH3)|(?:OH3.*Cherry City)", ["cch3-or", "oh3"]], // NEW: multi-kennel
  ["^OH3\\b|OH3 Full Moon", "oh3"],
  ["TGIF|Friday.*Pubcrawl", "tgif"],
  ["Cherry City|Cherry Cherry City", "cch3-or"],
],
```
Joint trails (e.g. "Cherry City H3 #1 / OH3 # 1340") now land on **both** kennel pages.

**Validators (`config-validation.ts` + `suggest-source-config-action.ts`):**
- Both gate array-tag values to a per-type allowlist (`TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS = { GOOGLE_CALENDAR }`). Add adapters to the set when they migrate to `matchKennelPatterns`.
- Other source types (Meetup, iCal, HTML_SCRAPER, RSS_FEED) continue to require `string` tag values and reject arrays with a friendly error naming the allowed types.

### Codex adversarial review caught + fixed

- **BLOCKER** — Validator originally accepted array-tag values for any source type. Non-migrated adapters (Phoenix, Frankfurt, Meetup, iCal, etc.) would have silently emitted malformed `kennelTags` (e.g. `[["cch3-or","oh3"]]` instead of `["cch3-or","oh3"]`). Both validator and AI suggest-config path now gate by source type with explicit error messages.
- 1 IMPORTANT (single-element array footgun — accepted as documented spec behavior; can be revisited if it surfaces in practice) and 1 NIT (O(n²) dedupe — fine at pattern scale).

### Local verification (5,406 unit tests pass)

- 11 helper tests in `kennel-patterns.test.ts` (legacy single-tag, multi-kennel array, mixed precedence)
- 4 Oregon Calendar integration tests in `gcal/adapter.test.ts` (Cherry City+OH3 → both; OH3-only → [oh3]; etc.)
- Validator tests for the per-type gate (allows GOOGLE_CALENDAR, rejects MEETUP/ICAL_FEED/HTML_SCRAPER/RSS_FEED)
- `tsc --noEmit` clean
- `scripts/live-verify-multi-kennel-pattern.ts` against `hashtracks_dev`: synthetic "Cherry City H3 #1 / OH3 # 1340" RawEvent → `processRawEvents` creates 1 Event with primary EventKennel = cch3-or + co-host EventKennel = oh3 (isPrimary=false). Verified against the actual partial unique index.

### Adapters NOT migrated in this PR (intentional)

iCal, SFH3, Frankfurt, Phoenix, Generic HTML, lvh3, indyh3, Meetup, Harrier Central all keep their existing string-only matchers. They migrate when they need multi-kennel support; the type-gated validator prevents accidental array-tag configs from being saved against them in the meantime.

### What's NOT in this PR

- Display-layer migration + authorization paths — step 5
- Historical co-host backfill (rerun against existing prod data to retroactively add EventKennel rows for Oregon Calendar's joint trails) — step 6
- `Event.kennelId` column drop — step 7

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 5,406 pass, 0 new failures
- [x] `scripts/live-verify-multi-kennel-pattern.ts` end-to-end pass (Oregon Calendar config → multi-kennel event → primary + co-host EventKennel rows)
- [x] Step 1/2/3 verification scripts still pass (no regression)
- [ ] Vercel preview deploys cleanly
- [ ] Post-merge: monitor next Oregon Calendar scrape — joint trails should produce events with two EventKennel rows

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)