### PR TITLE
feat(display): co-host events visible on both kennel pages + EventCard conjunction (step 5 of #1023)

### DIFF
--- a/scripts/live-verify-display-co-host.ts
+++ b/scripts/live-verify-display-co-host.ts
@@ -1,0 +1,159 @@
+/**
+ * Live smoke for the display-layer multi-kennel migration (#1023 step 5)
+ * against `hashtracks_dev`. Builds a synthetic Cherry City + OH3 co-host
+ * event, then reads it back through the same WHERE filter the kennel
+ * page uses — assert it surfaces on BOTH kennels' pages.
+ *
+ * Idempotent: cleans up the synthetic event + revertable SourceKennel
+ * links it created. Refuses to run against any non-local DATABASE_URL.
+ *
+ * Run: `npx tsx scripts/live-verify-display-co-host.ts`
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { processRawEvents } from "@/pipeline/merge";
+
+const PROBE_TITLE = "PROBE_DISPLAY: Cherry City × OH3 step-5 visibility";
+const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "0.0.0.0", "host.docker.internal", "postgres", "db"]);
+
+function assertLocalDb(): void {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL not set");
+  const host = new URL(url.replace(/^postgresql:/, "http:")).hostname;
+  if (!LOCAL_DB_HOSTS.has(host)) {
+    throw new Error(`Refusing to run live verification against non-local host ${host}.`);
+  }
+}
+
+async function main() {
+  assertLocalDb();
+
+  // 1. Find Cherry City + OH3 + Oregon Calendar source.
+  const [cch3, oh3] = await Promise.all([
+    prisma.kennel.findFirst({ where: { kennelCode: "cch3-or" }, select: { id: true, slug: true } }),
+    prisma.kennel.findFirst({ where: { kennelCode: "oh3" }, select: { id: true, slug: true } }),
+  ]);
+  if (!cch3 || !oh3) throw new Error("cch3-or or oh3 missing from hashtracks_dev — bail");
+
+  const source = await prisma.source.findFirst({
+    where: { name: "Oregon Hashing Calendar" },
+    select: { id: true },
+  });
+  if (!source) throw new Error("Oregon Hashing Calendar source missing — bail");
+
+  const createdLinks: Array<{ sourceId: string; kennelId: string }> = [];
+  const ensureLinked = async (kennelId: string) => {
+    const existing = await prisma.sourceKennel.findUnique({
+      where: { sourceId_kennelId: { sourceId: source.id, kennelId } },
+    });
+    if (!existing) {
+      await prisma.sourceKennel.create({ data: { sourceId: source.id, kennelId } });
+      createdLinks.push({ sourceId: source.id, kennelId });
+    }
+  };
+  await ensureLinked(cch3.id);
+  await ensureLinked(oh3.id);
+
+  // 2. Cleanup any prior probe state.
+  const stale = await prisma.event.findMany({ where: { title: PROBE_TITLE }, select: { id: true } });
+  for (const e of stale) {
+    await prisma.eventKennel.deleteMany({ where: { eventId: e.id } });
+    await prisma.rawEvent.deleteMany({ where: { eventId: e.id } });
+    await prisma.event.delete({ where: { id: e.id } });
+  }
+
+  let createdEventId: string | null = null;
+  try {
+    // 3. Create a synthetic multi-kennel event via the merge pipeline.
+    const result = await processRawEvents(source.id, [
+      {
+        date: "2099-08-15",
+        kennelTags: ["cch3-or", "oh3"],
+        title: PROBE_TITLE,
+        runNumber: 9999,
+        sourceUrl: "https://example.com/probe-display",
+      },
+    ]);
+    if (result.created !== 1) {
+      throw new Error(`Expected created=1, got ${result.created}: ${JSON.stringify(result)}`);
+    }
+    const event = await prisma.event.findFirst({
+      where: { title: PROBE_TITLE },
+      include: { eventKennels: { select: { kennelId: true, isPrimary: true } } },
+    });
+    if (!event) throw new Error("Created event not found");
+    createdEventId = event.id;
+    console.log(`Synthetic event ${event.id} written ✓`);
+
+    // 4. Run the kennel-page WHERE filter shape from BOTH kennels.
+    //    This is the rewritten predicate used in kennels/[slug]/page.tsx.
+    const probeForKennel = (kennelId: string) =>
+      prisma.event.findFirst({
+        where: {
+          eventKennels: { some: { kennelId } },
+          status: { not: "CANCELLED" },
+          isManualEntry: { not: true },
+          isCanonical: true,
+          parentEventId: null,
+          title: PROBE_TITLE, // narrow to the probe so we don't scan all 34k events
+        },
+        include: {
+          eventKennels: {
+            where: { isPrimary: false },
+            select: { kennel: { select: { shortName: true } } },
+          },
+        },
+      });
+
+    const onPrimary = await probeForKennel(cch3.id);
+    if (!onPrimary) throw new Error("Probe missing on cch3-or kennel page query");
+    console.log("Visible on cch3-or page ✓");
+
+    const onCoHost = await probeForKennel(oh3.id);
+    if (!onCoHost) {
+      throw new Error(
+        "Probe missing on oh3 kennel page query — co-host EventKennel filter not surfacing the event",
+      );
+    }
+    console.log("Visible on oh3 page ✓ (co-host visibility working)");
+
+    // 5. Verify coHosts SELECT shape matches what the page maps into the card.
+    //    Our SELECT filters EventKennel.isPrimary=false, so this is just the
+    //    secondary kennel(s). For the cch3-or × oh3 probe, that's exactly OH3.
+    const coHostKennels = onPrimary.eventKennels.map((ek) => ek.kennel.shortName);
+    if (coHostKennels.length !== 1) {
+      throw new Error(`Expected exactly 1 co-host on cch3-or's view, got ${JSON.stringify(coHostKennels)}`);
+    }
+    console.log(`Primary view's coHosts = [${coHostKennels.join(", ")}] ✓`);
+
+    // The same SELECT shape from OH3's page also returns 1 co-host row
+    // (primary-anchored: the SELECT is `where: { isPrimary: false }` — fixed
+    // regardless of which kennel page is viewing. Always returns the
+    // non-primary kennel(s), so on OH3's page this is the cch3-or row).
+    const coHostFromOh3 = onCoHost.eventKennels.map((ek) => ek.kennel.shortName);
+    if (coHostFromOh3.length !== 1) {
+      throw new Error(`Expected co-host count of 1, got ${coHostFromOh3.length}`);
+    }
+    console.log(`OH3-page view's coHosts = [${coHostFromOh3.join(", ")}] ✓ (primary-anchored)`);
+  } finally {
+    if (createdEventId) {
+      await prisma.eventKennel.deleteMany({ where: { eventId: createdEventId } });
+      await prisma.rawEvent.deleteMany({ where: { eventId: createdEventId } });
+      await prisma.event.delete({ where: { id: createdEventId } }).catch(() => {});
+    }
+    for (const link of createdLinks) {
+      await prisma.sourceKennel.delete({ where: { sourceId_kennelId: link } }).catch(() => {});
+    }
+    console.log("Cleanup OK");
+  }
+
+  console.log("\nDisplay-layer co-host visibility ✓");
+}
+
+main()
+  .catch((err) => {
+    console.error("\nDisplay-layer verification failed:");
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/admin/events/actions.ts
+++ b/src/app/admin/events/actions.ts
@@ -265,7 +265,15 @@ function buildEventWhere(filters: {
 
   if (filters.kennelId) {
     // #1023 step 5: include co-hosted events when filtering by kennel.
-    conditions.push({ eventKennels: { some: { kennelId: filters.kennelId } } });
+    // OR-fallback against the legacy `Event.kennelId` denorm so admins
+    // never lose an event from the filter view if (hypothetically) an
+    // EventKennel row is missing for it.
+    conditions.push({
+      OR: [
+        { eventKennels: { some: { kennelId: filters.kennelId } } },
+        { kennelId: filters.kennelId },
+      ],
+    });
   }
 
   if (filters.sourceId === "none") {

--- a/src/app/admin/events/actions.ts
+++ b/src/app/admin/events/actions.ts
@@ -264,7 +264,8 @@ function buildEventWhere(filters: {
   const conditions: Record<string, unknown>[] = [];
 
   if (filters.kennelId) {
-    conditions.push({ kennelId: filters.kennelId });
+    // #1023 step 5: include co-hosted events when filtering by kennel.
+    conditions.push({ eventKennels: { some: { kennelId: filters.kennelId } } });
   }
 
   if (filters.sourceId === "none") {

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -50,7 +50,8 @@ export default async function AdminEventsPage({ searchParams }: PageProps) {
 
   // Build where clause from filters
   const conditions: Record<string, unknown>[] = [];
-  if (kennelId) conditions.push({ kennelId });
+  // #1023 step 5: include co-hosted events when filtering by kennel.
+  if (kennelId) conditions.push({ eventKennels: { some: { kennelId } } });
   if (sourceId === "none") {
     conditions.push({ rawEvents: { none: {} } });
   } else if (sourceId) {

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -50,8 +50,16 @@ export default async function AdminEventsPage({ searchParams }: PageProps) {
 
   // Build where clause from filters
   const conditions: Record<string, unknown>[] = [];
-  // #1023 step 5: include co-hosted events when filtering by kennel.
-  if (kennelId) conditions.push({ eventKennels: { some: { kennelId } } });
+  // #1023 step 5: include co-hosted events when filtering by kennel,
+  // OR-fallback to the legacy `Event.kennelId` denorm for safety.
+  if (kennelId) {
+    conditions.push({
+      OR: [
+        { eventKennels: { some: { kennelId } } },
+        { kennelId },
+      ],
+    });
+  }
   if (sourceId === "none") {
     conditions.push({ rawEvents: { none: {} } });
   } else if (sourceId) {

--- a/src/app/admin/kennels/actions.ts
+++ b/src/app/admin/kennels/actions.ts
@@ -360,9 +360,12 @@ export async function deleteKennel(kennelId: string) {
     };
   }
 
-  // Check for attendance records via events (events belong to kennels)
+  // Check for attendance records via events. #1023 step 5: scope by
+  // EventKennel set so co-hosted events are also covered (the prior
+  // co-host guard already short-circuits when any exist, but using the
+  // join here keeps semantics consistent).
   const attendanceCount = await prisma.kennelAttendance.count({
-    where: { event: { kennelId } },
+    where: { event: { eventKennels: { some: { kennelId } } } },
   });
   if (attendanceCount > 0) {
     return {

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { prisma } from "@/lib/db";
-import { getOrCreateUser, getAdminUser, getMismanUser } from "@/lib/auth";
+import { getOrCreateUser, getAdminUser, getMismanUserForEvent } from "@/lib/auth";
 import { getStravaConnection } from "@/app/strava/actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -126,7 +126,9 @@ export default async function EventDetailPage({
     prisma.attendance.count({ where: { eventId, status: "CONFIRMED" } }),
     prisma.attendance.count({ where: { eventId, status: "INTENDING" } }),
     user ? getStravaConnection() : Promise.resolve(null),
-    user ? getMismanUser(event.kennelId) : Promise.resolve(null),
+    // #1023 step 5: scan all kennels on the event so secondary co-host
+    // mismans get the misman UI, not just the primary kennel's misman.
+    user ? getMismanUserForEvent(event.id) : Promise.resolve(null),
     event.status === "CANCELLED" ? getAdminUser() : Promise.resolve(null),
   ]);
 

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -122,18 +122,22 @@ export default async function EventDetailPage({
     }
   }
 
-  const [confirmedCount, goingCount, stravaResult, mismanUser, adminUser] = await Promise.all([
+  const [confirmedCount, goingCount, stravaResult, mismanResult, adminUser] = await Promise.all([
     prisma.attendance.count({ where: { eventId, status: "CONFIRMED" } }),
     prisma.attendance.count({ where: { eventId, status: "INTENDING" } }),
     user ? getStravaConnection() : Promise.resolve(null),
     // #1023 step 5: scan all kennels on the event so secondary co-host
     // mismans get the misman UI, not just the primary kennel's misman.
+    // The resolved kennel slug also drives the "Take Attendance" link
+    // below so it routes to a kennel the user actually manages, not
+    // necessarily the event's primary kennel.
     user ? getMismanUserForEvent(event.id) : Promise.resolve(null),
     event.status === "CANCELLED" ? getAdminUser() : Promise.resolve(null),
   ]);
 
   const stravaConnected = stravaResult?.success ? stravaResult.connected : false;
-  const isMisman = !!mismanUser;
+  const isMisman = !!mismanResult;
+  const mismanKennelSlug = mismanResult?.kennelSlug ?? null;
   const isAdmin = !!adminUser;
 
   // Fetch weather forecast for upcoming events (0–10 days out).
@@ -396,9 +400,11 @@ export default async function EventDetailPage({
 
       {/* Actions */}
       <div className="flex flex-wrap gap-2">
-        {isMisman && (
+        {isMisman && mismanKennelSlug && (
           <Button variant="outline" size="sm" asChild>
-            <Link href={`/misman/${event.kennel.slug}/attendance/${event.id}`}>
+            {/* #1023 step 5: link must point at the kennel the user manages —
+                a secondary co-host's misman would 404 on the primary's slug. */}
+            <Link href={`/misman/${mismanKennelSlug}/attendance/${event.id}`}>
               Take Attendance
             </Link>
           </Button>

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -25,20 +25,24 @@ import { DISPLAY_EVENT_WHERE } from "@/lib/event-filters";
 import { HARELINE_EVENTS_TAG } from "@/lib/cache-tags";
 
 /** Matches the slim shape rendered by EventCard's list view. */
+interface HarelineKennelLite {
+  id: string;
+  shortName: string;
+  fullName: string;
+  slug: string;
+  region: string;
+  country: string;
+}
+
 export interface HarelineListEvent {
   id: string;
   date: string; // ISO string
   dateUtc: Date | null;
   timezone: string | null;
   kennelId: string;
-  kennel: {
-    id: string;
-    shortName: string;
-    fullName: string;
-    slug: string;
-    region: string;
-    country: string;
-  } | null;
+  kennel: HarelineKennelLite | null;
+  /** Co-host kennels (#1023 step 5). Empty when the event has only a primary. */
+  coHosts: HarelineKennelLite[];
   runNumber: number | null;
   title: string | null;
   haresText: string | null;
@@ -142,6 +146,16 @@ const fetchSlimEventsCached = unstable_cache(
         kennel: {
           select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },
         },
+        // Co-hosts (#1023 step 5) — drives the EventCard conjunction
+        // ("Cherry City × OH3"). Empty array for single-kennel events,
+        // which is the common case.
+        eventKennels: {
+          where: { isPrimary: false },
+          select: {
+            kennel: { select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true } },
+          },
+          orderBy: { kennel: { shortName: "asc" } },
+        },
       },
       orderBy: { date: isPast ? "desc" : "asc" },
       ...(isPast ? { take: PAST_EVENTS_LIMIT } : {}),
@@ -154,6 +168,7 @@ const fetchSlimEventsCached = unstable_cache(
       timezone: e.timezone,
       kennelId: e.kennelId,
       kennel: e.kennel,
+      coHosts: e.eventKennels.map((ek) => ek.kennel),
       runNumber: e.runNumber,
       title: e.title,
       haresText: e.haresText,

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -93,10 +93,22 @@ export default async function KennelDetailPage({
   const [user, events] = await Promise.all([
     getOrCreateUser(),
     prisma.event.findMany({
-      where: { kennelId: kennel.id, status: { not: "CANCELLED" }, isManualEntry: { not: true }, isCanonical: true, parentEventId: null },
+      // #1023 step 5: filter via EventKennel join so co-host events
+      // (where this kennel is a secondary, not the primary) appear here too.
+      where: { eventKennels: { some: { kennelId: kennel.id } }, status: { not: "CANCELLED" }, isManualEntry: { not: true }, isCanonical: true, parentEventId: null },
       include: {
         kennel: {
           select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },
+        },
+        // Populate co-host kennels (#1023 step 5) — surfaces the
+        // "Cherry City × OH3" conjunction in EventCard for multi-kennel
+        // events. Empty array for the common single-kennel case.
+        eventKennels: {
+          where: { isPrimary: false },
+          select: {
+            kennel: { select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true } },
+          },
+          orderBy: { kennel: { shortName: "asc" } },
         },
       },
       orderBy: { date: "asc" },
@@ -130,6 +142,10 @@ export default async function KennelDetailPage({
     timezone: e.timezone,
     kennelId: e.kennelId,
     kennel: e.kennel,
+    // #1023 step 5: surface co-host kennels for the EventCard conjunction
+    // ("Cherry City × OH3"). `eventKennels` was filtered to isPrimary=false
+    // in the SELECT above, so this is just the secondaries.
+    coHosts: e.eventKennels.map((ek) => ek.kennel),
     runNumber: e.runNumber,
     title: e.title,
     haresText: e.haresText,

--- a/src/app/logbook/actions.ts
+++ b/src/app/logbook/actions.ts
@@ -537,7 +537,8 @@ export async function searchEvents(params: {
       events = await prisma.event.findMany({
         where: {
           ...commonFilters,
-          kennelId: { in: kennelIds },
+          // #1023 step 5: include co-hosted events at any subscribed kennel.
+          eventKennels: { some: { kennelId: { in: kennelIds } } },
           date: { gte: windowStart, lte: todayNoon },
         },
         include: {

--- a/src/app/misman/[slug]/attendance/[eventId]/page.tsx
+++ b/src/app/misman/[slug]/attendance/[eventId]/page.tsx
@@ -19,19 +19,26 @@ export default async function EventAttendancePage({ params }: Props) {
   const user = await getMismanUser(kennel.id);
   if (!user) notFound();
 
-  // Verify the event exists and belongs to this kennel
+  // Verify the event exists and is hosted by this kennel (primary OR co-host).
+  // #1023 step 5: check EventKennel set, not just Event.kennelId.
   const event = await prisma.event.findUnique({
     where: { id: eventId },
-    select: { id: true, kennelId: true },
+    select: {
+      id: true,
+      kennelId: true,
+      eventKennels: { select: { kennelId: true } },
+    },
   });
-  if (!event || event.kennelId !== kennel.id) notFound();
+  const eventKennelIds = event ? event.eventKennels.map((ek) => ek.kennelId) : [];
+  const isOnEvent = event && (eventKennelIds.includes(kennel.id) || event.kennelId === kennel.id);
+  if (!isOnEvent) notFound();
 
   const oneYearAgo = new Date();
   oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
 
   const events = await prisma.event.findMany({
     where: {
-      kennelId: kennel.id,
+      eventKennels: { some: { kennelId: kennel.id } },
       date: { gte: oneYearAgo },
     },
     select: {

--- a/src/app/misman/[slug]/attendance/actions.ts
+++ b/src/app/misman/[slug]/attendance/actions.ts
@@ -18,6 +18,23 @@ import { syncEventHares } from "@/lib/misman/hare-sync";
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 /**
+ * Resolve the full set of kennelIds participating in an event (#1023 step 5).
+ * Prefers the EventKennel join when populated; falls back to the legacy
+ * `Event.kennelId` denormalized primary pointer for any pre-step-1-backfill
+ * row that somehow lacks EventKennel entries.
+ *
+ * Centralizes the lookup so all three IDOR scope guards in this file
+ * (loadAttendanceForMisman, validateEventForAttendance, clearEventAttendance)
+ * accept the same set of kennels for any given event.
+ */
+function getEventKennelIds(
+  event: { kennelId: string; eventKennels?: ReadonlyArray<{ kennelId: string }> | null },
+): string[] {
+  const ekRows = event.eventKennels ?? [];
+  return ekRows.length > 0 ? ekRows.map((ek) => ek.kennelId) : [event.kennelId];
+}
+
+/**
  * Load a `KennelAttendance` record by ID, together with its parent
  * event's kennelId, and verify that kennel is in the caller's roster
  * scope. Returns `null` for both missing and out-of-scope IDs so
@@ -40,9 +57,7 @@ async function loadAttendanceForMisman(
     getRosterKennelIds(kennelId),
   ]);
   if (!record) return null;
-  const eventKennelIds = (record.event.eventKennels ?? []).length > 0
-    ? record.event.eventKennels.map((ek) => ek.kennelId)
-    : [record.event.kennelId];
+  const eventKennelIds = getEventKennelIds(record.event);
   if (!eventKennelIds.some((id) => rosterKennelIds.includes(id))) {
     return null;
   }
@@ -71,9 +86,7 @@ async function validateEventForAttendance(
   if (!event) return { error: "Event not found" };
 
   const rosterKennelIds = await getRosterKennelIds(kennelId);
-  const eventKennelIds = (event.eventKennels ?? []).length > 0
-    ? event.eventKennels.map((ek) => ek.kennelId)
-    : [event.kennelId];
+  const eventKennelIds = getEventKennelIds(event);
   if (!eventKennelIds.some((id) => rosterKennelIds.includes(id))) {
     return { error: "Event does not belong to this kennel or roster group" };
   }
@@ -289,10 +302,9 @@ export async function clearEventAttendance(kennelId: string, eventId: string) {
     }),
     getRosterKennelIds(kennelId),
   ]);
-  const eventKennelIds = event
-    ? ((event.eventKennels ?? []).length > 0 ? event.eventKennels.map((ek) => ek.kennelId) : [event.kennelId])
-    : [];
-  if (!event || !eventKennelIds.some((id) => rosterKennelIds.includes(id))) {
+  if (!event) return { error: "Event not found" };
+  const eventKennelIds = getEventKennelIds(event);
+  if (!eventKennelIds.some((id) => rosterKennelIds.includes(id))) {
     return { error: "Event not found" };
   }
 

--- a/src/app/misman/[slug]/attendance/actions.ts
+++ b/src/app/misman/[slug]/attendance/actions.ts
@@ -31,11 +31,19 @@ async function loadAttendanceForMisman(
   const [record, rosterKennelIds] = await Promise.all([
     prisma.kennelAttendance.findUnique({
       where: { id: attendanceId },
-      include: { event: { select: { kennelId: true } } },
+      // #1023 step 5: scope check via the full EventKennel set so
+      // co-hosted events admit a secondary kennel's misman too.
+      include: {
+        event: { select: { kennelId: true, eventKennels: { select: { kennelId: true } } } },
+      },
     }),
     getRosterKennelIds(kennelId),
   ]);
-  if (!record || !rosterKennelIds.includes(record.event.kennelId)) {
+  if (!record) return null;
+  const eventKennelIds = (record.event.eventKennels ?? []).length > 0
+    ? record.event.eventKennels.map((ek) => ek.kennelId)
+    : [record.event.kennelId];
+  if (!eventKennelIds.some((id) => rosterKennelIds.includes(id))) {
     return null;
   }
   return record;
@@ -51,12 +59,22 @@ async function validateEventForAttendance(
 ): Promise<{ error?: string; event?: { id: string; kennelId: string } }> {
   const event = await prisma.event.findUnique({
     where: { id: eventId },
-    select: { id: true, kennelId: true, date: true },
+    // #1023 step 5: include EventKennel set so a co-host kennel's misman
+    // can record attendance on the event (not just the primary kennel's).
+    select: {
+      id: true,
+      kennelId: true,
+      date: true,
+      eventKennels: { select: { kennelId: true } },
+    },
   });
   if (!event) return { error: "Event not found" };
 
   const rosterKennelIds = await getRosterKennelIds(kennelId);
-  if (!rosterKennelIds.includes(event.kennelId)) {
+  const eventKennelIds = (event.eventKennels ?? []).length > 0
+    ? event.eventKennels.map((ek) => ek.kennelId)
+    : [event.kennelId];
+  if (!eventKennelIds.some((id) => rosterKennelIds.includes(id))) {
     return { error: "Event does not belong to this kennel or roster group" };
   }
 
@@ -259,14 +277,22 @@ export async function clearEventAttendance(kennelId: string, eventId: string) {
 
   // Roster-scope check (IDOR prevention). Collapse scope miss + missing
   // event into a single not-found response.
+  // #1023 step 5: scope via EventKennel set so a co-host kennel's misman
+  // can clear attendance on shared events.
   const [event, rosterKennelIds] = await Promise.all([
     prisma.event.findUnique({
       where: { id: eventId },
-      select: { kennelId: true },
+      select: {
+        kennelId: true,
+        eventKennels: { select: { kennelId: true } },
+      },
     }),
     getRosterKennelIds(kennelId),
   ]);
-  if (!event || !rosterKennelIds.includes(event.kennelId)) {
+  const eventKennelIds = event
+    ? ((event.eventKennels ?? []).length > 0 ? event.eventKennels.map((ek) => ek.kennelId) : [event.kennelId])
+    : [];
+  if (!event || !eventKennelIds.some((id) => rosterKennelIds.includes(id))) {
     return { error: "Event not found" };
   }
 
@@ -449,8 +475,10 @@ export async function getSuggestions(kennelId: string) {
   );
 
   // Fetch kennel events (this kennel only, within lookback)
+  // #1023 step 5: filter via EventKennel join so co-hosted events
+  // (where this kennel is a secondary) appear too.
   const kennelEvents = await prisma.event.findMany({
-    where: { kennelId, date: { gte: lookbackDate } },
+    where: { eventKennels: { some: { kennelId } }, date: { gte: lookbackDate } },
     select: { id: true, date: true },
     orderBy: { date: "desc" },
   });
@@ -459,7 +487,7 @@ export async function getSuggestions(kennelId: string) {
   const isMultiKennel = rosterKennelIds.length > 1;
   const rosterEvents = isMultiKennel
     ? await prisma.event.findMany({
-        where: { kennelId: { in: rosterKennelIds }, date: { gte: lookbackDate } },
+        where: { eventKennels: { some: { kennelId: { in: rosterKennelIds } } }, date: { gte: lookbackDate } },
         select: { id: true, date: true },
         orderBy: { date: "desc" },
       })

--- a/src/app/misman/[slug]/attendance/page.tsx
+++ b/src/app/misman/[slug]/attendance/page.tsx
@@ -25,7 +25,8 @@ export default async function AttendancePage({ params }: Props) {
 
   const events = await prisma.event.findMany({
     where: {
-      kennelId: kennel.id,
+      // #1023 step 5: filter via EventKennel join so co-hosted events appear too.
+      eventKennels: { some: { kennelId: kennel.id } },
       date: { gte: oneYearAgo },
     },
     select: {

--- a/src/app/misman/[slug]/attendance/page.tsx
+++ b/src/app/misman/[slug]/attendance/page.tsx
@@ -25,8 +25,14 @@ export default async function AttendancePage({ params }: Props) {
 
   const events = await prisma.event.findMany({
     where: {
-      // #1023 step 5: filter via EventKennel join so co-hosted events appear too.
-      eventKennels: { some: { kennelId: kennel.id } },
+      // #1023 step 5: filter via EventKennel join so co-hosted events
+      // appear too. OR-fallback to the legacy denorm pointer so a misman
+      // never loses an event from the picker if (hypothetically) an
+      // EventKennel row is missing for it.
+      OR: [
+        { eventKennels: { some: { kennelId: kennel.id } } },
+        { kennelId: kennel.id },
+      ],
       date: { gte: oneYearAgo },
     },
     select: {

--- a/src/app/misman/[slug]/history/actions.test.ts
+++ b/src/app/misman/[slug]/history/actions.test.ts
@@ -98,7 +98,7 @@ describe("getAttendanceHistory", () => {
     expect(findManyCall?.where).toHaveProperty("date");
   });
 
-  it("filters by single kennelId, not roster group scope", async () => {
+  it("filters by single kennel via EventKennel join, not roster group scope", async () => {
     mockRosterKennelIds.mockResolvedValueOnce(["kennel_1", "kennel_2"]);
 
     vi.mocked(prisma.event.findMany).mockResolvedValueOnce([] as never);
@@ -106,8 +106,10 @@ describe("getAttendanceHistory", () => {
 
     await getAttendanceHistory("kennel_1");
 
+    // #1023 step 5: history scopes via EventKennel.some so co-hosted
+    // events (where this kennel is a secondary) appear too.
     const findManyCall = vi.mocked(prisma.event.findMany).mock.calls[0][0];
-    expect(findManyCall?.where?.kennelId).toBe("kennel_1");
+    expect(findManyCall?.where?.eventKennels).toEqual({ some: { kennelId: "kennel_1" } });
   });
 
   it("paginates correctly", async () => {
@@ -360,11 +362,12 @@ describe("seedRosterFromHares", () => {
 
     await seedRosterFromHares("kennel_1");
 
-    // Should query events from both kennels
+    // Should query events from both kennels (#1023 step 5: via EventKennel join
+    // so co-hosted events at any roster-group kennel are also covered).
     expect(vi.mocked(prisma.event.findMany)).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          kennelId: { in: ["kennel_1", "kennel_2"] },
+          eventKennels: { some: { kennelId: { in: ["kennel_1", "kennel_2"] } } },
         }),
       }),
     );

--- a/src/app/misman/[slug]/history/actions.ts
+++ b/src/app/misman/[slug]/history/actions.ts
@@ -31,9 +31,12 @@ export async function getAttendanceHistory(
     dateFilter.lte = new Date(filters.endDate);
   }
 
+  // #1023 step 5: filter via EventKennel join so co-hosted events appear in
+  // history too. (KennelAttendance is hasher-scoped, so per-kennel attendance
+  // already segregates by misman roster regardless of primary/co-host status.)
   const where = {
     kennelAttendances: { some: {} },
-    kennelId,
+    eventKennels: { some: { kennelId } },
     ...(Object.keys(dateFilter).length > 0 ? { date: dateFilter } : {}),
   };
 
@@ -267,7 +270,8 @@ export async function seedRosterFromHares(kennelId: string) {
 
   const events = await prisma.event.findMany({
     where: {
-      kennelId: { in: rosterKennelIds },
+      // #1023 step 5: include co-hosted events for any roster-group kennel.
+      eventKennels: { some: { kennelId: { in: rosterKennelIds } } },
       date: { gte: oneYearAgo },
       haresText: { not: null },
     },

--- a/src/app/misman/[slug]/history/actions.ts
+++ b/src/app/misman/[slug]/history/actions.ts
@@ -32,10 +32,12 @@ export async function getAttendanceHistory(
   }
 
   // #1023 step 5: filter via EventKennel join so co-hosted events appear in
-  // history too. (KennelAttendance is hasher-scoped, so per-kennel attendance
-  // already segregates by misman roster regardless of primary/co-host status.)
+  // history too. The `kennelAttendances` predicate must be scoped to THIS
+  // kennel's roster — on a co-hosted event, kennel A and kennel B both have
+  // their own KennelAttendance rows and we must not leak the other kennel's
+  // attendees into this kennel's history view.
   const where = {
-    kennelAttendances: { some: {} },
+    kennelAttendances: { some: { kennelHasher: { kennelId } } },
     eventKennels: { some: { kennelId } },
     ...(Object.keys(dateFilter).length > 0 ? { date: dateFilter } : {}),
   };
@@ -46,6 +48,9 @@ export async function getAttendanceHistory(
       include: {
         kennel: { select: { shortName: true } },
         kennelAttendances: {
+          // Same scope as the where-clause: only attendance recorded by
+          // THIS kennel's misman appears in this history view.
+          where: { kennelHasher: { kennelId } },
           include: {
             kennelHasher: {
               select: { hashName: true, nerdName: true },

--- a/src/app/misman/[slug]/history/page.tsx
+++ b/src/app/misman/[slug]/history/page.tsx
@@ -23,7 +23,8 @@ export default async function HistoryPage({ params }: Props) {
 
   const where = {
     kennelAttendances: { some: {} },
-    kennelId: kennel.id,
+    // #1023 step 5: include co-hosted events in history.
+    eventKennels: { some: { kennelId: kennel.id } },
   };
 
   const [events, total] = await Promise.all([

--- a/src/app/misman/[slug]/history/page.tsx
+++ b/src/app/misman/[slug]/history/page.tsx
@@ -21,9 +21,12 @@ export default async function HistoryPage({ params }: Props) {
   const user = await getMismanUser(kennel.id);
   if (!user) notFound();
 
+  // #1023 step 5: include co-hosted events but scope kennelAttendances to
+  // THIS kennel's roster only — co-hosted events have separate attendance
+  // rows per kennel (one set per kennelHasher.kennelId), and we must not
+  // leak the other kennel's attendees into this kennel's history view.
   const where = {
-    kennelAttendances: { some: {} },
-    // #1023 step 5: include co-hosted events in history.
+    kennelAttendances: { some: { kennelHasher: { kennelId: kennel.id } } },
     eventKennels: { some: { kennelId: kennel.id } },
   };
 
@@ -33,6 +36,7 @@ export default async function HistoryPage({ params }: Props) {
       include: {
         kennel: { select: { shortName: true } },
         kennelAttendances: {
+          where: { kennelHasher: { kennelId: kennel.id } },
           include: {
             kennelHasher: {
               select: { hashName: true, nerdName: true },

--- a/src/app/misman/[slug]/import/actions.ts
+++ b/src/app/misman/[slug]/import/actions.ts
@@ -75,8 +75,10 @@ export async function previewCSVImport(
   );
 
   // Fetch events (no date limit for imports)
+  // #1023 step 5: include co-hosted events in import lookup so a misman can
+  // map CSV rows onto trails their kennel co-hosted (not just primary-hosted).
   const events: EventLookup[] = await prisma.event.findMany({
-    where: { kennelId },
+    where: { eventKennels: { some: { kennelId } } },
     select: { id: true, date: true, runNumber: true, kennelId: true },
   });
 
@@ -88,8 +90,11 @@ export async function previewCSVImport(
   );
 
   // Fetch existing attendance for dedup
+  // #1023 step 5: KennelAttendance is hasher-scoped (already segregated per
+  // kennel via the hasher's kennelId), so dedup against existing attendance
+  // for events this kennel hosts (primary OR co-host).
   const existingAttendance = await prisma.kennelAttendance.findMany({
-    where: { event: { kennelId } },
+    where: { event: { eventKennels: { some: { kennelId } } } },
     select: { kennelHasherId: true, eventId: true },
   });
 
@@ -211,8 +216,10 @@ export async function executeCSVImport(
   }
 
   // Fetch events (no date limit)
+  // #1023 step 5: include co-hosted events in import lookup so a misman can
+  // map CSV rows onto trails their kennel co-hosted (not just primary-hosted).
   const events: EventLookup[] = await prisma.event.findMany({
-    where: { kennelId },
+    where: { eventKennels: { some: { kennelId } } },
     select: { id: true, date: true, runNumber: true, kennelId: true },
   });
 
@@ -224,8 +231,11 @@ export async function executeCSVImport(
   );
 
   // Fetch existing attendance for dedup
+  // #1023 step 5: KennelAttendance is hasher-scoped (already segregated per
+  // kennel via the hasher's kennelId), so dedup against existing attendance
+  // for events this kennel hosts (primary OR co-host).
   const existingAttendance = await prisma.kennelAttendance.findMany({
-    where: { event: { kennelId } },
+    where: { event: { eventKennels: { some: { kennelId } } } },
     select: { kennelHasherId: true, eventId: true },
   });
 

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -32,20 +32,30 @@ import { getDisplayTitle, getLocationDisplay } from "@/lib/event-display";
  * list and detail views share a single type, and the detail panel can tell
  * "not yet loaded" (undefined) apart from "loaded and empty" (null).
  */
+/** Kennel shape consumed by EventCard for both primary and co-host display. */
+export type HarelineEventKennel = {
+  id: string;
+  shortName: string;
+  fullName: string;
+  slug: string;
+  region: string;
+  country: string;
+};
+
 export type HarelineEvent = {
   id: string;
   date: string; // ISO string
   dateUtc: Date | null;
   timezone: string | null;
   kennelId: string;
-  kennel: {
-    id: string;
-    shortName: string;
-    fullName: string;
-    slug: string;
-    region: string;
-    country: string;
-  } | null;
+  /** Primary kennel (the one Event.kennelId points at). */
+  kennel: HarelineEventKennel | null;
+  /**
+   * Co-host kennels (#1023 step 5). Empty/undefined for the common
+   * single-kennel case; EventCard's conjunction component is conditional
+   * on this so single-kennel rendering is byte-identical to pre-#1023.
+   */
+  coHosts?: HarelineEventKennel[];
   runNumber: number | null;
   title: string | null;
   haresText: string | null;
@@ -75,10 +85,86 @@ function formatDate(iso: string): string {
 
 export { formatDate };
 
+/**
+ * Render a co-host kennel link with its own region-color underline accent
+ * and a tooltip showing the kennel's fullName + "co-host" annotation.
+ * Visually equal-class to the primary anchor but with `font-bold` (vs the
+ * primary's `font-extrabold`) so the primary still wins the eye.
+ */
+function CoHostKennelLink({
+  kennel,
+  size,
+}: {
+  readonly kennel: HarelineEventKennel;
+  readonly size: "compact" | "medium";
+}) {
+  const color = getRegionColor(kennel.region);
+  const fontSize = size === "medium" ? "text-base" : "text-sm";
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          href={`/kennels/${kennel.slug}`}
+          className={`${fontSize} font-bold tracking-tight text-foreground/90 hover:underline decoration-2 underline-offset-3 truncate`}
+          style={{ textDecorationColor: color }}
+          onClick={(e) => e.stopPropagation()}
+          title={`${kennel.fullName} (co-host)`}
+        >
+          {kennel.shortName}
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent>{kennel.fullName} <span className="opacity-60">· co-host</span></TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * Render `× <co-host>` (or `× <co-host> +N more` for 3+ kennels) — the
+ * typographic conjunction idiom for multi-kennel co-hosted events
+ * (#1023 step 5). The × glyph is decorative and aria-hidden; aria-label
+ * uses "with" instead.
+ */
+function CoHostConjunction({
+  coHosts,
+  size,
+}: {
+  readonly coHosts: readonly HarelineEventKennel[];
+  readonly size: "compact" | "medium";
+}) {
+  if (coHosts.length === 0) return null;
+  const [first, ...rest] = coHosts;
+  return (
+    <>
+      <span aria-hidden="true" className="text-muted-foreground/40 font-light px-0.5 select-none">×</span>
+      <CoHostKennelLink kennel={first} size={size} />
+      {rest.length > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="text-[10px] font-mono text-muted-foreground/60 cursor-help">
+              +{rest.length}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            Also co-hosted by:{" "}
+            {rest.map((k) => k.shortName).join(", ")}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </>
+  );
+}
+
 /** Compose an accessible label from event fields. */
 function buildAriaLabel(event: HarelineEvent, attendance?: AttendanceData | null): string {
   const parts: string[] = [];
-  if (event.kennel?.shortName) parts.push(event.kennel.shortName);
+  if (event.kennel?.shortName) {
+    const coHostNames = event.coHosts?.map((k) => k.shortName) ?? [];
+    parts.push(
+      coHostNames.length > 0
+        ? `${event.kennel.shortName} with ${coHostNames.join(" and ")}`
+        : event.kennel.shortName,
+    );
+  }
   const { title, isFallback } = getDisplayTitle({ ...event, kennel: event.kennel ?? { shortName: "", fullName: "" } });
   if (!isFallback) parts.push(title);
   parts.push(formatDate(event.date));
@@ -194,22 +280,29 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
             </span>
           )}
 
-          <span className="relative w-20 shrink-0 truncate">
+          <span className={`relative shrink-0 flex items-baseline gap-1 truncate ${
+            event.coHosts && event.coHosts.length > 0 ? "max-w-[180px]" : "w-20"
+          }`}>
             {event.kennel ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Link
-                    href={`/kennels/${event.kennel.slug}`}
-                    className="font-extrabold tracking-tight text-foreground hover:underline decoration-2 underline-offset-2 truncate block"
-                    style={{ textDecorationColor: regionColor }}
-                    onClick={(e) => e.stopPropagation()}
-                    title={event.kennel.fullName}
-                  >
-                    {event.kennel.shortName}
-                  </Link>
-                </TooltipTrigger>
-                <TooltipContent>{event.kennel.fullName}</TooltipContent>
-              </Tooltip>
+              <>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Link
+                      href={`/kennels/${event.kennel.slug}`}
+                      className="font-extrabold tracking-tight text-foreground hover:underline decoration-2 underline-offset-2 truncate block"
+                      style={{ textDecorationColor: regionColor }}
+                      onClick={(e) => e.stopPropagation()}
+                      title={event.kennel.fullName}
+                    >
+                      {event.kennel.shortName}
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent>{event.kennel.fullName}</TooltipContent>
+                </Tooltip>
+                {event.coHosts && event.coHosts.length > 0 && (
+                  <CoHostConjunction coHosts={event.coHosts} size="compact" />
+                )}
+              </>
             ) : null}
           </span>
 
@@ -325,20 +418,25 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
             <div className="flex items-center gap-2 min-w-0 flex-wrap">
               {/* Kennel name — the bold visual anchor */}
               {event.kennel ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Link
-                      href={`/kennels/${event.kennel.slug}`}
-                      className="text-base font-extrabold tracking-tight text-foreground hover:underline decoration-2 underline-offset-3"
-                      style={{ textDecorationColor: regionColor }}
-                      onClick={(e) => e.stopPropagation()}
-                      title={event.kennel.fullName}
-                    >
-                      {event.kennel.shortName}
-                    </Link>
-                  </TooltipTrigger>
-                  <TooltipContent>{event.kennel.fullName}</TooltipContent>
-                </Tooltip>
+                <>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Link
+                        href={`/kennels/${event.kennel.slug}`}
+                        className="text-base font-extrabold tracking-tight text-foreground hover:underline decoration-2 underline-offset-3"
+                        style={{ textDecorationColor: regionColor }}
+                        onClick={(e) => e.stopPropagation()}
+                        title={event.kennel.fullName}
+                      >
+                        {event.kennel.shortName}
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent>{event.kennel.fullName}</TooltipContent>
+                  </Tooltip>
+                  {event.coHosts && event.coHosts.length > 0 && (
+                    <CoHostConjunction coHosts={event.coHosts} size="medium" />
+                  )}
+                </>
               ) : null}
 
               {event.kennel && <RegionBadge region={event.kennel.region} size="sm" />}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -123,49 +123,83 @@ export async function getMismanUser(kennelId: string): Promise<User | null> {
 }
 
 /**
- * Get user if they have MISMAN or ADMIN role for ANY kennel on the given
- * event (#1023 step 5). Co-hosted events have multiple kennels via
- * EventKennel; a misman of any one of them should be able to record
- * attendance / view misman UI on the event detail page.
+ * Authorization result for an event-scoped misman check.
+ * `kennelSlug` is the slug of an authorized kennel — useful for routing the
+ * caller to a misman page they actually have access to (e.g. the
+ * "Take Attendance" button on the event detail page must link to a kennel
+ * the user manages, not necessarily the event's primary kennel).
+ */
+export interface EventMismanResult {
+  user: User;
+  kennelId: string;
+  kennelSlug: string;
+}
+
+/**
+ * Get user (+ an authorized kennel slug) if they have MISMAN or ADMIN role
+ * for ANY kennel on the given event (#1023 step 5). Co-hosted events have
+ * multiple kennels via EventKennel; a misman of any one of them should be
+ * able to record attendance / view misman UI on the event detail page —
+ * and the misman link must point at one of THEIR kennels' slugs, not the
+ * event's primary kennel.
  *
  * Falls back to the legacy `Event.kennelId` denormalized primary pointer
  * if the event has no EventKennel rows (shouldn't happen post-step-1
  * backfill, but defensive).
+ *
+ * For site admins, returns the event's primary kennel slug (admins have
+ * access to every misman route, so any slug works).
  */
-export async function getMismanUserForEvent(eventId: string): Promise<User | null> {
+export async function getMismanUserForEvent(eventId: string): Promise<EventMismanResult | null> {
   const clerkUser = await safeCurrentUser();
   if (!clerkUser) return null;
-
-  // Site admins always have misman access (cheap pre-check, avoids the DB roundtrip).
-  const metadata = clerkUser.publicMetadata as { role?: string } | null;
-  if (metadata?.role === "admin") {
-    return getOrCreateUser();
-  }
 
   const event = await prisma.event.findUnique({
     where: { id: eventId },
     select: {
-      kennelId: true, // legacy denorm fallback
-      eventKennels: { select: { kennelId: true } },
+      kennelId: true,
+      kennel: { select: { slug: true } },
+      eventKennels: {
+        select: {
+          kennelId: true,
+          kennel: { select: { slug: true } },
+        },
+      },
     },
   });
   if (!event) return null;
 
+  const eventKennels = event.eventKennels.length > 0
+    ? event.eventKennels.map((ek) => ({ kennelId: ek.kennelId, kennelSlug: ek.kennel.slug }))
+    : [{ kennelId: event.kennelId, kennelSlug: event.kennel?.slug ?? "" }];
+
+  // Site admins have access to every misman route — return the event's
+  // primary kennel slug for the link.
+  const metadata = clerkUser.publicMetadata as { role?: string } | null;
+  if (metadata?.role === "admin") {
+    const user = await getOrCreateUser();
+    if (!user) return null;
+    return { user, kennelId: event.kennelId, kennelSlug: event.kennel?.slug ?? "" };
+  }
+
   const user = await getOrCreateUser();
   if (!user) return null;
-
-  const kennelIds = event.eventKennels.length > 0
-    ? event.eventKennels.map((ek) => ek.kennelId)
-    : [event.kennelId];
 
   const membership = await prisma.userKennel.findFirst({
     where: {
       userId: user.id,
-      kennelId: { in: kennelIds },
+      kennelId: { in: eventKennels.map((k) => k.kennelId) },
       role: { in: ["MISMAN", "ADMIN"] },
     },
+    select: { kennelId: true },
   });
-  return membership ? user : null;
+  if (!membership) return null;
+
+  // Resolve the matching kennel's slug from the event's set so the link
+  // routes to a kennel the user actually manages.
+  const matched = eventKennels.find((k) => k.kennelId === membership.kennelId);
+  if (!matched) return null;
+  return { user, kennelId: matched.kennelId, kennelSlug: matched.kennelSlug };
 }
 
 /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -123,6 +123,52 @@ export async function getMismanUser(kennelId: string): Promise<User | null> {
 }
 
 /**
+ * Get user if they have MISMAN or ADMIN role for ANY kennel on the given
+ * event (#1023 step 5). Co-hosted events have multiple kennels via
+ * EventKennel; a misman of any one of them should be able to record
+ * attendance / view misman UI on the event detail page.
+ *
+ * Falls back to the legacy `Event.kennelId` denormalized primary pointer
+ * if the event has no EventKennel rows (shouldn't happen post-step-1
+ * backfill, but defensive).
+ */
+export async function getMismanUserForEvent(eventId: string): Promise<User | null> {
+  const clerkUser = await safeCurrentUser();
+  if (!clerkUser) return null;
+
+  // Site admins always have misman access (cheap pre-check, avoids the DB roundtrip).
+  const metadata = clerkUser.publicMetadata as { role?: string } | null;
+  if (metadata?.role === "admin") {
+    return getOrCreateUser();
+  }
+
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    select: {
+      kennelId: true, // legacy denorm fallback
+      eventKennels: { select: { kennelId: true } },
+    },
+  });
+  if (!event) return null;
+
+  const user = await getOrCreateUser();
+  if (!user) return null;
+
+  const kennelIds = event.eventKennels.length > 0
+    ? event.eventKennels.map((ek) => ek.kennelId)
+    : [event.kennelId];
+
+  const membership = await prisma.userKennel.findFirst({
+    where: {
+      userId: user.id,
+      kennelId: { in: kennelIds },
+      role: { in: ["MISMAN", "ADMIN"] },
+    },
+  });
+  return membership ? user : null;
+}
+
+/**
  * Get all kennel IDs in the same Roster Group as the given kennel.
  * Returns [kennelId] if the kennel is not in any group (standalone).
  * Still needed for event validation (events belong to kennels, not groups).

--- a/src/lib/travel/search.test.ts
+++ b/src/lib/travel/search.test.ts
@@ -41,7 +41,11 @@ interface MockKennel {
 
 interface MockEvent {
   id: string;
-  kennelId: string;
+  kennelId: string; // primary
+  /** Optional co-host kennel IDs. Combined with `kennelId` to model the
+   *  EventKennel set for multi-kennel events (#1023). When omitted, the
+   *  event behaves single-kennel (just `kennelId`). */
+  coHostKennelIds?: string[];
   date: Date;
   startTime: string | null;
   title: string | null;
@@ -88,13 +92,15 @@ function createMockPrisma(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       findMany: vi.fn().mockImplementation(({ where }: { where: any }) => {
         let filtered = [...events];
-        // #1023 step 5: production query filters via EventKennel.some.
-        // Mock matches Event.kennelId (the denormalized primary pointer) —
-        // for single-kennel test fixtures, primary is the only kennel so
-        // this is equivalent to the EventKennel filter.
+        // #1023 step 5: production query filters via EventKennel.some on
+        // the full kennel set (primary + co-hosts). Match against the
+        // event's `coHostKennelIds` plus its primary `kennelId`.
         const kennelInList = where.eventKennels?.some?.kennelId?.in ?? where.kennelId?.in;
         if (kennelInList) {
-          filtered = filtered.filter((e: MockEvent) => kennelInList.includes(e.kennelId));
+          filtered = filtered.filter((e: MockEvent) => {
+            const allKennelIds = [e.kennelId, ...(e.coHostKennelIds ?? [])];
+            return allKennelIds.some((id) => kennelInList.includes(id));
+          });
         }
         if (where.status === "CONFIRMED") {
           filtered = filtered.filter((e: MockEvent) => e.status === "CONFIRMED");
@@ -105,7 +111,18 @@ function createMockPrisma(
         if (where.date?.lte) {
           filtered = filtered.filter((e: MockEvent) => e.date <= where.date.lte);
         }
-        return Promise.resolve(filtered);
+        // Production includes `eventKennels: { select: { kennelId: true } }`
+        // so the result-builder can pivot to the matching co-host. Mirror
+        // that in the mock by attaching the kennel-set on each row.
+        return Promise.resolve(
+          filtered.map((e) => ({
+            ...e,
+            eventKennels: [
+              { kennelId: e.kennelId },
+              ...(e.coHostKennelIds ?? []).map((id) => ({ kennelId: id })),
+            ],
+          })),
+        );
       }),
     },
     scheduleRule: {
@@ -214,6 +231,36 @@ describe("executeTravelSearch", () => {
     // broaderRadiusKm must be undefined on primary-only searches or
     // TripSummary will render the "routing revised" expanded-radius UI.
     expect(result.destinations[0].broaderRadiusKm).toBeUndefined();
+  });
+
+  it("pivots co-host events onto the matching nearby kennel (#1023 step 5)", async () => {
+    // Event has primary kennel FAR from Atlanta (London) and a co-host
+    // kennel IN Atlanta. The query matches because Atlanta is in nearbyIds.
+    // Result must surface metadata for the Atlanta kennel, not the
+    // (out-of-range) London primary.
+    const londonKennel: MockKennel = {
+      ...testKennel,
+      id: "k-london",
+      slug: "london-h3",
+      shortName: "London H3",
+      latitude: 51.5,
+      longitude: -0.13,
+    };
+    const coHostEvent: MockEvent = {
+      ...testEvent,
+      id: "e-cohost",
+      kennelId: "k-london",        // primary is London (far from Atlanta)
+      coHostKennelIds: ["k-atl"],   // co-host is Atlanta (in range)
+    };
+    const prisma = createMockPrisma([testKennel, londonKennel], [coHostEvent], []);
+    const result = await executeTravelSearch(prisma, baseParams);
+
+    expect(result.confirmed).toHaveLength(1);
+    // Pivoted: kennel metadata is Atlanta H3, not London H3.
+    expect(result.confirmed[0].kennelId).toBe("k-atl");
+    expect(result.confirmed[0].kennelName).toBe("Atlanta H3");
+    expect(result.confirmed[0].kennelSlug).toBe("atlanta-h3");
+    expect(result.confirmed[0].distanceTier).toBe("nearby");
   });
 
   it("returns likely projections from schedule rules", async () => {

--- a/src/lib/travel/search.test.ts
+++ b/src/lib/travel/search.test.ts
@@ -88,8 +88,13 @@ function createMockPrisma(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       findMany: vi.fn().mockImplementation(({ where }: { where: any }) => {
         let filtered = [...events];
-        if (where.kennelId?.in) {
-          filtered = filtered.filter((e: MockEvent) => where.kennelId.in.includes(e.kennelId));
+        // #1023 step 5: production query filters via EventKennel.some.
+        // Mock matches Event.kennelId (the denormalized primary pointer) —
+        // for single-kennel test fixtures, primary is the only kennel so
+        // this is equivalent to the EventKennel filter.
+        const kennelInList = where.eventKennels?.some?.kennelId?.in ?? where.kennelId?.in;
+        if (kennelInList) {
+          filtered = filtered.filter((e: MockEvent) => kennelInList.includes(e.kennelId));
         }
         if (where.status === "CONFIRMED") {
           filtered = filtered.filter((e: MockEvent) => e.status === "CONFIRMED");

--- a/src/lib/travel/search.ts
+++ b/src/lib/travel/search.ts
@@ -487,7 +487,8 @@ async function runStopSearch(
     prisma.event.findMany({
       where: {
         ...CANONICAL_EVENT_WHERE,
-        kennelId: { in: nearbyIds },
+        // #1023 step 5: include co-hosted events at any nearby kennel.
+        eventKennels: { some: { kennelId: { in: nearbyIds } } },
         date: { gte: startDate, lte: confirmedEndDate },
         status: "CONFIRMED",
       },

--- a/src/lib/travel/search.ts
+++ b/src/lib/travel/search.ts
@@ -488,12 +488,17 @@ async function runStopSearch(
       where: {
         ...CANONICAL_EVENT_WHERE,
         // #1023 step 5: include co-hosted events at any nearby kennel.
+        // The result construction below pivots metadata onto whichever
+        // EventKennel.kennelId is in `nearbyIds` (not necessarily the
+        // event's primary), so the query returns the kennel-link rows
+        // alongside the event for that pivot.
         eventKennels: { some: { kennelId: { in: nearbyIds } } },
         date: { gte: startDate, lte: confirmedEndDate },
         status: "CONFIRMED",
       },
       include: {
         eventLinks: { select: { url: true, label: true } },
+        eventKennels: { select: { kennelId: true } },
       },
       orderBy: { date: "asc" },
       take: CONFIRMED_EVENT_ROW_CAP,
@@ -564,8 +569,17 @@ async function runStopSearch(
   const weatherInputs: WeatherInput[] = [];
 
   // Step 13: Assign distance tiers + build result objects
+  // #1023 step 5: when an event matches because a CO-HOST kennel is in
+  // `nearbyIds` (the primary `event.kennelId` may not be), pivot the
+  // result's kennel metadata onto that nearby kennel — otherwise we'd
+  // emit empty kennelSlug/kennelName/distance for the user's intended
+  // destination kennel.
+  const nearbyIdsSet = new Set(nearbyIds);
   const confirmedResults: ConfirmedResult[] = confirmedEvents.map((event) => {
-    const kennel = kennelMap.get(event.kennelId);
+    const pivotKennelId = nearbyIdsSet.has(event.kennelId)
+      ? event.kennelId
+      : (event.eventKennels.find((ek) => nearbyIdsSet.has(ek.kennelId))?.kennelId ?? event.kennelId);
+    const kennel = kennelMap.get(pivotKennelId);
     const eventLat = event.latitude ?? kennel?.latitude;
     const eventLng = event.longitude ?? kennel?.longitude;
     const distanceKm = eventLat != null && eventLng != null
@@ -585,7 +599,7 @@ async function runStopSearch(
       destinationIndex: index,
       destinationLabel,
       eventId: event.id,
-      kennelId: event.kennelId,
+      kennelId: pivotKennelId,
       kennelSlug: kennel?.slug ?? "",
       kennelName: kennel?.shortName ?? "",
       kennelFullName: kennel?.fullName ?? "",


### PR DESCRIPTION
## Summary

Fifth implementation step of the multi-kennel co-hosted events spec ([docs/multi-kennel-events-spec.md](docs/multi-kennel-events-spec.md)). Steps 1–4 merged. **This is the first user-visible feature exposure** — co-hosted events (Cherry City × OH3 inaugural is the canonical example) now appear on BOTH kennels' pages and render their relationship in the EventCard.

19 files changed, +483/−81.

### What lands

**Authorization**
- `src/lib/auth.ts` — new `getMismanUserForEvent(eventId)` checks misman role across the event's full kennel set (primary + co-hosts).
- `src/app/hareline/[eventId]/page.tsx` — uses the new helper. Secondary co-host kennel mismans now get the misman UI on event detail pages.
- `src/app/misman/[slug]/attendance/actions.ts` — three IDOR scope guards (`loadAttendanceForMisman`, `validateEventForAttendance`, delete-attendance scope check) now compute `eventKennelIds` from the EventKennel set.

**WHERE-filter rewrites** (`where: { kennelId: X }` → `where: { eventKennels: { some: { kennelId: X } } }`):
- Kennel page event list, misman attendance/roster/history/import, admin event filters, logbook subscriptions, travel search

**EventCard co-host UI** ([frontend-design pass](https://chatgpt.com)):
- Typographic conjunction: `Cherry City × OH3` — primary kennel keeps existing visual anchor; co-host renders equal-class with its own region-color underline accent
- Conditional render — single-kennel events render byte-identical to today
- Hover tooltips disclose fullName + "co-host" annotation
- 3+ kennels: collapse to `× <first> +N` with tooltip listing the rest
- aria-label says "Cherry City with OH3" for screen readers
- Stance: **primary-anchored** — same event renders identically across surfaces (`/k/cch3-or`, `/k/oh3`, `/hareline`)

**Server-side coHosts SELECT** — added `eventKennels: { where: { isPrimary: false }, include: ... }` to kennel page + hareline queries; mapped into `coHosts` array.

### Local verification

- **5,406 unit tests pass**; `tsc --noEmit` clean
- Lint: 14 pre-existing warnings, no new
- `scripts/live-verify-display-co-host.ts` (new) — synthetic Cherry City × OH3 event surfaces on BOTH `/k/cch3-or` and `/k/oh3` page queries via the rewritten EventKennel.some predicate
- All earlier step 1/2/4 live-verify scripts still pass

### What's NOT in this PR

- Pipeline (`src/pipeline/merge.ts`) keeps `Event.kennelId` reads — the denorm pointer is still maintained per the dual-write helper from step 2; gets dropped in step 7
- Kennel directory `_count.events` stays primary-only (deferred — needs `_count.eventKennels` filtered by date+status)
- Travel search evidence/timeline scoring stays primary-only
- `EventDetailPanel` co-host treatment deferred to a follow-up (heavier "Co-hosted by" section)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 5,406 pass
- [x] `scripts/live-verify-display-co-host.ts` — synthetic Cherry City × OH3 surfaces on both kennel pages
- [x] All earlier step live-verify scripts still pass
- [ ] Vercel preview: visit `/k/cch3-or` and `/k/oh3` and confirm Cherry City × OH3 inaugural appears on both with the conjunction badge
- [ ] Visit `/hareline` — confirm conjunction renders on multi-kennel events
- [ ] Misman scope: log in as a misman of OH3 → visit Cherry City × OH3 event detail page → confirm misman UI is visible (was denied pre-step-5)

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)