### PR TITLE
feat(backfill): historical co-host EventKennel rows (step 6 of #1023)

### DIFF
--- a/scripts/backfill-historical-co-hosts.ts
+++ b/scripts/backfill-historical-co-hosts.ts
@@ -1,0 +1,311 @@
+/**
+ * Historical co-host backfill (#1023 step 6).
+ *
+ * Scans for known multi-kennel co-hosted events whose `EventKennel` set
+ * only contains the primary kennel (missing the secondary). Inserts the
+ * missing EventKennel(eventId, kennelId, isPrimary=false) rows so the
+ * event surfaces on BOTH kennels' pages.
+ *
+ * The list of (titlePattern, requiredKennelCodes) tuples is curated by
+ * hand — no fuzzy adapter heuristics. Each entry is a real-world co-host
+ * relationship that's been verified to exist in production.
+ *
+ * Idempotent: safe to re-run. Existing EventKennel rows are kept.
+ *
+ * Run modes:
+ *   - Dry run (default): `npx tsx scripts/backfill-historical-co-hosts.ts`
+ *   - Apply:             `npx tsx scripts/backfill-historical-co-hosts.ts --apply`
+ *
+ * Refuses to run against any DATABASE_URL that isn't on the local-safe
+ * allowlist UNLESS `--prod` is passed (production runs require explicit
+ * opt-in to avoid accidentally mutating prod from a wrong shell).
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const LOCAL_DB_HOSTS = new Set([
+  "localhost", "127.0.0.1", "::1", "0.0.0.0",
+  "host.docker.internal", "postgres", "db",
+]);
+
+/**
+ * Curated list of historical multi-kennel events. Each entry says
+ * "for events on `eventDate` whose title matches `titlePattern` and primary
+ * kennel is `primaryKennelCode`, add EventKennel rows for the listed
+ * `coHostKennelCodes`".
+ *
+ * `titlePattern` is a case-insensitive substring match (NOT regex) so the
+ * curation is unambiguous; if a future event needs different matching, add
+ * a new entry rather than expanding this one.
+ *
+ * `eventDate` (YYYY-MM-DD) is REQUIRED so re-runs months from now don't
+ * accidentally over-match similarly-titled future events. Per Codex review.
+ *
+ * `kennelCode` lookups are exact (Kennel.kennelCode is immutable).
+ */
+interface CoHostBackfillEntry {
+  eventDate: string;             // YYYY-MM-DD — date-scopes the title match
+  titlePattern: string;
+  primaryKennelCode: string;
+  coHostKennelCodes: string[];
+  /** Free-form note for the dry-run log — explains why this entry was added. */
+  note: string;
+}
+
+const BACKFILL_ENTRIES: CoHostBackfillEntry[] = [
+  // ── Cherry City H3 × OH3 inaugural (#991) ──
+  // The canonical case. Both kennels' calendars surfaced the trail, so prod
+  // has TWO Event rows (one per primary). Each is missing the other as a
+  // co-host EventKennel row; this backfill adds both. (Cross-kennel dedup
+  // — collapsing the two Events into one canonical — is intentionally out
+  // of scope; tracked separately in docs/roadmap.md.)
+  {
+    eventDate: "2025-07-12",
+    titlePattern: "Cherry City H3 #1 / OH3",
+    primaryKennelCode: "cch3-or",
+    coHostKennelCodes: ["oh3"],
+    note: "#991 Cherry City × OH3 inaugural (cch3-or primary row)",
+  },
+  {
+    eventDate: "2025-07-12",
+    titlePattern: "Cherry City H3 #1 / OH3",
+    primaryKennelCode: "oh3",
+    coHostKennelCodes: ["cch3-or"],
+    note: "#991 Cherry City × OH3 inaugural (oh3 primary row)",
+  },
+
+  // ── Space City × Galveston H3 (recurring joint hashes) ──
+  {
+    eventDate: "2025-10-28",
+    titlePattern: "Space City H3 #313 - Joint Trail with Galveston H3",
+    primaryKennelCode: "galh3",
+    coHostKennelCodes: ["space-city-h3"],
+    note: "Space City × Galveston joint trail (2025-10-28)",
+  },
+  {
+    eventDate: "2025-12-30",
+    titlePattern: "Galveston H3 #297 - Joint Hash with Space City H3",
+    primaryKennelCode: "galh3",
+    coHostKennelCodes: ["space-city-h3"],
+    note: "Galveston × Space City joint hash (2025-12-30)",
+  },
+
+  // ── Cleveland H4 × Rubber City H3 (5th-Saturday recurring tradition) ──
+  // Rubber City primary, Cleveland H4 co-host
+  {
+    eventDate: "2026-05-30",
+    titlePattern: "5th Saturday with Cleveland H4",
+    primaryKennelCode: "rch3",
+    coHostKennelCodes: ["cleh4"],
+    note: "RCH3 × CH4 5th-Saturday joint trail (2026-05-30)",
+  },
+  {
+    eventDate: "2023-07-29",
+    titlePattern: "5th Saturday of July Trail with Cleveland H4",
+    primaryKennelCode: "rch3",
+    coHostKennelCodes: ["cleh4"],
+    note: "RCH3 × CH4 5th-Saturday joint trail (2023-07-29)",
+  },
+  {
+    eventDate: "2019-03-30",
+    titlePattern: "Joint Cleveland Hash",
+    primaryKennelCode: "rch3",
+    coHostKennelCodes: ["cleh4"],
+    note: "RCH3 × CH4 joint Cleveland hash (2019-03-30)",
+  },
+  // Cleveland H4 primary, Rubber City co-host
+  {
+    eventDate: "2025-12-13",
+    titlePattern: "CH4 and Rubber City Christmas Trail",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 Christmas trail (2025-12-13)",
+  },
+  {
+    eventDate: "2024-06-29",
+    titlePattern: "CH4 5th Saturday with Rubber City",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 5th-Saturday (2024-06-29)",
+  },
+  {
+    eventDate: "2023-07-29",
+    titlePattern: "CH4's 5th Saturday with Rubber City",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 5th-Saturday (2023-07-29)",
+  },
+  {
+    eventDate: "2022-07-30",
+    titlePattern: "Joint Trail with Rubber City H3",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 joint trail (2022-07-30)",
+  },
+  {
+    eventDate: "2018-09-29",
+    titlePattern: "CH4 Trail #790/ Rubber City",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 trail #790 5th-Saturday (2018-09-29)",
+  },
+
+  // ── SSH3 × SWH3 (joint trail) ──
+  // SSH3 (Seattle) — kennelCode is `ssh3-wa` in the DB.
+  {
+    eventDate: "2026-05-16",
+    titlePattern: "SSH3 #236 with SWH3",
+    primaryKennelCode: "ssh3-wa",
+    coHostKennelCodes: ["swh3"],
+    note: "SSH3 × SWH3 joint trail (2026-05-16)",
+  },
+];
+
+interface PlannedAction {
+  eventId: string;
+  eventDate: string;
+  eventTitle: string;
+  primaryKennelCode: string;
+  coHostKennelCode: string;
+  coHostKennelId: string;
+  alreadyExists: boolean;
+}
+
+function assertLocalDbOrProdFlag(args: string[]): void {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL not set");
+  const host = new URL(url.replace(/^postgresql:/, "http:")).hostname;
+  if (LOCAL_DB_HOSTS.has(host)) return;
+  if (!args.includes("--prod")) {
+    throw new Error(
+      `Refusing to run against non-local host ${host}. Pass --prod to override (production runs).`,
+    );
+  }
+  console.warn(`⚠️  Running against PRODUCTION host ${host} (--prod flag set).`);
+}
+
+async function planActions(): Promise<PlannedAction[]> {
+  const planned: PlannedAction[] = [];
+
+  for (const entry of BACKFILL_ENTRIES) {
+    const primaryKennel = await prisma.kennel.findFirst({
+      where: { kennelCode: { equals: entry.primaryKennelCode, mode: "insensitive" } },
+      select: { id: true },
+    });
+    if (!primaryKennel) {
+      console.warn(`SKIP entry ${entry.note} — primary kennel "${entry.primaryKennelCode}" not in DB`);
+      continue;
+    }
+
+    // Resolve every co-host once; bail with a clear error rather than
+    // silently dropping the row (curation bugs should be loud).
+    const coHosts: { kennelCode: string; kennelId: string }[] = [];
+    for (const coHostCode of entry.coHostKennelCodes) {
+      const k = await prisma.kennel.findFirst({
+        where: { kennelCode: { equals: coHostCode, mode: "insensitive" } },
+        select: { id: true },
+      });
+      if (!k) {
+        console.warn(`SKIP entry ${entry.note} — co-host kennel "${coHostCode}" not in DB`);
+        coHosts.length = 0;
+        break;
+      }
+      coHosts.push({ kennelCode: coHostCode, kennelId: k.id });
+    }
+    if (coHosts.length === 0) continue;
+
+    // Events are stored at UTC noon — match the day window so a date-only
+    // entry catches the row regardless of its dateUtc time-of-day.
+    const dayStart = new Date(`${entry.eventDate}T00:00:00Z`);
+    const dayEnd = new Date(`${entry.eventDate}T23:59:59.999Z`);
+    const events = await prisma.event.findMany({
+      where: {
+        kennelId: primaryKennel.id,
+        title: { contains: entry.titlePattern, mode: "insensitive" },
+        date: { gte: dayStart, lte: dayEnd },
+      },
+      select: { id: true, date: true, title: true },
+    });
+
+    for (const event of events) {
+      for (const coHost of coHosts) {
+        const existing = await prisma.eventKennel.findUnique({
+          where: { eventId_kennelId: { eventId: event.id, kennelId: coHost.kennelId } },
+          select: { isPrimary: true },
+        });
+        planned.push({
+          eventId: event.id,
+          eventDate: event.date.toISOString().slice(0, 10),
+          eventTitle: event.title ?? "",
+          primaryKennelCode: entry.primaryKennelCode,
+          coHostKennelCode: coHost.kennelCode,
+          coHostKennelId: coHost.kennelId,
+          alreadyExists: existing !== null,
+        });
+      }
+    }
+  }
+
+  return planned;
+}
+
+async function applyActions(planned: PlannedAction[]): Promise<{ inserted: number; skipped: number }> {
+  let inserted = 0;
+  let skipped = 0;
+  for (const action of planned) {
+    if (action.alreadyExists) {
+      skipped++;
+      continue;
+    }
+    // Use upsert defensively in case the row appeared between plan + apply
+    // (long-running script, concurrent dual-write from a fresh scrape).
+    await prisma.eventKennel.upsert({
+      where: { eventId_kennelId: { eventId: action.eventId, kennelId: action.coHostKennelId } },
+      create: {
+        eventId: action.eventId,
+        kennelId: action.coHostKennelId,
+        isPrimary: false,
+      },
+      update: {}, // keep existing isPrimary state if any (won't demote a primary)
+    });
+    inserted++;
+  }
+  return { inserted, skipped };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  assertLocalDbOrProdFlag(args);
+  const apply = args.includes("--apply");
+
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN (pass --apply to write)"}`);
+  console.log(`Curated entries: ${BACKFILL_ENTRIES.length}`);
+
+  const planned = await planActions();
+  console.log(`\nPlanned actions: ${planned.length}`);
+  for (const p of planned) {
+    const tag = p.alreadyExists ? "EXISTS" : "INSERT";
+    console.log(
+      `  [${tag}] ${p.eventDate} ${p.eventId} (${p.primaryKennelCode} primary) +co-host ${p.coHostKennelCode}`,
+    );
+    console.log(`           "${p.eventTitle}"`);
+  }
+
+  if (!apply) {
+    const insertCount = planned.filter((p) => !p.alreadyExists).length;
+    const existsCount = planned.length - insertCount;
+    console.log(`\nDry-run summary: would insert ${insertCount}, ${existsCount} already exist.`);
+    return;
+  }
+
+  const { inserted, skipped } = await applyActions(planned);
+  console.log(`\nApplied: inserted ${inserted}, skipped ${skipped} (already existed).`);
+}
+
+main()
+  .catch((err) => {
+    console.error("\nBackfill failed:");
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/backfill-historical-co-hosts.ts
+++ b/scripts/backfill-historical-co-hosts.ts
@@ -22,144 +22,15 @@
  */
 import "dotenv/config";
 import { prisma } from "@/lib/db";
+import { HISTORICAL_CO_HOST_ENTRIES } from "./data/historical-co-hosts";
 
 const LOCAL_DB_HOSTS = new Set([
   "localhost", "127.0.0.1", "::1", "0.0.0.0",
   "host.docker.internal", "postgres", "db",
 ]);
 
-/**
- * Curated list of historical multi-kennel events. Each entry says
- * "for events on `eventDate` whose title matches `titlePattern` and primary
- * kennel is `primaryKennelCode`, add EventKennel rows for the listed
- * `coHostKennelCodes`".
- *
- * `titlePattern` is a case-insensitive substring match (NOT regex) so the
- * curation is unambiguous; if a future event needs different matching, add
- * a new entry rather than expanding this one.
- *
- * `eventDate` (YYYY-MM-DD) is REQUIRED so re-runs months from now don't
- * accidentally over-match similarly-titled future events. Per Codex review.
- *
- * `kennelCode` lookups are exact (Kennel.kennelCode is immutable).
- */
-interface CoHostBackfillEntry {
-  eventDate: string;             // YYYY-MM-DD — date-scopes the title match
-  titlePattern: string;
-  primaryKennelCode: string;
-  coHostKennelCodes: string[];
-  /** Free-form note for the dry-run log — explains why this entry was added. */
-  note: string;
-}
+const BACKFILL_ENTRIES = HISTORICAL_CO_HOST_ENTRIES;
 
-const BACKFILL_ENTRIES: CoHostBackfillEntry[] = [
-  // ── Cherry City H3 × OH3 inaugural (#991) ──
-  // The canonical case. Both kennels' calendars surfaced the trail, so prod
-  // has TWO Event rows (one per primary). Each is missing the other as a
-  // co-host EventKennel row; this backfill adds both. (Cross-kennel dedup
-  // — collapsing the two Events into one canonical — is intentionally out
-  // of scope; tracked separately in docs/roadmap.md.)
-  {
-    eventDate: "2025-07-12",
-    titlePattern: "Cherry City H3 #1 / OH3",
-    primaryKennelCode: "cch3-or",
-    coHostKennelCodes: ["oh3"],
-    note: "#991 Cherry City × OH3 inaugural (cch3-or primary row)",
-  },
-  {
-    eventDate: "2025-07-12",
-    titlePattern: "Cherry City H3 #1 / OH3",
-    primaryKennelCode: "oh3",
-    coHostKennelCodes: ["cch3-or"],
-    note: "#991 Cherry City × OH3 inaugural (oh3 primary row)",
-  },
-
-  // ── Space City × Galveston H3 (recurring joint hashes) ──
-  {
-    eventDate: "2025-10-28",
-    titlePattern: "Space City H3 #313 - Joint Trail with Galveston H3",
-    primaryKennelCode: "galh3",
-    coHostKennelCodes: ["space-city-h3"],
-    note: "Space City × Galveston joint trail (2025-10-28)",
-  },
-  {
-    eventDate: "2025-12-30",
-    titlePattern: "Galveston H3 #297 - Joint Hash with Space City H3",
-    primaryKennelCode: "galh3",
-    coHostKennelCodes: ["space-city-h3"],
-    note: "Galveston × Space City joint hash (2025-12-30)",
-  },
-
-  // ── Cleveland H4 × Rubber City H3 (5th-Saturday recurring tradition) ──
-  // Rubber City primary, Cleveland H4 co-host
-  {
-    eventDate: "2026-05-30",
-    titlePattern: "5th Saturday with Cleveland H4",
-    primaryKennelCode: "rch3",
-    coHostKennelCodes: ["cleh4"],
-    note: "RCH3 × CH4 5th-Saturday joint trail (2026-05-30)",
-  },
-  {
-    eventDate: "2023-07-29",
-    titlePattern: "5th Saturday of July Trail with Cleveland H4",
-    primaryKennelCode: "rch3",
-    coHostKennelCodes: ["cleh4"],
-    note: "RCH3 × CH4 5th-Saturday joint trail (2023-07-29)",
-  },
-  {
-    eventDate: "2019-03-30",
-    titlePattern: "Joint Cleveland Hash",
-    primaryKennelCode: "rch3",
-    coHostKennelCodes: ["cleh4"],
-    note: "RCH3 × CH4 joint Cleveland hash (2019-03-30)",
-  },
-  // Cleveland H4 primary, Rubber City co-host
-  {
-    eventDate: "2025-12-13",
-    titlePattern: "CH4 and Rubber City Christmas Trail",
-    primaryKennelCode: "cleh4",
-    coHostKennelCodes: ["rch3"],
-    note: "CH4 × RCH3 Christmas trail (2025-12-13)",
-  },
-  {
-    eventDate: "2024-06-29",
-    titlePattern: "CH4 5th Saturday with Rubber City",
-    primaryKennelCode: "cleh4",
-    coHostKennelCodes: ["rch3"],
-    note: "CH4 × RCH3 5th-Saturday (2024-06-29)",
-  },
-  {
-    eventDate: "2023-07-29",
-    titlePattern: "CH4's 5th Saturday with Rubber City",
-    primaryKennelCode: "cleh4",
-    coHostKennelCodes: ["rch3"],
-    note: "CH4 × RCH3 5th-Saturday (2023-07-29)",
-  },
-  {
-    eventDate: "2022-07-30",
-    titlePattern: "Joint Trail with Rubber City H3",
-    primaryKennelCode: "cleh4",
-    coHostKennelCodes: ["rch3"],
-    note: "CH4 × RCH3 joint trail (2022-07-30)",
-  },
-  {
-    eventDate: "2018-09-29",
-    titlePattern: "CH4 Trail #790/ Rubber City",
-    primaryKennelCode: "cleh4",
-    coHostKennelCodes: ["rch3"],
-    note: "CH4 × RCH3 trail #790 5th-Saturday (2018-09-29)",
-  },
-
-  // ── SSH3 × SWH3 (joint trail) ──
-  // SSH3 (Seattle) — kennelCode is `ssh3-wa` in the DB.
-  {
-    eventDate: "2026-05-16",
-    titlePattern: "SSH3 #236 with SWH3",
-    primaryKennelCode: "ssh3-wa",
-    coHostKennelCodes: ["swh3"],
-    note: "SSH3 × SWH3 joint trail (2026-05-16)",
-  },
-];
 
 interface PlannedAction {
   eventId: string;

--- a/scripts/data/historical-co-hosts.ts
+++ b/scripts/data/historical-co-hosts.ts
@@ -1,0 +1,137 @@
+/**
+ * Curated registry of known historical multi-kennel co-host events
+ * (#1023 step 6). Single source of truth shared between the backfill
+ * mutator (`scripts/backfill-historical-co-hosts.ts`) and the read-only
+ * verifier (`scripts/verify-historical-cohost-visibility.ts`) — keeping
+ * the list here prevents the two scripts from drifting out of sync.
+ *
+ * Each entry says "for events on `eventDate` whose title matches
+ * `titlePattern` (case-insensitive substring) and whose primary kennel is
+ * `primaryKennelCode`, add EventKennel rows for the listed
+ * `coHostKennelCodes` as `isPrimary=false`".
+ *
+ * `eventDate` (YYYY-MM-DD) is REQUIRED so re-runs months from now don't
+ * accidentally over-match similarly-titled future events.
+ *
+ * `kennelCode` lookups are exact (Kennel.kennelCode is immutable).
+ *
+ * Adding a new entry: append below; both scripts pick it up automatically
+ * on next run. Verify the kennelCodes resolve in production before applying.
+ */
+export interface CoHostBackfillEntry {
+  eventDate: string;             // YYYY-MM-DD — date-scopes the title match
+  titlePattern: string;
+  primaryKennelCode: string;
+  coHostKennelCodes: string[];
+  /** Free-form note for the dry-run log — explains why this entry exists. */
+  note: string;
+}
+
+export const HISTORICAL_CO_HOST_ENTRIES: CoHostBackfillEntry[] = [
+  // ── Cherry City H3 × OH3 inaugural (#991) ──
+  // The canonical case. Both kennels' calendars surfaced the trail, so prod
+  // has TWO Event rows (one per primary). Each is missing the other as a
+  // co-host EventKennel row; this backfill adds both. (Cross-kennel dedup
+  // — collapsing the two Events into one canonical — is intentionally out
+  // of scope; tracked separately in docs/roadmap.md.)
+  {
+    eventDate: "2025-07-12",
+    titlePattern: "Cherry City H3 #1 / OH3",
+    primaryKennelCode: "cch3-or",
+    coHostKennelCodes: ["oh3"],
+    note: "#991 Cherry City × OH3 inaugural (cch3-or primary row)",
+  },
+  {
+    eventDate: "2025-07-12",
+    titlePattern: "Cherry City H3 #1 / OH3",
+    primaryKennelCode: "oh3",
+    coHostKennelCodes: ["cch3-or"],
+    note: "#991 Cherry City × OH3 inaugural (oh3 primary row)",
+  },
+
+  // ── Space City × Galveston H3 (recurring joint hashes) ──
+  {
+    eventDate: "2025-10-28",
+    titlePattern: "Space City H3 #313 - Joint Trail with Galveston H3",
+    primaryKennelCode: "galh3",
+    coHostKennelCodes: ["space-city-h3"],
+    note: "Space City × Galveston joint trail (2025-10-28)",
+  },
+  {
+    eventDate: "2025-12-30",
+    titlePattern: "Galveston H3 #297 - Joint Hash with Space City H3",
+    primaryKennelCode: "galh3",
+    coHostKennelCodes: ["space-city-h3"],
+    note: "Galveston × Space City joint hash (2025-12-30)",
+  },
+
+  // ── Cleveland H4 × Rubber City H3 (5th-Saturday recurring tradition) ──
+  // Rubber City primary, Cleveland H4 co-host
+  {
+    eventDate: "2026-05-30",
+    titlePattern: "5th Saturday with Cleveland H4",
+    primaryKennelCode: "rch3",
+    coHostKennelCodes: ["cleh4"],
+    note: "RCH3 × CH4 5th-Saturday joint trail (2026-05-30)",
+  },
+  {
+    eventDate: "2023-07-29",
+    titlePattern: "5th Saturday of July Trail with Cleveland H4",
+    primaryKennelCode: "rch3",
+    coHostKennelCodes: ["cleh4"],
+    note: "RCH3 × CH4 5th-Saturday joint trail (2023-07-29)",
+  },
+  {
+    eventDate: "2019-03-30",
+    titlePattern: "Joint Cleveland Hash",
+    primaryKennelCode: "rch3",
+    coHostKennelCodes: ["cleh4"],
+    note: "RCH3 × CH4 joint Cleveland hash (2019-03-30)",
+  },
+  // Cleveland H4 primary, Rubber City co-host
+  {
+    eventDate: "2025-12-13",
+    titlePattern: "CH4 and Rubber City Christmas Trail",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 Christmas trail (2025-12-13)",
+  },
+  {
+    eventDate: "2024-06-29",
+    titlePattern: "CH4 5th Saturday with Rubber City",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 5th-Saturday (2024-06-29)",
+  },
+  {
+    eventDate: "2023-07-29",
+    titlePattern: "CH4's 5th Saturday with Rubber City",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 5th-Saturday (2023-07-29)",
+  },
+  {
+    eventDate: "2022-07-30",
+    titlePattern: "Joint Trail with Rubber City H3",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 joint trail (2022-07-30)",
+  },
+  {
+    eventDate: "2018-09-29",
+    titlePattern: "CH4 Trail #790/ Rubber City",
+    primaryKennelCode: "cleh4",
+    coHostKennelCodes: ["rch3"],
+    note: "CH4 × RCH3 trail #790 5th-Saturday (2018-09-29)",
+  },
+
+  // ── SSH3 × SWH3 (joint trail) ──
+  // SSH3 (Seattle) — kennelCode is `ssh3-wa` in the DB.
+  {
+    eventDate: "2026-05-16",
+    titlePattern: "SSH3 #236 with SWH3",
+    primaryKennelCode: "ssh3-wa",
+    coHostKennelCodes: ["swh3"],
+    note: "SSH3 × SWH3 joint trail (2026-05-16)",
+  },
+];

--- a/scripts/verify-historical-cohost-visibility.ts
+++ b/scripts/verify-historical-cohost-visibility.ts
@@ -1,0 +1,132 @@
+/**
+ * Read-only verifier for the historical co-host backfill (#1023 step 6).
+ *
+ * After running `scripts/backfill-historical-co-hosts.ts --apply`, this
+ * script confirms the affected events actually surface on BOTH kennel
+ * pages via the kennel-page WHERE filter. Mirrors the production page
+ * predicate in `src/app/kennels/[slug]/page.tsx`.
+ *
+ * Read-only — no DB mutations. Safe to run anywhere.
+ *
+ * Run: `npx tsx scripts/verify-historical-cohost-visibility.ts`
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+/**
+ * Each entry mirrors a `BACKFILL_ENTRIES` row in
+ * `backfill-historical-co-hosts.ts` — keep in sync if entries are added.
+ */
+interface VerifyEntry {
+  eventDate: string;
+  titlePattern: string;
+  primaryKennelCode: string;
+  coHostKennelCodes: string[];
+}
+
+const ENTRIES: VerifyEntry[] = [
+  { eventDate: "2025-07-12", titlePattern: "Cherry City H3 #1 / OH3", primaryKennelCode: "cch3-or", coHostKennelCodes: ["oh3"] },
+  { eventDate: "2025-07-12", titlePattern: "Cherry City H3 #1 / OH3", primaryKennelCode: "oh3", coHostKennelCodes: ["cch3-or"] },
+  { eventDate: "2025-10-28", titlePattern: "Space City H3 #313 - Joint Trail with Galveston H3", primaryKennelCode: "galh3", coHostKennelCodes: ["space-city-h3"] },
+  { eventDate: "2025-12-30", titlePattern: "Galveston H3 #297 - Joint Hash with Space City H3", primaryKennelCode: "galh3", coHostKennelCodes: ["space-city-h3"] },
+  { eventDate: "2026-05-30", titlePattern: "5th Saturday with Cleveland H4", primaryKennelCode: "rch3", coHostKennelCodes: ["cleh4"] },
+  { eventDate: "2023-07-29", titlePattern: "5th Saturday of July Trail with Cleveland H4", primaryKennelCode: "rch3", coHostKennelCodes: ["cleh4"] },
+  { eventDate: "2019-03-30", titlePattern: "Joint Cleveland Hash", primaryKennelCode: "rch3", coHostKennelCodes: ["cleh4"] },
+  { eventDate: "2025-12-13", titlePattern: "CH4 and Rubber City Christmas Trail", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
+  { eventDate: "2024-06-29", titlePattern: "CH4 5th Saturday with Rubber City", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
+  { eventDate: "2023-07-29", titlePattern: "CH4's 5th Saturday with Rubber City", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
+  { eventDate: "2022-07-30", titlePattern: "Joint Trail with Rubber City H3", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
+  { eventDate: "2018-09-29", titlePattern: "CH4 Trail #790/ Rubber City", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
+  { eventDate: "2026-05-16", titlePattern: "SSH3 #236 with SWH3", primaryKennelCode: "ssh3-wa", coHostKennelCodes: ["swh3"] },
+];
+
+/**
+ * Mirror of the kennel page production query at
+ * `src/app/kennels/[slug]/page.tsx` — the only filter we tighten here is
+ * the title (so we land on the specific historical row, not the kennel's
+ * full event list). If the production WHERE clause changes, update this.
+ */
+async function eventVisibleOnKennelPage(eventId: string, kennelId: string): Promise<boolean> {
+  const found = await prisma.event.findFirst({
+    where: {
+      id: eventId,
+      eventKennels: { some: { kennelId } },
+    },
+    select: { id: true },
+  });
+  return found !== null;
+}
+
+async function main() {
+  let failures = 0;
+  let passes = 0;
+
+  for (const entry of ENTRIES) {
+    const dayStart = new Date(`${entry.eventDate}T00:00:00Z`);
+    const dayEnd = new Date(`${entry.eventDate}T23:59:59.999Z`);
+
+    const primary = await prisma.kennel.findFirst({
+      where: { kennelCode: { equals: entry.primaryKennelCode, mode: "insensitive" } },
+      select: { id: true, slug: true },
+    });
+    if (!primary) {
+      console.warn(`SKIP "${entry.titlePattern}" — primary kennel ${entry.primaryKennelCode} missing`);
+      continue;
+    }
+
+    const events = await prisma.event.findMany({
+      where: {
+        kennelId: primary.id,
+        title: { contains: entry.titlePattern, mode: "insensitive" },
+        date: { gte: dayStart, lte: dayEnd },
+      },
+      select: { id: true, title: true },
+    });
+
+    if (events.length === 0) {
+      console.warn(`MISS  ${entry.eventDate} ${entry.primaryKennelCode}: no event matches "${entry.titlePattern}"`);
+      failures++;
+      continue;
+    }
+
+    for (const event of events) {
+      // Should appear on the primary kennel's page (it always did)
+      const onPrimary = await eventVisibleOnKennelPage(event.id, primary.id);
+      if (!onPrimary) {
+        console.error(`✗ ${event.id} NOT visible on primary /k/${primary.slug}`);
+        failures++;
+      }
+
+      for (const coHostCode of entry.coHostKennelCodes) {
+        const coHost = await prisma.kennel.findFirst({
+          where: { kennelCode: { equals: coHostCode, mode: "insensitive" } },
+          select: { id: true, slug: true },
+        });
+        if (!coHost) {
+          console.error(`✗ co-host kennel ${coHostCode} missing in DB`);
+          failures++;
+          continue;
+        }
+        const onCoHost = await eventVisibleOnKennelPage(event.id, coHost.id);
+        if (!onCoHost) {
+          console.error(`✗ ${event.id} NOT visible on co-host /k/${coHost.slug}`);
+          failures++;
+        } else {
+          console.log(`✓ ${entry.eventDate} ${event.id.slice(0, 12)}… visible on /k/${primary.slug} AND /k/${coHost.slug}`);
+          passes++;
+        }
+      }
+    }
+  }
+
+  console.log(`\nPass: ${passes}  Fail: ${failures}`);
+  if (failures > 0) process.exit(1);
+}
+
+main()
+  .catch((err) => {
+    console.error("\nVerifier crashed:");
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/verify-historical-cohost-visibility.ts
+++ b/scripts/verify-historical-cohost-visibility.ts
@@ -12,33 +12,10 @@
  */
 import "dotenv/config";
 import { prisma } from "@/lib/db";
-
-/**
- * Each entry mirrors a `BACKFILL_ENTRIES` row in
- * `backfill-historical-co-hosts.ts` — keep in sync if entries are added.
- */
-interface VerifyEntry {
-  eventDate: string;
-  titlePattern: string;
-  primaryKennelCode: string;
-  coHostKennelCodes: string[];
-}
-
-const ENTRIES: VerifyEntry[] = [
-  { eventDate: "2025-07-12", titlePattern: "Cherry City H3 #1 / OH3", primaryKennelCode: "cch3-or", coHostKennelCodes: ["oh3"] },
-  { eventDate: "2025-07-12", titlePattern: "Cherry City H3 #1 / OH3", primaryKennelCode: "oh3", coHostKennelCodes: ["cch3-or"] },
-  { eventDate: "2025-10-28", titlePattern: "Space City H3 #313 - Joint Trail with Galveston H3", primaryKennelCode: "galh3", coHostKennelCodes: ["space-city-h3"] },
-  { eventDate: "2025-12-30", titlePattern: "Galveston H3 #297 - Joint Hash with Space City H3", primaryKennelCode: "galh3", coHostKennelCodes: ["space-city-h3"] },
-  { eventDate: "2026-05-30", titlePattern: "5th Saturday with Cleveland H4", primaryKennelCode: "rch3", coHostKennelCodes: ["cleh4"] },
-  { eventDate: "2023-07-29", titlePattern: "5th Saturday of July Trail with Cleveland H4", primaryKennelCode: "rch3", coHostKennelCodes: ["cleh4"] },
-  { eventDate: "2019-03-30", titlePattern: "Joint Cleveland Hash", primaryKennelCode: "rch3", coHostKennelCodes: ["cleh4"] },
-  { eventDate: "2025-12-13", titlePattern: "CH4 and Rubber City Christmas Trail", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
-  { eventDate: "2024-06-29", titlePattern: "CH4 5th Saturday with Rubber City", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
-  { eventDate: "2023-07-29", titlePattern: "CH4's 5th Saturday with Rubber City", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
-  { eventDate: "2022-07-30", titlePattern: "Joint Trail with Rubber City H3", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
-  { eventDate: "2018-09-29", titlePattern: "CH4 Trail #790/ Rubber City", primaryKennelCode: "cleh4", coHostKennelCodes: ["rch3"] },
-  { eventDate: "2026-05-16", titlePattern: "SSH3 #236 with SWH3", primaryKennelCode: "ssh3-wa", coHostKennelCodes: ["swh3"] },
-];
+import {
+  HISTORICAL_CO_HOST_ENTRIES,
+  type CoHostBackfillEntry,
+} from "./data/historical-co-hosts";
 
 /**
  * Mirror of the kennel page production query at
@@ -57,66 +34,108 @@ async function eventVisibleOnKennelPage(eventId: string, kennelId: string): Prom
   return found !== null;
 }
 
+interface KennelLite {
+  id: string;
+  slug: string;
+}
+
+async function findKennelByCode(kennelCode: string): Promise<KennelLite | null> {
+  return prisma.kennel.findFirst({
+    where: { kennelCode: { equals: kennelCode, mode: "insensitive" } },
+    select: { id: true, slug: true },
+  });
+}
+
+async function findEventsForEntry(
+  entry: CoHostBackfillEntry,
+  primary: KennelLite,
+): Promise<Array<{ id: string; title: string | null }>> {
+  const dayStart = new Date(`${entry.eventDate}T00:00:00Z`);
+  const dayEnd = new Date(`${entry.eventDate}T23:59:59.999Z`);
+  return prisma.event.findMany({
+    where: {
+      kennelId: primary.id,
+      title: { contains: entry.titlePattern, mode: "insensitive" },
+      date: { gte: dayStart, lte: dayEnd },
+    },
+    select: { id: true, title: true },
+  });
+}
+
+interface VerifyTally {
+  passes: number;
+  failures: number;
+}
+
+/** Verify a single (event, primary, co-host) triple. Returns the tally delta. */
+async function verifyEventOnBothPages(
+  eventId: string,
+  eventDate: string,
+  primary: KennelLite,
+  coHostCode: string,
+): Promise<VerifyTally> {
+  const tally: VerifyTally = { passes: 0, failures: 0 };
+
+  if (await eventVisibleOnKennelPage(eventId, primary.id)) {
+    // Primary visibility is the pre-backfill baseline; only counted if it
+    // ALSO surfaces on the co-host page.
+  } else {
+    console.error(`✗ ${eventId} NOT visible on primary /k/${primary.slug}`);
+    tally.failures++;
+    return tally;
+  }
+
+  const coHost = await findKennelByCode(coHostCode);
+  if (!coHost) {
+    console.error(`✗ co-host kennel ${coHostCode} missing in DB`);
+    tally.failures++;
+    return tally;
+  }
+
+  if (await eventVisibleOnKennelPage(eventId, coHost.id)) {
+    console.log(`✓ ${eventDate} ${eventId.slice(0, 12)}… visible on /k/${primary.slug} AND /k/${coHost.slug}`);
+    tally.passes++;
+  } else {
+    console.error(`✗ ${eventId} NOT visible on co-host /k/${coHost.slug}`);
+    tally.failures++;
+  }
+  return tally;
+}
+
+async function verifyEntry(entry: CoHostBackfillEntry): Promise<VerifyTally> {
+  const tally: VerifyTally = { passes: 0, failures: 0 };
+
+  const primary = await findKennelByCode(entry.primaryKennelCode);
+  if (!primary) {
+    console.warn(`SKIP "${entry.titlePattern}" — primary kennel ${entry.primaryKennelCode} missing`);
+    return tally;
+  }
+
+  const events = await findEventsForEntry(entry, primary);
+  if (events.length === 0) {
+    console.warn(`MISS  ${entry.eventDate} ${entry.primaryKennelCode}: no event matches "${entry.titlePattern}"`);
+    tally.failures++;
+    return tally;
+  }
+
+  for (const event of events) {
+    for (const coHostCode of entry.coHostKennelCodes) {
+      const sub = await verifyEventOnBothPages(event.id, entry.eventDate, primary, coHostCode);
+      tally.passes += sub.passes;
+      tally.failures += sub.failures;
+    }
+  }
+  return tally;
+}
+
 async function main() {
-  let failures = 0;
   let passes = 0;
+  let failures = 0;
 
-  for (const entry of ENTRIES) {
-    const dayStart = new Date(`${entry.eventDate}T00:00:00Z`);
-    const dayEnd = new Date(`${entry.eventDate}T23:59:59.999Z`);
-
-    const primary = await prisma.kennel.findFirst({
-      where: { kennelCode: { equals: entry.primaryKennelCode, mode: "insensitive" } },
-      select: { id: true, slug: true },
-    });
-    if (!primary) {
-      console.warn(`SKIP "${entry.titlePattern}" — primary kennel ${entry.primaryKennelCode} missing`);
-      continue;
-    }
-
-    const events = await prisma.event.findMany({
-      where: {
-        kennelId: primary.id,
-        title: { contains: entry.titlePattern, mode: "insensitive" },
-        date: { gte: dayStart, lte: dayEnd },
-      },
-      select: { id: true, title: true },
-    });
-
-    if (events.length === 0) {
-      console.warn(`MISS  ${entry.eventDate} ${entry.primaryKennelCode}: no event matches "${entry.titlePattern}"`);
-      failures++;
-      continue;
-    }
-
-    for (const event of events) {
-      // Should appear on the primary kennel's page (it always did)
-      const onPrimary = await eventVisibleOnKennelPage(event.id, primary.id);
-      if (!onPrimary) {
-        console.error(`✗ ${event.id} NOT visible on primary /k/${primary.slug}`);
-        failures++;
-      }
-
-      for (const coHostCode of entry.coHostKennelCodes) {
-        const coHost = await prisma.kennel.findFirst({
-          where: { kennelCode: { equals: coHostCode, mode: "insensitive" } },
-          select: { id: true, slug: true },
-        });
-        if (!coHost) {
-          console.error(`✗ co-host kennel ${coHostCode} missing in DB`);
-          failures++;
-          continue;
-        }
-        const onCoHost = await eventVisibleOnKennelPage(event.id, coHost.id);
-        if (!onCoHost) {
-          console.error(`✗ ${event.id} NOT visible on co-host /k/${coHost.slug}`);
-          failures++;
-        } else {
-          console.log(`✓ ${entry.eventDate} ${event.id.slice(0, 12)}… visible on /k/${primary.slug} AND /k/${coHost.slug}`);
-          passes++;
-        }
-      }
-    }
+  for (const entry of HISTORICAL_CO_HOST_ENTRIES) {
+    const sub = await verifyEntry(entry);
+    passes += sub.passes;
+    failures += sub.failures;
   }
 
   console.log(`\nPass: ${passes}  Fail: ${failures}`);


### PR DESCRIPTION
## Summary

Sixth implementation step of the multi-kennel co-hosted events spec ([docs/multi-kennel-events-spec.md](docs/multi-kennel-events-spec.md)). Steps 1–5 merged. **One-shot DB script + read-only verifier** — no runtime code changes. Adds the missing `EventKennel(co-host, isPrimary=false)` rows so 13 historical multi-kennel events become visible on BOTH kennels' pages via step 5's WHERE filter rewrite.

Per memory `feedback_historical_backfill`: "Prefer one-shot DB scripts over adapter changes for deep-dive history gaps."

### What lands

**`scripts/backfill-historical-co-hosts.ts`** (new, 167 lines):
- Curated list of 13 (eventDate, titlePattern, primaryKennelCode, coHostKennelCodes) entries — every one verified to exist in prod
- **Date-scoped substring matching** (per Codex review: prevents future similarly-titled events from being silently affected by re-runs)
- **Idempotent**: upsert with `update: {}` no-op preserves existing rows
- **Dry-run by default**; `--apply` writes; `--prod` required for non-local DATABASE_URL

**Curated entries** (13 total, 5 distinct kennel pairs):
| Pair | Events |
|---|---|
| Cherry City × OH3 inaugural (2025-07-12) | ×2 (one per Event row — both adapters scraped it) |
| Galveston × Space City joint hashes | 2025-10-28, 2025-12-30 |
| Cleveland H4 × Rubber City H3 5th-Saturday tradition | ×8: 2018-09-29, 2019-03-30, 2022-07-30, 2023-07-29 ×2, 2024-06-29, 2025-12-13, 2026-05-30 |
| SSH3 × SWH3 | 2026-05-16 |

**`scripts/verify-historical-cohost-visibility.ts`** (new, 132 lines):
- Read-only post-apply verifier (per Codex review: "Don't put it inside the mutator script")
- Runs the production kennel-page WHERE filter (`{ eventKennels: { some: { kennelId } } }`) once for primary, once for each co-host; asserts the event surfaces on both
- All 13 events verified visible on both kennel pages

### Local verification (hashtracks_dev)

- Dry-run: 13 planned actions
- Apply: inserted 10 (3 from earlier test run were already there)
- Re-run dry-run: 0 INSERT + 13 EXISTS (idempotent ✓)
- `scripts/verify-event-kennel-backfill.ts`: **34,205 events, 34,218 EventKennel total (+13), 34,205 primaries unchanged**, partial unique index intact, no drift
- `scripts/verify-historical-cohost-visibility.ts`: **13 pass, 0 fail**

### What's NOT in this PR

- **Cross-kennel duplicate Event collapse** — the Cherry City inaugural exists as 2 separate Event rows from different adapters; this backfill makes both visible on both kennel pages (displays the trail twice on each). Codex flagged this as known product debt; tracked separately in `docs/roadmap.md` as cross-kennel dedup work — out of scope for step 6

### Production rollout

After merge, run against prod:
```bash
# Dry-run first to verify the planned actions
npx tsx scripts/backfill-historical-co-hosts.ts --prod

# Apply
npx tsx scripts/backfill-historical-co-hosts.ts --prod --apply

# Verify
npx tsx scripts/verify-historical-cohost-visibility.ts --prod
npx tsx scripts/verify-event-kennel-backfill.ts
```

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)