### PR TITLE
fix(static-schedule): Butterworth wrong day + titleTemplate + DST backstop

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -663,7 +663,6 @@ export const SOURCES = [
       config: {
         kennelTag: "dst-h3",
         rrule: "FREQ=WEEKLY;BYDAY=TU",
-        anchorDate: "2026-04-28",
         startTime: "18:30",
         titleTemplate: "DST — {date} Hash (hare TBD)",
         defaultLocation: "Stuttgart, Germany",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -648,6 +648,29 @@ export const SOURCES = [
       },
       kennelCodes: ["sh3-de", "dst-h3", "fm-stgt", "super-h3"],
     },
+    // Backstop for the Stuttgart H3 GCal source: the CTA filter in
+    // google-calendar/adapter.ts strips "DST # - Hare Needed" placeholder rows,
+    // leaving only weeks where a hare is named. This static source fills the
+    // resulting Tuesday gaps. trustLevel 2 < GCal's 7 so real-titled GCal rows
+    // still win the canonical event for any Tuesday they cover.
+    {
+      name: "DST H3 Static Schedule",
+      url: "https://calendar.google.com/calendar/u/0/embed?src=1op2o8a7q9k5gif7m7b4n2ft7g@group.calendar.google.com",
+      type: "STATIC_SCHEDULE" as const,
+      trustLevel: 2,
+      scrapeFreq: "weekly",
+      scrapeDays: 90,
+      config: {
+        kennelTag: "dst-h3",
+        rrule: "FREQ=WEEKLY;BYDAY=TU",
+        anchorDate: "2026-04-28",
+        startTime: "18:30",
+        titleTemplate: "DST — {date} Hash (hare TBD)",
+        defaultLocation: "Stuttgart, Germany",
+        defaultDescription: "Stuttgart's weekly DST Tuesday-evening hash. Hare often listed on the Stuttgart H3 calendar — placeholder until a specific hare is named.",
+      },
+      kennelCodes: ["dst-h3"],
+    },
     // Bay Area iCal feed (sfh3.com aggregator — ~11 kennels)
     {
       name: "SFH3 MultiHash iCal Feed",
@@ -1560,7 +1583,7 @@ export const SOURCES = [
         rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA",
         anchorDate: "2026-03-07",
         startTime: "11:00",
-        defaultTitle: "CVH3 Biweekly Run",
+        titleTemplate: "CVH3 — {date} Hash",
         defaultLocation: "Columbus, GA",
         defaultDescription: "Alternate Saturday morning trail. Check Facebook for start location.",
       },
@@ -1646,7 +1669,7 @@ export const SOURCES = [
         rrule: "FREQ=MONTHLY;BYDAY=1SU",
         anchorDate: "2026-03-01",
         startTime: "15:00",
-        defaultTitle: "ColH3 Biweekly Run",
+        titleTemplate: "ColH3 — 1st Sunday Hash",
         defaultLocation: "Columbia, SC",
         defaultDescription: "1st & 3rd Sunday trail. Check Facebook for start location.",
       },
@@ -1664,7 +1687,7 @@ export const SOURCES = [
         rrule: "FREQ=MONTHLY;BYDAY=3SU",
         anchorDate: "2026-03-15",
         startTime: "15:00",
-        defaultTitle: "ColH3 Biweekly Run",
+        titleTemplate: "ColH3 — 3rd Sunday Hash",
         defaultLocation: "Columbia, SC",
         defaultDescription: "1st & 3rd Sunday trail. Check Facebook for start location.",
       },
@@ -3838,13 +3861,16 @@ export const SOURCES = [
       trustLevel: 3,
       scrapeFreq: "weekly",
       scrapeDays: 90,
+      // malaysiahash.com directory: Wednesdays @ 6:00pm. The earlier Saturday
+      // 17:00 was a data-entry mistake (likely confused with Butterworth
+      // Hashettes/Hazards, both Mondays).
       config: {
         kennelTag: "butterworth-h3",
-        rrule: "FREQ=WEEKLY;BYDAY=SA",
-        startTime: "17:00",
-        defaultTitle: "Butterworth H3 Weekly Run",
+        rrule: "FREQ=WEEKLY;BYDAY=WE",
+        startTime: "18:00",
+        defaultTitle: "Butterworth H3 Weekly Hash",
         defaultLocation: "Butterworth, Penang, Malaysia",
-        defaultDescription: "Weekly Saturday evening trail on mainland Penang. Founded 1980. Check the malaysiahash.com directory for contact details.",
+        defaultDescription: "Weekly Wednesday evening trail on mainland Penang. Founded 1980. Check the malaysiahash.com directory for contact details.",
       },
       kennelCodes: ["butterworth-h3"],
     },

--- a/src/adapters/static-schedule/adapter.test.ts
+++ b/src/adapters/static-schedule/adapter.test.ts
@@ -2,6 +2,7 @@ import {
   StaticScheduleAdapter,
   parseRRule,
   generateOccurrences,
+  renderTitleTemplate,
 } from "./adapter";
 import type { StaticScheduleConfig } from "./adapter";
 import type { RawEventData } from "../types";
@@ -490,6 +491,115 @@ describe("StaticScheduleAdapter", () => {
     for (const event of result.events) {
       const daysDiff = Math.abs(Math.round((new Date(event.date + "T12:00:00Z").getTime() - anchorMs) / 86_400_000));
       expect(daysDiff % 14).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderTitleTemplate
+// ---------------------------------------------------------------------------
+
+describe("renderTitleTemplate", () => {
+  // Anchor: 2026-05-03 is a Sunday in May.
+  it("renders {dayName}", () => {
+    expect(renderTitleTemplate("Hash on {dayName}", "2026-05-03")).toBe("Hash on Sunday");
+  });
+
+  it("renders {monthName}", () => {
+    expect(renderTitleTemplate("Run in {monthName}", "2026-05-03")).toBe("Run in May");
+  });
+
+  it("renders {date} as month + day-of-month without leading zero", () => {
+    expect(renderTitleTemplate("CVH3 — {date} Hash", "2026-05-03")).toBe("CVH3 — May 3 Hash");
+    expect(renderTitleTemplate("CVH3 — {date} Hash", "2026-05-23")).toBe("CVH3 — May 23 Hash");
+  });
+
+  it("renders {iso} as the input date string", () => {
+    expect(renderTitleTemplate("[{iso}] Hash", "2026-05-03")).toBe("[2026-05-03] Hash");
+  });
+
+  it("renders multiple tokens in one template", () => {
+    expect(renderTitleTemplate("DST — {date} ({dayName}) Hash", "2026-05-12")).toBe(
+      "DST — May 12 (Tuesday) Hash",
+    );
+  });
+
+  it("leaves unknown tokens literal", () => {
+    expect(renderTitleTemplate("Hash {frobnitz} {date}", "2026-05-03")).toBe("Hash {frobnitz} May 3");
+  });
+
+  it("leaves a literal template unchanged when no tokens are present", () => {
+    expect(renderTitleTemplate("ColH3 — 1st Sunday Hash", "2026-05-03")).toBe("ColH3 — 1st Sunday Hash");
+  });
+
+  it("returns the template untouched on malformed dates (defensive)", () => {
+    expect(renderTitleTemplate("{date}", "not-a-date")).toBe("{date}");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StaticScheduleAdapter — titleTemplate end-to-end
+// ---------------------------------------------------------------------------
+
+describe("StaticScheduleAdapter titleTemplate", () => {
+  const adapter = new StaticScheduleAdapter();
+
+  it("renders titleTemplate per occurrence", async () => {
+    const result = await adapter.fetch(rumsonSource({ titleTemplate: "Rumson — {date} Hash" }));
+    expect(result.errors).toHaveLength(0);
+    expect(result.events.length).toBeGreaterThan(0);
+    for (const event of result.events) {
+      expect(event.title).toMatch(/^Rumson — [A-Z][a-z]+ \d{1,2} Hash$/);
+    }
+  });
+
+  it("falls back to defaultTitle when titleTemplate is absent", async () => {
+    const result = await adapter.fetch(rumsonSource({ defaultTitle: "Rumson H3 Weekly Run" }));
+    expectAllEvents(result.events, "title", "Rumson H3 Weekly Run");
+  });
+
+  it("titleTemplate wins when both fields are set", async () => {
+    const result = await adapter.fetch(
+      rumsonSource({
+        defaultTitle: "Rumson H3 Weekly Run",
+        titleTemplate: "Rumson — {dayName} Hash",
+      }),
+    );
+    for (const event of result.events) {
+      expect(event.title).toBe("Rumson — Saturday Hash");
+    }
+  });
+
+  it("treats empty titleTemplate as absent", async () => {
+    const result = await adapter.fetch(
+      rumsonSource({ defaultTitle: "Rumson H3 Weekly Run", titleTemplate: "" }),
+    );
+    expectAllEvents(result.events, "title", "Rumson H3 Weekly Run");
+  });
+
+  it("treats whitespace-only titleTemplate as absent", async () => {
+    const result = await adapter.fetch(
+      rumsonSource({ defaultTitle: "Rumson H3 Weekly Run", titleTemplate: "   " }),
+    );
+    expectAllEvents(result.events, "title", "Rumson H3 Weekly Run");
+  });
+
+  it("falls back to defaultTitle when titleTemplate is a non-string (admin payload corruption)", async () => {
+    // Cast through unknown to simulate a malformed JSON payload reaching the adapter.
+    const result = await adapter.fetch(
+      rumsonSource({
+        defaultTitle: "Rumson H3 Weekly Run",
+        titleTemplate: [] as unknown as string,
+      }),
+    );
+    expect(result.errors).toHaveLength(0);
+    expectAllEvents(result.events, "title", "Rumson H3 Weekly Run");
+  });
+
+  it("leaves unknown tokens literal in the rendered title", async () => {
+    const result = await adapter.fetch(rumsonSource({ titleTemplate: "Rumson {frobnitz} on {dayName}" }));
+    for (const event of result.events) {
+      expect(event.title).toBe("Rumson {frobnitz} on Saturday");
     }
   });
 });

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -417,7 +417,7 @@ export function renderTitleTemplate(template: string, dateStr: string): string {
     "{date}": `${monthName} ${dayNum}`,
     "{iso}": dateStr,
   };
-  return template.replace(/\{[A-Za-z]+\}/g, (match) => tokens[match] ?? match);
+  return template.replaceAll(/\{[A-Za-z]+\}/g, (match) => tokens[match] ?? match);
 }
 
 /**

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -8,7 +8,7 @@
 
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
-import { validateSourceConfig } from "../utils";
+import { validateSourceConfig, WEEKDAY_NAMES } from "../utils";
 
 /** Configuration shape for a STATIC_SCHEDULE source. */
 export interface StaticScheduleConfig {
@@ -19,15 +19,24 @@ export interface StaticScheduleConfig {
   defaultTitle?: string;       // e.g. "Rumson H3 Weekly Run"
   defaultLocation?: string;    // e.g. "Rumson, NJ"
   defaultDescription?: string; // e.g. "Check Facebook for start location"
+  /**
+   * Title template with date-derived tokens. When present, it overrides
+   * `defaultTitle`. Tokens (case-sensitive):
+   *   {dayName}    → "Sunday"
+   *   {monthName}  → "May"
+   *   {date}       → "May 3"
+   *   {iso}        → "2026-05-03"
+   * Unknown tokens are left literal so typos surface visibly.
+   *
+   * No schedule-semantic tokens (e.g. nth-of-month) — those can lie about
+   * the schedule on weekly rules. Encode "1st Sunday" / "3rd Sunday" intent
+   * as literal text on per-source rows whose RRULE matches that slot.
+   */
+  titleTemplate?: string;
 }
 
 /** Supported FREQ values. Other values (DAILY, YEARLY, etc.) are rejected. */
 const SUPPORTED_FREQS = new Set(["WEEKLY", "MONTHLY"]);
-
-/** Day abbreviation to JS Date.getUTCDay() number (Sunday=0). */
-const DAY_MAP: Record<string, number> = {
-  SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6,
-};
 
 /**
  * Parse INTERVAL from RRULE parts. Returns 1 if not specified.
@@ -51,7 +60,7 @@ function parseByDay(parts: Record<string, string>): { day: number; nth?: number 
   if (!parts.BYDAY) return undefined;
   const match = /^(-?\d+)?([A-Z]{2})$/.exec(parts.BYDAY);
   if (!match) throw new Error(`Invalid BYDAY: ${parts.BYDAY}`);
-  const dayNum = DAY_MAP[match[2]];
+  const dayNum = WEEKDAY_NAMES[match[2]];
   if (dayNum === undefined) throw new Error(`Unknown day: ${match[2]}`);
   if (match[1]) {
     const nth = Number.parseInt(match[1], 10);
@@ -380,6 +389,37 @@ function normalizeTime(raw: string): string | undefined {
   return undefined;
 }
 
+const DAY_NAMES_FULL = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] as const;
+const MONTH_NAMES_FULL = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+] as const;
+
+/**
+ * Render a title template with date-derived tokens. Tokens not in the supported
+ * set are left literal so typos like `{Date}` (capital D) surface visibly in the
+ * UI rather than silently rendering empty. Only date-derived tokens are
+ * supported — schedule-semantic tokens (nth-of-month etc.) would lie about
+ * weekly rules, so admins encode that intent as literal text per source row.
+ *
+ * @param template - e.g. `"DST — {date} Hash"`
+ * @param dateStr  - YYYY-MM-DD (interpreted as UTC noon)
+ */
+export function renderTitleTemplate(template: string, dateStr: string): string {
+  const dt = new Date(dateStr + "T12:00:00Z");
+  if (Number.isNaN(dt.getTime())) return template;
+  const dayName = DAY_NAMES_FULL[dt.getUTCDay()];
+  const monthName = MONTH_NAMES_FULL[dt.getUTCMonth()];
+  const dayNum = dt.getUTCDate();
+  const tokens: Record<string, string> = {
+    "{dayName}": dayName,
+    "{monthName}": monthName,
+    "{date}": `${monthName} ${dayNum}`,
+    "{iso}": dateStr,
+  };
+  return template.replace(/\{[A-Za-z]+\}/g, (match) => tokens[match] ?? match);
+}
+
 /**
  * Adapter for kennels that operate on a consistent, predictable schedule but lack
  * a scrapeable website (e.g., Facebook-only groups). Generates recurring events
@@ -452,10 +492,19 @@ export class StaticScheduleAdapter implements SourceAdapter {
       ? normalizeTime(config.startTime)
       : undefined;
 
+    // titleTemplate is opt-in; we accept only strings here so a malformed admin
+    // payload (e.g. `titleTemplate: []`) fails closed to defaultTitle instead of
+    // crashing the scrape inside renderTitleTemplate(). Whitespace-only strings
+    // are treated as absent so a field cleared in the admin panel doesn't render
+    // empty titles on every event.
+    const rawTpl = config.titleTemplate;
+    const titleTemplate =
+      typeof rawTpl === "string" && rawTpl.trim().length > 0 ? rawTpl : undefined;
+
     const events: RawEventData[] = occurrences.map((date) => ({
       date,
       kennelTags: [config.kennelTag],
-      title: config.defaultTitle,
+      title: titleTemplate ? renderTitleTemplate(titleTemplate, date) : config.defaultTitle,
       description: config.defaultDescription,
       location: config.defaultLocation,
       startTime,

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -16,6 +16,7 @@ import {
   stripPlaceholder,
   extractAddressWithAi,
   stripNonEnglishCountry,
+  applyWeekdayShift,
 } from "./utils";
 import { validateSourceUrlWithDns } from "./ssrf-dns";
 
@@ -770,5 +771,96 @@ describe("stripNonEnglishCountry", () => {
 
   it("does not modify locations without country suffix", () => {
     expect(stripNonEnglishCountry("Lucien Morin Park, Rochester, NY")).toBe("Lucien Morin Park, Rochester, NY");
+  });
+});
+
+// ── applyWeekdayShift ──
+
+describe("applyWeekdayShift", () => {
+  // Sanity anchor: 2026-05-01 is a Friday, 2026-05-03 is a Sunday.
+  const FRIDAY = "2026-05-01";
+  const THURSDAY_BEFORE = "2026-04-30";
+  const SUNDAY = "2026-05-03";
+  const SATURDAY_BEFORE = "2026-05-02";
+
+  it("shifts Friday → Thursday by −1 day and rewrites startTime", () => {
+    const result = applyWeekdayShift(FRIDAY, "00:00", {
+      from: "Friday",
+      to: "Thursday",
+      placeholderTime: "00:00",
+      defaultStartTime: "20:00",
+    });
+    expect(result).toEqual({ date: THURSDAY_BEFORE, startTime: "20:00", shifted: true });
+  });
+
+  it("shifts Sunday → Saturday across the week boundary using shortest signed delta", () => {
+    const result = applyWeekdayShift(SUNDAY, "10:00", { from: "Sunday", to: "Saturday" });
+    expect(result).toEqual({ date: SATURDAY_BEFORE, startTime: "10:00", shifted: true });
+  });
+
+  it("accepts RFC 5545 abbreviations interchangeably with full names", () => {
+    const a = applyWeekdayShift(FRIDAY, "00:00", { from: "FR", to: "TH" });
+    const b = applyWeekdayShift(FRIDAY, "00:00", { from: "Friday", to: "Thursday" });
+    expect(a.date).toBe(b.date);
+    expect(a.shifted).toBe(true);
+  });
+
+  it("leaves event unchanged when source weekday differs from `from`", () => {
+    // 2026-05-02 is a Saturday — does not match `from: Friday`.
+    const result = applyWeekdayShift("2026-05-02", "00:00", {
+      from: "Friday",
+      to: "Thursday",
+      defaultStartTime: "20:00",
+    });
+    expect(result).toEqual({ date: "2026-05-02", startTime: "00:00", shifted: false });
+  });
+
+  it("leaves event unchanged when placeholderTime is set and startTime mismatches", () => {
+    const result = applyWeekdayShift(FRIDAY, "19:00", {
+      from: "Friday",
+      to: "Thursday",
+      placeholderTime: "00:00",
+      defaultStartTime: "20:00",
+    });
+    expect(result).toEqual({ date: FRIDAY, startTime: "19:00", shifted: false });
+  });
+
+  it("shifts when placeholderTime is absent (always-shift mode)", () => {
+    const result = applyWeekdayShift(FRIDAY, "19:00", { from: "Friday", to: "Thursday" });
+    expect(result).toEqual({ date: THURSDAY_BEFORE, startTime: "19:00", shifted: true });
+  });
+
+  it("preserves original startTime when defaultStartTime is absent", () => {
+    const result = applyWeekdayShift(FRIDAY, "19:00", {
+      from: "Friday",
+      to: "Thursday",
+      placeholderTime: "19:00",
+    });
+    expect(result.shifted).toBe(true);
+    expect(result.startTime).toBe("19:00");
+  });
+
+  it("shifts even when startTime is undefined and placeholderTime is unset", () => {
+    const result = applyWeekdayShift(FRIDAY, undefined, { from: "Friday", to: "Thursday" });
+    expect(result).toEqual({ date: THURSDAY_BEFORE, startTime: undefined, shifted: true });
+  });
+
+  it("does not shift when startTime is undefined and placeholderTime is set", () => {
+    // placeholderTime gate requires an exact string match, and undefined !== "00:00".
+    const result = applyWeekdayShift(FRIDAY, undefined, {
+      from: "Friday",
+      to: "Thursday",
+      placeholderTime: "00:00",
+    });
+    expect(result.shifted).toBe(false);
+  });
+
+  it("throws on unknown weekday names", () => {
+    expect(() => applyWeekdayShift(FRIDAY, "00:00", { from: "Funday", to: "Thursday" })).toThrow(/unknown weekday/);
+    expect(() => applyWeekdayShift(FRIDAY, "00:00", { from: "Friday", to: "Xxx" })).toThrow(/unknown weekday/);
+  });
+
+  it("throws on malformed date input", () => {
+    expect(() => applyWeekdayShift("not-a-date", "00:00", { from: "Friday", to: "Thursday" })).toThrow(/invalid date/);
   });
 });

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -855,6 +855,15 @@ describe("applyWeekdayShift", () => {
     expect(result.shifted).toBe(false);
   });
 
+  it("returns shifted: false when from and to are the same weekday (no-op)", () => {
+    const result = applyWeekdayShift(FRIDAY, "00:00", {
+      from: "Friday",
+      to: "Friday",
+      defaultStartTime: "20:00",
+    });
+    expect(result).toEqual({ date: FRIDAY, startTime: "00:00", shifted: false });
+  });
+
   it("throws on unknown weekday names", () => {
     expect(() => applyWeekdayShift(FRIDAY, "00:00", { from: "Funday", to: "Thursday" })).toThrow(/unknown weekday/);
     expect(() => applyWeekdayShift(FRIDAY, "00:00", { from: "Friday", to: "Xxx" })).toThrow(/unknown weekday/);

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -11,6 +11,7 @@ import * as cheerio from "cheerio";
 import * as chrono from "chrono-node";
 import he from "he";
 import { buildUrlVariantCandidates } from "@/adapters/url-variants";
+import { toIsoDateString } from "@/lib/date";
 import { safeFetch } from "./safe-fetch";
 import { generateStructureHash } from "@/pipeline/structure-hash";
 import type { ErrorDetails, ScrapeResult } from "./types";
@@ -22,6 +23,90 @@ import type { ErrorDetails, ScrapeResult } from "./types";
  */
 export function decodeEntities(text: string): string {
   return he.decode(text).replace(/\u00A0/g, " ");
+}
+
+// ---------------------------------------------------------------------------
+// Weekday shift \u2014 opt-in remap of generated/scraped occurrences from one
+// weekday to another. Used when a kennel's published schedule disagrees with
+// when they actually run.
+//
+// Not wired into STATIC_SCHEDULE: that adapter's RRULE is the single source
+// of truth, and a hidden second-shift layer would let a future RRULE edit
+// silently re-misdate events.
+// ---------------------------------------------------------------------------
+
+/**
+ * Weekday name \u2192 JS Date.getUTCDay() number (Sunday=0..Saturday=6).
+ * Accepts both full names ("FRIDAY") and RFC 5545 abbreviations ("FR").
+ * Keys are uppercase; callers must normalize input before lookup.
+ */
+export const WEEKDAY_NAMES: Record<string, number> = {
+  SUNDAY: 0, MONDAY: 1, TUESDAY: 2, WEDNESDAY: 3, THURSDAY: 4, FRIDAY: 5, SATURDAY: 6,
+  SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6,
+};
+
+export interface WeekdayShiftConfig {
+  /** Source weekday \u2014 full name ("Friday") or RFC 5545 abbr ("FR"). */
+  from: string;
+  /** Target weekday \u2014 same forms accepted as `from`. */
+  to: string;
+  /** When set, only events with this exact startTime ("HH:MM") get shifted. */
+  placeholderTime?: string;
+  /** When set, the shifted event's startTime is rewritten to this value. */
+  defaultStartTime?: string;
+}
+
+function parseWeekday(name: string, field: string): number {
+  const key = name.trim().toUpperCase();
+  const num = WEEKDAY_NAMES[key];
+  if (num === undefined) {
+    throw new Error(`applyWeekdayShift: unknown weekday "${name}" for ${field}`);
+  }
+  return num;
+}
+
+/**
+ * Apply a weekday shift to a (date, startTime) pair if eligible.
+ *
+ * Eligibility:
+ *   - the source date's weekday matches `cfg.from`, AND
+ *   - either no `placeholderTime` is configured or `startTime === placeholderTime`.
+ *
+ * When eligible, the date is shifted by the shortest signed day-delta from
+ * `from` to `to` (Friday\u2192Thursday is \u22121, Sunday\u2192Saturday is also \u22121 across
+ * the week boundary). If `defaultStartTime` is set, the returned startTime
+ * is rewritten to that value; otherwise the original is preserved.
+ *
+ * Date in/out is YYYY-MM-DD. Internally normalized at UTC noon to match the
+ * project-wide UTC-noon date convention.
+ */
+export function applyWeekdayShift(
+  date: string,
+  startTime: string | undefined,
+  cfg: WeekdayShiftConfig,
+): { date: string; startTime: string | undefined; shifted: boolean } {
+  const fromDow = parseWeekday(cfg.from, "from");
+  const toDow = parseWeekday(cfg.to, "to");
+  const dt = new Date(date + "T12:00:00Z");
+  if (Number.isNaN(dt.getTime())) {
+    throw new Error(`applyWeekdayShift: invalid date "${date}" (expected YYYY-MM-DD)`);
+  }
+  if (dt.getUTCDay() !== fromDow) return { date, startTime, shifted: false };
+  if (cfg.placeholderTime !== undefined && startTime !== cfg.placeholderTime) {
+    return { date, startTime, shifted: false };
+  }
+
+  // Shortest signed delta in [-3, +3]. Friday(5)\u2192Thursday(4) = -1; Sunday(0)\u2192Saturday(6) = -1.
+  let delta = toDow - fromDow;
+  if (delta > 3) delta -= 7;
+  if (delta < -3) delta += 7;
+
+  const shifted = new Date(dt.getTime() + delta * 86_400_000);
+  return {
+    date: toIsoDateString(shifted),
+    startTime: cfg.defaultStartTime ?? startTime,
+    shifted: true,
+  };
 }
 
 /**

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -45,6 +45,8 @@ export const WEEKDAY_NAMES: Record<string, number> = {
   SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6,
 };
 
+const MS_PER_DAY = 86_400_000;
+
 export interface WeekdayShiftConfig {
   /** Source weekday \u2014 full name ("Friday") or RFC 5545 abbr ("FR"). */
   from: string;
@@ -101,7 +103,11 @@ export function applyWeekdayShift(
   if (delta > 3) delta -= 7;
   if (delta < -3) delta += 7;
 
-  const shifted = new Date(dt.getTime() + delta * 86_400_000);
+  // Same-weekday shift is a no-op \u2014 return shifted: false so callers don't
+  // mistakenly treat a same-day pass-through as a successful remap.
+  if (delta === 0) return { date, startTime, shifted: false };
+
+  const shifted = new Date(dt.getTime() + delta * MS_PER_DAY);
   return {
     date: toIsoDateString(shifted),
     startTime: cfg.defaultStartTime ?? startTime,

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -91,7 +91,7 @@ export function applyWeekdayShift(
   const toDow = parseWeekday(cfg.to, "to");
   const dt = new Date(date + "T12:00:00Z");
   if (Number.isNaN(dt.getTime())) {
-    throw new Error(`applyWeekdayShift: invalid date "${date}" (expected YYYY-MM-DD)`);
+    throw new TypeError(`applyWeekdayShift: invalid date "${date}" (expected YYYY-MM-DD)`);
   }
   if (dt.getUTCDay() !== fromDow) return { date, startTime, shifted: false };
   if (cfg.placeholderTime !== undefined && startTime !== cfg.placeholderTime) {

--- a/src/components/admin/config-panels/StaticScheduleConfigPanel.tsx
+++ b/src/components/admin/config-panels/StaticScheduleConfigPanel.tsx
@@ -11,6 +11,7 @@ export interface StaticScheduleConfig {
   anchorDate?: string;
   startTime?: string;
   defaultTitle?: string;
+  titleTemplate?: string;
   defaultLocation?: string;
   defaultDescription?: string;
 }
@@ -109,6 +110,29 @@ export function StaticScheduleConfigPanel({
           }
           placeholder="e.g. Rumson H3 Weekly Run"
         />
+        <p className="text-xs text-muted-foreground">
+          Used when Title Template is empty. Same string on every generated event.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="ss-title-template">Title Template</Label>
+        <Input
+          id="ss-title-template"
+          value={current.titleTemplate ?? ""}
+          onChange={(e) =>
+            onChange({ ...current, titleTemplate: e.target.value || undefined })
+          }
+          placeholder="e.g. CVH3 — {date} Hash"
+        />
+        <p className="text-xs text-muted-foreground">
+          Optional. When set, overrides Default Title. Tokens:{" "}
+          <code className="rounded bg-muted px-1">{"{dayName}"}</code>,{" "}
+          <code className="rounded bg-muted px-1">{"{monthName}"}</code>,{" "}
+          <code className="rounded bg-muted px-1">{"{date}"}</code>,{" "}
+          <code className="rounded bg-muted px-1">{"{iso}"}</code>. Unknown
+          tokens render literal.
+        </p>
       </div>
 
       <div className="space-y-2">


### PR DESCRIPTION
## Summary

- **#1033 Butterworth H3 (CRITICAL data bug):** every generated event was on Saturday 17:00, but the malaysiahash.com directory lists this kennel as Wednesday 18:00 — a likely data-entry mix-up with the Hashettes/Hazards (both Mondays). Source `rrule` flipped to `BYDAY=WE`, `startTime: "18:00"`. Once seed reseeds, all 27 misdated events regenerate on the right day.
- **#1094 CVH3 / #1102 ColH3 generic titles:** adds `titleTemplate` to `StaticScheduleConfig` with strictly date-derived tokens (`{dayName}`, `{monthName}`, `{date}`, `{iso}`). CVH3 now renders e.g. `"CVH3 — May 9 Hash"`; the two ColH3 source rows render distinct literal `"ColH3 — 1st Sunday Hash"` / `"ColH3 — 3rd Sunday Hash"` titles. No schedule-semantic tokens (`{ordinal}`/nth-of-month) — those would lie on weekly rules; admins encode that intent as literal text per source row.
- **#1070 DST coverage gap:** adds a STATIC_SCHEDULE backstop source for `dst-h3`. The Stuttgart GCal source's CTA filter (`google-calendar/adapter.ts` → `CTA_EMBEDDED_PATTERNS`) strips `"DST # - Hare Needed"` placeholders at fetch, so those Tuesdays never reach merge. The backstop only fills truly-empty `(kennel, date)` rows. trustLevel 2 < GCal's 7, so any real-titled GCal Tuesday wins canonical-event selection.
- **#1006 weekdayShift (partial):** ships the pure `applyWeekdayShift` helper in `src/adapters/utils.ts` as the prerequisite for BCH3 wiring. Deliberately not wired into STATIC_SCHEDULE — that adapter's RRULE is the single source of truth, and a hidden second-shift layer would let a future RRULE edit silently re-misdate events. BCH3 wiring lands in WS4 follow-up.
- **Admin UI:** `StaticScheduleConfigPanel` gains a `Title Template` input so admins can edit the field through the structured panel rather than raw JSON.

## Adversarial review trail

Two passes of `/codex:adversarial-review` shaped the final design:

1. **Plan review (pre-code)** flagged that wiring `weekdayShift` into STATIC_SCHEDULE would create a hidden second schedule layer, that `{ordinal}` tokens can lie about weekly rules, and that the Butterworth kennel-row edit collides with the parallel WS3 metadata sweep. All accepted: helper-only for `weekdayShift`, no `{ordinal}` token, source-row-only Butterworth fix.
2. **Working-tree review** flagged that the admin `SourceForm.handleConfigChange` rewrites config from panel fields only — it would erase `titleTemplate` on the next admin edit — and that `titleTemplate` had no type guard so a malformed payload could crash the scrape. Both fixed: `titleTemplate` exposed in the admin panel; adapter accepts only non-empty strings and falls back to `defaultTitle` for arrays/objects/whitespace-only.

## Scope boundary

- ✅ Edited: `src/adapters/static-schedule/`, `src/adapters/utils.ts`, `src/adapters/utils.test.ts`, `src/components/admin/config-panels/StaticScheduleConfigPanel.tsx`, `prisma/seed-data/sources.ts` (STATIC_SCHEDULE rows only).
- ❌ Did not edit per parallel-workstream boundaries: any GCal/HTML/Meetup adapter, `prisma/seed-data/kennels.ts` (WS3 owns kennel metadata; Butterworth's kennel-row `scheduleDayOfWeek`/`scheduleTime`/`description` strings need a follow-up to fully clear the kennel-page banner inconsistency), DeMon/WA Source rows (WS1), travel pages.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (14 pre-existing unrelated warnings)
- [x] `npm test` — 5433 tests pass (3 new utils tests for `applyWeekdayShift`, 11 new static-schedule tests for `renderTitleTemplate` + malformed `titleTemplate` regressions)
- [x] Adapter live-equivalent run against the 5 updated/new seed configs — Butterworth lands on Wednesdays at 18:00; CVH3/ColH3/DST render correct per-date or literal titles; `applyWeekdayShift("2026-05-01", "00:00", { from: "Friday", to: "Thursday", placeholderTime: "00:00", defaultStartTime: "20:00" })` shifts to `2026-04-30 20:00`.

## Follow-up (not in this PR)

- **WS3:** update `prisma/seed-data/kennels.ts:3185` Butterworth kennel-row (`scheduleDayOfWeek`, `scheduleTime`, `scheduleNotes`, `description`) so the kennel-page banner copy matches the corrected events.
- **WS4 / #1006:** wire `applyWeekdayShift` into `BrewCityH3Adapter` for the BCH3 placeholder-Friday → real-Thursday case.

Closes #1033, #1094, #1102, #1070
Refs #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)