### PR TITLE
feat(directory): count co-hosted events for both kennels in directory + OG (follow-up #1023)

### DIFF
--- a/src/app/kennels/[slug]/opengraph-image.tsx
+++ b/src/app/kennels/[slug]/opengraph-image.tsx
@@ -22,9 +22,14 @@ export default async function OgImage({ params }: { params: Promise<{ slug: stri
       scheduleDayOfWeek: true,
       scheduleFrequency: true,
       isHidden: true,
+      // #1023 spec D8: count co-hosted events too — go through the
+      // EventKennel join so a kennel that's only a secondary on upcoming
+      // events still reads as "active" on its own page's OG image.
       _count: {
         select: {
-          events: { where: { date: { gte: todayUtc }, status: "CONFIRMED" } },
+          eventKennels: {
+            where: { event: { date: { gte: todayUtc }, status: "CONFIRMED" } },
+          },
         },
       },
     },
@@ -39,7 +44,7 @@ export default async function OgImage({ params }: { params: Promise<{ slug: stri
     );
   }
 
-  const status = getActivityStatus(kennel.lastEventDate, kennel._count.events > 0);
+  const status = getActivityStatus(kennel.lastEventDate, kennel._count.eventKennels > 0);
   const statusText = status === "active" ? "Active" : status === "possibly-inactive" ? "Possibly Inactive" : status === "inactive" ? "Inactive" : "";
   const statusColor = status === "active" ? "#4ade80" : status === "possibly-inactive" ? "#facc15" : status === "inactive" ? "#f87171" : "#71717a";
   const schedule = [kennel.scheduleFrequency, kennel.scheduleDayOfWeek].filter(Boolean).join(" · ");

--- a/src/app/kennels/[slug]/opengraph-image.tsx
+++ b/src/app/kennels/[slug]/opengraph-image.tsx
@@ -25,10 +25,12 @@ export default async function OgImage({ params }: { params: Promise<{ slug: stri
       // #1023 spec D8: count co-hosted events too — go through the
       // EventKennel join so a kennel that's only a secondary on upcoming
       // events still reads as "active" on its own page's OG image.
+      // `isCanonical: true` matches the kennel page's event list query
+      // so the OG status badge agrees with what the page actually shows.
       _count: {
         select: {
           eventKennels: {
-            where: { event: { date: { gte: todayUtc }, status: "CONFIRMED" } },
+            where: { event: { date: { gte: todayUtc }, status: "CONFIRMED", isCanonical: true } },
           },
         },
       },

--- a/src/app/kennels/page.tsx
+++ b/src/app/kennels/page.tsx
@@ -4,7 +4,8 @@ import { Plus } from "lucide-react";
 import { prisma } from "@/lib/db";
 import { KennelDirectory } from "@/components/kennels/KennelDirectory";
 import Link from "next/link";
-import { getStateGroup, regionAbbrev, regionNameToSlug } from "@/lib/region";
+import { regionAbbrev, regionNameToSlug } from "@/lib/region";
+import { buildNextEventMap, serializeKennelWithNext } from "@/lib/kennel-directory";
 import { buildRegionItemListJsonLd, safeJsonLd } from "@/lib/seo";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -78,28 +79,11 @@ export default async function KennelsPage() {
     }),
   ]);
 
-  // Build Map<kennelId, firstEvent> — events are sorted by date, so first
-  // per kennel is next. Attribute each event to every kennel on it so a
-  // co-host kennel's card shows the upcoming joint trail too.
-  const nextEventMap = new Map<string, { date: Date; title: string | null }>();
-  for (const event of upcomingEvents) {
-    for (const ek of event.eventKennels) {
-      if (!nextEventMap.has(ek.kennelId)) {
-        nextEventMap.set(ek.kennelId, { date: event.date, title: event.title });
-      }
-    }
-  }
-
-  // Serialize for client
-  const kennelsWithNext = kennels.map((k) => {
-    const next = nextEventMap.get(k.id);
-    return {
-      ...k,
-      stateGroup: getStateGroup(k.region),
-      nextEvent: next ? { date: next.date.toISOString(), title: next.title } : null,
-      lastEventDate: k.lastEventDate ? k.lastEventDate.toISOString() : null,
-    };
-  });
+  // #1023 spec D8: attribute each event to every visible kennel on it so
+  // co-host events surface on co-host kennels' cards. See
+  // `src/lib/kennel-directory.ts` for the shared helper.
+  const nextEventMap = buildNextEventMap(upcomingEvents);
+  const kennelsWithNext = kennels.map((k) => serializeKennelWithNext(k, nextEventMap));
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://hashtracks.xyz";
   // Cap at 100 items — schema.org recommends bounded ItemLists for large catalogs
@@ -112,7 +96,7 @@ export default async function KennelsPage() {
   // Only include regions that resolve to a valid landing page slug
   const uniqueRegions = Array.from(new Set(kennels.map((k) => k.region)))
     .filter((r) => regionNameToSlug(r) !== null)
-    .sort();
+    .sort((a, b) => a.localeCompare(b));
 
   return (
     <div>

--- a/src/app/kennels/page.tsx
+++ b/src/app/kennels/page.tsx
@@ -56,18 +56,37 @@ export default async function KennelsPage() {
         lastEventDate: true,
       },
     }),
+    // #1023 spec D8: include co-hosted events. The nested `eventKennels`
+    // selector pushes the not-hidden filter into SQL so we only return the
+    // kennel-link rows the directory actually attributes to.
     prisma.event.findMany({
-      where: { date: { gte: todayUtc }, status: "CONFIRMED", isCanonical: true, kennel: { isHidden: false } },
+      where: {
+        date: { gte: todayUtc },
+        status: "CONFIRMED",
+        isCanonical: true,
+        eventKennels: { some: { kennel: { isHidden: false } } },
+      },
       orderBy: { date: "asc" },
-      select: { kennelId: true, date: true, title: true },
+      select: {
+        date: true,
+        title: true,
+        eventKennels: {
+          where: { kennel: { isHidden: false } },
+          select: { kennelId: true },
+        },
+      },
     }),
   ]);
 
-  // Build Map<kennelId, firstEvent> — events are sorted by date, so first per kennel is next
+  // Build Map<kennelId, firstEvent> — events are sorted by date, so first
+  // per kennel is next. Attribute each event to every kennel on it so a
+  // co-host kennel's card shows the upcoming joint trail too.
   const nextEventMap = new Map<string, { date: Date; title: string | null }>();
   for (const event of upcomingEvents) {
-    if (!nextEventMap.has(event.kennelId)) {
-      nextEventMap.set(event.kennelId, { date: event.date, title: event.title });
+    for (const ek of event.eventKennels) {
+      if (!nextEventMap.has(ek.kennelId)) {
+        nextEventMap.set(ek.kennelId, { date: event.date, title: event.title });
+      }
     }
   }
 

--- a/src/app/kennels/region/[slug]/page.tsx
+++ b/src/app/kennels/region/[slug]/page.tsx
@@ -32,15 +32,20 @@ export async function generateMetadata({
       id: true,
       lastEventDate: true,
       scheduleDayOfWeek: true,
+      // #1023 spec D8: directory counts include co-hosted events for both
+      // kennels — go through the EventKennel join so a kennel that's only
+      // a secondary co-host on upcoming events still reads as "active".
       _count: {
         select: {
-          events: { where: { date: { gte: todayMeta }, status: "CONFIRMED" } },
+          eventKennels: {
+            where: { event: { date: { gte: todayMeta }, status: "CONFIRMED" } },
+          },
         },
       },
     },
   });
   const activeCount = kennels.filter(
-    (k) => getActivityStatus(k.lastEventDate, k._count.events > 0) === "active",
+    (k) => getActivityStatus(k.lastEventDate, k._count.eventKennels > 0) === "active",
   ).length;
   const days = kennels.map((k) => k.scheduleDayOfWeek).filter(Boolean) as string[];
   const intro = generateRegionIntro(region.name, activeCount, days);
@@ -97,23 +102,37 @@ export default async function RegionPage({
         lastEventDate: true,
       },
     }),
+    // #1023 spec D8: include co-hosted events. The nested `eventKennels`
+    // selector pushes the visible-in-region filter into SQL so we only
+    // return the kennel-link rows the directory actually attributes to.
     prisma.event.findMany({
       where: {
         date: { gte: todayUtc },
         status: "CONFIRMED",
         isCanonical: true,
-        kennel: { region: region.name, isHidden: false },
+        eventKennels: { some: { kennel: { region: region.name, isHidden: false } } },
       },
       orderBy: { date: "asc" },
-      select: { kennelId: true, date: true, title: true },
+      select: {
+        date: true,
+        title: true,
+        eventKennels: {
+          where: { kennel: { region: region.name, isHidden: false } },
+          select: { kennelId: true },
+        },
+      },
     }),
   ]);
 
-  // Build next event map
+  // Build next event map. Attribute each event to every region-matching
+  // kennel on it (primary + co-hosts) — so a co-host kennel's directory
+  // card shows the upcoming joint trail too.
   const nextEventMap = new Map<string, { date: Date; title: string | null }>();
   for (const event of upcomingEvents) {
-    if (!nextEventMap.has(event.kennelId)) {
-      nextEventMap.set(event.kennelId, { date: event.date, title: event.title });
+    for (const ek of event.eventKennels) {
+      if (!nextEventMap.has(ek.kennelId)) {
+        nextEventMap.set(ek.kennelId, { date: event.date, title: event.title });
+      }
     }
   }
 

--- a/src/app/kennels/region/[slug]/page.tsx
+++ b/src/app/kennels/region/[slug]/page.tsx
@@ -35,10 +35,13 @@ export async function generateMetadata({
       // #1023 spec D8: directory counts include co-hosted events for both
       // kennels — go through the EventKennel join so a kennel that's only
       // a secondary co-host on upcoming events still reads as "active".
+      // `isCanonical: true` matches the next-event-map query below + the
+      // page intro's canonical-only event derivation so the metadata stat
+      // and the rendered page agree.
       _count: {
         select: {
           eventKennels: {
-            where: { event: { date: { gte: todayMeta }, status: "CONFIRMED" } },
+            where: { event: { date: { gte: todayMeta }, status: "CONFIRMED", isCanonical: true } },
           },
         },
       },

--- a/src/app/kennels/region/[slug]/page.tsx
+++ b/src/app/kennels/region/[slug]/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { prisma } from "@/lib/db";
-import { regionBySlug, getStateGroup } from "@/lib/region";
+import { regionBySlug } from "@/lib/region";
+import { buildNextEventMap, serializeKennelWithNext } from "@/lib/kennel-directory";
 import { getActivityStatus } from "@/lib/activity-status";
 import { getTodayUtcNoon } from "@/lib/date";
 import { generateRegionIntro, buildRegionItemListJsonLd, safeJsonLd } from "@/lib/seo";
@@ -127,28 +128,10 @@ export default async function RegionPage({
     }),
   ]);
 
-  // Build next event map. Attribute each event to every region-matching
-  // kennel on it (primary + co-hosts) — so a co-host kennel's directory
-  // card shows the upcoming joint trail too.
-  const nextEventMap = new Map<string, { date: Date; title: string | null }>();
-  for (const event of upcomingEvents) {
-    for (const ek of event.eventKennels) {
-      if (!nextEventMap.has(ek.kennelId)) {
-        nextEventMap.set(ek.kennelId, { date: event.date, title: event.title });
-      }
-    }
-  }
-
-  // Serialize for client
-  const kennelsWithNext = kennels.map((k) => {
-    const next = nextEventMap.get(k.id);
-    return {
-      ...k,
-      stateGroup: getStateGroup(k.region),
-      nextEvent: next ? { date: next.date.toISOString(), title: next.title } : null,
-      lastEventDate: k.lastEventDate ? k.lastEventDate.toISOString() : null,
-    };
-  });
+  // #1023 spec D8: attribute each event to every region-matching kennel
+  // on it (primary + co-hosts). See `src/lib/kennel-directory.ts`.
+  const nextEventMap = buildNextEventMap(upcomingEvents);
+  const kennelsWithNext = kennels.map((k) => serializeKennelWithNext(k, nextEventMap));
 
   // Compute intro
   const activeCount = kennels.filter(

--- a/src/lib/kennel-directory.ts
+++ b/src/lib/kennel-directory.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared helpers for the kennel directory surfaces (`/kennels` global +
+ * `/kennels/region/[slug]`). Centralizes the "next event per kennel" map
+ * building (which attributes each event to every kennel on it via the
+ * EventKennel join — co-host events surface on co-host kennels' cards
+ * per #1023 spec D8) and the per-kennel serialization the directory UI
+ * consumes.
+ */
+import { getStateGroup } from "@/lib/region";
+
+export interface NextEvent {
+  date: Date;
+  title: string | null;
+}
+
+/** Minimal shape this helper needs from a Prisma upcoming-event row. */
+export interface UpcomingEventForNextMap {
+  date: Date;
+  title: string | null;
+  eventKennels: ReadonlyArray<{ kennelId: string }>;
+}
+
+/**
+ * Build a `Map<kennelId, firstUpcomingEvent>` keyed by every kennel on
+ * each event. Caller MUST sort `events` by date ascending — first match
+ * per kennel wins.
+ *
+ * The events should already be filtered (e.g. via
+ * `eventKennels.where: { kennel: { region, isHidden: false } }`) so we
+ * don't attribute to kennels the directory wouldn't render anyway.
+ */
+export function buildNextEventMap(
+  events: ReadonlyArray<UpcomingEventForNextMap>,
+): Map<string, NextEvent> {
+  const map = new Map<string, NextEvent>();
+  for (const event of events) {
+    for (const ek of event.eventKennels) {
+      if (!map.has(ek.kennelId)) {
+        map.set(ek.kennelId, { date: event.date, title: event.title });
+      }
+    }
+  }
+  return map;
+}
+
+/** Minimal shape this helper needs from a Prisma kennel row. */
+export interface KennelForDirectorySerialize {
+  id: string;
+  region: string;
+  lastEventDate: Date | null;
+}
+
+/**
+ * Serialize a kennel for the directory client component: adds
+ * `stateGroup`, `nextEvent` (from the map built above), and converts
+ * `lastEventDate` to an ISO string. Spreads the input so every other
+ * field on the kennel passes through.
+ */
+export function serializeKennelWithNext<K extends KennelForDirectorySerialize>(
+  kennel: K,
+  nextEventMap: Map<string, NextEvent>,
+): Omit<K, "lastEventDate"> & {
+  stateGroup: string;
+  nextEvent: { date: string; title: string | null } | null;
+  lastEventDate: string | null;
+} {
+  const next = nextEventMap.get(kennel.id);
+  return {
+    ...kennel,
+    stateGroup: getStateGroup(kennel.region),
+    nextEvent: next ? { date: next.date.toISOString(), title: next.title } : null,
+    lastEventDate: kennel.lastEventDate ? kennel.lastEventDate.toISOString() : null,
+  };
+}


### PR DESCRIPTION
## Summary

Spec D8 follow-up to issue [#1023](https://github.com/johnrclem/hashtracks-web/issues/1023) step 5. Steps 1–6 merged. The kennel **directory** surfaces (region + global directory pages + kennel-page OG image) were left primary-only in step 5; this PR brings them in line with D8: **"Kennel directory stats count co-hosted events for both kennels — recent activity is a community engagement signal."**

3 files changed, +57/−14.

### What lands

| File | Change |
|---|---|
| `src/app/kennels/region/[slug]/page.tsx` | `_count.events` → `_count.eventKennels` for active-count stat. Next-event map iterates every region-matching kennel on each event via the EventKennel join. |
| `src/app/kennels/page.tsx` | Same next-event map treatment for the global directory. |
| `src/app/kennels/[slug]/opengraph-image.tsx` | `_count.events` → `_count.eventKennels` for activity status badge. |

**Per Codex review**, the visible + in-region filter is pushed into the nested `eventKennels.where` selector (SQL-side) so we don't overfetch kennel objects to filter+drop in JS.

### What's NOT changed

- Admin audit + admin/sources/coverage `_count.events` — internal / source-attribution surfaces, not directory display per D8 scope
- Admin/kennels delete-guard — already covered by step 2's separate EventKennel co-host guard

### User-visible effect

After this ships, on the kennels directory and region directory pages:
- A kennel that's a secondary co-host on an upcoming joint trail (e.g. OH3 on the Cherry City × OH3 inaugural) reads as **"Active"** in the directory stats and shows the upcoming joint trail in its **"Next event"** widget.
- The kennel-page OG image (the social card image) reflects activity through co-host events too.

### Local verification

- **5,478 unit tests pass**; `tsc --noEmit` clean
- Lint: 14 pre-existing warnings, no new
- `scripts/verify-historical-cohost-visibility.ts`: 13/13 historical co-hosts still visible on both kennel pages

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 5,478 pass
- [x] `verify-historical-cohost-visibility.ts` still 13/13
- [ ] Vercel preview: visit `/kennels/region/oregon` and confirm both Cherry City + OH3 read as "Active" with the joint trail in the next-event widget
- [ ] Visit `/k/oh3` and confirm OG image renders "Active" status

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)