### PR TITLE
fix(sonar): PR-gate relief bundle (Phase A of #1086)

### DIFF
--- a/docs/sonarcloud-gate.md
+++ b/docs/sonarcloud-gate.md
@@ -37,11 +37,9 @@ The `main` branch gate currently shows ERROR because of historical debt:
 
 This is **deferred Phase B** of [#1086](https://github.com/johnrclem/hashtracks-web/issues/1086): a one-time SAFE-resolve sweep of the existing hotspots and any genuinely-stale bug findings. PR-gate relief (this doc) lands first; the main-gate green-up follows separately.
 
-If you want to help with Phase B, query unreviewed hotspots via the SonarQube MCP:
-```
-mcp__sonarqube__hotspots(project_key="johnrclem_hashtracks-web", status="TO_REVIEW")
-```
-Most are bounded-input regex (`typescript:S5852`) or `http://` URLs in seed files (`typescript:S5332`) — low-risk in context, but each needs a per-hotspot SAFE-resolve.
+If you want to help with Phase B, query unreviewed hotspots via the SonarQube MCP tool from inside Claude Code — invoke the `mcp__sonarqube__hotspots` tool with `project_key="johnrclem_hashtracks-web"` and `status="TO_REVIEW"`. (Note: this is a Claude Code tool name, not a shell command — there is no CLI you can run literally.) For ad-hoc browsing, the SonarCloud web UI works too: <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web>.
+
+Most hotspots are bounded-input regex (`typescript:S5852`) or `http://` URLs in seed files (`typescript:S5332`) — low-risk in context, but each needs a per-hotspot SAFE-resolve.
 
 ## Why we don't use "previous version" for the PR new-code period
 

--- a/docs/sonarcloud-gate.md
+++ b/docs/sonarcloud-gate.md
@@ -1,0 +1,52 @@
+# SonarCloud Quality Gate Conventions
+
+## How the gate is configured
+
+- **Project:** `johnrclem_hashtracks-web`
+- **PR new-code period:** "since branch from main" (branch-based baseline)
+  - PR analyses only count issues introduced by the PR's diff against `main`.
+  - Touching a file with pre-existing issues no longer drags those issues into the PR's "new code" view.
+- **`main` new-code period:** "previous version" — but `package.json` is `0.1.0` and there is no release-bump discipline. The `main` gate is currently informational; it does not block deploys (Vercel deploys on push to `main`, not on Sonar status).
+- **`new_security_hotspots_reviewed` condition:** kept on the gate, but with the branch-based PR baseline it only fires when a PR introduces *new* hotspots — not when a PR touches a file that has historical hotspots.
+
+## What this means in practice
+
+### When you open a PR
+- The Sonar PR check should pass cleanly if your diff doesn't introduce new bugs, vulnerabilities, code smells, or security hotspots.
+- If the PR check fails, the failures are *attributable to your diff*. Read the report and address them.
+
+### If a Sonar hotspot appears in your diff
+- Triage it: real risk, false positive, or acceptable.
+- Mark it `SAFE` or `FIXED` in the SonarCloud UI with a one-line comment explaining why.
+- Don't merge with unreviewed hotspots. The gate condition exists for a reason now that it only fires on actual new code.
+
+### If a Sonar reliability/security/maintainability issue appears in your diff
+- Treat as a real finding. Either fix in the PR, or open a follow-up issue and SAFE-resolve with a link to the issue.
+
+## What's excluded
+
+`sonar-project.properties` excludes:
+- `prisma/seed.ts`, `prisma/seed-data/**/*.ts` — duplication checks (large hand-curated data files)
+- `docs/mockups/**` — full Sonar analysis (these are static design references, not shipped code)
+
+## `main` gate is currently ERROR — by design (for now)
+
+The `main` branch gate currently shows ERROR because of historical debt:
+- ~399 unreviewed security hotspots accumulated over time
+- Reliability rating D from a backlog of medium-severity bugs in test files and mockups
+
+This is **deferred Phase B** of [#1086](https://github.com/johnrclem/hashtracks-web/issues/1086): a one-time SAFE-resolve sweep of the existing hotspots and any genuinely-stale bug findings. PR-gate relief (this doc) lands first; the main-gate green-up follows separately.
+
+If you want to help with Phase B, query unreviewed hotspots via the SonarQube MCP:
+```
+mcp__sonarqube__hotspots(project_key="johnrclem_hashtracks-web", status="TO_REVIEW")
+```
+Most are bounded-input regex (`typescript:S5852`) or `http://` URLs in seed files (`typescript:S5332`) — low-risk in context, but each needs a per-hotspot SAFE-resolve.
+
+## Why we don't use "previous version" for the PR new-code period
+
+Sonar's "previous version" mode resets the baseline whenever `package.json` (or another version source) bumps. This repo is `0.1.0` with no release/version-bump discipline, so "previous version" would either:
+- Never reset (everything in the project is "new"), or
+- Reset only when someone manually bumps the version (unpredictable and easy to forget)
+
+Branch-based ("since branch from main") is the right baseline for trunk-based development like this one.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,5 @@
 sonar.cpd.exclusions=prisma/seed.ts,prisma/seed-data/**/*.ts
+
+# Mockup files are design references, not shipped code. Sonar's HTML/CSS rules
+# flag accessibility/structural issues that are intentional in static mockups.
+sonar.exclusions=docs/mockups/**

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -292,8 +292,7 @@ export function splitToRawEvents(
   // Multi-day event: one RawEventData per date
   const seriesId = slug; // Use the Hash Rego slug as series identifier
   return parsed.dates.map((date, i) => {
-    const dayLabel =
-      i === 0 ? "Day 1" : i === parsed.dates.length - 1 ? `Day ${i + 1}` : `Day ${i + 1}`;
+    const dayLabel = `Day ${i + 1}`;
     return {
       date,
       kennelTags: [parsed.hostKennelName || parsed.kennelSlug],

--- a/src/adapters/html-scraper/bruh3.test.ts
+++ b/src/adapters/html-scraper/bruh3.test.ts
@@ -438,7 +438,7 @@ describe("BruH3Adapter", () => {
     // 2339 from upcoming, 2340 from upcoming, 2338 from write-ups
     // 2339 from write-ups is deduplicated
     expect(result.events).toHaveLength(3);
-    expect(result.events.map((e) => e.runNumber).sort()).toEqual([2338, 2339, 2340]);
+    expect(result.events.map((e) => e.runNumber).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([2338, 2339, 2340]);
 
     // Verify 2339 comes from upcoming (sourceUrl check)
     const ev2339 = result.events.find((e) => e.runNumber === 2339);

--- a/src/adapters/html-scraper/frankfurt-hash.test.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.test.ts
@@ -183,7 +183,7 @@ describe("stripHareSuffix (#961)", () => {
 describe("parseJEMEvent", () => {
   const compiled: [RegExp, string][] = [
     [/SHITS|Shits/i, "SHITS"],
-    [/^FM\b|Full Moon|Frankfurt Full Moon/i, "FFMH3"],
+    [/(?:^FM\b)|Full Moon|Frankfurt Full Moon/i, "FFMH3"],
     [/^DOM Run/i, "DOM"],
     [/Bike Hash|Bike Bash/i, "Bike Hash"],
   ];
@@ -468,7 +468,7 @@ describe("parseJEMEvent", () => {
 describe("parseJEMEventList", () => {
   const compiled: [RegExp, string][] = [
     [/SHITS|Shits/i, "SHITS"],
-    [/^FM\b|Full Moon|Frankfurt Full Moon/i, "FFMH3"],
+    [/(?:^FM\b)|Full Moon|Frankfurt Full Moon/i, "FFMH3"],
     [/^DOM Run/i, "DOM"],
     [/Bike Hash|Bike Bash/i, "Bike Hash"],
   ];

--- a/src/adapters/html-scraper/wcfh-calendar.test.ts
+++ b/src/adapters/html-scraper/wcfh-calendar.test.ts
@@ -233,7 +233,7 @@ describe("WCFHCalendarAdapter.fetch", () => {
     // Apr 5 has both CH3 (circus-h3) and B2BH3 (b2b-h3)
     const apr5Events = result.events.filter(e => e.date === "2026-04-05");
     expect(apr5Events).toHaveLength(2);
-    expect(apr5Events.map(e => e.kennelTags[0]).sort()).toEqual(["b2b-h3", "circus-h3"]);
+    expect(apr5Events.map(e => e.kennelTags[0]).sort((a, b) => a.localeCompare(b))).toEqual(["b2b-h3", "circus-h3"]);
 
     vi.restoreAllMocks();
   });

--- a/src/app/kennels/page.tsx
+++ b/src/app/kennels/page.tsx
@@ -93,7 +93,7 @@ export default async function KennelsPage() {
   // Only include regions that resolve to a valid landing page slug
   const uniqueRegions = Array.from(new Set(kennels.map((k) => k.region)))
     .filter((r) => regionNameToSlug(r) !== null)
-    .sort();
+    .sort((a, b) => a.localeCompare(b));
 
   return (
     <div>

--- a/src/components/providers/time-preference-provider.tsx
+++ b/src/components/providers/time-preference-provider.tsx
@@ -27,6 +27,7 @@ export function TimePreferenceProvider({
     }, [initialPreference]);
 
     const setPreference = async (newPref: TimeDisplayPref) => {
+        const previousPref = preference;
         // Optimistic update
         setPreferenceState(newPref);
         setIsLoading(true);
@@ -43,8 +44,7 @@ export function TimePreferenceProvider({
             }
         } catch (err) {
             console.error("Error setting time preference:", err);
-            // Revert on failure
-            setPreferenceState(preference);
+            setPreferenceState(previousPref);
         } finally {
             setIsLoading(false);
         }

--- a/src/components/shared/ClearFilterButton.tsx
+++ b/src/components/shared/ClearFilterButton.tsx
@@ -2,13 +2,24 @@
 
 import { X } from "lucide-react";
 
-/** Small inline clear button used inside filter trigger buttons. */
+// Rendered inside parent <button> filter triggers — must stay a <span>
+// to avoid nested interactive elements (invalid HTML + hydration warnings).
 export function ClearFilterButton({ onClick, label }: Readonly<{ onClick: () => void; label: string }>) {
+  const activate = () => onClick();
   return (
     <span
+      role="button"
+      tabIndex={0}
       className="ml-1 rounded-full p-0.5 hover:bg-muted"
-      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      onClick={(e) => { e.stopPropagation(); activate(); }}
       onMouseDown={(e) => { e.preventDefault(); }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          activate();
+        }
+      }}
       aria-label={label}
     >
       <X className="h-3 w-3" />

--- a/src/components/shared/ClearFilterButton.tsx
+++ b/src/components/shared/ClearFilterButton.tsx
@@ -5,19 +5,18 @@ import { X } from "lucide-react";
 // Rendered inside parent <button> filter triggers — must stay a <span>
 // to avoid nested interactive elements (invalid HTML + hydration warnings).
 export function ClearFilterButton({ onClick, label }: Readonly<{ onClick: () => void; label: string }>) {
-  const activate = () => onClick();
   return (
     <span
       role="button"
       tabIndex={0}
-      className="ml-1 rounded-full p-0.5 hover:bg-muted"
-      onClick={(e) => { e.stopPropagation(); activate(); }}
+      className="ml-1 rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
       onMouseDown={(e) => { e.preventDefault(); }}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           e.stopPropagation();
-          activate();
+          onClick();
         }
       }}
       aria-label={label}

--- a/src/lib/travel/projections.test.ts
+++ b/src/lib/travel/projections.test.ts
@@ -498,7 +498,7 @@ describe("filterProjectionsByHorizon", () => {
 
   it("keeps HIGH + LOW but drops MEDIUM at tier 'high'", () => {
     const out = filterProjectionsByHorizon(mixed, "high");
-    expect(out.map((p) => p.id).sort()).toEqual(["h1", "l1"]);
+    expect(out.map((p) => p.id).sort((a, b) => a.localeCompare(b))).toEqual(["h1", "l1"]);
   });
 
   it("returns [] at tier 'none' — projections drop entirely past 365d", () => {

--- a/src/pipeline/audit-issue-sync.test.ts
+++ b/src/pipeline/audit-issue-sync.test.ts
@@ -186,8 +186,8 @@ describe("audit-issue-sync — pure helpers", () => {
         },
         NOW,
       );
-      expect(events.map((e) => e.type).sort()).toEqual(
-        [AuditIssueEventType.CLOSED, AuditIssueEventType.RELABELED].sort(),
+      expect(events.map((e) => e.type).sort((a, b) => a.localeCompare(b))).toEqual(
+        [AuditIssueEventType.CLOSED, AuditIssueEventType.RELABELED].sort((a, b) => a.localeCompare(b)),
       );
     });
 


### PR DESCRIPTION
## Summary

Pick 1 of the audit-issue focus plan. Triages the 19 reliability bugs SonarCloud sees in the new-code period and fixes the real ones; excludes mockup files from analysis; documents the gate convention.

**Acceptance criterion:** PR gates stop false-failing on hotspots not introduced by the diff. **`main` will remain ERROR** until Phase B (#1141) lands separately — that is intentionally out of scope.

## Real bug fixes (6)

- **hashrego parser** ([src/adapters/hashrego/parser.ts](src/adapters/hashrego/parser.ts)) — collapsed dead-branch ternary in `dayLabel` (S3923). Both non-first branches returned `Day ${i+1}`, so the conditional was a no-op. Behavior preserved.
- **kennels page** ([src/app/kennels/page.tsx:96](src/app/kennels/page.tsx#L96)) — `.sort((a, b) => a.localeCompare(b))` for region names (S2871). Default sort would mis-order accented region names.
- **ClearFilterButton** ([src/components/shared/ClearFilterButton.tsx](src/components/shared/ClearFilterButton.tsx)) — added Enter/Space `onKeyDown` so the clear chip is keyboard-activatable (S1082). Kept as `<span role="button">` because the component is rendered inside parent `<button>` filter triggers at 5 call sites — swapping to `<button>` would create invalid nested-button HTML and React hydration warnings. Deeper structural fix in #1140.
- **time-preference-provider** ([src/components/providers/time-preference-provider.tsx](src/components/providers/time-preference-provider.tsx)) — capture `previousPref` before optimistic update (S6443). Note: a deeper overlapping-update race remains, tracked in #1139.
- **4 test files** — `.sort()` → `.sort((a, b) => a.localeCompare(b))` or numeric compare (S2871). Test fixtures only.
- **frankfurt-hash test regex** — explicit precedence grouping `(?:^FM\b)|...` (S5850). Test fixtures only.

## Config

- `sonar.exclusions=docs/mockups/**` so static design references stop polluting reliability/a11y analysis (was contributing 5 of the 19 BUG findings).

## Docs

- New [docs/sonarcloud-gate.md](docs/sonarcloud-gate.md) explaining the gate convention, why we use a branch-based PR new-code period (vs. \"previous version\" — `package.json` is `0.1.0` with no release-bump discipline), and why `main` remains ERROR until Phase B.

## Manual SonarCloud step (separate from this PR)

Phase A also requires a SonarCloud project config change (web UI, not in repo): switch the **PR new-code period** from rolling-30-day calendar to **\"since branch from main\"**. See [docs/sonarcloud-gate.md](docs/sonarcloud-gate.md) for the rationale.

## Adversarial review notes

Codex flagged two structural issues that are real but pre-existing and out of scope for a Sonar bundle. Both spun off as follow-ups:
- **#1139** — TimePreferenceProvider single-flight (race under overlapping toggles)
- **#1140** — FilterBar restructure: clear affordance as sibling, not nested interactive control

## Deferred

- **#1141** — Phase B: bulk SAFE-resolve 399 hotspots + green-up the `main` gate.
- 3 SAFE-resolve candidates that are Sonar false positives (will mark in the SonarCloud UI as part of Phase B): bull-moon.ts regex char class, AttendanceBadge.tsx (already has conditional onKeyDown), time-preference-provider's remaining S6443 if it persists.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — pre-existing warnings unrelated to this diff
- [x] `npm test` — 5478 passed, 7 skipped (pre-existing)
- [x] `npm test src/components/shared/ClearFilterButton.test.ts` — passes after the `<button>` → `<span>` revert
- [ ] After merge: confirm SonarCloud PR gate passes on a doc-only follow-up PR
- [ ] After merge: confirm `mcp__sonarqube__quality_gate_status` shows PR-level OK

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)