### PR TITLE
feat(health): regime-aware baseline (#1115)

### DIFF
--- a/prisma/migrations/20260430162226_health_regime_baseline/migration.sql
+++ b/prisma/migrations/20260430162226_health_regime_baseline/migration.sql
@@ -1,0 +1,24 @@
+-- Regime-aware health baseline (#1115).
+--
+-- Adds two columns + one index so rolling-window health checks can
+-- detect regime boundaries (config edits / manual code-rollout markers)
+-- and avoid firing false-positive FIELD_FILL_DROP / EVENT_COUNT_ANOMALY /
+-- EXCESSIVE_CANCELLATIONS alerts when an adapter improves.
+
+-- Source: optional manual reset boundary. Health baselines ignore
+-- ScrapeLog rows with startedAt < this timestamp.
+ALTER TABLE "Source"
+  ADD COLUMN IF NOT EXISTS "baselineResetAt" TIMESTAMP(3);
+
+-- ScrapeLog: SHA-256 hash of Source.config snapshotted at scrape time.
+-- Health baselines filter recentSuccessful by this hash. NULL is
+-- treated as "matches anything" during the migration backfill window
+-- so existing rows still seed baselines until the first post-deploy
+-- scrape stamps a current hash.
+ALTER TABLE "ScrapeLog"
+  ADD COLUMN IF NOT EXISTS "configHash" TEXT;
+
+-- Composite index supporting the baseline query
+-- (sourceId, status="SUCCESS", configHash=current OR NULL, startedAt DESC).
+CREATE INDEX IF NOT EXISTS "ScrapeLog_sourceId_status_configHash_startedAt_idx"
+  ON "ScrapeLog" ("sourceId", "status", "configHash", "startedAt" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -272,7 +272,7 @@ model ScrapeLog {
   alerts            Alert[]
 
   @@index([sourceId, startedAt])
-  @@index([sourceId, status, configHash, startedAt])
+  @@index([sourceId, status, configHash, startedAt(sort: Desc)])
 }
 
 enum ScrapeStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,6 +202,12 @@ model Source {
   healthStatus  SourceHealth   @default(UNKNOWN)
   scrapeDays    Int            @default(90) // Lookback window in days for cron
   enabled       Boolean        @default(true) // False = skip in cron (temporary disable)
+  // Manual baseline boundary: health checks ignore ScrapeLog rows with
+  // startedAt < this value when computing rolling averages. Set after a
+  // code-led adapter improvement so stale baselines don't fire false
+  // FIELD_FILL_DROP / EVENT_COUNT_ANOMALY alerts. Auto-managed regime
+  // shifts (config edits) flow through ScrapeLog.configHash separately.
+  baselineResetAt DateTime?
   kennels       SourceKennel[]
   rawEvents     RawEvent[]
   scrapeLogs    ScrapeLog[]
@@ -251,6 +257,10 @@ model ScrapeLog {
   fillRateStartTime Int? // % of events with non-empty startTime
   fillRateRunNumber Int? // % of events with non-empty runNumber
   structureHash     String? // HTML structural fingerprint (HTML sources only)
+  // SHA-256 of Source.config at scrape time. Health baselines filter
+  // recent scrape rows by this hash so a config edit resets the rolling
+  // average instead of firing false-positive deviation alerts (#1115).
+  configHash        String?
   // Enhanced logging (Phase 2 + Phase 3)
   errorDetails      Json? // Structured error breakdown: {fetch: [], parse: [], merge: []}
   sampleBlocked     Json? // 3-5 example blocked events with reason + suggested action
@@ -262,6 +272,7 @@ model ScrapeLog {
   alerts            Alert[]
 
   @@index([sourceId, startedAt])
+  @@index([sourceId, status, configHash, startedAt])
 }
 
 enum ScrapeStatus {

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -754,6 +754,7 @@ function buildSource(configOverrides?: { kennelSlugs?: string[] }) {
     healthStatus: "UNKNOWN" as const,
     scrapeDays: 90,
     enabled: true,
+    baselineResetAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/src/adapters/html-scraper/ch4-dk.test.ts
+++ b/src/adapters/html-scraper/ch4-dk.test.ts
@@ -237,10 +237,17 @@ describe("Ch4DkAdapter.fetch", () => {
   });
 
   it("filters events outside the date window", async () => {
-    mockFetchResponse(minimalRunsheet);
-    const result = await adapter.fetch(makeSource(), { days: 1 });
-    // none of the 2026 runs are within ±1 day of test execution
-    expect(result.events).toHaveLength(0);
+    // Pin the clock to a date far from any 2026 fixture event so the ±1-day
+    // window can't accidentally catch one when CI runs near a fixture date.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
+    try {
+      mockFetchResponse(minimalRunsheet);
+      const result = await adapter.fetch(makeSource(), { days: 1 });
+      expect(result.events).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("captures runsheetYear in diagnosticContext", async () => {

--- a/src/pipeline/config-hash.test.ts
+++ b/src/pipeline/config-hash.test.ts
@@ -1,0 +1,37 @@
+import { computeConfigHash } from "./config-hash";
+
+describe("computeConfigHash", () => {
+  it("returns identical hashes for objects with reordered keys", () => {
+    const a = { calendarId: "x@gmail.com", days: 90, kennelPatterns: { foo: "FOO" } };
+    const b = { kennelPatterns: { foo: "FOO" }, days: 90, calendarId: "x@gmail.com" };
+    expect(computeConfigHash(a)).toBe(computeConfigHash(b));
+  });
+
+  it("returns different hashes when a value changes", () => {
+    const a = { selector: "table.past_hashes" };
+    const b = { selector: "table.future_hashes" };
+    expect(computeConfigHash(a)).not.toBe(computeConfigHash(b));
+  });
+
+  it("returns different hashes when a key is added", () => {
+    const a = { selector: "table" };
+    const b = { selector: "table", upcomingOnly: true };
+    expect(computeConfigHash(a)).not.toBe(computeConfigHash(b));
+  });
+
+  it("treats null and missing config as the same regime", () => {
+    expect(computeConfigHash(null)).toBe(computeConfigHash(undefined));
+  });
+
+  it("hashes nested arrays stably regardless of object-key order inside elements", () => {
+    const a = { rules: [{ a: 1, b: 2 }, { c: 3 }] };
+    const b = { rules: [{ b: 2, a: 1 }, { c: 3 }] };
+    expect(computeConfigHash(a)).toBe(computeConfigHash(b));
+  });
+
+  it("preserves array order (not sorted) — order is semantically significant", () => {
+    const a = { rules: ["a", "b", "c"] };
+    const b = { rules: ["c", "b", "a"] };
+    expect(computeConfigHash(a)).not.toBe(computeConfigHash(b));
+  });
+});

--- a/src/pipeline/config-hash.ts
+++ b/src/pipeline/config-hash.ts
@@ -1,0 +1,23 @@
+import { createHash } from "crypto";
+
+// Stable JSON stringify: keys sorted recursively so the same logical
+// object always produces the same string regardless of key order.
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const parts = keys.map(
+    (k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`,
+  );
+  return `{${parts.join(",")}}`;
+}
+
+/**
+ * SHA-256 fingerprint of `Source.config`, used as the regime-boundary
+ * key in health-check baselines (#1115). Sources without a config
+ * (STATIC_SCHEDULE, MANUAL, etc.) get a stable sentinel hash.
+ */
+export function computeConfigHash(config: unknown): string {
+  const canonical = config == null ? "null" : stableStringify(config);
+  return createHash("sha256").update(canonical).digest("hex");
+}

--- a/src/pipeline/config-hash.ts
+++ b/src/pipeline/config-hash.ts
@@ -5,7 +5,7 @@ import { createHash } from "crypto";
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
-  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const keys = Object.keys(value as Record<string, unknown>).sort((a, b) => a.localeCompare(b));
   const parts = keys.map(
     (k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`,
   );

--- a/src/pipeline/health.test.ts
+++ b/src/pipeline/health.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/db", () => ({
   prisma: {
-    scrapeLog: { findMany: vi.fn() },
+    scrapeLog: { findMany: vi.fn(), findFirst: vi.fn() },
     alert: { findMany: vi.fn(), update: vi.fn() },
     kennel: { findMany: vi.fn() },
   },
@@ -12,6 +12,7 @@ import { prisma } from "@/lib/db";
 import { analyzeHealth, autoResolveCleared } from "./health";
 
 const mockScrapeLogFind = vi.mocked(prisma.scrapeLog.findMany);
+const mockScrapeLogFindFirst = vi.mocked(prisma.scrapeLog.findFirst);
 const mockKennelFindMany = vi.mocked(prisma.kennel.findMany);
 
 const baseFillRates = { title: 100, location: 80, hares: 50, startTime: 90, runNumber: 70 };
@@ -98,7 +99,10 @@ describe("analyzeHealth", () => {
     expect(result.checkedTypes).not.toContain("RECONCILE_SUPPRESSED");
   });
 
-  it("omits trend check types from checkedTypes when no baseline", async () => {
+  it("registers trend types in checkedTypes even when baseline is empty (#1115)", async () => {
+    // Trend types are registered as checked on any successful scrape so
+    // that stale alerts auto-resolve when a regime reset wipes the
+    // baseline. The actual checks short-circuit when there's no baseline.
     mockScrapeLogFind.mockReset();
     mockScrapeLogFind
       .mockResolvedValueOnce([] as never)  // no baseline
@@ -108,7 +112,22 @@ describe("analyzeHealth", () => {
     expect(result.checkedTypes).toContain("SCRAPE_FAILURE");
     expect(result.checkedTypes).toContain("CONSECUTIVE_FAILURES");
     expect(result.checkedTypes).toContain("SOURCE_KENNEL_MISMATCH");
-    // Trend checks not evaluated without baseline
+    expect(result.checkedTypes).toContain("EVENT_COUNT_ANOMALY");
+    expect(result.checkedTypes).toContain("FIELD_FILL_DROP");
+    expect(result.checkedTypes).toContain("STRUCTURE_CHANGE");
+    expect(result.checkedTypes).toContain("UNMATCHED_TAGS");
+    // Verify the actual check did NOT fire alerts (baseline-empty short-circuit)
+    expect(result.alerts.find((a) => a.type === "EVENT_COUNT_ANOMALY")).toBeUndefined();
+    expect(result.alerts.find((a) => a.type === "FIELD_FILL_DROP")).toBeUndefined();
+  });
+
+  it("omits trend types from checkedTypes when scrape fails", async () => {
+    // On scrape failure, trend types must NOT be marked checked — auto-resolve
+    // would otherwise wrongly clear stale CRITICAL alerts during an outage.
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      scrapeFailed: true,
+      errors: ["timeout"],
+    }));
     expect(result.checkedTypes).not.toContain("EVENT_COUNT_ANOMALY");
     expect(result.checkedTypes).not.toContain("FIELD_FILL_DROP");
     expect(result.checkedTypes).not.toContain("STRUCTURE_CHANGE");
@@ -184,6 +203,176 @@ describe("SOURCE_KENNEL_MISMATCH alerts", () => {
     const alert = result.alerts.find(a => a.type === "SOURCE_KENNEL_MISMATCH");
     expect(alert!.title).toContain("1 kennel tag blocked");
     expect(alert!.title).not.toContain("tags");
+  });
+});
+
+describe("regime-aware baseline (#1115)", () => {
+  it("filters baseline by configHash equality (no OR-on-null) when currentConfigHash is provided", async () => {
+    await analyzeHealth("src_1", "log_1", baseInput({ currentConfigHash: "abc123" }));
+
+    const baselineWhere = mockScrapeLogFind.mock.calls[0][0]?.where;
+    expect(baselineWhere).toMatchObject({
+      sourceId: "src_1",
+      status: "SUCCESS",
+      configHash: "abc123",
+    });
+    expect(baselineWhere).not.toHaveProperty("OR");
+  });
+
+  it("falls back to NULL configHash only when source has no hashed history at all", async () => {
+    // Primary empty + scrapeLog.findFirst probe finds no hashed row → fall back to NULL.
+    mockScrapeLogFind.mockReset();
+    mockScrapeLogFind
+      .mockResolvedValueOnce([] as never)  // primary (hashed): empty
+      .mockResolvedValueOnce(baselineEntries as never)  // fallback (null): rows
+      .mockResolvedValueOnce([] as never);  // recentAll
+    mockScrapeLogFindFirst.mockResolvedValueOnce(null);  // no prior hashed row
+
+    await analyzeHealth("src_1", "log_1", baseInput({ currentConfigHash: "new-config" }));
+
+    expect(mockScrapeLogFind.mock.calls[0][0]?.where).toMatchObject({ configHash: "new-config" });
+    // Probe must exclude the current scrape's row — see "first post-deploy scrape" test below
+    expect(mockScrapeLogFindFirst).toHaveBeenCalledWith({
+      where: { sourceId: "src_1", id: { not: "log_1" }, configHash: { not: null } },
+      select: { id: true },
+    });
+    expect(mockScrapeLogFind.mock.calls[1][0]?.where).toMatchObject({ configHash: null });
+  });
+
+  it("does NOT fall back to NULL when source has hashed rows from a previous regime", async () => {
+    // Critical regression case: post-#1115 source with rows for OLD config.
+    // Config edits to NEW config. Primary (NEW) is empty. Fallback MUST NOT
+    // pull legacy NULL rows in — that would mix regimes (Codex finding).
+    mockScrapeLogFind.mockReset();
+    mockScrapeLogFind
+      .mockResolvedValueOnce([] as never)  // primary (hashed: NEW): empty
+      .mockResolvedValueOnce([] as never);  // recentAll
+    mockScrapeLogFindFirst.mockResolvedValueOnce({ id: "log_old_regime" } as never);  // prior hashed row exists
+
+    await analyzeHealth("src_1", "log_1", baseInput({ currentConfigHash: "new-config" }));
+
+    // findFirst probe was called (current scrape excluded)
+    expect(mockScrapeLogFindFirst).toHaveBeenCalledWith({
+      where: { sourceId: "src_1", id: { not: "log_1" }, configHash: { not: null } },
+      select: { id: true },
+    });
+    // Only 2 findMany calls: primary + recentAll. No NULL fallback.
+    expect(mockScrapeLogFind).toHaveBeenCalledTimes(2);
+    expect(mockScrapeLogFind.mock.calls[1][0]?.select).toEqual({ status: true });
+  });
+
+  it("first post-deploy scrape: NULL fallback fires even though current row already has configHash (Codex regression)", async () => {
+    // The scrape orchestrator writes configHash on the current ScrapeLog
+    // BEFORE analyzeHealth runs. The findFirst probe must exclude the
+    // current row, otherwise it sees its own just-written hash and
+    // wrongly concludes "hashed history exists" — defeating the legacy
+    // NULL fallback for every source's first post-deploy scrape.
+    mockScrapeLogFind.mockReset();
+    mockScrapeLogFind
+      .mockResolvedValueOnce([] as never)  // primary (hashed: current): empty (no prior hashed)
+      .mockResolvedValueOnce(baselineEntries as never)  // fallback (null): legacy rows
+      .mockResolvedValueOnce([] as never);  // recentAll
+    // Probe with id-exclusion finds no PRIOR hashed row (the current row is excluded)
+    mockScrapeLogFindFirst.mockResolvedValueOnce(null);
+
+    await analyzeHealth("src_1", "log_1", baseInput({ currentConfigHash: "first-hashed" }));
+
+    // Probe excludes the current scrape's id
+    expect(mockScrapeLogFindFirst).toHaveBeenCalledWith({
+      where: { sourceId: "src_1", id: { not: "log_1" }, configHash: { not: null } },
+      select: { id: true },
+    });
+    // Fallback fired with legacy NULL rows
+    expect(mockScrapeLogFind.mock.calls[1][0]?.where).toMatchObject({ configHash: null });
+  });
+
+  it("does NOT issue the NULL fallback query once hashed rows exist", async () => {
+    // Primary query returns rows → fallback must not run, no findFirst probe needed.
+    mockScrapeLogFind.mockReset();
+    mockScrapeLogFind
+      .mockResolvedValueOnce(baselineEntries as never)  // primary returns 3 rows
+      .mockResolvedValueOnce([] as never);  // recentAll
+
+    await analyzeHealth("src_1", "log_1", baseInput({ currentConfigHash: "current" }));
+
+    expect(mockScrapeLogFind).toHaveBeenCalledTimes(2);
+    expect(mockScrapeLogFind.mock.calls[1][0]?.select).toEqual({ status: true });
+    expect(mockScrapeLogFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("filters baseline by baselineResetAt when provided", async () => {
+    const reset = new Date("2026-04-15T00:00:00Z");
+    await analyzeHealth("src_1", "log_1", baseInput({ baselineResetAt: reset }));
+
+    const baselineWhere = mockScrapeLogFind.mock.calls[0][0]?.where;
+    expect(baselineWhere).toMatchObject({
+      startedAt: { gte: reset },
+    });
+  });
+
+  it("combines configHash equality and baselineResetAt filters", async () => {
+    const reset = new Date("2026-04-15T00:00:00Z");
+    await analyzeHealth("src_1", "log_1", baseInput({
+      currentConfigHash: "xyz789",
+      baselineResetAt: reset,
+    }));
+
+    const baselineWhere = mockScrapeLogFind.mock.calls[0][0]?.where;
+    expect(baselineWhere).toMatchObject({
+      configHash: "xyz789",
+      startedAt: { gte: reset },
+    });
+  });
+
+  it("omits regime filters when neither field is provided (back-compat)", async () => {
+    await analyzeHealth("src_1", "log_1", baseInput());
+
+    const baselineWhere = mockScrapeLogFind.mock.calls[0][0]?.where;
+    expect(baselineWhere).not.toHaveProperty("configHash");
+    expect(baselineWhere).not.toHaveProperty("startedAt");
+  });
+
+  it("suppresses FIELD_FILL_DROP after a regime change wipes the baseline", async () => {
+    mockScrapeLogFind.mockReset();
+    mockScrapeLogFind
+      .mockResolvedValueOnce([] as never)  // primary (hashed): no rows yet for new regime
+      .mockResolvedValueOnce([] as never);  // recentAll
+    // Source has hashed history from the OLD regime → fallback is gated off
+    mockScrapeLogFindFirst.mockResolvedValueOnce({ id: "log_old" } as never);
+
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      currentConfigHash: "new-config",
+      // Drastically different fill rates that would have triggered alerts
+      // against the original 100/80/50/90/70 baseline:
+      fillRates: { title: 50, location: 20, hares: 10, startTime: 30, runNumber: 0 },
+    }));
+
+    expect(result.alerts.find((a) => a.type === "FIELD_FILL_DROP")).toBeUndefined();
+    expect(result.alerts.find((a) => a.type === "EVENT_COUNT_ANOMALY")).toBeUndefined();
+    // But trend types ARE marked checked so stale prior-regime alerts auto-resolve
+    expect(result.checkedTypes).toContain("FIELD_FILL_DROP");
+    expect(result.checkedTypes).toContain("EVENT_COUNT_ANOMALY");
+  });
+
+  it("suppresses EXCESSIVE_CANCELLATIONS warning when baseline is empty (post-regime-reset)", async () => {
+    // Codex finding: a legitimate first-scrape catch-up cleanup wave after a
+    // regime reset shouldn't fire EXCESSIVE_CANCELLATIONS just on the >10
+    // absolute threshold. Without baseline, we can't tell benign cleanup
+    // from a real regression — so suppress the alert entirely.
+    mockScrapeLogFind.mockReset();
+    mockScrapeLogFind
+      .mockResolvedValueOnce([] as never)  // primary: empty
+      .mockResolvedValueOnce([] as never);  // recentAll
+    mockScrapeLogFindFirst.mockResolvedValueOnce({ id: "log_old" } as never);  // gate fallback off
+
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      currentConfigHash: "new-config",
+      cancelledCount: 25,  // would normally fire WARNING (> 10 absolute threshold)
+    }));
+
+    expect(result.alerts.find((a) => a.type === "EXCESSIVE_CANCELLATIONS")).toBeUndefined();
+    // Still registered as checked so any stale prior-regime alert auto-resolves
+    expect(result.checkedTypes).toContain("EXCESSIVE_CANCELLATIONS");
   });
 });
 

--- a/src/pipeline/health.ts
+++ b/src/pipeline/health.ts
@@ -44,6 +44,10 @@ interface AnalyzeInput {
   reconcileEvaluated?: boolean;
   /** Kennel IDs whose stale-event cancellation was suppressed because the adapter emitted unparseable dates. */
   reconcileSuppressedKennels?: string[];
+  /** SHA-256 of `Source.config` at scrape time. Used as a regime-boundary key — rolling-window baselines (#1115) only consider scrape rows whose hash matches this one (or is NULL during the migration backfill window). */
+  currentConfigHash?: string;
+  /** Optional manual baseline boundary (`Source.baselineResetAt`). Health checks ignore scrape rows older than this when computing rolling averages. Use after a code-led adapter improvement that doesn't change `Source.config`. */
+  baselineResetAt?: Date;
 }
 
 /** Type alias for the shape of recent scrape log rows used across checks. */
@@ -274,12 +278,17 @@ function checkExcessiveCancellations(
   const count = input.cancelledCount ?? 0;
   if (count === 0) return null;
 
+  // Both thresholds need a same-regime baseline to avoid false-positive
+  // catch-up cleanup waves on the first scrape after a regime reset (#1115).
+  // Without baseline data we can't tell a benign one-shot reconciliation
+  // (e.g. adapter improvement cleared stale events) from a real regression.
+  if (recentSuccessful.length === 0) return null;
+
   // Absolute threshold: >10 cancellations in one scrape is always suspicious
   const absoluteThreshold = 10;
   // Relative threshold: cancellations > 50% of average event count
-  const avgEvents = recentSuccessful.length > 0
-    ? recentSuccessful.reduce((sum, l) => sum + l.eventsFound, 0) / recentSuccessful.length
-    : 0;
+  const avgEvents =
+    recentSuccessful.reduce((sum, l) => sum + l.eventsFound, 0) / recentSuccessful.length;
   const relativeThreshold = avgEvents > 0 ? avgEvents * 0.5 : Infinity;
 
   const isCritical = avgEvents > 0 && count > relativeThreshold;
@@ -361,22 +370,61 @@ export async function analyzeHealth(
   // Track which alert types were actually evaluated (for safe auto-resolution)
   const checkedTypes = new Set<string>();
 
-  // Fetch last 10 successful scrapes for baseline (excluding current)
-  const recentSuccessful = await prisma.scrapeLog.findMany({
-    where: { sourceId, status: "SUCCESS", id: { not: scrapeLogId } },
+  // Regime-aware baseline (#1115): only consider scrape rows from the
+  // current config regime so a config edit / manual code-rollout marker
+  // resets the rolling average instead of firing false-positive alerts.
+  //   - prefer rows with the current configHash
+  //   - fall back to NULL-configHash rows ONLY when zero hashed rows
+  //     exist yet (pre-#1115 backfill window, before the source has its
+  //     first post-deploy successful scrape). Once any hashed row exists
+  //     for this source, null rows are excluded — mixing old/new regime
+  //     baselines is the class of bug this PR is meant to prevent.
+  //   - startedAt ignores rows before `Source.baselineResetAt` when set
+  const baselineSelect = {
+    eventsFound: true,
+    unmatchedTags: true,
+    fillRateTitle: true,
+    fillRateLocation: true,
+    fillRateHares: true,
+    fillRateStartTime: true,
+    fillRateRunNumber: true,
+    structureHash: true,
+  } as const;
+  const baseWhere: Prisma.ScrapeLogWhereInput = {
+    sourceId,
+    status: "SUCCESS",
+    id: { not: scrapeLogId },
+    ...(input.baselineResetAt
+      ? { startedAt: { gte: input.baselineResetAt } }
+      : {}),
+  };
+  let recentSuccessful = await prisma.scrapeLog.findMany({
+    where: input.currentConfigHash
+      ? { ...baseWhere, configHash: input.currentConfigHash }
+      : baseWhere,
     orderBy: { startedAt: "desc" },
     take: 10,
-    select: {
-      eventsFound: true,
-      unmatchedTags: true,
-      fillRateTitle: true,
-      fillRateLocation: true,
-      fillRateHares: true,
-      fillRateStartTime: true,
-      fillRateRunNumber: true,
-      structureHash: true,
-    },
+    select: baselineSelect,
   });
+  if (recentSuccessful.length === 0 && input.currentConfigHash) {
+    // Only fall back to NULL rows when the source has *no* hashed history
+    // at all (any status), excluding the current scrape — which already
+    // wrote its own configHash before we got here. If a prior row has a
+    // hash, those rows are an explicitly old regime; pulling NULL legacy
+    // rows in would mix regimes (the bug Codex flagged in the first pass).
+    const hasAnyHashedRow = await prisma.scrapeLog.findFirst({
+      where: { sourceId, id: { not: scrapeLogId }, configHash: { not: null } },
+      select: { id: true },
+    });
+    if (!hasAnyHashedRow) {
+      recentSuccessful = await prisma.scrapeLog.findMany({
+        where: { ...baseWhere, configHash: null },
+        orderBy: { startedAt: "desc" },
+        take: 10,
+        select: baselineSelect,
+      });
+    }
+  }
 
   // Fetch last 3 scrapes (any status) for consecutive failure check
   const recentAll = await prisma.scrapeLog.findMany({
@@ -396,26 +444,29 @@ export async function analyzeHealth(
   const consecutiveAlert = checkConsecutiveFailures(input, recentAll);
   if (consecutiveAlert) alerts.push(consecutiveAlert);
 
-  // Trend checks require baseline data and a successful scrape
-  if (!input.scrapeFailed && recentSuccessful.length > 0) {
-    // 3. Event count anomaly
+  // Trend checks: register as checked on any successful scrape so stale
+  // alerts auto-resolve when a regime reset (#1115) wipes the baseline.
+  // The actual checks only run when there's baseline data to compare
+  // against — otherwise auto-resolve clears any prior-regime trend alerts
+  // since no current alerts will be in the candidate set.
+  if (!input.scrapeFailed) {
     checkedTypes.add("EVENT_COUNT_ANOMALY");
-    const countAlert = checkEventCountAnomaly(input, recentSuccessful);
-    if (countAlert) alerts.push(countAlert);
-
-    // 4. Field fill rate drops
     checkedTypes.add("FIELD_FILL_DROP");
-    alerts.push(...checkFieldFillDrops(input, recentSuccessful));
-
-    // 5. Structural change detection
     checkedTypes.add("STRUCTURE_CHANGE");
-    const structureAlert = await checkStructuralChange(sourceId, input, recentSuccessful);
-    if (structureAlert) alerts.push(structureAlert);
-
-    // 6. New unmatched kennel tags
     checkedTypes.add("UNMATCHED_TAGS");
-    const unmatchedAlert = checkUnmatchedTags(input, recentSuccessful);
-    if (unmatchedAlert) alerts.push(unmatchedAlert);
+
+    if (recentSuccessful.length > 0) {
+      const countAlert = checkEventCountAnomaly(input, recentSuccessful);
+      if (countAlert) alerts.push(countAlert);
+
+      alerts.push(...checkFieldFillDrops(input, recentSuccessful));
+
+      const structureAlert = await checkStructuralChange(sourceId, input, recentSuccessful);
+      if (structureAlert) alerts.push(structureAlert);
+
+      const unmatchedAlert = checkUnmatchedTags(input, recentSuccessful);
+      if (unmatchedAlert) alerts.push(unmatchedAlert);
+    }
   }
 
   // 7. Source-kennel mismatches (always check, even without baseline)

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -8,6 +8,7 @@ import { reconcileStaleEvents } from "./reconcile";
 import { computeFillRates } from "./fill-rates";
 import type { FieldFillRates } from "./fill-rates";
 import { analyzeHealth, persistAlerts, autoResolveCleared } from "./health";
+import { computeConfigHash } from "./config-hash";
 import { autoFileIssuesForAlerts } from "./auto-issue";
 import { verifyResolvedAutoFixes } from "./verify-fixes";
 import { attemptAiRecovery, isAiRecoveryAvailable } from "@/lib/ai/parse-recovery";
@@ -298,12 +299,22 @@ export async function scrapeSource(
 
   const days = options?.days ?? source.scrapeDays ?? 90;
 
+  // Snapshot config-hash on the ScrapeLog so health checks can detect
+  // regime boundaries (#1115). Set at scrape start so even FAILED scrapes
+  // preserve which config they ran under.
+  const configHash = computeConfigHash(source.config);
+  const regimeContext = {
+    currentConfigHash: configHash,
+    baselineResetAt: source.baselineResetAt ?? undefined,
+  };
+
   // Create ScrapeLog record
   const startedAt = new Date();
   const scrapeLog = await prisma.scrapeLog.create({
     data: {
       sourceId,
       forced: force,
+      configHash,
     },
   });
 
@@ -486,6 +497,7 @@ export async function scrapeSource(
       cancelledCount,
       reconcileEvaluated,
       reconcileSuppressedKennels,
+      ...regimeContext,
     });
 
     // Post-merge housekeeping is best-effort: a Next.js request-scope error
@@ -556,6 +568,7 @@ export async function scrapeSource(
       errors: [errorMsg],
       unmatchedTags: [],
       fillRates: { title: 0, location: 0, hares: 0, startTime: 0, runNumber: 0 },
+      ...regimeContext,
     });
 
     return {


### PR DESCRIPTION
## Summary

Pick 2 of the audit-issue focus plan. Rolling-window health checks (`FIELD_FILL_DROP`, `EVENT_COUNT_ANOMALY`, `EXCESSIVE_CANCELLATIONS`, `STRUCTURE_CHANGE`, `UNMATCHED_TAGS`) currently fire false positives whenever an adapter improves — the baseline includes pre-improvement scrapes, so the new (better) fill rates look like regressions. The auto-issue → triage → autofix loop then taxes every adapter improvement with noise.

This PR adds a regime boundary so a config edit (or manual code-led shift via `Source.baselineResetAt`) resets the rolling baseline.

## Mechanism

- **`ScrapeLog.configHash`** — SHA-256 of `Source.config` snapshotted at scrape start. Composite index `(sourceId, status, configHash, startedAt)` for the baseline query.
- **`Source.baselineResetAt`** — optional manual boundary for code-led shifts the configHash can't catch (e.g. parser improvements that don't change config). Health checks ignore scrape rows older than this.
- **`analyzeHealth()`** filters `recentSuccessful` by current `configHash`. A NULL fallback covers the migration backfill window — but **only** when the source has zero hashed history at all, excluding the current scrape's just-written row. Once any prior scrape has a hash, legacy NULL rows are never queried — preventing cross-regime mixing.
- **Trend types** are added to `checkedTypes` whenever scrape succeeded so stale prior-regime alerts auto-resolve on the next scrape after a regime reset, even when the new baseline is empty. Failure-path safety preserved: `scrapeFailed` skips trend-type registration to avoid wrongly auto-resolving CRITICAL alerts during outages.
- **`EXCESSIVE_CANCELLATIONS`** gates on baseline presence so a benign catch-up cleanup wave on the first scrape after a reset doesn't trigger the absolute >10 threshold.

## Adversarial review

Three Codex passes; final structural design verified sound. Five findings landed across the passes:
- **Pass 1**: OR-on-null query mixed regimes; trend-type registration blocked auto-resolve on regime reset; cleanup script used `Source.updatedAt` as a config-edit proxy that fired on every scrape (deleted entirely).
- **Pass 2**: NULL fallback gate didn't differentiate "no history" from "no current-regime history"; `EXCESSIVE_CANCELLATIONS` first-scrape bug.
- **Pass 3**: `findFirst` probe matched the current scrape's just-written hash, defeating the legacy NULL fallback for every source's first post-deploy scrape (fixed with `id: { not: scrapeLogId }` exclusion).

## Files

- [prisma/schema.prisma](prisma/schema.prisma) — `Source.baselineResetAt`, `ScrapeLog.configHash`, composite index
- [prisma/migrations/20260430162226_health_regime_baseline/migration.sql](prisma/migrations/20260430162226_health_regime_baseline/migration.sql) — hand-written ALTER TABLE + CREATE INDEX with `IF NOT EXISTS` (matches the `audit_suppression_global_unique` precedent)
- [src/pipeline/config-hash.ts](src/pipeline/config-hash.ts) — `stableStringify` (recursive key sort) + `computeConfigHash` (SHA-256 hex)
- [src/pipeline/scrape.ts](src/pipeline/scrape.ts) — compute configHash at scrape start, store on ScrapeLog, pass into healthInput via shared `regimeContext`
- [src/pipeline/health.ts](src/pipeline/health.ts) — extended `AnalyzeInput`; two-stage baseline query with gated NULL fallback; trend-type registration restructured
- [src/pipeline/health.test.ts](src/pipeline/health.test.ts) — 5 new + 5 updated regime-boundary tests including the pass-3 regression case
- [src/pipeline/config-hash.test.ts](src/pipeline/config-hash.test.ts) — 6 new tests (key-order stability, null/undefined parity, array order significance)

## Drive-by fix

Second commit (`test(ch4-dk): pin system time to fix date-window flake`) pins the test clock to 2024-01-01 in `src/adapters/html-scraper/ch4-dk.test.ts`. Was failing intermittently because the fixture has a hardcoded 2026-05-01 event and CI runs near that date were within the `days: 1` window. Unrelated to #1115 but blocking my full-suite verification.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — pre-existing 14 warnings, none on changed files
- [x] `npm test` — 5495 passed, 0 failures, 7 skipped + 25 todo (pre-existing)
- [x] New tests cover: stable hashing, two-stage query, NULL fallback gate (correct + first-post-deploy scenarios), trend-type registration on regime reset, EXCESSIVE_CANCELLATIONS first-scrape suppression
- [ ] After merge: monitor next overnight automated audit cycle — expect fewer baseline-deviation issues filed

## Considered and deferred

- **Drop redundant `(sourceId, startedAt)` index** — the new `(sourceId, status, configHash, startedAt)` is a strict superset for sourceId-prefixed queries. Defer dropping the old one until `pg_stat_user_indexes` confirms it's unused post-deploy.

Closes #1115

🤖 Generated with [Claude Code](https://claude.com/claude-code)