### PR TITLE
fix(event-kennel): reconcile 309 orphans from step-1/step-2 deploy gap

### DIFF
--- a/scripts/reconcile-missing-event-kennel-primaries.ts
+++ b/scripts/reconcile-missing-event-kennel-primaries.ts
@@ -100,6 +100,10 @@ main()
   .catch((err) => {
     console.error("\nReconciler failed:");
     console.error(err);
-    process.exit(1);
+    // Set exitCode (don't `process.exit` synchronously) so `.finally` runs
+    // and `prisma.$disconnect()` resolves before the process exits.
+    process.exitCode = 1;
   })
-  .finally(() => prisma.$disconnect());
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/reconcile-missing-event-kennel-primaries.ts
+++ b/scripts/reconcile-missing-event-kennel-primaries.ts
@@ -1,0 +1,105 @@
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+/**
+ * One-shot reconciler for #1023 step-1/step-2 deploy-window orphans.
+ *
+ * The original step-1 migration (`20260428024100_backfill_event_kennel_from_kennel_id`)
+ * backfilled an EventKennel primary row for every Event that existed when it
+ * ran. The migration was applied to prod at 2026-04-28T02:50:32Z (via a Vercel
+ * preview-branch build of `feat/event-kennel-join-table`). The step-2 dual-write
+ * application code did not deploy to prod until ~14h later when PR #1099 merged
+ * to main at 2026-04-28T17:06:05Z. In that intervening window the merge
+ * pipeline kept running its pre-dual-write code path, creating Events without
+ * an EventKennel row. As of 2026-04-30 there are 309 such orphans (all
+ * createdAt between 2026-04-28T03:00:07Z and 2026-04-28T17:03:50Z).
+ *
+ * Event.kennelId is correct on every orphan (the merge pipeline set it the
+ * normal way), so the fix is a literal re-run of the original backfill
+ * INSERT, scoped to Events lacking a primary EK row. Idempotent via the
+ * partial unique index — re-running is safe.
+ *
+ * Run:
+ *   DATABASE_URL=$PROD_DATABASE_URL npx tsx scripts/reconcile-missing-event-kennel-primaries.ts          # dry-run
+ *   DATABASE_URL=$PROD_DATABASE_URL npx tsx scripts/reconcile-missing-event-kennel-primaries.ts --apply  # write
+ */
+const APPLY = process.argv.includes("--apply");
+
+async function main() {
+  const before = await prisma.$queryRaw<{ orphans: bigint }[]>`
+    SELECT COUNT(*)::bigint AS orphans
+    FROM "Event" e
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "EventKennel" ek
+      WHERE ek."eventId" = e.id AND ek."isPrimary" = true
+    )
+  `;
+  const orphanCount = Number(before[0].orphans);
+  console.log(`Orphans before: ${orphanCount}`);
+
+  if (orphanCount === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  if (!APPLY) {
+    // Show the kennels that will receive new EK rows.
+    const byKennel = await prisma.$queryRaw<{ shortName: string; count: bigint }[]>`
+      SELECT k."shortName", COUNT(*)::bigint AS count
+      FROM "Event" e
+      JOIN "Kennel" k ON k.id = e."kennelId"
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "EventKennel" ek
+        WHERE ek."eventId" = e.id AND ek."isPrimary" = true
+      )
+      GROUP BY k."shortName"
+      ORDER BY count DESC
+    `;
+    console.log("\nDRY RUN — would insert EK rows for these kennels:");
+    for (const row of byKennel) {
+      console.log(`  ${row.shortName.padEnd(30)} ${row.count}`);
+    }
+    console.log("\nRe-run with --apply to write.");
+    return;
+  }
+
+  // Same SQL the original migration used. ON CONFLICT DO UPDATE handles the
+  // edge case where a non-primary EventKennel(eventId, kennelId) row was
+  // created in between (e.g. by historical co-host backfill writing a
+  // co-host link first) — promote it to primary.
+  const result = await prisma.$executeRaw`
+    INSERT INTO "EventKennel" ("eventId", "kennelId", "isPrimary")
+    SELECT e."id", e."kennelId", true
+    FROM "Event" e
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "EventKennel" ek
+      WHERE ek."eventId" = e.id AND ek."isPrimary" = true
+    )
+    ON CONFLICT ("eventId", "kennelId") DO UPDATE
+      SET "isPrimary" = true
+  `;
+  console.log(`Inserted/promoted: ${result} rows`);
+
+  const after = await prisma.$queryRaw<{ orphans: bigint }[]>`
+    SELECT COUNT(*)::bigint AS orphans
+    FROM "Event" e
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "EventKennel" ek
+      WHERE ek."eventId" = e.id AND ek."isPrimary" = true
+    )
+  `;
+  console.log(`Orphans after:  ${after[0].orphans}`);
+
+  if (Number(after[0].orphans) !== 0) {
+    throw new Error(`Reconciler did not zero out orphans — ${after[0].orphans} remain. Investigate.`);
+  }
+  console.log("\nAll Events now have a primary EventKennel row ✓");
+}
+
+main()
+  .catch((err) => {
+    console.error("\nReconciler failed:");
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/verify-event-kennel-backfill.ts
+++ b/scripts/verify-event-kennel-backfill.ts
@@ -60,7 +60,7 @@ async function main() {
   }
   console.log("Denorm/join sync:      OK (no drift)");
 
-  if (ekPrimary !== eventCount) {
+  if (ekPrimary < eventCount) {
     const gap = eventCount - ekPrimary;
     const missing = await prisma.$queryRaw<{ id: string }[]>`
       SELECT e.id
@@ -79,6 +79,18 @@ async function main() {
     );
   }
 
+  if (ekPrimary > eventCount) {
+    // Structurally impossible given the FK from EventKennel.eventId →
+    // Event.id (ON DELETE CASCADE) plus the partial unique index that caps
+    // primaries at one per event. If we hit this branch, one of those
+    // invariants has been compromised — point at that, not the reconciler.
+    throw new Error(
+      `Primary EventKennel rows (${ekPrimary}) exceed Event rows (${eventCount}) — ` +
+        `the FK + partial unique index should make this impossible. Investigate index/constraint state ` +
+        `(\\d "EventKennel" in psql) and any direct DB writes that bypass Prisma before reconciling.`,
+    );
+  }
+
   console.log("\nAll invariants hold ✓");
 }
 
@@ -86,6 +98,10 @@ main()
   .catch((err) => {
     console.error("\nVerification failed:");
     console.error(err.message);
-    process.exit(1);
+    // Set exitCode (don't `process.exit` synchronously) so `.finally` runs
+    // and `prisma.$disconnect()` resolves before the process exits.
+    process.exitCode = 1;
   })
-  .finally(() => prisma.$disconnect());
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/verify-event-kennel-backfill.ts
+++ b/scripts/verify-event-kennel-backfill.ts
@@ -2,23 +2,25 @@ import "dotenv/config";
 import { prisma } from "@/lib/db";
 
 /**
- * Post-deploy verification for the EventKennel backfill (issue #1023, step 1).
+ * Post-deploy verification for the EventKennel backfill (issue #1023).
  *
- * Hard assertions (throw on failure): partial unique index exists, no drift
- * between primary EventKennel.kennelId and Event.kennelId.
+ * Hard assertions (throw on failure):
+ *   - Partial unique index `EventKennel_eventId_isPrimary_unique` exists.
+ *   - No drift between primary EventKennel.kennelId and Event.kennelId.
+ *   - Every Event has exactly one primary EventKennel row.
  *
- * Soft check (warn, do not throw): every Event has exactly one primary
- * EventKennel row. Until step 2 (dual-write) ships, new Events written via
- * the existing single-FK code path won't have an EventKennel row — that gap
- * is expected during the rollout window. The script logs up to 25 missing
- * Event IDs so on-call can spot-check whether they're recent (gap-window) or
- * old (real backfill bug).
- *
- * TODO(#1023 step 2): once dual-write ships, restore the strict equality
- * assertion `ekPrimary === eventCount` as a hard throw.
+ * If the third check fails, run
+ * `scripts/reconcile-missing-event-kennel-primaries.ts --apply` to backfill
+ * the missing rows (Event.kennelId is the source of truth) and then re-run
+ * this verifier. The reconciler exists because step-1's migration backfill
+ * only covered Events that existed at migration deploy time — Events created
+ * between migration deploy and step-2 (dual-write) deploy were not picked up.
+ * After step 2 shipped, the merge pipeline writes both sides atomically, so
+ * any new orphan signals a real bug (a write path bypassing
+ * `createEventWithKennel`, or a row deletion).
  *
  * Run: `npx tsx scripts/verify-event-kennel-backfill.ts` — exits non-zero
- * only when a hard assertion fails.
+ * on any failure.
  */
 const PARTIAL_UNIQUE_INDEX_NAME = "EventKennel_eventId_isPrimary_unique";
 const MISSING_ID_SAMPLE = 25;
@@ -69,13 +71,12 @@ async function main() {
       )
       LIMIT ${MISSING_ID_SAMPLE}
     `;
-    console.warn(
-      `\nWARN: ${gap} event(s) missing a primary EventKennel row. Expected during the rollout window between step 1 and step 2 (dual-write); investigate if these are old IDs (pre-backfill).`,
+    const sampleList = missing.map(({ id }) => `  ${id}`).join("\n");
+    throw new Error(
+      `${gap} event(s) missing a primary EventKennel row — first ${missing.length}:\n${sampleList}\n\n` +
+        `Run \`npx tsx scripts/reconcile-missing-event-kennel-primaries.ts --apply\` to backfill, ` +
+        `then investigate which write path created Events without going through createEventWithKennel.`,
     );
-    console.warn(`First ${missing.length} missing event IDs:`);
-    for (const { id } of missing) console.warn(`  ${id}`);
-    console.log("\nHard assertions passed (count gap is expected pre-step-2)");
-    return;
   }
 
   console.log("\nAll invariants hold ✓");


### PR DESCRIPTION
## Summary

While verifying step 6 (historical co-host backfill, PR #1114), `verify-event-kennel-backfill.ts` flagged 309 events on prod missing a primary `EventKennel` row, with the script's stale tolerance message claiming this was "expected pre-step-2." Step 2 (dual-write) shipped weeks ago, so the gap was unexpected.

## Root cause

Issue #1023's step-1 migration `20260428024100_backfill_event_kennel_from_kennel_id` deployed to prod at **2026-04-28T02:50:32Z** — applied by a Vercel preview-branch build of `feat/event-kennel-join-table` (Vercel previews share the prod `DATABASE_URL`, so any branch deploy runs `prisma migrate deploy` on prod; this is documented in `CLAUDE.md`).

The matching application code (PR #1099, `createEventWithKennel` dual-write) did not deploy to prod until ~14h later, when PR #1099 merged to main at **2026-04-28T17:06:05Z**. In that window the merge pipeline kept running its pre-dual-write code path: every Event it created had `Event.kennelId` set normally but no `EventKennel` row.

309 such orphans accumulated across 22 kennels (172 El Paso H3, 26 each of NOSE H3 and HK H3, etc.), all `createdAt` between 03:00 UTC and 17:03 UTC on 2026-04-28.

## Fix

- **`scripts/reconcile-missing-event-kennel-primaries.ts`** — one-shot reconciler that re-runs the original backfill INSERT, scoped to Events without a primary EK row. Idempotent (`ON CONFLICT DO UPDATE` promotes a non-primary row if one exists; otherwise inserts). Gated behind `--apply`, refuses to exit clean if any orphans remain.

  **Already applied to prod**: 309 inserted, 0 remaining. `verify-event-kennel-backfill.ts` reports `Event count = EventKennel primaries = 34,621`, no drift.

- **`scripts/verify-event-kennel-backfill.ts`** — drop the warn-only tolerance for the count check; promote it to a hard throw and point the failure message at the reconciler. Post-step-2, any future orphan signals a real bug (a write path bypassing `createEventWithKennel`, or an EK row deletion) and should fail the verifier loudly, not log a stale "expected" line.

## Test plan

- [x] `scripts/reconcile-missing-event-kennel-primaries.ts` — dry run shows 309 across 22 kennels, all with `Event.kennelId` set
- [x] `scripts/reconcile-missing-event-kennel-primaries.ts --apply` — `Inserted/promoted: 309 rows`, `Orphans after: 0`
- [x] `scripts/verify-event-kennel-backfill.ts` — `All invariants hold ✓`
- [x] `npx tsc --noEmit`
- [x] `npm run lint` — 0 errors

## Out of scope (no action needed)

The reconciler closes the back-window. Forward writes have been going through `createEventWithKennel` since step-2 deploy on 2026-04-28T17:15Z (Event count delta during this investigation: 34,613 → 34,621, every new Event got a primary EK row at write time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)