### PR TITLE
feat(audit): fingerprint schema + DSL evaluator + rule registry (P0a foundation)

### DIFF
--- a/prisma/migrations/20260430195339_audit_fingerprint_p0a/migration.sql
+++ b/prisma/migrations/20260430195339_audit_fingerprint_p0a/migration.sql
@@ -1,0 +1,48 @@
+-- AuditIssue: fingerprint-based dedup columns + GitHub close reason.
+-- Columns added here but not yet wired into runtime dedup decisions —
+-- the file-finding endpoint, bridging tier, and recurrence escalation
+-- logic that read/write these fields land in follow-up PRs.
+
+ALTER TABLE "AuditIssue"
+  ADD COLUMN "closeReason" TEXT,
+  ADD COLUMN "fingerprint" TEXT,
+  ADD COLUMN "affectedEventIds" TEXT[] NOT NULL DEFAULT '{}',
+  ADD COLUMN "recurrenceCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "escalatedAt" TIMESTAMP(3),
+  ADD COLUMN "escalatedToIssueNumber" INTEGER;
+
+CREATE INDEX "AuditIssue_fingerprint_idx" ON "AuditIssue"("fingerprint");
+
+-- AuditFilingNonce: payload-bound single-use nonces for chrome filing.
+CREATE TABLE "AuditFilingNonce" (
+  "id" TEXT NOT NULL,
+  "nonceHash" TEXT NOT NULL,
+  "adminUserId" TEXT NOT NULL,
+  "kennelCode" TEXT NOT NULL,
+  "ruleSlug" TEXT NOT NULL,
+  "payloadHash" TEXT NOT NULL,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "consumedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "AuditFilingNonce_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "AuditFilingNonce_nonceHash_key" ON "AuditFilingNonce"("nonceHash");
+CREATE INDEX "AuditFilingNonce_adminUserId_expiresAt_idx" ON "AuditFilingNonce"("adminUserId", "expiresAt");
+
+-- AuditRuleVersionHistory: tracks (ruleVersion, semanticHash) timeline
+-- per rule. The bridging tier reads this to decide whether to merge
+-- legacy null-fingerprint rows into a new finding's history.
+CREATE TABLE "AuditRuleVersionHistory" (
+  "id" TEXT NOT NULL,
+  "ruleSlug" TEXT NOT NULL,
+  "ruleVersion" INTEGER NOT NULL,
+  "semanticHash" TEXT NOT NULL,
+  "validFrom" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "AuditRuleVersionHistory_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "AuditRuleVersionHistory_ruleSlug_ruleVersion_key" ON "AuditRuleVersionHistory"("ruleSlug", "ruleVersion");
+CREATE INDEX "AuditRuleVersionHistory_ruleSlug_validFrom_idx" ON "AuditRuleVersionHistory"("ruleSlug", "validFrom");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -962,16 +962,74 @@ model AuditIssue {
   kennel          Kennel?           @relation("AuditIssueKennel", fields: [kennelCode], references: [kennelCode])
   githubCreatedAt DateTime // GitHub issue.created_at
   githubClosedAt  DateTime? // GitHub issue.closed_at — current closure only
+  // GitHub `state_reason` ("completed" | "not_planned" | "reopened" | null).
+  // Populated by the sync pipeline; powers the closed-not-planned ratio panel
+  // (P2) and is the strongest signal that the audit prompt over-flagged.
+  closeReason     String?
   delistedAt      DateTime? // non-null when the issue has fallen out of the audit corpus
   // (operator removed the `audit` label, issue deleted, etc.)
   // Preserves the AuditIssueEvent trail for historical trends
   // instead of the cascade-delete codex flagged as a data-loss risk.
-  syncedAt        DateTime          @updatedAt
-  events          AuditIssueEvent[]
+
+  // Fingerprint-based dedup (audit-process improvement plan, P0a).
+  // Null on legacy rows the bridging tier hasn't backfilled yet. Same
+  // (kennelCode, ruleSlug, ruleVersion, semanticHash) hashes to the same
+  // fingerprint regardless of which event sample surfaced the finding —
+  // so cross-stream coalescing works.
+  fingerprint            String? // sha256 hex
+  affectedEventIds       String[] // event IDs sampled into this issue
+  recurrenceCount        Int               @default(0) // bumps each time the same fingerprint fires
+  escalatedAt            DateTime? // set once when recurrenceCount crosses threshold
+  escalatedToIssueNumber Int? // GitHub issue number of the meta-escalation issue
+
+  syncedAt DateTime          @updatedAt
+  events   AuditIssueEvent[]
 
   @@index([stream, state])
   @@index([kennelCode])
   @@index([delistedAt])
+  @@index([fingerprint])
+}
+
+// Single-use, payload-bound nonces minted by /api/audit/mint-filing-nonce
+// and consumed atomically by /api/audit/file-finding. Binding each nonce
+// to (adminUserId, kennelCode, ruleSlug, payloadHash) means a leaked
+// nonce can only file the exact (kennel, rule, payload) it was minted
+// for — not a generic write capability against the admin's session.
+//
+// Hash-not-raw: only the HMAC hash is persisted; the raw nonce never
+// lives at rest.
+model AuditFilingNonce {
+  id          String    @id @default(cuid())
+  nonceHash   String    @unique
+  adminUserId String // Clerk user.id
+  kennelCode  String
+  ruleSlug    String
+  payloadHash String // sha256 over (stream, kennelCode, ruleSlug, sortedEventIds, bodyMarkdown)
+  expiresAt   DateTime
+  consumedAt  DateTime?
+  createdAt   DateTime  @default(now())
+
+  @@index([adminUserId, expiresAt])
+}
+
+// Audit rule version history. Records the (ruleVersion, semanticHash) that
+// was active when an AuditIssue was filed. The bridging tier (bundle 5)
+// consults this table to decide whether `semanticHash` rolled forward
+// since a legacy null-fingerprint row was filed; if so, bridging is unsafe
+// (semantics changed) and a new issue gets filed cleanly.
+//
+// Populated by the rule-registry codegen step. One row per
+// (ruleSlug, ruleVersion); `validFrom` orders the timeline.
+model AuditRuleVersionHistory {
+  id           String   @id @default(cuid())
+  ruleSlug     String
+  ruleVersion  Int
+  semanticHash String
+  validFrom    DateTime @default(now())
+
+  @@unique([ruleSlug, ruleVersion])
+  @@index([ruleSlug, validFrom])
 }
 
 model AuditIssueEvent {

--- a/src/lib/audit-evaluator.test.ts
+++ b/src/lib/audit-evaluator.test.ts
@@ -1,0 +1,176 @@
+import {
+  evaluate,
+  canonicalizeMatcher,
+  EVALUATOR_VERSION,
+  type Matcher,
+  type NormalizedRow,
+} from "./audit-evaluator";
+
+const FIXTURE: NormalizedRow = {
+  haresText: "Just Frank, BareGain",
+  title: "NYCH3 #1234 — Frank's run",
+  description: "BYOB, $5 hash cash, runs at 7 PM",
+  locationName: "Central Park, NYC",
+  locationCity: "New York",
+  startTime: "19:00",
+  rawDescription: "BYOB, $5 hash cash, runs at 7 PM\nMore details...",
+  kennelCode: "nych3",
+  kennelShortName: "NYCH3",
+};
+
+describe("evaluate", () => {
+  it("regex-test fires when the pattern matches the field", () => {
+    const m: Matcher = { op: "regex-test", field: "haresText", pattern: "Frank" };
+    expect(evaluate(m, FIXTURE)).toBe(true);
+  });
+
+  it("regex-test does not fire on a missing field", () => {
+    const m: Matcher = { op: "regex-test", field: "haresText", pattern: "Frank" };
+    expect(evaluate(m, { ...FIXTURE, haresText: null })).toBe(false);
+  });
+
+  it("regex-test honors flags (case-insensitive)", () => {
+    const m: Matcher = { op: "regex-test", field: "title", pattern: "nych3", flags: "i" };
+    expect(evaluate(m, FIXTURE)).toBe(true);
+  });
+
+  it("regex-test rejects empty pattern at compile time", () => {
+    const m: Matcher = { op: "regex-test", field: "title", pattern: "" };
+    expect(() => evaluate(m, FIXTURE)).toThrow(/non-empty/);
+  });
+
+  it("regex-test rejects unsupported flags so the evaluator stays deterministic", () => {
+    // 'x' is not in the supported flag set — fingerprint integrity depends on
+    // every variation of behavior being caught by the validator.
+    const m: Matcher = { op: "regex-test", field: "title", pattern: "x", flags: "xyz" };
+    expect(() => evaluate(m, FIXTURE)).toThrow(/invalid flags/);
+  });
+
+  it("starts-with is case-sensitive (use regex-test with ^ for fuzzier matching)", () => {
+    const lower: Matcher = { op: "starts-with", field: "title", value: "nych3" };
+    expect(evaluate(lower, FIXTURE)).toBe(false);
+    const upper: Matcher = { op: "starts-with", field: "title", value: "NYCH3" };
+    expect(evaluate(upper, FIXTURE)).toBe(true);
+  });
+
+  it("starts-with does not fire on a null field", () => {
+    const m: Matcher = { op: "starts-with", field: "haresText", value: "anything" };
+    expect(evaluate(m, { ...FIXTURE, haresText: null })).toBe(false);
+  });
+
+  it("equals does strict string comparison and treats null as not-equal", () => {
+    const yes: Matcher = { op: "equals", field: "kennelCode", value: "nych3" };
+    expect(evaluate(yes, FIXTURE)).toBe(true);
+    const no: Matcher = { op: "equals", field: "kennelCode", value: "NYCH3" };
+    expect(evaluate(no, FIXTURE)).toBe(false);
+    const nullish: Matcher = { op: "equals", field: "haresText", value: "" };
+    expect(evaluate(nullish, { ...FIXTURE, haresText: null })).toBe(false);
+  });
+
+  it("length-eq treats null as length 0", () => {
+    const m: Matcher = { op: "length-eq", field: "haresText", value: 0 };
+    expect(evaluate(m, { ...FIXTURE, haresText: null })).toBe(true);
+    expect(evaluate(m, FIXTURE)).toBe(false);
+  });
+
+  it("length-gt fires when the field exceeds the threshold", () => {
+    const m: Matcher = { op: "length-gt", field: "rawDescription", value: 20 };
+    expect(evaluate(m, FIXTURE)).toBe(true);
+    expect(evaluate(m, { ...FIXTURE, rawDescription: "short" })).toBe(false);
+  });
+
+  it("and short-circuits — all conditions must hold", () => {
+    const m: Matcher = {
+      op: "and",
+      conditions: [
+        { op: "starts-with", field: "title", value: "NYCH3" },
+        { op: "regex-test", field: "title", pattern: "Frank" },
+      ],
+    };
+    expect(evaluate(m, FIXTURE)).toBe(true);
+    expect(evaluate(m, { ...FIXTURE, title: "DIFFERENT_KENNEL #1234" })).toBe(false);
+  });
+
+  it("or fires when any condition holds", () => {
+    const m: Matcher = {
+      op: "or",
+      conditions: [
+        { op: "equals", field: "kennelCode", value: "nope" },
+        { op: "equals", field: "kennelCode", value: "nych3" },
+      ],
+    };
+    expect(evaluate(m, FIXTURE)).toBe(true);
+  });
+
+  it("not negates the inner condition", () => {
+    const m: Matcher = {
+      op: "not",
+      condition: { op: "equals", field: "kennelCode", value: "other-kennel" },
+    };
+    expect(evaluate(m, FIXTURE)).toBe(true);
+  });
+
+  it("nested boolean composition stays deterministic across re-runs", () => {
+    // Same inputs → same output: gives us confidence that the evaluator
+    // has no hidden state that would invalidate fingerprint identity.
+    const m: Matcher = {
+      op: "and",
+      conditions: [
+        {
+          op: "or",
+          conditions: [
+            { op: "regex-test", field: "title", pattern: "Frank" },
+            { op: "regex-test", field: "title", pattern: "Doe" },
+          ],
+        },
+        { op: "not", condition: { op: "starts-with", field: "kennelCode", value: "x" } },
+      ],
+    };
+    expect(evaluate(m, FIXTURE)).toBe(true);
+    expect(evaluate(m, FIXTURE)).toBe(true);
+  });
+});
+
+describe("canonicalizeMatcher", () => {
+  it("produces stable output regardless of object key order", () => {
+    // Same matcher built with keys in different declaration order should
+    // canonicalize identically — that's what makes semanticHash stable.
+    const a: Matcher = { op: "regex-test", field: "title", pattern: "x", flags: "i" };
+    const b: Matcher = { flags: "i", pattern: "x", field: "title", op: "regex-test" } as Matcher;
+    expect(canonicalizeMatcher(a)).toBe(canonicalizeMatcher(b));
+  });
+
+  it("changes when the matcher payload changes", () => {
+    const a: Matcher = { op: "regex-test", field: "title", pattern: "x" };
+    const b: Matcher = { op: "regex-test", field: "title", pattern: "y" };
+    expect(canonicalizeMatcher(a)).not.toBe(canonicalizeMatcher(b));
+  });
+
+  it("treats arrays positionally — reordering conditions changes the hash", () => {
+    // Boolean composition is commutative for evaluation, but for fingerprint
+    // identity we want to detect any change. Authors who reorder conditions
+    // must accept a fingerprint roll.
+    const a: Matcher = {
+      op: "and",
+      conditions: [
+        { op: "equals", field: "kennelCode", value: "a" },
+        { op: "equals", field: "kennelCode", value: "b" },
+      ],
+    };
+    const b: Matcher = {
+      op: "and",
+      conditions: [
+        { op: "equals", field: "kennelCode", value: "b" },
+        { op: "equals", field: "kennelCode", value: "a" },
+      ],
+    };
+    expect(canonicalizeMatcher(a)).not.toBe(canonicalizeMatcher(b));
+  });
+});
+
+describe("EVALUATOR_VERSION", () => {
+  it("is a positive integer", () => {
+    expect(Number.isInteger(EVALUATOR_VERSION)).toBe(true);
+    expect(EVALUATOR_VERSION).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/audit-evaluator.test.ts
+++ b/src/lib/audit-evaluator.test.ts
@@ -46,6 +46,32 @@ describe("evaluate", () => {
     expect(() => evaluate(m, FIXTURE)).toThrow(/invalid flags/);
   });
 
+  it.each([["g"], ["y"], ["gi"], ["iy"]])(
+    "regex-test rejects stateful flag '%s' (cached RegExp + lastIndex would break determinism)",
+    (flags) => {
+      // Compiled regex is memoized in a WeakMap and reused across many
+      // evaluations. `g` and `y` mutate `lastIndex` on `.test()`, which
+      // would make identical inputs alternate between match/non-match
+      // depending on prior call history. PR #1163 reviewers (Gemini,
+      // Codex, Qodo, CodeRabbit) all flagged this on the initial pass.
+      const m: Matcher = { op: "regex-test", field: "title", pattern: "x", flags };
+      expect(() => evaluate(m, FIXTURE)).toThrow(/invalid flags/);
+    },
+  );
+
+  it("regex-test rejects ReDoS-vulnerable patterns via safe-regex2", () => {
+    // Classic catastrophic-backtrack pattern: nested quantifiers with
+    // overlapping character classes. Rule authors are trusted (registry
+    // is source-controlled), but isSafeRegex is cheap defense-in-depth
+    // so a bad rule can't hang every audit run.
+    const m: Matcher = {
+      op: "regex-test",
+      field: "title",
+      pattern: "(a+)+$",
+    };
+    expect(() => evaluate(m, FIXTURE)).toThrow(/catastrophic backtracking/);
+  });
+
   it("starts-with is case-sensitive (use regex-test with ^ for fuzzier matching)", () => {
     const lower: Matcher = { op: "starts-with", field: "title", value: "nych3" };
     expect(evaluate(lower, FIXTURE)).toBe(false);

--- a/src/lib/audit-evaluator.ts
+++ b/src/lib/audit-evaluator.ts
@@ -93,6 +93,14 @@ const regexCache = new WeakMap<object, RegExp>();
  */
 const ALLOWED_FLAGS_RE = /^[imsu]*$/;
 
+/**
+ * Compile a registry-supplied regex pattern. Patterns come from the
+ * source-controlled rule registry (not user input), but `isSafeRegex`
+ * is cheap defense-in-depth so a rule author can't accidentally land
+ * a catastrophic-backtrack pattern that would hang every audit run.
+ * The check cost is amortized by the WeakMap cache (one isSafeRegex
+ * call per first-compile per matcher node).
+ */
 function compileRegex(matcher: Extract<Matcher, { op: "regex-test" }>): RegExp {
   const cached = regexCache.get(matcher);
   if (cached) return cached;
@@ -104,12 +112,7 @@ function compileRegex(matcher: Extract<Matcher, { op: "regex-test" }>): RegExp {
       `Matcher regex-test: invalid flags "${matcher.flags}" (allowed: i, m, s, u)`,
     );
   }
-  // Patterns come from the source-controlled rule registry, not from
-  // user input — but `isSafeRegex` is cheap defense-in-depth so a
-  // rule author can't accidentally land a catastrophic-backtrack
-  // pattern that would hang every audit run. The cost (one check per
-  // first-compile) is amortized by the WeakMap cache.
-  // nosemgrep: detect-non-literal-regexp — pattern is registry-supplied + ReDoS-validated
+  // nosemgrep: detect-non-literal-regexp — pattern is registry-supplied + ReDoS-validated below
   const compiled = new RegExp(matcher.pattern, matcher.flags); // NOSONAR
   if (!isSafeRegex(compiled)) {
     throw new Error(

--- a/src/lib/audit-evaluator.ts
+++ b/src/lib/audit-evaluator.ts
@@ -13,6 +13,8 @@
  * fingerprint = same matching semantics" a sound invariant.
  */
 
+import isSafeRegex from "safe-regex2";
+
 import type { AuditEventRow } from "@/pipeline/audit-checks";
 
 /**
@@ -80,18 +82,40 @@ export type Matcher =
  */
 const regexCache = new WeakMap<object, RegExp>();
 
+/**
+ * Allowed flag set: `i`, `m`, `s`, `u`. The stateful flags `g` and `y`
+ * are banned because the compiled `RegExp` is cached and reused across
+ * many `evaluate()` calls — `RegExp.prototype.test()` mutates
+ * `lastIndex` for those flags, which would make the evaluator
+ * non-deterministic and break the fingerprint invariant. Multiple PR
+ * reviewers (Gemini, Codex, Qodo, CodeRabbit) flagged this on the
+ * initial pass; the test suite locks the rejection in.
+ */
+const ALLOWED_FLAGS_RE = /^[imsu]*$/;
+
 function compileRegex(matcher: Extract<Matcher, { op: "regex-test" }>): RegExp {
   const cached = regexCache.get(matcher);
   if (cached) return cached;
   if (matcher.pattern.length === 0) {
     throw new Error("Matcher regex-test: pattern must be non-empty");
   }
-  // Flags string is data, not a runtime configuration knob — anything
-  // that varies at request time would invalidate the fingerprint.
-  if (matcher.flags !== undefined && !/^[gimsuy]*$/.test(matcher.flags)) {
-    throw new Error(`Matcher regex-test: invalid flags "${matcher.flags}"`);
+  if (matcher.flags !== undefined && !ALLOWED_FLAGS_RE.test(matcher.flags)) {
+    throw new Error(
+      `Matcher regex-test: invalid flags "${matcher.flags}" (allowed: i, m, s, u)`,
+    );
   }
-  const compiled = new RegExp(matcher.pattern, matcher.flags);
+  // Patterns come from the source-controlled rule registry, not from
+  // user input — but `isSafeRegex` is cheap defense-in-depth so a
+  // rule author can't accidentally land a catastrophic-backtrack
+  // pattern that would hang every audit run. The cost (one check per
+  // first-compile) is amortized by the WeakMap cache.
+  // nosemgrep: detect-non-literal-regexp — pattern is registry-supplied + ReDoS-validated
+  const compiled = new RegExp(matcher.pattern, matcher.flags); // NOSONAR
+  if (!isSafeRegex(compiled)) {
+    throw new Error(
+      `Matcher regex-test: pattern "${matcher.pattern}" may cause catastrophic backtracking (ReDoS)`,
+    );
+  }
   regexCache.set(matcher, compiled);
   return compiled;
 }
@@ -114,8 +138,7 @@ export function evaluate(matcher: Matcher, row: NormalizedRow): boolean {
       return compileRegex(matcher).test(value);
     }
     case "starts-with": {
-      const value = readField(row, matcher.field);
-      return value !== null && value.startsWith(matcher.value);
+      return readField(row, matcher.field)?.startsWith(matcher.value) ?? false;
     }
     case "equals": {
       const value = readField(row, matcher.field);
@@ -156,7 +179,7 @@ function sortedKeyReplacer(_key: string, value: unknown): unknown {
     !Array.isArray(value)
   ) {
     const obj = value as Record<string, unknown>;
-    const sortedKeys = Object.keys(obj).sort();
+    const sortedKeys = Object.keys(obj).sort((a, b) => a.localeCompare(b));
     const out: Record<string, unknown> = {};
     for (const k of sortedKeys) {
       // `k` came from Object.keys(obj) directly — same source.

--- a/src/lib/audit-evaluator.ts
+++ b/src/lib/audit-evaluator.ts
@@ -1,0 +1,168 @@
+/**
+ * Tiny pure interpreter for the audit-rule DSL.
+ *
+ * Every fingerprintable rule's matching logic must be expressible
+ * entirely from data declared in its registry entry — no shared regex
+ * constants, no `new RegExp` at runtime, no env reads. Rules call
+ * `evaluate(matcher, row)` and that's the entire matching surface.
+ *
+ * Including {@link EVALUATOR_VERSION} in each rule's `semanticHash`
+ * means a behavior change in the interpreter (the `evaluate()` switch,
+ * the row normalizer, the canonicalizer) rolls fingerprints forward
+ * even when matcher data is unchanged. That's what makes "same
+ * fingerprint = same matching semantics" a sound invariant.
+ */
+
+import type { AuditEventRow } from "@/pipeline/audit-checks";
+
+/**
+ * Bump when ANY of the following change:
+ *   - the `evaluate()` switch / control flow
+ *   - the {@link NormalizedRow} shape
+ *   - the {@link Matcher} type union (adding/removing/renaming ops)
+ */
+export const EVALUATOR_VERSION = 1;
+
+// ── Field projection ────────────────────────────────────────────────
+
+/**
+ * Subset of audit-event fields the evaluator can project from. Derived
+ * from {@link AuditEventRow} via Pick<> so any future schema field that
+ * needs to be matchable just gets added here, not re-listed in a
+ * parallel union.
+ */
+export type NormalizedRow = Pick<
+  AuditEventRow,
+  | "haresText"
+  | "title"
+  | "description"
+  | "locationName"
+  | "locationCity"
+  | "startTime"
+  | "rawDescription"
+  | "kennelCode"
+  | "kennelShortName"
+>;
+
+/** Field the DSL can read off a normalized row. */
+export type RowField = keyof NormalizedRow;
+
+// ── Matcher DSL ─────────────────────────────────────────────────────
+
+/**
+ * Discriminated union of supported ops. Each variant is data-only — no
+ * function references, no regex literals (regex patterns are stored as
+ * strings and compiled lazily via {@link compileRegex}, with the source
+ * + flags participating in `semanticHash`).
+ */
+export type Matcher =
+  | { op: "regex-test"; field: RowField; pattern: string; flags?: string }
+  // String prefix test. Case-sensitive — use `regex-test` with `^…` for fuzzier matching.
+  | { op: "starts-with"; field: RowField; value: string }
+  | { op: "equals"; field: RowField; value: string }
+  // Field length comparisons. Null fields treat length as 0.
+  | { op: "length-eq"; field: RowField; value: number }
+  | { op: "length-gt"; field: RowField; value: number }
+  // Boolean composition.
+  | { op: "and"; conditions: readonly Matcher[] }
+  | { op: "or"; conditions: readonly Matcher[] }
+  | { op: "not"; condition: Matcher };
+
+// ── Evaluator ───────────────────────────────────────────────────────
+
+/**
+ * Compiled-regex cache keyed by the matcher node identity. A typical
+ * audit run evaluates the same matcher tree against thousands of
+ * events; without this cache each event would recompile every regex
+ * via `new RegExp(pattern, flags)`. WeakMap so cache entries clear
+ * automatically when a Matcher object goes out of scope (registry
+ * reload, tests).
+ */
+const regexCache = new WeakMap<object, RegExp>();
+
+function compileRegex(matcher: Extract<Matcher, { op: "regex-test" }>): RegExp {
+  const cached = regexCache.get(matcher);
+  if (cached) return cached;
+  if (matcher.pattern.length === 0) {
+    throw new Error("Matcher regex-test: pattern must be non-empty");
+  }
+  // Flags string is data, not a runtime configuration knob — anything
+  // that varies at request time would invalidate the fingerprint.
+  if (matcher.flags !== undefined && !/^[gimsuy]*$/.test(matcher.flags)) {
+    throw new Error(`Matcher regex-test: invalid flags "${matcher.flags}"`);
+  }
+  const compiled = new RegExp(matcher.pattern, matcher.flags);
+  regexCache.set(matcher, compiled);
+  return compiled;
+}
+
+function readField(row: NormalizedRow, field: RowField): string | null {
+  // `field` is a literal union of known column names — dynamic access
+  // is type-safe by construction, no untrusted input.
+  return row[field];
+}
+
+/**
+ * Evaluate a matcher against a row. Pure function — same inputs always
+ * yield the same output. No side effects, no I/O, no env reads.
+ */
+export function evaluate(matcher: Matcher, row: NormalizedRow): boolean {
+  switch (matcher.op) {
+    case "regex-test": {
+      const value = readField(row, matcher.field);
+      if (value === null) return false;
+      return compileRegex(matcher).test(value);
+    }
+    case "starts-with": {
+      const value = readField(row, matcher.field);
+      return value !== null && value.startsWith(matcher.value);
+    }
+    case "equals": {
+      const value = readField(row, matcher.field);
+      return value === matcher.value;
+    }
+    case "length-eq": {
+      const value = readField(row, matcher.field);
+      return (value?.length ?? 0) === matcher.value;
+    }
+    case "length-gt": {
+      const value = readField(row, matcher.field);
+      return (value?.length ?? 0) > matcher.value;
+    }
+    case "and":
+      return matcher.conditions.every((c) => evaluate(c, row));
+    case "or":
+      return matcher.conditions.some((c) => evaluate(c, row));
+    case "not":
+      return !evaluate(matcher.condition, row);
+  }
+}
+
+// ── Canonicalization (for semanticHash) ─────────────────────────────
+
+/**
+ * Deterministic JSON encoding of a matcher tree — keys sorted, arrays
+ * preserved in declared order. The `semanticHash` of a rule is
+ * `sha256(canonicalize(matcher) + EVALUATOR_VERSION)`.
+ */
+export function canonicalizeMatcher(matcher: Matcher): string {
+  return JSON.stringify(matcher, sortedKeyReplacer);
+}
+
+function sortedKeyReplacer(_key: string, value: unknown): unknown {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value)
+  ) {
+    const obj = value as Record<string, unknown>;
+    const sortedKeys = Object.keys(obj).sort();
+    const out: Record<string, unknown> = {};
+    for (const k of sortedKeys) {
+      // `k` came from Object.keys(obj) directly — same source.
+      out[k] = obj[k];
+    }
+    return out;
+  }
+  return value;
+}

--- a/src/lib/audit-fingerprint.test.ts
+++ b/src/lib/audit-fingerprint.test.ts
@@ -1,0 +1,76 @@
+import { computeAuditFingerprint } from "./audit-fingerprint";
+
+const BASE = {
+  kennelCode: "nych3",
+  ruleSlug: "hare-cta-text",
+  ruleVersion: 1,
+  semanticHash: "abc123def456",
+};
+
+describe("computeAuditFingerprint", () => {
+  it("produces a 64-char hex sha256", () => {
+    const fp = computeAuditFingerprint(BASE);
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for the same inputs", () => {
+    expect(computeAuditFingerprint(BASE)).toBe(computeAuditFingerprint(BASE));
+  });
+
+  it("differs when kennelCode changes", () => {
+    expect(computeAuditFingerprint(BASE)).not.toBe(
+      computeAuditFingerprint({ ...BASE, kennelCode: "other-kennel" }),
+    );
+  });
+
+  it("differs when ruleSlug changes", () => {
+    expect(computeAuditFingerprint(BASE)).not.toBe(
+      computeAuditFingerprint({ ...BASE, ruleSlug: "title-cta-text" }),
+    );
+  });
+
+  it("differs when ruleVersion changes", () => {
+    expect(computeAuditFingerprint(BASE)).not.toBe(
+      computeAuditFingerprint({ ...BASE, ruleVersion: 2 }),
+    );
+  });
+
+  it("differs when semanticHash changes", () => {
+    expect(computeAuditFingerprint(BASE)).not.toBe(
+      computeAuditFingerprint({ ...BASE, semanticHash: "different" }),
+    );
+  });
+
+  it("does NOT incorporate event-id sets — same rule + same kennel coalesce across streams", () => {
+    // The fingerprint must be a property of the (rule, kennel) pair,
+    // not of the particular event window that surfaced it — otherwise
+    // automated, chrome-event, and chrome-kennel streams would each
+    // produce different hashes for the same defect because they
+    // sampled different events. Belt-and-suspenders test: the
+    // function's signature has no event-id parameter.
+    expect(computeAuditFingerprint(BASE)).toBe(computeAuditFingerprint(BASE));
+  });
+
+  it("survives newline injection — kennelCode containing a newline doesn't collide with adjacent fields", () => {
+    // Defensive: kennelCode is slug-shaped today (`[a-z0-9-]`), but if a
+    // future schema migration relaxes that constraint we don't want a
+    // raw `\n` in kennelCode to silently produce the same fingerprint as
+    // (kennelCode-without-newline) + (ruleSlug-with-prefix).
+    //
+    // The current implementation joins fields with newlines, so this
+    // test will fail if/when someone changes the encoding without
+    // adopting a stricter delimiter scheme. That's the prompt to make
+    // the choice deliberate.
+    const innocuous = computeAuditFingerprint({
+      ...BASE,
+      kennelCode: "nych3",
+      ruleSlug: "hare-cta-text",
+    });
+    const evil = computeAuditFingerprint({
+      ...BASE,
+      kennelCode: "nych3\nhare-cta-text",
+      ruleSlug: "",
+    });
+    expect(innocuous).not.toBe(evil);
+  });
+});

--- a/src/lib/audit-fingerprint.ts
+++ b/src/lib/audit-fingerprint.ts
@@ -1,0 +1,54 @@
+/**
+ * Audit-issue fingerprint computation.
+ *
+ * The fingerprint is a SHA-256 hash that uniquely identifies the rule
+ * variation that produced an audit finding. The file-finding endpoint
+ * (added in bundle 5) queries `AuditIssue.fingerprint` to coalesce
+ * duplicates across the three audit streams — same
+ * `(kennelCode, ruleSlug, ruleVersion, semanticHash)` tuple → same hash
+ * → comment on the existing issue instead of opening a new one.
+ *
+ * The four inputs deliberately exclude the affected event-id set —
+ * sampling-dependent inputs would hash differently across streams that
+ * happened to surface different events for the same defect, breaking
+ * cross-stream coalescing.
+ *
+ * `semanticHash` is computed by the rule registry from the rule's
+ * matcher DSL plus `EVALUATOR_VERSION`, so any change to matcher data
+ * OR interpreter behavior rolls the fingerprint forward. `ruleVersion`
+ * is bumped manually when the registry author wants to treat a change
+ * as a fresh version even if the matcher payload's canonical form is
+ * unchanged (rare).
+ */
+
+import { createHash } from "node:crypto";
+
+export interface AuditFingerprintInput {
+  kennelCode: string;
+  ruleSlug: string;
+  ruleVersion: number;
+  /** sha256 hex from `rule-registry.ts:semanticHashFor`. */
+  semanticHash: string;
+}
+
+/**
+ * Compute the canonical fingerprint for an audit finding.
+ *
+ * Inputs are joined with newline separators and hashed once. Newline as
+ * the separator (rather than a delimiter character that could appear in
+ * any input) keeps the encoding unambiguous: kennelCode, ruleSlug, and
+ * the hex-only `semanticHash` are all guaranteed not to contain newlines
+ * by their respective producers (slug regex, sha256 output), and
+ * `ruleVersion` is an integer.
+ */
+export function computeAuditFingerprint(
+  input: AuditFingerprintInput,
+): string {
+  const payload = [
+    input.kennelCode,
+    input.ruleSlug,
+    String(input.ruleVersion),
+    input.semanticHash,
+  ].join("\n");
+  return createHash("sha256").update(payload).digest("hex");
+}

--- a/src/pipeline/audit-checks.ts
+++ b/src/pipeline/audit-checks.ts
@@ -18,6 +18,9 @@ export interface AuditEventRow {
   rawDescription: string | null;
 }
 
+export type AuditCategory = "hares" | "title" | "location" | "event" | "description";
+export type AuditSeverity = "error" | "warning";
+
 export interface AuditFinding {
   kennelShortName: string;
   kennelCode: string;
@@ -25,12 +28,12 @@ export interface AuditFinding {
   eventUrl: string;
   sourceUrl: string | null;
   adapterType: string;
-  category: "hares" | "title" | "location" | "event" | "description";
+  category: AuditCategory;
   field: string;
   currentValue: string;
   expectedValue?: string;
   rule: string;
-  severity: "error" | "warning";
+  severity: AuditSeverity;
 }
 
 const HARELINE_BASE_URL = "https://www.hashtracks.xyz/hareline";

--- a/src/pipeline/rule-registry.test.ts
+++ b/src/pipeline/rule-registry.test.ts
@@ -1,0 +1,92 @@
+import {
+  AUDIT_RULES,
+  getRule,
+  semanticHashFor,
+  type AuditRule,
+} from "./rule-registry";
+
+const SAMPLE_RULE: AuditRule = {
+  slug: "test-only-sample",
+  category: "title",
+  severity: "warning",
+  version: 1,
+  matcher: { op: "regex-test", field: "title", pattern: "test" },
+  fingerprint: true,
+  description: "Test fixture, not registered in AUDIT_RULES.",
+};
+
+describe("AUDIT_RULES", () => {
+  it("is empty in the P0a scaffolding PR", () => {
+    // Bundle 4b populates this; if a rule lands here without the
+    // companion bridging-tier work in bundle 5, dedup behavior will
+    // diverge from the rest of the audit pipeline.
+    expect(AUDIT_RULES.size).toBe(0);
+  });
+
+  it("returns undefined for unknown slugs via getRule()", () => {
+    expect(getRule("nonexistent")).toBeUndefined();
+  });
+});
+
+describe("semanticHashFor", () => {
+  it("returns a 64-char hex sha256", () => {
+    expect(semanticHashFor(SAMPLE_RULE)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for the same rule", () => {
+    expect(semanticHashFor(SAMPLE_RULE)).toBe(semanticHashFor(SAMPLE_RULE));
+  });
+
+  it("rolls forward when the matcher payload changes", () => {
+    const a = semanticHashFor(SAMPLE_RULE);
+    const b = semanticHashFor({
+      ...SAMPLE_RULE,
+      matcher: { op: "regex-test", field: "title", pattern: "different" },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("rolls forward when the matcher field changes", () => {
+    const a = semanticHashFor(SAMPLE_RULE);
+    const b = semanticHashFor({
+      ...SAMPLE_RULE,
+      matcher: { op: "regex-test", field: "haresText", pattern: "test" },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("rolls forward when boolean composition is restructured", () => {
+    // and([a, b]) and or([a, b]) must hash differently even if both
+    // would happen to evaluate the same way for some inputs.
+    const a = semanticHashFor({
+      ...SAMPLE_RULE,
+      matcher: {
+        op: "and",
+        conditions: [
+          { op: "regex-test", field: "title", pattern: "x" },
+          { op: "regex-test", field: "title", pattern: "y" },
+        ],
+      },
+    });
+    const b = semanticHashFor({
+      ...SAMPLE_RULE,
+      matcher: {
+        op: "or",
+        conditions: [
+          { op: "regex-test", field: "title", pattern: "x" },
+          { op: "regex-test", field: "title", pattern: "y" },
+        ],
+      },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("does NOT roll forward when only the human-readable description changes", () => {
+    // semanticHash is about matching behavior, not documentation. A
+    // typo-fix in `description` shouldn't invalidate every existing
+    // open issue's fingerprint.
+    const a = semanticHashFor(SAMPLE_RULE);
+    const b = semanticHashFor({ ...SAMPLE_RULE, description: "different prose" });
+    expect(a).toBe(b);
+  });
+});

--- a/src/pipeline/rule-registry.ts
+++ b/src/pipeline/rule-registry.ts
@@ -58,8 +58,20 @@ export interface AuditRule {
   description?: string;
 }
 
+/**
+ * Build a registry from `(slug, rule)` entries. Separating construction
+ * from the exported `AUDIT_RULES` instance lets bundle 4b populate the
+ * registry by passing entries here, and lets tests build smaller
+ * registries without monkey-patching the exported singleton.
+ */
+export function buildRegistry(
+  entries: ReadonlyArray<readonly [string, AuditRule]> = [],
+): ReadonlyMap<string, AuditRule> {
+  return new Map(entries);
+}
+
 /** Registry of fingerprintable audit rules. */
-export const AUDIT_RULES: ReadonlyMap<string, AuditRule> = new Map();
+export const AUDIT_RULES: ReadonlyMap<string, AuditRule> = buildRegistry();
 
 export function getRule(slug: string): AuditRule | undefined {
   return AUDIT_RULES.get(slug);
@@ -73,11 +85,15 @@ export function getRule(slug: string): AuditRule | undefined {
  * canonicalizer — rolls the fingerprint forward even if the matcher
  * data didn't change. Captures the FULL match-surface, not just the
  * rule's data.
+ *
+ * Built from explicit string concatenation rather than `JSON.stringify`
+ * so the encoding is bit-stable regardless of object-key order
+ * variations across JS engines (the inner `canonicalizeMatcher` already
+ * sorts keys deterministically; we just don't want to layer another
+ * `JSON.stringify` on top of an outer object whose key order isn't
+ * guaranteed by spec).
  */
 export function semanticHashFor(rule: AuditRule): string {
-  const payload = JSON.stringify({
-    matcher: canonicalizeMatcher(rule.matcher),
-    evaluatorVersion: EVALUATOR_VERSION,
-  });
+  const payload = `v${EVALUATOR_VERSION}\n${canonicalizeMatcher(rule.matcher)}`;
   return createHash("sha256").update(payload).digest("hex");
 }

--- a/src/pipeline/rule-registry.ts
+++ b/src/pipeline/rule-registry.ts
@@ -1,0 +1,83 @@
+/**
+ * Audit rule registry — single source of truth for rule semantics.
+ *
+ * Each entry owns its matcher DSL tree (consumed by the
+ * `audit-evaluator`), its version number, and its fingerprint flag. The
+ * hash computed by {@link semanticHashFor} participates in the audit-
+ * issue fingerprint, so any change to a rule's matcher payload (or the
+ * evaluator interpreting it) rolls the fingerprint forward.
+ *
+ * **Constraint:** every entry whose `fingerprint` flag is `true` MUST
+ * express its matching logic entirely in declarative {@link Matcher}
+ * data — no shared regex constants, no runtime regex construction, no
+ * env reads. Rules that can't satisfy that constraint (e.g. cross-row
+ * checks like `checkLocationQuality`'s aggregate dedup) tag
+ * `fingerprint: false` and opt out of cross-stream coalescing for those
+ * specific rules. They keep filing legacy-style with title-based dedup
+ * until the DSL grows to support them.
+ *
+ * `AUDIT_RULES` is empty in this PR (P0a foundation). Rule migration
+ * from `audit-checks.ts` happens in a follow-up PR — one rule per
+ * commit so each fingerprint roll is reviewable in isolation. No live
+ * caller reads from this Map yet; the file-finding endpoint that
+ * triggers fingerprint-based dedup arrives in bundle 5.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  EVALUATOR_VERSION,
+  canonicalizeMatcher,
+  type Matcher,
+} from "@/lib/audit-evaluator";
+import type {
+  AuditCategory,
+  AuditSeverity,
+} from "@/pipeline/audit-checks";
+
+export interface AuditRule {
+  /** Stable rule identifier (e.g. `"hare-cta-text"`). Matches the
+   *  existing `KNOWN_AUDIT_RULES` slugs so the suppressions UI keeps
+   *  working through the migration. */
+  slug: string;
+  category: AuditCategory;
+  severity: AuditSeverity;
+  /** Bumped manually when the registry author wants to treat a change
+   *  as a fresh version even if the matcher payload's canonical form
+   *  is unchanged. Most authors don't touch this — changing matcher
+   *  data automatically rolls the fingerprint via semanticHash. */
+  version: number;
+  /** Declarative matcher tree. Consumed by `audit-evaluator.evaluate`. */
+  matcher: Matcher;
+  /** Whether dedup uses fingerprint-based coalescing (true) or legacy
+   *  title-based dedup (false). Cross-row aggregate rules opt out
+   *  until the DSL grows to support them. */
+  fingerprint: boolean;
+  /** Short human-readable description for the registry inspector and
+   *  registry-admin tooling. Optional — semanticHash ignores it so
+   *  prose edits don't roll fingerprints. */
+  description?: string;
+}
+
+/** Registry of fingerprintable audit rules. */
+export const AUDIT_RULES: ReadonlyMap<string, AuditRule> = new Map();
+
+export function getRule(slug: string): AuditRule | undefined {
+  return AUDIT_RULES.get(slug);
+}
+
+/**
+ * SHA-256 of the canonicalized matcher payload + the evaluator version.
+ *
+ * Including `EVALUATOR_VERSION` in the hash means a behavior change in
+ * the interpreter — the `evaluate()` switch, the row normalizer, the
+ * canonicalizer — rolls the fingerprint forward even if the matcher
+ * data didn't change. Captures the FULL match-surface, not just the
+ * rule's data.
+ */
+export function semanticHashFor(rule: AuditRule): string {
+  const payload = JSON.stringify({
+    matcher: canonicalizeMatcher(rule.matcher),
+    evaluatorVersion: EVALUATOR_VERSION,
+  });
+  return createHash("sha256").update(payload).digest("hex");
+}


### PR DESCRIPTION
## Summary

Foundation for the audit-process improvement plan's fingerprint-based dedup work. **Schema-only + library scaffolding** in this PR — no live caller reads from the registry or computes fingerprints yet. The file-finding endpoint, bridging tier, and recurrence-escalation logic that exercise these primitives land in follow-up PRs.

The plan was approved in PR #1162 (which shipped the prompt + dialog improvements). Plan file lives at `~/.claude/plans/please-look-at-issue-giggly-wren.md`; five Codex adversarial passes converged on the design that this PR begins implementing.

## Schema changes

`AuditIssue` gets six new columns:
- `closeReason` (GitHub `state_reason`, drives the upcoming closed-not-planned ratio panel)
- `fingerprint` (sha256 hex, null on legacy rows that the bridging tier hasn't backfilled)
- `affectedEventIds` (TEXT[])
- `recurrenceCount`, `escalatedAt`, `escalatedToIssueNumber`

Plus a new index on `fingerprint`, and two new tables:
- `AuditFilingNonce` — payload-bound single-use nonces for the chrome-stream filing endpoints (hash-not-raw; only the HMAC hash is persisted)
- `AuditRuleVersionHistory` — tracks `(ruleSlug, ruleVersion, semanticHash, validFrom)` so the bridging tier can decide whether a legacy null-fingerprint row predates a matcher-semantics change

Migration applied locally; Vercel will run `prisma migrate deploy` automatically on build.

## Library scaffolding

**`src/lib/audit-evaluator.ts`** — tiny pure interpreter for the rule DSL. Ops: `regex-test`, `starts-with`, `equals`, `length-eq`, `length-gt`, `and` / `or` / `not`. Rules must express their entire match logic in declarative `Matcher` data — no shared regex constants, no runtime regex construction, no env reads. Compiled regex memoized per-matcher in a WeakMap so evaluating one rule across thousands of events doesn't recompile the same pattern.

**`src/lib/audit-fingerprint.ts`** — `computeAuditFingerprint({kennelCode, ruleSlug, ruleVersion, semanticHash})` returns a 64-char hex sha256 over the newline-joined inputs. Deliberately excludes affected event IDs so that automated, chrome-event, and chrome-kennel streams that surfaced different events for the same defect coalesce on the same fingerprint.

**`src/pipeline/rule-registry.ts`** — empty `AUDIT_RULES` Map shape + `semanticHashFor(rule)` helper. Each rule entry owns its `slug`, `category`, `severity`, `version`, `matcher` (DSL tree), `fingerprint` flag, and optional `description`. `semanticHashFor` includes `EVALUATOR_VERSION` in the hash so a behavior change in the interpreter rolls fingerprints forward even when matcher data is unchanged.

`AuditCategory` and `AuditSeverity` extracted from `audit-checks.ts` into named exports so the registry imports them rather than re-declaring the unions.

## What's not in this PR

- **No rule migration.** The 17 rules in `audit-checks.ts` keep using their inline regex form. Migration to the registry happens one rule per commit in a follow-up PR so each fingerprint roll is reviewable in isolation.
- **No runtime wiring.** Nothing in the audit-issue mirror, sync pipeline, or filing path reads the new fields yet. That's bundle 5.
- **No filing endpoint, no nonce mint/consume, no bridging tier.** All in bundle 5.
- **No queue-snapshot HMAC token for #1160.** That's bundle 6.

## Test plan

- [x] `npx vitest run src/lib/audit-evaluator.test.ts src/lib/audit-fingerprint.test.ts src/pipeline/rule-registry.test.ts` — 34 new tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (14 pre-existing warnings, none on touched files)
- [x] `npm test` — 5558 passing. One failing test (`google-calendar/adapter.test.ts` RECURRENCE-ID override) is pre-existing on main; verified by stashing this PR's changes and running on a clean checkout
- [x] Migration applied locally via `npm run prisma -- migrate deploy` against `hashtracks_dev`; schema reports clean
- [ ] Vercel preview build runs `prisma migrate deploy` against the preview branch DB to validate the migration end-to-end before merge

## Codex adversarial-review history

The fingerprint shape, evaluator-version-in-hash design, and explicit exclusion of event IDs from the hash are all corrections that came out of five rounds of `/codex:adversarial-review` on the original plan. Notable:
- Pass 2: dropped event-id set from fingerprint inputs (sampling dependence)
- Pass 5: tied `EVALUATOR_VERSION` into `semanticHash` to capture interpreter behavior, not just rule data; constrained rules to express logic via the DSL (no shared helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)