### PR TITLE
docs(static-schedule): canonicalize BYMONTH seasonal pattern; drop Tier 1 seasonal-RRULE

### DIFF
--- a/docs/facebook-integration-strategy.md
+++ b/docs/facebook-integration-strategy.md
@@ -27,7 +27,7 @@ Examples: Rumson, NOSE H3, Mosquito H3, Wildcard, H6, PBH3, all 11 GA/SC fillers
 
 These work, but they have known limitations the playbook already documents:
 - Can't express **lunar recurrence** (Full Moon / New Moon hashes — KFMH3 Osaka uses Google Calendar instead because of this; many MY/HK FM kennels are unsupported).
-- Can't express **seasonal schedule switching** (NOSE summer Thursday → winter Wednesday is two seeded sources today; brittle).
+- ~~Can't express seasonal schedule switching~~ — **resolved.** NOSE H3 (summer Thursday May–Oct / winter Wednesday Nov–Apr) ships correctly today as two seed sources with disjoint `BYMONTH` filters. The pattern was canonicalized in `source-onboarding-playbook.md` lesson #102 on 2026-04-30; see decision log entry 2026-04-30 below for why a single-source `seasons` schema was investigated and dropped.
 - Don't know about **cancellations** (city event conflicts — see Charleston bridge-run example in [`facebook-user-research.md`](facebook-user-research.md) line 39).
 - Don't carry **per-run details** (location, hares, on-after) — placeholder only.
 
@@ -66,7 +66,7 @@ Derived from the inventory above. Each row is a real scenario we hit today.
 | # | Use case | Concrete example | What we have | What's missing |
 |---|---|---|---|---|
 | **U1** | Recurring schedule, no per-run detail | Rumson Saturday | STATIC_SCHEDULE | Nothing — works |
-| **U2** | Seasonal switch | NOSE Thursday-summer / Wednesday-winter | Two STATIC_SCHEDULE sources | First-class seasonal RRULE; modest adapter change |
+| **U2** | Seasonal switch | NOSE Thursday-summer / Wednesday-winter | Two STATIC_SCHEDULE sources with disjoint `BYMONTH` (works correctly today) | Nothing — pattern canonicalized in source-onboarding-playbook.md #102 on 2026-04-30 |
 | **U3** | Lunar recurrence | KFMH3 Full Moon, HKFH3, FCH3-HK, ~30+ MY full-moon kennels | Workaround via Google Calendar where the kennel maintains one | Lunar generator with timezone + ephemeris model |
 | **U4** | Per-run location/hare/start-time | Little Rock posts day-of FB, Singapore Harriets, most MY kennels | Placeholder text only | Live FB read OR human submission |
 | **U5** | Cancellations / conflicts | Charleston bridge-run cancellation | Nothing — we'd show a phantom event | Live FB read OR admin override |
@@ -112,7 +112,7 @@ These are the only items that are simultaneously low-risk, immediately useful, a
 
 - **The strategy doc itself (this file).** Future "why aren't we scraping FB" pushback gets routed here. Update [`roadmap.md`](roadmap.md) line 917 to point at this doc and reframe `FACEBOOK_EVENTS` as a deferred design until the T2f pilot graduates.
 - **Cancellation override on STATIC_SCHEDULE-generated events** (U5). Admin marks a generated event as cancelled; the override sticks across re-scrapes. Reuses existing machinery in [`src/app/admin/events/actions.ts`](../src/app/admin/events/actions.ts). No new ingestion path; closes the most-cited correctness gap (Charleston-style conflicts) using human input we already have.
-- **Seasonal RRULE switch in STATIC_SCHEDULE** (U2). NOSE-style "summer Thursday / winter Wednesday" expressed as one source instead of two. **Limited to date-range switches in a known timezone** — not lunar, not equinox-based, not observance-based. This is a config-shape change and is provably bounded.
+- ~~**Seasonal RRULE switch in STATIC_SCHEDULE** (U2)~~ — **dropped 2026-04-30.** Investigation showed NOSE H3 already ships seasonal switching correctly via two STATIC_SCHEDULE sources with disjoint `BYMONTH` filters (PR #1035 added `BYMONTH` parsing to the adapter); a single-source `seasons` schema would have duplicated month-partitioning semantics, rippled across the admin validator + `StaticScheduleConfigPanel` + seed helpers + `fetch()` validation, and added test surface for zero user-visible value. Codex's adversarial review surfaced these compatibility costs before code was written. The two-source-with-`BYMONTH` pattern is now the canonical seasonal-switch onboarding pattern (`source-onboarding-playbook.md` lesson #102). NOSE is the only validated seasonal-switch kennel in the repo today; future kennels with the same shape will use the same pattern. See decision log entry 2026-04-30 below.
 
 Tier 1 explicitly does **not** include lunar recurrence. See Tier 2.
 
@@ -236,6 +236,17 @@ Until this snapshot exists, no percentage-based decision in this doc can fire.
 ## Decision Log
 
 This section is intentionally append-only. **New entries on top.**
+
+**2026-04-30 — Seasonal RRULE feature dropped from Tier 1**
+
+When work began on the Tier 1 "Seasonal RRULE switch in STATIC_SCHEDULE" item, exploration revealed:
+- NOSE H3 (the example named in the original Tier 1 entry) already ships seasonal switching correctly via two `STATIC_SCHEDULE` sources sharing one `kennelTag`, each scoped via disjoint `BYMONTH` filters (May–Oct Thursday / Nov–Apr Wednesday). PR #1035 added `BYMONTH` parsing to the `parseRRule()` helper before this strategy doc was written; the original "NOSE is brittle" framing was inaccurate.
+- The proposed single-source `seasons: SeasonRule[]` schema was put through Codex adversarial review pre-code. Findings: (a) `months[]` duplicates `BYMONTH`'s existing month-partitioning semantics — a config can silently disagree with itself; (b) making top-level `rrule` optional ripples into the admin validator, the `StaticScheduleConfigPanel` UI, the shared seed helper, and `fetch()` validation — far beyond a "config-shape change"; (c) NOSE migration in the same PR creates manual prod-cleanup debt; (d) the proposed "annual parity" test is weaker than the actual fetch contract (window-dependent, anchor-aligned).
+- The user-visible value was zero (NOSE works today). The cost was a multi-layer schema change with non-trivial validation and window-boundary tests.
+
+**Decision:** drop the feature. Document the BYMONTH-on-multiple-sources pattern as canonical (`source-onboarding-playbook.md` lesson #102 + step-6 example). Update Tier 1 in this doc to reflect the corrected scope. Move to the cancellation override item (the Tier 1 entry with actual user value — phantom-event correctness gap).
+
+If a future, validated seasonal-switch onboarding case materially benefits from a single-source seasons schema (i.e. the two-source-with-`BYMONTH` pattern produces real friction beyond DRY-only), this decision can be revisited with the corrected understanding of the cost surface. The earlier draft of this entry named LBH3 and Cherry Capital as motivating cases; that was inaccurate — LBH3 already has a `GOOGLE_CALENDAR` source covering its schedule, and Cherry Capital's schedule is unverified (FB-only with unclear regularity per `docs/kennel-research/us-deepen-nj-md-mi-la-research.md`). Reopening the question requires a real validated case, not a speculative one.
 
 **2026-04-29 — Initial decisions**
 

--- a/docs/source-onboarding-playbook.md
+++ b/docs/source-onboarding-playbook.md
@@ -160,7 +160,7 @@ Existing adapter types:
 - `HARRIER_CENTRAL` — For kennels listed on hashruns.org (Harrier Central). Config-driven with `cityNames`, `kennelUniqueShortName`, `publicKennelId`, `defaultKennelTag`, or `kennelPatterns`. Returns rich data: event name, run number, date/time, lat/lng coordinates, hares, location descriptions. Currently: Tokyo H3. Known kennels on platform: Tokyo H3, SeaMon H3, Glasgow H3, City Hash, London H3, WLH3, Puget Sound H3, Rain City H3, Seattle H3, Morgantown H3, New Town H3, East End London H3, Brussels Manneke Piss H3, Amsterdam H3, Lisbon H3, Nairobi H3, Taiwan H3.
 - `HTML_SCRAPER` (WordPress REST API) — For WordPress-hosted sites with public REST API. Uses shared `fetchWordPressPosts()` from `src/adapters/wordpress-api.ts`. Title contains event name/date, body contains labeled fields (Hare, Location, Date, Time). Currently: EWH3, DCH4, Voodoo H3, KCH3, BruH3. **Check first**: `curl -s "https://site.com/wp-json/wp/v2/posts?per_page=3" | python3 -m json.tool` — if it returns JSON posts, use this pattern.
 - `HTML_SCRAPER` (Substack API) — For Substack-hosted newsletters. Public API at `{domain}/api/v1/archive` (listing) + `{domain}/api/v1/posts/{slug}` (detail with body_html). No auth required. Parse event date from title, time from subtitle, location from Google Maps links in body. Currently: STLH3. **Check**: `curl -s "https://site.com/api/v1/archive?limit=3"` — if it returns JSON array of posts, use this pattern.
-- `STATIC_SCHEDULE` — For kennels without scrapeable web sources (Facebook-only). Generates placeholder events from RRULE recurrence rules — no external fetch. Config-driven with `rrule`, `defaultTitle`, `defaultLocation`, `startTime`, `kennelTag`. Currently: 28 sources across FL, GA, SC, MA, NJ, RI, TX. **Cannot express lunar recurrence** (full/new moon schedules). **Cannot express seasonal schedule switching** (e.g., summer Friday / winter Sunday) — add kennel record with `scheduleNotes` but no source until seasonal RRULE support is implemented.
+- `STATIC_SCHEDULE` — For kennels without scrapeable web sources (Facebook-only). Generates placeholder events from RRULE recurrence rules — no external fetch. Config-driven with `rrule`, `defaultTitle`, `defaultLocation`, `startTime`, `kennelTag`. Currently: 28 sources across FL, GA, SC, MA, NJ, RI, TX. **Cannot express lunar recurrence** (full/new moon schedules). **Seasonal schedule switching** (e.g., summer Thursday / winter Wednesday) **is supported via `BYMONTH` on disjoint per-season sources** — see the seasonal-switch pattern in step 6 below; NOSE H3 is the reference example.
 
 If none fit, create a new adapter implementing `SourceAdapter` from `src/adapters/types.ts`.
 
@@ -232,6 +232,49 @@ config: { rrule: "FREQ=MONTHLY;BYDAY=1SU,3SU", ... }
 // Every other Saturday
 config: { rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA", ... }
 ```
+
+**Seasonal schedule switching (canonical pattern):** kennels that change run day with the seasons (e.g. summer Thursday / winter Wednesday) are encoded as **two source records sharing the same `kennelTag`, each scoped to disjoint months via `BYMONTH`**. The two RRULEs together must cover the full year with no overlap. Reference: NOSE H3 in `prisma/seed-data/sources.ts` lines 184–214 — summer Thursdays use `BYMONTH=5,6,7,8,9,10` (May–Oct), winter Wednesdays use `BYMONTH=1,2,3,4,11,12` (Nov–Apr). The block below is the full runnable seed shape; copy and adapt for new seasonal-switch kennels.
+
+```typescript
+// Source 1 — summer schedule (NOSE H3 actual seed)
+{
+  name: "NOSE Hash Static Schedule (Summer Thursdays)",
+  url: "https://www.facebook.com/groups/NOSEHash",
+  type: "STATIC_SCHEDULE" as const,
+  trustLevel: 3,
+  scrapeFreq: "weekly",
+  scrapeDays: 90,
+  config: {
+    kennelTag: "nose-h3",
+    rrule: "FREQ=WEEKLY;BYDAY=TH;BYMONTH=5,6,7,8,9,10",
+    startTime: "19:00",
+    defaultTitle: "NOSE H3 Weekly Run",
+    defaultLocation: "North NJ",
+    defaultDescription: "Summer schedule: Thursdays 7pm in North NJ. ...",
+  },
+  kennelCodes: ["nose-h3"],
+},
+// Source 2 — winter schedule (NOSE H3 actual seed)
+{
+  name: "NOSE Hash Static Schedule (Winter Wednesdays)",
+  url: "https://www.facebook.com/groups/NOSEHash#winter-wed",
+  type: "STATIC_SCHEDULE" as const,
+  trustLevel: 3,
+  scrapeFreq: "weekly",
+  scrapeDays: 90,
+  config: {
+    kennelTag: "nose-h3",
+    rrule: "FREQ=WEEKLY;BYDAY=WE;BYMONTH=1,2,3,4,11,12",
+    startTime: "19:00",
+    defaultTitle: "NOSE H3 Weekly Run",
+    defaultLocation: "North NJ",
+    defaultDescription: "Winter schedule: Wednesdays 7pm in North NJ. ...",
+  },
+  kennelCodes: ["nose-h3"],
+},
+```
+
+Note the `url` field on the second source — adding a fragment (`#winter-wed`) keeps the two source URLs distinct so the seed upsert treats them as separate rows. Each source is scraped/scheduled independently; the merge pipeline produces one event per real run because the two `BYMONTH` ranges never produce a date for the same kennel on the same day. A single-source `seasons` schema was considered and rejected — see [`facebook-integration-strategy.md`](facebook-integration-strategy.md) decision log entry 2026-04-30 for the full rationale.
 
 **For new HTML scrapers:**
 1. Create `src/adapters/html-scraper/{site-name}.ts` implementing `SourceAdapter`
@@ -657,7 +700,7 @@ The display layer (`getLocationDisplay()` in `EventCard.tsx`) deduplicates city 
 32. **Listing + detail fetch pattern** — When an API provides a listing endpoint with IDs and a detail endpoint per event, fetch detail sequentially (not in parallel) to be a good API citizen. Always implement a listing-only fallback when detail fetches fail — partial data is better than no data.
 33. **STATIC_SCHEDULE is the default for Facebook-only kennels** — Most small-market kennels have no website, calendar, or API — just a Facebook group. STATIC_SCHEDULE sources generate placeholder events from RRULE patterns, giving users visibility into the schedule even without automated scraping.
 34. **KennelCode conflicts need region suffixes** — As coverage expands, shortName collisions across regions become common (e.g., CH3 in both Chicago and Charleston). Use region suffixes on the `kennelCode` (e.g., `ch3-sc`, `ph3-atl`) to disambiguate. The `shortName` stays clean for display.
-35. **Moon-phase scheduling can't be expressed as RRULE** — Kennels that run on full/new moons (Luna Ticks, Dark Side) need a custom recurrence model. For now, add them as kennel-only records (no source) and note the lunar schedule in `scheduleNotes`.
+35. **Moon-phase scheduling can't be expressed as RRULE** — Kennels that run on full/new moons (Luna Ticks, Dark Side) need a custom recurrence model. For now, add them as kennel-only records (no source) and note the lunar schedule in `scheduleNotes`. (Seasonal day-of-week switches *can* be expressed — see lesson #102.)
 36. **Zero-code onboarding at scale** — South Carolina onboarded 10 kennels with 9 sources and zero new adapter code. Config-driven adapters (MEETUP, STATIC_SCHEDULE) + seed data changes are sufficient for regions without structured web sources. This pattern scales to any region with known schedules.
 37. **Wix/Google Sites/SPAs need headless browser rendering** — JS-rendered sites return empty containers to Cheerio. Use `fetchBrowserRenderedPage()` (wraps `browserRender()` from `src/lib/browser-render.ts`) to render via NAS-hosted Playwright, then parse normally. The adapter still uses `HTML_SCRAPER` type and URL-based routing in the registry. See `northboro-hash.ts` for the reference implementation. Config: Cloudflare Tunnel path routing `proxy.hashtracks.xyz/render` → `browser-render:3200`.
 38. **Facebook Events are the biggest untapped source** — Many small-market kennels exist only on Facebook (no website, calendar, or API). Public Facebook pages show events without login, but the page is JS-rendered and returns empty HTML to standard fetch. A future `FACEBOOK_EVENTS` adapter could use the NAS headless browser with an authenticated session (persistent cookies) to scrape public page events. This would unlock dozens of currently un-scrapeable kennels. Key challenges: Facebook anti-scraping measures (behavioral analysis, CAPTCHAs), session cookie expiration requiring periodic re-auth, and fragile DOM selectors that change frequently. Until this adapter exists, use `STATIC_SCHEDULE` for Facebook-only kennels with known schedules.
@@ -724,6 +767,7 @@ The display layer (`getLocationDisplay()` in `EventCard.tsx`) deduplicates city 
 99. **Multi-run event blocks require array return types** — Sydney Thirsty H3 publishes AGPU-style multi-day specials as "Runs (Sat and Sun) 1843 & 1844" — a single block with two run numbers. Codex caught that the parser was dropping these because it required a singular `Run #NNNN` line. Fix: parse the alternate `Runs N & M` regex and return `RawEventData[]` instead of `RawEventData | null`, emitting one event per run number. For multi-day specials (e.g. "Sat and Sun"), offset the date for the second run (+1 day) to avoid fingerprint collisions — two events with the same kennel + date deduplicate in the merge pipeline. Test the alternate format explicitly.
 100. **hhh.asn.au is the Australian national kennel directory** — static HTML-frameset site listing ~220 AU kennels across 14 state-page codes with URLs and schedules. No other aggregator covers Australia — Harrier Central has zero AU kennels, HashRego has zero, Half-Mind explicitly excludes AU/Asia. Use `hhh.asn.au` as the primary Stage-2 discovery source for any AU region research. Cross-reference with `genealogy.gotothehash.net` for founding dates and aliases (195 historical AU records).
 101. **Chrome verification is mandatory, not optional** — the Australia research pass classified 9 kennels as "ready to ship" but Chrome verification proved 4 were wrong (dead Meetup groups, wrong URLs, wrong source types), and discovered 3 additional kennels not in the original research. Only 2 of the original 9 shipped as-planned (with URL corrections). Without Chrome verification, the PR would have shipped 4 non-functional sources. Always run Chrome verification before committing to an implementation plan.
+102. **Seasonal schedule switching uses two STATIC_SCHEDULE sources with disjoint `BYMONTH`** — kennels that change run day with the seasons (e.g. NOSE H3: summer Thursday May–Oct / winter Wednesday Nov–Apr) ship as two `STATIC_SCHEDULE` sources sharing one `kennelTag`. Reference NOSE H3 in `prisma/seed-data/sources.ts` lines 184–214 and the step-6 example. NOSE is the only validated case in the repo today; if a future onboarding case requires this pattern, follow the same shape. A single-source `seasons` schema was considered and rejected — see [`facebook-integration-strategy.md`](facebook-integration-strategy.md) decision log entry 2026-04-30 for the full rationale.
 
 ---
 

--- a/docs/source-onboarding-playbook.md
+++ b/docs/source-onboarding-playbook.md
@@ -250,7 +250,7 @@ config: { rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA", ... }
     startTime: "19:00",
     defaultTitle: "NOSE H3 Weekly Run",
     defaultLocation: "North NJ",
-    defaultDescription: "Summer schedule: Thursdays 7pm in North NJ. ...",
+    defaultDescription: "Summer schedule: Thursdays 7pm in North NJ. Check the Facebook group at https://www.facebook.com/groups/NOSEHash for start location.",
   },
   kennelCodes: ["nose-h3"],
 },
@@ -268,13 +268,13 @@ config: { rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA", ... }
     startTime: "19:00",
     defaultTitle: "NOSE H3 Weekly Run",
     defaultLocation: "North NJ",
-    defaultDescription: "Winter schedule: Wednesdays 7pm in North NJ. ...",
+    defaultDescription: "Winter schedule: Wednesdays 7pm in North NJ. Check the Facebook group at https://www.facebook.com/groups/NOSEHash for start location.",
   },
   kennelCodes: ["nose-h3"],
 },
 ```
 
-Note the `url` field on the second source — adding a fragment (`#winter-wed`) keeps the two source URLs distinct so the seed upsert treats them as separate rows. Each source is scraped/scheduled independently; the merge pipeline produces one event per real run because the two `BYMONTH` ranges never produce a date for the same kennel on the same day. A single-source `seasons` schema was considered and rejected — see [`facebook-integration-strategy.md`](facebook-integration-strategy.md) decision log entry 2026-04-30 for the full rationale.
+**The two seasonal sources MUST have distinct `name` values.** The seed upsert identity is `(name, type)` — see `@@unique([name, type])` in `prisma/schema.prisma:221` and the lookup at `prisma/seed.ts:364`. URL is *not* part of the identity key, so two seed entries sharing a `name` (even with different URLs or URL fragments) collapse to a single row on seed: the second entry updates the first rather than creating a second source, dropping one season's RRULE. The only operational signal is the normal `~ Updated ... for <name>` log line from `seed.ts:401-406`, so the failure is easy to miss in a long seed run. The `#winter-wed` fragment on the second source's URL is for human readability only — the actual deduplication guarantee comes from the distinct names ("Summer Thursdays" vs. "Winter Wednesdays"). Each source is scraped/scheduled independently; the merge pipeline produces one event per real run because the two `BYMONTH` ranges never produce a date for the same kennel on the same day. A single-source `seasons` schema was considered and rejected — see [`facebook-integration-strategy.md`](facebook-integration-strategy.md) decision log entry 2026-04-30 for the full rationale.
 
 **For new HTML scrapers:**
 1. Create `src/adapters/html-scraper/{site-name}.ts` implementing `SourceAdapter`

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3135,9 +3135,12 @@ export const SOURCES = [
     // in feedback_sourceless_kennels memory. Description fields link to their FB
     // page so users can check the actual trail location day-of.
     //
-    // The two records below share the same Facebook page but use distinct URL
-    // fragments (#sunday / #wednesday) so the OR(url+type, name+type) match in
-    // prisma/seed.ts treats them as separate sources rather than overwriting.
+    // The two records below share the same Facebook page but are kept as
+    // separate seed rows by their distinct `name` values — the seed upsert
+    // identity is `(name, type)` per `prisma/schema.prisma:221` and
+    // `prisma/seed.ts:364`. The `#sunday` / `#wednesday` URL fragments are
+    // only for human readability; identical names with different URLs would
+    // collapse to a single row on seed.
     {
       name: "Little Rock H3 Static Schedule (Sunday)",
       url: "https://www.facebook.com/littlerockhashhouseharriers#sunday",


### PR DESCRIPTION
## Summary

- Documents the **BYMONTH-on-two-sources** pattern as the canonical way to encode seasonal schedule switching in `STATIC_SCHEDULE` sources, with NOSE H3 as the runnable reference.
- Drops the Tier 1 "seasonal RRULE switch" item from the FB strategy doc with a full decision-log entry explaining why, plus a corrected acknowledgment that the earlier draft's LBH3/Cherry Capital framing was speculative.
- Updates `source-onboarding-playbook.md` lesson #102 + step-6 example + a cross-reference parenthetical on lesson #35.

No code changes. This PR is a course correction on a planned Tier 1 feature.

## Why this exists

When work began on the FB-strategy-doc Tier 1 "seasonal RRULE switch in STATIC_SCHEDULE" item, exploration showed the original premise was wrong. NOSE H3 (the cited example) **already ships seasonal switching correctly** via two `STATIC_SCHEDULE` sources with disjoint `BYMONTH` filters; PR #1035 added `BYMONTH` parsing to `parseRRule()` before the strategy doc was even written. The "NOSE is brittle" framing was inaccurate.

A pre-code Codex adversarial review of the proposed single-source `seasons` schema surfaced four real costs: (1) `months[]` would duplicate `BYMONTH`'s existing month-partitioning semantics, creating self-contradictory configs, (2) making top-level `rrule` optional rippled into the admin validator, the `StaticScheduleConfigPanel` UI, the shared seed helper, and `fetch()` validation — far more than a "config-shape change", (3) NOSE migration in the same PR created manual prod-cleanup debt, (4) the proposed parity test was weaker than the actual fetch contract. **Zero user-visible value** since NOSE works today.

Decision: drop the feature; document the existing pattern as canonical so future onboarders land on it without re-asking the same question.

## What this PR changes

**`docs/source-onboarding-playbook.md`** (~48 line additions):
- Line 163: replaces the "Cannot express seasonal schedule switching" claim on the `STATIC_SCHEDULE` bullet with a pointer to the new step-6 pattern.
- Step 6 (after line 234): adds a "Seasonal schedule switching (canonical pattern)" subsection with a **runnable** code example matching `prisma/seed-data/sources.ts` lines 184–214 verbatim (modulo trailing description text).
- Lesson #35 (moon-phase): adds a parenthetical pointing readers at #102.
- Lesson #102 (new): summarizes the pattern + links to the strategy doc decision log for the rejection rationale.

**`docs/facebook-integration-strategy.md`** (~17 line changes):
- Line 30: marks the "Can't express seasonal schedule switching" limitation as resolved.
- Line 69: updates the U2 "Seasonal switch" row to reflect that the pattern is canonicalized.
- Line 115: marks the Tier 1 seasonal-RRULE item as dropped with rationale.
- Decision log: new 2026-04-30 entry on top of the append-only log explaining the investigation, the four Codex findings, the decision, and the corrected understanding (LBH3 / Cherry Capital were speculative — LBH3 has `GOOGLE_CALENDAR`; Cherry Capital is unverified FB-only).

## Process

- **Pre-code Codex adversarial review** on the proposed `seasons` schema → user pivoted to docs-only after seeing the cost surface.
- **/simplify pass** on the doc diff → caught three real issues: invented field values in the step-6 example (now matches seed), a strikethrough that retroactively edited a historical decision-log entry (reverted; supersedence-only), and triple-stated rationale (trimmed to one canonical location in the strategy doc).
- **Post-fix Codex adversarial review** → caught the LBH3/Cherry Capital speculation regression + the "copy-pasteable" snippet missing required seed fields. Both fixed.
- **Final Codex pass: approve.**

## Test plan

Doc-only change; nothing to test in the running app.

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (warnings-only, all pre-existing)
- [x] `npm test` clean (1 pre-existing failure on `main` in `google-calendar/adapter.test.ts` unrelated to this PR; verified by checking out `origin/main` and reproducing)
- [ ] Reviewer: confirm the step-6 example matches `prisma/seed-data/sources.ts` lines 184–214 by spot-check
- [ ] Reviewer: confirm doc cross-references render correctly in GitHub Markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)