### PR TITLE
feat(audit): chrome prompts call file-finding endpoint (5c-C)

### DIFF
--- a/src/app/api/audit/mint-filing-nonce/route.test.ts
+++ b/src/app/api/audit/mint-filing-nonce/route.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/site-url", () => ({
 
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
+import { computePayloadHash, type FilingPayload } from "@/lib/audit-nonce";
 import { buildApiPostRequest, type ApiPostInit } from "@/test/audit-request";
 import { POST } from "./route";
 
@@ -96,5 +97,55 @@ describe("POST /api/audit/mint-filing-nonce", () => {
   it("sets Cache-Control: no-store so admin-bound nonces don't get cached", async () => {
     const res = await POST(buildReq());
     expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  describe("canonical-fields shape (chrome prompt path)", () => {
+    // 5c-C added a second request shape so chrome agents don't have
+    // to compute SHA-256 client-side. Server computes the hash from
+    // the canonical fields and persists it the same as the
+    // pre-hashed shape. Same security envelope at consume time.
+    const CANONICAL_BODY = {
+      stream: "CHROME_KENNEL" as const,
+      kennelCode: "nych3",
+      ruleSlug: "hare-url",
+      title: "NYCH3: hare field is a URL",
+      eventIds: ["evt-1", "evt-2"],
+      bodyMarkdown: "## Finding\n\nDetails go here.",
+    };
+
+    it("accepts canonical fields and computes payloadHash server-side", async () => {
+      const res = await POST(buildReq({ body: CANONICAL_BODY }));
+      expect(res.status).toBe(200);
+
+      // The persisted payloadHash must equal what the server-side
+      // helper computes from the same fields, so the file-finding
+      // endpoint's recompute-and-verify works end-to-end.
+      const expected: FilingPayload = {
+        stream: CANONICAL_BODY.stream,
+        kennelCode: CANONICAL_BODY.kennelCode,
+        ruleSlug: CANONICAL_BODY.ruleSlug,
+        title: CANONICAL_BODY.title,
+        eventIds: CANONICAL_BODY.eventIds,
+        bodyMarkdown: CANONICAL_BODY.bodyMarkdown,
+      };
+      const args = mockCreate.mock.calls[0][0] as {
+        data: { payloadHash: string };
+      };
+      expect(args.data.payloadHash).toBe(computePayloadHash(expected));
+    });
+
+    it("rejects canonical-fields requests missing eventIds", async () => {
+      const { eventIds: _eventIds, ...withoutEventIds } = CANONICAL_BODY;
+      const res = await POST(buildReq({ body: withoutEventIds }));
+      expect(res.status).toBe(400);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("rejects unsupported stream values", async () => {
+      const res = await POST(
+        buildReq({ body: { ...CANONICAL_BODY, stream: "AUTOMATED" } }),
+      );
+      expect(res.status).toBe(400);
+    });
   });
 });

--- a/src/app/api/audit/mint-filing-nonce/route.ts
+++ b/src/app/api/audit/mint-filing-nonce/route.ts
@@ -22,27 +22,87 @@ import {
   generateNonce,
   hashNonce,
   computeNonceExpiresAt,
+  computePayloadHash,
+  type FilingPayload,
 } from "@/lib/audit-nonce";
 
-interface MintRequest {
+/**
+ * Pre-hashed shape: caller computed `payloadHash` client-side. Used
+ * by tooling that wants an explicit binding of the agent's intent.
+ */
+interface PreHashedMintRequest {
   kennelCode: string;
   ruleSlug: string;
-  /** sha256 of the canonical filing payload — see
-   *  `computePayloadHash` in audit-nonce.ts. The agent computes
-   *  this client-side, the consume endpoint recomputes from the
-   *  posted body and rejects on mismatch. */
   payloadHash: string;
 }
 
-function isMintRequest(value: unknown): value is MintRequest {
-  if (typeof value !== "object" || value === null) return false;
-  const v = value as Record<string, unknown>;
+/**
+ * Canonical-fields shape: caller posts the full payload and the
+ * server computes the hash. This is the path used by the chrome
+ * prompts (5c-C) — agents don't need to call `crypto.subtle`.
+ *
+ * Same security envelope as the pre-hashed variant: the server's
+ * `computePayloadHash` produces the same value the consume
+ * endpoint will recompute from its request body, so a leaked nonce
+ * still only files the exact (kennel, rule, title, body) it was
+ * minted for.
+ */
+interface CanonicalFieldsMintRequest {
+  stream: "CHROME_KENNEL" | "CHROME_EVENT";
+  kennelCode: string;
+  ruleSlug: string;
+  title: string;
+  eventIds: string[];
+  bodyMarkdown: string;
+}
+
+type MintRequest = PreHashedMintRequest | CanonicalFieldsMintRequest;
+
+function isPreHashedMintRequest(v: Record<string, unknown>): v is PreHashedMintRequest & Record<string, unknown> {
   return (
     typeof v.kennelCode === "string" &&
     typeof v.ruleSlug === "string" &&
     typeof v.payloadHash === "string" &&
     /^[0-9a-f]{64}$/.test(v.payloadHash)
   );
+}
+
+function isCanonicalFieldsMintRequest(
+  v: Record<string, unknown>,
+): v is CanonicalFieldsMintRequest & Record<string, unknown> {
+  return (
+    (v.stream === "CHROME_KENNEL" || v.stream === "CHROME_EVENT") &&
+    typeof v.kennelCode === "string" &&
+    typeof v.ruleSlug === "string" &&
+    typeof v.title === "string" &&
+    Array.isArray(v.eventIds) &&
+    v.eventIds.every((id) => typeof id === "string") &&
+    typeof v.bodyMarkdown === "string"
+  );
+}
+
+function isMintRequest(value: unknown): value is MintRequest {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return isPreHashedMintRequest(v) || isCanonicalFieldsMintRequest(v);
+}
+
+/**
+ * Resolve the payload hash from either the pre-hashed shape or the
+ * canonical-fields shape. Both end up persisted to the same nonce
+ * row for verification at consume time.
+ */
+function resolvePayloadHash(req: MintRequest): string {
+  if ("payloadHash" in req) return req.payloadHash;
+  const payload: FilingPayload = {
+    stream: req.stream,
+    kennelCode: req.kennelCode,
+    ruleSlug: req.ruleSlug,
+    title: req.title,
+    eventIds: req.eventIds,
+    bodyMarkdown: req.bodyMarkdown,
+  };
+  return computePayloadHash(payload);
 }
 
 export async function POST(req: Request): Promise<NextResponse> {
@@ -52,7 +112,10 @@ export async function POST(req: Request): Promise<NextResponse> {
 
   if (!isMintRequest(body)) {
     return NextResponse.json(
-      { error: "Missing or malformed kennelCode / ruleSlug / payloadHash" },
+      {
+        error:
+          "Body must be either {kennelCode, ruleSlug, payloadHash} or {stream, kennelCode, ruleSlug, title, eventIds, bodyMarkdown}",
+      },
       { status: 400 },
     );
   }
@@ -64,7 +127,7 @@ export async function POST(req: Request): Promise<NextResponse> {
       adminUserId: admin.id,
       kennelCode: body.kennelCode,
       ruleSlug: body.ruleSlug,
-      payloadHash: body.payloadHash,
+      payloadHash: resolvePayloadHash(body),
       expiresAt: computeNonceExpiresAt(),
     },
   });

--- a/src/lib/admin/audit-prompt-shared.ts
+++ b/src/lib/admin/audit-prompt-shared.ts
@@ -48,26 +48,70 @@ export interface FilingInstructionsInput {
   kennelLabel: string;
 }
 
+/**
+ * Map the prompt's stream slug ("chrome-kennel" / "chrome-event") to
+ * the API endpoint's enum literal ("CHROME_KENNEL" / "CHROME_EVENT").
+ */
+function streamLiteralFor(stream: FilingInstructionsInput["stream"]): string {
+  return stream === "chrome-kennel" ? "CHROME_KENNEL" : "CHROME_EVENT";
+}
+
 export function renderFilingInstructions(
   input: FilingInstructionsInput,
 ): string {
-  // URL-encode the labels list for safety. Today's kennelCodes are slug-shaped
-  // (`[a-z0-9-]`), but encoding defensively means a future kennelCode containing
-  // `+`, space, or `&` won't silently corrupt the prefilled-issue link. The
-  // hareline `{KENNEL_CODE}` placeholder becomes `%7BKENNEL_CODE%7D` — uglier
-  // but the prompt's surrounding text still tells the agent how to substitute.
-  const labels = encodeURIComponent(
-    `audit,alert,audit:${input.stream},kennel:${input.kennelLabel}`,
-  );
-  const issueUrl = `https://github.com/${HASHTRACKS_REPO}/issues/new?labels=${labels}&title={URL-ENCODED TITLE}&body={URL-ENCODED BODY}`;
+  const apiStream = streamLiteralFor(input.stream);
+  // Always JSON-quote the kennelLabel value — even the hareline
+  // placeholder. Codex 5c-C pass-1 finding: an unquoted
+  // `{KENNEL_CODE}` produces invalid JSON in the prompt example,
+  // which confuses the agent at copy time. With quotes the example
+  // is valid JSON syntactically; the surrounding prose tells the
+  // agent to substitute the literal placeholder.
+  const kennelJsonValue = `"${input.kennelLabel}"`;
 
-  return `**Option 1 (preferred):** Open this URL in a new tab with title and body URL-encoded. The labels list is pre-baked with \`audit:${input.stream}\` (stream attribution) and \`kennel:${input.kennelLabel}\` (kennel attribution) so the dashboard's "Findings by stream" panel can route the issue correctly:
+  return `**Option 1 (preferred): file via the audit API**
 
-\`\`\`text
-${issueUrl}
+Two-step flow: mint a single-use nonce, then POST the finding. Both calls run in your browser (admin Clerk session, same-origin). Server computes the payload hash, files the GitHub issue, and runs cross-stream coalescing — so if the same finding already has an open issue you'll get a "recurred" outcome instead of a duplicate.
+
+**Step 1 — mint:** \`POST /api/audit/mint-filing-nonce\`
+
+\`\`\`json
+{
+  "stream": "${apiStream}",
+  "kennelCode": ${kennelJsonValue},
+  "ruleSlug": "<rule-slug>",
+  "title": "<your issue title>",
+  "eventIds": ["<event-id-1>", "<event-id-2>"],
+  "bodyMarkdown": "<your issue body, markdown>"
+}
 \`\`\`
 
-**Option 2 (fallback):** Output the finding in this format and the admin will file it:
+Response: \`{ "nonce": "<base64url>" }\` (5-minute TTL, single-use).
+
+**Step 2 — file:** \`POST /api/audit/file-finding\`
+
+\`\`\`json
+{
+  "nonce": "<from step 1>",
+  "stream": "${apiStream}",
+  "kennelCode": ${kennelJsonValue},
+  "ruleSlug": "<same as step 1>",
+  "title": "<same>",
+  "eventIds": ["<same>"],
+  "bodyMarkdown": "<same>"
+}
+\`\`\`
+
+Response shapes:
+- \`{ "action": "created", "issueNumber": N, "issueHtmlUrl": "..." }\` — fresh issue filed.
+- \`{ "action": "recurred", "tier": "strict" | "bridging", "existingIssueNumber": N, "existingIssueHtmlUrl": "...", "recurrenceCount": N }\` — same finding already had an open issue; we commented "still recurring" instead of forking. **Don't refile.**
+- \`{ "error": "...", "existingIssueNumber"?: N }\` (502) — GitHub side effect failed; safe to retry the same nonce.
+- \`{ "error": "Nonce invalid, expired, or payload tampered" }\` (401) — nonce mismatch; mint a fresh one and retry.
+
+The labels (\`audit\`, \`alert\`, \`audit:${input.stream}\`, \`kennel:${input.kennelLabel}\`) are applied server-side; you don't set them yourself.
+
+**Option 2 (fallback): paste the finding for an admin to file manually**
+
+Use this only if the API call fails after a fresh nonce. Output the finding in this format:
 
 ### [Kennel] — [Issue Category]
 * **HashTracks Event URL:** [link]
@@ -76,5 +120,9 @@ ${issueUrl}
 * **Field(s) Affected:** [field name]
 * **Current Extracted Value:** "[exact text from the HashTracks page, verbatim]"
 * **Expected Value:** "[verbatim text from the source — **not** a synthesized cleanup or inference. If the source says "2FC Takes Fenton", that's the expected value; don't 'clean it up' to "2FC" unless the source literally shows that string somewhere.]"
-* **Fix Hypothesis:** [brief guess on root cause]`;
+* **Fix Hypothesis:** [brief guess on root cause]
+
+**Option 3 (legacy fallback): GitHub URL flow**
+
+Old prompts used to direct agents to a prefilled \`https://github.com/${HASHTRACKS_REPO}/issues/new?...\` URL. That path is still supported and will be detected by the bridging tier on the next sync round, but **prefer Option 1** so cross-stream coalescing fires immediately and you don't fork a duplicate.`;
 }

--- a/src/lib/admin/deep-dive-prompt.test.ts
+++ b/src/lib/admin/deep-dive-prompt.test.ts
@@ -39,10 +39,11 @@ const CONTAINS_CASES: readonly ContainsCase[] = [
   ["every source with type and URL", ["hashnyc.com", "HTML_SCRAPER", "https://hashnyc.com", "Hash Rego (NYCH3)", "HASHREGO"]],
   // Last-dived display when never run.
   ["'never' for kennels without a prior deep dive", ["Last deep dive:** never"]],
-  // Filing instructions present; labels list is URL-encoded so future kennelCodes with reserved chars don't corrupt the link.
-  ["What-to-check + filing instructions + URL-encoded labels", ["## What to check", "## Filing findings", "audit%2Calert"]],
-  // Stream + kennel labels in the prefilled URL — without these the dashboard's "Findings by stream" panel buckets the issue as UNKNOWN.
-  ["stream + kennel labels in the prefilled new-issue URL", ["audit:chrome-kennel", "kennel:nych3"]],
+  // Filing instructions present; new flow uses the audit API endpoints (5c-C).
+  ["What-to-check + filing instructions + audit API references", ["## What to check", "## Filing findings", "/api/audit/mint-filing-nonce", "/api/audit/file-finding"]],
+  // Stream literal + kennel slug appear in the JSON body shape so the agent
+  // can copy the example payload directly without guessing field shapes.
+  ["stream + kennel literals in the API payload example", ["CHROME_KENNEL", "\"nych3\""]],
   // Kennel-page completeness section.
   ["kennel-page improvements (founded year, social, hash cash)", ["Kennel page completeness", "Founded year", "Facebook", "Hash Cash"]],
   // Verify-current-state pre-step: guards against false-positive "missing data" findings where the auditor inspected only the source.

--- a/src/lib/admin/hareline-prompt.test.ts
+++ b/src/lib/admin/hareline-prompt.test.ts
@@ -63,4 +63,25 @@ describe("buildHarelinePrompt", () => {
     const empty = buildHarelinePrompt({ ...FIXTURE, focusAreas: [] });
     expect(empty).toContain("no new sources onboarded in the last 14 days");
   });
+
+  it("emits valid JSON in the file-finding payload examples (with quoted {KENNEL_CODE} placeholder)", () => {
+    // Codex 5c-C pass-1 finding: an unquoted `{KENNEL_CODE}`
+    // produced invalid JSON in the prompt example. The fix: always
+    // JSON-quote the kennelCode value, even the placeholder. The
+    // surrounding prose tells the agent to substitute the literal.
+    //
+    // Extract every \`\`\`json fenced block and JSON.parse them all.
+    // Failure to parse is a regression of the original bug.
+    const jsonBlocks = prompt.match(/```json\n([\s\S]*?)\n```/g);
+    expect(jsonBlocks).not.toBeNull();
+    if (!jsonBlocks) return;
+    expect(jsonBlocks.length).toBeGreaterThan(0);
+    for (const block of jsonBlocks) {
+      const inner = block.replace(/^```json\n/, "").replace(/\n```$/, "");
+      // Should not throw; placeholders like "{KENNEL_CODE}",
+      // "<rule-slug>", etc. are all string-quoted so JSON.parse
+      // succeeds.
+      expect(() => JSON.parse(inner)).not.toThrow();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Wires the deep-dive (chrome-kennel) and hareline (chrome-event) prompts to the audit API endpoints shipped in #1181/5c-A so chrome agents file findings via the same fingerprint-aware path that the cron uses, instead of the legacy GitHub-issue-URL prefill. **This is what activates 5a/5b/5c-A end-to-end.**

## Endpoint extension

`POST /api/audit/mint-filing-nonce` now accepts a canonical-fields shape in addition to the existing pre-hashed shape:

```json
{
  "stream": "CHROME_KENNEL",
  "kennelCode": "nych3",
  "ruleSlug": "hare-url",
  "title": "...",
  "eventIds": ["..."],
  "bodyMarkdown": "..."
}
```

Server computes the payload hash via `computePayloadHash` (same helper `file-finding` uses to verify on consume), so chrome agents don't need to touch `crypto.subtle`. Persisted hash is identical regardless of shape, so the consume-side recompute-and-verify works end-to-end.

## Prompt rewrite

`renderFilingInstructions` now surfaces three options:

| Option | Use | Why |
|---|---|---|
| **1 — Audit API (preferred)** | Two-step `mint-filing-nonce` → `file-finding` flow with example JSON payloads + response shapes documented inline | Cross-stream coalescing fires immediately; recur outcomes prevent duplicates |
| **2 — Paste finding** | Fallback when API call fails after a fresh nonce | Unchanged from before |
| **3 — Legacy GitHub URL** | Last-resort bridging | Bridging tier in 5c-A picks these up on next sync |

## Codex pass-1 catch

Earlier revision emitted invalid JSON in the hareline prompt because `{KENNEL_CODE}` was left unquoted. Fixed: always JSON-quote the kennelCode value, even the literal placeholder. **New regression test** extracts every \`\`\`json fenced block from the prompt and runs `JSON.parse` on each.

## Test plan

- [ ] Local: ✅ 5776 tests pass, tsc clean, lint clean
- [ ] SonarCloud / Codacy clean
- [ ] Manual: copy chrome-event prompt → paste into Claude in Chrome → agent finds an event-quality issue → calls `mint-filing-nonce` with canonical fields → calls `file-finding` → issue appears in GH with correct labels
- [ ] Manual: file the same finding twice → second call returns `recurred` (strict tier), `recurrenceCount: 2`, comments "Still recurring on …" on the existing issue
- [ ] Manual: hareline prompt's JSON examples are syntactically valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)