### PR TITLE
feat(admin): audit dashboard UX pass — surface 5c/bundle-6 signals

### DIFF
--- a/src/app/admin/audit/actions.test.ts
+++ b/src/app/admin/audit/actions.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/lib/db", () => ({
     },
     auditIssue: {
       groupBy: vi.fn(),
+      findMany: vi.fn(),
     },
   },
 }));
@@ -65,6 +66,7 @@ import {
   getCloseReasonRatiosByStream,
   getDeepDiveQueueToken,
   recordDeepDive,
+  getEscalatedFindings,
 } from "./actions";
 import {
   computeQueueSnapshotId,
@@ -126,6 +128,15 @@ describe("getAuditTrends", () => {
 });
 
 describe("getTopOffenders", () => {
+  const mockIssueFindMany = vi.mocked(prisma.auditIssue.findMany);
+
+  beforeEach(() => {
+    // Default: no open AuditIssue rows → recurrence/escalation
+    // enrichment fields are null on every offender. Tests that
+    // exercise the enrichment override.
+    mockIssueFindMany.mockResolvedValue([] as never);
+  });
+
   it("aggregates by kennelCode + rule and flags suppressed entries", async () => {
     mockLogFind.mockResolvedValue([
       {
@@ -144,6 +155,8 @@ describe("getTopOffenders", () => {
     const cta = result.find(r => r.kennelCode === "NYCH3")!;
     expect(cta.count).toBe(2);
     expect(cta.suppressed).toBe(true);
+    expect(cta.recurrenceCount).toBeNull();
+    expect(cta.escalatedToIssueNumber).toBeNull();
     const title = result.find(r => r.kennelCode === "BFM")!;
     expect(title.suppressed).toBe(false);
   });
@@ -161,6 +174,180 @@ describe("getTopOffenders", () => {
 
     const result = await getTopOffenders();
     expect(result[0].suppressed).toBe(true);
+  });
+
+  it("enriches offender rows with recurrenceCount + escalatedToIssueNumber from the AuditIssue mirror", async () => {
+    mockLogFind.mockResolvedValue([
+      {
+        createdAt: new Date("2026-04-04T12:00:00Z"),
+        findings: [
+          {
+            kennelCode: "nych3",
+            kennelShortName: "NYCH3",
+            rule: "hare-url",
+            category: "hares",
+          },
+        ],
+      },
+    ] as never);
+    mockSupFind.mockResolvedValue([] as never);
+    // Open AuditIssue with the slug bracket in the title that
+    // `extractRuleSlugFromAutomatedTitle` matches: enrichment hits.
+    mockIssueFindMany.mockResolvedValue([
+      {
+        kennelCode: "nych3",
+        title:
+          "[Audit] NYCH3 — Hare Quality [hare-url] (3 events) — 2026-04-30",
+        recurrenceCount: 7,
+        escalatedToIssueNumber: 555,
+      },
+    ] as never);
+
+    const result = await getTopOffenders();
+    expect(result).toHaveLength(1);
+    expect(result[0].recurrenceCount).toBe(7);
+    expect(result[0].escalatedToIssueNumber).toBe(555);
+  });
+
+  it("leaves enrichment fields null when no open AuditIssue title carries the slug bracket", async () => {
+    // Chrome-stream rows have free-form titles; the bracket regex
+    // misses them, so enrichment for chrome-only kennels stays
+    // null. Documented limitation per the helper's doc.
+    mockLogFind.mockResolvedValue([
+      {
+        createdAt: new Date("2026-04-04T12:00:00Z"),
+        findings: [
+          {
+            kennelCode: "nych3",
+            kennelShortName: "NYCH3",
+            rule: "hare-url",
+            category: "hares",
+          },
+        ],
+      },
+    ] as never);
+    mockSupFind.mockResolvedValue([] as never);
+    mockIssueFindMany.mockResolvedValue([
+      {
+        kennelCode: "nych3",
+        title: "Finding: NYCH3 hare-url",  // chrome-style — no bracket
+        recurrenceCount: 4,
+        escalatedToIssueNumber: null,
+      },
+    ] as never);
+
+    const result = await getTopOffenders();
+    expect(result[0].recurrenceCount).toBeNull();
+    expect(result[0].escalatedToIssueNumber).toBeNull();
+  });
+});
+
+describe("getEscalatedFindings", () => {
+  const mockIssueFindMany = vi.mocked(prisma.auditIssue.findMany);
+
+  beforeEach(() => {
+    mockIssueFindMany.mockReset();
+  });
+
+  it("requires admin", async () => {
+    mockAdmin.mockResolvedValue(null);
+    await expect(getEscalatedFindings()).rejects.toThrow("Unauthorized");
+  });
+
+  it("returns rows that have crossed the escalation threshold, ordered by most-recent escalation", async () => {
+    const now = new Date("2026-05-01T12:00:00Z");
+    const yesterday = new Date("2026-04-30T12:00:00Z");
+    mockIssueFindMany.mockResolvedValue([
+      {
+        githubNumber: 1100,
+        title: "[Audit] NYCH3 — Hare Quality [hare-url] (5 events)",
+        htmlUrl: "https://github.com/x/y/issues/1100",
+        stream: "AUTOMATED",
+        kennelCode: "nych3",
+        kennel: { shortName: "NYCH3" },
+        recurrenceCount: 7,
+        escalatedAt: now,
+        escalatedToIssueNumber: 1200,
+      },
+      {
+        githubNumber: 950,
+        title: "[Audit] BFM — Title Quality [title-cta-text] (2 events)",
+        htmlUrl: "https://github.com/x/y/issues/950",
+        stream: "AUTOMATED",
+        kennelCode: "bfm",
+        kennel: { shortName: "BFM" },
+        recurrenceCount: 5,
+        escalatedAt: yesterday,
+        escalatedToIssueNumber: 1000,
+      },
+    ] as never);
+
+    const result = await getEscalatedFindings();
+    expect(result).toHaveLength(2);
+    expect(result[0].baseIssueNumber).toBe(1100);
+    expect(result[0].baseKennelShortName).toBe("NYCH3");
+    expect(result[0].recurrenceCount).toBe(7);
+    expect(result[0].escalatedToIssueNumber).toBe(1200);
+    expect(result[1].baseIssueNumber).toBe(950);
+
+    // Confirm the WHERE clause filters to escalated + open + not-delisted.
+    expect(mockIssueFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          state: "open",
+          delistedAt: null,
+          escalatedAt: { not: null },
+        }),
+      }),
+    );
+  });
+
+  it("computes the escalatedAgoLabel server-side to avoid hydration drift", async () => {
+    // Hardcode a known `escalatedAt` and rely on `Date.now()` at
+    // call time. The exact label depends on timing (today vs 1 day
+    // ago around midnight); just assert it's one of the
+    // human-readable shapes the helper produces.
+    mockIssueFindMany.mockResolvedValue([
+      {
+        githubNumber: 1,
+        title: "[Audit] X — [hare-url] (1 events)",
+        htmlUrl: "https://github.com/x/y/issues/1",
+        stream: "AUTOMATED",
+        kennelCode: "x",
+        kennel: { shortName: "X" },
+        recurrenceCount: 5,
+        escalatedAt: new Date(Date.now() - 3 * 86_400_000),
+        escalatedToIssueNumber: 100,
+      },
+    ] as never);
+
+    const result = await getEscalatedFindings();
+    expect(result[0].escalatedAgoLabel).toMatch(/^(today|\d+ days? ago)$/);
+    // For a 3-day-old escalation specifically, expect "3 days ago".
+    expect(result[0].escalatedAgoLabel).toBe("3 days ago");
+  });
+
+  it("surfaces rows with null escalatedToIssueNumber (half-state) so operators can investigate", async () => {
+    // Rare but possible: claim landed but finalize update didn't.
+    // The dashboard panel still shows the row so an operator can
+    // clear the manual debt — see audit-filer.ts header comment.
+    mockIssueFindMany.mockResolvedValue([
+      {
+        githubNumber: 800,
+        title: "[Audit] NYCH3 — Hare Quality [hare-url] (1 events)",
+        htmlUrl: "https://github.com/x/y/issues/800",
+        stream: "AUTOMATED",
+        kennelCode: "nych3",
+        kennel: { shortName: "NYCH3" },
+        recurrenceCount: 5,
+        escalatedAt: new Date(),
+        escalatedToIssueNumber: null,
+      },
+    ] as never);
+
+    const result = await getEscalatedFindings();
+    expect(result).toHaveLength(1);
+    expect(result[0].escalatedToIssueNumber).toBeNull();
   });
 });
 

--- a/src/app/admin/audit/actions.test.ts
+++ b/src/app/admin/audit/actions.test.ts
@@ -209,10 +209,11 @@ describe("getTopOffenders", () => {
     expect(result[0].escalatedToIssueNumber).toBe(555);
   });
 
-  it("leaves enrichment fields null when no open AuditIssue title carries the slug bracket", async () => {
-    // Chrome-stream rows have free-form titles; the bracket regex
-    // misses them, so enrichment for chrome-only kennels stays
-    // null. Documented limitation per the helper's doc.
+  it("enriches via the chrome-title fallback for `Finding: KENNEL slug` rows (Gemini PR #1205)", async () => {
+    // Chrome-stream rows have a known title shape too — the
+    // secondary `extractRuleSlugFromChromeTitle` extractor catches
+    // them, so chrome-only kennels also surface recurrence /
+    // escalation badges in the offenders table.
     mockLogFind.mockResolvedValue([
       {
         createdAt: new Date("2026-04-04T12:00:00Z"),
@@ -230,15 +231,56 @@ describe("getTopOffenders", () => {
     mockIssueFindMany.mockResolvedValue([
       {
         kennelCode: "nych3",
-        title: "Finding: NYCH3 hare-url",  // chrome-style — no bracket
+        title: "Finding: NYCH3 hare-url",  // chrome-style
         recurrenceCount: 4,
         escalatedToIssueNumber: null,
       },
     ] as never);
 
     const result = await getTopOffenders();
-    expect(result[0].recurrenceCount).toBeNull();
-    expect(result[0].escalatedToIssueNumber).toBeNull();
+    expect(result[0].recurrenceCount).toBe(4);
+  });
+
+  it("picks the oldest row deterministically when multiple open issues share a (kennel, ruleSlug) key", async () => {
+    // Codex P2 / Gemini medium PR #1205: without first-wins indexing
+    // + ASC orderBy, the badge data could flicker between rows on
+    // each query when multiple open issues happen to share the same
+    // key (rare incident-recovery state). Order-by-asc + has-guard
+    // makes the choice deterministic — oldest row anchors the badges.
+    mockLogFind.mockResolvedValue([
+      {
+        createdAt: new Date("2026-04-04T12:00:00Z"),
+        findings: [
+          {
+            kennelCode: "nych3",
+            kennelShortName: "NYCH3",
+            rule: "hare-url",
+            category: "hares",
+          },
+        ],
+      },
+    ] as never);
+    mockSupFind.mockResolvedValue([] as never);
+    // Mock returns rows in the same order Prisma would produce
+    // them with `orderBy: { githubCreatedAt: "asc" }` — oldest first.
+    mockIssueFindMany.mockResolvedValue([
+      {
+        kennelCode: "nych3",
+        title: "[Audit] NYCH3 — Hare Quality [hare-url] (1 events) — 2026-04-15",
+        recurrenceCount: 9, // older; should win under has-guard
+        escalatedToIssueNumber: 100,
+      },
+      {
+        kennelCode: "nych3",
+        title: "[Audit] NYCH3 — Hare Quality [hare-url] (2 events) — 2026-04-30",
+        recurrenceCount: 2, // newer; loses
+        escalatedToIssueNumber: null,
+      },
+    ] as never);
+
+    const result = await getTopOffenders();
+    expect(result[0].recurrenceCount).toBe(9);
+    expect(result[0].escalatedToIssueNumber).toBe(100);
   });
 });
 

--- a/src/app/admin/audit/actions.ts
+++ b/src/app/admin/audit/actions.ts
@@ -4,6 +4,7 @@ import { Prisma, AuditStream, AuditIssueEventType } from "@/generated/prisma/cli
 import { prisma } from "@/lib/db";
 import { getAdminUser } from "@/lib/auth";
 import { KNOWN_AUDIT_RULES, type AuditFinding } from "@/pipeline/audit-checks";
+import { extractRuleSlugFromAutomatedTitle } from "@/pipeline/audit-issue-sync";
 import { DASHBOARD_STREAMS } from "@/lib/audit-stream-meta";
 import type {
   HarelinePromptInputs,
@@ -97,6 +98,20 @@ export interface TopOffender {
   count: number;
   lastSeen: string;
   suppressed: boolean;
+  /** Recurrence count from the matching open AuditIssue (cron-side
+   *  fingerprint dedup, 5c-A). Null when no open mirror row matches —
+   *  e.g. non-fingerprintable rule, all matching issues already
+   *  closed, or rule-slug extraction failed. The dashboard shows this
+   *  alongside `count` so operators can distinguish "many separate
+   *  events under one rule" from "one persistent finding the
+   *  cron-coalescer has been tracking". */
+  recurrenceCount: number | null;
+  /** When the matching open AuditIssue has crossed the escalation
+   *  threshold (5c-B), the meta-issue's GitHub number. The
+   *  `Needs Decision` panel surfaces these globally too — duplicating
+   *  them inline here lets operators triage from the offenders view
+   *  without scrolling. */
+  escalatedToIssueNumber: number | null;
 }
 
 export async function getTopOffenders(days = OFFENDER_DAYS): Promise<TopOffender[]> {
@@ -104,16 +119,47 @@ export async function getTopOffenders(days = OFFENDER_DAYS): Promise<TopOffender
   // Rows are ordered desc, so the first encounter for a (kennelCode, rule) key is the most
   // recent date — used for `lastSeen` below. `count` is per-finding occurrence across runs,
   // which inflates for events that persist day-to-day; that's intentional for ranking impact.
-  const [rows, suppressions] = await Promise.all([
+  const [rows, suppressions, openIssues] = await Promise.all([
     prisma.auditLog.findMany({
       where: { type: "HARELINE", createdAt: { gte: daysAgo(days) } },
       select: { createdAt: true, findings: true },
       orderBy: { createdAt: "desc" },
     }),
     prisma.auditSuppression.findMany({ select: { kennelCode: true, rule: true } }),
+    // Pull the open AuditIssue mirror so we can enrich each offender row
+    // with its recurrenceCount + escalation status. We extract ruleSlug
+    // from the title (matching the cron-format bracket) since the
+    // mirror doesn't store the slug as a column.
+    prisma.auditIssue.findMany({
+      where: { state: "open", delistedAt: null, kennelCode: { not: null } },
+      select: {
+        kennelCode: true,
+        title: true,
+        recurrenceCount: true,
+        escalatedToIssueNumber: true,
+      },
+    }),
   ]);
 
   const suppressedKeys = new Set(suppressions.map(s => suppressionKey(s.kennelCode, s.rule)));
+
+  // Index open issues by (kennelCode, ruleSlug) for O(1) lookup. Rows
+  // whose title doesn't yield a slug (chrome-stream legacy prose,
+  // operator-edited titles) drop out of the index — their offender
+  // rows render with `recurrenceCount: null`.
+  const openIssueByKey = new Map<
+    string,
+    { recurrenceCount: number; escalatedToIssueNumber: number | null }
+  >();
+  for (const issue of openIssues) {
+    if (!issue.kennelCode) continue;
+    const slug = extractRuleSlugFromAutomatedTitle(issue.title);
+    if (!slug) continue;
+    openIssueByKey.set(suppressionKey(issue.kennelCode, slug), {
+      recurrenceCount: issue.recurrenceCount,
+      escalatedToIssueNumber: issue.escalatedToIssueNumber,
+    });
+  }
 
   const map = new Map<string, TopOffender>();
   for (const r of rows) {
@@ -124,6 +170,7 @@ export async function getTopOffenders(days = OFFENDER_DAYS): Promise<TopOffender
       if (existing) {
         existing.count += 1;
       } else {
+        const mirror = openIssueByKey.get(key);
         map.set(key, {
           kennelCode: f.kennelCode,
           kennelShortName: f.kennelShortName,
@@ -132,6 +179,8 @@ export async function getTopOffenders(days = OFFENDER_DAYS): Promise<TopOffender
           count: 1,
           lastSeen: easternDate(r.createdAt),
           suppressed: suppressedKeys.has(key) || suppressedKeys.has(suppressionKey(null, f.rule)),
+          recurrenceCount: mirror?.recurrenceCount ?? null,
+          escalatedToIssueNumber: mirror?.escalatedToIssueNumber ?? null,
         });
       }
     }
@@ -839,6 +888,96 @@ export async function getRecentOpenIssues(limit = 30): Promise<RecentOpenIssue[]
     },
     orderBy: { githubCreatedAt: "desc" },
     take: limit,
+  });
+}
+
+export interface EscalatedFinding {
+  /** Base issue (the original recurring finding). */
+  baseIssueNumber: number;
+  baseIssueTitle: string;
+  baseIssueUrl: string;
+  baseStream: AuditStream;
+  baseKennelCode: string | null;
+  baseKennelShortName: string | null;
+  /** How many times the strict tier has commented "still recurring" on
+   *  the base. The threshold-cross was at 5; this number tells the
+   *  operator how far past the threshold the finding has gone before
+   *  they decided to act. */
+  recurrenceCount: number;
+  /** When escalation fired. */
+  escalatedAt: Date;
+  /** Server-computed "today" / "1 day ago" / "N days ago" label.
+   *  Pre-computed here rather than on the client to avoid React
+   *  hydration drift from `Date.now()` running in render — the
+   *  next `router.refresh()` re-renders this anyway. */
+  escalatedAgoLabel: string;
+  /** Meta-issue number filed with the `audit:needs-decision` label.
+   *  May be null if the finalize update hasn't landed yet (the rare
+   *  half-state documented in audit-filer.ts) — the panel still
+   *  surfaces these so an operator can investigate. */
+  escalatedToIssueNumber: number | null;
+}
+
+/** "today" / "1 day ago" / "N days ago" — pure helper, server-rendered. */
+function relativeDaysAgoLabel(escalatedAt: Date, now = Date.now()): string {
+  const days = Math.max(0, Math.floor((now - escalatedAt.getTime()) / 86_400_000));
+  if (days === 0) return "today";
+  if (days === 1) return "1 day ago";
+  return `${days} days ago`;
+}
+
+/**
+ * Open AuditIssue rows whose recurrence has crossed the escalation
+ * threshold (5+ days same fingerprint without resolution; meta-issue
+ * filed with `audit:needs-decision`). These are the highest-priority
+ * signal on the dashboard: the system has already given up
+ * auto-coalescing and is asking an operator to decide between fix,
+ * suppress, and reclassify.
+ *
+ * Sorted by `escalatedAt DESC` so freshly-escalated bases land at
+ * the top of the panel.
+ */
+export async function getEscalatedFindings(
+  limit = 20,
+): Promise<EscalatedFinding[]> {
+  await requireAdmin();
+  const rows = await prisma.auditIssue.findMany({
+    where: {
+      state: "open",
+      delistedAt: null,
+      escalatedAt: { not: null },
+    },
+    select: {
+      githubNumber: true,
+      title: true,
+      htmlUrl: true,
+      stream: true,
+      kennelCode: true,
+      kennel: { select: { shortName: true } },
+      recurrenceCount: true,
+      escalatedAt: true,
+      escalatedToIssueNumber: true,
+    },
+    orderBy: { escalatedAt: "desc" },
+    take: limit,
+  });
+  const now = Date.now();
+  return rows.map((r) => {
+    // `escalatedAt: { not: null }` in the WHERE clause guarantees
+    // this is non-null at runtime; the Prisma type just doesn't narrow.
+    const escalatedAt = r.escalatedAt as Date;
+    return {
+      baseIssueNumber: r.githubNumber,
+      baseIssueTitle: r.title,
+      baseIssueUrl: r.htmlUrl,
+      baseStream: r.stream,
+      baseKennelCode: r.kennelCode,
+      baseKennelShortName: r.kennel?.shortName ?? null,
+      recurrenceCount: r.recurrenceCount,
+      escalatedAt,
+      escalatedAgoLabel: relativeDaysAgoLabel(escalatedAt, now),
+      escalatedToIssueNumber: r.escalatedToIssueNumber,
+    };
   });
 }
 

--- a/src/app/admin/audit/actions.ts
+++ b/src/app/admin/audit/actions.ts
@@ -4,7 +4,10 @@ import { Prisma, AuditStream, AuditIssueEventType } from "@/generated/prisma/cli
 import { prisma } from "@/lib/db";
 import { getAdminUser } from "@/lib/auth";
 import { KNOWN_AUDIT_RULES, type AuditFinding } from "@/pipeline/audit-checks";
-import { extractRuleSlugFromAutomatedTitle } from "@/pipeline/audit-issue-sync";
+import {
+  extractRuleSlugFromAutomatedTitle,
+  extractRuleSlugFromChromeTitle,
+} from "@/pipeline/audit-issue-sync";
 import { DASHBOARD_STREAMS } from "@/lib/audit-stream-meta";
 import type {
   HarelinePromptInputs,
@@ -128,8 +131,15 @@ export async function getTopOffenders(days = OFFENDER_DAYS): Promise<TopOffender
     prisma.auditSuppression.findMany({ select: { kennelCode: true, rule: true } }),
     // Pull the open AuditIssue mirror so we can enrich each offender row
     // with its recurrenceCount + escalation status. We extract ruleSlug
-    // from the title (matching the cron-format bracket) since the
-    // mirror doesn't store the slug as a column.
+    // from the title (cron-format bracket OR chrome `Finding: <KENNEL>
+    // <slug>` shape) since the mirror doesn't store the slug as a column.
+    //
+    // Order by oldest githubCreatedAt first so that when multiple open
+    // rows resolve to the same `(kennelCode, ruleSlug)` key (rare
+    // incident-recovery / migration windows), the loop below picks the
+    // oldest row deterministically — matching the strict-tier match
+    // ordering in `audit-filer.ts`. Without this, badges could flicker
+    // between rows on each query (Codex / Gemini PR #1205 review).
     prisma.auditIssue.findMany({
       where: { state: "open", delistedAt: null, kennelCode: { not: null } },
       select: {
@@ -138,6 +148,7 @@ export async function getTopOffenders(days = OFFENDER_DAYS): Promise<TopOffender
         recurrenceCount: true,
         escalatedToIssueNumber: true,
       },
+      orderBy: { githubCreatedAt: "asc" },
     }),
   ]);
 
@@ -153,9 +164,18 @@ export async function getTopOffenders(days = OFFENDER_DAYS): Promise<TopOffender
   >();
   for (const issue of openIssues) {
     if (!issue.kennelCode) continue;
-    const slug = extractRuleSlugFromAutomatedTitle(issue.title);
+    // Try cron-format bracket first, fall back to chrome-format
+    // `Finding: <KENNEL> <slug>` so chrome-stream rows also enrich
+    // (Gemini PR #1205 review). Same fallback chain `tryBridge` uses.
+    const slug =
+      extractRuleSlugFromAutomatedTitle(issue.title) ??
+      extractRuleSlugFromChromeTitle(issue.title);
     if (!slug) continue;
-    openIssueByKey.set(suppressionKey(issue.kennelCode, slug), {
+    const key = suppressionKey(issue.kennelCode, slug);
+    // First-wins so the oldest row (per the orderBy above) anchors
+    // the badge data deterministically.
+    if (openIssueByKey.has(key)) continue;
+    openIssueByKey.set(key, {
       recurrenceCount: issue.recurrenceCount,
       escalatedToIssueNumber: issue.escalatedToIssueNumber,
     });
@@ -355,12 +375,19 @@ export interface DeepDiveCandidate {
   sources: DeepDiveSource[];
 }
 
-/** Default page size for the deep-dive queue display. Centralized so
- *  `getDeepDiveQueue` and the snapshot-bound token endpoints all
- *  capture the same window — drift would let a token mint against a
- *  larger queue than the dashboard shows, weakening the snapshot
- *  binding. */
-export const DEEP_DIVE_QUEUE_DEFAULT_LIMIT = 20;
+/**
+ * Default page size for the deep-dive queue display. Centralized so
+ * `getDeepDiveQueue` and the snapshot-bound token endpoints all
+ * capture the same window — drift would let a token mint against a
+ * larger queue than the dashboard shows, weakening the snapshot
+ * binding.
+ *
+ * NOT exported: Next.js 16's `"use server"` directive rejects modules
+ * that export anything other than async functions. Callers that need
+ * the constant should import from a non-server module; today, all
+ * usage is internal to this file.
+ */
+const DEEP_DIVE_QUEUE_DEFAULT_LIMIT = 20;
 
 /**
  * Lightweight queue snapshot — just the kennelCodes in the same

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -10,6 +10,7 @@ import {
   getOpenIssueCountsByStream,
   getCloseReasonRatiosByStream,
   getRecentOpenIssues,
+  getEscalatedFindings,
   getHarelinePromptInputs,
 } from "./actions";
 import { KNOWN_AUDIT_RULES } from "@/pipeline/audit-checks";
@@ -45,6 +46,7 @@ export default async function AuditPage() {
     streamOpenCountsResult,
     streamCloseReasonRatiosResult,
     recentOpenIssuesResult,
+    escalatedFindingsResult,
   ] = await Promise.all([
     getAuditTrends().catch(() => []),
     getTopOffenders().catch(() => []),
@@ -65,6 +67,7 @@ export default async function AuditPage() {
     // hide schema skew / Prisma errors during rollout.
     getCloseReasonRatiosByStream().catch(() => null),
     getRecentOpenIssues().catch(() => []),
+    getEscalatedFindings().catch(() => []),
   ]);
 
   return (
@@ -82,6 +85,7 @@ export default async function AuditPage() {
       streamOpenCounts={streamOpenCountsResult}
       streamCloseReasonRatios={streamCloseReasonRatiosResult}
       recentOpenIssues={recentOpenIssuesResult}
+      escalatedFindings={escalatedFindingsResult}
     />
   );
 }

--- a/src/components/admin/AuditDashboard.tsx
+++ b/src/components/admin/AuditDashboard.tsx
@@ -12,6 +12,8 @@ import {
   Telescope,
   Copy,
   Check,
+  Flame,
+  Lock,
 } from "lucide-react";
 import {
   LineChart,
@@ -39,6 +41,7 @@ import {
   type StreamOpenCounts,
   type StreamCloseReasonRatio,
   type RecentOpenIssue,
+  type EscalatedFinding,
 } from "@/app/admin/audit/actions";
 import { AuditStreamPanel } from "@/components/admin/AuditStreamPanel";
 import { buildDeepDivePrompt } from "@/lib/admin/deep-dive-prompt";
@@ -99,6 +102,7 @@ interface Props {
    *  an explicit "metric unavailable" line instead of fake zeros. */
   streamCloseReasonRatios: StreamCloseReasonRatio[] | null;
   recentOpenIssues: RecentOpenIssue[];
+  escalatedFindings: EscalatedFinding[];
 }
 
 const CATEGORY_LINES: { key: keyof TrendPoint; label: string; color: string }[] = [
@@ -125,6 +129,7 @@ export function AuditDashboard({
   streamOpenCounts,
   streamCloseReasonRatios,
   recentOpenIssues,
+  escalatedFindings,
 }: Props) {
   const router = useRouter();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -158,6 +163,9 @@ export function AuditDashboard({
 
   return (
     <div className="space-y-10">
+      {/* ── Escalated findings (highest-priority signal post-5c-B) ── */}
+      <NeedsDecisionPanel findings={escalatedFindings} />
+
       {/* ── Stream attribution ─────────────────────────────────── */}
       <AuditStreamPanel
         streamTrends={streamTrends}
@@ -290,20 +298,44 @@ export function AuditDashboard({
                       className="hover:bg-accent/30 transition-colors"
                     >
                       <td className="px-5 py-2.5 font-medium">
-                        <div className="flex items-center gap-2">
+                        <div className="flex flex-wrap items-center gap-1.5">
                           <span>{o.kennelShortName}</span>
                           {o.suppressed && (
                             <Badge variant="secondary" className="text-[10px]">
                               Suppressed
                             </Badge>
                           )}
+                          {o.escalatedToIssueNumber !== null && (
+                            <a
+                              href={`https://github.com/${HASHTRACKS_REPO}/issues/${o.escalatedToIssueNumber}`}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex items-center gap-1 rounded border border-red-500/40 bg-red-500/10 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-red-600 hover:bg-red-500/20 dark:text-red-400"
+                              title={`Escalated meta-issue #${o.escalatedToIssueNumber}`}
+                            >
+                              <Flame className="h-3 w-3" />
+                              #{o.escalatedToIssueNumber}
+                            </a>
+                          )}
                         </div>
                       </td>
                       <td className="px-5 py-2.5 font-mono text-xs text-muted-foreground">
                         {o.rule}
                       </td>
-                      <td className="px-5 py-2.5 text-right tabular-nums font-mono text-xs">
-                        {o.count}
+                      <td className="px-5 py-2.5 text-right">
+                        <div className="flex flex-col items-end gap-0.5 leading-tight">
+                          <span className="tabular-nums font-mono text-xs">
+                            {o.count}
+                          </span>
+                          {o.recurrenceCount !== null && o.recurrenceCount > 0 && (
+                            <span
+                              className="text-[10px] tabular-nums text-muted-foreground"
+                              title="Strict-tier recurrence count from the AuditIssue mirror — distinct from per-event finding count above"
+                            >
+                              ×{o.recurrenceCount} recurs
+                            </span>
+                          )}
+                        </div>
                       </td>
                       <td className="px-5 py-2.5 text-muted-foreground tabular-nums text-xs">
                         {o.lastSeen}
@@ -484,6 +516,94 @@ export function AuditDashboard({
 }
 
 // ── Suppression Row + Delete Confirmation ───────────────────────────
+
+// ── Needs Decision panel ────────────────────────────────────────────
+//
+// Surfaces open AuditIssue rows that crossed the recurrence escalation
+// threshold (5c-B). Each row is a finding the auto-coalescer has given
+// up on — the operator must pick fix / suppress / reclassify before
+// the comment trail bloats further. Hidden when there's nothing to
+// surface so the dashboard's first paint isn't a wall of red boxes for
+// no reason.
+
+function NeedsDecisionPanel({ findings }: { findings: EscalatedFinding[] }) {
+  if (findings.length === 0) return null;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <SectionHeader
+          icon={Flame}
+          title={`Needs Decision (${findings.length})`}
+          color="bg-red-500/10 text-red-500"
+        />
+        <p className="text-xs text-muted-foreground max-w-md text-right">
+          Recurred 5+ times; auto-coalesce gave up. Pick{" "}
+          <span className="font-medium text-foreground">fix</span>,{" "}
+          <span className="font-medium text-foreground">suppress</span>, or{" "}
+          <span className="font-medium text-foreground">reclassify</span>.
+        </p>
+      </div>
+      <div className="rounded-xl border border-red-500/30 bg-red-500/[0.03] overflow-hidden">
+        <ul className="divide-y divide-red-500/15">
+          {findings.map((f) => (
+            <NeedsDecisionRow key={f.baseIssueNumber} finding={f} />
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function NeedsDecisionRow({ finding }: { finding: EscalatedFinding }) {
+  return (
+    <li className="flex flex-col gap-2 px-5 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          {finding.baseKennelShortName && (
+            <span className="font-medium">{finding.baseKennelShortName}</span>
+          )}
+          <Badge
+            variant="outline"
+            className="border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400 font-mono text-[10px] tabular-nums"
+          >
+            ×{finding.recurrenceCount} recurrences
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            escalated {finding.escalatedAgoLabel}
+          </span>
+        </div>
+        <a
+          href={finding.baseIssueUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="block truncate text-sm hover:underline"
+        >
+          <span className="font-mono tabular-nums text-muted-foreground">
+            #{finding.baseIssueNumber}
+          </span>{" "}
+          {finding.baseIssueTitle}
+        </a>
+      </div>
+      <div className="flex shrink-0 items-center gap-2 text-xs">
+        {finding.escalatedToIssueNumber !== null ? (
+          <a
+            href={`https://github.com/${HASHTRACKS_REPO}/issues/${finding.escalatedToIssueNumber}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 rounded-md border border-red-500/40 bg-red-500/10 px-2.5 py-1 font-mono tabular-nums text-red-600 hover:bg-red-500/20 dark:text-red-400"
+          >
+            Decision → #{finding.escalatedToIssueNumber}
+          </a>
+        ) : (
+          <span className="text-muted-foreground italic">
+            meta unlinked — see logs
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}
 
 function SuppressionRowView({
   row,
@@ -851,12 +971,33 @@ function DeepDiveCard({
       {/* ── Queue table (clickable rows select the kennel above) ── */}
       {queue.length > 1 && (
         <div className="rounded-xl border border-border/50 bg-card overflow-hidden">
-          <div className="px-5 py-3 border-b border-border/50">
+          <div className="flex items-center justify-between gap-2 px-5 py-3 border-b border-border/50">
             <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               Queue
             </h3>
+            {/* Visual lock when the completion dialog is open: the
+              * snapshot token from bundle 6 has bound `selectedCode`
+              * for the duration of that submission. Reordering the
+              * queue from a second tab during this window would now
+              * 409 the submit; making it clear that the queue is
+              * "frozen" prevents the operator from confusing
+              * themselves. */}
+            {completeOpen && (
+              <span
+                id="dd-queue-lock-message"
+                className="inline-flex items-center gap-1.5 rounded border border-purple-500/40 bg-purple-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-purple-600 dark:text-purple-400"
+                title="Snapshot token bound — cancel the dialog to retarget another kennel"
+              >
+                <Lock className="h-3 w-3" />
+                Locked to {currentKennel.shortName}
+              </span>
+            )}
           </div>
-          <div className="overflow-x-auto">
+          <div
+            className={`overflow-x-auto transition-opacity ${
+              completeOpen ? "opacity-50" : ""
+            }`}
+          >
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border/30">
@@ -882,14 +1023,27 @@ function DeepDiveCard({
                   <tr
                     key={k.kennelCode}
                     role="button"
-                    tabIndex={0}
-                    className={`cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 ${
+                    tabIndex={completeOpen ? -1 : 0}
+                    aria-disabled={completeOpen || undefined}
+                    aria-describedby={
+                      completeOpen ? "dd-queue-lock-message" : undefined
+                    }
+                    className={`transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 ${
+                      completeOpen ? "cursor-not-allowed" : "cursor-pointer"
+                    } ${
                       k.kennelCode === selectedCode
                         ? "bg-accent/50 border-l-2 border-l-purple-500"
-                        : "hover:bg-accent/30"
+                        : completeOpen
+                          ? ""
+                          : "hover:bg-accent/30"
                     }`}
-                    onClick={() => { setSelectedCode(k.kennelCode); setCopied(false); }}
+                    onClick={() => {
+                      if (completeOpen) return;
+                      setSelectedCode(k.kennelCode);
+                      setCopied(false);
+                    }}
                     onKeyDown={(e) => {
+                      if (completeOpen) return;
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
                         setSelectedCode(k.kennelCode);

--- a/src/components/admin/AuditDashboard.tsx
+++ b/src/components/admin/AuditDashboard.tsx
@@ -537,12 +537,22 @@ function NeedsDecisionPanel({ findings }: { findings: EscalatedFinding[] }) {
           title={`Needs Decision (${findings.length})`}
           color="bg-red-500/10 text-red-500"
         />
-        <p className="text-xs text-muted-foreground max-w-md text-right">
-          Recurred 5+ times; auto-coalesce gave up. Pick{" "}
-          <span className="font-medium text-foreground">fix</span>,{" "}
-          <span className="font-medium text-foreground">suppress</span>, or{" "}
-          <span className="font-medium text-foreground">reclassify</span>.
-        </p>
+        <div className="flex flex-col items-end gap-1">
+          <p className="text-xs text-muted-foreground max-w-md text-right">
+            Recurred 5+ times; auto-coalesce gave up. Pick{" "}
+            <span className="font-medium text-foreground">fix</span>,{" "}
+            <span className="font-medium text-foreground">suppress</span>, or{" "}
+            <span className="font-medium text-foreground">reclassify</span>.
+          </p>
+          <a
+            href={`https://github.com/${HASHTRACKS_REPO}/issues?q=is%3Aopen+label%3A%22audit%3Aneeds-decision%22`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-[11px] font-medium text-red-600 hover:underline dark:text-red-400"
+          >
+            View all on GitHub →
+          </a>
+        </div>
       </div>
       <div className="rounded-xl border border-red-500/30 bg-red-500/[0.03] overflow-hidden">
         <ul className="divide-y divide-red-500/15">


### PR DESCRIPTION
## Summary

Final UX-focused PR after the audit-process backend bundles (#1190 5c-A, #1197 5c-B, #1198 5c-C, #1203 bundle 6). Three focused changes that surface the new signals on `/admin/audit`:

> **Note**: this PR is stacked on top of #1203 (bundle 6 / queue-snapshot token). Merge order: #1203 → this. Re-target this PR to `main` once #1203 lands.

### 1. "Needs Decision" panel (top of dashboard)

Pulls open `AuditIssue` rows with `escalatedAt: { not: null }` — 5c-B's threshold-crossed findings the auto-coalescer has given up on. Each row: kennel, recurrence count, "escalated <relative>", and a link to the `audit:needs-decision` meta-issue. **Hidden when there's nothing to surface** so the dashboard's first paint isn't a wall of red boxes.

### 2. Top Offenders enrichment

`getTopOffenders` now JOINs against the open AuditIssue mirror (extracts ruleSlug from titles via `extractRuleSlugFromAutomatedTitle`). Adds:
- `×N recurs` indicator below per-event count when the matching issue's `recurrenceCount > 0`
- Red `Flame` badge linking to the escalated meta-issue when the row's issue has crossed threshold

Chrome-stream rows with free-form titles get null enrichment — documented limitation.

### 3. Visual lock on deep-dive queue

When `DeepDiveCompleteDialog` is open, the queue table dims and becomes non-interactive, with a `Lock — Locked to <kennel>` badge in the section header. Server-side, bundle 6's snapshot token already binds `selectedCode`; this is visual feedback so the operator knows reordering won't help during a submit.

**a11y**: each `tr role="button"` carries `aria-disabled` + `aria-describedby="dd-queue-lock-message"` when locked, pointing to the badge.

### Codex pre-PR catches

- Hydration-drift on `escalatedAgoLabel` — pre-computed server-side in `getEscalatedFindings` rather than via `Date.now()` in client render.
- Tightened `aria-disabled` placement from a wrapper div to per-row.

## Test plan

- [ ] Local CI gate: ✅ 5800 tests pass, tsc + lint clean (5 new tests on the action surface)
- [ ] SonarCloud / Codacy clean
- [ ] Manual: load `/admin/audit` with no escalated findings → "Needs Decision" panel hidden, dashboard renders cleanly
- [ ] Manual: seed an escalated row in dev DB → panel appears at top with the meta-issue link
- [ ] Manual: open the deep-dive complete dialog → queue table dims + "Locked to X" badge appears → cancel → table re-enables
- [ ] Manual: a Top Offender row whose underlying AuditIssue has `recurrenceCount=8, escalatedToIssueNumber=999` → row shows ×8 recurs + red flame badge linking to #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)