### PR TITLE
fix(dfw-hash): extract description + cost, trust detail-page date over grid

### DIFF
--- a/scripts/verify-dfw-adapter.ts
+++ b/scripts/verify-dfw-adapter.ts
@@ -1,0 +1,64 @@
+/**
+ * Live verification harness for the DFW adapter (issues #1151 + #1155).
+ *
+ * Runs DFWHashAdapter.fetch() against the live dfwhhh.org calendar and prints:
+ *   - event count + date range
+ *   - count of events with description / cost populated
+ *   - one fully-populated sample event
+ *
+ * Usage: npx tsx scripts/verify-dfw-adapter.ts
+ */
+
+import "dotenv/config";
+import { DFWHashAdapter } from "@/adapters/html-scraper/dfw-hash";
+
+async function main() {
+  const adapter = new DFWHashAdapter();
+  const source = {
+    id: "live-verify",
+    url: "http://www.dfwhhh.org/calendar/",
+  };
+
+  const result = await adapter.fetch(source as never);
+
+  const dates = result.events.map((e) => e.date).sort();
+  const withDescription = result.events.filter((e) => e.description);
+  const withCost = result.events.filter((e) => e.cost);
+  const withRunNumber = result.events.filter((e) => e.runNumber !== undefined);
+
+  console.log(`\n=== DFW Live Verification ===\n`);
+  console.log(`Events parsed: ${result.events.length}`);
+  console.log(`Date range:    ${dates[0] ?? "n/a"} → ${dates[dates.length - 1] ?? "n/a"}`);
+  console.log(`With description: ${withDescription.length}`);
+  console.log(`With cost:        ${withCost.length}`);
+  console.log(`With runNumber:   ${withRunNumber.length}`);
+  console.log(`Errors: ${result.errors.length}`);
+  console.log(`Diagnostic:`, result.diagnosticContext);
+
+  if (result.errors.length) {
+    console.log(`\nFirst 3 errors:`);
+    result.errors.slice(0, 3).forEach((e) => console.log(`  - ${e}`));
+  }
+
+  const sample = result.events.find((e) => e.description && e.cost) ?? result.events[0];
+  if (sample) {
+    console.log(`\n=== Sample event ===\n${JSON.stringify(sample, null, 2)}`);
+  }
+
+  // Per-kennel breakdown
+  const byKennel = new Map<string, number>();
+  for (const e of result.events) {
+    for (const tag of e.kennelTags ?? []) {
+      byKennel.set(tag, (byKennel.get(tag) ?? 0) + 1);
+    }
+  }
+  console.log(`\n=== Events per kennel ===`);
+  for (const [tag, n] of [...byKennel.entries()].sort()) {
+    console.log(`  ${tag}: ${n}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/verify-dfw-adapter.ts
+++ b/scripts/verify-dfw-adapter.ts
@@ -16,7 +16,7 @@ async function main() {
   const adapter = new DFWHashAdapter();
   const source = {
     id: "live-verify",
-    url: "http://www.dfwhhh.org/calendar/",
+    url: "http://www.dfwhhh.org/calendar/", // NOSONAR — source has expired SSL
   };
 
   const result = await adapter.fetch(source as never);

--- a/scripts/verify-dfw-adapter.ts
+++ b/scripts/verify-dfw-adapter.ts
@@ -37,7 +37,9 @@ async function main() {
 
   if (result.errors.length) {
     console.log(`\nFirst 3 errors:`);
-    result.errors.slice(0, 3).forEach((e) => console.log(`  - ${e}`));
+    result.errors.slice(0, 3).forEach((e) => {
+      console.log(`  - ${e}`);
+    });
   }
 
   const sample = result.events.find((e) => e.description && e.cost) ?? result.events[0];

--- a/scripts/verify-dfw-adapter.ts
+++ b/scripts/verify-dfw-adapter.ts
@@ -21,14 +21,14 @@ async function main() {
 
   const result = await adapter.fetch(source as never);
 
-  const dates = result.events.map((e) => e.date).sort();
+  const dates = result.events.map((e) => e.date).sort((a, b) => a.localeCompare(b));
   const withDescription = result.events.filter((e) => e.description);
   const withCost = result.events.filter((e) => e.cost);
   const withRunNumber = result.events.filter((e) => e.runNumber !== undefined);
 
   console.log(`\n=== DFW Live Verification ===\n`);
   console.log(`Events parsed: ${result.events.length}`);
-  console.log(`Date range:    ${dates[0] ?? "n/a"} → ${dates[dates.length - 1] ?? "n/a"}`);
+  console.log(`Date range:    ${dates[0] ?? "n/a"} → ${dates.at(-1) ?? "n/a"}`);
   console.log(`With description: ${withDescription.length}`);
   console.log(`With cost:        ${withCost.length}`);
   console.log(`With runNumber:   ${withRunNumber.length}`);
@@ -53,7 +53,7 @@ async function main() {
     }
   }
   console.log(`\n=== Events per kennel ===`);
-  for (const [tag, n] of [...byKennel.entries()].sort()) {
+  for (const [tag, n] of [...byKennel.entries()].sort(([a], [b]) => a.localeCompare(b))) {
     console.log(`  ${tag}: ${n}`);
   }
 }

--- a/src/adapters/html-scraper/dfw-hash.test.ts
+++ b/src/adapters/html-scraper/dfw-hash.test.ts
@@ -813,7 +813,7 @@ describe("DFWHashAdapter.fetch", () => {
 
     const result = await adapter.fetch({
       id: "test-dfw",
-      url: "http://www.dfwhhh.org/calendar/",
+      url: "http://www.dfwhhh.org/calendar/", // NOSONAR — source has expired SSL
     } as never);
 
     const duhhhEvents = result.events.filter((e) => e.kennelTags?.includes("duhhh"));

--- a/src/adapters/html-scraper/dfw-hash.test.ts
+++ b/src/adapters/html-scraper/dfw-hash.test.ts
@@ -4,6 +4,7 @@ import {
   buildDFWMonthUrl,
   ICON_TO_KENNEL,
   extractDFWEvents,
+  extractDetailPageDate,
   parseDFWDetailPage,
   DFWHashAdapter,
 } from "./dfw-hash";
@@ -372,6 +373,80 @@ describe("parseDFWDetailPage", () => {
     expect(detail.location).toBe("Sam Houston Trail Park, Irving");
     expect(detail.hares).toBe("Casting Cooch");
     expect(detail.runNumber).toBe(340);
+    expect(detail.cost).toBe("$7.00");
+    expect(detail.description).toBe("Give me beer or give me death!");
+    expect(detail.date).toBe("2026-03-23");
+  });
+
+  it("extracts verbatim FWH3 cost string without cleanup (#1151)", () => {
+    // FWH3's hash cash row is a long free-form string with payment instructions.
+    // The adapter must store it verbatim — issue authors explicitly call this out.
+    const html = `
+      <html><body>
+        <h3>Hash Run No 1056</h3>
+        <h5><em>Hash cash:</em> $7.00 cash - Paypal $7 - Pay pal (FWH3) or Zelle 817-689-9363 - BYOB pre-lube beer</h5>
+        <h5><em>Description:</em> Y'all know what to bring when you see my name as the hare</h5>
+      </body></html>
+    `;
+    const $ = cheerio.load(html);
+    const detail = parseDFWDetailPage($);
+    expect(detail.cost).toBe(
+      "$7.00 cash - Paypal $7 - Pay pal (FWH3) or Zelle 817-689-9363 - BYOB pre-lube beer",
+    );
+    expect(detail.description).toBe(
+      "Y'all know what to bring when you see my name as the hare",
+    );
+  });
+
+  it("returns canonical date from <h2> heading (#1155)", () => {
+    // DUHHH #849 was stored on Fri 4/3 but the source detail page says
+    // Wednesday, April 22, 2026. parseDFWDetailPage should surface the date
+    // so the adapter enrich loop can override the (drifted) grid date.
+    const html = `
+      <html><body>
+        <h1>Dallas Urban Hash</h1>
+        <h2>Wednesday, April 22, 2026</h2>
+        <h3>Hash Run No 849</h3>
+        <h5><em>Time:</em> 6:30 PM</h5>
+        <h5><em>Hares:</em> My Boyfriend Joe</h5>
+      </body></html>
+    `;
+    const $ = cheerio.load(html);
+    const detail = parseDFWDetailPage($);
+    expect(detail.date).toBe("2026-04-22");
+    expect(detail.runNumber).toBe(849);
+  });
+});
+
+describe("extractDetailPageDate", () => {
+  it("parses a Wednesday date heading", () => {
+    const $ = cheerio.load("<h2>Wednesday, April 22, 2026</h2>");
+    expect(extractDetailPageDate($)).toBe("2026-04-22");
+  });
+
+  it("parses a Saturday date heading", () => {
+    const $ = cheerio.load("<h2>Saturday, March 14, 2026</h2>");
+    expect(extractDetailPageDate($)).toBe("2026-03-14");
+  });
+
+  it("falls back to <h1> when <h2> has no date", () => {
+    const $ = cheerio.load(`
+      <html><body>
+        <h1>Friday, January 9, 2026</h1>
+        <h2>Some Venue</h2>
+      </body></html>
+    `);
+    expect(extractDetailPageDate($)).toBe("2026-01-09");
+  });
+
+  it("returns undefined when no date heading exists", () => {
+    const $ = cheerio.load("<h2>Twin Peaks</h2><h3>Hash Run No 1</h3>");
+    expect(extractDetailPageDate($)).toBeUndefined();
+  });
+
+  it("ignores headings without a day-of-week prefix", () => {
+    const $ = cheerio.load("<h2>April 22, 2026</h2>");
+    expect(extractDetailPageDate($)).toBeUndefined();
   });
 
   it("skips 'Nothing yet' values", () => {
@@ -697,6 +772,56 @@ describe("DFWHashAdapter.fetch", () => {
     expect(eventsWithHares.length).toBeGreaterThan(0);
     for (const evt of eventsWithHares) {
       expect(evt.hares).toBe("Son of a Peach");
+    }
+  });
+
+  it("detail-page date overrides drifted grid date (DUHHH #849 regression, #1155)", async () => {
+    // Calendar grid puts the DUHHH event on day 3 of the current month, but
+    // the detail page's <h2> says Wednesday, April 22, 2026. The adapter must
+    // trust the detail-page date and overwrite the grid-derived date.
+    const adapter = new DFWHashAdapter();
+
+    const calendarHtml = `
+      <html><body>
+        <table class="main">
+          <tr><th>Sun</th><th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th><th>Fri</th><th>Sat</th></tr>
+          <tr>
+            <td class="day"><table class="inner"><tr><td class="dom">3</td></tr><tr><td class="event">
+              <a href="event.php?month=4&day=22&year=2026&no=1"><img src="/icons/DUH.png" /></a><br />Hickery House Bar<br /><em>My Boyfriend Joe</em>
+            </td></tr></table></td>
+          </tr>
+        </table>
+      </body></html>
+    `;
+
+    const detailHtml = `
+      <html><body>
+        <h1>Dallas Urban Hash</h1>
+        <h2>Wednesday, April 22, 2026</h2>
+        <h3>Hash Run No 849</h3>
+        <h5><em>Time:</em> 6:30 PM</h5>
+        <h5><em>Hares:</em> My Boyfriend Joe</h5>
+        <h5><em>Hash cash:</em> $3</h5>
+      </body></html>
+    `;
+
+    const mockModule = await import("../safe-fetch");
+    vi.spyOn(mockModule, "safeFetch")
+      .mockResolvedValueOnce(new Response(calendarHtml, { status: 200 }) as never)
+      .mockResolvedValueOnce(new Response(calendarHtml, { status: 200 }) as never)
+      .mockImplementation(async () => new Response(detailHtml, { status: 200 }) as never);
+
+    const result = await adapter.fetch({
+      id: "test-dfw",
+      url: "http://www.dfwhhh.org/calendar/",
+    } as never);
+
+    const duhhhEvents = result.events.filter((e) => e.kennelTags?.includes("duhhh"));
+    expect(duhhhEvents.length).toBeGreaterThan(0);
+    for (const evt of duhhhEvents) {
+      expect(evt.date).toBe("2026-04-22");
+      expect(evt.runNumber).toBe(849);
+      expect(evt.cost).toBe("$3");
     }
   });
 

--- a/src/adapters/html-scraper/dfw-hash.ts
+++ b/src/adapters/html-scraper/dfw-hash.ts
@@ -257,6 +257,47 @@ const KENNEL_NAME_PATTERNS = [
 /** Day-of-week prefix pattern (detail pages sometimes have date headings). */
 const DAY_PREFIX_PATTERN = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)/i;
 
+/** Month-name → 0-indexed month (matches the long-form names used in detail-page <h2> headings). */
+const MONTH_NAME_TO_INDEX: Record<string, number> = {
+  january: 0, february: 1, march: 2, april: 3, may: 4, june: 5,
+  july: 6, august: 7, september: 8, october: 9, november: 10, december: 11,
+};
+
+/**
+ * Extract the canonical event date from a detail-page heading.
+ *
+ * Detail pages render the date as `<h2>Wednesday, April 22, 2026</h2>` (or
+ * occasionally in `<h1>`). This is the source of truth — the calendar grid
+ * cell can drift when a wide multi-day event (e.g. Texas Interhash) confuses
+ * cell-to-day-of-week alignment, mistagging events with the wrong date (#1155).
+ *
+ * Returns ISO `YYYY-MM-DD` (UTC) or undefined if no parseable heading is found.
+ */
+export function extractDetailPageDate($: CheerioAPI): string | undefined {
+  const candidates: string[] = [];
+  $("h2").each((_i, el) => {
+    candidates.push($(el).text().trim());
+  });
+  $("h1").each((_i, el) => {
+    candidates.push($(el).text().trim());
+  });
+
+  for (const text of candidates) {
+    if (!text || !DAY_PREFIX_PATTERN.test(text)) continue;
+    const match = text.match(
+      /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})\b/i,
+    );
+    if (!match) continue;
+    const month = MONTH_NAME_TO_INDEX[match[1].toLowerCase()];
+    const day = parseInt(match[2], 10);
+    const year = parseInt(match[3], 10);
+    if (day < 1 || day > 31) continue;
+    return new Date(Date.UTC(year, month, day, 12, 0, 0)).toISOString().split("T")[0];
+  }
+
+  return undefined;
+}
+
 /**
  * Extract a venue name from the detail page headings.
  *
@@ -294,19 +335,28 @@ function extractVenueName($: CheerioAPI): string | undefined {
  *   - Time: "7:00 PM"
  *   - Start address: "Sam Houston Trail Park, Irving"
  *   - Hares: "Casting Cooch"
+ *   - Hash cash: "$7.00 cash - Paypal $7 ..." (verbatim, no cleanup — see #1151)
+ *   - Description: free-form prose
  *   - Hash Run No NNN (in <h3>)
+ *   - Canonical date in <h2> (e.g. "Wednesday, April 22, 2026") — see #1155
  */
 export function parseDFWDetailPage($: CheerioAPI): {
   startTime?: string;
   location?: string;
   hares?: string;
   runNumber?: number;
+  description?: string;
+  cost?: string;
+  date?: string;
 } {
   const result: {
     startTime?: string;
     location?: string;
     hares?: string;
     runNumber?: number;
+    description?: string;
+    cost?: string;
+    date?: string;
   } = {};
 
   // Extract fields from <h5><em>Label:</em> Value</h5> pattern. Multi-line
@@ -333,8 +383,15 @@ export function parseDFWDetailPage($: CheerioAPI): {
       result.location = value;
     } else if (label.startsWith("hares:") || label.startsWith("hare:")) {
       result.hares = value;
+    } else if (label.startsWith("hash cash:")) {
+      result.cost = value;
+    } else if (label.startsWith("description:")) {
+      result.description = value;
     }
   });
+
+  const detailDate = extractDetailPageDate($);
+  if (detailDate) result.date = detailDate;
 
   const h3Text = $("h3").first().text().trim();
   const runMatch = h3Text.match(/Hash Run No\s*(\d+)/i);
@@ -479,6 +536,16 @@ export class DFWHashAdapter implements SourceAdapter {
           if (detail.location) evt.location = detail.location;
           if (detail.runNumber) evt.runNumber = detail.runNumber;
           if (detail.hares) evt.hares = detail.hares;
+          if (detail.description) evt.description = detail.description;
+          if (detail.cost) evt.cost = detail.cost;
+          // Detail-page date is canonical — overrides the grid cell date when
+          // they disagree. Calendar grid can drift on multi-day cells (#1155).
+          if (detail.date && detail.date !== evt.date) {
+            console.warn(
+              `[dfw-hash] date override for run #${detail.runNumber ?? "?"}: grid=${evt.date} → detail=${detail.date}`,
+            );
+            evt.date = detail.date;
+          }
 
           detailFetched++;
         } else {

--- a/src/adapters/html-scraper/dfw-hash.ts
+++ b/src/adapters/html-scraper/dfw-hash.ts
@@ -24,7 +24,7 @@ import type {
 } from "../types";
 import { hasAnyErrors } from "../types";
 import { safeFetch } from "../safe-fetch";
-import { parse12HourTime, stripHtmlTags } from "../utils";
+import { MONTHS_ZERO, parse12HourTime, stripHtmlTags } from "../utils";
 import { generateStructureHash } from "@/pipeline/structure-hash";
 import * as cheerio from "cheerio";
 import type { CheerioAPI, Cheerio } from "cheerio";
@@ -257,11 +257,9 @@ const KENNEL_NAME_PATTERNS = [
 /** Day-of-week prefix pattern (detail pages sometimes have date headings). */
 const DAY_PREFIX_PATTERN = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)/i;
 
-/** Month-name → 0-indexed month (matches the long-form names used in detail-page <h2> headings). */
-const MONTH_NAME_TO_INDEX: Record<string, number> = {
-  january: 0, february: 1, march: 2, april: 3, may: 4, june: 5,
-  july: 6, august: 7, september: 8, october: 9, november: 10, december: 11,
-};
+/** Long-form month + day + year regex for detail-page date headings. */
+const DETAIL_DATE_PATTERN =
+  /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})\b/i;
 
 /**
  * Extract the canonical event date from a detail-page heading.
@@ -284,15 +282,23 @@ export function extractDetailPageDate($: CheerioAPI): string | undefined {
 
   for (const text of candidates) {
     if (!text || !DAY_PREFIX_PATTERN.test(text)) continue;
-    const match = text.match(
-      /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})\b/i,
-    );
+    const match = DETAIL_DATE_PATTERN.exec(text);
     if (!match) continue;
-    const month = MONTH_NAME_TO_INDEX[match[1].toLowerCase()];
-    const day = parseInt(match[2], 10);
-    const year = parseInt(match[3], 10);
+    const month = MONTHS_ZERO[match[1].toLowerCase()];
+    const day = Number.parseInt(match[2], 10);
+    const year = Number.parseInt(match[3], 10);
     if (day < 1 || day > 31) continue;
-    return new Date(Date.UTC(year, month, day, 12, 0, 0)).toISOString().split("T")[0];
+    // Date.UTC silently normalizes overflowed inputs (Feb 31 → Mar 3); reject
+    // those rather than mis-key downstream merge/fingerprint logic.
+    const candidate = new Date(Date.UTC(year, month, day, 12, 0, 0));
+    if (
+      candidate.getUTCFullYear() !== year ||
+      candidate.getUTCMonth() !== month ||
+      candidate.getUTCDate() !== day
+    ) {
+      continue;
+    }
+    return candidate.toISOString().split("T")[0];
   }
 
   return undefined;
@@ -384,9 +390,12 @@ export function parseDFWDetailPage($: CheerioAPI): {
     } else if (label.startsWith("hares:") || label.startsWith("hare:")) {
       result.hares = value;
     } else if (label.startsWith("hash cash:")) {
-      result.cost = value;
+      // Verbatim — issue authors explicitly call this out (#1151). Use
+      // rawValue (no run-collapsing) so payment instructions and embedded
+      // separators are preserved as the source published them.
+      result.cost = rawValue.replace(/^[\s:,]+/, "").trim();
     } else if (label.startsWith("description:")) {
-      result.description = value;
+      result.description = rawValue.replace(/^[\s:,]+/, "").trim();
     }
   });
 


### PR DESCRIPTION
## Summary

The DFW adapter (`src/adapters/html-scraper/dfw-hash.ts`) was missing two user-visible event-detail fields (`description`, `cost`) and could mistag events with the wrong date when the calendar grid drifted on multi-day cells.

- **#1151** — `parseDFWDetailPage` now extracts `Description:` and `Hash cash:` rows verbatim (no cleanup; FWH3 strings include payment instructions).
- **#1155** — New `extractDetailPageDate($)` helper parses the canonical date from the detail-page `<h2>Wednesday, April 22, 2026</h2>` heading. The adapter enrich loop trusts this over the grid-cell date and `console.warn`s when they disagree, surfacing future drift in scrape logs.

Live adapter window unchanged (current + next month). Historical backfill is a separate one-shot script tracked under #1027 / #1152 / #1158.

## Live verification

Run via `npx tsx scripts/verify-dfw-adapter.ts` (new diagnostic script).

```
=== DFW Live Verification ===
Events parsed: 24
Date range:    2026-05-02 → 2026-06-28
With description: 5
With cost:        12
With runNumber:   19
Errors: 0

[dfw-hash] date override for run #858: grid=2026-06-05 → detail=2026-06-24
[dfw-hash] date override for run #1227: grid=2026-06-08 → detail=2026-06-27
[dfw-hash] date override for run #?: grid=2026-06-09 → detail=2026-06-28

=== Events per kennel ===
  dh3-tx: 3
  duhhh: 8
  fwh3: 4
  noduhhh: 4
  yakh3: 5
```

The 3 overrides confirm #1155 is a recurring bug class — different runs in the live window were also drifting. Sample event has both `description` (long Tarzan-themed prose) and `cost` (`"$5.00 - Pay Online: Paypal $5"`) populated.

## Test plan

- [x] `npm test -- src/adapters/html-scraper/dfw-hash.test.ts` — 40 tests pass (5 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Full suite: `npm test` — 5819 pass, 0 fail
- [x] Live verification against `http://www.dfwhhh.org/calendar/` — see above

Closes #1151
Closes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)