### PR TITLE
feat(scripts): historical backfill for DFW Hash calendar (Texas)

### DIFF
--- a/scripts/backfill-dfw-history.ts
+++ b/scripts/backfill-dfw-history.ts
@@ -1,0 +1,279 @@
+/**
+ * One-shot historical backfill for the DFW Hash House Harriers calendar.
+ *
+ * The live adapter (`DFWHashAdapter`) intentionally fetches only the current
+ * and next month — `dfwhhh.org/calendar/` is partial-enumeration HTML and
+ * widening the live window would let the reconcile pipeline cancel events on
+ * transient page failures. Historical coverage gaps (#1027 Dallas H3 ~16
+ * runs, #1152 Fort Worth H3 #1053-#1055, #1158 DUHHH #845-#846 and earlier)
+ * land here as a one-shot DB write.
+ *
+ * Two-phase strategy:
+ *   1. Walk past monthly calendar pages and parse the grid via
+ *      `extractDFWEvents`. Catches the bulk (~95%).
+ *   2. Probe Wednesday + Saturday `event.php` URLs for any date in the window
+ *      not already covered by phase 1. The source's grid sometimes omits
+ *      runs whose detail pages still exist (e.g. DH3 #1203, DUHHH #846).
+ *      Kennel routing comes from a `<h1>`/`<h2>` heading match.
+ *
+ * Both phases produce `RawEventData[]` and feed through `runBackfillScript`,
+ * which partitions on `date < today-in-Chicago` (so the backfill cannot
+ * encroach on the live adapter's window) and routes through `processRawEvents`
+ * (fingerprint dedup → re-runnable as a no-op).
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-dfw-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-dfw-history.ts
+ *
+ *   BACKFILL_MONTHS=24 (default)  Months back from today to walk
+ *   BACKFILL_PROBE_DAYS=730 (default)  Days back to probe via direct event.php URLs
+ *   BACKFILL_PROBE=0  Disable phase 2 (calendar grid only)
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import type { CheerioAPI } from "cheerio";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import {
+  buildDFWMonthUrl,
+  extractDFWEvents,
+  parseDFWDetailPage,
+} from "@/adapters/html-scraper/dfw-hash";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "DFW Hash Calendar";
+const KENNEL_TIMEZONE = "America/Chicago";
+const USER_AGENT = "Mozilla/5.0 (compatible; HashTracks-Backfill)";
+
+/** Per-batch concurrency for detail page fetches. Mirrors the live adapter. */
+const DETAIL_CONCURRENCY = 3;
+/** Delay between detail-page batches (ms). */
+const DETAIL_BATCH_DELAY = 300;
+
+/**
+ * Detail-page heading → kennelTag. Used by the probing pass to figure out
+ * which kennel a probed `event.php` URL belongs to. Order matters: more
+ * specific names (e.g. "Dallas Urban Hash") must come before "Dallas Hash".
+ */
+const HEADING_TO_KENNEL: Array<[RegExp, string]> = [
+  [/Dallas Urban Hash/i, "duhhh"],
+  [/NoDuh Hash|NODUH Hash/i, "noduhhh"],
+  [/Dallas Hash/i, "dh3-tx"],
+  [/Fort Worth Hash/i, "fwh3"],
+];
+
+interface MonthRef {
+  year: number;
+  month: number; // 0-indexed
+}
+
+/** Build the list of (year, month) pairs to walk, oldest first. */
+function monthsBackFromToday(months: number): MonthRef[] {
+  const refs: MonthRef[] = [];
+  const now = new Date();
+  let year = now.getUTCFullYear();
+  let month = now.getUTCMonth();
+  for (let i = 0; i < months; i++) {
+    refs.push({ year, month });
+    month -= 1;
+    if (month < 0) {
+      month = 11;
+      year -= 1;
+    }
+  }
+  return refs.reverse();
+}
+
+async function fetchHtml(url: string): Promise<string | null> {
+  try {
+    const res = await safeFetch(url, { headers: { "User-Agent": USER_AGENT } });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/** Map a detail page's heading to a known DFW kennelTag, or undefined. */
+function detectKennelFromHeadings($: CheerioAPI): string | undefined {
+  const headings: string[] = [];
+  $("h1, h2").each((_i, el) => {
+    headings.push($(el).text().trim());
+  });
+  for (const text of headings) {
+    for (const [pattern, tag] of HEADING_TO_KENNEL) {
+      if (pattern.test(text)) return tag;
+    }
+  }
+  return undefined;
+}
+
+/** Run an async mapper across `items` in batches with a delay between batches. */
+async function batchProcess<T, R>(
+  items: T[],
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = [];
+  for (let i = 0; i < items.length; i += DETAIL_CONCURRENCY) {
+    if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_BATCH_DELAY));
+    const batch = items.slice(i, i + DETAIL_CONCURRENCY);
+    const results = await Promise.allSettled(batch.map(mapper));
+    for (const r of results) {
+      if (r.status === "fulfilled") out.push(r.value);
+    }
+  }
+  return out;
+}
+
+interface FetchedEvent {
+  event: RawEventData;
+  /** Absolute detail URL — used to dedupe phase 2 against phase 1. */
+  detailKey?: string;
+}
+
+async function fetchMonth({ year, month }: MonthRef): Promise<FetchedEvent[]> {
+  const url = buildDFWMonthUrl(year, month);
+  const html = await fetchHtml(url);
+  if (!html) {
+    console.warn(`  ${year}-${String(month + 1).padStart(2, "0")}: month page fetch failed`);
+    return [];
+  }
+
+  const $ = cheerio.load(html);
+  const { events: indexEvents, errors } = extractDFWEvents($, year, month, url);
+  if (errors.length > 0) {
+    console.warn(`  ${year}-${String(month + 1).padStart(2, "0")}: ${errors.length} parse errors`);
+  }
+  if (indexEvents.length === 0) return [];
+
+  const enriched = await batchProcess(indexEvents, async ({ event, detailUrl }) => {
+    if (!detailUrl) return { event, detailKey: undefined };
+    const detailHtml = await fetchHtml(detailUrl);
+    if (!detailHtml) return { event, detailKey: detailUrl };
+    const $detail = cheerio.load(detailHtml);
+    const detail = parseDFWDetailPage($detail);
+    return {
+      event: {
+        ...event,
+        ...(detail.startTime && { startTime: detail.startTime }),
+        ...(detail.location && { location: detail.location }),
+        ...(detail.hares && { hares: detail.hares }),
+        ...(detail.runNumber !== undefined && { runNumber: detail.runNumber }),
+        ...(detail.description && { description: detail.description }),
+        ...(detail.cost && { cost: detail.cost }),
+        // Detail-page date wins over the grid date (#1155).
+        date: detail.date ?? event.date,
+      },
+      detailKey: detailUrl,
+    };
+  });
+
+  console.log(
+    `  ${year}-${String(month + 1).padStart(2, "0")}: ${enriched.length} events from ${indexEvents.length} index rows`,
+  );
+  return enriched;
+}
+
+/**
+ * DFW kennels run on fixed weekdays — DUHHH on Wed, DH3/FWH3 on Sat. Probing
+ * those weekdays catches events the source's grid forgot to link (#1158 #846,
+ * #1027 #1203/#1212).
+ */
+function probeDates(daysBack: number): { year: number; month: number; day: number }[] {
+  const targets: { year: number; month: number; day: number }[] = [];
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  for (let i = 1; i <= daysBack; i++) {
+    const d = new Date(today.getTime() - i * 86400000);
+    const dow = d.getUTCDay(); // 0=Sun..6=Sat
+    if (dow !== 3 && dow !== 6) continue; // Wed or Sat only
+    targets.push({
+      year: d.getUTCFullYear(),
+      month: d.getUTCMonth() + 1, // 1-indexed for the source URL
+      day: d.getUTCDate(),
+    });
+  }
+  return targets;
+}
+
+function probeUrl(year: number, month1: number, day: number): string {
+  return `http://www.dfwhhh.org/calendar/${year}/event.php?month=${month1}&day=${day}&year=${year}&no=1`;
+}
+
+async function probeDate(
+  target: { year: number; month: number; day: number },
+): Promise<FetchedEvent | null> {
+  const url = probeUrl(target.year, target.month, target.day);
+  const html = await fetchHtml(url);
+  if (!html) return null;
+  const $ = cheerio.load(html);
+
+  const kennelTag = detectKennelFromHeadings($);
+  if (!kennelTag) return null;
+
+  const detail = parseDFWDetailPage($);
+  // Without a parseable detail-page date this URL probably 404'd silently
+  // into a default page — skip rather than guess.
+  if (!detail.date) return null;
+
+  const event: RawEventData = {
+    date: detail.date,
+    kennelTags: [kennelTag],
+    sourceUrl: url,
+    ...(detail.startTime && { startTime: detail.startTime }),
+    ...(detail.location && { location: detail.location }),
+    ...(detail.hares && { hares: detail.hares }),
+    ...(detail.runNumber !== undefined && { runNumber: detail.runNumber }),
+    ...(detail.description && { description: detail.description }),
+    ...(detail.cost && { cost: detail.cost }),
+  };
+  return { event, detailKey: url };
+}
+
+async function fetchAllEvents(): Promise<RawEventData[]> {
+  const months = parseInt(process.env.BACKFILL_MONTHS ?? "24", 10);
+  const probeDays = parseInt(process.env.BACKFILL_PROBE_DAYS ?? "730", 10);
+  const probeEnabled = process.env.BACKFILL_PROBE !== "0";
+
+  const refs = monthsBackFromToday(months);
+  console.log(
+    `Phase 1: walking ${refs.length} months from ${refs[0].year}-${String(refs[0].month + 1).padStart(2, "0")} → ${refs.at(-1)!.year}-${String(refs.at(-1)!.month + 1).padStart(2, "0")}`,
+  );
+
+  const phase1: FetchedEvent[] = [];
+  for (const ref of refs) {
+    phase1.push(...(await fetchMonth(ref)));
+  }
+  console.log(`  Phase 1 total: ${phase1.length} events`);
+
+  if (!probeEnabled) {
+    return phase1.map((f) => f.event);
+  }
+
+  const covered = new Set(
+    phase1.map((f) => f.detailKey).filter((k): k is string => Boolean(k)),
+  );
+
+  const allTargets = probeDates(probeDays);
+  const newTargets = allTargets.filter((t) => !covered.has(probeUrl(t.year, t.month, t.day)));
+  console.log(
+    `\nPhase 2: probing ${newTargets.length} Wed+Sat dates over the past ${probeDays} days (${allTargets.length - newTargets.length} already covered by phase 1)`,
+  );
+
+  const probed = await batchProcess(newTargets, probeDate);
+  const phase2 = probed.filter((p): p is FetchedEvent => p !== null);
+  console.log(`  Phase 2 added: ${phase2.length} events not in monthly grid`);
+
+  return [...phase1, ...phase2].map((f) => f.event);
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: `Walking dfwhhh.org monthly grid + probing direct event.php URLs`,
+  fetchEvents: fetchAllEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The live DFW adapter is partial-enumeration (current+next month only) — widening the window would let the reconcile pipeline cancel events on transient page failures. Per [adapter-patterns.md](../blob/main/.claude/rules/adapter-patterns.md) and the pinned `feedback_historical_backfill.md`, the safe pattern is a one-shot DB backfill. This PR adds `scripts/backfill-dfw-history.ts`.

**Strategy:**

1. **Phase 1 — walk monthly calendars** (`/calendar/{year}/$MM-{year}.php`) using the existing `extractDFWEvents` + `parseDFWDetailPage` parsers from the adapter PR (#1218).
2. **Phase 2 — probe Wed+Sat `event.php` URLs** not already covered by phase 1. The source's grid sometimes omits runs whose detail pages still exist (e.g. DH3 #1203, DUHHH #846). Kennel routing comes from a `<h1>/<h2>` heading match.

Both phases produce `RawEventData[]` and feed through `runBackfillScript` → `reportAndApplyBackfill`, which partitions on `date < today-in-Chicago` (no encroachment on the live adapter window) and routes through `processRawEvents` (fingerprint dedup → idempotent re-runs).

Stacks on top of [#1218](https://github.com/johnrclem/hashtracks-web/pull/1218) (the adapter parse fixes) — phase 1 reuses the description/cost/date-override behaviour added there. Once #1218 merges, GitHub will collapse those changes out of this diff.

## Verification

Run against local dev DB (Railway mirror, see `.claude/rules/local-dev-db.md`):

```
$ BACKFILL_APPLY=1 npx tsx scripts/backfill-dfw-history.ts
Phase 1 total: 256 events
Phase 2: probing 26 Wed+Sat dates over the past 730 days (183 already covered by phase 1)
  Phase 2 added: 21 events not in monthly grid
  Total parsed: 277

  Partition: 265 past rows, 12 skipped (date >= 2026-05-03)
  Date range: 2024-05-04 → 2026-05-02

Merging via pipeline...
  created=22 updated=0 skipped=233 blocked=0 eventErrors=0
```

**Idempotency proof — re-run is a no-op:**

```
$ BACKFILL_APPLY=1 npx tsx scripts/backfill-dfw-history.ts
  ...
Merging via pipeline...
  created=0 updated=0 skipped=255 blocked=0 eventErrors=0
```

**All 19 named-missing runs are now present**, including the 3 grid-omitted ones found by phase 2 (#1203, #1212, #846):

```
dh3-tx | 1203 | 2025-08-09 | Dallas H3 Trail #1203
dh3-tx | 1204 | 2025-08-23 | It's HOT AF Hash
dh3-tx | 1205 | 2025-09-06 | Dallas H3 Trail #1205
dh3-tx | 1206 | 2025-09-20 | Pirate Hash
dh3-tx | 1207 | 2025-10-04 | DFW Pink Dress Run
dh3-tx | 1208 | 2025-10-18 | B-Day Hash
dh3-tx | 1209 | 2025-11-01 | Walk of Shame
dh3-tx | 1210 | 2025-11-15 | M-Streets canned food drive hash
dh3-tx | 1212 | 2025-12-13 | Dallas H3 Trail #1212
dh3-tx | 1213 | 2025-12-27 | Three French Hens
dh3-tx | 1215 | 2026-01-10 | Onsie Hash
dh3-tx | 1217 | 2026-02-07 | Soap Does Dallas again
dh3-tx | 1218 | 2026-02-21 | Flag Pole Hill
dh3-tx | 1220 | 2026-03-14 | St Patrick's Day Parade and Hash
duhhh  |  845 | 2026-03-25 | Twin Peaks
duhhh  |  846 | 2026-04-01 | DUHHH Trail #846
fwh3   | 1053 | 2026-02-28 | Fort Worth H3 Trail #1053
fwh3   | 1054 | 2026-03-21 | Good Bye Winter/Hello Spring Hash
fwh3   | 1055 | 2026-03-28 | Toga Hash
```

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 5819 pass
- [x] Dry-run against local dev DB — 256 events parsed, partition output correct
- [x] Apply against local dev DB — 22 events created, 0 blocked
- [x] Re-apply — 0 created (idempotent via fingerprint dedup)
- [x] Spot-check: all 19 named-missing runs present in DB
- [ ] Operator runs `BACKFILL_APPLY=1 npx tsx scripts/backfill-dfw-history.ts` against prod after merge

## Knobs

- `BACKFILL_MONTHS=24` (default) — months back from today to walk
- `BACKFILL_PROBE_DAYS=730` (default) — days back to probe via direct event.php URLs
- `BACKFILL_PROBE=0` — disable phase 2 (calendar grid only)
- `BACKFILL_APPLY=1` — write to DB (default is dry-run)

Closes #1027
Closes #1152
Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)