### PR TITLE
fix(travel): #768 #769 #770 #784 — Phase 5 polish remainder

### DIFF
--- a/src/app/travel/actions.test.ts
+++ b/src/app/travel/actions.test.ts
@@ -718,6 +718,73 @@ describe("findExistingSavedSearch", () => {
     expect(prisma.travelSearch.findFirst).not.toHaveBeenCalled();
   });
 
+  it("builds an extra placeId-based signature when placeId is provided (#784)", async () => {
+    vi.mocked(prisma.travelSearch.findFirst).mockResolvedValueOnce(null);
+    await findExistingSavedSearch({ ...BASE, placeId: "ChIJplace123" });
+    const call = vi.mocked(prisma.travelSearch.findFirst).mock.calls[0][0];
+    const sigIn = (
+      call?.where?.itinerarySignature as { in?: string[] } | undefined
+    )?.in;
+    expect(sigIn).toHaveLength(2);
+  });
+
+  it("matches a saved row whose coords drifted, via the placeId signature (#784)", async () => {
+    const SAVED_PLACE_ID = "ChIJOwg_06VPwokRYv534QaPC8g";
+    const driftedLookup = {
+      ...BASE,
+      latitude: BASE.latitude + 0.0001,
+      longitude: BASE.longitude - 0.0001,
+      placeId: SAVED_PLACE_ID,
+    };
+
+    const { computeItinerarySignature } = await import("@/lib/travel/limits");
+    const expectedSavedSig = computeItinerarySignature([
+      {
+        placeId: SAVED_PLACE_ID,
+        // canonicalStop strips coords when placeId is set; values
+        // here don't affect the signature output.
+        latitude: 0,
+        longitude: 0,
+        radiusKm: BASE.radiusKm,
+        startDate: BASE.startDate,
+        endDate: BASE.endDate,
+      },
+    ]);
+
+    vi.mocked(prisma.travelSearch.findFirst).mockResolvedValueOnce({
+      id: "ts-place-match",
+      destinations: [{ latitude: BASE.latitude, longitude: BASE.longitude }],
+    } as never);
+    const result = await findExistingSavedSearch(driftedLookup);
+    expect(result).toBe("ts-place-match");
+
+    const call = vi.mocked(prisma.travelSearch.findFirst).mock.calls[0][0];
+    const sigIn = (
+      call?.where?.itinerarySignature as { in?: string[] } | undefined
+    )?.in;
+    expect(sigIn).toContain(expectedSavedSig);
+  });
+
+  it("rejects a placeId-bearing lookup whose coords are far from the matched row (#784)", async () => {
+    // Crafted URL pairs Tokyo coords with London's placeId. The
+    // placeId-only signature would otherwise resolve to the London
+    // saved row and let the page mis-flag a totally different
+    // destination as "Saved". Proximity guard rejects this.
+    const tampered = {
+      ...BASE,
+      latitude: 35.6762, // Tokyo
+      longitude: 139.6503,
+      placeId: "ChIJdd4hrwug2EcRmSrV3Vo6llI", // London City of London
+    };
+    vi.mocked(prisma.travelSearch.findFirst).mockResolvedValueOnce({
+      id: "ts-london",
+      // Saved row's actual coords (London) are thousands of km from URL.
+      destinations: [{ latitude: 51.5074, longitude: -0.1278 }],
+    } as never);
+    const result = await findExistingSavedSearch(tampered);
+    expect(result).toBeNull();
+  });
+
   it("swallows errors and returns null so the page renders as unsaved", async () => {
     vi.mocked(prisma.travelSearch.findFirst).mockRejectedValueOnce(
       new Error("db down"),

--- a/src/app/travel/actions.test.ts
+++ b/src/app/travel/actions.test.ts
@@ -718,14 +718,40 @@ describe("findExistingSavedSearch", () => {
     expect(prisma.travelSearch.findFirst).not.toHaveBeenCalled();
   });
 
-  it("builds an extra placeId-based signature when placeId is provided (#784)", async () => {
-    vi.mocked(prisma.travelSearch.findFirst).mockResolvedValueOnce(null);
+  it("queries placeId signatures first, then coord signatures on miss (#784)", async () => {
+    // First call (placeId-bearing sigs) returns null → fall back to the
+    // coord-only query. Both calls must hit `findFirst`. Order matters:
+    // placeId-saved rows must take precedence over coord-only rows when
+    // a user has both for the same destination, otherwise downstream
+    // saved-trip actions can target the wrong row.
+    vi.mocked(prisma.travelSearch.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
     await findExistingSavedSearch({ ...BASE, placeId: "ChIJplace123" });
-    const call = vi.mocked(prisma.travelSearch.findFirst).mock.calls[0][0];
-    const sigIn = (
-      call?.where?.itinerarySignature as { in?: string[] } | undefined
+    const calls = vi.mocked(prisma.travelSearch.findFirst).mock.calls;
+    expect(calls).toHaveLength(2);
+    const firstSigs = (
+      calls[0][0]?.where?.itinerarySignature as { in?: string[] } | undefined
     )?.in;
-    expect(sigIn).toHaveLength(2);
+    const secondSigs = (
+      calls[1][0]?.where?.itinerarySignature as { in?: string[] } | undefined
+    )?.in;
+    expect(firstSigs).toHaveLength(1);
+    expect(secondSigs).toHaveLength(1);
+    expect(firstSigs?.[0]).not.toBe(secondSigs?.[0]);
+  });
+
+  it("returns the placeId match without falling back to the coord query (#784)", async () => {
+    vi.mocked(prisma.travelSearch.findFirst).mockResolvedValueOnce({
+      id: "ts-placeid",
+      destinations: [{ latitude: BASE.latitude, longitude: BASE.longitude }],
+    } as never);
+    const result = await findExistingSavedSearch({
+      ...BASE,
+      placeId: "ChIJplace123",
+    });
+    expect(result).toBe("ts-placeid");
+    expect(vi.mocked(prisma.travelSearch.findFirst).mock.calls).toHaveLength(1);
   });
 
   it("matches a saved row whose coords drifted, via the placeId signature (#784)", async () => {
@@ -776,12 +802,50 @@ describe("findExistingSavedSearch", () => {
       longitude: 139.6503,
       placeId: "ChIJdd4hrwug2EcRmSrV3Vo6llI", // London City of London
     };
-    vi.mocked(prisma.travelSearch.findFirst).mockResolvedValueOnce({
-      id: "ts-london",
-      // Saved row's actual coords (London) are thousands of km from URL.
-      destinations: [{ latitude: 51.5074, longitude: -0.1278 }],
-    } as never);
+    // First call (placeId sigs) returns the London row → guard rejects.
+    // Second call (coord sigs) also returns null since no row matches.
+    vi.mocked(prisma.travelSearch.findFirst)
+      .mockResolvedValueOnce({
+        id: "ts-london",
+        destinations: [{ latitude: 51.5074, longitude: -0.1278 }],
+      } as never)
+      .mockResolvedValueOnce(null);
     const result = await findExistingSavedSearch(tampered);
+    expect(result).toBeNull();
+  });
+
+  it("accepts a placeId-bearing match within the 10km proximity boundary (#784)", async () => {
+    // Saved row coords ~1km north of URL coords — well within the
+    // PLACEID_PROXIMITY_KM_LIMIT cutoff. Locks the boundary against
+    // off-by-one regressions in the haversine guard.
+    vi.mocked(prisma.travelSearch.findFirst).mockResolvedValueOnce({
+      id: "ts-near",
+      destinations: [
+        { latitude: BASE.latitude + 0.009, longitude: BASE.longitude },
+      ],
+    } as never);
+    const result = await findExistingSavedSearch({
+      ...BASE,
+      placeId: "ChIJplace123",
+    });
+    expect(result).toBe("ts-near");
+  });
+
+  it("rejects a placeId-bearing match just past the 10km proximity boundary (#784)", async () => {
+    // Saved row coords ~12km from URL coords — outside the cutoff.
+    // Pairs with the boundary-accept test above to lock the threshold.
+    vi.mocked(prisma.travelSearch.findFirst)
+      .mockResolvedValueOnce({
+        id: "ts-far",
+        destinations: [
+          { latitude: BASE.latitude + 0.11, longitude: BASE.longitude },
+        ],
+      } as never)
+      .mockResolvedValueOnce(null);
+    const result = await findExistingSavedSearch({
+      ...BASE,
+      placeId: "ChIJplace123",
+    });
     expect(result).toBeNull();
   });
 

--- a/src/app/travel/actions.ts
+++ b/src/app/travel/actions.ts
@@ -161,14 +161,46 @@ export async function findExistingSavedSearch(
         status: TravelSearchStatus.ACTIVE,
         itinerarySignature: { in: Array.from(new Set(signatures)) },
       },
-      select: { id: true },
+      select: {
+        id: true,
+        // Pulled so a placeId-bearing lookup can verify coord proximity
+        // post-query — defense against a tampered URL that pairs
+        // coords-of-A with placeId-of-B. The placeId-only signature
+        // variant ignores coords by design (it exists to absorb
+        // ~0.0001° geocoder drift), so without this check a crafted
+        // URL could resolve to trip B's id and let downstream
+        // mutations target the wrong saved row.
+        destinations: {
+          select: { latitude: true, longitude: true },
+          orderBy: { position: "asc" },
+          take: 1,
+        },
+      },
     });
-    return match?.id ?? null;
+    if (!match) return null;
+    if (placeId) {
+      const dest = match.destinations[0];
+      if (!dest) return null;
+      const km = haversineDistance(
+        latitude,
+        longitude,
+        dest.latitude,
+        dest.longitude,
+      );
+      if (km > PLACEID_PROXIMITY_KM_LIMIT) return null;
+    }
+    return match.id;
   } catch (err) {
     console.error("[travel] findExistingSavedSearch failed", err);
     return null;
   }
 }
+
+/** Max distance between URL coords and the matched saved row's coords
+ *  when the lookup used a placeId-bearing signature. Wide enough to
+ *  cover any legitimate provider drift; tight enough to reject a
+ *  cross-city `pid` tampered into the URL. */
+const PLACEID_PROXIMITY_KM_LIMIT = 10;
 
 // ============================================================================
 // saveTravelSearch

--- a/src/app/travel/actions.ts
+++ b/src/app/travel/actions.ts
@@ -149,35 +149,46 @@ export async function findExistingSavedSearch(
         },
       ]);
 
-    const signatures: string[] = [];
+    const placeIdSigs: string[] = [];
+    const coordSigs: string[] = [];
     for (const radiusKm of radii) {
-      signatures.push(buildSig(radiusKm, false));
-      if (placeId) signatures.push(buildSig(radiusKm, true));
+      coordSigs.push(buildSig(radiusKm, false));
+      if (placeId) placeIdSigs.push(buildSig(radiusKm, true));
     }
 
-    const match = await prisma.travelSearch.findFirst({
-      where: {
-        userId: user.id,
-        status: TravelSearchStatus.ACTIVE,
-        itinerarySignature: { in: Array.from(new Set(signatures)) },
-      },
-      select: {
-        id: true,
-        // Pulled so a placeId-bearing lookup can verify coord proximity
-        // post-query — defense against a tampered URL that pairs
-        // coords-of-A with placeId-of-B. The placeId-only signature
-        // variant ignores coords by design (it exists to absorb
-        // ~0.0001° geocoder drift), so without this check a crafted
-        // URL could resolve to trip B's id and let downstream
-        // mutations target the wrong saved row.
-        destinations: {
-          select: { latitude: true, longitude: true },
-          orderBy: { position: "asc" },
-          take: 1,
+    const queryFor = (sigs: string[]) =>
+      prisma.travelSearch.findFirst({
+        where: {
+          userId: user.id,
+          status: TravelSearchStatus.ACTIVE,
+          itinerarySignature: { in: Array.from(new Set(sigs)) },
         },
-      },
-    });
+        select: {
+          id: true,
+          // Pulled so a placeId-bearing lookup can verify coord proximity
+          // post-query — defense against a tampered URL that pairs
+          // coords-of-A with placeId-of-B. The placeId-only signature
+          // variant ignores coords by design (it exists to absorb
+          // ~0.0001° geocoder drift), so without this check a crafted
+          // URL could resolve to trip B's id and let downstream
+          // mutations target the wrong saved row.
+          destinations: {
+            select: { latitude: true, longitude: true },
+            orderBy: { position: "asc" },
+            take: 1,
+          },
+        },
+      });
+
+    // Prefer the placeId-bearing signature so a user who has BOTH a
+    // legacy coord-only row AND a newer placeId-saved row for the same
+    // destination binds to the placeId one — `findFirst` returns
+    // undefined order on `in: [...]` matches, and downstream actions
+    // (delete/update) need to target the row the page just resolved.
+    let match = placeIdSigs.length > 0 ? await queryFor(placeIdSigs) : null;
+    if (!match) match = await queryFor(coordSigs);
     if (!match) return null;
+
     if (placeId) {
       const dest = match.destinations[0];
       if (!dest) return null;

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -74,6 +74,7 @@ export default async function TravelPage({ searchParams }: TravelPageProps) {
   const q = getParam(params, "q");
   const r = getParam(params, "r");
   const tz = getParam(params, "tz");
+  const pid = getParam(params, "pid");
 
   const hasSearchParams =
     lat != null && lng != null && from != null && to != null;
@@ -138,6 +139,7 @@ export default async function TravelPage({ searchParams }: TravelPageProps) {
           endDate: to,
           radiusKm,
           timezone: tz,
+          placeId: pid,
         }}
       />
 
@@ -152,6 +154,7 @@ export default async function TravelPage({ searchParams }: TravelPageProps) {
           endDate={to}
           destination={q ?? ""}
           timezone={tz}
+          placeId={pid}
           filterParams={params}
           pendingAutoSave={getParam(params, "saved") === "1"}
         />
@@ -174,6 +177,7 @@ async function TravelResultsServer({
   endDate,
   destination,
   timezone,
+  placeId,
   filterParams,
   pendingAutoSave,
 }: {
@@ -185,6 +189,7 @@ async function TravelResultsServer({
   endDate: string;
   destination: string;
   timezone?: string;
+  placeId?: string;
   filterParams: Record<string, string | string[] | undefined>;
   pendingAutoSave: boolean;
 }) {
@@ -221,6 +226,7 @@ async function TravelResultsServer({
       ? await findExistingSavedSearch({
           latitude,
           longitude,
+          placeId,
           radiusKm: radiusKm === requestedRadiusKm
             ? radiusKm
             : [radiusKm, requestedRadiusKm],
@@ -268,6 +274,7 @@ async function TravelResultsServer({
       longitude,
       radiusKm,
       requestedRadiusKm,
+      placeId,
       // When the service expanded to a broader region, surface the
       // larger radius so the hero count + summary can stop lying about
       // which radius the trails are actually within.
@@ -300,6 +307,7 @@ async function TravelResultsServer({
             longitude={longitude}
             radiusKm={radiusKm}
             timezone={timezone}
+            placeId={placeId}
           />
         )}
       </>

--- a/src/components/travel/PossibleRow.tsx
+++ b/src/components/travel/PossibleRow.tsx
@@ -9,7 +9,10 @@ export interface PossibleRowData {
   distanceKm: number;
   explanation: string;
   sourceLinks: { url: string; label: string; type: string }[];
-  /** Most recent confirmed event in the last 12 weeks, or null/undefined. */
+  /** Most recent confirmed event for this kennel — preferring the
+   *  in-window 12-week evidence; falling back to the kennel's all-time
+   *  `lastEventDate` if the kennel has no recent activity. Null/undefined
+   *  only when the kennel has no event history at all. */
   lastConfirmedAt?: string | null;
 }
 

--- a/src/components/travel/PossibleSection.tsx
+++ b/src/components/travel/PossibleSection.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { capture } from "@/lib/analytics";
 import { PossibleRow, type PossibleRowData } from "./PossibleRow";
+import { TravelHintBadge } from "./TravelHintBadge";
 
 interface PossibleResult extends PossibleRowData {
   date: string | null;
@@ -20,8 +21,17 @@ export function PossibleSection({ results, confirmedCount }: Readonly<PossibleSe
 
   if (results.length === 0) return null;
 
+  const autoPromoted = confirmedCount === 0;
+
   return (
     <div className="mt-8 border-l-2 border-dashed border-border pl-5">
+      {autoPromoted && (
+        <TravelHintBadge
+          glyph="◆"
+          label="Showing possible activity"
+          ariaLabel={`No confirmed runs in this window — showing ${results.length} possible kennel${results.length !== 1 ? "s" : ""} instead`}
+        />
+      )}
       <button
         type="button"
         onClick={() => {

--- a/src/components/travel/PossibleSection.tsx
+++ b/src/components/travel/PossibleSection.tsx
@@ -29,7 +29,7 @@ export function PossibleSection({ results, confirmedCount }: Readonly<PossibleSe
         <TravelHintBadge
           glyph="◆"
           label="Showing possible activity"
-          ariaLabel={`No confirmed runs in this window — showing ${results.length} possible kennel${results.length !== 1 ? "s" : ""} instead`}
+          ariaLabel={`No confirmed runs in this window — showing ${results.length} possible kennel${results.length === 1 ? "" : "s"} instead`}
         />
       )}
       <button

--- a/src/components/travel/TravelAutoSave.tsx
+++ b/src/components/travel/TravelAutoSave.tsx
@@ -16,6 +16,10 @@ interface TravelAutoSaveProps {
   longitude: number;
   radiusKm: number;
   timezone?: string;
+  /** Round-tripped from the URL `pid` param. Persisted on save so a
+   *  later SSR lookup can match on placeId identity even when coords
+   *  drift between autocomplete and geocode-fallback paths. */
+  placeId?: string;
 }
 
 /**
@@ -41,6 +45,7 @@ export function TravelAutoSave({
   longitude,
   radiusKm,
   timezone,
+  placeId,
 }: TravelAutoSaveProps) {
   const router = useRouter();
   const fired = useRef(false);
@@ -65,6 +70,7 @@ export function TravelAutoSave({
       startDate,
       endDate,
       timezone,
+      placeId,
     });
 
     if (!hasIntent) {
@@ -82,6 +88,7 @@ export function TravelAutoSave({
           startDate,
           endDate,
           timezone,
+          placeId,
         });
         if ("success" in result && result.success) {
           capture("travel_saved_search_created", {
@@ -106,7 +113,7 @@ export function TravelAutoSave({
         stripSavedParam();
       }
     })();
-  }, [destination, startDate, endDate, latitude, longitude, radiusKm, timezone, router]);
+  }, [destination, startDate, endDate, latitude, longitude, radiusKm, timezone, placeId, router]);
 
   return null;
 }

--- a/src/components/travel/TravelHintBadge.tsx
+++ b/src/components/travel/TravelHintBadge.tsx
@@ -1,0 +1,24 @@
+/**
+ * Amber mono "tell-the-user-you-helped" badge used by Travel Mode when the
+ * service made a non-obvious revision: expanding the radius, snapping to a
+ * tier, auto-promoting Possible activity over an empty Confirmed list.
+ * Single component so the three call sites can't drift in styling.
+ */
+export function TravelHintBadge({
+  glyph,
+  label,
+  ariaLabel,
+}: {
+  glyph: "◆" | "◇";
+  label: string;
+  ariaLabel: string;
+}) {
+  return (
+    <p
+      className="mb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-amber-600 dark:text-amber-400"
+      aria-label={ariaLabel}
+    >
+      {glyph} {label}
+    </p>
+  );
+}

--- a/src/components/travel/TravelHintBadge.tsx
+++ b/src/components/travel/TravelHintBadge.tsx
@@ -8,11 +8,11 @@ export function TravelHintBadge({
   glyph,
   label,
   ariaLabel,
-}: {
+}: Readonly<{
   glyph: "◆" | "◇";
   label: string;
   ariaLabel: string;
-}) {
+}>) {
   return (
     <p
       className="mb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-amber-600 dark:text-amber-400"

--- a/src/components/travel/TravelSearchForm/LegRow.tsx
+++ b/src/components/travel/TravelSearchForm/LegRow.tsx
@@ -39,13 +39,14 @@ export const LegRow = memo(function LegRow({
   const datesInvalid = showRequiredStamps && !legDatesValid(leg);
 
   const onDestinationChange = useCallback(
-    (place: { label: string; latitude: number; longitude: number; timezone?: string }) => {
+    (place: { label: string; latitude: number; longitude: number; timezone?: string; placeId?: string }) => {
       updateLeg(legIndex, {
         destination: place.label,
         latitude: place.latitude,
         longitude: place.longitude,
         coordsResolved: true,
         timezone: place.timezone ?? "",
+        placeId: place.placeId,
       });
     },
     [updateLeg, legIndex],
@@ -57,6 +58,7 @@ export const LegRow = memo(function LegRow({
       longitude: 0,
       coordsResolved: false,
       timezone: "",
+      placeId: undefined,
     });
   }, [updateLeg, legIndex]);
   const onStartDateChange = useCallback(

--- a/src/components/travel/TravelSearchForm/TravelSearchForm.tsx
+++ b/src/components/travel/TravelSearchForm/TravelSearchForm.tsx
@@ -192,6 +192,10 @@ export function TravelSearchForm({
       q: leg.destination,
     });
     if (leg.timezone) params.set("tz", leg.timezone);
+    // placeId round-trip lets SSR saved-trip lookup prefer placeId identity
+    // over coord equality — same place geocoded vs. picked from autocomplete
+    // can produce coords that drift by ~0.0001°.
+    if (leg.placeId) params.set("pid", leg.placeId);
     router.push(`/travel?${params.toString()}`);
     if (variant === "compact") setIsExpanded(false);
   }, [router, variant]);

--- a/src/components/travel/TravelSearchForm/helpers.ts
+++ b/src/components/travel/TravelSearchForm/helpers.ts
@@ -32,6 +32,7 @@ export function makeLegFromInitial(
     // Types mark latitude/longitude as required numbers; any LegState we
     // build from initialValues is coord-resolved by construction.
     coordsResolved: true,
+    placeId: initial.placeId,
   };
 }
 
@@ -46,6 +47,7 @@ export function legToDestParams(leg: LegState) {
     startDate: leg.startDate,
     endDate: leg.endDate,
     timezone: leg.timezone || undefined,
+    placeId: leg.placeId,
   };
 }
 

--- a/src/components/travel/TravelSearchForm/types.ts
+++ b/src/components/travel/TravelSearchForm/types.ts
@@ -8,6 +8,12 @@ export interface InitialLegValues {
   endDate: string;
   radiusKm: number;
   timezone?: string;
+  /** Google Places ID if the destination was picked from autocomplete.
+   *  Round-tripped through the URL (`pid` param) so saved-trip lookups
+   *  can match on placeId even when re-rendered from a stateless URL —
+   *  geocoder fallback and autocomplete return coords that drift
+   *  ~0.0001° apart for the same place. */
+  placeId?: string;
 }
 
 export interface TravelSearchFormProps {
@@ -39,6 +45,11 @@ export interface LegState {
   radiusKm: number;
   /** DestinationInput reported resolved coords — (0, 0) is a valid equatorial destination so this is not just `latitude !== 0`. */
   coordsResolved: boolean;
+  /** Optional Google Places ID. Set when the destination was picked from
+   *  autocomplete; absent on the geocode-fallback path. Threaded into
+   *  the URL as `pid` so SSR saved-trip lookup can prefer placeId
+   *  identity over coord equality. */
+  placeId?: string;
 }
 
 export type BoardingStampVariant = "leg" | "ghost" | "required";

--- a/src/components/travel/TripSummary.tsx
+++ b/src/components/travel/TripSummary.tsx
@@ -26,6 +26,7 @@ import { buildMultiEventIcs } from "@/lib/calendar";
 import { capture } from "@/lib/analytics";
 import { stashSaveIntent } from "@/lib/travel/save-intent";
 import type { ExportableConfirmedEvent } from "@/lib/travel/export";
+import { TravelHintBadge } from "./TravelHintBadge";
 
 // Re-export so existing consumers that imported `ExportableConfirmedEvent`
 // from TripSummary keep working. The canonical definition + projection
@@ -59,6 +60,9 @@ interface TripSummaryProps {
   /** Effective radius after the broader-region fallback; triggers the ROUTING REVISED badge when larger than radiusKm. */
   effectiveRadiusKm?: number;
   timezone?: string;
+  /** Round-tripped from URL `pid`. Persisted on save so a later SSR
+   *  lookup can match on placeId identity rather than coord equality. */
+  placeId?: string;
   isAuthenticated: boolean;
   initialSavedId: string | null;
   confirmedCount: number;
@@ -92,6 +96,7 @@ export function TripSummary({
   requestedRadiusKm,
   effectiveRadiusKm,
   timezone,
+  placeId,
   isAuthenticated,
   initialSavedId,
   confirmedCount,
@@ -165,6 +170,7 @@ export function TripSummary({
         startDate,
         endDate,
         timezone,
+        placeId,
       });
       const here = new URL(window.location.href);
       here.searchParams.set("saved", "1");
@@ -190,6 +196,7 @@ export function TripSummary({
         startDate,
         endDate,
         timezone,
+        placeId,
       });
       if ("success" in result && result.success) {
         setSavedId(result.id);
@@ -308,19 +315,17 @@ export function TripSummary({
   return (
     <section className="mt-8 border-b border-border pb-8">
       {broaderExpanded ? (
-        <p
-          className="mb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-amber-600 dark:text-amber-400"
-          aria-label="Search radius was automatically expanded to find results"
-        >
-          ◆ Routing revised
-        </p>
+        <TravelHintBadge
+          glyph="◆"
+          label="Routing revised"
+          ariaLabel="Search radius was automatically expanded to find results"
+        />
       ) : radiusSnapped ? (
-        <p
-          className="mb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-amber-600 dark:text-amber-400"
-          aria-label="Requested radius was adjusted to the nearest supported tier"
-        >
-          ◇ Radius adjusted
-        </p>
+        <TravelHintBadge
+          glyph="◇"
+          label="Radius adjusted"
+          ariaLabel="Requested radius was adjusted to the nearest supported tier"
+        />
       ) : null}
 
       {legs && legs.length > 1 ? (

--- a/src/lib/travel/save-intent.ts
+++ b/src/lib/travel/save-intent.ts
@@ -27,6 +27,10 @@ export interface SaveIntentParams {
   longitude: number;
   radiusKm: number;
   timezone?: string;
+  /** Bound into the intent so a tampered redirect URL can't substitute a
+   *  different placeId between the guest Save click and the post-sign-in
+   *  auto-save — the consume side rejects mismatches. */
+  placeId?: string;
 }
 
 interface StoredIntent {
@@ -47,6 +51,7 @@ export function signatureForIntent(p: SaveIntentParams): string {
     p.longitude.toFixed(6),
     p.radiusKm,
     p.timezone ?? "",
+    p.placeId ?? "",
   ].join("|");
 }
 

--- a/src/lib/travel/search.test.ts
+++ b/src/lib/travel/search.test.ts
@@ -591,7 +591,10 @@ describe("executeTravelSearch", () => {
     expect(result.possible[0].lastConfirmedAt!.getTime()).toBe(recentEvidence.getTime());
   });
 
-  it("leaves lastConfirmedAt null when no evidence in the 12-week window", async () => {
+  it("falls back to kennel.lastEventDate when no in-window evidence (#769)", async () => {
+    // No in-window evidence, but the kennel has an all-time `lastEventDate`
+    // from outside the 12-week window. That older anchor should still
+    // surface so the Possible card explains why we listed the kennel.
     const lowRule: MockScheduleRule = {
       ...testRule,
       id: "r-low",
@@ -599,6 +602,29 @@ describe("executeTravelSearch", () => {
       confidence: "LOW",
     };
     const prisma = createMockPrisma([testKennel], [], [lowRule]);
+    const result = await executeTravelSearch(prisma, baseParams);
+
+    expect(result.possible).toHaveLength(1);
+    expect(result.possible[0].lastConfirmedAt).toBeInstanceOf(Date);
+    expect(result.possible[0].lastConfirmedAt!.getTime()).toBe(
+      testKennel.lastEventDate!.getTime(),
+    );
+  });
+
+  it("leaves lastConfirmedAt null when kennel has no history at all (#769)", async () => {
+    // Truly history-less kennel: no in-window evidence AND no all-time
+    // lastEventDate. Render path hides the line in this case.
+    const lowRule: MockScheduleRule = {
+      ...testRule,
+      id: "r-low",
+      rrule: "CADENCE=MONTHLY",
+      confidence: "LOW",
+    };
+    const historyLessKennel: MockKennel = {
+      ...testKennel,
+      lastEventDate: null,
+    };
+    const prisma = createMockPrisma([historyLessKennel], [], [lowRule]);
     const result = await executeTravelSearch(prisma, baseParams);
 
     expect(result.possible).toHaveLength(1);

--- a/src/lib/travel/search.ts
+++ b/src/lib/travel/search.ts
@@ -147,7 +147,11 @@ export interface PossibleResult extends DestinationTag {
   distanceTier: DistanceTier;
   explanation: string;
   sourceLinks: SourceLink[];
-  /** Most recent confirmed event in the 12-week evidence window, or null. */
+  /** Most recent confirmed event for this kennel — preferring the
+   *  in-window 12-week evidence event so the line moves as the kennel
+   *  posts; falling back to the kennel's all-time `lastEventDate` when
+   *  no in-window evidence exists. Null only when the kennel has no
+   *  event history at all. */
   lastConfirmedAt: Date | null;
 }
 

--- a/src/lib/travel/search.ts
+++ b/src/lib/travel/search.ts
@@ -652,9 +652,14 @@ async function runStopSearch(
   const possibleResults: PossibleResult[] = possibleProjections.map((proj) => {
     const kennel = kennelMap.get(proj.kennelId);
     const evidence = evidenceByKennel.get(proj.kennelId) ?? [];
-    const lastConfirmedAt = evidence.length > 0
+    // Prefer the most-recent in-window event so the line moves as the kennel
+    // posts. Fall back to the kennel's all-time `lastEventDate` so a Low
+    // projection still anchors to *something* — even old history justifies
+    // why we listed the kennel.
+    const recentLast = evidence.length > 0
       ? new Date(evidence.reduce((max, e) => Math.max(max, e.date.getTime()), 0))
       : null;
+    const lastConfirmedAt = recentLast ?? kennel?.lastEventDate ?? null;
     return {
       type: "possible" as const,
       destinationIndex: index,

--- a/src/lib/weather.test.ts
+++ b/src/lib/weather.test.ts
@@ -166,4 +166,15 @@ describe("getEventDayWeather", () => {
     expect(calledUrl).toContain("location.longitude=-0.13");
     expect(calledUrl).toContain("weather.googleapis.com");
   });
+
+  it("attaches an AbortSignal so a hung upstream can't stall the SSR (#768)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(buildWeatherResponse("2026-03-01")),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    await getEventDayWeather(51.51, -0.13, new Date("2026-03-01T12:00:00Z"));
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });

--- a/src/lib/weather.test.ts
+++ b/src/lib/weather.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getEventDayWeather } from "./weather";
+import { getEventDayWeather, getWeatherForEvents } from "./weather";
 
 const MOCK_API_KEY = "test-api-key";
 
@@ -174,6 +174,46 @@ describe("getEventDayWeather", () => {
     });
     vi.stubGlobal("fetch", mockFetch);
     await getEventDayWeather(51.51, -0.13, new Date("2026-03-01T12:00:00Z"));
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("getWeatherForEvents", () => {
+  beforeEach(() => {
+    vi.stubEnv("GOOGLE_WEATHER_API_KEY", "test-key");
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("attaches an AbortSignal to each batched fetch (#768)", async () => {
+    // Pick a date inside the 10-day forecast window so the batch
+    // actually issues a fetch. Anchor on today + 1d so the test stays
+    // green regardless of when it runs.
+    const tomorrow = new Date();
+    tomorrow.setUTCHours(12, 0, 0, 0);
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    const dateStr = tomorrow.toISOString().slice(0, 10);
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(buildWeatherResponse(dateStr)),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await getWeatherForEvents([
+      {
+        id: "evt-1",
+        date: tomorrow,
+        latitude: 51.5,
+        longitude: -0.1,
+        kennel: { region: "London" },
+      },
+    ]);
+
+    expect(mockFetch).toHaveBeenCalled();
     const init = mockFetch.mock.calls[0][1] as RequestInit;
     expect(init.signal).toBeInstanceOf(AbortSignal);
   });

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -34,6 +34,11 @@ interface GoogleWeatherApiResponse {
   forecastDays?: GoogleWeatherForecastDay[];
 }
 
+/** Caps each upstream Google Weather call so a hung response can't push
+ *  the SSR render past Vercel's gateway window into a 503. The catch
+ *  path renders the page without weather data. */
+const WEATHER_FETCH_TIMEOUT_MS = 8000;
+
 /**
  * Fetch daily forecast for a given event date and location.
  * Returns null if the date is not found in the 10-day window or the API fails.
@@ -61,6 +66,7 @@ export async function getEventDayWeather(
   try {
     const res = await fetch(url, { // NOSONAR - domain is hardcoded; lat/lng are DB-sourced numbers
       next: { revalidate: 1800 }, // 30-minute cache
+      signal: AbortSignal.timeout(WEATHER_FETCH_TIMEOUT_MS),
     });
 
     if (!res.ok) return null;
@@ -187,7 +193,10 @@ export async function getWeatherForEvents(
       `&days=10`;
 
     try {
-      const res = await fetch(url, { next: { revalidate: 1800 } });
+      const res = await fetch(url, {
+        next: { revalidate: 1800 },
+        signal: AbortSignal.timeout(WEATHER_FETCH_TIMEOUT_MS),
+      });
       if (!res.ok) return;
 
       const data = (await res.json()) as GoogleWeatherApiResponse;


### PR DESCRIPTION
## Summary

PR #795 shipped most of the Phase 5 polish batch but its body used a single `Closes #794 #793 #770 #769 #783 #784` line — only #794 actually closed. This PR finishes the remainder and addresses Codex's adversarial-review findings on the new placeId trust boundary.

#793 and #783 — already fixed in PR #795 — closed separately with a pointer to that PR's tests; no code change here.

## Changes

### #769 — Possible card last-confirmed uses all-time history
`PossibleResult.lastConfirmedAt` previously came only from the 12-week evidence window. Falls back to `kennel.lastEventDate` (already loaded by `fetchAllVisibleKennels`) so older history still anchors a Low projection. The render path was already in place from #795.

### #770 — Visible inline hint when Possible auto-promotes
Extracted `TravelHintBadge` so the amber mono "tell-the-user-you-helped" surface (the same one TripSummary uses for ROUTING REVISED / RADIUS ADJUSTED) lives in one place. Three call sites; new badge above `PossibleSection` reads `◆ Showing possible activity` when `confirmedCount === 0`.

### #784 — placeId URL round-trip + hardened trust boundary
- `LegState` / `InitialLegValues` carry `placeId`. `DestinationInput`'s autocomplete pick now survives the URL round-trip via a new `pid` param.
- `page.tsx` reads `pid` and threads it into `findExistingSavedSearch`, `TravelAutoSave`, and `TripSummary` so SSR prefers placeId identity over raw lat/lng (autocomplete vs. geocode-fallback drift ~0.0001°).
- **Hardening (Codex review):**
  - `findExistingSavedSearch` now selects the matched row's first destination coords and rejects the match when a placeId-bearing lookup pairs with coords >10km from the saved row. Defends against a tampered URL that pairs coords-of-A with placeId-of-B.
  - `save-intent` signature includes `placeId` so a redirect URL can't substitute a different `pid` between the guest Save click and the post-sign-in auto-save.

### #768 — bound weather upstream
Added `AbortSignal.timeout(WEATHER_FETCH_TIMEOUT_MS = 8000)` to both Google Weather fetches. Without it, a hung upstream pushed the Travel SSR past Vercel's gateway window into a 503. The existing try/catch + null fallback already gracefully degrades to a weather-less page when the abort fires.

A root-cause writeup is posted as a follow-up comment on the issue with the next investigative step (Vercel runtime logs filtered to `/travel` + 503).

## Tests

- `actions.test.ts`: dual-signature build, drift-match, tampered-pid rejection (proximity guard)
- `search.test.ts`: extends #769 to cover both the all-time fallback and the truly history-less case
- `weather.test.ts`: asserts `AbortSignal` is attached

Full suite: **5816 passing** (no regressions).

## Test plan

- [x] `npx tsc --noEmit && npm run lint && npm test`
- [ ] `/travel?lat=51.5074&lng=-0.1278&from=2026-06-01&to=2026-06-07&r=25&q=London` — Possible cards render `Last posted ...` for older history; amber `◆ Showing possible activity` hint shows when confirmedCount = 0
- [ ] Save a trip via Places autocomplete → copy URL → reload in a fresh tab — chip shows "Saved", `pid=...` appears in URL
- [ ] Manually edit URL to pair Tokyo coords with London `pid` — chip stays at "Save trip" (proximity guard rejects)

Closes #768
Closes #769
Closes #770
Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)