### PR TITLE
fix(adapters): WS3 quick-win bundle — 8 bugs across 5 adapters

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2836,6 +2836,36 @@ export const SOURCES = [
       config: {
         cityNames: "Tokyo",
         defaultKennelTag: "tokyo-h3",
+        // Tokyo H3 enters trail names in HC's eventName field as the
+        // neighborhood/station nearest the meeting point — not a real trail
+        // name. Substitute the synthesized "Tokyo H3 Trail #N" for the
+        // observed placeholder strings. Extend this list when new
+        // neighborhood-only titles surface in scrapes. (#1166)
+        defaultTitle: "Tokyo H3 Trail",
+        staleTitleAliases: [
+          "Akabane",
+          "Akihabara",
+          "Asakusa",
+          "Ebisu",
+          "Ginza",
+          "Ikebukuro",
+          "Iidabashi",
+          "Kanda",
+          "Meguro",
+          "Nakameguro",
+          "Nishiogikubo",
+          "Roppongi",
+          "Shibuya",
+          "Shimbashi",
+          "Shinagawa",
+          "Shinjuku",
+          "Suidobashi",
+          "Takadanobaba",
+          "Takadanobanba",
+          "Tokyo",
+          "Ueno",
+          "Yotsuya",
+        ],
       },
       kennelCodes: ["tokyo-h3"],
     },
@@ -3834,6 +3864,11 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 180,
+      // TablePress hareline strips past rows automatically (see comment in
+      // src/adapters/html-scraper/gold-coast-h3.ts:14-16). Without
+      // upcomingOnly, the reconcile step cancels live past events the
+      // moment they age out of the future-only table. (#1229)
+      config: { upcomingOnly: true },
       kennelCodes: ["gch3-au"],
     },
     {

--- a/scripts/audit-stale-cancellations.ts
+++ b/scripts/audit-stale-cancellations.ts
@@ -1,0 +1,170 @@
+/**
+ * Read-only fleet audit — surface other kennels likely affected by the
+ * same upcoming-only mis-config that triggered #1229 (Gold Coast TablePress
+ * past events stale-cancelled).
+ *
+ * Smoking-gun signature: `status = CANCELLED`, `adminCancelledAt IS NULL`
+ * (so this isn't an admin override), and the event date is in the past
+ * (so the cancellation can't be a real "the kennel cancelled the upcoming
+ * trail" decision — by definition, real cancellations happen BEFORE the
+ * date passes). Sources whose `config.upcomingOnly` is already true are
+ * excluded — they're using the correct mode and any past-cancellation
+ * there has another root cause.
+ *
+ * Usage:
+ *   npx tsx scripts/audit-stale-cancellations.ts
+ *   npx tsx scripts/audit-stale-cancellations.ts --since 2025-01-01   # filter window
+ *
+ * Output: a per-source table sorted by stale-cancellation count, plus a
+ * per-source list of sample event ids for spot-checking. The user reviews
+ * the output and decides which sources need follow-up `upcomingOnly: true`
+ * config additions (each shipped in its own PR to keep WS3 scope tight).
+ *
+ * Read-only — never writes to the database.
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const MIN_COUNT_TO_REPORT = 3;
+
+function parseSince(): Date {
+  const idx = process.argv.indexOf("--since");
+  if (idx === -1 || !process.argv[idx + 1]) {
+    // Default: 1 year back. The reconcile bug isn't time-bounded — older
+    // cancellations that fit the signature are equally suspicious — but
+    // 1 year is a reasonable cap for a quick-scan report.
+    const d = new Date();
+    d.setUTCFullYear(d.getUTCFullYear() - 1);
+    d.setUTCHours(0, 0, 0, 0);
+    return d;
+  }
+  const d = new Date(process.argv[idx + 1] + "T00:00:00Z");
+  if (Number.isNaN(d.getTime())) {
+    console.error(`Invalid --since date: ${process.argv[idx + 1]}`);
+    process.exit(1);
+  }
+  return d;
+}
+
+async function main() {
+  const since = parseSince();
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    // Filter sources up front so we never load full Source.config blobs
+    // (potentially large JSONB) per event. Build an in-memory lookup of
+    // eligible sources (those NOT already marked upcomingOnly) and keyed by id.
+    const allSources = await prisma.source.findMany({
+      select: { id: true, name: true, type: true, config: true },
+    });
+    type EligibleSource = { id: string; name: string; type: string };
+    const eligibleSources = new Map<string, EligibleSource>();
+    for (const s of allSources) {
+      const cfg = (s.config ?? {}) as { upcomingOnly?: boolean };
+      if (cfg.upcomingOnly === true) continue;
+      eligibleSources.set(s.id, { id: s.id, name: s.name, type: s.type });
+    }
+    if (eligibleSources.size === 0) {
+      console.log("All sources already use upcomingOnly: true. Nothing to audit.");
+      return;
+    }
+
+    // Now pull cancelled past events whose RawEvents reference an eligible
+    // source. Prisma's relational filter pushes the IN-list to the DB.
+    const candidates = await prisma.event.findMany({
+      where: {
+        status: "CANCELLED",
+        adminCancelledAt: null,
+        date: { gte: since, lt: today },
+        rawEvents: { some: { sourceId: { in: [...eligibleSources.keys()] } } },
+      },
+      select: {
+        id: true,
+        date: true,
+        kennelId: true,
+        kennel: { select: { kennelCode: true, shortName: true } },
+        rawEvents: { select: { sourceId: true } },
+      },
+    });
+
+    // Group by source. An event with multiple sources gets counted under
+    // each (the bug typically fires on a per-source basis).
+    type Bucket = {
+      sourceName: string;
+      sourceType: string;
+      kennels: Set<string>;
+      events: { id: string; date: string; kennel: string }[];
+    };
+    const bySource = new Map<string, Bucket>();
+
+    for (const event of candidates) {
+      const dateStr = event.date.toISOString().slice(0, 10);
+      const kennelLabel =
+        event.kennel?.shortName ?? event.kennel?.kennelCode ?? event.kennelId;
+      for (const r of event.rawEvents) {
+        const src = eligibleSources.get(r.sourceId);
+        if (!src) continue;
+        let bucket = bySource.get(r.sourceId);
+        if (!bucket) {
+          bucket = {
+            sourceName: src.name,
+            sourceType: src.type,
+            kennels: new Set(),
+            events: [],
+          };
+          bySource.set(r.sourceId, bucket);
+        }
+        bucket.kennels.add(kennelLabel);
+        bucket.events.push({ id: event.id, date: dateStr, kennel: kennelLabel });
+      }
+    }
+
+    // Filter to noisy buckets and sort by event count desc.
+    const reported = [...bySource.entries()]
+      .filter(([, b]) => b.events.length >= MIN_COUNT_TO_REPORT)
+      .sort((a, b) => b[1].events.length - a[1].events.length);
+
+    console.log(
+      `\nStale-cancellation audit (since ${since.toISOString().slice(0, 10)}): ` +
+        `${reported.length} suspect source(s) with ≥${MIN_COUNT_TO_REPORT} past CANCELLED events.\n`,
+    );
+
+    if (reported.length === 0) {
+      console.log("No suspects. Either the fleet is healthy or the bug is contained to upcomingOnly-eligible sources.");
+      return;
+    }
+
+    for (const [sourceId, b] of reported) {
+      const kennelList = [...b.kennels].sort().join(", ");
+      console.log(
+        `  ${b.events.length.toString().padStart(4)}  ${b.sourceType.padEnd(18)}  ${b.sourceName}`,
+      );
+      console.log(`         kennel(s): ${kennelList}`);
+      console.log(`         sourceId:  ${sourceId}`);
+      const samples = b.events.slice(0, 5);
+      console.log(`         sample(s): ${samples.map((s) => `${s.date} ${s.id}`).join(", ")}`);
+      console.log("");
+    }
+
+    console.log(
+      "Suggested follow-up: for each suspect source above, verify the source URL is upcoming-only " +
+        "(does the live page strip past rows?). If yes, add `config: { upcomingOnly: true }` to its " +
+        "row in prisma/seed-data/sources.ts in a follow-up PR.",
+    );
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/audit-stale-cancellations.ts
+++ b/scripts/audit-stale-cancellations.ts
@@ -53,6 +53,96 @@ function parseSince(): Date {
   return d;
 }
 
+type EligibleSource = { id: string; name: string; type: string };
+type Bucket = {
+  sourceName: string;
+  sourceType: string;
+  kennels: Set<string>;
+  events: { id: string; date: string; kennel: string; scrapes: number }[];
+};
+type CandidateEvent = {
+  id: string;
+  date: Date;
+  kennelId: string;
+  kennel: { kennelCode: string | null; shortName: string | null } | null;
+  rawEvents: { sourceId: string }[];
+};
+
+async function loadEligibleSources(prisma: PrismaClient): Promise<Map<string, EligibleSource>> {
+  const allSources = await prisma.source.findMany({
+    select: { id: true, name: true, type: true, config: true },
+  });
+  const eligible = new Map<string, EligibleSource>();
+  for (const s of allSources) {
+    const cfg = (s.config ?? {}) as { upcomingOnly?: boolean };
+    if (cfg.upcomingOnly === true) continue;
+    eligible.set(s.id, { id: s.id, name: s.name, type: s.type });
+  }
+  return eligible;
+}
+
+function bucketEvent(
+  event: CandidateEvent,
+  eligibleSources: Map<string, EligibleSource>,
+  bySource: Map<string, Bucket>,
+): void {
+  const dateStr = event.date.toISOString().slice(0, 10);
+  const kennelLabel =
+    event.kennel?.shortName ?? event.kennel?.kennelCode ?? event.kennelId;
+  // Per-source scrape count for this event — dedupes the rawEvents
+  // append-only history (Codex finding 3) and gates each event on the
+  // multi-scrape signature (Codex finding 2).
+  const scrapesPerSource = new Map<string, number>();
+  for (const r of event.rawEvents) {
+    scrapesPerSource.set(r.sourceId, (scrapesPerSource.get(r.sourceId) ?? 0) + 1);
+  }
+  for (const [sourceId, scrapes] of scrapesPerSource) {
+    const src = eligibleSources.get(sourceId);
+    if (!src || scrapes < MIN_SCRAPES_PER_EVENT) continue;
+    let bucket = bySource.get(sourceId);
+    if (!bucket) {
+      bucket = {
+        sourceName: src.name,
+        sourceType: src.type,
+        kennels: new Set(),
+        events: [],
+      };
+      bySource.set(sourceId, bucket);
+    }
+    bucket.kennels.add(kennelLabel);
+    bucket.events.push({ id: event.id, date: dateStr, kennel: kennelLabel, scrapes });
+  }
+}
+
+function printReport(reported: [string, Bucket][], since: Date): void {
+  const sinceStr = since.toISOString().slice(0, 10);
+  const header = `\nStale-cancellation shortlist (since ${sinceStr}): ${reported.length} suspect source(s) with ≥${MIN_COUNT_TO_REPORT} past CANCELLED events that were emitted ≥${MIN_SCRAPES_PER_EVENT}× before going silent.\n`;
+  console.log(header);
+  console.log(
+    "NOTE: This is a shortlist for human review, not a list of bugs. The multi-scrape " +
+      "signature is suggestive but not conclusive — you must spot-check each source's live URL " +
+      "to confirm it's future-only before adding `config.upcomingOnly: true` in a follow-up PR.\n",
+  );
+  if (reported.length === 0) {
+    console.log("No suspects.");
+    return;
+  }
+  for (const [sourceId, b] of reported) {
+    const kennelList = [...b.kennels].sort((a, c) => a.localeCompare(c)).join(", ");
+    const count = b.events.length.toString().padStart(4);
+    const type = b.sourceType.padEnd(18);
+    console.log(`  ${count}  ${type}  ${b.sourceName}`);
+    console.log(`         kennel(s): ${kennelList}`);
+    console.log(`         sourceId:  ${sourceId}`);
+    const samplesStr = b.events
+      .slice(0, 5)
+      .map((s) => `${s.date} ${s.id} (${s.scrapes} scrapes)`)
+      .join(", ");
+    console.log(`         sample(s): ${samplesStr}`);
+    console.log("");
+  }
+}
+
 async function main() {
   const since = parseSince();
   const today = new Date();
@@ -63,18 +153,7 @@ async function main() {
   const prisma = new PrismaClient({ adapter });
 
   try {
-    // Fetch all sources up front so we don't load full Source.config blobs
-    // per event during the main scan.
-    const allSources = await prisma.source.findMany({
-      select: { id: true, name: true, type: true, config: true },
-    });
-    type EligibleSource = { id: string; name: string; type: string };
-    const eligibleSources = new Map<string, EligibleSource>();
-    for (const s of allSources) {
-      const cfg = (s.config ?? {}) as { upcomingOnly?: boolean };
-      if (cfg.upcomingOnly === true) continue;
-      eligibleSources.set(s.id, { id: s.id, name: s.name, type: s.type });
-    }
+    const eligibleSources = await loadEligibleSources(prisma);
     if (eligibleSources.size === 0) {
       console.log("All sources already use upcomingOnly: true. Nothing to audit.");
       return;
@@ -92,84 +171,20 @@ async function main() {
         date: true,
         kennelId: true,
         kennel: { select: { kennelCode: true, shortName: true } },
-        // Ask Prisma to give us per-event scrape counts grouped by source —
-        // a single canonical event has multiple RawEvent rows in the
-        // append-only history table.
         rawEvents: { select: { sourceId: true } },
       },
     });
 
-    type Bucket = {
-      sourceName: string;
-      sourceType: string;
-      kennels: Set<string>;
-      events: { id: string; date: string; kennel: string; scrapes: number }[];
-    };
     const bySource = new Map<string, Bucket>();
-
     for (const event of candidates) {
-      const dateStr = event.date.toISOString().slice(0, 10);
-      const kennelLabel =
-        event.kennel?.shortName ?? event.kennel?.kennelCode ?? event.kennelId;
-      // Per-source scrape count for this event — dedupes the rawEvents
-      // append-only history (Codex finding 3) and gates each event on the
-      // multi-scrape signature (Codex finding 2).
-      const scrapesPerSource = new Map<string, number>();
-      for (const r of event.rawEvents) {
-        scrapesPerSource.set(r.sourceId, (scrapesPerSource.get(r.sourceId) ?? 0) + 1);
-      }
-      for (const [sourceId, scrapes] of scrapesPerSource) {
-        const src = eligibleSources.get(sourceId);
-        if (!src) continue;
-        if (scrapes < MIN_SCRAPES_PER_EVENT) continue;
-        let bucket = bySource.get(sourceId);
-        if (!bucket) {
-          bucket = {
-            sourceName: src.name,
-            sourceType: src.type,
-            kennels: new Set(),
-            events: [],
-          };
-          bySource.set(sourceId, bucket);
-        }
-        bucket.kennels.add(kennelLabel);
-        bucket.events.push({ id: event.id, date: dateStr, kennel: kennelLabel, scrapes });
-      }
+      bucketEvent(event, eligibleSources, bySource);
     }
 
     const reported = [...bySource.entries()]
       .filter(([, b]) => b.events.length >= MIN_COUNT_TO_REPORT)
       .sort((a, b) => b[1].events.length - a[1].events.length);
 
-    console.log(
-      `\nStale-cancellation shortlist (since ${since.toISOString().slice(0, 10)}): ` +
-        `${reported.length} suspect source(s) with ≥${MIN_COUNT_TO_REPORT} past CANCELLED ` +
-        `events that were emitted ≥${MIN_SCRAPES_PER_EVENT}× before going silent.\n`,
-    );
-    console.log(
-      "NOTE: This is a shortlist for human review, not a list of bugs. The multi-scrape " +
-        "signature is suggestive but not conclusive — you must spot-check each source's live URL " +
-        "to confirm it's future-only before adding `config.upcomingOnly: true` in a follow-up PR.\n",
-    );
-
-    if (reported.length === 0) {
-      console.log("No suspects.");
-      return;
-    }
-
-    for (const [sourceId, b] of reported) {
-      const kennelList = [...b.kennels].sort().join(", ");
-      console.log(
-        `  ${b.events.length.toString().padStart(4)}  ${b.sourceType.padEnd(18)}  ${b.sourceName}`,
-      );
-      console.log(`         kennel(s): ${kennelList}`);
-      console.log(`         sourceId:  ${sourceId}`);
-      const samples = b.events.slice(0, 5);
-      console.log(
-        `         sample(s): ${samples.map((s) => `${s.date} ${s.id} (${s.scrapes} scrapes)`).join(", ")}`,
-      );
-      console.log("");
-    }
+    printReport(reported, since);
   } finally {
     await prisma.$disconnect();
     await pool.end();

--- a/scripts/audit-stale-cancellations.ts
+++ b/scripts/audit-stale-cancellations.ts
@@ -3,22 +3,29 @@
  * same upcoming-only mis-config that triggered #1229 (Gold Coast TablePress
  * past events stale-cancelled).
  *
- * Smoking-gun signature: `status = CANCELLED`, `adminCancelledAt IS NULL`
- * (so this isn't an admin override), and the event date is in the past
- * (so the cancellation can't be a real "the kennel cancelled the upcoming
- * trail" decision — by definition, real cancellations happen BEFORE the
- * date passes). Sources whose `config.upcomingOnly` is already true are
- * excluded — they're using the correct mode and any past-cancellation
- * there has another root cause.
+ * Per Codex adversarial review (PR #1236): the simple "past + CANCELLED +
+ * no admin lock" heuristic is unsafe — adapter-driven legitimate
+ * cancellations (Meetup/iCal drop-on-ingest then reconcile-cancel) land
+ * in exactly that state. So this script doesn't claim to find bugs.
+ * Instead, it identifies a STRONGER pattern unique to stale-reconcile
+ * cancellation:
+ *
+ *   - Event is CANCELLED, past-dated, no admin override
+ *   - Event has 2+ RawEvent rows from a single source (the source
+ *     definitely emitted this event multiple times before going silent —
+ *     a real source-side cancellation typically drops the row entirely
+ *     after one or zero scrapes)
+ *   - Source's config does NOT already enable upcomingOnly
+ *
+ * Even that signal isn't proof — a source could legitimately re-confirm
+ * an event across multiple scrapes and then mark it cancelled. The
+ * output is a SHORTLIST for human review, not a directive. The operator
+ * is expected to spot-check the live source URL to confirm it's
+ * future-only before adding upcomingOnly: true to its row.
  *
  * Usage:
  *   npx tsx scripts/audit-stale-cancellations.ts
- *   npx tsx scripts/audit-stale-cancellations.ts --since 2025-01-01   # filter window
- *
- * Output: a per-source table sorted by stale-cancellation count, plus a
- * per-source list of sample event ids for spot-checking. The user reviews
- * the output and decides which sources need follow-up `upcomingOnly: true`
- * config additions (each shipped in its own PR to keep WS3 scope tight).
+ *   npx tsx scripts/audit-stale-cancellations.ts --since 2025-01-01
  *
  * Read-only — never writes to the database.
  */
@@ -28,13 +35,11 @@ import { PrismaClient } from "@/generated/prisma/client";
 import { createScriptPool } from "./lib/db-pool";
 
 const MIN_COUNT_TO_REPORT = 3;
+const MIN_SCRAPES_PER_EVENT = 2;
 
 function parseSince(): Date {
   const idx = process.argv.indexOf("--since");
   if (idx === -1 || !process.argv[idx + 1]) {
-    // Default: 1 year back. The reconcile bug isn't time-bounded — older
-    // cancellations that fit the signature are equally suspicious — but
-    // 1 year is a reasonable cap for a quick-scan report.
     const d = new Date();
     d.setUTCFullYear(d.getUTCFullYear() - 1);
     d.setUTCHours(0, 0, 0, 0);
@@ -58,9 +63,8 @@ async function main() {
   const prisma = new PrismaClient({ adapter });
 
   try {
-    // Filter sources up front so we never load full Source.config blobs
-    // (potentially large JSONB) per event. Build an in-memory lookup of
-    // eligible sources (those NOT already marked upcomingOnly) and keyed by id.
+    // Fetch all sources up front so we don't load full Source.config blobs
+    // per event during the main scan.
     const allSources = await prisma.source.findMany({
       select: { id: true, name: true, type: true, config: true },
     });
@@ -76,8 +80,6 @@ async function main() {
       return;
     }
 
-    // Now pull cancelled past events whose RawEvents reference an eligible
-    // source. Prisma's relational filter pushes the IN-list to the DB.
     const candidates = await prisma.event.findMany({
       where: {
         status: "CANCELLED",
@@ -90,17 +92,18 @@ async function main() {
         date: true,
         kennelId: true,
         kennel: { select: { kennelCode: true, shortName: true } },
+        // Ask Prisma to give us per-event scrape counts grouped by source —
+        // a single canonical event has multiple RawEvent rows in the
+        // append-only history table.
         rawEvents: { select: { sourceId: true } },
       },
     });
 
-    // Group by source. An event with multiple sources gets counted under
-    // each (the bug typically fires on a per-source basis).
     type Bucket = {
       sourceName: string;
       sourceType: string;
       kennels: Set<string>;
-      events: { id: string; date: string; kennel: string }[];
+      events: { id: string; date: string; kennel: string; scrapes: number }[];
     };
     const bySource = new Map<string, Bucket>();
 
@@ -108,10 +111,18 @@ async function main() {
       const dateStr = event.date.toISOString().slice(0, 10);
       const kennelLabel =
         event.kennel?.shortName ?? event.kennel?.kennelCode ?? event.kennelId;
+      // Per-source scrape count for this event — dedupes the rawEvents
+      // append-only history (Codex finding 3) and gates each event on the
+      // multi-scrape signature (Codex finding 2).
+      const scrapesPerSource = new Map<string, number>();
       for (const r of event.rawEvents) {
-        const src = eligibleSources.get(r.sourceId);
+        scrapesPerSource.set(r.sourceId, (scrapesPerSource.get(r.sourceId) ?? 0) + 1);
+      }
+      for (const [sourceId, scrapes] of scrapesPerSource) {
+        const src = eligibleSources.get(sourceId);
         if (!src) continue;
-        let bucket = bySource.get(r.sourceId);
+        if (scrapes < MIN_SCRAPES_PER_EVENT) continue;
+        let bucket = bySource.get(sourceId);
         if (!bucket) {
           bucket = {
             sourceName: src.name,
@@ -119,25 +130,30 @@ async function main() {
             kennels: new Set(),
             events: [],
           };
-          bySource.set(r.sourceId, bucket);
+          bySource.set(sourceId, bucket);
         }
         bucket.kennels.add(kennelLabel);
-        bucket.events.push({ id: event.id, date: dateStr, kennel: kennelLabel });
+        bucket.events.push({ id: event.id, date: dateStr, kennel: kennelLabel, scrapes });
       }
     }
 
-    // Filter to noisy buckets and sort by event count desc.
     const reported = [...bySource.entries()]
       .filter(([, b]) => b.events.length >= MIN_COUNT_TO_REPORT)
       .sort((a, b) => b[1].events.length - a[1].events.length);
 
     console.log(
-      `\nStale-cancellation audit (since ${since.toISOString().slice(0, 10)}): ` +
-        `${reported.length} suspect source(s) with ≥${MIN_COUNT_TO_REPORT} past CANCELLED events.\n`,
+      `\nStale-cancellation shortlist (since ${since.toISOString().slice(0, 10)}): ` +
+        `${reported.length} suspect source(s) with ≥${MIN_COUNT_TO_REPORT} past CANCELLED ` +
+        `events that were emitted ≥${MIN_SCRAPES_PER_EVENT}× before going silent.\n`,
+    );
+    console.log(
+      "NOTE: This is a shortlist for human review, not a list of bugs. The multi-scrape " +
+        "signature is suggestive but not conclusive — you must spot-check each source's live URL " +
+        "to confirm it's future-only before adding `config.upcomingOnly: true` in a follow-up PR.\n",
     );
 
     if (reported.length === 0) {
-      console.log("No suspects. Either the fleet is healthy or the bug is contained to upcomingOnly-eligible sources.");
+      console.log("No suspects.");
       return;
     }
 
@@ -149,15 +165,11 @@ async function main() {
       console.log(`         kennel(s): ${kennelList}`);
       console.log(`         sourceId:  ${sourceId}`);
       const samples = b.events.slice(0, 5);
-      console.log(`         sample(s): ${samples.map((s) => `${s.date} ${s.id}`).join(", ")}`);
+      console.log(
+        `         sample(s): ${samples.map((s) => `${s.date} ${s.id} (${s.scrapes} scrapes)`).join(", ")}`,
+      );
       console.log("");
     }
-
-    console.log(
-      "Suggested follow-up: for each suspect source above, verify the source URL is upcoming-only " +
-        "(does the live page strip past rows?). If yes, add `config: { upcomingOnly: true }` to its " +
-        "row in prisma/seed-data/sources.ts in a follow-up PR.",
-    );
   } finally {
     await prisma.$disconnect();
     await pool.end();

--- a/scripts/uncancel-gch3-stale.ts
+++ b/scripts/uncancel-gch3-stale.ts
@@ -8,15 +8,35 @@
  * `upcomingOnly: true` so reconcile no longer cancels past rows; this
  * script un-cancels the events that were already wrongly marked.
  *
- * Usage:
- *   npx tsx scripts/uncancel-gch3-stale.ts            # dry-run (default)
- *   npx tsx scripts/uncancel-gch3-stale.ts --apply    # write changes
+ * Per Codex adversarial review (PR #1236): bulk-status sweeps over a
+ * kennel's CANCELLED rows are unsafe because adapter-driven legitimate
+ * cancellations land in the same status. This script therefore requires
+ * an explicit allowlist of canonical Event IDs that the operator has
+ * verified (e.g. by querying `prisma studio` and confirming each row was
+ * cancelled by the upcomingOnly bug, not by the kennel).
  *
- * Filter rules — only events that match ALL of these are touched:
+ * Usage:
+ *   1. Identify candidate event IDs by running:
+ *        npx tsx scripts/uncancel-gch3-stale.ts --candidates
+ *      This prints a Gold-Coast-attributed shortlist (CANCELLED canonical
+ *      events whose only RawEvent source is the Gold Coast hareline AND
+ *      whose RawEvent history spans at least 2 scrapes — i.e. they were
+ *      previously confirmed before the stale-cancel fired). Review the
+ *      output by hand.
+ *   2. Build a comma-separated allowlist of IDs you want to restore and
+ *      run with --apply:
+ *        npx tsx scripts/uncancel-gch3-stale.ts --apply --ids "id1,id2,id3"
+ *
+ *   --apply without --ids is rejected.
+ *
+ * The candidate query enforces:
  *   - kennel.kennelCode = "gch3-au"
  *   - status = "CANCELLED"
  *   - adminCancelledAt IS NULL  (don't override admin-driven cancellations)
  *   - date < today              (the reconcile bug only affects past events)
+ *   - has at least one RawEvent from the Gold Coast Hareline source
+ *   - RawEvent history shows 2+ scrapes from the Gold Coast source
+ *     (proves the source previously emitted this event before dropping it)
  *
  * Closes #1229.
  */
@@ -26,74 +46,158 @@ import { PrismaClient } from "@/generated/prisma/client";
 import { createScriptPool } from "./lib/db-pool";
 
 const KENNEL_CODE = "gch3-au";
+const SOURCE_NAME = "Gold Coast H3 Hareline";
 const APPLY = process.argv.includes("--apply");
+const SHOW_CANDIDATES = process.argv.includes("--candidates");
+
+function parseIdsArg(): string[] | null {
+  const idx = process.argv.indexOf("--ids");
+  if (idx === -1 || !process.argv[idx + 1]) return null;
+  return process.argv[idx + 1]
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
 
 async function main() {
+  if (APPLY && SHOW_CANDIDATES) {
+    console.error("--apply and --candidates are mutually exclusive.");
+    process.exit(1);
+  }
+  const ids = parseIdsArg();
+  if (APPLY && (!ids || ids.length === 0)) {
+    console.error("--apply requires --ids \"id1,id2,...\". See script docs.");
+    process.exit(1);
+  }
+
   const pool = createScriptPool();
   const adapter = new PrismaPg(pool);
   const prisma = new PrismaClient({ adapter });
 
   try {
-    const kennel = await prisma.kennel.findFirst({
-      where: { kennelCode: KENNEL_CODE },
-      select: { id: true, shortName: true },
-    });
-    if (!kennel) {
-      console.error(`Kennel "${KENNEL_CODE}" not found in database.`);
-      process.exit(1);
-    }
-
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);
-
-    const candidates = await prisma.event.findMany({
-      where: {
-        kennelId: kennel.id,
-        status: "CANCELLED",
-        adminCancelledAt: null,
-        date: { lt: today },
-      },
-      select: {
-        id: true,
-        date: true,
-        runNumber: true,
-        title: true,
-        updatedAt: true,
-      },
-      orderBy: { date: "asc" },
-    });
-
-    if (candidates.length === 0) {
-      console.log("No stale-cancelled gch3-au events found. Nothing to do.");
+    if (APPLY && ids) {
+      await applyRestore(prisma, ids);
       return;
     }
 
+    // Default + --candidates: print the source-attributed shortlist.
+    const candidates = await findCandidates(prisma);
+    if (candidates.length === 0) {
+      console.log("No Gold-Coast-attributed stale-cancelled events found.");
+      return;
+    }
     console.log(
-      `Found ${candidates.length} stale-cancelled gch3-au event(s):\n`,
+      `Found ${candidates.length} candidate event(s) (Gold Coast attribution + multi-scrape history):\n`,
     );
-    for (const e of candidates) {
-      const dateStr = e.date.toISOString().slice(0, 10);
+    for (const c of candidates) {
       console.log(
-        `  ${e.id}  ${dateStr}  #${e.runNumber ?? "?"}  ${e.title ?? "(no title)"}`,
+        `  ${c.id}  ${c.dateStr}  #${c.runNumber ?? "?"}  scrapes=${c.scrapeCount}  ${c.title ?? "(no title)"}`,
       );
     }
-
-    if (!APPLY) {
-      console.log("\n--- DRY RUN ---");
-      console.log("Re-run with --apply to flip these events to CONFIRMED.");
-      return;
-    }
-
-    const ids = candidates.map((c) => c.id);
-    const result = await prisma.event.updateMany({
-      where: { id: { in: ids }, status: "CANCELLED", adminCancelledAt: null },
-      data: { status: "CONFIRMED" },
-    });
-    console.log(`\nFlipped ${result.count} event(s) back to CONFIRMED.`);
+    console.log("\nReview each row by hand, then run:");
+    console.log(
+      `  npx tsx scripts/uncancel-gch3-stale.ts --apply --ids "${candidates.map((c) => c.id).join(",")}"`,
+    );
   } finally {
     await prisma.$disconnect();
     await pool.end();
   }
+}
+
+interface Candidate {
+  id: string;
+  dateStr: string;
+  runNumber: number | null;
+  title: string | null;
+  scrapeCount: number;
+}
+
+async function findCandidates(prisma: PrismaClient): Promise<Candidate[]> {
+  const kennel = await prisma.kennel.findFirst({
+    where: { kennelCode: KENNEL_CODE },
+    select: { id: true },
+  });
+  if (!kennel) {
+    console.error(`Kennel "${KENNEL_CODE}" not found.`);
+    process.exit(1);
+  }
+  const source = await prisma.source.findFirst({
+    where: { name: SOURCE_NAME },
+    select: { id: true },
+  });
+  if (!source) {
+    console.error(`Source "${SOURCE_NAME}" not found.`);
+    process.exit(1);
+  }
+
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  const events = await prisma.event.findMany({
+    where: {
+      kennelId: kennel.id,
+      status: "CANCELLED",
+      adminCancelledAt: null,
+      date: { lt: today },
+      // Must have at least one RawEvent from the Gold Coast Hareline source
+      // — this is the source-attribution gate Codex flagged as missing.
+      rawEvents: { some: { sourceId: source.id } },
+    },
+    select: {
+      id: true,
+      date: true,
+      runNumber: true,
+      title: true,
+      rawEvents: {
+        where: { sourceId: source.id },
+        select: { id: true },
+      },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  // The smoking-gun signature of a stale-reconcile cancellation: the source
+  // emitted the event multiple times (2+ RawEvent rows), then stopped emitting
+  // it after the run date. A real source-side cancellation typically has
+  // exactly one RawEvent row (the source dropped it before re-scrape).
+  return events
+    .filter((e) => e.rawEvents.length >= 2)
+    .map((e) => ({
+      id: e.id,
+      dateStr: e.date.toISOString().slice(0, 10),
+      runNumber: e.runNumber,
+      title: e.title,
+      scrapeCount: e.rawEvents.length,
+    }));
+}
+
+async function applyRestore(prisma: PrismaClient, ids: string[]) {
+  // Re-validate every supplied ID against the same gating predicates the
+  // candidate query uses — never trust the operator's allowlist alone.
+  const candidates = await findCandidates(prisma);
+  const eligibleIds = new Set(candidates.map((c) => c.id));
+  const accepted = ids.filter((id) => eligibleIds.has(id));
+  const rejected = ids.filter((id) => !eligibleIds.has(id));
+  if (rejected.length > 0) {
+    console.warn(
+      `Rejected ${rejected.length} id(s) that don't match the candidate predicates:`,
+    );
+    for (const id of rejected) console.warn(`  ${id}`);
+  }
+  if (accepted.length === 0) {
+    console.error("No accepted ids — nothing to restore.");
+    process.exit(1);
+  }
+  console.log(`Restoring ${accepted.length} event(s) to CONFIRMED:`);
+  for (const id of accepted) {
+    const c = candidates.find((x) => x.id === id);
+    if (c) console.log(`  ${c.id}  ${c.dateStr}  #${c.runNumber ?? "?"}`);
+  }
+  const result = await prisma.event.updateMany({
+    where: { id: { in: accepted }, status: "CANCELLED", adminCancelledAt: null },
+    data: { status: "CONFIRMED" },
+  });
+  console.log(`\nFlipped ${result.count} event(s) back to CONFIRMED.`);
 }
 
 main().catch((err) => {

--- a/scripts/uncancel-gch3-stale.ts
+++ b/scripts/uncancel-gch3-stale.ts
@@ -1,0 +1,102 @@
+/**
+ * Repair past Gold Coast H3 (gch3-au) events that the reconcile pipeline
+ * stale-cancelled before #1229 added `upcomingOnly: true` to the source row.
+ *
+ * The Gold Coast TablePress hareline strips past rows automatically — every
+ * scrape after a run made the canonical Event look "missing from source",
+ * which the reconciler then marked CANCELLED. The fix flips
+ * `upcomingOnly: true` so reconcile no longer cancels past rows; this
+ * script un-cancels the events that were already wrongly marked.
+ *
+ * Usage:
+ *   npx tsx scripts/uncancel-gch3-stale.ts            # dry-run (default)
+ *   npx tsx scripts/uncancel-gch3-stale.ts --apply    # write changes
+ *
+ * Filter rules — only events that match ALL of these are touched:
+ *   - kennel.kennelCode = "gch3-au"
+ *   - status = "CANCELLED"
+ *   - adminCancelledAt IS NULL  (don't override admin-driven cancellations)
+ *   - date < today              (the reconcile bug only affects past events)
+ *
+ * Closes #1229.
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const KENNEL_CODE = "gch3-au";
+const APPLY = process.argv.includes("--apply");
+
+async function main() {
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const kennel = await prisma.kennel.findFirst({
+      where: { kennelCode: KENNEL_CODE },
+      select: { id: true, shortName: true },
+    });
+    if (!kennel) {
+      console.error(`Kennel "${KENNEL_CODE}" not found in database.`);
+      process.exit(1);
+    }
+
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+
+    const candidates = await prisma.event.findMany({
+      where: {
+        kennelId: kennel.id,
+        status: "CANCELLED",
+        adminCancelledAt: null,
+        date: { lt: today },
+      },
+      select: {
+        id: true,
+        date: true,
+        runNumber: true,
+        title: true,
+        updatedAt: true,
+      },
+      orderBy: { date: "asc" },
+    });
+
+    if (candidates.length === 0) {
+      console.log("No stale-cancelled gch3-au events found. Nothing to do.");
+      return;
+    }
+
+    console.log(
+      `Found ${candidates.length} stale-cancelled gch3-au event(s):\n`,
+    );
+    for (const e of candidates) {
+      const dateStr = e.date.toISOString().slice(0, 10);
+      console.log(
+        `  ${e.id}  ${dateStr}  #${e.runNumber ?? "?"}  ${e.title ?? "(no title)"}`,
+      );
+    }
+
+    if (!APPLY) {
+      console.log("\n--- DRY RUN ---");
+      console.log("Re-run with --apply to flip these events to CONFIRMED.");
+      return;
+    }
+
+    const ids = candidates.map((c) => c.id);
+    const result = await prisma.event.updateMany({
+      where: { id: { in: ids }, status: "CANCELLED", adminCancelledAt: null },
+      data: { status: "CONFIRMED" },
+    });
+    console.log(`\nFlipped ${result.count} event(s) back to CONFIRMED.`);
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { HarrierCentralAdapter, composeHcLocation, hcGeocodeFailed } from "./adapter";
+import {
+  HarrierCentralAdapter,
+  applyTitleFallback,
+  composeHcLocation,
+  hcGeocodeFailed,
+} from "./adapter";
 import type { HCEvent } from "./adapter";
 import { generateAccessToken, PUBLIC_HASHER_ID } from "./token";
 import type { Source } from "@/generated/prisma/client";
@@ -90,6 +95,113 @@ describe("composeHcLocation", () => {
     expect(
       composeHcLocation("Iron Horse", "Iron Horse Tavern Road, Morgantown, WV"),
     ).toBe("Iron Horse, Iron Horse Tavern Road, Morgantown, WV");
+  });
+
+  it("appends cityCountry when HC's geocoder failed (#1167)", () => {
+    // place === resolvable means HC couldn't resolve a real address; the
+    // downstream geocoder needs city context to avoid landing on a region
+    // default pin (e.g. Imperial Palace ~10km from Akabane).
+    expect(
+      composeHcLocation(
+        "JR Keihintohoku line, Akabane station, North Exit",
+        "JR Keihintohoku line, Akabane station, North Exit",
+        "Tokyo, Japan",
+      ),
+    ).toBe("JR Keihintohoku line, Akabane station, North Exit, Tokyo, Japan");
+  });
+
+  it("does not double-append when cityCountry already appears in the place text", () => {
+    // Some HC kennels include the city name in their place description; avoid
+    // "...Tokyo, Tokyo, Japan".
+    expect(
+      composeHcLocation("Shibuya, Tokyo", "Shibuya, Tokyo", "Tokyo, Japan"),
+    ).toBe("Shibuya, Tokyo");
+  });
+
+  it("does not append cityCountry when geocoder succeeded (different fields)", () => {
+    // The compose path with a real address never invokes the city-append
+    // branch — the address itself already disambiguates the location.
+    expect(
+      composeHcLocation(
+        "Apothecary Ale House",
+        "227 Spruce Street, Morgantown, WV",
+        "Morgantown, United States",
+      ),
+    ).toBe("Apothecary Ale House, 227 Spruce Street, Morgantown, WV");
+  });
+
+  it("does not append cityCountry when resolvable is bare coordinates (HC partial geocode)", () => {
+    // Real coords + descriptive place — coords already pin the meeting point,
+    // no need to enrich the user-facing string with city context.
+    expect(
+      composeHcLocation("Waseda exit", "35.713, 139.704", "Tokyo, Japan"),
+    ).toBe("Waseda exit");
+  });
+});
+
+describe("applyTitleFallback (#1166)", () => {
+  it("passes through real eventName when no aliases configured", () => {
+    expect(applyTitleFallback("Takadanobanba", 2577, {})).toBe("Takadanobanba");
+    expect(applyTitleFallback("50th Anniversary Run", 2585, {})).toBe(
+      "50th Anniversary Run",
+    );
+  });
+
+  it("substitutes synthesized title when eventName matches stale alias and defaultTitle is set", () => {
+    const config = {
+      defaultTitle: "Tokyo H3 Trail",
+      staleTitleAliases: ["Ikebukuro", "Akabane"],
+    };
+    expect(applyTitleFallback("Ikebukuro", 2580, config)).toBe(
+      "Tokyo H3 Trail #2580",
+    );
+    expect(applyTitleFallback("akabane", 2581, config)).toBe(
+      "Tokyo H3 Trail #2581",
+    );
+    // Whitespace-trimmed match.
+    expect(applyTitleFallback(" Ikebukuro ", 2582, config)).toBe(
+      "Tokyo H3 Trail #2582",
+    );
+  });
+
+  it("substitutes synthesized title when eventName is empty/missing and defaultTitle is set", () => {
+    const config = {
+      defaultTitle: "Tokyo H3 Trail",
+      staleTitleAliases: ["Ikebukuro"],
+    };
+    expect(applyTitleFallback(undefined, 2583, config)).toBe("Tokyo H3 Trail #2583");
+    expect(applyTitleFallback("", 2584, config)).toBe("Tokyo H3 Trail #2584");
+    expect(applyTitleFallback("   ", 2585, config)).toBe("Tokyo H3 Trail #2585");
+  });
+
+  it("returns undefined when alias matches but no defaultTitle is configured", () => {
+    // Lets sources opt into stale-name detection (clearing the bad title)
+    // without committing to a specific brand string yet.
+    expect(
+      applyTitleFallback("Ikebukuro", 2580, {
+        staleTitleAliases: ["Ikebukuro"],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when eventNumber is missing/zero and alias matches", () => {
+    // Synthesizing "Tokyo H3 Trail #0" or "Tokyo H3 Trail #undefined" is
+    // worse than an empty title — fall through to undefined.
+    const config = { defaultTitle: "Tokyo H3 Trail", staleTitleAliases: ["Ikebukuro"] };
+    expect(applyTitleFallback("Ikebukuro", 0, config)).toBeUndefined();
+    expect(applyTitleFallback("Ikebukuro", undefined, config)).toBeUndefined();
+    expect(applyTitleFallback("Ikebukuro", null, config)).toBeUndefined();
+  });
+
+  it("does not substitute a real trail name even when defaultTitle is configured", () => {
+    const config = {
+      defaultTitle: "Tokyo H3 Trail",
+      staleTitleAliases: ["Ikebukuro", "Akabane"],
+    };
+    expect(applyTitleFallback("50th Anniversary Run", 2585, config)).toBe(
+      "50th Anniversary Run",
+    );
+    expect(applyTitleFallback("Hashmas Eve", 2590, config)).toBe("Hashmas Eve");
   });
 });
 
@@ -421,12 +533,44 @@ describe("HarrierCentralAdapter", () => {
       expect(result.events).toHaveLength(1);
       expect(result.events[0].latitude).toBeUndefined();
       expect(result.events[0].longitude).toBeUndefined();
-      // Place text still flows through so the geocoder has something to use.
+      // Place text still flows through so the geocoder has something to use,
+      // enriched with eventCityAndCountry per #1167 so geocoding doesn't
+      // fall back to a region-default pin.
       expect(result.events[0].location).toBe(
-        "Ikebukuro (Yamanote) Metropolitan exit(west exit)",
+        "Ikebukuro (Yamanote) Metropolitan exit(west exit), Tokyo, Japan",
       );
       // Adapter signals the merge pipeline to bypass the existingCoords cache
       // short-circuit so previously-stored fallback pins get refreshed.
+      expect(result.events[0].dropCachedCoords).toBe(true);
+    });
+
+    it("substitutes neighborhood titles + appends city to transit-prose location (#1166 + #1167)", async () => {
+      // Tokyo H3 #2580 reproduction: HC returns the neighborhood as both
+      // eventName and locationOneLineDesc; resolvableLocation is verbatim and
+      // syncLat/Lng are HC's fallback region default. With the source seeded
+      // with defaultTitle + staleTitleAliases, the adapter should substitute a
+      // synthesized title AND enrich the location with city/country.
+      mockApiResponse([
+        buildHCEvent({
+          eventNumber: 2580,
+          eventName: "Akabane",
+          locationOneLineDesc: "JR Keihintohoku line, Akabane station, North Exit",
+          resolvableLocation: "JR Keihintohoku line, Akabane station, North Exit",
+        }),
+      ]);
+      const result = await adapter.fetch(
+        makeSource({
+          cityNames: "Tokyo",
+          defaultKennelTag: "tokyo-h3",
+          defaultTitle: "Tokyo H3 Trail",
+          staleTitleAliases: ["Ikebukuro", "Akabane", "Suidobashi"],
+        }),
+      );
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].title).toBe("Tokyo H3 Trail #2580");
+      expect(result.events[0].location).toBe(
+        "JR Keihintohoku line, Akabane station, North Exit, Tokyo, Japan",
+      );
       expect(result.events[0].dropCachedCoords).toBe(true);
     });
 

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -118,6 +118,34 @@ describe("composeHcLocation", () => {
     ).toBe("Shibuya, Tokyo");
   });
 
+  it("does not double-append for multi-word cities (Hong Kong, Kuala Lumpur, New York)", () => {
+    // Token-only checks would miss multi-word cities — the contiguous-
+    // subsequence walk catches "Hong Kong" inside "Wan Chai, Hong Kong".
+    expect(
+      composeHcLocation(
+        "Wan Chai, Hong Kong",
+        "Wan Chai, Hong Kong",
+        "Hong Kong, China",
+      ),
+    ).toBe("Wan Chai, Hong Kong");
+    expect(
+      composeHcLocation(
+        "Mid Valley, Kuala Lumpur",
+        "Mid Valley, Kuala Lumpur",
+        "Kuala Lumpur, Malaysia",
+      ),
+    ).toBe("Mid Valley, Kuala Lumpur");
+    expect(
+      composeHcLocation("Brooklyn, New York", "Brooklyn, New York", "New York, USA"),
+    ).toBe("Brooklyn, New York");
+  });
+
+  it("appends multi-word city when not already present in place text", () => {
+    expect(
+      composeHcLocation("Mong Kok MTR exit B2", "Mong Kok MTR exit B2", "Hong Kong, China"),
+    ).toBe("Mong Kok MTR exit B2, Hong Kong, China");
+  });
+
   it("does not append cityCountry when geocoder succeeded (different fields)", () => {
     // The compose path with a real address never invokes the city-append
     // branch — the address itself already disambiguates the location.

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -45,6 +45,20 @@ export interface HarrierCentralConfig {
   defaultKennelTag?: string;
   /** Kennel patterns for multi-kennel sources: [["regex", "kennelTag"], ...] */
   kennelPatterns?: [string, string][];
+  /**
+   * Human-readable fallback when an event's `eventName` is empty or matches
+   * `staleTitleAliases`. Combined with `eventNumber` to produce e.g.
+   * "Tokyo H3 Trail #2580". Mirrors the GCal `defaultTitle` pattern. (#1166)
+   */
+  defaultTitle?: string;
+  /**
+   * Title strings (case-insensitive, trimmed) that aren't real trail names —
+   * typically neighborhood / station names that surface from kennels who use
+   * the location field as a working title (Tokyo H3: "Ikebukuro", "Akabane").
+   * Matched events have title replaced by `${defaultTitle} #${eventNumber}`,
+   * or cleared to undefined when no defaultTitle is configured. (#1166)
+   */
+  staleTitleAliases?: readonly string[];
 }
 
 /**
@@ -144,7 +158,11 @@ export class HarrierCentralAdapter implements SourceAdapter {
       const startTime = timeMatch ? timeMatch[1] : undefined;
 
       let hares = stripTba(hcEvent.hares);
-      const location = composeHcLocation(hcEvent.locationOneLineDesc, hcEvent.resolvableLocation);
+      const location = composeHcLocation(
+        hcEvent.locationOneLineDesc,
+        hcEvent.resolvableLocation,
+        hcEvent.eventCityAndCountry,
+      );
 
       // Data-entry safety net: when a kennel user pastes the same text into
       // both the hare and location slots (observed on Tokyo H3 #2578, where
@@ -176,7 +194,8 @@ export class HarrierCentralAdapter implements SourceAdapter {
       // to the kennel website / other EventLinks when sourceUrl is null.
       const raw: RawEventData = {
         date: dateStr,
-        kennelTags: [kennelTag],        title: hcEvent.eventName || undefined,
+        kennelTags: [kennelTag],
+        title: applyTitleFallback(hcEvent.eventName, hcEvent.eventNumber, config),
         // Socials / "drinking practices" come back as eventNumber=0. Map that
         // sentinel to null (explicit clear) and positive values to the number;
         // anything else stays undefined so the merge UPDATE path preserves an
@@ -253,6 +272,39 @@ export function hcGeocodeFailed(
 }
 
 /**
+ * Apply title fallback rules from HarrierCentralConfig.
+ *
+ * Returns the synthesized "{defaultTitle} #{eventNumber}" when:
+ *   - eventName is empty/missing OR matches a `staleTitleAliases` entry, AND
+ *   - `defaultTitle` is configured AND `eventNumber > 0`.
+ * Returns `undefined` when an alias matches but no `defaultTitle` is set
+ * (so the canonical event renders via UI's run-number fallback).
+ * Otherwise returns the trimmed `eventName` unchanged.
+ *
+ * #1166 — Tokyo H3 surfaces neighborhood names ("Ikebukuro", "Akabane") as
+ * eventName; this lets the source seed a fixed list of placeholder strings
+ * to substitute without touching adapter code each time a new one appears.
+ */
+export function applyTitleFallback(
+  eventName: string | undefined,
+  eventNumber: number | undefined | null,
+  config: HarrierCentralConfig,
+): string | undefined {
+  const trimmed = eventName?.trim();
+  const aliases = config.staleTitleAliases;
+  const isStale =
+    !trimmed ||
+    (aliases?.some((a) => a.trim().toLowerCase() === trimmed.toLowerCase()) ?? false);
+
+  if (!isStale) return trimmed || undefined;
+
+  if (config.defaultTitle && typeof eventNumber === "number" && eventNumber > 0) {
+    return `${config.defaultTitle} #${eventNumber}`;
+  }
+  return undefined;
+}
+
+/**
  * Compose a location string from HC's two location fields.
  *
  * `locationOneLineDesc` is typically the venue/place name ("Iron Horse Tavern").
@@ -263,10 +315,18 @@ export function hcGeocodeFailed(
  *
  * Prefer "{place}, {full address}" when both fields carry real, distinct data
  * so hashers get street-level context in addition to the venue name (#907).
+ *
+ * `cityCountry` is `eventCityAndCountry` from the HC payload (e.g. "Tokyo, Japan").
+ * Appended ONLY when HC's geocoder failed (place === resolvable) AND the
+ * city/country isn't already present in the place text. Gives the merge-
+ * pipeline geocoder enough context to resolve a transit-prose place like
+ * "JR Keihintohoku line, Akabane station, North Exit" to the correct city
+ * instead of falling back to a region-default pin (#1167).
  */
 export function composeHcLocation(
   placeName: string | undefined,
   resolvable: string | undefined,
+  cityCountry?: string | undefined,
 ): string | undefined {
   const place = stripTba(placeName);
   const full = stripTba(resolvable);
@@ -279,7 +339,7 @@ export function composeHcLocation(
   if (!place && !addressShaped) return undefined;
   if (!addressShaped) return place;
   if (!place) return addressShaped;
-  if (place === addressShaped) return place;
+  if (place === addressShaped) return appendCityCountry(place, cityCountry);
   // Drop place when it duplicates the address — either as a complete comma
   // segment (e.g. place "Morgantown" inside "...Morgantown, WV") or as a
   // leading prefix of the address (e.g. place "227 Spruce Street, Morgantown"
@@ -292,6 +352,28 @@ export function composeHcLocation(
   if (segments.includes(placeLc)) return addressShaped;
   if (addressLc.startsWith(`${placeLc},`)) return addressShaped;
   return `${place}, ${addressShaped}`;
+}
+
+/**
+ * Append `, ${cityCountry}` to `place` when the city/country isn't already
+ * a substring of place (case-insensitive). Used to enrich transit-prose
+ * place names like "JR Keihintohoku line" with city context for the
+ * downstream geocoder. See #1167.
+ */
+function appendCityCountry(
+  place: string | undefined,
+  cityCountry: string | undefined,
+): string | undefined {
+  if (!place) return place;
+  const cc = cityCountry?.trim();
+  if (!cc) return place;
+  // Skip the append when ANY segment of cityCountry ("Tokyo, Japan" → "Tokyo",
+  // "Japan") already appears as a word inside place. Catches both the full
+  // form ("...Tokyo, Japan") and the common partial form ("Shibuya, Tokyo").
+  const placeTokens = new Set(place.toLowerCase().split(/\W+/).filter(Boolean));
+  const ccSegments = cc.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
+  if (ccSegments.some((seg) => placeTokens.has(seg))) return place;
+  return `${place}, ${cc}`;
 }
 
 /** Resolve kennel tag from HC event using pre-compiled config patterns */

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -367,12 +367,29 @@ function appendCityCountry(
   if (!place) return place;
   const cc = cityCountry?.trim();
   if (!cc) return place;
-  // Skip the append when ANY segment of cityCountry ("Tokyo, Japan" → "Tokyo",
-  // "Japan") already appears as a word inside place. Catches both the full
+  // Skip the append when ANY comma-segment of cityCountry already appears
+  // as a contiguous word sequence inside place. Tokenize both sides so
+  // multi-word cities like "Hong Kong" / "Kuala Lumpur" / "New York" match
+  // when the place text already names them. Catches both the full
   // form ("...Tokyo, Japan") and the common partial form ("Shibuya, Tokyo").
-  const placeTokens = new Set(place.toLowerCase().split(/\W+/).filter(Boolean));
+  const placeTokens = place.toLowerCase().split(/\W+/).filter(Boolean);
+  const placeTokenSet = new Set(placeTokens);
   const ccSegments = cc.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
-  if (ccSegments.some((seg) => placeTokens.has(seg))) return place;
+  const segmentInPlace = (seg: string) => {
+    const segTokens = seg.split(/\W+/).filter(Boolean);
+    if (segTokens.length === 0) return false;
+    if (segTokens.length === 1) return placeTokenSet.has(segTokens[0]);
+    // Multi-word: scan placeTokens for the contiguous subsequence.
+    for (let i = 0; i + segTokens.length <= placeTokens.length; i++) {
+      let hit = true;
+      for (let j = 0; j < segTokens.length; j++) {
+        if (placeTokens[i + j] !== segTokens[j]) { hit = false; break; }
+      }
+      if (hit) return true;
+    }
+    return false;
+  };
+  if (ccSegments.some(segmentInPlace)) return place;
   return `${place}, ${cc}`;
 }
 

--- a/src/adapters/html-scraper/frankfurt-hash.test.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
 import {
+  extractHaresFromText,
   parseJEMEvent,
   parseJEMEventList,
   stripHareSuffix,
@@ -175,6 +176,40 @@ describe("stripHareSuffix (#961)", () => {
     // run-# colon is left intact, only the trailing "Hare - …" is removed.
     expect(stripHareSuffix("FH3 Run #1639: Hare - Wankula")).toBe("FH3 Run #1639:");
     expect(stripHareSuffix("FH3 Run #1636: Hare - The Blacks")).toBe("FH3 Run #1636:");
+  });
+
+  it("strips trailing 'Hares:' (no name) so empty announcements don't ship the dangling label (#1228)", () => {
+    expect(stripHareSuffix("FH3 Run #2114 Hares:")).toBe("FH3 Run #2114");
+    expect(stripHareSuffix("FH3 Run #2114 Hare:")).toBe("FH3 Run #2114");
+    // With trailing whitespace.
+    expect(stripHareSuffix("FH3 Run #2115 Hares: ")).toBe("FH3 Run #2115");
+    // With dash separator + nothing after.
+    expect(stripHareSuffix("FH3 Run #2116 Hare -")).toBe("FH3 Run #2116");
+    // Bare 'Hares' word (no separator) at end.
+    expect(stripHareSuffix("FH3 Run #2117 Hares")).toBe("FH3 Run #2117");
+  });
+});
+
+describe("extractHaresFromText nav-menu denylist (#1228)", () => {
+  it("returns undefined when the captured value is a generic nav word", () => {
+    // Simulates a flattened detail-page HTML where the Hares anchor is
+    // followed by a sibling 'Home' menu link in the same line.
+    const html = `<div class="menu"><a href="/hares">Hares</a> | <a href="/home">Home</a></div>`;
+    expect(extractHaresFromText(html)).toBeUndefined();
+  });
+
+  it("rejects 'About', 'Calendar', and similar nav words", () => {
+    expect(extractHaresFromText("Hares: About")).toBeUndefined();
+    expect(extractHaresFromText("Hares: Calendar")).toBeUndefined();
+    expect(extractHaresFromText("Hare: Login")).toBeUndefined();
+  });
+
+  it("still returns real hare names that share characters with nav words", () => {
+    // "About Time" is a plausible hash name — only exact matches are
+    // suppressed, not substrings.
+    expect(extractHaresFromText("Hares: About Time")).toBe("About Time");
+    // Sanity: regular hare name unaffected.
+    expect(extractHaresFromText("Hares: Whore Durve")).toBe("Whore Durve");
   });
 });
 

--- a/src/adapters/html-scraper/frankfurt-hash.test.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.test.ts
@@ -178,6 +178,15 @@ describe("stripHareSuffix (#961)", () => {
     expect(stripHareSuffix("FH3 Run #1636: Hare - The Blacks")).toBe("FH3 Run #1636:");
   });
 
+  it("does NOT clobber themed titles where 'Hares' appears mid-string (PR #1236 review)", () => {
+    // The bare-label strip must be anchored at end-of-string so a mid-title
+    // "Hares" token (e.g. "Hares vs Hounds") survives unchanged.
+    expect(stripHareSuffix("Hares vs Hounds #2120")).toBe("Hares vs Hounds #2120");
+    expect(stripHareSuffix("FH3 Hare Raising Hell #2121")).toBe(
+      "FH3 Hare Raising Hell #2121",
+    );
+  });
+
   it("strips trailing 'Hares:' (no name) so empty announcements don't ship the dangling label (#1228)", () => {
     expect(stripHareSuffix("FH3 Run #2114 Hares:")).toBe("FH3 Run #2114");
     expect(stripHareSuffix("FH3 Run #2114 Hare:")).toBe("FH3 Run #2114");

--- a/src/adapters/html-scraper/frankfurt-hash.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.ts
@@ -64,11 +64,22 @@ function matchKennelTag(title: string, compiled: [RegExp, string][], defaultTag:
  * a malformed bare "Hare: X" passes through). See #961.
  */
 export function stripHareSuffix(title: string): string {
-  // Optional separator + greedy `.*` so a trailing label with no hare name
-  // ("FH3 Run #2114 Hares:") strips down to "FH3 Run #2114". The leading
-  // `\s+` requirement still prevents matching "FH3-Hare: X" with no
-  // whitespace before the keyword.
-  const stripped = title.replace(/\s+Hares?\s*[:-]?\s*.*$/i, "").trim();
+  // Two-pass strip: first the separator-required form ("Hares: Name",
+  // "Hare - Name"), then the trailing-bare-label form ("Hares:", "Hare").
+  // Splitting the patterns keeps the second pass anchored to end-of-string
+  // (`$`) so a mid-title token like "Hares vs Hounds" doesn't get clobbered
+  // by an over-broad `\s+Hares?\s*[:-]?\s*.*$` regex. The leading `\s+`
+  // requirement still prevents matching "FH3-Hare: X" with no whitespace
+  // before the keyword. (#1228 + PR #1236 review)
+  const stripped = title
+    // NOSONAR — anchored to end-of-string, fixed-literal keyword `Hares?`,
+    // single-class character runs (`\s+`, `[:-]`, `\s*`), and a greedy
+    // `.+$` tail. No nested quantifiers; backtracking is linear.
+    .replace(/\s+Hares?\s*[:-]\s*.+$/i, "")  // "Hares: <name>" / "Hare - <name>"
+    // NOSONAR — same shape, anchored at `$`. Optional separator + trailing
+    // whitespace cannot trigger super-linear backtracking.
+    .replace(/\s+Hares?\s*[:-]?\s*$/i, "")   // bare trailing "Hares:" / "Hare" / "Hare -"
+    .trim();
   return stripped || title;
 }
 

--- a/src/adapters/html-scraper/frankfurt-hash.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.ts
@@ -53,18 +53,34 @@ function matchKennelTag(title: string, compiled: [RegExp, string][], defaultTag:
 }
 
 /**
- * Strip a trailing " Hare(s): <name>" suffix from a title. The Frankfurt
- * JEM list page appends hare names to event titles (e.g.
- * "FH3 Run #2119 Hare: Whore Durve"), but the hare name is also extracted
- * into RawEventData.hares from the same `<li>` HTML — keeping it in the
- * title is pure duplication. Returns the original title if stripping
- * would leave nothing (defensive: a malformed bare "Hare: X" passes through).
- * See #961.
+ * Strip a trailing " Hare(s): <name>" / " Hare(s) - <name>" / bare " Hares:"
+ * suffix from a title. The Frankfurt JEM list page appends hare names to
+ * event titles (e.g. "FH3 Run #2119 Hare: Whore Durve"), but the hare name
+ * is also extracted into RawEventData.hares from the same `<li>` HTML —
+ * keeping it in the title is pure duplication. The trailing-only "Hares:"
+ * variant (no hare name) also gets stripped so empty announcements don't
+ * ship with the dangling label visible to users (#1228).
+ * Returns the original title if stripping would leave nothing (defensive:
+ * a malformed bare "Hare: X" passes through). See #961.
  */
 export function stripHareSuffix(title: string): string {
-  const stripped = title.replace(/\s+Hares?\s*[:-]\s*.+$/i, "").trim();
+  // Optional separator + greedy `.*` so a trailing label with no hare name
+  // ("FH3 Run #2114 Hares:") strips down to "FH3 Run #2114". The leading
+  // `\s+` requirement still prevents matching "FH3-Hare: X" with no
+  // whitespace before the keyword.
+  const stripped = title.replace(/\s+Hares?\s*[:-]?\s*.*$/i, "").trim();
   return stripped || title;
 }
+
+/**
+ * Generic nav-menu words that are sometimes captured by the Hares regex
+ * when it runs against a full detail-page HTML (Joomla menu blocks render
+ * "Hares" as a menu link followed by sibling links like "Home", "About", etc.
+ * After stripHtmlTags flattens those siblings into the same line, the
+ * non-greedy capture grabs the next nav word). Reject these explicitly so
+ * a bogus "Home" never overwrites the real `hares` field. (#1228)
+ */
+const HARES_NAV_DENYLIST = /^(?:Home|About|Contact|Calendar|Members|News|Blog|Login|Logout|Menu|Search|Categories|Archive|Events?|Trail\s*News)$/i;
 
 // ── Exported helpers (for unit testing) ──
 
@@ -164,11 +180,29 @@ export function extractHaresFromText(text: string): string | undefined {
   const m = /\bHares?\s*[:-]\s*([^\n.|]+?)(?=\s*(?:[.|\n]|\bby\b|$))/i.exec(cleaned);
   if (!m) return undefined;
   const value = m[1].trim();
-  return value || undefined;
+  if (!value) return undefined;
+  // Drop nav-menu fall-throughs like "Home" / "About" — these surface when
+  // the regex runs against a detail page and the Hares anchor is followed
+  // by a sibling menu link in the same flattened block. (#1228)
+  if (HARES_NAV_DENYLIST.test(value)) return undefined;
+  return value;
 }
 
 /** Cap the number of detail-page fetches per scrape so a long upcoming list can't fan out. */
 const MAX_ENRICH_PER_SCRAPE = 30;
+
+/**
+ * Narrow a JEM detail-page HTML string to its main-content subtree before
+ * the Hares regex runs. Joomla detail pages bundle a global nav/menu block
+ * whose flattened text can pollute the non-greedy capture group (a
+ * `Hares` link followed by a `Home` link). When no recognized content
+ * wrapper is present, return the original HTML so we never fail closed.
+ */
+function scopeToContent(html: string): string {
+  const $ = cheerio.load(html);
+  const main = $("main, .jem-event-content, article, .item-page").first();
+  return main.length ? (main.html() ?? html) : html;
+}
 
 /**
  * Fetch the event detail page for events missing hares and enrich them in place.
@@ -205,7 +239,12 @@ export async function enrichFrankfurtHares(
         continue;
       }
       const { html, event } = result.value;
-      const hares = extractHaresFromText(html);
+      // Scope to the main content area before regex extraction so global
+      // nav/menu blocks (whose flattened text can otherwise feed words like
+      // "Home" into the Hares regex's capture group) never reach
+      // extractHaresFromText. Falls back to the full page when the JEM
+      // template doesn't expose a recognized content wrapper. (#1228)
+      const hares = extractHaresFromText(scopeToContent(html));
       if (hares) {
         event.hares = hares;
         enriched++;

--- a/src/adapters/html-scraper/frankfurt-hash.ts
+++ b/src/adapters/html-scraper/frankfurt-hash.ts
@@ -71,14 +71,13 @@ export function stripHareSuffix(title: string): string {
   // by an over-broad `\s+Hares?\s*[:-]?\s*.*$` regex. The leading `\s+`
   // requirement still prevents matching "FH3-Hare: X" with no whitespace
   // before the keyword. (#1228 + PR #1236 review)
+  // Both regexes are end-anchored with single-class character runs and no
+  // nested quantifiers — Sonar S5852 fires conservatively on `\s+...\s*.+$`
+  // shapes but backtracking here is linear. NOSONAR markers are per-line
+  // (Sonar requires them on the same line as the flagged code).
   const stripped = title
-    // NOSONAR — anchored to end-of-string, fixed-literal keyword `Hares?`,
-    // single-class character runs (`\s+`, `[:-]`, `\s*`), and a greedy
-    // `.+$` tail. No nested quantifiers; backtracking is linear.
-    .replace(/\s+Hares?\s*[:-]\s*.+$/i, "")  // "Hares: <name>" / "Hare - <name>"
-    // NOSONAR — same shape, anchored at `$`. Optional separator + trailing
-    // whitespace cannot trigger super-linear backtracking.
-    .replace(/\s+Hares?\s*[:-]?\s*$/i, "")   // bare trailing "Hares:" / "Hare" / "Hare -"
+    .replace(/\s+Hares?\s*[:-]\s*.+$/i, "")  // NOSONAR S5852 — "Hares: <name>" / "Hare - <name>", linear
+    .replace(/\s+Hares?\s*[:-]?\s*$/i, "")   // NOSONAR S5852 — bare trailing "Hares:" / "Hare" / "Hare -", linear
     .trim();
   return stripped || title;
 }

--- a/src/adapters/html-scraper/gold-coast-h3.test.ts
+++ b/src/adapters/html-scraper/gold-coast-h3.test.ts
@@ -16,20 +16,20 @@ describe("gold-coast-h3 parseGoldCoastDate", () => {
 });
 
 describe("gold-coast-h3 parseGoldCoastRow", () => {
-  it("parses a full row", () => {
-    const e = parseGoldCoastRow(["April 13 2026", "2500", "Hierarchy", "Special Event"], URL);
+  it("parses a full row and synthesizes title with theme suffix (#1225)", () => {
+    const e = parseGoldCoastRow(["April 13 2026", "2500", "Hierarchy", "Birthday"], URL);
     expect(e).not.toBeNull();
     expect(e!.date).toBe("2026-04-13");
     expect(e!.runNumber).toBe(2500);
     expect(e!.kennelTags[0]).toBe("gch3-au");
     expect(e!.hares).toBe("Hierarchy");
-    expect(e!.title).toBe("Special Event");
+    expect(e!.title).toBe("Gold Coast H3 Run #2500 — Birthday");
   });
 
-  it("parses a row with no theme", () => {
+  it("synthesizes plain 'Run #N' title when theme column is empty (#1225)", () => {
     const e = parseGoldCoastRow(["April 20 2026", "2501", "Rug", ""], URL);
     expect(e).not.toBeNull();
-    expect(e!.title).toBeUndefined();
+    expect(e!.title).toBe("Gold Coast H3 Run #2501");
   });
 
   it("returns null on header row", () => {

--- a/src/adapters/html-scraper/gold-coast-h3.ts
+++ b/src/adapters/html-scraper/gold-coast-h3.ts
@@ -61,12 +61,18 @@ export function parseGoldCoastRow(
   const runNumber = Number.parseInt(runDigits, 10);
   const hareRaw = cells[2].trim();
   const themeRaw = cells[3].trim();
+  // Synthesize a stable title from the run number — the Theme column is a
+  // one-word annotation ("Birthday", "5pm Start") not a real trail name, and
+  // it's blank for most rows. Append the theme when present so the
+  // annotation surfaces without becoming the entire title. (#1225)
+  const baseTitle = `Gold Coast H3 Run #${runNumber}`;
+  const title = themeRaw ? `${baseTitle} — ${themeRaw}` : baseTitle;
   return {
     date,
     kennelTags: [KENNEL_TAG],
     runNumber,
     hares: hareRaw || undefined,
-    title: themeRaw || undefined,
+    title,
     sourceUrl,
   };
 }

--- a/src/adapters/html-scraper/klj-h3.test.ts
+++ b/src/adapters/html-scraper/klj-h3.test.ts
@@ -30,6 +30,12 @@ describe("cleanKljTitle", () => {
   it("synthesizes 'Run #N' when title is bare run number without trailer (#1213)", () => {
     expect(cleanKljTitle("Run # 528")).toBe("Run #528");
   });
+  it("preserves themed titles that legitimately start with 'near' (PR #1236 review)", () => {
+    // "near" alone isn't a venue marker — only "near <CapitalizedPlace>" is.
+    expect(cleanKljTitle("Run # 530, 6th October – Near Death Experience")).toBe(
+      "Near Death Experience",
+    );
+  });
 });
 
 describe("parseKljTitleDate", () => {
@@ -78,11 +84,26 @@ describe("parseKljBody", () => {
     expect(parsed.date).toBe("2026-11-01");
   });
 
-  it("strips leading 'probably' qualifier from runSite (#1213)", () => {
+  it("strips leading 'probably' qualifier from runSite + flags as tentative (#1213)", () => {
     const html = `<p>Run-site: probably Nambee estate</p>
 <p>Date: Sunday 1st November, 2026</p>`;
     const parsed = parseKljBody(html);
     expect(parsed.runSite).toBe("Nambee estate");
+    expect(parsed.runSiteTentative).toBe(true);
+  });
+
+  it("does not flag tentative when runSite has no 'probably' prefix", () => {
+    const html = `<p>Run-site: Nambee estate</p>
+<p>Date: Sunday 1st November, 2026</p>`;
+    const parsed = parseKljBody(html);
+    expect(parsed.runSite).toBe("Nambee estate");
+    expect(parsed.runSiteTentative).toBe(false);
+  });
+
+  it("leaves runSiteTentative undefined when runSite is missing", () => {
+    const parsed = parseKljBody(`<p>Date: Sunday 1st November, 2026</p>`);
+    expect(parsed.runSite).toBeUndefined();
+    expect(parsed.runSiteTentative).toBeUndefined();
   });
 
   it("handles empty body", () => {

--- a/src/adapters/html-scraper/klj-h3.test.ts
+++ b/src/adapters/html-scraper/klj-h3.test.ts
@@ -19,6 +19,17 @@ describe("cleanKljTitle", () => {
   it("leaves titles without a run prefix alone", () => {
     expect(cleanKljTitle("Welcome to KLJ H3")).toBe("Welcome to KLJ H3");
   });
+  it("synthesizes 'Run #N' when trailer is just '@ <venue>' (#1213)", () => {
+    expect(cleanKljTitle("Run # 526, 7th June @ Nambee estate, near Rasa")).toBe(
+      "Run #526",
+    );
+  });
+  it("synthesizes 'Run #N' when trailer is just a venue (no @ separator) (#1213)", () => {
+    expect(cleanKljTitle("Run # 527, 5th July near KL")).toBe("Run #527");
+  });
+  it("synthesizes 'Run #N' when title is bare run number without trailer (#1213)", () => {
+    expect(cleanKljTitle("Run # 528")).toBe("Run #528");
+  });
 });
 
 describe("parseKljTitleDate", () => {
@@ -65,6 +76,13 @@ describe("parseKljBody", () => {
     expect(parsed.runSite).toBeUndefined();
     expect(parsed.hares).toBeUndefined();
     expect(parsed.date).toBe("2026-11-01");
+  });
+
+  it("strips leading 'probably' qualifier from runSite (#1213)", () => {
+    const html = `<p>Run-site: probably Nambee estate</p>
+<p>Date: Sunday 1st November, 2026</p>`;
+    const parsed = parseKljBody(html);
+    expect(parsed.runSite).toBe("Nambee estate");
   });
 
   it("handles empty body", () => {

--- a/src/adapters/html-scraper/klj-h3.ts
+++ b/src/adapters/html-scraper/klj-h3.ts
@@ -74,7 +74,11 @@ export function parseKljBody(bodyHtml: string): {
     return value;
   };
 
-  const runSite = grab("Run[- ]?site");
+  // Strip a leading "probably " qualifier — KLJ posts use it to mark a
+  // tentative venue choice; the qualifier belongs in description, not in
+  // the location field that drives geocoding. (#1213)
+  const runSiteRaw = grab("Run[- ]?site");
+  const runSite = runSiteRaw?.replace(/^probably\s+/i, "").trim() || undefined;
   const travelTime = grab("Travel\\s*Time");
   const dateRaw = grab("Date");
   const hares = grab("Hares?");
@@ -113,20 +117,39 @@ export function parseKljTitleDate(title: string, publishDateIso: string): string
 }
 
 /**
- * Strip the "Run # N, <date> – " prefix from a post title, leaving just
+ * Strip the "Run # N, <date> ..." prefix from a post title, leaving just
  * the themed title (e.g. "Halloween @ TBD", "Christmas Party"). Also
  * decodes HTML entities left by WordPress (–, &amp;, …).
+ *
+ * When the post-date trailer is purely a venue (e.g.
+ * "Run # 526, 7th June @ Nambee estate, near Rasa") with no themed-event
+ * content, synthesize a clean "Run #N" string — the venue is already
+ * stored separately in `RawEventData.location`. (#1213)
  *
  * Exported for unit testing.
  */
 export function cleanKljTitle(title: string): string {
   const decoded = decodeEntities(title);
   const withoutTags = decoded.replace(/<[^>]+>/g, "").trim();
-  // Drop "Run # 532, 6th December 2026 - " / "Run # 524, 5th April – "
-  const m = /^Run\s*#\s*\d+\s*[,:\-]?\s*[0-9]{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?\s*[–\-]\s*(.+)$/i
-    .exec(withoutTags);
-  if (m) return m[1].trim();
-  return withoutTags;
+  const runMatch = /^Run\s*#\s*(\d+)/i.exec(withoutTags);
+  if (!runMatch) return withoutTags;
+  const runNum = runMatch[1];
+
+  let rest = withoutTags.slice(runMatch[0].length).trim();
+  // Drop the leading separator after the run number ("Run # 532, …").
+  rest = rest.replace(/^[,:\-–—]\s*/, "");
+  // Drop the date token ("6th December 2026 ", "1st November ").
+  rest = rest.replace(/^[0-9]{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?\s*/, "");
+  // Drop the dash separator between date and themed title ("– Christmas Party").
+  rest = rest.replace(/^[–\-—:]\s*/, "");
+
+  // Empty trailer or one that opens with a venue marker ("@ …", ", …",
+  // "near …") means the post title carries no themed name — synthesize
+  // a stable "Run #N" instead of leaving date + venue in the title.
+  if (!rest || /^[@,]\s/.test(rest) || /^near\s/i.test(rest)) {
+    return `Run #${runNum}`;
+  }
+  return rest;
 }
 
 /**

--- a/src/adapters/html-scraper/klj-h3.ts
+++ b/src/adapters/html-scraper/klj-h3.ts
@@ -39,7 +39,7 @@ const KENNEL_TAG = "kljhhh";
 const DEFAULT_START_TIME = "14:00"; // 2:00 PM, first Sunday monthly
 const TITLE_RUN_NUMBER_RE = /Run\s*#\s*(\d+)/i;
 const TITLE_DATE_RE =
-  /Run\s*#\s*\d+\s*[,:\-]?\s*([0-9]{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?)/i;
+  /Run\s*#\s*\d+\s*[,:\-]?\s*(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?)/i;
 
 /**
  * Extract labeled fields from an HTML post body.
@@ -54,6 +54,7 @@ const TITLE_DATE_RE =
 export function parseKljBody(bodyHtml: string): {
   date?: string;
   runSite?: string;
+  runSiteTentative?: boolean;
   travelTime?: string;
   hares?: string;
   coHares?: string;
@@ -76,8 +77,11 @@ export function parseKljBody(bodyHtml: string): {
 
   // Strip a leading "probably " qualifier — KLJ posts use it to mark a
   // tentative venue choice; the qualifier belongs in description, not in
-  // the location field that drives geocoding. (#1213)
+  // the location field that drives geocoding. We surface a separate
+  // `runSiteTentative` flag so parseKljPost can preserve the source's
+  // hedge in the description (#1213, PR #1236 review).
   const runSiteRaw = grab("Run[- ]?site");
+  const runSiteTentative = runSiteRaw ? /^probably\s+/i.test(runSiteRaw) : undefined;
   const runSite = runSiteRaw?.replace(/^probably\s+/i, "").trim() || undefined;
   const travelTime = grab("Travel\\s*Time");
   const dateRaw = grab("Date");
@@ -98,7 +102,16 @@ export function parseKljBody(bodyHtml: string): {
     startTime = parse12HourTime(normalized);
   }
 
-  return { date, runSite, travelTime, hares, coHares, startTime, registration };
+  return {
+    date,
+    runSite,
+    runSiteTentative,
+    travelTime,
+    hares,
+    coHares,
+    startTime,
+    registration,
+  };
 }
 
 /**
@@ -139,14 +152,17 @@ export function cleanKljTitle(title: string): string {
   // Drop the leading separator after the run number ("Run # 532, …").
   rest = rest.replace(/^[,:\-–—]\s*/, "");
   // Drop the date token ("6th December 2026 ", "1st November ").
-  rest = rest.replace(/^[0-9]{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?\s*/, "");
+  rest = rest.replace(/^\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?\s*/, "");
   // Drop the dash separator between date and themed title ("– Christmas Party").
   rest = rest.replace(/^[–\-—:]\s*/, "");
 
   // Empty trailer or one that opens with a venue marker ("@ …", ", …",
-  // "near …") means the post title carries no themed name — synthesize
-  // a stable "Run #N" instead of leaving date + venue in the title.
-  if (!rest || /^[@,]\s/.test(rest) || /^near\s/i.test(rest)) {
+  // "near <Place>") means the post title carries no themed name —
+  // synthesize a stable "Run #N" instead of leaving date + venue in the
+  // title. The "near" branch requires a following capitalized word so a
+  // legitimate themed title like "Near Death Experience" isn't rewritten
+  // (PR #1236 review).
+  if (!rest || /^[@,]\s/.test(rest) || /^near\s+[A-Z][a-zA-Z]+/.test(rest)) {
     return `Run #${runNum}`;
   }
   return rest;
@@ -189,9 +205,19 @@ export function parseKljPost(post: KljPostInput): ParseKljPostResult {
   if (!date) return { ok: false, reason: "no-date", title: rawTitle };
 
   const title = cleanKljTitle(rawTitle) || undefined;
-  const description = body.registration
-    ? `Registration: ${body.registration}`
-    : undefined;
+  // Combine the source's "probably <venue>" hedge (stripped from the
+  // location field for clean geocoding — see parseKljBody) with the
+  // registration line so neither signal is lost downstream. Sorted in
+  // a stable order so the merge fingerprint doesn't churn (#1213 +
+  // PR #1236 review).
+  const descriptionParts: string[] = [];
+  if (body.runSiteTentative && body.runSite) {
+    descriptionParts.push(`Run-site: probably ${body.runSite}`);
+  }
+  if (body.registration) {
+    descriptionParts.push(`Registration: ${body.registration}`);
+  }
+  const description = descriptionParts.length > 0 ? descriptionParts.join("\n") : undefined;
 
   // Merge hares + coHares into a single normalized field so the
   // fingerprint is stable across scrapes regardless of WP post-body

--- a/src/adapters/html-scraper/klj-h3.ts
+++ b/src/adapters/html-scraper/klj-h3.ts
@@ -41,7 +41,7 @@ const TITLE_RUN_NUMBER_RE = /Run\s*#\s*(\d+)/i;
 // Match the date trailer in two passes (split to keep regex complexity
 // under Sonar S5843's threshold of 20): first locate the run-number prefix
 // + optional separator, then capture the date token from what follows.
-const TITLE_RUN_PREFIX_RE = /Run\s*#\s*\d+\s*[,:\-]?\s*/i;
+const TITLE_RUN_PREFIX_RE = /Run\s*#\s*\d+\s*[,:-]?\s*/i;
 const TITLE_DATE_TOKEN_RE = /^(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?)/;
 
 /**

--- a/src/adapters/html-scraper/klj-h3.ts
+++ b/src/adapters/html-scraper/klj-h3.ts
@@ -38,8 +38,11 @@ import {
 const KENNEL_TAG = "kljhhh";
 const DEFAULT_START_TIME = "14:00"; // 2:00 PM, first Sunday monthly
 const TITLE_RUN_NUMBER_RE = /Run\s*#\s*(\d+)/i;
-const TITLE_DATE_RE =
-  /Run\s*#\s*\d+\s*[,:\-]?\s*(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?)/i;
+// Match the date trailer in two passes (split to keep regex complexity
+// under Sonar S5843's threshold of 20): first locate the run-number prefix
+// + optional separator, then capture the date token from what follows.
+const TITLE_RUN_PREFIX_RE = /Run\s*#\s*\d+\s*[,:\-]?\s*/i;
+const TITLE_DATE_TOKEN_RE = /^(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+(?:\s+\d{4})?)/;
 
 /**
  * Extract labeled fields from an HTML post body.
@@ -119,14 +122,19 @@ export function parseKljBody(bodyHtml: string): {
  * post's publish year as reference. Exported for unit testing.
  */
 export function parseKljTitleDate(title: string, publishDateIso: string): string | null {
-  const m = TITLE_DATE_RE.exec(title);
-  if (!m) return null;
+  // Two-pass split (per Sonar S5843): peel the "Run # N <sep>" prefix,
+  // then look for the date token at the start of what's left.
+  const prefixMatch = TITLE_RUN_PREFIX_RE.exec(title);
+  if (!prefixMatch) return null;
+  const trailer = title.slice(prefixMatch.index + prefixMatch[0].length);
+  const dateMatch = TITLE_DATE_TOKEN_RE.exec(trailer);
+  if (!dateMatch) return null;
   // Use the post's publish date as the chrono reference, with forwardDate so
   // year-less dates ("1st November") resolve to the *next* occurrence after
   // the post was published — KLJ posts are always published ahead of the
   // run they announce.
   const refDate = new Date(publishDateIso);
-  return chronoParseDate(m[1], "en-GB", refDate, { forwardDate: true });
+  return chronoParseDate(dateMatch[1], "en-GB", refDate, { forwardDate: true });
 }
 
 /**

--- a/src/adapters/html-scraper/lion-city-h3.test.ts
+++ b/src/adapters/html-scraper/lion-city-h3.test.ts
@@ -1,4 +1,10 @@
-import { parseLionCityTitle, parseLionCityBody, buildLionCityEvent } from "./lion-city-h3";
+import {
+  buildLionCityEvent,
+  extractThemedTitle,
+  parseLionCityBody,
+  parseLionCityTitle,
+  trimLocationNavText,
+} from "./lion-city-h3";
 
 describe("parseLionCityTitle", () => {
   it("parses run number with comma", () => {
@@ -23,6 +29,45 @@ describe("parseLionCityTitle", () => {
       runNumber: 2193,
       title: "Hash Run #2193",
     });
+  });
+});
+
+describe("extractThemedTitle (#1168)", () => {
+  it("returns the first short quoted string", () => {
+    expect(extractThemedTitle('Date: ...   "Thank God it is Good Friday"\nHare(s)...'))
+      .toBe("Thank God it is Good Friday");
+  });
+  it("supports curly quotes", () => {
+    expect(extractThemedTitle('blah “Hello World” foo')).toBe("Hello World");
+  });
+  it("returns undefined when no quoted text", () => {
+    expect(extractThemedTitle("plain post body without quotes")).toBeUndefined();
+  });
+  it("skips quoted text that contains a colon (caption-like)", () => {
+    // "Bus: 67, 71" is a caption, not a themed title.
+    expect(extractThemedTitle('something "Bus: 67, 71"')).toBeUndefined();
+  });
+  it("rejects too-short quoted text", () => {
+    expect(extractThemedTitle('a "b" c')).toBeUndefined();
+  });
+});
+
+describe("trimLocationNavText (#1169)", () => {
+  it("truncates at '. Note:'", () => {
+    expect(
+      trimLocationNavText("corner of Path 6 and 7. Note: Don't use Google Directions"),
+    ).toBe("corner of Path 6 and 7");
+  });
+  it("truncates at '. NB:'", () => {
+    expect(trimLocationNavText("Place X. NB: bring water")).toBe("Place X");
+  });
+  it("truncates at '. Tip:'", () => {
+    expect(trimLocationNavText("Place Y. Tip: park behind")).toBe("Place Y");
+  });
+  it("returns input unchanged when no nav block follows", () => {
+    expect(trimLocationNavText("Just an address, somewhere")).toBe(
+      "Just an address, somewhere",
+    );
   });
 });
 
@@ -56,6 +101,37 @@ describe("parseLionCityBody", () => {
     const html = "<p>Date: Friday, 02 January, 6 pm sharp.</p>";
     const out = parseLionCityBody(html, ref);
     expect(out.date).toBe("2026-01-02");
+  });
+
+  it("captures themed title from quoted body text (#1168)", () => {
+    const html = `<p>Date: Friday, 03 April, 6 pm sharp. "Thank God it is Good Friday"
+Hare(s): Lap Dog
+Map – Run Location: Somewhere</p>`;
+    const out = parseLionCityBody(html, ref);
+    expect(out.themeTitle).toBe("Thank God it is Good Friday");
+  });
+
+  it("captures themed title with curly quotes (#1168)", () => {
+    const html = `<p>Date: Friday, 03 April, 6 pm sharp. “The Jurong Innovation District Run”
+Hare(s): Lap Dog</p>`;
+    const out = parseLionCityBody(html, ref);
+    expect(out.themeTitle).toBe("The Jurong Innovation District Run");
+  });
+
+  it("leaves themeTitle undefined when no quoted line is present (#1168)", () => {
+    const html = `<p>Date: Friday, 03 April, 6 pm sharp.
+Hare(s): Lap Dog
+Map – Run Location: Somewhere</p>`;
+    const out = parseLionCityBody(html, ref);
+    expect(out.themeTitle).toBeUndefined();
+  });
+
+  it("truncates location at trailing nav-instructions (#1169)", () => {
+    const html = `<p>Date: Friday, 03 April, 6 pm sharp.
+Hare(s): Lap Dog
+Map – Run Location: corner of Christian Cemetery Path 6 and 7. Note: Don't use Google Directions. Use your own brain and a map (which could be Google Maps), Singapore</p>`;
+    const out = parseLionCityBody(html, ref);
+    expect(out.location).toBe("corner of Christian Cemetery Path 6 and 7");
   });
 
   it("does not leak the next-paragraph link label into hares when fields live in sibling <p> elements (#583)", () => {
@@ -102,6 +178,21 @@ Map – On On: A bar</p>`;
   it("returns null when body has no parseable date", () => {
     const event = buildLionCityEvent("Hash Run #999", "<p>No date here</p>", "https://x", new Date());
     expect(event).toBeNull();
+  });
+
+  it("uses themed body title when present, overrides generic Hash Run #N (#1168)", () => {
+    const html = `<p>Date: Friday, 03 April, 6 pm sharp. "Thank God it is Good Friday"
+Hare(s): Lap Dog
+Map – Run Location: Somewhere</p>`;
+    const event = buildLionCityEvent(
+      "Hash Run #2,193",
+      html,
+      "https://x",
+      new Date("2026-03-31T00:00:00Z"),
+    );
+    expect(event?.title).toBe("Thank God it is Good Friday");
+    // Run number still extracted from the post title.
+    expect(event?.runNumber).toBe(2193);
   });
 
   it("leaves description undefined when there is no on-on block", () => {

--- a/src/adapters/html-scraper/lion-city-h3.ts
+++ b/src/adapters/html-scraper/lion-city-h3.ts
@@ -47,6 +47,39 @@ interface ParsedBody {
   hares?: string;
   location?: string;
   onAfter?: string;
+  themeTitle?: string;
+}
+
+/**
+ * Extract a themed run title from the post body — Lion City posts often
+ * surface a thematic name in straight or curly quotes, e.g.
+ *   Date: Friday, 03 April, 6 pm sharp. "Thank God it is Good Friday"
+ *
+ * Returns the first quoted string of length 4–80 chars whose content has
+ * no `:` (to skip "MRT:" / "Bus:" prefixed captions). Returns undefined
+ * when no themed line is present so callers fall back to the generic
+ * "Hash Run #N" title. (#1168)
+ */
+export function extractThemedTitle(text: string): string | undefined {
+  // Match an open quote (straight or curly) followed by 4-80 chars of
+  // anything-but-quote, then a close quote. Curly quotes are U+201C/D.
+  const m = /["“”]([^"“”]{4,80})["“”]/.exec(text);
+  if (!m) return undefined;
+  const value = m[1].trim();
+  if (!value || value.includes(":")) return undefined;
+  return value;
+}
+
+/**
+ * Truncate a Lion City location string at trailing nav-instruction blocks.
+ * Production posts often inline advisory text after the location, e.g.
+ *   "corner of Christian Cemetery Path 6 and 7. Note: Don't use Google Directions..."
+ * The advisory is for hasher convenience but pollutes the geocoder input
+ * and the user-facing locationName. Truncate at the first `. Note:` /
+ * `. NB:` / `. Tip:` boundary. (#1169)
+ */
+export function trimLocationNavText(location: string): string {
+  return location.split(/\.\s*(?:Note|N\.?B\.?|Tip)\b/i)[0].trim();
 }
 
 /**
@@ -99,12 +132,15 @@ export function parseLionCityBody(html: string, referenceDate: Date): ParsedBody
 
   // Run Location: handles "Map – Run Location:", "Map - Run Location:", "Run Location:"
   const locMatch = /(?:Map\s*[–-]\s*)?Run\s*Location:\s*([^\n]+?)(?:\n|$)/i.exec(cleaned);
-  if (locMatch) result.location = locMatch[1].trim();
+  if (locMatch) result.location = trimLocationNavText(locMatch[1].trim()) || undefined;
 
   // On On: handles "Map – O n On:" (spaces, common WordPress artifact),
   // "Map - On On:", "On On:", "On-On:"
   const onOnMatch = /(?:Map\s*[–-]\s*)?O\s*n\s*[-–]?\s*On:\s*([^\n]+?)(?:\n|$)/i.exec(cleaned);
   if (onOnMatch) result.onAfter = onOnMatch[1].trim();
+
+  // Themed title in body quotes — surfaces e.g. "Thank God it is Good Friday".
+  result.themeTitle = extractThemedTitle(cleaned);
 
   return result;
 }
@@ -137,12 +173,15 @@ export function buildLionCityEvent(
   if (!parsedBody.date) return null;
   // RawEventData doesn't have an on-after field; surface it in description.
   const description = parsedBody.onAfter ? `On-On: ${parsedBody.onAfter}` : undefined;
+  // Prefer the themed title from the post body when present; fall back to
+  // the generic "Hash Run #N" derived from the post title. (#1168)
+  const finalTitle = parsedBody.themeTitle ?? parsedTitle.title;
   return {
     date: parsedBody.date,
     startTime: parsedBody.startTime,
     kennelTags: [KENNEL_TAG],
     runNumber: parsedTitle.runNumber,
-    title: parsedTitle.title,
+    title: finalTitle,
     description,
     hares: parsedBody.hares,
     location: parsedBody.location,


### PR DESCRIPTION
## Summary

Eight scraper bugs across five HashTracks adapters share a common shape: placeholder/leakage text bleeding into structured fields (`title`, `locationName`, `haresText`) and weak fallbacks when source columns are blank. WS3 ships fixes + tests + live-verification for all eight in a single PR.

| Adapter | Issue(s) |
|---|---|
| Tokyo H3 (HARRIER_CENTRAL) | #1166, #1167 |
| Lion City H3 | #1168, #1169 |
| KLJ H3 (adapter portion) | #1213 |
| Gold Coast H3 | #1225, #1229 |
| Frankfurt H3 + co-hosts | #1228 |

## Per-issue notes

### #1166 — Tokyo HC neighborhood titles
Extends `HarrierCentralConfig` with `defaultTitle` + `staleTitleAliases` (mirrors GCal). Tokyo source row seeds 22 known neighborhood placeholders (Ikebukuro, Akabane, Suidobashi, Shibuya, …). When `eventName` matches an alias OR is empty, adapter substitutes `${defaultTitle} #${eventNumber}`. Real trail names like "50th Anniversary Run" pass through unchanged.

### #1167 — Tokyo HC transit-prose location
`composeHcLocation` now takes an optional `cityCountry` (= HC's `eventCityAndCountry`). When HC's geocoder failed (place === resolvable), the composed location appends `, ${cityCountry}` so the merge-pipeline geocoder gets city context — eliminates the "Imperial Palace ~10 km from Akabane" pin drift documented in #957/#1167. Token-set intersection guards against double-append when the city is already in the place text.

### #1168 — Lion City themed titles
New `extractThemedTitle` helper scans the post body for the first quoted string (4–80 chars, no colon — caption-like). Live verify: titles now read "Return of the Phantom Hare Run" / "The Jurong Innovation District Run" instead of "Hash Run #2197".

### #1169 — Lion City nav instructions in location
New `trimLocationNavText` helper truncates location at `. Note:` / `. NB:` / `. Tip:` boundaries. Live verify: `corner of Christian Cemetery Path 6 and 7` is now stored without trailing "Don't use Google Directions…".

### #1213 — KLJ titles + 'probably' qualifier (adapter portion only)
- `cleanKljTitle`: extended to handle `@ <venue>` and `, <venue>` separators after the date. When the trailer is purely a venue, synthesizes `Run #N`. Themed titles like "Christmas Party" still pass through.
- `parseKljBody.runSite`: strips a leading `probably ` qualifier before assignment.

> **Cross-WS coordination:** This issue's profile-metadata half (founded year + logo for the KLJ kennel record) is owned by **WS4**. That WS4 PR will close the metadata half — do not reuse `Closes #1213` there since this PR will close it on merge.

### #1225 — Gold Coast title from Theme column
`parseGoldCoastRow` now synthesizes `Gold Coast H3 Run #N` (and appends `— Theme` when the column is non-empty), instead of using the bare Theme as the title or leaving it undefined.

### #1228 — Frankfurt 'Home' nav-leak + trailing 'Hares:'
- `stripHareSuffix`: regex updated to also strip bare trailing `Hares:` (no name).
- `extractHaresFromText`: denylists nav-menu words (Home, About, Contact, Calendar, …) so flattened detail-page nav blocks can't pollute the captured hare name.
- `enrichFrankfurtHares`: new `scopeToContent` helper narrows the detail-page HTML to `<main>` / `.jem-event-content` / `article` / `.item-page` before regex extraction — defense in depth.

### #1229 — Gold Coast past events stale-cancelled (config + repair + audit)
1. **Config fix:** Gold Coast source row gains `config: { upcomingOnly: true }`. Aligns with the file comment at `gold-coast-h3.ts:14-16` ("table is future-only — TablePress strips past rows automatically").
2. **One-shot repair:** `scripts/uncancel-gch3-stale.ts` flips already-mis-cancelled events back to CONFIRMED. Dry-run by default; `--apply` to write. Skips events with `adminCancelledAt` set so admin-driven cancellations stay locked.
3. **Fleet audit:** `scripts/audit-stale-cancellations.ts` (read-only) surfaces other kennels likely affected by the same root cause — past CANCELLED events with no admin override, scoped to sources that don't already use `upcomingOnly: true`. Output drives follow-up PRs to add the config to each suspect source. Run manually after merge.

## Live verification

All 5 adapters live-verified per `.claude/rules/live-verification.md`:

| Adapter | Events | Date range | Verification |
|---|---|---|---|
| Tokyo H3 | 7 | 2026-05-04 → 2026-07-20 | titles ↔ "Tokyo H3 Trail #2579" + real names like "50th Anniversary Run"; locations include Tokyo, Japan |
| Lion City H3 | 4 | 2026-04-17 → 2026-05-08 | themed titles: "Return of the Phantom Hare Run", "The Jurong Innovation District Run" |
| KLJ H3 | 20 | 2025-05-04 → 2026-12-06 | "Run #530" synthesized; "Christmas Party" / "Halloween @ TBD" themed titles preserved |
| Gold Coast H3 | 18 | 2026-05-04 → 2026-08-31 | titles "Gold Coast H3 Run #2503 — 5pm Start" |
| Frankfurt H3 | 20 | 2026-02-08 → 2026-05-28 | clean "FH3 Run #2121" titles; no nav leakage in hares |

## Test plan

- [x] Unit tests cover each new edge case (5895 tests passing, 125 across the 5 changed adapters)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean on changed files
- [x] Live verification against production URLs for all 5 adapters
- [ ] After merge: run `npx tsx scripts/uncancel-gch3-stale.ts --apply` to repair the 3 stale Gold Coast events flagged in #1229
- [ ] After merge: run `npx tsx scripts/audit-stale-cancellations.ts` to surface other sources needing `upcomingOnly: true` (file follow-up PRs per source)

## Reviewer notes

- `/codex:adversarial-review` could not be invoked from this session (only `/codex:rescue` is available as a skill; per memory `feedback_codex_review_command`, that one hangs on diff review). Please run it manually before merging.
- `/simplify` review was completed; three findings were addressed before push: eliminated `escapeRegExp` duplication via tokenized-Set rewrite; narrowed `enrichFrankfurtHares` scope to main-content subtree; restructured audit script to filter sources first to avoid loading full JSONB configs per row.

Closes #1166
Closes #1167
Closes #1168
Closes #1169
Closes #1213
Closes #1225
Closes #1228
Closes #1229

🤖 Generated with [Claude Code](https://claude.com/claude-code)