### PR TITLE
fix(adapters): cycle-2 audit-stream fixes for 8 GCal+phoenix bugs

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -650,8 +650,8 @@ export const SOURCES = [
         // Testigel" (placeholder) or "DST #814 - Full of Spunk" (assigned).
         // The hare follows the dash with no `Hare:` label (#1208).
         titleHarePattern: [
-          "Hare:?\\s+(.+?)(?:(?=[-\u2013\u2014]\\s*\\S)|\\s*$)",
-          "^DST\\s*#?\\s*\\d*\\s*-\\s*(.+)$",
+          String.raw`Hare:?\s+(.+?)(?:(?=[-\u2013\u2014]\s*\S)|\s*$)`,
+          String.raw`^DST\s*#?\s*\d*\s*-\s*(.+)$`,
         ],
       },
       kennelCodes: ["sh3-de", "dst-h3", "fm-stgt", "super-h3"],
@@ -3047,8 +3047,8 @@ export const SOURCES = [
         // Patterns fire only when description has no hares. The first
         // capture-group hit wins.
         titleHarePattern: [
-          "[.]\\s*Hare:\\s*(.+)$",
-          "^CH3\\s+\\d+\\s+-\\s+[^-]+\\s+-\\s+(.+)$",
+          String.raw`[.]\s*Hare:\s*(.+)$`,
+          String.raw`^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$`,
         ],
       },
       kennelCodes: ["ch3-dk", "ch4-dk", "rdh3"],

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -646,7 +646,13 @@ export const SOURCES = [
         // name after "Hare:" up to the neighborhood delimiter or end of
         // string. Middle-match: the full `Hare: X-` span is stripped from
         // the title so it reads "SH3 #880 - Degerloch". #807.
-        titleHarePattern: "Hare:?\\s+(.+?)(?:(?=[-\u2013\u2014]\\s*\\S)|\\s*$)",
+        // DST sub-kennel uses a different title shape: "DST # - Lucky
+        // Testigel" (placeholder) or "DST #814 - Full of Spunk" (assigned).
+        // The hare follows the dash with no `Hare:` label (#1208).
+        titleHarePattern: [
+          "Hare:?\\s+(.+?)(?:(?=[-\u2013\u2014]\\s*\\S)|\\s*$)",
+          "^DST\\s*#?\\s*\\d*\\s*-\\s*(.+)$",
+        ],
       },
       kennelCodes: ["sh3-de", "dst-h3", "fm-stgt", "super-h3"],
     },
@@ -793,7 +799,12 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "ah3",
-        titleHarePattern: String.raw`^(.+?)\s+AH3\s+#`,
+        // Title format: "{Hare1 and Hare2} - AH3 #N". Requiring an explicit
+        // " - " separator keeps the dash out of the capture group (#1210 —
+        // lazy match `(.+?)\s+AH3\s+#` left a trailing " -" on every event)
+        // and avoids matching titles where the slot before AH3 isn't a hare
+        // (e.g. titles whose author wrote a trail-type name in the hare slot).
+        titleHarePattern: String.raw`^(.+?)\s+-\s+AH3\s+#`,
       },
       kennelCodes: ["ah3"],
     },
@@ -3028,11 +3039,17 @@ export const SOURCES = [
           ["RDH3|Rabid", "rdh3"],
         ],
         defaultKennelTag: "ch3-dk",
-        // RDH3 events embed hares in the title: "RDH3 134 Walkers. Hare: Lust Jucie".
-        // The pattern only fires when the description has no hares. Empty "Hare:"
-        // (upcoming/TBA events) produce an empty capture group → skipped.
-        // CH3/CH4 don't use this format so the pattern won't match their titles.
-        titleHarePattern: "[.]\\s*Hare:\\s*(.+)$",
+        // Hares embedded in title — two formats coexist on this calendar:
+        // 1. RDH3: "RDH3 134 Walkers. Hare: Lust Jucie" — period + label.
+        // 2. CH3:  "CH3 2730 - Nørreport St - Mr Petit" — third dash segment
+        //    is the hare (#1209/#1221). The kennel slug `^CH3\b` constraint
+        //    keeps this pattern from misfiring on CH4/RDH3 titles.
+        // Patterns fire only when description has no hares. The first
+        // capture-group hit wins.
+        titleHarePattern: [
+          "[.]\\s*Hare:\\s*(.+)$",
+          "^CH3\\s+\\d+\\s+-\\s+[^-]+\\s+-\\s+(.+)$",
+        ],
       },
       kennelCodes: ["ch3-dk", "ch4-dk", "rdh3"],
     },
@@ -3801,6 +3818,13 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "capital-h3-au",
+        // Capital H3 packs hares + address into the title with no item.location:
+        // "Kwine & Mitzi 68 Macleay Street Turner." → hares "Kwine & Mitzi",
+        // location "68 Macleay Street Turner" (#1222). The hare pattern stops
+        // at the first run of digits (street number); the location pattern
+        // captures from that digit run to end-of-string.
+        titleHarePattern: String.raw`^(.+?)\s+\d+\s+[A-Z]`,
+        titleLocationPattern: String.raw`(\d+\s+.+?)\.?\s*$`,
       },
       kennelCodes: ["capital-h3-au"],
     },

--- a/scripts/live-verify-gcal-cycle2.ts
+++ b/scripts/live-verify-gcal-cycle2.ts
@@ -29,21 +29,41 @@ function formatSample(e: RawEventData): string {
   return `[${e.date} ${time}] ${titleSlice} | hares=${e.hares ?? "—"} | loc=${locSlice}${runSuffix}`;
 }
 
+/** Filter to events whose primary kennel tag is `tag`. */
+function byKennelTag(events: RawEventData[], tag: string): RawEventData[] {
+  return events.filter((e) => e.kennelTags[0] === tag);
+}
+
+/** Append up to `limit` formatted samples to `lines`, prefixed with `prefix`. */
+function appendSamples(lines: string[], events: RawEventData[], limit: number, prefix = ""): void {
+  for (const e of events.slice(0, limit)) lines.push(`  ${prefix}${formatSample(e)}`);
+}
+
+/** Group events by date and return only dates that have more than one event. */
+function datesWithMultiple(events: RawEventData[]): [string, RawEventData[]][] {
+  const byKey = new Map<string, RawEventData[]>();
+  for (const e of events) byKey.set(e.date, [...(byKey.get(e.date) ?? []), e]);
+  return [...byKey.entries()].filter(([, es]) => es.length > 1);
+}
+
+/** Common per-kennel-bucket summary line: "Tag: total (with hares: N)". */
+function bucketSummary(label: string, bucket: RawEventData[]): string {
+  return `${label}: ${bucket.length} (with hares: ${bucket.filter((e) => !!e.hares).length})`;
+}
+
 const TARGETS: VerifyTarget[] = [
   {
     sourceName: "Capital Hash Calendar",
     describe: "#1222 — split title into hares + location; reject 'venue TBC'",
     inspect: (events) => {
-      const withHares = events.filter((e) => !!e.hares);
-      const withLoc = events.filter((e) => !!e.location);
-      const venueTbc = events.filter((e) => /venue\s+TB[CDA]/i.test(JSON.stringify(e.hares ?? "") + JSON.stringify(e.location ?? "")));
+      const venueTbc = events.filter((e) => /venue\s+TB[CDA]/i.test(`${e.hares ?? ""} ${e.location ?? ""}`));
       const lines = [
         `events: ${events.length}`,
-        `with hares: ${withHares.length}`,
-        `with location: ${withLoc.length}`,
+        `with hares: ${events.filter((e) => !!e.hares).length}`,
+        `with location: ${events.filter((e) => !!e.location).length}`,
         `'venue TBC' surviving in any field: ${venueTbc.length} (expect 0)`,
       ];
-      for (const e of events.slice(0, 6)) lines.push(`  ${formatSample(e)}`);
+      appendSamples(lines, events, 6);
       return lines;
     },
   },
@@ -56,7 +76,7 @@ const TARGETS: VerifyTarget[] = [
         `events: ${events.length}`,
         `events with trailing-dash hares: ${trailingDash.length} (expect 0)`,
       ];
-      for (const e of events.slice(0, 6)) lines.push(`  ${formatSample(e)}`);
+      appendSamples(lines, events, 6);
       return lines;
     },
   },
@@ -64,10 +84,9 @@ const TARGETS: VerifyTarget[] = [
     sourceName: "GLH3 Google Calendar",
     describe: "#1212 — Co-Hare merge + annotation strip",
     inspect: (events) => {
-      const lines = [`events: ${events.length}`];
-      for (const e of events.slice(0, 8)) lines.push(`  ${formatSample(e)}`);
-      // Look for annotation leakage
       const annotations = events.filter((e) => e.hares && / - [a-z]/.test(e.hares));
+      const lines = [`events: ${events.length}`];
+      appendSamples(lines, events, 8);
       lines.push(`hares with ' - lowercase' annotation tail: ${annotations.length} (expect 0)`);
       return lines;
     },
@@ -77,23 +96,18 @@ const TARGETS: VerifyTarget[] = [
     describe: "#1199 — drops Giggity all-day placeholder when timed sibling exists",
     kennelTagFilter: "giggity-h3",
     inspect: (events, diag) => {
-      const giggity = events.filter((e) => e.kennelTags[0] === "giggity-h3");
-      const cunth = events.filter((e) => e.kennelTags[0] === "cunth3-wa");
+      const giggity = byKennelTag(events, "giggity-h3");
+      const cunth = byKennelTag(events, "cunth3-wa");
+      const collapsedRaw = diag?.allDayCollapsed;
+      const collapsed = typeof collapsedRaw === "number" ? collapsedRaw : 0;
       const lines = [
         `total events: ${events.length}`,
         `Giggity events: ${giggity.length}`,
         `CUNTh events (all-day overrides should still survive): ${cunth.length}`,
-        `diag.allDayCollapsed: ${typeof diag?.allDayCollapsed === "number" ? diag.allDayCollapsed : 0}`,
+        `diag.allDayCollapsed: ${collapsed}`,
       ];
-      for (const e of giggity.slice(0, 6)) lines.push(`  ${formatSample(e)}`);
-      // Check: any (giggity-h3, date) with both timed + all-day? Should not exist post-dedup.
-      const byKey = new Map<string, RawEventData[]>();
-      for (const e of giggity) {
-        const k = e.date;
-        byKey.set(k, [...(byKey.get(k) ?? []), e]);
-      }
-      const dupDates = [...byKey.entries()].filter(([, es]) => es.length > 1);
-      lines.push(`Giggity dates with multiple events surviving: ${dupDates.length} (expect 0)`);
+      appendSamples(lines, giggity, 6);
+      lines.push(`Giggity dates with multiple events surviving: ${datesWithMultiple(giggity).length} (expect 0)`);
       return lines;
     },
   },
@@ -101,15 +115,11 @@ const TARGETS: VerifyTarget[] = [
     sourceName: "Stuttgart H3 Google Calendar",
     describe: "#1208 — DST hares from 'DST # - Hare' format; SH3 still works",
     inspect: (events) => {
-      const dst = events.filter((e) => e.kennelTags[0] === "dst-h3");
-      const sh3 = events.filter((e) => e.kennelTags[0] === "sh3-de");
-      const lines = [
-        `events: ${events.length}`,
-        `DST: ${dst.length} (with hares: ${dst.filter((e) => !!e.hares).length})`,
-        `SH3: ${sh3.length} (with hares: ${sh3.filter((e) => !!e.hares).length})`,
-      ];
-      for (const e of dst.slice(0, 4)) lines.push(`  DST ${formatSample(e)}`);
-      for (const e of sh3.slice(0, 4)) lines.push(`  SH3 ${formatSample(e)}`);
+      const dst = byKennelTag(events, "dst-h3");
+      const sh3 = byKennelTag(events, "sh3-de");
+      const lines = [`events: ${events.length}`, bucketSummary("DST", dst), bucketSummary("SH3", sh3)];
+      appendSamples(lines, dst, 4, "DST ");
+      appendSamples(lines, sh3, 4, "SH3 ");
       return lines;
     },
   },
@@ -117,15 +127,11 @@ const TARGETS: VerifyTarget[] = [
     sourceName: "Copenhagen H3 Google Calendar",
     describe: "#1209/#1221 — CH3 third-dash-segment hare; RDH3 still works",
     inspect: (events) => {
-      const ch3 = events.filter((e) => e.kennelTags[0] === "ch3-dk");
-      const rdh3 = events.filter((e) => e.kennelTags[0] === "rdh3");
-      const lines = [
-        `events: ${events.length}`,
-        `CH3: ${ch3.length} (with hares: ${ch3.filter((e) => !!e.hares).length})`,
-        `RDH3: ${rdh3.length} (with hares: ${rdh3.filter((e) => !!e.hares).length})`,
-      ];
-      for (const e of ch3.slice(0, 4)) lines.push(`  CH3 ${formatSample(e)}`);
-      for (const e of rdh3.slice(0, 3)) lines.push(`  RDH3 ${formatSample(e)}`);
+      const ch3 = byKennelTag(events, "ch3-dk");
+      const rdh3 = byKennelTag(events, "rdh3");
+      const lines = [`events: ${events.length}`, bucketSummary("CH3", ch3), bucketSummary("RDH3", rdh3)];
+      appendSamples(lines, ch3, 4, "CH3 ");
+      appendSamples(lines, rdh3, 3, "RDH3 ");
       return lines;
     },
   },

--- a/scripts/live-verify-gcal-cycle2.ts
+++ b/scripts/live-verify-gcal-cycle2.ts
@@ -1,0 +1,168 @@
+/**
+ * Live verification for the cycle-2 audit-stream adapter fixes
+ * (#1199, #1208, #1209, #1210, #1212, #1221, #1222). Hits each affected
+ * calendar's public Google Calendar API with the freshly-edited adapter +
+ * seed config and prints a digest per source.
+ *
+ * Run: `set -a && source .env && set +a && npx tsx scripts/live-verify-gcal-cycle2.ts`
+ *
+ * Read-only — does not mutate the DB.
+ */
+import "dotenv/config";
+import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
+import type { RawEventData } from "@/adapters/types";
+import { SOURCES } from "../prisma/seed-data/sources";
+import type { Source } from "@/generated/prisma/client";
+
+interface VerifyTarget {
+  sourceName: string;
+  describe: string;
+  kennelTagFilter?: string;
+  inspect: (events: RawEventData[], diag: Record<string, unknown> | undefined) => string[];
+}
+
+function formatSample(e: RawEventData): string {
+  return `[${e.date} ${e.startTime ?? "all-day"}] ${(e.title ?? "").slice(0, 60)} | hares=${e.hares ?? "—"} | loc=${(e.location ?? "—").slice(0, 50)}${e.runNumber ? ` | run=${e.runNumber}` : ""}`;
+}
+
+const TARGETS: VerifyTarget[] = [
+  {
+    sourceName: "Capital Hash Calendar",
+    describe: "#1222 — split title into hares + location; reject 'venue TBC'",
+    inspect: (events) => {
+      const withHares = events.filter((e) => !!e.hares);
+      const withLoc = events.filter((e) => !!e.location);
+      const venueTbc = events.filter((e) => /venue\s+TB[CDA]/i.test(JSON.stringify(e.hares ?? "") + JSON.stringify(e.location ?? "")));
+      const lines = [
+        `events: ${events.length}`,
+        `with hares: ${withHares.length}`,
+        `with location: ${withLoc.length}`,
+        `'venue TBC' surviving in any field: ${venueTbc.length} (expect 0)`,
+      ];
+      for (const e of events.slice(0, 6)) lines.push(`  ${formatSample(e)}`);
+      return lines;
+    },
+  },
+  {
+    sourceName: "Austin H3 Calendar",
+    describe: "#1210 — no trailing ' -' on hares; tightened pattern",
+    inspect: (events) => {
+      const trailingDash = events.filter((e) => e.hares && /[-–—]\s*$/.test(e.hares));
+      const lines = [
+        `events: ${events.length}`,
+        `events with trailing-dash hares: ${trailingDash.length} (expect 0)`,
+      ];
+      for (const e of events.slice(0, 6)) lines.push(`  ${formatSample(e)}`);
+      return lines;
+    },
+  },
+  {
+    sourceName: "GLH3 Google Calendar",
+    describe: "#1212 — Co-Hare merge + annotation strip",
+    inspect: (events) => {
+      const lines = [`events: ${events.length}`];
+      for (const e of events.slice(0, 8)) lines.push(`  ${formatSample(e)}`);
+      // Look for annotation leakage
+      const annotations = events.filter((e) => e.hares && / - [a-z]/.test(e.hares));
+      lines.push(`hares with ' - lowercase' annotation tail: ${annotations.length} (expect 0)`);
+      return lines;
+    },
+  },
+  {
+    sourceName: "WA Hash Google Calendar",
+    describe: "#1199 — drops Giggity all-day placeholder when timed sibling exists",
+    kennelTagFilter: "giggity-h3",
+    inspect: (events, diag) => {
+      const giggity = events.filter((e) => e.kennelTags[0] === "giggity-h3");
+      const cunth = events.filter((e) => e.kennelTags[0] === "cunth3-wa");
+      const lines = [
+        `total events: ${events.length}`,
+        `Giggity events: ${giggity.length}`,
+        `CUNTh events (all-day overrides should still survive): ${cunth.length}`,
+        `diag.allDayCollapsed: ${diag?.allDayCollapsed ?? "0"}`,
+      ];
+      for (const e of giggity.slice(0, 6)) lines.push(`  ${formatSample(e)}`);
+      // Check: any (giggity-h3, date) with both timed + all-day? Should not exist post-dedup.
+      const byKey = new Map<string, RawEventData[]>();
+      for (const e of giggity) {
+        const k = e.date;
+        byKey.set(k, [...(byKey.get(k) ?? []), e]);
+      }
+      const dupDates = [...byKey.entries()].filter(([, es]) => es.length > 1);
+      lines.push(`Giggity dates with multiple events surviving: ${dupDates.length} (expect 0)`);
+      return lines;
+    },
+  },
+  {
+    sourceName: "Stuttgart H3 Google Calendar",
+    describe: "#1208 — DST hares from 'DST # - Hare' format; SH3 still works",
+    inspect: (events) => {
+      const dst = events.filter((e) => e.kennelTags[0] === "dst-h3");
+      const sh3 = events.filter((e) => e.kennelTags[0] === "sh3-de");
+      const lines = [
+        `events: ${events.length}`,
+        `DST: ${dst.length} (with hares: ${dst.filter((e) => !!e.hares).length})`,
+        `SH3: ${sh3.length} (with hares: ${sh3.filter((e) => !!e.hares).length})`,
+      ];
+      for (const e of dst.slice(0, 4)) lines.push(`  DST ${formatSample(e)}`);
+      for (const e of sh3.slice(0, 4)) lines.push(`  SH3 ${formatSample(e)}`);
+      return lines;
+    },
+  },
+  {
+    sourceName: "Copenhagen H3 Google Calendar",
+    describe: "#1209/#1221 — CH3 third-dash-segment hare; RDH3 still works",
+    inspect: (events) => {
+      const ch3 = events.filter((e) => e.kennelTags[0] === "ch3-dk");
+      const rdh3 = events.filter((e) => e.kennelTags[0] === "rdh3");
+      const lines = [
+        `events: ${events.length}`,
+        `CH3: ${ch3.length} (with hares: ${ch3.filter((e) => !!e.hares).length})`,
+        `RDH3: ${rdh3.length} (with hares: ${rdh3.filter((e) => !!e.hares).length})`,
+      ];
+      for (const e of ch3.slice(0, 4)) lines.push(`  CH3 ${formatSample(e)}`);
+      for (const e of rdh3.slice(0, 3)) lines.push(`  RDH3 ${formatSample(e)}`);
+      return lines;
+    },
+  },
+];
+
+async function main() {
+  if (!process.env.GOOGLE_CALENDAR_API_KEY) {
+    throw new Error("GOOGLE_CALENDAR_API_KEY not set — source .env first");
+  }
+  const adapter = new GoogleCalendarAdapter();
+  let failures = 0;
+  for (const target of TARGETS) {
+    const seedRow = SOURCES.find((s) => s.name === target.sourceName);
+    if (!seedRow) {
+      console.log(`\n## ${target.sourceName} — NOT FOUND IN SEED`);
+      failures++;
+      continue;
+    }
+    const source = {
+      id: "stub",
+      name: seedRow.name,
+      url: seedRow.url,
+      type: seedRow.type as Source["type"],
+      enabled: true,
+      config: (seedRow as { config?: unknown }).config ?? null,
+    } as unknown as Source;
+    console.log(`\n## ${target.sourceName}`);
+    console.log(`   ${target.describe}`);
+    try {
+      const result = await adapter.fetch(source, { days: 365 });
+      console.log(`   diag: ${JSON.stringify(result.diagnosticContext)}`);
+      for (const line of target.inspect(result.events, result.diagnosticContext)) {
+        console.log(`   ${line}`);
+      }
+    } catch (err) {
+      failures++;
+      console.log(`   FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  console.log(failures === 0 ? "\n✓ All targets fetched" : `\n✗ ${failures} failed`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/scripts/live-verify-gcal-cycle2.ts
+++ b/scripts/live-verify-gcal-cycle2.ts
@@ -22,7 +22,11 @@ interface VerifyTarget {
 }
 
 function formatSample(e: RawEventData): string {
-  return `[${e.date} ${e.startTime ?? "all-day"}] ${(e.title ?? "").slice(0, 60)} | hares=${e.hares ?? "—"} | loc=${(e.location ?? "—").slice(0, 50)}${e.runNumber ? ` | run=${e.runNumber}` : ""}`;
+  const time = e.startTime ?? "all-day";
+  const titleSlice = (e.title ?? "").slice(0, 60);
+  const locSlice = (e.location ?? "—").slice(0, 50);
+  const runSuffix = e.runNumber ? ` | run=${e.runNumber}` : "";
+  return `[${e.date} ${time}] ${titleSlice} | hares=${e.hares ?? "—"} | loc=${locSlice}${runSuffix}`;
 }
 
 const TARGETS: VerifyTarget[] = [
@@ -79,7 +83,7 @@ const TARGETS: VerifyTarget[] = [
         `total events: ${events.length}`,
         `Giggity events: ${giggity.length}`,
         `CUNTh events (all-day overrides should still survive): ${cunth.length}`,
-        `diag.allDayCollapsed: ${diag?.allDayCollapsed ?? "0"}`,
+        `diag.allDayCollapsed: ${typeof diag?.allDayCollapsed === "number" ? diag.allDayCollapsed : 0}`,
       ];
       for (const e of giggity.slice(0, 6)) lines.push(`  ${formatSample(e)}`);
       // Check: any (giggity-h3, date) with both timed + all-day? Should not exist post-dedup.

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -14,6 +14,7 @@ import {
   buildRawEventFromGCalItem,
   normalizeGCalDescription,
   GoogleCalendarAdapter,
+  dedupGCalEvents,
 } from "./adapter";
 import type { RawEventData } from "../types";
 import { SOURCES } from "../../../prisma/seed-data/sources";
@@ -433,7 +434,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         description: "MAP: https://maps.app.goo.gl/bPryrj1CNfrg6kxQ7\nA to B, Dog Friendly",
         location: "12017 Amherst Dr, Austin, TX 78759, USA",
       }),
-      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePattern: titleHareRE });
+      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePatterns: [titleHareRE] });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Baba Gagush & Crusty Beaver");
     expect(result!.title).toBe("AH3 #2269");
@@ -460,7 +461,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
       const result = buildRawEventFromGCalItem(
         testGCalEvent({ summary, start: { dateTime: "2026-04-19T13:00:00-07:00" } }),
         { defaultKennelTag: "dwh3", titleHarePattern: dwh3Pattern },
-        { compiledTitleHarePattern: dwh3RE },
+        { compiledTitleHarePatterns: [dwh3RE] },
       );
       expect(result).not.toBeNull();
       expect(result!.hares).toBe(expectedHares);
@@ -478,7 +479,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         summary: "AH3 #1833 - Manoa Valley District Park - International Dicklomat",
         start: { dateTime: "2026-04-18T14:00:00-10:00" },
       }),
-      { defaultKennelTag: "ah3-hi", titleHarePattern: String.raw`^AH3\s*#\d+.*-\s+(.+)$` }, { compiledTitleHarePattern: suffixRE });
+      { defaultKennelTag: "ah3-hi", titleHarePattern: String.raw`^AH3\s*#\d+.*-\s+(.+)$` }, { compiledTitleHarePatterns: [suffixRE] });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("International Dicklomat");
     expect(result!.title).toBe("AH3 #1833 - Manoa Valley District Park");
@@ -492,7 +493,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         summary: "AH3 #1828 - **EARLY START** - Kailua District Park - Green Machine",
         start: { dateTime: "2026-03-14T10:00:00-10:00" },
       }),
-      { defaultKennelTag: "ah3-hi", titleHarePattern: String.raw`^AH3\s*#\d+.*-\s+(.+)$` }, { compiledTitleHarePattern: suffixRE });
+      { defaultKennelTag: "ah3-hi", titleHarePattern: String.raw`^AH3\s*#\d+.*-\s+(.+)$` }, { compiledTitleHarePatterns: [suffixRE] });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Green Machine");
     expect(result!.title).toBe("AH3 #1828 - **EARLY START** - Kailua District Park");
@@ -508,7 +509,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         summary: "Alice AH3 #2269 - Event with Alice",
         start: { dateTime: "2026-04-18T14:00:00-05:00" },
       }),
-      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePattern: prefixRE });
+      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePatterns: [prefixRE] });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Alice");
     // Title should strip from the front, not the back
@@ -525,7 +526,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
         summary: "SH3 #880 Hare: Kiss Me- Degerloch",
         start: { dateTime: "2026-04-19T12:00:00+02:00" },
       }),
-      { defaultKennelTag: "sh3-de", titleHarePattern: String.raw`Hare:\s+(.+?)(?=-\s+\S)` }, { compiledTitleHarePattern: midRE });
+      { defaultKennelTag: "sh3-de", titleHarePattern: String.raw`Hare:\s+(.+?)(?=-\s+\S)` }, { compiledTitleHarePatterns: [midRE] });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Kiss Me");
     expect(result!.title).toBe("SH3 #880 - Degerloch");
@@ -543,7 +544,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
       {
         defaultKennelTag: "sh3-de",
         titleHarePattern: String.raw`Hare:?\s+(.+?)(?:(?=[-\u2013\u2014]\s*\S)|\s*$)`,
-      }, { compiledTitleHarePattern: pattern });
+      }, { compiledTitleHarePatterns: [pattern] });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Kiss Me");
     expect(result!.title).toBe("SH3 #881 — Degerloch");
@@ -563,7 +564,7 @@ describe("titleHarePattern — hare extraction from summary", () => {
       {
         defaultKennelTag: "ah3-hi",
         titleHarePattern: String.raw`Hare:\s+(.+?)(?:\s*$)`,
-      }, { compiledTitleHarePattern: pattern });
+      }, { compiledTitleHarePatterns: [pattern] });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("AH3");
     expect(result!.title).toBe("AH3 #880");
@@ -576,11 +577,222 @@ describe("titleHarePattern — hare extraction from summary", () => {
         start: { dateTime: "2026-04-05T14:00:00-05:00" },
         description: "Hare: Actual Hare Name\nDetails here",
       }),
-      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePattern: titleHareRE });
+      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+AH3\s+#` }, { compiledTitleHarePatterns: [titleHareRE] });
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Actual Hare Name");
     // Title should NOT be stripped when hares came from description
     expect(result!.title).toContain("AH3");
+  });
+});
+
+// ── Cycle-2 audit-stream fixes (#1208, #1209, #1210, #1221, #1222) ──
+
+describe("titleHarePattern array — multi-pattern fallback (#1208/#1209/#1221)", () => {
+  it("Stuttgart: SH3 first pattern wins for 'Hare:' titles", () => {
+    const patterns = [
+      /Hare:?\s+(.+?)(?:(?=[-–—]\s*\S)|\s*$)/i,
+      /^DST\s*#?\s*-\s*(.+)$/i,
+    ];
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "SH3 #880 Hare: Kiss Me- Degerloch",
+        start: { dateTime: "2026-04-19T12:00:00+02:00" },
+      }),
+      { defaultKennelTag: "sh3-de" },
+      { compiledTitleHarePatterns: patterns },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Kiss Me");
+    expect(result!.title).toBe("SH3 #880 - Degerloch");
+  });
+
+  it.each([
+    { name: "placeholder '#'", summary: "DST # - Lucky Testigel", expected: "Lucky Testigel" },
+    { name: "assigned run number", summary: "DST #814 - Full of Spunk", expected: "Full of Spunk" },
+    { name: "no '#' at all", summary: "DST - Bad Sex", expected: "Bad Sex" },
+  ])("Stuttgart: DST second pattern matches $name (#1208)", ({ summary, expected }) => {
+    const patterns = [
+      /Hare:?\s+(.+?)(?:(?=[-–—]\s*\S)|\s*$)/i,
+      /^DST\s*#?\s*\d*\s*-\s*(.+)$/i,
+    ];
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary,
+        start: { dateTime: "2026-04-21T18:30:00+02:00" },
+      }),
+      { defaultKennelTag: "sh3-de", kennelPatterns: [["^DST\\b", "dst-h3"]] },
+      {
+        compiledTitleHarePatterns: patterns,
+        compiledKennelPatterns: [[/^DST\b/i, "dst-h3"] as const],
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe(expected);
+  });
+
+  it("Copenhagen: CH3 second pattern matches 'CH3 NNNN - Loc - Hare' (#1209/#1221)", () => {
+    const patterns = [
+      /[.]\s*Hare:\s*(.+)$/i,
+      /^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$/i,
+    ];
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "CH3 2730 - Nørreport St - Mr Petit",
+        start: { dateTime: "2026-05-04T18:30:00+02:00" },
+      }),
+      { defaultKennelTag: "ch3-dk", kennelPatterns: [["^CH3\\b|Copenhagen", "ch3-dk"]] },
+      {
+        compiledTitleHarePatterns: patterns,
+        compiledKennelPatterns: [[/^CH3\b|Copenhagen/i, "ch3-dk"] as const],
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Mr Petit");
+  });
+
+  it("Copenhagen: RDH3 first pattern still wins for legacy '. Hare:' titles", () => {
+    const patterns = [
+      /[.]\s*Hare:\s*(.+)$/i,
+      /^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$/i,
+    ];
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "RDH3 134 Walkers. Hare: Lust Jucie",
+        start: { dateTime: "2026-05-10T12:00:00+02:00" },
+      }),
+      { defaultKennelTag: "ch3-dk", kennelPatterns: [["RDH3|Rabid", "rdh3"]] },
+      {
+        compiledTitleHarePatterns: patterns,
+        compiledKennelPatterns: [[/RDH3|Rabid/i, "rdh3"] as const],
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Lust Jucie");
+  });
+});
+
+describe("titleHarePattern trailing-dash strip on capture (#1210)", () => {
+  it("strips trailing ' -' left by lazy `(.+?)` AH3 pattern", () => {
+    const re = /^(.+?)\s+-\s+AH3\s+#/i;
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "Crusty Beaver and Pissfull Ignorinse - AH3 #2274",
+        start: { dateTime: "2026-05-02T14:00:00-05:00" },
+      }),
+      { defaultKennelTag: "ah3", titleHarePattern: String.raw`^(.+?)\s+-\s+AH3\s+#` },
+      { compiledTitleHarePatterns: [re] },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Crusty Beaver and Pissfull Ignorinse");
+    expect(result!.hares).not.toMatch(/[-–—]\s*$/);
+  });
+});
+
+describe("titleLocationPattern — capture address from title (#1222)", () => {
+  it("Capital H3: 'Hares <street>' → split into hares + location", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "Kwine & Mitzi 68 Macleay Street Turner.",
+        start: { dateTime: "2026-05-04T18:00:00+10:00" },
+      }),
+      { defaultKennelTag: "capital-h3-au" },
+      {
+        compiledTitleHarePatterns: [/^(.+?)\s+\d+\s+[A-Z]/i],
+        compiledTitleLocationPatterns: [/(\d+\s+.+?)\.?\s*$/i],
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Kwine & Mitzi");
+    expect(result!.location).toBe("68 Macleay Street Turner");
+  });
+
+  it("rejects 'venue TBC' as a location placeholder", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "Kwine & Mitzi venue TBC",
+        start: { dateTime: "2026-05-11T18:00:00+10:00" },
+      }),
+      { defaultKennelTag: "capital-h3-au" },
+      {
+        // Capture group 1 is "venue TBC" — should be rejected by isPlaceholder.
+        compiledTitleLocationPatterns: [/\s+(venue\s+TBC)\s*$/i],
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.location).toBeUndefined();
+  });
+});
+
+describe("dedupGCalEvents — all-day vs timed collapse (#1199)", () => {
+  it("drops the all-day placeholder when a timed sibling exists for same kennel/date", () => {
+    const allDayEventSet = new WeakSet<RawEventData>();
+    const gcalIdMap = new WeakMap<RawEventData, string>();
+    const placeholder = buildRawEventFromGCalItem(
+      { summary: "Giggity H3 #? (TBD)", start: { date: "2026-05-09" }, status: "confirmed", id: "all-day-1" },
+      { defaultKennelTag: "giggity-h3", includeAllDayEvents: true },
+      { allDayEventSet, gcalIdMap },
+    );
+    const real = buildRawEventFromGCalItem(
+      { summary: "Giggity #113 Cuthacopia Can't Drive 55", start: { dateTime: "2026-05-09T18:00:00-07:00" }, status: "confirmed", id: "timed-1" },
+      { defaultKennelTag: "giggity-h3", includeAllDayEvents: true },
+      { allDayEventSet, gcalIdMap },
+    );
+    expect(placeholder).not.toBeNull();
+    expect(real).not.toBeNull();
+    const { events: deduped, allDayCollapsedCount } = dedupGCalEvents(
+      [placeholder!, real!],
+      gcalIdMap,
+      allDayEventSet,
+    );
+    expect(allDayCollapsedCount).toBe(1);
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0].title).not.toContain("(TBD)");
+    expect(deduped[0].startTime).toBe("18:00");
+  });
+
+  it("PRESERVES a real all-day event when a timed sibling shares the date (campout, away weekend)", () => {
+    // Adversarial: a kennel may legitimately have an all-day campout AND a
+    // timed regular trail on the same date. The all-day must NOT be dropped
+    // — only placeholder shells (no run number, '#?' or TBD title) collapse.
+    const allDayEventSet = new WeakSet<RawEventData>();
+    const gcalIdMap = new WeakMap<RawEventData, string>();
+    const campout = buildRawEventFromGCalItem(
+      { summary: "Giggity Annual Campout — Lake Cushman", start: { date: "2026-05-09" }, status: "confirmed", id: "campout-1", description: "Hare: Beerstroke #200" },
+      { defaultKennelTag: "giggity-h3", includeAllDayEvents: true },
+      { allDayEventSet, gcalIdMap },
+    );
+    const trail = buildRawEventFromGCalItem(
+      { summary: "Giggity #114 Pre-Campout Warmup", start: { dateTime: "2026-05-09T18:00:00-07:00" }, status: "confirmed", id: "timed-2" },
+      { defaultKennelTag: "giggity-h3", includeAllDayEvents: true },
+      { allDayEventSet, gcalIdMap },
+    );
+    expect(campout).not.toBeNull();
+    expect(trail).not.toBeNull();
+    const { events: deduped, allDayCollapsedCount } = dedupGCalEvents(
+      [campout!, trail!],
+      gcalIdMap,
+      allDayEventSet,
+    );
+    expect(allDayCollapsedCount).toBe(0);
+    expect(deduped).toHaveLength(2);
+  });
+
+  it("preserves all-day events when no timed sibling exists (CUNTh-style overrides)", () => {
+    const allDayEventSet = new WeakSet<RawEventData>();
+    const gcalIdMap = new WeakMap<RawEventData, string>();
+    const allDay = buildRawEventFromGCalItem(
+      { summary: "CUNTh trail", start: { date: "2026-05-09" }, status: "confirmed", id: "cunth-1" },
+      { defaultKennelTag: "cunth3-wa", includeAllDayEvents: true },
+      { allDayEventSet, gcalIdMap },
+    );
+    expect(allDay).not.toBeNull();
+    const { events: deduped, allDayCollapsedCount } = dedupGCalEvents(
+      [allDay!],
+      gcalIdMap,
+      allDayEventSet,
+    );
+    expect(allDayCollapsedCount).toBe(0);
+    expect(deduped).toHaveLength(1);
   });
 });
 
@@ -2849,7 +3061,7 @@ describe("buildRawEventFromGCalItem — coord-only location preservation (#1195)
 describe("buildRawEventFromGCalItem — COH3 'with X' titleHarePattern (#981)", () => {
   // Mirrors the seed config for "Central Oregon H3 Calendar".
   const config = { defaultKennelTag: "coh3", titleHarePattern: String.raw`\bwith\s+(\S.*)` };
-  const compiledTitleHarePattern = /\bwith\s+(\S.*)/i;
+  const compiledTitleHarePatterns = [/\bwith\s+(\S.*)/i];
 
   it.each([
     { name: "single-name `with X`", summary: "COH3 #125 with Copper Cunt", description: undefined, hares: "Copper Cunt" as string | undefined, title: "COH3 #125" as string | undefined },
@@ -2861,7 +3073,7 @@ describe("buildRawEventFromGCalItem — COH3 'with X' titleHarePattern (#981)", 
     const event = buildRawEventFromGCalItem(
       testGCalEvent({ summary, description }),
       config,
-      { compiledTitleHarePattern },
+      { compiledTitleHarePatterns },
     );
     expect(event).not.toBeNull();
     expect(event!.hares).toBe(hares);
@@ -2881,13 +3093,13 @@ describe("buildRawEventFromGCalItem — Eugene H3 emoji-delimited title parsing 
       String.raw`👣.*`,
     ],
   };
-  const compiledTitleHarePattern = /👣[\s:\-–—]*(\S.*)/i;
+  const compiledTitleHarePatterns = [/👣[\s:\-–—]*(\S.*)/i];
   const compiledTitleStripPatterns = [
     /^🌲\s*/i,
     /🍺.*/i,
     /👣.*/i,
   ];
-  const opts = { compiledTitleHarePattern, compiledTitleStripPatterns };
+  const opts = { compiledTitleHarePatterns, compiledTitleStripPatterns };
 
   it.each([
     { name: "extracts 👣 hare and strips leading 🌲", summary: "🌲 EH3 Sasquach Hash 👣 Fembot", description: undefined, date: "2026-05-02", title: "EH3 Sasquach Hash", hares: "Fembot" as string | undefined },

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -590,8 +590,8 @@ describe("titleHarePattern — hare extraction from summary", () => {
 describe("titleHarePattern array — multi-pattern fallback (#1208/#1209/#1221)", () => {
   it("Stuttgart: SH3 first pattern wins for 'Hare:' titles", () => {
     const patterns = [
-      /Hare:?\s+(.+?)(?:(?=[-–—]\s*\S)|\s*$)/i,
-      /^DST\s*#?\s*-\s*(.+)$/i,
+      /Hare:?\s+(.+?)(?:(?=[-–—]\s*\S)|\s*$)/i, // NOSONAR — non-greedy with bounded lookahead, test fixture
+      /^DST\s*#?\s*-\s*(.+)$/i, // NOSONAR — anchored, single capture, test fixture
     ];
     const result = buildRawEventFromGCalItem(
       testGCalEvent({
@@ -612,15 +612,15 @@ describe("titleHarePattern array — multi-pattern fallback (#1208/#1209/#1221)"
     { name: "no '#' at all", summary: "DST - Bad Sex", expected: "Bad Sex" },
   ])("Stuttgart: DST second pattern matches $name (#1208)", ({ summary, expected }) => {
     const patterns = [
-      /Hare:?\s+(.+?)(?:(?=[-–—]\s*\S)|\s*$)/i,
-      /^DST\s*#?\s*\d*\s*-\s*(.+)$/i,
+      /Hare:?\s+(.+?)(?:(?=[-–—]\s*\S)|\s*$)/i, // NOSONAR — non-greedy with bounded lookahead, test fixture
+      /^DST\s*#?\s*\d*\s*-\s*(.+)$/i, // NOSONAR — anchored, single capture, test fixture
     ];
     const result = buildRawEventFromGCalItem(
       testGCalEvent({
         summary,
         start: { dateTime: "2026-04-21T18:30:00+02:00" },
       }),
-      { defaultKennelTag: "sh3-de", kennelPatterns: [["^DST\\b", "dst-h3"]] },
+      { defaultKennelTag: "sh3-de", kennelPatterns: [[String.raw`^DST\b`, "dst-h3"]] },
       {
         compiledTitleHarePatterns: patterns,
         compiledKennelPatterns: [[/^DST\b/i, "dst-h3"] as const],
@@ -632,18 +632,18 @@ describe("titleHarePattern array — multi-pattern fallback (#1208/#1209/#1221)"
 
   it("Copenhagen: CH3 second pattern matches 'CH3 NNNN - Loc - Hare' (#1209/#1221)", () => {
     const patterns = [
-      /[.]\s*Hare:\s*(.+)$/i,
-      /^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$/i,
+      /[.]\s*Hare:\s*(.+)$/i, // NOSONAR — anchored, single capture, test fixture
+      /^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$/i, // NOSONAR — anchored, char-class delimited, test fixture
     ];
     const result = buildRawEventFromGCalItem(
       testGCalEvent({
         summary: "CH3 2730 - Nørreport St - Mr Petit",
         start: { dateTime: "2026-05-04T18:30:00+02:00" },
       }),
-      { defaultKennelTag: "ch3-dk", kennelPatterns: [["^CH3\\b|Copenhagen", "ch3-dk"]] },
+      { defaultKennelTag: "ch3-dk", kennelPatterns: [[String.raw`(?:^CH3\b|Copenhagen)`, "ch3-dk"]] },
       {
         compiledTitleHarePatterns: patterns,
-        compiledKennelPatterns: [[/^CH3\b|Copenhagen/i, "ch3-dk"] as const],
+        compiledKennelPatterns: [[/(?:^CH3\b|Copenhagen)/i, "ch3-dk"] as const],
       },
     );
     expect(result).not.toBeNull();
@@ -652,8 +652,8 @@ describe("titleHarePattern array — multi-pattern fallback (#1208/#1209/#1221)"
 
   it("Copenhagen: RDH3 first pattern still wins for legacy '. Hare:' titles", () => {
     const patterns = [
-      /[.]\s*Hare:\s*(.+)$/i,
-      /^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$/i,
+      /[.]\s*Hare:\s*(.+)$/i, // NOSONAR — anchored, single capture, test fixture
+      /^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$/i, // NOSONAR — anchored, char-class delimited, test fixture
     ];
     const result = buildRawEventFromGCalItem(
       testGCalEvent({
@@ -673,7 +673,7 @@ describe("titleHarePattern array — multi-pattern fallback (#1208/#1209/#1221)"
 
 describe("titleHarePattern trailing-dash strip on capture (#1210)", () => {
   it("strips trailing ' -' left by lazy `(.+?)` AH3 pattern", () => {
-    const re = /^(.+?)\s+-\s+AH3\s+#/i;
+    const re = /^(.+?)\s+-\s+AH3\s+#/i; // NOSONAR — non-greedy bounded by literal " - AH3 #", test fixture
     const result = buildRawEventFromGCalItem(
       testGCalEvent({
         summary: "Crusty Beaver and Pissfull Ignorinse - AH3 #2274",
@@ -697,8 +697,8 @@ describe("titleLocationPattern — capture address from title (#1222)", () => {
       }),
       { defaultKennelTag: "capital-h3-au" },
       {
-        compiledTitleHarePatterns: [/^(.+?)\s+\d+\s+[A-Z]/i],
-        compiledTitleLocationPatterns: [/(\d+\s+.+?)\.?\s*$/i],
+        compiledTitleHarePatterns: [/^(.+?)\s+\d+\s+[A-Z]/i], // NOSONAR — non-greedy bounded by digit run, test fixture
+        compiledTitleLocationPatterns: [/(\d+\s+.+?)\.?\s*$/i], // NOSONAR — non-greedy bounded by literal end, test fixture
       },
     );
     expect(result).not.toBeNull();
@@ -715,7 +715,7 @@ describe("titleLocationPattern — capture address from title (#1222)", () => {
       { defaultKennelTag: "capital-h3-au" },
       {
         // Capture group 1 is "venue TBC" — should be rejected by isPlaceholder.
-        compiledTitleLocationPatterns: [/\s+(venue\s+TBC)\s*$/i],
+        compiledTitleLocationPatterns: [/\s+(venue\s+TBC)\s*$/i], // NOSONAR — anchored, single capture, test fixture
       },
     );
     expect(result).not.toBeNull();

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry } from "../utils";
+import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber } from "../utils";
 import { matchKennelPatterns, matchCompiledKennelPatterns, compileKennelPatterns, type KennelPattern, type CompiledKennelPattern } from "../kennel-patterns";
 import { LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 import { parseDMSFromLocation } from "@/lib/geo";
@@ -39,11 +39,10 @@ export function extractRunNumber(
   customPatterns?: string[] | RegExp[],
 ): number | undefined {
   // 1. Check summary first (e.g., "Beantown #255: ...", "BH3: ... #2781", "Cunth # 40: ...").
-  // Require a clean delimiter (whitespace, punctuation, or end-of-string) after the
-  // digits — otherwise "#30X?" parses as 30, contradicting the kennel's intent that
-  // the run number is unknown (#1147). Mid-token alphanumeric leaves runNumber undefined.
-  const summaryMatch = /#\s*(\d+)(?=$|[\s:\-–—,.()/])/.exec(summary);
-  if (summaryMatch) return Number.parseInt(summaryMatch[1], 10);
+  // Shared `extractHashRunNumber` enforces the delimiter guard (#1147) — "#30X?"
+  // rejects rather than parsing as 30.
+  const fromSummary = extractHashRunNumber(summary);
+  if (fromSummary !== undefined) return fromSummary;
 
   if (!description) return undefined;
 
@@ -464,7 +463,16 @@ interface CalendarSourceConfig {
   skipPatterns?: string[];              // regex strings — skip events whose summary matches
   harePatterns?: string[];              // regex strings to extract hares from descriptions
   runNumberPatterns?: string[];         // regex strings to extract run numbers from descriptions
-  titleHarePattern?: string;            // regex to extract hare names from summary when description has none
+  /** Regex(es) to extract hare names from summary when description has none.
+   *  Accepts a single pattern string or an array tried in order — first
+   *  capture-group hit wins (#1208 DST + Stuttgart SH3 share a source;
+   *  #1209/#1221 CH3 + RDH3 share a source). */
+  titleHarePattern?: string | string[];
+  /** Regex(es) to extract a location from the summary when item.location is
+   *  empty or a placeholder. Tried after titleHarePattern; first capture-group
+   *  hit wins. The matched span is stripped from the title. Candidates that
+   *  trip `isPlaceholder()` (e.g. "venue TBC") are rejected (#1222). */
+  titleLocationPattern?: string | string[];
   /**
    * Regex strings applied as `title.replace(re, "")` in sequence after hare
    * extraction and before the `defaultTitle` fallback. Compiled with `i`
@@ -629,7 +637,8 @@ export interface BuildRawEventFromGCalItemOptions {
   compiledHarePatterns?: RegExp[];
   compiledRunNumberPatterns?: RegExp[];
   compiledSkipPatterns?: RegExp[];
-  compiledTitleHarePattern?: RegExp;
+  compiledTitleHarePatterns?: RegExp[];
+  compiledTitleLocationPatterns?: RegExp[];
   compiledTitleStripPatterns?: RegExp[];
   /** Pre-compiled kennelPatterns. Production fetch path passes this so
    *  we don't re-compile every event; tests can omit. */
@@ -638,6 +647,10 @@ export interface BuildRawEventFromGCalItemOptions {
    *  dedup at the end of `fetch` can use stable GCal ids without
    *  changing the public RawEventData shape. */
   gcalIdMap?: WeakMap<RawEventData, string>;
+  /** Set of RawEventData built from all-day GCal items. Used by
+   *  `dedupGCalEvents` to drop placeholder all-day rows when a timed
+   *  sibling exists for the same `(kennelTag, date)` (#1199 Giggity). */
+  allDayEventSet?: WeakSet<RawEventData>;
 }
 
 /** Build a RawEventData from a single Google Calendar event item. Returns null if the item should be skipped. */
@@ -650,10 +663,12 @@ export function buildRawEventFromGCalItem(
     compiledHarePatterns,
     compiledRunNumberPatterns,
     compiledSkipPatterns,
-    compiledTitleHarePattern,
+    compiledTitleHarePatterns,
+    compiledTitleLocationPatterns,
     compiledTitleStripPatterns,
     compiledKennelPatterns,
     gcalIdMap,
+    allDayEventSet,
   } = options;
   if (item.status === "cancelled") return null;
   if (!item.summary) return null;
@@ -665,7 +680,8 @@ export function buildRawEventFromGCalItem(
   // `recurringEventId` here: that field is also set on materialized RRULE instances,
   // so a carve-out would silently ingest unwanted all-day recurring instances on
   // sources that never opted in.
-  if (item.start?.date && !item.start?.dateTime && !sourceConfig?.includeAllDayEvents) return null;
+  const isAllDay = !!(item.start?.date && !item.start?.dateTime);
+  if (isAllDay && !sourceConfig?.includeAllDayEvents) return null;
 
   const { dateISO, startTime } = extractDateTimeFromGCalItem(item.start);
   if (!dateISO) return null;
@@ -692,13 +708,29 @@ export function buildRawEventFromGCalItem(
   }
   const { rawDescription, description } = normalizeGCalDescription(item.description);
   let hares = rawDescription ? extractHares(rawDescription, compiledHarePatterns) : undefined;
-  // Fall back to extracting hares from title when description has none
+  // Fall back to extracting hares from title when description has none. Try
+  // each pattern in order; first capture-group hit wins. Track which pattern
+  // matched so the downstream title-cleanup block uses the same regex span.
   let haresFromTitle = false;
-  if (!hares && compiledTitleHarePattern) {
-    const titleMatch = compiledTitleHarePattern.exec(summary);
-    if (titleMatch?.[1]) {
-      hares = titleMatch[1].trim() || undefined;
-      haresFromTitle = !!hares;
+  let matchedTitleHarePattern: RegExp | undefined;
+  if (!hares && compiledTitleHarePatterns?.length) {
+    for (const re of compiledTitleHarePatterns) {
+      const titleMatch = re.exec(summary);
+      if (titleMatch?.[1]) {
+        // #1210: lazy `^(.+?)\s+AH3\s+#` leaves a trailing " -" on titles like
+        // "Alice and Bob - AH3 #2351". Anchored char-class strip is SonarCloud
+        // safe (≤20 complexity, no nesting).
+        const cleaned = titleMatch[1]
+          .trim()
+          .replace(/^\s*[-–—:]+\s*|\s*[-–—:]+\s*$/g, "") // NOSONAR — anchored char-class alternation
+          .trim();
+        if (cleaned) {
+          hares = cleaned;
+          haresFromTitle = true;
+          matchedTitleHarePattern = re;
+          break;
+        }
+      }
     }
   }
   const resolved = resolveKennelTagFromSummary(summary, sourceConfig, compiledKennelPatterns);
@@ -776,8 +808,8 @@ export function buildRawEventFromGCalItem(
   // and suffix patterns (hares at end: "AH3 #1833 - Location - Hare Name").
   // The prior code assumed prefix-only and did title.slice(captureGroup.length),
   // which mangled titles when the capture group was at the end.
-  if (haresFromTitle && compiledTitleHarePattern) {
-    const titleMatch = compiledTitleHarePattern.exec(title);
+  if (haresFromTitle && matchedTitleHarePattern) {
+    const titleMatch = matchedTitleHarePattern.exec(title);
     if (titleMatch && titleMatch[1]) {
       const hareText = titleMatch[1];
       const start = titleMatch.index;
@@ -811,6 +843,26 @@ export function buildRawEventFromGCalItem(
           .trim();
       }
       if (cleaned) title = cleaned;
+    }
+  }
+
+  // Title-embedded location extraction (#1222 Capital H3): the source has no
+  // separate item.location and packs the address into the title after the
+  // hare names. Try each pattern in order; first capture-group hit wins.
+  // Reject placeholders like "venue TBC" via isPlaceholder().
+  if (!location && compiledTitleLocationPatterns?.length) {
+    for (const re of compiledTitleLocationPatterns) {
+      const locMatch = re.exec(title);
+      if (locMatch?.[1]) {
+        const candidate = locMatch[1].trim().replace(/[.,;:\s]+$/, "").trim();
+        if (candidate && !isPlaceholder(candidate)) {
+          location = candidate;
+          title = (title.slice(0, locMatch.index) + title.slice(locMatch.index + locMatch[0].length))
+            .replace(/^\s*[-–—:]\s*|\s*[-–—:]\s*$/g, "")
+            .trim();
+          break;
+        }
+      }
     }
   }
 
@@ -987,6 +1039,7 @@ export function buildRawEventFromGCalItem(
     sourceUrl: item.htmlLink,
   };
   if (gcalIdMap && item.id) gcalIdMap.set(event, item.id);
+  if (allDayEventSet && isAllDay) allDayEventSet.add(event);
   return event;
 }
 
@@ -1004,6 +1057,11 @@ function buildGCalDiagnosticContext(item: GCalEvent): string {
  * pattern needed by `buildRawEventFromGCalItem` (or `undefined` when the
  * config didn't supply one).
  */
+function compileMaybeArray(p: string | string[] | undefined, flags?: string): RegExp[] | undefined {
+  if (!p) return undefined;
+  return compilePatterns(Array.isArray(p) ? p : [p], flags);
+}
+
 function compileSourceConfigPatterns(sourceConfig: CalendarSourceConfig | null) {
   return {
     compiledHarePatterns: sourceConfig?.harePatterns?.length
@@ -1015,9 +1073,8 @@ function compileSourceConfigPatterns(sourceConfig: CalendarSourceConfig | null) 
     compiledSkipPatterns: sourceConfig?.skipPatterns?.length
       ? compilePatterns(sourceConfig.skipPatterns, "i")
       : undefined,
-    compiledTitleHarePattern: sourceConfig?.titleHarePattern
-      ? compilePatterns([sourceConfig.titleHarePattern], "i")[0]
-      : undefined,
+    compiledTitleHarePatterns: compileMaybeArray(sourceConfig?.titleHarePattern, "i"),
+    compiledTitleLocationPatterns: compileMaybeArray(sourceConfig?.titleLocationPattern, "i"),
     compiledTitleStripPatterns: sourceConfig?.titleStripPatterns?.length
       ? compilePatterns(sourceConfig.titleStripPatterns, "i")
       : undefined,
@@ -1036,12 +1093,57 @@ function compileSourceConfigPatterns(sourceConfig: CalendarSourceConfig | null) 
  *      series that share key but differ in id (#1101 CFMH3). On collision
  *      the survivor inherits non-empty fields from the donor before drop.
  */
-function dedupGCalEvents(
+/** A placeholder all-day shell looks like "Giggity H3 #? (TBD)" — no run
+ *  number, no real hares/location, and a title containing `#?` or a TBD/TBA/
+ *  TBC marker. Real all-day entries (campouts, away weekends) will have a
+ *  populated title or run number and must NOT be collapsed when a timed
+ *  sibling exists on the same date. */
+function isPlaceholderShell(e: RawEventData): boolean {
+  if (e.runNumber !== undefined) return false;
+  const title = (e.title ?? "").trim();
+  if (!title) return true;
+  if (/#\s*\?/.test(title)) return true;
+  if (/\b(?:TBD|TBA|TBC)\b/i.test(title)) return true;
+  if (e.hares && isPlaceholder(e.hares)) return true;
+  return false;
+}
+
+export function dedupGCalEvents(
   events: RawEventData[],
   gcalIdMap: WeakMap<RawEventData, string>,
-): { events: RawEventData[]; compositeDedupedCount: number } {
+  allDayEventSet: WeakSet<RawEventData>,
+): { events: RawEventData[]; compositeDedupedCount: number; allDayCollapsedCount: number } {
+  // #1199 pre-pass: drop placeholder all-day events when a timed sibling
+  // exists for the same `(kennelTag, date)`. Sources with
+  // `includeAllDayEvents: true` (WA Hash for CUNTh) admit both placeholder
+  // shells like "Giggity H3 #? (TBD)" and real timed runs; the merge
+  // pipeline collapses them into one canonical event by `(kennelId, date)`,
+  // so whichever survives this dedup wins. Prefer the timed one — but ONLY
+  // when the all-day event LOOKS like a placeholder. A real all-day event
+  // (campout, away weekend, RDR) sharing the date with a timed trail must
+  // survive so the merge pipeline can keep both via signature-based
+  // multi-event handling. Placeholder evidence: missing run number AND
+  // (title contains `#?`, "TBD"/"TBA"/"TBC" placeholder marker, or
+  // hares/location are placeholder strings).
+  const timedKeys = new Set<string>();
+  for (const e of events) {
+    if (!allDayEventSet.has(e)) timedKeys.add(`${e.kennelTags[0]}|${e.date}`);
+  }
+  let allDayCollapsedCount = 0;
+  const timedFiltered = events.filter(e => {
+    if (
+      allDayEventSet.has(e)
+      && timedKeys.has(`${e.kennelTags[0]}|${e.date}`)
+      && isPlaceholderShell(e)
+    ) {
+      allDayCollapsedCount++;
+      return false;
+    }
+    return true;
+  });
+
   const seen = new Set<string>();
-  const idDeduped = events.filter(e => {
+  const idDeduped = timedFiltered.filter(e => {
     const id = gcalIdMap.get(e);
     const key = id
       ? `id:${id}`
@@ -1062,7 +1164,7 @@ function dedupGCalEvents(
   // Skip the rebuild when nothing collapsed — saves an O(n) array copy on
   // the typical scrape where parallel-series duplicates don't exist.
   const result = compositeDedupedCount === 0 ? idDeduped : [...compositeMap.values()];
-  return { events: result, compositeDedupedCount };
+  return { events: result, compositeDedupedCount, allDayCollapsedCount };
 }
 
 /** Google Calendar API v3 adapter. Fetches events from a public calendar and extracts kennel tags via configurable patterns. */
@@ -1100,6 +1202,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
     let pagesProcessed = 0;
     const compiled = compileSourceConfigPatterns(sourceConfig);
     const gcalIdMap = new WeakMap<RawEventData, string>();
+    const allDayEventSet = new WeakSet<RawEventData>();
 
     const buildEvents = (items: GCalEvent[], filter?: (item: GCalEvent) => boolean): void => {
       let eventIndex = 0;
@@ -1109,7 +1212,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
           continue;
         }
         try {
-          const event = buildRawEventFromGCalItem(item, sourceConfig, { ...compiled, gcalIdMap });
+          const event = buildRawEventFromGCalItem(item, sourceConfig, { ...compiled, gcalIdMap, allDayEventSet });
           if (event) events.push(event);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -1175,7 +1278,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
 
     const hasErrorDetails = hasAnyErrors(errorDetails);
 
-    const { events: compositeDeduped, compositeDedupedCount } = dedupGCalEvents(events, gcalIdMap);
+    const { events: compositeDeduped, compositeDedupedCount, allDayCollapsedCount } = dedupGCalEvents(events, gcalIdMap, allDayEventSet);
 
     return {
       events: compositeDeduped,
@@ -1188,6 +1291,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
         ...(backfillCount > 0 && { inlineHarelineBackfilled: backfillCount }),
         ...(exceptionsRecovered > 0 && { exceptionsRecovered }),
         ...(compositeDedupedCount > 0 && { compositeDeduped: compositeDedupedCount }),
+        ...(allDayCollapsedCount > 0 && { allDayCollapsed: allDayCollapsedCount }),
       },
     };
   }

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -854,11 +854,11 @@ export function buildRawEventFromGCalItem(
     for (const re of compiledTitleLocationPatterns) {
       const locMatch = re.exec(title);
       if (locMatch?.[1]) {
-        const candidate = locMatch[1].trim().replace(/[.,;:\s]+$/, "").trim();
+        const candidate = locMatch[1].trim().replace(/[.,;:\s]+$/, "").trim(); // NOSONAR — anchored end-of-string char-class
         if (candidate && !isPlaceholder(candidate)) {
           location = candidate;
           title = (title.slice(0, locMatch.index) + title.slice(locMatch.index + locMatch[0].length))
-            .replace(/^\s*[-–—:]\s*|\s*[-–—:]\s*$/g, "")
+            .replaceAll(/^\s*[-–—:]+\s*|\s*[-–—:]+\s*$/g, "") // NOSONAR — anchored char-class alternation, mirrors title-hare strip
             .trim();
           break;
         }

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -254,6 +254,17 @@ describe("extractHares — Co-Hare merge + annotation strip (#1212 GLH3)", () =>
     expect(extractHares(desc)).toBe("Alice, Bob");
   });
 
+  it("merges multiple Co-Hare lines", () => {
+    const desc = "Hare: Alice\nCo-Hare: Bob\nCo-Hare: Carol\nLocation: ...";
+    expect(extractHares(desc)).toBe("Alice, Bob, Carol");
+  });
+
+  it("token comparison handles comma-joined primary (Alice, Bob vs Bob)", () => {
+    const desc = "Hare: Alice and Bob\nCo-Hare: Bob\nCo-Hare: Carol";
+    // Bob is already in primary; only Carol gets appended.
+    expect(extractHares(desc)).toBe("Alice and Bob, Carol");
+  });
+
   it("strips trailing ' - lowercase commentary' annotation", () => {
     const desc = "Hare: Just Ayaka - it's her first time haring!";
     expect(extractHares(desc)).toBe("Just Ayaka");

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -237,3 +237,47 @@ describe("extractHares — anchored single-case scenarios", () => {
     expect(extractHares(desc)).toBe("Alice");
   });
 });
+
+describe("extractHares — Co-Hare merge + annotation strip (#1212 GLH3)", () => {
+  it("merges a separate Co-Hare line into the primary hare", () => {
+    const desc = "Hare: Just Ayaka\nCo-Hare: Backseat Muffher\nDirections: ...";
+    expect(extractHares(desc)).toBe("Just Ayaka, Backseat Muffher");
+  });
+
+  it("merges Co-Hares (plural) variant", () => {
+    const desc = "Hare: Alice\nCo-Hares: Bob & Carol";
+    expect(extractHares(desc)).toBe("Alice, Bob & Carol");
+  });
+
+  it("merges 'Cohare' (no dash) variant", () => {
+    const desc = "Hare: Alice\nCohare: Bob";
+    expect(extractHares(desc)).toBe("Alice, Bob");
+  });
+
+  it("strips trailing ' - lowercase commentary' annotation", () => {
+    const desc = "Hare: Just Ayaka - it's her first time haring!";
+    expect(extractHares(desc)).toBe("Just Ayaka");
+  });
+
+  it("preserves capital-leading second name (e.g. 'Alice - Bob')", () => {
+    // Annotation strip is anchored to a lowercase first char after the dash;
+    // a real co-hare written inline after a dash starts with a capital letter
+    // and survives the strip.
+    const desc = "Hare: Alice - Bob";
+    expect(extractHares(desc)).toBe("Alice - Bob");
+  });
+
+  it("regression: lone Hare line still returns just the primary", () => {
+    expect(extractHares("Hare: Alice")).toBe("Alice");
+  });
+
+  it("regression: no spurious join when description has unrelated text", () => {
+    const desc = "Hare: Alice\nLocation: 123 Main St";
+    expect(extractHares(desc)).toBe("Alice");
+  });
+
+  it("avoids duplicate when Co-Hare name already appears in primary", () => {
+    const desc = "Hare: Alice and Bob\nCo-Hare: Bob";
+    expect(extractHares(desc)).toBe("Alice and Bob");
+  });
+});

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -239,56 +239,21 @@ describe("extractHares — anchored single-case scenarios", () => {
 });
 
 describe("extractHares — Co-Hare merge + annotation strip (#1212 GLH3)", () => {
-  it("merges a separate Co-Hare line into the primary hare", () => {
-    const desc = "Hare: Just Ayaka\nCo-Hare: Backseat Muffher\nDirections: ...";
-    expect(extractHares(desc)).toBe("Just Ayaka, Backseat Muffher");
-  });
-
-  it("merges Co-Hares (plural) variant", () => {
-    const desc = "Hare: Alice\nCo-Hares: Bob & Carol";
-    expect(extractHares(desc)).toBe("Alice, Bob & Carol");
-  });
-
-  it("merges 'Cohare' (no dash) variant", () => {
-    const desc = "Hare: Alice\nCohare: Bob";
-    expect(extractHares(desc)).toBe("Alice, Bob");
-  });
-
-  it("merges multiple Co-Hare lines", () => {
-    const desc = "Hare: Alice\nCo-Hare: Bob\nCo-Hare: Carol\nLocation: ...";
-    expect(extractHares(desc)).toBe("Alice, Bob, Carol");
-  });
-
-  it("token comparison handles comma-joined primary (Alice, Bob vs Bob)", () => {
-    const desc = "Hare: Alice and Bob\nCo-Hare: Bob\nCo-Hare: Carol";
-    // Bob is already in primary; only Carol gets appended.
-    expect(extractHares(desc)).toBe("Alice and Bob, Carol");
-  });
-
-  it("strips trailing ' - lowercase commentary' annotation", () => {
-    const desc = "Hare: Just Ayaka - it's her first time haring!";
-    expect(extractHares(desc)).toBe("Just Ayaka");
-  });
-
-  it("preserves capital-leading second name (e.g. 'Alice - Bob')", () => {
-    // Annotation strip is anchored to a lowercase first char after the dash;
-    // a real co-hare written inline after a dash starts with a capital letter
-    // and survives the strip.
-    const desc = "Hare: Alice - Bob";
-    expect(extractHares(desc)).toBe("Alice - Bob");
-  });
-
-  it("regression: lone Hare line still returns just the primary", () => {
-    expect(extractHares("Hare: Alice")).toBe("Alice");
-  });
-
-  it("regression: no spurious join when description has unrelated text", () => {
-    const desc = "Hare: Alice\nLocation: 123 Main St";
-    expect(extractHares(desc)).toBe("Alice");
-  });
-
-  it("avoids duplicate when Co-Hare name already appears in primary", () => {
-    const desc = "Hare: Alice and Bob\nCo-Hare: Bob";
-    expect(extractHares(desc)).toBe("Alice and Bob");
+  // Each row is independent — no shared object state between them. Note that
+  // the annotation-strip cases stand alone (no Co-Hare line) and the
+  // capital-leading test verifies the strip is gated on lowercase-only.
+  it.each([
+    { name: "single Co-Hare line", desc: "Hare: Just Ayaka\nCo-Hare: Backseat Muffher\nDirections: ...", expected: "Just Ayaka, Backseat Muffher" },
+    { name: "Co-Hares plural", desc: "Hare: Alice\nCo-Hares: Bob & Carol", expected: "Alice, Bob & Carol" },
+    { name: "Cohare no-dash", desc: "Hare: Alice\nCohare: Bob", expected: "Alice, Bob" },
+    { name: "multiple Co-Hare lines", desc: "Hare: Alice\nCo-Hare: Bob\nCo-Hare: Carol\nLocation: ...", expected: "Alice, Bob, Carol" },
+    { name: "token compare on comma-joined primary", desc: "Hare: Alice and Bob\nCo-Hare: Bob\nCo-Hare: Carol", expected: "Alice and Bob, Carol" },
+    { name: "duplicate Co-Hare already in primary", desc: "Hare: Alice and Bob\nCo-Hare: Bob", expected: "Alice and Bob" },
+    { name: "trailing lowercase commentary stripped", desc: "Hare: Just Ayaka - it's her first time haring!", expected: "Just Ayaka" },
+    { name: "capital-leading second name preserved", desc: "Hare: Alice - Bob", expected: "Alice - Bob" },
+    { name: "lone Hare line — primary only", desc: "Hare: Alice", expected: "Alice" },
+    { name: "unrelated description text — primary only", desc: "Hare: Alice\nLocation: 123 Main St", expected: "Alice" },
+  ])("$name", ({ desc, expected }) => {
+    expect(extractHares(desc)).toBe(expected);
   });
 });

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -55,6 +55,15 @@ const PHONE_LABEL_TRAILING_RE = /[,:;\s-]*(?:phone|tel|mobile|cell)\b\s*:?\s*$/i
 const PUNCT_TRAILING_RE = /[,:;\s-]+$/; // NOSONAR — single char class + `$` anchor
 const ASTERISK_TAIL_RE = /\s*\*{2,}\s*.*$/; // NOSONAR — bounded `.*$` on first-line slice (no nesting); input ≤200 chars
 const COHARE_COMMENTARY_RE = /\s*(?:could|need)\s+.*?co-?hares?\b.*$/i; // NOSONAR — non-greedy `.*?` anchored to literal `co-?hares?\b`
+// Strip trailing " - lowercase commentary" annotations like
+// "Just Ayaka - it's her first time haring!" (#1212 GLH3). Anchored to
+// end-of-string; `[a-z]` rules out names whose 2nd token starts uppercase
+// (e.g. "Alice - Bob" — second hare survives the existing comma split).
+const TRAILING_LOWERCASE_COMMENTARY_RE = /\s+[-–—]\s+[a-z][^A-Z]*$/; // NOSONAR — anchored, single char class
+// Sibling Co-Hare label scan (#1212): when the primary `Hare:` capture
+// succeeded, also look for a separate `Co-Hare:` / `Co-Hares:` line in the
+// same description. Non-greedy until end of line.
+const COHARE_LABEL_RE = /(?:^|\n)[ \t]*Co-?Hares?:[ \t]*([^\n]+)/im; // NOSONAR — anchored, capture is `[^\n]+` (no nesting)
 // Pre-normalize: rejoin lines where HTML stripping split a label from its colon
 // e.g., "<b>WHO (hares)</b>: Name" → after stripHtmlTags → "WHO (hares)\n: Name"
 const LABEL_COLON_REJOIN_RE = /(\b(?:Who|Hares?)\s*\(?[^)]*\)?)\s*\n\s*:/gim; // NOSONAR — bounded by literal `\n` and char classes; capture is `[^)]*` (no nesting)
@@ -135,6 +144,13 @@ function cleanAndFilterHares(raw: string): string | undefined {
       .trim();
   }
 
+  // Trailing " - lowercase commentary" annotation strip (#1212 GLH3).
+  // Runs after punctuation/phone trimming so the dash is reliably present.
+  // Cheap substring gate skips the regex for the vast majority of inputs.
+  if (/\s[-–—]\s/.test(hares)) {
+    hares = hares.replace(TRAILING_LOWERCASE_COMMENTARY_RE, "").trim();
+  }
+
   if (GENERIC_WHO_ANSWER_RE.test(hares)) return undefined;
   if (PROSE_PREFIX_RE.test(hares)) return undefined;
   if (hares.length === 0 || hares.length >= MAX_HARES_LEN) return undefined;
@@ -159,8 +175,31 @@ export function extractHares(description: string, customPatterns?: string[] | Re
     if (!raw) raw = collectContinuationLines(normalized, match);
 
     const cleaned = cleanAndFilterHares(raw);
-    if (cleaned) return cleaned;
+    if (cleaned) return mergeCoHareIfPresent(cleaned, normalized);
   }
 
   return undefined;
+}
+
+/** Token-set containment: every word in `b` already appears (case-insensitive)
+ *  as a whole word in `a`. Avoids substring false-positives where "Ali" would
+ *  match inside "Alice and Bob" and silently suppress a real co-hare. */
+function tokensFullyContained(a: string, b: string): boolean {
+  const aTokens = new Set(a.toLowerCase().split(/\s+/));
+  return b.toLowerCase().split(/\s+/).every((t) => aTokens.has(t));
+}
+
+/** Append a sibling `Co-Hare:` / `Co-Hares:` capture to the primary hare
+ *  string when one exists in the description. Gated on a cheap substring
+ *  check so consumers without Co-Hare labels (Meetup, Phoenix, most GCal)
+ *  skip the regex altogether. Order is text-derived (deterministic) — no
+ *  sort required for fingerprint stability. */
+function mergeCoHareIfPresent(primary: string, normalized: string): string {
+  if (!/co-?hare/i.test(normalized)) return primary;
+  const coMatch = COHARE_LABEL_RE.exec(normalized);
+  if (!coMatch?.[1]) return primary;
+  const coRaw = coMatch[1].trim().split("\n")[0].trim();
+  const coCleaned = cleanAndFilterHares(coRaw);
+  if (!coCleaned || tokensFullyContained(primary, coCleaned)) return primary;
+  return `${primary}, ${coCleaned}`;
 }

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -183,23 +183,35 @@ export function extractHares(description: string, customPatterns?: string[] | Re
 
 /** Token-set containment: every word in `b` already appears (case-insensitive)
  *  as a whole word in `a`. Avoids substring false-positives where "Ali" would
- *  match inside "Alice and Bob" and silently suppress a real co-hare. */
+ *  match inside "Alice and Bob" and silently suppress a real co-hare. Splits
+ *  on whitespace + commas so the primary's joined form ("Alice, Bob") still
+ *  matches a co-hare candidate of "Bob". */
 function tokensFullyContained(a: string, b: string): boolean {
-  const aTokens = new Set(a.toLowerCase().split(/\s+/));
-  return b.toLowerCase().split(/\s+/).every((t) => aTokens.has(t));
+  const aTokens = new Set(a.toLowerCase().split(/[\s,]+/).filter(Boolean));
+  return b.toLowerCase().split(/[\s,]+/).filter(Boolean).every((t) => aTokens.has(t));
 }
 
-/** Append a sibling `Co-Hare:` / `Co-Hares:` capture to the primary hare
- *  string when one exists in the description. Gated on a cheap substring
- *  check so consumers without Co-Hare labels (Meetup, Phoenix, most GCal)
- *  skip the regex altogether. Order is text-derived (deterministic) — no
- *  sort required for fingerprint stability. */
+/** Global form so `matchAll` can capture every `Co-Hare:` / `Co-Hares:` line
+ *  on descriptions that list multiple co-hares on separate lines. */
+const COHARE_LABEL_GLOBAL_RE = new RegExp(COHARE_LABEL_RE.source, "gim"); // NOSONAR — reuses anchored source
+
+/** Append every sibling `Co-Hare:` / `Co-Hares:` capture to the primary hare
+ *  string. Gated on a cheap substring check so consumers without Co-Hare
+ *  labels (Meetup, Phoenix, most GCal) skip the regex iteration altogether.
+ *  Each candidate is filtered through `cleanAndFilterHares` and added only
+ *  if it's not already token-contained in the running result. Order is
+ *  text-derived (deterministic) — no sort required for fingerprint
+ *  stability. */
 function mergeCoHareIfPresent(primary: string, normalized: string): string {
   if (!/co-?hare/i.test(normalized)) return primary;
-  const coMatch = COHARE_LABEL_RE.exec(normalized);
-  if (!coMatch?.[1]) return primary;
-  const coRaw = coMatch[1].trim().split("\n")[0].trim();
-  const coCleaned = cleanAndFilterHares(coRaw);
-  if (!coCleaned || tokensFullyContained(primary, coCleaned)) return primary;
-  return `${primary}, ${coCleaned}`;
+  let result = primary;
+  for (const match of normalized.matchAll(COHARE_LABEL_GLOBAL_RE)) {
+    const coRaw = match[1]?.trim().split("\n")[0].trim();
+    if (!coRaw) continue;
+    const coCleaned = cleanAndFilterHares(coRaw);
+    if (coCleaned && !tokensFullyContained(result, coCleaned)) {
+      result = `${result}, ${coCleaned}`;
+    }
+  }
+  return result;
 }

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -61,9 +61,14 @@ const COHARE_COMMENTARY_RE = /\s*(?:could|need)\s+.*?co-?hares?\b.*$/i; // NOSON
 // (e.g. "Alice - Bob" — second hare survives the existing comma split).
 const TRAILING_LOWERCASE_COMMENTARY_RE = /\s+[-–—]\s+[a-z][^A-Z]*$/; // NOSONAR — anchored, single char class
 // Sibling Co-Hare label scan (#1212): when the primary `Hare:` capture
-// succeeded, also look for a separate `Co-Hare:` / `Co-Hares:` line in the
-// same description. Non-greedy until end of line.
+// succeeded, also look for separate `Co-Hare:` / `Co-Hares:` lines in the
+// same description. Both forms exposed: single-match (used internally as a
+// substring gate) and global-match (used by `mergeCoHareIfPresent` to
+// iterate every line via `matchAll`). Declared as literals so Codacy's
+// non-literal-RegExp rule (security/detect-non-literal-regexp) doesn't
+// flag the construction.
 const COHARE_LABEL_RE = /(?:^|\n)[ \t]*Co-?Hares?:[ \t]*([^\n]+)/im; // NOSONAR — anchored, capture is `[^\n]+` (no nesting)
+const COHARE_LABEL_GLOBAL_RE = /(?:^|\n)[ \t]*Co-?Hares?:[ \t]*([^\n]+)/gim; // NOSONAR — same shape, global flag for matchAll
 // Pre-normalize: rejoin lines where HTML stripping split a label from its colon
 // e.g., "<b>WHO (hares)</b>: Name" → after stripHtmlTags → "WHO (hares)\n: Name"
 const LABEL_COLON_REJOIN_RE = /(\b(?:Who|Hares?)\s*\(?[^)]*\)?)\s*\n\s*:/gim; // NOSONAR — bounded by literal `\n` and char classes; capture is `[^)]*` (no nesting)
@@ -190,10 +195,6 @@ function tokensFullyContained(a: string, b: string): boolean {
   const aTokens = new Set(a.toLowerCase().split(/[\s,]+/).filter(Boolean));
   return b.toLowerCase().split(/[\s,]+/).filter(Boolean).every((t) => aTokens.has(t));
 }
-
-/** Global form so `matchAll` can capture every `Co-Hare:` / `Co-Hares:` line
- *  on descriptions that list multiple co-hares on separate lines. */
-const COHARE_LABEL_GLOBAL_RE = new RegExp(COHARE_LABEL_RE.source, "gim"); // NOSONAR — reuses anchored source
 
 /** Append every sibling `Co-Hare:` / `Co-Hares:` capture to the primary hare
  *  string. Gated on a cheap substring check so consumers without Co-Hare

--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -6,6 +6,7 @@ import {
   parseEventFromItem,
   PhoenixHHHAdapter,
 } from "./phoenixhhh";
+import { extractHashRunNumber } from "../utils";
 
 // ── Sample HTML fixtures ──
 
@@ -287,6 +288,61 @@ describe("hare extraction", () => {
     const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
 
     expect(event!.hares).toBeUndefined();
+  });
+});
+
+// ── runNumber extraction (#1211) ──
+
+describe("extractHashRunNumber (#1211 Wrong Way URL-slug fix)", () => {
+  it("extracts run number from 'Kennel #NNN: Trail' title", () => {
+    expect(extractHashRunNumber("Wrong Way #1156: Master Shake n' Baker")).toBe(1156);
+  });
+
+  it("extracts run number with whitespace after #", () => {
+    expect(extractHashRunNumber("Wrong Way # 1156")).toBe(1156);
+  });
+
+  it("returns undefined for ambiguous mid-token alphanumeric", () => {
+    // Mirrors the GCal #1147 delimiter guard — "#30X?" is the kennel saying
+    // run number unknown.
+    expect(extractHashRunNumber("Wrong Way #30X?")).toBeUndefined();
+  });
+
+  it("returns undefined when no run number present", () => {
+    expect(extractHashRunNumber("Wrong Way Trail")).toBeUndefined();
+  });
+
+  it("returns undefined for null/empty title", () => {
+    expect(extractHashRunNumber(undefined)).toBeUndefined();
+    expect(extractHashRunNumber("")).toBeUndefined();
+  });
+});
+
+describe("parseEventFromItem — runNumber from img-alt title (#1211)", () => {
+  it("extracts runNumber from a title containing '#NNN'", () => {
+    const html = `
+      <div class="em-item em-event">
+        <div class="em-item-image">
+          <img src="/img/x.jpg" alt="Wrong Way #1156: Master Shake n' Baker" />
+        </div>
+        <div class="em-item-meta-line em-event-date">Saturday - 05/02/2026</div>
+        <div class="em-item-meta-line em-event-time">6:30 pm - 9:30 pm</div>
+        <a class="em-item-read-more" href="/?event=wrong-way-1155-need-hares">Read More</a>
+      </div>
+    `;
+    const $ = cheerio.load(html);
+    const $item = $(".em-item").first();
+    const config = {
+      kennelPatterns: [["Wrong Way", "wrong-way"] as [string, string]],
+      defaultKennelTag: "wrong-way",
+    };
+    const compiledPatterns: [RegExp, string][] = [[/Wrong Way/i, "wrong-way"]];
+    const event = parseEventFromItem($item, $, config, compiledPatterns);
+    expect(event).not.toBeNull();
+    expect(event!.runNumber).toBe(1156);
+    // The sourceUrl still contains the stale slug — that's fine; we just
+    // don't trust it for runNumber extraction.
+    expect(event!.sourceUrl).toContain("wrong-way-1155-need-hares");
   });
 });
 

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -14,7 +14,7 @@ import type { AnyNode } from "domhandler";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails, ParseError } from "../types";
 import { safeFetch } from "../safe-fetch";
-import { parse12HourTime, validateSourceConfig, compilePatterns, buildDateWindow, stripHtmlTags, decodeEntities } from "../utils";
+import { parse12HourTime, validateSourceConfig, compilePatterns, buildDateWindow, stripHtmlTags, decodeEntities, extractHashRunNumber } from "../utils";
 import { extractHares } from "../hare-extraction";
 
 // ── Config shape ──
@@ -136,7 +136,9 @@ export function parseEventFromItem(
 
   return {
     date,
-    kennelTags: [kennelTag],    title,
+    kennelTags: [kennelTag],
+    title,
+    runNumber: extractHashRunNumber(title),
     description,
     hares,
     location,
@@ -295,6 +297,14 @@ export class PhoenixHHHAdapter implements SourceAdapter {
               break;
             }
           }
+          // #1211: detail-page title is the authoritative run number source.
+          // Always overwrite when the fetched title yields a number — the
+          // list-page img.alt may carry a stale placeholder (e.g. "Wrong Way
+          // #1155 need hares") that the kennel later corrected on the detail
+          // page (#1156). Falling back to the previous value only when the
+          // detail title yields nothing keeps us no worse than before.
+          const detailRun = extractHashRunNumber(result.value);
+          if (detailRun !== undefined) batch[j].runNumber = detailRun;
           titlesFetched++;
         }
       }

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -707,15 +707,20 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
 // Placeholder detection — shared across adapters for TBD/TBA/TBC cleanup
 // ---------------------------------------------------------------------------
 
-// Split into two simpler patterns to stay under SonarCloud's per-regex
-// complexity budget (S5856). `(?:venue[\s-]+)?` on the TBC branch lets
-// "venue TBC" / "venue TBD" / "venue TBA" pass through (#1222 Capital H3).
-const PLACEHOLDER_SHORT_RE =
-  /^(?:(?:venue[\s-]+)?(?:tbd|tba|tbc)|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3})$/i;
-const PLACEHOLDER_HARE_NEEDED_RE =
-  /^(?:hares?\s+needed\b[\s\S]*|needs?\s+(?:a\s+)?hares?\b[\s\S]*)$/i;
+// Split into narrow patterns to stay under SonarCloud's per-regex complexity
+// budget (S5856). `(?:venue[\s-]+)?` on the TBC branch lets "venue TBC" /
+// "venue TBD" / "venue TBA" pass through (#1222 Capital H3). The
+// `hares?\s+needed` / `needs?\s+(?:a\s+)?hares?` branches share the same
+// `[\s\S]*` tail so they're folded into a single anchored regex via
+// alternation and a single tail.
+const PLACEHOLDER_TBD_RE = /^(?:venue[\s-]+)?(?:tbd|tba|tbc)$/i;
+const PLACEHOLDER_OTHER_RE =
+  /^(?:n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3})$/i;
+const PLACEHOLDER_HARES_NEEDED_RE = /^(?:hares?\s+needed|needs?\s+(?:a\s+)?hares?)\b[\s\S]*$/i;
 function isPlaceholderText(value: string): boolean {
-  return PLACEHOLDER_SHORT_RE.test(value) || PLACEHOLDER_HARE_NEEDED_RE.test(value);
+  return PLACEHOLDER_TBD_RE.test(value)
+    || PLACEHOLDER_OTHER_RE.test(value)
+    || PLACEHOLDER_HARES_NEEDED_RE.test(value);
 }
 
 /**

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -707,11 +707,16 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
 // Placeholder detection — shared across adapters for TBD/TBA/TBC cleanup
 // ---------------------------------------------------------------------------
 
-// `(?:venue[\s-]+)?` lets "venue TBC" / "venue TBD" / "venue TBA" pass through
-// the placeholder filter (#1222 Capital H3). Other branches stay anchored as
-// they were — extension is scoped to the tbd|tba|tbc branch.
-const PLACEHOLDER_RE =
-  /^(?:(?:venue[\s-]+)?(?:tbd|tba|tbc)|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3}|hares?\s+needed\b[\s\S]*|needs?\s+(?:a\s+)?hares?\b[\s\S]*)$/i;
+// Split into two simpler patterns to stay under SonarCloud's per-regex
+// complexity budget (S5856). `(?:venue[\s-]+)?` on the TBC branch lets
+// "venue TBC" / "venue TBD" / "venue TBA" pass through (#1222 Capital H3).
+const PLACEHOLDER_SHORT_RE =
+  /^(?:(?:venue[\s-]+)?(?:tbd|tba|tbc)|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3})$/i;
+const PLACEHOLDER_HARE_NEEDED_RE =
+  /^(?:hares?\s+needed\b[\s\S]*|needs?\s+(?:a\s+)?hares?\b[\s\S]*)$/i;
+function isPlaceholderText(value: string): boolean {
+  return PLACEHOLDER_SHORT_RE.test(value) || PLACEHOLDER_HARE_NEEDED_RE.test(value);
+}
 
 /**
  * Field labels that frequently appear next to a colon in event descriptions
@@ -741,7 +746,7 @@ export const EVENT_FIELD_LABEL_UPPERCASE_RE =
  * Fully anchored + case-insensitive. Trims input before matching.
  */
 export function isPlaceholder(value: string): boolean {
-  return PLACEHOLDER_RE.test(value.trim());
+  return isPlaceholderText(value.trim());
 }
 
 /**
@@ -751,7 +756,7 @@ export function isPlaceholder(value: string): boolean {
 export function stripPlaceholder(value: string | undefined | null): string | undefined {
   if (value == null) return undefined;
   const trimmed = value.trim();
-  if (!trimmed || PLACEHOLDER_RE.test(trimmed)) return undefined;
+  if (!trimmed || isPlaceholderText(trimmed)) return undefined;
   return trimmed;
 }
 

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -686,12 +686,32 @@ export function stripNonEnglishCountry(location: string): string {
   return location.replace(NON_ENGLISH_COUNTRY_SUFFIX_RE, "").trim();
 }
 
+/**
+ * Match `#NNN` in free-form text and return the integer. Lookahead requires a
+ * clean delimiter after the digits so ambiguous tokens like `#30X?` (kennel
+ * signaling unknown run number) reject instead of being parsed as 30 (#1147).
+ * Shared by the Google Calendar summary path (`extractRunNumber` in
+ * `google-calendar/adapter.ts`) and the Phoenix HHH HTML scraper which
+ * preempts a stale-WordPress-slug fallback (#1211).
+ */
+const HASH_RUN_NUMBER_RE = /#\s*(\d+)(?=$|[\s:\-–—,.()/])/;
+export function extractHashRunNumber(text: string | undefined): number | undefined {
+  if (!text) return undefined;
+  const m = HASH_RUN_NUMBER_RE.exec(text);
+  if (!m) return undefined;
+  const n = Number.parseInt(m[1], 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Placeholder detection — shared across adapters for TBD/TBA/TBC cleanup
 // ---------------------------------------------------------------------------
 
+// `(?:venue[\s-]+)?` lets "venue TBC" / "venue TBD" / "venue TBA" pass through
+// the placeholder filter (#1222 Capital H3). Other branches stay anchored as
+// they were — extension is scoped to the tbd|tba|tbc branch.
 const PLACEHOLDER_RE =
-  /^(?:tbd|tba|tbc|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3}|hares?\s+needed\b[\s\S]*|needs?\s+(?:a\s+)?hares?\b[\s\S]*)$/i;
+  /^(?:(?:venue[\s-]+)?(?:tbd|tba|tbc)|n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3}|hares?\s+needed\b[\s\S]*|needs?\s+(?:a\s+)?hares?\b[\s\S]*)$/i;
 
 /**
  * Field labels that frequently appear next to a colon in event descriptions


### PR DESCRIPTION
## Summary

Cycle-2 audit-stream Deep Dive — fixes 8 production bugs across the Google Calendar adapter (7) and the Phoenix HHH HTML scraper (1). All eight surfaced after cycle-1 WS1 (#1215) merged.

| # | Theme | Source | Fix |
|---|---|---|---|
| #1199 | All-day vs timed dedup | WA Hash (Giggity) | Placeholder-gated dedup pre-pass — drops shells (no run number + `#?`/TBD/placeholder hares) only when a timed sibling exists |
| #1208 | DST title-embedded hare | Stuttgart | New `^DST\s*#?\s*\d*\s*-\s*(.+)$` pattern in titleHarePattern array |
| #1209/#1221 | CH3 third-dash hare | Copenhagen | New `^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$` pattern in titleHarePattern array |
| #1210 | Austin trailing `-` leak | Austin H3 | Tightened to require ` - ` + adapter-side anchored strip |
| #1211 | Stale WordPress slug runNumber | Phoenix HHH | Lifted shared `extractHashRunNumber` to utils; detail-page title unconditionally overwrites list-page number |
| #1212 | Co-Hare + annotation | GLH3 | extractHares merges sibling `Co-Hare:` lines (token-set check); strips ` - lowercase commentary` |
| #1222 | Title hares + location + placeholder | Capital H3 | New `titleLocationPattern` config; `PLACEHOLDER_RE` extended for `venue TBC` |

### Architectural notes

- **`titleHarePattern` widened to `string | string[]`** — Stuttgart and Copenhagen each need two patterns to handle multiple sub-kennels on one calendar. Compile path normalizes via new `compileMaybeArray` helper. Backwards compatible.
- **`titleLocationPattern` (new field)** — separate from `titleHarePattern` to avoid mixed-purpose patterns; isPlaceholder() rejects `venue TBC`-style values before assignment.
- **All-day dedup is placeholder-gated** (Codex adversarial finding) — `isPlaceholderShell` requires `runNumber === undefined` AND placeholder evidence (`#?`, TBD/TBA/TBC marker, placeholder hares). Real all-day events (campouts, away weekends) survive even when sharing a date with a timed trail. Regression test included.
- **Phoenix detail title is authoritative for runNumber** (Codex adversarial finding) — the post-fetch loop now overwrites the list-page value when the detail title yields a number, preempting WordPress slug fallback even if the list-page img-alt was stale.
- **`extractHares` extensions are additive** — Co-Hare merge gated on cheap `co-?hare` substring + token-set containment check (avoids `Ali`-in-`Alice` false positives). Trailing-commentary strip gated on `' - '` substring. Meetup + Phoenix HHH consumer tests rerun green.

### Verification

- `npm run lint && npx tsc --noEmit && npm test` — green (5888 tests, +3 from baseline)
- Live-verified against 6 calendars + 1 HTML source: Capital H3 (Canberra), Austin H3, GLH3, WA Hash (Giggity + CUNTh both behave correctly), Stuttgart H3 (DST 53/54 hares populated, was 10/54), Copenhagen H3 (CH3 28/73 + RDH3 26/48 hares populated)
- Live-verify script: [scripts/live-verify-gcal-cycle2.ts](https://github.com/johnrclem/hashtracks-web/blob/claude/amazing-brattain-6817f6/scripts/live-verify-gcal-cycle2.ts)

### Pre-PR review

- `/simplify`: 5 fixes applied (Co-Hare token-set check; cross-adapter `extractHashRunNumber` reuse; `compileMaybeArray` helper; Co-Hare regex hot-path gate; trailing-commentary regex hot-path gate)
- `/codex:adversarial-review`: 2 high/medium findings → both fixed (placeholder-gated dedup + Phoenix detail-overwrite + campout regression test)

## Test plan

- [x] Unit tests: 8 new `describe` blocks across `adapter.test.ts`, `hare-extraction.test.ts`, `phoenixhhh.test.ts`
- [x] Type check: 0 errors
- [x] Live verification against 4+ kennels per `.claude/rules/live-verification.md`
- [x] Coupling check: Meetup + Phoenix HHH (extractHares consumers) tests still pass
- [ ] Post-merge: monitor self-healing pipeline for any audit-stream re-flag on these 8 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1199
Closes #1208
Closes #1209
Closes #1210
Closes #1211
Closes #1212
Closes #1221
Closes #1222