### PR TITLE
fix(audit): pre-mint deep-dive tokens at page render (closes #1207, #1216, #1175)

### DIFF
--- a/src/app/admin/audit/actions.ts
+++ b/src/app/admin/audit/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import * as Sentry from "@sentry/nextjs";
 import { Prisma, AuditStream, AuditIssueEventType } from "@/generated/prisma/client";
 import { prisma } from "@/lib/db";
 import { getAdminUser } from "@/lib/auth";
@@ -505,16 +506,24 @@ export async function getDeepDiveCoverage(): Promise<DeepDiveCoverage> {
 export async function getDeepDiveQueueToken(
   kennelCode: string,
 ): Promise<{ token: string; expiresAt: number } | null> {
-  await requireAdmin();
-  if (!kennelCode) return null;
+  try {
+    await requireAdmin();
+    if (!kennelCode) return null;
 
-  const kennelCodes = await getDeepDiveQueueKennelCodes();
-  if (!kennelCodes.includes(kennelCode)) return null;
+    const kennelCodes = await getDeepDiveQueueKennelCodes();
+    if (!kennelCodes.includes(kennelCode)) return null;
 
-  const expiresAt = computeQueueTokenExpiresAt();
-  const queueSnapshotId = computeQueueSnapshotId(kennelCodes);
-  const token = signQueueToken({ kennelCode, queueSnapshotId, expiresAt });
-  return { token, expiresAt };
+    const expiresAt = computeQueueTokenExpiresAt();
+    const queueSnapshotId = computeQueueSnapshotId(kennelCodes);
+    const token = signQueueToken({ kennelCode, queueSnapshotId, expiresAt });
+    return { token, expiresAt };
+  } catch (err) {
+    // Production-sanitized "Server Components render" error hides the
+    // root cause from the dialog. Capture before rethrowing so the
+    // actual digest stays diagnosable in Sentry (issues #1207 / #1216).
+    Sentry.captureException(err, { extra: { kennelCode } });
+    throw err;
+  }
 }
 
 /** Result shape for `recordDeepDive`. Discriminated union on `ok`

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -15,6 +15,7 @@ import {
 import { KNOWN_AUDIT_RULES } from "@/pipeline/audit-checks";
 import { AuditDashboard } from "@/components/admin/AuditDashboard";
 import { buildHarelinePrompt } from "@/lib/admin/hareline-prompt";
+import { mintQueueTokens } from "@/lib/queue-snapshot-token";
 
 /** Build the daily hareline audit prompt at request time so the curated
  *  sections (recently-fixed, focus areas) reflect live data. Returns null on
@@ -67,6 +68,16 @@ export default async function AuditPage() {
     getRecentOpenIssues().catch(() => []),
   ]);
 
+  // Pre-mint a queue token per candidate at page render so the dialog
+  // doesn't have to round-trip a server action on open. Eliminates the
+  // "Server Components render" error path from #1207 / #1216 caused by
+  // intermittent failures in the on-open token mint. `mintQueueTokens`
+  // returns `{}` on failure (e.g. missing secret), in which case the
+  // dialog falls back to its async `getDeepDiveQueueToken` path.
+  const deepDiveTokens = mintQueueTokens(
+    deepDiveQueueResult.map((k) => k.kennelCode),
+  );
+
   return (
     <AuditDashboard
       trends={trendsResult}
@@ -77,6 +88,7 @@ export default async function AuditPage() {
       knownRules={[...KNOWN_AUDIT_RULES]}
       deepDiveQueue={deepDiveQueueResult}
       deepDiveCoverage={deepDiveCoverageResult}
+      deepDiveTokens={deepDiveTokens}
       harelinePrompt={harelinePrompt}
       streamTrends={streamTrendsResult}
       streamOpenCounts={streamOpenCountsResult}

--- a/src/components/admin/AuditDashboard.tsx
+++ b/src/components/admin/AuditDashboard.tsx
@@ -83,6 +83,18 @@ interface KennelOption {
   shortName: string;
 }
 
+import type {
+  MintedQueueToken,
+  MintedQueueTokens,
+} from "@/lib/queue-snapshot-token";
+
+/** Pre-minted queue tokens keyed by kennelCode. Empty when the
+ *  page-render mint failed (e.g. missing secret) — the dialog falls
+ *  back to the async `getDeepDiveQueueToken` path. Re-exports the
+ *  lib type so the `page → dashboard → dialog` prop chain stays in
+ *  one shape; rename to `DeepDiveTokens` for context at call sites. */
+export type DeepDiveTokens = MintedQueueTokens;
+
 interface Props {
   trends: TrendPoint[];
   topOffenders: TopOffender[];
@@ -92,6 +104,7 @@ interface Props {
   knownRules: string[];
   deepDiveQueue: DeepDiveCandidate[];
   deepDiveCoverage: DeepDiveCoverage;
+  deepDiveTokens: DeepDiveTokens;
   harelinePrompt: string | null;
   streamTrends: StreamTrendPoint[];
   streamOpenCounts: StreamOpenCounts[];
@@ -120,6 +133,7 @@ export function AuditDashboard({
   knownRules,
   deepDiveQueue,
   deepDiveCoverage,
+  deepDiveTokens,
   harelinePrompt,
   streamTrends,
   streamOpenCounts,
@@ -338,6 +352,7 @@ export function AuditDashboard({
         <DeepDiveCard
           queue={deepDiveQueue}
           coverage={deepDiveCoverage}
+          tokens={deepDiveTokens}
           onCompleted={() => router.refresh()}
         />
       </section>
@@ -755,10 +770,12 @@ function CopyHarelinePromptButton({ prompt }: Readonly<{ prompt: string }>) {
 function DeepDiveCard({
   queue,
   coverage,
+  tokens,
   onCompleted,
 }: {
   queue: DeepDiveCandidate[];
   coverage: DeepDiveCoverage;
+  tokens: DeepDiveTokens;
   onCompleted: () => void;
 }) {
   const [selectedCode, setSelectedCode] = useState(queue[0]?.kennelCode ?? "");
@@ -804,13 +821,24 @@ function DeepDiveCard({
             <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-1.5">
               Deep dive target
             </div>
+            {/* `data-kennel-code` on the trigger, items, and queue rows lets
+                accessibility-tree-driven agents (and e2e tests) verify which
+                kennel is bound without parsing display text — closes #1175's
+                ask 6 (the misattribution that motivated #1160 / #1175). */}
             <Select value={selectedCode} onValueChange={(v) => { setSelectedCode(v); setCopied(false); }}>
-              <SelectTrigger className="h-9 w-full max-w-sm text-base font-semibold">
+              <SelectTrigger
+                className="h-9 w-full max-w-sm text-base font-semibold"
+                data-kennel-code={selectedCode}
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
                 {queue.map((k) => (
-                  <SelectItem key={k.kennelCode} value={k.kennelCode}>
+                  <SelectItem
+                    key={k.kennelCode}
+                    value={k.kennelCode}
+                    data-kennel-code={k.kennelCode}
+                  >
                     <span className="font-medium">{k.shortName}</span>
                     <span className="ml-2 text-xs text-muted-foreground">{k.region}</span>
                   </SelectItem>
@@ -883,6 +911,7 @@ function DeepDiveCard({
                     key={k.kennelCode}
                     role="button"
                     tabIndex={0}
+                    data-kennel-code={k.kennelCode}
                     className={`cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 ${
                       k.kennelCode === selectedCode
                         ? "bg-accent/50 border-l-2 border-l-purple-500"
@@ -922,6 +951,7 @@ function DeepDiveCard({
         open={completeOpen}
         onOpenChange={setCompleteOpen}
         kennel={currentKennel}
+        prefetchedToken={tokens[currentKennel.kennelCode] ?? null}
         onCompleted={() => {
           setCompleteOpen(false);
           onCompleted();
@@ -935,11 +965,17 @@ function DeepDiveCompleteDialog({
   open,
   onOpenChange,
   kennel,
+  prefetchedToken,
   onCompleted,
 }: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
   kennel: DeepDiveCandidate;
+  /** Token minted server-side at page render. When present, the
+   *  dialog skips the on-open server action — the round trip was the
+   *  failure surface in #1207 / #1216. `null` falls back to the
+   *  async path. */
+  prefetchedToken: MintedQueueToken | null;
   onCompleted: () => void;
 }) {
   const [findingsCount, setFindingsCount] = useState(0);
@@ -957,10 +993,12 @@ function DeepDiveCompleteDialog({
     null,
   );
 
-  // Fetch the snapshot-bound token on open. The token captures the
-  // queue's membership at click time so a queue change between
-  // dialog-open and submit can't misattribute the deep dive
-  // (issue #1160).
+  // Bind the dialog to a kennel + token on open. The page mints a
+  // token server-side and passes it via `prefetchedToken`; we use
+  // that synchronously to skip the on-open server action that
+  // intermittently failed in production (#1207 / #1216). When the
+  // prefetched token is missing (e.g. page-render mint failed), fall
+  // back to the async `getDeepDiveQueueToken` path.
   useEffect(() => {
     if (!open) return;
     // Freeze the dialog target on this open transition. Subsequent
@@ -971,6 +1009,21 @@ function DeepDiveCompleteDialog({
     setFindingsCount(0);
     setSummary("");
     setError(null);
+
+    // Reject prefetched tokens that are at or past their TTL — falling
+    // through to the async fetch lets a long-idle dashboard recover
+    // without a page refresh. 30s buffer absorbs the round-trip
+    // between dialog-open and submit.
+    const TOKEN_FRESHNESS_BUFFER_MS = 30_000;
+    if (
+      prefetchedToken &&
+      prefetchedToken.expiresAt - Date.now() > TOKEN_FRESHNESS_BUFFER_MS
+    ) {
+      setQueueToken(prefetchedToken.token);
+      setTokenLoading(false);
+      return;
+    }
+
     setQueueToken(null);
     setTokenLoading(true);
     let cancelled = false;
@@ -999,9 +1052,9 @@ function DeepDiveCompleteDialog({
     return () => {
       cancelled = true;
     };
-    // Intentionally exclude `kennel` from deps — see freeze rationale
-    // above. Re-running this effect on `kennel` change would defeat
-    // the misattribution defense.
+    // Intentionally exclude `kennel` and `prefetchedToken` from deps —
+    // see freeze rationale above. Re-running this effect on prop
+    // change would defeat the misattribution defense.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
@@ -1072,10 +1125,19 @@ function DeepDiveCompleteDialog({
           );
           return;
         }
-        // invalidToken: session expired or tampered
-        setError(
-          "Submission token rejected. Cancel and re-open the dialog to refresh.",
-        );
+        // invalidToken: session expired or tampered. Try refetching
+        // in-place — the page-render-minted prefetched token expires
+        // after QUEUE_TOKEN_TTL_MS, and an idle dashboard would
+        // otherwise need a full refresh to recover. If the refetch
+        // succeeds, prompt the operator to submit again with the
+        // fresh token. If it fails, refetchToken already set its
+        // own error.
+        const fresh = await refetchToken();
+        if (fresh) {
+          setError(
+            "Submission token expired — refreshed automatically. Submit again to confirm.",
+          );
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to record deep dive");
       }

--- a/src/lib/queue-snapshot-token.test.ts
+++ b/src/lib/queue-snapshot-token.test.ts
@@ -5,6 +5,7 @@ import {
   signQueueToken,
   verifyQueueToken,
   computeQueueTokenExpiresAt,
+  mintQueueTokens,
   QUEUE_TOKEN_TTL_MS,
 } from "./queue-snapshot-token";
 
@@ -164,6 +165,67 @@ describe("computeQueueTokenExpiresAt", () => {
   it("honors an explicit ttl override", () => {
     const exp = computeQueueTokenExpiresAt(60_000);
     expect(exp).toBeLessThan(Date.now() + 90_000);
+  });
+});
+
+describe("mintQueueTokens", () => {
+  it("returns one verifiable token per kennelCode sharing the same snapshot", () => {
+    const codes = ["nych3", "philly-h3", "agnews"];
+    const tokens = mintQueueTokens(codes);
+    expect(Object.keys(tokens).sort()).toEqual([...codes].sort());
+
+    const expectedSnapshot = computeQueueSnapshotId(codes);
+    for (const code of codes) {
+      const minted = tokens[code];
+      expect(minted).toBeDefined();
+      if (!minted) continue;
+      const result = verifyQueueToken(minted.token);
+      expect(result.ok).toBe(true);
+      if (!result.ok) continue;
+      expect(result.payload.kennelCode).toBe(code);
+      expect(result.payload.queueSnapshotId).toBe(expectedSnapshot);
+      expect(minted.expiresAt).toBe(result.payload.expiresAt);
+    }
+  });
+
+  it("returns the same snapshot regardless of input order", () => {
+    const a = mintQueueTokens(["nych3", "philly-h3", "agnews"]);
+    const b = mintQueueTokens(["agnews", "nych3", "philly-h3"]);
+    const aMinted = a.nych3;
+    const bMinted = b.nych3;
+    expect(aMinted && bMinted).toBeDefined();
+    if (!aMinted || !bMinted) return;
+    const aResult = verifyQueueToken(aMinted.token);
+    const bResult = verifyQueueToken(bMinted.token);
+    expect(aResult.ok && bResult.ok).toBe(true);
+    if (!aResult.ok || !bResult.ok) return;
+    expect(aResult.payload.queueSnapshotId).toBe(
+      bResult.payload.queueSnapshotId,
+    );
+  });
+
+  it("returns {} for an empty input", () => {
+    expect(mintQueueTokens([])).toEqual({});
+  });
+
+  it("returns {} when the secret is missing instead of throwing (page must still render)", () => {
+    delete process.env.AUDIT_QUEUE_TOKEN_SECRET;
+    expect(mintQueueTokens(["nych3"])).toEqual({});
+  });
+
+  it("stamps expiresAt at QUEUE_TOKEN_TTL_MS in the future so callers can detect staleness", () => {
+    // Codex flagged a no-ship: the dialog accepts prefetchedToken
+    // unconditionally, so a tab idle past the TTL submits an expired
+    // token. The mint side returns expiresAt; the dialog gates on
+    // `expiresAt - Date.now() > buffer` to fall back to async fetch.
+    const before = Date.now();
+    const tokens = mintQueueTokens(["nych3"]);
+    const after = Date.now();
+    const minted = tokens.nych3;
+    expect(minted).toBeDefined();
+    if (!minted) return;
+    expect(minted.expiresAt).toBeGreaterThanOrEqual(before + QUEUE_TOKEN_TTL_MS);
+    expect(minted.expiresAt).toBeLessThanOrEqual(after + QUEUE_TOKEN_TTL_MS);
   });
 });
 

--- a/src/lib/queue-snapshot-token.test.ts
+++ b/src/lib/queue-snapshot-token.test.ts
@@ -172,7 +172,8 @@ describe("mintQueueTokens", () => {
   it("returns one verifiable token per kennelCode sharing the same snapshot", () => {
     const codes = ["nych3", "philly-h3", "agnews"];
     const tokens = mintQueueTokens(codes);
-    expect(Object.keys(tokens).sort()).toEqual([...codes].sort());
+    const cmp = (a: string, b: string) => a.localeCompare(b);
+    expect(Object.keys(tokens).sort(cmp)).toEqual([...codes].sort(cmp));
 
     const expectedSnapshot = computeQueueSnapshotId(codes);
     for (const code of codes) {

--- a/src/lib/queue-snapshot-token.ts
+++ b/src/lib/queue-snapshot-token.ts
@@ -157,3 +157,47 @@ export function computeQueueTokenExpiresAt(
 ): number {
   return Date.now() + ttlMs;
 }
+
+/** Single signed token + its expiration. The shape callers store and
+ *  hand off to a submission. */
+export interface MintedQueueToken {
+  token: string;
+  expiresAt: number;
+}
+
+/** Map of `kennelCode → MintedQueueToken`. `Partial` because lookups
+ *  by an unrecognized kennelCode return `undefined` — callers must
+ *  handle the missing case (typically by falling back to the async
+ *  `getDeepDiveQueueToken` server action). */
+export type MintedQueueTokens = Partial<Record<string, MintedQueueToken>>;
+
+/**
+ * Mint one queue token per candidate kennelCode in a single pass —
+ * shares the snapshot ID and expiration across all entries so the
+ * caller can hand each dialog a pre-signed token at page render time.
+ *
+ * Returns `{}` when the secret isn't configured (or any other signing
+ * failure) so the caller can fall back to the on-open server action
+ * without crashing the page render. Failure is logged so the
+ * underlying cause stays diagnosable.
+ */
+export function mintQueueTokens(
+  kennelCodes: readonly string[],
+): MintedQueueTokens {
+  if (kennelCodes.length === 0) return {};
+  try {
+    const queueSnapshotId = computeQueueSnapshotId(kennelCodes);
+    const expiresAt = computeQueueTokenExpiresAt();
+    const out: MintedQueueTokens = {};
+    for (const kennelCode of kennelCodes) {
+      out[kennelCode] = {
+        token: signQueueToken({ kennelCode, queueSnapshotId, expiresAt }),
+        expiresAt,
+      };
+    }
+    return out;
+  } catch (err) {
+    console.warn("[queue-snapshot-token] mintQueueTokens failed:", err);
+    return {};
+  }
+}


### PR DESCRIPTION
Closes #1207
Closes #1216
Closes #1175

## Summary

Fixes the admin audit "Mark deep dive complete" dialog which intermittently rendered a *"Server Components render"* error and left submit as a silent no-op for GLH3 (#1207) and GGFM (#1216). Also addresses the residual a11y asks from #1175 not already covered by PR #1203's snapshot-token guard.

## Root cause

PR #1203 introduced the `getDeepDiveQueueToken` server action and the dialog called it from a `useEffect` on every open. Under intermittent Prisma `TooManyConnections` pressure (visible in production logs around the same window) that action threw. Next.js sanitized the message to *"An error occurred in the Server Components render…"* and the dialog wrote that text into its error state. Submit button was `disabled={!queueToken}`, so the click looked like a silent no-op.

`AUDIT_QUEUE_TOKEN_SECRET` is set in Vercel — the missing-secret theory was ruled out.

## Fix

- **Mint queue tokens at page render** (`src/lib/queue-snapshot-token.ts`) — one batch pass over the already-fetched queue, sharing the snapshot ID + expiration. Returns `{}` on signing failure so the page still renders and the dialog falls back to its async path.
- **Pass tokens through props** (`src/app/admin/audit/page.tsx` → `src/components/admin/AuditDashboard.tsx`) — eliminates the on-open server action call from the happy path entirely.
- **Freshness gate** — Codex flagged that a tab idle past the 10-min TTL would submit a stale token and the user couldn't recover via reopen. Tokens with ≤30s of TTL fall through to the async fetch.
- **In-place refresh on `invalidToken`** — same retry path the `queueChanged` branch already uses, so a long-idle dashboard recovers without a page reload.
- **Sentry capture in the fallback action** — production sanitization swallows the digest from the user; Sentry preserves the actual error.
- **`data-kennel-code` attributes** on the `Select` trigger, items, and queue rows — closes #1175 ask 6 (stable read path for accessibility-tree agents).

## Why this approach

`getDeepDiveQueueToken` already duplicated work the parent page did 1s earlier. Moving the mint to the page render uses data we already have, drops three Prisma calls per dialog open, and routes around the `TooManyConnections` failure surface entirely. The async path stays as the fallback for stale-prop and edited-queue cases, and the existing snapshot-binding (`computeQueueSnapshotId`) keeps #1160's misattribution defense intact — the server still recomputes from live state at submit time.

#1175 asks 6 (stable a11y attribute) and 8 (server-side guard) are now both addressed; ask 7 (virtualization) is moot since the row-click pattern landed in #1203 doesn't virtualize.

## Test plan

- [x] `npm test` — 6001 passed (1 new test added; Codex regression test for token expiry + freshness gate)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (0 errors)
- [x] `/codex:adversarial-review` flagged the TTL/recovery gap; addressed in this PR
- [x] `/simplify` 3-agent pass; type/comment polish applied
- [ ] Manual: open `/admin/audit`, click Mark complete on a queue kennel, verify submit succeeds and queue updates
- [ ] Manual: hard-reload after submit, verify `last dived` shows today and coverage tick increments
- [ ] Manual: leave dashboard idle >10 min, click Mark complete, verify dialog re-fetches token instead of failing
- [ ] Post-merge: mark GLH3 (#1207) and GGFM (#1216) complete on production using the summaries from those issue bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)