### PR TITLE
feat(backfill): one-shot historical backfill for East Bay H3

### DIFF
--- a/scripts/backfill-east-bay-h3-history.ts
+++ b/scripts/backfill-east-bay-h3-history.ts
@@ -1,0 +1,29 @@
+/**
+ * One-shot historical backfill for East Bay H3 (#1032).
+ *
+ * Thin wrapper around the reusable SFH3 backfill helper. See
+ * scripts/lib/sfh3-backfill.ts for the full explanation.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-east-bay-h3-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-east-bay-h3-history.ts
+ */
+
+import "dotenv/config";
+import { backfillSfh3Kennel } from "./lib/sfh3-backfill";
+
+async function main(): Promise<void> {
+  try {
+    await backfillSfh3Kennel({
+      sfh3KennelId: 4,
+      kennelCode: "ebh3",
+      sourceName: "SFH3 MultiHash HTML Hareline",
+      expectedLabel: "EBH3",
+    });
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+void main();

--- a/scripts/lib/sfh3-backfill.ts
+++ b/scripts/lib/sfh3-backfill.ts
@@ -59,6 +59,18 @@ export interface Sfh3BackfillParams {
    * without descriptions are low-value.
    */
   enrichDetailPages?: boolean;
+  /**
+   * Expected label text inside the selected `<option>` for `sfh3KennelId`
+   * (e.g. "EBH3"). When set, the page must emit
+   * `<option selected="selected" value="<id>">{expectedLabel}</option>` —
+   * proving the numeric id still maps to the intended kennel upstream. If
+   * sfh3.com renumbers its dropdown or this wrapper is given a wrong id by
+   * a copy-paste mistake, the assertion fails before any writes instead of
+   * silently importing another kennel's history under our `kennelCode`.
+   * Optional for backward compatibility with existing wrappers; new
+   * wrappers should always set it.
+   */
+  expectedLabel?: string;
 }
 
 /** Build the SFH3 hareline URL for a given kennel + period bucket. */
@@ -79,7 +91,12 @@ function localTodayIso(timezone: string): string {
 }
 
 /** Guard: confirm the fetched page is actually filtered to the expected kennel. */
-function assertKennelFilterApplied(html: string, sfh3KennelId: number, url: string): void {
+function assertKennelFilterApplied(
+  html: string,
+  sfh3KennelId: number,
+  url: string,
+  expectedLabel?: string,
+): void {
   // The hareline renders `<option selected="selected" value="<id>">` inside
   // the kennel <select>. If SFH3 ever stops honoring `kennel=<id>`, the
   // selected value will be "*" (All kennels) and we'd silently import other
@@ -92,6 +109,20 @@ function assertKennelFilterApplied(html: string, sfh3KennelId: number, url: stri
       `SFH3 kennel filter not applied at ${url} — expected selected kennel id ${sfh3KennelId}. ` +
         `Refusing to backfill to avoid cross-kennel data corruption.`,
     );
+  }
+  // Identity check: id alone proves the page is filtered, not that the id
+  // maps to the kennel we think it does. If a wrapper passes a wrong id (or
+  // sfh3.com renumbers the dropdown), this catches the mismatch before any
+  // writes — instead of importing another kennel's full history under
+  // `kennelCode`.
+  if (expectedLabel !== undefined) {
+    const labelMarker = `${marker}>${expectedLabel}</option>`;
+    if (!html.includes(labelMarker)) {
+      throw new Error(
+        `SFH3 kennel id ${sfh3KennelId} does not map to "${expectedLabel}" at ${url}. ` +
+          `Refusing to backfill — verify the kennel dropdown on sfh3.com.`,
+      );
+    }
   }
 }
 
@@ -120,13 +151,14 @@ async function fetchPeriodRows(
   sfh3KennelId: number,
   period: string,
   kennelCode: string,
+  expectedLabel?: string,
 ): Promise<{ events: RawEventData[]; skippedDate: number }> {
   const url = buildUrl(sfh3KennelId, period);
   const page = await fetchHTMLPage(url);
   if (!page.ok) {
     throw new Error(`Failed to fetch ${url}: ${page.result.errors.join("; ")}`);
   }
-  assertKennelFilterApplied(page.html, sfh3KennelId, url);
+  assertKennelFilterApplied(page.html, sfh3KennelId, url, expectedLabel);
 
   const rows = parseHarelineRows(page.html);
   const events: RawEventData[] = [];
@@ -176,6 +208,7 @@ export async function backfillSfh3Kennel(params: Sfh3BackfillParams): Promise<vo
       params.sfh3KennelId,
       period,
       params.kennelCode,
+      params.expectedLabel,
     );
     const historical = events.filter((e) => e.date < todayIso);
     console.log(


### PR DESCRIPTION
## Summary

- Adds `scripts/backfill-east-bay-h3-history.ts` — a 28-line thin wrapper around the existing `backfillSfh3Kennel()` helper.
- Extends `scripts/lib/sfh3-backfill.ts` with an optional `expectedLabel` identity check that proves the numeric SFH3 id still maps to the intended kennel before any writes.
- No live-adapter or seed changes; `ebh3` was already in `sfh3KennelCodes` so the `SourceKennel` link pre-existed.

## Why

Per #1032, EBH3 is missing 31 historical events (#1126–#1156). Both configured SFH3 sources are partial-enumeration:
- `SFH3 MultiHash HTML Hareline` defaults to `kennels=all` (upcoming-only).
- `SFH3 MultiHash iCal Feed` only emits ~11 EBH3 VEVENTs (~90-day window).

Reconcile-cancels-missing means widening either feed risks cancelling live history. The right tool is the existing one-shot helper, which routes through `processRawEvents` and is idempotent on re-run.

## Why the helper change

The Codex adversarial review flagged a real structural risk: the existing `assertKennelFilterApplied` only checks that the page filtered by the requested id, not that the id maps to the intended kennel. A copy-paste mistake or an upstream dropdown renumbering would silently import another kennel's full history under our `kennelCode`. The new optional `expectedLabel` param requires the rendered `<option selected="selected" value="<id>">{expectedLabel}</option>` to match before any writes. Backward-compatible with existing wrappers (agnews keeps working untouched).

## Verification (local Postgres dev DB)

**Dry run:**
```
SFH3 historical backfill: kennel=ebh3 (sfh3 id 4)
Mode: DRY RUN (no writes)
Periods: 2025-2026, 2021-2024, 2017-2020, 2009-2016
  period 2025-2026: fetched 35, historical 35
  period 2021-2024: fetched 103, historical 103
  period 2017-2020: fetched 0, historical 0
  period 2009-2016: fetched 104, historical 104
Total historical rows: 242 (unique 242)
Enrichment complete: 233 enriched, 0 failures.
```

**Apply (`BACKFILL_APPLY=1`):**
```
Done. created=242 updated=0 skipped=0 unmatched=0 blocked=0
```

**Idempotency proof (second run):**
```
Done. created=0 updated=0 skipped=242 unmatched=0 blocked=0
```

**Spot-check #1140** matches the issue's example exactly:
| runNumber | date       | title                              | haresText   | locationName |
|-----------|------------|------------------------------------|-------------|--------------|
| 1140      | 2025-07-20 | 7th Anal Russian River Sperm Float | Sperm Donor | On the River: Read all the directions |

**Coverage of target range #1126–#1156:** 28 of 31 in DB. Runs #1149, #1150, #1151 are absent from sfh3.com itself — no upstream RawEvent rows for those numbers (verified with a direct RawEvent JSON query). This is an upstream gap, not a backfill omission.

**Identity-check negative test** — passing `expectedLabel: "WRONGLABEL"` aborts before any work:
```
THREW (expected): SFH3 kennel id 4 does not map to "WRONGLABEL" at https://www.sfh3.com/runs?kennel=4&period=2025-2026. Refusing to backfill — verify the kennel dropdown on sfh3.com.
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (19 pre-existing warnings unrelated)
- [x] `npm test` — 5996/5996 passed
- [x] Dry run on local DB — 242 events, 0 failures
- [x] Apply on local DB — created=242, blocked=0
- [x] Idempotency re-run — created=0, skipped=242
- [x] Identity check rejects wrong label
- [x] Codex adversarial review — finding addressed via `expectedLabel`
- [ ] Run on prod DB after merge

Closes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)