### PR TITLE
First-class trailLength + difficulty (Shiggy Level) on Event, lit up for BurlyH3

### DIFF
--- a/prisma/migrations/20260506144142_add_event_trail_length_difficulty/migration.sql
+++ b/prisma/migrations/20260506144142_add_event_trail_length_difficulty/migration.sql
@@ -1,0 +1,21 @@
+-- Issue #890: First-class trail length + Shiggy Scale on Event.
+--
+-- Three-field shape preserves source intent:
+--   * trailLengthText  — verbatim string ("3-5 Miles", "2.69 (miles)")
+--   * trailLengthMinMiles / trailLengthMaxMiles — parsed numerics
+--     (min == max for fixed values, distinct for ranges)
+--
+-- difficulty is a 1–5 Shiggy Scale, validated at the adapter layer
+-- (Prisma can't enforce range). Column name stays generic so other
+-- adapters' "rating"/"hardness" fields can land here later.
+--
+-- Hand-authored: `prisma migrate dev` couldn't run a shadow-DB pass
+-- because pending migration `20260504010411_kennel_profile_bundle...`
+-- has a kennelCode existence guard that fails on an empty shadow DB.
+-- Diff was generated via `prisma migrate diff --from-config-datasource
+-- --to-schema prisma/schema.prisma --script`.
+
+ALTER TABLE "Event" ADD COLUMN     "trailLengthText" TEXT,
+ADD COLUMN     "trailLengthMinMiles" DOUBLE PRECISION,
+ADD COLUMN     "trailLengthMaxMiles" DOUBLE PRECISION,
+ADD COLUMN     "difficulty" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -336,6 +336,15 @@ model Event {
   startTime         String? // Local time string "HH:MM" — NOT a timestamp
   endTime           String? // Local time string "HH:MM" — same convention as startTime
   cost              String? // Free-form: "$10", "$5 cash / $10 card", "Free for virgins"
+  /// Verbatim trail-length string from the source ("3-5 Miles", "2.69 (miles)", "13 miles").
+  /// Preserves source intent for display; min/max below carry the parsed numerics.
+  trailLengthText      String?
+  trailLengthMinMiles  Float? // Parsed lower bound; equal to max when source is fixed (e.g. "2.69" → min=max=2.69).
+  trailLengthMaxMiles  Float? // Parsed upper bound; for ranges only ("3-5 Miles" → min=3, max=5).
+  /// Shiggy Scale (1–5). Range validated at adapter layer — Prisma can't enforce.
+  /// User-facing label is "Shiggy Level" (hash vernacular); DB column stays generic so other
+  /// adapters' "rating"/"hardness" fields can land in the same column later.
+  difficulty           Int?
   sourceUrl         String? // Link to original event page
   trustLevel        Int         @default(5)
   isSeriesParent    Boolean     @default(false)

--- a/scripts/verify-burly-trail.ts
+++ b/scripts/verify-burly-trail.ts
@@ -1,0 +1,85 @@
+/**
+ * Live-verification one-shot for issue #890.
+ *
+ * Fetches BurlyH3's hareline via the production browser-render path and
+ * prints the parsed `trailLengthText` / min / max / difficulty for the
+ * first events. Writes a compact summary to stdout for paste-into-PR.
+ *
+ *   npx tsx scripts/verify-burly-trail.ts
+ *
+ * Requires BROWSER_RENDER_URL + BROWSER_RENDER_KEY in env (loaded from .env).
+ */
+import "dotenv/config";
+import { BurlingtonHashAdapter } from "@/adapters/html-scraper/burlington-hash";
+import type { Source } from "@/generated/prisma/client";
+
+function makeSource(): Source {
+  return {
+    id: "verify-burly",
+    name: "Burlington H3 Website Hareline (verify)",
+    url: "https://www.burlingtonh3.com/hareline",
+    type: "HTML_SCRAPER",
+    trustLevel: 6,
+    scrapeFreq: "weekly",
+    scrapeDays: 365,
+    config: null,
+    isActive: true,
+    lastScrapeAt: null,
+    lastScrapeStatus: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastStructureHash: null,
+  } as unknown as Source;
+}
+
+async function main() {
+  const adapter = new BurlingtonHashAdapter();
+  const result = await adapter.fetch(makeSource());
+
+  console.log(`fetched ${result.events.length} events from burlingtonh3.com/hareline`);
+  console.log(`errors: ${result.errors.length}`);
+  if (result.errors.length > 0) {
+    console.log("error detail:", result.errors[0]);
+  }
+  console.log("");
+  console.log("─── trail length + Shiggy Level extraction ───");
+
+  const populated = result.events.filter(
+    (e) => e.trailLengthText !== undefined || e.difficulty !== undefined,
+  );
+  const fixed = populated.filter(
+    (e) =>
+      e.trailLengthMinMiles !== undefined &&
+      e.trailLengthMaxMiles !== undefined &&
+      e.trailLengthMinMiles === e.trailLengthMaxMiles,
+  );
+  const ranged = populated.filter(
+    (e) =>
+      e.trailLengthMinMiles !== undefined &&
+      e.trailLengthMaxMiles !== undefined &&
+      e.trailLengthMinMiles !== e.trailLengthMaxMiles,
+  );
+
+  console.log(`populated total : ${populated.length}`);
+  console.log(`fixed-length    : ${fixed.length}`);
+  console.log(`ranged-length   : ${ranged.length}`);
+  console.log("");
+
+  for (const e of result.events.slice(0, 12)) {
+    const summary = [
+      e.date,
+      `#${e.runNumber ?? "?"}`,
+      `text=${JSON.stringify(e.trailLengthText)}`,
+      `min=${e.trailLengthMinMiles}`,
+      `max=${e.trailLengthMaxMiles}`,
+      `shiggy=${e.difficulty}`,
+      e.title ? `· ${e.title.slice(0, 40)}` : "",
+    ];
+    console.log(summary.join("  "));
+  }
+}
+
+main().catch((err) => {
+  console.error("verify failed:", err);
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/burlington-hash.test.ts
+++ b/src/adapters/html-scraper/burlington-hash.test.ts
@@ -205,6 +205,83 @@ describe("parseCalendarLink", () => {
     expect(result?.cost).toBe("$6.90");
     expect(result?.description).toContain("Earth day");
     expect(result?.description).toContain("Sunny Hollow");
+    // #890: Length + Shiggy Scale extraction from the same Wix payload.
+    expect(result?.trailLengthText).toBe("2.69");
+    expect(result?.trailLengthMinMiles).toBe(2.69);
+    expect(result?.trailLengthMaxMiles).toBe(2.69);
+    expect(result?.difficulty).toBe(4);
+  });
+
+  it("parses ranged trail length and Shiggy Scale (#890)", () => {
+    // Mountain Man scenario from issue #890: Length: 3-5 Miles, Shiggy Scale: 5
+    const details =
+      "%3Cb%3EHares%3A%3C%2Fb%3E+Mountain+Goat" +
+      "%3Cbr%3E%3Cb%3ELength%3A+%3C%2Fb%3E3-5+Miles" +
+      "%3Cbr%3E%3Cb%3EShiggy+Scale%3A+%3C%2Fb%3E5" +
+      "%3Cbr%3E%3Cb%3ECost%3A%3C%2Fb%3E+%2410.00";
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23854%3A+Mountain+Man" +
+      "&dates=20260820T223000Z/20260820T233000Z" +
+      `&details=${details}`;
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.trailLengthText).toBe("3-5 Miles");
+    expect(result?.trailLengthMinMiles).toBe(3);
+    expect(result?.trailLengthMaxMiles).toBe(5);
+    expect(result?.difficulty).toBe(5);
+  });
+
+  it("emits explicit null numerics when Length label is present but unparseable (#890)", () => {
+    // Atomic-bundle semantics: when text="TBD" is sourced, min/max emit
+    // explicit null so the merge UPDATE clears any stale parsed range
+    // from a prior scrape. Without this, `3-5 Miles → TBD` would leave
+    // stale min=3, max=5 wired to fresh text="TBD" (Codex finding).
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23855%3A+TBD+Trail" +
+      "&dates=20260827T223000Z/20260827T233000Z" +
+      "&details=Hares%3A+Sherpa+Length%3A+TBD+Shiggy+Scale%3A+4";
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.trailLengthText).toBe("TBD");
+    expect(result?.trailLengthMinMiles).toBeNull();
+    expect(result?.trailLengthMaxMiles).toBeNull();
+    expect(result?.difficulty).toBe(4);
+  });
+
+  it("emits explicit null difficulty when Shiggy Scale is present but out of range (#890)", () => {
+    // Same atomic guarantee for difficulty — a typo'd "7" must clear any
+    // stale rating, not silently preserve it.
+    const details =
+      "%3Cb%3EHares%3A%3C%2Fb%3E+X" +
+      "%3Cbr%3E%3Cb%3ELength%3A+%3C%2Fb%3E4" +
+      "%3Cbr%3E%3Cb%3EShiggy+Scale%3A+%3C%2Fb%3E7";
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23856%3A+Out+of+range" +
+      "&dates=20260903T223000Z/20260903T233000Z" +
+      `&details=${details}`;
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.trailLengthMinMiles).toBe(4);
+    expect(result?.difficulty).toBeNull();
+  });
+
+  it("leaves trail-length and difficulty undefined (preserve) when neither label is present (#890)", () => {
+    // Distinct from the explicit-null cases above: no label found means
+    // "source didn't speak", so the merge preserves any prior values.
+    const href =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" +
+      "&text=BTVH3+%23857%3A+Bare+payload" +
+      "&dates=20260910T223000Z/20260910T233000Z" +
+      "&details=Hares%3A+Lone+Wolf";
+
+    const result = parseCalendarLink(href, SOURCE_URL);
+    expect(result?.trailLengthText).toBeUndefined();
+    expect(result?.trailLengthMinMiles).toBeUndefined();
+    expect(result?.trailLengthMaxMiles).toBeUndefined();
+    expect(result?.difficulty).toBeUndefined();
   });
 
   it("leaves cost undefined when the details payload has no 'Cost:' marker (#887)", () => {

--- a/src/adapters/html-scraper/burlington-hash.ts
+++ b/src/adapters/html-scraper/burlington-hash.ts
@@ -110,6 +110,34 @@ export function parseCalendarLink(
   const costMatch = /Cost:\s*\$?([0-9]+(?:\.[0-9]{1,2})?)/i.exec(detailText);
   if (costMatch) cost = `$${costMatch[1]}`;
 
+  // #890: extract Length + Shiggy Scale. Both labels already terminate
+  // hares (HARES_TERMINATORS_RE), so the values land between the label and
+  // the next labeled field — same indexOf-based slicing pattern.
+  //
+  // Atomic-bundle semantics for the trail-length triple:
+  //   • Label NOT found → all three stay `undefined`. Merge preserves
+  //     existing values (consistent with description/haresText handling).
+  //   • Label found but numerics unparseable (e.g. "TBD") → text is
+  //     populated; numerics emit explicit `null`. Merge writes nulls,
+  //     clearing any stale parsed range from a prior scrape. Without this,
+  //     `Length: 3-5 Miles → Length: TBD` would leave `min=3, max=5`
+  //     wired to fresh text="TBD" — a silent corruption (Codex finding).
+  const lengthRaw = extractLabeledField(detailText, LENGTH_LABEL_RE);
+  const parsedLength = parseTrailLength(lengthRaw);
+  const trailLengthText =
+    lengthRaw !== undefined ? parsedLength.trailLengthText ?? null : undefined;
+  const trailLengthMinMiles =
+    lengthRaw !== undefined ? parsedLength.trailLengthMinMiles ?? null : undefined;
+  const trailLengthMaxMiles =
+    lengthRaw !== undefined ? parsedLength.trailLengthMaxMiles ?? null : undefined;
+
+  // Same atomic semantic for difficulty: label-present-but-out-of-range
+  // emits `null` so the canonical event doesn't keep a stale Shiggy
+  // rating after the source drops the value.
+  const shiggyRaw = extractLabeledField(detailText, SHIGGY_LABEL_RE);
+  const difficulty =
+    shiggyRaw !== undefined ? parseShiggyScale(shiggyRaw) ?? null : undefined;
+
   // #887: extract free-form description. Wix puts `<br><br>` (a blank line
   // after `<br>→\n` conversion) before the prose paragraph that follows the
   // labeled fields. Anchoring on that paragraph break avoids treating any
@@ -133,6 +161,10 @@ export function parseCalendarLink(
     location: location.trim() || undefined,
     startTime,
     sourceUrl,
+    trailLengthText,
+    trailLengthMinMiles,
+    trailLengthMaxMiles,
+    difficulty,
   };
 }
 
@@ -147,6 +179,78 @@ function extractHares(detailText: string): string | undefined {
   const value = termMatch ? rest.slice(0, termMatch.index) : rest;
   const cleaned = value.replace(HARE_BOILERPLATE_RE, "").trim();
   return cleaned || undefined;
+}
+
+// #890: terminators for trail-length / shiggy-scale values. Matches
+// HARES_TERMINATORS_RE in spirit — handles BurlyH3's #850 payload where
+// labels run together with no whitespace ("...Length: TBDShiggy Scale:
+// 4Cost:..."), so a labeled value ends at the next label even without
+// a delimiter.
+const FIELD_TERMINATORS_RE = /Length\s*:|Shiggy\s*Scale\s*:|Hares?:|Location\s*:|Cost\s*:|HASH\s*CASH|On[\s-]*On|\n[\t ]*\n/i;
+const LENGTH_LABEL_RE = /Length\s*:\s*/i;
+const SHIGGY_LABEL_RE = /Shiggy\s*Scale\s*:\s*/i;
+
+function extractLabeledField(detailText: string, labelRe: RegExp): string | undefined {
+  const labelMatch = labelRe.exec(detailText);
+  if (!labelMatch) return undefined;
+  const rest = detailText.slice(labelMatch.index + labelMatch[0].length);
+  const termMatch = FIELD_TERMINATORS_RE.exec(rest);
+  const value = (termMatch ? rest.slice(0, termMatch.index) : rest).trim();
+  return value || undefined;
+}
+
+interface ParsedTrailLength {
+  trailLengthText?: string;
+  trailLengthMinMiles?: number;
+  trailLengthMaxMiles?: number;
+}
+
+// Capture group: digits with optional decimal — both range bounds and fixed
+// values flow through it. Inline so reviewers don't have to hop to a const.
+function parseTrailLength(raw: string | undefined): ParsedTrailLength {
+  if (!raw) return {};
+  // Strip a trailing unit suffix for numeric parsing only — keep the
+  // verbatim string in trailLengthText so the UI can render exactly what
+  // the source shows ("3-5 Miles" stays "3-5 Miles", not "3-5").
+  const numericPart = raw
+    .replace(/\s*\(?\s*miles?\s*\)?\s*$/i, "")
+    .replace(/\s*mi\s*$/i, "")
+    .trim();
+
+  const range = /^(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)$/.exec(numericPart);
+  if (range) {
+    const min = parseFloat(range[1]);
+    const max = parseFloat(range[2]);
+    return {
+      trailLengthText: raw,
+      trailLengthMinMiles: min,
+      trailLengthMaxMiles: max,
+    };
+  }
+  const fixed = /^(\d+(?:\.\d+)?)$/.exec(numericPart);
+  if (fixed) {
+    const n = parseFloat(fixed[1]);
+    return {
+      trailLengthText: raw,
+      trailLengthMinMiles: n,
+      trailLengthMaxMiles: n,
+    };
+  }
+  // Unparseable (TBD, ?, ranges-with-units, etc.): preserve the verbatim
+  // string for display, but leave numerics undefined so future filter/sort
+  // doesn't false-bucket the event.
+  return { trailLengthText: raw };
+}
+
+// Shiggy Scale is 1–5. Reject anything outside that integer range, including
+// "TBD"/"?"/floats — better to drop the field than store ambiguous data.
+function parseShiggyScale(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const match = /^(\d+)$/.exec(raw.trim());
+  if (!match) return undefined;
+  const n = parseInt(match[1], 10);
+  if (!Number.isInteger(n) || n < 1 || n > 5) return undefined;
+  return n;
 }
 
 /**

--- a/src/adapters/html-scraper/burlington-hash.ts
+++ b/src/adapters/html-scraper/burlington-hash.ts
@@ -240,11 +240,10 @@ function parseTrailLength(raw: string | undefined): ParsedTrailLength {
   if (!raw) return {};
   // Strip a trailing unit suffix for numeric parsing only — keep the
   // verbatim string in trailLengthText so the UI can render exactly what
-  // the source shows ("3-5 Miles" stays "3-5 Miles", not "3-5").
-  const numericPart = raw
-    .replace(/\s*\(?\s*miles?\s*\)?\s*$/i, "")
-    .replace(/\s*mi\s*$/i, "")
-    .trim();
+  // the source shows ("3-5 Miles" stays "3-5 Miles", not "3-5"). Single
+  // alternation with one `\s*` quantifier avoids nested quantifiers that
+  // SonarCloud S5852 flags as ReDoS-prone.
+  const numericPart = raw.replace(/\s*(?:\(miles?\)|miles?|mi)$/i, "").trim();
 
   const range = /^(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)$/.exec(numericPart);
   if (range) {

--- a/src/adapters/html-scraper/burlington-hash.ts
+++ b/src/adapters/html-scraper/burlington-hash.ts
@@ -48,12 +48,12 @@ export function parseCalendarLink(
 
   const utcDate = new Date(
     Date.UTC(
-      parseInt(dateMatch[1]),
-      parseInt(dateMatch[2]) - 1,
-      parseInt(dateMatch[3]),
-      parseInt(dateMatch[4]),
-      parseInt(dateMatch[5]),
-      parseInt(dateMatch[6]),
+      Number.parseInt(dateMatch[1]),
+      Number.parseInt(dateMatch[2]) - 1,
+      Number.parseInt(dateMatch[3]),
+      Number.parseInt(dateMatch[4]),
+      Number.parseInt(dateMatch[5]),
+      Number.parseInt(dateMatch[6]),
     ),
   );
 
@@ -70,25 +70,7 @@ export function parseCalendarLink(
   const min = String(localDate.getMinutes()).padStart(2, "0");
   const startTime = `${hh}:${min}`;
 
-  // Parse title and run number. Three accepted forms (#889):
-  //   "BTVH3 #846: Season Premier"       → title "Season Premier"
-  //   "BTVH3 #851 ft. Not Just the Tip"  → title "ft. Not Just the Tip" (prefix kept)
-  //   "BTVH3 #852"                        → title "BurlyH3 #852"
-  let title = text.trim();
-  let runNumber: number | undefined;
-  const colonMatch = /(?:BTVH3|BurlyH3|Burlington)\s*#(\d+)\s*[:\-–]\s*(.*)/i.exec(title);
-  if (colonMatch) {
-    runNumber = parseInt(colonMatch[1], 10);
-    title = colonMatch[2].trim() || `BurlyH3 #${runNumber}`;
-  } else {
-    const altMatch = /(?:BTVH3|BurlyH3|Burlington)\s*#(\d+)(?:\s+(ft\.|feat\.)\s+(.+)|\s*$)/i.exec(title);
-    if (altMatch) {
-      runNumber = parseInt(altMatch[1], 10);
-      const featSep = altMatch[2];
-      const rest = altMatch[3];
-      title = featSep ? `${featSep} ${rest}`.trim() : `BurlyH3 #${runNumber}`;
-    }
-  }
+  const { title, runNumber } = parseTitleAndRunNumber(text.trim());
 
   // Parse details — strip HTML, then extract labeled fields and free-form prose.
   // The live Wix payload uses `<br>` between labeled fields and before the
@@ -125,18 +107,18 @@ export function parseCalendarLink(
   const lengthRaw = extractLabeledField(detailText, LENGTH_LABEL_RE);
   const parsedLength = parseTrailLength(lengthRaw);
   const trailLengthText =
-    lengthRaw !== undefined ? parsedLength.trailLengthText ?? null : undefined;
+    lengthRaw === undefined ? undefined : parsedLength.trailLengthText ?? null;
   const trailLengthMinMiles =
-    lengthRaw !== undefined ? parsedLength.trailLengthMinMiles ?? null : undefined;
+    lengthRaw === undefined ? undefined : parsedLength.trailLengthMinMiles ?? null;
   const trailLengthMaxMiles =
-    lengthRaw !== undefined ? parsedLength.trailLengthMaxMiles ?? null : undefined;
+    lengthRaw === undefined ? undefined : parsedLength.trailLengthMaxMiles ?? null;
 
   // Same atomic semantic for difficulty: label-present-but-out-of-range
   // emits `null` so the canonical event doesn't keep a stale Shiggy
   // rating after the source drops the value.
   const shiggyRaw = extractLabeledField(detailText, SHIGGY_LABEL_RE);
   const difficulty =
-    shiggyRaw !== undefined ? parseShiggyScale(shiggyRaw) ?? null : undefined;
+    shiggyRaw === undefined ? undefined : parseShiggyScale(shiggyRaw) ?? null;
 
   // #887: extract free-form description. Wix puts `<br><br>` (a blank line
   // after `<br>→\n` conversion) before the prose paragraph that follows the
@@ -185,10 +167,35 @@ function extractHares(detailText: string): string | undefined {
 // HARES_TERMINATORS_RE in spirit — handles BurlyH3's #850 payload where
 // labels run together with no whitespace ("...Length: TBDShiggy Scale:
 // 4Cost:..."), so a labeled value ends at the next label even without
-// a delimiter.
-const FIELD_TERMINATORS_RE = /Length\s*:|Shiggy\s*Scale\s*:|Hares?:|Location\s*:|Cost\s*:|HASH\s*CASH|On[\s-]*On|\n[\t ]*\n/i;
+// a delimiter. Colon-suffixed labels share one alternation group to keep
+// regex complexity under SonarCloud's S5843 threshold.
+const FIELD_TERMINATORS_RE = /(?:Length|Shiggy\s*Scale|Hares?|Location|Cost)\s*:|HASH\s*CASH|On[\s-]*On|\n[\t ]*\n/i;
 const LENGTH_LABEL_RE = /Length\s*:\s*/i;
 const SHIGGY_LABEL_RE = /Shiggy\s*Scale\s*:\s*/i;
+
+/**
+ * Parse the calendar-link `text` field into title + run number.
+ *
+ * Three accepted forms (#889):
+ *   "BTVH3 #846: Season Premier"       → title "Season Premier"
+ *   "BTVH3 #851 ft. Not Just the Tip"  → title "ft. Not Just the Tip" (prefix kept)
+ *   "BTVH3 #852"                        → title "BurlyH3 #852"
+ */
+function parseTitleAndRunNumber(raw: string): { title: string; runNumber: number | undefined } {
+  const colonMatch = /(?:BTVH3|BurlyH3|Burlington)\s*#(\d+)\s*[:\-–]\s*(.*)/i.exec(raw);
+  if (colonMatch) {
+    const runNumber = Number.parseInt(colonMatch[1], 10);
+    return { title: colonMatch[2].trim() || `BurlyH3 #${runNumber}`, runNumber };
+  }
+  const altMatch = /(?:BTVH3|BurlyH3|Burlington)\s*#(\d+)(?:\s+(ft\.|feat\.)\s+(.+)|\s*$)/i.exec(raw);
+  if (altMatch) {
+    const runNumber = Number.parseInt(altMatch[1], 10);
+    const featSep = altMatch[2];
+    const rest = altMatch[3];
+    return { title: featSep ? `${featSep} ${rest}`.trim() : `BurlyH3 #${runNumber}`, runNumber };
+  }
+  return { title: raw, runNumber: undefined };
+}
 
 function extractLabeledField(detailText: string, labelRe: RegExp): string | undefined {
   const labelMatch = labelRe.exec(detailText);
@@ -219,8 +226,8 @@ function parseTrailLength(raw: string | undefined): ParsedTrailLength {
 
   const range = /^(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)$/.exec(numericPart);
   if (range) {
-    const min = parseFloat(range[1]);
-    const max = parseFloat(range[2]);
+    const min = Number.parseFloat(range[1]);
+    const max = Number.parseFloat(range[2]);
     return {
       trailLengthText: raw,
       trailLengthMinMiles: min,
@@ -229,7 +236,7 @@ function parseTrailLength(raw: string | undefined): ParsedTrailLength {
   }
   const fixed = /^(\d+(?:\.\d+)?)$/.exec(numericPart);
   if (fixed) {
-    const n = parseFloat(fixed[1]);
+    const n = Number.parseFloat(fixed[1]);
     return {
       trailLengthText: raw,
       trailLengthMinMiles: n,
@@ -248,7 +255,7 @@ function parseShiggyScale(raw: string | undefined): number | undefined {
   if (!raw) return undefined;
   const match = /^(\d+)$/.exec(raw.trim());
   if (!match) return undefined;
-  const n = parseInt(match[1], 10);
+  const n = Number.parseInt(match[1], 10);
   if (!Number.isInteger(n) || n < 1 || n > 5) return undefined;
   return n;
 }

--- a/src/adapters/html-scraper/burlington-hash.ts
+++ b/src/adapters/html-scraper/burlington-hash.ts
@@ -234,16 +234,28 @@ interface ParsedTrailLength {
   trailLengthMaxMiles?: number;
 }
 
-// Capture group: digits with optional decimal — both range bounds and fixed
-// values flow through it. Inline so reviewers don't have to hop to a const.
+// Recognized trailing units, longest first so "miles" is consumed before
+// "mile" / "mi" prefixes match. Procedural matching avoids the nested
+// `\s*` quantifiers in regex alternation that SonarCloud S5852 flags as
+// ReDoS-prone.
+const TRAIL_LENGTH_UNITS = ["(miles)", "(mile)", "miles", "mile", "mi"];
+
+function stripTrailingUnit(input: string): string {
+  const lower = input.toLowerCase();
+  for (const unit of TRAIL_LENGTH_UNITS) {
+    if (lower.endsWith(unit)) {
+      return input.slice(0, input.length - unit.length).trimEnd();
+    }
+  }
+  return input;
+}
+
 function parseTrailLength(raw: string | undefined): ParsedTrailLength {
   if (!raw) return {};
   // Strip a trailing unit suffix for numeric parsing only — keep the
   // verbatim string in trailLengthText so the UI can render exactly what
-  // the source shows ("3-5 Miles" stays "3-5 Miles", not "3-5"). Single
-  // alternation with one `\s*` quantifier avoids nested quantifiers that
-  // SonarCloud S5852 flags as ReDoS-prone.
-  const numericPart = raw.replace(/\s*(?:\(miles?\)|miles?|mi)$/i, "").trim();
+  // the source shows ("3-5 Miles" stays "3-5 Miles", not "3-5").
+  const numericPart = stripTrailingUnit(raw.trimEnd());
 
   const range = /^(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)$/.exec(numericPart);
   if (range) {

--- a/src/adapters/html-scraper/burlington-hash.ts
+++ b/src/adapters/html-scraper/burlington-hash.ts
@@ -163,15 +163,37 @@ function extractHares(detailText: string): string | undefined {
   return cleaned || undefined;
 }
 
-// #890: terminators for trail-length / shiggy-scale values. Matches
-// HARES_TERMINATORS_RE in spirit — handles BurlyH3's #850 payload where
-// labels run together with no whitespace ("...Length: TBDShiggy Scale:
-// 4Cost:..."), so a labeled value ends at the next label even without
-// a delimiter. Colon-suffixed labels share one alternation group to keep
-// regex complexity under SonarCloud's S5843 threshold.
-const FIELD_TERMINATORS_RE = /(?:Length|Shiggy\s*Scale|Hares?|Location|Cost)\s*:|HASH\s*CASH|On[\s-]*On|\n[\t ]*\n/i;
+// #890: terminators for trail-length / shiggy-scale values. Handles
+// BurlyH3's #850 payload where labels run together with no whitespace
+// ("...Length: TBDShiggy Scale: 4Cost:..."), so a labeled value ends
+// at the next label even without a delimiter.
+//
+// Split into three smaller regexes scanned via Math.min() of match
+// indices, rather than one fat alternation. SonarCloud S5843 caps
+// regex complexity at 20; the unified form clocked in at 24+. Splitting
+// also matches the codebase's documented preference (.claude/rules/
+// adapter-patterns.md) for multi-pass tokenizers over single complex
+// regexes — see hash-horrors.ts findYearHeadings/findRunLineStarts.
+const FIELD_LABEL_RE = /(?:Length|Shiggy\s*Scale|Hares?|Location|Cost)\s*:/i;
+const FIELD_KEYWORD_RE = /HASH\s*CASH|On[\s-]*On/i;
+const PARAGRAPH_BREAK_RE = /\n[\t ]*\n/;
 const LENGTH_LABEL_RE = /Length\s*:\s*/i;
 const SHIGGY_LABEL_RE = /Shiggy\s*Scale\s*:\s*/i;
+
+/**
+ * Index of the earliest terminator in `text`, or -1 if none.
+ * Scans three independent regexes and returns whichever matches first.
+ */
+function findFirstTerminatorIndex(text: string): number {
+  let nearest = -1;
+  for (const re of [FIELD_LABEL_RE, FIELD_KEYWORD_RE, PARAGRAPH_BREAK_RE]) {
+    const match = re.exec(text);
+    if (match && (nearest === -1 || match.index < nearest)) {
+      nearest = match.index;
+    }
+  }
+  return nearest;
+}
 
 /**
  * Parse the calendar-link `text` field into title + run number.
@@ -201,8 +223,8 @@ function extractLabeledField(detailText: string, labelRe: RegExp): string | unde
   const labelMatch = labelRe.exec(detailText);
   if (!labelMatch) return undefined;
   const rest = detailText.slice(labelMatch.index + labelMatch[0].length);
-  const termMatch = FIELD_TERMINATORS_RE.exec(rest);
-  const value = (termMatch ? rest.slice(0, termMatch.index) : rest).trim();
+  const termIdx = findFirstTerminatorIndex(rest);
+  const value = (termIdx === -1 ? rest : rest.slice(0, termIdx)).trim();
   return value || undefined;
 }
 

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -22,6 +22,14 @@ export interface RawEventData {
   startTime?: string | null; // HH:MM (local time); null = explicit clear signal
   endTime?: string | null; // HH:MM (local time); null = explicit clear signal
   cost?: string | null; // Free-form cost text; null = explicit clear signal
+  /** Verbatim trail-length string from the source ("3-5 Miles", "2.69 (miles)"). */
+  trailLengthText?: string | null;
+  /** Parsed lower bound in miles. Equal to max when source is fixed (e.g. "2.69" → both 2.69). */
+  trailLengthMinMiles?: number | null;
+  /** Parsed upper bound in miles. Distinct from min only for ranges ("3-5 Miles" → 3, 5). */
+  trailLengthMaxMiles?: number | null;
+  /** Shiggy Scale 1–5 (user-facing label "Shiggy Level"). Adapter-validated range. */
+  difficulty?: number | null;
   sourceUrl?: string;
   externalLinks?: { url: string; label: string }[]; // Additional links (creates EventLink records)
   seriesId?: string; // Groups multi-day events (e.g., Hash Rego event slug)

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -15,6 +15,8 @@ import { CheckInButton } from "@/components/logbook/CheckInButton";
 import { CalendarExportButton } from "@/components/hareline/CalendarExportButton";
 import { EventLocationMap } from "@/components/hareline/EventLocationMap";
 import { EventWeatherCard } from "@/components/hareline/EventWeatherCard";
+import { ShiggyLevelFlames, TrailLengthLine, formatTrailLength } from "@/components/hareline/TrailDifficulty";
+import { getRegionColor } from "@/lib/region";
 import { EventTimeDisplay } from "@/components/hareline/EventTimeDisplay";
 import { SourcesDropdown } from "@/components/hareline/SourcesDropdown";
 import { getEventDayWeather } from "@/lib/weather";
@@ -172,6 +174,10 @@ export default async function EventDetailPage({
 
   const hasLocation =
     (event.latitude != null && event.longitude != null) || !!event.locationName;
+
+  // #890 — hoist once for reuse in the trail-length + Shiggy-level rows.
+  const regionColor = getRegionColor(event.kennel.region);
+  const trailLengthDisplay = formatTrailLength(event);
 
   function getAttendancePrompt(eventDate: Date, status: string | null): string {
     // Compare at UTC noon to match date storage convention (Appendix F.4)
@@ -350,6 +356,37 @@ export default async function EventDetailPage({
                 ) : event.haresText ? (
                   <DetailItem label="Hares" value={event.haresText} />
                 ) : null}
+                {/* #890 — first-class trail length + Shiggy Level. Same
+                    Route/Flame iconography + kennel region tint as the
+                    card and detail panel so the visual language is
+                    consistent across surfaces. */}
+                {trailLengthDisplay && (
+                  <div>
+                    <dt className="text-sm font-medium text-muted-foreground">Trail Length</dt>
+                    <dd className="mt-0.5">
+                      <TrailLengthLine
+                        text={trailLengthDisplay}
+                        color={regionColor}
+                        size="md"
+                      />
+                    </dd>
+                  </div>
+                )}
+                {event.difficulty != null && event.difficulty >= 1 && event.difficulty <= 5 && (
+                  <div>
+                    <dt className="text-sm font-medium text-muted-foreground">Shiggy Level</dt>
+                    <dd className="mt-0.5 flex items-center gap-2">
+                      <ShiggyLevelFlames
+                        level={event.difficulty}
+                        color={regionColor}
+                        size="md"
+                      />
+                      <span className="tabular-nums text-muted-foreground/70">
+                        {event.difficulty}/5
+                      </span>
+                    </dd>
+                  </div>
+                )}
                 {event.locationName && (
                   <div>
                     <dt className="text-sm font-medium text-muted-foreground">Location</dt>

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -52,6 +52,14 @@ export interface HarelineListEvent {
   status: string;
   latitude: number | null;
   longitude: number | null;
+  /** #890 — verbatim source string ("3-5 Miles", "2.69 (miles)") for in-card display. */
+  trailLengthText: string | null;
+  /** #890 — parsed lower bound; equal to max for fixed values. */
+  trailLengthMinMiles: number | null;
+  /** #890 — parsed upper bound; only distinct from min for ranges. */
+  trailLengthMaxMiles: number | null;
+  /** #890 — Shiggy Level (1–5). UI-facing label is "Shiggy Level". */
+  difficulty: number | null;
 }
 
 export type TimeMode = "upcoming" | "past";
@@ -143,6 +151,10 @@ const fetchSlimEventsCached = unstable_cache(
         status: true,
         latitude: true,
         longitude: true,
+        trailLengthText: true,
+        trailLengthMinMiles: true,
+        trailLengthMaxMiles: true,
+        difficulty: true,
         kennel: {
           select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },
         },
@@ -178,6 +190,10 @@ const fetchSlimEventsCached = unstable_cache(
       status: e.status,
       latitude: e.latitude ?? null,
       longitude: e.longitude ?? null,
+      trailLengthText: e.trailLengthText,
+      trailLengthMinMiles: e.trailLengthMinMiles,
+      trailLengthMaxMiles: e.trailLengthMaxMiles,
+      difficulty: e.difficulty,
     }));
   },
   ["hareline:events"],

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -157,6 +157,10 @@ export default async function KennelDetailPage({
     description: e.description,
     sourceUrl: e.sourceUrl,
     status: e.status,
+    trailLengthText: e.trailLengthText,
+    trailLengthMinMiles: e.trailLengthMinMiles,
+    trailLengthMaxMiles: e.trailLengthMaxMiles,
+    difficulty: e.difficulty,
   }));
 
   const upcoming = serialized.filter(

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -20,6 +20,7 @@ import { useUnitsPreference } from "@/components/providers/units-preference-prov
 import type { DailyWeather } from "@/lib/weather";
 import { getConditionEmoji, cToF } from "@/lib/weather-display";
 import { getDisplayTitle, getLocationDisplay } from "@/lib/event-display";
+import { ShiggyLevelFlames, TrailLengthLine, formatTrailLength } from "./TrailDifficulty";
 
 /**
  * Event shape consumed by EventCard (list rendering) and EventDetailPanel
@@ -65,6 +66,12 @@ export type HarelineEvent = {
   status: string;
   latitude?: number | null;
   longitude?: number | null;
+  /** #890 — verbatim trail-length string from the source. */
+  trailLengthText?: string | null;
+  trailLengthMinMiles?: number | null;
+  trailLengthMaxMiles?: number | null;
+  /** #890 — Shiggy Level (1–5). UI label is always "Shiggy Level". */
+  difficulty?: number | null;
   // Heavy / on-demand fields — undefined until `getEventDetail` resolves.
   locationStreet?: string | null;
   locationAddress?: string | null;
@@ -72,6 +79,7 @@ export type HarelineEvent = {
   sourceUrl?: string | null;
   eventLinks?: { id: string; url: string; label: string }[];
 };
+
 
 function formatDate(iso: string): string {
   const d = new Date(iso);
@@ -363,6 +371,7 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
 
   // ── Medium density ──
   const locationDisplay = getLocationDisplay(event);
+  const trailLengthDisplay = formatTrailLength(event);
   const { title: displayTitle } = getDisplayTitle({ ...event, kennel: event.kennel ?? { shortName: "", fullName: "" } });
 
   return (
@@ -532,7 +541,40 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
               </span>
             )}
 
-            {weather && (locationDisplay || event.haresText) && (
+            {/* #890 — trail length + Shiggy Level. Inline alongside
+                location/hares so hashers can size up "how far / how hard"
+                without expanding the detail panel. Region-color flame tint
+                ties difficulty to kennel identity (same color used by the
+                kennel-name underline + left border + time pill). */}
+            {trailLengthDisplay && (locationDisplay || event.haresText) && (
+              <span className="text-muted-foreground/30" aria-hidden="true">&middot;</span>
+            )}
+            {trailLengthDisplay && (
+              <TrailLengthLine
+                text={trailLengthDisplay}
+                color={regionColor}
+                size="sm"
+                className="shrink-0 max-w-[140px]"
+              />
+            )}
+            {event.difficulty != null && (trailLengthDisplay || locationDisplay || event.haresText) && (
+              <span className="text-muted-foreground/30" aria-hidden="true">&middot;</span>
+            )}
+            {event.difficulty != null && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ShiggyLevelFlames
+                    level={event.difficulty}
+                    color={regionColor}
+                    size="sm"
+                    className="shrink-0"
+                  />
+                </TooltipTrigger>
+                <TooltipContent>Shiggy Level {event.difficulty}/5</TooltipContent>
+              </Tooltip>
+            )}
+
+            {weather && (locationDisplay || event.haresText || trailLengthDisplay || event.difficulty != null) && (
               <span className="text-muted-foreground/30" aria-hidden="true">&middot;</span>
             )}
 

--- a/src/components/hareline/EventDetailPanel.tsx
+++ b/src/components/hareline/EventDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { formatTime, formatDateLong, getLabelForUrl, stripMarkdown, stripUrlsFromText } from "@/lib/format";
 import { getFullLocationDisplay } from "@/lib/event-display";
 import type { HarelineEvent } from "./EventCard";
+import { ShiggyLevelFlames, TrailLengthLine, formatTrailLength } from "./TrailDifficulty";
 import { useTimePreference } from "@/components/providers/time-preference-provider";
 import { formatTimeInZone, formatDateInZone, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
 import { CheckInButton } from "@/components/logbook/CheckInButton";
@@ -66,6 +67,7 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
     : "";
 
   const regionColor = event.kennel?.region ? getRegionColor(event.kennel.region) : "#6b7280";
+  const trailLengthDisplay = formatTrailLength(event);
 
   return (
     <Card className="flex max-h-[calc(100vh-4rem)] flex-col overflow-hidden border-t-[3px]" style={{ borderTopColor: regionColor }}>
@@ -163,6 +165,32 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
             <div>
               <dt className="font-medium text-muted-foreground">Hares</dt>
               <dd>{event.haresText}</dd>
+            </div>
+          )}
+          {/* #890 — Trail length + Shiggy Level. Same Route/Flame icons
+              and region tint as the card so the iconography users learn
+              there carries through to the detail surface unchanged. */}
+          {trailLengthDisplay && (
+            <div>
+              <dt className="font-medium text-muted-foreground">Trail Length</dt>
+              <dd className="mt-0.5">
+                <TrailLengthLine
+                  text={trailLengthDisplay}
+                  color={regionColor}
+                  size="md"
+                />
+              </dd>
+            </div>
+          )}
+          {event.difficulty != null && (
+            <div>
+              <dt className="font-medium text-muted-foreground">Shiggy Level</dt>
+              <dd className="mt-0.5 flex items-center gap-2">
+                <ShiggyLevelFlames level={event.difficulty} color={regionColor} size="md" />
+                <span className="tabular-nums text-muted-foreground/70">
+                  {event.difficulty}/5
+                </span>
+              </dd>
             </div>
           )}
           {event.locationName && (

--- a/src/components/hareline/TrailDifficulty.tsx
+++ b/src/components/hareline/TrailDifficulty.tsx
@@ -1,0 +1,136 @@
+import { Flame, Route } from "lucide-react";
+
+/**
+ * #890 — shared visual vocabulary for trail length + Shiggy Level.
+ *
+ * Lives outside `EventCard.tsx` (which is `"use client"`) so the
+ * server-rendered full-page detail (`src/app/hareline/[eventId]/page.tsx`)
+ * can import the same components without dragging the parent into a client
+ * boundary. The presentational pieces are pure SVG + spans — no client
+ * hooks needed — so they render identically on either side.
+ *
+ * Design notes
+ * ────────────
+ * Iconography:
+ *   • Route  — distance/path semantic. Distinct from MapPin (location)
+ *               and Footprints (hares) so each metadata field has its
+ *               own glyph. Hashers learn it once on the card and
+ *               recognize it on the detail panel.
+ *   • Flame  — universal "intensity level" idiom (think Yelp peppers,
+ *               Hot Ones flames). Reads instantly as a 1–5 difficulty
+ *               cluster without legend.
+ *
+ * Color treatment:
+ *   Filled flames take the kennel's region color (passed via the
+ *   `color` prop). The same color drives the kennel-name underline,
+ *   the left-border stripe, and the time-pill tint elsewhere on the
+ *   card, so Shiggy Level renders as "this kennel's interpretation
+ *   of difficulty" rather than a context-free heatmap. Empty flames
+ *   stay at a low-alpha foreground tint so the level reads at a glance.
+ */
+
+interface ShiggyLevelFlamesProps {
+  /** 1–5; values outside that range render nothing. */
+  readonly level: number | null | undefined;
+  /** Compact for in-card use, comfortable for detail panels. */
+  readonly size?: "sm" | "md";
+  /** Hex color for filled flames — typically the kennel's region color. */
+  readonly color?: string;
+  /** Extra wrapper classes (e.g. spacing the cluster from neighbors). */
+  readonly className?: string;
+}
+
+/**
+ * Render the Shiggy Level as a 5-flame row.
+ * Filled flames use solid `fill="currentColor"` tinted with `color`;
+ * empty flames are stroke-only at a muted foreground alpha. Returns
+ * `null` when `level` is missing or out of range so callers can use
+ * it freely without guards.
+ */
+export function ShiggyLevelFlames({
+  level,
+  size = "sm",
+  color,
+  className,
+}: ShiggyLevelFlamesProps) {
+  if (level == null || level < 1 || level > 5) return null;
+  const dim = size === "md" ? "h-3.5 w-3.5" : "h-3 w-3";
+  return (
+    <span
+      role="img"
+      aria-label={`Shiggy Level ${level} of 5`}
+      className={`inline-flex items-center gap-px ${className ?? ""}`}
+    >
+      {Array.from({ length: 5 }, (_, i) => {
+        const filled = i < level;
+        return (
+          <Flame
+            key={i}
+            className={`${dim} shrink-0 ${filled ? "fill-current" : "text-foreground/15 fill-transparent"}`}
+            style={filled && color ? { color } : undefined}
+            aria-hidden="true"
+          />
+        );
+      })}
+    </span>
+  );
+}
+
+interface TrailLengthLineProps {
+  /** Verbatim trail-length text from the source ("3-5 Miles", "13 miles"). */
+  readonly text: string | null | undefined;
+  /** Hex color for the leading Route icon. */
+  readonly color?: string;
+  /** Compact for in-card use, comfortable for detail panels. */
+  readonly size?: "sm" | "md";
+  readonly className?: string;
+}
+
+/**
+ * Single-line trail-length display: a region-tinted Route icon followed
+ * by the verbatim source string in `tabular-nums`. Returns `null` when
+ * `text` is empty so callers can use it without guards.
+ */
+export function TrailLengthLine({
+  text,
+  color,
+  size = "sm",
+  className,
+}: TrailLengthLineProps) {
+  if (!text) return null;
+  const dim = size === "md" ? "h-3.5 w-3.5" : "h-3 w-3";
+  const textCls = size === "md" ? "text-sm" : "text-xs";
+  return (
+    <span className={`inline-flex items-center gap-1 tabular-nums ${textCls} ${className ?? ""}`}>
+      <Route
+        className={`${dim} shrink-0 opacity-90`}
+        style={color ? { color: `${color}b0` } : undefined}
+        aria-hidden="true"
+      />
+      <span className="truncate">{text}</span>
+    </span>
+  );
+}
+
+/**
+ * Preferred display string for trail length.
+ *
+ * Uses the source's verbatim `trailLengthText` when present (preserves
+ * formatting hashers wrote: "3-5 Miles", "2.69 (miles)"). Falls back to
+ * a parsed `min–max mi` composite when only the numerics are populated.
+ * Returns `null` when nothing is set.
+ */
+export function formatTrailLength(event: {
+  trailLengthText?: string | null;
+  trailLengthMinMiles?: number | null;
+  trailLengthMaxMiles?: number | null;
+}): string | null {
+  if (event.trailLengthText) return event.trailLengthText;
+  const min = event.trailLengthMinMiles;
+  const max = event.trailLengthMaxMiles;
+  if (min == null && max == null) return null;
+  if (min != null && max != null && min !== max) return `${min}–${max} mi`;
+  if (min != null) return `${min} mi`;
+  if (max != null) return `${max} mi`;
+  return null;
+}

--- a/src/components/hareline/TrailDifficulty.tsx
+++ b/src/components/hareline/TrailDifficulty.tsx
@@ -103,8 +103,8 @@ export function TrailLengthLine({
   return (
     <span className={`inline-flex items-center gap-1 tabular-nums ${textCls} ${className ?? ""}`}>
       <Route
-        className={`${dim} shrink-0 opacity-90`}
-        style={color ? { color: `${color}b0` } : undefined}
+        className={`${dim} shrink-0`}
+        style={color ? { color, opacity: 0.7 } : { opacity: 0.9 }}
         aria-hidden="true"
       />
       <span className="truncate">{text}</span>

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1098,18 +1098,18 @@ async function upsertCanonicalEvent(
           ...(event.cost !== undefined
             ? { cost: event.cost ?? null }
             : {}),
-          ...(event.trailLengthText !== undefined
-            ? { trailLengthText: event.trailLengthText ?? null }
-            : {}),
-          ...(event.trailLengthMinMiles !== undefined
-            ? { trailLengthMinMiles: event.trailLengthMinMiles ?? null }
-            : {}),
-          ...(event.trailLengthMaxMiles !== undefined
-            ? { trailLengthMaxMiles: event.trailLengthMaxMiles ?? null }
-            : {}),
-          ...(event.difficulty !== undefined
-            ? { difficulty: event.difficulty ?? null }
-            : {}),
+          ...(event.trailLengthText === undefined
+            ? {}
+            : { trailLengthText: event.trailLengthText ?? null }),
+          ...(event.trailLengthMinMiles === undefined
+            ? {}
+            : { trailLengthMinMiles: event.trailLengthMinMiles ?? null }),
+          ...(event.trailLengthMaxMiles === undefined
+            ? {}
+            : { trailLengthMaxMiles: event.trailLengthMaxMiles ?? null }),
+          ...(event.difficulty === undefined
+            ? {}
+            : { difficulty: event.difficulty ?? null }),
           // Cross-window fuzzy match (#990) physically moves the row from
           // its old `date` bucket to the incoming source's date, so display
           // paths that compose `date + startTime + timezone` render the

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1098,6 +1098,18 @@ async function upsertCanonicalEvent(
           ...(event.cost !== undefined
             ? { cost: event.cost ?? null }
             : {}),
+          ...(event.trailLengthText !== undefined
+            ? { trailLengthText: event.trailLengthText ?? null }
+            : {}),
+          ...(event.trailLengthMinMiles !== undefined
+            ? { trailLengthMinMiles: event.trailLengthMinMiles ?? null }
+            : {}),
+          ...(event.trailLengthMaxMiles !== undefined
+            ? { trailLengthMaxMiles: event.trailLengthMaxMiles ?? null }
+            : {}),
+          ...(event.difficulty !== undefined
+            ? { difficulty: event.difficulty ?? null }
+            : {}),
           // Cross-window fuzzy match (#990) physically moves the row from
           // its old `date` bucket to the incoming source's date, so display
           // paths that compose `date + startTime + timezone` render the
@@ -1154,6 +1166,24 @@ async function upsertCanonicalEvent(
       if (!existingEvent.startTime && event.startTime) {
         enrichData.startTime = event.startTime;
       }
+      // #890 — fill the trail-length bundle when the canonical event has
+      // it unset, so a higher-trust primary that lacks these fields
+      // doesn't drop a lower-trust source's parsed values on the floor.
+      // The bundle is treated atomically: if the source provided text but
+      // not numerics (or vice versa), we still backfill what we have so
+      // partial data lands rather than nothing.
+      if (existingEvent.trailLengthText == null && event.trailLengthText) {
+        enrichData.trailLengthText = event.trailLengthText;
+      }
+      if (existingEvent.trailLengthMinMiles == null && event.trailLengthMinMiles != null) {
+        enrichData.trailLengthMinMiles = event.trailLengthMinMiles;
+      }
+      if (existingEvent.trailLengthMaxMiles == null && event.trailLengthMaxMiles != null) {
+        enrichData.trailLengthMaxMiles = event.trailLengthMaxMiles;
+      }
+      if (existingEvent.difficulty == null && event.difficulty != null) {
+        enrichData.difficulty = event.difficulty;
+      }
       if (Object.keys(enrichData).length > 0) {
         const enriched = await prisma.event.update({
           where: { id: existingEvent.id },
@@ -1208,6 +1238,10 @@ async function upsertCanonicalEvent(
       startTime: event.startTime,
       endTime: event.endTime,
       cost: event.cost,
+      trailLengthText: event.trailLengthText,
+      trailLengthMinMiles: event.trailLengthMinMiles,
+      trailLengthMaxMiles: event.trailLengthMaxMiles,
+      difficulty: event.difficulty,
       sourceUrl: event.sourceUrl,
       trustLevel: ctx.trustLevel,
       latitude: coords.latitude,


### PR DESCRIPTION
Closes #890

## Summary

- Adds four optional fields to `Event`: `trailLengthText` (verbatim source string like "3-5 Miles"), `trailLengthMinMiles` / `trailLengthMaxMiles` (parsed bounds; min == max for fixed values), and `difficulty` (1–5 Shiggy Scale, validated at adapter layer).
- Plumbs the fields through `RawEventData` → `merge.ts` (UPDATE + CREATE + lower-trust enrichment) → all five UI surfaces (slim hareline cache, EventCard, EventDetailPanel, kennel page, full-page event detail).
- Burlington (BurlyH3) adapter is the first to populate them — it already had `Length:` / `Shiggy Scale:` as terminators on its hares regex; this PR turns them into first-class fields. Other adapters with the same data (SDH3, etc.) can light up later in follow-up PRs.
- New shared component `TrailDifficulty.tsx` exports `ShiggyLevelFlames` (region-tinted lucide Flame cluster) + `TrailLengthLine` (Route icon + verbatim text) + `formatTrailLength()` helper. Used identically on card, detail panel, and full-page detail so the visual vocabulary is consistent across surfaces.

DB column `difficulty` stays generic so other adapters' "rating" / "hardness" fields can land in the same column later. **User-facing UI label is always "Shiggy Level"** — hash vernacular for trail difficulty.

## Atomic-bundle merge semantics (Codex review finding)

When an adapter sees a label with an unparseable value (e.g. `Length: TBD` or `Shiggy Scale: 7`), it now emits explicit `null` for the affected numeric fields rather than `undefined`. The merge UPDATE writes nulls, clearing any stale parsed range from a prior scrape. Without this, `3-5 Miles → TBD` would leave `min=3, max=5` wired to fresh `text="TBD"`.

The lower-trust enrichment branch in `merge.ts` was also extended to backfill the new fields when the canonical row has them unset, so a higher-trust primary that lacks Shiggy/Length data doesn't drop a lower-trust source's values on the floor.

Tests cover the four parser shapes: fixed length (`2.69`), ranged (`3-5 Miles`), TBD (text passes, numerics → `null`), and out-of-range Shiggy (difficulty → `null`).

## Live verification

Run earlier in the cycle (browser-render is currently down for unrelated DNS reasons; the adapter and merge logic haven't changed in shape since this run — only the explicit-null semantic added later for unparseable values):

```
fetched 16 events from burlingtonh3.com/hareline
errors: 0

─── trail length + Shiggy Level extraction ───
populated total : 4
fixed-length    : 2
ranged-length   : 1

2026-05-06  #852  text="1 Mile"     min=1   max=1   shiggy=1   · Memorial Karl Marx Tequila Mile
2026-05-25  #?    text="13 miles"   min=13  max=13  shiggy=undefined  · Soup H3's Beer Half
2026-06-10  #857  text="TBD"        min=undefined  max=undefined  shiggy=undefined  · Break a Leg
2026-06-17  #858  text="3-5 Miles"  min=3   max=5   shiggy=5   · Mountain Man
```

Note: under the current explicit-null semantic, the TBD line above would emit `min=null, max=null` instead of `undefined` — that's the intentional Codex-driven change so the merge UPDATE clears stale numerics. The unit tests in `burlington-hash.test.ts` assert `toBeNull()` for that case.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (19 pre-existing warnings, none in changed files)
- [x] `npm test` — 6000 / 6000 pass
- [x] `npx prisma migrate deploy` against local DB — clean apply (`add_event_trail_length_difficulty`)
- [x] `npx prisma db seed` — clean apply against migrated DB
- [x] Burlington adapter unit tests cover fixed / ranged / TBD / out-of-range / no-label cases
- [x] /codex:adversarial-review surfaced two atomic-bundle issues; both addressed in this PR (explicit-null semantic + lower-trust enrichment)
- [x] /simplify review pass applied (5 small consistency wins: hoisted `regionColor` + `trailLengthDisplay` consts, dropped wrapper span, hoisted module-level regexes, trimmed narrative comments)
- [ ] Live live-verify rerun once browser-render service is reachable again
- [ ] Visual screenshot of an actual rendered BurlyH3 card on prod after merge — local DB has 0 BurlyH3 events because the dump pre-dated active scraping; HTML preview confirms visual treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)