### PR TITLE
chore(sonar): close Phase B — HTTPS upgrades + gate doc rewrite

### DIFF
--- a/docs/sonarcloud-gate.md
+++ b/docs/sonarcloud-gate.md
@@ -25,21 +25,21 @@
 
 ## What's excluded
 
-`sonar-project.properties` excludes:
-- `prisma/seed.ts`, `prisma/seed-data/**/*.ts` — duplication checks (large hand-curated data files)
-- `docs/mockups/**` — full Sonar analysis (these are static design references, not shipped code)
+`sonar-project.properties` lists exclusions for:
+- `sonar.cpd.exclusions`: `prisma/seed.ts`, `prisma/seed-data/**/*.ts`, `src/lib/admin/*-prompt.test.ts`, `src/adapters/hare-extraction.test.ts` — duplication only
+- `sonar.exclusions`: `docs/mockups/**` — full analysis (static design references, not shipped code)
 
-## `main` gate is currently ERROR — by design (for now)
+> **Important:** SonarCloud Automatic Analysis ignores `sonar-project.properties` — exclusions must also be set in the SonarCloud UI (Project Settings → Analysis Scope) for them to take effect. Until that UI config is in place, the duplication gate condition counts seed-data files. See [#1267](https://github.com/johnrclem/hashtracks-web/issues/1267).
 
-The `main` branch gate currently shows ERROR because of historical debt:
-- ~399 unreviewed security hotspots accumulated over time
-- Reliability rating D from a backlog of medium-severity bugs in test files and mockups
+## Phase B status
 
-This is **deferred Phase B** of [#1086](https://github.com/johnrclem/hashtracks-web/issues/1086): a one-time SAFE-resolve sweep of the existing hotspots and any genuinely-stale bug findings. PR-gate relief (this doc) lands first; the main-gate green-up follows separately.
+Phase B sweep landed via [#1141](https://github.com/johnrclem/hashtracks-web/issues/1141): all 398 hotspots in `TO_REVIEW` were triaged through the SonarQube MCP (most SAFE-resolved with per-hotspot context, 16 FIXED inline via HTTPS upgrades on kennel-website seed URLs that actually serve TLS), and the 6 BUG findings on `main` were resolved (5 mockup wirefames marked WONTFIX, 1 conditional-keyboard-handler false-positive). Verifiable at <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web> (filter to `Reviewed`) and via `mcp__sonarqube__quality_gate_status`.
 
-If you want to help with Phase B, query unreviewed hotspots via the SonarQube MCP tool from inside Claude Code — invoke the `mcp__sonarqube__hotspots` tool with `project_key="johnrclem_hashtracks-web"` and `status="TO_REVIEW"`. (Note: this is a Claude Code tool name, not a shell command — there is no CLI you can run literally.) For ad-hoc browsing, the SonarCloud web UI works too: <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web>.
+Current `main` gate: 5 of 6 conditions OK. The remaining ERROR is `new_duplicated_lines_density` (4.5% > 3% threshold). By directory: `src/adapters` 3,705 dup lines (mostly test fixtures), `prisma` 2,425, `src/pipeline` 1,368. Closing it has two prerequisites tracked in [#1267](https://github.com/johnrclem/hashtracks-web/issues/1267):
+1. **SonarCloud UI exclusions** for the patterns currently in `sonar.cpd.exclusions` (the in-repo properties file is inert under Automatic Analysis). This alone resolves the seed-data contribution (~2,425 lines) but is **not sufficient** — the existing CPD exclusion list does not cover generic adapter test fixtures.
+2. **Adapter test fixture deduping** for `src/adapters/**/*.test.ts` — either by adding a broader pattern to the UI CPD exclusions, or by refactoring shared fixtures via `it.each` (memory `feedback_it_each_for_sonar_cpd.md`).
 
-Most hotspots are bounded-input regex (`typescript:S5852`) or `http://` URLs in seed files (`typescript:S5332`) — low-risk in context, but each needs a per-hotspot SAFE-resolve.
+If new hotspots or bugs accrue, query them with `mcp__sonarqube__hotspots` (`project_key="johnrclem_hashtracks-web"`, `status="TO_REVIEW"`) from Claude Code, or browse <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web>.
 
 ## Why we don't use "previous version" for the PR new-code period
 

--- a/docs/sonarcloud-gate.md
+++ b/docs/sonarcloud-gate.md
@@ -33,11 +33,11 @@
 
 ## Phase B status
 
-Phase B sweep landed via [#1141](https://github.com/johnrclem/hashtracks-web/issues/1141): all 398 hotspots in `TO_REVIEW` were triaged through the SonarQube MCP (most SAFE-resolved with per-hotspot context, 16 FIXED inline via HTTPS upgrades on kennel-website seed URLs that actually serve TLS), and the 6 BUG findings on `main` were resolved (5 mockup wirefames marked WONTFIX, 1 conditional-keyboard-handler false-positive). Verifiable at <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web> (filter to `Reviewed`) and via `mcp__sonarqube__quality_gate_status`.
+Phase B sweep landed via [#1141](https://github.com/johnrclem/hashtracks-web/issues/1141): all 398 hotspots in `TO_REVIEW` were triaged through the SonarQube MCP (most SAFE-resolved with per-hotspot context, 16 FIXED inline via HTTPS upgrades on kennel-website seed URLs that actually serve TLS), and the 6 BUG findings on `main` were resolved (5 mockup wireframes marked WONTFIX, 1 conditional-keyboard-handler false-positive). Verifiable at <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web> (filter to `Reviewed`) and via `mcp__sonarqube__quality_gate_status`.
 
 Current `main` gate: 5 of 6 conditions OK. The remaining ERROR is `new_duplicated_lines_density` (4.5% > 3% threshold). By directory: `src/adapters` 3,705 dup lines (mostly test fixtures), `prisma` 2,425, `src/pipeline` 1,368. Closing it has two prerequisites tracked in [#1267](https://github.com/johnrclem/hashtracks-web/issues/1267):
 1. **SonarCloud UI exclusions** for the patterns currently in `sonar.cpd.exclusions` (the in-repo properties file is inert under Automatic Analysis). This alone resolves the seed-data contribution (~2,425 lines) but is **not sufficient** — the existing CPD exclusion list does not cover generic adapter test fixtures.
-2. **Adapter test fixture deduping** for `src/adapters/**/*.test.ts` — either by adding a broader pattern to the UI CPD exclusions, or by refactoring shared fixtures via `it.each` (memory `feedback_it_each_for_sonar_cpd.md`).
+2. **Adapter test fixture deduping** for `src/adapters/**/*.test.ts` — either by adding a broader pattern to the UI CPD exclusions, or by refactoring shared fixtures via `it.each` tables and shared helpers.
 
 If new hotspots or bugs accrue, query them with `mcp__sonarqube__hotspots` (`project_key="johnrclem_hashtracks-web"`, `status="TO_REVIEW"`) from Claude Code, or browse <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web>.
 

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -106,7 +106,7 @@ export const KENNELS: KennelSeed[] = [
     // --- Rochester ---
     {
       kennelCode: "flour-city", shortName: "Flour City H3", fullName: "Flour City Hash House Harriers", region: "Rochester, NY",
-      website: "http://flourcityhhh.com/",
+      website: "https://flourcityhhh.com/",
       logoUrl: "https://static1.squarespace.com/static/5159d000e4b0faeba238a2f8/t/5a43b07ae2c483652f03b5de/1514385531224/VerticalStacked-AllWhite-Transparent.png?format=1500w",
       contactEmail: "flourcitymismanagement@gmail.com",
       scheduleDayOfWeek: "Sunday", scheduleFrequency: "Weekly", scheduleTime: "1:09 PM",
@@ -118,7 +118,7 @@ export const KENNELS: KennelSeed[] = [
     // --- Buffalo ---
     {
       kennelCode: "bh3", shortName: "Buffalo H3", fullName: "Buffalo Hash House Harriers", region: "Buffalo, NY",
-      website: "http://hashinthebuff.com/",
+      website: "https://hashinthebuff.com/",
       logoUrl: "/kennel-logos/bh3.gif",
       facebookUrl: "https://www.facebook.com/groups/1692560221019401/",
       contactEmail: "hashinthebuff@gmail.com",
@@ -455,7 +455,7 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "mvh3", shortName: "MVH3", fullName: "Mount Vernon Hash House Harriers", region: "Washington, DC",
-      website: "http://www.dchashing.org/mvh3/", foundedYear: 1985,
+      website: "https://www.dchashing.org/mvh3/", foundedYear: 1985,
       scheduleDayOfWeek: "Saturday", scheduleTime: "10:00 AM", scheduleFrequency: "Weekly",
       description: "Weekly Saturday 10 AM hash in the DC metro area (est. 1985).",
     },
@@ -803,7 +803,7 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "barnesh3", shortName: "BarnesH3", fullName: "Barnes Hash House Harriers", region: "London", country: "UK",
-      website: "http://www.barnesh3.com",
+      website: "https://www.barnesh3.com",
       scheduleDayOfWeek: "Wednesday", scheduleTime: "7:30 PM", scheduleFrequency: "Weekly",
       hashCash: "£2",
     },
@@ -1390,7 +1390,7 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "pbh3", shortName: "Palm Beach H3", fullName: "Palm Beach Hash House Harriers", region: "Miami, FL",
-      website: "http://www.pbh3.org",
+      website: "https://www.pbh3.org",
       facebookUrl: "https://www.facebook.com/groups/pbhhh/",
       scheduleDayOfWeek: "Wednesday", scheduleFrequency: "Weekly",
       description: "Weekly Wednesday runs in the Palm Beach County area.",
@@ -1517,7 +1517,7 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "bvd-h3", shortName: "BVDH3", fullName: "BVD Hash House Harriers", region: "Orlando, FL",
-      website: "http://www.bvdh3.com",
+      website: "https://www.bvdh3.com",
       facebookUrl: "https://www.facebook.com/groups/506635549502193/",
       scheduleDayOfWeek: "Saturday", scheduleTime: "4:00 PM", scheduleFrequency: "Biweekly",
       hashCash: "$5", foundedYear: 1999,
@@ -1793,7 +1793,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "okh3", shortName: "OKH3", fullName: "Oregon Kahuna Hash House Harriers",
       region: "Portland, OR",
-      website: "http://oregonkahunah3.pbworks.com/",
+      website: "https://oregonkahunah3.pbworks.com/",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:00 PM", scheduleFrequency: "Weekly",
       description: "Portland's Monday evening hash. Also runs as Ka-Three-Na and Katuna for alternating events.",
       latitude: 45.52, longitude: -122.68,
@@ -3473,7 +3473,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "phhh", shortName: "PHHH", fullName: "Phuket Hash House Harriers",
       region: "Phuket", country: "Thailand",
-      website: "http://www.phuket-hhh.com",
+      website: "https://www.phuket-hhh.com",
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Weekly",
       scheduleTime: "4:00 PM",
       scheduleNotes: "Weekly Saturday runs. Shared hareline at phuket-hhh.com covers PHHH, Pooying, Tinmen, Iron Pussy, Bike Hash, and Kamala Koma.",
@@ -3483,7 +3483,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "phuket-tinmen", shortName: "Phuket Tin Men", fullName: "Phuket Tin Men Hash House Harriers",
       region: "Phuket", country: "Thailand",
-      website: "http://www.phuket-hhh.com",
+      website: "https://www.phuket-hhh.com",
       scheduleDayOfWeek: "Wednesday", scheduleFrequency: "Monthly",
       scheduleTime: "3:00 PM",
       scheduleNotes: "1st Wednesday monthly. Listed on the shared phuket-hhh.com hareline.",
@@ -3493,7 +3493,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "iron-pussy", shortName: "Iron Pussy", fullName: "Iron Pussy Hash House Harriers",
       region: "Phuket", country: "Thailand",
-      website: "http://www.phuket-hhh.com",
+      website: "https://www.phuket-hhh.com",
       scheduleDayOfWeek: "Wednesday", scheduleFrequency: "Monthly",
       scheduleTime: "4:00 PM",
       scheduleNotes: "2nd Wednesday monthly. Listed on the shared phuket-hhh.com hareline.",
@@ -3503,7 +3503,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "phuket-pooying", shortName: "Phuket Pooying", fullName: "Phuket Pooying Picnic Hash",
       region: "Phuket", country: "Thailand",
-      website: "http://www.phuket-hhh.com",
+      website: "https://www.phuket-hhh.com",
       scheduleDayOfWeek: "Sunday", scheduleFrequency: "Monthly",
       scheduleTime: "3:00 PM",
       scheduleNotes: "2nd/3rd Sunday monthly. 'The most dangerous hash on the island.' Listed on shared phuket-hhh.com hareline.",
@@ -3604,7 +3604,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "bhhb", shortName: "BHHB", fullName: "Bangkok Hash House Bikers",
       region: "Bangkok", country: "Thailand",
-      website: "http://www.bangkokbikehash.org",
+      website: "https://www.bangkokbikehash.org",
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
       scheduleNotes: "Monthly weekend mountain bike rides, 40-50km. Trail laid by hares, circle up with beers afterward.",
       description: "Bangkok's mountain bike hash. Monthly rides of 40-50km on trails laid by hares, followed by a beer circle.",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4387,7 +4387,7 @@ export const SOURCES = [
     // --- Phuket HHH Shared Hareline ---
     {
       name: "Phuket HHH Hareline",
-      url: "http://www.phuket-hhh.com/hareline.php",
+      url: "https://www.phuket-hhh.com/hareline.php",
       type: "HTML_SCRAPER" as const,
       trustLevel: 8,
       scrapeFreq: "daily",
@@ -4479,7 +4479,7 @@ export const SOURCES = [
     // Needs live Chrome verification before enabling.
     {
       name: "Bangkok Bikers Website",
-      url: "http://www.bangkokbikehash.org",
+      url: "https://www.bangkokbikehash.org",
       type: "HTML_SCRAPER" as const,
       enabled: false,
       trustLevel: 5,

--- a/src/adapters/html-scraper/bangkok-bikers.ts
+++ b/src/adapters/html-scraper/bangkok-bikers.ts
@@ -73,7 +73,7 @@ export class BangkokBikersAdapter implements SourceAdapter {
     source: Source,
     options?: { days?: number },
   ): Promise<ScrapeResult> {
-    const baseUrl = source.url || "http://www.bangkokbikehash.org";
+    const baseUrl = source.url || "https://www.bangkokbikehash.org";
 
     // Fetch the /hash_weekends/upcoming page (the canonical ride list),
     // NOT just the homepage which only shows the single next ride.

--- a/src/adapters/html-scraper/barnes-hash.ts
+++ b/src/adapters/html-scraper/barnes-hash.ts
@@ -83,7 +83,7 @@ function extractHaresFromCells(cells: string[]): string | undefined {
   return undefined;
 }
 
-export function parseBarnesRow(cells: string[], sourceUrl = "http://www.barnesh3.com/HareLine.htm"): RawEventData | null {
+export function parseBarnesRow(cells: string[], sourceUrl = "https://www.barnesh3.com/HareLine.htm"): RawEventData | null {
   if (cells.length < 2) return null;
 
   const allText = cells.join(" ");
@@ -125,7 +125,7 @@ export class BarnesHashAdapter implements SourceAdapter {
     source: Source,
     _options?: { days?: number },
   ): Promise<ScrapeResult> {
-    const baseUrl = source.url || "http://www.barnesh3.com/HareLine.htm";
+    const baseUrl = source.url || "https://www.barnesh3.com/HareLine.htm";
 
     const events: RawEventData[] = [];
     const errors: string[] = [];

--- a/src/adapters/html-scraper/phuket-hhh.ts
+++ b/src/adapters/html-scraper/phuket-hhh.ts
@@ -121,7 +121,7 @@ export class PhuketHHHAdapter implements SourceAdapter {
     source: Source,
     options?: { days?: number },
   ): Promise<ScrapeResult> {
-    const baseUrl = source.url || "http://www.phuket-hhh.com/hareline.php";
+    const baseUrl = source.url || "https://www.phuket-hhh.com/hareline.php";
     const config = (source.config ?? {}) as Record<string, unknown>;
     const kennelMap = (config.kennelMap as Record<string, string>) ?? DEFAULT_KENNEL_MAP;
 


### PR DESCRIPTION
## Summary

Closes the SonarCloud Phase B sweep started in #1141. Most of the work was MCP-driven (398 hotspots SAFE-resolved + 6 BUGs triaged via the SonarQube API); this PR carries the in-repo half:

- **HTTPS upgrades** (16 inline FIXED hotspots): kennel website fields, production `Source.url` entries, and adapter fallback defaults — only for hosts that actually serve TLS, verified via `curl -sIL`.
- **Gate doc rewrite**: removes the "currently ERROR — by design" framing now that 5 of 6 conditions are OK on `main`. The remaining `new_duplicated_lines_density` failure is tracked in #1267.

## What was done in SonarCloud (verifiable via [Project Hotspots](https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web))

| Bucket | Count | Disposition |
|---|---|---|
| `typescript:S5852` regex DoS | 245 | SAFE — bounded scraper input, regex matches short fragments |
| `typescript:S5332` http:// in test files | 94 | SAFE — fixture string literals |
| `typescript:S5332` http:// in `prisma/seed-data/kennels.ts` | 33 | 12 FIXED inline + 21 SAFE (host doesn't serve HTTPS) |
| `typescript:S5332` http:// in adapter sources | 9 | 4 FIXED inline + 5 SAFE (HTTP-only fallback default) |
| `typescript:S1313` hardcoded IPs | 10 | SAFE — test fixtures or SSRF defense literal |
| `Web:S5725` SRI | 2 | SAFE — design wireframes |
| `typescript:S4036` / `javascript:S4036` PATH | 3 | SAFE — dev tooling, dev-controlled PATH |
| `githubactions:S7637` action SHA-pin | 1 | SAFE — first-party `anthropics/claude-code-action@v1` |
| `typescript:S2245` Math.random | 1 | SAFE — one-shot completed migration |
| **BUGs**: mockup HTML | 5 | WONTFIX — `docs/mockups/`, never shipped |
| **BUG**: `AttendanceBadge.tsx:20` a11y | 1 | FALSE-POSITIVE — conditional onKeyDown spread is present (lines 27–36) |

## Quality gate state

Verified via `mcp__sonarqube__quality_gate_status` (post-PR, `main`):
- `new_security_hotspots_reviewed`: **100%** (was 16.5%) — OK
- `new_reliability_rating`: **1** (was 3) — OK
- `new_security_rating`: 1 — OK
- `new_maintainability_rating`: 1 — OK
- `new_coverage`: OK
- `new_duplicated_lines_density`: 4.5% > 3% — **ERROR**, tracked in #1267

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors (19 pre-existing warnings, unrelated)
- [x] `npx vitest run` for `barnes-hash`, `phuket-hhh` (38 tests passed; bangkok-bikers has no test file)
- [x] HTTPS responsiveness re-verified for the 9 upgraded hosts (curl 2xx/4xx)
- [x] Straggler scan: 0 remaining `http://<upgraded-host>` references in `src/` or `prisma/`
- [x] `/codex:adversarial-review` — findings addressed in the gate doc rewrite

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)