### PR TITLE
chore(sonar): broaden CPD exclusions to all test files (#1267)

### DIFF
--- a/docs/sonarcloud-gate.md
+++ b/docs/sonarcloud-gate.md
@@ -6,7 +6,7 @@
 - **PR new-code period:** "since branch from main" (branch-based baseline)
   - PR analyses only count issues introduced by the PR's diff against `main`.
   - Touching a file with pre-existing issues no longer drags those issues into the PR's "new code" view.
-- **`main` new-code period:** "previous version" — but `package.json` is `0.1.0` and there is no release-bump discipline. The `main` gate is currently informational; it does not block deploys (Vercel deploys on push to `main`, not on Sonar status).
+- **`main` new-code period:** "previous version" — but `package.json` is `0.1.0` and there is no release-bump discipline. The `main` gate is informational; it does not block deploys (Vercel deploys on push to `main`, not on Sonar status).
 - **`new_security_hotspots_reviewed` condition:** kept on the gate, but with the branch-based PR baseline it only fires when a PR introduces *new* hotspots — not when a PR touches a file that has historical hotspots.
 
 ## What this means in practice
@@ -26,18 +26,16 @@
 ## What's excluded
 
 `sonar-project.properties` lists exclusions for:
-- `sonar.cpd.exclusions`: `prisma/seed.ts`, `prisma/seed-data/**/*.ts`, `src/lib/admin/*-prompt.test.ts`, `src/adapters/hare-extraction.test.ts` — duplication only
+- `sonar.cpd.exclusions`: `prisma/seed.ts`, `prisma/seed-data/**/*.ts`, `**/*.test.ts` — duplication only. Test code is intentionally repetitive (clear, locally-readable cases beat DRY); seed data is a hand-curated dataset where every kennel record shares the same shape.
 - `sonar.exclusions`: `docs/mockups/**` — full analysis (static design references, not shipped code)
 
-> **Important:** SonarCloud Automatic Analysis ignores `sonar-project.properties` — exclusions must also be set in the SonarCloud UI (Project Settings → Analysis Scope) for them to take effect. Until that UI config is in place, the duplication gate condition counts seed-data files. See [#1267](https://github.com/johnrclem/hashtracks-web/issues/1267).
+> **Important:** SonarCloud Automatic Analysis ignores `sonar-project.properties` — the same patterns must also be set in the SonarCloud UI under Project Settings → Analysis Scope → Duplications. The repo file exists for in-repo parity; the UI is the source of truth.
 
 ## Phase B status
 
 Phase B sweep landed via [#1141](https://github.com/johnrclem/hashtracks-web/issues/1141): all 398 hotspots in `TO_REVIEW` were triaged through the SonarQube MCP (most SAFE-resolved with per-hotspot context, 16 FIXED inline via HTTPS upgrades on kennel-website seed URLs that actually serve TLS), and the 6 BUG findings on `main` were resolved (5 mockup wireframes marked WONTFIX, 1 conditional-keyboard-handler false-positive). Verifiable at <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web> (filter to `Reviewed`) and via `mcp__sonarqube__quality_gate_status`.
 
-Current `main` gate: 5 of 6 conditions OK. The remaining ERROR is `new_duplicated_lines_density` (4.5% > 3% threshold). By directory: `src/adapters` 3,705 dup lines (mostly test fixtures), `prisma` 2,425, `src/pipeline` 1,368. Closing it has two prerequisites tracked in [#1267](https://github.com/johnrclem/hashtracks-web/issues/1267):
-1. **SonarCloud UI exclusions** for the patterns currently in `sonar.cpd.exclusions` (the in-repo properties file is inert under Automatic Analysis). This alone resolves the seed-data contribution (~2,425 lines) but is **not sufficient** — the existing CPD exclusion list does not cover generic adapter test fixtures.
-2. **Adapter test fixture deduping** for `src/adapters/**/*.test.ts` — either by adding a broader pattern to the UI CPD exclusions, or by refactoring shared fixtures via `it.each` tables and shared helpers.
+Phase B follow-up [#1267](https://github.com/johnrclem/hashtracks-web/issues/1267) closed the remaining `new_duplicated_lines_density` condition by broadening the CPD exclusion to `**/*.test.ts`. The seed-data exclusion alone wasn't enough (4.5% → ~3.17%, still over 3%); test-file duplication was the dominant signal (`src/pipeline/merge.test.ts` alone contributed 778 dup lines). The current `main` gate should be OK on all six conditions.
 
 If new hotspots or bugs accrue, query them with `mcp__sonarqube__hotspots` (`project_key="johnrclem_hashtracks-web"`, `status="TO_REVIEW"`) from Claude Code, or browse <https://sonarcloud.io/project/security_hotspots?id=johnrclem_hashtracks-web>.
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,12 @@
-sonar.cpd.exclusions=prisma/seed.ts,prisma/seed-data/**/*.ts,src/lib/admin/*-prompt.test.ts,src/adapters/hare-extraction.test.ts
+# Test files are intentionally repetitive (clear, locally-readable cases beat DRY).
+# Seed data is a hand-curated dataset where every kennel record shares the same
+# shape — duplication is intrinsic, not a smell.
+#
+# NOTE: SonarCloud Automatic Analysis ignores this file. The same patterns must
+# also be set in the SonarCloud UI under Project Settings → Analysis Scope →
+# Duplications. This file exists for in-repo parity so maintainers can see the
+# active exclusion list without leaving the codebase.
+sonar.cpd.exclusions=prisma/seed.ts,prisma/seed-data/**/*.ts,**/*.test.ts
 
 # Mockup files are design references, not shipped code. Sonar's HTML/CSS rules
 # flag accessibility/structural issues that are intentional in static mockups.


### PR DESCRIPTION
## Summary

Closes #1267.

Broadens `sonar.cpd.exclusions` to cover all `**/*.test.ts` files. Test code is intentionally repetitive (clear locally-readable cases beat DRY) and was already partially excluded — this generalizes the existing carve-out from two specific files to the whole pattern.

## Why

The original #1267 framing assumed UI-only seed-data exclusion would green-up the `main` gate's `new_duplicated_lines_density` condition. Verified post-#1141 measurements showed that wasn't enough:

```
new_duplicated_lines        : 8,975
ncloc (project)             : 206,537
new_duplicated_lines_density: 4.47%   (threshold ≤ 3%)
```

| If excluded | Drops by | Density after |
|---|---|---|
| Seed data only (~2,425 lines) | 2,425 | ~3.17% — still over |
| Seed data + all `*.test.ts` (~7,825 lines) | 7,825 | **~0.56%** ✓ |

Root cause is test-file duplication. The single biggest contributor is `src/pipeline/merge.test.ts` (778 dup lines on its own). Across 239 `*.test.ts` files in `src/`, total ~5,400 dup lines.

## What changed

- `sonar-project.properties`: replace the file-by-file CPD test exclusions (`src/lib/admin/*-prompt.test.ts`, `src/adapters/hare-extraction.test.ts`) with the broad pattern `**/*.test.ts`. Seed-data and mockup exclusions unchanged.
- `docs/sonarcloud-gate.md`: update the "What's excluded" section and the Phase B status note to reflect the new exclusion list and the expected closed gate.

## ⚠️ User action required (UI)

SonarCloud Automatic Analysis **ignores** `sonar-project.properties`. The repo file is for in-repo parity; the UI is the source of truth. Please mirror the change at:

<https://sonarcloud.io/project/settings?id=johnrclem_hashtracks-web>

Administration → Analysis Scope → **Duplications** → set the patterns to:

```
prisma/seed.ts
prisma/seed-data/**/*.ts
**/*.test.ts
```

(Confirm Source File Exclusions still has `docs/mockups/**` for full-analysis exclusion.) Re-analysis on `main` happens automatically on next push.

## Test plan

- [ ] Merge this PR
- [ ] Set the same CPD patterns in SonarCloud UI (per the box above)
- [ ] After re-analysis triggers on `main`, verify gate is OK on all six conditions:
  - `mcp__sonarqube__quality_gate_status({ project_key: "johnrclem_hashtracks-web", branch: "main" })` → all OK
  - `mcp__sonarqube__measures_component` for `new_duplicated_lines_density` → < 3%

🤖 Generated with [Claude Code](https://claude.com/claude-code)