### PR TITLE
feat(static-schedule): lunar-phase recurrence (T2a) + moon-phase calendar glyphs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "rss-parser": "^3.13.0",
         "safe-regex2": "^5.0.0",
         "sonner": "^2.0.7",
+        "suncalc": "^1.9.0",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -54,6 +55,7 @@
         "@types/pg": "^8.16.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/suncalc": "^1.9.2",
         "dotenv": "^17.2.4",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
@@ -7141,6 +7143,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/suncalc": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/suncalc/-/suncalc-1.9.2.tgz",
+      "integrity": "sha512-ATAGBHHfA1TlE2tjfidLyTcysjoT2JHHEAmWRULh73SU9UTn++j5fqHEW16X6Y/2Li87jEQXzgu4R/OOdlDqzw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16795,6 +16804,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
     },
     "node_modules/supercluster": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "rss-parser": "^3.13.0",
     "safe-regex2": "^5.0.0",
     "sonner": "^2.0.7",
+    "suncalc": "^1.9.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
@@ -58,6 +59,7 @@
     "@types/pg": "^8.16.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/suncalc": "^1.9.2",
     "dotenv": "^17.2.4",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -740,6 +740,30 @@ export const SOURCES = [
       },
       kennelCodes: ["ebh3"],
     },
+    // SF Full Moon Hash — lunar STATIC_SCHEDULE.
+    // Lunar dates are deterministic so scrapeDays:365 costs nothing.
+    // The SFH3 multihash feed maps `^FMH3` → sffmh3 but doesn't publish FMH3
+    // events on its calendar; this is the primary coverage path for sffmh3.
+    {
+      name: "SFFMH3 Static Schedule (Lunar)",
+      url: "https://www.facebook.com/sffmh",
+      type: "STATIC_SCHEDULE" as const,
+      trustLevel: 5,
+      scrapeFreq: "weekly",
+      scrapeDays: 365,
+      config: {
+        kennelTag: "sffmh3",
+        lunar: {
+          phase: "full",
+          timezone: "America/Los_Angeles",
+        },
+        startTime: "18:30",
+        defaultTitle: "SFFMH3 Full Moon Run",
+        defaultLocation: "San Francisco, CA",
+        defaultDescription: "Monthly full-moon hash. Check Facebook for start location and hare details.",
+      },
+      kennelCodes: ["sffmh3"],
+    },
     // DC / DMV area — iCal feeds (ai1ec WordPress plugin)
     {
       name: "Charm City H3 iCal Feed",
@@ -795,6 +819,33 @@ export const SOURCES = [
       scrapeFreq: "daily",
       scrapeDays: 90,
       kennelCodes: ["h4"],
+    },
+    // DC Full Moon Hash — anchor-mode lunar STATIC_SCHEDULE.
+    // DCFMH3 runs Friday/Saturday "near the full moon" rather than on the
+    // exact phase. `nearest` snaps each phase to the closest Saturday
+    // (forward on tie). Hash Rego covers individual registrations; this
+    // source provides forward-looking projections for Travel Mode + calendar.
+    {
+      name: "DCFMH3 Static Schedule (Lunar Anchor)",
+      url: "https://sites.google.com/site/dcfmh3/home",
+      type: "STATIC_SCHEDULE" as const,
+      trustLevel: 5,
+      scrapeFreq: "weekly",
+      scrapeDays: 365,
+      config: {
+        kennelTag: "dcfmh3",
+        lunar: {
+          phase: "full",
+          timezone: "America/New_York",
+          anchorWeekday: "SA",
+          anchorRule: "nearest",
+        },
+        startTime: "18:30",
+        defaultTitle: "DCFMH3 Full Moon Run",
+        defaultLocation: "Washington, DC",
+        defaultDescription: "Monthly full-moon hash, run on the Saturday nearest the full moon. Check Hash Rego or the kennel website for hare and start details.",
+      },
+      kennelCodes: ["dcfmh3"],
     },
     // Hash Rego (hashrego.com — multi-kennel registration platform)
     {

--- a/scripts/backfill-schedule-rules.test.ts
+++ b/scripts/backfill-schedule-rules.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseScheduleTime, parseFrequencyDay, normalizeRRule } from "./backfill-schedule-rules";
+import {
+  parseScheduleTime,
+  parseFrequencyDay,
+  normalizeRRule,
+  runStaticSchedulePass,
+} from "./backfill-schedule-rules";
 
 describe("parseScheduleTime", () => {
   it("parses PM times to 24-hour", () => {
@@ -210,5 +215,235 @@ describe("normalizeRRule", () => {
     expect(normalizeRRule("FREQ=MONTHLY;BYDAY=SA,FR;BYSETPOS=3")).toBe(
       "FREQ=MONTHLY;BYDAY=SA,FR;BYSETPOS=3",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runStaticSchedulePass — lunar sentinel emission (T2a, PR #1)
+// ---------------------------------------------------------------------------
+
+interface FakeKennelLink {
+  kennel: { id: string; shortName: string; isHidden: boolean };
+}
+
+interface FakeSource {
+  id: string;
+  name: string;
+  url: string | null;
+  type: "STATIC_SCHEDULE";
+  enabled: boolean;
+  lastSuccessAt: Date | null;
+  lastScrapeAt: Date | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: any;
+  kennels: FakeKennelLink[];
+}
+
+function fakePrisma(sources: FakeSource[]) {
+  return {
+    source: {
+      findMany: async () => sources,
+    },
+    // Other methods on PrismaClient are not exercised by runStaticSchedulePass.
+  } as unknown as Parameters<typeof runStaticSchedulePass>[0];
+}
+
+const FMH3_KENNEL: FakeKennelLink = {
+  kennel: { id: "k_sffmh3", shortName: "SFFMH3", isHidden: false },
+};
+const DCFMH3_KENNEL: FakeKennelLink = {
+  kennel: { id: "k_dcfmh3", shortName: "DCFMH3", isHidden: false },
+};
+
+describe("runStaticSchedulePass — lunar branch", () => {
+  it("emits FREQ=LUNAR sentinel at LOW confidence for exact-mode lunar config", async () => {
+    const planned: Parameters<typeof runStaticSchedulePass>[1] = [];
+    const prisma = fakePrisma([
+      {
+        id: "src1",
+        name: "SFFMH3 Static Schedule (Lunar)",
+        url: "https://www.facebook.com/sffmh",
+        type: "STATIC_SCHEDULE",
+        enabled: true,
+        lastSuccessAt: null,
+        lastScrapeAt: null,
+        config: {
+          kennelTag: "sffmh3",
+          lunar: { phase: "full", timezone: "America/Los_Angeles" },
+        },
+        kennels: [FMH3_KENNEL],
+      },
+    ]);
+    await runStaticSchedulePass(prisma, planned);
+    expect(planned).toHaveLength(1);
+    expect(planned[0]).toMatchObject({
+      kennelId: "k_sffmh3",
+      rrule: "FREQ=LUNAR",
+      confidence: "LOW",
+    });
+    // Notes should mention the phase + timezone for admin context.
+    expect(planned[0].notes).toContain("full");
+    expect(planned[0].notes).toContain("America/Los_Angeles");
+  });
+
+  it("emits FREQ=LUNAR sentinel at LOW confidence for anchor-mode lunar config", async () => {
+    const planned: Parameters<typeof runStaticSchedulePass>[1] = [];
+    const prisma = fakePrisma([
+      {
+        id: "src2",
+        name: "DCFMH3 Static Schedule (Lunar Anchor)",
+        url: "https://sites.google.com/site/dcfmh3/home",
+        type: "STATIC_SCHEDULE",
+        enabled: true,
+        lastSuccessAt: null,
+        lastScrapeAt: null,
+        config: {
+          kennelTag: "dcfmh3",
+          lunar: {
+            phase: "full",
+            timezone: "America/New_York",
+            anchorWeekday: "SA",
+            anchorRule: "nearest",
+          },
+        },
+        kennels: [DCFMH3_KENNEL],
+      },
+    ]);
+    await runStaticSchedulePass(prisma, planned);
+    expect(planned).toHaveLength(1);
+    expect(planned[0]).toMatchObject({
+      kennelId: "k_dcfmh3",
+      rrule: "FREQ=LUNAR",
+      confidence: "LOW",
+    });
+    expect(planned[0].notes).toContain("anchored");
+    expect(planned[0].notes).toContain("SA");
+    expect(planned[0].notes).toContain("nearest");
+  });
+
+  it("skips lunar config with missing or invalid phase", async () => {
+    const planned: Parameters<typeof runStaticSchedulePass>[1] = [];
+    const prisma = fakePrisma([
+      {
+        id: "src3",
+        name: "Bogus Lunar",
+        url: null,
+        type: "STATIC_SCHEDULE",
+        enabled: true,
+        lastSuccessAt: null,
+        lastScrapeAt: null,
+        config: {
+          kennelTag: "bogus",
+          lunar: { phase: "quarter", timezone: "UTC" }, // invalid phase
+        },
+        kennels: [{ kennel: { id: "k_bogus", shortName: "BOGUS", isHidden: false } }],
+      },
+    ]);
+    const result = await runStaticSchedulePass(prisma, planned);
+    expect(planned).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("skips lunar config missing timezone (matches adapter rejection)", async () => {
+    // Codex pass-2 finding: backfill must reject configs the adapter rejects,
+    // otherwise Travel Mode shows possible-activity rules for sources that
+    // produce zero canonical events.
+    const planned: Parameters<typeof runStaticSchedulePass>[1] = [];
+    const prisma = fakePrisma([
+      {
+        id: "src5",
+        name: "Lunar without timezone",
+        url: null,
+        type: "STATIC_SCHEDULE",
+        enabled: true,
+        lastSuccessAt: null,
+        lastScrapeAt: null,
+        config: {
+          kennelTag: "no-tz",
+          lunar: { phase: "full" }, // missing timezone
+        },
+        kennels: [{ kennel: { id: "k_notz", shortName: "NOTZ", isHidden: false } }],
+      },
+    ]);
+    const result = await runStaticSchedulePass(prisma, planned);
+    expect(planned).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("skips lunar config with partial anchor pair (matches adapter rejection)", async () => {
+    const planned: Parameters<typeof runStaticSchedulePass>[1] = [];
+    const prisma = fakePrisma([
+      {
+        id: "src6",
+        name: "Lunar with anchorWeekday but no anchorRule",
+        url: null,
+        type: "STATIC_SCHEDULE",
+        enabled: true,
+        lastSuccessAt: null,
+        lastScrapeAt: null,
+        config: {
+          kennelTag: "partial-anchor",
+          lunar: { phase: "full", timezone: "UTC", anchorWeekday: "SA" },
+        },
+        kennels: [{ kennel: { id: "k_partial", shortName: "PARTIAL", isHidden: false } }],
+      },
+    ]);
+    const result = await runStaticSchedulePass(prisma, planned);
+    expect(planned).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("skips dual-config rows where both rrule and lunar are set (Codex pass-4: XOR enforcement)", async () => {
+    const planned: Parameters<typeof runStaticSchedulePass>[1] = [];
+    const prisma = fakePrisma([
+      {
+        id: "src-dual",
+        name: "Dual-config (XOR violation)",
+        url: null,
+        type: "STATIC_SCHEDULE",
+        enabled: true,
+        lastSuccessAt: null,
+        lastScrapeAt: null,
+        config: {
+          kennelTag: "dual",
+          rrule: "FREQ=WEEKLY;BYDAY=SA",
+          lunar: { phase: "full", timezone: "America/Los_Angeles" },
+        },
+        kennels: [{ kennel: { id: "k_dual", shortName: "DUAL", isHidden: false } }],
+      },
+    ]);
+    const result = await runStaticSchedulePass(prisma, planned);
+    // Adapter rejects dual-config; backfill must too — otherwise Travel Mode
+    // would project a HIGH-confidence rule for a source that never materializes.
+    expect(planned).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("does not regress rrule-mode handling (existing GSH3-shape source still HIGH confidence)", async () => {
+    const planned: Parameters<typeof runStaticSchedulePass>[1] = [];
+    const prisma = fakePrisma([
+      {
+        id: "src4",
+        name: "Grand Strand H3 Static Schedule",
+        url: "https://www.facebook.com/GrandStrandHashing/",
+        type: "STATIC_SCHEDULE",
+        enabled: true,
+        lastSuccessAt: null,
+        lastScrapeAt: null,
+        config: {
+          kennelTag: "gsh3",
+          rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA",
+          anchorDate: "2026-03-07",
+        },
+        kennels: [{ kennel: { id: "k_gsh3", shortName: "GSH3", isHidden: false } }],
+      },
+    ]);
+    await runStaticSchedulePass(prisma, planned);
+    expect(planned).toHaveLength(1);
+    expect(planned[0]).toMatchObject({
+      rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA",
+      anchorDate: "2026-03-07",
+      confidence: "HIGH",
+    });
   });
 });

--- a/scripts/backfill-schedule-rules.ts
+++ b/scripts/backfill-schedule-rules.ts
@@ -453,11 +453,78 @@ function processSourceKennel(
   return true;
 }
 
+/**
+ * Build the `notes` string for a `FREQ=LUNAR` sentinel rule. `lunar` is
+ * pre-validated (`isValidLunarConfig`) so timezone is non-empty here.
+ */
+function buildLunarNotes(lunar: NonNullable<StaticScheduleConfig["lunar"]>): string {
+  const isAnchored = !!(lunar.anchorWeekday && lunar.anchorRule);
+  return isAnchored
+    ? `Lunar ${lunar.phase} moon, anchored to ${lunar.anchorWeekday} (${lunar.anchorRule})`
+    : `Lunar ${lunar.phase} moon, exact phase date in ${lunar.timezone}`;
+}
+
+interface PassResult {
+  count: number;
+  skipped: number;
+}
+
+/** Lunar source branch: validate, emit FREQ=LUNAR sentinel per kennel. */
+function processLunarSource(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  src: any,
+  config: StaticScheduleConfig,
+  planned: PlannedRule[],
+  options: BackfillOptions,
+): PassResult {
+  if (!config.lunar || !isValidLunarConfig(config.lunar)) {
+    if (options.verbose) {
+      console.log(`  ⊘ ${src.name} — lunar config malformed (missing or invalid phase)`);
+    }
+    return { count: 0, skipped: 1 };
+  }
+  const notes = buildLunarNotes(config.lunar);
+  let count = 0;
+  let skipped = 0;
+  for (const { kennel } of src.kennels) {
+    const ok = processSourceKennel(src, kennel, config, "FREQ=LUNAR", planned, options, {
+      confidence: "LOW",
+      notes,
+    });
+    if (ok) count++;
+    else skipped++;
+  }
+  return { count, skipped };
+}
+
+/** RRULE source branch: normalize + emit HIGH-confidence rule per kennel. */
+function processRruleSource(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  src: any,
+  config: StaticScheduleConfig,
+  rawRrule: string,
+  planned: PlannedRule[],
+  options: BackfillOptions,
+): PassResult {
+  const rrule = normalizeRRule(rawRrule);
+  if (options.verbose && rrule !== rawRrule) {
+    console.log(`  ↻ ${src.name} — normalized ${rawRrule} → ${rrule}`);
+  }
+  let count = 0;
+  let skipped = 0;
+  for (const { kennel } of src.kennels) {
+    const ok = processSourceKennel(src, kennel, config, rrule, planned, options);
+    if (ok) count++;
+    else skipped++;
+  }
+  return { count, skipped };
+}
+
 export async function runStaticSchedulePass(
   prisma: PrismaClientLike,
   planned: PlannedRule[],
   options: BackfillOptions = {},
-): Promise<{ count: number; skipped: number }> {
+): Promise<PassResult> {
   console.log("━━━ Pass 1: STATIC_SCHEDULE sources → HIGH confidence ━━━");
 
   const staticSources = await prisma.source.findMany({
@@ -477,63 +544,26 @@ export async function runStaticSchedulePass(
     const config = (src.config ?? {}) as StaticScheduleConfig;
     const rawRrule = config.rrule?.trim();
 
-    // XOR enforcement matching `validateRruleLunarXor` in the adapter (Codex
-    // pass-4 finding). Dual-config rows previously took the rrule branch
-    // silently — projecting HIGH-confidence rules for sources whose canonical
-    // event generation would later reject the same shape.
+    // XOR enforcement matching `validateRruleLunarXor` in the adapter — dual-
+    // config rows are skipped to avoid projecting HIGH-confidence rules for
+    // sources whose canonical event generation would later reject the shape.
     if (rawRrule && config.lunar) {
       skipped++;
-      if (options.verbose) {
-        console.log(`  ⊘ ${src.name} — XOR violation: both rrule and lunar set`);
-      }
+      if (options.verbose) console.log(`  ⊘ ${src.name} — XOR violation: both rrule and lunar set`);
       continue;
     }
 
-    // Lunar branch — emits the `FREQ=LUNAR` sentinel at LOW confidence so
-    // Travel Mode surfaces the kennel as "possible activity" beyond the
-    // materialized event horizon. LOW for both exact and anchor modes:
-    // the projection engine cannot reproduce astronomical phase math.
-    if (!rawRrule && config.lunar) {
-      if (!isValidLunarConfig(config.lunar)) {
-        skipped++;
-        if (options.verbose) {
-          console.log(`  ⊘ ${src.name} — lunar config malformed (missing or invalid phase)`);
-        }
-        continue;
-      }
-      const isAnchored = !!(config.lunar.anchorWeekday && config.lunar.anchorRule);
-      const notes = isAnchored
-        ? `Lunar ${config.lunar.phase} moon, anchored to ${config.lunar.anchorWeekday} (${config.lunar.anchorRule})`
-        : `Lunar ${config.lunar.phase} moon, exact phase date in ${config.lunar.timezone ?? "(timezone unknown)"}`;
-      for (const { kennel } of src.kennels) {
-        if (processSourceKennel(src, kennel, config, "FREQ=LUNAR", planned, options, {
-          confidence: "LOW",
-          notes,
-        })) {
-          count++;
-        } else {
-          skipped++;
-        }
-      }
-      continue;
-    }
-
-    if (!rawRrule) {
-      skipped++;
+    let result: PassResult;
+    if (config.lunar) {
+      result = processLunarSource(src, config, planned, options);
+    } else if (rawRrule) {
+      result = processRruleSource(src, config, rawRrule, planned, options);
+    } else {
       if (options.verbose) console.log(`  ⊘ ${src.name} — missing rrule in config`);
-      continue;
+      result = { count: 0, skipped: 1 };
     }
-    const rrule = normalizeRRule(rawRrule);
-    if (options.verbose && rrule !== rawRrule) {
-      console.log(`  ↻ ${src.name} — normalized ${rawRrule} → ${rrule}`);
-    }
-    for (const { kennel } of src.kennels) {
-      if (processSourceKennel(src, kennel, config, rrule, planned, options)) {
-        count++;
-      } else {
-        skipped++;
-      }
-    }
+    count += result.count;
+    skipped += result.skipped;
   }
   console.log(`  ✓ ${count} rules planned (${skipped} sources skipped)\n`);
   return { count, skipped };

--- a/scripts/backfill-schedule-rules.ts
+++ b/scripts/backfill-schedule-rules.ts
@@ -50,6 +50,8 @@ import {
   ScheduleRuleSource,
 } from "@/generated/prisma/client";
 import { createScriptPool } from "./lib/db-pool";
+import { ANCHOR_WEEKDAYS, ANCHOR_RULES } from "@/adapters/static-schedule/lunar";
+import { isValidTimezone } from "@/lib/timezone";
 
 interface BackfillOptions {
   verbose?: boolean;
@@ -357,7 +359,48 @@ type StaticScheduleConfig = {
   anchorDate?: string;
   startTime?: string;
   kennelTag?: string;
+  /** Lunar mode (XOR with rrule). See src/adapters/static-schedule/lunar.ts. */
+  lunar?: {
+    phase?: "full" | "new";
+    timezone?: string;
+    anchorWeekday?: "SU" | "MO" | "TU" | "WE" | "TH" | "FR" | "SA";
+    anchorRule?: "nearest" | "on-or-after" | "on-or-before";
+  };
 };
+
+/**
+ * Validate the lunar block matches the adapter's contract — phase, timezone,
+ * and the anchorWeekday/anchorRule XOR pair. MUST stay in sync with
+ * `validateRruleLunarXor` in `src/adapters/static-schedule/adapter.ts`: if
+ * backfill is more permissive than the adapter, Travel Mode would surface a
+ * `FREQ=LUNAR` "possible activity" rule for a source that produces zero
+ * canonical events, masking the misconfiguration behind a synthetic schedule.
+ *
+ * Phase + anchor metadata is carried in the rule's `notes` (admin-visible)
+ * rather than the rrule string: `src/lib/travel/projections.ts` matches the
+ * sentinel via exact equality (`rrule === "FREQ=LUNAR"`), so extending the
+ * rrule with `;PHASE=…` segments would silently bypass the existing match.
+ */
+function isValidLunarConfig(lunar: NonNullable<StaticScheduleConfig["lunar"]>): boolean {
+  if (lunar.phase !== "full" && lunar.phase !== "new") return false;
+  if (typeof lunar.timezone !== "string" || !isValidTimezone(lunar.timezone)) return false;
+  const hasWeekday = lunar.anchorWeekday !== undefined && lunar.anchorWeekday !== null;
+  const hasRule = lunar.anchorRule !== undefined && lunar.anchorRule !== null;
+  if (hasWeekday !== hasRule) return false;
+  if (
+    hasWeekday &&
+    !ANCHOR_WEEKDAYS.includes(lunar.anchorWeekday as (typeof ANCHOR_WEEKDAYS)[number])
+  ) {
+    return false;
+  }
+  if (
+    hasRule &&
+    !ANCHOR_RULES.includes(lunar.anchorRule as (typeof ANCHOR_RULES)[number])
+  ) {
+    return false;
+  }
+  return true;
+}
 
 /**
  * Pass 1 of the backfill: collect HIGH-confidence rules from STATIC_SCHEDULE
@@ -389,6 +432,7 @@ function processSourceKennel(
   rrule: string,
   planned: PlannedRule[],
   options: BackfillOptions,
+  overrides?: { confidence?: ScheduleConfidence; notes?: string | null },
 ): boolean {
   if (kennel.isHidden) {
     if (options.verbose) console.log(`  ⊘ ${src.name} → ${kennel.shortName} — hidden kennel, skipping`);
@@ -400,11 +444,11 @@ function processSourceKennel(
     rrule,
     anchorDate: config.anchorDate?.trim() || null,
     startTime: config.startTime?.trim() || null,
-    confidence: "HIGH",
+    confidence: overrides?.confidence ?? "HIGH",
     source: "STATIC_SCHEDULE",
     sourceReference: src.url || src.name,
     lastValidatedAt: src.lastSuccessAt ?? src.lastScrapeAt ?? null,
-    notes: null,
+    notes: overrides?.notes ?? null,
   });
   return true;
 }
@@ -432,6 +476,48 @@ export async function runStaticSchedulePass(
   for (const src of staticSources) {
     const config = (src.config ?? {}) as StaticScheduleConfig;
     const rawRrule = config.rrule?.trim();
+
+    // XOR enforcement matching `validateRruleLunarXor` in the adapter (Codex
+    // pass-4 finding). Dual-config rows previously took the rrule branch
+    // silently — projecting HIGH-confidence rules for sources whose canonical
+    // event generation would later reject the same shape.
+    if (rawRrule && config.lunar) {
+      skipped++;
+      if (options.verbose) {
+        console.log(`  ⊘ ${src.name} — XOR violation: both rrule and lunar set`);
+      }
+      continue;
+    }
+
+    // Lunar branch — emits the `FREQ=LUNAR` sentinel at LOW confidence so
+    // Travel Mode surfaces the kennel as "possible activity" beyond the
+    // materialized event horizon. LOW for both exact and anchor modes:
+    // the projection engine cannot reproduce astronomical phase math.
+    if (!rawRrule && config.lunar) {
+      if (!isValidLunarConfig(config.lunar)) {
+        skipped++;
+        if (options.verbose) {
+          console.log(`  ⊘ ${src.name} — lunar config malformed (missing or invalid phase)`);
+        }
+        continue;
+      }
+      const isAnchored = !!(config.lunar.anchorWeekday && config.lunar.anchorRule);
+      const notes = isAnchored
+        ? `Lunar ${config.lunar.phase} moon, anchored to ${config.lunar.anchorWeekday} (${config.lunar.anchorRule})`
+        : `Lunar ${config.lunar.phase} moon, exact phase date in ${config.lunar.timezone ?? "(timezone unknown)"}`;
+      for (const { kennel } of src.kennels) {
+        if (processSourceKennel(src, kennel, config, "FREQ=LUNAR", planned, options, {
+          confidence: "LOW",
+          notes,
+        })) {
+          count++;
+        } else {
+          skipped++;
+        }
+      }
+      continue;
+    }
+
     if (!rawRrule) {
       skipped++;
       if (options.verbose) console.log(`  ⊘ ${src.name} — missing rrule in config`);

--- a/src/adapters/static-schedule/adapter.test.ts
+++ b/src/adapters/static-schedule/adapter.test.ts
@@ -603,3 +603,163 @@ describe("StaticScheduleAdapter titleTemplate", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Lunar mode (XOR with rrule)
+// ---------------------------------------------------------------------------
+
+describe("StaticScheduleAdapter lunar mode", () => {
+  const adapter = new StaticScheduleAdapter();
+
+  it("rejects config with neither rrule nor lunar", async () => {
+    const source = makeSource({ kennelTag: "FMH3" });
+    const result = await adapter.fetch(source);
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toMatch(/rrule.*lunar|lunar.*rrule/);
+  });
+
+  it("rejects config with both rrule and lunar (XOR)", async () => {
+    const source = makeSource({
+      kennelTag: "FMH3",
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      lunar: { phase: "full", timezone: "America/Los_Angeles" },
+    });
+    const result = await adapter.fetch(source);
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toMatch(/cannot specify both/i);
+  });
+
+  it("rejects lunar without timezone", async () => {
+    const source = makeSource({
+      kennelTag: "FMH3",
+      lunar: { phase: "full" },
+    });
+    const result = await adapter.fetch(source);
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toContain("timezone");
+  });
+
+  it("rejects lunar with invalid phase", async () => {
+    const source = makeSource({
+      kennelTag: "FMH3",
+      lunar: { phase: "quarter", timezone: "UTC" },
+    });
+    const result = await adapter.fetch(source);
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toContain("phase");
+  });
+
+  it("rejects anchorWeekday without anchorRule (and vice versa)", async () => {
+    const a = await adapter.fetch(makeSource({
+      kennelTag: "FMH3",
+      lunar: { phase: "full", timezone: "UTC", anchorWeekday: "SA" },
+    }));
+    expect(a.errors[0]).toMatch(/anchor/);
+    const b = await adapter.fetch(makeSource({
+      kennelTag: "FMH3",
+      lunar: { phase: "full", timezone: "UTC", anchorRule: "nearest" },
+    }));
+    expect(b.errors[0]).toMatch(/anchor/);
+  });
+
+  it("rejects an invalid IANA timezone (Codex pass-3: typos must not silently fall back to UTC)", async () => {
+    const result = await adapter.fetch(makeSource({
+      kennelTag: "FMH3",
+      lunar: { phase: "full", timezone: "America/Los_Angles" }, // typo
+    }));
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toMatch(/not a recognized IANA timezone/);
+  });
+
+  it("rejects an invalid anchorWeekday value (Codex pass-3: enum check needed)", async () => {
+    const result = await adapter.fetch(makeSource({
+      kennelTag: "FMH3",
+      lunar: {
+        phase: "full",
+        timezone: "America/Los_Angeles",
+        anchorWeekday: "BOGUS",
+        anchorRule: "nearest",
+      },
+    }));
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toMatch(/anchorWeekday/);
+  });
+
+  it("rejects an invalid anchorRule value (Codex pass-3: enum check needed)", async () => {
+    const result = await adapter.fetch(makeSource({
+      kennelTag: "FMH3",
+      lunar: {
+        phase: "full",
+        timezone: "America/Los_Angeles",
+        anchorWeekday: "SA",
+        anchorRule: "whenever",
+      },
+    }));
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toMatch(/anchorRule/);
+  });
+
+  it("generates lunar full-moon events for an FMH3 SF style config", async () => {
+    const source = makeSource({
+      kennelTag: "fmh3-sf",
+      lunar: { phase: "full", timezone: "America/Los_Angeles" },
+      defaultTitle: "FMH3 SF Full Moon Run",
+      defaultLocation: "San Francisco",
+    });
+    // ±365 day window centered on now → expect ~25 full moons (one per ~29.5 days).
+    const result = await adapter.fetch(source, { days: 365 });
+    expect(result.errors).toEqual([]);
+    expect(result.events.length).toBeGreaterThanOrEqual(20);
+    expect(result.events.length).toBeLessThanOrEqual(28);
+    expect(result.events[0].kennelTags).toEqual(["fmh3-sf"]);
+    expect(result.events[0].title).toBe("FMH3 SF Full Moon Run");
+    expect(result.events[0].location).toBe("San Francisco");
+    // diagnosticContext should reflect lunar mode, not rrule.
+    expect(result.diagnosticContext?.mode).toBe("lunar");
+    expect(result.diagnosticContext?.phase).toBe("full");
+  });
+
+  it("generates anchor-mode events for a DCFMH3 style config (Saturday near full moon)", async () => {
+    const source = makeSource({
+      kennelTag: "dcfmh3",
+      lunar: {
+        phase: "full",
+        timezone: "America/New_York",
+        anchorWeekday: "SA",
+        anchorRule: "nearest",
+      },
+      defaultTitle: "DCFMH3 Full Moon Hash",
+    });
+    const result = await adapter.fetch(source, { days: 90 });
+    expect(result.errors).toEqual([]);
+    expect(result.events.length).toBeGreaterThanOrEqual(2);
+    // Every event should land on a Saturday (UTC-day 6, since dates are stored UTC noon).
+    for (const event of result.events) {
+      const d = new Date(event.date + "T12:00:00Z");
+      expect(d.getUTCDay()).toBe(6);
+    }
+  });
+
+  it("respects options.days for lunar mode (smaller window → fewer events)", async () => {
+    const source = makeSource({
+      kennelTag: "fmh3-sf",
+      lunar: { phase: "full", timezone: "America/Los_Angeles" },
+    });
+    const small = await adapter.fetch(source, { days: 30 });
+    const large = await adapter.fetch(source, { days: 365 });
+    // 30-day window: 1 or 2 full moons; 365-day window: ~25.
+    expect(small.events.length).toBeLessThanOrEqual(3);
+    expect(large.events.length).toBeGreaterThan(small.events.length);
+  });
+
+  it("emits dates as YYYY-MM-DD UTC-noon strings (matches RRULE-mode convention)", async () => {
+    const source = makeSource({
+      kennelTag: "fmh3-sf",
+      lunar: { phase: "full", timezone: "America/Los_Angeles" },
+    });
+    const result = await adapter.fetch(source, { days: 365 });
+    for (const event of result.events) {
+      expect(event.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+});

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -9,11 +9,28 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
 import { validateSourceConfig, WEEKDAY_NAMES } from "../utils";
+import {
+  generateLunarOccurrences,
+  ANCHOR_WEEKDAYS,
+  ANCHOR_RULES,
+  type LunarConfig,
+} from "./lunar";
+import { isValidTimezone } from "@/lib/timezone";
 
-/** Configuration shape for a STATIC_SCHEDULE source. */
+/**
+ * Configuration shape for a STATIC_SCHEDULE source.
+ *
+ * Exactly one of `rrule` OR `lunar` must be set — the adapter and the admin
+ * `validateStaticScheduleConfig` validator both enforce this XOR. RRULE-mode
+ * generates calendar-rule occurrences (FREQ=WEEKLY|MONTHLY etc.). Lunar-mode
+ * generates occurrences anchored to astronomical full or new moons in the
+ * kennel's timezone, with optional snap-to-weekday for kennels that run
+ * "Friday/Saturday near full moon" rather than on the exact phase day.
+ */
 export interface StaticScheduleConfig {
   kennelTag: string;           // Kennel shortName for all generated events (e.g. "Rumson")
-  rrule: string;               // RRULE string, e.g. "FREQ=WEEKLY;BYDAY=SA"
+  rrule?: string;              // RRULE string, e.g. "FREQ=WEEKLY;BYDAY=SA". XOR with `lunar`.
+  lunar?: LunarConfig;         // Lunar-phase recurrence config. XOR with `rrule`.
   anchorDate?: string;         // YYYY-MM-DD — a known past occurrence, stabilizes INTERVAL > 1
   startTime?: string;          // "HH:MM" 24-hour format (e.g. "10:17", "19:00")
   defaultTitle?: string;       // e.g. "Rumson H3 Weekly Run"
@@ -441,11 +458,20 @@ export class StaticScheduleAdapter implements SourceAdapter {
       config = validateSourceConfig<StaticScheduleConfig>(
         source.config,
         "StaticScheduleAdapter",
-        { kennelTag: "string", rrule: "string" },
+        { kennelTag: "string" },
       );
     } catch (err) {
       const message = err instanceof Error ? err.message : "Invalid source config";
       return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
+    }
+
+    const validated = validateRruleLunarXor(config);
+    if (!validated.ok) {
+      return {
+        events: [],
+        errors: [validated.error],
+        errorDetails: { fetch: [{ message: validated.error }] },
+      };
     }
 
     const days = options?.days ?? 90;
@@ -454,38 +480,60 @@ export class StaticScheduleAdapter implements SourceAdapter {
     const windowStart = new Date(todayNoon - days * 86_400_000);
     const windowEnd = new Date(todayNoon + days * 86_400_000);
 
-    let rule: ReturnType<typeof parseRRule>;
-    try {
-      rule = parseRRule(config.rrule);
-    } catch (err) {
-      const message = `Invalid RRULE "${config.rrule}": ${err instanceof Error ? err.message : String(err)}`;
-      return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
-    }
-
-    const occurrences = generateOccurrences(rule, windowStart, windowEnd, config.anchorDate);
-
-    if (occurrences.length === 0) {
-      // Off-season for a seasonal rule is expected, not a misconfiguration.
-      // Only alert when the window actually overlaps an active month.
-      const seasonalOffSeason =
-        rule.byMonth !== undefined && rule.byMonth.length > 0 &&
-        !windowOverlapsAnyMonth(windowStart, windowEnd, rule.byMonth);
-      if (seasonalOffSeason) {
-        return {
-          events: [],
-          errors: [],
-          diagnosticContext: {
-            rrule: config.rrule,
-            occurrencesGenerated: 0,
-            windowDays: days,
-            windowStart: windowStart.toISOString(),
-            windowEnd: windowEnd.toISOString(),
-            note: "off-season: window does not overlap any BYMONTH month",
-          },
-        };
+    let occurrences: string[];
+    let diagnosticRule: DiagnosticRule;
+    if (validated.kind === "lunar") {
+      const lunar = validated.lunar;
+      occurrences = generateLunarOccurrences(lunar, windowStart, windowEnd);
+      diagnosticRule = {
+        mode: "lunar",
+        phase: lunar.phase,
+        timezone: lunar.timezone,
+        anchorWeekday: lunar.anchorWeekday ?? null,
+        anchorRule: lunar.anchorRule ?? null,
+      };
+      if (occurrences.length === 0) {
+        // Lunar has no "season" — every month has a full+new moon. Empty here
+        // means the window is degenerate or the timezone is invalid.
+        const message = `Lunar config (${lunar.phase}) generated 0 events in ${days}-day window — check timezone and window`;
+        return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
       }
-      const message = `RRULE "${config.rrule}" generated 0 events in ${days}-day window — check schedule configuration`;
-      return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
+    } else {
+      const rruleStr = validated.rrule;
+      let rule: ReturnType<typeof parseRRule>;
+      try {
+        rule = parseRRule(rruleStr);
+      } catch (err) {
+        const message = `Invalid RRULE "${rruleStr}": ${err instanceof Error ? err.message : String(err)}`;
+        return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
+      }
+
+      occurrences = generateOccurrences(rule, windowStart, windowEnd, config.anchorDate);
+      diagnosticRule = { mode: "rrule", rrule: rruleStr };
+
+      if (occurrences.length === 0) {
+        // Off-season for a seasonal rule is expected, not a misconfiguration.
+        // Only alert when the window actually overlaps an active month.
+        const seasonalOffSeason =
+          rule.byMonth !== undefined && rule.byMonth.length > 0 &&
+          !windowOverlapsAnyMonth(windowStart, windowEnd, rule.byMonth);
+        if (seasonalOffSeason) {
+          return {
+            events: [],
+            errors: [],
+            diagnosticContext: {
+              ...diagnosticRule,
+              occurrencesGenerated: 0,
+              windowDays: days,
+              windowStart: windowStart.toISOString(),
+              windowEnd: windowEnd.toISOString(),
+              note: "off-season: window does not overlap any BYMONTH month",
+            },
+          };
+        }
+        const message = `RRULE "${rruleStr}" generated 0 events in ${days}-day window — check schedule configuration`;
+        return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
+      }
     }
 
     const startTime = config.startTime
@@ -515,7 +563,7 @@ export class StaticScheduleAdapter implements SourceAdapter {
       events,
       errors: [],
       diagnosticContext: {
-        rrule: config.rrule,
+        ...diagnosticRule,
         occurrencesGenerated: events.length,
         windowDays: days,
         windowStart: windowStart.toISOString(),
@@ -523,4 +571,83 @@ export class StaticScheduleAdapter implements SourceAdapter {
       },
     };
   }
+}
+
+/** Diagnostic-context shape per branch — surfaces in scrape logs and self-healing alerts. */
+type DiagnosticRule =
+  | { mode: "lunar"; phase: LunarConfig["phase"]; timezone: string; anchorWeekday: LunarConfig["anchorWeekday"] | null; anchorRule: LunarConfig["anchorRule"] | null }
+  | { mode: "rrule"; rrule: string };
+
+type ValidatedSchedule =
+  | { ok: true; kind: "rrule"; rrule: string }
+  | { ok: true; kind: "lunar"; lunar: LunarConfig }
+  | { ok: false; error: string };
+
+/**
+ * Enforce that exactly one of rrule | lunar is set, and that the chosen branch
+ * has its required fields. The discriminated return lets the caller branch
+ * on `kind` without non-null assertions on the original config. Mirrored by
+ * `validateStaticScheduleConfig` in the admin wizard so the same rule applies
+ * in both cron and admin contexts.
+ */
+function validateRruleLunarXor(config: StaticScheduleConfig): ValidatedSchedule {
+  const rrule = typeof config.rrule === "string" ? config.rrule.trim() : "";
+  const hasRrule = rrule.length > 0;
+  const hasLunar = config.lunar !== undefined && config.lunar !== null;
+  if (!hasRrule && !hasLunar) {
+    return { ok: false, error: "StaticScheduleAdapter: config must specify either rrule or lunar" };
+  }
+  if (hasRrule && hasLunar) {
+    return { ok: false, error: "StaticScheduleAdapter: config cannot specify both rrule and lunar (XOR)" };
+  }
+  if (hasRrule) {
+    return { ok: true, kind: "rrule", rrule };
+  }
+  const lunar = config.lunar as LunarConfig;
+  if (lunar.phase !== "full" && lunar.phase !== "new") {
+    return {
+      ok: false,
+      error: `StaticScheduleAdapter: lunar.phase must be "full" or "new", got ${JSON.stringify(lunar.phase)}`,
+    };
+  }
+  if (typeof lunar.timezone !== "string" || lunar.timezone.trim().length === 0) {
+    return {
+      ok: false,
+      error: 'StaticScheduleAdapter: lunar.timezone is required (IANA timezone string, e.g. "America/Los_Angeles")',
+    };
+  }
+  // Codex pass-3 finding: a typo like "America/Los_Angles" was previously
+  // accepted, then silently remapped to UTC by the formatter — generating
+  // events on the wrong calendar day. Reject invalid IANA zones up front.
+  if (!isValidTimezone(lunar.timezone)) {
+    return {
+      ok: false,
+      error: `StaticScheduleAdapter: lunar.timezone "${lunar.timezone}" is not a recognized IANA timezone`,
+    };
+  }
+  const hasWeekday = lunar.anchorWeekday !== undefined && lunar.anchorWeekday !== null;
+  const hasRule = lunar.anchorRule !== undefined && lunar.anchorRule !== null;
+  if (hasWeekday !== hasRule) {
+    return {
+      ok: false,
+      error: "StaticScheduleAdapter: lunar.anchorWeekday and lunar.anchorRule must be set together (or both omitted)",
+    };
+  }
+  // Codex pass-3 finding: persisted JSON can carry arbitrary strings here;
+  // without an enum check, snapToAnchorWeekday reads `WEEKDAY_NAMES[bogus]`
+  // as undefined and produces NaN dates that crash `toIsoDateString`. Fail
+  // closed before generation.
+  if (hasWeekday && !ANCHOR_WEEKDAYS.includes(lunar.anchorWeekday as (typeof ANCHOR_WEEKDAYS)[number])) {
+    return {
+      ok: false,
+      error: `StaticScheduleAdapter: lunar.anchorWeekday "${lunar.anchorWeekday}" must be one of ${ANCHOR_WEEKDAYS.join(", ")}`,
+    };
+  }
+  if (hasRule && !ANCHOR_RULES.includes(lunar.anchorRule as (typeof ANCHOR_RULES)[number])) {
+    return {
+      ok: false,
+      error: `StaticScheduleAdapter: lunar.anchorRule "${lunar.anchorRule}" must be one of ${ANCHOR_RULES.join(", ")}`,
+    };
+  }
+  return { ok: true, kind: "lunar", lunar };
 }

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -453,92 +453,34 @@ export class StaticScheduleAdapter implements SourceAdapter {
     source: Source,
     options?: { days?: number },
   ): Promise<ScrapeResult> {
-    let config: StaticScheduleConfig;
-    try {
-      config = validateSourceConfig<StaticScheduleConfig>(
-        source.config,
-        "StaticScheduleAdapter",
-        { kennelTag: "string" },
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Invalid source config";
-      return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
-    }
+    const configResult = parseAdapterConfig(source);
+    if (!configResult.ok) return errorResult(configResult.error);
 
-    const validated = validateRruleLunarXor(config);
-    if (!validated.ok) {
+    const { config, validated } = configResult;
+    const window = computeScrapeWindow(options?.days ?? 90);
+
+    const occurrencesResult =
+      validated.kind === "lunar"
+        ? computeLunarOccurrences(validated.lunar, window)
+        : computeRruleOccurrences(validated.rrule, config.anchorDate, window);
+    if (occurrencesResult.kind === "error") return errorResult(occurrencesResult.message);
+    if (occurrencesResult.kind === "off-season") {
       return {
         events: [],
-        errors: [validated.error],
-        errorDetails: { fetch: [{ message: validated.error }] },
+        errors: [],
+        diagnosticContext: {
+          ...occurrencesResult.diagnostic,
+          occurrencesGenerated: 0,
+          windowDays: window.days,
+          windowStart: window.start.toISOString(),
+          windowEnd: window.end.toISOString(),
+          note: "off-season: window does not overlap any BYMONTH month",
+        },
       };
     }
 
-    const days = options?.days ?? 90;
-    const now = new Date();
-    const todayNoon = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0);
-    const windowStart = new Date(todayNoon - days * 86_400_000);
-    const windowEnd = new Date(todayNoon + days * 86_400_000);
-
-    let occurrences: string[];
-    let diagnosticRule: DiagnosticRule;
-    if (validated.kind === "lunar") {
-      const lunar = validated.lunar;
-      occurrences = generateLunarOccurrences(lunar, windowStart, windowEnd);
-      diagnosticRule = {
-        mode: "lunar",
-        phase: lunar.phase,
-        timezone: lunar.timezone,
-        anchorWeekday: lunar.anchorWeekday ?? null,
-        anchorRule: lunar.anchorRule ?? null,
-      };
-      if (occurrences.length === 0) {
-        // Lunar has no "season" — every month has a full+new moon. Empty here
-        // means the window is degenerate or the timezone is invalid.
-        const message = `Lunar config (${lunar.phase}) generated 0 events in ${days}-day window — check timezone and window`;
-        return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
-      }
-    } else {
-      const rruleStr = validated.rrule;
-      let rule: ReturnType<typeof parseRRule>;
-      try {
-        rule = parseRRule(rruleStr);
-      } catch (err) {
-        const message = `Invalid RRULE "${rruleStr}": ${err instanceof Error ? err.message : String(err)}`;
-        return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
-      }
-
-      occurrences = generateOccurrences(rule, windowStart, windowEnd, config.anchorDate);
-      diagnosticRule = { mode: "rrule", rrule: rruleStr };
-
-      if (occurrences.length === 0) {
-        // Off-season for a seasonal rule is expected, not a misconfiguration.
-        // Only alert when the window actually overlaps an active month.
-        const seasonalOffSeason =
-          rule.byMonth !== undefined && rule.byMonth.length > 0 &&
-          !windowOverlapsAnyMonth(windowStart, windowEnd, rule.byMonth);
-        if (seasonalOffSeason) {
-          return {
-            events: [],
-            errors: [],
-            diagnosticContext: {
-              ...diagnosticRule,
-              occurrencesGenerated: 0,
-              windowDays: days,
-              windowStart: windowStart.toISOString(),
-              windowEnd: windowEnd.toISOString(),
-              note: "off-season: window does not overlap any BYMONTH month",
-            },
-          };
-        }
-        const message = `RRULE "${rruleStr}" generated 0 events in ${days}-day window — check schedule configuration`;
-        return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
-      }
-    }
-
-    const startTime = config.startTime
-      ? normalizeTime(config.startTime)
-      : undefined;
+    const { occurrences, diagnostic } = occurrencesResult;
+    const startTime = config.startTime ? normalizeTime(config.startTime) : undefined;
 
     // titleTemplate is opt-in; we accept only strings here so a malformed admin
     // payload (e.g. `titleTemplate: []`) fails closed to defaultTitle instead of
@@ -563,14 +505,115 @@ export class StaticScheduleAdapter implements SourceAdapter {
       events,
       errors: [],
       diagnosticContext: {
-        ...diagnosticRule,
+        ...diagnostic,
         occurrencesGenerated: events.length,
-        windowDays: days,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
+        windowDays: window.days,
+        windowStart: window.start.toISOString(),
+        windowEnd: window.end.toISOString(),
       },
     };
   }
+}
+
+/** Helper: package a fetch error as the standard `ScrapeResult` shape. */
+function errorResult(message: string): ScrapeResult {
+  return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
+}
+
+interface ScrapeWindow {
+  start: Date;
+  end: Date;
+  days: number;
+}
+
+/** Compute the symmetric ±days window centered on UTC noon today. */
+function computeScrapeWindow(days: number): ScrapeWindow {
+  const now = new Date();
+  const todayNoon = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0);
+  return {
+    start: new Date(todayNoon - days * 86_400_000),
+    end: new Date(todayNoon + days * 86_400_000),
+    days,
+  };
+}
+
+type ConfigParseResult =
+  | { ok: true; config: StaticScheduleConfig; validated: Extract<ValidatedSchedule, { ok: true }> }
+  | { ok: false; error: string };
+
+/** Validate source.config shape + XOR contract. Pulls the success/error
+ *  branching out of fetch() so the main flow stays linear. */
+function parseAdapterConfig(source: Source): ConfigParseResult {
+  let config: StaticScheduleConfig;
+  try {
+    config = validateSourceConfig<StaticScheduleConfig>(
+      source.config,
+      "StaticScheduleAdapter",
+      { kennelTag: "string" },
+    );
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Invalid source config" };
+  }
+  const validated = validateRruleLunarXor(config);
+  if (!validated.ok) return { ok: false, error: validated.error };
+  return { ok: true, config, validated };
+}
+
+type OccurrencesResult =
+  | { kind: "ok"; occurrences: string[]; diagnostic: DiagnosticRule }
+  | { kind: "off-season"; diagnostic: DiagnosticRule }
+  | { kind: "error"; message: string };
+
+/** Lunar branch: generate occurrences and the lunar diagnostic shape. */
+function computeLunarOccurrences(
+  lunar: LunarConfig,
+  window: ScrapeWindow,
+): OccurrencesResult {
+  const occurrences = generateLunarOccurrences(lunar, window.start, window.end);
+  const diagnostic: DiagnosticRule = {
+    mode: "lunar",
+    phase: lunar.phase,
+    timezone: lunar.timezone,
+    anchorWeekday: lunar.anchorWeekday ?? null,
+    anchorRule: lunar.anchorRule ?? null,
+  };
+  if (occurrences.length === 0) {
+    return {
+      kind: "error",
+      message: `Lunar config (${lunar.phase}) generated 0 events in ${window.days}-day window — check timezone and window`,
+    };
+  }
+  return { kind: "ok", occurrences, diagnostic };
+}
+
+/** RRULE branch: parse + generate + classify zero-output as off-season vs misconfiguration. */
+function computeRruleOccurrences(
+  rruleStr: string,
+  anchorDate: string | undefined,
+  window: ScrapeWindow,
+): OccurrencesResult {
+  let rule: ReturnType<typeof parseRRule>;
+  try {
+    rule = parseRRule(rruleStr);
+  } catch (err) {
+    return {
+      kind: "error",
+      message: `Invalid RRULE "${rruleStr}": ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  const occurrences = generateOccurrences(rule, window.start, window.end, anchorDate);
+  const diagnostic: DiagnosticRule = { mode: "rrule", rrule: rruleStr };
+  if (occurrences.length > 0) return { kind: "ok", occurrences, diagnostic };
+
+  // Off-season for a seasonal rule is expected, not a misconfiguration.
+  const seasonalOffSeason =
+    rule.byMonth !== undefined && rule.byMonth.length > 0 &&
+    !windowOverlapsAnyMonth(window.start, window.end, rule.byMonth);
+  if (seasonalOffSeason) return { kind: "off-season", diagnostic };
+  return {
+    kind: "error",
+    message: `RRULE "${rruleStr}" generated 0 events in ${window.days}-day window — check schedule configuration`,
+  };
 }
 
 /** Diagnostic-context shape per branch — surfaces in scrape logs and self-healing alerts. */
@@ -582,6 +625,41 @@ type ValidatedSchedule =
   | { ok: true; kind: "rrule"; rrule: string }
   | { ok: true; kind: "lunar"; lunar: LunarConfig }
   | { ok: false; error: string };
+
+/**
+ * Lunar-specific validation. Extracted from `validateRruleLunarXor` so each
+ * function stays under SonarCloud's cognitive-complexity cap. Mirrors the
+ * admin-side `validateLunarConfig` in `config-validation.ts`. Returns the
+ * first error encountered, or `null` for a valid block.
+ */
+function validateLunarBlock(lunar: LunarConfig): string | null {
+  if (lunar.phase !== "full" && lunar.phase !== "new") {
+    return `lunar.phase must be "full" or "new", got ${JSON.stringify(lunar.phase)}`;
+  }
+  if (typeof lunar.timezone !== "string" || lunar.timezone.trim().length === 0) {
+    return 'lunar.timezone is required (IANA timezone string, e.g. "America/Los_Angeles")';
+  }
+  // Codex pass-3: invalid IANA tz was silently remapped to UTC by the formatter,
+  // generating events on the wrong calendar day. Reject up front.
+  if (!isValidTimezone(lunar.timezone)) {
+    return `lunar.timezone "${lunar.timezone}" is not a recognized IANA timezone`;
+  }
+  const hasWeekday = lunar.anchorWeekday !== undefined && lunar.anchorWeekday !== null;
+  const hasRule = lunar.anchorRule !== undefined && lunar.anchorRule !== null;
+  if (hasWeekday !== hasRule) {
+    return "lunar.anchorWeekday and lunar.anchorRule must be set together (or both omitted)";
+  }
+  // Codex pass-3: persisted JSON can carry arbitrary strings; without enum
+  // check, snapToAnchorWeekday reads WEEKDAY_NAMES[bogus] as undefined and
+  // produces NaN dates that crash toIsoDateString.
+  if (hasWeekday && !ANCHOR_WEEKDAYS.includes(lunar.anchorWeekday as (typeof ANCHOR_WEEKDAYS)[number])) {
+    return `lunar.anchorWeekday "${lunar.anchorWeekday}" must be one of ${ANCHOR_WEEKDAYS.join(", ")}`;
+  }
+  if (hasRule && !ANCHOR_RULES.includes(lunar.anchorRule as (typeof ANCHOR_RULES)[number])) {
+    return `lunar.anchorRule "${lunar.anchorRule}" must be one of ${ANCHOR_RULES.join(", ")}`;
+  }
+  return null;
+}
 
 /**
  * Enforce that exactly one of rrule | lunar is set, and that the chosen branch
@@ -600,54 +678,9 @@ function validateRruleLunarXor(config: StaticScheduleConfig): ValidatedSchedule 
   if (hasRrule && hasLunar) {
     return { ok: false, error: "StaticScheduleAdapter: config cannot specify both rrule and lunar (XOR)" };
   }
-  if (hasRrule) {
-    return { ok: true, kind: "rrule", rrule };
-  }
+  if (hasRrule) return { ok: true, kind: "rrule", rrule };
   const lunar = config.lunar as LunarConfig;
-  if (lunar.phase !== "full" && lunar.phase !== "new") {
-    return {
-      ok: false,
-      error: `StaticScheduleAdapter: lunar.phase must be "full" or "new", got ${JSON.stringify(lunar.phase)}`,
-    };
-  }
-  if (typeof lunar.timezone !== "string" || lunar.timezone.trim().length === 0) {
-    return {
-      ok: false,
-      error: 'StaticScheduleAdapter: lunar.timezone is required (IANA timezone string, e.g. "America/Los_Angeles")',
-    };
-  }
-  // Codex pass-3 finding: a typo like "America/Los_Angles" was previously
-  // accepted, then silently remapped to UTC by the formatter — generating
-  // events on the wrong calendar day. Reject invalid IANA zones up front.
-  if (!isValidTimezone(lunar.timezone)) {
-    return {
-      ok: false,
-      error: `StaticScheduleAdapter: lunar.timezone "${lunar.timezone}" is not a recognized IANA timezone`,
-    };
-  }
-  const hasWeekday = lunar.anchorWeekday !== undefined && lunar.anchorWeekday !== null;
-  const hasRule = lunar.anchorRule !== undefined && lunar.anchorRule !== null;
-  if (hasWeekday !== hasRule) {
-    return {
-      ok: false,
-      error: "StaticScheduleAdapter: lunar.anchorWeekday and lunar.anchorRule must be set together (or both omitted)",
-    };
-  }
-  // Codex pass-3 finding: persisted JSON can carry arbitrary strings here;
-  // without an enum check, snapToAnchorWeekday reads `WEEKDAY_NAMES[bogus]`
-  // as undefined and produces NaN dates that crash `toIsoDateString`. Fail
-  // closed before generation.
-  if (hasWeekday && !ANCHOR_WEEKDAYS.includes(lunar.anchorWeekday as (typeof ANCHOR_WEEKDAYS)[number])) {
-    return {
-      ok: false,
-      error: `StaticScheduleAdapter: lunar.anchorWeekday "${lunar.anchorWeekday}" must be one of ${ANCHOR_WEEKDAYS.join(", ")}`,
-    };
-  }
-  if (hasRule && !ANCHOR_RULES.includes(lunar.anchorRule as (typeof ANCHOR_RULES)[number])) {
-    return {
-      ok: false,
-      error: `StaticScheduleAdapter: lunar.anchorRule "${lunar.anchorRule}" must be one of ${ANCHOR_RULES.join(", ")}`,
-    };
-  }
+  const lunarError = validateLunarBlock(lunar);
+  if (lunarError) return { ok: false, error: `StaticScheduleAdapter: ${lunarError}` };
   return { ok: true, kind: "lunar", lunar };
 }

--- a/src/adapters/static-schedule/lunar.test.ts
+++ b/src/adapters/static-schedule/lunar.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect } from "vitest";
+import {
+  phaseDistance,
+  generateLunarPhaseInstants,
+  lunarInstantToLocalDate,
+  snapToAnchorWeekday,
+  generateLunarOccurrences,
+  type LunarConfig,
+} from "./lunar";
+
+/**
+ * USNO-derived ground truth for 2026 lunar phases (UTC).
+ * Source: https://aa.usno.navy.mil/data/MoonPhases (cross-checked against NASA).
+ * Used as ±36-hour tolerance reference points — suncalc's accuracy is well within
+ * that window, but the threshold is generous enough to absorb any minor drift
+ * across suncalc versions.
+ */
+const KNOWN_FULL_MOONS_2026_UTC = [
+  "2026-01-03T10:03:00Z",
+  "2026-02-01T22:09:00Z",
+  "2026-03-03T11:38:00Z",
+  "2026-04-01T23:15:00Z",
+  "2026-05-01T09:23:00Z",
+];
+
+const KNOWN_NEW_MOONS_2026_UTC = [
+  "2026-01-18T19:52:00Z",
+  "2026-02-17T12:01:00Z",
+  "2026-03-19T01:23:00Z",
+  "2026-04-17T11:52:00Z",
+  "2026-05-16T20:01:00Z",
+];
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function utcNoon(yyyyMmDd: string): Date {
+  return new Date(`${yyyyMmDd}T12:00:00Z`);
+}
+
+describe("phaseDistance", () => {
+  it("returns 0 when actual equals target (full moon)", () => {
+    expect(phaseDistance(0.5, 0.5)).toBe(0);
+  });
+
+  it("returns 0 when actual equals target (new moon)", () => {
+    expect(phaseDistance(0, 0)).toBe(0);
+  });
+
+  it("treats 0.99 and 0.0 as ~0.01 apart (wraparound)", () => {
+    expect(phaseDistance(0.99, 0)).toBeCloseTo(0.01, 5);
+  });
+
+  it("treats 0.01 and 0.0 as 0.01 apart (no wraparound)", () => {
+    expect(phaseDistance(0.01, 0)).toBeCloseTo(0.01, 5);
+  });
+
+  it("returns 0.05 for a near-full reading (0.45 vs 0.5)", () => {
+    expect(phaseDistance(0.45, 0.5)).toBeCloseTo(0.05, 5);
+  });
+
+  it("returns 0.5 for a quarter-moon vs new (0.5 vs 0.0)", () => {
+    expect(phaseDistance(0.5, 0)).toBe(0.5);
+  });
+
+  it("is symmetric in its arguments", () => {
+    expect(phaseDistance(0.3, 0.7)).toBe(phaseDistance(0.7, 0.3));
+    expect(phaseDistance(0.95, 0.05)).toBe(phaseDistance(0.05, 0.95));
+  });
+
+  it("never exceeds 0.5 (the maximum cyclic distance)", () => {
+    for (let a = 0; a <= 1; a += 0.1) {
+      for (let b = 0; b <= 1; b += 0.1) {
+        expect(phaseDistance(a, b)).toBeLessThanOrEqual(0.5 + 1e-9);
+      }
+    }
+  });
+});
+
+describe("generateLunarPhaseInstants", () => {
+  it("returns 12 or 13 full moons in calendar year 2026", () => {
+    const start = new Date("2026-01-01T00:00:00Z");
+    const end = new Date("2026-12-31T23:59:59Z");
+    const moons = generateLunarPhaseInstants("full", start, end);
+    expect(moons.length).toBeGreaterThanOrEqual(12);
+    expect(moons.length).toBeLessThanOrEqual(13);
+  });
+
+  it("returns 12 or 13 new moons in calendar year 2026", () => {
+    const start = new Date("2026-01-01T00:00:00Z");
+    const end = new Date("2026-12-31T23:59:59Z");
+    const moons = generateLunarPhaseInstants("new", start, end);
+    expect(moons.length).toBeGreaterThanOrEqual(12);
+    expect(moons.length).toBeLessThanOrEqual(13);
+  });
+
+  it("matches USNO ground truth for full moons (Jan-May 2026, sub-12-hour tolerance)", () => {
+    // Codex pass-10: lunar dates schedule events by local calendar day, so a
+    // > 12h drift could move a kennel run to the wrong date in some
+    // timezones. Sub-12h ensures even DST-transition / westward zones can't
+    // get pushed across a calendar boundary.
+    const start = new Date("2026-01-01T00:00:00Z");
+    const end = new Date("2026-05-31T23:59:59Z");
+    const moons = generateLunarPhaseInstants("full", start, end);
+    for (const knownIso of KNOWN_FULL_MOONS_2026_UTC) {
+      const known = new Date(knownIso).getTime();
+      const closest = moons.reduce((best, m) =>
+        Math.abs(m.getTime() - known) < Math.abs(best.getTime() - known) ? m : best,
+      moons[0]);
+      const drift = Math.abs(closest.getTime() - known);
+      expect(drift).toBeLessThan(12 * HOUR_MS);
+    }
+  });
+
+  it("matches USNO ground truth for new moons (Jan-May 2026, sub-12-hour tolerance)", () => {
+    const start = new Date("2026-01-01T00:00:00Z");
+    const end = new Date("2026-05-31T23:59:59Z");
+    const moons = generateLunarPhaseInstants("new", start, end);
+    for (const knownIso of KNOWN_NEW_MOONS_2026_UTC) {
+      const known = new Date(knownIso).getTime();
+      const closest = moons.reduce((best, m) =>
+        Math.abs(m.getTime() - known) < Math.abs(best.getTime() - known) ? m : best,
+      moons[0]);
+      const drift = Math.abs(closest.getTime() - known);
+      expect(drift).toBeLessThan(12 * HOUR_MS);
+    }
+  });
+
+  it("emits the right LOCAL CALENDAR DATE per timezone for May 1 2026 full moon", () => {
+    // Codex pass-10: tighten beyond instant-precision — the user-facing
+    // contract is the YYYY-MM-DD that the merge pipeline ingests. Spot-check
+    // representative timezones for the May 1 full moon (USNO 09:23 UTC).
+    const tomorrow = new Date("2026-05-15T00:00:00Z");
+    // Window includes the May 1 full moon; LA exact-mode should land May 1.
+    const laConfig: LunarConfig = { phase: "full", timezone: "America/Los_Angeles" };
+    const laDates = generateLunarOccurrences(
+      laConfig,
+      new Date("2026-04-15T00:00:00Z"),
+      tomorrow,
+    );
+    expect(laDates).toContain("2026-05-01");
+
+    // Tokyo +9: 09:23 UTC = 18:23 JST same day, calendar = May 1.
+    const tokyoConfig: LunarConfig = { phase: "full", timezone: "Asia/Tokyo" };
+    const tokyoDates = generateLunarOccurrences(
+      tokyoConfig,
+      new Date("2026-04-15T00:00:00Z"),
+      tomorrow,
+    );
+    expect(tokyoDates).toContain("2026-05-01");
+  });
+
+  it("anchored mode emits weekend-leaning Saturday for the May 1 (Friday) phase", () => {
+    // DCFMH3 shape — anchorWeekday SA, nearest. May 1 2026 is a Friday →
+    // nearest Saturday is May 2 (1 day fwd) or Apr 25 (6 days back).
+    // `nearest` picks the closer (Apr 25 is 6 days vs May 2 is 1 day).
+    const config: LunarConfig = {
+      phase: "full",
+      timezone: "America/New_York",
+      anchorWeekday: "SA",
+      anchorRule: "nearest",
+    };
+    const dates = generateLunarOccurrences(
+      config,
+      new Date("2026-04-15T00:00:00Z"),
+      new Date("2026-05-15T00:00:00Z"),
+    );
+    expect(dates).toContain("2026-05-02");
+  });
+
+  it("returns instants in chronological order", () => {
+    const start = new Date("2026-01-01T00:00:00Z");
+    const end = new Date("2027-12-31T23:59:59Z");
+    const moons = generateLunarPhaseInstants("full", start, end);
+    for (let i = 1; i < moons.length; i++) {
+      expect(moons[i].getTime()).toBeGreaterThan(moons[i - 1].getTime());
+    }
+  });
+
+  it("returns spacing approximately equal to a synodic month (~29.5 days)", () => {
+    const start = new Date("2026-01-01T00:00:00Z");
+    const end = new Date("2027-12-31T23:59:59Z");
+    const moons = generateLunarPhaseInstants("full", start, end);
+    for (let i = 1; i < moons.length; i++) {
+      const gapDays = (moons[i].getTime() - moons[i - 1].getTime()) / DAY_MS;
+      expect(gapDays).toBeGreaterThan(28);
+      expect(gapDays).toBeLessThan(31);
+    }
+  });
+
+  it("returns empty array for a window that spans no phase (impossible — sanity check on inverted window)", () => {
+    const start = new Date("2026-05-01T00:00:00Z");
+    const end = new Date("2026-04-01T23:59:59Z"); // end before start
+    const moons = generateLunarPhaseInstants("full", start, end);
+    expect(moons).toEqual([]);
+  });
+
+  it("filters strictly inside the window — instants outside are excluded", () => {
+    const fullMoonInstant = new Date(KNOWN_FULL_MOONS_2026_UTC[2]); // Mar 3, 2026
+    // Window starting one minute AFTER the instant should NOT include it.
+    const start = new Date(fullMoonInstant.getTime() + 60_000);
+    const end = new Date(start.getTime() + 5 * DAY_MS);
+    const moons = generateLunarPhaseInstants("full", start, end);
+    for (const m of moons) {
+      expect(m.getTime()).toBeGreaterThanOrEqual(start.getTime());
+    }
+  });
+});
+
+describe("lunarInstantToLocalDate", () => {
+  it("returns the same calendar date in UTC for a UTC instant at noon", () => {
+    const instant = new Date("2026-05-01T12:00:00Z");
+    const local = lunarInstantToLocalDate(instant, "UTC");
+    expect(local.toISOString()).toBe("2026-05-01T12:00:00.000Z");
+  });
+
+  it("rolls back one day for a Honolulu instant before midnight UTC (10h offset)", () => {
+    // UTC noon → Honolulu 02:00 same day. Use an instant that's late UTC instead.
+    const instant = new Date("2026-05-01T03:00:00Z"); // Apr 30 17:00 HST
+    const local = lunarInstantToLocalDate(instant, "Pacific/Honolulu");
+    expect(local.toISOString()).toBe("2026-04-30T12:00:00.000Z");
+  });
+
+  it("preserves the calendar date for a New York instant during the same UTC day", () => {
+    // 09:23 UTC = 05:23 EDT (still May 1).
+    const instant = new Date("2026-05-01T09:23:00Z");
+    const local = lunarInstantToLocalDate(instant, "America/New_York");
+    expect(local.toISOString()).toBe("2026-05-01T12:00:00.000Z");
+  });
+
+  it("rolls back one day for a Los_Angeles instant in the early UTC morning", () => {
+    // 03:00 UTC = 20:00 PDT (previous day, May 16 → May 15 PDT in DST).
+    const instant = new Date("2026-05-16T03:00:00Z");
+    const local = lunarInstantToLocalDate(instant, "America/Los_Angeles");
+    expect(local.toISOString()).toBe("2026-05-15T12:00:00.000Z");
+  });
+
+  it("rolls forward one day for a Tokyo instant in the late UTC evening", () => {
+    // UTC May 1 17:00 = JST May 2 02:00.
+    const instant = new Date("2026-05-01T17:00:00Z");
+    const local = lunarInstantToLocalDate(instant, "Asia/Tokyo");
+    expect(local.toISOString()).toBe("2026-05-02T12:00:00.000Z");
+  });
+
+  it("handles invalid timezone by falling back to UTC", () => {
+    const instant = new Date("2026-05-01T12:00:00Z");
+    const local = lunarInstantToLocalDate(instant, "Not/A_Real_Tz");
+    expect(local.toISOString()).toBe("2026-05-01T12:00:00.000Z");
+  });
+});
+
+describe("snapToAnchorWeekday", () => {
+  // 2026-05-01 is a Friday (UTC).
+  const friday = utcNoon("2026-05-01");
+  // 2026-05-03 is a Sunday.
+  const sunday = utcNoon("2026-05-03");
+  // 2026-05-05 is a Tuesday.
+  const tuesday = utcNoon("2026-05-05");
+
+  it("returns the same date when already on the anchor weekday (nearest)", () => {
+    const result = snapToAnchorWeekday(friday, "FR", "nearest");
+    expect(result.toISOString()).toBe(friday.toISOString());
+  });
+
+  it("returns the same date when already on the anchor weekday (on-or-after)", () => {
+    const result = snapToAnchorWeekday(friday, "FR", "on-or-after");
+    expect(result.toISOString()).toBe(friday.toISOString());
+  });
+
+  it("returns the same date when already on the anchor weekday (on-or-before)", () => {
+    const result = snapToAnchorWeekday(friday, "FR", "on-or-before");
+    expect(result.toISOString()).toBe(friday.toISOString());
+  });
+
+  it("snaps Tuesday → Saturday (nearest) forward (4 days fwd vs 3 days back, picks fwd Saturday)", () => {
+    // Tuesday May 5 → fwd to Saturday May 9 (4d) or back to Saturday May 2 (3d).
+    // Nearest picks the closer (back). Asserts the actual deterministic choice.
+    const result = snapToAnchorWeekday(tuesday, "SA", "nearest");
+    const fwdMs = utcNoon("2026-05-09").getTime();
+    const backMs = utcNoon("2026-05-02").getTime();
+    const r = result.getTime();
+    expect([fwdMs, backMs]).toContain(r);
+    // Specifically: closer is back (3 days vs 4 days forward).
+    expect(r).toBe(backMs);
+  });
+
+  it("snaps Tuesday → Saturday (on-or-after) → next Saturday (May 9)", () => {
+    const result = snapToAnchorWeekday(tuesday, "SA", "on-or-after");
+    expect(result.toISOString()).toBe(utcNoon("2026-05-09").toISOString());
+  });
+
+  it("snaps Tuesday → Saturday (on-or-before) → previous Saturday (May 2)", () => {
+    const result = snapToAnchorWeekday(tuesday, "SA", "on-or-before");
+    expect(result.toISOString()).toBe(utcNoon("2026-05-02").toISOString());
+  });
+
+  it("ties break forward (later) for nearest at exactly 3.5 days", () => {
+    // No actual half-day tie possible with integer-day weekdays, but verify
+    // the deterministic rule for an equidistant case: e.g. Wed → SU (Sun) where
+    // fwd is 4 days (Sun May 10), back is 3 days (Sun May 3).
+    // 2026-05-06 is a Wednesday.
+    const wed = utcNoon("2026-05-06");
+    // From Wed: Sat fwd = 3 days (May 9), Sat back = 4 days (May 2). So nearest = May 9.
+    const result = snapToAnchorWeekday(wed, "SA", "nearest");
+    expect(result.toISOString()).toBe(utcNoon("2026-05-09").toISOString());
+  });
+
+  it("snaps Sunday → Saturday (on-or-after) → next Saturday (6 days forward)", () => {
+    const result = snapToAnchorWeekday(sunday, "SA", "on-or-after");
+    expect(result.toISOString()).toBe(utcNoon("2026-05-09").toISOString());
+  });
+
+  it("snaps Sunday → Saturday (on-or-before) → previous Saturday (1 day back)", () => {
+    const result = snapToAnchorWeekday(sunday, "SA", "on-or-before");
+    expect(result.toISOString()).toBe(utcNoon("2026-05-02").toISOString());
+  });
+
+  it("supports all seven weekday codes", () => {
+    // Round-trip Friday → each day, on-or-after, verify result's UTC day.
+    const codes = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"] as const;
+    for (let i = 0; i < codes.length; i++) {
+      const result = snapToAnchorWeekday(friday, codes[i], "on-or-after");
+      expect(result.getUTCDay()).toBe(i);
+    }
+  });
+});
+
+describe("generateLunarOccurrences", () => {
+  it("exact-mode (no anchor) full moon in May 2026 (UTC tz)", () => {
+    const config: LunarConfig = { phase: "full", timezone: "UTC" };
+    const start = new Date("2026-04-15T00:00:00Z");
+    const end = new Date("2026-05-31T23:59:59Z");
+    const dates = generateLunarOccurrences(config, start, end);
+    // April 1 full moon is BEFORE window start. Should include May 1.
+    expect(dates).toContain("2026-05-01");
+    // Window ends May 31; May 31 has a full moon at 18:45 UTC, so it's included.
+    expect(dates.some((d) => d === "2026-05-31" || d === "2026-06-01")).toBe(true);
+  });
+
+  it("anchor-mode full moon → SA nearest (DCFMH3 shape)", () => {
+    const config: LunarConfig = {
+      phase: "full",
+      timezone: "America/New_York",
+      anchorWeekday: "SA",
+      anchorRule: "nearest",
+    };
+    const start = new Date("2026-04-15T00:00:00Z");
+    const end = new Date("2026-05-31T23:59:59Z");
+    const dates = generateLunarOccurrences(config, start, end);
+    // May 1 full moon (Fri) → nearest Sat = May 2.
+    expect(dates).toContain("2026-05-02");
+    // Apr 1 full moon would be a Wed; nearest Sat = Mar 28 or Apr 4? Apr 4 (3 days fwd vs 4 days back).
+    // But Apr 1 is before window start (Apr 15) — verify Apr 4 NOT in result if outside window.
+  });
+
+  it("returns chronologically sorted YYYY-MM-DD strings", () => {
+    const config: LunarConfig = { phase: "full", timezone: "UTC" };
+    const start = new Date("2026-01-01T00:00:00Z");
+    const end = new Date("2026-12-31T23:59:59Z");
+    const dates = generateLunarOccurrences(config, start, end);
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i] > dates[i - 1]).toBe(true);
+    }
+  });
+
+  it("anchor-mode strips out-of-window dates after snap", () => {
+    // Phase on May 1 (Fri); on-or-after SA = May 2. If window ends May 1, May 2 is excluded.
+    const config: LunarConfig = {
+      phase: "full",
+      timezone: "UTC",
+      anchorWeekday: "SA",
+      anchorRule: "on-or-after",
+    };
+    const start = new Date("2026-04-15T00:00:00Z");
+    const end = new Date("2026-05-01T23:59:59Z");
+    const dates = generateLunarOccurrences(config, start, end);
+    expect(dates).not.toContain("2026-05-02");
+  });
+
+  it("dedups when two phases snap to the same anchor weekday", () => {
+    // Pathological but possible: a phase at the very end of one month + a phase at
+    // the start of the next month, both snapping to the same Saturday under
+    // on-or-before — the function must collapse to a single output.
+    // Empirically rare; this test asserts the dedup behavior exists rather than
+    // fabricating exact dates.
+    const config: LunarConfig = {
+      phase: "full",
+      timezone: "UTC",
+      anchorWeekday: "SA",
+      anchorRule: "nearest",
+    };
+    const start = new Date("2026-01-01T00:00:00Z");
+    const end = new Date("2027-12-31T23:59:59Z");
+    const dates = generateLunarOccurrences(config, start, end);
+    const set = new Set(dates);
+    expect(set.size).toBe(dates.length);
+  });
+});

--- a/src/adapters/static-schedule/lunar.ts
+++ b/src/adapters/static-schedule/lunar.ts
@@ -261,5 +261,8 @@ export function generateLunarOccurrences(
     if (t < startMs || t > endMs) continue;
     out.add(toIsoDateString(local));
   }
-  return [...out].sort();
+  // Explicit comparator: ISO YYYY-MM-DD strings ARE chronological under
+  // lexicographic order, but bare `.sort()` is locale-dependent in some
+  // engines and trips Sonar S2871.
+  return [...out].sort((a, b) => a.localeCompare(b));
 }

--- a/src/adapters/static-schedule/lunar.ts
+++ b/src/adapters/static-schedule/lunar.ts
@@ -1,0 +1,265 @@
+/**
+ * Lunar phase recurrence helpers for the STATIC_SCHEDULE adapter.
+ *
+ * Two operating modes covered:
+ *   - Exact (no anchor): event lands on the calendar date of the astronomical
+ *     phase in the kennel's timezone (e.g. FMH3 SF on the full moon).
+ *   - Anchor: event lands on the nearest matching weekday relative to the phase
+ *     date (e.g. DCFMH3 — "Fri/Sat near full moon").
+ *
+ * No network I/O. SunCalc computes the moon phase locally from astronomical
+ * tables (~10KB, MIT, no deps). USNO/FarmSense alternatives are not used to
+ * avoid rate-limit risk and an external dependency.
+ *
+ * See `lunar.test.ts` for behavioral specification.
+ */
+
+import SunCalc from "suncalc";
+import { WEEKDAY_NAMES } from "../utils";
+import { toIsoDateString, parseUtcNoonDate } from "@/lib/date";
+import { formatYmdInTimezone } from "@/lib/timezone";
+
+/**
+ * Configuration for a lunar STATIC_SCHEDULE source. Either `rrule` OR `lunar`
+ * is required on the parent `StaticScheduleConfig` — never both. XOR enforced
+ * by `validateStaticScheduleConfig` and the adapter's `fetch()`.
+ */
+export interface LunarConfig {
+  /** Which lunar phase the kennel runs on. */
+  phase: "full" | "new";
+  /**
+   * IANA timezone the kennel operates in (e.g. "America/Los_Angeles"). The
+   * astronomical phase instant is converted to a calendar date in this zone
+   * — a full moon at 03:00 UTC is the previous day in Honolulu but the same
+   * day in London. Required because the adapter is pure: it doesn't look up
+   * the kennel's region. The admin UI defaults this from the kennel's region
+   * timezone; seed rows include it explicitly for transparency.
+   */
+  timezone: string;
+  /**
+   * Optional: instead of the exact phase date, snap to the nearest day
+   * matching this weekday. Two-letter RRULE-style code (SU/MO/TU/WE/TH/FR/SA).
+   * Omitted: event lands on the calendar date of the astronomical phase in
+   * the kennel's timezone (FMH3 shape).
+   * Set: event lands on the matching weekday per `anchorRule` (DCFMH3 shape).
+   */
+  anchorWeekday?: AnchorWeekday;
+  /**
+   * How to snap to anchorWeekday relative to the phase date. Required iff
+   * `anchorWeekday` is set (and vice versa).
+   *   "nearest"        — closest occurrence; ties break forward (later).
+   *   "on-or-after"    — first matching weekday on or after the phase.
+   *   "on-or-before"   — first matching weekday on or before the phase.
+   */
+  anchorRule?: AnchorRule;
+}
+
+export type AnchorWeekday = "SU" | "MO" | "TU" | "WE" | "TH" | "FR" | "SA";
+export type AnchorRule = "nearest" | "on-or-after" | "on-or-before";
+
+/** Allowed values for runtime validation; mirrors `AnchorWeekday`. */
+export const ANCHOR_WEEKDAYS = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"] as const;
+/** Allowed values for runtime validation; mirrors `AnchorRule`. */
+export const ANCHOR_RULES = ["nearest", "on-or-after", "on-or-before"] as const;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Wraparound-safe distance between two phase fractions in [0, 1).
+ *
+ * The moon's phase is cyclic — phase 0.99 and 0.01 are both ~1% from new moon
+ * (target 0.0), not 98% apart. A naive `Math.abs(a - b)` is wrong at the
+ * 1.0 → 0.0 boundary. This function returns the shortest cyclic distance,
+ * which has a maximum of 0.5 (a quarter moon away from any target phase).
+ *
+ * Symmetric in its arguments.
+ */
+export function phaseDistance(actualPhase: number, targetPhase: number): number {
+  const d = Math.abs(actualPhase - targetPhase);
+  return Math.min(d, 1 - d);
+}
+
+/**
+ * Generate UTC instants of full or new moons inside [windowStart, windowEnd].
+ *
+ * Algorithm:
+ *   1. Walk daily noon-UTC across the window (with one day of padding on each
+ *      side so a phase exactly at the boundary is still detected).
+ *   2. A daily sample is a candidate if its phaseDistance is below ~0.05 AND
+ *      it's a strict local minimum vs the previous day AND a non-strict local
+ *      minimum vs the next day. (Strict-LT on one side breaks any equal-pair
+ *      tie deterministically by picking the earlier date.) The 0.05 threshold
+ *      is chosen so that exactly one daily sample per cycle qualifies — the
+ *      sun's daily phase delta is ~0.034 so two consecutive days within the
+ *      threshold is impossible.
+ *   3. Refine each candidate to its sub-day astronomical instant by ternary
+ *      search inside ±36h. The phaseDistance function is U-shaped (unimodal)
+ *      near the target so ternary search converges quickly.
+ *   4. Filter to the requested [windowStart, windowEnd] window.
+ */
+export function generateLunarPhaseInstants(
+  phase: "full" | "new",
+  windowStart: Date,
+  windowEnd: Date,
+): Date[] {
+  if (windowStart.getTime() > windowEnd.getTime()) return [];
+
+  const target = phase === "full" ? 0.5 : 0;
+
+  // Sample once per day at noon UTC, padded ±1 day so boundary phases are seen.
+  const sampleStart = startOfUtcDayNoon(windowStart) - DAY_MS;
+  const sampleEnd = startOfUtcDayNoon(windowEnd) + DAY_MS;
+
+  type Sample = { time: number; dist: number };
+  const samples: Sample[] = [];
+  for (let t = sampleStart; t <= sampleEnd; t += DAY_MS) {
+    const phaseFrac = SunCalc.getMoonIllumination(new Date(t)).phase;
+    samples.push({ time: t, dist: phaseDistance(phaseFrac, target) });
+  }
+
+  const candidates: Date[] = [];
+  for (let i = 1; i < samples.length - 1; i++) {
+    const cur = samples[i];
+    if (cur.dist > 0.05) continue;
+    const prev = samples[i - 1];
+    const next = samples[i + 1];
+    // Strict-LT on the previous side (earlier-date wins on a tie),
+    // non-strict on the next side.
+    if (cur.dist < prev.dist && cur.dist <= next.dist) {
+      const refined = refinePhaseInstant(target, cur.time - 36 * HOUR_MS, cur.time + 36 * HOUR_MS);
+      candidates.push(new Date(refined));
+    }
+  }
+
+  // Filter to requested window.
+  const startMs = windowStart.getTime();
+  const endMs = windowEnd.getTime();
+  return candidates.filter((d) => d.getTime() >= startMs && d.getTime() <= endMs);
+}
+
+/**
+ * Refine a phase candidate to the precise UTC instant by ternary search on
+ * `phaseDistance`. The search range is wide enough (±36h) to bracket the
+ * actual minimum even when our daily sample missed by half a day, and the
+ * 1-minute precision is well below any kennel scheduling cadence.
+ */
+function refinePhaseInstant(target: number, lo: number, hi: number): number {
+  let l = lo;
+  let h = hi;
+  // Ternary search converges to 1-minute precision in ~24 iterations on a 72h
+  // bracket; the loop cap is dead headroom. SunCalc's intrinsic accuracy is
+  // ~5 minutes, so sub-minute precision is already overkill.
+  for (let i = 0; i < 60; i++) {
+    if (h - l <= 60_000) break;
+    const m1 = l + (h - l) / 3;
+    const m2 = h - (h - l) / 3;
+    const d1 = phaseDistance(SunCalc.getMoonIllumination(new Date(m1)).phase, target);
+    const d2 = phaseDistance(SunCalc.getMoonIllumination(new Date(m2)).phase, target);
+    if (d1 < d2) {
+      h = m2;
+    } else {
+      l = m1;
+    }
+  }
+  return Math.round((l + h) / 2);
+}
+
+/** Start-of-noon-UTC milliseconds for a given Date (used for daily sampling). */
+function startOfUtcDayNoon(d: Date): number {
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 12, 0, 0);
+}
+
+/**
+ * Convert an astronomical UTC instant to a calendar date in the kennel's
+ * timezone, returned as that local date represented as UTC noon (matching the
+ * project's UTC-noon date convention used throughout the merge pipeline).
+ *
+ * Example: full moon at `2026-05-16T03:00:00Z` for `America/Los_Angeles`
+ *   → local time `2026-05-15T20:00:00-07:00`
+ *   → local date `2026-05-15`
+ *   → returned as `2026-05-15T12:00:00.000Z`.
+ *
+ * Falls back to UTC if the timezone is invalid.
+ */
+export function lunarInstantToLocalDate(instant: Date, timezone: string): Date {
+  return parseUtcNoonDate(formatYmdInTimezone(instant, timezone));
+}
+
+/**
+ * Snap a calendar date (UTC noon) to the requested anchor weekday under one
+ * of three rules. Pure date arithmetic — does not consult the moon phase.
+ *
+ * "nearest" ties (equidistant forward / back) break forward (later date) —
+ * this matches kennel intent of leaning into the upcoming weekend rather
+ * than the previous one. The fwd-distance < back-distance (strict) check
+ * makes the tie deterministic.
+ */
+export function snapToAnchorWeekday(
+  localDate: Date,
+  anchorWeekday: AnchorWeekday,
+  anchorRule: AnchorRule,
+): Date {
+  // WEEKDAY_NAMES from ../utils maps SU/MO/TU/WE/TH/FR/SA to JS getUTCDay() values (0..6).
+  const target = WEEKDAY_NAMES[anchorWeekday];
+  const current = localDate.getUTCDay();
+  if (current === target) return localDate;
+
+  const fwdDelta = (target - current + 7) % 7; // 1..6
+  const backDelta = (current - target + 7) % 7; // 1..6
+
+  let delta: number;
+  if (anchorRule === "on-or-after") {
+    delta = fwdDelta;
+  } else if (anchorRule === "on-or-before") {
+    delta = -backDelta;
+  } else {
+    // nearest: ties break forward (later) → require strict-less for back.
+    delta = backDelta < fwdDelta ? -backDelta : fwdDelta;
+  }
+
+  return new Date(localDate.getTime() + delta * DAY_MS);
+}
+
+/**
+ * Top-level entry point: generate `YYYY-MM-DD` occurrence dates for a lunar
+ * config inside a window, anchored to the kennel's timezone.
+ *
+ * Flow:
+ *   1. Find UTC instants of the requested phase inside an extended window
+ *      (padded by 7 days on each side so a phase outside the window can still
+ *      snap into the window via `anchorWeekday`).
+ *   2. Convert each instant to a local-date in the kennel's timezone.
+ *   3. If `anchorWeekday` is set, snap to the requested weekday under
+ *      `anchorRule`.
+ *   4. Filter to the requested [windowStart, windowEnd] window (post-snap
+ *      dates outside the window are dropped).
+ *   5. Dedup (rare: two phases can snap to the same anchor weekday).
+ *   6. Sort chronologically.
+ */
+export function generateLunarOccurrences(
+  config: LunarConfig,
+  windowStart: Date,
+  windowEnd: Date,
+): string[] {
+  // Pad by 7 days so a phase that lands just outside [windowStart, windowEnd]
+  // can still snap INTO the window via on-or-before / on-or-after.
+  const paddedStart = new Date(windowStart.getTime() - 7 * DAY_MS);
+  const paddedEnd = new Date(windowEnd.getTime() + 7 * DAY_MS);
+
+  const instants = generateLunarPhaseInstants(config.phase, paddedStart, paddedEnd);
+  const startMs = windowStart.getTime();
+  const endMs = windowEnd.getTime();
+
+  const out = new Set<string>();
+  for (const instant of instants) {
+    let local = lunarInstantToLocalDate(instant, config.timezone);
+    if (config.anchorWeekday && config.anchorRule) {
+      local = snapToAnchorWeekday(local, config.anchorWeekday, config.anchorRule);
+    }
+    const t = local.getTime();
+    if (t < startMs || t > endMs) continue;
+    out.add(toIsoDateString(local));
+  }
+  return [...out].sort();
+}

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -1,4 +1,5 @@
 import isSafeRegex from "safe-regex2";
+import { isValidTimezone } from "@/lib/timezone";
 
 /** Returns true if the string is a valid, ReDoS-safe regex. Shared by config validation and AI suggestion filtering. */
 export function isSafeRegexString(p: unknown): boolean {
@@ -188,16 +189,74 @@ function validateRssFeedConfig(obj: Record<string, unknown>, errors: string[]): 
   }
 }
 
-/** Validate STATIC_SCHEDULE required fields. */
+/** RRULE-style two-letter weekday codes (RFC 5545 §3.3.10). */
+const LUNAR_WEEKDAYS = new Set(["SU", "MO", "TU", "WE", "TH", "FR", "SA"]);
+const LUNAR_ANCHOR_RULES = new Set(["nearest", "on-or-after", "on-or-before"]);
+
+/**
+ * Validate the lunar config block (when set). Mirror of `validateRruleLunarXor`
+ * in the adapter — kept in sync so admin-side and cron-side rejection messages
+ * read consistently.
+ */
+function validateLunarConfig(lunar: Record<string, unknown>, errors: string[]): void {
+  if (lunar.phase !== "full" && lunar.phase !== "new") {
+    errors.push('Static Schedule lunar.phase must be "full" or "new"');
+  }
+  if (typeof lunar.timezone !== "string" || !lunar.timezone.trim()) {
+    errors.push('Static Schedule lunar.timezone is required (IANA timezone, e.g. "America/Los_Angeles")');
+  } else if (!isValidTimezone(lunar.timezone)) {
+    errors.push(`Static Schedule lunar.timezone "${lunar.timezone}" is not a recognized IANA timezone`);
+  }
+  const weekday = lunar.anchorWeekday;
+  const rule = lunar.anchorRule;
+  const hasWeekday = weekday !== undefined && weekday !== null;
+  const hasRule = rule !== undefined && rule !== null;
+  if (hasWeekday !== hasRule) {
+    errors.push("Static Schedule lunar.anchorWeekday and lunar.anchorRule must be set together (or both omitted)");
+    return;
+  }
+  if (hasWeekday) {
+    if (typeof weekday !== "string" || !LUNAR_WEEKDAYS.has(weekday)) {
+      errors.push("Static Schedule lunar.anchorWeekday must be one of SU/MO/TU/WE/TH/FR/SA");
+    }
+    if (typeof rule !== "string" || !LUNAR_ANCHOR_RULES.has(rule)) {
+      errors.push('Static Schedule lunar.anchorRule must be one of "nearest", "on-or-after", "on-or-before"');
+    }
+  }
+}
+
+/**
+ * Validate STATIC_SCHEDULE required fields.
+ *
+ * XOR contract: exactly one of `rrule | lunar` must be present.
+ *  - RRULE mode: traditional calendar recurrence (FREQ=WEEKLY;BYDAY=SA, etc.)
+ *  - Lunar mode: phase-anchored ("full" / "new") with optional weekday anchor
+ *    for kennels like DCFMH3 ("Fri/Sat near full moon").
+ */
 function validateStaticScheduleConfig(obj: Record<string, unknown>, errors: string[]): void {
   if (typeof obj.kennelTag !== "string" || !obj.kennelTag.trim()) {
     errors.push("Static Schedule config requires a non-empty kennelTag");
   }
-  if (typeof obj.rrule !== "string" || !obj.rrule.trim()) {
-    errors.push("Static Schedule config requires a non-empty rrule");
-  } else if (!/^FREQ=/i.test(obj.rrule.trim())) {
-    errors.push("Static Schedule rrule must start with FREQ= (e.g. FREQ=WEEKLY;BYDAY=SA)");
+
+  const hasRrule = typeof obj.rrule === "string" && obj.rrule.trim().length > 0;
+  const hasLunar = obj.lunar !== undefined && obj.lunar !== null;
+  if (!hasRrule && !hasLunar) {
+    errors.push("Static Schedule config requires either rrule or lunar (exactly one)");
+  } else if (hasRrule && hasLunar) {
+    errors.push("Static Schedule config cannot specify both rrule and lunar (XOR)");
+  } else if (hasRrule) {
+    const rrule = obj.rrule as string;
+    if (!/^FREQ=/i.test(rrule.trim())) {
+      errors.push("Static Schedule rrule must start with FREQ= (e.g. FREQ=WEEKLY;BYDAY=SA)");
+    }
+  } else if (hasLunar) {
+    if (typeof obj.lunar !== "object" || Array.isArray(obj.lunar)) {
+      errors.push("Static Schedule lunar must be an object");
+    } else {
+      validateLunarConfig(obj.lunar as Record<string, unknown>, errors);
+    }
   }
+
   if (obj.startTime !== undefined) {
     if (typeof obj.startTime !== "string") {
       errors.push("Static Schedule config startTime must be a string");

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -233,44 +233,60 @@ function validateLunarConfig(lunar: Record<string, unknown>, errors: string[]): 
  *  - Lunar mode: phase-anchored ("full" / "new") with optional weekday anchor
  *    for kennels like DCFMH3 ("Fri/Sat near full moon").
  */
-function validateStaticScheduleConfig(obj: Record<string, unknown>, errors: string[]): void {
-  if (typeof obj.kennelTag !== "string" || !obj.kennelTag.trim()) {
-    errors.push("Static Schedule config requires a non-empty kennelTag");
-  }
-
+/** Validate the recurrence XOR (rrule | lunar). Pulled out so the parent
+ *  stays under SonarCloud's cognitive-complexity cap. */
+function validateRecurrenceBlock(obj: Record<string, unknown>, errors: string[]): void {
   const hasRrule = typeof obj.rrule === "string" && obj.rrule.trim().length > 0;
   const hasLunar = obj.lunar !== undefined && obj.lunar !== null;
   if (!hasRrule && !hasLunar) {
     errors.push("Static Schedule config requires either rrule or lunar (exactly one)");
-  } else if (hasRrule && hasLunar) {
+    return;
+  }
+  if (hasRrule && hasLunar) {
     errors.push("Static Schedule config cannot specify both rrule and lunar (XOR)");
-  } else if (hasRrule) {
+    return;
+  }
+  if (hasRrule) {
     const rrule = obj.rrule as string;
     if (!/^FREQ=/i.test(rrule.trim())) {
       errors.push("Static Schedule rrule must start with FREQ= (e.g. FREQ=WEEKLY;BYDAY=SA)");
     }
-  } else if (hasLunar) {
-    if (typeof obj.lunar !== "object" || Array.isArray(obj.lunar)) {
-      errors.push("Static Schedule lunar must be an object");
-    } else {
-      validateLunarConfig(obj.lunar as Record<string, unknown>, errors);
-    }
+    return;
   }
+  if (typeof obj.lunar !== "object" || Array.isArray(obj.lunar)) {
+    errors.push("Static Schedule lunar must be an object");
+    return;
+  }
+  validateLunarConfig(obj.lunar as Record<string, unknown>, errors);
+}
 
-  if (obj.startTime !== undefined) {
-    if (typeof obj.startTime !== "string") {
-      errors.push("Static Schedule config startTime must be a string");
-    } else if (!TIME_HHMM_RE.test(obj.startTime)) {
-      errors.push('Static Schedule config startTime must be HH:MM format (e.g. "10:17", "19:00")');
-    }
+/** Validate optional `startTime` field. */
+function validateStartTimeField(obj: Record<string, unknown>, errors: string[]): void {
+  if (obj.startTime === undefined) return;
+  if (typeof obj.startTime !== "string") {
+    errors.push("Static Schedule config startTime must be a string");
+  } else if (!TIME_HHMM_RE.test(obj.startTime)) {
+    errors.push('Static Schedule config startTime must be HH:MM format (e.g. "10:17", "19:00")');
   }
-  if (obj.anchorDate !== undefined) {
-    if (typeof obj.anchorDate !== "string") {
-      errors.push("Static Schedule config anchorDate must be a string");
-    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(obj.anchorDate)) {
-      errors.push('Static Schedule config anchorDate must be YYYY-MM-DD format (e.g. "2026-01-03")');
-    }
+}
+
+/** Validate optional `anchorDate` field. */
+function validateAnchorDateField(obj: Record<string, unknown>, errors: string[]): void {
+  if (obj.anchorDate === undefined) return;
+  if (typeof obj.anchorDate !== "string") {
+    errors.push("Static Schedule config anchorDate must be a string");
+  } else if (!/^\d{4}-\d{2}-\d{2}$/.test(obj.anchorDate)) {
+    errors.push('Static Schedule config anchorDate must be YYYY-MM-DD format (e.g. "2026-01-03")');
   }
+}
+
+function validateStaticScheduleConfig(obj: Record<string, unknown>, errors: string[]): void {
+  if (typeof obj.kennelTag !== "string" || !obj.kennelTag.trim()) {
+    errors.push("Static Schedule config requires a non-empty kennelTag");
+  }
+  validateRecurrenceBlock(obj, errors);
+  validateStartTimeField(obj, errors);
+  validateAnchorDateField(obj, errors);
 }
 
 /** Dangerous patterns blocked in CSS selectors (XSS prevention). */

--- a/src/components/admin/config-panels/StaticScheduleConfigPanel.test.ts
+++ b/src/components/admin/config-panels/StaticScheduleConfigPanel.test.ts
@@ -30,7 +30,17 @@ describe("syncStashFromConfig", () => {
       phase: "full",
       timezone: "America/Los_Angeles",
     });
+    // In lunar mode, rrule stash is preserved unchanged (it's the previous draft).
     expect(next.rrule).toEqual({});
+  });
+
+  it("captures anchorDate edits when in rrule mode even if rrule is empty (CodeRabbit fix)", () => {
+    const next = syncStashFromConfig(
+      { rrule: { rrule: "FREQ=WEEKLY;BYDAY=SA", anchorDate: "2026-01-03" }, lunar: undefined },
+      // User cleared rrule and edited anchorDate (no lunar — still in rrule mode).
+      { rrule: "", anchorDate: "2026-04-04" },
+    );
+    expect(next.rrule).toEqual({ rrule: "", anchorDate: "2026-04-04" });
   });
 
   it("preserves the inactive mode's stash across mode-switch transitions", () => {

--- a/src/components/admin/config-panels/StaticScheduleConfigPanel.test.ts
+++ b/src/components/admin/config-panels/StaticScheduleConfigPanel.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { syncStashFromConfig } from "./StaticScheduleConfigPanel";
+
+/**
+ * Pure derive-state-from-props rule for the panel's mode-switch stash.
+ * Stash lives in `useState` (commit-safe; rolls back on aborted renders) —
+ * see Codex pass-2/7/8/9/10 for the iterations that landed at this contract.
+ */
+
+describe("syncStashFromConfig", () => {
+  const emptyPrev = { rrule: {}, lunar: undefined };
+
+  it("captures the active rrule mode's draft when config has rrule set", () => {
+    const next = syncStashFromConfig(emptyPrev, {
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      anchorDate: "2026-01-03",
+    });
+    expect(next.rrule).toEqual({
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      anchorDate: "2026-01-03",
+    });
+    expect(next.lunar).toBeUndefined();
+  });
+
+  it("captures the active lunar mode's draft when config has lunar set", () => {
+    const next = syncStashFromConfig(emptyPrev, {
+      lunar: { phase: "full", timezone: "America/Los_Angeles" },
+    });
+    expect(next.lunar).toEqual({
+      phase: "full",
+      timezone: "America/Los_Angeles",
+    });
+    expect(next.rrule).toEqual({});
+  });
+
+  it("preserves the inactive mode's stash across mode-switch transitions", () => {
+    const initialPrev = { rrule: {}, lunar: undefined };
+
+    // 1. RRULE source loaded
+    const afterLoad = syncStashFromConfig(initialPrev, {
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      anchorDate: "2026-01-03",
+    });
+    expect(afterLoad.rrule).toEqual({
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      anchorDate: "2026-01-03",
+    });
+
+    // 2. User toggles to lunar mode (rrule cleared, fresh lunar form seeded)
+    const afterToggleToLunar = syncStashFromConfig(afterLoad, {
+      lunar: { phase: "full", timezone: "" },
+    });
+    expect(afterToggleToLunar.rrule).toEqual({
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      anchorDate: "2026-01-03",
+    });
+
+    // 3. User fills in lunar fields
+    const afterFillLunar = syncStashFromConfig(afterToggleToLunar, {
+      lunar: { phase: "full", timezone: "America/Los_Angeles" },
+    });
+
+    // 4. User toggles back to rrule — stashed lunar must persist for next toggle
+    const afterToggleBack = syncStashFromConfig(afterFillLunar, {
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      anchorDate: "2026-01-03",
+    });
+    expect(afterToggleBack.lunar).toEqual({
+      phase: "full",
+      timezone: "America/Los_Angeles",
+    });
+  });
+
+  it("overwrites stash when the parent passes a different source's config", () => {
+    const sourceAStash = {
+      rrule: { rrule: "FREQ=WEEKLY;BYDAY=SA", anchorDate: "2026-01-03" },
+      lunar: undefined,
+    };
+    const sourceBConfig = {
+      rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA",
+      anchorDate: "2026-03-07",
+    };
+    const next = syncStashFromConfig(sourceAStash, sourceBConfig);
+    expect(next.rrule).toEqual({
+      rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA",
+      anchorDate: "2026-03-07",
+    });
+  });
+
+  it("passes stash through unchanged when both modes are momentarily undefined", () => {
+    const prev = {
+      rrule: { rrule: "FREQ=WEEKLY;BYDAY=SA", anchorDate: "2026-01-03" },
+      lunar: { phase: "full" as const, timezone: "America/Los_Angeles" },
+    };
+    const next = syncStashFromConfig(prev, {});
+    expect(next).toEqual(prev);
+  });
+});

--- a/src/components/admin/config-panels/StaticScheduleConfigPanel.tsx
+++ b/src/components/admin/config-panels/StaticScheduleConfigPanel.tsx
@@ -78,12 +78,20 @@ export function syncStashFromConfig(
   prev: StashState,
   current: { rrule?: string; anchorDate?: string; lunar?: LunarConfigForm },
 ): StashState {
+  // Source of truth is the *active* mode: when `current.lunar` is set we're
+  // in lunar mode and the parent has locally cleared rrule/anchorDate; keep
+  // the previous draft for both. When lunar is unset we're in rrule mode —
+  // capture rrule AND anchorDate together so an anchorDate edit isn't lost
+  // when rrule happens to be empty (CodeRabbit review finding). The
+  // `hasRruleField` guard preserves the previous draft when current is fully
+  // empty (e.g. initial null config) instead of wiping it.
+  const inRruleMode = current.lunar === undefined;
+  const hasRruleField = current.rrule !== undefined || current.anchorDate !== undefined;
   return {
-    rrule:
-      current.rrule !== undefined
-        ? { rrule: current.rrule, anchorDate: current.anchorDate }
-        : prev.rrule,
-    lunar: current.lunar !== undefined ? current.lunar : prev.lunar,
+    rrule: inRruleMode && hasRruleField
+      ? { rrule: current.rrule, anchorDate: current.anchorDate }
+      : prev.rrule,
+    lunar: current.lunar ?? prev.lunar,
   };
 }
 
@@ -297,8 +305,8 @@ export function StaticScheduleConfigPanel({
           <p className="text-xs text-muted-foreground">
             Anchor mode snaps the event to the nearest matching weekday relative
             to the astronomical phase — useful for kennels like DCFMH3
-            (&quot;Friday/Saturday near full moon&quot;). Leave anchor weekday set to
-            <em> None</em> to land directly on the phase date.
+            (&quot;Friday/Saturday near full moon&quot;). Leave anchor weekday set
+            to <em>None</em> to land directly on the phase date.
           </p>
         </div>
       )}

--- a/src/components/admin/config-panels/StaticScheduleConfigPanel.tsx
+++ b/src/components/admin/config-panels/StaticScheduleConfigPanel.tsx
@@ -1,13 +1,36 @@
 "use client";
 
+import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { KennelTagInput, type KennelOption } from "./KennelTagInput";
 
-/** Form-level config shape for the STATIC_SCHEDULE source type. */
+/** Form-level lunar config block. */
+export interface LunarConfigForm {
+  phase?: "full" | "new";
+  timezone?: string;
+  anchorWeekday?: "SU" | "MO" | "TU" | "WE" | "TH" | "FR" | "SA";
+  anchorRule?: "nearest" | "on-or-after" | "on-or-before";
+}
+
+/**
+ * Form-level config shape for the STATIC_SCHEDULE source type.
+ *
+ * Modes are mutually exclusive (XOR enforced server-side):
+ *   - RRULE mode: `rrule` is set, `lunar` is omitted.
+ *   - Lunar mode: `lunar` is set, `rrule` is omitted.
+ */
 export interface StaticScheduleConfig {
   kennelTag?: string;
   rrule?: string;
+  lunar?: LunarConfigForm;
   anchorDate?: string;
   startTime?: string;
   defaultTitle?: string;
@@ -22,13 +45,107 @@ interface StaticScheduleConfigPanelProps {
   readonly allKennels?: KennelOption[];
 }
 
-/** Admin panel for editing STATIC_SCHEDULE source config (RRULE, kennel tag, defaults). */
+const WEEKDAY_OPTIONS: { value: NonNullable<LunarConfigForm["anchorWeekday"]>; label: string }[] = [
+  { value: "SU", label: "Sunday" },
+  { value: "MO", label: "Monday" },
+  { value: "TU", label: "Tuesday" },
+  { value: "WE", label: "Wednesday" },
+  { value: "TH", label: "Thursday" },
+  { value: "FR", label: "Friday" },
+  { value: "SA", label: "Saturday" },
+];
+
+// Radix `Select` requires non-empty values; these sentinels stand in for an
+// "unset" anchor pair without colliding with real anchorWeekday/anchorRule values.
+const ANCHOR_NONE = "__none__";
+
+interface StashState {
+  rrule: { rrule?: string; anchorDate?: string };
+  lunar: LunarConfigForm | undefined;
+}
+
+/**
+ * Pure derive-state-from-props rule for the mode-switch stash.
+ *
+ * Keeps the most recent non-undefined value of each mode's draft. Switching
+ * modes clears the inactive mode's fields locally; the stash retains the
+ * value so switching back restores it. Commit-safe (React rolls back useState
+ * updates from aborted renders).
+ *
+ * Exported for unit testing — see `StaticScheduleConfigPanel.test.ts`.
+ */
+export function syncStashFromConfig(
+  prev: StashState,
+  current: { rrule?: string; anchorDate?: string; lunar?: LunarConfigForm },
+): StashState {
+  return {
+    rrule:
+      current.rrule !== undefined
+        ? { rrule: current.rrule, anchorDate: current.anchorDate }
+        : prev.rrule,
+    lunar: current.lunar !== undefined ? current.lunar : prev.lunar,
+  };
+}
+
+/**
+ * Admin panel for editing STATIC_SCHEDULE source config.
+ *
+ * Top-level mode selector swaps the recurrence inputs between RRULE (calendar
+ * recurrence) and Lunar (full/new moon, optional weekday anchor). The XOR
+ * contract is enforced server-side; the UI just hides the irrelevant inputs.
+ */
 export function StaticScheduleConfigPanel({
   config,
   onChange,
   allKennels,
 }: StaticScheduleConfigPanelProps) {
   const current = config ?? {};
+  // Mode is derived from which field is set. Default to "rrule" for new sources
+  // (rrule is the more common case; lunar is opt-in for ~30 of the 200+ sources).
+  const mode: "rrule" | "lunar" = current.lunar ? "lunar" : "rrule";
+  const lunar = current.lunar ?? {};
+
+  // Per-mode drafts in commit-safe React state (not refs — refs mutated in
+  // render are not rollback-safe under React concurrent rendering, see Codex
+  // pass-9). Stash preserves the inactive mode's draft so switching back
+  // restores it instead of starting from blank.
+  const [stash, setStash] = useState<StashState>(() => ({
+    rrule: { rrule: config?.rrule, anchorDate: config?.anchorDate },
+    lunar: config?.lunar,
+  }));
+  // "Derive state from props" pattern keyed on the *prop reference* — NOT on
+  // `current` (which is `config ?? {}` and allocates a fresh object every
+  // render when config is null, which would infinite-loop the setState below).
+  // Codex pass-11 caught this regression.
+  const [lastConfig, setLastConfig] = useState(config);
+  if (config !== lastConfig) {
+    setLastConfig(config);
+    setStash((prev) => syncStashFromConfig(prev, config ?? {}));
+  }
+
+  const setMode = (next: "rrule" | "lunar") => {
+    if (next === mode) return;
+    if (next === "lunar") {
+      const restoredLunar = stash.lunar ?? { phase: "full", timezone: "" };
+      onChange({
+        ...current,
+        rrule: undefined,
+        anchorDate: undefined,
+        lunar: restoredLunar,
+      });
+    } else {
+      onChange({
+        ...current,
+        lunar: undefined,
+        rrule: stash.rrule.rrule,
+        anchorDate: stash.rrule.anchorDate,
+      });
+    }
+  };
+
+  const updateLunar = (patch: Partial<LunarConfigForm>) => {
+    onChange({ ...current, lunar: { ...lunar, ...patch } });
+  };
 
   return (
     <div className="space-y-4">
@@ -49,28 +166,145 @@ export function StaticScheduleConfigPanel({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="ss-rrule">Recurrence Rule (RRULE) *</Label>
-        <Input
-          id="ss-rrule"
-          value={current.rrule ?? ""}
-          onChange={(e) =>
-            onChange({ ...current, rrule: e.target.value || undefined })
-          }
-          placeholder="FREQ=WEEKLY;BYDAY=SA"
-        />
+        <Label htmlFor="ss-mode">Recurrence Mode *</Label>
+        <Select value={mode} onValueChange={(v) => setMode(v as "rrule" | "lunar")}>
+          <SelectTrigger id="ss-mode">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="rrule">RRULE (calendar — weekly, monthly, etc.)</SelectItem>
+            <SelectItem value="lunar">Lunar phase (full or new moon)</SelectItem>
+          </SelectContent>
+        </Select>
         <p className="text-xs text-muted-foreground">
-          RFC 5545 RRULE string. Examples:{" "}
-          <code className="rounded bg-muted px-1">FREQ=WEEKLY;BYDAY=SA</code>{" "}
-          (every Saturday),{" "}
-          <code className="rounded bg-muted px-1">FREQ=WEEKLY;INTERVAL=2;BYDAY=SA</code>{" "}
-          (biweekly),{" "}
-          <code className="rounded bg-muted px-1">FREQ=MONTHLY;BYDAY=2SA</code>{" "}
-          (2nd Saturday of month).
+          Use Lunar mode for kennels that run on the full or new moon (e.g. FMH3,
+          DCFMH3). Otherwise use RRULE.
         </p>
       </div>
 
+      {mode === "rrule" && (
+        <div className="space-y-2">
+          <Label htmlFor="ss-rrule">Recurrence Rule (RRULE) *</Label>
+          <Input
+            id="ss-rrule"
+            value={current.rrule ?? ""}
+            onChange={(e) =>
+              onChange({ ...current, rrule: e.target.value || undefined })
+            }
+            placeholder="FREQ=WEEKLY;BYDAY=SA"
+          />
+          <p className="text-xs text-muted-foreground">
+            RFC 5545 RRULE string. Examples:{" "}
+            <code className="rounded bg-muted px-1">FREQ=WEEKLY;BYDAY=SA</code>{" "}
+            (every Saturday),{" "}
+            <code className="rounded bg-muted px-1">FREQ=WEEKLY;INTERVAL=2;BYDAY=SA</code>{" "}
+            (biweekly),{" "}
+            <code className="rounded bg-muted px-1">FREQ=MONTHLY;BYDAY=2SA</code>{" "}
+            (2nd Saturday of month).
+          </p>
+        </div>
+      )}
+
+      {mode === "lunar" && (
+        <div className="space-y-4 rounded-md border bg-muted/30 p-3">
+          <div className="space-y-2">
+            <Label htmlFor="ss-lunar-phase">Lunar Phase *</Label>
+            <Select
+              value={lunar.phase ?? "full"}
+              onValueChange={(v) => updateLunar({ phase: v as "full" | "new" })}
+            >
+              <SelectTrigger id="ss-lunar-phase">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="full">Full moon</SelectItem>
+                <SelectItem value="new">New moon</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="ss-lunar-tz">Kennel Timezone *</Label>
+            <Input
+              id="ss-lunar-tz"
+              value={lunar.timezone ?? ""}
+              onChange={(e) => updateLunar({ timezone: e.target.value })}
+              placeholder="America/Los_Angeles"
+            />
+            <p className="text-xs text-muted-foreground">
+              IANA timezone the kennel operates in. The phase instant is
+              converted to the calendar date in this zone — e.g. a full moon at
+              03:00 UTC is the previous day in Honolulu but the same day in London.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="ss-lunar-anchor-weekday">Anchor Weekday</Label>
+              <Select
+                value={lunar.anchorWeekday ?? ANCHOR_NONE}
+                onValueChange={(v) =>
+                  updateLunar({
+                    anchorWeekday:
+                      v === ANCHOR_NONE
+                        ? undefined
+                        : (v as NonNullable<LunarConfigForm["anchorWeekday"]>),
+                    // Anchor weekday + rule are an XOR pair — clearing one
+                    // clears the other; setting one defaults to "nearest".
+                    anchorRule: v === ANCHOR_NONE ? undefined : (lunar.anchorRule ?? "nearest"),
+                  })
+                }
+              >
+                <SelectTrigger id="ss-lunar-anchor-weekday">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ANCHOR_NONE}>None (exact phase date)</SelectItem>
+                  {WEEKDAY_OPTIONS.map((d) => (
+                    <SelectItem key={d.value} value={d.value}>
+                      {d.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="ss-lunar-anchor-rule">Anchor Rule</Label>
+              <Select
+                // Radix Select requires non-empty value; sentinel for the
+                // disabled-Select state when no anchor weekday is chosen.
+                value={lunar.anchorRule ?? ANCHOR_NONE}
+                onValueChange={(v) =>
+                  updateLunar({
+                    anchorRule: v as NonNullable<LunarConfigForm["anchorRule"]>,
+                  })
+                }
+                disabled={!lunar.anchorWeekday}
+              >
+                <SelectTrigger id="ss-lunar-anchor-rule">
+                  <SelectValue placeholder={lunar.anchorWeekday ? "Pick a rule" : "Anchor disabled"} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="nearest">Nearest weekday</SelectItem>
+                  <SelectItem value="on-or-after">On or after phase</SelectItem>
+                  <SelectItem value="on-or-before">On or before phase</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Anchor mode snaps the event to the nearest matching weekday relative
+            to the astronomical phase — useful for kennels like DCFMH3
+            (&quot;Friday/Saturday near full moon&quot;). Leave anchor weekday set to
+            <em> None</em> to land directly on the phase date.
+          </p>
+        </div>
+      )}
+
       <div className="space-y-2">
-        <Label htmlFor="ss-anchor-date">Anchor Date</Label>
+        <Label htmlFor="ss-anchor-date">RRULE Anchor Date</Label>
         <Input
           id="ss-anchor-date"
           value={current.anchorDate ?? ""}
@@ -78,10 +312,11 @@ export function StaticScheduleConfigPanel({
             onChange({ ...current, anchorDate: e.target.value || undefined })
           }
           placeholder="2026-01-03"
+          disabled={mode === "lunar"}
         />
         <p className="text-xs text-muted-foreground">
-          YYYY-MM-DD of a known past occurrence. Required for INTERVAL &gt; 1 to
-          keep generated dates stable between scrapes.
+          YYYY-MM-DD of a known past occurrence. Required for RRULE INTERVAL &gt; 1
+          to keep generated dates stable between scrapes. Ignored in Lunar mode.
         </p>
       </div>
 

--- a/src/components/hareline/CalendarView.tsx
+++ b/src/components/hareline/CalendarView.tsx
@@ -113,6 +113,32 @@ function dateKeyFromParts(y: number, m: number, d: number): string {
 
 type CalendarMode = "month" | "weeks";
 
+/**
+ * Decorative moon-phase glyph rendered in the calendar day-cell corner.
+ * Extracted from `renderDayCell` so the cell renderer stays under
+ * SonarCloud's cognitive-complexity cap.
+ */
+function MoonPhaseGlyph({ phase }: Readonly<{ phase: "full" | "new" | null }>) {
+  if (!phase) return null;
+  const label = phase === "full" ? "Full moon" : "New moon";
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="text-xs leading-none"
+          aria-label={`${phase} moon (your local sky)`}
+          data-testid={`moon-phase-${phase}`}
+        >
+          {MOON_PHASE_GLYPHS[phase]}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {label} in your local sky. Lunar kennels in other regions may run a day earlier or later.
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 export function CalendarView({ events, timeFilter }: CalendarViewProps) {
   const router = useRouter();
   const { preference: timePref } = useTimePreference();
@@ -409,23 +435,7 @@ export function CalendarView({ events, timeFilter }: CalendarViewProps) {
         >
           {dayLabel}
           {isToday && <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />}
-          {moonPhase && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="text-xs leading-none"
-                  aria-label={`${moonPhase} moon (your local sky)`}
-                  data-testid={`moon-phase-${moonPhase}`}
-                >
-                  {MOON_PHASE_GLYPHS[moonPhase]}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                {moonPhase === "full" ? "Full moon" : "New moon"} in your local sky.
-                Lunar kennels in other regions may run a day earlier or later.
-              </TooltipContent>
-            </Tooltip>
-          )}
+          <MoonPhaseGlyph phase={moonPhase} />
         </span>
         {dayEvents.length > 0 && (
           <div className="mt-0.5 flex flex-col gap-1">

--- a/src/components/hareline/CalendarView.tsx
+++ b/src/components/hareline/CalendarView.tsx
@@ -20,6 +20,7 @@ import { EventCard, type HarelineEvent } from "./EventCard";
 import { regionColorClasses, regionBgClass, regionAbbrev, formatTimeCompact, formatTime } from "@/lib/format";
 import { getRegionColor } from "@/lib/region";
 import { getTimezoneAbbreviation, getBrowserTimezone, formatTimeInZone } from "@/lib/timezone";
+import { getMoonPhaseGlyphForDate, MOON_PHASE_GLYPHS } from "@/lib/moon-phase";
 import { useTimePreference } from "@/components/providers/time-preference-provider";
 import { type TimeFilter, WEEKS_DAYS } from "./HarelineView";
 
@@ -119,6 +120,16 @@ export function CalendarView({ events, timeFilter }: CalendarViewProps) {
   const [year, setYear] = useState(today.getUTCFullYear());
   const [month, setMonth] = useState(today.getUTCMonth());
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
+  // viewerTimezone resolves only after mount. During SSR and the first client
+  // render, `getBrowserTimezone()` would return the server's zone (typically
+  // UTC) — re-rendering with the actual viewer zone after hydration could
+  // shift the glyph to a different day, producing a React hydration warning.
+  // Codex pass-6 finding — fixed by deferring the glyph until the client
+  // timezone is known. The `null` initial state suppresses the glyph.
+  const [viewerTimezone, setViewerTimezone] = useState<string | null>(null);
+  useEffect(() => {
+    setViewerTimezone(getBrowserTimezone());
+  }, []);
 
   // Calendar mode: auto-switch to weeks when a rolling filter is active
   const [calendarMode, setCalendarModeState] = useState<CalendarMode>(
@@ -354,6 +365,13 @@ export function CalendarView({ events, timeFilter }: CalendarViewProps) {
     const isSelected = dateKey === selectedDay;
     const isPast = cellDate < todayDate && !isToday;
     const day = cellDate.getUTCDate();
+    // Glyph marks the calendar day the moon is full/new in the *viewer's*
+    // local sky. For lunar kennels in the viewer's region this matches the
+    // event date; for kennels far from the viewer's timezone the glyph and
+    // event can land on adjacent days (the tooltip calls this out). Glyph
+    // is suppressed during SSR / pre-hydration to avoid a server-vs-client
+    // timezone mismatch (Codex pass-6 finding).
+    const moonPhase = viewerTimezone ? getMoonPhaseGlyphForDate(cellDate, viewerTimezone) : null;
 
     const fullDateLabel = ariaDateFormatter.format(cellDate);
     const cellAriaLabel = buildCellLabel(fullDateLabel, dayEvents.length);
@@ -391,6 +409,23 @@ export function CalendarView({ events, timeFilter }: CalendarViewProps) {
         >
           {dayLabel}
           {isToday && <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />}
+          {moonPhase && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="text-xs leading-none"
+                  aria-label={`${moonPhase} moon (your local sky)`}
+                  data-testid={`moon-phase-${moonPhase}`}
+                >
+                  {MOON_PHASE_GLYPHS[moonPhase]}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {moonPhase === "full" ? "Full moon" : "New moon"} in your local sky.
+                Lunar kennels in other regions may run a day earlier or later.
+              </TooltipContent>
+            </Tooltip>
+          )}
         </span>
         {dayEvents.length > 0 && (
           <div className="mt-0.5 flex flex-col gap-1">

--- a/src/lib/moon-phase.test.ts
+++ b/src/lib/moon-phase.test.ts
@@ -113,6 +113,25 @@ describe("MOON_PHASE_GLYPHS", () => {
   });
 });
 
+/** Walk a 5-day window centered on `centerDay` and return the dates that
+ *  glyph as `phase` in the given timezone. Hoisted to module scope so the
+ *  closure isn't recreated per test (SonarCloud S7721). */
+function findGlyphDays(
+  yearMonthPrefix: string,
+  centerDay: number,
+  phase: "full" | "new",
+  timezone: string,
+): string[] {
+  const matches: string[] = [];
+  for (let day = centerDay - 2; day <= centerDay + 2; day++) {
+    const dateStr = `${yearMonthPrefix}${String(day).padStart(2, "0")}`;
+    if (getMoonPhaseGlyphForDate(utcDate(dateStr), timezone) === phase) {
+      matches.push(dateStr);
+    }
+  }
+  return matches;
+}
+
 describe("getMoonPhaseGlyphForDate timezone awareness", () => {
   // Codex pass-2 finding: marking glyphs at noon UTC drifts by a day for any
   // viewer west of UTC. Marker must fire on the viewer's local calendar day
@@ -121,24 +140,6 @@ describe("getMoonPhaseGlyphForDate timezone awareness", () => {
   // USNO 2026 full-moon UTC instants used in these tests:
   //   May  1 2026 09:23 UTC  (chosen — late morning UTC, day-stable across zones)
   //   Aug 28 2026 04:18 UTC  (chosen — early UTC, expected to differ between LA and Tokyo)
-
-  /** Walk a 5-day window centered on `centerDay` and return the dates that
-   *  glyph as `phase` in the given timezone. */
-  function findGlyphDays(
-    yearMonthPrefix: string,
-    centerDay: number,
-    phase: "full" | "new",
-    timezone: string,
-  ): string[] {
-    const matches: string[] = [];
-    for (let day = centerDay - 2; day <= centerDay + 2; day++) {
-      const dateStr = `${yearMonthPrefix}${String(day).padStart(2, "0")}`;
-      if (getMoonPhaseGlyphForDate(utcDate(dateStr), timezone) === phase) {
-        matches.push(dateStr);
-      }
-    }
-    return matches;
-  }
 
   it("UTC and LA both mark the May 1 2026 full moon (UTC instant 09:23 — same calendar day in both)", () => {
     // 09:23 UTC on May 1 = 02:23 PDT on May 1 — same calendar day in both.

--- a/src/lib/moon-phase.test.ts
+++ b/src/lib/moon-phase.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "vitest";
+import { getMoonPhaseGlyphForDate, MOON_PHASE_GLYPHS } from "./moon-phase";
+
+/**
+ * Per the spec, exactly one calendar day per ~29.5-day cycle should be
+ * marked for each phase. The implementation uses adjacent-day local-minimum
+ * comparison rather than a fixed threshold so that:
+ *   1. There is always exactly one marker per cycle (no zero-marker months
+ *      from a noon-UTC sample falling outside the threshold).
+ *   2. Adjacent equal-distance days break deterministically toward the earlier
+ *      date (no two-day double-marking).
+ *
+ * USNO ground truth for full moons in Jan-Apr 2026 (UTC):
+ *   Jan 3, Feb 1, Mar 3, Apr 1.
+ * Returned glyph day in UTC may be ±1 from the strict UTC instant date when
+ * the astronomical phase falls within ~12h of a UTC midnight; this asserts
+ * the expected ±1 day window.
+ */
+function utcDate(yyyyMmDd: string): Date {
+  return new Date(`${yyyyMmDd}T12:00:00Z`);
+}
+
+describe("getMoonPhaseGlyphForDate", () => {
+  it("marks exactly one day per cycle for full moon — Jan 2026", () => {
+    const phaseDays: string[] = [];
+    for (let day = 1; day <= 31; day++) {
+      const dateStr = `2026-01-${String(day).padStart(2, "0")}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr)) === "full") {
+        phaseDays.push(dateStr);
+      }
+    }
+    expect(phaseDays).toHaveLength(1);
+    // USNO: Jan 3, 2026 10:03 UTC. Glyph could be Jan 3 (most likely) or Jan 2/4.
+    expect(["2026-01-02", "2026-01-03", "2026-01-04"]).toContain(phaseDays[0]);
+  });
+
+  it("marks exactly one day per cycle for new moon — Jan 2026", () => {
+    const phaseDays: string[] = [];
+    for (let day = 1; day <= 31; day++) {
+      const dateStr = `2026-01-${String(day).padStart(2, "0")}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr)) === "new") {
+        phaseDays.push(dateStr);
+      }
+    }
+    expect(phaseDays).toHaveLength(1);
+    // USNO: Jan 18, 2026 19:52 UTC.
+    expect(["2026-01-17", "2026-01-18", "2026-01-19"]).toContain(phaseDays[0]);
+  });
+
+  it("returns null for a quarter moon day (not full, not new)", () => {
+    // Roughly 1 week after a full moon — a third quarter, not at either extreme.
+    // USNO Feb 1 2026 full → ~Feb 9 third quarter.
+    expect(getMoonPhaseGlyphForDate(utcDate("2026-02-09"))).toBeNull();
+  });
+
+  it("returns null for the day immediately after a full moon (no double-marking)", () => {
+    // After the full-moon day, the next day's distance must be > the full-moon
+    // day's distance, so the glyph does NOT fire on day+1.
+    const fullDays: string[] = [];
+    const candidateDays = ["2026-01-02", "2026-01-03", "2026-01-04"] as const;
+    for (const dateStr of candidateDays) {
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr)) === "full") {
+        fullDays.push(dateStr);
+      }
+    }
+    expect(fullDays).toHaveLength(1);
+  });
+
+  it("marks 12-13 full moons in calendar year 2026", () => {
+    const fullMoonDays: string[] = [];
+    const start = new Date("2026-01-01T12:00:00Z");
+    const end = new Date("2026-12-31T12:00:00Z");
+    for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+      if (getMoonPhaseGlyphForDate(new Date(d)) === "full") {
+        fullMoonDays.push(d.toISOString().slice(0, 10));
+      }
+    }
+    expect(fullMoonDays.length).toBeGreaterThanOrEqual(12);
+    expect(fullMoonDays.length).toBeLessThanOrEqual(13);
+  });
+
+  it("marks 12-13 new moons in calendar year 2026", () => {
+    const newMoonDays: string[] = [];
+    const start = new Date("2026-01-01T12:00:00Z");
+    const end = new Date("2026-12-31T12:00:00Z");
+    for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+      if (getMoonPhaseGlyphForDate(new Date(d)) === "new") {
+        newMoonDays.push(d.toISOString().slice(0, 10));
+      }
+    }
+    expect(newMoonDays.length).toBeGreaterThanOrEqual(12);
+    expect(newMoonDays.length).toBeLessThanOrEqual(13);
+  });
+
+  it("never marks the same day as both full and new", () => {
+    const start = new Date("2026-01-01T12:00:00Z");
+    const end = new Date("2026-12-31T12:00:00Z");
+    for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+      const glyph = getMoonPhaseGlyphForDate(new Date(d));
+      // We want phase to be exactly one of "full"|"new"|null, never overlap.
+      // (The guard in implementation iterates phases in priority order.)
+      if (glyph !== null) {
+        expect(["full", "new"]).toContain(glyph);
+      }
+    }
+  });
+});
+
+describe("MOON_PHASE_GLYPHS", () => {
+  it("exposes a glyph for each phase", () => {
+    expect(MOON_PHASE_GLYPHS.full).toBeTruthy();
+    expect(MOON_PHASE_GLYPHS.new).toBeTruthy();
+  });
+});
+
+describe("getMoonPhaseGlyphForDate timezone awareness", () => {
+  // Codex pass-2 finding: marking glyphs at noon UTC drifts by a day for any
+  // viewer west of UTC. Marker must fire on the viewer's local calendar day
+  // matching the lunar adapter's `lunarInstantToLocalDate` assignment.
+  //
+  // USNO 2026 full-moon UTC instants used in these tests:
+  //   May  1 2026 09:23 UTC  (chosen — late morning UTC, day-stable across zones)
+  //   Aug 28 2026 04:18 UTC  (chosen — early UTC, expected to differ between LA and Tokyo)
+
+  /** Walk a 5-day window centered on `centerDay` and return the dates that
+   *  glyph as `phase` in the given timezone. */
+  function findGlyphDays(
+    yearMonthPrefix: string,
+    centerDay: number,
+    phase: "full" | "new",
+    timezone: string,
+  ): string[] {
+    const matches: string[] = [];
+    for (let day = centerDay - 2; day <= centerDay + 2; day++) {
+      const dateStr = `${yearMonthPrefix}${String(day).padStart(2, "0")}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr), timezone) === phase) {
+        matches.push(dateStr);
+      }
+    }
+    return matches;
+  }
+
+  it("UTC and LA both mark the May 1 2026 full moon (UTC instant 09:23 — same calendar day in both)", () => {
+    // 09:23 UTC on May 1 = 02:23 PDT on May 1 — same calendar day in both.
+    const utcMatches = findGlyphDays("2026-05-", 1, "full", "UTC");
+    const laMatches = findGlyphDays("2026-05-", 1, "full", "America/Los_Angeles");
+    expect(utcMatches).toEqual(["2026-05-01"]);
+    expect(laMatches).toEqual(["2026-05-01"]);
+  });
+
+  it("Aug 28 2026 04:18 UTC full moon: LA sees Aug 27, UTC sees Aug 28", () => {
+    // 04:18 UTC on Aug 28 = 21:18 PDT on Aug 27 (UTC-7). LA's local day is Aug 27.
+    const utcMatches = findGlyphDays("2026-08-", 28, "full", "UTC");
+    const laMatches = findGlyphDays("2026-08-", 28, "full", "America/Los_Angeles");
+    expect(utcMatches).toEqual(["2026-08-28"]);
+    expect(laMatches).toEqual(["2026-08-27"]);
+  });
+
+  it("defaults to UTC when no timezone is supplied (backwards compat)", () => {
+    const withDefault = getMoonPhaseGlyphForDate(utcDate("2026-05-01"));
+    const withUtc = getMoonPhaseGlyphForDate(utcDate("2026-05-01"), "UTC");
+    expect(withDefault).toBe(withUtc);
+  });
+
+  it("invalid timezone falls back to UTC instead of crashing", () => {
+    expect(() => getMoonPhaseGlyphForDate(utcDate("2026-05-01"), "Not/A_Real_Tz")).not.toThrow();
+  });
+
+  it("UTC+14 (Pacific/Kiritimati) handles day-rollover correctly", () => {
+    // Codex pass-3 finding: the original "extract only the hour" offset math
+    // miscomputed UTC+14 zones because noon UTC formats as "02" in Kiritimati
+    // (next day), giving offset 2 instead of -22. The fixed implementation
+    // uses full-component extraction and day-rollover-correct arithmetic.
+    // Expected: Kiritimati's local-noon sample for May 1 2026 is 8h22m before
+    // the May 1 09:23 UTC full moon → distance is small and a glyph day fires
+    // somewhere in the May 1 ± 1 day window. Just assert no crash + glyph
+    // appears within 5 days.
+    const matches: string[] = [];
+    for (let day = 1; day <= 5; day++) {
+      const dateStr = `2026-05-0${day}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr), "Pacific/Kiritimati") === "full") {
+        matches.push(dateStr);
+      }
+    }
+    expect(matches).toHaveLength(1);
+  });
+
+  it("UTC+5:45 (Asia/Kathmandu, half-/quarter-hour offset) handles minute offsets", () => {
+    // The "hour only" offset math miscomputed half-hour zones by up to ~30
+    // minutes, which is enough to flip the local-min comparison at boundary
+    // dates. Verify the Kathmandu case produces exactly one full-moon glyph.
+    const matches: string[] = [];
+    for (let day = 1; day <= 5; day++) {
+      const dateStr = `2026-05-0${day}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr), "Asia/Kathmandu") === "full") {
+        matches.push(dateStr);
+      }
+    }
+    expect(matches).toHaveLength(1);
+  });
+
+  it("UTC+9:30 (Australia/Adelaide, half-hour offset) handles minute offsets", () => {
+    const matches: string[] = [];
+    for (let day = 1; day <= 5; day++) {
+      const dateStr = `2026-05-0${day}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr), "Australia/Adelaide") === "full") {
+        matches.push(dateStr);
+      }
+    }
+    expect(matches).toHaveLength(1);
+  });
+
+  it("LA never marks a calendar day strictly later than Tokyo for the same astronomical phase", () => {
+    // The astronomical phase is at one UTC instant; LA (UTC-7/8) is always
+    // behind Tokyo (UTC+9), so Tokyo's local calendar day for the same phase
+    // is the same or LATER than LA's. Verify across a full 2026 calendar year.
+    for (let month = 0; month < 12; month++) {
+      const monthStr = `2026-${String(month + 1).padStart(2, "0")}-`;
+      const laDays: string[] = [];
+      const tokyoDays: string[] = [];
+      const daysInMonth = new Date(Date.UTC(2026, month + 1, 0)).getUTCDate();
+      for (let day = 1; day <= daysInMonth; day++) {
+        const dateStr = `${monthStr}${String(day).padStart(2, "0")}`;
+        if (getMoonPhaseGlyphForDate(utcDate(dateStr), "America/Los_Angeles") === "full") {
+          laDays.push(dateStr);
+        }
+        if (getMoonPhaseGlyphForDate(utcDate(dateStr), "Asia/Tokyo") === "full") {
+          tokyoDays.push(dateStr);
+        }
+      }
+      // For each LA mark, Tokyo's matching mark must be on the same or later day.
+      // (LA may mark in this month and Tokyo may mark in the next month.)
+      // Just assert no cross-zone inversion within the month.
+      if (laDays.length > 0 && tokyoDays.length > 0) {
+        expect(tokyoDays[0] >= laDays[0]).toBe(true);
+      }
+    }
+  });
+
+  it("DST spring-forward boundary in America/New_York (Mar 8 2026) marks one full moon", () => {
+    // Codex pass-5 finding: neighbor-day sampling via ±24h is wrong on DST
+    // transitions where consecutive local noons are 23 or 25 hours apart.
+    // Mar 3 2026 is a full moon, Mar 8 2026 is the US DST start. Verify
+    // exactly one full-moon glyph fires in a window straddling the DST
+    // transition — proves the per-day local-noon resampling holds.
+    const matches: string[] = [];
+    for (let day = 1; day <= 12; day++) {
+      const dateStr = `2026-03-${String(day).padStart(2, "0")}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr), "America/New_York") === "full") {
+        matches.push(dateStr);
+      }
+    }
+    expect(matches).toHaveLength(1);
+  });
+
+  it("DST fall-back boundary in America/New_York (Nov 1 2026) does not double-mark", () => {
+    // Window straddling the fall-back transition for the Oct 26 2026 full
+    // moon (USNO 23:11 UTC). Verify no double-mark or missed mark.
+    const matches: string[] = [];
+    for (let day = 21; day <= 31; day++) {
+      const dateStr = `2026-10-${String(day).padStart(2, "0")}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr), "America/New_York") === "full") {
+        matches.push(dateStr);
+      }
+    }
+    for (let day = 1; day <= 5; day++) {
+      const dateStr = `2026-11-0${day}`;
+      if (getMoonPhaseGlyphForDate(utcDate(dateStr), "America/New_York") === "full") {
+        matches.push(dateStr);
+      }
+    }
+    expect(matches).toHaveLength(1);
+  });
+});

--- a/src/lib/moon-phase.ts
+++ b/src/lib/moon-phase.ts
@@ -1,0 +1,176 @@
+/**
+ * Moon-phase glyph helper for the public hareline calendar view.
+ *
+ * Pure decoration — visually marks the day of each full and new moon in the
+ * calendar grid so users can correlate the lunar STATIC_SCHEDULE entries with
+ * the cycle. The actual occurrence dates for lunar kennels are rendered via
+ * the existing canonical-event pipeline; this helper just adds a glyph in the
+ * day-cell corner.
+ *
+ * Algorithm matches the lunar adapter's `phaseDistance` wraparound math: the
+ * day's noon-UTC phase distance to the target is compared to its neighbors,
+ * and the day is marked only when it's the local minimum of the cycle. This
+ * guarantees exactly one glyph per cycle and avoids two-day double-marking
+ * at threshold boundaries.
+ *
+ * See `moon-phase.test.ts` for the behavioral specification.
+ */
+
+import SunCalc from "suncalc";
+
+/**
+ * Wraparound-safe distance between two phase fractions in [0, 1).
+ *
+ * Inlined here (rather than imported from `@/adapters/static-schedule/lunar`)
+ * because this module is loaded by the public hareline calendar — a client
+ * component. The adapter's `lunar.ts` transitively imports server-only modules
+ * (`safe-fetch` → `node:dns/promises`, `structure-hash` → `node:crypto`) via
+ * `../utils`, which would either explode the client bundle or fail at build
+ * time. Codex pass-6 finding — fixed here.
+ *
+ * The implementation mirrors the lunar adapter's helper exactly. If both
+ * grow non-trivial, a shared client-safe `src/lib/phase-math.ts` would be
+ * the next step; for two lines, duplication is honest and lower-risk.
+ */
+function phaseDistance(actualPhase: number, targetPhase: number): number {
+  const d = Math.abs(actualPhase - targetPhase);
+  return Math.min(d, 1 - d);
+}
+
+/** Public emoji glyphs matching the canonical Unicode moon-phase set. */
+export const MOON_PHASE_GLYPHS = {
+  full: "🌕",
+  new: "🌑",
+} as const;
+
+/** Phase distance threshold for early skip — days well outside the cycle peak. */
+const NEAR_PHASE_THRESHOLD = 0.05;
+
+/**
+ * Return "full", "new", or null for a given calendar day, evaluated against
+ * the supplied IANA timezone.
+ *
+ * The day is marked only when its phase distance to the target (0.5 for full,
+ * 0.0 for new) is the local minimum compared to the previous and next day,
+ * sampled at noon **in the supplied timezone**. This matches the lunar
+ * adapter's date-assignment rule (`lunarInstantToLocalDate`) so the glyph
+ * fires on the same calendar day a lunar kennel in that timezone would
+ * publish an event for. Pass `"UTC"` if no timezone-correlation is wanted.
+ *
+ * Without timezone support, a US-West-Coast user looking at the calendar
+ * would see the glyph on the day AFTER an FMH3 SF event. Codex pass-2
+ * finding — fixed here.
+ *
+ * `date` is interpreted as a UTC-noon date (the project's canonical day
+ * representation); only the date components are read.
+ */
+export function getMoonPhaseGlyphForDate(
+  date: Date,
+  timezone = "UTC",
+): "full" | "new" | null {
+  // Resolve neighbor days through the same `localNoonInTimezoneMs` helper so
+  // each sample is genuinely at local noon for its calendar day. Codex pass-5
+  // finding: a naive `today ± 24h` is wrong on DST-transition days where
+  // consecutive local noons are 23 or 25 hours apart, which can flip the
+  // local-min comparison and mark/miss the wrong day.
+  const yesterdayDateStr = utcDateString(addUtcDays(date, -1));
+  const todayDateStr = utcDateString(date);
+  const tomorrowDateStr = utcDateString(addUtcDays(date, 1));
+  const yesterdayLocalNoonMs = localNoonInTimezoneMs(yesterdayDateStr, timezone);
+  const todayLocalNoonMs = localNoonInTimezoneMs(todayDateStr, timezone);
+  const tomorrowLocalNoonMs = localNoonInTimezoneMs(tomorrowDateStr, timezone);
+
+  for (const phase of ["full", "new"] as const) {
+    const target = phase === "full" ? 0.5 : 0;
+    const today = phaseDistance(
+      SunCalc.getMoonIllumination(new Date(todayLocalNoonMs)).phase,
+      target,
+    );
+    if (today > NEAR_PHASE_THRESHOLD) continue;
+    const yesterday = phaseDistance(
+      SunCalc.getMoonIllumination(new Date(yesterdayLocalNoonMs)).phase,
+      target,
+    );
+    const tomorrow = phaseDistance(
+      SunCalc.getMoonIllumination(new Date(tomorrowLocalNoonMs)).phase,
+      target,
+    );
+    // Strict-LT on the previous side, non-strict on the next side: deterministic
+    // tie-break to the earlier date when two consecutive samples are equal.
+    if (today < yesterday && today <= tomorrow) {
+      return phase;
+    }
+  }
+  return null;
+}
+
+/** Format a Date's UTC date components as YYYY-MM-DD. */
+function utcDateString(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Add `days` to a Date's UTC date components and return a new Date. */
+function addUtcDays(d: Date, days: number): Date {
+  return new Date(Date.UTC(
+    d.getUTCFullYear(),
+    d.getUTCMonth(),
+    d.getUTCDate() + days,
+    12, 0, 0,
+  ));
+}
+
+/**
+ * Resolve `YYYY-MM-DD` + IANA timezone to the UTC ms timestamp that represents
+ * 12:00 local time on that calendar day. Falls back to UTC noon if the
+ * timezone is invalid.
+ *
+ * Implementation: project the UTC-noon anchor into the requested zone via
+ * `formatToParts`, read every component (year/month/day/hour/minute), and
+ * compute the full delta — including day rollover and minute offsets. A
+ * naive "extract only the hour" approach miscomputes UTC+13/+14 (Kiritimati,
+ * day-rollover) and half-/quarter-hour zones (Kathmandu UTC+5:45, Adelaide
+ * UTC+9:30). Codex pass-3 finding — fixed here.
+ */
+function localNoonInTimezoneMs(dateStr: string, timezone: string): number {
+  const [yStr, mStr, dStr] = dateStr.split("-");
+  const y = Number.parseInt(yStr, 10);
+  const m = Number.parseInt(mStr, 10) - 1;
+  const d = Number.parseInt(dStr, 10);
+  const utcNoonMs = Date.UTC(y, m, d, 12, 0, 0);
+
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(new Date(utcNoonMs));
+  } catch {
+    return utcNoonMs;
+  }
+
+  const lookup: Record<string, string> = {};
+  for (const p of parts) {
+    if (p.type !== "literal") lookup[p.type] = p.value;
+  }
+  const localUtcEquivalentMs = Date.UTC(
+    Number.parseInt(lookup.year, 10),
+    Number.parseInt(lookup.month, 10) - 1,
+    Number.parseInt(lookup.day, 10),
+    Number.parseInt(lookup.hour, 10),
+    Number.parseInt(lookup.minute, 10),
+    0,
+  );
+  // The zone's offset (in ms) at the anchor — positive for east of UTC.
+  const offsetMs = localUtcEquivalentMs - utcNoonMs;
+  // Local noon for `dateStr` at this offset = UTC midnight + 12h − offset.
+  const utcMidnightMs = Date.UTC(y, m, d, 0, 0, 0);
+  return utcMidnightMs + 12 * 60 * 60 * 1000 - offsetMs;
+}

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -87,22 +87,28 @@ export function getTimezoneAbbreviation(date: Date, timezone: string): string {
 }
 
 /**
- * Returns "today" as YYYY-MM-DD in the given IANA timezone. Used for trip
- * status comparisons (isPast / isSoon) so a Hawaii trip ending 2026-04-14
- * stays "active" while it's still 2026-04-14 in Honolulu, even after UTC
- * has rolled into 2026-04-15.
- *
- * en-CA + 2-digit components yields YYYY-MM-DD reliably across modern Node
- * and browsers. Falls back to the UTC date if the tz is invalid.
+ * Format any Date as YYYY-MM-DD in the given IANA timezone. Falls back to
+ * UTC if the timezone is invalid. en-CA + 2-digit components yields the ISO
+ * date reliably across modern Node and browsers.
  */
-export function todayInTimezone(timezone: string | null | undefined): string {
+export function formatYmdInTimezone(date: Date, timezone: string | null | undefined): string {
     const tz = timezone && isValidTimezone(timezone) ? timezone : "UTC";
     return new Intl.DateTimeFormat("en-CA", {
         timeZone: tz,
         year: "numeric",
         month: "2-digit",
         day: "2-digit",
-    }).format(new Date());
+    }).format(date);
+}
+
+/**
+ * Returns "today" as YYYY-MM-DD in the given IANA timezone. Used for trip
+ * status comparisons (isPast / isSoon) so a Hawaii trip ending 2026-04-14
+ * stays "active" while it's still 2026-04-14 in Honolulu, even after UTC
+ * has rolled into 2026-04-15.
+ */
+export function todayInTimezone(timezone: string | null | undefined): string {
+    return formatYmdInTimezone(new Date(), timezone);
 }
 
 /**

--- a/src/lib/travel/projections.test.ts
+++ b/src/lib/travel/projections.test.ts
@@ -96,13 +96,38 @@ describe("projectTrails", () => {
     const rules = [makeRule({
       rrule: "FREQ=LUNAR",
       confidence: "LOW",
-      notes: "Full moon schedule",
+      notes: "Lunar full moon, exact phase date in America/Los_Angeles",
     })];
     const results = projectTrails(rules, windowStart, windowEnd);
 
     expect(results).toHaveLength(1);
     expect(results[0].date).toBeNull();
     expect(results[0].confidence).toBe("low");
+    expect(results[0].explanation).toContain("Full moon");
+  });
+
+  it("FREQ=LUNAR with new-moon notes renders as new-moon (Codex pass-5: phase metadata)", () => {
+    const rules = [makeRule({
+      rrule: "FREQ=LUNAR",
+      confidence: "LOW",
+      notes: "Lunar new moon, exact phase date in Asia/Tokyo",
+    })];
+    const results = projectTrails(rules, windowStart, windowEnd);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].date).toBeNull();
+    expect(results[0].explanation).toContain("New moon");
+    expect(results[0].explanation).not.toContain("Full moon");
+  });
+
+  it("FREQ=LUNAR with anchored full-moon notes renders as full-moon", () => {
+    const rules = [makeRule({
+      rrule: "FREQ=LUNAR",
+      confidence: "LOW",
+      notes: "Lunar full moon, anchored to SA (nearest)",
+    })];
+    const results = projectTrails(rules, windowStart, windowEnd);
+
     expect(results[0].explanation).toContain("Full moon");
   });
 

--- a/src/lib/travel/projections.ts
+++ b/src/lib/travel/projections.ts
@@ -383,10 +383,36 @@ function timeSuffix(startTime: string | null | undefined): string {
   return startTime ? ` at ${formatTime(startTime)}` : "";
 }
 
+/**
+ * Extract the lunar phase ("full" | "new") from a backfill-emitted notes
+ * string. Format produced by `runStaticSchedulePass`:
+ *   "Lunar full moon, exact phase date in <tz>"
+ *   "Lunar new moon, anchored to SA (nearest)"
+ *
+ * Returns null when the notes don't follow that pattern (older rules with
+ * only the FREQ=LUNAR sentinel and no notes).
+ */
+function parseLunarPhaseFromNotes(notes: string | null | undefined): "full" | "new" | null {
+  if (!notes) return null;
+  if (/\blunar\s+new\s+moon\b/i.test(notes)) return "new";
+  if (/\blunar\s+full\s+moon\b/i.test(notes)) return "full";
+  return null;
+}
+
 /** Explanation strings for the non-parseable CADENCE / LUNAR sentinels. */
-function explainSentinel(rrule: string, startTime: string | null | undefined): string | null {
+function explainSentinel(
+  rrule: string,
+  startTime: string | null | undefined,
+  notes?: string | null,
+): string | null {
   if (rrule === "FREQ=LUNAR") {
-    return "Full moon schedule — check kennel sources for exact dates";
+    // Phase + anchor metadata is carried in the rule's notes (set by
+    // backfill-schedule-rules.ts). Default to "Full" if notes are missing
+    // or unrecognized, since `phase: "full"` is by far the more common case
+    // in the seed (there's no `phase: "new"` kennel as of this writing).
+    const phase = parseLunarPhaseFromNotes(notes);
+    const phaseLabel = phase === "new" ? "New moon" : "Full moon";
+    return `${phaseLabel} schedule — check kennel sources for exact dates`;
   }
   if (rrule.startsWith("CADENCE=BIWEEKLY")) {
     const day = extractDayFromSentinel(rrule);
@@ -435,7 +461,7 @@ export function generateExplanationFromRule(
 ): string {
   const { rrule, startTime, notes, confidence } = rule;
 
-  const sentinelExplanation = explainSentinel(rrule, startTime);
+  const sentinelExplanation = explainSentinel(rrule, startTime, notes);
   if (sentinelExplanation) return sentinelExplanation;
 
   try {


### PR DESCRIPTION
## Summary

Adds lunar-phase recurrence to the STATIC_SCHEDULE adapter — the first PR in a 3-PR Tier 2 sequence per [`docs/facebook-integration-strategy.md`](docs/facebook-integration-strategy.md).

Kennels that run on the full or new moon (FMH3 SF, DCFMH3 DMV, ~30 MY full-moon kennels in the Phase-2 backlog) can now be seeded as proper sources instead of kennel-only records. Two operating modes:

- **Exact** — event lands on the calendar date of the astronomical phase in the kennel's timezone (FMH3 shape)
- **Anchor** — event snaps to `nearest` / `on-or-after` / `on-or-before` weekday relative to the phase date (DCFMH3 "Fri/Sat near full moon" shape)

**XOR contract**: exactly one of `rrule | lunar` per `StaticScheduleConfig`. Enforced uniformly across the adapter (`validateRruleLunarXor`), the admin form validator (`validateStaticScheduleConfig`), and the ScheduleRule backfill so canonical event generation never disagrees with Travel Mode projections.

**Bonus**: full + new moon glyphs render in the public hareline calendar grid, sampled in the viewer's local timezone. Decorative only — does not change event data.

## Seed canaries

- **SFFMH3** (San Francisco Full Moon) — exact-mode, `America/Los_Angeles`
- **DCFMH3** (DC Full Moon) — anchor-mode, `America/New_York` + Saturday-nearest
- Both at `scrapeDays: 365` since lunar dates are deterministic decades into the future
- **GSH3** stays as the non-lunar control to regression-prove the XOR validation flip doesn't break existing rrule-mode sources

## Travel Mode integration

`scripts/backfill-schedule-rules.ts` emits `FREQ=LUNAR` sentinel rules at LOW confidence with phase + anchor metadata in `notes`. The projection engine in `src/lib/travel/projections.ts` parses the notes for the explanation string so `phase: "new"` kennels render correctly (not as "full moon"). Beyond the materialized event horizon, lunar kennels surface as "possible activity" with `date: null`.

## Review history

12 Codex adversarial-review passes resolved before approval. Highlights:

1. RRULE contract sites + phase wraparound math (initial plan)
2. Source-kennel guard + body-size limit + ScheduleRule path
3. Invalid IANA timezone / anchor enum runtime validation; UTC+14 + half-/quarter-hour offsets handled correctly
4. `localNoonInTimezoneMs` rewritten with `formatToParts` for full-offset arithmetic (handles `Pacific/Kiritimati`, `Asia/Kathmandu`, `Australia/Adelaide`)
5. Backfill XOR enforcement matching adapter contract — dual-config rows now skipped
6. Travel Mode `FREQ=LUNAR` phase parsing from notes
7. DST-boundary neighbor sampling fix
8. Client/SSR boundary: inlined `phaseDistance` in `moon-phase.ts` to break the adapter→server-only-modules import chain; `viewerTimezone` deferred to post-mount via `useEffect`
9. Stash refs → `useState` ("derive state from props") for commit-safe rollback under React concurrent rendering
10. Tightened lunar test tolerance from 36h → 12h + explicit YYYY-MM-DD assertions
11. Mode-toggle no longer destructive (preserves drafts via `useState` stash)
12. Fixed null-config infinite-render loop (compare against `config` prop reference, not derived `current`)

## Test plan

- [ ] Watch CI: `npx tsc --noEmit && npm run lint && npm test` (6084 tests pass locally, 0 lint errors)
- [ ] Verify the new lunar adapter unit tests (37 in `lunar.test.ts`, 9 in `adapter.test.ts`)
- [ ] Verify moon-phase glyph tests (18, including DST + UTC+14 + half-hour offsets)
- [ ] Verify ScheduleRule backfill XOR + lunar branch tests (4 new in `backfill-schedule-rules.test.ts`)
- [ ] Verify Travel Mode projection rendering tests (3 new for FREQ=LUNAR phase metadata)
- [ ] Verify panel pure-helper tests (5 in `StaticScheduleConfigPanel.test.ts`)
- [ ] Manual local: `npx prisma db seed`, scrape SFFMH3 + DCFMH3, confirm dates match USNO ground truth
- [ ] Manual local: visit `/hareline`, confirm moon glyphs appear in the calendar grid in the viewer's local timezone
- [ ] Manual local: open admin source form, switch a STATIC_SCHEDULE source between RRULE and Lunar modes, confirm drafts preserve and saving works

## Out of scope (follow-up PRs)

- **PR 2 (T2c)** — `FACEBOOK_HOSTED_EVENTS` adapter for automated FB Page event scraping (Grand Strand H3 canary)
- **PR 3 (T2b)** — admin paste-a-FB-post flow with URL + text + screenshot modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)