### PR TITLE
perf(merge): batch RawEvent dedup prefetch to fix N+1 in scrape pipeline

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -53,7 +53,38 @@ import { processRawEvents, sanitizeTitle, sanitizeLocation, sanitizeHares, frien
 const mockSourceFind = vi.mocked(prisma.source.findUnique);
 const _mockSourceUpdate = vi.mocked(prisma.source.update);
 const mockSourceKennelFind = vi.mocked(prisma.sourceKennel.findMany);
-const mockRawEventFind = vi.mocked(prisma.rawEvent.findFirst);
+// Compat shim: tests historically seeded the per-event dedup query by mocking
+// `prisma.rawEvent.findFirst`. The N+1 fix in `merge.ts` collapsed that into a
+// single per-batch `prisma.rawEvent.findMany` prefetch (Sentry JAVASCRIPT-NEXTJS-3).
+// This shim preserves the legacy `mockResolvedValueOnce({...})` interface by
+// translating each seeded value into a one-element findMany result keyed by the
+// mocked fingerprint. `null` (no dedup hit) translates to an empty array.
+type DedupSeed = { id: string; processed: boolean; eventId?: string | null } | null;
+// The mocked `generateFingerprint` returns "fp_abc123" by default (see vi.mock above);
+// tests that override that don't seed the dedup map, so this constant is safe.
+const DEFAULT_MOCK_FINGERPRINT = "fp_abc123";
+function seedDedup(value: DedupSeed): unknown[] {
+  if (!value) return [];
+  return [{ fingerprint: DEFAULT_MOCK_FINGERPRINT, eventId: null, ...value }];
+}
+const mockRawEventFind = {
+  mockResolvedValueOnce(value: DedupSeed) {
+    vi.mocked(prisma.rawEvent.findMany).mockResolvedValueOnce(seedDedup(value) as never);
+    return this;
+  },
+  mockResolvedValue(value: DedupSeed) {
+    vi.mocked(prisma.rawEvent.findMany).mockResolvedValue(seedDedup(value) as never);
+    return this;
+  },
+  mockRejectedValueOnce(err: Error) {
+    vi.mocked(prisma.rawEvent.findMany).mockRejectedValueOnce(err);
+    return this;
+  },
+  mockRejectedValue(err: Error) {
+    vi.mocked(prisma.rawEvent.findMany).mockRejectedValue(err);
+    return this;
+  },
+};
 const mockRawEventCreate = vi.mocked(prisma.rawEvent.create);
 const mockRawEventUpdate = vi.mocked(prisma.rawEvent.update);
 const mockEventFindMany = vi.mocked(prisma.event.findMany);
@@ -64,6 +95,12 @@ const mockFingerprint = vi.mocked(generateFingerprint);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `vi.clearAllMocks()` clears call history but does NOT drain `mockResolvedValueOnce`
+  // queues. Drain `prisma.rawEvent.findMany` explicitly because the dedup-prefetch
+  // path (Sentry JAVASCRIPT-NEXTJS-3 fix) added a new findMany call inside
+  // `processRawEvents` that would consume any leftover Once entry from a
+  // preceding test, scrambling the ordering for tests that seed multiple Onces.
+  vi.mocked(prisma.rawEvent.findMany).mockReset();
   mockSourceFind.mockResolvedValue({ trustLevel: 5, type: "HTML_SCRAPER" } as never);
   mockSourceKennelFind.mockResolvedValue([{ kennelId: "kennel_1" }] as never);
   mockRawEventCreate.mockResolvedValue({ id: "raw_1" } as never);
@@ -92,6 +129,64 @@ beforeEach(() => {
 });
 
 describe("processRawEvents", () => {
+  it("dedup prefetch issues exactly one rawEvent.findMany for the whole batch (Sentry JAVASCRIPT-NEXTJS-3)", async () => {
+    // Regression test: the merge loop previously called `prisma.rawEvent.findFirst`
+    // once per incoming event (Sentry flagged this as N+1). The fix collapses the
+    // dedup into a single `rawEvent.findMany({ fingerprint: { in: [...] } })`
+    // before the loop. Lock that in so no future change reintroduces the N+1.
+    const findManyMock = vi.mocked(prisma.rawEvent.findMany);
+    findManyMock.mockReset();
+    // Default empty return covers the prefetch and any in-loop fuzzy probes.
+    findManyMock.mockResolvedValue([] as never);
+    mockEventFindMany.mockResolvedValue([] as never);
+    mockEventCreate.mockResolvedValue({ id: "evt" } as never);
+    // Queue exactly N=3 one-shot returns so no leftover Once entries can bleed
+    // into the next test — `vi.clearAllMocks()` does not drain queues.
+    mockFingerprint
+      .mockReturnValueOnce("fp_a")
+      .mockReturnValueOnce("fp_b")
+      .mockReturnValueOnce("fp_c");
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-04-01" }),
+      buildRawEvent({ date: "2026-04-02" }),
+      buildRawEvent({ date: "2026-04-03" }),
+    ]);
+
+    // Find the prefetch call — it's the one keyed by `fingerprint: { in: [...] }`.
+    const dedupCalls = findManyMock.mock.calls.filter(
+      ([args]) => (args as { where?: { fingerprint?: { in?: unknown } } })?.where?.fingerprint?.in !== undefined,
+    );
+    expect(dedupCalls).toHaveLength(1);
+    expect(dedupCalls[0][0]).toMatchObject({
+      where: { sourceId: "src_1", fingerprint: { in: ["fp_a", "fp_b", "fp_c"] } },
+    });
+  });
+
+  it("treats a duplicate fingerprint within the same batch as a dedup hit (in-memory write-back)", async () => {
+    // Two events fingerprint to the same value. The first creates a new RawEvent;
+    // the second iteration must see the just-created row via the in-memory map
+    // and treat it as a duplicate — no second canonical Event is created.
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_first" } as never);
+    // mockReturnValueOnce (not mockReturnValue) so the implementation override
+    // doesn't persist into the next test's default fingerprint.
+    mockFingerprint.mockReturnValueOnce("fp_dup").mockReturnValueOnce("fp_dup");
+    mockRawEventCreate.mockResolvedValueOnce({ id: "raw_first" } as never);
+    // refreshExistingEvent on the dup-iter path reads the canonical event;
+    // returning null short-circuits the refresh so the test focuses on dedup.
+    vi.mocked(prisma.event.findUnique).mockResolvedValue(null as never);
+
+    const result = await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-04-01" }),
+      buildRawEvent({ date: "2026-04-01" }),
+    ]);
+    expect(result.created).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(mockRawEventCreate).toHaveBeenCalledTimes(1);
+  });
+
   it("skips event when fingerprint already exists (processed)", async () => {
     mockRawEventFind.mockResolvedValueOnce({ id: "existing", processed: true, eventId: "evt_1" } as never);
     const result = await processRawEvents("src_1", [buildRawEvent()]);
@@ -255,13 +350,17 @@ describe("processRawEvents", () => {
   });
 
   it("continues processing after individual event error", async () => {
-    // First event: fingerprint lookup throws
-    mockRawEventFind.mockRejectedValueOnce(new Error("DB error"));
-    // Second event: succeeds
-    mockRawEventFind.mockResolvedValueOnce(null);
+    // Dedup prefetch returns no matches for either fingerprint — both events
+    // are new and pass into `processNewRawEvent`. The first iteration's
+    // RawEvent insert throws; the per-event try/catch in `processRawEvents`
+    // must swallow it and let the second iteration proceed. (The pre-N+1-fix
+    // version of this test threw from `findFirst` per iteration; that path no
+    // longer exists — dedup is now a single batch prefetch outside the loop.)
+    mockRawEventFind.mockResolvedValue(null);
+    mockRawEventCreate.mockRejectedValueOnce(new Error("DB error"));
+    mockRawEventCreate.mockResolvedValueOnce({ id: "raw_2" } as never);
     mockEventFindMany.mockResolvedValueOnce([] as never);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
-    // Need unique fingerprints
     mockFingerprint.mockReturnValueOnce("fp_1").mockReturnValueOnce("fp_2");
 
     const result = await processRawEvents("src_1", [
@@ -431,8 +530,13 @@ describe("source-kennel guard", () => {
 
 describe("mergeErrorDetails", () => {
   it("populates mergeErrorDetails with fingerprint and reason on error", async () => {
-    mockRawEventFind.mockRejectedValueOnce(new Error("DB connection lost"));
-    // generateFingerprint is called twice: once at line 53, once in catch block at line 200
+    // Dedup prefetch returns empty (event is new), then `rawEvent.create` inside
+    // `processNewRawEvent` throws — exercises the per-event try/catch in
+    // `processRawEvents` that records mergeErrorDetails. (Pre-N+1-fix this test
+    // simulated a per-event `findFirst` rejection; that query path is gone now.)
+    mockRawEventFind.mockResolvedValue(null);
+    mockRawEventCreate.mockRejectedValueOnce(new Error("DB connection lost"));
+    // generateFingerprint is called twice: once during prefetch, once in the loop
     mockFingerprint.mockReturnValueOnce("fp_error_event").mockReturnValueOnce("fp_error_event");
 
     const result = await processRawEvents("src_1", [
@@ -446,11 +550,14 @@ describe("mergeErrorDetails", () => {
   });
 
   it("caps mergeErrorDetails at 50 entries", async () => {
-    // Create 55 events that all fail
+    // Create 55 events that all fail. With the dedup prefetch outside the loop,
+    // we simulate per-iteration failure by rejecting `rawEvent.create` instead
+    // of the (now batched) dedup query.
     const events = Array.from({ length: 55 }, (_, i) =>
       buildRawEvent({ date: `2026-03-${String(i + 1).padStart(2, "0")}` }),
     );
-    mockRawEventFind.mockRejectedValue(new Error("Repeated failure"));
+    mockRawEventFind.mockResolvedValue(null);
+    mockRawEventCreate.mockRejectedValue(new Error("Repeated failure"));
 
     const result = await processRawEvents("src_1", events);
     expect(result.mergeErrorDetails!.length).toBe(50);

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -76,6 +76,9 @@ const mockRawEventFind = {
     vi.mocked(prisma.rawEvent.findMany).mockResolvedValue(seedDedup(value) as never);
     return this;
   },
+  // NOTE: rejection now aborts the entire `processRawEvents` call (the
+  // prefetch runs once, before the per-event try/catch), not a single
+  // iteration. To simulate per-event failure use `mockRawEventCreate`.
   mockRejectedValueOnce(err: Error) {
     vi.mocked(prisma.rawEvent.findMany).mockRejectedValueOnce(err);
     return this;
@@ -161,6 +164,32 @@ describe("processRawEvents", () => {
     expect(dedupCalls[0][0]).toMatchObject({
       where: { sourceId: "src_1", fingerprint: { in: ["fp_a", "fp_b", "fp_c"] } },
     });
+  });
+
+  it("isolates fingerprint-precompute errors per event (one bad event does not abort the batch)", async () => {
+    // Regression for the Codex P1 in PR #1280: precomputing fingerprints
+    // outside the per-event try/catch must not abort the whole batch when
+    // one event throws. The bad event records a merge error; the good one
+    // proceeds.
+    mockRawEventFind.mockResolvedValue(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_good" } as never);
+    mockRawEventCreate.mockResolvedValueOnce({ id: "raw_good" } as never);
+    // First event: fingerprint throws. Second event: fingerprint succeeds.
+    mockFingerprint
+      .mockImplementationOnce(() => { throw new Error("malformed event"); })
+      .mockReturnValueOnce("fp_good");
+
+    const result = await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-04-01" }),
+      buildRawEvent({ date: "2026-04-02" }),
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(result.eventErrors).toBe(1);
+    expect(result.mergeErrorDetails).toEqual([
+      { fingerprint: "<fingerprint-error>", reason: "malformed event" },
+    ]);
   });
 
   it("treats a duplicate fingerprint within the same batch as a dedup hit (in-memory write-back)", async () => {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -304,7 +304,56 @@ interface MergeContext {
    *  Key = `${kennelId}:${dateIso}`, value = set of canonical Event IDs matched in this batch.
    *  Used to distinguish double-headers (same source, second event) from cross-source merges. */
   batchMatchedEvents: Map<string, Set<string>>;
+  /** Per-batch prefetched RawEvents keyed by fingerprint. Avoids the N+1 in
+   *  `handleDuplicateFingerprint` (one `findFirst` per incoming event). Populated
+   *  once before the loop; updated in-place when `processNewRawEvent` creates a
+   *  new RawEvent so duplicate fingerprints later in the same batch still resolve. */
+  existingByFingerprint: Map<string, ExistingRawEventEntry>;
   result: MergeResult;
+}
+
+/** `select` for the dedup prefetch — kept as a hoisted const so the value type
+ *  derived from it (`ExistingRawEventEntry`) stays in lock-step with the query. */
+const RAW_EVENT_DEDUP_SELECT = {
+  id: true,
+  fingerprint: true,
+  processed: true,
+  eventId: true,
+} as const satisfies Prisma.RawEventSelect;
+type ExistingRawEventEntry = Prisma.RawEventGetPayload<{ select: typeof RAW_EVENT_DEDUP_SELECT }>;
+
+/** Cap on `WHERE fingerprint IN (...)` size per query — keeps Postgres planner
+ *  cost linear and stays well below the 65535 bind-parameter limit. Historical
+ *  re-scrapes (e.g. SDH3 ~7649 events) chunk transparently. */
+const DEDUP_PREFETCH_CHUNK_SIZE = 1000;
+
+/** Single-query batch dedup prefetch (with chunking for very large batches).
+ *  Returns the prefetched RawEvent rows, in any order. The caller keys them
+ *  by fingerprint into `existingByFingerprint`. */
+async function prefetchExistingByFingerprint(
+  sourceId: string,
+  fingerprints: readonly string[],
+): Promise<ExistingRawEventEntry[]> {
+  if (fingerprints.length === 0) return [];
+  if (fingerprints.length <= DEDUP_PREFETCH_CHUNK_SIZE) {
+    return prisma.rawEvent.findMany({
+      where: { sourceId, fingerprint: { in: [...fingerprints] } },
+      select: RAW_EVENT_DEDUP_SELECT,
+    });
+  }
+  const chunks: string[][] = [];
+  for (let i = 0; i < fingerprints.length; i += DEDUP_PREFETCH_CHUNK_SIZE) {
+    chunks.push([...fingerprints.slice(i, i + DEDUP_PREFETCH_CHUNK_SIZE)]);
+  }
+  const results = await Promise.all(
+    chunks.map((chunk) =>
+      prisma.rawEvent.findMany({
+        where: { sourceId, fingerprint: { in: chunk } },
+        select: RAW_EVENT_DEDUP_SELECT,
+      }),
+    ),
+  );
+  return results.flat();
 }
 
 /** Resolve kennel data (name + region + coords + country + region centroid), using the per-batch cache to avoid N+1 queries. */
@@ -443,10 +492,9 @@ async function handleDuplicateFingerprint(
   fingerprint: string,
   ctx: MergeContext,
 ): Promise<false | string | null> {
-  const existing = await prisma.rawEvent.findFirst({
-    where: { fingerprint, sourceId: ctx.sourceId },
-    select: { id: true, processed: true, eventId: true },
-  });
+  // Read-through the per-batch prefetch map populated in `processRawEvents`
+  // (Sentry JAVASCRIPT-NEXTJS-3 — was one `findFirst` per incoming event).
+  const existing = ctx.existingByFingerprint.get(fingerprint);
   if (!existing) return false; // Not a duplicate — proceed normally
 
   ctx.result.skipped++;
@@ -1408,6 +1456,18 @@ async function processNewRawEvent(
   }
 
   const targetEventId = await upsertCanonicalEvent(event, kennelId, rawEvent.id, ctx);
+  // Mirror DB state into the dedup map *immediately* after upsertCanonicalEvent
+  // marks the RawEvent processed. If a later side-effect (createEventLinks, the
+  // kennel cache update) throws, the per-event try/catch records the error but
+  // the row is already `processed: true` in the DB — keeping map ↔ DB aligned
+  // means a later in-batch duplicate still takes the existing-Event branch
+  // instead of being re-processed as new.
+  ctx.existingByFingerprint.set(fingerprint, {
+    id: rawEvent.id,
+    fingerprint,
+    processed: true,
+    eventId: targetEventId,
+  });
 
   await createEventLinks(targetEventId, sourceId, event.externalLinks);
 
@@ -1739,31 +1799,60 @@ export async function processRawEvents(
     sampleSkipped: [],
   };
 
-  const source = await prisma.source.findUnique({
-    where: { id: sourceId },
-    select: { trustLevel: true, type: true },
-  });
+  // Fingerprint precompute (sync) — runs first so the prefetch query can join
+  // the parallel batch below. The Map keys by event identity so the per-event
+  // loop can reuse the same fingerprint without recomputing.
+  const fingerprintByEvent = new Map<RawEventData, string>();
+  for (const event of events) {
+    fingerprintByEvent.set(event, generateFingerprint(event));
+  }
+  const uniqueFingerprints = [...new Set(fingerprintByEvent.values())];
+
+  // Three independent reads — source metadata, source-kennel links, and the
+  // dedup prefetch (Sentry JAVASCRIPT-NEXTJS-3) — fan out together to save
+  // round-trips on every scrape.
+  const [source, sourceKennels, prefetchedRawEvents] = await Promise.all([
+    prisma.source.findUnique({
+      where: { id: sourceId },
+      select: { trustLevel: true, type: true },
+    }),
+    prisma.sourceKennel.findMany({
+      where: { sourceId },
+      select: { kennelId: true },
+    }),
+    prefetchExistingByFingerprint(sourceId, uniqueFingerprints),
+  ]);
   const trustLevel = source?.trustLevel ?? 5;
   const sourceType: SourceType | null = source?.type ?? null;
-
-  const sourceKennels = await prisma.sourceKennel.findMany({
-    where: { sourceId },
-    select: { kennelId: true },
-  });
-  const linkedKennelIds = new Set(sourceKennels.map(sk => sk.kennelId));
+  const linkedKennelIds = new Set(sourceKennels.map((sk) => sk.kennelId));
 
   clearResolverCache();
+
+  const existingByFingerprint = new Map<string, ExistingRawEventEntry>(
+    prefetchedRawEvents.map((r) => [r.fingerprint, r]),
+  );
 
   const kennelCache = new Map<string, KennelCacheEntry>();
   const shortUrlCache = new Map<string, string | null>();
   const batchMatchedEvents = new Map<string, Set<string>>();
-  const ctx: MergeContext = { sourceId, trustLevel, sourceType, linkedKennelIds, kennelCache, shortUrlCache, batchMatchedEvents, result };
+  const ctx: MergeContext = {
+    sourceId,
+    trustLevel,
+    sourceType,
+    linkedKennelIds,
+    kennelCache,
+    shortUrlCache,
+    batchMatchedEvents,
+    existingByFingerprint,
+    result,
+  };
 
   const seriesGroups = new Map<string, string[]>();
 
   for (const event of events) {
     try {
-      const fingerprint = generateFingerprint(event);
+      // Reuse the fingerprint computed for the prefetch (set above for every event).
+      const fingerprint = fingerprintByEvent.get(event)!;
 
       const dupResult = await handleDuplicateFingerprint(event, fingerprint, ctx);
       if (dupResult !== false) {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -330,6 +330,25 @@ const DEDUP_PREFETCH_CHUNK_SIZE = 1000;
 /** Single-query batch dedup prefetch (with chunking for very large batches).
  *  Returns the prefetched RawEvent rows, in any order. The caller keys them
  *  by fingerprint into `existingByFingerprint`. */
+/** Compute fingerprints for every event up front so the prefetch query and the
+ *  per-event loop can share them. Wraps each call so a malformed event
+ *  (rare) is recorded as an isolated `eventError` instead of aborting the
+ *  whole batch. Events absent from the returned map are skipped by the loop. */
+function precomputeFingerprints(
+  events: RawEventData[],
+  result: MergeResult,
+): Map<RawEventData, string> {
+  const fingerprintByEvent = new Map<RawEventData, string>();
+  for (const event of events) {
+    try {
+      fingerprintByEvent.set(event, generateFingerprint(event));
+    } catch (err) {
+      recordMergeError(event, err, result, "<fingerprint-error>");
+    }
+  }
+  return fingerprintByEvent;
+}
+
 async function prefetchExistingByFingerprint(
   sourceId: string,
   fingerprints: string[],
@@ -1809,21 +1828,10 @@ export async function processRawEvents(
     sampleSkipped: [],
   };
 
-  // Fingerprint precompute (sync) — runs first so the prefetch query can join
-  // the parallel batch below. The Map keys by event identity so the per-event
-  // loop can reuse the same fingerprint without recomputing. Each call is
-  // wrapped to preserve the per-event error isolation the loop body has —
-  // a malformed event must not abort the whole batch's prefetch. We pass the
-  // sentinel directly to `recordMergeError` so it doesn't re-call
-  // `generateFingerprint` on the same event (which would just throw again).
-  const fingerprintByEvent = new Map<RawEventData, string>();
-  for (const event of events) {
-    try {
-      fingerprintByEvent.set(event, generateFingerprint(event));
-    } catch (err) {
-      recordMergeError(event, err, result, "<fingerprint-error>");
-    }
-  }
+  // Sync fingerprint precompute keyed by event identity. Runs first so the
+  // prefetch query can join the parallel batch below; the loop body reuses
+  // the same fingerprints without recomputing.
+  const fingerprintByEvent = precomputeFingerprints(events, result);
   const uniqueFingerprints = [...new Set(fingerprintByEvent.values())];
 
   // Three independent reads — source metadata, source-kennel links, and the

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -332,18 +332,18 @@ const DEDUP_PREFETCH_CHUNK_SIZE = 1000;
  *  by fingerprint into `existingByFingerprint`. */
 async function prefetchExistingByFingerprint(
   sourceId: string,
-  fingerprints: readonly string[],
+  fingerprints: string[],
 ): Promise<ExistingRawEventEntry[]> {
   if (fingerprints.length === 0) return [];
   if (fingerprints.length <= DEDUP_PREFETCH_CHUNK_SIZE) {
     return prisma.rawEvent.findMany({
-      where: { sourceId, fingerprint: { in: [...fingerprints] } },
+      where: { sourceId, fingerprint: { in: fingerprints } },
       select: RAW_EVENT_DEDUP_SELECT,
     });
   }
   const chunks: string[][] = [];
   for (let i = 0; i < fingerprints.length; i += DEDUP_PREFETCH_CHUNK_SIZE) {
-    chunks.push([...fingerprints.slice(i, i + DEDUP_PREFETCH_CHUNK_SIZE)]);
+    chunks.push(fingerprints.slice(i, i + DEDUP_PREFETCH_CHUNK_SIZE));
   }
   const results = await Promise.all(
     chunks.map((chunk) =>
@@ -1751,6 +1751,7 @@ function recordMergeError(
   event: RawEventData,
   err: unknown,
   result: MergeResult,
+  precomputedFingerprint?: string,
 ): void {
   const reason = err instanceof Error ? err.message : String(err);
   const msg = `${event.date}/${event.kennelTags[0]}: ${reason}`;
@@ -1760,10 +1761,19 @@ function recordMergeError(
     result.eventErrorMessages.push(msg);
   }
   if (result.mergeErrorDetails && result.mergeErrorDetails.length < 50) {
-    result.mergeErrorDetails.push({
-      fingerprint: generateFingerprint(event),
-      reason,
-    });
+    // Prefer the caller's fingerprint (the precompute always passes one,
+    // including the `<fingerprint-error>` sentinel for events that failed
+    // there). For loop-body errors with no precomputed value, regenerate —
+    // and shield against the rare case where regenerate also throws.
+    let fingerprint = precomputedFingerprint;
+    if (fingerprint === undefined) {
+      try {
+        fingerprint = generateFingerprint(event);
+      } catch {
+        fingerprint = "<fingerprint-error>";
+      }
+    }
+    result.mergeErrorDetails.push({ fingerprint, reason });
   }
 }
 
@@ -1801,10 +1811,18 @@ export async function processRawEvents(
 
   // Fingerprint precompute (sync) — runs first so the prefetch query can join
   // the parallel batch below. The Map keys by event identity so the per-event
-  // loop can reuse the same fingerprint without recomputing.
+  // loop can reuse the same fingerprint without recomputing. Each call is
+  // wrapped to preserve the per-event error isolation the loop body has —
+  // a malformed event must not abort the whole batch's prefetch. We pass the
+  // sentinel directly to `recordMergeError` so it doesn't re-call
+  // `generateFingerprint` on the same event (which would just throw again).
   const fingerprintByEvent = new Map<RawEventData, string>();
   for (const event of events) {
-    fingerprintByEvent.set(event, generateFingerprint(event));
+    try {
+      fingerprintByEvent.set(event, generateFingerprint(event));
+    } catch (err) {
+      recordMergeError(event, err, result, "<fingerprint-error>");
+    }
   }
   const uniqueFingerprints = [...new Set(fingerprintByEvent.values())];
 
@@ -1850,10 +1868,12 @@ export async function processRawEvents(
   const seriesGroups = new Map<string, string[]>();
 
   for (const event of events) {
+    // Events that failed the fingerprint precompute were already recorded as
+    // errors and are skipped here so the prefetch's empty-fingerprint case
+    // doesn't re-classify them as new.
+    const fingerprint = fingerprintByEvent.get(event);
+    if (fingerprint === undefined) continue;
     try {
-      // Reuse the fingerprint computed for the prefetch (set above for every event).
-      const fingerprint = fingerprintByEvent.get(event)!;
-
       const dupResult = await handleDuplicateFingerprint(event, fingerprint, ctx);
       if (dupResult !== false) {
         if (dupResult) await createEventLinks(dupResult, sourceId, event.externalLinks);
@@ -1868,7 +1888,7 @@ export async function processRawEvents(
         seriesGroups.set(event.seriesId, group);
       }
     } catch (err) {
-      recordMergeError(event, err, result);
+      recordMergeError(event, err, result, fingerprint);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the Sentry [JAVASCRIPT-NEXTJS-3](https://hashtracks.sentry.io/issues/7375103156/) N+1: `POST /api/cron/scrape/[sourceId]` was issuing one `prisma.rawEvent.findFirst({ fingerprint, sourceId })` per scraped event (376 occurrences since 2026-03-30, ~16 repeated DB spans per request, 5.7s sample transaction).

- Replace the per-event `findFirst` with a single `rawEvent.findMany({ fingerprint: { in: [...] } })` prefetch before the merge loop, keyed into a `Map<fingerprint, ExistingRawEventEntry>` on `MergeContext`.
- Fan the prefetch out via `Promise.all` alongside `source.findUnique` and `sourceKennel.findMany` — saves a round-trip on every scrape, and chunks at 1000 fingerprints to keep planner cost linear on historical replays (SDH3 ~7649 events).
- Mirror new RawEvents into the in-memory map immediately after `upsertCanonicalEvent` marks them processed, so an in-batch duplicate fingerprint still takes the existing-Event branch even when a later side-effect throws.

Drops dedup-phase DB round-trips from O(events) to O(1).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — full 6007-test suite green; merge.test.ts covers 287 cases including two new regressions (one asserting exactly one `findMany({ fingerprint: { in } })` per batch, one asserting the in-memory write-back handles same-fingerprint dupes within a batch)
- [x] `npm run lint` clean for the changed files
- [ ] Production verify: after deploy, confirm the next QStash-driven scrape's Sentry trace collapses the repeated `prisma:client:db_query` group from N to 1, and that the issue's occurrences counter stops incrementing within ~24 hrs.

## Out-of-scope follow-ups (intentionally not in this PR)

- Add `@@unique([sourceId, fingerprint])` on `RawEvent` to close the cross-worker race window the prefetch widens (existed before, just smaller). Needs a migration that may have to dedupe historical rows first.
- Batch `event.findMany({ kennelId, date })` sameDayEvents in `upsertCanonicalEvent` (line 921) and the fuzzy `event.findMany({ kennelId, date in window })` (line 865) for new-event-heavy scrapes.
- Replace per-event `prisma.\$executeRaw UPDATE "Kennel" SET "lastEventDate"` with a single batched `updateMany` after the loop.

Closes Sentry JAVASCRIPT-NEXTJS-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)