### PR TITLE
fix(fb-hosted-events): use SSR envelope markers, not byte count, for shape-break heuristic

### DIFF
--- a/src/adapters/facebook-hosted-events/adapter.test.ts
+++ b/src/adapters/facebook-hosted-events/adapter.test.ts
@@ -266,10 +266,16 @@ describe("FacebookHostedEventsAdapter — fetch", () => {
     expect(result.errors[0]).toMatch(/ECONNRESET|fetch error/);
   });
 
-  it("returns 0 events silently for a small empty-page response (legit no-events case)", async () => {
-    // Small page (<200KB) + 0 events is the legit "no upcoming events"
-    // shape — pass through silently so the surrounding alerts don't fire.
-    mockedFetch.mockResolvedValueOnce(htmlResponse("<html><body>No events</body></html>"));
+  it("returns 0 events silently for an empty FB Page that ships SSR envelope markers (legit no-events case)", async () => {
+    // Real-world empty FB Page: 600KB+ SSR bundle with the envelope
+    // markers intact, just no Event nodes. The #1294 audit confirmed this
+    // is what every empty-but-active hosted_events Page looks like.
+    const emptyPageHtml =
+      `<html><body>` +
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `<div data-bbox='{"__bbox":{"complete":true,"result":{"data":null}}}'></div>` +
+      `</body></html>`;
+    mockedFetch.mockResolvedValueOnce(htmlResponse(emptyPageHtml));
     const adapter = new FacebookHostedEventsAdapter();
     const result = await adapter.fetch(
       makeSource({
@@ -392,12 +398,13 @@ describe("FacebookHostedEventsAdapter — fetch", () => {
     });
   });
 
-  it("flags a shape-break heuristic error when a heavy 200-OK response yields 0 events", async () => {
-    // A fat (>200KB) page with 0 parsed events is almost certainly an SSR
-    // shape change — surface as a non-fatal error so SCRAPE_FAILURE fires
-    // before EVENT_COUNT_ANOMALY's baseline accrues.
-    const fatHtml = "<html><body>" + "x".repeat(200_001) + "</body></html>";
-    mockedFetch.mockResolvedValueOnce(htmlResponse(fatHtml));
+  it("flags a shape-break heuristic error when SSR envelope markers are absent", async () => {
+    // A 200-OK response that's missing FB's GraphQL envelope markers
+    // (RelayPrefetchedStreamCache / __bbox) AND parses 0 events is an
+    // actual shape rotation — surface as a non-fatal error so
+    // SCRAPE_FAILURE fires before EVENT_COUNT_ANOMALY's baseline accrues.
+    const noEnvelopeHtml = "<html><body>" + "x".repeat(200_001) + "</body></html>";
+    mockedFetch.mockResolvedValueOnce(htmlResponse(noEnvelopeHtml));
     const adapter = new FacebookHostedEventsAdapter();
     const result = await adapter.fetch(
       makeSource({
@@ -409,6 +416,30 @@ describe("FacebookHostedEventsAdapter — fetch", () => {
     );
     expect(result.events).toEqual([]);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toMatch(/SSR GraphQL shape change/i);
+    expect(result.errors[0]).toMatch(/GraphQL shape change/i);
+  });
+
+  it("does NOT flag shape-break when a fat empty-Page response carries SSR envelope markers (#1294 audit fix)", async () => {
+    // Real-world: empty FB Pages still ship 600KB+ SSR bundles with the
+    // RelayPrefetchedStreamCache / __bbox envelope intact. The byte-count
+    // heuristic mis-classified those as shape rotations; the envelope
+    // check correctly identifies them as legit "no upcoming events" pages.
+    const fatEmptyWithEnvelope =
+      `<html><body>${"x".repeat(700_000)}` +
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `<div data-bbox='{"__bbox":{"complete":true,"result":{"data":null}}}'></div>` +
+      `</body></html>`;
+    mockedFetch.mockResolvedValueOnce(htmlResponse(fatEmptyWithEnvelope));
+    const adapter = new FacebookHostedEventsAdapter();
+    const result = await adapter.fetch(
+      makeSource({
+        kennelTag: "gsh3",
+        pageHandle: "GrandStrandHashing",
+        timezone: "America/New_York",
+        upcomingOnly: true,
+      }),
+    );
+    expect(result.events).toEqual([]);
+    expect(result.errors).toEqual([]);
   });
 });

--- a/src/adapters/facebook-hosted-events/adapter.ts
+++ b/src/adapters/facebook-hosted-events/adapter.ts
@@ -48,11 +48,20 @@ const FB_REQUEST_HEADERS = {
 };
 
 const DEFAULT_WINDOW_DAYS = 90;
-/** Below this byte count, an empty parse result is the legit "no upcoming
- *  events" page. Above it (with 0 events) the SSR shape almost certainly
- *  rotated and the parser-fixture needs refreshing. Calibrated against the
- *  ~900KB GSH3 fixture; FB's empty-page response is well under 50KB. */
-const SHAPE_BREAK_BYTES = 200_000;
+
+/**
+ * SSR markers FB ships in every hosted_events response when the GraphQL
+ * shape we know is intact — both in pages with events and in empty pages.
+ * If the response carries neither marker, the SSR shape has rotated and
+ * our parser surface is stale; if at least one is present and we still
+ * parse 0 events, the Page just genuinely has no events on this tab.
+ *
+ * Replaces the earlier byte-count heuristic (#1294 audit), which wrongly
+ * flagged every 600KB+ empty-Page response as a shape break — empty FB
+ * Pages still ship the full SSR bundle (Page UI, comments, photos, etc.),
+ * not a stub.
+ */
+const FB_SSR_ENVELOPE_MARKERS = ["RelayPrefetchedStreamCache", '"__bbox"'] as const;
 
 /**
  * Cap on detail-page fetches per scrape. FB doesn't aggressively rate-limit
@@ -128,16 +137,17 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
       timezone: config.timezone,
     });
 
-    // Shape-break heuristic: a real "no upcoming events" page is small
-    // (FB ships <50KB when the events list is empty). A 200-OK page with
-    // a fat payload but 0 parsed events almost certainly means the SSR
-    // GraphQL shape rotated. Surface as a non-fatal error so the existing
-    // SCRAPE_FAILURE alert path catches it on first scrape — without
-    // requiring the EVENT_COUNT_ANOMALY rolling baseline.
+    // Shape-break heuristic: 0 parsed events AND none of FB's SSR envelope
+    // markers present → the GraphQL shape rotated. If at least one marker
+    // is there and we still got 0 events, the Page genuinely has nothing
+    // scheduled (and that's not an alert condition). Surface as non-fatal
+    // so the existing SCRAPE_FAILURE alert path catches a real shape
+    // change on first scrape, without false-positive-firing on empty Pages.
     const errors: string[] = [];
-    if (allEvents.length === 0 && html.length > SHAPE_BREAK_BYTES) {
+    const hasEnvelopeMarker = FB_SSR_ENVELOPE_MARKERS.some((m) => html.includes(m));
+    if (allEvents.length === 0 && !hasEnvelopeMarker) {
       errors.push(
-        `FB hosted_events page returned ${html.length} bytes but parser found 0 events — likely SSR GraphQL shape change. Refresh the parser fixture and re-test.`,
+        `FB hosted_events page returned ${html.length} bytes but parser found 0 events and the SSR envelope markers are absent — likely a GraphQL shape change. Refresh the parser fixture and re-test.`,
       );
     }
 

--- a/src/adapters/facebook-hosted-events/adapter.ts
+++ b/src/adapters/facebook-hosted-events/adapter.ts
@@ -152,7 +152,7 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
     const hasEnvelopeMarker = FB_SSR_ENVELOPE_MARKERS.some((m) => html.includes(m));
     if (allEvents.length === 0 && !hasEnvelopeMarker) {
       errors.push(
-        `FB hosted_events page returned ${html.length} bytes but parser found 0 events and the SSR envelope markers are absent — likely a GraphQL shape change. Refresh the parser fixture and re-test.`,
+        `FB hosted_events page returned ${html.length} chars but parser found 0 events and the SSR envelope markers are absent — likely a GraphQL shape change. Refresh the parser fixture and re-test.`,
       );
     }
 

--- a/src/adapters/facebook-hosted-events/adapter.ts
+++ b/src/adapters/facebook-hosted-events/adapter.ts
@@ -56,12 +56,17 @@ const DEFAULT_WINDOW_DAYS = 90;
  * our parser surface is stale; if at least one is present and we still
  * parse 0 events, the Page just genuinely has no events on this tab.
  *
+ * Both markers are matched in their quoted JSON-token form so a Page
+ * coincidentally mentioning either string in plain text or a comment
+ * can't false-negative the shape-break check. Tightening per Gemini
+ * review on PR #1295.
+ *
  * Replaces the earlier byte-count heuristic (#1294 audit), which wrongly
  * flagged every 600KB+ empty-Page response as a shape break — empty FB
  * Pages still ship the full SSR bundle (Page UI, comments, photos, etc.),
  * not a stub.
  */
-const FB_SSR_ENVELOPE_MARKERS = ["RelayPrefetchedStreamCache", '"__bbox"'] as const;
+const FB_SSR_ENVELOPE_MARKERS = ['"RelayPrefetchedStreamCache"', '"__bbox"'] as const;
 
 /**
  * Cap on detail-page fetches per scrape. FB doesn't aggressively rate-limit


### PR DESCRIPTION
## Summary

Surfaced by the PR #1294 audit: the production FACEBOOK_HOSTED_EVENTS adapter's shape-break heuristic (\`htmlBytes > 200_000 && events.length === 0\`) was calibrated against an assumption that disagrees with reality.

**The wrong assumption:** "FB ships <50KB when the events list is empty."

**Reality (audit found this):** Every empty FB Page in the audit shipped 600KB+ of full SSR bundle — Page UI, comments, photos, the whole shell — even with zero hosted events. The byte-count gate would have false-positive alerted "SSR shape change" on every one of them.

**The fix:** Replace the byte-count check with a presence check for FB's GraphQL envelope markers — \`RelayPrefetchedStreamCache\` and \`__bbox\`. Both ship in every hosted_events response when the shape we know is intact (with or without events); their absence is the actual shape-rotation signal.

## Behavior matrix

| State | Envelope marker | Events parsed | Adapter result |
|---|---|---|---|
| Real Page with events | present | ≥1 | Enrich + return *(unchanged)* |
| Real empty Page | present | 0 | **Silent pass** *(was: false-positive alert)* |
| Shape rotation | absent | 0 | Alert "SSR shape change" *(now: caught regardless of byte count)* |

## Why this matters

This unblocks the FB hosted_events historical backfill (\`scripts/backfill-fb-hosted-events-history.ts\`, planned per the Seletar pattern). A paginated \`/past_hosted_events\` script that walks back to a Page's inception will eventually hit the end of the archive — at which point the response is "page rendered, 0 events". The old heuristic would have falsely alerted on that terminal page; the new heuristic correctly silently passes it.

The 33 active FB Pages identified in the PR #1294 audit (6 upcoming-rich + 27 past-only) all share this profile.

## Test plan

- [x] \`npx tsc --noEmit && npm run lint && npm test -- src/adapters/facebook-hosted-events\` (48 FB tests pass, 0 errors)
- [x] Existing "small empty page passes silently" test updated to use a payload that includes envelope markers (matches what real empty FB Pages ship per the audit)
- [x] "Shape-break flagged" test relabeled "envelope absent" — now asserts failure mode is missing markers, not byte count
- [x] **New positive test**: a 700KB empty-Page payload **with** envelope markers does NOT trigger the alert. The exact false-positive case the audit caught
- [ ] Post-merge: re-run the audit script on this branch's adapter to confirm zero false-positive shape-break flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)