### PR TITLE
fix(gcal): clear stale runNumber on placeholder retitle, drop personal-calendar drift

### DIFF
--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -264,6 +264,30 @@ describe("extractRunNumber", () => {
   it("does not match qualifier text without a # (e.g. 'CUNTh 66ish')", () => {
     expect(extractRunNumber("CUNTh 66ish Hiidea's Bday")).toBeUndefined();
   });
+
+  // Summary placeholder must beat description fallback (Codex adversarial
+  // review #1297). A partial retitle (kennel admin updates the title to
+  // `#30X?` but leaves the prior `BH3 #30` reference in the description)
+  // would otherwise let the description number reassert itself and re-
+  // anchor the runNumber on the next merge instead of clearing it.
+  it("summary placeholder overrides stale description run number", () => {
+    expect(
+      extractRunNumber(
+        "FCH3 #30X?: Frisky Whisk-her and CBD",
+        "Trail #30 was last week — see you Saturday at the park",
+      ),
+    ).toBeNull();
+  });
+
+  it("summary placeholder overrides stale description with custom pattern", () => {
+    expect(
+      extractRunNumber(
+        "FCH3 #30X?: TBD",
+        "Hash # 30",
+        [String.raw`Hash\s*#\s*(\d+)`],
+      ),
+    ).toBeNull();
+  });
 });
 
 // ── extractTitle ──

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -320,6 +320,64 @@ describe("CTA placeholder event skip", () => {
   });
 });
 
+describe("non-hash event filter (#1271)", () => {
+  it.each([
+    "Meet for wedding talk", // #1271
+    "Meet with Bob",
+    "Meeting at the office",
+    "Lunch with Sarah",
+    "Dinner with the in-laws",
+    "Brunch with friends",
+    "Doctor appointment",
+    "Dentist visit",
+    "Doctor's",
+    "Appointment with the realtor",
+    "Pick up dry cleaning",
+    "Drop off the kids",
+    "Call with the lawyer",
+  ])("skips personal-verb pattern: %s", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary }),
+      { defaultKennelTag: "h4-tx" },
+    );
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    ["bare proper noun", "Rex Manning Day"],
+    ["short title", "TGIF Friday"],
+    ["social with venue", "Social @ JBs Fuel Dock, 6pm"],
+    ["AGM acronym", "AGM 2026"],
+    ["campout", "Annual Campout"],
+    ["holiday party", "Christmas Hash Party"],
+  ])("preserves non-personal title: %s", (_, summary) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary }),
+      { defaultKennelTag: "h4-tx" },
+    );
+    expect(result).not.toBeNull();
+  });
+
+  // Structured fields override the personal-title filter — the kennel
+  // admin's intent is a hash event whenever they fill in a description,
+  // location, or run number (clean OR placeholder).
+  it.each<[string, Record<string, unknown>, number | null | undefined]>([
+    ["description present", { summary: "Lunch with the kennel", description: "Annual mismanagement lunch — RSVP required." }, undefined],
+    ["location present", { summary: "Meet for the trail", location: "Memorial Park" }, undefined],
+    ["clean run number", { summary: "Meet for hash #1234" }, 1234],
+    ["placeholder run number", { summary: "Meet for hash #1234TBD" }, null],
+  ])("preserves personal-pattern title when %s", (_, overrides, expectedRunNumber) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent(overrides),
+      { defaultKennelTag: "h4-tx" },
+    );
+    expect(result).not.toBeNull();
+    if (expectedRunNumber !== undefined) {
+      expect(result!.runNumber).toBe(expectedRunNumber);
+    }
+  });
+});
+
 describe("Google holiday calendar filter", () => {
   it("skips events from Google's imported US holiday calendar", () => {
     const result = buildRawEventFromGCalItem(
@@ -2933,16 +2991,20 @@ describe("GoogleCalendarAdapter — RECURRENCE-ID override recovery (#1021/#1024
 // ── Audit-stream Deep Dive — 11 GCal adapter bugs ──
 
 describe("audit-stream pure-function cases", () => {
-  it.each<[string, string, string | undefined, number | undefined]>([
-    // [#issue-tag, summary, description-or-na, expected-runNumber]
-    // #1147 — `extractRunNumber` rejects mid-token alphanumeric, accepts
-    // clean numeric tokens regardless of trailing delimiter.
-    ["#1147", "FCH3 #30X?: Frisky Whisk-her and CBD", undefined, undefined],
-    ["#1147", "FCH3 #308: Laporte: Squeeze", undefined, 308],
-    ["#1147", "CUNTh # 66 - Winner Winner Dildo Dinner", undefined, 66],
-    ["#1147", "BH3 #2781", undefined, 2781],
-    ["#1147", "FCH3 #30TBD", undefined, undefined],
-  ])("extractRunNumber %s %j → %p", (_, summary, _desc, expected) => {
+  // #1147 — clean numeric tokens accepted regardless of delimiter.
+  // #1272/#1274/#1275 — placeholder shapes return null (merge.ts clears
+  // stale runNumbers when a kennel retitles to a placeholder).
+  it.each<[string, string, number | null | undefined]>([
+    ["#1275 placeholder X?", "FCH3 #30X?: Frisky Whisk-her and CBD", null],
+    ["#1272 placeholder XX", "H4 Run #25XX— Erections", null],
+    ["#1274 placeholder X", "Open for Hares--Jhav Trail #208X", null],
+    ["#1147 clean #N", "FCH3 #308: Laporte: Squeeze", 308],
+    ["#1147 spaced #", "CUNTh # 66 - Winner Winner Dildo Dinner", 66],
+    ["#1147 trailing", "BH3 #2781", 2781],
+    ["#1147 TBD suffix", "FCH3 #30TBD", null],
+    ["#1275 ? only", "Run #100?", null],
+    ["no run number, no placeholder", "Just a regular run", undefined],
+  ])("extractRunNumber %s %j → %p", (_, summary, expected) => {
     expect(extractRunNumber(summary)).toBe(expected);
   });
 

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -348,7 +348,7 @@ describe("non-hash event filter (#1271)", () => {
   it.each([
     "Meet for wedding talk", // #1271
     "Meet with Bob",
-    "Meeting at the office",
+    "Meet up with the team",
     "Lunch with Sarah",
     "Dinner with the in-laws",
     "Brunch with friends",
@@ -374,6 +374,11 @@ describe("non-hash event filter (#1271)", () => {
     ["AGM acronym", "AGM 2026"],
     ["campout", "Annual Campout"],
     ["holiday party", "Christmas Hash Party"],
+    // Codex review on PR #1297 — `Meet at <venue>` is a common kennel
+    // summary-only format, must NOT be classified as personal.
+    ["meet at venue", "Meet at the Tipsy Cow, 7pm"],
+    ["meet at park", "Meet at Memorial Park"],
+    ["meeting at venue", "Meeting at Pat's house"],
   ])("preserves non-personal title: %s", (_, summary) => {
     const result = buildRawEventFromGCalItem(
       testGCalEvent({ summary }),

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -53,7 +53,13 @@ export function extractRunNumber(
   const fromSummary = extractHashRunNumber(summary);
   if (fromSummary !== undefined) return fromSummary;
 
-  // 2. Fall back to description patterns
+  // 2. Summary placeholder takes precedence over description fallback. A
+  // partial retitle (`#30: …` → `#30X?: …` while description still says
+  // "#30") would otherwise let the stale description number reassert
+  // itself and re-anchor the cleared run on the next merge.
+  if (hasPlaceholderRunNumber(summary)) return null;
+
+  // 3. Fall back to description patterns
   if (description) {
     let patterns: RegExp[];
     if (customPatterns && customPatterns.length > 0) {
@@ -76,11 +82,6 @@ export function extractRunNumber(
     const standaloneMatch = /(?:^|\n)[ \t]*#(\d{3,})[ \t]*(?:\n|$)/m.exec(description);
     if (standaloneMatch) return Number.parseInt(standaloneMatch[1], 10);
   }
-
-  // 3. Explicit placeholder marker in summary → null (clear stale value).
-  // Without this, a retitle from `FCH3 #30: ...` to `FCH3 #30X?: ...`
-  // emits undefined and merge.ts preserves the stale 30 (#1275).
-  if (hasPlaceholderRunNumber(summary)) return null;
 
   return undefined;
 }

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -60,30 +60,30 @@ export function extractRunNumber(
   if (hasPlaceholderRunNumber(summary)) return null;
 
   // 3. Fall back to description patterns
-  if (description) {
-    let patterns: RegExp[];
-    if (customPatterns && customPatterns.length > 0) {
-      patterns = typeof customPatterns[0] === "string"
+  return description
+    ? extractRunNumberFromDescription(description, customPatterns)
+    : undefined;
+}
+
+function extractRunNumberFromDescription(
+  description: string,
+  customPatterns?: string[] | RegExp[],
+): number | undefined {
+  const patterns = customPatterns && customPatterns.length > 0
+    ? (typeof customPatterns[0] === "string"
         ? compilePatterns(customPatterns as string[])
-        : customPatterns as RegExp[];
-    } else {
-      patterns = DEFAULT_RUN_NUMBER_PATTERNS;
-    }
+        : customPatterns as RegExp[])
+    : DEFAULT_RUN_NUMBER_PATTERNS;
 
-    for (const pattern of patterns) {
-      const match = pattern.exec(description);
-      if (match?.[1]) {
-        const num = Number.parseInt(match[1], 10);
-        if (!Number.isNaN(num) && num > 0) return num;
-      }
-    }
-
-    // Standalone run number in description (e.g., "#2792" on its own line)
-    const standaloneMatch = /(?:^|\n)[ \t]*#(\d{3,})[ \t]*(?:\n|$)/m.exec(description);
-    if (standaloneMatch) return Number.parseInt(standaloneMatch[1], 10);
+  for (const pattern of patterns) {
+    const match = pattern.exec(description);
+    const num = match?.[1] ? Number.parseInt(match[1], 10) : NaN;
+    if (Number.isFinite(num) && num > 0) return num;
   }
 
-  return undefined;
+  // Standalone run number in description (e.g., "#2792" on its own line)
+  const standaloneMatch = /(?:^|\n)[ \t]*#(\d{3,})[ \t]*(?:\n|$)/m.exec(description);
+  return standaloneMatch ? Number.parseInt(standaloneMatch[1], 10) : undefined;
 }
 
 /** Strip the "Kennel: " or "Kennel #N: " prefix from a calendar summary to extract the event title. */
@@ -1142,13 +1142,15 @@ function compileSourceConfigPatterns(sourceConfig: CalendarSourceConfig | null) 
  *      series that share key but differ in id (#1101 CFMH3). On collision
  *      the survivor inherits non-empty fields from the donor before drop.
  */
-/** A placeholder all-day shell looks like "Giggity H3 #? (TBD)" — no run
- *  number, no real hares/location, and a title containing `#?` or a TBD/TBA/
- *  TBC marker. Real all-day entries (campouts, away weekends) will have a
- *  populated title or run number and must NOT be collapsed when a timed
- *  sibling exists on the same date. */
+/** A placeholder all-day shell looks like "Giggity H3 #? (TBD)" — no real
+ *  run number, no real hares/location, and a title containing `#?` or a
+ *  TBD/TBA/TBC marker. Real all-day entries (campouts, away weekends) will
+ *  have a populated title or numeric run number and must NOT be collapsed
+ *  when a timed sibling exists on the same date. `runNumber === null` is an
+ *  explicit placeholder-marker emission (#1272/#1274/#1275) and counts as
+ *  evidence of a shell, not as a real number. */
 function isPlaceholderShell(e: RawEventData): boolean {
-  if (e.runNumber !== undefined) return false;
+  if (typeof e.runNumber === "number" && e.runNumber > 0) return false;
   const title = (e.title ?? "").trim();
   if (!title) return true;
   if (/#\s*\?/.test(title)) return true;

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -108,9 +108,14 @@ const VALID_HHMM_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
  * outside the allowlist passes through `buildRawEventFromGCalItem` even
  * when other fields are sparse (campouts, named annual events, kennel
  * acronyms like "TGIF Friday").
+ *
+ * Deliberately NOT included: `meet at <venue>` — kennel admins commonly
+ * encode the venue in the summary alone ("Meet at the Tipsy Cow, 7pm")
+ * with no other fields. Only `meet for|with|up with` are unambiguous
+ * personal verbs (Codex review on PR #1297).
  */
 const PERSONAL_TITLE_PATTERNS: readonly RegExp[] = [
-  /^\s*meet(?:ing)?\s+(?:for|with|up\s+with|at)\b/i,
+  /^\s*meet\s+(?:for|with|up\s+with)\b/i,
   /^\s*(?:lunch|dinner|brunch|breakfast|drinks|coffee)\s+with\b/i,
   /^\s*(?:doctor|dentist|optician|orthodontist|chiropractor)(?:'s)?(?:\s+(?:appointment|visit))?\b/i,
   /^\s*(?:appointment|interview)\s+(?:for|with|at)\b/i,

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -65,19 +65,20 @@ export function extractRunNumber(
     : undefined;
 }
 
+function resolveRunNumberPatterns(customPatterns?: string[] | RegExp[]): RegExp[] {
+  if (!customPatterns || customPatterns.length === 0) return DEFAULT_RUN_NUMBER_PATTERNS;
+  if (typeof customPatterns[0] === "string") return compilePatterns(customPatterns as string[]);
+  return customPatterns as RegExp[];
+}
+
 function extractRunNumberFromDescription(
   description: string,
   customPatterns?: string[] | RegExp[],
 ): number | undefined {
-  const patterns = customPatterns && customPatterns.length > 0
-    ? (typeof customPatterns[0] === "string"
-        ? compilePatterns(customPatterns as string[])
-        : customPatterns as RegExp[])
-    : DEFAULT_RUN_NUMBER_PATTERNS;
-
-  for (const pattern of patterns) {
+  for (const pattern of resolveRunNumberPatterns(customPatterns)) {
     const match = pattern.exec(description);
-    const num = match?.[1] ? Number.parseInt(match[1], 10) : NaN;
+    if (!match?.[1]) continue;
+    const num = Number.parseInt(match[1], 10);
     if (Number.isFinite(num) && num > 0) return num;
   }
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber } from "../utils";
+import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber } from "../utils";
 import { matchKennelPatterns, matchCompiledKennelPatterns, compileKennelPatterns, type KennelPattern, type CompiledKennelPattern } from "../kennel-patterns";
 import { LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 import { parseDMSFromLocation } from "@/lib/geo";
@@ -32,41 +32,55 @@ const DEFAULT_RUN_NUMBER_PATTERNS = [
  * Always checks summary first with `#(\d+)`. Then checks description with
  * custom patterns (if provided) or default patterns.
  * Accepts pre-compiled RegExp[] or raw string[] (compiled on the fly for one-off use).
+ *
+ * Returns:
+ *   - `number` when a clean run number is found
+ *   - `null` when the summary contains an explicit placeholder marker
+ *     (`#NN[X|XX|X?|TBD|TBA|?]`) — merge.ts's tri-state treats null as
+ *     "explicit clear" so stale runNumbers from prior scrapes get
+ *     overwritten when a kennel admin retitles to a placeholder
+ *     (#1272/#1274/#1275)
+ *   - `undefined` when no run-number signal is present (preserve existing)
  */
 export function extractRunNumber(
   summary: string,
   description?: string,
   customPatterns?: string[] | RegExp[],
-): number | undefined {
+): number | null | undefined {
   // 1. Check summary first (e.g., "Beantown #255: ...", "BH3: ... #2781", "Cunth # 40: ...").
   // Shared `extractHashRunNumber` enforces the delimiter guard (#1147) — "#30X?"
   // rejects rather than parsing as 30.
   const fromSummary = extractHashRunNumber(summary);
   if (fromSummary !== undefined) return fromSummary;
 
-  if (!description) return undefined;
-
   // 2. Fall back to description patterns
-  let patterns: RegExp[];
-  if (customPatterns && customPatterns.length > 0) {
-    patterns = typeof customPatterns[0] === "string"
-      ? compilePatterns(customPatterns as string[])
-      : customPatterns as RegExp[];
-  } else {
-    patterns = DEFAULT_RUN_NUMBER_PATTERNS;
-  }
-
-  for (const pattern of patterns) {
-    const match = pattern.exec(description);
-    if (match?.[1]) {
-      const num = Number.parseInt(match[1], 10);
-      if (!Number.isNaN(num) && num > 0) return num;
+  if (description) {
+    let patterns: RegExp[];
+    if (customPatterns && customPatterns.length > 0) {
+      patterns = typeof customPatterns[0] === "string"
+        ? compilePatterns(customPatterns as string[])
+        : customPatterns as RegExp[];
+    } else {
+      patterns = DEFAULT_RUN_NUMBER_PATTERNS;
     }
+
+    for (const pattern of patterns) {
+      const match = pattern.exec(description);
+      if (match?.[1]) {
+        const num = Number.parseInt(match[1], 10);
+        if (!Number.isNaN(num) && num > 0) return num;
+      }
+    }
+
+    // Standalone run number in description (e.g., "#2792" on its own line)
+    const standaloneMatch = /(?:^|\n)[ \t]*#(\d{3,})[ \t]*(?:\n|$)/m.exec(description);
+    if (standaloneMatch) return Number.parseInt(standaloneMatch[1], 10);
   }
 
-  // Standalone run number in description (e.g., "#2792" on its own line)
-  const standaloneMatch = /(?:^|\n)[ \t]*#(\d{3,})[ \t]*(?:\n|$)/m.exec(description);
-  if (standaloneMatch) return Number.parseInt(standaloneMatch[1], 10);
+  // 3. Explicit placeholder marker in summary → null (clear stale value).
+  // Without this, a retitle from `FCH3 #30: ...` to `FCH3 #30X?: ...`
+  // emits undefined and merge.ts preserves the stale 30 (#1275).
+  if (hasPlaceholderRunNumber(summary)) return null;
 
   return undefined;
 }
@@ -84,6 +98,25 @@ const DATE_PREFIX_NUMERIC_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*[,\s]+\d{1,2}
 
 /** Strict "HH:MM" 24-hour format — guards `CalendarSourceConfig.defaultStartTime` against typos. */
 const VALID_HHMM_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+/**
+ * Personal-calendar drift detector for the non-hash event filter (#1271).
+ * One regex per intent keeps each pattern under SonarCloud's S5843
+ * complexity budget. Anchored at `^` so a hash title that mentions
+ * "lunch" mid-string never matches. FALSE-NEGATIVE bias — anything
+ * outside the allowlist passes through `buildRawEventFromGCalItem` even
+ * when other fields are sparse (campouts, named annual events, kennel
+ * acronyms like "TGIF Friday").
+ */
+const PERSONAL_TITLE_PATTERNS: readonly RegExp[] = [
+  /^\s*meet(?:ing)?\s+(?:for|with|up\s+with|at)\b/i,
+  /^\s*(?:lunch|dinner|brunch|breakfast|drinks|coffee)\s+with\b/i,
+  /^\s*(?:doctor|dentist|optician|orthodontist|chiropractor)(?:'s)?(?:\s+(?:appointment|visit))?\b/i,
+  /^\s*(?:appointment|interview)\s+(?:for|with|at)\b/i,
+  /^\s*pick\s+up\s+\S/i,
+  /^\s*drop\s+off\s+\S/i,
+  /^\s*call\s+(?:with|to)\b/i,
+];
 
 /** Strip leading day/date prefixes like "Wed April 1st", "Sat 3/28" from titles. */
 export function stripDatePrefix(text: string): string {
@@ -1019,12 +1052,27 @@ export function buildRawEventFromGCalItem(
   // not stored as display location. resolveCoords handles URL → address resolution.
   const locationIsUrl = location && /^https?:\/\//i.test(location);
   const cost = rawDescription ? extractCostFromDescription(rawDescription) : undefined;
+  const runNumber = extractRunNumber(summary, rawDescription, compiledRunNumberPatterns);
+
+  // #1271 — drop personal-calendar drift only when no structured signal.
+  // `runNumber !== undefined` covers both clean numbers and placeholder
+  // markers (kennel admin's intent was a hash run, even if number is TBD).
+  const hasStructuredField = !!(
+    runNumber !== undefined ||
+    hares ||
+    location ||
+    description?.trim()
+  );
+  if (!hasStructuredField && PERSONAL_TITLE_PATTERNS.some((re) => re.test(summary))) {
+    return null;
+  }
+
   const event: RawEventData = {
     date: dateISO,
     // Pass the full multi-kennel set (#1023): for single-tag patterns this
     // is `[primary]`; for array patterns it's the union of all matched kennels.
     kennelTags,
-    runNumber: extractRunNumber(summary, rawDescription, compiledRunNumberPatterns),
+    runNumber,
     title,
     description: appendDescriptionSuffix(description, sourceConfig?.descriptionSuffix),
     hares,

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -882,7 +882,7 @@ describe("applyWeekdayShift", () => {
 // "explicit placeholder" so the merge pipeline's tri-state can clear stale
 // runNumbers from prior scrapes.
 describe("hasPlaceholderRunNumber", () => {
-  it.each<[string, string, boolean]>([
+  it.each<[string, string | undefined, boolean]>([
     // Houston H4 #1272
     ["#1272 X-suffix double", "H4 Run #25XX— Erections", true],
     // jHav #1274
@@ -896,6 +896,11 @@ describe("hasPlaceholderRunNumber", () => {
     ["question-mark only", "FCH3 #30?", true],
     ["lower-case x", "Run #50x", true],
     ["space before placeholder", "Run #100 TBD", true],
+    // Digit-free placeholders — kennel admin hasn't typed any digit yet
+    // (Gemini + Claude review feedback on PR #1297).
+    ["digit-free TBD", "Run #TBD", true],
+    ["digit-free question", "Run #?", true],
+    ["digit-free X", "Run #X", true],
     // Negative — clean run numbers must not register as placeholders
     ["clean simple", "FCH3 #308: Laporte", false],
     ["clean with delimiter", "BH3 #2781", false],
@@ -903,7 +908,7 @@ describe("hasPlaceholderRunNumber", () => {
     ["no run number", "Just a regular run", false],
     ["bare digits", "Event 100", false],
     ["empty", "", false],
-    ["undefined", undefined as unknown as string, false],
+    ["undefined", undefined, false],
   ])("%s: %j → %p", (_, input, expected) => {
     expect(hasPlaceholderRunNumber(input)).toBe(expected);
   });

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -17,6 +17,7 @@ import {
   extractAddressWithAi,
   stripNonEnglishCountry,
   applyWeekdayShift,
+  hasPlaceholderRunNumber,
 } from "./utils";
 import { validateSourceUrlWithDns } from "./ssrf-dns";
 
@@ -871,5 +872,39 @@ describe("applyWeekdayShift", () => {
 
   it("throws on malformed date input", () => {
     expect(() => applyWeekdayShift("not-a-date", "00:00", { from: "Friday", to: "Thursday" })).toThrow(/invalid date/);
+  });
+});
+
+// #1272/#1274/#1275 — placeholder-runNumber detection. Kennel admins use
+// `#NN[X|XX|X?|TBD|TBA|?]` to signal "next run, number not yet assigned".
+// `extractHashRunNumber` correctly rejects these, but downstream callers
+// (the GCal `extractRunNumber`) also need to distinguish "no signal" from
+// "explicit placeholder" so the merge pipeline's tri-state can clear stale
+// runNumbers from prior scrapes.
+describe("hasPlaceholderRunNumber", () => {
+  it.each<[string, string, boolean]>([
+    // Houston H4 #1272
+    ["#1272 X-suffix double", "H4 Run #25XX— Erections", true],
+    // jHav #1274
+    ["#1274 X-suffix single", "Open for Hares--Jhav Trail #208X", true],
+    // FCH3 #1275
+    ["#1275 X-question", "FCH3 #30X?: Frisky Whisk-her and CBD", true],
+    // Common variants
+    ["TBD suffix", "FCH3 #30TBD", true],
+    ["TBA suffix", "Boston #2784 TBA", true],
+    ["TBC suffix", "BH3 #2792TBC", true],
+    ["question-mark only", "FCH3 #30?", true],
+    ["lower-case x", "Run #50x", true],
+    ["space before placeholder", "Run #100 TBD", true],
+    // Negative — clean run numbers must not register as placeholders
+    ["clean simple", "FCH3 #308: Laporte", false],
+    ["clean with delimiter", "BH3 #2781", false],
+    ["clean with comma", "Hash #100, hare needed", false],
+    ["no run number", "Just a regular run", false],
+    ["bare digits", "Event 100", false],
+    ["empty", "", false],
+    ["undefined", undefined as unknown as string, false],
+  ])("%s: %j → %p", (_, input, expected) => {
+    expect(hasPlaceholderRunNumber(input)).toBe(expected);
   });
 });

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -895,7 +895,7 @@ describe("hasPlaceholderRunNumber", () => {
     ["TBC suffix", "BH3 #2792TBC", true],
     ["question-mark only", "FCH3 #30?", true],
     ["lower-case x", "Run #50x", true],
-    ["space before placeholder", "Run #100 TBD", true],
+    ["digit + space before suffix", "Run #100 TBD", true],
     // Digit-free placeholders — kennel admin hasn't typed any digit yet
     // (Gemini + Claude review feedback on PR #1297).
     ["digit-free TBD", "Run #TBD", true],

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -703,6 +703,18 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
   return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
+/**
+ * Detect placeholder run-number markers like `#25XX`, `#208X`, `#30X?`,
+ * `#30TBD`, `#100?` — "next run, number not yet assigned"
+ * (#1272/#1274/#1275). Callers emit `null` so merge.ts's tri-state clears
+ * stale runNumbers from prior scrapes when a retitle drops the digit.
+ */
+const HASH_RUN_NUMBER_PLACEHOLDER_RE =
+  /#\s*\d+\s*(?:[Xx]+\??|TBD|TBA|TBC|\?+)(?=$|[^A-Za-z0-9])/i;
+export function hasPlaceholderRunNumber(text: string | undefined): boolean {
+  return !!text && HASH_RUN_NUMBER_PLACEHOLDER_RE.test(text);
+}
+
 // ---------------------------------------------------------------------------
 // Placeholder detection — shared across adapters for TBD/TBA/TBC cleanup
 // ---------------------------------------------------------------------------

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -709,10 +709,13 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
  * — "next run, number not yet assigned" (#1272/#1274/#1275). Callers emit
  * `null` so merge.ts's tri-state clears stale runNumbers from prior
  * scrapes when a retitle drops the digit. The `/i` flag handles case;
- * the character classes deliberately list one case only.
+ * the character classes deliberately list one case only. The
+ * `(?:\d+[ \t]*)?` non-capturing wrapper keeps `\d` and the trailing
+ * spaces glued together — avoids the `\s*\d*\s*` triple-quantifier
+ * shape that Sonar S5852 flags as ReDoS-prone.
  */
 const HASH_RUN_NUMBER_PLACEHOLDER_RE =
-  /#\s*\d*\s*(?:X+\??|TBD|TBA|TBC|\?+)(?=$|[^A-Z0-9])/i;
+  /#[ \t]*(?:\d+[ \t]*)?(?:X+\??|TBD|TBA|TBC|\?+)(?=$|[^A-Z0-9])/i;
 export function hasPlaceholderRunNumber(text: string | undefined): boolean {
   return !!text && HASH_RUN_NUMBER_PLACEHOLDER_RE.test(text);
 }

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -717,7 +717,7 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
  * — dropping the leading `[ \t]*` after `#` keeps each pattern
  * unambiguous.
  */
-const HASH_PLACEHOLDER_SUFFIX = "(?:X+\\??|TBD|TBA|TBC|\\?+)(?=$|[^A-Z0-9])";
+const HASH_PLACEHOLDER_SUFFIX = "(?:X+\\??|TB[ADC]|\\?+)(?=$|[^A-Z0-9])";
 const HASH_RUN_NUMBER_PLACEHOLDER_DIGITS_RE = new RegExp(
   `#\\d+[ \\t]*${HASH_PLACEHOLDER_SUFFIX}`, "i",
 );

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -705,19 +705,29 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
 
 /**
  * Detect placeholder run-number markers like `#25XX`, `#208X`, `#30X?`,
- * `#30TBD`, `#100?`, plus digit-free variants like `#TBD`, `#?`, `#X`
- * — "next run, number not yet assigned" (#1272/#1274/#1275). Callers emit
- * `null` so merge.ts's tri-state clears stale runNumbers from prior
- * scrapes when a retitle drops the digit. The `/i` flag handles case;
- * the character classes deliberately list one case only. The
- * `(?:\d+[ \t]*)?` non-capturing wrapper keeps `\d` and the trailing
- * spaces glued together — avoids the `\s*\d*\s*` triple-quantifier
- * shape that Sonar S5852 flags as ReDoS-prone.
+ * `#30TBD`, `#2784 TBA`, plus digit-free variants like `#TBD`, `#?`, `#X`
+ * — "next run, number not yet assigned" (#1272/#1274/#1275). Callers
+ * emit `null` so merge.ts's tri-state clears stale runNumbers from prior
+ * scrapes when a retitle drops the digit.
+ *
+ * Split into two patterns, each carrying at most one zero-or-more
+ * quantifier so Sonar S5852 sees them as provably linear: the digit form
+ * matches `#NN[ ?][suffix]`, the bare form matches `#[suffix]` directly.
+ * `#` is never followed by a space in real reported placeholder titles
+ * — dropping the leading `[ \t]*` after `#` keeps each pattern
+ * unambiguous.
  */
-const HASH_RUN_NUMBER_PLACEHOLDER_RE =
-  /#[ \t]*(?:\d+[ \t]*)?(?:X+\??|TBD|TBA|TBC|\?+)(?=$|[^A-Z0-9])/i;
+const HASH_PLACEHOLDER_SUFFIX = "(?:X+\\??|TBD|TBA|TBC|\\?+)(?=$|[^A-Z0-9])";
+const HASH_RUN_NUMBER_PLACEHOLDER_DIGITS_RE = new RegExp(
+  `#\\d+[ \\t]*${HASH_PLACEHOLDER_SUFFIX}`, "i",
+);
+const HASH_RUN_NUMBER_PLACEHOLDER_BARE_RE = new RegExp(
+  `#${HASH_PLACEHOLDER_SUFFIX}`, "i",
+);
 export function hasPlaceholderRunNumber(text: string | undefined): boolean {
-  return !!text && HASH_RUN_NUMBER_PLACEHOLDER_RE.test(text);
+  if (!text) return false;
+  return HASH_RUN_NUMBER_PLACEHOLDER_DIGITS_RE.test(text)
+    || HASH_RUN_NUMBER_PLACEHOLDER_BARE_RE.test(text);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -717,9 +717,9 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
  * — dropping the leading `[ \t]*` after `#` keeps each pattern
  * unambiguous.
  */
-const HASH_PLACEHOLDER_SUFFIX = "(?:X+\\??|TB[ADC]|\\?+)(?=$|[^A-Z0-9])";
+const HASH_PLACEHOLDER_SUFFIX = String.raw`(?:X+\??|TB[ADC]|\?+)(?=$|[^A-Z0-9])`;
 const HASH_RUN_NUMBER_PLACEHOLDER_DIGITS_RE = new RegExp(
-  `#\\d+[ \\t]*${HASH_PLACEHOLDER_SUFFIX}`, "i",
+  String.raw`#\d+[ \t]*${HASH_PLACEHOLDER_SUFFIX}`, "i",
 );
 const HASH_RUN_NUMBER_PLACEHOLDER_BARE_RE = new RegExp(
   `#${HASH_PLACEHOLDER_SUFFIX}`, "i",

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -705,12 +705,14 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
 
 /**
  * Detect placeholder run-number markers like `#25XX`, `#208X`, `#30X?`,
- * `#30TBD`, `#100?` — "next run, number not yet assigned"
- * (#1272/#1274/#1275). Callers emit `null` so merge.ts's tri-state clears
- * stale runNumbers from prior scrapes when a retitle drops the digit.
+ * `#30TBD`, `#100?`, plus digit-free variants like `#TBD`, `#?`, `#X`
+ * — "next run, number not yet assigned" (#1272/#1274/#1275). Callers emit
+ * `null` so merge.ts's tri-state clears stale runNumbers from prior
+ * scrapes when a retitle drops the digit. The `/i` flag handles case;
+ * the character classes deliberately list one case only.
  */
 const HASH_RUN_NUMBER_PLACEHOLDER_RE =
-  /#\s*\d+\s*(?:[Xx]+\??|TBD|TBA|TBC|\?+)(?=$|[^A-Za-z0-9])/i;
+  /#\s*\d*\s*(?:X+\??|TBD|TBA|TBC|\?+)(?=$|[^A-Z0-9])/i;
 export function hasPlaceholderRunNumber(text: string | undefined): boolean {
   return !!text && HASH_RUN_NUMBER_PLACEHOLDER_RE.test(text);
 }

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -717,13 +717,13 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
  * — dropping the leading `[ \t]*` after `#` keeps each pattern
  * unambiguous.
  */
-const HASH_PLACEHOLDER_SUFFIX = String.raw`(?:X+\??|TB[ADC]|\?+)(?=$|[^A-Z0-9])`;
-const HASH_RUN_NUMBER_PLACEHOLDER_DIGITS_RE = new RegExp(
-  String.raw`#\d+[ \t]*${HASH_PLACEHOLDER_SUFFIX}`, "i",
-);
-const HASH_RUN_NUMBER_PLACEHOLDER_BARE_RE = new RegExp(
-  `#${HASH_PLACEHOLDER_SUFFIX}`, "i",
-);
+// Suffix `(?:X+\??|TB[ADC]|\?+)(?=$|[^A-Z0-9])` is intentionally
+// duplicated inline across both regexes — extracting it forces template
+// literals or `new RegExp(...)` which Sonar S7780 then flags.
+const HASH_RUN_NUMBER_PLACEHOLDER_DIGITS_RE =
+  /#\d+[ \t]*(?:X+\??|TB[ADC]|\?+)(?=$|[^A-Z0-9])/i;
+const HASH_RUN_NUMBER_PLACEHOLDER_BARE_RE =
+  /#(?:X+\??|TB[ADC]|\?+)(?=$|[^A-Z0-9])/i;
 export function hasPlaceholderRunNumber(text: string | undefined): boolean {
   if (!text) return false;
   return HASH_RUN_NUMBER_PLACEHOLDER_DIGITS_RE.test(text)


### PR DESCRIPTION
## Summary

Two bug classes from the audit-stream chrome agent against the Google Calendar adapter.

**Class A — Placeholder run-numbers preserved at leading-digit value** (#1272, #1274, #1275)

The shared [`extractHashRunNumber`](src/adapters/utils.ts:697) helper *already* rejects placeholders like `#25XX`, `#208X`, `#30X?` via its delimiter-lookahead. The actual bug was downstream in the merge pipeline's tri-state at [`merge.ts:1133-1137`](src/pipeline/merge.ts:1133): `runNumber=undefined` preserves the prior scrape's value. When a kennel admin retitled `FCH3 #30: Foo` → `FCH3 #30X?: Foo`, the new RawEvent emitted `undefined` and the stale `30` survived.

Fix: add `hasPlaceholderRunNumber()` helper and have GCal `extractRunNumber` return **`null`** when a placeholder is detected, so merge.ts's tri-state explicitly clears the field.

**Class B — Personal-calendar drift onto a public hash calendar** (#1271)

A "Meet for wedding talk" entry on the Houston H3 calendar reached the public hareline. Add a narrow allowlist of personal-verb title patterns ("Meet for/with/at", "Lunch/Dinner/Brunch with", "Doctor/Dentist appointment", "Pick up", "Drop off", "Call with/to") that drop **only** when no structured fields (runNumber, hares, location, description) exist. FALSE-NEGATIVE bias — anything outside the allowlist passes unconditionally.

## Live verification

Per [`.claude/rules/live-verification.md`](.claude/rules/live-verification.md):

**Phoenix HHH** (`extractHashRunNumber` coupling, must not regress):
```
events: 44, range 2026-02-07 → 2026-06-20
runNumber populated: 32  (Wrong Way #1149, LBH #730, FDTDD #26, …)
runNumber undefined: 12  (no placeholders observed; clean titles parse)
```

**FCH3 / jHav / Houston** (live GCal feeds):
```
=== Fort Collins H3 ===  events=6, placeholders=1
  date=2026-05-30 title="FCH3 #30X?: Frisky Whisk-her and CBD"  → runNumber=null ✓
  clean: FCH3 #305, FCH3 #306 → unchanged
  preserved: "Rex Manning Day" (sparse, but not a personal-verb pattern) ✓

=== jHav ===  events=24, placeholders=4
  Trail #208X events on 2026-05-23, 05-30, 06-06, 06-13  → runNumber=null ✓
  clean: JHavelina H3 Trail #2067, #2068 → unchanged

=== Houston Hash Calendar ===  events=153, placeholders=4
  H4 Run #25XX— events on 2026-05-24, 06-21, 07-19, 07-26  → runNumber=null ✓
  clean: H4 Run #2546 → unchanged
  preserved: "Drinking Practice", "Cychohash" (not personal-verb patterns) ✓
```

## Test plan

- [x] Unit tests cover all four placeholder shapes (`#25XX`, `#208X`, `#30X?`, `#30TBD`) + `#100?` + clean-number controls
- [x] Personal-event filter unit tests cover `Meet for…`, `Lunch with…`, `Doctor appointment`, `Pick up…`, `Drop off…`, `Call with…`, plus negative controls (Rex Manning Day, TGIF Friday, Social @ JBs, AGM, campout, Christmas Hash Party)
- [x] Phoenix HHH live-verified (no regression on `extractHashRunNumber`)
- [x] FCH3 / jHav / Houston GCal live-verified (placeholders → `null`, clean numbers unchanged)
- [x] `npm run lint && npx tsc --noEmit && npm test` green (6215 tests pass)
- [x] `/simplify` review pass applied (split monolithic regex into per-intent array, collapsed redundant `runNumber` checks, consolidated test cases via `it.each`)

Closes #1271
Closes #1272
Closes #1274
Closes #1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)