### PR TITLE
Historical backfill for H5 (#1247)

### DIFF
--- a/scripts/backfill-h5-history.ts
+++ b/scripts/backfill-h5-history.ts
@@ -1,0 +1,57 @@
+/**
+ * One-shot historical backfill for H5 (Honolulu H5, kennel `h5-hi`). Issue #1247.
+ *
+ * Two Google Calendars contribute H5 events:
+ *   1. "Honolulu H5 Google Calendar" — defaultKennelTag `h5-hi` (primary, ~172 events 2024–2026)
+ *   2. "Aloha H3 Google Calendar"    — kennelPatterns route `H5`/`Honolulu H[45]` → `h5-hi` (~62 partial-overlap entries)
+ *
+ * The recurring scrape's `scrapeDays: 365` discards everything older every run,
+ * which is why HashTracks has 1 upcoming + 66 past vs. ~172 source events.
+ * Wide-window pull is safe — GOOGLE_CALENDAR is API-backed and reconcile only
+ * operates within its own window.
+ *
+ * Each calendar has its own Source.id → independent RawEvent fingerprint
+ * namespace. The merge pipeline collapses two raw rows for the same
+ * `(kennelId, date)` into one canonical Event, so pulling both is correct
+ * and dedupes cleanly. Trust-level wins for conflicting fields.
+ *
+ * NOTE: must be applied AFTER WS1's GoogleCalendarAdapter fixes merge
+ * (#1271/#1272/#1274/#1275). The Aloha calendar in particular feeds three
+ * kennels (AH3, H5, PHH) — any mis-parsed run number or personal-event
+ * false positive becomes a durable RawEvent row that a later parser fix
+ * cannot retroactively repair.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-h5-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-h5-history.ts
+ *   Env:     GOOGLE_CALENDAR_API_KEY, DATABASE_URL
+ */
+
+import "dotenv/config";
+import { backfillGCalSource } from "./lib/gcal-backfill";
+
+const TIMEZONE = "Pacific/Honolulu";
+// 4000 days ≈ 11 yr — comfortably covers the 2024 archive floor and any
+// pre-2024 runs we've never seen.
+const DAYS = 4000;
+
+async function main(): Promise<void> {
+  console.log("===== Source 1/2: Honolulu H5 Google Calendar =====\n");
+  await backfillGCalSource({
+    sourceName: "Honolulu H5 Google Calendar",
+    days: DAYS,
+    timezone: TIMEZONE,
+  });
+
+  console.log("\n===== Source 2/2: Aloha H3 Google Calendar (H5 events via kennelPatterns) =====\n");
+  await backfillGCalSource({
+    sourceName: "Aloha H3 Google Calendar",
+    days: DAYS,
+    timezone: TIMEZONE,
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-h5-history.ts
+++ b/scripts/backfill-h5-history.ts
@@ -37,10 +37,15 @@ const DAYS = 4000;
 
 async function main(): Promise<void> {
   console.log("===== Source 1/2: Honolulu H5 Google Calendar =====\n");
+  // keepConnected: the helper's default `finally { prisma.$disconnect() }`
+  // would terminate the cached global client; the second call below would
+  // then fail to query. Last call leaves keepConnected unset so the script
+  // still exits cleanly.
   await backfillGCalSource({
     sourceName: "Honolulu H5 Google Calendar",
     days: DAYS,
     timezone: TIMEZONE,
+    keepConnected: true,
   });
 
   console.log("\n===== Source 2/2: Aloha H3 Google Calendar (H5 events via kennelPatterns) =====\n");

--- a/scripts/lib/gcal-backfill.ts
+++ b/scripts/lib/gcal-backfill.ts
@@ -29,6 +29,13 @@ export interface GCalBackfillParams {
   days: number;
   /** IANA timezone for the today-cutoff (e.g. "Europe/Copenhagen"). */
   timezone: string;
+  /**
+   * Skip the trailing `prisma.$disconnect()`. Set on every call but the last
+   * when chaining multiple `backfillGCalSource` invocations in one process —
+   * Prisma's `$disconnect` is terminal, and the global client is cached, so
+   * a second call after disconnect would fail to query.
+   */
+  keepConnected?: boolean;
 }
 
 function logEventSamples(events: readonly RawEventData[]): void {
@@ -127,7 +134,9 @@ export async function backfillGCalSource(params: GCalBackfillParams): Promise<vo
       console.log(`  Errors:\n    ${sampleErrors}`);
     }
   } finally {
-    await prisma.$disconnect();
+    if (!params.keepConnected) {
+      await prisma.$disconnect();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- New `scripts/backfill-h5-history.ts`: dual-source one-shot historical backfill for H5 (`h5-hi`, Honolulu).
- Pulls **both** calendars that contribute H5 events:
  1. `Honolulu H5 Google Calendar` (primary, defaultKennelTag `h5-hi`)
  2. `Aloha H3 Google Calendar` (secondary; H5 routed via kennelPatterns)
- `days=4000` (~11 yr) covers the 2024 archive floor.

## Why both calendars
Each source has its own `Source.id` → independent RawEvent fingerprint namespace. The merge pipeline collapses two raw rows for the same `(kennelId, date)` into one canonical Event, so pulling both correctly dedupes and trust-levels conflicting fields. Skipping the secondary would leave ~62 H5-routed Aloha-cal events unimported.

## ⚠️ Sequencing — DO NOT APPLY YET
This script must be run **after** WS1's `GoogleCalendarAdapter` parser fixes merge:
- #1271 (personal-event filter)
- #1272 / #1274 / #1275 (placeholder run-number parsing)

The Aloha calendar in particular feeds three kennels (AH3, H5, PHH) and is the most exposed to the personal-event false-positive class — applying before WS1 merges would write durable mis-parsed RawEvent rows that the later parser fix cannot retroactively repair.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passes
- [ ] **After WS1 merges**: rebase on top → dry-run (capture per-source counts) → apply → re-apply (idempotency proof; expect both sources `created=0`) → spot-check `https://www.hashtracks.xyz/kennels/h5-hi` Past tab.

Closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)