### PR TITLE
fix(audit + gcal): C2H3 timezone + permanent coarse-dedup tier

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1038,6 +1038,10 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "c2h3",
+        // Calendar feed publishes dateTime as UTC; without this the wall-clock
+        // slice misreads the UTC hour as local and trips event-improbable-time
+        // on every Thursday run (#964 + 15 daily duplicates).
+        timezone: "America/Chicago",
       },
       kennelCodes: ["c2h3"],
     },

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -1042,6 +1042,126 @@ describe("buildRawEventFromGCalItem — all-day events", () => {
   });
 });
 
+// ── buildRawEventFromGCalItem — timezone-aware extraction (#964 / C2H3) ──
+
+describe("buildRawEventFromGCalItem — timezone-aware extraction (#964)", () => {
+  it("converts UTC dateTime to local HH:MM in the configured timezone (C2H3)", () => {
+    // 19:00 UTC = 14:00 CDT (May 2026 is in DST).
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "C2H3 Thursday Run",
+        start: { dateTime: "2026-05-14T19:00:00.000Z" },
+        end: { dateTime: "2026-05-14T21:00:00.000Z" },
+        status: "confirmed",
+      },
+      { defaultKennelTag: "c2h3", timezone: "America/Chicago" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-05-14");
+    expect(result!.startTime).toBe("14:00");
+    expect(result!.endTime).toBe("16:00");
+  });
+
+  it("handles DST transitions (US fall-back, 2026-11-01)", () => {
+    // Fall-back happens at 07:00 UTC; 06:00 UTC is unambiguously 01:00 CDT.
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Late Hash",
+        start: { dateTime: "2026-11-01T06:00:00.000Z" },
+        status: "confirmed",
+      },
+      { defaultKennelTag: "c2h3", timezone: "America/Chicago" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-11-01");
+    expect(result!.startTime).toBe("01:00");
+  });
+
+  it("preserves endTime when start and end localize to the same local date even if UTC dates differ", () => {
+    // Both UTC values fall on 2026-05-15, but in Central they are both
+    // 2026-05-14. Without timezone applied to BOTH start and end, the raw
+    // UTC slice would emit dateISO="2026-05-15" and endParts.dateISO would
+    // disagree with dateISO, silently dropping endTime at line 1092.
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Late Trail",
+        start: { dateTime: "2026-05-15T02:30:00.000Z" },
+        end: { dateTime: "2026-05-15T04:30:00.000Z" },
+        status: "confirmed",
+      },
+      { defaultKennelTag: "c2h3", timezone: "America/Chicago" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-05-14");
+    expect(result!.startTime).toBe("21:30");
+    expect(result!.endTime).toBe("23:30");
+  });
+
+  it("does not affect all-day events (date-only, no dateTime)", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Annual Campout",
+        start: { date: "2026-05-14" },
+        end: { date: "2026-05-15" },
+        description: "Hares: Trail Boss\nWhat: Campout",
+        status: "confirmed",
+      },
+      { defaultKennelTag: "c2h3", timezone: "America/Chicago", includeAllDayEvents: true, defaultStartTime: "18:00" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-05-14");
+    expect(result!.startTime).toBe("18:00");
+  });
+
+  it("preserves legacy raw-slice behavior when timezone is undefined", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Legacy Source",
+        start: { dateTime: "2026-04-15T19:00:00-04:00" },
+        status: "confirmed",
+      },
+      { defaultKennelTag: "test" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-04-15");
+    expect(result!.startTime).toBe("19:00");
+  });
+
+  it("falls back to raw-slice when dateTime is malformed (does not throw on Invalid Date)", () => {
+    // formatToParts(Invalid Date) throws RangeError. Guard must catch
+    // unparseable strings and let the regex fallback handle them.
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Bad Payload",
+        start: { dateTime: "not-a-date-2026-04-15T19:00:00" },
+        status: "confirmed",
+      },
+      { defaultKennelTag: "test", timezone: "America/Chicago" },
+    );
+    expect(result).not.toBeNull();
+    // Regex fallback recovers the YYYY-MM-DD substring.
+    expect(result!.date).toBe("2026-04-15");
+  });
+
+  it("falls back to raw-slice when the configured timezone is invalid (admin validator bypassed via seed/DB)", () => {
+    // Intl.DateTimeFormat({ timeZone: "Bogus/Zone" }) throws RangeError.
+    // The cache stores `null` so subsequent events with the same bad
+    // zone don't repeat the throw. Adapter must NOT crash the scrape.
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Bad TZ Source",
+        start: { dateTime: "2026-04-15T19:00:00-04:00" },
+        status: "confirmed",
+      },
+      { defaultKennelTag: "test", timezone: "Bogus/Not_Real" },
+    );
+    expect(result).not.toBeNull();
+    // Raw-slice extracts wall-clock digits from the RFC3339 string directly.
+    expect(result!.date).toBe("2026-04-15");
+    expect(result!.startTime).toBe("19:00");
+  });
+});
+
 // ── buildRawEventFromGCalItem — skipPatterns ──
 
 describe("buildRawEventFromGCalItem — skipPatterns", () => {

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -653,6 +653,39 @@ function getTzFormatter(timezone: string): Intl.DateTimeFormat | null {
 }
 
 /**
+ * Convert a UTC `dateTime` to local wall-clock parts in the given zone.
+ * Returns `null` on any failure (invalid Date, invalid timezone, missing
+ * formatToParts components) so the caller can fall back to raw-slice.
+ *
+ * All five parts (year/month/day/hour/minute) are required — without
+ * this guard a missing component would silently emit malformed output
+ * like `"2026--14"` or `"14:"`. ICU should always populate every part
+ * for the configured options on a valid date, but defending against
+ * exotic locale builds is cheap.
+ */
+function extractDateTimeWithTimezone(
+  dateTime: string,
+  timezone: string,
+): { dateISO: string; startTime: string } | null {
+  const fmt = getTzFormatter(timezone);
+  if (!fmt) return null;
+  const date = new Date(dateTime);
+  if (Number.isNaN(date.getTime())) return null;
+  const parts = fmt.formatToParts(date);
+  let year = "", month = "", day = "", hour = "", minute = "";
+  for (const p of parts) {
+    if (p.type === "year") year = p.value;
+    else if (p.type === "month") month = p.value;
+    else if (p.type === "day") day = p.value;
+    else if (p.type === "hour") hour = p.value;
+    else if (p.type === "minute") minute = p.value;
+  }
+  if (!year || !month || !day || !hour || !minute) return null;
+  if (hour === "24") hour = "00";
+  return { dateISO: `${year}-${month}-${day}`, startTime: `${hour}:${minute}` };
+}
+
+/**
  * Extract local date and time from a Google Calendar start/end object.
  * With `timezone`, the instant is converted via Intl into wall-clock
  * digits in that zone — required for feeds that publish `dateTime` as
@@ -664,26 +697,8 @@ function extractDateTimeFromGCalItem(
 ): { dateISO: string; startTime: string | undefined } {
   if (start.dateTime) {
     if (timezone) {
-      const fmt = getTzFormatter(timezone);
-      const date = new Date(start.dateTime);
-      // Guard both: formatToParts throws RangeError on Invalid Date,
-      // and `fmt === null` means the timezone itself failed to compile.
-      if (fmt && !Number.isNaN(date.getTime())) {
-        const parts = fmt.formatToParts(date);
-        let year = "", month = "", day = "", hour = "", minute = "";
-        for (const p of parts) {
-          if (p.type === "year") year = p.value;
-          else if (p.type === "month") month = p.value;
-          else if (p.type === "day") day = p.value;
-          else if (p.type === "hour") hour = p.value;
-          else if (p.type === "minute") minute = p.value;
-        }
-        if (year && hour) {
-          if (hour === "24") hour = "00";
-          return { dateISO: `${year}-${month}-${day}`, startTime: `${hour}:${minute}` };
-        }
-      }
-      // Invalid Date, invalid timezone, or missing parts — raw-slice fallback.
+      const tz = extractDateTimeWithTimezone(start.dateTime, timezone);
+      if (tz) return tz;
     }
     const dtMatch = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})/.exec(
       start.dateTime,

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -549,6 +549,13 @@ interface CalendarSourceConfig {
     kennelTag: string;       // which kennel's events to back-fill
     blockHeader: string;     // e.g. "4x2 H4 Hareline:"
   };
+  /**
+   * IANA timezone name. Required for calendars that publish `dateTime` as
+   * UTC (`...Z`) — without it the wall-clock slice misreads the UTC hour
+   * as local and trips `event-improbable-time` on every late run (#964).
+   * Undefined preserves the legacy raw-slice behavior.
+   */
+  timezone?: string;
 }
 
 /**
@@ -602,9 +609,82 @@ interface GCalListResponse {
   error?: { code: number; message: string };
 }
 
-/** Extract local date and time from a Google Calendar start object. */
-function extractDateTimeFromGCalItem(start: { dateTime?: string; date?: string }): { dateISO: string; startTime: string | undefined } {
+// One Intl.DateTimeFormat per IANA zone. The set is bounded by the
+// configured GCal sources; without caching, busy scrapes allocate a
+// fresh formatter for every event (~5K per cron tick on a 365-day window).
+// `null` is cached ONLY for RangeError (invalid IANA name — durable config
+// error). Transient errors don't poison the cache; the next event retries.
+const tzFormatterCache = new Map<string, Intl.DateTimeFormat | null>();
+function getTzFormatter(timezone: string): Intl.DateTimeFormat | null {
+  if (tzFormatterCache.has(timezone)) return tzFormatterCache.get(timezone) ?? null;
+  try {
+    // en-GB: predictable 24-hour formatting. We still normalize "24" → "00"
+    // below as a belt-and-braces guard against ICU edge cases.
+    const fmt = new Intl.DateTimeFormat("en-GB", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    tzFormatterCache.set(timezone, fmt);
+    return fmt;
+  } catch (err) {
+    if (err instanceof RangeError) {
+      // Durable config error (invalid IANA name) — admin validator catches
+      // new edits but pre-existing seed/DB rows could still slip through.
+      // Cache null so we don't re-throw on every event.
+      console.warn(
+        `[gcal-adapter] Invalid timezone "${timezone}" — falling back to raw-slice extraction:`,
+        err,
+      );
+      tzFormatterCache.set(timezone, null);
+      return null;
+    }
+    // Unexpected error — log and DO NOT poison the cache. Next event retries.
+    console.error(
+      `[gcal-adapter] Unexpected error constructing formatter for "${timezone}":`,
+      err,
+    );
+    return null;
+  }
+}
+
+/**
+ * Extract local date and time from a Google Calendar start/end object.
+ * With `timezone`, the instant is converted via Intl into wall-clock
+ * digits in that zone — required for feeds that publish `dateTime` as
+ * UTC (`...Z`). Without it, the legacy raw-slice path runs unchanged.
+ */
+function extractDateTimeFromGCalItem(
+  start: { dateTime?: string; date?: string },
+  timezone?: string,
+): { dateISO: string; startTime: string | undefined } {
   if (start.dateTime) {
+    if (timezone) {
+      const fmt = getTzFormatter(timezone);
+      const date = new Date(start.dateTime);
+      // Guard both: formatToParts throws RangeError on Invalid Date,
+      // and `fmt === null` means the timezone itself failed to compile.
+      if (fmt && !Number.isNaN(date.getTime())) {
+        const parts = fmt.formatToParts(date);
+        let year = "", month = "", day = "", hour = "", minute = "";
+        for (const p of parts) {
+          if (p.type === "year") year = p.value;
+          else if (p.type === "month") month = p.value;
+          else if (p.type === "day") day = p.value;
+          else if (p.type === "hour") hour = p.value;
+          else if (p.type === "minute") minute = p.value;
+        }
+        if (year && hour) {
+          if (hour === "24") hour = "00";
+          return { dateISO: `${year}-${month}-${day}`, startTime: `${hour}:${minute}` };
+        }
+      }
+      // Invalid Date, invalid timezone, or missing parts — raw-slice fallback.
+    }
     const dtMatch = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})/.exec(
       start.dateTime,
     );
@@ -618,7 +698,6 @@ function extractDateTimeFromGCalItem(start: { dateTime?: string; date?: string }
     }
     return { dateISO: "", startTime: undefined };
   }
-  // All-day event: start.date is already YYYY-MM-DD
   return { dateISO: start.date ?? "", startTime: undefined };
 }
 
@@ -723,9 +802,9 @@ export function buildRawEventFromGCalItem(
   const isAllDay = !!(item.start?.date && !item.start?.dateTime);
   if (isAllDay && !sourceConfig?.includeAllDayEvents) return null;
 
-  const { dateISO, startTime } = extractDateTimeFromGCalItem(item.start);
+  const { dateISO, startTime } = extractDateTimeFromGCalItem(item.start, sourceConfig?.timezone);
   if (!dateISO) return null;
-  const endParts = item.end ? extractDateTimeFromGCalItem(item.end) : undefined;
+  const endParts = item.end ? extractDateTimeFromGCalItem(item.end, sourceConfig?.timezone) : undefined;
   const summary = decodeEntities(item.summary);
 
   // Skip events whose summary matches any configured skip pattern (e.g., cross-kennel posts)

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -412,9 +412,26 @@ function validateGenericHtmlConfig(obj: Record<string, unknown>, errors: string[
   validateDefaultStartTimeByKennel(obj.defaultStartTimeByKennel, errors);
 }
 
+/**
+ * Validate Google Calendar source config. Currently only validates the
+ * optional `timezone` field (IANA name); other GCal fields are validated
+ * via the shared regex / pattern paths in `validateSourceConfig`.
+ */
+function validateGoogleCalendarConfig(obj: Record<string, unknown>, errors: string[]): void {
+  if (obj.timezone === undefined) return;
+  if (typeof obj.timezone !== "string" || !obj.timezone.trim()) {
+    errors.push("Google Calendar config timezone must be a non-empty IANA name (e.g. \"America/Chicago\")");
+    return;
+  }
+  if (!isValidTimezone(obj.timezone)) {
+    errors.push(`Google Calendar config timezone "${obj.timezone}" is not a recognized IANA timezone`);
+  }
+}
+
 /** Run type-specific validation for a source config. */
 function runTypeValidator(type: string, obj: Record<string, unknown>, errors: string[]): void {
   if (type === "GOOGLE_SHEETS") validateGoogleSheetsConfig(obj, errors);
+  else if (type === "GOOGLE_CALENDAR") validateGoogleCalendarConfig(obj, errors);
   else if (type === "MEETUP") validateMeetupConfig(obj, errors);
   else if (type === "RSS_FEED") validateRssFeedConfig(obj, errors);
   else if (type === "STATIC_SCHEDULE") validateStaticScheduleConfig(obj, errors);

--- a/src/app/api/audit/file-finding/route.ts
+++ b/src/app/api/audit/file-finding/route.ts
@@ -239,6 +239,7 @@ function errorMessageFor(reason: FilerErrorReason): string {
   switch (reason) {
     case "comment-failed-strict":
     case "comment-failed-bridging":
+    case "comment-failed-coarse":
       return "GitHub comment failed; refusing to fork a duplicate issue";
     case "db-update-failed":
       return "Filing-mirror DB update failed after successful GitHub comment; retry is safe";

--- a/src/lib/admin/audit-prompt-shared.ts
+++ b/src/lib/admin/audit-prompt-shared.ts
@@ -103,7 +103,7 @@ Response: \`{ "nonce": "<base64url>" }\` (5-minute TTL, single-use).
 
 Response shapes:
 - \`{ "action": "created", "issueNumber": N, "issueHtmlUrl": "..." }\` — fresh issue filed.
-- \`{ "action": "recurred", "tier": "strict" | "bridging", "existingIssueNumber": N, "existingIssueHtmlUrl": "...", "recurrenceCount": N }\` — same finding already had an open issue; we commented "still recurring" instead of forking. **Don't refile.**
+- \`{ "action": "recurred", "tier": "strict" | "bridging" | "coarse", "existingIssueNumber": N, "existingIssueHtmlUrl": "...", "recurrenceCount": N }\` — same finding already had an open issue; we commented "still recurring" instead of forking. **Don't refile.** (\`coarse\` is the dedup path for non-fingerprintable rules — see #964.)
 - \`{ "error": "...", "existingIssueNumber"?: N }\` (502) — GitHub side effect failed; safe to retry the same nonce.
 - \`{ "error": "Nonce invalid, expired, or payload tampered" }\` (401) — nonce mismatch; mint a fresh one and retry.
 

--- a/src/pipeline/audit-filer.test.ts
+++ b/src/pipeline/audit-filer.test.ts
@@ -461,15 +461,24 @@ describe("fileAuditFinding — create tier", () => {
     expect(createCall.labels).toEqual(BASE_INPUT.labels);
   });
 
-  it("creates without canonical block (and skips dedup tiers) for non-fingerprintable rules", async () => {
+  it("creates without canonical block (and skips fingerprint dedup tiers) for non-fingerprintable rules when coarse-dedup finds no match", async () => {
+    // Non-fingerprintable rules skip the strict + bridging tiers
+    // entirely (canonical === null short-circuits both). The coarse
+    // tier (#964) runs in their place; with no candidates it falls
+    // through to a fresh create.
+    mockFindMany.mockResolvedValue([] as never);
     const actions = buildActions();
     const input = { ...BASE_INPUT, ruleSlug: "hare-cta-text" };
 
     const out = await fileAuditFinding(input, actions);
     expect(out.action).toBe("created");
-    // No fingerprint queries at all.
+    // No fingerprint-keyed strict-tier query.
     expect(mockFindFirst).not.toHaveBeenCalled();
-    expect(mockFindMany).not.toHaveBeenCalled();
+    // Coarse-dedup ran (single findMany with stream filter present);
+    // no fingerprint:null query without stream filter.
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    const callArgs = mockFindMany.mock.calls[0][0] as { where: Record<string, unknown> };
+    expect(callArgs.where).toHaveProperty("stream", AuditStream.AUTOMATED);
     const createCall = vi.mocked(actions.createIssue).mock.calls[0][0];
     expect(createCall.body).not.toContain("<!-- audit-canonical:");
   });
@@ -758,5 +767,388 @@ describe("fileAuditFinding — recurrence escalation", () => {
     // Meta is filed and tracked even though link comment failed.
     expect(out.escalatedToIssueNumber).toBe(777);
     expect(postComment).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Coarse-dedup tier (non-fingerprintable rules; #964 / C2H3) ─────────
+
+const COARSE_INPUT = {
+  stream: AuditStream.AUTOMATED,
+  kennelCode: "c2h3",
+  // `hare-cta-text` is registered with `fingerprint: false` in the test
+  // mock above — same shape as `event-improbable-time` and the other 4
+  // unmigrated rules. canonical block returns null → coarse-dedup runs.
+  ruleSlug: "hare-cta-text",
+  title: "[Audit] C2H3 — Hare Quality [hare-cta-text] (1 events) — 2026-05-09",
+  bodyMarkdown: "## C2H3 hare-cta-text\n\nDetails here.",
+  labels: ["audit", "alert", "audit:automated", "kennel:c2h3"],
+} as const;
+
+describe("fileAuditFinding — coarse-dedup tier (non-fingerprintable rules)", () => {
+  it("comments + CAS-increments recurrenceCount when an open same-stream null-fingerprint row matches kennel + rule", async () => {
+    // recurrenceCount 2 keeps us under ESCALATION_THRESHOLD so the
+    // escalation path stays out of this test (covered separately).
+    mockFindMany.mockResolvedValue([
+      {
+        id: "coarse_1",
+        githubNumber: 964,
+        htmlUrl: "https://github.com/x/y/issues/964",
+        title:
+          "[Audit] C2H3 — Hare Quality [hare-cta-text] (1 events) — 2026-05-08",
+        recurrenceCount: 2,
+        kennel: { shortName: "C2H3" },
+      },
+    ] as never);
+    mockUpdateMany.mockResolvedValue({ count: 1 } as never); // CAS wins
+    const actions = buildActions();
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+
+    expect(out).toEqual({
+      action: "recurred",
+      issueNumber: 964,
+      htmlUrl: "https://github.com/x/y/issues/964",
+      recurrenceCount: 3,
+      tier: "coarse",
+    });
+    expect(mockFindFirst).not.toHaveBeenCalled();
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          kennelCode: "c2h3",
+          stream: AuditStream.AUTOMATED,
+          fingerprint: null,
+          state: "open",
+          delistedAt: null,
+        }),
+      }),
+    );
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: "coarse_1",
+        recurrenceCount: 2,
+        state: "open",
+        delistedAt: null,
+      },
+      data: { recurrenceCount: { increment: 1 } },
+    });
+    expect(actions.postComment).toHaveBeenCalledWith(
+      964,
+      expect.stringContaining("Still recurring on"),
+    );
+    expect(actions.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("escalates after crossing ESCALATION_THRESHOLD on a coarse-dedup recurrence", async () => {
+    // Coarse-dedup uses the same escalation path as strict / bridging.
+    // When a non-fingerprintable rule has been recurring for
+    // ESCALATION_THRESHOLD consecutive cron ticks, the next coarse hit
+    // claims the escalation slot and files a meta-issue.
+    mockFindMany.mockResolvedValue([
+      {
+        id: "coarse_1",
+        githubNumber: 964,
+        htmlUrl: "https://github.com/x/y/issues/964",
+        title:
+          "[Audit] C2H3 — Hare Quality [hare-cta-text] (1 events) — 2026-05-04",
+        recurrenceCount: ESCALATION_THRESHOLD - 1,
+        kennel: { shortName: "C2H3" },
+      },
+    ] as never);
+    // First updateMany: coarse CAS wins. Second updateMany: escalation claim.
+    mockUpdateMany
+      .mockResolvedValueOnce({ count: 1 } as never)
+      .mockResolvedValueOnce({ count: 1 } as never);
+    const actions = buildActions();
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+    if (out.action !== "recurred") throw new Error("expected recurred");
+    expect(out.tier).toBe("coarse");
+    expect(out.recurrenceCount).toBe(ESCALATION_THRESHOLD);
+    expect(out.escalatedToIssueNumber).toBe(999); // default mocked createIssue number
+    // Two postComment calls: recurrence comment + escalation link comment.
+    expect(actions.postComment).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT coalesce across audit streams", async () => {
+    // chrome-kennel rows for the same kennel + rule must not be
+    // attached to by an automated finding (different triage contexts).
+    // The mock simulates the DB honoring the stream filter.
+    mockFindMany.mockResolvedValue([] as never);
+    const actions = buildActions();
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+    // Falls through to fresh-create because no same-stream candidate.
+    expect(out.action).toBe("created");
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+    expect(actions.createIssue).toHaveBeenCalled();
+    // The query that actually went out had the stream filter applied.
+    const findManyCall = mockFindMany.mock.calls[0][0] as {
+      where: { stream: AuditStream };
+    };
+    expect(findManyCall.where.stream).toBe(AuditStream.AUTOMATED);
+  });
+
+  it("on CAS loss after a successful comment, refetches the canonical row and returns the peer's count (single canonical thread)", async () => {
+    // Codex round-2 MEDIUM #3 regression. Without refetch-and-return,
+    // a CAS loss would either advance to the next candidate (splitting
+    // the thread) or retry the CAS (over-counting). After the fix: post
+    // comment, lose CAS to a peer, refetch the same row, return peer's
+    // count as our outcome.
+    const cand = {
+      id: "coarse_1",
+      githubNumber: 964,
+      htmlUrl: "https://github.com/x/y/issues/964",
+      title: "[Audit] C2H3 — Hare Quality [hare-cta-text] (1 events) — 2026-05-08",
+      recurrenceCount: 2,
+      kennel: { shortName: "C2H3" },
+    };
+    mockFindMany.mockResolvedValue([cand] as never);
+    mockUpdateMany.mockResolvedValue({ count: 0 } as never); // CAS loses
+    mockFindUnique.mockResolvedValue({
+      recurrenceCount: 3,            // peer's increment
+      escalatedToIssueNumber: null,
+      state: "open",
+      delistedAt: null,
+    } as never);
+    const actions = buildActions();
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+    expect(out.action).toBe("recurred");
+    if (out.action !== "recurred") return;
+    expect(out.issueNumber).toBe(964);
+    expect(out.recurrenceCount).toBe(3);            // peer's count, not ours+1
+    expect(out.tier).toBe("coarse");
+    // Comment posted exactly once (our attempt). CAS attempted once
+    // (lost). No create.
+    expect(actions.postComment).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
+    expect(actions.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("does NOT increment recurrenceCount when the coarse-dedup comment fails (idempotent across cron retries)", async () => {
+    // Codex round-3 HIGH #2 regression. Comment-first ordering means a
+    // comment failure surfaces before any DB mutation. Next cron tick
+    // re-finds the same canonical with the same recurrenceCount and
+    // retries cleanly — never over-counting from a partial run.
+    const cand = {
+      id: "coarse_1",
+      githubNumber: 964,
+      htmlUrl: "https://github.com/x/y/issues/964",
+      title: "[Audit] C2H3 — Hare Quality [hare-cta-text] (1 events) — 2026-05-08",
+      recurrenceCount: 2,
+      kennel: { shortName: "C2H3" },
+    };
+    mockFindMany.mockResolvedValue([cand] as never);
+    const actions = buildActions({
+      postComment: vi.fn().mockResolvedValue(false),
+    });
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+    expect(out).toEqual({
+      action: "error",
+      reason: "comment-failed-coarse",
+      existingIssueNumber: 964,
+    });
+    // Critically: NO CAS / DB increment. recurrenceCount is unchanged.
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+    expect(actions.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("retries the candidate fetch when the canonical row vanished between findMany and CAS", async () => {
+    // Edge case: between candidate fetch and refetch, the canonical row
+    // was closed/delisted. The loop tries again from scratch — maybe
+    // there's another open candidate.
+    const stale = {
+      id: "coarse_stale",
+      githubNumber: 800,
+      htmlUrl: "https://github.com/x/y/issues/800",
+      title: "[Audit] C2H3 — Hare Quality [hare-cta-text] (1 events) — 2026-04-10",
+      recurrenceCount: 5,
+      kennel: { shortName: "C2H3" },
+    };
+    const fresh = {
+      id: "coarse_fresh",
+      githubNumber: 964,
+      htmlUrl: "https://github.com/x/y/issues/964",
+      title: "[Audit] C2H3 — Hare Quality [hare-cta-text] (1 events) — 2026-05-08",
+      recurrenceCount: 1,
+      kennel: { shortName: "C2H3" },
+    };
+    // Attempt 1: stale row, CAS loses, refetch shows row closed → retry.
+    // Attempt 2: fresh row, CAS wins.
+    mockFindMany
+      .mockResolvedValueOnce([stale] as never)
+      .mockResolvedValueOnce([fresh] as never);
+    mockUpdateMany
+      .mockResolvedValueOnce({ count: 0 } as never)
+      .mockResolvedValueOnce({ count: 1 } as never);
+    mockFindUnique.mockResolvedValueOnce({
+      recurrenceCount: 5,
+      escalatedToIssueNumber: null,
+      state: "closed",      // row was closed
+      delistedAt: null,
+    } as never);
+    const actions = buildActions();
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+    expect(out.action).toBe("recurred");
+    if (out.action !== "recurred") return;
+    expect(out.issueNumber).toBe(964);
+    expect(out.recurrenceCount).toBe(2);
+    expect(actions.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("filters by [<ruleSlug>] in the SQL query for the automated stream", async () => {
+    // Without the SQL title filter the 25-row candidate cap could hide
+    // the canonical row behind unrelated open audit issues. For automated
+    // stream, the [<slug>] bracket is in the title format and gets pushed
+    // down to the DB.
+    mockFindMany.mockResolvedValue([] as never);
+    const actions = buildActions();
+
+    await fileAuditFinding(COARSE_INPUT, actions);
+    const callArgs = mockFindMany.mock.calls[0][0] as {
+      where: { title?: { contains: string } };
+    };
+    expect(callArgs.where.title).toEqual({ contains: "[hare-cta-text]" });
+  });
+
+  it("filters by trailing ' <ruleSlug>' in the SQL query for chrome streams", async () => {
+    // Chrome title format is `Finding: {kennel} {slug}` — slug at end of
+    // title. Pushing endsWith into SQL ensures the 25-row cap can't hide
+    // the canonical row even if the kennel accumulates many open
+    // chrome-stream issues across distinct rules.
+    mockFindMany.mockResolvedValue([] as never);
+    const actions = buildActions();
+
+    const chromeInput = { ...COARSE_INPUT, stream: AuditStream.CHROME_KENNEL };
+    await fileAuditFinding(chromeInput, actions);
+    const callArgs = mockFindMany.mock.calls[0][0] as {
+      where: { title?: { endsWith: string } };
+    };
+    expect(callArgs.where.title).toEqual({ endsWith: " hare-cta-text" });
+  });
+
+  it("rejects chrome titles whose slug appears amid extra prose (exact-format identity check)", async () => {
+    // The chrome title regex is permissive — it captures the LAST slug
+    // token. An operator-edited title like `Finding: C2H3 please ignore
+    // hare-cta-text` parses as `hare-cta-text` and would be accepted
+    // by the SQL endsWith filter. The exact-format in-memory check
+    // catches this and forces fall-through to fresh-create.
+    mockFindMany.mockResolvedValue([
+      {
+        id: "chrome_noisy",
+        githubNumber: 500,
+        htmlUrl: "https://github.com/x/y/issues/500",
+        title: "Finding: C2H3 please ignore hare-cta-text",
+        recurrenceCount: 0,
+        kennel: { shortName: "C2H3" },
+      },
+    ] as never);
+    const actions = buildActions();
+
+    const chromeInput = { ...COARSE_INPUT, stream: AuditStream.CHROME_KENNEL };
+    const out = await fileAuditFinding(chromeInput, actions);
+    // Strict format mismatch → no canonical match → fresh create.
+    expect(out.action).toBe("created");
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+    expect(actions.postComment).not.toHaveBeenCalled();
+  });
+
+  it("matches chrome titles in the canonical exact format", async () => {
+    mockFindMany.mockResolvedValue([
+      {
+        id: "chrome_canon",
+        githubNumber: 500,
+        htmlUrl: "https://github.com/x/y/issues/500",
+        title: "Finding: C2H3 hare-cta-text",
+        recurrenceCount: 1,
+        kennel: { shortName: "C2H3" },
+      },
+    ] as never);
+    mockUpdateMany.mockResolvedValue({ count: 1 } as never);
+    const actions = buildActions();
+
+    const chromeInput = { ...COARSE_INPUT, stream: AuditStream.CHROME_KENNEL };
+    const out = await fileAuditFinding(chromeInput, actions);
+    expect(out.action).toBe("recurred");
+    if (out.action !== "recurred") return;
+    expect(out.issueNumber).toBe(500);
+    expect(out.tier).toBe("coarse");
+  });
+
+  it("returns comment-failed-coarse without rolling back the increment if the recur comment fails", async () => {
+    // CAS already incremented; if the comment fails, the count is
+    // bumped but no comment landed. A retry will pick a different
+    // candidate (recurrenceCount no longer matches the original
+    // snapshot). This mirrors strict-tier semantics: comment spam
+    // is preferable to a lost recurrence count.
+    mockFindMany.mockResolvedValue([
+      {
+        id: "coarse_1",
+        githubNumber: 964,
+        htmlUrl: "https://github.com/x/y/issues/964",
+        title:
+          "[Audit] C2H3 — Hare Quality [hare-cta-text] (1 events) — 2026-05-08",
+        recurrenceCount: 7,
+        kennel: { shortName: "C2H3" },
+      },
+    ] as never);
+    mockUpdateMany.mockResolvedValue({ count: 1 } as never);
+    const actions = buildActions({
+      postComment: vi.fn().mockResolvedValue(false),
+    });
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+    expect(out).toEqual({
+      action: "error",
+      reason: "comment-failed-coarse",
+      existingIssueNumber: 964,
+    });
+    expect(actions.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("skips candidates whose title slug does not match the input rule slug", async () => {
+    // Same kennel + stream, but the candidate's title carries a
+    // different rule slug. The loop skips it without attempting the
+    // CAS, and the cascade falls through to fresh-create.
+    mockFindMany.mockResolvedValue([
+      {
+        id: "coarse_other_rule",
+        githubNumber: 99,
+        htmlUrl: "https://github.com/x/y/issues/99",
+        title:
+          "[Audit] C2H3 — Title Quality [title-raw-kennel-code] (1 events) — 2026-05-09",
+        recurrenceCount: 0,
+        kennel: { shortName: "C2H3" },
+      },
+    ] as never);
+    const actions = buildActions();
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+    expect(out.action).toBe("created");
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+    expect(actions.createIssue).toHaveBeenCalled();
+  });
+
+  it("does NOT run for fingerprintable rules — canonical-non-null routes through strict/bridging only", async () => {
+    // Codex review note: coarse-dedup is gated to canonical === null.
+    // For a fingerprintable rule (hare-url here), the cascade goes
+    // strict → bridging → create; coarse-dedup is never invoked even
+    // if the bridging tier exhausts its candidates.
+    mockFindFirst.mockResolvedValue(null); // strict miss
+    mockFindMany.mockResolvedValue([] as never); // bridging empty
+    const actions = buildActions();
+
+    const out = await fileAuditFinding(BASE_INPUT, actions); // hare-url (fingerprintable)
+    expect(out.action).toBe("created");
+    // Bridging fired exactly once with fingerprint:null + kennelCode
+    // (no stream filter — bridging accepts cross-stream legacy rows).
+    // Coarse-dedup would have been a SECOND findMany call with
+    // stream filter — that must not happen.
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    const callArgs = mockFindMany.mock.calls[0][0] as { where: Record<string, unknown> };
+    expect(callArgs.where).not.toHaveProperty("stream");
   });
 });

--- a/src/pipeline/audit-filer.ts
+++ b/src/pipeline/audit-filer.ts
@@ -72,7 +72,7 @@ import {
   NEEDS_DECISION_LABEL,
   kennelLabel,
 } from "@/lib/audit-labels";
-import type { AuditStream } from "@/lib/audit-stream-meta";
+import { AUDIT_STREAM, type AuditStream } from "@/lib/audit-stream-meta";
 import {
   extractRuleSlugFromAutomatedTitle,
   extractRuleSlugFromChromeTitle,
@@ -127,7 +127,7 @@ export type FileFindingOutcome =
       issueNumber: number;
       htmlUrl: string;
       recurrenceCount: number;
-      tier: "strict" | "bridging";
+      tier: "strict" | "bridging" | "coarse";
       /** Set when this recur crossed the escalation threshold and a
        *  meta-issue was filed (or had previously been filed for this
        *  base lifecycle). Lets callers surface a link to the meta in
@@ -147,6 +147,7 @@ export type FileFindingOutcome =
 export type FilerErrorReason =
   | "comment-failed-strict"
   | "comment-failed-bridging"
+  | "comment-failed-coarse"
   | "create-failed"
   | "db-update-failed";
 
@@ -598,9 +599,198 @@ async function tryBridge(
 }
 
 /**
- * File an audit finding through the strict-tier → bridging-tier →
- * create cascade. Returns a tagged outcome so the caller can render
- * appropriate logs / response payloads.
+ * Bound on the candidate-vanished retry loop in `tryCoarseDedup`. Two
+ * attempts handles the rare case where a row closes between findMany
+ * and the CAS; if neither attempt finds a stable canonical, the loop
+ * exits with `null` (truly no match) and the caller creates fresh.
+ */
+const COARSE_DEDUP_MAX_RETRIES = 2;
+
+/**
+ * Coarse-dedup tier for non-fingerprintable rules. The 5 unmigrated
+ * rules (header in `rule-definitions.ts`) skip strict + bridging and
+ * would otherwise create a fresh issue per cron tick — that's how #964
+ * accumulated 16 daily duplicates for C2H3 / `event-improbable-time`.
+ *
+ * Stream-scoped to prevent automated/chrome cross-coalescing. For the
+ * automated stream, the title's `[<ruleSlug>]` bracket is part of the
+ * SQL filter so the 25-row candidate cap can't hide the canonical row
+ * behind unrelated open issues. Chrome streams are low-volume; their
+ * `Finding: <kennel> <slug>` titles are matched in-memory.
+ *
+ * Order mirrors `runStrictTier`: post comment first, then CAS-increment
+ * `recurrenceCount`. The comment-first ordering keeps retries idempotent
+ * across cron ticks — a comment failure surfaces without bumping the
+ * count, so the next tick re-runs cleanly. CAS-loss after a successful
+ * comment means a peer caller raced to the increment; we refetch the
+ * row's current state and return the peer's count (mild duplicate
+ * recurrence comments under contention is the same trade-off the
+ * strict tier accepts and is preferable to over-counting).
+ */
+async function tryCoarseDedup(
+  input: FileFindingInput,
+  actions: FilerActions,
+): Promise<FileFindingOutcome | null> {
+  // Push the rule-slug discriminator into SQL so the 25-row LIMIT can't
+  // push the canonical row outside the candidate window for kennels with
+  // deep backlogs. Per-stream because the title formats differ:
+  //   - automated: `[Audit] {kennel} — {category} [{slug}] (...) — date`
+  //   - chrome:    `Finding: {kennel} {slug}`
+  //   - unknown:   no enforced format → no SQL filter, fall back to in-memory
+  const titleFilter = ((): { contains: string } | { endsWith: string } | undefined => {
+    if (input.stream === AUDIT_STREAM.AUTOMATED) return { contains: `[${input.ruleSlug}]` };
+    if (input.stream === AUDIT_STREAM.CHROME_EVENT || input.stream === AUDIT_STREAM.CHROME_KENNEL) {
+      return { endsWith: ` ${input.ruleSlug}` };
+    }
+    return undefined;
+  })();
+
+  for (let attempt = 0; attempt < COARSE_DEDUP_MAX_RETRIES; attempt++) {
+    const candidates = await prisma.auditIssue.findMany({
+      where: {
+        kennelCode: input.kennelCode,
+        stream: input.stream,
+        fingerprint: null,
+        state: "open",
+        delistedAt: null,
+        ...(titleFilter ? { title: titleFilter } : {}),
+      },
+      select: {
+        id: true,
+        githubNumber: true,
+        htmlUrl: true,
+        title: true,
+        recurrenceCount: true,
+        escalatedToIssueNumber: true,
+        kennel: { select: { shortName: true } },
+      },
+      orderBy: { githubCreatedAt: "asc" },
+      take: 25,
+    });
+
+    // In-memory identity check. Two reasons we don't trust the SQL
+    // filter alone: (1) the chrome regex is intentionally permissive
+    // (`extractRuleSlugFromChromeTitle` accepts any trailing slug-shaped
+    // token, so a title like `Finding: NYCH3 note about hare-cta-text`
+    // would parse as that slug); (2) operator-edited titles can drift
+    // from the canonical format. For chrome streams we additionally
+    // require the exact format `Finding: <kennelShortName> <ruleSlug>`
+    // so an edited title can't silently absorb the wrong recurrence.
+    const canonical = candidates.find((c) => {
+      const slug = extractRuleSlugFromTitle(c.title);
+      if (slug !== input.ruleSlug) return false;
+      if (input.stream === AUDIT_STREAM.CHROME_EVENT || input.stream === AUDIT_STREAM.CHROME_KENNEL) {
+        const expected = `Finding: ${c.kennel?.shortName ?? input.kennelCode} ${input.ruleSlug}`;
+        if (c.title !== expected) return false;
+      }
+      return true;
+    });
+    if (!canonical) return null;
+
+    // Step 1: post comment first (idempotent ordering). On failure we
+    // surface a typed error WITHOUT incrementing — next cron tick will
+    // re-find the same canonical and retry cleanly.
+    const ok = await actions.postComment(
+      canonical.githubNumber,
+      formatRecurComment(input),
+    );
+    if (!ok) {
+      return {
+        action: "error",
+        reason: "comment-failed-coarse",
+        existingIssueNumber: canonical.githubNumber,
+      };
+    }
+
+    // Step 2: CAS-increment `recurrenceCount`. On loss, a concurrent
+    // caller already incremented this same canonical row — refetch its
+    // current state and return their count (no additional increment
+    // from us; mild double-comment is the accepted trade-off).
+    let claim;
+    try {
+      claim = await prisma.auditIssue.updateMany({
+        where: {
+          id: canonical.id,
+          recurrenceCount: canonical.recurrenceCount,
+          state: "open",
+          delistedAt: null,
+        },
+        data: { recurrenceCount: { increment: 1 } },
+      });
+    } catch (err) {
+      console.error(
+        `[audit-filer] Coarse-dedup CAS update failed for #${canonical.githubNumber}:`,
+        err,
+      );
+      return {
+        action: "error",
+        reason: "db-update-failed",
+        existingIssueNumber: canonical.githubNumber,
+      };
+    }
+
+    if (claim.count === 0) {
+      // CAS lost. Refetch the canonical's current state.
+      const refetched = await prisma.auditIssue.findUnique({
+        where: { id: canonical.id },
+        select: {
+          recurrenceCount: true,
+          escalatedToIssueNumber: true,
+          state: true,
+          delistedAt: true,
+        },
+      });
+      if (refetched && refetched.state === "open" && !refetched.delistedAt) {
+        return {
+          action: "recurred",
+          issueNumber: canonical.githubNumber,
+          htmlUrl: canonical.htmlUrl,
+          recurrenceCount: refetched.recurrenceCount,
+          tier: "coarse",
+          escalatedToIssueNumber: refetched.escalatedToIssueNumber ?? undefined,
+        };
+      }
+      // Row vanished (closed / delisted between findMany and refetch).
+      // Retry from scratch — there may be another open canonical.
+      continue;
+    }
+
+    // We won the CAS.
+    const newRecurrenceCount = canonical.recurrenceCount + 1;
+    const escalatedToIssueNumber =
+      canonical.escalatedToIssueNumber ??
+      (await tryEscalate(
+        canonical.id,
+        canonical.githubNumber,
+        newRecurrenceCount,
+        canonical.kennel?.shortName ?? input.kennelCode,
+        input,
+        actions,
+      ));
+
+    return {
+      action: "recurred",
+      issueNumber: canonical.githubNumber,
+      htmlUrl: canonical.htmlUrl,
+      recurrenceCount: newRecurrenceCount,
+      tier: "coarse",
+      escalatedToIssueNumber,
+    };
+  }
+  // Exhausted retries — every attempt found a candidate that vanished
+  // before we could attach. No stable canonical exists; create-fresh
+  // is the correct fallthrough.
+  return null;
+}
+
+/**
+ * File an audit finding through the dedup cascade.
+ *   - Fingerprintable (canonical !== null): strict → bridging → create.
+ *   - Non-fingerprintable (canonical === null): coarse-dedup → create.
+ *
+ * Coarse-dedup is gated to the canonical-null branch on purpose:
+ * bridging already handles the (kennelCode, ruleSlug) match for
+ * fingerprintable rules and additionally backfills the fingerprint.
  */
 export async function fileAuditFinding(
   input: FileFindingInput,
@@ -619,6 +809,10 @@ export async function fileAuditFinding(
     // Bridging tier — only when no strict match.
     const bridged = await tryBridge(canonical.fingerprint, input, actions);
     if (bridged) return bridged;
+  } else {
+    // Coarse-dedup tier — only for non-fingerprintable rules.
+    const coarse = await tryCoarseDedup(input, actions);
+    if (coarse) return coarse;
   }
 
   // Embedding the canonical block on fresh creates lets the next

--- a/src/pipeline/audit-issue.test.ts
+++ b/src/pipeline/audit-issue.test.ts
@@ -157,7 +157,16 @@ describe("fileAuditIssues", () => {
 
     const result = await fileAuditIssues([buildGroup()]);
     expect(result).toEqual(["https://github.com/test/5"]);
-    expect(mockFindMany).not.toHaveBeenCalled();
+    // Stale mirror → mirror title query is skipped; the GitHub API
+    // fallback is what populates `existingTitles`. Note: the
+    // unmigrated-rule coarse-dedup tier (#964) runs at the audit-filer
+    // layer regardless of mirror staleness — that's a separate concern
+    // (kennel-scoped query, not a global title scan), so findMany may
+    // still be called once by that path before falling through to
+    // create. The mirror-bypass invariant is observed via mockAggregate
+    // returning a stale date and the GH API receiving the title fetch.
+    expect(mockAggregate).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("embeds the canonical block for fingerprintable rules", async () => {


### PR DESCRIPTION
## Summary

Two-layer fix for the C2H3 daily-issue spam — 16 open duplicates of [#964](https://github.com/johnrclem/hashtracks-web/issues/964), one filed per cron tick for the `event-improbable-time` rule.

- **Data fix**: GCal adapter now converts UTC `dateTime` → local `HH:MM` via `Intl.DateTimeFormat` when `timezone` is set on `CalendarSourceConfig`. C2H3 source flagged with `timezone: "America/Chicago"`.
- **Pipeline fix**: New `tryCoarseDedup` tier in `fileAuditFinding` for the 5 non-fingerprintable rules. Stream-scoped, SQL slug-discriminator filter, comment-first then CAS-increment ordering, refetch-and-return on CAS loss to keep a single canonical thread under contention.

This addresses the **dedup gap that affects all 5 unmigrated audit rules**, not just `event-improbable-time`. C2H3 is the materialized case; future spam from `hare-cta-text`, `title-raw-kennel-code`, `location-duplicate-segments`, or `description-dropped` will get coalesced by the same path.

Refs [#964](https://github.com/johnrclem/hashtracks-web/issues/964) [#925](https://github.com/johnrclem/hashtracks-web/issues/925) [#971](https://github.com/johnrclem/hashtracks-web/issues/971) [#1061](https://github.com/johnrclem/hashtracks-web/issues/1061) [#1095](https://github.com/johnrclem/hashtracks-web/issues/1095) [#1109](https://github.com/johnrclem/hashtracks-web/issues/1109) [#1145](https://github.com/johnrclem/hashtracks-web/issues/1145) [#1170](https://github.com/johnrclem/hashtracks-web/issues/1170) [#1214](https://github.com/johnrclem/hashtracks-web/issues/1214) [#1223](https://github.com/johnrclem/hashtracks-web/issues/1223) [#1239](https://github.com/johnrclem/hashtracks-web/issues/1239) [#1245](https://github.com/johnrclem/hashtracks-web/issues/1245) [#1260](https://github.com/johnrclem/hashtracks-web/issues/1260) [#1276](https://github.com/johnrclem/hashtracks-web/issues/1276) [#1304](https://github.com/johnrclem/hashtracks-web/issues/1304) [#1312](https://github.com/johnrclem/hashtracks-web/issues/1312)

> **Deliberate**: no `Closes` keyword. The phased close strategy below keeps a canonical anchor open through prod verification before closing.

## Three-stream review

Inventory of all open audit-stream issues at the time of this PR:

| Stream | Open total | Pile-ups ≥3 (kennel + rule) |
|---|---|---|
| `audit:automated` | (varies) | **C2H3 / `event-improbable-time`** — 16 |
| `audit:chrome-kennel` | 40 | none (max 3 per kennel, all distinct rules) |
| `audit:chrome-event` | 9 | none (each event distinct) |

Coarse-dedup runs through the shared `fileAuditFinding` cascade, so the fix benefits all three streams uniformly without per-stream code paths. Chrome streams additionally require an exact `Finding: <kennel> <slug>` title format in-memory after the SQL `endsWith` filter, so an operator-edited noisy chrome title can't absorb the wrong recurrence.

## Risks addressed (Codex adversarial-review, 6 rounds)

| Severity | Concern | Fix |
|---|---|---|
| HIGH | cross-stream coalescing | `stream: input.stream` in candidate query |
| HIGH | race-unsafe under concurrent callers | CAS guard on `recurrenceCount` snapshot |
| HIGH | 25-row LIMIT blind spot | SQL slug discriminator (automated `contains [<slug>]`, chrome `endsWith " <slug>"`) |
| HIGH | comment-after-CAS over-counted on retry | reordered: comment first, then CAS-increment |
| HIGH | retry exhaustion forked duplicates | refetch on CAS loss → return peer's count, single canonical thread |
| HIGH | `formatToParts(Invalid Date)` would throw `RangeError` | NaN guard restored before formatter call |
| MEDIUM | `endTime` silently dropped at UTC day boundaries | localize BOTH `start` AND `end` |
| MEDIUM | chrome dedup permissive title parser | exact `Finding: <kennel> <slug>` in-memory check |
| MEDIUM | tz formatter cache poisoned by transient errors | cache `null` only on `RangeError` |
| MEDIUM | admin filing prompt drift | added `coarse` to documented `tier` union |
| MEDIUM | bulk-close removed canonical anchor mid-rollout | phased close (Phase A: 14 dupes, Phase B: verify in #964, Phase C: close anchor) |

## Phased post-merge close strategy

PR body intentionally uses `Refs` (not `Closes`) so all 16 issues stay open through verification. After merge:

**Phase A** — close 14 of 15 dupes (keep #964 + #1312 open):
\`\`\`bash
PR=<this PR number>
for n in 925 971 1061 1095 1109 1145 1170 1214 1223 1239 1245 1260 1276 1304; do
  gh issue close $n -c "Closed as duplicate of #964 — fixed in PR #${PR}"
done
\`\`\`

**Phase B** — wait for next 6:00 AM UTC cron run; verify in #964 thread:
- A "still recurring" comment was posted (proves coarse-dedup hit path in prod), AND
- No new fresh issue was created with the daily date suffix.
- If the data fix is fully effective and `event-improbable-time` no longer fires, manually trigger the audit pipeline against another kennel that still trips an unmigrated rule to confirm the coarse path works.

**Phase C** — close the anchor:
\`\`\`bash
gh issue close 1312 -c "Closed as duplicate of #964 — verified coarse-dedup tier in PR #${PR}"
gh issue close 964  -c "Fixed in PR #${PR}: C2H3 timezone (data) + audit dedup pipeline (coarse-dedup tier). Verified in production."
\`\`\`

## Test plan

- [x] `npm run lint && npx tsc --noEmit` clean (the 10 unrelated failing test files all depend on the pre-existing missing `suncalc` package on `origin/main`).
- [x] 5 GCal timezone regression tests pass (UTC→Central, DST fall-back, UTC-midnight-crosser endTime preservation, all-day passthrough, malformed-dateTime + invalid-timezone fallbacks).
- [x] 9 coarse-dedup tests pass (hit + escalation, stream isolation, CAS-loss refetch with peer count, comment-failure idempotency, candidate-vanished retry, AUTOMATED + CHROME SQL filters, chrome strict-format rejection, chrome canonical match).
- [ ] **Live verification post-merge** (per `.claude/rules/live-verification.md`):
  - Trigger admin re-scrape of "Corpus Christi H3 Calendar" via `/admin/sources`.
  - Spot-check a fresh C2H3 RawEvent + canonical Event in prod; confirm `startTime` is in 14:xx–21:xx Central, not 19:xx–02:xx (raw-slice artifact).
  - Re-run the audit pipeline against C2H3 and confirm `event-improbable-time` no longer flags.
- [ ] **Phase B verification** (next 6:00 AM UTC cron run):
  - Recurrence comment posted on #964, OR fresh-create suppressed for another unmigrated-rule kennel known to still trip a rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)