### PR TITLE
perf(merge): collapse source + sourceKennel reads via Prisma include

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -52,7 +52,6 @@ import { processRawEvents, sanitizeTitle, sanitizeLocation, sanitizeHares, frien
 
 const mockSourceFind = vi.mocked(prisma.source.findUnique);
 const _mockSourceUpdate = vi.mocked(prisma.source.update);
-const mockSourceKennelFind = vi.mocked(prisma.sourceKennel.findMany);
 // Compat shim: tests historically seeded the per-event dedup query by mocking
 // `prisma.rawEvent.findFirst`. The N+1 fix in `merge.ts` collapsed that into a
 // single per-batch `prisma.rawEvent.findMany` prefetch (Sentry JAVASCRIPT-NEXTJS-3).
@@ -104,8 +103,11 @@ beforeEach(() => {
   // `processRawEvents` that would consume any leftover Once entry from a
   // preceding test, scrambling the ordering for tests that seed multiple Onces.
   vi.mocked(prisma.rawEvent.findMany).mockReset();
-  mockSourceFind.mockResolvedValue({ trustLevel: 5, type: "HTML_SCRAPER" } as never);
-  mockSourceKennelFind.mockResolvedValue([{ kennelId: "kennel_1" }] as never);
+  mockSourceFind.mockResolvedValue({
+    trustLevel: 5,
+    type: "HTML_SCRAPER",
+    kennels: [{ kennelId: "kennel_1" }],
+  } as never);
   mockRawEventCreate.mockResolvedValue({ id: "raw_1" } as never);
   mockRawEventUpdate.mockResolvedValue({} as never);
   // Default fuzzy probe's same-source RawEvent lookup to empty so existing
@@ -436,7 +438,11 @@ describe("processRawEvents", () => {
   });
 
   it("never writes locationCity for HARRIER_CENTRAL sources on create (#471)", async () => {
-    mockSourceFind.mockResolvedValue({ trustLevel: 5, type: "HARRIER_CENTRAL" } as never);
+    mockSourceFind.mockResolvedValue({
+      trustLevel: 5,
+      type: "HARRIER_CENTRAL",
+      kennels: [{ kennelId: "kennel_1" }],
+    } as never);
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
@@ -489,7 +495,11 @@ describe("processRawEvents", () => {
     // On UPDATE we never touch locationCity for canonical-location sources. If a non-HC
     // source previously populated city for this canonical event (cross-source merge),
     // an HC scrape must not wipe it.
-    mockSourceFind.mockResolvedValue({ trustLevel: 5, type: "HARRIER_CENTRAL" } as never);
+    mockSourceFind.mockResolvedValue({
+      trustLevel: 5,
+      type: "HARRIER_CENTRAL",
+      kennels: [{ kennelId: "kennel_1" }],
+    } as never);
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([
       { id: "evt_existing", trustLevel: 5, locationCity: "Tokyo" },
@@ -543,7 +553,11 @@ describe("source-kennel guard", () => {
     expect(result.blockedTags).toEqual(["OtherH3"]);
   });
 
-  it("fetches SourceKennel links only once per batch", async () => {
+  it("fetches source metadata + linked kennels in a single query per batch", async () => {
+    // Issue #1288: source + sourceKennel reads were collapsed via Prisma
+    // `include`. The merge pipeline must hit the database once for source
+    // metadata regardless of batch size, and the request must pull the
+    // linked `kennels` relation in the same round-trip.
     mockRawEventFind.mockResolvedValue(null);
     mockEventFindMany.mockResolvedValue([] as never);
     mockEventCreate.mockResolvedValue({ id: "evt_1" } as never);
@@ -553,7 +567,15 @@ describe("source-kennel guard", () => {
       buildRawEvent({ date: "2026-02-14" }),
       buildRawEvent({ date: "2026-02-15" }),
     ]);
-    expect(mockSourceKennelFind).toHaveBeenCalledTimes(1);
+    expect(mockSourceFind).toHaveBeenCalledTimes(1);
+    expect(mockSourceFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "src_1" },
+        select: expect.objectContaining({
+          kennels: { select: { kennelId: true } },
+        }),
+      }),
+    );
   });
 });
 

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1834,23 +1834,25 @@ export async function processRawEvents(
   const fingerprintByEvent = precomputeFingerprints(events, result);
   const uniqueFingerprints = [...new Set(fingerprintByEvent.values())];
 
-  // Three independent reads — source metadata, source-kennel links, and the
-  // dedup prefetch (Sentry JAVASCRIPT-NEXTJS-3) — fan out together to save
-  // round-trips on every scrape.
-  const [source, sourceKennels, prefetchedRawEvents] = await Promise.all([
+  // Two independent reads — source metadata (with linked kennels via the FK
+  // relation) and the dedup prefetch (Sentry JAVASCRIPT-NEXTJS-3) — fan out
+  // together to save round-trips on every scrape. Collapsing the previous
+  // separate `sourceKennel.findMany` into the same `findUnique` saves one
+  // round-trip per scrape (issue #1288).
+  const [source, prefetchedRawEvents] = await Promise.all([
     prisma.source.findUnique({
       where: { id: sourceId },
-      select: { trustLevel: true, type: true },
-    }),
-    prisma.sourceKennel.findMany({
-      where: { sourceId },
-      select: { kennelId: true },
+      select: {
+        trustLevel: true,
+        type: true,
+        kennels: { select: { kennelId: true } },
+      },
     }),
     prefetchExistingByFingerprint(sourceId, uniqueFingerprints),
   ]);
   const trustLevel = source?.trustLevel ?? 5;
   const sourceType: SourceType | null = source?.type ?? null;
-  const linkedKennelIds = new Set(sourceKennels.map((sk) => sk.kennelId));
+  const linkedKennelIds = new Set((source?.kennels ?? []).map((sk) => sk.kennelId));
 
   clearResolverCache();
 


### PR DESCRIPTION
## Summary

`processRawEvents` previously fanned out three reads in `Promise.all`:
1. `prisma.source.findUnique` (trustLevel + type)
2. `prisma.sourceKennel.findMany` (linked kennel IDs)
3. The dedup-fingerprint prefetch landed in PR #1280

#1 and #2 share a `sourceId` and have a clear FK relation
(`Source.kennels: SourceKennel[]`), so collapsing them via Prisma
`include` drops the parallel batch from 3 reads to 2 — one fewer
connection round-trip on every scrape.

This is a pure micro-optimization on top of the N+1 fix from PR #1280.
No behavior change; `linkedKennelIds` is identical.

Note: the relation field on `Source` is `kennels` (not `sourceKennels`);
the model name is `SourceKennel`.

## Test plan

- [x] `npx tsc --noEmit` — clean (only pre-existing `suncalc` errors)
- [x] `npm test src/pipeline/merge.test.ts` — 288/288 passing, including the renamed regression test (now asserts on `mockSourceFind` shape with `kennels` include)
- [x] `npm run lint` — 0 errors on changed files
- [ ] Production verify: after deploy, confirm Sentry trace shows 2 parallel reads at `processRawEvents` entry instead of 3.

Closes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)