### PR TITLE
chore(scripts): one-shot RawEvent fingerprint dedup (pre #1286 migration)

### DIFF
--- a/scripts/dedup-rawevent-fingerprint.test.ts
+++ b/scripts/dedup-rawevent-fingerprint.test.ts
@@ -57,4 +57,24 @@ describe("pickSurvivor", () => {
   it("throws on an empty group (defensive — caller should never invoke this)", () => {
     expect(() => pickSurvivor([])).toThrow(/empty group/);
   });
+
+  it("breaks ties on id when scrapedAt is identical (linked branch)", () => {
+    const sameTime = new Date("2026-03-25T16:00:10.064Z");
+    const rows = [
+      row({ id: "id_b", scrapedAt: sameTime, eventId: "evt_1" }),
+      row({ id: "id_a", scrapedAt: sameTime, eventId: "evt_1" }),
+      row({ id: "id_c", scrapedAt: sameTime, eventId: "evt_1" }),
+    ];
+    expect(pickSurvivor(rows).id).toBe("id_a");
+  });
+
+  it("breaks ties on id when scrapedAt is identical (unlinked branch)", () => {
+    const sameTime = new Date("2026-03-25T16:00:10.064Z");
+    const rows = [
+      row({ id: "id_b", scrapedAt: sameTime }),
+      row({ id: "id_a", scrapedAt: sameTime }),
+      row({ id: "id_c", scrapedAt: sameTime }),
+    ];
+    expect(pickSurvivor(rows).id).toBe("id_a");
+  });
 });

--- a/scripts/dedup-rawevent-fingerprint.test.ts
+++ b/scripts/dedup-rawevent-fingerprint.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({ prisma: {} }));
+
+import { pickSurvivor } from "./dedup-rawevent-fingerprint";
+
+type Row = Parameters<typeof pickSurvivor>[0][number];
+const row = (overrides: Partial<Row>): Row => ({
+  id: "id",
+  sourceId: "src",
+  fingerprint: "fp",
+  scrapedAt: new Date("2026-01-01"),
+  processed: false,
+  eventId: null,
+  ...overrides,
+});
+
+describe("pickSurvivor", () => {
+  it("prefers a linked row over any unlinked sibling", () => {
+    const rows = [
+      row({ id: "a", scrapedAt: new Date("2026-01-10") }),
+      row({ id: "b", scrapedAt: new Date("2026-01-05"), eventId: "evt_1" }),
+      row({ id: "c", scrapedAt: new Date("2026-01-20") }),
+    ];
+    expect(pickSurvivor(rows).id).toBe("b");
+  });
+
+  it("among linked rows picks the most-recent scrapedAt", () => {
+    const rows = [
+      row({ id: "old", scrapedAt: new Date("2026-01-01"), eventId: "evt_1" }),
+      row({ id: "new", scrapedAt: new Date("2026-03-01"), eventId: "evt_1" }),
+      row({ id: "mid", scrapedAt: new Date("2026-02-01"), eventId: "evt_1" }),
+    ];
+    expect(pickSurvivor(rows).id).toBe("new");
+  });
+
+  it("among unlinked rows picks the OLDEST scrapedAt", () => {
+    const rows = [
+      row({ id: "old", scrapedAt: new Date("2026-01-01") }),
+      row({ id: "new", scrapedAt: new Date("2026-03-01") }),
+      row({ id: "mid", scrapedAt: new Date("2026-02-01") }),
+    ];
+    expect(pickSurvivor(rows).id).toBe("old");
+  });
+
+  it("does not consider `processed` as a tiebreaker (linkage is the only first-tier key)", () => {
+    // Pre-flight diagnostic showed all multi-link groups point to a single
+    // canonical Event, so processed=true vs false among linked siblings is
+    // not a survivor-selection decider — the most-recent scrapedAt wins.
+    const rows = [
+      row({ id: "linked-unprocessed-new", scrapedAt: new Date("2026-03-01"), eventId: "evt_1", processed: false }),
+      row({ id: "linked-processed-old", scrapedAt: new Date("2026-01-01"), eventId: "evt_1", processed: true }),
+    ];
+    expect(pickSurvivor(rows).id).toBe("linked-unprocessed-new");
+  });
+
+  it("throws on an empty group (defensive — caller should never invoke this)", () => {
+    expect(() => pickSurvivor([])).toThrow(/empty group/);
+  });
+});

--- a/scripts/dedup-rawevent-fingerprint.ts
+++ b/scripts/dedup-rawevent-fingerprint.ts
@@ -36,6 +36,7 @@
 import "dotenv/config";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { prisma } from "@/lib/db";
 
 const APPLY = process.argv.includes("--apply");
@@ -64,7 +65,10 @@ function toAuditRow(r: RawEventRow): AuditRow {
 
 /**
  * Pick the survivor for a duplicate group. Linked rows beat unlinked rows.
- * Tiebreakers: linked → most-recent `scrapedAt`; unlinked → oldest.
+ * Tiebreakers: linked → most-recent `scrapedAt`, then `id` ASC for stability;
+ * unlinked → oldest `scrapedAt`, then `id` ASC. The `id` tiebreaker makes
+ * dry-run and apply produce identical survivors even when two rows share a
+ * `scrapedAt` (concurrent scrapes can land within the same millisecond).
  */
 export function pickSurvivor(rows: RawEventRow[]): RawEventRow {
   if (rows.length === 0) {
@@ -72,16 +76,33 @@ export function pickSurvivor(rows: RawEventRow[]): RawEventRow {
   }
   const linked = rows.filter((r) => r.eventId !== null);
   if (linked.length > 0) {
-    return [...linked].sort((a, b) => b.scrapedAt.getTime() - a.scrapedAt.getTime())[0];
+    return [...linked].sort(
+      (a, b) =>
+        b.scrapedAt.getTime() - a.scrapedAt.getTime() ||
+        a.id.localeCompare(b.id),
+    )[0];
   }
-  return [...rows].sort((a, b) => a.scrapedAt.getTime() - b.scrapedAt.getTime())[0];
+  return [...rows].sort(
+    (a, b) =>
+      a.scrapedAt.getTime() - b.scrapedAt.getTime() ||
+      a.id.localeCompare(b.id),
+  )[0];
+}
+
+function extractHost(databaseUrl: string | undefined): string {
+  if (!databaseUrl) return "<unknown>";
+  try {
+    return new URL(databaseUrl).hostname || "<unknown>";
+  } catch {
+    return "<unparseable>";
+  }
 }
 
 async function main() {
   // Surface the target host before the first DB write — the user has to
   // confirm the script is pointed at the intended environment.
-  const host = (process.env.DATABASE_URL ?? "").replace(/^[^@]*@/, "").replace(/[:/].*$/, "");
-  console.log(`Target DB host: ${host || "<unknown>"}`);
+  const host = extractHost(process.env.DATABASE_URL);
+  console.log(`Target DB host: ${host}`);
   console.log(`Mode: ${APPLY ? "APPLY (will DELETE)" : "DRY RUN (no writes)"}`);
 
   console.log("Fetching all rows in duplicate (sourceId, fingerprint) groups…");
@@ -92,7 +113,7 @@ async function main() {
       SELECT "sourceId", "fingerprint" FROM "RawEvent"
       GROUP BY "sourceId", "fingerprint" HAVING COUNT(*) > 1
     )
-    ORDER BY "sourceId", "fingerprint", "scrapedAt"
+    ORDER BY "sourceId", "fingerprint", "scrapedAt", id
   `;
   console.log(`Fetched ${dupRows.length} rows across duplicate groups`);
 
@@ -145,7 +166,7 @@ async function main() {
       {
         mode: APPLY ? "APPLY" : "DRY_RUN",
         runAt: new Date().toISOString(),
-        targetHost: host || null,
+        targetHost: host,
         groupsProcessed: auditEntries.length,
         totalDeleted: doomedIds.length,
         linkagePreservedSurvivors,
@@ -178,8 +199,10 @@ async function main() {
 }
 
 // Only auto-run main() when invoked directly (`tsx scripts/dedup-...ts`),
-// not when imported from a test file.
-if (import.meta.url === `file://${process.argv[1]}`) {
+// not when imported from a test file. Use `fileURLToPath` + `path.resolve`
+// for cross-platform safety (handles Windows backslashes and missing
+// `file://` prefix on `process.argv[1]`).
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
   main()
     .catch((err) => {
       console.error(err);

--- a/scripts/dedup-rawevent-fingerprint.ts
+++ b/scripts/dedup-rawevent-fingerprint.ts
@@ -1,0 +1,189 @@
+/**
+ * One-shot cleanup: collapse `(sourceId, fingerprint)` duplicate groups in
+ * `RawEvent` ahead of issue #1286's `@@unique([sourceId, fingerprint])`
+ * migration. Without this cleanup, the migration would fail on the existing
+ * dupe rows.
+ *
+ * Pre-flight diagnostics (run 2026-05-10 against prod):
+ *   - 766 duplicate groups, 7647 doomed rows
+ *   - 468 groups have NO linkage (orphan dupes — pick any survivor)
+ *   - 298 groups have linkage; of the 136 multi-link groups, ALL have
+ *     `distinct_event_ids = 1` (every linked row in a group points to the
+ *     same canonical Event). So the "transfer eventId from doomed → survivor"
+ *     path is unneeded — preferring a linked-row survivor naturally inherits
+ *     the canonical Event linkage.
+ *
+ * Survivor selection (linkage-aware):
+ *   1. If any sibling has `eventId IS NOT NULL`, pick the linked row with
+ *      most-recent `scrapedAt` as survivor.
+ *   2. Else (no linkage in the group), pick the OLDEST sibling by
+ *      `scrapedAt` — preserves the original observation timestamp.
+ *
+ * Defaults to dry run. Pass `--apply` to issue the deletes.
+ *
+ * Writes a JSON audit log to `tmp/dedup-rawevent-{audit,dryrun}-<ts>.json`
+ * with every group's survivor + deleted row IDs. The cleanup is irreversible
+ * once Vercel applies the unique-constraint migration; keep the audit log
+ * for forensic recovery.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/dedup-rawevent-fingerprint.ts
+ *   Apply:    npx tsx scripts/dedup-rawevent-fingerprint.ts --apply
+ *
+ * Idempotent: a re-run sees fewer (or zero) duplicate groups.
+ */
+
+import "dotenv/config";
+import fs from "node:fs";
+import path from "node:path";
+import { prisma } from "@/lib/db";
+
+const APPLY = process.argv.includes("--apply");
+const DELETE_CHUNK_SIZE = 500;
+
+type RawEventRow = {
+  id: string;
+  sourceId: string;
+  fingerprint: string;
+  scrapedAt: Date;
+  processed: boolean;
+  eventId: string | null;
+};
+
+type AuditRow = Pick<RawEventRow, "id" | "scrapedAt" | "processed" | "eventId">;
+type AuditEntry = {
+  sourceId: string;
+  fingerprint: string;
+  survivor: AuditRow;
+  deleted: AuditRow[];
+};
+
+function toAuditRow(r: RawEventRow): AuditRow {
+  return { id: r.id, scrapedAt: r.scrapedAt, processed: r.processed, eventId: r.eventId };
+}
+
+/**
+ * Pick the survivor for a duplicate group. Linked rows beat unlinked rows.
+ * Tiebreakers: linked → most-recent `scrapedAt`; unlinked → oldest.
+ */
+export function pickSurvivor(rows: RawEventRow[]): RawEventRow {
+  if (rows.length === 0) {
+    throw new Error("pickSurvivor called on empty group");
+  }
+  const linked = rows.filter((r) => r.eventId !== null);
+  if (linked.length > 0) {
+    return [...linked].sort((a, b) => b.scrapedAt.getTime() - a.scrapedAt.getTime())[0];
+  }
+  return [...rows].sort((a, b) => a.scrapedAt.getTime() - b.scrapedAt.getTime())[0];
+}
+
+async function main() {
+  // Surface the target host before the first DB write — the user has to
+  // confirm the script is pointed at the intended environment.
+  const host = (process.env.DATABASE_URL ?? "").replace(/^[^@]*@/, "").replace(/[:/].*$/, "");
+  console.log(`Target DB host: ${host || "<unknown>"}`);
+  console.log(`Mode: ${APPLY ? "APPLY (will DELETE)" : "DRY RUN (no writes)"}`);
+
+  console.log("Fetching all rows in duplicate (sourceId, fingerprint) groups…");
+  const dupRows = await prisma.$queryRaw<RawEventRow[]>`
+    SELECT id, "sourceId", "fingerprint", "scrapedAt", processed, "eventId"
+    FROM "RawEvent"
+    WHERE ("sourceId", "fingerprint") IN (
+      SELECT "sourceId", "fingerprint" FROM "RawEvent"
+      GROUP BY "sourceId", "fingerprint" HAVING COUNT(*) > 1
+    )
+    ORDER BY "sourceId", "fingerprint", "scrapedAt"
+  `;
+  console.log(`Fetched ${dupRows.length} rows across duplicate groups`);
+
+  // Group by (sourceId, fingerprint) in JS.
+  const groups = new Map<string, RawEventRow[]>();
+  for (const r of dupRows) {
+    const key = `${r.sourceId}:${r.fingerprint}`;
+    const arr = groups.get(key) ?? [];
+    arr.push(r);
+    groups.set(key, arr);
+  }
+  console.log(`Identified ${groups.size} duplicate groups`);
+
+  if (groups.size === 0) {
+    console.log("No duplicates — nothing to do.");
+    await prisma.$disconnect();
+    return;
+  }
+
+  const auditEntries: AuditEntry[] = [];
+  const doomedIds: string[] = [];
+  let linkagePreservedSurvivors = 0;
+
+  for (const rows of groups.values()) {
+    if (rows.length < 2) continue; // race-safe
+    const survivor = pickSurvivor(rows);
+    const doomed = rows.filter((r) => r.id !== survivor.id);
+    if (survivor.eventId !== null) linkagePreservedSurvivors++;
+    auditEntries.push({
+      sourceId: rows[0].sourceId,
+      fingerprint: rows[0].fingerprint,
+      survivor: toAuditRow(survivor),
+      deleted: doomed.map(toAuditRow),
+    });
+    for (const d of doomed) doomedIds.push(d.id);
+  }
+
+  // Write audit log BEFORE deleting so a crash mid-delete still leaves a
+  // record of intended action.
+  const auditDir = path.join(process.cwd(), "tmp");
+  fs.mkdirSync(auditDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const logName = APPLY
+    ? `dedup-rawevent-audit-${ts}.json`
+    : `dedup-rawevent-dryrun-${ts}.json`;
+  const logPath = path.join(auditDir, logName);
+  fs.writeFileSync(
+    logPath,
+    JSON.stringify(
+      {
+        mode: APPLY ? "APPLY" : "DRY_RUN",
+        runAt: new Date().toISOString(),
+        targetHost: host || null,
+        groupsProcessed: auditEntries.length,
+        totalDeleted: doomedIds.length,
+        linkagePreservedSurvivors,
+        entries: auditEntries,
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`Audit log written to ${logPath}`);
+
+  if (APPLY) {
+    console.log(`Deleting ${doomedIds.length} rows in chunks of ${DELETE_CHUNK_SIZE}…`);
+    let deleted = 0;
+    for (let i = 0; i < doomedIds.length; i += DELETE_CHUNK_SIZE) {
+      const chunk = doomedIds.slice(i, i + DELETE_CHUNK_SIZE);
+      const res = await prisma.rawEvent.deleteMany({ where: { id: { in: chunk } } });
+      deleted += res.count;
+      console.log(`  deleted ${deleted}/${doomedIds.length} (chunk ${Math.floor(i / DELETE_CHUNK_SIZE) + 1})`);
+    }
+    console.log(`Done: ${deleted} rows deleted.`);
+  } else {
+    console.log("DRY RUN — no rows deleted. Pass --apply to execute.");
+  }
+
+  console.log("\nSummary:");
+  console.log(`  groups processed:           ${auditEntries.length}`);
+  console.log(`  rows ${APPLY ? "deleted" : "to delete"}:        ${doomedIds.length}`);
+  console.log(`  survivors with eventId set: ${linkagePreservedSurvivors}`);
+}
+
+// Only auto-run main() when invoked directly (`tsx scripts/dedup-...ts`),
+// not when imported from a test file.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .finally(() => prisma.$disconnect());
+}


### PR DESCRIPTION
## Summary

One-shot cleanup script that collapses existing duplicate `(sourceId, fingerprint)` groups in `RawEvent` ahead of issue #1286's `@@unique([sourceId, fingerprint])` migration. Without this cleanup the migration would fail on the existing dupe rows; this PR ships the script first so we can run it against prod and verify `COUNT(*) = 0` **before** opening the migration PR.

This PR is review-only — **no DB writes happen on merge.** I'll run \`npx tsx scripts/dedup-rawevent-fingerprint.ts --apply\` against prod after merge, attach the audit log, then open the migration PR.

## Pre-flight diagnostics (2026-05-10, prod)

| Metric | Count |
|---|---|
| Duplicate \`(sourceId, fingerprint)\` groups | **766** |
| Doomed rows (count − 1 per group) | **7,647** |
| Groups with NO linkage (orphan dupes) | 468 |
| Groups with linkage | 298 |
| Multi-link groups (≥2 rows linked) | 136 |
| Multi-link groups with split canonical Events | **0** |
| Max distinct \`eventId\`s in any one group | 1 |

The "split canonical Event = 0" outcome simplifies survivor selection: every linked group's linked rows point to the *same* canonical Event, so picking any linked-row survivor naturally inherits the linkage. The "transfer eventId from doomed → survivor" path my plan called for is unneeded.

Top sources by doomed row count:
- Whoreman H3 Calendar (1,495), Boston Hash Calendar (1,438), Princeton NJ Hash Calendar (1,309), HashNYC Website (601) — high-multiplicity dupes (~50 dupes/group on average), suggest a long-running issue where the per-event \`findFirst\` dedup was bypassed.
- Charm City iCal (81/81), Bangkok Full Moon (65/65), Hudson Valley Meetup (10/30) — exactly 2 dupes/group, the classic concurrent-scrape race.

Whatever the historical root causes, the new \`@@unique([sourceId, fingerprint])\` constraint (issue #1286) closes the door going forward.

## Survivor selection

\`\`\`ts
// pickSurvivor (pure function, 5 unit tests)
// 1. If any sibling has \`eventId IS NOT NULL\`, pick the linked row with
//    most-recent \`scrapedAt\` (naturally inherits canonical Event linkage).
// 2. Else (no linkage), pick the OLDEST sibling by \`scrapedAt\` —
//    preserves the original observation timestamp.
\`\`\`

## Script behavior

- Defaults to **dry run** — fetches all duplicate-group rows, simulates survivor selection, writes audit log, prints summary. **No DB writes.**
- \`--apply\` issues the deletes (chunked, 500 IDs per \`deleteMany\`).
- Writes JSON audit log to \`tmp/dedup-rawevent-{audit,dryrun}-<ts>.json\` containing every group's survivor + deleted row IDs.
- Idempotent: re-runs after a successful apply see zero duplicate groups.
- Surfaces target DB host before the first read so the operator can confirm the environment.

## Sample audit entry (linked-survivor case)

\`\`\`json
{
  "sourceId": "...",
  "fingerprint": "...",
  "survivor": {
    "id": "...",
    "scrapedAt": "2026-03-25T16:00:10.064Z",
    "processed": true,
    "eventId": "cmm5yasru000z04lacy26h9ja"
  },
  "deleted": [
    { "id": "...", "scrapedAt": "2026-03-23T14:42:38.648Z", "processed": false, "eventId": null },
    { "id": "...", "scrapedAt": "2026-03-23T15:52:26.150Z", "processed": false, "eventId": null },
    {
      "id": "...",
      "scrapedAt": "2026-03-24T16:00:08.744Z",
      "processed": true,
      "eventId": "cmm5yasru000z04lacy26h9ja"
    }
  ]
}
\`\`\`

The doomed sibling that ALSO points to the same \`eventId\` (multi-link group) gets cleaned up safely — the canonical Event remains intact (referenced by the survivor).

## Test plan

- [x] \`npx vitest run scripts/dedup-rawevent-fingerprint.test.ts\` — 5/5 pass (linkage preference, scrapedAt direction per branch, defensive empty-group throw)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean for new files
- [x] Dry run against prod: 766 groups / 7,647 doomed / 298 linked-survivors — exact match to pre-flight diagnostic counts
- [ ] Post-merge: run \`--apply\` against prod, attach audit log, verify \`COUNT(*) = 0\` for the duplicates query

## Refs

- Issue #1286 (depends on this cleanup)
- PR #1280 (the N+1 fix that exposed the race window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)