### PR TITLE
perf(merge): batch sameDayEvents, fuzzy ±48h, lastEventDate per kennel

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -3124,7 +3124,10 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     // catches this via a RawEvent join even when title/time/location all
     // pass.
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never); // same-day empty
+    // Cache prefetch returns the candidate; getSameDayEvents filters it
+    // out of the incoming bucket (different date) and the fuzzy probe
+    // picks it up from the in-memory pool (#1287). The wide ±48h prefetch
+    // window (MERGE_FUZZY_DEDUP=true in beforeEach) keeps it visible.
     mockEventFindMany.mockResolvedValueOnce([
       existingFuzzyRow({ id: "evt_same_source_yesterday" }),
     ] as never);
@@ -3151,7 +3154,10 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
 
   it("does NOT merge when runNumber differs (double-header on consecutive days)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never); // same-day empty
+    // Cache prefetch returns the candidate; getSameDayEvents filters it
+    // out of the incoming bucket (different date) and the fuzzy probe
+    // picks it up from the in-memory pool (#1287). The wide ±48h prefetch
+    // window (MERGE_FUZZY_DEDUP=true in beforeEach) keeps it visible.
     mockEventFindMany.mockResolvedValueOnce([
       existingFuzzyRow({ runNumber: 786, title: "Annual Bash Trail" }),
     ] as never); // fuzzy probe candidate, but runNumber will conflict
@@ -3190,7 +3196,10 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
 
   it("does NOT merge when locationName diverges sharply (different venues)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never); // same-day empty
+    // Cache prefetch returns the candidate; getSameDayEvents filters it
+    // out of the incoming bucket (different date) and the fuzzy probe
+    // picks it up from the in-memory pool (#1287). The wide ±48h prefetch
+    // window (MERGE_FUZZY_DEDUP=true in beforeEach) keeps it visible.
     mockEventFindMany.mockResolvedValueOnce([
       existingFuzzyRow({ locationName: "Central Park" }),
     ] as never); // fuzzy probe candidate, location will conflict
@@ -3210,7 +3219,10 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
 
   it("does NOT merge when startTime daypart conflicts (morning vs evening)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never); // same-day empty
+    // Cache prefetch returns the candidate; getSameDayEvents filters it
+    // out of the incoming bucket (different date) and the fuzzy probe
+    // picks it up from the in-memory pool (#1287). The wide ±48h prefetch
+    // window (MERGE_FUZZY_DEDUP=true in beforeEach) keeps it visible.
     mockEventFindMany.mockResolvedValueOnce([
       existingFuzzyRow({ startTime: "10:00" }),
     ] as never);
@@ -3319,6 +3331,103 @@ describe("processRawEvents — per-kennel read batching (#1287)", () => {
       { lastEventDate: null },
       { lastEventDate: { lt: updateData.data.lastEventDate } },
     ]);
+  });
+
+  it("does not reject the whole batch when one kennel.updateMany flush fails", async () => {
+    // Pre-#1287 the equivalent `$executeRaw UPDATE "Kennel"` fired inside
+    // the per-event try/catch — a single failure was recorded as
+    // `eventErrors` while the batch still completed. The batched flush
+    // moves these writes outside the try/catch boundary, so we use
+    // `Promise.allSettled` (not `Promise.all`) to keep the same semantics:
+    // a `lastEventDate` cache-write rejection logs but does not throw.
+    const mockKennelUpdateMany = vi.mocked(prisma.kennel.updateMany);
+    mockKennelUpdateMany.mockRejectedValueOnce(new Error("transient DB error"));
+    mockRawEventFind.mockResolvedValue(null);
+    mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      processRawEvents("src_1", [
+        buildRawEvent({ date: "2026-04-01", kennelTags: ["TestH3"] }),
+      ]),
+    ).resolves.toBeDefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[merge] lastEventDate flush failed for kennel kennel_1"),
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("writes a high-trust UPDATE back into the per-batch cache so later events see post-update state", async () => {
+    // Cross-source same-day match: source A updates the canonical row in
+    // the high-trust branch, source B (later in the batch, different
+    // sourceUrl) must see the post-update row when it consults the cache.
+    // Pre-fix: getSameDayEvents returned a freshly-filtered array, so
+    // sameDayEvents[idx] = updated only patched the local slice; the
+    // shared cache still held the pre-update reference, leaving source
+    // B's lookup looking at stale (pre-update) startTime/runNumber/etc.
+    // and falling through to a spurious CREATE.
+    mockRawEventFind.mockResolvedValue(null);
+    // Cache prefetch returns one existing canonical row with empty fields
+    // so the high-trust UPDATE has something to fill.
+    mockEventFindMany.mockResolvedValueOnce([
+      {
+        id: "evt_canonical",
+        kennelId: "kennel_1",
+        date: new Date("2026-04-01T12:00:00.000Z"),
+        trustLevel: 5,
+        sourceUrl: "https://source-a.example/event/1",
+        startTime: null,
+        runNumber: null,
+        title: null,
+        locationName: null,
+        parentEventId: null,
+        isSeriesParent: false,
+        isCanonical: true,
+        status: "CONFIRMED",
+      },
+    ] as never);
+    // The UPDATE returns the post-update row (startTime now set).
+    mockEventUpdate.mockResolvedValue({
+      id: "evt_canonical",
+      kennelId: "kennel_1",
+      date: new Date("2026-04-01T12:00:00.000Z"),
+      trustLevel: 5,
+      sourceUrl: "https://source-a.example/event/1",
+      startTime: "18:00",
+      runNumber: 42,
+      title: "Trail #42",
+      locationName: null,
+      parentEventId: null,
+      isSeriesParent: false,
+      isCanonical: true,
+      status: "CONFIRMED",
+    } as never);
+    mockFingerprint.mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b");
+
+    await processRawEvents("src_1", [
+      buildRawEvent({
+        date: "2026-04-01",
+        kennelTags: ["TestH3"],
+        sourceUrl: "https://source-a.example/event/1",
+        startTime: "18:00",
+        runNumber: 42,
+      }),
+      // Source B emits a different sourceUrl but the same logical event
+      // (same kennel + date + startTime + runNumber). It should match the
+      // canonical row via the post-A-update cache, NOT create a new row.
+      buildRawEvent({
+        date: "2026-04-01",
+        kennelTags: ["TestH3"],
+        sourceUrl: "https://source-b.example/event/2",
+        startTime: "18:00",
+        runNumber: 42,
+      }),
+    ]);
+
+    // No second canonical row was created — both events resolve to evt_canonical.
+    expect(mockEventCreate).not.toHaveBeenCalled();
   });
 
   it("does not call kennel.updateMany when no new events are processed (all duplicates)", async () => {

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/db", () => ({
     event: { findUnique: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
     eventKennel: { create: vi.fn(), upsert: vi.fn() },
     eventLink: { upsert: vi.fn() },
-    kennel: { findUnique: vi.fn() },
+    kennel: { findUnique: vi.fn(), updateMany: vi.fn() },
     $executeRaw: vi.fn().mockResolvedValue(0),
     $transaction: vi.fn(),
   },
@@ -104,6 +104,12 @@ beforeEach(() => {
   // `processRawEvents` that would consume any leftover Once entry from a
   // preceding test, scrambling the ordering for tests that seed multiple Onces.
   vi.mocked(prisma.rawEvent.findMany).mockReset();
+  // Same Once-queue hygiene for `event.findMany` — `ensureKennelEventCache`
+  // (issue #1287) added a per-kennel prefetch that runs before the
+  // disambiguation lookup, so any leftover `mockResolvedValueOnce` from a
+  // preceding test would now be consumed by the prefetch instead of the
+  // intended caller.
+  vi.mocked(prisma.event.findMany).mockReset();
   mockSourceFind.mockResolvedValue({
     trustLevel: 5,
     type: "HTML_SCRAPER",
@@ -3032,8 +3038,11 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
 
   it("merges into ±24h row with fuzzy-matching title (the BurlyH3 Invihash case from #886)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never); // same-day empty (incoming bucket)
-    mockEventFindMany.mockResolvedValueOnce([existingFuzzyRow()] as never); // fuzzy probe hit
+    // After #1287, the per-kennel ensureKennelEventCache fetches one batch
+    // covering ±48h around the union of batchDates and serves both same-day
+    // and fuzzy lookups in memory. Old-bucket recanonicalize still issues
+    // its own findMany after the cross-window date update + cache invalidate.
+    mockEventFindMany.mockResolvedValueOnce([existingFuzzyRow()] as never); // cache prefetch
     mockEventFindMany.mockResolvedValueOnce([] as never); // old-bucket recanonicalize refetch
     mockEventUpdate.mockResolvedValueOnce({ id: "evt_existing" } as never);
 
@@ -3056,18 +3065,17 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
       }),
     );
 
-    // Verify the fuzzy probe used a ±48h window predicate (not just kennelId).
-    // Order-coupled mocks would otherwise pass for the wrong reason if the
-    // implementation ever flipped query order.
-    const fuzzyCall = mockEventFindMany.mock.calls[1];
-    const fuzzyWhere = (fuzzyCall[0] as { where: { date: { gte?: Date; lte?: Date; not?: Date } } }).where;
-    expect(fuzzyWhere.date.gte).toBeInstanceOf(Date);
-    expect(fuzzyWhere.date.lte).toBeInstanceOf(Date);
-    expect(fuzzyWhere.date.not).toBeInstanceOf(Date);
+    // Verify the cache prefetch used a ±48h date-range predicate (not just
+    // kennelId) — this is what makes the fuzzy candidate visible in memory.
+    const cacheCall = mockEventFindMany.mock.calls[0];
+    const cacheWhere = (cacheCall[0] as { where: { date: { gte?: Date; lte?: Date } } }).where;
+    expect(cacheWhere.date.gte).toBeInstanceOf(Date);
+    expect(cacheWhere.date.lte).toBeInstanceOf(Date);
 
     // Cross-window match physically MOVES the row to the incoming source's
     // date so display paths render the correct day. Old bucket gets
-    // recanonicalized via the third findMany above.
+    // recanonicalized via the second findMany above (after the cache is
+    // invalidated by the cross-window update).
     const updateCall = mockEventUpdate.mock.calls.find(c => (c[0] as { where: { id: string } }).where.id === "evt_existing");
     expect(updateCall).toBeDefined();
     const updateData = (updateCall![0] as { data: Record<string, unknown> }).data;
@@ -3081,7 +3089,9 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     // had higher trust), it lands alone in the new bucket and would stay
     // invisible without a length-1 promotion path in recomputeCanonical.
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never); // same-day empty
+    // Cache prefetch returns the fuzzy candidate; getSameDayEvents filters
+    // it out of the incoming bucket (different date) and the fuzzy probe
+    // picks it up from the in-memory pool (#1287).
     mockEventFindMany.mockResolvedValueOnce([
       existingFuzzyRow({ id: "evt_was_noncanonical", isCanonical: false }),
     ] as never);
@@ -3216,6 +3226,114 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
 
     expect(result.created).toBe(1);
     expect(result.updated).toBe(0);
+  });
+});
+
+// Issue #1287: three previously per-new-event Prisma queries (sameDayEvents,
+// fuzzy ±48h, lastEventDate UPDATE) collapsed into per-kennel/per-batch
+// patterns. The `event.findMany` from `ensureKennelEventCache` runs at most
+// once per kennel touched in a batch (regardless of how many events that
+// kennel sees), and `kennel.updateMany` runs at most once per kennel after
+// the loop (regardless of new-event count).
+describe("processRawEvents — per-kennel read batching (#1287)", () => {
+  it("issues at most one event.findMany per distinct kennel across a multi-event batch (fuzzy off)", async () => {
+    mockRawEventFind.mockResolvedValue(null); // every event is new
+    mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+    mockFingerprint
+      .mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b").mockReturnValueOnce("fp_c");
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-04-01", kennelTags: ["TestH3"] }),
+      buildRawEvent({ date: "2026-04-08", kennelTags: ["TestH3"] }),
+      buildRawEvent({ date: "2026-04-15", kennelTags: ["TestH3"] }),
+    ]);
+
+    // Pre-#1287: 3 same-day findMany calls (one per new event).
+    // Post-#1287 (fuzzy off): 1 cache prefetch with `date IN [batchDates]`
+    // — narrow query, never pulls non-batch events for the kennel (avoids
+    // the SDH3-backfill pathology where one scrape would otherwise load 7K+
+    // historical rows because batchDates spans a year).
+    expect(mockEventFindMany).toHaveBeenCalledTimes(1);
+    const cacheCall = mockEventFindMany.mock.calls[0];
+    const cacheWhere = (cacheCall[0] as { where: { kennelId: string; date: { in: Date[] } } }).where;
+    expect(cacheWhere.kennelId).toBe("kennel_1");
+    expect(cacheWhere.date.in).toEqual([
+      new Date("2026-04-01T12:00:00.000Z"),
+      new Date("2026-04-08T12:00:00.000Z"),
+      new Date("2026-04-15T12:00:00.000Z"),
+    ]);
+  });
+
+  it("widens the cache prefetch to ±48h around batch dates when MERGE_FUZZY_DEDUP is on", async () => {
+    const prevFlag = process.env.MERGE_FUZZY_DEDUP;
+    process.env.MERGE_FUZZY_DEDUP = "true";
+    try {
+      mockRawEventFind.mockResolvedValue(null);
+      mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+      mockFingerprint.mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b");
+
+      await processRawEvents("src_1", [
+        buildRawEvent({ date: "2026-04-01", kennelTags: ["TestH3"] }),
+        buildRawEvent({ date: "2026-04-08", kennelTags: ["TestH3"] }),
+      ]);
+
+      expect(mockEventFindMany).toHaveBeenCalledTimes(1);
+      const cacheCall = mockEventFindMany.mock.calls[0];
+      const cacheWhere = (cacheCall[0] as { where: { date: { gte: Date; lte: Date } } }).where;
+      // ±48h around 2026-04-01 (min) and 2026-04-08 (max)
+      expect(cacheWhere.date.gte).toEqual(new Date("2026-03-30T12:00:00.000Z"));
+      expect(cacheWhere.date.lte).toEqual(new Date("2026-04-10T12:00:00.000Z"));
+    } finally {
+      if (prevFlag === undefined) delete process.env.MERGE_FUZZY_DEDUP;
+      else process.env.MERGE_FUZZY_DEDUP = prevFlag;
+    }
+  });
+
+  it("issues at most one kennel.updateMany per distinct kennel across a multi-event batch", async () => {
+    const mockKennelUpdateMany = vi.mocked(prisma.kennel.updateMany);
+    mockKennelUpdateMany.mockResolvedValue({ count: 1 } as never);
+    mockRawEventFind.mockResolvedValue(null);
+    mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+    mockFingerprint
+      .mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b").mockReturnValueOnce("fp_c");
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-04-01", kennelTags: ["TestH3"] }),
+      buildRawEvent({ date: "2026-04-08", kennelTags: ["TestH3"] }),
+      buildRawEvent({ date: "2026-04-15", kennelTags: ["TestH3"] }),
+    ]);
+
+    // Pre-#1287: 3 per-event `$executeRaw UPDATE "Kennel"` (one per new event).
+    // Post-#1287: 1 batched `kennel.updateMany` for kennel_1.
+    expect(mockKennelUpdateMany).toHaveBeenCalledTimes(1);
+    const updateCall = mockKennelUpdateMany.mock.calls[0];
+    const updateData = (updateCall[0] as {
+      where: { id: string; OR: Array<{ lastEventDate: null | { lt: Date } }> };
+      data: { lastEventDate: Date };
+    });
+    expect(updateData.where.id).toBe("kennel_1");
+    // Max event date in the batch is 2026-04-15.
+    expect(updateData.data.lastEventDate.toISOString()).toBe("2026-04-15T12:00:00.000Z");
+    // Guard preserves "only update if newer" semantic.
+    expect(updateData.where.OR).toEqual([
+      { lastEventDate: null },
+      { lastEventDate: { lt: updateData.data.lastEventDate } },
+    ]);
+  });
+
+  it("does not call kennel.updateMany when no new events are processed (all duplicates)", async () => {
+    const mockKennelUpdateMany = vi.mocked(prisma.kennel.updateMany);
+    // Pre-seed dedup map so the event takes the duplicate-fingerprint path.
+    // The seedDedup shim keys the prefetch result by the default fingerprint
+    // ("fp_abc123" — matches the default `mockFingerprint` return), so the
+    // event's fingerprint must NOT be overridden here.
+    mockRawEventFind.mockResolvedValue({ id: "raw_seen", processed: true, eventId: "evt_seen" });
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-04-01", kennelTags: ["TestH3"] }),
+    ]);
+
+    expect(mockKennelUpdateMany).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -288,6 +288,8 @@ function shouldSkipReverseGeocode(sourceType: SourceType | null): boolean {
 }
 
 /** Per-batch state threaded through all merge helper functions. */
+type EventRow = Awaited<ReturnType<typeof prisma.event.findMany>>[number];
+
 interface MergeContext {
   sourceId: string;
   /** Source trust level (1–10); higher-trust sources overwrite lower-trust data. */
@@ -310,6 +312,24 @@ interface MergeContext {
    *  once before the loop; updated in-place when `processNewRawEvent` creates a
    *  new RawEvent so duplicate fingerprints later in the same batch still resolve. */
   existingByFingerprint: Map<string, ExistingRawEventEntry>;
+  /** Union of UTC-noon event dates across the whole batch — drives the
+   *  per-kennel ±48h window for `ensureKennelEventCache` (issue #1287). */
+  batchDates: Date[];
+  /** Per-kennel pool of canonical Events within the union ±48h window —
+   *  replaces the per-event `event.findMany` at the top of
+   *  `upsertCanonicalEvent` (and the fuzzy probe via `fuzzyPoolByKennel`).
+   *  Populated lazily on first touch via `ensureKennelEventCache`; mirrored
+   *  with each new canonical Event from `rememberCreatedEvent`. Lookup
+   *  helpers filter by date on access. */
+  sameDayCache: Map<string, EventRow[]>;
+  /** Per-kennel pool of fuzzy candidates (parents and non-series only,
+   *  sorted by trustLevel desc, createdAt asc). Derived from the same
+   *  prefetch as `sameDayCache`. */
+  fuzzyPoolByKennel: Map<string, EventRow[]>;
+  /** Per-kennel max event date observed for newly-created Events; flushed after
+   *  the loop as a single batched `kennel.updateMany` per kennel, replacing the
+   *  per-event `$executeRaw UPDATE "Kennel" SET "lastEventDate"`. */
+  kennelMaxDates: Map<string, Date>;
   result: MergeResult;
 }
 
@@ -410,6 +430,116 @@ async function resolveKennelData(kennelId: string, ctx: MergeContext): Promise<K
 async function resolveRegion(kennelId: string, ctx: MergeContext): Promise<string> {
   const data = await resolveKennelData(kennelId, ctx);
   return data.region;
+}
+
+/**
+ * Lazy-warm the per-batch event caches for a kennel (issue #1287).
+ *
+ * On first call for a kennelId, runs ONE `event.findMany` covering the union
+ * of `ctx.batchDates ± FUZZY_WINDOW_MS`, then partitions the result into:
+ *   - `ctx.sameDayCache`     — `Map<dateISO, EventRow[]>` for same-day matching
+ *                              in `upsertCanonicalEvent` (no parent/series filter).
+ *   - `ctx.fuzzyPoolByKennel` — sorted `EventRow[]` of parents/non-series only,
+ *                              for `findFuzzyDuplicateInWindow`.
+ *
+ * Replaces two per-new-event `event.findMany` calls. Subsequent calls for the
+ * same kennelId are no-ops; CREATE paths in `upsertCanonicalEvent` keep both
+ * caches in sync via `rememberCreatedEvent`. A cross-window match (rare —
+ * `MERGE_FUZZY_DEDUP=true` is off in prod) physically moves an Event's date,
+ * so we invalidate via `invalidateKennelEventCache` and re-fetch on next use.
+ */
+async function ensureKennelEventCache(kennelId: string, ctx: MergeContext): Promise<void> {
+  if (ctx.sameDayCache.has(kennelId)) return;
+
+  if (ctx.batchDates.length === 0) {
+    ctx.sameDayCache.set(kennelId, []);
+    ctx.fuzzyPoolByKennel.set(kennelId, []);
+    return;
+  }
+
+  // Window strategy:
+  //   - Fuzzy OFF (default in prod): query `date IN [...batchDates]`. Narrow
+  //     and Postgres uses the (kennelId, date) index efficiently — never
+  //     pulls non-batch events for a kennel (avoids the SDH3-backfill
+  //     pathology where one scrape would otherwise load 7K+ historical
+  //     rows because batchDates spans a year).
+  //   - Fuzzy ON: widen to `date BETWEEN min - 48h AND max + 48h` so the
+  //     fuzzy probe sees ±48h neighbors. Acceptable cost since fuzzy is
+  //     gated by `MERGE_FUZZY_DEDUP=true` and only enabled deliberately.
+  const fuzzyEnabled = process.env.MERGE_FUZZY_DEDUP === "true";
+  let where: { kennelId: string; date: Prisma.DateTimeFilter | { in: Date[] } };
+  if (fuzzyEnabled) {
+    let minMs = Infinity;
+    let maxMs = -Infinity;
+    for (const d of ctx.batchDates) {
+      const t = d.getTime();
+      if (t < minMs) minMs = t;
+      if (t > maxMs) maxMs = t;
+    }
+    where = {
+      kennelId,
+      date: { gte: new Date(minMs - FUZZY_WINDOW_MS), lte: new Date(maxMs + FUZZY_WINDOW_MS) },
+    };
+  } else {
+    where = { kennelId, date: { in: ctx.batchDates } };
+  }
+
+  const events = await prisma.event.findMany({
+    where,
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  });
+  ctx.sameDayCache.set(kennelId, events);
+
+  // Fuzzy pool: parents/non-series only, sorted by trustLevel desc (createdAt
+  // asc preserves the secondary key from the cache-wide sort). `== null`
+  // matches both `null` (real Events) and `undefined` (test mocks that omit
+  // parentEventId — same loose contract the prior `where:` filter gave when
+  // Vitest mocks ignored the `parentEventId: null` predicate).
+  const fuzzyPool = events.filter(
+    (e) => e.parentEventId == null && !e.isSeriesParent,
+  );
+  fuzzyPool.sort((a, b) => b.trustLevel - a.trustLevel);
+  ctx.fuzzyPoolByKennel.set(kennelId, fuzzyPool);
+}
+
+/** Filter a kennel's cached pool down to events on a specific UTC-noon date.
+ *  Rows without a Date `date` (test mocks) match every lookup, mirroring the
+ *  loose contract of the prior per-event `event.findMany` whose `where.date`
+ *  was ignored by Vitest mocks. */
+function getSameDayEvents(kennelId: string, eventDate: Date, ctx: MergeContext): EventRow[] {
+  const pool = ctx.sameDayCache.get(kennelId);
+  if (!pool) return [];
+  const eventTime = eventDate.getTime();
+  return pool.filter((e) => !(e.date instanceof Date) || e.date.getTime() === eventTime);
+}
+
+/** Mirror a freshly-created Event into both per-kennel caches so subsequent
+ *  events in the same batch see it on lookup. Mirrors the row reference, so
+ *  in-place updates by later iterations stay visible. The fuzzy-pool insert
+ *  uses an O(N) walk + splice instead of `Array.sort` so a batch creating
+ *  M events on one kennel stays linear, not M·N·logN. */
+function rememberCreatedEvent(kennelId: string, created: EventRow, ctx: MergeContext): void {
+  const pool = ctx.sameDayCache.get(kennelId);
+  if (pool) pool.push(created);
+  if (created.parentEventId == null && !created.isSeriesParent) {
+    const fuzzyPool = ctx.fuzzyPoolByKennel.get(kennelId);
+    if (fuzzyPool) {
+      // Pool is sorted by trustLevel desc; insert before the first row with
+      // a lower trustLevel (or push if `created` is the new lowest).
+      let i = 0;
+      while (i < fuzzyPool.length && fuzzyPool[i].trustLevel >= created.trustLevel) i++;
+      fuzzyPool.splice(i, 0, created);
+    }
+  }
+}
+
+/** Force a refetch of the kennel's event caches on next access. Used when a
+ *  cross-window fuzzy match physically moves an Event's date in DB; the cache
+ *  index by date would otherwise be stale. Cheap because cross-window matches
+ *  are gated by MERGE_FUZZY_DEDUP and very rare. */
+function invalidateKennelEventCache(kennelId: string, ctx: MergeContext): void {
+  ctx.sameDayCache.delete(kennelId);
+  ctx.fuzzyPoolByKennel.delete(kennelId);
 }
 
 /**
@@ -919,34 +1049,35 @@ async function findFuzzyDuplicateInWindow(
   event: RawEventData,
   kennelId: string,
   eventDate: Date,
-  sourceId: string,
+  ctx: MergeContext,
 ): Promise<FuzzyCandidate | null> {
   const incomingTitle = normalizeTitleForFuzzy(event.title);
   if (incomingTitle.length < FUZZY_MIN_TITLE_LEN) return null;
 
-  const windowStart = new Date(eventDate.getTime() - FUZZY_WINDOW_MS);
-  const windowEnd = new Date(eventDate.getTime() + FUZZY_WINDOW_MS);
+  const windowStart = eventDate.getTime() - FUZZY_WINDOW_MS;
+  const windowEnd = eventDate.getTime() + FUZZY_WINDOW_MS;
+  const eventTime = eventDate.getTime();
 
-  // Tie-break on `createdAt: "asc"` to match `pickCanonicalEventIds`'s
-  // older-wins stability rule — fuzzy-merging into the existing canonical row
-  // keeps `isCanonical` and EventLink history coherent across scrapes.
-  const candidates = await prisma.event.findMany({
-    where: {
-      kennelId,
-      date: { gte: windowStart, lte: windowEnd, not: eventDate },
-      parentEventId: null,
-      isSeriesParent: false,
-    },
-    orderBy: [{ trustLevel: "desc" }, { createdAt: "asc" }],
+  // Pull the per-kennel fuzzy pool from the per-batch cache — issue #1287
+  // collapsed the previous per-event `event.findMany` here. Pool is already
+  // filtered to parents/non-series and sorted by trustLevel desc, createdAt
+  // asc; we just narrow to the per-event ±48h window in memory.
+  await ensureKennelEventCache(kennelId, ctx);
+  const pool = ctx.fuzzyPoolByKennel.get(kennelId) ?? [];
+  const candidates = pool.filter((c) => {
+    if (!(c.date instanceof Date)) return true; // tolerate test mocks without date
+    const t = c.date.getTime();
+    return t >= windowStart && t <= windowEnd && t !== eventTime;
   });
   if (candidates.length === 0) return null;
 
   // Batch-query: which of these candidates already have a RawEvent from our
   // source? Those are same-source events (e.g. back-to-back weekend trails)
   // and must NOT be fuzzy-merge targets — would silently collapse two
-  // legitimate adjacent-day trails into one.
+  // legitimate adjacent-day trails into one. Kept per-event for now since
+  // the candidate set is already small (#1287 deferred this batching).
   const sameSourceLinks = await prisma.rawEvent.findMany({
-    where: { eventId: { in: candidates.map(c => c.id) }, sourceId },
+    where: { eventId: { in: candidates.map(c => c.id) }, sourceId: ctx.sourceId },
     select: { eventId: true },
   });
   const sameSourceEventIds = new Set(
@@ -984,12 +1115,13 @@ async function upsertCanonicalEvent(
 ): Promise<string> {
   const eventDate = parseUtcNoonDate(event.date);
 
-  // Deterministic orderBy so the matcher's `.find()` picks a stable row on
-  // ties across retries or parallel scrapes.
-  const sameDayEvents = await prisma.event.findMany({
-    where: { kennelId, date: eventDate },
-    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-  });
+  // Read sameDayEvents from the per-batch per-kennel cache instead of issuing
+  // a per-event `event.findMany` (#1287). The pool is sorted by createdAt asc
+  // / id asc to preserve the matcher's stable-tiebreak rule on ties.
+  // `getSameDayEvents` returns a fresh array; local mutations (cross-window
+  // splice and post-create push) don't leak back into the cache.
+  await ensureKennelEventCache(kennelId, ctx);
+  const sameDayEvents = getSameDayEvents(kennelId, eventDate, ctx);
 
   // Match strategy:
   // 1. Zero existing → create new
@@ -1053,7 +1185,7 @@ async function upsertCanonicalEvent(
     && process.env.MERGE_FUZZY_DEDUP === "true"
     && !event.seriesId
   ) {
-    const fuzzy = await findFuzzyDuplicateInWindow(event, kennelId, eventDate, ctx.sourceId);
+    const fuzzy = await findFuzzyDuplicateInWindow(event, kennelId, eventDate, ctx);
     if (fuzzy) {
       existingEvent = fuzzy;
       sameDayEvents.push(fuzzy);
@@ -1210,6 +1342,13 @@ async function upsertCanonicalEvent(
       // added fields that would flip the pick).
       const idx = sameDayEvents.findIndex(e => e.id === existingEvent.id);
       if (idx !== -1) sameDayEvents[idx] = updated;
+
+      // The cross-window UPDATE above mutated `date` in DB, so the per-
+      // batch cache's view of this row is stale. Invalidate so the next
+      // event in the batch refetches. Only fires when the date actually
+      // changed (this trust-gated branch); the lower-trust enrichment
+      // path leaves date untouched and doesn't need invalidation.
+      if (crossWindowMatch) invalidateKennelEventCache(kennelId, ctx);
     }
 
     // Lower-trust enrichment: fill NULL fields without overwriting non-null
@@ -1319,6 +1458,9 @@ async function upsertCanonicalEvent(
 
     targetEventId = newEvent.id;
     sameDayEvents.push(newEvent); // keep finalCandidates consistent for recomputeCanonical
+    // Mirror the new row into the per-batch caches so subsequent events for
+    // the same kennel see it (#1287 — replaces the per-event findMany).
+    rememberCreatedEvent(kennelId, newEvent, ctx);
 
     // Link RawEvent to new Event
     await prisma.rawEvent.update({
@@ -1523,14 +1665,14 @@ async function processNewRawEvent(
 
   await createEventLinks(targetEventId, sourceId, event.externalLinks);
 
-  // Update kennel's lastEventDate cache if this event is newer
+  // Track the max event date per kennel — flushed as one batched
+  // `kennel.updateMany` per kennel after the loop in `processRawEvents`
+  // (#1287 — replaces the per-event `$executeRaw UPDATE "Kennel"`).
   const eventDateForCache = parseUtcNoonDate(event.date);
-  await prisma.$executeRaw`
-    UPDATE "Kennel"
-    SET "lastEventDate" = ${eventDateForCache}, "updatedAt" = NOW()
-    WHERE id = ${kennelId}
-    AND ("lastEventDate" IS NULL OR "lastEventDate" < ${eventDateForCache})
-  `;
+  const previousMax = ctx.kennelMaxDates.get(kennelId);
+  if (!previousMax || previousMax.getTime() < eventDateForCache.getTime()) {
+    ctx.kennelMaxDates.set(kennelId, eventDateForCache);
+  }
 
   return targetEventId;
 }
@@ -1896,6 +2038,26 @@ export async function processRawEvents(
   const kennelCache = new Map<string, KennelCacheEntry>();
   const shortUrlCache = new Map<string, string | null>();
   const batchMatchedEvents = new Map<string, Set<string>>();
+
+  // Union of UTC-noon dates across the batch — drives the per-kennel
+  // prefetch in `ensureKennelEventCache` (#1287). Skip events whose
+  // fingerprint precompute failed (their dates may be unparseable).
+  const batchDates: Date[] = [];
+  const seenDates = new Set<number>();
+  for (const e of events) {
+    if (!fingerprintByEvent.has(e)) continue;
+    try {
+      const d = parseUtcNoonDate(e.date);
+      const t = d.getTime();
+      if (!Number.isNaN(t) && !seenDates.has(t)) {
+        seenDates.add(t);
+        batchDates.push(d);
+      }
+    } catch {
+      // ignore — recordMergeError handles per-event date errors below
+    }
+  }
+
   const ctx: MergeContext = {
     sourceId,
     trustLevel,
@@ -1905,6 +2067,10 @@ export async function processRawEvents(
     shortUrlCache,
     batchMatchedEvents,
     existingByFingerprint,
+    batchDates,
+    sameDayCache: new Map(),
+    fuzzyPoolByKennel: new Map(),
+    kennelMaxDates: new Map(),
     result,
   };
 
@@ -1936,6 +2102,24 @@ export async function processRawEvents(
   }
 
   await linkMultiDaySeries(seriesGroups);
+
+  // Flush per-kennel max event dates as a single batched write per kennel
+  // (#1287 — replaces the per-event `$executeRaw UPDATE "Kennel"`). The
+  // OR-NULL-or-LT guard in `where` preserves the "only update if newer"
+  // semantic. `updatedAt` auto-updates via Prisma's @updatedAt.
+  if (ctx.kennelMaxDates.size > 0) {
+    await Promise.all(
+      [...ctx.kennelMaxDates].map(([kennelId, maxDate]) =>
+        prisma.kennel.updateMany({
+          where: {
+            id: kennelId,
+            OR: [{ lastEventDate: null }, { lastEventDate: { lt: maxDate } }],
+          },
+          data: { lastEventDate: maxDate },
+        }),
+      ),
+    );
+  }
 
   return result;
 }

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1343,12 +1343,32 @@ async function upsertCanonicalEvent(
       const idx = sameDayEvents.findIndex(e => e.id === existingEvent.id);
       if (idx !== -1) sameDayEvents[idx] = updated;
 
-      // The cross-window UPDATE above mutated `date` in DB, so the per-
-      // batch cache's view of this row is stale. Invalidate so the next
-      // event in the batch refetches. Only fires when the date actually
-      // changed (this trust-gated branch); the lower-trust enrichment
-      // path leaves date untouched and doesn't need invalidation.
-      if (crossWindowMatch) invalidateKennelEventCache(kennelId, ctx);
+      if (crossWindowMatch) {
+        // Cross-window UPDATE moved `date` in DB, shifting the row's bucket
+        // in the cache. Invalidate so the next event refetches; surgical
+        // patching of a moved-date row is bug-prone.
+        invalidateKennelEventCache(kennelId, ctx);
+      } else {
+        // Non-cross-window UPDATE: the row's `date` is unchanged but other
+        // fields the matcher reads (runNumber, startTime, sourceUrl,
+        // trustLevel, title, etc.) may have moved. Patch the shared caches
+        // in place so a later event in the same batch matching against
+        // this canonical row sees post-update values, not stale ones —
+        // skipping this leaks the same "stale match → spurious create"
+        // regression a fresh DB findMany would have avoided pre-#1287.
+        const sharedPool = ctx.sameDayCache.get(kennelId);
+        if (sharedPool) {
+          const si = sharedPool.findIndex(e => e.id === updated.id);
+          if (si !== -1) sharedPool[si] = updated;
+        }
+        if (updated.parentEventId == null && !updated.isSeriesParent) {
+          const fuzzyPool = ctx.fuzzyPoolByKennel.get(kennelId);
+          if (fuzzyPool) {
+            const fi = fuzzyPool.findIndex(e => e.id === updated.id);
+            if (fi !== -1) fuzzyPool[fi] = updated;
+          }
+        }
+      }
     }
 
     // Lower-trust enrichment: fill NULL fields without overwriting non-null
@@ -2107,9 +2127,18 @@ export async function processRawEvents(
   // (#1287 — replaces the per-event `$executeRaw UPDATE "Kennel"`). The
   // OR-NULL-or-LT guard in `where` preserves the "only update if newer"
   // semantic. `updatedAt` auto-updates via Prisma's @updatedAt.
+  //
+  // `allSettled` (not `all`) so a transient DB error on one kennel's cache
+  // write doesn't reject the whole batch — pre-#1287 the equivalent
+  // `$executeRaw` was inside the per-event try/catch and a single failure
+  // was recorded as `eventErrors` while the batch still completed.
+  // `lastEventDate` is a non-critical UI-cache field (used by the kennel
+  // directory's "recently active" filter); a missed update self-heals on
+  // the next scrape.
   if (ctx.kennelMaxDates.size > 0) {
-    await Promise.all(
-      [...ctx.kennelMaxDates].map(([kennelId, maxDate]) =>
+    const entries = [...ctx.kennelMaxDates];
+    const settled = await Promise.allSettled(
+      entries.map(([kennelId, maxDate]) =>
         prisma.kennel.updateMany({
           where: {
             id: kennelId,
@@ -2119,6 +2148,16 @@ export async function processRawEvents(
         }),
       ),
     );
+    for (let i = 0; i < settled.length; i++) {
+      const outcome = settled[i];
+      if (outcome.status === "rejected") {
+        const [kennelId] = entries[i];
+        console.error(
+          `[merge] lastEventDate flush failed for kennel ${kennelId}:`,
+          outcome.reason,
+        );
+      }
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary

Closes the last three per-new-event Prisma reads in `processRawEvents`, deferred from PR #1280's N+1 fix:

- `event.findMany({ kennelId, date: eventDate })` (sameDayEvents) — once per new event in `upsertCanonicalEvent`.
- `event.findMany({ kennelId, date: { gte, lte, not }, parentEventId: null, isSeriesParent: false })` (fuzzy ±48h candidates) — once per new event in `findFuzzyDuplicateInWindow`.
- `$executeRaw UPDATE "Kennel" SET "lastEventDate"` — once per new event in `processNewRawEvent`.

These only fire for events that pass the dedup prefetch (i.e. genuinely new), so steady-state mostly-duplicate scrapes don't see them — but backfills and first scrapes do. The N+1 was the next bottleneck after PR #1280 closed the Sentry-flagged one.

## Approach

**Per-kennel cache, lazy-populated.** `ensureKennelEventCache(kennelId, ctx)` runs ONE `event.findMany` per kennel touched in a batch, populating:
- `ctx.sameDayCache: Map<kennelId, EventRow[]>` — flat list per kennel; `getSameDayEvents` filters by exact date on access.
- `ctx.fuzzyPoolByKennel: Map<kennelId, EventRow[]>` — pre-filtered to parents/non-series, pre-sorted by trustLevel desc.

**Window strategy adapts to the fuzzy flag:**
- `MERGE_FUZZY_DEDUP=true` (off in prod): widens to `date BETWEEN min(batchDates) - 48h AND max(batchDates) + 48h`.
- Default: `date: { in: [...batchDates] }` — narrow, avoids the SDH3-backfill pathology where one scrape would pull 7K+ historical rows because `batchDates` spans a year.

**`rememberCreatedEvent` mirrors fresh creates** into both caches via an O(N) insertion-sort splice (not `Array.sort`), keeping a batch of M new-event creations linear in fuzzy-pool size, not M·N·logN.

**`invalidateKennelEventCache` runs only inside the trust-gated UPDATE branch** where `date` actually changes in DB. Lower-trust enrichment paths don't move the row, so the cache stays valid and we skip a redundant refetch.

**Per-event `$executeRaw` replaced by `ctx.kennelMaxDates: Map<kennelId, Date>`,** flushed as one `Promise.all` of `kennel.updateMany` after the loop. Preserves the "only update if newer" semantic via the `OR: [{ lastEventDate: null }, { lastEventDate: { lt: maxDate } }]` guard.

## Query count change

For a batch of M new events on K distinct kennels:

| Read | Pre-#1287 | Post-#1287 |
|---|---|---|
| sameDayEvents | M `event.findMany` | K `event.findMany` (with sameDayCache + fuzzy pool) |
| Fuzzy ±48h candidates | M `event.findMany` | 0 (in-memory from sameDay prefetch) |
| Kennel.lastEventDate | M `$executeRaw` | K `kennel.updateMany` (parallel) |
| **Total per-event reads** | **2M + M writes** | **K reads + K writes** |

For the typical scrape (M=20–50 events on K=1 kennel): 60–150 round-trips → 2 round-trips. For SDH3-style backfill (M=7,649 on K=10): 22,947 round-trips → 20 round-trips.

## Tests

- 4 new regressions in `merge.test.ts`:
  - "issues at most one event.findMany per distinct kennel across a multi-event batch (fuzzy off)" — verifies `date: { in: batchDates }` narrow shape.
  - "widens the cache prefetch to ±48h around batch dates when MERGE_FUZZY_DEDUP is on" — verifies `date: { gte, lte }` wide shape.
  - "issues at most one kennel.updateMany per distinct kennel" — verifies the batched flush + max-date guard.
  - "does not call kennel.updateMany when no new events are processed (all duplicates)" — verifies the dedup-only path skips the flush.
- Two existing fuzzy tests updated to match the new query order (single cache prefetch + cross-window old-bucket refetch instead of three separate findMany calls).
- Added `vi.mocked(prisma.event.findMany).mockReset()` in `beforeEach` to prevent leftover `mockResolvedValueOnce` queues from prior tests being consumed by the new prefetch — same hygiene fix PR #1280 made for `rawEvent.findMany`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test src/pipeline/merge.test.ts` — 298/298 passing (4 new + 2 updated fuzzy + 1 new for cross-source race-window cleanup)
- [x] `npm test` (full suite) — 6,311 passing, 7 skipped, 25 todo
- [x] `npm run lint` — 0 errors on changed files
- [x] `/simplify` review applied 4 fixes (window gating, insertion sort, trust-gated cache invalidation, comment trim)
- [ ] Production verify post-deploy: confirm a chatty source's Sentry trace shows 1 `event.findMany` per kennel and 1 `kennel.updateMany` per kennel, not per new event

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)