### PR TITLE
fix(ih3): adapter parse fixes + 99-event Trail Log archive backfill

### DIFF
--- a/scripts/backfill-ih3-history.ts
+++ b/scripts/backfill-ih3-history.ts
@@ -60,7 +60,7 @@ import type { RawEventData } from "@/adapters/types";
 
 const SOURCE_NAME = "IH3 Website Hareline";
 const KENNEL_TIMEZONE = "America/New_York";
-const TRAIL_LOG_URL = "http://ithacah3.org/hair_line-trail_log/";
+const TRAIL_LOG_URL = "http://ithacah3.org/hair_line-trail_log/"; // NOSONAR — source has expired SSL
 
 async function fetchEvents(): Promise<RawEventData[]> {
   console.log(`Fetching ${TRAIL_LOG_URL}`);

--- a/scripts/backfill-ih3-history.ts
+++ b/scripts/backfill-ih3-history.ts
@@ -1,0 +1,87 @@
+/**
+ * One-shot historical backfill for IH3 (Ithaca H3).
+ * Issue #1345.
+ *
+ * `http://ithacah3.org/hair_line-trail_log/` carries ~99 past trails
+ * (#999–#1097, 2022-09-04 → 2025-07-20). The live hare-line adapter only
+ * fetches upcoming runs, so before this backfill HashTracks showed just
+ * 5 past events vs. the source's ~1,123 lifetime runs.
+ *
+ * Strategy:
+ *   1. Fetch the Trail Log archive via `fetchHTMLPage`.
+ *   2. Parse rows with `parseTrailLog` (lives next to the live adapter so
+ *      schema drift surfaces in unit tests, not at backfill time).
+ *   3. Attribute to the existing "IH3 Website Hareline" source — already
+ *      `SourceKennel`-linked to `ih3`, so the per-event merge guard accepts
+ *      every row with no seed change.
+ *   4. `runBackfillScript` partitions to past-only (date < today
+ *      America/New_York) and routes through the merge pipeline.
+ *
+ * Idempotency:
+ *   The merge pipeline dedupes RawEvents by `(sourceId, fingerprint)`. The
+ *   fingerprint is deterministic over the parsed payload, so a second apply
+ *   pass is a no-op on every row. The live page also duplicates `#1083`;
+ *   fingerprint dedup absorbs it. Verified end-to-end:
+ *     pass 1: created=99 updated=0 skipped=1   (the duplicate `#1083`)
+ *     pass 2: created=0  updated=0 skipped=100 (full no-op idempotency)
+ *
+ * Cross-source overlap with existing past events:
+ *   The Trail Log range is #999–#1097 (2022-09 → 2025-07-20). Any past IH3
+ *   events that pre-date this backfill in prod were captured by the live
+ *   hare-line scraper, which only carries upcoming runs; those past rows
+ *   therefore have runNumber > #1097 and cannot overlap with the trail-log
+ *   range. RawEvent fingerprint differs across sourceUrls, so even in a
+ *   hypothetical overlap, two RawEvents would coexist (audit-trail
+ *   immutability is intentional) and the canonical-Event matcher in merge.ts
+ *   (`getSameDayEvents` + runNumber-based disambiguation) would route them
+ *   to the same canonical Event without duplication.
+ *
+ * Reconcile risk:
+ *   Zero. `src/pipeline/reconcile.ts` skips cancellation decisions on
+ *   past-dated events ("a past-dated event missing from a scrape is not a
+ *   cancellation signal"), so the live hare-line adapter's upcoming-only
+ *   scrape will never cancel these historical rows.
+ *
+ * Coverage limit:
+ *   The Trail Log carries date + title + location only. Hares, start time,
+ *   cost stay null on backfilled rows. Acceptable per issue #1345.
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-ih3-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-ih3-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { parseTrailLog } from "@/adapters/html-scraper/ithaca-h3";
+import { fetchHTMLPage } from "@/adapters/utils";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "IH3 Website Hareline";
+const KENNEL_TIMEZONE = "America/New_York";
+const TRAIL_LOG_URL = "http://ithacah3.org/hair_line-trail_log/";
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log(`Fetching ${TRAIL_LOG_URL}`);
+  const page = await fetchHTMLPage(TRAIL_LOG_URL);
+  if (!page.ok) {
+    throw new Error(`Trail Log fetch failed: ${page.result.errors.join("; ")}`);
+  }
+
+  // No explicit sort here — `reportAndApplyBackfill` sorts past rows by date
+  // after the partition.
+  const events = parseTrailLog(page.html, TRAIL_LOG_URL);
+  console.log(`  Parsed ${events.length} rows from the Trail Log archive.`);
+  return events;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Walking IH3 Trail Log archive",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/ithaca-h3.test.ts
+++ b/src/adapters/html-scraper/ithaca-h3.test.ts
@@ -193,7 +193,7 @@ describe("parseIH3Block", () => {
 });
 
 describe("parseTrailLog", () => {
-  const sourceUrl = "http://ithacah3.org/hair_line-trail_log/";
+  const sourceUrl = "http://ithacah3.org/hair_line-trail_log/"; // NOSONAR — source has expired SSL
 
   it("parses a complete trail log row with title + location", () => {
     const html = `<p><strong>Hash #1097:</strong> Not at Grass Roots trail<br>2025-07-20; Mulholland Wildflower Preserve</p>`;

--- a/src/adapters/html-scraper/ithaca-h3.test.ts
+++ b/src/adapters/html-scraper/ithaca-h3.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as cheerio from "cheerio";
-import { parseIH3Date, parseIH3Block } from "./ithaca-h3";
+import { parseIH3Date, parseIH3Block, parseTrailLog } from "./ithaca-h3";
 
 describe("parseIH3Date", () => {
   beforeEach(() => {
@@ -50,7 +50,7 @@ describe("parseIH3Block", () => {
 
   const sourceUrl = "http://ithacah3.org/hare-line/";
 
-  it("parses a complete event block", () => {
+  it("parses a complete event block with no source title (default fallback)", () => {
     const html = `<p>
       <strong>#1119: March 15</strong><br>
       <strong>Hares:</strong> Flesh Flaps &amp; Spike<br>
@@ -67,9 +67,12 @@ describe("parseIH3Block", () => {
     expect(result!.runNumber).toBe(1119);
     expect(result!.date).toBe("2026-03-15");
     expect(result!.kennelTags[0]).toBe("ih3");
-    expect(result!.title).toBe("IH3 #1119");
+    // No source-published title → undefined; merge.ts synthesizes
+    // "Ithaca H3 Trail #1119" via friendlyKennelName (#1344).
+    expect(result!.title).toBeUndefined();
     expect(result!.hares).toBe("Flesh Flaps & Spike");
     expect(result!.startTime).toBe("14:00");
+    expect(result!.cost).toBe("$5 (first timers free)");
     expect(result!.latitude).toBeCloseTo(42.44, 1);
     expect(result!.longitude).toBeCloseTo(-76.50, 1);
   });
@@ -132,5 +135,117 @@ describe("parseIH3Block", () => {
       expect(result!.location).not.toContain("2:00");
       expect(result!.location).not.toContain("Cost:");
     }
+  });
+
+  // ---- #1123 regression: early-start trail must parse 12:00 not 2:00 ----
+  it("parses 'When: 12:00 pm' when the <br> is inside the next <span> (#1123)", () => {
+    vi.setSystemTime(new Date(2026, 4, 5)); // May 5, 2026 — #1123 is May 10
+    const html = `<p><strong>#1123: May 10</strong> (—<em><mark>early start</mark></em>—)<br><strong>Hares:</strong> OTD<br><span style="font-weight: 600;">Where</span>: <a href="https://www.google.com/maps/place/Cayuga+Plaza/@42.482,-76.486,17z">Taco Bell, Cayuga Plaza</a><br><span style="font-weight: 600;">When:</span> 12:00 pm<span style="font-weight: 600;"><br>Cost:</span> $8 (first timers free)<span style="font-weight: 600;"><br>Details</span>: <a href="https://ithacah3.org/hash-1123/">see details</a></p>`;
+
+    const $ = cheerio.load(html);
+    const result = parseIH3Block($("p").first(), $, sourceUrl);
+
+    expect(result).not.toBeNull();
+    expect(result!.runNumber).toBe(1123);
+    expect(result!.date).toBe("2026-05-10");
+    expect(result!.startTime).toBe("12:00");
+    expect(result!.cost).toBe("$8 (first timers free)");
+    expect(result!.hares).toBe("OTD");
+    expect(result!.location).toContain("Taco Bell");
+  });
+
+  // ---- #1344 regression: source-provided title must surface ----
+  it("surfaces source-provided trail name from a non-label <strong> (#1344)", () => {
+    vi.setSystemTime(new Date(2026, 4, 20));
+    const html = `<p><strong>#1125: May 30</strong> (<em>—<mark>off-week trail</mark></em>–)<br><strong><mark>RAI</mark><mark>NB</mark><mark>OW </mark><mark>DRE</mark><mark>SS</mark> <mark>RUN</mark></strong><br><strong>Hares:</strong> Penguin<br><span style="font-weight: 600;">Where</span>: <a href="https://www.google.com/maps?q=Liquid+State">Liquid State</a><br><span style="font-weight: 600;">When:</span> 12:00 pm<span style="font-weight: 600;"><br>Cost:</span> $50<span style="font-weight: 600;"><br>Details</span>: <a href="https://hashrego.com/events/ih3-2nd-annual-rainbow-dress-run-for-charity">see details</a></p>`;
+
+    const $ = cheerio.load(html);
+    const result = parseIH3Block($("p").first(), $, sourceUrl);
+
+    expect(result).not.toBeNull();
+    expect(result!.runNumber).toBe(1125);
+    expect(result!.date).toBe("2026-05-30");
+    expect(result!.title).toBe("RAINBOW DRESS RUN");
+    expect(result!.startTime).toBe("12:00");
+    expect(result!.cost).toBe("$50");
+    expect(result!.location).toBe("Liquid State");
+  });
+
+  it("leaves title undefined when only label strongs follow the header", () => {
+    vi.setSystemTime(new Date(2026, 5, 1));
+    const html = `<p><strong>#1126: June 7</strong><br><strong>Hares:</strong> TBD<br><span style="font-weight: 600;">Where</span>: TBD<br><span style="font-weight: 600;">When:</span> 2:00 pm<span style="font-weight: 600;"><br>Cost:</span> $7 (first timers free)<span style="font-weight: 600;"><br>Details</span>: TBD</p>`;
+
+    const $ = cheerio.load(html);
+    const result = parseIH3Block($("p").first(), $, sourceUrl);
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBeUndefined();
+    expect(result!.cost).toBe("$7 (first timers free)");
+  });
+
+  it("suppresses TBD cost", () => {
+    const html = `<p><strong>#1130: July 12</strong><br><span style="font-weight: 600;">When:</span> 2:00 pm<span style="font-weight: 600;"><br>Cost:</span> TBD</p>`;
+    const $ = cheerio.load(html);
+    const result = parseIH3Block($("p").first(), $, sourceUrl);
+    expect(result).not.toBeNull();
+    expect(result!.cost).toBeUndefined();
+  });
+});
+
+describe("parseTrailLog", () => {
+  const sourceUrl = "http://ithacah3.org/hair_line-trail_log/";
+
+  it("parses a complete trail log row with title + location", () => {
+    const html = `<p><strong>Hash #1097:</strong> Not at Grass Roots trail<br>2025-07-20; Mulholland Wildflower Preserve</p>`;
+    const events = parseTrailLog(html, sourceUrl);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      runNumber: 1097,
+      date: "2025-07-20",
+      title: "Not at Grass Roots trail",
+      location: "Mulholland Wildflower Preserve",
+      kennelTags: ["ih3"],
+      sourceUrl,
+    });
+  });
+
+  it("handles rows without a title (empty between </strong> and <br>)", () => {
+    const html = `<p><strong>Hash #1093:</strong> <br>2025-05-25; Hammond Hill</p>`;
+    const events = parseTrailLog(html, sourceUrl);
+    expect(events).toHaveLength(1);
+    expect(events[0].title).toBeUndefined();
+    expect(events[0].date).toBe("2025-05-25");
+    expect(events[0].location).toBe("Hammond Hill");
+  });
+
+  it("ignores the category class (event_W) but still emits the row", () => {
+    const html = `<p class="event_W"><strong>Hash #1068:</strong> Fat-boy trail<br>2024-08-25; Camp Owahta</p>`;
+    const events = parseTrailLog(html, sourceUrl);
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(1068);
+    expect(events[0].title).toBe("Fat-boy trail");
+  });
+
+  it("decodes HTML entities in titles and locations", () => {
+    const html = `<p><strong>Hash #1086:</strong> Head&rsquo;s birthday trail!<br>2025-03-16; Lime Hollow</p>`;
+    const events = parseTrailLog(html, sourceUrl);
+    expect(events).toHaveLength(1);
+    expect(events[0].title).toBe("Head’s birthday trail!");
+  });
+
+  it("emits duplicate rows verbatim (fingerprint dedup handles it)", () => {
+    const html = `
+      <p><strong>Hash #1083:</strong> Sledding for Groundhog Day<br>2025-02-02; Mundy Wildflower Garden, Cornell Plantations</p>
+      <p><strong>Hash #1083:</strong> Sledding for Groundhog Day<br>2025-02-02; Mundy Wildflower Garden, Cornell Plantations</p>
+    `;
+    const events = parseTrailLog(html, sourceUrl);
+    expect(events).toHaveLength(2);
+  });
+
+  it("ignores non-event paragraphs", () => {
+    const html = `<p>Welcome to the Trail Log archive!</p><p><strong>Hash #1043:</strong> New Beers hash<br>2024-01-01; Lime Hollow</p>`;
+    const events = parseTrailLog(html, sourceUrl);
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(1043);
   });
 });

--- a/src/adapters/html-scraper/ithaca-h3.ts
+++ b/src/adapters/html-scraper/ithaca-h3.ts
@@ -8,8 +8,18 @@ import type {
   ErrorDetails,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { fetchHTMLPage, parse12HourTime, HARE_BOILERPLATE_RE } from "../utils";
+import {
+  fetchHTMLPage,
+  parse12HourTime,
+  HARE_BOILERPLATE_RE,
+  decodeEntities,
+  stripPlaceholder,
+} from "../utils";
 import { extractCoordsFromMapsUrl } from "@/lib/geo";
+
+/** Labels that appear inside `<strong>` tags on the hare-line — used to skip
+ *  label-only strongs when hunting for the event title strong. */
+const IH3_LABEL_STRONG_RE = /^\s*(?:hares?|where|when|cost|details)\s*:?\s*$/i;
 
 /**
  * Parse a date string like "March 15" into "YYYY-MM-DD" with year inference.
@@ -48,15 +58,23 @@ export function parseIH3Date(text: string): string | null {
 /**
  * Parse a single event <p> block from the IH3 hare-line page.
  *
- * Expected HTML structure:
+ * Expected HTML structure (the title strong is optional and only present when
+ * the trail has a published name — #1344):
  *   <p>
  *     <strong>#1119: March 15</strong><br>
+ *     <strong>RAINBOW DRESS RUN</strong><br>    (optional — title)
  *     <strong>Hares:</strong> Flesh Flaps &amp; Spike<br>
  *     <span style="font-weight: 600;">Where</span>: <a href="maps-url">Flat Rock</a><br>
  *     <span style="font-weight: 600;">When:</span> 2:00 pm<br>
  *     <span style="font-weight: 600;">Cost:</span> $5 (first timers free)<br>
  *     <span style="font-weight: 600;">Details</span>: <a href="...">touch me</a>
  *   </p>
+ *
+ * The site frequently embeds `<br>` inside the next decorative `<span>` rather
+ * than as a separator between fields, so `$block.text()` collapses adjacent
+ * fields with no whitespace (e.g. `When: 12:00 pmCost: $8`). The `.+?`
+ * lazy-match + next-label alternation in the When/Cost regexes is the load-
+ * bearing fix for that — don't simplify to `.*$` (#1123).
  */
 export function parseIH3Block(
   $block: cheerio.Cheerio<AnyNode>,
@@ -67,13 +85,37 @@ export function parseIH3Block(
   const blockText = $block.text();
 
   // Extract trail number and date from the first <strong>
-  const headerMatch = /#(\d+)\s*:\s*(.+)/i.exec($block.find("strong").first().text());
+  const strongs = $block.find("strong");
+  const headerMatch = /#(\d+)\s*:\s*(.+)/i.exec(strongs.first().text());
   if (!headerMatch) return null;
 
   const runNumber = parseInt(headerMatch[1], 10);
   const dateText = headerMatch[2].trim();
   const date = parseIH3Date(dateText);
   if (!date) return null;
+
+  // Extract event title — first <strong> after the header that isn't a field
+  // label (Hares/Where/When/Cost/Details). When the source omits a title,
+  // leave it undefined so merge.ts synthesizes "Ithaca H3 Trail #NNNN" via
+  // friendlyKennelName instead of locking in a placeholder #1344.
+  //
+  // Known tradeoff (#1344 / codex adversarial review): if a source admin
+  // removes a previously published title, the next scrape emits undefined and
+  // merge.ts will overwrite the canonical Event.title with the synthesized
+  // default. This is the same behavior every conditional-title adapter has
+  // in the codebase (see hashnyc.ts). Acceptable because (a) source admins
+  // rarely strip published titles, and (b) the synthesized fallback is
+  // strictly better than the pre-PR "IH3 #N" placeholder we used to ship.
+  let title: string | undefined;
+  strongs.each((i, el) => {
+    if (i === 0) return;
+    const t = $(el).text();
+    if (IH3_LABEL_STRONG_RE.test(t)) return;
+    const cleaned = decodeEntities(t).replaceAll(/\s+/g, " ").trim();
+    if (!cleaned) return;
+    title = cleaned;
+    return false; // break cheerio .each() once we have the title
+  });
 
   // Extract hares
   let hares: string | undefined;
@@ -132,19 +174,96 @@ export function parseIH3Block(
     startTime = parse12HourTime(whenMatch[1]);
   }
 
+  // Extract cost — fixed "Cost: $X (...)" line on every event (#1346).
+  // `\n` is a terminator because cheerio's `.text()` collapses well-formed
+  // `<br>` to newlines; `Details` is the terminator when the source omits
+  // `<br>` and labels run together (see TBDWhen test).
+  const costMatch = /Cost\s*:?\s*(.+?)(?:\n|Details|$)/i.exec(blockText);
+  const cost = costMatch ? stripPlaceholder(costMatch[1]) : undefined;
+
   return {
     date,
     kennelTags: ["ih3"],
-    runNumber: !isNaN(runNumber) ? runNumber : undefined,
-    title: `IH3 #${runNumber}`,
+    runNumber,
+    title,
     hares,
     location,
     locationUrl,
     latitude,
     longitude,
     startTime,
+    cost,
     sourceUrl: detailUrl || sourceUrl,
   };
+}
+
+/**
+ * Parse the IH3 Trail Log archive page (`/hair_line-trail_log/`).
+ *
+ * Row shape (verified live 2026-05):
+ *   <p[ class="event_W|I|L|D"]?>
+ *     <strong>Hash #NNNN:</strong> [optional title]
+ *     <br>YYYY-MM-DD; Location
+ *   </p>
+ *
+ * Used by `scripts/backfill-ih3-history.ts` to backfill ~99 historical events
+ * (#999–#1097, 2022-09 → 2025-07) that pre-date the kennel's WordPress hare-line
+ * (which only carries upcoming runs).
+ *
+ * Notes:
+ * - Title can be empty (`<strong>Hash #1093:</strong> <br>2025-05-25; …`).
+ * - `class="event_W"` etc. are category colors — not relevant to parsing.
+ * - The live page duplicates one row (`#1083` appears twice). We don't dedupe
+ *   here; the merge pipeline's `(sourceId, fingerprint)` unique index catches
+ *   it. Don't "fix" the duplicate emit — fingerprint dedup is the load-bearing
+ *   correctness guarantee, and one row twice in the parser output is harmless.
+ */
+export function parseTrailLog(html: string, sourceUrl: string): RawEventData[] {
+  const $ = cheerio.load(html);
+  const out: RawEventData[] = [];
+
+  $("p").each((_i, el) => {
+    const $p = $(el);
+    const strongText = $p.find("strong").first().text();
+    const header = /Hash\s*#(\d+)\s*:/i.exec(strongText);
+    if (!header) return;
+    const runNumber = parseInt(header[1], 10);
+
+    // Split inner HTML on the <br> separating "Hash #N: Title" from "Date; Location".
+    const inner = $.html($p);
+    const brSplit = inner.split(/<br\s*\/?>/i);
+    if (brSplit.length < 2) return;
+
+    // Title: text content of the first half, after the closing </strong>.
+    const titleMatch = /<\/strong>([\s\S]*)$/i.exec(brSplit[0]);
+    const titleRaw = titleMatch
+      ? cheerio.load(`<div>${titleMatch[1]}</div>`)("div").text()
+      : "";
+    const titleClean = decodeEntities(titleRaw).replaceAll(/\s+/g, " ").trim();
+    const title = titleClean || undefined;
+
+    // Date + location: "YYYY-MM-DD; Location" in the second half.
+    const datesHalfRaw = cheerio
+      .load(`<div>${brSplit[1]}</div>`)("div")
+      .text();
+    const datesHalf = decodeEntities(datesHalfRaw).trim();
+    const dateMatch = /^(\d{4}-\d{2}-\d{2})\s*[;,]?\s*(.*)$/.exec(datesHalf);
+    if (!dateMatch) return;
+    const date = dateMatch[1];
+    const locationClean = dateMatch[2].replaceAll(/\s+/g, " ").trim();
+    const location = locationClean || undefined;
+
+    out.push({
+      date,
+      kennelTags: ["ih3"],
+      runNumber,
+      title,
+      location,
+      sourceUrl,
+    });
+  });
+
+  return out;
 }
 
 /**

--- a/src/adapters/html-scraper/ithaca-h3.ts
+++ b/src/adapters/html-scraper/ithaca-h3.ts
@@ -176,13 +176,19 @@ export function parseIH3Block(
   }
 
   // Extract cost — fixed "Cost: $X (...)" line on every event (#1346).
-  // `\n` is a terminator because cheerio's `.text()` collapses well-formed
-  // `<br>` to newlines; the label list is the terminator when the source
-  // omits `<br>` and labels run together (see TBDWhen test). Carrying the
-  // full label set defends against any field-reordering the source might
-  // introduce in the future (gemini-code-assist review on #1379).
-  const costMatch = /Cost\s*:?\s*(.+?)(?:\n|Details\s*:|Hares?\s*:|Where\s*:|When\s*:|$)/i.exec(blockText);
-  const cost = costMatch ? stripPlaceholder(costMatch[1]) : undefined;
+  // Uses the same slice-+-split shape the location extraction above uses:
+  // anchor on the label, then split on the next label / newline. This
+  // avoids the `Label\s*:?\s*(.+?)(?:alt|...|$)` lazy-quantifier shape that
+  // Sonar S5852 flags as ReDoS-vulnerable (the actual input is a single
+  // event block, so it's linear in practice, but reusing the established
+  // pattern keeps the analyzer quiet and matches the file's house style).
+  let cost: string | undefined;
+  const costLabelMatch = /Cost\s*:?\s*/i.exec(blockText);
+  if (costLabelMatch) {
+    const afterCost = blockText.slice(costLabelMatch.index + costLabelMatch[0].length);
+    const costRaw = afterCost.split(/\n|Details\s*:|Hares?\s*:|Where\s*:|When\s*:/i)[0] ?? "";
+    cost = stripPlaceholder(costRaw);
+  }
 
   return {
     date,

--- a/src/adapters/html-scraper/ithaca-h3.ts
+++ b/src/adapters/html-scraper/ithaca-h3.ts
@@ -236,7 +236,7 @@ export function parseTrailLog(html: string, sourceUrl: string): RawEventData[] {
     const strongText = $p.find("strong").first().text();
     const header = /Hash\s*#(\d+)\s*:/i.exec(strongText);
     if (!header) return;
-    const runNumber = parseInt(header[1], 10);
+    const runNumber = Number.parseInt(header[1], 10);
 
     // Split inner HTML on <br>. The documented row shape has a single <br>,
     // but slice(1).join("<br>") preserves any extras inside the location half

--- a/src/adapters/html-scraper/ithaca-h3.ts
+++ b/src/adapters/html-scraper/ithaca-h3.ts
@@ -18,8 +18,10 @@ import {
 import { extractCoordsFromMapsUrl } from "@/lib/geo";
 
 /** Labels that appear inside `<strong>` tags on the hare-line — used to skip
- *  label-only strongs when hunting for the event title strong. */
-const IH3_LABEL_STRONG_RE = /^\s*(?:hares?|where|when|cost|details)\s*:?\s*$/i;
+ *  label-only strongs when hunting for the event title strong. Inputs are
+ *  pre-trimmed by the caller, so this anchor pair doesn't need outer `\s*`
+ *  (which Sonar S5852 flags as ReDoS-shaped). */
+const IH3_LABEL_STRONG_RE = /^(?:hares?|where|when|cost|details):?$/i;
 
 /**
  * Parse a date string like "March 15" into "YYYY-MM-DD" with year inference.
@@ -109,10 +111,9 @@ export function parseIH3Block(
   let title: string | undefined;
   strongs.each((i, el) => {
     if (i === 0) return;
-    const t = $(el).text();
-    if (IH3_LABEL_STRONG_RE.test(t)) return;
-    const cleaned = decodeEntities(t).replaceAll(/\s+/g, " ").trim();
+    const cleaned = decodeEntities($(el).text()).replaceAll(/\s+/g, " ").trim();
     if (!cleaned) return;
+    if (IH3_LABEL_STRONG_RE.test(cleaned)) return;
     title = cleaned;
     return false; // break cheerio .each() once we have the title
   });
@@ -176,9 +177,11 @@ export function parseIH3Block(
 
   // Extract cost — fixed "Cost: $X (...)" line on every event (#1346).
   // `\n` is a terminator because cheerio's `.text()` collapses well-formed
-  // `<br>` to newlines; `Details` is the terminator when the source omits
-  // `<br>` and labels run together (see TBDWhen test).
-  const costMatch = /Cost\s*:?\s*(.+?)(?:\n|Details|$)/i.exec(blockText);
+  // `<br>` to newlines; the label list is the terminator when the source
+  // omits `<br>` and labels run together (see TBDWhen test). Carrying the
+  // full label set defends against any field-reordering the source might
+  // introduce in the future (gemini-code-assist review on #1379).
+  const costMatch = /Cost\s*:?\s*(.+?)(?:\n|Details\s*:|Hares?\s*:|Where\s*:|When\s*:|$)/i.exec(blockText);
   const cost = costMatch ? stripPlaceholder(costMatch[1]) : undefined;
 
   return {
@@ -229,28 +232,38 @@ export function parseTrailLog(html: string, sourceUrl: string): RawEventData[] {
     if (!header) return;
     const runNumber = parseInt(header[1], 10);
 
-    // Split inner HTML on the <br> separating "Hash #N: Title" from "Date; Location".
+    // Split inner HTML on <br>. The documented row shape has a single <br>,
+    // but slice(1).join("<br>") preserves any extras inside the location half
+    // (e.g. a multi-line address) instead of silently truncating them.
     const inner = $.html($p);
     const brSplit = inner.split(/<br\s*\/?>/i);
     if (brSplit.length < 2) return;
+    const headerHalf = brSplit[0];
+    const tailHalf = brSplit.slice(1).join("<br>");
 
-    // Title: text content of the first half, after the closing </strong>.
-    const titleMatch = /<\/strong>([\s\S]*)$/i.exec(brSplit[0]);
+    // Title: text content after the closing </strong> on the header half.
+    const titleMatch = /<\/strong>([\s\S]*)$/i.exec(headerHalf);
     const titleRaw = titleMatch
       ? cheerio.load(`<div>${titleMatch[1]}</div>`)("div").text()
       : "";
     const titleClean = decodeEntities(titleRaw).replaceAll(/\s+/g, " ").trim();
     const title = titleClean || undefined;
 
-    // Date + location: "YYYY-MM-DD; Location" in the second half.
+    // Date + location: "YYYY-MM-DD; Location" on the tail half. The regex
+    // anchors on the fixed date prefix; the location split is done with
+    // string ops to keep the regex shape away from Sonar S5852's
+    // `\s*[;,]?\s*` false-positive trigger.
     const datesHalfRaw = cheerio
-      .load(`<div>${brSplit[1]}</div>`)("div")
+      .load(`<div>${tailHalf}</div>`)("div")
       .text();
     const datesHalf = decodeEntities(datesHalfRaw).trim();
-    const dateMatch = /^(\d{4}-\d{2}-\d{2})\s*[;,]?\s*(.*)$/.exec(datesHalf);
+    const dateMatch = /^(\d{4}-\d{2}-\d{2})([\s\S]*)$/.exec(datesHalf);
     if (!dateMatch) return;
     const date = dateMatch[1];
-    const locationClean = dateMatch[2].replaceAll(/\s+/g, " ").trim();
+    const locationClean = dateMatch[2]
+      .replace(/^[;,\s]+/, "")
+      .replaceAll(/\s+/g, " ")
+      .trim();
     const location = locationClean || undefined;
 
     out.push({


### PR DESCRIPTION
## Summary

Bundle for the Ithaca H3 (`ih3`) audit-stream cluster — adapter parse fixes
plus a one-shot historical backfill. Same shape as cycle-4 HAH3 PR #1366.

- **#1123 start time** — pinned regression fixture for the "early start"
  trail. `IH3 #1123` parses to `12:00` against the live HTML shape where the
  `<br>` is embedded inside the next decorative `<span>` (cheerio's `.text()`
  collapses to `…When: 12:00 pmCost: $8…` with no separating whitespace).
- **#1344 placeholder titles** — adapter now iterates `<strong>` blocks,
  skips the header + label-only strongs (Hares/Where/When/Cost/Details), and
  emits the first remaining strong as the event title. Drops the unconditional
  `title: \`IH3 #${runNumber}\`` so `merge.ts` synthesizes
  `"Ithaca H3 Trail #N"` via `friendlyKennelName` instead.
- **#1346 cost field** — `Cost: $X (...)` line parsed on every event; piped
  through `stripPlaceholder` so `TBD`/`TBA` are suppressed.
- **#1345 Trail Log backfill** — new `parseTrailLog` export +
  `scripts/backfill-ih3-history.ts` pull 99 historical rows
  (#999–#1097, 2022-09 → 2025-07) into the existing "IH3 Website Hareline"
  source. Source already SourceKennel-linked to `ih3`; reconcile is safe
  because past-dated events are excluded from cancellation decisions.

Pre-PR loop: `/simplify` (drops `IH3_PLACEHOLDER_VALUE_RE` in favor of
`stripPlaceholder` from `utils.ts`, short-circuits the title `.each` with
`return false`, removes dead `!isNaN(runNumber)` guard, removes pre-sort
duplicated by `reportAndApplyBackfill`). `/codex:adversarial-review` flagged
two tradeoffs which are documented in code comments — neither is a real
blocker (regression risk #1 is codebase-wide existing behavior + strictly
better than the pre-PR baseline; overlap risk #2 is impossible given the
trail-log range #999–#1097 is disjoint from the live hare-line range #1117+).

Closes #1343
Closes #1344
Closes #1345
Closes #1346

## Test plan

- [ ] CI green (`npx tsc --noEmit` + `npm run lint` + `npm test`) — all 6362 tests pass locally.
- [ ] 21/21 IH3 adapter tests pass, including new regressions for #1123 time, #1125 title+cost, label-only-strongs, TBD-suppression, and 6 `parseTrailLog` shape cases.
- [ ] Live-verify of the hare-line adapter against `http://ithacah3.org/hare-line/`:
  ```
  events=7  errors=0
    #1123  2026-05-10  time=12:00  cost=$8 (first timers free)  title=(default fallback)  hares=OTD  loc=Taco Bell, Cayuga Plaza
    #1124  2026-05-24  time=14:00  cost=$7 (first timers free)  title=(default fallback)  hares=Shiggy  loc=TBD
    #1125  2026-05-30  time=12:00  cost=$50                    title=RAINBOW DRESS RUN  hares=Penguin  loc=Liquid State
    #1126  2026-06-07  time=14:00  cost=$7 (first timers free)  title=(default fallback)
    #1127  2026-06-21  time=14:00  cost=$7 (first timers free)  title=(default fallback)
    #1128  2026-07-05  time=14:00  cost=$7 (first timers free)  title=(default fallback)
    #1129  2026-07-19  time=14:00  cost=$7 (first timers free)  title=(default fallback)
  ```
- [ ] Backfill applied twice against local dev DB:
  - pass 1: `created=99 updated=0 skipped=1 blocked=0 eventErrors=0` (skipped is the duplicate `#1083` row that the live page emits twice)
  - pass 2: `created=0 updated=0 skipped=100 blocked=0` — fingerprint dedup idempotency proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)