### PR TITLE
fix(kch3): year anchor + AM/PM defaulting + ~530-event historical backfill

### DIFF
--- a/scripts/backfill-kch3-history.ts
+++ b/scripts/backfill-kch3-history.ts
@@ -1,0 +1,87 @@
+/**
+ * One-shot historical backfill for KCH3 (Kansas City Hash) + sister kennel
+ * PNH3 (Pearl Necklace). Issue #1370.
+ *
+ * `https://kansascityh3.com/` publishes every trail announcement (KCH3 +
+ * PNH3) as a WordPress post. The live `KCH3Adapter` only requests the latest
+ * 10 via `fetchWordPressPosts`; this script walks every WP REST API page via
+ * `?per_page=100&page=N` (~535 total posts, 2018-05 → 2026-05) and ingests
+ * the full archive in one shot.
+ *
+ * Two parser fixes (#1368, #1369) must land before this runs, or every
+ * backfilled row inherits the broken year + AM/PM defaults and the merge
+ * pipeline fingerprints the bad payload:
+ *   - #1368: year-less titles like "28 February" need the WP publish date
+ *     as the chrono refDate, not "today".
+ *   - #1369: bare meetup times like "Meet Up 2:00" must default to PM.
+ *
+ * Both fixes live in `src/adapters/html-scraper/kch3.ts`; this script reuses
+ * `processKCH3Post` directly so the live adapter and the backfill agree on
+ * every parse rule. Kennel routing (KCH3 vs PNH3) is handled by
+ * `resolveKennelTag` based on title text.
+ *
+ * Idempotency + strict partitioning:
+ *   - `reportAndApplyBackfill` filters `date < todayInTimezone("America/Chicago")`
+ *     before insert — the live adapter keeps owning current + upcoming.
+ *   - The merge pipeline dedupes RawEvents by `(sourceId, fingerprint)`.
+ *     A second apply pass is a no-op on every row.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-kch3-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-kch3-history.ts
+ *   Env:      DATABASE_URL
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { processKCH3Post } from "@/adapters/html-scraper/kch3";
+import { fetchAllWordPressPosts } from "@/adapters/wordpress-api";
+import { htmlToNewlineText } from "@/adapters/utils";
+import type { RawEventData } from "@/adapters/types";
+
+const BASE_URL = "https://kansascityh3.com";
+const SOURCE_NAME = "Kansas City H3 Website";
+const KENNEL_TIMEZONE = "America/Chicago";
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log(`Fetching WordPress posts from ${BASE_URL}/wp-json/wp/v2/posts …`);
+  const posts = await fetchAllWordPressPosts(BASE_URL);
+  console.log(`Fetched ${posts.length} total posts.\n`);
+
+  const events: RawEventData[] = [];
+  let unparseable = 0;
+  for (const post of posts) {
+    const bodyText = htmlToNewlineText(post.content);
+    const event = processKCH3Post(post.title, bodyText, post.url, post.date);
+    if (event) {
+      events.push(event);
+    } else {
+      unparseable++;
+    }
+  }
+  console.log(`Parsed ${events.length} events; ${unparseable} posts had no parseable date.`);
+
+  // Per-kennel breakdown — helps confirm the KCH3-vs-PNH3 routing is sane.
+  const tagCounts = new Map<string, number>();
+  for (const e of events) {
+    const tag = e.kennelTags[0];
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  }
+  console.log("Kennel routing:");
+  for (const [tag, count] of [...tagCounts.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${tag}: ${count}`);
+  }
+
+  events.sort((a, b) => a.date.localeCompare(b.date));
+  return events;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "KCH3 WP archive backfill (~535 posts, 2018-05 → 2026-05)",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/kch3.test.ts
+++ b/src/adapters/html-scraper/kch3.test.ts
@@ -38,6 +38,37 @@ describe("parseKCH3Time", () => {
   it("returns default for unparseable string", () => {
     expect(parseKCH3Time("early as you want")).toBe("14:00");
   });
+
+  // ── #1369 — When the source omits the AM/PM marker entirely, default to PM
+  //    (hash convention). Explicit AM tokens are still honored. The
+  //    regression case is "2:00 at: Fox & Hound" — the old regex matched the
+  //    `a` in `at` as the AM marker.
+
+  it("does not treat the `a` in `at` as an AM marker (#1369)", () => {
+    expect(parseKCH3Time("2:00 at: Fox & Hound")).toBe("14:00");
+  });
+
+  it.each([
+    ["2:00", "14:00"],
+    ["5:00", "17:00"],
+    ["6:00", "18:00"],
+    ["12:00", "12:00"], // noon — no PM shift
+  ])("defaults bare %s to PM (#1369)", (input, expected) => {
+    expect(parseKCH3Time(input)).toBe(expected);
+  });
+
+  it("honors an explicit AM marker (sunrise event)", () => {
+    expect(parseKCH3Time("7:00 a.m.")).toBe("07:00");
+  });
+
+  it("honors 12 a.m. as midnight", () => {
+    expect(parseKCH3Time("12 a.m.")).toBe("00:00");
+  });
+
+  it("falls back to default for joke time '1:69' (minutes > 59)", () => {
+    // Real source data: "Meetup: 1:69" appeared in #1874 (April 2025).
+    expect(parseKCH3Time("1:69")).toBe("14:00");
+  });
 });
 
 describe("parseKCH3Body", () => {
@@ -152,6 +183,67 @@ describe("processKCH3Post", () => {
 
     expect(result).not.toBeNull();
     expect(result!.description).toBe("Hash Cash: $5");
+  });
+
+  // ── #1368 — When the title omits the year, anchor on the WordPress post
+  //    publish date so "28 February" posted in 2026 resolves to 2026-02-28,
+  //    not 2027-02-28. The fix passes `post.date` as the chrono refDate.
+
+  it("anchors year-less title to publishDate (28 February → 2026-02-28)", () => {
+    const result = processKCH3Post(
+      "28 February Short, Sunny TAIL Trail",
+      "Meet Up 2:00 at: Fox & Hound",
+      "https://kansascityh3.com/x",
+      "2026-02-28T10:00:00",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-02-28");
+  });
+
+  it("anchors year-less title to publishDate (14 March → 2026-03-14)", () => {
+    const result = processKCH3Post(
+      "14 March Snake Saturday Trail",
+      "Meetup: 8 a.m.",
+      "https://kansascityh3.com/x",
+      "2026-03-11T08:00:00",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-03-14");
+  });
+
+  it("ignores a malformed publishDate and still parses an explicit-year title", () => {
+    // Defensive: an invalid `new Date("garbage")` produces NaN, which chrono
+    // would honor as a reference and drop the parse. Fall back to undefined.
+    const result = processKCH3Post(
+      "21 March 2026 SHHHHHHH Trail",
+      "Meetup: 2 p.m.",
+      "https://kansascityh3.com/x",
+      "not-a-date",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-03-21");
+  });
+
+  it("honors explicit year in title regardless of publishDate", () => {
+    const result = processKCH3Post(
+      "21 March 2026 SHHHHHHH Trail",
+      "Meetup: 2 p.m.",
+      "https://kansascityh3.com/x",
+      "2020-01-01T00:00:00",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2026-03-21");
+  });
+
+  it("integrates with the AM/PM fix: bare 2:00 in body → 14:00 (#1369)", () => {
+    const result = processKCH3Post(
+      "7 March 2026 Trail",
+      "Meet Up 2:00 at: Fox & Hound\nHash Cash $5\nHare PMS",
+      "https://kansascityh3.com/x",
+      "2026-03-04T12:00:00",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.startTime).toBe("14:00");
   });
 });
 

--- a/src/adapters/html-scraper/kch3.test.ts
+++ b/src/adapters/html-scraper/kch3.test.ts
@@ -48,6 +48,13 @@ describe("parseKCH3Time", () => {
     expect(parseKCH3Time("2:00 at: Fox & Hound")).toBe("14:00");
   });
 
+  it("finds an hour token after leading filler text (PR #1382 codex P1)", () => {
+    // parseKCH3Body captures the whole meetup line as time, so "Meetup at
+    // 6 p.m." reaches this function as "at 6 p.m.". Anchoring to `^` would
+    // mis-default it to 14:00.
+    expect(parseKCH3Time("at 6 p.m.")).toBe("18:00");
+  });
+
   it.each([
     ["2:00", "14:00"],
     ["5:00", "17:00"],
@@ -125,7 +132,7 @@ describe("resolveKennelTag", () => {
     expect(resolveKennelTag("14 March Snake Saturday Trail")).toBe("kch3");
   });
 
-  it("returns pnh3 for Pearl Necklace title", () => {
+  it("returns kch3 for a non-PNH3 ladies trail title", () => {
     expect(
       resolveKennelTag("8 February 2026 Ladies Only Olympic Trials Trail"),
     ).toBe("kch3");

--- a/src/adapters/html-scraper/kch3.ts
+++ b/src/adapters/html-scraper/kch3.ts
@@ -15,7 +15,12 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
 import { fetchWordPressPosts } from "../wordpress-api";
-import { applyDateWindow, chronoParseDate, htmlToNewlineText } from "../utils";
+import {
+  applyDateWindow,
+  chronoParseDate,
+  htmlToNewlineText,
+  parsePublishDate,
+} from "../utils";
 
 /** Default start time when the meetup line is missing or unparseable. */
 const DEFAULT_START_TIME = "14:00";
@@ -38,7 +43,11 @@ export function parseKCH3Time(timeStr?: string): string {
   if (!timeStr) return DEFAULT_START_TIME;
   const t = timeStr.trim();
 
-  const hourMatch = /^(\d{1,2})(?::(\d{2}))?/.exec(t);
+  // Find the first hour token anywhere in the string — the meetup-line
+  // capture can include filler text like "at 6 p.m.", "the trail starts at
+  // 2:00", or "2:00 at: Fox & Hound". Anchoring to `^` would mis-fire on
+  // any post that doesn't begin with a digit (codex P1 on PR #1382).
+  const hourMatch = /(\d{1,2})(?::(\d{2}))?/.exec(t);
   if (!hourMatch) return DEFAULT_START_TIME;
   let hours = Number.parseInt(hourMatch[1], 10);
   const minutes = hourMatch[2] ?? "00";
@@ -49,7 +58,7 @@ export function parseKCH3Time(timeStr?: string): string {
 
   // `\b` after `m` / lone `a`/`p` blocks matches like the `a` in `at`
   // (next char is `t` — a word char — so no word boundary).
-  const rest = t.slice(hourMatch[0].length);
+  const rest = t.slice((hourMatch.index ?? 0) + hourMatch[0].length);
   const ampmMatch = /^\s*(a\.m\.?|p\.m\.?|am\b|pm\b|a\b|p\b)/i.exec(rest);
 
   if (ampmMatch) {
@@ -124,14 +133,9 @@ export function processKCH3Post(
   postUrl: string,
   publishDate?: string,
 ): RawEventData | null {
-  // A malformed non-empty publishDate yields `new Date(NaN)`, which chrono
-  // honors as the reference and then drops the parse — silently losing the
-  // event. Fall back to undefined so chrono uses its own default.
-  let refDate: Date | undefined;
-  if (publishDate) {
-    const parsed = new Date(publishDate);
-    if (!Number.isNaN(parsed.getTime())) refDate = parsed;
-  }
+  // `parsePublishDate` returns undefined for missing or malformed input,
+  // sidestepping a silent parse failure when chrono is handed `Date(NaN)`.
+  const refDate = parsePublishDate(publishDate);
   const dateStr = chronoParseDate(titleText, "en-US", refDate);
   if (!dateStr) return null;
 

--- a/src/adapters/html-scraper/kch3.ts
+++ b/src/adapters/html-scraper/kch3.ts
@@ -12,29 +12,53 @@
  * Uses fetchWordPressPosts() from the shared WordPress API utility.
  */
 
-import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
 import { fetchWordPressPosts } from "../wordpress-api";
-import { applyDateWindow, chronoParseDate } from "../utils";
+import { applyDateWindow, chronoParseDate, htmlToNewlineText } from "../utils";
+
+/** Default start time when the meetup line is missing or unparseable. */
+const DEFAULT_START_TIME = "14:00";
 
 /**
  * Parse a time string from KCH3 post body.
- * Formats: "8 a.m.", "2 p.m.", "2:00 p.m.", "12:00p", "2:15pm CST", "12:30"
- * Returns "HH:MM" in 24-hour format, or "14:00" as default.
+ *
+ * Two-step parse so a bare hour like "2:00 at: Fox & Hound" doesn't get the
+ * `a` in `at` interpreted as the AM marker (#1369):
+ *   1. Capture the leading H or H:MM token.
+ *   2. Look for an explicit AM/PM marker immediately adjacent to it.
+ *
+ * When the source omits the AM/PM marker entirely, default to PM (hash
+ * convention — trails are afternoon events). Explicit AM tokens are honored.
+ *
+ * Returns "HH:MM" in 24-hour format, or DEFAULT_START_TIME when no hour is
+ * parseable.
  */
 export function parseKCH3Time(timeStr?: string): string {
-  if (!timeStr) return "14:00";
+  if (!timeStr) return DEFAULT_START_TIME;
+  const t = timeStr.trim();
 
-  const match = /(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s*m?\.?/i.exec(timeStr);
-  if (!match) return "14:00";
+  const hourMatch = /^(\d{1,2})(?::(\d{2}))?/.exec(t);
+  if (!hourMatch) return DEFAULT_START_TIME;
+  let hours = Number.parseInt(hourMatch[1], 10);
+  const minutes = hourMatch[2] ?? "00";
+  if (hours < 0 || hours > 23) return DEFAULT_START_TIME;
+  // KCH3 occasionally posts joke times like "Meetup: 1:69" (#1874).
+  // Reject minutes outside 00–59 so downstream UTC composition stays valid.
+  if (Number.parseInt(minutes, 10) > 59) return DEFAULT_START_TIME;
 
-  let hours = Number.parseInt(match[1], 10);
-  const minutes = match[2] || "00";
-  const ampm = match[3].toLowerCase(); // "a" or "p"
+  // `\b` after `m` / lone `a`/`p` blocks matches like the `a` in `at`
+  // (next char is `t` — a word char — so no word boundary).
+  const rest = t.slice(hourMatch[0].length);
+  const ampmMatch = /^\s*(a\.m\.?|p\.m\.?|am\b|pm\b|a\b|p\b)/i.exec(rest);
 
-  if (ampm === "p" && hours !== 12) hours += 12;
-  if (ampm === "a" && hours === 12) hours = 0;
+  if (ampmMatch) {
+    const ampm = ampmMatch[1][0].toLowerCase();
+    if (ampm === "p" && hours !== 12) hours += 12;
+    if (ampm === "a" && hours === 12) hours = 0;
+  } else if (hours < 12) {
+    hours += 12;
+  }
 
   return `${hours.toString().padStart(2, "0")}:${minutes}`;
 }
@@ -87,31 +111,42 @@ export function resolveKennelTag(title: string): string {
 /**
  * Process a single WordPress post into a RawEventData.
  * Returns null if the post cannot be parsed into a valid event.
+ *
+ * `publishDate` (ISO timestamp from the WordPress REST API) anchors the year
+ * when the title omits it. Without an anchor, chrono `forwardDate` would roll
+ * year-less titles past the current date — "28 February" posted in 2026
+ * resolves to 2027 instead of 2026 (#1368). Anchoring on the post's publish
+ * date lets chrono pick the year nearest to publication.
  */
 export function processKCH3Post(
   titleText: string,
   bodyText: string,
   postUrl: string,
+  publishDate?: string,
 ): RawEventData | null {
-  // Parse date from the title (e.g., "14 March Snake Saturday Trail", "21 March 2026 SHHHHHHH Trail")
-  const dateStr = chronoParseDate(titleText, "en-US", undefined, {
-    forwardDate: true,
-  });
+  // A malformed non-empty publishDate yields `new Date(NaN)`, which chrono
+  // honors as the reference and then drops the parse — silently losing the
+  // event. Fall back to undefined so chrono uses its own default.
+  let refDate: Date | undefined;
+  if (publishDate) {
+    const parsed = new Date(publishDate);
+    if (!Number.isNaN(parsed.getTime())) refDate = parsed;
+  }
+  const dateStr = chronoParseDate(titleText, "en-US", refDate);
   if (!dateStr) return null;
 
   const body = parseKCH3Body(bodyText);
   const startTime = parseKCH3Time(body.time);
   const kennelTag = resolveKennelTag(titleText);
 
-  // Strip date from title to get trail name
-  // Remove leading date patterns: "14 March", "21 March 2026", "28 February"
   const trailName = titleText
     .replace(/^\d{1,2}\s+\w+\s*(?:\d{4}\s*)?/i, "")
     .trim() || titleText;
 
   return {
     date: dateStr,
-    kennelTags: [kennelTag],    title: trailName,
+    kennelTags: [kennelTag],
+    title: trailName,
     hares: body.hares,
     location: body.location,
     startTime,
@@ -135,7 +170,6 @@ export class KCH3Adapter implements SourceAdapter {
     options?: { days?: number },
   ): Promise<ScrapeResult> {
     const baseUrl = source.url || "https://kansascityh3.com/";
-    // Honor source.scrapeDays via options.days (default 365)
     const days = options?.days ?? source.scrapeDays ?? 365;
 
     const wpResult = await fetchWordPressPosts(baseUrl);
@@ -159,12 +193,8 @@ export class KCH3Adapter implements SourceAdapter {
     const events: RawEventData[] = [];
 
     for (const post of wpResult.posts) {
-      const $ = cheerio.load(post.content);
-      // Insert newlines at <br> and <p> boundaries so labeled fields parse correctly
-      $("p, br").before("\n");
-      const bodyText = $.text();
-
-      const event = processKCH3Post(post.title, bodyText, post.url);
+      const bodyText = htmlToNewlineText(post.content);
+      const event = processKCH3Post(post.title, bodyText, post.url, post.date);
       if (event) events.push(event);
     }
 

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -364,6 +364,22 @@ export function stripUrls(text: string): string {
   return text.replaceAll(/https?:\/\/\S+/g, " ");
 }
 
+/**
+ * Render WordPress / WYSIWYG HTML to plain text with `<p>` and `<br>`
+ * boundaries preserved as newlines. Adapters parse labeled fields like
+ * `Hash Cash: $5` on a per-line basis, so without this collapse cheerio's
+ * whitespace coalescing would join all paragraphs into one line and break
+ * the label extraction.
+ *
+ * Used by every adapter that consumes WP post bodies (kch3, ewh3, voodoo-h3
+ * et al.) plus the matching one-shot backfill scripts.
+ */
+export function htmlToNewlineText(html: string): string {
+  const $ = cheerio.load(html);
+  $("p, br").before("\n");
+  return $.text();
+}
+
 export function parse12HourTime(text: string): string | undefined {
   const match = /(\d{1,2}):(\d{2,3})\s*(am|pm)/i.exec(text);
   if (!match) return undefined;

--- a/src/adapters/wordpress-api.ts
+++ b/src/adapters/wordpress-api.ts
@@ -301,6 +301,47 @@ export async function fetchWordPressPosts(
  * Decodes title entities so callers can match against the live adapter's
  * post.title shape without re-decoding.
  */
+interface WordPressBatchItem {
+  title?: { rendered?: string };
+  content?: { rendered?: string };
+  link?: string;
+  date?: string;
+}
+
+function toWordPressPost(item: WordPressBatchItem): WordPressPost {
+  return {
+    title: he.decode(item.title?.rendered ?? ""),
+    content: item.content?.rendered ?? "",
+    url: item.link ?? "",
+    date: item.date ?? "",
+  };
+}
+
+/**
+ * Sanitize a WP REST API JSON page and parse it. Some sites embed literal
+ * control characters inside JSON string values (e.g. Voodoo H3 has raw
+ * newlines inside post bodies) which makes a plain `JSON.parse` throw.
+ * Strips non-whitespace control bytes, escapes whitespace control bytes
+ * only inside string literals, then parses.
+ */
+function parseWordPressBatch(raw: string, page: number): WordPressBatchItem[] {
+  const sanitized = raw
+    .replaceAll(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "")
+    .replaceAll(/"(?:[^"\\]|\\.)*"/g, (match) =>
+      match
+        .replaceAll("\t", String.raw`\t`)
+        .replaceAll("\n", String.raw`\n`)
+        .replaceAll("\r", String.raw`\r`),
+    );
+  const batch: unknown = JSON.parse(sanitized);
+  if (!Array.isArray(batch)) {
+    throw new TypeError(
+      `WordPress paginator page ${page}: expected JSON array, got ${typeof batch}`,
+    );
+  }
+  return batch as WordPressBatchItem[];
+}
+
 export async function fetchAllWordPressPosts(
   siteUrl: string,
   options: { perPage?: number; maxPages?: number } = {},
@@ -336,36 +377,10 @@ export async function fetchAllWordPressPosts(
     if (!response.ok) {
       throw new Error(`WordPress paginator page ${page}: HTTP ${response.status}`);
     }
-    // Some WordPress sites embed literal control characters in JSON string
-    // values (e.g. Voodoo H3 has raw newlines inside post bodies). Use the
-    // same sanitization as `fetchWordPressPosts` so the paginator survives.
-    const raw = await response.text();
-    const sanitized = raw
-      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "")
-      .replace(/"(?:[^"\\]|\\.)*"/g, (match) =>
-        match.replace(/\t/g, "\\t").replace(/\n/g, "\\n").replace(/\r/g, "\\r"),
-      );
-    const batch: unknown = JSON.parse(sanitized);
-    if (!Array.isArray(batch)) {
-      throw new Error(
-        `WordPress paginator page ${page}: expected JSON array, got ${typeof batch}`,
-      );
-    }
+    const batch = parseWordPressBatch(await response.text(), page);
     lastBatchSize = batch.length;
     if (batch.length === 0) return posts;
-    for (const item of batch as Array<{
-      title?: { rendered?: string };
-      content?: { rendered?: string };
-      link?: string;
-      date?: string;
-    }>) {
-      posts.push({
-        title: he.decode(item.title?.rendered ?? ""),
-        content: item.content?.rendered ?? "",
-        url: item.link ?? "",
-        date: item.date ?? "",
-      });
-    }
+    posts.push(...batch.map(toWordPressPost));
     if (batch.length < perPage) return posts;
   }
 

--- a/src/adapters/wordpress-api.ts
+++ b/src/adapters/wordpress-api.ts
@@ -291,3 +291,72 @@ export async function fetchWordPressPosts(
     fetchDurationMs: Date.now() - fetchStart,
   };
 }
+
+/**
+ * Paginated walk of the WordPress REST API. Used by one-shot historical
+ * backfill scripts that need every post on a self-hosted WP site, not just
+ * the latest N. Stops when the API returns 400 (past totalPages) or when
+ * fewer than `perPage` items come back (final page).
+ *
+ * Decodes title entities so callers can match against the live adapter's
+ * post.title shape without re-decoding.
+ */
+export async function fetchAllWordPressPosts(
+  siteUrl: string,
+  options: { perPage?: number; maxPages?: number } = {},
+): Promise<WordPressPost[]> {
+  const perPage = options.perPage ?? 100;
+  const maxPages = options.maxPages ?? 100;
+  const base = siteUrl.replace(/\/+$/, "");
+  const posts: WordPressPost[] = [];
+  let lastBatchSize = 0;
+
+  for (let page = 1; page <= maxPages; page++) {
+    const params = new URLSearchParams({
+      per_page: String(perPage),
+      page: String(page),
+      _fields: "title,content,link,date",
+    });
+    const url = `${base}/wp-json/wp/v2/posts?${params.toString()}`;
+    const response = await fetch(url, {
+      headers: { Accept: "application/json", "User-Agent": WP_USER_AGENT },
+    });
+    if (response.status === 400) return posts; // past totalPages
+    if (!response.ok) {
+      throw new Error(`WordPress paginator page ${page}: HTTP ${response.status}`);
+    }
+    const batch: unknown = await response.json();
+    if (!Array.isArray(batch)) {
+      throw new Error(
+        `WordPress paginator page ${page}: expected JSON array, got ${typeof batch}`,
+      );
+    }
+    lastBatchSize = batch.length;
+    if (batch.length === 0) return posts;
+    for (const item of batch as Array<{
+      title?: { rendered?: string };
+      content?: { rendered?: string };
+      link?: string;
+      date?: string;
+    }>) {
+      posts.push({
+        title: he.decode(item.title?.rendered ?? ""),
+        content: item.content?.rendered ?? "",
+        url: item.link ?? "",
+        date: item.date ?? "",
+      });
+    }
+    if (batch.length < perPage) return posts;
+  }
+
+  // Hit maxPages with a full final batch — more pages exist. Fail loud
+  // rather than silently truncate (would corrupt one-shot backfills).
+  if (lastBatchSize === perPage) {
+    throw new Error(
+      `WordPress paginator exhausted maxPages=${maxPages} with a full ` +
+        `final batch of ${perPage}. Archive may have more posts. ` +
+        `Raise maxPages and re-run.`,
+    );
+  }
+  return posts;
+}

--- a/src/adapters/wordpress-api.ts
+++ b/src/adapters/wordpress-api.ts
@@ -307,7 +307,9 @@ export async function fetchAllWordPressPosts(
 ): Promise<WordPressPost[]> {
   const perPage = options.perPage ?? 100;
   const maxPages = options.maxPages ?? 100;
-  const base = siteUrl.replace(/\/+$/, "");
+  // Procedural trim avoids the Sonar S5852 ReDoS hotspot that `/\/+$/` trips.
+  let base = siteUrl;
+  while (base.endsWith("/")) base = base.slice(0, -1);
   const posts: WordPressPost[] = [];
   let lastBatchSize = 0;
 
@@ -321,11 +323,29 @@ export async function fetchAllWordPressPosts(
     const response = await fetch(url, {
       headers: { Accept: "application/json", "User-Agent": WP_USER_AGENT },
     });
-    if (response.status === 400) return posts; // past totalPages
+    if (response.status === 400) {
+      if (page === 1) {
+        // First-page 400 means bad URL / bad perPage, not "past last page".
+        // Returning [] would silently mask that as an empty archive.
+        throw new Error(
+          `WordPress paginator failed on first page: HTTP 400 from ${url}. Check siteUrl or perPage.`,
+        );
+      }
+      return posts;
+    }
     if (!response.ok) {
       throw new Error(`WordPress paginator page ${page}: HTTP ${response.status}`);
     }
-    const batch: unknown = await response.json();
+    // Some WordPress sites embed literal control characters in JSON string
+    // values (e.g. Voodoo H3 has raw newlines inside post bodies). Use the
+    // same sanitization as `fetchWordPressPosts` so the paginator survives.
+    const raw = await response.text();
+    const sanitized = raw
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "")
+      .replace(/"(?:[^"\\]|\\.)*"/g, (match) =>
+        match.replace(/\t/g, "\\t").replace(/\n/g, "\\n").replace(/\r/g, "\\r"),
+      );
+    const batch: unknown = JSON.parse(sanitized);
     if (!Array.isArray(batch)) {
       throw new Error(
         `WordPress paginator page ${page}: expected JSON array, got ${typeof batch}`,


### PR DESCRIPTION
## Summary

Resolves three concurrent bugs in the KCH3 (Kansas City Hash) cluster and ingests the full ~535-post archive in one shot.

- **#1369** — `parseKCH3Time` parsed `"Meet Up 2:00 at: Fox & Hound"` as **2 AM** because the regex `[ap]\.?\s*m?\.?` matched the `a` in `at`. Rewritten as a two-step parse with bounded AM/PM tokens. Bare times like `2:00` now default to **PM** (hash convention).
- **#1368** — `processKCH3Post` passed no `refDate` to chrono with `forwardDate: true`, so year-less titles like `"28 February"` rolled forward to 2027. Now anchors on the WordPress post-publish date returned by the REST API. Invalid date strings safely fall back to `undefined`.
- **#1370** — New `scripts/backfill-kch3-history.ts` paginates the full WP archive and reuses `processKCH3Post` end-to-end. Lifted two shared helpers along the way (`fetchAllWordPressPosts`, `htmlToNewlineText`) — both immediately replace duplicated logic in the live adapter.

## Live-verify output (post-fix)

```
Events: 10  Errors: 0  Range: 2026-02-21 → 2026-05-02

Bug repro spot-checks:
  2026-02-28 14:00 [kch3] "Short, Sunny TAIL Trail"   → Meadowbrook Park 9101 Nall Ave in Prairie Village
  2026-03-07 14:00 [kch3] "Trail"                     → (was 02:00 AM, now 14:00)
  2026-03-14 08:00 [kch3] "Snake Saturday Trail"      → Macken Park (8 AM is the explicit source value)
```

Before this PR these three rows showed as `Sun, Feb 28 2027`, `Sat, Mar 7 02:00`, and `Sun, Mar 14 2027`.

## Backfill results

```
Fetched 535 total posts.
Parsed 526 events; 9 posts had no parseable date.
Kennel routing:
  kch3: 521
  pnh3: 5

Partition: 526 past rows, 0 skipped (date >= 2026-05-11)
Date range: 2017-07-18 → 2026-05-02

Pass 1: created=521 skipped=5  (carryover from earlier failed run + 1 fixed row)
Pass 2: created=0   skipped=526  ← idempotency proven
```

Per-kennel canonical Event count after backfill: **KCH3 = 522 events**, **PNH3 = 6 events**.

## Test plan

- [x] `npm test` — 6364 passed (1 new vs main)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] Live-verified against `kansascityh3.com` — all 3 bug-repro events resolve correctly
- [x] Backfill applied twice; second pass `created=0 updated=0 skipped=526 blocked=0`
- [x] `/simplify` review applied (shared helpers lifted)
- [x] `/codex:adversarial-review` applied (publishDate NaN guard + paginator cap-detection added)

## Known follow-up (not in this PR)

The pre-existing #1368 bug left **3 ghost canonical events** dated 2027 (`2027-02-07 Cold Break Trail`, `2027-02-28 Short, Sunny TAIL Trail`, `2027-03-14 Snake Saturday Trail`). The fresh RawEvents under the fixed parser correctly produce 2026-dated canonical Events, but the old 2027 rows are no longer reachable from any RawEvent fingerprint. Cleanup requires deleting 3 prod canonical-event rows — out of scope here, would benefit from explicit user approval.

Closes #1368
Closes #1369
Closes #1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)