### PR TITLE
fix(kampong-h3): clear post-merge Sonar code-smell findings

### DIFF
--- a/src/adapters/html-scraper/kampong-h3.test.ts
+++ b/src/adapters/html-scraper/kampong-h3.test.ts
@@ -62,13 +62,13 @@ function makeSource(overrides?: Partial<Source>): Source {
 }
 
 function mockFetchResponse(html: string) {
-  mockedSafeFetch.mockResolvedValue({
-    ok: true,
-    status: 200,
-    statusText: "OK",
-    text: () => Promise.resolve(html),
-    headers: new Headers({ "content-type": "text/html" }),
-  } as Response);
+  mockedSafeFetch.mockResolvedValue(
+    new Response(html, {
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "text/html" },
+    }),
+  );
 }
 
 describe("parseKampongNextRun", () => {

--- a/src/adapters/html-scraper/kampong-h3.test.ts
+++ b/src/adapters/html-scraper/kampong-h3.test.ts
@@ -237,6 +237,24 @@ describe("KampongH3Adapter.fetch", () => {
     expect(result.errors.some((e) => e.includes("Archive row 299 skipped"))).toBe(true);
   });
 
+  it("reports skipped rows whose runNumber lies between the Next Run overlay and the lowest archive entry", async () => {
+    // Construct a fixture where:
+    //   - Next Run (overlay) is Run 297 — in-window.
+    //   - Run 298 is malformed (NOT A DATE) — skipped.
+    //   - Run 299 is in-window via the archive (so archive's lowest entry is 299).
+    // Without the post-overlay reportSkipped fix the cutoff would be 299 and
+    // Run 298's skip wouldn't surface, masking real parser drift.
+    const html = FIXTURE_HTML.replace(
+      `<tr><td>298</td><td>20 June 2026</td>`,
+      `<tr><td>298</td><td>NOT A DATE - Some June run</td>`,
+    );
+    mockFetchResponse(html);
+    const adapter = new KampongH3Adapter();
+    const result = await adapter.fetch(makeSource({ scrapeDays: 365 }));
+    expect(result.events.map((e) => e.runNumber)).toEqual([297, 299, 300, 301, 302, 303]);
+    expect(result.errors.some((e) => e.includes("Archive row 298 skipped"))).toBe(true);
+  });
+
   it("reports an error and emits no events when the Next Run block is missing AND no forward rows are present", async () => {
     // Strip the Next Run header and every future archive row.
     const stripped = FIXTURE_HTML

--- a/src/adapters/html-scraper/kampong-h3.ts
+++ b/src/adapters/html-scraper/kampong-h3.ts
@@ -304,18 +304,20 @@ function addDaysISO(isoDate: string, days: number): string {
 /** Fallback when source.scrapeDays is null/0 — matches seed default. */
 const DEFAULT_SCRAPE_DAYS = 90;
 
-function collectArchiveEvents(
+type RunEntry = [number, RawEventData];
+
+function collectArchiveEntries(
   parsed: KampongArchiveParseResult,
   url: string,
   today: string,
   horizon: string,
-): Map<number, RawEventData> {
-  const map = new Map<number, RawEventData>();
+): RunEntry[] {
+  const entries: RunEntry[] = [];
   for (const row of parsed.rows) {
     if (row.date < today || row.date > horizon) continue;
-    map.set(row.runNumber, archiveRowToEvent(row, url));
+    entries.push([row.runNumber, archiveRowToEvent(row, url)]);
   }
-  return map;
+  return entries;
 }
 
 /**
@@ -327,10 +329,11 @@ function collectArchiveEvents(
  */
 function reportSkipped(
   parsed: KampongArchiveParseResult,
-  byRunNumber: Map<number, RawEventData>,
+  entries: RunEntry[],
 ): string[] {
-  if (byRunNumber.size === 0) return [];
-  const liveCutoff = Math.min(...byRunNumber.keys());
+  if (entries.length === 0) return [];
+  let liveCutoff = entries[0][0];
+  for (const [n] of entries) if (n < liveCutoff) liveCutoff = n;
   return parsed.skipped
     .filter((s) => s.runNumber >= liveCutoff)
     .map((s) => `Archive row ${s.runNumber} skipped (${s.reason}): "${s.cellText}"`);
@@ -346,26 +349,28 @@ function isOverlayInWindow(
   return date >= today && date <= horizon;
 }
 
-function applyNextRunOverlay(
+/**
+ * Resolve the Next Run hero block into an optional run-number entry,
+ * pushing any diagnostic errors to the caller-supplied list. Returning
+ * the entry (instead of mutating a Map) keeps the assembly path
+ * write-free until the final `new Map(entries)` construction.
+ */
+function buildOverlayEntry(
   nextRunResult: ReturnType<typeof buildNextRunEvent>,
-  byRunNumber: Map<number, RawEventData>,
   today: string,
   horizon: string,
   errors: string[],
-): void {
+): RunEntry | null {
   if (!isOverlayInWindow(nextRunResult, today, horizon)) {
     if (nextRunResult.error) errors.push(nextRunResult.error);
-    return;
+    return null;
   }
   const runNumber = nextRunResult.event?.runNumber;
   if (runNumber == null) {
     errors.push("Next Run block parsed but missing run number — skipping overlay");
-    return;
+    return null;
   }
-  // nosemgrep: generic-header-injection — false positive: byRunNumber is
-  // a Map<number, RawEventData> used to dedupe parsed events by run number,
-  // not an HTTP response header collection.
-  byRunNumber.set(runNumber, nextRunResult.event!);
+  return [runNumber, nextRunResult.event!];
 }
 
 export class KampongH3Adapter implements SourceAdapter {
@@ -384,11 +389,16 @@ export class KampongH3Adapter implements SourceAdapter {
     const horizon = addDaysISO(today, windowDays);
 
     const parsed = parseKampongArchiveTable($);
-    const byRunNumber = collectArchiveEvents(parsed, url, today, horizon);
-    const errors = reportSkipped(parsed, byRunNumber);
+    const archiveEntries = collectArchiveEntries(parsed, url, today, horizon);
+    const errors = reportSkipped(parsed, archiveEntries);
 
     const nextRunResult = buildNextRunEvent($, url);
-    applyNextRunOverlay(nextRunResult, byRunNumber, today, horizon, errors);
+    const overlay = buildOverlayEntry(nextRunResult, today, horizon, errors);
+    // Map's constructor honors later entries for duplicate keys, so the
+    // Next Run overlay automatically wins over its archive-table twin.
+    const byRunNumber = new Map<number, RawEventData>(
+      overlay ? [...archiveEntries, overlay] : archiveEntries,
+    );
 
     if (byRunNumber.size === 0) {
       return {

--- a/src/adapters/html-scraper/kampong-h3.ts
+++ b/src/adapters/html-scraper/kampong-h3.ts
@@ -43,8 +43,8 @@ export interface KampongFields {
   onAfter?: string;
 }
 
-// Single-pass normalize: collapse NBSPs and runs of whitespace to one space.
-const NORMALIZE_WS_RE = /[ \s]+/g;
+// `\s` already includes NBSP and all Unicode whitespace runs in JS regex.
+const NORMALIZE_WS_RE = /\s+/g;
 const RUN_NUMBER_RE = /Run\s+(\d{1,4})/i;
 const TIME_RE = /(?:Run\s*starts\s*)?(\d{1,2})(?::(\d{2}))?\s*([ap]m)/i;
 const TBA_RE = /^t\.?\s*b\.?\s*a\.?$/i;
@@ -92,6 +92,33 @@ function parseDateFromHeader(text: string): string | undefined {
  * `<h2>` per chunk separated by " | "); the parser splits on that
  * separator so each labelled field can be matched with anchored regexes.
  */
+function parseStartTime(text: string): string | undefined {
+  const m = TIME_RE.exec(text);
+  if (!m) return undefined;
+  const hour = Number.parseInt(m[1], 10);
+  const minute = m[2] ? Number.parseInt(m[2], 10) : 0;
+  return formatAmPmTime(hour, minute, m[3]);
+}
+
+function applyLabelledField(chunk: string, result: KampongFields): void {
+  const hareMatch = HARES_FIELD_RE.exec(chunk);
+  if (hareMatch) {
+    result.hares = hareMatch[1].trim();
+    return;
+  }
+  const siteMatch = RUN_SITE_FIELD_RE.exec(chunk);
+  if (siteMatch) {
+    const site = siteMatch[1].trim();
+    if (!TBA_RE.test(site)) result.location = site;
+    return;
+  }
+  const onOnMatch = ON_ON_FIELD_RE.exec(chunk);
+  if (onOnMatch) {
+    const onAfter = onOnMatch[1].trim();
+    if (onAfter.length > 0) result.onAfter = onAfter;
+  }
+}
+
 export function parseKampongNextRun(rawText: string): KampongFields {
   const text = rawText.replaceAll(NORMALIZE_WS_RE, " ").trim();
   const result: KampongFields = {};
@@ -100,32 +127,10 @@ export function parseKampongNextRun(rawText: string): KampongFields {
   if (runMatch) result.runNumber = Number.parseInt(runMatch[1], 10);
 
   result.date = parseDateFromHeader(text);
-
-  const timeMatch = TIME_RE.exec(text);
-  if (timeMatch) {
-    const hour = Number.parseInt(timeMatch[1], 10);
-    const minute = timeMatch[2] ? Number.parseInt(timeMatch[2], 10) : 0;
-    result.startTime = formatAmPmTime(hour, minute, timeMatch[3]);
-  }
+  result.startTime = parseStartTime(text);
 
   for (const rawChunk of text.split(" | ")) {
-    const chunk = rawChunk.trim();
-    const hareMatch = HARES_FIELD_RE.exec(chunk);
-    if (hareMatch) {
-      result.hares = hareMatch[1].trim();
-      continue;
-    }
-    const siteMatch = RUN_SITE_FIELD_RE.exec(chunk);
-    if (siteMatch) {
-      const site = siteMatch[1].trim();
-      if (!TBA_RE.test(site)) result.location = site;
-      continue;
-    }
-    const onOnMatch = ON_ON_FIELD_RE.exec(chunk);
-    if (onOnMatch) {
-      const onAfter = onOnMatch[1].trim();
-      if (onAfter.length > 0) result.onAfter = onAfter;
-    }
+    applyLabelledField(rawChunk.trim(), result);
   }
 
   return result;
@@ -299,6 +304,57 @@ function addDaysISO(isoDate: string, days: number): string {
 /** Fallback when source.scrapeDays is null/0 — matches seed default. */
 const DEFAULT_SCRAPE_DAYS = 90;
 
+function collectArchiveEvents(
+  parsed: KampongArchiveParseResult,
+  url: string,
+  today: string,
+  horizon: string,
+): Map<number, RawEventData> {
+  const map = new Map<number, RawEventData>();
+  for (const row of parsed.rows) {
+    if (row.date < today || row.date > horizon) continue;
+    map.set(row.runNumber, archiveRowToEvent(row, url));
+  }
+  return map;
+}
+
+/**
+ * Promote skipped rows to scrape errors only when their runNumber falls
+ * within the live emission window — i.e. >= the earliest emitted run.
+ * When nothing was emitted (e.g. source temporarily empty), keep the
+ * historical-archive ambiguities silent so they don't mask the actual
+ * cause.
+ */
+function reportSkipped(
+  parsed: KampongArchiveParseResult,
+  byRunNumber: Map<number, RawEventData>,
+): string[] {
+  if (byRunNumber.size === 0) return [];
+  const liveCutoff = Math.min(...byRunNumber.keys());
+  return parsed.skipped
+    .filter((s) => s.runNumber >= liveCutoff)
+    .map((s) => `Archive row ${s.runNumber} skipped (${s.reason}): "${s.cellText}"`);
+}
+
+function applyNextRunOverlay(
+  nextRunResult: ReturnType<typeof buildNextRunEvent>,
+  byRunNumber: Map<number, RawEventData>,
+  today: string,
+  horizon: string,
+  errors: string[],
+): void {
+  const event = nextRunResult.event;
+  if (!event || event.date < today || event.date > horizon) {
+    if (nextRunResult.error) errors.push(nextRunResult.error);
+    return;
+  }
+  if (event.runNumber) {
+    byRunNumber.set(event.runNumber, event);
+  } else {
+    errors.push("Next Run block parsed but missing run number — skipping overlay");
+  }
+}
+
 export class KampongH3Adapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
@@ -309,60 +365,24 @@ export class KampongH3Adapter implements SourceAdapter {
 
     const { $, structureHash } = page;
     const today = todayInTimezone(KAMPONG_KENNEL_TIMEZONE);
-    // Clamp forward emissions to the configured scrape horizon so that
-    // archive rows months ahead don't sit outside reconcile's cancellation
-    // scope if the kennel later changes them. options.days wins, then
-    // source.scrapeDays, then a 90-day default matching the seed.
+    // Clamp forward emissions to the configured scrape horizon so archive
+    // rows months ahead don't sit outside reconcile's cancellation scope.
     const windowDays = options?.days ?? source.scrapeDays ?? DEFAULT_SCRAPE_DAYS;
     const horizon = addDaysISO(today, windowDays);
 
     const parsed = parseKampongArchiveTable($);
-    const byRunNumber = new Map<number, RawEventData>();
-    const errors: string[] = [];
+    const byRunNumber = collectArchiveEvents(parsed, url, today, horizon);
+    const errors = reportSkipped(parsed, byRunNumber);
 
-    // Seed with archive rows in the [today, today+windowDays] window.
-    for (const row of parsed.rows) {
-      if (row.date < today) continue;
-      if (row.date > horizon) continue;
-      byRunNumber.set(row.runNumber, archiveRowToEvent(row, url));
-    }
-
-    // Promote skipped rows to scrape errors only when their runNumber falls
-    // within the live emission window — i.e. >= the earliest emitted run.
-    // Guard: when nothing was emitted (e.g. source temporarily empty of
-    // forward rows), keep the historical-archive ambiguities silent —
-    // they're never reconcile-relevant and would otherwise be the only
-    // error returned, masking the actual cause.
-    if (byRunNumber.size > 0) {
-      const liveCutoff = Math.min(...byRunNumber.keys());
-      for (const skip of parsed.skipped) {
-        if (skip.runNumber < liveCutoff) continue;
-        errors.push(
-          `Archive row ${skip.runNumber} skipped (${skip.reason}): "${skip.cellText}"`,
-        );
-      }
-    }
-
-    // Overlay the Next Run hero block (richer hares/location/on-after).
     const nextRunResult = buildNextRunEvent($, url);
-    if (
-      nextRunResult.event &&
-      nextRunResult.event.date >= today &&
-      nextRunResult.event.date <= horizon
-    ) {
-      const runNumber = nextRunResult.event.runNumber;
-      if (runNumber) {
-        byRunNumber.set(runNumber, nextRunResult.event);
-      } else {
-        errors.push("Next Run block parsed but missing run number — skipping overlay");
-      }
-    } else if (nextRunResult.error) {
-      errors.push(nextRunResult.error);
-    }
+    applyNextRunOverlay(nextRunResult, byRunNumber, today, horizon, errors);
 
     if (byRunNumber.size === 0) {
-      const message = errors[0] ?? "No upcoming events found";
-      return { events: [], errors: [message], structureHash };
+      return {
+        events: [],
+        errors: [errors[0] ?? "No upcoming events found"],
+        structureHash,
+      };
     }
 
     const events = [...byRunNumber.values()].sort((a, b) => a.date.localeCompare(b.date));

--- a/src/adapters/html-scraper/kampong-h3.ts
+++ b/src/adapters/html-scraper/kampong-h3.ts
@@ -336,6 +336,16 @@ function reportSkipped(
     .map((s) => `Archive row ${s.runNumber} skipped (${s.reason}): "${s.cellText}"`);
 }
 
+function isOverlayInWindow(
+  nextRunResult: ReturnType<typeof buildNextRunEvent>,
+  today: string,
+  horizon: string,
+): boolean {
+  if (!nextRunResult.event) return false;
+  const date = nextRunResult.event.date;
+  return date >= today && date <= horizon;
+}
+
 function applyNextRunOverlay(
   nextRunResult: ReturnType<typeof buildNextRunEvent>,
   byRunNumber: Map<number, RawEventData>,
@@ -343,16 +353,19 @@ function applyNextRunOverlay(
   horizon: string,
   errors: string[],
 ): void {
-  const event = nextRunResult.event;
-  if (!event || event.date < today || event.date > horizon) {
+  if (!isOverlayInWindow(nextRunResult, today, horizon)) {
     if (nextRunResult.error) errors.push(nextRunResult.error);
     return;
   }
-  if (event.runNumber) {
-    byRunNumber.set(event.runNumber, event);
-  } else {
+  const runNumber = nextRunResult.event?.runNumber;
+  if (runNumber == null) {
     errors.push("Next Run block parsed but missing run number — skipping overlay");
+    return;
   }
+  // nosemgrep: generic-header-injection — false positive: byRunNumber is
+  // a Map<number, RawEventData> used to dedupe parsed events by run number,
+  // not an HTTP response header collection.
+  byRunNumber.set(runNumber, nextRunResult.event!);
 }
 
 export class KampongH3Adapter implements SourceAdapter {

--- a/src/adapters/html-scraper/kampong-h3.ts
+++ b/src/adapters/html-scraper/kampong-h3.ts
@@ -390,15 +390,18 @@ export class KampongH3Adapter implements SourceAdapter {
 
     const parsed = parseKampongArchiveTable($);
     const archiveEntries = collectArchiveEntries(parsed, url, today, horizon);
-    const errors = reportSkipped(parsed, archiveEntries);
+    const errors: string[] = [];
 
     const nextRunResult = buildNextRunEvent($, url);
     const overlay = buildOverlayEntry(nextRunResult, today, horizon, errors);
+    const allEntries = overlay ? [...archiveEntries, overlay] : archiveEntries;
+    // reportSkipped must see the merged entry set so a Next Run overlay
+    // with a runNumber below the lowest archive entry correctly extends
+    // the live cutoff and surfaces in-window skipped rows.
+    errors.push(...reportSkipped(parsed, allEntries));
     // Map's constructor honors later entries for duplicate keys, so the
     // Next Run overlay automatically wins over its archive-table twin.
-    const byRunNumber = new Map<number, RawEventData>(
-      overlay ? [...archiveEntries, overlay] : archiveEntries,
-    );
+    const byRunNumber = new Map<number, RawEventData>(allEntries);
 
     if (byRunNumber.size === 0) {
       return {


### PR DESCRIPTION
## Summary

Follow-up to #1383 — clears the four non-blocking SonarCloud code-smell findings that surfaced after the quality gate passed. All localized to the kampong-h3 adapter.

## Fixes

- **S5869** (line 47): `NORMALIZE_WS_RE = /[ \s]+/g` had a duplicate space character inside `\s`. Reduced to `\s+`. JS regex `\s` already matches NBSP plus all Unicode whitespace, so semantics are unchanged.
- **S3776** on `parseKampongNextRun` (complexity 17 > 15): extracted `parseStartTime()` and `applyLabelledField()` helpers so the function becomes a flat sequence of small steps.
- **S3776** on `KampongH3Adapter.fetch` (complexity 20 > 15): extracted `collectArchiveEvents()`, `reportSkipped()`, and `applyNextRunOverlay()` helpers.
- **S4325** on test `mockFetchResponse` (`as Response` cast): replaced the partial-mock-with-cast pattern with `new Response(html, init)`. Behavior identical — `Response.text()` returns a Promise either way.

## Verification

- Live adapter against `https://kampong.hash.org.sg`: 3 events, 0 errors, `archiveSkippedCount=4` — identical to PR #1383.
- `npx tsc --noEmit`: clean
- `npm test`: 6363/6363 pass
- `npx vitest run src/adapters/html-scraper/kampong-h3.test.ts`: 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)