### PR TITLE
fix(seed): defuse Hockessin seasonal-schedule time-bomb

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1075,10 +1075,8 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "hockessin", shortName: "Hockessin H3", fullName: "Hockessin Hash House Harriers", region: "Wilmington, DE",
       website: "https://www.hockessinhash.org/",
       logoUrl: "https://www.hockessinhash.org/logo.GIF",
-      // Seasonal split: Wednesdays 6:30 PM summer, Saturdays 3 PM winter. Schema has one cadence slot;
-      // picking summer (current season). Manual flip needed each Nov/Mar until schema supports both.
-      scheduleDayOfWeek: "Wednesday", scheduleFrequency: "Weekly", scheduleTime: "6:30 PM",
-      scheduleNotes: "Wednesdays 6:30 PM (summer); Saturdays 3 PM (winter). Runs in DE/MD/PA/NJ.",
+      scheduleFrequency: "Weekly",
+      scheduleNotes: "Wednesdays 6:30 PM (summer, ~Mar–Oct); Saturdays 3 PM (winter, ~Nov–Feb). Runs in DE/MD/PA/NJ.",
       hashCash: "$5",
       description: "Delaware's most active hash with 1,656+ trails across the tri-state area.",
       latitude: 39.78, longitude: -75.68,

--- a/scripts/fix-kennel-data-hockessin-2026-05.ts
+++ b/scripts/fix-kennel-data-hockessin-2026-05.ts
@@ -1,0 +1,57 @@
+/**
+ * One-shot data correction for Hockessin H3 (hockessin) schedule fields.
+ *
+ * The seed previously hardcoded summer cadence (Wednesday 6:30 PM) with a
+ * comment requiring a manual flip each Nov/Mar to winter cadence (Saturday
+ * 3 PM). That's a documented time-bomb — kennel directory shows the wrong
+ * day/time for half the year unless someone remembers to patch and reseed.
+ *
+ * Hockessin's source page only has free-text "Saturdays in winter, Wednesdays
+ * in summer" with no machine-readable indicator, so we can't pick at runtime.
+ * Fix: null out scheduleDayOfWeek + scheduleTime and document both cadences
+ * in scheduleNotes. The seed change won't clear existing values in prod
+ * (fill-if-null semantics), so this script does it.
+ *
+ * Run after the PR merges:
+ *   npx tsx scripts/fix-kennel-data-hockessin-2026-05.ts
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const pool = createScriptPool();
+const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+async function main() {
+  const updated = await prisma.kennel.update({
+    where: { kennelCode: "hockessin" },
+    data: {
+      scheduleDayOfWeek: null,
+      scheduleTime: null,
+      scheduleNotes:
+        "Wednesdays 6:30 PM (summer, ~Mar–Oct); Saturdays 3 PM (winter, ~Nov–Feb). Runs in DE/MD/PA/NJ.",
+    },
+    select: {
+      kennelCode: true,
+      scheduleDayOfWeek: true,
+      scheduleTime: true,
+      scheduleFrequency: true,
+      scheduleNotes: true,
+    },
+  });
+  console.log("Updated Hockessin H3:", updated);
+}
+
+async function run() {
+  try {
+    await main();
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await Promise.allSettled([prisma.$disconnect(), pool.end()]);
+  }
+}
+
+void run();


### PR DESCRIPTION
## Summary

- Remove hardcoded summer cadence (`scheduleDayOfWeek: "Wednesday"`, `scheduleTime: "6:30 PM"`) from the Hockessin H3 seed entry — both seasonal cadences now live in `scheduleNotes` as free text.
- Add `scripts/fix-kennel-data-hockessin-2026-05.ts` to null the existing prod values (seed merge is fill-if-null and won't overwrite them).

## Why

Codex adversarial review on PR #1387 flagged the Hockessin entry as a documented time-bomb: the schema only has one cadence slot, the seed picked summer, and a comment required manual flips each Nov/Mar to winter. Without intervention, the kennel directory shows the wrong day/time for ~half the year.

[hockessinhash.org](https://www.hockessinhash.org/) only carries free text — *"Saturdays in winter, Wednesdays in summer"* — with no machine-readable indicator, so the scraper can't pick a cadence at runtime. The cleanest fix is to leave both slots null and document both cadences in `scheduleNotes`.

## What changed

- [`prisma/seed-data/kennels.ts:1077-1079`](prisma/seed-data/kennels.ts) — drop `scheduleDayOfWeek` + `scheduleTime`, rewrite `scheduleNotes` to cover both cadences with month ranges.
- [`scripts/fix-kennel-data-hockessin-2026-05.ts`](scripts/fix-kennel-data-hockessin-2026-05.ts) — one-shot `prisma.kennel.update` to NULL the prod values + sync the updated note. Follows the `fix-kennel-data-*-2026-*.ts` template.

## Reviewer notes

- This is unrelated to PR #1387 (merge.ts perf work) — surfaced during the adversarial review on that PR but lives in its own change.
- Run the one-shot script after merge: `npx tsx scripts/fix-kennel-data-hockessin-2026-05.ts`
- No schema migration needed; the schema already allows null on both fields.

## Test plan

- [x] `npm run lint` clean (warnings only, none related)
- [ ] Visual: after script runs, Hockessin kennel page should show `scheduleNotes` text instead of "Wednesdays 6:30 PM"
- [ ] Verify seed is idempotent — re-running won't repopulate the dropped fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)