### PR TITLE
fix(kennels): point Houston H3 at canonical FB group

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1258,7 +1258,9 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "h4-tx", shortName: "Houston H3", fullName: "Houston Hash House Harriers", region: "Houston, TX",
       website: "https://h4.org",
       logoUrl: "/kennel-logos/h4-tx.jpg",
-      facebookUrl: "https://www.facebook.com/groups/HoustonHash/",
+      // Canonical FB group per h4.org header/footer (numeric-id group, not the
+      // older vanity-handle `groups/HoustonHash/` — see #1389).
+      facebookUrl: "https://www.facebook.com/groups/567061830081997",
       mailingListUrl: "https://groups.io/g/h4/join",
       foundedYear: 1979,
       scheduleDayOfWeek: "Sunday", scheduleTime: "3:00 PM", scheduleFrequency: "Weekly",


### PR DESCRIPTION
## Summary

Houston H3 (`h4-tx`) has two distinct, both-live Facebook group URLs in the wild:

| URL | Status |
|---|---|
| `https://www.facebook.com/groups/HoustonHash/` | HTTP 200 — current seed value (older vanity handle) |
| `https://www.facebook.com/groups/567061830081997` | HTTP 200 — linked from `h4.org` header/footer (the kennel's own canonical website) |

The kennel's own site links **only** the numeric-id group (verified: `curl https://h4.org/ | grep facebook.com/groups/` returns exactly `facebook.com/groups/567061830081997`). The vanity-handle group is nowhere on h4.org. Flipping the seed sends hashers to the group the kennel itself considers canonical.

## Notes

- Seed merge is fill-only on profile fields (see `prisma/seed.ts:299-303`), so prod rows with the existing non-null URL **won't** be updated by re-seeding alone — a manual prod `UPDATE` will be needed post-merge, per #1389's acceptance criterion #2.
- Verified locally by nulling `h4-tx.facebookUrl`, re-running `npx prisma db seed`, and confirming the new URL fills in:
  ```
   h4-tx | https://www.facebook.com/groups/567061830081997
  ```
- The change touches only the `Kennel.facebookUrl` display field — the scrape pipeline reads `Source → SourceKennel → Kennel.id` and never reads this field, so no scraping behavior is affected.

Closes #1389

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings unrelated)
- [x] `npm test` — 243 test files / 6421 tests pass
- [x] Re-seed local DB and confirm new URL backfills onto null row
- [x] `git diff` is the single-line URL change + comment, nothing else
- [ ] Post-merge: prod `UPDATE "Kennel" SET "facebookUrl" = 'https://www.facebook.com/groups/567061830081997' WHERE "kennelCode" = 'h4-tx';`

🤖 Generated with [Claude Code](https://claude.com/claude-code)