### PR TITLE
fix(ih3): reset title fill-rate baseline (#1385)

### DIFF
--- a/scripts/reset-ih3-title-baseline.ts
+++ b/scripts/reset-ih3-title-baseline.ts
@@ -1,0 +1,76 @@
+/**
+ * One-shot: set `Source.baselineResetAt = NOW()` on "IH3 Website Hareline" to
+ * resolve the FIELD_FILL_DROP title alert (#1385).
+ *
+ * PR #1379 intentionally dropped the unconditional `title: "IH3 #N"` placeholder
+ * so that `merge.ts` synthesizes `"Ithaca H3 Trail #N"` via `friendlyKennelName`.
+ * After deploy, only 1 of 7 events carries a published source title (e.g.
+ * `"RAINBOW DRESS RUN"`), and `fill-rates.ts` — which measures
+ * `RawEventData.title` *before* merge — drops to 14%. User-visible `Event.title`
+ * is unaffected.
+ *
+ * This is a textbook `baselineResetAt` case (see `prisma/schema.prisma:205-210`
+ * and `src/pipeline/health.ts:397-399`). Setting the boundary to NOW cuts the
+ * rolling baseline so the next scrape sees no prior rows in window and the
+ * FIELD_FILL_DROP comparison short-circuits. The baseline then re-accumulates
+ * around the honest post-#1379 rate.
+ *
+ * Usage:
+ *   npx tsx scripts/reset-ih3-title-baseline.ts           # dry run (default)
+ *   npx tsx scripts/reset-ih3-title-baseline.ts --apply   # apply against prod
+ *
+ * Load env before running (tsx does not auto-load .env):
+ *   set -a && source .env && set +a
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const dryRun = !process.argv.includes("--apply");
+const SOURCE_NAME = "IH3 Website Hareline";
+
+async function main() {
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  try {
+    console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
+
+    const source = await prisma.source.findFirst({
+      where: { name: SOURCE_NAME, type: "HTML_SCRAPER" },
+      select: { id: true, name: true, url: true, baselineResetAt: true },
+    });
+
+    if (!source) {
+      console.error(`❌ Source "${SOURCE_NAME}" not found.`);
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(`Source: ${source.name} (${source.id})`);
+    console.log(`  URL: ${source.url}`);
+    console.log(`  Current baselineResetAt: ${source.baselineResetAt?.toISOString() ?? "null"}`);
+
+    if (dryRun) {
+      console.log("\n(dry run) re-run with --apply to set baselineResetAt = NOW().");
+      return;
+    }
+
+    const now = new Date();
+    await prisma.source.update({
+      where: { id: source.id },
+      data: { baselineResetAt: now },
+    });
+    console.log(`\n✅ Set baselineResetAt = ${now.toISOString()} on "${SOURCE_NAME}".`);
+    console.log("   Alert #1385 will auto-resolve at the next scheduled scrape.");
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/reset-ih3-title-baseline.ts
+++ b/scripts/reset-ih3-title-baseline.ts
@@ -24,22 +24,23 @@
  */
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
+import { PrismaClient, SourceType } from "@/generated/prisma/client";
 import { createScriptPool } from "./lib/db-pool";
 
 const dryRun = !process.argv.includes("--apply");
 const SOURCE_NAME = "IH3 Website Hareline";
 
 async function main() {
-  const pool = createScriptPool();
-  const adapter = new PrismaPg(pool);
-  const prisma = new PrismaClient({ adapter } as never);
-
+  let pool: ReturnType<typeof createScriptPool> | undefined;
   try {
+    pool = createScriptPool();
+    const adapter = new PrismaPg(pool);
+    const prisma = new PrismaClient({ adapter });
+
     console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
 
-    const source = await prisma.source.findFirst({
-      where: { name: SOURCE_NAME, type: "HTML_SCRAPER" },
+    const source = await prisma.source.findUnique({
+      where: { name_type: { name: SOURCE_NAME, type: SourceType.HTML_SCRAPER } },
       select: { id: true, name: true, url: true, baselineResetAt: true },
     });
 
@@ -66,7 +67,7 @@ async function main() {
     console.log(`\n✅ Set baselineResetAt = ${now.toISOString()} on "${SOURCE_NAME}".`);
     console.log("   Alert #1385 will auto-resolve at the next scheduled scrape.");
   } finally {
-    await pool.end();
+    await pool?.end();
   }
 }
 


### PR DESCRIPTION
## Summary

Resolves the FIELD_FILL_DROP title alert for IH3 Website Hareline by setting `Source.baselineResetAt = NOW()` via a one-shot script.

## Root cause

[#1379](https://github.com/johnrclem/hashtracks-web/pull/1379) (cycle-5 WS2) intentionally dropped the unconditional `title: \`IH3 #${runNumber}\`` placeholder so `merge.ts` synthesizes \"Ithaca H3 Trail #N\" via `friendlyKennelName` downstream. Live verify from that PR: 1 of 7 events carries a published source title (\"RAINBOW DRESS RUN\") — the rest let merge synthesize. **User-visible `Event.title` is fine.**

But `src/pipeline/fill-rates.ts:16-30` runs on `RawEventData` *before* merge ([`src/pipeline/scrape.ts:417`](https://github.com/johnrclem/hashtracks-web/blob/main/src/pipeline/scrape.ts#L417)), and `e.title` counts `undefined` as not-filled. So the metric drops from 100% → 14% (= 1/7), tripping FIELD_FILL_DROP. The metric is right at the layer it measures; the layer is just below the synthesis.

## Fix: baselineResetAt, not adapter changes

[`prisma/schema.prisma:205-210`](https://github.com/johnrclem/hashtracks-web/blob/main/prisma/schema.prisma#L205) documents `baselineResetAt` verbatim for this case: *\"Set after a code-led adapter improvement so stale baselines don't fire false FIELD_FILL_DROP / EVENT_COUNT_ANOMALY alerts.\"* [`src/pipeline/health.ts:397-399`](https://github.com/johnrclem/hashtracks-web/blob/main/src/pipeline/health.ts#L397) honors it (`startedAt: { gte: baselineResetAt }`). One row update, alert auto-resolves at next scrape.

### Why not fix-forward the adapter?

My first plan was to emit `title: \"Ithaca H3 Trail #N\"` from the adapter as a fallback. `/codex:adversarial-review` flagged two load-bearing problems:

1. **Permanently blinds the metric.** `computeFillRates` runs on raw adapter output. Stuffing presentation defaults into `RawEventData.title` would report 100% even when the upstream source *stops publishing titles entirely* — a real regression we'd want to catch.
2. **Forces fingerprint churn.** `title` is in `generateFingerprint`. The change would create a one-time re-merge wave for every existing IH3 RawEvent — write-volume cost for zero product gain when the documented escape hatch exists.

The reviewer was right. Adapter semantics stay intentional; honest raw data preserved.

## Operational steps

After this PR merges:

```bash
set -a && source .env && set +a
BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/reset-ih3-title-baseline.ts            # dry run
BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/reset-ih3-title-baseline.ts --apply    # apply
```

Dry-run verified against prod from worktree:

```
🔍 DRY RUN — no changes will be made

Source: IH3 Website Hareline (cmmr1yd7d001bfcm9q37b61l1)
  URL: http://ithacah3.org/hare-line/
  Current baselineResetAt: null

(dry run) re-run with --apply to set baselineResetAt = NOW().
```

`sourceId` matches the alert AGENT_CONTEXT.

Closes #1385

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (19 pre-existing warnings unrelated)
- [x] `npm test` — 6421 passed / 7 skipped / 250 files
- [x] Dry-run against prod resolves the IH3 source by name and reports current `baselineResetAt: null`
- [ ] After merge: run with `--apply`, observe alert auto-resolution on next IH3 scrape

🤖 Generated with [Claude Code](https://claude.com/claude-code)