### PR TITLE
Disable dead MiHi-HuHa Facebook hosted events source (#1391)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -5014,6 +5014,9 @@ export const SOURCES = [
       name: "MiHi-HuHa Facebook Hosted Events",
       url: "https://www.facebook.com/MileHighH3/upcoming_hosted_events",
       type: "FACEBOOK_HOSTED_EVENTS" as const,
+      // FB page exposes zero events; kennel's About text directs users to
+      // coloradoh3.com + private FB group. GCal is the canonical feed. (#1391)
+      enabled: false,
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,


### PR DESCRIPTION
## Summary

- Disable the `MiHi-HuHa Facebook Hosted Events` source in seed (`enabled: false`); the FB page exposes zero events and the kennel explicitly redirects users to coloradoh3.com + a private FB group.
- Investigation confirms all 13 upcoming events on `/kennels/mihihuha` come from the GCal feed (`huhahareraiser@gmail.com`), not the FB source. The FB adapter is fine; the page is just empty.

## Investigation (#1391)

Read-only prod query joining `Event` → `RawEvent` → `Source` for `kennelId = mihi-huha, date >= today`:

| source                            | type            | distinct events | raw rows |
|-----------------------------------|-----------------|-----------------|----------|
| Mile High Humpin Hash Calendar    | GOOGLE_CALENDAR | 13              | 32       |
| MiHi-HuHa Facebook Hosted Events  | FACEBOOK_HOSTED_EVENTS | 0     | 0        |

The "stub-looking" cards in the audit screenshot are real GCal content the kennel publishes verbatim (title `Mile High Humpin' Hash`, description `Visit https://m.facebook.com/MileHighH3/ for trail details.`). Not an adapter bug.

## Prod flip (manual, after merge)

Seed doesn't auto-run in Vercel build. To stop the dead source from being scraped immediately, run:

```sql
UPDATE "Source"
SET enabled = false
WHERE id = 'cmoxaqg0c001k5ehnq2179phl'; -- MiHi-HuHa Facebook Hosted Events
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` (no new errors; pre-existing warnings only)
- [x] `npm test` — 6421 passing
- [ ] After merge: run prod `UPDATE` above

Closes #1391

🤖 Generated with [Claude Code](https://claude.com/claude-code)