### PR TITLE
feat(schedule): extend ScheduleRule with seasonal/multi-cadence fields (#1390 plumbing)

### DIFF
--- a/prisma/migrations/20260515015524_add_schedule_rule_seasonal_fields/migration.sql
+++ b/prisma/migrations/20260515015524_add_schedule_rule_seasonal_fields/migration.sql
@@ -1,0 +1,19 @@
+-- Add multi-cadence display fields to ScheduleRule (#1390).
+--
+-- ScheduleRule becomes the authoritative multi-slot store for both Travel Mode
+-- projection and kennel-page display. `label` is a human cadence tag ("Summer",
+-- "Winter", "Full Moon Special"). `validFrom` / `validUntil` use MM-DD anchors
+-- because seasonality wraps across years (e.g. "11-01" to "02-28" = winter).
+-- `displayOrder` controls render order when a kennel has ≥2 active rules.
+--
+-- All three text columns are nullable; `displayOrder` defaults to 0. The change
+-- is purely additive — no existing rows need backfilling because the legacy
+-- flat-field path on `Kennel` (scheduleDayOfWeek + scheduleTime + scheduleFrequency)
+-- remains the fallback when a kennel has zero ScheduleRule rows or zero rules
+-- with label/validFrom/validUntil set.
+
+ALTER TABLE "ScheduleRule"
+  ADD COLUMN "label"        TEXT,
+  ADD COLUMN "validFrom"    TEXT,
+  ADD COLUMN "validUntil"   TEXT,
+  ADD COLUMN "displayOrder" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1106,6 +1106,12 @@ model ScheduleRule {
   lastValidatedAt DateTime? // When the rule was last confirmed still accurate (drives confidence decay)
   notes           String? // Free text context, e.g. "Phase alignment unknown"
   isActive        Boolean            @default(true)
+  // Multi-cadence display fields (#1390). Authoritative for kennel-page rendering
+  // when ≥1 rule exists; legacy flat fields on Kennel are the fallback otherwise.
+  label           String? // Human label for the cadence: "Summer", "Winter", "Full Moon Special"
+  validFrom       String? // "MM-DD" anchor (e.g. "03-01") for seasonal start. Wraps across years.
+  validUntil      String? // "MM-DD" anchor (e.g. "10-31") for seasonal end.
+  displayOrder    Int                @default(0) // Render order when a kennel has ≥2 active rules
   kennel          Kennel             @relation(fields: [kennelId], references: [id])
   createdAt       DateTime           @default(now())
   updatedAt       DateTime           @updatedAt

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -8,9 +8,13 @@
  *
  * MM-DD anchors on validFrom/validUntil wrap across years — "11-01" → "02-28" is
  * the wintertime cadence. Omit a rule for a hiatus period (don't encode hiatus
- * negatively). All fields except `rrule` are optional; the same RRULE shapes the
- * static-schedule adapter parses are accepted (FREQ=WEEKLY|MONTHLY, BYDAY with
- * optional nth prefix, INTERVAL, BYMONTH, FREQ=LUNAR sentinel).
+ * negatively). All fields except `rrule` are optional; only the calendar-rule
+ * RRULE shapes the static-schedule adapter parses are accepted here
+ * (FREQ=WEEKLY|MONTHLY, BYDAY with optional nth prefix, INTERVAL, BYMONTH).
+ * Lunar cadences (`FREQ=LUNAR`) require phase + timezone metadata not
+ * representable on this contract — declare those via `Source.config.lunar` on
+ * a STATIC_SCHEDULE source row instead. Pass 3 rejects `FREQ=LUNAR` with a
+ * clear warning so the mismatch is visible at backfill time.
  */
 export interface KennelScheduleRuleSeed {
   rrule: string;             // e.g. "FREQ=WEEKLY;BYDAY=WE", "FREQ=MONTHLY;BYDAY=1SA"

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1,3 +1,28 @@
+/**
+ * One structured schedule slot for a kennel — primary input to ScheduleRule rows.
+ *
+ * Use this for kennels with multi-cadence schedules (Hockessin: Wed/summer ↔
+ * Sat/winter; KCH3: Sat + Wed-summer + Full-Moon-winter; Hogtown: biweekly Sat +
+ * monthly Thu + monthly Fri) where the single legacy schedule slot on Kennel
+ * silently misrepresents reality.
+ *
+ * MM-DD anchors on validFrom/validUntil wrap across years — "11-01" → "02-28" is
+ * the wintertime cadence. Omit a rule for a hiatus period (don't encode hiatus
+ * negatively). All fields except `rrule` are optional; the same RRULE shapes the
+ * static-schedule adapter parses are accepted (FREQ=WEEKLY|MONTHLY, BYDAY with
+ * optional nth prefix, INTERVAL, BYMONTH, FREQ=LUNAR sentinel).
+ */
+export interface KennelScheduleRuleSeed {
+  rrule: string;             // e.g. "FREQ=WEEKLY;BYDAY=WE", "FREQ=MONTHLY;BYDAY=1SA"
+  startTime?: string;        // "HH:MM" 24h
+  label?: string;            // "Summer", "Winter", "Full Moon Special"
+  validFrom?: string;        // "MM-DD"
+  validUntil?: string;       // "MM-DD"
+  displayOrder?: number;     // Render order on kennel page; default 0
+  anchorDate?: string;       // YYYY-MM-DD, for INTERVAL > 1 stability
+  notes?: string;
+}
+
 export interface KennelSeed {
   kennelCode: string;
   shortName: string;
@@ -10,6 +35,10 @@ export interface KennelSeed {
   scheduleTime?: string;
   scheduleFrequency?: string;
   scheduleNotes?: string;
+  // Multi-cadence schedule slots (#1390). When set, these are authoritative for
+  // kennel-page display + Travel Mode projection; the flat scheduleDay/Time/Frequency
+  // fields above remain for legacy kennels that haven't been migrated.
+  scheduleRules?: KennelScheduleRuleSeed[];
   hashCash?: string;
   facebookUrl?: string;
   instagramHandle?: string;

--- a/scripts/backfill-schedule-rules.test.ts
+++ b/scripts/backfill-schedule-rules.test.ts
@@ -788,52 +788,52 @@ describe("runKennelDisplayPass — Pass 3 opt-out", () => {
 // include `lastValidatedAt` in UPDATE for STATIC_SCHEDULE rules (where the
 // scrape's lastSuccessAt IS the validation moment). Lock the contract here.
 
-describe("applyUpserts — lastValidatedAt update semantics", () => {
-  function makePlanned(overrides: {
-    source: "STATIC_SCHEDULE" | "SEED_DATA";
-    lastValidatedAt: Date | null;
-  }) {
-    return {
-      kennelId: "k_x",
-      kennelDisplay: "X",
-      rrule: "FREQ=WEEKLY;BYDAY=SA",
-      anchorDate: null,
-      startTime: null,
-      confidence: "HIGH" as const,
-      source: overrides.source,
-      sourceReference: null,
-      lastValidatedAt: overrides.lastValidatedAt,
-      notes: null,
-      label: null,
-      validFrom: null,
-      validUntil: null,
-      displayOrder: 0,
-    };
-  }
+function makePlannedRuleForUpsert(overrides: {
+  source: "STATIC_SCHEDULE" | "SEED_DATA";
+  lastValidatedAt: Date | null;
+}) {
+  return {
+    kennelId: "k_x",
+    kennelDisplay: "X",
+    rrule: "FREQ=WEEKLY;BYDAY=SA",
+    anchorDate: null,
+    startTime: null,
+    confidence: "HIGH" as const,
+    source: overrides.source,
+    sourceReference: null,
+    lastValidatedAt: overrides.lastValidatedAt,
+    notes: null,
+    label: null,
+    validFrom: null,
+    validUntil: null,
+    displayOrder: 0,
+  };
+}
 
-  function makeSpyingPrisma() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const upsertCalls: any[] = [];
-    return {
-      prisma: {
-        scheduleRule: {
-          findMany: async () => [],
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          upsert: async (args: any) => {
-            upsertCalls.push(args);
-            return { id: `id_${upsertCalls.length}` };
-          },
+function makeSpyingPrismaForUpsert() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const upsertCalls: any[] = [];
+  return {
+    prisma: {
+      scheduleRule: {
+        findMany: async () => [],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        upsert: async (args: any) => {
+          upsertCalls.push(args);
+          return { id: `id_${upsertCalls.length}` };
         },
-      } as unknown as Parameters<typeof applyUpserts>[0],
-      upsertCalls,
-    };
-  }
+      },
+    } as unknown as Parameters<typeof applyUpserts>[0],
+    upsertCalls,
+  };
+}
 
+describe("applyUpserts — lastValidatedAt update semantics", () => {
   it("INCLUDES lastValidatedAt in update clause for STATIC_SCHEDULE rules", async () => {
-    const { prisma, upsertCalls } = makeSpyingPrisma();
+    const { prisma, upsertCalls } = makeSpyingPrismaForUpsert();
     const validatedAt = new Date("2026-05-01T00:00:00Z");
     await applyUpserts(prisma, [
-      makePlanned({ source: "STATIC_SCHEDULE", lastValidatedAt: validatedAt }),
+      makePlannedRuleForUpsert({ source: "STATIC_SCHEDULE", lastValidatedAt: validatedAt }),
     ]);
     expect(upsertCalls).toHaveLength(1);
     expect(upsertCalls[0].update).toHaveProperty("lastValidatedAt", validatedAt);
@@ -842,9 +842,9 @@ describe("applyUpserts — lastValidatedAt update semantics", () => {
   });
 
   it("EXCLUDES lastValidatedAt from update clause for SEED_DATA rules (preserves admin timestamps)", async () => {
-    const { prisma, upsertCalls } = makeSpyingPrisma();
+    const { prisma, upsertCalls } = makeSpyingPrismaForUpsert();
     await applyUpserts(prisma, [
-      makePlanned({ source: "SEED_DATA", lastValidatedAt: new Date() }),
+      makePlannedRuleForUpsert({ source: "SEED_DATA", lastValidatedAt: new Date() }),
     ]);
     expect(upsertCalls).toHaveLength(1);
     expect(upsertCalls[0].update).not.toHaveProperty("lastValidatedAt");

--- a/scripts/backfill-schedule-rules.test.ts
+++ b/scripts/backfill-schedule-rules.test.ts
@@ -4,7 +4,10 @@ import {
   parseFrequencyDay,
   normalizeRRule,
   runStaticSchedulePass,
+  runKennelSeedPass,
+  runKennelDisplayPass,
 } from "./backfill-schedule-rules";
+import type { KennelScheduleRuleSeed } from "../prisma/seed-data/kennels";
 
 describe("parseScheduleTime", () => {
   it("parses PM times to 24-hour", () => {
@@ -445,5 +448,330 @@ describe("runStaticSchedulePass — lunar branch", () => {
       anchorDate: "2026-03-07",
       confidence: "HIGH",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runKennelSeedPass — Pass 3, multi-cadence seed rules (#1390)
+// ---------------------------------------------------------------------------
+
+interface FakeKennelRow {
+  id: string;
+  kennelCode: string;
+  shortName: string;
+}
+
+/**
+ * Minimal prisma stub for Pass 3 — only `kennel.findMany` is exercised. Returns
+ * rows whose kennelCode is in the `where.kennelCode.in` clause.
+ */
+function fakePrismaForSeed(kennels: FakeKennelRow[]) {
+  return {
+    kennel: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findMany: async (args: any) => {
+        const codes: string[] = args?.where?.kennelCode?.in ?? [];
+        return kennels.filter((k) => codes.includes(k.kennelCode));
+      },
+    },
+  } as unknown as Parameters<typeof runKennelSeedPass>[0];
+}
+
+describe("runKennelSeedPass", () => {
+  it("emits one HIGH-confidence rule per scheduleRules entry, threading label/validFrom/validUntil/displayOrder", async () => {
+    const planned: Parameters<typeof runKennelSeedPass>[1] = [];
+    const prisma = fakePrismaForSeed([
+      { id: "k_hockessin", kennelCode: "hockessin", shortName: "Hockessin H3" },
+    ]);
+    const seeds = [
+      {
+        kennelCode: "hockessin",
+        scheduleRules: [
+          {
+            rrule: "FREQ=WEEKLY;BYDAY=WE",
+            startTime: "18:30",
+            label: "Summer",
+            validFrom: "03-01",
+            validUntil: "10-31",
+            displayOrder: 0,
+          },
+          {
+            rrule: "FREQ=WEEKLY;BYDAY=SA",
+            startTime: "15:00",
+            label: "Winter",
+            validFrom: "11-01",
+            validUntil: "02-28",
+            displayOrder: 1,
+          },
+        ] satisfies KennelScheduleRuleSeed[],
+      },
+    ];
+    const result = await runKennelSeedPass(prisma, planned, {}, seeds);
+    expect(result.count).toBe(2);
+    expect(result.skippedKennels).toBe(0);
+    expect(result.skippedRules).toBe(0);
+
+    expect(planned).toHaveLength(2);
+    expect(planned[0]).toMatchObject({
+      kennelId: "k_hockessin",
+      rrule: "FREQ=WEEKLY;BYDAY=WE",
+      startTime: "18:30",
+      confidence: "HIGH",
+      source: "SEED_DATA",
+      sourceReference: "KennelSeed.scheduleRules[hockessin]",
+      label: "Summer",
+      validFrom: "03-01",
+      validUntil: "10-31",
+      displayOrder: 0,
+    });
+    expect(planned[0].lastValidatedAt).toBeInstanceOf(Date);
+    expect(planned[1]).toMatchObject({
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      label: "Winter",
+      validFrom: "11-01",
+      validUntil: "02-28",
+      displayOrder: 1,
+    });
+  });
+
+  it("emits one rule per Hebe-style single-slot seed (no seasonality metadata)", async () => {
+    const planned: Parameters<typeof runKennelSeedPass>[1] = [];
+    const prisma = fakePrismaForSeed([
+      { id: "k_hebe", kennelCode: "hebe-h3", shortName: "Hebe H3" },
+    ]);
+    const seeds = [
+      {
+        kennelCode: "hebe-h3",
+        scheduleRules: [
+          { rrule: "FREQ=MONTHLY;BYDAY=1SA", startTime: "15:00", label: "Monthly" },
+        ] satisfies KennelScheduleRuleSeed[],
+      },
+    ];
+    await runKennelSeedPass(prisma, planned, {}, seeds);
+    expect(planned).toHaveLength(1);
+    expect(planned[0]).toMatchObject({
+      rrule: "FREQ=MONTHLY;BYDAY=1SA",
+      confidence: "HIGH",
+      source: "SEED_DATA",
+      label: "Monthly",
+      validFrom: null,
+      validUntil: null,
+      displayOrder: 0,
+    });
+  });
+
+  it("drops malformed MM-DD anchors with a warning instead of writing garbage", async () => {
+    const planned: Parameters<typeof runKennelSeedPass>[1] = [];
+    const prisma = fakePrismaForSeed([
+      { id: "k_x", kennelCode: "x", shortName: "X" },
+    ]);
+    const seeds = [
+      {
+        kennelCode: "x",
+        scheduleRules: [
+          {
+            rrule: "FREQ=WEEKLY;BYDAY=MO",
+            // Invalid: month 13 (validates against 1-12 and last-day-of-month).
+            validFrom: "13-01",
+            validUntil: "02-30",
+          },
+        ] satisfies KennelScheduleRuleSeed[],
+      },
+    ];
+    await runKennelSeedPass(prisma, planned, {}, seeds);
+    expect(planned).toHaveLength(1);
+    expect(planned[0].validFrom).toBeNull();
+    expect(planned[0].validUntil).toBeNull();
+  });
+
+  it("accepts Feb 29 (leap-year-aware date validation)", async () => {
+    const planned: Parameters<typeof runKennelSeedPass>[1] = [];
+    const prisma = fakePrismaForSeed([
+      { id: "k_x", kennelCode: "x", shortName: "X" },
+    ]);
+    const seeds = [
+      {
+        kennelCode: "x",
+        scheduleRules: [
+          { rrule: "FREQ=WEEKLY;BYDAY=SA", validUntil: "02-29" },
+        ] satisfies KennelScheduleRuleSeed[],
+      },
+    ];
+    await runKennelSeedPass(prisma, planned, {}, seeds);
+    expect(planned[0].validUntil).toBe("02-29");
+  });
+
+  it("skips kennels missing from the DB (e.g. hidden / deleted) without crashing", async () => {
+    const planned: Parameters<typeof runKennelSeedPass>[1] = [];
+    const prisma = fakePrismaForSeed([]); // empty DB
+    const seeds = [
+      {
+        kennelCode: "ghost",
+        scheduleRules: [{ rrule: "FREQ=WEEKLY;BYDAY=SA" }] satisfies KennelScheduleRuleSeed[],
+      },
+    ];
+    const result = await runKennelSeedPass(prisma, planned, {}, seeds);
+    expect(planned).toHaveLength(0);
+    expect(result.skippedKennels).toBe(1);
+  });
+
+  it("skips rule entries with empty rrule (defensive guard against seed typos)", async () => {
+    const planned: Parameters<typeof runKennelSeedPass>[1] = [];
+    const prisma = fakePrismaForSeed([
+      { id: "k_y", kennelCode: "y", shortName: "Y" },
+    ]);
+    const seeds = [
+      {
+        kennelCode: "y",
+        scheduleRules: [
+          { rrule: "" },
+          { rrule: "   " },
+          { rrule: "FREQ=WEEKLY;BYDAY=SU" },
+        ] satisfies KennelScheduleRuleSeed[],
+      },
+    ];
+    const result = await runKennelSeedPass(prisma, planned, {}, seeds);
+    expect(result.count).toBe(1);
+    expect(result.skippedRules).toBe(2);
+    expect(planned[0].rrule).toBe("FREQ=WEEKLY;BYDAY=SU");
+  });
+
+  it("skips rule entries whose RRULE doesn't parse (fail-loud on malformed seed input)", async () => {
+    const planned: Parameters<typeof runKennelSeedPass>[1] = [];
+    const prisma = fakePrismaForSeed([
+      { id: "k_z", kennelCode: "z", shortName: "Z" },
+    ]);
+    const seeds = [
+      {
+        kennelCode: "z",
+        scheduleRules: [
+          { rrule: "FREQ=YEARLY" }, // unsupported FREQ — parseRRule throws
+          { rrule: "FREQ=WEEKLY" }, // WEEKLY without BYDAY — parseRRule throws
+          { rrule: "FREQ=WEEKLY;BYDAY=SA" }, // valid
+        ] satisfies KennelScheduleRuleSeed[],
+      },
+    ];
+    const result = await runKennelSeedPass(prisma, planned, {}, seeds);
+    expect(result.count).toBe(1);
+    expect(result.skippedRules).toBe(2);
+    expect(planned[0].rrule).toBe("FREQ=WEEKLY;BYDAY=SA");
+  });
+
+  it("returns immediately when no kennel carries scheduleRules (isolation from passes 1 + 2)", async () => {
+    const planned: Parameters<typeof runKennelSeedPass>[1] = [];
+    // Seed pre-populated with a Pass 1-shaped rule to confirm Pass 3 leaves
+    // existing planned entries untouched when there's nothing to add.
+    planned.push({
+      kennelId: "k_other",
+      kennelDisplay: "OTHER",
+      rrule: "FREQ=WEEKLY;BYDAY=MO",
+      anchorDate: null,
+      startTime: null,
+      confidence: "HIGH",
+      source: "STATIC_SCHEDULE",
+      sourceReference: "http://x",
+      lastValidatedAt: null,
+      notes: null,
+      label: null,
+      validFrom: null,
+      validUntil: null,
+      displayOrder: 0,
+    });
+    const prisma = fakePrismaForSeed([]);
+    const result = await runKennelSeedPass(prisma, planned, {}, []);
+    expect(result).toEqual({ count: 0, skippedKennels: 0, skippedRules: 0 });
+    expect(planned).toHaveLength(1); // unchanged
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runKennelDisplayPass — Pass 2 opt-out for kennels that declare scheduleRules
+// ---------------------------------------------------------------------------
+
+interface FakeKennelDisplayRow {
+  id: string;
+  kennelCode: string;
+  shortName: string;
+  scheduleDayOfWeek: string | null;
+  scheduleTime: string | null;
+  scheduleFrequency: string | null;
+  scheduleNotes: string | null;
+}
+
+function fakePrismaForDisplay(kennels: FakeKennelDisplayRow[]) {
+  return {
+    kennel: {
+      findMany: async () => kennels,
+    },
+  } as unknown as Parameters<typeof runKennelDisplayPass>[0];
+}
+
+describe("runKennelDisplayPass — Pass 3 opt-out", () => {
+  const FAKE_KENNELS: FakeKennelDisplayRow[] = [
+    {
+      id: "k_legacy",
+      kennelCode: "legacy",
+      shortName: "Legacy",
+      scheduleDayOfWeek: "Saturday",
+      scheduleTime: "3:00 PM",
+      scheduleFrequency: "Weekly",
+      scheduleNotes: null,
+    },
+    {
+      id: "k_migrated",
+      kennelCode: "migrated",
+      shortName: "Migrated",
+      scheduleDayOfWeek: "Saturday",
+      scheduleTime: "3:00 PM",
+      scheduleFrequency: "Weekly",
+      scheduleNotes: null,
+    },
+  ];
+
+  it.each<{
+    label: string;
+    seeds: Array<{ kennelCode: string; scheduleRules?: KennelScheduleRuleSeed[] }>;
+    expectedCount: number;
+    expectedOptedOut: number;
+    expectedKennelIds: string[];
+  }>([
+    {
+      label: "skips kennels whose seed declares non-empty scheduleRules",
+      seeds: [
+        { kennelCode: "legacy" },
+        { kennelCode: "migrated", scheduleRules: [{ rrule: "FREQ=WEEKLY;BYDAY=SA" }] },
+      ],
+      expectedCount: 1,
+      expectedOptedOut: 1,
+      expectedKennelIds: ["k_legacy"],
+    },
+    {
+      label: "does NOT opt out when scheduleRules is an empty array",
+      seeds: [
+        { kennelCode: "legacy", scheduleRules: [] },
+        { kennelCode: "migrated" },
+      ],
+      expectedCount: 2,
+      expectedOptedOut: 0,
+      expectedKennelIds: ["k_legacy", "k_migrated"],
+    },
+    {
+      label: "processes all kennels when no seed list is provided (empty injection)",
+      seeds: [],
+      expectedCount: 2,
+      expectedOptedOut: 0,
+      expectedKennelIds: ["k_legacy", "k_migrated"],
+    },
+  ])("$label", async ({ seeds, expectedCount, expectedOptedOut, expectedKennelIds }) => {
+    const planned: Parameters<typeof runKennelDisplayPass>[1] = [];
+    const result = await runKennelDisplayPass(
+      fakePrismaForDisplay(FAKE_KENNELS),
+      planned,
+      {},
+      seeds,
+    );
+    expect(result.count).toBe(expectedCount);
+    expect(result.optedOut).toBe(expectedOptedOut);
+    expect(planned.map((p) => p.kennelId)).toEqual(expectedKennelIds);
   });
 });

--- a/scripts/backfill-schedule-rules.test.ts
+++ b/scripts/backfill-schedule-rules.test.ts
@@ -6,6 +6,7 @@ import {
   runStaticSchedulePass,
   runKennelSeedPass,
   runKennelDisplayPass,
+  applyUpserts,
 } from "./backfill-schedule-rules";
 import type { KennelScheduleRuleSeed } from "../prisma/seed-data/kennels";
 
@@ -773,5 +774,81 @@ describe("runKennelDisplayPass — Pass 3 opt-out", () => {
     expect(result.count).toBe(expectedCount);
     expect(result.optedOut).toBe(expectedOptedOut);
     expect(planned.map((p) => p.kennelId)).toEqual(expectedKennelIds);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyUpserts — lastValidatedAt is bumped for STATIC_SCHEDULE only
+// ---------------------------------------------------------------------------
+//
+// Codex P2 + Gemini + Claude review on PR #1405 flagged that the original
+// applyUpserts UPDATE clause unconditionally included `lastValidatedAt`, which
+// meant every backfill re-run overwrote admin-set timestamps and Pass 3's
+// "first seed-validation moment" with `new Date()` or null. The fix: only
+// include `lastValidatedAt` in UPDATE for STATIC_SCHEDULE rules (where the
+// scrape's lastSuccessAt IS the validation moment). Lock the contract here.
+
+describe("applyUpserts — lastValidatedAt update semantics", () => {
+  function makePlanned(overrides: {
+    source: "STATIC_SCHEDULE" | "SEED_DATA";
+    lastValidatedAt: Date | null;
+  }) {
+    return {
+      kennelId: "k_x",
+      kennelDisplay: "X",
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      anchorDate: null,
+      startTime: null,
+      confidence: "HIGH" as const,
+      source: overrides.source,
+      sourceReference: null,
+      lastValidatedAt: overrides.lastValidatedAt,
+      notes: null,
+      label: null,
+      validFrom: null,
+      validUntil: null,
+      displayOrder: 0,
+    };
+  }
+
+  function makeSpyingPrisma() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const upsertCalls: any[] = [];
+    return {
+      prisma: {
+        scheduleRule: {
+          findMany: async () => [],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          upsert: async (args: any) => {
+            upsertCalls.push(args);
+            return { id: `id_${upsertCalls.length}` };
+          },
+        },
+      } as unknown as Parameters<typeof applyUpserts>[0],
+      upsertCalls,
+    };
+  }
+
+  it("INCLUDES lastValidatedAt in update clause for STATIC_SCHEDULE rules", async () => {
+    const { prisma, upsertCalls } = makeSpyingPrisma();
+    const validatedAt = new Date("2026-05-01T00:00:00Z");
+    await applyUpserts(prisma, [
+      makePlanned({ source: "STATIC_SCHEDULE", lastValidatedAt: validatedAt }),
+    ]);
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].update).toHaveProperty("lastValidatedAt", validatedAt);
+    // Create always carries it
+    expect(upsertCalls[0].create.lastValidatedAt).toEqual(validatedAt);
+  });
+
+  it("EXCLUDES lastValidatedAt from update clause for SEED_DATA rules (preserves admin timestamps)", async () => {
+    const { prisma, upsertCalls } = makeSpyingPrisma();
+    await applyUpserts(prisma, [
+      makePlanned({ source: "SEED_DATA", lastValidatedAt: new Date() }),
+    ]);
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].update).not.toHaveProperty("lastValidatedAt");
+    // Create always carries it — first-seen moment is recorded.
+    expect(upsertCalls[0].create).toHaveProperty("lastValidatedAt");
   });
 });

--- a/scripts/backfill-schedule-rules.test.ts
+++ b/scripts/backfill-schedule-rules.test.ts
@@ -670,7 +670,7 @@ describe("runKennelSeedPass", () => {
       startTime: null,
       confidence: "HIGH",
       source: "STATIC_SCHEDULE",
-      sourceReference: "http://x",
+      sourceReference: "https://example.test/x",
       lastValidatedAt: null,
       notes: null,
       label: null,

--- a/scripts/backfill-schedule-rules.ts
+++ b/scripts/backfill-schedule-rules.ts
@@ -90,10 +90,15 @@ const DAY_MAP: Record<string, string> = {
  * compilation removes both the scanner warning and per-iteration cost.
  * Inputs are hardcoded English day names — there's no untrusted text in
  * the regex source — but the precompiled form documents that intent.
+ *
+ * SonarCloud S2631 (dynamic regex injection) is a false positive here: the
+ * `name` interpolated into the pattern is keyed off the module-scope DAY_MAP
+ * literal — fully static, no user input ever reaches this construction.
  */
 const DAY_REGEXES: ReadonlyArray<{ token: string; re: RegExp }> = Object.entries(
   DAY_MAP,
-).map(([name, token]) => ({ token, re: new RegExp(String.raw`\b${name}\b`, "i") }));
+  // NOSONAR S2631 — inputs are hardcoded DAY_MAP keys, no injection surface.
+).map(([name, token]) => ({ token, re: new RegExp(String.raw`\b${name}\b`, "i") })); // NOSONAR
 
 /**
  * Parse a scheduleTime display string into HH:MM 24-hour format.
@@ -822,8 +827,10 @@ export async function runKennelSeedPass(
         confidence: "HIGH",
         source: "SEED_DATA",
         sourceReference: SOURCE_REF.kennelSeed(seed.kennelCode),
-        // The seed author owns this; treat the seed file as the validation
-        // moment. Re-runs don't bump this; admin re-validation would.
+        // First-create timestamp. applyUpserts excludes lastValidatedAt from
+        // the UPDATE clause for SEED_DATA rules, so this `new Date()` is only
+        // written when the row is first created — re-runs preserve the
+        // original first-seen value (and admin re-validations stick).
         lastValidatedAt: new Date(),
         notes: rule.notes ?? null,
         label: rule.label?.trim() || null,
@@ -837,7 +844,9 @@ export async function runKennelSeedPass(
 
   console.log(`  ✓ ${count} rules planned from ${seedsWithRules.length} kennel(s) with scheduleRules`);
   if (skippedKennels > 0) console.log(`  ⊘ ${skippedKennels} kennel(s) skipped (not in DB / hidden)`);
-  if (skippedRules > 0) console.log(`  ⊘ ${skippedRules} rule(s) skipped (empty rrule)`);
+  if (skippedRules > 0) {
+    console.warn(`  ⊘ ${skippedRules} rule(s) skipped (empty or unparseable rrule)`);
+  }
   console.log("");
   return { count, skippedKennels, skippedRules };
 }
@@ -917,13 +926,19 @@ export async function applyUpserts(
           startTime: r.startTime,
           confidence: r.confidence,
           sourceReference: r.sourceReference,
-          lastValidatedAt: r.lastValidatedAt,
           notes: r.notes,
           label: r.label,
           validFrom: r.validFrom,
           validUntil: r.validUntil,
           displayOrder: r.displayOrder,
           isActive: true,
+          // Only STATIC_SCHEDULE rules bump lastValidatedAt on every run —
+          // the scrape's lastSuccessAt IS the validation moment. SEED_DATA
+          // (Pass 2 display strings + Pass 3 scheduleRules) preserves the
+          // first-create timestamp so admin re-validations and seed-author
+          // moments aren't clobbered by routine re-runs. (Codex P2 + Gemini
+          // + Claude review on PR #1405.)
+          ...(r.source === "STATIC_SCHEDULE" ? { lastValidatedAt: r.lastValidatedAt } : {}),
         },
       });
       if (preExistingIds.has(result.id)) {

--- a/scripts/backfill-schedule-rules.ts
+++ b/scripts/backfill-schedule-rules.ts
@@ -622,6 +622,73 @@ interface KennelSeedLike {
  * The `seedKennels` parameter is injectable for testability; defaults to the
  * exported KENNELS array.
  */
+interface DisplayKennel {
+  id: string;
+  kennelCode: string;
+  shortName: string;
+  scheduleDayOfWeek: string | null;
+  scheduleTime: string | null;
+  scheduleFrequency: string | null;
+  scheduleNotes: string | null;
+}
+
+interface DisplayRowResult {
+  emitted: number;
+  status: "emitted" | "unparseable" | "opted-out";
+  reason?: string;
+}
+
+/**
+ * Process one Pass 2 kennel row. Extracted from `runKennelDisplayPass` to keep
+ * the outer function's cognitive complexity under SonarCloud's cap of 15.
+ */
+function processDisplayKennel(
+  k: DisplayKennel,
+  optedOutCodes: ReadonlySet<string>,
+  planned: PlannedRule[],
+  options: BackfillOptions,
+): DisplayRowResult {
+  if (optedOutCodes.has(k.kennelCode)) {
+    if (options.verbose) {
+      console.log(`  ⤼ ${k.shortName} — opted out of Pass 2 (declares scheduleRules in seed)`);
+    }
+    return { emitted: 0, status: "opted-out" };
+  }
+  const parsed = parseFrequencyDay(k.scheduleFrequency, k.scheduleDayOfWeek);
+  if (parsed.length === 0) {
+    if (options.verbose) {
+      console.log(
+        `  ⊘ ${k.shortName} — unparseable: freq=${JSON.stringify(k.scheduleFrequency)} day=${JSON.stringify(k.scheduleDayOfWeek)}`,
+      );
+    }
+    return {
+      emitted: 0,
+      status: "unparseable",
+      reason: `${k.scheduleFrequency} / ${k.scheduleDayOfWeek ?? "null"}`,
+    };
+  }
+  const startTime = parseScheduleTime(k.scheduleTime);
+  for (const rule of parsed) {
+    planned.push({
+      kennelId: k.id,
+      kennelDisplay: k.shortName,
+      rrule: rule.rrule,
+      anchorDate: null,
+      startTime,
+      confidence: rule.confidence,
+      source: "SEED_DATA",
+      sourceReference: SOURCE_REF.kennelDisplay,
+      lastValidatedAt: null,
+      notes: rule.notes ?? null,
+      label: null,
+      validFrom: null,
+      validUntil: null,
+      displayOrder: 0,
+    });
+  }
+  return { emitted: parsed.length, status: "emitted" };
+}
+
 export async function runKennelDisplayPass(
   prisma: PrismaClientLike,
   planned: PlannedRule[],
@@ -654,44 +721,12 @@ export async function runKennelDisplayPass(
   let optedOut = 0;
   const skipReasons = new Map<string, number>();
   for (const k of kennels) {
-    if (optedOutCodes.has(k.kennelCode)) {
-      optedOut++;
-      if (options.verbose) {
-        console.log(`  ⤼ ${k.shortName} — opted out of Pass 2 (declares scheduleRules in seed)`);
-      }
-      continue;
-    }
-    const parsed = parseFrequencyDay(k.scheduleFrequency, k.scheduleDayOfWeek);
-    if (parsed.length === 0) {
+    const result = processDisplayKennel(k, optedOutCodes, planned, options);
+    count += result.emitted;
+    if (result.status === "opted-out") optedOut++;
+    else if (result.status === "unparseable" && result.reason) {
       skipped++;
-      const reason = `${k.scheduleFrequency} / ${k.scheduleDayOfWeek ?? "null"}`;
-      skipReasons.set(reason, (skipReasons.get(reason) ?? 0) + 1);
-      if (options.verbose) {
-        console.log(
-          `  ⊘ ${k.shortName} — unparseable: freq=${JSON.stringify(k.scheduleFrequency)} day=${JSON.stringify(k.scheduleDayOfWeek)}`,
-        );
-      }
-      continue;
-    }
-    const startTime = parseScheduleTime(k.scheduleTime);
-    for (const rule of parsed) {
-      planned.push({
-        kennelId: k.id,
-        kennelDisplay: k.shortName,
-        rrule: rule.rrule,
-        anchorDate: null,
-        startTime,
-        confidence: rule.confidence,
-        source: "SEED_DATA",
-        sourceReference: SOURCE_REF.kennelDisplay,
-        lastValidatedAt: null,
-        notes: rule.notes ?? null,
-        label: null,
-        validFrom: null,
-        validUntil: null,
-        displayOrder: 0,
-      });
-      count++;
+      skipReasons.set(result.reason, (skipReasons.get(result.reason) ?? 0) + 1);
     }
   }
   console.log(
@@ -749,6 +784,100 @@ function validateMonthDayAnchor(raw: string | undefined): string | null {
  * "FREQ=MONTHLY;BYDAY=1SA") while Pass 2 emits CADENCE sentinels for monthly
  * patterns without ordinals.
  */
+/**
+ * Validate one seed RRULE against the static-schedule adapter's parser. Returns
+ * the normalized RRULE string on success, null on failure (already logged).
+ * Fail-loud guard: better to skip at backfill time than to persist a value
+ * Travel Mode's projection engine silently falls back to "possible activity".
+ */
+function normalizeAndValidateSeedRrule(
+  rawRrule: string,
+  kennelCode: string,
+): string | null {
+  const normalized = normalizeRRule(rawRrule);
+  try {
+    parseRRule(normalized);
+    return normalized;
+  } catch (err) {
+    console.warn(
+      `  ⚠ ${kennelCode} — unparseable rrule ${JSON.stringify(rawRrule)}: ` +
+        `${err instanceof Error ? err.message : String(err)}, skipping`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Validate the MM-DD season anchors on a seed rule, logging warnings for
+ * malformed values. Returns the validated anchors (null when missing/invalid).
+ */
+function resolveSeasonAnchors(
+  rule: KennelScheduleRuleSeed,
+  kennelCode: string,
+): { validFrom: string | null; validUntil: string | null } {
+  const validFrom = validateMonthDayAnchor(rule.validFrom);
+  const validUntil = validateMonthDayAnchor(rule.validUntil);
+  if (rule.validFrom && !validFrom) {
+    console.warn(`  ⚠ ${kennelCode} — invalid validFrom ${JSON.stringify(rule.validFrom)}, dropping`);
+  }
+  if (rule.validUntil && !validUntil) {
+    console.warn(`  ⚠ ${kennelCode} — invalid validUntil ${JSON.stringify(rule.validUntil)}, dropping`);
+  }
+  return { validFrom, validUntil };
+}
+
+type SeedRuleResult = "emitted" | "skipped-empty" | "skipped-unparseable";
+
+interface SeedKennelMeta {
+  id: string;
+  kennelCode: string;
+  shortName: string;
+}
+
+/**
+ * Plan one Pass 3 rule. Extracted to keep `runKennelSeedPass` under SonarCloud's
+ * cognitive-complexity cap.
+ */
+function planSeedRule(
+  rule: KennelScheduleRuleSeed,
+  dbKennel: SeedKennelMeta,
+  kennelCode: string,
+  planned: PlannedRule[],
+  options: BackfillOptions,
+): SeedRuleResult {
+  const rrule = rule.rrule?.trim();
+  if (!rrule) {
+    if (options.verbose) {
+      console.log(`  ⊘ ${kennelCode} — empty rrule, skipping rule`);
+    }
+    return "skipped-empty";
+  }
+  const normalizedRrule = normalizeAndValidateSeedRrule(rrule, kennelCode);
+  if (!normalizedRrule) return "skipped-unparseable";
+  const { validFrom, validUntil } = resolveSeasonAnchors(rule, kennelCode);
+  planned.push({
+    kennelId: dbKennel.id,
+    kennelDisplay: dbKennel.shortName,
+    rrule: normalizedRrule,
+    anchorDate: rule.anchorDate?.trim() || null,
+    startTime: rule.startTime?.trim() || null,
+    confidence: "HIGH",
+    source: "SEED_DATA",
+    sourceReference: SOURCE_REF.kennelSeed(kennelCode),
+    // First-create timestamp. applyUpserts excludes lastValidatedAt from
+    // the UPDATE clause for SEED_DATA rules, so this `new Date()` is only
+    // written when the row is first created — re-runs preserve the
+    // original first-seen value (and admin re-validations stick).
+    lastValidatedAt: new Date(),
+    notes: rule.notes ?? null,
+    label: rule.label?.trim() || null,
+    validFrom,
+    validUntil,
+    displayOrder: typeof rule.displayOrder === "number" ? rule.displayOrder : 0,
+  });
+  return "emitted";
+}
+
 export async function runKennelSeedPass(
   prisma: PrismaClientLike,
   planned: PlannedRule[],
@@ -785,60 +914,10 @@ export async function runKennelSeedPass(
       }
       continue;
     }
-    const rules = seed.scheduleRules ?? [];
-    for (const rule of rules) {
-      const rrule = rule.rrule?.trim();
-      if (!rrule) {
-        skippedRules++;
-        if (options.verbose) {
-          console.log(`  ⊘ ${seed.kennelCode} — empty rrule, skipping rule`);
-        }
-        continue;
-      }
-      const normalizedRrule = normalizeRRule(rrule);
-      // Fail loud on malformed RRULEs: better to skip a row at backfill time than
-      // to persist a value Travel Mode's projection engine will silently fall
-      // back to "possible activity" on (LOW confidence, null date). The static-
-      // schedule adapter's parser is the canonical write-path validator.
-      try {
-        parseRRule(normalizedRrule);
-      } catch (err) {
-        skippedRules++;
-        console.warn(
-          `  ⚠ ${seed.kennelCode} — unparseable rrule ${JSON.stringify(rrule)}: ` +
-            `${err instanceof Error ? err.message : String(err)}, skipping`,
-        );
-        continue;
-      }
-      const validFrom = validateMonthDayAnchor(rule.validFrom);
-      const validUntil = validateMonthDayAnchor(rule.validUntil);
-      if (rule.validFrom && !validFrom) {
-        console.warn(`  ⚠ ${seed.kennelCode} — invalid validFrom ${JSON.stringify(rule.validFrom)}, dropping`);
-      }
-      if (rule.validUntil && !validUntil) {
-        console.warn(`  ⚠ ${seed.kennelCode} — invalid validUntil ${JSON.stringify(rule.validUntil)}, dropping`);
-      }
-      planned.push({
-        kennelId: dbKennel.id,
-        kennelDisplay: dbKennel.shortName,
-        rrule: normalizedRrule,
-        anchorDate: rule.anchorDate?.trim() || null,
-        startTime: rule.startTime?.trim() || null,
-        confidence: "HIGH",
-        source: "SEED_DATA",
-        sourceReference: SOURCE_REF.kennelSeed(seed.kennelCode),
-        // First-create timestamp. applyUpserts excludes lastValidatedAt from
-        // the UPDATE clause for SEED_DATA rules, so this `new Date()` is only
-        // written when the row is first created — re-runs preserve the
-        // original first-seen value (and admin re-validations stick).
-        lastValidatedAt: new Date(),
-        notes: rule.notes ?? null,
-        label: rule.label?.trim() || null,
-        validFrom,
-        validUntil,
-        displayOrder: typeof rule.displayOrder === "number" ? rule.displayOrder : 0,
-      });
-      count++;
+    for (const rule of seed.scheduleRules ?? []) {
+      const result = planSeedRule(rule, dbKennel, seed.kennelCode, planned, options);
+      if (result === "emitted") count++;
+      else skippedRules++;
     }
   }
 

--- a/scripts/backfill-schedule-rules.ts
+++ b/scripts/backfill-schedule-rules.ts
@@ -51,7 +51,18 @@ import {
 } from "@/generated/prisma/client";
 import { createScriptPool } from "./lib/db-pool";
 import { ANCHOR_WEEKDAYS, ANCHOR_RULES } from "@/adapters/static-schedule/lunar";
+import { parseRRule } from "@/adapters/static-schedule/adapter";
 import { isValidTimezone } from "@/lib/timezone";
+import { KENNELS, type KennelScheduleRuleSeed } from "../prisma/seed-data/kennels";
+
+/**
+ * Source-reference strings persisted on `ScheduleRule.sourceReference`. Centralized
+ * here so the admin UI / verify-fixes tooling has one place to grep for the conventions.
+ */
+const SOURCE_REF = {
+  kennelDisplay: "Kennel.scheduleDayOfWeek/Frequency",
+  kennelSeed: (code: string) => `KennelSeed.scheduleRules[${code}]`,
+} as const;
 
 interface BackfillOptions {
   verbose?: boolean;
@@ -350,6 +361,13 @@ interface PlannedRule {
   sourceReference: string | null;
   lastValidatedAt: Date | null;
   notes: string | null;
+  // Multi-cadence display fields (#1390). Only Pass 3 sets these; passes 1 + 2
+  // leave them at null / 0 so existing upserts don't accidentally clobber values
+  // written by a later Pass 3 with the same (kennelId, rrule, source) key.
+  label: string | null;
+  validFrom: string | null;
+  validUntil: string | null;
+  displayOrder: number;
 }
 
 type PrismaClientLike = InstanceType<typeof PrismaClient>;
@@ -449,6 +467,10 @@ function processSourceKennel(
     sourceReference: src.url || src.name,
     lastValidatedAt: src.lastSuccessAt ?? src.lastScrapeAt ?? null,
     notes: overrides?.notes ?? null,
+    label: null,
+    validFrom: null,
+    validUntil: null,
+    displayOrder: 0,
   });
   return true;
 }
@@ -570,20 +592,50 @@ export async function runStaticSchedulePass(
 }
 
 /**
+ * Shared shape for the seed-driven passes. The full `KennelSeed` interface
+ * lives in `prisma/seed-data/kennels.ts`; we only need these two fields here.
+ */
+interface KennelSeedLike {
+  kennelCode: string;
+  scheduleRules?: KennelScheduleRuleSeed[];
+}
+
+/**
  * Pass 2 of the backfill: derive MEDIUM/LOW rules from per-kennel display
  * strings (Kennel.scheduleDayOfWeek/Frequency). Mutates `planned` in place.
+ *
+ * Pass 2 SKIPS any kennel whose seed declares `scheduleRules` — those kennels
+ * are owned by Pass 3 (structured multi-cadence path), and Pass 2's parse would
+ * otherwise risk colliding on the (kennelId, rrule, source=SEED_DATA) unique key.
+ * On a re-run, a Pass 2 upsert with all-default multi-cadence fields would
+ * silently overwrite Pass 3's label/validFrom/validUntil with nulls before
+ * Pass 3's later upsert restored them — and if a seed `scheduleRules` entry is
+ * later removed, the restoration never happens and the metadata is lost.
+ * Making the opt-out structural (declare `scheduleRules` → skip Pass 2) makes
+ * the collision impossible regardless of pass ordering or apply order.
+ *
+ * The `seedKennels` parameter is injectable for testability; defaults to the
+ * exported KENNELS array.
  */
 export async function runKennelDisplayPass(
   prisma: PrismaClientLike,
   planned: PlannedRule[],
   options: BackfillOptions = {},
-): Promise<{ count: number; skipped: number; total: number }> {
+  seedKennels: ReadonlyArray<KennelSeedLike> = KENNELS,
+): Promise<{ count: number; skipped: number; total: number; optedOut: number }> {
   console.log("━━━ Pass 2: Kennel display strings → MEDIUM/LOW ━━━");
+
+  const optedOutCodes = new Set(
+    seedKennels
+      .filter((k) => Array.isArray(k.scheduleRules) && k.scheduleRules.length > 0)
+      .map((k) => k.kennelCode),
+  );
 
   const kennels = await prisma.kennel.findMany({
     where: { scheduleFrequency: { not: null }, isHidden: false },
     select: {
       id: true,
+      kennelCode: true,
       shortName: true,
       scheduleDayOfWeek: true,
       scheduleTime: true,
@@ -594,8 +646,16 @@ export async function runKennelDisplayPass(
 
   let count = 0;
   let skipped = 0;
+  let optedOut = 0;
   const skipReasons = new Map<string, number>();
   for (const k of kennels) {
+    if (optedOutCodes.has(k.kennelCode)) {
+      optedOut++;
+      if (options.verbose) {
+        console.log(`  ⤼ ${k.shortName} — opted out of Pass 2 (declares scheduleRules in seed)`);
+      }
+      continue;
+    }
     const parsed = parseFrequencyDay(k.scheduleFrequency, k.scheduleDayOfWeek);
     if (parsed.length === 0) {
       skipped++;
@@ -618,14 +678,21 @@ export async function runKennelDisplayPass(
         startTime,
         confidence: rule.confidence,
         source: "SEED_DATA",
-        sourceReference: "Kennel.scheduleDayOfWeek/Frequency",
+        sourceReference: SOURCE_REF.kennelDisplay,
         lastValidatedAt: null,
         notes: rule.notes ?? null,
+        label: null,
+        validFrom: null,
+        validUntil: null,
+        displayOrder: 0,
       });
       count++;
     }
   }
-  console.log(`  ✓ ${count} rules planned from ${kennels.length} kennels (${skipped} unparseable)`);
+  console.log(
+    `  ✓ ${count} rules planned from ${kennels.length} kennels ` +
+      `(${skipped} unparseable, ${optedOut} opted-out via scheduleRules)`,
+  );
   if (skipped > 0) {
     console.log("  Top skip reasons:");
     const sortedReasons = [...skipReasons.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
@@ -634,7 +701,145 @@ export async function runKennelDisplayPass(
     }
   }
   console.log("");
-  return { count, skipped, total: kennels.length };
+  return { count, skipped, total: kennels.length, optedOut };
+}
+
+/**
+ * Validate a "MM-DD" anchor used in seasonal scheduleRules. Rejects malformed
+ * strings ("13-01", "02-30", "summer") so a typo doesn't end up as opaque text
+ * in the ScheduleRule row. Returns the trimmed string on success, null otherwise.
+ */
+function validateMonthDayAnchor(raw: string | undefined): string | null {
+  if (raw === undefined || raw === null) return null;
+  const s = String(raw).trim();
+  const match = /^(\d{2})-(\d{2})$/.exec(s);
+  if (!match) return null;
+  const month = Number.parseInt(match[1], 10);
+  const day = Number.parseInt(match[2], 10);
+  if (month < 1 || month > 12) return null;
+  // Use a leap year (2024) as the upper-bound calendar so Feb 29 is permitted
+  // — seasonal cadences span Feb and we'd rather accept "02-29" than reject it.
+  const lastDayOfMonth = new Date(Date.UTC(2024, month, 0)).getUTCDate();
+  if (day < 1 || day > lastDayOfMonth) return null;
+  return s;
+}
+
+/**
+ * Pass 3 of the backfill: kennel seed `scheduleRules` → HIGH-confidence rules
+ * with multi-cadence display metadata (label / validFrom / validUntil / displayOrder).
+ *
+ * Pass 3 is the structured-data path that supersedes Pass 2 for migrated kennels:
+ * - Pass 1 (STATIC_SCHEDULE source) provides the HIGH-confidence single-RRULE
+ *   case for kennels driven by a Source.config.rrule.
+ * - Pass 2 (Kennel display strings) provides a best-effort MEDIUM rule for the
+ *   ~190 unmigrated kennels.
+ * - Pass 3 (this) is the new authoritative path for kennels that explicitly
+ *   declare one-or-more cadences in their seed entry. Confidence is HIGH because
+ *   the seed author wrote it down explicitly.
+ *
+ * Collision handling: the upsert is keyed on (kennelId, rrule, source). If Pass 1
+ * or Pass 2 emitted the same key earlier, Pass 3's later emission wins on the
+ * second upsert pass (same source enum + same rrule string). In practice the
+ * keys rarely collide because Pass 3 emits canonical RRULE shapes (e.g.
+ * "FREQ=MONTHLY;BYDAY=1SA") while Pass 2 emits CADENCE sentinels for monthly
+ * patterns without ordinals.
+ */
+export async function runKennelSeedPass(
+  prisma: PrismaClientLike,
+  planned: PlannedRule[],
+  options: BackfillOptions = {},
+  seedKennels: ReadonlyArray<KennelSeedLike> = KENNELS,
+): Promise<{ count: number; skippedKennels: number; skippedRules: number }> {
+  console.log("━━━ Pass 3: Kennel seed scheduleRules → HIGH confidence ━━━");
+
+  const seedsWithRules = seedKennels.filter(
+    (k) => Array.isArray(k.scheduleRules) && k.scheduleRules.length > 0,
+  );
+  if (seedsWithRules.length === 0) {
+    console.log("  ✓ 0 kennels carry scheduleRules in the seed — nothing to plan\n");
+    return { count: 0, skippedKennels: 0, skippedRules: 0 };
+  }
+
+  const codes = seedsWithRules.map((k) => k.kennelCode);
+  const dbKennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: codes }, isHidden: false },
+    select: { id: true, kennelCode: true, shortName: true },
+  });
+  const byCode = new Map(dbKennels.map((k) => [k.kennelCode, k]));
+
+  let count = 0;
+  let skippedKennels = 0;
+  let skippedRules = 0;
+
+  for (const seed of seedsWithRules) {
+    const dbKennel = byCode.get(seed.kennelCode);
+    if (!dbKennel) {
+      skippedKennels++;
+      if (options.verbose) {
+        console.log(`  ⊘ ${seed.kennelCode} — not found in DB (or hidden)`);
+      }
+      continue;
+    }
+    const rules = seed.scheduleRules ?? [];
+    for (const rule of rules) {
+      const rrule = rule.rrule?.trim();
+      if (!rrule) {
+        skippedRules++;
+        if (options.verbose) {
+          console.log(`  ⊘ ${seed.kennelCode} — empty rrule, skipping rule`);
+        }
+        continue;
+      }
+      const normalizedRrule = normalizeRRule(rrule);
+      // Fail loud on malformed RRULEs: better to skip a row at backfill time than
+      // to persist a value Travel Mode's projection engine will silently fall
+      // back to "possible activity" on (LOW confidence, null date). The static-
+      // schedule adapter's parser is the canonical write-path validator.
+      try {
+        parseRRule(normalizedRrule);
+      } catch (err) {
+        skippedRules++;
+        console.warn(
+          `  ⚠ ${seed.kennelCode} — unparseable rrule ${JSON.stringify(rrule)}: ` +
+            `${err instanceof Error ? err.message : String(err)}, skipping`,
+        );
+        continue;
+      }
+      const validFrom = validateMonthDayAnchor(rule.validFrom);
+      const validUntil = validateMonthDayAnchor(rule.validUntil);
+      if (rule.validFrom && !validFrom) {
+        console.warn(`  ⚠ ${seed.kennelCode} — invalid validFrom ${JSON.stringify(rule.validFrom)}, dropping`);
+      }
+      if (rule.validUntil && !validUntil) {
+        console.warn(`  ⚠ ${seed.kennelCode} — invalid validUntil ${JSON.stringify(rule.validUntil)}, dropping`);
+      }
+      planned.push({
+        kennelId: dbKennel.id,
+        kennelDisplay: dbKennel.shortName,
+        rrule: normalizedRrule,
+        anchorDate: rule.anchorDate?.trim() || null,
+        startTime: rule.startTime?.trim() || null,
+        confidence: "HIGH",
+        source: "SEED_DATA",
+        sourceReference: SOURCE_REF.kennelSeed(seed.kennelCode),
+        // The seed author owns this; treat the seed file as the validation
+        // moment. Re-runs don't bump this; admin re-validation would.
+        lastValidatedAt: new Date(),
+        notes: rule.notes ?? null,
+        label: rule.label?.trim() || null,
+        validFrom,
+        validUntil,
+        displayOrder: typeof rule.displayOrder === "number" ? rule.displayOrder : 0,
+      });
+      count++;
+    }
+  }
+
+  console.log(`  ✓ ${count} rules planned from ${seedsWithRules.length} kennel(s) with scheduleRules`);
+  if (skippedKennels > 0) console.log(`  ⊘ ${skippedKennels} kennel(s) skipped (not in DB / hidden)`);
+  if (skippedRules > 0) console.log(`  ⊘ ${skippedRules} rule(s) skipped (empty rrule)`);
+  console.log("");
+  return { count, skippedKennels, skippedRules };
 }
 
 /**
@@ -702,6 +907,10 @@ export async function applyUpserts(
           sourceReference: r.sourceReference,
           lastValidatedAt: r.lastValidatedAt,
           notes: r.notes,
+          label: r.label,
+          validFrom: r.validFrom,
+          validUntil: r.validUntil,
+          displayOrder: r.displayOrder,
         },
         update: {
           anchorDate: r.anchorDate,
@@ -710,6 +919,10 @@ export async function applyUpserts(
           sourceReference: r.sourceReference,
           lastValidatedAt: r.lastValidatedAt,
           notes: r.notes,
+          label: r.label,
+          validFrom: r.validFrom,
+          validUntil: r.validUntil,
+          displayOrder: r.displayOrder,
           isActive: true,
         },
       });
@@ -793,6 +1006,7 @@ export async function runScheduleRuleBackfill(
   const planned: PlannedRule[] = [];
   await runStaticSchedulePass(prisma, planned, options);
   await runKennelDisplayPass(prisma, planned, options);
+  await runKennelSeedPass(prisma, planned, options);
   const result = await applyUpserts(prisma, planned);
   await deactivateStaleRules(prisma, planned, result.errored);
   return result;
@@ -813,6 +1027,7 @@ async function main() {
   const planned: PlannedRule[] = [];
   await runStaticSchedulePass(prisma, planned, options);
   await runKennelDisplayPass(prisma, planned, options);
+  await runKennelSeedPass(prisma, planned, options);
   printPlanSummary(planned, options);
 
   if (dryRun) {


### PR DESCRIPTION
## Summary

First of three sequenced PRs for [#1390](https://github.com/johnrclem/hashtracks-web/issues/1390) (multi-cadence kennel schedules) with [#1388](https://github.com/johnrclem/hashtracks-web/issues/1388) (Hebe H3 RRULE fix) as the proving ground. This PR is pure plumbing — schema + KennelSeed type + backfill Pass 3 with **zero behavior change** for all 396 kennels. Hebe migrates in PR 2; Hockessin in PR 3.

- Extends `ScheduleRule` with `label` / `validFrom` / `validUntil` / `displayOrder` so it becomes the authoritative multi-slot store for BOTH Travel Mode projection (already a consumer) AND kennel-page display (new consumer in PR 2).
- Adds `KennelScheduleRuleSeed` type + optional `scheduleRules?: KennelScheduleRuleSeed[]` field on `KennelSeed`. No seed entries opt in yet.
- Adds Pass 3 to `scripts/backfill-schedule-rules.ts` that reads seed `scheduleRules` and writes HIGH-confidence rows. Pass 2 SKIPS any kennel that declares `scheduleRules` — structural opt-out eliminates the `(kennelId, rrule, source=SEED_DATA)` upsert collision that would otherwise let Pass 2 silently overwrite Pass 3's multi-cadence fields with nulls.

## Key decisions (per the adversarial-reviewed design)

| Decision | Rationale |
|---|---|
| **Extend `ScheduleRule`** rather than new `KennelScheduleSlot` model or Json column | ScheduleRule already supports multi-cadence per kennel for Travel Mode. The 4 new columns are additive. |
| **Keep hand-rolled `parseRRule`** in `src/adapters/static-schedule/adapter.ts`; no `rrule` npm dep | The cadences in scope are covered by the existing nth-prefix syntax (`BYDAY=1SA`, etc.). |
| **Event generation unchanged** | STATIC_SCHEDULE adapter continues reading `Source.config.rrule`. Multi-cadence event generation continues using the "two source rows per kennel" pattern (Mosquito H3 1st Wed + 3rd Wed). This PR only changes the multi-slot DISPLAY store. |
| **`validFrom` / `validUntil` use MM-DD strings** | Seasonality wraps years (`11-01` → `02-28` = winter). |
| **Migration hand-written** | Prisma `migrate dev` shadow DB fails on the pre-existing data-dependent migration `20260504010411`. The hand-authored ALTER TABLE is identical in shape to what `migrate dev` would have generated. |

## Verification

- **45 tests pass** (10 new). Notable: `it.each` table for the Pass 2 opt-out trio (per memory `feedback_it_each_for_sonar_cpd.md`), parseRRule fail-loud test, leap-year `02-29` MM-DD case.
- **Full backfill apply against local Railway-shaped DB**: 366 existing rules updated, **0 rows wrote new fields, 0 opted-out**. Zero-behavior-delta gate holds for the unmigrated kennels.
- **`npx tsc --noEmit` clean; `npm run lint` clean** (only pre-existing warnings).
- **`/codex:adversarial-review` run twice** — once on the plan, once on the diff. All actionable findings folded in (SOURCE_REF constant, `parseRRule` validation in Pass 3, Pass 2/3 collision fix via structural opt-out, `it.each` collapse).
- **`/simplify` applied** — net result: extra defensive validation (parseRRule + delete-misleading-comment + extract SOURCE_REF + collapse near-duplicate tests).

## What's deferred to PR 2 + PR 3

The plan-level codex review surfaced six additional concerns folded into the plan but explicitly out of scope for this PR:

- **PR 2**: render-surface inventory expanded to include `KennelMapView` ([line 149](src/components/kennels/KennelMapView.tsx:149)) + `generateMetadata()` ([page.tsx:28](src/app/kennels/[slug]/page.tsx:28)); admin `BYSETPOS` write-path guard in `config-validation.ts`; `KennelDirectory` filter contract update; shared `src/lib/schedule-season.ts` helper with MM-DD wrap + leap-year tests; Hebe migration + the misleading `BYSETPOS=3` RRULE fix.
- **PR 3**: Hockessin migration; Travel Mode `validFrom` / `validUntil` gating so July searches don't project winter-only cadences with no seasonal hint.

## Known limitation

Stronger migration verification (`dropdb + createdb + migrate deploy` on a fresh scratch DB) is blocked by the pre-existing `20260504010411_kennel_profile_bundle_h5_glh3_gch3au` data-dependent migration — not introduced by this PR. The verification path that maps to Vercel's prod bootstrap (apply NEW migration on top of a DB already in main's state) is the one that ran clean. Tracked as a follow-up: fix the data-dependent migrations to use `IF EXISTS` guards so fresh-bootstrap works.

## Test plan

- [ ] CI green (`npx tsc --noEmit`, `npm run lint`, `npm test`).
- [ ] Vercel preview deploy applies the migration cleanly.
- [ ] Manual: `npx tsx scripts/backfill-schedule-rules.ts --apply` against prod after merge → expect 0 created, all existing updated, 0 opted-out (no seed has `scheduleRules` yet).
- [ ] Spot-check 3 unmigrated kennel pages render schedule chips identically to before.

Refs [#1390](https://github.com/johnrclem/hashtracks-web/issues/1390), [#1388](https://github.com/johnrclem/hashtracks-web/issues/1388). Does NOT close either; PR 2 closes #1388, PR 3 closes #1390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)