### PR TITLE
fix(seed): cycle-6 profile bundles (Kimchi, Humpin', GyNO H3) + AH4 proxy scaffolding

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2096,7 +2096,7 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "kimchi-h3", shortName: "Kimchi", fullName: "Colorado Kimchi Hash House Harriers", region: "Colorado Springs, CO",
-      website: "http://www.cspringsh3.com",
+      website: "http://www.cspringsh3.com", // NOSONAR — source is HTTP-only; HTTPS returns ERR_SSL_VERSION_OR_CIPHER_MISMATCH (#1380)
       facebookUrl: "https://www.facebook.com/groups/2147541855493092/",
       scheduleDayOfWeek: "Saturday", scheduleTime: "2:00 PM", scheduleFrequency: "Biweekly",
       scheduleNotes: "Alternating Saturdays with PPH4",

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -736,7 +736,9 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "humpin-sd", shortName: "Humpin'", fullName: "Humpin' Hash House Harriers", region: "San Diego, CA",
+      contactEmail: "HumpinHashCash@gmail.com",
       scheduleDayOfWeek: "Sunday", scheduleFrequency: "Weekly",
+      hashCash: "$8",
       description: "San Diego Sunday hash.",
       latitude: 32.72, longitude: -117.16,
     },
@@ -2094,9 +2096,12 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "kimchi-h3", shortName: "Kimchi", fullName: "Colorado Kimchi Hash House Harriers", region: "Colorado Springs, CO",
+      website: "http://www.cspringsh3.com",
+      facebookUrl: "https://www.facebook.com/groups/2147541855493092/",
       scheduleDayOfWeek: "Saturday", scheduleTime: "2:00 PM", scheduleFrequency: "Biweekly",
       scheduleNotes: "Alternating Saturdays with PPH4",
-      description: "Colorado Springs biweekly Saturday afternoon hash, alternating weeks with Pikes Peak.",
+      foundedYear: 2002,
+      description: "Colorado Springs biweekly Saturday afternoon hash, alternating weeks with Pikes Peak. Founded in 2002 by Yongsan Kimchi H3 (Korea) alumni to offset PPH4 with a Saturday hash; name lineage from the original Seoul Kimchi kennel.",
       latitude: 38.83, longitude: -104.82,
     },
     {
@@ -2559,9 +2564,11 @@ export const KENNELS: KennelSeed[] = [
       latitude: 35.15, longitude: -90.05,
     },
     {
-      kennelCode: "gynoh3", shortName: "GyNO H3", fullName: "GyNO Hash House Harriers", region: "Memphis, TN",
-      scheduleFrequency: "Monthly",
-      description: "Memphis harriette kennel. Monthly events appearing on the Memphis H3 calendar.",
+      kennelCode: "gynoh3", shortName: "GyNO H3", fullName: "Gyrls Night Out Hash House Harriers", region: "Memphis, TN",
+      scheduleDayOfWeek: "Monday", scheduleTime: "6:00 PM", scheduleFrequency: "Monthly",
+      scheduleNotes: "3rd Monday of each month. Plus 1st Thursday Harriette Happy Hour at 6:00 PM.",
+      foundedYear: 2025,
+      description: "Women-only kennel in Memphis, TN, supported by Memphis Hash House Harriers. Founded October 20, 2025. Monthly trail on 3rd Mondays at 6:00 PM, with a Harriette Happy Hour the 1st Thursday of each month.",
       latitude: 35.15, longitude: -90.05,
     },
 

--- a/scripts/cleanup-cycle6-profile-overrides.ts
+++ b/scripts/cleanup-cycle6-profile-overrides.ts
@@ -1,0 +1,145 @@
+/**
+ * One-off overrides for the cycle-6 profile bundle PR (#1380, #1392, #1393).
+ *
+ * Background: prisma/seed.ts performs a fill-only merge for existing kennels
+ * — it never overwrites an already-populated column (seed.ts:298-303), and
+ * `fullName` is set only at create time (seed.ts:265, not in PROFILE_FIELDS).
+ *
+ * This script applies the rewrites that can't be expressed in seed:
+ *   - gynoh3.fullName  → "Gyrls Night Out Hash House Harriers"     (#1393)
+ *   - gynoh3.description → expanded blurb with founding details    (#1393)
+ *   - kimchi-h3.description → expanded blurb with Korean lineage   (#1380)
+ *
+ * Idempotent and safe to re-run. Default mode is DRY-RUN; pass --execute
+ * to actually write to the DB.
+ *
+ * Usage:
+ *   eval "$(fnm env)" && fnm use 20
+ *   set -a && source .env && set +a
+ *   npx tsx scripts/cleanup-cycle6-profile-overrides.ts            # dry-run
+ *   npx tsx scripts/cleanup-cycle6-profile-overrides.ts --execute  # apply
+ */
+
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const EXECUTE = process.argv.includes("--execute");
+
+type OverrideField = "fullName" | "description";
+type FieldRewrite = { expected: string | null; target: string };
+type Override = {
+  kennelCode: string;
+  rewrites: Partial<Record<OverrideField, FieldRewrite>>;
+};
+
+// Each rewrite carries the EXPECTED current value so the script refuses to
+// overwrite admin curations applied between merge and execution. `expected`
+// is captured from the prod-state query in cycle-6 PR Step 0 — see PR body.
+const OVERRIDES: Override[] = [
+  {
+    kennelCode: "gynoh3",
+    rewrites: {
+      fullName: {
+        expected: "GyNO Hash House Harriers",
+        target: "Gyrls Night Out Hash House Harriers",
+      },
+      description: {
+        expected: null,
+        target:
+          "Women-only kennel in Memphis, TN, supported by Memphis Hash House Harriers. Founded October 20, 2025. Monthly trail on 3rd Mondays at 6:00 PM, with a Harriette Happy Hour the 1st Thursday of each month.",
+      },
+    },
+  },
+  {
+    kennelCode: "kimchi-h3",
+    rewrites: {
+      description: {
+        expected:
+          "Colorado Springs biweekly Saturday afternoon hash, alternating weeks with Pikes Peak.",
+        target:
+          "Colorado Springs biweekly Saturday afternoon hash, alternating weeks with Pikes Peak. Founded in 2002 by Yongsan Kimchi H3 (Korea) alumni to offset PPH4 with a Saturday hash; name lineage from the original Seoul Kimchi kennel.",
+      },
+    },
+  },
+];
+
+async function main() {
+  const mode = EXECUTE ? "EXECUTE (will update DB)" : "DRY-RUN (read-only)";
+  console.log(`\n=== cleanup-cycle6-profile-overrides ===`);
+  console.log(`Mode: ${mode}\n`);
+
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+  try {
+    let plannedUpdates = 0;
+    let skippedDueToDrift = 0;
+    for (const { kennelCode, rewrites } of OVERRIDES) {
+      const kennel = await prisma.kennel.findUnique({
+        where: { kennelCode },
+        select: { id: true, kennelCode: true, fullName: true, description: true },
+      });
+      if (!kennel) {
+        console.error(`✗ Kennel "${kennelCode}" not found — skipping.`);
+        continue;
+      }
+
+      const updateData: Partial<Record<OverrideField, string>> = {};
+      let driftSkip = false;
+      for (const field of Object.keys(rewrites) as OverrideField[]) {
+        const { expected, target } = rewrites[field]!;
+        const current = kennel[field];
+        if (current === target) {
+          console.log(`  · ${kennelCode}.${field} already correct.`);
+        } else if (current !== expected) {
+          console.warn(`  ⚠ ${kennelCode}.${field} drifted from expected — refusing to overwrite.`);
+          console.warn(`      expected: ${JSON.stringify(expected)}`);
+          console.warn(`      current:  ${JSON.stringify(current)}`);
+          console.warn(`      target:   ${JSON.stringify(target)}`);
+          driftSkip = true;
+        } else {
+          updateData[field] = target;
+          console.log(`  ~ ${kennelCode}.${field}`);
+          console.log(`      current: ${JSON.stringify(current)}`);
+          console.log(`      target:  ${JSON.stringify(target)}`);
+        }
+      }
+
+      if (driftSkip) {
+        skippedDueToDrift++;
+        continue;
+      }
+      if (Object.keys(updateData).length === 0) continue;
+      plannedUpdates++;
+
+      if (!EXECUTE) continue;
+
+      await prisma.kennel.update({
+        where: { id: kennel.id },
+        data: updateData,
+      });
+      console.log(`  ✓ Updated ${kennelCode} (${Object.keys(updateData).join(", ")})`);
+    }
+
+    if (skippedDueToDrift > 0) {
+      console.warn(`\n⚠ Skipped ${skippedDueToDrift} kennel(s) due to drift from expected values — review manually.`);
+    }
+    if (plannedUpdates === 0) {
+      console.log(skippedDueToDrift > 0 ? "" : "\nNothing to do — all overrides already applied.");
+    } else if (!EXECUTE) {
+      console.log(`\nDry-run complete. ${plannedUpdates} kennel(s) would be updated. Re-run with --execute to apply.`);
+    } else {
+      console.log(`\nApplied overrides to ${plannedUpdates} kennel(s).`);
+    }
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("\nFatal error:", err);
+  process.exit(1);
+});

--- a/scripts/cleanup-cycle6-profile-overrides.ts
+++ b/scripts/cleanup-cycle6-profile-overrides.ts
@@ -28,7 +28,7 @@ import { createScriptPool } from "./lib/db-pool";
 const EXECUTE = process.argv.includes("--execute");
 
 type OverrideField = "fullName" | "description";
-type FieldRewrite = { expected: string | null; target: string };
+type FieldRewrite = { expected: string; target: string };
 type Override = {
   kennelCode: string;
   rewrites: Partial<Record<OverrideField, FieldRewrite>>;
@@ -46,7 +46,8 @@ const OVERRIDES: Override[] = [
         target: "Gyrls Night Out Hash House Harriers",
       },
       description: {
-        expected: null,
+        expected:
+          "Memphis harriette kennel. Monthly events appearing on the Memphis H3 calendar.",
         target:
           "Women-only kennel in Memphis, TN, supported by Memphis Hash House Harriers. Founded October 20, 2025. Monthly trail on 3rd Mondays at 6:00 PM, with a Harriette Happy Hour the 1st Thursday of each month.",
       },

--- a/scripts/cleanup-cycle6-profile-overrides.ts
+++ b/scripts/cleanup-cycle6-profile-overrides.ts
@@ -28,11 +28,18 @@ import { createScriptPool } from "./lib/db-pool";
 const EXECUTE = process.argv.includes("--execute");
 
 type OverrideField = "fullName" | "description";
-type FieldRewrite = { expected: string; target: string };
-type Override = {
+interface FieldRewrite {
+  expected: string;
+  target: string;
+}
+interface Override {
   kennelCode: string;
   rewrites: Partial<Record<OverrideField, FieldRewrite>>;
-};
+}
+interface RewriteEvaluation {
+  updateData: Partial<Record<OverrideField, string>>;
+  driftSkip: boolean;
+}
 
 // Each rewrite carries the EXPECTED current value so the script refuses to
 // overwrite admin curations applied between merge and execution. `expected`
@@ -66,6 +73,71 @@ const OVERRIDES: Override[] = [
   },
 ];
 
+type KennelRow = { id: string; kennelCode: string; fullName: string; description: string | null };
+
+function evaluateRewrites(
+  kennel: KennelRow,
+  rewrites: Override["rewrites"],
+): RewriteEvaluation {
+  const updateData: Partial<Record<OverrideField, string>> = {};
+  let driftSkip = false;
+  for (const field of Object.keys(rewrites) as OverrideField[]) {
+    const { expected, target } = rewrites[field]!;
+    const current = kennel[field];
+    if (current === target) {
+      console.log(`  · ${kennel.kennelCode}.${field} already correct.`);
+    } else if (current === expected) {
+      updateData[field] = target;
+      console.log(`  ~ ${kennel.kennelCode}.${field}`);
+      console.log(`      current: ${JSON.stringify(current)}`);
+      console.log(`      target:  ${JSON.stringify(target)}`);
+    } else {
+      console.warn(`  ⚠ ${kennel.kennelCode}.${field} drifted from expected — refusing to overwrite.`);
+      console.warn(`      expected: ${JSON.stringify(expected)}`);
+      console.warn(`      current:  ${JSON.stringify(current)}`);
+      console.warn(`      target:   ${JSON.stringify(target)}`);
+      driftSkip = true;
+    }
+  }
+  return { updateData, driftSkip };
+}
+
+async function processOverride(
+  prisma: PrismaClient,
+  override: Override,
+): Promise<"updated" | "skipped-drift" | "noop" | "missing"> {
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: override.kennelCode },
+    select: { id: true, kennelCode: true, fullName: true, description: true },
+  });
+  if (!kennel) {
+    console.error(`✗ Kennel "${override.kennelCode}" not found — skipping.`);
+    return "missing";
+  }
+
+  const { updateData, driftSkip } = evaluateRewrites(kennel, override.rewrites);
+  if (driftSkip) return "skipped-drift";
+  if (Object.keys(updateData).length === 0) return "noop";
+  if (!EXECUTE) return "updated";
+
+  await prisma.kennel.update({ where: { id: kennel.id }, data: updateData });
+  console.log(`  ✓ Updated ${kennel.kennelCode} (${Object.keys(updateData).join(", ")})`);
+  return "updated";
+}
+
+function summarize(plannedUpdates: number, skippedDueToDrift: number) {
+  if (skippedDueToDrift > 0) {
+    console.warn(`\n⚠ Skipped ${skippedDueToDrift} kennel(s) due to drift from expected values — review manually.`);
+  }
+  if (plannedUpdates === 0 && skippedDueToDrift === 0) {
+    console.log("\nNothing to do — all overrides already applied.");
+  } else if (plannedUpdates > 0 && !EXECUTE) {
+    console.log(`\nDry-run complete. ${plannedUpdates} kennel(s) would be updated. Re-run with --execute to apply.`);
+  } else if (plannedUpdates > 0) {
+    console.log(`\nApplied overrides to ${plannedUpdates} kennel(s).`);
+  }
+}
+
 async function main() {
   const mode = EXECUTE ? "EXECUTE (will update DB)" : "DRY-RUN (read-only)";
   console.log(`\n=== cleanup-cycle6-profile-overrides ===`);
@@ -77,63 +149,12 @@ async function main() {
   try {
     let plannedUpdates = 0;
     let skippedDueToDrift = 0;
-    for (const { kennelCode, rewrites } of OVERRIDES) {
-      const kennel = await prisma.kennel.findUnique({
-        where: { kennelCode },
-        select: { id: true, kennelCode: true, fullName: true, description: true },
-      });
-      if (!kennel) {
-        console.error(`✗ Kennel "${kennelCode}" not found — skipping.`);
-        continue;
-      }
-
-      const updateData: Partial<Record<OverrideField, string>> = {};
-      let driftSkip = false;
-      for (const field of Object.keys(rewrites) as OverrideField[]) {
-        const { expected, target } = rewrites[field]!;
-        const current = kennel[field];
-        if (current === target) {
-          console.log(`  · ${kennelCode}.${field} already correct.`);
-        } else if (current !== expected) {
-          console.warn(`  ⚠ ${kennelCode}.${field} drifted from expected — refusing to overwrite.`);
-          console.warn(`      expected: ${JSON.stringify(expected)}`);
-          console.warn(`      current:  ${JSON.stringify(current)}`);
-          console.warn(`      target:   ${JSON.stringify(target)}`);
-          driftSkip = true;
-        } else {
-          updateData[field] = target;
-          console.log(`  ~ ${kennelCode}.${field}`);
-          console.log(`      current: ${JSON.stringify(current)}`);
-          console.log(`      target:  ${JSON.stringify(target)}`);
-        }
-      }
-
-      if (driftSkip) {
-        skippedDueToDrift++;
-        continue;
-      }
-      if (Object.keys(updateData).length === 0) continue;
-      plannedUpdates++;
-
-      if (!EXECUTE) continue;
-
-      await prisma.kennel.update({
-        where: { id: kennel.id },
-        data: updateData,
-      });
-      console.log(`  ✓ Updated ${kennelCode} (${Object.keys(updateData).join(", ")})`);
+    for (const override of OVERRIDES) {
+      const outcome = await processOverride(prisma, override);
+      if (outcome === "updated") plannedUpdates++;
+      else if (outcome === "skipped-drift") skippedDueToDrift++;
     }
-
-    if (skippedDueToDrift > 0) {
-      console.warn(`\n⚠ Skipped ${skippedDueToDrift} kennel(s) due to drift from expected values — review manually.`);
-    }
-    if (plannedUpdates === 0) {
-      console.log(skippedDueToDrift > 0 ? "" : "\nNothing to do — all overrides already applied.");
-    } else if (!EXECUTE) {
-      console.log(`\nDry-run complete. ${plannedUpdates} kennel(s) would be updated. Re-run with --execute to apply.`);
-    } else {
-      console.log(`\nApplied overrides to ${plannedUpdates} kennel(s).`);
-    }
+    summarize(plannedUpdates, skippedDueToDrift);
   } finally {
     await prisma.$disconnect();
     await pool.end();

--- a/src/adapters/html-scraper/atlanta-hash-board.test.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.test.ts
@@ -13,6 +13,10 @@ import {
 
 const mockSafeFetch = vi.mocked(safeFetch);
 
+// Adapter only touches a small surface of Response (`ok`, `status`, `text`),
+// so build a partial stub and cast once here rather than per call site.
+const mockResponse = (init: Partial<Response>): Response => init as Response;
+
 // ── Sample Atom XML fixtures ──
 
 const SAMPLE_ATOM_FEED = `<?xml version="1.0" encoding="UTF-8"?>
@@ -221,10 +225,10 @@ describe("AtlantaHashBoardAdapter", () => {
   });
 
   it("fetches and parses events from multiple forums", async () => {
-    mockSafeFetch.mockResolvedValue({
+    mockSafeFetch.mockResolvedValue(mockResponse({
       ok: true,
       text: () => Promise.resolve(SAMPLE_ATOM_FEED),
-    } as Response);
+    }));
 
     const adapter = new AtlantaHashBoardAdapter();
     const source = {
@@ -262,11 +266,11 @@ describe("AtlantaHashBoardAdapter", () => {
   });
 
   it("handles fetch errors gracefully", async () => {
-    mockSafeFetch.mockResolvedValue({
+    mockSafeFetch.mockResolvedValue(mockResponse({
       ok: false,
       status: 503,
       statusText: "Service Unavailable",
-    } as Response);
+    }));
 
     const adapter = new AtlantaHashBoardAdapter();
     const source = {
@@ -303,10 +307,10 @@ describe("AtlantaHashBoardAdapter", () => {
     { configValue: true, expectedForwarded: true, label: "true forwards through" },
     { configValue: undefined, expectedForwarded: false, label: "undefined defaults to false" },
   ])("useResidentialProxy: $label", async ({ configValue, expectedForwarded }) => {
-    mockSafeFetch.mockResolvedValue({
+    mockSafeFetch.mockResolvedValue(mockResponse({
       ok: true,
       text: () => Promise.resolve(SAMPLE_ATOM_FEED),
-    } as Response);
+    }));
 
     const adapter = new AtlantaHashBoardAdapter();
     const config: Record<string, unknown> = {

--- a/src/adapters/html-scraper/atlanta-hash-board.test.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.test.ts
@@ -1,3 +1,8 @@
+vi.mock("../safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+
+import { safeFetch } from "../safe-fetch";
 import {
   parseAtomFeed,
   isReplyEntry,
@@ -5,6 +10,8 @@ import {
   extractEventFields,
   AtlantaHashBoardAdapter,
 } from "./atlanta-hash-board";
+
+const mockSafeFetch = vi.mocked(safeFetch);
 
 // ── Sample Atom XML fixtures ──
 
@@ -205,7 +212,7 @@ describe("extractEventFields", () => {
 
 describe("AtlantaHashBoardAdapter", () => {
   beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn());
+    mockSafeFetch.mockReset();
   });
 
   it("has correct type", () => {
@@ -214,11 +221,10 @@ describe("AtlantaHashBoardAdapter", () => {
   });
 
   it("fetches and parses events from multiple forums", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
+    mockSafeFetch.mockResolvedValue({
       ok: true,
       text: () => Promise.resolve(SAMPLE_ATOM_FEED),
-    });
-    vi.stubGlobal("fetch", mockFetch);
+    } as Response);
 
     const adapter = new AtlantaHashBoardAdapter();
     const source = {
@@ -234,13 +240,13 @@ describe("AtlantaHashBoardAdapter", () => {
 
     const result = await adapter.fetch(source, { days: 90 });
 
-    // Should have made 2 fetch calls (one per forum)
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch).toHaveBeenCalledWith(
+    // Should have made 2 safeFetch calls (one per forum)
+    expect(mockSafeFetch).toHaveBeenCalledTimes(2);
+    expect(mockSafeFetch).toHaveBeenCalledWith(
       expect.stringContaining("/app.php/feed/forum/2"),
       expect.any(Object),
     );
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockSafeFetch).toHaveBeenCalledWith(
       expect.stringContaining("/app.php/feed/forum/8"),
       expect.any(Object),
     );
@@ -252,12 +258,11 @@ describe("AtlantaHashBoardAdapter", () => {
   });
 
   it("handles fetch errors gracefully", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
+    mockSafeFetch.mockResolvedValue({
       ok: false,
       status: 503,
       statusText: "Service Unavailable",
-    });
-    vi.stubGlobal("fetch", mockFetch);
+    } as Response);
 
     const adapter = new AtlantaHashBoardAdapter();
     const source = {
@@ -286,5 +291,35 @@ describe("AtlantaHashBoardAdapter", () => {
     } as never;
 
     await expect(adapter.fetch(source)).rejects.toThrow("source.config is null");
+  });
+
+  // Per-source useResidentialProxy flag — origin WAF blocks cloud-egress IPs (#633);
+  // adapter forwards the flag to safeFetch when the source row opts in, else defaults false.
+  it.each([
+    { configValue: true, expectedForwarded: true, label: "true forwards through" },
+    { configValue: undefined, expectedForwarded: false, label: "undefined defaults to false" },
+  ])("useResidentialProxy: $label", async ({ configValue, expectedForwarded }) => {
+    mockSafeFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(SAMPLE_ATOM_FEED),
+    } as Response);
+
+    const adapter = new AtlantaHashBoardAdapter();
+    const config: Record<string, unknown> = {
+      forums: { "2": { kennelTags: ["ah4"], hashDay: "Saturday" } },
+    };
+    if (configValue !== undefined) config.useResidentialProxy = configValue;
+    const source = {
+      id: "test-source",
+      url: "http://board.atlantahash.com",
+      config,
+    } as never;
+
+    await adapter.fetch(source);
+
+    expect(mockSafeFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ useResidentialProxy: expectedForwarded }),
+    );
   });
 });

--- a/src/adapters/html-scraper/atlanta-hash-board.test.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.test.ts
@@ -232,8 +232,8 @@ describe("AtlantaHashBoardAdapter", () => {
       url: "https://board.atlantahash.com",
       config: {
         forums: {
-          "2": { kennelTags: ["ah4"], hashDay: "Saturday" },
-          "8": { kennelTags: ["mlh4"], hashDay: "Monday" },
+          "2": { kennelTag: "ah4", hashDay: "Saturday" },
+          "8": { kennelTag: "mlh4", hashDay: "Monday" },
         },
       },
     } as never;
@@ -255,6 +255,10 @@ describe("AtlantaHashBoardAdapter", () => {
     expect(result.diagnosticContext?.skippedReplies).toBe(2);
     // Each forum has 2 non-reply entries; events within date window should be parsed
     expect(result.events.length).toBeGreaterThan(0);
+    // Attribution check — every event must carry the kennelTag from its forum config
+    const tags = new Set(result.events.flatMap((e) => e.kennelTags));
+    expect(tags.has("ah4") || tags.has("mlh4")).toBe(true);
+    expect(tags.has(undefined as unknown as string)).toBe(false);
   });
 
   it("handles fetch errors gracefully", async () => {
@@ -270,7 +274,7 @@ describe("AtlantaHashBoardAdapter", () => {
       url: "https://board.atlantahash.com",
       config: {
         forums: {
-          "2": { kennelTags: ["ah4"], hashDay: "Saturday" },
+          "2": { kennelTag: "ah4", hashDay: "Saturday" },
         },
       },
     } as never;
@@ -306,7 +310,7 @@ describe("AtlantaHashBoardAdapter", () => {
 
     const adapter = new AtlantaHashBoardAdapter();
     const config: Record<string, unknown> = {
-      forums: { "2": { kennelTags: ["ah4"], hashDay: "Saturday" } },
+      forums: { "2": { kennelTag: "ah4", hashDay: "Saturday" } },
     };
     if (configValue !== undefined) config.useResidentialProxy = configValue;
     const source = {

--- a/src/adapters/html-scraper/atlanta-hash-board.test.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.test.ts
@@ -1,8 +1,8 @@
-vi.mock("../safe-fetch", () => ({
+vi.mock("@/adapters/safe-fetch", () => ({
   safeFetch: vi.fn(),
 }));
 
-import { safeFetch } from "../safe-fetch";
+import { safeFetch } from "@/adapters/safe-fetch";
 import {
   parseAtomFeed,
   isReplyEntry,
@@ -315,7 +315,7 @@ describe("AtlantaHashBoardAdapter", () => {
     if (configValue !== undefined) config.useResidentialProxy = configValue;
     const source = {
       id: "test-source",
-      url: "http://board.atlantahash.com",
+      url: "https://board.atlantahash.com",
       config,
     } as never;
 

--- a/src/adapters/html-scraper/atlanta-hash-board.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.ts
@@ -314,8 +314,14 @@ export class AtlantaHashBoardAdapter implements SourceAdapter {
       { forums: "object" },
     );
 
-    const baseUrl = source.url || "http://board.atlantahash.com";
-    const useResidentialProxy = config.useResidentialProxy ?? false;
+    const baseUrl = source.url || "https://board.atlantahash.com";
+    const rawProxyFlag = config.useResidentialProxy;
+    if (rawProxyFlag !== undefined && typeof rawProxyFlag !== "boolean") {
+      throw new Error(
+        `AtlantaHashBoardAdapter: config.useResidentialProxy must be a boolean, got ${typeof rawProxyFlag}`,
+      );
+    }
+    const useResidentialProxy = rawProxyFlag ?? false;
     const { minDate, maxDate } = buildDateWindow(options?.days);
 
     const allEvents: RawEventData[] = [];

--- a/src/adapters/html-scraper/atlanta-hash-board.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.ts
@@ -24,6 +24,13 @@ interface ForumConfig {
 
 interface AtlantaHashBoardConfig {
   forums: Record<string, ForumConfig>;
+  /**
+   * Route fetches through the NAS residential proxy. The origin WAF blocks
+   * cloud-egress IPs entirely; this flag opts a source into proxy routing.
+   * Not a guaranteed bypass — some residential IPs (including the NAS at
+   * times) are also blocked. (#633)
+   */
+  useResidentialProxy?: boolean;
 }
 
 // ── Atom feed types ──
@@ -307,7 +314,8 @@ export class AtlantaHashBoardAdapter implements SourceAdapter {
       { forums: "object" },
     );
 
-    const baseUrl = source.url || "https://board.atlantahash.com";
+    const baseUrl = source.url || "http://board.atlantahash.com";
+    const useResidentialProxy = config.useResidentialProxy ?? false;
     const { minDate, maxDate } = buildDateWindow(options?.days);
 
     const allEvents: RawEventData[] = [];
@@ -325,6 +333,7 @@ export class AtlantaHashBoardAdapter implements SourceAdapter {
         try {
           const response = await safeFetch(feedUrl, {
             headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+            useResidentialProxy,
           });
           if (!response.ok) {
             return {


### PR DESCRIPTION
## Summary

Cycle 6 of the per-kennel audit (\"chrome-kennel\" deep dive) cleared three profile-bundle issues and built out adapter scaffolding for reviving the Atlanta Hash Board source. The cycle-6 prompt also asked WS1 to make an AH4 lifecycle decision; that part is documented under \"AH4 status\" below — it's NOT being closed by this PR.

- **#1380 Kimchi** — website, FB group, foundedYear, expanded description with Yongsan Kimchi (Korea) lineage
- **#1392 Humpin' (SD)** — contactEmail (HumpinHashCash@gmail.com), hashCash (\$8)
- **#1393 GyNO H3** — fullName rename, schedule fields, foundedYear, expanded description

### Step 0 — prod field-state verification

All target fields verified NULL on prod (kimchi-h3, humpin-sd, gynoh3) before edits. Per WS1 cycle-6 policy, fields stay in the seed for source-of-truth completeness even when prod is already populated (fresh installs get the right value). One field for kimchi-h3 (`description`) and two for gynoh3 (`fullName`, `description`) are non-NULL on prod with the OLD value; the seed merge is fill-only and won't overwrite them, so a one-shot script handles those rewrites — see below.

### One-shot script for fields seed can't update

`scripts/cleanup-cycle6-profile-overrides.ts` rewrites the three fields the seed merge skips:
- `gynoh3.fullName` → \"Gyrls Night Out Hash House Harriers\"
- `gynoh3.description` → expanded blurb
- `kimchi-h3.description` → expanded blurb (Korean lineage)

Each rewrite carries an `expected` current value; the script **refuses to overwrite drift** (e.g. admin curations applied between merge and execution) — addresses /codex:adversarial-review finding. Default mode is dry-run; pass `--execute` to apply.

**Post-merge action required:**
\`\`\`bash
eval \"\$(fnm env)\" && fnm use 20
set -a && source .env && set +a
npx tsx scripts/cleanup-cycle6-profile-overrides.ts            # dry-run (review)
npx tsx scripts/cleanup-cycle6-profile-overrides.ts --execute  # apply to prod
\`\`\`

Tested end-to-end against local Postgres copy of prod, including drift-guard behavior (refuses to overwrite when current value diverges from expected).

## AH4 status (#633 + #638) — NOT closed by this PR

Cycle-6 asked for a lifecycle decision on AH4. Findings:

- DNS resolves, ICMP pings clean (20ms) → the OVH origin is alive
- HTTP/HTTPS from cloud egress: HTTP 000 / 15s timeout
- HTTP via NAS residential proxy: 502 (proxy → origin failed)
- HTTP via NAS browser-render (full browser TLS fingerprint): 502
- Reachable from author's Android phone but not from author's Mac or the NAS

Diagnosis: aggressive WAF blocking that whitelists narrow IP/carrier ranges only. Neither cloud egress nor the NAS residential gateway is currently whitelisted.

**Adapter scaffolding shipped (intentionally not enabled):**
- `atlanta-hash-board.ts`: reads `config.useResidentialProxy` and forwards to `safeFetch`
- 2 new it.each tests verify the flag flows through correctly
- `sources.ts` row UNCHANGED — flipping the flag without a working egress would just exchange HTTP 000 timeouts for HTTP 502s, no net change for cron

This is the cycle-6 prompt's outcome (c) variant: \"replacement found but onboarding requires a new adapter [or working egress]\" → ship the scaffolding, file a follow-up for the gateway problem.

**Follow-ups to file after merge:**

1. Find a working residential gateway for board.atlantahash.com — supersedes #633 + #638
2. Plumb `logoUrl` upload/admin path for kennel profiles (#1380 left logoUrl unfilled — http-only image URL with mixed-content risk)
3. Extend KennelSeed with `gm`, `hareRaiser`, `signatureEvent`, `founder`, `parentKennel` fields (#1392 + #1393 had asks beyond current schema)
4. AH4 kennel website URL audit — HTTP-only website handling policy

## Pre-PR review

- `/simplify` — clean (3 minor refactors applied: it.each test consolidation, drop type cast in cleanup script, soften adapter comment)
- `/codex:adversarial-review` — drift-guard finding applied to cleanup script; other two findings (intentional non-enable + migration vs script) match documented WS1 scope decisions per `.claude/rules/` and cycle-6 prompt outcome catalog

## Scope deviation (cycle-6 prompt)

The cycle-6 prompt scopes WS1 to `prisma/seed-data/*.ts` only, blocking `src/adapters/**`. The Atlanta adapter scaffolding crosses that boundary; the user **explicitly approved the bend** during plan-mode planning. Total adapter delta: 1 interface field, 1 line in fetch(), and a test refactor — small enough that splitting into a separate WS0 PR adds churn without value.

Closes #1380
Closes #1392
Closes #1393

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean (0 errors, 19 unrelated pre-existing warnings)
- [x] \`npm test\` — 6423 passed
- [x] \`npx prisma db seed\` clean against local Postgres copy of prod
- [x] Cleanup script dry-run + execute + idempotency + drift-guard verified
- [x] Three profile pages spot-checked in dev server — new fields render correctly
- [ ] After merge: run \`scripts/cleanup-cycle6-profile-overrides.ts --execute\` against prod
- [ ] After merge: spot-check Kimchi / Humpin' / GyNO H3 kennel pages on prod
- [ ] After merge: file follow-ups 1–4 listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)