### PR TITLE
perf(merge): batch EventLink writes into a single createMany flush

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/lib/db", () => ({
     rawEvent: { findFirst: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
     event: { findUnique: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
     eventKennel: { create: vi.fn(), upsert: vi.fn() },
-    eventLink: { upsert: vi.fn() },
+    eventLink: { upsert: vi.fn(), createMany: vi.fn() },
     kennel: { findUnique: vi.fn(), updateMany: vi.fn() },
     $executeRaw: vi.fn().mockResolvedValue(0),
     $transaction: vi.fn(),
@@ -110,6 +110,13 @@ beforeEach(() => {
   // preceding test would now be consumed by the prefetch instead of the
   // intended caller.
   vi.mocked(prisma.event.findMany).mockReset();
+  // Fingerprint mock impl can leak across tests because `vi.clearAllMocks()`
+  // clears call history but does NOT restore the factory's default. A test
+  // that swaps in a per-event `mockImplementation` (e.g. unique fingerprints
+  // for batch-size assertions) would otherwise poison every subsequent test
+  // that relies on the "fp_abc123" default.
+  mockFingerprint.mockReset();
+  mockFingerprint.mockReturnValue(DEFAULT_MOCK_FINGERPRINT);
   mockSourceFind.mockResolvedValue({
     trustLevel: 5,
     type: "HTML_SCRAPER",
@@ -121,6 +128,7 @@ beforeEach(() => {
   // tests are unaffected; per-test overrides exercise the same-source guard.
   vi.mocked(prisma.rawEvent.findMany).mockResolvedValue([] as never);
   vi.mocked(prisma.eventLink.upsert).mockResolvedValue({} as never);
+  vi.mocked(prisma.eventLink.createMany).mockResolvedValue({ count: 0 } as never);
   mockResolve.mockResolvedValue({ kennelId: "kennel_1", matched: true });
   // recomputeCanonical calls findMany once per successful upsert AFTER the
   // existing disambiguation findMany. Tests queue responses for the first
@@ -847,9 +855,76 @@ describe("double-header support", () => {
     // Cross-source: first time seeing this kennel+date in batch → match existing + create EventLink
     expect(result.updated).toBe(1);
     expect(result.created).toBe(0);
-    expect(vi.mocked(prisma.eventLink.upsert)).toHaveBeenCalledWith(
+    // Batched via end-of-loop createMany (Sentry JAVASCRIPT-NEXTJS-3 follow-up):
+    // exactly one flush call carrying the alternate-source EventLink.
+    expect(vi.mocked(prisma.eventLink.upsert)).not.toHaveBeenCalled();
+    expect(vi.mocked(prisma.eventLink.createMany)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(prisma.eventLink.createMany)).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { eventId_url: { eventId: "evt_1", url: "https://source-b.com/event" } },
+        skipDuplicates: true,
+        data: expect.arrayContaining([
+          expect.objectContaining({ eventId: "evt_1", url: "https://source-b.com/event" }),
+        ]),
+      }),
+    );
+  });
+
+  it("batches EventLink inserts across the batch into a single createMany call (Sentry JAVASCRIPT-NEXTJS-3)", async () => {
+    // 10 fresh events, each carrying 2 unique externalLinks. The pre-fix
+    // path issued one `eventLink.upsert` per link per event (20 round-trips).
+    // The post-fix path queues them all and flushes a single
+    // `eventLink.createMany({ skipDuplicates: true })` after the loop.
+    const N = 10;
+    // Each event gets its own fingerprint so they're all "new" (not dedup
+    // hits), exercising the create-path queueEventLinks call site at
+    // upsertCanonicalEvent. The dedup prefetch (mocked findMany) returns
+    // [] so none of them collide with existing RawEvents.
+    mockFingerprint.mockImplementation((e) => `fp_${e.title ?? "blank"}`);
+    vi.mocked(prisma.rawEvent.findMany).mockResolvedValue([] as never);
+    // `ensureKennelEventCache` returns no existing events on this kennel +
+    // dates so each event takes the create path in `upsertCanonicalEvent`.
+    mockEventFindMany.mockResolvedValue([] as never);
+    const events = Array.from({ length: N }, (_, i) =>
+      buildRawEvent({
+        date: `2026-04-${String(i + 1).padStart(2, "0")}`,
+        title: `Trail ${i}`,
+        sourceUrl: `https://source-a.com/event-${i}`,
+        externalLinks: [
+          { url: `https://meetup.com/event-${i}`, label: "Meetup" },
+          { url: `https://hashrego.com/event-${i}`, label: "Hash Rego" },
+        ],
+      }),
+    );
+    const expectedLinkCount = events.flatMap((e) => e.externalLinks ?? []).length;
+    // Each `event.create` returns a unique id AND its own date so subsequent
+    // events in the batch see a populated cache but `getSameDayEvents`
+    // filters them out by strict Date equality. Omitting the date triggers
+    // the loose-mode filter (test-mock compat) and would silently route 9
+    // of 10 through the update path instead of create.
+    for (let i = 0; i < N; i++) {
+      const eventDate = new Date(`${events[i].date}T12:00:00.000Z`);
+      mockEventCreate.mockResolvedValueOnce({ id: `evt_${i + 1}`, date: eventDate } as never);
+      mockRawEventCreate.mockResolvedValueOnce({ id: `raw_${i + 1}` } as never);
+    }
+
+    const result = await processRawEvents("src_1", events);
+
+    expect(result.created).toBe(N);
+    expect(vi.mocked(prisma.eventLink.upsert)).not.toHaveBeenCalled();
+    expect(vi.mocked(prisma.eventLink.createMany)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(prisma.eventLink.createMany).mock.calls[0][0] as {
+      data: { eventId: string; url: string; label: string; sourceId: string }[];
+      skipDuplicates: boolean;
+    };
+    expect(call.skipDuplicates).toBe(true);
+    expect(call.data).toHaveLength(expectedLinkCount);
+    // Spot-check one entry to confirm shape.
+    expect(call.data).toContainEqual(
+      expect.objectContaining({
+        eventId: "evt_1",
+        url: "https://meetup.com/event-0",
+        label: "Meetup",
+        sourceId: "src_1",
       }),
     );
   });
@@ -3180,10 +3255,15 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
 
     expect(result.updated).toBe(1);
     expect(result.created).toBe(0);
-    // EventLink for the cross-source URL
-    expect(vi.mocked(prisma.eventLink.upsert)).toHaveBeenCalledWith(
+    // EventLink for the cross-source URL — batched via createMany (Sentry
+    // JAVASCRIPT-NEXTJS-3 follow-up).
+    expect(vi.mocked(prisma.eventLink.upsert)).not.toHaveBeenCalled();
+    expect(vi.mocked(prisma.eventLink.createMany)).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { eventId_url: { eventId: "evt_existing", url: "https://hashrego.com/event/123" } },
+        skipDuplicates: true,
+        data: expect.arrayContaining([
+          expect.objectContaining({ eventId: "evt_existing", url: "https://hashrego.com/event/123" }),
+        ]),
       }),
     );
 

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -128,7 +128,7 @@ beforeEach(() => {
   // tests are unaffected; per-test overrides exercise the same-source guard.
   vi.mocked(prisma.rawEvent.findMany).mockResolvedValue([] as never);
   vi.mocked(prisma.eventLink.upsert).mockResolvedValue({} as never);
-  vi.mocked(prisma.eventLink.createMany).mockResolvedValue({ count: 0 } as never);
+  vi.mocked(prisma.eventLink.createMany).mockResolvedValue({ count: 0 });
   mockResolve.mockResolvedValue({ kennelId: "kennel_1", matched: true });
   // recomputeCanonical calls findMany once per successful upsert AFTER the
   // existing disambiguation findMany. Tests queue responses for the first
@@ -903,8 +903,8 @@ describe("double-header support", () => {
     // of 10 through the update path instead of create.
     for (let i = 0; i < N; i++) {
       const eventDate = new Date(`${events[i].date}T12:00:00.000Z`);
-      mockEventCreate.mockResolvedValueOnce({ id: `evt_${i + 1}`, date: eventDate } as never);
-      mockRawEventCreate.mockResolvedValueOnce({ id: `raw_${i + 1}` } as never);
+      mockEventCreate.mockResolvedValueOnce({ id: `evt_${i + 1}`, date: eventDate } as never); // NOSONAR S4325
+      mockRawEventCreate.mockResolvedValueOnce({ id: `raw_${i + 1}` } as never); // NOSONAR S4325
     }
 
     const result = await processRawEvents("src_1", events);

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -244,21 +244,34 @@ const SCHEDULE_DESC_RE = new RegExp(
 const isAdminTitle = (s: string) => ADMIN_TITLE_PATTERNS.some(re => re.test(s));
 
 /**
- * Create EventLink records for an event from externalLinks + alternate sourceUrls.
- * Uses upsert with eventId+url unique key to prevent duplicates.
+ * Queue EventLink inserts for the batch. The post-loop flush in
+ * `processRawEvents` emits a single `createMany({ skipDuplicates: true })`
+ * keyed off the `@@unique([eventId, url])` index — behavior-equivalent to the
+ * prior per-link `upsert` with `update: {}` (no-op on conflict), but one
+ * round-trip instead of N (Sentry JAVASCRIPT-NEXTJS-3 follow-up to #1287).
+ *
+ * In-batch dedup uses a `${eventId}|${url}` key. cuids are alphanumeric, so
+ * the only theoretical collision is a URL containing a literal `|` that
+ * coincidentally matched another entry — vanishingly unlikely, and the DB
+ * `@@unique([eventId, url])` + `skipDuplicates` catches any real duplicate
+ * at flush time anyway.
  */
-async function createEventLinks(
+function queueEventLinks(
   eventId: string,
-  sourceId: string,
-  externalLinks?: { url: string; label: string }[],
-) {
+  externalLinks: { url: string; label: string }[] | undefined,
+  ctx: MergeContext,
+): void {
   if (!externalLinks?.length) return;
   for (const link of externalLinks) {
-    await prisma.eventLink.upsert({
-      where: { eventId_url: { eventId, url: link.url } },
-      create: { eventId, url: link.url, label: link.label, sourceId },
-      update: {}, // No-op if already exists
-    });
+    const key = `${eventId}|${link.url}`;
+    if (!ctx.eventBatch.pendingEventLinks.has(key)) {
+      ctx.eventBatch.pendingEventLinks.set(key, {
+        eventId,
+        url: link.url,
+        label: link.label,
+        sourceId: ctx.sourceId,
+      });
+    }
   }
 }
 
@@ -373,6 +386,11 @@ interface EventBatchState {
   /** Mark-processed buffer: rawEventId → eventId. Flushed as one raw SQL
    *  after the loop (Sentry JAVASCRIPT-NEXTJS-3 — write-side N+1 follow-up). */
   processedRawEvents: Map<string, string>;
+  /** Pending EventLink inserts keyed by `${eventId}|${url}` to dedupe within
+   *  the batch. Flushed as a single `createMany({ skipDuplicates: true })`
+   *  after the per-event loop (Sentry JAVASCRIPT-NEXTJS-3 — EventLink
+   *  write-side N+1 follow-up to #1287). */
+  pendingEventLinks: Map<string, { eventId: string; url: string; label: string; sourceId: string }>;
 }
 
 /** `select` for the dedup prefetch — kept as a hoisted const so the value type
@@ -1479,13 +1497,14 @@ async function upsertCanonicalEvent(
       }
     }
 
-    // If this source provides a different sourceUrl, create an EventLink for it
+    // If this source provides a different sourceUrl, queue an EventLink for it.
+    // Flushed with the rest of the batch via `eventLink.createMany` after the loop.
     if (event.sourceUrl && existingEvent.sourceUrl && event.sourceUrl !== existingEvent.sourceUrl) {
-      await prisma.eventLink.upsert({
-        where: { eventId_url: { eventId: existingEvent.id, url: event.sourceUrl } },
-        create: { eventId: existingEvent.id, url: event.sourceUrl, label: getLabelForUrl(event.sourceUrl), sourceId: ctx.sourceId },
-        update: {},
-      });
+      queueEventLinks(
+        existingEvent.id,
+        [{ url: event.sourceUrl, label: getLabelForUrl(event.sourceUrl) }],
+        ctx,
+      );
     }
 
     // Queue the RawEvent link-to-Event write for the post-loop bulk flush
@@ -1707,7 +1726,7 @@ async function processNewRawEvent(
       rawEvent = winner;
     } else {
       if (!dupId) return null;
-      await createEventLinks(dupId, sourceId, event.externalLinks);
+      queueEventLinks(dupId, event.externalLinks, ctx);
       return dupId;
     }
   }
@@ -1730,7 +1749,7 @@ async function processNewRawEvent(
 
   const targetEventId = await upsertCanonicalEvent(event, kennelId, rawEvent.id, ctx);
   // Mirror DB state into the dedup map *immediately* after upsertCanonicalEvent
-  // marks the RawEvent processed. If a later side-effect (createEventLinks, the
+  // marks the RawEvent processed. If a later side-effect (queueEventLinks, the
   // kennel cache update) throws, the per-event try/catch records the error but
   // the row is already `processed: true` in the DB — keeping map ↔ DB aligned
   // means a later in-batch duplicate still takes the existing-Event branch
@@ -1742,7 +1761,7 @@ async function processNewRawEvent(
     eventId: targetEventId,
   });
 
-  await createEventLinks(targetEventId, sourceId, event.externalLinks);
+  queueEventLinks(targetEventId, event.externalLinks, ctx);
 
   // Track the max event date per kennel — flushed as one batched
   // `kennel.updateMany` per kennel after the loop in `processRawEvents`
@@ -2169,6 +2188,7 @@ export async function processRawEvents(
       fuzzyPoolByKennel: new Map(),
       kennelMaxDates: new Map(),
       processedRawEvents: new Map(),
+      pendingEventLinks: new Map(),
     },
     result,
   };
@@ -2184,7 +2204,7 @@ export async function processRawEvents(
     try {
       const dupResult = await handleDuplicateFingerprint(event, fingerprint, ctx);
       if (dupResult !== false) {
-        if (dupResult) await createEventLinks(dupResult, sourceId, event.externalLinks);
+        if (dupResult) queueEventLinks(dupResult, event.externalLinks, ctx);
         continue;
       }
 
@@ -2230,6 +2250,20 @@ export async function processRawEvents(
       FROM (VALUES ${valuesClause}) AS update_map(id, "eventId")
       WHERE "RawEvent"."id" = update_map.id
     `;
+  }
+
+  // Flush queued EventLink inserts as a single `createMany` keyed off the
+  // `@@unique([eventId, url])` index (Sentry JAVASCRIPT-NEXTJS-3 — EventLink
+  // write-side N+1 follow-up to #1287). One round-trip per scrape replaces
+  // N per-link `upsert({ update: {} })` calls. Rethrows on failure to match
+  // the `processedRawEvents` flush above — QStash auto-retry repairs on
+  // the next attempt and dedup prefetch correctly classifies the second
+  // run as duplicates.
+  if (ctx.eventBatch.pendingEventLinks.size > 0) {
+    await prisma.eventLink.createMany({
+      data: [...ctx.eventBatch.pendingEventLinks.values()],
+      skipDuplicates: true,
+    });
   }
 
   // Flush per-kennel max event dates as a single batched write per kennel


### PR DESCRIPTION
## Summary

- Replaces N per-event `prisma.eventLink.upsert` calls in the scrape pipeline with a per-batch buffer flushed once via `eventLink.createMany({ skipDuplicates: true })` after the per-event loop.
- Drops the redundant `sourceId` param from the new `queueEventLinks` helper (callers all passed `ctx.sourceId`).
- Resets `mockFingerprint` in `beforeEach` so future `mockImplementation` overrides can't bleed across tests (drive-by from authoring the new batching test).

## Why

Sentry [JAVASCRIPT-NEXTJS-3](https://hashtracks.sentry.io/issues/JAVASCRIPT-NEXTJS-3) reports a 40-query N+1 in `POST /api/cron/scrape/[sourceId]` (460 occurrences since 2026-03-30). #1287 / #1288 already collapsed the read-side N+1s (dedup prefetch, per-kennel event cache, kennel data cache, `processedRawEvents` raw-SQL flush, `kennelMaxDates` `updateMany` flush). The remaining contributor was the two `eventLink.upsert` call sites — `createEventLinks` (sequential `await` per link in a for-loop) and the inline upsert in `upsertCanonicalEvent` for the cross-source `sourceUrl` branch. For a typical 10-15 event scrape carrying 1-2 external links each, this collapses 10-30 round-trips into one.

## Behavior equivalence

The pre-fix per-link `upsert` used `update: {}` (no-op on conflict) and discarded the return value, so INSERT-or-skip via `@@unique([eventId, url])` is behavior-equivalent. Flush rethrows on failure to match the `processedRawEvents` flush — QStash auto-retry repairs on the next attempt and dedup prefetch correctly classifies the second run as duplicates.

## Test plan

- [x] `npx tsc --noEmit` (clean)
- [x] `npm run lint` (0 errors)
- [x] `npm test` (6437 tests pass, including the new `batches EventLink inserts across the batch into a single createMany call` assertion for N=10 events × 2 external links → exactly one `createMany` with 20 entries)
- [ ] Post-merge: monitor [JAVASCRIPT-NEXTJS-3](https://hashtracks.sentry.io/issues/JAVASCRIPT-NEXTJS-3) for 48h. Expected: rate drops sharply on external-link-heavy sources (Hash Rego, Meetup). If it keeps firing, the next pass would target per-event `event.create` / `event.update` writes (deferred — batching them loses per-event error isolation).

Closes JAVASCRIPT-NEXTJS-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)