### PR TITLE
feat(travel): Hockessin seasonal migration + Travel Mode seasonality gating (closes #1390)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1107,10 +1107,31 @@ export const KENNELS: KennelSeed[] = [
     },
     // ===== DELAWARE =====
     {
+      // #1390: second kennel migrated to structured `scheduleRules` — Hockessin
+      // is the proving ground for the seasonal-swap case (Wed/summer ↔
+      // Sat/winter). Pass 2 backfill opts out structurally (PR #1405).
       kennelCode: "hockessin", shortName: "Hockessin H3", fullName: "Hockessin Hash House Harriers", region: "Wilmington, DE",
       website: "https://www.hockessinhash.org/",
       logoUrl: "https://www.hockessinhash.org/logo.GIF",
       scheduleFrequency: "Weekly",
+      scheduleRules: [
+        {
+          rrule: "FREQ=WEEKLY;BYDAY=WE",
+          startTime: "18:30",
+          label: "Summer",
+          validFrom: "03-01",
+          validUntil: "10-31",
+          displayOrder: 0,
+        },
+        {
+          rrule: "FREQ=WEEKLY;BYDAY=SA",
+          startTime: "15:00",
+          label: "Winter",
+          validFrom: "11-01",
+          validUntil: "02-28",
+          displayOrder: 1,
+        },
+      ],
       scheduleNotes: "Wednesdays 6:30 PM (summer, ~Mar–Oct); Saturdays 3 PM (winter, ~Nov–Feb). Runs in DE/MD/PA/NJ.",
       hashCash: "$5",
       description: "Delaware's most active hash with 1,656+ trails across the tri-state area.",

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -6,7 +6,7 @@
  * monthly Thu + monthly Fri) where the single legacy schedule slot on Kennel
  * silently misrepresents reality.
  *
- * MM-DD anchors on validFrom/validUntil wrap across years — "11-01" → "02-28" is
+ * MM-DD anchors on validFrom/validUntil wrap across years — "11-01" → "02-29" is
  * the wintertime cadence. Omit a rule for a hiatus period (don't encode hiatus
  * negatively). All fields except `rrule` are optional; only the calendar-rule
  * RRULE shapes the static-schedule adapter parses are accepted here
@@ -1128,7 +1128,7 @@ export const KENNELS: KennelSeed[] = [
           startTime: "15:00",
           label: "Winter",
           validFrom: "11-01",
-          validUntil: "02-28",
+          validUntil: "02-29",
           displayOrder: 1,
         },
       ],

--- a/scripts/inspect-hockessin-orphan-synthetic-events.ts
+++ b/scripts/inspect-hockessin-orphan-synthetic-events.ts
@@ -1,0 +1,141 @@
+/**
+ * Inspect Hockessin H3 (`hockessin`) for ORPHAN synthetic events.
+ *
+ * Background (#1390 + #1394):
+ *   PR #1394 nulled `Kennel.scheduleDayOfWeek` + `scheduleTime` on the
+ *   Hockessin row to defuse a seasonal-cadence time-bomb (the seed had
+ *   hardcoded summer-Wed which would render wrong half the year). PR 3 of
+ *   the multi-cadence rollout migrates Hockessin to structured
+ *   `scheduleRules` (Wed/summer + Sat/winter).
+ *
+ *   Hockessin has NO STATIC_SCHEDULE source — its only source is an
+ *   HTML_SCRAPER that hits hockessinhash.org. The PR #1394 display-only
+ *   change generated zero synthetic events, and the PR 3 structured-rules
+ *   change doesn't drive event generation either (the existing HTML scrape
+ *   continues unchanged).
+ *
+ *   Expected result of this script: ZERO orphan candidates. Documented as
+ *   the no-op proof that the schedule-shape evolution didn't disturb
+ *   historical event records.
+ *
+ * This is a DRY-RUN-ONLY script. It surfaces:
+ *   1. The current set of STATIC_SCHEDULE sources for Hockessin (expect 0).
+ *   2. The count of past Hockessin events partitioned by which source
+ *      generated them — confirms the HTML scrape is the sole origin.
+ *
+ * It does NOT delete anything. If a non-empty STATIC_SCHEDULE source ever
+ * surfaces, the cleanup pass should use `scripts/lib/cascade-delete.ts`
+ * (`cascadeDeleteEvents`).
+ *
+ * Usage:
+ *   npx tsx scripts/inspect-hockessin-orphan-synthetic-events.ts
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const HOCKESSIN_KENNEL_CODE = "hockessin";
+
+async function main() {
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+  try {
+    const kennel = await prisma.kennel.findUnique({
+      where: { kennelCode: HOCKESSIN_KENNEL_CODE },
+      select: { id: true, shortName: true },
+    });
+    if (!kennel) {
+      console.error(`✗ Kennel "${HOCKESSIN_KENNEL_CODE}" not found.`);
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(`━━━ Hockessin H3 (${kennel.shortName}) source-origin audit ━━━`);
+
+    // 1. Look for any STATIC_SCHEDULE sources linked to Hockessin. Expected: 0.
+    const staticSources = await prisma.source.findMany({
+      where: {
+        type: "STATIC_SCHEDULE",
+        kennels: { some: { kennelId: kennel.id } },
+      },
+      select: { id: true, name: true, url: true, enabled: true },
+    });
+
+    console.log(`  STATIC_SCHEDULE sources linked: ${staticSources.length}`);
+    if (staticSources.length === 0) {
+      console.log(`  ✓ No STATIC_SCHEDULE source — display-only schedule changes`);
+      console.log(`    cannot have produced synthetic events.`);
+    } else {
+      console.log(`\n  ⚠ Found STATIC_SCHEDULE source(s) — investigate:`);
+      for (const s of staticSources) {
+        console.log(`    ${s.id}  enabled=${s.enabled}  ${s.name}  ${s.url ?? ""}`);
+      }
+    }
+
+    // 2. Per-source past-event distribution for Hockessin. Restricted to past
+    //    CONFIRMED canonical events so cancelled / duplicate / future-projected
+    //    rows don't pad the histogram.
+    const now = new Date();
+    const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0));
+
+    const hockessinEvents = await prisma.event.findMany({
+      where: {
+        eventKennels: { some: { kennelId: kennel.id } },
+        date: { lt: todayUtc },
+        status: "CONFIRMED",
+        isCanonical: true,
+      },
+      select: { id: true, date: true, rawEvents: { select: { sourceId: true } } },
+    });
+
+    const sourceIdCounts = new Map<string, number>();
+    for (const e of hockessinEvents) {
+      for (const re of e.rawEvents) {
+        sourceIdCounts.set(re.sourceId, (sourceIdCounts.get(re.sourceId) ?? 0) + 1);
+      }
+    }
+    const sourceIds = [...sourceIdCounts.keys()];
+    const sourceMeta = sourceIds.length > 0
+      ? await prisma.source.findMany({
+          where: { id: { in: sourceIds } },
+          select: { id: true, name: true, type: true },
+        })
+      : [];
+    const metaById = new Map(sourceMeta.map((s) => [s.id, s]));
+
+    console.log(`\n  RawEvent counts by source (past CONFIRMED canonical events):`);
+    if (sourceIdCounts.size === 0) {
+      console.log(`    (no RawEvent rows yet — Hockessin events may all be manual entries)`);
+    }
+    for (const [sourceId, count] of sourceIdCounts) {
+      const meta = metaById.get(sourceId);
+      console.log(
+        `    ${(meta?.type ?? "(unknown)").padEnd(20)} ${count.toString().padStart(5)}  ` +
+          `${meta?.name ?? sourceId}`,
+      );
+    }
+
+    console.log(`\n  Total past CONFIRMED canonical Hockessin events: ${hockessinEvents.length}`);
+    if (staticSources.length === 0) {
+      console.log(
+        `  ✓ No-op proof: no STATIC_SCHEDULE source means no synthetic-event\n` +
+          `    origin path; the seed change for #1390 is display-only.`,
+      );
+    } else {
+      console.log(
+        `  ⚠ STATIC_SCHEDULE source(s) detected (see above). Cleanup may be needed —\n` +
+          `    review the linked source(s) and the per-source counts above to decide.`,
+      );
+      process.exitCode = 1;
+    }
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    await Promise.allSettled([prisma.$disconnect(), pool.end()]);
+  }
+}
+
+void main();

--- a/src/lib/schedule-season.test.ts
+++ b/src/lib/schedule-season.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseMonthDay,
   isWithinSeason,
+  windowOverlapsSeason,
   formatSeasonHint,
 } from "./schedule-season";
 
@@ -115,5 +116,45 @@ describe("formatSeasonHint", () => {
   it("ignores malformed anchors (label-only output)", () => {
     expect(formatSeasonHint("Summer", "13-99", null)).toBe("Summer");
     expect(formatSeasonHint(null, "13-99", "99-99")).toBeNull();
+  });
+});
+
+describe("windowOverlapsSeason", () => {
+  const noon = (s: string) => new Date(s + "T12:00:00Z");
+
+  it("returns true when both anchors are null (always-on rule)", () => {
+    expect(windowOverlapsSeason(noon("2026-07-01"), noon("2026-07-31"), null, null)).toBe(true);
+  });
+
+  it("returns true when window contains an in-season day (non-wrapping)", () => {
+    expect(windowOverlapsSeason(noon("2026-07-01"), noon("2026-07-31"), "03-01", "10-31")).toBe(true);
+  });
+
+  it("returns false when window is wholly off-season (non-wrapping)", () => {
+    // Window in December, season is Mar–Oct → no overlap.
+    expect(windowOverlapsSeason(noon("2026-12-01"), noon("2026-12-31"), "03-01", "10-31")).toBe(false);
+  });
+
+  it("returns true when window straddles into the season (wrap-around winter)", () => {
+    // Window Oct 25 → Nov 10 hits winter (Nov–Feb) on Nov 1+.
+    expect(windowOverlapsSeason(noon("2026-10-25"), noon("2026-11-10"), "11-01", "02-29")).toBe(true);
+  });
+
+  it("returns false when window is wholly off-season (wrap-around winter)", () => {
+    // July is mid-summer, season is winter (Nov–Feb) → no overlap.
+    expect(windowOverlapsSeason(noon("2026-07-01"), noon("2026-07-31"), "11-01", "02-29")).toBe(false);
+  });
+
+  it("returns true for windows ≥ 1 year (any season necessarily overlaps)", () => {
+    expect(windowOverlapsSeason(noon("2026-01-01"), noon("2027-01-15"), "11-01", "02-28")).toBe(true);
+  });
+
+  it("returns true for single-day in-season window", () => {
+    // Apr 15 is within Mar–Oct.
+    expect(windowOverlapsSeason(noon("2026-04-15"), noon("2026-04-15"), "03-01", "10-31")).toBe(true);
+  });
+
+  it("returns false for single-day off-season window", () => {
+    expect(windowOverlapsSeason(noon("2026-12-15"), noon("2026-12-15"), "03-01", "10-31")).toBe(false);
   });
 });

--- a/src/lib/schedule-season.ts
+++ b/src/lib/schedule-season.ts
@@ -144,6 +144,37 @@ export function isWithinSeason(
 }
 
 /**
+ * Does the [windowStart, windowEnd] range overlap the [validFrom, validUntil]
+ * MM-DD season? Used by Travel Mode to gate off ENTIRE rules (including
+ * possible-activity LOW-confidence rules that produce no individual dates) when
+ * the search window is wholly out of season. Without this gate, a winter-only
+ * rule with confidence=LOW would emit a date-null "possible activity" entry on
+ * a July search because the per-date filter only fires when there ARE dates.
+ *
+ * When BOTH anchors are null/missing, returns true (always-on rule). When the
+ * window is ≥ 1 year, returns true unconditionally — any season necessarily
+ * overlaps a year-long window. Otherwise walks daily and short-circuits on
+ * first in-season day.
+ */
+export function windowOverlapsSeason(
+  windowStart: Date,
+  windowEnd: Date,
+  validFrom: string | null | undefined,
+  validUntil: string | null | undefined,
+): boolean {
+  if (!validFrom && !validUntil) return true;
+  const ms = windowEnd.getTime() - windowStart.getTime();
+  if (ms >= 366 * 86_400_000) return true;
+  const days = Math.ceil(ms / 86_400_000);
+  for (let i = 0; i <= days; i++) {
+    const d = new Date(windowStart.getTime() + i * 86_400_000);
+    if (d.getTime() > windowEnd.getTime()) break;
+    if (isWithinSeason(d, validFrom, validUntil)) return true;
+  }
+  return false;
+}
+
+/**
  * Format a season hint suitable for display. Examples:
  *   ("Summer", "03-01", "10-31") → "Summer, Mar–Oct"
  *   ("Winter", "11-01", "02-28") → "Winter, Nov–Feb"

--- a/src/lib/travel/projections.test.ts
+++ b/src/lib/travel/projections.test.ts
@@ -562,7 +562,7 @@ describe("projectTrails — seasonal gating (#1390)", () => {
     confidence: "HIGH",
     label: "Winter",
     validFrom: "11-01",
-    validUntil: "02-28",
+    validUntil: "02-29",
   });
 
   it("emits ONLY summer Wednesdays in a July search window", () => {

--- a/src/lib/travel/projections.test.ts
+++ b/src/lib/travel/projections.test.ts
@@ -25,6 +25,9 @@ function makeRule(overrides: Partial<ScheduleRuleInput> = {}): ScheduleRuleInput
     startTime: "14:00",
     confidence: "MEDIUM",
     notes: null,
+    label: null,
+    validFrom: null,
+    validUntil: null,
     ...overrides,
   };
 }
@@ -533,5 +536,112 @@ describe("filterProjectionsByHorizon", () => {
     // trails" copy with a stray Possible row.
     expect(filterProjectionsByHorizon(mixed, "none")).toEqual([]);
     expect(filterProjectionsByHorizon([{ confidence: "low" as const }], "none")).toEqual([]);
+  });
+});
+
+// ============================================================================
+// #1390: seasonal gating — Hockessin Wed/summer ↔ Sat/winter is the proving case
+// ============================================================================
+
+describe("projectTrails — seasonal gating (#1390)", () => {
+  // Hockessin's structured-cadence shape: Wed at 18:30 from Mar 1 → Oct 31,
+  // Sat at 15:00 from Nov 1 → Feb 28.
+  const summerWednesdayRule = makeRule({
+    id: "rule-summer",
+    rrule: "FREQ=WEEKLY;BYDAY=WE",
+    startTime: "18:30",
+    confidence: "HIGH",
+    label: "Summer",
+    validFrom: "03-01",
+    validUntil: "10-31",
+  });
+  const winterSaturdayRule = makeRule({
+    id: "rule-winter",
+    rrule: "FREQ=WEEKLY;BYDAY=SA",
+    startTime: "15:00",
+    confidence: "HIGH",
+    label: "Winter",
+    validFrom: "11-01",
+    validUntil: "02-28",
+  });
+
+  it("emits ONLY summer Wednesdays in a July search window", () => {
+    // July is mid-summer; winter rule should produce zero projections.
+    const projections = projectTrails(
+      [summerWednesdayRule, winterSaturdayRule],
+      utcNoon("2026-07-01"),
+      utcNoon("2026-07-31"),
+    );
+    expect(projections.length).toBeGreaterThan(0);
+    expect(projections.every((p) => p.scheduleRuleId === "rule-summer")).toBe(true);
+    // Every projected date should be a Wednesday (day=3).
+    expect(projections.every((p) => p.date?.getUTCDay() === 3)).toBe(true);
+  });
+
+  it("emits ONLY winter Saturdays in a January search window (wrap-around)", () => {
+    const projections = projectTrails(
+      [summerWednesdayRule, winterSaturdayRule],
+      utcNoon("2026-01-01"),
+      utcNoon("2026-01-31"),
+    );
+    expect(projections.length).toBeGreaterThan(0);
+    expect(projections.every((p) => p.scheduleRuleId === "rule-winter")).toBe(true);
+    expect(projections.every((p) => p.date?.getUTCDay() === 6)).toBe(true);
+  });
+
+  it("emits BOTH cadences in a search window that straddles the season boundary", () => {
+    // Oct 25 → Nov 10 covers the summer-Wed Oct 28 AND the winter-Sat Nov 7.
+    const projections = projectTrails(
+      [summerWednesdayRule, winterSaturdayRule],
+      utcNoon("2026-10-25"),
+      utcNoon("2026-11-10"),
+    );
+    const ruleIds = new Set(projections.map((p) => p.scheduleRuleId));
+    expect(ruleIds.has("rule-summer")).toBe(true);
+    expect(ruleIds.has("rule-winter")).toBe(true);
+  });
+
+  it("includes the season label in the explanation string", () => {
+    const explanation = generateExplanationFromRule(summerWednesdayRule);
+    expect(explanation).toContain("Summer");
+    expect(explanation).toContain("Mar"); // Mar–Oct range
+  });
+
+  it("works for rules with only validFrom (open-ended end)", () => {
+    const openEndedRule = makeRule({
+      rrule: "FREQ=WEEKLY;BYDAY=MO",
+      confidence: "HIGH",
+      validFrom: "06-01",
+      validUntil: null,
+    });
+    // May → before season → no projections
+    const beforeSeason = projectTrails(
+      [openEndedRule],
+      utcNoon("2026-05-01"),
+      utcNoon("2026-05-31"),
+    );
+    expect(beforeSeason).toEqual([]);
+    // July → in season
+    const inSeason = projectTrails(
+      [openEndedRule],
+      utcNoon("2026-07-01"),
+      utcNoon("2026-07-31"),
+    );
+    expect(inSeason.length).toBeGreaterThan(0);
+  });
+
+  it("rules without season anchors continue to project normally", () => {
+    // Pre-PR behavior preservation: a rule with label=null/validFrom=null
+    // emits every occurrence in the window.
+    const noSeasonRule = makeRule({
+      rrule: "FREQ=WEEKLY;BYDAY=SA",
+      confidence: "HIGH",
+    });
+    const projections = projectTrails(
+      [noSeasonRule],
+      utcNoon("2026-07-01"),
+      utcNoon("2026-07-31"),
+    );
+    expect(projections.length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/travel/projections.test.ts
+++ b/src/lib/travel/projections.test.ts
@@ -630,6 +630,64 @@ describe("projectTrails — seasonal gating (#1390)", () => {
     expect(inSeason.length).toBeGreaterThan(0);
   });
 
+  it("skips LOW-confidence rule entirely when window is wholly off-season (Codex P2)", () => {
+    // Winter-only CADENCE sentinel rule (LOW confidence — no date generation).
+    // A July search must NOT emit a date-null "possible activity" entry for it.
+    const winterOnlyLowRule = makeRule({
+      rrule: "CADENCE=BIWEEKLY;BYDAY=SA",
+      confidence: "LOW",
+      notes: "Biweekly without anchor",
+      label: "Winter",
+      validFrom: "11-01",
+      validUntil: "02-28",
+    });
+    const julyProjections = projectTrails(
+      [winterOnlyLowRule],
+      utcNoon("2026-07-01"),
+      utcNoon("2026-07-31"),
+    );
+    expect(julyProjections).toEqual([]);
+  });
+
+  it("still emits LOW-confidence possible-activity when window IS in-season", () => {
+    const winterOnlyLowRule = makeRule({
+      rrule: "CADENCE=BIWEEKLY;BYDAY=SA",
+      confidence: "LOW",
+      notes: "Biweekly without anchor",
+      label: "Winter",
+      validFrom: "11-01",
+      validUntil: "02-28",
+    });
+    const januaryProjections = projectTrails(
+      [winterOnlyLowRule],
+      utcNoon("2026-01-01"),
+      utcNoon("2026-01-31"),
+    );
+    expect(januaryProjections).toHaveLength(1);
+    expect(januaryProjections[0].date).toBeNull();
+    expect(januaryProjections[0].confidence).toBe("low");
+  });
+
+  it("skips interval-without-anchor demoted rules when wholly off-season (Codex P2)", () => {
+    // Biweekly without anchorDate is demoted to LOW inside projectScheduledRule.
+    // The rule-level season gate should catch it BEFORE projectScheduledRule
+    // runs.
+    const winterBiweeklyNoAnchor = makeRule({
+      rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA",
+      confidence: "HIGH",
+      anchorDate: null,
+      label: "Winter",
+      validFrom: "11-01",
+      validUntil: "02-28",
+    });
+    const julyProjections = projectTrails(
+      [winterBiweeklyNoAnchor],
+      utcNoon("2026-07-01"),
+      utcNoon("2026-07-31"),
+    );
+    expect(julyProjections).toEqual([]);
+  });
+
   it("rules without season anchors continue to project normally", () => {
     // Pre-PR behavior preservation: a rule with label=null/validFrom=null
     // emits every occurrence in the window.

--- a/src/lib/travel/projections.ts
+++ b/src/lib/travel/projections.ts
@@ -18,7 +18,11 @@ import {
   generateOccurrences,
 } from "@/adapters/static-schedule/adapter";
 import { formatTime, ordinal } from "@/lib/format";
-import { isWithinSeason, formatSeasonHint } from "@/lib/schedule-season";
+import {
+  isWithinSeason,
+  windowOverlapsSeason,
+  formatSeasonHint,
+} from "@/lib/schedule-season";
 import type { ScheduleConfidence } from "@/generated/prisma/client";
 
 // ============================================================================
@@ -196,6 +200,15 @@ export function projectTrails(
   const results: ProjectedTrail[] = [];
   for (const rule of rules) {
     if (!rule.rrule) continue;
+    // #1390 (Codex review): rule-level season gate. Without this, LOW-confidence
+    // rules (CADENCE sentinels, interval-without-anchor demotions, parse-error
+    // fallbacks) emit a date-null "possible activity" entry regardless of
+    // season — so a winter-only biweekly-without-anchor would show up as
+    // possible in a July search. Gating at the rule level catches every path
+    // before any ProjectedTrail is emitted.
+    if (!windowOverlapsSeason(windowStart, windowEnd, rule.validFrom, rule.validUntil)) {
+      continue;
+    }
     if (rule.confidence === "LOW") {
       results.push(projectAsLowConfidence(rule));
     } else {

--- a/src/lib/travel/projections.ts
+++ b/src/lib/travel/projections.ts
@@ -151,23 +151,25 @@ function projectScheduledRule(
       ? "Based on a known schedule source"
       : "Based on known schedule pattern";
 
+    // #1390: seasonal gating. When the rule carries `validFrom`/`validUntil`
+    // MM-DD anchors, drop any generated date that falls outside the season
+    // (with wrap-around support for winter spans). Without this, a July search
+    // would project Hockessin's winter-Saturday cadence as well as its
+    // summer-Wednesday cadence, double-listing the kennel with the wrong
+    // season's run text. We materialize the Date once, filter, then map — vs.
+    // the previous filter→map which built `new Date(dateStr + "T12:00:00Z")`
+    // twice per occurrence.
+    const hasSeasonality = !!(rule.validFrom || rule.validUntil);
     return dateStrings
-      // #1390: seasonal gating. When the rule carries `validFrom`/`validUntil`
-      // MM-DD anchors, drop any generated date that falls outside the season
-      // (with wrap-around support for winter spans). Without this, a July
-      // search would project Hockessin's winter-Saturday cadence as well as
-      // its summer-Wednesday cadence, double-listing the kennel with the
-      // wrong season's run text.
-      .filter((dateStr) =>
-        isWithinSeason(
-          new Date(dateStr + "T12:00:00Z"),
-          rule.validFrom,
-          rule.validUntil,
-        ),
+      .map((dateStr) => new Date(dateStr + "T12:00:00Z"))
+      .filter(
+        (date) =>
+          !hasSeasonality ||
+          isWithinSeason(date, rule.validFrom, rule.validUntil),
       )
-      .map((dateStr) => ({
+      .map((date) => ({
         kennelId: rule.kennelId,
-        date: new Date(dateStr + "T12:00:00Z"),
+        date,
         startTime: rule.startTime,
         confidence,
         scheduleRuleId: rule.id,

--- a/src/lib/travel/projections.ts
+++ b/src/lib/travel/projections.ts
@@ -18,6 +18,7 @@ import {
   generateOccurrences,
 } from "@/adapters/static-schedule/adapter";
 import { formatTime, ordinal } from "@/lib/format";
+import { isWithinSeason, formatSeasonHint } from "@/lib/schedule-season";
 import type { ScheduleConfidence } from "@/generated/prisma/client";
 
 // ============================================================================
@@ -32,6 +33,14 @@ export interface ScheduleRuleInput {
   startTime: string | null;
   confidence: ScheduleConfidence;
   notes: string | null;
+  // #1390: multi-cadence seasonality. When `validFrom`/`validUntil` are set,
+  // the projection engine emits dates only inside that MM-DD window (with
+  // wrap-around support for winter spans). `label` becomes part of the
+  // explanation so the user sees e.g. "Wednesdays at 6:30 PM (Summer)" on a
+  // July search, not just "Wednesdays at 6:30 PM".
+  label: string | null;
+  validFrom: string | null;
+  validUntil: string | null;
 }
 
 export interface KennelContext {
@@ -142,15 +151,29 @@ function projectScheduledRule(
       ? "Based on a known schedule source"
       : "Based on known schedule pattern";
 
-    return dateStrings.map((dateStr) => ({
-      kennelId: rule.kennelId,
-      date: new Date(dateStr + "T12:00:00Z"),
-      startTime: rule.startTime,
-      confidence,
-      scheduleRuleId: rule.id,
-      explanation,
-      evidenceWindow,
-    }));
+    return dateStrings
+      // #1390: seasonal gating. When the rule carries `validFrom`/`validUntil`
+      // MM-DD anchors, drop any generated date that falls outside the season
+      // (with wrap-around support for winter spans). Without this, a July
+      // search would project Hockessin's winter-Saturday cadence as well as
+      // its summer-Wednesday cadence, double-listing the kennel with the
+      // wrong season's run text.
+      .filter((dateStr) =>
+        isWithinSeason(
+          new Date(dateStr + "T12:00:00Z"),
+          rule.validFrom,
+          rule.validUntil,
+        ),
+      )
+      .map((dateStr) => ({
+        kennelId: rule.kennelId,
+        date: new Date(dateStr + "T12:00:00Z"),
+        startTime: rule.startTime,
+        confidence,
+        scheduleRuleId: rule.id,
+        explanation,
+        evidenceWindow,
+      }));
   } catch {
     // Unparseable rrule — surface as possible activity rather than crashing.
     return [projectAsLowConfidence(rule)];
@@ -457,6 +480,20 @@ export function generateExplanationFromRule(
   // Optional: callers that already parsed the rrule (projectScheduledRule)
   // can pass the result to avoid a second parse. parseRRule is cheap but
   // skipping it is free.
+  parsed?: ReturnType<typeof parseRRule>,
+): string {
+  const base = buildExplanationBody(rule, parsed);
+  // #1390: append a "(Summer, Mar–Oct)" hint when the rule carries seasonality
+  // anchors. Lives outside buildExplanationBody so every explanation path
+  // (sentinel, parsed-rrule, generic-fallback) picks up the hint uniformly.
+  const seasonHint = formatSeasonHint(rule.label, rule.validFrom, rule.validUntil);
+  return seasonHint ? `${base} (${seasonHint})` : base;
+}
+
+/** Internal body of generateExplanationFromRule — split out so the season-hint
+ *  append logic stays out of every branch's tail. */
+function buildExplanationBody(
+  rule: ScheduleRuleInput,
   parsed?: ReturnType<typeof parseRRule>,
 ): string {
   const { rrule, startTime, notes, confidence } = rule;

--- a/src/lib/travel/search.ts
+++ b/src/lib/travel/search.ts
@@ -536,6 +536,11 @@ async function runStopSearch(
     startTime: r.startTime,
     confidence: r.confidence,
     notes: r.notes,
+    // #1390: thread seasonal anchors + label through so projectTrails can gate
+    // by season and surface "(Winter, Nov–Feb)" hints in the explanation.
+    label: r.label,
+    validFrom: r.validFrom,
+    validUntil: r.validUntil,
   }));
   const projections = projectTrails(ruleInputs, startDate, projectionEndDate);
 


### PR DESCRIPTION
## Summary

Third and final PR of the cycle 6 multi-cadence schedule rollout for [#1390](https://github.com/johnrclem/hashtracks-web/issues/1390). **Closes [#1390](https://github.com/johnrclem/hashtracks-web/issues/1390).**

- [PR #1405](https://github.com/johnrclem/hashtracks-web/pull/1405) (merged) — schema + KennelSeed type + backfill Pass 3
- [PR #1430](https://github.com/johnrclem/hashtracks-web/pull/1430) (merged) — Hebe migration + display layer + BYSETPOS guard
- **PR 3 (this)** — Hockessin migration + Travel Mode seasonality gating

## What changed

### Hockessin migration (seasonal Wed/summer ↔ Sat/winter)
- `prisma/seed-data/kennels.ts`: added `scheduleRules`:
  - Wed @ 18:30, `label: "Summer"`, `validFrom: "03-01"`, `validUntil: "10-31"`
  - Sat @ 15:00, `label: "Winter"`, `validFrom: "11-01"`, `validUntil: "02-28"`
- `scheduleFrequency: "Weekly"` stays for filter visibility (KennelDirectory + FilterBar OR-semantics from PR 2).
- `scheduleDayOfWeek` + `scheduleTime` stayed null from the [#1394](https://github.com/johnrclem/hashtracks-web/pull/1394) defuse.

### Travel Mode seasonality gating
- `ScheduleRuleInput` extended with `label` / `validFrom` / `validUntil` (`string | null` to match the project's "no undefined" contract).
- `projectScheduledRule` now filters generated dates through `isWithinSeason(date, validFrom, validUntil)` before building `ProjectedTrail` entries. **July search → summer-Wed only; January → winter-Sat only (wrap-around).**
- `generateExplanationFromRule` appends `(Summer, Mar–Oct)` / `(Winter, Nov–Feb)` via `formatSeasonHint()`. Internally refactored: outer function owns the hint append, internal `buildExplanationBody(rule, parsed?)` owns the sentinel/parsed/generic branching.
- `search.ts` threads the three new fields into `ruleInputs` (the existing `findMany` without `select` already returns all columns).

### Hockessin orphan inspect script (dry-run)
- `scripts/inspect-hockessin-orphan-synthetic-events.ts`: confirms Hockessin has no `STATIC_SCHEDULE` source, so the display-only seed change cannot have produced synthetic events. Per-source RawEvent histogram restricted to past CONFIRMED canonical events. Sets `process.exitCode = 1` if STATIC_SCHEDULE source ever appears so CI surfaces it.

## Tests (6 new in `projections.test.ts`)
- July search → summer-Wed only
- January search → winter-Sat only (wrap-around)
- Straddle window → both cadences emitted
- Open-ended validFrom → before/in-season behavior
- No-season rule → pre-PR behavior preservation
- Explanation string includes label + month range

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | Clean |
| `npm run lint` | Clean (only pre-existing warnings) |
| `npm test` | **6512 pass** (+~7 for seasonal gating) |
| `/codex:adversarial-review` | 3 LOW findings; 2 applied, 1 deferred |
| `/simplify` | 1 MEDIUM applied (`buildExplanationBody` signature collapse) |
| Inspect script (local DB) | 0 `STATIC_SCHEDULE` sources for Hockessin confirmed |

## Codex findings (3 LOW)

| Finding | Action |
|---|---|
| Inspect script "no-op proof" message printed unconditionally even on warning branch | Gated on `staticSources.length === 0`; non-zero sets `process.exitCode = 1` |
| Inspect script source histogram counted cancelled/duplicate/future rows | Added `status: "CONFIRMED"`, `isCanonical: true`, `date: { lt: todayUtc }` filters |
| Malformed `MM-DD` anchors silently treated as missing — fail-loud project value | Deferred — backfill already validates + warns, no admin write path exists yet. Future admin UI should `validateMonthDayAnchor` before persist |

## /simplify findings (1 MEDIUM)

- `buildExplanationBody` 5-param signature (rrule, startTime, notes, confidence, parsed) collapsed to `(rule, parsed?)`. Reuse review confirmed no duplication worth extracting (Hockessin vs Hebe inspect scripts diverge in audit shape, `isWithinSeason` doesn't apply to the STATIC_SCHEDULE event-gen path which uses `BYMONTH` instead, etc.).

## Test plan
- [ ] CI green (`npx tsc --noEmit`, `npm run lint`, `npm test`).
- [ ] Vercel preview: spot-check Hockessin kennel page renders "Wednesdays at 6:30 PM (Summer, Mar–Oct) / Saturdays at 3:00 PM (Winter, Nov–Feb)".
- [ ] Vercel preview: spot-check a Travel Mode search that overlaps Hockessin in July — projection card shows the summer-Wed only, with "(Summer, Mar–Oct)" hint in the explanation.
- [ ] Vercel preview: same search but in November — winter-Sat only.
- [ ] After merge, run `npx tsx scripts/inspect-hockessin-orphan-synthetic-events.ts` against prod — expect "0 STATIC_SCHEDULE sources" and clean exit.

Closes [#1390](https://github.com/johnrclem/hashtracks-web/issues/1390).

🤖 Generated with [Claude Code](https://claude.com/claude-code)