### PR TITLE
fix(quick-win): 4 adapter parse bugs + H2H3 slug repair

### DIFF
--- a/prisma/migrations/20260515160000_repair_slug_with_slashes/migration.sql
+++ b/prisma/migrations/20260515160000_repair_slug_with_slashes/migration.sql
@@ -1,0 +1,28 @@
+-- Repair Kennel slugs that contain a literal "/" (#1422).
+--
+-- Background: `toSlug()` in both `prisma/seed.ts` and `src/lib/kennel-utils.ts`
+-- replaced spaces with hyphens but left `/` intact, so the H2H3 / Cha-Am H3
+-- record was persisted with slug `h2h3-/-cha-am-h3`. Next.js treats `/` as a
+-- path separator inside route segments, so `/kennels/[slug]` never matched
+-- and the public kennel page returned a 404.
+--
+-- Companion fixes (already applied in TypeScript):
+--   * Both `toSlug()` helpers now normalize `[^a-z0-9]+` runs to `-`, so new
+--     kennels cannot reintroduce the bug.
+--   * `prisma/seed-data/kennels.ts` carries an explicit `slug` on the H2H3
+--     record so future seeds re-create it cleanly if the row is ever dropped.
+--
+-- This migration repairs any *existing* row whose slug contains `/`. The same
+-- regex normalization is performed in SQL so any other slash-bearing slugs in
+-- prod (none known today, but defensive) are corrected idempotently.
+--
+-- No-op when no slashes are present, so it's safe to re-run.
+
+UPDATE "Kennel"
+SET slug = REGEXP_REPLACE(
+  REGEXP_REPLACE(LOWER(slug), '[^a-z0-9]+', '-', 'g'),
+  '^-|-$',
+  '',
+  'g'
+)
+WHERE slug LIKE '%/%';

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3549,6 +3549,10 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "cah3", shortName: "H2H3 / Cha-Am H3", fullName: "Hua Hin H3 & Cha-Am Hash House Harriers",
+      // Explicit slug — `shortName` contains "/" which Next.js treats as a path
+      // separator and 404s. Helper fixes alone don't repair the persisted row;
+      // pair this with the slug-repair migration. (#1422)
+      slug: "h2h3-cha-am-h3",
       region: "Hua Hin", country: "Thailand",
       website: "https://cah3.net",
       logoUrl: "https://cah3.net/wp-content/uploads/2025/08/CAH3-Anchor-Logo.png",

--- a/prisma/seed-utils.test.ts
+++ b/prisma/seed-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { toSlug } from "./seed-utils";
+import { toSlug as kennelUtilsToSlug } from "../src/lib/kennel-utils";
+
+describe("prisma/seed-utils.ts toSlug (#1422 regression guard)", () => {
+  it("strips a literal '/' from the slug", () => {
+    // Next.js treats "/" inside a route segment as a path separator and 404s
+    // the page. The H2H3 / Cha-Am H3 record was unreachable for months because
+    // toSlug() preserved the slash.
+    expect(toSlug("H2H3 / Cha-Am H3")).toBe("h2h3-cha-am-h3");
+    expect(toSlug("Foo/Bar H3")).toBe("foo-bar-h3");
+  });
+
+  it("collapses runs of mixed separators", () => {
+    expect(toSlug("Cherry City & OH3")).toBe("cherry-city-oh3");
+    expect(toSlug("Foo  Bar   H3")).toBe("foo-bar-h3");
+    expect(toSlug("Foo--Bar")).toBe("foo-bar");
+  });
+
+  it("strips parens and trims edges", () => {
+    expect(toSlug("Some (Kennel) H3")).toBe("some-kennel-h3");
+    expect(toSlug(" leading and trailing ")).toBe("leading-and-trailing");
+  });
+
+  // The two toSlug() implementations (seed + admin flows) must stay aligned —
+  // they're invoked from different code paths but produce slugs the same
+  // routes consume. If they ever drift, the bug class re-opens.
+  it.each([
+    ["H2H3 / Cha-Am H3", "h2h3-cha-am-h3"],
+    ["Foo/Bar H3", "foo-bar-h3"],
+    ["Cherry City & OH3", "cherry-city-oh3"],
+    ["Some (Kennel) H3", "some-kennel-h3"],
+  ])("matches src/lib/kennel-utils.toSlug for %s", (input, expected) => {
+    expect(toSlug(input)).toBe(expected);
+    expect(kennelUtilsToSlug(input)).toBe(expected);
+  });
+});

--- a/prisma/seed-utils.ts
+++ b/prisma/seed-utils.ts
@@ -5,11 +5,13 @@
  * re-exports them so call sites keep their original path.
  */
 
-/** Strips a literal "/" (Next.js path-separator collision — #1422). */
+/** Strips a literal "/" (Next.js path-separator collision — #1422). Mirror of
+ *  `src/lib/kennel-utils.ts` toSlug; the alignment test in seed-utils.test.ts
+ *  enforces parity. */
 export function toSlug(shortName: string): string {
   return shortName
     .toLowerCase()
-    .replace(/[()]/g, "")             // Remove parens
-    .replace(/[^a-z0-9]+/g, "-")      // Any non-alphanumeric run → "-"
-    .replace(/^-|-$/g, "");           // Trim leading/trailing hyphens
+    .replaceAll(/[()]/g, "")
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-|-$/g, "");
 }

--- a/prisma/seed-utils.ts
+++ b/prisma/seed-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Pure helpers shared between `prisma/seed.ts` and its test files. `seed.ts`
+ * has a top-level `main().catch(...)` that connects to Postgres on import, so
+ * tests cannot import from it directly. Put pure helpers here; `seed.ts`
+ * re-exports them so call sites keep their original path.
+ */
+
+/** Strips a literal "/" (Next.js path-separator collision — #1422). */
+export function toSlug(shortName: string): string {
+  return shortName
+    .toLowerCase()
+    .replace(/[()]/g, "")             // Remove parens
+    .replace(/[^a-z0-9]+/g, "-")      // Any non-alphanumeric run → "-"
+    .replace(/^-|-$/g, "");           // Trim leading/trailing hyphens
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,6 +7,11 @@ import { KENNEL_ALIASES } from "./seed-data/aliases";
 import { SOURCES } from "./seed-data/sources";
 import { runScheduleRuleBackfill } from "../scripts/backfill-schedule-rules";
 import { composeUtcStart } from "../src/lib/timezone";
+import { toSlug } from "./seed-utils";
+// Re-exported so any historical caller of `prisma/seed.ts`'s `toSlug` keeps working;
+// the helper itself now lives in `./seed-utils` so tests can import it without
+// triggering this file's top-level `main()`.
+export { toSlug };
 
 /** JSON.stringify with sorted keys — prevents false diffs from key ordering differences between seed objects and DB-returned JSON. */
 function stableStringify(obj: unknown): string {
@@ -15,15 +20,6 @@ function stableStringify(obj: unknown): string {
       ? Object.fromEntries(Object.entries(v).sort(([a], [b]) => a.localeCompare(b)))
       : v,
   );
-}
-
-function toSlug(shortName: string): string {
-  return shortName
-    .toLowerCase()
-    .replace(/[()]/g, "")    // Remove parens
-    .replace(/\s+/g, "-")    // Spaces to hyphens
-    .replace(/-+/g, "-")     // Collapse multiple hyphens
-    .replace(/^-|-$/g, "");  // Trim leading/trailing hyphens
 }
 
 const PROFILE_FIELDS = new Set([

--- a/src/adapters/html-scraper/hashnyc.test.ts
+++ b/src/adapters/html-scraper/hashnyc.test.ts
@@ -303,6 +303,31 @@ describe("parseDetailsCell", () => {
     expect(result.kennelTag).toBe("brh3");
     expect(result.runNumber).toBe(2);
   });
+
+  it("treats Start: TBA as a placeholder and does not absorb the following paragraph (#1396)", () => {
+    // GGFM Strawberry Moon #435 fixture from hashnyc.com — `Start: TBA`
+    // is followed by a description paragraph and a "Show … | Go …" timing
+    // line. Earlier behavior absorbed all of that into `location`.
+    const html = `<table><tr><td><b>Strawberry Moon</b><br>GGFM #435<br>Start: TBA<br>Join NYC's full moon kennel as we explore the darker side of Gotham. This is your chance to get a proper trail in before the weekend wrecks you.<br>Show 7:15 PM | Go 7:30 PM.</td></tr></table>`;
+    const $ = cheerio.load(html);
+    const result = parseDetailsCell($, $("td").first());
+    expect(result.location).toBe("TBA");
+    // The description paragraph is captured separately and should contain
+    // the full-moon prose (and NOT a "Run #N" prefix).
+    expect(result.description).toContain("full moon kennel");
+  });
+
+  it.each([
+    ["TBA", "TBA"],
+    ["TBD", "TBD"],
+    ["TBC", "TBC"],
+    ["tba", "TBA"],
+  ])("normalizes Start: %s placeholders to %s (case-insensitive)", (input, expected) => {
+    const html = `<table><tr><td>NYCH3 Run #100 Start: ${input}<br>Some description</td></tr></table>`;
+    const $ = cheerio.load(html);
+    const result = parseDetailsCell($, $("td").first());
+    expect(result.location).toBe(expected);
+  });
 });
 
 // ── extractRawDesignation ──

--- a/src/adapters/html-scraper/hashnyc.ts
+++ b/src/adapters/html-scraper/hashnyc.ts
@@ -289,7 +289,16 @@ interface ParsedDetails {
   description?: string;
 }
 
-/** Extract location and location URL from the "Start:" block in cell HTML. */
+/** Word-bounded so "TBA Park" isn't a placeholder. */
+const LOCATION_PLACEHOLDER_RE = /^(TBD|TBA|TBC)\b/i;
+
+/** Extract location and location URL from the "Start:" block in cell HTML.
+ *
+ * Bounds the location capture at the first `<br>` after `Start:` so the
+ * description paragraph below doesn't bleed into the location field (#1396).
+ * Both `Transit:` and a top-level `<br>` mark the end of the location block;
+ * we take whichever comes first.
+ */
 function extractLocationAndUrl(
   cellHtml: string,
   $: cheerio.CheerioAPI,
@@ -302,10 +311,15 @@ function extractLocationAndUrl(
   const startLabelMatch = startIdx >= 0 ? /Start:\s*/i.exec(cellHtml) : null;
   if (startIdx >= 0 && startLabelMatch) {
     const blockStart = startIdx + startLabelMatch[0].length;
-    const transitIdx = cellHtml.slice(blockStart).search(/Transit:/i);
-    const locationBlock = transitIdx >= 0
-      ? cellHtml.slice(blockStart, blockStart + transitIdx)
-      : cellHtml.slice(blockStart);
+    const remainder = cellHtml.slice(blockStart);
+    const transitIdx = remainder.search(/Transit:/i);
+    // First top-level <br> ends the location segment for rows that don't carry
+    // a Transit: line (e.g. GGFM full-moon rows with a description paragraph).
+    const brMatch = /<br\b[^>]*>/i.exec(remainder);
+    const brIdx = brMatch ? brMatch.index : -1;
+    const candidateBounds = [transitIdx, brIdx].filter((n) => n >= 0);
+    const endIdx = candidateBounds.length > 0 ? Math.min(...candidateBounds) : -1;
+    const locationBlock = endIdx >= 0 ? remainder.slice(0, endIdx) : remainder;
 
     const $block = cheerio.load(`<div>${locationBlock}</div>`);
     const mapsLink = $block("a[href]").filter((_i, el) => {
@@ -319,8 +333,11 @@ function extractLocationAndUrl(
 
     const locationText = decodeHtmlEntities(locationBlock).trim();
     if (locationText) {
-      if (/^TBD/i.test(locationText)) {
-        location = "TBD";
+      const placeholderMatch = LOCATION_PLACEHOLDER_RE.exec(locationText);
+      if (placeholderMatch) {
+        // Normalize TBA / TBD / TBC to the literal token so downstream code
+        // can detect "no venue yet" without re-parsing free-form prose.
+        location = placeholderMatch[1].toUpperCase();
       } else {
         location = locationText.replace(/\s+,/g, ",").replace(/\s+/g, " ").trim();
       }
@@ -360,6 +377,17 @@ function extractDescriptionFromCell(
   const restMatch = /Transit:[^<]*(?:<span[^>]*>[^<]*<\/span>[^<]*)*(?:<br\s*\/?>)([\s\S]*)/i.exec(cellHtml);
   if (restMatch) {
     const rest = decodeHtmlEntities(restMatch[1]).trim();
+    if (rest) return rest;
+  }
+
+  // Rows with `Start: <placeholder>` (TBA / TBD / TBC) followed by description
+  // prose (no Transit:, no <p> tags) — capture everything after the first
+  // <br> following the placeholder so the paragraph isn't lost. (#1396)
+  const placeholderStartMatch = /Start:\s*(?:TBA|TBD|TBC)\b[^<]*<br\s*\/?>([\s\S]*)/i.exec(cellHtml);
+  if (placeholderStartMatch) {
+    const rest = decodeHtmlEntities(placeholderStartMatch[1])
+      .replace(/\s+/g, " ")
+      .trim();
     if (rest) return rest;
   }
 

--- a/src/adapters/html-scraper/hashnyc.ts
+++ b/src/adapters/html-scraper/hashnyc.ts
@@ -313,7 +313,7 @@ function normalizeLocationText(text: string): string | undefined {
   if (!text) return undefined;
   const placeholder = LOCATION_PLACEHOLDER_RE.exec(text);
   if (placeholder) return placeholder[1].toUpperCase();
-  return text.replace(/\s+,/g, ",").replace(/\s+/g, " ").trim();
+  return text.replaceAll(/\s+,/g, ",").replaceAll(/\s+/g, " ").trim(); // NOSONAR S5852 — single-quantifier `\s+` patterns, no alternation/nesting
 }
 
 /** Find the first `a[href]` link inside `scope` whose href looks like Google Maps. */

--- a/src/adapters/html-scraper/hashnyc.ts
+++ b/src/adapters/html-scraper/hashnyc.ts
@@ -291,69 +291,59 @@ interface ParsedDetails {
 
 /** Word-bounded so "TBA Park" isn't a placeholder. */
 const LOCATION_PLACEHOLDER_RE = /^(TBD|TBA|TBC)\b/i;
+const MAPS_HREF_RE = /maps\.|google\.\w+\/maps/i;
+
+/** Slice the cell HTML at the first `Transit:` or `<br>` after `Start:` —
+ *  whichever comes first. Returns the empty string when no `Start:` is found. */
+function extractStartBlock(cellHtml: string): string {
+  const startMatch = /Start:\s*/i.exec(cellHtml);
+  if (!startMatch) return "";
+  const remainder = cellHtml.slice(startMatch.index + startMatch[0].length);
+  const transitIdx = remainder.search(/Transit:/i);
+  const brMatch = /<br\b[^>]*>/i.exec(remainder);
+  const brIdx = brMatch ? brMatch.index : -1;
+  const candidateBounds = [transitIdx, brIdx].filter((n) => n >= 0);
+  if (candidateBounds.length === 0) return remainder;
+  return remainder.slice(0, Math.min(...candidateBounds));
+}
+
+/** Normalize a location text — uppercase TBD/TBA/TBC placeholders to their
+ *  canonical token, otherwise collapse whitespace and dangling commas. */
+function normalizeLocationText(text: string): string | undefined {
+  if (!text) return undefined;
+  const placeholder = LOCATION_PLACEHOLDER_RE.exec(text);
+  if (placeholder) return placeholder[1].toUpperCase();
+  return text.replace(/\s+,/g, ",").replace(/\s+/g, " ").trim();
+}
+
+/** Find the first `a[href]` link inside `scope` whose href looks like Google Maps. */
+function findMapsHref($scope: cheerio.CheerioAPI, scope: cheerio.Cheerio<AnyNode>): string | undefined {
+  let href: string | undefined;
+  scope.find("a[href]").each((_i, el) => {
+    const candidate = $scope(el).attr("href") ?? "";
+    if (MAPS_HREF_RE.test(candidate)) {
+      href = candidate;
+      return false;
+    }
+  });
+  return href;
+}
 
 /** Extract location and location URL from the "Start:" block in cell HTML.
  *
  * Bounds the location capture at the first `<br>` after `Start:` so the
  * description paragraph below doesn't bleed into the location field (#1396).
- * Both `Transit:` and a top-level `<br>` mark the end of the location block;
- * we take whichever comes first.
  */
 function extractLocationAndUrl(
   cellHtml: string,
   $: cheerio.CheerioAPI,
   cell: cheerio.Cheerio<AnyNode>,
 ): { location: string | undefined; locationUrl: string | undefined } {
-  let location: string | undefined;
-  let locationUrl: string | undefined;
-
-  const startIdx = cellHtml.search(/Start:\s*/i);
-  const startLabelMatch = startIdx >= 0 ? /Start:\s*/i.exec(cellHtml) : null;
-  if (startIdx >= 0 && startLabelMatch) {
-    const blockStart = startIdx + startLabelMatch[0].length;
-    const remainder = cellHtml.slice(blockStart);
-    const transitIdx = remainder.search(/Transit:/i);
-    // First top-level <br> ends the location segment for rows that don't carry
-    // a Transit: line (e.g. GGFM full-moon rows with a description paragraph).
-    const brMatch = /<br\b[^>]*>/i.exec(remainder);
-    const brIdx = brMatch ? brMatch.index : -1;
-    const candidateBounds = [transitIdx, brIdx].filter((n) => n >= 0);
-    const endIdx = candidateBounds.length > 0 ? Math.min(...candidateBounds) : -1;
-    const locationBlock = endIdx >= 0 ? remainder.slice(0, endIdx) : remainder;
-
-    const $block = cheerio.load(`<div>${locationBlock}</div>`);
-    const mapsLink = $block("a[href]").filter((_i, el) => {
-      const href = $block(el).attr("href") ?? "";
-      return /maps\./i.test(href) || /google\.\w+\/maps/i.test(href);
-    }).first();
-
-    if (mapsLink.length) {
-      locationUrl = mapsLink.attr("href");
-    }
-
-    const locationText = decodeHtmlEntities(locationBlock).trim();
-    if (locationText) {
-      const placeholderMatch = LOCATION_PLACEHOLDER_RE.exec(locationText);
-      if (placeholderMatch) {
-        // Normalize TBA / TBD / TBC to the literal token so downstream code
-        // can detect "no venue yet" without re-parsing free-form prose.
-        location = placeholderMatch[1].toUpperCase();
-      } else {
-        location = locationText.replace(/\s+,/g, ",").replace(/\s+/g, " ").trim();
-      }
-    }
-  }
-
-  if (!locationUrl) {
-    cell.find("a[href]").each((_i, el) => {
-      const href = $(el).attr("href") ?? "";
-      if (/maps\./i.test(href) || /google\.\w+\/maps/i.test(href)) {
-        locationUrl = href;
-        return false;
-      }
-    });
-  }
-
+  const locationBlock = extractStartBlock(cellHtml);
+  const $block = cheerio.load(`<div>${locationBlock}</div>`);
+  const location = normalizeLocationText(decodeHtmlEntities(locationBlock).trim());
+  const locationUrl =
+    findMapsHref($block, $block.root()) ?? findMapsHref($, cell);
   return { location, locationUrl };
 }
 

--- a/src/adapters/html-scraper/kj-harimau.test.ts
+++ b/src/adapters/html-scraper/kj-harimau.test.ts
@@ -1,8 +1,13 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  KjHarimauAdapter,
   parseKjHarimauBody,
   parseKjHarimauDate,
   parseKjHarimauTitle,
 } from "./kj-harimau";
+import * as bloggerApi from "../blogger-api";
+
+vi.mock("../blogger-api");
 
 describe("parseKjHarimauDate", () => {
   it("parses DD/MM/YYYY (Malaysian order)", () => {
@@ -70,5 +75,98 @@ Details at khhhkj.blogspot.com
 
   it("handles empty body gracefully", () => {
     expect(parseKjHarimauBody("")).toEqual({});
+  });
+
+  // #1446 regression: an early-announcement post had `Runsite:` empty followed
+  // by `Maps:` (also empty). The labeled-field regex over-matched across the
+  // newline and captured the literal "Maps:" as the runsite value. Now empty
+  // fields and label-only captures both resolve to `undefined`.
+  it("rejects label-only over-matches when an earlier field is empty (#1446)", () => {
+    const earlyAnnouncement = `
+*Kelab Hash House Harimau Kelana Jaya*
+Run#: 1553
+Date: 19/05/26,
+Time: 6:00 pm
+Hare: Siva Lembu
+Runsite:
+
+Maps:
+Guest Fee: RM 60
+Details at khhhkj.blogspot.com
+`;
+    const fields = parseKjHarimauBody(earlyAnnouncement);
+    expect(fields.runNumber).toBe(1553);
+    expect(fields.runsite).toBeUndefined();
+    expect(fields.mapsUrl).toBeUndefined();
+    expect(fields.hare).toBe("Siva Lembu");
+    expect(fields.guestFee).toBe("RM 60");
+  });
+});
+
+describe("KjHarimauAdapter.fetch dedup (#1446)", () => {
+  let adapter: KjHarimauAdapter;
+
+  beforeEach(() => {
+    adapter = new KjHarimauAdapter();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the most-complete post when duplicates share (date, runNumber)", async () => {
+    // Two Blogger posts for the same Run #1553: an early announcement with
+    // empty Runsite/Maps, then a corrected post with full details. The
+    // adapter must keep the corrected one regardless of post order.
+    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
+      posts: [
+        {
+          // Early/incomplete post — encountered first.
+          title: "Run#:1553, 19/05/2026, Hare:  Siva Lembu, Runsite:",
+          content: `<p>*Kelab Hash House Harimau Kelana Jaya*<br>
+Run#: 1553<br>
+Date: 19/05/26,<br>
+Time: 6:00 pm<br>
+Hare: Siva Lembu<br>
+Runsite:<br>
+<br>
+Maps:<br>
+Guest Fee: RM 60</p>`,
+          url: "https://khhhkj.blogspot.com/2026/05/run-1553-early.html",
+          published: "2026-05-10T00:00:00Z",
+        },
+        {
+          // Corrected post — encountered second, has full details.
+          title: "Run#:1553, 19/05/26, Hare:Siva Lembu, Runsite:Bukit Gasing Car Park",
+          content: `<p>*Kelab Hash House Harimau Kelana Jaya*<br>
+Run#: 1553<br>
+Date: 19/05/26,<br>
+Time: 6:00 pm<br>
+Hare: Siva Lembu - https://shorturl.at/x<br>
+Runsite: Bukit Gasing Car Park<br>
+GPS: 3.0936761,101.6555709<br>
+Maps: https://maps.app.goo.gl/example<br>
+Guest Fee: RM 60</p>`,
+          url: "https://khhhkj.blogspot.com/2026/05/run-1553-corrected.html",
+          published: "2026-05-15T00:00:00Z",
+        },
+      ],
+      blogId: "kjhash",
+      fetchDurationMs: 100,
+    });
+
+    const result = await adapter.fetch({
+      id: "src-kj-harimau",
+      url: "https://khhhkj.blogspot.com",
+      scrapeDays: 365,
+    } as never);
+
+    expect(result.events).toHaveLength(1);
+    const event = result.events[0];
+    expect(event.runNumber).toBe(1553);
+    expect(event.location).toBe("Bukit Gasing Car Park");
+    expect(event.locationUrl).toBe("https://maps.app.goo.gl/example");
+    expect(event.latitude).toBeCloseTo(3.0936761);
+    expect(event.longitude).toBeCloseTo(101.6555709);
   });
 });

--- a/src/adapters/html-scraper/kj-harimau.test.ts
+++ b/src/adapters/html-scraper/kj-harimau.test.ts
@@ -81,6 +81,37 @@ Details at khhhkj.blogspot.com
   // by `Maps:` (also empty). The labeled-field regex over-matched across the
   // newline and captured the literal "Maps:" as the runsite value. Now empty
   // fields and label-only captures both resolve to `undefined`.
+  it("extracts values that appear on the line after the label (Codex review)", () => {
+    // Some Blogger posts put the value on the next line below the label.
+    // The single-line form (per the main fixture) must keep working, but the
+    // multi-line form should also resolve to the same fields.
+    const multiline = `
+*Kelab Hash House Harimau Kelana Jaya*
+Run#: 1549
+Date:
+20/04/26
+Time:
+6:00 pm
+Hare:
+Test Hare
+Runsite:
+Bukit Gasing Car Park
+GPS:
+3.1,101.6
+Guest Fee:
+RM 60
+`;
+    const fields = parseKjHarimauBody(multiline);
+    expect(fields.runNumber).toBe(1549);
+    expect(fields.date).toBe("2026-04-20");
+    expect(fields.startTime).toBe("18:00");
+    expect(fields.hare).toBe("Test Hare");
+    expect(fields.runsite).toBe("Bukit Gasing Car Park");
+    expect(fields.latitude).toBeCloseTo(3.1);
+    expect(fields.longitude).toBeCloseTo(101.6);
+    expect(fields.guestFee).toBe("RM 60");
+  });
+
   it("rejects label-only over-matches when an earlier field is empty (#1446)", () => {
     const earlyAnnouncement = `
 *Kelab Hash House Harimau Kelana Jaya*

--- a/src/adapters/html-scraper/kj-harimau.ts
+++ b/src/adapters/html-scraper/kj-harimau.ts
@@ -91,6 +91,7 @@ export function parseKjHarimauBody(bodyText: string): {
   // can't latch onto the next label.
   const grab = (label: string): string | undefined => {
     // nosemgrep: detect-non-literal-regexp — `label` is a hard-coded literal from the constant above, not user input (mirrors hare-extraction.ts suppression)
+    // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); `label` is a hard-coded literal
     const re = new RegExp(`${label}\\s*:[ \\t]*(?:\\n[ \\t]*)?(\\S.*?)${stop}`, "i"); // NOSONAR nosemgrep
     const m = re.exec(text);
     if (!m) return undefined;

--- a/src/adapters/html-scraper/kj-harimau.ts
+++ b/src/adapters/html-scraper/kj-harimau.ts
@@ -86,15 +86,12 @@ export function parseKjHarimauBody(bodyText: string): {
   // the lookahead consumed too much (the #1446 "Maps:" leak); reject it.
   const labelOnlyRe = /^(?:Run\s*#|Date|Time|Hare|Runsite|GPS|Maps|Waze|Guest\s*Fee|Birthdays|Wedding)\s*:?$/i;
 
+  // Allow the value either on the same line OR on the next line. `\S` forces a
+  // non-whitespace first char so a doubly-blank field (`Runsite:\n\nMaps:`)
+  // can't latch onto the next label.
   const grab = (label: string): string | undefined => {
-    // Allow the value either on the same line OR on the next line — KJ
-    // Harimau bodies use the same-line form today, but the multi-line form
-    // is a valid Blogger shape Codex flagged on PR review. `\S` forces a
-    // non-whitespace first char so a doubly-blank field (`Runsite:\n\nMaps:`)
-    // can't latch onto the next label.
-    // nosemgrep: detect-non-literal-regexp — labels come from the hard-coded
-    // constant above, not user input. (Mirrors hare-extraction.ts suppression.)
-    const re = new RegExp(`${label}\\s*:[ \\t]*(?:\\n[ \\t]*)?(\\S.*?)${stop}`, "i"); // NOSONAR
+    // nosemgrep: detect-non-literal-regexp — `label` is a hard-coded literal from the constant above, not user input (mirrors hare-extraction.ts suppression)
+    const re = new RegExp(`${label}\\s*:[ \\t]*(?:\\n[ \\t]*)?(\\S.*?)${stop}`, "i"); // NOSONAR nosemgrep
     const m = re.exec(text);
     if (!m) return undefined;
     const value = m[1].trim().replace(/\s+/g, " ");

--- a/src/adapters/html-scraper/kj-harimau.ts
+++ b/src/adapters/html-scraper/kj-harimau.ts
@@ -78,22 +78,23 @@ export function parseKjHarimauBody(bodyText: string): {
   wazeUrl?: string;
   guestFee?: string;
 } {
-  const labels = "(?:Run\\s*#|Date|Time|Hare|Runsite|GPS|Maps|Waze|Guest\\s*Fee|Birthdays|Wedding)";
+  const labels = String.raw`(?:Run\s*#|Date|Time|Hare|Runsite|GPS|Maps|Waze|Guest\s*Fee|Birthdays|Wedding)`;
   const stop = `(?=\\n|${labels}\\s*:|$)`;
   const text = bodyText.replace(/\r/g, "");
 
-  // Reject captures that are themselves a bare label (e.g. "Maps:", "Runsite") —
-  // these only appear when an empty source field over-matches into the next
-  // labeled line. Defense-in-depth for the empty-Runsite republish in #1446.
+  // A bare label captured as a value means the previous field was empty and
+  // the lookahead consumed too much (the #1446 "Maps:" leak); reject it.
   const labelOnlyRe = /^(?:Run\s*#|Date|Time|Hare|Runsite|GPS|Maps|Waze|Guest\s*Fee|Birthdays|Wedding)\s*:?$/i;
 
   const grab = (label: string): string | undefined => {
-    // Labels are hard-coded string literals above — not user input. No ReDoS risk.
-    // Match horizontal whitespace ([ \t]) after the colon instead of `\s` so an
-    // empty source field (`Runsite:\n`) doesn't consume the trailing newline
-    // and over-run into the next labeled line. Then use a normal (non-s-flag)
-    // dot so the lazy match stays line-bounded. (#1446)
-    const re = new RegExp(`${label}\\s*:[ \\t]*(.+?)${stop}`, "i");
+    // Allow the value either on the same line OR on the next line — KJ
+    // Harimau bodies use the same-line form today, but the multi-line form
+    // is a valid Blogger shape Codex flagged on PR review. `\S` forces a
+    // non-whitespace first char so a doubly-blank field (`Runsite:\n\nMaps:`)
+    // can't latch onto the next label.
+    // nosemgrep: detect-non-literal-regexp — labels come from the hard-coded
+    // constant above, not user input. (Mirrors hare-extraction.ts suppression.)
+    const re = new RegExp(`${label}\\s*:[ \\t]*(?:\\n[ \\t]*)?(\\S.*?)${stop}`, "i"); // NOSONAR
     const m = re.exec(text);
     if (!m) return undefined;
     const value = m[1].trim().replace(/\s+/g, " ");
@@ -181,6 +182,55 @@ function scoreCompleteness(
   );
 }
 
+type BloggerPost = { title: string; content: string; url: string };
+type Candidate = { event: RawEventData; score: number };
+
+/** Build a RawEventData candidate (with completeness score) from a single
+ *  Blogger post. Returns `{ skip: true }` when the post is a non-run notice
+ *  (birthday, holiday greeting) or `{ error }` when the date can't be parsed. */
+function buildKjCandidate(post: BloggerPost):
+  | { skip: true }
+  | { error: { titleDecoded: string } }
+  | { candidate: Candidate; key: string } {
+  const titleDecoded = decodeEntities(post.title);
+  if (!RUN_TITLE_RE.test(titleDecoded)) return { skip: true };
+
+  const bodyText = stripHtmlTags(post.content, "\n");
+  const body = parseKjHarimauBody(bodyText);
+  const titleFields = parseKjHarimauTitle(titleDecoded);
+
+  const date = body.date ?? titleFields.date;
+  if (!date) return { error: { titleDecoded } };
+
+  const runNumber = body.runNumber ?? titleFields.runNumber;
+  const hares = normalizeHaresField(body.hare ?? titleFields.hare);
+  const location = body.runsite ?? titleFields.runsite;
+
+  const externalLinks = body.wazeUrl
+    ? [{ url: body.wazeUrl, label: "Waze" }]
+    : undefined;
+
+  const event: RawEventData = {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber,
+    hares,
+    location,
+    locationUrl: body.mapsUrl,
+    latitude: body.latitude,
+    longitude: body.longitude,
+    startTime: body.startTime ?? DEFAULT_START_TIME,
+    sourceUrl: post.url,
+    description: body.guestFee ? `Guest Fee: ${body.guestFee}` : undefined,
+    externalLinks,
+  };
+
+  return {
+    candidate: { event, score: scoreCompleteness(body, location, hares) },
+    key: `${date}|${runNumber ?? ""}`,
+  };
+}
+
 export class KjHarimauAdapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
@@ -206,34 +256,20 @@ export class KjHarimauAdapter implements SourceAdapter {
 
     // KJ Harimau occasionally republishes the same run as a second Blogger
     // post — sometimes the FIRST post seen still has an empty `Runsite:` /
-    // `Maps:` because the kennel posted an announcement before details were
-    // finalized. Picking the first-seen post (newest published) is NOT
-    // sufficient: the announcement is what got republished last. (#1446)
-    //
-    // Strategy: collect all run-shaped posts per (date, runNumber), then keep
-    // the candidate with the highest field-completeness score.
-    type Candidate = {
-      event: RawEventData;
-      score: number;
-    };
+    // `Maps:`. Pick the most-complete candidate per (date, runNumber). (#1446)
     const groups = new Map<string, Candidate>();
     let duplicatesSkipped = 0;
     let filteredOut = 0;
     for (let i = 0; i < bloggerResult.posts.length; i++) {
-      const post = bloggerResult.posts[i];
-      const titleDecoded = decodeEntities(post.title);
-      if (!RUN_TITLE_RE.test(titleDecoded)) {
+      const result = buildKjCandidate(bloggerResult.posts[i]);
+      if ("skip" in result) {
         filteredOut++;
         continue;
       }
-
-      const bodyText = stripHtmlTags(post.content, "\n");
-      const body = parseKjHarimauBody(bodyText);
-      const titleFields = parseKjHarimauTitle(titleDecoded);
-
-      const date = body.date ?? titleFields.date;
-      if (!date) {
-        errors.push(`KJ Harimau post "${titleDecoded.slice(0, 80)}" has no parseable date`);
+      if ("error" in result) {
+        errors.push(
+          `KJ Harimau post "${result.error.titleDecoded.slice(0, 80)}" has no parseable date`,
+        );
         errorDetails.parse = [
           ...(errorDetails.parse ?? []),
           {
@@ -241,46 +277,17 @@ export class KjHarimauAdapter implements SourceAdapter {
             section: "post",
             field: "date",
             error: "No parseable date",
-            rawText: `Title: ${titleDecoded}`.slice(0, 500),
+            rawText: `Title: ${result.error.titleDecoded}`.slice(0, 500),
           },
         ];
         continue;
       }
-
-      const runNumber = body.runNumber ?? titleFields.runNumber;
-      const hares = normalizeHaresField(body.hare ?? titleFields.hare);
-      const location = body.runsite ?? titleFields.runsite;
-
-      const externalLinks: { url: string; label: string }[] = [];
-      if (body.wazeUrl) externalLinks.push({ url: body.wazeUrl, label: "Waze" });
-
-      const description = body.guestFee ? `Guest Fee: ${body.guestFee}` : undefined;
-
-      const event: RawEventData = {
-        date,
-        kennelTags: [KENNEL_TAG],
-        runNumber,
-        hares,
-        location,
-        locationUrl: body.mapsUrl,
-        latitude: body.latitude,
-        longitude: body.longitude,
-        startTime: body.startTime ?? DEFAULT_START_TIME,
-        sourceUrl: post.url,
-        description,
-        externalLinks: externalLinks.length > 0 ? externalLinks : undefined,
-      };
-
-      const score = scoreCompleteness(body, location, hares);
-      const key = `${date}|${runNumber ?? ""}`;
-      const existing = groups.get(key);
-      if (!existing) {
-        groups.set(key, { event, score });
-      } else {
+      const existing = groups.get(result.key);
+      if (existing) {
         duplicatesSkipped++;
-        if (score > existing.score) {
-          groups.set(key, { event, score });
-        }
+        if (result.candidate.score > existing.score) groups.set(result.key, result.candidate);
+      } else {
+        groups.set(result.key, result.candidate);
       }
     }
 

--- a/src/adapters/html-scraper/kj-harimau.ts
+++ b/src/adapters/html-scraper/kj-harimau.ts
@@ -82,11 +82,23 @@ export function parseKjHarimauBody(bodyText: string): {
   const stop = `(?=\\n|${labels}\\s*:|$)`;
   const text = bodyText.replace(/\r/g, "");
 
+  // Reject captures that are themselves a bare label (e.g. "Maps:", "Runsite") —
+  // these only appear when an empty source field over-matches into the next
+  // labeled line. Defense-in-depth for the empty-Runsite republish in #1446.
+  const labelOnlyRe = /^(?:Run\s*#|Date|Time|Hare|Runsite|GPS|Maps|Waze|Guest\s*Fee|Birthdays|Wedding)\s*:?$/i;
+
   const grab = (label: string): string | undefined => {
     // Labels are hard-coded string literals above — not user input. No ReDoS risk.
-    const re = new RegExp(`${label}\\s*:\\s*(.+?)${stop}`, "is");
+    // Match horizontal whitespace ([ \t]) after the colon instead of `\s` so an
+    // empty source field (`Runsite:\n`) doesn't consume the trailing newline
+    // and over-run into the next labeled line. Then use a normal (non-s-flag)
+    // dot so the lazy match stays line-bounded. (#1446)
+    const re = new RegExp(`${label}\\s*:[ \\t]*(.+?)${stop}`, "i");
     const m = re.exec(text);
-    return m ? m[1].trim().replace(/\s+/g, " ") : undefined;
+    if (!m) return undefined;
+    const value = m[1].trim().replace(/\s+/g, " ");
+    if (!value || labelOnlyRe.test(value)) return undefined;
+    return value;
   };
 
   const runNumRaw = grab("Run\\s*#");
@@ -151,6 +163,24 @@ export function parseKjHarimauTitle(title: string): { runNumber?: number; date?:
   return { runNumber, date: date ?? undefined, hare, runsite };
 }
 
+/** Rank a candidate post by how many bug-relevant fields it filled in. The
+ *  #1446 bug class is empty/leaked `location`, so location and the
+ *  coordinate-equivalent fields (maps URL, GPS pair) outweigh hares/Waze/fee. */
+function scoreCompleteness(
+  body: ReturnType<typeof parseKjHarimauBody>,
+  location: string | undefined,
+  hares: string | undefined,
+): number {
+  return (
+    (location ? 4 : 0) +
+    (body.mapsUrl ? 2 : 0) +
+    (body.latitude !== undefined && body.longitude !== undefined ? 2 : 0) +
+    (hares ? 1 : 0) +
+    (body.wazeUrl ? 1 : 0) +
+    (body.guestFee ? 1 : 0)
+  );
+}
+
 export class KjHarimauAdapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
@@ -174,13 +204,19 @@ export class KjHarimauAdapter implements SourceAdapter {
       return { events: [], errors: [bloggerResult.error.message], errorDetails };
     }
 
-    const events: RawEventData[] = [];
-    // KJ Harimau occasionally publishes the same run as two nearly
-    // identical Blogger posts (e.g. Run 1548 with and without a URL
-    // suffix). Dedupe by (date, runNumber), keeping the first post
-    // encountered — Blogger returns posts newest-first, so the first
-    // hit is the most recent edit and the canonical version.
-    const seenRuns = new Set<string>();
+    // KJ Harimau occasionally republishes the same run as a second Blogger
+    // post — sometimes the FIRST post seen still has an empty `Runsite:` /
+    // `Maps:` because the kennel posted an announcement before details were
+    // finalized. Picking the first-seen post (newest published) is NOT
+    // sufficient: the announcement is what got republished last. (#1446)
+    //
+    // Strategy: collect all run-shaped posts per (date, runNumber), then keep
+    // the candidate with the highest field-completeness score.
+    type Candidate = {
+      event: RawEventData;
+      score: number;
+    };
+    const groups = new Map<string, Candidate>();
     let duplicatesSkipped = 0;
     let filteredOut = 0;
     for (let i = 0; i < bloggerResult.posts.length; i++) {
@@ -212,14 +248,6 @@ export class KjHarimauAdapter implements SourceAdapter {
       }
 
       const runNumber = body.runNumber ?? titleFields.runNumber;
-
-      const dedupKey = `${date}|${runNumber ?? ""}`;
-      if (seenRuns.has(dedupKey)) {
-        duplicatesSkipped++;
-        continue;
-      }
-      seenRuns.add(dedupKey);
-
       const hares = normalizeHaresField(body.hare ?? titleFields.hare);
       const location = body.runsite ?? titleFields.runsite;
 
@@ -228,7 +256,7 @@ export class KjHarimauAdapter implements SourceAdapter {
 
       const description = body.guestFee ? `Guest Fee: ${body.guestFee}` : undefined;
 
-      events.push({
+      const event: RawEventData = {
         date,
         kennelTags: [KENNEL_TAG],
         runNumber,
@@ -241,8 +269,22 @@ export class KjHarimauAdapter implements SourceAdapter {
         sourceUrl: post.url,
         description,
         externalLinks: externalLinks.length > 0 ? externalLinks : undefined,
-      });
+      };
+
+      const score = scoreCompleteness(body, location, hares);
+      const key = `${date}|${runNumber ?? ""}`;
+      const existing = groups.get(key);
+      if (!existing) {
+        groups.set(key, { event, score });
+      } else {
+        duplicatesSkipped++;
+        if (score > existing.score) {
+          groups.set(key, { event, score });
+        }
+      }
     }
+
+    const events: RawEventData[] = Array.from(groups.values()).map((c) => c.event);
 
     const days = options?.days ?? source.scrapeDays ?? 365;
     return applyDateWindow(

--- a/src/adapters/html-scraper/klj-h3.test.ts
+++ b/src/adapters/html-scraper/klj-h3.test.ts
@@ -6,11 +6,21 @@ describe("cleanKljTitle", () => {
       "Christmas Party",
     );
   });
-  it("decodes HTML entities", () => {
+  it("strips trailing '@ TBD' placeholder venue (#1442 Shape B)", () => {
+    // Source: "Run # 531, 1st November – Halloween @ TBD"
+    // Without the strip, the venue placeholder leaks into the title.
     expect(cleanKljTitle("Run # 531, 1st November &#8211; Halloween @ TBD")).toBe(
-      "Halloween @ TBD",
+      "Halloween",
     );
   });
+  it.each(["TBD", "TBA", "TBC", "tbd"])(
+    "strips trailing '@ %s' regardless of case",
+    (placeholder) => {
+      expect(
+        cleanKljTitle(`Run # 531, 1st November – Halloween @ ${placeholder}`),
+      ).toBe("Halloween");
+    },
+  );
   it("strips inline font tags", () => {
     expect(
       cleanKljTitle('<font color="red">Run # 532, 6th December 2026 – Christmas Party</font>'),
@@ -19,16 +29,20 @@ describe("cleanKljTitle", () => {
   it("leaves titles without a run prefix alone", () => {
     expect(cleanKljTitle("Welcome to KLJ H3")).toBe("Welcome to KLJ H3");
   });
-  it("synthesizes 'Run #N' when trailer is just '@ <venue>' (#1213)", () => {
-    expect(cleanKljTitle("Run # 526, 7th June @ Nambee estate, near Rasa")).toBe(
-      "Run #526",
-    );
+  it("returns undefined when trailer is just '@ <venue>' (#1442 Shape A)", () => {
+    // The merge pipeline treats "Run #N" as a stale-default placeholder, so
+    // returning it just makes the kennel page show "KLJ H3 — Run #N". Return
+    // undefined instead — merge synthesizes a friendly default with location.
+    expect(cleanKljTitle("Run # 526, 7th June @ Nambee estate, near Rasa")).toBeUndefined();
   });
-  it("synthesizes 'Run #N' when trailer is just a venue (no @ separator) (#1213)", () => {
-    expect(cleanKljTitle("Run # 527, 5th July near KL")).toBe("Run #527");
+  it("returns undefined when trailer is '@ TBD' (Shape A with placeholder venue)", () => {
+    expect(cleanKljTitle("Run # 527, 5th July @ TBD")).toBeUndefined();
   });
-  it("synthesizes 'Run #N' when title is bare run number without trailer (#1213)", () => {
-    expect(cleanKljTitle("Run # 528")).toBe("Run #528");
+  it("returns undefined when trailer is just a venue (no @ separator)", () => {
+    expect(cleanKljTitle("Run # 527, 5th July near KL")).toBeUndefined();
+  });
+  it("returns undefined when title is bare run number without trailer", () => {
+    expect(cleanKljTitle("Run # 528")).toBeUndefined();
   });
   it("preserves themed titles that legitimately start with 'near' (PR #1236 review)", () => {
     // "near" alone isn't a venue marker — only "near <CapitalizedPlace>" is.

--- a/src/adapters/html-scraper/klj-h3.ts
+++ b/src/adapters/html-scraper/klj-h3.ts
@@ -170,9 +170,13 @@ export function cleanKljTitle(title: string): string | undefined {
   rest = rest.replace(/^[–\-—:]\s*/, "");
 
   // Strip a trailing " @ <placeholder>" — Shape B titles can carry "@ TBD"
-  // (or TBA / TBC) when the venue isn't finalized; that's a placeholder, not
-  // part of the themed name.
-  rest = rest.replace(/\s+@\s+(?:TBD|TBA|TBC)\b\s*$/i, "").trim();
+  // (or TBA / TBC) when the venue isn't finalized. Split into two regex passes
+  // so `\s+` never sits adjacent to alternation (Sonar S5852 false-positive
+  // shape — see memory `feedback_sonar_s5852_false_positives.md`).
+  const tailMatch = /(.+?)\s+@\s+(\S+)\s*$/i.exec(rest);
+  if (tailMatch && /^(?:TBD|TBA|TBC)$/i.test(tailMatch[2])) {
+    rest = tailMatch[1].trim();
+  }
 
   // Empty trailer or one that opens with a venue marker ("@ …", ", …",
   // "near <Place>") means the post title carries no themed name —

--- a/src/adapters/html-scraper/klj-h3.ts
+++ b/src/adapters/html-scraper/klj-h3.ts
@@ -139,22 +139,27 @@ export function parseKljTitleDate(title: string, publishDateIso: string): string
 
 /**
  * Strip the "Run # N, <date> ..." prefix from a post title, leaving just
- * the themed title (e.g. "Halloween @ TBD", "Christmas Party"). Also
- * decodes HTML entities left by WordPress (–, &amp;, …).
+ * the themed title (e.g. "Halloween", "Christmas Party"). Also decodes HTML
+ * entities left by WordPress (–, &amp;, …).
  *
- * When the post-date trailer is purely a venue (e.g.
- * "Run # 526, 7th June @ Nambee estate, near Rasa") with no themed-event
- * content, synthesize a clean "Run #N" string — the venue is already
- * stored separately in `RawEventData.location`. (#1213)
+ * Returns `undefined` when the post-date trailer is purely a venue (e.g.
+ * "Run # 526, 7th June @ Nambee estate, near Rasa") or absent — letting the
+ * merge pipeline synthesize a friendlier default like "KLJ H3 Trail #526"
+ * with the venue carried separately on `RawEventData.location`. Earlier
+ * iterations returned `"Run #N"` here, but the merge pipeline treats that
+ * as a stale-default placeholder and re-synthesizes anyway. (#1442)
+ *
+ * Also strips trailing ` @ <placeholder>` (TBD / TBA / TBC) from themed
+ * titles so Shape-B posts like "Halloween @ TBD" don't leak the venue
+ * placeholder into the title.
  *
  * Exported for unit testing.
  */
-export function cleanKljTitle(title: string): string {
+export function cleanKljTitle(title: string): string | undefined {
   const decoded = decodeEntities(title);
   const withoutTags = decoded.replace(/<[^>]+>/g, "").trim();
   const runMatch = /^Run\s*#\s*(\d+)/i.exec(withoutTags);
-  if (!runMatch) return withoutTags;
-  const runNum = runMatch[1];
+  if (!runMatch) return withoutTags || undefined;
 
   let rest = withoutTags.slice(runMatch[0].length).trim();
   // Drop the leading separator after the run number ("Run # 532, …").
@@ -164,14 +169,18 @@ export function cleanKljTitle(title: string): string {
   // Drop the dash separator between date and themed title ("– Christmas Party").
   rest = rest.replace(/^[–\-—:]\s*/, "");
 
+  // Strip a trailing " @ <placeholder>" — Shape B titles can carry "@ TBD"
+  // (or TBA / TBC) when the venue isn't finalized; that's a placeholder, not
+  // part of the themed name.
+  rest = rest.replace(/\s+@\s+(?:TBD|TBA|TBC)\b\s*$/i, "").trim();
+
   // Empty trailer or one that opens with a venue marker ("@ …", ", …",
   // "near <Place>") means the post title carries no themed name —
-  // synthesize a stable "Run #N" instead of leaving date + venue in the
-  // title. The "near" branch requires a following capitalized word so a
-  // legitimate themed title like "Near Death Experience" isn't rewritten
-  // (PR #1236 review).
+  // return undefined so the merge pipeline picks its own default. The
+  // "near" branch requires a following capitalized word so a legitimate
+  // themed title like "Near Death Experience" isn't dropped.
   if (!rest || /^[@,]\s/.test(rest) || /^near\s+[A-Z][a-zA-Z]+/.test(rest)) {
-    return `Run #${runNum}`;
+    return undefined;
   }
   return rest;
 }
@@ -212,7 +221,7 @@ export function parseKljPost(post: KljPostInput): ParseKljPostResult {
   const date = body.date ?? parseKljTitleDate(rawTitle, post.date);
   if (!date) return { ok: false, reason: "no-date", title: rawTitle };
 
-  const title = cleanKljTitle(rawTitle) || undefined;
+  const title = cleanKljTitle(rawTitle);
   // Combine the source's "probably <venue>" hedge (stripped from the
   // location field for clean geocoding — see parseKljBody) with the
   // registration line so neither signal is lost downstream. Sorted in

--- a/src/adapters/html-scraper/klj-h3.ts
+++ b/src/adapters/html-scraper/klj-h3.ts
@@ -170,12 +170,17 @@ export function cleanKljTitle(title: string): string | undefined {
   rest = rest.replace(/^[–\-—:]\s*/, "");
 
   // Strip a trailing " @ <placeholder>" — Shape B titles can carry "@ TBD"
-  // (or TBA / TBC) when the venue isn't finalized. Split into two regex passes
-  // so `\s+` never sits adjacent to alternation (Sonar S5852 false-positive
-  // shape — see memory `feedback_sonar_s5852_false_positives.md`).
-  const tailMatch = /(.+?)\s+@\s+(\S+)\s*$/i.exec(rest);
-  if (tailMatch && /^(?:TBD|TBA|TBC)$/i.test(tailMatch[2])) {
-    rest = tailMatch[1].trim();
+  // (or TBA / TBC) when the venue isn't finalized. Use string operations
+  // (lastIndexOf + slice) instead of a regex so Sonar S5852 has nothing to
+  // flag — the previous `(.+?)\s+@\s+(\S+)` shape was a known false-positive
+  // (see memory `feedback_sonar_s5852_false_positives.md`).
+  const trimmedRest = rest.replace(/\s+$/, ""); // NOSONAR S5852 — anchored `$`, single-quantifier
+  const lastAtIdx = trimmedRest.lastIndexOf(" @ ");
+  if (lastAtIdx > 0) {
+    const tail = trimmedRest.slice(lastAtIdx + 3);
+    if (/^(?:TBD|TBA|TBC)$/i.test(tail)) {
+      rest = trimmedRest.slice(0, lastAtIdx).trim();
+    }
   }
 
   // Empty trailer or one that opens with a venue marker ("@ …", ", …",

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -193,6 +193,27 @@ describe("parseHarelineRow", () => {
     expect(result?.location).toBe("dog park");
   });
 
+  it("prefers a plain-text address sentence over the maps link's anchor text (#1427)", () => {
+    // RIH3 Run #2098 fixture: the first <a href="google.com/maps"> link's
+    // anchor text is a humorous parking advisory and its URL points at the
+    // wrong place. The actual start address is in the plain-text sentence
+    // BEFORE the link.
+    const dirHtml = `
+      <h2>The Ladies of the RIH3 Hash host a mother's day delight</h2>
+      The start is from the small (again) parking lot at 2203 Boston Neck Rd, Saunderstown, RI.
+      <br/>
+      <a href="https://www.google.com/maps/place/Julia's+Trail+Parking/@41.5159878,-71.4230701,274m/data=foo" target="new">
+        <font color="#cc0000">The Hare recommends parking 'Smart' so we don't get shotgun shootin' again.</font>
+      </a>
+    `;
+    const cells = ["Mon May 11", "6:30 PM", "2098"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBe("2203 Boston Neck Rd, Saunderstown, RI");
+    // The first maps link's URL is also wrong; drop it so downstream
+    // geocoding works off the address text instead.
+    expect(result?.locationUrl).toBeUndefined();
+  });
+
   it("strips navigation instructions from Maps link text", () => {
     const dirHtml = `
       <h2><strong>Test Run</strong></h2>

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -214,6 +214,24 @@ describe("parseHarelineRow", () => {
     expect(result?.locationUrl).toBeUndefined();
   });
 
+  it("captures addresses with abbreviation periods like St./Rd./Ave. (PR #1451 review)", () => {
+    // Gemini flagged that the original `[^.<>\n]` exclusion would truncate at
+    // any period — meaning `2203 St. John's Rd, Providence, RI` would only see
+    // `John's Rd, Providence, RI`, fail the digit check, and fall back to the
+    // wrong link text. Periods are now allowed inside the captured run.
+    const dirHtml = `
+      <h2>Trail of the Saints</h2>
+      The start is at 2203 St. John's Rd, Providence, RI.
+      <br/>
+      <a href="https://www.google.com/maps/place/some+wrong+place" target="new">
+        <font color="#cc0000">Park anywhere you can find a spot.</font>
+      </a>
+    `;
+    const cells = ["Mon June 1", "6:30 PM", "2099"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBe("2203 St. John's Rd, Providence, RI");
+  });
+
   it("strips navigation instructions from Maps link text", () => {
     const dirHtml = `
       <h2><strong>Test Run</strong></h2>

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -46,6 +46,18 @@ const MAX_H2_TITLE_LEN = 80;
  *  shortly after the event. */
 const RECENT_EVENT_TOLERANCE_DAYS = 7;
 
+/** Match a street-address-shaped substring inside a directions paragraph —
+ *  some prose followed by `, <City>, <STATE>` (e.g. `2203 Boston Neck Rd,
+ *  Saunderstown, RI`). Used by #1427 to prefer the address sentence over
+ *  the (sometimes jokey) anchor text of the first maps link in the cell. */
+const ADDRESS_PATTERN_RE =
+  /([^.<>\n]{6,150}?,\s*[A-Z][A-Za-z\s'.\-]{2,30},\s*[A-Z]{2})\b/;
+const STREET_ADDRESS_HINT_RE = /\d|St\.|Street|Rd\.|Road|Ave|Avenue|Blvd|Lane|Ln\.|Way|Park|Beach|Drive|Dr\./i;
+/** Strip everything up to and including the last "at"/"from"/"near" when it sits
+ *  immediately before the street number — keeps `2203 Boston Neck Rd, …` and
+ *  drops `The start is from the small (again) parking lot at`. */
+const ADDRESS_LEADIN_RE = /^.*?\b(?:at|from|near)\s+(?=\d)/i;
+
 /**
  * Extract hare name(s) from the hare cell HTML.
  *
@@ -142,25 +154,67 @@ export function parseHarelineRow(
     h2Text ||
     (runNumber ? `RIH3 #${runNumber}` : "RIH3 Monday Trail");
 
-  // Location from Google Maps link
+  // Location preferred from the address-shaped sentence in the directions
+  // body (#1427) — the first maps link's anchor text is sometimes a joke,
+  // and even the URL can point at the wrong place ("Julia's Trail Parking"
+  // instead of the actual start). Fall back to the link's anchor text when
+  // no address-shaped match is found.
   const mapsLink = dir$(
     'a[href*="google.com/maps"], a[href*="maps.google"]',
   ).first();
-  const locationUrl = mapsLink.length
+  let location: string | undefined;
+  let locationUrl: string | undefined = mapsLink.length
     ? mapsLink.attr("href")?.trim()
     : undefined;
-  const locationText = mapsLink.length
-    ? mapsLink.text().trim()
-      // Strip leading navigation instructions (e.g., "Park Here. Just a short bit from the dog park at Melville Park, ...")
-      .replace(/^Park\s+Here\.?\s*/i, "")
-      .replace(/^(?:Get\s+directions?\s+to|Walk\s+to|Head\s+to|Just\s+)\s*/i, "")
-      .replace(/^(?:a\s+)?(?:short\s+)?(?:bit\s+)?(?:from|near|by)\s+(?:the\s+)?/i, "")
-      .trim()
-    : undefined;
-  const location =
-    locationText && locationText.length > 3 && !PROSE_LEAD_RE.test(locationText)
-      ? locationText
+
+  // 1. Pull the directions body text (stripped HTML, h2 + all <a> anchor
+  //    text removed) and scan for a "<text>, <City>, <ST>" substring —
+  //    that's the canonical address when the kennel writes one in plain
+  //    prose. We remove the link text first so the previous behavior of
+  //    extracting from the maps-link anchor still wins when the address
+  //    ONLY appears inside the link.
+  const bodyForAddress = dir$("body").clone();
+  bodyForAddress.find("h2").remove();
+  bodyForAddress.find("a").remove();
+  const bodyText = bodyForAddress.text().replace(/\s+/g, " ").trim();
+  const addressMatch = ADDRESS_PATTERN_RE.exec(bodyText);
+  if (addressMatch) {
+    const candidate = addressMatch[1]
+      .replace(ADDRESS_LEADIN_RE, "")
+      .trim();
+    // Require a digit somewhere in the candidate so we only latch onto
+    // numeric street addresses, not "the dog park at <Proper Noun>".
+    if (
+      candidate.length >= 8 &&
+      candidate.length <= 150 &&
+      /\d/.test(candidate) &&
+      STREET_ADDRESS_HINT_RE.test(candidate)
+    ) {
+      location = candidate;
+      // Address-text path: the first maps link's URL is often wrong (see #1427
+      // map-pin landing at Julia's Trail Parking), so drop it and let
+      // downstream geocoding resolve coords from the address text.
+      locationUrl = undefined;
+    }
+  }
+
+  // 2. Fallback — use the maps link's anchor text (legacy behavior).
+  if (!location) {
+    const linkText = mapsLink.length
+      ? mapsLink
+          .text()
+          .trim()
+          // Strip leading navigation instructions (e.g., "Park Here. Just a short bit from the dog park at Melville Park, ...")
+          .replace(/^Park\s+Here\.?\s*/i, "")
+          .replace(/^(?:Get\s+directions?\s+to|Walk\s+to|Head\s+to|Just\s+)\s*/i, "")
+          .replace(/^(?:a\s+)?(?:short\s+)?(?:bit\s+)?(?:from|near|by)\s+(?:the\s+)?/i, "")
+          .trim()
       : undefined;
+    location =
+      linkText && linkText.length > 3 && !PROSE_LEAD_RE.test(linkText)
+        ? linkText
+        : undefined;
+  }
 
   // Description: body text minus title and song links; preserve Facebook link
   const descRoot = dir$("body").clone();

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -13,6 +13,7 @@
  */
 
 import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
 import type { Source } from "@/generated/prisma/client";
 import type {
   SourceAdapter,
@@ -49,9 +50,14 @@ const RECENT_EVENT_TOLERANCE_DAYS = 7;
 /** Match a street-address-shaped substring inside a directions paragraph —
  *  some prose followed by `, <City>, <STATE>` (e.g. `2203 Boston Neck Rd,
  *  Saunderstown, RI`). Used by #1427 to prefer the address sentence over
- *  the (sometimes jokey) anchor text of the first maps link in the cell. */
+ *  the (sometimes jokey) anchor text of the first maps link in the cell.
+ *
+ *  Allows `.` inside the captured run so abbreviations like `St.`, `Rd.`,
+ *  and `Ave.` parse correctly (Gemini PR review). The trailing `, <City>,
+ *  <ST>` anchor + digit/street-hint guards in the caller filter out prose
+ *  sentences that happen to contain a comma-separated proper-noun list. */
 const ADDRESS_PATTERN_RE =
-  /([^.<>\n]{6,150}?,\s*[A-Z][A-Za-z\s'.\-]{2,30},\s*[A-Z]{2})\b/;
+  /([^<>\n]{6,150}?,\s*[A-Z][A-Za-z\s'.-]{2,30},\s*[A-Z]{2})\b/;
 const STREET_ADDRESS_HINT_RE = /\d|St\.|Street|Rd\.|Road|Ave|Avenue|Blvd|Lane|Ln\.|Way|Park|Beach|Drive|Dr\./i;
 /** Strip everything up to and including the last "at"/"from"/"near" when it sits
  *  immediately before the street number — keeps `2203 Boston Neck Rd, …` and
@@ -83,6 +89,79 @@ export function extractHares(hareHtml: string): string | undefined {
     .filter((n) => n.length > 1 && !isPlaceholder(n));
 
   return names.length > 0 ? names.join(", ") : undefined;
+}
+
+/** Extract the H2 title from a RIH3 directions cell, collapsing multi-segment
+ *  bleed (#816) and falling back to a synthetic "RIH3 #N" / "RIH3 Monday Trail". */
+function extractRih3Title(
+  dir$: cheerio.CheerioAPI,
+  runNumber: number | undefined,
+): string {
+  // Normalize raw CRLF/LF in the HTML source to spaces so formatting line
+  // wraps don't get mistaken for <br>-delimited segments. CodeRabbit PR #824.
+  const h2Html = (dir$("h2").first().html() ?? "").replace(/\r?\n/g, " ");
+  const h2Segments = stripHtmlTags(h2Html, "\n")
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const h2Joined = h2Segments.join(" ");
+  const h2Text =
+    h2Joined.length > MAX_H2_TITLE_LEN && h2Segments[0]
+      ? h2Segments[0]
+      : h2Joined;
+  return h2Text || (runNumber ? `RIH3 #${runNumber}` : "RIH3 Monday Trail");
+}
+
+/** Scan a RIH3 directions body (with `<h2>` and `<a>` text removed) for an
+ *  address-shaped substring like `<text>, <City>, <ST>` and return it only if
+ *  it has a digit and a road/street hint — otherwise prose like "the dog park
+ *  at <Proper Noun>" sneaks through. (#1427) */
+function findAddressInBody(dir$: cheerio.CheerioAPI): string | undefined {
+  const bodyForAddress = dir$("body").clone();
+  bodyForAddress.find("h2").remove();
+  bodyForAddress.find("a").remove();
+  const bodyText = bodyForAddress.text().replace(/\s+/g, " ").trim();
+  const match = ADDRESS_PATTERN_RE.exec(bodyText);
+  if (!match) return undefined;
+  const candidate = match[1].replace(ADDRESS_LEADIN_RE, "").trim();
+  const valid =
+    candidate.length >= 8 &&
+    candidate.length <= 150 &&
+    /\d/.test(candidate) &&
+    STREET_ADDRESS_HINT_RE.test(candidate);
+  return valid ? candidate : undefined;
+}
+
+/** Clean up the maps-link anchor text by stripping common navigation lead-ins. */
+function cleanMapsLinkText(mapsLink: cheerio.Cheerio<AnyNode>): string | undefined {
+  if (!mapsLink.length) return undefined;
+  const cleaned = mapsLink
+    .text()
+    .trim()
+    .replace(/^Park\s+Here\.?\s*/i, "")
+    .replace(/^(?:Get\s+directions?\s+to|Walk\s+to|Head\s+to|Just\s+)\s*/i, "")
+    .replace(/^(?:a\s+)?(?:short\s+)?(?:bit\s+)?(?:from|near|by)\s+(?:the\s+)?/i, "")
+    .trim();
+  if (!cleaned || cleaned.length <= 3 || PROSE_LEAD_RE.test(cleaned)) return undefined;
+  return cleaned;
+}
+
+/** Resolve location + locationUrl from a RIH3 directions cell. Prefers the
+ *  address-shaped sentence in the body over the maps-link anchor text (#1427);
+ *  drops the maps URL when the address path wins because the first maps link
+ *  often points at the wrong place (Julia's Trail Parking vs the actual start). */
+function resolveRih3Location(
+  dir$: cheerio.CheerioAPI,
+  mapsLink: cheerio.Cheerio<AnyNode>,
+): { location: string | undefined; locationUrl: string | undefined } {
+  const addressLocation = findAddressInBody(dir$);
+  if (addressLocation) {
+    return { location: addressLocation, locationUrl: undefined };
+  }
+  return {
+    location: cleanMapsLinkText(mapsLink),
+    locationUrl: mapsLink.length ? mapsLink.attr("href")?.trim() : undefined,
+  };
 }
 
 /**
@@ -134,87 +213,11 @@ export function parseHarelineRow(
 
   // --- Directions cell: title, location, description ---
   const dir$ = cheerio.load(directionHtml);
-
-  // Title from <h2>. If h2 has multiple <br>-separated segments and the full
-  // joined text runs long (prose bleed from unstructured authoring), fall back
-  // to the first segment only. #816.
-  // Normalize raw CRLF/LF in the HTML source to spaces so formatting line
-  // wraps don't get mistaken for <br>-delimited segments. CodeRabbit PR #824.
-  const h2Html = (dir$("h2").first().html() ?? "").replace(/\r?\n/g, " ");
-  const h2Segments = stripHtmlTags(h2Html, "\n")
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const h2Joined = h2Segments.join(" ");
-  const h2Text =
-    h2Joined.length > MAX_H2_TITLE_LEN && h2Segments[0]
-      ? h2Segments[0]
-      : h2Joined;
-  const title =
-    h2Text ||
-    (runNumber ? `RIH3 #${runNumber}` : "RIH3 Monday Trail");
-
-  // Location preferred from the address-shaped sentence in the directions
-  // body (#1427) — the first maps link's anchor text is sometimes a joke,
-  // and even the URL can point at the wrong place ("Julia's Trail Parking"
-  // instead of the actual start). Fall back to the link's anchor text when
-  // no address-shaped match is found.
+  const title = extractRih3Title(dir$, runNumber);
   const mapsLink = dir$(
     'a[href*="google.com/maps"], a[href*="maps.google"]',
   ).first();
-  let location: string | undefined;
-  let locationUrl: string | undefined = mapsLink.length
-    ? mapsLink.attr("href")?.trim()
-    : undefined;
-
-  // 1. Pull the directions body text (stripped HTML, h2 + all <a> anchor
-  //    text removed) and scan for a "<text>, <City>, <ST>" substring —
-  //    that's the canonical address when the kennel writes one in plain
-  //    prose. We remove the link text first so the previous behavior of
-  //    extracting from the maps-link anchor still wins when the address
-  //    ONLY appears inside the link.
-  const bodyForAddress = dir$("body").clone();
-  bodyForAddress.find("h2").remove();
-  bodyForAddress.find("a").remove();
-  const bodyText = bodyForAddress.text().replace(/\s+/g, " ").trim();
-  const addressMatch = ADDRESS_PATTERN_RE.exec(bodyText);
-  if (addressMatch) {
-    const candidate = addressMatch[1]
-      .replace(ADDRESS_LEADIN_RE, "")
-      .trim();
-    // Require a digit somewhere in the candidate so we only latch onto
-    // numeric street addresses, not "the dog park at <Proper Noun>".
-    if (
-      candidate.length >= 8 &&
-      candidate.length <= 150 &&
-      /\d/.test(candidate) &&
-      STREET_ADDRESS_HINT_RE.test(candidate)
-    ) {
-      location = candidate;
-      // Address-text path: the first maps link's URL is often wrong (see #1427
-      // map-pin landing at Julia's Trail Parking), so drop it and let
-      // downstream geocoding resolve coords from the address text.
-      locationUrl = undefined;
-    }
-  }
-
-  // 2. Fallback — use the maps link's anchor text (legacy behavior).
-  if (!location) {
-    const linkText = mapsLink.length
-      ? mapsLink
-          .text()
-          .trim()
-          // Strip leading navigation instructions (e.g., "Park Here. Just a short bit from the dog park at Melville Park, ...")
-          .replace(/^Park\s+Here\.?\s*/i, "")
-          .replace(/^(?:Get\s+directions?\s+to|Walk\s+to|Head\s+to|Just\s+)\s*/i, "")
-          .replace(/^(?:a\s+)?(?:short\s+)?(?:bit\s+)?(?:from|near|by)\s+(?:the\s+)?/i, "")
-          .trim()
-      : undefined;
-    location =
-      linkText && linkText.length > 3 && !PROSE_LEAD_RE.test(linkText)
-        ? linkText
-        : undefined;
-  }
+  const { location, locationUrl } = resolveRih3Location(dir$, mapsLink);
 
   // Description: body text minus title and song links; preserve Facebook link
   const descRoot = dir$("body").clone();

--- a/src/lib/kennel-utils.test.ts
+++ b/src/lib/kennel-utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { toSlug, toKennelCode, buildKennelIdentifiers } from "./kennel-utils";
+
+describe("toSlug", () => {
+  it("lowercases and replaces spaces with hyphens", () => {
+    expect(toSlug("NYC H3")).toBe("nyc-h3");
+  });
+
+  it("strips parentheses", () => {
+    expect(toSlug("Some (Kennel) H3")).toBe("some-kennel-h3");
+  });
+
+  it("collapses multiple separators into a single hyphen", () => {
+    expect(toSlug("Foo  Bar   H3")).toBe("foo-bar-h3");
+    expect(toSlug("Foo--Bar")).toBe("foo-bar");
+  });
+
+  it("strips literal slashes — regression for #1422 (H2H3 / Cha-Am H3 → h2h3-cha-am-h3)", () => {
+    // Next.js routes treat "/" as a path separator; the public kennel page returns
+    // 404 if the slug contains one. The kennel utils helper is reached by admin
+    // creation/update flows — keep it slash-safe so admins can't reintroduce the bug.
+    expect(toSlug("H2H3 / Cha-Am H3")).toBe("h2h3-cha-am-h3");
+    expect(toSlug("Foo/Bar H3")).toBe("foo-bar-h3");
+  });
+
+  it("handles ampersands and other non-alphanumeric characters", () => {
+    expect(toSlug("Cherry City & OH3")).toBe("cherry-city-oh3");
+    expect(toSlug("X H3 + Y H3")).toBe("x-h3-y-h3");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(toSlug(" leading and trailing ")).toBe("leading-and-trailing");
+    expect(toSlug("-foo-")).toBe("foo");
+  });
+});
+
+describe("toKennelCode", () => {
+  it("strips slashes and other non-alphanumeric characters", () => {
+    expect(toKennelCode("H2H3 / Cha-Am H3")).toBe("h2h3-cha-am-h3");
+  });
+});
+
+describe("buildKennelIdentifiers", () => {
+  it("returns matching slug + kennelCode for slash-bearing shortNames", () => {
+    expect(buildKennelIdentifiers("H2H3 / Cha-Am H3")).toEqual({
+      slug: "h2h3-cha-am-h3",
+      kennelCode: "h2h3-cha-am-h3",
+    });
+  });
+});

--- a/src/lib/kennel-utils.ts
+++ b/src/lib/kennel-utils.ts
@@ -1,13 +1,14 @@
 import { prisma } from "@/lib/db";
 import { isUniqueConstraintViolation } from "@/lib/prisma-errors";
 
-/** Generate a URL-safe slug from a kennel shortName. Strips parens, collapses hyphens. */
+/** Generate a URL-safe slug from a kennel shortName. Normalizes any non-alphanumeric
+ *  run (spaces, slashes, ampersands, hyphens, parens, …) to a single "-". Must reject `/`
+ *  in particular — Next.js treats it as a path separator and silently 404s the page (#1422). */
 export function toSlug(shortName: string): string {
   return shortName
     .toLowerCase()
     .replaceAll(/[()]/g, "")
-    .replaceAll(/\s+/g, "-")
-    .replaceAll(/-+/g, "-")
+    .replaceAll(/[^a-z0-9]+/g, "-")
     .replaceAll(/^-|-$/g, "");
 }
 


### PR DESCRIPTION
## Summary

Quick Win bundle — 4 HTML_SCRAPER parse bugs + a Next.js slug-collision fix that 404'd a kennel page.

- **#1446 KJ Harimau** — `Run #1553` location stuck on `"Maps:"` because the labeled-field regex over-matched newlines into the next label when `Runsite:` was empty. Tightened the post-colon whitespace to horizontal-only + reject label-only captures; switched the per-post dedup to keep the most-complete candidate by completeness score.
- **#1442 KLJ H3** — Shape-A titles (`Run # 526, 7th June @ Nambee estate`) rendered as stale-default `Run #N`; Shape-B leaked `@ TBD`. `cleanKljTitle` now returns `undefined` for venue-only trailers (merge synthesizes friendly default) and strips trailing ` @ <placeholder>` for themed titles.
- **#1427 RIH3** — Run #2098 used the joke parking-advisory sentence as `location` because the first maps link's anchor text won. Prefer a street-address-shaped sentence (`<text>, <City>, <ST>` with a digit) from the directions body before falling back to the link text; drop the URL when the link wasn't trustworthy.
- **#1396 GGFM Strawberry Moon** — `Start: TBA` rows absorbed the full description paragraph. Bound the location capture at the first `<br>` after `Start:`, expand placeholder detection to TBA/TBC, and capture the post-placeholder prose as `description`.
- **#1422 H2H3 / Cha-Am H3 slug** — Public kennel page returned 404 because `toSlug()` left `/` intact in `H2H3 / Cha-Am H3`. Three-part fix: normalize `[^a-z0-9]+` to `-` in both helpers (`prisma/seed.ts` + `src/lib/kennel-utils.ts`), pin the H2H3 seed row to `slug: "h2h3-cha-am-h3"`, and ship a migration that repairs any persisted slash-bearing slug.

## Live verification

Ran each adapter against its production URL from the worktree (worktree env lacks the Blogger key, so KJ Harimau is unit-tested only; the unit fixture mirrors the exact body shape from the issue).

| Adapter | Status | Sample |
|---|---|---|
| RIH3 | ✅ Live verified | Run #2098 → `location: "2203 Boston Neck Rd, Saunderstown, RI"`, `locationUrl: undefined` |
| KLJ H3 | ✅ Live verified | Run #532 → `title: "Christmas Party"`; Run #531 → `title: "Halloween"` (no `@ TBD`); Runs #526-530 → `title: undefined` (merge fallback) |
| hashnyc (GGFM #435) | ✅ Live verified | `location: "TBA"`, `description: "Join NYC's full moon kennel as we explore the darker side of Gotham. …"` |
| KJ Harimau | ⚠️ Unit-tested only | Worktree sandbox lacks `GOOGLE_CALENDAR_API_KEY`. Unit test fixture matches the exact empty-`Runsite:` / `Maps:` body from the issue; dedup test covers the two-post completeness-score scenario. |

H2H3 slug fix verified statically: `toSlug("H2H3 / Cha-Am H3")` → `"h2h3-cha-am-h3"` in both helpers; the explicit `slug` override on the seed row ensures fresh seeds match; the migration repairs the prod row on `migrate deploy`. (Local 200-vs-404 page check deferred — no local Postgres in this worktree.)

## CI gate

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, only pre-existing warnings
- `npm test` — 6584 passed, 2 skipped, 25 todo (no regressions)

## Test plan

- [ ] CI: type check + lint + tests
- [ ] After merge, confirm `https://www.hashtracks.xyz/kennels/h2h3-cha-am-h3` returns 200 once the slug-repair migration deploys
- [ ] Next scrape cycle: verify Run #1553 KJ Harimau picks up `location: "Bukit Gasing Car Park"`
- [ ] Next scrape cycle: verify GGFM #435 location is `"TBA"` (or `undefined`) and description carries the full-moon prose
- [ ] Next scrape cycle: verify RIH3 #2098 location is the address, not the joke

Closes #1446
Closes #1442
Closes #1427
Closes #1396
Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)