### PR TITLE
fix(audit): log GitHub API failures in file-finding route (#1468)

### DIFF
--- a/src/app/api/audit/file-finding/route.test.ts
+++ b/src/app/api/audit/file-finding/route.test.ts
@@ -97,6 +97,14 @@ function buildReq(opts: ApiPostInit = {}): Request {
 const fetchMock = vi.fn();
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
+/** Recur-tier existing issue used across the postComment failure tests. */
+const RECUR_ISSUE = {
+  id: "ai_existing",
+  githubNumber: 42,
+  htmlUrl: "https://github.com/x/y/issues/42",
+  recurrenceCount: 0,
+} as never;
+
 /**
  * Build a minimal mock of `Response.body.getReader()` that yields `text`
  * in a single chunk. `safeErrorBody` uses streaming reads (#1468 follow-up
@@ -426,12 +434,7 @@ describe("POST /api/audit/file-finding", () => {
   });
 
   it("logs failed postComment status + body on recur-comment path (#1468)", async () => {
-    mockFindIssue.mockResolvedValue({
-      id: "ai_existing",
-      githubNumber: 42,
-      htmlUrl: "https://github.com/x/y/issues/42",
-      recurrenceCount: 0,
-    } as never);
+    mockFindIssue.mockResolvedValue(RECUR_ISSUE);
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 410,
@@ -448,12 +451,7 @@ describe("POST /api/audit/file-finding", () => {
   });
 
   it("logs when GITHUB_TOKEN is missing on recur-comment path (#1468)", async () => {
-    mockFindIssue.mockResolvedValue({
-      id: "ai_existing",
-      githubNumber: 42,
-      htmlUrl: "https://github.com/x/y/issues/42",
-      recurrenceCount: 0,
-    } as never);
+    mockFindIssue.mockResolvedValue(RECUR_ISSUE);
     delete process.env.GITHUB_TOKEN;
     const res = await POST(buildReq());
     expect(res.status).toBe(502);
@@ -465,12 +463,7 @@ describe("POST /api/audit/file-finding", () => {
   });
 
   it("logs thrown errors from postComment on recur-comment path (#1468)", async () => {
-    mockFindIssue.mockResolvedValue({
-      id: "ai_existing",
-      githubNumber: 42,
-      htmlUrl: "https://github.com/x/y/issues/42",
-      recurrenceCount: 0,
-    } as never);
+    mockFindIssue.mockResolvedValue(RECUR_ISSUE);
     fetchMock.mockRejectedValueOnce(new Error("ETIMEDOUT"));
     const res = await POST(buildReq());
     expect(res.status).toBe(502);

--- a/src/app/api/audit/file-finding/route.test.ts
+++ b/src/app/api/audit/file-finding/route.test.ts
@@ -95,6 +95,7 @@ function buildReq(opts: ApiPostInit = {}): Request {
 }
 
 const fetchMock = vi.fn();
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -107,6 +108,7 @@ beforeEach(() => {
   mockFindManyIssue.mockResolvedValue([] as never);
   mockUpdateIssue.mockResolvedValue({ recurrenceCount: 1 } as never);
   mockUpdateManyIssue.mockResolvedValue({ count: 0 } as never);
+  consoleErrorSpy.mockClear();
 });
 
 describe("POST /api/audit/file-finding", () => {
@@ -335,10 +337,105 @@ describe("POST /api/audit/file-finding", () => {
     expect(requestBody.labels).toContain("kennel:nych3");
   });
 
-  it("returns 502 when GitHub issue creation fails", async () => {
-    fetchMock.mockResolvedValue({ ok: false });
+  it("returns 502 when GitHub issue creation fails — logs status and body for triage (#1468)", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => '{"message":"Bad credentials"}',
+    });
     const res = await POST(buildReq());
     expect(res.status).toBe(502);
+    // Lock the existing failure-envelope contract — a regression away from
+    // this body would silently change the caller's retry behavior.
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("GitHub issue creation failed");
+    // Operators need the status + body to diagnose. Without these logs, every
+    // failing filing surfaces only as `{"error":"GitHub issue creation failed"}`
+    // with zero signal about whether it's auth, rate-limit, or payload shape.
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("createIssue GitHub API 401"),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Bad credentials"),
+    );
+  });
+
+  it("truncates oversized upstream bodies before logging (#1468 Codex pass)", async () => {
+    // Defense against an intermediary returning an HTML error page that
+    // reflects request content. Cap at 500 chars so logs stay bounded.
+    const huge = "x".repeat(2000);
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => huge,
+    });
+    await POST(buildReq());
+    const logged = consoleErrorSpy.mock.calls
+      .map((call) => String(call[0]))
+      .find((s) => s.includes("createIssue GitHub API 502"));
+    expect(logged).toBeDefined();
+    expect(logged).toContain("(truncated)");
+    // Logged tail should be a strict prefix of the upstream body plus the marker.
+    expect(logged!.length).toBeLessThan(huge.length);
+  });
+
+  it("logs thrown errors from createIssue (#1468)", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNRESET"));
+    const res = await POST(buildReq());
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("GitHub issue creation failed");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[audit-file-finding] createIssue fetch threw:",
+      expect.objectContaining({ message: "ECONNRESET" }),
+    );
+  });
+
+  it("logs when GITHUB_TOKEN is missing (#1468)", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const res = await POST(buildReq());
+    expect(res.status).toBe(502);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[audit-file-finding] createIssue: GITHUB_TOKEN not set",
+    );
+  });
+
+  it("logs failed postComment status + body on recur-comment path (#1468)", async () => {
+    mockFindIssue.mockResolvedValue({
+      id: "ai_existing",
+      githubNumber: 42,
+      htmlUrl: "https://github.com/x/y/issues/42",
+      recurrenceCount: 0,
+    } as never);
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 410,
+      text: async () => '{"message":"Issue is locked"}',
+    });
+    const res = await POST(buildReq());
+    expect(res.status).toBe(502);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("postComment GitHub API #42 410"),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Issue is locked"),
+    );
+  });
+
+  it("logs thrown errors from postComment on recur-comment path (#1468)", async () => {
+    mockFindIssue.mockResolvedValue({
+      id: "ai_existing",
+      githubNumber: 42,
+      htmlUrl: "https://github.com/x/y/issues/42",
+      recurrenceCount: 0,
+    } as never);
+    fetchMock.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+    const res = await POST(buildReq());
+    expect(res.status).toBe(502);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[audit-file-finding] postComment fetch threw:",
+      expect.objectContaining({ message: "ETIMEDOUT" }),
+    );
   });
 
   it("does not look up an existing issue by fingerprint for non-fingerprintable rules", async () => {

--- a/src/app/api/audit/file-finding/route.test.ts
+++ b/src/app/api/audit/file-finding/route.test.ts
@@ -97,6 +97,30 @@ function buildReq(opts: ApiPostInit = {}): Request {
 const fetchMock = vi.fn();
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
+/**
+ * Build a minimal mock of `Response.body.getReader()` that yields `text`
+ * in a single chunk. `safeErrorBody` uses streaming reads (#1468 follow-up
+ * — Gemini + Codex pass on PR #1482) instead of `await res.text()` so the
+ * defensive truncation bound applies before the full body is buffered.
+ */
+function mockResponseBody(text: string) {
+  const chunk = new TextEncoder().encode(text);
+  return {
+    body: {
+      getReader: () => {
+        let emitted = false;
+        return {
+          read: async () =>
+            emitted
+              ? { done: true, value: undefined }
+              : ((emitted = true), { done: false, value: chunk }),
+          cancel: async () => {},
+        };
+      },
+    },
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.stubGlobal("fetch", fetchMock);
@@ -341,7 +365,7 @@ describe("POST /api/audit/file-finding", () => {
     fetchMock.mockResolvedValue({
       ok: false,
       status: 401,
-      text: async () => '{"message":"Bad credentials"}',
+      ...mockResponseBody('{"message":"Bad credentials"}'),
     });
     const res = await POST(buildReq());
     expect(res.status).toBe(502);
@@ -360,14 +384,16 @@ describe("POST /api/audit/file-finding", () => {
     );
   });
 
-  it("truncates oversized upstream bodies before logging (#1468 Codex pass)", async () => {
-    // Defense against an intermediary returning an HTML error page that
-    // reflects request content. Cap at 500 chars so logs stay bounded.
-    const huge = "x".repeat(2000);
+  it("truncates oversized upstream bodies before logging (#1468 — streaming read bound)", async () => {
+    // Defense against an intermediary returning a multi-megabyte HTML error
+    // page that reflects request content. The streaming reader caps at
+    // LOG_BODY_MAX BYTES BEFORE the body is fully buffered — verified here
+    // by mocking a 50KB body and asserting the logged string is much shorter.
+    const huge = "x".repeat(50_000);
     fetchMock.mockResolvedValue({
       ok: false,
       status: 502,
-      text: async () => huge,
+      ...mockResponseBody(huge),
     });
     await POST(buildReq());
     const logged = consoleErrorSpy.mock.calls
@@ -375,7 +401,6 @@ describe("POST /api/audit/file-finding", () => {
       .find((s) => s.includes("createIssue GitHub API 502"));
     expect(logged).toBeDefined();
     expect(logged).toContain("(truncated)");
-    // Logged tail should be a strict prefix of the upstream body plus the marker.
     expect(logged!.length).toBeLessThan(huge.length);
   });
 
@@ -410,7 +435,7 @@ describe("POST /api/audit/file-finding", () => {
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 410,
-      text: async () => '{"message":"Issue is locked"}',
+      ...mockResponseBody('{"message":"Issue is locked"}'),
     });
     const res = await POST(buildReq());
     expect(res.status).toBe(502);
@@ -420,6 +445,23 @@ describe("POST /api/audit/file-finding", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Issue is locked"),
     );
+  });
+
+  it("logs when GITHUB_TOKEN is missing on recur-comment path (#1468)", async () => {
+    mockFindIssue.mockResolvedValue({
+      id: "ai_existing",
+      githubNumber: 42,
+      htmlUrl: "https://github.com/x/y/issues/42",
+      recurrenceCount: 0,
+    } as never);
+    delete process.env.GITHUB_TOKEN;
+    const res = await POST(buildReq());
+    expect(res.status).toBe(502);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[audit-file-finding] postComment: GITHUB_TOKEN not set",
+    );
+    // No fetch attempted — the no-token guard short-circuits.
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("logs thrown errors from postComment on recur-comment path (#1468)", async () => {

--- a/src/app/api/audit/file-finding/route.ts
+++ b/src/app/api/audit/file-finding/route.ts
@@ -268,6 +268,24 @@ async function persistFilingResult(
 
 // ── GitHub IO ────────────────────────────────────────────────────────
 
+const LOG_PREFIX = "[audit-file-finding]";
+
+/**
+ * Truncate an upstream response body for safe logging. GitHub error responses
+ * are normally tiny JSON `{message, documentation_url}` bodies, but a proxy or
+ * intermediary could return an HTML error page that reflects request content
+ * (Codex pass — #1468). Cap defensively so logs never grow unbounded.
+ */
+const LOG_BODY_MAX = 500;
+async function safeErrorBody(res: Response): Promise<string> {
+  try {
+    const text = await res.text();
+    return text.length > LOG_BODY_MAX ? `${text.slice(0, LOG_BODY_MAX)}…(truncated)` : text;
+  } catch {
+    return "<unreadable body>";
+  }
+}
+
 /** Standard POST init for any GitHub repos/* call. */
 function githubPostInit(token: string, body: unknown): RequestInit {
   return {
@@ -296,7 +314,10 @@ function buildApiActions(): FilerActions {
   return {
     createIssue: async ({ title, body, labels }) => {
       const token = process.env.GITHUB_TOKEN;
-      if (!token) return null;
+      if (!token) {
+        console.error(`${LOG_PREFIX} createIssue: GITHUB_TOKEN not set`);
+        return null;
+      }
       const repo = getValidatedRepo();
       try {
         // SSRF-safe: URL constructor anchors the request to the
@@ -306,7 +327,12 @@ function buildApiActions(): FilerActions {
           url,
           githubPostInit(token, { title, body, labels }),
         );
-        if (!res.ok) return null;
+        if (!res.ok) {
+          console.error(
+            `${LOG_PREFIX} createIssue GitHub API ${res.status}: ${await safeErrorBody(res)}`,
+          );
+          return null;
+        }
         // Local name carries "Html" so the xss/no-mixed-html rule
         // doesn't flag the typed-cast local as "non-HTML variable
         // storing raw HTML" — Codacy tracks the source field name
@@ -316,13 +342,17 @@ function buildApiActions(): FilerActions {
           number: number;
         };
         return { htmlUrl: issueHtml.html_url, number: issueHtml.number };
-      } catch {
+      } catch (err) {
+        console.error(`${LOG_PREFIX} createIssue fetch threw:`, err);
         return null;
       }
     },
     postComment: async (issueNumber, body) => {
       const token = process.env.GITHUB_TOKEN;
-      if (!token) return false;
+      if (!token) {
+        console.error(`${LOG_PREFIX} postComment: GITHUB_TOKEN not set`);
+        return false;
+      }
       if (!Number.isInteger(issueNumber) || issueNumber <= 0) return false;
       const repo = getValidatedRepo();
       try {
@@ -332,8 +362,14 @@ function buildApiActions(): FilerActions {
           "https://api.github.com",
         );
         const res = await fetch(url, githubPostInit(token, { body }));
+        if (!res.ok) {
+          console.error(
+            `${LOG_PREFIX} postComment GitHub API #${issueNumber} ${res.status}: ${await safeErrorBody(res)}`,
+          );
+        }
         return res.ok;
-      } catch {
+      } catch (err) {
+        console.error(`${LOG_PREFIX} postComment fetch threw:`, err);
         return false;
       }
     },

--- a/src/app/api/audit/file-finding/route.ts
+++ b/src/app/api/audit/file-finding/route.ts
@@ -271,16 +271,31 @@ async function persistFilingResult(
 const LOG_PREFIX = "[audit-file-finding]";
 
 /**
- * Truncate an upstream response body for safe logging. GitHub error responses
- * are normally tiny JSON `{message, documentation_url}` bodies, but a proxy or
- * intermediary could return an HTML error page that reflects request content
- * (Codex pass — #1468). Cap defensively so logs never grow unbounded.
+ * Read an upstream error response body for safe logging, capped at
+ * `LOG_BODY_MAX` bytes. GitHub error responses are normally tiny JSON
+ * `{message, documentation_url}` bodies, but a proxy or intermediary could
+ * return a multi-megabyte HTML error page that reflects request content
+ * (#1468). We stream the body and stop reading once we have enough — this
+ * keeps the defensive bound on the read itself rather than post-decode
+ * slicing, so a misbehaving upstream cannot pressure memory or latency
+ * even before truncation (Gemini + Codex pass on PR #1482).
  */
 const LOG_BODY_MAX = 500;
 async function safeErrorBody(res: Response): Promise<string> {
   try {
-    const text = await res.text();
-    return text.length > LOG_BODY_MAX ? `${text.slice(0, LOG_BODY_MAX)}…(truncated)` : text;
+    const reader = res.body?.getReader();
+    if (!reader) return "<empty body>";
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    let collected = "";
+    while (collected.length < LOG_BODY_MAX) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) collected += decoder.decode(value, { stream: true });
+    }
+    void reader.cancel();
+    return collected.length > LOG_BODY_MAX
+      ? `${collected.slice(0, LOG_BODY_MAX)}…(truncated)`
+      : collected;
   } catch {
     return "<unreadable body>";
   }


### PR DESCRIPTION
## Summary
- `/api/audit/file-finding` was returning HTTP 502 `{"error":"GitHub issue creation failed"}` with zero upstream detail — every chrome-stream audit filing in prod was blocked with no operator signal on whether it was auth, rate limit, payload, or network.
- Mirror the cron path's logging pattern ([src/pipeline/audit-issue.ts:86](src/pipeline/audit-issue.ts#L86)) at all 4 silent failure points (createIssue !ok / catch, postComment !ok / catch) plus the missing-token guards.
- `safeErrorBody` caps the response body at 500 chars before logging (Codex pass — defends against intermediaries that may reflect request content in error pages).

The 502 envelope contract is preserved; tests now lock it.

## Test plan
- [x] `npx tsc --noEmit && npm run lint && npm test src/app/api/audit/file-finding/` — 21 passed (16 existing + 5 new).
- [x] Full suite — 6674 passed, no regressions.
- [ ] After merge & deploy: re-run a chrome-stream filing from `/admin/events` and inspect Vercel logs to identify the underlying upstream cause (token / rate limit / payload). A follow-up surgical fix can then target the actual GitHub failure mode.

Closes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)