### PR TITLE
fix(merge): accept Postgres string meta.target in P2002 helper (#1464)

### DIFF
--- a/src/lib/prisma-errors.test.ts
+++ b/src/lib/prisma-errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+
+import { Prisma } from "@/generated/prisma/client";
+import { isUniqueConstraintViolation } from "@/lib/prisma-errors";
+import { buildPrismaUniqueViolation } from "@/test/factories";
+
+describe("isUniqueConstraintViolation", () => {
+  it.each([
+    // [label, err, required, expected]
+    [
+      "no-arg form matches any P2002",
+      buildPrismaUniqueViolation(["x"]),
+      undefined,
+      true,
+    ],
+    [
+      "array-target shape — exact match",
+      buildPrismaUniqueViolation(["sourceId", "fingerprint"]),
+      ["sourceId", "fingerprint"],
+      true,
+    ],
+    [
+      "array-target shape — wrong length (different constraint)",
+      buildPrismaUniqueViolation(["sourceId", "fingerprint", "extra"]),
+      ["sourceId", "fingerprint"],
+      false,
+    ],
+    [
+      "array-target shape — missing column",
+      buildPrismaUniqueViolation(["sourceId", "wrong"]),
+      ["sourceId", "fingerprint"],
+      false,
+    ],
+    [
+      // #1464 root cause: the production Postgres driver emits `meta.target`
+      // as the constraint NAME string, not the column tuple. Pre-fix this
+      // returned false and the race-window catch in merge.ts re-threw.
+      "string-target shape (production Postgres) — constraint name contains both columns",
+      buildPrismaUniqueViolation("RawEvent_sourceId_fingerprint_key"),
+      ["sourceId", "fingerprint"],
+      true,
+    ],
+    [
+      "string-target shape — constraint name missing a required column",
+      buildPrismaUniqueViolation("RawEvent_sourceId_key"),
+      ["sourceId", "fingerprint"],
+      false,
+    ],
+    [
+      // Codex pass: raw substring matching would false-positive when a
+      // column is a prefix of an unrelated column on the same constraint.
+      // Token-boundary match must reject this.
+      "string-target shape — superstring collision (fingerprintVersion ≠ fingerprint)",
+      buildPrismaUniqueViolation("RawEvent_sourceId_fingerprintVersion_key"),
+      ["sourceId", "fingerprint"],
+      false,
+    ],
+    [
+      "non-P2002 error never matches",
+      new Prisma.PrismaClientKnownRequestError("not found", {
+        code: "P2025",
+        clientVersion: "0.0.0",
+      }),
+      ["sourceId", "fingerprint"],
+      false,
+    ],
+    [
+      "non-Prisma error never matches",
+      new Error("boom"),
+      undefined,
+      false,
+    ],
+    [
+      "narrowed mode with undefined meta returns false",
+      new Prisma.PrismaClientKnownRequestError("missing meta", {
+        code: "P2002",
+        clientVersion: "0.0.0",
+      }),
+      ["sourceId", "fingerprint"],
+      false,
+    ],
+  ])("%s", (_label, err, required, expected) => {
+    expect(isUniqueConstraintViolation(err, required)).toBe(expected);
+  });
+});

--- a/src/lib/prisma-errors.test.ts
+++ b/src/lib/prisma-errors.test.ts
@@ -56,6 +56,27 @@ describe("isUniqueConstraintViolation", () => {
       false,
     ],
     [
+      // Gemini pass (#1483): a naive `target.split("_")` would explode the
+      // column `user_id` into `["user","id"]` and miss the actual column.
+      // The boundary-anchored regex must match the multi-token column whole.
+      "string-target shape — snake_case column matches inside constraint name",
+      buildPrismaUniqueViolation("User_user_id_email_key"),
+      ["user_id", "email"],
+      true,
+    ],
+    [
+      // Defensive: a future Prisma version could emit some other shape
+      // (number, null, object). Fall through to false rather than crash.
+      "unknown target shape (number) falls through to false",
+      new Prisma.PrismaClientKnownRequestError("weird shape", {
+        code: "P2002",
+        clientVersion: "0.0.0",
+        meta: { target: 42 },
+      }),
+      ["sourceId", "fingerprint"],
+      false,
+    ],
+    [
       "non-P2002 error never matches",
       new Prisma.PrismaClientKnownRequestError("not found", {
         code: "P2025",

--- a/src/lib/prisma-errors.ts
+++ b/src/lib/prisma-errors.ts
@@ -36,18 +36,18 @@ export function isUniqueConstraintViolation(
   }
   if (typeof target === "string") {
     // Postgres-shaped constraint name (e.g. `RawEvent_sourceId_fingerprint_key`).
-    // Match each column with `_`-or-string-boundary anchors on both sides so:
-    //   - `fingerprintVersion` does NOT shadow `fingerprint` (Codex pass — #1464)
-    //   - snake_case column names like `user_id` still match cleanly inside
-    //     constraint names like `User_user_id_email_key` (Gemini pass — #1483)
+    // Wrap with `_` on both sides and require each column to appear bracketed
+    // by `_` boundaries — equivalent to a `(?:^|_)col(?:_|$)` regex but
+    // expressed as plain `String.includes` to avoid dynamic-regex construction
+    // (Codacy security pass — #1483) and any ReDoS surface. This:
+    //   - rejects `fingerprintVersion` shadowing `fingerprint` (Codex pass)
+    //   - matches snake_case columns like `user_id` cleanly inside
+    //     constraint names like `User_user_id_email_key` (Gemini pass)
     // Subset semantics are intentional: the constraint name always carries
     // the model prefix and `_key`/`_idx` suffix as non-column tokens, so we
-    // can't require length parity the way the array path does — anchored
-    // membership is the strongest check available without knowing the model.
-    return requiredTargetColumns.every((col) => {
-      const escaped = col.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      return new RegExp(`(?:^|_)${escaped}(?:_|$)`).test(target);
-    });
+    // can't require length parity the way the array path does.
+    const padded = `_${target}_`;
+    return requiredTargetColumns.every((col) => padded.includes(`_${col}_`));
   }
   return false;
 }

--- a/src/lib/prisma-errors.ts
+++ b/src/lib/prisma-errors.ts
@@ -4,12 +4,20 @@ import { Prisma } from "@/generated/prisma/client";
  * Type guard for Prisma `P2002` unique-constraint violations.
  *
  * Pass `requiredTargetColumns` to narrow to a specific composite constraint;
- * the helper requires the exact tuple — same length AND every column
- * present (since a unique constraint targets a fixed tuple, the column-
- * set match is a set-equality, not a subset). Use the no-arg form when
- * you need to handle any P2002 — e.g. when several single-column unique
- * constraints could plausibly fire at the same call site, since the
- * narrowed mode would never match a single-column violation.
+ * the helper requires every named column to be referenced by the error's
+ * `meta.target` (since a unique constraint targets a fixed tuple). Use the
+ * no-arg form when you need to handle any P2002 — e.g. when several
+ * single-column unique constraints could plausibly fire at the same call
+ * site, since the narrowed mode would never match a single-column violation.
+ *
+ * `meta.target` shape varies by driver (#1464 root cause):
+ *   - Array of column names: `["sourceId", "fingerprint"]` — what unit tests
+ *     and some Prisma engines emit.
+ *   - String constraint name: `"RawEvent_sourceId_fingerprint_key"` — what
+ *     the production Postgres engine actually emits at our call sites.
+ * Both shapes must match, otherwise the race-window catch in
+ * `src/pipeline/merge.ts:1707` silently re-throws and 9 RawEvent inserts
+ * leak past per HashNYC scrape.
  *
  * Examples:
  *   isUniqueConstraintViolation(err)                                   // any P2002
@@ -22,6 +30,17 @@ export function isUniqueConstraintViolation(
   if (!(err instanceof Prisma.PrismaClientKnownRequestError) || err.code !== "P2002") return false;
   if (!requiredTargetColumns || requiredTargetColumns.length === 0) return true;
   const target = err.meta?.target;
-  if (!Array.isArray(target) || target.length !== requiredTargetColumns.length) return false;
-  return requiredTargetColumns.every((col) => target.includes(col));
+  if (Array.isArray(target)) {
+    if (target.length !== requiredTargetColumns.length) return false;
+    return requiredTargetColumns.every((col) => target.includes(col));
+  }
+  if (typeof target === "string") {
+    // Postgres-shaped constraint name (e.g. `RawEvent_sourceId_fingerprint_key`).
+    // Tokenize on `_` and require every column to appear as an exact token —
+    // raw substring matching would false-positive against superstring columns
+    // (e.g. `fingerprintVersion` would shadow `fingerprint`) (Codex pass — #1464).
+    const tokens = new Set(target.split("_"));
+    return requiredTargetColumns.every((col) => tokens.has(col));
+  }
+  return false;
 }

--- a/src/lib/prisma-errors.ts
+++ b/src/lib/prisma-errors.ts
@@ -36,11 +36,18 @@ export function isUniqueConstraintViolation(
   }
   if (typeof target === "string") {
     // Postgres-shaped constraint name (e.g. `RawEvent_sourceId_fingerprint_key`).
-    // Tokenize on `_` and require every column to appear as an exact token —
-    // raw substring matching would false-positive against superstring columns
-    // (e.g. `fingerprintVersion` would shadow `fingerprint`) (Codex pass — #1464).
-    const tokens = new Set(target.split("_"));
-    return requiredTargetColumns.every((col) => tokens.has(col));
+    // Match each column with `_`-or-string-boundary anchors on both sides so:
+    //   - `fingerprintVersion` does NOT shadow `fingerprint` (Codex pass — #1464)
+    //   - snake_case column names like `user_id` still match cleanly inside
+    //     constraint names like `User_user_id_email_key` (Gemini pass — #1483)
+    // Subset semantics are intentional: the constraint name always carries
+    // the model prefix and `_key`/`_idx` suffix as non-column tokens, so we
+    // can't require length parity the way the array path does — anchored
+    // membership is the strongest check available without knowing the model.
+    return requiredTargetColumns.every((col) => {
+      const escaped = col.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return new RegExp(`(?:^|_)${escaped}(?:_|$)`).test(target);
+    });
   }
   return false;
 }

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -3847,6 +3847,46 @@ describe("processNewRawEvent — P2002 race-window fall-through (#1286)", () => 
     expect(vi.mocked(prisma.rawEvent.findUnique)).not.toHaveBeenCalled();
   });
 
+  it("routes string-shaped meta.target through the duplicate path + emits branch-trace log (#1464)", async () => {
+    // Issue #1464: HashNYC was leaking 9 eventErrors per scrape because
+    // the production Postgres driver emits `meta.target` as the constraint
+    // NAME string ("RawEvent_sourceId_fingerprint_key"), not the column
+    // tuple. Pre-fix `isUniqueConstraintViolation` array-only check
+    // returned false and the race-window catch re-threw. Lock the
+    // string-shape path so a future helper regression surfaces here.
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockRawEventCreate.mockRejectedValueOnce(
+      buildPrismaUniqueViolation("RawEvent_sourceId_fingerprint_key"),
+    );
+    vi.mocked(prisma.rawEvent.findUnique).mockResolvedValueOnce({
+      id: "raw_winner",
+      fingerprint: "fp_abc123",
+      processed: true,
+      eventId: "evt_winner",
+    } as never);
+    vi.mocked(prisma.event.findUnique).mockResolvedValueOnce({
+      id: "evt_winner",
+      kennelId: "kennel_1",
+      trustLevel: 5,
+    } as never);
+
+    const result = await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-04-01", kennelTags: ["TestH3"] }),
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.eventErrors).toBe(0);
+    expect(result.mergeErrorDetails).toEqual([]);
+    // Operator-facing trace: one log per handled race with the branch label.
+    const raceLog = logSpy.mock.calls
+      .map((call) => String(call[0]))
+      .find((s) => s.includes("[merge] race-window P2002"));
+    expect(raceLog).toBeDefined();
+    expect(raceLog).toContain("branch=use-existing-event");
+    logSpy.mockRestore();
+  });
+
   it("does not double-count: a successful create after a P2002 in the same batch counts as 1 created + 1 skipped", async () => {
     // Two events. First hits P2002, falls through to duplicate path. Second
     // creates normally. Verifies the per-event try/catch boundary doesn't

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1714,6 +1714,15 @@ async function processNewRawEvent(
 
     ctx.existingByFingerprint.set(fingerprint, winner);
     const dupId = await handleDuplicateFingerprint(event, fingerprint, ctx);
+    // Trace the race-window branch we took so production surprises are
+    // visible in Vercel logs (#1464 follow-up — operators previously had
+    // no signal once the catch was entered). Info level: a handled race
+    // is normal at concurrent-worker scale, not an operational problem.
+    console.log(
+      `[merge] race-window P2002 sourceId=${sourceId} fingerprint=${fingerprint} ` +
+        `winner.processed=${winner.processed} winner.eventId=${winner.eventId ?? "null"} ` +
+        `branch=${dupId === false ? "adopt-orphan" : dupId === null ? "skip" : "use-existing-event"}`,
+    );
     if (dupId === false) {
       // Orphan-reprocess signal: the racing worker's row is unprocessed
       // and unlinked. Pre-#1286 the caller would have created its own

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1718,10 +1718,14 @@ async function processNewRawEvent(
     // visible in Vercel logs (#1464 follow-up — operators previously had
     // no signal once the catch was entered). Info level: a handled race
     // is normal at concurrent-worker scale, not an operational problem.
+    let branch: "adopt-orphan" | "skip" | "use-existing-event";
+    if (dupId === false) branch = "adopt-orphan";
+    else if (dupId === null) branch = "skip";
+    else branch = "use-existing-event";
     console.log(
       `[merge] race-window P2002 sourceId=${sourceId} fingerprint=${fingerprint} ` +
         `winner.processed=${winner.processed} winner.eventId=${winner.eventId ?? "null"} ` +
-        `branch=${dupId === false ? "adopt-orphan" : dupId === null ? "skip" : "use-existing-event"}`,
+        `branch=${branch}`,
     );
     if (dupId === false) {
       // Orphan-reprocess signal: the racing worker's row is unprocessed

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -17,13 +17,21 @@ import { Prisma } from "@/generated/prisma/client";
  * Build a P2002 unique-constraint-violation error matching what the Prisma
  * client raises when an INSERT collides with a unique index. Pass `target`
  * to populate `err.meta.target`, which `isUniqueConstraintViolation` reads
- * when the caller wants to narrow to a specific constraint.
+ * when the caller wants to narrow to a specific constraint. Accepts either
+ * the array-of-columns shape (some engines) or the constraint-name string
+ * shape that the production Postgres engine actually emits (#1464).
  */
-export function buildPrismaUniqueViolation(target: string[]): Prisma.PrismaClientKnownRequestError {
-  return new Prisma.PrismaClientKnownRequestError(
-    `Unique constraint failed on the fields: ${target.join(", ")}`,
-    { code: "P2002", clientVersion: "0.0.0", meta: { target } },
-  );
+export function buildPrismaUniqueViolation(
+  target: string[] | string,
+): Prisma.PrismaClientKnownRequestError {
+  const message = Array.isArray(target)
+    ? `Unique constraint failed on the fields: ${target.join(", ")}`
+    : `Unique constraint failed on the constraint: \`${target}\``;
+  return new Prisma.PrismaClientKnownRequestError(message, {
+    code: "P2002",
+    clientVersion: "0.0.0",
+    meta: { target },
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- HashNYC was leaking 9 `eventErrors` per scrape against `RawEvent.@@unique([sourceId, fingerprint])`. Root cause: the production Postgres engine emits `meta.target` as the constraint NAME string (`"RawEvent_sourceId_fingerprint_key"`), not the column tuple unit tests use. `isUniqueConstraintViolation(["sourceId","fingerprint"])` only checked array-shape and returned `false` — the race-window catch at [src/pipeline/merge.ts:1707](src/pipeline/merge.ts#L1707) re-threw on every handled race.
- Helper now matches both shapes. String shape tokenizes the constraint name on `_` and requires every column to appear as an exact token (Codex pass — avoids `fingerprintVersion` shadowing `fingerprint`).
- Added an info-level branch trace at the catch site so future race-shape surprises are visible in Vercel logs — `branch=adopt-orphan | use-existing-event | skip`. Locked by a spy assertion.
- Test factory accepts `string | string[]` for `target`.

## Test plan
- [x] `npx tsc --noEmit && npm run lint && npm test` — 6681 passed, no regressions.
- [x] New `src/lib/prisma-errors.test.ts` — 10 it.each cases covering array shape, string shape, superstring collisions, non-P2002, missing meta.
- [x] New race-window test in `src/pipeline/merge.test.ts` for the Postgres string shape, locking both the duplicate-path routing and the trace log.
- [ ] Post-deploy live-verify: trigger HashNYC re-scrape from `/admin/sources/.../preview-action`. Expect `ScrapeLog.errors` to drop from 9 P2002 messages to 0 and one `[merge] race-window P2002 …` log line per handled race.

Closes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)