### PR TITLE
fix(phoenixhhh): parse compact `D MMM YY` date rows (#1473)

### DIFF
--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -75,6 +75,46 @@ const SAMPLE_EVENT_NO_DATE = `
   <a class="em-item-read-more" href="https://www.phoenixhhh.org/?event=tbd-event">Read More</a>
 </div>`;
 
+// Multi-day event with a long-form date range (#1473 — Annual Whiskey Row
+// Hash Campout shape on the live calendar). The adapter must take the FIRST
+// embedded MM/DD/YYYY, which is the event start date — handing the full
+// range string to chrono would be ambiguous.
+const SAMPLE_EVENT_MULTI_DAY = `
+<div class="em-item em-event">
+  <div class="em-item-image"></div>
+  <div class="em-item-info">
+    <div class="em-item-name"><a href="https://www.phoenixhhh.org/?event=campout">Annual Campout</a></div>
+    <div class="em-item-meta">
+      <div class="em-item-meta-line em-event-date">Thursday - 04/30/2026 - Sunday - 05/03/2026</div>
+      <div class="em-item-meta-line em-event-time">2:00 pm</div>
+    </div>
+    <a class="em-item-read-more" href="https://www.phoenixhhh.org/?event=campout">Read More</a>
+  </div>
+</div>`;
+
+// Live HTML captured from the Events Manager calendar (#1473). The plugin
+// renders some events in the compact `D MMM YY` row form instead of the
+// long `Weekday - MM/DD/YYYY` form. Prior to the fix, half of every month's
+// grid failed `Could not extract date from event item` parse errors.
+const SAMPLE_EVENT_COMPACT_DATE = `
+<div class="em-item em-event">
+  <div class="em-item-image has-placeholder">
+    <div class="em-item-image-placeholder">
+      <div class="date"><span class="day">27</span><span class="month">Apr</span></div>
+    </div>
+  </div>
+  <div class="em-item-info">
+    <div class="em-item-name"><a href="https://www.phoenixhhh.org/?event=lbh-741">LBH #741</a></div>
+    <div class="em-item-meta">
+      <div class="em-item-meta-line em-event-date em-event-meta-datetime"><span class="em-icon em-icon-calendar"></span><span>27 Apr 26</span></div>
+      <div class="em-item-meta-line em-event-time"><span>6:30 pm</span></div>
+      <div class="em-item-meta-line em-event-location em-event-meta-location"><a href="https://maps.google.com/?q=Groggys">Groggy's</a></div>
+    </div>
+    <div class="em-item-desc">Join us for the 741st running of LBH! Hare: Crayon.</div>
+    <a class="em-item-read-more" href="https://www.phoenixhhh.org/?event=lbh-741">More Info</a>
+  </div>
+</div>`;
+
 const DEFAULT_CONFIG = {
   kennelPatterns: [
     ["^LBH\\b|Lost Boobs", "LBH"],
@@ -146,6 +186,33 @@ describe("parseEventFromItem", () => {
     const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
 
     expect(event!.date).toBe("2026-03-02");
+  });
+
+  it("takes the start date from a multi-day long-form range (#1473)", () => {
+    // "Thursday - 04/30/2026 - Sunday - 05/03/2026" must resolve to the
+    // first embedded MM/DD/YYYY (event start), not the second.
+    const $ = cheerio.load(SAMPLE_EVENT_MULTI_DAY);
+    const $item = $(".em-item").first();
+    const compiled = makeCompiledPatterns(DEFAULT_CONFIG);
+    const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
+
+    expect(event!.date).toBe("2026-04-30");
+  });
+
+  it("extracts date from compact `D MMM YY` Events Manager row form (#1473)", () => {
+    // The Events Manager plugin renders calendar rows in two formats —
+    // the long `Weekday - MM/DD/YYYY` shape and the compact `D MMM YY`
+    // shape (e.g. "27 Apr 26"). Pre-fix, the latter failed the regex
+    // and ~half the month's grid was dropped as "Could not extract date".
+    const $ = cheerio.load(SAMPLE_EVENT_COMPACT_DATE);
+    const $item = $(".em-item").first();
+    const compiled = makeCompiledPatterns(DEFAULT_CONFIG);
+    const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
+
+    expect(event).not.toBeNull();
+    expect(event!.date).toBe("2026-04-27");
+    expect(event!.startTime).toBe("18:30");
+    expect(event!.location).toBe("Groggy's");
   });
 
   it("extracts start time", () => {

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -14,7 +14,7 @@ import type { AnyNode } from "domhandler";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails, ParseError } from "../types";
 import { safeFetch } from "../safe-fetch";
-import { parse12HourTime, validateSourceConfig, compilePatterns, buildDateWindow, stripHtmlTags, decodeEntities, extractHashRunNumber } from "../utils";
+import { parse12HourTime, validateSourceConfig, compilePatterns, buildDateWindow, stripHtmlTags, decodeEntities, extractHashRunNumber, chronoParseDate } from "../utils";
 import { extractHares } from "../hare-extraction";
 
 // ── Config shape ──
@@ -90,12 +90,26 @@ export function parseEventFromItem(
   }
   // If no title from img alt, it will be fetched from the detail page later
 
-  // Date extraction: "Monday - 03/02/2026"
+  // Date extraction. Events Manager emits two shapes:
+  //   - Long: "Monday - 03/02/2026" (single-day events with weekday prefix,
+  //     or "Thursday - 04/30/2026 - Sunday - 05/03/2026" multi-day spans)
+  //   - Compact: "27 Apr 26" (#1473 — appears for events the plugin renders
+  //     in the compact calendar row form; broke the legacy `MM/DD/YYYY`-only
+  //     regex against ~half of the May 2026 month grid)
+  // Try the long form first (matches an embedded `MM/DD/YYYY` even in the
+  // multi-day case — first date wins, matching prior behavior). Fall back to
+  // `chronoParseDate` which has a `D MMM YY` fast-path baked in.
   const dateText = $item.find(".em-item-meta-line.em-event-date").text().trim();
   const dateMatch = /(\d{2})\/(\d{2})\/(\d{4})/.exec(dateText);
-  if (!dateMatch) return null;
-  const [, mm, dd, yyyy] = dateMatch;
-  const date = `${yyyy}-${mm}-${dd}`;
+  let date: string;
+  if (dateMatch) {
+    const [, mm, dd, yyyy] = dateMatch;
+    date = `${yyyy}-${mm}-${dd}`;
+  } else {
+    const parsed = chronoParseDate(dateText);
+    if (!parsed) return null;
+    date = parsed;
+  }
 
   // Time extraction: "6:30 pm - 9:30 pm"
   const timeText = $item.find(".em-item-meta-line.em-event-time").text().trim();


### PR DESCRIPTION
## Summary
- Phoenix HHH Big Ass Calendar adapter has been failing parse all of 2026-05-17. Root cause: the Events Manager plugin renders calendar rows in two shapes — long `Weekday - MM/DD/YYYY` and compact `D MMM YY` (e.g. "27 Apr 26"). Adapter only handled the first, so ~half of every month's grid was dropped.
- Fix: match the embedded `MM/DD/YYYY` first (preserves "first date wins" for multi-day long-form ranges), then fall back to `chronoParseDate` from utils (already has a `D MMM YY` fast-path with year-boundary + impossible-date rejection — see existing utils tests).

## Live verification

Ran the adapter against `https://www.phoenixhhh.org/?page_id=21` (days=90):

```
Events: 80
Errors: 0
Diagnostic: { monthsFetched: 7, totalItems: 115, eventsParsed: 80, titlesFetched: 30, parseErrors: 0 }

Kennel breakdown:
  wrong-way    count=59  sample=2026-02-21 | Wrong Way #1150 – Thailor Plays Pantsless Cupid
  lbh-phx      count=16  sample=2026-02-23 | LBH #732: Gay Ol Floundering
  hump-d       count=4   sample=2026-03-04 | Hump D Hash 3/4 – Roses by the Stairs
  fdtdd        count=1   sample=2026-03-13 | From Dusk Till Down-Down #26

Date range: 2026-02-21 → 2026-06-20
```

All 4 kennels (LBH, Hump D, Wrong Way, FDTDD) ingesting cleanly.

## Test plan
- [x] `npx tsc --noEmit && npm run lint && npm test src/adapters/html-scraper/phoenixhhh` — 31 passed.
- [x] Full suite — 6672 passed, no regressions.
- [x] Live verify per `.claude/rules/live-verification.md` — above.

Closes #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)