### PR TITLE
fix(gcal): three title-extraction bugs — DWH3 slash, Austin stub, MoA2H3 doubled prefix

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -882,12 +882,15 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "ah3",
-        // Title format: "{Hare1 and Hare2} - AH3 #N". Requiring an explicit
-        // " - " separator keeps the dash out of the capture group (#1210 —
-        // lazy match `(.+?)\s+AH3\s+#` left a trailing " -" on every event)
-        // and avoids matching titles where the slot before AH3 isn't a hare
-        // (e.g. titles whose author wrote a trail-type name in the hare slot).
-        titleHarePattern: String.raw`^(.+?)\s+-\s+AH3\s+#`,
+        // #1466 — no titleHarePattern. Kennel admins use the prefix slot
+        // ambiguously for both hare lists ("Alice & Bob - AH3 #N") and
+        // trail titles ("VSP Red Dress Run Hangover - AH3 #N"), and no
+        // regex shape distinguishes them safely. Letting the lazy
+        // `^(.+?) - AH3 #` capture run silently routed trail titles into
+        // `haresText` and truncated the user-visible title to a stub
+        // ("- AH3 #493"). With no titleHarePattern, all summaries pass
+        // through verbatim; hares come from the description path only
+        // (which already handles the common formats Austin uses).
       },
       kennelCodes: ["ah3"],
     },
@@ -2494,7 +2497,13 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "every_6h",
       scrapeDays: 90,
-      config: { defaultKennelTag: "moa2h3" },
+      config: {
+        defaultKennelTag: "moa2h3",
+        // #1458 — kennel admins double-paste "MoA2H3" into event titles on
+        // the source side. Opt in to the doubled-prefix strip so titles
+        // like "MoA2H3 MoA2H3 Red Dress Run" surface as a single prefix.
+        stripDoubledKennelPrefix: true,
+      },
       kennelCodes: ["moa2h3"],
     },
     {

--- a/scripts/live-verify-gcal-title-bundle.ts
+++ b/scripts/live-verify-gcal-title-bundle.ts
@@ -3,6 +3,9 @@
  *
  * Run: `set -a && source .env && set +a && npx tsx scripts/live-verify-gcal-title-bundle.ts`
  *
+ * Exits non-zero when any check detects a regression OR when a fetch
+ * fails — usable as a CI gate.
+ *
  * Read-only — does not mutate the DB.
  */
 import "dotenv/config";
@@ -11,6 +14,24 @@ import type { RawEventData } from "@/adapters/types";
 import { SOURCES } from "../prisma/seed-data/sources";
 import type { Source } from "@/generated/prisma/client";
 
+interface Check {
+  /** Label shown next to the count; the "(expect 0)" suffix is added automatically. */
+  label: string;
+  /** Predicate over a single event; events matching count toward `failedChecks`. */
+  predicate: (e: RawEventData) => boolean;
+}
+
+interface Target {
+  sourceName: string;
+  describe: string;
+  /** Per-event regression predicates. Any non-zero count fails the script. */
+  checks: Check[];
+  /** Optional summary lines (counts, etc.) appended before samples. */
+  summary?: (events: RawEventData[]) => string[];
+  /** How many sample events to print after the checks/summary lines. */
+  sampleLimit?: number;
+}
+
 function formatSample(e: RawEventData): string {
   const time = e.startTime ?? "all-day";
   const titleSlice = (e.title ?? "").slice(0, 80);
@@ -18,62 +39,77 @@ function formatSample(e: RawEventData): string {
   return `[${e.date} ${time}] title=${JSON.stringify(titleSlice)} | hares=${e.hares ?? "—"}${runSuffix}`;
 }
 
-interface Target {
-  sourceName: string;
-  describe: string;
-  inspect: (events: RawEventData[]) => string[];
-}
+/** Trail-vocab keywords that should never appear in a `hares` value. Used
+ *  by the Austin H3 check to detect title-text leaking into haresText. */
+const TRAIL_VOCAB_RE = /\b(?:Run Hangover|Red Dress|Hash Trash|Mardi Hash)\b/i;
 
 const TARGETS: Target[] = [
   {
     sourceName: "Dead Whores H3 Calendar",
     describe: "#1471 — no trailing '/' in title; hares still extracted",
-    inspect: (events) => {
-      const slashTitles = events.filter((e) => e.title && /\/\s*$/.test(e.title));
-      const lines = [
-        `events: ${events.length}`,
-        `with hares: ${events.filter((e) => !!e.hares).length}`,
-        `titles ending in '/': ${slashTitles.length} (expect 0)`,
-      ];
-      for (const e of events.slice(0, 10)) lines.push(`  ${formatSample(e)}`);
-      return lines;
-    },
+    checks: [
+      { label: "titles ending in '/'", predicate: (e) => !!e.title && /\/\s*$/.test(e.title) },
+    ],
+    summary: (events) => [`with hares: ${events.filter((e) => !!e.hares).length}`],
   },
   {
     sourceName: "Austin H3 Calendar",
-    describe: "#1466 — stub-revert preserves descriptive titles; bogus hares cleared",
-    inspect: (events) => {
-      // Detect both pre-fix shapes ("- AH3 #N") and any residual bare
-      // "AH3 #N" stub that the prefix-cleanup might leave behind if the
-      // opt-in flag isn't seeded.
-      const stubTitles = events.filter((e) => e.title && /^-?\s*AH3\s*#\s*\d+\s*$/i.test(e.title));
-      // After stub-revert, hares should not contain trail-title text. Look
-      // for trail-vocab keywords leaking into haresText.
-      const haresLeakage = events.filter((e) => e.hares && /\b(?:Run Hangover|Red Dress|Hash Trash|Mardi Hash)\b/i.test(e.hares));
-      const lines = [
-        `events: ${events.length}`,
-        `with hares: ${events.filter((e) => !!e.hares).length}`,
-        `bare 'AH3 #N' / '- AH3 #N' stub titles: ${stubTitles.length} (expect 0)`,
-        `trail-vocab leakage in hares: ${haresLeakage.length} (expect 0)`,
-      ];
-      for (const e of events.slice(0, 12)) lines.push(`  ${formatSample(e)}`);
-      return lines;
-    },
+    describe: "#1466 — descriptive titles preserved; bogus hares cleared",
+    checks: [
+      // Both pre-fix shape "- AH3 #N" and bare "AH3 #N" stub.
+      { label: "bare 'AH3 #N' / '- AH3 #N' stub titles", predicate: (e) => !!e.title && /^-?\s*AH3\s*#\s*\d+\s*$/i.test(e.title) },
+      { label: "trail-vocab leakage in hares", predicate: (e) => !!e.hares && TRAIL_VOCAB_RE.test(e.hares) },
+    ],
+    summary: (events) => [`with hares: ${events.filter((e) => !!e.hares).length}`],
+    sampleLimit: 12,
   },
   {
     sourceName: "MoA2H3 Google Calendar",
     describe: "#1458 — no doubled 'MoA2H3 MoA2H3' prefix",
-    inspect: (events) => {
-      const doubled = events.filter((e) => e.title && /^moa2h3\s+moa2h3\b/i.test(e.title));
-      const lines = [
-        `events: ${events.length}`,
-        `with doubled 'MoA2H3 MoA2H3' prefix: ${doubled.length} (expect 0)`,
-      ];
-      for (const e of events.slice(0, 10)) lines.push(`  ${formatSample(e)}`);
-      return lines;
-    },
+    checks: [
+      { label: "doubled 'MoA2H3 MoA2H3' prefix", predicate: (e) => !!e.title && /^moa2h3\s+moa2h3\b/i.test(e.title) },
+    ],
   },
 ];
+
+async function runTarget(adapter: GoogleCalendarAdapter, target: Target): Promise<number> {
+  const seedRow = SOURCES.find((s) => s.name === target.sourceName);
+  console.log(`\n## ${target.sourceName}`);
+  console.log(`   ${target.describe}`);
+  if (!seedRow) {
+    console.log(`   NOT FOUND IN SEED`);
+    return 1;
+  }
+  const source = {
+    id: "stub",
+    name: seedRow.name,
+    url: seedRow.url,
+    type: seedRow.type as Source["type"],
+    enabled: true,
+    config: (seedRow as { config?: unknown }).config ?? null,
+  } as unknown as Source;
+  try {
+    const result = await adapter.fetch(source, { days: 365 });
+    console.log(`   diag: ${JSON.stringify(result.diagnosticContext)}`);
+    console.log(`   events: ${result.events.length}`);
+    for (const line of target.summary?.(result.events) ?? []) console.log(`   ${line}`);
+    let failedChecks = 0;
+    for (const check of target.checks) {
+      const violators = result.events.filter(check.predicate);
+      console.log(`   ${check.label}: ${violators.length} (expect 0)`);
+      if (violators.length > 0) {
+        failedChecks += violators.length;
+        for (const e of violators.slice(0, 5)) console.log(`     VIOLATION ${formatSample(e)}`);
+      }
+    }
+    for (const e of result.events.slice(0, target.sampleLimit ?? 10)) console.log(`   ${formatSample(e)}`);
+    if (failedChecks > 0) console.log(`   ✗ ${failedChecks} regression(s) detected`);
+    return failedChecks;
+  } catch (err) {
+    console.log(`   FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
 
 async function main() {
   if (!process.env.GOOGLE_CALENDAR_API_KEY) {
@@ -81,35 +117,8 @@ async function main() {
   }
   const adapter = new GoogleCalendarAdapter();
   let failures = 0;
-  for (const target of TARGETS) {
-    const seedRow = SOURCES.find((s) => s.name === target.sourceName);
-    if (!seedRow) {
-      console.log(`\n## ${target.sourceName} — NOT FOUND IN SEED`);
-      failures++;
-      continue;
-    }
-    const source = {
-      id: "stub",
-      name: seedRow.name,
-      url: seedRow.url,
-      type: seedRow.type as Source["type"],
-      enabled: true,
-      config: (seedRow as { config?: unknown }).config ?? null,
-    } as unknown as Source;
-    console.log(`\n## ${target.sourceName}`);
-    console.log(`   ${target.describe}`);
-    try {
-      const result = await adapter.fetch(source, { days: 365 });
-      console.log(`   diag: ${JSON.stringify(result.diagnosticContext)}`);
-      for (const line of target.inspect(result.events)) {
-        console.log(`   ${line}`);
-      }
-    } catch (err) {
-      failures++;
-      console.log(`   FAILED: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-  console.log(failures === 0 ? "\n✓ All targets fetched" : `\n✗ ${failures} failed`);
+  for (const target of TARGETS) failures += await runTarget(adapter, target);
+  console.log(failures === 0 ? "\n✓ All targets clean" : `\n✗ ${failures} regression(s) / fetch failure(s)`);
   process.exit(failures === 0 ? 0 : 1);
 }
 

--- a/scripts/live-verify-gcal-title-bundle.ts
+++ b/scripts/live-verify-gcal-title-bundle.ts
@@ -1,0 +1,116 @@
+/**
+ * Live verification for the GCal title-bundle fixes (#1471, #1466, #1458).
+ *
+ * Run: `set -a && source .env && set +a && npx tsx scripts/live-verify-gcal-title-bundle.ts`
+ *
+ * Read-only — does not mutate the DB.
+ */
+import "dotenv/config";
+import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
+import type { RawEventData } from "@/adapters/types";
+import { SOURCES } from "../prisma/seed-data/sources";
+import type { Source } from "@/generated/prisma/client";
+
+function formatSample(e: RawEventData): string {
+  const time = e.startTime ?? "all-day";
+  const titleSlice = (e.title ?? "").slice(0, 80);
+  const runSuffix = e.runNumber ? ` | run=${e.runNumber}` : "";
+  return `[${e.date} ${time}] title=${JSON.stringify(titleSlice)} | hares=${e.hares ?? "—"}${runSuffix}`;
+}
+
+interface Target {
+  sourceName: string;
+  describe: string;
+  inspect: (events: RawEventData[]) => string[];
+}
+
+const TARGETS: Target[] = [
+  {
+    sourceName: "Dead Whores H3 Calendar",
+    describe: "#1471 — no trailing '/' in title; hares still extracted",
+    inspect: (events) => {
+      const slashTitles = events.filter((e) => e.title && /\/\s*$/.test(e.title));
+      const lines = [
+        `events: ${events.length}`,
+        `with hares: ${events.filter((e) => !!e.hares).length}`,
+        `titles ending in '/': ${slashTitles.length} (expect 0)`,
+      ];
+      for (const e of events.slice(0, 10)) lines.push(`  ${formatSample(e)}`);
+      return lines;
+    },
+  },
+  {
+    sourceName: "Austin H3 Calendar",
+    describe: "#1466 — stub-revert preserves descriptive titles; bogus hares cleared",
+    inspect: (events) => {
+      // Detect both pre-fix shapes ("- AH3 #N") and any residual bare
+      // "AH3 #N" stub that the prefix-cleanup might leave behind if the
+      // opt-in flag isn't seeded.
+      const stubTitles = events.filter((e) => e.title && /^-?\s*AH3\s*#\s*\d+\s*$/i.test(e.title));
+      // After stub-revert, hares should not contain trail-title text. Look
+      // for trail-vocab keywords leaking into haresText.
+      const haresLeakage = events.filter((e) => e.hares && /\b(?:Run Hangover|Red Dress|Hash Trash|Mardi Hash)\b/i.test(e.hares));
+      const lines = [
+        `events: ${events.length}`,
+        `with hares: ${events.filter((e) => !!e.hares).length}`,
+        `bare 'AH3 #N' / '- AH3 #N' stub titles: ${stubTitles.length} (expect 0)`,
+        `trail-vocab leakage in hares: ${haresLeakage.length} (expect 0)`,
+      ];
+      for (const e of events.slice(0, 12)) lines.push(`  ${formatSample(e)}`);
+      return lines;
+    },
+  },
+  {
+    sourceName: "MoA2H3 Google Calendar",
+    describe: "#1458 — no doubled 'MoA2H3 MoA2H3' prefix",
+    inspect: (events) => {
+      const doubled = events.filter((e) => e.title && /^moa2h3\s+moa2h3\b/i.test(e.title));
+      const lines = [
+        `events: ${events.length}`,
+        `with doubled 'MoA2H3 MoA2H3' prefix: ${doubled.length} (expect 0)`,
+      ];
+      for (const e of events.slice(0, 10)) lines.push(`  ${formatSample(e)}`);
+      return lines;
+    },
+  },
+];
+
+async function main() {
+  if (!process.env.GOOGLE_CALENDAR_API_KEY) {
+    throw new Error("GOOGLE_CALENDAR_API_KEY not set — source .env first");
+  }
+  const adapter = new GoogleCalendarAdapter();
+  let failures = 0;
+  for (const target of TARGETS) {
+    const seedRow = SOURCES.find((s) => s.name === target.sourceName);
+    if (!seedRow) {
+      console.log(`\n## ${target.sourceName} — NOT FOUND IN SEED`);
+      failures++;
+      continue;
+    }
+    const source = {
+      id: "stub",
+      name: seedRow.name,
+      url: seedRow.url,
+      type: seedRow.type as Source["type"],
+      enabled: true,
+      config: (seedRow as { config?: unknown }).config ?? null,
+    } as unknown as Source;
+    console.log(`\n## ${target.sourceName}`);
+    console.log(`   ${target.describe}`);
+    try {
+      const result = await adapter.fetch(source, { days: 365 });
+      console.log(`   diag: ${JSON.stringify(result.diagnosticContext)}`);
+      for (const line of target.inspect(result.events)) {
+        console.log(`   ${line}`);
+      }
+    } catch (err) {
+      failures++;
+      console.log(`   FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  console.log(failures === 0 ? "\n✓ All targets fetched" : `\n✗ ${failures} failed`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -974,6 +974,23 @@ describe("Austin H3 title pass-through (#1466)", () => {
     expect(result!.title).toBe(summary);
     expect(result!.hares).toBeUndefined();
   });
+
+  it("still extracts hares from description when titleHarePattern is absent", () => {
+    // Without titleHarePattern, hares still come from the description's
+    // labeled `Hare:` / `Hares:` line (the default extractHares path).
+    // Guards against accidental regressions if anyone re-disables that.
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "VSP Red Dress Run Hangover - AH3 #493",
+        description: "Hare: Banana Boat",
+        start: { dateTime: "2026-04-04T14:00:00-05:00" },
+      }),
+      austinConfig,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("VSP Red Dress Run Hangover - AH3 #493");
+    expect(result!.hares).toBe("Banana Boat");
+  });
 });
 
 // #1458 — opt-in guard against doubled kennelCode prefix in title.
@@ -986,6 +1003,7 @@ describe("doubled kennelCode prefix guard (#1458)", () => {
   it.each([
     ["MoA2H3 MoA2H3 Red Dress Run", "MoA2H3 Red Dress Run", "doubled prefix stripped (case-insensitive)"],
     ["MoA2H3 moa2h3 Red Dress Run", "MoA2H3 Red Dress Run", "typed casing of surviving prefix preserved"],
+    ["MoA2H3 MoA2H3", "MoA2H3", "exact-doubled placeholder (no trailing content)"],
     ["MoA2H3 Red Dress Run", "MoA2H3 Red Dress Run", "no-op when title is already single-prefixed"],
     ["Brain Fart", "Brain Fart", "no-op when title is unrelated to the kennelCode"],
   ])("summary %j → title %j (%s)", (summary, expectedTitle) => {

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -703,6 +703,23 @@ describe("titleHarePattern — hare extraction from summary", () => {
       expect(result).not.toBeNull();
       expect(result!.hares).toBe(expectedHares);
     });
+
+    // #1471 — slash-delimited variants left a trailing "/" in the title
+    // after the hare capture was stripped, because the spansEntireTitle
+    // cleanup didn't include `/` in the trailing-delimiter strip.
+    it("strips trailing '/' from DWH3 title after slash-delimited hare capture", () => {
+      const result = buildRawEventFromGCalItem(
+        testGCalEvent({
+          summary: "Dead Whores H3/Milkbone and Strippin in the Rain",
+          start: { dateTime: "2026-05-17T13:00:00-07:00" },
+        }),
+        { defaultKennelTag: "dwh3", titleHarePattern: dwh3Pattern },
+        { compiledTitleHarePatterns: [dwh3RE] },
+      );
+      expect(result).not.toBeNull();
+      expect(result!.hares).toBe("Milkbone and Strippin in the Rain");
+      expect(result!.title).toBe("Dead Whores H3");
+    });
   });
 
   it("handles SUFFIX-style titleHarePattern (hares at end of title, not start) (#575)", () => {
@@ -922,6 +939,81 @@ describe("titleHarePattern trailing-dash strip on capture (#1210)", () => {
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Crusty Beaver and Pissfull Ignorinse");
     expect(result!.hares).not.toMatch(/[-–—]\s*$/);
+  });
+});
+
+// #1466 — Austin H3's titleHarePattern was removed because no regex shape
+// safely distinguishes hare lists ("Alice & Bob - AH3 #N") from trail
+// titles ("VSP Red Dress Run Hangover - AH3 #N") in the prefix slot.
+// Verify the production config has no titleHarePattern and the summary
+// passes through verbatim. Hares are still extracted from the description
+// path for events that have them there.
+describe("Austin H3 title pass-through (#1466)", () => {
+  const austinSource = SOURCES.find((s) => s.name === "Austin H3 Calendar");
+  if (!austinSource) throw new Error("Austin H3 Calendar seed source missing");
+  const austinConfig = austinSource.config as { defaultKennelTag: string; titleHarePattern?: string };
+
+  it("seed config has no titleHarePattern", () => {
+    expect(austinConfig.titleHarePattern).toBeUndefined();
+    expect(austinConfig.defaultKennelTag).toBe("ah3");
+  });
+
+  it.each<[string, string]>([
+    ["VSP Red Dress Run Hangover - AH3 #493", "trail title preserved"],
+    ["Alice & Bob - AH3 #2269", "hare-list-shaped title still preserved (no hare extraction from title)"],
+    ["AH3 - Trail #2226 Ditch, Sweet Thighs, and F*cktronix", "modern format preserved"],
+  ])("summary %j → title kept verbatim (%s)", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary,
+        start: { dateTime: "2026-04-04T14:00:00-05:00" },
+      }),
+      austinConfig,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe(summary);
+    expect(result!.hares).toBeUndefined();
+  });
+});
+
+// #1458 — opt-in guard against doubled kennelCode prefix in title.
+// Some kennel admins paste the prefix twice on the source side
+// ("MoA2H3 MoA2H3 Red Dress Run"); the adapter de-dups symptom-side. Gated
+// per-source so unrelated kennels' legitimate titles aren't rewritten.
+describe("doubled kennelCode prefix guard (#1458)", () => {
+  const moa2Cfg = { defaultKennelTag: "moa2h3", stripDoubledKennelPrefix: true };
+
+  it.each([
+    ["MoA2H3 MoA2H3 Red Dress Run", "MoA2H3 Red Dress Run", "doubled prefix stripped (case-insensitive)"],
+    ["MoA2H3 moa2h3 Red Dress Run", "MoA2H3 Red Dress Run", "typed casing of surviving prefix preserved"],
+    ["MoA2H3 Red Dress Run", "MoA2H3 Red Dress Run", "no-op when title is already single-prefixed"],
+    ["Brain Fart", "Brain Fart", "no-op when title is unrelated to the kennelCode"],
+  ])("summary %j → title %j (%s)", (summary, expectedTitle) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary,
+        start: { dateTime: "2026-06-07T13:00:00-04:00" },
+      }),
+      moa2Cfg,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe(expectedTitle);
+  });
+
+  it("guard is no-op when stripDoubledKennelPrefix flag is not set", () => {
+    // Defensive: confirms the opt-in. Without the flag, a doubled prefix
+    // passes through untouched (relying on description-side fallback or
+    // admin cleanup at the source). Prevents accidental scope creep to
+    // other sources whose admins haven't been observed double-pasting.
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "MoA2H3 MoA2H3 Red Dress Run",
+        start: { dateTime: "2026-06-07T13:00:00-04:00" },
+      }),
+      { defaultKennelTag: "moa2h3" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("MoA2H3 MoA2H3 Red Dress Run");
   });
 });
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -699,6 +699,15 @@ interface CalendarSourceConfig {
    * Undefined preserves the legacy raw-slice behavior.
    */
   timezone?: string;
+  /**
+   * Opt-in: strip a doubled kennelCode prefix from the start of the title
+   * (e.g. "MoA2H3 MoA2H3 Red Dress Run" → "MoA2H3 Red Dress Run"). #1458.
+   * Off by default — set true only for sources whose admins are known to
+   * paste the prefix twice. Generic enablement risks rewriting legitimate
+   * brand titles like "X X News" when the kennelCode happens to be a
+   * common word.
+   */
+  stripDoubledKennelPrefix?: boolean;
 }
 
 /**
@@ -1069,6 +1078,21 @@ export function buildRawEventFromGCalItem(
   // an empty string with a configured fallback; without this strip the
   // title shipped to users as "… -" / "… :".
   title = title.replace(/\s*[-–—:]\s*$/, "").trim(); // NOSONAR — anchored end-of-string strip, no nested quantifiers
+  // #1458 — opt-in: strip a doubled kennelCode prefix at title start
+  // ("MoA2H3 MoA2H3 Red Dress Run" → "MoA2H3 Red Dress Run"). Some kennels
+  // double-paste the prefix on the GCal admin side. merge.ts's
+  // rewriteStaleDefaultTitle only handles "<kennelCode> Trail #N" patterns,
+  // not free-form titles. Gated on per-source config to avoid rewriting
+  // legitimate "X X News" titles where the kennelCode happens to be a
+  // common word. Keep the first occurrence (preserves typed casing) and
+  // drop the second.
+  if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
+    const tagLen = kennelTag.length;
+    const tagLc = kennelTag.toLowerCase();
+    if (title.toLowerCase().startsWith(`${tagLc} ${tagLc} `)) {
+      title = (title.slice(0, tagLen + 1) + title.slice(tagLen * 2 + 2)).trim();
+    }
+  }
   // Stale-default detection: equality is whitespace-insensitive so a SUMMARY
   // of "4X2 H4" still matches kennelTag "4x2h4".
   if (titleMatchesKennelTag(title, kennelTag) && rawDescription) {
@@ -1101,14 +1125,21 @@ export function buildRawEventFromGCalItem(
       if (spansEntireTitle) {
         // Regex anchors entire title (Aloha `^AH3\s*#\d+.*-\s+(.+)$`):
         // strip only the capture group so the non-hare prefix survives.
+        // #1471 — include `/` so DWH3's slash-delimited variant
+        // ("Dead Whores H3/Milkbone…") trims its trailing separator.
         cleaned = title
           .slice(0, captureStart)
-          .replace(/\s*[-–—]\s*$/, "")
+          .replace(/\s*[-–—/]\s*$/, "") // NOSONAR — anchored end-of-string strip, no nested quantifiers
           .trim();
       } else if (start === 0 && captureStart === 0) {
         // Pure prefix capture (e.g. "Alice AH3 #2269"): strip the hare
-        // text from the start, preserve the match's trailing delimiter.
-        cleaned = title.slice(hareText.length).trimStart();
+        // text from the start, then drop any leading separator delimiter
+        // left behind by patterns that require " - " (or "/", "—" …)
+        // between the hare list and the rest of the title (#1466).
+        cleaned = title
+          .slice(hareText.length)
+          .trimStart()
+          .replace(/^[-–—:/]+\s*/, ""); // NOSONAR — anchored start-of-string strip, no nested quantifiers
       } else {
         // Mid- or partial-suffix match: strip the full regex span (label
         // + name) and collapse leftover delimiters. Handles Stuttgart

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1079,18 +1079,22 @@ export function buildRawEventFromGCalItem(
   // title shipped to users as "… -" / "… :".
   title = title.replace(/\s*[-–—:]\s*$/, "").trim(); // NOSONAR — anchored end-of-string strip, no nested quantifiers
   // #1458 — opt-in: strip a doubled kennelCode prefix at title start
-  // ("MoA2H3 MoA2H3 Red Dress Run" → "MoA2H3 Red Dress Run"). Some kennels
-  // double-paste the prefix on the GCal admin side. merge.ts's
-  // rewriteStaleDefaultTitle only handles "<kennelCode> Trail #N" patterns,
-  // not free-form titles. Gated on per-source config to avoid rewriting
-  // legitimate "X X News" titles where the kennelCode happens to be a
-  // common word. Keep the first occurrence (preserves typed casing) and
-  // drop the second.
+  // ("MoA2H3 MoA2H3 Red Dress Run" → "MoA2H3 Red Dress Run", or the bare
+  // placeholder "MoA2H3 MoA2H3" → "MoA2H3"). Some kennels double-paste
+  // the prefix on the GCal admin side. merge.ts's rewriteStaleDefaultTitle
+  // only handles "<kennelCode> Trail #N" patterns, not free-form titles.
+  // Gated on per-source config to avoid rewriting legitimate "X X News"
+  // titles where the kennelCode happens to be a common word.
   if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
     const tagLen = kennelTag.length;
     const tagLc = kennelTag.toLowerCase();
-    if (title.toLowerCase().startsWith(`${tagLc} ${tagLc} `)) {
-      title = (title.slice(0, tagLen + 1) + title.slice(tagLen * 2 + 2)).trim();
+    const lc = title.toLowerCase();
+    const doubledLen = tagLen * 2 + 1; // "<tag> <tag>"
+    // Match exact doubled prefix OR doubled prefix followed by a space + rest.
+    if (lc.startsWith(`${tagLc} ${tagLc}`) && (title.length === doubledLen || title[doubledLen] === " ")) {
+      // Keep the first occurrence (preserves typed casing), drop the
+      // second and the separator space.
+      title = (title.slice(0, tagLen) + title.slice(doubledLen)).trim();
     }
   }
   // Stale-default detection: equality is whitespace-insensitive so a SUMMARY


### PR DESCRIPTION
## Summary

Quick-win bundle for three independent GCal title-extraction bugs surfaced by the audit pipeline.

- **DWH3 trailing slash** ([#1471](https://github.com/johnrclem/hashtracks-web/issues/1471)) — when `titleHarePattern` spans the entire title (DWH3's `/`-delimited hare format), the spans-entire-title cleanup didn't include `/` in the trailing-delim strip, leaving titles like `"Dead Whores H3/"`. Fix: extend the strip char-class to include `/`. Also extends the pure-prefix branch to drop leading separators (`- `, `/`, `: `) left behind by patterns that require a separator between hare and rest.

- **Austin H3 stub title** ([#1466](https://github.com/johnrclem/hashtracks-web/issues/1466)) — Austin's lazy `^(.+?)\s+-\s+AH3\s+#` pattern misclassified trail titles as hare lists (`VSP Red Dress Run Hangover - AH3 #493` → title `"- AH3 #493"`). Multi-round adversarial review confirmed no regex shape reliably distinguishes hare lists from trail titles in this slot — every alternative left residual corruption. Final design: **remove the `titleHarePattern` entirely**. Titles now pass through verbatim; hares come from the description path. Trade-off documented inline: summary-only hare attribution is dropped for the rare events where hares appeared only in the title. Anchored on project philosophy: fail-loud over silent corruption.

- **MoA2H3 doubled prefix** ([#1458](https://github.com/johnrclem/hashtracks-web/issues/1458)) — kennel admins double-paste `MoA2H3` into event titles on the source side. Added an opt-in `stripDoubledKennelPrefix` flag on `CalendarSourceConfig`. When set, the adapter strips a duplicated kennelCode at title start with case-insensitive matching that preserves the typed casing of the surviving prefix. Per-source so unrelated kennels with legitimate repeated leading words aren't affected.

## Test plan

- [x] `npx tsc --noEmit` (clean)
- [x] `npm run lint` (0 errors)
- [x] `npm test` — 6681/6708 pass (7 skipped, 25 todo; all pre-existing)
- [x] Live verification via [scripts/live-verify-gcal-title-bundle.ts](scripts/live-verify-gcal-title-bundle.ts) against all three production calendars:
  - **DWH3**: 16 events, 0 titles ending in `/`, hares still extracted
  - **Austin H3**: 116 events, 0 stub titles, 0 trail-vocab leakage in hares
  - **MoA2H3**: 46 events, 0 doubled `MoA2H3 MoA2H3` prefixes (source returns single-prefix; defensive guard tested via synthetic fixture)
- [x] `/simplify` agents (reuse / quality / efficiency) run — addressed dedup-guard duplication, refactored MoA2H3 tests to `it.each`, replaced regex de-dup with `startsWith`+`slice`
- [x] `/codex:adversarial-review` (6 rounds) — final design anchors on project philosophy after Codex oscillated between "corruption" and "data loss" trade-off framings

## Notes

- New verification script: [scripts/live-verify-gcal-title-bundle.ts](scripts/live-verify-gcal-title-bundle.ts) — read-only, requires `GOOGLE_CALENDAR_API_KEY` in env.
- Three existing tests' expected title assertions are unchanged from main (stub-revert mechanism explored mid-review but removed in the final design).
- After deploy: the next scrape window will recompute DWH3 + MoA2H3 titles and the merge pipeline will overwrite the canonical Events; no SQL backfill needed.

Closes #1471
Closes #1466
Closes #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)