### PR TITLE
fix(adapters): Phoenix HHH + Chicago H3 parse fixes (4 issues)

### DIFF
--- a/src/adapters/html-scraper/chicago-hash.test.ts
+++ b/src/adapters/html-scraper/chicago-hash.test.ts
@@ -152,6 +152,62 @@ describe("parseBodyFields", () => {
     expect(result.hares).toBe("Solo Runner");
     expect(result.location).toBeUndefined();
   });
+
+  // ── #1467: leading-dash artifact strip ──
+
+  it.each([
+    {
+      label: "leading '- ' inside colon-delimited Hares",
+      body: "Hares: - Antiques Load Show & Ritalin Cum Bubble  Hash Cash: $10",
+      expected: "Antiques Load Show & Ritalin Cum Bubble",
+    },
+    {
+      label: "en-dash separator instead of colon (Memorial Day post format)",
+      body: "Hares – Antiques Load Show & Ritalin Cum Bubble  Hash Cash: $10",
+      expected: "Antiques Load Show & Ritalin Cum Bubble",
+    },
+    {
+      label: "em-dash separator instead of colon",
+      body: "Hares — Antiques Load Show & Ritalin Cum Bubble",
+      expected: "Antiques Load Show & Ritalin Cum Bubble",
+    },
+    {
+      label: "mixed leading bullets and dashes are all stripped",
+      body: "Hares: –— • * Some Name",
+      expected: "Some Name",
+    },
+    {
+      label: "single hyphen separator (Hares - Name)",
+      body: "Hares - Antiques Load Show",
+      expected: "Antiques Load Show",
+    },
+  ])("strips leading dash/bullet artifact: $label (#1467)", ({ body, expected }) => {
+    const result = parseBodyFields(body);
+    expect(result.hares).toBe(expected);
+    expect(result.hares).not.toMatch(/^[-–—•*\s]/);
+  });
+
+  it("strips leading dash from non-hare fields too (#1467 consistency)", () => {
+    const body = "Venue: - The Pub  Hares: Someone  Hash Cash: - $5";
+    const result = parseBodyFields(body);
+    expect(result.location).toBe("The Pub");
+    expect(result.hashCash).toBe("$5");
+  });
+
+  it("terminates dash-separated Hares at a subsequent dash-separated label (#1467 codex follow-up)", () => {
+    // If the source escalates from "Hares –" to also using "Venue –", the
+    // colon-only terminator would let Hares overrun into the next field.
+    // The terminator lookahead now matches `(?:label)\s*[:–—-]` so Hares
+    // stops at "Venue" even when the next separator is a dash. Venue value
+    // extraction itself is still colon-only (opt-in per label), so it
+    // stays undefined when the source uses a dash there — better to lose
+    // a venue than to leak it into the hare list.
+    const body = "Hares – Alice Venue – The Pub Hash Cash: $5";
+    const result = parseBodyFields(body);
+    expect(result.hares).toBe("Alice");
+    expect(result.location).toBeUndefined();
+    expect(result.hashCash).toBe("$5");
+  });
 });
 
 const SAMPLE_HTML = `

--- a/src/adapters/html-scraper/chicago-hash.ts
+++ b/src/adapters/html-scraper/chicago-hash.ts
@@ -22,6 +22,34 @@ export function parseDateFromText(text: string): string | null {
   return chronoParseDate(text, "en-US");
 }
 
+// Strip leading dash/bullet artifacts (#1467 — CH3 Memorial Day post used
+// `<strong>Hares –</strong>` and `Hares: -` formats that leaked the
+// separator into the captured value). Safe for all CH3 fields: no
+// legitimate value starts with a hyphen, dash, or bullet character.
+const LEADING_BULLET_RE = /^[\s\-–—•*]+/;
+
+// Label set + terminator inlined as regex literals to avoid Codacy's
+// `security/detect-non-literal-regexp` / `security-node/non-literal-reg-expr`
+// findings on `new RegExp(<expression>)` — these only fire on the constructor
+// form. The terminator recognizes both `:` and dash separators so a dash-
+// separated Hares value can't overrun into a subsequent dash-separated label
+// (codex review follow-up). `[\s\S]+?` is used in place of `.+?` because the
+// tsconfig target (ES2017) predates the `s` (dotall) regex flag.
+// S5852 false-positive — the `\s*` adjacent to a literal-alternation lookahead
+// is flagged by Sonar's ReDoS heuristic, but the engine doesn't backtrack
+// into a non-capturing lookahead anchored to a finite label set. Inputs come
+// from a small WordPress excerpt (<2KB), not user-supplied text.
+const CH3_VENUE_RE = /(?:Venue|Where):\s*([\s\S]+?)(?=(?:Venue|Hares?|Event|Hash Cash|Transit|Shag Wagon|When|Where|Time)\s*[:–—\-]|$)/i; // NOSONAR S5852
+const CH3_HARES_RE = /Hares?\s*[:–—\-]\s*([\s\S]+?)(?=(?:Venue|Hares?|Event|Hash Cash|Transit|Shag Wagon|When|Where|Time)\s*[:–—\-]|$)/i; // NOSONAR S5852
+const CH3_CASH_RE = /Hash Cash:\s*([\s\S]+?)(?=(?:Venue|Hares?|Event|Hash Cash|Transit|Shag Wagon|When|Where|Time)\s*[:–—\-]|$)/i; // NOSONAR S5852
+const CH3_EVENT_RE = /Event:\s*([\s\S]+?)(?=(?:Venue|Hares?|Event|Hash Cash|Transit|Shag Wagon|When|Where|Time)\s*[:–—\-]|$)/i; // NOSONAR S5852
+const CH3_TIME_RE = /(?:When|Time):\s*([\s\S]+?)(?=(?:Venue|Hares?|Event|Hash Cash|Transit|Shag Wagon|When|Where|Time)\s*[:–—\-]|$)/i; // NOSONAR S5852
+
+function cleanFieldValue(raw: string): string | undefined {
+  const cleaned = raw.trim().replace(/\s+/g, " ").replace(LEADING_BULLET_RE, "").trim();
+  return cleaned || undefined;
+}
+
 /**
  * Parse the body content of a CH3 WordPress post to extract labeled fields.
  * Fields are delimited by labels like "Venue:", "Hare:", "Hash Cash:", etc.
@@ -42,49 +70,23 @@ export function parseBodyFields(bodyText: string): {
     startTime?: string;
   } = {};
 
-  // Known labels as delimiters (lookahead-based splitting)
-  const labels = ["Venue", "Hares?", "Event", "Hash Cash", "Transit", "Shag Wagon", "When", "Where", "Time"];
-  const labelPattern = labels.join("|");
+  const venueMatch = CH3_VENUE_RE.exec(bodyText);
+  if (venueMatch) result.location = cleanFieldValue(venueMatch[1]);
 
-  // Extract "Venue:" or "Where:" field
-  const venueMatch = bodyText.match(
-    new RegExp(`(?:Venue|Where):\\s*(.+?)(?=(?:${labelPattern}):|$)`, "is"),
-  );
-  if (venueMatch) {
-    result.location = venueMatch[1].trim().replace(/\s+/g, " ");
-  }
+  // `Hares –` (no colon) is accepted alongside `Hares:` — Memorial Day post
+  // shape (#1467). `cleanFieldValue` strips any residual leading bullet.
+  const hareMatch = CH3_HARES_RE.exec(bodyText);
+  if (hareMatch) result.hares = cleanFieldValue(hareMatch[1]);
 
-  // Extract "Hare:" or "Hares:" field
-  const hareMatch = bodyText.match(
-    new RegExp(`Hares?:\\s*(.+?)(?=(?:${labelPattern}):|$)`, "is"),
-  );
-  if (hareMatch) {
-    result.hares = hareMatch[1].trim().replace(/\s+/g, " ");
-  }
+  const cashMatch = CH3_CASH_RE.exec(bodyText);
+  if (cashMatch) result.hashCash = cleanFieldValue(cashMatch[1]);
 
-  // Extract "Hash Cash:" field
-  const cashMatch = bodyText.match(
-    new RegExp(`Hash Cash:\\s*(.+?)(?=(?:${labelPattern}):|$)`, "is"),
-  );
-  if (cashMatch) {
-    result.hashCash = cashMatch[1].trim().replace(/\s+/g, " ");
-  }
+  const eventMatch = CH3_EVENT_RE.exec(bodyText);
+  if (eventMatch) result.eventName = cleanFieldValue(eventMatch[1]);
 
-  // Extract "Event:" field
-  const eventMatch = bodyText.match(
-    new RegExp(`Event:\\s*(.+?)(?=(?:${labelPattern}):|$)`, "is"),
-  );
-  if (eventMatch) {
-    result.eventName = eventMatch[1].trim().replace(/\s+/g, " ");
-  }
-
-  // Extract start time from "When:" or "Time:" field
-  const timeMatch = bodyText.match(
-    new RegExp(`(?:When|Time):\\s*(.+?)(?=(?:${labelPattern}):|$)`, "is"),
-  );
+  const timeMatch = CH3_TIME_RE.exec(bodyText);
   if (timeMatch) {
-    const timeText = timeMatch[1].trim();
-    const parsed = parseTimeString(timeText);
+    const parsed = parseTimeString(timeMatch[1].trim());
     if (parsed) result.startTime = parsed;
   }
 

--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -1,12 +1,14 @@
 import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import {
-  fetchEventTitle as _fetchEventTitle,
+  fetchEventDetail,
   buildMonthFormData,
   parseEventFromItem,
+  PHOENIX_HARE_PATTERNS,
   PhoenixHHHAdapter,
 } from "./phoenixhhh";
 import { extractHashRunNumber } from "../utils";
+import { extractHares } from "../hare-extraction";
 
 // ── Sample HTML fixtures ──
 
@@ -458,5 +460,209 @@ describe("PhoenixHHHAdapter", () => {
   it("has correct type", () => {
     const adapter = new PhoenixHHHAdapter();
     expect(adapter.type).toBe("HTML_SCRAPER");
+  });
+});
+
+// ── PHOENIX_HARE_PATTERNS (#1472, #1192) ──
+
+describe("PHOENIX_HARE_PATTERNS — list-view extraction", () => {
+  it("captures `Hare(s):` after `Harriers!!! ` sentence boundary (#1472)", () => {
+    // List-view excerpt: labels run together because <p> tags are collapsed.
+    // The Phoenix-scoped patterns allow mid-line `Hare:` after sentence
+    // punctuation. The age-restriction line ("Who: People …") must NOT
+    // be returned even though the generic default `Who:` catchall would
+    // have matched it.
+    const desc =
+      "Join us for the 744th running of the Lost Boobs Hash House Harriers!!! " +
+      "Hare(s): Prostitutor, Just Rick, Just Christin " +
+      "Who: People that are at least 21 years old (no exceptions).";
+    expect(extractHares(desc, PHOENIX_HARE_PATTERNS as RegExp[])).toBe(
+      "Prostitutor, Just Rick, Just Christin",
+    );
+  });
+
+  it("returns undefined when only an age-restriction `Who:` line is present (#1472)", () => {
+    // No Hare label at all — Phoenix patterns must NOT fall back to a
+    // generic Who: capture. Returning undefined is the correct behavior;
+    // an empty hares field is preferable to the age-restriction prose.
+    const desc =
+      "Join us for the 745th running. Who: People that are at least 21 years old (no exceptions).";
+    expect(extractHares(desc, PHOENIX_HARE_PATTERNS as RegExp[])).toBeUndefined();
+  });
+
+  it("captures FDTDD `With your Hares:` mid-paragraph (#1192)", () => {
+    const desc =
+      'The From Dusk Till Down-Down Hash presents My Bloody Hashentine! ' +
+      'With your Hares: Chew Oyster Cult & Cumming to Dinner "The most evil hash …"';
+    expect(extractHares(desc, PHOENIX_HARE_PATTERNS as RegExp[])).toBe(
+      "Chew Oyster Cult & Cumming to Dinner",
+    );
+  });
+
+  it("captures FDTDD singular `With your Hare:` (#1192)", () => {
+    const desc = "The From Dusk Till Down-Downs Hash presents Foo. With your Hare: Makin' Me Gay …";
+    expect(extractHares(desc, PHOENIX_HARE_PATTERNS as RegExp[])).toBe("Makin' Me Gay");
+  });
+
+  it("captures literal `With your Hare(s):` parenthesized form (codex P1 follow-up to #1192)", () => {
+    // The FDTDD kennel uses three label variants — singular, plural, and the
+    // parenthesized `Hare(s):` literal. All three must extract.
+    const desc = "The From Dusk Till Down-Downs Hash presents Bar. With your Hare(s): Spermin Williams, 1000 Cock Stare";
+    expect(extractHares(desc, PHOENIX_HARE_PATTERNS as RegExp[])).toBe(
+      "Spermin Williams, 1000 Cock Stare",
+    );
+  });
+
+  it("captures `Hare(s):` block on its own line (detail-page <p>-separated form)", () => {
+    const desc = "LBH #744\n\nHare(s): Prostitutor, Just Rick, Just Christin\n\nWho: People that are at least 21";
+    expect(extractHares(desc, PHOENIX_HARE_PATTERNS as RegExp[])).toBe(
+      "Prostitutor, Just Rick, Just Christin",
+    );
+  });
+});
+
+describe("parseEventFromItem — list-view hare fallback uses Phoenix patterns (#1472)", () => {
+  it("does not capture `Who:` age-restriction line as hares", () => {
+    const html = `
+      <div class="em-item em-event">
+        <div class="em-item-image"><img src="/img/lbh.jpg" alt="LBH #744 Hares Needed" /></div>
+        <div class="em-item-meta-line em-event-date">Monday - 05/18/2026</div>
+        <div class="em-item-meta-line em-event-time">6:30 pm</div>
+        <div class="em-item-desc">
+          <p>Join us for the 744th running of the Lost Boobs Hash House Harriers!!! Hare(s): Prostitutor, Just Rick, Just Christin Who: People that are at least 21 years old (no exceptions).</p>
+        </div>
+        <a class="em-item-read-more" href="/?event=lbh-744">Read More</a>
+      </div>
+    `;
+    const $ = cheerio.load(html);
+    const $item = $(".em-item").first();
+    const compiled: [RegExp, string][] = [[/LBH/i, "LBH"]];
+    const event = parseEventFromItem(
+      $item,
+      $,
+      { kennelPatterns: [["LBH", "LBH"]], defaultKennelTag: "Wrong Way" },
+      compiled,
+    );
+
+    expect(event).not.toBeNull();
+    expect(event!.hares).toBe("Prostitutor, Just Rick, Just Christin");
+    expect(event!.hares).not.toContain("Who:");
+    expect(event!.hares).not.toContain("People that are");
+  });
+});
+
+// ── fetchEventDetail (#1193) ──
+
+const SAMPLE_DETAIL_PAGE_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>LBH #744 – HashTracks Test</title></head>
+<body>
+<article>
+  <h1 class="entry-title">LBH #744: Hares Needed - Be the Hero We Don't Deserve</h1>
+  <div class="entry-content">
+    <p><strong>Hare(s):</strong> Prostitutor, Just Rick, Just Christin</p>
+    <p><strong>Who:</strong> People that are at least 21 years old (no exceptions).</p>
+    <p><strong>What:</strong> A 4-5 mile trail with beer stops.</p>
+    <p><strong>Where:</strong> See the location field above.</p>
+  </div>
+</article>
+</body>
+</html>`;
+
+describe("fetchEventDetail", () => {
+  it("extracts title, full description, and hares from the detail page (#1193)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(SAMPLE_DETAIL_PAGE_HTML, { status: 200 }),
+    );
+
+    const detail = await fetchEventDetail("https://www.phoenixhhh.org/?event=lbh-744");
+    vi.restoreAllMocks();
+
+    expect(detail.title).toContain("LBH #744");
+    expect(detail.description).toContain("Prostitutor, Just Rick, Just Christin");
+    expect(detail.description).toContain("People that are at least 21 years old");
+    // The detail-page description does NOT carry the WordPress `[...]`
+    // truncation marker that the list-view excerpt does.
+    expect(detail.description).not.toContain("[...]");
+    // The hare extraction uses Phoenix-scoped patterns, which means
+    // the `Who:` age-restriction line is NOT captured as a hare.
+    expect(detail.hares).toBe("Prostitutor, Just Rick, Just Christin");
+  });
+
+  it("throws on HTTP error so the post-loop can record the failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Not Found", { status: 404 }),
+    );
+    await expect(fetchEventDetail("https://www.phoenixhhh.org/?event=missing")).rejects.toThrow(/HTTP 404/);
+    vi.restoreAllMocks();
+  });
+
+  it("propagates network failures so the post-loop can distinguish error modes", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("ECONNRESET"));
+    await expect(fetchEventDetail("https://www.phoenixhhh.org/?event=any")).rejects.toThrow(/ECONNRESET/);
+    vi.restoreAllMocks();
+  });
+
+  it("returns null content fields when the detail page lacks `.entry-content`", async () => {
+    const html = `<html><body><article><h1 class="entry-title">Bare Page</h1></article></body></html>`;
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(html, { status: 200 }));
+    const detail = await fetchEventDetail("https://www.phoenixhhh.org/?event=bare");
+    vi.restoreAllMocks();
+    expect(detail.title).toBe("Bare Page");
+    expect(detail.description).toBeNull();
+    expect(detail.hares).toBeNull();
+  });
+});
+
+// ── Detail-fetch failures surface in errorDetails (codex follow-up) ──
+
+describe("PhoenixHHHAdapter.fetch — detail-fetch failures are visible", () => {
+  it("records detail-fetch failures in errorDetails.fetch (bounded sample)", async () => {
+    // Build a fixture with TODAY's date so it falls inside the
+    // adapter's date window regardless of when the test runs.
+    const now = new Date();
+    const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+    const dd = String(now.getUTCDate()).padStart(2, "0");
+    const yyyy = now.getUTCFullYear();
+    const sampleAjaxResponse = `
+      <div class="em-calendar-wrap">
+        <div class="em-item em-event">
+          <div class="em-item-image">
+            <img src="/img/lbh.jpg" alt="Lost Boobs Hash Test" />
+          </div>
+          <div class="em-item-meta-line em-event-date">Today - ${mm}/${dd}/${yyyy}</div>
+          <div class="em-item-meta-line em-event-time">6:30 pm</div>
+          <a class="em-item-read-more" href="https://www.phoenixhhh.org/?event=test">Read More</a>
+        </div>
+      </div>
+    `;
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // First call: the month AJAX returns the list HTML.
+    fetchSpy.mockResolvedValueOnce(new Response(sampleAjaxResponse, { status: 200 }));
+    // Every detail-page fetch returns 503 (origin rate-limit / outage).
+    fetchSpy.mockImplementation(async () => new Response("Service Unavailable", { status: 503 }));
+
+    const adapter = new PhoenixHHHAdapter();
+    const source = {
+      id: "test",
+      url: "https://www.phoenixhhh.org/?page_id=21",
+      config: DEFAULT_CONFIG,
+    } as unknown as Source;
+
+    const result = await adapter.fetch(source, { days: 1 });
+    vi.restoreAllMocks();
+
+    // Events still parse (list-view fallback).
+    expect(result.events.length).toBeGreaterThan(0);
+    // BUT the detail-fetch failures are surfaced — fail-loud over silent
+    // truncated-description regressions.
+    expect(result.errorDetails?.fetch).toBeDefined();
+    expect(result.errorDetails!.fetch!.length).toBeGreaterThan(0);
+    expect(result.errorDetails!.fetch!.length).toBeLessThanOrEqual(5);
+    expect(result.errorDetails!.fetch![0].message).toMatch(/Detail fetch/i);
+    expect(result.diagnosticContext?.detailFetchFailures).toBeGreaterThan(0);
+    expect(result.diagnosticContext?.detailsFetched).toBe(0);
   });
 });

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -27,24 +27,77 @@ interface PhoenixHHHConfig {
 
 // ── Exported helpers (for unit testing) ──
 
+// Phoenix-cluster hare patterns. The default `extractHares` set includes a
+// generic `Who:` catchall that would capture the age-restriction line
+// (#1472 — "Who: People that are at least 21 years old"). The cluster
+// always uses `Hare:` / `Hares:` / `Hare(s):` / `With your Hare(s):`, so
+// `Who:` is reserved for restrictions and deliberately excluded here.
+//
+// Capture excludes newline, quote/curly-quote (FDTDD's `"The most evil hash"`
+// blurb runs straight off the hare list) and ellipsis. Terminator stops at
+// the next labeled section, a quote, or end-of-line.
+//
+// Both patterns are regex literals — `new RegExp(<expression>)` trips
+// Codacy's `security/detect-non-literal-regexp` rule on new code (the
+// shared `PHOENIX_HARE_TERMINATOR` was inlined to avoid this).
+export const PHOENIX_HARE_PATTERNS: readonly RegExp[] = [
+  // FDTDD: "With your Hare: X" / "With your Hares: X, Y" / "With your Hare(s): X" (#1192).
+  // The `(?:\(s\))?` group matches the literal `(s)` form alongside `Hare` / `Hares`
+  // (codex P1: the kennel uses all three; bare `Hares?` would miss the parenthesized form).
+  // S5852 false-positive — Sonar flags `\s*` near alternation; engine
+  // anchored to finite label set + character-class exclusion (`[^\n"”…]+?`)
+  // makes catastrophic backtracking impossible.
+  /\bWith\s+your\s+Hares?\s*(?:\(s\))?\s*:\s*([^\n"”…]+?)(?=\s*(?:Who|What|When|Where|Wear|Why|How|Theme)\s*:|["”…]|\.{3}|\n|$)/i, // NOSONAR S5852
+  // Standard `Hare:` / `Hares:` / `Hare(s):` — anchored to line start OR a
+  // sentence boundary so list-view excerpts like "…Harriers!!! Hare(s): …"
+  // resolve before detail-page enrichment lands.
+  /(?:^|\n|[.!;]\s+)Hares?\s*(?:\(s\))?\s*:\s*([^\n"”…]+?)(?=\s*(?:Who|What|When|Where|Wear|Why|How|Theme)\s*:|["”…]|\.{3}|\n|$)/i, // NOSONAR S5852
+];
+
+/** Detail-page extraction result. Null fields mean "missing on the page"
+ *  (adapter falls back to list-view values). */
+export interface PhoenixEventDetail {
+  title: string | null;
+  description: string | null;
+  hares: string | null;
+}
+
 /**
- * Fetch the event detail page and extract the title from the `<h1>` heading.
- * Returns null if fetch fails or no title found.
+ * Fetch the per-event detail page and extract title, description, and hares.
+ *
+ * The Big Ass Calendar list view emits a WordPress excerpt that's truncated
+ * with `[...]` (#1193) and lacks `<p>` boundaries needed for line-anchored
+ * hare patterns (#1192, #1472). The detail page carries the full body with
+ * `<p>`-separated labels.
+ *
+ * Throws on HTTP errors and network failures so the adapter post-loop can
+ * distinguish failure modes in `errorDetails.fetch`.
  */
-export async function fetchEventTitle(eventUrl: string): Promise<string | null> {
-  try {
-    const res = await safeFetch(eventUrl, {
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
-    });
-    if (!res.ok) return null;
-    const html = await res.text();
-    const $ = cheerio.load(html);
-    const h1 = $("article h1, .entry-title, h1.tribe-events-single-event-title").first();
-    const title = h1.text().trim();
-    return title ? decodeEntities(title) : null;
-  } catch {
-    return null;
+export async function fetchEventDetail(eventUrl: string): Promise<PhoenixEventDetail> {
+  const res = await safeFetch(eventUrl, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const html = await res.text();
+  const $ = cheerio.load(html);
+
+  const h1 = $("article h1, .entry-title, h1.tribe-events-single-event-title").first();
+  const titleText = h1.text().trim();
+  const title = titleText ? decodeEntities(titleText) : null;
+
+  const contentEl = $(".entry-content, article .em-event-content, .em-event-content").first();
+  let description: string | null = null;
+  let hares: string | null = null;
+  if (contentEl.length > 0) {
+    const text = stripHtmlTags(contentEl.html() ?? "", "\n").trim();
+    description = text || null;
+    if (text) {
+      hares = extractHares(text, PHOENIX_HARE_PATTERNS as RegExp[]) ?? null;
+    }
   }
+
+  return { title, description, hares };
 }
 
 /**
@@ -124,8 +177,11 @@ export function parseEventFromItem(
   const descHtml = $item.find(".em-item-desc").html() ?? "";
   const description = stripHtmlTags(descHtml, "\n").trim() || undefined;
 
-  // Hares from description
-  const hares = description ? extractHares(description) : undefined;
+  // List-view fallback (post-loop detail fetch usually overrides this).
+  // Phoenix-scoped patterns omit the generic `Who:` catchall — see #1472.
+  const hares = description
+    ? extractHares(description, PHOENIX_HARE_PATTERNS as RegExp[])
+    : undefined;
 
   // Source URL from read-more link
   const readMoreHref = $item.find("a.em-item-read-more").attr("href");
@@ -286,27 +342,49 @@ export class PhoenixHHHAdapter implements SourceAdapter {
       }
     }
 
-    // Fetch titles for events that don't have one (no img.alt — need detail page)
-    const needsTitle = allEvents.filter((e) => !e.title && e.sourceUrl);
+    // Detail-page enrichment for every event with a sourceUrl. See
+    // `fetchEventDetail` docblock for the #1192/#1193/#1472 rationale.
+    const needsDetail = allEvents.filter((e) => e.sourceUrl);
+    let detailsFetched = 0;
+    let detailFetchFailures = 0;
     let titlesFetched = 0;
-    const TITLE_CONCURRENCY = 3;
-    const TITLE_BATCH_DELAY = 300;
+    const DETAIL_CONCURRENCY = 3;
+    const DETAIL_BATCH_DELAY = 300;
+    const MAX_DETAIL_FETCH_ERROR_SAMPLES = 5;
 
-    for (let i = 0; i < needsTitle.length; i += TITLE_CONCURRENCY) {
-      if (i > 0) await new Promise((r) => setTimeout(r, TITLE_BATCH_DELAY));
+    for (let i = 0; i < needsDetail.length; i += DETAIL_CONCURRENCY) {
+      if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_BATCH_DELAY));
 
-      const batch = needsTitle.slice(i, i + TITLE_CONCURRENCY);
+      const batch = needsDetail.slice(i, i + DETAIL_CONCURRENCY);
       const results = await Promise.allSettled(
-        batch.map((e) => fetchEventTitle(e.sourceUrl!)),
+        batch.map((e) => fetchEventDetail(e.sourceUrl!)),
       );
 
       for (let j = 0; j < batch.length; j++) {
         const result = results[j];
-        if (result.status === "fulfilled" && result.value) {
-          batch[j].title = result.value;
+        if (result.status === "rejected") {
+          // Detail-fetch enrichment failed — fall back to the list-view
+          // excerpt. Surface a bounded sample in `errorDetails.fetch` so a
+          // sustained failure rate (origin rate-limit, outage) doesn't
+          // silently re-introduce truncated descriptions across the cluster.
+          detailFetchFailures++;
+          if (detailFetchFailures <= MAX_DETAIL_FETCH_ERROR_SAMPLES) {
+            errorDetails.fetch ??= [];
+            errorDetails.fetch.push({
+              url: batch[j].sourceUrl!,
+              message: `Detail fetch failed: ${String(result.reason).slice(0, 120)}`,
+            });
+          }
+          continue;
+        }
+        const detail = result.value;
+        detailsFetched++;
+
+        if (detail.title) {
+          batch[j].title = detail.title;
           // Re-resolve kennel tag now that we have the real title
           for (const [pattern, tag] of compiledPatterns) {
-            if (pattern.test(result.value)) {
+            if (pattern.test(detail.title)) {
               batch[j].kennelTags[0] = tag;
               break;
             }
@@ -317,10 +395,12 @@ export class PhoenixHHHAdapter implements SourceAdapter {
           // #1155 need hares") that the kennel later corrected on the detail
           // page (#1156). Falling back to the previous value only when the
           // detail title yields nothing keeps us no worse than before.
-          const detailRun = extractHashRunNumber(result.value);
+          const detailRun = extractHashRunNumber(detail.title);
           if (detailRun !== undefined) batch[j].runNumber = detailRun;
           titlesFetched++;
         }
+        if (detail.description) batch[j].description = detail.description;
+        if (detail.hares) batch[j].hares = detail.hares;
       }
     }
 
@@ -338,8 +418,11 @@ export class PhoenixHHHAdapter implements SourceAdapter {
         monthsFetched,
         totalItems,
         eventsParsed: allEvents.length,
+        detailsFetched,
+        detailFetchFailures,
+        eventsWithoutDetail: needsDetail.length - detailsFetched,
         titlesFetched,
-        eventsWithoutTitle: needsTitle.length - titlesFetched,
+        eventsWithoutTitle: needsDetail.length - titlesFetched,
         parseErrors: allParseErrors.length,
       },
     };


### PR DESCRIPTION
## Summary

WS3 cycle-8 quick-win bundle — 4 audit-stream issues across 2 HTML_SCRAPER adapters. All are field-mapping / parsing bugs; no schema, seed, or pipeline changes.

**Branched from fresh `origin/main` after [#1484](https://github.com/johnrclem/hashtracks-web/pull/1484) (WS0 Phoenix parse-failure hotfix) merged — sequential gate per the workstream plan.**

Closes #1472
Closes #1192
Closes #1193
Closes #1467

## Root cause + fixes

### Phoenix HHH (3 issues, single root cause)

The Big Ass Calendar list view emits a WordPress *excerpt* of each event post:
1. Truncated with the `[...]` marker — **#1193**.
2. Collapses `<p>` boundaries → labels like `Hare(s):` and `Who:` run together → the line-anchored `extractHares` patterns fail to match → the generic `Who:` catchall captures the age-restriction line — **#1472**.
3. FDTDD's `With your Hare(s):` prefix isn't matched by any default pattern — **#1192**.

**Fix:** the post-loop concurrency batch (previously only enriching titles for events missing img.alt) now calls `fetchEventDetail()` on every event with a `sourceUrl`. The detail page (`?event=<slug>`) has the full body with `<p>`-separated labels. Hare extraction uses a new Phoenix-scoped pattern set (`PHOENIX_HARE_PATTERNS`) that handles the cluster's `Hare:` / `Hares:` / `Hare(s):` / `With your Hare(s):` idioms and deliberately omits the generic `Who:` catchall.

**Codex follow-up:** detail-fetch failures surface in `errorDetails.fetch` (bounded sample of 5) + `detailFetchFailures` counter in `diagnosticContext`, so a sustained outage doesn't silently re-introduce truncated descriptions. `fetchEventDetail` throws on HTTP/network errors so the post-loop can distinguish failure modes.

### Chicago H3 (#1467)

`parseBodyFields` was capturing the literal `- ` artifact from `Hares: -` / `<strong>Hares –</strong>` formats. Fixed via:
- `cleanFieldValue` helper that strips leading `- / – / — / • / *` after capture
- Hares label regex extended to accept `:` OR `–`/`—`/`-` as separator
- Field terminator alternation now also recognizes dash separators so a dash-separated Hares value can't overrun into a future dash-separated Venue (codex follow-up)
- Hoisted the 5 field regexes + label constants to module scope (were reconstructed on every call)

## Live verification ([live-verification.md](.claude/rules/live-verification.md))

### Phoenix HHH — 29 May-2026 events, 0 parse errors

```
✅ #1472: no `Who:` leak across 29 list-view events

LBH #744 (2026-05-18):
  title:           "LBH #744: Prostitutors Department of Just-Us"  (from detail page)
  hares_listView:  "Prostitutor, Just Rick, Just Christin"
  hares_detail:    "Prostitutor, Just Rick, Just Christin"          (same value)
  description_listEndsWithTrunc:    true   (excerpt has `[...]`)
  description_detailEndsWithTrunc:  false  (detail page has full body)

✅ #1192: FDTDD `With your Hares:` synthetic test extracts "Chew Oyster Cult & Cumming to Dinner"
```

### Chicago H3 — Memorial Day post

```
Memorial Day event found: hares="Antiques Load Show & Ritalin Cum Bubble Sunday 5/24 …"
✅ Chicago: no leading dash/bullet in any hare field
```

The hares value now starts with the correct names (no leading `- `). Pre-existing parse issues with this post (description bleeding into hares because `Location:` / `From the hares:` aren't in the label set) reproduce identically on `main` and are out of scope for #1467.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (no errors on touched files)
- [x] `npm test` — 6710 passed, 0 failed, 2 skipped, 25 todo (added 12 new test cases)
- [x] Live-verified Phoenix LBH #744 and FDTDD pattern on production
- [x] Live-verified Chicago Memorial Day post on production
- [x] /codex:adversarial-review run (2 findings addressed: detail-fetch failure tracking, dash-separator label terminator)
- [x] /simplify run (6 simplifications applied: dead-code removal, comment trimming, regex hoisting, throw-don't-return-null, 30s timeout)

## Scope notes

- **#1233 C2B3H4 attribution storm** was originally bundled but **dropped** — Chicagoland Hash Calendar is GOOGLE_CALENDAR (not HTML_SCRAPER) and the kennelPatterns routing lives in `prisma/seed-data/sources.ts`, not `chicago-hash.ts`. Deferred to a focused cycle-9 investigation.
- The "From the" trailing artifact on CH3 weekly posts (e.g. `"Lifa From the"`) is a pre-existing parse issue (the `Hares?` label-terminator lookahead matches `hares:` in `From the hares:`) that reproduces identically on `main`. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)