### PR TITLE
feat(adapters): HHHS Hareline HTML_SCRAPER (Wix Table Master)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3447,10 +3447,12 @@ export const SOURCES = [
       kennelCodes: ["kampong-h3"],
     },
 
-    // 4. HHHS (Father Hash) — STATIC_SCHEDULE under historic-kennel exception
-    // (per feedback_sourceless_kennels memory). Founded 1962, the 2nd hash kennel
-    // in the world ever. The Wix hareline iframe is richer but out of scope for
-    // this PR; STATIC_SCHEDULE covers the weekly Monday recurrence.
+    // 4. HHHS (Father Hash) — STATIC_SCHEDULE low-trust fallback.
+    // Founded 1962, the 2nd hash kennel in the world ever. The Wix Table Master
+    // hareline iframe (HHHS Hareline source below) is the primary, trust-8 source
+    // and fills run number, hares, and street address per-event. This static row
+    // remains enabled at trust 3 so a Wix outage doesn't black out coverage for
+    // a founder kennel — GSH3 (Grand Strand) is the canonical precedent (#1474).
     {
       name: "HHHS Father Hash Static Schedule",
       url: "https://www.hhhs.org.sg/hareline",
@@ -3464,8 +3466,21 @@ export const SOURCES = [
         startTime: "18:00",
         defaultTitle: "HHHS Monday Run",
         defaultLocation: "Singapore",
-        defaultDescription: "Weekly Monday evening run for the Father Hash (founded 1962, the 2nd hash kennel in the world). Run number, hares, and exact location are published on the HHHS hareline at https://www.hhhs.org.sg/hareline. Men only.",
+        defaultDescription: "Weekly Monday evening run for the Father Hash, founded 1962 — the 2nd hash kennel in the world. Men only.",
       },
+      kennelCodes: ["hhhs"],
+    },
+    // 4b. HHHS Hareline — primary trust-8 HTML scraper for the Wix Table Master
+    // iframe at /hareline. Provides run#, hares, street address, and theme
+    // (Notes column) per event. Browser-render is required because the table
+    // lives in a cross-origin Wix iframe.
+    {
+      name: "HHHS Hareline",
+      url: "https://www.hhhs.org.sg/hareline",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 8,
+      scrapeFreq: "daily",
+      scrapeDays: 90,
       kennelCodes: ["hhhs"],
     },
 

--- a/scripts/live-verify-hhhs.ts
+++ b/scripts/live-verify-hhhs.ts
@@ -57,7 +57,7 @@ async function main() {
 
   const sorted = [...result.events].sort((a, b) => a.date.localeCompare(b.date));
   const first = sorted[0];
-  const last = sorted[sorted.length - 1];
+  const last = sorted.at(-1)!;
   console.log(`\n── Date range ──`);
   console.log(`  ${first.date} → ${last.date}`);
 

--- a/scripts/live-verify-hhhs.ts
+++ b/scripts/live-verify-hhhs.ts
@@ -1,0 +1,89 @@
+/**
+ * Live verification for the HHHS Hareline HTML_SCRAPER adapter (#1474).
+ *
+ * Runs the actual HHHSAdapter against https://www.hhhs.org.sg/hareline via the
+ * NAS browser-render service, prints a summary of parsed events, and asserts
+ * that:
+ *   - the scrape returns ≥1 event
+ *   - rich data flows through (runNumber, hares, location, title from Notes)
+ *   - dispatch goes through HHHSAdapter (diagnosticContext.adapter)
+ *
+ * Run: `set -a && source .env && set +a && npx tsx scripts/live-verify-hhhs.ts`
+ *
+ * Requires BROWSER_RENDER_URL + BROWSER_RENDER_KEY in the environment.
+ * Does NOT touch the database — purely an upstream-fetch + parse smoke test.
+ */
+import "dotenv/config";
+import { getAdapter } from "@/adapters/registry";
+import type { Source } from "@/generated/prisma/client";
+
+const SOURCE_URL = "https://www.hhhs.org.sg/hareline";
+
+async function main() {
+  if (!process.env.BROWSER_RENDER_URL || !process.env.BROWSER_RENDER_KEY) {
+    console.error(
+      "✗ BROWSER_RENDER_URL / BROWSER_RENDER_KEY not set; cannot reach the NAS browser-render service.",
+    );
+    console.error("  Source .env first: set -a && source .env && set +a");
+    process.exit(1);
+  }
+
+  const adapter = getAdapter("HTML_SCRAPER", SOURCE_URL);
+  console.log(`Adapter dispatch: ${adapter.constructor.name}`);
+  if (adapter.constructor.name !== "HHHSAdapter") {
+    console.error(`✗ Expected HHHSAdapter, got ${adapter.constructor.name}`);
+    process.exit(1);
+  }
+  console.log("✓ Registry resolves https://www.hhhs.org.sg/hareline → HHHSAdapter");
+
+  const source = {
+    id: "live-verify-hhhs",
+    url: SOURCE_URL,
+    type: "HTML_SCRAPER",
+  } as unknown as Source;
+
+  console.log(`\nFetching ${SOURCE_URL} via browser-render…`);
+  const result = await adapter.fetch(source, { days: 365 });
+
+  console.log(`\n── Result summary ──`);
+  console.log(`  events: ${result.events.length}`);
+  console.log(`  errors: ${JSON.stringify(result.errors)}`);
+  console.log(`  diagnosticContext: ${JSON.stringify(result.diagnosticContext)}`);
+
+  if (result.events.length === 0) {
+    console.error("\n✗ No events returned — fetch or parse failed");
+    process.exit(1);
+  }
+
+  const sorted = [...result.events].sort((a, b) => a.date.localeCompare(b.date));
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  console.log(`\n── Date range ──`);
+  console.log(`  ${first.date} → ${last.date}`);
+
+  console.log(`\n── First 3 events ──`);
+  for (const ev of sorted.slice(0, 3)) {
+    console.log(`  #${ev.runNumber ?? "?"} ${ev.date} @ ${ev.startTime ?? "?"}`);
+    console.log(`    title:    ${ev.title ?? "(none)"}`);
+    console.log(`    hares:    ${ev.hares ?? "(none)"}`);
+    console.log(`    location: ${ev.location ?? "(none)"}`);
+  }
+
+  const withRich = result.events.filter(
+    (e) => e.runNumber !== undefined && e.hares && e.location,
+  );
+  console.log(`\n── Rich-data coverage ──`);
+  console.log(`  events with runNumber + hares + location: ${withRich.length}/${result.events.length}`);
+
+  if (withRich.length === 0) {
+    console.error("\n✗ Zero events carry the rich fields — adapter is shipping placeholders");
+    process.exit(1);
+  }
+
+  console.log("\n✓ Live verification passed");
+}
+
+main().catch((err) => {
+  console.error("✗ Live verification crashed:", err);
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/hhhs.test.ts
+++ b/src/adapters/html-scraper/hhhs.test.ts
@@ -207,10 +207,9 @@ describe("HHHSAdapter", () => {
       } else {
         vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
       }
-      return new HHHSAdapter().fetch(
-        source,
-        opts?.days !== undefined ? { days: opts.days } : undefined,
-      );
+      const fetchOpts =
+        opts?.days === undefined ? undefined : { days: opts.days };
+      return new HHHSAdapter().fetch(source, fetchOpts);
     }
 
     it("parses the hareline table end-to-end", async () => {

--- a/src/adapters/html-scraper/hhhs.test.ts
+++ b/src/adapters/html-scraper/hhhs.test.ts
@@ -1,0 +1,267 @@
+import {
+  parseHHHSDate,
+  parseHHHSRow,
+  buildColumnMap,
+  buildTitle,
+  HHHSAdapter,
+} from "./hhhs";
+import type { Source } from "@/generated/prisma/client";
+
+vi.mock("@/lib/browser-render", () => ({
+  browserRender: vi.fn().mockResolvedValue("<html><body></body></html>"),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-18T12:00:00.000Z"));
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Representative table from the HHHS Wix Table Master iframe (issue #1474).
+// Columns: Run#, Date, Hares, Location, Notes — verbatim row text from the
+// hareline screenshot.
+const FIXTURE_HTML = `
+<html>
+  <body>
+    <table>
+      <thead>
+        <tr>
+          <th>Run#</th>
+          <th>Date</th>
+          <th>Hares</th>
+          <th>Location</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>3289</td>
+          <td>9 February 2026</td>
+          <td>Committee</td>
+          <td>Kranji War Memorial</td>
+          <td>AGM and Gisbert Memorial Run - T-Shirts</td>
+        </tr>
+        <tr>
+          <td>3290</td>
+          <td>16 February 2026</td>
+          <td>Pasi</td>
+          <td>42 Ridout Road - Pasi's place</td>
+          <td>Pizza on site</td>
+        </tr>
+        <tr>
+          <td>3293</td>
+          <td>9 March 2026</td>
+          <td>Meinte &amp; Tony</td>
+          <td>Toa Payoh E</td>
+          <td>Woodleigh Wack &amp; Wail run</td>
+        </tr>
+        <tr>
+          <td>3295</td>
+          <td>23 March 2026</td>
+          <td>Larry &amp; Stan</td>
+          <td>118 Depot Lane</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>
+`;
+
+describe("HHHSAdapter", () => {
+  describe("parseHHHSDate", () => {
+    it.each([
+      ["29 December 2025", "2025-12-29"],
+      ["5 January 2026", "2026-01-05"],
+      ["9 February 2026", "2026-02-09"],
+      ["16 February 2026", "2026-02-16"],
+      ["1 May 2027", "2027-05-01"],
+    ])("parses %s", (input, expected) => {
+      expect(parseHHHSDate(input)).toBe(expected);
+    });
+
+    it.each([
+      ["", "empty"],
+      ["February 16 2026", "month-first"],
+      ["16/02/2026", "slash format"],
+      ["16 Foo 2026", "invalid month"],
+      ["32 March 2026", "invalid day"],
+      ["16 Feb 26", "abbreviated month + 2-digit year"],
+    ])("returns null for %s (%s)", (input) => {
+      expect(parseHHHSDate(input)).toBeNull();
+    });
+  });
+
+  describe("buildColumnMap", () => {
+    it("maps the canonical HHHS headers", () => {
+      const headers = ["Run#", "Date", "Hares", "Location", "Notes"];
+      const map = buildColumnMap(headers);
+      expect(map.get("runNumber")).toBe(0);
+      expect(map.get("date")).toBe(1);
+      expect(map.get("hares")).toBe(2);
+      expect(map.get("location")).toBe(3);
+      expect(map.get("notes")).toBe(4);
+    });
+
+    it.each([
+      ["Run #", "runNumber"],
+      ["RUN#", "runNumber"],
+      ["run number", "runNumber"],
+      ["Hare", "hares"],
+      ["Venue", "location"],
+      ["Note", "notes"],
+      ["Theme", "notes"],
+    ])("normalizes header %s → %s", (header, key) => {
+      const map = buildColumnMap([header]);
+      expect(map.get(key)).toBe(0);
+    });
+  });
+
+  describe("buildTitle", () => {
+    it("synthesizes 'HHHS Trail #<run>' when a run number is present", () => {
+      expect(buildTitle({ date: "2026-02-16", runNumber: 3290 })).toBe(
+        "HHHS Trail #3290",
+      );
+    });
+
+    it("falls back to 'HHHS Run' when the run number is missing", () => {
+      expect(buildTitle({ date: "2026-02-16" })).toBe("HHHS Run");
+    });
+
+    it("ignores notes — title is always synthesized, not promoted", () => {
+      // Codex flagged the earlier code that mapped Notes -> title. Both
+      // logistics blurbs and real-event-name shapes must collapse to the
+      // synthesized title; Notes belongs in description.
+      expect(
+        buildTitle({ date: "2026-02-16", runNumber: 3290, notes: "Pizza on site" }),
+      ).toBe("HHHS Trail #3290");
+      expect(
+        buildTitle({
+          date: "2026-03-16",
+          runNumber: 3294,
+          notes: "St Patrick's Day Run",
+        }),
+      ).toBe("HHHS Trail #3294");
+    });
+  });
+
+  describe("parseHHHSRow", () => {
+    const headers = ["Run#", "Date", "Hares", "Location", "Notes"];
+    const columnMap = buildColumnMap(headers);
+
+    it("extracts all five columns for a full row", () => {
+      const cells = [
+        "3290",
+        "16 February 2026",
+        "Pasi",
+        "42 Ridout Road - Pasi's place",
+        "Pizza on site",
+      ];
+      expect(parseHHHSRow(cells, columnMap)).toEqual({
+        date: "2026-02-16",
+        runNumber: 3290,
+        hares: "Pasi",
+        location: "42 Ridout Road - Pasi's place",
+        notes: "Pizza on site",
+      });
+    });
+
+    it("leaves notes undefined when the cell is blank", () => {
+      const cells = ["3295", "23 March 2026", "Larry & Stan", "118 Depot Lane", ""];
+      const parsed = parseHHHSRow(cells, columnMap);
+      expect(parsed?.date).toBe("2026-03-23");
+      expect(parsed?.notes).toBeUndefined();
+    });
+
+    it("returns null when the date column is unparseable", () => {
+      const cells = ["3290", "TBA", "Pasi", "42 Ridout Road", "Pizza on site"];
+      expect(parseHHHSRow(cells, columnMap)).toBeNull();
+    });
+
+    it("returns null when the date column is empty", () => {
+      const cells = ["3290", "", "Pasi", "42 Ridout Road", "Pizza on site"];
+      expect(parseHHHSRow(cells, columnMap)).toBeNull();
+    });
+  });
+
+  describe("fetch()", () => {
+    const source = {
+      id: "src-hhhs",
+      url: "https://www.hhhs.org.sg/hareline",
+      type: "HTML_SCRAPER",
+    } as unknown as Source;
+
+    it("parses the hareline table end-to-end", async () => {
+      const { browserRender } = await import("@/lib/browser-render");
+      vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
+
+      const result = await new HHHSAdapter().fetch(source);
+
+      expect(result.events).toHaveLength(4);
+      expect(result.errors).toEqual([]);
+      expect(result.diagnosticContext).toMatchObject({
+        fetchMethod: "browser-render",
+        adapter: "HHHSAdapter",
+        totalEvents: 4,
+      });
+
+      const ridout = result.events.find((e) => e.runNumber === 3290);
+      expect(ridout).toMatchObject({
+        date: "2026-02-16",
+        kennelTags: ["hhhs"],
+        runNumber: 3290,
+        title: "HHHS Trail #3290",
+        description: "Pizza on site",
+        hares: "Pasi",
+        location: "42 Ridout Road - Pasi's place",
+        startTime: "18:00",
+        sourceUrl: "https://www.hhhs.org.sg/hareline",
+      });
+    });
+
+    it("synthesizes title and leaves description undefined when Notes is blank", async () => {
+      const { browserRender } = await import("@/lib/browser-render");
+      vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
+
+      const result = await new HHHSAdapter().fetch(source);
+
+      const depotLane = result.events.find((e) => e.runNumber === 3295);
+      expect(depotLane?.title).toBe("HHHS Trail #3295");
+      expect(depotLane?.description).toBeUndefined();
+      expect(depotLane?.location).toBe("118 Depot Lane");
+    });
+
+    it("synthesizes title for an event-name-shaped Notes row (still not promoted)", async () => {
+      const { browserRender } = await import("@/lib/browser-render");
+      vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
+
+      const result = await new HHHSAdapter().fetch(source);
+
+      const agm = result.events.find((e) => e.runNumber === 3289);
+      expect(agm?.title).toBe("HHHS Trail #3289");
+      expect(agm?.description).toBe("AGM and Gisbert Memorial Run - T-Shirts");
+    });
+
+    it("filters events outside the date window", async () => {
+      const { browserRender } = await import("@/lib/browser-render");
+      vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
+
+      // Narrow window: 10 days from 2026-05-18 → only events between
+      // 2026-05-08 and 2026-05-28 would pass. None of the fixture rows
+      // (all Feb/Mar 2026) fall in that window.
+      const result = await new HHHSAdapter().fetch(source, { days: 10 });
+      expect(result.events).toHaveLength(0);
+    });
+
+    it("surfaces a fetch error when browser-render throws", async () => {
+      const { browserRender } = await import("@/lib/browser-render");
+      vi.mocked(browserRender).mockRejectedValueOnce(new Error("frame not found"));
+
+      const result = await new HHHSAdapter().fetch(source);
+      expect(result.events).toEqual([]);
+      expect(result.errors[0]).toMatch(/Browser render failed/);
+    });
+  });
+});

--- a/src/adapters/html-scraper/hhhs.test.ts
+++ b/src/adapters/html-scraper/hhhs.test.ts
@@ -130,6 +130,13 @@ describe("HHHSAdapter", () => {
       expect(buildTitle({ date: "2026-02-16" })).toBe("HHHS Run");
     });
 
+    it("preserves runNumber: 0 (Number.isFinite, not truthiness)", () => {
+      // HHHS in practice is #3300+, but the contract must match
+      // parseHHHSRow's `Number.isFinite` guard so a hypothetical 0 still
+      // renders as "HHHS Trail #0" rather than falling back.
+      expect(buildTitle({ date: "2026-02-16", runNumber: 0 })).toBe("HHHS Trail #0");
+    });
+
     it("ignores notes — title is always synthesized, not promoted", () => {
       // Codex flagged the earlier code that mapped Notes -> title. Both
       // logistics blurbs and real-event-name shapes must collapse to the
@@ -193,11 +200,21 @@ describe("HHHSAdapter", () => {
       type: "HTML_SCRAPER",
     } as unknown as Source;
 
-    it("parses the hareline table end-to-end", async () => {
+    async function runFetch(opts?: { days?: number; reject?: Error }) {
       const { browserRender } = await import("@/lib/browser-render");
-      vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
+      if (opts?.reject) {
+        vi.mocked(browserRender).mockRejectedValueOnce(opts.reject);
+      } else {
+        vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
+      }
+      return new HHHSAdapter().fetch(
+        source,
+        opts?.days !== undefined ? { days: opts.days } : undefined,
+      );
+    }
 
-      const result = await new HHHSAdapter().fetch(source);
+    it("parses the hareline table end-to-end", async () => {
+      const result = await runFetch();
 
       expect(result.events).toHaveLength(4);
       expect(result.errors).toEqual([]);
@@ -222,10 +239,7 @@ describe("HHHSAdapter", () => {
     });
 
     it("synthesizes title and leaves description undefined when Notes is blank", async () => {
-      const { browserRender } = await import("@/lib/browser-render");
-      vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
-
-      const result = await new HHHSAdapter().fetch(source);
+      const result = await runFetch();
 
       const depotLane = result.events.find((e) => e.runNumber === 3295);
       expect(depotLane?.title).toBe("HHHS Trail #3295");
@@ -234,10 +248,7 @@ describe("HHHSAdapter", () => {
     });
 
     it("synthesizes title for an event-name-shaped Notes row (still not promoted)", async () => {
-      const { browserRender } = await import("@/lib/browser-render");
-      vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
-
-      const result = await new HHHSAdapter().fetch(source);
+      const result = await runFetch();
 
       const agm = result.events.find((e) => e.runNumber === 3289);
       expect(agm?.title).toBe("HHHS Trail #3289");
@@ -245,21 +256,14 @@ describe("HHHSAdapter", () => {
     });
 
     it("filters events outside the date window", async () => {
-      const { browserRender } = await import("@/lib/browser-render");
-      vi.mocked(browserRender).mockResolvedValueOnce(FIXTURE_HTML);
-
-      // Narrow window: 10 days from 2026-05-18 → only events between
-      // 2026-05-08 and 2026-05-28 would pass. None of the fixture rows
-      // (all Feb/Mar 2026) fall in that window.
-      const result = await new HHHSAdapter().fetch(source, { days: 10 });
+      // Narrow window: 10 days from 2026-05-18 — fixture rows are all
+      // Feb/Mar 2026 so none survive.
+      const result = await runFetch({ days: 10 });
       expect(result.events).toHaveLength(0);
     });
 
     it("surfaces a fetch error when browser-render throws", async () => {
-      const { browserRender } = await import("@/lib/browser-render");
-      vi.mocked(browserRender).mockRejectedValueOnce(new Error("frame not found"));
-
-      const result = await new HHHSAdapter().fetch(source);
+      const result = await runFetch({ reject: new Error("frame not found") });
       expect(result.events).toEqual([]);
       expect(result.errors[0]).toMatch(/Browser render failed/);
     });

--- a/src/adapters/html-scraper/hhhs.ts
+++ b/src/adapters/html-scraper/hhhs.ts
@@ -1,0 +1,268 @@
+/**
+ * HHHS (Hash House Harriers Singapore — "Father Hash") HTML Scraper
+ *
+ * Scrapes https://www.hhhs.org.sg/hareline for upcoming Monday runs.
+ * The site is Wix-hosted with a cross-origin "Table Master" iframe holding
+ * the hareline — requires browser rendering via the NAS Playwright service.
+ *
+ * Table columns: Run#, Date, Hares, Location, Notes
+ * Date format: "29 December 2025" (D MMMM YYYY — full month, 4-digit year)
+ *
+ * Single kennel: HHHS (Singapore, founded 1962 — the 2nd hash kennel in the world).
+ * Paired with a lower-trust STATIC_SCHEDULE fallback so a Wix outage does not
+ * black out coverage for a founder kennel.
+ *
+ * Title policy: always synthesized as `"HHHS Trail #<runNumber>"` (or
+ * `"HHHS Run"` if the run number is missing). The Notes column is routed
+ * to `description`, NOT `title`, because Notes mixes real event names
+ * with logistics-only blurbs ("Pizza on site") that would publish as ugly
+ * card titles and churn the raw-event fingerprint on every harmless edit.
+ */
+import type { CheerioAPI } from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
+import {
+  MONTHS,
+  stripPlaceholder,
+  buildDateWindow,
+  fetchBrowserRenderedPage,
+} from "../utils";
+
+const KENNEL_CODE = "hhhs";
+const DISPLAY_NAME = "HHHS";
+const DEFAULT_START_TIME = "18:00";
+const SOURCE_TIMEZONE = "Asia/Singapore";
+/**
+ * Wix Table Master iframe compId. Substring-matched against the iframe `src`.
+ * The hareline page hosts two iframes (Table Master + Wix Chat); matching the
+ * specific compId disambiguates so we don't render the chat widget by mistake.
+ * Confirmed by inspecting SSR HTML at https://www.hhhs.org.sg/hareline (the
+ * Table Master parent `<div id="comp-jxzijgcm">`).
+ */
+const TABLE_MASTER_COMP_ID = "comp-jxzijgcm";
+
+// ---------------------------------------------------------------------------
+// Date parsing
+// ---------------------------------------------------------------------------
+
+const HHHS_DATE_RE = /^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/;
+
+/**
+ * Strict "D MMMM YYYY" parse → `YYYY-MM-DD` or `null`. We avoid chrono here
+ * so off-format input fails loud instead of resolving to a guessed date.
+ */
+export function parseHHHSDate(text: string): string | null {
+  const match = HHHS_DATE_RE.exec(text.trim());
+  if (!match) return null;
+
+  const day = Number.parseInt(match[1], 10);
+  const monthStr = match[2].toLowerCase();
+  const year = Number.parseInt(match[3], 10);
+
+  const month = MONTHS[monthStr];
+  if (month === undefined) return null;
+
+  const maxDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  if (day < 1 || day > maxDay) return null;
+
+  const mm = String(month).padStart(2, "0");
+  const dd = String(day).padStart(2, "0");
+  return `${year}-${mm}-${dd}`;
+}
+
+// ---------------------------------------------------------------------------
+// Column mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a header label by lowercasing and stripping `#`/whitespace so
+ * "Run#", "Run #", and "RUN  #" all collapse to "run".
+ */
+function normalizeHeader(raw: string): string {
+  return raw.toLowerCase().replace(/[#\s]+/g, "");
+}
+
+export function buildColumnMap(headers: string[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (let i = 0; i < headers.length; i++) {
+    const normalized = normalizeHeader(headers[i]);
+    if (normalized === "run" || normalized === "runnumber") map.set("runNumber", i);
+    else if (normalized === "date") map.set("date", i);
+    else if (normalized === "hares" || normalized === "hare") map.set("hares", i);
+    else if (normalized === "location" || normalized === "venue") map.set("location", i);
+    else if (normalized === "notes" || normalized === "note" || normalized === "theme") {
+      map.set("notes", i);
+    }
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Row parsing
+// ---------------------------------------------------------------------------
+
+export interface ParsedHHHSRun {
+  date: string;
+  runNumber?: number;
+  hares?: string;
+  location?: string;
+  notes?: string;
+}
+
+function getCell(
+  cells: string[],
+  columnMap: Map<string, number>,
+  name: string,
+): string | undefined {
+  const idx = columnMap.get(name);
+  if (idx === undefined) return undefined;
+  return stripPlaceholder(cells[idx]?.trim());
+}
+
+export function parseHHHSRow(
+  cells: string[],
+  columnMap: Map<string, number>,
+): ParsedHHHSRun | null {
+  const rawDate = getCell(cells, columnMap, "date");
+  if (!rawDate) return null;
+
+  const date = parseHHHSDate(rawDate);
+  if (!date) return null;
+
+  const runNumText = getCell(cells, columnMap, "runNumber");
+  const parsedRun = runNumText ? Number.parseInt(runNumText, 10) : NaN;
+  const runNumber = Number.isFinite(parsedRun) ? parsedRun : undefined;
+
+  return {
+    date,
+    runNumber,
+    hares: getCell(cells, columnMap, "hares"),
+    location: getCell(cells, columnMap, "location"),
+    notes: getCell(cells, columnMap, "notes"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Table extraction
+// ---------------------------------------------------------------------------
+
+function extractTableRows($: CheerioAPI): { headers: string[]; rows: string[][] } {
+  const tables = $("table").toArray();
+  if (tables.length === 0) return { headers: [], rows: [] };
+
+  const tableEl = tables.find((t) => $(t).find("th").length >= 2) ?? tables[0];
+  const table = $(tableEl);
+
+  const headers: string[] = [];
+  table.find("thead th, tr:first-child th").each((_, el) => {
+    headers.push($(el).text().trim());
+  });
+
+  if (headers.length === 0) {
+    table.find("tr:first-child td").each((_, el) => {
+      headers.push($(el).text().trim());
+    });
+  }
+
+  const rows: string[][] = [];
+  const trSelector = table.find("tbody").length > 0 ? "tbody tr" : "tr:not(:first-child)";
+
+  for (const row of table.find(trSelector).toArray()) {
+    const cells: string[] = [];
+    $(row)
+      .find("td")
+      .each((_, el) => {
+        cells.push($(el).text().trim());
+      });
+    if (cells.length > 0 && cells.some((c) => c.length > 0)) {
+      rows.push(cells);
+    }
+  }
+
+  return { headers, rows };
+}
+
+// ---------------------------------------------------------------------------
+// Event building
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthesize a stable title (see file-header title policy). Explicit so we
+ * side-step `friendlyKennelName()` expanding HHHS to
+ * `"Hash House Harriers Singapore H3 Trail #N"` when notes are blank.
+ */
+export function buildTitle(parsed: ParsedHHHSRun): string {
+  return parsed.runNumber
+    ? `${DISPLAY_NAME} Trail #${parsed.runNumber}`
+    : `${DISPLAY_NAME} Run`;
+}
+
+function buildRawEvent(parsed: ParsedHHHSRun, sourceUrl: string): RawEventData {
+  return {
+    date: parsed.date,
+    kennelTags: [KENNEL_CODE],
+    runNumber: parsed.runNumber,
+    title: buildTitle(parsed),
+    hares: parsed.hares,
+    location: parsed.location,
+    startTime: DEFAULT_START_TIME,
+    description: parsed.notes,
+    sourceUrl,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class HHHSAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(
+    source: Source,
+    options?: { days?: number },
+  ): Promise<ScrapeResult> {
+    const sourceUrl = source.url;
+    const { minDate, maxDate } = buildDateWindow(options?.days ?? 365);
+
+    // Wix renders Table Master cell text client-side via Intl.DateTimeFormat;
+    // pinning the browser timezone keeps date strings stable (#960 BCH3 fix).
+    const page = await fetchBrowserRenderedPage(sourceUrl, {
+      waitFor: "iframe[title='Table Master']",
+      frameUrl: TABLE_MASTER_COMP_ID,
+      timezoneId: SOURCE_TIMEZONE,
+      timeout: 25000,
+    });
+
+    if (!page.ok) {
+      return page.result;
+    }
+
+    const events: RawEventData[] = [];
+    const { headers, rows } = extractTableRows(page.$);
+    const columnMap = buildColumnMap(headers);
+
+    for (const cells of rows) {
+      const parsed = parseHHHSRow(cells, columnMap);
+      if (!parsed) continue;
+
+      const eventDate = new Date(parsed.date + "T12:00:00Z");
+      if (eventDate < minDate || eventDate > maxDate) continue;
+
+      events.push(buildRawEvent(parsed, sourceUrl));
+    }
+
+    return {
+      events,
+      errors: [],
+      structureHash: page.structureHash,
+      diagnosticContext: {
+        fetchMethod: "browser-render",
+        totalEvents: events.length,
+        fetchDurationMs: page.fetchDurationMs,
+        adapter: "HHHSAdapter",
+        displayName: DISPLAY_NAME,
+      },
+    };
+  }
+}

--- a/src/adapters/html-scraper/hhhs.ts
+++ b/src/adapters/html-scraper/hhhs.ts
@@ -130,7 +130,7 @@ export function parseHHHSRow(
   if (!date) return null;
 
   const runNumText = getCell(cells, columnMap, "runNumber");
-  const parsedRun = runNumText ? Number.parseInt(runNumText, 10) : NaN;
+  const parsedRun = runNumText ? Number.parseInt(runNumText, 10) : Number.NaN;
   const runNumber = Number.isFinite(parsedRun) ? parsedRun : undefined;
 
   return {
@@ -174,7 +174,7 @@ function extractTableRows($: CheerioAPI): { headers: string[]; rows: string[][] 
       .each((_, el) => {
         cells.push($(el).text().trim());
       });
-    if (cells.length > 0 && cells.some((c) => c.length > 0)) {
+    if (cells.some((c) => c.length > 0)) {
       rows.push(cells);
     }
   }
@@ -192,7 +192,9 @@ function extractTableRows($: CheerioAPI): { headers: string[]; rows: string[][] 
  * `"Hash House Harriers Singapore H3 Trail #N"` when notes are blank.
  */
 export function buildTitle(parsed: ParsedHHHSRun): string {
-  return parsed.runNumber
+  // Number.isFinite (not truthiness) so a hypothetical runNumber: 0 still
+  // renders as `"HHHS Trail #0"` — matches the contract in parseHHHSRow.
+  return Number.isFinite(parsed.runNumber)
     ? `${DISPLAY_NAME} Trail #${parsed.runNumber}`
     : `${DISPLAY_NAME} Run`;
 }

--- a/src/adapters/html-scraper/hhhs.ts
+++ b/src/adapters/html-scraper/hhhs.ts
@@ -18,15 +18,14 @@
  * with logistics-only blurbs ("Pizza on site") that would publish as ugly
  * card titles and churn the raw-event fingerprint on every harmless edit.
  */
-import type { CheerioAPI } from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
 import {
-  MONTHS,
   stripPlaceholder,
   buildDateWindow,
   fetchBrowserRenderedPage,
 } from "../utils";
+import { extractWixTableRows, parseDayMonthYearDate } from "./wix-table-master";
 
 const KENNEL_CODE = "hhhs";
 const DISPLAY_NAME = "HHHS";
@@ -48,26 +47,11 @@ const TABLE_MASTER_COMP_ID = "comp-jxzijgcm";
 const HHHS_DATE_RE = /^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/;
 
 /**
- * Strict "D MMMM YYYY" parse → `YYYY-MM-DD` or `null`. We avoid chrono here
- * so off-format input fails loud instead of resolving to a guessed date.
+ * Strict "D MMMM YYYY" parse → `YYYY-MM-DD` or `null`. Delegates to the
+ * shared `parseDayMonthYearDate` helper with an HHHS-specific regex.
  */
 export function parseHHHSDate(text: string): string | null {
-  const match = HHHS_DATE_RE.exec(text.trim());
-  if (!match) return null;
-
-  const day = Number.parseInt(match[1], 10);
-  const monthStr = match[2].toLowerCase();
-  const year = Number.parseInt(match[3], 10);
-
-  const month = MONTHS[monthStr];
-  if (month === undefined) return null;
-
-  const maxDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
-  if (day < 1 || day > maxDay) return null;
-
-  const mm = String(month).padStart(2, "0");
-  const dd = String(day).padStart(2, "0");
-  return `${year}-${mm}-${dd}`;
+  return parseDayMonthYearDate(text, HHHS_DATE_RE);
 }
 
 // ---------------------------------------------------------------------------
@@ -143,46 +127,6 @@ export function parseHHHSRow(
 }
 
 // ---------------------------------------------------------------------------
-// Table extraction
-// ---------------------------------------------------------------------------
-
-function extractTableRows($: CheerioAPI): { headers: string[]; rows: string[][] } {
-  const tables = $("table").toArray();
-  if (tables.length === 0) return { headers: [], rows: [] };
-
-  const tableEl = tables.find((t) => $(t).find("th").length >= 2) ?? tables[0];
-  const table = $(tableEl);
-
-  const headers: string[] = [];
-  table.find("thead th, tr:first-child th").each((_, el) => {
-    headers.push($(el).text().trim());
-  });
-
-  if (headers.length === 0) {
-    table.find("tr:first-child td").each((_, el) => {
-      headers.push($(el).text().trim());
-    });
-  }
-
-  const rows: string[][] = [];
-  const trSelector = table.find("tbody").length > 0 ? "tbody tr" : "tr:not(:first-child)";
-
-  for (const row of table.find(trSelector).toArray()) {
-    const cells: string[] = [];
-    $(row)
-      .find("td")
-      .each((_, el) => {
-        cells.push($(el).text().trim());
-      });
-    if (cells.some((c) => c.length > 0)) {
-      rows.push(cells);
-    }
-  }
-
-  return { headers, rows };
-}
-
-// ---------------------------------------------------------------------------
 // Event building
 // ---------------------------------------------------------------------------
 
@@ -241,7 +185,7 @@ export class HHHSAdapter implements SourceAdapter {
     }
 
     const events: RawEventData[] = [];
-    const { headers, rows } = extractTableRows(page.$);
+    const { headers, rows } = extractWixTableRows(page.$);
     const columnMap = buildColumnMap(headers);
 
     for (const cells of rows) {

--- a/src/adapters/html-scraper/wix-table-master.test.ts
+++ b/src/adapters/html-scraper/wix-table-master.test.ts
@@ -1,0 +1,73 @@
+import * as cheerio from "cheerio";
+import { extractWixTableRows, parseDayMonthYearDate } from "./wix-table-master";
+
+describe("extractWixTableRows", () => {
+  it("returns empty when no tables are present", () => {
+    const $ = cheerio.load("<html><body><p>no tables</p></body></html>");
+    expect(extractWixTableRows($)).toEqual({ headers: [], rows: [] });
+  });
+
+  it("picks the first table with ≥2 <th> headers", () => {
+    const $ = cheerio.load(`
+      <table><tr><td>not headers</td></tr></table>
+      <table>
+        <thead><tr><th>A</th><th>B</th></tr></thead>
+        <tbody><tr><td>1</td><td>2</td></tr></tbody>
+      </table>
+    `);
+    expect(extractWixTableRows($)).toEqual({
+      headers: ["A", "B"],
+      rows: [["1", "2"]],
+    });
+  });
+
+  it("falls back to tr:first-child th when there is no <thead>", () => {
+    const $ = cheerio.load(`
+      <table>
+        <tr><th>X</th><th>Y</th></tr>
+        <tr><td>a</td><td>b</td></tr>
+      </table>
+    `);
+    expect(extractWixTableRows($)).toEqual({
+      headers: ["X", "Y"],
+      rows: [["a", "b"]],
+    });
+  });
+
+  it("drops rows where every cell is empty", () => {
+    const $ = cheerio.load(`
+      <table>
+        <thead><tr><th>A</th><th>B</th></tr></thead>
+        <tbody>
+          <tr><td></td><td></td></tr>
+          <tr><td>1</td><td>2</td></tr>
+        </tbody>
+      </table>
+    `);
+    expect(extractWixTableRows($).rows).toEqual([["1", "2"]]);
+  });
+});
+
+describe("parseDayMonthYearDate", () => {
+  const D_MMMM_YYYY = /^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/;
+  const D_MMM_YY = /^(\d{1,2})-([A-Za-z]+)-(\d{2})$/;
+
+  it.each([
+    ["29 December 2025", D_MMMM_YYYY, "2025-12-29"],
+    ["5 January 2026", D_MMMM_YYYY, "2026-01-05"],
+    ["31-Jan-26", D_MMM_YY, "2026-01-31"],
+    ["1-Dec-99", D_MMM_YY, "2099-12-01"],
+  ])("parses %s with the supplied regex", (input, regex, expected) => {
+    expect(parseDayMonthYearDate(input, regex)).toBe(expected);
+  });
+
+  it.each([
+    ["", D_MMMM_YYYY, "empty"],
+    ["February 16 2026", D_MMMM_YYYY, "month-first"],
+    ["16 Foo 2026", D_MMMM_YYYY, "invalid month"],
+    ["32 March 2026", D_MMMM_YYYY, "day out of range"],
+    ["29 February 2025", D_MMMM_YYYY, "non-leap Feb 29"],
+  ])("returns null for %s (%s)", (input, regex) => {
+    expect(parseDayMonthYearDate(input, regex)).toBeNull();
+  });
+});

--- a/src/adapters/html-scraper/wix-table-master.ts
+++ b/src/adapters/html-scraper/wix-table-master.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared helpers for Wix Table Master cross-origin iframe scraping.
+ *
+ * Wix Table Master is a third-party widget Wix sites embed via an iframe.
+ * The DOM it renders is identical regardless of host site:
+ *   - The first `<table>` with `>=2 <th>` cells (or first table as fallback)
+ *   - Header row in `thead th, tr:first-child th`, with `tr:first-child td`
+ *     as a last-resort fallback
+ *   - Body rows in `tbody tr` (or `tr:not(:first-child)` if no `<tbody>`)
+ *
+ * Today this is consumed by `hhhs.ts`. New Wix Table Master adapters
+ * (Samurai H3, New Tokyo Katch, Bull Moon currently inline their own
+ * copies) should migrate to this helper rather than continuing to fork it.
+ */
+import type { CheerioAPI } from "cheerio";
+import { MONTHS } from "../utils";
+
+/**
+ * Pull `(headers, rows)` from the first hareline-shaped `<table>` on the
+ * page. Empty headers/rows arrays are returned when no candidate table
+ * is present so callers can short-circuit deterministically.
+ */
+export function extractWixTableRows(
+  $: CheerioAPI,
+): { headers: string[]; rows: string[][] } {
+  const tables = $("table").toArray();
+  if (tables.length === 0) return { headers: [], rows: [] };
+
+  const tableEl = tables.find((t) => $(t).find("th").length >= 2) ?? tables[0];
+  const table = $(tableEl);
+
+  const headers: string[] = [];
+  table.find("thead th, tr:first-child th").each((_, el) => {
+    headers.push($(el).text().trim());
+  });
+
+  if (headers.length === 0) {
+    table.find("tr:first-child td").each((_, el) => {
+      headers.push($(el).text().trim());
+    });
+  }
+
+  const rows: string[][] = [];
+  const trSelector =
+    table.find("tbody").length > 0 ? "tbody tr" : "tr:not(:first-child)";
+
+  for (const row of table.find(trSelector).toArray()) {
+    const cells: string[] = [];
+    $(row)
+      .find("td")
+      .each((_, el) => {
+        cells.push($(el).text().trim());
+      });
+    if (cells.some((c) => c.length > 0)) {
+      rows.push(cells);
+    }
+  }
+
+  return { headers, rows };
+}
+
+/**
+ * Strict day/month/year date parse with a caller-supplied regex.
+ *
+ * The regex must capture three groups in this order: day, month, year.
+ * Months may be full names (`December`) or abbreviations (`Dec`) — both
+ * lower-case lookups resolve via the shared `MONTHS` table in utils.
+ *
+ * Returns `YYYY-MM-DD` on success or `null` for any off-format, unknown
+ * month, or out-of-range day. Year may be 2- or 4-digit; 2-digit years
+ * are promoted to `2000 + yy` (callers that need a different windowing
+ * rule should pre-normalize before passing in).
+ *
+ * Designed for Wix Table Master adapters that publish unambiguous,
+ * year-bearing date cells. Adapters with year-less dates ("28-Mar") need
+ * a separate forward-window helper — chrono is not used here so any
+ * malformed cell fails loud rather than resolving to a guessed value.
+ */
+export function parseDayMonthYearDate(
+  text: string,
+  pattern: RegExp,
+): string | null {
+  const match = pattern.exec(text.trim());
+  if (!match) return null;
+
+  const day = Number.parseInt(match[1], 10);
+  const monthStr = match[2].toLowerCase();
+  let year = Number.parseInt(match[3], 10);
+  if (year < 100) year += 2000;
+
+  const month = MONTHS[monthStr];
+  if (month === undefined) return null;
+
+  const maxDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  if (day < 1 || day > maxDay) return null;
+
+  const mm = String(month).padStart(2, "0");
+  const dd = String(day).padStart(2, "0");
+  return `${year}-${mm}-${dd}`;
+}

--- a/src/adapters/registry.test.ts
+++ b/src/adapters/registry.test.ts
@@ -15,6 +15,7 @@ import { OCH3Adapter } from "./html-scraper/och3";
 import { SlashHashAdapter } from "./html-scraper/slash-hash";
 import { EnfieldHashAdapter } from "./html-scraper/enfield-hash";
 import { SFH3Adapter } from "./html-scraper/sfh3";
+import { HHHSAdapter } from "./html-scraper/hhhs";
 import { RssAdapter } from "./rss/adapter";
 import { StaticScheduleAdapter } from "./static-schedule/adapter";
 
@@ -49,6 +50,12 @@ describe("getAdapter", () => {
 
   it("returns SFH3Adapter for sfh3.com URL", () => {
     expect(getAdapter("HTML_SCRAPER", "https://www.sfh3.com/runs?kennels=all")).toBeInstanceOf(SFH3Adapter);
+  });
+
+  it("returns HHHSAdapter for hhhs.org.sg URL (not the HashNYCAdapter default)", () => {
+    const adapter = getAdapter("HTML_SCRAPER", "https://www.hhhs.org.sg/hareline");
+    expect(adapter).toBeInstanceOf(HHHSAdapter);
+    expect(adapter).not.toBeInstanceOf(HashNYCAdapter);
   });
 
   it("returns GoogleCalendarAdapter for GOOGLE_CALENDAR", () => {

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -69,6 +69,7 @@ import { LionCityH3Adapter } from "./html-scraper/lion-city-h3";
 import { KampongH3Adapter } from "./html-scraper/kampong-h3";
 import { HashHorrorsAdapter } from "./html-scraper/hash-horrors";
 import { SeletarH3Adapter } from "./html-scraper/seletar-h3";
+import { HHHSAdapter } from "./html-scraper/hhhs";
 import { MotherHashAdapter } from "./html-scraper/mother-hash";
 import { YiiHarelineAdapter } from "./html-scraper/yii-hareline";
 import { KljH3Adapter } from "./html-scraper/klj-h3";
@@ -198,6 +199,7 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /kampong\.hash\.org\.sg/i, name: "KampongH3Adapter", factory: () => new KampongH3Adapter() },
   { pattern: /hashhousehorrors\.com/i, name: "HashHorrorsAdapter", factory: () => new HashHorrorsAdapter() },
   { pattern: /sh3app\.hash\.org\.sg/i, name: "SeletarH3Adapter", factory: () => new SeletarH3Adapter() },
+  { pattern: /hhhs\.org\.sg/i, name: "HHHSAdapter", factory: () => new HHHSAdapter() },
   // ── Malaysia (Phase 1: KL + Penang founder pack) ──
   { pattern: /motherhash\.org/i, name: "MotherHashAdapter", factory: () => new MotherHashAdapter() },
   { pattern: /ph3\.org/i, name: "YiiHarelineAdapter", factory: () => new YiiHarelineAdapter() },


### PR DESCRIPTION
## Summary

- Adds an `HTML_SCRAPER` adapter for HHHS (Hash House Harriers Singapore, founded 1962 — the 2nd hash kennel in the world) targeting the cross-origin **Wix Table Master** iframe at https://www.hhhs.org.sg/hareline.
- Replaces placeholder Monday-run titles + generic `Singapore` location with real run number, hares, street address, and operator notes for every upcoming run.
- Pairs the new trust-level-8 scraper with the existing trust-level-3 `STATIC_SCHEDULE` row as a fail-soft fallback (canonical GSH3 pattern) so a Wix outage does not black out a founder kennel.

Closes #1474

## Title policy (Codex adversarial review)

Initial implementation mapped the Notes column → `title`. Codex flagged two real failure modes:

1. **Free-form notes published as titles**: rows like Notes=`Pizza on site` would publish `Pizza on site` as the event title and churn the raw-event fingerprint on every harmless edit.
2. **Blank-Notes title synthesis breaks for HHHS**: leaving `title` undefined falls into `friendlyKennelName()` which would expand HHHS into `Hash House Harriers Singapore H3 Trail #<n>`.

Adapter now synthesizes `"HHHS Trail #<run>"` in-adapter and routes Notes → `description` so operator copy still surfaces on the detail page. Three dedicated unit tests pin this contract (run #3289 event-name-shaped notes, run #3290 logistics blurb, run #3295 blank notes).

## Changes

- `src/adapters/html-scraper/hhhs.ts` — Wix iframe scraper (browser-render, timezone-pinned to `Asia/Singapore`, strict `D MMMM YYYY` date parse, `buildTitle` synthesis).
- `src/adapters/html-scraper/hhhs.test.ts` — 31 fixture-backed tests.
- `src/adapters/registry.ts` + test — adds `/hhhs\.org\.sg/i` → `HHHSAdapter` route (previously dispatched to the default `HashNYCAdapter`).
- `prisma/seed-data/sources.ts` — new `HHHS Hareline` HTML_SCRAPER row (trustLevel 8, daily, 90d); softens the existing static row's `defaultDescription` to drop the now-stale "go to the source for the missing data" sentence.
- `scripts/live-verify-hhhs.ts` — one-shot live-verification harness (asserts registry dispatch + ≥1 event + rich-field coverage).

## Backfill

Hareline shows only ~18 future runs — no public HHHS archive identified. Historical backfill is **deferred to a follow-up** once an archive source surfaces.

## Test plan

- [x] `npm test` — 252 files / 6703 passed (incl. 31 HHHS + 25 registry)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] `/codex:adversarial-review` — high+medium findings fixed (title policy)
- [x] `/simplify` — trimmed redundant comments, simplified runNumber parse
- [ ] Live verification post-merge: `set -a && source .env && set +a && npx tsx scripts/live-verify-hhhs.ts` (requires `BROWSER_RENDER_URL` / `BROWSER_RENDER_KEY`)
- [ ] Confirm seed applied + at least 2 consecutive Monday scrapes show rich data on the HHHS kennel page

🤖 Generated with [Claude Code](https://claude.com/claude-code)