### PR TITLE
fix(audit): harden filing resilience after #1494 GITHUB_TOKEN outage

### DIFF
--- a/src/app/api/audit/file-finding/route.ts
+++ b/src/app/api/audit/file-finding/route.ts
@@ -41,6 +41,7 @@
 import { NextResponse } from "next/server";
 
 import { authorizeAuditApi } from "@/lib/audit-api-auth";
+import { reportAuditFilerFailure } from "@/pipeline/audit-filer-telemetry";
 import { prisma } from "@/lib/db";
 import {
   hashNonce,
@@ -331,6 +332,7 @@ function buildApiActions(): FilerActions {
       const token = process.env.GITHUB_TOKEN;
       if (!token) {
         console.error(`${LOG_PREFIX} createIssue: GITHUB_TOKEN not set`);
+        reportAuditFilerFailure("chrome", "createIssue", { error: "GITHUB_TOKEN not set" });
         return null;
       }
       const repo = getValidatedRepo();
@@ -343,9 +345,14 @@ function buildApiActions(): FilerActions {
           githubPostInit(token, { title, body, labels }),
         );
         if (!res.ok) {
+          const errBody = await safeErrorBody(res);
           console.error(
-            `${LOG_PREFIX} createIssue GitHub API ${res.status}: ${await safeErrorBody(res)}`,
+            `${LOG_PREFIX} createIssue GitHub API ${res.status}: ${errBody}`,
           );
+          reportAuditFilerFailure("chrome", "createIssue", {
+            githubStatus: res.status,
+            body: errBody,
+          });
           return null;
         }
         // Local name carries "Html" so the xss/no-mixed-html rule
@@ -359,6 +366,7 @@ function buildApiActions(): FilerActions {
         return { htmlUrl: issueHtml.html_url, number: issueHtml.number };
       } catch (err) {
         console.error(`${LOG_PREFIX} createIssue fetch threw:`, err);
+        reportAuditFilerFailure("chrome", "createIssue", { error: err });
         return null;
       }
     },
@@ -366,6 +374,10 @@ function buildApiActions(): FilerActions {
       const token = process.env.GITHUB_TOKEN;
       if (!token) {
         console.error(`${LOG_PREFIX} postComment: GITHUB_TOKEN not set`);
+        reportAuditFilerFailure("chrome", "postComment", {
+          error: "GITHUB_TOKEN not set",
+          issueNumber,
+        });
         return false;
       }
       if (!Number.isInteger(issueNumber) || issueNumber <= 0) return false;
@@ -378,13 +390,20 @@ function buildApiActions(): FilerActions {
         );
         const res = await fetch(url, githubPostInit(token, { body }));
         if (!res.ok) {
+          const errBody = await safeErrorBody(res);
           console.error(
-            `${LOG_PREFIX} postComment GitHub API #${issueNumber} ${res.status}: ${await safeErrorBody(res)}`,
+            `${LOG_PREFIX} postComment GitHub API #${issueNumber} ${res.status}: ${errBody}`,
           );
+          reportAuditFilerFailure("chrome", "postComment", {
+            githubStatus: res.status,
+            body: errBody,
+            issueNumber,
+          });
         }
         return res.ok;
       } catch (err) {
         console.error(`${LOG_PREFIX} postComment fetch threw:`, err);
+        reportAuditFilerFailure("chrome", "postComment", { error: err, issueNumber });
         return false;
       }
     },

--- a/src/app/api/audit/file-finding/route.ts
+++ b/src/app/api/audit/file-finding/route.ts
@@ -41,6 +41,7 @@
 import { NextResponse } from "next/server";
 
 import { authorizeAuditApi } from "@/lib/audit-api-auth";
+import { safeErrorBody } from "@/lib/safe-error-body";
 import { reportAuditFilerFailure } from "@/pipeline/audit-filer-telemetry";
 import { prisma } from "@/lib/db";
 import {
@@ -270,37 +271,6 @@ async function persistFilingResult(
 // ── GitHub IO ────────────────────────────────────────────────────────
 
 const LOG_PREFIX = "[audit-file-finding]";
-
-/**
- * Read an upstream error response body for safe logging, capped at
- * `LOG_BODY_MAX` bytes. GitHub error responses are normally tiny JSON
- * `{message, documentation_url}` bodies, but a proxy or intermediary could
- * return a multi-megabyte HTML error page that reflects request content
- * (#1468). We stream the body and stop reading once we have enough — this
- * keeps the defensive bound on the read itself rather than post-decode
- * slicing, so a misbehaving upstream cannot pressure memory or latency
- * even before truncation (Gemini + Codex pass on PR #1482).
- */
-const LOG_BODY_MAX = 500;
-async function safeErrorBody(res: Response): Promise<string> {
-  try {
-    const reader = res.body?.getReader();
-    if (!reader) return "<empty body>";
-    const decoder = new TextDecoder("utf-8", { fatal: false });
-    let collected = "";
-    while (collected.length < LOG_BODY_MAX) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value) collected += decoder.decode(value, { stream: true });
-    }
-    void reader.cancel();
-    return collected.length > LOG_BODY_MAX
-      ? `${collected.slice(0, LOG_BODY_MAX)}…(truncated)`
-      : collected;
-  } catch {
-    return "<unreadable body>";
-  }
-}
 
 /** Standard POST init for any GitHub repos/* call. */
 function githubPostInit(token: string, body: unknown): RequestInit {

--- a/src/app/api/audit/filing-health/route.test.ts
+++ b/src/app/api/audit/filing-health/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/auth", () => ({ getAdminUser: vi.fn() }));
 vi.mock("@/lib/github-repo", () => ({
@@ -13,6 +13,14 @@ const mockedAdmin = vi.mocked(getAdminUser);
 const ORIGINAL_TOKEN = process.env.GITHUB_TOKEN;
 
 let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+const okRateLimit = (remaining = 4321) =>
+  Response.json({
+    resources: { core: { limit: 5000, remaining, reset: 9999 } },
+  });
+
+const okRepoWithPush = () =>
+  Response.json({ permissions: { admin: false, push: true, pull: true } });
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -55,27 +63,67 @@ describe("GET /api/audit/filing-health", () => {
     expect(body.message).toMatch(/Rotate GITHUB_TOKEN/);
   });
 
-  it("returns ok with remaining budget when the token works", async () => {
-    fetchSpy.mockResolvedValueOnce(
-      Response.json({
-        resources: { core: { limit: 5000, remaining: 4321, reset: 9999 } },
-      }),
-    );
+  it("returns ok with remaining budget when both probes succeed and token has push", async () => {
+    fetchSpy.mockResolvedValueOnce(okRateLimit());
+    fetchSpy.mockResolvedValueOnce(okRepoWithPush());
     const res = await GET();
     const body = await res.json();
     expect(body.status).toBe("ok");
     expect(body.remaining).toBe(4321);
     expect(body.resetAt).toBe(9999);
+    expect(body.message).toMatch(/can write to johnrclem\/hashtracks-web/);
   });
 
-  it("returns warn when remaining budget is dangerously low", async () => {
-    fetchSpy.mockResolvedValueOnce(
-      Response.json({
-        resources: { core: { limit: 5000, remaining: 12, reset: 1 } },
-      }),
-    );
+  it("returns warn when remaining budget is dangerously low but token can still write", async () => {
+    fetchSpy.mockResolvedValueOnce(okRateLimit(12));
+    fetchSpy.mockResolvedValueOnce(okRepoWithPush());
     const res = await GET();
     const body = await res.json();
     expect(body.status).toBe("warn");
+    expect(body.message).toMatch(/can write to johnrclem\/hashtracks-web/);
+  });
+
+  // Codex adversarial review on PR #1509: /rate_limit alone could green-light
+  // a token that has zero write capability on the target repo. The repo-probe
+  // closes that hole by checking `permissions.push`.
+  it("returns error when token is valid but lacks push permission on the repo", async () => {
+    fetchSpy.mockResolvedValueOnce(okRateLimit());
+    fetchSpy.mockResolvedValueOnce(
+      Response.json({ permissions: { admin: false, push: false, pull: true } }),
+    );
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe("error");
+    expect(body.message).toMatch(/lacks write access/);
+  });
+
+  it("returns error when token has admin permission instead of push", async () => {
+    fetchSpy.mockResolvedValueOnce(okRateLimit());
+    fetchSpy.mockResolvedValueOnce(
+      Response.json({ permissions: { admin: true, push: false, pull: true } }),
+    );
+    const res = await GET();
+    const body = await res.json();
+    // admin implies push at the GitHub-API contract level; we accept it.
+    expect(body.status).toBe("ok");
+  });
+
+  it("returns error with 404 hint when the repo is invisible to the token", async () => {
+    fetchSpy.mockResolvedValueOnce(okRateLimit());
+    fetchSpy.mockResolvedValueOnce(new Response("Not Found", { status: 404 }));
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe("error");
+    expect(body.message).toMatch(/cannot see repo/);
+  });
+
+  it("returns error when /repos returns 200 but no permissions block", async () => {
+    fetchSpy.mockResolvedValueOnce(okRateLimit());
+    fetchSpy.mockResolvedValueOnce(Response.json({ name: "hashtracks-web" }));
+    const res = await GET();
+    const body = await res.json();
+    // No permissions block means we can't confirm write access — fail closed.
+    expect(body.status).toBe("error");
+    expect(body.message).toMatch(/lacks write access/);
   });
 });

--- a/src/app/api/audit/filing-health/route.test.ts
+++ b/src/app/api/audit/filing-health/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ getAdminUser: vi.fn() }));
+vi.mock("@/lib/github-repo", () => ({
+  getValidatedRepo: () => "johnrclem/hashtracks-web",
+}));
+
+import { GET } from "./route";
+import { getAdminUser } from "@/lib/auth";
+
+const mockedAdmin = vi.mocked(getAdminUser);
+
+const ORIGINAL_TOKEN = process.env.GITHUB_TOKEN;
+
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+  mockedAdmin.mockResolvedValue({ id: "u1" } as never);
+  process.env.GITHUB_TOKEN = "test-token";
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+  if (ORIGINAL_TOKEN === undefined) delete process.env.GITHUB_TOKEN;
+  else process.env.GITHUB_TOKEN = ORIGINAL_TOKEN;
+});
+
+describe("GET /api/audit/filing-health", () => {
+  it("returns 403 with error payload when no admin session", async () => {
+    mockedAdmin.mockResolvedValueOnce(null);
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.status).toBe("error");
+  });
+
+  it("reports error when GITHUB_TOKEN is missing", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("error");
+    expect(body.message).toMatch(/GITHUB_TOKEN/);
+  });
+
+  it("surfaces a 401 from GitHub as a token-rotation hint", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response("Bad credentials", { status: 401 }),
+    );
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe("error");
+    expect(body.message).toMatch(/Rotate GITHUB_TOKEN/);
+  });
+
+  it("returns ok with remaining budget when the token works", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      Response.json({
+        resources: { core: { limit: 5000, remaining: 4321, reset: 9999 } },
+      }),
+    );
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.remaining).toBe(4321);
+    expect(body.resetAt).toBe(9999);
+  });
+
+  it("returns warn when remaining budget is dangerously low", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      Response.json({
+        resources: { core: { limit: 5000, remaining: 12, reset: 1 } },
+      }),
+    );
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe("warn");
+  });
+});

--- a/src/app/api/audit/filing-health/route.test.ts
+++ b/src/app/api/audit/filing-health/route.test.ts
@@ -126,4 +126,26 @@ describe("GET /api/audit/filing-health", () => {
     expect(body.status).toBe("error");
     expect(body.message).toMatch(/lacks write access/);
   });
+
+  // Regression for CodeRabbit/Gemini/Claude-bot reviews on PR #1509:
+  // a non-numeric `x-ratelimit-reset` header used to throw RangeError
+  // and silently flip the rate-limit response into a generic catch-path
+  // error. The guard must keep the actionable rate-limit message.
+  it("handles non-numeric x-ratelimit-reset header without throwing", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response("rate limited", {
+        status: 403,
+        headers: {
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": "not-a-number",
+        },
+      }),
+    );
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe("error");
+    expect(body.message).toMatch(/rate-limited/);
+    // No resets-at suffix when the header is garbage — better than throwing.
+    expect(body.message).not.toMatch(/resets at/);
+  });
 });

--- a/src/app/api/audit/filing-health/route.test.ts
+++ b/src/app/api/audit/filing-health/route.test.ts
@@ -25,7 +25,9 @@ const okRepoWithPush = () =>
 beforeEach(() => {
   vi.resetAllMocks();
   fetchSpy = vi.spyOn(globalThis, "fetch");
-  mockedAdmin.mockResolvedValue({ id: "u1" } as never);
+  // Cast-to-Awaited matches the documented codebase convention but avoids
+  // Sonar S4325 by naming the precise expected type instead of `as never`.
+  mockedAdmin.mockResolvedValue({ id: "u1" } as Awaited<ReturnType<typeof getAdminUser>>);
   process.env.GITHUB_TOKEN = "test-token";
 });
 
@@ -94,7 +96,7 @@ describe("GET /api/audit/filing-health", () => {
     const res = await GET();
     const body = await res.json();
     expect(body.status).toBe("error");
-    expect(body.message).toMatch(/lacks write access/);
+    expect(body.message).toMatch(/lacks any issue-management role/);
   });
 
   it("returns error when token has admin permission instead of push", async () => {
@@ -105,6 +107,22 @@ describe("GET /api/audit/filing-health", () => {
     const res = await GET();
     const body = await res.json();
     // admin implies push at the GitHub-API contract level; we accept it.
+    expect(body.status).toBe("ok");
+  });
+
+  // Regression for Codex P1 on PR #1509: fine-grained PATs scoped to
+  // `Issues: Read+Write` but `Contents: Read` typically report at the
+  // `triage` collaborator level. Such tokens CAN file issues — flagging
+  // them as "Filing broken" would be a persistent false alarm.
+  it("accepts triage permission (covers fine-grained PATs with Issues:Write)", async () => {
+    fetchSpy.mockResolvedValueOnce(okRateLimit());
+    fetchSpy.mockResolvedValueOnce(
+      Response.json({
+        permissions: { admin: false, push: false, triage: true, pull: true },
+      }),
+    );
+    const res = await GET();
+    const body = await res.json();
     expect(body.status).toBe("ok");
   });
 
@@ -124,7 +142,7 @@ describe("GET /api/audit/filing-health", () => {
     const body = await res.json();
     // No permissions block means we can't confirm write access — fail closed.
     expect(body.status).toBe("error");
-    expect(body.message).toMatch(/lacks write access/);
+    expect(body.message).toMatch(/lacks any issue-management role/);
   });
 
   // Regression for CodeRabbit/Gemini/Claude-bot reviews on PR #1509:

--- a/src/app/api/audit/filing-health/route.ts
+++ b/src/app/api/audit/filing-health/route.ts
@@ -1,23 +1,33 @@
 /**
  * Audit filing-health probe.
  *
- * GET-only, admin-gated. Hits GitHub's `/rate_limit` endpoint with the same
- * `GITHUB_TOKEN` the filing routes use, and reports back a small status
- * object the admin audit page renders as a chip. Exists so that an expired
- * or revoked token (the #1494 root cause) surfaces on the dashboard the
- * moment an admin loads `/admin/audit` instead of after a chrome agent
- * stalls on a 502 loop.
+ * GET-only, admin-gated. Runs two non-mutating GitHub probes with the same
+ * `GITHUB_TOKEN` the filing routes use, then renders a single status object
+ * the admin audit page surfaces as a chip:
  *
- * `/rate_limit` is the canonical "does this token work and what's its
- * remaining budget" endpoint — it does not file an issue, post a
- * comment, or otherwise mutate state, so it's safe to call on every
- * dashboard render. GitHub docs: https://docs.github.com/en/rest/rate-limit
+ *   1. `GET /rate_limit` — confirms the token is syntactically accepted and
+ *      reports remaining core-API budget. Detects the #1494 root cause
+ *      (expired token → 401) and rate-limit exhaustion (403 with
+ *      `x-ratelimit-remaining: 0`).
+ *   2. `GET /repos/{owner}/{repo}` — confirms the token has access to the
+ *      configured repo AND that its permissions include `push: true`, which
+ *      is the GitHub-side signal for "can create issues and post comments"
+ *      on a fine-grained PAT. Without this second probe, a token that's
+ *      valid but scoped to the wrong repo or downgraded to read-only would
+ *      pass `/rate_limit` and render a green chip while every actual
+ *      filing 401s — Codex adversarial review on PR #1509.
+ *
+ * Neither probe mutates state, so the endpoint is safe to call on every
+ * dashboard render. GitHub docs:
+ *   https://docs.github.com/en/rest/rate-limit
+ *   https://docs.github.com/en/rest/repos/repos#get-a-repository
  */
 import { NextResponse } from "next/server";
 import { getAdminUser } from "@/lib/auth";
 import { getValidatedRepo } from "@/lib/github-repo";
 
 const FETCH_TIMEOUT_MS = 5_000;
+const LOW_REMAINING_THRESHOLD = 100;
 
 interface RateLimitResponse {
   resources?: {
@@ -29,10 +39,21 @@ interface RateLimitResponse {
   };
 }
 
+interface RepoResponse {
+  permissions?: {
+    admin?: boolean;
+    maintain?: boolean;
+    push?: boolean;
+    triage?: boolean;
+    pull?: boolean;
+  };
+}
+
 export interface FilingHealthResult {
-  /** `ok` — token validated against /rate_limit, has remaining budget.
-   *  `warn` — token works but remaining budget is dangerously low.
-   *  `error` — token missing, rejected, or GitHub unreachable. */
+  /** `ok` — token validated, repo accessible, write capability confirmed.
+   *  `warn` — token works but remaining core-API budget is dangerously low.
+   *  `error` — token missing, rejected, lacks repo access or write capability,
+   *  or GitHub unreachable. */
   status: "ok" | "warn" | "error";
   /** Human-readable summary suitable for chip + tooltip. */
   message: string;
@@ -44,15 +65,13 @@ export interface FilingHealthResult {
   resetAt?: number;
 }
 
-const LOW_REMAINING_THRESHOLD = 100;
-
 /**
  * Surface the most common GitHub failure shapes with actionable hints
  * instead of a generic "GitHub returned N" line. The dashboard chip
  * shows the message verbatim in its tooltip, so a clear sentence here
  * saves the admin a log dive.
  */
-function errorMessageFor(res: Response, body: string): string {
+function rateLimitErrorMessageFor(res: Response, body: string): string {
   if (res.status === 401) {
     return "GitHub rejected the token (401 Bad Credentials). Rotate GITHUB_TOKEN in Vercel prod env.";
   }
@@ -62,6 +81,23 @@ function errorMessageFor(res: Response, body: string): string {
     return `Token works but is rate-limited${resetHint}. Wait for the reset window or rotate to a token with higher quota.`;
   }
   return `GitHub /rate_limit returned ${res.status}: ${body.slice(0, 200)}`;
+}
+
+function repoErrorMessageFor(res: Response, body: string, repo: string): string {
+  if (res.status === 404) {
+    return `Token cannot see repo ${repo} (404). Check the token is scoped to the right repo and has the Metadata permission.`;
+  }
+  if (res.status === 403) {
+    return `Token is forbidden from reading repo ${repo} (403). Check repo-permission scopes.`;
+  }
+  return `GitHub /repos/${repo} returned ${res.status}: ${body.slice(0, 200)}`;
+}
+
+function githubAuthHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+  };
 }
 
 export async function GET(): Promise<NextResponse<FilingHealthResult>> {
@@ -86,21 +122,19 @@ export async function GET(): Promise<NextResponse<FilingHealthResult>> {
     );
   }
 
+  // Probe 1: /rate_limit — token liveness + budget
+  let rateLimit: { remaining: number; limit: number; reset: number };
   try {
     const url = new URL("/rate_limit", "https://api.github.com");
     const res = await fetch(url, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-      },
+      headers: githubAuthHeaders(token),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      const message = errorMessageFor(res, body);
       return NextResponse.json(
-        { status: "error", message, repo },
+        { status: "error", message: rateLimitErrorMessageFor(res, body), repo },
         { status: 200 },
       );
     }
@@ -116,21 +150,7 @@ export async function GET(): Promise<NextResponse<FilingHealthResult>> {
         { status: 200 },
       );
     }
-    const status = core.remaining < LOW_REMAINING_THRESHOLD ? "warn" : "ok";
-    const message =
-      status === "warn"
-        ? `Token works but only ${core.remaining}/${core.limit} core calls remain until reset.`
-        : `Token works. ${core.remaining}/${core.limit} core calls remain.`;
-    return NextResponse.json(
-      {
-        status,
-        message,
-        repo,
-        remaining: core.remaining,
-        resetAt: core.reset,
-      },
-      { status: 200 },
-    );
+    rateLimit = core;
   } catch (err) {
     return NextResponse.json(
       {
@@ -141,4 +161,73 @@ export async function GET(): Promise<NextResponse<FilingHealthResult>> {
       { status: 200 },
     );
   }
+
+  // Probe 2: /repos/{repo} — repo access + write-capability check
+  try {
+    const url = new URL(`/repos/${repo}`, "https://api.github.com");
+    const res = await fetch(url, {
+      method: "GET",
+      headers: githubAuthHeaders(token),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return NextResponse.json(
+        {
+          status: "error",
+          message: repoErrorMessageFor(res, body, repo),
+          repo,
+          remaining: rateLimit.remaining,
+          resetAt: rateLimit.reset,
+        },
+        { status: 200 },
+      );
+    }
+    const json = (await res.json()) as RepoResponse;
+    // `permissions.push: true` means the calling token can write to the
+    // repo, which covers issue creation and comments. `admin`/`maintain`
+    // imply push. Read-only tokens (`pull`-only) explicitly fail here so
+    // we don't ship a green chip while filings 401 silently.
+    const perms = json.permissions ?? {};
+    const canWrite = perms.push === true || perms.maintain === true || perms.admin === true;
+    if (!canWrite) {
+      return NextResponse.json(
+        {
+          status: "error",
+          message: `Token can read ${repo} but lacks write access (permissions.push !== true). Rotate to a token with Issues: Read+Write on the repo.`,
+          repo,
+          remaining: rateLimit.remaining,
+          resetAt: rateLimit.reset,
+        },
+        { status: 200 },
+      );
+    }
+  } catch (err) {
+    return NextResponse.json(
+      {
+        status: "error",
+        message: `Could not reach GitHub /repos/${repo}: ${err instanceof Error ? err.message : String(err)}`,
+        repo,
+        remaining: rateLimit.remaining,
+        resetAt: rateLimit.reset,
+      },
+      { status: 200 },
+    );
+  }
+
+  const status = rateLimit.remaining < LOW_REMAINING_THRESHOLD ? "warn" : "ok";
+  const message =
+    status === "warn"
+      ? `Token works and can write to ${repo}, but only ${rateLimit.remaining}/${rateLimit.limit} core calls remain until reset.`
+      : `Token works and can write to ${repo}. ${rateLimit.remaining}/${rateLimit.limit} core calls remain.`;
+  return NextResponse.json(
+    {
+      status,
+      message,
+      repo,
+      remaining: rateLimit.remaining,
+      resetAt: rateLimit.reset,
+    },
+    { status: 200 },
+  );
 }

--- a/src/app/api/audit/filing-health/route.ts
+++ b/src/app/api/audit/filing-health/route.ts
@@ -25,6 +25,7 @@
 import { NextResponse } from "next/server";
 import { getAdminUser } from "@/lib/auth";
 import { getValidatedRepo } from "@/lib/github-repo";
+import { safeErrorBody } from "@/lib/safe-error-body";
 
 const FETCH_TIMEOUT_MS = 5_000;
 const LOW_REMAINING_THRESHOLD = 100;
@@ -76,8 +77,15 @@ function rateLimitErrorMessageFor(res: Response, body: string): string {
     return "GitHub rejected the token (401 Bad Credentials). Rotate GITHUB_TOKEN in Vercel prod env.";
   }
   if (res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0") {
+    // Guard: a misbehaving GitHub proxy or future format change could ship a
+    // non-numeric `x-ratelimit-reset` header; `new Date(NaN).toISOString()`
+    // throws RangeError and converts a 403 rate-limit response into a
+    // generic catch-path error — exactly the diagnostic we lose.
     const reset = res.headers.get("x-ratelimit-reset");
-    const resetHint = reset ? ` (resets at ${new Date(Number(reset) * 1000).toISOString()})` : "";
+    const resetEpoch = reset ? Number(reset) : Number.NaN;
+    const resetHint = Number.isFinite(resetEpoch)
+      ? ` (resets at ${new Date(resetEpoch * 1000).toISOString()})`
+      : "";
     return `Token works but is rate-limited${resetHint}. Wait for the reset window or rotate to a token with higher quota.`;
   }
   return `GitHub /rate_limit returned ${res.status}: ${body.slice(0, 200)}`;
@@ -132,7 +140,7 @@ export async function GET(): Promise<NextResponse<FilingHealthResult>> {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
-      const body = await res.text().catch(() => "");
+      const body = await safeErrorBody(res);
       return NextResponse.json(
         { status: "error", message: rateLimitErrorMessageFor(res, body), repo },
         { status: 200 },
@@ -171,7 +179,7 @@ export async function GET(): Promise<NextResponse<FilingHealthResult>> {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
-      const body = await res.text().catch(() => "");
+      const body = await safeErrorBody(res);
       return NextResponse.json(
         {
           status: "error",

--- a/src/app/api/audit/filing-health/route.ts
+++ b/src/app/api/audit/filing-health/route.ts
@@ -192,17 +192,31 @@ export async function GET(): Promise<NextResponse<FilingHealthResult>> {
       );
     }
     const json = (await res.json()) as RepoResponse;
-    // `permissions.push: true` means the calling token can write to the
-    // repo, which covers issue creation and comments. `admin`/`maintain`
-    // imply push. Read-only tokens (`pull`-only) explicitly fail here so
-    // we don't ship a green chip while filings 401 silently.
+    // The `permissions` block on `/repos/{repo}` reflects the calling
+    // identity's repo-collaborator role. We accept any role that grants
+    // issue-management capability for our purposes:
+    //   - `admin` / `maintain` / `push` — write-class roles (classic PATs
+    //     with `repo`/`public_repo` and the repo owner identity all fall here)
+    //   - `triage` — explicitly grants issue / PR management without code
+    //     push. Fine-grained PATs scoped to `Issues: Read+Write` but
+    //     `Contents: Read` typically report at this level, and they CAN
+    //     file issues — flagging them red would be a false positive
+    //     (Codex P1 on PR #1509).
+    //
+    // Pure `pull` (read-only collaborator) or no permissions block at
+    // all falls through to the error branch — we can't confirm write
+    // capability without a mutating probe, so fail closed.
     const perms = json.permissions ?? {};
-    const canWrite = perms.push === true || perms.maintain === true || perms.admin === true;
+    const canWrite =
+      perms.admin === true ||
+      perms.maintain === true ||
+      perms.push === true ||
+      perms.triage === true;
     if (!canWrite) {
       return NextResponse.json(
         {
           status: "error",
-          message: `Token can read ${repo} but lacks write access (permissions.push !== true). Rotate to a token with Issues: Read+Write on the repo.`,
+          message: `Token can read ${repo} but lacks any issue-management role (admin/maintain/push/triage). Rotate to a token with Issues: Read+Write on the repo.`,
           repo,
           remaining: rateLimit.remaining,
           resetAt: rateLimit.reset,

--- a/src/app/api/audit/filing-health/route.ts
+++ b/src/app/api/audit/filing-health/route.ts
@@ -1,0 +1,144 @@
+/**
+ * Audit filing-health probe.
+ *
+ * GET-only, admin-gated. Hits GitHub's `/rate_limit` endpoint with the same
+ * `GITHUB_TOKEN` the filing routes use, and reports back a small status
+ * object the admin audit page renders as a chip. Exists so that an expired
+ * or revoked token (the #1494 root cause) surfaces on the dashboard the
+ * moment an admin loads `/admin/audit` instead of after a chrome agent
+ * stalls on a 502 loop.
+ *
+ * `/rate_limit` is the canonical "does this token work and what's its
+ * remaining budget" endpoint — it does not file an issue, post a
+ * comment, or otherwise mutate state, so it's safe to call on every
+ * dashboard render. GitHub docs: https://docs.github.com/en/rest/rate-limit
+ */
+import { NextResponse } from "next/server";
+import { getAdminUser } from "@/lib/auth";
+import { getValidatedRepo } from "@/lib/github-repo";
+
+const FETCH_TIMEOUT_MS = 5_000;
+
+interface RateLimitResponse {
+  resources?: {
+    core?: {
+      limit: number;
+      remaining: number;
+      reset: number;
+    };
+  };
+}
+
+export interface FilingHealthResult {
+  /** `ok` — token validated against /rate_limit, has remaining budget.
+   *  `warn` — token works but remaining budget is dangerously low.
+   *  `error` — token missing, rejected, or GitHub unreachable. */
+  status: "ok" | "warn" | "error";
+  /** Human-readable summary suitable for chip + tooltip. */
+  message: string;
+  /** Repo the filing endpoints will target. */
+  repo: string;
+  /** Remaining core-API budget reported by GitHub, when available. */
+  remaining?: number;
+  /** Unix-seconds reset time reported by GitHub, when available. */
+  resetAt?: number;
+}
+
+const LOW_REMAINING_THRESHOLD = 100;
+
+/**
+ * Surface the most common GitHub failure shapes with actionable hints
+ * instead of a generic "GitHub returned N" line. The dashboard chip
+ * shows the message verbatim in its tooltip, so a clear sentence here
+ * saves the admin a log dive.
+ */
+function errorMessageFor(res: Response, body: string): string {
+  if (res.status === 401) {
+    return "GitHub rejected the token (401 Bad Credentials). Rotate GITHUB_TOKEN in Vercel prod env.";
+  }
+  if (res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0") {
+    const reset = res.headers.get("x-ratelimit-reset");
+    const resetHint = reset ? ` (resets at ${new Date(Number(reset) * 1000).toISOString()})` : "";
+    return `Token works but is rate-limited${resetHint}. Wait for the reset window or rotate to a token with higher quota.`;
+  }
+  return `GitHub /rate_limit returned ${res.status}: ${body.slice(0, 200)}`;
+}
+
+export async function GET(): Promise<NextResponse<FilingHealthResult>> {
+  const admin = await getAdminUser();
+  if (!admin) {
+    return NextResponse.json(
+      { status: "error", message: "Not authorized", repo: "" },
+      { status: 403 },
+    );
+  }
+
+  const repo = getValidatedRepo();
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return NextResponse.json(
+      {
+        status: "error",
+        message: "GITHUB_TOKEN is not set on this deployment",
+        repo,
+      },
+      { status: 200 },
+    );
+  }
+
+  try {
+    const url = new URL("/rate_limit", "https://api.github.com");
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      const message = errorMessageFor(res, body);
+      return NextResponse.json(
+        { status: "error", message, repo },
+        { status: 200 },
+      );
+    }
+    const json = (await res.json()) as RateLimitResponse;
+    const core = json.resources?.core;
+    if (!core) {
+      return NextResponse.json(
+        {
+          status: "error",
+          message: "GitHub /rate_limit returned a payload with no core block",
+          repo,
+        },
+        { status: 200 },
+      );
+    }
+    const status = core.remaining < LOW_REMAINING_THRESHOLD ? "warn" : "ok";
+    const message =
+      status === "warn"
+        ? `Token works but only ${core.remaining}/${core.limit} core calls remain until reset.`
+        : `Token works. ${core.remaining}/${core.limit} core calls remain.`;
+    return NextResponse.json(
+      {
+        status,
+        message,
+        repo,
+        remaining: core.remaining,
+        resetAt: core.reset,
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    return NextResponse.json(
+      {
+        status: "error",
+        message: `Could not reach GitHub /rate_limit: ${err instanceof Error ? err.message : String(err)}`,
+        repo,
+      },
+      { status: 200 },
+    );
+  }
+}

--- a/src/components/admin/AuditDashboard.tsx
+++ b/src/components/admin/AuditDashboard.tsx
@@ -12,6 +12,9 @@ import {
   Telescope,
   Copy,
   Check,
+  CircleAlert,
+  CircleCheck,
+  CircleHelp,
 } from "lucide-react";
 import {
   LineChart,
@@ -83,6 +86,7 @@ interface KennelOption {
   shortName: string;
 }
 
+import type { FilingHealthResult } from "@/app/api/audit/filing-health/route";
 import type {
   MintedQueueToken,
   MintedQueueTokens,
@@ -188,7 +192,10 @@ export function AuditDashboard({
             title="Data Quality Audit"
             color="bg-blue-500/10 text-blue-500"
           />
-          {harelinePrompt && <CopyHarelinePromptButton prompt={harelinePrompt} />}
+          <div className="flex items-center gap-2">
+            <FilingHealthChip />
+            {harelinePrompt && <CopyHarelinePromptButton prompt={harelinePrompt} />}
+          </div>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -730,6 +737,98 @@ function SuppressionDialog({
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+// ── Filing-Health Chip ──────────────────────────────────────────────
+
+type FilingHealthStatus = FilingHealthResult["status"] | "loading";
+
+interface FilingHealthState {
+  status: FilingHealthStatus;
+  message: string;
+}
+
+const FILING_HEALTH_STYLES: Record<
+  FilingHealthStatus,
+  { palette: string; Icon: typeof CircleCheck; label: string }
+> = {
+  ok: {
+    palette: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    Icon: CircleCheck,
+    label: "Filing OK",
+  },
+  warn: {
+    palette: "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    Icon: CircleAlert,
+    label: "Filing low budget",
+  },
+  error: {
+    palette: "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
+    Icon: CircleAlert,
+    label: "Filing broken",
+  },
+  loading: {
+    palette: "border-border bg-muted text-muted-foreground",
+    Icon: CircleHelp,
+    label: "Filing…",
+  },
+};
+
+/**
+ * Probes `/api/audit/filing-health` on mount and renders a colored chip
+ * summarizing whether the GitHub filing token is still valid. Exists so
+ * that an expired/revoked `GITHUB_TOKEN` (the #1494 outage root cause)
+ * surfaces the moment an admin loads the audit dashboard — without it,
+ * chrome agents are the first to discover the failure when they hit 502
+ * on a fresh nonce.
+ */
+function FilingHealthChip() {
+  const [state, setState] = useState<FilingHealthState>({
+    status: "loading",
+    message: "Checking GitHub token…",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/audit/filing-health")
+      .then(async (res) => {
+        const body = (await res.json().catch(() => null)) as Partial<FilingHealthResult> | null;
+        if (cancelled) return;
+        if (!body || typeof body.status === "undefined") {
+          setState({
+            status: "error",
+            message: `Health probe failed (${res.status})`,
+          });
+          return;
+        }
+        setState({
+          status: body.status,
+          message: body.message ?? "no message",
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          status: "error",
+          message:
+            err instanceof Error ? err.message : "Health probe network error",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const { palette, Icon, label } = FILING_HEALTH_STYLES[state.status];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium ${palette}`}
+      title={state.message}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {label}
+    </span>
   );
 }
 

--- a/src/components/admin/AuditDashboard.tsx
+++ b/src/components/admin/AuditDashboard.tsx
@@ -749,6 +749,12 @@ interface FilingHealthState {
   message: string;
 }
 
+function isFilingHealthApiStatus(
+  value: unknown,
+): value is FilingHealthResult["status"] {
+  return value === "ok" || value === "warn" || value === "error";
+}
+
 const FILING_HEALTH_STYLES: Record<
   FilingHealthStatus,
   { palette: string; Icon: typeof CircleCheck; label: string }
@@ -795,10 +801,13 @@ function FilingHealthChip() {
       .then(async (res) => {
         const body = (await res.json().catch(() => null)) as Partial<FilingHealthResult> | null;
         if (cancelled) return;
-        if (!body || typeof body.status === "undefined") {
+        if (!body || !isFilingHealthApiStatus(body.status)) {
+          // Fail closed on an unrecognized status string so the chip
+          // render's `FILING_HEALTH_STYLES[state.status]` lookup can
+          // never index off the end of the map.
           setState({
             status: "error",
-            message: `Health probe failed (${res.status})`,
+            message: `Health probe returned unexpected payload (HTTP ${res.status})`,
           });
           return;
         }

--- a/src/lib/admin/audit-prompt-shared.test.ts
+++ b/src/lib/admin/audit-prompt-shared.test.ts
@@ -1,0 +1,46 @@
+import { renderFilingInstructions } from "./audit-prompt-shared";
+
+const HARELINE = renderFilingInstructions({
+  stream: "chrome-event",
+  kennelLabel: "{KENNEL_CODE}",
+});
+const DEEP_DIVE = renderFilingInstructions({
+  stream: "chrome-kennel",
+  kennelLabel: "hockessin",
+});
+
+type ContainsCase = readonly [label: string, expected: readonly string[]];
+
+// prettier-ignore
+const CONTAINS_CASES: readonly ContainsCase[] = [
+  // 502 escalation language must be unambiguous — the chrome agent had been
+  // looping indefinitely on persistent server-side outages (issue #1494).
+  ["502 retry cap with explicit Option-2 escalation language", ["502", "Retry the same nonce exactly once", "switch to Option 2"]],
+  // The URL-prefill flow is the auto-fallback for chrome-only sessions where
+  // no admin is in the loop, so it must come BEFORE the paste-to-admin option.
+  ["Option 2 is the URL-prefill flow, not paste-to-admin", ["Option 2 (automatic fallback when Option 1 errors): GitHub URL prefill"]],
+  ["Option 3 is the manual paste-to-admin fallback", ["Option 3 (manual fallback", "an admin will pick it up"]],
+  // The prefill URL must carry the stream + kennel labels so the bridging tier
+  // can reattach the filing to the dedup graph on the next sync round.
+  ["URL prefill template includes stream + kennel labels", ["labels=audit,alert,audit:chrome-event,kennel:{KENNEL_CODE}"]],
+];
+
+describe("renderFilingInstructions — hareline (chrome-event)", () => {
+  it.each(CONTAINS_CASES)("contains %s", (_label, expected) => {
+    for (const substring of expected) {
+      expect(HARELINE).toContain(substring);
+    }
+  });
+});
+
+describe("renderFilingInstructions — deep-dive (chrome-kennel)", () => {
+  it("substitutes the resolved kennelLabel into the URL prefill template", () => {
+    expect(DEEP_DIVE).toContain(
+      "labels=audit,alert,audit:chrome-kennel,kennel:hockessin",
+    );
+  });
+
+  it("retains the 502 retry cap across both streams", () => {
+    expect(DEEP_DIVE).toContain("Retry the same nonce exactly once");
+  });
+});

--- a/src/lib/admin/audit-prompt-shared.test.ts
+++ b/src/lib/admin/audit-prompt-shared.test.ts
@@ -1,4 +1,5 @@
 import { renderFilingInstructions } from "./audit-prompt-shared";
+import { extractRuleSlugFromChromeTitle } from "@/pipeline/audit-issue-sync";
 
 const HARELINE = renderFilingInstructions({
   stream: "chrome-event",
@@ -30,6 +31,26 @@ describe("renderFilingInstructions — hareline (chrome-event)", () => {
     for (const substring of expected) {
       expect(HARELINE).toContain(substring);
     }
+  });
+});
+
+describe("renderFilingInstructions — fallback title contract", () => {
+  // Regression for the Codex adversarial review on PR #1509: an
+  // earlier version recommended `[Audit] <Kennel> — <ruleSlug>:
+  // <summary>` for the URL-prefill fallback, which silently failed
+  // `extractRuleSlugFromChromeTitle` and broke the bridging promise.
+  // The recommended title shape MUST round-trip through the actual
+  // production extractor so URL-filed issues bridge into the dedup
+  // graph on the next sync round.
+  it("recommended Option 2 title shape parses through extractRuleSlugFromChromeTitle", () => {
+    const sampleTitle = "Finding: NYCH3 hares column missing for #2143 hares-theme-leak";
+    expect(extractRuleSlugFromChromeTitle(sampleTitle)).toBe("hares-theme-leak");
+  });
+
+  it("hareline prompt names the extractor + the exact required shape", () => {
+    expect(HARELINE).toContain("extractRuleSlugFromChromeTitle");
+    expect(HARELINE).toContain("Finding: <KENNEL_SHORTNAME>");
+    expect(HARELINE).toContain("trailing token MUST be the rule slug");
   });
 });
 

--- a/src/lib/admin/audit-prompt-shared.ts
+++ b/src/lib/admin/audit-prompt-shared.ts
@@ -117,7 +117,13 @@ Use this whenever Option 1 returns 502 twice in a row, or any non-401 error you 
 https://github.com/${HASHTRACKS_REPO}/issues/new?labels=audit,alert,audit:${input.stream},kennel:${input.kennelLabel}&title={URL-ENCODED TITLE}&body={URL-ENCODED BODY}
 \`\`\`
 
-The next sync round's bridging tier (5c-A) detects URL-filed audit issues by the matching kennel + ruleSlug bracket in the title and back-links them to the dedup graph, so you don't fork duplicates. Use the same title format the API flow would have used: \`[Audit] <Kennel> — <ruleSlug>: <short summary>\`.
+The next sync round's bridging tier (5c-A) detects URL-filed audit issues by parsing the rule slug out of the title. **Use this exact title shape so the bridge fires:**
+
+\`\`\`text
+Finding: <KENNEL_SHORTNAME> <short prose summary> <rule-slug>
+\`\`\`
+
+The trailing token MUST be the rule slug (lowercase, hyphenated, e.g. \`hares-theme-leak\`, \`title-raw-kennel-code\`). Anything goes between, but \`Finding:\` must be the prefix and the slug must be the last whitespace-delimited token — see \`extractRuleSlugFromChromeTitle\` in \`src/pipeline/audit-issue-sync.ts\`. Get this wrong and your URL-filed issue will not back-link to the dedup graph; later filings for the same finding will fork duplicates and lose recurrence history.
 
 **Option 3 (manual fallback when no browser path lands the issue): paste the finding for an admin to file**
 

--- a/src/lib/admin/audit-prompt-shared.ts
+++ b/src/lib/admin/audit-prompt-shared.ts
@@ -104,14 +104,24 @@ Response: \`{ "nonce": "<base64url>" }\` (5-minute TTL, single-use).
 Response shapes:
 - \`{ "action": "created", "issueNumber": N, "issueHtmlUrl": "..." }\` — fresh issue filed.
 - \`{ "action": "recurred", "tier": "strict" | "bridging" | "coarse", "existingIssueNumber": N, "existingIssueHtmlUrl": "...", "recurrenceCount": N }\` — same finding already had an open issue; we commented "still recurring" instead of forking. **Don't refile.** (\`coarse\` is the dedup path for non-fingerprintable rules — see #964.)
-- \`{ "error": "...", "existingIssueNumber"?: N }\` (502) — GitHub side effect failed; safe to retry the same nonce.
+- \`{ "error": "...", "existingIssueNumber"?: N }\` (502) — GitHub side effect failed. **Retry the same nonce exactly once.** If the second attempt also returns 502, do not loop — the server-side filer is degraded (typically an expired GITHUB_TOKEN or rate-limit exhaustion). **Stop the API flow and switch to Option 2 (URL prefill)** so the finding still lands as a GitHub issue. The next daily sync round's bridging tier will auto-link the URL-filed issue back to the dedup graph. Never repeat-loop the API past two attempts — silent retry storms make the outage harder to diagnose.
 - \`{ "error": "Nonce invalid, expired, or payload tampered" }\` (401) — nonce mismatch; mint a fresh one and retry.
 
 The labels (\`audit\`, \`alert\`, \`audit:${input.stream}\`, \`kennel:${input.kennelLabel}\`) are applied server-side; you don't set them yourself.
 
-**Option 2 (fallback): paste the finding for an admin to file manually**
+**Option 2 (automatic fallback when Option 1 errors): GitHub URL prefill**
 
-Use this only if the API call fails after a fresh nonce. Output the finding in this format:
+Use this whenever Option 1 returns 502 twice in a row, or any non-401 error you can't recover from. Navigate to a prefilled new-issue URL — this always works as long as github.com itself is up. Both \`title\` and \`body\` MUST be URL-encoded with \`encodeURIComponent\` — raw newlines, \`&\`, or \`#\` will break the query string.
+
+\`\`\`text
+https://github.com/${HASHTRACKS_REPO}/issues/new?labels=audit,alert,audit:${input.stream},kennel:${input.kennelLabel}&title={URL-ENCODED TITLE}&body={URL-ENCODED BODY}
+\`\`\`
+
+The next sync round's bridging tier (5c-A) detects URL-filed audit issues by the matching kennel + ruleSlug bracket in the title and back-links them to the dedup graph, so you don't fork duplicates. Use the same title format the API flow would have used: \`[Audit] <Kennel> — <ruleSlug>: <short summary>\`.
+
+**Option 3 (manual fallback when no browser path lands the issue): paste the finding for an admin to file**
+
+Last-resort path when both Option 1 and Option 2 fail (e.g. GitHub itself is down, or you're sandboxed with no nav permission). Output the finding in this format and stop — an admin will pick it up:
 
 ### [Kennel] — [Issue Category]
 * **HashTracks Event URL:** [link]
@@ -120,9 +130,5 @@ Use this only if the API call fails after a fresh nonce. Output the finding in t
 * **Field(s) Affected:** [field name]
 * **Current Extracted Value:** "[exact text from the HashTracks page, verbatim]"
 * **Expected Value:** "[verbatim text from the source — **not** a synthesized cleanup or inference. If the source says "2FC Takes Fenton", that's the expected value; don't 'clean it up' to "2FC" unless the source literally shows that string somewhere.]"
-* **Fix Hypothesis:** [brief guess on root cause]
-
-**Option 3 (legacy fallback): GitHub URL flow**
-
-Old prompts used to direct agents to a prefilled \`https://github.com/${HASHTRACKS_REPO}/issues/new?...\` URL. That path is still supported and will be detected by the bridging tier on the next sync round, but **prefer Option 1** so cross-stream coalescing fires immediately and you don't fork a duplicate.`;
+* **Fix Hypothesis:** [brief guess on root cause]`;
 }

--- a/src/lib/safe-error-body.test.ts
+++ b/src/lib/safe-error-body.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { safeErrorBody } from "./safe-error-body";
+
+describe("safeErrorBody", () => {
+  it("returns the full body when it's under the cap", async () => {
+    const res = new Response("oops");
+    expect(await safeErrorBody(res)).toBe("oops");
+  });
+
+  it("truncates with marker when the body exceeds the cap", async () => {
+    const big = "x".repeat(2_000);
+    const res = new Response(big);
+    const out = await safeErrorBody(res, 100);
+    expect(out.length).toBeLessThanOrEqual(120);
+    expect(out.endsWith("…(truncated)")).toBe(true);
+  });
+
+  it("returns <empty body> when the response has no readable stream", async () => {
+    const res = new Response(null);
+    expect(await safeErrorBody(res)).toBe("<empty body>");
+  });
+});

--- a/src/lib/safe-error-body.ts
+++ b/src/lib/safe-error-body.ts
@@ -1,0 +1,39 @@
+/**
+ * Bounded reader for upstream error response bodies.
+ *
+ * GitHub error responses are normally tiny JSON `{message, documentation_url}`
+ * blobs, but a proxy or intermediary can return a multi-megabyte HTML error
+ * page that reflects request content (#1468). We stream the body and stop
+ * reading once we have enough bytes — this keeps the defensive bound on the
+ * read itself rather than post-decode slicing, so a misbehaving upstream
+ * cannot pressure memory or latency even before truncation. Used by every
+ * audit-filer / health-probe / auto-issue site that logs an upstream error
+ * body to console or Sentry — keeping the cap consistent here prevents the
+ * next defensive review (or runtime OOM) from pointing at one site that
+ * forgot the bound.
+ */
+
+const DEFAULT_LIMIT = 500;
+
+export async function safeErrorBody(
+  res: Response,
+  limit: number = DEFAULT_LIMIT,
+): Promise<string> {
+  try {
+    const reader = res.body?.getReader();
+    if (!reader) return "<empty body>";
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    let collected = "";
+    while (collected.length < limit) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) collected += decoder.decode(value, { stream: true });
+    }
+    void reader.cancel();
+    return collected.length > limit
+      ? `${collected.slice(0, limit)}…(truncated)`
+      : collected;
+  } catch {
+    return "<unreadable body>";
+  }
+}

--- a/src/pipeline/audit-filer-telemetry.test.ts
+++ b/src/pipeline/audit-filer-telemetry.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
+import { reportAuditFilerFailure } from "./audit-filer-telemetry";
+
+const captureMessage = vi.mocked(Sentry.captureMessage);
+
+beforeEach(() => {
+  captureMessage.mockClear();
+});
+
+// The dedup map is module-scoped (intentional — production reuses it across
+// requests within a serverless instance). To keep tests independent without
+// reaching into module internals, each test below uses a status code that no
+// other test reuses, so suppressions can't bleed across tests.
+describe("reportAuditFilerFailure dedup", () => {
+  it("captures the first failure and suppresses an identical repeat within the window", () => {
+    reportAuditFilerFailure("chrome", "createIssue", { githubStatus: 500 });
+    reportAuditFilerFailure("chrome", "createIssue", { githubStatus: 500 });
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: pre-fix, both `{ error: "GITHUB_TOKEN not set" }` and
+  // `{ error: new TypeError(...) }` collapsed to one `:noerr` bucket and
+  // suppressed each other for 60s — defeating the dedup's whole point of
+  // distinguishing auth-vs-connectivity outages.
+  it("does NOT suppress a different failure mode in the same (origin,stage) bucket", () => {
+    reportAuditFilerFailure("cron", "createIssue", { error: "GITHUB_TOKEN not set" });
+    reportAuditFilerFailure("cron", "createIssue", { error: new TypeError("fetch failed") });
+    expect(captureMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("distinguishes failure modes across stages", () => {
+    reportAuditFilerFailure("cron", "createIssue", { githubStatus: 502 });
+    reportAuditFilerFailure("cron", "postComment", { githubStatus: 502 });
+    expect(captureMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("distinguishes failure modes across origins", () => {
+    reportAuditFilerFailure("chrome", "createIssue", { githubStatus: 503 });
+    reportAuditFilerFailure("cron", "createIssue", { githubStatus: 503 });
+    expect(captureMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("tags the event with origin / stage / github_status", () => {
+    reportAuditFilerFailure("chrome", "postComment", {
+      githubStatus: 422,
+      issueNumber: 7,
+    });
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("postComment"),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          audit_filer: "chrome",
+          stage: "postComment",
+          github_status: "422",
+        }),
+      }),
+    );
+  });
+});

--- a/src/pipeline/audit-filer-telemetry.ts
+++ b/src/pipeline/audit-filer-telemetry.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared Sentry capture for audit-filer GitHub failures.
+ *
+ * Both filing paths — chrome (`src/app/api/audit/file-finding/route.ts`)
+ * and cron (`src/pipeline/audit-issue.ts`) — call this when a GitHub
+ * createIssue/postComment side effect fails. Tagged so Sentry-side rules
+ * can alert on filer outages without burying us in unrelated chatter —
+ * issue #1494 (expired GITHUB_TOKEN) silently broke filing for days
+ * before anyone noticed.
+ *
+ * A degraded token can fan out: cron loops over groups, chrome agents
+ * POST in bursts. The in-memory dedup window collapses identical
+ * `(origin, stage, githubStatus)` failures within DEDUP_WINDOW_MS to a
+ * single Sentry event, so a token outage produces one alert per failure
+ * mode per origin instead of dozens per minute. The first failure of
+ * each kind is always reported; Sentry's server-side issue grouping
+ * handles cross-instance duplication.
+ */
+import * as Sentry from "@sentry/nextjs";
+
+export type FilerOrigin = "chrome" | "cron";
+export type FilerStage = "createIssue" | "postComment";
+
+export interface FilerFailureDetail {
+  githubStatus?: number;
+  body?: string;
+  error?: unknown;
+  issueNumber?: number;
+}
+
+const DEDUP_WINDOW_MS = 60_000;
+const recentlyReported = new Map<string, number>();
+
+function shouldReport(origin: FilerOrigin, stage: FilerStage, status?: number): boolean {
+  const key = `${origin}:${stage}:${status ?? "noerr"}`;
+  const now = Date.now();
+  const last = recentlyReported.get(key);
+  if (last !== undefined && now - last < DEDUP_WINDOW_MS) return false;
+  recentlyReported.set(key, now);
+  return true;
+}
+
+export function reportAuditFilerFailure(
+  origin: FilerOrigin,
+  stage: FilerStage,
+  detail: FilerFailureDetail,
+): void {
+  if (!shouldReport(origin, stage, detail.githubStatus)) return;
+  Sentry.captureMessage(`audit-filer/${origin} ${stage} failed`, {
+    level: "error",
+    tags: {
+      audit_filer: origin,
+      stage,
+      github_status: detail.githubStatus?.toString() ?? "n/a",
+    },
+    extra: { ...detail },
+  });
+}

--- a/src/pipeline/audit-filer-telemetry.ts
+++ b/src/pipeline/audit-filer-telemetry.ts
@@ -31,8 +31,27 @@ export interface FilerFailureDetail {
 const DEDUP_WINDOW_MS = 60_000;
 const recentlyReported = new Map<string, number>();
 
-function shouldReport(origin: FilerOrigin, stage: FilerStage, status?: number): boolean {
-  const key = `${origin}:${stage}:${status ?? "noerr"}`;
+/**
+ * Build a discriminator that distinguishes the failure modes a single
+ * `(origin, stage)` pair can experience. Without this, `githubStatus`
+ * being absent collapses every non-HTTP failure into one bucket — a
+ * missing-token alert can be suppressed for 60s by an earlier
+ * fetch-throw, or vice versa — defeating the dedup's whole point of
+ * letting operators see "what changed".
+ */
+function failureDiscriminator(detail: FilerFailureDetail): string {
+  if (detail.githubStatus !== undefined) return `status:${detail.githubStatus}`;
+  if (detail.error instanceof Error) return `error:${detail.error.name}`;
+  if (typeof detail.error === "string") return `error:${detail.error}`;
+  return "noerr";
+}
+
+function shouldReport(
+  origin: FilerOrigin,
+  stage: FilerStage,
+  detail: FilerFailureDetail,
+): boolean {
+  const key = `${origin}:${stage}:${failureDiscriminator(detail)}`;
   const now = Date.now();
   const last = recentlyReported.get(key);
   if (last !== undefined && now - last < DEDUP_WINDOW_MS) return false;
@@ -45,7 +64,7 @@ export function reportAuditFilerFailure(
   stage: FilerStage,
   detail: FilerFailureDetail,
 ): void {
-  if (!shouldReport(origin, stage, detail.githubStatus)) return;
+  if (!shouldReport(origin, stage, detail)) return;
   Sentry.captureMessage(`audit-filer/${origin} ${stage} failed`, {
     level: "error",
     tags: {

--- a/src/pipeline/audit-issue.ts
+++ b/src/pipeline/audit-issue.ts
@@ -19,6 +19,7 @@
  */
 import type { AuditGroup } from "./audit-runner";
 import { formatGroupIssueTitle, formatGroupIssueBody } from "./audit-format";
+import { reportAuditFilerFailure } from "./audit-filer-telemetry";
 import {
   AUDIT_LABEL,
   ALERT_LABEL,
@@ -78,7 +79,10 @@ function buildCronActions(): FilerActions {
   return {
     createIssue: async ({ title, body, labels }) => {
       const token = process.env.GITHUB_TOKEN;
-      if (!token) return null;
+      if (!token) {
+        reportAuditFilerFailure("cron", "createIssue", { error: "GITHUB_TOKEN not set" });
+        return null;
+      }
       const repo = getValidatedRepo();
       try {
         // SSRF-safe: URL constructor anchors the request to the
@@ -86,7 +90,12 @@ function buildCronActions(): FilerActions {
         const url = new URL(`/repos/${repo}/issues`, "https://api.github.com");
         const res = await fetch(url, githubPostInit(token, { title, body, labels }));
         if (!res.ok) {
-          console.error(`[audit-issue] GitHub API ${res.status}: ${await res.text()}`);
+          const errBody = await res.text();
+          console.error(`[audit-issue] GitHub API ${res.status}: ${errBody}`);
+          reportAuditFilerFailure("cron", "createIssue", {
+            githubStatus: res.status,
+            body: errBody,
+          });
           return null;
         }
         // Local name carries "Html" so the xss/no-mixed-html rule
@@ -100,12 +109,19 @@ function buildCronActions(): FilerActions {
         return { htmlUrl: issueHtml.html_url, number: issueHtml.number };
       } catch (err) {
         console.error("[audit-issue] Failed to create GitHub issue:", err);
+        reportAuditFilerFailure("cron", "createIssue", { error: err });
         return null;
       }
     },
     postComment: async (issueNumber, body) => {
       const token = process.env.GITHUB_TOKEN;
-      if (!token) return false;
+      if (!token) {
+        reportAuditFilerFailure("cron", "postComment", {
+          error: "GITHUB_TOKEN not set",
+          issueNumber,
+        });
+        return false;
+      }
       if (!Number.isInteger(issueNumber) || issueNumber <= 0) return false;
       const repo = getValidatedRepo();
       try {
@@ -119,11 +135,16 @@ function buildCronActions(): FilerActions {
           console.error(
             `[audit-issue] Comment failed (#${issueNumber}, ${res.status})`,
           );
+          reportAuditFilerFailure("cron", "postComment", {
+            githubStatus: res.status,
+            issueNumber,
+          });
           return false;
         }
         return true;
       } catch (err) {
         console.error("[audit-issue] Comment threw:", err);
+        reportAuditFilerFailure("cron", "postComment", { error: err, issueNumber });
         return false;
       }
     },

--- a/src/pipeline/audit-issue.ts
+++ b/src/pipeline/audit-issue.ts
@@ -20,6 +20,7 @@
 import type { AuditGroup } from "./audit-runner";
 import { formatGroupIssueTitle, formatGroupIssueBody } from "./audit-format";
 import { reportAuditFilerFailure } from "./audit-filer-telemetry";
+import { safeErrorBody } from "@/lib/safe-error-body";
 import {
   AUDIT_LABEL,
   ALERT_LABEL,
@@ -90,7 +91,7 @@ function buildCronActions(): FilerActions {
         const url = new URL(`/repos/${repo}/issues`, "https://api.github.com");
         const res = await fetch(url, githubPostInit(token, { title, body, labels }));
         if (!res.ok) {
-          const errBody = await res.text();
+          const errBody = await safeErrorBody(res);
           console.error(`[audit-issue] GitHub API ${res.status}: ${errBody}`);
           reportAuditFilerFailure("cron", "createIssue", {
             githubStatus: res.status,


### PR DESCRIPTION
## Summary

#1494 root cause was an expired `GITHUB_TOKEN` in Vercel prod env. You rotated the token and the immediate outage is resolved (verified: 6/7 chrome filings succeeded post-rotation, zero new GitHub 401s in logs). This PR makes the next occurrence loud and graceful instead of silent.

- **Prompt:** `renderFilingInstructions()` caps 502 retries at one and promotes the GitHub URL-prefill flow to Option 2 (was "legacy fallback"). Chrome agents no longer loop indefinitely on persistent server-side failures.
- **Sentry:** both filing paths share a `reportAuditFilerFailure(origin, stage, detail)` helper with a 60s in-memory dedup window — token outages now produce one alert per failure mode per origin instead of dozens per minute.
- **Health probe:** new admin-only `GET /api/audit/filing-health` hits GitHub `/rate_limit` and surfaces 401 (token rotation needed) + 403 rate-limit-exhausted with actionable messages.
- **Dashboard:** `<FilingHealthChip />` on `/admin/audit` renders green/amber/red so the next token expiry shows up the moment you open the page.

## Files

| File | Change |
|---|---|
| `src/lib/admin/audit-prompt-shared.ts` | 502 retry cap, reordered options |
| `src/lib/admin/audit-prompt-shared.test.ts` | **new** — 6 tests pinning prompt behavior |
| `src/pipeline/audit-filer-telemetry.ts` | **new** — shared Sentry helper + dedup window |
| `src/pipeline/audit-issue.ts` | uses shared helper |
| `src/app/api/audit/file-finding/route.ts` | uses shared helper |
| `src/app/api/audit/filing-health/route.ts` | **new** — `/rate_limit` probe |
| `src/app/api/audit/filing-health/route.test.ts` | **new** — 5 tests |
| `src/components/admin/AuditDashboard.tsx` | adds chip + lookup-table styling |

## Test plan
- [ ] CI: `npx tsc --noEmit && npm run lint && npm test` (locally green on touched modules — 83/83)
- [ ] Open `/admin/audit` after merge → chip renders **green** (`Filing OK`) with `<remaining>/<limit> core calls remain` in the tooltip
- [ ] In DevTools console, simulate a probe failure: temporarily mismatch `GITHUB_TOKEN` in Vercel preview → chip flips **red** with `"GitHub rejected the token (401 Bad Credentials). Rotate GITHUB_TOKEN…"` in the tooltip
- [ ] Trigger another chrome audit via Claude in Chrome → confirm `/api/audit/file-finding` returns 200 / `action: created`, and no Sentry events fire (success path)
- [ ] Tomorrow's 7:07 AM ET cron audit posts new audit issues cleanly with no `[audit-issue] GitHub API` errors in logs

Closes #1494

🤖 Generated with [Claude Code](https://claude.com/claude-code)