### PR TITLE
fix(fb): harden hosted-events adapter against placeholder, admin-notice & hare-trailer leaks

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -5089,6 +5089,9 @@ export const SOURCES = [
       name: "Narwhal H3 Facebook Hosted Events",
       url: "https://www.facebook.com/HashNarwhal/upcoming_hosted_events",
       type: "FACEBOOK_HOSTED_EVENTS" as const,
+      // FB Page shows "No events to show" and an admin post announcing
+      // departure from Meetup. Kennel does not use FB Hosted Events. (#1500)
+      enabled: false,
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,
@@ -5120,6 +5123,10 @@ export const SOURCES = [
       name: "RH3 Columbus Facebook Hosted Events",
       url: "https://www.facebook.com/rh3columbus/upcoming_hosted_events",
       type: "FACEBOOK_HOSTED_EVENTS" as const,
+      // FB Page shows "No events to show". Kennel does not use FB Hosted
+      // Events; their canonical site is renegadeh3.com — follow-up to
+      // onboard an HTML_SCRAPER source for it. (#1499)
+      enabled: false,
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,
@@ -5150,6 +5157,10 @@ export const SOURCES = [
       name: "Sir Walters H3 Facebook Hosted Events",
       url: "https://www.facebook.com/sirwaltersh3/upcoming_hosted_events",
       type: "FACEBOOK_HOSTED_EVENTS" as const,
+      // FB Page shows "No events to show". SWH3 announces runs via posts on
+      // their WordPress blog (already wired as the swh3.wordpress.com source
+      // above) rather than Hosted Events. (#1496)
+      enabled: false,
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,

--- a/scripts/live-verify-fb.ts
+++ b/scripts/live-verify-fb.ts
@@ -1,0 +1,67 @@
+import "dotenv/config";
+import { FacebookHostedEventsAdapter } from "../src/adapters/facebook-hosted-events/adapter";
+
+interface TestCase {
+  label: string;
+  config: {
+    kennelTag: string;
+    pageHandle: string;
+    timezone: string;
+    upcomingOnly: true;
+  };
+}
+
+const cases: TestCase[] = [
+  {
+    label: "GSH3 (canary — expects ≥1 event)",
+    config: { kennelTag: "gsh3", pageHandle: "GrandStrandHashing", timezone: "America/New_York", upcomingOnly: true },
+  },
+  {
+    label: "SWH3 (#1496 — expects 0 events, no admin notices)",
+    config: { kennelTag: "swh3", pageHandle: "sirwaltersh3", timezone: "America/New_York", upcomingOnly: true },
+  },
+  {
+    label: "HashNarwhal (#1500 — expects admin notice filtered or 0 events)",
+    config: { kennelTag: "narwhal-h3", pageHandle: "HashNarwhal", timezone: "America/New_York", upcomingOnly: true },
+  },
+  {
+    label: "rh3columbus (#1499 — expects 0 events)",
+    config: { kennelTag: "renh3", pageHandle: "rh3columbus", timezone: "America/New_York", upcomingOnly: true },
+  },
+];
+
+async function main() {
+  const adapter = new FacebookHostedEventsAdapter();
+  for (const tc of cases) {
+    console.log(`\n=== ${tc.label} ===`);
+    try {
+      const source = { config: tc.config } as never;
+      const result = await adapter.fetch(source, { days: 90 });
+      console.log("events:", result.events.length);
+      if (result.events.length > 0) {
+        const sample = result.events[0];
+        console.log("sample[0]:", JSON.stringify({
+          date: sample.date,
+          startTime: sample.startTime,
+          title: sample.title,
+          location: sample.location,
+          locationStreet: sample.locationStreet,
+          hares: sample.hares,
+          runNumber: sample.runNumber,
+          sourceUrl: sample.sourceUrl,
+          descriptionFirst200: sample.description?.slice(0, 200),
+        }, null, 2));
+      }
+      console.log("errors:", result.errors);
+      console.log("parserFiltered:", result.diagnosticContext?.parserFiltered);
+      console.log("htmlBytes:", result.diagnosticContext?.htmlBytes);
+    } catch (err) {
+      console.error("FAILED:", err instanceof Error ? err.message : String(err));
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/live-verify-fb.ts
+++ b/scripts/live-verify-fb.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import type { Source } from "../src/generated/prisma/client";
 import { FacebookHostedEventsAdapter } from "../src/adapters/facebook-hosted-events/adapter";
 
 interface TestCase {
@@ -35,7 +36,7 @@ async function main() {
   for (const tc of cases) {
     console.log(`\n=== ${tc.label} ===`);
     try {
-      const source = { config: tc.config } as never;
+      const source = { config: tc.config } as unknown as Source;
       const result = await adapter.fetch(source, { days: 90 });
       console.log("events:", result.events.length);
       if (result.events.length > 0) {

--- a/src/adapters/facebook-hosted-events/adapter.test.ts
+++ b/src/adapters/facebook-hosted-events/adapter.test.ts
@@ -503,6 +503,121 @@ describe("FacebookHostedEventsAdapter — fetch", () => {
     expect(bandoleros?.description).toMatch(/Hare:/);
   });
 
+  // #1496 / #1499 / #1500 — Source-coverage-gap signal: SSR envelope intact
+  // but every event candidate was filtered for content reasons. Distinguishes
+  // "this kennel doesn't use FB Events" / "the Page admin posted notices
+  // instead of trails" from the normal "Page has nothing scheduled" case.
+  it("flags a coverage-gap error when every candidate is filtered as an admin notice", async () => {
+    const adminNoticeHtml =
+      `<html><body>` +
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"123456789012345","name":"Moving to a new website site - Last day in Meetup is March 10th"},
+        "time":{"id":"123456789012345","start_timestamp":1778353200}
+      }</script>` +
+      `</body></html>`;
+    mockedFetch.mockResolvedValueOnce(htmlResponse(adminNoticeHtml));
+    const adapter = new FacebookHostedEventsAdapter();
+    const result = await adapter.fetch(
+      makeSource({
+        kennelTag: "narwhal-h3",
+        pageHandle: "HashNarwhal",
+        timezone: "America/New_York",
+        upcomingOnly: true,
+      }),
+    );
+    expect(result.events).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/all were filtered/i);
+    expect(result.errors[0]).toMatch(/admin-notice=1/);
+    expect(result.diagnosticContext).toMatchObject({
+      parserFiltered: expect.objectContaining({ "admin-notice": 1 }),
+    });
+  });
+
+  it("does NOT flag coverage-gap when the page genuinely has no events (no candidates filtered)", async () => {
+    // Distinguishes #1496's "Page exists but no Hosted Events feature" case:
+    // SSR intact, parser sees zero candidate bags. This is the legitimate
+    // empty-page case and must not surface the coverage-gap error.
+    const emptyHtml =
+      `<html><body>` +
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `</body></html>`;
+    mockedFetch.mockResolvedValueOnce(htmlResponse(emptyHtml));
+    const adapter = new FacebookHostedEventsAdapter();
+    const result = await adapter.fetch(
+      makeSource({
+        kennelTag: "swh3",
+        pageHandle: "sirwaltersh3",
+        timezone: "America/New_York",
+        upcomingOnly: true,
+      }),
+    );
+    expect(result.events).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("flags a coverage-gap when every candidate is a placeholder (#1497-style)", async () => {
+    const placeholderOnlyHtml =
+      `<html><body>` +
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"123456789012345","name":"Test"},
+        "time":{"id":"123456789012345","start_timestamp":1778353200}
+      }</script>` +
+      `</body></html>`;
+    mockedFetch.mockResolvedValueOnce(htmlResponse(placeholderOnlyHtml));
+    const adapter = new FacebookHostedEventsAdapter();
+    const result = await adapter.fetch(
+      makeSource({
+        kennelTag: "swh3",
+        pageHandle: "sirwaltersh3",
+        timezone: "America/New_York",
+        upcomingOnly: true,
+      }),
+    );
+    expect(result.events).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/placeholder=1/);
+  });
+
+  it("does NOT flag coverage-gap when at least one real event is emitted alongside filtered ones", async () => {
+    const mixedHtml =
+      `<html><body>` +
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"100000000000001","name":"Test"},
+        "time":{"id":"100000000000001","start_timestamp":1778353200}
+      }</script>` +
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"100000000000002","name":"Real Trail #42","event_place":{"contextual_name":"Bar"}},
+        "time":{"id":"100000000000002","start_timestamp":1778353200}
+      }</script>` +
+      `</body></html>`;
+    // Detail-page fetches for the real event will 404 (we don't mock them) —
+    // that's fine, the listing data still emits.
+    mockedFetch.mockImplementation((url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/upcoming_hosted_events")) {
+        return Promise.resolve(htmlResponse(mixedHtml));
+      }
+      return Promise.resolve({ ok: false, status: 404, text: async () => "" } as Response);
+    });
+    const adapter = new FacebookHostedEventsAdapter();
+    const result = await adapter.fetch(
+      makeSource({
+        kennelTag: "swh3",
+        pageHandle: "sirwaltersh3",
+        timezone: "America/New_York",
+        upcomingOnly: true,
+      }),
+    );
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].runNumber).toBe(42);
+    // No coverage-gap error — real events made it through.
+    expect(result.errors.filter((e) => /all were filtered/i.test(e))).toEqual([]);
+  });
+
   it("does NOT flag shape-break when a fat empty-Page response carries SSR envelope markers (#1294 audit fix)", async () => {
     // Real-world: empty FB Pages still ship 600KB+ SSR bundles with the
     // RelayPrefetchedStreamCache / __bbox envelope intact. The byte-count

--- a/src/adapters/facebook-hosted-events/adapter.test.ts
+++ b/src/adapters/facebook-hosted-events/adapter.test.ts
@@ -528,7 +528,7 @@ describe("FacebookHostedEventsAdapter — fetch", () => {
     );
     expect(result.events).toEqual([]);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toMatch(/all were filtered/i);
+    expect(result.errors[0]).toMatch(/all were content-filtered/i);
     expect(result.errors[0]).toMatch(/admin-notice=1/);
     expect(result.diagnosticContext).toMatchObject({
       parserFiltered: expect.objectContaining({ "admin-notice": 1 }),
@@ -581,6 +581,56 @@ describe("FacebookHostedEventsAdapter — fetch", () => {
     expect(result.errors[0]).toMatch(/placeholder=1/);
   });
 
+  // Codex P1: cancelled / missing-half / no-title / invalid-time are NOT
+  // content quality issues — they're shape drift or legitimate FB state.
+  // The coverage-gap signal must NOT fire on a Page where every candidate
+  // happens to be cancelled (which is a real, normal state).
+  it("does NOT flag coverage-gap when every candidate is cancelled (Codex P1)", async () => {
+    const allCancelledHtml =
+      `<html><body>` +
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"100000000000001","name":"Real Trail #42","is_canceled":true},
+        "time":{"id":"100000000000001","start_timestamp":1778353200}
+      }</script>` +
+      `</body></html>`;
+    mockedFetch.mockResolvedValueOnce(htmlResponse(allCancelledHtml));
+    const adapter = new FacebookHostedEventsAdapter();
+    const result = await adapter.fetch(
+      makeSource({
+        kennelTag: "x",
+        pageHandle: "x",
+        timezone: "America/New_York",
+        upcomingOnly: true,
+      }),
+    );
+    expect(result.events).toEqual([]);
+    expect(result.errors.filter((e) => /content-filtered/i.test(e))).toEqual([]);
+  });
+
+  it("does NOT flag coverage-gap when every candidate is missing-half (Codex P1)", async () => {
+    // Time-only nodes (no rich __typename:Event) are shape drift, not a
+    // content-quality issue. EVENT_COUNT_ANOMALY + the shape-break
+    // heuristic cover this — coverage-gap must not double-fire.
+    const missingHalfHtml =
+      `<html><body>` +
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `<script type="application/json">{"e":{"id":"100000000000001","start_timestamp":1778353200}}</script>` +
+      `</body></html>`;
+    mockedFetch.mockResolvedValueOnce(htmlResponse(missingHalfHtml));
+    const adapter = new FacebookHostedEventsAdapter();
+    const result = await adapter.fetch(
+      makeSource({
+        kennelTag: "x",
+        pageHandle: "x",
+        timezone: "America/New_York",
+        upcomingOnly: true,
+      }),
+    );
+    expect(result.events).toEqual([]);
+    expect(result.errors.filter((e) => /content-filtered/i.test(e))).toEqual([]);
+  });
+
   it("does NOT flag coverage-gap when at least one real event is emitted alongside filtered ones", async () => {
     const mixedHtml =
       `<html><body>` +
@@ -615,7 +665,7 @@ describe("FacebookHostedEventsAdapter — fetch", () => {
     expect(result.events).toHaveLength(1);
     expect(result.events[0].runNumber).toBe(42);
     // No coverage-gap error — real events made it through.
-    expect(result.errors.filter((e) => /all were filtered/i.test(e))).toEqual([]);
+    expect(result.errors.filter((e) => /all were content-filtered/i.test(e))).toEqual([]);
   });
 
   it("does NOT flag shape-break when a fat empty-Page response carries SSR envelope markers (#1294 audit fix)", async () => {

--- a/src/adapters/facebook-hosted-events/adapter.ts
+++ b/src/adapters/facebook-hosted-events/adapter.ts
@@ -147,7 +147,13 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
     });
     const allEvents = parseResult.events;
     const filteredCounts = parseResult.filtered;
-    const filteredTotal = Object.values(filteredCounts).reduce((a, b) => a + b, 0);
+    // Only `admin-notice` and `placeholder` reflect content-quality drops
+    // ("this Page admin posts non-trails on the events feed"). The other
+    // reject reasons (missing-half, no-title, invalid-time, cancelled)
+    // reflect shape drift or normal cancellations and must NOT raise the
+    // coverage-gap signal — those would create false alerts on Pages with
+    // legitimate cancelled events or partial graph payloads (Codex P1).
+    const contentFilteredTotal = filteredCounts["admin-notice"] + filteredCounts.placeholder;
 
     // Shape-break heuristic: 0 parsed events AND none of FB's SSR envelope
     // markers present → the GraphQL shape rotated. If at least one marker
@@ -163,21 +169,22 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
       );
     }
 
-    // Coverage-gap signal (#1496, #1499): SSR envelope intact AND every
-    // event candidate was filtered for content reasons (admin notices,
-    // placeholder rows). This is distinct from "Page genuinely has nothing
-    // scheduled" and worth surfacing so an operator can re-evaluate the
-    // FB source vs. switching to MEETUP / website / static schedule.
-    // EVENT_COUNT_ANOMALY only fires once a baseline accrues — this signal
-    // fires on first scrape too. Routed via the standard `errors[]` channel
-    // so the existing SCRAPE_FAILURE / health pipeline can pick it up.
-    if (allEvents.length === 0 && hasEnvelopeMarker && filteredTotal > 0) {
-      const reasonSummary = Object.entries(filteredCounts)
-        .filter(([, n]) => n > 0)
-        .map(([reason, n]) => `${reason}=${n}`)
+    // Coverage-gap signal (#1496, #1499): SSR envelope intact AND at least
+    // one event candidate was content-filtered (admin notices, placeholder
+    // rows) and zero real events made it through. This is distinct from
+    // "Page genuinely has nothing scheduled" and worth surfacing so an
+    // operator can re-evaluate the FB source vs. switching to MEETUP /
+    // website / static schedule. EVENT_COUNT_ANOMALY only fires once a
+    // baseline accrues — this signal fires on first scrape too. Routed
+    // via the standard `errors[]` channel so the existing SCRAPE_FAILURE /
+    // health pipeline can pick it up.
+    if (allEvents.length === 0 && hasEnvelopeMarker && contentFilteredTotal > 0) {
+      const reasonSummary = (["admin-notice", "placeholder"] as const)
+        .filter((reason) => filteredCounts[reason] > 0)
+        .map((reason) => `${reason}=${filteredCounts[reason]}`)
         .join(", ");
       errors.push(
-        `FB hosted_events page returned ${filteredTotal} candidate events but all were filtered (${reasonSummary}). Source likely does not use FB Hosted Events for runs — consider replacing with a website / Meetup source.`,
+        `FB hosted_events page returned ${contentFilteredTotal} candidate events but all were content-filtered (${reasonSummary}). Source likely does not use FB Hosted Events for runs — consider replacing with a website / Meetup source.`,
       );
     }
 

--- a/src/adapters/facebook-hosted-events/adapter.ts
+++ b/src/adapters/facebook-hosted-events/adapter.ts
@@ -24,7 +24,7 @@ import { validateSourceConfig, applyDateWindow } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { isValidTimezone } from "@/lib/timezone";
 import {
-  parseFacebookHostedEvents,
+  parseFacebookHostedEventsWithStats,
   parseFacebookEventDetail,
   extractFieldsFromFbDescription,
 } from "./parser";
@@ -141,10 +141,13 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
     // shape drift (returns [] rather than throwing) so a 0-event result
     // here means EITHER the page genuinely has no upcoming events OR FB's
     // SSR shape changed.
-    const allEvents = parseFacebookHostedEvents(html, {
+    const parseResult = parseFacebookHostedEventsWithStats(html, {
       kennelTag: config.kennelTag,
       timezone: config.timezone,
     });
+    const allEvents = parseResult.events;
+    const filteredCounts = parseResult.filtered;
+    const filteredTotal = Object.values(filteredCounts).reduce((a, b) => a + b, 0);
 
     // Shape-break heuristic: 0 parsed events AND none of FB's SSR envelope
     // markers present → the GraphQL shape rotated. If at least one marker
@@ -157,6 +160,24 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
     if (allEvents.length === 0 && !hasEnvelopeMarker) {
       errors.push(
         `FB hosted_events page returned ${html.length} chars but parser found 0 events and the SSR envelope markers are absent — likely a GraphQL shape change. Refresh the parser fixture and re-test.`,
+      );
+    }
+
+    // Coverage-gap signal (#1496, #1499): SSR envelope intact AND every
+    // event candidate was filtered for content reasons (admin notices,
+    // placeholder rows). This is distinct from "Page genuinely has nothing
+    // scheduled" and worth surfacing so an operator can re-evaluate the
+    // FB source vs. switching to MEETUP / website / static schedule.
+    // EVENT_COUNT_ANOMALY only fires once a baseline accrues — this signal
+    // fires on first scrape too. Routed via the standard `errors[]` channel
+    // so the existing SCRAPE_FAILURE / health pipeline can pick it up.
+    if (allEvents.length === 0 && hasEnvelopeMarker && filteredTotal > 0) {
+      const reasonSummary = Object.entries(filteredCounts)
+        .filter(([, n]) => n > 0)
+        .map(([reason, n]) => `${reason}=${n}`)
+        .join(", ");
+      errors.push(
+        `FB hosted_events page returned ${filteredTotal} candidate events but all were filtered (${reasonSummary}). Source likely does not use FB Hosted Events for runs — consider replacing with a website / Meetup source.`,
       );
     }
 
@@ -173,6 +194,7 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
           timezone: config.timezone,
           windowDays: days,
           htmlBytes: html.length,
+          parserFiltered: filteredCounts,
         },
       },
       days,

--- a/src/adapters/facebook-hosted-events/constants.ts
+++ b/src/adapters/facebook-hosted-events/constants.ts
@@ -79,3 +79,49 @@ export function isReservedFacebookHandle(value: string): boolean {
   const normalized = value.trim().toLowerCase();
   return FB_RESERVED_FIRST_SEGMENTS.some((r) => r.toLowerCase() === normalized);
 }
+
+/**
+ * Generic single-word/draft titles that admins post when testing FB Events.
+ * Used as the "title side" of the placeholder-event quality gate (#1497): a
+ * match here is necessary but NOT sufficient — the event must also lack a
+ * run number AND a location to be dropped at parser time. Hares aren't
+ * visible at parser time (they come from the detail-page enrichment step)
+ * so we deliberately don't require their absence here.
+ *
+ * Anchored to start/end so e.g. "Test Trail #186" doesn't match.
+ */
+export const PLACEHOLDER_TITLE_RE = /^(?:test|testing|draft|placeholder|untitled|new event|sample)$/i;
+
+/**
+ * Admin / meta announcement title patterns. Match means the row is NOT a
+ * hash trail — it's a Page-admin notice (#1500: "Moving to a new website",
+ * #1500-class: "Last day in Meetup", farewell posts, etc.). Unlike the
+ * placeholder gate above, a match here drops the event UNCONDITIONALLY
+ * because no combination of run number / location / hares can rehabilitate
+ * a notice into a real run.
+ *
+ * Patterns intentionally narrow — broad matches (e.g. bare /update/i) would
+ * catch real titles like "Memorial Day Update Trail". Each entry encodes a
+ * domain-specific phrase that admins use when posting non-event meta
+ * announcements.
+ */
+export const ADMIN_NOTICE_PATTERNS = [
+  /\bmoving\s+to\s+(?:a\s+)?new\s+(?:website|site|home|platform)\b/i,
+  /\blast\s+day\s+(?:in|on|at)\b/i,
+  /\bnew\s+website\b/i,
+  /\bfarewell\b/i,
+  /\bRIP\b/, // case-sensitive — "rip" lowercase appears in real trail descriptions
+  /\bgoodbye\b/i,
+  /\bdeprecated\b/i,
+  /\bplease\s+(?:use|visit|follow)\s+(?:our\s+)?new\b/i,
+] as const;
+
+/** True when `title` matches the placeholder set (test/draft/etc.). */
+export function isPlaceholderTitle(title: string): boolean {
+  return PLACEHOLDER_TITLE_RE.test(title.trim());
+}
+
+/** True when `title` matches any admin-notice pattern. */
+export function isAdminNoticeTitle(title: string): boolean {
+  return ADMIN_NOTICE_PATTERNS.some((re) => re.test(title));
+}

--- a/src/adapters/facebook-hosted-events/parser.test.ts
+++ b/src/adapters/facebook-hosted-events/parser.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   parseFacebookHostedEvents,
+  parseFacebookHostedEventsWithStats,
   parseFacebookEventDetail,
   facebookEventToRawEvent,
   extractFieldsFromFbDescription,
@@ -208,8 +209,9 @@ describe("parseFacebookHostedEvents — edge cases", () => {
   });
 
   it("survives invalid JSON in a script tag without throwing", () => {
+    // Title with run number so the #1497 placeholder filter doesn't fire.
     const html = `<script type="application/json">{ invalid </script><script type="application/json">{
-      "rich":{"__typename":"Event","id":"123456789012345","name":"Test"},
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Trail #1"},
       "time":{"id":"123456789012345","start_timestamp":1778353200}
     }</script>`;
     expect(() => parseFacebookHostedEvents(html, { kennelTag: "any" })).not.toThrow();
@@ -221,8 +223,9 @@ describe("parseFacebookHostedEvents — edge cases", () => {
     // 1778295600 = 2026-05-09 03:00 UTC.
     //   PDT (UTC-7) → 2026-05-08 20:00 (previous day)
     //   JST (UTC+9) → 2026-05-09 12:00 (same day)
+    // Title with run number so the #1497 placeholder filter doesn't fire.
     const html = `<script type="application/json">{
-      "rich":{"__typename":"Event","id":"123456789012345","name":"Test"},
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Trail #1"},
       "time":{"id":"123456789012345","start_timestamp":1778295600}
     }</script>`;
     const laEvents = parseFacebookHostedEvents(html, { kennelTag: "la", timezone: "America/Los_Angeles" });
@@ -536,5 +539,160 @@ describe("extractFieldsFromFbDescription (#1319)", () => {
     const desc = "Location: 📍 123 Main St, Anytown, NY 10001";
     const fields = extractFieldsFromFbDescription(desc);
     expect(fields.locationStreet).toBe("123 Main St, Anytown, NY 10001");
+  });
+
+  // #1498 — SWH3 Run #1781 leaked the next-run announcement after the hare names.
+  it("strips an `on <weekday>` next-run trailer from the hare names (#1498 SWH3)", () => {
+    const desc = "Hare: Comfort and Tight Lips on Saturday, March 14";
+    const fields = extractFieldsFromFbDescription(desc);
+    expect(fields.hares).toBe("Comfort and Tight Lips");
+  });
+
+  it.each([
+    ["Hare: Alice on Sunday, April 5", "Alice"],
+    ["Hare: Alice and Bob on Friday, June 12th", "Alice and Bob"],
+    ["Hare: Big Hare on Wednesday\nLocation: …", "Big Hare"],
+  ])("strips next-run trailer for %p → %p", (desc, expected) => {
+    expect(extractFieldsFromFbDescription(desc).hares).toBe(expected);
+  });
+
+  it("leaves the hare line untouched when no weekday-trailer follows", () => {
+    // Defensive: a hare name like "Ronnie On the Run" contains "on" but no
+    // weekday, so the strip must not fire.
+    const fields = extractFieldsFromFbDescription("Hare: Ronnie On the Run");
+    expect(fields.hares).toBe("Ronnie On the Run");
+  });
+});
+
+describe("parseFacebookHostedEvents — quality gate (#1497)", () => {
+  // #1497 — SWH3 ingested a one-word "Test" event with no run number,
+  // no location, no hares.
+  const TEST_EVENT_HTML = `<script type="application/json">{
+    "rich":{"__typename":"Event","id":"123456789012345","name":"Test"},
+    "time":{"id":"123456789012345","start_timestamp":1778353200}
+  }</script>`;
+
+  it("rejects a one-word placeholder title with no run number and no location", () => {
+    const events = parseFacebookHostedEvents(TEST_EVENT_HTML, { kennelTag: "swh3" });
+    expect(events).toEqual([]);
+  });
+
+  it("counts the rejection under the `placeholder` reason in the stats result", () => {
+    const result = parseFacebookHostedEventsWithStats(TEST_EVENT_HTML, { kennelTag: "swh3" });
+    expect(result.events).toEqual([]);
+    expect(result.filtered.placeholder).toBe(1);
+  });
+
+  it.each(["Test", "Testing", "Draft", "Placeholder", "Untitled", "New Event", "SAMPLE"])(
+    "rejects placeholder title %p when no other identifying field is present",
+    (title) => {
+      const html = `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"123456789012345","name":${JSON.stringify(title)}},
+        "time":{"id":"123456789012345","start_timestamp":1778353200}
+      }</script>`;
+      expect(parseFacebookHostedEvents(html, { kennelTag: "swh3" })).toEqual([]);
+    },
+  );
+
+  it("does NOT reject a placeholder-shaped title that has a location", () => {
+    // A real one-off event titled "Test" with a venue name is not a test
+    // artifact and should not be silently dropped — better a noisy hareline
+    // entry than silent corruption of real events.
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Test","event_place":{"contextual_name":"Some Bar"}},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    const events = parseFacebookHostedEvents(html, { kennelTag: "swh3" });
+    expect(events).toHaveLength(1);
+    expect(events[0].location).toBe("Some Bar");
+  });
+
+  it("does NOT reject a title that contains 'Test' as a substring (e.g. 'Test Trail #186')", () => {
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Test Trail #186"},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    const events = parseFacebookHostedEvents(html, { kennelTag: "swh3" });
+    expect(events).toHaveLength(1);
+    expect(events[0].title).toBe("Test Trail #186");
+    expect(events[0].runNumber).toBe(186);
+  });
+});
+
+describe("parseFacebookHostedEvents — admin-notice filter (#1500)", () => {
+  // #1500 — Narwhal H3 admin posted "Moving to a new website site - Last day
+  // in Meetup is March 10th" — verbatim title from the issue.
+  it("rejects 'Moving to a new website site - Last day in Meetup …' verbatim (#1500 Narwhal)", () => {
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Moving to a new website site - Last day in Meetup is March 10th"},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    const result = parseFacebookHostedEventsWithStats(html, { kennelTag: "narwhal-h3" });
+    expect(result.events).toEqual([]);
+    expect(result.filtered["admin-notice"]).toBe(1);
+  });
+
+  it.each([
+    "Moving to a new website",
+    "Moving to a new platform - last day in Meetup",
+    "Farewell trail — wrapping up",
+    "Please use our new website at example.com",
+    "DEPRECATED: see new Page",
+    "Goodbye Hashers",
+    "RIP Hash Cash",
+  ])("rejects admin/meta title %p unconditionally", (title) => {
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":${JSON.stringify(title)},"event_place":{"contextual_name":"Real Venue"}},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    // Even with a location present — admin notices are never real runs.
+    expect(parseFacebookHostedEvents(html, { kennelTag: "x" })).toEqual([]);
+  });
+
+  it("does NOT reject a real trail title that contains 'new' or 'website' in passing", () => {
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":"New Year's Day Trail — visit our website"},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    const events = parseFacebookHostedEvents(html, { kennelTag: "x" });
+    expect(events).toHaveLength(1);
+  });
+});
+
+describe("parseFacebookHostedEventsWithStats — counts", () => {
+  it("returns zero counts when the page is empty", () => {
+    const result = parseFacebookHostedEventsWithStats("<html></html>", { kennelTag: "x" });
+    expect(result.events).toEqual([]);
+    expect(Object.values(result.filtered).every((n) => n === 0)).toBe(true);
+  });
+
+  it("counts mixed reasons in a single scrape", () => {
+    const html = [
+      // Admin notice
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"100000000000001","name":"Moving to a new website"},
+        "time":{"id":"100000000000001","start_timestamp":1778353200}
+      }</script>`,
+      // Placeholder
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"100000000000002","name":"Test"},
+        "time":{"id":"100000000000002","start_timestamp":1778353200}
+      }</script>`,
+      // Cancelled
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"100000000000003","name":"Real Trail","is_canceled":true},
+        "time":{"id":"100000000000003","start_timestamp":1778353200}
+      }</script>`,
+      // Real event
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"100000000000004","name":"Real Trail #42","event_place":{"contextual_name":"Bar"}},
+        "time":{"id":"100000000000004","start_timestamp":1778353200}
+      }</script>`,
+    ].join("");
+    const result = parseFacebookHostedEventsWithStats(html, { kennelTag: "x" });
+    expect(result.events).toHaveLength(1);
+    expect(result.filtered["admin-notice"]).toBe(1);
+    expect(result.filtered.placeholder).toBe(1);
+    expect(result.filtered.cancelled).toBe(1);
   });
 });

--- a/src/adapters/facebook-hosted-events/parser.test.ts
+++ b/src/adapters/facebook-hosted-events/parser.test.ts
@@ -197,6 +197,31 @@ describe("parseFacebookHostedEvents — edge cases", () => {
     expect(event.location).toBe("Real Place");
   });
 
+  it("drops NaN / Infinity coordinates (Number.isFinite guard, Gemini review)", () => {
+    // typeof NaN === "number" is true — a typeof guard would let a NaN
+    // coordinate slip through and pollute lat/lng on the canonical Event.
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Trail #1","event_place":{"contextual_name":"V","location":{"latitude":"not-a-number","longitude":"not-a-number"}}},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    const [event] = parseFacebookHostedEvents(html, { kennelTag: "x" });
+    expect(event.latitude).toBeUndefined();
+    expect(event.longitude).toBeUndefined();
+  });
+
+  it("accepts 0,0 as a real coordinate (Number.isFinite admits zero)", () => {
+    // Equator/prime-meridian intersection — improbable for a hash trail
+    // but the typeof check would already let this through; verifying
+    // Number.isFinite preserves the same behavior.
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Trail #1","event_place":{"contextual_name":"V","location":{"latitude":0,"longitude":0}}},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    const [event] = parseFacebookHostedEvents(html, { kennelTag: "x" });
+    expect(event.latitude).toBe(0);
+    expect(event.longitude).toBe(0);
+  });
+
   it("merges location lat/lng per axis (one ref has latitude, the other has longitude)", () => {
     const html = `<script type="application/json">{
       "lat":{"__typename":"Event","id":"123456789012345","name":"T","event_place":{"contextual_name":"V","location":{"latitude":33.69}}},
@@ -561,6 +586,17 @@ describe("extractFieldsFromFbDescription (#1319)", () => {
     // weekday, so the strip must not fire.
     const fields = extractFieldsFromFbDescription("Hare: Ronnie On the Run");
     expect(fields.hares).toBe("Ronnie On the Run");
+  });
+
+  it.each([
+    // Codex P2: 'on <weekday>' followed by prose (not a date) — must NOT
+    // truncate. Without the date-suffix gate, "Born on Saturday Night"
+    // would silently collapse to "Born".
+    ["Hare: Born on Saturday Night", "Born on Saturday Night"],
+    ["Hare: Made on Friday Adventures", "Made on Friday Adventures"],
+    ["Hare: Closed on Sunday Brunch", "Closed on Sunday Brunch"],
+  ])("leaves the hare line untouched for %p (prose, not a date trailer)", (desc, expected) => {
+    expect(extractFieldsFromFbDescription(desc).hares).toBe(expected);
   });
 });
 

--- a/src/adapters/facebook-hosted-events/parser.ts
+++ b/src/adapters/facebook-hosted-events/parser.ts
@@ -26,7 +26,7 @@
 
 import type { RawEventData } from "../types";
 import { formatYmdInTimezone, formatTimeInZone, isValidTimezone } from "@/lib/timezone";
-import { FB_EVENT_ID_RE } from "./constants";
+import { FB_EVENT_ID_RE, isAdminNoticeTitle, isPlaceholderTitle } from "./constants";
 import { extractHashRunNumber, hasPlaceholderRunNumber } from "../utils";
 import { extractHares } from "../hare-extraction";
 
@@ -43,6 +43,42 @@ export interface ParseFacebookOptions {
 }
 
 /**
+ * Reasons `bagToRawEvent` may drop a candidate. Surfaced via
+ * `parseFacebookHostedEventsWithStats` so the adapter can tell "FB Page
+ * returned zero usable events because they were all placeholders/admin
+ * notices" apart from "FB Page genuinely has nothing scheduled" — the
+ * former is signal-worthy (per-source-config drift), the latter is normal.
+ */
+export type FbBagRejectReason =
+  | "missing-half"
+  | "cancelled"
+  | "no-title"
+  | "invalid-time"
+  | "admin-notice"
+  | "placeholder";
+
+export interface ParseFacebookResult {
+  events: RawEventData[];
+  /**
+   * Per-reason counts of bags rejected during projection. Zero values
+   * preserved so callers can JSON-serialize the entire shape into
+   * diagnosticContext without branching on undefined keys.
+   */
+  filtered: Record<FbBagRejectReason, number>;
+}
+
+function emptyFilteredCounts(): Record<FbBagRejectReason, number> {
+  return {
+    "missing-half": 0,
+    cancelled: 0,
+    "no-title": 0,
+    "invalid-time": 0,
+    "admin-notice": 0,
+    placeholder: 0,
+  };
+}
+
+/**
  * Parse Facebook hosted_events HTML into RawEventData[].
  *
  * Returns `[]` when no script tags contain Event payloads; never throws
@@ -54,6 +90,20 @@ export function parseFacebookHostedEvents(
   html: string,
   options: ParseFacebookOptions,
 ): RawEventData[] {
+  return parseFacebookHostedEventsWithStats(html, options).events;
+}
+
+/**
+ * Same as `parseFacebookHostedEvents`, but also returns per-reason
+ * rejection counts (#1497, #1500). The adapter consumes this to surface
+ * a `source-coverage-gap` signal when every parsed candidate was filtered
+ * for content reasons (admin-notice / placeholder) rather than when the
+ * Page genuinely had nothing on the listing tab.
+ */
+export function parseFacebookHostedEventsWithStats(
+  html: string,
+  options: ParseFacebookOptions,
+): ParseFacebookResult {
   const tz = options.timezone && isValidTimezone(options.timezone) ? options.timezone : "UTC";
 
   // Collect both halves of each event by id across all JSON islands.
@@ -64,12 +114,17 @@ export function parseFacebookHostedEvents(
     walkAndCollect(parsed, byId);
   }
 
-  const results: RawEventData[] = [];
+  const events: RawEventData[] = [];
+  const filtered = emptyFilteredCounts();
   for (const bag of byId.values()) {
-    const evt = bagToRawEvent(bag, options.kennelTag, tz);
-    if (evt) results.push(evt);
+    const outcome = projectBag(bag, options.kennelTag, tz);
+    if (outcome.kind === "event") {
+      events.push(outcome.event);
+    } else {
+      filtered[outcome.reason] += 1;
+    }
   }
-  return results;
+  return { events, filtered };
 }
 
 interface EventBag {
@@ -379,31 +434,57 @@ export function facebookEventToRawEvent(
   );
 }
 
-function bagToRawEvent(bag: EventBag, kennelTag: string, timezone: string): RawEventData | null {
-  if (!bag.time || !bag.rich) return null;
-  if (bag.rich.is_canceled === true) return null;
+type BagOutcome =
+  | { kind: "event"; event: RawEventData }
+  | { kind: "rejected"; reason: FbBagRejectReason };
+
+function projectBag(bag: EventBag, kennelTag: string, timezone: string): BagOutcome {
+  if (!bag.time || !bag.rich) return { kind: "rejected", reason: "missing-half" };
+  if (bag.rich.is_canceled === true) return { kind: "rejected", reason: "cancelled" };
   const title = bag.rich.name?.trim() || undefined;
-  if (!title) return null;
+  if (!title) return { kind: "rejected", reason: "no-title" };
   const ms = bag.time.start_timestamp * 1000;
   const instant = new Date(ms);
-  if (Number.isNaN(instant.getTime())) return null;
+  if (Number.isNaN(instant.getTime())) return { kind: "rejected", reason: "invalid-time" };
 
-  const date = formatYmdInTimezone(instant, timezone);
-  const startTime = formatTimeInZone(instant, timezone, "HH:mm");
+  // Admin-notice filter (#1500): titles like "Moving to a new website" are
+  // Page-admin announcements, not trails. Drop unconditionally — no field
+  // combo can rehabilitate a notice into a real run.
+  if (isAdminNoticeTitle(title)) return { kind: "rejected", reason: "admin-notice" };
+
   const location = bag.rich.event_place?.contextual_name?.trim() || undefined;
   const lat = bag.rich.event_place?.location?.latitude;
   const lng = bag.rich.event_place?.location?.longitude;
+  const parsedRunNumber = extractHashRunNumber(title);
+  const placeholderRun = parsedRunNumber === undefined && hasPlaceholderRunNumber(title);
+
+  // Placeholder-event filter (#1497): single-word titles like "Test" with
+  // no run number AND no location AND no parseable run marker. Hares come
+  // from the detail-page enrichment step which the parser doesn't run, so
+  // we deliberately don't require their absence — a real test event would
+  // not have hares either.
+  if (
+    isPlaceholderTitle(title) &&
+    parsedRunNumber === undefined &&
+    !placeholderRun &&
+    !location
+  ) {
+    return { kind: "rejected", reason: "placeholder" };
+  }
+
+  const date = formatYmdInTimezone(instant, timezone);
+  const startTime = formatTimeInZone(instant, timezone, "HH:mm");
 
   const event: RawEventData = {
     date,
     kennelTags: [kennelTag],
+    title,
     startTime,
     sourceUrl: `https://www.facebook.com/events/${bag.id}/`,
     externalLinks: [
       { url: `https://www.facebook.com/events/${bag.id}/`, label: "Facebook event" },
     ],
   };
-  if (title !== undefined) event.title = title;
   if (location !== undefined) event.location = location;
   if (typeof lat === "number" && typeof lng === "number") {
     event.latitude = lat;
@@ -413,16 +494,18 @@ function bagToRawEvent(bag: EventBag, kennelTag: string, timezone: string): RawE
   // Placeholder titles ("H6#28?") emit `runNumber: null` so the merge
   // pipeline's tri-state clears any stale value from a prior non-placeholder
   // scrape — see the `runNumber?: number | null` contract on RawEventData.
-  if (title) {
-    const parsed = extractHashRunNumber(title);
-    if (typeof parsed === "number") {
-      event.runNumber = parsed;
-    } else if (hasPlaceholderRunNumber(title)) {
-      event.runNumber = null;
-    }
+  if (typeof parsedRunNumber === "number") {
+    event.runNumber = parsedRunNumber;
+  } else if (placeholderRun) {
+    event.runNumber = null;
   }
-  // Cancelled events are filtered above (return null when is_canceled).
-  return event;
+  return { kind: "event", event };
+}
+
+/** Back-compat shim for the existing `facebookEventToRawEvent` external API. */
+function bagToRawEvent(bag: EventBag, kennelTag: string, timezone: string): RawEventData | null {
+  const outcome = projectBag(bag, kennelTag, timezone);
+  return outcome.kind === "event" ? outcome.event : null;
 }
 
 /**
@@ -482,7 +565,7 @@ export function extractFieldsFromFbDescription(description: string): FacebookDes
 
   const haresRaw = extractHares(trimmed);
   if (haresRaw) {
-    const cleaned = stripLeadingDecoration(haresRaw).trim();
+    const cleaned = stripNextRunTrailer(stripLeadingDecoration(haresRaw).trim()).trim();
     if (cleaned.length > 0) out.hares = cleaned;
   }
 
@@ -496,6 +579,29 @@ export function extractFieldsFromFbDescription(description: string): FacebookDes
   }
 
   return out;
+}
+
+/**
+ * Truncate a hare-names string at the first next-run announcement teaser.
+ *
+ * Some Page admins format the Hare line as
+ *   `Hare: Comfort and Tight Lips on Saturday, March 14`
+ * where `on Saturday, March 14` is the NEXT trail's date, not part of the
+ * attribution (#1498). Strip everything from the first ` on <weekday>` token
+ * onward when it's followed by a date-shaped suffix — date suffix gates the
+ * strip so legitimate hare names containing the word "on" don't get
+ * truncated (e.g. "On On Lee", "Ronnie On the Run").
+ *
+ * The required date-shape suffix is a comma, a month name, an "the Nth",
+ * or end-of-string within a few words. Anchored bounded lookahead so the
+ * regex is provably linear (Sonar S5852 safe).
+ */
+const HARE_NEXT_RUN_TRAILER_RE =
+  /\s+on\s+(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[a-z]*(?=\b)(?:[\s,]|$)/i;
+function stripNextRunTrailer(value: string): string {
+  const m = HARE_NEXT_RUN_TRAILER_RE.exec(value);
+  if (!m) return value;
+  return value.slice(0, m.index).replace(/[\s,;:]+$/, "");
 }
 
 function stripLeadingDecoration(value: string): string {

--- a/src/adapters/facebook-hosted-events/parser.ts
+++ b/src/adapters/facebook-hosted-events/parser.ts
@@ -599,10 +599,15 @@ export function extractFieldsFromFbDescription(description: string): FacebookDes
  *            with `, <date>` (month name or digit), which is the only
  *            real-world shape of a next-run trailer.
  */
-const HARE_TRAILER_WEEKDAY_RE = /\s+on\s+(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[a-z]*\b/i;
+// Each `\s+` is sandwiched between literal anchors (` on `, weekday prefix)
+// and `[a-z]*\b` is bounded by a word boundary — no nested quantifiers, no
+// catastrophic backtracking risk. Input is a single hare-line ≤200 chars.
+const HARE_TRAILER_WEEKDAY_RE = /\s+on\s+(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[a-z]*\b/i; // NOSONAR — flat regex, single quantifier per position, input ≤200 chars
+// `^`-anchored, single `\s*` per position. Each alternative is a literal
+// month prefix or single digit; `the\s+\d` is anchored to a literal digit.
 const HARE_TRAILER_DATE_SUFFIX_RE =
-  /^\s*,\s*(?:\d|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|the\s+\d)/i;
-const HARE_TRAILER_PUNCT_TAIL_RE = /[\s,;:]+$/;
+  /^\s*,\s*(?:\d|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|the\s+\d)/i; // NOSONAR — anchored, literal alternation, input ≤200 chars
+const HARE_TRAILER_PUNCT_TAIL_RE = /[\s,;:]+$/; // NOSONAR — single char class + `$` anchor
 function stripNextRunTrailer(value: string): string {
   const m = HARE_TRAILER_WEEKDAY_RE.exec(value);
   if (!m) return value;

--- a/src/adapters/facebook-hosted-events/parser.ts
+++ b/src/adapters/facebook-hosted-events/parser.ts
@@ -486,7 +486,9 @@ function projectBag(bag: EventBag, kennelTag: string, timezone: string): BagOutc
     ],
   };
   if (location !== undefined) event.location = location;
-  if (typeof lat === "number" && typeof lng === "number") {
+  // `Number.isFinite` guards `NaN` / `Infinity` that a schema-drift node
+  // could ship — `typeof NaN === "number"` is true.
+  if (Number.isFinite(lat) && Number.isFinite(lng)) {
     event.latitude = lat;
     event.longitude = lng;
   }
@@ -587,21 +589,28 @@ export function extractFieldsFromFbDescription(description: string): FacebookDes
  * Some Page admins format the Hare line as
  *   `Hare: Comfort and Tight Lips on Saturday, March 14`
  * where `on Saturday, March 14` is the NEXT trail's date, not part of the
- * attribution (#1498). Strip everything from the first ` on <weekday>` token
- * onward when it's followed by a date-shaped suffix — date suffix gates the
- * strip so legitimate hare names containing the word "on" don't get
- * truncated (e.g. "On On Lee", "Ronnie On the Run").
+ * attribution (#1498). Two-stage match keeps the regex provably linear
+ * (Sonar S5852 safe) AND guards against false positives on hare names
+ * that happen to contain ` on <weekday>` followed by non-date prose
+ * ("Born on Saturday Night" → don't truncate to "Born", Codex P2):
  *
- * The required date-shape suffix is a comma, a month name, an "the Nth",
- * or end-of-string within a few words. Anchored bounded lookahead so the
- * regex is provably linear (Sonar S5852 safe).
+ *   Stage 1: a flat regex locates the candidate ` on <weekday>` token.
+ *   Stage 2: a procedural check confirms the suffix is empty OR begins
+ *            with `, <date>` (month name or digit), which is the only
+ *            real-world shape of a next-run trailer.
  */
-const HARE_NEXT_RUN_TRAILER_RE =
-  /\s+on\s+(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[a-z]*(?=\b)(?:[\s,]|$)/i;
+const HARE_TRAILER_WEEKDAY_RE = /\s+on\s+(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[a-z]*\b/i;
+const HARE_TRAILER_DATE_SUFFIX_RE =
+  /^\s*,\s*(?:\d|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|the\s+\d)/i;
+const HARE_TRAILER_PUNCT_TAIL_RE = /[\s,;:]+$/;
 function stripNextRunTrailer(value: string): string {
-  const m = HARE_NEXT_RUN_TRAILER_RE.exec(value);
+  const m = HARE_TRAILER_WEEKDAY_RE.exec(value);
   if (!m) return value;
-  return value.slice(0, m.index).replace(/[\s,;:]+$/, "");
+  const suffix = value.slice(m.index + m[0].length);
+  // Empty suffix (end-of-string) OR ", <date>" — anything else is prose,
+  // not a trailer. Leave the original untouched in the prose case.
+  if (suffix.length > 0 && !HARE_TRAILER_DATE_SUFFIX_RE.test(suffix)) return value;
+  return value.slice(0, m.index).replace(HARE_TRAILER_PUNCT_TAIL_RE, "");
 }
 
 function stripLeadingDecoration(value: string): string {


### PR DESCRIPTION
## Summary

Cycle 9 of FACEBOOK_HOSTED_EVENTS hardening. Five issues, one shared root cause: the adapter ingests raw FB Hosted Events with no content-quality gate. This PR adds three parser-level filters and an adapter-level coverage-gap signal, then disables three known-empty FB sources following the MileHighH3 precedent.

## What changed

**Parser filters (`src/adapters/facebook-hosted-events/`):**
- `PLACEHOLDER_TITLE_RE` — one-word `test`/`draft`/`untitled`/etc. titles drop when they also lack a run number AND a location. (Closes #1497)
- `ADMIN_NOTICE_PATTERNS` — 8 narrow phrases like *"moving to a new website"*, *"last day in"*, *"farewell"* drop unconditionally. (Closes #1500)
- `stripNextRunTrailer` — strips ` on <weekday>` next-run teasers from `haresText` (`Comfort and Tight Lips on Saturday, March 14` → `Comfort and Tight Lips`). (Closes #1498)

**Adapter signal:**
- `parseFacebookHostedEventsWithStats` returns per-reason rejection counts. When SSR envelope is intact AND every candidate was content-filtered, the adapter emits a coverage-gap entry in `errors[]` so the alert pipeline catches first-scrape garbage before `EVENT_COUNT_ANOMALY`'s baseline accrues. (Helps close #1496, #1499)

**Operator decisions (`prisma/seed-data/sources.ts`):**
- SWH3, Narwhal H3, RH3 Columbus FACEBOOK_HOSTED_EVENTS sources set `enabled: false` — manual inspection confirms the Pages don't use the Hosted Events feature. Same precedent as MileHighH3 (#1391).
- The `renh3` kennel record already exists in `prisma/seed-data/kennels.ts:2417`; the `kennels/renh3` 404 is a prod DB state issue that the post-merge `npx prisma db seed` run will resolve.

## Live verification

Ran the adapter against four FB Pages:

| Page | Result |
|------|--------|
| GrandStrandHashing (canary) | 1 event, `Trail #187`, runNumber=187, location & description enriched |
| sirwaltersh3 (#1496) | 0 events, 0 filtered, no false alert |
| HashNarwhal (#1500) | 0 events, 0 filtered, no false alert |
| rh3columbus (#1499) | 0 events, 0 filtered, no false alert |

Synthetic tests confirm the three filters fire for the exact verbatim payloads in the issues (`"Test"`, `"Moving to a new website site - Last day in Meetup is March 10th"`, SWH3 #1781 hare line).

## Test plan

- [x] `npx vitest run src/adapters/facebook-hosted-events/` — 105 tests pass (30 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 6850 pass, 0 fail
- [x] Live-verify against 4 FB Pages (above)
- [x] `scripts/live-verify-fb.ts` added for future debugging (matches `live-verify-gcal-*.ts` convention)

## Post-merge required

Run `npx prisma db seed` against prod so the `renh3` kennel row lands (resolves the `/kennels/renh3` 404 in #1499).

Closes #1496
Closes #1497
Closes #1498
Closes #1499
Closes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)