### PR TITLE
fix(adapters): NZ scraper parse bugs (#1501, #1505, #1506)

### DIFF
--- a/src/adapters/html-scraper/auckland-hussies.test.ts
+++ b/src/adapters/html-scraper/auckland-hussies.test.ts
@@ -175,6 +175,47 @@ describe("AucklandHussiesAdapter.fetch", () => {
     expect(second.hares).not.toContain("�");
   });
 
+  it("falls back to windows-1252 when the meta tag advertises a bogus charset", async () => {
+    // Defence against a misdeclared meta tag — TextDecoder would throw
+    // RangeError on `charset=not-a-real-charset` and kill the scrape.
+    // The fallback must keep the adapter alive (logs a warning).
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const head = Buffer.from(
+      '<!DOCTYPE html><html><head><meta charset="not-a-real-charset"></head><body><table>' +
+        '<tr><td>5-May</td><td></td><td></td><td>Triple One</td><td>',
+      "ascii",
+    );
+    const eAcute = Buffer.from([0xe9]); // windows-1252 é — survives if fallback fired
+    const tail = Buffer.from("clair St</td></tr></table></body></html>", "ascii");
+    mockFetchBytes(new Uint8Array(Buffer.concat([head, eAcute, tail])));
+    const adapter = new AucklandHussiesAdapter();
+    const result = await adapter.fetch(makeSource(), { days: 365 });
+    expect(result.errors).toEqual([]);
+    expect(result.events.length).toBe(1);
+    expect(result.events[0].location).toBe("éclair St");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("not-a-real-charset"),
+      expect.anything(),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("rejects responses larger than the body cap", async () => {
+    // 3 MB declared length blows the 2 MB cap; safeFetch returns the
+    // header alone (the body never gets consumed). The adapter must not
+    // crash and must surface the rejection as a fetch error.
+    mockedSafeFetch.mockResolvedValue(
+      new Response("<html></html>", {
+        status: 200,
+        headers: { "content-type": "text/html", "content-length": String(3 * 1024 * 1024) },
+      }),
+    );
+    const adapter = new AucklandHussiesAdapter();
+    const result = await adapter.fetch(makeSource(), { days: 365 });
+    expect(result.events).toEqual([]);
+    expect(result.errors[0]).toMatch(/Response too large/);
+  });
+
   it("prefers the Content-Type header charset when it is present", async () => {
     // If the header advertises utf-8, trust the header (proper bytes) and
     // skip the meta-tag sniff. Modern servers do this; the legacy Auckland

--- a/src/adapters/html-scraper/auckland-hussies.test.ts
+++ b/src/adapters/html-scraper/auckland-hussies.test.ts
@@ -37,6 +37,15 @@ function mockFetch(html: string) {
   );
 }
 
+function mockFetchBytes(bytes: Uint8Array, contentType = "text/html") {
+  // Copy into a fresh ArrayBuffer so the Response constructor accepts the
+  // body (Uint8Array isn't directly assignable to BodyInit under TS 5.7+).
+  const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  mockedSafeFetch.mockResolvedValue(
+    new Response(buffer, { status: 200, headers: { "content-type": contentType } }),
+  );
+}
+
 describe("parseAucklandHussiesRow", () => {
   const refDate = new Date("2026-05-15T00:00:00Z");
 
@@ -106,5 +115,80 @@ describe("AucklandHussiesAdapter.fetch", () => {
     expect(hares).toContain("Demon");
     expect(hares).toContain("Triple One & Cross Dresser");
     expect(result.diagnosticContext?.rowsConsidered).toBe(3);
+  });
+
+  it("decodes windows-1252 bytes (NBSP = 0xA0) without U+FFFD leakage (#1506)", async () => {
+    // The live source ships bytes like:
+    //   <td>With the men on a Monday night<span ...>\xA0 </span>- 4pm</td>
+    // and declares the encoding only via `<meta charset=windows-1252>`. The
+    // previous fetchHTMLPage path decoded as UTF-8 and the 0xA0 NBSP became
+    // U+FFFD ("Monday night� - 4pm"). Build the exact byte sequence here.
+    const head = Buffer.from(
+      '<!DOCTYPE html><html><head><meta http-equiv=Content-Type content="text/html; charset=windows-1252"></head>' +
+        "<body><table>" +
+        // Row 1: location cell exercises the windows-1252 NBSP (0xA0) byte
+        // that the previous fetchHTMLPage path turned into U+FFFD.
+        "<tr><td>1-Jun</td><td></td><td></td><td>TBA</td><td>With the men on a Monday night",
+      "ascii",
+    );
+    const nbspSpan = Buffer.from([
+      0x3c, 0x73, 0x70, 0x61, 0x6e, 0x3e, // <span>
+      0xa0,                                // windows-1252 NBSP (would be U+FFFD if decoded as UTF-8)
+      0x20,                                // space
+      0x3c, 0x2f, 0x73, 0x70, 0x61, 0x6e, 0x3e, // </span>
+    ]);
+    // Row 2: hare cell contains a windows-1252 0xE9 byte (`é`) — proves the
+    // decode actually picked windows-1252, not UTF-8 + U+FFFD scrubbing
+    // (which would erase 0xE9 too instead of converting it to "é").
+    const cafeRowAscii = Buffer.from(
+      "- 4pm</td><td></td></tr>" +
+        "<tr><td>8-Jun</td><td></td><td></td><td>",
+      "ascii",
+    );
+    const cafeRowBytes = Buffer.from([
+      // "Caf" + 0xE9 (windows-1252 é) + "" (no extra chars)
+      0x43, 0x61, 0x66, 0xe9,
+    ]);
+    const cafeRowTail = Buffer.from(
+      " & Friends</td><td>1 Beach Rd, Mission Bay</td></tr></table></body></html>",
+      "ascii",
+    );
+    const bytes = Buffer.concat([head, nbspSpan, cafeRowAscii, cafeRowBytes, cafeRowTail]);
+
+    mockFetchBytes(new Uint8Array(bytes));
+    const adapter = new AucklandHussiesAdapter();
+    const result = await adapter.fetch(makeSource(), { days: 365 });
+
+    expect(result.errors).toEqual([]);
+    expect(result.events.length).toBe(2);
+    const [first, second] = result.events;
+    expect(first.location).toBeDefined();
+    expect(first.location).not.toContain("�");
+    expect(first.location).toBe("With the men on a Monday night - 4pm");
+    // TBA → undefined is the intentional placeholder behaviour, shared with
+    // Geriatrix's "Hare Required" handling. Documented here so the contract
+    // doesn't silently flip back to populating placeholders.
+    expect(first.hares).toBeUndefined();
+    // Decode must actually round-trip 0xE9 to "é" — not strip-as-U+FFFD,
+    // which would erroneously pass the no-U+FFFD assertion on row 1.
+    expect(second.hares).toBe("Café & Friends");
+    expect(second.hares).not.toContain("�");
+  });
+
+  it("prefers the Content-Type header charset when it is present", async () => {
+    // If the header advertises utf-8, trust the header (proper bytes) and
+    // skip the meta-tag sniff. Modern servers do this; the legacy Auckland
+    // Hussies Apache config doesn't.
+    const utf8 = Buffer.from(
+      '<!DOCTYPE html><html><body><table>' +
+        '<tr><td>5-May</td><td></td><td></td><td>Triple One</td><td>Café corner</td></tr>' +
+        '</table></body></html>',
+      "utf8",
+    );
+    mockFetchBytes(new Uint8Array(utf8), "text/html; charset=utf-8");
+    const adapter = new AucklandHussiesAdapter();
+    const result = await adapter.fetch(makeSource(), { days: 365 });
+    expect(result.events.length).toBe(1);
+    expect(result.events[0].location).toBe("Café corner");
   });
 });

--- a/src/adapters/html-scraper/auckland-hussies.ts
+++ b/src/adapters/html-scraper/auckland-hussies.ts
@@ -52,17 +52,40 @@ const DATE_CELL_RE = /^\s*(\d{1,2})-([A-Za-z]{3})\s*$/;
 // charset from header → meta → fallback to windows-1252.
 const META_CHARSET_RE = /<meta[^>]+charset\s*=\s*["']?([\w-]+)/i;
 const CONTENT_TYPE_CHARSET_RE = /charset\s*=\s*"?([\w-]+)"?/i;
+const FALLBACK_CHARSET = "windows-1252";
+
+// Cap on the response body we'll buffer into memory. The live source is
+// ~56KB; 2MB leaves plenty of headroom for growth while bounding the worst
+// case if the upstream ever serves a malformed or hostile payload.
+const MAX_BODY_BYTES = 2 * 1024 * 1024;
 
 function detectCharset(bytes: Uint8Array, contentType: string | null): string {
   if (contentType) {
     const m = CONTENT_TYPE_CHARSET_RE.exec(contentType);
     if (m) return m[1].toLowerCase();
   }
-  // Scan the first ~2KB as ASCII for a <meta charset> declaration.
-  const head = new TextDecoder("ascii", { fatal: false }).decode(bytes.subarray(0, 2048));
+  // Scan the first ~2KB for a <meta charset> declaration. UTF-8 is ASCII-
+  // compatible (and the WHATWG-recommended label), so it safely decodes
+  // any all-ASCII meta-tag prefix even when the body itself isn't UTF-8.
+  const head = new TextDecoder("utf-8", { fatal: false }).decode(bytes.subarray(0, 2048));
   const m1 = META_CHARSET_RE.exec(head);
   if (m1) return m1[1].toLowerCase();
-  return "windows-1252";
+  return FALLBACK_CHARSET;
+}
+
+/** Wrap `new TextDecoder(label)` so a bogus charset (from a malformed
+ *  meta tag) falls back to windows-1252 with a warning instead of
+ *  throwing RangeError and killing the scrape. */
+function makeDecoder(label: string): TextDecoder {
+  try {
+    return new TextDecoder(label, { fatal: false });
+  } catch (err) {
+    console.warn(
+      `[auckland-hussies] Unsupported charset label "${label}" — falling back to ${FALLBACK_CHARSET}`,
+      err,
+    );
+    return new TextDecoder(FALLBACK_CHARSET, { fatal: false });
+  }
 }
 
 interface FetchSuccess {
@@ -90,9 +113,28 @@ async function fetchCharsetAwareHTMLPage(url: string): Promise<FetchOutcome> {
         },
       };
     }
+    // Reject oversized payloads up-front when the server tells us the size.
+    // Without this, a hostile/misbehaving origin could push the response
+    // arbitrarily large before we ever decode.
+    const declaredLength = Number(response.headers.get("content-length") ?? "");
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+      const message = `Response too large: ${declaredLength} bytes > ${MAX_BODY_BYTES} cap`;
+      return {
+        ok: false,
+        result: { events: [], errors: [message], errorDetails: { fetch: [{ url, message }] } },
+      };
+    }
     const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > MAX_BODY_BYTES) {
+      // Belt-and-suspenders for servers that omit Content-Length.
+      const message = `Response too large: ${bytes.byteLength} bytes > ${MAX_BODY_BYTES} cap`;
+      return {
+        ok: false,
+        result: { events: [], errors: [message], errorDetails: { fetch: [{ url, message }] } },
+      };
+    }
     const charset = detectCharset(bytes, response.headers.get("content-type"));
-    const html = new TextDecoder(charset, { fatal: false }).decode(bytes);
+    const html = makeDecoder(charset).decode(bytes);
     return {
       ok: true,
       $: cheerio.load(html),

--- a/src/adapters/html-scraper/auckland-hussies.ts
+++ b/src/adapters/html-scraper/auckland-hussies.ts
@@ -1,4 +1,4 @@
-import type * as cheerio from "cheerio";
+import * as cheerio from "cheerio";
 import type { AnyNode } from "domhandler";
 import type { Source } from "@/generated/prisma/client";
 import type {
@@ -12,10 +12,11 @@ import {
   buildDateWindow,
   bumpYearIfBefore,
   chronoParseDate,
-  fetchHTMLPage,
   normalizeHaresField,
   stripPlaceholder,
 } from "../utils";
+import { safeFetch } from "../safe-fetch";
+import { generateStructureHash } from "@/pipeline/structure-hash";
 
 /**
  * Auckland Hussies HTML Scraper
@@ -28,12 +29,93 @@ import {
  *
  * Year inference uses refDate-year + monotonic-walk year bump across the
  * chronologically-sorted run list, so a Dec → Jan rollover correctly maps
- * the January row into next year.
+ * the January run into next year.
+ *
+ * Encoding: the source emits windows-1252 bytes (NBSP = 0xA0, smart quotes)
+ * but declares the charset only in `<meta http-equiv=Content-Type ...>` —
+ * never in the HTTP header. We bypass `fetchHTMLPage` (which assumes UTF-8
+ * via `response.text()`) and use {@link fetchCharsetAwareHTMLPage} to read
+ * the bytes, sniff the charset from header → meta tag → windows-1252
+ * fallback, and decode accordingly. See #1506.
  */
 
 // Allowed date shapes in column 0 — strict `D[D]-MMM` to avoid grabbing
 // stray text like "021-420209" (phone numbers in adjacent rows).
 const DATE_CELL_RE = /^\s*(\d{1,2})-([A-Za-z]{3})\s*$/;
+
+// The source is an Excel "Save as Web Page" export that emits windows-1252
+// bytes (NBSP = 0xA0, smart quotes, etc.) and declares the encoding only in
+// a `<meta http-equiv=Content-Type content="text/html; charset=windows-1252">`
+// tag — the HTTP Content-Type header itself omits the charset. The default
+// `response.text()` decodes as UTF-8 and silently turns each high byte into
+// U+FFFD ("With the men on a Monday night� - 4pm" — #1506). Detect the
+// charset from header → meta → fallback to windows-1252.
+const META_CHARSET_RE = /<meta[^>]+charset\s*=\s*["']?([\w-]+)/i;
+const CONTENT_TYPE_CHARSET_RE = /charset\s*=\s*"?([\w-]+)"?/i;
+
+function detectCharset(bytes: Uint8Array, contentType: string | null): string {
+  if (contentType) {
+    const m = CONTENT_TYPE_CHARSET_RE.exec(contentType);
+    if (m) return m[1].toLowerCase();
+  }
+  // Scan the first ~2KB as ASCII for a <meta charset> declaration.
+  const head = new TextDecoder("ascii", { fatal: false }).decode(bytes.subarray(0, 2048));
+  const m1 = META_CHARSET_RE.exec(head);
+  if (m1) return m1[1].toLowerCase();
+  return "windows-1252";
+}
+
+interface FetchSuccess {
+  ok: true;
+  $: cheerio.CheerioAPI;
+  structureHash: string;
+  fetchDurationMs: number;
+}
+type FetchOutcome = FetchSuccess | { ok: false; result: ScrapeResult };
+
+async function fetchCharsetAwareHTMLPage(url: string): Promise<FetchOutcome> {
+  const fetchStart = Date.now();
+  try {
+    const response = await safeFetch(url, {
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+    });
+    if (!response.ok) {
+      const message = `HTTP ${response.status}: ${response.statusText}`;
+      return {
+        ok: false,
+        result: {
+          events: [],
+          errors: [message],
+          errorDetails: { fetch: [{ url, status: response.status, message }] },
+        },
+      };
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const charset = detectCharset(bytes, response.headers.get("content-type"));
+    const html = new TextDecoder(charset, { fatal: false }).decode(bytes);
+    return {
+      ok: true,
+      $: cheerio.load(html),
+      structureHash: generateStructureHash(html),
+      fetchDurationMs: Date.now() - fetchStart,
+    };
+  } catch (err) {
+    const message = `Fetch failed: ${err}`;
+    return {
+      ok: false,
+      result: { events: [], errors: [message], errorDetails: { fetch: [{ url, message }] } },
+    };
+  }
+}
+
+/** Drop U+FFFD (only fires if the meta-tag sniff ever picks the wrong
+ *  charset) and collapse whitespace runs — including U+00A0 NBSP that
+ *  cheerio leaves verbatim — so the saved cell reads as one sentence. */
+function cleanCellText(text: string | undefined): string | undefined {
+  if (text == null) return undefined;
+  const cleaned = text.replaceAll('\uFFFD', '').replace(/\s+/g, ' ').trim();
+  return cleaned || undefined;
+}
 
 export interface AucklandHussiesParsedRow {
   dateText: string;
@@ -98,7 +180,11 @@ function extractRunRowCells(
   if (cells.length < 5) return null;
   const dateCell = cells.at(0)?.trim() ?? "";
   if (!DATE_CELL_RE.test(dateCell)) return null;
-  return { dateText: dateCell, hareText: cells.at(3), locationText: cells.at(4) };
+  return {
+    dateText: dateCell,
+    hareText: cleanCellText(cells.at(3)),
+    locationText: cleanCellText(cells.at(4)),
+  };
 }
 
 export class AucklandHussiesAdapter implements SourceAdapter {
@@ -118,7 +204,7 @@ export class AucklandHussiesAdapter implements SourceAdapter {
     }
     const { kennelTag } = source.config;
 
-    const page = await fetchHTMLPage(sourceUrl);
+    const page = await fetchCharsetAwareHTMLPage(sourceUrl);
     if (!page.ok) return page.result;
     const { $, structureHash, fetchDurationMs } = page;
 

--- a/src/adapters/html-scraper/geriatrix-h3.test.ts
+++ b/src/adapters/html-scraper/geriatrix-h3.test.ts
@@ -52,6 +52,27 @@ describe("parseGeriatrixParagraphs", () => {
     expect(rows[1].mapUrl).toBe("https://maps.app.goo.gl/fFAQ9tVgaTAj97qm6");
   });
 
+  it("accepts both singular 'Hare:' and plural 'Hares:' labels (#1501)", () => {
+    // Regression: source switches between "Hare:" (one trail-setter) and
+    // "Hares:" (multiple), and the previous `\b`-anchored gate dropped the
+    // plural form because `\b` doesn't match between 'e' and 's' inside
+    // "Hares". TBA-venue rows in #1501 had hares disappear for that reason.
+    const rows = parseGeriatrixParagraphs([
+      { text: "26/05/2026" },
+      { text: "Venue: TBA" },
+      { text: "Hares: Flatbitz & Browneye" },
+      { text: "Map:" },
+      { text: "02/06/2026" },
+      { text: "Venue: TBA" },
+      { text: "Hares: Cheeky & Fishy Fingers" },
+      { text: "Map:" },
+    ]);
+    expect(rows.length).toBe(2);
+    expect(rows[0].hare).toBe("Flatbitz & Browneye");
+    expect(rows[0].venue).toBeUndefined();
+    expect(rows[1].hare).toBe("Cheeky & Fishy Fingers");
+  });
+
   it("normalises TBA/Hare Required placeholders to undefined", () => {
     const rows = parseGeriatrixParagraphs([
       { text: "19/05/2026" },

--- a/src/adapters/html-scraper/geriatrix-h3.ts
+++ b/src/adapters/html-scraper/geriatrix-h3.ts
@@ -79,14 +79,20 @@ export function parseGeriatrixParagraphs(
       continue;
     }
     if (!current) continue;
-    if (/^\s*venue\b/i.test(p.text)) {
+    // Accept "Hare:" AND "Hares:" — sporty editors swap labels depending on
+    // trail-setter count. We capture the actual matched label so the slice
+    // in valueAfterLabel lands at the right offset.
+    const labelMatch = /^\s*(venue|hares?|map)\b/i.exec(p.text);
+    if (!labelMatch) continue;
+    const label = labelMatch[1].toLowerCase();
+    if (label === "venue") {
       current.venue = valueAfterLabel(p.text, "Venue");
-    } else if (/^\s*hare\b/i.test(p.text)) {
-      current.hare = valueAfterLabel(p.text, "Hare");
-    } else if (/^\s*map\b/i.test(p.text)) {
-      // Prefer the <a href> over the visible text — visible text on Geriatrix
+    } else if (label === "map") {
+      // Prefer the <a href> over visible text — visible text on Geriatrix
       // duplicates the URL but may be visually truncated.
       current.mapUrl = p.firstHref ?? valueAfterLabel(p.text, "Map");
+    } else {
+      current.hare = valueAfterLabel(p.text, labelMatch[1]);
     }
   }
   if (current) out.push(current);

--- a/src/adapters/html-scraper/geriatrix-h3.ts
+++ b/src/adapters/html-scraper/geriatrix-h3.ts
@@ -62,6 +62,32 @@ export interface ParsedGeriatrixRow {
   mapUrl?: string;
 }
 
+// Accept "Hare:" AND "Hares:" — sporty editors swap labels depending on
+// trail-setter count. The captured label is passed back to valueAfterLabel
+// so the slice lands at the right offset.
+const GERIATRIX_LABEL_RE = /^\s*(venue|hares?|map)\b/i;
+
+/** Apply one non-date paragraph to the in-progress row by matching its
+ *  label prefix. Extracted from {@link parseGeriatrixParagraphs} to keep
+ *  that function under Sonar S3776's cognitive-complexity threshold. */
+function applyGeriatrixLabel(
+  row: ParsedGeriatrixRow,
+  p: { text: string; firstHref?: string },
+): void {
+  const labelMatch = GERIATRIX_LABEL_RE.exec(p.text);
+  if (!labelMatch) return;
+  const label = labelMatch[1].toLowerCase();
+  if (label === "venue") {
+    row.venue = valueAfterLabel(p.text, "Venue");
+  } else if (label === "map") {
+    // Prefer the <a href> over visible text — Geriatrix duplicates the
+    // URL into the visible text but it may be visually truncated.
+    row.mapUrl = p.firstHref ?? valueAfterLabel(p.text, "Map");
+  } else {
+    row.hare = valueAfterLabel(p.text, labelMatch[1]);
+  }
+}
+
 /** Walk the ordered `<p>` list and group consecutive runs into 4-line
  *  blocks anchored by a DD/MM/YYYY paragraph. Exported for unit tests. */
 export function parseGeriatrixParagraphs(
@@ -76,23 +102,8 @@ export function parseGeriatrixParagraphs(
     if (dateIso) {
       if (current) out.push(current);
       current = { date: dateIso };
-      continue;
-    }
-    if (!current) continue;
-    // Accept "Hare:" AND "Hares:" — sporty editors swap labels depending on
-    // trail-setter count. We capture the actual matched label so the slice
-    // in valueAfterLabel lands at the right offset.
-    const labelMatch = /^\s*(venue|hares?|map)\b/i.exec(p.text);
-    if (!labelMatch) continue;
-    const label = labelMatch[1].toLowerCase();
-    if (label === "venue") {
-      current.venue = valueAfterLabel(p.text, "Venue");
-    } else if (label === "map") {
-      // Prefer the <a href> over visible text — visible text on Geriatrix
-      // duplicates the URL but may be visually truncated.
-      current.mapUrl = p.firstHref ?? valueAfterLabel(p.text, "Map");
-    } else {
-      current.hare = valueAfterLabel(p.text, labelMatch[1]);
+    } else if (current) {
+      applyGeriatrixLabel(current, p);
     }
   }
   if (current) out.push(current);

--- a/src/adapters/html-scraper/mooloo-hhh.test.ts
+++ b/src/adapters/html-scraper/mooloo-hhh.test.ts
@@ -31,7 +31,7 @@ function makeSource(overrides: Partial<Source> = {}): Source {
 describe("parseMoolooRunLine", () => {
   const opts = { sourceUrl: "https://www.sporty.co.nz/mooloohhh/UpCumming-Runs", kennelTag: "mooloo-h3" };
 
-  it("parses the canonical 'DD Mon YYYY RUN# NNNN <body>' format", () => {
+  it("parses the canonical 'DD Mon YYYY RUN# NNNN <body>' format (#1505)", () => {
     const ev = parseMoolooRunLine(
       "25 May 2026 RUN# 1886 Tittannic's Trail from ReefUnder and Shunter's 8 Joffre St. 6PM.",
       opts,
@@ -40,8 +40,37 @@ describe("parseMoolooRunLine", () => {
     expect(ev!.date).toBe("2026-05-25");
     expect(ev!.runNumber).toBe(1886);
     expect(ev!.startTime).toBe("18:00");
+    // Hare = name before "'s Trail" (Tittannic). The "from ReefUnder and
+    // Shunter's" suffix names the *hosts* (whose place the trail starts
+    // from), not the hare; they're preserved verbatim in description.
+    expect(ev!.hares).toBe("Tittannic");
+    expect(ev!.locationStreet).toBe("8 Joffre St");
     expect(ev!.description).toContain("Tittannic's Trail");
+    expect(ev!.description).toContain("ReefUnder and Shunter");
     expect(ev!.kennelTags).toEqual(["mooloo-h3"]);
+  });
+
+  it("captures multi-word and hyphenated hare names before \"'s Trail\"", () => {
+    // Hash names with spaces, hyphens, or digits are common — single-token
+    // capture would silently drop them. Each case below has a different
+    // hare-name shape; description should still preserve the full body.
+    expect(parseMoolooRunLine("25 May 2026 RUN# 1900 Mr Ed's Trail 1 Bridge Rd. 6PM.", opts)!.hares)
+      .toBe("Mr Ed");
+    expect(parseMoolooRunLine("25 May 2026 RUN# 1901 No More's Trail 2 Main St. 6PM.", opts)!.hares)
+      .toBe("No More");
+    expect(parseMoolooRunLine("25 May 2026 RUN# 1902 Dog-Food's Trail 3 Park Ave. 6PM.", opts)!.hares)
+      .toBe("Dog-Food");
+  });
+
+  it("leaves hares/locationStreet undefined when body lacks the Trail/address idioms", () => {
+    // "At ToeTruck's" is a host-place form (no "'s Trail"), and no street
+    // number appears in the body — both extractors should bail cleanly.
+    const ev = parseMoolooRunLine("1 Jun 2026 RUN#1887 At ToeTruck's 6:30pm", opts);
+    expect(ev).not.toBeNull();
+    expect(ev!.runNumber).toBe(1887);
+    expect(ev!.startTime).toBe("18:30");
+    expect(ev!.hares).toBeUndefined();
+    expect(ev!.locationStreet).toBeUndefined();
   });
 
   it("tolerates RUN# with no space + spelling variants", () => {

--- a/src/adapters/html-scraper/mooloo-hhh.ts
+++ b/src/adapters/html-scraper/mooloo-hhh.ts
@@ -14,11 +14,13 @@ import { runSportyAdapter } from "./sporty-co-nz";
  *
  * We extract every `<p>` line that matches that prefix pattern (date +
  * "RUN# NNNN" + free-form body). Run number and date drive Event identity;
- * a 12-hour time mention drives `startTime`. The remainder of the line
- * becomes the `description` so users can see venue/hare verbatim — we
- * deliberately don't try to split hares from address (the trailing prose
- * is too messy to parse reliably; the paired STATIC_SCHEDULE source
- * supplies the biweekly recurrence anyway).
+ * a 12-hour time mention drives `startTime`. The body also gets two
+ * conservative tokenizers applied (#1505):
+ *   - hare = the name preceding "'s Trail" (so "Tittannic's Trail from
+ *     ReefUnder and Shunter's" yields hare=Tittannic, not the hosts)
+ *   - locationStreet = a numeric street address like "8 Joffre St"
+ * The full body still goes into `description` so hosts and any free-form
+ * context the source author included aren't lost.
  *
  * Cloudflare bypass + boilerplate is delegated to {@link runSportyAdapter}.
  */
@@ -26,6 +28,24 @@ import { runSportyAdapter } from "./sporty-co-nz";
 // "DD Mon YYYY RUN# NNNN <body>". Tolerant of unicode dashes and
 // "RUN#NNNN" / "RUN # NNNN" spacing. Trailing period stripped post-match.
 const MOOLOO_RUN_LINE_RE = /^(\d{1,2}\s+[A-Za-z]{3,9}\s+\d{4})\s+RUN\s*#?\s*(\d+)\s+(.+?)\.?\s*$/; // NOSONAR S5852
+
+// Hare = the name preceding "'s Trail" in the free-form body. The source
+// authors consistently use the possessive-Trail idiom for the trail-setter
+// ("Tittannic's Trail from ReefUnder and Shunter's 8 Joffre St.") and
+// "from <Hosts>" / "at <Hosts>'s" for the people whose place the trail
+// starts from. We deliberately only extract the "<Name>'s Trail" form so
+// hosts aren't mislabelled as hares; the full body remains in description.
+//
+// `[\w \-]` accepts multi-word hash names ("Mr Ed", "No More", "Dog-Food")
+// without admitting apostrophes (which would race the trailing `'s`).
+// Bounded to 40 chars to keep this backtrack-safe under Sonar S5852.
+const MOOLOO_HARE_RE = /^([A-Za-z][\w \-]{0,40})'s\s+Trail\b/i;
+
+// Street address shape: 1–4 digit street number + 1–4 capitalised words +
+// a NZ/AU/UK street-type suffix. Bounded quantifiers + leading word
+// boundary keep this Sonar S5852-safe and prevent grabbing run numbers
+// or distances mid-sentence.
+const MOOLOO_ADDRESS_RE = /\b(\d{1,4}(?:\s+[A-Z][\w']+){1,4}\s+(?:St|Rd|Ave|Cres|Way|Dr|Pl|Cl|Ln|Cct|Blvd|Tce|Crt|Ct|Pde|Lane|Street|Road|Avenue|Drive|Place|Close))\.?(?=$|[\s,])/;
 
 /** Pull a 12-hour time out of free-form text, normalizing bare-hour forms
  *  like "6PM" / "6 pm" (which parse12HourTime requires minutes for) into
@@ -36,6 +56,16 @@ function extractStartTime(text: string): string | undefined {
   const raw = match[1].trim();
   const normalized = raw.includes(":") ? raw : raw.replace(/(\d{1,2})\s*([ap]m)/i, "$1:00 $2");
   return parse12HourTime(normalized);
+}
+
+function extractHares(body: string): string | undefined {
+  const m = MOOLOO_HARE_RE.exec(body);
+  return m ? m[1] : undefined;
+}
+
+function extractStreetAddress(body: string): string | undefined {
+  const m = MOOLOO_ADDRESS_RE.exec(body);
+  return m ? m[1] : undefined;
 }
 
 /** Parse one Mooloo run-line `<p>` text into a RawEventData, or null. Exported for unit tests. */
@@ -59,6 +89,8 @@ export function parseMoolooRunLine(
     kennelTags: [opts.kennelTag],
     runNumber: Number.isFinite(runNumber) ? runNumber : undefined,
     startTime: extractStartTime(body),
+    hares: extractHares(body),
+    locationStreet: extractStreetAddress(body),
     description: body,
     sourceUrl: opts.sourceUrl,
   };

--- a/src/adapters/html-scraper/mooloo-hhh.ts
+++ b/src/adapters/html-scraper/mooloo-hhh.ts
@@ -36,16 +36,27 @@ const MOOLOO_RUN_LINE_RE = /^(\d{1,2}\s+[A-Za-z]{3,9}\s+\d{4})\s+RUN\s*#?\s*(\d+
 // starts from. We deliberately only extract the "<Name>'s Trail" form so
 // hosts aren't mislabelled as hares; the full body remains in description.
 //
-// `[\w \-]` accepts multi-word hash names ("Mr Ed", "No More", "Dog-Food")
+// `[\w -]` accepts multi-word hash names ("Mr Ed", "No More", "Dog-Food")
 // without admitting apostrophes (which would race the trailing `'s`).
-// Bounded to 40 chars to keep this backtrack-safe under Sonar S5852.
-const MOOLOO_HARE_RE = /^([A-Za-z][\w \-]{0,40})'s\s+Trail\b/i;
+// `\w` already covers a-z/A-Z/0-9/_ — no separate `[A-Za-z]` anchor needed
+// under /i (S5869). Bounded to 40 chars to stay backtrack-safe (S5852).
+const MOOLOO_HARE_RE = /^([A-Z][\w -]{0,40})'s\s+Trail\b/i;
 
 // Street address shape: 1–4 digit street number + 1–4 capitalised words +
-// a NZ/AU/UK street-type suffix. Bounded quantifiers + leading word
-// boundary keep this Sonar S5852-safe and prevent grabbing run numbers
+// a final word that we post-check against {@link STREET_SUFFIXES}. The
+// post-check keeps the regex complexity under Sonar S5843's threshold of
+// 20 (the alternation list alone pushed it to 35). Bounded quantifiers +
+// leading word boundary stay S5852-safe and avoid grabbing run numbers
 // or distances mid-sentence.
-const MOOLOO_ADDRESS_RE = /\b(\d{1,4}(?:\s+[A-Z][\w']+){1,4}\s+(?:St|Rd|Ave|Cres|Way|Dr|Pl|Cl|Ln|Cct|Blvd|Tce|Crt|Ct|Pde|Lane|Street|Road|Avenue|Drive|Place|Close))\.?(?=$|[\s,])/;
+const MOOLOO_ADDRESS_RE = /\b(\d{1,4}\s+(?:[A-Z][\w']+\s+){1,4}[A-Za-z]+)\.?(?=$|[\s,])/;
+
+const STREET_SUFFIXES = new Set(
+  [
+    "St", "Rd", "Ave", "Cres", "Way", "Dr", "Pl", "Cl", "Ln", "Cct", "Blvd",
+    "Tce", "Crt", "Ct", "Pde", "Lane", "Street", "Road", "Avenue", "Drive",
+    "Place", "Close",
+  ].map((s) => s.toLowerCase()),
+);
 
 /** Pull a 12-hour time out of free-form text, normalizing bare-hour forms
  *  like "6PM" / "6 pm" (which parse12HourTime requires minutes for) into
@@ -65,7 +76,10 @@ function extractHares(body: string): string | undefined {
 
 function extractStreetAddress(body: string): string | undefined {
   const m = MOOLOO_ADDRESS_RE.exec(body);
-  return m ? m[1] : undefined;
+  if (!m) return undefined;
+  const lastWord = m[1].split(/\s+/).pop();
+  if (!lastWord || !STREET_SUFFIXES.has(lastWord.toLowerCase())) return undefined;
+  return m[1];
 }
 
 /** Parse one Mooloo run-line `<p>` text into a RawEventData, or null. Exported for unit tests. */


### PR DESCRIPTION
## Summary

Three independent NZ HTML_SCRAPER parse bugs bundled in one PR — all live-verified against the production sources.

- **Geriatrix H3 ([#1501](https://github.com/johnrclem/hashtracks-web/issues/1501))** — accept both `Hare:` and `Hares:` labels on the sporty.co.nz richtext-editor. The previous `\b`-anchored gate silently dropped the plural form, so every TBA-venue row's hares disappeared.
- **Mooloo HHH ([#1505](https://github.com/johnrclem/hashtracks-web/issues/1505))** — single-line tokenizer extracts hare (name before `'s Trail`) and street address from the freeform newsletter row. Hosts (`from ReefUnder and Shunter's`) stay in `description` rather than being mislabelled as hares.
- **Auckland Hussies ([#1506](https://github.com/johnrclem/hashtracks-web/issues/1506))** — windows-1252 source declared charset only via `<meta>`, so default UTF-8 decoding mangled `0xA0` NBSP into U+FFFD. Charset-aware fetch (`header → meta → windows-1252` fallback) + belt-and-suspenders U+FFFD/whitespace scrub.

## Live verification

Run against the production endpoints (`scripts/verify-nz-adapters.mjs`, deleted post-verification):

**Auckland Hussies — 9 events, 0 errors**
```
{ date: "2026-04-27", hares: "Butcher", location: "With the men on a Monday night - 4pm" }   ← no U+FFFD
{ date: "2026-05-12", hares: "Demon", location: "Chang Thai Café, Queens Road, Panmure" }    ← 0xE9 decoded
{ date: "2026-06-01", hares: undefined, location: "With the men on a Monday night - 4pm" }   ← TBA → undefined
```

**Mooloo HHH — 1 event, 0 errors**
```
{ date: "2026-05-25", runNumber: 1886, hares: "Tittannic", locationStreet: "8 Joffre St",
  startTime: "18:00", description: "Tittannic's Trail from ReefUnder and Shunter's 8 Joffre St. 6PM" }
```

**Geriatrix H3 — 8 events, 0 errors** (TBA-venue rows now populate hares)
```
{ date: "2026-05-26", hares: "Flatbitz & Browneye" }       ← was empty pre-fix
{ date: "2026-06-02", hares: "Cheeky & Fishy Fingers" }    ← was empty pre-fix
{ date: "2026-06-09", hares: undefined }                    ← "Hare Required" placeholder, undefined intentional
```

## Tests

24 adapter tests pass (8 Geriatrix, 9 Mooloo, 7 Auckland Hussies). New regression coverage:

- Geriatrix: plural `Hares:` label test ([#1501](https://github.com/johnrclem/hashtracks-web/issues/1501) regression)
- Mooloo: canonical single-line shape + multi-word hare names (`Mr Ed`, `No More`, `Dog-Food`) + no-`'s Trail` cases
- Auckland Hussies: byte-level fixture with `0xA0` (NBSP) + `0xE9` (`é`) windows-1252 bytes; asserts `é` survives decode (proves the path isn't UTF-8 + U+FFFD scrub) and that header-charset `utf-8` takes precedence over the meta tag

Full check suite green: `npx tsc --noEmit && npm run lint && npm test` → 258 test files / 6824 tests passing.

## Adversarial review notes

Pre-PR `/codex:adversarial-review` flagged two real issues addressed in the diff:

1. Initial `MOOLOO_HARE_RE = /^([A-Z]\w+)'s\s+Trail\b/i` was too narrow — multi-word hash names (`Mr Ed`, `No More`, `Dog-Food`) would silently miss. Widened to `[A-Za-z][\w \-]{0,40}` and added test coverage.
2. Initial Auckland Hussies encoding test only used `0xA0` (which `cleanCellText` strips alongside `U+FFFD`), so a broken UTF-8-decoder path could still pass. Added `0xE9` byte to fixture; assertion that `é` survives proves the windows-1252 path is actually exercised.

## Out of scope (deferred)

The reuse review flagged that `fetchCharsetAwareHTMLPage` could live in `src/adapters/utils.ts` and replace `fetchHTMLPage` / consolidate with `sdh3.ts`'s custom UTF-8-forcing fetch wrapper. Deferring — that's a separate refactor with its own design decisions (and `sdh3.ts` would need its own test updates).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors
- [x] `npm test` 6824 passing
- [x] Live-verify against `aucklandhussies.co.nz`, `sporty.co.nz/mooloohhh/UpCumming-Runs`, `sporty.co.nz/geriatrixhhh/Receding-Hareline/NewTab1`
- [x] `/codex:adversarial-review` + `/simplify` run pre-PR

Closes #1501
Closes #1505
Closes #1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)