### PR TITLE
fix(hash-horrors): scrape upcoming hareline page + BREAK handling (#1253)

### DIFF
--- a/src/adapters/html-scraper/hash-horrors.test.ts
+++ b/src/adapters/html-scraper/hash-horrors.test.ts
@@ -1,4 +1,8 @@
-import { parseHashHorrorsRunLine, parseHashHorrorsHareline } from "./hash-horrors";
+import {
+  parseHashHorrorsRunLine,
+  parseHashHorrorsHareline,
+  parseHashHorrorsUpcoming,
+} from "./hash-horrors";
 
 describe("parseHashHorrorsRunLine", () => {
   it("parses a complete line with run/date/hares/location", () => {
@@ -21,10 +25,46 @@ describe("parseHashHorrorsRunLine", () => {
     });
   });
 
+  it("keeps the full hare list when '&' joins two families (#1253 1016)", () => {
+    const out = parseHashHorrorsRunLine("1016 – May 17 – Wade & Child Families");
+    expect(out).toMatchObject({
+      runNumber: 1016,
+      hares: "Wade & Child Families",
+      location: undefined,
+    });
+  });
+
+  it("keeps hyphenated family names intact (#1253 1017)", () => {
+    const out = parseHashHorrorsRunLine("1017 – May 31 – Fanjul-Lemaistre Family");
+    expect(out).toMatchObject({
+      runNumber: 1017,
+      hares: "Fanjul-Lemaistre Family",
+      location: undefined,
+    });
+  });
+
+  it("flags BREAK markers with isBreak (#1253 1018)", () => {
+    const out = parseHashHorrorsRunLine("1018 – June 14 – Hash Committee BREAK");
+    expect(out).toMatchObject({ runNumber: 1018, isBreak: true });
+    expect(out?.hares).toBeUndefined();
+  });
+
   it("treats 'Hares Needed' as no hares", () => {
     const out = parseHashHorrorsRunLine("1014 – April 19 – Hares Needed");
     expect(out?.hares).toBeUndefined();
     expect(out?.runNumber).toBe(1014);
+  });
+
+  it("treats '*Hares Needed*' (asterisk-wrapped) as no hares (#1253 1019)", () => {
+    const out = parseHashHorrorsRunLine("1019 – August 9 – *Hares Needed*");
+    expect(out?.hares).toBeUndefined();
+    expect(out?.runNumber).toBe(1019);
+  });
+
+  it("treats '***Hares Needed***' (triple-asterisk) as no hares", () => {
+    const out = parseHashHorrorsRunLine("1020 – August 23 – ***Hares Needed***");
+    expect(out?.hares).toBeUndefined();
+    expect(out?.runNumber).toBe(1020);
   });
 
   it("preserves multi-family hare lists with internal em dashes by splitting on the LAST one", () => {
@@ -37,16 +77,52 @@ describe("parseHashHorrorsRunLine", () => {
     expect(out?.location).toBe("Pearl Hill & Chinatown");
   });
 
+  it("tolerates ordinal day suffixes used in the pre-2018 archive", () => {
+    const out = parseHashHorrorsRunLine("890 – September 23rd – Fire Tornado & Liu Family – Dempsey Road");
+    expect(out).toMatchObject({
+      runNumber: 890,
+      monthIdx: 9,
+      day: 23,
+      hares: "Fire Tornado & Liu Family",
+      location: "Dempsey Road",
+    });
+  });
+
+  it("captures parenthetical themed-run titles after the day", () => {
+    const out = parseHashHorrorsRunLine(
+      "985 – December 15 (Christmas Hash) – Poyner Family – Gillman Barracks",
+    );
+    expect(out).toMatchObject({
+      runNumber: 985,
+      monthIdx: 12,
+      day: 15,
+      theme: "Christmas Hash",
+      hares: "Poyner Family",
+      location: "Gillman Barracks",
+    });
+  });
+
+  it("tolerates a missing space before the leading dash (legacy archive rows)", () => {
+    const out = parseHashHorrorsRunLine("881 -May 20th – Harvie Family – Seah Im");
+    expect(out).toMatchObject({
+      runNumber: 881,
+      monthIdx: 5,
+      day: 20,
+      hares: "Harvie Family",
+      location: "Seah Im",
+    });
+  });
+
   it("returns null on unparseable input", () => {
     expect(parseHashHorrorsRunLine("nothing useful here")).toBeNull();
   });
 });
 
-describe("parseHashHorrorsHareline", () => {
+describe("parseHashHorrorsHareline (year-grouped archive)", () => {
   it("walks year sections and emits one event per run line with the correct year", () => {
-    const text = "2026 1016 – May 17 – Wade Family 1015 – May 3 – Baudoux Family 2025 1006 – December 14 – Dew Family – Bukit Batok";
-    const events = parseHashHorrorsHareline(text).events;
-    expect(events.length).toBeGreaterThanOrEqual(3);
+    const text =
+      "2026 1016 – May 17 – Wade Family 1015 – May 3 – Baudoux Family 2025 1006 – December 14 – Dew Family – Bukit Batok";
+    const { events } = parseHashHorrorsHareline(text);
     const map = new Map(events.map((e) => [e.runNumber, e]));
     expect(map.get(1016)?.date).toBe("2026-05-17");
     expect(map.get(1015)?.date).toBe("2026-05-03");
@@ -56,15 +132,90 @@ describe("parseHashHorrorsHareline", () => {
 
   it("tags every event with kennelTag 'hhhorrors' and default startTime", () => {
     const text = "2026 1016 – May 17 – Wade Family";
-    const events = parseHashHorrorsHareline(text).events;
+    const { events } = parseHashHorrorsHareline(text);
     expect(events[0].kennelTags[0]).toBe("hhhorrors");
     expect(events[0].startTime).toBe("16:30");
   });
 
   it("ignores run lines that appear before any year heading", () => {
     const text = "1016 – May 17 – Wade Family 2026 1015 – May 3 – Baudoux Family";
-    const events = parseHashHorrorsHareline(text).events;
+    const { events } = parseHashHorrorsHareline(text);
     expect(events.find((e) => e.runNumber === 1016)).toBeUndefined();
     expect(events.find((e) => e.runNumber === 1015)?.date).toBe("2026-05-03");
+  });
+
+  it("counts BREAK rows as skippedMarkers, not skippedLines (no parse-error alert)", () => {
+    const text = "2026 1018 – June 14 – Hash Committee BREAK 1017 – May 31 – Fanjul-Lemaistre Family";
+    const out = parseHashHorrorsHareline(text);
+    expect(out.events.find((e) => e.runNumber === 1018)).toBeUndefined();
+    expect(out.events.find((e) => e.runNumber === 1017)?.hares).toBe("Fanjul-Lemaistre Family");
+    expect(out.skippedLines).toBe(0);
+    expect(out.skippedMarkers).toBe(1);
+  });
+
+  it("appends themed-run titles to the default kennel title", () => {
+    const text = "2015 985 – December 15 (Christmas Hash) – Poyner Family – Gillman Barracks";
+    const { events } = parseHashHorrorsHareline(text);
+    expect(events[0]).toMatchObject({
+      runNumber: 985,
+      title: "Hash Horrors 985 — Christmas Hash",
+    });
+  });
+});
+
+describe("parseHashHorrorsUpcoming (no year heading, current-year default)", () => {
+  // Live /hareline-2/ snapshot (2026-05-05): exercises every #1253 case in one fixture.
+  const liveFixture =
+    "1015 – May 3 – Baudoux, Guthrie and Poyner Families " +
+    "1016 – May 17 – Wade & Child Families " +
+    "1017 – May 31 – Fanjul-Lemaistre Family " +
+    "1018 – June 14 – Hash Committee BREAK " +
+    "1019 – August 9 – *Hares Needed*";
+
+  it("emits an event per upcoming run with the provided year", () => {
+    const { events } = parseHashHorrorsUpcoming(liveFixture, 2026);
+    const map = new Map(events.map((e) => [e.runNumber, e]));
+    expect(map.get(1015)).toMatchObject({
+      date: "2026-05-03",
+      hares: "Baudoux, Guthrie and Poyner Families",
+    });
+    expect(map.get(1016)).toMatchObject({
+      date: "2026-05-17",
+      hares: "Wade & Child Families",
+    });
+    expect(map.get(1017)).toMatchObject({
+      date: "2026-05-31",
+      hares: "Fanjul-Lemaistre Family",
+    });
+    // BREAK row is intentionally not emitted as a calendar event.
+    expect(map.get(1018)).toBeUndefined();
+    // *Hares Needed* normalises to no hares but the event still ships.
+    expect(map.get(1019)).toMatchObject({ date: "2026-08-09" });
+    expect(map.get(1019)?.hares).toBeUndefined();
+  });
+
+  it("counts BREAK as a marker, not a parse error", () => {
+    const out = parseHashHorrorsUpcoming(liveFixture, 2026);
+    expect(out.skippedLines).toBe(0);
+    expect(out.skippedMarkers).toBe(1);
+  });
+
+  it("rolls the year forward when the calendar date wraps backwards", () => {
+    // Hypothetical December-into-January transition.
+    const text = "1020 – December 6 – A Family 1021 – January 3 – B Family";
+    const { events } = parseHashHorrorsUpcoming(text, 2026);
+    const map = new Map(events.map((e) => [e.runNumber, e]));
+    expect(map.get(1020)?.date).toBe("2026-12-06");
+    expect(map.get(1021)?.date).toBe("2027-01-03");
+  });
+
+  it("keeps rollover detection in sync when a BREAK row falls between calendar months", () => {
+    // BREAK in the middle of the sequence must still update prev-month state so a
+    // downstream Jan row after a Dec BREAK rolls the year.
+    const text =
+      "1020 – December 6 – A Family 1021 – December 20 – Committee BREAK 1022 – January 3 – B Family";
+    const { events } = parseHashHorrorsUpcoming(text, 2026);
+    expect(events.find((e) => e.runNumber === 1021)).toBeUndefined();
+    expect(events.find((e) => e.runNumber === 1022)?.date).toBe("2027-01-03");
   });
 });

--- a/src/adapters/html-scraper/hash-horrors.test.ts
+++ b/src/adapters/html-scraper/hash-horrors.test.ts
@@ -88,6 +88,30 @@ describe("parseHashHorrorsRunLine", () => {
     });
   });
 
+  it("parses day-first format with ordinal suffix used in the 2018-2019 rewrite", () => {
+    const out = parseHashHorrorsRunLine("952 – 9th April – Merette Family – Bukit Timah MTB Trail");
+    expect(out).toMatchObject({
+      runNumber: 952,
+      monthIdx: 4,
+      day: 9,
+      hares: "Merette Family",
+      location: "Bukit Timah MTB Trail",
+    });
+  });
+
+  it("parses day-first format with inline year + ordinal", () => {
+    const out = parseHashHorrorsRunLine("897 – 13th January – Jonas Family – Old Holland and Blakemore Dr. 2018");
+    expect(out).toMatchObject({
+      runNumber: 897,
+      monthIdx: 1,
+      day: 13,
+      hares: "Jonas Family",
+    });
+    // Trailing year inside location text stays in the location field (no
+    // procedural strip after the tail).
+    expect(out?.location).toContain("Old Holland");
+  });
+
   it("captures parenthetical themed-run titles after the day", () => {
     const out = parseHashHorrorsRunLine(
       "985 – December 15 (Christmas Hash) – Poyner Family – Gillman Barracks",
@@ -173,7 +197,8 @@ describe("parseHashHorrorsUpcoming (no year heading, current-year default)", () 
     "1019 – August 9 – *Hares Needed*";
 
   it("emits an event per upcoming run with the provided year", () => {
-    const { events } = parseHashHorrorsUpcoming(liveFixture, 2026);
+    // Scrape on 2026-05-05 → currentYear=2026, currentMonth=5.
+    const { events } = parseHashHorrorsUpcoming(liveFixture, 2026, 5);
     const map = new Map(events.map((e) => [e.runNumber, e]));
     expect(map.get(1015)).toMatchObject({
       date: "2026-05-03",
@@ -195,15 +220,15 @@ describe("parseHashHorrorsUpcoming (no year heading, current-year default)", () 
   });
 
   it("counts BREAK as a marker, not a parse error", () => {
-    const out = parseHashHorrorsUpcoming(liveFixture, 2026);
+    const out = parseHashHorrorsUpcoming(liveFixture, 2026, 5);
     expect(out.skippedLines).toBe(0);
     expect(out.skippedMarkers).toBe(1);
   });
 
   it("rolls the year forward when the calendar date wraps backwards", () => {
-    // Hypothetical December-into-January transition.
+    // Hypothetical December-into-January transition (Dec scrape).
     const text = "1020 – December 6 – A Family 1021 – January 3 – B Family";
-    const { events } = parseHashHorrorsUpcoming(text, 2026);
+    const { events } = parseHashHorrorsUpcoming(text, 2026, 12);
     const map = new Map(events.map((e) => [e.runNumber, e]));
     expect(map.get(1020)?.date).toBe("2026-12-06");
     expect(map.get(1021)?.date).toBe("2027-01-03");
@@ -214,8 +239,26 @@ describe("parseHashHorrorsUpcoming (no year heading, current-year default)", () 
     // downstream Jan row after a Dec BREAK rolls the year.
     const text =
       "1020 – December 6 – A Family 1021 – December 20 – Committee BREAK 1022 – January 3 – B Family";
-    const { events } = parseHashHorrorsUpcoming(text, 2026);
+    const { events } = parseHashHorrorsUpcoming(text, 2026, 12);
     expect(events.find((e) => e.runNumber === 1021)).toBeUndefined();
     expect(events.find((e) => e.runNumber === 1022)?.date).toBe("2027-01-03");
+  });
+
+  it("seeds the first run to next year when its month is earlier than today's month", () => {
+    // Late-December scrape with an upcoming page that's already pivoted to
+    // January runs — gemini-code-assist review on PR #1536. Without seeding
+    // currentMonth, January rows would be dated to the wrong year.
+    const text = "1021 – January 3 – B Family 1022 – January 17 – C Family";
+    const { events } = parseHashHorrorsUpcoming(text, 2026, 12);
+    expect(events.find((e) => e.runNumber === 1021)?.date).toBe("2027-01-03");
+    expect(events.find((e) => e.runNumber === 1022)?.date).toBe("2027-01-17");
+  });
+
+  it("keeps the first run in the current year when its month is the current month", () => {
+    // Same-month scrape — no rollover needed.
+    const text = "1015 – May 3 – A Family 1016 – May 17 – B Family";
+    const { events } = parseHashHorrorsUpcoming(text, 2026, 5);
+    expect(events.find((e) => e.runNumber === 1015)?.date).toBe("2026-05-03");
+    expect(events.find((e) => e.runNumber === 1016)?.date).toBe("2026-05-17");
   });
 });

--- a/src/adapters/html-scraper/hash-horrors.test.ts
+++ b/src/adapters/html-scraper/hash-horrors.test.ts
@@ -177,6 +177,23 @@ describe("parseHashHorrorsHareline (year-grouped archive)", () => {
     expect(out.skippedMarkers).toBe(1);
   });
 
+  it("flags non-empty pages with no year headings as a parse failure (#1536 review)", () => {
+    // If the WP.com template drops the year heading shape entirely, the
+    // adapter must surface a scrape error rather than silently emit zero
+    // events (which would cause the reconciler to cancel the whole archive).
+    const text = "1016 – May 17 – Wade Family 1015 – May 3 – Baudoux Family";
+    const out = parseHashHorrorsHareline(text);
+    expect(out.events).toEqual([]);
+    expect(out.skippedLines).toBe(1);
+  });
+
+  it("returns an empty success result for genuinely empty input (no spurious skippedLines)", () => {
+    const out = parseHashHorrorsHareline("");
+    expect(out.events).toEqual([]);
+    expect(out.skippedLines).toBe(0);
+    expect(out.skippedMarkers).toBe(0);
+  });
+
   it("appends themed-run titles to the default kennel title", () => {
     const text = "2015 985 – December 15 (Christmas Hash) – Poyner Family – Gillman Barracks";
     const { events } = parseHashHorrorsHareline(text);

--- a/src/adapters/html-scraper/hash-horrors.ts
+++ b/src/adapters/html-scraper/hash-horrors.ts
@@ -1,8 +1,8 @@
+import { createHash } from "node:crypto";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { fetchWordPressComPage } from "../wordpress-api";
 import { MONTHS, decodeEntities, buildDateWindow, stripHtmlTags } from "../utils";
-import { generateStructureHash } from "@/pipeline/structure-hash";
 import { todayInTimezone } from "@/lib/timezone";
 
 const DEFAULT_SITE_DOMAIN = "hashhousehorrors.com";
@@ -40,15 +40,25 @@ const KENNEL_TIMEZONE = "Asia/Singapore";
 // Each run line begins with the run number followed by a separator (en-dash,
 // em-dash, ASCII hyphen, or colon — older archive entries use ":"). The body
 // after the separator carries the month/day in either "Month D" (post-2019)
-// or "D Month" order (2018-2019 hareline rewrite), optionally suffixed with
-// an ordinal (1st/2nd/3rd/Nth), an inline year (1900-2099), and/or a
-// parenthetical themed-run annotation, then an optional tail with hares and
-// location.
+// or "D Month" order (2018-2019 hareline rewrite). Optional decorations
+// (ordinal suffixes, inline year, parenthetical themed-run annotation) and
+// the tail (hares ± location) are stripped procedurally rather than via one
+// catastrophic-backtracking regex — Sonar S5852 flags any `\s*` adjacent to
+// optional alternation, so the linear shape below avoids the analyzer
+// hotspot without sacrificing coverage. See burlington-hash.ts for the same
+// pattern.
 const RUN_PREFIX_RE = /^(\d{3,4})\s*[–—:-]\s*/i;
-const MONTH_DAY_RE =
-  /^([a-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?\s*(?:(?:19|20)\d{2})?\s*(?:\(([^)]*)\))?\s*(?:[–—-]\s*(.+))?$/i;
-const DAY_MONTH_RE =
-  /^(\d{1,2})(?:st|nd|rd|th)?\s+([a-z]+)\s*(?:(?:19|20)\d{2})?\s*(?:\(([^)]*)\))?\s*(?:[–—-]\s*(.+))?$/i;
+// Day in "Month D" order is captured *before* the optional ordinal so
+// `afterHead` can strip "rd" / "th" procedurally. In "D Month" order the
+// ordinal sits between digit and month, so it has to be in the head regex
+// (e.g. "9th April"). Both heads are linear — no `\s*`-adjacent alternation
+// that would trip Sonar S5852.
+const MONTH_DAY_HEAD = /^([a-z]+)\s+(\d{1,2})/i;
+const DAY_MONTH_HEAD = /^(\d{1,2})(?:st|nd|rd|th)?\s+([a-z]+)/i;
+const ORDINAL_SUFFIX_RE = /^(?:st|nd|rd|th)\b/i;
+const INLINE_YEAR_RE = /^(?:19|20)\d{2}\b/;
+const PAREN_THEME_RE = /^\(([^)]*)\)/;
+const TAIL_DASH_RE = /^[–—-]\s*(.+)$/;
 
 interface ParsedRunLine {
   runNumber: number;
@@ -62,6 +72,32 @@ interface ParsedRunLine {
   isBreak?: true;
 }
 
+/** Strip leading and trailing asterisks (and any whitespace they wrap) from
+ *  a string. Procedural rather than regex-based so we don't trip Sonar S5852
+ *  on the `\s*`-adjacent-to-alternation pattern. */
+function stripWrappingAsterisks(value: string): string {
+  let s = value;
+  while (s.startsWith("*")) s = s.slice(1);
+  s = s.trimStart();
+  while (s.endsWith("*")) s = s.slice(0, -1);
+  return s.trimEnd();
+}
+
+/** Consume any optional ordinal/year/whitespace/parenthetical theme prefix
+ *  from `remainder`, returning what's left plus an extracted theme (if any). */
+function stripDecorations(remainder: string): { rest: string; theme: string | undefined } {
+  let rest = remainder.trimStart();
+  rest = rest.replace(ORDINAL_SUFFIX_RE, "").trimStart();
+  rest = rest.replace(INLINE_YEAR_RE, "").trimStart();
+  const paren = PAREN_THEME_RE.exec(rest);
+  let theme: string | undefined;
+  if (paren) {
+    theme = paren[1].trim() || undefined;
+    rest = rest.slice(paren[0].length).trimStart();
+  }
+  return { rest, theme };
+}
+
 /** Parse a single line like "1016 – May 17 – Wade Family – Pearl Hill". */
 export function parseHashHorrorsRunLine(line: string): ParsedRunLine | null {
   const cleaned = line.trim();
@@ -71,31 +107,34 @@ export function parseHashHorrorsRunLine(line: string): ParsedRunLine | null {
   const body = cleaned.slice(prefix[0].length);
 
   // Try "Month D" first (post-2019 format), fall back to "D Month" used by
-  // the 2018-2019 hareline rewrite. Whichever matches gives us month, day,
-  // optional themed-run annotation, and the optional tail with hares ± loc.
+  // the 2018-2019 hareline rewrite. Whichever head matches gives us month +
+  // day; remaining decorations (ordinal/year/paren-theme) and the tail get
+  // stripped procedurally below so the regex pieces stay linear (Sonar S5852).
   let monthStr: string;
   let dayStr: string;
-  let theme: string | undefined;
-  let tail: string | undefined;
-  const md = MONTH_DAY_RE.exec(body);
+  let afterHead: string;
+  const md = MONTH_DAY_HEAD.exec(body);
   if (md) {
     monthStr = md[1];
     dayStr = md[2];
-    theme = md[3]?.trim() || undefined;
-    tail = md[4]?.trim();
+    afterHead = body.slice(md[0].length);
   } else {
-    const dm = DAY_MONTH_RE.exec(body);
+    const dm = DAY_MONTH_HEAD.exec(body);
     if (!dm) return null;
     dayStr = dm[1];
     monthStr = dm[2];
-    theme = dm[3]?.trim() || undefined;
-    tail = dm[4]?.trim();
+    afterHead = body.slice(dm[0].length);
   }
 
   const monthIdx = MONTHS[monthStr.toLowerCase()];
   if (!monthIdx) return null;
   const day = Number.parseInt(dayStr, 10);
   if (day < 1 || day > 31) return null;
+
+  const { rest, theme } = stripDecorations(afterHead);
+  const tailMatch = TAIL_DASH_RE.exec(rest);
+  const tail = tailMatch?.[1]?.trim() || undefined;
+
   let hares: string | undefined;
   let location: string | undefined;
   if (tail) {
@@ -127,8 +166,10 @@ export function parseHashHorrorsRunLine(line: string): ParsedRunLine | null {
 
   // "Hares Needed" sentinel — drop the value. Strip wrapping asterisks first
   // (the kennel sometimes writes it as "*Hares Needed*" or "***Hares Needed***").
+  // Procedural strip avoids Sonar S5852 on the `\s*`-adjacent-to-alternation
+  // shape the regex form trips.
   if (hares) {
-    const unstarred = hares.replace(/^\*+\s*|\s*\*+$/g, "").trim();
+    const unstarred = stripWrappingAsterisks(hares);
     if (/^Hares\s+Needed$/i.test(unstarred)) hares = undefined;
   }
 
@@ -171,6 +212,12 @@ function findYearHeadings(text: string): Array<{ year: number; start: number; en
  * (2018-2019 layout). Year-shaped numbers (1900-2099) are filtered out to
  * prevent inline year tokens from being treated as run-number prefixes when
  * the surrounding row is "23rd 2017 – The Mitchell Family"-style.
+ *
+ * LIMIT: at ~26 runs/year, the kennel reaches run #1900 around 2060 (~34
+ * years out). When run numbers approach 1900, replace this numeric filter
+ * with a context-aware check (e.g. look backwards from the candidate for an
+ * ordinal/space pattern) or shift to a per-row tokenizer. Codex flagged
+ * this on PR #1536 as a long-horizon correctness regression.
  */
 function findRunLineStarts(section: string): number[] {
   const starts: number[] = [];
@@ -255,13 +302,25 @@ export function parseHashHorrorsHareline(text: string): ParseHarelineResult {
  * Walk the `/hareline-2/` upcoming page. There is no year heading — the
  * implied year is `currentYear`, advancing by one whenever the calendar
  * date wraps backwards (e.g. Dec → Jan crossing).
+ *
+ * `currentMonth` (1-12) seeds the year for the FIRST run on the page. When
+ * the upcoming list begins in a month earlier than today's month, those
+ * runs belong to next year (e.g. a Dec-15 scrape sees a Jan-3 run as 2027,
+ * not 2026). Without this seed, January-only upcoming pages would be
+ * mis-dated for the last ~6 weeks of every year.
  */
-export function parseHashHorrorsUpcoming(text: string, currentYear: number): ParseHarelineResult {
+export function parseHashHorrorsUpcoming(
+  text: string,
+  currentYear: number,
+  currentMonth: number,
+): ParseHarelineResult {
   let year = currentYear;
   let prev: { month: number; day: number } | null = null;
   return walkRunLines(text, (parsed) => {
     const cur = { month: parsed.monthIdx, day: parsed.day };
-    if (prev && (cur.month < prev.month || (cur.month === prev.month && cur.day < prev.day))) {
+    if (prev === null) {
+      if (cur.month < currentMonth) year++;
+    } else if (cur.month < prev.month || (cur.month === prev.month && cur.day < prev.day)) {
       year++;
     }
     prev = cur;
@@ -337,11 +396,14 @@ export class HashHorrorsAdapter implements SourceAdapter {
     } else {
       upcomingUrl = upcomingResult.page.URL || `https://${siteDomain}/${HARELINE_UPCOMING_SLUG}/`;
       upcomingText = flattenPageText(upcomingResult.page.content);
-      // Pin the implied year to Singapore-local "today" so a 2027-01-01
-      // SGT scrape doesn't mis-date January upcoming rows as 2026 just
-      // because UTC hasn't ticked over yet.
-      const currentYear = Number.parseInt(todayInTimezone(KENNEL_TIMEZONE).slice(0, 4), 10);
-      upcoming = parseHashHorrorsUpcoming(upcomingText, currentYear);
+      // Pin the implied year + month to Singapore-local "today" so a late-Dec
+      // scrape that finds only January upcoming rows seeds them to next year
+      // (gemini-code-assist review on PR #1536). UTC would also mis-date the
+      // first 8h of January every year.
+      const ymd = todayInTimezone(KENNEL_TIMEZONE);
+      const currentYear = Number.parseInt(ymd.slice(0, 4), 10);
+      const currentMonth = Number.parseInt(ymd.slice(5, 7), 10);
+      upcoming = parseHashHorrorsUpcoming(upcomingText, currentYear, currentMonth);
     }
 
     // The hareline pages between them carry the full archive back to Hash 1.
@@ -375,7 +437,16 @@ export class HashHorrorsAdapter implements SourceAdapter {
     if (fetchErrors.length > 0) errorDetails.fetch = fetchErrors;
     if (parseErrors.length > 0) errorDetails.parse = parseErrors;
 
-    const structureHash = generateStructureHash(archiveText + upcomingText);
+    // Content-based fingerprint of the raw page HTML. The shared
+    // `generateStructureHash` helper is hashnyc-specific (it looks for
+    // `table.past_hashes` / `table.future_hashes` CSS classes that don't
+    // exist on WordPress.com) and would return a constant for this adapter,
+    // which is strictly worse than no signal at all. A SHA-256 over the raw
+    // HTML changes on every edit — useful for diffing successive scrapes
+    // even though it's noisier than a true structural fingerprint.
+    const structureHash = createHash("sha256")
+      .update(archiveResult.page.content + (upcomingResult.page?.content ?? ""))
+      .digest("hex");
     return {
       events,
       errors,

--- a/src/adapters/html-scraper/hash-horrors.ts
+++ b/src/adapters/html-scraper/hash-horrors.ts
@@ -3,67 +3,99 @@ import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "..
 import { fetchWordPressComPage } from "../wordpress-api";
 import { MONTHS, decodeEntities, buildDateWindow, stripHtmlTags } from "../utils";
 import { generateStructureHash } from "@/pipeline/structure-hash";
+import { todayInTimezone } from "@/lib/timezone";
 
 const DEFAULT_SITE_DOMAIN = "hashhousehorrors.com";
-const HARELINE_SLUG = "hareline";
+const HARELINE_ARCHIVE_SLUG = "hareline";
+const HARELINE_UPCOMING_SLUG = "hareline-2";
 const KENNEL_TAG = "hhhorrors";
 const DEFAULT_START_TIME = "16:30";
+// Hash House Horrors runs in Singapore (UTC+8). The /hareline-2/ upcoming
+// page has no year heading, so we default to the kennel's local year — using
+// UTC would mis-date the first ~8 hours of January 1 every year.
+const KENNEL_TIMEZONE = "Asia/Singapore";
 
 /**
  * Hash House Horrors (Singapore) adapter.
  *
- * The kennel uses a WordPress.com hosted blog (NOT self-hosted), so the
- * standard `/wp-json/` endpoint returns 404. Instead we use the WordPress.com
- * Public REST API to fetch the `/hareline` page (page id 18, "Previous Runs"),
- * which contains the entire run history grouped by year.
+ * The kennel publishes runs across two WordPress.com hosted pages:
+ *   - `/hareline`     → the year-grouped historical archive (1993 → present).
+ *                       Most-recent past runs are at the top, oldest at the bottom.
+ *   - `/hareline-2/`  → the small "upcoming" list (typically 4-6 future runs).
+ *                       No year heading; the current calendar year is implied,
+ *                       with auto-rollover when the date sequence wraps.
  *
- * Format inside the page content:
+ * Both pages share the same per-row format:
+ *   `<runNumber> – <month> <day> – <hares>[ – <location>]`
  *
- *   2026
- *   1016 – May 17 – Wade Family
- *   1015 – May 3 – Baudoux, Guthrie and Poyner Families
- *   1014 – April 19 – Hares Needed
- *   1013 – April 5 – Campbell Family
- *   ...
- *   2025
- *   1006 – December 14 – Dew, Jones, Petrocelli and Waage Families – Bukit Batok East Avenue 2 Heavy Vehicle Park
- *   ...
- *
- * - Year sections (`2026`, `2025`, ...) act as parser anchors
- * - Per-run line: `<runNumber> – <month> <day> – <hares>[ – <location>]`
- * - "Hares Needed" sentinel for unfilled future runs (drop the value)
- * - Some lines omit the location
+ * Quirks we handle here (see #1253):
+ *   - "BREAK" notices (`<p>NNNN – Mon D – Hash Committee</p><p>BREAK</p>`)
+ *     are informational no-run markers and emit no event.
+ *   - "*Hares Needed*" / "***Hares Needed***" — the kennel sometimes wraps
+ *     the sentinel in asterisks; we strip them before the sentinel check.
  *
  * Children's hash, biweekly Sundays starting 4:30 PM.
  */
 
-// Match en-dash, em-dash, and ASCII hyphen as field separators (the live page
-// uses en-dash, but defensive coverage in case the kennel changes formatting).
-const RUN_LINE_RE = /^(\d{3,4})\s*[–—-]\s*([a-z]+)\s+(\d{1,2})(?:\s*[–—-]\s*(.+))?$/i;
+// Each run line begins with the run number followed by a separator (en-dash,
+// em-dash, ASCII hyphen, or colon — older archive entries use ":"). The body
+// after the separator carries the month/day in either "Month D" (post-2019)
+// or "D Month" order (2018-2019 hareline rewrite), optionally suffixed with
+// an ordinal (1st/2nd/3rd/Nth), an inline year (1900-2099), and/or a
+// parenthetical themed-run annotation, then an optional tail with hares and
+// location.
+const RUN_PREFIX_RE = /^(\d{3,4})\s*[–—:-]\s*/i;
+const MONTH_DAY_RE =
+  /^([a-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?\s*(?:(?:19|20)\d{2})?\s*(?:\(([^)]*)\))?\s*(?:[–—-]\s*(.+))?$/i;
+const DAY_MONTH_RE =
+  /^(\d{1,2})(?:st|nd|rd|th)?\s+([a-z]+)\s*(?:(?:19|20)\d{2})?\s*(?:\(([^)]*)\))?\s*(?:[–—-]\s*(.+))?$/i;
 
 interface ParsedRunLine {
   runNumber: number;
   monthIdx: number;
   day: number;
+  /** Theme annotation from parentheses after the day (e.g. "Christmas Hash"). */
+  theme?: string;
   hares?: string;
   location?: string;
+  /** Source emitted an informational no-run marker (e.g. BREAK) — emit no event. */
+  isBreak?: true;
 }
 
 /** Parse a single line like "1016 – May 17 – Wade Family – Pearl Hill". */
 export function parseHashHorrorsRunLine(line: string): ParsedRunLine | null {
   const cleaned = line.trim();
-  const m = RUN_LINE_RE.exec(cleaned);
-  if (!m) return null;
+  const prefix = RUN_PREFIX_RE.exec(cleaned);
+  if (!prefix) return null;
+  const runNumber = Number.parseInt(prefix[1], 10);
+  const body = cleaned.slice(prefix[0].length);
 
-  const runNumber = Number.parseInt(m[1], 10);
-  const monthIdx = MONTHS[m[2].toLowerCase()];
+  // Try "Month D" first (post-2019 format), fall back to "D Month" used by
+  // the 2018-2019 hareline rewrite. Whichever matches gives us month, day,
+  // optional themed-run annotation, and the optional tail with hares ± loc.
+  let monthStr: string;
+  let dayStr: string;
+  let theme: string | undefined;
+  let tail: string | undefined;
+  const md = MONTH_DAY_RE.exec(body);
+  if (md) {
+    monthStr = md[1];
+    dayStr = md[2];
+    theme = md[3]?.trim() || undefined;
+    tail = md[4]?.trim();
+  } else {
+    const dm = DAY_MONTH_RE.exec(body);
+    if (!dm) return null;
+    dayStr = dm[1];
+    monthStr = dm[2];
+    theme = dm[3]?.trim() || undefined;
+    tail = dm[4]?.trim();
+  }
+
+  const monthIdx = MONTHS[monthStr.toLowerCase()];
   if (!monthIdx) return null;
-  const day = Number.parseInt(m[3], 10);
+  const day = Number.parseInt(dayStr, 10);
   if (day < 1 || day > 31) return null;
-
-  // Split tail on the LAST dash so multi-family hare lists with internal "–"
-  // don't get sliced. Cover all three dash characters used in the wild.
-  const tail = m[4]?.trim();
   let hares: string | undefined;
   let location: string | undefined;
   if (tail) {
@@ -85,72 +117,160 @@ export function parseHashHorrorsRunLine(line: string): ParsedRunLine | null {
     }
   }
 
-  // "Hares Needed" sentinel — drop the value
-  if (hares && /^Hares\s+Needed$/i.test(hares)) hares = undefined;
+  // BREAK detection — kennel publishes the marker in a separate <p> from the
+  // run line; after HTML strip + whitespace collapse it tails the hares field
+  // ("Hash Committee BREAK"). Treat the whole row as an informational marker,
+  // not a parse failure (don't increment skippedLines or surface to alerts).
+  if (hares && /\bBREAK\s*$/i.test(hares)) {
+    return { runNumber, monthIdx, day, theme, isBreak: true };
+  }
 
-  return { runNumber, monthIdx, day, hares, location };
+  // "Hares Needed" sentinel — drop the value. Strip wrapping asterisks first
+  // (the kennel sometimes writes it as "*Hares Needed*" or "***Hares Needed***").
+  if (hares) {
+    const unstarred = hares.replace(/^\*+\s*|\s*\*+$/g, "").trim();
+    if (/^Hares\s+Needed$/i.test(unstarred)) hares = undefined;
+  }
+
+  return { runNumber, monthIdx, day, theme, hares, location };
 }
 
 export interface ParseHarelineResult {
   events: RawEventData[];
-  /** Run lines that matched the year-anchor tokenizer but failed the line parser. */
+  /** Run lines that matched the run-start tokenizer but failed the line parser. */
   skippedLines: number;
+  /** Run lines that were recognised but intentionally emit no event (e.g. BREAK). */
+  skippedMarkers: number;
 }
 
 /**
- * Walk the rendered hareline text and emit events. Years act as parser
- * anchors — each `2026` / `2025` / etc. token resets the active year.
+ * Find year-heading positions in the archive text.
+ *
+ * After HTML strip + whitespace collapse, real year headings appear as a
+ * standalone 4-digit number immediately followed by the next run line
+ * ("…2017 871 – December 17th – Coke Family…"), whereas inline year usages
+ * inside a row ("April 23rd 2017 – The Mitchell Family") never have a run
+ * number right after the year. Anchoring on the following run number filters
+ * out the inline year noise that previously chopped the 2017 archive section
+ * into 14 unparseable fragments. The followed-by-token can be a month name
+ * (post-2019 layout) or a day number (2018-2019 layout).
  */
-/** Find all standalone 4-digit year headings (1900-2099) with their positions. */
 function findYearHeadings(text: string): Array<{ year: number; start: number; end: number }> {
   const headings: Array<{ year: number; start: number; end: number }> = [];
-  for (const m of text.matchAll(/\b((?:19|20)\d{2})\b/g)) {
+  for (const m of text.matchAll(/\b((?:19|20)\d{2})\s+\d{3,4}\s*[–—:-]\s*(?:[a-z]+|\d{1,2})/gi)) {
     const start = m.index ?? 0;
-    headings.push({ year: Number.parseInt(m[1], 10), start, end: start + m[0].length });
+    headings.push({ year: Number.parseInt(m[1], 10), start, end: start + m[1].length });
   }
   return headings;
 }
 
-/** Find run-line start positions (`1016 – May`) within a year section. */
+/**
+ * Find run-line start positions within a year section. Each candidate match
+ * begins with the run number and the field separator (dash or colon). The
+ * follow-up token can be a month name (post-2019 layout) or a day number
+ * (2018-2019 layout). Year-shaped numbers (1900-2099) are filtered out to
+ * prevent inline year tokens from being treated as run-number prefixes when
+ * the surrounding row is "23rd 2017 – The Mitchell Family"-style.
+ */
 function findRunLineStarts(section: string): number[] {
   const starts: number[] = [];
-  for (const m of section.matchAll(/\d{3,4}\s*[–—-]\s*[a-z]+/gi)) {
+  for (const m of section.matchAll(/(\d{3,4})\s*[–—:-]\s*(?:[a-z]+|\d{1,2})/gi)) {
+    const n = Number.parseInt(m[1], 10);
+    if (n >= 1900 && n <= 2099) continue;
     if (m.index !== undefined) starts.push(m.index);
   }
   return starts;
 }
 
+function buildEvent(parsed: ParsedRunLine, year: number): RawEventData {
+  const date = `${year}-${String(parsed.monthIdx).padStart(2, "0")}-${String(parsed.day).padStart(2, "0")}`;
+  const baseTitle = `Hash Horrors ${parsed.runNumber}`;
+  const title = parsed.theme ? `${baseTitle} — ${parsed.theme}` : baseTitle;
+  return {
+    date,
+    startTime: DEFAULT_START_TIME,
+    kennelTags: [KENNEL_TAG],
+    runNumber: parsed.runNumber,
+    title,
+    hares: parsed.hares,
+    location: parsed.location,
+  };
+}
+
+/**
+ * Walk a run-line region of text. The `yearForLine` callback owns year
+ * selection: the archive page returns a section's fixed year heading, the
+ * upcoming page maintains a rolling year that bumps when the calendar wraps.
+ * Skip markers (BREAK rows) are still passed to the callback so the
+ * upcoming-page rollover detector stays in sync across no-event rows.
+ */
+function walkRunLines(
+  text: string,
+  yearForLine: (parsed: ParsedRunLine) => number,
+): ParseHarelineResult {
+  const events: RawEventData[] = [];
+  let skippedLines = 0;
+  let skippedMarkers = 0;
+  const starts = findRunLineStarts(text);
+  for (let i = 0; i < starts.length; i++) {
+    const lineEnd = starts[i + 1] ?? text.length;
+    const line = text.slice(starts[i], lineEnd).trim();
+    const parsed = parseHashHorrorsRunLine(line);
+    if (!parsed) {
+      skippedLines++;
+      continue;
+    }
+    const year = yearForLine(parsed);
+    if (parsed.isBreak) {
+      skippedMarkers++;
+      continue;
+    }
+    events.push(buildEvent(parsed, year));
+  }
+  return { events, skippedLines, skippedMarkers };
+}
+
+/**
+ * Walk the year-grouped archive page. Each `2026` / `2025` / etc. heading
+ * acts as the active year for the run lines that follow until the next.
+ */
 export function parseHashHorrorsHareline(text: string): ParseHarelineResult {
   const events: RawEventData[] = [];
   let skippedLines = 0;
+  let skippedMarkers = 0;
   const headings = findYearHeadings(text);
-
   for (let i = 0; i < headings.length; i++) {
     const { year, end } = headings[i];
     const sectionEnd = headings[i + 1]?.start ?? text.length;
     const section = text.slice(end, sectionEnd);
-    const starts = findRunLineStarts(section);
-    for (let j = 0; j < starts.length; j++) {
-      const lineEnd = starts[j + 1] ?? section.length;
-      const line = section.slice(starts[j], lineEnd).trim();
-      const parsed = parseHashHorrorsRunLine(line);
-      if (!parsed) {
-        skippedLines++;
-        continue;
-      }
-      const date = `${year}-${String(parsed.monthIdx).padStart(2, "0")}-${String(parsed.day).padStart(2, "0")}`;
-      events.push({
-        date,
-        startTime: DEFAULT_START_TIME,
-        kennelTags: [KENNEL_TAG],
-        runNumber: parsed.runNumber,
-        title: `Hash Horrors ${parsed.runNumber}`,
-        hares: parsed.hares,
-        location: parsed.location,
-      });
-    }
+    const sectionResult = walkRunLines(section, () => year);
+    events.push(...sectionResult.events);
+    skippedLines += sectionResult.skippedLines;
+    skippedMarkers += sectionResult.skippedMarkers;
   }
-  return { events, skippedLines };
+  return { events, skippedLines, skippedMarkers };
+}
+
+/**
+ * Walk the `/hareline-2/` upcoming page. There is no year heading — the
+ * implied year is `currentYear`, advancing by one whenever the calendar
+ * date wraps backwards (e.g. Dec → Jan crossing).
+ */
+export function parseHashHorrorsUpcoming(text: string, currentYear: number): ParseHarelineResult {
+  let year = currentYear;
+  let prev: { month: number; day: number } | null = null;
+  return walkRunLines(text, (parsed) => {
+    const cur = { month: parsed.monthIdx, day: parsed.day };
+    if (prev && (cur.month < prev.month || (cur.month === prev.month && cur.day < prev.day))) {
+      year++;
+    }
+    prev = cur;
+    return year;
+  });
+}
+
+function flattenPageText(content: string): string {
+  return decodeEntities(stripHtmlTags(content)).replaceAll(/\s+/g, " ").trim();
 }
 
 export class HashHorrorsAdapter implements SourceAdapter {
@@ -173,56 +293,107 @@ export class HashHorrorsAdapter implements SourceAdapter {
       }
     }
 
-    const result = await fetchWordPressComPage(siteDomain, HARELINE_SLUG);
-    if (result.error || !result.page) {
-      const message = result.error?.message ?? "WordPress.com API returned no page";
-      errorDetails.fetch = [{ url: `https://${siteDomain}/${HARELINE_SLUG}/`, message, status: result.error?.status }];
+    // Fetch archive and upcoming pages concurrently. Archive is the primary
+    // feed (full 1993→present history); the upcoming page carries the 4-6
+    // future runs that haven't yet been promoted into the archive.
+    const [archiveResult, upcomingResult] = await Promise.all([
+      fetchWordPressComPage(siteDomain, HARELINE_ARCHIVE_SLUG),
+      fetchWordPressComPage(siteDomain, HARELINE_UPCOMING_SLUG),
+    ]);
+
+    // Archive failure is a hard error — the bulk of the data lives there.
+    if (archiveResult.error || !archiveResult.page) {
+      const message = archiveResult.error?.message ?? "WordPress.com API returned no archive page";
+      errorDetails.fetch = [
+        {
+          url: `https://${siteDomain}/${HARELINE_ARCHIVE_SLUG}/`,
+          message,
+          status: archiveResult.error?.status,
+        },
+      ];
       return { events: [], errors: [message], errorDetails };
     }
 
-    const pageUrl = result.page.URL || `https://${siteDomain}/${HARELINE_SLUG}/`;
-    // Collapse whitespace so the year/run-line tokenizer works on a flat string.
-    const text = decodeEntities(stripHtmlTags(result.page.content)).replaceAll(/\s+/g, " ").trim();
+    const archiveUrl = archiveResult.page.URL || `https://${siteDomain}/${HARELINE_ARCHIVE_SLUG}/`;
+    const archiveText = flattenPageText(archiveResult.page.content);
+    const archive = parseHashHorrorsHareline(archiveText);
 
-    const { events: allEvents, skippedLines } = parseHashHorrorsHareline(text);
-    // The hareline page is the ONLY feed for Hash Horrors and contains the
-    // full archive back to Hash 1. Default to a 50-year window so the
-    // recurring scrape ingests the entire historical archive regardless
-    // of founding date — the filter is a no-op for events before the
-    // kennel existed, so going wide has no cost.
-    const { minDate, maxDate } = buildDateWindow(options?.days ?? 365 * 50);
-    const events = allEvents
-      .map((e) => ({ ...e, sourceUrl: pageUrl }))
-      .filter((e) => {
-        const d = new Date(`${e.date}T12:00:00Z`);
-        return d >= minDate && d <= maxDate;
-      });
-
+    // Upcoming-page failure is soft — archive still provides the historical
+    // data; we surface the warning so monitoring sees the partial fetch.
     const errors: string[] = [];
+    const fetchErrors: NonNullable<ErrorDetails["fetch"]> = [];
+    let upcomingUrl: string | undefined;
+    let upcomingText = "";
+    let upcoming: ParseHarelineResult = { events: [], skippedLines: 0, skippedMarkers: 0 };
+
+    if (upcomingResult.error || !upcomingResult.page) {
+      const message = upcomingResult.error?.message ?? "WordPress.com API returned no upcoming page";
+      errors.push(message);
+      fetchErrors.push({
+        url: `https://${siteDomain}/${HARELINE_UPCOMING_SLUG}/`,
+        message,
+        status: upcomingResult.error?.status,
+      });
+    } else {
+      upcomingUrl = upcomingResult.page.URL || `https://${siteDomain}/${HARELINE_UPCOMING_SLUG}/`;
+      upcomingText = flattenPageText(upcomingResult.page.content);
+      // Pin the implied year to Singapore-local "today" so a 2027-01-01
+      // SGT scrape doesn't mis-date January upcoming rows as 2026 just
+      // because UTC hasn't ticked over yet.
+      const currentYear = Number.parseInt(todayInTimezone(KENNEL_TIMEZONE).slice(0, 4), 10);
+      upcoming = parseHashHorrorsUpcoming(upcomingText, currentYear);
+    }
+
+    // The hareline pages between them carry the full archive back to Hash 1.
+    // Default to a 50-year window so the recurring scrape ingests the entire
+    // historical archive regardless of founding date — the filter is a no-op
+    // for events before the kennel existed, so going wide has no cost.
+    const { minDate, maxDate } = buildDateWindow(options?.days ?? 365 * 50);
+    const allEvents = [
+      ...archive.events.map((e) => ({ ...e, sourceUrl: archiveUrl })),
+      ...(upcomingUrl ? upcoming.events.map((e) => ({ ...e, sourceUrl: upcomingUrl })) : []),
+    ];
+    const events = allEvents.filter((e) => {
+      const d = new Date(`${e.date}T12:00:00Z`);
+      return d >= minDate && d <= maxDate;
+    });
+
+    const skippedLines = archive.skippedLines + upcoming.skippedLines;
+    const skippedMarkers = archive.skippedMarkers + upcoming.skippedMarkers;
 
     // Surface dropped lines as scrape errors so the reconciler doesn't cancel
     // events on a partial parse (it only runs when errors.length === 0). A
     // single dropped line is enough to suppress reconciliation since the format
     // is fragile and silent drops would be indistinguishable from real removals.
+    const parseErrors: NonNullable<ErrorDetails["parse"]> = [];
     if (skippedLines > 0) {
       const message = `Hash Horrors hareline parser dropped ${skippedLines} line(s) — possible format drift`;
       errors.push(message);
-      errorDetails.parse = [{ row: 0, error: message }];
+      parseErrors.push({ row: 0, error: message });
     }
 
-    const structureHash = generateStructureHash(text);
+    if (fetchErrors.length > 0) errorDetails.fetch = fetchErrors;
+    if (parseErrors.length > 0) errorDetails.parse = parseErrors;
+
+    const structureHash = generateStructureHash(archiveText + upcomingText);
     return {
       events,
       errors,
       structureHash,
       errorDetails: errors.length > 0 ? errorDetails : undefined,
       diagnosticContext: {
-        pageId: result.page.ID,
-        pageModified: result.page.modified,
-        runsParsed: allEvents.length,
+        archivePageId: archiveResult.page.ID,
+        archivePageModified: archiveResult.page.modified,
+        upcomingPageId: upcomingResult.page?.ID,
+        upcomingPageModified: upcomingResult.page?.modified,
+        runsParsed: archive.events.length + upcoming.events.length,
+        archiveRunsParsed: archive.events.length,
+        upcomingRunsParsed: upcoming.events.length,
         skippedLines,
+        skippedMarkers,
         eventsInWindow: events.length,
-        fetchDurationMs: result.fetchDurationMs,
+        archiveFetchDurationMs: archiveResult.fetchDurationMs,
+        upcomingFetchDurationMs: upcomingResult.fetchDurationMs,
       },
     };
   }

--- a/src/adapters/html-scraper/hash-horrors.ts
+++ b/src/adapters/html-scraper/hash-horrors.ts
@@ -58,7 +58,10 @@ const DAY_MONTH_HEAD = /^(\d{1,2})(?:st|nd|rd|th)?\s+([a-z]+)/i;
 const ORDINAL_SUFFIX_RE = /^(?:st|nd|rd|th)\b/i;
 const INLINE_YEAR_RE = /^(?:19|20)\d{2}\b/;
 const PAREN_THEME_RE = /^\(([^)]*)\)/;
-const TAIL_DASH_RE = /^[–—-]\s*(.+)$/;
+// `\s*(.+)` together is the canonical S5852 false-positive shape (memory:
+// feedback_sonar_s5852_false_positives). Anchoring on `\S` keeps the match
+// unambiguously linear without losing any input we'd otherwise capture.
+const TAIL_DASH_RE = /^[–—-]\s*(\S.*)$/;
 
 interface ParsedRunLine {
   runNumber: number;

--- a/src/adapters/html-scraper/hash-horrors.ts
+++ b/src/adapters/html-scraper/hash-horrors.ts
@@ -285,12 +285,20 @@ function walkRunLines(
 /**
  * Walk the year-grouped archive page. Each `2026` / `2025` / etc. heading
  * acts as the active year for the run lines that follow until the next.
+ *
+ * If `findYearHeadings` returns nothing for a non-empty page, count it as a
+ * skippedLine so the adapter's drift signal fires (and the reconciler
+ * doesn't cancel every event). Otherwise a future WP.com template change
+ * that drops the year heading shape would silently empty the archive feed.
  */
 export function parseHashHorrorsHareline(text: string): ParseHarelineResult {
   const events: RawEventData[] = [];
   let skippedLines = 0;
   let skippedMarkers = 0;
   const headings = findYearHeadings(text);
+  if (text.trim() && headings.length === 0) {
+    return { events: [], skippedLines: 1, skippedMarkers: 0 };
+  }
   for (let i = 0; i < headings.length; i++) {
     const { year, end } = headings[i];
     const sectionEnd = headings[i + 1]?.start ?? text.length;

--- a/src/adapters/html-scraper/hash-horrors.ts
+++ b/src/adapters/html-scraper/hash-horrors.ts
@@ -86,6 +86,21 @@ function stripWrappingAsterisks(value: string): string {
   return s.trimEnd();
 }
 
+/** Match either head shape ("Month D" then "D Month") against `body` and
+ *  return the parts plus the body suffix to keep parsing. Extracted from
+ *  `parseHashHorrorsRunLine` to keep that function under Sonar S3776. */
+function matchHead(
+  body: string,
+): { monthStr: string; dayStr: string; afterHead: string } | null {
+  const md = MONTH_DAY_HEAD.exec(body);
+  if (md) {
+    return { monthStr: md[1], dayStr: md[2], afterHead: body.slice(md[0].length) };
+  }
+  const dm = DAY_MONTH_HEAD.exec(body);
+  if (!dm) return null;
+  return { monthStr: dm[2], dayStr: dm[1], afterHead: body.slice(dm[0].length) };
+}
+
 /** Consume any optional ordinal/year/whitespace/parenthetical theme prefix
  *  from `remainder`, returning what's left plus an extracted theme (if any). */
 function stripDecorations(remainder: string): { rest: string; theme: string | undefined } {
@@ -110,25 +125,12 @@ export function parseHashHorrorsRunLine(line: string): ParsedRunLine | null {
   const body = cleaned.slice(prefix[0].length);
 
   // Try "Month D" first (post-2019 format), fall back to "D Month" used by
-  // the 2018-2019 hareline rewrite. Whichever head matches gives us month +
-  // day; remaining decorations (ordinal/year/paren-theme) and the tail get
+  // the 2018-2019 hareline rewrite. `matchHead` returns the body suffix; the
+  // remaining decorations (ordinal/year/paren-theme) and the tail get
   // stripped procedurally below so the regex pieces stay linear (Sonar S5852).
-  let monthStr: string;
-  let dayStr: string;
-  let afterHead: string;
-  const md = MONTH_DAY_HEAD.exec(body);
-  if (md) {
-    monthStr = md[1];
-    dayStr = md[2];
-    afterHead = body.slice(md[0].length);
-  } else {
-    const dm = DAY_MONTH_HEAD.exec(body);
-    if (!dm) return null;
-    dayStr = dm[1];
-    monthStr = dm[2];
-    afterHead = body.slice(dm[0].length);
-  }
-
+  const head = matchHead(body);
+  if (!head) return null;
+  const { monthStr, dayStr, afterHead } = head;
   const monthIdx = MONTHS[monthStr.toLowerCase()];
   if (!monthIdx) return null;
   const day = Number.parseInt(dayStr, 10);


### PR DESCRIPTION
## Summary

- Adapter now fetches both `/hareline` (year-grouped archive) and `/hareline-2/` (upcoming) concurrently; the 5 future runs on the upcoming page (#1015-1019) finally reach HashTracks.
- New `parseHashHorrorsUpcoming(text, currentYear)` walker pins the implied year to Singapore-local "today" with Dec→Jan rollover detection — fixes the timezone bug that would mis-date January upcoming rows for the first 8h every year.
- Hardens run-line parsing across the archive format drift discovered while live-verifying:
  - **BREAK marker** (`<p>1018 – June 14 – Hash Committee</p><p>BREAK</p>`) now flagged as `isBreak: true` and emits no event (no parse-error alert).
  - **`*Hares Needed*`** / **`***Hares Needed***`** canonicalised to no hares.
  - **Ordinal day suffixes** (`1st`/`2nd`/`23rd`/`Nth`) tolerated.
  - **Inline year tokens** after the day (`April 23rd 2017 – …`) consumed instead of fragmenting the row.
  - **Parenthetical themed-run annotations** (`December 15 (Christmas Hash)`) captured as title suffix.
  - **Colon-separator legacy rows** (`793: December 22 – …`) accepted.
  - **Day-first variant** (`965 – 17 December – …` from the 2018-2019 hareline rewrite) parsed alongside the post-2019 Month-Day layout.
- Year-heading detection now anchors on the following run-line shape so inline year references no longer chop the 2017 section into 14 unparseable fragments. Run-line start scanner filters year-shaped numbers (1900-2099) for the same reason.
- Both walkers share `walkRunLines` so the skip-marker + rollover logic lives in one place.

## Live verify (2026-05-20)

```
runsParsed: 292  (288 archive + 4 upcoming)
skippedLines: 10 (real format drift, surfaced as scrape errors)
skippedMarkers: 1 (the #1018 BREAK row)
```

All 5 #1253 exemplars render correctly:

| Run | Date | Hares as scraped |
|-----|------|------------------|
| 1015 | 2026-05-03 | Baudoux, Guthrie and Poyner Families |
| 1016 | 2026-05-17 | **Wade & Child Families** (co-hare preserved) |
| 1017 | 2026-05-31 | **Fanjul-Lemaistre Family** (hyphenated name intact) |
| 1018 | 2026-06-14 | — BREAK row, no event emitted |
| 1019 | 2026-08-09 | — `*Hares Needed*` canonicalised |

## Test plan

- [x] `npx vitest run src/adapters/html-scraper/hash-horrors.test.ts` — 22 tests pass (8 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 6833 pass
- [x] Live fetch against `public-api.wordpress.com` for both slugs — 292 events, all 5 exemplars correct
- [x] codex:adversarial-review caught and resolved the `getUTCFullYear()` Singapore timezone bug

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)