### PR TITLE
chore(backfill): land HHH backfill scripts + export on main

### DIFF
--- a/scripts/backfill-hash-horrors-history.ts
+++ b/scripts/backfill-hash-horrors-history.ts
@@ -1,0 +1,96 @@
+/**
+ * One-shot historical backfill for Hash House Horrors (Singapore).
+ * Issue #1252.
+ *
+ * The kennel's WordPress.com `/hareline` page carries ~240 numbered runs
+ * spanning 1993-08-08 (#248) → present (#1014). The recurring adapter
+ * (`HashHorrorsAdapter`) only ingests `options.days` worth of events per
+ * scrape (typically 365 via `Source.scrapeDays`), so before this backfill
+ * HashTracks held just 23 past events vs. the source's ~240-run lifetime
+ * archive.
+ *
+ * Strategy:
+ *   1. Fetch the `/hareline` page via the WP.com Public REST API (same call
+ *      the live adapter uses).
+ *   2. Parse rows with `parseHashHorrorsHareline` (year-anchored archive
+ *      walker) — kept colocated with the live adapter so any format-drift
+ *      fix flows to both the recurring scrape and the backfill at once.
+ *   3. Attribute every row to the existing "Hash House Horrors Hareline"
+ *      source, which is already `SourceKennel`-linked to `hhhorrors`.
+ *   4. `runBackfillScript` partitions to past-only (date < today in
+ *      Asia/Singapore) and routes through the merge pipeline.
+ *
+ * Idempotency:
+ *   `processRawEvents` dedupes by `(sourceId, fingerprint)`. The fingerprint
+ *   is deterministic over the parsed payload, so a second apply pass is a
+ *   no-op. Hares values are a single string per row (no joined multi-value
+ *   field), so there's no ordering risk to worry about.
+ *
+ * Strict date partitioning vs. the live adapter:
+ *   `reportAndApplyBackfill` filters to `date < todayInTimezone(SGT)`. The
+ *   live adapter scrapes the same `/hareline` page but is bounded by
+ *   `Source.scrapeDays` (~365), so the two paths can both produce a row
+ *   for the same recent past event — same fingerprint, dedup absorbs it.
+ *
+ * Reconcile risk:
+ *   None for the deep history. `src/pipeline/reconcile.ts` only cancels
+ *   future events missing from a scrape; past events are immutable once
+ *   ingested.
+ *
+ * Coverage limit:
+ *   The archive page itself carries some real format drift on the oldest
+ *   rows (e.g. #248-#249 from 1993 have reversed hares/location, #527 has
+ *   no date in the row text). Those ~10 rows surface as scraper "format
+ *   drift" warnings rather than backfilled events — see issue #1253 for
+ *   the parser fix that recovered the bulk of the archive (199→288 rows).
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-hash-horrors-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-hash-horrors-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import {
+  flattenHashHorrorsPageText,
+  parseHashHorrorsHareline,
+} from "@/adapters/html-scraper/hash-horrors";
+import { fetchWordPressComPage } from "@/adapters/wordpress-api";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Hash House Horrors Hareline";
+const KENNEL_TIMEZONE = "Asia/Singapore";
+const SITE_DOMAIN = "hashhousehorrors.com";
+const HARELINE_SLUG = "hareline";
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log(`Fetching https://${SITE_DOMAIN}/${HARELINE_SLUG}/ via WP.com API`);
+  const result = await fetchWordPressComPage(SITE_DOMAIN, HARELINE_SLUG);
+  if (result.error || !result.page) {
+    throw new Error(`WP.com API fetch failed: ${result.error?.message ?? "no page returned"}`);
+  }
+
+  const pageUrl = result.page.URL || `https://${SITE_DOMAIN}/${HARELINE_SLUG}/`;
+  const text = flattenHashHorrorsPageText(result.page.content);
+  const parsed = parseHashHorrorsHareline(text);
+  console.log(
+    `  Parsed ${parsed.events.length} rows | skippedLines=${parsed.skippedLines} | skippedMarkers=${parsed.skippedMarkers}`,
+  );
+  if (parsed.skippedLines > 0) {
+    console.warn(
+      `  (${parsed.skippedLines} rows surfaced as format drift — see issue #1252 / #1253 for the recovered subset.)`,
+    );
+  }
+  return parsed.events.map((e) => ({ ...e, sourceUrl: pageUrl }));
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Walking Hash Horrors hareline archive",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/spotcheck-hhhorrors.ts
+++ b/scripts/spotcheck-hhhorrors.ts
@@ -6,7 +6,7 @@ async function main() {
   if (!kennel) throw new Error("kennel not found");
 
   const fmt = (e: { runNumber: number | null; date: Date; title: string | null; locationName: string | null; haresText: string | null }) =>
-    `  #${e.runNumber} ${e.date.toISOString().slice(0, 10)} | ${e.title ?? "—"} | hares=${e.haresText ?? "—"} | loc=${e.locationName ?? "—"}`;
+    "  #" + (e.runNumber ?? "?") + " " + e.date.toISOString().slice(0, 10) + " | " + (e.title ?? "—") + " | hares=" + (e.haresText ?? "—") + " | loc=" + (e.locationName ?? "—");
 
   const oldest = await prisma.event.findMany({
     where: { eventKennels: { some: { kennelId: kennel.id } } },
@@ -35,9 +35,10 @@ async function main() {
       date: { gte: new Date("2026-05-21T00:00:00Z") },
     },
     orderBy: { date: "asc" },
+    take: 5,
     select: { runNumber: true, date: true, title: true, locationName: true, haresText: true },
   });
-  console.log("\nUpcoming:");
+  console.log("\nUpcoming (next 5):");
   for (const e of upcoming) console.log(fmt(e));
 
   await prisma.$disconnect();

--- a/scripts/spotcheck-hhhorrors.ts
+++ b/scripts/spotcheck-hhhorrors.ts
@@ -1,0 +1,46 @@
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+async function main() {
+  const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "hhhorrors" } });
+  if (!kennel) throw new Error("kennel not found");
+
+  const fmt = (e: { runNumber: number | null; date: Date; title: string | null; locationName: string | null; haresText: string | null }) =>
+    `  #${e.runNumber} ${e.date.toISOString().slice(0, 10)} | ${e.title ?? "—"} | hares=${e.haresText ?? "—"} | loc=${e.locationName ?? "—"}`;
+
+  const oldest = await prisma.event.findMany({
+    where: { eventKennels: { some: { kennelId: kennel.id } } },
+    orderBy: { date: "asc" },
+    take: 5,
+    select: { runNumber: true, date: true, title: true, locationName: true, haresText: true },
+  });
+  console.log("Oldest 5:");
+  for (const e of oldest) console.log(fmt(e));
+
+  const recent = await prisma.event.findMany({
+    where: {
+      eventKennels: { some: { kennelId: kennel.id } },
+      date: { lt: new Date("2026-05-21T00:00:00Z") },
+    },
+    orderBy: { date: "desc" },
+    take: 5,
+    select: { runNumber: true, date: true, title: true, locationName: true, haresText: true },
+  });
+  console.log("\nNewest 5 (past):");
+  for (const e of recent) console.log(fmt(e));
+
+  const upcoming = await prisma.event.findMany({
+    where: {
+      eventKennels: { some: { kennelId: kennel.id } },
+      date: { gte: new Date("2026-05-21T00:00:00Z") },
+    },
+    orderBy: { date: "asc" },
+    select: { runNumber: true, date: true, title: true, locationName: true, haresText: true },
+  });
+  console.log("\nUpcoming:");
+  for (const e of upcoming) console.log(fmt(e));
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/adapters/html-scraper/hash-horrors.ts
+++ b/src/adapters/html-scraper/hash-horrors.ts
@@ -341,7 +341,7 @@ export function parseHashHorrorsUpcoming(
   });
 }
 
-function flattenPageText(content: string): string {
+export function flattenHashHorrorsPageText(content: string): string {
   return decodeEntities(stripHtmlTags(content)).replaceAll(/\s+/g, " ").trim();
 }
 
@@ -387,7 +387,7 @@ export class HashHorrorsAdapter implements SourceAdapter {
     }
 
     const archiveUrl = archiveResult.page.URL || `https://${siteDomain}/${HARELINE_ARCHIVE_SLUG}/`;
-    const archiveText = flattenPageText(archiveResult.page.content);
+    const archiveText = flattenHashHorrorsPageText(archiveResult.page.content);
     const archive = parseHashHorrorsHareline(archiveText);
 
     // Upcoming-page failure is soft — archive still provides the historical
@@ -408,7 +408,7 @@ export class HashHorrorsAdapter implements SourceAdapter {
       });
     } else {
       upcomingUrl = upcomingResult.page.URL || `https://${siteDomain}/${HARELINE_UPCOMING_SLUG}/`;
-      upcomingText = flattenPageText(upcomingResult.page.content);
+      upcomingText = flattenHashHorrorsPageText(upcomingResult.page.content);
       // Pin the implied year + month to Singapore-local "today" so a late-Dec
       // scrape that finds only January upcoming rows seeds them to next year
       // (gemini-code-assist review on PR #1536). UTC would also mis-date the


### PR DESCRIPTION
## Summary

PR #1540 (backfill) merged into `fix/hashhorrors-parser-1253` 19 seconds **after** #1536 had already merged that branch into `main`, so three files never reached `main`:

- `scripts/backfill-hash-horrors-history.ts` — one-shot importer (already run against prod)
- `scripts/spotcheck-hhhorrors.ts` — read-only audit verifier for future use
- `src/adapters/html-scraper/hash-horrors.ts` — renames `flattenPageText` → `flattenHashHorrorsPageText` and exports it so the backfill script can reuse the exact whitespace-collapse path

The backfill **has already been applied** to prod (2026-05-20):
- created=266 updated=2 skipped=20 | Past events: 24 → 290 | Range: 1993-08-08 → 2026-04-19

This cherry-pick of `43a23d75` brings all three files onto `main` for audit-trail completeness. `tsc --noEmit` passes cleanly.

## Test plan
- [ ] CI passes (tsc + lint + tests — no behavior change, pure file addition + export rename)
- [ ] Confirm `scripts/backfill-hash-horrors-history.ts` and `scripts/spotcheck-hhhorrors.ts` visible on main post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)