### PR TITLE
fix(eventcard): NZ kennel date-chip TZ regression — always format event.date as UTC

### DIFF
--- a/src/components/hareline/EventCard.test.ts
+++ b/src/components/hareline/EventCard.test.ts
@@ -38,6 +38,12 @@ const GERIATRIX_TUE_MAY_19 = { date: "2026-05-19T12:00:00.000Z" };
 // #1517 that independently rules out a Tuesday-specific hypothesis.
 const HUSSIES_FRI_APR_24 = { date: "2026-04-24T12:00:00.000Z" };
 
+// US west-of-UTC sanity check (claude[bot] PR #1566 review). NY is UTC-5/-4;
+// the common-case kennel that was working before this PR must still work
+// after. UTC noon in NY is morning-same-day, never the previous day, so
+// `formatDate(event.date)` UTC-formatting always lands on the right day.
+const NYC_THU_MAY_28 = { date: "2026-05-28T12:00:00.000Z" };
+
 describe("EventCard chip + EventDetailPanel heading — NZ TZ regression (#1510/#1517/#1522)", () => {
   it("Capital H3 Mon Jun 1: chip reads 'Mon, Jun 1' (matches aria-label)", () => {
     expect(computeChipDate(CAPITAL_H3_MON_JUN_1)).toBe("Mon, Jun 1");
@@ -49,6 +55,10 @@ describe("EventCard chip + EventDetailPanel heading — NZ TZ regression (#1510/
 
   it("Auckland Hussies Fri Apr 24 (Mangawhai special): chip reads 'Fri, Apr 24'", () => {
     expect(computeChipDate(HUSSIES_FRI_APR_24)).toBe("Fri, Apr 24");
+  });
+
+  it("US west-of-UTC kennel Thu May 28: chip still reads 'Thu, May 28' (no regression on the common case)", () => {
+    expect(computeChipDate(NYC_THU_MAY_28)).toBe("Thu, May 28");
   });
 
   it("EventDetailPanel heading Capital H3 Mon Jun 1: reads 'Monday, June 1, 2026'", () => {

--- a/src/components/hareline/EventCard.test.ts
+++ b/src/components/hareline/EventCard.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { computeChipDate } from "./EventCard";
+import { computeHeadingDate } from "./EventDetailPanel";
+import { formatDateInZone } from "@/lib/timezone";
+
+/**
+ * Pre-cycle bundle 1: regression guard for the NZ kennel listing-page date
+ * chip bug (#1510 Geriatrix H3, #1517 Auckland Hussies, #1522 Capital H3).
+ *
+ * Root cause: when an event lacks a `startTime`, `src/pipeline/merge.ts:1261`
+ * sets `Event.dateUtc = Event.date` (UTC noon of the local day). The pre-fix
+ * EventCard formatted that UTC-noon timestamp in the kennel's IANA zone via
+ * `formatDateInZone`, which for Pacific/Auckland (UTC+12/13) rolls the day
+ * forward — the visible chip read "Wed, May 20" for an event whose
+ * aria-label correctly said "Tue, May 19".
+ *
+ * The fix: extract the chip/heading formatter into `computeChipDate` /
+ * `computeHeadingDate` (single source of truth) that always formats
+ * `event.date` (UTC noon) as UTC. This matches `buildAriaLabel`'s date
+ * emission and yields the correct local day for every kennel TZ.
+ *
+ * These tests import the same helpers the components call. A future
+ * refactor that swaps either helper back to `formatDateInZone(dateUtc, tz)`
+ * will fail the assertions below — the bug cannot resurface silently.
+ */
+
+const NZ_TZ = "Pacific/Auckland";
+
+// Capital H3 Run #2328 — Mon, Jun 1 2026. Monday cadence independently
+// rules out any weekday-specific heuristic; this is the case issue #1522
+// explicitly asked the regression test to cover.
+const CAPITAL_H3_MON_JUN_1 = { date: "2026-06-01T12:00:00.000Z" };
+
+// Geriatrix H3 — Tue May 19. Tuesday case from #1510.
+const GERIATRIX_TUE_MAY_19 = { date: "2026-05-19T12:00:00.000Z" };
+
+// Auckland Hussies Mangawhai special — Fri Apr 24. The Friday case from
+// #1517 that independently rules out a Tuesday-specific hypothesis.
+const HUSSIES_FRI_APR_24 = { date: "2026-04-24T12:00:00.000Z" };
+
+describe("EventCard chip + EventDetailPanel heading — NZ TZ regression (#1510/#1517/#1522)", () => {
+  it("Capital H3 Mon Jun 1: chip reads 'Mon, Jun 1' (matches aria-label)", () => {
+    expect(computeChipDate(CAPITAL_H3_MON_JUN_1)).toBe("Mon, Jun 1");
+  });
+
+  it("Geriatrix H3 Tue May 19: chip reads 'Tue, May 19'", () => {
+    expect(computeChipDate(GERIATRIX_TUE_MAY_19)).toBe("Tue, May 19");
+  });
+
+  it("Auckland Hussies Fri Apr 24 (Mangawhai special): chip reads 'Fri, Apr 24'", () => {
+    expect(computeChipDate(HUSSIES_FRI_APR_24)).toBe("Fri, Apr 24");
+  });
+
+  it("EventDetailPanel heading Capital H3 Mon Jun 1: reads 'Monday, June 1, 2026'", () => {
+    expect(computeHeadingDate(CAPITAL_H3_MON_JUN_1)).toBe("Monday, June 1, 2026");
+  });
+
+  it("regression guard: a refactor that revives `formatDateInZone(UTC-noon, Pacific/Auckland)` would roll Mon Jun 1 forward to Tue Jun 2", () => {
+    // Captures the exact trap the fix avoids. If a future refactor pipes
+    // `event.dateUtc` (the UTC-noon fallback) through `formatDateInZone` for
+    // the chip, the assertions above will start failing because chip text
+    // will diverge from aria-label. This assertion documents the trap.
+    const trapOutput = formatDateInZone(new Date(CAPITAL_H3_MON_JUN_1.date), NZ_TZ);
+    expect(trapOutput).toBe("Tue, Jun 2");
+  });
+});

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -15,7 +15,7 @@ import type { AttendanceData } from "@/components/logbook/CheckInButton";
 import { RegionBadge } from "./RegionBadge";
 import { useTimePreference } from "@/components/providers/time-preference-provider";
 import { getRegionColor } from "@/lib/region";
-import { formatTimeInZone, formatDateInZone, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
+import { formatTimeInZone, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
 import { useUnitsPreference } from "@/components/providers/units-preference-provider";
 import type { DailyWeather } from "@/lib/weather";
 import { getConditionEmoji, cToF } from "@/lib/weather-display";
@@ -99,7 +99,23 @@ function formatDate(iso: string): string {
   });
 }
 
-export { formatDate };
+/**
+ * Compute the display string for the event-card date chip.
+ *
+ * Always formats `event.date` as UTC. `event.date` is stored as UTC noon of
+ * the kennel-local day (PRD F.4), so UTC formatting yields the correct
+ * kennel-local day regardless of viewer or kennel timezone. This matches
+ * `buildAriaLabel`'s date emission and avoids the trap where merge.ts
+ * falls back to `dateUtc = event.date` (UTC noon) for startTime-less events
+ * and `formatDateInZone(dateUtc, kennelTZ)` rolls forward a day for kennels
+ * east of UTC (#1510, #1517, #1522).
+ *
+ * Exported as a single source of truth so the regression test exercises the
+ * same code the chip renders.
+ */
+export function computeChipDate(event: { date: string }): string {
+  return formatDate(event.date);
+}
 
 /**
  * Render a co-host kennel link with its own region-color underline accent
@@ -220,13 +236,10 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
   const isUserLocal = preference === "USER_LOCAL";
   const displayTz = isUserLocal ? getBrowserTimezone() : (event.timezone ?? "America/New_York");
 
-  // Choose standard date parsing if there's no reliable UTC timestamp, otherwise format in
-  // the kennel's region — the date chip answers "what day is this run on" and must match
-  // the source's local day, not the viewer's browser day. Browser TZ stays in charge of the
-  // time display below. (#1502)
-  const displayDateStr = event.dateUtc
-    ? formatDateInZone(event.dateUtc, event.timezone ?? displayTz)
-    : formatDate(event.date);
+  // See `computeChipDate` above for why we always format `event.date` as UTC
+  // and intentionally don't use `event.dateUtc` here (#1510, #1517, #1522).
+  // Time formatting below still uses `displayTz`. (#1502)
+  const displayDateStr = computeChipDate(event);
 
   const displayTimeStr = (event.dateUtc && event.startTime)
     ? formatTimeInZone(event.dateUtc, displayTz)

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -199,7 +199,9 @@ function buildAriaLabel(event: HarelineEvent, attendance?: AttendanceData | null
   }
   const { title, isFallback } = getDisplayTitle({ ...event, kennel: event.kennel ?? { shortName: "", fullName: "" } });
   if (!isFallback) parts.push(title);
-  parts.push(formatDate(event.date));
+  // Route through `computeChipDate` so chip + aria-label can never drift
+  // (per claude[bot] PR #1566 review).
+  parts.push(computeChipDate(event));
   if (event.runNumber) parts.push(`Run #${event.runNumber}`);
   if (event.startTime) parts.push(formatTime(event.startTime));
   // #1316 — surface card-visible structured fields to screen readers.

--- a/src/components/hareline/EventDetailPanel.tsx
+++ b/src/components/hareline/EventDetailPanel.tsx
@@ -15,12 +15,29 @@ import { getFullLocationDisplay } from "@/lib/event-display";
 import type { HarelineEvent } from "./EventCard";
 import { ShiggyLevelFlames, TrailLengthLine, formatTrailLength } from "./TrailDifficulty";
 import { useTimePreference } from "@/components/providers/time-preference-provider";
-import { formatTimeInZone, formatDateInZone, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
+import { formatTimeInZone, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
 import { CheckInButton } from "@/components/logbook/CheckInButton";
 import type { AttendanceData } from "@/components/logbook/CheckInButton";
 import { CalendarExportButton } from "./CalendarExportButton";
 import { EventLocationMap } from "./EventLocationMap";
 import { getRegionColor } from "@/lib/region";
+
+/**
+ * Compute the long-form display string for the detail-panel heading.
+ *
+ * Always formats `event.date` as UTC via `formatDateLong`. `event.date` is
+ * stored as UTC noon of the kennel-local day (PRD F.4), so UTC formatting
+ * yields the correct kennel-local day. We intentionally do NOT format
+ * `event.dateUtc` in the kennel's TZ — merge.ts falls back to
+ * `dateUtc = event.date` (UTC noon) when an event lacks a `startTime`, and
+ * `formatDateInZone(UTC-noon, Pacific/Auckland)` rolls the heading forward
+ * a day for kennels east of UTC (#1510, #1517, #1522).
+ *
+ * Exported so the regression test exercises the same code the heading renders.
+ */
+export function computeHeadingDate(event: { date: string }): string {
+  return formatDateLong(event.date);
+}
 
 interface EventDetailPanelProps {
   event: HarelineEvent | null;
@@ -54,12 +71,10 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
   const isUserLocal = preference === "USER_LOCAL";
   const displayTz = isUserLocal ? getBrowserTimezone() : (event.timezone ?? "America/New_York");
 
-  // Format the date in the kennel's region — answers "what day is this run on"
-  // in the source's local sense, matching the EventCard chip + aria-label.
-  // Browser TZ still drives the time line below. (#1502)
-  const displayDateStr = event.dateUtc
-    ? formatDateInZone(event.dateUtc, event.timezone ?? displayTz, "EEEE, MMMM d, yyyy")
-    : formatDateLong(event.date);
+  // See `computeHeadingDate` above for why we always format `event.date` as
+  // UTC and intentionally don't use `event.dateUtc` here (#1510, #1517,
+  // #1522). Time line below still uses `displayTz`. (#1502)
+  const displayDateStr = computeHeadingDate(event);
 
   const displayTimeStr = (event.dateUtc && event.startTime)
     ? formatTimeInZone(event.dateUtc, displayTz)


### PR DESCRIPTION
## Summary

Pre-cycle bundle 1: fixes the systemic kennel-listing date-chip timezone bug observed across three NZ kennels.

The cycle-9 #1502 fix (c29199d3) switched the EventCard chip + EventDetailPanel heading from `formatDateInZone(dateUtc, browserTz)` to `formatDateInZone(dateUtc, kennelTz)`, assuming `event.dateUtc` was always a "reliable UTC timestamp." The premise was wrong: [src/pipeline/merge.ts:1261](src/pipeline/merge.ts:1261) falls back to `dateUtc = eventDate` (UTC noon) when an event lacks a `startTime`, and rendering UTC noon in `Pacific/Auckland` (UTC+12/+13) rolls the chip forward a day.

Three NZ kennels reproduced the bug across **Mon/Tue/Fri** cadences, which independently rules out any weekday-specific heuristic:

| Issue | Kennel | Symptom |
|---|---|---|
| [#1510](https://github.com/johnrclem/hashtracks-web/issues/1510) | Geriatrix H3 | Tue displayed as Wed (8 events) |
| [#1517](https://github.com/johnrclem/hashtracks-web/issues/1517) | Auckland Hussies | Every weekday +1 day (9 events, mixed Mon/Tue/Fri) |
| [#1522](https://github.com/johnrclem/hashtracks-web/issues/1522) | Capital H3 | Mon displayed as Tue (4 events) |

## Fix

Always use `formatDate(event.date)` / `formatDateLong(event.date)` for the chip + heading. `event.date` is stored as UTC noon of the kennel-local day (PRD F.4), so UTC formatting yields the right local day for every TZ — matching the aria-label, which has used this same convention all along.

Extracted `computeChipDate(event)` and `computeHeadingDate(event)` as exported helpers so the regression test exercises the same code path the component renders (per Codex review — purely-inlined logic would make the test tautological).

## Live verification

```
$ curl -s http://localhost:3001/kennels/capital-h3-nz | grep -oE "(Mon|Tue|...), (May|Jun) [0-9]+" | sort -u
Mon, Jun 1   ✓  (issue #1522 expected aria-label)
Mon, Jun 15  ✓
Mon, Jun 8   ✓
Mon, May 25  ✓

$ curl -s http://localhost:3001/kennels/geriatrix-h3 | ...
Tue, May 26  ✓  (issue #1510 expected aria-label)
Tue, Jun 2   ✓
Tue, Jun 9   ✓
Tue, Jun 16  ✓

$ curl -s http://localhost:3001/kennels/auckland-hussies | ...
Mon, Jun 1   ✓  (issue #1517 — intentional Monday joint run with men's hash)
Tue, May 26  ✓
Tue, Jun 9   ✓
Tue, Jun 16  ✓
```

Each matches the corresponding issue's "aria-label (correct)" column verbatim.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 6921 passed, 0 failed
- [x] New regression test `src/components/hareline/EventCard.test.ts` — 5 assertions covering Capital H3 (Monday cadence — explicitly requested by #1522), Geriatrix H3 (Tuesday), Auckland Hussies Mangawhai (Friday), the EventDetailPanel heading, and a regression guard that documents the exact trap the fix avoids
- [x] Live-verified all three NZ kennel listing pages render correct weekdays
- [x] `/codex:adversarial-review` — initial pass flagged tautological test; rewritten to import the exported helpers by name. Final pass: "No findings."

Closes #1510
Closes #1517
Closes #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)