### PR TITLE
fix(nz): 5 kennel profile bundles (Geriatrix, Hussies, Capital, Hibiscus, CHH3)

### DIFF
--- a/prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql
+++ b/prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql
@@ -33,7 +33,7 @@ DECLARE
   v_logo_url            text := 'https://prodcdn.sporty.co.nz/cms/3076/logo.png';
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
-    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;  -- NOSONAR plsql:S1192
   END IF;
 
   UPDATE "Kennel"
@@ -65,7 +65,7 @@ DECLARE
   v_logo_url            text := 'https://prodcdn.sporty.co.nz/cms/5181/logo.gif';
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
-    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;  -- NOSONAR plsql:S1192
   END IF;
 
   UPDATE "Kennel"
@@ -96,7 +96,7 @@ DECLARE
   v_contact_email       text := 'trailmaster@aucklandhussies.co.nz';
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
-    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;  -- NOSONAR plsql:S1192
   END IF;
 
   UPDATE "Kennel"
@@ -119,7 +119,7 @@ DECLARE
   v_correct_description text := 'Hibiscus Coast hash kennel covering Orewa, Whangaparaoa, and the northern Auckland coast. Weekly Monday evening trails since 1987. No fees, no committee — an optional post-run meal and drinks are pay-as-you-go.';
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
-    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;  -- NOSONAR plsql:S1192
   END IF;
 
   UPDATE "Kennel"
@@ -136,7 +136,7 @@ DECLARE
   v_facebook_url text := 'https://www.facebook.com/groups/155409764478320/';
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
-    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;  -- NOSONAR plsql:S1192
   END IF;
 
   UPDATE "Kennel"

--- a/prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql
+++ b/prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql
@@ -1,0 +1,149 @@
+-- NZ quick-win profile bundle (#1507, #1514, #1520, #1525, #1532) — converge
+-- prod kennel fields with the refreshed seed data in prisma/seed-data/kennels.ts.
+--
+-- Why a migration and not just a seed update: `ensureKennelRecords`
+-- (prisma/seed.ts) only fills NULL profile fields on existing rows — it
+-- never overwrites populated ones. Capital H3 has a stale foundedYear
+-- (1979 → 1981 per the kennel's own history page), Geriatrix has a stale
+-- scheduleTime (5:30 PM → 6:30 PM per the source's "Next Run"), and
+-- several descriptions need refreshed copy that folds in hash cash prose.
+-- A plain seed change wouldn't reach end users without this UPDATE.
+--
+-- The null-only fills (facebookUrl, logoUrl, contactEmail, and the
+-- Geriatrix-only foundedYear since prod currently has it NULL) are also
+-- issued here via COALESCE so Vercel's automatic `migrate deploy` pushes
+-- them to prod without waiting for the next manual `prisma db seed`
+-- (see memory: feedback_post_merge_seed_required.md). Capital H3's
+-- foundedYear is a forced overwrite (1979 → 1981) handled separately
+-- via `IS DISTINCT FROM` since the prod value is non-NULL.
+--
+-- Idempotency: `IS DISTINCT FROM` gates make re-application a no-op on
+-- an already-corrected DB. A NOTICE surfaces missing-row situations on
+-- fresh / preview DBs.
+
+BEGIN;
+
+-- ── #1520: Capital H3 — foundedYear 1979→1981, description, FB, logo ─────────
+DO $$
+DECLARE
+  v_kennel_code         text := 'capital-h3-nz';
+  v_correct_founded     int  := 1981;
+  v_correct_description text := 'Founded 2 February 1981 by Mad Max with an inaugural run from the Thorndon Tavern (briefly in recess Nov 1981 until re-erected Sept 1983). Weekly Monday evening trails across Wellington and the wider Hutt Valley. Hash cash is $2 per run; food and drinks at the on-on are BYO.';
+  v_facebook_url        text := 'https://www.facebook.com/Capitalhhh/';
+  v_logo_url            text := 'https://prodcdn.sporty.co.nz/cms/3076/logo.png';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+  END IF;
+
+  UPDATE "Kennel"
+  SET "foundedYear" = v_correct_founded,
+      description   = v_correct_description,
+      "updatedAt"   = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND (
+      "foundedYear" IS DISTINCT FROM v_correct_founded
+      OR description IS DISTINCT FROM v_correct_description
+    );
+
+  UPDATE "Kennel"
+  SET "facebookUrl" = COALESCE("facebookUrl", v_facebook_url),
+      "logoUrl"     = COALESCE("logoUrl",     v_logo_url),
+      "updatedAt"   = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND ("facebookUrl" IS NULL OR "logoUrl" IS NULL);
+END $$;
+
+-- ── #1507: Geriatrix H3 — scheduleTime, scheduleNotes, description, foundedYear, logo ──
+DO $$
+DECLARE
+  v_kennel_code         text := 'geriatrix-h3';
+  v_correct_time        text := '6:30 PM';
+  v_correct_notes       text := 'Weekly Tuesday evenings at 6:30 PM. Each run lists venue, hare, and a map link.';
+  v_correct_description text := 'Wellington''s relaxed-pace Tuesday hash — "the drinking club with a running problem," founded 24 September 1985. Shorter, accessible trails around Wellington and Lower Hutt. Hash cash is $2 (non piss-stop) or $4 (piss-stop) per run; home runs are $15–$20 (cashless, direct credit preferred).';
+  v_correct_founded     int  := 1985;
+  v_logo_url            text := 'https://prodcdn.sporty.co.nz/cms/5181/logo.gif';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+  END IF;
+
+  UPDATE "Kennel"
+  SET "scheduleTime"  = v_correct_time,
+      "scheduleNotes" = v_correct_notes,
+      description     = v_correct_description,
+      "updatedAt"     = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND (
+      "scheduleTime"  IS DISTINCT FROM v_correct_time
+      OR "scheduleNotes" IS DISTINCT FROM v_correct_notes
+      OR description     IS DISTINCT FROM v_correct_description
+    );
+
+  UPDATE "Kennel"
+  SET "foundedYear" = COALESCE("foundedYear", v_correct_founded),
+      "logoUrl"     = COALESCE("logoUrl",     v_logo_url),
+      "updatedAt"   = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND ("foundedYear" IS NULL OR "logoUrl" IS NULL);
+END $$;
+
+-- ── #1514: Auckland Hussies — description + contactEmail ─────────────────────
+DO $$
+DECLARE
+  v_kennel_code         text := 'auckland-hussies';
+  v_correct_description text := 'Auckland''s women-founded hash, established 1978. Weekly Tuesday evening trails across Auckland with a published run list. Mixed attendance though women-led. Hash cash is $15 when starting from home or a park (pay-as-you-go at restaurants and pubs), plus $5 for drinks.';
+  v_contact_email       text := 'trailmaster@aucklandhussies.co.nz';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+  END IF;
+
+  UPDATE "Kennel"
+  SET description = v_correct_description,
+      "updatedAt" = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND description IS DISTINCT FROM v_correct_description;
+
+  UPDATE "Kennel"
+  SET "contactEmail" = COALESCE("contactEmail", v_contact_email),
+      "updatedAt"    = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND "contactEmail" IS NULL;
+END $$;
+
+-- ── #1525: Hibiscus H3 — description (folds in "no fees" hash cash prose) ────
+DO $$
+DECLARE
+  v_kennel_code         text := 'hibiscus-h3';
+  v_correct_description text := 'Hibiscus Coast hash kennel covering Orewa, Whangaparaoa, and the northern Auckland coast. Weekly Monday evening trails since 1987. No fees, no committee — an optional post-run meal and drinks are pay-as-you-go.';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+  END IF;
+
+  UPDATE "Kennel"
+  SET description = v_correct_description,
+      "updatedAt" = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND description IS DISTINCT FROM v_correct_description;
+END $$;
+
+-- ── #1532: Christchurch H3 — facebookUrl (group link) ────────────────────────
+DO $$
+DECLARE
+  v_kennel_code  text := 'christchurch-h3';
+  v_facebook_url text := 'https://www.facebook.com/groups/155409764478320/';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;
+  END IF;
+
+  UPDATE "Kennel"
+  SET "facebookUrl" = COALESCE("facebookUrl", v_facebook_url),
+      "updatedAt"   = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND "facebookUrl" IS NULL;
+END $$;
+
+COMMIT;

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3908,6 +3908,7 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "christchurch-h3", shortName: "CHH3", fullName: "Christchurch Hash House Harriers",
       region: "Christchurch, NZ", country: "New Zealand",
       website: "https://christchurchhash.net.nz",
+      facebookUrl: "https://www.facebook.com/groups/155409764478320/",
       foundedYear: 1979,
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       hashCash: "$7 (includes food)",
@@ -3932,7 +3933,7 @@ export const KENNELS: KennelSeed[] = [
       foundedYear: 1987,
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Monday evenings at 6:30 PM on Auckland's Hibiscus Coast (Orewa). Hareline published as a public Google Sheet.",
-      description: "Hibiscus Coast hash kennel covering Orewa, Whangaparaoa, and the northern Auckland coast. Weekly Monday evening trails since 1987.",
+      description: "Hibiscus Coast hash kennel covering Orewa, Whangaparaoa, and the northern Auckland coast. Weekly Monday evening trails since 1987. No fees, no committee — an optional post-run meal and drinks are pay-as-you-go.",
       latitude: -36.5868, longitude: 174.6968,
     },
     {
@@ -3960,21 +3961,28 @@ export const KENNELS: KennelSeed[] = [
       region: "Auckland, NZ", country: "New Zealand",
       website: "https://aucklandhussies.co.nz",
       facebookUrl: "https://www.facebook.com/AK.HASH.HARRIETS",
+      contactEmail: "trailmaster@aucklandhussies.co.nz",
       foundedYear: 1978,
       scheduleDayOfWeek: "Tuesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Tuesday evenings at 6:30 PM. Run list published as a static HTML table at /Run%20List.html.",
-      description: "Auckland's women-founded hash, established 1978. Weekly Tuesday evening trails across Auckland with a published run list. Mixed attendance though women-led.",
+      description: "Auckland's women-founded hash, established 1978. Weekly Tuesday evening trails across Auckland with a published run list. Mixed attendance though women-led. Hash cash is $15 when starting from home or a park (pay-as-you-go at restaurants and pubs), plus $5 for drinks.",
       latitude: -36.8485, longitude: 174.7633,
     },
     // ── sporty.co.nz CMS subsites — Wellington + Hamilton ──
     {
+      // #1520: these fields are also UPDATE'd in
+      // prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql
+      // because `ensureKennelRecords` only fills NULLs. Edits here must
+      // update that migration (or author a follow-up) to reach prod.
       kennelCode: "capital-h3-nz", shortName: "Capital H3", fullName: "Capital Hash House Harriers",
       region: "Wellington, NZ", country: "New Zealand",
       website: "https://www.sporty.co.nz/capitalh3",
-      foundedYear: 1979,
+      facebookUrl: "https://www.facebook.com/Capitalhhh/",
+      logoUrl: "https://prodcdn.sporty.co.nz/cms/3076/logo.png",
+      foundedYear: 1981,
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Monday evenings at 6:30 PM unless otherwise noted. Run list maintained on the homepage notices panel with run number, date, location, and hare.",
-      description: "Wellington's longest-running hash kennel — founded 1979 and still ticking past run 2,300. Weekly Monday evening trails across Wellington and the wider Hutt Valley.",
+      description: "Founded 2 February 1981 by Mad Max with an inaugural run from the Thorndon Tavern (briefly in recess Nov 1981 until re-erected Sept 1983). Weekly Monday evening trails across Wellington and the wider Hutt Valley. Hash cash is $2 per run; food and drinks at the on-on are BYO.",
       latitude: -41.2866, longitude: 174.7756,
     },
     {
@@ -3987,12 +3995,18 @@ export const KENNELS: KennelSeed[] = [
       latitude: -37.787, longitude: 175.2793,
     },
     {
+      // #1507: these fields are also UPDATE'd in
+      // prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql
+      // because `ensureKennelRecords` only fills NULLs. Edits here must
+      // update that migration (or author a follow-up) to reach prod.
       kennelCode: "geriatrix-h3", shortName: "Geriatrix H3", fullName: "Port Nicholson Geriatrix Hash House Harriers",
       region: "Wellington, NZ", country: "New Zealand",
       website: "https://www.sporty.co.nz/geriatrixhhh",
-      scheduleDayOfWeek: "Tuesday", scheduleTime: "5:30 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Weekly Tuesday afternoons. Hareline maintained as a CKEditor block on /Receding-Hareline/NewTab1 — date / venue / hare / map URL per run.",
-      description: "Wellington's relaxed-pace Tuesday hash with regular venue + hare + map information per run. Focuses on shorter, accessible trails around Wellington and Lower Hutt.",
+      logoUrl: "https://prodcdn.sporty.co.nz/cms/5181/logo.gif",
+      foundedYear: 1985,
+      scheduleDayOfWeek: "Tuesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
+      scheduleNotes: "Weekly Tuesday evenings at 6:30 PM. Each run lists venue, hare, and a map link.",
+      description: "Wellington's relaxed-pace Tuesday hash — \"the drinking club with a running problem,\" founded 24 September 1985. Shorter, accessible trails around Wellington and Lower Hutt. Hash cash is $2 (non piss-stop) or $4 (piss-stop) per run; home runs are $15–$20 (cashless, direct credit preferred).",
       latitude: -41.2866, longitude: 174.7756,
     },
   ];


### PR DESCRIPTION
## Summary

Quick Win bundle landing 5 NZ kennel profile bundles in one PR. Single seed file edit + one convergence migration to push the corrections through to prod (since `ensureKennelRecords` only fills NULLs).

## What changed

- **Capital H3** (#1520) — `foundedYear` 1979 → **1981** (kennel's own history page on sporty.co.nz says "founded in 1981 by Mad Max … inaugural run on 2 February"), `facebookUrl`, `logoUrl`, refreshed description with hash cash prose. The previous "Wellington's longest-running" framing was also wrong (Wellington Mens HHH @ 1976 is older) — corrected to reflect the founding-date + brief 1981–1983 hiatus.
- **Geriatrix H3** (#1507) — `foundedYear` 1985 (from the kennel's history page: "first meeting in forming Geri's was held on Tuesday 24th September 1985"), `logoUrl` (sporty.co.nz CDN), `scheduleTime` 5:30 PM → **6:30 PM** (source's "Next Run" listing shows 6:36pm, which is the verbatim source signal — treating as 6:30 PM with sensible rounding), refreshed description with the kennel's "drinking club with a running problem" tagline and hash cash prose.
- **Auckland Hussies** (#1514) — `contactEmail` (the source-published `trailmaster@aucklandhussies.co.nz` role inbox), refreshed description with hash cash prose. Logo intentionally skipped — source page has no `<img>`, no og:image, no favicon to embed.
- **Hibiscus H3** (#1525) — refreshed description with "no fees, no committee" hash cash prose (source: nzhhh.nz/hibiscus). The dead-bare-domain claim in the issue is already resolved in prod (`https://www.edmondsfamily.co.nz/community/hibiscus-hhh` is the stored value).
- **CHH3** (#1532) — `facebookUrl` (the Christchurch HHH FB group: `https://www.facebook.com/groups/155409764478320/`).

## hashCash handling

Per the cycle-10 user direction (and the deferred state of #1504), hash cash values are intentionally folded into the description prose rather than the dedicated `hashCash` field. A follow-up tracker issue will be filed referencing #1504 to catalogue the prose-captured values so a future schema migration can backfill them.

## How it's wired

1. **`prisma/seed-data/kennels.ts`** — 5 rows edited. The two rows that take forced overwrites (Capital + Geriatrix) carry an inline comment pointing at the migration file.
2. **`prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql`** — converges prod fields that the seed merge cannot reach:
   - `IS DISTINCT FROM` gates for forced overwrites (Capital `foundedYear`, all 4 affected descriptions, Geriatrix `scheduleTime` + `scheduleNotes`)
   - `COALESCE` for null-only fills (new `facebookUrl`, `logoUrl`, `contactEmail`, and Geriatrix's currently-NULL `foundedYear`) so Vercel's auto-`migrate deploy` pushes them to prod without waiting for a manual `prisma db seed` re-run.

Idempotent on re-application thanks to the gates + COALESCE pattern. `RAISE NOTICE` if the row is missing (fresh / preview DBs).

## Test plan

- [x] `npm run prisma -- migrate deploy` → migration applied cleanly locally
- [x] `npx prisma db seed` → re-ran successfully, no-op on already-converged rows
- [x] Direct SQL spot-check of all 5 kennels — `foundedYear` / `scheduleTime` / `facebookUrl` / `logoUrl` / `contactEmail` / description all match expected
- [x] `npm run lint` → 0 errors (20 pre-existing unrelated warnings)
- [x] `npx tsc --noEmit` → clean
- [x] `npm test` → 261 files / 6935 tests pass
- [x] `/codex:adversarial-review` → 2 low-severity comment-drift findings, both fixed
- [x] `code-simplifier` → tightened the 2 mirror-migration inline comments

Closes #1507
Closes #1514
Closes #1520
Closes #1525
Closes #1532

🤖 Generated with [Claude Code](https://claude.com/claude-code)