### PR TITLE
fix(klfmh3,kfmh3): backfill 10yr KLFMH3 history + profile bundles

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2563,7 +2563,8 @@ export const KENNELS: KennelSeed[] = [
     // ── Japan: Kansai ──
     {
       kennelCode: "kfmh3", shortName: "KFMH3", fullName: "Kinky Fully Mooned Hash House Harriers", region: "Kansai", country: "Japan",
-      website: "https://kfmh3.github.io/Home",
+      website: "https://kfmh3.github.io/Home/",
+      logoUrl: "https://kfmh3.github.io/Home/KFMH3.GIF",
       scheduleFrequency: "Monthly",
       scheduleNotes: "Sunday nearest full moon",
       hashCash: "¥1,000", foundedYear: 1994,
@@ -3251,10 +3252,12 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "klfmh3", shortName: "KL Full Moon", fullName: "KL Full Moon Hash House Harriers",
       region: "Kuala Lumpur, MY", country: "Malaysia",
       website: "https://klfullmoonhash.com",
-      scheduleDayOfWeek: "Varies", scheduleTime: "6:00 PM", scheduleFrequency: "Monthly",
-      scheduleNotes: "Runs once per lunar month on the night closest to the full moon. Hareline at klfullmoonhash.com/index.php?r=site/hareline.",
+      logoUrl: "https://klfullmoonhash.com/klfm_images/icon-klfm.png",
+      founder: "Chuck 'Titanic' Pollock",
+      scheduleDayOfWeek: "Sunday", scheduleTime: "6:00 PM", scheduleFrequency: "Monthly",
+      scheduleNotes: "Runs once per lunar month on the Sunday closest to the full moon. Hareline at klfullmoonhash.com/index.php?r=site/hareline.",
       foundedYear: 1992,
-      description: "Founded 11 September 1992 in Kuala Lumpur. A monthly full-moon hash — runs are scheduled around the lunar calendar rather than a fixed weekday. Approximately 144 runs since founding.",
+      description: "Founded 11 September 1992 in Kuala Lumpur by Chuck 'Titanic' Pollock. A monthly full-moon hash — runs are scheduled on the Sunday closest to the full moon rather than a fixed weekday. Approximately 144 runs since founding.",
       latitude: 3.139, longitude: 101.687,
     },
     {

--- a/scripts/backfill-klfmh3-history.ts
+++ b/scripts/backfill-klfmh3-history.ts
@@ -1,0 +1,101 @@
+/**
+ * One-shot historical backfill for KL Full Moon H3 (klfullmoonhash.com).
+ * Issue #1539.
+ *
+ * The kennel's Yii GridView hareline at
+ *   https://klfullmoonhash.com/index.php?r=site/hareline
+ * publishes 144 historical rows (Run #276 / 2015 → #413 / present + 6
+ * `runNumber=0` placeholders) across 12 paginated pages of 12 rows each.
+ * The recurring `YiiHarelineAdapter` only fetches the last few pages, so
+ * ~130 historical runs (#276 → #401) have never landed in HashTracks.
+ *
+ * **Strategy:** walk every page (page 1 → maxPage), reuse the shared Yii
+ * parser, and route through `reportAndApplyBackfill` so the merge pipeline
+ * dedupes against the recurring adapter's RawEvents and upserts canonical
+ * Events in a single pass.
+ *
+ * **Run No = 0 handling:** the shared Yii row parser skips `runNumber=0`
+ * rows by design (these are tripartite/cancelled placeholders). We mirror
+ * that here for behavioral parity with the recurring adapter — adding them
+ * would diverge state and require special schema-side handling. The 6
+ * dropped rows (3 CANCELLED + 3 tripartite/interhowl) are listed in
+ * issue #1539 for the audit log; if we ever want them, file a follow-up.
+ *
+ * **Idempotency + strict partitioning:** `reportAndApplyBackfill` filters
+ * to `date < today (Asia/Kuala_Lumpur)` so the recurring adapter still
+ * owns the upcoming window. Fingerprint dedup in `processRawEvents`
+ * makes re-runs a no-op.
+ *
+ * Usage:
+ *   Dry run:  set -a && source .env && set +a && npx tsx scripts/backfill-klfmh3-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-klfmh3-history.ts
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import { runBackfillScript } from "./lib/backfill-runner";
+import {
+  buildYiiPageUrl,
+  extractMaxYiiPage,
+  parseYiiHarelinePage,
+  type YiiHarelineConfig,
+} from "@/adapters/html-scraper/yii-hareline";
+import { safeFetch } from "@/adapters/safe-fetch";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "KL Full Moon H3 Hareline";
+const BASE_URL = "https://klfullmoonhash.com/index.php?r=site/hareline";
+const KENNEL_TIMEZONE = "Asia/Kuala_Lumpur";
+const CONFIG: YiiHarelineConfig = { kennelTag: "klfmh3", startTime: "18:00" };
+
+async function fetchPageHtml(pageNum: number): Promise<string> {
+  const url = buildYiiPageUrl(BASE_URL, pageNum);
+  const res = await safeFetch(url, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" },
+  });
+  if (!res.ok) throw new Error(`Page ${pageNum}: HTTP ${res.status}`);
+  return await res.text();
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.warn(`Walking ${BASE_URL} (Yii GridView, every page)`);
+  const page1Html = await fetchPageHtml(1);
+  const maxPage = extractMaxYiiPage(page1Html);
+  console.warn(`  Discovered maxPage = ${maxPage}`);
+
+  const allEvents: RawEventData[] = parseYiiHarelinePage(
+    cheerio.load(page1Html),
+    CONFIG,
+    BASE_URL,
+  );
+
+  for (let p = 2; p <= maxPage; p++) {
+    const html = await fetchPageHtml(p);
+    const events = parseYiiHarelinePage(cheerio.load(html), CONFIG, BASE_URL);
+    allEvents.push(...events);
+  }
+  console.warn(`  Raw rows parsed across ${maxPage} pages: ${allEvents.length}`);
+
+  // Dedupe by (runNumber, date) — the recurring adapter does the same; page
+  // tails can overlap if a row is added mid-walk.
+  const seen = new Set<string>();
+  const unique: RawEventData[] = [];
+  for (const e of allEvents) {
+    const key = `${e.runNumber ?? ""}|${e.date}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(e);
+  }
+  console.warn(`  Unique events after dedupe: ${unique.length}`);
+  return unique;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: `Walking klfullmoonhash.com Yii hareline (every page)`,
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-klfmh3-history.ts
+++ b/scripts/backfill-klfmh3-history.ts
@@ -77,7 +77,9 @@ async function fetchEvents(): Promise<RawEventData[]> {
   console.warn(`  Raw rows parsed across ${maxPage} pages: ${allEvents.length}`);
 
   // Dedupe by (runNumber, date) — the recurring adapter does the same; page
-  // tails can overlap if a row is added mid-walk.
+  // tails can overlap if a row is added mid-walk. KLFMH3 is monthly so `date`
+  // alone is unique in practice, but the key shape matches the YiiHarelineAdapter
+  // dedupe so we don't drift from the canonical fingerprint surface.
   const seen = new Set<string>();
   const unique: RawEventData[] = [];
   for (const e of allEvents) {

--- a/scripts/fix-kennel-data-klfmh3-kfmh3-2026-05.ts
+++ b/scripts/fix-kennel-data-klfmh3-kfmh3-2026-05.ts
@@ -13,8 +13,11 @@
  * The companion seed change adds new NULL fields (klfmh3.founder,
  * klfmh3.logoUrl, kfmh3.logoUrl) which seed-merge will handle on its own.
  *
- * Run after the PR merges:
- *   npx tsx scripts/fix-kennel-data-klfmh3-kfmh3-2026-05.ts
+ * Already applied 2026-05-21 against Railway prod (within the PR session).
+ * Kept in-repo for audit history; re-running is idempotent because every
+ * field is written to the same constant value.
+ *
+ *   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/fix-kennel-data-klfmh3-kfmh3-2026-05.ts
  */
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";

--- a/scripts/fix-kennel-data-klfmh3-kfmh3-2026-05.ts
+++ b/scripts/fix-kennel-data-klfmh3-kfmh3-2026-05.ts
@@ -1,0 +1,76 @@
+/**
+ * One-shot data correction for KLFMH3 (#1538) + KFMH3 (#1528) profile fields
+ * that seed-merge won't fix (seed only fills NULL fields, not overrides).
+ *
+ * - klfmh3: description and scheduleNotes both said "night closest to the
+ *   full moon" — the kennel's About page explicitly says "Sunday closest
+ *   to the Full Moon", and every event on the hareline lands on a Sunday.
+ * - kfmh3: website pointed at `https://kfmh3.github.io/Home` (no trailing
+ *   slash) which GitHub Pages serves OK in browsers but is the form the
+ *   audit issue flagged as inconsistent with the working canonical URL
+ *   (`/Home/`).
+ *
+ * The companion seed change adds new NULL fields (klfmh3.founder,
+ * klfmh3.logoUrl, kfmh3.logoUrl) which seed-merge will handle on its own.
+ *
+ * Run after the PR merges:
+ *   npx tsx scripts/fix-kennel-data-klfmh3-kfmh3-2026-05.ts
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const pool = createScriptPool();
+const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+async function main() {
+  const klfmh3 = await prisma.kennel.update({
+    where: { kennelCode: "klfmh3" },
+    data: {
+      founder: "Chuck 'Titanic' Pollock",
+      logoUrl: "https://klfullmoonhash.com/klfm_images/icon-klfm.png",
+      // "Varies" rendered as "Variess" via formatSchedule's blind +"s" and
+      // also leaked into the day filter via collectKennelWeekdays. The
+      // kennel's own About page says runs are on the Sunday closest to the
+      // full moon, and every hareline row lands on a Sunday.
+      scheduleDayOfWeek: "Sunday",
+      scheduleNotes:
+        "Runs once per lunar month on the Sunday closest to the full moon. Hareline at klfullmoonhash.com/index.php?r=site/hareline.",
+      description:
+        "Founded 11 September 1992 in Kuala Lumpur by Chuck 'Titanic' Pollock. A monthly full-moon hash — runs are scheduled on the Sunday closest to the full moon rather than a fixed weekday. Approximately 144 runs since founding.",
+    },
+    select: {
+      kennelCode: true,
+      founder: true,
+      logoUrl: true,
+      scheduleDayOfWeek: true,
+      scheduleNotes: true,
+      description: true,
+    },
+  });
+  console.log("Updated KLFMH3:", klfmh3);
+
+  const kfmh3 = await prisma.kennel.update({
+    where: { kennelCode: "kfmh3" },
+    data: {
+      website: "https://kfmh3.github.io/Home/",
+      logoUrl: "https://kfmh3.github.io/Home/KFMH3.GIF",
+    },
+    select: { kennelCode: true, website: true, logoUrl: true },
+  });
+  console.log("Updated KFMH3:", kfmh3);
+}
+
+async function run() {
+  try {
+    await main();
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await Promise.allSettled([prisma.$disconnect(), pool.end()]);
+  }
+}
+
+void run();

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -154,6 +154,15 @@ describe("formatSchedule", () => {
       expect(formatSchedule({ scheduleDayOfWeek: day })).toBe(day + "s");
     }
   });
+  it("does not pluralize non-weekday day text (e.g. KLFMH3 'Varies' #1538)", () => {
+    expect(
+      formatSchedule({
+        scheduleDayOfWeek: "Varies",
+        scheduleTime: "6:00 PM",
+        scheduleFrequency: "Monthly",
+      }),
+    ).toBe("Varies at 6:00 PM · Monthly");
+  });
 
   // Multi-cadence path (#1390): scheduleRules overrides the flat fields.
   describe("scheduleRules (multi-cadence path)", () => {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,5 +1,5 @@
 import { regionNameToSlug } from "@/lib/region";
-import { formatSeasonHint, type ScheduleSlot } from "@/lib/schedule-season";
+import { formatSeasonHint, WEEKDAY_NAMES, type ScheduleSlot } from "@/lib/schedule-season";
 import { parseRRule } from "@/adapters/static-schedule/rrule-parser";
 
 // Re-export ScheduleSlot from format.ts for backward compat with existing
@@ -295,10 +295,6 @@ function describeRruleDay(rrule: string): string | null {
   }
   return null;
 }
-
-const WEEKDAY_NAMES = [
-  "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
-] as const;
 
 /**
  * Ordinal WORD for the small set used in nth-weekday display ("1st", "last",

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -223,7 +223,13 @@ export function formatSchedule(kennel: {
   }
   const parts: string[] = [];
   if (kennel.scheduleDayOfWeek) {
-    parts.push(kennel.scheduleDayOfWeek + "s");
+    // Only pluralize recognized weekday names — guards against free-text
+    // values like "Varies" rendering as "Variess" (#1538). The seed
+    // currently forbids non-weekday values, but `collectKennelWeekdays`
+    // and the day filter would also misbehave if one slipped in, so this
+    // is defense-in-depth.
+    const isWeekday = WEEKDAY_NAMES.includes(kennel.scheduleDayOfWeek as (typeof WEEKDAY_NAMES)[number]);
+    parts.push(isWeekday ? kennel.scheduleDayOfWeek + "s" : kennel.scheduleDayOfWeek);
   }
   if (kennel.scheduleTime) {
     parts.push(parts.length ? `at ${kennel.scheduleTime}` : kennel.scheduleTime);

--- a/src/lib/schedule-season.ts
+++ b/src/lib/schedule-season.ts
@@ -23,7 +23,7 @@ const MONTH_ABBREV = [
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ] as const;
 
-const WEEKDAY_NAMES = [
+export const WEEKDAY_NAMES = [
   "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
 ] as const;
 


### PR DESCRIPTION
## Summary

Deep Dive bundling three issues: backfill KLFMH3's missing decade of history, and clean up profile fields on KLFMH3 + KFMH3 that the audit pipeline flagged.

- **#1539 — KLFMH3 history:** the recurring `YiiHarelineAdapter` only fetches the last few pages of the klfullmoonhash.com Yii GridView, so 116 historical RawEvents (Run #276 / 2015 → #401 / 2026, with #277 already partially present) had never landed. Walks all 12 source pages once via `reportAndApplyBackfill`, strict-partitioned to `date < today (Asia/Kuala_Lumpur)` so the recurring adapter still owns the upcoming window.
- **#1538 — KLFMH3 profile:** founder, logoUrl, schedule label/description fixes.
- **#1528 — KFMH3 profile:** websiteUrl trailing-slash + logoUrl.

## What's in the diff

1. `scripts/backfill-klfmh3-history.ts` — one-shot every-page Yii hareline walker.
2. `scripts/fix-kennel-data-klfmh3-kfmh3-2026-05.ts` — companion prod UPDATE script for fields seed-merge can't override (non-null values). **Already applied during this session.**
3. `prisma/seed-data/kennels.ts` — klfmh3: add `founder`, `logoUrl`, change `scheduleDayOfWeek` "Varies" → "Sunday" (every hareline row lands on Sunday — confirmed via the kennel's About page + every backfilled date); kfmh3: add `logoUrl`, fix `website` to `/Home/`.
4. `src/lib/format.ts` — defensive guard in `formatSchedule()`: only pluralize recognized weekday names. Originally written to fix the "Varies" → "Variess" rendering bug, kept as defense-in-depth after switching the data to "Sunday".
5. `src/lib/format.test.ts` — one test exercising the guard.

## Verification

Backfill apply against Railway:

```
created=116 updated=2 skipped=12 blocked=0 eventErrors=0
```

Post-backfill DB state for klfmh3:

```
past_events: 130  (was 14, +116 created)

Oldest 3:
  #276 2015-01-11  KL Full Moon Trail #276   Patsy Yap
  #277 2015-01-18  Tripartite                Les Sposito
  #278 2015-02-08  KL Full Moon Trail #278   Nalini

Newest 3 past:
  #405 2026-05-10  Margie's Memorial run     Ken Gurusamy
  #404 2026-04-05  AGM run                   ErikB
  #403 2026-03-22  St. Patrick's Day run     Jason Moriarty
```

URL/asset checks:

```
HTTP 200 image/png   https://klfullmoonhash.com/klfm_images/icon-klfm.png
HTTP 200 image/gif   https://kfmh3.github.io/Home/KFMH3.GIF
HTTP 200 text/html   https://kfmh3.github.io/Home/
```

Adversarial review (codex) caught that "Varies" would also leak into `collectKennelWeekdays` and break the day filter — fixed by switching `scheduleDayOfWeek` to "Sunday".

Browser preview deliberately not exercised: the only dev server on :3000 belongs to a parallel worktree (per the scope-boundary note). The format.ts change is covered by the new unit test + 111 pre-existing tests; the prod DB and live asset URLs are confirmed.

## Notes

- Run-No = 0 placeholders (3 CANCELLED + 3 tripartite/interhowl) intentionally skipped for parity with the recurring `YiiHarelineAdapter`. If we ever want to surface them, file a follow-up.
- The fix script was already applied. Re-running it is idempotent (no-op when values already match).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (20 pre-existing warnings unchanged)
- [x] `npm test` — 6936 pass, 2 skipped, 25 todo
- [x] Prod DB verified via `psql` SELECT
- [x] /codex:adversarial-review (1 finding addressed)
- [x] /simplify (nothing to simplify)

Closes #1539
Closes #1538
Closes #1528

🤖 Generated with [Claude Code](https://claude.com/claude-code)