### PR TITLE
fix(adapters): WS5 source-mismatch bundle — 7 placeholder + leak fixes

### DIFF
--- a/scripts/live-verify-ws5-bundle.ts
+++ b/scripts/live-verify-ws5-bundle.ts
@@ -1,0 +1,165 @@
+/**
+ * Live verification for the WS5 source-mismatch bundle.
+ *
+ *   #1547 ABQ H3              — GCal: no date-range haresText
+ *   #1549 RVA (Richmond)      — GCal: no "CLAIM THIS TRAIL" titles
+ *   #1551 Wasatch H3          — GCal: hares stops at first sentence
+ *   #1557 Memphis FB          — FB: no trailing " -" / " :" in titles
+ *   #1548 Sydney Thirsty H3   — HTML: no "at the map location below" in location
+ *   #1550 BH4 (Big Hump)      — HTML: no haresText "Open" + h4 subtitle preserved
+ *
+ * Run: `set -a && source .env && set +a && npx tsx scripts/live-verify-ws5-bundle.ts`
+ *
+ * Exits non-zero when any check detects a regression OR when a fetch
+ * fails — usable as a CI gate. Read-only.
+ */
+import "dotenv/config";
+import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
+import { FacebookHostedEventsAdapter } from "@/adapters/facebook-hosted-events/adapter";
+import { SydneyThirstyH3Adapter } from "@/adapters/html-scraper/sydney-thirsty-h3";
+import { BigHumpAdapter } from "@/adapters/html-scraper/big-hump";
+import type { RawEventData } from "@/adapters/types";
+import { SOURCES } from "../prisma/seed-data/sources";
+import type { Source } from "@/generated/prisma/client";
+
+type AnyAdapter = { fetch: (source: Source, options?: { days?: number }) => Promise<{ events: RawEventData[]; diagnosticContext?: unknown }> };
+
+interface Check {
+  label: string;
+  predicate: (e: RawEventData) => boolean;
+}
+
+interface Target {
+  sourceName: string;
+  describe: string;
+  adapter: AnyAdapter;
+  checks: Check[];
+  summary?: (events: RawEventData[]) => string[];
+  sampleLimit?: number;
+}
+
+function formatSample(e: RawEventData): string {
+  const time = e.startTime ?? "all-day";
+  const titleSlice = (e.title ?? "").slice(0, 80);
+  const runSuffix = e.runNumber ? ` | run=${e.runNumber}` : "";
+  const locSuffix = e.location ? ` | loc=${JSON.stringify(e.location.slice(0, 60))}` : "";
+  return `[${e.date} ${time}] title=${JSON.stringify(titleSlice)} | hares=${e.hares ?? "—"}${runSuffix}${locSuffix}`;
+}
+
+const DATE_RANGE_RE = /\b\d{1,2}\s*\/\s*\d{1,2}\b/;
+
+const TARGETS: Target[] = [
+  {
+    sourceName: "ABQ H3 Google Calendar",
+    describe: "#1547 — no slash-date date-range strings in haresText",
+    adapter: new GoogleCalendarAdapter(),
+    checks: [
+      { label: "haresText with M/D date tokens", predicate: (e) => !!e.hares && DATE_RANGE_RE.test(e.hares) },
+    ],
+    summary: (events) => [`with hares: ${events.filter((e) => !!e.hares).length}`],
+  },
+  {
+    sourceName: "Richmond H3 Google Calendar",
+    describe: "#1549 — no 'CLAIM THIS TRAIL' placeholder events ingested",
+    adapter: new GoogleCalendarAdapter(),
+    checks: [
+      { label: "titles containing 'CLAIM THIS TRAIL'", predicate: (e) => !!e.title && /\bclaim\s+this\s+trail\b/i.test(e.title) },
+    ],
+  },
+  {
+    sourceName: "Whoreman H3 Calendar",
+    describe: "#1551 — haresText truncated at first sentence boundary",
+    adapter: new GoogleCalendarAdapter(),
+    checks: [
+      // Description leak signal: hare text containing a period followed by
+      // 3+ words. The new HARE_SENTENCE_TRAILER_RE should strip these.
+      { label: "haresText with sentence trailer", predicate: (e) => !!e.hares && /\.\s+\S+(?:\s+\S+){2,}/.test(e.hares) },
+    ],
+    summary: (events) => [`with hares: ${events.filter((e) => !!e.hares).length}`],
+  },
+  {
+    sourceName: "Memphis H3 Facebook Hosted Events",
+    describe: "#1557 — no titles ending in ' -' / ' —' / ' :'",
+    adapter: new FacebookHostedEventsAdapter(),
+    checks: [
+      { label: "titles ending in trailing delimiter", predicate: (e) => !!e.title && /\s+[-–—:]\s*$/.test(e.title) },
+    ],
+  },
+  {
+    sourceName: "Sydney Thirsty H3 Upcoming Runs",
+    describe: "#1548 — 'at the map location below' boilerplate stripped",
+    adapter: new SydneyThirstyH3Adapter(),
+    checks: [
+      { label: "location containing 'at the map location below'", predicate: (e) => !!e.location && /at the map location below/i.test(e.location) },
+    ],
+    summary: (events) => [`with location: ${events.filter((e) => !!e.location).length}`],
+  },
+  {
+    sourceName: "Big Hump H3 Hareline",
+    describe: "#1550 — no haresText 'Open' placeholder; h4 subtitles preserved",
+    adapter: new BigHumpAdapter(),
+    checks: [
+      { label: "haresText literal 'Open'", predicate: (e) => !!e.hares && /^open$/i.test(e.hares) },
+    ],
+    summary: (events) => {
+      const withSubtitle = events.filter((e) => {
+        if (!e.title || !e.hares) return false;
+        // h4 was "<hare> <verb> ... @ <venue>" → preserved title includes the verb phrase.
+        return e.title.toLowerCase().startsWith(e.hares.toLowerCase() + " ") && e.title.includes(" @ ") && !e.title.startsWith("BH4 #");
+      });
+      return [`with hares: ${events.filter((e) => !!e.hares).length}`, `with subtitle-preserved title: ${withSubtitle.length}`];
+    },
+    sampleLimit: 12,
+  },
+];
+
+async function runTarget(target: Target): Promise<number> {
+  const seedRow = SOURCES.find((s) => s.name === target.sourceName);
+  console.log(`\n## ${target.sourceName}`);
+  console.log(`   ${target.describe}`);
+  if (!seedRow) {
+    console.log(`   NOT FOUND IN SEED`);
+    return 1;
+  }
+  const source = {
+    id: "stub",
+    name: seedRow.name,
+    url: seedRow.url,
+    type: seedRow.type as Source["type"],
+    enabled: true,
+    config: (seedRow as { config?: unknown }).config ?? null,
+    scrapeDays: (seedRow as { scrapeDays?: number }).scrapeDays ?? 365,
+  } as unknown as Source;
+  try {
+    const result = await target.adapter.fetch(source, { days: 365 });
+    console.log(`   events: ${result.events.length}`);
+    for (const line of target.summary?.(result.events) ?? []) console.log(`   ${line}`);
+    let failedChecks = 0;
+    for (const check of target.checks) {
+      const violators = result.events.filter(check.predicate);
+      console.log(`   ${check.label}: ${violators.length} (expect 0)`);
+      if (violators.length > 0) {
+        failedChecks += violators.length;
+        for (const e of violators.slice(0, 5)) console.log(`     VIOLATION ${formatSample(e)}`);
+      }
+    }
+    for (const e of result.events.slice(0, target.sampleLimit ?? 6)) console.log(`   ${formatSample(e)}`);
+    if (failedChecks > 0) console.log(`   ✗ ${failedChecks} regression(s) detected`);
+    return failedChecks;
+  } catch (err) {
+    console.log(`   FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+async function main() {
+  if (!process.env.GOOGLE_CALENDAR_API_KEY) {
+    throw new Error("GOOGLE_CALENDAR_API_KEY not set — source .env first");
+  }
+  let failures = 0;
+  for (const target of TARGETS) failures += await runTarget(target);
+  console.log(failures === 0 ? "\n✓ All targets clean" : `\n✗ ${failures} regression(s) / fetch failure(s)`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/scripts/live-verify-ws5-bundle.ts
+++ b/scripts/live-verify-ws5-bundle.ts
@@ -23,18 +23,14 @@ import { SOURCES } from "../prisma/seed-data/sources";
 import type { Source } from "@/generated/prisma/client";
 
 type AnyAdapter = { fetch: (source: Source, options?: { days?: number }) => Promise<{ events: RawEventData[]; diagnosticContext?: unknown }> };
-
-interface Check {
-  label: string;
-  predicate: (e: RawEventData) => boolean;
-}
+type Predicate = (e: RawEventData) => boolean;
 
 interface Target {
   sourceName: string;
   describe: string;
   adapter: AnyAdapter;
-  checks: Check[];
-  summary?: (events: RawEventData[]) => string[];
+  checks: { label: string; predicate: Predicate }[];
+  countField?: "hares" | "location";
   sampleLimit?: number;
 }
 
@@ -48,75 +44,59 @@ function formatSample(e: RawEventData): string {
 
 const DATE_RANGE_RE = /\b\d{1,2}\s*\/\s*\d{1,2}\b/;
 
+const gcal = new GoogleCalendarAdapter();
 const TARGETS: Target[] = [
   {
     sourceName: "ABQ H3 Google Calendar",
     describe: "#1547 — no slash-date date-range strings in haresText",
-    adapter: new GoogleCalendarAdapter(),
-    checks: [
-      { label: "haresText with M/D date tokens", predicate: (e) => !!e.hares && DATE_RANGE_RE.test(e.hares) },
-    ],
-    summary: (events) => [`with hares: ${events.filter((e) => !!e.hares).length}`],
+    adapter: gcal,
+    checks: [{ label: "haresText with M/D date tokens", predicate: (e) => !!e.hares && DATE_RANGE_RE.test(e.hares) }],
+    countField: "hares",
   },
   {
     sourceName: "Richmond H3 Google Calendar",
     describe: "#1549 — no 'CLAIM THIS TRAIL' placeholder events ingested",
-    adapter: new GoogleCalendarAdapter(),
-    checks: [
-      { label: "titles containing 'CLAIM THIS TRAIL'", predicate: (e) => !!e.title && /\bclaim\s+this\s+trail\b/i.test(e.title) },
-    ],
+    adapter: gcal,
+    checks: [{ label: "titles containing 'CLAIM THIS TRAIL'", predicate: (e) => !!e.title && /\bclaim\s+this\s+trail\b/i.test(e.title) }],
   },
   {
     sourceName: "Whoreman H3 Calendar",
     describe: "#1551 — haresText truncated at first sentence boundary",
-    adapter: new GoogleCalendarAdapter(),
-    checks: [
-      // Description leak signal: hare text containing a period followed by
-      // 3+ words. The new HARE_SENTENCE_TRAILER_RE should strip these.
-      { label: "haresText with sentence trailer", predicate: (e) => !!e.hares && /\.\s+\S+(?:\s+\S+){2,}/.test(e.hares) },
-    ],
-    summary: (events) => [`with hares: ${events.filter((e) => !!e.hares).length}`],
+    adapter: gcal,
+    // Description leak signal: hare text containing a period followed by 3+ words.
+    checks: [{ label: "haresText with sentence trailer", predicate: (e) => !!e.hares && /\.\s+\S+(?:\s+\S+){2,}/.test(e.hares) }],
+    countField: "hares",
   },
   {
     sourceName: "Memphis H3 Facebook Hosted Events",
     describe: "#1557 — no titles ending in ' -' / ' —' / ' :'",
     adapter: new FacebookHostedEventsAdapter(),
-    checks: [
-      { label: "titles ending in trailing delimiter", predicate: (e) => !!e.title && /\s+[-–—:]\s*$/.test(e.title) },
-    ],
+    checks: [{ label: "titles ending in trailing delimiter", predicate: (e) => !!e.title && /\s+[-–—:]\s*$/.test(e.title) }],
   },
   {
     sourceName: "Sydney Thirsty H3 Upcoming Runs",
     describe: "#1548 — 'at the map location below' boilerplate stripped",
     adapter: new SydneyThirstyH3Adapter(),
-    checks: [
-      { label: "location containing 'at the map location below'", predicate: (e) => !!e.location && /at the map location below/i.test(e.location) },
-    ],
-    summary: (events) => [`with location: ${events.filter((e) => !!e.location).length}`],
+    checks: [{ label: "location containing 'at the map location below'", predicate: (e) => !!e.location && /at the map location below/i.test(e.location) }],
+    countField: "location",
   },
   {
     sourceName: "Big Hump H3 Hareline",
-    describe: "#1550 — no haresText 'Open' placeholder; h4 subtitles preserved",
+    describe: "#1550 — no haresText 'Open' placeholder",
     adapter: new BigHumpAdapter(),
-    checks: [
-      { label: "haresText literal 'Open'", predicate: (e) => !!e.hares && /^open$/i.test(e.hares) },
-    ],
-    summary: (events) => {
-      const withSubtitle = events.filter((e) => {
-        if (!e.title || !e.hares) return false;
-        // h4 was "<hare> <verb> ... @ <venue>" → preserved title includes the verb phrase.
-        return e.title.toLowerCase().startsWith(e.hares.toLowerCase() + " ") && e.title.includes(" @ ") && !e.title.startsWith("BH4 #");
-      });
-      return [`with hares: ${events.filter((e) => !!e.hares).length}`, `with subtitle-preserved title: ${withSubtitle.length}`];
-    },
+    checks: [{ label: "haresText literal 'Open'", predicate: (e) => !!e.hares && /^open$/i.test(e.hares) }],
+    countField: "hares",
     sampleLimit: 12,
   },
 ];
 
+function countWith(events: RawEventData[], field: "hares" | "location"): number {
+  return events.filter((e) => !!e[field]).length;
+}
+
 async function runTarget(target: Target): Promise<number> {
   const seedRow = SOURCES.find((s) => s.name === target.sourceName);
-  console.log(`\n## ${target.sourceName}`);
-  console.log(`   ${target.describe}`);
+  console.log(`\n## ${target.sourceName}\n   ${target.describe}`);
   if (!seedRow) {
     console.log(`   NOT FOUND IN SEED`);
     return 1;
@@ -133,19 +113,19 @@ async function runTarget(target: Target): Promise<number> {
   try {
     const result = await target.adapter.fetch(source, { days: 365 });
     console.log(`   events: ${result.events.length}`);
-    for (const line of target.summary?.(result.events) ?? []) console.log(`   ${line}`);
-    let failedChecks = 0;
-    for (const check of target.checks) {
-      const violators = result.events.filter(check.predicate);
-      console.log(`   ${check.label}: ${violators.length} (expect 0)`);
+    if (target.countField) console.log(`   with ${target.countField}: ${countWith(result.events, target.countField)}`);
+    let failed = 0;
+    for (const { label, predicate } of target.checks) {
+      const violators = result.events.filter(predicate);
+      console.log(`   ${label}: ${violators.length} (expect 0)`);
       if (violators.length > 0) {
-        failedChecks += violators.length;
+        failed += violators.length;
         for (const e of violators.slice(0, 5)) console.log(`     VIOLATION ${formatSample(e)}`);
       }
     }
     for (const e of result.events.slice(0, target.sampleLimit ?? 6)) console.log(`   ${formatSample(e)}`);
-    if (failedChecks > 0) console.log(`   ✗ ${failedChecks} regression(s) detected`);
-    return failedChecks;
+    if (failed > 0) console.log(`   ✗ ${failed} regression(s) detected`);
+    return failed;
   } catch (err) {
     console.log(`   FAILED: ${err instanceof Error ? err.message : String(err)}`);
     return 1;

--- a/scripts/live-verify-ws5-bundle.ts
+++ b/scripts/live-verify-ws5-bundle.ts
@@ -64,6 +64,7 @@ const TARGETS: Target[] = [
     describe: "#1551 — haresText truncated at first sentence boundary",
     adapter: gcal,
     // Description leak signal: hare text containing a period followed by 3+ words.
+    // NOSONAR S5852 — verification script, bounded input, not a server hot path.
     checks: [{ label: "haresText with sentence trailer", predicate: (e) => !!e.hares && /\.\s+\S+(?:\s+\S+){2,}/.test(e.hares) }],
     countField: "hares",
   },

--- a/scripts/live-verify-ws5-bundle.ts
+++ b/scripts/live-verify-ws5-bundle.ts
@@ -64,15 +64,14 @@ const TARGETS: Target[] = [
     describe: "#1551 — haresText truncated at first sentence boundary",
     adapter: gcal,
     // Description leak signal: hare text containing a period followed by 3+ words.
-    // NOSONAR S5852 — verification script, bounded input, not a server hot path.
-    checks: [{ label: "haresText with sentence trailer", predicate: (e) => !!e.hares && /\.\s+\S+(?:\s+\S+){2,}/.test(e.hares) }],
+    checks: [{ label: "haresText with sentence trailer", predicate: (e) => !!e.hares && /\.\s+\S+(?:\s+\S+){2,}/.test(e.hares) }], // NOSONAR S5852 — verification script, bounded input, not a server hot path
     countField: "hares",
   },
   {
     sourceName: "Memphis H3 Facebook Hosted Events",
     describe: "#1557 — no titles ending in ' -' / ' —' / ' :'",
     adapter: new FacebookHostedEventsAdapter(),
-    checks: [{ label: "titles ending in trailing delimiter", predicate: (e) => !!e.title && /\s+[-–—:]\s*$/.test(e.title) }],
+    checks: [{ label: "titles ending in trailing delimiter", predicate: (e) => !!e.title && /\s+[-–—:]\s*$/.test(e.title) }], // NOSONAR S5852 — verification script, anchored end-of-string char class
   },
   {
     sourceName: "Sydney Thirsty H3 Upcoming Runs",

--- a/src/adapters/facebook-hosted-events/parser.test.ts
+++ b/src/adapters/facebook-hosted-events/parser.test.ts
@@ -417,6 +417,39 @@ function rawFromTitle(title: string) {
   return parseFacebookHostedEvents(html, { kennelTag: "h6" })[0];
 }
 
+describe("facebookEventToRawEvent — title trailing-delimiter strip (#1557 Memphis)", () => {
+  const baseEvent = {
+    id: "1234567890123456",
+    startTimestamp: 1714521600,
+    isCanceled: false,
+  };
+
+  it.each([
+    ["GyNO H3 Trail 8 -", "GyNO H3 Trail 8"],
+    ["MH3 Trail -", "MH3 Trail"],
+    ["Trail #42 —", "Trail #42"],
+    ["Trail #42 –", "Trail #42"],
+    ["Trail #42 :", "Trail #42"],
+    ["Trail #42 - ", "Trail #42"],
+  ])("strips trailing delimiter from %s", (raw, expected) => {
+    const result = facebookEventToRawEvent(
+      { ...baseEvent, name: raw },
+      "mh3-tn",
+      "America/New_York",
+    );
+    expect(result?.title).toBe(expected);
+  });
+
+  it("preserves a real mid-string dash", () => {
+    const result = facebookEventToRawEvent(
+      { ...baseEvent, name: "Trail - Red Dress Run" },
+      "mh3-tn",
+      "America/New_York",
+    );
+    expect(result?.title).toBe("Trail - Red Dress Run");
+  });
+});
+
 describe("bagToRawEvent — runNumber extraction (#1319)", () => {
   it.each([
     ["…HapPy Hour ~ Boston Johnny's May's Birthday Party ~ H6#307", 307],

--- a/src/adapters/facebook-hosted-events/parser.ts
+++ b/src/adapters/facebook-hosted-events/parser.ts
@@ -438,10 +438,19 @@ type BagOutcome =
   | { kind: "event"; event: RawEventData }
   | { kind: "rejected"; reason: FbBagRejectReason };
 
+// Title trailing-delimiter strip (#1557 Memphis): Page admins frequently
+// leave templated suffixes like " - " in the FB event name when the theme
+// segment is empty ("MH3 Trail -", "GyNO H3 Trail 8 -"). Anchored to
+// end-of-string, single char class — Sonar S5852 safe. Mirrors the GCal
+// adapter strip in `google-calendar/adapter.ts` (#756 / #1060).
+const TITLE_TRAILING_DELIMITER_RE = /\s*[-–—:]\s*$/; // NOSONAR — anchored end-of-string strip, single char class
+
 function projectBag(bag: EventBag, kennelTag: string, timezone: string): BagOutcome {
   if (!bag.time || !bag.rich) return { kind: "rejected", reason: "missing-half" };
   if (bag.rich.is_canceled === true) return { kind: "rejected", reason: "cancelled" };
-  const title = bag.rich.name?.trim() || undefined;
+  // Inner `.trim()` is needed before the regex so the anchored `\s*$` strip
+  // sees a delimiter at the end; the regex itself absorbs surrounding spaces.
+  const title = bag.rich.name?.trim().replace(TITLE_TRAILING_DELIMITER_RE, "") || undefined;
   if (!title) return { kind: "rejected", reason: "no-title" };
   const ms = bag.time.start_timestamp * 1000;
   const instant = new Date(ms);

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -2127,6 +2127,39 @@ describe("buildRawEventFromGCalItem — parenthetical hare extraction", () => {
   });
 });
 
+describe("buildRawEventFromGCalItem — #1547 date-range parenthetical rejection", () => {
+  it("strips '(Friday 5/22-Monday 5/25)' date range from ABQ campout title and does NOT set hares", () => {
+    const event = buildRawEventFromGCalItem(
+      {
+        summary: "DoT Birthday Weekend Campout (Friday 5/22-Monday 5/25)",
+        start: { dateTime: "2026-05-22T12:00:00-06:00" },
+        status: "confirmed",
+      },
+      { defaultKennelTag: "abqh3" },
+    );
+    expect(event).not.toBeNull();
+    expect(event!.title).toBe("DoT Birthday Weekend Campout");
+    expect(event!.hares).toBeUndefined();
+  });
+
+  it.each<[string]>([
+    ["Trail Camp (May 22-25)"],         // word-range, no slashes — preserved (not a M/D pair)
+    ["Trail Camp (5/22-5/25)"],         // bare slash range
+    ["Trail #100 (Fri 5/22 - Mon 5/25)"], // weekday-abbreviated slash range
+  ])("strips slash-date paren from %s", (summary) => {
+    const event = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-05-22T12:00:00-06:00" }, status: "confirmed" },
+      { defaultKennelTag: "abqh3" },
+    );
+    expect(event).not.toBeNull();
+    if (summary.includes("/")) {
+      // Slash pattern: paren is treated as instructional date hint → stripped, no hares.
+      expect(event!.title).not.toMatch(/\(/);
+      expect(event!.hares).toBeUndefined();
+    }
+  });
+});
+
 describe("buildRawEventFromGCalItem — w/ hare-location extraction", () => {
   it("extracts hares and location from 'w/' pattern", () => {
     const item = {

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -344,6 +344,11 @@ const NON_NAME_PAREN_RE = /\b(?:to|from|no|not|only|all|free|via|and back|cancel
  * them.
  */
 const ACRONYM_PAREN_RE = /^(?:\d+\s*[a-z]{0,2}|AM|PM|BYOB|TBD|TBA|TBC|FYI|NSFW|DNF|DNS|RIP)$/i;
+// #1547 ABQ: parenthetical date-range strings like "(Friday 5/22-Monday 5/25)"
+// are multi-day campout date hints, not hare names. M/D digit pair is the
+// reliable signal — real hare names never contain slash-separated date
+// tokens. Mirrors the same DATE_RANGE_RE in hare-extraction.ts.
+const DATE_RANGE_PAREN_RE = /\b\d{1,2}\s*\/\s*\d{1,2}\b/;
 const MAX_HARE_PAREN_LENGTH = 40;
 
 /**
@@ -1211,7 +1216,13 @@ export function buildRawEventFromGCalItem(
   const parenMatch = TITLE_TRAILING_PAREN_RE.exec(title);
   if (parenMatch) {
     const inner = parenMatch[1].trim();
-    const isInstructional = inner.length > MAX_HARE_PAREN_LENGTH || INSTRUCTIONAL_PAREN_RE.test(inner);
+    // #1547: a parenthetical date-range like "(Friday 5/22-Monday 5/25)" is
+    // a multi-day campout date hint, not a hare name OR a title element —
+    // treat it as instructional ("(posted Sunday)" etc.) so it gets stripped.
+    const isInstructional =
+      inner.length > MAX_HARE_PAREN_LENGTH ||
+      INSTRUCTIONAL_PAREN_RE.test(inner) ||
+      DATE_RANGE_PAREN_RE.test(inner);
     // #1444 — three independent reject checks. NON_NAME catches descriptive
     // and status words; ACRONYM catches CTAs/units; isInitialsWordplay
     // catches the Larryville pattern (preceding caps + matching lowercase

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -238,6 +238,62 @@ describe("extractHares — anchored single-case scenarios", () => {
   });
 });
 
+describe("extractHares — description-sentence trailer strip (#1551 Wasatch)", () => {
+  it.each([
+    {
+      name: "single name + sentence description",
+      desc: "hare: Nipples. A Wasarch/Bash crossover event. Bring your bike and ride the trails around Bingham Creek Regional park.",
+      expected: "Nipples",
+    },
+    {
+      name: "Dr. <name> survives — only 1 word after period",
+      desc: "Hare: Dr. Strange",
+      expected: "Dr. Strange",
+    },
+    {
+      name: "St. <name> survives — only 1 word after period",
+      desc: "Hare: St. John",
+      expected: "St. John",
+    },
+    {
+      name: "two short words after period strip threshold not met",
+      desc: "Hare: Alice. Bob",
+      expected: "Alice. Bob",
+    },
+    {
+      name: "Title-Case-only tail preserved — 'Dr. Strange. Captain Hook' (Codex review)",
+      desc: "Hare: Dr. Strange. Captain Hook",
+      expected: "Dr. Strange. Captain Hook",
+    },
+    {
+      name: "Title-Case-only tail preserved — 'Mr. Happy. Big Fun Bob' (Codex review)",
+      desc: "Hare: Mr. Happy. Big Fun Bob",
+      expected: "Mr. Happy. Big Fun Bob",
+    },
+  ])("$name", ({ desc, expected }) => {
+    expect(extractHares(desc)).toBe(expected);
+  });
+});
+
+describe("extractHares — date-range rejection (#1547 ABQ)", () => {
+  it.each([
+    {
+      name: "weekday + slash-date range rejected",
+      desc: "hare: Friday 5/22-Monday 5/25",
+    },
+    {
+      name: "bare slash-date range rejected",
+      desc: "Hares: 5/22-5/25",
+    },
+    {
+      name: "date range embedded after a name still rejects (whole captured value is a date range)",
+      desc: "Who: 12/31 - 1/2",
+    },
+  ])("$name", ({ desc }) => {
+    expect(extractHares(desc)).toBeUndefined();
+  });
+});
+
 describe("extractHares — Co-Hare merge + annotation strip (#1212 GLH3)", () => {
   // Each row is independent — no shared object state between them. Note that
   // the annotation-strip cases stand alone (no Co-Hare line) and the

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -270,6 +270,21 @@ describe("extractHares — description-sentence trailer strip (#1551 Wasatch)", 
       desc: "Hare: Mr. Happy. Big Fun Bob",
       expected: "Mr. Happy. Big Fun Bob",
     },
+    {
+      name: "honorific period skipped — 'Dr. Strange. A crossover event…' truncates to 'Dr. Strange' (Claude bot review)",
+      desc: "Hare: Dr. Strange. A crossover event with disc golf and snacks",
+      expected: "Dr. Strange",
+    },
+    {
+      name: "honorific period skipped — 'St. Mary. The trail starts at noon' truncates to 'St. Mary'",
+      desc: "Hare: St. Mary. The trail starts at the park at noon",
+      expected: "St. Mary",
+    },
+    {
+      name: "Mrs. honorific skipped",
+      desc: "Hare: Mrs. Robinson. A trail with surprises and beverages",
+      expected: "Mrs. Robinson",
+    },
   ])("$name", ({ desc, expected }) => {
     expect(extractHares(desc)).toBe(expected);
   });

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -67,15 +67,30 @@ const TRAILING_LOWERCASE_COMMENTARY_RE = /\s+[-–—]\s+[a-z][^A-Z]*$/; // NOSO
 const DATE_RANGE_RE = /\b\d{1,2}\s*\/\s*\d{1,2}\b/;
 // Description-sentence leak (#1551 Wasatch): kennel uses "hare: NAME. event
 // description..." on one line. The greedy `(.*)` capture pulls the entire
-// remainder. Truncate at the first ". " when the post-period tail is sentence-
-// shaped — 3+ tokens AND at least one token starts with a lowercase letter.
-// Hash names use Title Case; sentence tails contain lowercase function words
-// like "crossover", "is", "and". This refinement preserves period-prefixed
-// names like "Dr. Strange. Captain Hook" (tail all Title Case → no truncate)
-// while still catching "Nipples. A Wasarch/Bash crossover event…" (Codex
-// review on this PR).
-const HARE_SENTENCE_BOUNDARY_RE = /\.\s+/;
+// remainder. Truncate at the first sentence-boundary `. ` when the tail is
+// sentence-shaped — 3+ tokens AND at least one token starts with a lowercase
+// letter. Hash names use Title Case; sentence tails contain lowercase
+// function words like "crossover", "is", "and".
+//
+// Periods after common honorifics ("Dr.", "Mr.", "St.", "Ms.", "Mrs.") are
+// skipped via per-position scan in `findHareSentenceBoundary` so
+// "Dr. Strange. A crossover event…" truncates at "A crossover" — not at
+// "Strange" — and "Dr. Strange. Captain Hook" stays intact when the tail
+// is all Title Case. (Claude bot / Gemini review on #1577.)
+const HARE_SENTENCE_BOUNDARY_RE = /\.\s+/g;
 const LOWERCASE_TOKEN_RE = /(?:^|\s)[a-z]/;
+const HONORIFICS = new Set(["dr", "mr", "ms", "mrs", "st"]);
+
+function findHareSentenceBoundary(text: string): number {
+  // Reset lastIndex on a fresh scan — the regex literal is `g`-flagged.
+  HARE_SENTENCE_BOUNDARY_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = HARE_SENTENCE_BOUNDARY_RE.exec(text)) !== null) {
+    const preceding = text.slice(0, m.index).split(/\s+/).pop()?.toLowerCase() ?? "";
+    if (!HONORIFICS.has(preceding)) return m.index;
+  }
+  return -1;
+}
 // Sibling Co-Hare label scan (#1212): when the primary `Hare:` capture
 // succeeded, also look for separate `Co-Hare:` / `Co-Hares:` lines in the
 // same description. Both forms exposed: single-match (used internally as a
@@ -173,13 +188,13 @@ function cleanAndFilterHares(raw: string): string | undefined {
   }
 
   // Description-sentence trailer strip (#1551 Wasatch). Truncate at first
-  // ". " when the tail is sentence-shaped (3+ tokens, at least one starting
-  // with a lowercase letter). Preserves period-prefixed names like
-  // "Dr. Strange" and even "Dr. Strange. Captain Hook" — tails of pure
-  // Title-Case tokens are kept.
-  const periodIdx = hares.search(HARE_SENTENCE_BOUNDARY_RE);
+  // non-honorific sentence boundary when the tail is sentence-shaped (3+
+  // tokens, at least one starting with a lowercase letter). Preserves
+  // honorific-prefixed names like "Dr. Strange. A crossover event…"
+  // (truncates at "A crossover", keeping "Dr. Strange").
+  const periodIdx = findHareSentenceBoundary(hares);
   if (periodIdx >= 0) {
-    const tail = hares.slice(periodIdx).replace(HARE_SENTENCE_BOUNDARY_RE, "");
+    const tail = hares.slice(periodIdx + 1).trimStart();
     const tailTokens = tail.split(/\s+/).filter(Boolean);
     if (tailTokens.length >= 3 && LOWERCASE_TOKEN_RE.test(tail)) {
       hares = hares.slice(0, periodIdx).trim();

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -60,6 +60,22 @@ const COHARE_COMMENTARY_RE = /\s*(?:could|need)\s+.*?co-?hares?\b.*$/i; // NOSON
 // end-of-string; `[a-z]` rules out names whose 2nd token starts uppercase
 // (e.g. "Alice - Bob" — second hare survives the existing comma split).
 const TRAILING_LOWERCASE_COMMENTARY_RE = /\s+[-–—]\s+[a-z][^A-Z]*$/; // NOSONAR — anchored, single char class
+// Date-range shape rejection (#1547 ABQ): multi-day campouts embed lines like
+// "Friday 5/22-Monday 5/25" as the first description line. The pre-existing
+// hare extractor captured the whole string as `hares`. Real hare names don't
+// contain `<digits>/<digits>` slash-separated date tokens.
+const DATE_RANGE_RE = /\b\d{1,2}\s*\/\s*\d{1,2}\b/;
+// Description-sentence leak (#1551 Wasatch): kennel uses "hare: NAME. event
+// description..." on one line. The greedy `(.*)` capture pulls the entire
+// remainder. Truncate at the first ". " when the post-period tail is sentence-
+// shaped — 3+ tokens AND at least one token starts with a lowercase letter.
+// Hash names use Title Case; sentence tails contain lowercase function words
+// like "crossover", "is", "and". This refinement preserves period-prefixed
+// names like "Dr. Strange. Captain Hook" (tail all Title Case → no truncate)
+// while still catching "Nipples. A Wasarch/Bash crossover event…" (Codex
+// review on this PR).
+const HARE_SENTENCE_BOUNDARY_RE = /\.\s+/;
+const LOWERCASE_TOKEN_RE = /(?:^|\s)[a-z]/;
 // Sibling Co-Hare label scan (#1212): when the primary `Hare:` capture
 // succeeded, also look for separate `Co-Hare:` / `Co-Hares:` lines in the
 // same description. Both forms exposed: single-match (used internally as a
@@ -156,8 +172,25 @@ function cleanAndFilterHares(raw: string): string | undefined {
     hares = hares.replace(TRAILING_LOWERCASE_COMMENTARY_RE, "").trim();
   }
 
+  // Description-sentence trailer strip (#1551 Wasatch). Truncate at first
+  // ". " when the tail is sentence-shaped (3+ tokens, at least one starting
+  // with a lowercase letter). Preserves period-prefixed names like
+  // "Dr. Strange" and even "Dr. Strange. Captain Hook" — tails of pure
+  // Title-Case tokens are kept.
+  const periodIdx = hares.search(HARE_SENTENCE_BOUNDARY_RE);
+  if (periodIdx >= 0) {
+    const tail = hares.slice(periodIdx).replace(HARE_SENTENCE_BOUNDARY_RE, "");
+    const tailTokens = tail.split(/\s+/).filter(Boolean);
+    if (tailTokens.length >= 3 && LOWERCASE_TOKEN_RE.test(tail)) {
+      hares = hares.slice(0, periodIdx).trim();
+    }
+  }
+
   if (GENERIC_WHO_ANSWER_RE.test(hares)) return undefined;
   if (PROSE_PREFIX_RE.test(hares)) return undefined;
+  // Date-range rejection (#1547 ABQ): "Friday 5/22-Monday 5/25" is a campout
+  // date range, not a hare name.
+  if (DATE_RANGE_RE.test(hares)) return undefined;
   if (hares.length === 0 || hares.length >= MAX_HARES_LEN) return undefined;
   return hares;
 }

--- a/src/adapters/html-scraper/big-hump.test.ts
+++ b/src/adapters/html-scraper/big-hump.test.ts
@@ -790,6 +790,45 @@ describe("BigHumpAdapter — #1550 Open placeholder + subtitled title", () => {
     expect(ev.location).toBe("Brentwood");
   });
 
+  it("preserves real hasher named 'Open' from description when venue is known (Codex P1)", async () => {
+    // Codex P1 review on #1577: a real hasher literally named "Open" with
+    // `Hare: Open` in description and a known venue must survive. The
+    // earlier parseHaresFromDescription filter dropped the description
+    // value unconditionally. Now: filter at the convergence point only
+    // when venue is also unknown. Multi-word h4 below skips title-side
+    // rules and lets descHares win.
+    const html = `
+      <html><body>
+        <div class="w3-card">
+          <header class="w3-container w3-green">
+            <h3>Wednesday 04/22/2026 <span class="w3-text-amber">#1996</span></h3>
+          </header>
+          <div class="w3-row"><div class="w3-col w3-container m9 l10">
+            <h4>A Long Themed Trail Description @ Forest Park</h4>
+            <span class="w3-small"><p>Circle up: 6:45 p.m.<p>Hare: Open</span>
+          </div></div>
+        </div>
+      </body></html>
+    `;
+    vi.mocked(utils.fetchHTMLPage).mockResolvedValueOnce({
+      ok: true as const,
+      html,
+      $: cheerio.load(html),
+      structureHash: "open-from-desc-known-venue",
+      fetchDurationMs: 50,
+    });
+
+    const mockSource = {
+      id: "test-bh4",
+      url: "http://www.big-hump.com/hareline.php",
+      config: null,
+    } as never;
+    const result = await adapter.fetch(mockSource, { days: 36500 });
+    const ev = result.events[0];
+    expect(ev.hares).toBe("Open");
+    expect(ev.location).toBe("Forest Park");
+  });
+
   it("preserves real hasher named 'Open' when venue is known (Codex review carve-out)", async () => {
     // A real hasher literally named "Open" with a known venue should NOT be
     // cleared by the placeholder filter. Mirrors the upstream

--- a/src/adapters/html-scraper/big-hump.test.ts
+++ b/src/adapters/html-scraper/big-hump.test.ts
@@ -18,6 +18,12 @@ vi.mock("../utils", async () => {
   };
 });
 
+// big-hump.com runs on http (no https variant available). Centralized so
+// SonarCloud's S5332 "Using http protocol is insecure" rule sees one
+// declaration instead of repeated literals across test fixtures.
+// NOSONAR typescript:S5332 — production source is http, mirrored here for fidelity.
+const BH4_HARELINE_URL = "http://www.big-hump.com/hareline.php"; // NOSONAR
+
 describe("parseEventHeader", () => {
   it("parses date and run number", () => {
     const result = parseEventHeader("Wednesday 04/01/2026 #1991");
@@ -569,7 +575,7 @@ describe("BigHumpAdapter", () => {
   it("parses events from hareline page (no history)", async () => {
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
 
@@ -591,7 +597,7 @@ describe("BigHumpAdapter", () => {
   it("fetches history when includeHistory is true", async () => {
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: { includeHistory: true, historyYearRange: [2026, 2026] },
     } as never;
 
@@ -613,7 +619,7 @@ describe("BigHumpAdapter", () => {
   it("deduplicates: hareline events win over history", async () => {
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: { includeHistory: true, historyYearRange: [2026, 2026] },
     } as never;
 
@@ -636,7 +642,7 @@ describe("BigHumpAdapter", () => {
   it("returns error on fetch failure", async () => {
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
 
@@ -645,7 +651,7 @@ describe("BigHumpAdapter", () => {
       result: {
         events: [],
         errors: ["HTTP 500"],
-        errorDetails: { fetch: [{ url: "http://www.big-hump.com/hareline.php", message: "HTTP 500" }] },
+        errorDetails: { fetch: [{ url: BH4_HARELINE_URL, message: "HTTP 500" }] },
       },
     });
 
@@ -675,7 +681,7 @@ describe("BigHumpAdapter", () => {
       structureHash: "828-test",
       fetchDurationMs: 50,
     });
-    const mockSource = { id: "test-bh4", url: "http://www.big-hump.com/hareline.php", config: null } as never;
+    const mockSource = { id: "test-bh4", url: BH4_HARELINE_URL, config: null } as never;
     return adapter.fetch(mockSource, { days: 36500 });
   }
 
@@ -727,7 +733,7 @@ describe("BigHumpAdapter", () => {
 
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
     const result = await adapter.fetch(mockSource, { days: 36500 });
@@ -777,7 +783,7 @@ describe("BigHumpAdapter — #1550 Open placeholder + subtitled title", () => {
 
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
     const result = await adapter.fetch(mockSource, { days: 36500 });
@@ -820,7 +826,7 @@ describe("BigHumpAdapter — #1550 Open placeholder + subtitled title", () => {
 
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
     const result = await adapter.fetch(mockSource, { days: 36500 });
@@ -856,7 +862,7 @@ describe("BigHumpAdapter — #1550 Open placeholder + subtitled title", () => {
 
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
     const result = await adapter.fetch(mockSource, { days: 36500 });
@@ -894,7 +900,7 @@ describe("BigHumpAdapter — #1550 Open placeholder + subtitled title", () => {
 
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
     const result = await adapter.fetch(mockSource, { days: 36500 });
@@ -928,7 +934,7 @@ describe("BigHumpAdapter — #1550 Open placeholder + subtitled title", () => {
 
     const mockSource = {
       id: "test-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
     const result = await adapter.fetch(mockSource, { days: 36500 });
@@ -946,7 +952,7 @@ describe.skip("BigHumpAdapter live", () => {
     const adapter = new LiveAdapter();
     const source = {
       id: "live-bh4",
-      url: "http://www.big-hump.com/hareline.php",
+      url: BH4_HARELINE_URL,
       config: null,
     } as never;
 

--- a/src/adapters/html-scraper/big-hump.test.ts
+++ b/src/adapters/html-scraper/big-hump.test.ts
@@ -826,6 +826,45 @@ describe("BigHumpAdapter — #1550 Open placeholder + subtitled title", () => {
     expect(ev.location).toBe("Forest Park");
   });
 
+  it("preserves descriptive h4 title when hare extraction returns undefined (CodeRabbit + Claude bot review)", async () => {
+    // "Bungle in the Jungle @ Steelville" — extractHaresFromTitlePart returns
+    // undefined (multi-word phrase, no separator, no verb). The previous
+    // `!hares ||` short-circuit silently rewrote the title to "BH4 #N @ ...",
+    // dropping "Bungle in the Jungle". The fix requires `hares` to be truthy
+    // AND match the harePart before rewriting.
+    const html = `
+      <html><body>
+        <div class="w3-card">
+          <header class="w3-container w3-green">
+            <h3>Wednesday 04/29/2026 <span class="w3-text-amber">#1997</span></h3>
+          </header>
+          <div class="w3-row"><div class="w3-col w3-container m9 l10">
+            <h4>Bungle in the Jungle @ Steelville</h4>
+            <span class="w3-small">Circle up: 6:45 p.m.</span>
+          </div></div>
+        </div>
+      </body></html>
+    `;
+    vi.mocked(utils.fetchHTMLPage).mockResolvedValueOnce({
+      ok: true as const,
+      html,
+      $: cheerio.load(html),
+      structureHash: "unparsed-h4-preserved",
+      fetchDurationMs: 50,
+    });
+
+    const mockSource = {
+      id: "test-bh4",
+      url: "http://www.big-hump.com/hareline.php",
+      config: null,
+    } as never;
+    const result = await adapter.fetch(mockSource, { days: 36500 });
+    const ev = result.events[0];
+    expect(ev.hares).toBeUndefined();
+    expect(ev.title).toBe("Bungle in the Jungle @ Steelville");
+    expect(ev.location).toBe("Steelville");
+  });
+
   it("falls back to BH4 #N rewrite when h4 is pure 'Hare @ Venue' (existing #828 behavior preserved)", async () => {
     const html = `
       <html><body>

--- a/src/adapters/html-scraper/big-hump.test.ts
+++ b/src/adapters/html-scraper/big-hump.test.ts
@@ -217,6 +217,22 @@ describe("parseEventTitle", () => {
     expect(result.hares).toBe("2FC");
     expect(result.location).toBe("Lemay");
   });
+
+  // ─── #1550: <hare> <action-verb> ... pattern ───
+
+  it.each([
+    ["Perpencockular Asks For Help To Move @ Brentwood", "Perpencockular", "Brentwood"],
+    ["Captain Says Goodbye To Summer @ Forest Park", "Captain", "Forest Park"],
+    ["Whiney Needs A Win @ Lemay", "Whiney", "Lemay"],
+    ["Beaver Hosts The Annual Hashapalooza @ South City", "Beaver", "South City"],
+    // Codex review: multi-word hare name before verb is preserved
+    ["Captain Hook Says Goodbye @ Forest Park", "Captain Hook", "Forest Park"],
+    ["Just Bob Hosts The Trail @ Lemay", "Just Bob", "Lemay"],
+  ])("#1550: extracts hare from action-verb phrase: %s", (h4, hare, loc) => {
+    const result = parseEventTitle(h4);
+    expect(result.hares).toBe(hare);
+    expect(result.location).toBe(loc);
+  });
 });
 
 // ─── History page parsing ───────────────────────────────────────────────────
@@ -724,6 +740,123 @@ describe("BigHumpAdapter", () => {
     // The description is preserved for the event body
     expect(result.events[0].description).toMatch(/shiggyfest hares/i);
     expect(result.events[0].startTime).toBe("18:45");
+  });
+});
+
+// ─── #1550: "Open" placeholder + subtitled-title preservation ──
+
+describe("BigHumpAdapter — #1550 Open placeholder + subtitled title", () => {
+  const adapter = new BigHumpAdapter();
+  beforeEach(() => vi.resetAllMocks());
+
+  it("preserves descriptive h4 title and extracts first-word hare when 'Open' leaks from description", async () => {
+    // Production-shaped fixture: #2002 has a multi-word h4 with verb subtitle.
+    // Description has "Hare: Open" leaking from the template, but the title's
+    // first word is the real hare. Title rewrite skipped because h4 has
+    // meaningful subtitle content.
+    const html = `
+      <html><body>
+        <div class="w3-card">
+          <header class="w3-container w3-green">
+            <h3>Saturday 05/23/2026 <span class="w3-text-amber">#2002</span></h3>
+          </header>
+          <div class="w3-row"><div class="w3-col w3-container m9 l10">
+            <h4>Perpencockular Asks For Help To Move @ Brentwood</h4>
+            <span class="w3-small"><p>Circle up: 3:00 p.m.<p>Hare: Open</span>
+          </div></div>
+        </div>
+      </body></html>
+    `;
+    vi.mocked(utils.fetchHTMLPage).mockResolvedValueOnce({
+      ok: true as const,
+      html,
+      $: cheerio.load(html),
+      structureHash: "open-placeholder-test",
+      fetchDurationMs: 50,
+    });
+
+    const mockSource = {
+      id: "test-bh4",
+      url: "http://www.big-hump.com/hareline.php",
+      config: null,
+    } as never;
+    const result = await adapter.fetch(mockSource, { days: 36500 });
+
+    expect(result.events).toHaveLength(1);
+    const ev = result.events[0];
+    expect(ev.runNumber).toBe(2002);
+    expect(ev.hares).toBe("Perpencockular");
+    expect(ev.title).toBe("Perpencockular Asks For Help To Move @ Brentwood");
+    expect(ev.location).toBe("Brentwood");
+  });
+
+  it("preserves real hasher named 'Open' when venue is known (Codex review carve-out)", async () => {
+    // A real hasher literally named "Open" with a known venue should NOT be
+    // cleared by the placeholder filter. Mirrors the upstream
+    // `h4Hare === 'open'` carve-out that requires an unknown venue.
+    const html = `
+      <html><body>
+        <div class="w3-card">
+          <header class="w3-container w3-green">
+            <h3>Wednesday 04/15/2026 <span class="w3-text-amber">#1995</span></h3>
+          </header>
+          <div class="w3-row"><div class="w3-col w3-container m9 l10">
+            <h4>Open's Trail @ Forest Park</h4>
+            <span class="w3-small">Circle up: 6:45 p.m.</span>
+          </div></div>
+        </div>
+      </body></html>
+    `;
+    vi.mocked(utils.fetchHTMLPage).mockResolvedValueOnce({
+      ok: true as const,
+      html,
+      $: cheerio.load(html),
+      structureHash: "open-real-hasher",
+      fetchDurationMs: 50,
+    });
+
+    const mockSource = {
+      id: "test-bh4",
+      url: "http://www.big-hump.com/hareline.php",
+      config: null,
+    } as never;
+    const result = await adapter.fetch(mockSource, { days: 36500 });
+    const ev = result.events[0];
+    expect(ev.hares).toBe("Open");
+    expect(ev.location).toBe("Forest Park");
+  });
+
+  it("falls back to BH4 #N rewrite when h4 is pure 'Hare @ Venue' (existing #828 behavior preserved)", async () => {
+    const html = `
+      <html><body>
+        <div class="w3-card">
+          <header class="w3-container w3-green">
+            <h3>Wednesday 04/01/2026 <span class="w3-text-amber">#1991</span></h3>
+          </header>
+          <div class="w3-row"><div class="w3-col w3-container m9 l10">
+            <h4>Whiney @ Forest Park</h4>
+            <span class="w3-small">Circle up: 6:45 p.m.</span>
+          </div></div>
+        </div>
+      </body></html>
+    `;
+    vi.mocked(utils.fetchHTMLPage).mockResolvedValueOnce({
+      ok: true as const,
+      html,
+      $: cheerio.load(html),
+      structureHash: "bare-rewrite",
+      fetchDurationMs: 50,
+    });
+
+    const mockSource = {
+      id: "test-bh4",
+      url: "http://www.big-hump.com/hareline.php",
+      config: null,
+    } as never;
+    const result = await adapter.fetch(mockSource, { days: 36500 });
+    const ev = result.events[0];
+    expect(ev.hares).toBe("Whiney");
+    expect(ev.title).toBe("BH4 #1991 @ Forest Park");
   });
 });
 

--- a/src/adapters/html-scraper/big-hump.ts
+++ b/src/adapters/html-scraper/big-hump.ts
@@ -263,15 +263,33 @@ function parseLocationFromDescription(text: string): string | undefined {
  * The caller must preserve paragraph newlines — cheerio's `.text()` strips
  * them, which defeats the `\n` anchor here; use `stripHtmlTags(.., "\n")`.
  */
+/**
+ * Pick the better of description-side and title-side hares. Default
+ * preference is description (it's the more structured field), but a
+ * description value of literal "Open" (placeholder for unfilled hare
+ * slot) yields to a non-Open title-side value when both are present.
+ * Codex P1 review on #1577.
+ */
+function pickHaresPreferringRealName(
+  descHares: string | undefined,
+  titleHares: string | undefined,
+): string | undefined {
+  const descIsOpen = !!descHares && /^open$/i.test(descHares);
+  const titleIsReal = !!titleHares && !/^open$/i.test(titleHares);
+  if (descIsOpen && titleIsReal) return titleHares;
+  return descHares ?? titleHares;
+}
+
 function parseHaresFromDescription(text: string): string | undefined {
   const match = /^\s*Hares?\s*(?:\([^)]*\))?\s*:\s*(.+?)$/im.exec(text);
   if (!match) return undefined;
   const name = match[1].trim();
   // "away: …" is departure time, not a hare name
   if (/^away/i.test(name)) return undefined;
-  // #1550: "Open" is a "hare slot available" placeholder, not a real name.
-  // Mirrors the upstream h4 "Open @ ???" guard in the adapter fetch().
-  if (/^open$/i.test(name)) return undefined;
+  // #1550: "Open" placeholder is filtered at the convergence point in
+  // `fetch()` where venue context is known — a real hasher literally named
+  // "Open" at a known venue must survive even when title-side extraction
+  // returned undefined (Codex P1 review on #1577).
   return name || undefined;
 }
 
@@ -537,13 +555,14 @@ export class BigHumpAdapter implements SourceAdapter {
           const descHares = parseHaresFromDescription(descText);
 
           const location = descLocation || titleLocation;
-          // #1550: "Open - <theme> @ ???" rows split via Rule 4 (dash) in
-          // extractHaresFromTitlePart and produced titleHares="Open". The
-          // upstream Open@??? guard only catches bare "Open @ ???" (no
-          // subtitle). Treat "Open" as a placeholder at the resolved-hares
-          // boundary, but gate on the venue also being unknown so a real
-          // hasher literally named "Open" at a known venue still survives.
-          const rawHares = descHares || titleHares;
+          // #1550: "Open" is a "hare slot available" placeholder used both
+          // in h4 ("Open - Skanksgiving @ ???") and in description
+          // ("Hare: Open"). Resolution:
+          //   - prefer description hare normally, BUT skip a descHares of
+          //     "Open" when titleHares has a non-Open value (Codex P1 review)
+          //   - final clear only when venue is also unknown — a real hasher
+          //     literally named "Open" at a known venue survives.
+          const rawHares = pickHaresPreferringRealName(descHares, titleHares);
           const venueUnknown = !location || isPlaceholder(location);
           const hares =
             rawHares && venueUnknown && /^open$/i.test(rawHares) ? undefined : rawHares;

--- a/src/adapters/html-scraper/big-hump.ts
+++ b/src/adapters/html-scraper/big-hump.ts
@@ -63,6 +63,32 @@ export function parseEventHeader(headerText: string): {
 }
 
 /**
+ * Narrow allowlist of 3rd-person action verbs BH4 uses to compose
+ * subtitled titles ("<Hare> Asks For Help To Move").
+ */
+const BH4_ACTION_VERBS = new Set([
+  "asks", "says", "wants", "needs", "hosts", "brings", "throws", "calls",
+  "welcomes", "loves", "hates", "returns", "visits", "moves", "goes",
+  "takes", "gives", "pays", "buys", "sells", "runs",
+]);
+
+/**
+ * Token-based "<hare> <action-verb> ..." matcher (#1550). Returns the
+ * leading hare prefix when a verb token appears after at least one prior
+ * token, else undefined. Set lookup avoids the SonarCloud S5843
+ * complexity hit a 20-branch alternation regex incurs.
+ */
+function matchActionVerbHare(harePart: string): string | undefined {
+  const tokens = harePart.split(/\s+/).filter(Boolean);
+  for (let i = 1; i < tokens.length - 1; i++) {
+    if (BH4_ACTION_VERBS.has(tokens[i].toLowerCase())) {
+      return tokens.slice(0, i).join(" ");
+    }
+  }
+  return undefined;
+}
+
+/**
  * Extract hare name(s) from a "Hare @ Location" title prefix.
  *
  * BH4 titles frequently embed theme text between the hare and the `@`:
@@ -116,13 +142,11 @@ function extractHaresFromTitlePart(harePart: string): string | undefined {
 
   // Rule 5b: "<hare> <action-verb> ..." (#1550 — "Perpencockular Asks For
   // Help To Move"). Narrow allowlist of 3rd-person action verbs the kennel
-  // uses to compose trail subtitles. Lazy `(.+?)` lets multi-word hare names
-  // ("Captain Hook Says Goodbye" → "Captain Hook") survive. Sonar S5852-safe:
-  // the literal verb alternation acts as a hard right anchor for backtracking.
-  const actionVerbMatch = /^(.+?)\s+(?:Asks|Says|Wants|Needs|Hosts|Brings|Throws|Calls|Welcomes|Loves|Hates|Returns|Visits|Moves|Goes|Takes|Gives|Pays|Buys|Sells|Runs)\s+/i.exec(
-    harePart,
-  );
-  if (actionVerbMatch) return actionVerbMatch[1].trim();
+  // uses to compose trail subtitles. Multi-word hare names are preserved
+  // ("Captain Hook Says Goodbye" → "Captain Hook"). Set lookup over a
+  // tokenized split avoids a 20-branch alternation regex (Sonar S5843).
+  const verbHare = matchActionVerbHare(harePart);
+  if (verbHare) return verbHare;
 
   // Rule 6: clean short name — no colons, no emoji.
   // Accept 1–2 word names, or a pair-joined form ("X & Y", "X and Y") where
@@ -172,6 +196,30 @@ export function parseEventTitle(h4Text: string): {
   const location = locationIsTbd ? undefined : locationPart;
 
   return { title, hares, location };
+}
+
+/**
+ * Build the title for a numbered BH4 event. Preserves the rich h4 text when
+ * its hare-side has descriptive content beyond the extracted hare name
+ * (#1550 "Perpencockular Asks For Help To Move @ Brentwood"). Rebuilds to
+ * "BH4 #N @ Venue" only when `hares` was extracted AND equals the harePart
+ * (CodeRabbit + Claude bot review on #1577): hares=undefined means the
+ * extractor could not parse the h4 — preserve the original to avoid
+ * silently dropping subtitle text.
+ */
+function buildBh4Title(
+  h4Text: string,
+  titleFromH4: string,
+  hares: string | undefined,
+  runNumber: number,
+  location: string | undefined,
+): string {
+  const atIdx = h4Text.lastIndexOf(" @ ");
+  const h4HarePart = (atIdx >= 0 ? h4Text.slice(0, atIdx) : h4Text).trim();
+  const isBareHareTitle =
+    !!hares && h4HarePart.toLowerCase() === hares.toLowerCase();
+  if (!isBareHareTitle) return titleFromH4;
+  return location ? `BH4 #${runNumber} @ ${location}` : `BH4 #${runNumber}`;
 }
 
 /**
@@ -516,17 +564,13 @@ export class BigHumpAdapter implements SourceAdapter {
           // beyond the bare hare name ("Perpencockular Asks For Help To Move
           // @ Brentwood"), the trail subtitle is meaningful and we preserve
           // titleFromH4. The harePart-before-` @ ` is the title's hare-side;
-          // if it equals `hares` (case-insensitive), there's no subtitle.
-          let title = titleFromH4;
-          if (runNumber) {
-            const atIdx = h4Text.lastIndexOf(" @ ");
-            const h4HarePart = (atIdx >= 0 ? h4Text.slice(0, atIdx) : h4Text).trim();
-            const isBareHareTitle =
-              !hares || h4HarePart.toLowerCase() === hares.toLowerCase();
-            if (isBareHareTitle) {
-              title = location ? `BH4 #${runNumber} @ ${location}` : `BH4 #${runNumber}`;
-            }
-          }
+          // only rewrite when `hares` was extracted AND equals that prefix
+          // (case-insensitive). Hare-extraction returning undefined means the
+          // h4 contains something we couldn't parse — preserve it as title
+          // rather than overwriting (CodeRabbit + Claude bot review).
+          const title = runNumber
+            ? buildBh4Title(h4Text, titleFromH4, hares, runNumber, location)
+            : titleFromH4;
 
           harelineEvents.push({
             date,

--- a/src/adapters/html-scraper/big-hump.ts
+++ b/src/adapters/html-scraper/big-hump.ts
@@ -114,6 +114,16 @@ function extractHaresFromTitlePart(harePart: string): string | undefined {
   );
   if (anniversaryMatch) return anniversaryMatch[1].trim();
 
+  // Rule 5b: "<hare> <action-verb> ..." (#1550 — "Perpencockular Asks For
+  // Help To Move"). Narrow allowlist of 3rd-person action verbs the kennel
+  // uses to compose trail subtitles. Lazy `(.+?)` lets multi-word hare names
+  // ("Captain Hook Says Goodbye" → "Captain Hook") survive. Sonar S5852-safe:
+  // the literal verb alternation acts as a hard right anchor for backtracking.
+  const actionVerbMatch = /^(.+?)\s+(?:Asks|Says|Wants|Needs|Hosts|Brings|Throws|Calls|Welcomes|Loves|Hates|Returns|Visits|Moves|Goes|Takes|Gives|Pays|Buys|Sells|Runs)\s+/i.exec(
+    harePart,
+  );
+  if (actionVerbMatch) return actionVerbMatch[1].trim();
+
   // Rule 6: clean short name — no colons, no emoji.
   // Accept 1–2 word names, or a pair-joined form ("X & Y", "X and Y") where
   // each side is 1–2 words. Bounded sides prevent long theme phrases like
@@ -211,6 +221,9 @@ function parseHaresFromDescription(text: string): string | undefined {
   const name = match[1].trim();
   // "away: …" is departure time, not a hare name
   if (/^away/i.test(name)) return undefined;
+  // #1550: "Open" is a "hare slot available" placeholder, not a real name.
+  // Mirrors the upstream h4 "Open @ ???" guard in the adapter fetch().
+  if (/^open$/i.test(name)) return undefined;
   return name || undefined;
 }
 
@@ -475,8 +488,17 @@ export class BigHumpAdapter implements SourceAdapter {
           const descLocation = parseLocationFromDescription(descText);
           const descHares = parseHaresFromDescription(descText);
 
-          const hares = descHares || titleHares;
           const location = descLocation || titleLocation;
+          // #1550: "Open - <theme> @ ???" rows split via Rule 4 (dash) in
+          // extractHaresFromTitlePart and produced titleHares="Open". The
+          // upstream Open@??? guard only catches bare "Open @ ???" (no
+          // subtitle). Treat "Open" as a placeholder at the resolved-hares
+          // boundary, but gate on the venue also being unknown so a real
+          // hasher literally named "Open" at a known venue still survives.
+          const rawHares = descHares || titleHares;
+          const venueUnknown = !location || isPlaceholder(location);
+          const hares =
+            rawHares && venueUnknown && /^open$/i.test(rawHares) ? undefined : rawHares;
 
           // #828: "Open @ ???" placeholder rows — skip. Key off raw h4Text so
           // a real hasher literally named "Open" still gets ingested if their
@@ -489,10 +511,21 @@ export class BigHumpAdapter implements SourceAdapter {
           const isUnknownVenue = placeholderVenues.has(h4Venue) || allQuestionMarks;
           if (h4Hare.trim().toLowerCase() === "open" && isUnknownVenue) return;
 
-          // #828: h4 is "Hare @ Venue" — rebuild as "BH4 #N @ Venue" so hares don't double as title.
+          // #828: h4 is "Hare @ Venue" — rebuild as "BH4 #N @ Venue" so hares
+          // don't double as title. #1550: when the h4 has descriptive content
+          // beyond the bare hare name ("Perpencockular Asks For Help To Move
+          // @ Brentwood"), the trail subtitle is meaningful and we preserve
+          // titleFromH4. The harePart-before-` @ ` is the title's hare-side;
+          // if it equals `hares` (case-insensitive), there's no subtitle.
           let title = titleFromH4;
           if (runNumber) {
-            title = location ? `BH4 #${runNumber} @ ${location}` : `BH4 #${runNumber}`;
+            const atIdx = h4Text.lastIndexOf(" @ ");
+            const h4HarePart = (atIdx >= 0 ? h4Text.slice(0, atIdx) : h4Text).trim();
+            const isBareHareTitle =
+              !hares || h4HarePart.toLowerCase() === hares.toLowerCase();
+            if (isBareHareTitle) {
+              title = location ? `BH4 #${runNumber} @ ${location}` : `BH4 #${runNumber}`;
+            }
           }
 
           harelineEvents.push({

--- a/src/adapters/html-scraper/sydney-thirsty-h3.test.ts
+++ b/src/adapters/html-scraper/sydney-thirsty-h3.test.ts
@@ -73,6 +73,34 @@ describe("sydney-thirsty-h3 parseThirstyBlock", () => {
     expect(events[0].locationUrl).toBe("https://maps.app.goo.gl/y");
   });
 
+  // #1548: source data-entry boilerplate stripped from Location field.
+  it.each([
+    [
+      "Location: Petersham Park, at the map location below",
+      "Petersham Park",
+    ],
+    [
+      "Location: St Leonards at the map location below.",
+      "St Leonards",
+    ],
+    [
+      "Location: Centennial Park, At The Map Location Below",
+      "Centennial Park",
+    ],
+  ])("#1548: strips 'at the map location below' boilerplate from location: %s", (locLine, expected) => {
+    const events = parseThirstyBlock(
+      [
+        { text: "Thursday April 9th at 6:30pm" },
+        { text: "Run #1842" },
+        { text: locLine },
+      ],
+      URL,
+      REF,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].location).toBe(expected);
+  });
+
   it("emits two events for multi-day AGPU-style 'Runs (Sat and Sun) N & M'", () => {
     const events = parseThirstyBlock(
       [

--- a/src/adapters/html-scraper/sydney-thirsty-h3.ts
+++ b/src/adapters/html-scraper/sydney-thirsty-h3.ts
@@ -44,9 +44,9 @@ const EM_DASH_RE = /^[—–-]$/;
 // Source data-entry boilerplate (#1548): the kennel writes "at the map
 // location below" into the Location: field on sth3.org, referring to an
 // embedded map that follows. The phrase is editorial, not part of the
-// geocodable venue. Anchored to end-of-string, tolerates optional leading
-// comma + trailing period.
-const MAP_BOILERPLATE_RE = /\s*,?\s*at the map location below\.?\s*$/i;
+// geocodable venue. Single `[,\s]*` char class avoids the Sonar S5852
+// "adjacent `\s*` + optional" backtracking heuristic.
+const MAP_BOILERPLATE_RE = /[,\s]*at the map location below\.?\s*$/i;
 
 interface ThirstyParagraph {
   text: string;

--- a/src/adapters/html-scraper/sydney-thirsty-h3.ts
+++ b/src/adapters/html-scraper/sydney-thirsty-h3.ts
@@ -43,10 +43,21 @@ const SOURCE_URL_DEFAULT = "https://www.sth3.org/upcoming-runs";
 const EM_DASH_RE = /^[—–-]$/;
 // Source data-entry boilerplate (#1548): the kennel writes "at the map
 // location below" into the Location: field on sth3.org, referring to an
-// embedded map that follows. The phrase is editorial, not part of the
-// geocodable venue. Single `[,\s]*` char class avoids the Sonar S5852
-// "adjacent `\s*` + optional" backtracking heuristic.
-const MAP_BOILERPLATE_RE = /[,\s]*at the map location below\.?\s*$/i;
+// embedded map that follows. Stripped via string operations to keep the
+// regex shape Sonar S5852-safe (memory: feedback_sonar_s5852_false_positives
+// — prefer string ops over `\s*` + optional adjacency).
+const MAP_BOILERPLATE_PHRASE = "at the map location below";
+
+function stripMapBoilerplate(value: string): string {
+  let s = value.replace(/\s+$/, "");
+  if (s.endsWith(".")) s = s.slice(0, -1).replace(/\s+$/, "");
+  const lc = s.toLowerCase();
+  if (lc.endsWith(MAP_BOILERPLATE_PHRASE)) {
+    s = s.slice(0, -MAP_BOILERPLATE_PHRASE.length);
+    s = s.replace(/[,\s]+$/, "");
+  }
+  return s;
+}
 
 interface ThirstyParagraph {
   text: string;
@@ -126,7 +137,7 @@ export function parseThirstyBlock(
 
     const locMatch = /^Location:\s*(.+)$/i.exec(t);
     if (locMatch && !location) {
-      const raw = locMatch[1].replace(MAP_BOILERPLATE_RE, "").trim();
+      const raw = stripMapBoilerplate(locMatch[1]).trim();
       location = stripPlaceholder(raw);
       continue;
     }

--- a/src/adapters/html-scraper/sydney-thirsty-h3.ts
+++ b/src/adapters/html-scraper/sydney-thirsty-h3.ts
@@ -41,6 +41,12 @@ const KENNEL_TAG = "sth3-au";
 const SOURCE_URL_DEFAULT = "https://www.sth3.org/upcoming-runs";
 
 const EM_DASH_RE = /^[—–-]$/;
+// Source data-entry boilerplate (#1548): the kennel writes "at the map
+// location below" into the Location: field on sth3.org, referring to an
+// embedded map that follows. The phrase is editorial, not part of the
+// geocodable venue. Anchored to end-of-string, tolerates optional leading
+// comma + trailing period.
+const MAP_BOILERPLATE_RE = /\s*,?\s*at the map location below\.?\s*$/i;
 
 interface ThirstyParagraph {
   text: string;
@@ -120,7 +126,8 @@ export function parseThirstyBlock(
 
     const locMatch = /^Location:\s*(.+)$/i.exec(t);
     if (locMatch && !location) {
-      location = stripPlaceholder(locMatch[1]);
+      const raw = locMatch[1].replace(MAP_BOILERPLATE_RE, "").trim();
+      location = stripPlaceholder(raw);
       continue;
     }
     if (/^Map:/i.test(t) && p.href && !locationUrl) {

--- a/src/adapters/html-scraper/sydney-thirsty-h3.ts
+++ b/src/adapters/html-scraper/sydney-thirsty-h3.ts
@@ -48,13 +48,18 @@ const EM_DASH_RE = /^[—–-]$/;
 // — prefer string ops over `\s*` + optional adjacency).
 const MAP_BOILERPLATE_PHRASE = "at the map location below";
 
+function stripTrailingCommas(value: string): string {
+  let s = value;
+  while (s.endsWith(",")) s = s.slice(0, -1).trimEnd();
+  return s;
+}
+
 function stripMapBoilerplate(value: string): string {
-  let s = value.replace(/\s+$/, "");
-  if (s.endsWith(".")) s = s.slice(0, -1).replace(/\s+$/, "");
-  const lc = s.toLowerCase();
-  if (lc.endsWith(MAP_BOILERPLATE_PHRASE)) {
-    s = s.slice(0, -MAP_BOILERPLATE_PHRASE.length);
-    s = s.replace(/[,\s]+$/, "");
+  let s = value.trimEnd();
+  if (s.endsWith(".")) s = s.slice(0, -1).trimEnd();
+  if (s.toLowerCase().endsWith(MAP_BOILERPLATE_PHRASE)) {
+    s = s.slice(0, -MAP_BOILERPLATE_PHRASE.length).trimEnd();
+    s = stripTrailingCommas(s);
   }
   return s;
 }

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -680,6 +680,9 @@ export const CTA_EMBEDDED_PATTERNS = [
   /\bhares?\s+(?:needed|wanted|required|volunteer\w*)\b/i,
   /\bneed(?:ed)?\s+(?:a\s+)?hares?\b/i,
   /\blooking\s+for\s+(?:a\s+)?hares?\b/i,
+  // RVA's hare-wanted placeholder (#1549). Kennel uses "CLAIM THIS TRAIL"
+  // in the GCal summary when a trail is open for volunteer hares.
+  /\bclaim\s+this\s+trail\b/i,
 ] as const;
 
 // ---------------------------------------------------------------------------

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -223,6 +223,34 @@ describe("formatSchedule", () => {
       ).toBe("Mondays at 6:00 PM");
     });
 
+    it("drops bare-day fragment subsumed by a peer with the same day + time (#1552 LRH3)", () => {
+      // LRH3 symptom: 3 ScheduleRule rows render as "Wednesdays at 7:00 PM /
+      // Sundays at 3:00 PM / Sundays". The bare-day "Sundays" peer comes from
+      // a stale row with `startTime: null` and is redundant. Drop it.
+      expect(
+        formatSchedule({
+          scheduleRules: [
+            { rrule: "FREQ=WEEKLY;BYDAY=WE", startTime: "19:00", displayOrder: 0 },
+            { rrule: "FREQ=WEEKLY;BYDAY=SU", startTime: "15:00", displayOrder: 1 },
+            { rrule: "FREQ=WEEKLY;BYDAY=SU", startTime: null, displayOrder: 2 },
+          ],
+        }),
+      ).toBe("Wednesdays at 7:00 PM / Sundays at 3:00 PM");
+    });
+
+    it("keeps standalone bare-day fragment when no peer with that day has a time (#1552 boundary)", () => {
+      // Defensive: if "Sundays" is the only Sunday slot, keep it. The dedupe
+      // only fires when a more-specific peer subsumes the bare-day fragment.
+      expect(
+        formatSchedule({
+          scheduleRules: [
+            { rrule: "FREQ=WEEKLY;BYDAY=WE", startTime: "19:00", displayOrder: 0 },
+            { rrule: "FREQ=WEEKLY;BYDAY=SU", startTime: null, displayOrder: 1 },
+          ],
+        }),
+      ).toBe("Wednesdays at 7:00 PM / Sundays");
+    });
+
     it("keeps distinct cadences after dedupe (only removes exact-string duplicates)", () => {
       // Same RRULE but different startTime → different rendered strings → both kept.
       expect(

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -245,7 +245,15 @@ function formatScheduleRules(rules: ScheduleSlot[]): string | null {
   // prevents new duplicates from being created, but this is a defense-in-depth
   // guard for any historical duplicates and any future duplicate-rule shapes.
   const deduped = [...new Set(rendered)];
-  return deduped.length > 0 ? deduped.join(" / ") : null;
+  // Drop bare-day fragments subsumed by a peer with a time (#1552 LRH3): a
+  // stale ScheduleRule with `startTime: null` renders as "Sundays", which
+  // gets concatenated alongside the real "Sundays at 3:00 PM" peer and
+  // produces a dangling fragment. The `" at "` boundary keeps unique
+  // day-only slots intact when no peer with that day has a time.
+  const final = deduped.filter(
+    (s) => !deduped.some((other) => other !== s && other.startsWith(`${s} at `)),
+  );
+  return final.length > 0 ? final.join(" / ") : null;
 }
 
 function formatScheduleSlot(slot: ScheduleSlot): string | null {

--- a/src/pipeline/audit-checks.test.ts
+++ b/src/pipeline/audit-checks.test.ts
@@ -299,6 +299,13 @@ describe("checkTitleQuality", () => {
     expect(findings[0].rule).toBe("title-cta-text");
   });
 
+  it("flags title-cta-text for RVA 'CLAIM THIS TRAIL' placeholder (#1549)", () => {
+    const event = makeEvent({ title: "Richmond H3 Trail #1695: CLAIM THIS TRAIL" });
+    const findings = checkTitleQuality(event);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("title-cta-text");
+  });
+
   it("flags title-schedule-description as warning for schedule language", () => {
     const event = makeEvent({
       title: "Mosquito H3 runs on the first and third Wednesdays",


### PR DESCRIPTION
## Summary

Quick Win bundle of 7 disjoint source-mismatch fixes — 4 GCal-adapter
fixes, 1 FB-parser fix, 1 HTML-scraper fix, 1 HTML-scraper data-entry
boilerplate, and 1 UI schedule-chip dedup.

## Fixes

| Issue | Where | Fix |
|---|---|---|
| #1547 | `src/adapters/google-calendar/adapter.ts` + `hare-extraction.ts` | Parenthetical date-range `(Friday 5/22-Monday 5/25)` treated as instructional → stripped from title, not extracted as hares. Defense-in-depth `DATE_RANGE_RE` in `cleanAndFilterHares`. |
| #1549 | `src/adapters/utils.ts` | `CLAIM THIS TRAIL` added to `CTA_EMBEDDED_PATTERNS` (GCal skips event + audit-checks flags `title-cta-text`). |
| #1551 | `src/adapters/hare-extraction.ts` | `cleanAndFilterHares` truncates at first `. ` when the tail is sentence-shaped (3+ tokens AND contains a lowercase token). `Dr. Strange` and `Mr. Happy. Big Fun Bob` survive (Codex review). |
| #1557 | `src/adapters/facebook-hosted-events/parser.ts` | FB title strips trailing `[-–—:]` delimiter (mirrors GCal #756 / #1060). |
| #1548 | `src/adapters/html-scraper/sydney-thirsty-h3.ts` | `MAP_BOILERPLATE_RE` strips `at the map location below` from `Location:` field. |
| #1550 | `src/adapters/html-scraper/big-hump.ts` | (a) `parseHaresFromDescription` rejects `"Open"`. (b) Rule 5b matches `<hare> <action-verb> …` with lazy capture (`Captain Hook Says Goodbye` → `Captain Hook`). (c) Resolved-hares boundary clears `"Open"` only when venue is also unknown (real hasher named `Open` at a known venue survives). (d) `h4` titles with descriptive subtitles preserved instead of being rewritten to `BH4 #N @ Venue`. |
| #1552 | `src/lib/format.ts` | `formatScheduleRules` drops bare-day fragments subsumed by a peer with same day + time (`Sundays` dropped when `Sundays at 3:00 PM` peer exists). |

## Live verification

`scripts/live-verify-ws5-bundle.ts` runs all 6 adapters against production
sources (`ABQ H3`, `Richmond H3`, `Whoreman H3 Calendar` for Wasatch,
`Memphis H3 FB`, `Sydney Thirsty H3`, `Big Hump H3`). All checks clean:

```
## ABQ H3 Google Calendar — events: 94 — haresText with M/D date tokens: 0 (expect 0)
## Richmond H3 Google Calendar — events: 2 — titles containing 'CLAIM THIS TRAIL': 0 (expect 0)
## Whoreman H3 Calendar — events: 147 — haresText with sentence trailer: 0 (expect 0)
## Memphis H3 Facebook Hosted Events — events: 8 — titles ending in trailing delimiter: 0 (expect 0)
## Sydney Thirsty H3 Upcoming Runs — events: 3 — location containing 'at the map location below': 0 (expect 0)
## Big Hump H3 Hareline — events: 102 — haresText literal 'Open': 0 (expect 0)
✓ All targets clean
```

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (20 pre-existing warnings)
- [x] `npm test` — 6970 passed, 0 failed
- [x] Live verify against 6 production sources (above)
- [x] `/codex:adversarial-review` — 3 findings addressed:
  - High: action-verb rule now matches multi-word hares
  - Medium: `Open` filter gated on `venueUnknown`
  - Medium: sentence-trailer requires lowercase-token in tail
- [x] `/simplify` — comment trimming + chain reductions applied

## Sequencing note

WS1 (issue #1233 Chicagoland `kennelPatterns`) wasn't open at branch
time; WS5 was branched from `main`. The conflict surface is the GCal
adapter, but WS5's edits are in title/hares extraction (separate code
paths from WS1's matcher logic) so a merge should be clean.

Closes #1547
Closes #1548
Closes #1549
Closes #1550
Closes #1551
Closes #1552
Closes #1557

🤖 Generated with [Claude Code](https://claude.com/claude-code)