### PR TITLE
chore(scripts): cleanup stale canonical Event fields from PR #1577 (WS5)

### DIFF
--- a/scripts/cleanup-ws5-canonical-ghosts.ts
+++ b/scripts/cleanup-ws5-canonical-ghosts.ts
@@ -94,104 +94,104 @@ interface Patch {
   after: string | null;
 }
 
-async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
-  const patches: Patch[] = [];
-
-  // ── ABQ haresText with slash-date (#1547) ──────────────────────────
-  const abqKennel = await prisma.kennel.findUnique({ where: { kennelCode: "abqh3" }, select: { id: true } });
-  if (abqKennel) {
-    const abqEvents = await prisma.event.findMany({
-      where: { kennelId: abqKennel.id, haresText: { contains: "/" } },
-      select: { id: true, haresText: true, date: true },
-    });
-    for (const e of abqEvents) {
-      if (e.haresText && isDateRangeHares(e.haresText)) {
-        patches.push({ kennelLabel: "abqh3 #1547", eventId: e.id, field: "haresText", before: e.haresText, after: null });
-      }
-    }
-  }
-
-  // ── Wasatch haresText sentence trailer (#1551) ─────────────────────
-  const wasKennel = await prisma.kennel.findUnique({ where: { kennelCode: "wasatch-h3" }, select: { id: true } });
-  if (wasKennel) {
-    const wasEvents = await prisma.event.findMany({
-      where: { kennelId: wasKennel.id, haresText: { contains: ". " } },
-      select: { id: true, haresText: true, date: true },
-    });
-    for (const e of wasEvents) {
-      if (!e.haresText) continue;
-      const truncated = truncateAtSentence(e.haresText);
-      if (truncated !== null && truncated !== e.haresText) {
-        patches.push({ kennelLabel: "wasatch-h3 #1551", eventId: e.id, field: "haresText", before: e.haresText, after: truncated || null });
-      }
-    }
-  }
-
-  // ── Memphis FB title trailing delimiter (#1557) ────────────────────
-  // mh3-tn + gynoh3 — via EventKennel join because GyNO events are routed via kennelPatterns
-  const mhKennels = await prisma.kennel.findMany({
-    where: { kennelCode: { in: ["mh3-tn", "gynoh3"] } },
-    select: { id: true, kennelCode: true },
+/** ABQ haresText with slash-date (#1547). */
+async function collectAbqPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "abqh3" }, select: { id: true } });
+  if (!kennel) return [];
+  const events = await prisma.event.findMany({
+    where: { kennelId: kennel.id, haresText: { contains: "/" } },
+    select: { id: true, haresText: true },
   });
-  const mhKennelIds = mhKennels.map((k) => k.id);
-  if (mhKennelIds.length > 0) {
-    const mhEvents = await prisma.event.findMany({
-      where: {
-        title: { not: null },
-        OR: [
-          { kennelId: { in: mhKennelIds } },
-          { eventKennels: { some: { kennelId: { in: mhKennelIds } } } },
-        ],
-      },
-      select: { id: true, title: true, date: true, kennelId: true },
-    });
-    for (const e of mhEvents) {
-      if (!e.title) continue;
-      const stripped = stripTitleTrailingDelimiter(e.title);
-      if (stripped !== null) {
-        // `stripped || null` matches sanitizeTitle behavior (empty → null)
-        patches.push({ kennelLabel: "mh3-tn/gynoh3 #1557", eventId: e.id, field: "title", before: e.title, after: stripped || null });
-      }
-    }
-  }
+  return events
+    .filter((e) => e.haresText && isDateRangeHares(e.haresText))
+    .map((e) => ({ kennelLabel: "abqh3 #1547", eventId: e.id, field: "haresText" as const, before: e.haresText, after: null }));
+}
 
-  // ── STH3-AU locationName boilerplate (#1548) ───────────────────────
-  const sthKennel = await prisma.kennel.findUnique({ where: { kennelCode: "sth3-au" }, select: { id: true } });
-  if (sthKennel) {
-    const sthEvents = await prisma.event.findMany({
-      where: { kennelId: sthKennel.id, locationName: { contains: "at the map location below", mode: "insensitive" } },
-      select: { id: true, locationName: true, date: true },
-    });
-    for (const e of sthEvents) {
-      if (!e.locationName) continue;
-      const stripped = stripMapBoilerplate(e.locationName);
-      if (stripped !== e.locationName) {
-        patches.push({ kennelLabel: "sth3-au #1548", eventId: e.id, field: "locationName", before: e.locationName, after: stripped || null });
-      }
-    }
+/** Wasatch haresText sentence trailer (#1551). */
+async function collectWasatchPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "wasatch-h3" }, select: { id: true } });
+  if (!kennel) return [];
+  const events = await prisma.event.findMany({
+    where: { kennelId: kennel.id, haresText: { contains: ". " } },
+    select: { id: true, haresText: true },
+  });
+  const patches: Patch[] = [];
+  for (const e of events) {
+    if (!e.haresText) continue;
+    const truncated = truncateAtSentence(e.haresText);
+    if (truncated === null || truncated === e.haresText) continue;
+    patches.push({ kennelLabel: "wasatch-h3 #1551", eventId: e.id, field: "haresText", before: e.haresText, after: truncated || null });
   }
-
-  // ── BH4 haresText "Open" placeholder (#1550) ───────────────────────
-  // BH4 events are routed via EventKennel (multi-kennel pattern). Match
-  // via either primary or secondary kennel link to catch both shapes.
-  const bh4Kennel = await prisma.kennel.findUnique({ where: { kennelCode: "bh4" }, select: { id: true } });
-  if (bh4Kennel) {
-    const bh4Events = await prisma.event.findMany({
-      where: {
-        haresText: { equals: "Open", mode: "insensitive" },
-        OR: [
-          { kennelId: bh4Kennel.id },
-          { eventKennels: { some: { kennelId: bh4Kennel.id } } },
-        ],
-      },
-      select: { id: true, haresText: true, date: true },
-    });
-    for (const e of bh4Events) {
-      patches.push({ kennelLabel: "bh4 #1550", eventId: e.id, field: "haresText", before: e.haresText ?? null, after: null });
-    }
-  }
-
   return patches;
+}
+
+/** Memphis FB title trailing delimiter (#1557). mh3-tn + gynoh3 via EventKennel join (GyNO via kennelPatterns). */
+async function collectMemphisPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const kennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: ["mh3-tn", "gynoh3"] } },
+    select: { id: true },
+  });
+  const ids = kennels.map((k) => k.id);
+  if (ids.length === 0) return [];
+  const events = await prisma.event.findMany({
+    where: {
+      title: { not: null },
+      OR: [{ kennelId: { in: ids } }, { eventKennels: { some: { kennelId: { in: ids } } } }],
+    },
+    select: { id: true, title: true },
+  });
+  const patches: Patch[] = [];
+  for (const e of events) {
+    if (!e.title) continue;
+    const stripped = stripTitleTrailingDelimiter(e.title);
+    if (stripped === null) continue;
+    // `stripped || null` matches sanitizeTitle behavior (empty → null)
+    patches.push({ kennelLabel: "mh3-tn/gynoh3 #1557", eventId: e.id, field: "title", before: e.title, after: stripped || null });
+  }
+  return patches;
+}
+
+/** STH3-AU locationName boilerplate (#1548). */
+async function collectSthAuPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "sth3-au" }, select: { id: true } });
+  if (!kennel) return [];
+  const events = await prisma.event.findMany({
+    where: { kennelId: kennel.id, locationName: { contains: "at the map location below", mode: "insensitive" } },
+    select: { id: true, locationName: true },
+  });
+  const patches: Patch[] = [];
+  for (const e of events) {
+    if (!e.locationName) continue;
+    const stripped = stripMapBoilerplate(e.locationName);
+    if (stripped === e.locationName) continue;
+    patches.push({ kennelLabel: "sth3-au #1548", eventId: e.id, field: "locationName", before: e.locationName, after: stripped || null });
+  }
+  return patches;
+}
+
+/** BH4 haresText "Open" placeholder (#1550). Routed via EventKennel (multi-kennel pattern). */
+async function collectBh4Patches(prisma: PrismaClient): Promise<Patch[]> {
+  const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "bh4" }, select: { id: true } });
+  if (!kennel) return [];
+  const events = await prisma.event.findMany({
+    where: {
+      haresText: { equals: "Open", mode: "insensitive" },
+      OR: [{ kennelId: kennel.id }, { eventKennels: { some: { kennelId: kennel.id } } }],
+    },
+    select: { id: true, haresText: true },
+  });
+  return events.map((e) => ({ kennelLabel: "bh4 #1550", eventId: e.id, field: "haresText" as const, before: e.haresText ?? null, after: null }));
+}
+
+async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const blocks = await Promise.all([
+    collectAbqPatches(prisma),
+    collectWasatchPatches(prisma),
+    collectMemphisPatches(prisma),
+    collectSthAuPatches(prisma),
+    collectBh4Patches(prisma),
+  ]);
+  return blocks.flat();
 }
 
 function summarize(patches: Patch[]): void {
@@ -222,12 +222,14 @@ async function applyPatches(prisma: PrismaClient, patches: Patch[]): Promise<voi
 }
 
 async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
   const pool = createScriptPool();
   const adapter = new PrismaPg(pool);
-  const prisma = new PrismaClient({ adapter } as never);
+  const prisma = new PrismaClient({ adapter });
 
   console.log(dryRun ? "🔍 DRY RUN — no changes will be made" : "✏️  APPLYING changes");
-  console.log(`DATABASE_URL host: ${new URL(process.env.DATABASE_URL!).host}\n`);
+  console.log(`DATABASE_URL host: ${new URL(databaseUrl).host}\n`);
 
   const patches = await collectPatches(prisma);
   summarize(patches);

--- a/scripts/cleanup-ws5-canonical-ghosts.ts
+++ b/scripts/cleanup-ws5-canonical-ghosts.ts
@@ -46,6 +46,7 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/generated/prisma/client";
+import { stripMapBoilerplate } from "../src/adapters/html-scraper/sydney-thirsty-h3";
 import { createScriptPool } from "./lib/db-pool";
 
 const dryRun = !process.argv.includes("--apply");
@@ -71,25 +72,6 @@ function truncateAtSentence(value: string): string | null {
   if (tailTokens.length < 3) return null;
   if (!/(?:^|\s)[a-z]/.test(tail)) return null;
   return value.slice(0, idx).trim();
-}
-
-/** Mirrors sydney-thirsty-h3.ts: strip "at the map location below" + trailing comma. */
-const MAP_BOILERPLATE_PHRASE = "at the map location below";
-
-function stripTrailingCommas(value: string): string {
-  let s = value;
-  while (s.endsWith(",")) s = s.slice(0, -1).trimEnd();
-  return s;
-}
-
-function stripMapBoilerplate(value: string): string {
-  let s = value.trimEnd();
-  if (s.endsWith(".")) s = s.slice(0, -1).trimEnd();
-  if (s.toLowerCase().endsWith(MAP_BOILERPLATE_PHRASE)) {
-    s = s.slice(0, -MAP_BOILERPLATE_PHRASE.length).trimEnd();
-    s = stripTrailingCommas(s);
-  }
-  return s;
 }
 
 /** Mirrors fb parser TITLE_TRAILING_DELIMITER_RE. Returns null when no change. */

--- a/scripts/cleanup-ws5-canonical-ghosts.ts
+++ b/scripts/cleanup-ws5-canonical-ghosts.ts
@@ -1,0 +1,267 @@
+/**
+ * One-shot cleanup for canonical Event field staleness left behind by
+ * PR #1577 (WS5 source-mismatch bundle).
+ *
+ * Why this exists:
+ * - PR #1577 changed how 6 adapters extract `hares` / `title` / `location`.
+ * - The merge pipeline uses tri-state semantics: `undefined` = preserve
+ *   existing, `null` = explicit clear, value = overwrite (see merge.ts
+ *   line 1324). For cases where the new adapter logic now returns
+ *   `undefined` (e.g., adapter rejects a value that was previously
+ *   extracted), the canonical Event field is NOT cleared by the next
+ *   scrape — it sticks with the pre-PR value.
+ * - This script patches those stuck fields directly so the canonical
+ *   Events match what the new adapter logic would produce on a fresh
+ *   scrape.
+ *
+ * Per memory entry `feedback_parser_fix_canonical_ghosts`:
+ *   "Fingerprint-changing fixes leave orphan Events + stale
+ *    Kennel.lastEventDate; always plan the cleanup pass alongside the
+ *    parser PR."
+ *
+ * In this case no canonical Events become orphans (all (kennelId, date)
+ * slots still match between pre- and post-PR scrapes). The RVA
+ * `CLAIM THIS TRAIL` events that the adapter now skips at ingest will
+ * be marked CANCELLED automatically by the reconcile pipeline on the
+ * next post-merge scrape — no manual deletion needed.
+ *
+ * Patches applied:
+ *   - abqh3      : clear haresText that contains a slash-date (#1547)
+ *   - wasatch-h3 : truncate haresText at first non-honorific sentence boundary (#1551)
+ *   - mh3-tn / gynoh3 : strip trailing ` -` / ` —` / ` :` from title (#1557)
+ *   - sth3-au    : strip "at the map location below" boilerplate from locationName (#1548)
+ *   - bh4        : clear haresText where value is literal "Open" (#1550)
+ *
+ * RVA `CLAIM THIS TRAIL` events (#1549) are left alone — reconcile
+ * cancels them automatically on next scrape.
+ *
+ * Usage:
+ *   npx tsx scripts/cleanup-ws5-canonical-ghosts.ts             # dry run (default)
+ *   npx tsx scripts/cleanup-ws5-canonical-ghosts.ts --apply     # apply changes
+ *
+ * Run on local-dev DB first (see .claude/rules/local-dev-db.md). Run
+ * against prod only after the post-merge scrape has cleared all 6
+ * affected sources (so future scrapes don't reintroduce stale values).
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const dryRun = !process.argv.includes("--apply");
+
+/** Mirrors hare-extraction.ts: skip period boundaries preceded by an honorific. */
+const HONORIFICS = new Set(["dr", "mr", "ms", "mrs", "st"]);
+
+function findHareSentenceBoundary(text: string): number {
+  const re = /\.\s+/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const preceding = text.slice(0, m.index).split(/\s+/).pop()?.toLowerCase() ?? "";
+    if (!HONORIFICS.has(preceding)) return m.index;
+  }
+  return -1;
+}
+
+function truncateAtSentence(value: string): string | null {
+  const idx = findHareSentenceBoundary(value);
+  if (idx < 0) return null;
+  const tail = value.slice(idx + 1).trimStart();
+  const tailTokens = tail.split(/\s+/).filter(Boolean);
+  if (tailTokens.length < 3) return null;
+  if (!/(?:^|\s)[a-z]/.test(tail)) return null;
+  return value.slice(0, idx).trim();
+}
+
+/** Mirrors sydney-thirsty-h3.ts: strip "at the map location below" + trailing comma. */
+const MAP_BOILERPLATE_PHRASE = "at the map location below";
+
+function stripTrailingCommas(value: string): string {
+  let s = value;
+  while (s.endsWith(",")) s = s.slice(0, -1).trimEnd();
+  return s;
+}
+
+function stripMapBoilerplate(value: string): string {
+  let s = value.trimEnd();
+  if (s.endsWith(".")) s = s.slice(0, -1).trimEnd();
+  if (s.toLowerCase().endsWith(MAP_BOILERPLATE_PHRASE)) {
+    s = s.slice(0, -MAP_BOILERPLATE_PHRASE.length).trimEnd();
+    s = stripTrailingCommas(s);
+  }
+  return s;
+}
+
+/** Mirrors fb parser TITLE_TRAILING_DELIMITER_RE. Returns null when no change. */
+function stripTitleTrailingDelimiter(title: string): string | null {
+  // anchored end-of-string, single char class — Sonar-safe shape mirroring parser.ts:444
+  const stripped = title.trimEnd().replace(/\s*[-–—:]\s*$/, "").trim(); // NOSONAR S5852 — anchored, single char class
+  return stripped === title ? null : stripped;
+}
+
+/** Date-range shape: `\b<digits>/<digits>\b`. Real hare names don't carry slash-dates. */
+function isDateRangeHares(value: string): boolean {
+  return /\b\d{1,2}\s*\/\s*\d{1,2}\b/.test(value);
+}
+
+interface Patch {
+  kennelLabel: string;
+  eventId: string;
+  field: "haresText" | "title" | "locationName";
+  before: string | null;
+  after: string | null;
+}
+
+async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const patches: Patch[] = [];
+
+  // ── ABQ haresText with slash-date (#1547) ──────────────────────────
+  const abqKennel = await prisma.kennel.findUnique({ where: { kennelCode: "abqh3" }, select: { id: true } });
+  if (abqKennel) {
+    const abqEvents = await prisma.event.findMany({
+      where: { kennelId: abqKennel.id, haresText: { contains: "/" } },
+      select: { id: true, haresText: true, date: true },
+    });
+    for (const e of abqEvents) {
+      if (e.haresText && isDateRangeHares(e.haresText)) {
+        patches.push({ kennelLabel: "abqh3 #1547", eventId: e.id, field: "haresText", before: e.haresText, after: null });
+      }
+    }
+  }
+
+  // ── Wasatch haresText sentence trailer (#1551) ─────────────────────
+  const wasKennel = await prisma.kennel.findUnique({ where: { kennelCode: "wasatch-h3" }, select: { id: true } });
+  if (wasKennel) {
+    const wasEvents = await prisma.event.findMany({
+      where: { kennelId: wasKennel.id, haresText: { contains: ". " } },
+      select: { id: true, haresText: true, date: true },
+    });
+    for (const e of wasEvents) {
+      if (!e.haresText) continue;
+      const truncated = truncateAtSentence(e.haresText);
+      if (truncated !== null && truncated !== e.haresText) {
+        patches.push({ kennelLabel: "wasatch-h3 #1551", eventId: e.id, field: "haresText", before: e.haresText, after: truncated || null });
+      }
+    }
+  }
+
+  // ── Memphis FB title trailing delimiter (#1557) ────────────────────
+  // mh3-tn + gynoh3 — via EventKennel join because GyNO events are routed via kennelPatterns
+  const mhKennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: ["mh3-tn", "gynoh3"] } },
+    select: { id: true, kennelCode: true },
+  });
+  const mhKennelIds = mhKennels.map((k) => k.id);
+  if (mhKennelIds.length > 0) {
+    const mhEvents = await prisma.event.findMany({
+      where: {
+        title: { not: null },
+        OR: [
+          { kennelId: { in: mhKennelIds } },
+          { eventKennels: { some: { kennelId: { in: mhKennelIds } } } },
+        ],
+      },
+      select: { id: true, title: true, date: true, kennelId: true },
+    });
+    for (const e of mhEvents) {
+      if (!e.title) continue;
+      const stripped = stripTitleTrailingDelimiter(e.title);
+      if (stripped !== null && stripped) {
+        patches.push({ kennelLabel: "mh3-tn/gynoh3 #1557", eventId: e.id, field: "title", before: e.title, after: stripped });
+      }
+    }
+  }
+
+  // ── STH3-AU locationName boilerplate (#1548) ───────────────────────
+  const sthKennel = await prisma.kennel.findUnique({ where: { kennelCode: "sth3-au" }, select: { id: true } });
+  if (sthKennel) {
+    const sthEvents = await prisma.event.findMany({
+      where: { kennelId: sthKennel.id, locationName: { contains: "at the map location below", mode: "insensitive" } },
+      select: { id: true, locationName: true, date: true },
+    });
+    for (const e of sthEvents) {
+      if (!e.locationName) continue;
+      const stripped = stripMapBoilerplate(e.locationName);
+      if (stripped !== e.locationName) {
+        patches.push({ kennelLabel: "sth3-au #1548", eventId: e.id, field: "locationName", before: e.locationName, after: stripped || null });
+      }
+    }
+  }
+
+  // ── BH4 haresText "Open" placeholder (#1550) ───────────────────────
+  // BH4 events are routed via EventKennel (multi-kennel pattern). Match
+  // via either primary or secondary kennel link to catch both shapes.
+  const bh4Kennel = await prisma.kennel.findUnique({ where: { kennelCode: "bh4" }, select: { id: true } });
+  if (bh4Kennel) {
+    const bh4Events = await prisma.event.findMany({
+      where: {
+        haresText: { equals: "Open", mode: "insensitive" },
+        OR: [
+          { kennelId: bh4Kennel.id },
+          { eventKennels: { some: { kennelId: bh4Kennel.id } } },
+        ],
+      },
+      select: { id: true, haresText: true, date: true },
+    });
+    for (const e of bh4Events) {
+      patches.push({ kennelLabel: "bh4 #1550", eventId: e.id, field: "haresText", before: e.haresText ?? null, after: null });
+    }
+  }
+
+  return patches;
+}
+
+function summarize(patches: Patch[]): void {
+  const byKennel = new Map<string, Patch[]>();
+  for (const p of patches) {
+    const list = byKennel.get(p.kennelLabel) ?? [];
+    list.push(p);
+    byKennel.set(p.kennelLabel, list);
+  }
+  for (const [label, list] of [...byKennel.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    console.log(`\n${label}: ${list.length} event(s)`);
+    for (const p of list.slice(0, 5)) {
+      console.log(`  ${p.eventId} ${p.field}:`);
+      console.log(`    - before: ${JSON.stringify(p.before)}`);
+      console.log(`    + after:  ${JSON.stringify(p.after)}`);
+    }
+    if (list.length > 5) console.log(`  … (${list.length - 5} more)`);
+  }
+}
+
+async function applyPatches(prisma: PrismaClient, patches: Patch[]): Promise<void> {
+  for (const p of patches) {
+    await prisma.event.update({
+      where: { id: p.eventId },
+      data: { [p.field]: p.after },
+    });
+  }
+}
+
+async function main() {
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  console.log(dryRun ? "🔍 DRY RUN — no changes will be made" : "✏️  APPLYING changes");
+  console.log(`DATABASE_URL host: ${new URL(process.env.DATABASE_URL!).host}\n`);
+
+  const patches = await collectPatches(prisma);
+  summarize(patches);
+  console.log(`\nTotal: ${patches.length} event field(s) to patch.`);
+
+  if (patches.length > 0 && !dryRun) {
+    console.log("\nApplying patches...");
+    await applyPatches(prisma, patches);
+    console.log(`✓ Applied ${patches.length} patch(es).`);
+  } else if (dryRun) {
+    console.log("\nRun with --apply to commit changes.");
+  }
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-ws5-canonical-ghosts.ts
+++ b/scripts/cleanup-ws5-canonical-ghosts.ts
@@ -148,8 +148,9 @@ async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
     for (const e of mhEvents) {
       if (!e.title) continue;
       const stripped = stripTitleTrailingDelimiter(e.title);
-      if (stripped !== null && stripped) {
-        patches.push({ kennelLabel: "mh3-tn/gynoh3 #1557", eventId: e.id, field: "title", before: e.title, after: stripped });
+      if (stripped !== null) {
+        // `stripped || null` matches sanitizeTitle behavior (empty → null)
+        patches.push({ kennelLabel: "mh3-tn/gynoh3 #1557", eventId: e.id, field: "title", before: e.title, after: stripped || null });
       }
     }
   }

--- a/src/adapters/html-scraper/sydney-thirsty-h3.ts
+++ b/src/adapters/html-scraper/sydney-thirsty-h3.ts
@@ -54,7 +54,10 @@ function stripTrailingCommas(value: string): string {
   return s;
 }
 
-function stripMapBoilerplate(value: string): string {
+// Exported for the one-shot cleanup script that backfills the same
+// transformation onto canonical Event.locationName values (see
+// scripts/cleanup-ws5-canonical-ghosts.ts).
+export function stripMapBoilerplate(value: string): string {
   let s = value.trimEnd();
   if (s.endsWith(".")) s = s.slice(0, -1).trimEnd();
   if (s.toLowerCase().endsWith(MAP_BOILERPLATE_PHRASE)) {


### PR DESCRIPTION
## Summary

One-shot cleanup script for the field-level staleness left behind by
[PR #1577](https://github.com/johnrclem/hashtracks-web/pull/1577) (WS5 source-mismatch bundle).

## Why this exists

PR #1577 changed how 6 adapters extract `hares` / `title` / `location`. The merge pipeline uses tri-state semantics where `undefined` preserves the existing value (merge.ts:1324). Where the new adapter logic now returns `undefined` for a value it previously extracted (ABQ date-range hares, BH4 "Open" placeholder), the canonical Event's existing field sticks across scrapes.

This script patches those stuck fields to match what the new adapter logic would produce.

**No canonical Events become orphans** — all `(kennelId, date)` slots still match between pre- and post-PR scrapes. The RVA `CLAIM THIS TRAIL` events that the adapter now skips at ingest are left alone here; the reconcile pipeline marks them `CANCELLED` automatically on the next post-merge scrape.

## Applied against prod (30 patches)

| Kennel | Patches | Action |
|---|---|---|
| `abqh3` #1547 | 1 | clear `"Friday 5/22-Monday 5/25"` date-range haresText |
| `bh4` #1550 | 24 | clear `haresText = "Open"` placeholders |
| `mh3-tn` / `gynoh3` #1557 | 2 | strip trailing ` -` from titles |
| `sth3-au` #1548 | 2 | strip `"at the map location below"` from locationName |
| `wasatch-h3` #1551 | 1 | truncate `"Nipples. A Wasarch/Bash…"` → `"Nipples"` |

Re-run after apply: **0 patches found** (idempotent).

## Script design

- **Default dry-run** with full before/after listing per kennel.
- **`--apply` flag** to commit.
- **Mirrors the new adapter logic in-script** (honorific-aware `findHareSentenceBoundary`, `stripMapBoilerplate`, `stripTitleTrailingDelimiter`, `isDateRangeHares`) so the script stays in lockstep with the parser PR.
- **Lives in `scripts/`** as a one-shot — not in cron. Per the memory entry `feedback_parser_fix_canonical_ghosts`: "always plan the cleanup pass alongside the parser PR."
- Uses `createScriptPool` + `BACKFILL_ALLOW_SELF_SIGNED_CERT=1` (Railway prod proxy convention).

## Test plan

- [x] `npx prisma generate && npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] Dry-run against prod: 30 patches identified
- [x] Apply against prod: 30 patches committed
- [x] Re-run dry-run: 0 patches (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)