### PR TITLE
chore(scripts): cleanup stale bare-day ScheduleRule rows (#1552 follow-up)

### DIFF
--- a/scripts/cleanup-stale-schedule-rules.ts
+++ b/scripts/cleanup-stale-schedule-rules.ts
@@ -38,9 +38,15 @@ import { createScriptPool } from "./lib/db-pool";
 
 const dryRun = !process.argv.includes("--apply");
 
-/** Extract the BYDAY value from an RRULE string. Returns null if missing. */
+/**
+ * Extract the BYDAY value from an RRULE string. Returns null if missing.
+ * Char class includes digits + `+`/`-` so monthly nth-weekday shapes
+ * (`BYDAY=1SA`, `BYDAY=-1SU`) extract cleanly (Gemini review on #1598).
+ * Quantifier stays `+` (not `*`) — an empty BYDAY is not a usable day
+ * signal and must skip rather than match across rows.
+ */
 function extractByDay(rrule: string): string | null {
-  const m = /BYDAY=([A-Z,]+)/.exec(rrule);
+  const m = /BYDAY=([0-9A-Z,+-]+)/.exec(rrule);
   return m ? m[1] : null;
 }
 
@@ -55,7 +61,8 @@ interface Candidate {
 }
 
 async function findCandidates(prisma: PrismaClient): Promise<Candidate[]> {
-  // Step 1: pull all candidate stale rows (inactive, bare-day, no season hint).
+  // Step 1: pull all candidate stale rows + kennelCode in one query
+  // (drop the per-row kennel.findUnique — Gemini review on #1598).
   const staleRows = await prisma.scheduleRule.findMany({
     where: {
       isActive: false,
@@ -64,43 +71,55 @@ async function findCandidates(prisma: PrismaClient): Promise<Candidate[]> {
       validFrom: null,
       validUntil: null,
     },
-    select: { id: true, kennelId: true, rrule: true, source: true },
+    select: {
+      id: true,
+      kennelId: true,
+      rrule: true,
+      source: true,
+      kennel: { select: { kennelCode: true } },
+    },
+    take: 1000,
   });
 
   if (staleRows.length === 0) return [];
 
-  // Step 2: for each, find an ACTIVE peer on the same kennel with the same BYDAY + a startTime.
+  // Step 2: bulk-fetch active timed peers for the relevant kennels once,
+  // group by kennelId in memory. Avoids the prior N+1 per stale row.
+  const kennelIds = [...new Set(staleRows.map((s) => s.kennelId))];
+  const activePeers = await prisma.scheduleRule.findMany({
+    where: {
+      kennelId: { in: kennelIds },
+      isActive: true,
+      startTime: { not: null },
+    },
+    select: { id: true, kennelId: true, rrule: true, startTime: true },
+    take: 1000,
+  });
+
+  const peersByKennel = new Map<string, typeof activePeers>();
+  for (const peer of activePeers) {
+    const list = peersByKennel.get(peer.kennelId) ?? [];
+    list.push(peer);
+    peersByKennel.set(peer.kennelId, list);
+  }
+
   const candidates: Candidate[] = [];
   for (const stale of staleRows) {
     const staleByDay = extractByDay(stale.rrule);
     if (!staleByDay) continue;
 
-    const peers = await prisma.scheduleRule.findMany({
-      where: {
-        kennelId: stale.kennelId,
-        isActive: true,
-        startTime: { not: null },
-        id: { not: stale.id },
-      },
-      select: { id: true, rrule: true, startTime: true },
-    });
-
+    const peers = peersByKennel.get(stale.kennelId) ?? [];
     const matchingPeer = peers.find((p) => extractByDay(p.rrule) === staleByDay);
-    if (!matchingPeer) continue;
-
-    const kennel = await prisma.kennel.findUnique({
-      where: { id: stale.kennelId },
-      select: { kennelCode: true },
-    });
+    if (!matchingPeer?.startTime) continue;
 
     candidates.push({
-      kennelCode: kennel?.kennelCode ?? "?",
+      kennelCode: stale.kennel?.kennelCode ?? "?",
       staleId: stale.id,
       staleRrule: stale.rrule,
       staleSource: stale.source,
       peerId: matchingPeer.id,
       peerRrule: matchingPeer.rrule,
-      peerStartTime: matchingPeer.startTime!,
+      peerStartTime: matchingPeer.startTime,
     });
   }
   return candidates;

--- a/scripts/cleanup-stale-schedule-rules.ts
+++ b/scripts/cleanup-stale-schedule-rules.ts
@@ -1,0 +1,153 @@
+/**
+ * One-shot cleanup for stale `ScheduleRule` rows that would render as a
+ * bare day label (no time) when a sibling row already covers the same day
+ * with a real time. Per issue #1552 (LRH3) and PR #1577's defense-in-depth
+ * UI fix in `formatScheduleRules` (src/lib/format.ts).
+ *
+ * Why this exists:
+ * - Pass-1 of `backfill-schedule-rules.ts` creates STATIC_SCHEDULE rules
+ *   with real `startTime` from Source.config.
+ * - Pass-2 reads Kennel.scheduleDayOfWeek / Kennel.scheduleTime. When
+ *   scheduleTime is null but scheduleDayOfWeek is set, it created a
+ *   SEED_DATA rule with `startTime: null` for the same day Pass-1
+ *   already covered.
+ * - The Pass-2-skip fix prevents NEW duplicates and flipped these rows
+ *   to `isActive: false`, but the rows still exist in the DB.
+ * - This script hard-deletes them so the data matches the rendered UI.
+ *
+ * Match criteria (conservative):
+ *   - target row: `isActive=false`, `startTime IS NULL`, no season hint
+ *     (label/validFrom/validUntil all NULL)
+ *   - has an ACTIVE peer on the same kennel with the same BYDAY weekday
+ *     and a non-null `startTime`
+ *
+ * Bare-day rows WITHOUT a timed peer on the same day (e.g. bjh3 SA bare
+ * vs WE timed) are NOT deleted — they represent a real-but-incomplete
+ * schedule the kennel may want to flesh out, not a stale duplicate.
+ *
+ * Usage:
+ *   npx tsx scripts/cleanup-stale-schedule-rules.ts             # dry run (default)
+ *   npx tsx scripts/cleanup-stale-schedule-rules.ts --apply     # apply changes
+ *
+ * Requires `BACKFILL_ALLOW_SELF_SIGNED_CERT=1` for Railway prod proxy.
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const dryRun = !process.argv.includes("--apply");
+
+/** Extract the BYDAY value from an RRULE string. Returns null if missing. */
+function extractByDay(rrule: string): string | null {
+  const m = /BYDAY=([A-Z,]+)/.exec(rrule);
+  return m ? m[1] : null;
+}
+
+interface Candidate {
+  kennelCode: string;
+  staleId: string;
+  staleRrule: string;
+  staleSource: string;
+  peerId: string;
+  peerRrule: string;
+  peerStartTime: string;
+}
+
+async function findCandidates(prisma: PrismaClient): Promise<Candidate[]> {
+  // Step 1: pull all candidate stale rows (inactive, bare-day, no season hint).
+  const staleRows = await prisma.scheduleRule.findMany({
+    where: {
+      isActive: false,
+      startTime: null,
+      label: null,
+      validFrom: null,
+      validUntil: null,
+    },
+    select: { id: true, kennelId: true, rrule: true, source: true },
+  });
+
+  if (staleRows.length === 0) return [];
+
+  // Step 2: for each, find an ACTIVE peer on the same kennel with the same BYDAY + a startTime.
+  const candidates: Candidate[] = [];
+  for (const stale of staleRows) {
+    const staleByDay = extractByDay(stale.rrule);
+    if (!staleByDay) continue;
+
+    const peers = await prisma.scheduleRule.findMany({
+      where: {
+        kennelId: stale.kennelId,
+        isActive: true,
+        startTime: { not: null },
+        id: { not: stale.id },
+      },
+      select: { id: true, rrule: true, startTime: true },
+    });
+
+    const matchingPeer = peers.find((p) => extractByDay(p.rrule) === staleByDay);
+    if (!matchingPeer) continue;
+
+    const kennel = await prisma.kennel.findUnique({
+      where: { id: stale.kennelId },
+      select: { kennelCode: true },
+    });
+
+    candidates.push({
+      kennelCode: kennel?.kennelCode ?? "?",
+      staleId: stale.id,
+      staleRrule: stale.rrule,
+      staleSource: stale.source,
+      peerId: matchingPeer.id,
+      peerRrule: matchingPeer.rrule,
+      peerStartTime: matchingPeer.startTime!,
+    });
+  }
+  return candidates;
+}
+
+function summarize(candidates: Candidate[]): void {
+  if (candidates.length === 0) {
+    console.log("No stale subsumed ScheduleRule rows found.");
+    return;
+  }
+  for (const c of candidates) {
+    console.log(`\n${c.kennelCode}`);
+    console.log(`  - DELETE ${c.staleId} ${c.staleRrule} (no startTime, source=${c.staleSource}, isActive=false)`);
+    console.log(`  + KEEP   ${c.peerId} ${c.peerRrule} startTime=${c.peerStartTime}`);
+  }
+}
+
+async function applyDeletes(prisma: PrismaClient, candidates: Candidate[]): Promise<void> {
+  const ids = candidates.map((c) => c.staleId);
+  const { count } = await prisma.scheduleRule.deleteMany({ where: { id: { in: ids } } });
+  console.log(`\n✓ Deleted ${count} ScheduleRule row(s).`);
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  console.log(dryRun ? "🔍 DRY RUN — no changes will be made" : "✏️  APPLYING changes");
+  console.log(`DATABASE_URL host: ${new URL(databaseUrl).host}\n`);
+
+  const candidates = await findCandidates(prisma);
+  summarize(candidates);
+  console.log(`\nTotal: ${candidates.length} stale row(s) to delete.`);
+
+  if (candidates.length > 0 && !dryRun) {
+    await applyDeletes(prisma, candidates);
+  } else if (dryRun && candidates.length > 0) {
+    console.log("\nRun with --apply to commit changes.");
+  }
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-stale-schedule-rules.ts
+++ b/scripts/cleanup-stale-schedule-rules.ts
@@ -63,6 +63,9 @@ interface Candidate {
 async function findCandidates(prisma: PrismaClient): Promise<Candidate[]> {
   // Step 1: pull all candidate stale rows + kennelCode in one query
   // (drop the per-row kennel.findUnique — Gemini review on #1598).
+  // No `take` cap — this is a cleanup script and must be exhaustive
+  // (Codex P2 review on #1598). The ScheduleRule table is small
+  // (~400 rows total) so a full scan is trivial.
   const staleRows = await prisma.scheduleRule.findMany({
     where: {
       isActive: false,
@@ -78,7 +81,6 @@ async function findCandidates(prisma: PrismaClient): Promise<Candidate[]> {
       source: true,
       kennel: { select: { kennelCode: true } },
     },
-    take: 1000,
   });
 
   if (staleRows.length === 0) return [];
@@ -93,7 +95,6 @@ async function findCandidates(prisma: PrismaClient): Promise<Candidate[]> {
       startTime: { not: null },
     },
     select: { id: true, kennelId: true, rrule: true, startTime: true },
-    take: 1000,
   });
 
   const peersByKennel = new Map<string, typeof activePeers>();


### PR DESCRIPTION
## Summary

One-shot DB cleanup of the stale `ScheduleRule` rows that triggered issue #1552 (LRH3 dangling "Sundays" schedule chip). PR #1577 landed a defense-in-depth UI fix in `formatScheduleRules` (src/lib/format.ts); this PR removes the underlying soft-deleted rows so the data matches the rendered UI.

## Context

- **Pass-1** of `backfill-schedule-rules.ts` creates STATIC_SCHEDULE rules with real `startTime` from `Source.config`.
- **Pass-2** reads `Kennel.scheduleDayOfWeek` / `Kennel.scheduleTime`. When `scheduleTime` was null but `scheduleDayOfWeek` was set, it created a SEED_DATA rule with `startTime: null` for the same day Pass-1 had already covered.
- The Pass-2-skip fix prevented NEW duplicates and flipped the original rows to `isActive: false`, but the rows persisted in the table.

## Match criteria (conservative)

A row is a delete target only when ALL hold:
- `isActive = false`
- `startTime IS NULL`
- no season hint (`label / validFrom / validUntil` all NULL)
- has an ACTIVE peer on the same kennel with the same BYDAY weekday AND a non-null `startTime`

Bare-day rows WITHOUT a timed peer on the same day are NOT deleted (e.g. `bjh3` SA bare vs WE timed) — those represent a real-but-incomplete schedule the kennel may want to flesh out, not a stale duplicate.

## Applied to prod — 3 rows deleted

| Kennel | Stale row | Active peer kept |
|---|---|---|
| `lrh3` | `cmo38hzlz0076twhncbgdttxk` Sun null | Sun 15:00 STATIC_SCHEDULE |
| `wildcard-h3` | `cmo38hzf9006ytwhnedwhcdi8` Mon null | Mon 18:30 STATIC_SCHEDULE |
| `pbh3` | `cmo38i0w4008ptwhnyh30e65h` Wed null | Wed 18:30 STATIC_SCHEDULE |

Re-run after apply: **0 candidates** (idempotent).

## Verification

- **LRH3 now has exactly 2 ScheduleRule rows**: Wed 19:00 + Sun 15:00 (matches the documented STATIC_SCHEDULE seed).
- The UI defense-in-depth fix in `formatScheduleRules` stays as-is — still useful protection against future bad backfill writes.
- 38 inactive ScheduleRule rows remain in the DB (Pass-2-skipped duplicates with valid startTime); these are out of scope per the brief ("don't touch Pass-1/Pass-2 backfill logic").

## Test plan

- [x] `npx prisma generate && npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] Dry-run on prod: 3 candidates identified
- [x] Apply: 3 deletes committed
- [x] Re-run dry-run: 0 candidates (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)