### PR TITLE
feat(events): multi-day series + campout foundation — #1560 PR A of 3

### DIFF
--- a/prisma/migrations/20260522170000_event_end_date_and_series_metadata/migration.sql
+++ b/prisma/migrations/20260522170000_event_end_date_and_series_metadata/migration.sql
@@ -1,0 +1,16 @@
+-- Add Event.endDate for multi-day event support (#1560).
+--
+-- Used by:
+--   * Series PARENT rows (umbrellas spanning N children) — endDate = last child's date.
+--   * Single-row date-range events with no children (one-registration weekend
+--     campouts — MadisonH3 case) — endDate set on the single canonical row.
+--
+-- Single-day events keep endDate = NULL. The UI inspects (isSeriesParent OR endDate IS NOT NULL)
+-- to decide whether to render the multi-day card treatment.
+--
+-- Hand-written (not `migrate dev`-generated) because a pre-existing data migration
+-- in this repo refuses to run on Prisma's empty shadow database. This migration
+-- is a pure additive ADD COLUMN — safe under prod load, no data backfill needed,
+-- nullable so existing rows pass NOT NULL checks trivially.
+
+ALTER TABLE "Event" ADD COLUMN "endDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -330,6 +330,10 @@ model Event {
   kennelId          String
   date              DateTime // Event date (UTC noon to avoid DST issues)
   dateUtc           DateTime? // Same moment in UTC (for cross-timezone queries)
+  /// Last day of a multi-day event (UTC noon), inclusive. Set on series PARENTS
+  /// (umbrella that spans children) and on single-row date-range events that
+  /// have no children (e.g. one-registration weekend campouts). null = single-day.
+  endDate           DateTime?
   timezone          String? // IANA timezone (e.g., "America/New_York")
   runNumber         Int? // Kennel-specific sequential number
   title             String? // Trail/event name

--- a/scripts/cleanup-orphan-events-after-series.ts
+++ b/scripts/cleanup-orphan-events-after-series.ts
@@ -40,9 +40,13 @@ async function main() {
   const apply = process.argv.includes("--apply");
   console.log(`Mode: ${apply ? "APPLY (will delete)" : "DRY-RUN"}`);
 
-  // Find canonical Events with no backing RawEvent. `parentEventId IS NULL`
-  // excludes series children — they're linked via the parent and shouldn't
-  // be evaluated by this pass even when the child has its own RawEvents.
+  // Find canonical Events with no backing RawEvent. `parentEventId: null`
+  // is enforced in the query (Codex P1 review): without this clause a child
+  // row that lost its sole backing RawEvent (upstream row churn, e.g. an
+  // adapter that stops emitting a specific day) would be hard-deleted,
+  // silently destroying valid series structure. Children with truly stale
+  // links should be cleaned by the merge pipeline's own reconciliation, not
+  // by this top-level orphan sweep.
   const orphans = await prisma.event.findMany({
     where: {
       rawEvents: { none: {} },
@@ -50,6 +54,7 @@ async function main() {
       adminCancelledAt: null,
       attendances: { none: {} },
       hares: { none: {} },
+      parentEventId: null,
     },
     select: {
       id: true,

--- a/scripts/cleanup-orphan-events-after-series.ts
+++ b/scripts/cleanup-orphan-events-after-series.ts
@@ -1,0 +1,117 @@
+/**
+ * Post-#1560 cleanup: drop canonical Events orphaned by the fingerprint
+ * change.
+ *
+ * Adding `endDate` to `generateFingerprint`'s input changes the SHA for
+ * every RawEvent on the next scrape. The pipeline correctly inserts a
+ * fresh RawEvent + reuses the existing canonical Event via the same-day
+ * matcher, so we don't get duplicate canonical rows. But if a canonical
+ * Event was previously linked to ONLY a single RawEvent and that RawEvent
+ * row was wiped by an upstream change (or a kennel rename) the canonical
+ * row may be left without any backing RawEvent at all. Those orphans
+ * shouldn't render on the hareline.
+ *
+ * Also handles the SFH3 umbrella migration: pre-#1560 the adapter
+ * suppressed `/events/N` umbrellas; post-#1560 it emits them as series
+ * parents. Any pre-existing canonical Events whose only RawEvent is
+ * a `/events/N` umbrella that was scrubbed before #1560 landed should be
+ * dropped here.
+ *
+ * Safety:
+ *   * Dry-run by default. Pass `--apply` to actually delete.
+ *   * Skips events with attendance, hares, or admin overrides — those
+ *     carry user-authored state that must not be silently destroyed.
+ *   * Skips manual-entry events.
+ *   * Caps at 1000 deletes per run; re-run if more remain.
+ *
+ * Run after each post-deploy re-scrape:
+ *   tsx scripts/cleanup-orphan-events-after-series.ts          # dry run
+ *   tsx scripts/cleanup-orphan-events-after-series.ts --apply  # destructive
+ *
+ * Per memory `feedback_script_env_loading.md` — `import "dotenv/config"`
+ * because tsx doesn't auto-load .env.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const DELETE_CAP = 1000;
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY (will delete)" : "DRY-RUN"}`);
+
+  // Find canonical Events with no backing RawEvent. `parentEventId IS NULL`
+  // excludes series children — they're linked via the parent and shouldn't
+  // be evaluated by this pass even when the child has its own RawEvents.
+  const orphans = await prisma.event.findMany({
+    where: {
+      rawEvents: { none: {} },
+      isManualEntry: false,
+      adminCancelledAt: null,
+      attendances: { none: {} },
+      hares: { none: {} },
+    },
+    select: {
+      id: true,
+      kennelId: true,
+      date: true,
+      title: true,
+      sourceUrl: true,
+      isSeriesParent: true,
+      parentEventId: true,
+    },
+    take: DELETE_CAP,
+    orderBy: { date: "asc" },
+  });
+
+  console.log(`Orphan canonical Events found: ${orphans.length}`);
+  if (orphans.length === 0) {
+    console.log("Nothing to clean up.");
+    return;
+  }
+
+  // Group by kennel for human-readable reporting.
+  const byKennel = new Map<string, typeof orphans>();
+  for (const o of orphans) {
+    const arr = byKennel.get(o.kennelId) ?? [];
+    arr.push(o);
+    byKennel.set(o.kennelId, arr);
+  }
+  for (const [kennelId, rows] of byKennel) {
+    console.log(`\n  kennel=${kennelId}  ${rows.length} orphan(s)`);
+    for (const r of rows.slice(0, 5)) {
+      console.log(`    ${r.id}  ${r.date.toISOString().slice(0, 10)}  ${(r.title ?? "—").slice(0, 50)}`);
+    }
+    if (rows.length > 5) console.log(`    … and ${rows.length - 5} more`);
+  }
+
+  if (!apply) {
+    console.log("\nDry-run complete. Re-run with --apply to delete.");
+    return;
+  }
+
+  // Series parents with orphaned children: cascade is ON DELETE SET NULL,
+  // so deleting a parent leaves its children as standalone Events. That's
+  // OK — they have their own RawEvents and stay visible. But warn so the
+  // operator notices.
+  const parentOrphans = orphans.filter((o) => o.isSeriesParent);
+  if (parentOrphans.length > 0) {
+    console.log(`\n⚠️  ${parentOrphans.length} of these are series parents — children will be promoted to standalone.`);
+  }
+
+  const ids = orphans.map((o) => o.id);
+  const result = await prisma.event.deleteMany({ where: { id: { in: ids } } });
+  console.log(`\nDeleted ${result.count} orphan Events.`);
+  if (orphans.length === DELETE_CAP) {
+    console.log("⚠️  Hit DELETE_CAP — re-run the script to clear remaining orphans.");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/dedup-event-rows.ts
+++ b/scripts/dedup-event-rows.ts
@@ -49,6 +49,7 @@ async function main() {
         startTime: true, endTime: true, cost: true, sourceUrl: true,
         runNumber: true, description: true,
         trailType: true, dogFriendly: true, prelube: true,
+        endDate: true,
       },
     });
 

--- a/src/adapters/html-scraper/sfh3-detail-enrichment.ts
+++ b/src/adapters/html-scraper/sfh3-detail-enrichment.ts
@@ -201,11 +201,16 @@ const SFH3_UMBRELLA_ID_RE = /sfh3\.com\/events\/(\d+)/;
  * Safe to call unconditionally — returns early when no `sfh3.com/events/`
  * URLs are present, so non-SFH3 iCal feeds pass through untouched.
  */
-export function markSFH3SeriesMembership(events: RawEventData[]): RawEventData[] {
-  // Pass 1: find umbrellas, assign their seriesId / seriesParent, and build
-  // a lookup of (kennelTag, date) → seriesId for the second pass.
-  type Umbrella = { event: RawEventData; seriesId: string; eventNum: number; kennelTags: string[] };
-  const umbrellas: Umbrella[] = [];
+type SFH3Umbrella = { event: RawEventData; seriesId: string; eventNum: number; kennelTags: string[] };
+
+/**
+ * Pass 1: find `/events/N` umbrellas, mark each as series parent in place,
+ * and return a deterministically-sorted list for the trail-tagging pass.
+ * Sort key: earliest start, then lowest `/events/N` id — never the iCal
+ * feed's server-controlled VEVENT order (Codex P2 review).
+ */
+function collectSFH3Umbrellas(events: RawEventData[]): SFH3Umbrella[] {
+  const umbrellas: SFH3Umbrella[] = [];
   for (const event of events) {
     if (!event.sourceUrl) continue;
     const m = SFH3_UMBRELLA_ID_RE.exec(event.sourceUrl);
@@ -221,51 +226,78 @@ export function markSFH3SeriesMembership(events: RawEventData[]): RawEventData[]
       kennelTags: event.kennelTags.map((t) => t.toLowerCase()),
     });
   }
-  if (umbrellas.length === 0) return events;
-
-  // Sort umbrellas deterministically — overlapping windows must never depend
-  // on the iCal feed's VEVENT order, which is server-controlled and can
-  // shift between scrapes (Codex P2 review). Earliest start wins on ties;
-  // then the lower /events/N id (more stable across years than re-uses).
   umbrellas.sort((a, b) => {
     if (a.event.date !== b.event.date) return a.event.date.localeCompare(b.event.date);
     return a.eventNum - b.eventNum;
   });
+  return umbrellas;
+}
 
-  // Pass 2: walk trails; tag them with the matching umbrella's seriesId when
-  // (kennel, date) overlaps the umbrella window. Also collect candidate
-  // endDate fallbacks (max trail date per umbrella) for umbrellas that
-  // arrived without DTEND populated.
+/**
+ * Resolve the first umbrella whose window matches a trail's `(kennel, date)`.
+ * Returns `null` if the trail isn't in any umbrella's window. `umbrellas` is
+ * expected to be pre-sorted by `collectSFH3Umbrellas`. Plain-string `<` / `>`
+ * comparisons are safe for YYYY-MM-DD date strings.
+ */
+function findUmbrellaForTrail(
+  trail: RawEventData,
+  umbrellas: SFH3Umbrella[],
+): SFH3Umbrella | null {
+  const trailTags = trail.kennelTags.map((t) => t.toLowerCase());
+  for (const u of umbrellas) {
+    const sharesKennel = trailTags.some((t) => u.kennelTags.includes(t));
+    if (!sharesKennel) continue;
+    const windowStart = u.event.date;
+    const windowEnd = u.event.endDate ?? u.event.date;
+    if (trail.date < windowStart || trail.date > windowEnd) continue;
+    return u;
+  }
+  return null;
+}
+
+/**
+ * Pass 2: tag each `/runs/M` trail whose `(kennel, date)` falls inside an
+ * umbrella's window with that umbrella's seriesId. Also collect the
+ * latest-matched trail date per series for the post-hoc endDate inference
+ * pass (used only when the umbrella's DTEND came in single-day — defensive,
+ * live SFH3 always supplies DTEND).
+ */
+function tagSFH3TrailsToUmbrellas(
+  events: RawEventData[],
+  umbrellas: SFH3Umbrella[],
+): Map<string, string> {
   const inferredEndDateBySeries = new Map<string, string>();
   for (const event of events) {
     if (!event.sourceUrl || !SFH3_TRAIL_URL_RE.test(event.sourceUrl)) continue;
-    const trailTags = event.kennelTags.map((t) => t.toLowerCase());
-
-    for (const u of umbrellas) {
-      const sharesKennel = trailTags.some((t) => u.kennelTags.includes(t));
-      if (!sharesKennel) continue;
-      const windowStart = u.event.date;
-      const windowEnd = u.event.endDate ?? u.event.date;
-      // String comparison is safe for "YYYY-MM-DD" date strings.
-      if (event.date < windowStart || event.date > windowEnd) continue;
-
-      event.seriesId = u.seriesId;
-      const prior = inferredEndDateBySeries.get(u.seriesId);
-      if (!prior || event.date > prior) {
-        inferredEndDateBySeries.set(u.seriesId, event.date);
-      }
-      break; // first matching umbrella wins; trails shouldn't span umbrellas
+    const u = findUmbrellaForTrail(event, umbrellas);
+    if (!u) continue;
+    event.seriesId = u.seriesId;
+    const prior = inferredEndDateBySeries.get(u.seriesId);
+    if (!prior || event.date > prior) {
+      inferredEndDateBySeries.set(u.seriesId, event.date);
     }
   }
+  return inferredEndDateBySeries;
+}
 
-  // Pass 3: fill missing endDate on umbrellas via the inferred max trail date.
-  // Live SFH3 always emits DTEND, but defensive — without it, the umbrella's
-  // own date stays as endDate (single-day weekend with one trail).
+/** Pass 3: fill `endDate` on umbrellas that lacked DTEND, using the
+ *  latest-matched trail date discovered in pass 2. */
+function backfillUmbrellaEndDates(
+  umbrellas: SFH3Umbrella[],
+  inferredEndDateBySeries: Map<string, string>,
+): void {
   for (const u of umbrellas) {
     if (u.event.endDate) continue;
     const inferred = inferredEndDateBySeries.get(u.seriesId);
     if (inferred && inferred > u.event.date) u.event.endDate = inferred;
   }
+}
+
+export function markSFH3SeriesMembership(events: RawEventData[]): RawEventData[] {
+  const umbrellas = collectSFH3Umbrellas(events);
+  if (umbrellas.length === 0) return events;
+  const inferredEndDateBySeries = tagSFH3TrailsToUmbrellas(events, umbrellas);
+  backfillUmbrellaEndDates(umbrellas, inferredEndDateBySeries);
   return events;
 }
 

--- a/src/adapters/html-scraper/sfh3-detail-enrichment.ts
+++ b/src/adapters/html-scraper/sfh3-detail-enrichment.ts
@@ -192,11 +192,12 @@ const SFH3_UMBRELLA_ID_RE = /sfh3\.com\/events\/(\d+)/;
  *    (no `seriesParent` flag). The merge pipeline's `linkMultiDaySeries`
  *    then links them via `parentEventId`.
  *
- * Returns the same `events` array (mutated in place) for chainable API symmetry
- * with `suppressSFH3UmbrellaDuplicates`. Trails outside any umbrella window
- * are untouched. Co-hosted umbrellas (multiple kennelTags) attach trails for
- * every overlapping (kennel, date) — a sibling kennel's standalone trail
- * is not pulled into the series.
+ * Mutates `events` in place; returns `void` (Sonar S3516 — when every return
+ * path returns the same reference, the return is just noise). Callers
+ * continue using the same array reference they passed in. Trails outside
+ * any umbrella window are untouched. Co-hosted umbrellas (multiple
+ * kennelTags) attach trails for every overlapping (kennel, date) — a
+ * sibling kennel's standalone trail is not pulled into the series.
  *
  * Safe to call unconditionally — returns early when no `sfh3.com/events/`
  * URLs are present, so non-SFH3 iCal feeds pass through untouched.
@@ -293,12 +294,11 @@ function backfillUmbrellaEndDates(
   }
 }
 
-export function markSFH3SeriesMembership(events: RawEventData[]): RawEventData[] {
+export function markSFH3SeriesMembership(events: RawEventData[]): void {
   const umbrellas = collectSFH3Umbrellas(events);
-  if (umbrellas.length === 0) return events;
+  if (umbrellas.length === 0) return;
   const inferredEndDateBySeries = tagSFH3TrailsToUmbrellas(events, umbrellas);
   backfillUmbrellaEndDates(umbrellas, inferredEndDateBySeries);
-  return events;
 }
 
 /**

--- a/src/adapters/html-scraper/sfh3-detail-enrichment.ts
+++ b/src/adapters/html-scraper/sfh3-detail-enrichment.ts
@@ -168,40 +168,105 @@ async function fetchSFH3DetailPage(event: EnrichableEvent): Promise<{ html: stri
   return { html: await response.text(), event };
 }
 
+/** Capture `/events/{n}` and yield `sfh3-event-{n}` as a stable seriesId. */
+const SFH3_UMBRELLA_ID_RE = /sfh3\.com\/events\/(\d+)/;
+
 /**
- * SFH3's `calendar.ics` double-publishes multi-day campouts: a `/events/{n}`
- * umbrella entry (all-day, no startTime) AND a `/runs/{m}` trail entry (timed,
- * with hares + venue) for the same date. The umbrella slips past
- * `upsertCanonicalEvent`'s `looksLikeSameEvent` guard (no startTime + no
- * runNumber to match against the already-batched trail), causing a duplicate
- * canonical Event — see #1421.
+ * SFH3's `calendar.ics` publishes multi-day campouts as a `/events/{n}` umbrella
+ * VEVENT (all-day, multi-day DTSTART/DTEND, no startTime) PLUS per-day
+ * `/runs/{m}` trail VEVENTs (timed, with hares + venue). Pre-#1560 the iCal
+ * adapter would suppress the umbrella to avoid a duplicate canonical Event —
+ * but that path threw away the umbrella's rich description (weekend theme,
+ * registration link, lodging info), which is exactly the metadata users want
+ * on the parent series card.
  *
- * Drop the umbrella only when EVERY one of its kennelTags has a same-date
- * `/runs/{m}` trail in the same scrape. A co-hosted umbrella where some kennels
- * lack a specific trail on that date is preserved (it's still the only signal
- * for those kennels). Umbrellas with no overlapping trails are also kept.
- * (The iCal adapter currently emits a single kennelTag per event, so the
- * multi-tag branch is reachable only via direct callers + tests — kept as
- * defensive future-proofing for a contract that may widen.)
+ * Instead, mark series membership in place:
  *
- * Safe to call unconditionally — the function returns early when no
- * `sfh3.com/runs/` URLs are present, so non-SFH3 iCal feeds pass through
- * untouched.
+ *  - The `/events/{n}` umbrella raw gets `seriesId = "sfh3-event-{n}"`,
+ *    `seriesParent: true`. Its `endDate` is already populated by
+ *    `buildRawEventFromVEvent` from DTSTART/DTEND when the VEVENT is multi-day
+ *    all-day. Falls back to inferring from trail-date max when DTEND wasn't
+ *    multi-day or wasn't set (defensive — should not happen for live SFH3).
+ *  - Each `/runs/{m}` trail whose `(kennelTag, date)` falls inside an
+ *    umbrella's `[date, endDate]` window picks up the same `seriesId`
+ *    (no `seriesParent` flag). The merge pipeline's `linkMultiDaySeries`
+ *    then links them via `parentEventId`.
+ *
+ * Returns the same `events` array (mutated in place) for chainable API symmetry
+ * with `suppressSFH3UmbrellaDuplicates`. Trails outside any umbrella window
+ * are untouched. Co-hosted umbrellas (multiple kennelTags) attach trails for
+ * every overlapping (kennel, date) — a sibling kennel's standalone trail
+ * is not pulled into the series.
+ *
+ * Safe to call unconditionally — returns early when no `sfh3.com/events/`
+ * URLs are present, so non-SFH3 iCal feeds pass through untouched.
  */
-export function suppressSFH3UmbrellaDuplicates(events: RawEventData[]): RawEventData[] {
-  const trailKeys = new Set<string>();
-  for (const e of events) {
-    if (!e.sourceUrl || !SFH3_TRAIL_URL_RE.test(e.sourceUrl)) continue;
-    for (const tag of e.kennelTags) {
-      trailKeys.add(`${tag.toLowerCase()}|${e.date}`);
+export function markSFH3SeriesMembership(events: RawEventData[]): RawEventData[] {
+  // Pass 1: find umbrellas, assign their seriesId / seriesParent, and build
+  // a lookup of (kennelTag, date) → seriesId for the second pass.
+  type Umbrella = { event: RawEventData; seriesId: string; eventNum: number; kennelTags: string[] };
+  const umbrellas: Umbrella[] = [];
+  for (const event of events) {
+    if (!event.sourceUrl) continue;
+    const m = SFH3_UMBRELLA_ID_RE.exec(event.sourceUrl);
+    if (!m) continue;
+    const eventNum = Number.parseInt(m[1], 10);
+    const seriesId = `sfh3-event-${m[1]}`;
+    event.seriesId = seriesId;
+    event.seriesParent = true;
+    umbrellas.push({
+      event,
+      seriesId,
+      eventNum,
+      kennelTags: event.kennelTags.map((t) => t.toLowerCase()),
+    });
+  }
+  if (umbrellas.length === 0) return events;
+
+  // Sort umbrellas deterministically — overlapping windows must never depend
+  // on the iCal feed's VEVENT order, which is server-controlled and can
+  // shift between scrapes (Codex P2 review). Earliest start wins on ties;
+  // then the lower /events/N id (more stable across years than re-uses).
+  umbrellas.sort((a, b) => {
+    if (a.event.date !== b.event.date) return a.event.date.localeCompare(b.event.date);
+    return a.eventNum - b.eventNum;
+  });
+
+  // Pass 2: walk trails; tag them with the matching umbrella's seriesId when
+  // (kennel, date) overlaps the umbrella window. Also collect candidate
+  // endDate fallbacks (max trail date per umbrella) for umbrellas that
+  // arrived without DTEND populated.
+  const inferredEndDateBySeries = new Map<string, string>();
+  for (const event of events) {
+    if (!event.sourceUrl || !SFH3_TRAIL_URL_RE.test(event.sourceUrl)) continue;
+    const trailTags = event.kennelTags.map((t) => t.toLowerCase());
+
+    for (const u of umbrellas) {
+      const sharesKennel = trailTags.some((t) => u.kennelTags.includes(t));
+      if (!sharesKennel) continue;
+      const windowStart = u.event.date;
+      const windowEnd = u.event.endDate ?? u.event.date;
+      // String comparison is safe for "YYYY-MM-DD" date strings.
+      if (event.date < windowStart || event.date > windowEnd) continue;
+
+      event.seriesId = u.seriesId;
+      const prior = inferredEndDateBySeries.get(u.seriesId);
+      if (!prior || event.date > prior) {
+        inferredEndDateBySeries.set(u.seriesId, event.date);
+      }
+      break; // first matching umbrella wins; trails shouldn't span umbrellas
     }
   }
-  if (trailKeys.size === 0) return events;
-  return events.filter((e) => {
-    if (!e.sourceUrl || !SFH3_UMBRELLA_URL_RE.test(e.sourceUrl)) return true;
-    if (e.kennelTags.length === 0) return true;
-    return !e.kennelTags.every((tag) => trailKeys.has(`${tag.toLowerCase()}|${e.date}`));
-  });
+
+  // Pass 3: fill missing endDate on umbrellas via the inferred max trail date.
+  // Live SFH3 always emits DTEND, but defensive — without it, the umbrella's
+  // own date stays as endDate (single-day weekend with one trail).
+  for (const u of umbrellas) {
+    if (u.event.endDate) continue;
+    const inferred = inferredEndDateBySeries.get(u.seriesId);
+    if (inferred && inferred > u.event.date) u.event.endDate = inferred;
+  }
+  return events;
 }
 
 /**

--- a/src/adapters/html-scraper/sfh3-detail-enrichment.ts
+++ b/src/adapters/html-scraper/sfh3-detail-enrichment.ts
@@ -33,7 +33,6 @@ const MAX_ENRICH_PER_SCRAPE = 200;
 const BATCH_SIZE = 10;
 
 const SFH3_TRAIL_URL_RE = /sfh3\.com\/runs\/\d+/;
-const SFH3_UMBRELLA_URL_RE = /sfh3\.com\/events\/\d+/;
 
 export interface SFH3Detail {
   title?: string;

--- a/src/adapters/html-scraper/sfh3.test.ts
+++ b/src/adapters/html-scraper/sfh3.test.ts
@@ -822,16 +822,15 @@ describe("markSFH3SeriesMembership (#1560)", () => {
       buildTrail({ date: "2026-05-16", sourceUrl: "https://www.sfh3.com/runs/6490", startTime: "11:30" }),
       buildTrail({ date: "2026-05-17", sourceUrl: "https://www.sfh3.com/runs/6488", startTime: "08:00" }),
     ];
-    const result = markSFH3SeriesMembership(events);
-    expect(result).toBe(events); // mutates in place
-    expect(result.map((e) => e.seriesId)).toEqual([
+    markSFH3SeriesMembership(events); // mutates in place; void return
+    expect(events.map((e) => e.seriesId)).toEqual([
       "sfh3-event-134", "sfh3-event-134", "sfh3-event-134", "sfh3-event-134",
     ]);
     // Only the umbrella carries the explicit parent flag.
-    expect(result[0].seriesParent).toBe(true);
-    expect(result.slice(1).every((e) => e.seriesParent !== true)).toBe(true);
+    expect(events[0].seriesParent).toBe(true);
+    expect(events.slice(1).every((e) => e.seriesParent !== true)).toBe(true);
     // Rich description preserved on the parent (was being dropped pre-#1560).
-    expect(result[0].description).toMatch(/registration|lodging/);
+    expect(events[0].description).toMatch(/registration|lodging/);
   });
 
   it("does not tag a trail outside the umbrella's [date, endDate] window", () => {
@@ -876,10 +875,9 @@ describe("markSFH3SeriesMembership (#1560)", () => {
     expect(trail.seriesId).toBe("sfh3-event-134");
   });
 
-  it("returns the input unchanged when there are no /events/ umbrellas", () => {
+  it("leaves the input untouched when there are no /events/ umbrellas", () => {
     const events = [buildTrail()];
-    const result = markSFH3SeriesMembership(events);
-    expect(result).toBe(events);
+    markSFH3SeriesMembership(events);
     expect(events[0].seriesId).toBeUndefined();
   });
 

--- a/src/adapters/html-scraper/sfh3.test.ts
+++ b/src/adapters/html-scraper/sfh3.test.ts
@@ -6,7 +6,7 @@ import {
   parseSFH3DetailPage,
   isGenericSFH3Title,
   enrichSFH3Events,
-  suppressSFH3UmbrellaDuplicates,
+  markSFH3SeriesMembership,
 } from "./sfh3";
 import { SFH3Adapter } from "./sfh3";
 import type { RawEventData } from "../types";
@@ -804,75 +804,109 @@ function buildTrail(overrides: Partial<RawEventData> = {}): RawEventData {
 }
 function buildUmbrella(overrides: Partial<RawEventData> = {}): RawEventData {
   return {
-    date: "2026-05-15",
+    date: "2026-05-14",
+    endDate: "2026-05-17",
     kennelTags: ["sfh3"],
     title: "Bay 2 Blackout 2026",
+    description: "Weekend campout — registration at sfh3.com/events/134, lodging info attached.",
     sourceUrl: "https://www.sfh3.com/events/134",
     ...overrides,
   };
 }
 
-describe("suppressSFH3UmbrellaDuplicates (#1421)", () => {
-  it("drops a /events/{n} umbrella when a /runs/{m} trail exists for the same kennel+date", () => {
-    const result = suppressSFH3UmbrellaDuplicates([buildTrail(), buildUmbrella()]);
-    expect(result).toHaveLength(1);
-    expect(result[0].sourceUrl).toBe("https://www.sfh3.com/runs/6485");
-  });
-
-  it("keeps an umbrella when no trail exists on that date", () => {
-    const standalone = buildUmbrella({ date: "2026-08-01", title: "BAWC5 Campout" });
-    const result = suppressSFH3UmbrellaDuplicates([buildTrail(), standalone]);
-    expect(result).toHaveLength(2);
-    expect(result.some((e) => e.sourceUrl?.includes("/events/"))).toBe(true);
-  });
-
-  it("keeps an umbrella when the trail is for a different kennel on the same date", () => {
-    const otherKennelTrail = buildTrail({ kennelTags: ["gph3"], sourceUrl: "https://www.sfh3.com/runs/6500" });
-    const result = suppressSFH3UmbrellaDuplicates([otherKennelTrail, buildUmbrella()]);
-    expect(result).toHaveLength(2);
-  });
-
-  it("keeps a co-hosted umbrella when only SOME of its kennels have a same-date trail", () => {
-    // Umbrella tagged for both sfh3 and barh3; only sfh3 has a /runs/ trail
-    // that day. Dropping the umbrella would lose barh3's only signal — keep it.
-    const cohostedUmbrella = buildUmbrella({ kennelTags: ["sfh3", "barh3"] });
-    const result = suppressSFH3UmbrellaDuplicates([buildTrail(), cohostedUmbrella]);
-    expect(result).toHaveLength(2);
-    expect(result.some((e) => e.sourceUrl?.includes("/events/"))).toBe(true);
-  });
-
-  it("drops a co-hosted umbrella when ALL of its kennels have a same-date trail", () => {
-    const sfh3Trail = buildTrail({ kennelTags: ["sfh3"] });
-    const barh3Trail = buildTrail({ kennelTags: ["barh3"], sourceUrl: "https://www.sfh3.com/runs/6600" });
-    const cohostedUmbrella = buildUmbrella({ kennelTags: ["sfh3", "barh3"] });
-    const result = suppressSFH3UmbrellaDuplicates([sfh3Trail, barh3Trail, cohostedUmbrella]);
-    expect(result).toHaveLength(2);
-    expect(result.every((e) => !e.sourceUrl?.includes("/events/"))).toBe(true);
-  });
-
-  it("is case-insensitive on kennelTags (iCal often emits 'SFH3', HTML emits 'sfh3')", () => {
-    const result = suppressSFH3UmbrellaDuplicates([
-      buildTrail({ kennelTags: ["SFH3"] }),
-      buildUmbrella({ kennelTags: ["sfh3"] }),
+describe("markSFH3SeriesMembership (#1560)", () => {
+  it("tags umbrella + same-kennel trails in the window with shared seriesId", () => {
+    const events = [
+      buildUmbrella(),
+      buildTrail({ date: "2026-05-15" }),
+      buildTrail({ date: "2026-05-16", sourceUrl: "https://www.sfh3.com/runs/6490", startTime: "11:30" }),
+      buildTrail({ date: "2026-05-17", sourceUrl: "https://www.sfh3.com/runs/6488", startTime: "08:00" }),
+    ];
+    const result = markSFH3SeriesMembership(events);
+    expect(result).toBe(events); // mutates in place
+    expect(result.map((e) => e.seriesId)).toEqual([
+      "sfh3-event-134", "sfh3-event-134", "sfh3-event-134", "sfh3-event-134",
     ]);
-    expect(result).toHaveLength(1);
-    expect(result[0].title).toBe("SFH3: Friday Turkey / Eagle Run & Pub Crawl");
+    // Only the umbrella carries the explicit parent flag.
+    expect(result[0].seriesParent).toBe(true);
+    expect(result.slice(1).every((e) => e.seriesParent !== true)).toBe(true);
+    // Rich description preserved on the parent (was being dropped pre-#1560).
+    expect(result[0].description).toMatch(/registration|lodging/);
   });
 
-  it("returns the input unchanged when there are no trail events", () => {
-    const events = [buildUmbrella()];
-    const result = suppressSFH3UmbrellaDuplicates(events);
+  it("does not tag a trail outside the umbrella's [date, endDate] window", () => {
+    const events = [
+      buildUmbrella({ endDate: "2026-05-17" }),
+      buildTrail({ date: "2026-05-20", sourceUrl: "https://www.sfh3.com/runs/9999" }),
+    ];
+    markSFH3SeriesMembership(events);
+    expect(events[0].seriesId).toBe("sfh3-event-134");
+    expect(events[1].seriesId).toBeUndefined();
+  });
+
+  it("does not tag a same-date trail from a different kennel as a series sibling", () => {
+    const otherKennelTrail = buildTrail({
+      date: "2026-05-15",
+      kennelTags: ["gph3"],
+      sourceUrl: "https://www.sfh3.com/runs/6500",
+    });
+    const events = [otherKennelTrail, buildUmbrella()];
+    markSFH3SeriesMembership(events);
+    expect(otherKennelTrail.seriesId).toBeUndefined();
+    expect(events[1].seriesId).toBe("sfh3-event-134");
+  });
+
+  it("attaches co-hosted umbrella's trails for EACH co-host kennel", () => {
+    const cohostedUmbrella = buildUmbrella({ kennelTags: ["sfh3", "barh3"] });
+    const sfh3Trail = buildTrail({ date: "2026-05-15", kennelTags: ["sfh3"] });
+    const barh3Trail = buildTrail({
+      date: "2026-05-16",
+      kennelTags: ["barh3"],
+      sourceUrl: "https://www.sfh3.com/runs/6600",
+    });
+    markSFH3SeriesMembership([sfh3Trail, barh3Trail, cohostedUmbrella]);
+    expect(sfh3Trail.seriesId).toBe("sfh3-event-134");
+    expect(barh3Trail.seriesId).toBe("sfh3-event-134");
+  });
+
+  it("is case-insensitive on kennelTags (iCal emits 'SFH3', HTML emits 'sfh3')", () => {
+    const trail = buildTrail({ kennelTags: ["SFH3"] });
+    const umbrella = buildUmbrella({ kennelTags: ["sfh3"] });
+    markSFH3SeriesMembership([trail, umbrella]);
+    expect(trail.seriesId).toBe("sfh3-event-134");
+  });
+
+  it("returns the input unchanged when there are no /events/ umbrellas", () => {
+    const events = [buildTrail()];
+    const result = markSFH3SeriesMembership(events);
     expect(result).toBe(events);
+    expect(events[0].seriesId).toBeUndefined();
   });
 
   it("ignores events without sfh3.com sourceUrls", () => {
     const otherSourced: RawEventData = {
-      date: "2026-05-15",
+      date: "2026-05-14",
       kennelTags: ["sfh3"],
       title: "Bay 2 Blackout 2026",
       sourceUrl: "https://example.com/events/134",
     };
-    const result = suppressSFH3UmbrellaDuplicates([buildTrail(), otherSourced]);
-    expect(result).toHaveLength(2);
+    markSFH3SeriesMembership([buildTrail(), otherSourced]);
+    expect(otherSourced.seriesId).toBeUndefined();
+  });
+
+  it("preserves an umbrella with no in-window trails as a standalone (no children)", () => {
+    const standalone = buildUmbrella({
+      date: "2026-08-01",
+      endDate: "2026-08-03",
+      sourceUrl: "https://www.sfh3.com/events/200",
+      title: "BAWC5 Campout",
+    });
+    markSFH3SeriesMembership([buildTrail({ date: "2026-05-15" }), standalone]);
+    // Umbrella keeps its own seriesId + parent flag + endDate even with zero
+    // matched children — UI renders it as a Madison-style "weekend, no trails
+    // visible" date-range card. The May 15 trail stays untagged.
+    expect(standalone.seriesId).toBe("sfh3-event-200");
+    expect(standalone.seriesParent).toBe(true);
+    expect(standalone.endDate).toBe("2026-08-03");
   });
 });

--- a/src/adapters/html-scraper/sfh3.ts
+++ b/src/adapters/html-scraper/sfh3.ts
@@ -14,7 +14,7 @@ import { parseICalSummary } from "../ical/adapter";
 import { enrichSFH3Events } from "./sfh3-detail-enrichment";
 
 // Re-export for existing test imports.
-export { parseSFH3DetailPage, enrichSFH3Events, isGenericSFH3Title, suppressSFH3UmbrellaDuplicates } from "./sfh3-detail-enrichment";
+export { parseSFH3DetailPage, enrichSFH3Events, isGenericSFH3Title, markSFH3SeriesMembership } from "./sfh3-detail-enrichment";
 export type { SFH3Detail, SFH3EnrichFailure } from "./sfh3-detail-enrichment";
 
 /** Config shape — reuses same kennelPatterns/skipPatterns as iCal adapter */

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -998,7 +998,7 @@ END:VCALENDAR`;
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses SFH3 umbrella VEVENTs when a same-date trail exists, even with enrichSFH3Details off (#1421)", async () => {
+  it("models SFH3 umbrella + trail as a series with shared seriesId, even with enrichSFH3Details off (#1560)", async () => {
     const dupIcs = `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Test//Test//EN
@@ -1014,9 +1014,10 @@ END:VEVENT
 BEGIN:VEVENT
 UID:event-999
 DTSTAMP:20260101T000000Z
-DTSTART;VALUE=DATE:20260515
-DTEND;VALUE=DATE:20260516
+DTSTART;VALUE=DATE:20260514
+DTEND;VALUE=DATE:20260518
 SUMMARY:SFH3 Campout Umbrella
+DESCRIPTION:Weekend campout — full schedule + registration
 LOCATION:San Francisco
 URL;VALUE=URI:https://www.sfh3.com/events/999
 END:VEVENT
@@ -1026,9 +1027,26 @@ END:VCALENDAR`;
     );
     const source = buildMockSource(); // no enrichSFH3Details
     const result = await adapter.fetch(source, { days: 9999 });
-    const may15 = result.events.filter((e) => e.date === "2026-05-15");
-    expect(may15).toHaveLength(1);
-    expect(may15[0].sourceUrl).toBe("https://www.sfh3.com/runs/9999");
+
+    // Both the umbrella and the trail are preserved — series modeling
+    // replaces the pre-#1560 suppression.
+    expect(result.events).toHaveLength(2);
+    const umbrella = result.events.find((e) => e.sourceUrl === "https://www.sfh3.com/events/999");
+    const trail = result.events.find((e) => e.sourceUrl === "https://www.sfh3.com/runs/9999");
+    expect(umbrella).toBeDefined();
+    expect(trail).toBeDefined();
+
+    // Shared seriesId derived from the umbrella URL's numeric ID.
+    expect(umbrella!.seriesId).toBe("sfh3-event-999");
+    expect(trail!.seriesId).toBe("sfh3-event-999");
+
+    // Umbrella carries the explicit-parent flag + the inclusive endDate
+    // (DTEND May 18 → May 17 inclusive).
+    expect(umbrella!.seriesParent).toBe(true);
+    expect(umbrella!.endDate).toBe("2026-05-17");
+
+    // Trails do NOT carry seriesParent; they're children.
+    expect(trail!.seriesParent).toBeFalsy();
   });
 
   it("works without config (defaultKennelTag fallback)", async () => {

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -611,7 +611,7 @@ export class ICalAdapter implements SourceAdapter {
     // (theme, registration, lodging) lands on the canonical parent Event;
     // trails fall under it via parentEventId after merge.
     // No-op for feeds without sfh3.com/events URLs, so unconditional is safe.
-    events = markSFH3SeriesMembership(events);
+    markSFH3SeriesMembership(events);
 
     // SFH3-specific enrichment: the .ics SUMMARY omits "Run" and has no Comment
     // field. Pull the canonical title + Comment from /runs/{id} so the merge

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -547,7 +547,7 @@ export class ICalAdapter implements SourceAdapter {
       ? compilePatterns([config.titleHarePattern], "i")[0]
       : undefined;
 
-    let events: RawEventData[] = [];
+    const events: RawEventData[] = [];
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
     let totalVEvents = 0;

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -3,7 +3,7 @@ import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails, ParseErro
 import { hasAnyErrors } from "../types";
 import { googleMapsSearchUrl, compilePatterns, appendDescriptionSuffix, isPlaceholder } from "../utils";
 import { safeFetch } from "../safe-fetch";
-import { enrichSFH3Events, suppressSFH3UmbrellaDuplicates } from "../html-scraper/sfh3-detail-enrichment";
+import { enrichSFH3Events, markSFH3SeriesMembership } from "../html-scraper/sfh3-detail-enrichment";
 import { enrichBerlinH3Events } from "../html-scraper/berlin-h3-detail-enrichment";
 import { sync as icalSync } from "node-ical";
 import type { VEvent, ParameterValue, DateWithTimeZone } from "node-ical";
@@ -415,6 +415,24 @@ function buildRawEventFromVEvent(
   // endTime is HH:MM only, so cross-date DTEND values (overnight runs) are dropped.
   const endDt = vevent.end as DateWithTimeZone | undefined;
   const endTime = endDt && formatDate(endDt) === dateStr ? formatTime(endDt) : undefined;
+  // endDate (#1560) — populated only for multi-day ALL-DAY VEVENTs (DTSTART
+  // and DTEND both VALUE=DATE, spanning >1 day). RFC 5545 makes all-day DTEND
+  // exclusive (an event May 14–17 has DTEND=May 18), so the inclusive last day
+  // is DTEND minus one day. Timed events that just cross midnight (overnight
+  // trails) are deliberately excluded — they're single-day events with a late
+  // end, not multi-day campouts.
+  let endDate: string | undefined;
+  if (endDt && (vevent.start as DateWithTimeZone).dateOnly && endDt.dateOnly) {
+    const startMs = (vevent.start as DateWithTimeZone).getTime();
+    const endMs = endDt.getTime();
+    const DAY_MS = 86_400_000;
+    if (endMs - startMs > DAY_MS + 60_000) {
+      const inclusiveEnd = new Date(endMs - DAY_MS) as DateWithTimeZone;
+      // Preserve dateOnly flag so formatDate takes the dateOnly branch.
+      (inclusiveEnd as { dateOnly?: boolean }).dateOnly = true;
+      endDate = formatDate(inclusiveEnd);
+    }
+  }
   const description = paramValue(vevent.description);
   let hares = description ? extractHaresFromDescription(description, compiledHarePatterns) : undefined;
 
@@ -459,6 +477,7 @@ function buildRawEventFromVEvent(
     endTime,
     cost,
     sourceUrl: paramValue(vevent.url) ?? undefined,
+    endDate,
   };
 }
 
@@ -585,10 +604,14 @@ export class ICalAdapter implements SourceAdapter {
       errorDetails.parse = parseErrors;
     }
 
-    // SFH3 emits two VEVENTs (/events/{n} umbrella + /runs/{m} trail) for the
-    // same campout day; drop the umbrella when a same-date trail exists (#1421).
-    // No-op for feeds without sfh3.com URLs, so unconditional is safe.
-    events = suppressSFH3UmbrellaDuplicates(events);
+    // SFH3 publishes multi-day campouts as a /events/{n} umbrella VEVENT plus
+    // per-day /runs/{m} trail VEVENTs. Mark series membership in place
+    // (#1560 — replaces the pre-existing umbrella-suppression hack from
+    // #1421). The umbrella becomes the series parent so its rich description
+    // (theme, registration, lodging) lands on the canonical parent Event;
+    // trails fall under it via parentEventId after merge.
+    // No-op for feeds without sfh3.com/events URLs, so unconditional is safe.
+    events = markSFH3SeriesMembership(events);
 
     // SFH3-specific enrichment: the .ics SUMMARY omits "Run" and has no Comment
     // field. Pull the canonical title + Comment from /runs/{id} so the merge

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -49,7 +49,22 @@ export interface RawEventData {
   prelube?: string | null;
   sourceUrl?: string;
   externalLinks?: { url: string; label: string }[]; // Additional links (creates EventLink records)
-  seriesId?: string; // Groups multi-day events (e.g., Hash Rego event slug)
+  seriesId?: string; // Groups multi-day events (e.g., Hash Rego event slug, SFH3 "sfh3-event-N")
+  /**
+   * Last day of a multi-day event (YYYY-MM-DD), inclusive. Set on:
+   *  - series PARENT umbrellas spanning N child days (with `seriesParent: true`)
+   *  - single-row date-range events with no children (one-registration weekend
+   *    campouts — MadisonH3 case)
+   * Omit for single-day events. Stored as `Event.endDate` on the canonical row.
+   */
+  endDate?: string;
+  /**
+   * Explicit "this raw is the series parent" marker for adapters that emit a
+   * standalone umbrella event alongside per-day children (SFH3 `/events/N`).
+   * Hash Rego doesn't set this; merge.ts falls back to earliest-by-date for
+   * groups where no raw is explicitly marked.
+   */
+  seriesParent?: boolean;
   /**
    * ISO-2 country code override used for geocoding region bias.
    * Set by adapters when a single event runs outside the kennel's home country

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -66,6 +66,31 @@ export interface HarelineListEvent {
   dogFriendly: boolean | null;
   /** #1316 — pre-event meetup venue/time, free-form. */
   prelube: string | null;
+  /** #1560 — multi-day series + standalone date-range support. */
+  isSeriesParent: boolean | null;
+  parentEventId: string | null;
+  endDate: string | null; // ISO; null = single-day
+  /** #1560 — per-trail children for series parents. Empty array for non-parents. */
+  childEvents: HarelineChildEvent[];
+}
+
+/**
+ * Compact child shape included inline on series-parent rows. Only carries the
+ * fields the expanded "Weekend at a glance" timeline renders (#1560) — heavy
+ * fields stream lazily through `getEventDetail` if the user clicks into a
+ * specific child.
+ */
+export interface HarelineChildEvent {
+  id: string;
+  date: string;
+  dateUtc: Date | null;
+  timezone: string | null;
+  title: string | null;
+  haresText: string | null;
+  startTime: string | null;
+  status: string;
+  locationName: string | null;
+  runNumber: number | null;
 }
 
 export type TimeMode = "upcoming" | "past";
@@ -81,7 +106,12 @@ const PAST_EVENTS_LIMIT = 200;
  * string. `unstable_cache` JSON-serializes its return value; keeping this
  * twin explicit means the boundary conversion is visible at the call site.
  */
-interface CachedHarelineEvent extends Omit<HarelineListEvent, "dateUtc"> {
+interface CachedHarelineEvent extends Omit<HarelineListEvent, "dateUtc" | "childEvents"> {
+  dateUtc: string | null;
+  childEvents: CachedHarelineChildEvent[];
+}
+
+interface CachedHarelineChildEvent extends Omit<HarelineChildEvent, "dateUtc"> {
   dateUtc: string | null;
 }
 
@@ -164,6 +194,34 @@ const fetchSlimEventsCached = unstable_cache(
         trailType: true,
         dogFriendly: true,
         prelube: true,
+        // #1560 — multi-day series metadata + inline children list.
+        isSeriesParent: true,
+        parentEventId: true,
+        endDate: true,
+        childEvents: {
+          where: {
+            // Mirror DISPLAY_EVENT_WHERE's visibility predicates on the
+            // child set (parentEventId stays unset here — children all have
+            // it pointing to this row).
+            status: { not: "CANCELLED" },
+            isManualEntry: { not: true },
+            isCanonical: true,
+            kennel: { isHidden: false },
+          },
+          orderBy: { date: "asc" },
+          select: {
+            id: true,
+            date: true,
+            dateUtc: true,
+            timezone: true,
+            title: true,
+            haresText: true,
+            startTime: true,
+            status: true,
+            locationName: true,
+            runNumber: true,
+          },
+        },
         kennel: {
           select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },
         },
@@ -206,6 +264,21 @@ const fetchSlimEventsCached = unstable_cache(
       trailType: e.trailType,
       dogFriendly: e.dogFriendly,
       prelube: e.prelube,
+      isSeriesParent: e.isSeriesParent,
+      parentEventId: e.parentEventId,
+      endDate: e.endDate ? e.endDate.toISOString() : null,
+      childEvents: e.childEvents.map((c) => ({
+        id: c.id,
+        date: c.date.toISOString(),
+        dateUtc: c.dateUtc ? c.dateUtc.toISOString() : null,
+        timezone: c.timezone,
+        title: c.title,
+        haresText: c.haresText,
+        startTime: c.startTime,
+        status: c.status,
+        locationName: c.locationName,
+        runNumber: c.runNumber,
+      })),
     }));
   },
   ["hareline:events"],
@@ -252,6 +325,10 @@ export async function loadEventsForTimeMode(
   return cached.map((e) => ({
     ...e,
     dateUtc: e.dateUtc ? new Date(e.dateUtc) : null,
+    childEvents: e.childEvents.map((c) => ({
+      ...c,
+      dateUtc: c.dateUtc ? new Date(c.dateUtc) : null,
+    })),
   }));
 }
 
@@ -267,13 +344,20 @@ export interface EventDetailFields {
 
 /**
  * Fetch heavy fields for a single event on detail-panel expand. Returns
- * `null` if the event doesn't exist or isn't visible (same
- * DISPLAY_EVENT_WHERE predicate used everywhere else).
+ * `null` if the event doesn't exist or isn't visible.
+ *
+ * #1560 — series children (`parentEventId != null`) DO resolve here because
+ * the right-side panel can navigate into a child trail from the parent's
+ * expanded timeline. We rebuild the where clause without the
+ * `parentEventId: null` predicate that DISPLAY_EVENT_WHERE adds for listings.
  */
 export async function getEventDetail(eventId: string): Promise<EventDetailFields | null> {
   if (!eventId) return null;
+  // Reuse DISPLAY_EVENT_WHERE's visibility predicates but skip the listing-
+  // only `parentEventId: null` so child rows can still be inspected.
+  const { parentEventId: _excluded, ...visibilityWhere } = DISPLAY_EVENT_WHERE;
   return prisma.event.findFirst({
-    where: { id: eventId, ...DISPLAY_EVENT_WHERE },
+    where: { id: eventId, ...visibilityWhere },
     select: {
       description: true,
       sourceUrl: true,

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -113,6 +113,29 @@ export default async function KennelDetailPage({
           },
           orderBy: { kennel: { shortName: "asc" } },
         },
+        // #1560 — per-trail children for series parents. Slim select to
+        // match the HarelineSeriesChild shape consumed by EventCard.
+        childEvents: {
+          where: {
+            status: { not: "CANCELLED" },
+            isManualEntry: { not: true },
+            isCanonical: true,
+            kennel: { isHidden: false },
+          },
+          orderBy: { date: "asc" },
+          select: {
+            id: true,
+            date: true,
+            dateUtc: true,
+            timezone: true,
+            title: true,
+            haresText: true,
+            startTime: true,
+            status: true,
+            locationName: true,
+            runNumber: true,
+          },
+        },
       },
       orderBy: { date: "asc" },
     }),
@@ -175,6 +198,21 @@ export default async function KennelDetailPage({
     dogFriendly: e.dogFriendly,
     prelube: e.prelube,
     cost: e.cost,
+    isSeriesParent: e.isSeriesParent,
+    parentEventId: e.parentEventId,
+    endDate: e.endDate ? e.endDate.toISOString() : null,
+    childEvents: e.childEvents.map((c) => ({
+      id: c.id,
+      date: c.date.toISOString(),
+      dateUtc: c.dateUtc,
+      timezone: c.timezone,
+      title: c.title,
+      haresText: c.haresText,
+      startTime: c.startTime,
+      status: c.status,
+      locationName: c.locationName,
+      runNumber: c.runNumber,
+    })),
   }));
 
   const upcoming = serialized.filter(

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -774,7 +774,11 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
                 aria-controls={`series-${event.id}-children`}
                 className="flex items-center gap-1 text-xs font-mono text-muted-foreground/80 hover:text-foreground transition-colors"
               >
-                {seriesExpanded ? "Hide trails" : `Show ${childCount} ${childCount === 1 ? "trail" : "trails"}`}
+                {(() => {
+                  if (seriesExpanded) return "Hide trails";
+                  const trailWord = childCount === 1 ? "trail" : "trails";
+                  return `Show ${childCount} ${trailWord}`;
+                })()}
                 <ChevronDown
                   className={`size-3 transition-transform ${seriesExpanded ? "rotate-180" : ""}`}
                   aria-hidden="true"
@@ -804,6 +808,17 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
   );
 }
 
+/**
+ * Time to render in a series child row. Prefer the timezone-aware composed
+ * value when both `dateUtc` and `startTime` are present; fall back to the
+ * raw HH:MM string when only `startTime` exists; otherwise `null`.
+ */
+function computeChildTime(child: HarelineSeriesChild, displayTz: string): string | null {
+  if (child.dateUtc && child.startTime) return formatTimeInZone(child.dateUtc, displayTz);
+  if (child.startTime) return formatTime(child.startTime);
+  return null;
+}
+
 /** One row in the expanded series children list (#1560). Compact: day chip
  *  + time + title + hares. Click navigates to the child's detail page.
  *  Stops propagation so the parent card's onClick doesn't also fire. */
@@ -817,9 +832,7 @@ function SeriesChildRow({
   readonly displayTz: string;
 }) {
   const router = useRouter();
-  const childTime = (child.dateUtc && child.startTime)
-    ? formatTimeInZone(child.dateUtc, displayTz)
-    : (child.startTime ? formatTime(child.startTime) : null);
+  const childTime = computeChildTime(child, displayTz);
   const childDate = new Date(child.date);
   const dayChip = childDate.toLocaleDateString("en-US", { weekday: "short", day: "numeric", timeZone: "UTC" });
   const isChildCancelled = child.status === "CANCELLED";

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -1,15 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { MapPin, Clock, Footprints } from "lucide-react";
+import { MapPin, Clock, Footprints, Tent, ChevronDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { formatTime } from "@/lib/format";
+import { formatTime, formatDateRange } from "@/lib/format";
 import { AttendanceBadge } from "@/components/logbook/AttendanceBadge";
 import type { AttendanceData } from "@/components/logbook/CheckInButton";
 import { RegionBadge } from "./RegionBadge";
@@ -86,6 +87,43 @@ export type HarelineEvent = {
   description?: string | null;
   sourceUrl?: string | null;
   eventLinks?: { id: string; url: string; label: string }[];
+  /**
+   * Multi-day series fields (#1560).
+   *  - `isSeriesParent` flips on when `linkMultiDaySeries` made this Event
+   *    the umbrella for a multi-trail weekend; `childEvents` carries the
+   *    per-day trails ordered by date.
+   *  - `endDate` carries the inclusive last day of either a series parent
+   *    or a standalone date-range event (one-registration venue weekend,
+   *    no children — MadisonH3 case). Either signal opts a card into the
+   *    multi-day visual treatment; the absence of children differentiates
+   *    "weekend with N trails" from "weekend at one venue".
+   *  - `parentEventId` is set on child Events; the hareline + kennel page
+   *    listings filter `parentEventId: null` so children only render
+   *    inside their parent's expanded view, never as top-level cards.
+   */
+  isSeriesParent?: boolean | null;
+  parentEventId?: string | null;
+  endDate?: string | null; // ISO; null = single-day
+  childEvents?: HarelineSeriesChild[];
+};
+
+/**
+ * Slim shape for children rendered inside a series parent's expanded
+ * timeline (#1560). Only the fields the timeline row reads — heavy
+ * details (location, weather, eventLinks, etc.) stream lazily through
+ * `getEventDetail` when the user opens a specific child.
+ */
+export type HarelineSeriesChild = {
+  id: string;
+  date: string;
+  dateUtc: Date | null;
+  timezone: string | null;
+  title: string | null;
+  haresText: string | null;
+  startTime: string | null;
+  status: string;
+  locationName: string | null;
+  runNumber: number | null;
 };
 
 
@@ -243,6 +281,25 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
   // Time formatting below still uses `displayTz`. (#1502)
   const displayDateStr = computeChipDate(event);
 
+  // #1560 series rendering — `isSeriesParent` carries N child trails (Bay 2
+  // Blackout-style); `endDate` alone signals a date-range standalone (one
+  // registration covers a venue weekend, no children). Both opt into the
+  // date-range chip + tent glyph; only the former expands.
+  //
+  // `event.date` and `event.endDate` are both serialized via `toISOString()`
+  // so we extract YYYY-MM-DD from each before comparing — pre-Codex-review
+  // this compared `endDate` (ISO) to `event.date.split("T")[0]` (YYYY-MM-DD)
+  // and never matched, so the same-day suppression guard was silently
+  // unreachable.
+  const isSeriesParent = event.isSeriesParent === true;
+  const endDay = event.endDate ? event.endDate.split("T")[0] : null;
+  const startDay = event.date.split("T")[0];
+  const hasDateRange = !!endDay && endDay !== startDay;
+  const isMultiDay = isSeriesParent || hasDateRange;
+  const childCount = event.childEvents?.length ?? 0;
+  const rangeDisplay = isMultiDay ? formatDateRange(event.date, event.endDate) : displayDateStr;
+  const [seriesExpanded, setSeriesExpanded] = useState(false);
+
   const displayTimeStr = (event.dateUtc && event.startTime)
     ? formatTimeInZone(event.dateUtc, displayTz)
     : (event.startTime ? formatTime(event.startTime) : null);
@@ -310,10 +367,28 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
             style={{ backgroundColor: `${regionColor}06` }}
           />
 
-          {/* Fixed-width columns: date, kennel, run# */}
+          {/* Fixed-width columns: date, kennel, run#
+              #1560 — multi-day events show the inclusive date range in place
+              of the single-day chip. Widening the column when a range is
+              present keeps the rest of the row from reflowing. */}
           {!hideDate && (
-            <span className="relative w-24 shrink-0 font-medium text-muted-foreground" suppressHydrationWarning>
-              {displayDateStr}
+            <span
+              className={`relative shrink-0 font-medium text-muted-foreground ${isMultiDay ? "w-32" : "w-24"}`}
+              suppressHydrationWarning
+            >
+              {isMultiDay && (
+                <Tent
+                  className="inline-block size-3 mr-1 -mt-px"
+                  style={{ color: regionColor, opacity: 0.7 }}
+                  aria-hidden="true"
+                />
+              )}
+              {rangeDisplay}
+              {isSeriesParent && childCount > 0 && (
+                <span className="ml-1 font-mono text-[10px] text-muted-foreground/70" aria-label={`${childCount} trails`}>
+                  · {childCount}t
+                </span>
+              )}
             </span>
           )}
 
@@ -487,8 +562,38 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
 
               {!hideDate && (
                 <span className="text-xs text-muted-foreground/50 hidden sm:inline" suppressHydrationWarning>
-                  {displayDateStr}
+                  {isMultiDay && (
+                    <Tent
+                      className="inline-block size-3 mr-1 -mt-px align-middle"
+                      style={{ color: regionColor, opacity: 0.7 }}
+                      aria-hidden="true"
+                    />
+                  )}
+                  {rangeDisplay}
                 </span>
+              )}
+
+              {/* #1560 — series-parent "+ N trails" badge. Sibling to the
+                  existing tentative/cancelled badges so it inherits flex-wrap
+                  behavior. Hidden when childCount is 0 (Madison-style
+                  date-range standalone). */}
+              {isSeriesParent && childCount > 0 && (
+                <Badge
+                  className="text-[10px] px-1.5 py-0 font-mono uppercase tracking-wider border-0"
+                  style={{ backgroundColor: `${regionColor}1a`, color: regionColor }}
+                  aria-label={`${childCount} trails in this series`}
+                >
+                  + {childCount} trails
+                </Badge>
+              )}
+              {hasDateRange && !isSeriesParent && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] px-1.5 py-0 text-muted-foreground border-dashed"
+                  aria-label="Multi-day weekend event"
+                >
+                  Weekend
+                </Badge>
               )}
 
               {/* Status badges */}
@@ -652,8 +757,106 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
               </Tooltip>
             )}
           </div>
+
+          {/* #1560 \u2014 series children expansion. Renders below the metadata
+              strip so the card's primary scan rhythm is untouched until the
+              user expands. Children are listed as compact rows tied to the
+              parent's region color via a timeline rail. */}
+          {isSeriesParent && childCount > 0 && (
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setSeriesExpanded((v) => !v);
+                }}
+                aria-expanded={seriesExpanded}
+                aria-controls={`series-${event.id}-children`}
+                className="flex items-center gap-1 text-xs font-mono text-muted-foreground/80 hover:text-foreground transition-colors"
+              >
+                {seriesExpanded ? "Hide trails" : `Show ${childCount} ${childCount === 1 ? "trail" : "trails"}`}
+                <ChevronDown
+                  className={`size-3 transition-transform ${seriesExpanded ? "rotate-180" : ""}`}
+                  aria-hidden="true"
+                />
+              </button>
+              {seriesExpanded && (
+                <ol
+                  id={`series-${event.id}-children`}
+                  className="mt-2 flex flex-col border-l-2 ml-1.5 pl-3 space-y-1"
+                  style={{ borderColor: regionColor }}
+                >
+                  {event.childEvents!.map((child) => (
+                    <SeriesChildRow
+                      key={child.id}
+                      child={child}
+                      regionColor={regionColor}
+                      displayTz={displayTz}
+                    />
+                  ))}
+                </ol>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>
+  );
+}
+
+/** One row in the expanded series children list (#1560). Compact: day chip
+ *  + time + title + hares. Click navigates to the child's detail page.
+ *  Stops propagation so the parent card's onClick doesn't also fire. */
+function SeriesChildRow({
+  child,
+  regionColor,
+  displayTz,
+}: {
+  readonly child: HarelineSeriesChild;
+  readonly regionColor: string;
+  readonly displayTz: string;
+}) {
+  const router = useRouter();
+  const childTime = (child.dateUtc && child.startTime)
+    ? formatTimeInZone(child.dateUtc, displayTz)
+    : (child.startTime ? formatTime(child.startTime) : null);
+  const childDate = new Date(child.date);
+  const dayChip = childDate.toLocaleDateString("en-US", { weekday: "short", day: "numeric", timeZone: "UTC" });
+  const isChildCancelled = child.status === "CANCELLED";
+  return (
+    <li className="relative">
+      <span
+        aria-hidden="true"
+        className="absolute -left-[14px] top-1.5 size-2 rounded-full"
+        style={{ backgroundColor: isChildCancelled ? "#9ca3af" : regionColor }}
+      />
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          router.push(`/hareline/${child.id}`);
+        }}
+        className={`group/child flex items-baseline gap-2 text-xs w-full text-left hover:text-foreground transition-colors ${
+          isChildCancelled ? "opacity-50" : ""
+        }`}
+      >
+        <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground/80 w-12 shrink-0">
+          {dayChip}
+        </span>
+        {childTime && (
+          <span className="font-mono tabular-nums text-muted-foreground/70 w-12 shrink-0" suppressHydrationWarning>
+            {childTime}
+          </span>
+        )}
+        <span className={`truncate font-medium ${isChildCancelled ? "line-through" : ""}`}>
+          {child.title ?? "Trail"}
+        </span>
+        {child.haresText && (
+          <span className="hidden sm:inline text-muted-foreground/60 truncate">
+            ({child.haresText})
+          </span>
+        )}
+      </button>
+    </li>
   );
 }

--- a/src/components/hareline/EventDetailPanel.tsx
+++ b/src/components/hareline/EventDetailPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Tent, ArrowUpLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -10,7 +10,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { formatTime, formatDateLong, getLabelForUrl, stripMarkdown, stripUrlsFromText } from "@/lib/format";
+import { formatTime, formatDateLong, formatDateRange, getLabelForUrl, stripMarkdown, stripUrlsFromText } from "@/lib/format";
 import { getFullLocationDisplay } from "@/lib/event-display";
 import type { HarelineEvent } from "./EventCard";
 import { ShiggyLevelFlames, TrailLengthLine, formatTrailLength } from "./TrailDifficulty";
@@ -87,15 +87,48 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
   const regionColor = event.kennel?.region ? getRegionColor(event.kennel.region) : "#6b7280";
   const trailLengthDisplay = formatTrailLength(event);
 
+  // #1560 — multi-day series / date-range standalone signals. Both `date`
+  // and `endDate` are serialized as full ISO strings, so we extract
+  // YYYY-MM-DD from each before comparing (Codex P1 review — the older
+  // form compared ISO to YYYY-MM-DD and the suppression guard never fired).
+  const isSeriesParent = event.isSeriesParent === true;
+  const endDay = event.endDate ? event.endDate.split("T")[0] : null;
+  const startDay = event.date.split("T")[0];
+  const hasDateRange = !!endDay && endDay !== startDay;
+  const isMultiDay = isSeriesParent || hasDateRange;
+  const childCount = event.childEvents?.length ?? 0;
+  const isChildOfSeries = !!event.parentEventId;
+  // Heading: range for parents/date-range events, single date for children + singles.
+  const headingDateStr = isMultiDay ? formatDateRange(event.date, event.endDate) : displayDateStr;
+
   return (
     <Card className="flex max-h-[calc(100vh-4rem)] flex-col overflow-hidden border-t-[3px]" style={{ borderTopColor: regionColor }}>
       {/* Scrollable content */}
       <CardContent className="min-h-0 flex-1 space-y-4 overflow-y-auto p-5">
+        {/* #1560 — child detail panel: back-link to parent series */}
+        {isChildOfSeries && event.parentEventId && (
+          <Link
+            href={`/hareline/${event.parentEventId}`}
+            className="flex items-center gap-2 px-2 py-1.5 -mx-1 mb-2 border-l-[3px] text-xs text-muted-foreground hover:text-foreground transition-colors"
+            style={{ borderColor: regionColor }}
+          >
+            <ArrowUpLeft className="size-3" aria-hidden="true" />
+            <span>Part of a multi-day series</span>
+          </Link>
+        )}
+
         {/* Header */}
         <div className="space-y-1">
           <div className="flex items-start justify-between gap-2">
             <div className="flex items-center gap-1.5">
-              <h2 className="text-lg font-bold" suppressHydrationWarning>{displayDateStr}</h2>
+              {isMultiDay && (
+                <Tent
+                  className="size-4 shrink-0"
+                  style={{ color: regionColor }}
+                  aria-hidden="true"
+                />
+              )}
+              <h2 className="text-lg font-bold" suppressHydrationWarning>{headingDateStr}</h2>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Link
@@ -139,12 +172,75 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
             {event.status === "TENTATIVE" && (
               <Badge variant="outline">Tentative</Badge>
             )}
+            {/* #1560 — series-parent + standalone date-range badges */}
+            {isSeriesParent && childCount > 0 && (
+              <Badge
+                className="text-[10px] px-1.5 py-0 font-mono uppercase tracking-wider border-0"
+                style={{ backgroundColor: `${regionColor}1a`, color: regionColor }}
+              >
+                + {childCount} trails
+              </Badge>
+            )}
+            {hasDateRange && !isSeriesParent && (
+              <Badge variant="outline" className="text-[10px] px-1.5 py-0 text-muted-foreground border-dashed">
+                Weekend
+              </Badge>
+            )}
           </div>
         </div>
 
         {/* Title */}
         {event.title && (
           <h3 className="text-base font-semibold">{event.title}</h3>
+        )}
+
+        {/* #1560 — series children mini-timeline. Renders right after the
+            title so the umbrella's description (further down) sits below
+            the at-a-glance schedule. */}
+        {isSeriesParent && childCount > 0 && (
+          <div>
+            <h4 className="mb-1.5 text-xs font-mono uppercase tracking-wider text-muted-foreground/70">
+              Weekend at a glance
+            </h4>
+            <ol
+              className="flex flex-col border-l-2 ml-1 pl-3 space-y-1.5"
+              style={{ borderColor: regionColor }}
+            >
+              {event.childEvents!.map((child) => {
+                const childDate = new Date(child.date);
+                const dayChip = childDate.toLocaleDateString("en-US", {
+                  weekday: "short", day: "numeric", timeZone: "UTC",
+                });
+                const childTime = child.startTime ? formatTime(child.startTime) : null;
+                const isChildCancelled = child.status === "CANCELLED";
+                return (
+                  <li key={child.id} className="relative">
+                    <span
+                      aria-hidden="true"
+                      className="absolute -left-[14px] top-1.5 size-2 rounded-full"
+                      style={{ backgroundColor: isChildCancelled ? "#9ca3af" : regionColor }}
+                    />
+                    <Link
+                      href={`/hareline/${child.id}`}
+                      className={`flex items-baseline gap-2 text-sm hover:text-primary transition-colors ${isChildCancelled ? "opacity-50" : ""}`}
+                    >
+                      <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground/80 w-14 shrink-0">
+                        {dayChip}
+                      </span>
+                      {childTime && (
+                        <span className="font-mono tabular-nums text-muted-foreground/70 w-14 shrink-0" suppressHydrationWarning>
+                          {childTime}
+                        </span>
+                      )}
+                      <span className={`truncate font-medium ${isChildCancelled ? "line-through" : ""}`}>
+                        {child.title ?? "Trail"}
+                      </span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
         )}
 
         {/* Check-in */}

--- a/src/lib/event-filters.ts
+++ b/src/lib/event-filters.ts
@@ -5,12 +5,20 @@ import type { Prisma } from "@/generated/prisma/client";
  * Display paths (Hareline list, Travel search, kennel page, map) all
  * exclude archived / non-canonical / hidden-kennel rows. Collapsing into one
  * helper keeps the filters from drifting when a new display path lands.
+ *
+ * `parentEventId: null` (#1560) excludes multi-day series CHILDREN from
+ * top-level listings — they render only inside their parent's expanded
+ * "Weekend at a glance" timeline. Children showing up as standalone cards
+ * is exactly the "3 trails for one weekend = 3 hareline rows" bug this PR
+ * is meant to fix. The detail-page lookup intentionally drops this filter
+ * (see `getEventDetail`) so a deep-link to a child page still resolves.
  */
 export const DISPLAY_EVENT_WHERE = {
   status: { not: "CANCELLED" },
   isManualEntry: { not: true },
   isCanonical: true,
   kennel: { isHidden: false },
+  parentEventId: null,
 } as const satisfies Prisma.EventWhereInput;
 
 /**

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -9,6 +9,7 @@ import {
   regionAbbrev,
   regionColorClasses,
   formatDateShort,
+  formatDateRange,
   formatSchedule,
   instagramUrl,
   twitterUrl,
@@ -113,6 +114,66 @@ describe("formatDateShort", () => {
   it("uses UTC to avoid date shift", () => {
     // A date stored as UTC noon should not shift to previous day
     expect(formatDateShort("2026-01-01T12:00:00.000Z")).toBe("Thu, Jan 1");
+  });
+});
+
+describe("formatDateRange (#1560)", () => {
+  // Table-driven per memory feedback_it_each_for_sonar_cpd.md — same shape
+  // shows up 5×, so a single it() with shared boilerplate would trip CPD.
+  it.each([
+    {
+      label: "single day (no endIso)",
+      start: "2026-05-14T12:00:00.000Z",
+      end: undefined,
+      expected: "Thu, May 14",
+    },
+    {
+      label: "single day (endIso null)",
+      start: "2026-05-14T12:00:00.000Z",
+      end: null,
+      expected: "Thu, May 14",
+    },
+    {
+      label: "single day (endIso === startIso)",
+      start: "2026-05-14T12:00:00.000Z",
+      end: "2026-05-14T12:00:00.000Z",
+      expected: "Thu, May 14",
+    },
+    {
+      label: "same month — SFH3 Bay 2 Blackout",
+      start: "2026-05-14T12:00:00.000Z",
+      end: "2026-05-17T12:00:00.000Z",
+      expected: "May 14 – 17",
+    },
+    {
+      label: "cross-month",
+      start: "2026-05-30T12:00:00.000Z",
+      end: "2026-06-01T12:00:00.000Z",
+      expected: "May 30 – Jun 1",
+    },
+    {
+      label: "cross-year (NYE campout)",
+      start: "2026-12-30T12:00:00.000Z",
+      end: "2027-01-02T12:00:00.000Z",
+      expected: "Dec 30, 2026 – Jan 2, 2027",
+    },
+  ])("$label → $expected", ({ start, end, expected }) => {
+    expect(formatDateRange(start, end)).toBe(expected);
+  });
+
+  it("uses en-dash (U+2013), never a hyphen", () => {
+    const result = formatDateRange("2026-05-14T12:00:00.000Z", "2026-05-17T12:00:00.000Z");
+    expect(result).toContain("–"); // en-dash
+    expect(result).not.toContain(" - "); // hyphen-as-separator
+  });
+
+  it("falls back to formatDateShort on malformed endIso (defensive)", () => {
+    expect(formatDateRange("2026-05-14T12:00:00.000Z", "not-a-date")).toBe("Thu, May 14");
+  });
+
+  it("collapses to single-day when endIso is earlier than startIso (defensive)", () => {
+    // Adapter bug or upstream data corruption shouldn't surface as "May 14 – 10".
+    expect(formatDateRange("2026-05-14T12:00:00.000Z", "2026-05-10T12:00:00.000Z")).toBe("Thu, May 14");
   });
 });
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -193,6 +193,61 @@ export function getDayOfWeek(iso: string): string {
   return d.toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" });
 }
 
+/**
+ * Format a multi-day series / campout date range, collapsing redundant parts
+ * (#1560). Output forms:
+ *
+ *   formatDateRange("2026-05-14")                       → "Wed, May 14"
+ *   formatDateRange("2026-05-14", "2026-05-17")         → "May 14 – 17"
+ *   formatDateRange("2026-05-30", "2026-06-01")         → "May 30 – Jun 1"
+ *   formatDateRange("2026-12-30", "2027-01-02")         → "Dec 30, 2026 – Jan 2, 2027"
+ *   formatDateRange("2026-05-14", "2026-05-14")         → "Wed, May 14"  (single day)
+ *
+ * Uses an en-dash (U+2013) between the two endpoints, never a hyphen. Single
+ * day matches `formatDateShort` output exactly. Cross-year always shows both
+ * full years for unambiguous reading.
+ *
+ * Storage convention: dates are UTC noon (CLAUDE.md §F.4), so all date math
+ * runs in UTC — no DST surprises.
+ */
+export function formatDateRange(startIso: string, endIso?: string | null): string {
+  if (!endIso || endIso === startIso) return formatDateShort(startIso);
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  // Defensive: malformed input → fall back to start only.
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return formatDateShort(startIso);
+  }
+  // Same-day collapse (handles ISO strings that differ by time of day).
+  if (end.getTime() <= start.getTime()) return formatDateShort(startIso);
+
+  const startYear = start.getUTCFullYear();
+  const endYear = end.getUTCFullYear();
+  const startMonth = start.getUTCMonth();
+  const endMonth = end.getUTCMonth();
+
+  if (startYear !== endYear) {
+    // Cross-year: full date including year on both sides.
+    const fmt = (d: Date) => d.toLocaleDateString("en-US", {
+      year: "numeric", month: "short", day: "numeric", timeZone: "UTC",
+    });
+    return `${fmt(start)} – ${fmt(end)}`;
+  }
+  if (startMonth !== endMonth) {
+    // Cross-month, same year: month + day on both sides.
+    const fmt = (d: Date) => d.toLocaleDateString("en-US", {
+      month: "short", day: "numeric", timeZone: "UTC",
+    });
+    return `${fmt(start)} – ${fmt(end)}`;
+  }
+  // Same month: "May 14 – 17" (month only on the left, bare day on the right).
+  const leftFmt = start.toLocaleDateString("en-US", {
+    month: "short", day: "numeric", timeZone: "UTC",
+  });
+  const rightDay = end.getUTCDate().toString();
+  return `${leftFmt} – ${rightDay}`;
+}
+
 // ── Kennel profile helpers ──
 
 /**

--- a/src/pipeline/fingerprint.ts
+++ b/src/pipeline/fingerprint.ts
@@ -79,6 +79,25 @@ export function generateFingerprint(data: RawEventData): string {
     withClearSignal(data.trailLengthMinMiles, (n) => n.toString()),
     withClearSignal(data.trailLengthMaxMiles, (n) => n.toString()),
     withClearSignal(data.difficulty, (n) => n.toString()),
+    // #1560 — endDate (multi-day series). Adapters shifting an event from
+    // single-day to multi-day (or extending the range) must invalidate the
+    // RawEvent dedup so the canonical UPDATE fires.
+    //
+    // CRITICAL: we ONLY append the endDate token when endDate is set. An
+    // unconditional `endDate ?? ""` token would change the fingerprint of
+    // every existing single-day RawEvent on next scrape — doubling the
+    // RawEvent table for the entire active source set (Codex P1 review).
+    // By gating, single-day events pre-#1560 and post-#1560 fingerprint
+    // identically; only adapters that newly emit endDate (SFH3 umbrellas,
+    // future Hash Rego date-range parsers) cause a one-time re-merge of
+    // their specific multi-day rows.
+    //
+    // seriesId itself stays out of the fingerprint: it groups raws across
+    // days but every raw still carries a distinct (date, runNumber, hares)
+    // tuple, and including seriesId would couple sibling raws' dedup state.
+    // seriesParent likewise stays out: the boolean is metadata for the
+    // linker, not display content.
+    ...(data.endDate ? [`endDate=${data.endDate}`] : []),
   ].join("|");
 
   return createHash("sha256").update(input).digest("hex");

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -2743,6 +2743,7 @@ const EMPTY_DISPLAY_FIELDS = {
   trailType: null,
   dogFriendly: null,
   prelube: null,
+  endDate: null,
 };
 
 type Candidate = Parameters<typeof pickCanonicalEventId>[0][number];
@@ -3980,5 +3981,310 @@ describe("processNewRawEvent — P2002 race-window fall-through (#1286)", () => 
     expect(result.created).toBe(1);
     expect(result.skipped).toBe(1);
     expect(result.eventErrors).toBe(0);
+  });
+});
+
+describe("linkMultiDaySeries (#1560)", () => {
+  // Shared helper: prime processRawEvents to land each incoming raw as a
+  // fresh canonical Event. The merge loop reads via prisma.event.findMany
+  // through TWO distinct query shapes — `ensureKennelEventCache` uses
+  // `where.kennelId/date`, and `linkMultiDaySeries` uses `where.id.in`.
+  // We route by inspecting the where clause so post-link Once seeds aren't
+  // eaten by the per-event ensureKennelEventCache call.
+  // Shape the EVENT_CACHE_SELECT contract expects post-create: every column
+  // recomputeCanonical / rememberCreatedEvent reads must be present, or the
+  // second event's ensureKennelEventCache hit on the in-memory pool crashes.
+  function buildCanonicalEventRow(id: string): Record<string, unknown> {
+    return {
+      id,
+      kennelId: "kennel_1",
+      date: new Date("2026-01-16T12:00:00Z"),
+      dateUtc: new Date("2026-01-16T12:00:00Z"),
+      timezone: "America/New_York",
+      runNumber: null,
+      title: "Stub Trail",
+      description: null,
+      haresText: null,
+      locationName: null,
+      locationStreet: null,
+      locationCity: null,
+      locationAddress: null,
+      latitude: null,
+      longitude: null,
+      startTime: null,
+      endTime: null,
+      cost: null,
+      trailLengthText: null,
+      trailLengthMinMiles: null,
+      trailLengthMaxMiles: null,
+      difficulty: null,
+      trailType: null,
+      dogFriendly: null,
+      prelube: null,
+      sourceUrl: null,
+      trustLevel: 5,
+      isSeriesParent: false,
+      parentEventId: null,
+      endDate: null,
+      status: "CONFIRMED",
+      adminCancelledAt: null,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      isCanonical: true,
+    };
+  }
+
+  function primeFreshCreate(eventIds: string[], postLinkStatuses?: Array<{ id: string; status: string }>) {
+    mockEventFindMany.mockReset();
+    // Loose typing on the impl — Prisma's generated client types are too
+    // strict for a router-style mock; the actual call shapes we route on
+    // are stable enough (the merge pipeline drives them).
+    (mockEventFindMany.mockImplementation as unknown as (fn: (args?: unknown) => Promise<unknown>) => unknown)(
+      async (args?: unknown) => {
+        const w = (args as { where?: { id?: { in?: string[] } } } | undefined)?.where;
+        if (w?.id && typeof w.id === "object" && Array.isArray(w.id.in) && postLinkStatuses) {
+          return postLinkStatuses;
+        }
+        return [];
+      },
+    );
+    for (const id of eventIds) {
+      mockEventCreate.mockResolvedValueOnce(buildCanonicalEventRow(id) as never);
+      mockRawEventCreate.mockResolvedValueOnce({ id: `raw_${id}` } as never);
+    }
+    // Stub event.update to echo the row back so post-update cache patching
+    // doesn't lose the EVENT_CACHE_SELECT-shaped fields recomputeCanonical needs.
+    (mockEventUpdate.mockImplementation as unknown as (fn: (args?: unknown) => Promise<unknown>) => unknown)(
+      async (args?: unknown) => {
+        const a = args as { where?: { id?: string }; data?: Record<string, unknown> } | undefined;
+        const row = buildCanonicalEventRow((a?.where?.id) ?? "evt_unknown");
+        return { ...row, ...(a?.data ?? {}) };
+      },
+    );
+    // Fingerprints distinct so dedup never short-circuits.
+    mockFingerprint.mockReset();
+    eventIds.forEach((id, i) => mockFingerprint.mockReturnValueOnce(`fp_${id}_${i}`));
+  }
+
+  it("picks earliest event as parent when no raw is marked seriesParent", async () => {
+    primeFreshCreate(["evt_fri", "evt_sat", "evt_sun"], [
+      { id: "evt_fri", status: "CONFIRMED" },
+      { id: "evt_sat", status: "CONFIRMED" },
+      { id: "evt_sun", status: "CONFIRMED" },
+    ]);
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-01-16", seriesId: "5boro-2026", title: "Day 1" }),
+      buildRawEvent({ date: "2026-01-17", seriesId: "5boro-2026", title: "Day 2" }),
+      buildRawEvent({ date: "2026-01-18", seriesId: "5boro-2026", title: "Day 3" }),
+    ]);
+
+    // Parent is the first (earliest) event; it gets isSeriesParent set.
+    const parentUpdate = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { where?: { id?: string } }).where?.id === "evt_fri"
+        && (args as { data?: { isSeriesParent?: boolean } }).data?.isSeriesParent === true,
+    );
+    expect(parentUpdate).toBeDefined();
+    // Children get parentEventId via the batched updateMany.
+    const childUpdateMany = vi.mocked(prisma.event.updateMany).mock.calls.find(
+      ([args]) => (args as { data?: { parentEventId?: string } }).data?.parentEventId === "evt_fri",
+    );
+    expect(childUpdateMany).toBeDefined();
+    expect((childUpdateMany![0] as { where: { id: { in: string[] } } }).where.id.in).toEqual(
+      expect.arrayContaining(["evt_sat", "evt_sun"]),
+    );
+  });
+
+  it("honors explicit seriesParent:true even when it's not the earliest by date", async () => {
+    // SFH3 umbrella case: umbrella DTSTART is May 14 (earliest), and that IS
+    // also the explicit parent. But if a series ever emitted the umbrella
+    // mid-window (defensive), the explicit flag must still win.
+    primeFreshCreate(["evt_child", "evt_umbrella", "evt_child2"], [
+      // post-link findMany returns rows sorted by date asc; evt_child (5/14)
+      // is earliest, but the seriesParent flag must override that pick.
+      { id: "evt_child", status: "CONFIRMED" },
+      { id: "evt_umbrella", status: "CONFIRMED" },
+      { id: "evt_child2", status: "CONFIRMED" },
+    ]);
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-05-14", seriesId: "sfh3-event-99", title: "Friday trail" }),
+      buildRawEvent({
+        date: "2026-05-15",
+        seriesId: "sfh3-event-99",
+        seriesParent: true,
+        endDate: "2026-05-17",
+        title: "Bay 2 Blackout 2026",
+        startTime: undefined,
+      }),
+      buildRawEvent({ date: "2026-05-16", seriesId: "sfh3-event-99", title: "Saturday trail" }),
+    ]);
+
+    // Parent should be the explicit one (evt_umbrella), NOT evt_child (earliest).
+    const parentUpdate = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { where?: { id?: string } }).where?.id === "evt_umbrella"
+        && (args as { data?: { isSeriesParent?: boolean } }).data?.isSeriesParent === true,
+    );
+    expect(parentUpdate).toBeDefined();
+    const childUpdateMany = vi.mocked(prisma.event.updateMany).mock.calls.find(
+      ([args]) => (args as { data?: { parentEventId?: string } }).data?.parentEventId === "evt_umbrella",
+    );
+    expect(childUpdateMany).toBeDefined();
+    expect((childUpdateMany![0] as { where: { id: { in: string[] } } }).where.id.in).toEqual(
+      expect.arrayContaining(["evt_child", "evt_child2"]),
+    );
+  });
+
+  it("cascades CANCELLED to parent when every child is cancelled", async () => {
+    primeFreshCreate(["evt_p", "evt_c1", "evt_c2"], [
+      { id: "evt_p", status: "CONFIRMED" },
+      { id: "evt_c1", status: "CANCELLED" },
+      { id: "evt_c2", status: "CANCELLED" },
+    ]);
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-06-01", seriesId: "campout-x" }),
+      buildRawEvent({ date: "2026-06-02", seriesId: "campout-x" }),
+      buildRawEvent({ date: "2026-06-03", seriesId: "campout-x" }),
+    ]);
+
+    const cancelUpdate = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { where?: { id?: string } }).where?.id === "evt_p"
+        && (args as { data?: { status?: string } }).data?.status === "CANCELLED",
+    );
+    expect(cancelUpdate).toBeDefined();
+  });
+
+  it("does NOT cascade-cancel an admin-locked parent (Codex P0 review)", async () => {
+    // Admin used the UI to cancel the parent (adminCancelledAt set). Next
+    // scrape comes back with all children CONFIRMED — pre-Codex-fix the
+    // linker would clobber the admin lock back to CONFIRMED.
+    primeFreshCreate(["evt_p", "evt_c1", "evt_c2"], [
+      { id: "evt_p", status: "CANCELLED", adminCancelledAt: new Date("2026-06-01") } as never,
+      { id: "evt_c1", status: "CONFIRMED" },
+      { id: "evt_c2", status: "CONFIRMED" },
+    ]);
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-06-01", seriesId: "campout-locked" }),
+      buildRawEvent({ date: "2026-06-02", seriesId: "campout-locked" }),
+      buildRawEvent({ date: "2026-06-03", seriesId: "campout-locked" }),
+    ]);
+
+    const restoreUpdate = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { where?: { id?: string } }).where?.id === "evt_p"
+        && (args as { data?: { status?: string } }).data?.status === "CONFIRMED",
+    );
+    expect(restoreUpdate).toBeUndefined();
+  });
+
+  it("does NOT cascade-cancel an admin-locked CONFIRMED parent (mirror case)", async () => {
+    // Admin un-cancelled but the lock stays set (lock survives uncancel by
+    // design). All children cancelled — without the admin-lock guard the
+    // linker would still flip to CANCELLED here.
+    primeFreshCreate(["evt_p", "evt_c1", "evt_c2"], [
+      { id: "evt_p", status: "CONFIRMED", adminCancelledAt: new Date("2026-06-01") } as never,
+      { id: "evt_c1", status: "CANCELLED" },
+      { id: "evt_c2", status: "CANCELLED" },
+    ]);
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-06-01", seriesId: "campout-locked-2" }),
+      buildRawEvent({ date: "2026-06-02", seriesId: "campout-locked-2" }),
+      buildRawEvent({ date: "2026-06-03", seriesId: "campout-locked-2" }),
+    ]);
+
+    const cancelUpdate = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { where?: { id?: string } }).where?.id === "evt_p"
+        && (args as { data?: { status?: string } }).data?.status === "CANCELLED",
+    );
+    expect(cancelUpdate).toBeUndefined();
+  });
+
+  it("does NOT cascade-cancel parent when at least one child is live", async () => {
+    primeFreshCreate(["evt_p", "evt_c1", "evt_c2"], [
+      { id: "evt_p", status: "CONFIRMED" },
+      { id: "evt_c1", status: "CANCELLED" },
+      { id: "evt_c2", status: "CONFIRMED" }, // one survivor → series stays alive
+    ]);
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-06-01", seriesId: "campout-y" }),
+      buildRawEvent({ date: "2026-06-02", seriesId: "campout-y" }),
+      buildRawEvent({ date: "2026-06-03", seriesId: "campout-y" }),
+    ]);
+
+    const cancelUpdate = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { where?: { id?: string } }).where?.id === "evt_p"
+        && (args as { data?: { status?: string } }).data?.status === "CANCELLED",
+    );
+    expect(cancelUpdate).toBeUndefined();
+  });
+
+  it("restores parent from CANCELLED → CONFIRMED when a child comes back alive", async () => {
+    // Mirrors auto-restore semantic in upsertCanonicalEvent: if any child is
+    // live, the parent shouldn't be stuck CANCELLED from a previous cascade.
+    primeFreshCreate(["evt_p", "evt_c1", "evt_c2"], [
+      { id: "evt_p", status: "CANCELLED" }, // previously cascaded
+      { id: "evt_c1", status: "CONFIRMED" }, // back from the dead
+      { id: "evt_c2", status: "CANCELLED" },
+    ]);
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-06-01", seriesId: "campout-z" }),
+      buildRawEvent({ date: "2026-06-02", seriesId: "campout-z" }),
+      buildRawEvent({ date: "2026-06-03", seriesId: "campout-z" }),
+    ]);
+
+    const restoreUpdate = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { where?: { id?: string } }).where?.id === "evt_p"
+        && (args as { data?: { status?: string } }).data?.status === "CONFIRMED",
+    );
+    expect(restoreUpdate).toBeDefined();
+  });
+
+  it("skips linking for groups with only one event (umbrella-only or single-child)", async () => {
+    primeFreshCreate(["evt_alone"]);
+    // No post-link findMany should run — linkMultiDaySeries early-exits on length<2.
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-07-04", seriesId: "lonely-umbrella", seriesParent: true }),
+    ]);
+
+    // No event should have parentEventId set; no updateMany call from the linker.
+    const childLinking = vi.mocked(prisma.event.updateMany).mock.calls.find(
+      ([args]) => (args as { data?: { parentEventId?: unknown } }).data?.parentEventId !== undefined,
+    );
+    expect(childLinking).toBeUndefined();
+    // No isSeriesParent flag flip either — the raw's seriesParent flag alone
+    // doesn't promote a single-event series (UI degrades gracefully to a
+    // standalone date-range card via Event.endDate).
+    const parentFlip = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { data?: { isSeriesParent?: boolean } }).data?.isSeriesParent === true,
+    );
+    expect(parentFlip).toBeUndefined();
+  });
+
+  it("deduplicates members that resolved to the same canonical event (cross-source absorption)", async () => {
+    // Scenario: hashrego Friday raw lands first → creates evt_fri.
+    // hashrego Saturday raw lands → creates evt_sat.
+    // Hypothetical re-emission of Friday raw lands on the SAME canonical event
+    // (dedup via fingerprint OR cross-source same-day match). seriesGroups
+    // captures both entries pointing to evt_fri; linker should dedup before
+    // picking parent so the eventCount-2 guard still fires correctly.
+    primeFreshCreate(["evt_fri", "evt_sat"], [
+      { id: "evt_fri", status: "CONFIRMED" },
+      { id: "evt_sat", status: "CONFIRMED" },
+    ]);
+
+    await processRawEvents("src_1", [
+      buildRawEvent({ date: "2026-01-16", seriesId: "5boro-dup" }),
+      buildRawEvent({ date: "2026-01-17", seriesId: "5boro-dup" }),
+    ]);
+
+    // Parent = earliest (evt_fri); child (evt_sat) gets parentEventId.
+    const parentUpdate = mockEventUpdate.mock.calls.find(
+      ([args]) => (args as { where?: { id?: string } }).where?.id === "evt_fri"
+        && (args as { data?: { isSeriesParent?: boolean } }).data?.isSeriesParent === true,
+    );
+    expect(parentUpdate).toBeDefined();
   });
 });

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -3984,6 +3984,52 @@ describe("processNewRawEvent — P2002 race-window fall-through (#1286)", () => 
   });
 });
 
+/**
+ * Shape the EVENT_CACHE_SELECT contract expects post-create: every column
+ * recomputeCanonical / rememberCreatedEvent reads must be present, or the
+ * second event's ensureKennelEventCache hit on the in-memory pool crashes.
+ * Lifted to module scope (Sonar S7721) so it's not re-allocated per describe
+ * invocation; tests pull it via `primeFreshCreate`.
+ */
+function buildCanonicalEventRow(id: string): Record<string, unknown> {
+  return {
+    id,
+    kennelId: "kennel_1",
+    date: new Date("2026-01-16T12:00:00Z"),
+    dateUtc: new Date("2026-01-16T12:00:00Z"),
+    timezone: "America/New_York",
+    runNumber: null,
+    title: "Stub Trail",
+    description: null,
+    haresText: null,
+    locationName: null,
+    locationStreet: null,
+    locationCity: null,
+    locationAddress: null,
+    latitude: null,
+    longitude: null,
+    startTime: null,
+    endTime: null,
+    cost: null,
+    trailLengthText: null,
+    trailLengthMinMiles: null,
+    trailLengthMaxMiles: null,
+    difficulty: null,
+    trailType: null,
+    dogFriendly: null,
+    prelube: null,
+    sourceUrl: null,
+    trustLevel: 5,
+    isSeriesParent: false,
+    parentEventId: null,
+    endDate: null,
+    status: "CONFIRMED",
+    adminCancelledAt: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    isCanonical: true,
+  };
+}
+
 describe("linkMultiDaySeries (#1560)", () => {
   // Shared helper: prime processRawEvents to land each incoming raw as a
   // fresh canonical Event. The merge loop reads via prisma.event.findMany
@@ -3991,47 +4037,6 @@ describe("linkMultiDaySeries (#1560)", () => {
   // `where.kennelId/date`, and `linkMultiDaySeries` uses `where.id.in`.
   // We route by inspecting the where clause so post-link Once seeds aren't
   // eaten by the per-event ensureKennelEventCache call.
-  // Shape the EVENT_CACHE_SELECT contract expects post-create: every column
-  // recomputeCanonical / rememberCreatedEvent reads must be present, or the
-  // second event's ensureKennelEventCache hit on the in-memory pool crashes.
-  function buildCanonicalEventRow(id: string): Record<string, unknown> {
-    return {
-      id,
-      kennelId: "kennel_1",
-      date: new Date("2026-01-16T12:00:00Z"),
-      dateUtc: new Date("2026-01-16T12:00:00Z"),
-      timezone: "America/New_York",
-      runNumber: null,
-      title: "Stub Trail",
-      description: null,
-      haresText: null,
-      locationName: null,
-      locationStreet: null,
-      locationCity: null,
-      locationAddress: null,
-      latitude: null,
-      longitude: null,
-      startTime: null,
-      endTime: null,
-      cost: null,
-      trailLengthText: null,
-      trailLengthMinMiles: null,
-      trailLengthMaxMiles: null,
-      difficulty: null,
-      trailType: null,
-      dogFriendly: null,
-      prelube: null,
-      sourceUrl: null,
-      trustLevel: 5,
-      isSeriesParent: false,
-      parentEventId: null,
-      endDate: null,
-      status: "CONFIRMED",
-      adminCancelledAt: null,
-      createdAt: new Date("2026-01-01T00:00:00Z"),
-      isCanonical: true,
-    };
-  }
 
   function primeFreshCreate(eventIds: string[], postLinkStatuses?: Array<{ id: string; status: string }>) {
     mockEventFindMany.mockReset();
@@ -4048,16 +4053,21 @@ describe("linkMultiDaySeries (#1560)", () => {
       },
     );
     for (const id of eventIds) {
-      mockEventCreate.mockResolvedValueOnce(buildCanonicalEventRow(id) as never);
-      mockRawEventCreate.mockResolvedValueOnce({ id: `raw_${id}` } as never);
+      // The `as never` casts are required: Prisma's generated mock types
+      // demand the FULL row shape (37+ fields including JsonValue rawData),
+      // but our stubs only carry the EVENT_CACHE_SELECT-shaped subset and
+      // a synthetic raw-id. Sonar's S4325 misfires here because it doesn't
+      // see Prisma's generated overload set.
+      mockEventCreate.mockResolvedValueOnce(buildCanonicalEventRow(id) as never); // NOSONAR S4325
+      mockRawEventCreate.mockResolvedValueOnce({ id: `raw_${id}` } as never); // NOSONAR S4325
     }
     // Stub event.update to echo the row back so post-update cache patching
     // doesn't lose the EVENT_CACHE_SELECT-shaped fields recomputeCanonical needs.
     (mockEventUpdate.mockImplementation as unknown as (fn: (args?: unknown) => Promise<unknown>) => unknown)(
       async (args?: unknown) => {
         const a = args as { where?: { id?: string }; data?: Record<string, unknown> } | undefined;
-        const row = buildCanonicalEventRow((a?.where?.id) ?? "evt_unknown");
-        return { ...row, ...(a?.data ?? {}) };
+        const row = buildCanonicalEventRow(a?.where?.id ?? "evt_unknown");
+        return { ...row, ...a?.data };
       },
     );
     // Fingerprints distinct so dedup never short-circuits.

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -4030,50 +4030,55 @@ function buildCanonicalEventRow(id: string): Record<string, unknown> {
   };
 }
 
-describe("linkMultiDaySeries (#1560)", () => {
-  // Shared helper: prime processRawEvents to land each incoming raw as a
-  // fresh canonical Event. The merge loop reads via prisma.event.findMany
-  // through TWO distinct query shapes — `ensureKennelEventCache` uses
-  // `where.kennelId/date`, and `linkMultiDaySeries` uses `where.id.in`.
-  // We route by inspecting the where clause so post-link Once seeds aren't
-  // eaten by the per-event ensureKennelEventCache call.
-
-  function primeFreshCreate(eventIds: string[], postLinkStatuses?: Array<{ id: string; status: string }>) {
-    mockEventFindMany.mockReset();
-    // Loose typing on the impl — Prisma's generated client types are too
-    // strict for a router-style mock; the actual call shapes we route on
-    // are stable enough (the merge pipeline drives them).
-    (mockEventFindMany.mockImplementation as unknown as (fn: (args?: unknown) => Promise<unknown>) => unknown)(
-      async (args?: unknown) => {
-        const w = (args as { where?: { id?: { in?: string[] } } } | undefined)?.where;
-        if (w?.id && typeof w.id === "object" && Array.isArray(w.id.in) && postLinkStatuses) {
-          return postLinkStatuses;
-        }
-        return [];
-      },
-    );
-    for (const id of eventIds) {
-      // The `as never` casts are required: Prisma's generated mock types
-      // demand the FULL row shape (37+ fields including JsonValue rawData),
-      // but our stubs only carry the EVENT_CACHE_SELECT-shaped subset and
-      // a synthetic raw-id. Sonar's S4325 misfires here because it doesn't
-      // see Prisma's generated overload set.
-      mockEventCreate.mockResolvedValueOnce(buildCanonicalEventRow(id) as never); // NOSONAR S4325
-      mockRawEventCreate.mockResolvedValueOnce({ id: `raw_${id}` } as never); // NOSONAR S4325
-    }
-    // Stub event.update to echo the row back so post-update cache patching
-    // doesn't lose the EVENT_CACHE_SELECT-shaped fields recomputeCanonical needs.
-    (mockEventUpdate.mockImplementation as unknown as (fn: (args?: unknown) => Promise<unknown>) => unknown)(
-      async (args?: unknown) => {
-        const a = args as { where?: { id?: string }; data?: Record<string, unknown> } | undefined;
-        const row = buildCanonicalEventRow(a?.where?.id ?? "evt_unknown");
-        return { ...row, ...a?.data };
-      },
-    );
-    // Fingerprints distinct so dedup never short-circuits.
-    mockFingerprint.mockReset();
-    eventIds.forEach((id, i) => mockFingerprint.mockReturnValueOnce(`fp_${id}_${i}`));
+/**
+ * Prime `processRawEvents` to land each incoming raw as a fresh canonical
+ * Event. The merge loop reads via `prisma.event.findMany` through TWO
+ * distinct query shapes — `ensureKennelEventCache` uses `where.kennelId/date`,
+ * and `linkMultiDaySeries` uses `where.id.in`. We route by inspecting the
+ * where clause so post-link `Once` seeds aren't eaten by the per-event
+ * ensureKennelEventCache call.
+ *
+ * Lifted to module scope (Sonar S7721) so the closure isn't re-allocated
+ * per `describe` invocation; reads from the module-level mock handles.
+ */
+function primeFreshCreate(eventIds: string[], postLinkStatuses?: Array<{ id: string; status: string }>) {
+  mockEventFindMany.mockReset();
+  // Loose typing on the impl — Prisma's generated client types are too
+  // strict for a router-style mock; the actual call shapes we route on
+  // are stable enough (the merge pipeline drives them).
+  (mockEventFindMany.mockImplementation as unknown as (fn: (args?: unknown) => Promise<unknown>) => unknown)(
+    async (args?: unknown) => {
+      const w = (args as { where?: { id?: { in?: string[] } } } | undefined)?.where;
+      if (w?.id && typeof w.id === "object" && Array.isArray(w.id.in) && postLinkStatuses) {
+        return postLinkStatuses;
+      }
+      return [];
+    },
+  );
+  for (const id of eventIds) {
+    // The `as never` casts are required: Prisma's generated mock types
+    // demand the FULL row shape (37+ fields including JsonValue rawData),
+    // but our stubs only carry the EVENT_CACHE_SELECT-shaped subset and
+    // a synthetic raw-id. Sonar's S4325 misfires here because it doesn't
+    // see Prisma's generated overload set.
+    mockEventCreate.mockResolvedValueOnce(buildCanonicalEventRow(id) as never); // NOSONAR S4325
+    mockRawEventCreate.mockResolvedValueOnce({ id: `raw_${id}` } as never); // NOSONAR S4325
   }
+  // Stub event.update to echo the row back so post-update cache patching
+  // doesn't lose the EVENT_CACHE_SELECT-shaped fields recomputeCanonical needs.
+  (mockEventUpdate.mockImplementation as unknown as (fn: (args?: unknown) => Promise<unknown>) => unknown)(
+    async (args?: unknown) => {
+      const a = args as { where?: { id?: string }; data?: Record<string, unknown> } | undefined;
+      const row = buildCanonicalEventRow(a?.where?.id ?? "evt_unknown");
+      return { ...row, ...a?.data };
+    },
+  );
+  // Fingerprints distinct so dedup never short-circuits.
+  mockFingerprint.mockReset();
+  eventIds.forEach((id, i) => mockFingerprint.mockReturnValueOnce(`fp_${id}_${i}`));
+}
+
+describe("linkMultiDaySeries (#1560)", () => {
 
   it("picks earliest event as parent when no raw is marked seriesParent", async () => {
     primeFreshCreate(["evt_fri", "evt_sat", "evt_sun"], [

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -4092,6 +4092,10 @@ describe("linkMultiDaySeries (#1560)", () => {
     expect((childUpdateMany![0] as { where: { id: { in: string[] } } }).where.id.in).toEqual(
       expect.arrayContaining(["evt_sat", "evt_sun"]),
     );
+    // Gemini review #2 regression guard — child updateMany must clear
+    // `isSeriesParent` so events demoted from parent in a prior scrape lose
+    // the UI's tent-glyph + "+ N trails" badge treatment.
+    expect((childUpdateMany![0] as { data: { isSeriesParent?: boolean } }).data.isSeriesParent).toBe(false);
   });
 
   it("honors explicit seriesParent:true even when it's not the earliest by date", async () => {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -336,6 +336,7 @@ const EVENT_CACHE_SELECT = {
   trustLevel: true,
   isSeriesParent: true,
   parentEventId: true,
+  endDate: true,
   status: true,
   adminCancelledAt: true,
   createdAt: true,
@@ -1397,6 +1398,13 @@ async function upsertCanonicalEvent(
           ...(event.prelube === undefined
             ? {}
             : { prelube: event.prelube ?? null }),
+          // endDate (#1560): multi-day series parents + standalone date-range
+          // events. Tri-state: undefined preserve, string overwrite, "" / null
+          // clear (single-day). String parses through parseUtcNoonDate so it
+          // lands at UTC noon like `date` (DST-safe per CLAUDE.md Appendix F.4).
+          ...(event.endDate === undefined
+            ? {}
+            : { endDate: event.endDate ? parseUtcNoonDate(event.endDate) : null }),
           // Cross-window fuzzy match (#990) physically moves the row from
           // its old `date` bucket to the incoming source's date, so display
           // paths that compose `date + startTime + timezone` render the
@@ -1510,6 +1518,11 @@ async function upsertCanonicalEvent(
       if (existingEvent.prelube == null && event.prelube != null) {
         enrichData.prelube = event.prelube;
       }
+      // endDate (#1560) — lower-trust source can promote a single-day canonical
+      // to multi-day when the higher-trust source omitted the range entirely.
+      if (existingEvent.endDate == null && event.endDate) {
+        enrichData.endDate = parseUtcNoonDate(event.endDate);
+      }
       if (Object.keys(enrichData).length > 0) {
         const enriched = await prisma.event.update({
           where: { id: existingEvent.id },
@@ -1552,6 +1565,9 @@ async function upsertCanonicalEvent(
     const newEvent = await createEventWithKennel(prisma, {
       kennelId,
       date: eventDate,
+      // endDate (#1560) — set on series parents + standalone date-range events.
+      // Adapter emits "YYYY-MM-DD"; parseUtcNoonDate normalizes to UTC noon.
+      endDate: event.endDate ? parseUtcNoonDate(event.endDate) : null,
       dateUtc,
       timezone,
       runNumber: event.runNumber,
@@ -1655,30 +1671,104 @@ async function upsertCanonicalEvent(
 }
 
 /**
+ * One slot per RawEvent that emitted a `seriesId`, captured at the point of
+ * canonical-Event resolution in `processRawEvents`. `eventId` is the target
+ * canonical Event the raw resolved into. `isExplicitParent` is the
+ * `RawEventData.seriesParent` flag — `true` on the SFH3-style umbrella raw
+ * that adapters explicitly designate as the series parent (#1560).
+ */
+type SeriesMember = { eventId: string; isExplicitParent: boolean };
+
+/**
  * Link multi-day series via parentEventId.
- * The earliest event in each series becomes the parent.
+ *
+ * Parent selection rules (in order, #1560):
+ *   1. If any raw in the group set `seriesParent: true` (SFH3 umbrella),
+ *      that raw's canonical Event becomes the parent — regardless of date
+ *      ordering. The umbrella's rich description + endDate need to live
+ *      on the parent, not a child.
+ *   2. Otherwise, earliest by date wins (Hash Rego fallback — no umbrella
+ *      concept, just per-day rows tied by event slug).
+ *
+ * After linking, cascade-cancel the parent if EVERY non-cancelled child is
+ * CANCELLED — an empty weekend is not a real weekend. Idempotent.
  */
 async function linkMultiDaySeries(
-  seriesGroups: Map<string, string[]>,
+  seriesGroups: Map<string, SeriesMember[]>,
 ): Promise<void> {
-  for (const [, eventIds] of seriesGroups) {
-    if (eventIds.length < 2) continue;
+  for (const [, members] of seriesGroups) {
+    if (members.length < 2) continue;
     try {
-      // Sort by date to pick the earliest as parent
+      // Deduplicate by eventId — two raws can share a seriesId and resolve to
+      // the same canonical Event (re-scrape, cross-source absorption). Keep
+      // the most-permissive explicit-parent signal (any true → true).
+      const byEventId = new Map<string, SeriesMember>();
+      for (const m of members) {
+        const prior = byEventId.get(m.eventId);
+        byEventId.set(m.eventId, {
+          eventId: m.eventId,
+          isExplicitParent: (prior?.isExplicitParent ?? false) || m.isExplicitParent,
+        });
+      }
+      const unique = [...byEventId.values()];
+      if (unique.length < 2) continue;
+
       const seriesEvents = await prisma.event.findMany({
-        where: { id: { in: eventIds } },
+        where: { id: { in: unique.map(m => m.eventId) } },
         orderBy: { date: "asc" },
-        select: { id: true },
+        // adminCancelledAt selected so the restore branch below honors the
+        // admin lock (Codex P0 — without this, a series scrape silently
+        // resurrects a parent an admin explicitly cancelled).
+        select: { id: true, status: true, adminCancelledAt: true },
       });
-      const parentId = seriesEvents[0].id;
+      if (seriesEvents.length < 2) continue;
+
+      // Pick parent: explicit-parent flag wins; among multiple explicits the
+      // earliest-by-date wins (deterministic — see Codex P2 #1). Fallback is
+      // earliest-by-date over all candidates.
+      const explicitIds = new Set(unique.filter(m => m.isExplicitParent).map(m => m.eventId));
+      const explicitParentRow = seriesEvents.find(e => explicitIds.has(e.id));
+      const parentRow = explicitParentRow ?? seriesEvents[0];
+      const parentId = parentRow.id;
+
       await prisma.event.update({
         where: { id: parentId },
-        data: { isSeriesParent: true },
+        data: { isSeriesParent: true, parentEventId: null },
       });
-      for (const child of seriesEvents.slice(1)) {
-        await prisma.event.update({
-          where: { id: child.id },
+      const childIds = seriesEvents.filter(e => e.id !== parentId).map(e => e.id);
+      if (childIds.length > 0) {
+        await prisma.event.updateMany({
+          where: { id: { in: childIds } },
           data: { parentEventId: parentId },
+        });
+      }
+
+      // Cancellation cascade — re-query post-link so we see fresh child status
+      // (any restore that ran during this batch is reflected).
+      //
+      // Admin-locked parents (`adminCancelledAt != null`) are exempt from
+      // BOTH branches: an admin explicitly cancelled the event and the lock
+      // survives source re-emission (mirrors the auto-restore guard in
+      // upsertCanonicalEvent — Codex P0 review).
+      const isAdminLocked = parentRow.adminCancelledAt != null;
+      const childStatuses = seriesEvents.filter(e => e.id !== parentId).map(e => e.status);
+      const allChildrenCancelled =
+        childStatuses.length > 0 && childStatuses.every(s => s === "CANCELLED");
+      const parentStatus = parentRow.status;
+      if (!isAdminLocked && allChildrenCancelled && parentStatus === "CONFIRMED") {
+        // Only cascade live → CANCELLED; leave TENTATIVE alone (a tentative
+        // parent shouldn't be auto-cancelled by a sourced child cancellation
+        // when an admin hasn't yet decided).
+        await prisma.event.update({
+          where: { id: parentId },
+          data: { status: "CANCELLED" },
+        });
+      } else if (!isAdminLocked && !allChildrenCancelled && parentStatus === "CANCELLED") {
+        // At least one child is live → parent should not be CANCELLED.
+        // Mirrors the auto-restore semantic used in upsertCanonicalEvent.
+        await prisma.event.update({
+          where: { id: parentId },
+          data: { status: "CONFIRMED" },
         });
       }
     } catch (err) {
@@ -1838,6 +1928,7 @@ type CanonicalCandidate = {
   trailType: string | null;
   dogFriendly: boolean | null;
   prelube: string | null;
+  endDate: Date | null;
 };
 
 /**
@@ -1870,6 +1961,9 @@ export function completenessScore(e: Omit<CanonicalCandidate, "id" | "trustLevel
   // Numeric/boolean fields where 0 / false is still "populated".
   if (e.runNumber != null) score++;
   if (e.dogFriendly != null) score++;
+  // endDate (#1560) — a row that knows it's a multi-day series carries more
+  // display value than a same-trust sibling that doesn't.
+  if (e.endDate != null) score++;
   return score;
 }
 
@@ -2229,7 +2323,7 @@ export async function processRawEvents(
     result,
   };
 
-  const seriesGroups = new Map<string, string[]>();
+  const seriesGroups = new Map<string, SeriesMember[]>();
 
   for (const event of events) {
     // Events that failed the fingerprint precompute were already recorded as
@@ -2241,6 +2335,14 @@ export async function processRawEvents(
       const dupResult = await handleDuplicateFingerprint(event, fingerprint, ctx);
       if (dupResult !== false) {
         if (dupResult) queueEventLinks(dupResult, event.externalLinks, ctx);
+        // Honor seriesParent/seriesId even on duplicate-fingerprint replays so
+        // a re-scrape of the same series still gets relinked (idempotent — the
+        // explicit-parent merge is "any true → true").
+        if (dupResult && event.seriesId) {
+          const group = seriesGroups.get(event.seriesId) ?? [];
+          group.push({ eventId: dupResult, isExplicitParent: event.seriesParent === true });
+          seriesGroups.set(event.seriesId, group);
+        }
         continue;
       }
 
@@ -2248,7 +2350,7 @@ export async function processRawEvents(
 
       if (targetEventId && event.seriesId) {
         const group = seriesGroups.get(event.seriesId) ?? [];
-        group.push(targetEventId);
+        group.push({ eventId: targetEventId, isExplicitParent: event.seriesParent === true });
         seriesGroups.set(event.seriesId, group);
       }
     } catch (err) {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1679,6 +1679,135 @@ async function upsertCanonicalEvent(
  */
 type SeriesMember = { eventId: string; isExplicitParent: boolean };
 
+/** Row shape returned from the series-link prefetch. */
+type SeriesLinkRow = {
+  id: string;
+  status: EventStatus;
+  adminCancelledAt: Date | null;
+};
+
+/**
+ * Deduplicate `SeriesMember` entries by `eventId`. Two raws can resolve to
+ * the same canonical Event (cross-source absorption); when that happens
+ * keep the most-permissive explicit-parent signal — any `true` wins.
+ */
+function dedupeSeriesMembers(members: SeriesMember[]): SeriesMember[] {
+  const byEventId = new Map<string, SeriesMember>();
+  for (const m of members) {
+    const prior = byEventId.get(m.eventId);
+    byEventId.set(m.eventId, {
+      eventId: m.eventId,
+      isExplicitParent: (prior?.isExplicitParent ?? false) || m.isExplicitParent,
+    });
+  }
+  return [...byEventId.values()];
+}
+
+/**
+ * Pick the parent row for a series. Explicit-parent flag wins; among
+ * multiple explicits the earliest (by the input sort order) wins. With no
+ * explicit flag, fall back to `seriesEvents[0]` — the caller queries with
+ * `orderBy: [{ date: "asc" }, { id: "asc" }]` for a deterministic
+ * tiebreaker (Gemini review #1).
+ */
+function pickSeriesParentRow(
+  unique: SeriesMember[],
+  seriesEvents: SeriesLinkRow[],
+): SeriesLinkRow {
+  const explicitIds = new Set(unique.filter(m => m.isExplicitParent).map(m => m.eventId));
+  return seriesEvents.find(e => explicitIds.has(e.id)) ?? seriesEvents[0];
+}
+
+/**
+ * Write parent/child relationships in two batched updates. The child
+ * updateMany clears `isSeriesParent` on every demoted row — an Event that
+ * was a series parent in a prior scrape and is now being linked as a
+ * child must lose the UI's tent-glyph / "+ N trails" treatment (Gemini
+ * review #2).
+ */
+async function writeSeriesLinks(
+  parentId: string,
+  childIds: string[],
+): Promise<void> {
+  await prisma.event.update({
+    where: { id: parentId },
+    data: { isSeriesParent: true, parentEventId: null },
+  });
+  if (childIds.length > 0) {
+    await prisma.event.updateMany({
+      where: { id: { in: childIds } },
+      data: { parentEventId: parentId, isSeriesParent: false },
+    });
+  }
+}
+
+/**
+ * Cancellation cascade for a series parent. Idempotent. Admin-locked
+ * parents (`adminCancelledAt != null`) are exempt from BOTH branches: an
+ * admin explicitly cancelled the event and the lock survives source
+ * re-emission (mirrors the auto-restore guard in upsertCanonicalEvent —
+ * Codex P0 review).
+ *
+ * The `seriesEvents` argument was fetched BEFORE the link writes ran but
+ * those writes only touched `isSeriesParent` / `parentEventId`. The
+ * `status` field is still accurate (claude[bot] review).
+ */
+async function cascadeSeriesCancellation(
+  parentRow: SeriesLinkRow,
+  seriesEvents: SeriesLinkRow[],
+): Promise<void> {
+  if (parentRow.adminCancelledAt != null) return;
+  const childStatuses = seriesEvents.filter(e => e.id !== parentRow.id).map(e => e.status);
+  const allChildrenCancelled =
+    childStatuses.length > 0 && childStatuses.every(s => s === "CANCELLED");
+  if (allChildrenCancelled && parentRow.status === "CONFIRMED") {
+    // Only cascade live → CANCELLED; leave TENTATIVE alone (a tentative
+    // parent shouldn't be auto-cancelled by a sourced child cancellation
+    // when an admin hasn't yet decided).
+    await prisma.event.update({
+      where: { id: parentRow.id },
+      data: { status: "CANCELLED" },
+    });
+  } else if (!allChildrenCancelled && parentRow.status === "CANCELLED") {
+    // At least one child is live → parent should not be CANCELLED.
+    // Mirrors the auto-restore semantic used in upsertCanonicalEvent.
+    await prisma.event.update({
+      where: { id: parentRow.id },
+      data: { status: "CONFIRMED" },
+    });
+  }
+}
+
+/**
+ * Process one series group end-to-end: dedup members, fetch the canonical
+ * rows, pick a parent, write the parent/child links, then run the
+ * cancellation cascade. Helpers above keep `linkMultiDaySeries` itself
+ * under Sonar's cognitive-complexity threshold.
+ */
+async function linkOneSeries(members: SeriesMember[]): Promise<void> {
+  if (members.length < 2) return;
+  const unique = dedupeSeriesMembers(members);
+  if (unique.length < 2) return;
+
+  const seriesEvents = await prisma.event.findMany({
+    where: { id: { in: unique.map(m => m.eventId) } },
+    // Compound order: dates can tie when an umbrella + a same-day child
+    // both fall on the same day (SFH3 Bay 2 Blackout). `id` is
+    // `@id @default(cuid())` which is monotonic, so it's a stable
+    // secondary key that prevents row-order luck from picking different
+    // parents across scrapes (Gemini review #1).
+    orderBy: [{ date: "asc" }, { id: "asc" }],
+    // adminCancelledAt selected so the cascade honors the admin lock.
+    select: { id: true, status: true, adminCancelledAt: true },
+  });
+  if (seriesEvents.length < 2) return;
+
+  const parentRow = pickSeriesParentRow(unique, seriesEvents);
+  const childIds = seriesEvents.filter(e => e.id !== parentRow.id).map(e => e.id);
+  await writeSeriesLinks(parentRow.id, childIds);
+  await cascadeSeriesCancellation(parentRow, seriesEvents);
+}
+
 /**
  * Link multi-day series via parentEventId.
  *
@@ -1697,95 +1826,8 @@ async function linkMultiDaySeries(
   seriesGroups: Map<string, SeriesMember[]>,
 ): Promise<void> {
   for (const [, members] of seriesGroups) {
-    if (members.length < 2) continue;
     try {
-      // Deduplicate by eventId — two raws can share a seriesId and resolve to
-      // the same canonical Event (re-scrape, cross-source absorption). Keep
-      // the most-permissive explicit-parent signal (any true → true).
-      const byEventId = new Map<string, SeriesMember>();
-      for (const m of members) {
-        const prior = byEventId.get(m.eventId);
-        byEventId.set(m.eventId, {
-          eventId: m.eventId,
-          isExplicitParent: (prior?.isExplicitParent ?? false) || m.isExplicitParent,
-        });
-      }
-      const unique = [...byEventId.values()];
-      if (unique.length < 2) continue;
-
-      const seriesEvents = await prisma.event.findMany({
-        where: { id: { in: unique.map(m => m.eventId) } },
-        // Compound order: dates can tie when an umbrella + a same-day child
-        // both fall on the same day (SFH3 Bay 2 Blackout has the umbrella
-        // and 2 trails all at 2026-05-14). `id` is `@id @default(cuid())`
-        // which is monotonic across rows, so it's a stable secondary key
-        // that prevents Prisma/Postgres row-order luck from picking
-        // different parents across scrapes (Gemini review #1).
-        orderBy: [{ date: "asc" }, { id: "asc" }],
-        // adminCancelledAt selected so the restore branch below honors the
-        // admin lock (Codex P0 — without this, a series scrape silently
-        // resurrects a parent an admin explicitly cancelled).
-        select: { id: true, status: true, adminCancelledAt: true },
-      });
-      if (seriesEvents.length < 2) continue;
-
-      // Pick parent: explicit-parent flag wins; among multiple explicits the
-      // earliest-by-date wins (deterministic — see Codex P2 #1). Fallback is
-      // earliest-by-date over all candidates.
-      const explicitIds = new Set(unique.filter(m => m.isExplicitParent).map(m => m.eventId));
-      const explicitParentRow = seriesEvents.find(e => explicitIds.has(e.id));
-      const parentRow = explicitParentRow ?? seriesEvents[0];
-      const parentId = parentRow.id;
-
-      await prisma.event.update({
-        where: { id: parentId },
-        data: { isSeriesParent: true, parentEventId: null },
-      });
-      const childIds = seriesEvents.filter(e => e.id !== parentId).map(e => e.id);
-      if (childIds.length > 0) {
-        // `isSeriesParent: false` is mandatory — an Event that was a series
-        // parent in a previous scrape and is now being demoted to child must
-        // clear the flag, or the UI (EventCard + EventDetailPanel both gate
-        // on `isSeriesParent === true`) will keep showing the tent glyph,
-        // `+ N trails` badge, and expand button on what is now a child row
-        // (Gemini review #2).
-        await prisma.event.updateMany({
-          where: { id: { in: childIds } },
-          data: { parentEventId: parentId, isSeriesParent: false },
-        });
-      }
-
-      // Cancellation cascade — `seriesEvents` was fetched BEFORE the writes
-      // above, but those writes only touched `isSeriesParent` and
-      // `parentEventId`. The `status` field is still accurate for the
-      // cascade decision (claude[bot] review — earlier comment misleadingly
-      // claimed a re-query).
-      //
-      // Admin-locked parents (`adminCancelledAt != null`) are exempt from
-      // BOTH branches: an admin explicitly cancelled the event and the lock
-      // survives source re-emission (mirrors the auto-restore guard in
-      // upsertCanonicalEvent — Codex P0 review).
-      const isAdminLocked = parentRow.adminCancelledAt != null;
-      const childStatuses = seriesEvents.filter(e => e.id !== parentId).map(e => e.status);
-      const allChildrenCancelled =
-        childStatuses.length > 0 && childStatuses.every(s => s === "CANCELLED");
-      const parentStatus = parentRow.status;
-      if (!isAdminLocked && allChildrenCancelled && parentStatus === "CONFIRMED") {
-        // Only cascade live → CANCELLED; leave TENTATIVE alone (a tentative
-        // parent shouldn't be auto-cancelled by a sourced child cancellation
-        // when an admin hasn't yet decided).
-        await prisma.event.update({
-          where: { id: parentId },
-          data: { status: "CANCELLED" },
-        });
-      } else if (!isAdminLocked && !allChildrenCancelled && parentStatus === "CANCELLED") {
-        // At least one child is live → parent should not be CANCELLED.
-        // Mirrors the auto-restore semantic used in upsertCanonicalEvent.
-        await prisma.event.update({
-          where: { id: parentId },
-          data: { status: "CONFIRMED" },
-        });
-      }
+      await linkOneSeries(members);
     } catch (err) {
       console.error(`Series linking error: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1715,7 +1715,13 @@ async function linkMultiDaySeries(
 
       const seriesEvents = await prisma.event.findMany({
         where: { id: { in: unique.map(m => m.eventId) } },
-        orderBy: { date: "asc" },
+        // Compound order: dates can tie when an umbrella + a same-day child
+        // both fall on the same day (SFH3 Bay 2 Blackout has the umbrella
+        // and 2 trails all at 2026-05-14). `id` is `@id @default(cuid())`
+        // which is monotonic across rows, so it's a stable secondary key
+        // that prevents Prisma/Postgres row-order luck from picking
+        // different parents across scrapes (Gemini review #1).
+        orderBy: [{ date: "asc" }, { id: "asc" }],
         // adminCancelledAt selected so the restore branch below honors the
         // admin lock (Codex P0 — without this, a series scrape silently
         // resurrects a parent an admin explicitly cancelled).
@@ -1737,14 +1743,23 @@ async function linkMultiDaySeries(
       });
       const childIds = seriesEvents.filter(e => e.id !== parentId).map(e => e.id);
       if (childIds.length > 0) {
+        // `isSeriesParent: false` is mandatory — an Event that was a series
+        // parent in a previous scrape and is now being demoted to child must
+        // clear the flag, or the UI (EventCard + EventDetailPanel both gate
+        // on `isSeriesParent === true`) will keep showing the tent glyph,
+        // `+ N trails` badge, and expand button on what is now a child row
+        // (Gemini review #2).
         await prisma.event.updateMany({
           where: { id: { in: childIds } },
-          data: { parentEventId: parentId },
+          data: { parentEventId: parentId, isSeriesParent: false },
         });
       }
 
-      // Cancellation cascade — re-query post-link so we see fresh child status
-      // (any restore that ran during this batch is reflected).
+      // Cancellation cascade — `seriesEvents` was fetched BEFORE the writes
+      // above, but those writes only touched `isSeriesParent` and
+      // `parentEventId`. The `status` field is still accurate for the
+      // cascade decision (claude[bot] review — earlier comment misleadingly
+      // claimed a re-query).
       //
       // Admin-locked parents (`adminCancelledAt != null`) are exempt from
       // BOTH branches: an admin explicitly cancelled the event and the lock


### PR DESCRIPTION
## Summary

Foundation for surfacing multi-day weekend events (SFH3 Bay 2 Blackout, NYC 5-Boro Pub Crawl, MadisonH3 Token Run Campout) as one parent card with expandable child trails on the hareline. PR A of a stacked 3-PR series — issue #1560 (intentionally NOT auto-closed; PR C closes).

- **Schema**: `Event.endDate DateTime?` (inclusive last day) on series parents AND standalone date-range events.
- **Merge pipeline**: `linkMultiDaySeries` honors explicit `seriesParent` flag from adapters, falls back to earliest-by-date for Hash Rego. Cancellation cascade (all children CANCELLED → parent CANCELLED; any child live → parent restored), with `Event.adminCancelledAt` admin-lock exemption per Codex P0 review.
- **SFH3 adapter**: `markSFH3SeriesMembership` replaces the `suppressSFH3UmbrellaDuplicates` hack from #1531. Umbrellas (`/events/N`) become series parents — their rich description (weekend theme, registration link, lodging info) lands on the canonical parent instead of being dropped on the floor.
- **UI**: `Tent` glyph + date-range chip + `+ N trails` badge on parent cards; expandable timeline of children with region-color rail; back-link breadcrumb in child detail panels. Hareline + kennel page queries inline children via Prisma `childEvents` select.

## What this PR does NOT do

- **Auto-close #1560** — deferred to PR C. Refs #1560 only.
- **Hash Rego `**DAY M/D —**` parser** — PR B will add it (NYC 5-Boro Day 2/3 currently dropped silently).
- **Hash Rego venue-weekend heuristic** — PR C will add it (MadisonH3 Token Run has no `endDate` today).
- **Cross-source dedup of series umbrellas** — the existing same-day matcher already handles cross-source dedup of series *children* (hashnyc Friday + hashrego Friday merge correctly because `sameDayByKennel` includes children). Cross-source dedup of *parents* (two sources both publishing the umbrella) stays out of scope.

## Codex adversarial review — addressed

The diff went through an adversarial review pass. All 5 findings addressed before merge:

| # | Severity | Fix |
|---|---|---|
| 1 | **P0** | `linkMultiDaySeries` now selects `adminCancelledAt` and gates BOTH cascade branches on `!isAdminLocked`; forward cascade requires `parentStatus === "CONFIRMED"` (preserves TENTATIVE). 2 new tests lock the behavior in. |
| 2 | **P1** | `hasDateRange` was comparing `endDate` (ISO) to `event.date.split("T")[0]` (YYYY-MM-DD) — never matched, so the same-day suppression guard was unreachable. Fixed in both EventCard + EventDetailPanel. |
| 3 | **P1** | Fingerprint `endDate ?? ""` token would have re-fingerprinted every existing single-day RawEvent. Now gated on truthiness — only adapters that newly emit `endDate` (SFH3 umbrellas) trigger a re-merge of their multi-day rows. |
| 4 | **P2** | Multi-explicit-parent: deterministic earliest-by-date tiebreaker among `seriesParent: true` raws. |
| 5 | **P2** | SFH3 overlapping umbrellas: deterministic tiebreaker (earliest date, then lowest `/events/N` id) so trail attachment does not flap on iCal VEVENT-order changes. |

## Live verification

Ran the modified adapter against the production SFH3 iCal feed (`https://www.sfh3.com/calendar.ics?kennels=all`):

- **127 events** fetched
- **18 events** tagged with `seriesId` across **7 distinct series groups**
- Multi-day campouts (BAWC5 Jun 19–21, Interhash May 8–10, SLuTty Ski Mar 27–29) all correctly populate `endDate` from DTSTART/DTEND span
- Bay 2 Blackout 2026 detected as a series with 2 same-day children — note: SFH3's feed publishes the umbrella with DTEND=May 15 (Thursday-only) even though the description describes May 14–17. The adapter does the right thing with the data it's given; upstream feed bug is a separate ticket.

## Browser verify limitation

The preview MCP iframe was stuck on a placeholder during this run (didn't navigate to `localhost:3000`). SSR HTML payload confirmed correct (`childEvents` array, `isSeriesParent`, `endDate` all serialized via curl + grep). Visual confirmation of the rendered parent card + expand button + child timeline pending post-merge re-scrape on Vercel preview.

## Post-merge runbook

1. Vercel deploy runs `prisma migrate deploy` → schema `endDate` column lands.
2. Trigger SFH3 + other scraped sources manually via admin UI.
3. Run `tsx scripts/cleanup-orphan-events-after-series.ts` (dry-run first, then `--apply`) to drop any canonical Events orphaned by the fingerprint-token gating.
4. Spot-check on `/kennels/sfh3` that Bay 2 Blackout 2026 and the other 6 series groups render as parent cards.

## Test plan

- [x] `npx tsc --noEmit` — clean (pre-existing suncalc/deck.gl errors fixed by `npm install`)
- [x] `npm run lint` — 0 errors, 21 pre-existing warnings in unrelated files
- [x] `npm test` — 7077 tests pass / 261 files
- [x] Live-verified SFH3 umbrella detection against production feed
- [x] Local DB schema migration applied + verified via `\d "Event"`
- [ ] Post-merge: trigger re-scrape + run cleanup script + visually verify on Vercel preview

Refs #1560. (Intentionally **not** using `Closes #1560` — that auto-close keyword is reserved for PR C.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)