### PR TITLE
feat(backfill): historical scripts for LIL + LBH-PHX (#1603 close, #1595 partial)

### DIFF
--- a/scripts/backfill-lbh-phx-history.test.ts
+++ b/scripts/backfill-lbh-phx-history.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCalendarPage,
+  parseDetailPage,
+  pickCanonicalSighting,
+} from "./backfill-lbh-phx-history";
+
+const CAL_HTML = `<html><body><table>
+  <tr>
+    <td><a href="https://www.phoenixhhh.org/?event=lbh-628-reverse-austrailian-jort-day" title="LBH #628: Reverse AusTRAILian Jort Day!">26</a></td>
+    <td><a href="https://www.phoenixhhh.org/?event=lbh-629-pulaski-day" title="LBH #629: Pulaski Day!">4</a></td>
+    <td><a href="https://www.phoenixhhh.org/?event=lbh-630-reach-into-my-magic-sack" title="LBH #630: Reach into My Magic Sack">11</a></td>
+    <td><a href="https://www.phoenixhhh.org/?event=lbh-628-reverse-austrailian-jort-day" title="LBH #628: Reverse AusTRAILian Jort Day!">More Info</a></td>
+    <td><a href="https://www.phoenixhhh.org/?event=hump-d-hash-5-6-taco-bell-cantina" title="Hump D Hash – 5/6 – Taco Bell Cantina">6</a></td>
+    <td><a href="https://www.phoenixhhh.org/?event=lbh-special-event" title="Lost Boobs Special">15</a></td>
+  </tr>
+</table></body></html>`;
+
+const DETAIL_HTML = `<html><body>
+<article>
+<div class="entry-content">
+  <p>Map Unavailable Date/Time Date(s) - Monday - 05/25/20266:30 pm - 9:30 pm Location Backyards Categories No Categories</p>
+  <p>Join us for the 745th running of the Lost Boobs Hash House Harriers!!!</p>
+  <p>Hare(s): Sir Public Display of Erection-ski</p>
+  <p>Who: People that are at least 21 years old (no exceptions).</p>
+  <p>What: A 3ish mile (true trail) Hash. Walker/runner friendly.A to A.</p>
+  <p>Where: Backyards. 9261 East Via de Ventura, Scottsdale, AZ 85258</p>
+  <p>Why: Monday is a hashing day.</p>
+  <p>When: Monday, 5/25/2026 Meet at 6pmHares away at 6:40 PM.Chalk talk at 6:45 PM.Walkers away around 7pm.</p>
+  <p>Hash Cash: $5 cash unless you're a virgin. Please arrive on time so that you can check in.</p>
+  <p>Bring: A whistle, head(!)lamp, trail chalk, a vessel, low expectations.</p>
+</div>
+</article>
+</body></html>`;
+
+describe("parseCalendarPage", () => {
+  it("extracts LBH anchors with runNumber + day + title + slug", () => {
+    const sightings = parseCalendarPage(CAL_HTML, 2024, 3);
+    expect(sightings).toHaveLength(3);
+    expect(sightings.map((s) => s.runNumber).sort((a, b) => a - b)).toEqual([628, 629, 630]);
+    const s628 = sightings.find((s) => s.runNumber === 628)!;
+    expect(s628.day).toBe(26);
+    expect(s628.yr).toBe(2024);
+    expect(s628.mo).toBe(3);
+    expect(s628.slug).toBe("lbh-628-reverse-austrailian-jort-day");
+  });
+
+  it("ignores 'More Info' duplicate anchors (text isn't a day number)", () => {
+    const sightings = parseCalendarPage(CAL_HTML, 2024, 3);
+    // The "More Info" anchor with the same lbh-628 slug should not produce
+    // a second sighting for the same slug.
+    const slug628 = sightings.filter((s) => s.slug === "lbh-628-reverse-austrailian-jort-day");
+    expect(slug628).toHaveLength(1);
+  });
+
+  it("ignores non-LBH anchors (Hump D Hash) and LBH anchors without a #N title", () => {
+    const sightings = parseCalendarPage(CAL_HTML, 2024, 3);
+    const slugs = sightings.map((s) => s.slug);
+    expect(slugs).not.toContain("hump-d-hash-5-6-taco-bell-cantina");
+    expect(slugs).not.toContain("lbh-special-event");
+  });
+
+  it("strips the LBH #N prefix from the title field", () => {
+    const sightings = parseCalendarPage(CAL_HTML, 2024, 3);
+    const s629 = sightings.find((s) => s.runNumber === 629);
+    expect(s629?.title).toBe("Pulaski Day!");
+  });
+});
+
+describe("pickCanonicalSighting", () => {
+  it("returns the single sighting when only one exists", () => {
+    const result = pickCanonicalSighting([
+      { slug: "x", runNumber: 1, title: "x", day: 15, yr: 2024, mo: 3 },
+    ]);
+    expect(result).toEqual({ slug: "x", runNumber: 1, title: "x", day: 15, yr: 2024, mo: 3 });
+  });
+
+  it("prefers a middle-of-month sighting (day 8-21)", () => {
+    const result = pickCanonicalSighting([
+      { slug: "x", runNumber: 1, title: "x", day: 11, yr: 2024, mo: 3 },
+      { slug: "x", runNumber: 1, title: "x", day: 11, yr: 2024, mo: 4 },
+    ]);
+    expect(result.mo).toBe(3);
+  });
+
+  it("prefers the LATER month when day <= 7 (next-month-leading spillover)", () => {
+    const result = pickCanonicalSighting([
+      { slug: "x", runNumber: 1, title: "x", day: 1, yr: 2024, mo: 3 },
+      { slug: "x", runNumber: 1, title: "x", day: 1, yr: 2024, mo: 4 },
+    ]);
+    expect(result.mo).toBe(4);
+  });
+
+  it("prefers the EARLIER month when day >= 22 (previous-month-trailing spillover)", () => {
+    const result = pickCanonicalSighting([
+      { slug: "x", runNumber: 1, title: "x", day: 26, yr: 2024, mo: 2 },
+      { slug: "x", runNumber: 1, title: "x", day: 26, yr: 2024, mo: 3 },
+    ]);
+    expect(result.mo).toBe(2);
+  });
+});
+
+describe("parseDetailPage", () => {
+  it("extracts startTime, hares, location, cost from a representative LBH detail page", () => {
+    const result = parseDetailPage(DETAIL_HTML);
+    expect(result.startTime).toBe("18:30");
+    expect(result.hares).toBe("Sir Public Display of Erection-ski");
+    expect(result.location).toBe("Backyards. 9261 East Via de Ventura, Scottsdale, AZ 85258");
+    expect(result.cost).toBe("$5 cash unless you're a virgin");
+  });
+
+  it("returns undefined for fields when regexes miss (preserve-existing semantics)", () => {
+    const result = parseDetailPage("<html><body><div class='entry-content'>No structured fields here.</div></body></html>");
+    expect(result.startTime).toBeUndefined();
+    expect(result.hares).toBeUndefined();
+    expect(result.location).toBeUndefined();
+    expect(result.cost).toBeUndefined();
+  });
+});

--- a/scripts/backfill-lbh-phx-history.ts
+++ b/scripts/backfill-lbh-phx-history.ts
@@ -42,7 +42,7 @@
 import "dotenv/config";
 import * as cheerio from "cheerio";
 import { safeFetch } from "@/adapters/safe-fetch";
-import { parse12HourTime } from "@/adapters/utils";
+import { decodeEntities, parse12HourTime } from "@/adapters/utils";
 import type { RawEventData } from "@/adapters/types";
 import { runBackfillScript } from "./lib/backfill-runner";
 
@@ -62,18 +62,6 @@ const DETAIL_CONCURRENCY = 5;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/** Decode HTML entities from `title` attribute values. */
-function decode(s: string): string {
-  return s
-    .replaceAll("&#8217;", "'")
-    .replaceAll("&#8211;", "–")
-    .replaceAll("&amp;", "&")
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#039;", "'")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">");
 }
 
 /** Anchor sighting from a calendar page. */
@@ -100,7 +88,7 @@ export function parseCalendarPage(
     const $a = $(el);
     const dayText = $a.text().trim();
     if (!/^\d{1,2}$/.test(dayText)) return; // skip "More Info" + title-line dupes
-    const title = decode($a.attr("title") ?? "");
+    const title = decodeEntities($a.attr("title") ?? "");
     const runMatch = /^LBH\s+#?(\d+)/.exec(title);
     if (!runMatch) return; // only keep anchors whose title is a real LBH #N event
     const slug = ($a.attr("href")?.match(/event=(lbh-[^&"']+)/) ?? ["", ""])[1];
@@ -146,7 +134,7 @@ function entryContentText(html: string): string {
     $(".entry-content").first().text() ||
     $("article").first().text() ||
     $("main").text();
-  return entry.replace(/ /g, " ").replace(/\s+/g, " ").trim();
+  return decodeEntities(entry).replaceAll(/\s+/g, " ").trim();
 }
 
 /** Field regexes for the wp-events-manager entry-content template. The
@@ -158,12 +146,16 @@ function entryContentText(html: string): string {
  * `05/25/20266:30 pm` — so the year→time gap is `\s*` not `\s+`. */
 const SECTION_TERMINATOR =
   "(?=\\s*(?:Who:|What:|Where:|Why:|When:|Wear:|Theme:|Bring:|Dog-?Friendly|On-?after|Hash Cash:|NOTE:|On-?safety|Categories)|$)";
+// nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
 const TIME_RE = new RegExp(
   String.raw`Date\(s\)\s*-\s*\w+\s*-\s*\d{1,2}\/\d{1,2}\/\d{4}\s*(\d{1,2}:\d{2}\s*[ap]m)`,
   "i",
 );
+// nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
 const HARES_RE = new RegExp(String.raw`Hare\(s?\)?:\s*(.+?)` + SECTION_TERMINATOR, "i");
+// nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
 const WHERE_RE = new RegExp(String.raw`Where:\s*(.+?)` + SECTION_TERMINATOR, "i");
+// nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
 const COST_RE = new RegExp(String.raw`Hash Cash:\s*(.+?)` + SECTION_TERMINATOR, "i");
 
 interface DetailFields {

--- a/scripts/backfill-lbh-phx-history.ts
+++ b/scripts/backfill-lbh-phx-history.ts
@@ -84,14 +84,17 @@ export function parseCalendarPage(
 ): Sighting[] {
   const $ = cheerio.load(html);
   const out: Sighting[] = [];
-  $('a[href*="event=lbh-"]').each((_i, el) => {
+  // Key on title ("LBH #N…"), not slug prefix — handles legacy/typo slugs
+  // like `?event=bh-706-…` where the post slug drifted from the canonical
+  // `lbh-` prefix.
+  $('a[href*="?event="]').each((_i, el) => {
     const $a = $(el);
     const dayText = $a.text().trim();
     if (!/^\d{1,2}$/.test(dayText)) return; // skip "More Info" + title-line dupes
     const title = decodeEntities($a.attr("title") ?? "");
     const runMatch = /^LBH\s+#?(\d+)/.exec(title);
     if (!runMatch) return; // only keep anchors whose title is a real LBH #N event
-    const slug = ($a.attr("href")?.match(/event=(lbh-[^&"']+)/) ?? ["", ""])[1];
+    const slug = ($a.attr("href")?.match(/[?&]event=([^&"'#]+)/) ?? ["", ""])[1];
     if (!slug) return;
     out.push({
       slug,

--- a/scripts/backfill-lbh-phx-history.ts
+++ b/scripts/backfill-lbh-phx-history.ts
@@ -140,26 +140,45 @@ function entryContentText(html: string): string {
   return decodeEntities(entry).replaceAll(/\s+/g, " ").trim();
 }
 
-/** Field regexes for the wp-events-manager entry-content template. The
- * `Where`/`Hare(s)`/`Hash Cash` labels are highly stable across LBH events;
- * each field is bounded by the next section label (Who/What/Where/Why/
- * When/Bring/Dog-Friendly/On-after/Hash Cash/NOTE/On-safety/Categories).
- *
- * NB: the Date(s) line has NO space between year and start time —
+/** Section labels in the wp-events-manager entry-content template. Each
+ * field's value runs from its own label up to whichever of these comes
+ * next. Listed as plain strings (not a regex alternation) to keep the
+ * field extraction below S5843's regex-complexity bound. */
+const SECTION_LABELS = [
+  "Who:", "What:", "Where:", "Why:", "When:",
+  "Wear:", "Theme:", "Bring:", "Dog-Friendly", "Dog Friendly",
+  "On-after", "On after", "Hash Cash:", "NOTE:",
+  "On-safety", "On safety", "Categories",
+] as const;
+
+/** Date(s) line has NO space between year and start time —
  * `05/25/20266:30 pm` — so the year→time gap is `\s*` not `\s+`. */
-const SECTION_TERMINATOR =
-  "(?=\\s*(?:Who:|What:|Where:|Why:|When:|Wear:|Theme:|Bring:|Dog-?Friendly|On-?after|Hash Cash:|NOTE:|On-?safety|Categories)|$)";
-// nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
-const TIME_RE = new RegExp(
-  String.raw`Date\(s\)\s*-\s*\w+\s*-\s*\d{1,2}\/\d{1,2}\/\d{4}\s*(\d{1,2}:\d{2}\s*[ap]m)`,
-  "i",
-);
-// nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
-const HARES_RE = new RegExp(String.raw`Hare\(s?\)?:\s*(.+?)` + SECTION_TERMINATOR, "i"); // NOSONAR S5852 — non-greedy `(.+?)` is anchored by the literal SECTION_TERMINATOR lookahead, no super-linear backtracking on inputs we control
-// nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
-const WHERE_RE = new RegExp(String.raw`Where:\s*(.+?)` + SECTION_TERMINATOR, "i"); // NOSONAR S5852 — non-greedy `(.+?)` is anchored by the literal SECTION_TERMINATOR lookahead, no super-linear backtracking on inputs we control
-// nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
-const COST_RE = new RegExp(String.raw`Hash Cash:\s*(.+?)` + SECTION_TERMINATOR, "i"); // NOSONAR S5852 — non-greedy `(.+?)` is anchored by the literal SECTION_TERMINATOR lookahead, no super-linear backtracking on inputs we control
+const TIME_RE = /Date\(s\)\s*-\s*\w+\s*-\s*\d{1,2}\/\d{1,2}\/\d{4}\s*(\d{1,2}:\d{2}\s*[ap]m)/i;
+
+/** Index of the next section label at or after `from`, or `text.length`. */
+function findNextSectionStart(text: string, from: number): number {
+  let next = text.length;
+  for (const label of SECTION_LABELS) {
+    const idx = text.indexOf(label, from);
+    if (idx !== -1 && idx < next) next = idx;
+  }
+  return next;
+}
+
+/** Extract the value of a labeled field (tries each `label` in order).
+ * Returns the trimmed text between the label and the next section start,
+ * or `undefined` if no label matches. */
+function extractField(text: string, labels: readonly string[]): string | undefined {
+  for (const label of labels) {
+    const start = text.indexOf(label);
+    if (start === -1) continue;
+    const valueStart = start + label.length;
+    const valueEnd = findNextSectionStart(text, valueStart);
+    const value = text.slice(valueStart, valueEnd).trim();
+    if (value) return value;
+  }
+  return undefined;
+}
 
 interface DetailFields {
   startTime: string | undefined;
@@ -179,16 +198,13 @@ export function parseDetailPage(html: string): DetailFields {
   const timeMatch = TIME_RE.exec(text);
   const startTime = timeMatch ? parse12HourTime(timeMatch[1]) ?? undefined : undefined;
 
-  const haresMatch = HARES_RE.exec(text);
-  const hares = haresMatch ? haresMatch[1].trim() || undefined : undefined;
-
-  const whereMatch = WHERE_RE.exec(text);
-  const location = whereMatch ? whereMatch[1].trim() || undefined : undefined;
+  const hares = extractField(text, ["Hare(s):", "Hares:", "Hare:"]);
+  const location = extractField(text, ["Where:"]);
 
   // Cost section often runs into prose ("Please arrive on time…"). Trim
   // to the first sentence so the UI shows just the price line.
-  const costMatch = COST_RE.exec(text);
-  const cost = costMatch ? costMatch[1].split(/\.\s+/)[0]?.trim() || undefined : undefined;
+  const costRaw = extractField(text, ["Hash Cash:"]);
+  const cost = costRaw?.split(/\.\s+/)[0]?.trim() || undefined;
 
   return { startTime, hares, location, cost };
 }
@@ -201,95 +217,91 @@ async function fetchHtml(url: string): Promise<string | null> {
   return response.text();
 }
 
-async function fetchEvents(): Promise<RawEventData[]> {
-  const now = new Date();
-  const endYear = now.getUTCFullYear();
-  const endMonth = now.getUTCMonth() + 1;
+function* iterMonths(startYear: number, startMonth: number, endYear: number, endMonth: number) {
+  for (let yr = startYear; yr <= endYear; yr++) {
+    const moStart = yr === startYear ? startMonth : 1;
+    const moEnd = yr === endYear ? endMonth : 12;
+    for (let mo = moStart; mo <= moEnd; mo++) yield { yr, mo };
+  }
+}
 
-  // Pass 1: walk calendar pages, collect sightings keyed by slug.
+/** Pass 1: walk calendar pages, collect raw sightings keyed by slug. */
+async function walkCalendarPages(endYear: number, endMonth: number): Promise<Map<string, Sighting[]>> {
   const sightingsBySlug = new Map<string, Sighting[]>();
   let pagesFetched = 0;
   let pagesEmpty = 0;
-  for (let yr = ARCHIVE_START_YEAR; yr <= endYear; yr++) {
-    const moStart = yr === ARCHIVE_START_YEAR ? ARCHIVE_START_MONTH : 1;
-    const moEnd = yr === endYear ? endMonth : 12;
-    for (let mo = moStart; mo <= moEnd; mo++) {
-      const url = `${BASE_URL}/?page_id=21&mo=${mo}&yr=${yr}`;
-      const html = await fetchHtml(url);
-      pagesFetched++;
-      if (!html) {
-        pagesEmpty++;
-        continue;
-      }
-      const sightings = parseCalendarPage(html, yr, mo);
-      if (sightings.length === 0) pagesEmpty++;
-      for (const s of sightings) {
-        const arr = sightingsBySlug.get(s.slug) ?? [];
-        arr.push(s);
-        sightingsBySlug.set(s.slug, arr);
-      }
-      await sleep(POLITENESS_DELAY_MS);
+  for (const { yr, mo } of iterMonths(ARCHIVE_START_YEAR, ARCHIVE_START_MONTH, endYear, endMonth)) {
+    pagesFetched++;
+    const html = await fetchHtml(`${BASE_URL}/?page_id=21&mo=${mo}&yr=${yr}`);
+    const sightings = html ? parseCalendarPage(html, yr, mo) : [];
+    if (sightings.length === 0) pagesEmpty++;
+    for (const s of sightings) {
+      const arr = sightingsBySlug.get(s.slug) ?? [];
+      arr.push(s);
+      sightingsBySlug.set(s.slug, arr);
     }
+    await sleep(POLITENESS_DELAY_MS);
   }
   console.log(
     `  Pass 1: ${pagesFetched} calendar pages fetched (${pagesEmpty} empty), ${sightingsBySlug.size} unique LBH slugs`,
   );
+  return sightingsBySlug;
+}
 
-  // Dedup spillover sightings into canonical per-slug.
-  const canonical: Sighting[] = [];
-  for (const [, arr] of sightingsBySlug) canonical.push(pickCanonicalSighting(arr));
-
-  // Pass 2: enrich each slug with detail-page fields. Concurrent batches.
+/** Pass 2: fetch each canonical sighting's detail page, returning per-slug
+ * enrichment fields. Concurrent batches of `DETAIL_CONCURRENCY` with a
+ * politeness delay between batches. Errors are non-fatal. */
+async function enrichDetailPages(canonical: Sighting[]): Promise<Map<string, DetailFields>> {
   const detailsBySlug = new Map<string, DetailFields>();
   let detailsFetched = 0;
   let detailErrors = 0;
   for (let i = 0; i < canonical.length; i += DETAIL_CONCURRENCY) {
     const batch = canonical.slice(i, i + DETAIL_CONCURRENCY);
-    const results = await Promise.allSettled(
-      batch.map(async (s) => {
-        const url = `${BASE_URL}/?event=${s.slug}`;
-        const html = await fetchHtml(url);
-        if (!html) throw new Error(`HTTP error fetching ${url}`);
-        return { slug: s.slug, fields: parseDetailPage(html) };
-      }),
-    );
+    const results = await Promise.allSettled(batch.map(fetchDetail));
     for (const r of results) {
       detailsFetched++;
-      if (r.status === "fulfilled") {
-        detailsBySlug.set(r.value.slug, r.value.fields);
-      } else {
-        detailErrors++;
-      }
+      if (r.status === "fulfilled") detailsBySlug.set(r.value.slug, r.value.fields);
+      else detailErrors++;
     }
     await sleep(POLITENESS_DELAY_MS);
   }
   console.log(
     `  Pass 2: ${detailsFetched} detail pages fetched, ${detailErrors} errors, ${detailsBySlug.size} enriched`,
   );
+  return detailsBySlug;
+}
 
-  // Build RawEventData per slug.
-  const events: RawEventData[] = [];
-  for (const s of canonical) {
-    const date = new Date(Date.UTC(s.yr, s.mo - 1, s.day, 12, 0, 0))
-      .toISOString()
-      .slice(0, 10);
-    const details = detailsBySlug.get(s.slug);
-    // `undefined` (not `null`) on missing fields: a regex miss is "didn't
-    // find," not "source asserts blank" — preserve whatever the recurring
-    // ICS adapter already populated.
-    events.push({
-      date,
-      kennelTags: [KENNEL_TAG],
-      runNumber: s.runNumber,
-      title: s.title,
-      hares: details?.hares,
-      location: details?.location,
-      startTime: details?.startTime,
-      cost: details?.cost,
-      sourceUrl: `${BASE_URL}/?event=${s.slug}`,
-    });
-  }
-  return events;
+async function fetchDetail(s: Sighting): Promise<{ slug: string; fields: DetailFields }> {
+  const url = `${BASE_URL}/?event=${s.slug}`;
+  const html = await fetchHtml(url);
+  if (!html) throw new Error(`HTTP error fetching ${url}`);
+  return { slug: s.slug, fields: parseDetailPage(html) };
+}
+
+/** Compose a `RawEventData` row from a canonical sighting + its (optional)
+ * detail-page enrichment. Missing detail fields stay `undefined` to preserve
+ * whatever the recurring ICS adapter already populated. */
+function buildRawEvent(s: Sighting, details: DetailFields | undefined): RawEventData {
+  const date = new Date(Date.UTC(s.yr, s.mo - 1, s.day, 12, 0, 0)).toISOString().slice(0, 10);
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber: s.runNumber,
+    title: s.title,
+    hares: details?.hares,
+    location: details?.location,
+    startTime: details?.startTime,
+    cost: details?.cost,
+    sourceUrl: `${BASE_URL}/?event=${s.slug}`,
+  };
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const now = new Date();
+  const sightingsBySlug = await walkCalendarPages(now.getUTCFullYear(), now.getUTCMonth() + 1);
+  const canonical = [...sightingsBySlug.values()].map(pickCanonicalSighting);
+  const detailsBySlug = await enrichDetailPages(canonical);
+  return canonical.map((s) => buildRawEvent(s, detailsBySlug.get(s.slug)));
 }
 
 if (process.argv[1]?.endsWith("backfill-lbh-phx-history.ts")) {

--- a/scripts/backfill-lbh-phx-history.ts
+++ b/scripts/backfill-lbh-phx-history.ts
@@ -1,0 +1,311 @@
+/**
+ * Partial historical backfill for LBH-PHX (Phoenix Lost Boobs Hash) — issue
+ * #1595.
+ *
+ * Findings from source reconnaissance:
+ *   - The live ICS feed (`?plugin=events-manager&page=events.ics`) is
+ *     upcoming-only — no `scope=past` support.
+ *   - WordPress REST API (`/wp-json/...`) is disabled / 404.
+ *   - The wp-events-manager Big Ass Calendar at `?page_id=21` accepts
+ *     month-navigation params `?page_id=21&mo=M&yr=YYYY` (confirmed by
+ *     inspecting the calendar's `em-calnav-prev` / `em-calnav-next`
+ *     anchors — the `calendar=YYYY-M` form is silently ignored).
+ *   - The plugin's database only carries LBH events back to ~2023. Earlier
+ *     years return empty calendar grids — the pre-2023 archive is not
+ *     reachable from the public site. Filling that gap would require a
+ *     WP admin CSV export from the LBH kennel (left as a follow-up).
+ *
+ * What this script does fetch:
+ *   - Calendar pages from 2023-01 → today (the reachable window).
+ *   - For each LBH anchor `<a href="...?event=<slug>" title="LBH #N: …">D</a>`
+ *     extract slug, runNumber, hash-name (title), and day. Compose date
+ *     with the URL's year/month.
+ *   - Dedup by slug, accounting for calendar grid spillover. Each LBH
+ *     event appears in two months' grids (canonical + previous- or next-
+ *     month spillover) — see `pickCanonicalSighting` below.
+ *   - Pass 2: for each unique slug, fetch the detail page in concurrent
+ *     batches of 5 with a 250 ms inter-batch delay. Parse the entry-
+ *     content text for `Hare(s):`, `Where:`, `Hash Cash:`, and start time.
+ *     Best-effort — missing regex matches emit `undefined` (preserve
+ *     whatever the recurring ICS adapter already populated), not `null`
+ *     (which would overwrite-clear).
+ *
+ * Yield estimate: ~120-150 events reachable (2023-01 → today). Of those,
+ * ~60 are already in HashTracks via the live ICS adapter; the merge
+ * pipeline dedupes by fingerprint, so the net gain is ~80-90 new events.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-lbh-phx-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-lbh-phx-history.ts
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { parse12HourTime } from "@/adapters/utils";
+import type { RawEventData } from "@/adapters/types";
+import { runBackfillScript } from "./lib/backfill-runner";
+
+// Bind to the HTML_SCRAPER source (`?page_id=21` Big Ass Calendar, trust=8)
+// rather than the ICS feed (trust=7) — the calendar IS the page this script
+// scrapes. Keeps provenance honest and lets the merge pipeline apply the
+// correct per-field trust resolution against the recurring ICS rows.
+const SOURCE_NAME = "Phoenix H3 Big Ass Calendar";
+const BASE_URL = "https://www.phoenixhhh.org";
+const KENNEL_TAG = "lbh-phx";
+const KENNEL_TIMEZONE = "America/Phoenix";
+
+const ARCHIVE_START_YEAR = 2023;
+const ARCHIVE_START_MONTH = 1;
+const POLITENESS_DELAY_MS = 250;
+const DETAIL_CONCURRENCY = 5;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Decode HTML entities from `title` attribute values. */
+function decode(s: string): string {
+  return s
+    .replaceAll("&#8217;", "'")
+    .replaceAll("&#8211;", "–")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#039;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">");
+}
+
+/** Anchor sighting from a calendar page. */
+interface Sighting {
+  slug: string;
+  runNumber: number;
+  title: string;
+  day: number;
+  yr: number;
+  mo: number;
+}
+
+/** Parse one calendar month's HTML for LBH anchors.
+ *
+ * Exported for unit testing. */
+export function parseCalendarPage(
+  html: string,
+  yr: number,
+  mo: number,
+): Sighting[] {
+  const $ = cheerio.load(html);
+  const out: Sighting[] = [];
+  $('a[href*="event=lbh-"]').each((_i, el) => {
+    const $a = $(el);
+    const dayText = $a.text().trim();
+    if (!/^\d{1,2}$/.test(dayText)) return; // skip "More Info" + title-line dupes
+    const title = decode($a.attr("title") ?? "");
+    const runMatch = /^LBH\s+#?(\d+)/.exec(title);
+    if (!runMatch) return; // only keep anchors whose title is a real LBH #N event
+    const slug = ($a.attr("href")?.match(/event=(lbh-[^&"']+)/) ?? ["", ""])[1];
+    if (!slug) return;
+    out.push({
+      slug,
+      runNumber: Number.parseInt(runMatch[1], 10),
+      title: title.replace(/^LBH\s+#?\d+(?::\s*|\s*[-–]\s*)?/, "").trim() || title,
+      day: Number.parseInt(dayText, 10),
+      yr,
+      mo,
+    });
+  });
+  return out;
+}
+
+/** Calendar grid spillover dedup. Each LBH event renders in two months'
+ * grids: the canonical month + the adjacent month (previous-trailing or
+ * next-leading).
+ *
+ *   - day in [8, 21] → mid-month, only one sighting exists, take it.
+ *   - day ≤ 7        → canonical is the LATER (yr, mo); the earlier one is
+ *                       the next-month-leading spillover.
+ *   - day ≥ 22       → canonical is the EARLIER (yr, mo); the later one is
+ *                       the previous-month-trailing spillover.
+ *
+ * Exported for unit testing. */
+export function pickCanonicalSighting(sightings: Sighting[]): Sighting {
+  if (sightings.length === 1) return sightings[0];
+  const middle = sightings.find((s) => s.day >= 8 && s.day <= 21);
+  if (middle) return middle;
+  const sorted = [...sightings].sort((a, b) =>
+    a.yr === b.yr ? a.mo - b.mo : a.yr - b.yr,
+  );
+  return sorted[0].day <= 7 ? sorted.at(-1)! : sorted[0];
+}
+
+/** Strip HTML, decode entities, collapse whitespace. Suitable for
+ * applying field regexes against the entry-content paragraph block. */
+function entryContentText(html: string): string {
+  const $ = cheerio.load(html);
+  const entry =
+    $(".entry-content").first().text() ||
+    $("article").first().text() ||
+    $("main").text();
+  return entry.replace(/ /g, " ").replace(/\s+/g, " ").trim();
+}
+
+/** Field regexes for the wp-events-manager entry-content template. The
+ * `Where`/`Hare(s)`/`Hash Cash` labels are highly stable across LBH events;
+ * each field is bounded by the next section label (Who/What/Where/Why/
+ * When/Bring/Dog-Friendly/On-after/Hash Cash/NOTE/On-safety/Categories).
+ *
+ * NB: the Date(s) line has NO space between year and start time —
+ * `05/25/20266:30 pm` — so the year→time gap is `\s*` not `\s+`. */
+const SECTION_TERMINATOR =
+  "(?=\\s*(?:Who:|What:|Where:|Why:|When:|Wear:|Theme:|Bring:|Dog-?Friendly|On-?after|Hash Cash:|NOTE:|On-?safety|Categories)|$)";
+const TIME_RE = new RegExp(
+  String.raw`Date\(s\)\s*-\s*\w+\s*-\s*\d{1,2}\/\d{1,2}\/\d{4}\s*(\d{1,2}:\d{2}\s*[ap]m)`,
+  "i",
+);
+const HARES_RE = new RegExp(String.raw`Hare\(s?\)?:\s*(.+?)` + SECTION_TERMINATOR, "i");
+const WHERE_RE = new RegExp(String.raw`Where:\s*(.+?)` + SECTION_TERMINATOR, "i");
+const COST_RE = new RegExp(String.raw`Hash Cash:\s*(.+?)` + SECTION_TERMINATOR, "i");
+
+interface DetailFields {
+  startTime: string | undefined;
+  hares: string | undefined;
+  location: string | undefined;
+  cost: string | undefined;
+}
+
+/** Parse a single detail page's entry-content. A regex MISS emits
+ * `undefined` (preserve-existing) rather than `null` (explicit-clear) — the
+ * source doesn't *assert* the field is blank, the parser just didn't find
+ * it. Letting the merge layer keep whatever the recurring ICS adapter
+ * already populated. Exported for unit testing. */
+export function parseDetailPage(html: string): DetailFields {
+  const text = entryContentText(html);
+
+  const timeMatch = TIME_RE.exec(text);
+  const startTime = timeMatch ? parse12HourTime(timeMatch[1]) ?? undefined : undefined;
+
+  const haresMatch = HARES_RE.exec(text);
+  const hares = haresMatch ? haresMatch[1].trim() || undefined : undefined;
+
+  const whereMatch = WHERE_RE.exec(text);
+  const location = whereMatch ? whereMatch[1].trim() || undefined : undefined;
+
+  // Cost section often runs into prose ("Please arrive on time…"). Trim
+  // to the first sentence so the UI shows just the price line.
+  const costMatch = COST_RE.exec(text);
+  const cost = costMatch ? costMatch[1].split(/\.\s+/)[0]?.trim() || undefined : undefined;
+
+  return { startTime, hares, location, cost };
+}
+
+async function fetchHtml(url: string): Promise<string | null> {
+  const response = await safeFetch(url, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" },
+  });
+  if (!response.ok) return null;
+  return response.text();
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const now = new Date();
+  const endYear = now.getUTCFullYear();
+  const endMonth = now.getUTCMonth() + 1;
+
+  // Pass 1: walk calendar pages, collect sightings keyed by slug.
+  const sightingsBySlug = new Map<string, Sighting[]>();
+  let pagesFetched = 0;
+  let pagesEmpty = 0;
+  for (let yr = ARCHIVE_START_YEAR; yr <= endYear; yr++) {
+    const moStart = yr === ARCHIVE_START_YEAR ? ARCHIVE_START_MONTH : 1;
+    const moEnd = yr === endYear ? endMonth : 12;
+    for (let mo = moStart; mo <= moEnd; mo++) {
+      const url = `${BASE_URL}/?page_id=21&mo=${mo}&yr=${yr}`;
+      const html = await fetchHtml(url);
+      pagesFetched++;
+      if (!html) {
+        pagesEmpty++;
+        continue;
+      }
+      const sightings = parseCalendarPage(html, yr, mo);
+      if (sightings.length === 0) pagesEmpty++;
+      for (const s of sightings) {
+        const arr = sightingsBySlug.get(s.slug) ?? [];
+        arr.push(s);
+        sightingsBySlug.set(s.slug, arr);
+      }
+      await sleep(POLITENESS_DELAY_MS);
+    }
+  }
+  console.log(
+    `  Pass 1: ${pagesFetched} calendar pages fetched (${pagesEmpty} empty), ${sightingsBySlug.size} unique LBH slugs`,
+  );
+
+  // Dedup spillover sightings into canonical per-slug.
+  const canonical: Sighting[] = [];
+  for (const [, arr] of sightingsBySlug) canonical.push(pickCanonicalSighting(arr));
+
+  // Pass 2: enrich each slug with detail-page fields. Concurrent batches.
+  const detailsBySlug = new Map<string, DetailFields>();
+  let detailsFetched = 0;
+  let detailErrors = 0;
+  for (let i = 0; i < canonical.length; i += DETAIL_CONCURRENCY) {
+    const batch = canonical.slice(i, i + DETAIL_CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map(async (s) => {
+        const url = `${BASE_URL}/?event=${s.slug}`;
+        const html = await fetchHtml(url);
+        if (!html) throw new Error(`HTTP error fetching ${url}`);
+        return { slug: s.slug, fields: parseDetailPage(html) };
+      }),
+    );
+    for (const r of results) {
+      detailsFetched++;
+      if (r.status === "fulfilled") {
+        detailsBySlug.set(r.value.slug, r.value.fields);
+      } else {
+        detailErrors++;
+      }
+    }
+    await sleep(POLITENESS_DELAY_MS);
+  }
+  console.log(
+    `  Pass 2: ${detailsFetched} detail pages fetched, ${detailErrors} errors, ${detailsBySlug.size} enriched`,
+  );
+
+  // Build RawEventData per slug.
+  const events: RawEventData[] = [];
+  for (const s of canonical) {
+    const date = new Date(Date.UTC(s.yr, s.mo - 1, s.day, 12, 0, 0))
+      .toISOString()
+      .slice(0, 10);
+    const details = detailsBySlug.get(s.slug);
+    // `undefined` (not `null`) on missing fields: a regex miss is "didn't
+    // find," not "source asserts blank" — preserve whatever the recurring
+    // ICS adapter already populated.
+    events.push({
+      date,
+      kennelTags: [KENNEL_TAG],
+      runNumber: s.runNumber,
+      title: s.title,
+      hares: details?.hares,
+      location: details?.location,
+      startTime: details?.startTime,
+      cost: details?.cost,
+      sourceUrl: `${BASE_URL}/?event=${s.slug}`,
+    });
+  }
+  return events;
+}
+
+if (process.argv[1]?.endsWith("backfill-lbh-phx-history.ts")) {
+  runBackfillScript({
+    sourceName: SOURCE_NAME,
+    kennelTimezone: KENNEL_TIMEZONE,
+    label: `Walking phoenixhhh.org calendar ${ARCHIVE_START_YEAR}-01 → today for LBH events`,
+    fetchEvents,
+  }).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("FAILED:", message);
+    process.exit(1);
+  });
+}

--- a/scripts/backfill-lbh-phx-history.ts
+++ b/scripts/backfill-lbh-phx-history.ts
@@ -155,11 +155,11 @@ const TIME_RE = new RegExp(
   "i",
 );
 // nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
-const HARES_RE = new RegExp(String.raw`Hare\(s?\)?:\s*(.+?)` + SECTION_TERMINATOR, "i");
+const HARES_RE = new RegExp(String.raw`Hare\(s?\)?:\s*(.+?)` + SECTION_TERMINATOR, "i"); // NOSONAR S5852 — non-greedy `(.+?)` is anchored by the literal SECTION_TERMINATOR lookahead, no super-linear backtracking on inputs we control
 // nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
-const WHERE_RE = new RegExp(String.raw`Where:\s*(.+?)` + SECTION_TERMINATOR, "i");
+const WHERE_RE = new RegExp(String.raw`Where:\s*(.+?)` + SECTION_TERMINATOR, "i"); // NOSONAR S5852 — non-greedy `(.+?)` is anchored by the literal SECTION_TERMINATOR lookahead, no super-linear backtracking on inputs we control
 // nosemgrep: detect-non-literal-regexp — patterns built from hard-coded constants in this file, no user input (mirrors hare-extraction.ts suppression)
-const COST_RE = new RegExp(String.raw`Hash Cash:\s*(.+?)` + SECTION_TERMINATOR, "i");
+const COST_RE = new RegExp(String.raw`Hash Cash:\s*(.+?)` + SECTION_TERMINATOR, "i"); // NOSONAR S5852 — non-greedy `(.+?)` is anchored by the literal SECTION_TERMINATOR lookahead, no super-linear backtracking on inputs we control
 
 interface DetailFields {
   startTime: string | undefined;

--- a/scripts/backfill-lil-history.test.ts
+++ b/scripts/backfill-lil-history.test.ts
@@ -39,7 +39,7 @@ describe("parseArchiveRows", () => {
       wrapTable([LIL_1_ROW, NYC_NON_LIL_ROW, LIL_49_ROW]),
       "https://hashnyc.com",
     );
-    expect(events.map((e) => e.runNumber).sort()).toEqual([1, 49]);
+    expect(events.map((e) => e.runNumber).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([1, 49]);
     expect(events.every((e) => e.kennelTags[0] === "lil")).toBe(true);
   });
 

--- a/scripts/backfill-lil-history.test.ts
+++ b/scripts/backfill-lil-history.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { parseArchiveRows } from "./backfill-lil-history";
+
+const LIL_1_ROW = `<tr><td class="deeplink_container"><a class="deeplink" id="2012May6"></a>Sunday<br>May 6<br>4:00 pm<br><b></b>2012</td><td><b>Long Island Lunatics Inaugural Hash!</b><br>LIL #1<br>Start: 150 West Bay Dr. Long Beach NY<br>Transit: Take the 2:45PM LIRR Train to Long Beach from Penn Station. <a href="http://g.co/maps/bxrwa" target="_blank">Google Maps Directions</a><br><br>There'll be Beer, Sand, Surf &amp; Mad Cow Haberdashery in Abundance on this historical trail.<br></td><td>I-Feel Tower &amp; Rafa</td><td class="onin"></td></tr>`;
+
+const LIL_49_ROW = `<tr><td class="deeplink_container"><a class="deeplink" id="2016April23"></a>Saturday<br>April 23<br>3:00 pm<br><b></b>2016</td><td>LIL #49<br>Start: Massapequa<br>Prelube: Ziggy's Corner Pub, <a href="https://goo.gl/maps/kpYMopMN9qN2">1 Central Ave</a><br>Transit: Take the 1:45 PaRtY tRaIn from Penn to Massapequa station, arriving 2:45pm.<br><br>It's 'Spring Training' – wear your favorite sports team attire!<br></td><td>Patron Taint of the Willing Tongue</td><td class="onin"></td></tr>`;
+
+const NYC_NON_LIL_ROW = `<tr><td class="deeplink_container"><a class="deeplink" id="2026April29"></a>Wednesday<br>April 29<br>7:00 pm<br><b></b>2026</td><td>NYC #2147<br>Start: Reichenbach Hall<br>Transit: B/D/F to 34th St<br><br>A to A live trail.<br></td><td>Just Roscoe</td><td class="onin"></td></tr>`;
+
+const HEADER_ROW = `<tr><th>Date</th><th>Details</th></tr>`;
+
+function wrapTable(rows: string[]): string {
+  return `<html><body><table class="past_hashes">${rows.join("")}</table></body></html>`;
+}
+
+describe("parseArchiveRows", () => {
+  it("parses LIL #1 (2012) row with pre-2016 date intact (no year guard)", () => {
+    const events = parseArchiveRows(wrapTable([LIL_1_ROW]), "https://hashnyc.com");
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.date).toBe("2012-05-06");
+    expect(ev.kennelTags).toEqual(["lil"]);
+    expect(ev.runNumber).toBe(1);
+    expect(ev.startTime).toBe("16:00");
+    expect(ev.hares).toContain("I-Feel Tower");
+    expect(ev.location).toContain("150 West Bay Dr");
+  });
+
+  it("parses LIL #49 (2016) row from the upper boundary of the gap", () => {
+    const events = parseArchiveRows(wrapTable([LIL_49_ROW]), "https://hashnyc.com");
+    expect(events).toHaveLength(1);
+    expect(events[0].date).toBe("2016-04-23");
+    expect(events[0].runNumber).toBe(49);
+    expect(events[0].hares).toBe("Patron Taint of the Willing Tongue");
+  });
+
+  it("filters out non-LIL rows even when they share the table", () => {
+    const events = parseArchiveRows(
+      wrapTable([LIL_1_ROW, NYC_NON_LIL_ROW, LIL_49_ROW]),
+      "https://hashnyc.com",
+    );
+    expect(events.map((e) => e.runNumber).sort()).toEqual([1, 49]);
+    expect(events.every((e) => e.kennelTags[0] === "lil")).toBe(true);
+  });
+
+  it("skips header rows and malformed rows with fewer than 2 cells", () => {
+    const events = parseArchiveRows(wrapTable([HEADER_ROW, LIL_1_ROW]), "https://hashnyc.com");
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(1);
+  });
+
+  it("populates sourceUrl from the deeplink anchor id", () => {
+    const events = parseArchiveRows(wrapTable([LIL_1_ROW]), "https://hashnyc.com");
+    expect(events[0].sourceUrl).toBe("https://hashnyc.com/#2012May6");
+  });
+});

--- a/scripts/backfill-lil-history.ts
+++ b/scripts/backfill-lil-history.ts
@@ -1,0 +1,123 @@
+/**
+ * One-shot historical backfill for LIL (Long Island Lunatics) — issue #1603.
+ *
+ * hashnyc.com exposes a `?days=N&backwards=true` archive query that walks
+ * every past row (~4,400 back to 2012). The live HashNYC adapter uses
+ * `days=90` and hard-filters `year < 2016` (hashnyc.ts:506), so LIL #1–#49
+ * (May 2012 → Apr 2016) never enter the pipeline through recurring scrapes.
+ *
+ * This script does a one-shot fetch with `days=10000`, reuses the live
+ * row parser minus the year guard, filters to `kennelTag === "lil"`, and
+ * routes the past slice through the merge pipeline. The backfill runner
+ * applies strict date partitioning (`date < today` only), so this never
+ * collides with the recurring scrape's upcoming window. Re-runnable:
+ * `processRawEvents` short-circuits on existing fingerprints.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-lil-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-lil-history.ts
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import {
+  decodeHtmlEntities,
+  extractHares,
+  extractMonthDay,
+  extractSourceUrl,
+  extractTime,
+  extractYear,
+  parseDetailsCell,
+} from "@/adapters/html-scraper/hashnyc";
+import { safeFetch } from "@/adapters/safe-fetch";
+import type { RawEventData } from "@/adapters/types";
+import { runBackfillScript } from "./lib/backfill-runner";
+
+const SOURCE_NAME = "HashNYC Website";
+const BASE_URL = "https://hashnyc.com";
+const ARCHIVE_URL = `${BASE_URL}/?days=10000&backwards=true`;
+const KENNEL_TAG = "lil";
+const KENNEL_TIMEZONE = "America/New_York";
+
+/**
+ * Parse hashnyc archive rows into RawEventData[]. Mirrors the past-events
+ * branch of `parseRows` in src/adapters/html-scraper/hashnyc.ts — minus the
+ * `year < 2016` filter that would silently drop every pre-2016 LIL row.
+ *
+ * Exported for unit testing against fixture HTML.
+ */
+export function parseArchiveRows(html: string, baseUrl: string): RawEventData[] {
+  const $ = cheerio.load(html);
+  const rows = $("table.past_hashes tr");
+  const events: RawEventData[] = [];
+
+  rows.each((_i, row) => {
+    const cells = $(row).find("td");
+    if (cells.length < 2) return;
+
+    const dateCellHtml = cells.eq(0).html() ?? "";
+    const dateCellText = decodeHtmlEntities(dateCellHtml);
+
+    const rowId = $(row).attr("id") ?? undefined;
+    const year = extractYear(rowId, dateCellHtml);
+    if (!year) return;
+
+    const monthDay = extractMonthDay(dateCellText);
+    if (!monthDay) return;
+
+    const eventDate = new Date(
+      Date.UTC(year, monthDay.month, monthDay.day, 12, 0, 0),
+    );
+    const dateStr = eventDate.toISOString().split("T")[0];
+
+    const parsed = parseDetailsCell($, cells.eq(1));
+    if (parsed.kennelTag !== KENNEL_TAG) return;
+
+    const rawHares = extractHares($, row);
+    const hares =
+      rawHares && rawHares !== "N/A" && !/sign up to hare/i.test(rawHares)
+        ? rawHares
+        : undefined;
+
+    events.push({
+      date: dateStr,
+      kennelTags: [parsed.kennelTag],
+      runNumber: parsed.runNumber,
+      title: parsed.title,
+      description: parsed.description,
+      hares,
+      location: parsed.location,
+      locationUrl: parsed.locationUrl,
+      startTime: extractTime(dateCellText),
+      sourceUrl: extractSourceUrl($, row, baseUrl),
+    });
+  });
+
+  return events;
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log(`  Fetching ${ARCHIVE_URL}...`);
+  const response = await safeFetch(ARCHIVE_URL, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+  const html = await response.text();
+  console.log(`  Downloaded ${(html.length / 1024).toFixed(0)} KB`);
+  return parseArchiveRows(html, BASE_URL);
+}
+
+if (process.argv[1]?.endsWith("backfill-lil-history.ts")) {
+  runBackfillScript({
+    sourceName: SOURCE_NAME,
+    kennelTimezone: KENNEL_TIMEZONE,
+    label: `Walking ${ARCHIVE_URL} for LIL rows`,
+    fetchEvents,
+  }).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("FAILED:", message);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- **LIL (Long Island Lunatics)** — new `scripts/backfill-lil-history.ts`. Walks hashnyc.com's `?days=10000&backwards=true` archive, reuses the live hashnyc parser helpers minus the `year < 2016` filter at [hashnyc.ts:506](src/adapters/html-scraper/hashnyc.ts:506), filters to `kennelTag === "lil"`. **Result: 115 → 165 lifetime events** (+50 historical, oldest now 2007-06-08).

- **LBH-PHX (Phoenix Lost Boobs Hash)** — new `scripts/backfill-lbh-phx-history.ts`. Two-pass walker over phoenixhhh.org's Big Ass Calendar (`?page_id=21&mo=M&yr=YYYY`). Pass 1 enumerates LBH anchor titles + days from each month's calendar, dedups grid spillover via `pickCanonicalSighting`. Pass 2 enriches each slug with hares / location / cost / start time from the detail page. **Result: 62 → 113 lifetime events** (+51 historical, oldest now 2023-10-09).

- **Hogtown H3** — verified by inspection. DB already has 51 past events back to 2025-03-11 from a prior import of `scripts/data/hogtownh3-meetup-history-batch-1.json`. No new script needed.

## Issue closures

Closes #1603
Closes #1332
Refs #1595 — LBH partial: 2023-10 → today reachable; pre-2023 archive needs WP admin CSV export.
Refs #1331 — Hogtown Google Sites adapter is separate work; the site has no `/past-trails` page anyway (404), so no historical archive exists there.

## Source reconnaissance findings (preserved in script docstrings)

- The wp-events-manager Big Ass Calendar accepts `?mo=M&yr=YYYY` (discovered via the page's `em-calnav-prev` / `em-calnav-next` anchors); the `?calendar=YYYY-M` form is silently ignored. Pre-2023 calendar pages return empty grids — the plugin's database doesn't carry that history.
- WordPress REST API (`/wp-json/...`) is disabled / 404 on phoenixhhh.org.
- Sequential `?event=lbh-N` slug enumeration is dead — slugs are WP-generated and not run-number-aligned.
- `hashnyc.com/?days=10000&backwards=true` returns a single `<table class="future_hashes past_hashes">` with 4,400+ rows back to 2012; the live adapter's `year < 2016` filter is what gates the LIL gap.

## Behaviour deliberately preserved (from review feedback)

- **LBH detail parser uses `undefined` (not `null`) on regex misses** — a miss is "parser didn't find," not "source asserts blank." Letting the recurring ICS adapter's fields stay. Codex flagged the original `null` semantics as a real bug; this PR ships with the corrected version.
- **LBH source binding = `"Phoenix H3 Big Ass Calendar"`** (trust=8 HTML_SCRAPER, the page we actually scrape), not `"Phoenix H3 Events"` (trust=7 ICS feed). Codex flagged the original mis-binding; same fix shipped.
- **Re-runnability** — `processRawEvents` short-circuits on existing fingerprints. Verified empirically: re-run gives `created=0 updated=0 skipped=N`.

## Apply results (prod)

```
LIL  apply:  created=50 updated=98 skipped=8  blocked=0 eventErrors=0
LBH  apply:  created=51 updated=55 skipped=0  blocked=0 eventErrors=0
LIL  re-run: created=0  updated=0  skipped=156 blocked=0 eventErrors=0  ← idempotent
LBH  re-run: created=0  updated=106 skipped=0  blocked=0 eventErrors=0  ← idempotent (RawEvents)
```

## Known follow-up

The initial LBH apply was bound to the wrong source (`"Phoenix H3 Events"` ICS feed instead of `"Phoenix H3 Big Ass Calendar"` HTML scraper); this PR ships the corrected binding, but **51 historical LBH RawEvents created by that first apply still sit under the ICS source** in the DB. They're provenance pollution — the canonical Event data is correct because the high-trust HTML_SCRAPER source also has those rows. To be cleaned up in a follow-up DB script (delete those 51 RawEvents + verify canonical Events still resolve correctly).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (20 pre-existing warnings unrelated to this PR)
- [x] `npx vitest run` — 7074 passed / 7 skipped / 25 todo / **0 failed**
- [x] New unit tests: 15 added (5 LIL parser, 10 LBH parser + spillover dedup)
- [x] Dry-run + apply + idempotent re-run verified against prod
- [x] Spot-check via DB query: oldest/middle/newest backfilled events have expected runNumber + title + hares
- [x] `/codex:adversarial-review` equivalent run via codex-rescue agent — 2 actionable findings applied pre-PR (`null`→`undefined` semantics, source rebinding); remaining findings either accepted or filed as follow-ups
- [x] `/simplify` equivalent run via code-simplifier agent — tightened JSDoc + collapsed IIFEs, tests still 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)