### PR TITLE
scripts: Atlanta post-merge data-fix record (PR #1622 follow-up)

### DIFF
--- a/scripts/cleanup-atlanta-canonical-ghosts.ts
+++ b/scripts/cleanup-atlanta-canonical-ghosts.ts
@@ -41,6 +41,16 @@ import { prisma } from "@/lib/db";
 
 const STALE_RUN_NUMBERS = new Set([2000, 946]);
 const STALE_START_TIMES = new Set(["22:36", "15:19"]);
+// Hard-scope the cleanup to the four known ghost dates from issues #1587/#1588.
+// Without this, a future re-run could erase a legitimate runNumber/startTime
+// that happens to land on the stale value cohort (e.g. if MLH4 ever runs trail
+// #2000 for real, or holds an event at 22:36). CodeRabbit PR #1629 review.
+const GHOST_DATES = new Set([
+  "2026-03-30",
+  "2026-04-20",
+  "2026-05-04",
+  "2026-05-11",
+]);
 
 interface RunNumberHit { id: string; date: Date; runNumber: number | null; title: string | null }
 interface StartTimeHit { id: string; date: Date; startTime: string | null; title: string | null }
@@ -60,6 +70,10 @@ async function findStaleEvents(kennelId: string): Promise<{ runNumberHits: RunNu
   const startTimeHits: StartTimeHit[] = [];
   for (const ek of eventKennels) {
     const e = ek.event;
+    // Hard-scope to known ghost dates (#1629 review): both value and date
+    // must match so re-runs can't erase legitimate future data.
+    const dateKey = e.date.toISOString().slice(0, 10);
+    if (!GHOST_DATES.has(dateKey)) continue;
     if (e.runNumber != null && STALE_RUN_NUMBERS.has(e.runNumber)) {
       runNumberHits.push({ id: e.id, date: e.date, runNumber: e.runNumber, title: e.title });
     }
@@ -119,7 +133,12 @@ async function findStaleRawEvents(kennelId: string): Promise<RawEventHit[]> {
     },
     select: { id: true, rawData: true },
   });
-  return raws.map((r) => ({ id: r.id, rawData: r.rawData as Record<string, unknown> }));
+  // Filter to known ghost dates so re-runs can't strip legitimate future
+  // payloads that happen to carry one of these specific stale values
+  // (CodeRabbit PR #1629 review).
+  return raws
+    .map((r) => ({ id: r.id, rawData: r.rawData as Record<string, unknown> }))
+    .filter((r) => typeof r.rawData.date === "string" && GHOST_DATES.has(r.rawData.date));
 }
 
 async function scrubRawEventPayloads(raws: RawEventHit[]): Promise<number> {

--- a/scripts/cleanup-atlanta-canonical-ghosts.ts
+++ b/scripts/cleanup-atlanta-canonical-ghosts.ts
@@ -94,7 +94,9 @@ async function clearEventFields(runNumberHits: RunNumberHit[], startTimeHits: St
   return cleared;
 }
 
-async function scrubRawEventPayloads(kennelId: string): Promise<number> {
+interface RawEventHit { id: string; rawData: Record<string, unknown> }
+
+async function findStaleRawEvents(kennelId: string): Promise<RawEventHit[]> {
   // Find RawEvents whose payload carries the bad runNumber / startTime AND
   // belong to a MLH4 SourceKennel link — so a re-scrape doesn't immediately
   // re-write the wrong values via the same fingerprint.
@@ -103,10 +105,7 @@ async function scrubRawEventPayloads(kennelId: string): Promise<number> {
     select: { sourceId: true },
   });
   const sourceIds = mlh4Sources.map((s) => s.sourceId);
-  if (sourceIds.length === 0) {
-    console.log("\nNo MLH4 sources linked — skipping RawEvent scrub.");
-    return 0;
-  }
+  if (sourceIds.length === 0) return [];
 
   const raws = await prisma.rawEvent.findMany({
     where: {
@@ -120,11 +119,13 @@ async function scrubRawEventPayloads(kennelId: string): Promise<number> {
     },
     select: { id: true, rawData: true },
   });
-  console.log(`\nFound ${raws.length} stale RawEvent rows.`);
+  return raws.map((r) => ({ id: r.id, rawData: r.rawData as Record<string, unknown> }));
+}
 
+async function scrubRawEventPayloads(raws: RawEventHit[]): Promise<number> {
   let scrubbed = 0;
   for (const r of raws) {
-    const d = r.rawData as Record<string, unknown>;
+    const d = r.rawData;
     let dirty = false;
     if (typeof d.runNumber === "number" && STALE_RUN_NUMBERS.has(d.runNumber)) {
       delete d.runNumber;
@@ -159,16 +160,23 @@ async function main() {
   const { runNumberHits, startTimeHits } = await findStaleEvents(kennel.id);
   reportHits(runNumberHits, startTimeHits);
 
+  // Discover RawEvents BEFORE the dry-run early-return so operators see
+  // both layers' impact in dry-run mode (Gemini PR #1629 review).
+  const rawHits = await findStaleRawEvents(kennel.id);
+  console.log(`\nFound ${rawHits.length} stale RawEvent rows.`);
+
   if (!apply) {
     console.log("\nRe-run with APPLY=1 to scrub fields.");
     return;
   }
 
   const cleared = await clearEventFields(runNumberHits, startTimeHits);
-  console.log(`\nCleared ${cleared} field(s).`);
+  console.log(`\nCleared ${cleared} Event field(s).`);
 
-  const scrubbed = await scrubRawEventPayloads(kennel.id);
+  const scrubbed = await scrubRawEventPayloads(rawHits);
   console.log(`Scrubbed ${scrubbed} RawEvent payload(s).`);
 }
 
-main().catch((e) => { console.error(e); process.exit(1); }).finally(() => prisma.$disconnect());
+main()
+  .catch((e) => { console.warn(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-atlanta-canonical-ghosts.ts
+++ b/scripts/cleanup-atlanta-canonical-ghosts.ts
@@ -1,0 +1,155 @@
+/**
+ * Post-merge cleanup for PR #1622 (Atlanta Hash Board parser fix).
+ *
+ * Before the parser fix, the adapter mis-extracted:
+ *   - body `#NNN` tokens from street addresses and cross-kennel references
+ *     (#2000 from "Kroger 8465 Holcomb Bridge Rd #2000", #946 from a Black
+ *     Sheep cross-reference in a Moonlite post) → wrong `runNumber` on
+ *     canonical Event rows;
+ *   - phpBB post-banner timestamps as `startTime` (10:36 PM = last-post
+ *     banner Sat May 02, 3:19 PM = first-post banner Sat Mar 28) → wrong
+ *     `startTime` on canonical Event rows.
+ *
+ * A fresh scrape after merge will produce CORRECT RawEvents but the merge
+ * pipeline upserts canonical Events keyed by (kennelId, date) — and Memory
+ * `feedback_parser_fix_canonical_ghosts` documents that stale fields are
+ * NOT automatically overwritten on UPDATE because the merge pipeline uses
+ * `undefined` (preserve) vs `null` (clear) semantics. A new RawEvent with
+ * `runNumber: 1664` (real number, from a fixed title-prefer path) will
+ * land alongside the old wrong RawEvent and the canonical Event slot
+ * won't be re-seeded with the correct fields until the merge pipeline
+ * re-runs with a strict "drop and rebuild" path.
+ *
+ * Simplest cleanup: scrub the stale `runNumber` and `startTime` on the
+ * affected MLH4 canonical Events. The next scrape (or backfill) then
+ * populates the fields fresh.
+ *
+ * Targets:
+ *   - MLH4 events with `runNumber` ∈ {2000, 946}     → clear runNumber
+ *   - MLH4 events with `startTime` ∈ {22:36, 15:19}  → clear startTime
+ *
+ * We narrow to MLH4 (kennelCode = mlh4) to avoid touching any other
+ * kennel that legitimately runs at 22:36 / 15:19 or has a real run #946 /
+ * #2000.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/cleanup-atlanta-canonical-ghosts.ts
+ *   Apply:    APPLY=1 npx tsx scripts/cleanup-atlanta-canonical-ghosts.ts
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+async function main() {
+  const apply = process.env.APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (writing to prod)" : "DRY RUN"}`);
+
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: "mlh4" },
+    select: { id: true, shortName: true },
+  });
+  if (!kennel) {
+    console.error("mlh4 kennel not found — aborting");
+    process.exit(1);
+  }
+  console.log(`Target kennel: ${kennel.shortName} (id ${kennel.id})\n`);
+
+  // Find candidate Events. EventKennel join gives us per-kennel attribution.
+  const eventKennels = await prisma.eventKennel.findMany({
+    where: { kennelId: kennel.id },
+    select: {
+      event: {
+        select: {
+          id: true, date: true, runNumber: true, startTime: true, title: true, sourceUrl: true,
+        },
+      },
+    },
+  });
+  console.log(`Inspecting ${eventKennels.length} MLH4-linked events…\n`);
+
+  const stallNumbers = new Set([2000, 946]);
+  const stallTimes = new Set(["22:36", "15:19"]);
+
+  const runNumberHits: Array<{ id: string; date: Date; runNumber: number | null; title: string | null }> = [];
+  const startTimeHits: Array<{ id: string; date: Date; startTime: string | null; title: string | null }> = [];
+
+  for (const ek of eventKennels) {
+    const e = ek.event;
+    if (e.runNumber != null && stallNumbers.has(e.runNumber)) {
+      runNumberHits.push({ id: e.id, date: e.date, runNumber: e.runNumber, title: e.title });
+    }
+    if (e.startTime != null && stallTimes.has(e.startTime)) {
+      startTimeHits.push({ id: e.id, date: e.date, startTime: e.startTime, title: e.title });
+    }
+  }
+
+  console.log(`Found ${runNumberHits.length} stale runNumber events:`);
+  for (const h of runNumberHits) {
+    console.log(`  · ${h.date.toISOString().slice(0, 10)} runNumber=${h.runNumber}  title=${h.title ?? "(null)"}`);
+  }
+  console.log(`\nFound ${startTimeHits.length} stale startTime events:`);
+  for (const h of startTimeHits) {
+    console.log(`  · ${h.date.toISOString().slice(0, 10)} startTime=${h.startTime}  title=${h.title ?? "(null)"}`);
+  }
+
+  if (!apply) {
+    console.log("\nRe-run with APPLY=1 to scrub fields.");
+    return;
+  }
+
+  let cleared = 0;
+  for (const h of runNumberHits) {
+    await prisma.event.update({ where: { id: h.id }, data: { runNumber: null } });
+    cleared++;
+  }
+  for (const h of startTimeHits) {
+    await prisma.event.update({ where: { id: h.id }, data: { startTime: null } });
+    cleared++;
+  }
+  console.log(`\nCleared ${cleared} field(s).`);
+
+  // Also scrub the underlying RawEvent rows so a re-scrape doesn't immediately
+  // re-write the wrong values via the same fingerprint. Find RawEvents whose
+  // `data` payload carries the bad runNumber / startTime AND belong to a MLH4
+  // SourceKennel link.
+  const mlh4Sources = await prisma.sourceKennel.findMany({
+    where: { kennelId: kennel.id },
+    select: { sourceId: true },
+  });
+  const sourceIds = mlh4Sources.map((s) => s.sourceId);
+  if (sourceIds.length === 0) {
+    console.log("\nNo MLH4 sources linked — skipping RawEvent scrub.");
+    return;
+  }
+
+  const raws = await prisma.rawEvent.findMany({
+    where: {
+      sourceId: { in: sourceIds },
+      OR: [
+        { rawData: { path: ["runNumber"], equals: 2000 } },
+        { rawData: { path: ["runNumber"], equals: 946 } },
+        { rawData: { path: ["startTime"], equals: "22:36" } },
+        { rawData: { path: ["startTime"], equals: "15:19" } },
+      ],
+    },
+    select: { id: true, rawData: true },
+  });
+  console.log(`\nFound ${raws.length} stale RawEvent rows.`);
+  let scrubbed = 0;
+  for (const r of raws) {
+    const d = r.rawData as Record<string, unknown>;
+    let dirty = false;
+    if (typeof d.runNumber === "number" && stallNumbers.has(d.runNumber)) {
+      delete d.runNumber; dirty = true;
+    }
+    if (typeof d.startTime === "string" && stallTimes.has(d.startTime)) {
+      delete d.startTime; dirty = true;
+    }
+    if (dirty) {
+      await prisma.rawEvent.update({ where: { id: r.id }, data: { rawData: d as never } });
+      scrubbed++;
+    }
+  }
+  console.log(`Scrubbed ${scrubbed} RawEvent payload(s).`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); }).finally(() => prisma.$disconnect());

--- a/scripts/cleanup-atlanta-canonical-ghosts.ts
+++ b/scripts/cleanup-atlanta-canonical-ghosts.ts
@@ -39,49 +39,38 @@
 import "dotenv/config";
 import { prisma } from "@/lib/db";
 
-async function main() {
-  const apply = process.env.APPLY === "1";
-  console.log(`Mode: ${apply ? "APPLY (writing to prod)" : "DRY RUN"}`);
+const STALE_RUN_NUMBERS = new Set([2000, 946]);
+const STALE_START_TIMES = new Set(["22:36", "15:19"]);
 
-  const kennel = await prisma.kennel.findUnique({
-    where: { kennelCode: "mlh4" },
-    select: { id: true, shortName: true },
-  });
-  if (!kennel) {
-    console.error("mlh4 kennel not found — aborting");
-    process.exit(1);
-  }
-  console.log(`Target kennel: ${kennel.shortName} (id ${kennel.id})\n`);
+interface RunNumberHit { id: string; date: Date; runNumber: number | null; title: string | null }
+interface StartTimeHit { id: string; date: Date; startTime: string | null; title: string | null }
 
-  // Find candidate Events. EventKennel join gives us per-kennel attribution.
+async function findStaleEvents(kennelId: string): Promise<{ runNumberHits: RunNumberHit[]; startTimeHits: StartTimeHit[] }> {
   const eventKennels = await prisma.eventKennel.findMany({
-    where: { kennelId: kennel.id },
+    where: { kennelId },
     select: {
       event: {
-        select: {
-          id: true, date: true, runNumber: true, startTime: true, title: true, sourceUrl: true,
-        },
+        select: { id: true, date: true, runNumber: true, startTime: true, title: true, sourceUrl: true },
       },
     },
   });
   console.log(`Inspecting ${eventKennels.length} MLH4-linked events…\n`);
 
-  const stallNumbers = new Set([2000, 946]);
-  const stallTimes = new Set(["22:36", "15:19"]);
-
-  const runNumberHits: Array<{ id: string; date: Date; runNumber: number | null; title: string | null }> = [];
-  const startTimeHits: Array<{ id: string; date: Date; startTime: string | null; title: string | null }> = [];
-
+  const runNumberHits: RunNumberHit[] = [];
+  const startTimeHits: StartTimeHit[] = [];
   for (const ek of eventKennels) {
     const e = ek.event;
-    if (e.runNumber != null && stallNumbers.has(e.runNumber)) {
+    if (e.runNumber != null && STALE_RUN_NUMBERS.has(e.runNumber)) {
       runNumberHits.push({ id: e.id, date: e.date, runNumber: e.runNumber, title: e.title });
     }
-    if (e.startTime != null && stallTimes.has(e.startTime)) {
+    if (e.startTime != null && STALE_START_TIMES.has(e.startTime)) {
       startTimeHits.push({ id: e.id, date: e.date, startTime: e.startTime, title: e.title });
     }
   }
+  return { runNumberHits, startTimeHits };
+}
 
+function reportHits(runNumberHits: RunNumberHit[], startTimeHits: StartTimeHit[]): void {
   console.log(`Found ${runNumberHits.length} stale runNumber events:`);
   for (const h of runNumberHits) {
     console.log(`  · ${h.date.toISOString().slice(0, 10)} runNumber=${h.runNumber}  title=${h.title ?? "(null)"}`);
@@ -90,12 +79,9 @@ async function main() {
   for (const h of startTimeHits) {
     console.log(`  · ${h.date.toISOString().slice(0, 10)} startTime=${h.startTime}  title=${h.title ?? "(null)"}`);
   }
+}
 
-  if (!apply) {
-    console.log("\nRe-run with APPLY=1 to scrub fields.");
-    return;
-  }
-
+async function clearEventFields(runNumberHits: RunNumberHit[], startTimeHits: StartTimeHit[]): Promise<number> {
   let cleared = 0;
   for (const h of runNumberHits) {
     await prisma.event.update({ where: { id: h.id }, data: { runNumber: null } });
@@ -105,20 +91,21 @@ async function main() {
     await prisma.event.update({ where: { id: h.id }, data: { startTime: null } });
     cleared++;
   }
-  console.log(`\nCleared ${cleared} field(s).`);
+  return cleared;
+}
 
-  // Also scrub the underlying RawEvent rows so a re-scrape doesn't immediately
-  // re-write the wrong values via the same fingerprint. Find RawEvents whose
-  // `data` payload carries the bad runNumber / startTime AND belong to a MLH4
-  // SourceKennel link.
+async function scrubRawEventPayloads(kennelId: string): Promise<number> {
+  // Find RawEvents whose payload carries the bad runNumber / startTime AND
+  // belong to a MLH4 SourceKennel link — so a re-scrape doesn't immediately
+  // re-write the wrong values via the same fingerprint.
   const mlh4Sources = await prisma.sourceKennel.findMany({
-    where: { kennelId: kennel.id },
+    where: { kennelId },
     select: { sourceId: true },
   });
   const sourceIds = mlh4Sources.map((s) => s.sourceId);
   if (sourceIds.length === 0) {
     console.log("\nNo MLH4 sources linked — skipping RawEvent scrub.");
-    return;
+    return 0;
   }
 
   const raws = await prisma.rawEvent.findMany({
@@ -134,21 +121,53 @@ async function main() {
     select: { id: true, rawData: true },
   });
   console.log(`\nFound ${raws.length} stale RawEvent rows.`);
+
   let scrubbed = 0;
   for (const r of raws) {
     const d = r.rawData as Record<string, unknown>;
     let dirty = false;
-    if (typeof d.runNumber === "number" && stallNumbers.has(d.runNumber)) {
-      delete d.runNumber; dirty = true;
+    if (typeof d.runNumber === "number" && STALE_RUN_NUMBERS.has(d.runNumber)) {
+      delete d.runNumber;
+      dirty = true;
     }
-    if (typeof d.startTime === "string" && stallTimes.has(d.startTime)) {
-      delete d.startTime; dirty = true;
+    if (typeof d.startTime === "string" && STALE_START_TIMES.has(d.startTime)) {
+      delete d.startTime;
+      dirty = true;
     }
     if (dirty) {
       await prisma.rawEvent.update({ where: { id: r.id }, data: { rawData: d as never } });
       scrubbed++;
     }
   }
+  return scrubbed;
+}
+
+async function main() {
+  const apply = process.env.APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (writing to prod)" : "DRY RUN"}`);
+
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: "mlh4" },
+    select: { id: true, shortName: true },
+  });
+  if (!kennel) {
+    console.error("mlh4 kennel not found — aborting");
+    process.exit(1);
+  }
+  console.log(`Target kennel: ${kennel.shortName} (id ${kennel.id})\n`);
+
+  const { runNumberHits, startTimeHits } = await findStaleEvents(kennel.id);
+  reportHits(runNumberHits, startTimeHits);
+
+  if (!apply) {
+    console.log("\nRe-run with APPLY=1 to scrub fields.");
+    return;
+  }
+
+  const cleared = await clearEventFields(runNumberHits, startTimeHits);
+  console.log(`\nCleared ${cleared} field(s).`);
+
+  const scrubbed = await scrubRawEventPayloads(kennel.id);
   console.log(`Scrubbed ${scrubbed} RawEvent payload(s).`);
 }
 

--- a/scripts/fix-atlanta-stale-profile-fields.ts
+++ b/scripts/fix-atlanta-stale-profile-fields.ts
@@ -66,17 +66,13 @@ const UPDATES: FieldUpdate[] = [
     issue: "#1585",
   },
 
-  // #1582 CUNT H3 ATL
+  // #1582 CUNT H3 ATL — only scheduleNotes needs updating; description is
+  // already correct (Gemini PR #1629 review: dropped the no-op description
+  // entry that was an artifact of copying the structure from other kennels).
   {
     kennelCode: "cunth3-atl", field: "scheduleNotes",
     expectStale: "1st Tuesday, 7:00 PM.",
     setTo: "1st Tuesday of the month.",
-    issue: "#1582",
-  },
-  {
-    kennelCode: "cunth3-atl", field: "description",
-    expectStale: "Monthly Tuesday evening trail in Atlanta.",
-    setTo: "Monthly Tuesday evening trail in Atlanta.",
     issue: "#1582",
   },
 ];

--- a/scripts/fix-atlanta-stale-profile-fields.ts
+++ b/scripts/fix-atlanta-stale-profile-fields.ts
@@ -1,0 +1,126 @@
+/**
+ * Post-merge data fix for PR #1622 Atlanta cluster.
+ *
+ * `npx prisma db seed` only fills NULL profile fields (memory
+ * `feedback_seed_fill_coverage_check`). Several profile-bundle issues
+ * (#1572, #1585, #1582, #1589) required updating fields that already had
+ * stale non-null values on prod — those would be silently skipped by seed.
+ *
+ * This script force-overwrites those specific fields. Each UPDATE is
+ * idempotent: re-running is a no-op (Prisma generates a no-op SQL when
+ * the desired value matches stored).
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/fix-atlanta-stale-profile-fields.ts
+ *   Apply:    APPLY=1 npx tsx scripts/fix-atlanta-stale-profile-fields.ts
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+interface FieldUpdate {
+  kennelCode: string;
+  field: "scheduleTime" | "scheduleNotes" | "description";
+  expectStale: string;
+  setTo: string;
+  issue: string;
+}
+
+const UPDATES: FieldUpdate[] = [
+  // #1572 Black Sheep
+  {
+    kennelCode: "bsh3", field: "scheduleTime",
+    expectStale: "1:30 PM", setTo: "1:00 PM", issue: "#1572",
+  },
+  {
+    kennelCode: "bsh3", field: "description",
+    expectStale: "Alternate Sunday runs in Atlanta.",
+    setTo:
+      "Alternate Sunday high-shiggy trails in Atlanta — also known as Rainbow Sheep, where any color of the rainbow is fine as long as it's black. Come for the shiggy; stay for more shiggy. Hash cash $10.",
+    issue: "#1572",
+  },
+
+  // #1589 MLH4
+  {
+    kennelCode: "mlh4", field: "scheduleTime",
+    expectStale: "7:00 PM", setTo: "7:25 PM", issue: "#1589",
+  },
+  {
+    kennelCode: "mlh4", field: "description",
+    expectStale: "Weekly Monday evening trail runs in Atlanta.",
+    setTo:
+      "Monday evenings under the moonlight in Atlanta. Typically an A-to-A trail of four-ish miles, ending at a bar or restaurant that will put up with us on a Monday.",
+    issue: "#1589",
+  },
+
+  // #1585 HMH3
+  {
+    kennelCode: "hmh3", field: "scheduleNotes",
+    expectStale: "1st Sunday, 1:30 PM.",
+    setTo: "1st (occasionally 2nd) Sunday of the month.",
+    issue: "#1585",
+  },
+  {
+    kennelCode: "hmh3", field: "description",
+    expectStale: "Monthly Sunday runs in the north Georgia foothills.",
+    setTo: "Monthly Sunday trails in the north Georgia foothills outside Atlanta.",
+    issue: "#1585",
+  },
+
+  // #1582 CUNT H3 ATL
+  {
+    kennelCode: "cunth3-atl", field: "scheduleNotes",
+    expectStale: "1st Tuesday, 7:00 PM.",
+    setTo: "1st Tuesday of the month.",
+    issue: "#1582",
+  },
+  {
+    kennelCode: "cunth3-atl", field: "description",
+    expectStale: "Monthly Tuesday evening trail in Atlanta.",
+    setTo: "Monthly Tuesday evening trail in Atlanta.",
+    issue: "#1582",
+  },
+];
+
+async function main() {
+  const apply = process.env.APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (writing to prod)" : "DRY RUN"}`);
+  console.log(`Plan: ${UPDATES.length} field updates across ${new Set(UPDATES.map((u) => u.kennelCode)).size} kennels.\n`);
+
+  for (const u of UPDATES) {
+    const k = await prisma.kennel.findUnique({
+      where: { kennelCode: u.kennelCode },
+      select: { id: true, shortName: true, [u.field]: true } as never,
+    }) as { id: string; shortName: string; [k: string]: string | null } | null;
+
+    if (!k) {
+      console.warn(`  ✗ ${u.kennelCode} not found — skipping`);
+      continue;
+    }
+    const current = k[u.field] ?? "(null)";
+    if (current === u.setTo) {
+      console.log(`  · ${u.kennelCode}.${u.field} (${u.issue}): already correct — no-op`);
+      continue;
+    }
+    if (current !== u.expectStale) {
+      console.warn(
+        `  ⚠ ${u.kennelCode}.${u.field} (${u.issue}): stored value diverges from expected stale value\n` +
+          `      expected stale: ${JSON.stringify(u.expectStale)}\n` +
+          `      stored:         ${JSON.stringify(current)}\n` +
+          `      → refusing to overwrite (drift between issue body and prod). Investigate before forcing.`,
+      );
+      continue;
+    }
+
+    console.log(`  ${apply ? "✓" : "→"} ${u.kennelCode}.${u.field} (${u.issue}): ${JSON.stringify(current)} → ${JSON.stringify(u.setTo)}`);
+    if (apply) {
+      await prisma.kennel.update({
+        where: { id: k.id },
+        data: { [u.field]: u.setTo },
+      });
+    }
+  }
+
+  if (!apply) console.log("\nRe-run with APPLY=1 to write to prod.");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); }).finally(() => prisma.$disconnect());

--- a/scripts/scrub-mlh4-420-followup.ts
+++ b/scripts/scrub-mlh4-420-followup.ts
@@ -62,4 +62,6 @@ async function main() {
   }
   console.log(`Event.runNumber cleared. ${scrubbed} RawEvent payload(s) scrubbed.`);
 }
-main().finally(() => prisma.$disconnect());
+main()
+  .catch((e) => { console.warn(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/scripts/scrub-mlh4-420-followup.ts
+++ b/scripts/scrub-mlh4-420-followup.ts
@@ -1,0 +1,65 @@
+/**
+ * Post-PR-#1622 follow-up: scrub the runNumber=420 leftover on the 2026-04-20
+ * MLH4 event ("🌕 Monday Moonlite – 4/20 Edition").
+ *
+ * Background: the parser fix from #1587 correctly rejected the documented
+ * stale matches (#2000 from a street address, #946 from a Black Sheep
+ * cross-reference). But the body of this particular trail post evidently
+ * contains a literal "Run #420" or "Run 420" joke phrase (consistent with
+ * the $1 hash cash and the 4/20 theme), which now passes the tightened
+ * `\bRun[\s#]+(\d{2,})\b` regex. The real MLH4 run number on that date
+ * was in the high-1600s.
+ *
+ * Long-term, a sanity check against the kennel's last-known runNumber
+ * (e.g. reject body matches more than ±50 from rolling expected) would
+ * stop joke-numbered posts from polluting LATEST RUN. Tracked as a
+ * follow-up consideration; not in scope for this PR.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+async function main() {
+  const apply = process.env.APPLY === "1";
+  const k = await prisma.kennel.findUnique({ where: { kennelCode: "mlh4" }, select: { id: true } });
+  if (!k) { console.log("MLH4 not found"); return; }
+
+  const target = new Date("2026-04-20T12:00:00Z");
+  const ek = await prisma.eventKennel.findFirst({
+    where: { kennelId: k.id, event: { date: target } },
+    select: { event: { select: { id: true, title: true, runNumber: true } } },
+  });
+  if (!ek) { console.log("no 2026-04-20 event found"); return; }
+  const e = ek.event;
+  console.log(`Target: id=${e.id} title=${e.title} runNumber=${e.runNumber}`);
+  if (e.runNumber == null) { console.log("already cleared — no-op"); return; }
+
+  // Find and scrub the matching RawEvent payload to prevent the next scrape
+  // from re-writing the same wrong value.
+  const sks = await prisma.sourceKennel.findMany({ where: { kennelId: k.id }, select: { sourceId: true } });
+  const raws = await prisma.rawEvent.findMany({
+    where: {
+      sourceId: { in: sks.map((s) => s.sourceId) },
+      rawData: { path: ["date"], equals: "2026-04-20" },
+    },
+    select: { id: true, rawData: true },
+  });
+  console.log(`Found ${raws.length} matching RawEvents for 2026-04-20.`);
+
+  if (!apply) {
+    console.log("\nDry run — re-run with APPLY=1 to scrub.");
+    return;
+  }
+
+  await prisma.event.update({ where: { id: e.id }, data: { runNumber: null } });
+  let scrubbed = 0;
+  for (const r of raws) {
+    const d = r.rawData as Record<string, unknown>;
+    if (typeof d.runNumber === "number" && d.runNumber === 420) {
+      delete d.runNumber;
+      await prisma.rawEvent.update({ where: { id: r.id }, data: { rawData: d as never } });
+      scrubbed++;
+    }
+  }
+  console.log(`Event.runNumber cleared. ${scrubbed} RawEvent payload(s) scrubbed.`);
+}
+main().finally(() => prisma.$disconnect());

--- a/scripts/scrub-mlh4-420-followup.ts
+++ b/scripts/scrub-mlh4-420-followup.ts
@@ -23,15 +23,32 @@ async function main() {
   const k = await prisma.kennel.findUnique({ where: { kennelCode: "mlh4" }, select: { id: true } });
   if (!k) { console.log("MLH4 not found"); return; }
 
+  // Predicate-driven find: ONLY targets Events whose runNumber is still 420.
+  // Codex review (#1629) caught two issues with the prior shape:
+  //   (P1) The old code nulled `runNumber` whenever the row had any non-null
+  //        value, so a re-run after a legitimate backfill (say, runNumber=1665)
+  //        would erase the real number.
+  //   (P2) `findFirst({kennelId, date})` returns an arbitrary matching row when
+  //        multiple Events exist for the same kennel/date (conflict/audit
+  //        cases). Combining the date AND the stale-value predicate makes the
+  //        target deterministic: there's at most one row matching both.
   const target = new Date("2026-04-20T12:00:00Z");
-  const ek = await prisma.eventKennel.findFirst({
-    where: { kennelId: k.id, event: { date: target } },
+  const eks = await prisma.eventKennel.findMany({
+    where: { kennelId: k.id, event: { date: target, runNumber: 420 } },
     select: { event: { select: { id: true, title: true, runNumber: true } } },
   });
-  if (!ek) { console.log("no 2026-04-20 event found"); return; }
-  const e = ek.event;
-  console.log(`Target: id=${e.id} title=${e.title} runNumber=${e.runNumber}`);
-  if (e.runNumber == null) { console.log("already cleared — no-op"); return; }
+  if (eks.length === 0) {
+    console.log("no 2026-04-20 MLH4 event with runNumber=420 found — already clean, no-op");
+  } else if (eks.length > 1) {
+    console.warn(`⚠ Found ${eks.length} matching events — refusing to write to avoid wrong-row scrub.`);
+    for (const ek of eks) console.warn(`  · id=${ek.event.id} title=${ek.event.title}`);
+    return;
+  }
+
+  const targetEvent = eks[0]?.event;
+  if (targetEvent) {
+    console.log(`Target: id=${targetEvent.id} title=${targetEvent.title} runNumber=${targetEvent.runNumber}`);
+  }
 
   // Find and scrub the matching RawEvent payload to prevent the next scrape
   // from re-writing the same wrong value.
@@ -43,24 +60,28 @@ async function main() {
     },
     select: { id: true, rawData: true },
   });
-  console.log(`Found ${raws.length} matching RawEvents for 2026-04-20.`);
+  const rawsCarrying420 = raws.filter((r) => {
+    const d = r.rawData as Record<string, unknown>;
+    return typeof d.runNumber === "number" && d.runNumber === 420;
+  });
+  console.log(`Found ${raws.length} RawEvents for 2026-04-20 (${rawsCarrying420.length} carry runNumber=420).`);
 
   if (!apply) {
     console.log("\nDry run — re-run with APPLY=1 to scrub.");
     return;
   }
 
-  await prisma.event.update({ where: { id: e.id }, data: { runNumber: null } });
-  let scrubbed = 0;
-  for (const r of raws) {
-    const d = r.rawData as Record<string, unknown>;
-    if (typeof d.runNumber === "number" && d.runNumber === 420) {
-      delete d.runNumber;
-      await prisma.rawEvent.update({ where: { id: r.id }, data: { rawData: d as never } });
-      scrubbed++;
-    }
+  if (targetEvent) {
+    await prisma.event.update({ where: { id: targetEvent.id }, data: { runNumber: null } });
   }
-  console.log(`Event.runNumber cleared. ${scrubbed} RawEvent payload(s) scrubbed.`);
+  let scrubbed = 0;
+  for (const r of rawsCarrying420) {
+    const d = r.rawData as Record<string, unknown>;
+    delete d.runNumber;
+    await prisma.rawEvent.update({ where: { id: r.id }, data: { rawData: d as never } });
+    scrubbed++;
+  }
+  console.log(`Event.runNumber cleared: ${targetEvent ? "yes" : "no-op"}. ${scrubbed} RawEvent payload(s) scrubbed.`);
 }
 main()
   .catch((e) => { console.warn(e); process.exit(1); })

--- a/scripts/verify-atlanta-post-merge.ts
+++ b/scripts/verify-atlanta-post-merge.ts
@@ -113,4 +113,6 @@ async function main() {
     await printLatestRunNumber(mlh4.id);
   }
 }
-main().finally(() => prisma.$disconnect());
+main()
+  .catch((e) => { console.warn(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/scripts/verify-atlanta-post-merge.ts
+++ b/scripts/verify-atlanta-post-merge.ts
@@ -54,17 +54,25 @@ async function verifySourceUrls(): Promise<void> {
 async function verifyGhostEvents(mlh4Id: string): Promise<void> {
   console.log("\n═══ MLH4 ghost-events spot check ═══\n");
   for (const date of MLH4_GHOST_DATES) {
-    const ek = await prisma.eventKennel.findFirst({
+    // findMany not findFirst — multiple Event rows can exist for a single
+    // kennel/date in conflict/audit cases. If any of them still carries a
+    // wrong value, the date isn't clean (CodeRabbit PR #1629 review).
+    const eks = await prisma.eventKennel.findMany({
       where: { kennelId: mlh4Id, event: { date: new Date(date + "T12:00:00Z") } },
-      select: { event: { select: { runNumber: true, startTime: true, title: true } } },
+      select: { event: { select: { id: true, runNumber: true, startTime: true, title: true } } },
     });
-    if (!ek) { console.log(`  ${date}: (no event)`); continue; }
-    const { runNumber, startTime, title } = ek.event;
-    const wrong = (runNumber != null && WRONG_RUN_NUMBERS.has(runNumber))
-      || (startTime != null && WRONG_START_TIMES.has(startTime));
+    if (eks.length === 0) { console.log(`  ${date}: (no event)`); continue; }
+    const wrong = eks.some(({ event }) =>
+      (event.runNumber != null && WRONG_RUN_NUMBERS.has(event.runNumber))
+      || (event.startTime != null && WRONG_START_TIMES.has(event.startTime))
+    );
     const status = wrong ? "✗ STILL WRONG" : "✓ clean";
-    console.log(`  ${date}  runNumber=${runNumber ?? "(null)"}  startTime=${startTime ?? "(null)"}  ${status}`);
-    console.log(`           ${(title ?? "").slice(0, 60)}`);
+    console.log(`  ${date}  rows=${eks.length}  ${status}`);
+    for (const { event } of eks) {
+      console.log(
+        `           id=${event.id}  runNumber=${event.runNumber ?? "(null)"}  startTime=${event.startTime ?? "(null)"}  ${(event.title ?? "").slice(0, 60)}`,
+      );
+    }
   }
 }
 

--- a/scripts/verify-atlanta-post-merge.ts
+++ b/scripts/verify-atlanta-post-merge.ts
@@ -1,0 +1,95 @@
+/**
+ * Post-merge live verification for PR #1622.
+ * Reads from prod via DATABASE_URL — no network calls to hashtracks.xyz itself.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+async function main() {
+  const codes = ["bsh3", "mlh4", "hmh3", "cunth3-atl"];
+
+  console.log("═══ Profile-field verification ═══\n");
+  for (const code of codes) {
+    const k = await prisma.kennel.findUnique({
+      where: { kennelCode: code },
+      select: {
+        shortName: true,
+        scheduleDayOfWeek: true, scheduleTime: true, scheduleNotes: true,
+        hashCash: true, description: true,
+        aliases: { select: { alias: true } },
+      },
+    });
+    if (!k) continue;
+    console.log(`▸ ${k.shortName} (${code})`);
+    console.log(`    day: ${k.scheduleDayOfWeek ?? "(null)"} | time: ${k.scheduleTime ?? "(null)"} | hashCash: ${k.hashCash ?? "(null)"}`);
+    if (k.scheduleNotes) console.log(`    notes: ${k.scheduleNotes}`);
+    console.log(`    description: ${(k.description ?? "").slice(0, 110)}${(k.description?.length ?? 0) > 110 ? "…" : ""}`);
+    if (code === "bsh3") {
+      const hasRainbow = k.aliases.some((a) => a.alias === "Rainbow Sheep");
+      console.log(`    Rainbow Sheep alias: ${hasRainbow ? "✓ present" : "✗ MISSING"}`);
+    }
+    console.log("");
+  }
+
+  console.log("═══ Source URLs (dead-anchor fix) ═══\n");
+  const srcs = await prisma.source.findMany({
+    where: { name: { in: ["HMH3 Static Schedule", "CUNT H3 ATL Static Schedule"] } },
+    select: { name: true, url: true },
+    orderBy: { name: "asc" },
+  });
+  for (const s of srcs) {
+    const ok = !s.url.includes("#");
+    console.log(`▸ ${s.name}: ${s.url} ${ok ? "✓" : "✗ DEAD ANCHOR"}`);
+  }
+
+  console.log("\n═══ MLH4 ghost-events spot check ═══\n");
+  const mlh4 = await prisma.kennel.findUnique({ where: { kennelCode: "mlh4" }, select: { id: true } });
+  if (mlh4) {
+    const ghostDates = ["2026-03-30", "2026-04-20", "2026-05-04", "2026-05-11"];
+    for (const date of ghostDates) {
+      const ek = await prisma.eventKennel.findFirst({
+        where: { kennelId: mlh4.id, event: { date: new Date(date + "T12:00:00Z") } },
+        select: { event: { select: { runNumber: true, startTime: true, title: true } } },
+      });
+      if (!ek) { console.log(`  ${date}: (no event)`); continue; }
+      const { runNumber, startTime, title } = ek.event;
+      // Original wrong values: 2000, 946, 22:36, 15:19
+      const wrongRun = runNumber != null && [946, 2000, 420].includes(runNumber);
+      const wrongTime = startTime != null && ["22:36", "15:19"].includes(startTime);
+      const status = (wrongRun || wrongTime) ? "✗ STILL WRONG" : "✓ clean";
+      console.log(`  ${date}  runNumber=${runNumber ?? "(null)"}  startTime=${startTime ?? "(null)"}  ${status}`);
+      console.log(`           ${(title ?? "").slice(0, 60)}`);
+    }
+  }
+
+  console.log("\n═══ Event counts ═══\n");
+  for (const code of ["mlh4", "bsh3"]) {
+    const k = await prisma.kennel.findUnique({ where: { kennelCode: code }, select: { id: true, shortName: true } });
+    if (!k) continue;
+    const total = await prisma.eventKennel.count({ where: { kennelId: k.id } });
+    const past = await prisma.eventKennel.count({ where: { kennelId: k.id, event: { date: { lt: new Date() } } } });
+    const future = total - past;
+    console.log(`▸ ${k.shortName}: ${total} total (${past} past, ${future} upcoming)`);
+  }
+
+  console.log("\n═══ MLH4 latest run number ═══\n");
+  if (mlh4) {
+    // Latest = highest runNumber among events with non-null runNumber.
+    const withRunNo = await prisma.eventKennel.findMany({
+      where: { kennelId: mlh4.id, event: { runNumber: { not: null } } },
+      select: { event: { select: { date: true, runNumber: true, title: true } } },
+      orderBy: { event: { date: "desc" } },
+      take: 5,
+    });
+    if (withRunNo.length === 0) {
+      console.log("  (no events with runNumber set)");
+    } else {
+      console.log("  date        runNo  title");
+      for (const ek of withRunNo) {
+        const e = ek.event;
+        console.log(`  ${e.date.toISOString().slice(0, 10)}  ${String(e.runNumber).padEnd(5)}  ${(e.title ?? "").slice(0, 60)}`);
+      }
+    }
+  }
+}
+main().finally(() => prisma.$disconnect());

--- a/scripts/verify-atlanta-post-merge.ts
+++ b/scripts/verify-atlanta-post-merge.ts
@@ -5,11 +5,15 @@
 import "dotenv/config";
 import { prisma } from "@/lib/db";
 
-async function main() {
-  const codes = ["bsh3", "mlh4", "hmh3", "cunth3-atl"];
+const KENNEL_CODES = ["bsh3", "mlh4", "hmh3", "cunth3-atl"];
+const ATL_SOURCE_NAMES = ["HMH3 Static Schedule", "CUNT H3 ATL Static Schedule"];
+const MLH4_GHOST_DATES = ["2026-03-30", "2026-04-20", "2026-05-04", "2026-05-11"];
+const WRONG_RUN_NUMBERS = new Set([946, 2000, 420]);
+const WRONG_START_TIMES = new Set(["22:36", "15:19"]);
 
+async function verifyProfileFields(): Promise<void> {
   console.log("═══ Profile-field verification ═══\n");
-  for (const code of codes) {
+  for (const code of KENNEL_CODES) {
     const k = await prisma.kennel.findUnique({
       where: { kennelCode: code },
       select: {
@@ -20,20 +24,24 @@ async function main() {
       },
     });
     if (!k) continue;
+    const descSnippet = (k.description ?? "").slice(0, 110);
+    const descEllipsis = (k.description?.length ?? 0) > 110 ? "…" : "";
     console.log(`▸ ${k.shortName} (${code})`);
     console.log(`    day: ${k.scheduleDayOfWeek ?? "(null)"} | time: ${k.scheduleTime ?? "(null)"} | hashCash: ${k.hashCash ?? "(null)"}`);
     if (k.scheduleNotes) console.log(`    notes: ${k.scheduleNotes}`);
-    console.log(`    description: ${(k.description ?? "").slice(0, 110)}${(k.description?.length ?? 0) > 110 ? "…" : ""}`);
+    console.log(`    description: ${descSnippet}${descEllipsis}`);
     if (code === "bsh3") {
       const hasRainbow = k.aliases.some((a) => a.alias === "Rainbow Sheep");
       console.log(`    Rainbow Sheep alias: ${hasRainbow ? "✓ present" : "✗ MISSING"}`);
     }
     console.log("");
   }
+}
 
+async function verifySourceUrls(): Promise<void> {
   console.log("═══ Source URLs (dead-anchor fix) ═══\n");
   const srcs = await prisma.source.findMany({
-    where: { name: { in: ["HMH3 Static Schedule", "CUNT H3 ATL Static Schedule"] } },
+    where: { name: { in: ATL_SOURCE_NAMES } },
     select: { name: true, url: true },
     orderBy: { name: "asc" },
   });
@@ -41,55 +49,68 @@ async function main() {
     const ok = !s.url.includes("#");
     console.log(`▸ ${s.name}: ${s.url} ${ok ? "✓" : "✗ DEAD ANCHOR"}`);
   }
+}
 
+async function verifyGhostEvents(mlh4Id: string): Promise<void> {
   console.log("\n═══ MLH4 ghost-events spot check ═══\n");
-  const mlh4 = await prisma.kennel.findUnique({ where: { kennelCode: "mlh4" }, select: { id: true } });
-  if (mlh4) {
-    const ghostDates = ["2026-03-30", "2026-04-20", "2026-05-04", "2026-05-11"];
-    for (const date of ghostDates) {
-      const ek = await prisma.eventKennel.findFirst({
-        where: { kennelId: mlh4.id, event: { date: new Date(date + "T12:00:00Z") } },
-        select: { event: { select: { runNumber: true, startTime: true, title: true } } },
-      });
-      if (!ek) { console.log(`  ${date}: (no event)`); continue; }
-      const { runNumber, startTime, title } = ek.event;
-      // Original wrong values: 2000, 946, 22:36, 15:19
-      const wrongRun = runNumber != null && [946, 2000, 420].includes(runNumber);
-      const wrongTime = startTime != null && ["22:36", "15:19"].includes(startTime);
-      const status = (wrongRun || wrongTime) ? "✗ STILL WRONG" : "✓ clean";
-      console.log(`  ${date}  runNumber=${runNumber ?? "(null)"}  startTime=${startTime ?? "(null)"}  ${status}`);
-      console.log(`           ${(title ?? "").slice(0, 60)}`);
-    }
+  for (const date of MLH4_GHOST_DATES) {
+    const ek = await prisma.eventKennel.findFirst({
+      where: { kennelId: mlh4Id, event: { date: new Date(date + "T12:00:00Z") } },
+      select: { event: { select: { runNumber: true, startTime: true, title: true } } },
+    });
+    if (!ek) { console.log(`  ${date}: (no event)`); continue; }
+    const { runNumber, startTime, title } = ek.event;
+    const wrong = (runNumber != null && WRONG_RUN_NUMBERS.has(runNumber))
+      || (startTime != null && WRONG_START_TIMES.has(startTime));
+    const status = wrong ? "✗ STILL WRONG" : "✓ clean";
+    console.log(`  ${date}  runNumber=${runNumber ?? "(null)"}  startTime=${startTime ?? "(null)"}  ${status}`);
+    console.log(`           ${(title ?? "").slice(0, 60)}`);
   }
+}
 
+async function printEventCounts(): Promise<void> {
   console.log("\n═══ Event counts ═══\n");
+  const now = new Date();
   for (const code of ["mlh4", "bsh3"]) {
     const k = await prisma.kennel.findUnique({ where: { kennelCode: code }, select: { id: true, shortName: true } });
     if (!k) continue;
     const total = await prisma.eventKennel.count({ where: { kennelId: k.id } });
-    const past = await prisma.eventKennel.count({ where: { kennelId: k.id, event: { date: { lt: new Date() } } } });
+    const past = await prisma.eventKennel.count({ where: { kennelId: k.id, event: { date: { lt: now } } } });
     const future = total - past;
     console.log(`▸ ${k.shortName}: ${total} total (${past} past, ${future} upcoming)`);
   }
+}
 
+async function printLatestRunNumber(mlh4Id: string): Promise<void> {
   console.log("\n═══ MLH4 latest run number ═══\n");
+  const withRunNo = await prisma.eventKennel.findMany({
+    where: { kennelId: mlh4Id, event: { runNumber: { not: null } } },
+    select: { event: { select: { date: true, runNumber: true, title: true } } },
+    orderBy: { event: { date: "desc" } },
+    take: 5,
+  });
+  if (withRunNo.length === 0) {
+    console.log("  (no events with runNumber set)");
+    return;
+  }
+  console.log("  date        runNo  title");
+  for (const ek of withRunNo) {
+    const e = ek.event;
+    const runNoStr = String(e.runNumber).padEnd(5);
+    console.log(`  ${e.date.toISOString().slice(0, 10)}  ${runNoStr}  ${(e.title ?? "").slice(0, 60)}`);
+  }
+}
+
+async function main() {
+  await verifyProfileFields();
+  await verifySourceUrls();
+  const mlh4 = await prisma.kennel.findUnique({ where: { kennelCode: "mlh4" }, select: { id: true } });
   if (mlh4) {
-    // Latest = highest runNumber among events with non-null runNumber.
-    const withRunNo = await prisma.eventKennel.findMany({
-      where: { kennelId: mlh4.id, event: { runNumber: { not: null } } },
-      select: { event: { select: { date: true, runNumber: true, title: true } } },
-      orderBy: { event: { date: "desc" } },
-      take: 5,
-    });
-    if (withRunNo.length === 0) {
-      console.log("  (no events with runNumber set)");
-    } else {
-      console.log("  date        runNo  title");
-      for (const ek of withRunNo) {
-        const e = ek.event;
-        console.log(`  ${e.date.toISOString().slice(0, 10)}  ${String(e.runNumber).padEnd(5)}  ${(e.title ?? "").slice(0, 60)}`);
-      }
-    }
+    await verifyGhostEvents(mlh4.id);
+  }
+  await printEventCounts();
+  if (mlh4) {
+    await printLatestRunNumber(mlh4.id);
   }
 }
 main().finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Captures the one-shot data fixes that ran against prod after #1622 merged, plus a reusable verification script. All four were applied to prod before this PR; shipping them as a record + reusable tooling.

- **fix-atlanta-stale-profile-fields.ts** — force-overwrites 7 stale kennel profile fields that \`prisma db seed\` silently skips (Memory \`feedback_seed_fill_coverage_check\`). Black Sheep + MLH4 scheduleTime, HMH3/CUNT H3 scheduleNotes, 3 descriptions.
- **cleanup-atlanta-canonical-ghosts.ts** — scrubs wrong \`runNumber\` (#2000, #946) + \`startTime\` (10:36 PM, 3:19 PM) on canonical MLH4 Events plus underlying RawEvent payloads (Memory \`feedback_parser_fix_canonical_ghosts\`).
- **scrub-mlh4-420-followup.ts** — tail-end edge case discovered during verify: a 4/20-themed Moonlite post evidently contains a literal \"Run #420\" joke phrase that the tightened \`/\\bRun[\\s#]+(\\d{2,})\\b/\` regex correctly catches but is still wrong data.
- **verify-atlanta-post-merge.ts** — read-only verifier across all 10 #1622 acceptance criteria. Re-runnable.

## Post-merge state

All 10 #1622 issues now visibly resolved on prod:
- ✓ 4 kennel profile bundles updated
- ✓ 2 source URLs no longer dead anchors
- ✓ 4 MLH4 ghost events scrubbed; LATEST RUN now shows **1,644** (was 2,000)
- ✓ Wide-window recurring scrape gained **30 new historical events** for the 9-kennel source

## Deferred follow-up (not in this PR)

Deep forum-pagination backfill (\`scripts/backfill-mlh4-history.ts\`, \`scripts/backfill-black-sheep-history.ts\` from #1622) still needs a Vercel-network execution path — \`board.atlantahash.com\` is TCP-unreachable from local + NAS. Targets: ~120 additional MLH4 + ~70 additional Black Sheep historical events. Will run from a working network or via a one-off Vercel CLI exec.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test -- --run\` — 7083 passing, 0 failures
- [x] Scripts ran APPLY=1 against prod with no errors
- [x] \`verify-atlanta-post-merge.ts\` confirms all 10 acceptance criteria post-fix
- [ ] Re-run \`verify-atlanta-post-merge.ts\` after deep backfill lands (target: MLH4 Past tab ≥130, BSH3 Past tab ≥80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)