### PR TITLE
feat(hashrego): DAY M/D section-header parser — #1560 PR B of 2

### DIFF
--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -983,7 +983,7 @@ describe("parseDayHeaderSections", () => {
       expected: ["2026-12-30", "2026-12-31", "2027-01-01", "2027-01-02"],
     },
   ])("$label", ({ desc, anchor, expected }) => {
-    expect(parseDayHeaderSections(desc, anchor)).toEqual(expected);
+    expect(parseDayHeaderSections(desc, anchor).map((e) => e.date)).toEqual(expected);
   });
 
   it("returns [] when only one day header is present (no false-positive series)", () => {
@@ -998,6 +998,38 @@ describe("parseDayHeaderSections", () => {
     // The required `\d+(?::|\s)\s*\d{1,2}/\d{1,2}` tail rules out bare
     // "Day" mentions that aren't day-section headers.
     expect(parseDayHeaderSections("Memorial Day weekend, Day of reckoning.", "2026-05-25")).toEqual([]);
+  });
+
+  // Codex P1 review on PR #1630 — section times stay paired with their
+  // header even when the headers are listed out of chronological order.
+  it("pairs each day's startTime with its own header even when headers are listed out of order", () => {
+    const desc =
+      "**DAY 3 1/17 —** Sunday 12:00 show, 12:30 go.\n" +
+      "**DAY 1 1/15 —** Friday 7:00 show, 7:30 go.\n" +
+      "**DAY 2 1/16 —** Saturday 10:00 show, 10:30 go.";
+    const entries = parseDayHeaderSections(desc, "2026-01-15");
+    // Sorted by date — but each entry carries the time from its own
+    // section, not the time at the matching index in document order.
+    expect(entries.map((e) => e.date)).toEqual([
+      "2026-01-15", "2026-01-16", "2026-01-17",
+    ]);
+    expect(entries.map((e) => e.startTime)).toEqual([
+      "19:00", "10:00", "12:00",
+    ]);
+    // (AM-bias adjustment: hours 1–9 bump to PM (+12). 7:00 → 19:00.
+    // 10:00 and 12:00 are outside the 1–9 range so they stay unchanged.
+    // Matches `extractPerDayStartTimes`' legacy semantics, which biases
+    // hashrego's bare "7:00 show" toward 7 PM but leaves explicit
+    // morning starts like "10:00 go" alone.)
+  });
+
+  it("returns startTime: undefined for a section that has no show/go/start time", () => {
+    const desc = "**DAY 1 4/4 —** Friday (no time given).\n**DAY 2 4/5 —** Saturday 10:00 go.";
+    const entries = parseDayHeaderSections(desc, "2026-04-04");
+    expect(entries).toEqual([
+      { date: "2026-04-04", startTime: undefined },
+      { date: "2026-04-05", startTime: "10:00" },
+    ]);
   });
 });
 

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -774,6 +774,43 @@ const FIVE_BORO_INDEX_ENTRY = {
   cost: "$75",
 };
 
+// #1630 PR B Gemini review — Strategy 1 (`MM/DD ... to MM/DD`) had a
+// silent year-rollover bug. A 12/31 → 1/1 NYE campout would emit endDate
+// before startDate, producing an empty `generateDatesInRange` result.
+const NYE_RANGE_HTML = `
+<html>
+<head>
+  <title>New Year's Eve Campout 2026</title>
+  <meta property="og:title" content="12/31 New Year's Eve Campout 2026" />
+  <meta property="og:description" content='12/31 06:00 PM to 1/1 10:00 AM
+
+Two-day NYE campout — Friday eve trail + Saturday recovery hike.
+
+**Cost:** $50' />
+</head>
+<body>
+  <a href="/kennels/NYCH3/">NYC H3</a>
+</body>
+</html>`;
+
+const NYE_INDEX_ENTRY = {
+  slug: "nye-campout-2026",
+  kennelSlug: "NYCH3",
+  title: "New Year's Eve Campout 2026",
+  startDate: "12/31/26",
+  startTime: "06:00 PM",
+  type: "Hash Weekend",
+  cost: "$50",
+};
+
+describe("parseEventDetail — Strategy 1 NYE year rollover (#1630 review)", () => {
+  it("12/31 → 1/1 range produces 2 dates spanning the year boundary", () => {
+    const parsed = parseEventDetail(NYE_RANGE_HTML, "nye-campout-2026", NYE_INDEX_ENTRY);
+    expect(parsed.isMultiDay).toBe(true);
+    expect(parsed.dates).toEqual(["2026-12-31", "2027-01-01"]);
+  });
+});
+
 describe("parseEventDetail + splitToRawEvents — `DAY N M/D` headers (#1560 PR B)", () => {
   it("recognizes the multi-day description and emits three children", () => {
     const parsed = parseEventDetail(FIVE_BORO_HTML, "5-boro-2026", FIVE_BORO_INDEX_ENTRY);
@@ -902,49 +939,65 @@ describe("parseDayHeaderSections", () => {
     {
       label: "NYC 5-Boro Pub Crawl — markdown bold + em-dash",
       desc: "**DAY 1 1/15 —** Friday night, Manhattan...\n**DAY 2 1/16 —** Saturday brunch, Brooklyn...\n**DAY 3 1/17 —** Sunday recovery, Queens...",
-      year: 2026,
+      anchor: "2026-01-15",
       expected: ["2026-01-15", "2026-01-16", "2026-01-17"],
     },
     {
       label: "Mixed case 'Day N: M/D'",
       desc: "Day 1: 2/14 — Valentine's trail\nDay 2: 2/15 — Recovery brunch",
-      year: 2026,
+      anchor: "2026-02-14",
       expected: ["2026-02-14", "2026-02-15"],
     },
     {
       label: "Bare 'Day N M/D' without colon or em-dash",
       desc: "Day 1 3/21 evening run\nDay 2 3/22 morning hike\nDay 3 3/23 brunch",
-      year: 2026,
+      anchor: "2026-03-21",
       expected: ["2026-03-21", "2026-03-22", "2026-03-23"],
     },
     {
       label: "Sorts mis-ordered headers by date",
       desc: "**DAY 3 1/17 —** Sunday\n**DAY 1 1/15 —** Friday\n**DAY 2 1/16 —** Saturday",
-      year: 2026,
+      anchor: "2026-01-15",
       expected: ["2026-01-15", "2026-01-16", "2026-01-17"],
     },
     {
       label: "Deduplicates same-date headers",
       desc: "**DAY 1 1/15 —** Friday morning\n**DAY 1 1/15 —** Friday evening",
-      year: 2026,
+      anchor: "2026-01-15",
       expected: [],
     },
-  ])("$label", ({ desc, year, expected }) => {
-    expect(parseDayHeaderSections(desc, year)).toEqual(expected);
+    {
+      // Gemini review on PR #1630 — year-rollover regression. Without the
+      // anchor-based year bump the parser would emit Jan 1 alongside Dec
+      // 31 under the SAME year, so the sort would produce the wrong
+      // chronological order.
+      label: "NYE rollover — 12/31 → 1/1 lands in following year",
+      desc: "**DAY 1 12/31 —** Friday NYE\n**DAY 2 1/1 —** Saturday New Year",
+      anchor: "2026-12-31",
+      expected: ["2026-12-31", "2027-01-01"],
+    },
+    {
+      label: "NYE rollover — 12/30 / 12/31 / 1/1 / 1/2 four-day campout",
+      desc: "**DAY 1 12/30 —**\n**DAY 2 12/31 —**\n**DAY 3 1/1 —**\n**DAY 4 1/2 —**",
+      anchor: "2026-12-30",
+      expected: ["2026-12-30", "2026-12-31", "2027-01-01", "2027-01-02"],
+    },
+  ])("$label", ({ desc, anchor, expected }) => {
+    expect(parseDayHeaderSections(desc, anchor)).toEqual(expected);
   });
 
   it("returns [] when only one day header is present (no false-positive series)", () => {
-    expect(parseDayHeaderSections("**DAY 1 4/4 —** opening only", 2026)).toEqual([]);
+    expect(parseDayHeaderSections("**DAY 1 4/4 —** opening only", "2026-04-04")).toEqual([]);
   });
 
   it("returns [] when description has no Day N M/D headers at all", () => {
-    expect(parseDayHeaderSections("Just a normal trail description, no days.", 2026)).toEqual([]);
+    expect(parseDayHeaderSections("Just a normal trail description, no days.", "2026-01-01")).toEqual([]);
   });
 
   it("does not match 'Memorial Day' / 'Day of' / other 'Day' false positives", () => {
-    // The required `\d+\s*:?\s+\d{1,2}/\d{1,2}` tail rules out bare
+    // The required `\d+(?::|\s)\s*\d{1,2}/\d{1,2}` tail rules out bare
     // "Day" mentions that aren't day-section headers.
-    expect(parseDayHeaderSections("Memorial Day weekend, Day of reckoning.", 2026)).toEqual([]);
+    expect(parseDayHeaderSections("Memorial Day weekend, Day of reckoning.", "2026-05-25")).toEqual([]);
   });
 });
 

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -6,6 +6,7 @@ import {
   parseHashRegoTime,
   parseEventDetail,
   splitToRawEvents,
+  parseDayHeaderSections,
 } from "./parser";
 import { HashRegoAdapter, apiToIndexEntry } from "./adapter";
 import { HashRegoApiError, type HashRegoKennelEvent } from "./api";
@@ -741,6 +742,66 @@ const ANTHRAX_INDEX_ENTRY = {
   cost: "$119",
 };
 
+// #1560 PR B — NYC H3 5-Boro Pub Crawl: description uses per-day section
+// headers (`**DAY N M/D —**`) instead of a single `MM/DD ... to MM/DD`
+// range. Pre-PR-B the parser dropped Day 2 / Day 3 silently because no
+// strategy recognized that format. Note the `og:description` is just a
+// teaser — no time-range present — so the existing strategy 1 fails and
+// strategy 2 (parseDayHeaderSections) takes over.
+const FIVE_BORO_HTML = `
+<html>
+<head>
+  <title>5-Boro Pub Crawl 2026</title>
+  <meta property="og:title" content="1/15 5-Boro Pub Crawl 2026" />
+  <meta property="og:description" content='**DAY 1 1/15 —** Friday night, Manhattan kickoff. Hares: Mudflap, Just Simon. 7:00 show, 7:30 go.
+**DAY 2 1/16 —** Saturday morning, Brooklyn run. Hares: Cocktail Sausage. 10:00 show, 10:30 go.
+**DAY 3 1/17 —** Sunday recovery, Queens brunch. Hares: TBD. 12:00 show, 12:30 go.
+
+**Cost:** $75 for all three days' />
+</head>
+<body>
+  <a href="/kennels/NYCH3/">NYC H3</a>
+</body>
+</html>`;
+
+const FIVE_BORO_INDEX_ENTRY = {
+  slug: "5-boro-2026",
+  kennelSlug: "NYCH3",
+  title: "5-Boro Pub Crawl 2026",
+  startDate: "01/15/26",
+  startTime: "07:00 PM",
+  type: "Hash Weekend",
+  cost: "$75",
+};
+
+describe("parseEventDetail + splitToRawEvents — `DAY N M/D` headers (#1560 PR B)", () => {
+  it("recognizes the multi-day description and emits three children", () => {
+    const parsed = parseEventDetail(FIVE_BORO_HTML, "5-boro-2026", FIVE_BORO_INDEX_ENTRY);
+    expect(parsed.isMultiDay).toBe(true);
+    expect(parsed.dates).toEqual(["2026-01-15", "2026-01-16", "2026-01-17"]);
+  });
+
+  it("series parent (Day 1) carries seriesParent + endDate; later days are children", () => {
+    const parsed = parseEventDetail(FIVE_BORO_HTML, "5-boro-2026", FIVE_BORO_INDEX_ENTRY);
+    const events = splitToRawEvents(parsed, "5-boro-2026");
+    expect(events).toHaveLength(3);
+
+    // All three share the slug-based seriesId.
+    expect(events.every((e) => e.seriesId === "5-boro-2026")).toBe(true);
+
+    // Day 1 = parent; carries endDate; title without "(Day N)" suffix.
+    expect(events[0].seriesParent).toBe(true);
+    expect(events[0].endDate).toBe("2026-01-17");
+    expect(events[0].title).not.toContain("(Day");
+
+    // Days 2 + 3 are children.
+    expect(events[1].seriesParent).toBeUndefined();
+    expect(events[1].title).toContain("(Day 2)");
+    expect(events[2].seriesParent).toBeUndefined();
+    expect(events[2].title).toContain("(Day 3)");
+  });
+});
+
 describe("parseEventDetail (multi-day)", () => {
   it("detects multi-day event from date range", () => {
     const parsed = parseEventDetail(MULTI_DAY_HTML, "anthrax-2025", ANTHRAX_INDEX_ENTRY);
@@ -796,12 +857,29 @@ describe("splitToRawEvents", () => {
     expect(events[2].seriesId).toBe("anthrax-2025");
   });
 
-  it("adds day labels to multi-day event titles", () => {
+  it("first day is the series parent (no day suffix); later days carry the suffix", () => {
+    // #1560 PR B — the earliest day represents the whole series, so it
+    // keeps the umbrella title verbatim. Later days get the "(Day N)"
+    // suffix so they're recognizable inside the parent's expanded
+    // timeline.
     const parsed = parseEventDetail(MULTI_DAY_HTML, "anthrax-2025", ANTHRAX_INDEX_ENTRY);
     const events = splitToRawEvents(parsed, "anthrax-2025");
-    expect(events[0].title).toContain("(Day 1)");
+    expect(events[0].title).not.toContain("(Day");
     expect(events[1].title).toContain("(Day 2)");
     expect(events[2].title).toContain("(Day 3)");
+  });
+
+  it("first day is marked seriesParent and carries the inclusive endDate", () => {
+    // #1560 PR B — explicit parent flag + endDate give the UI's
+    // date-range chip + "+ N trails" badge a deterministic anchor.
+    const parsed = parseEventDetail(MULTI_DAY_HTML, "anthrax-2025", ANTHRAX_INDEX_ENTRY);
+    const events = splitToRawEvents(parsed, "anthrax-2025");
+    expect(events[0].seriesParent).toBe(true);
+    expect(events[0].endDate).toBe("2025-12-14");
+    expect(events[1].seriesParent).toBeUndefined();
+    expect(events[1].endDate).toBeUndefined();
+    expect(events[2].seriesParent).toBeUndefined();
+    expect(events[2].endDate).toBeUndefined();
   });
 
   it("all multi-day events share the same Hash Rego link", () => {
@@ -812,6 +890,61 @@ describe("splitToRawEvents", () => {
         { url: "https://hashrego.com/events/anthrax-2025", label: "Hash Rego" },
       ]);
     }
+  });
+});
+
+// ── parseDayHeaderSections (#1560 PR B) ──
+
+describe("parseDayHeaderSections", () => {
+  // Table-driven per memory `feedback_it_each_for_sonar_cpd.md` — single
+  // it() blocks with shared boilerplate would trip CPD.
+  it.each([
+    {
+      label: "NYC 5-Boro Pub Crawl — markdown bold + em-dash",
+      desc: "**DAY 1 1/15 —** Friday night, Manhattan...\n**DAY 2 1/16 —** Saturday brunch, Brooklyn...\n**DAY 3 1/17 —** Sunday recovery, Queens...",
+      year: 2026,
+      expected: ["2026-01-15", "2026-01-16", "2026-01-17"],
+    },
+    {
+      label: "Mixed case 'Day N: M/D'",
+      desc: "Day 1: 2/14 — Valentine's trail\nDay 2: 2/15 — Recovery brunch",
+      year: 2026,
+      expected: ["2026-02-14", "2026-02-15"],
+    },
+    {
+      label: "Bare 'Day N M/D' without colon or em-dash",
+      desc: "Day 1 3/21 evening run\nDay 2 3/22 morning hike\nDay 3 3/23 brunch",
+      year: 2026,
+      expected: ["2026-03-21", "2026-03-22", "2026-03-23"],
+    },
+    {
+      label: "Sorts mis-ordered headers by date",
+      desc: "**DAY 3 1/17 —** Sunday\n**DAY 1 1/15 —** Friday\n**DAY 2 1/16 —** Saturday",
+      year: 2026,
+      expected: ["2026-01-15", "2026-01-16", "2026-01-17"],
+    },
+    {
+      label: "Deduplicates same-date headers",
+      desc: "**DAY 1 1/15 —** Friday morning\n**DAY 1 1/15 —** Friday evening",
+      year: 2026,
+      expected: [],
+    },
+  ])("$label", ({ desc, year, expected }) => {
+    expect(parseDayHeaderSections(desc, year)).toEqual(expected);
+  });
+
+  it("returns [] when only one day header is present (no false-positive series)", () => {
+    expect(parseDayHeaderSections("**DAY 1 4/4 —** opening only", 2026)).toEqual([]);
+  });
+
+  it("returns [] when description has no Day N M/D headers at all", () => {
+    expect(parseDayHeaderSections("Just a normal trail description, no days.", 2026)).toEqual([]);
+  });
+
+  it("does not match 'Memorial Day' / 'Day of' / other 'Day' false positives", () => {
+    // The required `\d+\s*:?\s+\d{1,2}/\d{1,2}` tail rules out bare
+    // "Day" mentions that aren't day-section headers.
+    expect(parseDayHeaderSections("Memorial Day weekend, Day of reckoning.", 2026)).toEqual([]);
   });
 });
 

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -383,7 +383,7 @@ export function splitToRawEvents(
   // UI's date-range chip + "+ N trails" badge render on the parent. Later
   // days are explicit children with their per-day title suffix.
   const seriesId = slug; // Use the Hash Rego slug as series identifier
-  const lastDate = parsed.dates[parsed.dates.length - 1];
+  const lastDate = parsed.dates.at(-1);
   return parsed.dates.map((date, i) => {
     const isParent = i === 0;
     const dayLabel = `Day ${i + 1}`;
@@ -523,10 +523,10 @@ const DAY_HEADER_RE = /\bDay\s+(\d{1,2})(?::|\s)\s*(\d{1,2})\/(\d{1,2})\b/gi;
  *  AM-bias adjustment as `extractPerDayStartTimes` (1–9 → +12 hours;
  *  hashrego writes evening times bare like "7:00 show"). */
 function extractFirstTimeFromSlice(slice: string): string | undefined {
-  const tm = slice.match(/(\d{1,2}):(\d{2})\s+(show|go|start)/i);
+  const tm = /(\d{1,2}):(\d{2})\s+(show|go|start)/i.exec(slice);
   if (!tm) return undefined;
-  const h = parseInt(tm[1], 10);
-  const min = parseInt(tm[2], 10);
+  const h = Number.parseInt(tm[1], 10);
+  const min = Number.parseInt(tm[2], 10);
   const adjustedH = h < 12 && h >= 1 && h <= 9 ? h + 12 : h;
   return `${String(adjustedH).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
 }
@@ -541,7 +541,7 @@ export function parseDayHeaderSections(
   description: string,
   startDateStr: string,
 ): DayHeaderSection[] {
-  const baseYear = parseInt(startDateStr.split("-")[0], 10);
+  const baseYear = Number.parseInt(startDateStr.split("-")[0], 10);
   if (!baseYear) return [];
   const matches = [...description.matchAll(DAY_HEADER_RE)];
   if (matches.length < 2) return [];
@@ -555,8 +555,8 @@ export function parseDayHeaderSections(
   // returned times in raw doc order and the caller paired them by index
   // into the sorted dates, silently shuffling them).
   const entries: DayHeaderSection[] = matches.map((m, i) => {
-    const month = parseInt(m[2], 10);
-    const day = parseInt(m[3], 10);
+    const month = Number.parseInt(m[2], 10);
+    const day = Number.parseInt(m[3], 10);
     const candidate = `${baseYear}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
     // Year-rollover: if the parsed M/D lands chronologically before the
     // event's anchor date, it must belong to the following year (the
@@ -594,17 +594,17 @@ function parseDateRangeFromDescription(
 ): { dates: string[]; startTimes: string[]; isMultiDay: boolean } | null {
   const startDateStr = parseHashRegoDate(indexEntry.startDate);
   if (!startDateStr) return null;
-  const year = parseInt(startDateStr.split("-")[0], 10);
+  const year = Number.parseInt(startDateStr.split("-")[0], 10);
 
   // Strategy 1: `MM/DD HH:MM PM to MM/DD HH:MM PM` (existing path).
   const rangeMatch = description.match(
     /(\d{1,2})\/(\d{1,2})\s+\d{1,2}:\d{2}\s*(?:AM|PM)\s+to\s+(\d{1,2})\/(\d{1,2})\s+\d{1,2}:\d{2}\s*(?:AM|PM)/i,
   );
   if (rangeMatch) {
-    const startMonth = parseInt(rangeMatch[1], 10);
-    const startDay = parseInt(rangeMatch[2], 10);
-    const endMonth = parseInt(rangeMatch[3], 10);
-    const endDay = parseInt(rangeMatch[4], 10);
+    const startMonth = Number.parseInt(rangeMatch[1], 10);
+    const startDay = Number.parseInt(rangeMatch[2], 10);
+    const endMonth = Number.parseInt(rangeMatch[3], 10);
+    const endDay = Number.parseInt(rangeMatch[4], 10);
     // Year-rollover guard (Gemini review on PR #1630): if the end month
     // is strictly earlier than the start month (12/31 → 1/1), the end
     // date must be in the following year. Strict inequality — same-month

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -518,34 +518,72 @@ const DAY_HEADER_RE = /\bDay\s+(\d{1,2})(?::|\s)\s*(\d{1,2})\/(\d{1,2})\b/gi;
  * following year (NYE campouts: `**DAY 1 12/31 —**`, `**DAY 2 1/1 —**`
  * starts in year N and finishes in N+1 — Gemini review on PR #1630).
  */
+/** First `HH:MM show/go/start` pattern in a slice, normalized to a 24h
+ *  string. Returns `undefined` when no time is present in the slice. Same
+ *  AM-bias adjustment as `extractPerDayStartTimes` (1–9 → +12 hours;
+ *  hashrego writes evening times bare like "7:00 show"). */
+function extractFirstTimeFromSlice(slice: string): string | undefined {
+  const tm = slice.match(/(\d{1,2}):(\d{2})\s+(show|go|start)/i);
+  if (!tm) return undefined;
+  const h = parseInt(tm[1], 10);
+  const min = parseInt(tm[2], 10);
+  const adjustedH = h < 12 && h >= 1 && h <= 9 ? h + 12 : h;
+  return `${String(adjustedH).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
+}
+
+/** One per-day entry from `parseDayHeaderSections`. */
+export interface DayHeaderSection {
+  date: string;        // YYYY-MM-DD
+  startTime?: string;  // HH:MM (24h) — undefined when the slice has no `show/go/start` time
+}
+
 export function parseDayHeaderSections(
   description: string,
   startDateStr: string,
-): string[] {
+): DayHeaderSection[] {
   const baseYear = parseInt(startDateStr.split("-")[0], 10);
   if (!baseYear) return [];
   const matches = [...description.matchAll(DAY_HEADER_RE)];
   if (matches.length < 2) return [];
-  const dates = matches.map((m) => {
+
+  // Walk headers in DOCUMENT order so each section's time can be extracted
+  // from the slice between THIS header and the next one. Sorting by date
+  // happens AFTER pairing so a description that lists headers
+  // out-of-order (admin error, "Day 3 ... Day 1 ... Day 2") still maps
+  // its 7:00 show / 10:00 show / 12:00 show times to the right days
+  // (Codex P1 review on PR #1630 — pre-fix, `extractPerDayStartTimes`
+  // returned times in raw doc order and the caller paired them by index
+  // into the sorted dates, silently shuffling them).
+  const entries: DayHeaderSection[] = matches.map((m, i) => {
     const month = parseInt(m[2], 10);
     const day = parseInt(m[3], 10);
     const candidate = `${baseYear}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
     // Year-rollover: if the parsed M/D lands chronologically before the
     // event's anchor date, it must belong to the following year (the
     // anchor is always the event's earliest known day).
-    if (candidate < startDateStr) {
-      return `${baseYear + 1}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-    }
-    return candidate;
+    const date = candidate < startDateStr
+      ? `${baseYear + 1}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`
+      : candidate;
+    // Slice between this header's end and the next header's start (or
+    // end-of-description for the last header).
+    const sliceStart = (m.index ?? 0) + m[0].length;
+    const sliceEnd = matches[i + 1]?.index ?? description.length;
+    const startTime = extractFirstTimeFromSlice(description.slice(sliceStart, sliceEnd));
+    return { date, startTime };
   });
-  // Deduplicate (a description mentioning the same day twice in two
-  // headers shouldn't double-count) then sort. After dedup we re-apply
-  // the < 2 guard: a description with two "DAY 1 1/15" headers
-  // (admin typo, same-day double bill, etc.) collapses to one unique
-  // date — which is NOT a multi-day series. Falling back to `[]` lets
-  // the caller's existing single-day path take over without spuriously
-  // marking the event as multi-day.
-  const unique = [...new Set(dates)].sort((a, b) => a.localeCompare(b));
+
+  // Deduplicate by date (a description mentioning the same day twice in
+  // two headers collapses; first occurrence wins for time). After dedup
+  // we re-apply the < 2 guard: two "DAY 1 1/15" headers — admin typo,
+  // same-day double bill, etc. — collapse to one unique date, which is
+  // NOT a multi-day series. Falling back to `[]` lets the caller's
+  // existing single-day path take over without spuriously marking the
+  // event as multi-day.
+  const byDate = new Map<string, DayHeaderSection>();
+  for (const e of entries) {
+    if (!byDate.has(e.date)) byDate.set(e.date, e);
+  }
+  const unique = [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
   return unique.length >= 2 ? unique : [];
 }
 
@@ -581,11 +619,20 @@ function parseDateRangeFromDescription(
 
   // Strategy 2 (#1560 PR B): per-day section headers — `DAY 1 M/D`, etc.
   // Fallback for NYC 5-Boro-style multi-day descriptions whose date range
-  // isn't expressible as a single `start to end` line.
-  const dayHeaderDates = parseDayHeaderSections(description, startDateStr);
-  if (dayHeaderDates.length >= 2) {
-    const startTimes = extractPerDayStartTimes(description, dayHeaderDates.length);
-    return { dates: dayHeaderDates, startTimes, isMultiDay: true };
+  // isn't expressible as a single `start to end` line. Per-section start
+  // times are extracted alongside each date in `parseDayHeaderSections`
+  // so out-of-order headers keep their times paired correctly across
+  // the post-sort (Codex P1 review).
+  const dayHeaderEntries = parseDayHeaderSections(description, startDateStr);
+  if (dayHeaderEntries.length >= 2) {
+    const dates = dayHeaderEntries.map((e) => e.date);
+    // Per-section times pair correctly with dates after sort. Where a
+    // section has no `show/go/start` time, fall back to the first
+    // populated section's time so downstream display still has a value
+    // (mirrors the legacy padding behavior in `extractPerDayStartTimes`).
+    const firstTime = dayHeaderEntries.find((e) => e.startTime)?.startTime ?? "";
+    const startTimes = dayHeaderEntries.map((e) => e.startTime ?? firstTime);
+    return { dates, startTimes, isMultiDay: true };
   }
 
   return null;

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -377,14 +377,20 @@ export function splitToRawEvents(
     ];
   }
 
-  // Multi-day event: one RawEventData per date
+  // Multi-day event: one RawEventData per date. The earliest day is marked
+  // as the explicit series parent (#1560 PR B) — it carries the umbrella
+  // title without the "(Day N)" suffix and the inclusive `endDate` so the
+  // UI's date-range chip + "+ N trails" badge render on the parent. Later
+  // days are explicit children with their per-day title suffix.
   const seriesId = slug; // Use the Hash Rego slug as series identifier
+  const lastDate = parsed.dates[parsed.dates.length - 1];
   return parsed.dates.map((date, i) => {
+    const isParent = i === 0;
     const dayLabel = `Day ${i + 1}`;
     return {
       date,
       kennelTags: [parsed.hostKennelName || parsed.kennelSlug],
-      title: `${parsed.title} (${dayLabel})`,
+      title: isParent ? parsed.title : `${parsed.title} (${dayLabel})`,
       description: parsed.description,
       hares: parsed.hares,
       location: parsed.location,
@@ -393,6 +399,7 @@ export function splitToRawEvents(
       sourceUrl: hashRegoUrl,
       externalLinks,
       seriesId,
+      ...(isParent ? { seriesParent: true, endDate: lastDate } : {}),
     };
   });
 }
@@ -483,31 +490,87 @@ function extractPerDayStartTimes(description: string, dateCount: number): string
   return startTimes;
 }
 
+/**
+ * Match per-day section headers like `**DAY 1 1/15 —**`, `Day 2: 2/16`,
+ * or `Day 3 1/17`. The `\s*:?\s*` between the day number and the M/D
+ * tolerates with-colon and without-colon variants; markdown `**` bolds
+ * around the whole phrase are absorbed because they're just whitespace
+ * to `\s+`. Em-dash / en-dash / hyphen separators after the date are NOT
+ * required — keeps the regex simple and the Sonar S5843 complexity low
+ * (per memory `feedback_sonar_s5852_false_positives.md`).
+ */
+const DAY_HEADER_RE = /\bDay\s+(\d{1,2})\s*:?\s+(\d{1,2})\/(\d{1,2})\b/gi;
+
+/**
+ * Parse per-day section headers from a Hash Rego event description (used
+ * for multi-day events like NYC H3 5-Boro Pub Crawl whose description
+ * carries `**DAY 1 1/15 —** ...` / `**DAY 2 1/16 —** ...` blocks instead
+ * of a `MM/DD HH:MM PM to MM/DD HH:MM PM` range — #1560 PR B).
+ *
+ * Returns `[]` for < 2 matches (avoids false positives where the
+ * description happens to mention a single "Day 1" but doesn't describe
+ * a multi-day event). Output is sorted by date ascending. The reference
+ * `year` comes from the event's start-date column (`indexEntry.startDate`)
+ * — Hash Rego always carries a 4-digit year there, so we never need to
+ * guess (avoids chrono's forwardDate trap from memory
+ * `feedback_chrono_forward_date_explicit_year.md`).
+ */
+export function parseDayHeaderSections(
+  description: string,
+  year: number,
+): string[] {
+  const matches = [...description.matchAll(DAY_HEADER_RE)];
+  if (matches.length < 2) return [];
+  const dates = matches.map((m) => {
+    const month = parseInt(m[2], 10);
+    const day = parseInt(m[3], 10);
+    return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  });
+  // Deduplicate (a description mentioning the same day twice in two
+  // headers shouldn't double-count) then sort. After dedup we re-apply
+  // the < 2 guard: a description with two "DAY 1 1/15" headers
+  // (admin typo, same-day double bill, etc.) collapses to one unique
+  // date — which is NOT a multi-day series. Falling back to `[]` lets
+  // the caller's existing single-day path take over without spuriously
+  // marking the event as multi-day.
+  const unique = [...new Set(dates)].sort((a, b) => a.localeCompare(b));
+  return unique.length >= 2 ? unique : [];
+}
+
 /** Try to parse a date range from the description and index entry. */
 function parseDateRangeFromDescription(
   description: string,
   indexEntry: IndexEntry,
 ): { dates: string[]; startTimes: string[]; isMultiDay: boolean } | null {
-  const rangeMatch = description.match(
-    /(\d{1,2})\/(\d{1,2})\s+\d{1,2}:\d{2}\s*(?:AM|PM)\s+to\s+(\d{1,2})\/(\d{1,2})\s+\d{1,2}:\d{2}\s*(?:AM|PM)/i,
-  );
-  if (!rangeMatch) return null;
-
   const year = parseYearFromIndex(indexEntry.startDate);
   if (!year) return null;
 
-  const startMonth = parseInt(rangeMatch[1], 10);
-  const startDay = parseInt(rangeMatch[2], 10);
-  const endMonth = parseInt(rangeMatch[3], 10);
-  const endDay = parseInt(rangeMatch[4], 10);
+  // Strategy 1: `MM/DD HH:MM PM to MM/DD HH:MM PM` (existing path).
+  const rangeMatch = description.match(
+    /(\d{1,2})\/(\d{1,2})\s+\d{1,2}:\d{2}\s*(?:AM|PM)\s+to\s+(\d{1,2})\/(\d{1,2})\s+\d{1,2}:\d{2}\s*(?:AM|PM)/i,
+  );
+  if (rangeMatch) {
+    const startMonth = parseInt(rangeMatch[1], 10);
+    const startDay = parseInt(rangeMatch[2], 10);
+    const endMonth = parseInt(rangeMatch[3], 10);
+    const endDay = parseInt(rangeMatch[4], 10);
+    const startDate = new Date(Date.UTC(year, startMonth - 1, startDay));
+    const endDate = new Date(Date.UTC(year, endMonth - 1, endDay));
+    const dates = generateDatesInRange(startDate, endDate);
+    const startTimes = extractPerDayStartTimes(description, dates.length);
+    return { dates, startTimes, isMultiDay: dates.length > 1 };
+  }
 
-  const startDate = new Date(Date.UTC(year, startMonth - 1, startDay));
-  const endDate = new Date(Date.UTC(year, endMonth - 1, endDay));
+  // Strategy 2 (#1560 PR B): per-day section headers — `DAY 1 M/D`, etc.
+  // Fallback for NYC 5-Boro-style multi-day descriptions whose date range
+  // isn't expressible as a single `start to end` line.
+  const dayHeaderDates = parseDayHeaderSections(description, year);
+  if (dayHeaderDates.length >= 2) {
+    const startTimes = extractPerDayStartTimes(description, dayHeaderDates.length);
+    return { dates: dayHeaderDates, startTimes, isMultiDay: true };
+  }
 
-  const dates = generateDatesInRange(startDate, endDate);
-  const startTimes = extractPerDayStartTimes(description, dates.length);
-
-  return { dates, startTimes, isMultiDay: dates.length > 1 };
+  return null;
 }
 
 /** Extract dates and detect multi-day events */

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -492,14 +492,14 @@ function extractPerDayStartTimes(description: string, dateCount: number): string
 
 /**
  * Match per-day section headers like `**DAY 1 1/15 —**`, `Day 2: 2/16`,
- * or `Day 3 1/17`. The `\s*:?\s*` between the day number and the M/D
- * tolerates with-colon and without-colon variants; markdown `**` bolds
- * around the whole phrase are absorbed because they're just whitespace
- * to `\s+`. Em-dash / en-dash / hyphen separators after the date are NOT
- * required — keeps the regex simple and the Sonar S5843 complexity low
- * (per memory `feedback_sonar_s5852_false_positives.md`).
+ * or `Day 3 1/17`. The separator between the day number and the M/D is
+ * `(?::|\s)` — exactly ONE colon-or-whitespace char, then `\s*` for any
+ * trailing whitespace. The original `\s*:?\s*` form had overlapping
+ * `\s` quantifiers around an optional `:` that Sonar S5852 flagged as
+ * ReDoS-prone (memory `feedback_sonar_s5852_false_positives.md`); the
+ * new form has no `\s*` adjacent to another `\s` quantifier.
  */
-const DAY_HEADER_RE = /\bDay\s+(\d{1,2})\s*:?\s+(\d{1,2})\/(\d{1,2})\b/gi;
+const DAY_HEADER_RE = /\bDay\s+(\d{1,2})(?::|\s)\s*(\d{1,2})\/(\d{1,2})\b/gi;
 
 /**
  * Parse per-day section headers from a Hash Rego event description (used
@@ -509,22 +509,34 @@ const DAY_HEADER_RE = /\bDay\s+(\d{1,2})\s*:?\s+(\d{1,2})\/(\d{1,2})\b/gi;
  *
  * Returns `[]` for < 2 matches (avoids false positives where the
  * description happens to mention a single "Day 1" but doesn't describe
- * a multi-day event). Output is sorted by date ascending. The reference
- * `year` comes from the event's start-date column (`indexEntry.startDate`)
- * — Hash Rego always carries a 4-digit year there, so we never need to
- * guess (avoids chrono's forwardDate trap from memory
- * `feedback_chrono_forward_date_explicit_year.md`).
+ * a multi-day event). Output is sorted by date ascending.
+ *
+ * `startDateStr` is the full YYYY-MM-DD anchor from the event index
+ * (parsed via `parseHashRegoDate(indexEntry.startDate)`). It serves both
+ * as the year source AND the year-rollover detector: when a parsed M/D
+ * is chronologically BEFORE the anchor, that day belongs to the
+ * following year (NYE campouts: `**DAY 1 12/31 —**`, `**DAY 2 1/1 —**`
+ * starts in year N and finishes in N+1 — Gemini review on PR #1630).
  */
 export function parseDayHeaderSections(
   description: string,
-  year: number,
+  startDateStr: string,
 ): string[] {
+  const baseYear = parseInt(startDateStr.split("-")[0], 10);
+  if (!baseYear) return [];
   const matches = [...description.matchAll(DAY_HEADER_RE)];
   if (matches.length < 2) return [];
   const dates = matches.map((m) => {
     const month = parseInt(m[2], 10);
     const day = parseInt(m[3], 10);
-    return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    const candidate = `${baseYear}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    // Year-rollover: if the parsed M/D lands chronologically before the
+    // event's anchor date, it must belong to the following year (the
+    // anchor is always the event's earliest known day).
+    if (candidate < startDateStr) {
+      return `${baseYear + 1}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    }
+    return candidate;
   });
   // Deduplicate (a description mentioning the same day twice in two
   // headers shouldn't double-count) then sort. After dedup we re-apply
@@ -542,8 +554,9 @@ function parseDateRangeFromDescription(
   description: string,
   indexEntry: IndexEntry,
 ): { dates: string[]; startTimes: string[]; isMultiDay: boolean } | null {
-  const year = parseYearFromIndex(indexEntry.startDate);
-  if (!year) return null;
+  const startDateStr = parseHashRegoDate(indexEntry.startDate);
+  if (!startDateStr) return null;
+  const year = parseInt(startDateStr.split("-")[0], 10);
 
   // Strategy 1: `MM/DD HH:MM PM to MM/DD HH:MM PM` (existing path).
   const rangeMatch = description.match(
@@ -554,8 +567,13 @@ function parseDateRangeFromDescription(
     const startDay = parseInt(rangeMatch[2], 10);
     const endMonth = parseInt(rangeMatch[3], 10);
     const endDay = parseInt(rangeMatch[4], 10);
+    // Year-rollover guard (Gemini review on PR #1630): if the end month
+    // is strictly earlier than the start month (12/31 → 1/1), the end
+    // date must be in the following year. Strict inequality — same-month
+    // events stay in the same year regardless of day ordering.
+    const endYear = endMonth < startMonth ? year + 1 : year;
     const startDate = new Date(Date.UTC(year, startMonth - 1, startDay));
-    const endDate = new Date(Date.UTC(year, endMonth - 1, endDay));
+    const endDate = new Date(Date.UTC(endYear, endMonth - 1, endDay));
     const dates = generateDatesInRange(startDate, endDate);
     const startTimes = extractPerDayStartTimes(description, dates.length);
     return { dates, startTimes, isMultiDay: dates.length > 1 };
@@ -564,7 +582,7 @@ function parseDateRangeFromDescription(
   // Strategy 2 (#1560 PR B): per-day section headers — `DAY 1 M/D`, etc.
   // Fallback for NYC 5-Boro-style multi-day descriptions whose date range
   // isn't expressible as a single `start to end` line.
-  const dayHeaderDates = parseDayHeaderSections(description, year);
+  const dayHeaderDates = parseDayHeaderSections(description, startDateStr);
   if (dayHeaderDates.length >= 2) {
     const startTimes = extractPerDayStartTimes(description, dayHeaderDates.length);
     return { dates: dayHeaderDates, startTimes, isMultiDay: true };


### PR DESCRIPTION
## Summary

Stacked on top of [PR #1627's series foundation](https://github.com/johnrclem/hashtracks-web/pull/1627). Adds a second strategy to the Hash Rego `parseDateRangeFromDescription` for multi-day events whose description carries per-day section headers (e.g. `**DAY 1 1/15 —** ...`) but no `MM/DD HH:MM PM to MM/DD HH:MM PM` time range — NYC H3 5-Boro Pub Crawl was the motivating case; pre-PR-B the parser dropped Day 2 / Day 3 silently because no strategy recognized that format.

- New `parseDayHeaderSections` helper — single tight regex matches `**DAY N M/D —**`, `Day N: M/D`, `Day N M/D`. Year sourced from the index entry's `startDate` (Hash Rego carries a 4-digit year there — no chrono / forwardDate trap).
- `parseDateRangeFromDescription` now tries (1) the existing time-range pattern, then (2) the new per-day headers as fallback.
- `splitToRawEvents` was emitting `(Day N)` suffix on every row's title. Updated so the **earliest** day represents the whole series: drops the suffix, sets `seriesParent: true`, carries `endDate` set to the latest day's date. Later days keep their `(Day 2)` / `(Day 3)` suffix and inherit `seriesId`. The merge pipeline's `linkMultiDaySeries` (from PR A) gets an explicit parent signal instead of relying on the earliest-by-date fallback.

## What this PR does NOT do
- Auto-close the umbrella tracking issue — that is deferred to PR C (venue-weekend heuristic for MadisonH3 Token Run).
- Add a heuristic for descriptions that mention weekdays without explicit dates ("Friday morning, Saturday afternoon, Sunday brunch") — that's PR C's territory.

## Tests
- 7 new `parseDayHeaderSections` cases via `it.each` per memory `feedback_it_each_for_sonar_cpd.md`: NYC 5-Boro formatting, mixed case (`Day 2: 2/16`), bare format (no colon/em-dash), date-sorting, dedup, single-day early-out, no-headers, Memorial-Day false-positive guard.
- 2 new `splitToRawEvents` assertions: parent has no `(Day N)` suffix / Day 2+ does; `seriesParent: true` + `endDate` only on the parent.
- Full integration test using a synthetic NYC 5-Boro HTML fixture (3 children, shared seriesId, parent carries `endDate: "2026-01-17"`).
- Updated the pre-existing "adds day labels" test which previously expected `(Day 1)` on the first row.

## Sonar regex hygiene
The new `DAY_HEADER_RE` avoids `\s*` adjacent to alternation (per memory `feedback_sonar_s5852_false_positives.md`). Should sail through SonarCloud without S5852 / S5843 flags.

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors, 20 pre-existing warnings
- [x] `npm test` — 7166 tests pass / 262 files (89 net new)
- [ ] Post-merge: Hash Rego re-scrape on prod will surface any NYC 5-Boro-style events as proper series parents in the hareline UI

Refs the multi-day umbrella tracking issue. (The auto-close keyword is intentionally reserved for PR C — this PR is non-closing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)