### PR TITLE
feat(hogtown): Google Sites adapter (#1331) + LBH cleanup script

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3880,6 +3880,22 @@ export const SOURCES = [
       },
       kennelCodes: ["hogtownh3"],
     },
+    {
+      // Closes #1331 — Google Sites SPA, browser-rendered. Carries per-event
+      // hash names + hares + costs that the Meetup adapter loses behind
+      // recycled template titles. Three sub-series (HOGTOWN / TWAT / HOGANS)
+      // share one kennel; the series prefix lives in the title.
+      name: "Hogtown H3 Website",
+      url: "https://www.hogtownh3.com/upcoming-trails",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 8,
+      scrapeFreq: "daily",
+      scrapeDays: 120,
+      config: {
+        kennelTag: "hogtownh3",
+      },
+      kennelCodes: ["hogtownh3"],
+    },
     // --- Edmonton: EH3 multi-kennel (7 kennels) ---
     {
       name: "EH3 Edmonton Area Harelines",

--- a/scripts/cleanup-lbh-misbound-rawevents.ts
+++ b/scripts/cleanup-lbh-misbound-rawevents.ts
@@ -1,0 +1,154 @@
+/**
+ * One-shot cleanup for the 107 LBH-PHX RawEvents that were misbound during
+ * the first apply of `scripts/backfill-lbh-phx-history.ts` (PR #1628).
+ *
+ * Background:
+ *   The initial backfill run bound to `"Phoenix H3 Events"` (the ICS source,
+ *   trust=7) before reviewer feedback caught that the script actually scrapes
+ *   the HTML Big Ass Calendar — which is a separate Source row,
+ *   `"Phoenix H3 Big Ass Calendar"` (HTML_SCRAPER, trust=8). The corrected
+ *   re-apply created the same 107 RawEvents under the right source. The
+ *   misbound 107 still sit under the ICS source and pollute provenance
+ *   (the ICS feed is upcoming-only and could never legitimately have
+ *   produced these past-event rows).
+ *
+ * Safety:
+ *   Each misbound RawEvent is paired against the canonical-source version
+ *   by `rawData` shape comparison (date + runNumber + kennelTag — fingerprint
+ *   is per-source so the SHA differs, but the underlying event identity is
+ *   the same). Only RawEvents that have a confirmed twin under the canonical
+ *   source are deleted. Canonical `Event` rows are NOT touched — they
+ *   continue to resolve via the surviving high-trust source's RawEvents.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-lbh-misbound-rawevents.ts
+ *   Apply:   CLEANUP_APPLY=1 npx tsx scripts/cleanup-lbh-misbound-rawevents.ts
+ */
+
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const ICS_SOURCE = "Phoenix H3 Events";
+const CALENDAR_SOURCE = "Phoenix H3 Big Ass Calendar";
+const KENNEL_TAG = "lbh-phx";
+// The misbound apply happened on 2026-05-22; bound the cleanup window to
+// that day so accumulated-over-years legitimate ICS RawEvents are safe.
+const APPLY_DATE = "2026-05-22";
+
+interface RawEventLike {
+  id: string;
+  fingerprint: string;
+  scrapedAt: Date;
+  eventId: string | null;
+  rawData: unknown;
+}
+
+function eventKey(rawData: unknown): string | null {
+  if (!rawData || typeof rawData !== "object") return null;
+  const obj = rawData as { date?: unknown; runNumber?: unknown; kennelTags?: unknown };
+  const date = typeof obj.date === "string" ? obj.date : null;
+  const run = typeof obj.runNumber === "number" ? obj.runNumber : null;
+  const tag = Array.isArray(obj.kennelTags) && typeof obj.kennelTags[0] === "string" ? obj.kennelTags[0] : null;
+  if (!date || run == null || !tag) return null;
+  return `${tag}|${date}|${run}`;
+}
+
+async function main(): Promise<void> {
+  const apply = process.env.CLEANUP_APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (will delete)" : "DRY RUN (no writes)"}`);
+
+  const ics = await prisma.source.findFirst({ where: { name: ICS_SOURCE }, select: { id: true } });
+  const cal = await prisma.source.findFirst({ where: { name: CALENDAR_SOURCE }, select: { id: true } });
+  if (!ics || !cal) throw new Error("Missing one or both source rows");
+
+  const start = new Date(`${APPLY_DATE}T00:00:00Z`);
+  const end = new Date(`${APPLY_DATE}T23:59:59Z`);
+
+  // Misbound candidates: all lbh-phx RawEvents under the ICS source scraped on
+  // the apply date.
+  const candidates: RawEventLike[] = await prisma.rawEvent.findMany({
+    where: {
+      sourceId: ics.id,
+      scrapedAt: { gte: start, lte: end },
+      rawData: { path: ["kennelTags"], array_contains: KENNEL_TAG },
+    },
+    select: { id: true, fingerprint: true, scrapedAt: true, eventId: true, rawData: true },
+  });
+  console.log(`Found ${candidates.length} misbound candidates under "${ICS_SOURCE}" scraped on ${APPLY_DATE}.`);
+
+  // Build a key set of canonical-source RawEvents for the same kennel.
+  const canonicalRaws: { rawData: unknown }[] = await prisma.rawEvent.findMany({
+    where: {
+      sourceId: cal.id,
+      rawData: { path: ["kennelTags"], array_contains: KENNEL_TAG },
+    },
+    select: { rawData: true },
+  });
+  const canonicalKeys = new Set<string>();
+  for (const r of canonicalRaws) {
+    const k = eventKey(r.rawData);
+    if (k) canonicalKeys.add(k);
+  }
+  console.log(`Canonical source has ${canonicalKeys.size} keyed LBH RawEvents available as backstop.`);
+
+  const safeToDelete: RawEventLike[] = [];
+  const unsafe: RawEventLike[] = [];
+  for (const c of candidates) {
+    const k = eventKey(c.rawData);
+    if (k && canonicalKeys.has(k)) safeToDelete.push(c);
+    else unsafe.push(c);
+  }
+
+  console.log(`Safe to delete (twin exists under "${CALENDAR_SOURCE}"): ${safeToDelete.length}`);
+  console.log(`UNSAFE (no canonical twin, will NOT delete): ${unsafe.length}`);
+  if (unsafe.length > 0) {
+    console.log("  Unsafe sample (first 3):");
+    for (const u of unsafe.slice(0, 3)) {
+      console.log("   ", u.id, "key=", eventKey(u.rawData));
+    }
+  }
+
+  if (!apply) {
+    console.log("\nDry run complete. Re-run with CLEANUP_APPLY=1 to delete.");
+    return;
+  }
+  if (safeToDelete.length === 0) {
+    console.log("\nNothing to delete.");
+    return;
+  }
+
+  const ids = safeToDelete.map((r) => r.id);
+  const result = await prisma.rawEvent.deleteMany({ where: { id: { in: ids } } });
+  console.log(`\nDeleted ${result.count} RawEvents.`);
+
+  // Sanity check: confirm canonical Events still have at least one RawEvent
+  // backing them. Only Events that the deleted RawEvents pointed to need
+  // checking.
+  const eventIds = [...new Set(safeToDelete.map((r) => r.eventId).filter((v): v is string => v != null))];
+  if (eventIds.length === 0) {
+    console.log("No deleted rows referenced a canonical Event; nothing to verify.");
+    return;
+  }
+  const orphans = await prisma.event.findMany({
+    where: { id: { in: eventIds }, rawEvents: { none: {} } },
+    select: { id: true, date: true, runNumber: true },
+  });
+  if (orphans.length > 0) {
+    console.warn(`WARNING: ${orphans.length} canonical Events lost all RawEvent backing:`);
+    for (const o of orphans.slice(0, 5)) {
+      console.warn(`  ${o.id} | ${o.date.toISOString().slice(0, 10)} #${o.runNumber}`);
+    }
+  } else {
+    console.log(`Verified: all ${eventIds.length} touched canonical Events still have at least one RawEvent backing.`);
+  }
+}
+
+main()
+  .catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("FAILED:", message);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/cleanup-lbh-misbound-rawevents.ts
+++ b/scripts/cleanup-lbh-misbound-rawevents.ts
@@ -53,78 +53,55 @@ function eventKey(rawData: unknown): string | null {
   return `${tag}|${date}|${run}`;
 }
 
-async function main(): Promise<void> {
-  const apply = process.env.CLEANUP_APPLY === "1";
-  console.log(`Mode: ${apply ? "APPLY (will delete)" : "DRY RUN (no writes)"}`);
-
+async function loadSources(): Promise<{ icsId: string; calId: string }> {
   const ics = await prisma.source.findFirst({ where: { name: ICS_SOURCE }, select: { id: true } });
   const cal = await prisma.source.findFirst({ where: { name: CALENDAR_SOURCE }, select: { id: true } });
   if (!ics || !cal) throw new Error("Missing one or both source rows");
+  return { icsId: ics.id, calId: cal.id };
+}
 
+async function findMisboundCandidates(sourceId: string): Promise<RawEventLike[]> {
   const start = new Date(`${APPLY_DATE}T00:00:00Z`);
   const end = new Date(`${APPLY_DATE}T23:59:59Z`);
-
-  // Misbound candidates: all lbh-phx RawEvents under the ICS source scraped on
-  // the apply date.
-  const candidates: RawEventLike[] = await prisma.rawEvent.findMany({
+  return prisma.rawEvent.findMany({
     where: {
-      sourceId: ics.id,
+      sourceId,
       scrapedAt: { gte: start, lte: end },
       rawData: { path: ["kennelTags"], array_contains: KENNEL_TAG },
     },
     select: { id: true, fingerprint: true, scrapedAt: true, eventId: true, rawData: true },
   });
-  console.log(`Found ${candidates.length} misbound candidates under "${ICS_SOURCE}" scraped on ${APPLY_DATE}.`);
+}
 
-  // Build a key set of canonical-source RawEvents for the same kennel.
-  const canonicalRaws: { rawData: unknown }[] = await prisma.rawEvent.findMany({
+async function buildCanonicalKeySet(sourceId: string): Promise<Set<string>> {
+  const rows = await prisma.rawEvent.findMany({
     where: {
-      sourceId: cal.id,
+      sourceId,
       rawData: { path: ["kennelTags"], array_contains: KENNEL_TAG },
     },
     select: { rawData: true },
   });
-  const canonicalKeys = new Set<string>();
-  for (const r of canonicalRaws) {
+  const keys = new Set<string>();
+  for (const r of rows) {
     const k = eventKey(r.rawData);
-    if (k) canonicalKeys.add(k);
+    if (k) keys.add(k);
   }
-  console.log(`Canonical source has ${canonicalKeys.size} keyed LBH RawEvents available as backstop.`);
+  return keys;
+}
 
-  const safeToDelete: RawEventLike[] = [];
+function partitionByTwin(candidates: RawEventLike[], canonicalKeys: Set<string>) {
+  const safe: RawEventLike[] = [];
   const unsafe: RawEventLike[] = [];
   for (const c of candidates) {
     const k = eventKey(c.rawData);
-    if (k && canonicalKeys.has(k)) safeToDelete.push(c);
+    if (k && canonicalKeys.has(k)) safe.push(c);
     else unsafe.push(c);
   }
+  return { safe, unsafe };
+}
 
-  console.log(`Safe to delete (twin exists under "${CALENDAR_SOURCE}"): ${safeToDelete.length}`);
-  console.log(`UNSAFE (no canonical twin, will NOT delete): ${unsafe.length}`);
-  if (unsafe.length > 0) {
-    console.log("  Unsafe sample (first 3):");
-    for (const u of unsafe.slice(0, 3)) {
-      console.log("   ", u.id, "key=", eventKey(u.rawData));
-    }
-  }
-
-  if (!apply) {
-    console.log("\nDry run complete. Re-run with CLEANUP_APPLY=1 to delete.");
-    return;
-  }
-  if (safeToDelete.length === 0) {
-    console.log("\nNothing to delete.");
-    return;
-  }
-
-  const ids = safeToDelete.map((r) => r.id);
-  const result = await prisma.rawEvent.deleteMany({ where: { id: { in: ids } } });
-  console.log(`\nDeleted ${result.count} RawEvents.`);
-
-  // Sanity check: confirm canonical Events still have at least one RawEvent
-  // backing them. Only Events that the deleted RawEvents pointed to need
-  // checking.
-  const eventIds = [...new Set(safeToDelete.map((r) => r.eventId).filter((v): v is string => v != null))];
+async function verifyNoOrphans(deleted: RawEventLike[]): Promise<void> {
+  const eventIds = [...new Set(deleted.map((r) => r.eventId).filter((v): v is string => v != null))];
   if (eventIds.length === 0) {
     console.log("No deleted rows referenced a canonical Event; nothing to verify.");
     return;
@@ -133,14 +110,44 @@ async function main(): Promise<void> {
     where: { id: { in: eventIds }, rawEvents: { none: {} } },
     select: { id: true, date: true, runNumber: true },
   });
-  if (orphans.length > 0) {
-    console.warn(`WARNING: ${orphans.length} canonical Events lost all RawEvent backing:`);
-    for (const o of orphans.slice(0, 5)) {
-      console.warn(`  ${o.id} | ${o.date.toISOString().slice(0, 10)} #${o.runNumber}`);
-    }
-  } else {
+  if (orphans.length === 0) {
     console.log(`Verified: all ${eventIds.length} touched canonical Events still have at least one RawEvent backing.`);
+    return;
   }
+  console.warn(`WARNING: ${orphans.length} canonical Events lost all RawEvent backing:`);
+  for (const o of orphans.slice(0, 5)) {
+    console.warn(`  ${o.id} | ${o.date.toISOString().slice(0, 10)} #${o.runNumber}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const apply = process.env.CLEANUP_APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (will delete)" : "DRY RUN (no writes)"}`);
+
+  const { icsId, calId } = await loadSources();
+
+  const candidates = await findMisboundCandidates(icsId);
+  console.log(`Found ${candidates.length} misbound candidates under "${ICS_SOURCE}" scraped on ${APPLY_DATE}.`);
+
+  const canonicalKeys = await buildCanonicalKeySet(calId);
+  console.log(`Canonical source has ${canonicalKeys.size} keyed LBH RawEvents available as backstop.`);
+
+  const { safe, unsafe } = partitionByTwin(candidates, canonicalKeys);
+  console.log(`Safe to delete (twin exists under "${CALENDAR_SOURCE}"): ${safe.length}`);
+  console.log(`UNSAFE (no canonical twin, will NOT delete): ${unsafe.length}`);
+
+  if (!apply) {
+    console.log("\nDry run complete. Re-run with CLEANUP_APPLY=1 to delete.");
+    return;
+  }
+  if (safe.length === 0) {
+    console.log("\nNothing to delete.");
+    return;
+  }
+
+  const result = await prisma.rawEvent.deleteMany({ where: { id: { in: safe.map((r) => r.id) } } });
+  console.log(`\nDeleted ${result.count} RawEvents.`);
+  await verifyNoOrphans(safe);
 }
 
 main()

--- a/src/adapters/html-scraper/hogtown.test.ts
+++ b/src/adapters/html-scraper/hogtown.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { parseHogtownEvents } from "./hogtown";
+
+/** Minimal fixture mirroring the live Google Sites DOM: each trail entry
+ * is a sequence of `<p>` siblings (header, date, hare, location, cost,
+ * RSVP url). Three sub-series rotate within one document. */
+const FIXTURE = `<html><body>
+  <p>Hogtown #2071- GDU Saves the Day!</p>
+  <p>Saturday, May 23, 2026, 5pm</p>
+  <p>Hare: GDU</p>
+  <p>Start Location:  Samara Brewery, 90 Cawthra Ave. A-B trail.</p>
+  <p>TTC to Start: Subway line 2 to Keele, bus north to West Toronto Street</p>
+  <p>Cost: $10 for drinkers, $2 for non-drinkers</p>
+  <p>RSVP here: https://www.meetup.com/meetup-group-pyrddkbc/events/314766795/</p>
+
+  <p>TWAT#582 - Naughty's Birthday Trail</p>
+  <p>Thursday, May 28, 2026, 7pm</p>
+  <p>Hares: Around the World in Naughty Ways</p>
+  <p>Start Location: TBD</p>
+  <p>TTC to Start: TBD</p>
+  <p>Cost: $10 for drinkers, $2 for non-drinkers</p>
+  <p>RSVP here: https://www.meetup.com/meetup-group-pyrddkbc/events/314766800/</p>
+
+  <p>HOGANS #462 - Hareless Hogans</p>
+  <p>Friday, June 12, 2026, 7:30pm</p>
+  <p>Hares: TBD - Hare needed!</p>
+  <p>Start Location: Bloor and Bathurst</p>
+  <p>Cost: $15 for drinkers, $2 for non-drinkers</p>
+</body></html>`;
+
+describe("parseHogtownEvents", () => {
+  it("extracts all three sub-series with rich titles", () => {
+    const events = parseHogtownEvents(FIXTURE, "https://www.hogtownh3.com/upcoming-trails");
+    expect(events).toHaveLength(3);
+    expect(events.map((e) => e.title)).toEqual([
+      "HOGTOWN #2071 - GDU Saves the Day!",
+      "TWAT #582 - Naughty's Birthday Trail",
+      "HOGANS #462 - Hareless Hogans",
+    ]);
+  });
+
+  it("parses dates and bare-hour start times correctly", () => {
+    const events = parseHogtownEvents(FIXTURE, "https://www.hogtownh3.com/upcoming-trails");
+    expect(events[0].date).toBe("2026-05-23");
+    expect(events[0].startTime).toBe("17:00");
+    expect(events[1].date).toBe("2026-05-28");
+    expect(events[1].startTime).toBe("19:00");
+    expect(events[2].date).toBe("2026-06-12");
+    expect(events[2].startTime).toBe("19:30");
+  });
+
+  it("parses hares from both 'Hare:' and 'Hares:' label variants", () => {
+    const events = parseHogtownEvents(FIXTURE, "https://www.hogtownh3.com/upcoming-trails");
+    expect(events[0].hares).toBe("GDU");
+    expect(events[1].hares).toBe("Around the World in Naughty Ways");
+    expect(events[2].hares).toBe("TBD - Hare needed!");
+  });
+
+  it("captures location text and drops TBD placeholders", () => {
+    const events = parseHogtownEvents(FIXTURE, "https://www.hogtownh3.com/upcoming-trails");
+    expect(events[0].location).toContain("Samara Brewery");
+    expect(events[1].location).toBeUndefined(); // TBD → undefined
+    expect(events[2].location).toBe("Bloor and Bathurst");
+  });
+
+  it("captures cost text", () => {
+    const events = parseHogtownEvents(FIXTURE, "https://www.hogtownh3.com/upcoming-trails");
+    expect(events[0].cost).toBe("$10 for drinkers, $2 for non-drinkers");
+    expect(events[2].cost).toBe("$15 for drinkers, $2 for non-drinkers");
+  });
+
+  it("emits the Meetup RSVP link as sourceUrl when present, falling back to the page URL", () => {
+    const events = parseHogtownEvents(FIXTURE, "https://www.hogtownh3.com/upcoming-trails");
+    expect(events[0].sourceUrl).toBe("https://www.meetup.com/meetup-group-pyrddkbc/events/314766795/");
+    expect(events[2].sourceUrl).toBe("https://www.hogtownh3.com/upcoming-trails"); // no RSVP → page fallback
+  });
+
+  it("emits kennelTags=['hogtownh3'] regardless of series prefix", () => {
+    const events = parseHogtownEvents(FIXTURE, "https://www.hogtownh3.com/upcoming-trails");
+    expect(events.every((e) => e.kennelTags.length === 1 && e.kennelTags[0] === "hogtownh3")).toBe(true);
+  });
+
+  it("returns empty when no series headers are present", () => {
+    const html = `<html><body><p>Welcome to Hogtown</p><p>Runs every other Saturday.</p></body></html>`;
+    expect(parseHogtownEvents(html, "https://www.hogtownh3.com/")).toEqual([]);
+  });
+});

--- a/src/adapters/html-scraper/hogtown.test.ts
+++ b/src/adapters/html-scraper/hogtown.test.ts
@@ -84,4 +84,16 @@ describe("parseHogtownEvents", () => {
     const html = `<html><body><p>Welcome to Hogtown</p><p>Runs every other Saturday.</p></body></html>`;
     expect(parseHogtownEvents(html, "https://www.hogtownh3.com/")).toEqual([]);
   });
+
+  it("handles the optional Meetup-ID prefix (e.g. '6795/TWAT#582 - …')", () => {
+    const html = `<html><body>
+      <p>6795/TWAT#582 - Naughty's Birthday Trail</p>
+      <p>Thursday, May 28, 2026, 7pm</p>
+      <p>Hare: Naughty</p>
+    </body></html>`;
+    const events = parseHogtownEvents(html, "https://www.hogtownh3.com/upcoming-trails");
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(582);
+    expect(events[0].title).toBe("TWAT #582 - Naughty's Birthday Trail");
+  });
 });

--- a/src/adapters/html-scraper/hogtown.ts
+++ b/src/adapters/html-scraper/hogtown.ts
@@ -34,21 +34,50 @@ const BASE_URL = "https://www.hogtownh3.com";
 const UPCOMING_PATH = "/upcoming-trails";
 const HOME_PATH = "/";
 
-/** Series prefix regex — matches the trail-header line. Case-insensitive
- * because the kennel mixes "Hogtown #" and "HOGTOWN -" capitalization. */
-const SERIES_HEADER_RE = /^\s*(?:\d+\s*\/\s*)?(HOGTOWN|HOGANS|TWAT|Hogtown|Hogans|Twat)\s*#?\s*(\d+)\s*[-–]?\s*(.*?)\s*$/;
-const WEEKDAY_PREFIX_RE = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat)[a-z]*\b/i;
-const HARES_LABEL_RE = /^Hares?\s*:\s*(.+)$/i;
-const LOCATION_LABEL_RE = /^Start\s+Location\s*:\s*(.+)$/i;
-const COST_LABEL_RE = /^Cost\s*:\s*(.+)$/i;
-const RSVP_URL_RE = /^RSVP\s+(?:here\s*:?\s*)?(https?:\/\/\S+)/i;
+/** Series prefix detector. Run separately from the title extraction below
+ * to keep each regex below the complexity bound — combining series +
+ * run-number + title in one regex tripped Sonar S5843 (#1635 review). */
+const SERIES_TOKEN_RE = /^(HOGTOWN|HOGANS|TWAT)\s*#?\s*(\d+)/i;
+const MEETUP_ID_PREFIX_RE = /^\d+\s*\/\s*/;
+const TITLE_DASH_PREFIX_RE = /^\s*[-–]\s*/;
+const WEEKDAY_PREFIX_RE = /^(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)/i;
+const URL_RE = /https?:\/\/\S+/;
 const BARE_TIME_RE = /(\d{1,2})(?::(\d{2}))?\s*([ap])m/i;
 
-/** Extract HH:MM start time from a date line like
- * "Saturday, May 23, 2026, 5pm" or "Thursday, April 30, 2026, 7:30pm". */
-function extractStartTime(line: string): string | undefined {
-  const m = BARE_TIME_RE.exec(line);
-  if (!m) return undefined;
+/** Try to extract a label-prefixed value. Case-insensitive label match,
+ * skips one optional `:` and any leading whitespace before the value.
+ * Returns undefined if none of the labels matched the text's prefix. */
+function tryExtractLabel(text: string, ...labels: string[]): string | undefined {
+  const lower = text.toLowerCase();
+  for (const label of labels) {
+    if (!lower.startsWith(label.toLowerCase())) continue;
+    const rest = text.slice(label.length).replace(/^\s*:?\s*/, "").trim();
+    return rest || undefined;
+  }
+  return undefined;
+}
+
+interface SeriesHeader {
+  series: string;
+  runNumber: number;
+  title: string;
+}
+
+/** Parse a trail-header paragraph (e.g., `"Hogtown #2071 - GDU Saves the
+ * Day!"` or `"6795/TWAT#582 - Naughty's Birthday Trail"`) into its three
+ * components. Returns null if the text isn't a recognizable header. */
+function parseSeriesHeader(text: string): SeriesHeader | null {
+  const stripped = text.trim().replace(MEETUP_ID_PREFIX_RE, "");
+  const m = SERIES_TOKEN_RE.exec(stripped);
+  if (!m) return null;
+  const runNumber = Number.parseInt(m[2], 10);
+  const series = normalizeSeries(m[1]);
+  const title = stripped.slice(m[0].length).replace(TITLE_DASH_PREFIX_RE, "").trim();
+  return { series, runNumber, title };
+}
+
+/** Convert a `BARE_TIME_RE` match to an HH:MM string. */
+function buildStartTime(m: RegExpExecArray): string {
   let hours = Number.parseInt(m[1], 10);
   const mins = m[2] ? Number.parseInt(m[2], 10) : 0;
   const ampm = m[3].toLowerCase();
@@ -87,7 +116,7 @@ function collectParagraphs(html: string): string[] {
   $("script, style").remove();
   const out: string[] = [];
   $("p").each((_i, el) => {
-    const text = $(el).text().replace(/ /g, " ").replace(/\s+/g, " ").trim();
+    const text = $(el).text().replaceAll(/\s+/g, " ").trim();
     if (text) out.push(text);
   });
   return out;
@@ -98,16 +127,17 @@ function collectParagraphs(html: string): string[] {
 function finalizeEntry(d: DraftEntry, sourcePageUrl: string): RawEventData | null {
   if (!d.dateLine) return null;
 
-  // Strip the leading weekday (e.g., "Saturday, May 23, 2026, 5pm") so
-  // chrono-node sees a clean "May 23, 2026" plus the time token.
-  const dateText = d.dateLine.replace(/\s*,?\s*(\d{1,2}(?::\d{2})?\s*[ap]m)\s*$/i, "").trim();
-  const dateStr = chronoParseDate(dateText, "en-US");
+  // Hogtown writes "Saturday, May 23, 2026, 5pm" — split the time off so
+  // chrono-node sees a clean date part. Sliced via indexOf rather than a
+  // strip-regex to keep this file under the Sonar S5852 ReDoS threshold.
+  const timeMatch = BARE_TIME_RE.exec(d.dateLine);
+  const datePart = timeMatch
+    ? d.dateLine.slice(0, timeMatch.index).replace(/,\s*$/, "").trim()
+    : d.dateLine.trim();
+  const dateStr = chronoParseDate(datePart, "en-US");
   if (!dateStr) return null;
 
-  // Pull the time token from the original line. Hogtown writes both
-  // bare-hour ("5pm") and minute-precise ("4:30pm") forms; parse12HourTime
-  // requires a colon, so handle the bare form ourselves.
-  const startTime = extractStartTime(d.dateLine);
+  const startTime = timeMatch ? buildStartTime(timeMatch) : undefined;
 
   // Title: "<SERIES> #N - <name>" — preserves the sub-series prefix per
   // #1331 spec. Falls back to "<SERIES> #N" when the kennel didn't fill
@@ -158,14 +188,10 @@ export function parseHogtownEvents(html: string, sourcePageUrl: string): RawEven
   };
 
   for (const p of paragraphs) {
-    const header = SERIES_HEADER_RE.exec(p);
+    const header = parseSeriesHeader(p);
     if (header) {
       flush();
-      draft = {
-        series: normalizeSeries(header[1]),
-        runNumber: Number.parseInt(header[2], 10),
-        rawTitle: header[3] ?? "",
-      };
+      draft = { series: header.series, runNumber: header.runNumber, rawTitle: header.title };
       continue;
     }
     if (!draft) continue;
@@ -174,25 +200,24 @@ export function parseHogtownEvents(html: string, sourcePageUrl: string): RawEven
       draft.dateLine = p;
       continue;
     }
-    const haresMatch = HARES_LABEL_RE.exec(p);
-    if (haresMatch) {
-      draft.hares = haresMatch[1];
+    const hares = tryExtractLabel(p, "Hares:", "Hare:");
+    if (hares !== undefined) {
+      draft.hares = hares;
       continue;
     }
-    const locMatch = LOCATION_LABEL_RE.exec(p);
-    if (locMatch) {
-      draft.location = locMatch[1];
+    const location = tryExtractLabel(p, "Start Location:");
+    if (location !== undefined) {
+      draft.location = location;
       continue;
     }
-    const costMatch = COST_LABEL_RE.exec(p);
-    if (costMatch) {
-      draft.cost = costMatch[1];
+    const cost = tryExtractLabel(p, "Cost:");
+    if (cost !== undefined) {
+      draft.cost = cost;
       continue;
     }
-    const rsvpMatch = RSVP_URL_RE.exec(p);
-    if (rsvpMatch) {
-      draft.sourceUrl = rsvpMatch[1];
-      continue;
+    if (/^RSVP\b/i.test(p)) {
+      const url = URL_RE.exec(p);
+      if (url) draft.sourceUrl = url[0];
     }
   }
   flush();

--- a/src/adapters/html-scraper/hogtown.ts
+++ b/src/adapters/html-scraper/hogtown.ts
@@ -1,0 +1,248 @@
+import * as cheerio from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import type {
+  SourceAdapter,
+  RawEventData,
+  ScrapeResult,
+  ErrorDetails,
+} from "../types";
+import { hasAnyErrors } from "../types";
+import { chronoParseDate, fetchBrowserRenderedPage } from "../utils";
+
+/**
+ * Hogtown H3 (Toronto) — Google Sites SPA at hogtownh3.com. Resolves
+ * issue #1331: replaces the Meetup adapter's three recycled template
+ * titles ("Saturday afternoon run/walk and beer with HH3", etc.) with
+ * the website's per-event hash names, run numbers, hares, and costs.
+ *
+ * The kennel runs THREE concurrent sub-series under one Meetup group:
+ *   - HOGTOWN (Saturdays, biweekly) — primary run-number sequence
+ *   - TWAT    (Toronto Women's Alternative Thursdays, monthly)
+ *   - HOGANS  (Fridays, monthly)
+ * Each has its own counter. The HashTracks schema doesn't have a
+ * sub-series field (per #1331's "otherwise leave them all on the same
+ * kennel and let the title carry the prefix" guidance), so the parser
+ * embeds the series label into the title.
+ *
+ * Sourcing: `/upcoming-trails` carries the next ~3 months. The Google
+ * Sites shell is JS-rendered (verified: raw curl returns zero hits for
+ * "HOGTOWN" / "Hare:"), so this adapter goes through the NAS
+ * browser-render service.
+ */
+
+const BASE_URL = "https://www.hogtownh3.com";
+const UPCOMING_PATH = "/upcoming-trails";
+const HOME_PATH = "/";
+
+/** Series prefix regex — matches the trail-header line. Case-insensitive
+ * because the kennel mixes "Hogtown #" and "HOGTOWN -" capitalization. */
+const SERIES_HEADER_RE = /^\s*(?:\d+\s*\/\s*)?(HOGTOWN|HOGANS|TWAT|Hogtown|Hogans|Twat)\s*#?\s*(\d+)\s*[-–]?\s*(.*?)\s*$/;
+const WEEKDAY_PREFIX_RE = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat)[a-z]*\b/i;
+const HARES_LABEL_RE = /^Hares?\s*:\s*(.+)$/i;
+const LOCATION_LABEL_RE = /^Start\s+Location\s*:\s*(.+)$/i;
+const COST_LABEL_RE = /^Cost\s*:\s*(.+)$/i;
+const RSVP_URL_RE = /^RSVP\s+(?:here\s*:?\s*)?(https?:\/\/\S+)/i;
+const BARE_TIME_RE = /(\d{1,2})(?::(\d{2}))?\s*([ap])m/i;
+
+/** Extract HH:MM start time from a date line like
+ * "Saturday, May 23, 2026, 5pm" or "Thursday, April 30, 2026, 7:30pm". */
+function extractStartTime(line: string): string | undefined {
+  const m = BARE_TIME_RE.exec(line);
+  if (!m) return undefined;
+  let hours = Number.parseInt(m[1], 10);
+  const mins = m[2] ? Number.parseInt(m[2], 10) : 0;
+  const ampm = m[3].toLowerCase();
+  if (ampm === "p" && hours !== 12) hours += 12;
+  if (ampm === "a" && hours === 12) hours = 0;
+  return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+}
+
+interface DraftEntry {
+  series: string;
+  runNumber: number;
+  rawTitle: string;
+  dateLine?: string;
+  hares?: string;
+  location?: string;
+  cost?: string;
+  sourceUrl?: string;
+}
+
+/** Normalize a series token to a consistent display label embedded in the
+ * event title. The source mixes casing (Hogtown vs HOGTOWN). */
+function normalizeSeries(s: string): string {
+  const upper = s.toUpperCase();
+  if (upper === "HOGTOWN") return "HOGTOWN";
+  if (upper === "HOGANS") return "HOGANS";
+  if (upper === "TWAT") return "TWAT";
+  return upper;
+}
+
+/** Read every `<p>` element in document order, returning its trimmed text
+ * with ` ` (NBSP) collapsed to regular spaces. Defensive against
+ * Google Sites rotating its `zfr3Q`-style class names — we key on content
+ * shape, not class. */
+function collectParagraphs(html: string): string[] {
+  const $ = cheerio.load(html);
+  $("script, style").remove();
+  const out: string[] = [];
+  $("p").each((_i, el) => {
+    const text = $(el).text().replace(/ /g, " ").replace(/\s+/g, " ").trim();
+    if (text) out.push(text);
+  });
+  return out;
+}
+
+/** Convert a draft entry (header + label/value paragraphs) into a
+ * RawEventData. Returns null if the date line couldn't be parsed. */
+function finalizeEntry(d: DraftEntry, sourcePageUrl: string): RawEventData | null {
+  if (!d.dateLine) return null;
+
+  // Strip the leading weekday (e.g., "Saturday, May 23, 2026, 5pm") so
+  // chrono-node sees a clean "May 23, 2026" plus the time token.
+  const dateText = d.dateLine.replace(/\s*,?\s*(\d{1,2}(?::\d{2})?\s*[ap]m)\s*$/i, "").trim();
+  const dateStr = chronoParseDate(dateText, "en-US");
+  if (!dateStr) return null;
+
+  // Pull the time token from the original line. Hogtown writes both
+  // bare-hour ("5pm") and minute-precise ("4:30pm") forms; parse12HourTime
+  // requires a colon, so handle the bare form ourselves.
+  const startTime = extractStartTime(d.dateLine);
+
+  // Title: "<SERIES> #N - <name>" — preserves the sub-series prefix per
+  // #1331 spec. Falls back to "<SERIES> #N" when the kennel didn't fill
+  // in a name.
+  const titleSuffix = d.rawTitle.trim();
+  const title = titleSuffix ? `${d.series} #${d.runNumber} - ${titleSuffix}` : `${d.series} #${d.runNumber}`;
+
+  // Treat literal TBD/TBA/TBC strings as "no value yet" — the Meetup link
+  // typically fills in later, but we don't want "TBD" in the canonical
+  // location field.
+  const cleanLocation = d.location && !/^TBD|^TBA|^TBC/i.test(d.location.trim())
+    ? d.location.trim()
+    : undefined;
+
+  return {
+    date: dateStr,
+    kennelTags: ["hogtownh3"],
+    runNumber: d.runNumber,
+    title,
+    hares: d.hares?.trim() || undefined,
+    location: cleanLocation,
+    startTime,
+    cost: d.cost?.trim() || undefined,
+    sourceUrl: d.sourceUrl ?? sourcePageUrl,
+  };
+}
+
+/**
+ * Parse Hogtown's browser-rendered HTML into RawEventData rows.
+ *
+ * The page is a flat sequence of `<p>` elements. A series-header
+ * paragraph (`Hogtown #2071 - GDU Saves the Day!`) starts a new entry;
+ * subsequent paragraphs add fields (date, hare, location, cost, RSVP url)
+ * until the next series header or end-of-document.
+ *
+ * Exported for unit testing.
+ */
+export function parseHogtownEvents(html: string, sourcePageUrl: string): RawEventData[] {
+  const paragraphs = collectParagraphs(html);
+  const out: RawEventData[] = [];
+  let draft: DraftEntry | null = null;
+
+  const flush = () => {
+    if (!draft) return;
+    const ev = finalizeEntry(draft, sourcePageUrl);
+    if (ev) out.push(ev);
+    draft = null;
+  };
+
+  for (const p of paragraphs) {
+    const header = SERIES_HEADER_RE.exec(p);
+    if (header) {
+      flush();
+      draft = {
+        series: normalizeSeries(header[1]),
+        runNumber: Number.parseInt(header[2], 10),
+        rawTitle: header[3] ?? "",
+      };
+      continue;
+    }
+    if (!draft) continue;
+
+    if (WEEKDAY_PREFIX_RE.test(p)) {
+      draft.dateLine = p;
+      continue;
+    }
+    const haresMatch = HARES_LABEL_RE.exec(p);
+    if (haresMatch) {
+      draft.hares = haresMatch[1];
+      continue;
+    }
+    const locMatch = LOCATION_LABEL_RE.exec(p);
+    if (locMatch) {
+      draft.location = locMatch[1];
+      continue;
+    }
+    const costMatch = COST_LABEL_RE.exec(p);
+    if (costMatch) {
+      draft.cost = costMatch[1];
+      continue;
+    }
+    const rsvpMatch = RSVP_URL_RE.exec(p);
+    if (rsvpMatch) {
+      draft.sourceUrl = rsvpMatch[1];
+      continue;
+    }
+  }
+  flush();
+
+  return out;
+}
+
+export class HogtownAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, _options?: { days?: number }): Promise<ScrapeResult> {
+    const baseUrl = source.url?.replace(/\/$/, "") || BASE_URL;
+    const upcomingUrl = `${baseUrl}${UPCOMING_PATH}`;
+    const homeUrl = `${baseUrl}${HOME_PATH}`;
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+    const all: RawEventData[] = [];
+
+    for (const [url, label] of [[upcomingUrl, "upcoming-trails"], [homeUrl, "home"]] as const) {
+      const result = await fetchBrowserRenderedPage(url, {
+        waitFor: "body",
+        timezoneId: "America/Toronto",
+        timeout: 25000,
+      });
+      if (!result.ok) {
+        const message = `Failed to render ${label}: ${result.result.errors.join("; ") || "browser-render error"}`;
+        errors.push(message);
+        errorDetails.fetch = [...(errorDetails.fetch ?? []), { url, message }];
+        continue;
+      }
+      const events = parseHogtownEvents(result.html, url);
+      all.push(...events);
+    }
+
+    // Dedup by (series prefix in title + runNumber) — the home page
+    // typically repeats the next trail also on /upcoming-trails. Keep the
+    // first occurrence (chronologically ordered on the source).
+    const seen = new Set<string>();
+    const deduped: RawEventData[] = [];
+    for (const ev of all) {
+      const key = `${ev.runNumber ?? ""}|${ev.title ?? ""}|${ev.date}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      deduped.push(ev);
+    }
+
+    return {
+      events: deduped,
+      errors,
+      errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+    };
+  }
+}

--- a/src/adapters/html-scraper/hogtown.ts
+++ b/src/adapters/html-scraper/hogtown.ts
@@ -7,7 +7,13 @@ import type {
   ErrorDetails,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { chronoParseDate, fetchBrowserRenderedPage } from "../utils";
+import {
+  buildDateWindow,
+  chronoParseDate,
+  decodeEntities,
+  fetchBrowserRenderedPage,
+  stripPlaceholder,
+} from "../utils";
 
 /**
  * Hogtown H3 (Toronto) — Google Sites SPA at hogtownh3.com. Resolves
@@ -34,13 +40,14 @@ const BASE_URL = "https://www.hogtownh3.com";
 const UPCOMING_PATH = "/upcoming-trails";
 const HOME_PATH = "/";
 
-/** Series prefix detector. Run separately from the title extraction below
- * to keep each regex below the complexity bound — combining series +
- * run-number + title in one regex tripped Sonar S5843 (#1635 review). */
-const SERIES_TOKEN_RE = /^(HOGTOWN|HOGANS|TWAT)\s*#?\s*(\d+)/i;
+/** Series prefixes the kennel publishes. Matched via case-insensitive
+ * startsWith — see `parseSeriesHeader` — rather than a single
+ * alternation regex, which trips Sonar S5852 on its alternation pattern. */
+const SERIES_PREFIXES = ["HOGTOWN", "HOGANS", "TWAT"] as const;
+const SERIES_RUN_RE = /^\s*#?\s*(\d+)/;
 const MEETUP_ID_PREFIX_RE = /^\d+\s*\/\s*/;
 const TITLE_DASH_PREFIX_RE = /^\s*[-–]\s*/;
-const WEEKDAY_PREFIX_RE = /^(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)/i;
+const WEEKDAY_PREFIXES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 const URL_RE = /https?:\/\/\S+/;
 const BARE_TIME_RE = /(\d{1,2})(?::(\d{2}))?\s*([ap])m/i;
 
@@ -68,12 +75,15 @@ interface SeriesHeader {
  * components. Returns null if the text isn't a recognizable header. */
 function parseSeriesHeader(text: string): SeriesHeader | null {
   const stripped = text.trim().replace(MEETUP_ID_PREFIX_RE, "");
-  const m = SERIES_TOKEN_RE.exec(stripped);
-  if (!m) return null;
-  const runNumber = Number.parseInt(m[2], 10);
-  const series = normalizeSeries(m[1]);
-  const title = stripped.slice(m[0].length).replace(TITLE_DASH_PREFIX_RE, "").trim();
-  return { series, runNumber, title };
+  const upper = stripped.toUpperCase();
+  const matchedPrefix = SERIES_PREFIXES.find((prefix) => upper.startsWith(prefix));
+  if (!matchedPrefix) return null;
+  const after = stripped.slice(matchedPrefix.length);
+  const runMatch = SERIES_RUN_RE.exec(after);
+  if (!runMatch) return null;
+  const runNumber = Number.parseInt(runMatch[1], 10);
+  const title = after.slice(runMatch[0].length).replace(TITLE_DASH_PREFIX_RE, "").trim();
+  return { series: matchedPrefix, runNumber, title };
 }
 
 /** Convert a `BARE_TIME_RE` match to an HH:MM string. */
@@ -97,26 +107,16 @@ interface DraftEntry {
   sourceUrl?: string;
 }
 
-/** Normalize a series token to a consistent display label embedded in the
- * event title. The source mixes casing (Hogtown vs HOGTOWN). */
-function normalizeSeries(s: string): string {
-  const upper = s.toUpperCase();
-  if (upper === "HOGTOWN") return "HOGTOWN";
-  if (upper === "HOGANS") return "HOGANS";
-  if (upper === "TWAT") return "TWAT";
-  return upper;
-}
-
-/** Read every `<p>` element in document order, returning its trimmed text
- * with ` ` (NBSP) collapsed to regular spaces. Defensive against
- * Google Sites rotating its `zfr3Q`-style class names — we key on content
- * shape, not class. */
+/** Read every <p> element in document order, returning its trimmed text
+ * with NBSP/named entities decoded and whitespace collapsed. Defensive
+ * against Google Sites rotating its `zfr3Q`-style class names — we key on
+ * content shape, not class. */
 function collectParagraphs(html: string): string[] {
   const $ = cheerio.load(html);
   $("script, style").remove();
   const out: string[] = [];
   $("p").each((_i, el) => {
-    const text = $(el).text().replaceAll(/\s+/g, " ").trim();
+    const text = decodeEntities($(el).text()).replaceAll(/\s+/g, " ").trim();
     if (text) out.push(text);
   });
   return out;
@@ -145,12 +145,10 @@ function finalizeEntry(d: DraftEntry, sourcePageUrl: string): RawEventData | nul
   const titleSuffix = d.rawTitle.trim();
   const title = titleSuffix ? `${d.series} #${d.runNumber} - ${titleSuffix}` : `${d.series} #${d.runNumber}`;
 
-  // Treat literal TBD/TBA/TBC strings as "no value yet" — the Meetup link
-  // typically fills in later, but we don't want "TBD" in the canonical
-  // location field.
-  const cleanLocation = d.location && !/^TBD|^TBA|^TBC/i.test(d.location.trim())
-    ? d.location.trim()
-    : undefined;
+  // Drop TBD/TBA placeholder locations through the shared helper — keeps
+  // canonical location fields free of "TBD" until the kennel posts the
+  // real venue (typically a few days before the trail).
+  const cleanLocation = stripPlaceholder(d.location);
 
   return {
     date: dateStr,
@@ -196,7 +194,7 @@ export function parseHogtownEvents(html: string, sourcePageUrl: string): RawEven
     }
     if (!draft) continue;
 
-    if (WEEKDAY_PREFIX_RE.test(p)) {
+    if (WEEKDAY_PREFIXES.some((w) => p.startsWith(w))) {
       draft.dateLine = p;
       continue;
     }
@@ -228,10 +226,18 @@ export function parseHogtownEvents(html: string, sourcePageUrl: string): RawEven
 export class HogtownAdapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
-  async fetch(source: Source, _options?: { days?: number }): Promise<ScrapeResult> {
-    const baseUrl = source.url?.replace(/\/$/, "") || BASE_URL;
-    const upcomingUrl = `${baseUrl}${UPCOMING_PATH}`;
-    const homeUrl = `${baseUrl}${HOME_PATH}`;
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    // Build URLs from the source URL's *origin* — the seeded source.url
+    // points at `/upcoming-trails` directly, so naive string concatenation
+    // would produce `/upcoming-trails/upcoming-trails`.
+    let origin = BASE_URL;
+    try {
+      if (source.url) origin = new URL(source.url).origin;
+    } catch {
+      origin = BASE_URL;
+    }
+    const upcomingUrl = `${origin}${UPCOMING_PATH}`;
+    const homeUrl = `${origin}${HOME_PATH}`;
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
     const all: RawEventData[] = [];
@@ -252,9 +258,10 @@ export class HogtownAdapter implements SourceAdapter {
       all.push(...events);
     }
 
-    // Dedup by (series prefix in title + runNumber) — the home page
-    // typically repeats the next trail also on /upcoming-trails. Keep the
-    // first occurrence (chronologically ordered on the source).
+    // Dedup by (runNumber + title + date) — the home page typically
+    // repeats the next trail that's also on /upcoming-trails. Title
+    // already carries the series prefix, so cross-series collisions on
+    // a shared run number can't happen.
     const seen = new Set<string>();
     const deduped: RawEventData[] = [];
     for (const ev of all) {
@@ -264,8 +271,16 @@ export class HogtownAdapter implements SourceAdapter {
       deduped.push(ev);
     }
 
+    // Honor `options.days` per the adapter-patterns rule: a tight admin
+    // re-scrape probe shouldn't pull events outside its requested window.
+    // Default to 120 days (matches seed.scrapeDays). minDate is open-ended
+    // on the past side — the source itself is upcoming-only.
+    const days = options?.days ?? source.scrapeDays ?? 120;
+    const { maxDate } = buildDateWindow(days);
+    const filtered = deduped.filter((ev) => new Date(ev.date) <= maxDate);
+
     return {
-      events: deduped,
+      events: filtered,
       errors,
       errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
     };

--- a/src/adapters/html-scraper/hogtown.ts
+++ b/src/adapters/html-scraper/hogtown.ts
@@ -177,6 +177,35 @@ function finalizeEntry(d: DraftEntry, sourcePageUrl: string): RawEventData | nul
  *
  * Exported for unit testing.
  */
+/** Apply a single content paragraph to an in-progress draft entry,
+ * setting the matching field. Extracted to keep `parseHogtownEvents`
+ * under the cognitive-complexity bound (Sonar S3776). */
+function applyParagraphToDraft(draft: DraftEntry, p: string): void {
+  if (WEEKDAY_PREFIXES.some((w) => p.startsWith(w))) {
+    draft.dateLine = p;
+    return;
+  }
+  const hares = tryExtractLabel(p, "Hares:", "Hare:");
+  if (hares !== undefined) {
+    draft.hares = hares;
+    return;
+  }
+  const location = tryExtractLabel(p, "Start Location:");
+  if (location !== undefined) {
+    draft.location = location;
+    return;
+  }
+  const cost = tryExtractLabel(p, "Cost:");
+  if (cost !== undefined) {
+    draft.cost = cost;
+    return;
+  }
+  if (/^RSVP\b/i.test(p)) {
+    const url = URL_RE.exec(p);
+    if (url) draft.sourceUrl = url[0];
+  }
+}
+
 export function parseHogtownEvents(html: string, sourcePageUrl: string): RawEventData[] {
   const paragraphs = collectParagraphs(html);
   const out: RawEventData[] = [];
@@ -194,32 +223,8 @@ export function parseHogtownEvents(html: string, sourcePageUrl: string): RawEven
     if (header) {
       flush();
       draft = { series: header.series, runNumber: header.runNumber, rawTitle: header.title };
-      continue;
-    }
-    if (!draft) continue;
-
-    if (WEEKDAY_PREFIXES.some((w) => p.startsWith(w))) {
-      draft.dateLine = p;
-      continue;
-    }
-    const hares = tryExtractLabel(p, "Hares:", "Hare:");
-    if (hares !== undefined) {
-      draft.hares = hares;
-      continue;
-    }
-    const location = tryExtractLabel(p, "Start Location:");
-    if (location !== undefined) {
-      draft.location = location;
-      continue;
-    }
-    const cost = tryExtractLabel(p, "Cost:");
-    if (cost !== undefined) {
-      draft.cost = cost;
-      continue;
-    }
-    if (/^RSVP\b/i.test(p)) {
-      const url = URL_RE.exec(p);
-      if (url) draft.sourceUrl = url[0];
+    } else if (draft) {
+      applyParagraphToDraft(draft, p);
     }
   }
   flush();

--- a/src/adapters/html-scraper/hogtown.ts
+++ b/src/adapters/html-scraper/hogtown.ts
@@ -44,7 +44,7 @@ const HOME_PATH = "/";
  * startsWith — see `parseSeriesHeader` — rather than a single
  * alternation regex, which trips Sonar S5852 on its alternation pattern. */
 const SERIES_PREFIXES = ["HOGTOWN", "HOGANS", "TWAT"] as const;
-const SERIES_RUN_RE = /^\s*#?\s*(\d+)/;
+const LEADING_DIGITS_RE = /^(\d+)/;
 const MEETUP_ID_PREFIX_RE = /^\d+\s*\/\s*/;
 const TITLE_DASH_PREFIX_RE = /^\s*[-–]\s*/;
 const WEEKDAY_PREFIXES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
@@ -78,8 +78,12 @@ function parseSeriesHeader(text: string): SeriesHeader | null {
   const upper = stripped.toUpperCase();
   const matchedPrefix = SERIES_PREFIXES.find((prefix) => upper.startsWith(prefix));
   if (!matchedPrefix) return null;
-  const after = stripped.slice(matchedPrefix.length);
-  const runMatch = SERIES_RUN_RE.exec(after);
+  // Skip whitespace + optional `#` + whitespace procedurally so the
+  // anchored regex below has no `\s*` quantifier — keeps Sonar S5852
+  // off this line.
+  let after = stripped.slice(matchedPrefix.length).trimStart();
+  if (after.startsWith("#")) after = after.slice(1).trimStart();
+  const runMatch = LEADING_DIGITS_RE.exec(after);
   if (!runMatch) return null;
   const runNumber = Number.parseInt(runMatch[1], 10);
   const title = after.slice(runMatch[0].length).replace(TITLE_DASH_PREFIX_RE, "").trim();

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -101,6 +101,7 @@ import { AucklandHussiesAdapter } from "./html-scraper/auckland-hussies";
 import { CapitalH3Adapter } from "./html-scraper/capital-h3";
 import { MoolooHhhAdapter } from "./html-scraper/mooloo-hhh";
 import { GeriatrixH3Adapter } from "./html-scraper/geriatrix-h3";
+import { HogtownAdapter } from "./html-scraper/hogtown";
 import { GoogleCalendarAdapter } from "./google-calendar/adapter";
 import { GoogleSheetsAdapter } from "./google-sheets/adapter";
 import { ICalAdapter } from "./ical/adapter";
@@ -248,6 +249,11 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /sporty\.co\.nz\/capitalh3/i,         name: "CapitalH3Adapter",   factory: () => new CapitalH3Adapter() },
   { pattern: /sporty\.co\.nz\/mooloohhh/i,         name: "MoolooHhhAdapter",   factory: () => new MoolooHhhAdapter() },
   { pattern: /sporty\.co\.nz\/geriatrixhhh/i,      name: "GeriatrixH3Adapter", factory: () => new GeriatrixH3Adapter() },
+  // ── Canada (Toronto) ──
+  // Hogtown H3 (#1331) — Google Sites SPA, browser-rendered. Three sub-series
+  // (HOGTOWN / TWAT / HOGANS) share one kennel; the series prefix lives in
+  // the title since the schema has no sub-series field.
+  { pattern: /hogtownh3\.com/i, name: "HogtownAdapter", factory: () => new HogtownAdapter() },
 ];
 
 /** URL-based routing for HTML_SCRAPER — derived from htmlScraperEntries (single source of truth). */


### PR DESCRIPTION
## Summary

- **`HogtownAdapter`** — new HTML_SCRAPER for `hogtownh3.com/upcoming-trails`. Browser-rendered (Google Sites SPA). Parses three concurrent sub-series (HOGTOWN / TWAT / HOGANS) into per-event hash names + run numbers + hares + locations + costs. Replaces the Meetup adapter's three recycled template titles.
- **`scripts/cleanup-lbh-misbound-rawevents.ts`** — one-shot cleanup for the 107 LBH-PHX RawEvents that landed under the wrong source ("Phoenix H3 Events" ICS instead of "Phoenix H3 Big Ass Calendar" HTML) during the first apply of #1628. Already run against prod with full verification.

## Hogtown adapter — design notes

- The kennel runs three sub-series under one Meetup group, each with its own run-number sequence. Per #1331's spec, the schema doesn't gain a sub-series field; instead the parser embeds the series prefix in the title (`"HOGTOWN #2071 - GDU Saves the Day!"`).
- Google Sites is an SPA — raw `curl` returns zero hits for `HOGTOWN`/`Hare:`. Adapter goes through the NAS browser-render service via `fetchBrowserRenderedPage` with `timezoneId: "America/Toronto"`.
- Parser keys off **content shape** (regex over leaf `<p>` text — series header + label/value siblings), not class names. Google Sites rotates opaque class names (`zfr3Q`, `CDt4Ke`) periodically, so anchoring on those is fragile.
- Bare-hour time parsing (`5pm`, `7:30pm`) — `parse12HourTime` requires a colon, so the adapter handles `\d{1,2}(:\d{2})?\s*[ap]m` inline.
- Fetches both `/upcoming-trails` and `/` (home), dedups by `(runNumber, title, date)`. Home page typically only shows the next trail, which dedup folds in.
- `TBD` / `TBA` / `TBC` locations are dropped to `undefined` (preserve-existing semantics, not overwrite-clear).
- Trust=8 HTML_SCRAPER. Lives alongside the existing trust=7 Meetup adapter — the merge pipeline picks the higher-trust source's per-field values, so the Meetup template titles get overridden by the website's real names.

## Live verification (against prod browser-render)

```
events: 4 | errors: 0
 - 2026-05-23 17:00 #2071 | HOGTOWN #2071 - GDU Saves the Day!         | hares: GDU                            | loc: Samara Brewery, 90 Cawthra Ave. A-B trail.
 - 2026-05-28 19:00 #582  | TWAT #582 - Naughty's Birthday Trail        | hares: Around the World in Naughty Ways| loc: —
 - 2026-06-06 17:00 #2072 | HOGTOWN #2072 - Half Wit's Hot Ones…        | hares: Half Wit                       | loc: Rainhard Brewery, 100 Symes Road
 - 2026-06-12 19:00 #462  | HOGANS #462 - Hareless Hogans               | hares: TBD - Hare needed!             | loc: —
```

## LBH cleanup — apply results

```
Found 107 misbound candidates under "Phoenix H3 Events" scraped on 2026-05-22.
Canonical source has 108 keyed LBH RawEvents available as backstop.
Safe to delete (twin exists under "Phoenix H3 Big Ass Calendar"): 107
UNSAFE (no canonical twin, will NOT delete): 0

Deleted 107 RawEvents.
Verified: all 107 touched canonical Events still have at least one RawEvent backing.
```

Post-cleanup state:
- `Phoenix H3 Events` lbh-phx RawEvents: 116 → 9 (back to legit accumulated ICS rows only)
- `Phoenix H3 Big Ass Calendar` lbh-phx RawEvents: 299 (untouched)
- LBH-PHX canonical Events: 113 total / 112 past (unchanged)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (20 pre-existing warnings unrelated to this PR)
- [x] `npm test` — 7178 passed / 7 skipped / 25 todo / **0 failed**
- [x] New unit tests: 8 for `parseHogtownEvents` covering all 3 series, bare-hour + colon time, `Hare:`/`Hares:` variants, TBD location dropping, RSVP url passthrough, empty-document path
- [x] Live HogtownAdapter fetch against prod browser-render — 4 events, 0 errors, all fields populated
- [x] Cleanup script dry-run + apply against prod — all 107 misbound RawEvents safely removed, canonical Events intact

Closes #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)