### PR TITLE
fix(pipeline): post-merge gaps from #1626 (locationStreet fingerprint + MoA2H3 seed)

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -273,7 +273,9 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "mh3-mn": ["Minneapolis Hash", "Minneapolis H3", "MH3", "MplsH3"],
     "t3h3": ["Twin Titties Hash", "Twin Titties Thirstday", "T3H3", "TTTH3"],
     // ===== MICHIGAN =====
-    "moa2h3": ["Motown Ann Arbor Hash", "MoA2H3", "Motown Hash", "Ann Arbor Hash", "A2H3"],
+    // "Motown/Ann Arbor H3" added so the Hash Rego detail page's
+    // hostKennelName resolves to moa2h3 (#1578 follow-up).
+    "moa2h3": ["Motown Ann Arbor Hash", "MoA2H3", "Motown Hash", "Ann Arbor Hash", "A2H3", "Motown/Ann Arbor H3"],
     "demon-h3": ["DeMon Hash", "DeMon H3", "Detroit Monday Hash"],
     "glh3": ["Greater Lansing Hash", "Greater Lansing H3", "GLH3", "Lansing Hash"],
     // ===== ARIZONA =====

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -869,11 +869,16 @@ export const SOURCES = [
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,
-      kennelCodes: ["bfm", "ewh3", "wh4", "gfh3", "ch3", "dch4", "dcfmh3", "fch3", "oh3", "wsh3", "mrh3", "bfh3"],
+      // #1578 follow-up — added moa2h3 so MoA2H3 events (e.g. Red Dress Run)
+      // on the Hash Rego index get scraped instead of being filtered out by
+      // the source-kennel guard. The detail page hostKennelName is
+      // "Motown/Ann Arbor H3" — added as an alias in `aliases.ts` so the
+      // kennel resolver maps it to moa2h3.
+      kennelCodes: ["bfm", "ewh3", "wh4", "gfh3", "ch3", "dch4", "dcfmh3", "fch3", "oh3", "wsh3", "mrh3", "bfh3", "moa2h3"],
       kennelSlugMap: {
         bfm: "BFMH3", ewh3: "EWH3", wh4: "WH4", gfh3: "GFH3",
         ch3: "CH3", dch4: "DCH4", dcfmh3: "DCFMH3", fch3: "FCH3", oh3: "OregonH3",
-        wsh3: "WSH3", mrh3: "MRH3", bfh3: "BFH3",
+        wsh3: "WSH3", mrh3: "MRH3", bfh3: "BFH3", moa2h3: "MoA2H3",
       },
     },
     // ===== TEXAS =====

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -26,7 +26,13 @@ export interface RawEventData {
    * not a venue — Auckland Hussies #1516).
    */
   location?: string | null;
-  locationStreet?: string; // Full street address (multi-line address blocks)
+  /**
+   * Street address (multi-line address blocks). Tri-state matching `location`:
+   * undefined = preserve existing, null = explicit clear, string = overwrite.
+   * The fingerprint includes this via `withClearSignal` so an adapter that
+   * newly emits or clears the street re-fingerprints (#1579 follow-up).
+   */
+  locationStreet?: string | null;
   locationUrl?: string; // Google Maps or other maps URL
   latitude?: number;
   longitude?: number;

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -29,8 +29,10 @@ export interface RawEventData {
   /**
    * Street address (multi-line address blocks). Tri-state matching `location`:
    * undefined = preserve existing, null = explicit clear, string = overwrite.
-   * The fingerprint includes this via `withClearSignal` so an adapter that
-   * newly emits or clears the street re-fingerprints (#1579 follow-up).
+   * The fingerprint includes this via a gated spread so an adapter that
+   * newly emits or clears the street re-fingerprints — without triggering a
+   * global re-merge wave for events that never had the field (#1579
+   * follow-up; same gating pattern as `endDate`).
    */
   locationStreet?: string | null;
   locationUrl?: string; // Google Maps or other maps URL

--- a/src/pipeline/fingerprint.test.ts
+++ b/src/pipeline/fingerprint.test.ts
@@ -61,6 +61,20 @@ describe("generateFingerprint", () => {
     expect(a).not.toBe(b);
   });
 
+  // #1579 gating regression — a baseline event that never carries
+  // locationStreet must fingerprint identically before and after the field
+  // was added (Gemini PR #1636 review). Without gating, `triStateStringToken`
+  // on undefined would append an empty token to every event's fingerprint
+  // → global re-merge wave + RawEvent table doubling on next scrape.
+  it("locationStreet=undefined contributes no token (no global re-merge wave)", () => {
+    // Manually reconstruct the pre-#1579-followup fingerprint by stripping
+    // locationStreet entirely. If the gated spread works, omitting the field
+    // produces the same hash as passing `undefined`.
+    const baseline = buildRawEvent();
+    const withExplicitUndefined = buildRawEvent({ locationStreet: undefined });
+    expect(generateFingerprint(baseline)).toBe(generateFingerprint(withExplicitUndefined));
+  });
+
   it("different hares produce different fingerprints", () => {
     const a = generateFingerprint(buildRawEvent({ hares: undefined }));
     const b = generateFingerprint(buildRawEvent({ hares: "Mudflap, Just Simon" }));

--- a/src/pipeline/fingerprint.test.ts
+++ b/src/pipeline/fingerprint.test.ts
@@ -43,6 +43,24 @@ describe("generateFingerprint", () => {
     expect(a).not.toBe(b);
   });
 
+  // #1579 follow-up — locationStreet is independent of location. Without
+  // this field in the fingerprint, OKissMe-style adapters that newly emit a
+  // street address would dedup against the prior RawEvent row and the
+  // canonical UPDATE would never persist locationStreet.
+  it("different locationStreet values produce different fingerprints", () => {
+    const a = generateFingerprint(buildRawEvent({ locationStreet: undefined }));
+    const b = generateFingerprint(buildRawEvent({
+      locationStreet: "215 Chapin St, Ann Arbor, MI, 48103",
+    }));
+    expect(a).not.toBe(b);
+  });
+
+  it("locationStreet null (explicit clear) differs from undefined", () => {
+    const a = generateFingerprint(buildRawEvent({ locationStreet: undefined }));
+    const b = generateFingerprint(buildRawEvent({ locationStreet: null }));
+    expect(a).not.toBe(b);
+  });
+
   it("different hares produce different fingerprints", () => {
     const a = generateFingerprint(buildRawEvent({ hares: undefined }));
     const b = generateFingerprint(buildRawEvent({ hares: "Mudflap, Just Simon" }));

--- a/src/pipeline/fingerprint.ts
+++ b/src/pipeline/fingerprint.ts
@@ -83,9 +83,23 @@ export function generateFingerprint(data: RawEventData): string {
     // `columns.address`). Without this, OKissMe-style adapters that newly
     // emit `locationStreet` for an existing event get fingerprint-deduped
     // against the prior RawEvent row, so the canonical UPDATE never fires
-    // and `Event.locationStreet` stays null forever. Triggers a one-time
-    // re-merge wave on first deploy (same comment block as #1316 above).
-    triStateStringToken(data.locationStreet),
+    // and `Event.locationStreet` stays null forever.
+    //
+    // CRITICAL: gated via spread (same pattern as `endDate` below — Codex P1
+    // review on #1560). An unconditional `triStateStringToken(...)` token
+    // would change the fingerprint of every existing RawEvent on next scrape
+    // (since most events have `locationStreet: undefined`), doubling the
+    // RawEvent table for the entire active source set. By gating, events
+    // that don't carry a street fingerprint identically pre/post-deploy;
+    // only adapters that newly emit or explicit-clear the street (OKissMe
+    // after its config update; future address-aware adapters) re-fingerprint
+    // their specific rows. The `!== undefined` check preserves tri-state
+    // semantics: `null` still distinguishes from `undefined` and contributes
+    // the EXPLICIT_CLEAR_TOKEN, so a flip from "had street" → "explicit
+    // clear" still re-fingerprints.
+    ...(data.locationStreet !== undefined
+      ? [`locationStreet=${triStateStringToken(data.locationStreet)}`]
+      : []),
     // #1560 — endDate (multi-day series). Adapters shifting an event from
     // single-day to multi-day (or extending the range) must invalidate the
     // RawEvent dedup so the canonical UPDATE fires.

--- a/src/pipeline/fingerprint.ts
+++ b/src/pipeline/fingerprint.ts
@@ -79,6 +79,13 @@ export function generateFingerprint(data: RawEventData): string {
     withClearSignal(data.trailLengthMinMiles, (n) => n.toString()),
     withClearSignal(data.trailLengthMaxMiles, (n) => n.toString()),
     withClearSignal(data.difficulty, (n) => n.toString()),
+    // #1579 follow-up — locationStreet (independent of location, see GSheets
+    // `columns.address`). Without this, OKissMe-style adapters that newly
+    // emit `locationStreet` for an existing event get fingerprint-deduped
+    // against the prior RawEvent row, so the canonical UPDATE never fires
+    // and `Event.locationStreet` stays null forever. Triggers a one-time
+    // re-merge wave on first deploy (same comment block as #1316 above).
+    triStateStringToken(data.locationStreet),
     // #1560 — endDate (multi-day series). Adapters shifting an event from
     // single-day to multi-day (or extending the range) must invalidate the
     // RawEvent dedup so the canonical UPDATE fires.

--- a/src/pipeline/fingerprint.ts
+++ b/src/pipeline/fingerprint.ts
@@ -93,13 +93,13 @@ export function generateFingerprint(data: RawEventData): string {
     // that don't carry a street fingerprint identically pre/post-deploy;
     // only adapters that newly emit or explicit-clear the street (OKissMe
     // after its config update; future address-aware adapters) re-fingerprint
-    // their specific rows. The `!== undefined` check preserves tri-state
+    // their specific rows. The `=== undefined` check preserves tri-state
     // semantics: `null` still distinguishes from `undefined` and contributes
     // the EXPLICIT_CLEAR_TOKEN, so a flip from "had street" → "explicit
     // clear" still re-fingerprints.
-    ...(data.locationStreet !== undefined
-      ? [`locationStreet=${triStateStringToken(data.locationStreet)}`]
-      : []),
+    ...(data.locationStreet === undefined
+      ? []
+      : [`locationStreet=${triStateStringToken(data.locationStreet)}`]),
     // #1560 — endDate (multi-day series). Adapters shifting an event from
     // single-day to multi-day (or extending the range) must invalidate the
     // RawEvent dedup so the canonical UPDATE fires.


### PR DESCRIPTION
## Summary

Two prod gaps surfaced after [#1626](https://github.com/johnrclem/hashtracks-web/pull/1626) merged and I tried to verify the 4 audit events on the live hareline. Quality Gate was passing; these are correctness follow-ups, not regressions in the merged code.

### (1) #1579 OKissMe — locationStreet missing from fingerprint

After pointing OKissMe's \`Source.config\` at the right columns (\`location: 3\`, \`address: 4\`) and forcing a re-scrape, the adapter produced 22 events with new \`locationStreet\` values — all reported as \`skipped\` (\`created: 0, updated: 0\`).

Root cause: \`locationStreet\` was never in \`generateFingerprint\`'s input array. So:

- Adapter emitted the same hares / location / runNumber as before
- ... plus a new \`locationStreet\`
- Fingerprint matched the pre-existing RawEvent → row dedup'd
- Merge UPDATE branch never fired → \`Event.locationStreet\` stayed null

**Fix:** add \`triStateStringToken(data.locationStreet)\` to the fingerprint array. Widens \`RawEventData.locationStreet\` to \`string | null\` to align with the tri-state pattern (\`location\`, \`hares\`, \`description\`, \`startTime\`, etc.). First re-scrape after this lands triggers a one-time re-merge wave (same comment block as #1316 / WS6 — \`(sourceId, fingerprint)\` unique index + source-kennel guard hold so no duplicates).

### (2) #1578 MoA2H3 — source-kennel link + alias gap

The adapter fix in #1626 correctly extracts hares + venue + address from the HashRego \`Start Location Details\` DOM block, but \`moa2h3\` was never linked to the Hash Rego source via \`SourceKennel\`. The adapter's index filter therefore skipped every MoA2H3 entry (\`unmappedKennelSlugs: [..., "MOA2H3", ...]\` in the scrape diag).

Adding the \`SourceKennel\` link directly in prod gets pruned by the seed reconciler (\`linkKennelsToSource\` in \`prisma/seed.ts\`) on next \`prisma db seed\`. So the durable fix is in seed:

- \`kennelCodes\`: \`[..., "moa2h3"]\`
- \`kennelSlugMap\`: \`{ ..., moa2h3: "MoA2H3" }\`

And once the link works, the kennel resolver *still* fails because the Hash Rego detail page emits \`hostKennelName: "Motown/Ann Arbor H3"\` (with the slash) — not in moa2h3's existing aliases. Added it to \`aliases.ts\`.

## Post-merge operator action

1. \`npx prisma db seed\` against prod — creates the \`moa2h3\` ↔ Hash Rego SourceKennel row + adds the alias.
2. Force re-scrape Hash Rego: \`POST /api/cron/scrape/cmlsh9ynh0021m4m9vem8z9kh\` with Bearer CRON_SECRET. Expected: \`eventsFound\` includes MoA2H3 events; \`Event.haresText\` + \`locationName\` populate for the Red Dress Run.
3. Force re-scrape OKissMe: \`POST /api/cron/scrape/cmmpaf3pb000004i8x3bqj87s\`. Expected: 22 events all \`updated\` (new fingerprint triggers merge UPDATE); \`Event.locationStreet\` populates for rows where the sheet's Address column is filled.

## Test plan

- [x] \`npx vitest run src/pipeline/fingerprint.test.ts\` → 14 pass (+2 new)
- [x] \`npx vitest run src/pipeline/merge.test.ts src/adapters/google-sheets/\` → 491 pass
- [x] \`npm test\` → 7172 pass / 0 fail
- [x] \`npx tsc --noEmit\` → clean
- [x] \`npm run lint\` → 0 errors
- [ ] Post-merge: run \`npx prisma db seed\` against prod, re-scrape Hash Rego + OKissMe, verify the 4 audit events display correctly on https://www.hashtracks.xyz/hareline

Refs #1578 #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)