### PR TITLE
feat(hashrego): venue-weekend campout heuristic — closes #1560

### DIFF
--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -7,6 +7,7 @@ import {
   parseEventDetail,
   splitToRawEvents,
   parseDayHeaderSections,
+  detectVenueWeekendEndDate,
 } from "./parser";
 import { HashRegoAdapter, apiToIndexEntry } from "./adapter";
 import { HashRegoApiError, type HashRegoKennelEvent } from "./api";
@@ -1030,6 +1031,163 @@ describe("parseDayHeaderSections", () => {
       { date: "2026-04-04", startTime: undefined },
       { date: "2026-04-05", startTime: "10:00" },
     ]);
+  });
+});
+
+// ── detectVenueWeekendEndDate (#1560 PR C) ──
+
+describe("detectVenueWeekendEndDate", () => {
+  // Table-driven per memory `feedback_it_each_for_sonar_cpd.md`.
+  it.each([
+    {
+      label: "MadisonH3 Token Run — Friday/Saturday/Sunday weekend",
+      // 2026-01-16 is a Friday; Sunday is +2 days.
+      desc: "Token Run Campout! Friday arrival 6pm, Saturday trail at 10am, Sunday brunch then home.",
+      title: "Token Run Campout 2026",
+      start: "2026-01-16",
+      expected: "2026-01-18",
+    },
+    {
+      label: "Trigger word in TITLE alone — description has no trigger but does mention weekdays",
+      desc: "Friday arrival, Saturday main trail, Sunday brunch.",
+      title: "Annual Weekend Retreat",
+      start: "2026-01-16",
+      expected: "2026-01-18",
+    },
+    {
+      label: "Trigger word `camp out` (with space) matches",
+      desc: "Two-night camp out. Fri pre-lube, Sat main trail, Sun departure.",
+      title: "Spring Camp Out",
+      start: "2026-03-20",
+      expected: "2026-03-22",
+    },
+    {
+      label: "Abbreviated weekday names",
+      desc: "Retreat schedule: Fri kickoff, Sat hike, Sun cooldown.",
+      title: "Spring Retreat",
+      start: "2026-04-10",
+      expected: "2026-04-12",
+    },
+    {
+      label: "Trigger 'rendezvous' counts",
+      desc: "Annual rendezvous. Friday meet & greet, Saturday trail, Sunday brunch.",
+      title: "Annual Rendezvous",
+      start: "2026-06-12",
+      expected: "2026-06-14",
+    },
+    {
+      label: "Start on Saturday, mentions Sunday only — wraps forward 1 day",
+      // 2026-07-04 is Saturday.
+      desc: "Saturday/Sunday weekend campout. Sat lead-off, Sun recovery.",
+      title: "July 4 Campout",
+      start: "2026-07-04",
+      expected: "2026-07-05",
+    },
+    {
+      label: "Year boundary — NYE campout Fri 12/31 → Sun 1/2",
+      // 2026-12-31 is Thursday actually. Let me pick a real NYE Fri:
+      // 2027-12-31 is Friday. End Sun = 2028-01-02.
+      desc: "NYE weekend! Friday party, Saturday hangover trail, Sunday brunch.",
+      title: "NYE Weekend Campout",
+      start: "2027-12-31",
+      expected: "2028-01-02",
+    },
+  ])("$label", ({ desc, title, start, expected }) => {
+    expect(detectVenueWeekendEndDate(desc, title, start)).toBe(expected);
+  });
+
+  // Non-trigger negatives — the heuristic must NOT expand single-day trails
+  // whose descriptions happen to name a weekday.
+  it("returns null when description has no trigger word", () => {
+    expect(
+      detectVenueWeekendEndDate(
+        "Join us Friday for a great trail. Saturday brunch optional.",
+        "Friday Trail",
+        "2026-01-16",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null with trigger but only one weekday mentioned", () => {
+    expect(
+      detectVenueWeekendEndDate("Annual campout — Saturday only.", "Saturday Campout", "2026-01-17"),
+    ).toBeNull();
+  });
+
+  it("returns null when every weekday mention collapses to the start day", () => {
+    // 2026-01-17 is Saturday. "Saturday" twice → all offsets = 0.
+    expect(
+      detectVenueWeekendEndDate(
+        "Weekend campout. Saturday lead-off, Saturday afterparty.",
+        "Campout",
+        "2026-01-17",
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores 'Sat' inside larger words (Saturn / Satellite)", () => {
+    // No real weekend trigger should fire — only "Saturday" as a word.
+    expect(
+      detectVenueWeekendEndDate(
+        "Campout weekend — Saturn-themed party. No real day mentions.",
+        "Saturn Campout",
+        "2026-01-17",
+      ),
+    ).toBeNull();
+  });
+});
+
+// ── splitToRawEvents — venue-weekend (#1560 PR C) ──
+
+const MADISON_TOKEN_RUN_HTML = `
+<html>
+<head>
+  <title>Token Run Campout 2026</title>
+  <meta property="og:title" content="1/16 Token Run Campout 2026" />
+  <meta property="og:description" content='Annual Token Run Campout!
+
+Friday arrival, fire pit & registration 6pm onwards.
+Saturday main trail 10am, BBQ + bonfire after.
+Sunday recovery hike, then departure by 11am.
+
+**Cost:** $85' />
+</head>
+<body>
+  <a href="/kennels/MadisonH3/">Madison H3</a>
+</body>
+</html>`;
+
+const MADISON_INDEX_ENTRY = {
+  slug: "madison-token-run-2026",
+  kennelSlug: "MadisonH3",
+  title: "Token Run Campout 2026",
+  // 2026-01-16 = Friday
+  startDate: "01/16/26",
+  startTime: "06:00 PM",
+  type: "Hash Campout",
+  cost: "$85",
+};
+
+describe("splitToRawEvents — venue-weekend campout (#1560 PR C)", () => {
+  it("emits ONE row with endDate set (no children, no seriesParent)", () => {
+    const parsed = parseEventDetail(MADISON_TOKEN_RUN_HTML, "madison-token-run-2026", MADISON_INDEX_ENTRY);
+    expect(parsed.isMultiDay).toBe(false);
+    expect(parsed.endDate).toBe("2026-01-18"); // Fri → Sun, +2 days
+
+    const events = splitToRawEvents(parsed, "madison-token-run-2026");
+    expect(events).toHaveLength(1);
+    expect(events[0].date).toBe("2026-01-16");
+    expect(events[0].endDate).toBe("2026-01-18");
+    // No series machinery — this is a single registration covering a weekend.
+    expect(events[0].seriesId).toBeUndefined();
+    expect(events[0].seriesParent).toBeUndefined();
+  });
+
+  it("a single-day event without weekend triggers leaves endDate undefined", () => {
+    const parsed = parseEventDetail(SINGLE_DAY_HTML, "bfmh3-agm-2026", BFMH3_INDEX_ENTRY);
+    expect(parsed.endDate).toBeUndefined();
+    const events = splitToRawEvents(parsed, "bfmh3-agm-2026");
+    expect(events[0].endDate).toBeUndefined();
   });
 });
 

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -1125,6 +1125,35 @@ describe("detectVenueWeekendEndDate", () => {
     ).toBeNull();
   });
 
+  // Codex P1 review on PR #1637 — Fri-start campouts that mention a
+  // "Thursday prelube" had `(Thu - Fri + 7) % 7 = 6` and inflated endDate
+  // to next Thursday. The MAX_FORWARD_OFFSET=4 cap treats the backward
+  // mention as a prelube reference and keeps the inferred end at Sunday.
+  it("Fri-start with 'Thursday prelube' mention does not wrap to next Thursday", () => {
+    // 2026-01-16 = Friday. The prelube Thursday (2026-01-15) is the day
+    // BEFORE the start and should be ignored.
+    expect(
+      detectVenueWeekendEndDate(
+        "Token Run Campout! Thursday prelube 7pm onwards, Friday arrival, Saturday main trail, Sunday brunch.",
+        "Token Run Campout 2026",
+        "2026-01-16",
+      ),
+    ).toBe("2026-01-18"); // Sunday, NOT next Thursday
+  });
+
+  // Inverse regression: a legitimate 4-day Thu→Mon campout should still
+  // produce Monday as the end date (offset 4 stays under the cap).
+  it("Thu-start through Monday — 4-day campout still resolves to Monday", () => {
+    // 2026-02-12 = Thursday.
+    expect(
+      detectVenueWeekendEndDate(
+        "Long weekend retreat. Thursday arrival, Friday relax, Saturday hike, Sunday brunch, Monday departure.",
+        "Long Weekend Retreat",
+        "2026-02-12",
+      ),
+    ).toBe("2026-02-16"); // Monday, offset 4
+  });
+
   it("ignores 'Sat' inside larger words (Saturn / Satellite)", () => {
     // No real weekend trigger should fire — only "Saturday" as a word.
     expect(

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -732,19 +732,31 @@ export function detectVenueWeekendEndDate(
   if (Number.isNaN(startDate.getTime())) return null;
   const startDow = startDate.getUTCDay();
 
+  // Cap the forward-wrap on each weekday's offset. Without this, a
+  // description mentioning a "Thursday prelube" on a Friday-start campout
+  // (`(Thu - Fri + 7) % 7 = 6`) would inflate endDate to NEXT Thursday
+  // instead of the actual Sunday (Codex P1 review). 4 days is the
+  // practical ceiling for "weekend campout" lengths — Thu→Mon, Fri→Tue,
+  // etc. Beyond 4 we treat the mention as a backward reference
+  // (prelube/teaser), not as an end-of-range signal. 7+ day events that
+  // really need a longer span should use Strategy 1's explicit
+  // `MM/DD ... to MM/DD` format.
+  const MAX_FORWARD_OFFSET = 4;
   let maxOffset = 0;
   for (const dow of mentioned) {
     const offset = (dow - startDow + 7) % 7;
+    if (offset > MAX_FORWARD_OFFSET) continue;
     if (offset > maxOffset) maxOffset = offset;
   }
-  if (maxOffset === 0) return null; // every mention collapsed onto the start day
+  if (maxOffset === 0) return null; // every kept mention collapsed onto the start day
 
-  const endMs = startDate.getTime() + maxOffset * 86_400_000;
-  const end = new Date(endMs);
-  const y = end.getUTCFullYear();
-  const mo = end.getUTCMonth() + 1;
-  const d = end.getUTCDate();
-  return `${y}-${String(mo).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+  // Date math via `setUTCDate` + `toISOString` is shorter and idiomatic
+  // (Gemini review). Centralizing into a shared util would also work but
+  // this is a one-shot end-of-range computation, not a repeated pattern
+  // anywhere else in this file.
+  const end = new Date(startDate);
+  end.setUTCDate(end.getUTCDate() + maxOffset);
+  return end.toISOString().split("T")[0];
 }
 
 /** Extract dates and detect multi-day events */

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -661,11 +661,30 @@ function parseDateRangeFromDescription(
 const VENUE_WEEKEND_TRIGGER_RE = /\b(?:camp\s?out|weekend|retreat|rendezvous)\b/i;
 
 /**
- * Weekday-name matcher. Captures both full ("Saturday") and abbreviated
- * ("Sat") forms; the abbreviated form's word-boundary `\b` keeps it from
- * matching inside larger words ("Satellite", "Frison").
+ * Word-boundary matcher for any 3–9 letter token. We then filter against
+ * the explicit weekday allow-list `WEEKDAY_NAMES_SET` below. This split
+ * (broad regex + Set lookup) keeps the regex complexity under Sonar's
+ * S5843 threshold of 20 — the previous form had 7 alternatives × nested
+ * optional suffixes, which counted as ~24 complexity. The Set lookup is
+ * O(1) and reads more transparently than a long alternation.
  */
-const WEEKDAY_NAME_RE = /\b(Sun(?:day)?|Mon(?:day)?|Tues?(?:day)?|Wed(?:nesday)?|Thurs?(?:day)?|Fri(?:day)?|Sat(?:urday)?)\b/gi;
+const WEEKDAY_NAME_RE = /\b([A-Za-z]{3,9})\b/g;
+
+/**
+ * Allow-list of every form `detectVenueWeekendEndDate` accepts. Lowercase
+ * so case-insensitive matching works without a global `i` flag. "Tues"
+ * and "Thurs" are common 4–5 letter abbreviations in hashing descriptions
+ * (alongside the canonical 3-letter abbrevs and full names).
+ */
+const WEEKDAY_NAMES_SET: ReadonlySet<string> = new Set([
+  "sun", "sunday",
+  "mon", "monday",
+  "tue", "tues", "tuesday",
+  "wed", "wednesday",
+  "thu", "thurs", "thursday",
+  "fri", "friday",
+  "sat", "saturday",
+]);
 
 /** Indexed 0=Sun, 6=Sat — matches `Date.getUTCDay()`. */
 const WEEKDAY_PREFIXES: ReadonlyArray<string> = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
@@ -698,7 +717,9 @@ export function detectVenueWeekendEndDate(
   }
   const mentioned = new Set<number>();
   for (const m of description.matchAll(WEEKDAY_NAME_RE)) {
-    const prefix = m[1].slice(0, 3).toLowerCase();
+    const lc = m[1].toLowerCase();
+    if (!WEEKDAY_NAMES_SET.has(lc)) continue;
+    const prefix = lc.slice(0, 3);
     const dow = WEEKDAY_PREFIXES.indexOf(prefix);
     if (dow >= 0) mentioned.add(dow);
   }

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -32,6 +32,14 @@ export interface ParsedEvent {
    * Tidewater H3 — hashrego #806). The display name is unambiguous. */
   hostKennelName?: string;
   isMultiDay: boolean;
+  /**
+   * Inclusive last day of a single-registration venue weekend (#1560 PR C).
+   * Populated by `detectVenueWeekendEndDate` when the description mentions
+   * a weekend / campout / retreat trigger word plus ≥2 weekday labels but
+   * no explicit per-day dates. MadisonH3 Token Run Campout is the
+   * motivating case. Single-day events leave this undefined.
+   */
+  endDate?: string;
 }
 
 /**
@@ -201,7 +209,7 @@ export function parseEventDetail(
   const locationUrl = descLocationUrl || domLocation.mapsUrl;
 
   // Parse dates from the description or index entry
-  const { dates, startTimes, isMultiDay } = extractDates(rawDescription, indexEntry);
+  const { dates, startTimes, isMultiDay, endDate } = extractDates(rawDescription, indexEntry, title);
 
   // Clean description: remove structured fields we already extracted
   const description = cleanDescription(rawDescription);
@@ -219,6 +227,7 @@ export function parseEventDetail(
     kennelSlug,
     hostKennelName,
     isMultiDay,
+    endDate,
   };
 }
 
@@ -357,7 +366,11 @@ export function splitToRawEvents(
   const externalLinks = [{ url: hashRegoUrl, label: "Hash Rego" }];
 
   if (!parsed.isMultiDay || parsed.dates.length <= 1) {
-    // Single-day event
+    // Single-day event — or a venue-weekend campout that registers as ONE
+    // row but spans multiple days (#1560 PR C — MadisonH3 Token Run). The
+    // venue-weekend branch surfaces `parsed.endDate`; the merge pipeline
+    // writes it onto the canonical Event so the UI renders the
+    // date-range pill without the "+ N trails" expansion (no children).
     const date = parsed.dates[0];
     if (!date) return [];
 
@@ -373,6 +386,7 @@ export function splitToRawEvents(
         startTime: parsed.startTimes[0] || undefined,
         sourceUrl: hashRegoUrl,
         externalLinks,
+        ...(parsed.endDate ? { endDate: parsed.endDate } : {}),
       },
     ];
   }
@@ -638,11 +652,86 @@ function parseDateRangeFromDescription(
   return null;
 }
 
+/**
+ * Trigger words that opt-in to the venue-weekend heuristic (#1560 PR C).
+ * A description has to mention at least one of these for the
+ * weekday-mention scan to fire — keeps the false-positive rate low on
+ * single-day trails whose descriptions happen to name a weekday.
+ */
+const VENUE_WEEKEND_TRIGGER_RE = /\b(?:camp\s?out|weekend|retreat|rendezvous)\b/i;
+
+/**
+ * Weekday-name matcher. Captures both full ("Saturday") and abbreviated
+ * ("Sat") forms; the abbreviated form's word-boundary `\b` keeps it from
+ * matching inside larger words ("Satellite", "Frison").
+ */
+const WEEKDAY_NAME_RE = /\b(Sun(?:day)?|Mon(?:day)?|Tues?(?:day)?|Wed(?:nesday)?|Thurs?(?:day)?|Fri(?:day)?|Sat(?:urday)?)\b/gi;
+
+/** Indexed 0=Sun, 6=Sat — matches `Date.getUTCDay()`. */
+const WEEKDAY_PREFIXES: ReadonlyArray<string> = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+
+/**
+ * Detect a venue-weekend campout (#1560 PR C — MadisonH3 Token Run-style).
+ *
+ * Trigger criteria, ALL required:
+ *   1. The title OR description contains `camp(out)|weekend|retreat|rendezvous`.
+ *   2. The description mentions ≥ 2 DISTINCT weekday names.
+ *   3. Counting forward from `startDateStr`'s weekday, the latest mentioned
+ *      weekday is at least 1 day in the future (i.e. not all mentions
+ *      collapse to the start day).
+ *
+ * Returns the inclusive last day (YYYY-MM-DD) — the offset from
+ * `startDateStr` to the latest mentioned weekday, counted forward through
+ * the week. Returns `null` when criteria aren't met.
+ *
+ * Wrapping convention: each mentioned weekday's offset = `(dow - startDow + 7) % 7`.
+ * That keeps the heuristic to a single 7-day window, the longest a
+ * reasonable hashing weekend would be.
+ */
+export function detectVenueWeekendEndDate(
+  description: string,
+  title: string,
+  startDateStr: string,
+): string | null {
+  if (!VENUE_WEEKEND_TRIGGER_RE.test(title) && !VENUE_WEEKEND_TRIGGER_RE.test(description)) {
+    return null;
+  }
+  const mentioned = new Set<number>();
+  for (const m of description.matchAll(WEEKDAY_NAME_RE)) {
+    const prefix = m[1].slice(0, 3).toLowerCase();
+    const dow = WEEKDAY_PREFIXES.indexOf(prefix);
+    if (dow >= 0) mentioned.add(dow);
+  }
+  if (mentioned.size < 2) return null;
+
+  // Anchor in UTC noon so the offset arithmetic doesn't slip across a
+  // DST boundary (matches the project's UTC-noon date convention from
+  // CLAUDE.md §F.4).
+  const startDate = new Date(`${startDateStr}T12:00:00Z`);
+  if (Number.isNaN(startDate.getTime())) return null;
+  const startDow = startDate.getUTCDay();
+
+  let maxOffset = 0;
+  for (const dow of mentioned) {
+    const offset = (dow - startDow + 7) % 7;
+    if (offset > maxOffset) maxOffset = offset;
+  }
+  if (maxOffset === 0) return null; // every mention collapsed onto the start day
+
+  const endMs = startDate.getTime() + maxOffset * 86_400_000;
+  const end = new Date(endMs);
+  const y = end.getUTCFullYear();
+  const mo = end.getUTCMonth() + 1;
+  const d = end.getUTCDate();
+  return `${y}-${String(mo).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+}
+
 /** Extract dates and detect multi-day events */
 function extractDates(
   description: string,
   indexEntry?: IndexEntry,
-): { dates: string[]; startTimes: string[]; isMultiDay: boolean } {
+  title?: string,
+): { dates: string[]; startTimes: string[]; isMultiDay: boolean; endDate?: string } {
   if (indexEntry) {
     const rangeResult = parseDateRangeFromDescription(description, indexEntry);
     if (rangeResult) return rangeResult;
@@ -650,10 +739,17 @@ function extractDates(
     const date = parseHashRegoDate(indexEntry.startDate);
     const time = parseHashRegoTime(indexEntry.startTime);
     if (date) {
+      // Try the venue-weekend campout heuristic (#1560 PR C) before
+      // committing to a single-day result. When it fires, the row stays
+      // single (no children) but carries an `endDate` so the UI renders
+      // a date-range pill — Madison-style "Jan 16 – 18" without the
+      // "+ N trails" expansion.
+      const endDate = detectVenueWeekendEndDate(description, title ?? "", date);
       return {
         dates: [date],
         startTimes: time ? [time] : [],
         isMultiDay: false,
+        ...(endDate ? { endDate } : {}),
       };
     }
   }


### PR DESCRIPTION
## Summary

Final PR in the multi-day series stack ([PR A #1627](https://github.com/johnrclem/hashtracks-web/pull/1627) → [PR B #1630](https://github.com/johnrclem/hashtracks-web/pull/1630) → this). Adds a third strategy to Hash Rego date extraction for events that register as ONE row but span multiple days — MadisonH3 Token Run Campout was the motivating case. The description mentions weekday names (Friday/Saturday/Sunday) with no explicit per-day dates AND a "weekend" / "campout" / "retreat" / "rendezvous" trigger word; the heuristic infers the inclusive last day by counting forward from the index entry's start date.

- New `detectVenueWeekendEndDate(description, title, startDateStr)` exported helper.
- `ParsedEvent.endDate?: string` new optional field.
- `extractDates` now threads `title` and surfaces `endDate` when the heuristic fires on the single-day fallback path.
- `splitToRawEvents` single-day branch emits `endDate` when present (no `seriesId`, no `seriesParent`, no children — one row, one registration, just a date range).

## How it differs from PR B's `parseDayHeaderSections`

| | PR B | PR C |
|---|---|---|
| Trigger | `**DAY N M/D —**` per-day section headers in description | "campout"/"weekend"/"retreat"/"rendezvous" + ≥2 weekday mentions |
| Output | Multi-day series with N children + explicit parent | Single row with `endDate` set |
| UI treatment | Date-range chip + `+ N trails` badge + expandable timeline | Date-range chip + `Weekend` badge, no expansion |

UI behavior comes from PR A's `hasDateRange` check (events with `endDate != null` AND `isSeriesParent === false` render the Madison-style date-range pill without an expandable timeline).

## Heuristic safety
- **Trigger gating**: Without the keyword (`camp(out)|weekend|retreat|rendezvous`), the weekday scan never runs. A single-day trail whose description happens to name "Saturday brunch on-after" doesn't spuriously expand.
- **`\b`-anchored weekday match**: "Sat" inside "Saturn" / "Satellite" doesn't fire.
- **Forward-counting offset**: `(dow - startDow + 7) % 7` keeps the inferred range inside a single 7-day window — the longest a reasonable hashing weekend would be.
- **Single-day collapse**: If every mentioned weekday resolves to the start day, return `null` (no spurious 0-day "range").

## Tests
- 7 `it.each` cases covering the motivating Madison case, title-only triggers, "camp out" with space, abbreviated weekday names, `rendezvous` trigger, Saturday-start single-wrap, and a NYE year-boundary case (Fri 2027-12-31 → Sun 2028-01-02).
- 4 negative cases: no trigger word, single weekday only, all mentions collapse to start day, "Saturn" doesn't match "Sat".
- Full integration test using a synthetic Madison Token Run HTML fixture (1 row, `endDate` present, no `seriesId`/`seriesParent`).
- Regression guard: single-day events without weekend triggers keep `endDate` undefined.

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors, 21 pre-existing warnings
- [x] `npm test` — 7199 tests pass (+13 new for venue-weekend)
- [ ] Post-merge: Hash Rego re-scrape on prod will surface MadisonH3-style venue weekends as date-range cards in the hareline.

Closes #1560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)