### PR TITLE
fix(adapters): pre-cycle bundle — 6 audit-driven recurrences

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2451,9 +2451,13 @@ export const SOURCES = [
       scrapeDays: 90,
       config: {
         defaultKennelTag: "dh3-co",
+        // Patterns are start-anchored so a Denver event whose summary
+        // mentions "Boulder H3" mid-text (e.g. "DH3 #1110 visiting Boulder
+        // H3 area for joint trail") doesn't mis-route to bh3-co. `(?!\w)`
+        // (negative lookahead) excludes compound tokens like "BH3FM".
         kennelPatterns: [
-          ["Boulder H3|^BH3\\b", "bh3-co"],
-          ["MiHiHuHa|MiHiHUHa|Mile High Humpin", "mihi-huha"],
+          ["^(?:Boulder H3|BH3)(?!\\w)", "bh3-co"],
+          ["^(?:MiHiHuHa|MiHiHUHa|Mile High Humpin)\\b", "mihi-huha"],
         ],
       },
       kennelCodes: ["dh3-co", "bh3-co", "mihi-huha"],

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2436,6 +2436,12 @@ export const SOURCES = [
     },
     // ===== COLORADO =====
     // --- Denver H3 (Google Calendar) ---
+    // #1649 — Boulder Hash cross-posts BH3/Toga events to the Denver kennel
+    // calendar; without kennelPatterns every event blindly tagged as dh3-co
+    // (e.g. "BH3 #969 12th Anal Toga Hash" routed to Denver H3). Mirrors the
+    // Colorado H3 Aggregator pattern set below so BH3 / MiHiHuHa cross-posts
+    // route to their actual kennel; unmatched titles still fall back to
+    // defaultKennelTag = "dh3-co" (the host kennel's own runs).
     {
       name: "Denver H3 Google Calendar",
       url: "denverkennel@gmail.com",
@@ -2443,8 +2449,14 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "every_6h",
       scrapeDays: 90,
-      config: { defaultKennelTag: "dh3-co" },
-      kennelCodes: ["dh3-co"],
+      config: {
+        defaultKennelTag: "dh3-co",
+        kennelPatterns: [
+          ["Boulder H3|^BH3\\b", "bh3-co"],
+          ["MiHiHuHa|MiHiHUHa|Mile High Humpin", "mihi-huha"],
+        ],
+      },
+      kennelCodes: ["dh3-co", "bh3-co", "mihi-huha"],
     },
     // --- Mile High Humpin' Hash (Google Calendar) ---
     {

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2456,8 +2456,8 @@ export const SOURCES = [
         // H3 area for joint trail") doesn't mis-route to bh3-co. `(?!\w)`
         // (negative lookahead) excludes compound tokens like "BH3FM".
         kennelPatterns: [
-          ["^(?:Boulder H3|BH3)(?!\\w)", "bh3-co"],
-          ["^(?:MiHiHuHa|MiHiHUHa|Mile High Humpin)\\b", "mihi-huha"],
+          [String.raw`^(?:Boulder H3|BH3)(?!\w)`, "bh3-co"],
+          [String.raw`^(?:MiHiHuHa|MiHiHUHa|Mile High Humpin)\b`, "mihi-huha"],
         ],
       },
       kennelCodes: ["dh3-co", "bh3-co", "mihi-huha"],

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -96,6 +96,34 @@ describe("Colorado H3 Aggregator multi-kennel routing (#850)", () => {
   });
 });
 
+// ── Denver H3 Google Calendar cross-post routing (#1649) ──
+
+describe("Denver H3 Google Calendar — cross-post routing (#1649)", () => {
+  const dhSource = SOURCES.find((s) => s.name === "Denver H3 Google Calendar");
+  if (!dhSource?.config) throw new Error("Denver H3 Google Calendar seed config missing");
+  const config = dhSource.config as {
+    kennelPatterns: [string, string][];
+    defaultKennelTag: string;
+  };
+
+  it.each([
+    // Cross-posted BH3 events must route to bh3-co, not Denver
+    ["BH3 #969 12th Anal Toga Hash", "bh3-co", "BH3 cross-post (#1649 root cause)"],
+    ["Boulder H3 #970 Memorial Trail", "bh3-co", "Boulder H3 full name cross-post"],
+    // Cross-posted MiHiHuHa events route to mihi-huha
+    ["MiHiHuHa #599 Trail", "mihi-huha", "MiHiHuHa cross-post"],
+    // True Denver events fall through to defaultKennelTag
+    ["Tuesday Trail", "dh3-co", "fallback to default for unmatched titles"],
+    ["DH3 #1109", "dh3-co", "Denver own runs"],
+  ])("routes %j → %s (%s)", (summary, expectedTag) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-05-25T09:00:00-06:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe(expectedTag);
+  });
+});
+
 // ── Oregon Hashing Calendar multi-kennel co-host pattern (#1023 step 4 / #991) ──
 
 describe("Oregon Hashing Calendar multi-kennel routing (#1023 step 4)", () => {
@@ -1026,6 +1054,18 @@ describe("doubled kennelCode prefix guard (#1458)", () => {
     ["MoA2H3 MoA2H3", "MoA2H3", "exact-doubled placeholder (no trailing content)"],
     ["MoA2H3 Red Dress Run", "MoA2H3 Red Dress Run", "no-op when title is already single-prefixed"],
     ["Brain Fart", "Brain Fart", "no-op when title is unrelated to the kennelCode"],
+    // #1653 follow-up — the literal-space check missed whitespace variants
+    // that the kennel admin sometimes types. \s+ in the new regex covers
+    // NBSP (U+00A0), double-space, and tab.
+    ["MoA2H3 MoA2H3 Red Dress Run", "MoA2H3 Red Dress Run", "NBSP separator (#1653)"],
+    ["MoA2H3  MoA2H3 Red Dress Run", "MoA2H3 Red Dress Run", "double-space separator (#1653)"],
+    ["MoA2H3\tMoA2H3 Red Dress Run", "MoA2H3 Red Dress Run", "tab separator (#1653)"],
+    // Boundary guard — `(?=\s|$)` prevents stripping inside a compound token.
+    // "MoA2H3 MoA2H3FM ..." must NOT collapse to "MoA2H3FM ..." because that
+    // would conflate two distinct kennelCodes (the strip is conceptually a
+    // double-paste cleanup, not a free substring removal).
+    ["MoA2H3 MoA2H3FM Run", "MoA2H3 MoA2H3FM Run", "compound-token boundary (no strip)"],
+    ["MoA2H3 MoA2H3rd Birthday", "MoA2H3 MoA2H3rd Birthday", "alphanumeric boundary (no strip)"],
   ])("summary %j → title %j (%s)", (summary, expectedTitle) => {
     const result = buildRawEventFromGCalItem(
       testGCalEvent({

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -115,6 +115,13 @@ describe("Denver H3 Google Calendar — cross-post routing (#1649)", () => {
     // True Denver events fall through to defaultKennelTag
     ["Tuesday Trail", "dh3-co", "fallback to default for unmatched titles"],
     ["DH3 #1109", "dh3-co", "Denver own runs"],
+    // Anchored patterns — mid-summary mentions of sister-kennel names must
+    // NOT mis-route. "Boulder H3" inside a Denver event description stays
+    // attributed to Denver.
+    ["DH3 #1110 visiting Boulder H3 area for joint trail", "dh3-co", "mid-summary 'Boulder H3' stays Denver"],
+    ["DH3 trail with MiHiHuHa friends joining", "dh3-co", "mid-summary 'MiHiHuHa' stays Denver"],
+    // Compound-token boundary — "BH3FM" / "BH3rd" must NOT match BH3.
+    ["BH3FM #5 Full Moon", "dh3-co", "BH3FM compound token does not match BH3"],
   ])("routes %j → %s (%s)", (summary, expectedTag) => {
     const result = buildRawEventFromGCalItem(
       { summary, start: { dateTime: "2026-05-25T09:00:00-06:00" }, status: "confirmed" },

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1106,17 +1106,19 @@ export function buildRawEventFromGCalItem(
   // only handles "<kennelCode> Trail #N" patterns, not free-form titles.
   // Gated on per-source config to avoid rewriting legitimate "X X News"
   // titles where the kennelCode happens to be a common word.
+  //
+  // #1653 — original literal-space `startsWith(`${tag} ${tag} `)` check
+  // missed whitespace variants the source side sometimes types (NBSP,
+  // double-space, tab). Switched to a regex with `\s+` and the `u` flag so
+  // Unicode whitespace (NBSP / em-space / ideographic space) all qualify.
+  // The trailing `(?=\s|$)` boundary prevents stripping inside compound
+  // tokens (e.g. "BH3 BH3FM" must not collapse to "BH3FM"). Capture group
+  // `$1` preserves the typed casing of the first occurrence.
   if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
-    const tagLen = kennelTag.length;
-    const tagLc = kennelTag.toLowerCase();
-    const lc = title.toLowerCase();
-    const doubledLen = tagLen * 2 + 1; // "<tag> <tag>"
-    // Match exact doubled prefix OR doubled prefix followed by a space + rest.
-    if (lc.startsWith(`${tagLc} ${tagLc}`) && (title.length === doubledLen || title[doubledLen] === " ")) {
-      // Keep the first occurrence (preserves typed casing), drop the
-      // second and the separator space.
-      title = (title.slice(0, tagLen) + title.slice(doubledLen)).trim();
-    }
+    const tagEsc = kennelTag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); `tagEsc` is regex-escaped from the source config's kennelTag string
+    const doubled = new RegExp(`^(${tagEsc})\\s+${tagEsc}(?=\\s|$)`, "iu"); // NOSONAR — escaped kennelTag (alphanumeric in practice), anchored, bounded by lookahead
+    title = title.replace(doubled, "$1").trim();
   }
   // Stale-default detection: equality is whitespace-insensitive so a SUMMARY
   // of "4X2 H4" still matches kennelTag "4x2h4".

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1116,7 +1116,7 @@ export function buildRawEventFromGCalItem(
   // `$1` preserves the typed casing of the first occurrence.
   if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
     const tagEsc = kennelTag.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-    const doubled = new RegExp(`^(${tagEsc})\\s+${tagEsc}(?=\\s|$)`, "iu"); // nosemgrep // NOSONAR — `tagEsc` is regex-escaped from kennelTag; anchored, bounded by lookahead
+    const doubled = new RegExp(String.raw`^(${tagEsc})\s+${tagEsc}(?=\s|$)`, "iu"); // nosemgrep // NOSONAR — `tagEsc` is regex-escaped from kennelTag; anchored, bounded by lookahead
     title = title.replace(doubled, "$1").trim();
   }
   // Stale-default detection: equality is whitespace-insensitive so a SUMMARY

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1115,8 +1115,8 @@ export function buildRawEventFromGCalItem(
   // tokens (e.g. "BH3 BH3FM" must not collapse to "BH3FM"). Capture group
   // `$1` preserves the typed casing of the first occurrence.
   if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
-    const tagEsc = kennelTag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); `tagEsc` is regex-escaped from the source config's kennelTag string
+    const tagEsc = kennelTag.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+    // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); `tagEsc` is regex-escaped from the source config's kennelTag string. NOSONAR S7724 — rule names omitted because the plugins aren't loaded locally; naming them errors as "rule not found"
     const doubled = new RegExp(`^(${tagEsc})\\s+${tagEsc}(?=\\s|$)`, "iu"); // NOSONAR — escaped kennelTag (alphanumeric in practice), anchored, bounded by lookahead
     title = title.replace(doubled, "$1").trim();
   }

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1116,7 +1116,7 @@ export function buildRawEventFromGCalItem(
   // `$1` preserves the typed casing of the first occurrence.
   if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
     const tagEsc = kennelTag.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-    // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); `tagEsc` is regex-escaped from the source config's kennelTag string. NOSONAR S7724 — rule names omitted because the plugins aren't loaded locally; naming them errors as "rule not found"
+    // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr; tagEsc is regex-escaped from kennelTag. Rule names omitted because the Codacy security plugins aren't loaded locally and naming them errors as "rule not found". // NOSONAR S7724
     const doubled = new RegExp(`^(${tagEsc})\\s+${tagEsc}(?=\\s|$)`, "iu"); // NOSONAR — escaped kennelTag (alphanumeric in practice), anchored, bounded by lookahead
     title = title.replace(doubled, "$1").trim();
   }

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1116,8 +1116,7 @@ export function buildRawEventFromGCalItem(
   // `$1` preserves the typed casing of the first occurrence.
   if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
     const tagEsc = kennelTag.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-    // nosemgrep: javascript.dos.rule-non-literal-regexp, detect-non-literal-regexp — `tagEsc` is regex-escaped from the source config's kennelTag
-    const doubled = new RegExp(`^(${tagEsc})\\s+${tagEsc}(?=\\s|$)`, "iu"); // NOSONAR — escaped kennelTag (alphanumeric in practice), anchored, bounded by lookahead
+    const doubled = new RegExp(`^(${tagEsc})\\s+${tagEsc}(?=\\s|$)`, "iu"); // nosemgrep // NOSONAR — `tagEsc` is regex-escaped from kennelTag; anchored, bounded by lookahead
     title = title.replace(doubled, "$1").trim();
   }
   // Stale-default detection: equality is whitespace-insensitive so a SUMMARY

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1116,7 +1116,7 @@ export function buildRawEventFromGCalItem(
   // `$1` preserves the typed casing of the first occurrence.
   if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
     const tagEsc = kennelTag.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-    // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr; tagEsc is regex-escaped from kennelTag. Rule names omitted because the Codacy security plugins aren't loaded locally and naming them errors as "rule not found". // NOSONAR S7724
+    // nosemgrep: detect-non-literal-regexp — `tagEsc` is regex-escaped from the source config's kennelTag
     const doubled = new RegExp(`^(${tagEsc})\\s+${tagEsc}(?=\\s|$)`, "iu"); // NOSONAR — escaped kennelTag (alphanumeric in practice), anchored, bounded by lookahead
     title = title.replace(doubled, "$1").trim();
   }

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1116,7 +1116,7 @@ export function buildRawEventFromGCalItem(
   // `$1` preserves the typed casing of the first occurrence.
   if (sourceConfig?.stripDoubledKennelPrefix && kennelTag) {
     const tagEsc = kennelTag.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-    // nosemgrep: detect-non-literal-regexp — `tagEsc` is regex-escaped from the source config's kennelTag
+    // nosemgrep: javascript.dos.rule-non-literal-regexp, detect-non-literal-regexp — `tagEsc` is regex-escaped from the source config's kennelTag
     const doubled = new RegExp(`^(${tagEsc})\\s+${tagEsc}(?=\\s|$)`, "iu"); // NOSONAR — escaped kennelTag (alphanumeric in practice), anchored, bounded by lookahead
     title = title.replace(doubled, "$1").trim();
   }

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -34,6 +34,13 @@ const EXPECTED_GROUPS: ExpectedGroup[] = [
       ["'Hares are X and Y' form", "Hares are Smegma Balls and Dry Hose. Pool party at the park.", "Smegma Balls and Dry Hose"],
       ["'Hares are X and Y' to end of line", "Some intro.\nHares are Alice and Bob\nLocation: Park", "Alice and Bob"],
       ["lowercase 'hares are X and Y'", "hares are Cool Beans and Banana Boat.", "Cool Beans and Banana Boat"],
+      // #1615 mid-sentence follow-up — Austin H3 publishes "...Birthday Hash! Hares are X..."
+      // after a sentence terminator (exclam/period/question + space). The line-start
+      // anchor in #1584 missed these. Lookbehind `(?<=[.!?]\s)` covers it. Capture
+      // still bounded by the next `[.!?]\s` / newline / end-of-string.
+      ["mid-sentence after exclamation", "Cookout - Birthday Hash! Hares are Smegma Balls and Dry Hose. Pool party after.", "Smegma Balls and Dry Hose"],
+      ["mid-sentence after period", "Welcome to the trail. Hares are Alice and Bob. Meet at 6pm.", "Alice and Bob"],
+      ["mid-sentence after question mark", "Ready for fun? Hares are Crusty Crab and Pearl. Bring water.", "Crusty Crab and Pearl"],
     ],
   },
   {
@@ -192,6 +199,11 @@ const UNDEFINED_GROUPS: UndefinedGroup[] = [
       // bars these; this confirms it.
       ["'Hares are getting ready'", "Hares are getting ready for the trail."],
       ["'Hares are running tomorrow'", "Hares are running tomorrow."],
+      // #1615 mid-sentence follow-up — denylist must still reject prose
+      // forms after a sentence terminator + space.
+      ["mid-sentence 'Hares are Needed'", "Sign up now! Hares are Needed for July."],
+      ["mid-sentence 'Hares are Welcome'", "Bring friends. Hares are Welcome to the pool party."],
+      ["mid-sentence lowercase 'the hares are bringing'", "Tonight the hares are bringing dogs and friends."],
     ],
   },
   {

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -40,13 +40,16 @@ const DEFAULT_HARE_PATTERNS = [
   /(?:^|\n)[ \t]*WHO\s+ARE\s+THE\s+HARES?\s*:[ \t]*(.+?)(?=(?:WHO|WHAT|WHEN|WHERE|HOW)\s+\w+|\n|$)/im, // NOSONAR — non-greedy, bounded by literal lookahead alternation; description is trusted GCal field
   /(?:^|\n)[ \t]*Who\s*\(?(?:hares?)?\)?:[ \t]*(.*)/im,  // Who:, WHO (hares):, Who(hare):
   /(?:^|\n)[ \t]*Hare[ \t]+([A-Z*].+)/im,  // "Hare C*ck Swap" (no colon, name starts uppercase/special)
-  // Natural-language form (#1584 Austin H3 #2278): "Hares are Smegma Balls and
-  // Dry Hose." Line-anchored, with an explicit-uppercase guard so
-  // "Hares are getting ready" (lowercase next word, normal prose) does NOT
-  // match. The `[Hh]ares?` literal label avoids /i (which would let `[A-Z*]`
-  // also match lowercase). The lazy `.+?` plus a sentence-end lookahead
-  // bound the capture so we stop at the next sentence terminator or newline.
-  /(?:^|\n)[ \t]*[Hh]ares?\s+are\s+([A-Z*].+?)(?=[.!?](?:\s|$)|\n|$)/m,  // NOSONAR — bounded non-greedy, anchored to sentence/line end
+  // Natural-language form (#1584 Austin H3 #2278, #1615 mid-sentence follow-up):
+  // "Hares are Smegma Balls and Dry Hose." Anchored to start-of-line OR after a
+  // sentence terminator (period/exclam/question + whitespace) so forms like
+  // "Birthday Hash! Hares are Smegma Balls..." also match. Explicit-uppercase
+  // guard on the capture (`[A-Z*]`) keeps "The hares are bringing dogs" out;
+  // `HARES_ARE_PROSE_FIRST_WORD_RE` catches "Hares are Needed/Welcome/...".
+  // The `[Hh]ares?` literal label avoids /i (which would let `[A-Z*]` also
+  // match lowercase). The lazy `.+?` plus a sentence-end lookahead bound the
+  // capture so we stop at the next sentence terminator or newline.
+  /(?:^|\n|(?<=[.!?]\s))[ \t]*[Hh]ares?\s+are\s+([A-Z*].+?)(?=[.!?](?:\s|$)|\n|$)/m,  // NOSONAR — bounded non-greedy, anchored to sentence/line end
 ];
 /* eslint-enable */
 

--- a/src/adapters/html-scraper/swh3.test.ts
+++ b/src/adapters/html-scraper/swh3.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from "vitest";
-import { parseSWH3Title, parseSWH3Body } from "./swh3";
+import { parseSWH3Title, parseSWH3Body, cleanTrailingPunct } from "./swh3";
+
+describe("cleanTrailingPunct (#1647)", () => {
+  it("strips trailing dash from 'SWH3 #1792-'", () => {
+    expect(cleanTrailingPunct("SWH3 #1792-")).toBe("SWH3 #1792");
+  });
+
+  it("strips trailing comma + spaces", () => {
+    expect(cleanTrailingPunct("SWH3 #1782, ")).toBe("SWH3 #1782");
+  });
+
+  it("strips trailing colon", () => {
+    expect(cleanTrailingPunct("Trail Name:")).toBe("Trail Name");
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(cleanTrailingPunct("")).toBeUndefined();
+  });
+
+  it("returns undefined when input is only punctuation", () => {
+    expect(cleanTrailingPunct(" - ")).toBeUndefined();
+  });
+
+  it("preserves clean titles unchanged", () => {
+    expect(cleanTrailingPunct("Crispy Creamer Invasion")).toBe("Crispy Creamer Invasion");
+  });
+});
 
 describe("parseSWH3Title", () => {
   it("extracts run number and date from standard format", () => {

--- a/src/adapters/html-scraper/swh3.ts
+++ b/src/adapters/html-scraper/swh3.ts
@@ -29,6 +29,18 @@ interface WPComPost {
 }
 
 /**
+ * #1647 — strip trailing punctuation that survives the SWH3 title path. The
+ * raw WordPress heading is "SWH3 #1792- Sunday, May 24"; parseSWH3Title
+ * carves off the date portion ("Sunday, May 24") but the connector dash
+ * remains on the title side. When bodyFields has no trail name, the dashed
+ * remainder leaks through verbatim. Returns undefined when the whole input
+ * collapses to empty so the merge pipeline can synthesize a default title.
+ */
+export function cleanTrailingPunct(raw: string): string | undefined {
+  return raw.replace(/[\s,\-–—:]+$/, "").trim() || undefined;
+}
+
+/**
  * Parse SWH3 post title into run number and trail date.
  *
  * Observed formats:
@@ -211,11 +223,13 @@ function processPost(
   if (bodyFields.trailName) descParts.push(bodyFields.trailName);
   if (bodyFields.onAfter) descParts.push(`On-After: ${bodyFields.onAfter}`);
 
+  const title = cleanTrailingPunct(bodyFields.trailName || titleText);
+
   return {
     date,
     kennelTags: ["swh3"],
     runNumber: titleFields.runNumber,
-    title: bodyFields.trailName || titleText,
+    title,
     hares: bodyFields.hares,
     location,
     locationUrl,

--- a/src/adapters/html-scraper/swh3.ts
+++ b/src/adapters/html-scraper/swh3.ts
@@ -37,7 +37,7 @@ interface WPComPost {
  * collapses to empty so the merge pipeline can synthesize a default title.
  */
 export function cleanTrailingPunct(raw: string): string | undefined {
-  return raw.replace(/[\s,\-–—:]+$/, "").trim() || undefined;
+  return raw.replace(/[\s,\-–—:]+$/, "").trim() || undefined; // NOSONAR S5852 — single char class + `+` anchored to `$`, linear in input length
 }
 
 /**

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription } from "./adapter";
+import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle } from "./adapter";
 import type { Source } from "@/generated/prisma/client";
 
 vi.mock("../safe-fetch", () => ({
@@ -1153,6 +1153,48 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     };
     const event = buildRawEventFromApollo(ev as never, emptyState, "rch3");
     expect(event.hares).toBeUndefined();
+  });
+});
+
+// ── cleanMeetupTitle — trailing CTA strip (#1645 RH3 / #1646 TMFMH3) ──
+
+describe("cleanMeetupTitle", () => {
+  it.each([
+    // #1645 RH3 — "CLAIM THIS TRAIL" trailing placeholder
+    ["RH3 # 1698 CLAIM THIS TRAIL", "RH3 # 1698"],
+    ["RH3 # 1701 CLAIM THIS TRAIL", "RH3 # 1701"],
+    ["RH3 # 1703 CLAIM THIS TRAIL", "RH3 # 1703"],
+    // #1646 TMFMH3 — case + punctuation variant
+    ["TMFMH3 Trail 300: Claim this Trail!", "TMFMH3 Trail 300"],
+    // Other CTA forms covered by CTA_EMBEDDED_PATTERNS
+    ["Saturday Trail - Hares Needed", "Saturday Trail"],
+    ["Friday Run - Looking for a hare", "Friday Run"],
+    // Stacked trailing CTAs — iteration over CTA_EMBEDDED_PATTERNS strips
+    // each pass; trailing-connector cleanup runs once at the end.
+    ["Trail 300 - Hares Needed - Claim This Trail!", "Trail 300"],
+  ])("strips trailing CTA: %q → %q", (raw, expected) => {
+    expect(cleanMeetupTitle(raw)).toBe(expected);
+  });
+
+  it.each([
+    // Themed titles where CTA-shaped text appears mid-title legitimately must NOT be stripped
+    ["Hares Needed Hash Theme: Costume Night", "Hares Needed Hash Theme: Costume Night"],
+    ["Claim This Trail Anniversary Edition", "Claim This Trail Anniversary Edition"],
+    ["Saturday Trail", "Saturday Trail"],
+    ["MH3 Trail #1048 MAY DAY EVE IN VIZCAYA", "MH3 Trail #1048 MAY DAY EVE IN VIZCAYA"],
+  ])("preserves legitimate titles: %q", (raw, expected) => {
+    expect(cleanMeetupTitle(raw)).toBe(expected);
+  });
+
+  it("returns undefined for null/undefined/empty inputs", () => {
+    expect(cleanMeetupTitle(null)).toBeUndefined();
+    expect(cleanMeetupTitle(undefined)).toBeUndefined();
+    expect(cleanMeetupTitle("")).toBeUndefined();
+  });
+
+  it("returns undefined when title collapses to empty after strip", () => {
+    expect(cleanMeetupTitle("Hares Needed")).toBeUndefined();
+    expect(cleanMeetupTitle("CLAIM THIS TRAIL")).toBeUndefined();
   });
 });
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -359,7 +359,7 @@ export function extractHaresFromMeetupDescription(
 // `CTA_EMBEDDED_PATTERNS` entry with a connector-punctuation prefix and `$`
 // anchor so only end-of-string CTAs strip ("Hares Needed Hash" stays intact).
 const TRAILING_CTA_RES = CTA_EMBEDDED_PATTERNS.map(
-  // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source patterns are hard-coded literals in utils.ts. NOSONAR S7724 — rule names omitted because the plugins aren't loaded locally; naming them errors as "rule not found"
+  // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr; source patterns are hard-coded literals in utils.ts. Rule names omitted because the Codacy security plugins aren't loaded locally and naming them errors as "rule not found". // NOSONAR S7724
   (re) => new RegExp(`[\\s.,!?:;\\-–—]*(?:${re.source})[\\s.,!?:;\\-–—]*$`, "i"), // NOSONAR — bounded char class + literal alternation source + `$` anchor
 );
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -383,7 +383,7 @@ export function cleanMeetupTitle(raw: string | null | undefined): string | undef
   }
   // Sweep leftover connectors (colon, hyphen, comma). Excludes `!` and `?`
   // so genuine "Saturday Trail!" / "Why?" titles keep their terminator.
-  return t.replace(/[\s,:\-–—]+$/, "").trim() || undefined;
+  return t.replace(/[\s,:\-–—]+$/, "").trim() || undefined; // NOSONAR S5852 — single char class + `+` anchored to `$`, linear in input length
 }
 
 /** Build a RawEventData from an Apollo event entry. */

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -359,8 +359,7 @@ export function extractHaresFromMeetupDescription(
 // `CTA_EMBEDDED_PATTERNS` entry with a connector-punctuation prefix and `$`
 // anchor so only end-of-string CTAs strip ("Hares Needed Hash" stays intact).
 const TRAILING_CTA_RES = CTA_EMBEDDED_PATTERNS.map(
-  // nosemgrep: javascript.dos.rule-non-literal-regexp, detect-non-literal-regexp — source patterns are hard-coded literals in utils.ts
-  (re) => new RegExp(`[\\s.,!?:;\\-–—]*(?:${re.source})[\\s.,!?:;\\-–—]*$`, "i"), // NOSONAR — bounded char class + literal alternation source + `$` anchor
+  (re) => new RegExp(`[\\s.,!?:;\\-–—]*(?:${re.source})[\\s.,!?:;\\-–—]*$`, "i"), // nosemgrep // NOSONAR — source patterns are hard-coded literals in utils.ts; anchored to `$`
 );
 
 export function cleanMeetupTitle(raw: string | null | undefined): string | undefined {

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -359,7 +359,7 @@ export function extractHaresFromMeetupDescription(
 // `CTA_EMBEDDED_PATTERNS` entry with a connector-punctuation prefix and `$`
 // anchor so only end-of-string CTAs strip ("Hares Needed Hash" stays intact).
 const TRAILING_CTA_RES = CTA_EMBEDDED_PATTERNS.map(
-  // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source patterns are hard-coded literals in utils.ts
+  // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source patterns are hard-coded literals in utils.ts. NOSONAR S7724 — rule names omitted because the plugins aren't loaded locally; naming them errors as "rule not found"
   (re) => new RegExp(`[\\s.,!?:;\\-–—]*(?:${re.source})[\\s.,!?:;\\-–—]*$`, "i"), // NOSONAR — bounded char class + literal alternation source + `$` anchor
 );
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -359,7 +359,7 @@ export function extractHaresFromMeetupDescription(
 // `CTA_EMBEDDED_PATTERNS` entry with a connector-punctuation prefix and `$`
 // anchor so only end-of-string CTAs strip ("Hares Needed Hash" stays intact).
 const TRAILING_CTA_RES = CTA_EMBEDDED_PATTERNS.map(
-  // nosemgrep: detect-non-literal-regexp — source patterns are hard-coded literals in utils.ts
+  // nosemgrep: javascript.dos.rule-non-literal-regexp, detect-non-literal-regexp — source patterns are hard-coded literals in utils.ts
   (re) => new RegExp(`[\\s.,!?:;\\-–—]*(?:${re.source})[\\s.,!?:;\\-–—]*$`, "i"), // NOSONAR — bounded char class + literal alternation source + `$` anchor
 );
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -2,7 +2,7 @@ import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { validateSourceConfig, stripHtmlTags, buildDateWindow, extractHashRunNumber, HARE_BOILERPLATE_RE } from "../utils";
+import { validateSourceConfig, stripHtmlTags, buildDateWindow, extractHashRunNumber, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { extractHares as extractHaresFromDescription } from "../hare-extraction";
 
@@ -344,6 +344,46 @@ export function extractHaresFromMeetupDescription(
   return undefined;
 }
 
+/**
+ * Strip CTA boilerplate ("CLAIM THIS TRAIL", "Hares Needed", "Looking for a
+ * hare", etc.) from the trailing end of a Meetup title and trim dangling
+ * punctuation left by the strip. The Meetup adapter previously shipped titles
+ * verbatim; RVA's RH3 (#1645) and TMFMH3 (#1646) used trailing CTAs as
+ * placeholder text. Strip is anchored to end-of-string only — mid-title CTA
+ * tokens are likely legitimate theme names ("Hares Needed Hash") and stay
+ * intact. Returns undefined when the strip empties the title so merge.ts
+ * synthesizes a default. Source list is the shared `CTA_EMBEDDED_PATTERNS`
+ * from `utils.ts` — already includes /\bclaim\s+this\s+trail\b/i from #1549.
+ */
+// Trailing-CTA regexes — precompiled once at module load. Each wraps a
+// `CTA_EMBEDDED_PATTERNS` entry with a connector-punctuation prefix and `$`
+// anchor so only end-of-string CTAs strip ("Hares Needed Hash" stays intact).
+const TRAILING_CTA_RES = CTA_EMBEDDED_PATTERNS.map(
+  // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source patterns are hard-coded literals in utils.ts
+  (re) => new RegExp(`[\\s.,!?:;\\-–—]*(?:${re.source})[\\s.,!?:;\\-–—]*$`, "i"), // NOSONAR — bounded char class + literal alternation source + `$` anchor
+);
+
+export function cleanMeetupTitle(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  // Stacked CTAs ("Trail 300 - Hares Needed - Claim This Trail!") need
+  // multiple passes — each iteration peels one trailing CTA until stable.
+  let t = raw;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const trailing of TRAILING_CTA_RES) {
+      const next = t.replace(trailing, "");
+      if (next !== t) {
+        t = next;
+        changed = true;
+      }
+    }
+  }
+  // Sweep leftover connectors (colon, hyphen, comma). Excludes `!` and `?`
+  // so genuine "Saturday Trail!" / "Why?" titles keep their terminator.
+  return t.replace(/[\s,:\-–—]+$/, "").trim() || undefined;
+}
+
 /** Build a RawEventData from an Apollo event entry. */
 export function buildRawEventFromApollo(
   ev: ApolloEvent,
@@ -390,7 +430,7 @@ export function buildRawEventFromApollo(
   return {
     date,
     kennelTags: [resolvedKennelTag],
-    title: ev.title || undefined,
+    title: cleanMeetupTitle(ev.title),
     runNumber: extractRunNumber ? extractHashRunNumber(ev.title) : undefined,
     description: cleanedDesc,
     hares,

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -359,7 +359,7 @@ export function extractHaresFromMeetupDescription(
 // `CTA_EMBEDDED_PATTERNS` entry with a connector-punctuation prefix and `$`
 // anchor so only end-of-string CTAs strip ("Hares Needed Hash" stays intact).
 const TRAILING_CTA_RES = CTA_EMBEDDED_PATTERNS.map(
-  // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr; source patterns are hard-coded literals in utils.ts. Rule names omitted because the Codacy security plugins aren't loaded locally and naming them errors as "rule not found". // NOSONAR S7724
+  // nosemgrep: detect-non-literal-regexp — source patterns are hard-coded literals in utils.ts
   (re) => new RegExp(`[\\s.,!?:;\\-–—]*(?:${re.source})[\\s.,!?:;\\-–—]*$`, "i"), // NOSONAR — bounded char class + literal alternation source + `$` anchor
 );
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -367,9 +367,11 @@ export function cleanMeetupTitle(raw: string | null | undefined): string | undef
   if (!raw) return undefined;
   // Stacked CTAs ("Trail 300 - Hares Needed - Claim This Trail!") need
   // multiple passes — each iteration peels one trailing CTA until stable.
+  // Hard iteration cap (10) defends against a hypothetical future zero-width
+  // CTA pattern that would otherwise spin the loop forever.
   let t = raw;
   let changed = true;
-  while (changed) {
+  for (let pass = 0; pass < 10 && changed; pass++) {
     changed = false;
     for (const trailing of TRAILING_CTA_RES) {
       const next = t.replace(trailing, "");

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -359,7 +359,7 @@ export function extractHaresFromMeetupDescription(
 // `CTA_EMBEDDED_PATTERNS` entry with a connector-punctuation prefix and `$`
 // anchor so only end-of-string CTAs strip ("Hares Needed Hash" stays intact).
 const TRAILING_CTA_RES = CTA_EMBEDDED_PATTERNS.map(
-  (re) => new RegExp(`[\\s.,!?:;\\-–—]*(?:${re.source})[\\s.,!?:;\\-–—]*$`, "i"), // nosemgrep // NOSONAR — source patterns are hard-coded literals in utils.ts; anchored to `$`
+  (re) => new RegExp(String.raw`[\s.,!?:;\-–—]*(?:${re.source})[\s.,!?:;\-–—]*$`, "i"), // nosemgrep // NOSONAR — source patterns are hard-coded literals in utils.ts; anchored to `$`
 );
 
 export function cleanMeetupTitle(raw: string | null | undefined): string | undefined {

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -1903,6 +1903,18 @@ describe("sanitizeTitle", () => {
     expect(sanitizeTitle("Trail Name <foo@bar.com> details")).toBe("Trail Name details");
   });
 
+  // #1647 — SWH3 WordPress headings are "SWH3 #NNNN- Sunday, Month DD". The
+  // trailing-day-of-week strip in sanitizeTitle removes the date portion but
+  // previously left the connector dash orphaned. Followup strip sweeps it.
+  it.each([
+    ["SWH3 #1792- Sunday, May 24", "SWH3 #1792"],
+    ["SWH3 #1782- Saturday, March 14", "SWH3 #1782"],
+    ["SWH3 #1779, Sunday, Feb 22", "SWH3 #1779"],
+    ["Trail Name - Sunday, May 24", "Trail Name"],
+  ])("strips orphan connector punct after trailing date: %j → %j (#1647)", (input, expected) => {
+    expect(sanitizeTitle(input)).toBe(expected);
+  });
+
   it("returns null for undefined", () => {
     expect(sanitizeTitle(undefined)).toBeNull();
   });

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -839,7 +839,7 @@ export function sanitizeTitle(title: string | undefined): string | null {
   // sweeps the orphan dash. Mirrors the adapter-level strip in
   // google-calendar/adapter.ts (#756/#1060) but applied universally for
   // adapters that don't pre-strip.
-  cleaned = cleaned.replace(/[\s,:\-–—]+$/, "").trim();
+  cleaned = cleaned.replace(/[\s,:\-–—]+$/, "").trim(); // NOSONAR S5852 — single char class + `+` anchored to `$`, linear in input length
   // Collapse multiple spaces from stripping and trim
   cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
   // Strip embedded email addresses

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -833,6 +833,13 @@ export function sanitizeTitle(title: string | undefined): string | null {
   );
   // Strip trailing " - Location TBD" suffixes (e.g., EWH3 calendar: "Hare Names - Location TBD")
   cleaned = cleaned.replace(/\s*-\s*Location\s+TBD\s*$/i, "").trim();
+  // #1647 — strip trailing connector punctuation left over after the date/
+  // Location-TBD suffix strips above. SWH3 emits "SWH3 #1792- Sunday, May
+  // 24"; after the trailing-day-of-week strip leaves "SWH3 #1792-", this
+  // sweeps the orphan dash. Mirrors the adapter-level strip in
+  // google-calendar/adapter.ts (#756/#1060) but applied universally for
+  // adapters that don't pre-strip.
+  cleaned = cleaned.replace(/[\s,:\-–—]+$/, "").trim();
   // Collapse multiple spaces from stripping and trim
   cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
   // Strip embedded email addresses


### PR DESCRIPTION
## Summary

Bundled fix for 6 audit-driven adapter bugs across 4 adapter surfaces. Each is a recurrence/escape of an earlier cycle-8 or cycle-11 fix.

| # | Symptom | Adapter | Approach |
|---|---------|---------|----------|
| #1615 | "Hares are X" line-anchor missed mid-sentence form | GCal (hare-extraction) | Added `(?<=[.!?]\s)` lookbehind alternative; existing prose denylist + `[A-Z*]` anchor keep FPs bounded |
| #1647 | "SWH3 #1792-" trailing dash leak | HTML_SCRAPER (WordPress) | Exported `cleanTrailingPunct` helper; applied at title emission |
| #1645 | RH3 "CLAIM THIS TRAIL" (3 events) | MEETUP | New `cleanMeetupTitle` strips end-anchored stacked CTAs via shared `CTA_EMBEDDED_PATTERNS` |
| #1646 | TMFMH3 "Claim this Trail!" | MEETUP | Same fix as #1645 |
| #1653 | MoA2H3 doubled prefix survived NBSP/tab/double-space | GCal | Replaced literal-space `startsWith` with `^(tag)\s+tag(?=\s\|$)` regex (`iu` flags) |
| #1649 | Colorado aggregate routes BH3 #969 → DH3 | seed (sources.ts) | Verified RawEvent provenance: bug is in **Denver H3 GCal source** (no kennelPatterns); added patterns mirroring the Colorado aggregator |

### Notes per issue

**#1649 verification gate (per the plan's risk callout)** — I queried the prod RawEvent for the affected Event (`cmpfx2r33002404k0mfb1gqg2`) and confirmed the raw GCal summary was a clean `"BH3 #969 12th Anal Toga Hash"`. The Colorado aggregator's regex would have matched correctly. The actual bug: Boulder cross-posts events to the **Denver H3 Google Calendar** (`denverkennel@gmail.com`), which had only `defaultKennelTag: "dh3-co"` with no patterns — every event was blindly tagged dh3-co. Fix mirrors the aggregator's pattern set on the Denver source. True Denver runs still route through `defaultKennelTag`.

**Known partial guard:** Future cross-posts from kennels other than BH3/MiHiHuHa would still be silently tagged dh3-co (acceptable scope — the Denver source's host runs need a default; new guests will surface as audit alerts).

**#1645/#1646 stacked-CTA support:** Added an iterate-until-stable loop so titles like `"Trail 300 - Hares Needed - Claim This Trail!"` reduce cleanly to `"Trail 300"`.

**#1615 lookbehind:** Variable-length lookbehind has full V8 support on Node 20+; matches existing patterns in the same file.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 7248 passed (3 new tests added across hare-extraction / swh3 / meetup / google-calendar)
- [x] `/codex:adversarial-review` — 1 P2 (acceptable: noted in PR body), 2 info findings addressed with additional test coverage
- [x] `/simplify` — code-simplifier hoisted CTA regex compilation out of the inner loop
- [x] Live verification (#1649): queried prod RawEvent `cmpfx2r33002404k0mfb1gqg2` — confirmed Denver H3 GCal source produced kennelTags=["dh3-co"] for the BH3 cross-post; raw title was a clean `"BH3 #969 12th Anal Toga Hash"`

### Post-merge

- **#1649 needs `npx prisma db seed` against prod** after merge — Vercel deploys the seed file but does NOT re-run `db seed`; the new `Source.config` patterns take effect only after re-seed + next scrape (memory: `feedback_post_merge_seed_required`).
- **#1653 stale Event row:** if the live event still shows doubled after merge + re-scrape, the raw GCal summary is no longer doubled (admin fixed it source-side) — manually trigger a refresh on the MoA2H3 GCal source.
- **#1615 cleanup:** Austin H3 events #2278/#2279/#2282 had `haresText` cleared to NULL pre-fix; next scrape will repopulate.

Closes #1615
Closes #1647
Closes #1645
Closes #1646
Closes #1653
Closes #1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)