### PR TITLE
fix(hashrego): 5-Boro year-rollover gap guard + missing NYCH3 alias (refs #1560)

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -1,5 +1,5 @@
 export const KENNEL_ALIASES: Record<string, string[]> = {
-    "nych3": ["NYC", "HashNYC", "NYC Hash", "NYCH3", "New York Hash", "NYC H3"],
+    "nych3": ["NYC", "HashNYC", "NYC Hash", "NYCH3", "New York Hash", "NYC H3", "New York City Hash House Harriers"],
     "boh3": ["Boston", "BH3", "BoH3", "Boston Hash"],
     "brh3": ["Brooklyn", "BrH3", "Brooklyn Hash", "Brooklyn H3"],
     "bobbh3": ["Ballbuster", "BoBBH3", "Boston Ballbuster", "Ballbuster Hash", "B3H4", "Boston Ballbuster Hardcore", "Boston Ballbuster H4"],

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -1172,6 +1172,24 @@ describe("parseDayHeaderSections", () => {
       anchor: "2026-12-30",
       expected: ["2026-12-30", "2026-12-31", "2027-01-01", "2027-01-02"],
     },
+    {
+      // Prod validation finding post-PR D (#1667): Hash Rego registered NYC
+      // 5-Boro Pub Crawl 2026 with index startDate `6/27/26` (Saturday — the
+      // main pub-crawl day), NOT `6/26/26` (Friday — the kickoff). The
+      // pre-#1668 year-rollover heuristic ("any candidate < anchor → year+1")
+      // wrongly promoted Friday's `6/26` to 2027. The 90-day gap guard
+      // ensures within-month admin off-by-one days stay in the same year.
+      label: "5-Boro 2026: Friday 6/26 stays in 2026 when anchor is Saturday 6/27",
+      desc: "**FRIDAY 6/26 — GGFM trail**\n**SATURDAY 6/27 — Pub Crawl**\n**SUNDAY 6/28 — Watch Party**",
+      anchor: "2026-06-27",
+      expected: ["2026-06-26", "2026-06-27", "2026-06-28"],
+    },
+    {
+      label: "60-day gap stays in same year (not far enough for year bump)",
+      desc: "**DAY 1 1/1 —** January start\n**DAY 2 2/15 —** Feb middle",
+      anchor: "2026-02-15", // ~45 days before 2/15
+      expected: ["2026-01-01", "2026-02-15"],
+    },
   ])("$label", ({ desc, anchor, expected }) => {
     expect(parseDayHeaderSections(desc, anchor).map((e) => e.date)).toEqual(expected);
   });

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -802,10 +802,26 @@ export function parseDayHeaderSections(
   // right days (Codex P1 review on PR #1630).
   const entries: DayHeaderSection[] = allMatches.map((m, i) => {
     const candidate = `${baseYear}-${String(m.month).padStart(2, "0")}-${String(m.day).padStart(2, "0")}`;
-    // Year-rollover: if the parsed M/D lands chronologically before the
-    // event's anchor date, it must belong to the following year (the
-    // anchor is always the event's earliest known day).
-    const date = candidate < startDateStr
+    // Year-rollover heuristic: only bump to the following year when the
+    // parsed M/D is **far enough before** the anchor date that it can't
+    // plausibly be earlier in the same event.
+    //
+    // Original rule (PR B #1630) was "any candidate < anchor → year+1",
+    // assuming the anchor is the event's earliest day. That broke when
+    // Hash Rego's index startDate is the MAIN event day (Saturday) instead
+    // of the kickoff (Friday) — verified against prod for the NYC 5-Boro
+    // Pub Crawl 2026 (index startDate 6/27, description says 6/26/6/27/6/28).
+    // Friday's `6/26` was wrongly bumped to 2027, scattering the series.
+    //
+    // 90-day gate: NYE campouts (12/31 → 1/1) have a calendar gap of ~365
+    // days when treated as same-year (1/1 minus 12/31 = -364 in same-year),
+    // so the bump fires. Within-month admin off-by-one days (6/26 vs 6/27)
+    // have a gap of ~1 day — stays in the same year.
+    const YEAR_BUMP_GAP_DAYS = 90;
+    const candidateMs = Date.parse(`${candidate}T00:00:00Z`);
+    const anchorMs = Date.parse(`${startDateStr}T00:00:00Z`);
+    const daysBeforeAnchor = (anchorMs - candidateMs) / (1000 * 60 * 60 * 24);
+    const date = daysBeforeAnchor > YEAR_BUMP_GAP_DAYS
       ? `${baseYear + 1}-${String(m.month).padStart(2, "0")}-${String(m.day).padStart(2, "0")}`
       : candidate;
     // Slice between this header's end and the next header's start (or


### PR DESCRIPTION
## Summary

Two narrow Hash Rego edge cases surfaced by prod validation after #1667 merged. Both block the NYC 5-Boro Pub Crawl 2026 (Jun 26–28) from rendering as a series.

## Issue 1 — Year-rollover heuristic misfires on within-month off-by-one days

Hash Rego registered the 5-Boro with index startDate `6/27/26` (Saturday — the main pub-crawl day) **not** `6/26/26` (Friday, the kickoff). The PR B year-rollover rule ("any candidate < anchor → year+1") then wrongly bumped Friday's `6/26` to **2027**, scattering the series.

**Fix:** replace strict `<` with a **90-day gap guard**. NYE rollovers (12/31 → 1/1) have a ~365-day same-year gap so the bump still fires. Within-month off-by-one days (6/26 vs 6/27, gap ~1 day) stay in the same year.

Adds two regression tests:
- `5-Boro 2026: Friday 6/26 stays in 2026 when anchor is Saturday 6/27` (the failing case)
- `60-day gap stays in same year (not far enough for year bump)` (sanity check the threshold)

## Issue 2 — Missing seed alias for the long Hash Rego display name

Hash Rego's `/events/nych3-5-boro-pub-crawl-2026` detail page emits `"New York City Hash House Harriers"` as the host kennel display name. The seed had `[NYC, HashNYC, NYC Hash, NYCH3, New York Hash, NYC H3]` but not the full long form. The merge resolver left the 5-Boro parent + Day 2 RawEvents stuck as `processed: false, eventId: NULL` (verified in prod).

**Fix:** add `"New York City Hash House Harriers"` to `nych3` aliases. ⚠️ **Requires `npx prisma db seed` post-deploy.**

## Expected post-merge prod state

After this PR merges, deploys, and the seed runs + scrapes re-fire:

| ID | date | endDate | isSeriesParent | parentEventId | kennel | title |
|---|---|---|---|---|---|---|
| `e_5boro_parent` | 2026-06-26 | 2026-06-28 | **true** | — | nych3 | NYCH3 5-Boro Pub Crawl 2026 |
| `e_5boro_fri` | 2026-06-26 | — | false | parent | **ggfm** | GGFM Strawberry Moon Trail (Day 1) |
| `e_5boro_sat` | 2026-06-27 | — | false | parent | nych3 | 5-Boro Pub Crawl (Day 2) |
| `e_5boro_sun` | 2026-06-28 | — | false | parent | nych3 | NYC Pride Watch (Day 3) |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 137 hashrego tests pass (+2 new); full suite green
- [ ] **Post-merge:** `npx prisma db seed` to apply the new alias
- [ ] **Post-merge:** trigger Hash Rego scrape; query prod and verify 4 events linked correctly

## Out of scope

- **BAWC5 Marin H3 missing child link** — separate issue: `/runs/6449` was removed from the SFH3 iCal feed (last scraped 5/11). PR D's `sharesKennel` drop works for the remaining 2 children (SVH3, EBH3); Marin would need a forced re-scrape OR for SFH3 to republish the trail in the iCal feed. Filing as a backlog issue.

Refs #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)