### PR TITLE
fix(lh3): structured field selectors in runlist + detail parsers (#1606)

### DIFF
--- a/src/adapters/html-scraper/london-hash.test.ts
+++ b/src/adapters/html-scraper/london-hash.test.ts
@@ -9,6 +9,7 @@ import {
   parseTitleFromBlock,
   parseLH3DetailPage,
   mergeLH3DetailIntoEvent,
+  extractStationOnly,
 } from "./london-hash";
 import type { LH3DetailPageData } from "./london-hash";
 import type { RawEventData } from "../types";
@@ -28,8 +29,10 @@ describe("parseDateFromBlock", () => {
     expect(parseDateFromBlock("Saturday 21st of February 2026")).toBe("2026-02-21");
   });
 
-  it("parses ordinal with 'of' without year (uses reference)", () => {
-    expect(parseDateFromBlock("Saturday 21st of February", 2026)).toBe("2026-02-21");
+  it("parses ordinal with 'of' without year (uses reference date)", () => {
+    expect(
+      parseDateFromBlock("Saturday 21st of February", new Date(Date.UTC(2026, 0, 1))),
+    ).toBe("2026-02-21");
   });
 
   it("parses ordinal without 'of'", () => {
@@ -56,12 +59,23 @@ describe("parseDateFromBlock", () => {
     expect(parseDateFromBlock("")).toBeNull();
   });
 
-  it("resolves year-less dates forward of reference year (live runlist behavior)", () => {
+  it("resolves year-less dates forward of reference date (live runlist behavior)", () => {
     // Live runlist rows omit the year — chrono must pick the next-future
     // occurrence (forwardDate semantics). Reference Jan 1 2026 + "6th of June"
     // → June 6 2026, not June 6 2025.
-    expect(parseDateFromBlock("Saturday 6th of June", 2026)).toBe("2026-06-06");
-    expect(parseDateFromBlock("Saturday 14th of February", 2026)).toBe("2026-02-14");
+    const refJan2026 = new Date(Date.UTC(2026, 0, 1));
+    expect(parseDateFromBlock("Saturday 6th of June", refJan2026)).toBe("2026-06-06");
+    expect(parseDateFromBlock("Saturday 14th of February", refJan2026)).toBe("2026-02-14");
+  });
+
+  it("rolls year-less January date forward when scraped in late December", () => {
+    // Year-end regression (Gemini + CodeRabbit reviews on PR #1682): a
+    // December 2026 scrape sees "Saturday 10th of January" on runlist and
+    // must resolve it to *next* January (2027), not the current-year past.
+    const refLateDec = new Date(Date.UTC(2026, 11, 28)); // Dec 28 2026
+    expect(parseDateFromBlock("Saturday 10th of January", refLateDec)).toBe(
+      "2027-01-10",
+    );
   });
 });
 
@@ -176,6 +190,27 @@ describe("parseLocationFromBlock", () => {
     );
     expect(result.station).toBe("Rotherhithe");
     expect(result.location).toBeUndefined();
+  });
+});
+
+describe("extractStationOnly (procedural fallback)", () => {
+  it("captures the station name from `from X station`", () => {
+    expect(extractStationOnly("Follow the P trail from Sydenham station")).toBe(
+      "Sydenham",
+    );
+  });
+
+  it("returns undefined when there's no `station` keyword", () => {
+    expect(extractStationOnly("Follow the P trail from somewhere")).toBeUndefined();
+  });
+
+  it("returns undefined when the prefix is missing", () => {
+    expect(extractStationOnly("Sydenham station is closed")).toBeUndefined();
+  });
+
+  it("rejects multi-line / star-polluted captures", () => {
+    expect(extractStationOnly("from Some\nstation station")).toBeUndefined();
+    expect(extractStationOnly("from *theme* station")).toBeUndefined();
   });
 });
 
@@ -403,6 +438,13 @@ describe("parseRunBlocks", () => {
     expect(blocks[0].locText).toContain("Sydenham");
     expect(blocks[0].locText).toContain("Dolphin");
   });
+
+  it("captures .runlistNote paragraphs into noteTexts", () => {
+    const blocks = parseRunBlocks(SAMPLE_HTML);
+    // Sydenham block ships a single note "** 50th Anniversary Special **".
+    expect(blocks[0].noteTexts.length).toBeGreaterThanOrEqual(1);
+    expect(blocks[0].noteTexts[0]).toContain("Anniversary");
+  });
 });
 
 describe("parseLH3DetailPage", () => {
@@ -452,6 +494,22 @@ describe("parseLH3DetailPage", () => {
     expect(detail).not.toBeNull();
     expect(detail!.hares).toBe("Knickers");
     expect(detail!.hares).not.toContain("Travel");
+  });
+
+  it("captures 'What Else' label content into detail.notes (#1606)", () => {
+    // Source ships event-specific notes in the "What Else" section
+    // (travel info, theme, anniversary marker). They should surface on
+    // the detail object instead of being silently dropped.
+    const html = `
+<html><body>
+<div id="nextRunDetailsHolder">
+  <div class="nextRunlistRow"><div class="runlistCat">Who</div><div class="runlistDetail">Hared by Sweetheart</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">What Else</div><div class="runlistDetail">Bring your hash cups as there may be a DS.</div></div>
+</div>
+</body></html>`;
+    const detail = parseDetail(html, "https://www.londonhash.org/nextrun.php?run=4112");
+    expect(detail).not.toBeNull();
+    expect(detail!.notes).toBe("Bring your hash cups as there may be a DS.");
   });
 
   it("tolerates the live-site class typo (`runlistRow` missing the `next` prefix)", () => {
@@ -648,6 +706,9 @@ describe("LondonHashAdapter.fetch", () => {
     expect(first!.location).toBe("The Dolphin");
     expect(first!.startTime).toBe("12:00");
     expect(first!.description).toContain("Nearest station: Sydenham");
+    // Runlist `.runlistNote` content is now propagated into description
+    // (per CodeRabbit review on PR #1682 — was previously discarded).
+    expect(first!.description).toContain("Anniversary");
     expect(first!.sourceUrl).toContain("nextrun.php?run=3840");
 
     // Placeholder `**To Be Announced` title falls back to synthesized default.

--- a/src/adapters/html-scraper/london-hash.test.ts
+++ b/src/adapters/html-scraper/london-hash.test.ts
@@ -6,6 +6,7 @@ import {
   parseHaresFromBlock,
   parseLocationFromBlock,
   parseTimeFromBlock,
+  parseTitleFromBlock,
   parseLH3DetailPage,
   mergeLH3DetailIntoEvent,
 } from "./london-hash";
@@ -53,6 +54,14 @@ describe("parseDateFromBlock", () => {
 
   it("returns null for empty text", () => {
     expect(parseDateFromBlock("")).toBeNull();
+  });
+
+  it("resolves year-less dates forward of reference year (live runlist behavior)", () => {
+    // Live runlist rows omit the year — chrono must pick the next-future
+    // occurrence (forwardDate semantics). Reference Jan 1 2026 + "6th of June"
+    // → June 6 2026, not June 6 2025.
+    expect(parseDateFromBlock("Saturday 6th of June", 2026)).toBe("2026-06-06");
+    expect(parseDateFromBlock("Saturday 14th of February", 2026)).toBe("2026-02-14");
   });
 });
 
@@ -158,6 +167,16 @@ describe("parseLocationFromBlock", () => {
     expect(result.location).toBe("The Red Lion");
     expect(result.station).toBe("Clapham");
   });
+
+  it("extracts station-only when no destination is given (live layout)", () => {
+    // Live runlist `.runlistLoc` for a TBA-destination row contains just
+    // "Follow the P trail from Rotherhithe station" — no "to PUB" clause.
+    const result = parseLocationFromBlock(
+      "Follow the P trail from Rotherhithe station",
+    );
+    expect(result.station).toBe("Rotherhithe");
+    expect(result.location).toBeUndefined();
+  });
 });
 
 describe("parseTimeFromBlock", () => {
@@ -183,6 +202,45 @@ describe("parseTimeFromBlock", () => {
 
   it("returns null for no time", () => {
     expect(parseTimeFromBlock("Some text")).toBeNull();
+  });
+});
+
+describe("parseTitleFromBlock", () => {
+  it("uses plain location heading as title", () => {
+    expect(parseTitleFromBlock("Bromley South", 2834)).toBe("Bromley South");
+  });
+
+  it("strips ** wrappers from themed-run titles", () => {
+    expect(
+      parseTitleFromBlock("**Sweetheart's 4th of July Hash**", 2839),
+    ).toBe("Sweetheart's 4th of July Hash");
+  });
+
+  it("strips stray leading ** on placeholders", () => {
+    // Live source ships `"**To Be Announced"` (unmatched markdown) — the
+    // sanitizer should strip the ** and recognize TBA → fall back to default.
+    expect(parseTitleFromBlock("**To Be Announced", 2838)).toBe("London Hash Run #2838");
+  });
+
+  it("strips all ** markers and collapses spaces in combined location+theme headings", () => {
+    expect(
+      parseTitleFromBlock("Hampstead Heath **Sweetheart's 4th of July Hash**", 2839),
+    ).toBe("Hampstead Heath Sweetheart's 4th of July Hash");
+  });
+
+  it.each([
+    ["To Be Announced"],
+    ["TBA"],
+    ["tba"],
+    ["TBD"],
+    ["details to be announced"],
+  ])("falls back to default for placeholder %s", (placeholder) => {
+    expect(parseTitleFromBlock(placeholder, 2837)).toBe("London Hash Run #2837");
+  });
+
+  it("falls back to default for empty title", () => {
+    expect(parseTitleFromBlock("", 2820)).toBe("London Hash Run #2820");
+    expect(parseTitleFromBlock("   ", 2821)).toBe("London Hash Run #2821");
   });
 });
 
@@ -231,7 +289,9 @@ const SAMPLE_HTML = `
 </body></html>
 `;
 
-// Sample detail page HTML (realistic, based on actual londonhash.org/nextrun.php structure)
+// Sample detail page mirroring the live nextrun.php structure — labels in
+// `.runlistCat`, values in `.runlistDetail`. Includes the "What Else"
+// section that historically bled into the hares field (issue #1606).
 const SAMPLE_LH3_DETAIL_HTML = `
 <html><head>
 <script>
@@ -240,41 +300,30 @@ async function initMap() {
   map = new Map(document.getElementById("mapId"), {
     center: { lat: 51.546173, lng: -0.178557 },
     zoom: 16,
-    mapTypeId: google.maps.MapTypeId.ROADMAP,
-  });
-  const marker1 = new google.maps.Marker({
-    position: { lat: 51.546826, lng: -0.179815 },
-    icon: "./images/train.png",
-    title: "P trail from Finchley Road",
   });
   const marker2 = new google.maps.Marker({
     position: { lat: 51.546173, lng: -0.178557 },
-    icon: "./images/beerbottle.png",
     title: "On Inn to The North Star",
   });
 }
 </script>
 </head><body>
-<h1>Finchley Road</h1>
-<hr />
-<p>London hash number 2823</p>
-<hr />
-<p>Follow the P trail from Finchley Road station to The North Star</p>
-<hr />
-<p>Saturday 14th of March at 12 Noon for 12:30 (5 days time)</p>
-<hr />
-<p>The North Star is 113 meters from Finchley Road station as the Skylark flies</p>
-<hr />
-<p>Hared by Not Out and Big In Japan</p>
-<hr />
-<p>Bring your hash cups as there may be a DS. Dogs welcome but must be kept on the lead.</p>
-<hr />
-<p><a href="http://maps.google.com/?q=51.546173,-0.178557">open in Google Maps</a></p>
-<div id="mapId"></div>
+<div id="titleHolder">
+  <h2 id="title">Finchley Road<br />Saturday 14th of March</h2>
+</div>
+<div id="nextRunDetailsHolder">
+  <div class="nextRunlistRow"><div class="runlistCat">What</div><div class="runlistDetail">London hash number <span class="bold">2823</span></div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">Where</div><div class="runlistDetail">Follow the P trail from<br /> Finchley Road station <br />to The North Star</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">When</div><div class="runlistDetail">Saturday 14th of March at 12 Noon for 12:30 (5 days time)</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">How Far</div><div class="runlistDetail">The North Star is 113 meters from Finchley Road station as the Skylark flies</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">Who</div><div class="runlistDetail">Hared by Not Out and Big In Japan</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">What Else</div><div class="runlistDetail">Bring your hash cups as there may be a DS.</div></div>
+</div>
+<div id="mapOpenPrompt"><a href="http://maps.google.com/?q=51.546173,-0.178557">open in Google Maps</a></div>
 </body></html>
 `;
 
-// Detail page with run number 2820 (matches first run list block)
+// Detail page for run #2820 (matches first run list block) — same structured layout.
 const SAMPLE_LH3_DETAIL_HTML_2820 = `
 <html><head>
 <script>
@@ -282,38 +331,24 @@ async function initMap() {
   const { Map } = await google.maps.importLibrary("maps");
   map = new Map(document.getElementById("mapId"), {
     center: { lat: 51.427391, lng: -0.054509 },
-    zoom: 16,
-    mapTypeId: google.maps.MapTypeId.ROADMAP,
-  });
-  const marker1 = new google.maps.Marker({
-    position: { lat: 51.427121, lng: -0.055213 },
-    icon: "./images/train.png",
-    title: "P trail from Sydenham",
   });
   const marker2 = new google.maps.Marker({
     position: { lat: 51.427391, lng: -0.054509 },
-    icon: "./images/beerbottle.png",
     title: "On Inn to The Dolphin",
   });
 }
 </script>
 </head><body>
-<h1>Sydenham</h1>
-<hr />
-<p>London hash number 2820</p>
-<hr />
-<p>Follow the P trail from Sydenham station to The Dolphin</p>
-<hr />
-<p>Saturday 21st of February at 12 Noon for 12:30 (5 days time)</p>
-<hr />
-<p>The Dolphin is 85 metres from Sydenham station as the Skylark flies</p>
-<hr />
-<p>Hared by Tuna Melt and Opee</p>
-<hr />
-<p>** 50th Anniversary Special **</p>
-<hr />
-<p><a href="http://maps.google.com/?q=51.427391,-0.054509">open in Google Maps</a></p>
-<div id="mapId"></div>
+<div id="titleHolder"><h2 id="title">Sydenham<br />Saturday 21st of February</h2></div>
+<div id="nextRunDetailsHolder">
+  <div class="nextRunlistRow"><div class="runlistCat">What</div><div class="runlistDetail">London hash number <span class="bold">2820</span></div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">Where</div><div class="runlistDetail">Follow the P trail from Sydenham station to The Dolphin</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">When</div><div class="runlistDetail">Saturday 21st of February at 12 Noon for 12:30</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">How Far</div><div class="runlistDetail">The Dolphin is 85 metres from Sydenham station as the Skylark flies</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">Who</div><div class="runlistDetail">Hared by Tuna Melt and Opee</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">What Else</div><div class="runlistDetail">** 50th Anniversary Special **</div></div>
+</div>
+<div id="mapOpenPrompt"><a href="http://maps.google.com/?q=51.427391,-0.054509">open in Google Maps</a></div>
 </body></html>
 `;
 
@@ -337,7 +372,7 @@ async function initMap() {
 `;
 
 describe("parseRunBlocks", () => {
-  it("splits page into run blocks", () => {
+  it("splits page into structured per-field blocks", () => {
     const blocks = parseRunBlocks(SAMPLE_HTML);
     expect(blocks.length).toBeGreaterThanOrEqual(4);
     expect(blocks[0].runNumber).toBe(2820);
@@ -347,19 +382,35 @@ describe("parseRunBlocks", () => {
     expect(blocks[3].runNumber).toBe(2823);
   });
 
-  it("captures text content for each block", () => {
+  it("extracts .titleRow content into titleText (per-field, not block-text)", () => {
     const blocks = parseRunBlocks(SAMPLE_HTML);
-    expect(blocks[0].text).toContain("Sydenham");
-    expect(blocks[0].text).toContain("Tuna Melt");
-    expect(blocks[0].text).toContain("February");
+    expect(blocks[0].titleText).toBe("Sydneham");
+    expect(blocks[1].titleText).toBe("Finsbury Park");
+    expect(blocks[2].titleText).toBe("**To Be Announced");
+    expect(blocks[3].titleText).toBe("Ealing Broadway");
+  });
+
+  it("extracts .runlistHare without bleeding into adjacent notes", () => {
+    const blocks = parseRunBlocks(SAMPLE_HTML);
+    expect(blocks[0].hareText).toContain("Tuna Melt and Opee");
+    expect(blocks[0].hareText).not.toMatch(/anniversary|special|note/i);
+    expect(blocks[1].hareText).toContain("Captain Adventures");
+  });
+
+  it("captures .runlistDate and .runlistLoc fields independently", () => {
+    const blocks = parseRunBlocks(SAMPLE_HTML);
+    expect(blocks[0].dateText).toContain("February");
+    expect(blocks[0].locText).toContain("Sydenham");
+    expect(blocks[0].locText).toContain("Dolphin");
   });
 });
 
 describe("parseLH3DetailPage", () => {
-  it("extracts all fields from a full detail page", () => {
+  it("extracts all fields from a structured detail page", () => {
     const detail = parseDetail(SAMPLE_LH3_DETAIL_HTML, "https://www.londonhash.org/nextrun.php?run=4092");
     expect(detail).not.toBeNull();
     expect(detail!.runNumber).toBe(2823);
+    expect(detail!.title).toBe("Finchley Road");
     expect(detail!.latitude).toBeCloseTo(51.546173, 4);
     expect(detail!.longitude).toBeCloseTo(-0.178557, 4);
     expect(detail!.locationUrl).toBe("http://maps.google.com/?q=51.546173,-0.178557");
@@ -369,6 +420,53 @@ describe("parseLH3DetailPage", () => {
     expect(detail!.distance).toBe("113 meters from Finchley Road station as the Skylark flies");
     expect(detail!.onOn).toBe("The North Star");
     expect(detail!.sourceUrl).toBe("https://www.londonhash.org/nextrun.php?run=4092");
+  });
+
+  it("does NOT bleed 'What Else' label into hares (#1606)", () => {
+    // Regression test: with the prior body-text-regex parser, the `Hared by K4`
+    // value would over-consume into the next "What Else" section because divs
+    // are siblings with no whitespace separator in the source HTML.
+    const html = `
+<html><body>
+<div id="nextRunDetailsHolder">
+  <div class="nextRunlistRow"><div class="runlistCat">What</div><div class="runlistDetail">London hash number 2833</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">Who</div><div class="runlistDetail">Hared by K4</div></div>
+  <div class="nextRunlistRow"><div class="runlistCat">What Else</div><div class="runlistDetail">Travel info: see TfL.</div></div>
+</div>
+</body></html>`;
+    const detail = parseDetail(html, "https://www.londonhash.org/nextrun.php?run=4106");
+    expect(detail).not.toBeNull();
+    expect(detail!.hares).toBe("K4");
+    expect(detail!.hares).not.toContain("What Else");
+  });
+
+  it("does NOT bleed travel-line into hares when 'What Else' section is absent (#1606)", () => {
+    const html = `
+<html><body>
+<div id="nextRunDetailsHolder">
+  <div class="nextRunlistRow"><div class="runlistCat">Who</div><div class="runlistDetail">Hared by Knickers</div></div>
+</div>
+<p>Travel details are yet to be announced</p>
+</body></html>`;
+    const detail = parseDetail(html, "https://www.londonhash.org/nextrun.php?run=4106");
+    expect(detail).not.toBeNull();
+    expect(detail!.hares).toBe("Knickers");
+    expect(detail!.hares).not.toContain("Travel");
+  });
+
+  it("tolerates the live-site class typo (`runlistRow` missing the `next` prefix)", () => {
+    // Verified on https://www.londonhash.org/nextrun.php?run=4108 — one row
+    // ships `class="runlistRow"` instead of `class="nextRunlistRow"`.
+    const html = `
+<html><body>
+<div id="nextRunDetailsHolder">
+  <div class="nextRunlistRow"><div class="runlistCat">Who</div><div class="runlistDetail">Hared by Boy Blunder</div></div>
+  <div class="runlistRow"><div class="runlistCat">What Else</div><div class="runlistDetail">Trail will be A to B</div></div>
+</div>
+</body></html>`;
+    const detail = parseDetail(html, "https://www.londonhash.org/nextrun.php?run=4108");
+    expect(detail).not.toBeNull();
+    expect(detail!.hares).toBe("Boy Blunder");
   });
 
   it("returns null for placeholder/TBA pages", () => {
@@ -381,10 +479,12 @@ describe("parseLH3DetailPage", () => {
     const html = `<html><head><script>
       map = new Map(el, { center: { lat: 51.508, lng: -0.128 }, zoom: 13 });
     </script></head><body>
-    <h1>Some Run</h1>
-    <p>London hash number 2825</p>
-    <p>Follow the P trail from Ealing Broadway station to The Red Lion</p>
-    <p>Hared by Pope</p>
+    <div id="titleHolder"><h2 id="title">Some Run</h2></div>
+    <div id="nextRunDetailsHolder">
+      <div class="nextRunlistRow"><div class="runlistCat">What</div><div class="runlistDetail">London hash number 2825</div></div>
+      <div class="nextRunlistRow"><div class="runlistCat">Where</div><div class="runlistDetail">Follow the P trail from Ealing Broadway station to The Red Lion</div></div>
+      <div class="nextRunlistRow"><div class="runlistCat">Who</div><div class="runlistDetail">Hared by Pope</div></div>
+    </div>
     </body></html>`;
     const detail = parseDetail(html, "https://www.londonhash.org/nextrun.php?run=4097");
     expect(detail).not.toBeNull();
@@ -399,7 +499,7 @@ describe("parseLH3DetailPage", () => {
 
   it("handles missing sections gracefully", () => {
     const html = `<html><body>
-    <h1>Partial Run</h1>
+    <div id="titleHolder"><h2 id="title">Partial Run</h2></div>
     <p>London hash number 2830</p>
     </body></html>`;
     const detail = parseDetail(html, "https://www.londonhash.org/nextrun.php?run=9999");
@@ -411,14 +511,14 @@ describe("parseLH3DetailPage", () => {
     expect(detail!.onOn).toBeUndefined();
   });
 
-  it("extracts coords from JS when no Maps link present", () => {
+  it("extracts coords from JS marker when no Maps link present", () => {
     const html = `<html><head><script>
       const marker = new google.maps.Marker({
         position: { lat: 51.6, lng: -0.2 },
         title: "On Inn to The Crown",
       });
     </script></head><body>
-    <h1>Test Run</h1>
+    <div id="titleHolder"><h2 id="title">Test Run</h2></div>
     <p>London hash number 2840</p>
     </body></html>`;
     const detail = parseDetail(html, "https://www.londonhash.org/nextrun.php?run=5000");
@@ -501,14 +601,33 @@ describe("mergeLH3DetailIntoEvent", () => {
     expect(merged.description).toContain("Nearest station: Some Station");
     expect(merged.description).toContain("On-On: The Crown");
   });
+
+  it("upgrades synthesized default title to detail-page title", () => {
+    const detail: LH3DetailPageData = {
+      title: "Finchley Road",
+      sourceUrl: "https://www.londonhash.org/nextrun.php?run=4092",
+    };
+    const merged = mergeLH3DetailIntoEvent(baseEvent, detail);
+    expect(merged.title).toBe("Finchley Road");
+  });
+
+  it("does NOT overwrite a real run-list title with detail-page title", () => {
+    const detail: LH3DetailPageData = {
+      title: "Different Title From Detail",
+      sourceUrl: "https://www.londonhash.org/nextrun.php?run=4092",
+    };
+    const merged = mergeLH3DetailIntoEvent(
+      { ...baseEvent, title: "Bromley South" }, // real title from run list
+      detail,
+    );
+    expect(merged.title).toBe("Bromley South");
+  });
 });
 
 describe("LondonHashAdapter.fetch", () => {
-  it("parses sample HTML and returns events", async () => {
-    // Run list + 3 detail page fetches (first 3 blocks)
+  it("parses sample HTML and emits per-block titles from .titleRow (no synthesized defaults)", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     fetchSpy.mockResolvedValueOnce(new Response(SAMPLE_HTML, { status: 200 }));
-    // Detail pages return placeholder HTML for simplicity
     fetchSpy.mockResolvedValue(new Response(SAMPLE_LH3_PLACEHOLDER_HTML, { status: 200 }));
 
     const adapter = new LondonHashAdapter();
@@ -520,9 +639,9 @@ describe("LondonHashAdapter.fetch", () => {
     expect(result.events.length).toBeGreaterThanOrEqual(3);
     expect(result.structureHash).toBeDefined();
 
-    // Check first event
     const first = result.events.find((e) => e.runNumber === 2820);
     expect(first).toBeDefined();
+    expect(first!.title).toBe("Sydneham"); // from .titleRow, NOT synthesized "London Hash Run #2820"
     expect(first!.date).toBe("2026-02-21");
     expect(first!.kennelTags[0]).toBe("lh3");
     expect(first!.hares).toBe("Tuna Melt and Opee");
@@ -531,16 +650,18 @@ describe("LondonHashAdapter.fetch", () => {
     expect(first!.description).toContain("Nearest station: Sydenham");
     expect(first!.sourceUrl).toContain("nextrun.php?run=3840");
 
+    // Placeholder `**To Be Announced` title falls back to synthesized default.
+    const placeholder = result.events.find((e) => e.runNumber === 2822);
+    expect(placeholder).toBeDefined();
+    expect(placeholder!.title).toBe("London Hash Run #2822");
+
     vi.restoreAllMocks();
   });
 
   it("enriches events from detail pages", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    // Run list page
     fetchSpy.mockResolvedValueOnce(new Response(SAMPLE_HTML, { status: 200 }));
-    // First detail page (run 3840 → run number 2820) — enriched with matching fixture
     fetchSpy.mockResolvedValueOnce(new Response(SAMPLE_LH3_DETAIL_HTML_2820, { status: 200 }));
-    // Remaining detail pages — placeholder
     fetchSpy.mockResolvedValue(new Response(SAMPLE_LH3_PLACEHOLDER_HTML, { status: 200 }));
 
     const adapter = new LondonHashAdapter();
@@ -549,13 +670,14 @@ describe("LondonHashAdapter.fetch", () => {
       url: "https://www.londonhash.org/runlist.php",
     } as never);
 
-    // The first event (2820) should be enriched from the detail page
     const enriched = result.events.find((e) => e.runNumber === 2820);
     expect(enriched).toBeDefined();
     expect(enriched!.latitude).toBeCloseTo(51.427391, 4);
     expect(enriched!.longitude).toBeCloseTo(-0.054509, 4);
     expect(enriched!.locationUrl).toBe("http://maps.google.com/?q=51.427391,-0.054509");
     expect(enriched!.description).toContain("On-On: The Dolphin");
+    // Run-list title "Sydneham" preserved over detail "Sydenham" (different spelling — keep authoritative run-list copy)
+    expect(enriched!.title).toBe("Sydneham");
 
     expect(result.diagnosticContext?.detailPagesEnriched).toBeGreaterThanOrEqual(1);
 
@@ -564,9 +686,7 @@ describe("LondonHashAdapter.fetch", () => {
 
   it("handles detail page fetch failures gracefully", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    // Run list succeeds
     fetchSpy.mockResolvedValueOnce(new Response(SAMPLE_HTML, { status: 200 }));
-    // All detail pages fail
     fetchSpy.mockRejectedValue(new Error("Detail fetch failed"));
 
     const adapter = new LondonHashAdapter();
@@ -575,7 +695,6 @@ describe("LondonHashAdapter.fetch", () => {
       url: "https://www.londonhash.org/runlist.php",
     } as never);
 
-    // Events from run list should still be present
     expect(result.events.length).toBeGreaterThanOrEqual(3);
     expect(result.diagnosticContext?.detailPagesEnriched).toBe(0);
 
@@ -665,6 +784,7 @@ describe("parseRunBlocks — inline element spacing", () => {
       <html><body>
       <div id="runListHolder">
         <div class="runListDetails">
+          <div class="runlistRow titleRow">Test Heading</div>
           <div class="runlistRow">
             <div class="runlistCat runlistNo"><a href="nextrun.php?run=2285">2285</a></div>
             <div class="runlistDate">Saturday 22nd of February 2026<br />12 Noon</div>
@@ -676,8 +796,8 @@ describe("parseRunBlocks — inline element spacing", () => {
     `;
     const blocks = parseRunBlocks(html);
     expect(blocks).toHaveLength(1);
-    // Hare names should be separated by space, not concatenated
-    expect(blocks[0].text).toContain("Not Out and Big In Japan");
-    expect(blocks[0].text).not.toContain("JapanWhat");
+    // Hare names should be separated by space, not concatenated.
+    expect(blocks[0].hareText).toContain("Not Out and Big In Japan");
+    expect(blocks[0].hareText).not.toContain("JapanWhat");
   });
 });

--- a/src/adapters/html-scraper/london-hash.test.ts
+++ b/src/adapters/html-scraper/london-hash.test.ts
@@ -10,6 +10,8 @@ import {
   parseLH3DetailPage,
   mergeLH3DetailIntoEvent,
   extractStationOnly,
+  extractDistance,
+  extractOnInnMarker,
 } from "./london-hash";
 import type { LH3DetailPageData } from "./london-hash";
 import type { RawEventData } from "../types";
@@ -190,6 +192,61 @@ describe("parseLocationFromBlock", () => {
     );
     expect(result.station).toBe("Rotherhithe");
     expect(result.location).toBeUndefined();
+  });
+});
+
+describe("extractDistance (procedural)", () => {
+  it("captures `<digits> meters from <rest-of-line>`", () => {
+    expect(extractDistance("The North Star is 113 meters from Finchley Road station as the Skylark flies")).toBe(
+      "113 meters from Finchley Road station as the Skylark flies",
+    );
+  });
+
+  it("accepts British 'metres'", () => {
+    expect(extractDistance("85 metres from Sydenham station")).toBe(
+      "85 metres from Sydenham station",
+    );
+  });
+
+  it("stops at newline", () => {
+    expect(extractDistance("100 meters from X station\nfollowed by curry")).toBe(
+      "100 meters from X station",
+    );
+  });
+
+  it("returns undefined when no distance phrase is present", () => {
+    expect(extractDistance("Some random text without a pattern")).toBeUndefined();
+  });
+
+  it("returns undefined when the unit is preceded by no digits", () => {
+    expect(extractDistance("walking meters from somewhere")).toBeUndefined();
+  });
+});
+
+describe("extractOnInnMarker (procedural)", () => {
+  it("returns the pub name from a `title:` JS line", () => {
+    expect(extractOnInnMarker('title: "On Inn to Cork n Cask"')).toBe("Cork n Cask");
+  });
+
+  it("skips earlier non-OnInn `title:` keys (multi-marker pages)", () => {
+    // Real nextrun.php emits a train-trail marker title BEFORE the on-inn one.
+    const html = `
+title: "P trail from Bromley South",
+title: "On Inn to Cork n Cask",
+`;
+    expect(extractOnInnMarker(html)).toBe("Cork n Cask");
+  });
+
+  it("tolerates extra whitespace between `title:` and the opening quote", () => {
+    expect(extractOnInnMarker('title:    "On Inn to The Crown"')).toBe("The Crown");
+  });
+
+  it("returns undefined when no `On Inn` marker is present", () => {
+    expect(extractOnInnMarker('title: "Something else"')).toBeUndefined();
+  });
+
+  it("returns undefined when there's no `title:` at all", () => {
+    expect(extractOnInnMarker("not a marker")).toBeUndefined();
   });
 });
 

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -1,4 +1,5 @@
 import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
 import type { Source } from "@/generated/prisma/client";
 import type {
   SourceAdapter,
@@ -20,63 +21,102 @@ const LONDON_CENTER_LAT = 51.508;
 const LONDON_CENTER_LNG = -0.128;
 const COORD_THRESHOLD = 0.01; // ~1km
 
-/** Represents a parsed run block from the London Hash run list page. */
+/** TBA / placeholder titles that should fall back to the synthesized default. */
+const TITLE_PLACEHOLDER_RE = /^(?:to be announced|tba|tbc|tbd|details to be announced)$/i;
+
+/**
+ * Represents a parsed run block from the London Hash run list page.
+ *
+ * Each field maps to a specific `.runlistRow` child in the source HTML, so
+ * downstream parsers operate on isolated text instead of the concatenated
+ * block content. This prevents cross-section bleed (e.g. the hare name
+ * running into the next "What Else" / travel-info row — issue #1606).
+ */
 export interface RunBlock {
   runNumber: number;
-  runId: string; // The nextrun.php ID parameter
-  text: string; // Raw text content of the block
+  runId: string;
+  titleText: string;
+  dateText: string;
+  locText: string;
+  hareText: string;
+  noteTexts: string[];
+}
+
+/** Inline-pad a cheerio block: replace `<br>` with newlines and append a space
+ * after inline elements so adjacent text nodes don't fuse in `.text()`. */
+function padBlock($block: cheerio.Cheerio<AnyNode>): void {
+  $block.find("br").replaceWith("\n");
+  $block.find("span, a, strong, em, b, i").after(" ");
+}
+
+/** Read text content of the first matching child, trimmed and whitespace-collapsed. */
+function readField(
+  $: cheerio.CheerioAPI,
+  $block: cheerio.Cheerio<AnyNode>,
+  selector: string,
+): string {
+  const node = $block.find(selector).first();
+  if (!node.length) return "";
+  return $(node).text().trim().replace(/[ \t]{2,}/g, " ");
 }
 
 /**
  * Split the London Hash run list page into individual run blocks.
  * Each block is anchored by a <a href="nextrun.php?run=XXXX"> link.
+ *
+ * Field extraction is keyed on the per-row CSS classes the site emits
+ * (`.titleRow`, `.runlistDate`, `.runlistLoc`, `.runlistHare`,
+ * `.runlistNote`) so each `RunBlock` field is the text of its own div —
+ * never the entire concatenated block. Closes #1606.
  */
 export function parseRunBlocks(html: string): RunBlock[] {
   const $ = cheerio.load(html);
   const blocks: RunBlock[] = [];
 
-  // Strategy 1: Structured layout with .runListDetails containers (actual website)
+  // Strategy 1: Structured `.runListDetails` containers (live site)
   const containers = $(".runListDetails");
   if (containers.length > 0) {
     containers.each((_i, el) => {
       const $block = $(el);
-      const $link = $block.find('a[href*="nextrun.php"]');
+      const $link = $block.find('a[href*="nextrun.php"]').first();
       if (!$link.length) return;
 
-      const href = $link.attr("href") || "";
-      const runIdMatch = href.match(/run=(\d+)/);
-      if (!runIdMatch) return;
-
-      const runId = runIdMatch[1];
+      const runId = ($link.attr("href")?.match(/run=(\d+)/) ?? ["", ""])[1];
       const runNumber = parseInt($link.text().trim(), 10);
-      if (isNaN(runNumber)) return;
+      if (!runId || isNaN(runNumber)) return;
 
-      // Replace <br> with newlines so date/time don't concatenate
-      $block.find("br").replaceWith("\n");
-      // Insert newlines at table-cell boundaries so "Who" row value doesn't
-      // run into the "What Else" row label in .text() output. Closes #609.
-      $block.find("td, th").before("\n");
-      // Insert space after inline elements to prevent "Name1Name2" concatenation
-      $block.find("span, a, strong, em, b, i").after(" ");
-      const text = $block.text().trim();
+      padBlock($block);
 
-      blocks.push({ runNumber, runId, text });
+      const noteNodes = $block.find(".runlistNote");
+      const noteTexts: string[] = [];
+      noteNodes.each((_j, noteEl) => {
+        const t = $(noteEl).text().trim().replace(/[ \t]{2,}/g, " ");
+        if (t) noteTexts.push(t);
+      });
+
+      blocks.push({
+        runNumber,
+        runId,
+        titleText: readField($, $block, ".runlistRow.titleRow"),
+        dateText: readField($, $block, ".runlistDate"),
+        locText: readField($, $block, ".runlistLoc"),
+        hareText: readField($, $block, ".runlistHare"),
+        noteTexts,
+      });
     });
     return blocks;
   }
 
-  // Strategy 2: Flat text layout (fallback for simple HTML)
+  // Strategy 2: Flat fallback — degraded but functional. No `.titleRow`
+  // means title falls through to the synthesized default; the other
+  // parsers run against the surrounding flat text.
   const runLinks = $('a[href*="nextrun.php"]');
   runLinks.each((i, el) => {
     const $link = $(el);
-    const href = $link.attr("href") || "";
-    const runIdMatch = href.match(/run=(\d+)/);
-    if (!runIdMatch) return;
-
-    const runId = runIdMatch[1];
+    const runId = ($link.attr("href")?.match(/run=(\d+)/) ?? ["", ""])[1];
     const linkText = $link.text().trim();
     const runNumber = parseInt(linkText, 10);
-    if (isNaN(runNumber)) return;
+    if (!runId || isNaN(runNumber)) return;
 
     let text = "";
     const $parent = $link.closest("p, li, section, body");
@@ -96,12 +136,17 @@ export function parseRunBlocks(html: string): RunBlock[] {
         }
       }
     }
+    if (!text) text = $link.parent().text().trim();
 
-    if (!text) {
-      text = $link.parent().text().trim();
-    }
-
-    blocks.push({ runNumber, runId, text });
+    blocks.push({
+      runNumber,
+      runId,
+      titleText: "",
+      dateText: text,
+      locText: text,
+      hareText: text,
+      noteTexts: [],
+    });
   });
 
   return blocks;
@@ -110,12 +155,18 @@ export function parseRunBlocks(html: string): RunBlock[] {
 /**
  * Parse a date from a London Hash run block using chrono-node.
  * Handles: "Saturday 21st of February 2026", "21/02/2026", "Monday 22nd June", etc.
+ *
+ * Live runlist rows omit the year ("Saturday 6th of June" + "(12 days time)").
+ * Without `forwardDate`, chrono interprets ambiguous "6th of June" with refDate
+ * Jan 1, 2026 as 2025-06-06 (closest match) instead of the intended 2026-06-06.
+ * Pass `forwardDate: true` since runlist is an upcoming-only page — every
+ * date is at or after the reference.
  */
 export function parseDateFromBlock(text: string, referenceYear?: number): string | null {
   const refDate = referenceYear
     ? new Date(Date.UTC(referenceYear, 0, 1)) // Jan 1 of reference year
     : undefined;
-  return chronoParseDate(text, "en-GB", refDate);
+  return chronoParseDate(text, "en-GB", refDate, { forwardDate: true });
 }
 
 /**
@@ -183,6 +234,13 @@ export function parseLocationFromBlock(text: string): { location?: string; stati
     return { location: loc };
   }
 
+  // Fallback: "P trail from STATION" (no destination — common when pub TBA).
+  // Only fires when no destination phrase was matched above.
+  const stationOnlyMatch = text.match(/from\s+([^\n*]+?)\s+station\b/i);
+  if (stationOnlyMatch) {
+    return { station: stationOnlyMatch[1].trim() };
+  }
+
   return {};
 }
 
@@ -216,9 +274,30 @@ export function parseTimeFromBlock(text: string): string | null {
   return null;
 }
 
+/**
+ * Sanitize the `.titleRow` content into an event title.
+ *
+ * - Strips `**` markdown wrappers from themed runs (`"**Sweetheart's 4th of July Hash**"`).
+ * - Strips stray leading `**` on placeholder rows (real source quirk: `"**To Be Announced"`).
+ * - Returns the synthesized default `"London Hash Run #N"` for TBA / blank titles.
+ *
+ * Exported for unit testing.
+ */
+export function parseTitleFromBlock(titleText: string, runNumber: number): string {
+  // Strip ** markdown markers anywhere in the string (source uses them for
+  // typographic emphasis on themed runs — meaningful for the website but
+  // noise in a list of event titles). Collapse the resulting double spaces.
+  const cleaned = titleText.replaceAll("**", " ").replace(/\s{2,}/g, " ").trim();
+  if (!cleaned || TITLE_PLACEHOLDER_RE.test(cleaned)) {
+    return `London Hash Run #${runNumber}`;
+  }
+  return cleaned;
+}
+
 /** Data extracted from a London Hash detail page (nextrun.php?run=XXXX). */
 export interface LH3DetailPageData {
   runNumber?: number;
+  title?: string;
   latitude?: number;
   longitude?: number;
   location?: string;
@@ -241,20 +320,60 @@ function isDefaultLondonCoords(lat: number, lng: number): boolean {
   );
 }
 
+/** Build a label → value map from the structured `.nextRunlistRow` rows.
+ *
+ * The site renders each field as
+ *   `<div class="nextRunlistRow"><div class="runlistCat">Label</div><div class="runlistDetail">Value</div></div>`
+ * with sibling divs and no whitespace separators in the source HTML. Iterating
+ * by `.runlistDetail` (instead of running regex against `body.text()`) keeps
+ * each value isolated to its own div, preventing the "K4What Else" bleed
+ * documented in #1606.
+ *
+ * One row on the live site uses `class="runlistRow"` (typo missing the
+ * `next` prefix) — match both for resilience.
+ */
+function buildDetailLabelMap($: cheerio.CheerioAPI): Map<string, string> {
+  const map = new Map<string, string>();
+  $(".nextRunlistRow, #nextRunDetailsHolder .runlistRow").each((_i, el) => {
+    const $row = $(el);
+    $row.find("br").replaceWith("\n");
+    $row.find("span, a, strong, em, b, i").after(" ");
+    const label = $row.find(".runlistCat").first().text().trim();
+    const value = $row.find(".runlistDetail").first().text().trim().replace(/[ \t]{2,}/g, " ");
+    if (label && value) map.set(label, value);
+  });
+  return map;
+}
+
 /**
  * Parse a London Hash detail page (nextrun.php) into structured data.
  * Accepts a cheerio instance (from fetchHTMLPage) plus raw HTML for JS regex extraction.
  * Returns null for placeholder/TBA pages.
  */
-export function parseLH3DetailPage($: cheerio.CheerioAPI, html: string, detailUrl: string): LH3DetailPageData | null {
+export function parseLH3DetailPage(
+  $: cheerio.CheerioAPI,
+  html: string,
+  detailUrl: string,
+): LH3DetailPageData | null {
   const fullText = $("body").text();
 
-  // Detect placeholder pages: "to be Announced" in headings or "details to be announced" in body
+  // Detect placeholder pages: "next run to be announced" heading and no P-trail content
   if (/next run to be announced/i.test(fullText) && !/follow the p trail/i.test(fullText)) {
     return null;
   }
 
   const result: LH3DetailPageData = { sourceUrl: detailUrl };
+
+  // Title: `<h2 id="title">Location<br />Date</h2>` — take the first line.
+  const $title = $("#title").first();
+  if ($title.length) {
+    $title.find("br").replaceWith("\n");
+    const firstLine = $title.text().split("\n").map((s) => s.trim()).find((s) => s.length > 0);
+    if (firstLine && !TITLE_PLACEHOLDER_RE.test(firstLine)) {
+      const stripped = firstLine.replaceAll("**", " ").replace(/\s{2,}/g, " ").trim();
+      if (stripped) result.title = stripped;
+    }
+  }
 
   // Extract Google Maps link: href="http://maps.google.com/?q=LAT,LNG"
   const mapsLink = $('a[href*="maps.google.com/?q="]').attr("href");
@@ -284,36 +403,58 @@ export function parseLH3DetailPage($: cheerio.CheerioAPI, html: string, detailUr
     }
   }
 
+  // Structured field map keyed on .runlistCat labels.
+  const labels = buildDetailLabelMap($);
+
   // "What" → run number: "London hash number XXXX"
-  const runNumMatch = fullText.match(/(?:London\s+hash\s+number|hash\s+number)\s+(\d+)/i);
-  if (runNumMatch) {
-    result.runNumber = parseInt(runNumMatch[1], 10);
+  const whatValue = labels.get("What");
+  if (whatValue) {
+    const runNumMatch = whatValue.match(/(?:London\s+hash\s+number|hash\s+number)?\s*(\d+)/i);
+    if (runNumMatch) result.runNumber = parseInt(runNumMatch[1], 10);
+  }
+  // Fallback: scan full text if no structured What row was present.
+  if (result.runNumber == null) {
+    const runNumMatch = fullText.match(/(?:London\s+hash\s+number|hash\s+number)\s+(\d+)/i);
+    if (runNumMatch) result.runNumber = parseInt(runNumMatch[1], 10);
   }
 
-  // "Where" → reuse existing location parser
-  const { location, station } = parseLocationFromBlock(fullText);
-  if (location) result.location = location;
-  if (station) result.station = station;
-
-  // "Who" → reuse existing hare parser
-  const hares = parseHaresFromBlock(fullText);
-  if (hares) result.hares = hares;
-
-  // "How Far" → distance text
-  const distMatch = fullText.match(/(\d+\s*(?:meters?|metres?)\s+from\s+.+?)(?:\n|$)/i);
-  if (distMatch) {
-    result.distance = distMatch[1].trim();
+  // "Where" → location parser (isolated, no cross-section bleed).
+  const whereValue = labels.get("Where");
+  if (whereValue) {
+    const { location, station } = parseLocationFromBlock(whereValue);
+    if (location) result.location = location;
+    if (station) result.station = station;
+  } else {
+    const { location, station } = parseLocationFromBlock(fullText);
+    if (location) result.location = location;
+    if (station) result.station = station;
   }
 
-  // On-On / On Inn: body text or JS marker title
-  const onOnMatch = fullText.match(/On\s+Inn\s+to\s+(.+?)(?:\n|$)/i);
+  // "Who" → hare parser (isolated).
+  const whoValue = labels.get("Who");
+  if (whoValue) {
+    const hares = parseHaresFromBlock(whoValue);
+    if (hares) result.hares = hares;
+  } else {
+    const hares = parseHaresFromBlock(fullText);
+    if (hares) result.hares = hares;
+  }
+
+  // "How Far" → distance text.
+  const howFarValue = labels.get("How Far") ?? fullText;
+  const distMatch = howFarValue.match(/(\d+\s*(?:meters?|metres?)\s+from\s+.+?)(?:\n|$)/i);
+  if (distMatch) result.distance = distMatch[1].trim();
+
+  // On-On / On Inn: from a body line or the JS marker title.
+  // Stop at a quote too — cheerio's body.text() includes <script> content,
+  // so the `marker.title: "On Inn to Cork n Cask",` JS line otherwise
+  // captures the trailing `",` quote-comma into the value.
+  const onOnMatch = fullText.match(/On\s+Inn\s+to\s+([^\n"]+)/i);
   if (onOnMatch) {
-    result.onOn = onOnMatch[1].trim();
+    result.onOn = onOnMatch[1].trim().replace(/[,;]\s*$/, "");
   } else {
     const markerOnOn = html.match(/title:\s*"On\s+Inn\s+to\s+(.+?)"/i);
-    if (markerOnOn) {
-      result.onOn = markerOnOn[1].trim();
-    }
+    if (markerOnOn) result.onOn = markerOnOn[1].trim();
   }
 
   return result;
@@ -338,6 +479,11 @@ export function mergeLH3DetailIntoEvent(event: RawEventData, detail: LH3DetailPa
   }
   if (detail.hares) {
     merged.hares = detail.hares;
+  }
+  // Title from detail page wins over the run-list `.titleRow` only when the
+  // run-list synthesized the default (i.e. the .titleRow was TBA/blank).
+  if (detail.title && /^London Hash Run #\d+$/.test(event.title ?? "")) {
+    merged.title = detail.title;
   }
 
   // Enrich description with detail page info, preserving base station if detail lacks one
@@ -386,17 +532,18 @@ export class LondonHashAdapter implements SourceAdapter {
     for (let i = 0; i < blocks.length; i++) {
       const block = blocks[i];
       try {
-        const date = parseDateFromBlock(block.text, currentYear);
+        const date = parseDateFromBlock(block.dateText, currentYear);
         if (!date) {
           (errorDetails.parse ??= []).push(
-            { row: i, section: "runlist", field: "date", error: `No date in block for run #${block.runNumber}`, rawText: block.text.slice(0, 2000) },
+            { row: i, section: "runlist", field: "date", error: `No date in block for run #${block.runNumber}`, rawText: block.dateText.slice(0, 2000) },
           );
           continue;
         }
 
-        const hares = parseHaresFromBlock(block.text);
-        const { location, station } = parseLocationFromBlock(block.text);
-        const startTime = parseTimeFromBlock(block.text) ?? "12:00";
+        const hares = parseHaresFromBlock(block.hareText);
+        const { location, station } = parseLocationFromBlock(block.locText);
+        const startTime = parseTimeFromBlock(block.dateText) ?? "12:00";
+        const title = parseTitleFromBlock(block.titleText, block.runNumber);
 
         // Build description with station info
         const descParts: string[] = [];
@@ -409,7 +556,7 @@ export class LondonHashAdapter implements SourceAdapter {
           date,
           kennelTags: ["lh3"],
           runNumber: block.runNumber,
-          title: `London Hash Run #${block.runNumber}`,
+          title,
           hares: hares ?? undefined,
           location: location ?? undefined,
           startTime,
@@ -419,7 +566,7 @@ export class LondonHashAdapter implements SourceAdapter {
       } catch (err) {
         errors.push(`Error parsing run #${block.runNumber}: ${err}`);
         (errorDetails.parse ??= []).push(
-          { row: i, section: "runlist", error: String(err), rawText: block.text.slice(0, 2000) },
+          { row: i, section: "runlist", error: String(err), rawText: block.titleText.slice(0, 2000) },
         );
       }
     }

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -633,27 +633,34 @@ export function mergeLH3DetailIntoEvent(event: RawEventData, detail: LH3DetailPa
     merged.latitude = detail.latitude;
     merged.longitude = detail.longitude;
   }
-  if (detail.locationUrl) {
-    merged.locationUrl = detail.locationUrl;
-  }
-  if (detail.location) {
-    merged.location = detail.location;
-  }
-  if (detail.hares) {
-    merged.hares = detail.hares;
-  }
+  if (detail.locationUrl) merged.locationUrl = detail.locationUrl;
+  if (detail.location) merged.location = detail.location;
+  if (detail.hares) merged.hares = detail.hares;
   // Title from detail page wins over the run-list `.titleRow` only when the
   // run-list synthesized the default (i.e. the .titleRow was TBA/blank).
-  if (detail.title && /^London Hash Run #\d+$/.test(event.title ?? "")) {
+  if (detail.title && SYNTHESIZED_TITLE_RE.test(event.title ?? "")) {
     merged.title = detail.title;
   }
 
-  // Enrich description with detail page info. Preserve base station + any
-  // run-list `.runlistNote` paragraphs the base description carried — only
-  // the station prefix is structured ("Nearest station: X."), the rest is
-  // free-form note content that should survive a detail-page merge.
+  const description = buildMergedDescription(event.description ?? "", detail);
+  if (description) merged.description = description;
+
+  merged.sourceUrl = detail.sourceUrl;
+  return merged;
+}
+
+/** Synthesized default title format: `London Hash Run #NNN`. */
+const SYNTHESIZED_TITLE_RE = /^London Hash Run #\d+$/;
+
+/** Compose the merged event description from base + detail-page info.
+ *
+ * Structured parts (station / On-On / distance) come first in fixed order,
+ * then any detail-page note, then any free-form note segments the base
+ * description carried that aren't already represented (preserves
+ * `.runlistNote` content through detail-page enrichment).
+ */
+function buildMergedDescription(baseDesc: string, detail: LH3DetailPageData): string {
   const descParts: string[] = [];
-  const baseDesc = event.description ?? "";
   const baseStationMatch = BASE_STATION_RE.exec(baseDesc);
   const station = detail.station ?? baseStationMatch?.[1];
   if (station) descParts.push(`Nearest station: ${station}`);
@@ -662,23 +669,20 @@ export function mergeLH3DetailIntoEvent(event: RawEventData, detail: LH3DetailPa
   // Detail-page "What Else" content (travel info, theme, anniversary). Avoid
   // duplicating a station prefix that's already captured above.
   if (detail.notes && !BASE_STATION_RE.test(detail.notes)) descParts.push(detail.notes);
-  // Append any base-description notes that weren't the structured station
-  // line (split on ". " then drop the station prefix). Preserves runlist
-  // `.runlistNote` content through detail-page enrichment.
+  appendBaseNoteSegments(descParts, baseDesc);
+  return descParts.length > 0 ? descParts.join(". ") : "";
+}
+
+/** Append base-description segments (split on ". ") that aren't the
+ * structured station prefix and aren't already in `parts`. */
+function appendBaseNoteSegments(parts: string[], baseDesc: string): void {
   for (const segment of baseDesc.split(". ")) {
     const t = segment.trim().replace(/\.\s*$/, "");
     if (!t) continue;
     if (BASE_STATION_RE.test(t)) continue;
-    if (descParts.includes(t)) continue;
-    descParts.push(t);
+    if (parts.includes(t)) continue;
+    parts.push(t);
   }
-  if (descParts.length > 0) {
-    merged.description = descParts.join(". ");
-  }
-
-  merged.sourceUrl = detail.sourceUrl;
-
-  return merged;
 }
 
 /**
@@ -752,7 +756,8 @@ function parseRunListEvents(
       if (event) {
         events.push(event);
       } else {
-        (errorDetails.parse ??= []).push({
+        const parseErrors = (errorDetails.parse ??= []);
+        parseErrors.push({
           row: i,
           section: "runlist",
           field: "date",
@@ -762,7 +767,8 @@ function parseRunListEvents(
       }
     } catch (err) {
       errors.push(`Error parsing run #${block.runNumber}: ${err}`);
-      (errorDetails.parse ??= []).push({
+      const parseErrors = (errorDetails.parse ??= []);
+      parseErrors.push({
         row: i,
         section: "runlist",
         error: String(err),

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -24,6 +24,27 @@ const COORD_THRESHOLD = 0.01; // ~1km
 /** TBA / placeholder titles that should fall back to the synthesized default. */
 const TITLE_PLACEHOLDER_RE = /^(?:to be announced|tba|tbc|tbd|details to be announced)$/i;
 
+/** `nextrun.php?run=NNN` → captures NNN. */
+const RUN_ID_RE = /run=(\d+)/;
+
+/** Google Maps `?q=LAT,LNG` href coords. */
+const MAPS_QUERY_COORDS_RE = /\?q=(-?[\d.]+),(-?[\d.]+)/;
+
+/** Inline JS coord object: `{ lat: 51.5, lng: -0.1 }`. */
+const JS_COORDS_RE = /\{\s*lat:\s*(-?[\d.]+),\s*lng:\s*(-?[\d.]+)\s*\}/g;
+
+/** "London hash number NNN" run-number extractor. */
+const RUN_NUM_RE = /(?:London\s+hash\s+number|hash\s+number)?\s*(\d+)/i;
+const RUN_NUM_FALLBACK_RE = /(?:London\s+hash\s+number|hash\s+number)\s+(\d+)/i;
+
+/** "85 metres from <station>" distance line. */
+const DISTANCE_RE = /(\d+\s*(?:meters?|metres?)\s+from\s+.+?)(?:\n|$)/i;
+
+/** On-Inn body line (stops at quote so JS marker title doesn't leak). */
+const ON_INN_RE = /On\s+Inn\s+to\s+([^\n"]+)/i;
+const ON_INN_MARKER_RE = /title:\s*"On\s+Inn\s+to\s+(.+?)"/i;
+const ON_INN_TRAILING_RE = /[,;]\s*$/;
+
 /**
  * Represents a parsed run block from the London Hash run list page.
  *
@@ -81,9 +102,9 @@ export function parseRunBlocks(html: string): RunBlock[] {
       const $link = $block.find('a[href*="nextrun.php"]').first();
       if (!$link.length) return;
 
-      const runId = ($link.attr("href")?.match(/run=(\d+)/) ?? ["", ""])[1];
-      const runNumber = parseInt($link.text().trim(), 10);
-      if (!runId || isNaN(runNumber)) return;
+      const runId = (RUN_ID_RE.exec($link.attr("href") ?? "") ?? ["", ""])[1];
+      const runNumber = Number.parseInt($link.text().trim(), 10);
+      if (!runId || Number.isNaN(runNumber)) return;
 
       padBlock($block);
 
@@ -113,10 +134,10 @@ export function parseRunBlocks(html: string): RunBlock[] {
   const runLinks = $('a[href*="nextrun.php"]');
   runLinks.each((i, el) => {
     const $link = $(el);
-    const runId = ($link.attr("href")?.match(/run=(\d+)/) ?? ["", ""])[1];
+    const runId = (RUN_ID_RE.exec($link.attr("href") ?? "") ?? ["", ""])[1];
     const linkText = $link.text().trim();
-    const runNumber = parseInt(linkText, 10);
-    if (!runId || isNaN(runNumber)) return;
+    const runNumber = Number.parseInt(linkText, 10);
+    if (!runId || Number.isNaN(runNumber)) return;
 
     let text = "";
     const $parent = $link.closest("p, li, section, body");
@@ -375,89 +396,84 @@ export function parseLH3DetailPage(
     }
   }
 
-  // Extract Google Maps link: href="http://maps.google.com/?q=LAT,LNG"
+  applyDetailCoords(result, $, html);
+
+  const labels = buildDetailLabelMap($);
+  applyDetailRunNumber(result, labels, fullText);
+  applyDetailLocation(result, labels, fullText);
+  applyDetailHares(result, labels, fullText);
+  applyDetailDistance(result, labels, fullText);
+  applyDetailOnOn(result, fullText, html);
+
+  return result;
+}
+
+/** Try Google Maps href first; fall back to inline JS `{lat,lng}`. */
+function applyDetailCoords(result: LH3DetailPageData, $: cheerio.CheerioAPI, html: string): void {
   const mapsLink = $('a[href*="maps.google.com/?q="]').attr("href");
   if (mapsLink) {
-    const qMatch = mapsLink.match(/\?q=(-?[\d.]+),(-?[\d.]+)/);
+    const qMatch = MAPS_QUERY_COORDS_RE.exec(mapsLink);
     if (qMatch) {
-      const lat = parseFloat(qMatch[1]);
-      const lng = parseFloat(qMatch[2]);
-      if (!isNaN(lat) && !isNaN(lng) && !isDefaultLondonCoords(lat, lng)) {
+      const lat = Number.parseFloat(qMatch[1]);
+      const lng = Number.parseFloat(qMatch[2]);
+      if (Number.isFinite(lat) && Number.isFinite(lng) && !isDefaultLondonCoords(lat, lng)) {
         result.locationUrl = mapsLink;
         result.latitude = lat;
         result.longitude = lng;
+        return;
       }
     }
   }
-
-  // Also try JS coords: { lat: X, lng: Y } (center or marker positions)
-  if (result.latitude == null) {
-    for (const m of html.matchAll(/\{\s*lat:\s*(-?[\d.]+),\s*lng:\s*(-?[\d.]+)\s*\}/g)) {
-      const lat = parseFloat(m[1]);
-      const lng = parseFloat(m[2]);
-      if (!isNaN(lat) && !isNaN(lng) && !isDefaultLondonCoords(lat, lng)) {
-        result.latitude = lat;
-        result.longitude = lng;
-        break;
-      }
+  // No usable Maps link — scan JS for the first non-placeholder coord pair.
+  for (const m of html.matchAll(JS_COORDS_RE)) {
+    const lat = Number.parseFloat(m[1]);
+    const lng = Number.parseFloat(m[2]);
+    if (Number.isFinite(lat) && Number.isFinite(lng) && !isDefaultLondonCoords(lat, lng)) {
+      result.latitude = lat;
+      result.longitude = lng;
+      return;
     }
   }
+}
 
-  // Structured field map keyed on .runlistCat labels.
-  const labels = buildDetailLabelMap($);
-
-  // "What" → run number: "London hash number XXXX"
+function applyDetailRunNumber(result: LH3DetailPageData, labels: Map<string, string>, fullText: string): void {
   const whatValue = labels.get("What");
-  if (whatValue) {
-    const runNumMatch = whatValue.match(/(?:London\s+hash\s+number|hash\s+number)?\s*(\d+)/i);
-    if (runNumMatch) result.runNumber = parseInt(runNumMatch[1], 10);
+  const fromLabel = whatValue ? RUN_NUM_RE.exec(whatValue) : null;
+  if (fromLabel) {
+    result.runNumber = Number.parseInt(fromLabel[1], 10);
+    return;
   }
-  // Fallback: scan full text if no structured What row was present.
-  if (result.runNumber == null) {
-    const runNumMatch = fullText.match(/(?:London\s+hash\s+number|hash\s+number)\s+(\d+)/i);
-    if (runNumMatch) result.runNumber = parseInt(runNumMatch[1], 10);
-  }
+  const fromBody = RUN_NUM_FALLBACK_RE.exec(fullText);
+  if (fromBody) result.runNumber = Number.parseInt(fromBody[1], 10);
+}
 
-  // "Where" → location parser (isolated, no cross-section bleed).
-  const whereValue = labels.get("Where");
-  if (whereValue) {
-    const { location, station } = parseLocationFromBlock(whereValue);
-    if (location) result.location = location;
-    if (station) result.station = station;
-  } else {
-    const { location, station } = parseLocationFromBlock(fullText);
-    if (location) result.location = location;
-    if (station) result.station = station;
-  }
+function applyDetailLocation(result: LH3DetailPageData, labels: Map<string, string>, fullText: string): void {
+  const whereValue = labels.get("Where") ?? fullText;
+  const { location, station } = parseLocationFromBlock(whereValue);
+  if (location) result.location = location;
+  if (station) result.station = station;
+}
 
-  // "Who" → hare parser (isolated).
-  const whoValue = labels.get("Who");
-  if (whoValue) {
-    const hares = parseHaresFromBlock(whoValue);
-    if (hares) result.hares = hares;
-  } else {
-    const hares = parseHaresFromBlock(fullText);
-    if (hares) result.hares = hares;
-  }
+function applyDetailHares(result: LH3DetailPageData, labels: Map<string, string>, fullText: string): void {
+  const whoValue = labels.get("Who") ?? fullText;
+  const hares = parseHaresFromBlock(whoValue);
+  if (hares) result.hares = hares;
+}
 
-  // "How Far" → distance text.
+function applyDetailDistance(result: LH3DetailPageData, labels: Map<string, string>, fullText: string): void {
   const howFarValue = labels.get("How Far") ?? fullText;
-  const distMatch = howFarValue.match(/(\d+\s*(?:meters?|metres?)\s+from\s+.+?)(?:\n|$)/i);
+  const distMatch = DISTANCE_RE.exec(howFarValue);
   if (distMatch) result.distance = distMatch[1].trim();
+}
 
-  // On-On / On Inn: from a body line or the JS marker title.
-  // Stop at a quote too — cheerio's body.text() includes <script> content,
-  // so the `marker.title: "On Inn to Cork n Cask",` JS line otherwise
-  // captures the trailing `",` quote-comma into the value.
-  const onOnMatch = fullText.match(/On\s+Inn\s+to\s+([^\n"]+)/i);
+function applyDetailOnOn(result: LH3DetailPageData, fullText: string, html: string): void {
+  const onOnMatch = ON_INN_RE.exec(fullText);
   if (onOnMatch) {
-    result.onOn = onOnMatch[1].trim().replace(/[,;]\s*$/, "");
-  } else {
-    const markerOnOn = html.match(/title:\s*"On\s+Inn\s+to\s+(.+?)"/i);
-    if (markerOnOn) result.onOn = markerOnOn[1].trim();
+    result.onOn = onOnMatch[1].trim().replace(ON_INN_TRAILING_RE, "");
+    return;
   }
-
-  return result;
+  const markerOnOn = ON_INN_MARKER_RE.exec(html);
+  if (markerOnOn) result.onOn = markerOnOn[1].trim();
 }
 
 /**
@@ -521,104 +537,25 @@ export class LondonHashAdapter implements SourceAdapter {
     if (!page.ok) return page.result;
     const { html, structureHash, fetchDurationMs } = page;
 
-    const events: RawEventData[] = [];
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
-    const currentYear = new Date().getFullYear();
     const blocks = parseRunBlocks(html);
     const baseUrlObj = new URL(baseUrl);
     const detailBase = `${baseUrlObj.protocol}//${baseUrlObj.host}`;
 
-    for (let i = 0; i < blocks.length; i++) {
-      const block = blocks[i];
-      try {
-        const date = parseDateFromBlock(block.dateText, currentYear);
-        if (!date) {
-          (errorDetails.parse ??= []).push(
-            { row: i, section: "runlist", field: "date", error: `No date in block for run #${block.runNumber}`, rawText: block.dateText.slice(0, 2000) },
-          );
-          continue;
-        }
-
-        const hares = parseHaresFromBlock(block.hareText);
-        const { location, station } = parseLocationFromBlock(block.locText);
-        const startTime = parseTimeFromBlock(block.dateText) ?? "12:00";
-        const title = parseTitleFromBlock(block.titleText, block.runNumber);
-
-        // Build description with station info
-        const descParts: string[] = [];
-        if (station) descParts.push(`Nearest station: ${station}`);
-        const description = descParts.length > 0 ? descParts.join(". ") : undefined;
-
-        const sourceUrl = `${detailBase}/nextrun.php?run=${block.runId}`;
-
-        events.push({
-          date,
-          kennelTags: ["lh3"],
-          runNumber: block.runNumber,
-          title,
-          hares: hares ?? undefined,
-          location: location ?? undefined,
-          startTime,
-          sourceUrl,
-          description,
-        });
-      } catch (err) {
-        errors.push(`Error parsing run #${block.runNumber}: ${err}`);
-        (errorDetails.parse ??= []).push(
-          { row: i, section: "runlist", error: String(err), rawText: block.titleText.slice(0, 2000) },
-        );
-      }
-    }
-
-    // Phase 2: Fetch detail pages for first N events
-    let detailPagesFetched = 0;
-    let detailPagesEnriched = 0;
-    const detailBlocks = blocks.slice(0, MAX_DETAIL_FETCHES);
-
-    if (detailBlocks.length > 0) {
-      const detailResults = await Promise.allSettled(
-        detailBlocks.map(async (block) => {
-          const detailUrl = `${detailBase}/nextrun.php?run=${block.runId}`;
-          const resp = await fetchHTMLPage(detailUrl);
-          return { block, resp, detailUrl };
-        }),
-      );
-
-      for (const settled of detailResults) {
-        if (settled.status !== "fulfilled") continue;
-        const { block, resp, detailUrl } = settled.value;
-        detailPagesFetched++;
-
-        if (!resp.ok) {
-          errors.push(`Detail page fetch failed for run #${block.runNumber}`);
-          continue;
-        }
-
-        const detail = parseLH3DetailPage(resp.$, resp.html, detailUrl);
-        if (!detail) continue;
-
-        // Verify run number matches before merging
-        if (detail.runNumber != null && detail.runNumber !== block.runNumber) {
-          errors.push(`Detail page run number mismatch for run #${block.runNumber}: got ${detail.runNumber}`);
-          continue;
-        }
-
-        const matchIdx = events.findIndex((e) => e.runNumber === block.runNumber);
-        if (matchIdx >= 0) {
-          events[matchIdx] = mergeLH3DetailIntoEvent(events[matchIdx], detail);
-          detailPagesEnriched++;
-        }
-      }
-    }
-
-    const hasErrorDetails = hasAnyErrors(errorDetails);
+    const events = parseRunListEvents(blocks, detailBase, errorDetails, errors);
+    const { detailPagesFetched, detailPagesEnriched } = await enrichWithDetailPages(
+      blocks,
+      events,
+      detailBase,
+      errors,
+    );
 
     return {
       events,
       errors,
       structureHash,
-      errorDetails: hasErrorDetails ? errorDetails : undefined,
+      errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
       diagnosticContext: {
         blocksFound: blocks.length,
         eventsParsed: events.length,
@@ -628,4 +565,126 @@ export class LondonHashAdapter implements SourceAdapter {
       },
     };
   }
+}
+
+/** Phase 1: walk parsed `RunBlock[]` and synthesize `RawEventData[]`. Push
+ * parse failures into `errorDetails.parse` / `errors`. */
+function parseRunListEvents(
+  blocks: RunBlock[],
+  detailBase: string,
+  errorDetails: ErrorDetails,
+  errors: string[],
+): RawEventData[] {
+  const events: RawEventData[] = [];
+  const currentYear = new Date().getFullYear();
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    try {
+      const event = buildEventFromBlock(block, currentYear, detailBase);
+      if (event) {
+        events.push(event);
+      } else {
+        (errorDetails.parse ??= []).push({
+          row: i,
+          section: "runlist",
+          field: "date",
+          error: `No date in block for run #${block.runNumber}`,
+          rawText: block.dateText.slice(0, 2000),
+        });
+      }
+    } catch (err) {
+      errors.push(`Error parsing run #${block.runNumber}: ${err}`);
+      (errorDetails.parse ??= []).push({
+        row: i,
+        section: "runlist",
+        error: String(err),
+        rawText: block.titleText.slice(0, 2000),
+      });
+    }
+  }
+  return events;
+}
+
+/** Build a single RawEventData from a RunBlock, or null if the date can't
+ * be parsed. Other field misses are non-fatal (left undefined). */
+function buildEventFromBlock(
+  block: RunBlock,
+  currentYear: number,
+  detailBase: string,
+): RawEventData | null {
+  const date = parseDateFromBlock(block.dateText, currentYear);
+  if (!date) return null;
+  const hares = parseHaresFromBlock(block.hareText);
+  const { location, station } = parseLocationFromBlock(block.locText);
+  const startTime = parseTimeFromBlock(block.dateText) ?? "12:00";
+  const title = parseTitleFromBlock(block.titleText, block.runNumber);
+  const description = station ? `Nearest station: ${station}` : undefined;
+  return {
+    date,
+    kennelTags: ["lh3"],
+    runNumber: block.runNumber,
+    title,
+    hares: hares ?? undefined,
+    location: location ?? undefined,
+    startTime,
+    sourceUrl: `${detailBase}/nextrun.php?run=${block.runId}`,
+    description,
+  };
+}
+
+/** Phase 2: fetch detail pages for the first `MAX_DETAIL_FETCHES` blocks
+ * and merge into the matching events. Returns diagnostic counters. */
+async function enrichWithDetailPages(
+  blocks: RunBlock[],
+  events: RawEventData[],
+  detailBase: string,
+  errors: string[],
+): Promise<{ detailPagesFetched: number; detailPagesEnriched: number }> {
+  const detailBlocks = blocks.slice(0, MAX_DETAIL_FETCHES);
+  if (detailBlocks.length === 0) {
+    return { detailPagesFetched: 0, detailPagesEnriched: 0 };
+  }
+  const detailResults = await Promise.allSettled(
+    detailBlocks.map(async (block) => {
+      const detailUrl = `${detailBase}/nextrun.php?run=${block.runId}`;
+      const resp = await fetchHTMLPage(detailUrl);
+      return { block, resp, detailUrl };
+    }),
+  );
+  let detailPagesFetched = 0;
+  let detailPagesEnriched = 0;
+  for (const settled of detailResults) {
+    if (settled.status !== "fulfilled") continue;
+    detailPagesFetched++;
+    if (applyDetailToEvents(settled.value, events, errors)) {
+      detailPagesEnriched++;
+    }
+  }
+  return { detailPagesFetched, detailPagesEnriched };
+}
+
+/** Merge one detail-page result into the matching event in-place. Returns
+ * true if a merge occurred. Records soft errors via `errors`. */
+function applyDetailToEvents(
+  result: { block: RunBlock; resp: Awaited<ReturnType<typeof fetchHTMLPage>>; detailUrl: string },
+  events: RawEventData[],
+  errors: string[],
+): boolean {
+  const { block, resp, detailUrl } = result;
+  if (!resp.ok) {
+    errors.push(`Detail page fetch failed for run #${block.runNumber}`);
+    return false;
+  }
+  const detail = parseLH3DetailPage(resp.$, resp.html, detailUrl);
+  if (!detail) return false;
+  if (detail.runNumber != null && detail.runNumber !== block.runNumber) {
+    errors.push(
+      `Detail page run number mismatch for run #${block.runNumber}: got ${detail.runNumber}`,
+    );
+    return false;
+  }
+  const matchIdx = events.findIndex((e) => e.runNumber === block.runNumber);
+  if (matchIdx < 0) return false;
+  events[matchIdx] = mergeLH3DetailIntoEvent(events[matchIdx], detail);
+  return true;
 }

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -33,17 +33,32 @@ const MAPS_QUERY_COORDS_RE = /\?q=(-?[\d.]+),(-?[\d.]+)/;
 /** Inline JS coord object: `{ lat: 51.5, lng: -0.1 }`. */
 const JS_COORDS_RE = /\{\s*lat:\s*(-?[\d.]+),\s*lng:\s*(-?[\d.]+)\s*\}/g;
 
-/** "London hash number NNN" run-number extractor. */
-const RUN_NUM_RE = /(?:London\s+hash\s+number|hash\s+number)?\s*(\d+)/i;
-const RUN_NUM_FALLBACK_RE = /(?:London\s+hash\s+number|hash\s+number)\s+(\d+)/i;
+/** "London hash number NNN" run-number extractor. Required prefix in
+ * structured-label values; the bare-number fallback is a separate regex
+ * applied only when the prefix variant misses. Each pattern has fixed
+ * structure so backtracking is linear (avoids Sonar S5852). */
+const RUN_NUM_LABELED_RE = /(?:London\s+hash\s+number|hash\s+number)\s+(\d+)/i;
+const RUN_NUM_BARE_RE = /\b(\d+)\b/;
 
-/** "85 metres from <station>" distance line. */
-const DISTANCE_RE = /(\d+\s*(?:meters?|metres?)\s+from\s+.+?)(?:\n|$)/i;
+/** "85 metres from <station>" distance line. `[^\n]+` is greedy with a
+ * single-char negated class — no nested quantifier backtracking. */
+const DISTANCE_RE = /(\d+\s*(?:meters?|metres?)\s+from\s+[^\n]+)/i;
 
-/** On-Inn body line (stops at quote so JS marker title doesn't leak). */
+/** On-Inn body line. `[^\n"]+` stops at newline or JS-quote so the
+ * cheerio body.text() pickup of `marker.title: "..."` doesn't leak. */
 const ON_INN_RE = /On\s+Inn\s+to\s+([^\n"]+)/i;
-const ON_INN_MARKER_RE = /title:\s*"On\s+Inn\s+to\s+(.+?)"/i;
+/** JS marker title: `title: "On Inn to <pub>"` — `[^"]+` stops at the
+ * closing quote, no non-greedy backtracking. */
+const ON_INN_MARKER_RE = /title:\s*"On\s+Inn\s+to\s+([^"]+)"/i;
 const ON_INN_TRAILING_RE = /[,;]\s*$/;
+
+/** Match a leading `from <prefix>` block; the station-only fallback then
+ * uses procedural slicing (avoids Sonar S5852 on `[^\n*]+?\s+station\b`). */
+const STATION_FROM_PREFIX_RE = /\bfrom\s+/i;
+
+/** "Nearest station: X" prefix in run-list / merged descriptions.
+ * `[^.]+` is a single-char negated class (linear, no Sonar S5852 risk). */
+const BASE_STATION_RE = /Nearest station: ([^.]+)/;
 
 /**
  * Represents a parsed run block from the London Hash run list page.
@@ -81,6 +96,26 @@ function readField(
   return $(node).text().trim().replace(/[ \t]{2,}/g, " ");
 }
 
+/** Source ships per-event note containers with skeleton template markers
+ * (`*Travel info -`, `*Other info -`, `Travel details are yet to be announced`)
+ * that hares fill in over time. Drop notes that are *only* the template
+ * with no real content — they're noise in the description.
+ *
+ * Returns the cleaned note, or empty string when the note carries no
+ * value-add content. Exported for unit testing. */
+export function stripNoteSkeleton(raw: string): string {
+  // Drop the bare "Travel details are yet to be announced" placeholder.
+  if (/^Travel details are yet to be announced\.?$/i.test(raw.trim())) return "";
+  // Strip the `*Travel info -` / `*Other info -` markers individually and
+  // see if any prose remains.
+  const stripped = raw
+    .replace(/\*\s*Travel info\s*-/gi, "")
+    .replace(/\*\s*Other info\s*-/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return stripped;
+}
+
 /**
  * Split the London Hash run list page into individual run blocks.
  * Each block is anchored by a <a href="nextrun.php?run=XXXX"> link.
@@ -111,8 +146,9 @@ export function parseRunBlocks(html: string): RunBlock[] {
       const noteNodes = $block.find(".runlistNote");
       const noteTexts: string[] = [];
       noteNodes.each((_j, noteEl) => {
-        const t = $(noteEl).text().trim().replace(/[ \t]{2,}/g, " ");
-        if (t) noteTexts.push(t);
+        const raw = $(noteEl).text().trim().replace(/[ \t]{2,}/g, " ");
+        const cleaned = stripNoteSkeleton(raw);
+        if (cleaned) noteTexts.push(cleaned);
       });
 
       blocks.push({
@@ -178,16 +214,21 @@ export function parseRunBlocks(html: string): RunBlock[] {
  * Handles: "Saturday 21st of February 2026", "21/02/2026", "Monday 22nd June", etc.
  *
  * Live runlist rows omit the year ("Saturday 6th of June" + "(12 days time)").
- * Without `forwardDate`, chrono interprets ambiguous "6th of June" with refDate
- * Jan 1, 2026 as 2025-06-06 (closest match) instead of the intended 2026-06-06.
+ * Without `forwardDate`, chrono interprets ambiguous "6th of June" with the
+ * default refDate as the past June 6 instead of the intended next June 6.
  * Pass `forwardDate: true` since runlist is an upcoming-only page — every
  * date is at or after the reference.
+ *
+ * `referenceDate` is the scrape-time anchor for ambiguous year-less dates.
+ * Production callers pass `new Date()` (the real scrape instant) so a late-
+ * December scrape resolves "Saturday 10th of January" to the *next* January,
+ * not the past one. Passing `Date.UTC(year, 0, 1)` here used to cause that
+ * year-end transition bug (cf. PR #1682 review feedback + memory
+ * `feedback_chrono_forward_date_explicit_year.md`). Tests can pass a fixed
+ * Date for determinism.
  */
-export function parseDateFromBlock(text: string, referenceYear?: number): string | null {
-  const refDate = referenceYear
-    ? new Date(Date.UTC(referenceYear, 0, 1)) // Jan 1 of reference year
-    : undefined;
-  return chronoParseDate(text, "en-GB", refDate, { forwardDate: true });
+export function parseDateFromBlock(text: string, referenceDate?: Date): string | null {
+  return chronoParseDate(text, "en-GB", referenceDate, { forwardDate: true });
 }
 
 /**
@@ -256,13 +297,29 @@ export function parseLocationFromBlock(text: string): { location?: string; stati
   }
 
   // Fallback: "P trail from STATION" (no destination — common when pub TBA).
-  // Only fires when no destination phrase was matched above.
-  const stationOnlyMatch = text.match(/from\s+([^\n*]+?)\s+station\b/i);
-  if (stationOnlyMatch) {
-    return { station: stationOnlyMatch[1].trim() };
-  }
+  // Procedural slice instead of `from\s+([^\n*]+?)\s+station\b` to avoid
+  // Sonar S5852 (the non-greedy + adjacent quantifier shape gets flagged
+  // even when linear in practice; per feedback_sonar_s5852_procedural_over_regex.md).
+  const station = extractStationOnly(text);
+  if (station) return { station };
 
   return {};
+}
+
+/** "Follow the P trail from <station> station" — return `<station>` or
+ * undefined if the shape isn't there. Exported for unit testing. */
+export function extractStationOnly(text: string): string | undefined {
+  const fromMatch = STATION_FROM_PREFIX_RE.exec(text);
+  if (!fromMatch) return undefined;
+  const valueStart = fromMatch.index + fromMatch[0].length;
+  // Look for the closing " station" boundary. Case-insensitive needle.
+  const lower = text.toLowerCase();
+  const stationIdx = lower.indexOf(" station", valueStart);
+  if (stationIdx < 0) return undefined;
+  const candidate = text.slice(valueStart, stationIdx).trim();
+  // Reject empty or pollution from upstream layout (newline / `*` markers).
+  if (!candidate || candidate.includes("\n") || candidate.includes("*")) return undefined;
+  return candidate;
 }
 
 /**
@@ -326,6 +383,10 @@ export interface LH3DetailPageData {
   hares?: string;
   distance?: string;
   onOn?: string;
+  /** Free-form text from the "What Else" label row (travel info, theme,
+   * anniversary marker, etc). Merged into the event description so the
+   * structured-but-misc content the source ships actually surfaces. */
+  notes?: string;
   locationUrl?: string;
   sourceUrl: string;
 }
@@ -376,6 +437,13 @@ export function parseLH3DetailPage(
   html: string,
   detailUrl: string,
 ): LH3DetailPageData | null {
+  // Strip `<script>` / `<style>` content from the cheerio tree before
+  // pulling `body.text()` — cheerio includes those tag bodies in `.text()`
+  // by default. The On-On regex already uses `[^\n"]+` to stop at JS
+  // string boundaries, but removing the script/style content entirely is
+  // cleaner and prevents future regex leaks (Gemini review on #1682).
+  $("script, style").remove();
+
   const fullText = $("body").text();
 
   // Detect placeholder pages: "next run to be announced" heading and no P-trail content
@@ -404,8 +472,21 @@ export function parseLH3DetailPage(
   applyDetailHares(result, labels, fullText);
   applyDetailDistance(result, labels, fullText);
   applyDetailOnOn(result, fullText, html);
+  applyDetailNotes(result, labels);
 
   return result;
+}
+
+/** Surface the "What Else" label content (travel info / theme / anniversary
+ * marker) so it doesn't get silently dropped — addresses the discarded-
+ * `noteTexts` finding from CodeRabbit review on PR #1682. Run through
+ * `stripNoteSkeleton` so the source's empty `*Travel info -` / `*Other
+ * info -` template skeletons don't pollute the description. */
+function applyDetailNotes(result: LH3DetailPageData, labels: Map<string, string>): void {
+  const value = labels.get("What Else");
+  if (!value) return;
+  const cleaned = stripNoteSkeleton(value);
+  if (cleaned) result.notes = cleaned;
 }
 
 /** Try Google Maps href first; fall back to inline JS `{lat,lng}`. */
@@ -437,13 +518,22 @@ function applyDetailCoords(result: LH3DetailPageData, $: cheerio.CheerioAPI, htm
 }
 
 function applyDetailRunNumber(result: LH3DetailPageData, labels: Map<string, string>, fullText: string): void {
+  // Prefer the labeled-prefix variant first; fall back to bare-number inside
+  // structured `What` value, then to labeled-prefix anywhere in the body.
   const whatValue = labels.get("What");
-  const fromLabel = whatValue ? RUN_NUM_RE.exec(whatValue) : null;
-  if (fromLabel) {
-    result.runNumber = Number.parseInt(fromLabel[1], 10);
-    return;
+  if (whatValue) {
+    const labeled = RUN_NUM_LABELED_RE.exec(whatValue);
+    if (labeled) {
+      result.runNumber = Number.parseInt(labeled[1], 10);
+      return;
+    }
+    const bare = RUN_NUM_BARE_RE.exec(whatValue);
+    if (bare) {
+      result.runNumber = Number.parseInt(bare[1], 10);
+      return;
+    }
   }
-  const fromBody = RUN_NUM_FALLBACK_RE.exec(fullText);
+  const fromBody = RUN_NUM_LABELED_RE.exec(fullText);
   if (fromBody) result.runNumber = Number.parseInt(fromBody[1], 10);
 }
 
@@ -461,6 +551,8 @@ function applyDetailHares(result: LH3DetailPageData, labels: Map<string, string>
 }
 
 function applyDetailDistance(result: LH3DetailPageData, labels: Map<string, string>, fullText: string): void {
+  // Prefer the structured "How Far" label so the greedy `[^\n]+` in
+  // DISTANCE_RE doesn't trip past the field boundary in the fullText fallback.
   const howFarValue = labels.get("How Far") ?? fullText;
   const distMatch = DISTANCE_RE.exec(howFarValue);
   if (distMatch) result.distance = distMatch[1].trim();
@@ -502,12 +594,30 @@ export function mergeLH3DetailIntoEvent(event: RawEventData, detail: LH3DetailPa
     merged.title = detail.title;
   }
 
-  // Enrich description with detail page info, preserving base station if detail lacks one
+  // Enrich description with detail page info. Preserve base station + any
+  // run-list `.runlistNote` paragraphs the base description carried — only
+  // the station prefix is structured ("Nearest station: X."), the rest is
+  // free-form note content that should survive a detail-page merge.
   const descParts: string[] = [];
-  const station = detail.station ?? event.description?.match(/Nearest station: (.+?)(?:\.|$)/)?.[1];
+  const baseDesc = event.description ?? "";
+  const baseStationMatch = BASE_STATION_RE.exec(baseDesc);
+  const station = detail.station ?? baseStationMatch?.[1];
   if (station) descParts.push(`Nearest station: ${station}`);
   if (detail.onOn) descParts.push(`On-On: ${detail.onOn}`);
   if (detail.distance) descParts.push(`Distance: ${detail.distance}`);
+  // Detail-page "What Else" content (travel info, theme, anniversary). Avoid
+  // duplicating a station prefix that's already captured above.
+  if (detail.notes && !BASE_STATION_RE.test(detail.notes)) descParts.push(detail.notes);
+  // Append any base-description notes that weren't the structured station
+  // line (split on ". " then drop the station prefix). Preserves runlist
+  // `.runlistNote` content through detail-page enrichment.
+  for (const segment of baseDesc.split(". ")) {
+    const t = segment.trim().replace(/\.\s*$/, "");
+    if (!t) continue;
+    if (BASE_STATION_RE.test(t)) continue;
+    if (descParts.includes(t)) continue;
+    descParts.push(t);
+  }
   if (descParts.length > 0) {
     merged.description = descParts.join(". ");
   }
@@ -576,11 +686,15 @@ function parseRunListEvents(
   errors: string[],
 ): RawEventData[] {
   const events: RawEventData[] = [];
-  const currentYear = new Date().getFullYear();
+  // Scrape-time anchor for year-less date strings ("Saturday 6th of June").
+  // Using the actual `new Date()` (not Jan 1 of the calendar year) lets a
+  // late-December scrape correctly resolve "10th of January" to the next
+  // January, not the prior one. See parseDateFromBlock for the full note.
+  const referenceDate = new Date();
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i];
     try {
-      const event = buildEventFromBlock(block, currentYear, detailBase);
+      const event = buildEventFromBlock(block, referenceDate, detailBase);
       if (event) {
         events.push(event);
       } else {
@@ -609,16 +723,25 @@ function parseRunListEvents(
  * be parsed. Other field misses are non-fatal (left undefined). */
 function buildEventFromBlock(
   block: RunBlock,
-  currentYear: number,
+  referenceDate: Date,
   detailBase: string,
 ): RawEventData | null {
-  const date = parseDateFromBlock(block.dateText, currentYear);
+  const date = parseDateFromBlock(block.dateText, referenceDate);
   if (!date) return null;
   const hares = parseHaresFromBlock(block.hareText);
   const { location, station } = parseLocationFromBlock(block.locText);
   const startTime = parseTimeFromBlock(block.dateText) ?? "12:00";
   const title = parseTitleFromBlock(block.titleText, block.runNumber);
-  const description = station ? `Nearest station: ${station}` : undefined;
+  // Build description: station first, then any `.runlistNote` content the
+  // runlist row carried (travel info, anniversary themes, joint-trail
+  // announcements). Previously parsed into `block.noteTexts` and discarded
+  // (per CodeRabbit review on #1682 — "structured notes parsed and then
+  // discarded"). Joining with `. ` matches the existing detail-page
+  // description shape ("Nearest station: X. On-On: Y. Distance: Z").
+  const descParts: string[] = [];
+  if (station) descParts.push(`Nearest station: ${station}`);
+  for (const note of block.noteTexts) descParts.push(note);
+  const description = descParts.length > 0 ? descParts.join(". ") : undefined;
   return {
     date,
     kennelTags: ["lh3"],

--- a/src/adapters/html-scraper/london-hash.ts
+++ b/src/adapters/html-scraper/london-hash.ts
@@ -40,17 +40,17 @@ const JS_COORDS_RE = /\{\s*lat:\s*(-?[\d.]+),\s*lng:\s*(-?[\d.]+)\s*\}/g;
 const RUN_NUM_LABELED_RE = /(?:London\s+hash\s+number|hash\s+number)\s+(\d+)/i;
 const RUN_NUM_BARE_RE = /\b(\d+)\b/;
 
-/** "85 metres from <station>" distance line. `[^\n]+` is greedy with a
- * single-char negated class — no nested quantifier backtracking. */
-const DISTANCE_RE = /(\d+\s*(?:meters?|metres?)\s+from\s+[^\n]+)/i;
-
 /** On-Inn body line. `[^\n"]+` stops at newline or JS-quote so the
  * cheerio body.text() pickup of `marker.title: "..."` doesn't leak. */
 const ON_INN_RE = /On\s+Inn\s+to\s+([^\n"]+)/i;
-/** JS marker title: `title: "On Inn to <pub>"` — `[^"]+` stops at the
- * closing quote, no non-greedy backtracking. */
-const ON_INN_MARKER_RE = /title:\s*"On\s+Inn\s+to\s+([^"]+)"/i;
 const ON_INN_TRAILING_RE = /[,;]\s*$/;
+/** Distance/On-Inn pattern needles for procedural slicing — `\s+`-heavy
+ * regexes here keep tripping Sonar S5852 even when linear in practice
+ * (per feedback_sonar_s5852_procedural_over_regex.md). Pre-compute the
+ * lowercase needles for case-insensitive searches. */
+const DISTANCE_UNITS = ["metres", "meters", "metre", "meter"] as const;
+const ON_INN_MARKER_PREFIX = 'title:';
+const ON_INN_MARKER_VALUE_PREFIX = '"On Inn to ';
 
 /** Match a leading `from <prefix>` block; the station-only fallback then
  * uses procedural slicing (avoids Sonar S5852 on `[^\n*]+?\s+station\b`). */
@@ -551,11 +551,11 @@ function applyDetailHares(result: LH3DetailPageData, labels: Map<string, string>
 }
 
 function applyDetailDistance(result: LH3DetailPageData, labels: Map<string, string>, fullText: string): void {
-  // Prefer the structured "How Far" label so the greedy `[^\n]+` in
-  // DISTANCE_RE doesn't trip past the field boundary in the fullText fallback.
+  // Prefer the structured "How Far" label so the procedural extractor
+  // doesn't trip past field boundaries in the fullText fallback.
   const howFarValue = labels.get("How Far") ?? fullText;
-  const distMatch = DISTANCE_RE.exec(howFarValue);
-  if (distMatch) result.distance = distMatch[1].trim();
+  const dist = extractDistance(howFarValue);
+  if (dist) result.distance = dist;
 }
 
 function applyDetailOnOn(result: LH3DetailPageData, fullText: string, html: string): void {
@@ -564,8 +564,62 @@ function applyDetailOnOn(result: LH3DetailPageData, fullText: string, html: stri
     result.onOn = onOnMatch[1].trim().replace(ON_INN_TRAILING_RE, "");
     return;
   }
-  const markerOnOn = ON_INN_MARKER_RE.exec(html);
-  if (markerOnOn) result.onOn = markerOnOn[1].trim();
+  const markerOnOn = extractOnInnMarker(html);
+  if (markerOnOn) result.onOn = markerOnOn;
+}
+
+/** Find a `"<digits> meter(s)/metre(s) from <rest-of-line>"` phrase and
+ * return it verbatim (trimmed). Procedural to avoid Sonar S5852 on the
+ * prior `\d+\s*(?:meters?|metres?)\s+from\s+[^\n]+` shape — the unit
+ * alternation flanked by `\s+/\s*` was the trip pattern. Exported for
+ * unit testing. */
+export function extractDistance(text: string): string | undefined {
+  const lower = text.toLowerCase();
+  for (const unit of DISTANCE_UNITS) {
+    const needle = ` ${unit} from `;
+    const phraseIdx = lower.indexOf(needle);
+    if (phraseIdx < 0) continue;
+    // Walk back to the start of the number that precedes the unit.
+    let numStart = phraseIdx;
+    while (numStart > 0 && text[numStart - 1] === " ") numStart--;
+    let digitStart = numStart;
+    while (digitStart > 0 && text[digitStart - 1] >= "0" && text[digitStart - 1] <= "9") {
+      digitStart--;
+    }
+    if (digitStart === numStart) continue; // no digits found
+    const eol = text.indexOf("\n", phraseIdx);
+    const end = eol < 0 ? text.length : eol;
+    return text.slice(digitStart, end).trim();
+  }
+  return undefined;
+}
+
+/** Parse `title: "On Inn to <PUB>"` from an HTML/JS source string and return
+ * `<PUB>` (trimmed). Procedural to avoid Sonar S5852 on the prior
+ * `title:\s*"On\s+Inn\s+to\s+([^"]+)"` shape — multiple `\s+` runs around
+ * literal tokens kept tripping the analyzer.
+ *
+ * The page emits multiple `title:` keys (one per Google Maps marker). Walk
+ * each occurrence and return the first whose value starts with
+ * `"On Inn to ` — the train-trail marker title comes first, the On-Inn
+ * marker comes second. Exported for unit testing. */
+export function extractOnInnMarker(html: string): string | undefined {
+  let searchFrom = 0;
+  while (searchFrom < html.length) {
+    const titleIdx = html.indexOf(ON_INN_MARKER_PREFIX, searchFrom);
+    if (titleIdx < 0) return undefined;
+    let cursor = titleIdx + ON_INN_MARKER_PREFIX.length;
+    while (cursor < html.length && (html[cursor] === " " || html[cursor] === "\t")) cursor++;
+    if (html.startsWith(ON_INN_MARKER_VALUE_PREFIX, cursor)) {
+      const valueStart = cursor + ON_INN_MARKER_VALUE_PREFIX.length;
+      const closeQuote = html.indexOf('"', valueStart);
+      if (closeQuote >= 0) {
+        return html.slice(valueStart, closeQuote).trim() || undefined;
+      }
+    }
+    searchFrom = titleIdx + ON_INN_MARKER_PREFIX.length;
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

The London Hash adapter was running regex against the concatenated text of the entire `.runListDetails` container (runlist.php) and against `$(\"body\").text()` of the detail page (nextrun.php). Because the source ships each field as a sibling `<div>` with no whitespace separators between them, `.text()` fused adjacent values into their next section's label, polluting **all 62 currently-indexed LH3 events**:

- **Titles**: every event got synthesized `"London Hash Run #N"` because the `.titleRow` heading ("Bromley South", "Hampstead Heath **Sweetheart's 4th of July Hash**", "**To Be Announced") was ignored.
- **Hares**: `"Hared by K4"` + sibling `"What Else"` rendered as `"K4What Else"`.
- **Description**: section labels (`"Who"`, `"What Else"`) inlined into prose.

## Fix

- `parseRunBlocks` reads `.titleRow` / `.runlistDate` / `.runlistLoc` / `.runlistHare` / `.runlistNote` independently into the new `RunBlock` fields (`titleText`, `dateText`, `locText`, `hareText`, `noteTexts`).
- `parseLH3DetailPage` builds a `Map<label,value>` from each `.nextRunlistRow`'s `.runlistCat` + `.runlistDetail` pair (matching live source HTML).
- New `parseTitleFromBlock` helper strips `**` markdown wrappers and falls back to the synthesized default for TBA / placeholder titles.
- `parseDateFromBlock` now passes `forwardDate: true` to chrono — live runlist rows omit the year (`\"Saturday 6th of June\"`) and ambiguity was resolving to past dates.
- Minor: On-On regex now stops at `\"` because `body.text()` includes `<script>` tag content with the `marker.title:` JS line.

## Live verification (`https://www.londonhash.org/runlist.php`)

30 events parsed, 3 detail-enriched, 0 errors:

```
#2834 2026-05-30 | title=\"Bromley South\"                                | hares=Masterbaker | loc=Cork n Cask
#2835 2026-06-06 | title=\"Rotherhithe\"                                  | hares=Boy Blunder
#2836 2026-06-13 | title=\"Clapham Junction\"                             | hares=No Foreplay
#2837 2026-06-20 | title=\"London Hash Run #2837\" (TBA fallback)         | hares=Giving Head
#2839 2026-07-04 | title=\"Hampstead Heath Sweetheart's 4th of July Hash\" | hares=Sweetheart
```

## Test plan

- [x] 71 tests pass (\`npx vitest run src/adapters/html-scraper/london-hash.test.ts\`)
- [x] Full suite green (\`npm test\` — 7301/7301)
- [x] \`npx tsc --noEmit\` clean for london-hash.ts
- [x] Live fetch verified end-to-end (titles, hares, dates, description)
- [ ] Post-merge: re-scrape source via admin to overwrite the 62 polluted RawEvents

Closes #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)