### PR TITLE
feat(lsw): historical backfill 1,725 events back to founding run #1 (#1611)

### DIFF
--- a/scripts/backfill-lsw-h3-history.test.ts
+++ b/scripts/backfill-lsw-h3-history.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeHares,
+  parseLswArchiveBody,
+} from "./backfill-lsw-h3-history";
+
+describe("normalizeHares", () => {
+  it("sorts comma-separated tokens deterministically", () => {
+    expect(normalizeHares("Charlie, Alpha, Bravo")).toBe("Alpha, Bravo, Charlie");
+  });
+
+  it("preserves single-hare values verbatim", () => {
+    expect(normalizeHares("Hopeless")).toBe("Hopeless");
+  });
+
+  it("returns undefined for empty / whitespace-only input", () => {
+    expect(normalizeHares("")).toBeUndefined();
+    expect(normalizeHares("   ")).toBeUndefined();
+  });
+
+  it("ignores trailing commas / empty tokens", () => {
+    expect(normalizeHares("Hands Off The Rear, Octopussy, ")).toBe(
+      "Hands Off The Rear, Octopussy",
+    );
+  });
+});
+
+/** Wrap rows in a minimal previousruns.htm-shaped table. */
+function wrapTable(rows: string[]): string {
+  return `<html><body><table><tr><td><p>DATE<td><p>RUN NO.<td><p>LOCATION<td><p>HARES<td><p>RUNNERS</tr>${rows.join("")}</table></body></html>`;
+}
+
+// Verbatim row shapes from `curl https://www.datadesignfactory.com/lsw/previousruns.htm`
+// (May 2026 issue body capture).
+const ROW_2598 = `<tr><td><p>20 May 26<td><p><a href="pages/LSW2598.htm">2598</a><td><p>Tiu Keng Leng<td><p>Ass Control Tower, Hand Solo<td><p>20</tr>`;
+const ROW_2595 = `<tr><td><p>29 Apr 26<td><p><a href="pages/LSW2595.htm">2595</a><td><p>Anzac Day Run<td><p>Indyanus, Octopussy, Hands Off The Rear<td><p>35</tr>`;
+const ROW_250_SEPT = `<tr><td><p>10 Sept 83<td><p>250</td><td><p>Frog & Toad cancelled Typhoon Ellen-Chung Hom Kok<td><p>Bob Lampard, Old Man Whithers<td><p></tr>`;
+const ROW_100_FOUNDING_ERA = `<tr><td><p>17 Dec 80<td><p>100</td><td><p>Kowloon Reservoir<td><p><td><p></tr>`;
+const ROW_NO_RUN_NUM = `<tr><td><p>23 Jan 91<td><p></td><td><p>Lockhart Road Playground<td><p><td><p></tr>`;
+const ROW_BAD_DATE = `<tr><td><p>not a date<td><p>9999<td><p>Somewhere<td><p>Person<td><p>1</tr>`;
+
+describe("parseLswArchiveBody", () => {
+  it("parses a verbatim 2598 row with all fields", () => {
+    const events = parseLswArchiveBody(wrapTable([ROW_2598]));
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.date).toBe("2026-05-20");
+    expect(ev.kennelTags).toEqual(["lsw-h3"]);
+    expect(ev.runNumber).toBe(2598);
+    expect(ev.location).toBe("Tiu Keng Leng");
+    // Hares are normalized — original "Ass Control Tower, Hand Solo" stays
+    // alphabetical (Ass… before Hand…), no change.
+    expect(ev.hares).toBe("Ass Control Tower, Hand Solo");
+    expect(ev.description).toBe("Pack: 20");
+    expect(ev.startTime).toBeUndefined();
+    expect(ev.sourceUrl).toBe("https://www.datadesignfactory.com/lsw/pages/LSW2598.htm");
+  });
+
+  it("sorts hares deterministically across re-runs (fingerprint stability)", () => {
+    // Row #2595 source order: "Indyanus, Octopussy, Hands Off The Rear".
+    // Normalized alphabetical: "Hands Off The Rear, Indyanus, Octopussy".
+    const events = parseLswArchiveBody(wrapTable([ROW_2595]));
+    expect(events).toHaveLength(1);
+    expect(events[0].hares).toBe("Hands Off The Rear, Indyanus, Octopussy");
+  });
+
+  it("accepts 4-char month names like 'Sept' (1983-era rows)", () => {
+    const events = parseLswArchiveBody(wrapTable([ROW_250_SEPT]));
+    expect(events).toHaveLength(1);
+    expect(events[0].date).toBe("1983-09-10");
+    expect(events[0].runNumber).toBe(250);
+  });
+
+  it("emits rows with no anchor or no hares (founding-era sparse data)", () => {
+    const events = parseLswArchiveBody(wrapTable([ROW_100_FOUNDING_ERA]));
+    expect(events).toHaveLength(1);
+    expect(events[0].date).toBe("1980-12-17");
+    expect(events[0].runNumber).toBe(100);
+    expect(events[0].hares).toBeUndefined();
+    // No anchor → sourceUrl falls back to the archive page.
+    expect(events[0].sourceUrl).toBe("https://www.datadesignfactory.com/lsw/previousruns.htm");
+    // No runner count → description undefined (not "Pack: 0").
+    expect(events[0].description).toBeUndefined();
+  });
+
+  it("skips rows without a usable run number", () => {
+    const events = parseLswArchiveBody(wrapTable([ROW_NO_RUN_NUM]));
+    expect(events).toHaveLength(0);
+  });
+
+  it("skips rows with an unparseable date", () => {
+    const events = parseLswArchiveBody(wrapTable([ROW_BAD_DATE]));
+    expect(events).toHaveLength(0);
+  });
+
+  it("skips the header row (literal 'DATE' in first cell)", () => {
+    const events = parseLswArchiveBody(wrapTable([])); // table has only the header row
+    expect(events).toHaveLength(0);
+  });
+
+  it("partitions a mixed table — keeps good rows, drops malformed ones", () => {
+    const events = parseLswArchiveBody(
+      wrapTable([ROW_2598, ROW_BAD_DATE, ROW_NO_RUN_NUM, ROW_250_SEPT, ROW_100_FOUNDING_ERA]),
+    );
+    expect(events.map((e) => e.runNumber).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([100, 250, 2598]);
+  });
+});

--- a/scripts/backfill-lsw-h3-history.ts
+++ b/scripts/backfill-lsw-h3-history.ts
@@ -1,0 +1,170 @@
+/**
+ * One-shot historical backfill for LSW (Little Sai Wan H3, Hong Kong) —
+ * issue #1611.
+ *
+ * The live source (`/lsw/hareline.htm`) is upcoming-only. The same site
+ * ships `/lsw/previousruns.htm` — a single static HTML table with every
+ * recorded run back to the kennel's founding (LSW #1, 17 Jan 1979). Issue
+ * #1611 framed the floor as #100 but the founding run is in the same table
+ * (sparse rows for 1979-82, dense from 1983 onward).
+ *
+ * This script does a one-shot fetch with realistic browser headers
+ * (server uses mod_security and rejects default Accept headers), decodes
+ * windows-1252 (page declares it explicitly; default UTF-8 corrupts
+ * accented hash names like "Prefers it�Wet"), and routes every parsable
+ * row through the backfill runner's strict-partitioning merge.
+ *
+ * Yield estimate: ~1,584 events (1979 → today). Re-runnable: the runner
+ * partitions to `date < today (Asia/Hong_Kong)` and `processRawEvents`
+ * short-circuits on existing fingerprints.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-lsw-h3-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-lsw-h3-history.ts
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { parseLswDate } from "@/adapters/html-scraper/lsw-h3";
+import { decodeEntities } from "@/adapters/utils";
+import type { RawEventData } from "@/adapters/types";
+import { runBackfillScript } from "./lib/backfill-runner";
+
+const SOURCE_NAME = "LSW Hareline";
+const BASE_URL = "https://www.datadesignfactory.com/lsw";
+const ARCHIVE_URL = `${BASE_URL}/previousruns.htm`;
+const KENNEL_TAG = "lsw-h3";
+const KENNEL_TIMEZONE = "Asia/Hong_Kong";
+
+/** Browser-realistic headers — mod_security rejects empty / default Accept. */
+const BROWSER_HEADERS: Record<string, string> = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+  Accept: "text/html,application/xhtml+xml",
+  "Accept-Language": "en-US,en;q=0.5",
+};
+
+/** Sort comma-separated hare names so re-runs produce identical fingerprints.
+ * Source row order is API-dependent and not guaranteed stable across scrapes
+ * (per feedback_fingerprint_stability.md). Exported for unit testing. */
+export function normalizeHares(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const tokens = trimmed
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) return undefined;
+  return [...tokens].sort((a, b) => a.localeCompare(b, "en")).join(", ");
+}
+
+/** Parse one TR row into RawEventData, or null when the row doesn't carry
+ * a usable date + run number. The HTML is a header-less table with five
+ * `<td>` columns: DATE, RUN NO. (anchored to detail page), LOCATION, HARES,
+ * RUNNERS. Header rows have the literal text "DATE" in the first cell.
+ *
+ * Exported for unit testing against fixture HTML.
+ */
+export function parseLswArchiveRow(
+  $: cheerio.CheerioAPI,
+  row: AnyNode,
+  baseUrl: string,
+): RawEventData | null {
+  const $row = $(row);
+  const cells = $row.find("td");
+  if (cells.length < 4) return null;
+
+  const dateText = decodeEntities($(cells[0]).text()).trim();
+  // Header row guard: first row of the table is literal "DATE".
+  if (/^date$/i.test(dateText)) return null;
+
+  const date = parseLswDate(dateText);
+  if (!date) return null;
+
+  // Run number — prefer anchor text; fall back to raw cell text. Skip rows
+  // with no run number at all (the archive has a handful of 1990-91 entries
+  // without numbers).
+  const $runCell = $(cells[1]);
+  const runAnchor = $runCell.find("a").first();
+  const runText = (runAnchor.length > 0 ? runAnchor.text() : $runCell.text()).trim();
+  const runDigits = runText.replace(/\D/g, "");
+  if (!runDigits) return null;
+  const runNumber = parseInt(runDigits, 10);
+  if (!runNumber || runNumber <= 0) return null;
+
+  const locationRaw = decodeEntities($(cells[2]).text()).trim();
+  const location = locationRaw || undefined;
+
+  const haresRaw = decodeEntities($(cells[3]).text()).trim();
+  const hares = normalizeHares(haresRaw);
+
+  // Runners → "Pack: NN" in description. Skip when not a positive integer.
+  const runnersRaw = cells.length > 4 ? $(cells[4]).text().trim() : "";
+  const runnersNum = parseInt(runnersRaw, 10);
+  const description = Number.isFinite(runnersNum) && runnersNum > 0
+    ? `Pack: ${runnersNum}`
+    : undefined;
+
+  // sourceUrl: derive from the anchor href if present, otherwise the archive page.
+  const href = runAnchor.attr("href")?.trim();
+  const sourceUrl = href
+    ? new URL(href, `${baseUrl}/`).toString()
+    : ARCHIVE_URL;
+
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber,
+    // title left undefined — merge pipeline synthesizes "LSW Trail #N".
+    hares,
+    location,
+    description,
+    // startTime intentionally undefined — historical archive doesn't carry
+    // per-run times; D14 atomic semantics preserve whatever the live adapter
+    // emits rather than asserting a stale default.
+    sourceUrl,
+  };
+}
+
+/** Parse the full previousruns.htm body. Exported for unit testing. */
+export function parseLswArchiveBody(html: string): RawEventData[] {
+  const $ = cheerio.load(html);
+  const events: RawEventData[] = [];
+  $("tr").each((_i, row) => {
+    const event = parseLswArchiveRow($, row, BASE_URL);
+    if (event) events.push(event);
+  });
+  return events;
+}
+
+/** Fetch + decode the windows-1252 archive page. */
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log(`  Fetching ${ARCHIVE_URL}...`);
+  const response = await safeFetch(ARCHIVE_URL, { headers: BROWSER_HEADERS });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+  // Source declares <META charset="windows-1252">. Decode explicitly —
+  // default fetch().text() treats bytes as UTF-8 and corrupts accented
+  // hash names ("Prefers it Wet" → "Prefers it�Wet"). Built-in TextDecoder
+  // handles windows-1252 natively; no extra dep needed.
+  const buf = await response.arrayBuffer();
+  const html = new TextDecoder("windows-1252").decode(new Uint8Array(buf));
+  console.log(`  Downloaded ${(buf.byteLength / 1024).toFixed(0)} KB (decoded windows-1252)`);
+  return parseLswArchiveBody(html);
+}
+
+if (process.argv[1]?.endsWith("backfill-lsw-h3-history.ts")) {
+  runBackfillScript({
+    sourceName: SOURCE_NAME,
+    kennelTimezone: KENNEL_TIMEZONE,
+    label: `Walking ${ARCHIVE_URL} for LSW historical rows`,
+    fetchEvents,
+  }).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("FAILED:", message);
+    process.exit(1);
+  });
+}

--- a/src/adapters/html-scraper/lsw-h3.test.ts
+++ b/src/adapters/html-scraper/lsw-h3.test.ts
@@ -12,6 +12,15 @@ describe("parseLswDate", () => {
     expect(parseLswDate("09 Apr 2025")).toBe("2025-04-09");
   });
 
+  it("parses 4-char month abbreviations (Sept)", () => {
+    // previousruns.htm uses "Sept" for some 1983-era rows.
+    expect(parseLswDate("10 Sept 83")).toBe("1983-09-10");
+  });
+
+  it("parses full month names", () => {
+    expect(parseLswDate("01 February 26")).toBe("2026-02-01");
+  });
+
   it("returns null for invalid input", () => {
     expect(parseLswDate("")).toBeNull();
     expect(parseLswDate("not a date")).toBeNull();

--- a/src/adapters/html-scraper/lsw-h3.ts
+++ b/src/adapters/html-scraper/lsw-h3.ts
@@ -14,20 +14,28 @@ const MONTH_NAMES: Record<string, number> = {
 
 /**
  * Parse a date string like "09 Apr 25", "23 Jul 26", "DD Mon YY".
+ * Also accepts 4–9 char month names ("Sept", "September") — the LSW
+ * previousruns.htm archive uses "Sept" for some 1983-era rows.
  * Returns YYYY-MM-DD or null.
  */
 export function parseLswDate(text: string): string | null {
-  const match = /(\d{1,2})\s+([A-Za-z]{3})\s+(\d{2,4})/.exec(text.trim());
+  const match = /(\d{1,2})\s+([A-Za-z]{3,9})\s+(\d{2,4})/.exec(text.trim());
   if (!match) return null;
 
   const day = parseInt(match[1], 10);
-  const monthStr = match[2].toLowerCase();
+  // Normalize to first 3 letters — every month has a unique 3-letter prefix.
+  const monthStr = match[2].slice(0, 3).toLowerCase();
   const rawYear = parseInt(match[3], 10);
 
   const month = MONTH_NAMES[monthStr];
   if (!month) return null;
 
-  const year = rawYear < 100 ? 2000 + rawYear : rawYear;
+  // Y2K pivot at 70: 00-69 → 2000-2069, 70-99 → 1970-1999.
+  // LSW founded 1979 and previousruns.htm carries dates back to "17 Jan 79".
+  // The original adapter assumed 20xx only (upcoming hareline never spans
+  // 19xx); the pivot is needed for the historical archive.
+  const year =
+    rawYear < 100 ? (rawYear < 70 ? 2000 + rawYear : 1900 + rawYear) : rawYear;
 
   if (day < 1 || day > 31 || month < 1 || month > 12) return null;
 


### PR DESCRIPTION
## Summary

LSW (Little Sai Wan H3, Hong Kong, founded **17 Jan 1979**) currently has only 10 upcoming events in HashTracks. The same site that hosts the live \`hareline.htm\` source also ships \`previousruns.htm\` — a single static HTML table with every recorded run back to the founding.

One-shot backfill script via the shared \`runBackfillScript\` helper, bound to the existing \"LSW Hareline\" source.

## Live dry-run

```
Total parsed: 1725
Date range: 1979-01-17 → 2026-05-20
Samples:
  #1    1979-01-17 | loc=Sui Sai Wan Tennis Court Carpark      <- founding run!
  #1736 2010-05-29 | hares=Pinky | loc=Germany
  #2598 2026-05-20 | hares=Ass Control Tower, Hand Solo | loc=Tiu Keng Leng
```

Issue #1611 framed the floor as #100 but #1 is in the same table (sparse rows for 1979-82, dense from 1983).

## Implementation notes

- **Charset**: page declares \`charset=windows-1252\`. Decoded explicitly via built-in \`TextDecoder('windows-1252')\` — default UTF-8 corrupts accented hash names (\"Prefers it Wet\" → \"Prefers it�Wet\"). No new dep.
- **Headers**: \`mod_security\` rejects empty Accept. Realistic browser headers passed to \`safeFetch\`.
- **Fingerprint stability**: hare tokens sorted deterministically (per memory \`feedback_fingerprint_stability.md\`) so re-runs produce identical fingerprints regardless of source row order.
- **parseLswDate extensions**:
  - Now accepts 4–9 char month names — \"Sept\" appears in 1983-era rows.
  - Y2K pivot at year 70 (00-69 → 20xx, 70-99 → 19xx). Original adapter assumed 20xx only (live hareline never spans 19xx); pivot needed for the historical archive.
- **startTime intentionally undefined** on historical rows (per D14 atomic semantics — preserve whatever the live adapter emits rather than asserting a stale default).

## Test plan

- [x] 12 fixture tests for archive parsing (\`scripts/backfill-lsw-h3-history.test.ts\`)
- [x] 2 new \`parseLswDate\` tests (\"Sept\", full month name)
- [x] Dry-run against live source → 1725 events parsed, 0 errors
- [x] \`npx tsc --noEmit\` clean for new files
- [ ] Post-merge: \`BACKFILL_APPLY=1 npx tsx scripts/backfill-lsw-h3-history.ts\`
- [ ] Verify LSW Past tab shows 1,500+ events; spot-check #1 / #1736 / #2598
- [ ] Re-run script → all skipped (idempotency check)

Closes #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)