### PR TITLE
feat(lh3): historical backfill 901 events back to 2010 (#1607)

### DIFF
--- a/scripts/backfill-london-h3-history.test.ts
+++ b/scripts/backfill-london-h3-history.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseHashtoryDate,
+  normalizeHares,
+  parseHashtoryYear,
+} from "./backfill-london-h3-history";
+
+describe("parseHashtoryDate", () => {
+  it("parses 'DOW Mon DDth' with year context", () => {
+    expect(parseHashtoryDate("Sun Dec 26th", 2010)).toBe("2010-12-26");
+    expect(parseHashtoryDate("Sat May 23rd", 2026)).toBe("2026-05-23");
+    expect(parseHashtoryDate("Fri Jan 1st", 2010)).toBe("2010-01-01");
+  });
+
+  it("tolerates trailing whitespace", () => {
+    expect(parseHashtoryDate("Sun Dec 26th ", 2010)).toBe("2010-12-26");
+  });
+
+  it("accepts 4-9 char month names", () => {
+    expect(parseHashtoryDate("Tue September 7th", 2010)).toBe("2010-09-07");
+  });
+
+  it("returns null for invalid month", () => {
+    expect(parseHashtoryDate("Sun Xyz 10th", 2010)).toBeNull();
+  });
+
+  it("returns null for invalid day", () => {
+    expect(parseHashtoryDate("Mon Feb 30th", 2010)).toBeNull();
+  });
+
+  it("returns null for empty / garbage", () => {
+    expect(parseHashtoryDate("", 2010)).toBeNull();
+    expect(parseHashtoryDate("blah", 2010)).toBeNull();
+  });
+});
+
+describe("normalizeHares", () => {
+  it("parses 'X and Y' format", () => {
+    expect(normalizeHares("Tuna Melt and Opee")).toBe("Opee, Tuna Melt");
+  });
+
+  it("parses 'X, Y and Z' format with alphabetical sort", () => {
+    expect(normalizeHares("Charlie, Alpha and Bravo")).toBe(
+      "Alpha, Bravo, Charlie",
+    );
+  });
+
+  it("returns single hare verbatim", () => {
+    expect(normalizeHares("Mick Mac")).toBe("Mick Mac");
+  });
+
+  it("returns undefined for placeholders", () => {
+    expect(normalizeHares("Hare required")).toBeUndefined();
+    expect(normalizeHares("TBA")).toBeUndefined();
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(normalizeHares("")).toBeUndefined();
+    expect(normalizeHares("   ")).toBeUndefined();
+  });
+
+  it("drops placeholder tokens but keeps real names alongside them", () => {
+    expect(normalizeHares("Alice and TBA")).toBe("Alice");
+  });
+});
+
+// Verbatim row from `curl https://www.londonhash.org/hashtory.php?year=2010`
+// (captures the issue-body sample for run #1988).
+const SAMPLE_HRLIST_ROW = `
+<div class='hrlistRow'><div class='hashtory htIcon'><image src='./images/hashMarker.png' alt='hash' /></div><div class='hashtory htRunNo'><a href='nextrun.php?run=316'>1988</a></div><div class='hashtory htDate'>Sun Dec 26th </div><div class='hashtory htlocDesc'><a href="http://www.beerintheevening.com/pubs/s/30/30389/Springfield_Park_Tavern/Bounds_Green" target="_blank">The Springfield Park Tavern</a> at Bounds Green</div><div class='hashtory htHare'>Mick Mac</div></div>
+<div class="packHolder"><span class="bold">The Pack:</span> <b>Mick Mac</b>, Anuconda, Born again, Karin De Gugilmoy and Marxist. Total <b>5</b>. </div>
+`;
+
+const SAMPLE_HRLIST_ROW_MULTI_HARES = `
+<div class='hrlistRow'><div class='hashtory htRunNo'><a href='nextrun.php?run=268'>1987</a></div><div class='hashtory htDate'>Sun Dec 19th </div><div class='hashtory htlocDesc'>The Lord Nelson at Brentford</div><div class='hashtory htHare'>Billy the Fish and Ryde</div></div>
+<div class="packHolder">The Pack: Billy the Fish, Ryde, 2AM, Bhopal. Total 4.</div>
+`;
+
+const SAMPLE_HRLIST_ROW_NO_RUN = `
+<div class='hrlistRow'><div class='hashtory htRunNo'></div><div class='hashtory htDate'>Sun Nov 21st </div><div class='hashtory htlocDesc'>Somewhere</div><div class='hashtory htHare'>Nobody</div></div>
+`;
+
+const SAMPLE_HRLIST_ROW_BAD_DATE = `
+<div class='hrlistRow'><div class='hashtory htRunNo'><a href='nextrun.php?run=999'>1999</a></div><div class='hashtory htDate'>Garbage</div><div class='hashtory htlocDesc'>X</div><div class='hashtory htHare'>Y</div></div>
+`;
+
+const SAMPLE_ANNIVERSARY_ROW = `
+<div class='hrlistRow'><div class='hashtory htRunNo'><a href='nextrun.php?run=4100'>2826</a></div><div class='hashtory htDate'>Sat Apr 11th </div><div class='hashtory htlocDesc'>St James Park <b>LH3 50th Anniversary Hash</b></div><div class='hashtory htHare'>Old Faithful</div></div>
+`;
+
+function wrap(rows: string[]): string {
+  return `<html><body><div id="pageContent"><h2>Hash Runs 2010</h2>${rows.join("")}</div></body></html>`;
+}
+
+describe("parseHashtoryYear", () => {
+  it("parses a verbatim live row (run #1988, Springfield Park Tavern)", () => {
+    const events = parseHashtoryYear(wrap([SAMPLE_HRLIST_ROW]), 2010);
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.date).toBe("2010-12-26");
+    expect(ev.kennelTags).toEqual(["lh3"]);
+    expect(ev.runNumber).toBe(1988);
+    expect(ev.hares).toBe("Mick Mac");
+    expect(ev.location).toContain("Springfield Park Tavern");
+    expect(ev.location).toContain("Bounds Green");
+    expect(ev.description).toContain("Pack");
+    expect(ev.description).toContain("Total");
+    expect(ev.startTime).toBeUndefined();
+    expect(ev.sourceUrl).toBe("https://www.londonhash.org/nextrun.php?run=316");
+  });
+
+  it("sorts multi-hare values deterministically (#1987)", () => {
+    const events = parseHashtoryYear(wrap([SAMPLE_HRLIST_ROW_MULTI_HARES]), 2010);
+    expect(events).toHaveLength(1);
+    // "Billy the Fish and Ryde" → ["Billy the Fish", "Ryde"] → alphabetical
+    expect(events[0].hares).toBe("Billy the Fish, Ryde");
+  });
+
+  it("preserves theme tags in location (anniversary runs)", () => {
+    const events = parseHashtoryYear(wrap([SAMPLE_ANNIVERSARY_ROW]), 2026);
+    expect(events).toHaveLength(1);
+    expect(events[0].location).toContain("St James Park");
+    expect(events[0].location).toContain("LH3 50th Anniversary Hash");
+  });
+
+  it("skips rows without a run number", () => {
+    const events = parseHashtoryYear(wrap([SAMPLE_HRLIST_ROW_NO_RUN]), 2010);
+    expect(events).toHaveLength(0);
+  });
+
+  it("skips rows with unparseable dates", () => {
+    const events = parseHashtoryYear(wrap([SAMPLE_HRLIST_ROW_BAD_DATE]), 2010);
+    expect(events).toHaveLength(0);
+  });
+
+  it("partitions a mixed page — keeps good rows, drops malformed ones", () => {
+    const events = parseHashtoryYear(
+      wrap([SAMPLE_HRLIST_ROW, SAMPLE_HRLIST_ROW_BAD_DATE, SAMPLE_HRLIST_ROW_MULTI_HARES, SAMPLE_HRLIST_ROW_NO_RUN]),
+      2010,
+    );
+    expect(events.map((e) => e.runNumber).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([1987, 1988]);
+  });
+
+  it("year context drives the resolved date (2026 page → 2026 dates)", () => {
+    const events = parseHashtoryYear(wrap([SAMPLE_HRLIST_ROW]), 2026);
+    expect(events[0].date).toBe("2026-12-26");
+  });
+});

--- a/scripts/backfill-london-h3-history.ts
+++ b/scripts/backfill-london-h3-history.ts
@@ -61,7 +61,7 @@ export function parseHashtoryDate(cellText: string, year: number): string | null
   const match = /([A-Za-z]{3,9})\s+(\d{1,2})(?:st|nd|rd|th)?/.exec(cellText.trim());
   if (!match) return null;
   const monthStr = match[1].slice(0, 3).toLowerCase();
-  const day = parseInt(match[2], 10);
+  const day = Number.parseInt(match[2], 10);
   const month = MONTH_NAMES[monthStr];
   if (!month || day < 1 || day > 31) return null;
   // Calendar-validate (rejects Feb 30, etc.)
@@ -100,7 +100,7 @@ export function parseHrlistRow(
   // Run number — text of the anchor in .htRunNo.
   const $runAnchor = $row.find(".htRunNo a").first();
   const runText = $runAnchor.text().trim();
-  const runNumber = parseInt(runText, 10);
+  const runNumber = Number.parseInt(runText, 10);
   if (!runNumber || runNumber <= 0) return null;
 
   // Date — .htDate text, parsed against the year-context.

--- a/scripts/backfill-london-h3-history.ts
+++ b/scripts/backfill-london-h3-history.ts
@@ -1,0 +1,196 @@
+/**
+ * One-shot historical backfill for London H3 (LH3) — issue #1607.
+ *
+ * LH3 currently has ~62 upcoming events from runlist.php (#2820–#2863).
+ * The same site exposes /hashtory.php — a 17-year archive (2010 → today)
+ * of ~907 completed runs. Per-year URLs `?year=YYYY` carry unambiguous
+ * year context via the `<h2>Hash Runs YYYY</h2>` header; the dates in
+ * row cells omit the year ("Sun Dec 26th").
+ *
+ * Bound to the live "London Hash Run List" source — same kennel, same
+ * site, sister archive page. Matches the LIL pattern (hashnyc.com hosts
+ * both the live source and the historical archive query).
+ *
+ * Yield estimate: ~887 events (Jan 2010 → today). Re-runnable: the
+ * runner partitions to `date < today (Europe/London)` and the merge
+ * pipeline short-circuits on existing fingerprints.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-london-h3-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-london-h3-history.ts
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { decodeEntities } from "@/adapters/utils";
+import type { RawEventData } from "@/adapters/types";
+import { runBackfillScript } from "./lib/backfill-runner";
+
+const SOURCE_NAME = "London Hash Run List";
+const BASE_URL = "https://www.londonhash.org";
+const KENNEL_TAG = "lh3";
+const KENNEL_TIMEZONE = "Europe/London";
+
+/** Archive's earliest available year. Year selector caps at 2010 — runs
+ * #1–#1932 (1975 → end of 2009) are not on the website. */
+const ARCHIVE_START_YEAR = 2010;
+const POLITENESS_DELAY_MS = 250;
+
+const MONTH_NAMES: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Parse a hashtory date cell like "Sun Dec 26th" with explicit year
+ * context. Returns YYYY-MM-DD or null. Exported for unit testing.
+ *
+ * Hand-rolled instead of chrono: the input is rigidly shaped (DOW Month
+ * Day-with-ordinal) and chrono's ambiguous-date heuristics are risky
+ * when year context lives in a separate variable (cf. memory note
+ * `feedback_chrono_forward_date_explicit_year.md`).
+ */
+export function parseHashtoryDate(cellText: string, year: number): string | null {
+  // Strip the day-of-week prefix and trailing ordinal/whitespace.
+  // Shape: "(Sun )Dec 26th( )" or "Dec 26th".
+  const match = /([A-Za-z]{3,9})\s+(\d{1,2})(?:st|nd|rd|th)?/.exec(cellText.trim());
+  if (!match) return null;
+  const monthStr = match[1].slice(0, 3).toLowerCase();
+  const day = parseInt(match[2], 10);
+  const month = MONTH_NAMES[monthStr];
+  if (!month || day < 1 || day > 31) return null;
+  // Calendar-validate (rejects Feb 30, etc.)
+  const d = new Date(Date.UTC(year, month - 1, day));
+  if (d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return null;
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/** Sort comma-separated hare names so re-runs produce identical fingerprints.
+ * Source row order isn't guaranteed stable across scrapes
+ * (per `feedback_fingerprint_stability.md`). Exported for unit testing. */
+export function normalizeHares(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  // Source uses "X and Y" / "X, Y and Z" formats. Normalize on "and" + ","
+  // then sort. "Hare required" / placeholder check happens after.
+  const tokens = trimmed
+    .split(/\s*(?:,|\band\b)\s*/i)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0 && !/required|volunteer|tba|tbd|tbc/i.test(t));
+  if (tokens.length === 0) return undefined;
+  return [...tokens].sort((a, b) => a.localeCompare(b, "en")).join(", ");
+}
+
+/** Parse one `.hrlistRow` + adjacent `.packHolder` into RawEventData,
+ * or null when the row doesn't carry a usable date + run number.
+ *
+ * Exported for unit testing. */
+export function parseHrlistRow(
+  $: cheerio.CheerioAPI,
+  row: AnyNode,
+  year: number,
+): RawEventData | null {
+  const $row = $(row);
+
+  // Run number — text of the anchor in .htRunNo.
+  const $runAnchor = $row.find(".htRunNo a").first();
+  const runText = $runAnchor.text().trim();
+  const runNumber = parseInt(runText, 10);
+  if (!runNumber || runNumber <= 0) return null;
+
+  // Date — .htDate text, parsed against the year-context.
+  const dateCellText = decodeEntities($row.find(".htDate").first().text());
+  const date = parseHashtoryDate(dateCellText, year);
+  if (!date) return null;
+
+  // Location — .htlocDesc text (verbatim). Includes theme tags like
+  // "LH3 50th Anniversary Hash" inline with the pub name — per the
+  // issue body, these are legitimate parts of the location string.
+  const locationRaw = decodeEntities($row.find(".htlocDesc").first().text()).trim();
+  const location = locationRaw || undefined;
+
+  // Hares — .htHare text, deterministically sorted.
+  const haresRaw = decodeEntities($row.find(".htHare").first().text());
+  const hares = normalizeHares(haresRaw);
+
+  // Pack list — next-sibling .packHolder, if present.
+  const $pack = $row.next(".packHolder");
+  const packText = $pack.length > 0
+    ? decodeEntities($pack.text()).replace(/\s+/g, " ").trim()
+    : undefined;
+  // Description = pack list verbatim ("The Pack: Name, Name. Total 5.")
+  // when present. Useful historical context.
+  const description = packText || undefined;
+
+  // sourceUrl: from the .htRunNo anchor href.
+  const href = $runAnchor.attr("href")?.trim();
+  const sourceUrl = href ? new URL(href, `${BASE_URL}/`).toString() : `${BASE_URL}/hashtory.php`;
+
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber,
+    // title left undefined — merge pipeline synthesizes "London H3 Trail #N".
+    hares,
+    location,
+    description,
+    // startTime intentionally undefined — historical rows have no time
+    // data; D14 atomic semantics preserve whatever the live adapter
+    // emits rather than asserting "London H3 has always been noon".
+    sourceUrl,
+  };
+}
+
+/** Parse a single hashtory.php?year=YYYY page. Exported for unit testing. */
+export function parseHashtoryYear(html: string, year: number): RawEventData[] {
+  const $ = cheerio.load(html);
+  const events: RawEventData[] = [];
+  $(".hrlistRow").each((_i, row) => {
+    const event = parseHrlistRow($, row, year);
+    if (event) events.push(event);
+  });
+  return events;
+}
+
+async function fetchYear(year: number): Promise<RawEventData[]> {
+  const url = `${BASE_URL}/hashtory.php?year=${year}`;
+  const response = await safeFetch(url, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText} for ${url}`);
+  }
+  const html = await response.text();
+  return parseHashtoryYear(html, year);
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const endYear = new Date().getUTCFullYear();
+  const events: RawEventData[] = [];
+  console.log(`  Walking ${ARCHIVE_START_YEAR}-${endYear} (${endYear - ARCHIVE_START_YEAR + 1} year pages)...`);
+  for (let yr = ARCHIVE_START_YEAR; yr <= endYear; yr++) {
+    const yearEvents = await fetchYear(yr);
+    console.log(`    year=${yr}: ${yearEvents.length} rows`);
+    events.push(...yearEvents);
+    if (yr < endYear) await sleep(POLITENESS_DELAY_MS);
+  }
+  return events;
+}
+
+if (process.argv[1]?.endsWith("backfill-london-h3-history.ts")) {
+  runBackfillScript({
+    sourceName: SOURCE_NAME,
+    kennelTimezone: KENNEL_TIMEZONE,
+    label: `Walking londonhash.org/hashtory.php year pages for LH3 archive`,
+    fetchEvents,
+  }).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("FAILED:", message);
+    process.exit(1);
+  });
+}

--- a/scripts/backfill-london-h3-history.ts
+++ b/scripts/backfill-london-h3-history.ts
@@ -70,20 +70,28 @@ export function parseHashtoryDate(cellText: string, year: number): string | null
   return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }
 
+/** Hare-name placeholder tokens to drop. Single alternation, no flanking
+ * quantifiers — safe shape for Sonar S5852. */
+const PLACEHOLDER_HARE_RE = /required|volunteer|tba|tbd|tbc/i;
+
 /** Sort comma-separated hare names so re-runs produce identical fingerprints.
  * Source row order isn't guaranteed stable across scrapes
- * (per `feedback_fingerprint_stability.md`). Exported for unit testing. */
+ * (per `feedback_fingerprint_stability.md`). Source uses "X and Y" / "X, Y
+ * and Z" / "X, Y, Z" formats — split on "," then on " and " (case-
+ * insensitive literal, no flanking `\s*` quantifier so Sonar S5852 stays
+ * clean). Exported for unit testing. */
 export function normalizeHares(raw: string): string | undefined {
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
-  // Source uses "X and Y" / "X, Y and Z" formats. Normalize on "and" + ","
-  // then sort. "Hare required" / placeholder check happens after.
-  const tokens = trimmed
-    .split(/\s*(?:,|\band\b)\s*/i)
-    .map((t) => t.trim())
-    .filter((t) => t.length > 0 && !/required|volunteer|tba|tbd|tbc/i.test(t));
+  const tokens: string[] = [];
+  for (const piece of trimmed.split(",")) {
+    for (const t of piece.split(/ and /i)) {
+      const cleaned = t.trim();
+      if (cleaned && !PLACEHOLDER_HARE_RE.test(cleaned)) tokens.push(cleaned);
+    }
+  }
   if (tokens.length === 0) return undefined;
-  return [...tokens].sort((a, b) => a.localeCompare(b, "en")).join(", ");
+  return tokens.sort((a, b) => a.localeCompare(b, "en")).join(", ");
 }
 
 /** Parse one `.hrlistRow` + adjacent `.packHolder` into RawEventData,


### PR DESCRIPTION
## Summary

London H3 currently has ~62 upcoming events from runlist.php. The same site exposes \`/hashtory.php\` — a 17-year archive (2010 → today) of completed runs. Per-year URLs \`?year=YYYY\` carry unambiguous year context via the \`<h2>Hash Runs YYYY</h2>\` header.

One-shot backfill via the shared \`runBackfillScript\` helper, bound to the existing \"London Hash Run List\" source.

## Live dry-run

```
Walking 2010-2026 (17 year pages, 250ms politeness):
  year=2010: 56 ... year=2026: 22 rows
Total parsed: 901
Date range: 2010-01-01 → 2026-05-23

Samples:
  #1933 2010-01-01 | Westminster | Mick Mac      <- archive's earliest run
  #2383 2017-11-04 | The Plough and Harrow at Hammersmith | Bhopal, Hands On
  #2833 2026-05-23 | The Viaduct at Hanwell | K4
```

Year selector caps at 2010; runs #1-#1932 (1975 → end of 2009) are not on the website.

## Implementation notes

- **Per-year fetches over \`?year=0\`**: year=0 returns 907 rows in one page with no inline year boundaries. Per-year carries explicit year context in the page header and the dates omit year — much safer.
- **\`parseHashtoryDate\` hand-rolled** instead of chrono — input is rigidly shaped (\"Sun Dec 26th\") and chrono's ambiguous-date heuristics are risky when year context lives in a separate variable (cf. \`feedback_chrono_forward_date_explicit_year.md\`).
- **Hares sorted deterministically** (per \`feedback_fingerprint_stability.md\`) so re-runs produce stable fingerprints regardless of source row order.
- **Pack list captured into description** for historical context (\"The Pack: Name, Name. Total 5.\").
- **\`startTime\` undefined** on historical rows (D14 atomic semantics).

## Ordering dependency

⚠️  **Apply this backfill ONLY after PR #1682 (runlist parser fix) is deployed.** Otherwise the merge pipeline routes 901 historical RawEvents through the same section-label bleed.

## Test plan

- [x] 19 fixture tests for hashtory parsing
- [x] Dry-run against live source → 901 events parsed, 0 errors
- [x] \`npx tsc --noEmit\` clean for new files
- [ ] Post-merge of #1682: \`BACKFILL_APPLY=1 npx tsx scripts/backfill-london-h3-history.ts\`
- [ ] Verify LH3 Past tab shows 800+ events; spot-check #1933 / #2383 / #2833
- [ ] Re-run script → all skipped (idempotency check)

Closes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)