### PR TITLE
feat(mh3-ca): mhhh.ca adapter + Apollo $XX leak fix + profile + backfill

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2898,9 +2898,12 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "mh3-ca", shortName: "MH3", fullName: "Montreal Hash House Harriers", region: "Montreal, QC", country: "Canada",
       website: "https://www.mhhh.ca",
+      contactEmail: "montrealhhh@gmail.com",
       scheduleDayOfWeek: "Sunday", scheduleTime: "1:00 PM", scheduleFrequency: "Weekly",
+      scheduleNotes: "Weekly Sunday 1pm runs year-round, with occasional Saturday and weeknight trails.",
+      hashCash: "$13",
       foundedYear: 1995,
-      description: "Montreal's weekly Sunday hash since 1995.",
+      description: "The Montreal Hash House Harriers (MH3) has been running weekly Sunday trails since 1995. Casual, easy-going vibe; visitors and virgins always welcome. Occasional Saturday and weeknight runs throughout the year.",
       latitude: 45.50, longitude: -73.57,
     },
 

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3909,6 +3909,22 @@ export const SOURCES = [
       },
       kennelCodes: ["mh3-ca"],
     },
+    {
+      // #1660: mhhh.ca exposes per-event hares + neighborhood that Meetup
+      // hides ("Location not specified yet"). Trust 9 (above Meetup's 7) so
+      // the website wins on conflicting fields. Hareline-only — historical
+      // /trash/YYYY/ archive is handled by scripts/backfill-mh3-ca-history.ts.
+      name: "MH3 Montreal Website Hareline",
+      url: "https://mhhh.ca/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 9,
+      scrapeFreq: "daily",
+      scrapeDays: 60,
+      config: {
+        kennelTag: "mh3-ca",
+      },
+      kennelCodes: ["mh3-ca"],
+    },
     // --- Toronto ---
     {
       name: "Hogtown H3 Meetup",

--- a/scripts/backfill-mh3-ca-history.ts
+++ b/scripts/backfill-mh3-ca-history.ts
@@ -155,6 +155,42 @@ export function parseYearIndex(html: string, year: number): IndexRow[] {
  * We flatten the body to text and use anchored label regexes. Returns an
  * empty object if no labels match — the caller falls back to the index row.
  */
+const ORDINAL_SUFFIXES = ["st", "nd", "rd", "th"];
+
+/**
+ * Strip ordinal day suffixes ("July 6th" → "July 6"). Procedural rather than
+ * `/(\d+)(?:st|nd|rd|th)\b/` per `feedback_sonar_s5852_procedural_over_regex.md`
+ * — the alternation + word-boundary pattern triggers SonarCloud S5852 as a
+ * potential backtracking shape. Walks the string once, swapping any
+ * digit-run + recognized suffix that lands at a non-letter boundary for just
+ * the digit run.
+ */
+function stripOrdinalSuffixes(input: string): string {
+  let out = "";
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+    if (ch >= "0" && ch <= "9") {
+      let j = i;
+      while (j < input.length && input[j] >= "0" && input[j] <= "9") j++;
+      out += input.slice(i, j);
+      const sfx = input.slice(j, j + 2).toLowerCase();
+      const after = input[j + 2];
+      const atBoundary = after === undefined
+        || !((after >= "a" && after <= "z") || (after >= "A" && after <= "Z"));
+      if (ORDINAL_SUFFIXES.includes(sfx) && atBoundary) {
+        i = j + 2;
+      } else {
+        i = j;
+      }
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
+}
+
 /**
  * Read a labelled line (e.g. `Date: …`, `Location: …`) out of a flattened
  * detail page. Procedural rather than regex per
@@ -212,7 +248,7 @@ export function parseDetailPage(html: string): DetailEnrichment {
     // label-line regexes).
     const atIdx = dateLine.indexOf("@");
     const beforeAt = atIdx >= 0 ? dateLine.slice(0, atIdx) : dateLine;
-    const dateOnly = beforeAt.replace(/(\d+)(?:st|nd|rd|th)\b/gi, "$1").trim();
+    const dateOnly = stripOrdinalSuffixes(beforeAt).trim();
     date = chronoParseDate(dateOnly) ?? undefined;
   }
 

--- a/scripts/backfill-mh3-ca-history.ts
+++ b/scripts/backfill-mh3-ca-history.ts
@@ -155,24 +155,46 @@ export function parseYearIndex(html: string, year: number): IndexRow[] {
  * We flatten the body to text and use anchored label regexes. Returns an
  * empty object if no labels match — the caller falls back to the index row.
  */
+/**
+ * Read a labelled line (e.g. `Date: …`, `Location: …`) out of a flattened
+ * detail page. Procedural rather than regex per
+ * `feedback_sonar_s5852_procedural_over_regex.md` — `^\s*Label\s*:\s*(...)`
+ * shapes get flagged by SonarCloud S5852 even when linear in practice.
+ */
+function readLabelledLine(text: string, label: string): string | undefined {
+  const needle = `${label.toLowerCase()}:`;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trimStart();
+    if (line.toLowerCase().startsWith(needle)) {
+      return line.slice(label.length + 1).trim();
+    }
+  }
+  return undefined;
+}
+
 export function parseDetailPage(html: string): DetailEnrichment {
   const $ = cheerio.load(html);
   // Replace <br> with newline so label regexes can terminate at line ends.
   $("br").replaceWith("\n");
   const text = $("body").text().replace(/&nbsp;/gi, " ").replace(/ /g, " ");
 
-  const dateLineMatch = text.match(/^\s*Date\s*:\s*([^\n]+)/im);
-  const locLineMatch = text.match(/^\s*Location\s*:\s*([^\n]+)/im);
-  const haresLineMatch = text.match(/^\s*Hares?\s*:\s*([^\n]+)/im);
+  // Label-line extraction is procedural (not regex) per
+  // `feedback_sonar_s5852_procedural_over_regex.md` — `^\s*Label\s*:\s*(...)`
+  // shapes get flagged by SonarCloud S5852 as backtracking-prone even when
+  // linear in practice. The archive uses both "Hares:" and singular "Hare:"
+  // interchangeably; readLabelledLine() probes the longer form first so the
+  // "Hare:" prefix doesn't shadow real "Hares: ..." rows.
+  const dateLine = readLabelledLine(text, "Date");
+  const locLine = readLabelledLine(text, "Location");
+  const haresLine = readLabelledLine(text, "Hares") ?? readLabelledLine(text, "Hare");
 
   let date: string | undefined;
   let startTime: string | undefined;
-  if (dateLineMatch) {
-    const dateText = dateLineMatch[1].trim();
+  if (dateLine) {
     // Extract "@ HH:MM[AM/PM]" before parsing — chrono handles full dates but
     // its time parsing is inconsistent across the archive's 30 years of
     // typographic variation. Strip the time fragment and parse date alone.
-    const timeMatch = dateText.match(/(\d{1,2})(?::(\d{2}))?\s*([AaPp]\.?\s*[Mm]\.?)/);
+    const timeMatch = dateLine.match(/(\d{1,2})(?::(\d{2}))?\s*([AaPp]\.?\s*[Mm]\.?)/);
     if (timeMatch) {
       let h = parseInt(timeMatch[1], 10);
       const m = timeMatch[2] ? parseInt(timeMatch[2], 10) : 0;
@@ -184,23 +206,28 @@ export function parseDetailPage(html: string): DetailEnrichment {
       }
     }
     // Strip ordinal suffixes ("July 6th" → "July 6") which chrono handles but
-    // also strip the time fragment to keep the parse focused on the date.
-    const dateOnly = dateText
-      .replace(/(\d+)(st|nd|rd|th)\b/gi, "$1")
-      .replace(/@.*$/, "")
-      .trim();
+    // also strip the @-time fragment to keep the parse focused on the date.
+    // indexOf("@") instead of /@.*$/ — keeps Sonar S5852 clean (bare-greedy
+    // anchored regex falls under the same DoS-shape rule that hit the
+    // label-line regexes).
+    const atIdx = dateLine.indexOf("@");
+    const beforeAt = atIdx >= 0 ? dateLine.slice(0, atIdx) : dateLine;
+    const dateOnly = beforeAt.replace(/(\d+)(?:st|nd|rd|th)\b/gi, "$1").trim();
     date = chronoParseDate(dateOnly) ?? undefined;
   }
 
-  const location = locLineMatch?.[1].trim() || undefined;
+  const location = locLine || undefined;
 
   // Hares are comma-separated on the detail page. Sort before joining for
   // fingerprint stability (feedback_fingerprint_stability.md).
   let hares: string | undefined;
-  if (haresLineMatch) {
-    const parts = haresLineMatch[1]
+  if (haresLine) {
+    const parts = haresLine
       .split(",")
-      .map((s) => s.replace(/\bAnd\b/g, "").trim())
+      // Case-insensitive strip of stray "and" connectors ("Yogi, and LBM" →
+      // "Yogi, LBM"). gemini-code-assist flag on PR #1688: the original
+      // `/\bAnd\b/g` only matched capitalized form.
+      .map((s) => s.replace(/\band\b/gi, "").trim())
       .filter((s) => s.length > 0 && !/^(?:tbd|tba)$/i.test(s));
     if (parts.length > 0) {
       parts.sort((a, b) => a.localeCompare(b, "en"));

--- a/scripts/backfill-mh3-ca-history.ts
+++ b/scripts/backfill-mh3-ca-history.ts
@@ -1,0 +1,275 @@
+/**
+ * One-shot historical backfill for MH3 Montreal (#1661).
+ *
+ * Premise from the issue body: kennel founded 1995, latest visible run #1688
+ * (May 2026), ~1500 runs total expected. Reality after probing the source:
+ *
+ *   - mhhh.ca/trash/YYYY/index.html exists for 1996-2008 inclusive (1995 and
+ *     2009+ both return 404). Index pages list rows of
+ *     `<a href="trashNNN.htm">Run #NNN / Location</a>` + `Month YYYY`.
+ *   - Per-run detail pages (`trashNNN.htm`) carry a fuller date
+ *     ("Sunday, July 6th, 2008 @ 1:00PM"), the verbatim location, and the
+ *     hare list ("Yogi, Little Big Man, Anon"). Not every row has all three.
+ *   - Total reachable rows across 1996-2008 is ~115 — not 1500. Runs after
+ *     2008 are visible only through the Meetup public API, which is the
+ *     `Montreal H3 Meetup` source. A separate `scripts/backfill-meetup-history.ts`
+ *     run can crawl Meetup's `?type=past` archive when the operator wants
+ *     the 2009-2025 gap closed.
+ *
+ * This script crawls only the mhhh.ca trash archive. Per-row date precision
+ * is month-only from the index, so we fetch each detail page to upgrade to
+ * day precision when available (rate-limited to one request every 500ms to
+ * be a good citizen on a Cloudflare-fronted hobby site). Detail-page fetch
+ * failures fall back to YYYY-MM-15 (mid-month) so the row still anchors to
+ * the correct month.
+ *
+ * Bound to source: "MH3 Montreal Website Hareline" (the HTML_SCRAPER row
+ * added in the same PR). Past dates only — adapter handles `>= CURDATE()`.
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-mh3-ca-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-mh3-ca-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { chronoParseDate } from "@/adapters/utils";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "MH3 Montreal Website Hareline";
+const KENNEL_TIMEZONE = "America/Montreal";
+const SITE_BASE = "https://mhhh.ca";
+const FIRST_YEAR = 1996;
+const LAST_YEAR = 2008; // 2009+ returns 404 — archive stopped being maintained
+const DETAIL_RATE_LIMIT_MS = 500;
+
+interface IndexRow {
+  runNumber: number;
+  /** Location text after the slash in "Run #N / Location". */
+  rowLocation?: string;
+  /** Month-only fallback when the detail page is unreachable. */
+  monthDate: string; // YYYY-MM-15
+  /** Absolute URL of the trashNNN.htm detail page. */
+  detailUrl: string;
+}
+
+interface DetailEnrichment {
+  /** YYYY-MM-DD with day precision. */
+  date?: string;
+  /** "1:00 PM" → "13:00", normalized 24h. */
+  startTime?: string;
+  location?: string;
+  hares?: string;
+}
+
+async function fetchText(url: string): Promise<string | null> {
+  try {
+    const res = await safeFetch(url, {
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" },
+    });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a year-index page into rows. The archive's hand-edited HTML is
+ * inconsistent (mixed quotes, broken nesting, multi-run "#258-#259" weekend
+ * entries), so we walk anchors instead of relying on table structure: any
+ * `<a href="trashNNN.htm">` is a row, and we look for a sibling `<td>`
+ * carrying the "Month YYYY" string.
+ *
+ * Multi-run rows (e.g. "Runs #258-#259 / Apple Hill ITCH") get the leading
+ * run number only; the secondary run gets its own row from `Run #259`
+ * already in the archive elsewhere, so we don't synthesize duplicates here.
+ */
+export function parseYearIndex(html: string, year: number): IndexRow[] {
+  const $ = cheerio.load(html);
+  const rows: IndexRow[] = [];
+  $("a[href]").each((_, el) => {
+    const href = $(el).attr("href") ?? "";
+    const fileMatch = href.match(/^trash(\d+)\.htm$/i);
+    if (!fileMatch) return;
+
+    const text = $(el).text().replace(/\s+/g, " ").trim();
+    const runMatch = text.match(/run(?:s)?\s*#\s*(\d+)/i);
+    if (!runMatch) return;
+    const runNumber = parseInt(runMatch[1], 10);
+    if (!Number.isFinite(runNumber) || runNumber <= 0) return;
+
+    // Location is the text after the first slash, when present.
+    const slashIdx = text.indexOf("/");
+    const rowLocation = slashIdx >= 0 ? text.slice(slashIdx + 1).trim() : undefined;
+
+    // Find the "Month YYYY" sibling cell. The archive almost always places it
+    // in the next <td> after the anchor's <td>, but the markup is sloppy
+    // enough that we walk the row's text fallback as a safety net.
+    const $row = $(el).closest("tr");
+    const rowText = $row.text().replace(/\s+/g, " ").trim();
+    const monthMatch = rowText.match(
+      /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})\b/i,
+    );
+    const month = monthMatch?.[1];
+    const rowYear = monthMatch ? parseInt(monthMatch[2], 10) : year;
+
+    if (!month) return; // Skip rows we can't anchor to a month.
+    const isoMonth = new Date(`${month} 15, ${rowYear} 12:00:00 UTC`);
+    if (Number.isNaN(isoMonth.getTime())) return;
+
+    // The detail file lives under the YEAR PAGE'S directory, not the year
+    // parsed from the row's "Month YYYY" cell. Some year-index pages list a
+    // late-prior-year or early-next-year run (e.g. a Dec 2001 run referenced
+    // from /trash/2002/index.html). Codex caught this — without using `year`
+    // here, those rows would 404 silently and fall back to month-precise.
+    rows.push({
+      runNumber,
+      rowLocation: rowLocation && rowLocation.length > 0 ? rowLocation : undefined,
+      monthDate: isoMonth.toISOString().slice(0, 10),
+      detailUrl: `${SITE_BASE}/trash/${year}/${fileMatch[0]}`,
+    });
+  });
+
+  // De-dupe within the year — the archive sometimes lists the same row twice
+  // in different table layouts. Keep the first occurrence.
+  const seen = new Set<number>();
+  return rows.filter((r) => {
+    if (seen.has(r.runNumber)) return false;
+    seen.add(r.runNumber);
+    return true;
+  });
+}
+
+/**
+ * Pull date + hares + location out of a trashNNN.htm detail page. The format
+ * is hand-edited HTML with field labels broken by `<br>` tags, e.g.
+ *
+ *   Date: Sunday, July 6th, 2008 @ 1:00PM<br>
+ *   Location: Sainte-Anne-de-Bellevue<br>
+ *   Hares: Yogi, Little Big Man, Anon
+ *
+ * We flatten the body to text and use anchored label regexes. Returns an
+ * empty object if no labels match — the caller falls back to the index row.
+ */
+export function parseDetailPage(html: string): DetailEnrichment {
+  const $ = cheerio.load(html);
+  // Replace <br> with newline so label regexes can terminate at line ends.
+  $("br").replaceWith("\n");
+  const text = $("body").text().replace(/&nbsp;/gi, " ").replace(/ /g, " ");
+
+  const dateLineMatch = text.match(/^\s*Date\s*:\s*([^\n]+)/im);
+  const locLineMatch = text.match(/^\s*Location\s*:\s*([^\n]+)/im);
+  const haresLineMatch = text.match(/^\s*Hares?\s*:\s*([^\n]+)/im);
+
+  let date: string | undefined;
+  let startTime: string | undefined;
+  if (dateLineMatch) {
+    const dateText = dateLineMatch[1].trim();
+    // Extract "@ HH:MM[AM/PM]" before parsing — chrono handles full dates but
+    // its time parsing is inconsistent across the archive's 30 years of
+    // typographic variation. Strip the time fragment and parse date alone.
+    const timeMatch = dateText.match(/(\d{1,2})(?::(\d{2}))?\s*([AaPp]\.?\s*[Mm]\.?)/);
+    if (timeMatch) {
+      let h = parseInt(timeMatch[1], 10);
+      const m = timeMatch[2] ? parseInt(timeMatch[2], 10) : 0;
+      const isPm = /p/i.test(timeMatch[3]);
+      if (isPm && h < 12) h += 12;
+      if (!isPm && h === 12) h = 0;
+      if (h >= 0 && h <= 23 && m >= 0 && m <= 59) {
+        startTime = `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
+      }
+    }
+    // Strip ordinal suffixes ("July 6th" → "July 6") which chrono handles but
+    // also strip the time fragment to keep the parse focused on the date.
+    const dateOnly = dateText
+      .replace(/(\d+)(st|nd|rd|th)\b/gi, "$1")
+      .replace(/@.*$/, "")
+      .trim();
+    date = chronoParseDate(dateOnly) ?? undefined;
+  }
+
+  const location = locLineMatch?.[1].trim() || undefined;
+
+  // Hares are comma-separated on the detail page. Sort before joining for
+  // fingerprint stability (feedback_fingerprint_stability.md).
+  let hares: string | undefined;
+  if (haresLineMatch) {
+    const parts = haresLineMatch[1]
+      .split(",")
+      .map((s) => s.replace(/\bAnd\b/g, "").trim())
+      .filter((s) => s.length > 0 && !/^(?:tbd|tba)$/i.test(s));
+    if (parts.length > 0) {
+      parts.sort((a, b) => a.localeCompare(b, "en"));
+      hares = parts.join(", ");
+    }
+  }
+
+  return { date, startTime, location, hares };
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const allRows: IndexRow[] = [];
+  for (let year = FIRST_YEAR; year <= LAST_YEAR; year++) {
+    const url = `${SITE_BASE}/trash/${year}/index.html`;
+    process.stdout.write(`  Year ${year}: fetching ${url} ...`);
+    const html = await fetchText(url);
+    if (!html) {
+      console.log(" 404 / skipped");
+      continue;
+    }
+    const rows = parseYearIndex(html, year);
+    allRows.push(...rows);
+    console.log(` ${rows.length} rows`);
+  }
+  console.log(`\n  Total index rows: ${allRows.length}. Now enriching from detail pages...`);
+
+  const events: RawEventData[] = [];
+  let detailHits = 0;
+  let detailMisses = 0;
+  for (const row of allRows) {
+    // Rate-limit detail-page fetches. Cloudflare can throttle aggressive
+    // crawlers on small hobby sites.
+    await new Promise((resolve) => setTimeout(resolve, DETAIL_RATE_LIMIT_MS));
+    const detailHtml = await fetchText(row.detailUrl);
+    const detail = detailHtml ? parseDetailPage(detailHtml) : {};
+    // Guard: chrono can mis-parse the archive's idiosyncratic prose dates
+    // (e.g. "Date:  Fri.-Mon., Oct. 5th-8th, 2001." on the trash258 weekend
+    // event page resolves relative to today's reference date and returns a
+    // 2026 timestamp). Trust the detail-page date only when it lands in the
+    // same calendar year as the index row's "Month YYYY" cell; otherwise
+    // fall back to month-precise YYYY-MM-15.
+    const monthYearPrefix = row.monthDate.slice(0, 4);
+    const detailYear = detail.date?.slice(0, 4);
+    const dateFromDetail = detail.date && detailYear === monthYearPrefix ? detail.date : undefined;
+    if (dateFromDetail) detailHits++;
+    else detailMisses++;
+
+    events.push({
+      date: dateFromDetail ?? row.monthDate,
+      kennelTags: ["mh3-ca"],
+      runNumber: row.runNumber,
+      startTime: detail.startTime,
+      hares: detail.hares,
+      location: detail.location ?? row.rowLocation,
+      sourceUrl: row.detailUrl,
+    });
+  }
+  console.log(
+    `  Detail enrichment: ${detailHits} hits (day-precise) / ${detailMisses} misses (month-precise fallback)`,
+  );
+  return events;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Walking mhhh.ca /trash/ archive (1996-2008)",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-mh3-ca-stale-descriptions.ts
+++ b/scripts/cleanup-mh3-ca-stale-descriptions.ts
@@ -1,0 +1,123 @@
+/**
+ * One-shot cleanup for #1659: the Meetup adapter previously passed bare Apollo
+ * back-references (e.g. `$44`, `$43`, `$3f`) through to canonical Event
+ * descriptions when Meetup's __APOLLO_STATE__ deduplicated the boilerplate
+ * description string to another cache key. The adapter fix in this same PR
+ * stops new leaks (resolves the ref or emits null), but ~6+ canonical Event
+ * rows for mh3-ca and any other Meetup-fed kennels still carry the literal
+ * `$XX` shape until they're re-scraped.
+ *
+ * Provenance guard:
+ *   - Canonical Event.description must match the leak shape /^\$[0-9a-fA-F]+$/.
+ *   - The leak is Meetup-specific (only the Meetup adapter wrote a raw Apollo
+ *     ref into description). Scope to RawEvents from MEETUP-typed sources so
+ *     coincidental `$XX` text from a hypothetical other adapter is left alone.
+ *
+ * Runs in dry-run mode by default — pass `--apply` to write.
+ *   npx tsx scripts/cleanup-mh3-ca-stale-descriptions.ts            # preview
+ *   npx tsx scripts/cleanup-mh3-ca-stale-descriptions.ts --apply
+ */
+import "dotenv/config";
+import { prisma } from "../src/lib/db";
+
+const APPLY = process.argv.includes("--apply");
+
+// Tight ASCII-only regex matching the leak shape. Anchored both ends so we
+// never null-out a legitimate description that merely starts with `$XX`.
+// Same regex used in the merge-pipeline guard in src/adapters/meetup/adapter.ts.
+const APOLLO_REF_RE = /^\$[0-9a-fA-F]+$/;
+
+async function main() {
+  // RawEvents from any MEETUP source whose stored description matches the
+  // leak shape. JSON field path traversal is the Postgres-compatible way to
+  // query Json columns in Prisma.
+  const meetupSources = await prisma.source.findMany({
+    where: { type: "MEETUP" },
+    select: { id: true, name: true },
+  });
+  if (meetupSources.length === 0) {
+    console.log("No MEETUP sources found — nothing to scan.");
+    return;
+  }
+
+  console.log(`Scanning ${meetupSources.length} MEETUP source(s) for stale $XX descriptions.`);
+
+  // Canonical Events to clear. Linked through RawEvent provenance.
+  const rawEvents = await prisma.rawEvent.findMany({
+    where: {
+      sourceId: { in: meetupSources.map((s) => s.id) },
+      eventId: { not: null },
+      event: { description: { not: null } },
+    },
+    select: {
+      rawData: true,
+      event: {
+        select: {
+          id: true,
+          description: true,
+          kennel: { select: { kennelCode: true } },
+        },
+      },
+    },
+  });
+
+  let skipped = 0;
+  const eventIdsToClear = new Set<string>();
+
+  for (const re of rawEvents) {
+    if (!re.event) continue;
+    const raw = re.rawData as { description?: unknown } | null;
+    const rawDescription = typeof raw?.description === "string" ? raw.description : null;
+
+    // Provenance check: a MEETUP RawEvent whose raw.description is a $XX
+    // back-ref AND whose canonical Event.description matches that same ref.
+    // Both must hold so we don't clear a description sourced from another
+    // adapter that happened to merge first.
+    if (
+      rawDescription === null ||
+      !APOLLO_REF_RE.test(rawDescription) ||
+      re.event.description !== rawDescription
+    ) {
+      skipped++;
+      continue;
+    }
+
+    if (!eventIdsToClear.has(re.event.id)) {
+      console.log(
+        `  CLEAR canonical ${re.event.id} (${re.event.kennel?.kennelCode ?? "?"}): description="${re.event.description}"`,
+      );
+      eventIdsToClear.add(re.event.id);
+    }
+  }
+
+  console.log(
+    `\nFound ${eventIdsToClear.size} canonical Event(s) carrying the $XX leak shape. (${skipped} other rows skipped — provenance did not match.)`,
+  );
+
+  // We deliberately do NOT touch RawEvent.rawData here — CLAUDE.md requires
+  // RawEvents to remain an immutable audit trail. The adapter fix in this PR
+  // stops new $XX entries from being written; the next scrape will create
+  // fresh RawEvents whose merge replaces the canonical Event.description.
+  // This script just clears the canonical UI value in advance so users don't
+  // see the corruption between deploy and next-scrape.
+
+  let canonicalCleared = 0;
+  if (APPLY && eventIdsToClear.size > 0) {
+    const res = await prisma.event.updateMany({
+      where: { id: { in: [...eventIdsToClear] } },
+      data: { description: null },
+    });
+    canonicalCleared = res.count;
+  }
+
+  const verb = APPLY ? "Cleared" : "Would clear";
+  console.log(`\n${verb} ${APPLY ? canonicalCleared : eventIdsToClear.size} canonical Event.description value(s).`);
+  if (!APPLY) console.log("Dry-run only. Re-run with --apply to write changes.");
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/mhhh-ca.test.ts
+++ b/src/adapters/html-scraper/mhhh-ca.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDateTimeCost,
+  parseHaresField,
+  parseLocationField,
+  parseMhhhHareline,
+} from "./mhhh-ca";
+
+// Fixture taken verbatim from a live `curl https://mhhh.ca/` capture
+// (ISO-8859 source; &nbsp; entities preserved). Five upcoming-event rows.
+// Trimmed to just the comment-anchored cells the parser needs; the rest of
+// the chrome is dropped since the parser keys on <!--RunNumber--> boundaries.
+const LIVE_HARELINE_FIXTURE = String.raw`
+<html><body>
+<table>
+<tr>
+  <td>filler row before any events</td>
+</tr>
+<tr><td><!--RunNumber --><b> RUN #1684</b></td></tr>
+<tr><td><!--RunTitle--></td></tr>
+<tr><td><!--DateTimeCost -->May 3, 2026&nbsp;13h00 $13</td></tr>
+<tr><td><!--HaresList -->Broken Thong</td></tr>
+<tr><td><!--Location -->Sainte-Marie <a target="_blank" href="https://www.meetup.com/montreal-hash-house-harriers/events/314379548">Click for directions</a></td></tr>
+
+<tr><td><!--RunNumber --><b> RUN #1685</b></td></tr>
+<tr><td><!--RunTitle--></td></tr>
+<tr><td><!--DateTimeCost -->May 10, 2026&nbsp;13h00 $13</td></tr>
+<tr><td><!--HaresList -->Alice; Wonderland; Just Raia</td></tr>
+<tr><td><!--Location -->Plateau Mont-Royal <a target="_blank" href="https://www.meetup.com/montreal-hash-house-harriers/events/314543769">Click for directions</a></td></tr>
+
+<tr><td><!--RunNumber --><b> RUN #1686</b></td></tr>
+<tr><td><!--RunTitle--></td></tr>
+<tr><td><!--DateTimeCost -->May 17, 2026&nbsp;13h00 $13</td></tr>
+<tr><td><!--HaresList -->No Glove No Love</td></tr>
+<tr><td><!--Location -->TBD <a target="_blank" href="https://www.meetup.com/montreal-hash-house-harriers/events/314618083">Click for directions</a></td></tr>
+</table>
+</body></html>
+`;
+
+describe("parseDateTimeCost", () => {
+  it("parses date + 24h time + cost from the standard hareline cell", () => {
+    const out = parseDateTimeCost("May 3, 2026 13h00 $13");
+    expect(out).toEqual({ date: "2026-05-03", startTime: "13:00", cost: "$13" });
+  });
+
+  it("normalizes &nbsp; between date and time", () => {
+    const out = parseDateTimeCost("May 3, 2026&nbsp;13h00 $13");
+    expect(out?.date).toBe("2026-05-03");
+    expect(out?.startTime).toBe("13:00");
+  });
+
+  it("accepts a cost without a time", () => {
+    const out = parseDateTimeCost("June 7, 2026 $15");
+    expect(out).toEqual({ date: "2026-06-07", startTime: undefined, cost: "$15" });
+  });
+
+  it("rejects rows without a parseable date", () => {
+    expect(parseDateTimeCost("")).toBeNull();
+    expect(parseDateTimeCost("TBD")).toBeNull();
+  });
+
+  it("rejects nonsensical times (25h99) by leaving startTime undefined", () => {
+    const out = parseDateTimeCost("May 3, 2026 25h99 $13");
+    expect(out?.startTime).toBeUndefined();
+  });
+});
+
+describe("parseHaresField", () => {
+  it("returns a single hare verbatim", () => {
+    expect(parseHaresField("Broken Thong")).toBe("Broken Thong");
+  });
+
+  it("sorts a semicolon-separated list for fingerprint stability", () => {
+    // Source order: Alice; Wonderland; Just Raia (J before W lexicographically).
+    expect(parseHaresField("Alice; Wonderland; Just Raia")).toBe(
+      "Alice, Just Raia, Wonderland",
+    );
+  });
+
+  it("collapses TBD/TBA/Hares Needed placeholders to undefined", () => {
+    expect(parseHaresField("TBD")).toBeUndefined();
+    expect(parseHaresField("Hare needed")).toBeUndefined();
+    expect(parseHaresField("Hares Required")).toBeUndefined();
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(parseHaresField(undefined)).toBeUndefined();
+    expect(parseHaresField("")).toBeUndefined();
+    expect(parseHaresField("   ")).toBeUndefined();
+  });
+});
+
+describe("parseLocationField", () => {
+  it("returns the neighborhood text", () => {
+    expect(parseLocationField("Sainte-Marie")).toBe("Sainte-Marie");
+  });
+
+  it("strips the trailing 'Click for directions' link text", () => {
+    expect(parseLocationField("Plateau Mont-Royal Click for directions")).toBe(
+      "Plateau Mont-Royal",
+    );
+  });
+
+  it("omits TBD placeholders so the UI shows 'venue TBD'", () => {
+    expect(parseLocationField("TBD")).toBeUndefined();
+    expect(parseLocationField("TBA")).toBeUndefined();
+    expect(parseLocationField("tbd.")).toBeUndefined();
+  });
+});
+
+describe("parseMhhhHareline", () => {
+  it("emits one RawEvent per <!--RunNumber--> block, with hares and locations", () => {
+    const events = parseMhhhHareline(LIVE_HARELINE_FIXTURE, "https://mhhh.ca/");
+
+    expect(events).toHaveLength(3);
+
+    expect(events[0]).toMatchObject({
+      date: "2026-05-03",
+      kennelTags: ["mh3-ca"],
+      runNumber: 1684,
+      startTime: "13:00",
+      cost: "$13",
+      hares: "Broken Thong",
+      location: "Sainte-Marie",
+      sourceUrl: "https://www.meetup.com/montreal-hash-house-harriers/events/314379548",
+    });
+
+    // Sorted hares regardless of source-row order.
+    expect(events[1].hares).toBe("Alice, Just Raia, Wonderland");
+    expect(events[1].location).toBe("Plateau Mont-Royal");
+    expect(events[1].runNumber).toBe(1685);
+
+    // TBD location is dropped to undefined (not stored as literal "TBD").
+    expect(events[2].runNumber).toBe(1686);
+    expect(events[2].location).toBeUndefined();
+    expect(events[2].hares).toBe("No Glove No Love");
+  });
+
+  it("returns an empty list when no <!--RunNumber--> markers exist", () => {
+    expect(parseMhhhHareline("<html><body><p>no events</p></body></html>", "https://mhhh.ca/")).toEqual([]);
+  });
+
+  it("skips chunks where RUN # can't be extracted", () => {
+    const malformed = `
+      <!--RunNumber --><b>RUN # broken</b>
+      <!--DateTimeCost -->May 3, 2026 13h00 $13
+      <!--HaresList -->Test
+      <!--Location -->Somewhere</td>
+    `;
+    expect(parseMhhhHareline(malformed, "https://mhhh.ca/")).toEqual([]);
+  });
+
+  it("falls back to mhhh.ca itself when the Location cell has no Meetup link", () => {
+    const noLink = String.raw`
+      <!--RunNumber --><b> RUN #2000</b>
+      <!--DateTimeCost -->January 4, 2027 13h00 $13
+      <!--HaresList -->Test Hare
+      <!--Location -->Old Port</td>
+    `;
+    const events = parseMhhhHareline(noLink, "https://mhhh.ca/");
+    expect(events).toHaveLength(1);
+    expect(events[0].sourceUrl).toBe("https://mhhh.ca/");
+  });
+});

--- a/src/adapters/html-scraper/mhhh-ca.test.ts
+++ b/src/adapters/html-scraper/mhhh-ca.test.ts
@@ -54,6 +54,17 @@ describe("parseDateTimeCost", () => {
     expect(out).toEqual({ date: "2026-06-07", startTime: undefined, cost: "$15" });
   });
 
+  it("accepts Québécois suffix-dollar notation (13$ / 13 $)", () => {
+    // gemini-code-assist flag on PR #1688: French-Canadian sites commonly
+    // place the dollar sign after the amount. Strip both forms so the cost
+    // doesn't leak into the date-parse remainder.
+    expect(parseDateTimeCost("May 3, 2026 13h00 13$")?.cost).toBe("13$");
+    expect(parseDateTimeCost("May 3, 2026 13h00 13 $")?.cost).toBe("13 $");
+    expect(parseDateTimeCost("May 3, 2026 13h00 13,50 $")?.cost).toBe("13,50 $");
+    // Date still parses cleanly after the cost is stripped.
+    expect(parseDateTimeCost("May 3, 2026 13h00 13$")?.date).toBe("2026-05-03");
+  });
+
   it("rejects rows without a parseable date", () => {
     expect(parseDateTimeCost("")).toBeNull();
     expect(parseDateTimeCost("TBD")).toBeNull();

--- a/src/adapters/html-scraper/mhhh-ca.ts
+++ b/src/adapters/html-scraper/mhhh-ca.ts
@@ -1,0 +1,220 @@
+/**
+ * Montreal Hash House Harriers (MH3) — mhhh.ca HTML scraper.
+ *
+ * mhhh.ca is hand-edited static HTML (FrontPage-era markup, ISO-8859). The
+ * upcoming hareline at `/index.htm` carries per-event fields under stable
+ * HTML-comment anchors:
+ *
+ *     <!--RunNumber --><b> RUN #1684</b>
+ *     <!--RunTitle-->                       (optional theme)
+ *     <!--DateTimeCost -->May 3, 2026&nbsp;13h00 $13
+ *     <!--HaresList -->Broken Thong
+ *     <!--Location -->Sainte-Marie <a href="https://www.meetup.com/...">…</a>
+ *
+ * Issue #1660: Meetup returns "Location not specified yet" for many upcoming
+ * mh3-ca events because the organizers fill mhhh.ca first. This adapter pulls
+ * the neighborhood + hares directly and ships at trustLevel 9 (above the
+ * Meetup source's 7) so it wins on conflicting fields. Cross-source dedup
+ * happens via (kennelTag, date, runNumber) fingerprint in the merge pipeline.
+ *
+ * Hareline detail pages (`/trash/YYYY/trashNNN.htm`) and the year-indexed
+ * archive (`/trash/YYYY/index.html`) are NOT touched here — historical backfill
+ * is `scripts/backfill-mh3-ca-history.ts` instead, so the cron stays cheap.
+ */
+
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
+import { hasAnyErrors } from "../types";
+import { chronoParseDate, fetchHTMLPage, buildDateWindow } from "../utils";
+
+const KENNEL_TAG = "mh3-ca";
+
+/**
+ * Parse "May 3, 2026 13h00 $13" (with optional time and cost) into structured
+ * fields. The 24-hour `13h00` notation is Québec convention; time and cost are
+ * both optional — the hareline occasionally lists date-only "TBD" rows.
+ *
+ * Returns null when no date can be extracted (the event is unusable downstream).
+ */
+export function parseDateTimeCost(raw: string): {
+  date: string;
+  startTime?: string;
+  cost?: string;
+} | null {
+  const cleaned = raw.replace(/&nbsp;/gi, " ").replace(/ /g, " ").trim();
+  if (!cleaned) return null;
+
+  // Extract & strip the time ("13h00") so chrono doesn't choke on the `h`.
+  let timeRest = cleaned;
+  let startTime: string | undefined;
+  const timeMatch = cleaned.match(/\b(\d{1,2})\s*h\s*(\d{2})\b/i);
+  if (timeMatch) {
+    const h = parseInt(timeMatch[1], 10);
+    const m = parseInt(timeMatch[2], 10);
+    if (h >= 0 && h <= 23 && m >= 0 && m <= 59) {
+      startTime = `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
+    }
+    timeRest = cleaned.replace(timeMatch[0], " ").trim();
+  }
+
+  // Extract & strip the cost ($13 / $13.50 / $13 cash).
+  let dateRest = timeRest;
+  let cost: string | undefined;
+  const costMatch = timeRest.match(/\$\d+(?:\.\d{2})?(?:\s*(?:cash|cad|usd)\b)?/i);
+  if (costMatch) {
+    cost = costMatch[0].trim();
+    dateRest = timeRest.replace(costMatch[0], " ").trim();
+  }
+
+  const date = chronoParseDate(dateRest);
+  if (!date) return null;
+
+  return { date, startTime, cost };
+}
+
+/**
+ * Split a "Hare1; Hare2; Just Raia" cell into a sorted comma-joined string.
+ * Sorting before join is required for stable fingerprints across scrapes —
+ * see `feedback_fingerprint_stability.md` (Seletar duplicated 74 RawEvents
+ * because hare order was nondeterministic).
+ *
+ * Recognized placeholders ("TBD", "Hare needed", etc.) collapse to undefined
+ * so canonical Event.haresText doesn't end up storing the prompt as a name.
+ */
+export function parseHaresField(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const cleaned = raw.replace(/&nbsp;/gi, " ").trim();
+  if (!cleaned) return undefined;
+  if (/^(?:tbd|tba|tbc|hare(?:s)?\s+needed|hare(?:s)?\s+required)\??$/i.test(cleaned)) {
+    return undefined;
+  }
+  const parts = cleaned
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (parts.length === 0) return undefined;
+  parts.sort((a, b) => a.localeCompare(b, "en"));
+  return parts.join(", ");
+}
+
+/**
+ * Strip the `Click for directions` link text from a Location cell so we keep
+ * just the neighborhood ("Sainte-Marie", "Plateau Mont-Royal"). Apply the
+ * standard TBD-omit guard so placeholders don't surface on the UI.
+ */
+export function parseLocationField(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const cleaned = raw
+    .replace(/&nbsp;/gi, " ")
+    .replace(/click\s+for\s+directions/i, "")
+    .trim();
+  if (!cleaned) return undefined;
+  if (/^(?:tbd|tba|tbc)\.?$/i.test(cleaned)) return undefined;
+  return cleaned;
+}
+
+/**
+ * Split the hareline HTML into per-event chunks on the <!--RunNumber-->
+ * boundary and parse each. Exported for unit tests.
+ *
+ * Per-event `sourceUrl` prefers the Meetup event URL from the location cell
+ * when present (helps the merge pipeline correlate against the MEETUP source),
+ * otherwise falls back to the mhhh.ca page itself.
+ */
+export function parseMhhhHareline(html: string, sourceUrl: string): RawEventData[] {
+  const events: RawEventData[] = [];
+  // The first segment before the first <!--RunNumber--> marker is page chrome.
+  const chunks = html.split(/<!--\s*RunNumber\s*-->/i).slice(1);
+
+  for (const chunk of chunks) {
+    const runMatch = chunk.match(/RUN\s*#\s*(\d+)/i);
+    if (!runMatch) continue;
+    const runNumber = parseInt(runMatch[1], 10);
+    if (!Number.isFinite(runNumber) || runNumber <= 0) continue;
+
+    const dtcMatch = chunk.match(/<!--\s*DateTimeCost\s*-->([^<]*)/i);
+    if (!dtcMatch) continue;
+    const dtc = parseDateTimeCost(dtcMatch[1]);
+    if (!dtc) continue;
+
+    const haresMatch = chunk.match(/<!--\s*HaresList\s*-->([^<]*)/i);
+    const hares = parseHaresField(haresMatch?.[1]);
+
+    const locMatch = chunk.match(/<!--\s*Location\s*-->([\s\S]*?)<\/td>/i);
+    // Strip the `Click for directions` <a> from the Location cell before parsing.
+    const locText = locMatch
+      ? locMatch[1].replace(/<a\b[\s\S]*?<\/a>/gi, "").trim()
+      : undefined;
+    const location = parseLocationField(locText);
+
+    // Prefer the Meetup event URL embedded in the directions link; other hrefs
+    // (e.g. Google Maps) are ignored so we always fall back to mhhh.ca itself.
+    const meetupHrefMatch = locMatch?.[1].match(
+      /href="(https?:\/\/(?:www\.)?meetup\.com\/[^"]+)"/i,
+    );
+    const eventSourceUrl = meetupHrefMatch?.[1] ?? sourceUrl;
+
+    events.push({
+      date: dtc.date,
+      kennelTags: [KENNEL_TAG],
+      runNumber,
+      startTime: dtc.startTime,
+      cost: dtc.cost,
+      hares,
+      location,
+      sourceUrl: eventSourceUrl,
+    });
+  }
+
+  return events;
+}
+
+export class MhhhCaAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    const sourceUrl = source.url || "https://mhhh.ca/";
+
+    const page = await fetchHTMLPage(sourceUrl);
+    if (!page.ok) return page.result;
+    const { html, structureHash, fetchDurationMs } = page;
+
+    const errorDetails: ErrorDetails = {};
+    const errors: string[] = [];
+    const { minDate, maxDate } = buildDateWindow(options?.days ?? 60);
+
+    let parsed: RawEventData[] = [];
+    try {
+      parsed = parseMhhhHareline(html, sourceUrl);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(`mhhh.ca hareline parse failed: ${message}`);
+      (errorDetails.parse ??= []).push({
+        row: 0,
+        section: "hareline",
+        error: message,
+      });
+    }
+
+    // Drop anything outside the lookback window — adapter is current/future
+    // only; the historical archive is handled by the one-shot backfill script.
+    const events = parsed.filter((ev) => {
+      const t = new Date(`${ev.date}T12:00:00Z`).getTime();
+      return t >= minDate.getTime() && t <= maxDate.getTime();
+    });
+
+    const hasErrors = hasAnyErrors(errorDetails);
+
+    return {
+      events,
+      errors,
+      structureHash,
+      errorDetails: hasErrors ? errorDetails : undefined,
+      diagnosticContext: {
+        chunksParsed: parsed.length,
+        eventsAfterWindow: events.length,
+        fetchDurationMs,
+      },
+    };
+  }
+}

--- a/src/adapters/html-scraper/mhhh-ca.ts
+++ b/src/adapters/html-scraper/mhhh-ca.ts
@@ -57,10 +57,15 @@ export function parseDateTimeCost(raw: string): {
     timeRest = cleaned.replace(timeMatch[0], " ").trim();
   }
 
-  // Extract & strip the cost ($13 / $13.50 / $13 cash).
+  // Extract & strip the cost. Supports both Anglo prefix ($13 / $13.50 / $13
+  // cash) and the Québécois suffix notation common on French-Canadian sites
+  // (13$ / 13 $ / 13,50 $). Reviewer flag (PR #1688): the original prefix-only
+  // regex would leave a trailing "$" on dateRest for any row using suffix form.
   let dateRest = timeRest;
   let cost: string | undefined;
-  const costMatch = timeRest.match(/\$\d+(?:\.\d{2})?(?:\s*(?:cash|cad|usd)\b)?/i);
+  const costMatch =
+    timeRest.match(/\$\d+(?:[.,]\d{2})?(?:\s*(?:cash|cad|usd)\b)?/i)
+    ?? timeRest.match(/\b\d+(?:[.,]\d{2})?\s*\$(?:\s*(?:cash|cad|usd)\b)?/i);
   if (costMatch) {
     cost = costMatch[0].trim();
     dateRest = timeRest.replace(costMatch[0], " ").trim();

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -485,6 +485,89 @@ describe("MeetupAdapter", () => {
     expect(result.events[0].description).toBe("Join us for a fun trail!");
   });
 
+  // #1659: Meetup's Apollo cache deduplicates long shared strings (like the
+  // boilerplate "Structure / This event..." block reused across every MH3
+  // Montreal event) by storing a bare back-reference like "$44" on the Event
+  // entry, with the prose target stored separately under the same key in
+  // __APOLLO_STATE__. Until #1659, the adapter passed the bare ref through to
+  // canonical Event.description verbatim, producing the visible pattern
+  // (run #1683 -> "$44", #1684 -> "$43", ...). Two regression shapes:
+  it("resolves Apollo back-reference description to prose when state has the target", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({ description: "$44" }),
+      "Venue:123": VENUE_ENTRY,
+      $44: "Structure / This event will be a run/walk, followed by a social gathering at a nearby venue. All are welcome — hashers and virgins alike.",
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events[0].description).toBe(
+      "Structure / This event will be a run/walk, followed by a social gathering at a nearby venue. All are welcome — hashers and virgins alike.",
+    );
+  });
+
+  it("emits null description when Apollo back-reference doesn't resolve to prose", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({ description: "$44" }),
+      "Venue:123": VENUE_ENTRY,
+      // No $44 entry in state -> unresolvable -> explicit clear.
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    // null (explicit clear) is the contract from merge.ts; never let the
+    // raw "$44" string persist.
+    expect(result.events[0].description).toBeNull();
+  });
+
+  it("follows chained Apollo back-references to the final prose target", async () => {
+    // Real Apollo state can hop through multiple dedup layers — $44 → $45 →
+    // wrapped { value: "actual prose" }. Without chain following, a perfectly
+    // good description would get NULLed (Codex finding on the cleanMeetupDescription
+    // fix). Anchor a 3-hop chain in regression tests.
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({ description: "$44" }),
+      "Venue:123": VENUE_ENTRY,
+      $44: "$45",
+      $45: { value: "Structure: weekly Sunday run, 13h00 start, all welcome. Hares lead the trail." },
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events[0].description).toBe(
+      "Structure: weekly Sunday run, 13h00 start, all welcome. Hares lead the trail.",
+    );
+  });
+
+  it("rejects a cyclic Apollo ref chain rather than looping forever", async () => {
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({ description: "$44" }),
+      "Venue:123": VENUE_ENTRY,
+      $44: "$45",
+      $45: "$44", // pathological loop
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events[0].description).toBeNull();
+  });
+
   it("filters events outside the lookback window", async () => {
     const futureDate = new Date(Date.now() + 200 * 24 * 60 * 60 * 1000);
     const futureIso = futureDate.toISOString().slice(0, 19) + "-05:00";

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -491,8 +491,8 @@ describe("MeetupAdapter", () => {
   // entry, with the prose target stored separately under the same key in
   // __APOLLO_STATE__. Until #1659, the adapter passed the bare ref through to
   // canonical Event.description verbatim, producing the visible pattern
-  // (run #1683 -> "$44", #1684 -> "$43", ...). Two regression shapes:
-  it("resolves Apollo back-reference description to prose when state has the target", async () => {
+  // (run #1683 -> "$44", #1684 -> "$43", ...). Regression shapes below.
+  it("resolves Apollo back-reference description to its target when state has it", async () => {
     const html = buildMeetupHtml({
       "Event:1": buildApolloEvent({ description: "$44" }),
       "Venue:123": VENUE_ENTRY,
@@ -510,11 +510,11 @@ describe("MeetupAdapter", () => {
     );
   });
 
-  it("emits null description when Apollo back-reference doesn't resolve to prose", async () => {
+  it("preserves existing description (undefined) when Apollo back-reference doesn't resolve", async () => {
     const html = buildMeetupHtml({
       "Event:1": buildApolloEvent({ description: "$44" }),
       "Venue:123": VENUE_ENTRY,
-      // No $44 entry in state -> unresolvable -> explicit clear.
+      // No $44 entry in state -> unresolvable.
     });
     mockHtmlResponse(html);
 
@@ -523,21 +523,44 @@ describe("MeetupAdapter", () => {
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
       { days: 365 },
     );
-    // null (explicit clear) is the contract from merge.ts; never let the
-    // raw "$44" string persist.
-    expect(result.events[0].description).toBeNull();
+    // undefined (preserve existing) is the adapter convention — never let the
+    // raw "$44" string persist, but don't clear legitimately stored prose
+    // either. Reviewer feedback on PR #1688 (gemini-code-assist + codex P1):
+    // prefer undefined over null in adapters.
+    expect(result.events[0].description).toBeUndefined();
   });
 
-  it("follows chained Apollo back-references to the final prose target", async () => {
+  it("accepts short non-English back-reference targets (no English-prose heuristic)", async () => {
+    // Reviewer feedback (PR #1688): an earlier `looksLikeProse` guard required
+    // ≥20 chars + ASCII letters, which would drop short or non-Latin
+    // descriptions. The fix is that resolveApolloDescriptionRef accepts any
+    // string the chain bottoms out on. Verify with a short French/Japanese
+    // string that the prior heuristic would have rejected.
+    const html = buildMeetupHtml({
+      "Event:1": buildApolloEvent({ description: "$44" }),
+      "Venue:123": VENUE_ENTRY,
+      $44: "ハッシュラン",
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events[0].description).toBe("ハッシュラン");
+  });
+
+  it("follows chained Apollo back-references to the final target", async () => {
     // Real Apollo state can hop through multiple dedup layers — $44 → $45 →
     // wrapped { value: "actual prose" }. Without chain following, a perfectly
-    // good description would get NULLed (Codex finding on the cleanMeetupDescription
-    // fix). Anchor a 3-hop chain in regression tests.
+    // good description would get dropped (Codex finding on the
+    // cleanMeetupDescription fix). Anchor a 3-hop chain in regression tests.
     const html = buildMeetupHtml({
       "Event:1": buildApolloEvent({ description: "$44" }),
       "Venue:123": VENUE_ENTRY,
       $44: "$45",
-      $45: { value: "Structure: weekly Sunday run, 13h00 start, all welcome. Hares lead the trail." },
+      $45: { value: "Trail #42 — pace yourself, watch for falsies, BYO drink." },
     });
     mockHtmlResponse(html);
 
@@ -547,7 +570,7 @@ describe("MeetupAdapter", () => {
       { days: 365 },
     );
     expect(result.events[0].description).toBe(
-      "Structure: weekly Sunday run, 13h00 start, all welcome. Hares lead the trail.",
+      "Trail #42 — pace yourself, watch for falsies, BYO drink.",
     );
   });
 
@@ -565,7 +588,7 @@ describe("MeetupAdapter", () => {
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
       { days: 365 },
     );
-    expect(result.events[0].description).toBeNull();
+    expect(result.events[0].description).toBeUndefined();
   });
 
   it("filters events outside the lookback window", async () => {

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -274,20 +274,20 @@ export function resolveVenue(
  */
 const APOLLO_REF_RE = /^\$[0-9a-fA-F]+$/;
 
-/** True if the resolved string looks like real prose (≥20 chars, has a word). */
-function looksLikeProse(value: string): boolean {
-  if (value.length < 20) return false;
-  return /[A-Za-z]{3,}/.test(value);
-}
-
 /**
  * Resolve an Apollo back-reference string against the cache state. Follows
  * up to MAX_REF_HOPS chained `$XX -> $YY -> "..."` indirections — Apollo's
  * normalized format permits chains when the same string is referenced from
- * multiple cache layers. Returns the prose target if any link in the chain
- * dereferences to a real string with prose content; otherwise returns
- * `undefined` to signal "no usable target." Tracks visited refs to defend
- * against pathological self-referential cycles.
+ * multiple cache layers. Returns the first non-ref string at the end of the
+ * chain; otherwise returns `undefined` to signal "no usable target." Tracks
+ * visited refs to defend against pathological self-referential cycles.
+ *
+ * Reviewer pushback (PR #1688, gemini-code-assist + codex P1): an earlier
+ * version of this helper required a `looksLikeProse` heuristic (≥20 chars +
+ * ASCII `[A-Za-z]{3,}` match) on the resolved value. That dropped legitimate
+ * short descriptions and any non-Latin (e.g. Japanese, French) prose. The
+ * design contract for ref resolution is just "follow indirection until you
+ * land on a literal" — accept any non-ref string the chain bottoms out on.
  */
 const MAX_REF_HOPS = 4;
 function resolveApolloDescriptionRef(
@@ -300,15 +300,12 @@ function resolveApolloDescriptionRef(
     if (visited.has(cursor)) return undefined;
     visited.add(cursor);
     const target: unknown = state[cursor];
-    // Direct string hit — accept if it's prose, otherwise treat as a ref-shape
-    // to keep chasing (a string like "$45" is itself a ref).
     if (typeof target === "string") {
-      if (looksLikeProse(target)) return target;
       if (APOLLO_REF_RE.test(target)) {
         cursor = target;
         continue;
       }
-      return undefined;
+      return target;
     }
     // Wrapper object — the common shape is { value: <string-or-ref> }, but
     // some Apollo variants nest under `data`. Probe both.
@@ -317,12 +314,11 @@ function resolveApolloDescriptionRef(
       const wrapped = (typeof obj.value === "string" ? obj.value : undefined)
         ?? (typeof obj.data === "string" ? obj.data : undefined);
       if (typeof wrapped !== "string") return undefined;
-      if (looksLikeProse(wrapped)) return wrapped;
       if (APOLLO_REF_RE.test(wrapped)) {
         cursor = wrapped;
         continue;
       }
-      return undefined;
+      return wrapped;
     }
     return undefined;
   }
@@ -331,19 +327,22 @@ function resolveApolloDescriptionRef(
 
 /**
  * Clean a Meetup description: dereference Apollo back-refs, strip HTML, truncate.
- * Returns `null` (explicit clear, per merge.ts contract) when the raw value is
- * an Apollo ref that doesn't resolve to prose — prevents `$XX` literals from
- * persisting on canonical Events. Returns `undefined` only for missing input.
+ * Returns `undefined` (preserve existing canonical value, per merge.ts contract)
+ * when the raw value is an Apollo ref that doesn't resolve — adapter convention
+ * prefers `undefined` over `null` so failed lookups don't wipe legitimately
+ * stored prose. A separate one-shot script (`scripts/cleanup-mh3-ca-stale-descriptions.ts`)
+ * handles the inverse — clearing already-corrupted `$XX` rows that pre-date
+ * the fix in this PR.
  */
 function cleanMeetupDescription(
   desc: string | undefined,
   state: Record<string, unknown>,
-): string | null | undefined {
+): string | undefined {
   if (!desc) return undefined;
   if (APOLLO_REF_RE.test(desc)) {
     const resolved = resolveApolloDescriptionRef(desc, state);
-    if (!resolved) return null;
-    return stripHtmlTags(resolved).slice(0, 2000) || null;
+    if (!resolved) return undefined;
+    return stripHtmlTags(resolved).slice(0, 2000) || undefined;
   }
   return stripHtmlTags(desc).slice(0, 2000) || undefined;
 }

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -265,9 +265,86 @@ export function resolveVenue(
   };
 }
 
-/** Strip HTML tags from Meetup description and truncate. */
-function cleanMeetupDescription(desc: string | undefined): string | undefined {
+/**
+ * Apollo back-reference shape — a bare `$XX` string that points elsewhere in the
+ * normalized cache (Meetup deduplicates long shared values like the boilerplate
+ * "Structure / This event..." across many Event entries). See #1659: when the
+ * extractor casts an Apollo entry to `ApolloEvent` without resolving these,
+ * canonical Event.description ends up storing `"$44"` instead of prose.
+ */
+const APOLLO_REF_RE = /^\$[0-9a-fA-F]+$/;
+
+/** True if the resolved string looks like real prose (≥20 chars, has a word). */
+function looksLikeProse(value: string): boolean {
+  if (value.length < 20) return false;
+  return /[A-Za-z]{3,}/.test(value);
+}
+
+/**
+ * Resolve an Apollo back-reference string against the cache state. Follows
+ * up to MAX_REF_HOPS chained `$XX -> $YY -> "..."` indirections — Apollo's
+ * normalized format permits chains when the same string is referenced from
+ * multiple cache layers. Returns the prose target if any link in the chain
+ * dereferences to a real string with prose content; otherwise returns
+ * `undefined` to signal "no usable target." Tracks visited refs to defend
+ * against pathological self-referential cycles.
+ */
+const MAX_REF_HOPS = 4;
+function resolveApolloDescriptionRef(
+  ref: string,
+  state: Record<string, unknown>,
+): string | undefined {
+  const visited = new Set<string>();
+  let cursor: string | undefined = ref;
+  for (let hop = 0; hop < MAX_REF_HOPS && cursor; hop++) {
+    if (visited.has(cursor)) return undefined;
+    visited.add(cursor);
+    const target: unknown = state[cursor];
+    // Direct string hit — accept if it's prose, otherwise treat as a ref-shape
+    // to keep chasing (a string like "$45" is itself a ref).
+    if (typeof target === "string") {
+      if (looksLikeProse(target)) return target;
+      if (APOLLO_REF_RE.test(target)) {
+        cursor = target;
+        continue;
+      }
+      return undefined;
+    }
+    // Wrapper object — the common shape is { value: <string-or-ref> }, but
+    // some Apollo variants nest under `data`. Probe both.
+    if (target && typeof target === "object" && !Array.isArray(target)) {
+      const obj = target as Record<string, unknown>;
+      const wrapped = (typeof obj.value === "string" ? obj.value : undefined)
+        ?? (typeof obj.data === "string" ? obj.data : undefined);
+      if (typeof wrapped !== "string") return undefined;
+      if (looksLikeProse(wrapped)) return wrapped;
+      if (APOLLO_REF_RE.test(wrapped)) {
+        cursor = wrapped;
+        continue;
+      }
+      return undefined;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Clean a Meetup description: dereference Apollo back-refs, strip HTML, truncate.
+ * Returns `null` (explicit clear, per merge.ts contract) when the raw value is
+ * an Apollo ref that doesn't resolve to prose — prevents `$XX` literals from
+ * persisting on canonical Events. Returns `undefined` only for missing input.
+ */
+function cleanMeetupDescription(
+  desc: string | undefined,
+  state: Record<string, unknown>,
+): string | null | undefined {
   if (!desc) return undefined;
+  if (APOLLO_REF_RE.test(desc)) {
+    const resolved = resolveApolloDescriptionRef(desc, state);
+    if (!resolved) return null;
+    return stripHtmlTags(resolved).slice(0, 2000) || null;
+  }
   return stripHtmlTags(desc).slice(0, 2000) || undefined;
 }
 
@@ -426,7 +503,7 @@ export function buildRawEventFromApollo(
   const hares =
     (descForHares ? extractHaresFromDescription(descForHares) : undefined)
     ?? extractHaresFromMeetupDescription(descForHares);
-  const cleanedDesc = cleanMeetupDescription(ev.description);
+  const cleanedDesc = cleanMeetupDescription(ev.description, state);
 
   return {
     date,

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -102,6 +102,7 @@ import { CapitalH3Adapter } from "./html-scraper/capital-h3";
 import { MoolooHhhAdapter } from "./html-scraper/mooloo-hhh";
 import { GeriatrixH3Adapter } from "./html-scraper/geriatrix-h3";
 import { HogtownAdapter } from "./html-scraper/hogtown";
+import { MhhhCaAdapter } from "./html-scraper/mhhh-ca";
 import { GoogleCalendarAdapter } from "./google-calendar/adapter";
 import { GoogleSheetsAdapter } from "./google-sheets/adapter";
 import { ICalAdapter } from "./ical/adapter";
@@ -254,6 +255,13 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   // (HOGTOWN / TWAT / HOGANS) share one kennel; the series prefix lives in
   // the title since the schema has no sub-series field.
   { pattern: /hogtownh3\.com/i, name: "HogtownAdapter", factory: () => new HogtownAdapter() },
+  // ── Canada (Montreal) ──
+  // MH3 Montreal (#1660) — hand-edited static HTML keyed on <!--RunNumber-->
+  // / <!--DateTimeCost--> / <!--HaresList--> / <!--Location--> comment anchors.
+  // Wins on Meetup when both fire (trustLevel 9 vs Meetup's 7) — see PR for
+  // the four bundled issues including a description-leak fix in the Meetup
+  // adapter (#1659) that gated this PR.
+  { pattern: /mhhh\.ca/i, name: "MhhhCaAdapter", factory: () => new MhhhCaAdapter() },
 ];
 
 /** URL-based routing for HTML_SCRAPER — derived from htmlScraperEntries (single source of truth). */


### PR DESCRIPTION
## Summary

Deep Dive bundling the four MH3 Montreal issues:

- **#1659 (data corruption)** — `Event.description` showed `$44, $43, $42, $41, $40, $3f` across runs #1683-#1688. Root cause: Meetup's `__APOLLO_STATE__` deduplicates long shared strings (the boilerplate "Structure / This event..." block reused across every event) by replacing them with a bare back-reference like `"$44"` on the Event entry, with the prose target stored under that key elsewhere in the cache. The adapter passed the bare ref through verbatim.

  Fix in [src/adapters/meetup/adapter.ts](src/adapters/meetup/adapter.ts): `cleanMeetupDescription` now takes the Apollo `state` map alongside the raw value, follows `$XX → $YY → "prose"` chains up to 4 hops (with a `visited` Set against cycles), accepts both direct string targets and `{ value | data }` wrappers, and emits explicit `null` when no link in the chain resolves to prose. Six new regression tests cover the direct-hit / wrapped / chained / cyclic / unresolved cases.

- **#1660 (source coverage)** — mhhh.ca exposes per-event hares + Montreal-neighborhood location while Meetup mostly returns "Location not specified yet". New [MhhhCaAdapter](src/adapters/html-scraper/mhhh-ca.ts) keys on the page's HTML-comment anchors (`<!--RunNumber-->`, `<!--DateTimeCost-->`, `<!--HaresList-->`, `<!--Location-->`) — the most stable signal on a hand-edited FrontPage-era site, per `feedback_browser_render_content_shape_parsing`. Registered in [registry.ts](src/adapters/registry.ts) and seeded as a HTML_SCRAPER source at trustLevel 9 (above Meetup's 7) so it wins on conflicting fields. 16 unit tests + live-verified against https://mhhh.ca/ (5 events, runs #1684-#1688, real hares + neighborhoods).

- **#1661 (historical backfill)** — Issue body estimated ~1500 runs since 1995; live probe shows mhhh.ca's `/trash/YYYY/` archive only exists for **1996-2008** (~109 events). 2009+ all 404 — the archive stopped being maintained. Closing this gap fully would also need a wide-window crawl of Meetup's `?type=past` archive via `scripts/backfill-meetup-history.ts`; this PR delivers what mhhh.ca actually carries.

  New [scripts/backfill-mh3-ca-history.ts](scripts/backfill-mh3-ca-history.ts) walks each year-index page, optionally fetches detail pages at 500ms intervals for day-precision + verbatim hares, and routes through the shared `runBackfillScript` helper. Dry-run: 109 events 1996-2008, 43 day-precise + 66 month-precise fallback, no future-dated rows. Bound to the new mhhh.ca source per `feedback_source_binding_correctness`.

- **#1658 (profile bundle)** — Added `contactEmail`, `hashCash: "$13"`, `scheduleNotes`, and an expanded user-facing description to the `mh3-ca` row in [kennels.ts](prisma/seed-data/kennels.ts). No `logoUrl` — neither Meetup CDN (expiring) nor mhhh.ca offered a stable image per `feedback_self_host_unstable_logos`.

Also ships [scripts/cleanup-mh3-ca-stale-descriptions.ts](scripts/cleanup-mh3-ca-stale-descriptions.ts) — NULLs canonical `Event.description` values whose linked MEETUP `RawEvent.rawData.description` matches the `$XX` leak shape. Dry-run against prod found **0 hits today** (corruption was real per the issue but has been overwritten by subsequent re-scrapes); script ships as defensive infrastructure in case the Apollo dedup format re-fires before the adapter fix deploys.

## Adversarial review

`/codex:adversarial-review` round caught two medium issues; both fixed before commit:
1. Single-hop ref resolution would convert valid `$44 → $45 → "prose"` chains to `null`. Resolver now follows up to 4 hops with cycle protection.
2. Backfill detail-URL used the row's parsed year instead of the index page's year — would 404 silently on cross-year rows like Dec-2001 runs listed on `/trash/2002/`. Now uses index page's `year` for URL construction.

`/simplify` pass tightened the Apollo-state parameter type, dropped a redundant typecast, and removed two paraphrasing comments.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (21 pre-existing warnings in unrelated files)
- [x] `npm test` — 7300+ tests pass
- [x] Live-verify mhhh.ca adapter: 5 upcoming events with real hares + neighborhoods
- [x] Cleanup script dry-run against prod: 0 hits (safe)
- [x] Backfill script dry-run: 109 events 1996-2008, date range valid, no future rows
- [ ] After merge: `npx prisma db seed` to land the new source row + profile updates (per `feedback_post_merge_seed_required`)
- [ ] After seed: `BACKFILL_APPLY=1 npx tsx scripts/backfill-mh3-ca-history.ts` to apply the 109-row historical backfill
- [ ] After re-scrape: spot-check 5 recent mh3-ca events on the kennel page — confirm hares + neighborhood appear from mhhh.ca enrichment

Closes #1658
Closes #1659
Closes #1660
Closes #1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)