### PR TITLE
Backfill cluster sweep — 8 issues across 2 patterns (WS6)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1179,7 +1179,10 @@ export const SOURCES = [
       type: "ICAL_FEED" as const,
       trustLevel: 7,
       scrapeFreq: "daily",
-      scrapeDays: 180,
+      // #1339: feed carries ~40+ past events; widened from 180 to 1500 to recover
+      // the historical archive. Paired with the iCal adapter's lookback derivation
+      // (lookbackDays = source.scrapeDays ?? 90) so this also expands the past window.
+      scrapeDays: 1500,
       config: {
         defaultKennelTag: "ich3",
       },
@@ -2342,7 +2345,10 @@ export const SOURCES = [
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "every_6h",
-      scrapeDays: 90,
+      // #1601: Leap Year #6-#8 (2008/2012/2016) sit far outside the default
+      // 90d window. Bumped to 1500 to recover them plus historical context for
+      // the other 12 WA kennels on this calendar (audit bonus).
+      scrapeDays: 1500,
       config: {
         kennelPatterns: [
           ["^SH3\\b|Seattle H3", "sh3-wa"],
@@ -2446,7 +2452,10 @@ export const SOURCES = [
       type: "GOOGLE_SHEETS" as const,
       trustLevel: 5,
       scrapeFreq: "daily",
-      scrapeDays: 800,
+      // #1601: Leap Year runs every 4 years; sheet carries placeholders out to
+      // #16 in 2048. 800d window stopped at ~2028. Widened to cover the full
+      // century-spanning placeholder sequence (matches Summit's 9999 pattern).
+      scrapeDays: 9999,
       config: {
         sheetId: "anonymous",
         csvUrl: "https://docs.google.com/spreadsheets/d/e/2PACX-1vQ_z30ZkQNOwcAka4qU22bAGYIVjJFc5NyICst9OeUWPvi27lNK8ICkZllzLI0gjLwQDjVvlt3mMlDM/pub?output=csv",
@@ -2569,7 +2578,10 @@ export const SOURCES = [
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "every_6h",
-      scrapeDays: 90,
+      // #1633: calendar carries ~120 MH3 numbered trails spanning the kennel's
+      // history. 90d window indexed only 60 numbered runs. Wide window
+      // (matches LBH3 / Madison) so full archive is reachable.
+      scrapeDays: 9999,
       config: {
         kennelPatterns: [
           ["\\bT3H3\\b|Twin Titties", "t3h3"],
@@ -2768,7 +2780,9 @@ export const SOURCES = [
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "every_6h",
-      scrapeDays: 90,
+      // #1609: calendar archive spans 2006-2027 (1,172 VEVENTs). 90d window
+      // indexed only 35 events. Wide window to recover the full LBH3 history.
+      scrapeDays: 9999,
       config: { defaultKennelTag: "lbh3" },
       kennelCodes: ["lbh3"],
     },
@@ -3876,7 +3890,10 @@ export const SOURCES = [
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "every_6h",
-      scrapeDays: 365,
+      // #1559: kennel founded 1977 with weekly runs (#2503+ as of 2026).
+      // 365d window indexed only recent events. Wide window to reach the
+      // full history exposed by the calendar.
+      scrapeDays: 9999,
       config: {
         calendarId: "q206h4gbp4cfg5m13ip95vch88@group.calendar.google.com",
         defaultKennelTag: "madisonh3",
@@ -4871,7 +4888,10 @@ export const SOURCES = [
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "every_6h",
-      scrapeDays: 365,
+      // #1600: LDS H3 #579-#627 (Feb-Jul 2024) sit ~22 months back, outside
+      // the 365d window. Widened to 1500 to recover those events plus extra
+      // history for wasatch-h3 / slosh-h3 / slut-h3 (4 kennels share calendar).
+      scrapeDays: 1500,
       config: {
         kennelPatterns: [
           ["^wasatch", "wasatch-h3"],

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2452,10 +2452,13 @@ export const SOURCES = [
       type: "GOOGLE_SHEETS" as const,
       trustLevel: 5,
       scrapeFreq: "daily",
-      // #1601: Leap Year runs every 4 years; sheet carries placeholders out to
-      // #16 in 2048. 800d window stopped at ~2028. Widened to cover the full
-      // century-spanning placeholder sequence (matches Summit's 9999 pattern).
-      scrapeDays: 9999,
+      // #1601 (partial): past runs #6-#8 (2008/2012/2016) ship via the WA Hash
+      // Google Calendar's widened window above. The 2 future placeholders
+      // #15-#16 (2044/2048) on this sheet are deferred — GoogleSheetsAdapter
+      // applies `days` symmetrically, so bumping scrapeDays past 22yr would
+      // surface every interstitial "??" placeholder row through 2048 as
+      // canonical data (Codex review pushback).
+      scrapeDays: 800,
       config: {
         sheetId: "anonymous",
         csvUrl: "https://docs.google.com/spreadsheets/d/e/2PACX-1vQ_z30ZkQNOwcAka4qU22bAGYIVjJFc5NyICst9OeUWPvi27lNK8ICkZllzLI0gjLwQDjVvlt3mMlDM/pub?output=csv",

--- a/scripts/backfill-hhh-penang-history.ts
+++ b/scripts/backfill-hhh-penang-history.ts
@@ -1,0 +1,76 @@
+/**
+ * One-shot historical backfill for Hash House Harriets Penang (issue #1282).
+ *
+ * The live `GoHashAdapter` fetches `/hareline/upcoming` (forward-only — the
+ * source's recurring adapter pins `upcomingOnly: true` so past rows that fall
+ * off the page aren't reconciled away). The same goHash tenant also exposes
+ * `/hareline/past`, which carries the kennel's historical archive (~70 runs
+ * as of #1282). This wrapper hits that endpoint once, runs each row through
+ * the shared `parseGoHashRun` helper, and pipes them into the merge pipeline
+ * via `runBackfillScript`.
+ *
+ * Strict date partitioning: `reportAndApplyBackfill` filters to
+ * `date < today-in-Asia/Kuala_Lumpur`. Re-runs are no-ops via fingerprint
+ * dedup in `processRawEvents`.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-hhh-penang-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-hhh-penang-history.ts
+ *   Env:      DATABASE_URL
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { extractInitialState, parseGoHashRun } from "@/adapters/html-scraper/gohash";
+import { fetchHTMLPage } from "@/adapters/utils";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Hash House Harriets Penang Hareline";
+const KENNEL_TIMEZONE = "Asia/Kuala_Lumpur";
+const HARELINE_URL = "https://www.hashhouseharrietspenang.com/hareline/past";
+const KENNEL_TAG = "hhhpenang";
+const START_TIME = "17:30";
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log(`Fetching ${HARELINE_URL}`);
+  const page = await fetchHTMLPage(HARELINE_URL);
+  if (!page.ok) {
+    throw new Error(
+      `Failed to fetch ${HARELINE_URL}: ${page.result.errors.join("; ")}`,
+    );
+  }
+
+  const state = extractInitialState(page.html);
+  if (!state) {
+    throw new Error(
+      `__INITIAL_STATE__ not found at ${HARELINE_URL} — page shape may have drifted`,
+    );
+  }
+
+  const rawRuns = state.runs?.runs ?? [];
+  const events: RawEventData[] = [];
+  let skipped = 0;
+  for (const run of rawRuns) {
+    const event = parseGoHashRun(
+      run,
+      { kennelTag: KENNEL_TAG, startTime: START_TIME },
+      HARELINE_URL,
+    );
+    if (event) events.push(event);
+    else skipped++;
+  }
+  console.log(
+    `  Found ${rawRuns.length} raw runs, parsed ${events.length}, skipped ${skipped} (missing/invalid date)`,
+  );
+  return events;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: `Walking ${HARELINE_URL}`,
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-marin-h3-history.ts
+++ b/scripts/backfill-marin-h3-history.ts
@@ -1,0 +1,32 @@
+/**
+ * One-shot historical backfill for Marin H3 (#1614).
+ *
+ * Thin wrapper around the reusable SFH3 backfill helper. SFH3 exposes ~144
+ * Marin H3 runs across 2002–2026 on its per-kennel filter (`?kennel=10`), but
+ * the live `kennels=all` adapter only sees the current period bucket. The
+ * shared helper walks every period bucket once and pipes the rows through
+ * the merge pipeline. See scripts/lib/sfh3-backfill.ts for the full
+ * explanation.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-marin-h3-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-marin-h3-history.ts
+ */
+
+import { backfillSfh3Kennel } from "./lib/sfh3-backfill";
+
+async function main(): Promise<void> {
+  try {
+    await backfillSfh3Kennel({
+      sfh3KennelId: 10,
+      kennelCode: "marinh3",
+      sourceName: "SFH3 MultiHash HTML Hareline",
+      expectedLabel: "Marin H3",
+    });
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+void main();

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -667,6 +667,39 @@ END:VCALENDAR`;
     expect(result.diagnosticContext!.skippedDateRange).toBe(2);
   });
 
+  it("honors options.days for fetch window (matches reconcile window)", async () => {
+    // Regression: scrapeSource() passes the same `days` to both adapter.fetch
+    // and reconcileStaleEvents. If fetch capped narrower than reconcile, the
+    // reconciler would cancel everything in the gap as "missing from scrape"
+    // — a critical data-loss risk during admin one-shot wide-window scrapes
+    // (e.g. #1339 ICH3 historical recovery).
+    const wideWindowIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:past-3-years
+DTSTART:20230601T190000Z
+SUMMARY:Three Years Back Trail
+END:VEVENT
+BEGIN:VEVENT
+UID:future-2-years
+DTSTART:20280601T190000Z
+SUMMARY:Two Years Forward Trail
+END:VEVENT
+END:VCALENDAR`;
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(wideWindowIcs, { status: 200 }),
+    );
+
+    // Source.scrapeDays=90 would filter both events out; admin passes
+    // options.days=1500 (~4 years), which must widen the fetch window.
+    const source = buildMockSource({ scrapeDays: 90 });
+    const result = await adapter.fetch(source, { days: 1500 });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.events).toHaveLength(2);
+    expect(result.diagnosticContext!.skippedDateRange).toBe(0);
+  });
+
   it("detects HTML response (deactivated calendar plugin)", async () => {
     const html = `<!DOCTYPE html>
 <html lang="en-US">

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -497,15 +497,17 @@ export class ICalAdapter implements SourceAdapter {
 
   async fetch(
     source: Source,
-    _options?: { days?: number },
+    options?: { days?: number },
   ): Promise<ScrapeResult> {
-    // Symmetric lookback/lookforward derived from source.scrapeDays so wide-window
-    // backfills (e.g. ICH3 #1339) actually pick up past events; iCal feeds often
-    // publish events 6+ months in advance, so the forward window tracks it too.
-    // Note: scrapeSource() passes source.scrapeDays as options.days, so we read
-    // source.scrapeDays directly to avoid double-applying the window.
-    const lookbackDays = source.scrapeDays ?? 90;
-    const lookforwardDays = source.scrapeDays ?? 365;
+    // Honor options.days so admin one-shot wide-window scrapes
+    // (e.g. ICH3 #1339 historical recovery) actually pick up past events.
+    // CRITICAL: scrapeSource() passes the same `days` to both fetch and
+    // reconcileStaleEvents — if fetch caps narrower than reconcile, reconcile
+    // would cancel every event in the gap as "missing from scrape". Falls
+    // back to source.scrapeDays then 90 (preserving prior default).
+    const days = options?.days ?? source.scrapeDays ?? 90;
+    const lookbackDays = days;
+    const lookforwardDays = options?.days ?? source.scrapeDays ?? 365;
     const fetchStart = Date.now();
 
     const now = new Date();

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -499,11 +499,12 @@ export class ICalAdapter implements SourceAdapter {
     source: Source,
     _options?: { days?: number },
   ): Promise<ScrapeResult> {
-    // Fixed 90-day lookback for historical events; use source.scrapeDays for
-    // forward window — iCal feeds often publish events 6+ months in advance.
+    // Symmetric lookback/lookforward derived from source.scrapeDays so wide-window
+    // backfills (e.g. ICH3 #1339) actually pick up past events; iCal feeds often
+    // publish events 6+ months in advance, so the forward window tracks it too.
     // Note: scrapeSource() passes source.scrapeDays as options.days, so we read
-    // source.scrapeDays directly to avoid the symmetric window that would create.
-    const lookbackDays = 90;
+    // source.scrapeDays directly to avoid double-applying the window.
+    const lookbackDays = source.scrapeDays ?? 90;
     const lookforwardDays = source.scrapeDays ?? 365;
     const fetchStart = Date.now();
 


### PR DESCRIPTION
## Summary

Closes 8 known historical-event gaps via the minimum-code path:

- **6 source-config bumps** unlock fully-enumerable feeds (GCal / iCal / GSheet) that already publish years of history — the missing events were simply outside the `scrapeDays` window. Memory: *"Always try wide-window scrape for GCal kennels."*
- **1 iCal adapter mod** makes the lookback symmetric with `scrapeDays` so ICH3 (and other iCal sources) pick up past events instead of capping at 90d. Defaults preserved.
- **2 one-shot scripts** cover the partial-enumeration HTML sources (HHH Penang `/hareline/past`, Marin H3 via SFH3 per-kennel periods) that a config bump can't reach.

This is **WS6** of a parallel multi-session sweep. WS3's phantom-date cleanup should run AFTER this lands so it operates on the backfilled events.

## Deviation from original brief

The brief categorized LDS H3 (#1600) and Leap Year (#1601) under Path A (one-shot scripts), but both have fully-enumerable sources where a `scrapeDays` bump achieves the same outcome with permanent ongoing coverage. Confirmed with maintainer before exiting plan mode. Path B count: 6 (was 4). Path A count: 2 (was 4).

## Changes

### `prisma/seed-data/sources.ts` — 7 scrapeDays bumps

| Source | Old → New | Issue | Side benefit |
|--------|-----------|-------|--------------|
| Whoreman H3 Calendar | 365 → 1500 | #1600 LDS H3 | wasatch-h3 / slosh-h3 / slut-h3 |
| WA Hash Google Calendar | 90 → 1500 | #1601 Leap Year past | 11 other WA kennels |
| Leap Year H3 Hareline Sheet | 800 → 9999 | #1601 future #15/#16 (2044/2048) | — |
| Madison H3 Google Calendar | 365 → 9999 | #1559 | — |
| LBH3 Google Calendar | 90 → 9999 | #1609 | — |
| Minneapolis H3 Calendar | 90 → 9999 | #1633 | t3h3 (sister) |
| Iron City H3 iCal Feed | 180 → 1500 | #1339 | — |

### `src/adapters/ical/adapter.ts`

```diff
-    const lookbackDays = 90;
+    const lookbackDays = source.scrapeDays ?? 90;
     const lookforwardDays = source.scrapeDays ?? 365;
```

Symmetric with the GCal adapter's window derivation. Default behavior preserved (sources without `scrapeDays` still get 90d lookback). The existing iCal date-filter test continues to pass.

### Two new one-shot scripts

- `scripts/backfill-hhh-penang-history.ts` (#1282) — fetches `/hareline/past`, parses goHash `__INITIAL_STATE__` via shared `parseGoHashRun`, routes through `runBackfillScript`. Source has `upcomingOnly: true` so the live adapter intentionally skips this endpoint.
- `scripts/backfill-marin-h3-history.ts` (#1614) — 30-line wrapper around `backfillSfh3Kennel({ sfh3KennelId: 10, ..., expectedLabel: "Marin H3" })`. The helper walks SFH3's 4 period buckets, applies strict-date partitioning, and enriches detail pages.

## Verification

- ✅ `npx tsc --noEmit` clean
- ✅ `npm run lint` 0 errors (only pre-existing warnings in unrelated travel components)
- ✅ `npm test -- --run` 7282/7282 pass across 265 files

### Dry-run results

**HHH Penang** (`/hareline/past`):
```
Found 73 raw runs, parsed 73, skipped 0
Partition: 73 past rows, 0 skipped (date >= 2026-05-26)
Date range: 2025-01-02 → 2026-05-21
Samples:
  #2673 2025-01-02 | hares=Cocktail
  #2709 2025-09-11 | hares=Dolly
  #2745 2026-05-21 | Birthday Run | hares=Biking Sheila
```

**Marin H3** (SFH3 4-period walk):
```
Total historical rows: 288 (unique 144, skipped-date 0)
Enriched 113/144 from detail pages
Date range: 2002-06-02 (#7000) → 2026-05-09 (#291)
Samples:
  2002-06-02 #7000 | Marin | hares=Doctor Kimble & Bag Lady
  2026-04-25 #290 | Rev Itchy Stick B'day and MH3 25th Anniversary
```

## Test plan

- [ ] **APPLY scripts against prod DB** (worktree has no `.env`, run from main repo):
  ```bash
  BACKFILL_APPLY=1 npx tsx scripts/backfill-hhh-penang-history.ts
  BACKFILL_APPLY=1 npx tsx scripts/backfill-marin-h3-history.ts
  ```
  Expected new Events: hhhpenang ~73, marinh3 ~144.
- [ ] **Re-run check** — both scripts under `BACKFILL_APPLY=1` should be no-ops (fingerprint dedup).
- [ ] **Post-merge: per-source admin re-scrape** to pick up the new `scrapeDays` windows (or wait up to 6h for the next cron cycle):
  ```bash
  curl -X POST -H "Authorization: Bearer $CRON_SECRET" \
    https://hashtracks.com/api/cron/scrape/<sourceId>
  ```
  for each of: Whoreman, WA Hash, Leap Year Sheet, Madison, LBH3, Minneapolis, Iron City iCal.
- [ ] Verify event-count jumps for LDS H3, Leap Year, Madison, LBH3, MH3-MN, ICH3 on each kennel's Past tab.
- [ ] Spot-check 3 oldest + 3 newest backfilled events per kennel.

## Notes for reviewers

- Per Memory `feedback_pre_pr_review_loop.md`, `/codex:adversarial-review` is requested manually on this PR (the slash command isn't available to me in this worktree). `/simplify` ran cleanly — only trimmed a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #1559
Closes #1600
Closes #1609
Closes #1614
Closes #1633
Closes #1282
Closes #1339

---

## Update (Codex review round)

 flagged two issues on the first commit; both fixed in 1afb0248:

- **[critical]** iCal adapter dropped the `options.days` contract. `scrapeSource` passes the same `days` to fetch + reconcile — fetch capping narrower than reconcile would have cancelled every event in the gap during admin wide-window scrapes. Restored: `options.days` wins, falls back to `source.scrapeDays` then 90 / 365. Added regression test that fails on the prior code path.
- **[high]** Leap Year Sheet `scrapeDays: 9999` would surface every interstitial `??` placeholder row through 2048 as canonical data (GoogleSheets adapter applies `days` symmetrically with no future cap). Reverted to 800. The 3 past Leap Year events (#6-#8 in 2008/2012/2016) still ship via the WA Hash GCal bump. The 2 future placeholders (#15-#16 in 2044/2048) are deferred — they need a past/future split mechanism that does not exist today. **Issue #1601 stays open as a reference** (downgraded to a reference).