### PR TITLE
feat(mh3-ca): mhhh.ca scraper + Meetup hex filter + profile + history backfill

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2897,10 +2897,12 @@ export const KENNELS: KennelSeed[] = [
     // ── Canada: Quebec — Montreal ──
     {
       kennelCode: "mh3-ca", shortName: "MH3", fullName: "Montreal Hash House Harriers", region: "Montreal, QC", country: "Canada",
-      website: "https://www.mhhh.ca",
+      website: "https://mhhh.ca",
+      contactEmail: "montrealhhh@gmail.com",
       scheduleDayOfWeek: "Sunday", scheduleTime: "1:00 PM", scheduleFrequency: "Weekly",
+      scheduleNotes: "Weekly Sunday 1pm runs, plus occasional Saturday or weeknight trails.",
       foundedYear: 1995,
-      description: "Montreal's weekly Sunday hash since 1995.",
+      description: "Montreal's hash since 1995 — Sunday trails go off every week rain or shine, with the odd Saturday or weeknight bonus run. Hash cash is $13 and covers food and beer. Casual, easygoing vibe; virgins welcome.",
       latitude: 45.50, longitude: -73.57,
     },
 

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3909,6 +3909,22 @@ export const SOURCES = [
       },
       kennelCodes: ["mh3-ca"],
     },
+    // mhhh.ca homepage carries the neighborhood + per-event hares that the
+    // Meetup listing usually leaves as "Location not specified yet" (#1660).
+    // Higher trustLevel than the Meetup source so the website wins those
+    // fields when both feed the same (kennel, date) row in the merge pipeline.
+    {
+      name: "Montreal H3 Website",
+      url: "https://mhhh.ca/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 8,
+      scrapeFreq: "daily",
+      scrapeDays: 60,
+      config: {
+        kennelTag: "mh3-ca",
+      },
+      kennelCodes: ["mh3-ca"],
+    },
     // --- Toronto ---
     {
       name: "Hogtown H3 Meetup",

--- a/scripts/backfill-mh3-ca-history.ts
+++ b/scripts/backfill-mh3-ca-history.ts
@@ -66,7 +66,8 @@ export function parseIndexRow(
   // "Run #204 / Ile-Perrot October 2000 Kristal Tits"
   // "Run #194 - Karaoke Hash / South Shore August 2000 Numbskull"
   // Some legacy rows omit the leading "Run #": skip those.
-  const runMatch = /Run\s*#?\s*(\d+)\b/i.exec(text);
+  // Anchored, no `\s*` adjacent to optional `#` — keeps Sonar S5852 happy.
+  const runMatch = /\bRun\s+#?(\d+)\b/i.exec(text);
   if (!runMatch) return null;
   const runNumber = Number.parseInt(runMatch[1], 10);
 
@@ -145,13 +146,20 @@ export function parseDetailPage(html: string): {
     }
   }
 
-  // "Hares: Yogi, Little Big Man, Anon"
-  const haresMatch = /Hares?:\s*([^\n]+?)(?:\(|Location:|Trail|$)/i.exec(text);
+  // "Hares: Yogi, Little Big Man, Anon" — single-line capture, then trim at
+  // the first downstream label / paren. Procedural slice avoids the lazy +
+  // alternation shape that trips Sonar S5852 even though it's linear here.
+  const haresMatch = /\bHares?:\s*(.+)/i.exec(text);
   if (haresMatch) {
-    const haresRaw = haresMatch[1].replace(/\s+/g, " ").trim();
+    let raw = haresMatch[1];
+    for (const stop of ["(", "Location:", "Trail", "\n"]) {
+      const i = raw.indexOf(stop);
+      if (i >= 0) raw = raw.slice(0, i);
+    }
+    const haresRaw = raw.replace(/\s+/g, " ").trim();
     if (haresRaw && haresRaw.length < 200) {
       // Sort multi-value joined fields for stable fingerprints (memory).
-      const list = haresRaw.split(/\s*,\s*/).filter(Boolean);
+      const list = haresRaw.split(",").map((s) => s.trim()).filter(Boolean);
       list.sort((a, b) => a.localeCompare(b));
       out.hares = list.join(", ");
     }

--- a/scripts/backfill-mh3-ca-history.ts
+++ b/scripts/backfill-mh3-ca-history.ts
@@ -115,129 +115,164 @@ export function parseYearIndex(html: string, year: number): IndexRow[] {
   return rows;
 }
 
-/** Parse a detail page to upgrade date precision and pick up hares. */
-export function parseDetailPage(html: string): {
+interface DetailParse {
   day?: number;
   month?: number;
   year?: number;
   hares?: string;
   startTime?: string;
   scribe?: string;
-} {
+}
+
+const WEEKDAYS = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
+
+/** "Date: Sunday, July 6th, 2008 @ 1:00PM" → { day, month, year, startTime? }. */
+export function parseDetailDate(text: string): Pick<DetailParse, "day" | "month" | "year" | "startTime"> | null {
+  // Strip the weekday prefix procedurally (Sonar S5843 dodge — a single regex
+  // with 7-way weekday alternation + month + day + year + optional time blew
+  // past the complexity cap of 20).
+  const idx = text.search(/\bDate:/i);
+  if (idx < 0) return null;
+  let body = text.slice(idx + "Date:".length).trimStart();
+  for (const wd of WEEKDAYS) {
+    if (body.toLowerCase().startsWith(wd)) {
+      body = body.slice(wd.length);
+      if (body.startsWith(",")) body = body.slice(1);
+      body = body.trimStart();
+      break;
+    }
+  }
+  const dateMatch = /^([A-Za-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?,?\s+(\d{4})(?:\s*@\s*(\d{1,2}):(\d{2})\s*(AM|PM))?/i.exec(body);
+  if (!dateMatch) return null;
+  const month = MONTHS[dateMatch[1].toLowerCase()];
+  if (month === undefined) return null;
+  const day = Number.parseInt(dateMatch[2], 10);
+  const year = Number.parseInt(dateMatch[3], 10);
+  let startTime: string | undefined;
+  if (dateMatch[4] && dateMatch[5] && dateMatch[6]) {
+    let hours = Number.parseInt(dateMatch[4], 10);
+    const minutes = dateMatch[5];
+    const ampm = dateMatch[6].toUpperCase();
+    if (ampm === "PM" && hours !== 12) hours += 12;
+    if (ampm === "AM" && hours === 12) hours = 0;
+    startTime = `${String(hours).padStart(2, "0")}:${minutes}`;
+  }
+  return { day, month, year, startTime };
+}
+
+/** "Hares: Yogi, Little Big Man, Anon" → "Anon, Little Big Man, Yogi" (sorted). */
+export function parseDetailHares(text: string): string | undefined {
+  const match = /\bHares?:\s*(.+)/i.exec(text);
+  if (!match) return undefined;
+  let raw = match[1];
+  for (const stop of ["(", "Location:", "Trail", "\n"]) {
+    const i = raw.indexOf(stop);
+    if (i >= 0) raw = raw.slice(0, i);
+  }
+  const cleaned = raw.replace(/\s+/g, " ").trim();
+  if (!cleaned || cleaned.length >= 200) return undefined;
+  // Sort multi-value joined fields for stable fingerprints (memory).
+  const list = cleaned.split(",").map((s) => s.trim()).filter(Boolean);
+  list.sort((a, b) => a.localeCompare(b));
+  return list.join(", ");
+}
+
+/** Parse a detail page to upgrade date precision and pick up hares/scribe. */
+export function parseDetailPage(html: string): DetailParse {
   const $ = cheerio.load(html);
   const text = decodeEntities($("body").text()).replace(/\s+/g, " ").trim();
-
-  const out: { day?: number; month?: number; year?: number; hares?: string; startTime?: string; scribe?: string } = {};
-
-  // "Date: Sunday, July 6th, 2008 @ 1:00PM"
-  const dateMatch = /Date:\s*(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday),?\s*([A-Z][a-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?,?\s+(\d{4})(?:\s*@\s*(\d{1,2}):(\d{2})\s*(AM|PM))?/i.exec(text);
-  if (dateMatch) {
-    const monthName = dateMatch[1];
-    out.month = MONTHS[monthName.toLowerCase()];
-    out.day = Number.parseInt(dateMatch[2], 10);
-    out.year = Number.parseInt(dateMatch[3], 10);
-    if (dateMatch[4] && dateMatch[5] && dateMatch[6]) {
-      let hours = Number.parseInt(dateMatch[4], 10);
-      const minutes = dateMatch[5];
-      const ampm = dateMatch[6].toUpperCase();
-      if (ampm === "PM" && hours !== 12) hours += 12;
-      if (ampm === "AM" && hours === 12) hours = 0;
-      out.startTime = `${String(hours).padStart(2, "0")}:${minutes}`;
-    }
-  }
-
-  // "Hares: Yogi, Little Big Man, Anon" — single-line capture, then trim at
-  // the first downstream label / paren. Procedural slice avoids the lazy +
-  // alternation shape that trips Sonar S5852 even though it's linear here.
-  const haresMatch = /\bHares?:\s*(.+)/i.exec(text);
-  if (haresMatch) {
-    let raw = haresMatch[1];
-    for (const stop of ["(", "Location:", "Trail", "\n"]) {
-      const i = raw.indexOf(stop);
-      if (i >= 0) raw = raw.slice(0, i);
-    }
-    const haresRaw = raw.replace(/\s+/g, " ").trim();
-    if (haresRaw && haresRaw.length < 200) {
-      // Sort multi-value joined fields for stable fingerprints (memory).
-      const list = haresRaw.split(",").map((s) => s.trim()).filter(Boolean);
-      list.sort((a, b) => a.localeCompare(b));
-      out.hares = list.join(", ");
-    }
-  }
-
-  // "written by Clit On"
+  const out: DetailParse = {};
+  const date = parseDetailDate(text);
+  if (date) Object.assign(out, date);
+  out.hares = parseDetailHares(text);
   const scribeMatch = /written by\s+([A-Z][^\n.(]{1,40})/i.exec(text);
-  if (scribeMatch) {
-    out.scribe = scribeMatch[1].trim();
-  }
-
+  if (scribeMatch) out.scribe = scribeMatch[1].trim();
   return out;
 }
 
 const pad2 = (n: number): string => String(n).padStart(2, "0");
 
+/** Merge detail-page enrichment over the index-row baseline. */
+function mergeDetail(row: IndexRow, detail: DetailParse | null): {
+  day?: number;
+  month: number;
+  year: number;
+  hares?: string;
+  startTime?: string;
+  scribe?: string;
+} {
+  const hasDetailDate = !!(detail?.day && detail?.month && detail?.year);
+  return {
+    day: hasDetailDate ? detail!.day : undefined,
+    month: hasDetailDate ? detail!.month! : row.month,
+    year: hasDetailDate ? detail!.year! : row.year,
+    hares: detail?.hares,
+    startTime: detail?.startTime,
+    scribe: detail?.scribe ?? row.scribe,
+  };
+}
+
+/** Build the RawEventData for one index row (with optional detail-page enrichment). */
+function buildBackfillEvent(
+  row: IndexRow,
+  detail: DetailParse | null,
+  year: number,
+  indexUrl: string,
+): RawEventData {
+  const merged = mergeDetail(row, detail);
+  // Same-day merge disambiguation in `src/pipeline/merge.ts`
+  // (`sameDayEvents.length > 1`) matches by sourceUrl BEFORE runNumber, so
+  // every month-precision row must carry a unique sourceUrl or sibling rows
+  // would collapse onto the first. The `#run-NNN` anchor keeps each row
+  // provenance-distinct while still pointing back to the archive.
+  const date = `${merged.year}-${pad2(merged.month)}-${pad2(merged.day ?? 1)}`;
+  const sourceUrl = row.detailPath
+    ? `${ARCHIVE_BASE}/${year}/${row.detailPath}`
+    : `${indexUrl}#run-${row.runNumber}`;
+  const descParts: string[] = [];
+  if (merged.scribe) descParts.push(`Trash written by ${merged.scribe}.`);
+  if (!merged.day) descParts.push("Day-precision unavailable; date approximated to first of month.");
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber: row.runNumber,
+    hares: merged.hares,
+    location: row.location,
+    startTime: merged.startTime,
+    sourceUrl,
+    description: descParts.length > 0 ? descParts.join(" ") : undefined,
+  };
+}
+
+/** Fetch + parse one year's index page and its detail pages. */
+async function fetchYearEvents(year: number): Promise<RawEventData[]> {
+  const indexUrl = `${ARCHIVE_BASE}/${year}/index.html`;
+  process.stdout.write(`  ${year}: `);
+  const indexHtml = await fetchText(indexUrl);
+  if (indexHtml === null) {
+    console.log("fetch failed");
+    return [];
+  }
+  const rows = parseYearIndex(indexHtml, year);
+  console.log(`${rows.length} rows`);
+
+  const events: RawEventData[] = [];
+  for (const row of rows) {
+    let detail: DetailParse | null = null;
+    if (row.detailPath) {
+      await new Promise((r) => setTimeout(r, FETCH_DELAY_MS));
+      const detailHtml = await fetchText(`${ARCHIVE_BASE}/${year}/${row.detailPath}`);
+      if (detailHtml) detail = parseDetailPage(detailHtml);
+    }
+    events.push(buildBackfillEvent(row, detail, year, indexUrl));
+  }
+  return events;
+}
+
 async function fetchEvents(): Promise<RawEventData[]> {
   const all: RawEventData[] = [];
   for (const year of YEARS) {
-    const indexUrl = `${ARCHIVE_BASE}/${year}/index.html`;
-    process.stdout.write(`  ${year}: `);
-    const indexHtml = await fetchText(indexUrl);
-    if (indexHtml === null) {
-      console.log("fetch failed");
-      continue;
-    }
-    const rows = parseYearIndex(indexHtml, year);
-    console.log(`${rows.length} rows`);
-
-    for (const row of rows) {
-      let day: number | undefined;
-      let month = row.month;
-      let detailYear = row.year;
-      let hares: string | undefined;
-      let startTime: string | undefined;
-      let scribe = row.scribe;
-
-      if (row.detailPath) {
-        await new Promise((r) => setTimeout(r, FETCH_DELAY_MS));
-        const detailHtml = await fetchText(`${ARCHIVE_BASE}/${year}/${row.detailPath}`);
-        if (detailHtml) {
-          const parsed = parseDetailPage(detailHtml);
-          if (parsed.day && parsed.month && parsed.year) {
-            day = parsed.day;
-            month = parsed.month;
-            detailYear = parsed.year;
-          }
-          if (parsed.hares) hares = parsed.hares;
-          if (parsed.startTime) startTime = parsed.startTime;
-          if (parsed.scribe) scribe = parsed.scribe;
-        }
-      }
-
-      // Same-day merge disambiguation in `src/pipeline/merge.ts`
-      // (`sameDayEvents.length > 1`) matches by sourceUrl BEFORE runNumber, so
-      // every month-precision row must carry a unique sourceUrl or sibling
-      // rows would collapse onto the first. The `#run-NNN` anchor keeps each
-      // row provenance-distinct while still pointing back to the archive.
-      const date = `${detailYear}-${pad2(month)}-${pad2(day ?? 1)}`;
-      const sourceUrl = row.detailPath
-        ? `${ARCHIVE_BASE}/${year}/${row.detailPath}`
-        : `${indexUrl}#run-${row.runNumber}`;
-
-      const descParts: string[] = [];
-      if (scribe) descParts.push(`Trash written by ${scribe}.`);
-      if (!day) descParts.push("Day-precision unavailable; date approximated to first of month.");
-
-      all.push({
-        date,
-        kennelTags: [KENNEL_TAG],
-        runNumber: row.runNumber,
-        hares,
-        location: row.location,
-        startTime,
-        sourceUrl,
-        description: descParts.length > 0 ? descParts.join(" ") : undefined,
-      });
-    }
+    all.push(...(await fetchYearEvents(year)));
   }
   return all;
 }

--- a/scripts/backfill-mh3-ca-history.ts
+++ b/scripts/backfill-mh3-ca-history.ts
@@ -1,0 +1,242 @@
+/**
+ * One-shot backfill of MH3 Montreal historical runs (#1661).
+ *
+ * Walks https://mhhh.ca/trash/{YEAR}/index.html for years 1996-2008 (the only
+ * years that respond 200 — the kennel stopped publishing per-run trash
+ * archives after 2008 even though they still run weekly). For each year-index
+ * row we extract the run number, location, month, year, and scribe. When
+ * the row links to a per-run detail page (`trashNNN.htm`), we fetch the
+ * detail page and parse the "Date:" line for day-precision and the "Hares:"
+ * line for hare names. Year-index-only rows fall back to month-precision
+ * (date = first of month) — the merge pipeline still upserts them and the
+ * fingerprint stays stable across re-runs.
+ *
+ * Honest scope: the run #1688 (May 2026) total implies ~1500 historical
+ * trails, but only ~100 are publicly archived in a parseable form. The
+ * remaining gap is held only as aggregated stats on hashstats.htm. We
+ * surface what's reachable; the rest are documented in the PR body.
+ *
+ * Partitioning (memory `feedback_historical_backfill`): events are filtered
+ * to date < today via the shared `reportAndApplyBackfill` helper before any
+ * DB write, so this script can re-run safely alongside the live adapter
+ * that owns date >= today.
+ *
+ * Usage:
+ *   npm run tsx scripts/backfill-mh3-ca-history.ts                  # dry-run
+ *   BACKFILL_APPLY=1 npm run tsx scripts/backfill-mh3-ca-history.ts # write
+ */
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import type { RawEventData } from "@/adapters/types";
+import { decodeEntities, MONTHS } from "@/adapters/utils";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { runBackfillScript } from "./lib/backfill-runner";
+
+const SOURCE_NAME = "Montreal H3 Website";
+const KENNEL_TIMEZONE = "America/Toronto"; // Quebec uses Eastern, same offsets as Toronto
+const KENNEL_TAG = "mh3-ca";
+const ARCHIVE_BASE = "https://mhhh.ca/trash";
+const YEARS = Array.from({ length: 13 }, (_, i) => 1996 + i); // 1996..2008
+const FETCH_DELAY_MS = 250;
+
+interface IndexRow {
+  runNumber: number;
+  location?: string;
+  month: number;
+  year: number;
+  scribe?: string;
+  detailPath?: string; // e.g. "trash646.htm"
+}
+
+async function fetchText(url: string): Promise<string | null> {
+  const res = await safeFetch(url, {
+    headers: { "User-Agent": "Mozilla/5.0 hashtracks-backfill" },
+  });
+  if (!res.ok) return null;
+  return res.text();
+}
+
+/** Parse one row of the year-index table. */
+export function parseIndexRow(
+  rowHtml: string,
+  fallbackYear: number,
+): IndexRow | null {
+  const $ = cheerio.load(`<table>${rowHtml}</table>`);
+  const text = decodeEntities($("tr").text()).replace(/\s+/g, " ").trim();
+  // "Run #204 / Ile-Perrot October 2000 Kristal Tits"
+  // "Run #194 - Karaoke Hash / South Shore August 2000 Numbskull"
+  // Some legacy rows omit the leading "Run #": skip those.
+  const runMatch = /Run\s*#?\s*(\d+)\b/i.exec(text);
+  if (!runMatch) return null;
+  const runNumber = Number.parseInt(runMatch[1], 10);
+
+  // Find Month Year token; restrict to known month names to avoid false hits.
+  const monthMatch = /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})\b/.exec(text);
+  if (!monthMatch) return null;
+  const month = MONTHS[monthMatch[1].toLowerCase()];
+  const year = Number.parseInt(monthMatch[2], 10);
+  if (year !== fallbackYear) {
+    // Cross-year row in a year-index page is suspicious; bail rather than guess.
+    return null;
+  }
+
+  // Location: between "/ " (after run #) and the month token.
+  const afterRunIdx = text.indexOf(runMatch[0]) + runMatch[0].length;
+  const monthIdx = text.indexOf(monthMatch[0], afterRunIdx);
+  const between = text.slice(afterRunIdx, monthIdx).trim();
+  let location: string | undefined;
+  const slashIdx = between.indexOf("/");
+  if (slashIdx >= 0) {
+    location = between.slice(slashIdx + 1).trim() || undefined;
+  }
+
+  // Scribe: trailing token after the month-year.
+  const scribePart = text.slice(monthIdx + monthMatch[0].length).trim();
+  const scribe = scribePart.length > 0 && scribePart.length < 40 ? scribePart : undefined;
+
+  // Detail page link.
+  const detailLink = $("a[href$='.htm']").first().attr("href");
+  const detailPath = detailLink && /^trash\d+\.htm$/i.test(detailLink) ? detailLink : undefined;
+
+  return { runNumber, location, month, year, scribe, detailPath };
+}
+
+/** Extract per-run rows from a year-index page. */
+export function parseYearIndex(html: string, year: number): IndexRow[] {
+  const $ = cheerio.load(html);
+  const rows: IndexRow[] = [];
+  $("tr").each((_, tr) => {
+    const html = $.html(tr);
+    if (!/Run\s*#/i.test(html)) return;
+    const parsed = parseIndexRow(html, year);
+    if (parsed) rows.push(parsed);
+  });
+  return rows;
+}
+
+/** Parse a detail page to upgrade date precision and pick up hares. */
+export function parseDetailPage(html: string): {
+  day?: number;
+  month?: number;
+  year?: number;
+  hares?: string;
+  startTime?: string;
+  scribe?: string;
+} {
+  const $ = cheerio.load(html);
+  const text = decodeEntities($("body").text()).replace(/\s+/g, " ").trim();
+
+  const out: { day?: number; month?: number; year?: number; hares?: string; startTime?: string; scribe?: string } = {};
+
+  // "Date: Sunday, July 6th, 2008 @ 1:00PM"
+  const dateMatch = /Date:\s*(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday),?\s*([A-Z][a-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?,?\s+(\d{4})(?:\s*@\s*(\d{1,2}):(\d{2})\s*(AM|PM))?/i.exec(text);
+  if (dateMatch) {
+    const monthName = dateMatch[1];
+    out.month = MONTHS[monthName.toLowerCase()];
+    out.day = Number.parseInt(dateMatch[2], 10);
+    out.year = Number.parseInt(dateMatch[3], 10);
+    if (dateMatch[4] && dateMatch[5] && dateMatch[6]) {
+      let hours = Number.parseInt(dateMatch[4], 10);
+      const minutes = dateMatch[5];
+      const ampm = dateMatch[6].toUpperCase();
+      if (ampm === "PM" && hours !== 12) hours += 12;
+      if (ampm === "AM" && hours === 12) hours = 0;
+      out.startTime = `${String(hours).padStart(2, "0")}:${minutes}`;
+    }
+  }
+
+  // "Hares: Yogi, Little Big Man, Anon"
+  const haresMatch = /Hares?:\s*([^\n]+?)(?:\(|Location:|Trail|$)/i.exec(text);
+  if (haresMatch) {
+    const haresRaw = haresMatch[1].replace(/\s+/g, " ").trim();
+    if (haresRaw && haresRaw.length < 200) {
+      // Sort multi-value joined fields for stable fingerprints (memory).
+      const list = haresRaw.split(/\s*,\s*/).filter(Boolean);
+      list.sort((a, b) => a.localeCompare(b));
+      out.hares = list.join(", ");
+    }
+  }
+
+  // "written by Clit On"
+  const scribeMatch = /written by\s+([A-Z][^\n.(]{1,40})/i.exec(text);
+  if (scribeMatch) {
+    out.scribe = scribeMatch[1].trim();
+  }
+
+  return out;
+}
+
+const pad2 = (n: number): string => String(n).padStart(2, "0");
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const all: RawEventData[] = [];
+  for (const year of YEARS) {
+    const indexUrl = `${ARCHIVE_BASE}/${year}/index.html`;
+    process.stdout.write(`  ${year}: `);
+    const indexHtml = await fetchText(indexUrl);
+    if (indexHtml === null) {
+      console.log("fetch failed");
+      continue;
+    }
+    const rows = parseYearIndex(indexHtml, year);
+    console.log(`${rows.length} rows`);
+
+    for (const row of rows) {
+      let day: number | undefined;
+      let month = row.month;
+      let detailYear = row.year;
+      let hares: string | undefined;
+      let startTime: string | undefined;
+      let scribe = row.scribe;
+
+      if (row.detailPath) {
+        await new Promise((r) => setTimeout(r, FETCH_DELAY_MS));
+        const detailHtml = await fetchText(`${ARCHIVE_BASE}/${year}/${row.detailPath}`);
+        if (detailHtml) {
+          const parsed = parseDetailPage(detailHtml);
+          if (parsed.day && parsed.month && parsed.year) {
+            day = parsed.day;
+            month = parsed.month;
+            detailYear = parsed.year;
+          }
+          if (parsed.hares) hares = parsed.hares;
+          if (parsed.startTime) startTime = parsed.startTime;
+          if (parsed.scribe) scribe = parsed.scribe;
+        }
+      }
+
+      // Same-day merge disambiguation in `src/pipeline/merge.ts`
+      // (`sameDayEvents.length > 1`) matches by sourceUrl BEFORE runNumber, so
+      // every month-precision row must carry a unique sourceUrl or sibling
+      // rows would collapse onto the first. The `#run-NNN` anchor keeps each
+      // row provenance-distinct while still pointing back to the archive.
+      const date = `${detailYear}-${pad2(month)}-${pad2(day ?? 1)}`;
+      const sourceUrl = row.detailPath
+        ? `${ARCHIVE_BASE}/${year}/${row.detailPath}`
+        : `${indexUrl}#run-${row.runNumber}`;
+
+      const descParts: string[] = [];
+      if (scribe) descParts.push(`Trash written by ${scribe}.`);
+      if (!day) descParts.push("Day-precision unavailable; date approximated to first of month.");
+
+      all.push({
+        date,
+        kennelTags: [KENNEL_TAG],
+        runNumber: row.runNumber,
+        hares,
+        location: row.location,
+        startTime,
+        sourceUrl,
+        description: descParts.length > 0 ? descParts.join(" ") : undefined,
+      });
+    }
+  }
+  return all;
+}
+
+await runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: `Walking mhhh.ca/trash archive (${YEARS[0]}-${YEARS.at(-1)})`,
+  fetchEvents,
+});

--- a/scripts/cleanup-mh3-meetup-hex-descriptions.ts
+++ b/scripts/cleanup-mh3-meetup-hex-descriptions.ts
@@ -1,0 +1,83 @@
+/**
+ * One-shot cleanup for #1659: MH3 Montreal Event.description rows contain
+ * placeholder tokens of the shape `$XX` (hex) instead of real prose.
+ *
+ * The adapter-side fix in `src/adapters/meetup/adapter.ts` (cleanMeetupDescription)
+ * prevents new ingest from re-introducing the shape, but the existing
+ * production rows need their `description` cleared so the merge pipeline
+ * can re-fill from a clean source (the new mhhh.ca HTML adapter, or a
+ * subsequent Meetup re-scrape now that the field is gated).
+ *
+ * Scope:
+ *   - Default: only mh3-ca (the only kennel where the shape was observed).
+ *   - Pass `--all-kennels` to clear across every kennel — useful if alerts
+ *     surface the shape on another Meetup kennel later.
+ *
+ * Safety:
+ *   - Dry-run by default. `--apply` actually writes.
+ *   - We never touch RawEvent rows (immutable audit trail per CLAUDE.md).
+ *     Instead, we clear Event.description only — next scrape + merge
+ *     refills from current (clean) sources.
+ *
+ * Usage:
+ *   npm run tsx scripts/cleanup-mh3-meetup-hex-descriptions.ts             # dry-run, mh3-ca
+ *   npm run tsx scripts/cleanup-mh3-meetup-hex-descriptions.ts -- --apply  # write, mh3-ca
+ *   npm run tsx scripts/cleanup-mh3-meetup-hex-descriptions.ts -- --all-kennels --apply
+ */
+import "dotenv/config";
+import { prisma } from "../src/lib/db";
+
+const APPLY = process.argv.includes("--apply");
+const ALL_KENNELS = process.argv.includes("--all-kennels");
+
+const HEX_TOKEN_RE = /^\s*\$[0-9a-f]+\s*$/i;
+
+async function main() {
+  const where = ALL_KENNELS
+    ? { description: { not: null } }
+    : { description: { not: null }, kennel: { kennelCode: "mh3-ca" } };
+
+  const events = await prisma.event.findMany({
+    where,
+    select: {
+      id: true,
+      description: true,
+      runNumber: true,
+      kennel: { select: { kennelCode: true } },
+      date: true,
+    },
+  });
+
+  console.log(`Scanning ${events.length} events with non-null description${ALL_KENNELS ? " (all kennels)" : " for mh3-ca"}.`);
+
+  const matches = events.filter((e) => e.description && HEX_TOKEN_RE.test(e.description));
+  console.log(`Found ${matches.length} events with placeholder-hex shape.`);
+
+  for (const ev of matches) {
+    const dateStr = ev.date.toISOString().slice(0, 10);
+    console.log(
+      `  CLEAR  ${ev.id}  ${ev.kennel?.kennelCode ?? "?"}  ${dateStr}  run #${ev.runNumber ?? "—"}  desc=${JSON.stringify(ev.description)}`,
+    );
+  }
+
+  if (APPLY && matches.length > 0) {
+    const ids = matches.map((m) => m.id);
+    const result = await prisma.event.updateMany({
+      where: { id: { in: ids } },
+      data: { description: null },
+    });
+    console.log(`\nCleared ${result.count} Event.description rows.`);
+  } else if (matches.length > 0) {
+    console.log("\nDry-run only. Re-run with --apply to clear descriptions.");
+  } else {
+    console.log("\nNothing to clean up.");
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/cleanup-mh3-meetup-hex-descriptions.ts
+++ b/scripts/cleanup-mh3-meetup-hex-descriptions.ts
@@ -30,6 +30,10 @@ import { prisma } from "../src/lib/db";
 const APPLY = process.argv.includes("--apply");
 const ALL_KENNELS = process.argv.includes("--all-kennels");
 
+// Mirrors `MEETUP_PLACEHOLDER_TOKEN_RE` in `src/adapters/meetup/adapter.ts`.
+// The adapter version asserts on already-trimmed input; this one tolerates
+// surrounding whitespace because we're querying historical DB rows whose
+// content predates the trimming guard. Keep them in sync if either changes.
 const HEX_TOKEN_RE = /^\s*\$[0-9a-f]+\s*$/i;
 
 async function main() {

--- a/src/adapters/html-scraper/mhhh-ca.test.ts
+++ b/src/adapters/html-scraper/mhhh-ca.test.ts
@@ -94,6 +94,8 @@ describe("parseDateCost", () => {
   });
 
   it("normalizes nbsp + extra whitespace", () => {
+    // Fixture uses real U+00A0 (NBSP) between tokens, not regular spaces —
+    // matches the &nbsp; entities mhhh.ca emits in its Date/Cost cells.
     const out = parseDateCost("May 3, 2026 13h00 $13");
     expect(out?.day).toBe(3);
     expect(out?.time).toBe("13:00");

--- a/src/adapters/html-scraper/mhhh-ca.test.ts
+++ b/src/adapters/html-scraper/mhhh-ca.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { parseDateCost, parseMhhhHomepage } from "./mhhh-ca";
+
+/**
+ * Representative slice of https://mhhh.ca/ — three of the May 2026 run blocks.
+ * Captured 2026-05-26. Mirrors the FrontPage-generated `<tr>` shape literally
+ * (whitespace, &nbsp;, html comments) so we exercise the parser against the
+ * real markup, not a normalized version.
+ */
+const FIXTURE_HOMEPAGE = `
+<table border="0" width=695 cellspacing="0" cellpadding="0">
+  <tr><td colspan="4"><b>&nbsp;May 2026&nbsp;</b></td></tr>
+  <tbody>
+    <tr>
+      <td style="width: 142px;">&nbsp;</td>
+      <td style="width: 96px;"><b> RUN #1684</b></td>
+      <td style="width: 448px;"><!--RunTitle--></td>
+      <td style="width: 9px;">&nbsp;</td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Date/Cost:</td>
+      <td>May 3, 2026&nbsp;13h00 $13</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Hare(s):</td>
+      <td>Broken Thong</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Location:</td>
+      <td>Sainte-Marie <a target="_blank" href="https://www.meetup.com/montreal-hash-house-harriers/events/314379548">Click for directions</a></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td style="width: 142px;">&nbsp;</td>
+      <td style="width: 96px;"><b> RUN #1685</b></td>
+      <td style="width: 448px;"><!--RunTitle--></td>
+      <td style="width: 9px;">&nbsp;</td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Date/Cost:</td>
+      <td>May 10, 2026&nbsp;13h00 $13</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Hare(s):</td>
+      <td>Alice; Wonderland; Just Raia</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Location:</td>
+      <td>Plateau Mont-Royal <a target="_blank" href="https://www.meetup.com/montreal-hash-house-harriers/events/314543769">Click for directions</a></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td style="width: 142px;">&nbsp;</td>
+      <td style="width: 96px;"><b> RUN #1688</b></td>
+      <td style="width: 448px;"><!--RunTitle--></td>
+      <td style="width: 9px;">&nbsp;</td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Date/Cost:</td>
+      <td>May 31, 2026&nbsp;13h00 $13</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Hare(s):</td>
+      <td>Mystery Hare</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>Location:</td>
+      <td>Le Plateau</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+describe("parseDateCost", () => {
+  it("parses month-day-year + 24h time + cost from real MH3 string", () => {
+    const out = parseDateCost("May 3, 2026 13h00 $13");
+    expect(out).toEqual({ day: 3, month: 5, year: 2026, time: "13:00", cost: "$13" });
+  });
+
+  it("normalizes nbsp + extra whitespace", () => {
+    const out = parseDateCost("May 3, 2026 13h00 $13");
+    expect(out?.day).toBe(3);
+    expect(out?.time).toBe("13:00");
+    expect(out?.cost).toBe("$13");
+  });
+
+  it("returns null when the value has no recognizable date", () => {
+    expect(parseDateCost("TBA")).toBeNull();
+    expect(parseDateCost("")).toBeNull();
+  });
+
+  it("omits year when the string lacks one (relies on header for context)", () => {
+    const out = parseDateCost("May 3");
+    expect(out).toEqual({ day: 3, month: 5, year: undefined, time: undefined, cost: undefined });
+  });
+});
+
+describe("parseMhhhHomepage", () => {
+  const runs = parseMhhhHomepage(FIXTURE_HOMEPAGE);
+
+  it("extracts every run block in the fixture", () => {
+    expect(runs).toHaveLength(3);
+  });
+
+  it("extracts run #, date, time, cost, hares, location, and url for the first block", () => {
+    expect(runs[0]).toEqual({
+      runNumber: 1684,
+      day: 3,
+      month: 5,
+      year: 2026,
+      startTime: "13:00",
+      cost: "$13",
+      hares: "Broken Thong",
+      location: "Sainte-Marie",
+      locationUrl: "https://www.meetup.com/montreal-hash-house-harriers/events/314379548",
+    });
+  });
+
+  it("handles multi-hare semicolon-separated list", () => {
+    expect(runs[1].hares).toBe("Alice; Wonderland; Just Raia");
+    expect(runs[1].runNumber).toBe(1685);
+  });
+
+  it("handles a Location: row without a directions link", () => {
+    expect(runs[2].locationUrl).toBeUndefined();
+    expect(runs[2].location).toBe("Le Plateau");
+  });
+
+  it("returns an empty array on completely unrelated HTML", () => {
+    expect(parseMhhhHomepage("<html><body><p>nothing here</p></body></html>")).toEqual([]);
+  });
+});

--- a/src/adapters/html-scraper/mhhh-ca.ts
+++ b/src/adapters/html-scraper/mhhh-ca.ts
@@ -102,8 +102,11 @@ export function parseMhhhHomepage(html: string): ParsedRun[] {
     if (!rawText) return;
 
     // Month header — e.g. "Show May 2026 Hide " or "May 2026". Strip the
-    // optional Show/Hide toggle wrapper before matching.
-    const headerText = rawText.replace(/^Show\s+|\s+Hide\s*$/g, "");
+    // optional Show/Hide toggle wrapper procedurally; a single regex with
+    // alternation + `\s*$` trips Sonar S5852 even though it's linear here.
+    let headerText = rawText;
+    if (headerText.startsWith("Show ")) headerText = headerText.slice(5).trimStart();
+    if (headerText.endsWith(" Hide")) headerText = headerText.slice(0, -5).trimEnd();
     const monthHeader = MONTH_HEADER_RE.exec(headerText);
     if (monthHeader) {
       const month = MONTHS[monthHeader[1].toLowerCase()];
@@ -184,13 +187,23 @@ export function parseMhhhHomepage(html: string): ParsedRun[] {
 function buildRawEvent(run: ParsedRun, kennelTag: string, sourceUrl: string): RawEventData {
   const m = String(run.month).padStart(2, "0");
   const d = String(run.day).padStart(2, "0");
+  // Resolve relative hrefs (defensive — observed hrefs today are absolute Meetup
+  // URLs, but FrontPage-era markup occasionally emits relative paths).
+  let locationUrl = run.locationUrl;
+  if (locationUrl) {
+    try {
+      locationUrl = new URL(locationUrl, sourceUrl).href;
+    } catch {
+      /* keep original if URL parsing throws */
+    }
+  }
   return {
     date: `${run.year}-${m}-${d}`,
     kennelTags: [kennelTag],
     runNumber: run.runNumber,
     hares: run.hares,
     location: run.location,
-    locationUrl: run.locationUrl,
+    locationUrl,
     startTime: run.startTime,
     cost: run.cost,
     sourceUrl,

--- a/src/adapters/html-scraper/mhhh-ca.ts
+++ b/src/adapters/html-scraper/mhhh-ca.ts
@@ -1,0 +1,259 @@
+/**
+ * Montreal H3 (MH3) Scraper — mhhh.ca
+ *
+ * Closes coverage gap from #1660: the kennel's Meetup source frequently shows
+ * "Location not specified yet" while mhhh.ca's homepage publishes the
+ * neighborhood + hares per upcoming run.
+ *
+ * The homepage hareline is a static HTML table grouped by month. Each run is
+ * a four-`<tr>` block keyed off label text in column 2:
+ *
+ *   tr1: "RUN #NNNN"
+ *   tr2: "Date/Cost:" → "May 3, 2026&nbsp;13h00 $13"
+ *   tr3: "Hare(s):"   → "Broken Thong"
+ *   tr4: "Location:"  → "Sainte-Marie <a href="meetup_url">Click for directions</a>"
+ *
+ * Month-header rows in between carry the year context (e.g. "May 2026"). The
+ * parser tracks the current month/year header and combines with the day from
+ * "Date/Cost:" to build a UTC-noon-normalized date.
+ *
+ * Parser keys on text-content shape (label prefixes "RUN #", "Date/Cost:",
+ * "Hare(s):", "Location:") rather than CSS classes — the page is FrontPage-
+ * generated and any future redesign would change classes long before it
+ * changed those labels.
+ */
+
+import * as cheerio from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
+import {
+  fetchHTMLPage,
+  buildDateWindow,
+  decodeEntities,
+  extractHashRunNumber,
+  MONTHS,
+} from "../utils";
+
+interface MhhhCaConfig {
+  /** Defaults to "mh3-ca". */
+  kennelTag?: string;
+}
+
+const KENNEL_TAG_DEFAULT = "mh3-ca";
+
+/** Recognize the "Month YYYY" header rows that separate run blocks. */
+const MONTH_HEADER_RE = /^([A-Za-z]+)\s+(\d{4})$/;
+
+/** "May 3, 2026 13h00 $13" → { day: 3, time: "13:00", cost: "$13" } */
+export function parseDateCost(
+  text: string,
+): { day: number; month?: number; year?: number; time?: string; cost?: string } | null {
+  const cleaned = decodeEntities(text).replace(/\s+/g, " ").trim();
+  const dateMatch = /\b([A-Za-z]+)\s+(\d{1,2})(?:,\s*(\d{4}))?/.exec(cleaned);
+  if (!dateMatch) return null;
+  const month = MONTHS[dateMatch[1].toLowerCase()];
+  if (month === undefined) return null;
+  const day = Number.parseInt(dateMatch[2], 10);
+  if (day < 1 || day > 31) return null;
+  const year = dateMatch[3] ? Number.parseInt(dateMatch[3], 10) : undefined;
+
+  // Kennel uses 24h "HHhMM" verbatim; no AM/PM variants observed.
+  const timeMatch = /\b(\d{1,2})h(\d{2})\b/.exec(cleaned);
+  const time = timeMatch
+    ? `${timeMatch[1].padStart(2, "0")}:${timeMatch[2]}`
+    : undefined;
+
+  const cost = /\$\d+(?:\.\d{2})?/.exec(cleaned)?.[0];
+
+  return { day, month, year, time, cost };
+}
+
+interface ParsedRun {
+  runNumber?: number;
+  day: number;
+  month: number;
+  year: number;
+  startTime?: string;
+  cost?: string;
+  hares?: string;
+  location?: string;
+  locationUrl?: string;
+}
+
+/**
+ * Extract event blocks from the homepage HTML.
+ *
+ * The homepage table interleaves month-header rows (`<b>&nbsp;May 2026&nbsp;</b>`)
+ * with 4-row run blocks. We walk every `<tr>` in document order, updating the
+ * "active month/year" when we hit a header, then assembling the run block
+ * when we see a "RUN #" cell followed by Date/Hares/Location labels.
+ */
+export function parseMhhhHomepage(html: string): ParsedRun[] {
+  const $ = cheerio.load(html);
+  const runs: ParsedRun[] = [];
+
+  let activeMonth: number | undefined;
+  let activeYear: number | undefined;
+  let current: Partial<ParsedRun> | null = null;
+
+  $("tr").each((_, tr) => {
+    const $tr = $(tr);
+    const rawText = decodeEntities($tr.text()).replace(/\s+/g, " ").trim();
+    if (!rawText) return;
+
+    // Month header — e.g. "Show May 2026 Hide " or "May 2026". Strip the
+    // optional Show/Hide toggle wrapper before matching.
+    const headerText = rawText.replace(/^Show\s+|\s+Hide\s*$/g, "");
+    const monthHeader = MONTH_HEADER_RE.exec(headerText);
+    if (monthHeader) {
+      const month = MONTHS[monthHeader[1].toLowerCase()];
+      if (month !== undefined) {
+        activeMonth = month;
+        activeYear = Number.parseInt(monthHeader[2], 10);
+      }
+      return;
+    }
+
+    // Pull all <td> cells of this row
+    const tds = $tr.find("td");
+    if (tds.length < 2) return;
+
+    // The label-bearing cell is always the 2nd td (index 1) in the homepage
+    // table — the first td is a 142px spacer. Reading it directly keeps the
+    // parser tight and dodges the run-into-month-header false positives we'd
+    // hit with full-row text matching.
+    const labelCell = $(tds[1]);
+    const labelText = decodeEntities(labelCell.text()).replace(/\s+/g, " ").trim();
+    const valueCell = tds.length >= 3 ? $(tds[2]) : null;
+    const valueText = valueCell
+      ? decodeEntities(valueCell.text()).replace(/\s+/g, " ").trim()
+      : "";
+
+    const runNumberFromLabel = extractHashRunNumber(labelText);
+    if (runNumberFromLabel !== undefined) {
+      current = { runNumber: runNumberFromLabel };
+      return;
+    }
+
+    if (!current) return; // ignore stray rows outside a block
+
+    if (/^Date\/Cost:/i.test(labelText)) {
+      const dc = parseDateCost(valueText);
+      if (dc) {
+        const month = dc.month ?? activeMonth;
+        const year = dc.year ?? activeYear;
+        if (month !== undefined && year !== undefined) {
+          current.day = dc.day;
+          current.month = month;
+          current.year = year;
+          current.startTime = dc.time;
+          current.cost = dc.cost;
+        }
+      }
+    } else if (/^Hare\(s\):/i.test(labelText)) {
+      current.hares = valueText || undefined;
+    } else if (/^Location:/i.test(labelText)) {
+      // Neighborhood text comes before the "Click for directions" link. Strip
+      // the link text (or its boilerplate variant) off the end and keep what's left.
+      const link = valueCell?.find("a").first();
+      const linkText = link ? decodeEntities(link.text()).trim() : "";
+      const neighborhood = (linkText
+        ? valueText.replace(linkText, "")
+        : valueText.replace(/\bClick for directions\b.*$/i, "")
+      ).trim();
+      current.location = neighborhood || undefined;
+      const href = link?.attr("href");
+      if (href) current.locationUrl = href;
+      // Location row terminates a run block in MH3's table.
+      if (
+        current.runNumber !== undefined &&
+        current.day !== undefined &&
+        current.month !== undefined &&
+        current.year !== undefined
+      ) {
+        runs.push(current as ParsedRun);
+      }
+      current = null;
+    }
+  });
+
+  return runs;
+}
+
+/** Map a ParsedRun to the RawEventData shape consumed by the merge pipeline. */
+function buildRawEvent(run: ParsedRun, kennelTag: string, sourceUrl: string): RawEventData {
+  const m = String(run.month).padStart(2, "0");
+  const d = String(run.day).padStart(2, "0");
+  return {
+    date: `${run.year}-${m}-${d}`,
+    kennelTags: [kennelTag],
+    runNumber: run.runNumber,
+    hares: run.hares,
+    location: run.location,
+    locationUrl: run.locationUrl,
+    startTime: run.startTime,
+    cost: run.cost,
+    sourceUrl,
+  };
+}
+
+export class MhhhCaAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    const cfg: MhhhCaConfig =
+      source.config && typeof source.config === "object" && !Array.isArray(source.config)
+        ? (source.config as MhhhCaConfig)
+        : {};
+    const kennelTag = cfg.kennelTag || KENNEL_TAG_DEFAULT;
+    const url = source.url || "https://mhhh.ca/";
+
+    const { minDate, maxDate } = buildDateWindow(options?.days);
+
+    const page = await fetchHTMLPage(url);
+    if (!page.ok) {
+      const errorDetails: ErrorDetails = {};
+      if (page.result.errorDetails?.fetch) {
+        errorDetails.fetch = page.result.errorDetails.fetch;
+      }
+      return {
+        events: [],
+        errors: [...page.result.errors],
+        errorDetails,
+        structureHash: page.result.structureHash,
+      };
+    }
+
+    let runs: ParsedRun[];
+    try {
+      runs = parseMhhhHomepage(page.html);
+    } catch (err) {
+      const msg = `Failed to parse mhhh.ca homepage: ${err instanceof Error ? err.message : String(err)}`;
+      return {
+        events: [],
+        errors: [msg],
+        errorDetails: { parse: [{ row: 0, error: msg }] },
+        structureHash: page.structureHash,
+      };
+    }
+
+    const events: RawEventData[] = [];
+    for (const run of runs) {
+      const ev = buildRawEvent(run, kennelTag, url);
+      const eventDate = new Date(`${ev.date}T12:00:00Z`);
+      if (eventDate < minDate || eventDate > maxDate) continue;
+      events.push(ev);
+    }
+
+    return {
+      events,
+      errors: [],
+      structureHash: page.structureHash,
+      diagnosticContext: {
+        runsParsed: runs.length,
+        eventsAfterWindow: events.length,
+        fetchDurationMs: page.fetchDurationMs,
+      },
+    };
+  }
+}

--- a/src/adapters/html-scraper/mhhh-ca.ts
+++ b/src/adapters/html-scraper/mhhh-ca.ts
@@ -24,6 +24,7 @@
  */
 
 import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import {
@@ -63,11 +64,17 @@ export function parseDateCost(
   if (day < 1 || day > 31) return null;
   const year = dateMatch[3] ? Number.parseInt(dateMatch[3], 10) : undefined;
 
-  // Kennel uses 24h "HHhMM" verbatim; no AM/PM variants observed.
+  // Kennel uses 24h "HHhMM" verbatim; no AM/PM variants observed. Bound-check
+  // hour/minute so a malformed cell like "25h99" doesn't poison startTime.
   const timeMatch = /\b(\d{1,2})h(\d{2})\b/.exec(cleaned);
-  const time = timeMatch
-    ? `${timeMatch[1].padStart(2, "0")}:${timeMatch[2]}`
-    : undefined;
+  let time: string | undefined;
+  if (timeMatch) {
+    const hh = Number.parseInt(timeMatch[1], 10);
+    const mm = Number.parseInt(timeMatch[2], 10);
+    if (hh >= 0 && hh <= 23 && mm >= 0 && mm <= 59) {
+      time = `${String(hh).padStart(2, "0")}:${timeMatch[2]}`;
+    }
+  }
 
   const cost = /\$\d+(?:\.\d{2})?/.exec(cleaned)?.[0];
 
@@ -84,6 +91,79 @@ interface ParsedRun {
   hares?: string;
   location?: string;
   locationUrl?: string;
+}
+
+/** "Show May 2026 Hide" / "May 2026" → { month: 5, year: 2026 } or null. */
+function parseMonthHeader(rawText: string): { month: number; year: number } | null {
+  // Strip optional Show/Hide toggle wrapper procedurally (Sonar S5852 dodge).
+  let text = rawText;
+  if (text.startsWith("Show ")) text = text.slice(5).trimStart();
+  if (text.endsWith(" Hide")) text = text.slice(0, -5).trimEnd();
+  const match = MONTH_HEADER_RE.exec(text);
+  if (!match) return null;
+  const month = MONTHS[match[1].toLowerCase()];
+  if (month === undefined) return null;
+  return { month, year: Number.parseInt(match[2], 10) };
+}
+
+/** Pull label + value cells from a row (always columns 2 and 3 of the table). */
+function extractRowCells(
+  $: cheerio.CheerioAPI,
+  $tr: cheerio.Cheerio<AnyNode>,
+): { labelText: string; valueText: string; valueCell: cheerio.Cheerio<AnyNode> | null } | null {
+  const tds = $tr.find("td");
+  if (tds.length < 2) return null;
+  const labelText = decodeEntities($(tds[1]).text()).replace(/\s+/g, " ").trim();
+  const valueCell = tds.length >= 3 ? $(tds[2]) : null;
+  const valueText = valueCell
+    ? decodeEntities(valueCell.text()).replace(/\s+/g, " ").trim()
+    : "";
+  return { labelText, valueText, valueCell };
+}
+
+/** Extract the neighborhood text from a "Location:" cell, stripping the directions link. */
+function extractLocation(
+  valueText: string,
+  valueCell: cheerio.Cheerio<AnyNode> | null,
+): { neighborhood: string | undefined; href: string | undefined } {
+  const link = valueCell?.find("a").first();
+  const linkText = link ? decodeEntities(link.text()).trim() : "";
+  const neighborhood = (linkText
+    ? valueText.replace(linkText, "")
+    : valueText.replace(/\bClick for directions\b.*$/i, "")
+  ).trim();
+  return { neighborhood: neighborhood || undefined, href: link?.attr("href") };
+}
+
+/** Push the in-progress block into `runs` if every required field is set. */
+function finalizeRun(current: Partial<ParsedRun>, runs: ParsedRun[]): void {
+  if (
+    current.runNumber !== undefined &&
+    current.day !== undefined &&
+    current.month !== undefined &&
+    current.year !== undefined
+  ) {
+    runs.push(current as ParsedRun);
+  }
+}
+
+/** Apply a parsed Date/Cost value to the in-progress block. */
+function applyDateCost(
+  current: Partial<ParsedRun>,
+  valueText: string,
+  activeMonth: number | undefined,
+  activeYear: number | undefined,
+): void {
+  const dc = parseDateCost(valueText);
+  if (!dc) return;
+  const month = dc.month ?? activeMonth;
+  const year = dc.year ?? activeYear;
+  if (month === undefined || year === undefined) return;
+  current.day = dc.day;
+  current.month = month;
+  current.year = year;
+  current.startTime = dc.time;
+  current.cost = dc.cost;
 }
 
 /**
@@ -107,81 +187,34 @@ export function parseMhhhHomepage(html: string): ParsedRun[] {
     const rawText = decodeEntities($tr.text()).replace(/\s+/g, " ").trim();
     if (!rawText) return;
 
-    // Month header — e.g. "Show May 2026 Hide " or "May 2026". Strip the
-    // optional Show/Hide toggle wrapper procedurally; a single regex with
-    // alternation + `\s*$` trips Sonar S5852 even though it's linear here.
-    let headerText = rawText;
-    if (headerText.startsWith("Show ")) headerText = headerText.slice(5).trimStart();
-    if (headerText.endsWith(" Hide")) headerText = headerText.slice(0, -5).trimEnd();
-    const monthHeader = MONTH_HEADER_RE.exec(headerText);
+    const monthHeader = parseMonthHeader(rawText);
     if (monthHeader) {
-      const month = MONTHS[monthHeader[1].toLowerCase()];
-      if (month !== undefined) {
-        activeMonth = month;
-        activeYear = Number.parseInt(monthHeader[2], 10);
-      }
+      activeMonth = monthHeader.month;
+      activeYear = monthHeader.year;
       return;
     }
 
-    // Pull all <td> cells of this row
-    const tds = $tr.find("td");
-    if (tds.length < 2) return;
-
-    // The label-bearing cell is always the 2nd td (index 1) in the homepage
-    // table — the first td is a 142px spacer. Reading it directly keeps the
-    // parser tight and dodges the run-into-month-header false positives we'd
-    // hit with full-row text matching.
-    const labelCell = $(tds[1]);
-    const labelText = decodeEntities(labelCell.text()).replace(/\s+/g, " ").trim();
-    const valueCell = tds.length >= 3 ? $(tds[2]) : null;
-    const valueText = valueCell
-      ? decodeEntities(valueCell.text()).replace(/\s+/g, " ").trim()
-      : "";
+    const cells = extractRowCells($, $tr);
+    if (!cells) return;
+    const { labelText, valueText, valueCell } = cells;
 
     const runNumberFromLabel = extractHashRunNumber(labelText);
     if (runNumberFromLabel !== undefined) {
       current = { runNumber: runNumberFromLabel };
       return;
     }
-
-    if (!current) return; // ignore stray rows outside a block
+    if (!current) return;
 
     if (/^Date\/Cost:/i.test(labelText)) {
-      const dc = parseDateCost(valueText);
-      if (dc) {
-        const month = dc.month ?? activeMonth;
-        const year = dc.year ?? activeYear;
-        if (month !== undefined && year !== undefined) {
-          current.day = dc.day;
-          current.month = month;
-          current.year = year;
-          current.startTime = dc.time;
-          current.cost = dc.cost;
-        }
-      }
+      applyDateCost(current, valueText, activeMonth, activeYear);
     } else if (/^Hare\(s\):/i.test(labelText)) {
       current.hares = valueText || undefined;
     } else if (/^Location:/i.test(labelText)) {
-      // Neighborhood text comes before the "Click for directions" link. Strip
-      // the link text (or its boilerplate variant) off the end and keep what's left.
-      const link = valueCell?.find("a").first();
-      const linkText = link ? decodeEntities(link.text()).trim() : "";
-      const neighborhood = (linkText
-        ? valueText.replace(linkText, "")
-        : valueText.replace(/\bClick for directions\b.*$/i, "")
-      ).trim();
-      current.location = neighborhood || undefined;
-      const href = link?.attr("href");
+      const { neighborhood, href } = extractLocation(valueText, valueCell);
+      current.location = neighborhood;
       if (href) current.locationUrl = href;
       // Location row terminates a run block in MH3's table.
-      if (
-        current.runNumber !== undefined &&
-        current.day !== undefined &&
-        current.month !== undefined &&
-        current.year !== undefined
-      ) {
-        runs.push(current as ParsedRun);
-      }
+      finalizeRun(current, runs);
       current = null;
     }
   });

--- a/src/adapters/html-scraper/mhhh-ca.ts
+++ b/src/adapters/html-scraper/mhhh-ca.ts
@@ -41,7 +41,13 @@ interface MhhhCaConfig {
 
 const KENNEL_TAG_DEFAULT = "mh3-ca";
 
-/** Recognize the "Month YYYY" header rows that separate run blocks. */
+/**
+ * Recognize the "Month YYYY" header rows that separate run blocks. The
+ * `[A-Za-z]+` capture is intentionally broad — non-month names like
+ * "Spring 2026" are rejected downstream by the `MONTHS` Set lookup. Don't
+ * "tighten" the regex to a literal month alternation; the broad-capture +
+ * Set-validation form is the lower-complexity option (Sonar S5843).
+ */
 const MONTH_HEADER_RE = /^([A-Za-z]+)\s+(\d{4})$/;
 
 /** "May 3, 2026 13h00 $13" → { day: 3, time: "13:00", cost: "$13" } */

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle } from "./adapter";
+import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle, cleanMeetupDescription } from "./adapter";
 import type { Source } from "@/generated/prisma/client";
 
 vi.mock("../safe-fetch", () => ({
@@ -314,6 +314,34 @@ describe("resolveVenue — name cleanup integration", () => {
     // "California" is a city in Missouri — should not be suppressed just because it's also a state name
     const result = resolveVenue({}, { name: "Some Bar", city: "California", state: "MO" });
     expect(result.location).toBe("Some Bar, California, MO");
+  });
+});
+
+describe("cleanMeetupDescription — #1659 hex placeholder filter", () => {
+  it.each([
+    ["$44", undefined],
+    ["$3f", undefined],
+    ["$FF", undefined],
+    ["$00", undefined],
+    ["  $43  ", undefined], // whitespace tolerated
+    ["<p>$42</p>", undefined], // HTML-wrapped placeholder
+  ])("drops placeholder-token %p", (input, expected) => {
+    expect(cleanMeetupDescription(input)).toBe(expected);
+  });
+
+  it.each([
+    "Trail #42 — meet at the pub. Cost: $13 cash.",
+    "**Structure**\n\nThis event will be a run/walk, followed by a social gathering.",
+    "$13 hash cash includes food and beer",
+    "Run 1683 — meet at the bar",
+  ])("preserves prose %p", (input) => {
+    expect(cleanMeetupDescription(input)).toContain(input.slice(0, 10));
+  });
+
+  it("returns undefined for empty / whitespace-only input", () => {
+    expect(cleanMeetupDescription(undefined)).toBeUndefined();
+    expect(cleanMeetupDescription("")).toBeUndefined();
+    expect(cleanMeetupDescription("   ")).toBeUndefined();
   });
 });
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -265,10 +265,26 @@ export function resolveVenue(
   };
 }
 
+/**
+ * Placeholder-token shape that Meetup occasionally surfaces in `description`
+ * instead of real prose. Observed on MH3 Montreal (#1659): six consecutive
+ * runs (#1683-#1688) each carried a single `$XX` hex token with no other
+ * content, satisfying `runNumber + parseInt(hex, 16) === 1751`. The current
+ * Meetup payload no longer reproduces it, but the stored shape is real and
+ * the live source is opaque — drop it defensively at ingest so the same
+ * shape can't slip through again on any Meetup kennel. A bare `$` followed
+ * only by hex is never a meaningful trail description; a real description
+ * starting with `$` (e.g. "$13 cash") has trailing prose and survives.
+ */
+const MEETUP_PLACEHOLDER_TOKEN_RE = /^\$[0-9a-f]+$/i;
+
 /** Strip HTML tags from Meetup description and truncate. */
-function cleanMeetupDescription(desc: string | undefined): string | undefined {
+export function cleanMeetupDescription(desc: string | undefined): string | undefined {
   if (!desc) return undefined;
-  return stripHtmlTags(desc).slice(0, 2000) || undefined;
+  const stripped = stripHtmlTags(desc).slice(0, 2000);
+  if (!stripped) return undefined;
+  if (MEETUP_PLACEHOLDER_TOKEN_RE.test(stripped.trim())) return undefined;
+  return stripped;
 }
 
 /**

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -102,6 +102,7 @@ import { CapitalH3Adapter } from "./html-scraper/capital-h3";
 import { MoolooHhhAdapter } from "./html-scraper/mooloo-hhh";
 import { GeriatrixH3Adapter } from "./html-scraper/geriatrix-h3";
 import { HogtownAdapter } from "./html-scraper/hogtown";
+import { MhhhCaAdapter } from "./html-scraper/mhhh-ca";
 import { GoogleCalendarAdapter } from "./google-calendar/adapter";
 import { GoogleSheetsAdapter } from "./google-sheets/adapter";
 import { ICalAdapter } from "./ical/adapter";
@@ -254,6 +255,9 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   // (HOGTOWN / TWAT / HOGANS) share one kennel; the series prefix lives in
   // the title since the schema has no sub-series field.
   { pattern: /hogtownh3\.com/i, name: "HogtownAdapter", factory: () => new HogtownAdapter() },
+  // Montreal H3 (#1660) — FrontPage static site; per-event hares + neighborhood
+  // fill the Meetup "Location not specified yet" gap.
+  { pattern: /mhhh\.ca/i, name: "MhhhCaAdapter", factory: () => new MhhhCaAdapter() },
 ];
 
 /** URL-based routing for HTML_SCRAPER — derived from htmlScraperEntries (single source of truth). */


### PR DESCRIPTION
## Summary

MH3 Montreal Deep Dive — one kennel, four issues, one PR.

Closes #1658
Closes #1659
Closes #1660
Closes #1661

### What changed

| # | Issue | Fix |
|---|---|---|
| #1659 | Meetup descriptions stored as descending `\$XX` hex tokens (algebraic shape: `runNumber + hex == 1751`) | Defensive filter in `cleanMeetupDescription` + one-shot cleanup script that nulls existing corrupted `Event.description` rows. Live MH3 Meetup payload no longer reproduces the shape, but the filter prevents regression on any Meetup kennel. |
| #1660 | Meetup events frequently show "Location not specified yet" — mhhh.ca exposes neighborhood + hares the Meetup feed lacks | New `MhhhCaAdapter` (FrontPage-generated static HTML, parsed via Cheerio) registered at `trustLevel: 8` so its hares/location win over the Meetup source (trustLevel 7) in cross-source merge. |
| #1661 | Kennel founded 1995 / latest run #1688; HT has only 2026 events | One-shot backfill script walks `/trash/{1996..2008}/` and parses both the year-index rows and the linked detail pages. **Honest scope**: only ~100 historical runs are publicly archived in parseable form — the remaining ~1500 are held only as aggregated stats on `hashstats.htm`. Detail pages reachable today yield day-precision dates + hares; year-index-only rows fall back to month-precision (date = 1st of month) with a `#run-NNN` sourceUrl anchor so the merge pipeline's same-day disambiguation doesn't collapse siblings. |
| #1658 | Profile bundle | `contactEmail: montrealhhh@gmail.com`, `scheduleNotes`, fleshed-out user-facing description prose (hash cash \$13 embedded in description per cycle-9+ deferred pattern tracked by #1571). |

### Live verification

`MhhhCaAdapter.fetch()` against production mhhh.ca returned 5 May 2026 events (runs 1684-1688). All have UTC-noon-normalized dates, run numbers, `startTime: "13:00"`, `cost: "$13"`, populated hares, neighborhood (or upstream "TBD" verbatim), and `locationUrl` to the Meetup directions link. Cross-source dedup against the existing Meetup source should collapse these onto one Event each at next scrape with mhhh.ca's hares/location winning the trustLevel-8 vs trustLevel-7 tiebreak.

### Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors in changed files
- [x] `npm test` — 7302 passed
- [x] `MhhhCaAdapter` live-verified against https://mhhh.ca/
- [x] Meetup adapter test suite: 127 cases (added 11 hex-filter cases)
- [x] mhhh.ca adapter test suite: 9 cases
- [ ] Post-merge: `npx prisma db seed` (new source row + kennel updates)
- [ ] Post-merge: `npm run tsx scripts/cleanup-mh3-meetup-hex-descriptions.ts -- --apply` (clear existing corrupted descriptions)
- [ ] Post-merge: `BACKFILL_APPLY=1 npm run tsx scripts/backfill-mh3-ca-history.ts` (insert ~100 historical RawEvents)
- [ ] Post-merge: re-run `/update-sources-rule` skill to sync `.claude/rules/active-sources.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)