### PR TITLE
fix(merge): detect same-sourceUrl date corrections; OFH3 year-anchor

### DIFF
--- a/scripts/cleanup-phantom-date-duplicates.ts
+++ b/scripts/cleanup-phantom-date-duplicates.ts
@@ -178,116 +178,134 @@ function pickWinnerLoser(a: ScanRow, b: ScanRow): { winner: ScanRow; loser: Scan
   return a.date.getTime() > b.date.getTime() ? { winner: a, loser: b } : { winner: b, loser: a };
 }
 
+interface CleanupState {
+  lossesById: Map<string, ScanRow>;
+  winsById: Map<string, ScanRow>;
+  blockingAttendance: { event: ScanRow; pair: PairRow }[];
+}
+
+function fmtScanRow(e: ScanRow): string {
+  return `${e.id} date=${e.date.toISOString().slice(0, 10)} trust=${e.trustLevel} ` +
+    `att=${e.attendanceCount}+${e.kennelAttendanceCount} ` +
+    `lastScrape=${e.latestScrapedAt?.toISOString() ?? "<none>"} ` +
+    `title=${JSON.stringify(e.title)}`;
+}
+
+async function ingestAutoPairs(pairs: PairRow[], state: CleanupState): Promise<void> {
+  for (const pair of pairs) {
+    const [a, b] = await Promise.all([inspectEvent(pair.a_id), inspectEvent(pair.b_id)]);
+    const { winner, loser } = pickWinnerLoser(a, b);
+
+    if (loser.attendanceCount + loser.kennelAttendanceCount > 0) {
+      state.blockingAttendance.push({ event: loser, pair });
+    }
+    if (!state.lossesById.has(loser.id)) state.lossesById.set(loser.id, loser);
+    if (!state.winsById.has(winner.id)) state.winsById.set(winner.id, winner);
+
+    console.log(
+      `[${pair.kennel_code}] sourceUrl=${pair.a_source_url}\n` +
+      `  KEEP : ${fmtScanRow(winner)}\n` +
+      `  DROP : ${fmtScanRow(loser)}\n`,
+    );
+  }
+}
+
+async function ingestNamedPhantoms(state: CleanupState): Promise<void> {
+  if (NAMED_PHANTOMS.length === 0) return;
+  console.log(`\nNamed-phantom purges (${NAMED_PHANTOMS.length}):`);
+  for (const entry of NAMED_PHANTOMS) {
+    const exists = await prisma.event.findUnique({
+      where: { id: entry.loserId },
+      select: { id: true },
+    });
+    if (!exists) {
+      console.log(`  [#${entry.issue} ${entry.kennelCode}] ${entry.loserId}  ALREADY CLEANED — skip`);
+      continue;
+    }
+    const ev = await inspectEvent(entry.loserId);
+    if (ev.attendanceCount + ev.kennelAttendanceCount > 0) {
+      // Synthesize a PairRow-shaped record so the attendance-error block
+      // can print one consistent format for both auto and named entries.
+      state.blockingAttendance.push({
+        event: ev,
+        pair: {
+          a_id: ev.id, a_date: ev.date,
+          a_source_url: ev.sourceUrl ?? "(named)",
+          b_id: "(named-purge)", b_date: ev.date,
+          kennel_code: entry.kennelCode,
+        },
+      });
+    }
+    if (!state.lossesById.has(ev.id)) state.lossesById.set(ev.id, ev);
+    console.log(
+      `  [#${entry.issue} ${entry.kennelCode}] ${entry.reason}\n` +
+      `    DROP : ${fmtScanRow(ev)}`,
+    );
+  }
+}
+
+function reportAttendanceBlocks(blocks: { event: ScanRow; pair: PairRow }[]): void {
+  console.error(
+    `\nABORT: ${blocks.length} losing Event(s) carry attendance rows. ` +
+    `Reassign attendance to the surviving canonical (via misman or admin tools) ` +
+    `before re-running this cleanup. Affected:`,
+  );
+  for (const { event, pair } of blocks) {
+    console.error(
+      `  ${pair.kennel_code} eventId=${event.id} date=${event.date.toISOString().slice(0, 10)} ` +
+      `attendance=${event.attendanceCount} kennelAttendance=${event.kennelAttendanceCount}`,
+    );
+  }
+}
+
+function findWinnerLoserCollision(state: CleanupState): string | null {
+  for (const id of state.lossesById.keys()) {
+    if (state.winsById.has(id)) return id;
+  }
+  return null;
+}
+
 async function main() {
   const pairs = await findPhantomPairs();
   console.log(`Mode: ${APPLY ? "APPLY (writing to prod)" : "DRY RUN"}`);
   console.log(`Found ${pairs.length} candidate phantom-date pair(s) within ±${WINDOW_DAYS} days.\n`);
 
-  if (pairs.length === 0) {
+  if (pairs.length === 0 && NAMED_PHANTOMS.length === 0) {
     console.log("Nothing to clean.");
     await prisma.$disconnect();
     return;
   }
 
-  // De-dupe loser IDs across pairs — a 3-way cluster could nominate the
-  // same event as the loser twice.
-  const lossesById = new Map<string, ScanRow>();
-  const winsById = new Map<string, ScanRow>();
-  const blockingAttendance: { event: ScanRow; pair: PairRow }[] = [];
+  const state: CleanupState = {
+    lossesById: new Map(),
+    winsById: new Map(),
+    blockingAttendance: [],
+  };
 
-  const fmt = (e: ScanRow) =>
-    `${e.id} date=${e.date.toISOString().slice(0, 10)} trust=${e.trustLevel} ` +
-    `att=${e.attendanceCount}+${e.kennelAttendanceCount} ` +
-    `lastScrape=${e.latestScrapedAt?.toISOString() ?? "<none>"} ` +
-    `title=${JSON.stringify(e.title)}`;
+  await ingestAutoPairs(pairs, state);
+  await ingestNamedPhantoms(state);
 
-  for (const pair of pairs) {
-    const [a, b] = await Promise.all([inspectEvent(pair.a_id), inspectEvent(pair.b_id)]);
-    const { winner, loser } = pickWinnerLoser(a, b);
-
-    const totalAttendance = loser.attendanceCount + loser.kennelAttendanceCount;
-    if (totalAttendance > 0) {
-      blockingAttendance.push({ event: loser, pair });
-    }
-
-    if (!lossesById.has(loser.id)) lossesById.set(loser.id, loser);
-    if (!winsById.has(winner.id)) winsById.set(winner.id, winner);
-
-    console.log(
-      `[${pair.kennel_code}] sourceUrl=${pair.a_source_url}\n` +
-      `  KEEP : ${fmt(winner)}\n` +
-      `  DROP : ${fmt(loser)}\n`,
-    );
-  }
-
-  // Named-phantom purges (see NAMED_PHANTOMS comment for rationale).
-  if (NAMED_PHANTOMS.length > 0) {
-    console.log(`\nNamed-phantom purges (${NAMED_PHANTOMS.length}):`);
-    for (const entry of NAMED_PHANTOMS) {
-      const exists = await prisma.event.findUnique({
-        where: { id: entry.loserId },
-        select: { id: true },
-      });
-      if (!exists) {
-        console.log(`  [#${entry.issue} ${entry.kennelCode}] ${entry.loserId}  ALREADY CLEANED — skip`);
-        continue;
-      }
-      const ev = await inspectEvent(entry.loserId);
-      if (ev.attendanceCount + ev.kennelAttendanceCount > 0) {
-        blockingAttendance.push({
-          event: ev,
-          // Synthesize a PairRow-shaped record for the attendance-error block.
-          pair: {
-            a_id: ev.id, a_date: ev.date,
-            a_source_url: ev.sourceUrl ?? "(named)",
-            b_id: "(named-purge)", b_date: ev.date,
-            kennel_code: entry.kennelCode,
-          },
-        });
-      }
-      if (!lossesById.has(ev.id)) lossesById.set(ev.id, ev);
-      console.log(
-        `  [#${entry.issue} ${entry.kennelCode}] ${entry.reason}\n` +
-        `    DROP : ${fmt(ev)}`,
-      );
-    }
-  }
-
-  if (blockingAttendance.length > 0) {
-    console.error(
-      `\nABORT: ${blockingAttendance.length} losing Event(s) carry attendance rows. ` +
-      `Reassign attendance to the surviving canonical (via misman or admin tools) ` +
-      `before re-running this cleanup. Affected:`,
-    );
-    for (const { event, pair } of blockingAttendance) {
-      console.error(
-        `  ${pair.kennel_code} eventId=${event.id} date=${event.date.toISOString().slice(0, 10)} ` +
-        `attendance=${event.attendanceCount} kennelAttendance=${event.kennelAttendanceCount}`,
-      );
-    }
+  if (state.blockingAttendance.length > 0) {
+    reportAttendanceBlocks(state.blockingAttendance);
     await prisma.$disconnect();
     process.exit(1);
   }
 
-  // Belt-and-suspenders: refuse to delete an Event that's also nominated as
-  // a winner in another pair (impossible by current discovery shape but
-  // cheap to assert before a destructive write).
-  for (const id of lossesById.keys()) {
-    if (winsById.has(id)) {
-      console.error(`ABORT: event ${id} is both a winner and a loser across pairs. Aborting to avoid data loss.`);
-      await prisma.$disconnect();
-      process.exit(1);
-    }
+  const collision = findWinnerLoserCollision(state);
+  if (collision !== null) {
+    console.error(`ABORT: event ${collision} is both a winner and a loser across pairs. Aborting to avoid data loss.`);
+    await prisma.$disconnect();
+    process.exit(1);
   }
 
   if (!APPLY) {
-    console.log(`\nDry-run only — ${lossesById.size} Event(s) would be cascade-deleted.`);
+    console.log(`\nDry-run only — ${state.lossesById.size} Event(s) would be cascade-deleted.`);
     console.log("Re-run with --apply to write changes.");
     await prisma.$disconnect();
     return;
   }
 
-  const deleted = await cascadeDeleteEvents(prisma, [...lossesById.keys()]);
+  const deleted = await cascadeDeleteEvents(prisma, [...state.lossesById.keys()]);
   console.log(`\nDeleted ${deleted} Event row(s) (dependents removed, RawEvent history unlinked).`);
   await prisma.$disconnect();
 }

--- a/scripts/cleanup-phantom-date-duplicates.ts
+++ b/scripts/cleanup-phantom-date-duplicates.ts
@@ -31,6 +31,7 @@
  *   npm run tsx scripts/cleanup-phantom-date-duplicates.ts -- --apply
  */
 import "dotenv/config";
+import { Prisma } from "../src/generated/prisma/client";
 import { prisma } from "../src/lib/db";
 import { cascadeDeleteEvents } from "./lib/cascade-delete";
 
@@ -121,7 +122,7 @@ async function findPhantomPairs(): Promise<PairRow[]> {
     JOIN "EventKennel" ka ON ka."eventId" = a.id
     JOIN "EventKennel" kb ON kb."eventId" = b.id AND kb."kennelId" = ka."kennelId"
     JOIN "Kennel" k       ON k.id = ka."kennelId"
-    WHERE k."kennelCode" = ANY (${[...AFFECTED_KENNEL_CODES]}::text[])
+    WHERE k."kennelCode" IN (${Prisma.join([...AFFECTED_KENNEL_CODES])})
       AND a."sourceUrl" IS NOT NULL AND a."sourceUrl" <> ''
       AND a.status <> 'CANCELLED' AND b.status <> 'CANCELLED'
       AND a."parentEventId" IS NULL AND b."parentEventId" IS NULL

--- a/scripts/cleanup-phantom-date-duplicates.ts
+++ b/scripts/cleanup-phantom-date-duplicates.ts
@@ -1,0 +1,298 @@
+/**
+ * One-shot cleanup for the phantom-date duplicate cohort (#1613 MarinH3,
+ * #1643 OFH3, #1648 Narwhal H3).
+ *
+ * Root cause (fixed in this PR's `src/pipeline/merge.ts` change): the merge
+ * pipeline keyed canonical-Event lookup on `(kennelId, date)` only, so when
+ * a source corrected an event's date the old canonical Event survived
+ * alongside the new one — both pointing at the same `sourceUrl`. This
+ * script resolves the existing pre-fix duplicate cohort by deleting the
+ * stale half of each pair.
+ *
+ * Discovery: self-join on `Event.sourceUrl` constrained to a single kennel
+ * via `EventKennel`, with `|date_a - date_b| ≤ N days`. Confined to the
+ * three affected kennels by kennelCode whitelist so this script can never
+ * misfire on unrelated data.
+ *
+ * Resolution policy (locked):
+ *   - Keep the Event whose linked RawEvent set has the most-recent
+ *     `scrapedAt` (latest scrape = source's current truth).
+ *   - **Attendance preflight**: if the losing Event has any Attendance or
+ *     KennelAttendance rows the script aborts with a listing — misman
+ *     attendance loss is unrecoverable, so a human must reassign before
+ *     this script can clean.
+ *   - Cascade-delete the loser via `cascadeDeleteEvents` (preserves
+ *     RawEvents via `eventId=null, processed=false` so the audit trail
+ *     survives and the merge pipeline will re-link them to the winner on
+ *     the next scrape).
+ *
+ * Dry-run by default; pass `--apply` to write.
+ *   npm run tsx scripts/cleanup-phantom-date-duplicates.ts           # preview
+ *   npm run tsx scripts/cleanup-phantom-date-duplicates.ts -- --apply
+ */
+import "dotenv/config";
+import { prisma } from "../src/lib/db";
+import { cascadeDeleteEvents } from "./lib/cascade-delete";
+
+const APPLY = process.argv.includes("--apply");
+
+// Must match SAME_SOURCE_URL_DEDUP_WINDOW_DAYS in src/pipeline/merge.ts —
+// using the same window means the cleanup catches exactly what the merge
+// fix would have caught had it been live for the original scrapes.
+const WINDOW_DAYS = 30;
+
+// Whitelist scope: only the three kennels in the audited issues. Adding a
+// kennel here without explicit issue tracking would risk merging legitimate
+// distinct events that happen to share a sourceUrl (rare but possible —
+// e.g. an iCal feed with one master URL per recurring run).
+const AFFECTED_KENNEL_CODES = ["marinh3", "ofh3", "narwhal-h3"] as const;
+
+/**
+ * Explicit-purge list: phantom-date pairs that the auto-discovery query
+ * misses, captured from issue bodies. Each entry deletes the named loser
+ * Event with the same attendance preflight as the auto path.
+ *
+ * Why these are listed manually rather than discovered:
+ *  - **Narwhal H3 #1648**: Meetup assigned the rescheduled event a new
+ *    eventId, so the two canonical Events carry distinct sourceUrls.
+ *    The merge.ts fix only matches identical sourceUrls (correct — distinct
+ *    URLs imply distinct events per the platform's data model). Cleanup
+ *    can only be one-shot.
+ *  - **OFH3 #1643**: The phantom currently has no sibling at the correct
+ *    date — it stands alone at 2026-06-01. Once the adapter year-anchor
+ *    fix re-scrapes, a new canonical at 2025-06-01 would appear, but the
+ *    365-day gap exceeds the ±30d auto-discovery window. Easier to delete
+ *    the 2026 phantom outright now.
+ */
+const NAMED_PHANTOMS: { issue: number; kennelCode: string; loserId: string; reason: string }[] = [
+  {
+    issue: 1648,
+    kennelCode: "narwhal-h3",
+    loserId: "cmmobywzg000f04i8df6ls0zi",
+    reason: "Wrong-weekday (Wed Jun 21 2023) duplicate of Sun Jun 25 trail #53; distinct Meetup eventId",
+  },
+  {
+    issue: 1643,
+    kennelCode: "ofh3",
+    loserId: "cmm3khyet000804jr5t5rr629",
+    reason: "2025 blog post mapped to 2026-06-01 by pre-fix chrono — year-anchor adapter fix re-scrapes correctly to 2025-06-01",
+  },
+];
+
+interface PairRow {
+  a_id: string;
+  a_date: Date;
+  a_source_url: string;
+  b_id: string;
+  b_date: Date;
+  kennel_code: string;
+}
+
+interface ScanRow {
+  id: string;
+  date: Date;
+  sourceUrl: string | null;
+  title: string | null;
+  trustLevel: number;
+  attendanceCount: number;
+  kennelAttendanceCount: number;
+  latestScrapedAt: Date | null;
+  status: string;
+}
+
+async function findPhantomPairs(): Promise<PairRow[]> {
+  // Self-join via EventKennel keeps the kennel scope tight. `b.id > a.id`
+  // canonicalizes pair ordering so a 3-way phantom cluster reports as
+  // (a,b) + (a,c) + (b,c) without double-counting in reverse.
+  return prisma.$queryRaw<PairRow[]>`
+    SELECT
+      a.id           AS a_id,
+      a.date         AS a_date,
+      a."sourceUrl"  AS a_source_url,
+      b.id           AS b_id,
+      b.date         AS b_date,
+      k."kennelCode" AS kennel_code
+    FROM "Event" a
+    JOIN "Event" b
+      ON b."sourceUrl" = a."sourceUrl"
+      AND b.id > a.id
+      AND ABS(EXTRACT(EPOCH FROM (b.date - a.date))) <= ${WINDOW_DAYS * 86400}
+      AND b.date <> a.date
+    JOIN "EventKennel" ka ON ka."eventId" = a.id
+    JOIN "EventKennel" kb ON kb."eventId" = b.id AND kb."kennelId" = ka."kennelId"
+    JOIN "Kennel" k       ON k.id = ka."kennelId"
+    WHERE k."kennelCode" = ANY (${[...AFFECTED_KENNEL_CODES]}::text[])
+      AND a."sourceUrl" IS NOT NULL AND a."sourceUrl" <> ''
+      AND a.status <> 'CANCELLED' AND b.status <> 'CANCELLED'
+      AND a."parentEventId" IS NULL AND b."parentEventId" IS NULL
+      AND a."isSeriesParent" = false AND b."isSeriesParent" = false
+    ORDER BY k."kennelCode", a."sourceUrl", a.date;
+  `;
+}
+
+async function inspectEvent(id: string): Promise<ScanRow> {
+  const event = await prisma.event.findUniqueOrThrow({
+    where: { id },
+    select: {
+      id: true,
+      date: true,
+      sourceUrl: true,
+      title: true,
+      trustLevel: true,
+      status: true,
+      _count: {
+        select: { attendances: true, kennelAttendances: true },
+      },
+      rawEvents: {
+        select: { scrapedAt: true },
+        orderBy: { scrapedAt: "desc" },
+        take: 1,
+      },
+    },
+  });
+  return {
+    id: event.id,
+    date: event.date,
+    sourceUrl: event.sourceUrl,
+    title: event.title,
+    trustLevel: event.trustLevel,
+    attendanceCount: event._count.attendances,
+    kennelAttendanceCount: event._count.kennelAttendances,
+    latestScrapedAt: event.rawEvents[0]?.scrapedAt ?? null,
+    status: event.status,
+  };
+}
+
+function pickWinnerLoser(a: ScanRow, b: ScanRow): { winner: ScanRow; loser: ScanRow } {
+  // Most-recent linked-RawEvent scrape wins — that's the version the source
+  // currently affirms. Ties (or both null) → keep the higher-trust row;
+  // ties on trust → keep the larger date (later corrections typically
+  // reflect the realized run date for late-finalizing sources).
+  const aMs = a.latestScrapedAt?.getTime() ?? 0;
+  const bMs = b.latestScrapedAt?.getTime() ?? 0;
+  if (aMs !== bMs) return aMs > bMs ? { winner: a, loser: b } : { winner: b, loser: a };
+  if (a.trustLevel !== b.trustLevel) {
+    return a.trustLevel > b.trustLevel ? { winner: a, loser: b } : { winner: b, loser: a };
+  }
+  return a.date.getTime() > b.date.getTime() ? { winner: a, loser: b } : { winner: b, loser: a };
+}
+
+async function main() {
+  const pairs = await findPhantomPairs();
+  console.log(`Mode: ${APPLY ? "APPLY (writing to prod)" : "DRY RUN"}`);
+  console.log(`Found ${pairs.length} candidate phantom-date pair(s) within ±${WINDOW_DAYS} days.\n`);
+
+  if (pairs.length === 0) {
+    console.log("Nothing to clean.");
+    await prisma.$disconnect();
+    return;
+  }
+
+  // De-dupe loser IDs across pairs — a 3-way cluster could nominate the
+  // same event as the loser twice.
+  const lossesById = new Map<string, ScanRow>();
+  const winsById = new Map<string, ScanRow>();
+  const blockingAttendance: { event: ScanRow; pair: PairRow }[] = [];
+
+  const fmt = (e: ScanRow) =>
+    `${e.id} date=${e.date.toISOString().slice(0, 10)} trust=${e.trustLevel} ` +
+    `att=${e.attendanceCount}+${e.kennelAttendanceCount} ` +
+    `lastScrape=${e.latestScrapedAt?.toISOString() ?? "<none>"} ` +
+    `title=${JSON.stringify(e.title)}`;
+
+  for (const pair of pairs) {
+    const [a, b] = await Promise.all([inspectEvent(pair.a_id), inspectEvent(pair.b_id)]);
+    const { winner, loser } = pickWinnerLoser(a, b);
+
+    const totalAttendance = loser.attendanceCount + loser.kennelAttendanceCount;
+    if (totalAttendance > 0) {
+      blockingAttendance.push({ event: loser, pair });
+    }
+
+    if (!lossesById.has(loser.id)) lossesById.set(loser.id, loser);
+    if (!winsById.has(winner.id)) winsById.set(winner.id, winner);
+
+    console.log(
+      `[${pair.kennel_code}] sourceUrl=${pair.a_source_url}\n` +
+      `  KEEP : ${fmt(winner)}\n` +
+      `  DROP : ${fmt(loser)}\n`,
+    );
+  }
+
+  // Named-phantom purges (see NAMED_PHANTOMS comment for rationale).
+  if (NAMED_PHANTOMS.length > 0) {
+    console.log(`\nNamed-phantom purges (${NAMED_PHANTOMS.length}):`);
+    for (const entry of NAMED_PHANTOMS) {
+      const exists = await prisma.event.findUnique({
+        where: { id: entry.loserId },
+        select: { id: true },
+      });
+      if (!exists) {
+        console.log(`  [#${entry.issue} ${entry.kennelCode}] ${entry.loserId}  ALREADY CLEANED — skip`);
+        continue;
+      }
+      const ev = await inspectEvent(entry.loserId);
+      if (ev.attendanceCount + ev.kennelAttendanceCount > 0) {
+        blockingAttendance.push({
+          event: ev,
+          // Synthesize a PairRow-shaped record for the attendance-error block.
+          pair: {
+            a_id: ev.id, a_date: ev.date,
+            a_source_url: ev.sourceUrl ?? "(named)",
+            b_id: "(named-purge)", b_date: ev.date,
+            kennel_code: entry.kennelCode,
+          },
+        });
+      }
+      if (!lossesById.has(ev.id)) lossesById.set(ev.id, ev);
+      console.log(
+        `  [#${entry.issue} ${entry.kennelCode}] ${entry.reason}\n` +
+        `    DROP : ${fmt(ev)}`,
+      );
+    }
+  }
+
+  if (blockingAttendance.length > 0) {
+    console.error(
+      `\nABORT: ${blockingAttendance.length} losing Event(s) carry attendance rows. ` +
+      `Reassign attendance to the surviving canonical (via misman or admin tools) ` +
+      `before re-running this cleanup. Affected:`,
+    );
+    for (const { event, pair } of blockingAttendance) {
+      console.error(
+        `  ${pair.kennel_code} eventId=${event.id} date=${event.date.toISOString().slice(0, 10)} ` +
+        `attendance=${event.attendanceCount} kennelAttendance=${event.kennelAttendanceCount}`,
+      );
+    }
+    await prisma.$disconnect();
+    process.exit(1);
+  }
+
+  // Belt-and-suspenders: refuse to delete an Event that's also nominated as
+  // a winner in another pair (impossible by current discovery shape but
+  // cheap to assert before a destructive write).
+  for (const id of lossesById.keys()) {
+    if (winsById.has(id)) {
+      console.error(`ABORT: event ${id} is both a winner and a loser across pairs. Aborting to avoid data loss.`);
+      await prisma.$disconnect();
+      process.exit(1);
+    }
+  }
+
+  if (!APPLY) {
+    console.log(`\nDry-run only — ${lossesById.size} Event(s) would be cascade-deleted.`);
+    console.log("Re-run with --apply to write changes.");
+    await prisma.$disconnect();
+    return;
+  }
+
+  const deleted = await cascadeDeleteEvents(prisma, [...lossesById.keys()]);
+  console.log(`\nDeleted ${deleted} Event row(s) (dependents removed, RawEvent history unlinked).`);
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/ofh3.test.ts
+++ b/src/adapters/html-scraper/ofh3.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
-import { parseOfh3Date, parseOfh3Body, cleanOfh3Title, extractBloggerYearAnchor } from "./ofh3";
-import { OFH3Adapter } from "./ofh3";
+import { parseOfh3Date, parseOfh3Body, cleanOfh3Title, extractBloggerYearAnchor, OFH3Adapter } from "./ofh3";
 import * as bloggerApi from "../blogger-api";
 
 vi.mock("../blogger-api");

--- a/src/adapters/html-scraper/ofh3.test.ts
+++ b/src/adapters/html-scraper/ofh3.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { parseOfh3Date, parseOfh3Body, cleanOfh3Title } from "./ofh3";
+import { parseOfh3Date, parseOfh3Body, cleanOfh3Title, extractBloggerYearAnchor } from "./ofh3";
 import { OFH3Adapter } from "./ofh3";
 import * as bloggerApi from "../blogger-api";
 
@@ -391,5 +391,92 @@ describe("parseOfh3Body — newline-delimited fields", () => {
     const result = parseOfh3Body(text);
     expect(result.location).toBe("Blue Heron Elementary");
     expect(result.trailType).toBe("A-A");
+  });
+});
+
+describe("extractBloggerYearAnchor (#1643)", () => {
+  it("extracts year+month from a standard Blogspot URL", () => {
+    const anchor = extractBloggerYearAnchor(
+      "https://www.ofh3.com/2025/05/ofh3-trail-387-june-tour-duh-hash-trail.html",
+    );
+    expect(anchor).toEqual(new Date(Date.UTC(2025, 4, 1, 12, 0, 0)));
+  });
+
+  it("returns null when URL lacks /YYYY/MM/ path", () => {
+    expect(extractBloggerYearAnchor("https://www.ofh3.com/")).toBeNull();
+    expect(extractBloggerYearAnchor("https://www.ofh3.com/some-page.html")).toBeNull();
+  });
+
+  it("rejects implausible years and months", () => {
+    expect(extractBloggerYearAnchor("https://example.com/1999/05/post.html")).toBeNull();
+    expect(extractBloggerYearAnchor("https://example.com/2025/13/post.html")).toBeNull();
+  });
+});
+
+describe("OFH3Adapter year-rollover guard (#1643)", () => {
+  let adapter: OFH3Adapter;
+
+  beforeEach(() => {
+    adapter = new OFH3Adapter();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("anchors bare 'June 1' in a 2025 post to 2025-06-01, NOT 2026-06-01 (regression for #1643)", async () => {
+    // The phantom: a 2025 blog post whose body says "When: Sunday, June 1st"
+    // — chrono without an anchor parses that as June 1 of the current year
+    // (2026 at scrape time), creating a 2026-06-01 phantom on next year's
+    // hareline. Anchoring to the URL's publication month (2025-05) fixes it.
+    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
+      posts: [
+        {
+          title: "OFH3 Trail #387 - June 1, 2025 - Tour Duh Hash Trail",
+          content: "<p><b>Hares:</b> Mudflap</p><p><b>When:</b> Sunday, June 1st</p><p><b>Where:</b> Frederick, MD</p>",
+          url: "https://www.ofh3.com/2025/05/ofh3-trail-387-june-tour-duh-hash-trail.html",
+          published: "2025-05-15T12:00:00Z",
+        },
+      ],
+      blogId: "67890",
+      fetchDurationMs: 100,
+    });
+
+    const result = await adapter.fetch({
+      id: "test-ofh3",
+      url: "https://www.ofh3.com/",
+      scrapeDays: 365 * 10,
+    } as never);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].date).toBe("2025-06-01");
+  });
+
+  it("explicit dot-format date in the body wins over URL anchor", async () => {
+    // Body carries "6.1.25" — the dot-format branch produces an explicit year
+    // (2025) regardless of the URL anchor. Guards against the anchor
+    // accidentally overriding precise data.
+    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
+      posts: [
+        {
+          title: "OFH3 Trail #387",
+          content: "<p><b>When:</b> 6.1.25</p><p><b>Where:</b> Frederick, MD</p>",
+          // Note: URL year is 2026 but body wins — explicit > anchor.
+          url: "https://www.ofh3.com/2026/05/trail-387.html",
+          published: "2025-05-15T12:00:00Z",
+        },
+      ],
+      blogId: "67890",
+      fetchDurationMs: 100,
+    });
+
+    const result = await adapter.fetch({
+      id: "test-ofh3",
+      url: "https://www.ofh3.com/",
+      scrapeDays: 365 * 10,
+    } as never);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].date).toBe("2025-06-01");
   });
 });

--- a/src/adapters/html-scraper/ofh3.test.ts
+++ b/src/adapters/html-scraper/ofh3.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Source } from "@/generated/prisma/client";
 import { parseOfh3Date, parseOfh3Body, cleanOfh3Title, extractBloggerYearAnchor } from "./ofh3";
 import { OFH3Adapter } from "./ofh3";
 import * as bloggerApi from "../blogger-api";
 
 vi.mock("../blogger-api");
+
+// Typed factory so tests can pass a partial Source without per-call
+// `as never` — Source has 14+ required fields the adapter never reads.
+function fakeSource(overrides: Partial<Source> & Pick<Source, "id" | "url">): Source {
+  return overrides as unknown as Source;
+}
 
 describe("parseOfh3Date", () => {
   it("parses 'Saturday, March 14, 2026'", () => {
@@ -442,11 +449,11 @@ describe("OFH3Adapter year-rollover guard (#1643)", () => {
       fetchDurationMs: 100,
     });
 
-    const result = await adapter.fetch({
+    const result = await adapter.fetch(fakeSource({
       id: "test-ofh3",
       url: "https://www.ofh3.com/",
       scrapeDays: 365 * 10,
-    } as never);
+    }));
 
     expect(result.events).toHaveLength(1);
     expect(result.events[0].date).toBe("2025-06-01");
@@ -470,11 +477,11 @@ describe("OFH3Adapter year-rollover guard (#1643)", () => {
       fetchDurationMs: 100,
     });
 
-    const result = await adapter.fetch({
+    const result = await adapter.fetch(fakeSource({
       id: "test-ofh3",
       url: "https://www.ofh3.com/",
       scrapeDays: 365 * 10,
-    } as never);
+    }));
 
     expect(result.events).toHaveLength(1);
     expect(result.events[0].date).toBe("2025-06-01");

--- a/src/adapters/html-scraper/ofh3.ts
+++ b/src/adapters/html-scraper/ofh3.ts
@@ -13,7 +13,7 @@ import { applyDateWindow, chronoParseDate, decodeEntities, isPlaceholder, stripH
  * Tries dot-separated format first (specific to OFH3) to avoid chrono picking
  * up a stray month name before the dot-separated date in title text.
  */
-export function parseOfh3Date(text: string): string | null {
+export function parseOfh3Date(text: string, referenceDate?: Date): string | null {
   // Try dot-separated format first: "3.14.26" or "03.14.2026"
   const dotMatch = text.match(/(\d{1,2})\.(\d{1,2})\.(\d{2,4})/);
   if (dotMatch) {
@@ -25,8 +25,11 @@ export function parseOfh3Date(text: string): string | null {
       return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
     }
   }
-  // Fall back to chrono-node for standard date formats
-  return chronoParseDate(text, "en-US");
+  // Fall back to chrono-node for standard date formats. `referenceDate`
+  // anchors year-less inputs ("June 1st") to the post's publication month
+  // (#1643) — chronoParseDate defaults to `forwardDate: false` so the
+  // anchor's literal year wins.
+  return chronoParseDate(text, "en-US", referenceDate);
 }
 
 /**
@@ -42,7 +45,7 @@ export function parseOfh3Date(text: string): string | null {
  *   Shiggy rating (1-10): 5
  *   On-After: Venue Name
  */
-export function parseOfh3Body(text: string): {
+export function parseOfh3Body(text: string, referenceDate?: Date): {
   date?: string;
   hares?: string;
   cost?: string;
@@ -65,7 +68,7 @@ export function parseOfh3Body(text: string): {
   const shiggyMatch = text.match(/Shiggy\s*(?:rating)?\s*(?:\(1-10\))?\s*:\s*(.+?)(?=(?:Hares?|When|Cost|Where|Trail Type|Distances?|On[- ]?After)|\n|$)/i);
   const onAfterMatch = text.match(new RegExp(`On[- ]?After:\\s*(.+?)${stopPattern}`, "i"));
 
-  const date = whenMatch ? parseOfh3Date(whenMatch[1].trim()) : undefined;
+  const date = whenMatch ? parseOfh3Date(whenMatch[1].trim(), referenceDate) : undefined;
 
   return {
     date: date ?? undefined,
@@ -83,13 +86,39 @@ export function parseOfh3Body(text: string): {
  * Process a single OFH3 blog post into a RawEventData.
  * Returns null if the post cannot be parsed (e.g., missing date).
  */
-/** Resolve the event date from body fields or title text. Returns null if unresolvable. */
+/**
+ * Extract the year anchor from a Blogspot post URL: `/YYYY/MM/...` → Date.
+ * Returns null if the URL doesn't carry the standard Blogger path shape.
+ *
+ * Used to anchor chrono's reference date when the post body/title carries a
+ * bare month+day (e.g. "June 1") with no explicit year. Without an anchor
+ * chrono parses against the *current* date so a 2025 post seen in 2026
+ * rescheduled to 2026-06-01 — the #1643 phantom.
+ */
+export function extractBloggerYearAnchor(postUrl: string): Date | null {
+  const match = /\/(\d{4})\/(\d{1,2})\//.exec(postUrl);
+  if (!match) return null;
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  if (year < 2000 || year > 2100) return null;
+  if (month < 1 || month > 12) return null;
+  return new Date(Date.UTC(year, month - 1, 1, 12, 0, 0));
+}
+
+/**
+ * Resolve the event date from body fields or title text. Returns null if
+ * unresolvable. Both code paths are anchored to the post's publication
+ * month (via the referenceDate threaded through `parseOfh3Body` /
+ * `parseOfh3Date`) so a 2025 post's bare "June 1" resolves to 2025-06-01,
+ * not 2026-06-01 (#1643).
+ */
 function resolveOfh3EventDate(
   bodyFields: ReturnType<typeof parseOfh3Body>,
   titleText: string,
+  referenceDate?: Date,
 ): string | null {
   if (bodyFields.date) return bodyFields.date;
-  return parseOfh3Date(titleText);
+  return parseOfh3Date(titleText, referenceDate);
 }
 
 /** Build a description string from OFH3 body fields. */
@@ -129,9 +158,13 @@ function processPost(
   errors: string[],
   errorDetails: ErrorDetails,
 ): RawEventData | null {
-  const bodyFields = parseOfh3Body(bodyText);
+  // Anchor chrono to the post's publication month (extracted from the
+  // canonical Blogspot URL) so a year-less "June 1" in body/title resolves
+  // against the post's own year, not the scraper's clock (#1643).
+  const referenceDate = extractBloggerYearAnchor(postUrl) ?? undefined;
+  const bodyFields = parseOfh3Body(bodyText, referenceDate);
 
-  const eventDate = resolveOfh3EventDate(bodyFields, titleText);
+  const eventDate = resolveOfh3EventDate(bodyFields, titleText, referenceDate);
   if (!eventDate) {
     if (bodyText.trim().length > 0) {
       const dateError = `No date found in post: ${titleText || "(untitled)"}`;

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -139,7 +139,7 @@ beforeEach(() => {
   // Same-sourceUrl date-correction probe (#1613 / #1648) defaults to "no match"
   // so existing tests are unaffected; per-test overrides exercise the
   // correction path itself.
-  vi.mocked(prisma.event.findFirst).mockResolvedValue(null as never);
+  vi.mocked(prisma.event.findFirst).mockResolvedValue(null);
   vi.mocked(prisma.eventKennel.create).mockResolvedValue({} as never);
   // $transaction supports two call shapes: array of ops (returns Promise.all)
   // and callback (invoked with the tx client). The dual-write helper added
@@ -4381,38 +4381,39 @@ describe("linkMultiDaySeries (#1560)", () => {
   });
 });
 
-describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
-  // Builds the EventRow shape EVENT_CACHE_SELECT returns from the correction
-  // probe. Date defaults to MarinH3's pre-correction date so the +14d shape
-  // is the natural call site.
-  function existingCorrectionRow(overrides?: Record<string, unknown>) {
-    return {
-      id: "evt_phantom",
-      kennelId: "kennel_1",
-      date: new Date("2026-05-23T12:00:00.000Z"),
-      trustLevel: 5,
-      sourceUrl: "https://www.sfh3.com/runs/6443",
-      title: "Marin H3 Run #291",
-      runNumber: 291,
-      startTime: "13:00",
-      locationName: null,
-      parentEventId: null,
-      isSeriesParent: false,
-      isCanonical: true,
-      status: "CONFIRMED",
-      adminCancelledAt: null,
-      ...overrides,
-    };
-  }
+// Builds the EventRow shape EVENT_CACHE_SELECT returns from the same-sourceUrl
+// correction probe (#1613 / #1648). Date defaults to MarinH3's pre-correction
+// date so the +14d shape is the natural call site. Hoisted to module scope
+// per Sonar S7721.
+function buildCorrectionCandidate(overrides?: Record<string, unknown>) {
+  return {
+    id: "evt_phantom",
+    kennelId: "kennel_1",
+    date: new Date("2026-05-23T12:00:00.000Z"),
+    trustLevel: 5,
+    sourceUrl: "https://www.sfh3.com/runs/6443",
+    title: "Marin H3 Run #291",
+    runNumber: 291,
+    startTime: "13:00",
+    locationName: null,
+    parentEventId: null,
+    isSeriesParent: false,
+    isCanonical: true,
+    status: "CONFIRMED",
+    adminCancelledAt: null,
+    ...overrides,
+  };
+}
 
+describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
   it("MarinH3-shape: +14d sourceUrl match moves canonical, does not create phantom (#1613)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     // Cache prefetch: empty same-day pool for the corrected date.
-    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([]);
     // Old-bucket recanonicalize refetch.
-    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([]);
     // Same-sourceUrl correction probe returns the phantom from May 23.
-    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(existingCorrectionRow() as never);
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(buildCorrectionCandidate() as never);
     mockEventUpdate.mockResolvedValueOnce({ id: "evt_phantom" } as never);
 
     const result = await processRawEvents("src_sfh3_html", [
@@ -4456,8 +4457,8 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     expect(probeWhere.eventKennels.some.kennelId).toBe("kennel_1");
     expect(probeWhere.date.not).toEqual(new Date("2026-05-09T12:00:00.000Z"));
     // ±30d window
-    const expectedLo = new Date("2026-05-09T12:00:00.000Z").getTime() - 30 * 86400_000;
-    const expectedHi = new Date("2026-05-09T12:00:00.000Z").getTime() + 30 * 86400_000;
+    const expectedLo = new Date("2026-05-09T12:00:00.000Z").getTime() - 30 * 86_400_000;
+    const expectedHi = new Date("2026-05-09T12:00:00.000Z").getTime() + 30 * 86_400_000;
     expect(probeWhere.date.gte.getTime()).toBe(expectedLo);
     expect(probeWhere.date.lte.getTime()).toBe(expectedHi);
   });
@@ -4469,7 +4470,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     // adjacent events for those adapters. runNumber acts as a required
     // second signal — when an event lacks it, the probe MUST be skipped.
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([]);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_no_runnumber" } as never);
 
     const result = await processRawEvents("src_baseurl_adapter", [
@@ -4494,11 +4495,11 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     // enforces this; we assert that filter is in the WHERE clause so it
     // can't regress to a sourceUrl-only probe.
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([]);
     // Mock returns null because the WHERE includes runNumber=43 and no
     // candidate matches — but the probe MUST have been issued with that
     // filter for the DB constraint to do its job.
-    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null as never);
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_runnumber_distinct" } as never);
 
     const result = await processRawEvents("src_shith3", [
@@ -4519,10 +4520,10 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
 
   it("Narwhal-shape: +4d sourceUrl match moves canonical, does not create phantom (#1648)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never); // cache prefetch empty
-    mockEventFindMany.mockResolvedValueOnce([] as never); // old-bucket refetch
+    mockEventFindMany.mockResolvedValueOnce([]); // cache prefetch empty
+    mockEventFindMany.mockResolvedValueOnce([]); // old-bucket refetch
     vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(
-      existingCorrectionRow({
+      buildCorrectionCandidate({
         id: "evt_narwhal_phantom",
         date: new Date("2023-06-21T12:00:00.000Z"), // Wednesday phantom
         sourceUrl: "https://www.meetup.com/narwhal-h3/events/293000000",
@@ -4549,11 +4550,11 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
 
   it("OFH3-shape: year-rollover gap (>30d) does NOT match — leaves the adapter fix to resolve (#1643)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([]);
     // Probe returns null because the gap (365d) exceeds the ±30d window
     // when applied as a DB-level date filter. We assert no correction
     // happens, even if the mock would otherwise allow it.
-    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null as never);
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_new_2025" } as never);
 
     const result = await processRawEvents("src_ofh3", [
@@ -4573,9 +4574,9 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
 
   it("does NOT dedup when sourceUrls differ — distinct events stay split", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([]);
     // Probe finds nothing because sourceUrl is unique per event.
-    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null as never);
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_distinct" } as never);
 
     const result = await processRawEvents("src_a", [
@@ -4592,7 +4593,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
 
   it("does NOT run probe when incoming event has seriesId (multi-day series share parent URLs)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([]);
     mockEventCreate.mockResolvedValueOnce({ id: "evt_series" } as never);
 
     const result = await processRawEvents("src_a", [
@@ -4620,10 +4621,10 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
       kennels: [{ kennelId: "kennel_1" }],
     } as never);
     mockRawEventFind.mockResolvedValueOnce(null);
-    mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([]);
+    mockEventFindMany.mockResolvedValueOnce([]);
     vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(
-      existingCorrectionRow({ trustLevel: 9 }) as never,
+      buildCorrectionCandidate({ trustLevel: 9 }) as never,
     );
     mockEventCreate.mockResolvedValueOnce({ id: "evt_new_phantom" } as never);
 

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -4443,6 +4443,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     const probeWhere = (probeCall[0] as {
       where: {
         sourceUrl: string;
+        runNumber: number;
         date: { gte: Date; lte: Date; not: Date };
         eventKennels: { some: { kennelId: string } };
         parentEventId: null;
@@ -4451,6 +4452,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
       };
     }).where;
     expect(probeWhere.sourceUrl).toBe("https://www.sfh3.com/runs/6443");
+    expect(probeWhere.runNumber).toBe(291); // required second signal — protects shared-URL adapters
     expect(probeWhere.eventKennels.some.kennelId).toBe("kennel_1");
     expect(probeWhere.date.not).toEqual(new Date("2026-05-09T12:00:00.000Z"));
     // ±30d window
@@ -4458,6 +4460,61 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     const expectedHi = new Date("2026-05-09T12:00:00.000Z").getTime() + 30 * 86400_000;
     expect(probeWhere.date.gte.getTime()).toBe(expectedLo);
     expect(probeWhere.date.lte.getTime()).toBe(expectedHi);
+  });
+
+  it("does NOT run probe when incoming event has no runNumber (protects shared-URL adapters)", async () => {
+    // Codex review on PR #1696: many adapters (BFM, OCH3, SHITH3, Bangkok,
+    // STATIC_SCHEDULE, HashPhilly) emit a single baseUrl as sourceUrl for
+    // every event. Probing by sourceUrl alone would falsely merge distinct
+    // adjacent events for those adapters. runNumber acts as a required
+    // second signal — when an event lacks it, the probe MUST be skipped.
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_no_runnumber" } as never);
+
+    const result = await processRawEvents("src_baseurl_adapter", [
+      buildRawEvent({
+        date: "2026-05-09",
+        kennelTags: ["TestH3"],
+        sourceUrl: "https://www.bfmh3.com/", // baseUrl reused across events
+        runNumber: undefined,
+      }),
+    ]);
+
+    expect(result.created).toBe(1);
+    // The findFirst correction probe MUST NOT have been called.
+    expect(vi.mocked(prisma.event.findFirst)).not.toHaveBeenCalled();
+  });
+
+  it("does NOT match when runNumber differs (SHITH3-style: distinct events share baseUrl)", async () => {
+    // SHITH3 emits `${BASE_URL}/events.php` as sourceUrl for every event.
+    // A new event with runNumber=43 must not match an existing canonical
+    // with the same baseUrl but runNumber=42, even though everything else
+    // (kennel, ±30d window) lines up. The DB-side runNumber filter
+    // enforces this; we assert that filter is in the WHERE clause so it
+    // can't regress to a sourceUrl-only probe.
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    // Mock returns null because the WHERE includes runNumber=43 and no
+    // candidate matches — but the probe MUST have been issued with that
+    // filter for the DB constraint to do its job.
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_runnumber_distinct" } as never);
+
+    const result = await processRawEvents("src_shith3", [
+      buildRawEvent({
+        date: "2026-05-09",
+        kennelTags: ["TestH3"],
+        sourceUrl: "https://shith3.com/events.php", // shared across events
+        runNumber: 43, // a different run from the canonical at /events.php
+      }),
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(0);
+    const probeCall = vi.mocked(prisma.event.findFirst).mock.calls[0];
+    const probeWhere = (probeCall[0] as { where: { runNumber: number } }).where;
+    expect(probeWhere.runNumber).toBe(43);
   });
 
   it("Narwhal-shape: +4d sourceUrl match moves canonical, does not create phantom (#1648)", async () => {

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/lib/db", () => ({
     source: { findUnique: vi.fn(), update: vi.fn() },
     sourceKennel: { findMany: vi.fn() },
     rawEvent: { findFirst: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
-    event: { findUnique: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
+    event: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
     eventKennel: { create: vi.fn(), upsert: vi.fn() },
     eventLink: { upsert: vi.fn(), createMany: vi.fn() },
     kennel: { findUnique: vi.fn(), updateMany: vi.fn() },
@@ -136,6 +136,10 @@ beforeEach(() => {
   // recomputeCanonical early-exits on length 0 and doesn't consume the
   // next test's queued response.
   mockEventFindMany.mockResolvedValue([] as never);
+  // Same-sourceUrl date-correction probe (#1613 / #1648) defaults to "no match"
+  // so existing tests are unaffected; per-test overrides exercise the
+  // correction path itself.
+  vi.mocked(prisma.event.findFirst).mockResolvedValue(null as never);
   vi.mocked(prisma.eventKennel.create).mockResolvedValue({} as never);
   // $transaction supports two call shapes: array of ops (returns Promise.all)
   // and callback (invoked with the tx client). The dual-write helper added
@@ -4374,5 +4378,213 @@ describe("linkMultiDaySeries (#1560)", () => {
         && (args as { data?: { isSeriesParent?: boolean } }).data?.isSeriesParent === true,
     );
     expect(parentUpdate).toBeDefined();
+  });
+});
+
+describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
+  // Builds the EventRow shape EVENT_CACHE_SELECT returns from the correction
+  // probe. Date defaults to MarinH3's pre-correction date so the +14d shape
+  // is the natural call site.
+  function existingCorrectionRow(overrides?: Record<string, unknown>) {
+    return {
+      id: "evt_phantom",
+      kennelId: "kennel_1",
+      date: new Date("2026-05-23T12:00:00.000Z"),
+      trustLevel: 5,
+      sourceUrl: "https://www.sfh3.com/runs/6443",
+      title: "Marin H3 Run #291",
+      runNumber: 291,
+      startTime: "13:00",
+      locationName: null,
+      parentEventId: null,
+      isSeriesParent: false,
+      isCanonical: true,
+      status: "CONFIRMED",
+      adminCancelledAt: null,
+      ...overrides,
+    };
+  }
+
+  it("MarinH3-shape: +14d sourceUrl match moves canonical, does not create phantom (#1613)", async () => {
+    mockRawEventFind.mockResolvedValueOnce(null);
+    // Cache prefetch: empty same-day pool for the corrected date.
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    // Old-bucket recanonicalize refetch.
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    // Same-sourceUrl correction probe returns the phantom from May 23.
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(existingCorrectionRow() as never);
+    mockEventUpdate.mockResolvedValueOnce({ id: "evt_phantom" } as never);
+
+    const result = await processRawEvents("src_sfh3_html", [
+      buildRawEvent({
+        date: "2026-05-09", // 14 days earlier than existing 2026-05-23
+        kennelTags: ["marinh3"],
+        sourceUrl: "https://www.sfh3.com/runs/6443",
+        runNumber: 291,
+        title: "Marin H3 Run #291",
+      }),
+    ]);
+
+    expect(result.updated).toBe(1);
+    expect(result.created).toBe(0);
+    expect(mockEventCreate).not.toHaveBeenCalled();
+
+    // The update writes the corrected date back to the existing canonical
+    // (crossWindowMatch plumbing reused — #990).
+    const updateCall = mockEventUpdate.mock.calls.find(
+      c => (c[0] as { where: { id: string } }).where.id === "evt_phantom",
+    );
+    expect(updateCall).toBeDefined();
+    const updateData = (updateCall![0] as { data: Record<string, unknown> }).data;
+    expect(updateData.date).toEqual(new Date("2026-05-09T12:00:00.000Z"));
+
+    // The probe was actually issued with the expected window + filters.
+    const probeCall = vi.mocked(prisma.event.findFirst).mock.calls[0];
+    const probeWhere = (probeCall[0] as {
+      where: {
+        sourceUrl: string;
+        date: { gte: Date; lte: Date; not: Date };
+        eventKennels: { some: { kennelId: string } };
+        parentEventId: null;
+        isSeriesParent: false;
+        status: { not: string };
+      };
+    }).where;
+    expect(probeWhere.sourceUrl).toBe("https://www.sfh3.com/runs/6443");
+    expect(probeWhere.eventKennels.some.kennelId).toBe("kennel_1");
+    expect(probeWhere.date.not).toEqual(new Date("2026-05-09T12:00:00.000Z"));
+    // ±30d window
+    const expectedLo = new Date("2026-05-09T12:00:00.000Z").getTime() - 30 * 86400_000;
+    const expectedHi = new Date("2026-05-09T12:00:00.000Z").getTime() + 30 * 86400_000;
+    expect(probeWhere.date.gte.getTime()).toBe(expectedLo);
+    expect(probeWhere.date.lte.getTime()).toBe(expectedHi);
+  });
+
+  it("Narwhal-shape: +4d sourceUrl match moves canonical, does not create phantom (#1648)", async () => {
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never); // cache prefetch empty
+    mockEventFindMany.mockResolvedValueOnce([] as never); // old-bucket refetch
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(
+      existingCorrectionRow({
+        id: "evt_narwhal_phantom",
+        date: new Date("2023-06-21T12:00:00.000Z"), // Wednesday phantom
+        sourceUrl: "https://www.meetup.com/narwhal-h3/events/293000000",
+        title: "Trail #53 - Spawning Narwhals",
+        runNumber: 53,
+      }) as never,
+    );
+    mockEventUpdate.mockResolvedValueOnce({ id: "evt_narwhal_phantom" } as never);
+
+    const result = await processRawEvents("src_meetup", [
+      buildRawEvent({
+        date: "2023-06-25", // 4 days later than phantom
+        kennelTags: ["narwhal-h3"],
+        sourceUrl: "https://www.meetup.com/narwhal-h3/events/293000000",
+        runNumber: 53,
+        title: "Trail #53 - Spawning Narwhals",
+      }),
+    ]);
+
+    expect(result.updated).toBe(1);
+    expect(result.created).toBe(0);
+    expect(mockEventCreate).not.toHaveBeenCalled();
+  });
+
+  it("OFH3-shape: year-rollover gap (>30d) does NOT match — leaves the adapter fix to resolve (#1643)", async () => {
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    // Probe returns null because the gap (365d) exceeds the ±30d window
+    // when applied as a DB-level date filter. We assert no correction
+    // happens, even if the mock would otherwise allow it.
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_new_2025" } as never);
+
+    const result = await processRawEvents("src_ofh3", [
+      buildRawEvent({
+        date: "2025-06-01", // correct year (after adapter fix lands)
+        kennelTags: ["ofh3"],
+        sourceUrl: "https://www.ofh3.com/2025/05/ofh3-trail-387-june-tour-duh-hash-trail.html",
+        runNumber: 387,
+      }),
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(0);
+    // The probe ran — but its result was null, so the regular CREATE path took over.
+    expect(vi.mocked(prisma.event.findFirst)).toHaveBeenCalled();
+  });
+
+  it("does NOT dedup when sourceUrls differ — distinct events stay split", async () => {
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    // Probe finds nothing because sourceUrl is unique per event.
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_distinct" } as never);
+
+    const result = await processRawEvents("src_a", [
+      buildRawEvent({
+        date: "2026-05-09",
+        kennelTags: ["TestH3"],
+        sourceUrl: "https://example.com/runs/A",
+      }),
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(0);
+  });
+
+  it("does NOT run probe when incoming event has seriesId (multi-day series share parent URLs)", async () => {
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_series" } as never);
+
+    const result = await processRawEvents("src_a", [
+      buildRawEvent({
+        date: "2026-05-09",
+        kennelTags: ["TestH3"],
+        sourceUrl: "https://example.com/series/X",
+        seriesId: "series-x",
+      }),
+    ]);
+
+    expect(result.created).toBe(1);
+    // The findFirst correction probe must NOT have been called — the
+    // seriesId guard short-circuits before the DB query.
+    expect(vi.mocked(prisma.event.findFirst)).not.toHaveBeenCalled();
+  });
+
+  it("does NOT dedup when ctx.trustLevel < correction.trustLevel — protects higher-trust canonical", async () => {
+    // Source has trust 3 but the existing canonical was written by trust 9 —
+    // a low-trust re-emission of the high-trust URL with a wrong date must
+    // NOT shift the canonical date. Falls through to current behavior.
+    mockSourceFind.mockResolvedValueOnce({
+      trustLevel: 3,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    } as never);
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    mockEventFindMany.mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(
+      existingCorrectionRow({ trustLevel: 9 }) as never,
+    );
+    mockEventCreate.mockResolvedValueOnce({ id: "evt_new_phantom" } as never);
+
+    const result = await processRawEvents("src_low_trust", [
+      buildRawEvent({
+        date: "2026-05-09",
+        kennelTags: ["marinh3"],
+        sourceUrl: "https://www.sfh3.com/runs/6443",
+      }),
+    ]);
+
+    // Low-trust source falls through to the regular CREATE path.
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(0);
+    // Verify no update against the higher-trust canonical's date.
+    const phantomUpdate = mockEventUpdate.mock.calls.find(
+      c => (c[0] as { where: { id: string } }).where.id === "evt_phantom",
+    );
+    expect(phantomUpdate).toBeUndefined();
   });
 });

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -96,6 +96,21 @@ const mockEventUpdate = vi.mocked(prisma.event.update);
 const mockResolve = vi.mocked(resolveKennelTag);
 const mockFingerprint = vi.mocked(generateFingerprint);
 
+// Typed factories for new tests — let call sites pass `eventRow("evt_x")`
+// instead of `eventRow("evt_x")`. The cast inside is structurally
+// necessary (Event has 30+ fields the mock doesn't populate); isolating it
+// here keeps each call site cast-free and quiets Sonar S4325.
+type EventCreateReturn = Awaited<ReturnType<typeof prisma.event.create>>;
+type SourceFindReturn = Awaited<ReturnType<typeof prisma.source.findUnique>>;
+
+function eventRow(id: string, overrides?: Record<string, unknown>): EventCreateReturn {
+  return { id, ...overrides } as unknown as EventCreateReturn;
+}
+
+function sourceRow(overrides: Record<string, unknown>): SourceFindReturn {
+  return overrides as unknown as SourceFindReturn;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   // `vi.clearAllMocks()` clears call history but does NOT drain `mockResolvedValueOnce`
@@ -194,7 +209,7 @@ describe("processRawEvents", () => {
     // proceeds.
     mockRawEventFind.mockResolvedValue(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_good" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_good"));
     mockRawEventCreate.mockResolvedValueOnce({ id: "raw_good" } as never);
     // First event: fingerprint throws. Second event: fingerprint succeeds.
     mockFingerprint
@@ -219,7 +234,7 @@ describe("processRawEvents", () => {
     // and treat it as a duplicate — no second canonical Event is created.
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_first" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_first"));
     // mockReturnValueOnce (not mockReturnValue) so the implementation override
     // doesn't persist into the next test's default fingerprint.
     mockFingerprint.mockReturnValueOnce("fp_dup").mockReturnValueOnce("fp_dup");
@@ -247,7 +262,7 @@ describe("processRawEvents", () => {
   it("re-processes orphaned RawEvent (processed=false, eventId=null) after admin delete", async () => {
     mockRawEventFind.mockResolvedValueOnce({ id: "existing", processed: false, eventId: null } as never);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
     const result = await processRawEvents("src_1", [buildRawEvent()]);
     expect(result.created).toBe(1);
     expect(result.skipped).toBe(0);
@@ -256,7 +271,7 @@ describe("processRawEvents", () => {
   it("creates new canonical event", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
 
     const result = await processRawEvents("src_1", [buildRawEvent()]);
     expect(result.created).toBe(1);
@@ -439,7 +454,7 @@ describe("processRawEvents", () => {
     // Existing event has trust 8; source trust is 5. All user-facing fields
     // are null/undefined so the lower-trust enrichment path fills them.
     mockEventFindMany.mockResolvedValueOnce([{ id: "evt_1", trustLevel: 8 }] as never);
-    mockEventUpdate.mockResolvedValue({ id: "evt_1" } as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_1"));
 
     const result = await processRawEvents("src_1", [buildRawEvent()]);
     // updated is 1 (the matched-event counter at line 850). The enrichment
@@ -488,7 +503,7 @@ describe("processRawEvents", () => {
     mockRawEventCreate.mockRejectedValueOnce(new Error("DB error"));
     mockRawEventCreate.mockResolvedValueOnce({ id: "raw_2" } as never);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
     mockFingerprint.mockReturnValueOnce("fp_1").mockReturnValueOnce("fp_2");
 
     const result = await processRawEvents("src_1", [
@@ -510,7 +525,7 @@ describe("processRawEvents", () => {
   it("parses date correctly as UTC noon", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
 
     await processRawEvents("src_1", [buildRawEvent({ date: "2026-02-14" })]);
 
@@ -539,7 +554,7 @@ describe("processRawEvents", () => {
     } as never);
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
     await processRawEvents("src_1", [
       buildRawEvent({ location: "Sobu line, West exit", kennelTags: ["tokyo-h3" ]}),
@@ -626,7 +641,7 @@ describe("source-kennel guard", () => {
   it("allows event when resolved kennel IS linked to source", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
     // kennel_1 is in the linked set (default mock)
 
     const result = await processRawEvents("src_1", [buildRawEvent()]);
@@ -654,7 +669,7 @@ describe("source-kennel guard", () => {
     // linked `kennels` relation in the same round-trip.
     mockRawEventFind.mockResolvedValue(null);
     mockEventFindMany.mockResolvedValue([] as never);
-    mockEventCreate.mockResolvedValue({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValue(eventRow("evt_1"));
     mockFingerprint.mockReturnValueOnce("fp_1").mockReturnValueOnce("fp_2");
 
     await processRawEvents("src_1", [
@@ -789,13 +804,13 @@ describe("double-header support", () => {
     // First event: no fingerprint match, no existing events → create
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
     // Second event: no fingerprint match, one existing with different sourceUrl → create new (double-header)
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([
       { id: "evt_1", trustLevel: 5, sourceUrl: "https://example.com/trail-a", startTime: "10:30", title: "Trail A" },
     ] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_2" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_2"));
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({ date: "2026-03-08", sourceUrl: "https://example.com/trail-a", startTime: "10:30", title: "Trail A" }),
@@ -814,7 +829,7 @@ describe("double-header support", () => {
       { id: "evt_1", trustLevel: 5, sourceUrl: "https://example.com/trail-a", startTime: "10:30", title: "Trail A" },
       { id: "evt_2", trustLevel: 5, sourceUrl: "https://example.com/trail-b", startTime: "14:30", title: "Trail B" },
     ] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_3" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_3"));
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({ date: "2026-03-08", sourceUrl: "https://example.com/trail-c", startTime: "18:00", title: "Trail C" }),
@@ -914,7 +929,7 @@ describe("double-header support", () => {
     mockEventFindMany.mockResolvedValueOnce([
       { id: "evt_1", trustLevel: 5, sourceUrl: "https://example.com/a", startTime: "10:30", runNumber: 100, title: "Morning Trail" },
     ] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_2" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_2"));
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({ date: "2026-03-08", startTime: "10:30", runNumber: 100, sourceUrl: "https://example.com/a", title: "Morning Trail" }),
@@ -1086,7 +1101,7 @@ describe("double-header support", () => {
       { id: "part_b", trustLevel: 5, sourceUrl: "https://meetup.com/a", startTime: "10:00", runNumber: 786, title: "AVLH3 #786 Part B" },
       { id: "part_c", trustLevel: 5, sourceUrl: "https://meetup.com/b", startTime: "18:00", runNumber: 786, title: "AVLH3 #786 Part C" },
     ] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
@@ -1259,7 +1274,7 @@ describe("empty event guard", () => {
   it("generates default title using kennel display name (not raw tag)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
     vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({
       shortName: "DUHHH", fullName: "DUHHH", region: "Dallas-Fort Worth, TX",
       latitude: null, longitude: null, country: "US", regionRef: null,
@@ -1286,7 +1301,7 @@ describe("empty event guard", () => {
   it("uses friendlyKennelName for short kennel codes in default title", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
     vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({
       shortName: "H5", fullName: "Harrisburg-Hershey Hash House Harriers", region: "Harrisburg, PA",
       latitude: null, longitude: null, country: "US", regionRef: null,
@@ -1313,7 +1328,7 @@ describe("empty event guard", () => {
   it("synthesizes 'Bristol Greyhound H3 Trail' for empty-title GREY events", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_grey_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_grey_1"));
     vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({
       shortName: "GREY", fullName: "Bristol Greyhound Hash House Harriers", region: "Bristol",
       latitude: null, longitude: null, country: "UK", regionRef: null,
@@ -1340,7 +1355,7 @@ describe("empty event guard", () => {
   it("includes run number in default title when available", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
     vi.mocked(prisma.kennel.findUnique).mockResolvedValueOnce({
       shortName: "Houston H3", fullName: "Houston Hash House Harriers", region: "Houston, TX",
       latitude: null, longitude: null, country: "US", regionRef: null,
@@ -1367,7 +1382,7 @@ describe("empty event guard", () => {
   it("preserves adapter-provided title over default", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
@@ -1390,7 +1405,7 @@ describe("empty event guard", () => {
   it("processes events that have at least a runNumber", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({
@@ -1813,7 +1828,7 @@ describe("time/cost field clearing on update (#530)", () => {
     async (field, newValue) => {
       mockRawEventFind.mockResolvedValueOnce(null);
       mockEventFindMany.mockResolvedValueOnce([] as never);
-      mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+      mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
       await processRawEvents("src_1", [buildRawEvent({ [field]: newValue })]);
 
@@ -1827,7 +1842,7 @@ describe("sanitizeLocationUrl", () => {
   it("filters Google My Maps viewer URLs from locationAddress on create", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
 
     await processRawEvents("src_1", [
       buildRawEvent({ locationUrl: "https://www.google.com/maps/d/u/0/viewer?mid=abc123" }),
@@ -1855,7 +1870,7 @@ describe("sanitizeLocationUrl", () => {
   it("filters Google My Maps URLs with multi-part TLDs (google.co.uk)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
 
     await processRawEvents("src_1", [
       buildRawEvent({ locationUrl: "https://www.google.co.uk/maps/d/viewer?mid=abc123" }),
@@ -1868,7 +1883,7 @@ describe("sanitizeLocationUrl", () => {
   it("passes through valid Google Maps URLs", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_1" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1"));
 
     const mapsUrl = "https://www.google.com/maps/search/?api=1&query=The+Pub";
     await processRawEvents("src_1", [
@@ -3333,7 +3348,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never); // same-day empty
     // No second findMany — fuzzy probe MUST NOT run.
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
     const result = await processRawEvents("src_b", [
       buildRawEvent({
@@ -3357,7 +3372,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     // its own findMany after the cross-window date update + cache invalidate.
     mockEventFindMany.mockResolvedValueOnce([existingFuzzyRow()] as never); // cache prefetch
     mockEventFindMany.mockResolvedValueOnce([] as never); // old-bucket recanonicalize refetch
-    mockEventUpdate.mockResolvedValueOnce({ id: "evt_existing" } as never);
+    mockEventUpdate.mockResolvedValueOnce(eventRow("evt_existing"));
 
     const result = await processRawEvents("src_hashrego", [
       buildRawEvent({
@@ -3415,7 +3430,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     ] as never);
     mockEventFindMany.mockResolvedValueOnce([] as never); // old-bucket refetch
 
-    mockEventUpdate.mockResolvedValue({ id: "evt_was_noncanonical" } as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_was_noncanonical"));
 
     const result = await processRawEvents("src_b", [
       buildRawEvent({
@@ -3454,7 +3469,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     vi.mocked(prisma.rawEvent.findMany).mockResolvedValueOnce([
       { eventId: "evt_same_source_yesterday" },
     ] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
     const result = await processRawEvents("src_b", [
       buildRawEvent({
@@ -3479,7 +3494,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     mockEventFindMany.mockResolvedValueOnce([
       existingFuzzyRow({ runNumber: 786, title: "Annual Bash Trail" }),
     ] as never); // fuzzy probe candidate, but runNumber will conflict
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
     const result = await processRawEvents("src_b", [
       buildRawEvent({
@@ -3498,7 +3513,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([] as never); // same-day empty
     // No second findMany — fuzzy probe MUST NOT run for series events.
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
     const result = await processRawEvents("src_b", [
       buildRawEvent({
@@ -3521,7 +3536,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     mockEventFindMany.mockResolvedValueOnce([
       existingFuzzyRow({ locationName: "Central Park" }),
     ] as never); // fuzzy probe candidate, location will conflict
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
     const result = await processRawEvents("src_b", [
       buildRawEvent({
@@ -3544,7 +3559,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
     mockEventFindMany.mockResolvedValueOnce([
       existingFuzzyRow({ startTime: "10:00" }),
     ] as never);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new"));
 
     const result = await processRawEvents("src_b", [
       buildRawEvent({
@@ -3568,7 +3583,7 @@ describe("fuzzy ±48h cross-source dedup (#990)", () => {
 describe("processRawEvents — per-kennel read batching (#1287)", () => {
   it("issues at most one event.findMany per distinct kennel across a multi-event batch (fuzzy off)", async () => {
     mockRawEventFind.mockResolvedValue(null); // every event is new
-    mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValue(eventRow("evt_new"));
     mockFingerprint
       .mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b").mockReturnValueOnce("fp_c");
 
@@ -3599,7 +3614,7 @@ describe("processRawEvents — per-kennel read batching (#1287)", () => {
     process.env.MERGE_FUZZY_DEDUP = "true";
     try {
       mockRawEventFind.mockResolvedValue(null);
-      mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+      mockEventCreate.mockResolvedValue(eventRow("evt_new"));
       mockFingerprint.mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b");
 
       await processRawEvents("src_1", [
@@ -3623,7 +3638,7 @@ describe("processRawEvents — per-kennel read batching (#1287)", () => {
     const mockKennelUpdateMany = vi.mocked(prisma.kennel.updateMany);
     mockKennelUpdateMany.mockResolvedValue({ count: 1 } as never);
     mockRawEventFind.mockResolvedValue(null);
-    mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValue(eventRow("evt_new"));
     mockFingerprint
       .mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b").mockReturnValueOnce("fp_c");
 
@@ -3661,7 +3676,7 @@ describe("processRawEvents — per-kennel read batching (#1287)", () => {
     const mockKennelUpdateMany = vi.mocked(prisma.kennel.updateMany);
     mockKennelUpdateMany.mockRejectedValueOnce(new Error("transient DB error"));
     mockRawEventFind.mockResolvedValue(null);
-    mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValue(eventRow("evt_new"));
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
@@ -3771,7 +3786,7 @@ describe("processRawEvents — per-kennel read batching (#1287)", () => {
     // — N events → 1 query, regardless of new vs. updated split.
     const mockExecuteRaw = vi.mocked(prisma.$executeRaw);
     mockRawEventFind.mockResolvedValue(null); // every event is new
-    mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValue(eventRow("evt_new"));
     mockFingerprint
       .mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b").mockReturnValueOnce("fp_c");
     mockRawEventCreate
@@ -3813,7 +3828,7 @@ describe("processRawEvents — per-kennel read batching (#1287)", () => {
     const mockExecuteRaw = vi.mocked(prisma.$executeRaw);
     mockExecuteRaw.mockRejectedValueOnce(new Error("transient DB error"));
     mockRawEventFind.mockResolvedValue(null);
-    mockEventCreate.mockResolvedValue({ id: "evt_new" } as never);
+    mockEventCreate.mockResolvedValue(eventRow("evt_new"));
 
     await expect(
       processRawEvents("src_1", [
@@ -3896,7 +3911,7 @@ describe("processNewRawEvent — P2002 race-window fall-through (#1286)", () => 
       eventId: null,
     } as never);
     mockEventFindMany.mockResolvedValue([] as never);
-    mockEventCreate.mockResolvedValue({ id: "evt_adopted" } as never);
+    mockEventCreate.mockResolvedValue(eventRow("evt_adopted"));
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({ date: "2026-04-01", kennelTags: ["TestH3"] }),
@@ -4023,7 +4038,7 @@ describe("processNewRawEvent — P2002 race-window fall-through (#1286)", () => 
       trustLevel: 5,
     } as never);
     mockEventFindMany.mockResolvedValue([] as never);
-    mockEventCreate.mockResolvedValue({ id: "evt_normal" } as never);
+    mockEventCreate.mockResolvedValue(eventRow("evt_normal"));
 
     const result = await processRawEvents("src_1", [
       buildRawEvent({ date: "2026-04-01", kennelTags: ["TestH3"] }),
@@ -4384,8 +4399,10 @@ describe("linkMultiDaySeries (#1560)", () => {
 // Builds the EventRow shape EVENT_CACHE_SELECT returns from the same-sourceUrl
 // correction probe (#1613 / #1648). Date defaults to MarinH3's pre-correction
 // date so the +14d shape is the natural call site. Hoisted to module scope
-// per Sonar S7721.
-function buildCorrectionCandidate(overrides?: Record<string, unknown>) {
+// per Sonar S7721; returns the typed findFirst result so call sites can drop
+// their own `as never` (Sonar S4325).
+type EventFindFirstReturn = Awaited<ReturnType<typeof prisma.event.findFirst>>;
+function buildCorrectionCandidate(overrides?: Record<string, unknown>): EventFindFirstReturn {
   return {
     id: "evt_phantom",
     kennelId: "kennel_1",
@@ -4402,7 +4419,7 @@ function buildCorrectionCandidate(overrides?: Record<string, unknown>) {
     status: "CONFIRMED",
     adminCancelledAt: null,
     ...overrides,
-  };
+  } as unknown as EventFindFirstReturn;
 }
 
 describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
@@ -4413,8 +4430,8 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     // Old-bucket recanonicalize refetch.
     mockEventFindMany.mockResolvedValueOnce([]);
     // Same-sourceUrl correction probe returns the phantom from May 23.
-    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(buildCorrectionCandidate() as never);
-    mockEventUpdate.mockResolvedValueOnce({ id: "evt_phantom" } as never);
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(buildCorrectionCandidate());
+    mockEventUpdate.mockResolvedValueOnce(eventRow("evt_phantom"));
 
     const result = await processRawEvents("src_sfh3_html", [
       buildRawEvent({
@@ -4471,7 +4488,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     // second signal — when an event lacks it, the probe MUST be skipped.
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([]);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_no_runnumber" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_no_runnumber"));
 
     const result = await processRawEvents("src_baseurl_adapter", [
       buildRawEvent({
@@ -4500,7 +4517,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     // candidate matches — but the probe MUST have been issued with that
     // filter for the DB constraint to do its job.
     vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_runnumber_distinct" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_runnumber_distinct"));
 
     const result = await processRawEvents("src_shith3", [
       buildRawEvent({
@@ -4529,9 +4546,9 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
         sourceUrl: "https://www.meetup.com/narwhal-h3/events/293000000",
         title: "Trail #53 - Spawning Narwhals",
         runNumber: 53,
-      }) as never,
+      }),
     );
-    mockEventUpdate.mockResolvedValueOnce({ id: "evt_narwhal_phantom" } as never);
+    mockEventUpdate.mockResolvedValueOnce(eventRow("evt_narwhal_phantom"));
 
     const result = await processRawEvents("src_meetup", [
       buildRawEvent({
@@ -4555,7 +4572,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     // when applied as a DB-level date filter. We assert no correction
     // happens, even if the mock would otherwise allow it.
     vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new_2025" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new_2025"));
 
     const result = await processRawEvents("src_ofh3", [
       buildRawEvent({
@@ -4577,7 +4594,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     mockEventFindMany.mockResolvedValueOnce([]);
     // Probe finds nothing because sourceUrl is unique per event.
     vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_distinct" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_distinct"));
 
     const result = await processRawEvents("src_a", [
       buildRawEvent({
@@ -4594,7 +4611,7 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
   it("does NOT run probe when incoming event has seriesId (multi-day series share parent URLs)", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([]);
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_series" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_series"));
 
     const result = await processRawEvents("src_a", [
       buildRawEvent({
@@ -4615,18 +4632,18 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     // Source has trust 3 but the existing canonical was written by trust 9 —
     // a low-trust re-emission of the high-trust URL with a wrong date must
     // NOT shift the canonical date. Falls through to current behavior.
-    mockSourceFind.mockResolvedValueOnce({
+    mockSourceFind.mockResolvedValueOnce(sourceRow({
       trustLevel: 3,
       type: "HTML_SCRAPER",
       kennels: [{ kennelId: "kennel_1" }],
-    } as never);
+    }));
     mockRawEventFind.mockResolvedValueOnce(null);
     mockEventFindMany.mockResolvedValueOnce([]);
     mockEventFindMany.mockResolvedValueOnce([]);
     vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(
-      buildCorrectionCandidate({ trustLevel: 9 }) as never,
+      buildCorrectionCandidate({ trustLevel: 9 }),
     );
-    mockEventCreate.mockResolvedValueOnce({ id: "evt_new_phantom" } as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_new_phantom"));
 
     const result = await processRawEvents("src_low_trust", [
       buildRawEvent({

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1282,6 +1282,17 @@ async function upsertCanonicalEvent(
   // update branch physically writes `date: eventDate`, then the abandoned
   // bucket is recanonicalized at the end of upsertCanonicalEvent.
   //
+  // **`runNumber` is a required second signal.** Multiple adapters reuse a
+  // single sourceUrl across many events (BFM, OCH3, SHITH3, STATIC_SCHEDULE,
+  // Bangkok, HashPhilly all emit a fixed baseUrl as `sourceUrl`). Probing
+  // by sourceUrl alone would falsely collapse distinct adjacent events for
+  // those adapters (Codex review on PR #1696). All three of the issue cases
+  // (#1613 Marin #291/#292, #1648 Narwhal #53, #1643 OFH3 #387) carry an
+  // explicit runNumber, so requiring it as a co-match preserves coverage
+  // while eliminating the URL-collision false-positive class. Adapters that
+  // don't emit a runNumber give up auto-dedup; they need a manual cleanup
+  // or a per-event sourceUrl emission to opt in.
+  //
   // Trust gate: only adopt when our trust ≥ the canonical's. A lower-trust
   // re-emission of a higher-trust canonical's URL with a wrong date must not
   // move the date — fall through to the regular flow (which would today
@@ -1290,12 +1301,14 @@ async function upsertCanonicalEvent(
     !existingEvent
     && event.sourceUrl
     && !event.seriesId
+    && event.runNumber != null
   ) {
     const windowMs = SAME_SOURCE_URL_DEDUP_WINDOW_DAYS * 24 * 60 * 60 * 1000;
     const correction = await prisma.event.findFirst({
       where: {
         sourceUrl: event.sourceUrl,
         eventKennels: { some: { kennelId } },
+        runNumber: event.runNumber,
         date: {
           gte: new Date(eventDate.getTime() - windowMs),
           lte: new Date(eventDate.getTime() + windowMs),
@@ -1311,6 +1324,7 @@ async function upsertCanonicalEvent(
     if (correction && ctx.trustLevel >= correction.trustLevel) {
       console.info(
         `[merge.date-correction] kennelId=${kennelId} sourceUrl=${event.sourceUrl} ` +
+          `runNumber=${event.runNumber} ` +
           `oldDate=${correction.date.toISOString()} newDate=${eventDate.toISOString()} ` +
           `eventId=${correction.id}`,
       );

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1080,6 +1080,13 @@ async function resolveCoords(
 const FUZZY_WINDOW_MS = 2 * 24 * 60 * 60 * 1000; // ±48h
 const FUZZY_TITLE_DISTANCE = 4;
 const FUZZY_LOCATION_DISTANCE = 8;
+// Same-sourceUrl date-correction window (#1613 / #1648). When an existing
+// canonical Event shares this raw's sourceUrl on a nearby date, the source
+// has corrected the date in place — move the canonical instead of forking
+// a phantom duplicate. Window chosen to cover observed corrections (#1613
+// MarinH3 +14d, #1648 Narwhal +4d) without colliding with annual recurrences
+// (#1643 OFH3 year-rollover is ~365d apart — handled by the adapter fix).
+const SAME_SOURCE_URL_DEDUP_WINDOW_DAYS = 30;
 // 120 min: setup-day vs main-day in #886 diverges by 60 min (14:00 vs 15:00),
 // AM/PM ambiguity can shift 12h but title/location gates catch those, and
 // >2h dayparts are reliably distinct trails worth keeping split.
@@ -1264,6 +1271,53 @@ async function upsertCanonicalEvent(
       sameDayEvents.push(fuzzy);
       crossWindowMatch = true;
       crossWindowOldDate = fuzzy.date;
+    }
+  }
+
+  // Same-sourceUrl date-correction (#1613, #1648). When the incoming row's
+  // sourceUrl already lives on a canonical Event within ±N days for this
+  // kennel, the source has corrected the event's date in place — move the
+  // existing canonical instead of forking a phantom duplicate at the new
+  // date. Reuses the crossWindowMatch plumbing (#990): the higher/equal-trust
+  // update branch physically writes `date: eventDate`, then the abandoned
+  // bucket is recanonicalized at the end of upsertCanonicalEvent.
+  //
+  // Trust gate: only adopt when our trust ≥ the canonical's. A lower-trust
+  // re-emission of a higher-trust canonical's URL with a wrong date must not
+  // move the date — fall through to the regular flow (which would today
+  // create a phantom; preferable to silently shifting a trusted canonical).
+  if (
+    !existingEvent
+    && event.sourceUrl
+    && !event.seriesId
+  ) {
+    const windowMs = SAME_SOURCE_URL_DEDUP_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+    const correction = await prisma.event.findFirst({
+      where: {
+        sourceUrl: event.sourceUrl,
+        eventKennels: { some: { kennelId } },
+        date: {
+          gte: new Date(eventDate.getTime() - windowMs),
+          lte: new Date(eventDate.getTime() + windowMs),
+          not: eventDate,
+        },
+        parentEventId: null,
+        isSeriesParent: false,
+        status: { not: "CANCELLED" },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: EVENT_CACHE_SELECT,
+    });
+    if (correction && ctx.trustLevel >= correction.trustLevel) {
+      console.info(
+        `[merge.date-correction] kennelId=${kennelId} sourceUrl=${event.sourceUrl} ` +
+          `oldDate=${correction.date.toISOString()} newDate=${eventDate.toISOString()} ` +
+          `eventId=${correction.id}`,
+      );
+      existingEvent = correction;
+      sameDayEvents.push(correction);
+      crossWindowMatch = true;
+      crossWindowOldDate = correction.date;
     }
   }
 


### PR DESCRIPTION
## Summary

Three open issues — [#1613](https://github.com/johnrclem/hashtracks-web/issues/1613) MarinH3, [#1643](https://github.com/johnrclem/hashtracks-web/issues/1643) OFH3, [#1648](https://github.com/johnrclem/hashtracks-web/issues/1648) Narwhal — all surface the same failure shape: when a source corrects an event's date, the merge pipeline creates a phantom canonical `Event` at the new date instead of moving the existing one. The orphan stays in the hareline.

**Root cause (single, systemic):**
1. `RawEvent.fingerprint` includes `date` ([fingerprint.ts:41-125](src/pipeline/fingerprint.ts:41)) → corrected date ⇒ new fingerprint ⇒ new `RawEvent`. The `@@unique([sourceId, fingerprint])` from #1355 does not collapse them.
2. Canonical-Event lookup uses `(kennelId, date)` bucketing ([merge.ts:1196-1244](src/pipeline/merge.ts:1196)). The existing `sourceUrl` match only fires *within* the same-day pool — it never crosses date buckets.

### What's in this PR

- **`src/pipeline/merge.ts`** — after the same-day match misses and before the new-Event-creation branch, probe for a canonical Event sharing this raw's `sourceUrl` on a nearby date (±30d) for the same kennel via `EventKennel`. On match, set `existingEvent = correction` + reuse the `crossWindowMatch` plumbing from #990 (date physically moves, abandoned bucket recanonicalizes). Trust-gated so a low-trust re-emission cannot shift a higher-trust canonical's date. `seriesId` guard preserves multi-day series rows.
- **`src/adapters/html-scraper/ofh3.ts`** — extract `/YYYY/MM/` from the Blogspot URL and pass as chrono's `referenceDate` so a year-less "June 1" in a 2025 post resolves to `2025-06-01`, not `2026-06-01`. With chrono's default `forwardDate: false` the anchor year wins (per memory `feedback_chrono_forward_date_explicit_year`).
- **`scripts/cleanup-phantom-date-duplicates.ts`** — self-join discovery for ±30d sourceUrl-matched pairs (catches the 2 MarinH3 phantoms automatically) plus a named-purge list for cases the auto path misses: Narwhal (distinct Meetup eventIds — same logical event but URLs differ) and the standalone OFH3 phantom (no sibling at the correct date yet). Attendance preflight aborts if any losing Event carries `Attendance` / `KennelAttendance` rows. `--apply` to write; DRY otherwise.

### Coverage of the three issues

| Issue | Drift | Fix path |
|---|---|---|
| #1613 MarinH3 | `/runs/6443` flipped May 23 → May 9 (14d) | merge.ts auto-dedup (no `marin-h3.ts` exists — uses SFH3 patterns) |
| #1648 Narwhal | Trail #53 reposted Jun 25 → Jun 21 (4d) | merge.ts auto-dedup (future); cleanup script (existing — distinct Meetup IDs) |
| #1643 OFH3 | 2025 blog post mapped to Jun 2026 (~365d) | ofh3.ts year-anchor (live-verified) + cleanup script (existing phantom) |

### Live verification

- **OFH3 adapter** against `https://www.ofh3.com/2025/05/ofh3-trail-387-june-tour-duh-hash-trail.html` now returns `date=2025-06-01` (previously `2026-06-01`). 14 events parsed, sample event has correct hares ("ICHY & PFT") and location ("Parking Lot off to the side of Fourth Dimension Fun Center, Frederick, MD").
- **Cleanup script DRY against prod** finds exactly the expected pairs (0 false positives, 0 attendance blocks):
  ```
  Found 2 candidate phantom-date pair(s) within ±30 days.
  [marinh3] /runs/6443 → KEEP cmog4v7nl000u04l4nd8j8wqv (May 9) DROP cmmtcm5th001p04jpenwbxvkh (May 23)
  [marinh3] /runs/6449 → KEEP cmp7a8fip000404jyz1s8s590 (Jun 13) DROP cmmtcm6k2002404jpgghtp6zg (Jun 20)
  Named-phantom purges (2):
    [#1648 narwhal-h3] DROP cmmobywzg000f04i8df6ls0zi (2023-06-21)
    [#1643 ofh3] DROP cmm3khyet000804jr5t5rr629 (2026-06-01)
  ```
  IDs match the ones cited in the issue bodies.

### Out of scope

- **No `meetup/adapter.ts` changes** — Narwhal isn't part of WS2's #1659 hex pattern overlap and is solved by the cleanup-script's named-purge path. The merge.ts dedup *will* catch future Narwhal-shape phantoms when Meetup keeps the same eventId across organizer edits.
- **No `Source.config` knob for the window** — 30d is hardcoded; revisit only if a false-positive surfaces.

## Test plan

- [x] `npm run lint` clean (21 pre-existing warnings, 0 errors)
- [x] `npx tsc --noEmit` clean for all touched files
- [x] `npm test` passes for all touched modules — 994/994 tests in `src/pipeline/` + `src/adapters/html-scraper/ofh3.test.ts`; pre-existing 10 file-load failures elsewhere are missing `suncalc` / `@deck.gl/*` deps in this worktree (unrelated)
- [x] OFH3 live verify: `date=2025-06-01` for the phantom URL
- [x] Cleanup script DRY: discovers exactly the expected 4 events (0 blocks, 0 false positives)
- [ ] Apply cleanup post-merge from main: `npx tsx scripts/cleanup-phantom-date-duplicates.ts --apply`

Closes #1613
Closes #1643
Closes #1648

🤖 Generated with [Claude Code](https://claude.com/claude-code)