### PR TITLE
feat(1560): per-day section titles + umbrella detail page + orphan cleanup (refs #1560)

### DIFF
--- a/scripts/cleanup-5-boro-2027-orphan.ts
+++ b/scripts/cleanup-5-boro-2027-orphan.ts
@@ -110,6 +110,10 @@ async function main() {
 main()
   .catch((err) => {
     console.error("[cleanup] fatal:", err);
-    process.exit(1);
+    // Set exitCode rather than calling process.exit(1) — the latter
+    // terminates Node synchronously and prevents the `.finally` cleanup
+    // (prisma.$disconnect) from running. Node will exit with code 1 once
+    // the event loop drains (CodeRabbit PR #1697 review).
+    process.exitCode = 1;
   })
   .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-5-boro-2027-orphan.ts
+++ b/scripts/cleanup-5-boro-2027-orphan.ts
@@ -1,0 +1,113 @@
+/**
+ * One-shot cleanup for the 2027-06-26 NYC 5-Boro orphan Event (PR E.7).
+ *
+ * Pre-PR-#1678, a Hash Rego scrape misfired the year-rollover heuristic
+ * on the 5-Boro Pub Crawl 2026 and emitted a Day-3 RawEvent dated
+ * `2027-06-26` (Friday 6/26 was wrongly bumped to next year because the
+ * Hash Rego index startDate was Saturday 6/27, not Friday). The
+ * fingerprint hashed in that mistake, so post-#1678 scrapes don't
+ * overwrite it — they create new RawEvents at the correct 2026 dates,
+ * leaving the 2027-06-26 row + its backing RawEvent as a fossil that
+ * pollutes `?q=5-boro` search results.
+ *
+ * The existing `scripts/cleanup-orphan-events-after-series.ts` filters
+ * on `rawEvents: { none: {} }` and won't catch this row (it still has
+ * its stale RawEvent backing it). This script targets the single known
+ * orphan by ID, with safety guards so re-running can't delete the
+ * wrong row:
+ *   - Event ID must match `cmplbbe9k000604ic44er23kw`
+ *   - Event date must be ≥ 2027-01-01
+ *   - Event title must include `5-boro` (case-insensitive)
+ *
+ * All three guards must pass before deletion. Re-running on a clean DB
+ * is a no-op (exit 0, logs "already cleaned").
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/cleanup-5-boro-2027-orphan.ts
+ *   Apply:    APPLY=1 npx tsx scripts/cleanup-5-boro-2027-orphan.ts
+ *
+ * Reference: #1560 follow-up (PR E.7); validation report on PR #1678.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const TARGET_EVENT_ID = "cmplbbe9k000604ic44er23kw";
+const TARGET_DATE_MIN = new Date("2027-01-01T00:00:00Z");
+const TARGET_TITLE_FRAGMENT = "5-boro";
+
+async function main() {
+  const apply = process.env.APPLY === "1";
+  console.log(`[cleanup-5-boro-2027-orphan] mode=${apply ? "APPLY" : "DRY RUN"}`);
+
+  const event = await prisma.event.findUnique({
+    where: { id: TARGET_EVENT_ID },
+    select: {
+      id: true,
+      date: true,
+      title: true,
+      parentEventId: true,
+      isSeriesParent: true,
+      _count: { select: { rawEvents: true } },
+    },
+  });
+
+  if (!event) {
+    console.log(`[cleanup] target ${TARGET_EVENT_ID} not found — already cleaned. Exiting 0.`);
+    return;
+  }
+
+  // Safety guards — all must pass before we'll touch the row.
+  if (event.date < TARGET_DATE_MIN) {
+    console.error(
+      `[cleanup] REFUSING: target Event date=${event.date.toISOString()} is BEFORE 2027-01-01. ` +
+        `The orphan we're chasing is at 2027-06-26; this row doesn't match. Aborting.`,
+    );
+    process.exit(2);
+  }
+  if (!event.title?.toLowerCase().includes(TARGET_TITLE_FRAGMENT)) {
+    console.error(
+      `[cleanup] REFUSING: target Event title=${JSON.stringify(event.title)} doesn't contain ` +
+        `"${TARGET_TITLE_FRAGMENT}". Aborting.`,
+    );
+    process.exit(2);
+  }
+  // Defensive: never delete a series parent or a child of an active series.
+  // The known orphan satisfies parentEventId=null AND isSeriesParent=false.
+  if (event.isSeriesParent || event.parentEventId) {
+    console.error(
+      `[cleanup] REFUSING: target Event is part of an active series (parentEventId=` +
+        `${event.parentEventId} isSeriesParent=${event.isSeriesParent}). Aborting.`,
+    );
+    process.exit(2);
+  }
+
+  console.log(`[cleanup] target found:`);
+  console.log(`  id:       ${event.id}`);
+  console.log(`  date:     ${event.date.toISOString()}`);
+  console.log(`  title:    ${event.title}`);
+  console.log(`  rawEvents: ${event._count.rawEvents}`);
+
+  if (!apply) {
+    console.log(`[cleanup] DRY RUN — would delete the Event and its ${event._count.rawEvents} backing RawEvent(s).`);
+    console.log(`[cleanup] Re-run with APPLY=1 to actually delete.`);
+    return;
+  }
+
+  // Delete in a transaction: RawEvents first (FK from RawEvent.eventId would
+  // block the Event delete otherwise, depending on schema cascade rules), then
+  // the Event row itself.
+  const result = await prisma.$transaction(async (tx) => {
+    const rawDel = await tx.rawEvent.deleteMany({ where: { eventId: event.id } });
+    const eventDel = await tx.event.delete({ where: { id: event.id } });
+    return { rawDeleted: rawDel.count, eventDeleted: eventDel.id };
+  });
+
+  console.log(`[cleanup] DONE — deleted ${result.rawDeleted} RawEvent(s) + Event ${result.eventDeleted}.`);
+}
+
+main()
+  .catch((err) => {
+    console.error("[cleanup] fatal:", err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-5-boro-2027-orphan.ts
+++ b/scripts/cleanup-5-boro-2027-orphan.ts
@@ -57,28 +57,27 @@ async function main() {
   }
 
   // Safety guards — all must pass before we'll touch the row.
+  // Throw rather than `process.exit` so the `.finally(prisma.$disconnect)`
+  // below still runs and releases the DB connection cleanly (Gemini review).
   if (event.date < TARGET_DATE_MIN) {
-    console.error(
-      `[cleanup] REFUSING: target Event date=${event.date.toISOString()} is BEFORE 2027-01-01. ` +
-        `The orphan we're chasing is at 2027-06-26; this row doesn't match. Aborting.`,
+    throw new Error(
+      `REFUSING: target Event date=${event.date.toISOString()} is BEFORE 2027-01-01. ` +
+        `The orphan we're chasing is at 2027-06-26; this row doesn't match.`,
     );
-    process.exit(2);
   }
   if (!event.title?.toLowerCase().includes(TARGET_TITLE_FRAGMENT)) {
-    console.error(
-      `[cleanup] REFUSING: target Event title=${JSON.stringify(event.title)} doesn't contain ` +
-        `"${TARGET_TITLE_FRAGMENT}". Aborting.`,
+    throw new Error(
+      `REFUSING: target Event title=${JSON.stringify(event.title)} doesn't contain ` +
+        `"${TARGET_TITLE_FRAGMENT}".`,
     );
-    process.exit(2);
   }
   // Defensive: never delete a series parent or a child of an active series.
   // The known orphan satisfies parentEventId=null AND isSeriesParent=false.
   if (event.isSeriesParent || event.parentEventId) {
-    console.error(
-      `[cleanup] REFUSING: target Event is part of an active series (parentEventId=` +
-        `${event.parentEventId} isSeriesParent=${event.isSeriesParent}). Aborting.`,
+    throw new Error(
+      `REFUSING: target Event is part of an active series (parentEventId=` +
+        `${event.parentEventId} isSeriesParent=${event.isSeriesParent}).`,
     );
-    process.exit(2);
   }
 
   console.log(`[cleanup] target found:`);
@@ -93,9 +92,12 @@ async function main() {
     return;
   }
 
-  // Delete in a transaction: RawEvents first (FK from RawEvent.eventId would
-  // block the Event delete otherwise, depending on schema cascade rules), then
-  // the Event row itself.
+  // Delete in a transaction: RawEvents first, then the Event row.
+  // `RawEvent.event` is an optional relation in prisma/schema.prisma WITHOUT
+  // an explicit `onDelete: Cascade`, so the default behavior is SetNull on
+  // the FK — deleting the Event would orphan the RawEvent at
+  // `eventId: null` instead of removing it. Explicit RawEvent.deleteMany
+  // is necessary here (Gemini PR #1697 review — verified against schema).
   const result = await prisma.$transaction(async (tx) => {
     const rawDel = await tx.rawEvent.deleteMany({ where: { eventId: event.id } });
     const eventDel = await tx.event.delete({ where: { id: event.id } });

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -927,23 +927,30 @@ describe("parseEventDetail + splitToRawEvents — 5-Boro 2026 weekday-form + per
     expect(events[0].hares).toBeUndefined();
     expect(events[0].startTime).toBeUndefined();
 
-    // Index 1 — Friday child overrides to GGFM.
+    // Index 1 — Friday child overrides to GGFM. Title comes from the
+    // section header ("GGFM Strawberry Moon Trail" — PR E.1) and the GGFM
+    // prefix is stripped because the kennel pill already surfaces it
+    // (PR E.2). No legacy "(Day N)" suffix.
     expect(events[1].seriesParent).toBeUndefined();
     expect(events[1].date).toBe("2026-06-26");
     expect(events[1].kennelTags).toEqual(["ggfm"]);
-    expect(events[1].title).toContain("(Day 1)");
+    expect(events[1].title).toBe("Strawberry Moon Trail");
 
-    // Index 2 — Saturday child falls back to host kennel.
+    // Index 2 — Saturday child falls back to host kennel. Section title
+    // "12th Annual 5-Borough Pub Crawl" doesn't lead with a kennel name,
+    // so no prefix stripping applies.
     expect(events[2].seriesParent).toBeUndefined();
     expect(events[2].date).toBe("2026-06-27");
     expect(events[2].kennelTags).toEqual(["NYCH3"]);
-    expect(events[2].title).toContain("(Day 2)");
+    expect(events[2].title).toBe("12th Annual 5-Borough Pub Crawl");
 
-    // Index 3 — Sunday child falls back to host kennel.
+    // Index 3 — Sunday child falls back to host kennel. Section title
+    // "NYC Pride March Watch Party!" starts with "NYC" but the kennel
+    // pattern requires `NYC\s*H3`, so the prefix stays.
     expect(events[3].seriesParent).toBeUndefined();
     expect(events[3].date).toBe("2026-06-28");
     expect(events[3].kennelTags).toEqual(["NYCH3"]);
-    expect(events[3].title).toContain("(Day 3)");
+    expect(events[3].title).toBe("NYC Pride March Watch Party!");
   });
 
   it("splitToRawEvents: ggfm-named Friday child rides on its sibling kennel even though parent is NYCH3-hosted", () => {
@@ -1376,6 +1383,127 @@ describe("parseDayHeaderSections", () => {
       expect(entries.map((e) => e.date)).toEqual(["2026-06-26", "2026-06-27"]);
       expect(entries.every((e) => e.kennelCode === undefined)).toBe(true);
       warn.mockRestore();
+    });
+  });
+
+  // ── PR E.1 — Per-day section title extraction ──
+  describe("per-day section title (PR E.1)", () => {
+    it("captures the section header text after the M/D delimiter", () => {
+      const desc =
+        "**FRIDAY 6/26 — GGFM Strawberry Moon Trail**\n" +
+        "**SATURDAY 6/27 — 12th Annual 5-Borough Pub Crawl**\n" +
+        "**SUNDAY 6/28 — NYC Pride March Watch Party!**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26");
+      // No kennel patterns → no prefix stripping → titles verbatim from source.
+      expect(entries.map((e) => e.sectionTitle)).toEqual([
+        "GGFM Strawberry Moon Trail",
+        "12th Annual 5-Borough Pub Crawl",
+        "NYC Pride March Watch Party!",
+      ]);
+    });
+
+    it("returns sectionTitle: undefined when the header line carries no title", () => {
+      // `**DAY 1 12/30 —**` followed by a newline → no title on the
+      // header line. The blurb on the next line belongs to the section
+      // body, not the header.
+      const desc =
+        "**DAY 1 12/30 —**\nBlurb describing day one.\n" +
+        "**DAY 2 12/31 —**\nMore blurb here.";
+      const entries = parseDayHeaderSections(desc, "2026-12-30");
+      expect(entries.every((e) => e.sectionTitle === undefined)).toBe(true);
+    });
+
+    it("strips trailing punctuation but preserves bang/question", () => {
+      // ", " gets dropped; "!" stays. Both behaviors are intentional —
+      // the camp's emphatic punctuation is part of the trail's identity.
+      const desc =
+        "**FRIDAY 6/26 — Strawberry Moon Trail,**\n" +
+        "**SATURDAY 6/27 — Pub Crawl!**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26");
+      expect(entries[0].sectionTitle).toBe("Strawberry Moon Trail");
+      expect(entries[1].sectionTitle).toBe("Pub Crawl!");
+    });
+  });
+
+  // ── PR E.2 — Kennel-prefix stripping ──
+  describe("kennel-prefix stripping from section title (PR E.2)", () => {
+    const PATTERNS = [
+      ["Greater Gotham", "ggfm"],
+      ["GGFM", "ggfm"],
+      [String.raw`NYC\s*H3`, "nych3"],
+    ] as const;
+
+    it("strips a leading kennel name when the kennel pill carries the same identity", () => {
+      // Friday: "GGFM Strawberry Moon Trail" + ggfm pill → "Strawberry Moon Trail"
+      const desc = "**FRIDAY 6/26 — GGFM Strawberry Moon Trail**\n**SATURDAY 6/27 — Recovery**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26", PATTERNS);
+      expect(entries[0].sectionTitle).toBe("Strawberry Moon Trail");
+      // Saturday has no kennel match → no strip.
+      expect(entries[1].sectionTitle).toBe("Recovery");
+    });
+
+    it("matches alternate kennel-name spellings via the same kennelCode", () => {
+      // "Greater Gotham" and "GGFM" both map to `ggfm`. Either prefix
+      // should strip cleanly.
+      const desc = "**FRIDAY 6/26 — Greater Gotham Moon Trail**\n**SATURDAY 6/27 — Recovery**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26", PATTERNS);
+      expect(entries[0].sectionTitle).toBe("Moon Trail");
+    });
+
+    it("preserves the prefix when stripping would leave under MIN_STRIPPED_TITLE_LENGTH chars", () => {
+      // "GGFM ✨" → stripped would be "✨" (1 char). Better to keep the prefix
+      // than render a 1-char card.
+      const desc = "**FRIDAY 6/26 — GGFM ✨**\n**SATURDAY 6/27 — Recovery**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26", PATTERNS);
+      expect(entries[0].sectionTitle).toBe("GGFM ✨");
+    });
+
+    it("no-op when no kennel pattern matches", () => {
+      // Saturday's section text doesn't name any kennel in PATTERNS.
+      const desc = "**SATURDAY 6/27 — Generic Saturday Trail**\n**SUNDAY 6/28 — More**";
+      const entries = parseDayHeaderSections(desc, "2026-06-27", PATTERNS);
+      expect(entries[0].sectionTitle).toBe("Generic Saturday Trail");
+    });
+
+    it("no-op when no patterns are configured", () => {
+      // Without kennelPatterns, the section title flows through verbatim
+      // even when it leads with what looks like a kennel name.
+      const desc = "**FRIDAY 6/26 — GGFM Strawberry Moon Trail**\n**SATURDAY 6/27 — Recovery**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26");
+      expect(entries[0].sectionTitle).toBe("GGFM Strawberry Moon Trail");
+    });
+  });
+
+  // ── PR E.1 + E.2 integration with splitToRawEvents ──
+  describe("splitToRawEvents uses section titles as child titles (PR E.1)", () => {
+    it("falls back to '(Day N)' when description has no section titles", () => {
+      // `**DAY 1 6/26 —**` with no title on the header line → fallback to
+      // legacy "${parent.title} (Day N)" form for every child.
+      const HTML = `
+        <html>
+          <head>
+            <meta property="og:title" content="06/26 NYE Campout Title" />
+            <meta property="og:description" content='**DAY 1 6/26 —**
+First day, no title on this line.
+**DAY 2 6/27 —**
+Second day, also bare.' />
+          </head>
+          <body><a href="/kennels/NYCH3/">NYC H3</a></body>
+        </html>`;
+      const parsed = parseEventDetail(HTML, "nye-bare", {
+        slug: "nye-bare",
+        kennelSlug: "NYCH3",
+        title: "NYE Campout Title",
+        startDate: "06/26/26",
+        startTime: "",
+        type: "Hash Weekend",
+        cost: "",
+      });
+      const events = splitToRawEvents(parsed, "nye-bare");
+      // Shape (1) — Day 1 is the parent, Day 2 is the child.
+      expect(events).toHaveLength(2);
+      expect(events[0].title).toBe("NYE Campout Title"); // parent
+      expect(events[1].title).toBe("NYE Campout Title (Day 2)"); // child fallback
     });
   });
 });

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -1518,6 +1518,29 @@ describe("parseDayHeaderSections", () => {
       // a backtracking regex on a ~20KB input would push 10s+.
       expect(elapsedMs).toBeLessThan(500);
     });
+
+    // Codacy ReDoS review on PR #1697 — `compileKennelPatterns` now runs
+    // every operator-supplied source through `safe-regex2.isSafeRegex` and
+    // rejects ReDoS-prone patterns fail-soft. Verifies the catastrophic-
+    // backtracking shape `(a+)+$` is skipped (with warn), while neighboring
+    // safe patterns still compile + apply.
+    it("rejects ReDoS-prone patterns fail-soft via safe-regex2", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const UNSAFE_MIX = [
+        ["(a+)+$", "bad"],            // classic catastrophic backtracking shape
+        ["GGFM", "ggfm"],             // safe — should still apply
+      ] as const;
+      const desc =
+        "**FRIDAY 6/26 — GGFM Strawberry Moon Trail**\n" +
+        "**SATURDAY 6/27 — Recovery**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26", UNSAFE_MIX);
+      // GGFM prefix-strip still works — the safe pattern survives compile.
+      expect(entries[0].sectionTitle).toBe("Strawberry Moon Trail");
+      // The unsafe pattern logged a warn (specific copy contains "ReDoS-prone").
+      const warnCalls = warn.mock.calls.flatMap((args) => args.map(String));
+      expect(warnCalls.some((s) => s.includes("ReDoS-prone"))).toBe(true);
+      warn.mockRestore();
+    });
   });
 
   // ── PR E.1 + E.2 integration with splitToRawEvents ──

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -1449,6 +1449,35 @@ describe("parseDayHeaderSections", () => {
       expect(entries[0].sectionTitle).toBe("Double Dash");
       expect(entries[1].sectionTitle).toBe("Mixed Delim");
     });
+
+    // CodeRabbit PR #1697 review — bare `Day N M/D` headers (no `—` / `:`
+    // delimiter) carry description content after the date, NOT a title.
+    // Pre-fix, the parser would emit "evening run" as Day 1's title and
+    // rewrite the Event.title + fingerprint on every existing such row.
+    // Post-fix, day-number headers require an explicit trailing delimiter
+    // before extractSectionTitle returns a title; bare forms get
+    // sectionTitle: undefined so the caller falls back to "(Day N)".
+    it("day-number header without trailing delimiter returns sectionTitle: undefined", () => {
+      const desc =
+        "Day 1 3/21 evening run\n" +
+        "Day 2 3/22 morning hike\n" +
+        "Day 3 3/23 brunch";
+      const entries = parseDayHeaderSections(desc, "2026-03-21");
+      expect(entries.map((e) => e.sectionTitle)).toEqual([undefined, undefined, undefined]);
+    });
+
+    it("day-number header WITH trailing delimiter still extracts the title", () => {
+      // Same shape as the regression for bare Day-form (above) but each
+      // header has an explicit `—` delimiter — title extraction fires.
+      const desc =
+        "Day 1 3/21 — Friday Kickoff\n" +
+        "Day 2 3/22 — Saturday Main";
+      const entries = parseDayHeaderSections(desc, "2026-03-21");
+      expect(entries.map((e) => e.sectionTitle)).toEqual([
+        "Friday Kickoff",
+        "Saturday Main",
+      ]);
+    });
   });
 
   // ── PR E.2 — Kennel-prefix stripping ──

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -1498,6 +1498,26 @@ describe("parseDayHeaderSections", () => {
       const entries = parseDayHeaderSections(desc, "2026-06-26");
       expect(entries[0].sectionTitle).toBe("GGFM Strawberry Moon Trail");
     });
+
+    // Codacy ReDoS review on PR #1697 — the anchored regex used to strip
+    // a kennel prefix is now pre-built in `compileKennelPatterns` rather
+    // than dynamically constructed at the strip site. This regression test
+    // exercises a pathological title length to confirm the matcher stays
+    // linear-time on operator-curated patterns. (Patterns themselves are
+    // seed-controlled, but the test pins the linear behavior so a future
+    // pattern change won't silently introduce a backtracking shape.)
+    it("strip handles pathological title length without runaway backtracking", () => {
+      const longTitle = "GGFM " + "Strawberry ".repeat(2000) + "Trail";
+      const desc = `**FRIDAY 6/26 — ${longTitle}**\n**SATURDAY 6/27 — Recovery**`;
+      const start = Date.now();
+      const entries = parseDayHeaderSections(desc, "2026-06-26", PATTERNS);
+      const elapsedMs = Date.now() - start;
+      // GGFM prefix stripped; title body preserved.
+      expect(entries[0].sectionTitle?.startsWith("Strawberry")).toBe(true);
+      // Linear-time bound — should be way under 500ms even on slow CI;
+      // a backtracking regex on a ~20KB input would push 10s+.
+      expect(elapsedMs).toBeLessThan(500);
+    });
   });
 
   // ── PR E.1 + E.2 integration with splitToRawEvents ──

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -1423,6 +1423,32 @@ describe("parseDayHeaderSections", () => {
       expect(entries[0].sectionTitle).toBe("Strawberry Moon Trail");
       expect(entries[1].sectionTitle).toBe("Pub Crawl!");
     });
+
+    // CodeRabbit PR #1697 review — DAY_NUMBER_HEADER_RE ends at `\b` after
+    // the day digit and does NOT consume the trailing `—` delimiter (unlike
+    // WEEKDAY_HEADER_RE which explicitly eats `\s*[-—:]`). The slice handed
+    // to `extractSectionTitle` for `**DAY 1 6/26 — Friday Kickoff**` starts
+    // at ` — Friday Kickoff**`, so the helper must strip the leading
+    // delimiter or the title lands as "— Friday Kickoff".
+    it("strips leading delimiter on Day-form headers (asymmetry with WEEKDAY-form)", () => {
+      const desc =
+        "**DAY 1 6/26 — Friday Kickoff**\n" +
+        "**DAY 2 6/27 — Saturday Main**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26");
+      expect(entries[0].sectionTitle).toBe("Friday Kickoff");
+      expect(entries[1].sectionTitle).toBe("Saturday Main");
+    });
+
+    it("strips multiple leading delimiter chars + whitespace combos", () => {
+      // Defensive: a typo'd `— — title` or `:– title` should still produce
+      // a clean title rather than carrying delimiter cruft.
+      const desc =
+        "**DAY 1 6/26 —— Double Dash**\n" +
+        "**DAY 2 6/27 :– Mixed Delim**";
+      const entries = parseDayHeaderSections(desc, "2026-06-26");
+      expect(entries[0].sectionTitle).toBe("Double Dash");
+      expect(entries[1].sectionTitle).toBe("Mixed Delim");
+    });
   });
 
   // ── PR E.2 — Kennel-prefix stripping ──

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -832,7 +832,7 @@ function stripKennelPrefixFromTitle(
     if (code !== matchedCode) continue;
     // Anchor the pattern to the start of the title. Build a fresh regex
     // because `re` is unanchored + has the `i` flag from compileKennelPatterns.
-    const anchored = new RegExp(`^\\s*${re.source}`, "i");
+    const anchored = new RegExp(String.raw`^\s*${re.source}`, "i");
     const m = anchored.exec(title);
     if (!m) continue;
     // Drop the matched prefix + any trailing separators (space, dash, colon,

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -711,24 +711,39 @@ function extractFirstTimeFromSlice(slice: string): string | undefined {
  * whichever comes first. Trailing punctuation (commas, periods, em-dashes)
  * is stripped so we don't render "Strawberry Moon Trail." with a dangling dot.
  *
- * Returns `undefined` when the slice has no title text on the header line —
- * e.g. `**DAY 1 12/30 —**\nblurb...` where the header carries the date only.
- * The caller then falls back to the legacy `"${title} (Day N)"` form.
+ * Returns `undefined` when:
+ *   - The slice has no title text on the header line
+ *     (e.g. `**DAY 1 12/30 —**\nblurb...`)
+ *   - The header is a `shape: "day-number"` form WITHOUT a trailing
+ *     delimiter (e.g. legacy `Day 1 3/21 evening run` — no `—`/`:`).
+ *     In that case the trailing text is description content, not a
+ *     title, and emitting it as `Event.title` would rewrite the title
+ *     on every existing such row (CodeRabbit PR #1697 review).
+ *
+ * The caller falls back to the legacy `"${title} (Day N)"` form on
+ * undefined.
  */
-function extractSectionTitle(slice: string): string | undefined {
-  // Strip leading whitespace + a leading delimiter (em-dash, en-dash,
-  // hyphen, colon) before extracting the title text.
+function extractSectionTitle(
+  slice: string,
+  shape: "day-number" | "weekday",
+): string | undefined {
+  // The two header shapes hand us slices with different leading structure:
   //
-  // The asymmetry matters: `WEEKDAY_HEADER_RE` ends with `\s*[-—:]` so the
-  // delimiter is already CONSUMED by the time we see the slice. But
-  // `DAY_NUMBER_HEADER_RE` ends at `\b` after the day digit, so the slice
-  // for `**DAY 1 6/26 — Friday Kickoff**` starts at ` — Friday…`. Without
-  // an explicit leading-delimiter strip, the title would land as
-  // "— Friday Kickoff" (CodeRabbit PR #1697 review).
-  const trimmed = slice
-    .replace(/^\s+/, "")
-    .replace(/^[-—–:]+/, "")
-    .replace(/^\s+/, "");
+  //   - WEEKDAY_HEADER_RE consumes `\s*[-—:]` so the slice STARTS with
+  //     the title text directly (no leading delimiter remains).
+  //   - DAY_NUMBER_HEADER_RE ends at `\b` after the day digit, so the
+  //     slice MAY start with ` — title…` (delimited title present) OR
+  //     ` evening run…` (no delimiter; trailing text is description).
+  //
+  // For day-number forms, REQUIRE an explicit leading delimiter — without
+  // it, treat the slice as having no title and let the caller fall back
+  // to the legacy `(Day N)` suffix. This preserves backward-compatibility
+  // for descriptions that use `Day 1 3/21 evening run` as plain prose.
+  let trimmed = slice.replace(/^\s+/, "");
+  if (shape === "day-number") {
+    if (!/^[-—–:]/.test(trimmed)) return undefined;
+  }
+  trimmed = trimmed.replace(/^[-—–:]+/, "").replace(/^\s+/, "");
   // Take up to the first closing `**` (markdown bold) or newline, whichever
   // comes first. We deliberately use indexOf for `**` rather than a regex
   // character class — Gemini PR #1697 caught that `/[*\n]/` would match a
@@ -919,8 +934,20 @@ function stripKennelPrefixFromTitle(
   return title;
 }
 
-/** Internal normalized header match — `month`/`day` regardless of source regex. */
-type HeaderMatch = { index: number; length: number; month: number; day: number };
+/**
+ * Internal normalized header match — `month`/`day` and the originating
+ * shape regardless of which source regex matched. `shape` is preserved so
+ * `extractSectionTitle` can apply the right delimiter-gating semantics
+ * (weekday-form: title flows verbatim; day-number form: title only when a
+ * trailing delimiter was present — CodeRabbit PR #1697 review).
+ */
+type HeaderMatch = {
+  index: number;
+  length: number;
+  month: number;
+  day: number;
+  shape: "day-number" | "weekday";
+};
 
 /**
  * Normalize a regex match from either header regex into `HeaderMatch`. The
@@ -947,6 +974,7 @@ function normalizeHeaderMatch(
     length: m[0].length,
     month: Number.parseInt(m[monthGroup], 10),
     day: Number.parseInt(m[dayGroup], 10),
+    shape,
   };
 }
 
@@ -1012,7 +1040,7 @@ export function parseDayHeaderSections(
     const slice = description.slice(sliceStart, sliceEnd);
     const startTime = extractFirstTimeFromSlice(slice);
     const kennelCode = matchPerDayKennel(slice, compiled);
-    const rawTitle = extractSectionTitle(slice);
+    const rawTitle = extractSectionTitle(slice, m.shape);
     // PR E.2: when the title leads with the kennel name that's already
     // surfacing on the kennel pill (e.g. "GGFM Strawberry Moon Trail" +
     // GGFM pill), strip the prefix so the card reads "Strawberry Moon Trail".

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -49,6 +49,15 @@ export interface ParsedEvent {
    * `splitToRawEvents` falls back to the host kennel for those days.
    */
   perDayKennelCodes?: ReadonlyArray<string | undefined>;
+  /**
+   * Per-day section-header title (PR E.1). Pulled from the text AFTER the
+   * `WEEKDAY/Day N M/D` delimiter on the same line (`**FRIDAY 6/26 — GGFM
+   * Strawberry Moon Trail**` → "GGFM Strawberry Moon Trail"). Aligned with
+   * `dates` by index. Entries are `undefined` when the slice has no title
+   * after the delimiter; `splitToRawEvents` falls back to
+   * `"${title} (Day N)"` for those days (the pre-E.1 behavior).
+   */
+  perDayTitles?: ReadonlyArray<string | undefined>;
 }
 
 /**
@@ -219,7 +228,7 @@ export function parseEventDetail(
   const locationUrl = descLocationUrl || domLocation.mapsUrl;
 
   // Parse dates from the description or index entry
-  const { dates, startTimes, isMultiDay, endDate, perDayKennelCodes } = extractDates(
+  const { dates, startTimes, isMultiDay, endDate, perDayKennelCodes, perDayTitles } = extractDates(
     rawDescription,
     indexEntry,
     title,
@@ -244,6 +253,7 @@ export function parseEventDetail(
     isMultiDay,
     endDate,
     perDayKennelCodes,
+    perDayTitles,
   };
 }
 
@@ -444,10 +454,17 @@ export function splitToRawEvents(
   const buildChild = (date: string, i: number): RawEventData => {
     const dayLabel = `Day ${i + 1}`;
     const perDayCode = parsed.perDayKennelCodes?.[i];
+    // PR E.1: prefer the section-header title from the source description
+    // ("Strawberry Moon Trail" — already kennel-prefix-stripped by
+    // `parseDayHeaderSections` when a matching kennel pattern was hit, per
+    // PR E.2) over the legacy "(Day N)" suffix. The suffix remains the
+    // fallback when the description had no parseable section title.
+    const sectionTitle = parsed.perDayTitles?.[i];
+    const childTitle = sectionTitle ?? `${parsed.title} (${dayLabel})`;
     return {
       date,
       kennelTags: [perDayCode ?? hostKennelTag],
-      title: `${parsed.title} (${dayLabel})`,
+      title: childTitle,
       description: parsed.description,
       hares: parsed.hares,
       location: parsed.location,
@@ -681,6 +698,37 @@ function extractFirstTimeFromSlice(slice: string): string | undefined {
   return `${String(adjustedH).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
 }
 
+/**
+ * Extract a per-day section-header title from the slice immediately after
+ * a `WEEKDAY/Day N M/D` header match (PR E.1).
+ *
+ * Real Hash Rego section headers look like
+ *   `**FRIDAY 6/26 — GGFM Strawberry Moon Trail**`
+ * Our `WEEKDAY_HEADER_RE` consumes up through the trailing dash (`—`), so
+ * the slice handed to this helper starts with " GGFM Strawberry Moon Trail**\n..."
+ * The title is everything up to the first closing `**` or first newline,
+ * whichever comes first. Trailing punctuation (commas, periods, em-dashes)
+ * is stripped so we don't render "Strawberry Moon Trail." with a dangling dot.
+ *
+ * Returns `undefined` when the slice has no title text on the header line —
+ * e.g. `**DAY 1 12/30 —**\nblurb...` where the header carries the date only.
+ * The caller then falls back to the legacy `"${title} (Day N)"` form.
+ */
+function extractSectionTitle(slice: string): string | undefined {
+  // Strip leading whitespace + a possible leading delimiter that the header
+  // regex's `[-—:]` already captured but might have an adjacent dup-char
+  // (defensive: harmless to skip another leading dash here).
+  const trimmed = slice.replace(/^\s+/, "");
+  // Take up to the first closing `**` (markdown bold) or newline.
+  const endMatch = /[*\n]/.exec(trimmed);
+  const raw = endMatch ? trimmed.slice(0, endMatch.index) : trimmed;
+  // Drop trailing whitespace and trailing punctuation runs (`.`, `,`, `;`,
+  // `:`, `—`, `–`, `-`). Stops short of full sentence-end stripping so
+  // titles like "Pub Crawl!" keep the bang.
+  const cleaned = raw.replace(/[\s.,;:—–-]+$/, "").trim();
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
 /** One per-day entry from `parseDayHeaderSections`. */
 export interface DayHeaderSection {
   date: string;        // YYYY-MM-DD
@@ -692,6 +740,15 @@ export interface DayHeaderSection {
    * pattern matched; the caller falls back to the host kennel.
    */
   kennelCode?: string;
+  /**
+   * Per-day section-header title (PR E.1). The text on the header line
+   * AFTER the trailing dash/colon delimiter, before the closing `**` or
+   * the end-of-line — e.g. `"GGFM Strawberry Moon Trail"` for
+   * `**FRIDAY 6/26 — GGFM Strawberry Moon Trail**`. Undefined when the
+   * header line carries no title (e.g. `**DAY 1 12/30 —**` followed by
+   * a blank line); the caller falls back to `"${title} (Day N)"`.
+   */
+  sectionTitle?: string;
 }
 
 /**
@@ -737,6 +794,54 @@ function matchPerDayKennel(
     if (re.test(slice)) return code;
   }
   return undefined;
+}
+
+/**
+ * Minimum length (in chars) the title must retain AFTER prefix stripping.
+ * Prevents a too-aggressive strip from leaving a 2-char fragment like "Tr".
+ */
+const MIN_STRIPPED_TITLE_LENGTH = 4;
+
+/**
+ * Strip a kennel-name prefix from a section title when the kennel pill on
+ * the card is going to surface that same identity right next to it (PR E.2).
+ *
+ * E.g. for NYC 5-Boro Friday: title `"GGFM Strawberry Moon Trail"` + kennel
+ * pill GGFM → "Strawberry Moon Trail". The kennel pattern that matched
+ * (`compiled[i][0]`) is the canonical pattern for "GGFM" / "Greater Gotham",
+ * so we test the title against the same compiled pattern, anchored to the
+ * start, and remove the matched run plus any trailing separators.
+ *
+ * Safety guards (per the plan):
+ * - Falls through (returns input verbatim) when no compiled patterns match
+ *   the matched code (defensive — `matchedCode` should always come from
+ *   `compiled`).
+ * - Falls through when the prefix-removed remainder would be <
+ *   MIN_STRIPPED_TITLE_LENGTH chars — we'd rather show "GGFM ✨" than "✨".
+ */
+function stripKennelPrefixFromTitle(
+  title: string,
+  matchedCode: string,
+  compiled: ReadonlyArray<readonly [RegExp, string]>,
+): string {
+  // Find every compiled pattern that maps to this kennelCode. Multiple
+  // patterns can point at the same code ("GGFM" + "Greater Gotham" → ggfm)
+  // so we try them all in declared order and take the first hit at the
+  // start of the title.
+  for (const [re, code] of compiled) {
+    if (code !== matchedCode) continue;
+    // Anchor the pattern to the start of the title. Build a fresh regex
+    // because `re` is unanchored + has the `i` flag from compileKennelPatterns.
+    const anchored = new RegExp(`^\\s*${re.source}`, "i");
+    const m = anchored.exec(title);
+    if (!m) continue;
+    // Drop the matched prefix + any trailing separators (space, dash, colon,
+    // em-dash, en-dash, comma) that link the kennel name to the trail name.
+    const rest = title.slice(m[0].length).replace(/^[\s—–\-:,]+/, "");
+    if (rest.length >= MIN_STRIPPED_TITLE_LENGTH) return rest;
+    return title;
+  }
+  return title;
 }
 
 /** Internal normalized header match — `month`/`day` regardless of source regex. */
@@ -832,7 +937,15 @@ export function parseDayHeaderSections(
     const slice = description.slice(sliceStart, sliceEnd);
     const startTime = extractFirstTimeFromSlice(slice);
     const kennelCode = matchPerDayKennel(slice, compiled);
-    return { date, startTime, kennelCode };
+    const rawTitle = extractSectionTitle(slice);
+    // PR E.2: when the title leads with the kennel name that's already
+    // surfacing on the kennel pill (e.g. "GGFM Strawberry Moon Trail" +
+    // GGFM pill), strip the prefix so the card reads "Strawberry Moon Trail".
+    // No-op when no per-day kennel match OR no compiled patterns.
+    const sectionTitle = rawTitle && kennelCode && compiled
+      ? stripKennelPrefixFromTitle(rawTitle, kennelCode, compiled)
+      : rawTitle;
+    return { date, startTime, kennelCode, sectionTitle };
   });
 
   // Deduplicate by date (a description mentioning the same day twice in
@@ -863,6 +976,8 @@ type DateRangeResult = {
   /** Inclusive last day of a single-registration venue weekend (#1560 PR C). */
   endDate?: string;
   perDayKennelCodes?: ReadonlyArray<string | undefined>;
+  /** Per-day section-header titles (PR E.1). Aligned with `dates` by index. */
+  perDayTitles?: ReadonlyArray<string | undefined>;
 };
 
 /** Try to parse a date range from the description and index entry. */
@@ -910,7 +1025,8 @@ function parseDateRangeFromDescription(
     const firstTime = dayHeaderEntries.find((e) => e.startTime)?.startTime ?? "";
     const startTimes = dayHeaderEntries.map((e) => e.startTime ?? firstTime);
     const perDayKennelCodes = dayHeaderEntries.map((e) => e.kennelCode);
-    return { dates, startTimes, isMultiDay: true, perDayKennelCodes };
+    const perDayTitles = dayHeaderEntries.map((e) => e.sectionTitle);
+    return { dates, startTimes, isMultiDay: true, perDayKennelCodes, perDayTitles };
   }
 
   return null;

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -856,7 +856,7 @@ function compileKennelPatterns(
       // on PR D). Mirrors src/app/admin/sources/config-validation.ts:33
       // and the suppression pattern from hare-extraction.ts:27-29.
       // nosemgrep: detect-non-literal-regexp — source is operator-curated config, ReDoS-validated below
-      // eslint-disable-next-line security/detect-non-literal-regexp, security-node/non-literal-reg-expr -- Codacy ESLint plugins not loaded locally; source is operator-curated and ReDoS-validated by safe-regex2 immediately below
+      // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source is operator-curated and ReDoS-validated by safe-regex2 immediately below // NOSONAR S7724
       const re = new RegExp(src, "i"); // NOSONAR nosemgrep
       if (!isSafeRegex(re)) {
         console.warn(

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -798,19 +798,50 @@ export interface DayHeaderSection {
 export type KennelPatternConfig = ReadonlyArray<readonly [string, string]>;
 
 /**
+ * Compiled form of one source-configured kennel pattern. We carry BOTH
+ * forms upfront so consumers can pick the right one without dynamically
+ * rebuilding a RegExp from `re.source` at call time:
+ *
+ *  - `unanchored`: used to scan a section's body text for a kennel mention
+ *    (`matchPerDayKennel`).
+ *  - `anchored`: same pattern with `^\s*` prepended, used to detect AND
+ *    strip a leading kennel-name from a section title
+ *    (`stripKennelPrefixFromTitle`). The anchored form is fully built at
+ *    config compile time so the strip site never calls
+ *    `new RegExp(<interpolated>, …)` — Codacy/Opengrep flagged that as a
+ *    ReDoS surface even though `re.source` is operator-curated (PR E
+ *    review).
+ */
+interface CompiledKennelPattern {
+  readonly unanchored: RegExp;
+  readonly anchored: RegExp;
+  readonly code: string;
+}
+
+/**
  * Compile per-day kennel patterns. **Fail-soft**: invalid regex sources are
  * dropped with a `console.warn` rather than thrown — a single typo in source
  * config must not strip enriched multi-day behavior from an entire scrape
  * (Codex review on PR D). Returns `undefined` when nothing compiled cleanly.
+ *
+ * Each entry builds BOTH an unanchored AND an anchored regex from the same
+ * source so downstream consumers can pick the right one without
+ * dynamically constructing regexes at the call site (Codacy ReDoS review
+ * on PR E #1697). Both share the `i` flag so casing is consistent.
  */
 function compileKennelPatterns(
   patterns: KennelPatternConfig | undefined,
-): ReadonlyArray<readonly [RegExp, string]> | undefined {
+): ReadonlyArray<CompiledKennelPattern> | undefined {
   if (!patterns || patterns.length === 0) return undefined;
-  const compiled: Array<readonly [RegExp, string]> = [];
+  const compiled: CompiledKennelPattern[] = [];
   for (const [src, code] of patterns) {
     try {
-      compiled.push([new RegExp(src, "i"), code] as const);
+      const unanchored = new RegExp(src, "i");
+      // Build the anchored form from the same operator-supplied source.
+      // Both regexes are constructed at config time — strip-site never
+      // touches the constructor.
+      const anchored = new RegExp(String.raw`^\s*(?:${src})`, "i");
+      compiled.push({ unanchored, anchored, code });
     } catch (err) {
       console.warn(
         `[hashrego] invalid kennelPattern source ${JSON.stringify(src)} for code ${code}: ${err}`,
@@ -822,11 +853,11 @@ function compileKennelPatterns(
 
 function matchPerDayKennel(
   slice: string,
-  compiled: ReadonlyArray<readonly [RegExp, string]> | undefined,
+  compiled: ReadonlyArray<CompiledKennelPattern> | undefined,
 ): string | undefined {
   if (!compiled) return undefined;
-  for (const [re, code] of compiled) {
-    if (re.test(slice)) return code;
+  for (const { unanchored, code } of compiled) {
+    if (unanchored.test(slice)) return code;
   }
   return undefined;
 }
@@ -842,10 +873,17 @@ const MIN_STRIPPED_TITLE_LENGTH = 4;
  * the card is going to surface that same identity right next to it (PR E.2).
  *
  * E.g. for NYC 5-Boro Friday: title `"GGFM Strawberry Moon Trail"` + kennel
- * pill GGFM → "Strawberry Moon Trail". The kennel pattern that matched
- * (`compiled[i][0]`) is the canonical pattern for "GGFM" / "Greater Gotham",
- * so we test the title against the same compiled pattern, anchored to the
- * start, and remove the matched run plus any trailing separators.
+ * pill GGFM → "Strawberry Moon Trail". Walks every compiled pattern that
+ * maps to `matchedCode` (multiple sources can point at one code:
+ * "GGFM" + "Greater Gotham" → ggfm) and takes the first hit of the
+ * pre-built anchored regex at the start of the title.
+ *
+ * The anchored regex is built ONCE in `compileKennelPatterns` rather than
+ * dynamically here — Codacy/Opengrep flagged the previous in-loop
+ * `new RegExp(String.raw\`^\\s*${re.source}\`, "i")` call as a ReDoS surface
+ * (operator-curated sources, but the rule is correct in principle and the
+ * pre-built form is also faster — patterns compile once per scrape, not
+ * once per child title).
  *
  * Safety guards (per the plan):
  * - Falls through (returns input verbatim) when no compiled patterns match
@@ -857,17 +895,10 @@ const MIN_STRIPPED_TITLE_LENGTH = 4;
 function stripKennelPrefixFromTitle(
   title: string,
   matchedCode: string,
-  compiled: ReadonlyArray<readonly [RegExp, string]>,
+  compiled: ReadonlyArray<CompiledKennelPattern>,
 ): string {
-  // Find every compiled pattern that maps to this kennelCode. Multiple
-  // patterns can point at the same code ("GGFM" + "Greater Gotham" → ggfm)
-  // so we try them all in declared order and take the first hit at the
-  // start of the title.
-  for (const [re, code] of compiled) {
+  for (const { anchored, code } of compiled) {
     if (code !== matchedCode) continue;
-    // Anchor the pattern to the start of the title. Build a fresh regex
-    // because `re` is unanchored + has the `i` flag from compileKennelPatterns.
-    const anchored = new RegExp(String.raw`^\s*${re.source}`, "i");
     const m = anchored.exec(title);
     if (!m) continue;
     // Drop the matched prefix + any trailing separators (space, dash, colon,

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -853,8 +853,10 @@ function compileKennelPatterns(
       // being kept. Invalid or unsafe patterns are dropped fail-soft with
       // a console.warn so a single typo in source config can't strip
       // enriched multi-day behavior from the whole scrape (Codex review
-      // on PR D). Mirrors src/app/admin/sources/config-validation.ts:33.
-      // nosemgrep: detect-non-literal-regexp
+      // on PR D). Mirrors src/app/admin/sources/config-validation.ts:33
+      // and the suppression pattern from hare-extraction.ts:27-29.
+      // nosemgrep: detect-non-literal-regexp — source is operator-curated config, ReDoS-validated below
+      // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source is operator-curated and ReDoS-validated
       const re = new RegExp(src, "i"); // NOSONAR nosemgrep
       if (!isSafeRegex(re)) {
         console.warn(

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -798,23 +798,20 @@ export interface DayHeaderSection {
 export type KennelPatternConfig = ReadonlyArray<readonly [string, string]>;
 
 /**
- * Compiled form of one source-configured kennel pattern. We carry BOTH
- * forms upfront so consumers can pick the right one without dynamically
- * rebuilding a RegExp from `re.source` at call time:
+ * Compiled form of one source-configured kennel pattern. We hold the
+ * compiled regex (unanchored, case-insensitive) and the kennelCode it
+ * resolves to. The strip site enforces "anchored at start" via
+ * `m.index === 0` rather than building a second anchored regex — that
+ * avoids a `new RegExp(<interpolated>, …)` call at the strip site, which
+ * Codacy/Opengrep flags as a ReDoS surface even though our sources are
+ * operator-curated (PR E #1697 review).
  *
- *  - `unanchored`: used to scan a section's body text for a kennel mention
- *    (`matchPerDayKennel`).
- *  - `anchored`: same pattern with `^\s*` prepended, used to detect AND
- *    strip a leading kennel-name from a section title
- *    (`stripKennelPrefixFromTitle`). The anchored form is fully built at
- *    config compile time so the strip site never calls
- *    `new RegExp(<interpolated>, …)` — Codacy/Opengrep flagged that as a
- *    ReDoS surface even though `re.source` is operator-curated (PR E
- *    review).
+ * The implicit precondition for the `m.index === 0` check is that the
+ * caller has already left-trimmed the title — see `extractSectionTitle`,
+ * which strips leading whitespace + delimiter runs before this is reached.
  */
 interface CompiledKennelPattern {
-  readonly unanchored: RegExp;
-  readonly anchored: RegExp;
+  readonly re: RegExp;
   readonly code: string;
 }
 
@@ -824,10 +821,10 @@ interface CompiledKennelPattern {
  * config must not strip enriched multi-day behavior from an entire scrape
  * (Codex review on PR D). Returns `undefined` when nothing compiled cleanly.
  *
- * Each entry builds BOTH an unanchored AND an anchored regex from the same
- * source so downstream consumers can pick the right one without
- * dynamically constructing regexes at the call site (Codacy ReDoS review
- * on PR E #1697). Both share the `i` flag so casing is consistent.
+ * Each pattern is compiled ONCE per scrape (not once per child title) with
+ * the `i` flag so casing is consistent. Consumers use the unanchored regex
+ * for both body-text scanning AND leading-kennel-name stripping — the
+ * latter enforces anchoring via `m.index === 0`.
  */
 function compileKennelPatterns(
   patterns: KennelPatternConfig | undefined,
@@ -836,12 +833,7 @@ function compileKennelPatterns(
   const compiled: CompiledKennelPattern[] = [];
   for (const [src, code] of patterns) {
     try {
-      const unanchored = new RegExp(src, "i");
-      // Build the anchored form from the same operator-supplied source.
-      // Both regexes are constructed at config time — strip-site never
-      // touches the constructor.
-      const anchored = new RegExp(String.raw`^\s*(?:${src})`, "i");
-      compiled.push({ unanchored, anchored, code });
+      compiled.push({ re: new RegExp(src, "i"), code });
     } catch (err) {
       console.warn(
         `[hashrego] invalid kennelPattern source ${JSON.stringify(src)} for code ${code}: ${err}`,
@@ -856,8 +848,8 @@ function matchPerDayKennel(
   compiled: ReadonlyArray<CompiledKennelPattern> | undefined,
 ): string | undefined {
   if (!compiled) return undefined;
-  for (const { unanchored, code } of compiled) {
-    if (unanchored.test(slice)) return code;
+  for (const { re, code } of compiled) {
+    if (re.test(slice)) return code;
   }
   return undefined;
 }
@@ -875,15 +867,14 @@ const MIN_STRIPPED_TITLE_LENGTH = 4;
  * E.g. for NYC 5-Boro Friday: title `"GGFM Strawberry Moon Trail"` + kennel
  * pill GGFM → "Strawberry Moon Trail". Walks every compiled pattern that
  * maps to `matchedCode` (multiple sources can point at one code:
- * "GGFM" + "Greater Gotham" → ggfm) and takes the first hit of the
- * pre-built anchored regex at the start of the title.
+ * "GGFM" + "Greater Gotham" → ggfm) and takes the first hit AT THE START
+ * of the title.
  *
- * The anchored regex is built ONCE in `compileKennelPatterns` rather than
- * dynamically here — Codacy/Opengrep flagged the previous in-loop
- * `new RegExp(String.raw\`^\\s*${re.source}\`, "i")` call as a ReDoS surface
- * (operator-curated sources, but the rule is correct in principle and the
- * pre-built form is also faster — patterns compile once per scrape, not
- * once per child title).
+ * Anchoring is enforced via `m.index === 0` rather than a second anchored
+ * regex — Codacy/Opengrep flags `new RegExp(<interpolated>, …)` calls as
+ * a ReDoS surface, even for operator-curated sources (PR E #1697 review).
+ * The `m.index === 0` check is sound because `extractSectionTitle` left-
+ * trims the title before this is reached (whitespace + delimiter runs).
  *
  * Safety guards (per the plan):
  * - Falls through (returns input verbatim) when no compiled patterns match
@@ -897,10 +888,12 @@ function stripKennelPrefixFromTitle(
   matchedCode: string,
   compiled: ReadonlyArray<CompiledKennelPattern>,
 ): string {
-  for (const { anchored, code } of compiled) {
+  for (const { re, code } of compiled) {
     if (code !== matchedCode) continue;
-    const m = anchored.exec(title);
-    if (!m) continue;
+    const m = re.exec(title);
+    // Require an at-start match (the title is already left-trimmed by
+    // `extractSectionTitle`, so a real prefix-match lands at index 0).
+    if (!m || m.index !== 0) continue;
     // Drop the matched prefix + any trailing separators (space, dash, colon,
     // em-dash, en-dash, comma) that link the kennel name to the trail name.
     const rest = title.slice(m[0].length).replace(/^[\s—–\-:,]+/, "");

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -834,13 +834,13 @@ function compileKennelPatterns(
   const compiled: CompiledKennelPattern[] = [];
   for (const [src, code] of patterns) {
     try {
-      // nosemgrep: detect-non-literal-regexp — intentional: each source is
-      // ReDoS-validated via `safe-regex2` before construction (mirrors the
-      // pattern in src/app/admin/sources/config-validation.ts:33). Invalid
-      // or unsafe patterns are dropped fail-soft with a console.warn so
-      // a single typo in source config can't strip enriched multi-day
-      // behavior from the whole scrape (Codex review on PR D).
-      const re = new RegExp(src, "i"); // NOSONAR
+      // Each source is ReDoS-validated via `safe-regex2` (below) before
+      // being kept. Invalid or unsafe patterns are dropped fail-soft with
+      // a console.warn so a single typo in source config can't strip
+      // enriched multi-day behavior from the whole scrape (Codex review
+      // on PR D). Mirrors src/app/admin/sources/config-validation.ts:33.
+      // nosemgrep: detect-non-literal-regexp
+      const re = new RegExp(src, "i"); // NOSONAR nosemgrep
       if (!isSafeRegex(re)) {
         console.warn(
           `[hashrego] kennelPattern source ${JSON.stringify(src)} for code ${code} is ReDoS-prone (rejected by safe-regex2); skipping`,

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -727,12 +727,11 @@ function extractSectionTitle(slice: string): string | undefined {
   // matches the literal closing-bold pair.
   const starsIdx = trimmed.indexOf("**");
   const newlineIdx = trimmed.indexOf("\n");
-  const endIdx =
-    starsIdx === -1
-      ? newlineIdx
-      : newlineIdx === -1
-        ? starsIdx
-        : Math.min(starsIdx, newlineIdx);
+  // Pick the earliest terminator. Sonar S3358 doesn't like the chained-ternary
+  // form; build a candidate list and take the min, treating "missing" as
+  // `Infinity` so it loses any actual hit.
+  const candidates = [starsIdx, newlineIdx].filter((i) => i !== -1);
+  const endIdx = candidates.length === 0 ? -1 : Math.min(...candidates);
   const raw = endIdx === -1 ? trimmed : trimmed.slice(0, endIdx);
   // Drop trailing whitespace + trailing punctuation runs (`.`, `,`, `;`,
   // `:`, `—`, `–`, `-`). Procedural strip rather than a regex with `\s`
@@ -741,7 +740,7 @@ function extractSectionTitle(slice: string): string | undefined {
   // Stops short of full sentence-end stripping so titles like "Pub Crawl!"
   // keep the bang.
   let cleaned = raw.trim();
-  while (cleaned.length > 0 && isTrailingPunct(cleaned[cleaned.length - 1])) {
+  while (cleaned.length > 0 && isTrailingPunct(cleaned.at(-1) ?? "")) {
     cleaned = cleaned.slice(0, -1);
   }
   cleaned = cleaned.trim();

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -715,10 +715,19 @@ function extractFirstTimeFromSlice(slice: string): string | undefined {
  * The caller then falls back to the legacy `"${title} (Day N)"` form.
  */
 function extractSectionTitle(slice: string): string | undefined {
-  // Strip leading whitespace + a possible leading delimiter that the header
-  // regex's `[-—:]` already captured but might have an adjacent dup-char
-  // (defensive: harmless to skip another leading dash here).
-  const trimmed = slice.replace(/^\s+/, "");
+  // Strip leading whitespace + a leading delimiter (em-dash, en-dash,
+  // hyphen, colon) before extracting the title text.
+  //
+  // The asymmetry matters: `WEEKDAY_HEADER_RE` ends with `\s*[-—:]` so the
+  // delimiter is already CONSUMED by the time we see the slice. But
+  // `DAY_NUMBER_HEADER_RE` ends at `\b` after the day digit, so the slice
+  // for `**DAY 1 6/26 — Friday Kickoff**` starts at ` — Friday…`. Without
+  // an explicit leading-delimiter strip, the title would land as
+  // "— Friday Kickoff" (CodeRabbit PR #1697 review).
+  const trimmed = slice
+    .replace(/^\s+/, "")
+    .replace(/^[-—–:]+/, "")
+    .replace(/^\s+/, "");
   // Take up to the first closing `**` (markdown bold) or newline, whichever
   // comes first. We deliberately use indexOf for `**` rather than a regex
   // character class — Gemini PR #1697 caught that `/[*\n]/` would match a

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -856,7 +856,7 @@ function compileKennelPatterns(
       // on PR D). Mirrors src/app/admin/sources/config-validation.ts:33
       // and the suppression pattern from hare-extraction.ts:27-29.
       // nosemgrep: detect-non-literal-regexp — source is operator-curated config, ReDoS-validated below
-      // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source is operator-curated and ReDoS-validated
+      // eslint-disable-next-line security/detect-non-literal-regexp, security-node/non-literal-reg-expr -- Codacy ESLint plugins not loaded locally; source is operator-curated and ReDoS-validated by safe-regex2 immediately below
       const re = new RegExp(src, "i"); // NOSONAR nosemgrep
       if (!isSafeRegex(re)) {
         console.warn(

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -893,7 +893,9 @@ function stripKennelPrefixFromTitle(
     const m = re.exec(title);
     // Require an at-start match (the title is already left-trimmed by
     // `extractSectionTitle`, so a real prefix-match lands at index 0).
-    if (!m || m.index !== 0) continue;
+    // Optional-chain form: when `m` is null, `m?.index` is undefined and
+    // `undefined !== 0` is true → continue (Sonar S6582).
+    if (m?.index !== 0) continue;
     // Drop the matched prefix + any trailing separators (space, dash, colon,
     // em-dash, en-dash, comma) that link the kennel name to the trail name.
     const rest = title.slice(m[0].length).replace(/^[\s—–\-:,]+/, "");

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -1,4 +1,5 @@
 import * as cheerio from "cheerio";
+import isSafeRegex from "safe-regex2";
 import type { RawEventData } from "../types";
 
 const BASE_URL = "https://hashrego.com";
@@ -833,7 +834,20 @@ function compileKennelPatterns(
   const compiled: CompiledKennelPattern[] = [];
   for (const [src, code] of patterns) {
     try {
-      compiled.push({ re: new RegExp(src, "i"), code });
+      // nosemgrep: detect-non-literal-regexp — intentional: each source is
+      // ReDoS-validated via `safe-regex2` before construction (mirrors the
+      // pattern in src/app/admin/sources/config-validation.ts:33). Invalid
+      // or unsafe patterns are dropped fail-soft with a console.warn so
+      // a single typo in source config can't strip enriched multi-day
+      // behavior from the whole scrape (Codex review on PR D).
+      const re = new RegExp(src, "i"); // NOSONAR
+      if (!isSafeRegex(re)) {
+        console.warn(
+          `[hashrego] kennelPattern source ${JSON.stringify(src)} for code ${code} is ReDoS-prone (rejected by safe-regex2); skipping`,
+        );
+        continue;
+      }
+      compiled.push({ re, code });
     } catch (err) {
       console.warn(
         `[hashrego] invalid kennelPattern source ${JSON.stringify(src)} for code ${code}: ${err}`,

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -719,14 +719,41 @@ function extractSectionTitle(slice: string): string | undefined {
   // regex's `[-—:]` already captured but might have an adjacent dup-char
   // (defensive: harmless to skip another leading dash here).
   const trimmed = slice.replace(/^\s+/, "");
-  // Take up to the first closing `**` (markdown bold) or newline.
-  const endMatch = /[*\n]/.exec(trimmed);
-  const raw = endMatch ? trimmed.slice(0, endMatch.index) : trimmed;
-  // Drop trailing whitespace and trailing punctuation runs (`.`, `,`, `;`,
-  // `:`, `—`, `–`, `-`). Stops short of full sentence-end stripping so
-  // titles like "Pub Crawl!" keep the bang.
-  const cleaned = raw.replace(/[\s.,;:—–-]+$/, "").trim();
+  // Take up to the first closing `**` (markdown bold) or newline, whichever
+  // comes first. We deliberately use indexOf for `**` rather than a regex
+  // character class — Gemini PR #1697 caught that `/[*\n]/` would match a
+  // SINGLE `*`, so a title with markdown emphasis like "GGFM *Strawberry*
+  // Moon Trail**" would truncate at the first inline asterisk. indexOf
+  // matches the literal closing-bold pair.
+  const starsIdx = trimmed.indexOf("**");
+  const newlineIdx = trimmed.indexOf("\n");
+  const endIdx =
+    starsIdx === -1
+      ? newlineIdx
+      : newlineIdx === -1
+        ? starsIdx
+        : Math.min(starsIdx, newlineIdx);
+  const raw = endIdx === -1 ? trimmed : trimmed.slice(0, endIdx);
+  // Drop trailing whitespace + trailing punctuation runs (`.`, `,`, `;`,
+  // `:`, `—`, `–`, `-`). Procedural strip rather than a regex with `\s`
+  // inside a char class with `+$` — Sonar S5852 false-positives that shape
+  // as ReDoS-prone (memory: `feedback_sonar_s5852_procedural_over_regex`).
+  // Stops short of full sentence-end stripping so titles like "Pub Crawl!"
+  // keep the bang.
+  let cleaned = raw.trim();
+  while (cleaned.length > 0 && isTrailingPunct(cleaned[cleaned.length - 1])) {
+    cleaned = cleaned.slice(0, -1);
+  }
+  cleaned = cleaned.trim();
   return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/** Trailing-punctuation set used by `extractSectionTitle`'s procedural strip. */
+const TRAILING_PUNCT_CHARS: ReadonlySet<string> = new Set([
+  ".", ",", ";", ":", "—", "–", "-",
+]);
+function isTrailingPunct(ch: string): boolean {
+  return TRAILING_PUNCT_CHARS.has(ch);
 }
 
 /** One per-day entry from `parseDayHeaderSections`. */

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { ArrowUpLeft, Tent } from "lucide-react";
 import { prisma } from "@/lib/db";
 import { getOrCreateUser, getAdminUser, getMismanUserForEvent } from "@/lib/auth";
 import { getStravaConnection } from "@/app/strava/actions";
@@ -23,7 +24,9 @@ import { getEventDayWeather } from "@/lib/weather";
 import { REGION_CENTROIDS } from "@/lib/geo";
 import { InfoPopover } from "@/components/ui/info-popover";
 import { RestoreEventButton } from "@/components/admin/RestoreEventButton";
-import { stripMarkdown, stripUrlsFromText, formatRelativeTime } from "@/lib/format";
+import { stripMarkdown, stripUrlsFromText, formatRelativeTime, formatDateRange } from "@/lib/format";
+import { SeriesChildTimeline } from "@/components/hareline/SeriesChildTimeline";
+import type { HarelineSeriesChild } from "@/components/hareline/EventCard";
 import { getFullLocationDisplay } from "@/lib/event-display";
 import { buildEventJsonLd, safeJsonLd } from "@/lib/seo";
 import { getCanonicalSiteUrl } from "@/lib/site-url";
@@ -105,6 +108,36 @@ export default async function EventDetailPage({
         select: { id: true, url: true, label: true },
         orderBy: { createdAt: "asc" },
       },
+      // #1560 PR E.6 — series-parent surface needs child events (rendered as
+      // the "Weekend at a glance" rail timeline below the umbrella name) and
+      // the parent's own back-link target for children. The child `where`
+      // mirrors the hareline list visibility predicates from `actions.ts`
+      // (DISPLAY_EVENT_WHERE) — without this, cancelled / manual / hidden-
+      // kennel / non-canonical children would leak into the timeline and
+      // inflate the `+ N TRAILS` badge on the umbrella's public page
+      // (Codex PR E.6 review).
+      parentEvent: { select: { id: true, title: true } },
+      childEvents: {
+        where: {
+          status: { not: "CANCELLED" },
+          isManualEntry: { not: true },
+          isCanonical: true,
+          kennel: { isHidden: false },
+        },
+        orderBy: { date: "asc" },
+        select: {
+          id: true,
+          date: true,
+          dateUtc: true,
+          timezone: true,
+          title: true,
+          haresText: true,
+          startTime: true,
+          status: true,
+          locationName: true,
+          runNumber: true,
+        },
+      },
     },
   });
 
@@ -179,6 +212,34 @@ export default async function EventDetailPage({
   const regionColor = getRegionColor(event.kennel.region);
   const trailLengthDisplay = formatTrailLength(event);
 
+  // #1560 PR E.6 — series-parent rendering. The umbrella detail page
+  // surfaces a date-range header (in place of the single-day `dateFormatted`),
+  // a `+ N TRAILS` badge with Tent glyph, the umbrella name as a secondary
+  // `<h2>`, and the shared `SeriesChildTimeline` rail BEFORE the description
+  // blob. Single-day events render unchanged (all the new branches gate on
+  // `isSeriesParent === true`). Children carry a parameterized back-link to
+  // their parent at the top of the page.
+  const isSeriesParent = event.isSeriesParent === true;
+  const childEvents: HarelineSeriesChild[] = isSeriesParent
+    ? event.childEvents.map((c) => ({
+        id: c.id,
+        date: c.date.toISOString(),
+        dateUtc: c.dateUtc ?? null,
+        timezone: c.timezone,
+        title: c.title,
+        haresText: c.haresText,
+        startTime: c.startTime,
+        status: c.status,
+        locationName: c.locationName,
+        runNumber: c.runNumber,
+      }))
+    : [];
+  const childCount = childEvents.length;
+  const headerDateStr = isSeriesParent
+    ? formatDateRange(event.date.toISOString(), event.endDate?.toISOString() ?? null)
+    : dateFormatted;
+  const isChildOfSeries = !!event.parentEventId;
+
   function getAttendancePrompt(eventDate: Date, status: string | null): string {
     // Compare at UTC noon to match date storage convention (Appendix F.4)
     const now = new Date();
@@ -238,9 +299,32 @@ export default async function EventDetailPage({
         <span className="text-foreground">{event.kennel.shortName} — {breadcrumbDate}</span>
       </nav>
 
+      {/* #1560 PR E.5/E.6 — child back-link to the parent series. Mirrors
+          `EventDetailPanel.tsx` and uses the parameterized parent title
+          when available so the user knows which weekend the child belongs to. */}
+      {isChildOfSeries && event.parentEventId && (
+        <Link
+          href={`/hareline/${event.parentEventId}`}
+          className="flex w-fit items-center gap-2 px-2 py-1.5 -mx-1 border-l-[3px] text-xs text-muted-foreground hover:text-foreground transition-colors"
+          style={{ borderColor: regionColor }}
+        >
+          <ArrowUpLeft className="size-3" aria-hidden="true" />
+          <span>Part of {event.parentEvent?.title ?? "a multi-day series"}</span>
+        </Link>
+      )}
+
       {/* Header */}
       <div className="space-y-2">
-        <h1 className="text-2xl font-bold">{dateFormatted}</h1>
+        <h1 className="text-2xl font-bold flex items-center gap-2 flex-wrap">
+          {isSeriesParent && (
+            <Tent
+              className="size-6 shrink-0"
+              style={{ color: regionColor }}
+              aria-hidden="true"
+            />
+          )}
+          <span suppressHydrationWarning>{headerDateStr}</span>
+        </h1>
 
         <div className="flex flex-wrap items-center gap-2">
           <Link
@@ -259,6 +343,16 @@ export default async function EventDetailPage({
           {event.status === "TENTATIVE" && (
             <Badge variant="outline">Tentative</Badge>
           )}
+          {/* #1560 PR E.6 — `+ N TRAILS` pill mirrors EventDetailPanel's
+              series-parent badge styling. */}
+          {isSeriesParent && childCount > 0 && (
+            <Badge
+              className="text-[10px] px-1.5 py-0 font-mono uppercase tracking-wider border-0"
+              style={{ backgroundColor: `${regionColor}1a`, color: regionColor }}
+            >
+              + {childCount} trails
+            </Badge>
+          )}
           {(event.status === "CANCELLED" || event.status === "TENTATIVE") && (
             <span className="text-xs text-muted-foreground">·</span>
           )}
@@ -273,45 +367,71 @@ export default async function EventDetailPage({
         <h2 className="text-xl font-semibold">{event.title}</h2>
       )}
 
-      {/* Check-in */}
-      <div>
-        <div className="flex items-center gap-3">
-          <CheckInButton
-            eventId={event.id}
-            eventDate={event.date.toISOString()}
-            isAuthenticated={!!user}
-            attendance={attendance}
-            stravaConnected={stravaConnected}
-            eventContext={{
-              kennelShortName: event.kennel.shortName,
-              runNumber: event.runNumber,
-              date: event.date.toISOString(),
-            }}
-          />
-          {(confirmedCount > 0 || goingCount > 0) && (
-            <div className="flex items-center gap-1.5">
-              {confirmedCount > 0 && (
-                <Badge variant="secondary" className="text-xs font-normal">
-                  {confirmedCount} checked in
-                </Badge>
-              )}
-              {goingCount > 0 && (
-                <Badge variant="secondary" className="text-xs font-normal">
-                  {goingCount} going
-                </Badge>
-              )}
-            </div>
-          )}
-        </div>
-        <p className="mt-1 text-xs text-muted-foreground">
-          {getAttendancePrompt(event.date, attendance?.status ?? null)}
-        </p>
-      </div>
+      {/* #1560 PR E.6 — Weekend-at-a-glance timeline. Placed HERE, BEFORE
+          the check-in card and the detail blob, because the umbrella's
+          three days are the lede on a series-parent page; the description
+          (registration, lodging, theme) is supporting context below. */}
+      {isSeriesParent && childCount > 0 && (
+        <SeriesChildTimeline
+          childEvents={childEvents}
+          parentRegionColor={regionColor}
+        />
+      )}
 
-      {/* Side-by-side: detail fields + description (left) | map (right) */}
-      <div className={`grid grid-cols-1 gap-0 ${hasLocation ? "md:grid-cols-[3fr_2fr] rounded-xl border overflow-hidden" : ""}`}>
+      {/* Check-in. #1560 PR E.6 — suppressed on series-parent umbrellas
+          (Codex review). An umbrella event isn't a real trail; users who
+          want to RSVP / check in pick a specific child from the timeline
+          above. Allowing attendance on the parent record fragments per-day
+          counts and produces misleading "N going" badges on a non-runnable
+          row. */}
+      {!isSeriesParent && (
+        <div>
+          <div className="flex items-center gap-3">
+            <CheckInButton
+              eventId={event.id}
+              eventDate={event.date.toISOString()}
+              isAuthenticated={!!user}
+              attendance={attendance}
+              stravaConnected={stravaConnected}
+              eventContext={{
+                kennelShortName: event.kennel.shortName,
+                runNumber: event.runNumber,
+                date: event.date.toISOString(),
+              }}
+            />
+            {(confirmedCount > 0 || goingCount > 0) && (
+              <div className="flex items-center gap-1.5">
+                {confirmedCount > 0 && (
+                  <Badge variant="secondary" className="text-xs font-normal">
+                    {confirmedCount} checked in
+                  </Badge>
+                )}
+                {goingCount > 0 && (
+                  <Badge variant="secondary" className="text-xs font-normal">
+                    {goingCount} going
+                  </Badge>
+                )}
+              </div>
+            )}
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {getAttendancePrompt(event.date, attendance?.status ?? null)}
+          </p>
+        </div>
+      )}
+
+      {/* Side-by-side: detail fields + description (left) | map (right).
+          #1560 PR E.6 — on a series-parent page we drop the entire <dl>
+          (run number / start time / hares / trail length / Shiggy / hash
+          cash / trail type / dog-friendly / pre-lube / location), the
+          weather card, AND the right-column map — none of those fields
+          apply to an umbrella event (children carry them per-day). The
+          description blob below still renders because that's where the
+          umbrella's registration / lodging / theme prose lives. */}
+      <div className={`grid grid-cols-1 gap-0 ${!isSeriesParent && hasLocation ? "md:grid-cols-[3fr_2fr] rounded-xl border overflow-hidden" : ""}`}>
             {/* Left column: detail fields + description */}
-            <div className={`space-y-4 ${hasLocation ? "p-5 md:p-6" : ""}`}>
+            <div className={`space-y-4 ${!isSeriesParent && hasLocation ? "p-5 md:p-6" : ""}`}>
+              {!isSeriesParent && (
               <dl className="grid gap-4 sm:grid-cols-2">
                 {event.runNumber && (
                   <DetailItem label="Run Number" value={`#${event.runNumber}`} />
@@ -422,6 +542,7 @@ export default async function EventDetailPage({
                   </div>
                 )}
               </dl>
+              )}
               {event.description && (
                 <div>
                   <h2 className="mb-1 text-sm font-medium text-muted-foreground">
@@ -432,8 +553,9 @@ export default async function EventDetailPage({
               )}
             </div>
 
-            {/* Right column: map */}
-            {hasLocation && (
+            {/* Right column: map. #1560 PR E.6 — suppressed on series parents
+                (the umbrella has no specific venue). */}
+            {!isSeriesParent && hasLocation && (
               <EventLocationMap
                 lat={event.latitude ?? undefined}
                 lng={event.longitude ?? undefined}

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -30,6 +30,15 @@ import type { HarelineSeriesChild } from "@/components/hareline/EventCard";
 import { getFullLocationDisplay } from "@/lib/event-display";
 import { buildEventJsonLd, safeJsonLd } from "@/lib/seo";
 import { getCanonicalSiteUrl } from "@/lib/site-url";
+import { DISPLAY_EVENT_WHERE } from "@/lib/event-filters";
+
+// #1560 PR E.6 — `childEvents` rendered on the umbrella page mirror the
+// hareline list visibility filters (status / isManualEntry / isCanonical /
+// kennel.isHidden) but DROP the `parentEventId: null` predicate (children
+// always have parentEventId set). Centralized here so the detail-page query
+// can't drift from the list query (Gemini PR #1697 review). Same pattern
+// `getEventDetail` uses in src/app/hareline/actions.ts.
+const { parentEventId: _excludedParentFilter, ...CHILD_EVENT_WHERE } = DISPLAY_EVENT_WHERE;
 
 export async function generateMetadata({
   params,
@@ -118,12 +127,7 @@ export default async function EventDetailPage({
       // (Codex PR E.6 review).
       parentEvent: { select: { id: true, title: true } },
       childEvents: {
-        where: {
-          status: { not: "CANCELLED" },
-          isManualEntry: { not: true },
-          isCanonical: true,
-          kennel: { isHidden: false },
-        },
+        where: CHILD_EVENT_WHERE,
         orderBy: { date: "asc" },
         select: {
           id: true,

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -340,6 +340,13 @@ export interface EventDetailFields {
   /** #1316 — Hash Cash. Detail-only because card has no room for a chip. */
   cost: string | null;
   eventLinks: { id: string; url: string; label: string }[];
+  /**
+   * Slim parent record for children opened in the detail panel (PR E.5).
+   * Powers the parameterized back-link copy `"Part of {parent.title}"` so
+   * users know which umbrella weekend a child belongs to. Null for events
+   * that aren't part of a series (`parentEventId IS NULL`).
+   */
+  parentEvent: { id: string; title: string | null } | null;
 }
 
 /**
@@ -365,6 +372,8 @@ export async function getEventDetail(eventId: string): Promise<EventDetailFields
       locationAddress: true,
       cost: true,
       eventLinks: { select: { id: true, url: true, label: true } },
+      // PR E.5 — parent title for the back-link copy on child detail panels.
+      parentEvent: { select: { id: true, title: true } },
     },
   });
 }

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -859,7 +859,7 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
  * startTime enrichment lands. Falls back to `dateUtc` when timezone is
  * missing, then to the raw HH:MM string, then `null`.
  */
-function computeChildTime(child: HarelineSeriesChild, displayTz: string): string | null {
+export function computeChildTime(child: HarelineSeriesChild, displayTz: string): string | null {
   if (child.startTime && child.timezone) {
     const composed = composeUtcStart(new Date(child.date), child.startTime, child.timezone);
     if (composed) return formatTimeInZone(composed, displayTz);

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -103,6 +103,13 @@ export type HarelineEvent = {
    */
   isSeriesParent?: boolean | null;
   parentEventId?: string | null;
+  /**
+   * Slim parent record for children, used by the back-link copy
+   * (`"Part of {parentEvent.title}"` — PR E.5). The hareline list query
+   * + the umbrella detail page both `select` `parentEvent: { id, title }`
+   * when present. Undefined on non-children.
+   */
+  parentEvent?: { id: string; title: string | null } | null;
   endDate?: string | null; // ISO; null = single-day
   childEvents?: HarelineSeriesChild[];
 };

--- a/src/components/hareline/EventDetailPanel.tsx
+++ b/src/components/hareline/EventDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { formatTime, formatDateLong, formatDateRange, getLabelForUrl, stripMarkdown, stripUrlsFromText } from "@/lib/format";
 import { getFullLocationDisplay } from "@/lib/event-display";
 import type { HarelineEvent } from "./EventCard";
+import { SeriesChildTimeline } from "./SeriesChildTimeline";
 import { ShiggyLevelFlames, TrailLengthLine, formatTrailLength } from "./TrailDifficulty";
 import { useTimePreference } from "@/components/providers/time-preference-provider";
 import { formatTimeInZone, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
@@ -105,7 +106,10 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
     <Card className="flex max-h-[calc(100vh-4rem)] flex-col overflow-hidden border-t-[3px]" style={{ borderTopColor: regionColor }}>
       {/* Scrollable content */}
       <CardContent className="min-h-0 flex-1 space-y-4 overflow-y-auto p-5">
-        {/* #1560 — child detail panel: back-link to parent series */}
+        {/* #1560 — child detail panel: back-link to parent series. PR E.5
+            — uses `parentEvent.title` when populated so the user knows
+            which umbrella weekend this child belongs to; falls back to
+            the generic copy when the query didn't include `parentEvent`. */}
         {isChildOfSeries && event.parentEventId && (
           <Link
             href={`/hareline/${event.parentEventId}`}
@@ -113,7 +117,7 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
             style={{ borderColor: regionColor }}
           >
             <ArrowUpLeft className="size-3" aria-hidden="true" />
-            <span>Part of a multi-day series</span>
+            <span>Part of {event.parentEvent?.title ?? "a multi-day series"}</span>
           </Link>
         )}
 
@@ -196,51 +200,13 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
 
         {/* #1560 — series children mini-timeline. Renders right after the
             title so the umbrella's description (further down) sits below
-            the at-a-glance schedule. */}
+            the at-a-glance schedule. Shared with the full umbrella detail
+            page (`/hareline/[eventId]`) via `SeriesChildTimeline` — PR E.4. */}
         {isSeriesParent && childCount > 0 && (
-          <div>
-            <h4 className="mb-1.5 text-xs font-mono uppercase tracking-wider text-muted-foreground/70">
-              Weekend at a glance
-            </h4>
-            <ol
-              className="flex flex-col border-l-2 ml-1 pl-3 space-y-1.5"
-              style={{ borderColor: regionColor }}
-            >
-              {event.childEvents!.map((child) => {
-                const childDate = new Date(child.date);
-                const dayChip = childDate.toLocaleDateString("en-US", {
-                  weekday: "short", day: "numeric", timeZone: "UTC",
-                });
-                const childTime = child.startTime ? formatTime(child.startTime) : null;
-                const isChildCancelled = child.status === "CANCELLED";
-                return (
-                  <li key={child.id} className="relative">
-                    <span
-                      aria-hidden="true"
-                      className="absolute -left-[14px] top-1.5 size-2 rounded-full"
-                      style={{ backgroundColor: isChildCancelled ? "#9ca3af" : regionColor }}
-                    />
-                    <Link
-                      href={`/hareline/${child.id}`}
-                      className={`flex items-baseline gap-2 text-sm hover:text-primary transition-colors ${isChildCancelled ? "opacity-50" : ""}`}
-                    >
-                      <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground/80 w-14 shrink-0">
-                        {dayChip}
-                      </span>
-                      {childTime && (
-                        <span className="font-mono tabular-nums text-muted-foreground/70 w-14 shrink-0" suppressHydrationWarning>
-                          {childTime}
-                        </span>
-                      )}
-                      <span className={`truncate font-medium ${isChildCancelled ? "line-through" : ""}`}>
-                        {child.title ?? "Trail"}
-                      </span>
-                    </Link>
-                  </li>
-                );
-              })}
-            </ol>
-          </div>
+          <SeriesChildTimeline
+            childEvents={event.childEvents!}
+            parentRegionColor={regionColor}
+          />
         )}
 
         {/* Check-in */}

--- a/src/components/hareline/SeriesChildTimeline.tsx
+++ b/src/components/hareline/SeriesChildTimeline.tsx
@@ -17,10 +17,10 @@ import type { HarelineSeriesChild } from "./EventCard";
 export function SeriesChildTimeline({
   childEvents,
   parentRegionColor,
-}: {
+}: Readonly<{
   childEvents: HarelineSeriesChild[];
   parentRegionColor: string;
-}) {
+}>) {
   if (childEvents.length === 0) return null;
   return (
     <div>

--- a/src/components/hareline/SeriesChildTimeline.tsx
+++ b/src/components/hareline/SeriesChildTimeline.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { formatTime } from "@/lib/format";
-import type { HarelineSeriesChild } from "./EventCard";
+import { useTimePreference } from "@/components/providers/time-preference-provider";
+import { getBrowserTimezone } from "@/lib/timezone";
+import { computeChildTime, type HarelineSeriesChild } from "./EventCard";
 
 /**
  * "Weekend at a glance" mini-timeline shown on series-parent surfaces
@@ -13,6 +14,18 @@ import type { HarelineSeriesChild } from "./EventCard";
  * Renders a region-colored vertical rail on the left with one filled dot
  * per child date. Each row links to `/hareline/{child.id}`. Cancelled
  * children render at 50% opacity with a strikethrough title + muted dot.
+ *
+ * Time formatting routes through `computeChildTime` (CodeRabbit PR #1697
+ * review) so it matches the top-level card's #1654 anchor logic:
+ *   1. `composeUtcStart(date, startTime, timezone)` when both startTime
+ *      and timezone are present (the canonical anchor — guards against
+ *      stale `dateUtc` after lower-trust startTime enrichment)
+ *   2. Stored `dateUtc` paired with `startTime` (pre-#1654 fallback)
+ *   3. Raw `HH:MM` (defensive — when timezone + dateUtc are both null)
+ *
+ * `displayTz` honors the user's "Local vs Kennel" time preference so the
+ * timeline matches both the EventCard row above it AND the child's own
+ * detail page on click.
  */
 export function SeriesChildTimeline({
   childEvents,
@@ -21,6 +34,7 @@ export function SeriesChildTimeline({
   childEvents: HarelineSeriesChild[];
   parentRegionColor: string;
 }>) {
+  const { preference } = useTimePreference();
   if (childEvents.length === 0) return null;
   return (
     <div>
@@ -38,7 +52,15 @@ export function SeriesChildTimeline({
             day: "numeric",
             timeZone: "UTC",
           });
-          const childTime = child.startTime ? formatTime(child.startTime) : null;
+          // #1654 — per-child timezone preference. USER_LOCAL renders in the
+          // viewer's browser TZ; KENNEL_LOCAL renders in the child's stored
+          // timezone (falls back to America/New_York if the child has none,
+          // matching EventCard's defaulting).
+          const displayTz =
+            preference === "USER_LOCAL"
+              ? getBrowserTimezone()
+              : (child.timezone ?? "America/New_York");
+          const childTime = computeChildTime(child, displayTz);
           const isChildCancelled = child.status === "CANCELLED";
           return (
             <li key={child.id} className="relative">

--- a/src/components/hareline/SeriesChildTimeline.tsx
+++ b/src/components/hareline/SeriesChildTimeline.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { formatTime } from "@/lib/format";
+import type { HarelineSeriesChild } from "./EventCard";
+
+/**
+ * "Weekend at a glance" mini-timeline shown on series-parent surfaces
+ * (#1560 — extracted from `EventDetailPanel.tsx` in PR E.4 so it can be
+ * reused by both the right-drawer panel AND the full umbrella detail page
+ * at `/hareline/[eventId]`).
+ *
+ * Renders a region-colored vertical rail on the left with one filled dot
+ * per child date. Each row links to `/hareline/{child.id}`. Cancelled
+ * children render at 50% opacity with a strikethrough title + muted dot.
+ */
+export function SeriesChildTimeline({
+  childEvents,
+  parentRegionColor,
+}: {
+  childEvents: HarelineSeriesChild[];
+  parentRegionColor: string;
+}) {
+  if (childEvents.length === 0) return null;
+  return (
+    <div>
+      <h4 className="mb-1.5 text-xs font-mono uppercase tracking-wider text-muted-foreground/70">
+        Weekend at a glance
+      </h4>
+      <ol
+        className="flex flex-col border-l-2 ml-1 pl-3 space-y-1.5"
+        style={{ borderColor: parentRegionColor }}
+      >
+        {childEvents.map((child) => {
+          const childDate = new Date(child.date);
+          const dayChip = childDate.toLocaleDateString("en-US", {
+            weekday: "short",
+            day: "numeric",
+            timeZone: "UTC",
+          });
+          const childTime = child.startTime ? formatTime(child.startTime) : null;
+          const isChildCancelled = child.status === "CANCELLED";
+          return (
+            <li key={child.id} className="relative">
+              <span
+                aria-hidden="true"
+                className="absolute -left-[14px] top-1.5 size-2 rounded-full"
+                style={{
+                  backgroundColor: isChildCancelled ? "#9ca3af" : parentRegionColor,
+                }}
+              />
+              <Link
+                href={`/hareline/${child.id}`}
+                className={`flex items-baseline gap-2 text-sm hover:text-primary transition-colors ${
+                  isChildCancelled ? "opacity-50" : ""
+                }`}
+              >
+                <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground/80 w-14 shrink-0">
+                  {dayChip}
+                </span>
+                {childTime && (
+                  <span
+                    className="font-mono tabular-nums text-muted-foreground/70 w-14 shrink-0"
+                    suppressHydrationWarning
+                  >
+                    {childTime}
+                  </span>
+                )}
+                <span
+                  className={`truncate font-medium ${
+                    isChildCancelled ? "line-through" : ""
+                  }`}
+                >
+                  {child.title ?? "Trail"}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the presentation gap left by PRs A/B/C/D. The merge pipeline already produces correct data (NYC 5-Boro 2026 = umbrella + 3 children with correct per-day kennel attribution); this PR fixes what the user actually sees.

Frontend-design skill reviewed the plan; recommendations folded in (timeline above description, parameterized back-link, no `—` placeholders).

## Three changes

### 1. Hash Rego parser — per-day section titles

`WEEKDAY_HEADER_RE` / `DAY_NUMBER_HEADER_RE` consume up through the trailing `—` delimiter. The text AFTER the delimiter (the section title written by the kennel webmaster) is now captured by `extractSectionTitle` and surfaced as the child's `title`. For NYC 5-Boro 2026:

| Day | Before | After |
|---|---|---|
| Fri 6/26 (ggfm) | "NYCH3 5-boro Pub Crawl 2026 (Day 1)" | **"Strawberry Moon Trail"** |
| Sat 6/27 (nych3) | "NYCH3 5-boro Pub Crawl 2026 (Day 2)" | **"12th Annual 5-Borough Pub Crawl"** |
| Sun 6/28 (nych3) | "NYCH3 5-boro Pub Crawl 2026 (Day 3)" | **"NYC Pride March Watch Party!"** |

Friday strips the redundant "GGFM " prefix because the kennel pill already carries that identity (`stripKennelPrefixFromTitle`; guarded against over-stripping via `MIN_STRIPPED_TITLE_LENGTH = 4`). Sunday's "NYC" prefix STAYS because the pattern requires `NYC\s*H3` and the section text doesn't satisfy it.

Falls back to legacy `(Day N)` suffix when descriptions have no parseable section title (regression-tested).

⚠️ **Fingerprint impact**: `data.title` is in the hash, so changing parser output triggers a one-time re-merge wave on first scrape after deploy (memory: `feedback_parser_fix_canonical_ghosts.md`). Existing 5-Boro children get their new titles via the merge UPDATE branch.

### 2. Umbrella detail page series rendering

`/hareline/[eventId]` queried + rendered the umbrella as a flat single-day event today. Now:

- Prisma query includes `childEvents` with the **same DISPLAY_EVENT_WHERE visibility filters** the list view uses (`status != CANCELLED`, `isManualEntry != true`, `isCanonical = true`, `kennel.isHidden = false`). **Codex review caught this gap**: non-canonical / cancelled / hidden-kennel children would otherwise leak into the public timeline and inflate the `+ N TRAILS` badge.
- `<h1>` renders `formatDateRange(date, endDate)` instead of a single day; `+ N TRAILS` badge + Tent glyph in the kennel row.
- Extracted `SeriesChildTimeline` Client Component (reused by `EventDetailPanel`) renders the "Weekend at a glance" rail **IMMEDIATELY below the umbrella title, BEFORE the description blob**. The three days are the lede; description (registration / lodging / theme) is supporting context.
- Single-day fields (run number / start time / hares / trail length / Shiggy / location / weather / map) are **suppressed entirely on series parents** — no `—` placeholders.
- **Check-in card also suppressed on umbrellas** (Codex review): allowing attendance against the synthetic parent fragments per-day counts; users RSVP via the timeline rows instead.
- Child Event detail pages get a parameterized parent back-link: `"Part of {parent.title}"` instead of the generic `"Part of a multi-day series"`. Same parameterization in `EventDetailPanel` via `getEventDetail`'s new `parentEvent` select.

### 3. One-shot 2027-06-26 orphan cleanup

`scripts/cleanup-5-boro-2027-orphan.ts` — idempotent deletion of the single Event row `cmplbbe9k000604ic44er23kw` (a pre-PR-#1678 year-rollover fossil that still backs a stale RawEvent, so the existing orphan-cleanup script's `rawEvents: { none: {} }` filter won't catch it). Three independent safety guards (ID match + date ≥ 2027-01-01 + title contains "5-boro") so accidental re-runs can't delete the wrong row. Dry-run by default; `APPLY=1` to commit.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (21 pre-existing warnings)
- [x] `npm test` — 7383 passing, 2 skipped, 25 todo
- [x] Codex `/codex:adversarial-review --wait` — 2 findings, both addressed in this commit
- [ ] **Post-merge**: trigger Hash Rego scrape against prod; expect `created/updated > 0` for the 5-Boro children (title fingerprints change)
- [ ] **Post-merge**: `tsx scripts/cleanup-5-boro-2027-orphan.ts` (dry-run first), then `APPLY=1 …` to delete the orphan
- [ ] **Browser-verify**:
  - `/hareline?q=5-boro` — child titles now distinct + readable; no stray "Saturday, June 26, 2027" row
  - `/hareline/cmplf9pwq000404l16q1lr3ub` (umbrella) — date-range `<h1>`, `+ 3 TRAILS` pill + Tent glyph, "Weekend at a glance" timeline ABOVE description; hares/startTime/weather/location/map all absent
  - Click any child row — `"Part of NYCH3 5-Boro Pub Crawl 2026"` back-link at top
  - Visit any non-series event — rendering byte-identical to pre-PR

## Out of scope

- Title-case normalization on the umbrella name ("5-boro" → "5-Boro"); source verbatim
- Admin maintenance flows (already filed: #1679, #1680)
- BAWC5 Marin H3 stale-feed orphan (#1681)
- Refactoring detail page to delegate to `EventDetailPanel` (bigger hydration-boundary refactor)

Refs #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)