### PR TITLE
fix(cron): bump per-source scrape maxDuration 120 → 300

### DIFF
--- a/src/app/api/cron/scrape/[sourceId]/route.test.ts
+++ b/src/app/api/cron/scrape/[sourceId]/route.test.ts
@@ -110,8 +110,10 @@ describe("POST /api/cron/scrape/[sourceId]", () => {
     expect(data.data.errors).toContain("Connection timeout");
   });
 
-  it("exports maxDuration of 120 for Vercel function timeout", () => {
-    expect(maxDuration).toBe(120);
+  it("exports maxDuration of 300 for Vercel function timeout", () => {
+    // 300s is Vercel's platform default since the 2026-02 update; needed for
+    // wide-window scrapes (#1693 saw Madison + LBH3 time out at the prior 120s).
+    expect(maxDuration).toBe(300);
   });
 
   it("returns 500 when scrapeSource throws an unhandled error", async () => {

--- a/src/app/api/cron/scrape/[sourceId]/route.ts
+++ b/src/app/api/cron/scrape/[sourceId]/route.ts
@@ -3,7 +3,13 @@ import { prisma } from "@/lib/db";
 import { verifyCronAuth } from "@/lib/cron-auth";
 import { scrapeSource, type ScrapeSourceResult } from "@/pipeline/scrape";
 
-export const maxDuration = 120; // seconds — needed for browser-rendered adapters (Hash Rego, Wix, etc.)
+// 300s matches Vercel's platform-wide default (2026-02 platform update).
+// Needed for wide-window scrapes — PR #1693 saw 120s timeouts on Madison H3 and
+// LBH3 GCal scrapes (scrapeDays=9999), and for browser-rendered adapters (Hash
+// Rego, Wix, etc.). Cron-dispatched scrapes default to `source.scrapeDays` so
+// the longer ceiling matters here even though body overrides are still capped
+// at 1825 below.
+export const maxDuration = 300;
 
 /**
  * Per-source scrape handler invoked by QStash. Validates the source exists and is enabled,


### PR DESCRIPTION
## Summary

Bumps `maxDuration` in [`src/app/api/cron/scrape/[sourceId]/route.ts`](src/app/api/cron/scrape/[sourceId]/route.ts:6) from **120s → 300s** to match Vercel's platform-wide default (2026-02 update).

## Why

PR #1693 backfill execution hit `FUNCTION_INVOCATION_TIMEOUT` at 120s on wide-window re-scrapes:

| Source | scrapeDays | Result |
|--------|-----------:|--------|
| Madison H3 GCal | 9999 | TIMEOUT @ 120s |
| LBH3 GCal | 9999 | TIMEOUT @ 120s |
| Madison H3 (retry, body `days=1825`) | 1825 | OK @ 30s |
| LBH3 (retry, body `days=1825`) | 1825 | OK @ 61s |

Manual body overrides got each scrape under the limit, but **cron-dispatched scrapes default to `source.scrapeDays` directly** (no body override), so the 9999d values seeded by #1693 would silently time out on every unattended run.

## What changes

- `maxDuration: 120 → 300` (Vercel's current platform default)
- Test [`route.test.ts:113`](src/app/api/cron/scrape/[sourceId]/route.test.ts:113) updated to assert the new value, with a rationale comment

## What deliberately doesn't change

- **Body `days` cap stays at 1825**. Body values are external-trigger input (QStash payload); the cap is a defense-in-depth limit, independent of function runtime. `source.scrapeDays` is admin-configured and trusted, so it remains uncapped at the route level.
- **No other route's `maxDuration` touched** — this is scoped to the per-source scrape endpoint that #1693 exercised.

## Verification

- ✅ `npx tsc --noEmit` clean
- ✅ `npm run lint` 0 errors
- ✅ `npm test -- --run src/app/api/cron/scrape` — 8/8 pass

## Test plan

- [ ] Merge → Vercel redeploys with `maxDuration: 300`
- [ ] Trigger a Madison or LBH3 re-scrape without body override:
  ```bash
  curl -X POST -H "Authorization: Bearer $CRON_SECRET" \
    https://hashtracks-web.vercel.app/api/cron/scrape/<madison-source-id>
  ```
- [ ] Expect 200 (not FUNCTION_INVOCATION_TIMEOUT) and event-count increase reflecting the full 9999d window

Refs #1693

🤖 Generated with [Claude Code](https://claude.com/claude-code)