### PR TITLE
fix(1560): surface series children on kennel-scoped views (PR F)

### DIFF
--- a/src/app/hareline/actions.test.ts
+++ b/src/app/hareline/actions.test.ts
@@ -103,6 +103,28 @@ describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
     expect(where).not.toHaveProperty("OR");
   });
 
+  it("normalizes kennelIds: trims whitespace, drops empties, dedupes", async () => {
+    // Same logical filter as ["a", "b"] — verify normalization collapses to
+    // the canonical Prisma `IN` shape regardless of caller noise.
+    await loadEventsForTimeMode("upcoming", NOW_MS, [" a ", "b", "", "a", "b  "]);
+
+    const where = mockFindMany.mock.calls[0][0]?.where as Record<string, unknown>;
+    expect(where.OR).toEqual([
+      { kennelId: { in: ["a", "b"] } },
+      { eventKennels: { some: { kennelId: { in: ["a", "b"] } } } },
+    ]);
+  });
+
+  it("caps kennelIds at MAX_KENNEL_FILTER_IDS to bound cache cardinality + IN size", async () => {
+    // 60 distinct IDs in → capped at 50 in the query.
+    const sixty = Array.from({ length: 60 }, (_, i) => `k${i.toString().padStart(2, "0")}`);
+    await loadEventsForTimeMode("upcoming", NOW_MS, sixty);
+
+    const where = mockFindMany.mock.calls[0][0]?.where as Record<string, unknown>;
+    const orClause = where.OR as Array<{ kennelId?: { in: string[] } }>;
+    expect(orClause[0].kennelId!.in).toHaveLength(50);
+  });
+
   it("drops children from top-level when their parent is also in the result (avoids double-render)", async () => {
     // NYCH3 5-Boro case: parent + Sat/Sun children all hosted by NYCH3.
     // Both surface from the query when kennel-filtered, but children must

--- a/src/app/hareline/actions.test.ts
+++ b/src/app/hareline/actions.test.ts
@@ -102,4 +102,56 @@ describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
     expect(where).toHaveProperty("parentEventId", null);
     expect(where).not.toHaveProperty("OR");
   });
+
+  it("drops children from top-level when their parent is also in the result (avoids double-render)", async () => {
+    // NYCH3 5-Boro case: parent + Sat/Sun children all hosted by NYCH3.
+    // Both surface from the query when kennel-filtered, but children must
+    // not render at the top level when their parent IS in the result —
+    // they already appear in the parent's expanded timeline.
+    const minimalEvent = (id: string, parentId: string | null, isSeriesParent: boolean) => ({
+      id,
+      date: new Date("2026-06-26T12:00:00Z"),
+      dateUtc: new Date("2026-06-26T22:00:00Z"),
+      timezone: "America/New_York",
+      kennelId: "nych3",
+      runNumber: null,
+      title: id,
+      haresText: null,
+      startTime: null,
+      locationName: null,
+      locationCity: null,
+      status: "SCHEDULED",
+      latitude: null,
+      longitude: null,
+      trailLengthText: null,
+      trailLengthMinMiles: null,
+      trailLengthMaxMiles: null,
+      difficulty: null,
+      trailType: null,
+      dogFriendly: null,
+      prelube: null,
+      isSeriesParent,
+      parentEventId: parentId,
+      endDate: null,
+      childEvents: [],
+      kennel: { id: "nych3", shortName: "NYCH3", fullName: "NYC", slug: "nych3", region: "NY", country: "USA" },
+      eventKennels: [],
+    });
+    mockFindMany.mockResolvedValueOnce([
+      minimalEvent("umbrella", null, true),
+      minimalEvent("sat-child", "umbrella", false),
+      minimalEvent("sun-child", "umbrella", false),
+      // Child whose parent is NOT in result (GGFM Friday case viewed from
+      // GGFM's kennel filter). Must NOT be dropped.
+      minimalEvent("ggfm-child", "external-parent", false),
+    ] as never);
+
+    const result = await loadEventsForTimeMode("upcoming", NOW_MS, ["nych3"]);
+
+    const ids = result.map((e) => e.id);
+    expect(ids).toContain("umbrella");
+    expect(ids).toContain("ggfm-child"); // parent NOT in result → kept
+    expect(ids).not.toContain("sat-child"); // parent IS in result → dropped
+    expect(ids).not.toContain("sun-child"); // parent IS in result → dropped
+  });
 });

--- a/src/app/hareline/actions.test.ts
+++ b/src/app/hareline/actions.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    event: { findMany: vi.fn() },
+  },
+}));
+
+// `unstable_cache` is opaque under test — pass through so our findMany mock
+// observes every call. Same pattern as other action tests (admin/events,
+// admin/kennels).
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  unstable_cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+}));
+
+import { prisma } from "@/lib/db";
+import { loadEventsForTimeMode } from "./actions";
+
+const mockFindMany = vi.mocked(prisma.event.findMany);
+
+// Fixed clock so cache-key assertions are deterministic across runs.
+// 2026-05-26T12:00:00Z → todayDateStr is "2026-05-26".
+const NOW_MS = Date.UTC(2026, 4, 26, 12, 0, 0);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFindMany.mockResolvedValue([] as never);
+});
+
+describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
+  it("unfiltered upcoming query keeps `parentEventId: null` (children stay hidden in global list)", async () => {
+    await loadEventsForTimeMode("upcoming", NOW_MS);
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    const where = mockFindMany.mock.calls[0][0]?.where as Record<string, unknown>;
+    expect(where).toHaveProperty("parentEventId", null);
+    expect(where).not.toHaveProperty("OR");
+  });
+
+  it("kennel-scoped query drops `parentEventId: null` and adds kennel OR-match", async () => {
+    await loadEventsForTimeMode("upcoming", NOW_MS, ["ggfm"]);
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    const where = mockFindMany.mock.calls[0][0]?.where as Record<string, unknown>;
+
+    // No parentEventId filter — series children whose primary kennel
+    // matches must be visible (GGFM Friday Strawberry Moon case).
+    expect(where).not.toHaveProperty("parentEventId");
+
+    // OR clause matches both root kennel and EventKennel co-host rows.
+    expect(where.OR).toEqual([
+      { kennelId: { in: ["ggfm"] } },
+      { eventKennels: { some: { kennelId: { in: ["ggfm"] } } } },
+    ]);
+
+    // Other visibility predicates still applied.
+    expect(where).toMatchObject({
+      status: { not: "CANCELLED" },
+      isManualEntry: { not: true },
+      isCanonical: true,
+      kennel: { isHidden: false },
+    });
+  });
+
+  it("past mode + kennel filter applies the same drop + OR shape with descending order", async () => {
+    await loadEventsForTimeMode("past", NOW_MS, ["nych3"]);
+
+    const call = mockFindMany.mock.calls[0][0];
+    const where = call?.where as Record<string, unknown>;
+
+    expect(where).not.toHaveProperty("parentEventId");
+    expect(where.OR).toEqual([
+      { kennelId: { in: ["nych3"] } },
+      { eventKennels: { some: { kennelId: { in: ["nych3"] } } } },
+    ]);
+    expect(call?.orderBy).toEqual({ date: "desc" });
+  });
+
+  it("hits the same cache entry regardless of kennelIds order ([a,b] === [b,a])", async () => {
+    // Cache key is built from a sorted-joined string. With unstable_cache
+    // stubbed to identity in this suite, we can't observe Next's cache hits
+    // directly — but we *can* assert that the underlying findMany sees the
+    // same `kennelId: { in: [...] }` shape regardless of caller order, which
+    // is the property the sorted key actually protects.
+    await loadEventsForTimeMode("upcoming", NOW_MS, ["b", "a"]);
+    await loadEventsForTimeMode("upcoming", NOW_MS, ["a", "b"]);
+
+    const first = mockFindMany.mock.calls[0][0]?.where as Record<string, unknown>;
+    const second = mockFindMany.mock.calls[1][0]?.where as Record<string, unknown>;
+    // Both calls produce identical `OR` clauses — i.e. caller order is
+    // normalized before it reaches Prisma.
+    expect(first.OR).toEqual(second.OR);
+  });
+
+  it("empty kennelIds array falls back to the unfiltered code path", async () => {
+    await loadEventsForTimeMode("upcoming", NOW_MS, []);
+
+    const where = mockFindMany.mock.calls[0][0]?.where as Record<string, unknown>;
+    // Empty array means "no filter", so parentEventId:null exclusion stays.
+    expect(where).toHaveProperty("parentEventId", null);
+    expect(where).not.toHaveProperty("OR");
+  });
+});

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -143,6 +143,7 @@ const fetchSlimEventsCached = unstable_cache(
   async (
     mode: TimeMode,
     todayDateStr: string,
+    kennelIdsKey: string,
   ): Promise<CachedHarelineEvent[]> => {
     // Reconstruct UTC boundaries from the date string so the cached function
     // is a pure function of its args. (No reading Date.now() here —
@@ -165,10 +166,28 @@ const fetchSlimEventsCached = unstable_cache(
     const tomorrowUtc = new Date(startOfTodayUtc.getTime() + 24 * 60 * 60 * 1000);
     const isPast = mode === "past";
 
-    const where = {
-      ...DISPLAY_EVENT_WHERE,
-      date: isPast ? { lt: tomorrowUtc } : { gte: yesterdayUtc },
-    };
+    // #1560 PR F — kennel-scoped fetches must include series children whose
+    // primary kennel matches the filter (e.g. GGFM Friday Strawberry Moon,
+    // a child of NYCH3's 5-Boro umbrella). When unfiltered, the original
+    // `parentEventId: null` exclusion stays so children only render inside
+    // their parent's expanded timeline. When filtered, swap the exclusion
+    // for a kennel OR-match: parents whose own kennel matches AND children
+    // whose own kennel matches both surface.
+    const kennelIds = kennelIdsKey ? kennelIdsKey.split(",") : [];
+    const dateFilter = isPast ? { lt: tomorrowUtc } : { gte: yesterdayUtc };
+    const where = kennelIds.length === 0
+      ? { ...DISPLAY_EVENT_WHERE, date: dateFilter }
+      : {
+          status: { not: "CANCELLED" as const },
+          isManualEntry: { not: true },
+          isCanonical: true,
+          kennel: { isHidden: false },
+          date: dateFilter,
+          OR: [
+            { kennelId: { in: kennelIds } },
+            { eventKennels: { some: { kennelId: { in: kennelIds } } } },
+          ],
+        };
 
     const events = await prisma.event.findMany({
       where,
@@ -312,11 +331,20 @@ const fetchSlimEventsCached = unstable_cache(
 export async function loadEventsForTimeMode(
   mode: TimeMode,
   nowMs?: number,
+  kennelIds?: ReadonlyArray<string>,
 ): Promise<HarelineListEvent[]> {
   // YYYY-MM-DD in UTC — the cache key that rotates at UTC midnight.
   const todayDateStr = new Date(nowMs ?? Date.now()).toISOString().slice(0, 10);
 
-  const cached = await fetchSlimEventsCached(mode, todayDateStr);
+  // #1560 PR F — normalize the kennel filter into a stable cache key.
+  // Sorted-joined so [a,b] and [b,a] hit the same cache entry; empty string
+  // for the unfiltered path so existing cache entries (no kennel filter)
+  // remain valid post-deploy.
+  const kennelIdsKey = (kennelIds && kennelIds.length > 0)
+    ? [...kennelIds].sort().join(",")
+    : "";
+
+  const cached = await fetchSlimEventsCached(mode, todayDateStr, kennelIdsKey);
 
   // Rehydrate `dateUtc` from ISO string back to `Date` at the cache
   // boundary. Keeps `HarelineListEvent` stable across the project so

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -173,15 +173,17 @@ const fetchSlimEventsCached = unstable_cache(
     // their parent's expanded timeline. When filtered, swap the exclusion
     // for a kennel OR-match: parents whose own kennel matches AND children
     // whose own kennel matches both surface.
+    //
+    // Destructure `parentEventId` out of `DISPLAY_EVENT_WHERE` and reuse the
+    // remaining visibility predicates verbatim so the two branches can't drift
+    // (mirrors `getEventDetail` below). Gemini PR review #1712.
     const kennelIds = kennelIdsKey ? kennelIdsKey.split(",") : [];
     const dateFilter = isPast ? { lt: tomorrowUtc } : { gte: yesterdayUtc };
+    const { parentEventId: _excluded, ...visibilityWhere } = DISPLAY_EVENT_WHERE;
     const where = kennelIds.length === 0
       ? { ...DISPLAY_EVENT_WHERE, date: dateFilter }
       : {
-          status: { not: "CANCELLED" as const },
-          isManualEntry: { not: true },
-          isCanonical: true,
-          kennel: { isHidden: false },
+          ...visibilityWhere,
           date: dateFilter,
           OR: [
             { kennelId: { in: kennelIds } },
@@ -259,7 +261,22 @@ const fetchSlimEventsCached = unstable_cache(
       ...(isPast ? { take: PAST_EVENTS_LIMIT } : {}),
     });
 
-    return events.map((e) => ({
+    // #1560 PR F — when both a series parent AND its children are returned
+    // (kennel-filtered query where the umbrella's host kennel matches the
+    // filter, e.g. NYCH3 viewing `/hareline?kennels=nych3-id` sees the 5-Boro
+    // umbrella + its Sat/Sun children), drop the children from the top-level
+    // list. They still appear in the parent's expanded timeline via
+    // `childEvents`. Without this dedup, the same trail renders twice on the
+    // same scroll page (Gemini PR #1712 review). When the parent is NOT in
+    // the result (GGFM viewing /hareline?kennels=ggfm-id sees only Friday's
+    // child of the NYCH3-hosted umbrella), the child correctly stays at the
+    // top level since `parentIdsInResult` doesn't contain its parentEventId.
+    const idsInResult = new Set(events.map((e) => e.id));
+    const visibleEvents = events.filter(
+      (e) => !e.parentEventId || !idsInResult.has(e.parentEventId),
+    );
+
+    return visibleEvents.map((e) => ({
       id: e.id,
       date: e.date.toISOString(),
       dateUtc: e.dateUtc ? e.dateUtc.toISOString() : null,

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -102,6 +102,15 @@ export type TimeMode = "upcoming" | "past";
 const PAST_EVENTS_LIMIT = 200;
 
 /**
+ * Defensive cap on the kennel-filter list (#1560 PR F, CodeRabbit review).
+ * Caps cache-key cardinality and bounds the Prisma `IN` clause size against
+ * pathological inputs. 50 comfortably covers any realistic regional filter
+ * — Chicago has 12 kennels, NYC ~11, SF Bay ~13. Above this, the user is
+ * almost certainly browsing globally, not filtering.
+ */
+const MAX_KENNEL_FILTER_IDS = 50;
+
+/**
  * Cache-shape twin of `HarelineListEvent` with `dateUtc` serialized to ISO
  * string. `unstable_cache` JSON-serializes its return value; keeping this
  * twin explicit means the boundary conversion is visible at the call site.
@@ -354,13 +363,20 @@ export async function loadEventsForTimeMode(
   const todayDateStr = new Date(nowMs ?? Date.now()).toISOString().slice(0, 10);
 
   // #1560 PR F — normalize the kennel filter into a stable cache key.
-  // Sorted-joined so [a,b] and [b,a] hit the same cache entry; empty string
-  // for the unfiltered path so existing cache entries (no kennel filter)
-  // remain valid post-deploy. `localeCompare` over default sort to satisfy
-  // Sonar S2871 — kennel IDs are ASCII-only cuids so the order is identical
-  // in practice, but the explicit comparator makes the intent obvious.
-  const kennelIdsKey = (kennelIds && kennelIds.length > 0)
-    ? [...kennelIds].sort((a, b) => a.localeCompare(b)).join(",")
+  // - Trim each ID (URL decoders sometimes leave stray whitespace)
+  // - Drop empties (e.g. `?kennels=a,,b`)
+  // - Dedupe (e.g. `?kennels=a&kennels=a`) so the cache key is canonical
+  //   regardless of how callers compose the URL
+  // - Cap at MAX_KENNEL_FILTER_IDS to bound cache cardinality + Prisma `IN`
+  //   list size against pathological inputs (CodeRabbit PR #1712 review)
+  // - Sort with `localeCompare` so [a,b] and [b,a] hit the same cache entry
+  //   (Sonar S2871). Empty string when no filter — preserves existing
+  //   unfiltered cache entries post-deploy.
+  const normalizedKennelIds = Array.from(
+    new Set((kennelIds ?? []).map((id) => id.trim()).filter(Boolean)),
+  ).slice(0, MAX_KENNEL_FILTER_IDS);
+  const kennelIdsKey = normalizedKennelIds.length > 0
+    ? [...normalizedKennelIds].sort((a, b) => a.localeCompare(b)).join(",")
     : "";
 
   const cached = await fetchSlimEventsCached(mode, todayDateStr, kennelIdsKey);

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -339,9 +339,11 @@ export async function loadEventsForTimeMode(
   // #1560 PR F — normalize the kennel filter into a stable cache key.
   // Sorted-joined so [a,b] and [b,a] hit the same cache entry; empty string
   // for the unfiltered path so existing cache entries (no kennel filter)
-  // remain valid post-deploy.
+  // remain valid post-deploy. `localeCompare` over default sort to satisfy
+  // Sonar S2871 — kennel IDs are ASCII-only cuids so the order is identical
+  // in practice, but the explicit comparator makes the intent obvious.
   const kennelIdsKey = (kennelIds && kennelIds.length > 0)
-    ? [...kennelIds].sort().join(",")
+    ? [...kennelIds].sort((a, b) => a.localeCompare(b)).join(",")
     : "";
 
   const cached = await fetchSlimEventsCached(mode, todayDateStr, kennelIdsKey);

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -370,8 +370,9 @@ export async function loadEventsForTimeMode(
   // - Cap at MAX_KENNEL_FILTER_IDS to bound cache cardinality + Prisma `IN`
   //   list size against pathological inputs (CodeRabbit PR #1712 review)
   // - Sort with `localeCompare` so [a,b] and [b,a] hit the same cache entry
-  //   (Sonar S2871). Empty string when no filter — preserves existing
-  //   unfiltered cache entries post-deploy.
+  //   (Sonar S2871). Empty string when no filter — a distinct cache entry
+  //   from any kennel-filtered key (the 3-arg signature is new in PR F, so
+  //   the unfiltered path cold-starts once on deploy regardless).
   const normalizedKennelIds = Array.from(
     new Set((kennelIds ?? []).map((id) => id.trim()).filter(Boolean)),
   ).slice(0, MAX_KENNEL_FILTER_IDS);

--- a/src/app/hareline/page.tsx
+++ b/src/app/hareline/page.tsx
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/db";
 import { getWeatherForEvents } from "@/lib/weather";
 import { getOrCreateUser } from "@/lib/auth";
 import { regionAbbrev } from "@/lib/region";
+import { parseList } from "@/lib/format";
 import { HarelineView } from "@/components/hareline/HarelineView";
 import HarelineLoading from "./loading";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -43,13 +44,18 @@ export default async function HarelinePage({
   // stayed client-side and series children (excluded from the default
   // unfiltered payload) never reached the client — GGFM Friday
   // Strawberry Moon went missing from /hareline?kennels=<ggfm-id>.
-  // Accepts both `?kennels=a,b` and `?kennels=a&kennels=b`.
+  //
+  // Delegates to `parseList` so SSR + client use identical parse rules.
+  // HarelineView writes `?kennels=a|b` (pipe-separated); `parseList` also
+  // accepts comma for legacy bookmarked URLs. Without sharing this helper
+  // (Codex PR #1712 review), pipe-separated deep links parsed as `["a|b"]`
+  // — a single bogus ID — and SSR returned an empty payload on refresh.
   const kennelsParam = params.kennels;
   let initialKennelIds: string[] = [];
   if (typeof kennelsParam === "string") {
-    initialKennelIds = kennelsParam.split(",").filter(Boolean);
+    initialKennelIds = parseList(kennelsParam);
   } else if (Array.isArray(kennelsParam)) {
-    initialKennelIds = kennelsParam.flatMap((v) => v.split(",")).filter(Boolean);
+    initialKennelIds = kennelsParam.flatMap((v) => parseList(v));
   }
 
   return (

--- a/src/app/hareline/page.tsx
+++ b/src/app/hareline/page.tsx
@@ -38,6 +38,19 @@ export default async function HarelinePage({
   const params = await searchParams;
   const timeParam = typeof params.time === "string" ? params.time : null;
   const initialTimeMode: TimeMode = timeParam === "past" ? "past" : "upcoming";
+  // #1560 PR F — read `?kennels` from the URL so the SSR fetch can scope
+  // the payload to a specific kennel set. Without this, kennel filtering
+  // stayed client-side and series children (excluded from the default
+  // unfiltered payload) never reached the client — GGFM Friday
+  // Strawberry Moon went missing from /hareline?kennels=<ggfm-id>.
+  // Accepts both `?kennels=a,b` and `?kennels=a&kennels=b`.
+  const kennelsParam = params.kennels;
+  let initialKennelIds: string[] = [];
+  if (typeof kennelsParam === "string") {
+    initialKennelIds = kennelsParam.split(",").filter(Boolean);
+  } else if (Array.isArray(kennelsParam)) {
+    initialKennelIds = kennelsParam.flatMap((v) => v.split(",")).filter(Boolean);
+  }
 
   return (
     <div>
@@ -50,7 +63,10 @@ export default async function HarelinePage({
 
       <FadeInSection delay={100}>
         <Suspense fallback={<HarelineLoading />}>
-          <HarelineData initialTimeMode={initialTimeMode} />
+          <HarelineData
+            initialTimeMode={initialTimeMode}
+            initialKennelIds={initialKennelIds}
+          />
         </Suspense>
       </FadeInSection>
     </div>
@@ -68,7 +84,8 @@ export default async function HarelinePage({
  */
 async function HarelineData({
   initialTimeMode,
-}: Readonly<{ initialTimeMode: TimeMode }>) {
+  initialKennelIds,
+}: Readonly<{ initialTimeMode: TimeMode; initialKennelIds: string[] }>) {
   // Capture `now` before awaiting and thread it into `loadEventsForTimeMode`
   // so the server query boundary, the `serverNowMs` prop, and the client's
   // hydrated bucket split all derive from the same instant. Without a shared
@@ -77,8 +94,14 @@ async function HarelineData({
   const now = new Date();
   const nowMs = now.getTime();
 
+  // #1560 PR F — pass `initialKennelIds` through so the SSR query can scope
+  // to a specific kennel set when `?kennels=<id>` is in the URL. Without
+  // this, kennel filtering stayed client-side and series children whose
+  // primary kennel matches the filter (excluded from the default unfiltered
+  // payload because the global hareline still uses `parentEventId: null`)
+  // never reached the client.
   const [events, user] = await Promise.all([
-    loadEventsForTimeMode(initialTimeMode, nowMs),
+    loadEventsForTimeMode(initialTimeMode, nowMs, initialKennelIds),
     getOrCreateUser(),
   ]);
 

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -176,7 +176,20 @@ export default async function KennelDetailPage({
   const now = new Date();
   const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0);
 
-  const serialized: HarelineEvent[] = events.map((e) => ({
+  // #1560 PR F — when both a series parent AND its children belong to this
+  // kennel (e.g. NYCH3 hosts the 5-Boro umbrella AND its Saturday + Sunday
+  // children), drop the children from the top-level list. They still surface
+  // in the parent's expanded "Weekend at a glance" timeline. Without this
+  // dedup, the Sat/Sun trails would render twice on the same page (Gemini
+  // PR #1712 review). The GGFM case (child whose parent is NOT in this
+  // kennel's events) is unaffected — the child stays as a flat row because
+  // its `parentEventId` isn't in `parentIdsInResult`.
+  const idsInResult = new Set(events.map((e) => e.id));
+  const visibleEvents = events.filter(
+    (e) => !e.parentEventId || !idsInResult.has(e.parentEventId),
+  );
+
+  const serialized: HarelineEvent[] = visibleEvents.map((e) => ({
     id: e.id,
     date: e.date.toISOString(),
     dateUtc: e.dateUtc,

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -98,7 +98,15 @@ export default async function KennelDetailPage({
     prisma.event.findMany({
       // #1023 step 5: filter via EventKennel join so co-host events
       // (where this kennel is a secondary, not the primary) appear here too.
-      where: { eventKennels: { some: { kennelId: kennel.id } }, status: { not: "CANCELLED" }, isManualEntry: { not: true }, isCanonical: true, parentEventId: null },
+      // #1560 PR F: NO `parentEventId: null` filter — series children whose
+      // primary kennel is this kennel (e.g. GGFM Friday Strawberry Moon as
+      // a child of NYCH3's 5-Boro umbrella) must appear on this kennel's
+      // page. The `eventKennels.some` join correctly fans out to children
+      // because each child gets its own primary `EventKennel` row per
+      // #1023 step 2. The umbrella itself only appears on its host kennel's
+      // page (its `kennelId` is the host's), so dropping the filter doesn't
+      // pollute other kennel pages with parents they don't host.
+      where: { eventKennels: { some: { kennelId: kennel.id } }, status: { not: "CANCELLED" }, isManualEntry: { not: true }, isCanonical: true },
       include: {
         kennel: {
           select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -30,7 +30,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         date: { gte: now },
         status: { not: "CANCELLED" },
         isCanonical: true,
-        parentEventId: null,
+        // #1560 PR F — NO `parentEventId: null` filter. Series children have
+        // their own detail pages (`/hareline/[eventId]`) post-PR E.6, so they
+        // belong in the sitemap. Including them helps search engines index
+        // per-day trail pages (Strawberry Moon Trail, NYC Pride Watch Party!,
+        // etc.) rather than only the umbrella parent.
         kennel: { isHidden: false },
       },
       select: { id: true, updatedAt: true },


### PR DESCRIPTION
## Summary

- Drop `parentEventId: null` from `/kennels/[slug]` events query — series children whose primary kennel matches now appear on that kennel's page (GGFM Friday Strawberry Moon as child of NYCH3's 5-Boro umbrella was previously invisible).
- Make `/hareline?kennels=<id>` kennel-aware on the SSR boundary: `loadEventsForTimeMode` accepts `kennelIds`, swaps `parentEventId: null` for an `OR` match on root kennel + co-host EventKennel when filtered, and uses a sorted-joined cache key so `[a,b]` and `[b,a]` share a cache entry.
- Drop `parentEventId: null` from `/sitemap.xml` so per-day trail pages get indexed (post-PR E.6 they have their own detail pages).

## Context

PR #1697 (PR E) closed the presentation-layer gap on the umbrella detail page. Post-merge verification confirmed the underlying data is correct: GGFM Friday `cmljgcp48...` is a child Event with `kennelId: ggfm`, title `"Strawberry Moon Trail"`, run number `#435`. But:

- `/kennels/ggfm` showed runs `#434` → `#436`, skipping `#435`. The `LATEST RUN: 434` and `NEXT RUN` stats were wrong by the same omission.
- `/hareline?kennels=<ggfm-id>` returned 7 upcoming GGFM events; `#435` was missing.

Root cause: kennel-scoped queries filtered `parentEventId: null` and silently dropped children whose primary kennel matched the filter. The `eventKennels.some { kennelId }` join already fans out to children (each child gets its own primary `EventKennel` row per #1023 step 2), so dropping the filter is correct — and the umbrella itself only appears on its host kennel's page (its root `kennelId` is the host's), so cross-pollution isn't possible.

## Out of scope

- Client-side kennel chip toggle on `/hareline` without an initial URL filter still excludes children (no server refetch on filter change). Known follow-up.
- No UI changes: children rendered on the kennel page use the existing flat-row `EventCard` non-parent branch.
- Hero / admin dashboard stats kept as-is (those advertise listings, not trail-days).

## Test plan

- [x] `npx tsc --noEmit && npm run lint && npm test` — 7446 tests pass
- [x] New `src/app/hareline/actions.test.ts` (5 tests) — exercises the kennel-filter `where` branch + sorted cache key
- [x] `/codex:adversarial-review` — clean (no findings)
- [ ] Post-merge browser verify:
  - `/kennels/ggfm` shows `LATEST RUN: 435`, next run Friday Jun 26 2026, and `#434 → #435 → #436` in order
  - `/hareline?kennels=<ggfm-id>` shows `#435` between `#434` and `#436`
  - `/kennels/nych3` shows the 5-Boro umbrella + its Sat + Sun children
  - `/hareline` (unfiltered) unchanged — children NOT top-level rows
  - `/sitemap.xml` contains the 5-Boro child IDs

Refs #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)