### PR TITLE
fix: cap STATIC_SCHEDULE forward window + clean 672 dormant-RRULE phantoms

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1,3 +1,41 @@
+/**
+ * Source seed data — one row per ingest pipeline (HTML_SCRAPER, GOOGLE_CALENDAR,
+ * GOOGLE_SHEETS, ICAL_FEED, HASHREGO, HARRIER_CENTRAL, MEETUP, STATIC_SCHEDULE,
+ * FACEBOOK_HOSTED_EVENTS). Each row's `config: Json` carries per-adapter knobs.
+ *
+ * ── Adapter config keys (cross-cutting) ──
+ *
+ *   futureHorizonDays?: number  (GOOGLE_CALENDAR + STATIC_SCHEDULE)
+ *     Forward-window cap for RRULE / lunar / recurring-event expansion, in
+ *     days. Default **365** in both adapters. Bounds the worst case when an
+ *     audit-driven wide-window scrape (e.g. `options.days = 1500`) reaches
+ *     an unbounded RRULE — without this cap a single dormant `FREQ=WEEKLY`
+ *     materializes ~8 years of placeholder rows that persist past the
+ *     reconciler's pruning window (chicago-h3 `lastEventDate=2034` was the
+ *     original incident, #939). The historical back-window is *not* capped
+ *     so deep backfills still reach as far as the caller asks.
+ *
+ *     Override on aggregator calendars that legitimately publish annual
+ *     campouts > 12 months out. Don't override on RRULE-heavy umbrella
+ *     calendars — that's how the dormant-RRULE pathology re-enters. See
+ *     issues #1419 (policy), #1692, #1676, #1704, #1663, #1673 for the
+ *     systemic fix that established this policy.
+ *
+ *   kennelPatterns?: Array<[regex, kennelCode | kennelCode[]]>
+ *     For GOOGLE_CALENDAR / iCal / HTML_SCRAPER sources that feed multiple
+ *     kennels off one feed. First-match-wins for string tuples; array
+ *     tuples are co-host emissions (see adapter-patterns.md §D15).
+ *
+ *   defaultKennelTag?: string
+ *     Fallback kennelCode when no `kennelPatterns` entry matches. Omit on
+ *     shared umbrella calendars where unmatched titles should surface as
+ *     UNMATCHED_TAGS alerts rather than silently contaminate one kennel.
+ *
+ * Adapter-specific keys (rrule/lunar/anchorDate/startTime, columns/groupFilter,
+ * titleStripPatterns, staleTitleAliases, etc.) are documented next to their
+ * adapter implementations and admin validators — search the adapter source.
+ */
+
 // ── SHARED SFH3 CONFIG (used by both iCal and HTML sources) ──
 
 const sfh3KennelPatterns: Array<[string, string]> = [

--- a/scripts/cleanup-knightvillian-projections.ts
+++ b/scripts/cleanup-knightvillian-projections.ts
@@ -29,6 +29,10 @@ cleanupDormantProjections(
     issues: [1419, 1692],
     // Dormant weekly RRULE in pormeh3hashcash@gmail.com — single series.
     sourceUrlPrefixes: ["https://www.google.com/calendar/event?eid=MG5ybW4zMjhzbjdjOWc0"],
+    // titleEquals defends against a RECURRENCE-ID exception override under
+    // the same eid prefix being mis-classified as a phantom (codex PR #1720
+    // adversarial review). Every prod-discovered phantom carries this title.
+    titleEquals: "Knightvillain H3",
   },
   APPLY,
 ).catch(async (err) => {

--- a/scripts/cleanup-knightvillian-projections.ts
+++ b/scripts/cleanup-knightvillian-projections.ts
@@ -1,0 +1,37 @@
+/**
+ * One-shot cleanup for #1419 + #1692 — Knightvillian (PorMe H3) dormant RRULE.
+ *
+ * The `pormeh3hashcash@gmail.com` Google Calendar contains an unbounded
+ * `FREQ=WEEKLY` event titled "Knightvillain H3" with no UNTIL clause. Earlier
+ * wide-window scrapes materialized 415 future + 28 past placeholder Events
+ * (verified 2026-05-26 against the prod DB), all sharing the same dormant
+ * series and all carrying runNumber=NULL / haresText=NULL / locationName
+ * empty. The handful of real titled Knightvillian trails (#499, #500, etc.)
+ * come from a different sourceUrl on the same calendar and are not touched.
+ *
+ * Discovery query (one-shot, pre-cleanup):
+ *   SELECT SUBSTRING(sourceUrl FROM '...eid=[A-Za-z0-9_-]{20}'), COUNT(*)
+ *   FROM Event WHERE kennelCode='knightvillian' AND runNumber IS NULL
+ *     AND haresText IS NULL/empty GROUP BY ...;
+ *   → 443 rows, all under one eid prefix `MG5ybW4zMjhzbjdjOWc0`.
+ *
+ *   npm run tsx scripts/cleanup-knightvillian-projections.ts           # preview
+ *   npm run tsx scripts/cleanup-knightvillian-projections.ts -- --apply
+ */
+import "dotenv/config";
+import { cleanupDormantProjections } from "./lib/dormant-projection-cleanup";
+
+const APPLY = process.argv.includes("--apply");
+
+cleanupDormantProjections(
+  {
+    kennelCode: "knightvillian",
+    issues: [1419, 1692],
+    // Dormant weekly RRULE in pormeh3hashcash@gmail.com — single series.
+    sourceUrlPrefixes: ["https://www.google.com/calendar/event?eid=MG5ybW4zMjhzbjdjOWc0"],
+  },
+  APPLY,
+).catch(async (err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-mihihuha-projections.ts
+++ b/scripts/cleanup-mihihuha-projections.ts
@@ -25,6 +25,12 @@ cleanupDormantProjections(
     kennelCode: "mihi-huha",
     issues: [1663],
     sourceUrlPrefixes: ["https://www.google.com/calendar/event?eid=azR2ajNnY2E2YXRma3F1"],
+    // titleEquals defends against a RECURRENCE-ID exception override under
+    // the same eid prefix being mis-classified as a phantom (codex PR #1720
+    // adversarial review). All 23 prod-discovered phantoms carry the bare
+    // kennel-name title because the dormant calendar's RRULE master VEVENT
+    // had no theme set.
+    titleEquals: "Mile High Humpin' Hash",
   },
   APPLY,
 ).catch(async (err) => {

--- a/scripts/cleanup-mihihuha-projections.ts
+++ b/scripts/cleanup-mihihuha-projections.ts
@@ -1,0 +1,33 @@
+/**
+ * One-shot cleanup for #1663 — MiHiHuHa dormant primary-calendar RRULE.
+ *
+ * The `huhahareraiser@gmail.com` Google Calendar went dormant in 2018 but
+ * still contains a 2017-04-27 `RRULE:FREQ=WEEKLY` VEVENT (UID
+ * `k4vj3gca6atfkqulmh1ieg7tk0`) with no UNTIL. Google keeps expanding it;
+ * earlier scrapes materialized 23 placeholder Mile-High-Humpin' rows in
+ * HashTracks, several of which duplicate properly-titled runs (e.g. #598)
+ * that arrive via the active Colorado H3 aggregator calendar.
+ *
+ * Discovery (prod DB, 2026-05-26): 23 rows under eid prefix
+ * `azR2ajNnY2E2YXRma3F1` (base64 of the dormant UID), all runNumber NULL /
+ * haresText empty / locationName empty.
+ *
+ *   npm run tsx scripts/cleanup-mihihuha-projections.ts           # preview
+ *   npm run tsx scripts/cleanup-mihihuha-projections.ts -- --apply
+ */
+import "dotenv/config";
+import { cleanupDormantProjections } from "./lib/dormant-projection-cleanup";
+
+const APPLY = process.argv.includes("--apply");
+
+cleanupDormantProjections(
+  {
+    kennelCode: "mihi-huha",
+    issues: [1663],
+    sourceUrlPrefixes: ["https://www.google.com/calendar/event?eid=azR2ajNnY2E2YXRma3F1"],
+  },
+  APPLY,
+).catch(async (err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-mooloo-projections.ts
+++ b/scripts/cleanup-mooloo-projections.ts
@@ -1,0 +1,63 @@
+/**
+ * One-shot cleanup for #1673 — Mooloo H3 STATIC_SCHEDULE over-projection.
+ *
+ * The static-schedule source (`https://www.sporty.co.nz/mooloohhh`,
+ * `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO`) was previously expanded with an
+ * audit-driven wide window, materializing 25 future + 26 past placeholder
+ * biweekly Mondays titled "Mooloo H3 Run" with no run number / no hares.
+ * Mooloo's actual cadence is host-driven (kennel newsletter says "every
+ * 2nd Monday or whenever you feel like setting a trail"), so the real
+ * source of truth is the HTML_SCRAPER at `/UpCumming-Runs` which currently
+ * publishes exactly one upcoming run at a time (Run #1886).
+ *
+ * **Title-equals guard is critical here**: the static-schedule and the
+ * HTML_SCRAPER share the same parent domain. The HTML_SCRAPER's sourceUrl
+ * is `https://www.sporty.co.nz/mooloohhh/UpCumming-Runs` (different prefix),
+ * but for defense-in-depth we ALSO require `title = 'Mooloo H3 Run'` — the
+ * static-schedule `defaultTitle`. Real titled trails like "Mooloo H3 Trail
+ * #1886" are excluded.
+ *
+ * Discovery (prod DB, 2026-05-26): 51 rows under sourceUrl
+ * `https://www.sporty.co.nz/mooloohhh` with title "Mooloo H3 Run", all
+ * runNumber/haresText NULL.
+ *
+ * Post-cleanup expectation: the new `futureHorizonDays = 365` default cap in
+ * the static-schedule adapter (this PR) means future scrapes will materialize
+ * at most ~26 biweekly Mondays. If that's still too aggressive for Mooloo's
+ * host-driven cadence, a follow-up PR can set `config.futureHorizonDays: 90`
+ * on the source row.
+ *
+ *   npm run tsx scripts/cleanup-mooloo-projections.ts           # preview
+ *   npm run tsx scripts/cleanup-mooloo-projections.ts -- --apply
+ */
+import "dotenv/config";
+import { cleanupDormantProjections } from "./lib/dormant-projection-cleanup";
+
+const APPLY = process.argv.includes("--apply");
+
+cleanupDormantProjections(
+  {
+    kennelCode: "mooloo-h3",
+    issues: [1673],
+    // STATIC_SCHEDULE root URL (not a GCal eid). The HTML_SCRAPER lives at
+    // /UpCumming-Runs which has a distinct sourceUrl prefix.
+    sourceUrlPrefixes: ["https://www.sporty.co.nz/mooloohhh"],
+    titleEquals: "Mooloo H3 Run",
+    // Defense in depth: the static-schedule URL is a prefix of the HTML
+    // scraper URL, so `startsWith` could in principle catch HTML-scraper
+    // rows. Explicitly exclude them so the script is safe even if a future
+    // newsletter post happens to produce a title that matches the default.
+    excludeSourceUrlContains: "/UpCumming-Runs",
+    // One-shot time bound: the new 365d cap (this PR) means every cron
+    // scrape post-merge materializes ~26 legitimate biweekly Mondays under
+    // the same sourceUrl + title + null-runNumber signature. Without this
+    // guard, a re-run after merge would delete those legitimate projections.
+    // The cutoff is "before any post-PR cron scrape" — choose a date strictly
+    // after the cleanup ran for the legacy cohort (2026-05-26 22:30 UTC).
+    createdBefore: new Date("2026-05-27T00:00:00Z"),
+  },
+  APPLY,
+).catch(async (err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-moooouston-projections.ts
+++ b/scripts/cleanup-moooouston-projections.ts
@@ -1,0 +1,32 @@
+/**
+ * One-shot cleanup for #1676 — Moooouston H3 dormant 2021 RRULE.
+ *
+ * The Houston Hash umbrella Google Calendar (`hashvoice` gmail) contains a
+ * 2021-09-27 `FREQ=WEEKLY` VEVENT with SUMMARY="Moooouston H3 -" (trailing
+ * dash placeholder, hits the #756 trailing-dash fallback) and no UNTIL.
+ * Materialized 52 future + 54 past placeholder Mondays sharing the same
+ * sourceUrl prefix; real titled Moooouston trails ("Moooouston H3 -
+ * Cowtastrophe", etc.) are distinct VEVENTs with a different eid.
+ *
+ * Discovery (prod DB, 2026-05-26): 106 rows under eid `NnNyamlkajU2cGhqZWI5`,
+ * all runNumber NULL / haresText empty / locationName empty.
+ *
+ *   npm run tsx scripts/cleanup-moooouston-projections.ts           # preview
+ *   npm run tsx scripts/cleanup-moooouston-projections.ts -- --apply
+ */
+import "dotenv/config";
+import { cleanupDormantProjections } from "./lib/dormant-projection-cleanup";
+
+const APPLY = process.argv.includes("--apply");
+
+cleanupDormantProjections(
+  {
+    kennelCode: "moooouston-h3",
+    issues: [1676],
+    sourceUrlPrefixes: ["https://www.google.com/calendar/event?eid=NnNyamlkajU2cGhqZWI5"],
+  },
+  APPLY,
+).catch(async (err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-moooouston-projections.ts
+++ b/scripts/cleanup-moooouston-projections.ts
@@ -24,6 +24,11 @@ cleanupDormantProjections(
     kennelCode: "moooouston-h3",
     issues: [1676],
     sourceUrlPrefixes: ["https://www.google.com/calendar/event?eid=NnNyamlkajU2cGhqZWI5"],
+    // titleEquals defends against a RECURRENCE-ID exception override under
+    // the same eid prefix being mis-classified as a phantom (codex PR #1720
+    // adversarial review). All 106 prod-discovered phantoms carry this title
+    // (the kennel-shortName fallback after #756's trailing-dash strip).
+    titleEquals: "Moooouston H3 Trail",
   },
   APPLY,
 ).catch(async (err) => {

--- a/scripts/cleanup-mosquito-projections.ts
+++ b/scripts/cleanup-mosquito-projections.ts
@@ -1,0 +1,43 @@
+/**
+ * One-shot cleanup for #1704 — Mosquito H3 3-RRULE phantom set.
+ *
+ * The Houston Hash umbrella Google Calendar (`hashvoice` gmail) contains THREE
+ * separate `FREQ=MONTHLY` VEVENTs (1st Wed, 2nd Wed, 3rd Wed) all with
+ * SUMMARY="Mosquito H3" and no UNTIL. The 2nd-Wed series is a mis-applied
+ * recurrence on a 2025-01-08 annual sign-up event; the 1st/3rd-Wed series are
+ * dormant duplicates of the STATIC_SCHEDULE rows we already trust. Together
+ * they emit 36 future + 13 past phantom Wednesdays (12 per series ~).
+ *
+ * Discovery (prod DB, 2026-05-26): 49 rows under three eid prefixes, all
+ * title="Mosquito H3 Trail" (kennel-shortName fallback), runNumber/hares/
+ * location all NULL/empty. The `titleEquals` guard is belt-and-suspenders
+ * against future GCal rows that might re-use the same eid prefix with a
+ * different title (e.g. if a real one-off event gets created under the
+ * dormant series ID). The hashrego.com campout row is already excluded by
+ * `sourceUrlPrefixes` since it has a different domain entirely.
+ *
+ *   npm run tsx scripts/cleanup-mosquito-projections.ts           # preview
+ *   npm run tsx scripts/cleanup-mosquito-projections.ts -- --apply
+ */
+import "dotenv/config";
+import { cleanupDormantProjections } from "./lib/dormant-projection-cleanup";
+
+const APPLY = process.argv.includes("--apply");
+
+cleanupDormantProjections(
+  {
+    kennelCode: "mosquito-h3",
+    issues: [1704],
+    // Three dormant monthly RRULEs on the same umbrella calendar.
+    sourceUrlPrefixes: [
+      "https://www.google.com/calendar/event?eid=YzRzbThvcG5jaGdtNGJi", // series A
+      "https://www.google.com/calendar/event?eid=Xzk1aG0ycjFtYzhyM2Fj", // series B
+      "https://www.google.com/calendar/event?eid=b2tmYnZpdG43aHFpZzhs", // series C
+    ],
+    titleEquals: "Mosquito H3 Trail",
+  },
+  APPLY,
+).catch(async (err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lib/dormant-projection-cleanup.ts
+++ b/scripts/lib/dormant-projection-cleanup.ts
@@ -14,25 +14,28 @@
  *        - `runNumber IS NULL`, AND
  *        - `haresText IS NULL OR ''` (placeholder shape — guards against
  *          deleting any titled trail that happened to share a sourceUrl), AND
- *        - optional `title` exact match (used when a kennel's static-schedule
- *          phantoms share their sourceUrl with the real HTML_SCRAPER source,
- *          e.g. Mooloo H3 — see `cleanup-mooloo-projections.ts`).
- *   3. **Attendance preflight** — count `attendances` + `kennelAttendances`
- *      across the candidate set. Abort with a listing if any non-zero — the
- *      misman/RSVP audit trail is unrecoverable. (Closes #1419, #1692, #1676,
- *      #1704, #1663, #1673.)
- *   4. Dry-run logs the candidate IDs / dates / titles. `--apply` calls
- *      `cascadeDeleteEvents()` which orphans the linked RawEvents
- *      (`eventId=null, processed=false`) so the audit trail survives and the
- *      next scrape will re-link them to a real titled VEVENT if the source
- *      publishes one at the same date.
+ *        - optional `titleEquals` exact match (the recommended belt-and-
+ *          suspenders defense against RECURRENCE-ID exception overrides that
+ *          could share a dormant series' eid prefix with a real title — see
+ *          codex review of PR #1720).
+ *   3. **Attendance preflight (atomic, isolation=Serializable)** — the
+ *      candidate set is re-counted inside the same transaction that performs
+ *      the delete. If attendance appears between the initial discovery and
+ *      the transaction start, the in-tx recheck catches it and rolls back.
+ *      Without this, the window between `findMany()` and `cascadeDeleteEvents`
+ *      let concurrent writes slip through and get silently deleted alongside
+ *      the phantom Events.
+ *   4. Dry-run logs the candidate IDs / dates / titles. `--apply` runs the
+ *      transactional delete in batches, unlinking RawEvents (`eventId=null,
+ *      processed=false`) so the audit trail survives and the next scrape can
+ *      re-link them if a real titled VEVENT appears at the same date.
  *
  * Idempotent: re-runs after `--apply` find zero candidates and exit cleanly,
  * because the sourceUrl + placeholder-shape filter excludes anything the
  * adapter would re-create with non-NULL `runNumber` / `haresText`.
  */
+import { Prisma } from "@/generated/prisma/client";
 import { prisma } from "@/lib/db";
-import { cascadeDeleteEvents } from "./cascade-delete";
 
 export interface DormantCleanupConfig {
   /** Human-readable identifier surfaced in logs (e.g. "knightvillian"). */
@@ -162,9 +165,37 @@ export async function cleanupDormantProjections(
   }
 
   if (apply && candidates.length > 0) {
-    const deleted = await cascadeDeleteEvents(
-      prisma,
-      candidates.map((c) => c.id),
+    const candidateIds = candidates.map((c) => c.id);
+    const deleted = await prisma.$transaction(
+      async (tx) => {
+        // In-transaction recheck — closes the TOCTOU window between the
+        // outer `findMany` and the delete. With Serializable isolation,
+        // any concurrent writer that adds attendance to a candidate row
+        // after our snapshot triggers a serialization-failure abort.
+        const recheck = await tx.event.findMany({
+          where: { id: { in: candidateIds } },
+          select: {
+            id: true,
+            _count: { select: { attendances: true, kennelAttendances: true } },
+          },
+        });
+        const newAttendance = recheck.filter(
+          (e) => e._count.attendances > 0 || e._count.kennelAttendances > 0,
+        );
+        if (newAttendance.length > 0) {
+          // Thrown errors roll the whole transaction back — no rows deleted.
+          throw new Error(
+            `Concurrent attendance detected on ${newAttendance.length} candidate(s); ` +
+              `rolling back. IDs: ${newAttendance.map((e) => e.id).join(", ")}`,
+          );
+        }
+        return cascadeDeleteEventsTx(tx, candidateIds);
+      },
+      {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        timeout: 60_000,
+        maxWait: 10_000,
+      },
     );
     console.log(
       `\nDeleted ${deleted} Event row(s). RawEvents unlinked (eventId=null, processed=false) ` +
@@ -175,4 +206,38 @@ export async function cleanupDormantProjections(
   }
 
   await prisma.$disconnect();
+}
+
+/**
+ * Tx-scoped variant of `cascadeDeleteEvents`. Same semantics as the standalone
+ * helper but uses an injected `Prisma.TransactionClient` so the recheck +
+ * delete share an atomic boundary. Reusing `cascadeDeleteEvents(prisma, ...)`
+ * directly inside an outer interactive transaction would open a *separate*
+ * connection and defeat the isolation guarantee — that's why we duplicate
+ * the cascade body here instead of calling the shared helper.
+ */
+async function cascadeDeleteEventsTx(
+  tx: Prisma.TransactionClient,
+  eventIds: string[],
+): Promise<number> {
+  if (eventIds.length === 0) return 0;
+  const BATCH_SIZE = 100;
+  let deleted = 0;
+  for (let i = 0; i < eventIds.length; i += BATCH_SIZE) {
+    const batch = eventIds.slice(i, i + BATCH_SIZE);
+    await tx.rawEvent.updateMany({
+      where: { eventId: { in: batch } },
+      data: { eventId: null, processed: false },
+    });
+    await tx.event.updateMany({
+      where: { parentEventId: { in: batch } },
+      data: { parentEventId: null },
+    });
+    await tx.eventHare.deleteMany({ where: { eventId: { in: batch } } });
+    await tx.attendance.deleteMany({ where: { eventId: { in: batch } } });
+    await tx.kennelAttendance.deleteMany({ where: { eventId: { in: batch } } });
+    const res = await tx.event.deleteMany({ where: { id: { in: batch } } });
+    deleted += res.count;
+  }
+  return deleted;
 }

--- a/scripts/lib/dormant-projection-cleanup.ts
+++ b/scripts/lib/dormant-projection-cleanup.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared helper for one-shot dormant-RRULE projection cleanup scripts.
+ *
+ * Five kennels were hit by the same pathology — an unbounded RRULE in a
+ * source calendar (or a static-schedule audit with a wide forward window)
+ * materialized hundreds of placeholder Events into the canonical store, none
+ * of which carry hares / run number / location. Each per-kennel script
+ * configures the kennelCode and the dormant series' sourceUrl prefix(es),
+ * and this helper does the rest:
+ *
+ *   1. Resolve the kennel by `kennelCode` (abort if missing).
+ *   2. Discover phantom Events scoped to that kennel where:
+ *        - `sourceUrl LIKE ANY(prefixes)` (anchors to the dormant series), AND
+ *        - `runNumber IS NULL`, AND
+ *        - `haresText IS NULL OR ''` (placeholder shape — guards against
+ *          deleting any titled trail that happened to share a sourceUrl), AND
+ *        - optional `title` exact match (used when a kennel's static-schedule
+ *          phantoms share their sourceUrl with the real HTML_SCRAPER source,
+ *          e.g. Mooloo H3 — see `cleanup-mooloo-projections.ts`).
+ *   3. **Attendance preflight** — count `attendances` + `kennelAttendances`
+ *      across the candidate set. Abort with a listing if any non-zero — the
+ *      misman/RSVP audit trail is unrecoverable. (Closes #1419, #1692, #1676,
+ *      #1704, #1663, #1673.)
+ *   4. Dry-run logs the candidate IDs / dates / titles. `--apply` calls
+ *      `cascadeDeleteEvents()` which orphans the linked RawEvents
+ *      (`eventId=null, processed=false`) so the audit trail survives and the
+ *      next scrape will re-link them to a real titled VEVENT if the source
+ *      publishes one at the same date.
+ *
+ * Idempotent: re-runs after `--apply` find zero candidates and exit cleanly,
+ * because the sourceUrl + placeholder-shape filter excludes anything the
+ * adapter would re-create with non-NULL `runNumber` / `haresText`.
+ */
+import { prisma } from "@/lib/db";
+import { cascadeDeleteEvents } from "./cascade-delete";
+
+export interface DormantCleanupConfig {
+  /** Human-readable identifier surfaced in logs (e.g. "knightvillian"). */
+  kennelCode: string;
+  /**
+   * Issue numbers this cleanup addresses — surfaced in the script's banner
+   * so future readers can trace the policy provenance.
+   */
+  issues: readonly number[];
+  /**
+   * `sourceUrl` LIKE-pattern prefixes (one per dormant series). The helper
+   * matches `sourceUrl LIKE '<prefix>%'`. For Mosquito's 3 RRULEs this is a
+   * three-element list; for the single-dormant-series kennels it's one.
+   */
+  sourceUrlPrefixes: readonly string[];
+  /**
+   * Optional title-exact-match guard. Use when the dormant sourceUrl is
+   * shared with a real source (Mooloo's `sporty.co.nz/mooloohhh` is the
+   * static-schedule URL; the HTML_SCRAPER uses `/UpCumming-Runs`). Leaving
+   * undefined skips the title check.
+   */
+  titleEquals?: string;
+  /**
+   * Optional `sourceUrl NOT CONTAINS <substring>` exclusion. Defends against
+   * the `startsWith` semantics of `sourceUrlPrefixes` overlapping a sibling
+   * source URL (Mooloo: static-schedule URL is a prefix of the HTML_SCRAPER's
+   * `/UpCumming-Runs` URL — without this guard a future scrape that emits an
+   * event with title="Mooloo H3 Run" via the HTML scraper would be caught).
+   */
+  excludeSourceUrlContains?: string;
+  /**
+   * Optional `createdAt < <date>` upper bound. Makes the cleanup time-bound
+   * for the legacy phantom cohort: Mooloo's STATIC_SCHEDULE post-cap scrape
+   * still emits ~26 placeholder Mondays per year with the same sourceUrl +
+   * title + null-runNumber signature, and we don't want a future re-run to
+   * delete them. Set this to a date just after the cleanup PR merges; only
+   * the pre-merge phantom cohort matches.
+   */
+  createdBefore?: Date;
+}
+
+export async function cleanupDormantProjections(
+  cfg: DormantCleanupConfig,
+  apply: boolean,
+): Promise<void> {
+  // Misconfig guard: empty prefix list would generate `OR: []` which Prisma
+  // treats as "no row" — silent false-negative that looks like success.
+  if (cfg.sourceUrlPrefixes.length === 0) {
+    throw new Error(
+      `cleanupDormantProjections(${cfg.kennelCode}): sourceUrlPrefixes must be non-empty`,
+    );
+  }
+
+  const banner = `${cfg.kennelCode} dormant-RRULE projection cleanup (issues ${cfg.issues.map((n) => `#${n}`).join(", ")})`;
+  console.log(`\n=== ${banner} ===`);
+
+  const kennel = await prisma.kennel.findFirst({ where: { kennelCode: cfg.kennelCode } });
+  if (!kennel) {
+    console.error(`Kennel ${cfg.kennelCode} not found — aborting.`);
+    await prisma.$disconnect();
+    process.exit(1);
+  }
+
+  // OR-chain of `startsWith` predicates — Prisma can express each cleanly,
+  // and we keep the query inside the type-checked client rather than dropping
+  // to raw SQL.
+  const sourceUrlOr = cfg.sourceUrlPrefixes.map((prefix) => ({
+    sourceUrl: { startsWith: prefix },
+  }));
+
+  const candidates = await prisma.event.findMany({
+    where: {
+      kennelId: kennel.id,
+      runNumber: null,
+      OR: sourceUrlOr,
+      AND: [
+        { OR: [{ haresText: null }, { haresText: "" }] },
+        ...(cfg.titleEquals ? [{ title: cfg.titleEquals }] : []),
+        ...(cfg.excludeSourceUrlContains
+          ? [{ NOT: { sourceUrl: { contains: cfg.excludeSourceUrlContains } } }]
+          : []),
+        ...(cfg.createdBefore ? [{ createdAt: { lt: cfg.createdBefore } }] : []),
+      ],
+    },
+    select: {
+      id: true,
+      date: true,
+      title: true,
+      locationName: true,
+      sourceUrl: true,
+      _count: { select: { attendances: true, kennelAttendances: true } },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  console.log(`Found ${candidates.length} phantom Event row(s) for ${cfg.kennelCode}.`);
+
+  // Attendance preflight: any candidate with attached attendance must NOT be
+  // touched — manual reassignment is required first. We list them and abort.
+  const withAttendance = candidates.filter(
+    (c) => c._count.attendances > 0 || c._count.kennelAttendances > 0,
+  );
+  if (withAttendance.length > 0) {
+    console.error(
+      `\nABORT — ${withAttendance.length} candidate(s) have attendance / kennel-attendance rows. ` +
+        `Reassign to a real Event before re-running:`,
+    );
+    for (const e of withAttendance) {
+      console.error(
+        `  ${e.id}  date=${e.date.toISOString().slice(0, 10)}  ` +
+          `attendances=${e._count.attendances}  kennelAttendances=${e._count.kennelAttendances}  ` +
+          `title=${JSON.stringify(e.title)}`,
+      );
+    }
+    await prisma.$disconnect();
+    process.exit(2);
+  }
+
+  // Compact log: just dates + the eid-tail of the sourceUrl so the operator
+  // can eyeball which dormant series each row belongs to.
+  for (const e of candidates) {
+    const eidTail = e.sourceUrl?.match(/eid=([A-Za-z0-9_-]{8,40})/)?.[1] ?? "<not-gcal>";
+    console.log(
+      `  ${apply ? "DELETE" : "  --  "}  ${e.id}  date=${e.date.toISOString().slice(0, 10)}  ` +
+        `title=${JSON.stringify(e.title)}  eid=${eidTail}`,
+    );
+  }
+
+  if (apply && candidates.length > 0) {
+    const deleted = await cascadeDeleteEvents(
+      prisma,
+      candidates.map((c) => c.id),
+    );
+    console.log(
+      `\nDeleted ${deleted} Event row(s). RawEvents unlinked (eventId=null, processed=false) ` +
+        `for re-link on next scrape; no attendance data lost.`,
+    );
+  } else if (!apply) {
+    console.log("\nDry-run only. Re-run with --apply to write changes.");
+  }
+
+  await prisma.$disconnect();
+}

--- a/scripts/verify-projection-cap.ts
+++ b/scripts/verify-projection-cap.ts
@@ -1,0 +1,88 @@
+/**
+ * Ad-hoc live verification for the WS1 dormant-RRULE / projection-cap fix.
+ *
+ * Not committed to a long-term path — used once to verify that:
+ *   1. The new STATIC_SCHEDULE `futureHorizonDays` cap (default 365) bounds
+ *      Mooloo's biweekly Monday expansion even when called with
+ *      `options.days = 1500` (simulating an admin force-scrape).
+ *   2. Re-scraping the 4 affected GCal sources produces no new phantom rows
+ *      beyond the 365-day horizon for the affected kennels.
+ *   3. Real titled events (#499 Knightvillian, etc.) are still present.
+ *
+ *   npx tsx scripts/verify-projection-cap.ts
+ */
+import "dotenv/config";
+import { prisma } from "../src/lib/db";
+import { StaticScheduleAdapter } from "../src/adapters/static-schedule/adapter";
+
+async function main() {
+  // --- (1) Static-schedule cap verification — Mooloo at days=1500 ---
+  const mooloo = await prisma.source.findFirst({
+    where: { url: "https://www.sporty.co.nz/mooloohhh", type: "STATIC_SCHEDULE" },
+  });
+  if (!mooloo) throw new Error("Mooloo static-schedule source not found");
+
+  const adapter = new StaticScheduleAdapter();
+  const result = await adapter.fetch(mooloo, { days: 1500 });
+  const now = Date.now();
+  const horizonMs = now + 365 * 86_400_000;
+  const beyondHorizon = result.events.filter(
+    (e) => new Date(e.date + "T12:00:00Z").getTime() > horizonMs,
+  );
+  console.log(`\n== Mooloo STATIC_SCHEDULE, options.days=1500 ==`);
+  console.log(`  Total events generated: ${result.events.length}`);
+  console.log(`  Events beyond 365d horizon: ${beyondHorizon.length} (expect 0)`);
+  console.log(`  Diagnostic forwardWindowDays: ${result.diagnosticContext?.forwardWindowDays} (expect 365)`);
+  console.log(`  Diagnostic windowDays:        ${result.diagnosticContext?.windowDays} (expect 1500)`);
+
+  // --- (2) Verify post-cleanup state for all 5 kennels ---
+  const kennels = ["knightvillian", "moooouston-h3", "mosquito-h3", "mihi-huha", "mooloo-h3"];
+  console.log(`\n== Post-cleanup Event inventory ==`);
+  for (const code of kennels) {
+    const total = await prisma.event.count({
+      where: { kennel: { kennelCode: code }, status: "CONFIRMED" },
+    });
+    const future = await prisma.event.count({
+      where: {
+        kennel: { kennelCode: code },
+        status: "CONFIRMED",
+        date: { gt: new Date() },
+      },
+    });
+    const futureBeyondHorizon = await prisma.event.count({
+      where: {
+        kennel: { kennelCode: code },
+        status: "CONFIRMED",
+        date: { gt: new Date(Date.now() + 365 * 86_400_000) },
+      },
+    });
+    console.log(
+      `  ${code.padEnd(16)} total=${String(total).padStart(4)}  future=${String(future).padStart(3)}  beyond365d=${futureBeyondHorizon} (expect 0)`,
+    );
+  }
+
+  // --- (3) Sanity: real Knightvillian trails (#499, #500) still present ---
+  console.log(`\n== Knightvillian sanity: real titled trails preserved ==`);
+  const realKnight = await prisma.event.findMany({
+    where: {
+      kennel: { kennelCode: "knightvillian" },
+      runNumber: { not: null },
+    },
+    select: { runNumber: true, date: true, title: true },
+    orderBy: { runNumber: "desc" },
+    take: 5,
+  });
+  for (const e of realKnight) {
+    console.log(
+      `  #${e.runNumber}  ${e.date.toISOString().slice(0, 10)}  ${JSON.stringify(e.title)}`,
+    );
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/src/adapters/static-schedule/adapter.test.ts
+++ b/src/adapters/static-schedule/adapter.test.ts
@@ -3,6 +3,7 @@ import {
   parseRRule,
   generateOccurrences,
   renderTitleTemplate,
+  DEFAULT_FUTURE_HORIZON_DAYS,
 } from "./adapter";
 import type { StaticScheduleConfig } from "./adapter";
 import type { RawEventData } from "../types";
@@ -765,5 +766,73 @@ describe("StaticScheduleAdapter lunar mode", () => {
     for (const event of result.events) {
       expect(event.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forward-horizon cap (#1419, #1673) — bounds RRULE expansion regardless of
+// options.days so an audit-driven wide-window scrape can't materialize years
+// of placeholder events when the underlying RRULE has no UNTIL.
+// ---------------------------------------------------------------------------
+
+describe("StaticScheduleAdapter forward-horizon cap", () => {
+  const adapter = new StaticScheduleAdapter();
+  const WEEKLY_MO = "FREQ=WEEKLY;BYDAY=MO";
+  const DAY_MS = 86_400_000;
+  const eventMs = (e: RawEventData) => new Date(e.date + "T12:00:00Z").getTime();
+  const moolooSource = (extra: Record<string, unknown> = {}) =>
+    makeSource({ kennelTag: "mooloo-h3", rrule: WEEKLY_MO, ...extra });
+
+  it("caps forward window at the default when options.days exceeds it", async () => {
+    // Unbounded weekly Monday RRULE — Mooloo H3 (#1673) pathology. Caller asks
+    // for ±1500 days; back-window honors that but forward-window must clamp.
+    const result = await adapter.fetch(moolooSource(), { days: 1500 });
+    expect(result.errors).toEqual([]);
+    const horizonMs = Date.now() + DEFAULT_FUTURE_HORIZON_DAYS * DAY_MS;
+    for (const event of result.events) {
+      expect(eventMs(event)).toBeLessThanOrEqual(horizonMs);
+    }
+    expect(result.diagnosticContext?.windowDays).toBe(1500);
+    expect(result.diagnosticContext?.forwardWindowDays).toBe(DEFAULT_FUTURE_HORIZON_DAYS);
+  });
+
+  it("preserves full back-window when forward cap engages (deep backfill unaffected)", async () => {
+    const result = await adapter.fetch(moolooSource(), { days: 1500 });
+    // Some events must land >365 days before today — confirms back-window isn't capped.
+    const cutoffMs = Date.now() - DEFAULT_FUTURE_HORIZON_DAYS * DAY_MS;
+    const oldEvents = result.events.filter((e) => eventMs(e) < cutoffMs);
+    expect(oldEvents.length).toBeGreaterThan(0);
+  });
+
+  it("honors per-source futureHorizonDays override", async () => {
+    // Override to 730 days — caller's 1500 still clamps, but to 730 not the default.
+    const OVERRIDE = 730;
+    const result = await adapter.fetch(moolooSource({ futureHorizonDays: OVERRIDE }), { days: 1500 });
+    expect(result.diagnosticContext?.forwardWindowDays).toBe(OVERRIDE);
+    const horizonMs = Date.now() + OVERRIDE * DAY_MS;
+    const beyondDefaultMs = Date.now() + DEFAULT_FUTURE_HORIZON_DAYS * DAY_MS;
+    const futureEvents = result.events.filter((e) => eventMs(e) > beyondDefaultMs);
+    expect(futureEvents.length).toBeGreaterThan(0);
+    for (const event of result.events) {
+      expect(eventMs(event)).toBeLessThanOrEqual(horizonMs);
+    }
+  });
+
+  it.each([
+    ["string", "365" as unknown as number],
+    ["NaN", Number.NaN],
+    ["negative", -1],
+    ["zero", 0],
+    ["Infinity", Infinity],
+  ])("falls back to default cap when futureHorizonDays is malformed (%s)", async (_label, bad) => {
+    const result = await adapter.fetch(moolooSource({ futureHorizonDays: bad }), { days: 1500 });
+    expect(result.diagnosticContext?.forwardWindowDays).toBe(DEFAULT_FUTURE_HORIZON_DAYS);
+  });
+
+  it("does not extend forward window when options.days is already below the cap", async () => {
+    // Caller asks for 90 days; cap stays at default → no behavior change vs pre-#1419.
+    const result = await adapter.fetch(moolooSource(), { days: 90 });
+    expect(result.diagnosticContext?.forwardWindowDays).toBe(90);
+    expect(result.diagnosticContext?.windowDays).toBe(90);
   });
 });

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -56,7 +56,24 @@ export interface StaticScheduleConfig {
    * as literal text on per-source rows whose RRULE matches that slot.
    */
   titleTemplate?: string;
+  /**
+   * Cap on the forward window (days from "now") used when expanding RRULE /
+   * lunar rules. Mirrors GOOGLE_CALENDAR's `futureHorizonDays` — same key
+   * name, same units, same default. Bounds how far an unbounded recurrence
+   * (no UNTIL / no COUNT) can materialize when an audit-driven wide-window
+   * scrape (e.g. `options.days = 1500`) reaches the adapter. The historical
+   * back-window is unaffected so deep backfills still work. Closes #1419.
+   */
+  futureHorizonDays?: number;
 }
+
+/**
+ * Default forward-horizon cap for RRULE / lunar expansion. Matches GOOGLE_CALENDAR's
+ * `DEFAULT_FUTURE_HORIZON_DAYS` so admins can reason about both adapters with one
+ * mental model. See header comment in `prisma/seed-data/sources.ts` for the policy
+ * (#1419) and the per-source override pattern.
+ */
+export const DEFAULT_FUTURE_HORIZON_DAYS = 365;
 
 /**
  * Generate weekly occurrence dates within a window. Supports anchor-based alignment
@@ -335,8 +352,9 @@ export class StaticScheduleAdapter implements SourceAdapter {
   type = "STATIC_SCHEDULE" as const;
 
   /**
-   * Generate recurring events from the source's RRULE schedule config.
-   * Produces events within a symmetric window around today (default ±90 days).
+   * Generate recurring events from the source's RRULE schedule config. Default
+   * window is ±90 days; the forward side is capped at `futureHorizonDays` so a
+   * wide-window backfill can't materialize years of placeholder events.
    */
   async fetch(
     source: Source,
@@ -346,7 +364,9 @@ export class StaticScheduleAdapter implements SourceAdapter {
     if (!configResult.ok) return errorResult(configResult.error);
 
     const { config, validated } = configResult;
-    const window = computeScrapeWindow(options?.days ?? 90);
+    const requestedDays = options?.days ?? 90;
+    const forwardDays = Math.min(requestedDays, resolveFutureHorizonDays(config.futureHorizonDays));
+    const window = computeScrapeWindow(requestedDays, forwardDays);
 
     const occurrencesResult =
       validated.kind === "lunar"
@@ -361,6 +381,7 @@ export class StaticScheduleAdapter implements SourceAdapter {
           ...occurrencesResult.diagnostic,
           occurrencesGenerated: 0,
           windowDays: window.days,
+          forwardWindowDays: window.forwardDays,
           windowStart: window.start.toISOString(),
           windowEnd: window.end.toISOString(),
           note: "off-season: window does not overlap any BYMONTH month",
@@ -397,6 +418,7 @@ export class StaticScheduleAdapter implements SourceAdapter {
         ...diagnostic,
         occurrencesGenerated: events.length,
         windowDays: window.days,
+        forwardWindowDays: window.forwardDays,
         windowStart: window.start.toISOString(),
         windowEnd: window.end.toISOString(),
       },
@@ -412,18 +434,39 @@ function errorResult(message: string): ScrapeResult {
 interface ScrapeWindow {
   start: Date;
   end: Date;
+  /** Days of historical back-window — the original `options.days` value. */
   days: number;
+  /** Days of forward projection — `min(options.days, futureHorizonDays)`. */
+  forwardDays: number;
 }
 
-/** Compute the symmetric ±days window centered on UTC noon today. */
-function computeScrapeWindow(days: number): ScrapeWindow {
+/**
+ * Compute an asymmetric scrape window centered on UTC noon today: `days` back,
+ * `forwardDays` forward. Deep backfills set `days` large; the forward cap
+ * (#1419, #1673) keeps an unbounded RRULE from materializing years of
+ * placeholder events.
+ */
+function computeScrapeWindow(days: number, forwardDays: number): ScrapeWindow {
   const now = new Date();
   const todayNoon = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0);
   return {
     start: new Date(todayNoon - days * 86_400_000),
-    end: new Date(todayNoon + days * 86_400_000),
+    end: new Date(todayNoon + forwardDays * 86_400_000),
     days,
+    forwardDays,
   };
+}
+
+/**
+ * Defensive parse for `config.futureHorizonDays` — non-numeric, NaN, ±Infinity,
+ * negative, or zero falls back to the default. NaN would otherwise propagate
+ * into Date arithmetic and silently emit zero events. Mirrors the same guard
+ * inlined in the GOOGLE_CALENDAR adapter so policy stays uniform.
+ */
+function resolveFutureHorizonDays(raw: unknown): number {
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0
+    ? raw
+    : DEFAULT_FUTURE_HORIZON_DAYS;
 }
 
 type ConfigParseResult =


### PR DESCRIPTION
## Summary

Five kennels carried **672 placeholder Events** materialized from unbounded RRULEs (no UNTIL) in source calendars or wide-window STATIC_SCHEDULE audit scrapes. The GCal adapter already capped its forward window at 365 days ([#939](https://github.com/johnrclem/hashtracks-web/issues/939)); this PR extends the same policy to STATIC_SCHEDULE and cleans up the residual phantom cohort.

| Kennel | Phantoms | Source pathology |
|--------|---------:|------------------|
| knightvillian | 443 | GCal `pormeh3hashcash@gmail.com` weekly RRULE, no UNTIL |
| moooouston-h3 | 106 | Houston umbrella, dormant 2021 weekly RRULE, SUMMARY="Moooouston H3 -" trailing dash |
| mosquito-h3 | 49 | Houston umbrella, 3 bare-SUMMARY monthly RRULEs (1st/2nd/3rd Wed) |
| mihi-huha | 23 | `huhahareraiser@gmail.com` (dormant since 2018) weekly RRULE |
| mooloo-h3 | 51 | STATIC_SCHEDULE biweekly Mondays projected forward 2yr by audit scrape |
| **Total** | **672** | |

## Policy decision (#1419)

**Hybrid 12-month cap, configurable per-source.** Reuses the existing GCal `futureHorizonDays` key (days, default 365) — same name, same units, same default — extended to STATIC_SCHEDULE. Documented in a header comment block in [`prisma/seed-data/sources.ts`](prisma/seed-data/sources.ts).

Rejected: introducing a parallel `maxProjectionMonths` key (months) would split the policy across two parallel knobs. Days + single key keeps the mental model uniform.

## Adapter change ([src/adapters/static-schedule/adapter.ts](src/adapters/static-schedule/adapter.ts))

- Added `StaticScheduleConfig.futureHorizonDays?: number` and exported `DEFAULT_FUTURE_HORIZON_DAYS = 365`.
- `computeScrapeWindow(days, forwardDays)` is now asymmetric: back-window honors `requestedDays`, forward-window clamps to `min(requestedDays, futureHorizonDays)`.
- Defensive parse via `resolveFutureHorizonDays(raw: unknown)` — string / NaN / ±Infinity / negative / zero all fall back to default.
- Diagnostic context exposes both `windowDays` (requested) and `forwardWindowDays` (clamped) so operators can see when the cap engages.

5 new tests at the bottom of [`adapter.test.ts`](src/adapters/static-schedule/adapter.test.ts) cover bounded cap, deep-backfill back-window preservation, per-source override, malformed values (5 cases via `it.each`), and the no-op case when `days <= cap`.

## Cleanup

Shared helper [`scripts/lib/dormant-projection-cleanup.ts`](scripts/lib/dormant-projection-cleanup.ts) + 5 thin per-kennel wrappers. Each wrapper documents the dormant-series sourceUrl + the issue it closes.

Helper features:
- **Triple-gated filter** (sourceUrl prefix + runNumber NULL + haresText NULL/empty + optional title-equals)
- **Attendance preflight** — aborts with listing if any candidate has Attendance / KennelAttendance rows (none did)
- **Dry-run by default**, `--apply` writes
- **`cascadeDeleteEvents()`** unlinks RawEvents (eventId=null, processed=false) so the audit trail survives and the next scrape re-links them if a real VEVENT appears
- **Mooloo-specific guards**: `excludeSourceUrlContains: "/UpCumming-Runs"` defends against the static-schedule URL overlapping the HTML scraper's URL prefix; `createdBefore: 2026-05-27` makes the cleanup time-bound so post-cap legitimate projections aren't re-deleted

Cleanup already executed against prod (verified before opening this PR):

```
=== knightvillian → 443 deleted
=== moooouston-h3 → 106 deleted
=== mosquito-h3   →  49 deleted
=== mihi-huha     →  23 deleted
=== mooloo-h3     →  51 deleted
                 ───────────
                    672 phantom Events removed
```

Idempotency: re-running each script's dry-run now reports `Found 0 phantom Event row(s)`.

## Live verification ([scripts/verify-projection-cap.ts](scripts/verify-projection-cap.ts))

```
== Mooloo STATIC_SCHEDULE, options.days=1500 ==
  Total events generated: 134
  Events beyond 365d horizon: 0 (expect 0)
  Diagnostic forwardWindowDays: 365 (expect 365)
  Diagnostic windowDays:        1500 (expect 1500)

== Post-cleanup Event inventory ==
  knightvillian    total=  43  future=  3  beyond365d=0 (expect 0)
  moooouston-h3    total=   7  future=  0  beyond365d=0 (expect 0)
  mosquito-h3      total=  22  future=  1  beyond365d=0 (expect 0)
  mihi-huha        total= 175  future=  0  beyond365d=0 (expect 0)
  mooloo-h3        total=   1  future=  0  beyond365d=0 (expect 0)

== Knightvillian sanity: real titled trails preserved ==
  #500  2026-06-11  "Knightvillain H3 #500"
  #499  2026-06-04  "Knightvillain H3 #499"
  #498  2026-05-28  "Knightvillain H3 #498"
  #497  2026-05-21  "Knightvillain H3 #497 - Ringo No Hana"
  #496  2026-05-14  "Knightvillain H3 #496 - Space Team!"
```

## Followups (NOT in this PR)

- Mooloo's 365d cap still produces ~26 biweekly Monday placeholders. If post-merge UX is still cluttered, a follow-up can set `config.futureHorizonDays: 90` on the source row (or `enabled: false` since the HTML scraper at `/UpCumming-Runs` is authoritative).
- iCal adapter currently doesn't expand RRULE at all (it ignores `vevent.rrule`). Latent gap unrelated to the 6 issues here — file separately if needed.
- Suggest running `/codex:adversarial-review` and `/simplify` on the final diff before merge (I ran the agent-callable code-reviewer + code-simplifier equivalents and addressed their findings — see commit message).

## Test plan

- [ ] CI green (lint + tsc + 7484 tests)
- [ ] /codex:adversarial-review pass
- [ ] /simplify pass
- [ ] Smoke kennel pages post-merge: hashtracks.xyz/kennels/{knightvillian,moooouston-h3,mosquito-h3,mihi-huha,mooloo-h3} forward count reasonable (≤ 1 year ahead)

Closes #1419
Closes #1692
Closes #1676
Closes #1704
Closes #1663
Closes #1673

🤖 Generated with [Claude Code](https://claude.com/claude-code)