### PR TITLE
kennels: WS7 jargon strip + multi-cadence scheduleRules (#1437, #1438)

### DIFF
--- a/prisma/migrations/20260527021807_kennel_jargon_strip_1437/migration.sql
+++ b/prisma/migrations/20260527021807_kennel_jargon_strip_1437/migration.sql
@@ -35,7 +35,6 @@ BEGIN
       ('rch3',             'Akron''s hash kennel with a 1,000+ member community. Also runs summer Thursday evening trails.'),
       ('lh4-hk',           'Hong Kong''s ladies hash. Weekly Tuesday evening runs with a published hareline showing dates, hares, locations, and on-on venues.'),
       ('tokoroa-h3',       'Founded 1983, restarted 2009 — Waikato''s Tokoroa hash. Seasonal schedule: Wednesday evenings in summer, Sunday afternoons in winter. Trail announcements posted on Facebook.'),
-      ('mooloo-h3',        'Hamilton/Waikato men''s hash. Trail starts shifted to 6:00 PM year-round; runs posted on the kennel website.'),
       ('cfh3',             'Runs on the 1st, 3rd, and 5th Saturday of each month in the Wilmington/Cape Fear area.')
     ) AS x("kennelCode", new_description)
   LOOP

--- a/prisma/migrations/20260527021807_kennel_jargon_strip_1437/migration.sql
+++ b/prisma/migrations/20260527021807_kennel_jargon_strip_1437/migration.sql
@@ -35,7 +35,8 @@ BEGIN
       ('rch3',             'Akron''s hash kennel with a 1,000+ member community. Also runs summer Thursday evening trails.'),
       ('lh4-hk',           'Hong Kong''s ladies hash. Weekly Tuesday evening runs with a published hareline showing dates, hares, locations, and on-on venues.'),
       ('tokoroa-h3',       'Founded 1983, restarted 2009 — Waikato''s Tokoroa hash. Seasonal schedule: Wednesday evenings in summer, Sunday afternoons in winter. Trail announcements posted on Facebook.'),
-      ('mooloo-h3',        'Hamilton/Waikato men''s hash. Trail starts shifted to 6:00 PM year-round; runs posted on the kennel website.')
+      ('mooloo-h3',        'Hamilton/Waikato men''s hash. Trail starts shifted to 6:00 PM year-round; runs posted on the kennel website.'),
+      ('cfh3',             'Runs on the 1st, 3rd, and 5th Saturday of each month in the Wilmington/Cape Fear area.')
     ) AS x("kennelCode", new_description)
   LOOP
     IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = r."kennelCode") THEN
@@ -84,21 +85,93 @@ BEGIN
 END $$;
 
 -- ──────────────────────────────────────────────────────────────────────────
--- #1438 — mosquito-h3 also gets scheduleDayOfWeek/scheduleTime backfill +
--- scheduleFrequency correction ("Bimonthly" → "Biweekly") so the legacy
--- flat-field fallback matches its new scheduleRules (added in seed data).
+-- #1438 — mosquito-h3 legacy flat fields: backfill scheduleDayOfWeek/Time
+-- and correct scheduleFrequency ("Bimonthly" → "Biweekly") so the
+-- fallback display matches the new scheduleRules. Direct assignment
+-- (Gemini review on PR #1725) — these three fields are authoritative
+-- once the kennel has been migrated to scheduleRules, so any stale
+-- non-NULL values must be corrected too.
 -- ──────────────────────────────────────────────────────────────────────────
 
 UPDATE "Kennel"
 SET "scheduleFrequency" = 'Biweekly',
-    "scheduleDayOfWeek" = COALESCE("scheduleDayOfWeek", 'Wednesday'),
-    "scheduleTime"      = COALESCE("scheduleTime",      '6:30 PM'),
+    "scheduleDayOfWeek" = 'Wednesday',
+    "scheduleTime"      = '6:30 PM',
     "updatedAt"         = NOW()
 WHERE "kennelCode" = 'mosquito-h3'
   AND (
     "scheduleFrequency" IS DISTINCT FROM 'Biweekly'
-    OR "scheduleDayOfWeek" IS NULL
-    OR "scheduleTime"      IS NULL
+    OR "scheduleDayOfWeek" IS DISTINCT FROM 'Wednesday'
+    OR "scheduleTime"      IS DISTINCT FROM '6:30 PM'
   );
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- #1438 — INSERT ScheduleRule rows for the two newly-migrated kennels.
+--
+-- Codex review on PR #1725: `runScheduleRuleBackfill` Pass 3 only fires
+-- on `prisma db seed`, which Vercel's `vercel-build` (just
+-- `prisma migrate deploy && next build`) does NOT run. Without these
+-- INSERTs, prod Travel Mode + kennel pages would keep showing the
+-- old Pass-2 rules until someone manually re-seeded.
+--
+-- Mirrors the lbh3/mgh4 inline-insert pattern from migration
+-- 20260525130000_add_lbh3_mgh4_schedule_rules. Idempotent via
+-- deterministic IDs + ON CONFLICT; `runScheduleRuleBackfill` will
+-- find the same (kennelId, rrule, source) keys on the next seed and
+-- ON CONFLICT will absorb without churn.
+-- ──────────────────────────────────────────────────────────────────────────
+
+DO $$
+DECLARE
+  v_missing text[];
+BEGIN
+  SELECT ARRAY_AGG(c) INTO v_missing
+  FROM unnest(ARRAY['mosquito-h3', 'cfh3']) AS c
+  WHERE NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = c);  -- NOSONAR plsql:S1138
+  IF v_missing IS NOT NULL THEN
+    RAISE NOTICE 'Kennels not found: % — ScheduleRule INSERT will no-op for them (run prisma db seed)', v_missing;  -- NOSONAR plsql:S1192
+  END IF;
+END $$;
+
+INSERT INTO "ScheduleRule" (
+  id, "kennelId", rrule, "startTime", confidence, source,
+  "sourceReference", "lastValidatedAt", "isActive", label,
+  "validFrom", "validUntil", "displayOrder", "createdAt", "updatedAt"
+)
+SELECT
+  v.id,
+  k.id,
+  v.rrule,
+  v.start_time,
+  'HIGH'::"ScheduleConfidence",
+  'SEED_DATA'::"ScheduleRuleSource",
+  v.source_ref,
+  NOW(),
+  true,
+  NULL,
+  NULL,
+  NULL,
+  v.display_order,
+  NOW(),
+  NOW()
+FROM (
+  VALUES
+    -- mosquito-h3 — 1st & 3rd Wednesday at 6:30 PM (mirror of larrikins).
+    ('mig_1438_mosquito_1we', 'mosquito-h3', 'FREQ=MONTHLY;BYDAY=1WE', '18:30', 0, 'KennelSeed.scheduleRules[mosquito-h3]'),
+    ('mig_1438_mosquito_3we', 'mosquito-h3', 'FREQ=MONTHLY;BYDAY=3WE', '18:30', 1, 'KennelSeed.scheduleRules[mosquito-h3]'),
+    -- cfh3 — 1st, 3rd, 5th Saturday at 2:00 PM.
+    ('mig_1438_cfh3_1sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=1SA', '14:00', 0, 'KennelSeed.scheduleRules[cfh3]'),
+    ('mig_1438_cfh3_3sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=3SA', '14:00', 1, 'KennelSeed.scheduleRules[cfh3]'),
+    ('mig_1438_cfh3_5sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=5SA', '14:00', 2, 'KennelSeed.scheduleRules[cfh3]')
+) AS v(id, kennel_code, rrule, start_time, display_order, source_ref)
+JOIN "Kennel" k ON k."kennelCode" = v.kennel_code
+ON CONFLICT ("kennelId", rrule, source) DO UPDATE SET
+  "startTime"       = EXCLUDED."startTime",
+  confidence        = EXCLUDED.confidence,
+  "sourceReference" = EXCLUDED."sourceReference",
+  "lastValidatedAt" = EXCLUDED."lastValidatedAt",
+  "isActive"        = true,
+  "displayOrder"    = EXCLUDED."displayOrder",
+  "updatedAt"       = NOW();
 
 COMMIT;

--- a/prisma/migrations/20260527021807_kennel_jargon_strip_1437/migration.sql
+++ b/prisma/migrations/20260527021807_kennel_jargon_strip_1437/migration.sql
@@ -98,7 +98,7 @@ SET "scheduleFrequency" = 'Biweekly',
     "scheduleDayOfWeek" = 'Wednesday',
     "scheduleTime"      = '6:30 PM',
     "updatedAt"         = NOW()
-WHERE "kennelCode" = 'mosquito-h3'
+WHERE "kennelCode" = 'mosquito-h3'  -- NOSONAR plsql:S1192 — same kennel code reused in INSERT block below; deduplication would obscure the row's standalone purpose
   AND (
     "scheduleFrequency" IS DISTINCT FROM 'Biweekly'
     OR "scheduleDayOfWeek" IS DISTINCT FROM 'Wednesday'
@@ -126,7 +126,7 @@ DECLARE
   v_missing text[];
 BEGIN
   SELECT ARRAY_AGG(c) INTO v_missing
-  FROM unnest(ARRAY['mosquito-h3', 'cfh3']) AS c
+  FROM unnest(ARRAY['mosquito-h3', 'cfh3']) AS c  -- NOSONAR plsql:S1192 — kennel codes reused in the INSERT VALUES below; data-row duplication
   WHERE NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = c);  -- NOSONAR plsql:S1138
   IF v_missing IS NOT NULL THEN
     RAISE NOTICE 'Kennels not found: % — ScheduleRule INSERT will no-op for them (run prisma db seed)', v_missing;  -- NOSONAR plsql:S1192
@@ -155,14 +155,16 @@ SELECT
   NOW(),
   NOW()
 FROM (
+  -- VALUES rows duplicate kennel_code / start_time / source_ref by design — each
+  -- row maps one ScheduleRule. SonarCloud plsql:S1192 suppressed per-line.
   VALUES
     -- mosquito-h3 — 1st & 3rd Wednesday at 6:30 PM (mirror of larrikins).
-    ('mig_1438_mosquito_1we', 'mosquito-h3', 'FREQ=MONTHLY;BYDAY=1WE', '18:30', 0, 'KennelSeed.scheduleRules[mosquito-h3]'),
-    ('mig_1438_mosquito_3we', 'mosquito-h3', 'FREQ=MONTHLY;BYDAY=3WE', '18:30', 1, 'KennelSeed.scheduleRules[mosquito-h3]'),
+    ('mig_1438_mosquito_1we', 'mosquito-h3', 'FREQ=MONTHLY;BYDAY=1WE', '18:30', 0, 'KennelSeed.scheduleRules[mosquito-h3]'),  -- NOSONAR plsql:S1192
+    ('mig_1438_mosquito_3we', 'mosquito-h3', 'FREQ=MONTHLY;BYDAY=3WE', '18:30', 1, 'KennelSeed.scheduleRules[mosquito-h3]'),  -- NOSONAR plsql:S1192
     -- cfh3 — 1st, 3rd, 5th Saturday at 2:00 PM.
-    ('mig_1438_cfh3_1sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=1SA', '14:00', 0, 'KennelSeed.scheduleRules[cfh3]'),
-    ('mig_1438_cfh3_3sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=3SA', '14:00', 1, 'KennelSeed.scheduleRules[cfh3]'),
-    ('mig_1438_cfh3_5sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=5SA', '14:00', 2, 'KennelSeed.scheduleRules[cfh3]')
+    ('mig_1438_cfh3_1sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=1SA', '14:00', 0, 'KennelSeed.scheduleRules[cfh3]'),  -- NOSONAR plsql:S1192
+    ('mig_1438_cfh3_3sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=3SA', '14:00', 1, 'KennelSeed.scheduleRules[cfh3]'),  -- NOSONAR plsql:S1192
+    ('mig_1438_cfh3_5sa',     'cfh3',        'FREQ=MONTHLY;BYDAY=5SA', '14:00', 2, 'KennelSeed.scheduleRules[cfh3]')   -- NOSONAR plsql:S1192
 ) AS v(id, kennel_code, rrule, start_time, display_order, source_ref)
 JOIN "Kennel" k ON k."kennelCode" = v.kennel_code
 ON CONFLICT ("kennelId", rrule, source) DO UPDATE SET

--- a/prisma/migrations/20260527021807_kennel_jargon_strip_1437/migration.sql
+++ b/prisma/migrations/20260527021807_kennel_jargon_strip_1437/migration.sql
@@ -1,0 +1,104 @@
+-- #1437 — Kennel description / scheduleNotes jargon strip.
+--
+-- 19 user-facing kennel rows had platform/CMS jargon leaking into the copy
+-- shown on profile cards and directory listings ("Wix-hosted hareline",
+-- "TablePress at ...", "DataTables grid", "Active Meetup group with X
+-- members", "Check Facebook for ...", "static HTML table", etc.).
+-- Rewrites land in prisma/seed-data/kennels.ts and must reach prod via
+-- this migration because `ensureKennelRecords` (prisma/seed.ts) only fills
+-- NULL profile fields on existing rows — it never overwrites populated
+-- ones. See memory: feedback_no_internal_data_in_copy.md +
+-- feedback_seed_fill_coverage_check.md.
+--
+-- Each block gates on IS DISTINCT FROM so re-application is a no-op on an
+-- already-corrected DB. A NOTICE surfaces missing-row situations on
+-- fresh / preview DBs (the next `prisma db seed` will create them).
+
+BEGIN;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Description rewrites
+-- ──────────────────────────────────────────────────────────────────────────
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT * FROM (VALUES
+      ('nose-h3',          'Active weekly kennel in North NJ (north of I-78). Runs flip from Thursdays in summer to Wednesdays in winter.'),
+      ('sfh3',             'The flagship Bay Area kennel (est. 1982). Weekly Monday evening runs in San Francisco. Hosts the sfh3.com Bay Area kennel directory.'),
+      ('lbh3',             'Founded January 6, 1985 by Dal "Jock" Trader, Jerry "Eject" Templeman, and Andy "Zapata" Limon. Runs Thursday evening during Spring/Summer and Sunday morning in the Fall/Winter, often with 50+ attendance. Visitors and virgins always welcome. Also hosts the Southern California kennel directory at lbh3.org/socal.'),
+      ('sdh3',             'San Diego''s flagship kennel. Hosts the sdh3.com directory covering 15+ San Diego area kennels.'),
+      ('lvh3',             'Monthly hash in the Allentown/Bethlehem/Easton area.'),
+      ('sh3-wa',           'Seattle''s flagship kennel. Founded 1983. Hosts wh3.org — the regional schedule for Puget Sound area hashes.'),
+      ('rch3',             'Akron''s hash kennel with a 1,000+ member community. Also runs summer Thursday evening trails.'),
+      ('lh4-hk',           'Hong Kong''s ladies hash. Weekly Tuesday evening runs with a published hareline showing dates, hares, locations, and on-on venues.'),
+      ('tokoroa-h3',       'Founded 1983, restarted 2009 — Waikato''s Tokoroa hash. Seasonal schedule: Wednesday evenings in summer, Sunday afternoons in winter. Trail announcements posted on Facebook.'),
+      ('mooloo-h3',        'Hamilton/Waikato men''s hash. Trail starts shifted to 6:00 PM year-round; runs posted on the kennel website.')
+    ) AS x("kennelCode", new_description)
+  LOOP
+    IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = r."kennelCode") THEN
+      RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', r."kennelCode";  -- NOSONAR plsql:S1192
+    END IF;
+
+    UPDATE "Kennel"
+    SET description = r.new_description,
+        "updatedAt" = NOW()
+    WHERE "kennelCode" = r."kennelCode"
+      AND description IS DISTINCT FROM r.new_description;
+  END LOOP;
+END $$;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- scheduleNotes rewrites
+-- ──────────────────────────────────────────────────────────────────────────
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT * FROM (VALUES
+      ('mia-h3',           'Mostly Thursdays, with occasional special weekend events.'),
+      ('dsh3-atl',         'New moon schedule — dates posted on Facebook.'),
+      ('sh3-au',           'Weekly Tuesday hash around the Sydney metro. Often called ''Posh Hash'' — Sydney''s senior mixed kennel, founded 1967. Trail list posted at sh3.link.'),
+      ('gch3-au',          'Weekly hash around the Gold Coast. Trail list posted on goldcoasthash.org/hareline.'),
+      ('larrikins-au',     'Weekly Tuesday Larrikin Run. Trail list posted on sydney.larrikins.org.'),
+      ('sth3-au',          'Weekly Thursday hash around inner Sydney. Trail list posted on sth3.org/upcoming-runs.'),
+      ('bkk-h3',           'Weekly Saturday runs. Men only.'),
+      ('hibiscus-h3',      'Weekly Monday evenings at 6:30 PM on Auckland''s Hibiscus Coast (Orewa). Trail list posted as a public schedule.'),
+      ('auckland-hussies', 'Weekly Tuesday evenings at 6:30 PM. Run list posted on aucklandhussies.co.nz.')
+    ) AS x("kennelCode", new_notes)
+  LOOP
+    IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = r."kennelCode") THEN
+      RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', r."kennelCode";  -- NOSONAR plsql:S1192
+    END IF;
+
+    UPDATE "Kennel"
+    SET "scheduleNotes" = r.new_notes,
+        "updatedAt"     = NOW()
+    WHERE "kennelCode" = r."kennelCode"
+      AND "scheduleNotes" IS DISTINCT FROM r.new_notes;
+  END LOOP;
+END $$;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- #1438 — mosquito-h3 also gets scheduleDayOfWeek/scheduleTime backfill +
+-- scheduleFrequency correction ("Bimonthly" → "Biweekly") so the legacy
+-- flat-field fallback matches its new scheduleRules (added in seed data).
+-- ──────────────────────────────────────────────────────────────────────────
+
+UPDATE "Kennel"
+SET "scheduleFrequency" = 'Biweekly',
+    "scheduleDayOfWeek" = COALESCE("scheduleDayOfWeek", 'Wednesday'),
+    "scheduleTime"      = COALESCE("scheduleTime",      '6:30 PM'),
+    "updatedAt"         = NOW()
+WHERE "kennelCode" = 'mosquito-h3'
+  AND (
+    "scheduleFrequency" IS DISTINCT FROM 'Biweekly'
+    OR "scheduleDayOfWeek" IS NULL
+    OR "scheduleTime"      IS NULL
+  );
+
+COMMIT;

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1336,7 +1336,7 @@ export const KENNELS: KennelSeed[] = [
       ],
       scheduleNotes: "1st, 3rd, and 5th Saturdays, 2:00 PM.",
       hashCash: "$5", foundedYear: 2006,
-      description: "Biweekly Saturday runs in the Wilmington/Cape Fear area.",
+      description: "Runs on the 1st, 3rd, and 5th Saturday of each month in the Wilmington/Cape Fear area.",
       latitude: 34.24, longitude: -77.95,
     },
     // --- Fayetteville ---

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -317,7 +317,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleNotes: "Summer (May–Oct): Thursdays 7pm. Winter (Nov–Apr): Wednesdays 7pm.",
       facebookUrl: "https://www.facebook.com/groups/NOSEHash",
       contactEmail: "anallickitall@gmail.com",
-      description: "Active weekly kennel in North NJ (north of I-78). Facebook-only presence; runs flip from Thursdays in summer to Wednesdays in winter.",
+      description: "Active weekly kennel in North NJ (north of I-78). Runs flip from Thursdays in summer to Wednesdays in winter.",
     },
     {
       kennelCode: "rumson", shortName: "Rumson", fullName: "Rumson Hash House Harriers", region: "New Jersey",
@@ -588,7 +588,7 @@ export const KENNELS: KennelSeed[] = [
       twitterHandle: "sfh3",
       discordUrl: "https://discord.gg/eGRZMFfHtC",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:15 PM", scheduleFrequency: "Weekly",
-      description: "The flagship Bay Area kennel (est. 1982). Weekly Monday evening runs in San Francisco. Hosts the sfh3.com aggregator platform.",
+      description: "The flagship Bay Area kennel (est. 1982). Weekly Monday evening runs in San Francisco. Hosts the sfh3.com Bay Area kennel directory.",
     },
     {
       kennelCode: "gph3", shortName: "GPH3", fullName: "Gypsies in the Palace Hash House Harriers", region: "San Francisco, CA",
@@ -716,7 +716,7 @@ export const KENNELS: KennelSeed[] = [
       contactEmail: "contact@lbh3.org",
       logoUrl: "/kennel-logos/lbh3.png",
       foundedYear: 1985,
-      description: "Founded January 6, 1985 by Dal \"Jock\" Trader, Jerry \"Eject\" Templeman, and Andy \"Zapata\" Limon. Runs Thursday evening during Spring/Summer and Sunday morning in the Fall/Winter, often with 50+ attendance. Visitors and virgins always welcome. Hash cash is $5 via cash or Venmo. Also hosts the SoCal calendar aggregator at lbh3.org/socal.",
+      description: "Founded January 6, 1985 by Dal \"Jock\" Trader, Jerry \"Eject\" Templeman, and Andy \"Zapata\" Limon. Runs Thursday evening during Spring/Summer and Sunday morning in the Fall/Winter, often with 50+ attendance. Visitors and virgins always welcome. Also hosts the Southern California kennel directory at lbh3.org/socal.",
       latitude: 33.77, longitude: -118.19,
     },
     {
@@ -768,7 +768,7 @@ export const KENNELS: KennelSeed[] = [
       website: "https://sdh3.com",
       scheduleDayOfWeek: "Friday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Also biweekly Sunday 10am",
-      hashCash: "$10", description: "San Diego's flagship kennel. Hosts the sdh3.com multi-kennel hareline aggregator covering 15+ SD area kennels.",
+      hashCash: "$10", description: "San Diego's flagship kennel. Hosts the sdh3.com directory covering 15+ San Diego area kennels.",
       latitude: 32.72, longitude: -117.16,
     },
     {
@@ -1125,7 +1125,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly", scheduleTime: "12:00 PM",
       scheduleNotes: "3rd Saturday monthly. Sub-kennels on other days.",
       hashCash: "$5",
-      description: "Monthly hash in the Allentown/Bethlehem/Easton area. Check the LVH3 Facebook page for the latest details.",
+      description: "Monthly hash in the Allentown/Bethlehem/Easton area.",
       latitude: 40.60, longitude: -75.49,
     },
     // --- Reading ---
@@ -1326,7 +1326,14 @@ export const KENNELS: KennelSeed[] = [
       logoUrl: "/kennel-logos/cfh3.png",
       facebookUrl: "https://www.facebook.com/CapeFearH3/",
       contactEmail: "capefearh3@gmail.com",
+      // Legacy flat fields kept for fallback only — scheduleRules below are
+      // authoritative for display + Travel Mode (#1438 multi-cadence migration).
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Biweekly", scheduleTime: "2:00 PM",
+      scheduleRules: [
+        { rrule: "FREQ=MONTHLY;BYDAY=1SA", startTime: "14:00", displayOrder: 0 },
+        { rrule: "FREQ=MONTHLY;BYDAY=3SA", startTime: "14:00", displayOrder: 1 },
+        { rrule: "FREQ=MONTHLY;BYDAY=5SA", startTime: "14:00", displayOrder: 2 },
+      ],
       scheduleNotes: "1st, 3rd, and 5th Saturdays, 2:00 PM.",
       hashCash: "$5", foundedYear: 2006,
       description: "Biweekly Saturday runs in the Wilmington/Cape Fear area.",
@@ -1396,7 +1403,16 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "mosquito-h3", shortName: "Mosquito H3", fullName: "Mosquito Hash House Harriers", region: "Houston, TX",
       facebookUrl: "https://www.facebook.com/groups/MosquitoH3/",
       hashCash: "$5 USD",
-      scheduleFrequency: "Bimonthly", scheduleNotes: "1st & 3rd Wednesdays, 6:30 PM",
+      // Legacy flat fields kept for fallback only — scheduleRules below are
+      // authoritative for display + Travel Mode (#1438 multi-cadence migration).
+      // scheduleFrequency corrected "Bimonthly" → "Biweekly" (1st & 3rd Wed
+      // is twice-monthly, not every-other-month).
+      scheduleDayOfWeek: "Wednesday", scheduleTime: "6:30 PM", scheduleFrequency: "Biweekly",
+      scheduleRules: [
+        { rrule: "FREQ=MONTHLY;BYDAY=1WE", startTime: "18:30", displayOrder: 0 },
+        { rrule: "FREQ=MONTHLY;BYDAY=3WE", startTime: "18:30", displayOrder: 1 },
+      ],
+      scheduleNotes: "1st & 3rd Wednesdays, 6:30 PM.",
       description: "Mosquito H3 runs on the first and third Wednesdays of the month on the west side of Houston, with trails outside Beltway 8 typically 3-4 miles in length and including shiggy.",
       latitude: 29.79, longitude: -95.76,
     },
@@ -1522,7 +1538,7 @@ export const KENNELS: KennelSeed[] = [
       instagramHandle: "miami_h3",
       contactEmail: "miamihashhouseharriers@gmail.com",
       scheduleDayOfWeek: "Thursday", scheduleFrequency: "Weekly", scheduleTime: "6:30 PM",
-      scheduleNotes: "Mostly Thursdays but sometimes on weekends — see Facebook for special weekend events.",
+      scheduleNotes: "Mostly Thursdays, with occasional special weekend events.",
       hashCash: "$5",
       logoUrl: "/kennel-logos/mia-h3.jpg",
       description: "Weekly Thursday runs in the Miami/Dade County area.",
@@ -1827,7 +1843,7 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "dsh3-atl", shortName: "Dark Side H3", fullName: "Dark Side Hash House Harriers", region: "Atlanta, GA",
-      scheduleNotes: "New moon schedule — check Facebook for dates.",
+      scheduleNotes: "New moon schedule — dates posted on Facebook.",
       description: "New moon trail runs in Atlanta. Schedule follows lunar calendar.",
     },
     // --- Savannah (update existing SavH3 — region fix + profile enrichment) ---
@@ -2089,7 +2105,7 @@ export const KENNELS: KennelSeed[] = [
       facebookUrl: "https://www.facebook.com/groups/25456554474/",
       scheduleDayOfWeek: "Saturday", scheduleTime: "2:00 PM", scheduleFrequency: "Biweekly",
       scheduleNotes: "2nd and 4th Saturday",
-      description: "Seattle's flagship kennel. Founded 1983. Hosts the wh3.org regional aggregator for all Puget Sound area hashes.",
+      description: "Seattle's flagship kennel. Founded 1983. Hosts wh3.org — the regional schedule for Puget Sound area hashes.",
       latitude: 47.61, longitude: -122.33,
     },
     {
@@ -2493,7 +2509,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Biweekly", scheduleTime: "3:00 PM",
       scheduleNotes: "2nd & 4th Saturday 3 PM + 1st & 3rd Thursday 6:30 PM (summer).",
       hashCash: "$15", foundedYear: 2004,
-      description: "Akron's hash kennel with 1,000+ Meetup members. Also runs summer Thursday evening trails.",
+      description: "Akron's hash kennel with a 1,000+ member community. Also runs summer Thursday evening trails.",
       latitude: 41.08, longitude: -81.52,
     },
     // --- Columbus ---
@@ -3444,7 +3460,7 @@ export const KENNELS: KennelSeed[] = [
       region: "Sydney, NSW", country: "Australia",
       website: "https://www.sh3.link",
       scheduleDayOfWeek: "Tuesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Weekly Tuesday hash around the Sydney metro. Often called 'Posh Hash' — Sydney's senior mixed kennel, founded 1967. Hareline published as labelled paragraphs at sh3.link/?page_id=9470.",
+      scheduleNotes: "Weekly Tuesday hash around the Sydney metro. Often called 'Posh Hash' — Sydney's senior mixed kennel, founded 1967. Trail list posted at sh3.link.",
       foundedYear: 1967,
       description: "Sydney's senior mixed hash kennel, founded in 1967. Runs every Tuesday evening across the Sydney metro and northern beaches. Known affectionately as 'Posh Hash'.",
       latitude: -33.8688, longitude: 151.2093,
@@ -3470,7 +3486,7 @@ export const KENNELS: KennelSeed[] = [
       facebookUrl: "https://www.facebook.com/groups/gch3thegourmehash",
       logoUrl: "https://www.goldcoasthash.org/wp-content/uploads/The-Royal-Header1.png",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:00 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Weekly hash around the Gold Coast. Hareline published via TablePress at goldcoasthash.org/hareline.",
+      scheduleNotes: "Weekly hash around the Gold Coast. Trail list posted on goldcoasthash.org/hareline.",
       foundedYear: 1978,
       description: "The Gourmet Hash — Gold Coast's men-only Hash kennel in Queensland, established 1978. Runs every Monday night, wet or fine, starting at 6:00 pm.",
       latitude: -28.0167, longitude: 153.4000,
@@ -3481,7 +3497,7 @@ export const KENNELS: KennelSeed[] = [
       website: "https://sydney.larrikins.org",
       logoUrl: "https://sydney.larrikins.org/wp-content/uploads/2022/09/Larrikins-S2H4-Logo-transparent.gif",
       scheduleDayOfWeek: "Tuesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Weekly Tuesday Larrikin Run. Hareline published as a server-side DataTables grid at sydney.larrikins.org.",
+      scheduleNotes: "Weekly Tuesday Larrikin Run. Trail list posted on sydney.larrikins.org.",
       description: "Sydney South Harbour HHH 'Larrikins' — the Tuesday Beers chapter. Weekly Tuesday runs around southern Sydney, currently around Run #2492+.",
       latitude: -33.8688, longitude: 151.2093,
     },
@@ -3490,7 +3506,7 @@ export const KENNELS: KennelSeed[] = [
       region: "Sydney, NSW", country: "Australia",
       website: "https://www.sth3.org",
       scheduleDayOfWeek: "Thursday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Weekly Thursday hash around inner Sydney. Hareline published as paragraph blocks (em-dash separated) at sth3.org/upcoming-runs.",
+      scheduleNotes: "Weekly Thursday hash around inner Sydney. Trail list posted on sth3.org/upcoming-runs.",
       description: "Sydney Thirsty H3 — the Thursday inner-city kennel. Weekly Thursday evening runs around Redfern, Camperdown, and the inner suburbs. Currently around Run #1842+.",
       latitude: -33.8688, longitude: 151.2093,
     },
@@ -3650,7 +3666,7 @@ export const KENNELS: KennelSeed[] = [
       region: "Hong Kong", country: "Hong Kong",
       website: "https://hkladiesh4.wixsite.com/hklh4",
       scheduleDayOfWeek: "Tuesday", scheduleTime: "6:45 PM", scheduleFrequency: "Weekly",
-      description: "Hong Kong's ladies hash. Weekly Tuesday evening runs with a Wix-hosted hareline showing dates, hares, locations and on-on venues.",
+      description: "Hong Kong's ladies hash. Weekly Tuesday evening runs with a published hareline showing dates, hares, locations, and on-on venues.",
       latitude: 22.2800, longitude: 114.1600,
     },
     {
@@ -3905,7 +3921,7 @@ export const KENNELS: KennelSeed[] = [
       website: "https://www.bangkokhhh.org",
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Weekly",
       scheduleTime: "5:00 PM",
-      scheduleNotes: "Weekly Saturday runs. Men only. Wix-hosted site requires browser rendering.",
+      scheduleNotes: "Weekly Saturday runs. Men only.",
       description: "Bangkok's Saturday hash, men only. Runs on the outskirts of the city or nearby countryside.",
       latitude: 13.76, longitude: 100.5,
     },
@@ -4043,7 +4059,7 @@ export const KENNELS: KennelSeed[] = [
       website: "https://www.edmondsfamily.co.nz/community/hibiscus-hhh",
       foundedYear: 1987,
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Weekly Monday evenings at 6:30 PM on Auckland's Hibiscus Coast (Orewa). Hareline published as a public Google Sheet.",
+      scheduleNotes: "Weekly Monday evenings at 6:30 PM on Auckland's Hibiscus Coast (Orewa). Trail list posted as a public schedule.",
       description: "Hibiscus Coast hash kennel covering Orewa, Whangaparaoa, and the northern Auckland coast. Weekly Monday evening trails since 1987. No fees, no committee — an optional post-run meal and drinks are pay-as-you-go.",
       latitude: -36.5868, longitude: 174.6968,
     },
@@ -4054,7 +4070,7 @@ export const KENNELS: KennelSeed[] = [
       foundedYear: 1983,
       scheduleFrequency: "Weekly",
       scheduleNotes: "Dual schedule: Wednesday 6pm during NZ daylight savings (Oct–Mar), Sunday 4pm in winter (Apr–Sep). Trail start locations posted on Facebook each week.",
-      description: "Founded 1983, restarted 2009 — Waikato's Tokoroa hash. Seasonal schedule: Wednesday evenings in summer, Sunday afternoons in winter. Active Facebook page with trail announcements.",
+      description: "Founded 1983, restarted 2009 — Waikato's Tokoroa hash. Seasonal schedule: Wednesday evenings in summer, Sunday afternoons in winter. Trail announcements posted on Facebook.",
       latitude: -38.223, longitude: 175.8627,
     },
     {
@@ -4075,7 +4091,7 @@ export const KENNELS: KennelSeed[] = [
       contactEmail: "trailmaster@aucklandhussies.co.nz",
       foundedYear: 1978,
       scheduleDayOfWeek: "Tuesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Weekly Tuesday evenings at 6:30 PM. Run list published as a static HTML table at /Run%20List.html.",
+      scheduleNotes: "Weekly Tuesday evenings at 6:30 PM. Run list posted on aucklandhussies.co.nz.",
       description: "Auckland's women-founded hash, established 1978. Weekly Tuesday evening trails across Auckland with a published run list. Mixed attendance though women-led. Hash cash is $15 when starting from home or a park (pay-as-you-go at restaurants and pubs), plus $5 for drinks.",
       latitude: -36.8485, longitude: 174.7633,
     },


### PR DESCRIPTION
WS7 deep dive — catch-up audit pass on `prisma/seed-data/kennels.ts` after ~5 cycles deferred.

Closes #1437
Closes #1438

---

## #1437 — Jargon Sweep (19 rows)

Strip platform/CMS jargon from `description` / `scheduleNotes` and rewrite as user-facing prose. Voice mirrors PR #1485.

### Before / after examples

| Kennel | Before | After |
|---|---|---|
| `gch3-au` | "Hareline published via TablePress at goldcoasthash.org/hareline." | "Trail list posted on goldcoasthash.org/hareline." |
| `lh4-hk` | "Weekly Tuesday evening runs with a Wix-hosted hareline showing dates, hares, locations and on-on venues." | "Weekly Tuesday evening runs with a published hareline showing dates, hares, locations, and on-on venues." |
| `auckland-hussies` | "Weekly Tuesday evenings at 6:30 PM. Run list published as a static HTML table at /Run%20List.html." | "Weekly Tuesday evenings at 6:30 PM. Run list posted on aucklandhussies.co.nz." |
| `larrikins-au` | "Hareline published as a server-side DataTables grid at sydney.larrikins.org." | "Trail list posted on sydney.larrikins.org." |
| `rch3` (Akron) | "Akron's hash kennel with 1,000+ Meetup members. Also runs summer Thursday evening trails." | "Akron's hash kennel with a 1,000+ member community. Also runs summer Thursday evening trails." |

### Full list of rewritten rows (10 descriptions + 9 scheduleNotes = 19 total)

**Descriptions:** `nose-h3`, `sfh3`, `lbh3`, `sdh3`, `lvh3`, `sh3-wa`, `rch3`, `lh4-hk`, `tokoroa-h3`, `mooloo-h3`

**scheduleNotes:** `mia-h3`, `dsh3-atl`, `sh3-au`, `gch3-au`, `larrikins-au`, `sth3-au`, `bkk-h3`, `hibiscus-h3`, `auckland-hussies`

### Migration

Per memory `feedback_seed_fill_coverage_check.md` + the #1507 / #1525 / #1532 precedent: `ensureKennelRecords` (prisma/seed.ts:296) only fills NULL profile fields, so seed-only description edits never reach prod for existing rows. Companion migration `20260527021807_kennel_jargon_strip_1437` UPDATEs the 19 rows directly. Idempotent via `IS DISTINCT FROM`; tested locally — second run is a no-op (UPDATE 0).

---

## #1438 — Multi-Cadence Migration (2 kennels)

Migrated 2 obvious multi-cadence kennels to structured `scheduleRules`:

| Kennel | Rules | Notes |
|---|---|---|
| `mosquito-h3` | 1st & 3rd Wed @ 6:30 PM (2 rules) | Mirror of larrikins. Also fixes mislabelled `scheduleFrequency: "Bimonthly"` → `"Biweekly"`. |
| `cfh3` | 1st, 3rd, 5th Sat @ 2:00 PM (3 rules) | Three-rule monthly-by-Nth-weekday pattern. |

Pass-3 SEED_DATA backfill now reports **7 kennels with scheduleRules, 14 rules total** (5 pre-existing + 2 new).

### Originally planned but reverted

`chh3` and `colh3` hit a real schema gap: both have **same rrule, different startTime per season** (`BYDAY=2SA` at 14:00 winter / 16:00 summer). The `@@unique([kennelId, rrule, source])` constraint causes the second time to silently overwrite the first on upsert. Reverted both — see #1723.

### Deferred to cycle-14+ follow-ups

- **#1723** — scheduleRules schema gap: support same-rrule different-startTime per season (chh3 + colh3).
- **#1724** — 10-kennel defer queue with classification: `psh3`, `wrong-way`, `cleh4`, `rch3`, `cch3`, `oth4`, `norfolkh3`, `dcfmh3`, `indyh3`, `hrh3`.

---

## Verification

- ✅ `npm run prisma -- db seed` runs clean against local dev DB (hashtracks_dev)
- ✅ Migration applies cleanly via `prisma migrate deploy` to local DB; re-application is a no-op (`UPDATE 0`)
- ✅ Pass-3 SEED_DATA upsert correctly identifies 7 kennels (5 pre-existing + 2 new) and plans 14 rules; mosquito-h3 has 2 active rules, cfh3 has 3
- ✅ `npx tsc --noEmit` clean
- ✅ `npm run lint` — 0 errors, 22 warnings (all pre-existing, unrelated)
- ✅ `npm test` — 269 test files / 7479 tests passed

### Pre-PR reviews

- `/codex:adversarial-review` flagged 2 P1s + 1 P2; the 2 P1s were addressed before commit (broadened the mosquito-h3 fallback UPDATE gate to fire on any NULL field, not just stale frequency; softened the mooloo-h3 "weekly newsletter" claim to "posted on the kennel website" since the cadence wasn't verified). P2 (lvh3 terseness) accepted as-is — row still has `facebookUrl` for navigation.
- Simplifier pass: nothing worth changing — migration shape, comments, and section bars are load-bearing.

## Test plan

- [ ] CI: lint + tsc + vitest green
- [ ] Vercel preview: spot-check `/kennels/{slug}` for `gch3-au`, `lh4-hk`, `auckland-hussies` — confirm descriptions read naturally with no platform jargon
- [ ] After merge: run `prisma db seed` against staging to confirm Pass-3 rules persist; verify mosquito-h3 / cfh3 show 1st & 3rd Wed / 1st-3rd-5th Sat in their schedule block

🤖 Generated with [Claude Code](https://claude.com/claude-code)