### PR TITLE
fix(cycle-12): quick-win bundle — 9 deferred parse + audit finds

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -460,6 +460,13 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "sth3-au": ["Sydney Thirsty H3", "Sydney Thirsty", "Thirsty H3", "Thirsty Hash", "STH3", "Sydney Thirsty Hash House Harriers"],
     // Australia — Victoria
     "mel-new-moon": ["Melbourne New Moon H3", "Melbourne New Moon", "New Moon H3 Melbourne", "MNMH3", "Melbourne Moon Hash"],
+    // #1617 — Melbourne sibling kennels routed off the shared Mel-NM Meetup
+    // aggregator. Aliases drawn from the actual title prefixes observed in
+    // the 256-event corpus surveyed in the issue body.
+    "melbourne-full-moon": ["Melbourne Full Moon H3", "Melbourne Full Moon HHH", "Melbourne FMH3", "Full Moon Run", "Mel Full Moon"],
+    "delinquents-hhh": ["Delinquents HHH", "Delinquents H3", "Melbourne Delinquents", "Delinquent Hash"],
+    "melbourne-city-h3": ["Melbourne City H3", "Melbourne City Hash", "Mel City H3", "City Hash Melbourne", "City Hash Beer Marathon"],
+    "melbourne-bike-hash": ["Melbourne Bike Hash", "Mel Bike Hash", "Bike Hash Ride", "Melbourne Bike H3"],
     // Malaysia Phase 2 — Historic Regionals
     "kuching-h3": ["Kuching H3", "Kuching Hash", "Kuching HHH", "KuchingH3"],
     "kk-h3": ["KK H3", "Kota Kinabalu H3", "KK Hash", "Kota Kinabalu Hash", "KKH3"],

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3500,7 +3500,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "melbourne-city-h3", shortName: "Melbourne City H3", fullName: "Melbourne City Hash House Harriers",
       region: "Melbourne, VIC", country: "Australia",
-      website: "http://melctyhhh.org",
+      website: "https://melctyhhh.org",
       scheduleDayOfWeek: "Thursday", scheduleFrequency: "Biweekly",
       scheduleNotes: "Twice a month on Thursdays, within 10km of the Melbourne CBD (per Mel-NM Meetup About). Stub pending full research.",
       description: "Melbourne City H3 — sister kennel to Melbourne New Moon. Publishes through the melbourne-new-moon-running-group Meetup aggregator. Profile is a stub pending full research.",

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3475,6 +3475,45 @@ export const KENNELS: KennelSeed[] = [
       description: "Melbourne New Moon HHH — Melbourne's city-runners new-moon kennel. A drinking club with a running problem: each run is a mystery fun run, with a known start but trail marks leading you somewhere unknown (beware false trails). Hash cash is $5 to cover the circle beers.",
       latitude: -37.8136, longitude: 144.9631,
     },
+    // #1617 — Melbourne sibling kennels that publish through the Mel-NM
+    // Meetup aggregator (melbourne-new-moon-running-group). Stubs with
+    // minimal data; full enrichment (founded year, schedule cadence,
+    // socials) belongs to a follow-up AU research pass. See
+    // `reference_hhh_asn_au_directory` memory for the discovery surface.
+    {
+      kennelCode: "melbourne-full-moon", shortName: "Melbourne Full Moon", fullName: "Melbourne Full Moon Hash House Harriers",
+      region: "Melbourne, VIC", country: "Australia",
+      website: "https://sites.google.com/view/melbournefullmoonhash",
+      scheduleFrequency: "Monthly",
+      scheduleNotes: "Posted via Melbourne New Moon Meetup aggregator — full cadence TBD (stub).",
+      description: "Melbourne Full Moon HHH — the New Moon HHH's country cousin (per the aggregator Meetup About). Events publish through the melbourne-new-moon-running-group Meetup. Profile is a stub pending full research.",
+      latitude: -37.8136, longitude: 144.9631,
+    },
+    {
+      kennelCode: "delinquents-hhh", shortName: "Delinquents HHH", fullName: "Delinquents Hash House Harriers",
+      region: "Melbourne, VIC", country: "Australia",
+      scheduleFrequency: "Weekly",
+      scheduleNotes: "Posted via Melbourne New Moon Meetup aggregator — full schedule TBD (stub).",
+      description: "Delinquents HHH — Melbourne sibling kennel that publishes via the melbourne-new-moon-running-group Meetup aggregator. Profile is a stub pending full research.",
+      latitude: -37.8136, longitude: 144.9631,
+    },
+    {
+      kennelCode: "melbourne-city-h3", shortName: "Melbourne City H3", fullName: "Melbourne City Hash House Harriers",
+      region: "Melbourne, VIC", country: "Australia",
+      website: "http://melctyhhh.org",
+      scheduleDayOfWeek: "Thursday", scheduleFrequency: "Biweekly",
+      scheduleNotes: "Twice a month on Thursdays, within 10km of the Melbourne CBD (per Mel-NM Meetup About). Stub pending full research.",
+      description: "Melbourne City H3 — sister kennel to Melbourne New Moon. Publishes through the melbourne-new-moon-running-group Meetup aggregator. Profile is a stub pending full research.",
+      latitude: -37.8136, longitude: 144.9631,
+    },
+    {
+      kennelCode: "melbourne-bike-hash", shortName: "Melbourne Bike Hash", fullName: "Melbourne Bike Hash",
+      region: "Melbourne, VIC", country: "Australia",
+      scheduleFrequency: "Weekly",
+      scheduleNotes: "Cycling sub-group that publishes via the melbourne-new-moon-running-group Meetup aggregator. Stub pending full research.",
+      description: "Melbourne Bike Hash — a bike-hash variant operating in the Melbourne New Moon ecosystem. Publishes through the melbourne-new-moon-running-group Meetup. Profile is a stub pending full research.",
+      latitude: -37.8136, longitude: 144.9631,
+    },
     // ===== MALAYSIA Phase 2 — Historic Regional kennels =====
     {
       // #1535: schedule strings, description, founder, and facebookUrl are

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1767,7 +1767,7 @@ export const SOURCES = [
       kennelCodes: ["augh3"],
     },
     {
-      name: "MGH4 Static Schedule",
+      name: "MGH4 Static Schedule (Biweekly Saturday)",
       url: "https://www.facebook.com/groups/middlegeorgiahash",
       type: "STATIC_SCHEDULE" as const,
       trustLevel: 3,
@@ -1778,9 +1778,31 @@ export const SOURCES = [
         rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA",
         anchorDate: "2026-03-07",
         startTime: "14:00",
-        defaultTitle: "MGH4 Biweekly Run",
+        defaultTitle: "MGH4 Alternate Saturday Run",
         defaultLocation: "Macon, GA",
         defaultDescription: "Alternate Saturday trail. Check Facebook for start location.",
+      },
+      kennelCodes: ["mgh4"],
+    },
+    {
+      // #1620: MGH4 advertises "Every Wednesday, every other Saturday" on
+      // HashRego but only the Saturday cadence was previously seeded — the
+      // entire Wednesday stream was missing from production. Split-row pattern
+      // mirrors Mosquito H3 Static Schedule (1st Wed) / (3rd Wed).
+      name: "MGH4 Static Schedule (Weekly Wednesday)",
+      url: "https://www.facebook.com/groups/middlegeorgiahash",
+      type: "STATIC_SCHEDULE" as const,
+      trustLevel: 3,
+      scrapeFreq: "weekly",
+      scrapeDays: 90,
+      config: {
+        kennelTag: "mgh4",
+        rrule: "FREQ=WEEKLY;BYDAY=WE",
+        anchorDate: "2026-03-04",
+        startTime: "18:30",
+        defaultTitle: "MGH4 Weekly Wednesday Run",
+        defaultLocation: "Macon, GA",
+        defaultDescription: "Weekly Wednesday evening trail. Check Facebook for start location.",
       },
       kennelCodes: ["mgh4"],
     },
@@ -4295,7 +4317,11 @@ export const SOURCES = [
     },
 
     // ===== AUSTRALIA — Victoria =====
-    // Melbourne New Moon H3 — Meetup source (existing adapter handles it)
+    // Melbourne New Moon H3 — Meetup source (aggregator hosting 5 sibling
+    // kennels per #1617). Patterns route per the title-prefix breakdown in
+    // the issue body. Order is most-specific-first (mel-new-moon's
+    // explicit "Melbourne New Moon" prefix wins over a bare "Run No."
+    // catch-all). Anything that doesn't match falls back to `kennelTag`.
     {
       name: "Melbourne New Moon Meetup",
       url: "https://www.meetup.com/melbourne-new-moon-running-group/",
@@ -4306,8 +4332,31 @@ export const SOURCES = [
       config: {
         groupUrlname: "melbourne-new-moon-running-group",
         kennelTag: "mel-new-moon",
+        kennelPatterns: [
+          // Mel-NM's own runs — anchor "Melbourne New Moon" so a bare
+          // "New Moon" prefix elsewhere doesn't shadow it.
+          ["^\\s*Melbourne\\s+New\\s+Moon\\b", "mel-new-moon"],
+          // Melbourne City H3 — match both "City Hash" prefix variants.
+          ["^\\s*(?:Melbourne\\s+)?City\\s+Hash\\b", "melbourne-city-h3"],
+          // Bike Hash — "Bike hash ride #N" / "Ride #N" patterns. The
+          // anchored "Bike Hash" form is unambiguous; a bare "Ride #N"
+          // is left to the default to avoid eating legit run names.
+          ["^\\s*Bike\\s+hash\\b", "melbourne-bike-hash"],
+          // Delinquents HHH — "Delinquents HHH No.N" form.
+          ["^\\s*Delinquents\\s+HHH\\b", "delinquents-hhh"],
+          // Melbourne Full Moon — "Full Moon Run No.N" form. Routed
+          // after Mel-NM so the more-specific "Melbourne New Moon"
+          // pattern wins on collision.
+          ["^\\s*Full\\s+Moon\\s+Run\\b", "melbourne-full-moon"],
+        ],
       },
-      kennelCodes: ["mel-new-moon"],
+      kennelCodes: [
+        "mel-new-moon",
+        "melbourne-full-moon",
+        "delinquents-hhh",
+        "melbourne-city-h3",
+        "melbourne-bike-hash",
+      ],
     },
 
     // ===== MALAYSIA Phase 2 — Historic Regional STATIC_SCHEDULE kennels =====

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4335,19 +4335,19 @@ export const SOURCES = [
         kennelPatterns: [
           // Mel-NM's own runs — anchor "Melbourne New Moon" so a bare
           // "New Moon" prefix elsewhere doesn't shadow it.
-          ["^\\s*Melbourne\\s+New\\s+Moon\\b", "mel-new-moon"],
+          [String.raw`^\s*Melbourne\s+New\s+Moon\b`, "mel-new-moon"],
           // Melbourne City H3 — match both "City Hash" prefix variants.
-          ["^\\s*(?:Melbourne\\s+)?City\\s+Hash\\b", "melbourne-city-h3"],
+          [String.raw`^\s*(?:Melbourne\s+)?City\s+Hash\b`, "melbourne-city-h3"],
           // Bike Hash — "Bike hash ride #N" / "Ride #N" patterns. The
           // anchored "Bike Hash" form is unambiguous; a bare "Ride #N"
           // is left to the default to avoid eating legit run names.
-          ["^\\s*Bike\\s+hash\\b", "melbourne-bike-hash"],
+          [String.raw`^\s*Bike\s+hash\b`, "melbourne-bike-hash"],
           // Delinquents HHH — "Delinquents HHH No.N" form.
-          ["^\\s*Delinquents\\s+HHH\\b", "delinquents-hhh"],
+          [String.raw`^\s*Delinquents\s+HHH\b`, "delinquents-hhh"],
           // Melbourne Full Moon — "Full Moon Run No.N" form. Routed
           // after Mel-NM so the more-specific "Melbourne New Moon"
           // pattern wins on collision.
-          ["^\\s*Full\\s+Moon\\s+Run\\b", "melbourne-full-moon"],
+          [String.raw`^\s*Full\s+Moon\s+Run\b`, "melbourne-full-moon"],
         ],
       },
       kennelCodes: [

--- a/scripts/cleanup-bawc5-marin-orphan.ts
+++ b/scripts/cleanup-bawc5-marin-orphan.ts
@@ -51,7 +51,12 @@ async function main() {
     return;
   }
 
-  const umbrella = await prisma.event.findFirst({
+  // findMany + exactly-one check (instead of findFirst) — Prisma's findFirst
+  // doesn't guarantee deterministic ordering without an orderBy, so on the
+  // off chance the predicate matched 2+ rows we'd silently bind to whichever
+  // one happened to come first. For a write script, fail closed when the
+  // anchor isn't unambiguous. CodeRabbit review on this PR.
+  const umbrellas = await prisma.event.findMany({
     where: {
       kennelId: sfh3Kennel.id,
       isSeriesParent: true,
@@ -59,19 +64,26 @@ async function main() {
     },
     select: { id: true, title: true, date: true },
   });
-  if (!umbrella) {
-    console.error(`BAWC5 umbrella Event not found in SFH3 between ${UMBRELLA_DATE_LO.toISOString()} and ${UMBRELLA_DATE_HI.toISOString()}. Aborting.`);
+  if (umbrellas.length !== 1) {
+    console.error(
+      `Expected exactly 1 BAWC5 umbrella Event in SFH3 between ${UMBRELLA_DATE_LO.toISOString()} and ${UMBRELLA_DATE_HI.toISOString()}, found ${umbrellas.length}. Aborting.`,
+    );
+    if (umbrellas.length > 1) {
+      for (const u of umbrellas) {
+        console.error(`  candidate: ${u.id}  ${u.date.toISOString().slice(0, 10)}  ${JSON.stringify(u.title)}`);
+      }
+    }
     process.exitCode = 1;
     return;
   }
+  const umbrella = umbrellas[0];
   console.log(`Umbrella: ${umbrella.id}  ${umbrella.date.toISOString().slice(0, 10)}  ${JSON.stringify(umbrella.title)}`);
 
   // Marin #292 on 2026-06-20. Strict (kennelId + runNumber + exact date)
-  // match — no date-window fallback. A write script should fail closed
-  // when the anchor row is missing rather than silently auto-pick from a
-  // multi-row date window (Codex review on the original draft).
+  // match — no date-window fallback, fail closed when not exactly one row
+  // matches (a write script should never auto-pick from an ambiguous set).
   const marinDateEnd = new Date(MARIN_DATE.getTime() + 86_400_000 - 1);
-  const marin = await prisma.event.findFirst({
+  const marins = await prisma.event.findMany({
     where: {
       kennelId: marinKennel.id,
       runNumber: MARIN_RUN_NUMBER,
@@ -79,15 +91,20 @@ async function main() {
     },
     select: { id: true, title: true, date: true, parentEventId: true, runNumber: true },
   });
-  if (!marin) {
+  if (marins.length !== 1) {
     console.error(
-      `Marin H3 #${MARIN_RUN_NUMBER} Event not found on ${MARIN_DATE.toISOString().slice(0, 10)}. ` +
-        "Refusing to auto-pick a different Marin event by date alone. " +
-        "Investigate manually (RawEvent state, possible kennel rename) and re-run with the correct anchor.",
+      `Expected exactly 1 Marin H3 #${MARIN_RUN_NUMBER} Event on ${MARIN_DATE.toISOString().slice(0, 10)}, found ${marins.length}. ` +
+        "Refusing to auto-pick. Investigate manually (RawEvent state, possible kennel rename) and re-run with the correct anchor.",
     );
+    if (marins.length > 1) {
+      for (const m of marins) {
+        console.error(`  candidate: ${m.id}  ${m.date.toISOString().slice(0, 10)}  ${JSON.stringify(m.title)}  parent=${m.parentEventId}`);
+      }
+    }
     process.exitCode = 1;
     return;
   }
+  const marin = marins[0];
   console.log(`Marin:    ${marin.id}  ${marin.date.toISOString().slice(0, 10)}  runNumber=${marin.runNumber}  title=${JSON.stringify(marin.title)}  parentEventId=${marin.parentEventId}`);
 
   if (marin.parentEventId === umbrella.id) {

--- a/scripts/cleanup-bawc5-marin-orphan.ts
+++ b/scripts/cleanup-bawc5-marin-orphan.ts
@@ -1,0 +1,118 @@
+/**
+ * One-shot link for issue #1681 — BAWC5 (Bay Area Weekend Camping) 2026
+ * umbrella has Marin H3 #292 unlinked.
+ *
+ * Background (per #1681): post-merge of PR D (#1667), the BAWC5 weekend
+ * June 19–21 renders as a series parent on SFH3 with SVH3 (Sat) and
+ * EBH3 (Sun) children linked. Marin H3 #292 (Saturday 6/20) should
+ * also be a child, but SFH3's iCal feed dropped `/runs/6449` after the
+ * 2026-05-11 scrape. Marin's stale RawEvent has `seriesId: null`, the
+ * trail isn't being re-emitted, so the merge pipeline's
+ * `linkMultiDaySeries` never refreshes the parent link.
+ *
+ * Fix: find the BAWC5 umbrella Event and the Marin #292 Event; set
+ * `parentEventId` on Marin to point at the umbrella.
+ *
+ * Safety:
+ *   - Dry-run by default; pass `--apply` to actually update.
+ *   - Idempotent: re-runs find Marin already linked and exit cleanly.
+ *   - Exits with informative message (non-zero) if either anchor row
+ *     isn't found, so the operator notices the schema/data drift
+ *     instead of silently no-opping.
+ *
+ * Run:
+ *   tsx scripts/cleanup-bawc5-marin-orphan.ts          # dry-run
+ *   tsx scripts/cleanup-bawc5-marin-orphan.ts --apply  # destructive
+ *
+ * Per memory `feedback_script_env_loading.md` — `import "dotenv/config"`
+ * because tsx doesn't auto-load .env.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const SFH3_CODE = "sfh3";
+const MARIN_CODE = "marinh3";
+const UMBRELLA_DATE_LO = new Date("2026-06-19T00:00:00Z");
+const UMBRELLA_DATE_HI = new Date("2026-06-21T23:59:59Z");
+const MARIN_RUN_NUMBER = 292;
+const MARIN_DATE = new Date("2026-06-20T12:00:00Z");
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY (will UPDATE parentEventId)" : "DRY-RUN"}`);
+
+  const [sfh3Kennel, marinKennel] = await Promise.all([
+    prisma.kennel.findUnique({ where: { kennelCode: SFH3_CODE }, select: { id: true } }),
+    prisma.kennel.findUnique({ where: { kennelCode: MARIN_CODE }, select: { id: true } }),
+  ]);
+  if (!sfh3Kennel || !marinKennel) {
+    console.error(`Anchor kennel(s) missing: sfh3=${!!sfh3Kennel} marinh3=${!!marinKennel}`);
+    process.exit(1);
+  }
+
+  const umbrella = await prisma.event.findFirst({
+    where: {
+      kennelId: sfh3Kennel.id,
+      isSeriesParent: true,
+      date: { gte: UMBRELLA_DATE_LO, lte: UMBRELLA_DATE_HI },
+    },
+    select: { id: true, title: true, date: true },
+  });
+  if (!umbrella) {
+    console.error(`BAWC5 umbrella Event not found in SFH3 between ${UMBRELLA_DATE_LO.toISOString()} and ${UMBRELLA_DATE_HI.toISOString()}. Aborting.`);
+    process.exit(1);
+  }
+  console.log(`Umbrella: ${umbrella.id}  ${umbrella.date.toISOString().slice(0, 10)}  ${JSON.stringify(umbrella.title)}`);
+
+  // Marin #292 on 2026-06-20. Strict (kennelId + runNumber + exact date)
+  // match — no date-window fallback. A write script should fail closed
+  // when the anchor row is missing rather than silently auto-pick from a
+  // multi-row date window (Codex review on the original draft).
+  const marinDateEnd = new Date(MARIN_DATE.getTime() + 86_400_000 - 1);
+  const marin = await prisma.event.findFirst({
+    where: {
+      kennelId: marinKennel.id,
+      runNumber: MARIN_RUN_NUMBER,
+      date: { gte: MARIN_DATE, lte: marinDateEnd },
+    },
+    select: { id: true, title: true, date: true, parentEventId: true, runNumber: true },
+  });
+  if (!marin) {
+    console.error(
+      `Marin H3 #${MARIN_RUN_NUMBER} Event not found on ${MARIN_DATE.toISOString().slice(0, 10)}. ` +
+        "Refusing to auto-pick a different Marin event by date alone. " +
+        "Investigate manually (RawEvent state, possible kennel rename) and re-run with the correct anchor.",
+    );
+    process.exit(1);
+  }
+  console.log(`Marin:    ${marin.id}  ${marin.date.toISOString().slice(0, 10)}  runNumber=${marin.runNumber}  title=${JSON.stringify(marin.title)}  parentEventId=${marin.parentEventId}`);
+
+  if (marin.parentEventId === umbrella.id) {
+    console.log("\nMarin already linked to BAWC5 umbrella — nothing to do.");
+    return;
+  }
+  if (marin.parentEventId && marin.parentEventId !== umbrella.id) {
+    console.error(`Marin is linked to a DIFFERENT parent (${marin.parentEventId}). Refusing to overwrite — investigate manually.`);
+    process.exit(1);
+  }
+
+  if (!apply) {
+    console.log(`\nDRY-RUN: would set parentEventId=${umbrella.id} on Marin Event ${marin.id}`);
+    return;
+  }
+
+  await prisma.event.update({
+    where: { id: marin.id },
+    data: { parentEventId: umbrella.id, isSeriesParent: false },
+  });
+  console.log(`\nLinked Marin H3 #292 (${marin.id}) → BAWC5 umbrella (${umbrella.id}).`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/cleanup-bawc5-marin-orphan.ts
+++ b/scripts/cleanup-bawc5-marin-orphan.ts
@@ -37,6 +37,25 @@ const UMBRELLA_DATE_HI = new Date("2026-06-21T23:59:59Z");
 const MARIN_RUN_NUMBER = 292;
 const MARIN_DATE = new Date("2026-06-20T12:00:00Z");
 
+/**
+ * findMany + exactly-one check (instead of findFirst) — Prisma's findFirst
+ * doesn't guarantee deterministic ordering without an orderBy, so a 2+
+ * predicate match would silently bind to whichever row came first. For a
+ * write script, fail closed when the anchor isn't unambiguous. Returns
+ * the single row, or null and sets process.exitCode after logging.
+ */
+function pickExactlyOne<T extends { id: string; title: string | null; date: Date }>(
+  label: string,
+  rows: T[],
+  formatCandidate: (row: T) => string = (r) => `${r.id}  ${r.date.toISOString().slice(0, 10)}  ${JSON.stringify(r.title)}`,
+): T | null {
+  if (rows.length === 1) return rows[0];
+  console.error(`Expected exactly 1 ${label}, found ${rows.length}. Aborting.`);
+  for (const r of rows) console.error(`  candidate: ${formatCandidate(r)}`);
+  process.exitCode = 1;
+  return null;
+}
+
 async function main() {
   const apply = process.argv.includes("--apply");
   console.log(`Mode: ${apply ? "APPLY (will UPDATE parentEventId)" : "DRY-RUN"}`);
@@ -51,11 +70,6 @@ async function main() {
     return;
   }
 
-  // findMany + exactly-one check (instead of findFirst) — Prisma's findFirst
-  // doesn't guarantee deterministic ordering without an orderBy, so on the
-  // off chance the predicate matched 2+ rows we'd silently bind to whichever
-  // one happened to come first. For a write script, fail closed when the
-  // anchor isn't unambiguous. CodeRabbit review on this PR.
   const umbrellas = await prisma.event.findMany({
     where: {
       kennelId: sfh3Kennel.id,
@@ -64,19 +78,11 @@ async function main() {
     },
     select: { id: true, title: true, date: true },
   });
-  if (umbrellas.length !== 1) {
-    console.error(
-      `Expected exactly 1 BAWC5 umbrella Event in SFH3 between ${UMBRELLA_DATE_LO.toISOString()} and ${UMBRELLA_DATE_HI.toISOString()}, found ${umbrellas.length}. Aborting.`,
-    );
-    if (umbrellas.length > 1) {
-      for (const u of umbrellas) {
-        console.error(`  candidate: ${u.id}  ${u.date.toISOString().slice(0, 10)}  ${JSON.stringify(u.title)}`);
-      }
-    }
-    process.exitCode = 1;
-    return;
-  }
-  const umbrella = umbrellas[0];
+  const umbrella = pickExactlyOne(
+    `BAWC5 umbrella Event in SFH3 between ${UMBRELLA_DATE_LO.toISOString()} and ${UMBRELLA_DATE_HI.toISOString()}`,
+    umbrellas,
+  );
+  if (!umbrella) return;
   console.log(`Umbrella: ${umbrella.id}  ${umbrella.date.toISOString().slice(0, 10)}  ${JSON.stringify(umbrella.title)}`);
 
   // Marin #292 on 2026-06-20. Strict (kennelId + runNumber + exact date)
@@ -91,27 +97,19 @@ async function main() {
     },
     select: { id: true, title: true, date: true, parentEventId: true, runNumber: true },
   });
-  if (marins.length !== 1) {
-    console.error(
-      `Expected exactly 1 Marin H3 #${MARIN_RUN_NUMBER} Event on ${MARIN_DATE.toISOString().slice(0, 10)}, found ${marins.length}. ` +
-        "Refusing to auto-pick. Investigate manually (RawEvent state, possible kennel rename) and re-run with the correct anchor.",
-    );
-    if (marins.length > 1) {
-      for (const m of marins) {
-        console.error(`  candidate: ${m.id}  ${m.date.toISOString().slice(0, 10)}  ${JSON.stringify(m.title)}  parent=${m.parentEventId}`);
-      }
-    }
-    process.exitCode = 1;
-    return;
-  }
-  const marin = marins[0];
+  const marin = pickExactlyOne(
+    `Marin H3 #${MARIN_RUN_NUMBER} Event on ${MARIN_DATE.toISOString().slice(0, 10)}`,
+    marins,
+    (m) => `${m.id}  ${m.date.toISOString().slice(0, 10)}  ${JSON.stringify(m.title)}  parent=${m.parentEventId}`,
+  );
+  if (!marin) return;
   console.log(`Marin:    ${marin.id}  ${marin.date.toISOString().slice(0, 10)}  runNumber=${marin.runNumber}  title=${JSON.stringify(marin.title)}  parentEventId=${marin.parentEventId}`);
 
   if (marin.parentEventId === umbrella.id) {
     console.log("\nMarin already linked to BAWC5 umbrella — nothing to do.");
     return;
   }
-  if (marin.parentEventId && marin.parentEventId !== umbrella.id) {
+  if (marin.parentEventId) {
     console.error(`Marin is linked to a DIFFERENT parent (${marin.parentEventId}). Refusing to overwrite — investigate manually.`);
     process.exitCode = 1;
     return;

--- a/scripts/cleanup-bawc5-marin-orphan.ts
+++ b/scripts/cleanup-bawc5-marin-orphan.ts
@@ -47,7 +47,8 @@ async function main() {
   ]);
   if (!sfh3Kennel || !marinKennel) {
     console.error(`Anchor kennel(s) missing: sfh3=${!!sfh3Kennel} marinh3=${!!marinKennel}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const umbrella = await prisma.event.findFirst({
@@ -60,7 +61,8 @@ async function main() {
   });
   if (!umbrella) {
     console.error(`BAWC5 umbrella Event not found in SFH3 between ${UMBRELLA_DATE_LO.toISOString()} and ${UMBRELLA_DATE_HI.toISOString()}. Aborting.`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   console.log(`Umbrella: ${umbrella.id}  ${umbrella.date.toISOString().slice(0, 10)}  ${JSON.stringify(umbrella.title)}`);
 
@@ -83,7 +85,8 @@ async function main() {
         "Refusing to auto-pick a different Marin event by date alone. " +
         "Investigate manually (RawEvent state, possible kennel rename) and re-run with the correct anchor.",
     );
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   console.log(`Marin:    ${marin.id}  ${marin.date.toISOString().slice(0, 10)}  runNumber=${marin.runNumber}  title=${JSON.stringify(marin.title)}  parentEventId=${marin.parentEventId}`);
 
@@ -93,7 +96,8 @@ async function main() {
   }
   if (marin.parentEventId && marin.parentEventId !== umbrella.id) {
     console.error(`Marin is linked to a DIFFERENT parent (${marin.parentEventId}). Refusing to overwrite — investigate manually.`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (!apply) {
@@ -111,7 +115,7 @@ async function main() {
 main()
   .catch((err) => {
     console.error(err);
-    process.exit(1);
+    process.exitCode = 1;
   })
   .finally(async () => {
     await prisma.$disconnect();

--- a/scripts/cleanup-mh3-mn-test-events.ts
+++ b/scripts/cleanup-mh3-mn-test-events.ts
@@ -33,19 +33,25 @@ import { deleteLeakedEvent } from "./lib/delete-leaked-event";
 
 const KENNEL_CODE = "mh3-mn";
 
-// Match the same shapes the adapter filter catches. Title patterns are
-// anchored to whole-title to avoid bulldozing legitimate trails that
-// happen to mention "test" or "PC" mid-title. The third entry catches
-// the kennelTag-as-title leakage path: when an empty-summary calendar
-// event fell through earlier code paths, the kennelCode "mh3-mn" itself
-// surfaced as title. The adapter's `if (!item.summary) return null`
-// guard prevents new ones from being created, but existing rows still
-// need a sweep.
-const TITLE_REGEXES: readonly RegExp[] = [
-  /^\s*trail\s*#?\s*test\s+event\s*$/i,
-  /^\s*pc\s+meeting\s*$/i,
-  /^\s*mh3-mn\s*$/i,
-];
+// Match the same shapes the adapter filter catches. Comparison strips
+// whitespace and `#` from a lowercased title so all the `Trail # Test
+// Event` / `Trail #Test Event` / `trail test event` variants collapse
+// to the same key (deliberately not a regex with `\s*` / `#?` — Sonar
+// S5852 flags those as ReDoS-shaped even for linear inputs). The
+// `mh3-mn` entry catches the kennelTag-as-title leakage path: an
+// empty-summary calendar event used to fall back to the kennelCode
+// itself. The adapter's `if (!item.summary) return null` guard
+// prevents new ones; this script sweeps existing rows.
+const SUSPECT_TITLE_KEYS = new Set([
+  "trailtestevent",
+  "pcmeeting",
+  "mh3-mn",
+]);
+
+function isSuspectTitle(title: string | null): boolean {
+  if (!title) return false;
+  return SUSPECT_TITLE_KEYS.has(title.toLowerCase().replaceAll(/[\s#]+/g, ""));
+}
 
 // Location is matched case-insensitive substring — "123 Fake St" only
 // appears on the synthetic test entry, so this is safe.
@@ -72,7 +78,7 @@ async function main() {
   });
 
   const matched = candidates.filter((e) => {
-    const titleHit = TITLE_REGEXES.some((re) => e.title && re.test(e.title));
+    const titleHit = isSuspectTitle(e.title);
     const locationHit = !!e.locationName && e.locationName.toLowerCase().includes(LOCATION_SUBSTRING);
     return titleHit || locationHit;
   });
@@ -96,7 +102,7 @@ async function main() {
 main()
   .catch((err) => {
     console.error(err);
-    process.exit(1);
+    process.exitCode = 1;
   })
   .finally(async () => {
     await prisma.$disconnect();

--- a/scripts/cleanup-mh3-mn-test-events.ts
+++ b/scripts/cleanup-mh3-mn-test-events.ts
@@ -1,0 +1,103 @@
+/**
+ * One-shot cleanup for issue #1632 — MH3-MN (Minneapolis H3) test /
+ * admin-internal events leaked from the GOOGLE_CALENDAR source.
+ *
+ * The source calendar carried at least three synthetic / non-trail
+ * entries that surfaced on /kennels/mh3-mn:
+ *   - "Trail # Test Event" (paired with location "123 Fake St")
+ *   - "PC Meeting" (admin-internal)
+ *   - Empty-summary events that fell back to the kennelTag "mh3-mn" as
+ *     title (Codex review caught this shape in the issue body)
+ *
+ * The adapter-side fix lands in `src/adapters/google-calendar/adapter.ts`
+ * via TEST_ARTIFACT_TITLE_PATTERNS (#1632) — but already-merged Events
+ * stay until we explicitly cancel them. This script hard-deletes the
+ * leaked rows so they stop rendering, using the same
+ * `deleteLeakedEvent` helper as the cleanup-issue-NNNN family.
+ *
+ * Safety:
+ *   - Dry-run by default; pass `--apply` to actually delete.
+ *   - Bounded to kennel `mh3-mn` to keep blast radius tight.
+ *   - Idempotent — re-runs find zero matching rows once applied.
+ *
+ * Run:
+ *   tsx scripts/cleanup-mh3-mn-test-events.ts          # dry-run
+ *   tsx scripts/cleanup-mh3-mn-test-events.ts --apply  # destructive
+ *
+ * Per memory `feedback_script_env_loading.md` — `import "dotenv/config"`
+ * because tsx doesn't auto-load .env.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { deleteLeakedEvent } from "./lib/delete-leaked-event";
+
+const KENNEL_CODE = "mh3-mn";
+
+// Match the same shapes the adapter filter catches. Title patterns are
+// anchored to whole-title to avoid bulldozing legitimate trails that
+// happen to mention "test" or "PC" mid-title. The third entry catches
+// the kennelTag-as-title leakage path: when an empty-summary calendar
+// event fell through earlier code paths, the kennelCode "mh3-mn" itself
+// surfaced as title. The adapter's `if (!item.summary) return null`
+// guard prevents new ones from being created, but existing rows still
+// need a sweep.
+const TITLE_REGEXES: readonly RegExp[] = [
+  /^\s*trail\s*#?\s*test\s+event\s*$/i,
+  /^\s*pc\s+meeting\s*$/i,
+  /^\s*mh3-mn\s*$/i,
+];
+
+// Location is matched case-insensitive substring — "123 Fake St" only
+// appears on the synthetic test entry, so this is safe.
+const LOCATION_SUBSTRING = "123 fake st";
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY (will hard-delete)" : "DRY-RUN"}`);
+
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: KENNEL_CODE },
+    select: { id: true, shortName: true },
+  });
+  if (!kennel) {
+    console.log(`Kennel "${KENNEL_CODE}" not found — nothing to do.`);
+    return;
+  }
+  console.log(`Targeting kennel: ${kennel.shortName} (${kennel.id})`);
+
+  const candidates = await prisma.event.findMany({
+    where: { kennelId: kennel.id },
+    select: { id: true, title: true, date: true, locationName: true },
+    orderBy: { date: "asc" },
+  });
+
+  const matched = candidates.filter((e) => {
+    const titleHit = TITLE_REGEXES.some((re) => e.title && re.test(e.title));
+    const locationHit = !!e.locationName && e.locationName.toLowerCase().includes(LOCATION_SUBSTRING);
+    return titleHit || locationHit;
+  });
+
+  console.log(`\nMatched ${matched.length} of ${candidates.length} ${KENNEL_CODE} Events:`);
+  for (const e of matched) {
+    console.log(`  ${e.id}  ${e.date.toISOString().slice(0, 10)}  title=${JSON.stringify(e.title)}  loc=${JSON.stringify(e.locationName)}`);
+  }
+
+  if (!apply || matched.length === 0) {
+    if (!apply) console.log("\nDry-run complete. Re-run with --apply to delete.");
+    return;
+  }
+
+  for (const e of matched) {
+    await deleteLeakedEvent(prisma, e.id);
+  }
+  console.log(`\nDeleted ${matched.length} leaked Event(s).`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/cleanup-morgantown-mh3-prefix.ts
+++ b/scripts/cleanup-morgantown-mh3-prefix.ts
@@ -1,0 +1,90 @@
+/**
+ * One-shot cleanup for issue #1701 — Morgantown H3 events with
+ * unstripped "MH3:" title prefix.
+ *
+ * Six events from 2026-03-01 through 2026-04-01 carry the source's
+ * "MH3:" prefix verbatim in the HashTracks title. Identical events
+ * from 2026-04-15 onward (same SUMMARY shape, same GOOGLE_CALENDAR
+ * source) had the prefix stripped correctly — the strip rule was
+ * deployed between those dates and the older rows weren't reprocessed.
+ *
+ * This script rewrites the affected Event.title rows in place. The
+ * fingerprint isn't touched (title isn't a fingerprint input), so the
+ * next scrape will continue to find the same RawEvent → Event linkage.
+ *
+ * Special-case skip: 2026-10-17 "MH3: MH3 Analversary - Calling All
+ * Wankers" → "MH3 Analversary - Calling All Wankers" is the legitimate
+ * stripped form (the second "MH3" is the event-name token, not a
+ * kennel prefix). The issue body calls this out; we still rewrite it
+ * here because the strip is identical and the result is identical.
+ *
+ * Safety:
+ *   - Dry-run by default; pass `--apply` to actually update.
+ *   - Bounded to kennel `mh3-wv` to keep blast radius tight.
+ *   - Idempotent: re-runs find zero matching titles once applied.
+ *
+ * Run:
+ *   tsx scripts/cleanup-morgantown-mh3-prefix.ts          # dry-run
+ *   tsx scripts/cleanup-morgantown-mh3-prefix.ts --apply  # destructive
+ *
+ * Per memory `feedback_script_env_loading.md` — `import "dotenv/config"`
+ * because tsx doesn't auto-load .env.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const KENNEL_CODE = "mh3-wv";
+const PREFIX_RE = /^MH3:\s*/;
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY (will UPDATE titles)" : "DRY-RUN"}`);
+
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: KENNEL_CODE },
+    select: { id: true, shortName: true },
+  });
+  if (!kennel) {
+    console.log(`Kennel "${KENNEL_CODE}" not found — nothing to do.`);
+    return;
+  }
+  console.log(`Targeting kennel: ${kennel.shortName} (${kennel.id})`);
+
+  const affected = await prisma.event.findMany({
+    where: {
+      kennelId: kennel.id,
+      title: { startsWith: "MH3:" },
+    },
+    select: { id: true, title: true, date: true },
+    orderBy: { date: "asc" },
+  });
+
+  console.log(`\nFound ${affected.length} Event(s) with "MH3:" prefix:`);
+  for (const e of affected) {
+    const stripped = (e.title ?? "").replace(PREFIX_RE, "");
+    console.log(`  ${e.id}  ${e.date.toISOString().slice(0, 10)}  ${JSON.stringify(e.title)} → ${JSON.stringify(stripped)}`);
+  }
+
+  if (!apply || affected.length === 0) {
+    if (!apply) console.log("\nDry-run complete. Re-run with --apply to rewrite.");
+    return;
+  }
+
+  let updated = 0;
+  for (const e of affected) {
+    const stripped = (e.title ?? "").replace(PREFIX_RE, "");
+    if (!stripped || stripped === e.title) continue;
+    await prisma.event.update({ where: { id: e.id }, data: { title: stripped } });
+    updated++;
+  }
+  console.log(`\nUpdated ${updated} of ${affected.length} Event(s).`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/cleanup-morgantown-mh3-prefix.ts
+++ b/scripts/cleanup-morgantown-mh3-prefix.ts
@@ -83,7 +83,7 @@ async function main() {
 main()
   .catch((err) => {
     console.error(err);
-    process.exit(1);
+    process.exitCode = 1;
   })
   .finally(async () => {
     await prisma.$disconnect();

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -570,6 +570,92 @@ describe("medical appointment filter (#1690)", () => {
   });
 });
 
+// #1632 — MH3-MN's calendar carried synthetic test entries ("Trail # Test
+// Event" with `123 Fake St`) and admin-internal ("PC Meeting") events.
+// Unconditional drop — no plausible real hash event has exactly those
+// titles, so we don't gate on hash signals.
+describe("synthetic test / admin-internal title filter (#1632)", () => {
+  it.each([
+    "Trail # Test Event",
+    "Trail #Test Event",
+    "trail test event",
+    "PC Meeting",
+    "pc meeting",
+  ])("drops synthetic test / admin title: %s", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary, location: "123 Fake St" }),
+      { defaultKennelTag: "mh3-mn" },
+    );
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    // Real titles that contain the words but aren't admin/test entries.
+    "Trail Test - April Fools Hash",
+    "Pre-Trail Briefing at the PC Club",
+  ])("preserves legitimate title that shares words with the filter: %s", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary, location: "Memorial Park" }),
+      { defaultKennelTag: "mh3-mn" },
+    );
+    expect(result).not.toBeNull();
+  });
+});
+
+// #1691 — Flour City May 28: source admin pasted the kennel's URL slug
+// "flour-city" as SUMMARY. Empty the title so merge.ts synthesizes a
+// "<KennelName> Trail #N" instead of surfacing the slug verbatim.
+// Gated on titleMatchesKennelTag — bare kebab-case is ambiguous (legit
+// theme titles like "red-dress-run" share the shape).
+describe("URL-slug title rejection (#1691)", () => {
+  it("empties title when summary equals the kennel URL slug", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "flour-city",
+        description: "Hare: \nWhere: \nWhen: 6:00 PM\nWhy: \nHow: $5 hash cash",
+      }),
+      { defaultKennelTag: "flour-city" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("");
+  });
+
+  it("empties title when summary equals another kennel's slug shape", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "lvh3-cin" }),
+      { defaultKennelTag: "lvh3-cin" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("");
+  });
+
+  it.each([
+    // Legit kebab-case theme titles — must NOT be emptied just because
+    // they share the URL-slug shape. The kennel-tag gate keeps them safe.
+    ["red-dress-run", "flour-city"],
+    ["pre-lube", "flour-city"],
+    ["full-moon", "flour-city"],
+    ["hash-trash", "flour-city"],
+    ["on-after", "flour-city"],
+  ])("preserves legit kebab-case title %q on kennelTag %q", (summary, kennelTag) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary, location: "Memorial Park" }),
+      { defaultKennelTag: kennelTag },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe(summary);
+  });
+
+  it("preserves real titles that happen to contain hyphens (mixed case / spaces)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "Inter-Hash 2026", location: "Park" }),
+      { defaultKennelTag: "flour-city" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Inter-Hash 2026");
+  });
+});
+
 // #1426 — sports-domain events leaked through #1271 because they had a real
 // location (Frances Park 2701 Moores River Dr). Drop when sport+qualifier
 // matches AND there's no run number / hares — the two hash-confirming

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -179,6 +179,31 @@ const NON_HASH_DOMAIN_PATTERNS: readonly RegExp[] = [
  */
 const HASH_KEYWORD_RE = /\bhash\b/i;
 
+/**
+ * #1632 — known synthetic-test / internal-admin titles that should never
+ * surface as runs. Matches the entire summary (anchored start/end) so a
+ * legitimate title that happens to mention "test" or "PC" stays safe.
+ * Unlike MEDICAL_TITLE_PATTERNS, no hash-signal override: these are
+ * obviously not real trails regardless of what the description carries.
+ * MH3-MN's calendar carried `Trail # Test Event` (with `123 Fake St`
+ * location) and `PC Meeting`; both were leaking through to /kennels/mh3-mn.
+ */
+const TEST_ARTIFACT_TITLE_PATTERNS: readonly RegExp[] = [
+  /^\s*trail\s*#?\s*test\s+event\s*$/i,
+  /^\s*pc\s+meeting\s*$/i,
+];
+
+/**
+ * #1691 — kebab-case shape detector. Matches lowercase alphanumeric
+ * strings with at least one hyphen and no spaces. This shape is
+ * AMBIGUOUS by itself — both kennel URL slugs ("flour-city", "lvh3-cin")
+ * and legitimate theme titles ("red-dress-run", "pre-lube", "hash-trash")
+ * fit it. Callers MUST gate this check on a kennel-tag equivalence
+ * (titleMatchesKennelTag) so only the slug case actually triggers
+ * title clearing.
+ */
+const URL_SLUG_TITLE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)+$/;
+
 /** Strip leading day/date prefixes like "Wed April 1st", "Sat 3/28" from titles. */
 export function stripDatePrefix(text: string): string {
   const stripped = text
@@ -1196,6 +1221,16 @@ export function buildRawEventFromGCalItem(
     const descTitle = titleFromDescription(rawDescription);
     if (descTitle) title = descTitle;
   }
+  // #1691 — title is kebab-case AND matches the kennel tag after
+  // normalization. That's the URL-slug shape (Flour City May 28: SUMMARY
+  // was literally "flour-city"). Empty the title so the defaultTitle
+  // path below or, failing that, the merge pipeline's "<KennelName>
+  // Trail #N" synthesis takes over. The kennel-tag gate is essential —
+  // bare kebab-case is ambiguous (legit theme titles like "red-dress-
+  // run" / "pre-lube" / "hash-trash" share the shape).
+  if (URL_SLUG_TITLE_RE.test(title) && titleMatchesKennelTag(title, kennelTag)) {
+    title = "";
+  }
   // Strip the hare-name capture group from the title, preserving the rest.
   // Handles both prefix patterns (hares at start: "Hare1 & Hare2 - AH3 #2269")
   // and suffix patterns (hares at end: "AH3 #1833 - Location - Hare Name").
@@ -1446,6 +1481,13 @@ export function buildRawEventFromGCalItem(
     !HASH_KEYWORD_RE.test(summary) &&
     NON_HASH_DOMAIN_PATTERNS.some((re) => re.test(summary))
   ) {
+    return null;
+  }
+
+  // #1632 — synthetic test / admin-internal titles. Unconditional drop:
+  // unlike the sport / medical filters there is no plausible real hash
+  // event whose summary is exactly "Trail # Test Event" or "PC Meeting".
+  if (TEST_ARTIFACT_TITLE_PATTERNS.some((re) => re.test(summary))) {
     return null;
   }
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -181,17 +181,25 @@ const HASH_KEYWORD_RE = /\bhash\b/i;
 
 /**
  * #1632 — known synthetic-test / internal-admin titles that should never
- * surface as runs. Matches the entire summary (anchored start/end) so a
- * legitimate title that happens to mention "test" or "PC" stays safe.
- * Unlike MEDICAL_TITLE_PATTERNS, no hash-signal override: these are
- * obviously not real trails regardless of what the description carries.
+ * surface as runs. Compared after stripping whitespace and `#` from a
+ * lowercased summary so all the `Trail # Test Event` / `Trail #Test
+ * Event` / `trail test event` variants collapse to the same key.
+ * Deliberately Set-based, not a regex with `\s*` / `#?` adjacency —
+ * Sonar S5852 flags those as ReDoS-shaped even for linear inputs
+ * (see `feedback_sonar_s5852_procedural_over_regex`).
+ *
  * MH3-MN's calendar carried `Trail # Test Event` (with `123 Fake St`
- * location) and `PC Meeting`; both were leaking through to /kennels/mh3-mn.
+ * location) and `PC Meeting`; both were leaking through to
+ * /kennels/mh3-mn before this filter landed.
  */
-const TEST_ARTIFACT_TITLE_PATTERNS: readonly RegExp[] = [
-  /^\s*trail\s*#?\s*test\s+event\s*$/i,
-  /^\s*pc\s+meeting\s*$/i,
-];
+const TEST_ARTIFACT_TITLE_KEYS = new Set([
+  "trailtestevent",
+  "pcmeeting",
+]);
+
+function isTestArtifactTitle(summary: string): boolean {
+  return TEST_ARTIFACT_TITLE_KEYS.has(summary.toLowerCase().replaceAll(/[\s#]+/g, ""));
+}
 
 /**
  * #1691 — kebab-case shape detector. Matches lowercase alphanumeric
@@ -1487,7 +1495,7 @@ export function buildRawEventFromGCalItem(
   // #1632 — synthetic test / admin-internal titles. Unconditional drop:
   // unlike the sport / medical filters there is no plausible real hash
   // event whose summary is exactly "Trail # Test Event" or "PC Meeting".
-  if (TEST_ARTIFACT_TITLE_PATTERNS.some((re) => re.test(summary))) {
+  if (isTestArtifactTitle(summary)) {
     return null;
   }
 

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -357,6 +357,85 @@ describe("HarrierCentralAdapter", () => {
       expect(result.events[0].location).toBe("Nishiogikubo");
     });
 
+    it("nulls hares when address-shaped haresText is a prefix of location (#1642)", async () => {
+      // SG Sunday H3 #798 reproduction: hares "Swiss Club Road, dead end old
+      // Turf City" is a strict prefix of location "Swiss Club Road, dead end
+      // old Turf City, Singapore". The exact-match guard from #521 missed it
+      // because the location has ", Singapore" appended.
+      mockApiResponse([
+        buildHCEvent({
+          hares: "Swiss Club Road, dead end old Turf City",
+          locationOneLineDesc: "Swiss Club Road, dead end old Turf City",
+          eventCityAndCountry: "Singapore",
+        }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "sh3-sg" }));
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].hares).toBeUndefined();
+      // Location is preserved as-is; what matters is the haresText was nulled.
+      expect(result.events[0].location).toContain(
+        "Swiss Club Road, dead end old Turf City",
+      );
+    });
+
+    it("keeps hares when value is a substring of location but lacks address signals", async () => {
+      // Defensive: a hare named after a street tile ("George") must NOT be
+      // nulled just because the location contains the same word. The
+      // address-shape signals (comma / street token / leading digit) gate
+      // the substring path; "George" alone trips none of them.
+      mockApiResponse([
+        buildHCEvent({
+          hares: "George",
+          locationOneLineDesc: "George Street Plaza",
+        }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
+      expect(result.events[0].hares).toBe("George");
+    });
+
+    it.each([
+      // Hash-name shapes that substring-match the location text but should
+      // NOT be nulled. Each fails the two-signal threshold (#1642 codex
+      // round-1 review caught this — "park"/"court" were too aggressive
+      // and are no longer in ADDRESS_TOKENS).
+      ["Park", "Central Park"],
+      ["George Park", "George Park Bar"],
+      ["Court", "Food Court"],
+      ["Way", "Way Out Bar"],
+    ])("keeps real hare name %q against location %q", async (hares, location) => {
+      mockApiResponse([
+        buildHCEvent({ hares, locationOneLineDesc: location }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
+      expect(result.events[0].hares).toBe(hares);
+    });
+
+    it("nulls hares when value has BOTH a leading number AND a street-type token", async () => {
+      // Two-signal threshold: leading digit AND "Street" token both
+      // present → strong enough to be confident the hares slot was
+      // pasted with an address by mistake.
+      mockApiResponse([
+        buildHCEvent({
+          hares: "1234 Main Street",
+          locationOneLineDesc: "1234 Main Street, Springfield",
+        }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
+      expect(result.events[0].hares).toBeUndefined();
+    });
+
+    it("keeps hares when only a single address signal is present", async () => {
+      // Just a leading digit ("4 Eyes" hash name) is one signal — not enough.
+      mockApiResponse([
+        buildHCEvent({
+          hares: "4 Eyes",
+          locationOneLineDesc: "4 Eyes Lounge",
+        }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
+      expect(result.events[0].hares).toBe("4 Eyes");
+    });
+
     it("uses kennelPatterns to resolve kennel tag", async () => {
       const seattleEvents = [
         buildHCEvent({ kennelName: "SeaMon H3", kennelShortName: "SeaMon", kennelUniqueShortName: "SeaMon" }),

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -171,7 +171,14 @@ export class HarrierCentralAdapter implements SourceAdapter {
       // subway line. Null the hare but keep location; if the location text
       // is also bad, the separate location-quality audit rules will flag
       // it without this adapter erasing a potentially-valid value. See #521.
-      if (hares && location && hares.trim().toLowerCase() === location.trim().toLowerCase()) {
+      // #1642 extension: also strip when the hare text is a prefix/substring
+      // of the location AND looks address-shaped (contains a comma, a
+      // street-type token, or a leading street number). SG Sunday H3 #798
+      // had hares "Swiss Club Road, dead end old Turf City" and location
+      // "Swiss Club Road, dead end old Turf City, Singapore" — the location
+      // is just the hares value with ", Singapore" appended, but exact-match
+      // didn't catch it.
+      if (hares && location && haresLooksLikeLocation(hares, location)) {
         hares = undefined;
       }
 
@@ -239,6 +246,64 @@ export class HarrierCentralAdapter implements SourceAdapter {
 function stripTba(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed && !/^tba$/i.test(trimmed) ? trimmed : undefined;
+}
+
+// Street-type tokens used by haresLooksLikeLocation to flag address-shaped
+// haresText. Stored as a Set + word-split (rather than a long regex
+// alternation) to keep Sonar S5843 regex complexity low and let us extend
+// the list without touching parse code.
+//
+// Intentionally narrower than a full USPS abbreviation table: "park" and
+// "court" are common in hash names (Park, Park Avenue Slut, Just Court),
+// "way" appears in nicknames, and bare directionals (N/S/E/W) are too
+// short. Stick to terms that are unambiguous as road suffixes.
+const ADDRESS_TOKENS = new Set([
+  "road", "rd",
+  "street", "st",
+  "avenue", "ave",
+  "lane", "ln",
+  "drive", "dr",
+  "boulevard", "blvd",
+  "highway", "hwy",
+]);
+
+function hasAddressToken(text: string): boolean {
+  for (const token of text.toLowerCase().split(/[\s,]+/)) {
+    if (token && ADDRESS_TOKENS.has(token)) return true;
+  }
+  return false;
+}
+
+/**
+ * #521 + #1642: detect when the source pasted address/location text into
+ * the Hares slot. Trigger shapes (intentionally narrow — false positives
+ * silently nullify real hare data):
+ *
+ *  1. Exact case-insensitive match of hares against location (Tokyo
+ *     #2578 reproduction).
+ *  2. Hares is a substring of location AND has TWO independent address
+ *     signals — the substring inclusion alone is not enough. Real hare
+ *     names like "Park" or "George Park" routinely substring-match
+ *     legitimate location text ("Central Park", "George Park Bar")
+ *     without being addresses.
+ *
+ *     Address signals counted: presence of a comma; leading digit (street
+ *     number); contains a narrow street-type token (Road/St/Ave/Lane/
+ *     Drive/Blvd/Hwy). Requiring two means a bare "Park" / "Court" / etc.
+ *     never trips the heuristic, but the SG Sunday H3 #798 case ("Swiss
+ *     Club Road, dead end old Turf City" — comma + "Road") still does.
+ */
+function haresLooksLikeLocation(hares: string, location: string): boolean {
+  const h = hares.trim().toLowerCase();
+  const l = location.trim().toLowerCase();
+  if (!h || !l) return false;
+  if (h === l) return true;
+  if (!l.includes(h)) return false;
+  let signals = 0;
+  if (h.includes(",")) signals++;
+  if (/^\d/.test(h)) signals++;
+  if (hasAddressToken(h)) signals++;
+  return signals >= 2;
 }
 
 /**

--- a/src/adapters/html-scraper/bkk-harriettes.test.ts
+++ b/src/adapters/html-scraper/bkk-harriettes.test.ts
@@ -208,4 +208,25 @@ describe("parseBkkHarrietteHarelineTable", () => {
     expect(events).toHaveLength(1);
     expect(events[0].runNumber).toBe(2271);
   });
+
+  it("preserves the rich quoted hash-name format used by BKK Harriettes (#1655)", () => {
+    // Reproduction of the homepage row that drove #1655: the table carries
+    // the full "Bob &#8216;Aunries Bitch&#8217; N" form. The dedup logic in
+    // fetch() now keeps the table's richer hares text over the post's
+    // truncated nickname-only form, so the table parse must produce the
+    // full string unmodified (apart from entity decoding).
+    const refDate = new Date(Date.UTC(2026, 4, 26));
+    const events = parseBkkHarrietteHarelineTable(
+      `<table>
+        <tr><td>2265</td><td>27 May</td><td>Bob &#8216;Aunries Bitch&#8217; N</td><td>Srinakarin 44, Somtam Srinakarin</td></tr>
+       </table>`,
+      refDate,
+      "https://bangkokharriettes.wordpress.com",
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(2265);
+    expect(events[0].date).toBe("2026-05-27");
+    expect(events[0].hares).toBe("Bob ‘Aunries Bitch’ N");
+    expect(events[0].location).toBe("Srinakarin 44, Somtam Srinakarin");
+  });
 });

--- a/src/adapters/html-scraper/bkk-harriettes.ts
+++ b/src/adapters/html-scraper/bkk-harriettes.ts
@@ -341,15 +341,57 @@ export class BkkHarriettesAdapter implements SourceAdapter {
     consumeTablePage(homepageResult, SITE_BASE, "homepage", refDate, tableEvents, errors, errorDetails);
     consumeTablePage(fullResult, FULL_HARELINE_URL, "hareline-in-full", refDate, tableEvents, errors, errorDetails);
 
-    // Dedupe by runNumber; post events come last so they override table rows
-    // (post events carry the permalink sourceUrl and a parsed startTime).
-    const byRun = new Map<number, RawEventData>();
-    for (const e of [...tableEvents, ...postEvents]) {
-      if (typeof e.runNumber === "number") byRun.set(e.runNumber, e);
+    // Dedupe by runNumber. Until #1655 we had posts blindly override tables,
+    // which lost the richer hare formatting tables carry
+    // ("Bob 'Aunries Bitch' N") to the reused "Next Run" post's truncated
+    // form ("Aunties Bitch"). The fix is fieldwise coalescing rather than
+    // a flat priority — neither surface dominates. Per-field rules:
+    //   - hares / location: table wins ONLY if defined; falls back to post
+    //   - startTime: post wins if it's non-default (i.e. parsed from body);
+    //     otherwise table's DEFAULT_START_TIME
+    //   - sourceUrl: post wins (permalink) if set; otherwise table's homepage
+    //   - other fields (date, runNumber, kennelTags): same in both
+    const postByRun = new Map<number, RawEventData>();
+    for (const e of postEvents) {
+      if (typeof e.runNumber === "number") postByRun.set(e.runNumber, e);
+    }
+    const tableByRun = new Map<number, RawEventData>();
+    for (const e of tableEvents) {
+      if (typeof e.runNumber === "number") tableByRun.set(e.runNumber, e);
+    }
+    const mergedByRun: RawEventData[] = [];
+    const allRunNumbers = new Set<number>([
+      ...postByRun.keys(),
+      ...tableByRun.keys(),
+    ]);
+    for (const rn of allRunNumbers) {
+      const table = tableByRun.get(rn);
+      const post = postByRun.get(rn);
+      if (!table) {
+        mergedByRun.push(post!);
+        continue;
+      }
+      if (!post) {
+        mergedByRun.push(table);
+        continue;
+      }
+      // Start from the table row so its rich-format fields are the baseline,
+      // then promote post values for fields the table left undefined or
+      // where the post is authoritative (parsed startTime, permalink URL).
+      mergedByRun.push({
+        ...table,
+        hares: table.hares ?? post.hares,
+        location: table.location ?? post.location,
+        startTime:
+          post.startTime && post.startTime !== DEFAULT_START_TIME
+            ? post.startTime
+            : table.startTime,
+        sourceUrl: post.sourceUrl ?? table.sourceUrl,
+      });
     }
     const events: RawEventData[] = [
       ...postEvents.filter((e) => typeof e.runNumber !== "number"),
-      ...byRun.values(),
+      ...mergedByRun,
     ];
 
     const fetchDurationMs = Date.now() - fetchStart;

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1321,7 +1321,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
         dateTime: "2026-04-01T18:30:00+10:00",
       };
       const event = buildRawEventFromApollo(
-        ev as never,
+        ev,
         emptyState,
         "mel-new-moon",
         melNmPatterns,
@@ -1337,7 +1337,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
         dateTime: "2026-04-01T18:30:00+10:00",
       };
       const event = buildRawEventFromApollo(
-        ev as never,
+        ev,
         emptyState,
         "mel-new-moon",
         melNmPatterns,

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1293,6 +1293,58 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     const event = buildRawEventFromApollo(ev as never, emptyState, "rch3");
     expect(event.hares).toBeUndefined();
   });
+
+  // #1617 — Mel-NM Meetup aggregator hosts events for 5 Melbourne kennels.
+  // The seed config wires kennelPatterns to split them. Verify the routing
+  // matches what `prisma/seed-data/sources.ts` ships.
+  describe("Mel-NM aggregator routing (#1617)", () => {
+    const melNmPatterns: [RegExp, string][] = [
+      [/^\s*Melbourne\s+New\s+Moon\b/i, "mel-new-moon"],
+      [/^\s*(?:Melbourne\s+)?City\s+Hash\b/i, "melbourne-city-h3"],
+      [/^\s*Bike\s+hash\b/i, "melbourne-bike-hash"],
+      [/^\s*Delinquents\s+HHH\b/i, "delinquents-hhh"],
+      [/^\s*Full\s+Moon\s+Run\b/i, "melbourne-full-moon"],
+    ];
+
+    it.each([
+      ["Melbourne New Moon #175- Klingon @ Exford Hotel", "mel-new-moon"],
+      ["Full Moon Run No. 303", "melbourne-full-moon"],
+      ["Delinquents HHH No.55 - Trail Theme", "delinquents-hhh"],
+      ["City Hash Beer Marathon", "melbourne-city-h3"],
+      ["Melbourne City Hash Thursday Run", "melbourne-city-h3"],
+      ["Bike hash ride #17", "melbourne-bike-hash"],
+    ])("routes %q → %q", (title, expectedTag) => {
+      const ev = {
+        __typename: "Event",
+        id: `mel-${expectedTag}`,
+        title,
+        dateTime: "2026-04-01T18:30:00+10:00",
+      };
+      const event = buildRawEventFromApollo(
+        ev as never,
+        emptyState,
+        "mel-new-moon",
+        melNmPatterns,
+      );
+      expect(event.kennelTags[0]).toBe(expectedTag);
+    });
+
+    it("falls back to mel-new-moon for unrouted titles", () => {
+      const ev = {
+        __typename: "Event",
+        id: "unrouted",
+        title: "Run No. 42",
+        dateTime: "2026-04-01T18:30:00+10:00",
+      };
+      const event = buildRawEventFromApollo(
+        ev as never,
+        emptyState,
+        "mel-new-moon",
+        melNmPatterns,
+      );
+      expect(event.kennelTags[0]).toBe("mel-new-moon");
+    });
+  });
 });
 
 // ── cleanMeetupTitle — trailing CTA strip (#1645 RH3 / #1646 TMFMH3) ──
@@ -1334,6 +1386,30 @@ describe("cleanMeetupTitle", () => {
   it("returns undefined when title collapses to empty after strip", () => {
     expect(cleanMeetupTitle("Hares Needed")).toBeUndefined();
     expect(cleanMeetupTitle("CLAIM THIS TRAIL")).toBeUndefined();
+  });
+
+  // #1618 — Mel-NM Meetup leaked the group recurrence blurb as event title
+  // on 13 events. Drop the template shape so merge.ts synthesizes a
+  // "<KennelName> Trail #N" replacement.
+  it.each([
+    "Every Wednesday @ 6:30pm from tbd",
+    "Every Wed @ 6:30",
+    "Every Sat @ 10am from TBA",
+    "Saturday Trail from TBD",
+    "Weekly Friday Run from TBC",
+  ])("drops template-shaped title: %q", (raw) => {
+    expect(cleanMeetupTitle(raw)).toBeUndefined();
+  });
+
+  it.each([
+    // Real titles with "every" that shouldn't false-positive.
+    "Every Saturday Trail",
+    "Every Wednesday Hash Run",
+    // Real titles that mention "from" without the TBA placeholder.
+    "Saturday Trail from Memorial Park",
+    "Friday Run from Brewery",
+  ])("preserves legitimate title that shares words with template patterns: %q", (raw) => {
+    expect(cleanMeetupTitle(raw)).toBe(raw);
   });
 });
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -439,8 +439,26 @@ const TRAILING_CTA_RES = CTA_EMBEDDED_PATTERNS.map(
   (re) => new RegExp(String.raw`[\s.,!?:;\-–—]*(?:${re.source})[\s.,!?:;\-–—]*$`, "i"), // nosemgrep // NOSONAR — source patterns are hard-coded literals in utils.ts; anchored to `$`
 );
 
+// #1618 — Meetup occasionally promotes the group-level recurrence blurb
+// ("Every Wednesday @ 6:30pm from tbd") into the event title when the
+// per-occurrence title is missing. These are pure schedule template
+// strings, not real event names. Two narrow shapes catch the observed
+// Mel-NM corpus without false-positiving real trail names:
+//   1. Starts with "Every <weekday>" AND contains "@" — that "@" is
+//      almost always the time separator in the template, never used in
+//      organic hash titles starting with "Every Saturday Trail".
+//   2. Ends with "from TBA/TBC/TBD" — placeholder venue token that
+//      doesn't appear in real titles.
+const TEMPLATE_TITLE_PATTERNS: readonly RegExp[] = [
+  /^every\s+(?:sun|mon|tue|wed|thu|fri|sat)\w*\s*@/i,
+  /\bfrom\s+tb[adc]\.?\s*$/i,
+];
+
 export function cleanMeetupTitle(raw: string | null | undefined): string | undefined {
   if (!raw) return undefined;
+  // Drop template-shaped titles before any CTA stripping — merge.ts then
+  // synthesizes a "<KennelName> Trail #N" so users see something real.
+  if (TEMPLATE_TITLE_PATTERNS.some((re) => re.test(raw))) return undefined;
   // Stacked CTAs ("Trail 300 - Hares Needed - Claim This Trail!") need
   // multiple passes — each iteration peels one trailing CTA until stable.
   // Hard iteration cap (10) defends against a hypothetical future zero-width


### PR DESCRIPTION
## Summary

WS5 cycle-12 quick-win bundle closing 9 HashTracks data-quality issues across disjoint adapter/seed/script files. ~480 LOC.

Closes #1620
Closes #1617
Closes #1655
Closes #1642
Closes #1632
Closes #1618
Closes #1691
Closes #1701
Closes #1681

## Changes by issue

| Issue | Change |
|---|---|
| **#1620** MGH4 missing weekly Wednesdays | Seed: add 2nd STATIC_SCHEDULE source row "MGH4 Static Schedule (Weekly Wednesday)" alongside existing biweekly Saturday. Split-row pattern matches Mosquito H3 (1st Wed)/(3rd Wed). |
| **#1617** Mel-NM cross-kennel conflation | Seed: wire `kennelPatterns` on Mel-NM Meetup source to route the aggregator's 5 sibling kennels. Add 4 stub kennel rows (`melbourne-full-moon`, `delinquents-hhh`, `melbourne-city-h3`, `melbourne-bike-hash`) + aliases. Profiles are stubs pending AU research pass. |
| **#1655** BKK Harriettes stale haresText | Adapter: replace post-wins dedup with fieldwise coalesce in `bkk-harriettes.ts`. Tables carry richer hare formatting (`"Bob 'Aunries Bitch' N"`) that the truncated post body (`"Aunties Bitch"`) was clobbering. Table fields win when defined; post promotes parsed startTime + permalink. |
| **#1642** SG Sunday H3 haresText==location | Adapter: extend `#521` HC guard to handle substring overlap. `haresLooksLikeLocation` requires 2+ address signals (comma / leading digit / narrow street-token list — `park`/`court`/`way` excluded to protect hash names). |
| **#1632** MH3-MN test/admin events | Adapter: add `TEST_ARTIFACT_TITLE_PATTERNS` to google-calendar adapter — unconditional drop for `Trail # Test Event` / `PC Meeting`. Cleanup script soft-deletes existing leaked rows. |
| **#1618** Mel-NM stale-default-title | Adapter: reject template-shaped titles (`Every Wednesday @ 6:30pm from tbd`) in `cleanMeetupTitle` so merge.ts synthesizes `<KennelName> Trail #N`. |
| **#1691** Flour City URL-slug title | Adapter: add URL-slug detector gated on `titleMatchesKennelTag` — clears title when summary is literally the kennel slug (`flour-city`). Legit kebab themes (`red-dress-run`, `hash-trash`) are protected by the kennel-tag equivalence gate. |
| **#1701** Morgantown `MH3:` prefix | Cleanup script: strip `^MH3:\s*` from 6 backfilled events on `mh3-wv` (adapter strip rule was deployed mid-window). |
| **#1681** BAWC5 Marin H3 unlinked | Cleanup script: re-link Marin H3 #292 to BAWC5 umbrella `parentEventId`. Fails closed if (kennelId + runNumber + exact date) anchor not found. |

## Cleanup scripts

All three dry-run by default, `--apply` flag for destructive ops, idempotent on re-run:

- [`scripts/cleanup-mh3-mn-test-events.ts`](scripts/cleanup-mh3-mn-test-events.ts) (#1632)
- [`scripts/cleanup-morgantown-mh3-prefix.ts`](scripts/cleanup-morgantown-mh3-prefix.ts) (#1701)
- [`scripts/cleanup-bawc5-marin-orphan.ts`](scripts/cleanup-bawc5-marin-orphan.ts) (#1681)

## Post-merge actions

1. `npx prisma db seed` on Vercel — required for new MGH4 source row + Mel-NM kennelPatterns config + 4 new Melbourne kennels (per `feedback_post_merge_seed_required`).
2. Trigger re-scrape on affected sources (Mel-NM Meetup, MGH4, BKK Harriettes, MH3-MN GCal, Flour City GCal, Morgantown GCal) to surface healed events.
3. Run cleanup scripts with `--apply` flag — dry-run first, then apply.

## Test plan

- [x] `npm run lint` — 0 errors (22 pre-existing warnings unchanged)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 7519 passing (10 more than main; +750 in 4 affected adapter test files)
- [x] `/codex:adversarial-review` round 1 → 3 BLOCKING + 2 NIT; all addressed
- [x] `/codex:adversarial-review` round 2 → all 5 LGTM, no new issues
- [x] BKK Harriettes #2265 live-fetched from `bangkokharriettes.wordpress.com` homepage — table parse extracts correct hares + location
- [ ] Post-merge: run each cleanup script in dry-run, review output, then `--apply`
- [ ] Post-merge: trigger re-scrape on Mel-NM Meetup, confirm events route to 5 distinct kennels
- [ ] Post-merge: spot-check Flour City May 28 event has synthesized title (not slug)
- [ ] Post-merge: confirm Morgantown 6 affected events no longer show `MH3:` prefix
- [ ] Post-merge: confirm BAWC5 Marin H3 #292 renders under umbrella on `/kennels/sfh3` and `/kennels/marinh3`

## Risks / caveats

- **#1617 stub kennels**: 4 new Melbourne kennels ship with minimal profile data (kennelCode + shortName + fullName + region + country + scheduleNotes + lat/lng). Full enrichment (founded year, social URLs, definitive schedule cadence) belongs to a follow-up AU research pass per `reference_hhh_asn_au_directory` memory.
- **#1681 cleanup limitations**: re-links Marin H3 #292 to the existing BAWC5 umbrella. If SFH3's iCal feed republishes `/runs/6449`, a future scrape will independently relink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)