### PR TITLE
chore(backfill): cluster sweep — Mission H4 + MiHiHuHa + 3 cycle-12 carryovers

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1193,9 +1193,26 @@ export const SOURCES = [
       // #1339: feed carries ~40+ past events; widened from 180 to 1500 to recover
       // the historical archive. Paired with the iCal adapter's lookback derivation
       // (lookbackDays = source.scrapeDays ?? 90) so this also expands the past window.
+      //
+      // Known upstream quirk (observed 2026-05-26): when the kennel has zero
+      // upcoming events, this URL returns HTTP 200 + Content-Length: 0 (the WP
+      // plugin's "list" template throws on empty result rather than rendering
+      // an empty VCALENDAR). When upcoming events resume being scheduled, the
+      // feed returns proper content. The historical backfill went through the
+      // `events/list/?eventDisplay=past&ical=1` variant via a script-side URL
+      // override in scripts/backfill-ich3-history.ts — kept out of seed because
+      // the past-tab URL doesn't surface upcoming events for the live cron.
       scrapeDays: 1500,
       config: {
         defaultKennelTag: "ich3",
+        // upcomingOnly:true — REQUIRED so reconcile won't cancel the
+        // backfilled past events (#1339) once the kennel starts publishing
+        // new upcoming runs again. The seeded URL is `?eventDisplay=list`
+        // (upcoming-only), so an upcoming-only scrape returning N events
+        // would otherwise reconcile against ALL ich3 canonical events in
+        // the ±1500d window — flipping every backfilled past row to
+        // CANCELLED on the next successful cron tick.
+        upcomingOnly: true,
       },
       kennelCodes: ["ich3"],
     },

--- a/scripts/backfill-ich3-history.ts
+++ b/scripts/backfill-ich3-history.ts
@@ -1,0 +1,170 @@
+/**
+ * One-shot historical backfill for ICH3 (Iron City Hash House Harriers,
+ * Pittsburgh). Issue #1339.
+ *
+ * Drives the `Iron City H3 iCal Feed` source with a 1500-day window. The
+ * iCal adapter derives its lookback from `source.scrapeDays`, so a wider
+ * window pulls past events as well as future ones. The seed already carries
+ * `scrapeDays: 1500` (post-#1339), but the prod cron honors `Source.scrapeDays`
+ * from the DB row — only refreshed when `npx prisma db seed` runs. This
+ * script bypasses the wait by driving the adapter directly.
+ *
+ * Per the issue body the feed exposes ~40+ past events back to mid-2024.
+ * The wide window also picks up the upcoming `IC-Lite#25` event that's been
+ * missing — same kennel, just a different series prefix mapped to `ich3` via
+ * the source's `defaultKennelTag`.
+ *
+ * No iCal-backfill helper exists (vs. scripts/lib/gcal-backfill.ts), so this
+ * inlines the same shape: uniqueness-guard on source name, fetch with explicit
+ * `days`, partition (we keep BOTH past and future here — the upcoming
+ * IC-Lite#25 case is part of the close criteria), route through
+ * `processRawEvents`.
+ *
+ * Idempotent: `processRawEvents` dedupes by (sourceId, fingerprint).
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-ich3-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-ich3-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { ICalAdapter } from "@/adapters/ical/adapter";
+import { processRawEvents } from "@/pipeline/merge";
+import { todayInTimezone } from "@/lib/timezone";
+
+const SOURCE_NAME = "Iron City H3 iCal Feed";
+const WINDOW_DAYS = 1500;
+const TIMEZONE = "America/New_York";
+/**
+ * URL override — see seed comment at prisma/seed-data/sources.ts:1188. The
+ * historical seeded URL (`?post_type=tribe_events&ical=1&eventDisplay=list`)
+ * returns HTTP 200 + Content-Length: 0 when the kennel has no upcoming
+ * events; the `events/list/?eventDisplay=past&ical=1` form returns past
+ * events as proper VCALENDAR. The seed URL is INTENTIONALLY left at the
+ * upcoming variant — it'll start working again once the kennel schedules
+ * new events, and the past-tab URL doesn't surface upcoming events for the
+ * live cron. This script-only override exists so the historical backfill
+ * can pull past events independently of live-cron URL semantics.
+ */
+const FEED_URL_OVERRIDE = "https://ironcityh3.com/events/list/?eventDisplay=past&ical=1";
+
+async function main(): Promise<void> {
+  const apply = process.env.BACKFILL_APPLY === "1";
+  const todayIso = todayInTimezone(TIMEZONE);
+  console.log(`ICH3 iCal historical backfill: source="${SOURCE_NAME}"`);
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
+  console.log(`Window: ± ${WINDOW_DAYS} days. Today (${TIMEZONE}): ${todayIso}`);
+
+  try {
+    const sources = await prisma.source.findMany({ where: { name: SOURCE_NAME } });
+    if (sources.length === 0) {
+      throw new Error(`Source "${SOURCE_NAME}" not found in DB. Run prisma db seed first.`);
+    }
+    if (sources.length > 1) {
+      throw new Error(
+        `Multiple sources named "${SOURCE_NAME}" found (${sources.length}). Aborting to avoid writing to the wrong one.`,
+      );
+    }
+    const source = sources[0];
+
+    console.log("\nFetching iCal feed...");
+    const adapter = new ICalAdapter();
+    // Shallow copy with the working URL — see FEED_URL_OVERRIDE comment above.
+    const sourceWithOverride = { ...source, url: FEED_URL_OVERRIDE };
+    if (source.url !== FEED_URL_OVERRIDE) {
+      console.log(`  URL override: ${source.url} → ${FEED_URL_OVERRIDE}`);
+    }
+    const result = await adapter.fetch(sourceWithOverride, { days: WINDOW_DAYS });
+    if (result.errors && result.errors.length > 0) {
+      console.warn(`  Adapter reported ${result.errors.length} non-fatal error(s):`);
+      for (const e of result.errors.slice(0, 5)) console.warn(`    ${e}`);
+    }
+    console.log(`  Adapter returned ${result.events.length} events.`);
+
+    const past = result.events.filter((e) => e.date < todayIso);
+    const future = result.events.filter((e) => e.date >= todayIso);
+    console.log(`  Past: ${past.length} | Upcoming: ${future.length}`);
+
+    // Tally per-kennel — primarily `ich3`, but log distinct tags in case
+    // the kennel map gains siblings later.
+    const byKennel = new Map<string, number>();
+    for (const ev of result.events) {
+      byKennel.set(ev.kennelTags[0], (byKennel.get(ev.kennelTags[0]) ?? 0) + 1);
+    }
+    if (byKennel.size > 0) {
+      console.log("  Per-kennel:");
+      for (const [tag, n] of [...byKennel.entries()].sort((a, b) => b[1] - a[1])) {
+        console.log(`    ${tag}: ${n}`);
+      }
+    }
+
+    const sortedAll = [...result.events].sort((a, b) => a.date.localeCompare(b.date));
+    if (sortedAll.length > 0) {
+      console.log(`\nDate range: ${sortedAll[0].date} → ${sortedAll.at(-1)!.date}`);
+      console.log("Samples (oldest, middle, newest):");
+      const sampleIdx = [0, Math.floor(sortedAll.length / 2), sortedAll.length - 1];
+      for (const i of sampleIdx) {
+        const e = sortedAll[i];
+        console.log(
+          `  #${e.runNumber ?? "?"} ${e.date} | ${e.title ?? "—"} | hares=${e.hares ?? "—"} | loc=${e.location ?? "—"}`,
+        );
+      }
+    }
+
+    if (!apply) {
+      console.log("\nDry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
+      return;
+    }
+    if (result.events.length === 0) {
+      console.log("\nNothing to insert.");
+      return;
+    }
+
+    // Defensive: before writing past events, ensure the live source has
+    // `upcomingOnly: true` in its config so the next live cron tick won't
+    // reconcile-cancel everything we're about to insert. The seed already
+    // declares this (see seed comment), but the prod DB only picks it up
+    // after `npx prisma db seed` runs — this update bridges the gap.
+    // Idempotent: a subsequent seed run will overwrite back to the same value.
+    const existingConfig = (source.config as Record<string, unknown> | null) ?? {};
+    if (existingConfig.upcomingOnly !== true) {
+      const newConfig = { ...existingConfig, upcomingOnly: true };
+      await prisma.source.update({
+        where: { id: source.id },
+        data: { config: newConfig },
+      });
+      console.log(`  Set Source.config.upcomingOnly=true on "${source.name}" (prevents reconcile-cancel of backfilled past events).`);
+    } else {
+      console.log(`  Source.config.upcomingOnly already true — skipping config update.`);
+    }
+
+    console.log(`\nDelegating ${result.events.length} events to merge pipeline...`);
+    const merge = await processRawEvents(source.id, result.events);
+    console.log(
+      `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
+        `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
+    );
+    if (merge.unmatched.length > 0) {
+      console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
+    }
+    if (merge.blocked > 0) {
+      console.log(
+        `  Blocked: ${merge.blocked} events were rejected by source-kennel guard ` +
+          `(SourceKennel link missing for tag(s): ${merge.blockedTags.join(", ")}).`,
+      );
+    }
+    if (merge.eventErrors > 0) {
+      const sampleErrors = merge.eventErrorMessages.slice(0, 5).join("\n    ");
+      console.log(`  Errors:\n    ${sampleErrors}`);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-ich3-history.ts
+++ b/scripts/backfill-ich3-history.ts
@@ -120,15 +120,15 @@ async function main(): Promise<void> {
     // after `npx prisma db seed` runs — this update bridges the gap.
     // Idempotent: a subsequent seed run will overwrite back to the same value.
     const existingConfig = (source.config as Record<string, unknown> | null) ?? {};
-    if (existingConfig.upcomingOnly !== true) {
+    if (existingConfig.upcomingOnly === true) {
+      console.log(`  Source.config.upcomingOnly already true — skipping config update.`);
+    } else {
       const newConfig = { ...existingConfig, upcomingOnly: true };
       await prisma.source.update({
         where: { id: source.id },
         data: { config: newConfig },
       });
       console.log(`  Set Source.config.upcomingOnly=true on "${source.name}" (prevents reconcile-cancel of backfilled past events).`);
-    } else {
-      console.log(`  Source.config.upcomingOnly already true — skipping config update.`);
     }
 
     await mergeAndReport(source.id, result.events);

--- a/scripts/backfill-ich3-history.ts
+++ b/scripts/backfill-ich3-history.ts
@@ -31,8 +31,8 @@
 import "dotenv/config";
 import { prisma } from "@/lib/db";
 import { ICalAdapter } from "@/adapters/ical/adapter";
-import { processRawEvents } from "@/pipeline/merge";
 import { todayInTimezone } from "@/lib/timezone";
+import { logPerKennelTally, mergeAndReport } from "./lib/backfill-reporting";
 
 const SOURCE_NAME = "Iron City H3 iCal Feed";
 const WINDOW_DAYS = 1500;
@@ -87,18 +87,9 @@ async function main(): Promise<void> {
     const future = result.events.filter((e) => e.date >= todayIso);
     console.log(`  Past: ${past.length} | Upcoming: ${future.length}`);
 
-    // Tally per-kennel — primarily `ich3`, but log distinct tags in case
+    // Per-kennel tally — primarily `ich3`, but logs distinct tags in case
     // the kennel map gains siblings later.
-    const byKennel = new Map<string, number>();
-    for (const ev of result.events) {
-      byKennel.set(ev.kennelTags[0], (byKennel.get(ev.kennelTags[0]) ?? 0) + 1);
-    }
-    if (byKennel.size > 0) {
-      console.log("  Per-kennel:");
-      for (const [tag, n] of [...byKennel.entries()].sort((a, b) => b[1] - a[1])) {
-        console.log(`    ${tag}: ${n}`);
-      }
-    }
+    logPerKennelTally(result.events);
 
     const sortedAll = [...result.events].sort((a, b) => a.date.localeCompare(b.date));
     if (sortedAll.length > 0) {
@@ -140,25 +131,7 @@ async function main(): Promise<void> {
       console.log(`  Source.config.upcomingOnly already true — skipping config update.`);
     }
 
-    console.log(`\nDelegating ${result.events.length} events to merge pipeline...`);
-    const merge = await processRawEvents(source.id, result.events);
-    console.log(
-      `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
-        `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
-    );
-    if (merge.unmatched.length > 0) {
-      console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
-    }
-    if (merge.blocked > 0) {
-      console.log(
-        `  Blocked: ${merge.blocked} events were rejected by source-kennel guard ` +
-          `(SourceKennel link missing for tag(s): ${merge.blockedTags.join(", ")}).`,
-      );
-    }
-    if (merge.eventErrors > 0) {
-      const sampleErrors = merge.eventErrorMessages.slice(0, 5).join("\n    ");
-      console.log(`  Errors:\n    ${sampleErrors}`);
-    }
+    await mergeAndReport(source.id, result.events);
   } finally {
     await prisma.$disconnect();
   }

--- a/scripts/backfill-lds-h3-history.ts
+++ b/scripts/backfill-lds-h3-history.ts
@@ -1,0 +1,151 @@
+/**
+ * One-shot historical backfill for LDS H3 (Salt Lake City Late Daylight Sucks
+ * H3). Issue #1600.
+ *
+ * The Whoreman H3 Calendar (`4c78e8fc...@group.calendar.google.com`) is the
+ * primary public source for four Utah kennels: wasatch-h3, lds-h3, slosh-h3,
+ * slut-h3.
+ *
+ * Critical finding (2026-05-26 dry-run): the Google Calendar API
+ * (`GoogleCalendarAdapter`) returns only 52 LDS events for this calendar,
+ * but the public ICS feed exposes 74. The 22 missing events (covering
+ * #580-#627, Feb-Jul 2024) ARE in the source but only via the ICS endpoint
+ * — a known asymmetry between the v3 API and the basic.ics export. This
+ * script hits the ICS feed directly via `ICalAdapter` to recover them.
+ *
+ * The Source row stays typed as `GOOGLE_CALENDAR` (so the live cron keeps
+ * working — the API path is good for steady-state freshness, just lossy on
+ * historical events). The script constructs an in-memory iCal-shaped
+ * Source pointed at the ICS URL and routes the result through
+ * `processRawEvents` bound to the real Source ID. Provenance stays honest
+ * because the merge pipeline records sourceId, not adapter type.
+ *
+ * Sibling backfills: per-kennel tally is printed below. The same pass
+ * recovers historical context for wasatch-h3 / slosh-h3 / slut-h3 too —
+ * explicitly called out in the #1600 issue body as an intended bonus.
+ *
+ * Idempotent: `processRawEvents` dedupes by (sourceId, fingerprint), so
+ * re-runs are no-ops.
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-lds-h3-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-lds-h3-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { ICalAdapter } from "@/adapters/ical/adapter";
+import { processRawEvents } from "@/pipeline/merge";
+import { todayInTimezone } from "@/lib/timezone";
+
+const SOURCE_NAME = "Whoreman H3 Calendar";
+const TIMEZONE = "America/Denver";
+const WINDOW_DAYS = 1500;
+const ICS_URL =
+  "https://calendar.google.com/calendar/ical/4c78e8fc64a9536fa1f839765faf0eb6169e19aaa485fa40cb423795ebdfe7cb%40group.calendar.google.com/public/basic.ics";
+
+async function main(): Promise<void> {
+  const apply = process.env.BACKFILL_APPLY === "1";
+  const todayIso = todayInTimezone(TIMEZONE);
+  console.log(`LDS H3 (Whoreman calendar via ICS) historical backfill`);
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
+  console.log(`Window: ± ${WINDOW_DAYS} days. Today (${TIMEZONE}): ${todayIso}`);
+
+  try {
+    const sources = await prisma.source.findMany({ where: { name: SOURCE_NAME } });
+    if (sources.length === 0) throw new Error(`Source "${SOURCE_NAME}" not found in DB.`);
+    if (sources.length > 1) {
+      throw new Error(`Multiple sources named "${SOURCE_NAME}" found (${sources.length}). Aborting.`);
+    }
+    const source = sources[0];
+
+    // The seeded source has type=GOOGLE_CALENDAR + a kennel-ID URL. Shim a
+    // copy that points at the public ICS feed so ICalAdapter can consume it.
+    // The kennelPatterns + defaultKennelTag fields share the same shape
+    // across both adapters, so kennel routing works identically. GCal-only
+    // config keys are NOT honored by the iCal adapter:
+    //   - `strictKennelRouting: true` → ICalAdapter has no equivalent.
+    //     Unmatched events bucket into kennelTag "UNKNOWN" rather than
+    //     getting dropped, which surfaces as a single Unmatched tag report
+    //     from the merge pipeline (acceptable for a one-shot).
+    //   - `defaultTitles: { "wasatch-h3": "Wasatch H3 Trail" }` → ICalAdapter
+    //     does not substitute default titles, so backfilled Wasatch rows
+    //     keep bare titles like "wasatch #1144" instead of the substituted
+    //     "Wasatch H3 Trail #1144" the live GCal cron emits. Subsequent live
+    //     cron writes will create a sibling RawEvent with the corrected
+    //     title (different fingerprint) and the canonical resolution picks
+    //     whichever has higher trust/recency. Storage overhead only — not
+    //     user-visible.
+    const icalShimmedSource = { ...source, url: ICS_URL };
+
+    console.log(`\nFetching ICS from ${ICS_URL.slice(0, 80)}...`);
+    const adapter = new ICalAdapter();
+    const result = await adapter.fetch(icalShimmedSource, { days: WINDOW_DAYS });
+    if (result.errors && result.errors.length > 0) {
+      console.warn(`  Adapter reported ${result.errors.length} non-fatal error(s):`);
+      for (const e of result.errors.slice(0, 5)) console.warn(`    ${e}`);
+    }
+    console.log(`  Adapter returned ${result.events.length} events.`);
+
+    const historical = result.events.filter((e) => e.date < todayIso);
+    console.log(`  Historical (date < ${todayIso}): ${historical.length}`);
+
+    const byKennel = new Map<string, number>();
+    for (const ev of historical) {
+      byKennel.set(ev.kennelTags[0], (byKennel.get(ev.kennelTags[0]) ?? 0) + 1);
+    }
+    if (byKennel.size > 0) {
+      console.log("  Per-kennel:");
+      for (const [tag, n] of [...byKennel.entries()].sort((a, b) => b[1] - a[1])) {
+        console.log(`    ${tag}: ${n}`);
+      }
+    }
+
+    historical.sort((a, b) => a.date.localeCompare(b.date));
+    if (historical.length > 0) {
+      console.log(`\nDate range: ${historical[0].date} → ${historical.at(-1)!.date}`);
+      const sampleIdx = [0, Math.floor(historical.length / 2), historical.length - 1];
+      console.log("Samples (oldest, middle, newest):");
+      for (const i of sampleIdx) {
+        const e = historical[i];
+        console.log(
+          `  #${e.runNumber ?? "?"} ${e.date} ${e.kennelTags[0]} | ${e.title ?? "—"} | hares=${e.hares ?? "—"}`,
+        );
+      }
+    }
+
+    if (!apply) {
+      console.log("\nDry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
+      return;
+    }
+    if (historical.length === 0) {
+      console.log("\nNothing to insert.");
+      return;
+    }
+
+    console.log(`\nDelegating ${historical.length} events to merge pipeline...`);
+    const merge = await processRawEvents(source.id, historical);
+    console.log(
+      `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
+        `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
+    );
+    if (merge.unmatched.length > 0) console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
+    if (merge.blocked > 0) {
+      console.log(
+        `  Blocked: ${merge.blocked} events rejected by source-kennel guard (tags: ${merge.blockedTags.join(", ")}).`,
+      );
+    }
+    if (merge.eventErrors > 0) {
+      const sampleErrors = merge.eventErrorMessages.slice(0, 5).join("\n    ");
+      console.log(`  Errors:\n    ${sampleErrors}`);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-lds-h3-history.ts
+++ b/scripts/backfill-lds-h3-history.ts
@@ -36,8 +36,8 @@
 import "dotenv/config";
 import { prisma } from "@/lib/db";
 import { ICalAdapter } from "@/adapters/ical/adapter";
-import { processRawEvents } from "@/pipeline/merge";
 import { todayInTimezone } from "@/lib/timezone";
+import { logPerKennelTally, mergeAndReport } from "./lib/backfill-reporting";
 
 const SOURCE_NAME = "Whoreman H3 Calendar";
 const TIMEZONE = "America/Denver";
@@ -91,16 +91,7 @@ async function main(): Promise<void> {
     const historical = result.events.filter((e) => e.date < todayIso);
     console.log(`  Historical (date < ${todayIso}): ${historical.length}`);
 
-    const byKennel = new Map<string, number>();
-    for (const ev of historical) {
-      byKennel.set(ev.kennelTags[0], (byKennel.get(ev.kennelTags[0]) ?? 0) + 1);
-    }
-    if (byKennel.size > 0) {
-      console.log("  Per-kennel:");
-      for (const [tag, n] of [...byKennel.entries()].sort((a, b) => b[1] - a[1])) {
-        console.log(`    ${tag}: ${n}`);
-      }
-    }
+    logPerKennelTally(historical);
 
     historical.sort((a, b) => a.date.localeCompare(b.date));
     if (historical.length > 0) {
@@ -124,22 +115,7 @@ async function main(): Promise<void> {
       return;
     }
 
-    console.log(`\nDelegating ${historical.length} events to merge pipeline...`);
-    const merge = await processRawEvents(source.id, historical);
-    console.log(
-      `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
-        `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
-    );
-    if (merge.unmatched.length > 0) console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
-    if (merge.blocked > 0) {
-      console.log(
-        `  Blocked: ${merge.blocked} events rejected by source-kennel guard (tags: ${merge.blockedTags.join(", ")}).`,
-      );
-    }
-    if (merge.eventErrors > 0) {
-      const sampleErrors = merge.eventErrorMessages.slice(0, 5).join("\n    ");
-      console.log(`  Errors:\n    ${sampleErrors}`);
-    }
+    await mergeAndReport(source.id, historical);
   } finally {
     await prisma.$disconnect();
   }

--- a/scripts/backfill-leap-year-history.ts
+++ b/scripts/backfill-leap-year-history.ts
@@ -1,0 +1,70 @@
+/**
+ * CROSS-KENNEL HISTORICAL BACKFILL — Leap Year H3 (Seattle) + 12 WA siblings.
+ * Issue #1601.
+ *
+ * ⚠️  This script writes historical events for ALL 13 kennels on the WA
+ *     Hash Google Calendar — not just leapyear-h3 — by design. The
+ *     wide-window scrape returns one stream that the merge pipeline routes
+ *     via the calendar's `kennelPatterns` config. Codex review flagged the
+ *     misleading filename; keeping it because:
+ *
+ *       (a) The #1601 issue body explicitly calls the sibling backfill an
+ *           "audit bonus" — the only Leap Year H3 events themselves are 3
+ *           total (#6, #7, #8); the headline yield is the 12-sibling
+ *           historical refresh.
+ *       (b) Seed comment at prisma/seed-data/sources.ts:2367 documents the
+ *           same intent.
+ *       (c) Filtering down to leapyear-h3 only would discard the audit
+ *           bonus the issue specifically commissioned.
+ *
+ *     If you need a leapyear-h3-ONLY pass (e.g. for re-running with a
+ *     different filter), fork this script and post-filter `result.events`
+ *     down to `kennelTags[0] === "leapyear-h3"` before delegating to merge.
+ *
+ * Drives the WA Hash Google Calendar with a 7500-day window (~20.5yr) to
+ * recover the three historical Leap Year events HashTracks was missing:
+ *
+ *   - #6 (2008-02-29) — NOT recovered: calendar owner cleaned it
+ *   - #7 (2012-02-29) ✓ landed
+ *   - #8 (2016-02-29) ✓ landed
+ *
+ * These sit in the Whoreman-format WA Hash Calendar (the primary aggregator
+ * for 13 WA kennels), and reach the LeapYear kennel via `kennelPatterns`
+ * routing in the seed. The seeded `scrapeDays: 1500` (post-#1601) only
+ * reaches Feb 2022, so we override to 7500 here to span back to ~2005.
+ *
+ * Sibling backfills: per-kennel tally printed by the helper. The same pass
+ * recovers historical context for the other 12 WA kennels (sh3-wa, psh3,
+ * nbh3-wa, rch3-wa, seamon-h3, th3-wa, ssh3-wa, cunth3-wa, taint-h3,
+ * giggity-h3, seh3-wa, hswtf-h3) — explicitly called out as an audit bonus
+ * in the seed comment at prisma/seed-data/sources.ts:2367.
+ *
+ * Explicitly out of scope (deferred):
+ *   The 2 future placeholders #15 (2044-02-29) / #16 (2048-02-29) live on
+ *   the Leap Year H3 Hareline Sheet (GOOGLE_SHEETS) source, not on this
+ *   calendar. Bumping the sheet's scrapeDays past 22yr would surface every
+ *   interstitial "??" placeholder row through 2048 as canonical data
+ *   (Codex pushback, reverted in commit e0a61808). See seed comment at
+ *   prisma/seed-data/sources.ts:2472-2477 for the rationale.
+ *
+ * Idempotent: `processRawEvents` dedupes by (sourceId, fingerprint).
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-leap-year-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-leap-year-history.ts
+ *   Env:       DATABASE_URL, GOOGLE_CALENDAR_API_KEY
+ */
+
+import "dotenv/config";
+import { runGCalBackfill } from "./lib/gcal-backfill";
+
+runGCalBackfill({
+  sourceName: "WA Hash Google Calendar",
+  // 7500 days ≈ 20.5 yr — spans back to ~2005-12, comfortably reaching
+  // Leap Year #6 (2008-02-29) and #7 (2012-02-29). 4500 / 6500 attempts
+  // landed only #7+; the calendar owner retains events to at least 2008.
+  // The Google Calendar API tolerates the deeper window — the calendar
+  // returns whatever it has (the owner controls retention).
+  days: 7500,
+  timezone: "America/Los_Angeles",
+});

--- a/scripts/backfill-mihihuha-history.test.ts
+++ b/scripts/backfill-mihihuha-history.test.ts
@@ -6,7 +6,7 @@ function ev(over: Partial<RawEventData>): RawEventData {
     date: "2017-06-01",
     kennelTags: ["mihi-huha"],
     ...over,
-  } as RawEventData;
+  };
 }
 
 describe("filterHandEditedMihiHuHa", () => {

--- a/scripts/backfill-mihihuha-history.test.ts
+++ b/scripts/backfill-mihihuha-history.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { filterHandEditedMihiHuHa } from "./backfill-mihihuha-history";
+import type { RawEventData } from "@/adapters/types";
+
+function ev(over: Partial<RawEventData>): RawEventData {
+  return {
+    date: "2017-06-01",
+    kennelTags: ["mihi-huha"],
+    ...over,
+  } as RawEventData;
+}
+
+describe("filterHandEditedMihiHuHa", () => {
+  it("keeps a 2017 hand-edited event with explicit #N", () => {
+    const kept = ev({ date: "2017-06-15", runNumber: 80, title: "MiHiHuHa #80" });
+    expect(filterHandEditedMihiHuHa([kept])).toEqual([kept]);
+  });
+
+  it("keeps a 2016 hand-edited event with theme separator (':')", () => {
+    const kept = ev({ date: "2016-04-13", title: "MiHiHuHa: Chip and Dale" });
+    expect(filterHandEditedMihiHuHa([kept])).toEqual([kept]);
+  });
+
+  it("keeps a 2016 event with theme separator (' - ')", () => {
+    const kept = ev({ date: "2016-08-03", title: "Mile High Humpin' Hash - Cream of Tuna" });
+    expect(filterHandEditedMihiHuHa([kept])).toEqual([kept]);
+  });
+
+  it("drops a phantom-titled 2017 event even when hares are present (phantom check wins)", () => {
+    const dropped = ev({ date: "2017-08-12", title: "Mile High Humpin' Hash", hares: "Fist Deep" });
+    // Bareness is checked BEFORE the positive-signal check — a phantom-title
+    // row is always noise, even if hare data was attached by mistake.
+    expect(filterHandEditedMihiHuHa([dropped])).toEqual([]);
+  });
+
+  it("keeps a 2017 event with hares + a non-phantom bare title variant", () => {
+    const kept = ev({ date: "2017-08-12", title: "MiHiHuHa Annual Trail", hares: "Tainted Glove" });
+    expect(filterHandEditedMihiHuHa([kept])).toEqual([kept]);
+  });
+
+  it("keeps a 2017 event with only location set", () => {
+    const kept = ev({ date: "2017-09-01", title: "Some other title", location: "Lions Park, Golden, CO" });
+    expect(filterHandEditedMihiHuHa([kept])).toEqual([kept]);
+  });
+
+  it("drops a 2017 event that is bare phantom title + nothing else", () => {
+    const noise = ev({ date: "2017-06-15", title: "Mile High Humpin' Hash" });
+    expect(filterHandEditedMihiHuHa([noise])).toEqual([]);
+  });
+
+  it("drops the bare RRULE-phantom title 'MiHiHuHa'", () => {
+    const noise = ev({ date: "2017-06-15", title: "MiHiHuHa" });
+    expect(filterHandEditedMihiHuHa([noise])).toEqual([]);
+  });
+
+  it("drops a 2017 event with non-phantom title but no positive signal (fail-closed)", () => {
+    const ambiguous = ev({ date: "2017-06-15", title: "Mystery 2017 entry" });
+    expect(filterHandEditedMihiHuHa([ambiguous])).toEqual([]);
+  });
+
+  it("ignores leading/trailing whitespace when matching phantom titles", () => {
+    const noise = ev({ date: "2017-06-15", title: "  Mile High Humpin' Hash  " });
+    expect(filterHandEditedMihiHuHa([noise])).toEqual([]);
+  });
+
+  it("drops a 2023 event (outside hand-edited era) even with run number", () => {
+    const recent = ev({ date: "2023-04-05", runNumber: 432, title: "MiHiHuHa #432" });
+    expect(filterHandEditedMihiHuHa([recent])).toEqual([]);
+  });
+
+  it("drops a 2015 event (before hand-edited era)", () => {
+    const tooOld = ev({ date: "2015-12-31", runNumber: 46, title: "MiHiHuHa #46" });
+    expect(filterHandEditedMihiHuHa([tooOld])).toEqual([]);
+  });
+
+  it("keeps boundary dates (Jan 1 2016 and Dec 31 2018)", () => {
+    const lower = ev({ date: "2016-01-01", runNumber: 47, title: "MiHiHuHa #47" });
+    const upper = ev({ date: "2018-12-31", runNumber: 160, title: "MiHiHuHa #160" });
+    expect(filterHandEditedMihiHuHa([lower, upper])).toEqual([lower, upper]);
+  });
+});

--- a/scripts/backfill-mihihuha-history.test.ts
+++ b/scripts/backfill-mihihuha-history.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { filterHandEditedMihiHuHa } from "./backfill-mihihuha-history";
 import type { RawEventData } from "@/adapters/types";
 
@@ -35,6 +34,11 @@ describe("filterHandEditedMihiHuHa", () => {
 
   it("keeps a 2017 event with hares + a non-phantom bare title variant", () => {
     const kept = ev({ date: "2017-08-12", title: "MiHiHuHa Annual Trail", hares: "Tainted Glove" });
+    expect(filterHandEditedMihiHuHa([kept])).toEqual([kept]);
+  });
+
+  it("keeps a 2017 event with only hares set (no runNumber, no theme, non-phantom title)", () => {
+    const kept = ev({ date: "2017-08-12", title: "MiHiHuHa Annual Theme", hares: "Tainted Glove" });
     expect(filterHandEditedMihiHuHa([kept])).toEqual([kept]);
   });
 

--- a/scripts/backfill-mihihuha-history.ts
+++ b/scripts/backfill-mihihuha-history.ts
@@ -35,8 +35,8 @@
 import "dotenv/config";
 import { prisma } from "@/lib/db";
 import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
-import { processRawEvents } from "@/pipeline/merge";
 import type { RawEventData } from "@/adapters/types";
+import { mergeAndReport } from "./lib/backfill-reporting";
 
 const SOURCE_NAME = "Mile High Humpin Hash Calendar";
 const WINDOW_DAYS = 4000;
@@ -150,25 +150,7 @@ async function main(): Promise<void> {
       return;
     }
 
-    console.log(`\nDelegating ${handEdited.length} events to merge pipeline...`);
-    const merge = await processRawEvents(source.id, handEdited);
-    console.log(
-      `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
-        `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
-    );
-    if (merge.unmatched.length > 0) {
-      console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
-    }
-    if (merge.blocked > 0) {
-      console.log(
-        `  Blocked: ${merge.blocked} events were rejected by source-kennel guard ` +
-          `(SourceKennel link missing for tag(s): ${merge.blockedTags.join(", ")}).`,
-      );
-    }
-    if (merge.eventErrors > 0) {
-      const sampleErrors = merge.eventErrorMessages.slice(0, 5).join("\n    ");
-      console.log(`  Errors:\n    ${sampleErrors}`);
-    }
+    await mergeAndReport(source.id, handEdited);
   } finally {
     await prisma.$disconnect();
   }

--- a/scripts/backfill-mihihuha-history.ts
+++ b/scripts/backfill-mihihuha-history.ts
@@ -1,0 +1,182 @@
+/**
+ * One-shot historical backfill for MiHiHuHa (Mile High Humpin' Hash, Denver).
+ * Issue #1664.
+ *
+ * Premise: HashTracks oldest run on file is #416 (2023-04). The primary
+ * `huhahareraiser@gmail.com` calendar carries ~44 hand-edited VEVENTs
+ * spanning 2016-02-10 (#47) → 2018-09 (#160) — the kennel's pre-aggregator
+ * history that no other source preserves.
+ *
+ * The catch (per the issue body): this calendar also harbors a stale
+ * recurring rule that would materialize phantom 2017 weekly trails if the
+ * live cron ran with a wide window. So we keep the live source's seeded
+ * `scrapeDays: 90` UNTOUCHED and run a one-shot wide-window pull here,
+ * filtered to the hand-edited slice only:
+ *
+ *   1. Date in [2016-01-01, 2018-12-31] — drops everything outside the
+ *      known hand-edited era, including future ghost expansions.
+ *   2. `runNumber !== undefined` — only events whose title carries an
+ *      explicit `#N` survive. The hand-edited rows always do
+ *      ("MiHiHuHa #47: Tunnel of Love"); the RRULE-noise rows don't.
+ *
+ * `runs #161–#415` (2018-10 → 2023-03) have no digital record — Apollo
+ * Discord channel history is the only trace, and that's not crawlable
+ * without OAuth. Deferred per the issue body.
+ *
+ * Idempotent: `processRawEvents` dedupes by (sourceId, fingerprint).
+ * Bound to source: "Mile High Humpin Hash Calendar".
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-mihihuha-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-mihihuha-history.ts
+ *   Env:       DATABASE_URL, GOOGLE_CALENDAR_API_KEY
+ */
+
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
+import { processRawEvents } from "@/pipeline/merge";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Mile High Humpin Hash Calendar";
+const WINDOW_DAYS = 4000;
+const HAND_EDITED_START = "2016-01-01";
+const HAND_EDITED_END = "2018-12-31";
+
+/**
+ * Hard-coded bare phantom titles emitted by the stale RRULE in the source
+ * calendar. The dry-run-against-prod pass on 2026-05-26 found exactly two
+ * distinct strings accounting for all 132 noise rows (118x + 14x); every
+ * hand-edited event has a unique theme-appended title and survives.
+ *
+ * Trimmed-and-compared, case-sensitive on purpose — these are the literal
+ * SUMMARY strings the calendar emits.
+ */
+const PHANTOM_TITLES: ReadonlySet<string> = new Set([
+  "Mile High Humpin' Hash",
+  "MiHiHuHa",
+]);
+
+/** Theme-separator markers that signal a hand-edited event whose title
+ * carries a sub-name ("Mile High Humpin' Hash - Cream of Tuna",
+ * "MiHiHuHa: Chip and Dale"). The phantom-title strings never contain
+ * these; including them as a positive signal keeps the filter from being
+ * fail-open against unknown future RRULE-noise variants. */
+const THEME_SEPARATORS: readonly string[] = [" - ", " — ", " – ", ": ", " | "];
+
+function hasThemeSeparator(title: string): boolean {
+  return THEME_SEPARATORS.some((sep) => title.includes(sep));
+}
+
+/**
+ * Filter the wide-window adapter output down to the hand-edited 2016-2018
+ * slice. Pure function so the test can exercise it in isolation.
+ *
+ * Conditions (all must hold):
+ *   - Date in the known hand-edited era [2016-01-01, 2018-12-31].
+ *   - Title is NOT one of the two bare RRULE-phantom strings.
+ *   - At least one POSITIVE hand-edited signal: a parsed run number, named
+ *     hares, a populated location, or a theme separator in the title. Pure
+ *     date+title-suffix events with no other content are dropped.
+ *
+ * The positive-signal requirement makes the filter fail-CLOSED: if a future
+ * RRULE-noise variant escapes the phantom set (e.g. a typo'd "MiHiHuHa  "
+ * with trailing whitespace, or a new bare title we haven't catalogued), it
+ * won't slip through unless it also carries a hashing-event fingerprint.
+ */
+export function filterHandEditedMihiHuHa(events: readonly RawEventData[]): RawEventData[] {
+  return events.filter((e) => {
+    if (e.date < HAND_EDITED_START || e.date > HAND_EDITED_END) return false;
+    const title = (e.title ?? "").trim();
+    if (PHANTOM_TITLES.has(title)) return false;
+    const hasRunNumber = e.runNumber !== undefined && e.runNumber !== null;
+    const hasHares = typeof e.hares === "string" && e.hares.trim().length > 0;
+    const hasLocation = typeof e.location === "string" && e.location.trim().length > 0;
+    return hasRunNumber || hasHares || hasLocation || hasThemeSeparator(title);
+  });
+}
+
+async function main(): Promise<void> {
+  const apply = process.env.BACKFILL_APPLY === "1";
+  console.log(`MiHiHuHa historical backfill: source="${SOURCE_NAME}"`);
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
+  console.log(`Window: ± ${WINDOW_DAYS} days, filtered to ${HAND_EDITED_START}..${HAND_EDITED_END}, RRULE-phantom titles dropped`);
+
+  try {
+    // Same uniqueness guard as scripts/lib/backfill-runner.ts — ambiguous
+    // source names must abort, never silently bind to the first match.
+    const sources = await prisma.source.findMany({ where: { name: SOURCE_NAME } });
+    if (sources.length === 0) {
+      throw new Error(`Source "${SOURCE_NAME}" not found in DB. Run prisma db seed first.`);
+    }
+    if (sources.length > 1) {
+      throw new Error(
+        `Multiple sources named "${SOURCE_NAME}" found (${sources.length}). Aborting to avoid writing to the wrong one.`,
+      );
+    }
+    const source = sources[0];
+
+    console.log("\nFetching from Google Calendar API...");
+    const adapter = new GoogleCalendarAdapter();
+    const result = await adapter.fetch(source, { days: WINDOW_DAYS });
+    if (result.errors && result.errors.length > 0) {
+      console.warn(`  Adapter reported ${result.errors.length} non-fatal error(s):`);
+      for (const e of result.errors.slice(0, 5)) console.warn(`    ${e}`);
+    }
+    console.log(`  Adapter returned ${result.events.length} events.`);
+
+    const handEdited = filterHandEditedMihiHuHa(result.events);
+    console.log(`  After hand-edited filter: ${handEdited.length}`);
+
+    handEdited.sort((a, b) => a.date.localeCompare(b.date));
+    if (handEdited.length > 0) {
+      console.log(`\nDate range: ${handEdited[0].date} → ${handEdited.at(-1)!.date}`);
+      const sampleIdx = [0, Math.floor(handEdited.length / 2), handEdited.length - 1];
+      console.log("Samples (oldest, middle, newest):");
+      for (const i of sampleIdx) {
+        const e = handEdited[i];
+        console.log(
+          `  #${e.runNumber ?? "?"} ${e.date} | ${e.title ?? "—"} | hares=${e.hares ?? "—"} | loc=${e.location ?? "—"}`,
+        );
+      }
+    }
+
+    if (!apply) {
+      console.log("\nDry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
+      return;
+    }
+    if (handEdited.length === 0) {
+      console.log("\nNothing to insert.");
+      return;
+    }
+
+    console.log(`\nDelegating ${handEdited.length} events to merge pipeline...`);
+    const merge = await processRawEvents(source.id, handEdited);
+    console.log(
+      `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
+        `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
+    );
+    if (merge.unmatched.length > 0) {
+      console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
+    }
+    if (merge.blocked > 0) {
+      console.log(
+        `  Blocked: ${merge.blocked} events were rejected by source-kennel guard ` +
+          `(SourceKennel link missing for tag(s): ${merge.blockedTags.join(", ")}).`,
+      );
+    }
+    if (merge.eventErrors > 0) {
+      const sampleErrors = merge.eventErrorMessages.slice(0, 5).join("\n    ");
+      console.log(`  Errors:\n    ${sampleErrors}`);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+if (process.argv[1]?.endsWith("backfill-mihihuha-history.ts")) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/backfill-mission-h4-history.ts
+++ b/scripts/backfill-mission-h4-history.ts
@@ -1,0 +1,43 @@
+/**
+ * One-shot historical backfill for Mission H4 / Mission Harriettes (San Diego).
+ * Issue #1666.
+ *
+ * `https://sdh3.com/history.shtml` lists every SD-area hash back to Dec 2006.
+ * Filtering for `(Mission Harriettes)` gives ~157 events spanning 2006-12-20 →
+ * present. HashTracks tracked only 15 (date floor 2025-03-26) before this
+ * backfill — the live SDH3 hareline source can only see upcoming events, and
+ * pre-2011 per-event detail pages are the only enrichment that still resolves
+ * (post-2011 detail URLs all 404).
+ *
+ * Strategy: delegated to `backfillSdh3HistoryKennel` (scripts/lib/sdh3-history-backfill.ts).
+ * Same pattern as backfill-hah3-history.ts (#1314) and backfill-irh3-history.ts (#1425).
+ *
+ * Why attribute to "SDH3 Hareline":
+ *   That source already has the 10-kennel SourceKennel link including
+ *   mh4-sd (see prisma/seed-data/sources.ts kennelCodes array), so the
+ *   merge pipeline's per-event source-kennel guard accepts the rows.
+ *   Reconcile risk is zero — historical events are far outside the live
+ *   reconcile window, so future live scrapes won't cancel them.
+ *
+ * Coverage limit:
+ *   The history page only carries date + start time + title + kennel; hares /
+ *   location / description / cost fields stay null on backfilled rows. That's
+ *   expected and documented in #1666.
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-mission-h4-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-mission-h4-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import { backfillSdh3HistoryKennel } from "./lib/sdh3-history-backfill";
+
+backfillSdh3HistoryKennel({
+  kennelCode: "mh4-sd",
+  kennelDisplayName: "Mission Harriettes",
+  label: "Walking SDH3 history.shtml for Mission Harriettes entries",
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lib/backfill-reporting.ts
+++ b/scripts/lib/backfill-reporting.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared reporting/merge tail for one-shot backfill scripts.
+ *
+ * Every adapter-driven backfill script ends with the same three blocks:
+ *   1. Per-kennel tally of the events about to be inserted.
+ *   2. Delegation to `processRawEvents` for the actual merge.
+ *   3. Pretty-printed merge result + per-error/blocked/unmatched breakdown.
+ *
+ * These are extracted here so the per-script files can collapse to the
+ * unique parts (URL override, kennel filter, config update). Without the
+ * extraction the same ~18 lines repeat across gcal-backfill.ts, lds-h3,
+ * ich3, and mihihuha — flagged as 9% duplicated lines by SonarCloud on
+ * the cluster-sweep PR.
+ *
+ * No DB connection management here — callers own `prisma.$disconnect()`
+ * in their own `try/finally`, because some scripts (e.g. ICH3) need to
+ * keep the connection open for a config-row update before the merge.
+ */
+
+import { processRawEvents } from "@/pipeline/merge";
+import type { RawEventData } from "@/adapters/types";
+
+/**
+ * Log a per-kennel tally of the events about to be inserted. Sorted by
+ * descending count so the biggest backfill targets surface first.
+ *
+ * Empty event list → no output. Caller is expected to handle the
+ * empty-input case separately.
+ */
+export function logPerKennelTally(events: readonly RawEventData[]): void {
+  if (events.length === 0) return;
+  const byKennel = new Map<string, number>();
+  for (const ev of events) {
+    const tag = ev.kennelTags[0];
+    byKennel.set(tag, (byKennel.get(tag) ?? 0) + 1);
+  }
+  if (byKennel.size === 0) return;
+  console.log("  Per-kennel:");
+  for (const [tag, n] of [...byKennel.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${tag}: ${n}`);
+  }
+}
+
+/**
+ * Delegate the historical event slice to the merge pipeline and pretty-
+ * print the result. Surfaces the standard breakdowns:
+ *   - created / updated / skipped / unmatched / blocked / eventErrors
+ *   - unmatched kennel tags (when any)
+ *   - blocked tags + reason (when any)
+ *   - first 5 event-error messages (when any)
+ *
+ * Returns the raw merge result so callers can post-assert (e.g. fail loud
+ * if blocked > N) if they want.
+ */
+export async function mergeAndReport(
+  sourceId: string,
+  events: readonly RawEventData[],
+): Promise<Awaited<ReturnType<typeof processRawEvents>>> {
+  console.log(`\nDelegating ${events.length} events to merge pipeline...`);
+  const merge = await processRawEvents(sourceId, events as RawEventData[]);
+  console.log(
+    `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
+      `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
+  );
+  if (merge.unmatched.length > 0) {
+    console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
+  }
+  if (merge.blocked > 0) {
+    console.log(
+      `  Blocked: ${merge.blocked} events were rejected by source-kennel guard ` +
+        `(SourceKennel link missing for tag(s): ${merge.blockedTags.join(", ")}).`,
+    );
+  }
+  if (merge.eventErrors > 0) {
+    const sampleErrors = merge.eventErrorMessages.slice(0, 5).join("\n    ");
+    console.log(`  Errors:\n    ${sampleErrors}`);
+  }
+  return merge;
+}

--- a/scripts/lib/gcal-backfill.ts
+++ b/scripts/lib/gcal-backfill.ts
@@ -18,9 +18,9 @@
 
 import { prisma } from "@/lib/db";
 import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
-import { processRawEvents } from "@/pipeline/merge";
 import { todayInTimezone } from "@/lib/timezone";
 import type { RawEventData } from "@/adapters/types";
+import { logPerKennelTally, mergeAndReport } from "./backfill-reporting";
 
 export interface GCalBackfillParams {
   /** Source.name to look up in the DB. */
@@ -87,17 +87,7 @@ export async function backfillGCalSource(params: GCalBackfillParams): Promise<vo
     const historical = result.events.filter((e) => e.date < todayIso);
     console.log(`  Historical (date < ${todayIso}): ${historical.length}`);
 
-    // Tally per-kennel for visibility on multi-kennel calendars.
-    const byKennel = new Map<string, number>();
-    for (const ev of historical) {
-      byKennel.set(ev.kennelTags[0], (byKennel.get(ev.kennelTags[0]) ?? 0) + 1);
-    }
-    if (byKennel.size > 0) {
-      console.log("  Per-kennel:");
-      for (const [tag, n] of [...byKennel.entries()].sort((a, b) => b[1] - a[1])) {
-        console.log(`    ${tag}: ${n}`);
-      }
-    }
+    logPerKennelTally(historical);
 
     historical.sort((a, b) => a.date.localeCompare(b.date));
     if (historical.length > 0) {
@@ -114,25 +104,7 @@ export async function backfillGCalSource(params: GCalBackfillParams): Promise<vo
       return;
     }
 
-    console.log(`\nDelegating ${historical.length} events to merge pipeline...`);
-    const merge = await processRawEvents(source.id, historical);
-    console.log(
-      `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
-        `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
-    );
-    if (merge.unmatched.length > 0) {
-      console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
-    }
-    if (merge.blocked > 0) {
-      console.log(
-        `  Blocked: ${merge.blocked} events were rejected by source-kennel guard ` +
-          `(SourceKennel link missing for tag(s): ${merge.blockedTags.join(", ")}).`,
-      );
-    }
-    if (merge.eventErrors > 0) {
-      const sampleErrors = merge.eventErrorMessages.slice(0, 5).join("\n    ");
-      console.log(`  Errors:\n    ${sampleErrors}`);
-    }
+    await mergeAndReport(source.id, historical);
   } finally {
     if (!params.keepConnected) {
       await prisma.$disconnect();


### PR DESCRIPTION
## Summary

Five one-shot historical backfill scripts + one test, plus an ICH3 seed comment and a defensive `upcomingOnly: true` config flag. All five scripts route through `processRawEvents` — idempotent on re-run via fingerprint dedup. Verified end-to-end against prod DB.

## Per-issue yield

| Issue | Kennel | Before → After | Notes |
|------|--------|---------------|-------|
| #1666 | Mission H4 | 15 → **148** (+133) | Wraps `backfillSdh3HistoryKennel`. Oldest now 2006-12-20. |
| #1664 | MiHiHuHa | 155 → **175** (+20 hand-edited #47-#126) | Filters wide-window GCal to hand-edited 2016-2018 + drops RRULE-phantom titles + requires positive signal. |
| #1600 | LDS H3 | 64 → **113** (+49) | Switched to ICS feed via `ICalAdapter` shim — GCal API returns 52, ICS exposes 74 for this calendar. |
| #1601 | Leap Year | 6 → **8** (+#7 2012, +#8 2016) | Partial; #6 (2008) not recoverable (calendar owner cleaned it). #15/#16 future placeholders stay deferred. |
| #1339 | ICH3 | 1 → **30** | + recovered upcoming IC-Lite#25. Script-only URL override; seed retains upcoming-events URL. |

## Sibling backfill bonus

LDS via Whoreman calendar + Leap Year via WA Hash calendar pulled in historical context for 15 other kennels (explicitly called out as bonus in the issue bodies):

- **Whoreman siblings:** wasatch-h3 +33 past, slosh-h3 +15 past, slut-h3 +10 past.
- **WA Hash siblings:** sh3-wa +815, seamon-h3 +571, psh3 +389, seh3-wa +371, rch3-wa +224, nbh3-wa +206, th3-wa +189, hswtf-h3 +138, ssh3-wa +134, giggity-h3 +115, cunth3-wa +87, taint-h3 +32.

## Design notes (Codex adversarial review applied)

- **MiHiHuHa filter**: fail-CLOSED — requires positive signal (runNumber, hares, location, or theme separator in title). Dry-run-against-prod confirmed 2 distinct phantom titles ("Mile High Humpin' Hash" 118x + "MiHiHuHa" 14x).
- **LDS script (ICS shim)**: ICalAdapter doesn't honor GCal-only config keys (`strictKennelRouting`, `defaultTitles`) — documented inline. Wasatch sibling titles may drift from live cron output by one fingerprint until next cron creates the canonical-titled twin (storage overhead, not user-visible).
- **Leap Year script**: cross-kennel scope by design — filename docstring carries a prominent ⚠️ warning. Filtering down to leapyear-h3 only would discard the audit-bonus the issue specifically commissioned.
- **ICH3 reconcile safety**: script defensively sets `Source.config.upcomingOnly=true` before writing past events — without this, the live cron's reconcile (`scrapeDays=1500`, no upcomingOnly) would cancel every backfilled past row once the kennel resumes scheduling upcoming events. Seed updated to match.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (22 pre-existing warnings, 0 new)
- [x] `npm test` — 7492 pass / 0 fail (13 new MiHiHuHa filter tests)
- [x] Dry-run + apply each script against prod DATABASE_URL
- [x] Spot-check oldest + middle + newest backfilled events per kennel
- [x] Re-run each script to confirm idempotency (created=0 on second pass)
- [x] Codex adversarial review (3 high findings addressed: filter strengthened, comment fixed, reconcile-cancel hazard mitigated)
- [x] `/simplify` 3-angle review (1 critical finding — ICH3 upcomingOnly — addressed)

Closes #1666
Closes #1664
Closes #1600
Closes #1601
Closes #1339

🤖 Generated with [Claude Code](https://claude.com/claude-code)