### PR TITLE
fix(1665): correct mh4-sd foundedYear 1991 → 1990 via follow-up migration

### DIFF
--- a/prisma/migrations/20260527143000_fix_mh4_sd_founded_year_1990/migration.sql
+++ b/prisma/migrations/20260527143000_fix_mh4_sd_founded_year_1990/migration.sql
@@ -1,0 +1,41 @@
+-- Follow-up to 20260526120000_fix_profile_round_13 (PR #1722 Codex P2).
+--
+-- The original migration was authored with v_founded=1991 (derived from the
+-- issue's "35th Analvesary Turnover 2026" math). Codex review on PR #1722
+-- pointed out the canonical source is sdh3.com history: "San Diego Mission
+-- Harriettes Established Nov 10, 1990". A subsequent fix commit on the same
+-- PR rewrote 20260526120000's SQL to v_founded=1990, but by that point the
+-- PR's preview deployment had already run `prisma migrate deploy` against
+-- prod (Vercel's vercel-build does this on every deploy, preview included)
+-- and applied the 1991 version. Editing an already-applied migration file
+-- can't reach prod — Prisma `migrate deploy` is keyed on migration_name and
+-- only runs each migration once.
+--
+-- This migration ships the 1990 correction as a forward fix per the
+-- "migrations are immutable once applied" rule in CLAUDE.md. Idempotent via
+-- `IS DISTINCT FROM` so re-application is a no-op.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_kennel_code         text := 'mh4-sd';
+  v_correct_founded     int  := 1990;
+  v_correct_description text := 'Mission Harriettes — San Diego''s women-only monthly hash, founded November 10, 1990 (per sdh3.com history). Wednesdays once a month, 6:30 PM start.';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
+    RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', v_kennel_code;  -- NOSONAR plsql:S1192
+  END IF;
+
+  UPDATE "Kennel"
+  SET "foundedYear" = v_correct_founded,
+      description   = v_correct_description,
+      "updatedAt"   = NOW()
+  WHERE "kennelCode" = v_kennel_code
+    AND (
+      "foundedYear" IS DISTINCT FROM v_correct_founded
+      OR description IS DISTINCT FROM v_correct_description
+    );
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Follow-up to PR #1722 (Profile Round 13).

## Why a follow-up migration

Codex review on #1722 flagged that Mission Harriettes was founded **November 10, 1990** per sdh3.com history, not 1991 as derived from the issue's "35th Analvesary Turnover 2026" math. A fix commit (`451ecb82`) on #1722 rewrote `20260526120000_fix_profile_round_13/migration.sql` from `v_founded := 1991` to `v_founded := 1990`.

**That edit reached the file on disk but not prod.** Vercel's \`vercel-build\` runs \`prisma migrate deploy\` on every deploy (preview included), which had already applied the 1991 version of the migration during the PR's preview deployment. Prisma keys migrations by \`migration_name\` and won't re-run an already-applied migration even if the SQL content changes. Result: prod ended up with \`foundedYear = 1991\` and the stale description text, despite the merged code showing 1990.

Per CLAUDE.md (\"Migration files are immutable once applied — to undo a change, add a new migration\"), this PR ships the 1990 correction as a forward fix instead of editing the already-applied file again.

## What it does

Single SQL migration block, idempotent via \`IS DISTINCT FROM\`:

\`\`\`sql
UPDATE "Kennel"
SET "foundedYear" = 1990,
    description   = 'Mission Harriettes — San Diego''s women-only monthly hash, founded November 10, 1990 (per sdh3.com history). Wednesdays once a month, 6:30 PM start.'
WHERE "kennelCode" = 'mh4-sd'
  AND (...IS DISTINCT FROM...);
\`\`\`

No seed/kennels.ts change needed — the merged seed already carries \`foundedYear: 1990\` from #1722.

## Test plan

- [x] Manually flipped local DB back to \`foundedYear=1991\` + stale description
- [x] Applied the new migration → converged to 1990 + new description
- [x] Re-applied → no-op (BEGIN/DO/COMMIT with zero row updates)
- [x] Seed-data tests pass (\`prisma/seed-data/{kennels,sources}.test.ts\`, 11 tests)
- [x] No new lint or TS errors from this change (pre-existing main TS errors in \`src/app/hareline/actions.ts\` re: \`eventLabel\` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)