### PR TITLE
fix(adapters): reject Squarespace tenant-default coord pin (Manhattan leak)

### DIFF
--- a/src/adapters/html-scraper/squarespace-events.test.ts
+++ b/src/adapters/html-scraper/squarespace-events.test.ts
@@ -37,10 +37,37 @@ const CAMPOUT_EVENT = {
     addressLine2: "Folsom, CA, 95630",
     mapLat: 38.6844644,
     mapLng: -121.1788914,
-    markerLat: 40.7207559,  // Squarespace's NYC fallback pin — must NOT be used
+    // Squarespace populates `markerLat`/`markerLng` with the tenant default
+    // (Manhattan, NY) for every event regardless of where the user pins the
+    // venue. Since this fixture has a real venue pin, the map pair differs
+    // from the marker pair → the adapter should emit the real Folsom coords.
+    markerLat: 40.7207559,
     markerLng: -74.0007613,
   },
   body: "<p>Three-day campout. Dog friendly. 21+.</p>",
+};
+
+// Real-world Squarespace shape when the user enters a street address but
+// doesn't drop a map pin — both lat/lng pairs collapse to the tenant
+// default (Manhattan, NY). 16 of 38 SACH3 events on first scrape landed
+// with these coords despite having Sacramento street addresses (#1742
+// follow-up).
+const UNSET_PIN_EVENT = {
+  id: "ghi-unset",
+  title: "Saturday Trail (no pin)",
+  fullUrl: "/events/saturday-trail-no-pin",
+  startDate: Date.UTC(2026, 6, 11, 1, 30, 0),
+  endDate: Date.UTC(2026, 6, 11, 4, 30, 0),
+  location: {
+    addressTitle: "",
+    addressLine1: "11351 S Bridge St,",
+    addressLine2: "Gold River, CA 95670",
+    mapLat: 40.7207559,
+    mapLng: -74.0007613,
+    markerLat: 40.7207559,
+    markerLng: -74.0007613,
+  },
+  body: "",
 };
 
 const NUMBERED_PAST_EVENT = {
@@ -85,7 +112,7 @@ describe("parseSquarespaceEvent", () => {
     expect(ev?.endDate).toBeUndefined();
   });
 
-  it("reads latitude/longitude from mapLat/mapLng (NOT markerLat/markerLng)", () => {
+  it("reads latitude/longitude from mapLat/mapLng when the user pinned a venue", () => {
     const ev = parseSquarespaceEvent(CAMPOUT_EVENT, CONFIG, BASE, PT);
     expect(ev?.latitude).toBe(38.6844644);
     expect(ev?.longitude).toBe(-121.1788914);
@@ -95,6 +122,43 @@ describe("parseSquarespaceEvent", () => {
     const ev = parseSquarespaceEvent(WEDNESDAY_EVENT, CONFIG, BASE, PT);
     expect(ev?.latitude).toBeUndefined();
     expect(ev?.longitude).toBeUndefined();
+  });
+
+  it("rejects the tenant-default pin when mapLat/mapLng equal markerLat/markerLng", () => {
+    // Regression test for the 16-of-38 Manhattan-coord leak on the initial
+    // SACH3 scrape: Squarespace's mapLat/mapLng silently fall back to the
+    // tenant default (~40.72/-74.00 Manhattan) when no venue pin is set.
+    // Equality between mapLat/mapLng and markerLat/markerLng is the canonical
+    // "unset pin" signal — those coords must not be emitted.
+    const ev = parseSquarespaceEvent(UNSET_PIN_EVENT, CONFIG, BASE, PT);
+    expect(ev?.latitude).toBeUndefined();
+    expect(ev?.longitude).toBeUndefined();
+    // But the address still flows through so the downstream geocoder can
+    // derive correct coords.
+    expect(ev?.locationStreet).toBe("11351 S Bridge St,, Gold River, CA 95670");
+  });
+
+  it("emits coords when mapLat/mapLng differ from markerLat/markerLng even by a small margin", () => {
+    // Defense against false-positives: a kennel whose real venue happens to
+    // be near the Squarespace default must still get coords if the user
+    // actively positioned the pin (mapLat ≠ markerLat).
+    const ev = parseSquarespaceEvent(
+      {
+        ...UNSET_PIN_EVENT,
+        location: {
+          ...UNSET_PIN_EVENT.location,
+          mapLat: 40.7300000, // user nudged pin ~1km north of default
+          mapLng: -74.0050000,
+          markerLat: 40.7207559,
+          markerLng: -74.0007613,
+        },
+      },
+      CONFIG,
+      BASE,
+      PT,
+    );
+    expect(ev?.latitude).toBe(40.73);
+    expect(ev?.longitude).toBe(-74.005);
   });
 
   it("leaves location/locationStreet undefined when address fields are blank", () => {

--- a/src/adapters/html-scraper/squarespace-events.ts
+++ b/src/adapters/html-scraper/squarespace-events.ts
@@ -66,14 +66,21 @@ interface SquarespaceLocation {
   addressLine2?: string | null;
   addressCountry?: string | null;
   /**
-   * Map pin coordinates of the venue. NOTE: the JSON also exposes
-   * `markerLat`/`markerLng` — those are a default fallback (often NYC) when
-   * the user pins the map but skips an explicit address, so we read
-   * `mapLat`/`mapLng` exclusively to avoid wiring 40.72/-74.00 onto trails
-   * across the country.
+   * Venue pin coordinates. CAUTION: Squarespace populates BOTH `mapLat`/`mapLng`
+   * AND `markerLat`/`markerLng` for every event. When the user pins the venue
+   * on the map, `mapLat`/`mapLng` reflect the pin and `markerLat`/`markerLng`
+   * stay at the tenant's default position (~40.7207559, -74.0007613 — Manhattan
+   * for English-language sites). When the user doesn't pin a venue,
+   * `mapLat`/`mapLng` ALSO fall back to the tenant default — making them equal
+   * to `markerLat`/`markerLng`. We detect the unset state by comparing the two
+   * pairs (see `parseSquarespaceEvent`); without this check 16 of 38 SACH3
+   * events on first scrape landed with Manhattan coords despite having
+   * Sacramento street addresses.
    */
   mapLat?: number | null;
   mapLng?: number | null;
+  markerLat?: number | null;
+  markerLng?: number | null;
 }
 
 interface SquarespaceEvent {
@@ -92,6 +99,47 @@ interface SquarespaceEventsPayload {
   website?: { timeZone?: string; baseUrl?: string };
   upcoming?: SquarespaceEvent[];
   past?: SquarespaceEvent[];
+}
+
+/**
+ * Extract venue coordinates from a Squarespace location, rejecting the
+ * tenant-default pin. Squarespace populates both `mapLat`/`mapLng` and
+ * `markerLat`/`markerLng` for every event; when no venue pin is set the
+ * map-pair falls back to the same default as the marker-pair (typically
+ * Manhattan for English-language sites). Equality between the two pairs
+ * is the canonical "unset pin" signal — see SquarespaceLocation docstring.
+ *
+ * Comparison uses a 6-decimal epsilon (≈11cm at the equator) since both
+ * pairs are stored at the same precision in the JSON payload; the float
+ * comparison would otherwise be brittle against round-trip noise.
+ */
+const DEFAULT_PIN_EPSILON = 1e-6;
+function extractVenueCoords(
+  loc: SquarespaceLocation,
+): [number | undefined, number | undefined] {
+  const mapLat = loc.mapLat;
+  const mapLng = loc.mapLng;
+  if (
+    typeof mapLat !== "number" ||
+    typeof mapLng !== "number" ||
+    !Number.isFinite(mapLat) ||
+    !Number.isFinite(mapLng)
+  ) {
+    return [undefined, undefined];
+  }
+  const markerLat = loc.markerLat;
+  const markerLng = loc.markerLng;
+  if (
+    typeof markerLat === "number" &&
+    typeof markerLng === "number" &&
+    Math.abs(mapLat - markerLat) < DEFAULT_PIN_EPSILON &&
+    Math.abs(mapLng - markerLng) < DEFAULT_PIN_EPSILON
+  ) {
+    // Both pairs match → user never positioned the venue. The mapLat/mapLng
+    // is the tenant default, not a real venue location.
+    return [undefined, undefined];
+  }
+  return [mapLat, mapLng];
 }
 
 /**
@@ -240,10 +288,12 @@ export function parseSquarespaceEvent(
     ? decodeEntities(stripHtmlTags(event.body))
     : undefined;
 
-  const latitude =
-    typeof loc.mapLat === "number" && Number.isFinite(loc.mapLat) ? loc.mapLat : undefined;
-  const longitude =
-    typeof loc.mapLng === "number" && Number.isFinite(loc.mapLng) ? loc.mapLng : undefined;
+  // Coord extraction with default-pin detection. See SquarespaceLocation
+  // docstring: when the user doesn't drop a venue pin, mapLat/mapLng fall
+  // back to the same tenant default as markerLat/markerLng. Treat that
+  // equality as "no real coords" and emit undefined so downstream geocoding
+  // can derive coords from `locationStreet` instead.
+  const [latitude, longitude] = extractVenueCoords(loc);
 
   return {
     date,


### PR DESCRIPTION
## Summary

Follow-up to #1742. The initial SACH3 scrape landed **16 of 38 events** with Manhattan, NY coords (40.7208, -74.0008) despite those events having Sacramento street addresses. Root cause: Squarespace populates `mapLat`/`mapLng` with the **tenant default** (Manhattan for English-language sites) whenever the user doesn't drop a venue pin — even when they've entered a real street address.

The previous adapter trusted `mapLat`/`mapLng` unconditionally. This PR detects the unset-pin case by comparing them to `markerLat`/`markerLng` (which always sit at the tenant default) and emits `undefined` when they match, letting the downstream geocoder derive coords from `locationStreet` instead.

## How Squarespace coords actually work

Discovered by inspecting raw JSON from `sach3.beer/events?format=json`:

| Scenario | `mapLat`/`mapLng` | `markerLat`/`markerLng` |
|---|---|---|
| User pinned venue (e.g. Hash Olympdicks Campout) | Folsom 38.68, -121.18 | Manhattan 40.72, -74.00 |
| User entered street, didn't pin (16 SACH3 trails) | **Manhattan 40.72, -74.00** | Manhattan 40.72, -74.00 |
| No location at all | Manhattan 40.72, -74.00 | Manhattan 40.72, -74.00 |

The map-pair equals the marker-pair iff the user never positioned the pin. That's the canonical "unset" signal.

## Fix

`extractVenueCoords()` returns `[undefined, undefined]` when `mapLat ≈ markerLat` AND `mapLng ≈ markerLng` (epsilon 1e-6, ≈11cm at the equator). Otherwise emits the map-pair as the venue's lat/lng.

Documented in the `SquarespaceLocation` interface so the next adapter author sees the trap.

## Live verification (against `sach3.beer`)

Before:
\`\`\`
Total: 38, with coords: 38, without: 0
Manhattan coords: 16
\`\`\`

After:
\`\`\`
Total: 38, with coords: 22, without: 16
Manhattan coords: 0
\`\`\`

The 22 real-coord events include the campout (Folsom), Inky's Birthday (Rocklin), 'Nilla No Flour (Roseville), and 18 other Sacramento-area trails. The 16 nulled events will pick up correct coords on the next merge pipeline run via the existing geocode path (most have a `locationStreet` like "11351 S Bridge St, Gold River, CA"; a few are placeholder "Wednesday Trail" entries with no address and will remain coordless until the kennel updates them).

## Tests

- **Regression test** — both pairs at NYC default → coords null, but `locationStreet` still flows.
- **False-positive guard** — a user who nudged the pin ~1km from the default still gets coords (mapLat ≠ markerLat).
- 20/20 squarespace-events tests pass; full suite + tsc + lint clean.

## Post-merge

After this lands, force-scrape the SACH3 source to overwrite the 16 bad coord events:

\`\`\`
POST /api/admin/scrape  { sourceId: <sach3 source id>, force: true }
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)