### PR TITLE
feat(adapters): Squarespace pagination + endTime emission + config cleanup

### DIFF
--- a/src/adapters/html-scraper/squarespace-events.test.ts
+++ b/src/adapters/html-scraper/squarespace-events.test.ts
@@ -171,6 +171,32 @@ describe("parseSquarespaceEvent", () => {
     expect(ev?.locationStreet).toBe("11351 S Bridge St,, Gold River, CA 95670");
   });
 
+  it("emits dropCachedCoords when the tenant-default pin is rejected", () => {
+    // Without this signal the merge pipeline's existing-coords cache
+    // short-circuit preserves the previously-stored Manhattan default
+    // forever (#957 precedent). The post-merge re-scrape after PR #1745
+    // landed with 16 events still on Manhattan coords for exactly this
+    // reason — the adapter was emitting `latitude: undefined` but not
+    // signaling that the OLD coords were stale.
+    const ev = parseSquarespaceEvent(UNSET_PIN_EVENT, CONFIG, BASE, PT);
+    expect(ev?.dropCachedCoords).toBe(true);
+  });
+
+  it("does NOT emit dropCachedCoords when the user actually pinned a venue", () => {
+    // Real venue pin → coords are legit, no need to invalidate any cache.
+    const ev = parseSquarespaceEvent(CAMPOUT_EVENT, CONFIG, BASE, PT);
+    expect(ev?.dropCachedCoords).toBeUndefined();
+    expect(ev?.latitude).toBe(38.6844644);
+  });
+
+  it("does NOT emit dropCachedCoords when location has no coord fields at all", () => {
+    // No mapLat/mapLng → no upstream coords to reject; legitimate
+    // "geocode from address" case, not a stale-pin scenario.
+    const ev = parseSquarespaceEvent(WEDNESDAY_EVENT, CONFIG, BASE, PT);
+    expect(ev?.dropCachedCoords).toBeUndefined();
+    expect(ev?.latitude).toBeUndefined();
+  });
+
   it("emits coords when mapLat/mapLng differ from markerLat/markerLng even by a small margin", () => {
     // Defense against false-positives: a kennel whose real venue happens to
     // be near the Squarespace default must still get coords if the user

--- a/src/adapters/html-scraper/squarespace-events.test.ts
+++ b/src/adapters/html-scraper/squarespace-events.test.ts
@@ -430,4 +430,64 @@ describe("SquarespaceEventsAdapter.fetch", () => {
     expect(result.events.length).toBeGreaterThanOrEqual(2);
     expect(result.errors).toEqual([]);
   });
+
+  it("isolates a per-event parse failure so siblings still flow through", async () => {
+    // Use a payload that survives JSON round-trip but breaks parseSquarespaceEvent:
+    // a numeric `title` value triggers `title?.trim is not a function` inside the
+    // parser. Without the loop's try/catch this would abort the whole batch
+    // (campout event would never be emitted).
+    const explodingBody = JSON.stringify({
+      website: { timeZone: PT },
+      upcoming: [
+        { ...WEDNESDAY_EVENT, title: 42 }, // 42.trim() throws TypeError
+        CAMPOUT_EVENT,
+      ],
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(explodingBody, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const source = buildSource({ url: BASE }) as unknown as Source;
+    (source as unknown as { config: unknown }).config = { kennelTag: "sach3" };
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await adapter.fetch(source);
+
+    // The campout still gets through; the TypeError is logged, not thrown.
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.title).toBe("Hash Olympdicks Campout");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to parse one event row"),
+      expect.stringContaining("trim is not a function"),
+    );
+  });
+
+  it("falls back to the 20-page default when maxPages is misconfigured (NaN / non-number)", async () => {
+    // A seed row that types `maxPages: "lots"` would `Math.floor` to NaN
+    // and (without the guard) cause an infinite loop on a tenant that
+    // always returns `nextPage: true`. Bound to default 20 instead.
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    for (let i = 0; i < 25; i++) {
+      fetchSpy.mockResolvedValueOnce(
+        mockJsonResponse({
+          website: { timeZone: PT },
+          past: [NUMBERED_PAST_EVENT],
+          pagination: { nextPage: true, nextPageOffset: 100 + i },
+        }),
+      );
+    }
+
+    const source = buildSource({ url: BASE }) as unknown as Source;
+    (source as unknown as { config: unknown }).config = {
+      kennelTag: "sach3",
+      maxPages: "not a number" as unknown as number, // simulates bad seed config
+    };
+
+    const result = await adapter.fetch(source);
+    expect(result.diagnosticContext?.pagesFetched).toBe(20);
+    expect(fetchSpy).toHaveBeenCalledTimes(20);
+  });
 });

--- a/src/adapters/html-scraper/squarespace-events.test.ts
+++ b/src/adapters/html-scraper/squarespace-events.test.ts
@@ -112,6 +112,39 @@ describe("parseSquarespaceEvent", () => {
     expect(ev?.endDate).toBeUndefined();
   });
 
+  it("emits endTime for same-day events when endDate epoch is later than start", () => {
+    // 2026-05-27 18:30 PDT → 2026-05-27 21:30 PDT (3-hour Wednesday trail).
+    // EventCard renders "18:30 – 21:30" once endTime is populated.
+    const ev = parseSquarespaceEvent(WEDNESDAY_EVENT, CONFIG, BASE, PT);
+    expect(ev?.startTime).toBe("18:30");
+    expect(ev?.endTime).toBe("21:30");
+  });
+
+  it("omits endTime for multi-day events (endDate flows instead)", () => {
+    // Multi-day Hash Olympdicks Campout — endDate populates instead of endTime
+    // so the UI knows this is a 3-day umbrella, not a single evening trail.
+    const ev = parseSquarespaceEvent(CAMPOUT_EVENT, CONFIG, BASE, PT);
+    expect(ev?.endDate).toBe("2026-06-07");
+    expect(ev?.endTime).toBeUndefined();
+  });
+
+  it("omits endTime when endDate is missing or ≤ startDate", () => {
+    const ev1 = parseSquarespaceEvent(
+      { ...WEDNESDAY_EVENT, endDate: undefined },
+      CONFIG,
+      BASE,
+      PT,
+    );
+    expect(ev1?.endTime).toBeUndefined();
+    const ev2 = parseSquarespaceEvent(
+      { ...WEDNESDAY_EVENT, endDate: WEDNESDAY_EVENT.startDate }, // equal, not >
+      CONFIG,
+      BASE,
+      PT,
+    );
+    expect(ev2?.endTime).toBeUndefined();
+  });
+
   it("reads latitude/longitude from mapLat/mapLng when the user pinned a venue", () => {
     const ev = parseSquarespaceEvent(CAMPOUT_EVENT, CONFIG, BASE, PT);
     expect(ev?.latitude).toBe(38.6844644);
@@ -203,6 +236,15 @@ function mockJsonResponse(payload: unknown): Response {
 
 describe("SquarespaceEventsAdapter.fetch", () => {
   const adapter = new SquarespaceEventsAdapter();
+
+  // Reset the global fetch spy between tests — `vi.spyOn(globalThis, "fetch")`
+  // returns the SAME underlying spy across re-spy calls, so .mock.calls
+  // accumulates across tests and assertions like `toHaveBeenCalledTimes(2)`
+  // see counts from earlier tests too. Restore-all clears both the call
+  // history and any queued `mockResolvedValueOnce` responses.
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("parses upcoming + past arrays into RawEvents", async () => {
     const payload = {
@@ -301,5 +343,91 @@ describe("SquarespaceEventsAdapter.fetch", () => {
     await expect(adapter.fetch(source)).rejects.toThrow(
       /missing required config field "kennelTag"/,
     );
+  });
+
+  it("paginates via nextPageOffset and merges past arrays across pages", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // Page 1 — has nextPage, links to offset=999
+    fetchSpy.mockResolvedValueOnce(
+      mockJsonResponse({
+        website: { timeZone: PT },
+        upcoming: [WEDNESDAY_EVENT],
+        past: [CAMPOUT_EVENT],
+        pagination: { nextPage: true, nextPageOffset: 999, pageSize: 30 },
+      }),
+    );
+    // Page 2 — no more pages
+    fetchSpy.mockResolvedValueOnce(
+      mockJsonResponse({
+        website: { timeZone: PT },
+        upcoming: [],
+        past: [NUMBERED_PAST_EVENT],
+        pagination: { pageSize: 30 },
+      }),
+    );
+
+    const source = buildSource({ url: BASE, scrapeDays: 365 }) as unknown as Source;
+    (source as unknown as { config: unknown }).config = { kennelTag: "sach3" };
+
+    const result = await adapter.fetch(source, { days: 365 });
+    expect(result.events).toHaveLength(3);
+    expect(result.diagnosticContext?.pagesFetched).toBe(2);
+
+    // Second fetch should hit the offset URL
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondCall = fetchSpy.mock.calls[1][0];
+    expect(String(secondCall)).toContain("offset=999");
+    expect(String(secondCall)).toContain("format=json");
+  });
+
+  it("stops pagination at maxPages even when nextPage is still true", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // Both pages claim more available; maxPages=2 caps the loop
+    for (let i = 0; i < 2; i++) {
+      fetchSpy.mockResolvedValueOnce(
+        mockJsonResponse({
+          website: { timeZone: PT },
+          past: [NUMBERED_PAST_EVENT],
+          pagination: { nextPage: true, nextPageOffset: 100 + i },
+        }),
+      );
+    }
+
+    const source = buildSource({ url: BASE }) as unknown as Source;
+    (source as unknown as { config: unknown }).config = {
+      kennelTag: "sach3",
+      maxPages: 2,
+    };
+
+    const result = await adapter.fetch(source);
+    expect(result.diagnosticContext?.pagesFetched).toBe(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps page-1 events when a deeper page transiently fails", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      mockJsonResponse({
+        website: { timeZone: PT },
+        upcoming: [WEDNESDAY_EVENT],
+        past: [CAMPOUT_EVENT],
+        pagination: { nextPage: true, nextPageOffset: 999 },
+      }),
+    );
+    // Page 2 fails with 500
+    fetchSpy.mockResolvedValueOnce(
+      new Response("oops", {
+        status: 500,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+
+    const source = buildSource({ url: BASE }) as unknown as Source;
+    (source as unknown as { config: unknown }).config = { kennelTag: "sach3" };
+
+    const result = await adapter.fetch(source);
+    // Page 1 events flow through; pagination loop just stops on the deeper failure
+    expect(result.events.length).toBeGreaterThanOrEqual(2);
+    expect(result.errors).toEqual([]);
   });
 });

--- a/src/adapters/html-scraper/squarespace-events.test.ts
+++ b/src/adapters/html-scraper/squarespace-events.test.ts
@@ -430,7 +430,7 @@ describe("SquarespaceEventsAdapter.fetch", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps page-1 events when a deeper page transiently fails", async () => {
+  it("keeps page-1 events when a deeper page transiently fails AND signals reconciliation suppression", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     fetchSpy.mockResolvedValueOnce(
       mockJsonResponse({
@@ -455,6 +455,60 @@ describe("SquarespaceEventsAdapter.fetch", () => {
     // Page 1 events flow through; pagination loop just stops on the deeper failure
     expect(result.events.length).toBeGreaterThanOrEqual(2);
     expect(result.errors).toEqual([]);
+    // Reconciliation-suppression signals MUST fire so scrape.ts:432-438
+    // doesn't cancel events from the unreached page (Codex P1, #1746).
+    expect(result.diagnosticContext?.kennelPageFetchErrors).toBe(1);
+    expect(result.diagnosticContext?.kennelPagesStopReason).toBe(
+      "deeper_page_fetch_failed",
+    );
+  });
+
+  it("does NOT suppress reconciliation when the maxPages cap is hit (intentional truncation)", async () => {
+    // The maxPages cap is by design — events past the cap are legitimately
+    // "outside our configured window" and reconciliation should still run.
+    // Only TRANSIENT pagination failures (deeper_page_fetch_failed) suppress.
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    for (let i = 0; i < 2; i++) {
+      fetchSpy.mockResolvedValueOnce(
+        mockJsonResponse({
+          website: { timeZone: PT },
+          past: [NUMBERED_PAST_EVENT],
+          pagination: { nextPage: true, nextPageOffset: 100 + i },
+        }),
+      );
+    }
+
+    const source = buildSource({ url: BASE }) as unknown as Source;
+    (source as unknown as { config: unknown }).config = {
+      kennelTag: "sach3",
+      maxPages: 2,
+    };
+
+    const result = await adapter.fetch(source);
+    expect(result.diagnosticContext?.pagesFetched).toBe(2);
+    expect(result.diagnosticContext?.kennelPageFetchErrors).toBe(0);
+    expect(result.diagnosticContext?.kennelPagesStopReason).toBeNull();
+  });
+
+  it("emits clean reconciliation signals on a successful single-page scrape", async () => {
+    // Sanity check: a clean walk to the natural end (no nextPage) must NOT
+    // set the suppression signals — otherwise reconciliation never fires
+    // and stale events accumulate forever.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockJsonResponse({
+        website: { timeZone: PT },
+        upcoming: [WEDNESDAY_EVENT],
+        past: [CAMPOUT_EVENT],
+        pagination: { pageSize: 30 }, // no nextPage flag
+      }),
+    );
+
+    const source = buildSource({ url: BASE }) as unknown as Source;
+    (source as unknown as { config: unknown }).config = { kennelTag: "sach3" };
+
+    const result = await adapter.fetch(source);
+    expect(result.diagnosticContext?.kennelPageFetchErrors).toBe(0);
+    expect(result.diagnosticContext?.kennelPagesStopReason).toBeNull();
   });
 
   it("isolates a per-event parse failure so siblings still flow through", async () => {

--- a/src/adapters/html-scraper/squarespace-events.ts
+++ b/src/adapters/html-scraper/squarespace-events.ts
@@ -54,10 +54,12 @@ export interface SquarespaceEventsConfig {
    */
   timezone?: string;
   /**
-   * Optional fallback startTime ("HH:MM") for events whose startDate has
-   * a degenerate time-of-day component (e.g. midnight epoch placeholders).
+   * Maximum pages to walk via Squarespace's `?offset=NNN` pagination when
+   * harvesting historical events. Default 20 — sufficient for ~600 events
+   * at the platform's pageSize of 30, and tenants with deeper history
+   * usually hit the date-window cutoff first. Tune up for backfills.
    */
-  fallbackStartTime?: string;
+  maxPages?: number;
 }
 
 interface SquarespaceLocation {
@@ -95,10 +97,17 @@ interface SquarespaceEvent {
   location?: SquarespaceLocation | null;
 }
 
+interface SquarespacePagination {
+  nextPage?: boolean;
+  nextPageOffset?: number;
+  pageSize?: number;
+}
+
 interface SquarespaceEventsPayload {
   website?: { timeZone?: string; baseUrl?: string };
   upcoming?: SquarespaceEvent[];
   past?: SquarespaceEvent[];
+  pagination?: SquarespacePagination;
 }
 
 /**
@@ -269,12 +278,23 @@ export function parseSquarespaceEvent(
   // "single-row date-range" field; emit only when the end day is strictly
   // after the start day so normal evening trails (start 18:30, end 21:30
   // same day) don't get a spurious endDate that re-fingerprints them.
+  //
+  // Same-day endDate populates RawEventData.endTime ("21:30") which the
+  // EventCard renders as "18:30 – 21:30". Different-day endDate populates
+  // RawEventData.endDate (multi-day umbrella) and leaves endTime undefined
+  // because "ends 12:00 on a different day" isn't a meaningful per-day
+  // trail time.
   const endMs = event.endDate;
   let endDate: string | undefined;
+  let endTime: string | undefined;
   if (typeof endMs === "number" && Number.isFinite(endMs) && endMs > startMs) {
     const endYmd = formatYmdInTimezone(new Date(endMs), timezone);
-    if (/^\d{4}-\d{2}-\d{2}$/.test(endYmd) && endYmd > date) {
-      endDate = endYmd;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(endYmd)) {
+      if (endYmd > date) {
+        endDate = endYmd;
+      } else {
+        endTime = formatLocalTime(endMs, timezone);
+      }
     }
   }
 
@@ -306,15 +326,101 @@ export function parseSquarespaceEvent(
     locationStreet: composeLocationStreet(loc),
     latitude,
     longitude,
-    startTime: formatLocalTime(startMs, timezone) ?? config.fallbackStartTime,
+    startTime: formatLocalTime(startMs, timezone),
+    endTime,
     sourceUrl: resolveEventUrl(baseUrl, event.fullUrl),
   };
 }
 
+/** Discriminated result of a single Squarespace page fetch. */
+type PageFetchResult =
+  | { ok: true; payload: SquarespaceEventsPayload; fetchDurationMs: number }
+  | {
+      ok: false;
+      errors: string[];
+      errorDetails: ErrorDetails;
+      fetchDurationMs: number;
+    };
+
 /**
- * Fetch + parse a Squarespace events collection. Exported so a one-shot
- * historical backfill script can paginate via `?offset=NNNN` without
- * re-implementing the per-event mapping.
+ * Fetch + validate one page of the Squarespace events JSON endpoint.
+ * Splits out the four guard-clause error returns (network, !ok status,
+ * wrong Content-Type, malformed JSON, payload-not-object, shape-mismatch)
+ * so the main `fetchSquarespaceEvents` body stays under Sonar's cognitive
+ * complexity budget for the pagination loop.
+ */
+async function fetchSquarespacePage(url: string): Promise<PageFetchResult> {
+  const t0 = Date.now();
+  let response: Response;
+  try {
+    response = await safeFetch(url, { headers: { Accept: "application/json" } });
+  } catch (err) {
+    const message = `Fetch failed: ${err instanceof Error ? err.message : String(err)}`;
+    return {
+      ok: false,
+      errors: [message],
+      errorDetails: { fetch: [{ url, message }] },
+      fetchDurationMs: Date.now() - t0,
+    };
+  }
+  const fetchDurationMs = Date.now() - t0;
+
+  if (!response.ok) {
+    const message = `HTTP ${response.status} from ${url}`;
+    return {
+      ok: false,
+      errors: [message],
+      errorDetails: { fetch: [{ url, status: response.status, message }] },
+      fetchDurationMs,
+    };
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("json")) {
+    const message =
+      `Expected JSON from ${url} but got Content-Type "${contentType}". ` +
+      "The tenant's events collection probably doesn't expose ?format=json.";
+    return {
+      ok: false,
+      errors: [message],
+      errorDetails: { fetch: [{ url, status: response.status, message }] },
+      fetchDurationMs,
+    };
+  }
+
+  let payload: SquarespaceEventsPayload;
+  try {
+    payload = (await response.json()) as SquarespaceEventsPayload;
+  } catch (err) {
+    const message = `JSON parse failed: ${err instanceof Error ? err.message : String(err)}`;
+    return {
+      ok: false,
+      errors: [message],
+      errorDetails: { parse: [{ row: 0, error: message }] },
+      fetchDurationMs,
+    };
+  }
+
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    const message = `Squarespace payload from ${url} is not an object`;
+    return {
+      ok: false,
+      errors: [message],
+      errorDetails: { parse: [{ row: 0, error: message }] },
+      fetchDurationMs,
+    };
+  }
+
+  return { ok: true, payload, fetchDurationMs };
+}
+
+/**
+ * Fetch + parse a Squarespace events collection, following the platform's
+ * `?offset=NNN` pagination chain up to `config.maxPages` pages.
+ *
+ * Exported so a one-shot historical backfill script can pass a high
+ * `maxPages` (or override `collectionPath`) and harvest deeper history
+ * without re-implementing the per-event mapping or the shape guards.
  */
 export async function fetchSquarespaceEvents(
   source: Source,
@@ -337,81 +443,27 @@ export async function fetchSquarespaceEvents(
     source.url,
     config.collectionPath ?? "/events",
   );
+  const maxPages = Math.max(1, Math.floor(config.maxPages ?? 20));
 
-  const t0 = Date.now();
-  let response: Response;
-  try {
-    response = await safeFetch(collectionUrl, {
-      headers: { Accept: "application/json" },
-    });
-  } catch (err) {
-    const message = `Fetch failed: ${err instanceof Error ? err.message : String(err)}`;
+  // First page: fail loud on shape mismatch (tenant disabled the
+  // collection, etc.) so the reconciler doesn't cancel live events.
+  // Subsequent pages: tolerate a single transient failure by stopping
+  // pagination — the events we've already harvested still flow through.
+  const firstPageResult = await fetchSquarespacePage(collectionUrl);
+  if (!firstPageResult.ok) {
     return {
       events: [],
-      errors: [message],
-      errorDetails: { fetch: [{ url: collectionUrl, message }] },
-      diagnosticContext: { fetchMethod: "squarespace-events-json" },
-    };
-  }
-  const fetchDurationMs = Date.now() - t0;
-
-  if (!response.ok) {
-    const message = `HTTP ${response.status} from ${collectionUrl}`;
-    return {
-      events: [],
-      errors: [message],
-      errorDetails: {
-        fetch: [{ url: collectionUrl, status: response.status, message }],
+      errors: firstPageResult.errors,
+      errorDetails: firstPageResult.errorDetails,
+      diagnosticContext: {
+        fetchMethod: "squarespace-events-json",
+        fetchDurationMs: firstPageResult.fetchDurationMs,
       },
-      diagnosticContext: { fetchMethod: "squarespace-events-json", fetchDurationMs },
     };
   }
 
-  const contentType = response.headers.get("content-type") ?? "";
-  if (!contentType.includes("json")) {
-    const message =
-      `Expected JSON from ${collectionUrl} but got Content-Type "${contentType}". ` +
-      "The tenant's events collection probably doesn't expose ?format=json.";
-    return {
-      events: [],
-      errors: [message],
-      errorDetails: { fetch: [{ url: collectionUrl, status: response.status, message }] },
-      diagnosticContext: { fetchMethod: "squarespace-events-json", fetchDurationMs },
-    };
-  }
-
-  let payload: SquarespaceEventsPayload;
-  try {
-    payload = (await response.json()) as SquarespaceEventsPayload;
-  } catch (err) {
-    const message = `JSON parse failed: ${err instanceof Error ? err.message : String(err)}`;
-    return {
-      events: [],
-      errors: [message],
-      errorDetails: { parse: [{ row: 0, error: message }] },
-      diagnosticContext: { fetchMethod: "squarespace-events-json", fetchDurationMs },
-    };
-  }
-
-  // Valid JSON can still be `null` (literal "null"), a primitive, or an
-  // array — none of which carry `upcoming`/`past`. Subsequent property
-  // access on a non-object would throw at runtime; fail loud here instead.
-  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
-    const message = `Squarespace payload from ${collectionUrl} is not an object`;
-    return {
-      events: [],
-      errors: [message],
-      errorDetails: { parse: [{ row: 0, error: message }] },
-      diagnosticContext: { fetchMethod: "squarespace-events-json", fetchDurationMs },
-    };
-  }
-
-  // Shape-mismatch guard. Squarespace tenants who disable the Events
-  // collection (or rotate the JSON shape) return valid JSON with neither
-  // `upcoming` nor `past`. If we treated that as "0 events" the reconciler
-  // would silently cancel every live event for this source on the next
-  // scrape. Fail loud — surface as a SCRAPE_FAILURE alert instead.
-  if (!Array.isArray(payload.upcoming) && !Array.isArray(payload.past)) {
+  const firstPayload = firstPageResult.payload;
+  if (!Array.isArray(firstPayload.upcoming) && !Array.isArray(firstPayload.past)) {
     const message =
       `Squarespace payload from ${collectionUrl} has no 'upcoming' or 'past' arrays — ` +
       "tenant may have disabled the Events collection or rotated the JSON shape.";
@@ -419,17 +471,53 @@ export async function fetchSquarespaceEvents(
       events: [],
       errors: [message],
       errorDetails: { parse: [{ row: 0, error: message }] },
-      diagnosticContext: { fetchMethod: "squarespace-events-json", fetchDurationMs },
+      diagnosticContext: {
+        fetchMethod: "squarespace-events-json",
+        fetchDurationMs: firstPageResult.fetchDurationMs,
+      },
     };
   }
 
-  const timezone = resolveTimezone(config.timezone, payload.website?.timeZone);
+  const timezone = resolveTimezone(config.timezone, firstPayload.website?.timeZone);
+  let upcomingCount = 0;
+  let pastCount = 0;
+  let pagesFetched = 0;
+  let totalFetchMs = 0;
+  const events: RawEventData[] = [];
 
-  const upcoming = Array.isArray(payload.upcoming) ? payload.upcoming : [];
-  const past = Array.isArray(payload.past) ? payload.past : [];
-  const events = [...upcoming, ...past]
-    .map((ev) => parseSquarespaceEvent(ev, config, source.url, timezone))
-    .filter((ev): ev is RawEventData => ev !== null);
+  let nextUrl: string | undefined = collectionUrl;
+  let currentPayload: SquarespaceEventsPayload | undefined = firstPayload;
+  let currentFetchMs = firstPageResult.fetchDurationMs;
+
+  while (currentPayload) {
+    const upcoming = Array.isArray(currentPayload.upcoming) ? currentPayload.upcoming : [];
+    const past = Array.isArray(currentPayload.past) ? currentPayload.past : [];
+    upcomingCount += upcoming.length;
+    pastCount += past.length;
+    pagesFetched++;
+    totalFetchMs += currentFetchMs;
+
+    for (const ev of [...upcoming, ...past]) {
+      const parsed = parseSquarespaceEvent(ev, config, source.url, timezone);
+      if (parsed) events.push(parsed);
+    }
+
+    // Stop conditions, checked AFTER processing the current page but
+    // BEFORE issuing the next request:
+    //   1. We've fetched `maxPages` pages already — don't fetch a page we
+    //      won't process.
+    //   2. The current payload has no `nextPage` link.
+    if (pagesFetched >= maxPages) break;
+    const pagination = currentPayload.pagination;
+    if (!pagination?.nextPage || typeof pagination.nextPageOffset !== "number") break;
+
+    nextUrl = appendOffset(collectionUrl, pagination.nextPageOffset);
+    const pageResult = await fetchSquarespacePage(nextUrl);
+    if (!pageResult.ok) break; // transient failure on a deeper page — keep what we have
+
+    currentPayload = pageResult.payload;
+    currentFetchMs = pageResult.fetchDurationMs;
+  }
 
   return {
     events,
@@ -438,13 +526,24 @@ export async function fetchSquarespaceEvents(
       fetchMethod: "squarespace-events-json",
       collectionUrl,
       timezone,
-      upcomingCount: upcoming.length,
-      pastCount: past.length,
+      pagesFetched,
+      upcomingCount,
+      pastCount,
       eventsParsed: events.length,
-      eventsSkipped: upcoming.length + past.length - events.length,
-      fetchDurationMs,
+      eventsSkipped: upcomingCount + pastCount - events.length,
+      fetchDurationMs: totalFetchMs,
     },
   };
+}
+
+/**
+ * Add or replace the `offset` query param on the collection URL so the
+ * next page request preserves `format=json` (and any other tenant params).
+ */
+function appendOffset(collectionUrl: string, offset: number): string {
+  const url = new URL(collectionUrl);
+  url.searchParams.set("offset", String(offset));
+  return url.toString();
 }
 
 export class SquarespaceEventsAdapter implements SourceAdapter {

--- a/src/adapters/html-scraper/squarespace-events.ts
+++ b/src/adapters/html-scraper/squarespace-events.ts
@@ -121,11 +121,20 @@ interface SquarespaceEventsPayload {
  * Comparison uses a 6-decimal epsilon (≈11cm at the equator) since both
  * pairs are stored at the same precision in the JSON payload; the float
  * comparison would otherwise be brittle against round-trip noise.
+ *
+ * Returns `defaultPinRejected: true` when the upstream coords were a
+ * tenant default — the caller emits `dropCachedCoords: true` so the
+ * merge pipeline clears any previously-stored bad pin instead of
+ * preserving it via the existing-coords cache short-circuit (see #957
+ * Harrier Central precedent + `RawEventData.dropCachedCoords` docs).
  */
 const DEFAULT_PIN_EPSILON = 1e-6;
-function extractVenueCoords(
-  loc: SquarespaceLocation,
-): [number | undefined, number | undefined] {
+interface ExtractedCoords {
+  latitude?: number;
+  longitude?: number;
+  defaultPinRejected: boolean;
+}
+function extractVenueCoords(loc: SquarespaceLocation): ExtractedCoords {
   const mapLat = loc.mapLat;
   const mapLng = loc.mapLng;
   if (
@@ -134,7 +143,7 @@ function extractVenueCoords(
     !Number.isFinite(mapLat) ||
     !Number.isFinite(mapLng)
   ) {
-    return [undefined, undefined];
+    return { defaultPinRejected: false };
   }
   const markerLat = loc.markerLat;
   const markerLng = loc.markerLng;
@@ -146,9 +155,9 @@ function extractVenueCoords(
   ) {
     // Both pairs match → user never positioned the venue. The mapLat/mapLng
     // is the tenant default, not a real venue location.
-    return [undefined, undefined];
+    return { defaultPinRejected: true };
   }
-  return [mapLat, mapLng];
+  return { latitude: mapLat, longitude: mapLng, defaultPinRejected: false };
 }
 
 /**
@@ -318,7 +327,12 @@ export function parseSquarespaceEvent(
   // back to the same tenant default as markerLat/markerLng. Treat that
   // equality as "no real coords" and emit undefined so downstream geocoding
   // can derive coords from `locationStreet` instead.
-  const [latitude, longitude] = extractVenueCoords(loc);
+  //
+  // When we DETECT and reject the default pin (defaultPinRejected=true),
+  // also emit `dropCachedCoords: true` so the merge pipeline clears any
+  // previously-stored bad pin. Without this flag the existing-coords cache
+  // short-circuit preserves the stored Manhattan default forever (#957).
+  const { latitude, longitude, defaultPinRejected } = extractVenueCoords(loc);
 
   return {
     date,
@@ -334,6 +348,7 @@ export function parseSquarespaceEvent(
     startTime: formatLocalTime(startMs, timezone),
     endTime,
     sourceUrl: resolveEventUrl(baseUrl, event.fullUrl),
+    ...(defaultPinRejected ? { dropCachedCoords: true } : {}),
   };
 }
 

--- a/src/adapters/html-scraper/squarespace-events.ts
+++ b/src/adapters/html-scraper/squarespace-events.ts
@@ -440,20 +440,75 @@ interface PaginationAccumulator {
   pastCount: number;
   pagesFetched: number;
   totalFetchMs: number;
+  /**
+   * Number of deeper-page fetches that failed during pagination. Surfaces
+   * to `diagnosticContext.kennelPageFetchErrors`, which `scrape.ts`
+   * consumes to suppress stale-event reconciliation — without this the
+   * reconciler would treat events behind a transiently-broken offset as
+   * "removed from source" and cancel them (Codex P1, #1746).
+   */
+  pageFetchErrors: number;
+  /**
+   * Non-empty string signals an INCOMPLETE pagination walk (transient
+   * fetch failure, NOT the intentional maxPages cap). Surfaces to
+   * `diagnosticContext.kennelPagesStopReason`; same reconciliation
+   * suppression contract as `pageFetchErrors`. The maxPages cap is
+   * intentional truncation and does NOT set this — events past the cap
+   * are legitimately "outside our configured window".
+   */
+  paginationStopReason: string | null;
+}
+
+/**
+ * Process one Squarespace page's events into the accumulator. Each event
+ * is wrapped in try/catch so a future bug or rotated payload shape that
+ * crashes `parseSquarespaceEvent` doesn't abort the whole batch.
+ */
+function pushPageEvents(
+  payload: SquarespaceEventsPayload,
+  parseEvent: (ev: SquarespaceEvent) => RawEventData | null,
+  acc: PaginationAccumulator,
+): void {
+  const upcoming = Array.isArray(payload.upcoming) ? payload.upcoming : [];
+  const past = Array.isArray(payload.past) ? payload.past : [];
+  acc.upcomingCount += upcoming.length;
+  acc.pastCount += past.length;
+  for (const ev of [...upcoming, ...past]) {
+    try {
+      const parsed = parseEvent(ev);
+      if (parsed) acc.events.push(parsed);
+    } catch (err) {
+      console.warn(
+        "SquarespaceEventsAdapter: failed to parse one event row:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+}
+
+/**
+ * Decide whether pagination should continue. Returns the next-page offset
+ * or null. Returning null does NOT distinguish "no more pages" from
+ * "intentional cap reached" — both are reconciliation-safe (the cap is by
+ * design; the absence of `nextPage` means the source published nothing
+ * deeper). Transient deeper-page failures are handled separately at the
+ * call site.
+ */
+function getNextPageOffset(
+  payload: SquarespaceEventsPayload,
+  pagesFetched: number,
+  maxPages: number,
+): number | null {
+  if (pagesFetched >= maxPages) return null;
+  const pagination = payload.pagination;
+  if (!pagination?.nextPage || typeof pagination.nextPageOffset !== "number") return null;
+  return pagination.nextPageOffset;
 }
 
 /**
  * Walk the Squarespace `?offset=NNN` pagination chain starting from a
- * known-good first page, processing each page's events and aggregating
- * counts. Extracted from `fetchSquarespaceEvents` to keep that function
- * under Sonar S3776's cognitive-complexity budget.
- *
- * Stop conditions, checked AFTER processing each page but BEFORE the
- * next request:
- *   1. `pagesFetched >= maxPages` — don't fetch a page we won't process.
- *   2. Current payload has no `nextPage` link.
- *   3. Deeper-page transient failure (5xx, network glitch) — preserve
- *      everything harvested so far rather than discarding.
+ * known-good first page. See helpers above for per-page processing and
+ * stop-condition logic.
  */
 async function walkPagination(
   firstPayload: SquarespaceEventsPayload,
@@ -468,42 +523,30 @@ async function walkPagination(
     pastCount: 0,
     pagesFetched: 0,
     totalFetchMs: 0,
+    pageFetchErrors: 0,
+    paginationStopReason: null,
   };
 
   let currentPayload: SquarespaceEventsPayload = firstPayload;
   let currentFetchMs = firstFetchMs;
 
   while (true) {
-    const upcoming = Array.isArray(currentPayload.upcoming) ? currentPayload.upcoming : [];
-    const past = Array.isArray(currentPayload.past) ? currentPayload.past : [];
-    acc.upcomingCount += upcoming.length;
-    acc.pastCount += past.length;
+    pushPageEvents(currentPayload, parseEvent, acc);
     acc.pagesFetched++;
     acc.totalFetchMs += currentFetchMs;
 
-    // Per-event try/catch: `parseSquarespaceEvent` is defensive (typeof
-    // checks, returns null on bad input) but a future bug or unexpected
-    // payload shape shouldn't take down the entire batch — keep harvesting
-    // siblings and log the offender for follow-up.
-    for (const ev of [...upcoming, ...past]) {
-      try {
-        const parsed = parseEvent(ev);
-        if (parsed) acc.events.push(parsed);
-      } catch (err) {
-        console.warn(
-          "SquarespaceEventsAdapter: failed to parse one event row:",
-          err instanceof Error ? err.message : String(err),
-        );
-      }
+    const nextOffset = getNextPageOffset(currentPayload, acc.pagesFetched, maxPages);
+    if (nextOffset === null) break;
+
+    const pageResult = await fetchSquarespacePage(appendOffset(collectionUrl, nextOffset));
+    if (!pageResult.ok) {
+      // Transient deeper-page failure — preserve events harvested so far
+      // AND suppress stale-event reconciliation. Without the suppression
+      // signal `scrape.ts` would cancel events from the unreached pages.
+      acc.pageFetchErrors++;
+      acc.paginationStopReason = "deeper_page_fetch_failed";
+      break;
     }
-
-    if (acc.pagesFetched >= maxPages) break;
-    const pagination = currentPayload.pagination;
-    if (!pagination?.nextPage || typeof pagination.nextPageOffset !== "number") break;
-
-    const nextUrl = appendOffset(collectionUrl, pagination.nextPageOffset);
-    const pageResult = await fetchSquarespacePage(nextUrl);
-    if (!pageResult.ok) break;
 
     currentPayload = pageResult.payload;
     currentFetchMs = pageResult.fetchDurationMs;
@@ -603,6 +646,14 @@ export async function fetchSquarespaceEvents(
       eventsParsed: acc.events.length,
       eventsSkipped: acc.upcomingCount + acc.pastCount - acc.events.length,
       fetchDurationMs: acc.totalFetchMs,
+      // Reconciliation-suppression signals consumed by `scrape.ts:432-438`.
+      // When a deeper page failed during pagination, the events we never
+      // reached must NOT be cancelled — they're not gone, we just didn't
+      // see them this scrape. Keys mirror Hash Rego's per-kennel-page
+      // diagnostics so the existing scrape-pipeline gate works without
+      // changes (Codex P1, #1746).
+      kennelPageFetchErrors: acc.pageFetchErrors,
+      kennelPagesStopReason: acc.paginationStopReason,
     },
   };
 }

--- a/src/adapters/html-scraper/squarespace-events.ts
+++ b/src/adapters/html-scraper/squarespace-events.ts
@@ -248,6 +248,31 @@ function formatLocalTime(epochMs: number, timezone: string): string | undefined 
 }
 
 /**
+ * Resolve `endDate` (different day) vs `endTime` (same day) from a
+ * Squarespace event's `endDate` epoch. Extracted from
+ * `parseSquarespaceEvent` so the parser stays under Sonar S3776's
+ * cognitive-complexity budget; mirrors the multi-day vs same-day split
+ * documented at the call site.
+ *
+ * Returns `{}` (both undefined) when `endDate` is missing, ≤ startDate,
+ * or unparseable. Same-day → `{ endTime }`. Different-day → `{ endDate }`.
+ */
+function resolveEndDateOrTime(
+  endMs: number | undefined,
+  startMs: number,
+  startDate: string,
+  timezone: string,
+): { endDate?: string; endTime?: string } {
+  if (typeof endMs !== "number" || !Number.isFinite(endMs) || endMs <= startMs) {
+    return {};
+  }
+  const endYmd = formatYmdInTimezone(new Date(endMs), timezone);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(endYmd)) return {};
+  if (endYmd > startDate) return { endDate: endYmd };
+  return { endTime: formatLocalTime(endMs, timezone) };
+}
+
+/**
  * Convert one Squarespace event row into RawEventData. Returns null when
  * `startDate` is missing or unparseable — date is the minimum viable field
  * for downstream dedup.
@@ -273,30 +298,10 @@ export function parseSquarespaceEvent(
   const date = formatYmdInTimezone(new Date(startMs), timezone);
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
 
-  // Multi-day events (campouts spanning Friday → Sunday) carry an endDate
-  // epoch on a later calendar day. RawEventData.endDate is the canonical
-  // "single-row date-range" field; emit only when the end day is strictly
-  // after the start day so normal evening trails (start 18:30, end 21:30
-  // same day) don't get a spurious endDate that re-fingerprints them.
-  //
-  // Same-day endDate populates RawEventData.endTime ("21:30") which the
-  // EventCard renders as "18:30 – 21:30". Different-day endDate populates
-  // RawEventData.endDate (multi-day umbrella) and leaves endTime undefined
-  // because "ends 12:00 on a different day" isn't a meaningful per-day
-  // trail time.
-  const endMs = event.endDate;
-  let endDate: string | undefined;
-  let endTime: string | undefined;
-  if (typeof endMs === "number" && Number.isFinite(endMs) && endMs > startMs) {
-    const endYmd = formatYmdInTimezone(new Date(endMs), timezone);
-    if (/^\d{4}-\d{2}-\d{2}$/.test(endYmd)) {
-      if (endYmd > date) {
-        endDate = endYmd;
-      } else {
-        endTime = formatLocalTime(endMs, timezone);
-      }
-    }
-  }
+  // Multi-day events (campouts spanning Friday → Sunday) emit `endDate`;
+  // same-day events emit `endTime` instead so the EventCard renders
+  // "18:30 – 21:30". See `resolveEndDateOrTime`.
+  const { endDate, endTime } = resolveEndDateOrTime(event.endDate, startMs, date, timezone);
 
   const title = event.title?.trim() || undefined;
   const loc = event.location ?? {};
@@ -414,6 +419,84 @@ async function fetchSquarespacePage(url: string): Promise<PageFetchResult> {
   return { ok: true, payload, fetchDurationMs };
 }
 
+interface PaginationAccumulator {
+  events: RawEventData[];
+  upcomingCount: number;
+  pastCount: number;
+  pagesFetched: number;
+  totalFetchMs: number;
+}
+
+/**
+ * Walk the Squarespace `?offset=NNN` pagination chain starting from a
+ * known-good first page, processing each page's events and aggregating
+ * counts. Extracted from `fetchSquarespaceEvents` to keep that function
+ * under Sonar S3776's cognitive-complexity budget.
+ *
+ * Stop conditions, checked AFTER processing each page but BEFORE the
+ * next request:
+ *   1. `pagesFetched >= maxPages` — don't fetch a page we won't process.
+ *   2. Current payload has no `nextPage` link.
+ *   3. Deeper-page transient failure (5xx, network glitch) — preserve
+ *      everything harvested so far rather than discarding.
+ */
+async function walkPagination(
+  firstPayload: SquarespaceEventsPayload,
+  firstFetchMs: number,
+  collectionUrl: string,
+  maxPages: number,
+  parseEvent: (ev: SquarespaceEvent) => RawEventData | null,
+): Promise<PaginationAccumulator> {
+  const acc: PaginationAccumulator = {
+    events: [],
+    upcomingCount: 0,
+    pastCount: 0,
+    pagesFetched: 0,
+    totalFetchMs: 0,
+  };
+
+  let currentPayload: SquarespaceEventsPayload = firstPayload;
+  let currentFetchMs = firstFetchMs;
+
+  while (true) {
+    const upcoming = Array.isArray(currentPayload.upcoming) ? currentPayload.upcoming : [];
+    const past = Array.isArray(currentPayload.past) ? currentPayload.past : [];
+    acc.upcomingCount += upcoming.length;
+    acc.pastCount += past.length;
+    acc.pagesFetched++;
+    acc.totalFetchMs += currentFetchMs;
+
+    // Per-event try/catch: `parseSquarespaceEvent` is defensive (typeof
+    // checks, returns null on bad input) but a future bug or unexpected
+    // payload shape shouldn't take down the entire batch — keep harvesting
+    // siblings and log the offender for follow-up.
+    for (const ev of [...upcoming, ...past]) {
+      try {
+        const parsed = parseEvent(ev);
+        if (parsed) acc.events.push(parsed);
+      } catch (err) {
+        console.warn(
+          "SquarespaceEventsAdapter: failed to parse one event row:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+
+    if (acc.pagesFetched >= maxPages) break;
+    const pagination = currentPayload.pagination;
+    if (!pagination?.nextPage || typeof pagination.nextPageOffset !== "number") break;
+
+    const nextUrl = appendOffset(collectionUrl, pagination.nextPageOffset);
+    const pageResult = await fetchSquarespacePage(nextUrl);
+    if (!pageResult.ok) break;
+
+    currentPayload = pageResult.payload;
+    currentFetchMs = pageResult.fetchDurationMs;
+  }
+
+  return acc;
+}
+
 /**
  * Fetch + parse a Squarespace events collection, following the platform's
  * `?offset=NNN` pagination chain up to `config.maxPages` pages.
@@ -443,12 +526,17 @@ export async function fetchSquarespaceEvents(
     source.url,
     config.collectionPath ?? "/events",
   );
-  const maxPages = Math.max(1, Math.floor(config.maxPages ?? 20));
+  // Guard against a misconfigured `maxPages` (e.g. seeded as a string or
+  // NaN). Without this, `Math.floor(NaN)` propagates and the loop's
+  // `pagesFetched >= maxPages` check would always be false → on a tenant
+  // that returns `nextPage: true` indefinitely the loop would never exit.
+  const maxPages =
+    typeof config.maxPages === "number" && Number.isFinite(config.maxPages)
+      ? Math.max(1, Math.floor(config.maxPages))
+      : 20;
 
   // First page: fail loud on shape mismatch (tenant disabled the
   // collection, etc.) so the reconciler doesn't cancel live events.
-  // Subsequent pages: tolerate a single transient failure by stopping
-  // pagination — the events we've already harvested still flow through.
   const firstPageResult = await fetchSquarespacePage(collectionUrl);
   if (!firstPageResult.ok) {
     return {
@@ -479,59 +567,27 @@ export async function fetchSquarespaceEvents(
   }
 
   const timezone = resolveTimezone(config.timezone, firstPayload.website?.timeZone);
-  let upcomingCount = 0;
-  let pastCount = 0;
-  let pagesFetched = 0;
-  let totalFetchMs = 0;
-  const events: RawEventData[] = [];
-
-  let nextUrl: string | undefined = collectionUrl;
-  let currentPayload: SquarespaceEventsPayload | undefined = firstPayload;
-  let currentFetchMs = firstPageResult.fetchDurationMs;
-
-  while (currentPayload) {
-    const upcoming = Array.isArray(currentPayload.upcoming) ? currentPayload.upcoming : [];
-    const past = Array.isArray(currentPayload.past) ? currentPayload.past : [];
-    upcomingCount += upcoming.length;
-    pastCount += past.length;
-    pagesFetched++;
-    totalFetchMs += currentFetchMs;
-
-    for (const ev of [...upcoming, ...past]) {
-      const parsed = parseSquarespaceEvent(ev, config, source.url, timezone);
-      if (parsed) events.push(parsed);
-    }
-
-    // Stop conditions, checked AFTER processing the current page but
-    // BEFORE issuing the next request:
-    //   1. We've fetched `maxPages` pages already — don't fetch a page we
-    //      won't process.
-    //   2. The current payload has no `nextPage` link.
-    if (pagesFetched >= maxPages) break;
-    const pagination = currentPayload.pagination;
-    if (!pagination?.nextPage || typeof pagination.nextPageOffset !== "number") break;
-
-    nextUrl = appendOffset(collectionUrl, pagination.nextPageOffset);
-    const pageResult = await fetchSquarespacePage(nextUrl);
-    if (!pageResult.ok) break; // transient failure on a deeper page — keep what we have
-
-    currentPayload = pageResult.payload;
-    currentFetchMs = pageResult.fetchDurationMs;
-  }
+  const acc = await walkPagination(
+    firstPayload,
+    firstPageResult.fetchDurationMs,
+    collectionUrl,
+    maxPages,
+    (ev) => parseSquarespaceEvent(ev, config, source.url, timezone),
+  );
 
   return {
-    events,
+    events: acc.events,
     errors: [],
     diagnosticContext: {
       fetchMethod: "squarespace-events-json",
       collectionUrl,
       timezone,
-      pagesFetched,
-      upcomingCount,
-      pastCount,
-      eventsParsed: events.length,
-      eventsSkipped: upcomingCount + pastCount - events.length,
-      fetchDurationMs: totalFetchMs,
+      pagesFetched: acc.pagesFetched,
+      upcomingCount: acc.upcomingCount,
+      pastCount: acc.pastCount,
+      eventsParsed: acc.events.length,
+      eventsSkipped: acc.upcomingCount + acc.pastCount - acc.events.length,
+      fetchDurationMs: acc.totalFetchMs,
     },
   };
 }


### PR DESCRIPTION
## Summary

Three follow-ups to the SACH3 onboarding (#1742). Each was deferred at PR-review time as a P3; combining them since they all live in the same file.

| Item | Live impact (SACH3) |
|---|---|
| Paginate via `?offset=NNN` | 38 → **57 events** (19 deeper historical trails recovered, back to 2025-09-03) |
| Emit `endTime` for same-day events | **53/57 events** now have "18:30 – 21:30" / "12:00 – 16:00" ranges on the EventCard |
| Drop unreachable `fallbackStartTime` config | Code-cleanliness; no runtime change |

## Details

### 1. Pagination

Squarespace exposes `pagination: { nextPage, nextPageOffset, pageSize }` on every events-collection JSON response. The original adapter ignored it. Now `fetchSquarespaceEvents` walks the chain up to `config.maxPages` pages (default 20 ≈ 600 events at the platform's pageSize=30).

- Single-page fetch extracted to a `fetchSquarespacePage` helper so the main loop stays under Sonar S3776's cognitive-complexity budget.
- Deeper-page transient failures (e.g. 500 on page 5) stop pagination but preserve everything we've already harvested — no "all-or-nothing" data loss.
- Backfill scripts can override `maxPages` for deeper history.

### 2. `endTime` emission

Squarespace events carry both `startDate` and `endDate` as epoch-ms. We were already using `endDate` for the multi-day campout case (populating `RawEventData.endDate`); now same-day `endDate` populates `RawEventData.endTime` instead.

| Event shape | startTime | endTime | endDate |
|---|---|---|---|
| Wednesday Trail 18:30→21:30 | 18:30 | **21:30** | — |
| Saturday Trail 12:00→16:00 | 12:00 | **16:00** | — |
| Campout Fri→Sun 13:00→12:00 | 13:00 | — | 2026-06-07 |

### 3. Drop `fallbackStartTime`

Adversarial review flagged this as unreachable code. `formatLocalTime` returns undefined only on invalid timezone (already caught upstream by `resolveTimezone`'s validation); valid timezone + valid epoch always yield hh:mm parts via `Intl.DateTimeFormat`. Removed the config field + the `?? config.fallbackStartTime` fallback.

## Tests

- **24 total** (was 18). Net +6:
  - 3 for endTime semantics (same-day populates, multi-day omits, missing endDate omits)
  - 3 for pagination (multi-page traversal, maxPages cap, deeper-page failure isolation)
- `vi.spyOn(globalThis, "fetch")` accumulates `.mock.calls` across tests in the same describe block — added `beforeEach(vi.restoreAllMocks)` to reset.

`npx tsc --noEmit && npm run lint && npm test` — all clean.

## Live verification (sach3.beer)

```
Events: 57  (was 38)
Diagnostics: {
  pagesFetched: 2,
  upcomingCount: 8,
  pastCount: 49,
  eventsSkipped: 0,
}

Events with endTime: 53/57
  2026-05-27 18:30-21:30  There Ain't a L Street in Robla
  2026-06-03 18:30-21:30  Wednesday Trail
  2026-06-20 12:00-16:00  Saturday Trail
  ...

Multi-day endDate: 2/57
  2026-06-05 → 2026-06-07  Hash Olympdicks Campout
  2025-09-20 → 2025-09-21  Happy Birthday Foreplay (#1685)

Date range: 2025-09-03 → 2026-07-01  (was 2025-12-06 → 2026-07-01)
```

## Notes for review

- This PR stacks behind [#1745](https://github.com/johnrclem/hashtracks-web/pull/1745) (Manhattan-coord fix). Both touch `squarespace-events.ts` but on different lines; mergeable in either order.
- After both merge + the next scrape, SACH3 will land with 57 canonical events instead of 38, ~50 with end-time data, and zero Manhattan-coord pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)