### PR TITLE
fix: pre-cycle bundle — Iron City outage + 4 cycle-13 data-quality escapes

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1251,6 +1251,12 @@ export const SOURCES = [
         // the ±1500d window — flipping every backfilled past row to
         // CANCELLED on the next successful cron tick.
         upcomingOnly: true,
+        // allowEmptyBody:true — the WP plugin returns HTTP 200 + 0-byte body
+        // when there are no upcoming events (#1753). Treat that as an
+        // empty-success rather than 3 consecutive "not valid ICS" failures.
+        // Safe because upcomingOnly:true stops reconcile from cancelling the
+        // backfilled past events on an empty scrape.
+        allowEmptyBody: true,
       },
       kennelCodes: ["ich3"],
     },
@@ -3651,6 +3657,13 @@ export const SOURCES = [
       config: {
         calendarId: "morgantownh3@gmail.com",
         defaultKennelTag: "mh3-wv",
+        // #1735: the GCal source re-emits a verbatim "MH3:" title prefix on a
+        // subset of events (the kennel stripped it at source from 2026-04-15
+        // onward but left older entries prefixed). Strip at parse-time so the
+        // one-shot cleanup (scripts/cleanup-morgantown-mh3-prefix.ts) isn't
+        // re-leaked on the next scrape. Harrier Central source ships clean
+        // titles, so this is GCal-only.
+        titleStripPatterns: [String.raw`^MH3:\s*`],
       },
       kennelCodes: ["mh3-wv"],
     },

--- a/scripts/cleanup-mel-nm-historical-placeholders.ts
+++ b/scripts/cleanup-mel-nm-historical-placeholders.ts
@@ -41,6 +41,7 @@ import "dotenv/config";
 import { prisma } from "@/lib/db";
 import { deleteLeakedEvent } from "./lib/delete-leaked-event";
 import { verifyNoOrphans } from "./lib/verify-no-orphans";
+import { parseApplyMode, resolveCleanupKennel } from "./lib/cleanup-cli";
 
 const KENNEL_CODE = "mel-new-moon";
 
@@ -55,18 +56,9 @@ const TEMPLATE_TITLE_PREFIX = "Every Wednesday @";
 const YEAR = 2024;
 
 async function main() {
-  const apply = process.argv.includes("--apply");
-  console.log(`Mode: ${apply ? "APPLY (will hard-delete)" : "DRY-RUN"}`);
-
-  const kennel = await prisma.kennel.findUnique({
-    where: { kennelCode: KENNEL_CODE },
-    select: { id: true, shortName: true },
-  });
-  if (!kennel) {
-    console.log(`Kennel "${KENNEL_CODE}" not found — nothing to do.`);
-    return;
-  }
-  console.log(`Targeting kennel: ${kennel.shortName} (${kennel.id})`);
+  const apply = parseApplyMode();
+  const kennel = await resolveCleanupKennel(prisma, KENNEL_CODE);
+  if (!kennel) return;
 
   const matched = await prisma.event.findMany({
     where: {

--- a/scripts/cleanup-mel-nm-historical-placeholders.ts
+++ b/scripts/cleanup-mel-nm-historical-placeholders.ts
@@ -61,7 +61,10 @@ async function verifyNoOrphans(deletedIds: string[]): Promise<void> {
     console.log(`Verified: all ${deletedIds.length} Event(s) gone, no dangling RawEvents.`);
     return;
   }
+  // Fail loud: a destructive run that left orphans behind must surface a
+  // non-zero exit code so an operator/pipeline doesn't read success.
   console.warn(`WARNING: ${stillPresent} Event(s) still present, ${danglingRaw} dangling RawEvent(s) remain.`);
+  process.exitCode = 1;
 }
 
 async function main() {

--- a/scripts/cleanup-mel-nm-historical-placeholders.ts
+++ b/scripts/cleanup-mel-nm-historical-placeholders.ts
@@ -40,6 +40,7 @@
 import "dotenv/config";
 import { prisma } from "@/lib/db";
 import { deleteLeakedEvent } from "./lib/delete-leaked-event";
+import { verifyNoOrphans } from "./lib/verify-no-orphans";
 
 const KENNEL_CODE = "mel-new-moon";
 
@@ -52,20 +53,6 @@ const TEMPLATE_TITLE_PREFIX = "Every Wednesday @";
 // Hard date guard: only 2024 rows. Keeps the sweep off any current-year
 // event even if a future template leak somehow shared the prefix.
 const YEAR = 2024;
-
-async function verifyNoOrphans(deletedIds: string[]): Promise<void> {
-  if (deletedIds.length === 0) return;
-  const stillPresent = await prisma.event.count({ where: { id: { in: deletedIds } } });
-  const danglingRaw = await prisma.rawEvent.count({ where: { eventId: { in: deletedIds } } });
-  if (stillPresent === 0 && danglingRaw === 0) {
-    console.log(`Verified: all ${deletedIds.length} Event(s) gone, no dangling RawEvents.`);
-    return;
-  }
-  // Fail loud: a destructive run that left orphans behind must surface a
-  // non-zero exit code so an operator/pipeline doesn't read success.
-  console.warn(`WARNING: ${stillPresent} Event(s) still present, ${danglingRaw} dangling RawEvent(s) remain.`);
-  process.exitCode = 1;
-}
 
 async function main() {
   const apply = process.argv.includes("--apply");
@@ -144,7 +131,7 @@ async function main() {
   }
   console.log(`\nDeleted ${matched.length} placeholder Event(s).`);
 
-  await verifyNoOrphans(matched.map((e) => e.id));
+  await verifyNoOrphans(prisma, matched.map((e) => e.id));
 }
 
 main()

--- a/scripts/cleanup-mel-nm-historical-placeholders.ts
+++ b/scripts/cleanup-mel-nm-historical-placeholders.ts
@@ -1,0 +1,154 @@
+/**
+ * One-shot cleanup for issue #1737 — Mel-NM (Melbourne New Moon H3)
+ * historical 2024 placeholder events.
+ *
+ * PR #1726 added TEMPLATE_TITLE_PATTERNS to the Meetup adapter's
+ * `cleanMeetupTitle`, blocking NEW template-shaped titles. But 13
+ * historical 2024 Events still carry the verbatim Meetup recurrence
+ * template `"Every Wednesday @ 6:30pm from tbd"` as their title — they
+ * fall outside the Mel-NM Meetup source's `scrapeDays: 180` window, so
+ * the adapter never re-emits them and the merge pipeline never gets a
+ * chance to apply the new rejection logic.
+ *
+ * Why hard-delete (not a title rewrite): inspection on 2026-05-28 showed
+ * all 13 rows have runNumber=null, zero hares, zero attendance, zero
+ * KennelAttendance, AND zero RawEvent backing. They are orphaned
+ * placeholder canonical Events with no recoverable identity and no data
+ * worth preserving — there's nothing to rewrite a title *for*. Deleting
+ * them is consistent with the other cleanup-* scripts in this bundle.
+ *
+ * Why NOT widen scrapeDays: per the issue, bumping Mel-NM's Meetup
+ * `scrapeDays` to ~600 to cover 2024 would waste API calls on every
+ * scrape just to fix a one-shot historical issue. One-shot cleanup is
+ * the right shape; the source config is intentionally left untouched.
+ *
+ * Safety:
+ *   - Dry-run by default; pass `--apply` to actually hard-delete.
+ *   - Bounded to kennel `mel-new-moon`, year 2024, and the exact
+ *     template-title shape — three independent guards.
+ *   - Hard-delete via `deleteLeakedEvent`.
+ *   - Post-delete orphan check confirms the rows are gone.
+ *   - Idempotent — re-runs find zero matching rows once applied.
+ *
+ * Run:
+ *   tsx scripts/cleanup-mel-nm-historical-placeholders.ts          # dry-run
+ *   tsx scripts/cleanup-mel-nm-historical-placeholders.ts --apply  # destructive
+ *
+ * Per memory `feedback_script_env_loading.md` — `import "dotenv/config"`
+ * because tsx doesn't auto-load .env.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { deleteLeakedEvent } from "./lib/delete-leaked-event";
+
+const KENNEL_CODE = "mel-new-moon";
+
+// The verbatim Meetup recurrence-template title. Matched as a prefix so
+// minor trailing drift ("...from tbd", "...from TBD") still collapses,
+// but the "Every Wednesday @" lead is specific enough to never hit a
+// real trail name. Not a regex — string prefix keeps it Sonar-clean.
+const TEMPLATE_TITLE_PREFIX = "Every Wednesday @";
+
+// Hard date guard: only 2024 rows. Keeps the sweep off any current-year
+// event even if a future template leak somehow shared the prefix.
+const YEAR = 2024;
+
+async function verifyNoOrphans(deletedIds: string[]): Promise<void> {
+  if (deletedIds.length === 0) return;
+  const stillPresent = await prisma.event.count({ where: { id: { in: deletedIds } } });
+  const danglingRaw = await prisma.rawEvent.count({ where: { eventId: { in: deletedIds } } });
+  if (stillPresent === 0 && danglingRaw === 0) {
+    console.log(`Verified: all ${deletedIds.length} Event(s) gone, no dangling RawEvents.`);
+    return;
+  }
+  console.warn(`WARNING: ${stillPresent} Event(s) still present, ${danglingRaw} dangling RawEvent(s) remain.`);
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY (will hard-delete)" : "DRY-RUN"}`);
+
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: KENNEL_CODE },
+    select: { id: true, shortName: true },
+  });
+  if (!kennel) {
+    console.log(`Kennel "${KENNEL_CODE}" not found — nothing to do.`);
+    return;
+  }
+  console.log(`Targeting kennel: ${kennel.shortName} (${kennel.id})`);
+
+  const matched = await prisma.event.findMany({
+    where: {
+      kennelId: kennel.id,
+      title: { startsWith: TEMPLATE_TITLE_PREFIX },
+      date: {
+        gte: new Date(Date.UTC(YEAR, 0, 1)),
+        lt: new Date(Date.UTC(YEAR + 1, 0, 1)),
+      },
+    },
+    select: {
+      id: true,
+      title: true,
+      date: true,
+      _count: { select: { hares: true, attendances: true, kennelAttendances: true, rawEvents: true } },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  console.log(`\nMatched ${matched.length} ${KENNEL_CODE} placeholder Event(s) in ${YEAR}:`);
+  for (const e of matched) {
+    const c = e._count;
+    console.log(
+      `  ${e.id}  ${e.date.toISOString().slice(0, 10)}  att=${c.attendances}/ka=${c.kennelAttendances}/hares=${c.hares}/raw=${c.rawEvents}  title=${JSON.stringify(e.title)}`,
+    );
+  }
+
+  if (!apply || matched.length === 0) {
+    if (!apply) console.log("\nDry-run complete. Re-run with --apply to delete.");
+    return;
+  }
+
+  // Safety invariant (Codex review): the hard-delete is only justified
+  // because these rows are pure orphaned placeholders — zero hares, zero
+  // attendance, zero kennelAttendance, AND zero RawEvent backing. Enforce
+  // that at execution time, not just in the header: if prod has drifted or
+  // a real `Every Wednesday @…` 2024 event exists, abort the whole run
+  // rather than irreversibly delete data.
+  const withData = matched.filter((e) => {
+    const c = e._count;
+    return c.hares > 0 || c.attendances > 0 || c.kennelAttendances > 0 || c.rawEvents > 0;
+  });
+  if (withData.length > 0) {
+    console.error(
+      `\nABORT: ${withData.length} matched Event(s) are not pure orphans (have hares/attendance/RawEvent) — refusing to hard-delete:`,
+    );
+    for (const e of withData) {
+      const c = e._count;
+      console.error(`  ${e.id}  att=${c.attendances}/ka=${c.kennelAttendances}/hares=${c.hares}/raw=${c.rawEvents}  title=${JSON.stringify(e.title)}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  // The batch guard above is a fast pre-flight abort; the real enforcement
+  // is the per-event transactional invariant — `deleteLeakedEvent` binds
+  // these required-empty relations to their deleteMany inside the
+  // transaction and rolls back if any row appeared after the snapshot
+  // (TOCTOU-proof under READ COMMITTED — Codex review).
+  for (const e of matched) {
+    await deleteLeakedEvent(prisma, e.id, ["hares", "attendances", "kennelAttendances", "rawEvents"]);
+  }
+  console.log(`\nDeleted ${matched.length} placeholder Event(s).`);
+
+  await verifyNoOrphans(matched.map((e) => e.id));
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/cleanup-mh3-mn-test-events-v2.ts
+++ b/scripts/cleanup-mh3-mn-test-events-v2.ts
@@ -61,7 +61,7 @@ const SUSPECT_TITLE_EXACT = new Set([
 
 function isSuspectTitle(title: string | null): boolean {
   if (!title) return false;
-  const normalized = title.toLowerCase().replaceAll(/[\s#]+/g, "");
+  const normalized = normalizeForMatch(title);
   if (SUSPECT_TITLE_EXACT.has(normalized)) return true;
   for (const prefix of SUSPECT_TITLE_PREFIXES) {
     if (normalized.startsWith(prefix)) return true;
@@ -69,10 +69,15 @@ function isSuspectTitle(title: string | null): boolean {
   return false;
 }
 
-// Location matched case-insensitive substring — both "123 Fake St" and
-// the no-space "123Fake St" variant the re-leak used appear only on the
-// synthetic test entry, so this is safe.
-const LOCATION_SUBSTRING = "123fake st";
+// Location matched as a substring AFTER the same whitespace+`#` normalize
+// the titles use, so both "123 Fake St" and the no-space "123Fake St"
+// variant the re-leak used collapse to the same key. Both appear only on
+// the synthetic test entry, so this is safe.
+const LOCATION_SUBSTRING = "123fakest";
+
+function normalizeForMatch(value: string): string {
+  return value.toLowerCase().replaceAll(/[\s#]+/g, "");
+}
 
 async function verifyNoOrphans(deletedIds: string[]): Promise<void> {
   if (deletedIds.length === 0) return;
@@ -82,9 +87,12 @@ async function verifyNoOrphans(deletedIds: string[]): Promise<void> {
     console.log(`Verified: all ${deletedIds.length} Event(s) gone, no dangling RawEvents.`);
     return;
   }
+  // Fail loud: a destructive run that left orphans behind must surface a
+  // non-zero exit code so an operator/pipeline doesn't read success.
   console.warn(
     `WARNING: ${stillPresent} Event(s) still present, ${danglingRaw} dangling RawEvent(s) remain.`,
   );
+  process.exitCode = 1;
 }
 
 async function main() {
@@ -115,7 +123,7 @@ async function main() {
 
   const matched = candidates.filter((e) => {
     const titleHit = isSuspectTitle(e.title);
-    const locationHit = !!e.locationName && e.locationName.toLowerCase().includes(LOCATION_SUBSTRING);
+    const locationHit = !!e.locationName && normalizeForMatch(e.locationName).includes(LOCATION_SUBSTRING);
     return titleHit || locationHit;
   });
 

--- a/scripts/cleanup-mh3-mn-test-events-v2.ts
+++ b/scripts/cleanup-mh3-mn-test-events-v2.ts
@@ -41,6 +41,7 @@ import "dotenv/config";
 import { prisma } from "@/lib/db";
 import { deleteLeakedEvent } from "./lib/delete-leaked-event";
 import { verifyNoOrphans } from "./lib/verify-no-orphans";
+import { parseApplyMode, resolveCleanupKennel } from "./lib/cleanup-cli";
 
 const KENNEL_CODE = "mh3-mn";
 
@@ -81,18 +82,9 @@ function normalizeForMatch(value: string): string {
 }
 
 async function main() {
-  const apply = process.argv.includes("--apply");
-  console.log(`Mode: ${apply ? "APPLY (will hard-delete)" : "DRY-RUN"}`);
-
-  const kennel = await prisma.kennel.findUnique({
-    where: { kennelCode: KENNEL_CODE },
-    select: { id: true, shortName: true },
-  });
-  if (!kennel) {
-    console.log(`Kennel "${KENNEL_CODE}" not found — nothing to do.`);
-    return;
-  }
-  console.log(`Targeting kennel: ${kennel.shortName} (${kennel.id})`);
+  const apply = parseApplyMode();
+  const kennel = await resolveCleanupKennel(prisma, KENNEL_CODE);
+  if (!kennel) return;
 
   const candidates = await prisma.event.findMany({
     where: { kennelId: kennel.id },

--- a/scripts/cleanup-mh3-mn-test-events-v2.ts
+++ b/scripts/cleanup-mh3-mn-test-events-v2.ts
@@ -40,6 +40,7 @@
 import "dotenv/config";
 import { prisma } from "@/lib/db";
 import { deleteLeakedEvent } from "./lib/delete-leaked-event";
+import { verifyNoOrphans } from "./lib/verify-no-orphans";
 
 const KENNEL_CODE = "mh3-mn";
 
@@ -77,22 +78,6 @@ const LOCATION_SUBSTRING = "123fakest";
 
 function normalizeForMatch(value: string): string {
   return value.toLowerCase().replaceAll(/[\s#]+/g, "");
-}
-
-async function verifyNoOrphans(deletedIds: string[]): Promise<void> {
-  if (deletedIds.length === 0) return;
-  const stillPresent = await prisma.event.count({ where: { id: { in: deletedIds } } });
-  const danglingRaw = await prisma.rawEvent.count({ where: { eventId: { in: deletedIds } } });
-  if (stillPresent === 0 && danglingRaw === 0) {
-    console.log(`Verified: all ${deletedIds.length} Event(s) gone, no dangling RawEvents.`);
-    return;
-  }
-  // Fail loud: a destructive run that left orphans behind must surface a
-  // non-zero exit code so an operator/pipeline doesn't read success.
-  console.warn(
-    `WARNING: ${stillPresent} Event(s) still present, ${danglingRaw} dangling RawEvent(s) remain.`,
-  );
-  process.exitCode = 1;
 }
 
 async function main() {
@@ -173,7 +158,7 @@ async function main() {
   }
   console.log(`\nDeleted ${matched.length} leaked Event(s).`);
 
-  await verifyNoOrphans(matched.map((e) => e.id));
+  await verifyNoOrphans(prisma, matched.map((e) => e.id));
 }
 
 main()

--- a/scripts/cleanup-mh3-mn-test-events-v2.ts
+++ b/scripts/cleanup-mh3-mn-test-events-v2.ts
@@ -1,0 +1,178 @@
+/**
+ * One-shot cleanup for issue #1736 — MH3-MN (Minneapolis H3) test /
+ * admin-internal events that a post-merge re-scrape recreated after the
+ * #1632 v1 cleanup (`cleanup-mh3-mn-test-events.ts`).
+ *
+ * v1 matched titles by exact equality after normalize; two re-leaked
+ * rows slipped past it:
+ *   - 2026-02-24  "Trail # Test Event Hare: L4 Location: 123Fake St,
+ *     Saint Paul, MN 55555" — the source pasted a multi-field admin blob
+ *     into the SUMMARY, so the whole blob appended past the
+ *     `trailtestevent` stem and equality failed.
+ *   - 2025-06-22  "mh3-mn" — an empty-SUMMARY row fell back to the
+ *     literal kennelTag as its title.
+ *
+ * This v2 matches the widened adapter filter (#1736): the same
+ * whitespace+`#` normalize, then a `startsWith` check against the
+ * known test-artifact stems (NOT exact equality). Kept as a separate
+ * script from v1 so the v1 audit trail / issue linkage stays intact.
+ *
+ * Deliberately not a regex with `\s*` / `#?` adjacency — Sonar S5852
+ * flags those as ReDoS-shaped even for linear inputs (see memory
+ * `feedback_sonar_s5852_procedural_over_regex`).
+ *
+ * Safety:
+ *   - Dry-run by default; pass `--apply` to actually hard-delete.
+ *   - Bounded to kennel `mh3-mn` to keep blast radius tight.
+ *   - Hard-delete via `deleteLeakedEvent` so a re-scrape can't resurrect
+ *     the leaked RawEvent (the adapter filter blocks NEW ones).
+ *   - Post-delete orphan check confirms the rows are gone and left no
+ *     dangling RawEvents.
+ *   - Idempotent — re-runs find zero matching rows once applied.
+ *
+ * Run:
+ *   tsx scripts/cleanup-mh3-mn-test-events-v2.ts          # dry-run
+ *   tsx scripts/cleanup-mh3-mn-test-events-v2.ts --apply  # destructive
+ *
+ * Per memory `feedback_script_env_loading.md` — `import "dotenv/config"`
+ * because tsx doesn't auto-load .env.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { deleteLeakedEvent } from "./lib/delete-leaked-event";
+
+const KENNEL_CODE = "mh3-mn";
+
+// Mirrors the adapter's two match modes in
+// src/adapters/google-calendar/adapter.ts:
+//   - PREFIX stems: admin-internal phrases that never lead a real run
+//     title, so `startsWith` is safe.
+//   - EXACT titles: `mh3-mn` is the kennel's own tag — matching it as a
+//     prefix would catch real titles like "MH3-MN Red Dress Run", so only
+//     the bare kennelTag-fallback title is an artifact (Codex review).
+const SUSPECT_TITLE_PREFIXES = new Set([
+  "trailtestevent",
+  "pcmeeting",
+]);
+
+const SUSPECT_TITLE_EXACT = new Set([
+  "mh3-mn",
+]);
+
+function isSuspectTitle(title: string | null): boolean {
+  if (!title) return false;
+  const normalized = title.toLowerCase().replaceAll(/[\s#]+/g, "");
+  if (SUSPECT_TITLE_EXACT.has(normalized)) return true;
+  for (const prefix of SUSPECT_TITLE_PREFIXES) {
+    if (normalized.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+// Location matched case-insensitive substring — both "123 Fake St" and
+// the no-space "123Fake St" variant the re-leak used appear only on the
+// synthetic test entry, so this is safe.
+const LOCATION_SUBSTRING = "123fake st";
+
+async function verifyNoOrphans(deletedIds: string[]): Promise<void> {
+  if (deletedIds.length === 0) return;
+  const stillPresent = await prisma.event.count({ where: { id: { in: deletedIds } } });
+  const danglingRaw = await prisma.rawEvent.count({ where: { eventId: { in: deletedIds } } });
+  if (stillPresent === 0 && danglingRaw === 0) {
+    console.log(`Verified: all ${deletedIds.length} Event(s) gone, no dangling RawEvents.`);
+    return;
+  }
+  console.warn(
+    `WARNING: ${stillPresent} Event(s) still present, ${danglingRaw} dangling RawEvent(s) remain.`,
+  );
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY (will hard-delete)" : "DRY-RUN"}`);
+
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: KENNEL_CODE },
+    select: { id: true, shortName: true },
+  });
+  if (!kennel) {
+    console.log(`Kennel "${KENNEL_CODE}" not found — nothing to do.`);
+    return;
+  }
+  console.log(`Targeting kennel: ${kennel.shortName} (${kennel.id})`);
+
+  const candidates = await prisma.event.findMany({
+    where: { kennelId: kennel.id },
+    select: {
+      id: true,
+      title: true,
+      date: true,
+      locationName: true,
+      _count: { select: { hares: true, attendances: true, kennelAttendances: true, rawEvents: true } },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  const matched = candidates.filter((e) => {
+    const titleHit = isSuspectTitle(e.title);
+    const locationHit = !!e.locationName && e.locationName.toLowerCase().includes(LOCATION_SUBSTRING);
+    return titleHit || locationHit;
+  });
+
+  console.log(`\nMatched ${matched.length} of ${candidates.length} ${KENNEL_CODE} Events:`);
+  for (const e of matched) {
+    const c = e._count;
+    console.log(
+      `  ${e.id}  ${e.date.toISOString().slice(0, 10)}  att=${c.attendances}/ka=${c.kennelAttendances}/hares=${c.hares}/raw=${c.rawEvents}  title=${JSON.stringify(e.title)}  loc=${JSON.stringify(e.locationName)}`,
+    );
+  }
+
+  if (!apply || matched.length === 0) {
+    if (!apply) console.log("\nDry-run complete. Re-run with --apply to delete.");
+    return;
+  }
+
+  // Safety invariant (Codex review): these are leaked SOURCE rows, so a
+  // RawEvent backing is EXPECTED (deleteLeakedEvent removes it so a
+  // re-scrape can't resurrect). But they must carry zero USER-generated
+  // data — any attendance/kennelAttendance/hare means a real event got
+  // caught by the predicate or prod drifted since inspection. Abort the
+  // whole run rather than hard-delete user data.
+  const withUserData = matched.filter(
+    (e) => e._count.attendances > 0 || e._count.kennelAttendances > 0 || e._count.hares > 0,
+  );
+  if (withUserData.length > 0) {
+    console.error(
+      `\nABORT: ${withUserData.length} matched Event(s) carry user data (attendance/hares) — refusing to hard-delete:`,
+    );
+    for (const e of withUserData) {
+      const c = e._count;
+      console.error(`  ${e.id}  att=${c.attendances}/ka=${c.kennelAttendances}/hares=${c.hares}  title=${JSON.stringify(e.title)}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  // The batch guard above is a fast pre-flight abort; the real enforcement
+  // is the per-event transactional invariant — `deleteLeakedEvent` binds
+  // these required-empty relations to their deleteMany inside the
+  // transaction and rolls back if user data appeared after the snapshot
+  // (TOCTOU-proof under READ COMMITTED — Codex review).
+  // rawEvents is intentionally omitted: a RawEvent backing is EXPECTED for
+  // these re-scrape leaks and is what the hard-delete must remove.
+  for (const e of matched) {
+    await deleteLeakedEvent(prisma, e.id, ["hares", "attendances", "kennelAttendances"]);
+  }
+  console.log(`\nDeleted ${matched.length} leaked Event(s).`);
+
+  await verifyNoOrphans(matched.map((e) => e.id));
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/lib/cleanup-cli.ts
+++ b/scripts/lib/cleanup-cli.ts
@@ -1,0 +1,35 @@
+import type { PrismaClient } from "@/generated/prisma/client";
+
+/**
+ * Shared CLI scaffolding for the one-shot `cleanup-*.ts` scripts: the
+ * `--apply` dry-run gate and the kennel lookup + targeting log that every
+ * script opens with. Extracted so the boilerplate lives once instead of being
+ * copy-pasted per script (SonarCloud CPD).
+ */
+
+/** Parse the `--apply` flag and log the resulting mode. */
+export function parseApplyMode(): boolean {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY (will hard-delete)" : "DRY-RUN"}`);
+  return apply;
+}
+
+/**
+ * Resolve the target kennel by code, or log + return null when it's absent so
+ * the caller can bail early.
+ */
+export async function resolveCleanupKennel(
+  prisma: PrismaClient,
+  kennelCode: string,
+): Promise<{ id: string; shortName: string } | null> {
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode },
+    select: { id: true, shortName: true },
+  });
+  if (!kennel) {
+    console.log(`Kennel "${kennelCode}" not found — nothing to do.`);
+    return null;
+  }
+  console.log(`Targeting kennel: ${kennel.shortName} (${kennel.id})`);
+  return kennel;
+}

--- a/scripts/lib/delete-leaked-event.test.ts
+++ b/scripts/lib/delete-leaked-event.test.ts
@@ -93,10 +93,15 @@ describe("deleteLeakedEvent safety invariant", () => {
   });
 
   it("takes a FOR UPDATE row lock before deleting any relation", async () => {
-    const { prisma, queryRaw } = buildPrisma({});
+    const { prisma, queryRaw, tx } = buildPrisma({});
     await deleteLeakedEvent(prisma, "evt_1", ["rawEvents"]);
     const sql = String(queryRaw.mock.calls[0][0]);
     expect(sql).toContain("FOR UPDATE");
+    // The lock must be acquired BEFORE any relation delete or the TOCTOU
+    // guarantee is void — assert ordering, not just that the lock ran.
+    expect(queryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.rawEvent.deleteMany.mock.invocationCallOrder[0],
+    );
   });
 
   it("short-circuits without deleting when the Event vanished before the lock", async () => {

--- a/scripts/lib/delete-leaked-event.test.ts
+++ b/scripts/lib/delete-leaked-event.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { deleteLeakedEvent, DeleteSafetyViolationError } from "./delete-leaked-event";
+import type { PrismaClient } from "@/generated/prisma/client";
+
+/**
+ * The safety invariant is bound to the deleteMany result, not a separate
+ * count read, so these tests drive the helper through a fake `tx` whose
+ * per-relation deleteMany counts are configurable. The whole point is the
+ * TOCTOU-proofing: a required-empty relation that removes a row must throw
+ * and leave `event.delete` un-called (the transaction would roll back).
+ */
+type RelationCounts = {
+  hares?: number;
+  attendances?: number;
+  kennelAttendances?: number;
+  rawEvents?: number;
+  eventKennels?: number;
+};
+
+function buildPrisma(counts: RelationCounts, lockedRows: Array<{ id: string }> = [{ id: "evt_1" }]) {
+  const eventDelete = vi.fn().mockResolvedValue({});
+  const queryRaw = vi.fn().mockResolvedValue(lockedRows);
+  const tx = {
+    $queryRaw: queryRaw,
+    eventHare: { deleteMany: vi.fn().mockResolvedValue({ count: counts.hares ?? 0 }) },
+    attendance: { deleteMany: vi.fn().mockResolvedValue({ count: counts.attendances ?? 0 }) },
+    kennelAttendance: {
+      deleteMany: vi.fn().mockResolvedValue({ count: counts.kennelAttendances ?? 0 }),
+    },
+    rawEvent: { deleteMany: vi.fn().mockResolvedValue({ count: counts.rawEvents ?? 0 }) },
+    eventKennel: { deleteMany: vi.fn().mockResolvedValue({ count: counts.eventKennels ?? 0 }) },
+    event: { delete: eventDelete },
+  };
+  const prisma = {
+    event: {
+      findUnique: vi.fn().mockResolvedValue({
+        id: "evt_1",
+        title: "Every Wednesday @ 6:30pm from tbd",
+        date: new Date("2024-06-01T12:00:00Z"),
+        kennelId: "kennel_1",
+        _count: { hares: 0, attendances: 0, kennelAttendances: 0 },
+      }),
+    },
+    // Run the callback with our fake tx; propagate throws like a rollback.
+    $transaction: vi.fn(async (fn: (t: typeof tx) => Promise<unknown>) => fn(tx)),
+  };
+  return { prisma: prisma as unknown as PrismaClient, eventDelete, queryRaw, tx };
+}
+
+describe("deleteLeakedEvent safety invariant", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("deletes the event when every required-empty relation removed zero rows", async () => {
+    const { prisma, eventDelete } = buildPrisma({ rawEvents: 3 });
+    await deleteLeakedEvent(prisma, "evt_1", ["hares", "attendances", "kennelAttendances"]);
+    expect(eventDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws and never deletes the event when a required-empty relation removed a row", async () => {
+    // A user RSVP landed after the script's pre-flight snapshot: the
+    // attendance deleteMany now reports 1, which must abort the delete.
+    const { prisma, eventDelete } = buildPrisma({ attendances: 1 });
+    await expect(
+      deleteLeakedEvent(prisma, "evt_1", ["hares", "attendances", "kennelAttendances"]),
+    ).rejects.toBeInstanceOf(DeleteSafetyViolationError);
+    expect(eventDelete).not.toHaveBeenCalled();
+  });
+
+  it("allows rawEvents to be removed when rawEvents is not a required-empty relation (re-scrape leak)", async () => {
+    // mh3-mn semantics: RawEvent backing is EXPECTED and must be deleted,
+    // so a nonzero rawEvents deleteMany is fine while user data stays guarded.
+    const { prisma, eventDelete } = buildPrisma({ rawEvents: 1 });
+    await deleteLeakedEvent(prisma, "evt_1", ["hares", "attendances", "kennelAttendances"]);
+    expect(eventDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("guards rawEvents too when it is listed (mel-nm pure-orphan semantics)", async () => {
+    const { prisma, eventDelete } = buildPrisma({ rawEvents: 1 });
+    await expect(
+      deleteLeakedEvent(prisma, "evt_1", ["hares", "attendances", "kennelAttendances", "rawEvents"]),
+    ).rejects.toBeInstanceOf(DeleteSafetyViolationError);
+    expect(eventDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes unconditionally when no invariant is requested (default callers)", async () => {
+    const { prisma, eventDelete } = buildPrisma({ attendances: 5, rawEvents: 5 });
+    await deleteLeakedEvent(prisma, "evt_1");
+    expect(eventDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("takes a FOR UPDATE row lock before deleting any relation", async () => {
+    const { prisma, queryRaw } = buildPrisma({});
+    await deleteLeakedEvent(prisma, "evt_1", ["rawEvents"]);
+    const sql = String(queryRaw.mock.calls[0][0]);
+    expect(sql).toContain("FOR UPDATE");
+  });
+
+  it("short-circuits without deleting when the Event vanished before the lock", async () => {
+    const { prisma, eventDelete, tx } = buildPrisma({}, []);
+    await deleteLeakedEvent(prisma, "evt_1", ["rawEvents"]);
+    expect(eventDelete).not.toHaveBeenCalled();
+    expect(tx.rawEvent.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/lib/delete-leaked-event.ts
+++ b/scripts/lib/delete-leaked-event.ts
@@ -1,27 +1,53 @@
 /**
- * One-shot hard-delete helper for the `cleanup-issue-NNNN.ts` family
- * (single-event leak cleanups — PII, admin notices, title leaks).
+ * One-shot HARD-delete helper for the `cleanup-*.ts` single-event leak
+ * cleanups (PII, admin notices, title leaks).
  *
- * Distinct from {@link cascadeDeleteEvents} in `cascade-delete.ts`, which
- * UNLINKS RawEvents (preserves the immutable audit trail) and re-flags
- * them as `processed=false`. That's the right shape for bulk admin
- * deletes; it's the WRONG shape for these one-shot leaks, because the
- * RawEvent.rawJson still carries the verbatim source row that produced
- * the leak. Resetting `processed=false` would let the merge pipeline
- * recreate the canonical Event on the next run.
- *
- * For an adapter-side filter (e.g. PERSONAL_TITLE_PATTERNS) to be
- * effective end-to-end, we have to also hard-delete the leaked RawEvent
- * so a re-scrape can't resurrect it. EventHare / Attendance /
- * KennelAttendance are also hard-deleted because their FKs don't
- * cascade (verified against prisma/schema.prisma); EventLink and
- * EventKennel do cascade automatically.
+ * Unlike {@link cascadeDeleteEvents} in `cascade-delete.ts` (which UNLINKS
+ * RawEvents and re-flags them `processed=false` for bulk admin deletes),
+ * this hard-deletes the leaked RawEvent. The RawEvent.rawJson still carries
+ * the verbatim source row, so resetting `processed=false` would let the
+ * merge pipeline recreate the leaked Event on the next run. Hard-deleting
+ * the RawEvent is what lets an adapter-side filter hold end-to-end against
+ * a re-scrape. EventHare / Attendance / KennelAttendance are hard-deleted
+ * too because their FKs don't cascade (per prisma/schema.prisma); EventLink
+ * and EventKennel cascade automatically.
  */
 import type { PrismaClient } from "@/generated/prisma/client";
+
+/**
+ * Relations a caller can require to be empty for a hard-delete to proceed.
+ * The invariant is bound to the delete: each relation's `deleteMany` runs
+ * inside the transaction and, for a required-empty relation, ANY row it
+ * removes throws and rolls the whole transaction back.
+ *
+ * TOCTOU-proof under PostgreSQL's default READ COMMITTED — the `deleteMany`
+ * result is the authoritative count of rows present at delete time, so no
+ * separate snapshot read can race a concurrent insert (the prior
+ * count-then-delete shape had that race — Codex review).
+ */
+export type RequireZeroCount = "hares" | "attendances" | "kennelAttendances" | "rawEvents";
+
+/** Thrown (rolling back the transaction) when a required-empty relation removed rows at delete time. */
+export class DeleteSafetyViolationError extends Error {
+  constructor(
+    readonly eventId: string,
+    readonly violations: Partial<Record<RequireZeroCount, number>>,
+  ) {
+    super(
+      `Refusing to delete Event ${eventId}: required-empty relation(s) had rows at delete time — ${Object.entries(
+        violations,
+      )
+        .map(([k, v]) => `${k}=${v}`)
+        .join(", ")}`,
+    );
+    this.name = "DeleteSafetyViolationError";
+  }
+}
 
 export async function deleteLeakedEvent(
   prisma: PrismaClient,
   eventId: string,
+  requireZeroCounts: RequireZeroCount[] = [],
 ): Promise<void> {
   const existing = await prisma.event.findUnique({
     where: { id: eventId },
@@ -43,11 +69,50 @@ export async function deleteLeakedEvent(
   );
 
   await prisma.$transaction(async (tx) => {
+    // Lock the parent Event for the transaction's lifetime. A concurrent
+    // scrape/merge linking a NEW child row needs FOR KEY SHARE on this row
+    // (FK insert/update); FOR UPDATE conflicts, so any such writer blocks
+    // until we commit or roll back. This is what makes the `rawEvents`
+    // invariant trustworthy: RawEvent.eventId is a NULLABLE FK with no
+    // cascade, so without the lock a RawEvent linked after `rawEvent
+    // .deleteMany` would be silently SET NULL by the Event delete instead of
+    // failing — bypassing the guard (Codex review). Non-nullable child FKs
+    // (Attendance/KennelAttendance/EventHare) would fail the delete anyway;
+    // the lock just makes the whole path uniformly race-free.
+    const locked = await tx.$queryRaw<Array<{ id: string }>>`
+      SELECT id FROM "Event" WHERE id = ${eventId} FOR UPDATE
+    `;
+    if (locked.length === 0) {
+      console.log(`Event ${eventId} vanished before lock — nothing to delete.`);
+      return;
+    }
+
     const hareDeleted = await tx.eventHare.deleteMany({ where: { eventId } });
     const attDeleted = await tx.attendance.deleteMany({ where: { eventId } });
     const kaDeleted = await tx.kennelAttendance.deleteMany({ where: { eventId } });
     const rawDeleted = await tx.rawEvent.deleteMany({ where: { eventId } });
     const ekDeleted = await tx.eventKennel.deleteMany({ where: { eventId } });
+
+    // Each deleteMany above reported exactly how many rows existed at delete
+    // time. For a required-empty relation, any nonzero count means data
+    // appeared after the script's pre-flight snapshot — throw so the whole
+    // transaction (including these deletes) rolls back rather than destroying it.
+    if (requireZeroCounts.length > 0) {
+      const deletedByRelation: Record<RequireZeroCount, number> = {
+        hares: hareDeleted.count,
+        attendances: attDeleted.count,
+        kennelAttendances: kaDeleted.count,
+        rawEvents: rawDeleted.count,
+      };
+      const violations: Partial<Record<RequireZeroCount, number>> = {};
+      for (const key of requireZeroCounts) {
+        if (deletedByRelation[key] > 0) violations[key] = deletedByRelation[key];
+      }
+      if (Object.keys(violations).length > 0) {
+        throw new DeleteSafetyViolationError(eventId, violations);
+      }
+    }
+
     await tx.event.delete({ where: { id: eventId } });
     console.log(
       `Deleted ${hareDeleted.count} EventHare(s), ${attDeleted.count} Attendance(s), ${kaDeleted.count} KennelAttendance(s), ${rawDeleted.count} RawEvent(s), ${ekDeleted.count} EventKennel(s), and the Event itself.`,

--- a/scripts/lib/verify-no-orphans.ts
+++ b/scripts/lib/verify-no-orphans.ts
@@ -1,0 +1,23 @@
+import type { PrismaClient } from "@/generated/prisma/client";
+
+/**
+ * Post-delete safety check shared by the one-shot `cleanup-*.ts` scripts that
+ * hard-delete leaked Events via {@link deleteLeakedEvent}: confirm every
+ * deleted id is gone and left no dangling RawEvent.
+ *
+ * Fail loud — a destructive run that left orphans behind must surface a
+ * non-zero exit code so an operator/pipeline doesn't read success.
+ */
+export async function verifyNoOrphans(prisma: PrismaClient, deletedIds: string[]): Promise<void> {
+  if (deletedIds.length === 0) return;
+  const stillPresent = await prisma.event.count({ where: { id: { in: deletedIds } } });
+  const danglingRaw = await prisma.rawEvent.count({ where: { eventId: { in: deletedIds } } });
+  if (stillPresent === 0 && danglingRaw === 0) {
+    console.log(`Verified: all ${deletedIds.length} Event(s) gone, no dangling RawEvents.`);
+    return;
+  }
+  console.warn(
+    `WARNING: ${stillPresent} Event(s) still present, ${danglingRaw} dangling RawEvent(s) remain.`,
+  );
+  process.exitCode = 1;
+}

--- a/src/adapters/facebook-hosted-events/constants.ts
+++ b/src/adapters/facebook-hosted-events/constants.ts
@@ -109,6 +109,7 @@ export const ADMIN_NOTICE_PATTERNS = [
   /\bmoving\s+to\s+(?:a\s+)?new\s+(?:website|site|home|platform)\b/i,
   /\blast\s+day\s+(?:in|on|at)\b/i,
   /\bnew\s+website\b/i,
+  /\bleaving\s+meetup\b/i, // #1728: "MIAMI HASH HOUSE HARRIERS ARE LEAVING MEETUP" — platform-departure dummy event. Narrow: bare "leaving" alone is fine ("Leaving Las Vegas Trail").
   /\bfarewell\b/i,
   /\bRIP\b/, // case-sensitive — "rip" lowercase appears in real trail descriptions
   /\bgoodbye\b/i,

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -600,6 +600,37 @@ describe("synthetic test / admin-internal title filter (#1632)", () => {
     );
     expect(result).not.toBeNull();
   });
+
+  // #1736 — two leaks a post-merge re-scrape recreated that the original
+  // exact-equality check missed: a multi-field admin blob pasted into the
+  // SUMMARY (only the `trailtestevent` stem leads), and an empty-SUMMARY
+  // row that fell back to the literal kennelTag `mh3-mn`.
+  it.each([
+    "Trail # Test Event Hare: L4 Location: 123Fake St, Saint Paul, MN 55555",
+    "mh3-mn",
+  ])("drops re-scrape leak missed by exact-equality (#1736): %s", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary, location: "123Fake St, Saint Paul, MN 55555" }),
+      { defaultKennelTag: "mh3-mn" },
+    );
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    // Real MH3-MN trails must survive. `mh3-mn` is matched EXACTLY, not as
+    // a prefix, so a kennel-prefixed theme title normalizes to
+    // `mh3-mnreddress` and must NOT be dropped (Codex review false-positive
+    // guard) — only the bare kennelTag-fallback `mh3-mn` is an artifact.
+    "Frostbite Trail #500",
+    "Saint Paul Winter Hash",
+    "MH3-MN Red Dress Run",
+  ])("preserves legitimate MH3-MN trail title (#1736): %s", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary, location: "Memorial Park" }),
+      { defaultKennelTag: "mh3-mn" },
+    );
+    expect(result).not.toBeNull();
+  });
 });
 
 // #1691 — Flour City May 28: source admin pasted the kennel's URL slug

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -191,14 +191,39 @@ const HASH_KEYWORD_RE = /\bhash\b/i;
  * MH3-MN's calendar carried `Trail # Test Event` (with `123 Fake St`
  * location) and `PC Meeting`; both were leaking through to
  * /kennels/mh3-mn before this filter landed.
+ *
+ * #1736 — a post-merge re-scrape recreated two leaks the equality check
+ * missed, handled by two distinct match modes:
+ *
+ *   - PREFIX stems (`trailtestevent`, `pcmeeting`): the source pasted a
+ *     multi-field admin blob into one SUMMARY (`Trail # Test Event Hare:
+ *     L4 Location: 123Fake St…` → the whole blob appends past the stem, so
+ *     exact equality failed but the `trailtestevent` lead still matches).
+ *     These stems are admin-internal phrases that never lead a real run
+ *     title, so `startsWith` is safe.
+ *
+ *   - EXACT titles (`mh3-mn`): an empty-SUMMARY row fell back to the
+ *     literal kennelTag. This is matched by exact equality, NOT prefix —
+ *     `mh3-mn` is the kennel's own tag, so a real title like `MH3-MN Red
+ *     Dress Run` (normalizes to `mh3-mnreddress`) must NOT be dropped
+ *     (Codex review). Only the bare fallback title is an artifact.
  */
-const TEST_ARTIFACT_TITLE_KEYS = new Set([
+const TEST_ARTIFACT_TITLE_PREFIXES = new Set([
   "trailtestevent",
   "pcmeeting",
 ]);
 
+const TEST_ARTIFACT_TITLE_EXACT = new Set([
+  "mh3-mn",
+]);
+
 function isTestArtifactTitle(summary: string): boolean {
-  return TEST_ARTIFACT_TITLE_KEYS.has(summary.toLowerCase().replaceAll(/[\s#]+/g, ""));
+  const normalized = summary.toLowerCase().replaceAll(/[\s#]+/g, "");
+  if (TEST_ARTIFACT_TITLE_EXACT.has(normalized)) return true;
+  for (const prefix of TEST_ARTIFACT_TITLE_PREFIXES) {
+    if (normalized.startsWith(prefix)) return true;
+  }
+  return false;
 }
 
 /**

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -739,6 +739,37 @@ END:VCALENDAR`;
     expect(result.errors[0]).toContain("not valid ICS");
   });
 
+  it("treats an empty 200 body as empty-success when allowEmptyBody is set (#1753 Iron City)", async () => {
+    // The Events Calendar's ?ical=1 export returns HTTP 200 + 0-byte body when
+    // a kennel has no upcoming events. With allowEmptyBody, that's a clean scrape.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("", { status: 200, headers: { "Content-Type": "text/calendar" } }),
+    );
+
+    const source = buildMockSource({
+      config: { defaultKennelTag: "ich3", upcomingOnly: true, allowEmptyBody: true },
+    });
+    const result = await adapter.fetch(source);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.events).toHaveLength(0);
+    expect(result.diagnosticContext).toBeDefined();
+    expect(result.diagnosticContext!.totalVEvents).toBe(0);
+  });
+
+  it("still rejects an empty body when allowEmptyBody is not set", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("", { status: 200, headers: { "Content-Type": "text/calendar" } }),
+    );
+
+    const source = buildMockSource({ config: { defaultKennelTag: "ich3" } });
+    const result = await adapter.fetch(source);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("not valid ICS");
+  });
+
   it("handles BOM prefix in valid ICS", async () => {
     const icsWithBom = "\uFEFF" + SAMPLE_ICS;
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -21,6 +21,7 @@ export interface ICalSourceConfig {
   descriptionSuffix?: string;          // static text appended to every event description
   enrichSFH3Details?: boolean;         // fetch sfh3.com/runs/{id} detail pages for canonical title + Comment field
   enrichBerlinH3Details?: boolean;     // fetch berlin-h3.eu event pages for Hares field from wp-event-manager
+  allowEmptyBody?: boolean;            // treat an empty 200 body as an empty-success (0 events) instead of an error — The Events Calendar's ?ical=1 export returns 0 bytes when there are no upcoming events (ICH3 #1753)
 }
 
 /**
@@ -298,6 +299,7 @@ function icalDiagnostics(overrides: {
 async function fetchAndValidateIcsContent(
   url: string,
   fetchStart: number,
+  allowEmptyBody: boolean,
 ): Promise<{ icsText: string; contentType: string | undefined } | { error: ScrapeResult }> {
   let contentType: string | undefined;
   try {
@@ -322,6 +324,12 @@ async function fetchAndValidateIcsContent(
     const icsText = await resp.text();
 
     const trimmed = icsText.trimStart().replace(/^\uFEFF/, "");
+    // The Events Calendar's ?ical=1 export returns HTTP 200 with a 0-byte body
+    // when a kennel has no upcoming events (ICH3 #1753). Treat that as an
+    // empty-success rather than a hard failure when the source opts in.
+    if (trimmed === "" && allowEmptyBody) {
+      return { icsText: "", contentType };
+    }
     if (!trimmed.startsWith("BEGIN:VCALENDAR")) {
       const preview = icsText.substring(0, 200).replace(/\n/g, "\\n");
       const message = `Response is not valid ICS (content-type: ${contentType ?? "unknown"}, starts with: "${preview}")`;
@@ -354,6 +362,9 @@ function parseIcsCalendar(
   fetchDurationMs: number,
   contentType: string | undefined,
 ): { calendar: ReturnType<typeof icalSync.parseICS> } | { error: ScrapeResult } {
+  // An allowed empty body (ICH3 #1753) parses to an empty calendar — no VEVENTs,
+  // no error. Short-circuit so we never depend on node-ical's empty-input behavior.
+  if (icsText === "") return { calendar: {} };
   try {
     return { calendar: icalSync.parseICS(icsText) };
   } catch (err) {
@@ -514,8 +525,12 @@ export class ICalAdapter implements SourceAdapter {
     const minDate = new Date(now.getTime() - lookbackDays * 86_400_000);
     const maxDate = new Date(now.getTime() + lookforwardDays * 86_400_000);
 
+    const config = (source.config && typeof source.config === "object" && !Array.isArray(source.config))
+      ? source.config as ICalSourceConfig
+      : null;
+
     // Step 1: Fetch the ICS content
-    const fetchResult = await fetchAndValidateIcsContent(source.url, fetchStart);
+    const fetchResult = await fetchAndValidateIcsContent(source.url, fetchStart, config?.allowEmptyBody ?? false);
     if ("error" in fetchResult) return fetchResult.error;
 
     const { icsText, contentType } = fetchResult;
@@ -528,9 +543,6 @@ export class ICalAdapter implements SourceAdapter {
     const { calendar } = parseResult;
 
     // Step 3: Process VEVENT entries
-    const config = (source.config && typeof source.config === "object" && !Array.isArray(source.config))
-      ? source.config as ICalSourceConfig
-      : null;
     const skipPatterns = config?.skipPatterns?.length
       ? compilePatterns(config.skipPatterns, "i")
       : undefined;

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -422,6 +422,43 @@ describe("MeetupAdapter", () => {
     expect(result.diagnosticContext?.adminNoticeSkipped).toBe(1);
   });
 
+  it("filters Miami's 'LEAVING MEETUP' departure notice and audit-logs it (#1728)", async () => {
+    // Miami H3 posted a dummy event titled "MIAMI HASH HOUSE HARRIERS ARE
+    // LEAVING MEETUP" to announce the platform departure. The new narrow
+    // /\bleaving\s+meetup\b/i pattern drops it; the dropped title is surfaced
+    // in diagnosticContext for admin false-positive review.
+    const html = buildMeetupHtml({
+      "Event:departure": buildApolloEvent({
+        id: "314543422",
+        title: "MIAMI HASH HOUSE HARRIERS ARE LEAVING MEETUP",
+        dateTime: "2026-06-01T18:00:00-04:00",
+        status: "ACTIVE",
+      }),
+      "Event:leavingLasVegas": buildApolloEvent({
+        id: "real-trail",
+        title: "Leaving Las Vegas Trail #42",
+        dateTime: "2026-06-03T18:00:00-04:00",
+        status: "ACTIVE",
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "miami-hash-house-harriers", kennelTag: "mia-h3" }),
+      { days: 365 },
+    );
+
+    // Departure notice dropped; a bare-"leaving" trail title is kept (narrow pattern).
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].title).toMatch(/Leaving Las Vegas/);
+    expect(result.diagnosticContext?.adminNoticeSkipped).toBe(1);
+    expect(result.diagnosticContext?.adminNoticeTitles).toEqual([
+      "MIAMI HASH HOUSE HARRIERS ARE LEAVING MEETUP",
+    ]);
+  });
+
   it("parses events and assigns kennelTag", async () => {
     const html = buildMeetupHtml({
       "Event:1": buildApolloEvent(),

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -702,6 +702,9 @@ export class MeetupAdapter implements SourceAdapter {
     const compiledPatterns = compileKennelPatterns(config.kennelPatterns);
     let cancelledSkipped = 0;
     let adminNoticeSkipped = 0;
+    // Collect the titles we drop as admin notices so admins can audit
+    // false positives in the scrape diagnostics (#1728).
+    const adminNoticeTitles: string[] = [];
     for (const [i, ev] of allApolloEvents.entries()) {
       try {
         if (!ev.dateTime) continue;
@@ -725,6 +728,7 @@ export class MeetupAdapter implements SourceAdapter {
         // ADMIN_NOTICE_PATTERNS docstring.
         if (ev.title && isAdminNoticeTitle(ev.title)) {
           adminNoticeSkipped++;
+          adminNoticeTitles.push(ev.title);
           continue;
         }
         // Strict-boolean check (CodeRabbit PR #1612 review): the config is
@@ -754,6 +758,7 @@ export class MeetupAdapter implements SourceAdapter {
         eventsAfterDedup: allApolloEvents.length,
         cancelledSkipped,
         adminNoticeSkipped,
+        adminNoticeTitles,
         detailPagesFetched,
         detailPagesEnriched,
       },


### PR DESCRIPTION
## Summary

Five urgent fixes bundled into one PR — one active scrape outage plus four cycle-13 data-quality escapes. They touch disjoint files (no overlap with parallel sessions) and are grouped only because they're all urgent.

| Issue | Area | Fix |
|---|---|---|
| **#1753** (outage) | iCal adapter | Iron City's `?ical=1` export returns HTTP 200 + **0-byte body** when there are no upcoming events (The Events Calendar WP-plugin quirk). The adapter rejected that as "not valid ICS" → 3 consecutive failures. Added opt-in `allowEmptyBody` to `ICalSourceConfig`: an empty body becomes an empty-success (0 events), not an error. `upcomingOnly` already guards reconcile from treating it as "all events removed". |
| **#1728** | Meetup adapter | Meetup ingested *"MIAMI HASH HOUSE HARRIERS ARE LEAVING MEETUP"* as an event. Added `/\bleaving\s+meetup\b/i` to `ADMIN_NOTICE_PATTERNS` (narrow — won't catch "Goodbye Run"/"Farewell Trail") and surfaced dropped titles in `diagnosticContext` for false-positive auditing. |
| **#1735** | GCal adapter / source config | Morgantown's GCal feed re-emits an `MH3:` title prefix. Strip it at parse time via `titleStripPatterns` on the **GCal** source row (Harrier Central source verified clean — untouched). |
| **#1736** | GCal adapter | `isTestArtifactTitle` used exact-equality and missed 2 re-leaks (a multi-field admin blob pasted into SUMMARY, and a bare `mh3-mn` kennelTag fallback). Widened to `startsWith` against test-artifact stems + exact match on the bare kennelTag. v2 cleanup script hard-deletes the 2 leaks. |
| **#1737** | one-shot cleanup | 13 mel-nm 2024 placeholder Events (`"Every Wednesday @ 6:30pm from tbd"`) sit outside the 180-day scrape window, so they can't self-correct. One-shot hard-delete; `scrapeDays` intentionally **not** widened (per issue guidance). |

### Shared hard-delete helper (TOCTOU-proof)

`scripts/lib/delete-leaked-event.ts` is the common hard-delete path for the cleanup scripts. It survived an adversarial concurrency review:

- A `SELECT … FOR UPDATE` row lock is the **first** statement in the transaction, before any `deleteMany`. A concurrent scrape/merge linking a new child row needs `FOR KEY SHARE` on that row; `FOR UPDATE` conflicts, so the writer blocks until we commit or roll back. This matters because `RawEvent.eventId` is a **nullable FK with no cascade** — without the lock, a RawEvent linked after `rawEvent.deleteMany` would be silently `SET NULL` by the Event delete, bypassing the guard.
- The safety invariant is bound to each `deleteMany` **result count** (not a separate read), so a late insert rolls the whole transaction back. 7-case regression test added.

### Data state

All three cleanup targets are **already clean in prod** (verified by read-only query): 0 Morgantown `MH3:` titles, 0 mh3-mn suspects, 0 mel-nm placeholders. The scripts are idempotent no-ops now; they're committed for audit trail + re-runnability, and the shared helper guards any future run.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors (23 pre-existing out-of-scope warnings)
- [x] `npm test` (bundle files) — 778/778 pass; new 7-case `delete-leaked-event` suite green
- [x] Live-verify Iron City iCal feed against production URL → `error: (none)`, empty-success (outage path confirmed)
- [x] `/codex:adversarial-review` → **approve**, no material findings
- [x] `/simplify` (comment/redundancy refinements only, behavior unchanged)
- [x] Prod data state verified clean for #1735/#1736/#1737

Closes #1753
Closes #1728
Closes #1735
Closes #1736
Closes #1737

🤖 Generated with [Claude Code](https://claude.com/claude-code)