### PR TITLE
fix(gcal): drop test-artifact events by resolved title (#1736 follow-up)

### DIFF
--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -631,6 +631,27 @@ describe("synthetic test / admin-internal title filter (#1632)", () => {
     );
     expect(result).not.toBeNull();
   });
+
+  // #1736 follow-up — the merged fix only checked the raw SUMMARY, but the
+  // artifact re-leaked post-merge from a different shape: MH3-MN's calendar
+  // had a malformed row with the whole HTML blob pasted into the SUMMARY
+  // (so summary !== "mh3-mn"), which the adapter reduced to the bare
+  // kennel-tag fallback "mh3-mn" only as the RESOLVED title. The drop must
+  // therefore evaluate the resolved title, not just the summary.
+  it("drops blob-summary row that resolves to the bare kennel-tag title", () => {
+    const blob =
+      'Minneapolis Hash House HarriersHare: Pop that Snatch<br>Location Crystal Beach: ' +
+      '1101 Crystal Lake Rd E, Burnsville, MN 55306<br>Hash Cash: $6<br>Zelle: ' +
+      '<a href="mailto:minneapolishash@gmail.com"><u>minneapolishash@gmail.com</u></a> T15:';
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: blob }),
+      {
+        kennelPatterns: [["\\bT3H3\\b|Twin Titties", "t3h3"], ["\\bMH3\\b", "mh3-mn"]],
+        defaultKennelTag: "mh3-mn",
+      },
+    );
+    expect(result).toBeNull();
+  });
 });
 
 // #1691 — Flour City May 28: source admin pasted the kennel's URL slug

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -636,21 +636,35 @@ describe("synthetic test / admin-internal title filter (#1632)", () => {
   // artifact re-leaked post-merge from a different shape: MH3-MN's calendar
   // had a malformed row with the whole HTML blob pasted into the SUMMARY
   // (so summary !== "mh3-mn"), which the adapter reduced to the bare
-  // kennel-tag fallback "mh3-mn" only as the RESOLVED title. The drop must
-  // therefore evaluate the resolved title, not just the summary.
+  // kennel-tag fallback "mh3-mn" only as the RESOLVED title. The follow-up
+  // also evaluates the resolved title — but gated on "no structured field"
+  // so legitimate address-only rows (below) survive.
+  const MH3MN_CFG = {
+    kennelPatterns: [["\\bT3H3\\b|Twin Titties", "t3h3"], ["\\bMH3\\b", "mh3-mn"]] as [string, string][],
+    defaultKennelTag: "mh3-mn",
+  };
+
   it("drops blob-summary row that resolves to the bare kennel-tag title", () => {
     const blob =
       'Minneapolis Hash House HarriersHare: Pop that Snatch<br>Location Crystal Beach: ' +
       '1101 Crystal Lake Rd E, Burnsville, MN 55306<br>Hash Cash: $6<br>Zelle: ' +
       '<a href="mailto:minneapolishash@gmail.com"><u>minneapolishash@gmail.com</u></a> T15:';
-    const result = buildRawEventFromGCalItem(
-      testGCalEvent({ summary: blob }),
-      {
-        kennelPatterns: [["\\bT3H3\\b|Twin Titties", "t3h3"], ["\\bMH3\\b", "mh3-mn"]],
-        defaultKennelTag: "mh3-mn",
-      },
-    );
+    const result = buildRawEventFromGCalItem(testGCalEvent({ summary: blob }), MH3MN_CFG);
     expect(result).toBeNull();
+  });
+
+  // Codex review #1788 (comment 3324401046) — false-positive guard. A
+  // legitimate address-only summary ALSO resolves title → kennel-tag (via
+  // ADDRESS_AS_TITLE_RE), but preserves the address as `location`. Gating the
+  // resolved-title drop on `hasStructuredField` must keep these real events.
+  it("keeps address-only row that resolves to the kennel-tag but has a location", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "123 Main Rd, Springfield, MN 55555" }),
+      MH3MN_CFG,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.title).toBe("mh3-mn");
+    expect(result?.location).toBe("123 Main Rd, Springfield, MN 55555");
   });
 });
 

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -640,7 +640,7 @@ describe("synthetic test / admin-internal title filter (#1632)", () => {
   // also evaluates the resolved title — but gated on "no structured field"
   // so legitimate address-only rows (below) survive.
   const MH3MN_CFG = {
-    kennelPatterns: [["\\bT3H3\\b|Twin Titties", "t3h3"], ["\\bMH3\\b", "mh3-mn"]] as [string, string][],
+    kennelPatterns: [[String.raw`\bT3H3\b|Twin Titties`, "t3h3"], [String.raw`\bMH3\b`, "mh3-mn"]] as [string, string][],
     defaultKennelTag: "mh3-mn",
   };
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1520,17 +1520,9 @@ export function buildRawEventFromGCalItem(
   // #1632 — synthetic test / admin-internal titles. Unconditional drop:
   // unlike the sport / medical filters there is no plausible real hash
   // event whose summary is exactly "Trail # Test Event" or "PC Meeting".
-  //
-  // Check BOTH the raw `summary` AND the fully-resolved `title`. The
-  // #1736 widening only tested `summary`, but the MH3-MN artifact re-leaked
-  // post-merge: a malformed calendar row pastes an HTML blob into the
-  // SUMMARY, so the summary never equals "mh3-mn" — the bare kennel-tag
-  // only emerges as the resolved `title` after the fallback path runs.
-  // Evaluating the resolved title closes that gap. Safe against false
-  // positives: TEST_ARTIFACT_TITLE_EXACT holds the bare tag exactly, so a
-  // real "MH3-MN Red Dress Run" (normalizes to "mh3-mnreddressrun") is
-  // untouched.
-  if (isTestArtifactTitle(summary) || isTestArtifactTitle(title)) {
+  // (A second, signal-gated pass below also catches the case where the
+  // artifact only surfaces on the RESOLVED title — see the #1736 follow-up.)
+  if (isTestArtifactTitle(summary)) {
     return null;
   }
 
@@ -1578,6 +1570,18 @@ export function buildRawEventFromGCalItem(
     !hasStructuredField &&
     (isUltraShort || PERSONAL_TITLE_PATTERNS.some((re) => re.test(summary)))
   ) {
+    return null;
+  }
+
+  // #1736 follow-up (PR #1788) — the summary-only artifact check above misses
+  // a row whose SUMMARY defies parsing and collapses to the bare kennel-tag
+  // only as the RESOLVED title (MH3-MN's HTML-blob row: the `<mailto:…>`
+  // fragment trips EMAIL_IN_TITLE_RE → `title = kennelTag`). Drop it — but
+  // ONLY when no structured field survived. A legitimate address-only summary
+  // ALSO resolves title → kennelTag (ADDRESS_AS_TITLE_RE) yet preserves the
+  // address as `location`, so gating on `hasStructuredField` keeps those real
+  // events (Codex review #1788, comment 3324401046).
+  if (!hasStructuredField && isTestArtifactTitle(title)) {
     return null;
   }
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1520,7 +1520,17 @@ export function buildRawEventFromGCalItem(
   // #1632 — synthetic test / admin-internal titles. Unconditional drop:
   // unlike the sport / medical filters there is no plausible real hash
   // event whose summary is exactly "Trail # Test Event" or "PC Meeting".
-  if (isTestArtifactTitle(summary)) {
+  //
+  // Check BOTH the raw `summary` AND the fully-resolved `title`. The
+  // #1736 widening only tested `summary`, but the MH3-MN artifact re-leaked
+  // post-merge: a malformed calendar row pastes an HTML blob into the
+  // SUMMARY, so the summary never equals "mh3-mn" — the bare kennel-tag
+  // only emerges as the resolved `title` after the fallback path runs.
+  // Evaluating the resolved title closes that gap. Safe against false
+  // positives: TEST_ARTIFACT_TITLE_EXACT holds the bare tag exactly, so a
+  // real "MH3-MN Red Dress Run" (normalizes to "mh3-mnreddressrun") is
+  // untouched.
+  if (isTestArtifactTitle(summary) || isTestArtifactTitle(title)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1779 (which closed #1736). Post-merge verification re-scraped the Minneapolis calendar and found the MH3-MN test artifact **re-leaked** — the merged fix didn't fully close the gap.

**Root cause:** The #1736 widening checked `isTestArtifactTitle(summary)`. But the offending row isn't a clean `"mh3-mn"` summary — it's a **malformed calendar entry** that pastes the whole HTML blob into the SUMMARY at a midnight start (`Minneapolis Hash House HarriersHare: …<br>Location…<br>Hash Cash:…<br>Zelle:…`), duplicating the real 15:00 recurring run. The adapter reduces that unparseable blob to the bare kennel-tag fallback `"mh3-mn"` **only as the resolved `title`** — `summary` never equals `"mh3-mn"`, so the summary-only check never fired and the junk event re-created on every scrape.

**Fix:** Evaluate `isTestArtifactTitle` against **both** the raw `summary` and the fully-resolved `title`.

- Safe against false positives: `TEST_ARTIFACT_TITLE_EXACT` holds the bare tag *exactly*, so a real `"MH3-MN Red Dress Run"` (normalizes to `mh3-mnreddressrun`) is untouched, and the real recurring run resolves to `"Minneapolis Hash House Harriers"`.
- Dropping (rather than emptying for merge synthesis) is correct: the blob row is a *duplicate* of the real 15:00 event, so emptying would make merge synthesize a second event for that date.

## Test

Adds a regression test feeding the **verbatim prod blob summary** and asserting the row is dropped. The prior #1736 test only fed the bare `"mh3-mn"` summary, which never exercised the resolved-title path.

## Verification

- Reproduced against prod: a re-scrape re-leaked exactly this row (`cmpqf55iu…`, 2025-06-22, title `"mh3-mn"`). Confirmed with the fix the adapter returns `null` for the blob and keeps the legitimate recurring event.
- `npx tsc --noEmit` ✓, `npx eslint` ✓, GCal adapter suite 551/551 ✓
- The already-leaked prod row was hard-deleted via `scripts/cleanup-mh3-mn-test-events-v2.ts --apply` during post-merge cleanup.

Closes #1736

🤖 Generated with [Claude Code](https://claude.com/claude-code)