### PR TITLE
fix(adapters): systemic locationName cleaning + GREY stale-data cleanup

### DIFF
--- a/scripts/cleanup-locationname-systemic.ts
+++ b/scripts/cleanup-locationname-systemic.ts
@@ -41,34 +41,23 @@
  * don't reintroduce stale values).
  */
 import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
+import type { PrismaClient } from "@/generated/prisma/client";
 import { cleanLocationName } from "../src/adapters/utils";
 import { rewriteStaleDefaultTitle } from "@/pipeline/merge";
-import { createScriptPool } from "./lib/db-pool";
-
-const dryRun = !process.argv.includes("--apply");
+import { type FieldPatch, runFieldPatchCleanup } from "./lib/cleanup-cli";
 
 // Single-kennel sources whose locationName is re-cleanable in place. The
 // generic GREY source also feeds bristolh3, but cleanLocationName is a no-op
 // on legitimate Bristol venues so scoping to bristol-grey is sufficient.
 const LOCATION_KENNELS = ["hagueh3", "tth3-ab", "norfolkh3", "bristol-grey"];
 
-interface Patch {
-  kennelLabel: string;
-  eventId: string;
-  field: "locationName" | "title";
-  before: string | null;
-  after: string | null;
-}
-
 /** Re-clean stored locationName for the affected kennels (#1729/#1730/#1747/#1749). */
-async function collectLocationPatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectLocationPatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const kennels = await prisma.kennel.findMany({
     where: { kennelCode: { in: LOCATION_KENNELS } },
     select: { id: true, kennelCode: true },
   });
-  const patches: Patch[] = [];
+  const patches: FieldPatch[] = [];
   for (const kennel of kennels) {
     const events = await prisma.event.findMany({
       where: { kennelId: kennel.id, locationName: { not: null } },
@@ -93,7 +82,7 @@ async function collectLocationPatches(prisma: PrismaClient): Promise<Patch[]> {
 }
 
 /** Null sh3-au locationName values that merely duplicate haresText (#1731 #3078). */
-async function collectSh3DuplicateHaresPatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectSh3DuplicateHaresPatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const kennel = await prisma.kennel.findUnique({
     where: { kennelCode: "sh3-au" },
     select: { id: true },
@@ -120,7 +109,7 @@ async function collectSh3DuplicateHaresPatches(prisma: PrismaClient): Promise<Pa
 }
 
 /** Rewrite stale "GREY Trail" titles to the current display name (#1217/#1184). */
-async function collectGreyTitlePatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectGreyTitlePatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const kennel = await prisma.kennel.findUnique({
     where: { kennelCode: "bristol-grey" },
     select: { id: true, kennelCode: true, shortName: true, fullName: true },
@@ -130,7 +119,7 @@ async function collectGreyTitlePatches(prisma: PrismaClient): Promise<Patch[]> {
     where: { kennelId: kennel.id, title: { not: null } },
     select: { id: true, title: true },
   });
-  const patches: Patch[] = [];
+  const patches: FieldPatch[] = [];
   for (const e of events) {
     if (!e.title) continue;
     // "GREY" is the kennel's canonical alias (aliases.ts) — pass it so the
@@ -154,7 +143,7 @@ async function collectGreyTitlePatches(prisma: PrismaClient): Promise<Patch[]> {
   return patches;
 }
 
-async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectPatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const blocks = await Promise.all([
     collectLocationPatches(prisma),
     collectSh3DuplicateHaresPatches(prisma),
@@ -163,59 +152,8 @@ async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
   return blocks.flat();
 }
 
-function summarize(patches: Patch[]): void {
-  const byKennel = new Map<string, Patch[]>();
-  for (const p of patches) {
-    const list = byKennel.get(p.kennelLabel) ?? [];
-    list.push(p);
-    byKennel.set(p.kennelLabel, list);
-  }
-  for (const [label, list] of [...byKennel.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    console.log(`\n${label}: ${list.length} event(s)`);
-    for (const p of list.slice(0, 8)) {
-      console.log(`  ${p.eventId} ${p.field}:`);
-      console.log(`    - before: ${JSON.stringify(p.before)}`);
-      console.log(`    + after:  ${JSON.stringify(p.after)}`);
-    }
-    if (list.length > 8) console.log(`  … (${list.length - 8} more)`);
-  }
-}
-
-async function applyPatches(prisma: PrismaClient, patches: Patch[]): Promise<void> {
-  for (const p of patches) {
-    await prisma.event.update({
-      where: { id: p.eventId },
-      data: { [p.field]: p.after },
-    });
-  }
-}
-
-async function main() {
-  const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl) throw new Error("DATABASE_URL is required");
-  const pool = createScriptPool();
-  const adapter = new PrismaPg(pool);
-  const prisma = new PrismaClient({ adapter });
-
-  console.log(dryRun ? "🔍 DRY RUN — no changes will be made" : "✏️  APPLYING changes");
-  console.log(`DATABASE_URL host: ${new URL(databaseUrl).host}\n`);
-
-  const patches = await collectPatches(prisma);
-  summarize(patches);
-  console.log(`\nTotal: ${patches.length} event field(s) to patch.`);
-
-  if (patches.length > 0 && !dryRun) {
-    console.log("\nApplying patches...");
-    await applyPatches(prisma, patches);
-    console.log(`✓ Applied ${patches.length} patch(es).`);
-  } else if (dryRun) {
-    console.log("\nRun with --apply to commit changes.");
-  }
-
-  await pool.end();
-}
-
-main().catch((err) => {
+runFieldPatchCleanup(collectPatches).catch((err) => {
   console.error(err);
-  process.exit(1);
+  // Set exitCode rather than process.exit() so the event loop drains cleanly.
+  process.exitCode = 1;
 });

--- a/scripts/cleanup-locationname-systemic.ts
+++ b/scripts/cleanup-locationname-systemic.ts
@@ -1,0 +1,221 @@
+/**
+ * One-shot cleanup for stale canonical `Event.locationName` (and stale GREY
+ * `Event.title`) left behind by the systemic locationName-extraction fix
+ * (issues #1729 #1730 #1731 #1747 #1749 / #1217).
+ *
+ * Why this exists:
+ * - The merge pipeline uses tri-state field semantics: `undefined` = preserve
+ *   existing, `null` = explicit clear, value = overwrite (see merge.ts).
+ * - The adapter fixes make the scrapers now RETURN a cleaned value or
+ *   `undefined` for the affected runs. Cases where the new logic returns a
+ *   *value* (e.g. Hague "…Rijswijk (Link)" → "…Rijswijk", Norfolk
+ *   "Maybe, … T.B.C" → "The Maids Head, …") self-heal on the next scrape
+ *   because merge overwrites. Cases where it now returns `undefined`
+ *   (GREY "Contact … to set this run", TTH3 "Hares: Sexy Hares Needed",
+ *   Norfolk "T.B.A") do NOT — merge preserves the stale canonical value.
+ * - This script patches those stuck fields directly so the canonical Events
+ *   match what the fixed adapters would produce on a fresh scrape.
+ *
+ * Per memory `feedback_parser_fix_canonical_ghosts`: fingerprint-changing
+ * fixes leave stale canonical fields; plan the cleanup pass alongside the
+ * parser PR.
+ *
+ * Collectors:
+ *   - locations : for hagueh3 / tth3-ab / norfolkh3 / bristol-grey, re-run
+ *     `cleanLocationName` over the stored locationName and patch when it
+ *     changes (to a cleaned value OR null).
+ *   - sh3-au    : null locationName when it merely duplicates haresText — the
+ *     #1731 field-swap leak (run #3078). Requires the post-merge re-scrape to
+ *     have repopulated haresText first (see Usage), so the duplicate is
+ *     detectable.
+ *   - GREY title: rewrite stale "GREY Trail[ #N]" → "Bristol Greyhound H3
+ *     Trail[ #N]" via the canonical merge helper (#1217 / #1184).
+ *
+ * Usage:
+ *   npx tsx scripts/cleanup-locationname-systemic.ts            # dry run (default)
+ *   npx tsx scripts/cleanup-locationname-systemic.ts --apply    # apply changes
+ *
+ * Run on the local-dev DB first (see .claude/rules/local-dev-db.md). Run
+ * against prod only AFTER the post-merge scrape has re-run the five affected
+ * sources (so the sh3-au haresText duplicate is detectable and future scrapes
+ * don't reintroduce stale values).
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { cleanLocationName } from "../src/adapters/utils";
+import { rewriteStaleDefaultTitle } from "@/pipeline/merge";
+import { createScriptPool } from "./lib/db-pool";
+
+const dryRun = !process.argv.includes("--apply");
+
+// Single-kennel sources whose locationName is re-cleanable in place. The
+// generic GREY source also feeds bristolh3, but cleanLocationName is a no-op
+// on legitimate Bristol venues so scoping to bristol-grey is sufficient.
+const LOCATION_KENNELS = ["hagueh3", "tth3-ab", "norfolkh3", "bristol-grey"];
+
+interface Patch {
+  kennelLabel: string;
+  eventId: string;
+  field: "locationName" | "title";
+  before: string | null;
+  after: string | null;
+}
+
+/** Re-clean stored locationName for the affected kennels (#1729/#1730/#1747/#1749). */
+async function collectLocationPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const kennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: LOCATION_KENNELS } },
+    select: { id: true, kennelCode: true },
+  });
+  const patches: Patch[] = [];
+  for (const kennel of kennels) {
+    const events = await prisma.event.findMany({
+      where: { kennelId: kennel.id, locationName: { not: null } },
+      select: { id: true, locationName: true },
+    });
+    for (const e of events) {
+      if (!e.locationName) continue;
+      const cleaned = cleanLocationName(e.locationName);
+      // cleanLocationName returns string | null; compare against the stored
+      // value (treat "no change" as a skip).
+      if ((cleaned ?? null) === e.locationName) continue;
+      patches.push({
+        kennelLabel: `${kennel.kennelCode} location`,
+        eventId: e.id,
+        field: "locationName",
+        before: e.locationName,
+        after: cleaned,
+      });
+    }
+  }
+  return patches;
+}
+
+/** Null sh3-au locationName values that merely duplicate haresText (#1731 #3078). */
+async function collectSh3DuplicateHaresPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: "sh3-au" },
+    select: { id: true },
+  });
+  if (!kennel) return [];
+  const events = await prisma.event.findMany({
+    where: { kennelId: kennel.id, locationName: { not: null }, haresText: { not: null } },
+    select: { id: true, locationName: true, haresText: true },
+  });
+  return events
+    .filter(
+      (e) =>
+        e.locationName != null &&
+        e.haresText != null &&
+        e.locationName.trim().toLowerCase() === e.haresText.trim().toLowerCase(),
+    )
+    .map((e) => ({
+      kennelLabel: "sh3-au location==hares (#1731)",
+      eventId: e.id,
+      field: "locationName" as const,
+      before: e.locationName,
+      after: null,
+    }));
+}
+
+/** Rewrite stale "GREY Trail" titles to the current display name (#1217/#1184). */
+async function collectGreyTitlePatches(prisma: PrismaClient): Promise<Patch[]> {
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: "bristol-grey" },
+    select: { id: true, kennelCode: true, shortName: true, fullName: true },
+  });
+  if (!kennel) return [];
+  const events = await prisma.event.findMany({
+    where: { kennelId: kennel.id, title: { not: null } },
+    select: { id: true, title: true },
+  });
+  const patches: Patch[] = [];
+  for (const e of events) {
+    if (!e.title) continue;
+    // "GREY" is the kennel's canonical alias (aliases.ts) — pass it so the
+    // shared rewriter recognizes the stale "GREY Trail" prefix.
+    const rewritten = rewriteStaleDefaultTitle(
+      e.title,
+      kennel.kennelCode,
+      kennel.shortName,
+      kennel.fullName,
+      ["GREY"],
+    );
+    if (rewritten === e.title) continue;
+    patches.push({
+      kennelLabel: "bristol-grey title (#1217)",
+      eventId: e.id,
+      field: "title",
+      before: e.title,
+      after: rewritten,
+    });
+  }
+  return patches;
+}
+
+async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
+  const blocks = await Promise.all([
+    collectLocationPatches(prisma),
+    collectSh3DuplicateHaresPatches(prisma),
+    collectGreyTitlePatches(prisma),
+  ]);
+  return blocks.flat();
+}
+
+function summarize(patches: Patch[]): void {
+  const byKennel = new Map<string, Patch[]>();
+  for (const p of patches) {
+    const list = byKennel.get(p.kennelLabel) ?? [];
+    list.push(p);
+    byKennel.set(p.kennelLabel, list);
+  }
+  for (const [label, list] of [...byKennel.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    console.log(`\n${label}: ${list.length} event(s)`);
+    for (const p of list.slice(0, 8)) {
+      console.log(`  ${p.eventId} ${p.field}:`);
+      console.log(`    - before: ${JSON.stringify(p.before)}`);
+      console.log(`    + after:  ${JSON.stringify(p.after)}`);
+    }
+    if (list.length > 8) console.log(`  … (${list.length - 8} more)`);
+  }
+}
+
+async function applyPatches(prisma: PrismaClient, patches: Patch[]): Promise<void> {
+  for (const p of patches) {
+    await prisma.event.update({
+      where: { id: p.eventId },
+      data: { [p.field]: p.after },
+    });
+  }
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  console.log(dryRun ? "🔍 DRY RUN — no changes will be made" : "✏️  APPLYING changes");
+  console.log(`DATABASE_URL host: ${new URL(databaseUrl).host}\n`);
+
+  const patches = await collectPatches(prisma);
+  summarize(patches);
+  console.log(`\nTotal: ${patches.length} event field(s) to patch.`);
+
+  if (patches.length > 0 && !dryRun) {
+    console.log("\nApplying patches...");
+    await applyPatches(prisma, patches);
+    console.log(`✓ Applied ${patches.length} patch(es).`);
+  } else if (dryRun) {
+    console.log("\nRun with --apply to commit changes.");
+  }
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-ws5-canonical-ghosts.ts
+++ b/scripts/cleanup-ws5-canonical-ghosts.ts
@@ -44,12 +44,9 @@
  * affected sources (so future scrapes don't reintroduce stale values).
  */
 import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
+import type { PrismaClient } from "@/generated/prisma/client";
 import { stripMapBoilerplate } from "../src/adapters/html-scraper/sydney-thirsty-h3";
-import { createScriptPool } from "./lib/db-pool";
-
-const dryRun = !process.argv.includes("--apply");
+import { type FieldPatch, runFieldPatchCleanup } from "./lib/cleanup-cli";
 
 /** Mirrors hare-extraction.ts: skip period boundaries preceded by an honorific. */
 const HONORIFICS = new Set(["dr", "mr", "ms", "mrs", "st"]);
@@ -86,16 +83,8 @@ function isDateRangeHares(value: string): boolean {
   return /\b\d{1,2}\s*\/\s*\d{1,2}\b/.test(value);
 }
 
-interface Patch {
-  kennelLabel: string;
-  eventId: string;
-  field: "haresText" | "title" | "locationName";
-  before: string | null;
-  after: string | null;
-}
-
 /** ABQ haresText with slash-date (#1547). */
-async function collectAbqPatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectAbqPatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "abqh3" }, select: { id: true } });
   if (!kennel) return [];
   const events = await prisma.event.findMany({
@@ -108,14 +97,14 @@ async function collectAbqPatches(prisma: PrismaClient): Promise<Patch[]> {
 }
 
 /** Wasatch haresText sentence trailer (#1551). */
-async function collectWasatchPatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectWasatchPatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "wasatch-h3" }, select: { id: true } });
   if (!kennel) return [];
   const events = await prisma.event.findMany({
     where: { kennelId: kennel.id, haresText: { contains: ". " } },
     select: { id: true, haresText: true },
   });
-  const patches: Patch[] = [];
+  const patches: FieldPatch[] = [];
   for (const e of events) {
     if (!e.haresText) continue;
     const truncated = truncateAtSentence(e.haresText);
@@ -126,7 +115,7 @@ async function collectWasatchPatches(prisma: PrismaClient): Promise<Patch[]> {
 }
 
 /** Memphis FB title trailing delimiter (#1557). mh3-tn + gynoh3 via EventKennel join (GyNO via kennelPatterns). */
-async function collectMemphisPatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectMemphisPatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const kennels = await prisma.kennel.findMany({
     where: { kennelCode: { in: ["mh3-tn", "gynoh3"] } },
     select: { id: true },
@@ -140,7 +129,7 @@ async function collectMemphisPatches(prisma: PrismaClient): Promise<Patch[]> {
     },
     select: { id: true, title: true },
   });
-  const patches: Patch[] = [];
+  const patches: FieldPatch[] = [];
   for (const e of events) {
     if (!e.title) continue;
     const stripped = stripTitleTrailingDelimiter(e.title);
@@ -152,14 +141,14 @@ async function collectMemphisPatches(prisma: PrismaClient): Promise<Patch[]> {
 }
 
 /** STH3-AU locationName boilerplate (#1548). */
-async function collectSthAuPatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectSthAuPatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "sth3-au" }, select: { id: true } });
   if (!kennel) return [];
   const events = await prisma.event.findMany({
     where: { kennelId: kennel.id, locationName: { contains: "at the map location below", mode: "insensitive" } },
     select: { id: true, locationName: true },
   });
-  const patches: Patch[] = [];
+  const patches: FieldPatch[] = [];
   for (const e of events) {
     if (!e.locationName) continue;
     const stripped = stripMapBoilerplate(e.locationName);
@@ -170,7 +159,7 @@ async function collectSthAuPatches(prisma: PrismaClient): Promise<Patch[]> {
 }
 
 /** BH4 haresText "Open" placeholder (#1550). Routed via EventKennel (multi-kennel pattern). */
-async function collectBh4Patches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectBh4Patches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const kennel = await prisma.kennel.findUnique({ where: { kennelCode: "bh4" }, select: { id: true } });
   if (!kennel) return [];
   const events = await prisma.event.findMany({
@@ -183,7 +172,7 @@ async function collectBh4Patches(prisma: PrismaClient): Promise<Patch[]> {
   return events.map((e) => ({ kennelLabel: "bh4 #1550", eventId: e.id, field: "haresText" as const, before: e.haresText ?? null, after: null }));
 }
 
-async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
+async function collectPatches(prisma: PrismaClient): Promise<FieldPatch[]> {
   const blocks = await Promise.all([
     collectAbqPatches(prisma),
     collectWasatchPatches(prisma),
@@ -194,59 +183,9 @@ async function collectPatches(prisma: PrismaClient): Promise<Patch[]> {
   return blocks.flat();
 }
 
-function summarize(patches: Patch[]): void {
-  const byKennel = new Map<string, Patch[]>();
-  for (const p of patches) {
-    const list = byKennel.get(p.kennelLabel) ?? [];
-    list.push(p);
-    byKennel.set(p.kennelLabel, list);
-  }
-  for (const [label, list] of [...byKennel.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    console.log(`\n${label}: ${list.length} event(s)`);
-    for (const p of list.slice(0, 5)) {
-      console.log(`  ${p.eventId} ${p.field}:`);
-      console.log(`    - before: ${JSON.stringify(p.before)}`);
-      console.log(`    + after:  ${JSON.stringify(p.after)}`);
-    }
-    if (list.length > 5) console.log(`  … (${list.length - 5} more)`);
-  }
-}
-
-async function applyPatches(prisma: PrismaClient, patches: Patch[]): Promise<void> {
-  for (const p of patches) {
-    await prisma.event.update({
-      where: { id: p.eventId },
-      data: { [p.field]: p.after },
-    });
-  }
-}
-
-async function main() {
-  const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl) throw new Error("DATABASE_URL is required");
-  const pool = createScriptPool();
-  const adapter = new PrismaPg(pool);
-  const prisma = new PrismaClient({ adapter });
-
-  console.log(dryRun ? "🔍 DRY RUN — no changes will be made" : "✏️  APPLYING changes");
-  console.log(`DATABASE_URL host: ${new URL(databaseUrl).host}\n`);
-
-  const patches = await collectPatches(prisma);
-  summarize(patches);
-  console.log(`\nTotal: ${patches.length} event field(s) to patch.`);
-
-  if (patches.length > 0 && !dryRun) {
-    console.log("\nApplying patches...");
-    await applyPatches(prisma, patches);
-    console.log(`✓ Applied ${patches.length} patch(es).`);
-  } else if (dryRun) {
-    console.log("\nRun with --apply to commit changes.");
-  }
-
-  await pool.end();
-}
-
-main().catch((err) => {
+// summarize / apply / pool boilerplate is shared via runFieldPatchCleanup
+// (scripts/lib/cleanup-cli.ts) — keep this script to its collectors only.
+runFieldPatchCleanup(collectPatches, 5).catch((err) => {
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/scripts/lib/cleanup-cli.ts
+++ b/scripts/lib/cleanup-cli.ts
@@ -1,4 +1,6 @@
-import type { PrismaClient } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./db-pool";
 
 /**
  * Shared CLI scaffolding for the one-shot `cleanup-*.ts` scripts: the
@@ -32,4 +34,80 @@ export async function resolveCleanupKennel(
   }
   console.log(`Targeting kennel: ${kennel.shortName} (${kennel.id})`);
   return kennel;
+}
+
+/**
+ * A single canonical-`Event` field patch produced by a cleanup collector.
+ * `after === null` clears the field; a string overwrites it.
+ */
+export interface FieldPatch {
+  kennelLabel: string;
+  eventId: string;
+  field: "haresText" | "title" | "locationName";
+  before: string | null;
+  after: string | null;
+}
+
+/** Print a grouped, truncated before/after diff of the collected patches. */
+export function summarizeFieldPatches(patches: FieldPatch[], sampleSize = 8): void {
+  const byKennel = new Map<string, FieldPatch[]>();
+  for (const p of patches) {
+    const list = byKennel.get(p.kennelLabel) ?? [];
+    list.push(p);
+    byKennel.set(p.kennelLabel, list);
+  }
+  for (const [label, list] of [...byKennel.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    console.log(`\n${label}: ${list.length} event(s)`);
+    for (const p of list.slice(0, sampleSize)) {
+      console.log(`  ${p.eventId} ${p.field}:`);
+      console.log(`    - before: ${JSON.stringify(p.before)}`);
+      console.log(`    + after:  ${JSON.stringify(p.after)}`);
+    }
+    if (list.length > sampleSize) console.log(`  … (${list.length - sampleSize} more)`);
+  }
+}
+
+/** Apply each field patch with a per-row `event.update`. */
+export async function applyFieldPatches(prisma: PrismaClient, patches: FieldPatch[]): Promise<void> {
+  for (const p of patches) {
+    await prisma.event.update({ where: { id: p.eventId }, data: { [p.field]: p.after } });
+  }
+}
+
+/**
+ * Full harness for a field-patch cleanup script: opens a pooled Prisma client,
+ * runs the collector, prints the diff, applies it unless `--apply` is absent
+ * (dry-run default), and always releases the pool. Sets `process.exitCode` on
+ * failure rather than calling `process.exit()` so the event loop drains. Both
+ * `cleanup-locationname-systemic.ts` and `cleanup-ws5-canonical-ghosts.ts`
+ * share this rather than copy-pasting the boilerplate (SonarCloud CPD).
+ */
+export async function runFieldPatchCleanup(
+  collect: (prisma: PrismaClient) => Promise<FieldPatch[]>,
+  sampleSize = 8,
+): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  const dryRun = !process.argv.includes("--apply");
+  const pool = createScriptPool();
+  try {
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+    console.log(dryRun ? "🔍 DRY RUN — no changes will be made" : "✏️  APPLYING changes");
+    console.log(`DATABASE_URL host: ${new URL(databaseUrl).host}\n`);
+
+    const patches = await collect(prisma);
+    summarizeFieldPatches(patches, sampleSize);
+    console.log(`\nTotal: ${patches.length} event field(s) to patch.`);
+
+    if (patches.length > 0 && !dryRun) {
+      console.log("\nApplying patches...");
+      await applyFieldPatches(prisma, patches);
+      console.log(`✓ Applied ${patches.length} patch(es).`);
+    } else if (dryRun) {
+      console.log("\nRun with --apply to commit changes.");
+    }
+  } finally {
+    await pool.end();
+  }
 }

--- a/src/adapters/html-scraper/hague-h3.test.ts
+++ b/src/adapters/html-scraper/hague-h3.test.ts
@@ -107,6 +107,20 @@ Hares: DW`;
     expect(event!.location).toBe("Rotterdamseweg near Vliet canal");
   });
 
+  it("strips trailing parenthesized (Link) anchor while keeping interior parens (#1729)", () => {
+    const text = `Run 2410
+When: Sunday, March 15
+Time: 14:00 hr
+Where: Parking Elsenburgerbos (Lange Kleiweg), Rijswijk (Link)
+Hares: DW`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.location).toBe(
+      "Parking Elsenburgerbos (Lange Kleiweg), Rijswijk",
+    );
+  });
+
   it("parses Hare(s) variant", () => {
     const text = `Run 2406 (Layer takes requests run)
 When: Sunday Februari 22th

--- a/src/adapters/html-scraper/hague-h3.ts
+++ b/src/adapters/html-scraper/hague-h3.ts
@@ -34,7 +34,12 @@ import type {
   ParseError,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { fetchHTMLPage, buildDateWindow, decodeEntities, EMOJI_RE } from "../utils";
+import {
+  fetchHTMLPage,
+  buildDateWindow,
+  cleanLocationName,
+  decodeEntities,
+} from "../utils";
 
 // ── Constants ──
 
@@ -129,21 +134,17 @@ export function parseEventBlock(
     startTime = `${timeMatch[1].padStart(2, "0")}:${timeMatch[2]}`;
   }
 
-  // Extract location — strip trailing "Link" text from Google Maps links,
-  // strip any URLs, and strip pictographic emoji that the source authors
-  // sprinkle into the Where: line (e.g. "Station Voorburg 👣 under the
-  // viaduct" — the 👣 is in the source markup, #1258).
-  let location: string | undefined;
+  // Extract location and run it through the shared cleaner, which strips the
+  // trailing Google-Maps anchor text ("(Link)" / bare "Link" — #1729 / #1258),
+  // any URLs, and pictographic emoji the source authors sprinkle into the
+  // Where: line (e.g. "Station Voorburg 👣 under the viaduct"). A Where: line
+  // that cleans to non-venue text keeps the cleaner's `null` (explicit clear)
+  // rather than `undefined` so a venue→placeholder transition clears the stale
+  // canonical value at merge time. `undefined` only when there is no Where:.
+  let location: string | null | undefined;
   const whereMatch = WHERE_RE.exec(text);
   if (whereMatch) {
-    location = whereMatch[1]
-      .trim()
-      .replace(/\s*Link\s*$/i, "")
-      .replace(/\s*https?:\/\/\S+/g, "")
-      .replace(EMOJI_RE, "")
-      .replace(/\s{2,}/g, " ")
-      .trim();
-    if (!location) location = undefined;
+    location = cleanLocationName(whereMatch[1]);
   }
 
   // Extract hares

--- a/src/adapters/html-scraper/norfolk-h3.test.ts
+++ b/src/adapters/html-scraper/norfolk-h3.test.ts
@@ -190,7 +190,9 @@ describe("NorfolkH3Adapter", () => {
       expect(run).not.toBeNull();
       expect(run!.date).toBe("2026-05-13");
       expect(run!.startTime).toBe("19:00");
-      expect(run!.location).toBeUndefined();
+      // The Venue: field was present ("???") but is a placeholder → explicit
+      // clear (null) so merge wipes any stale address, not preserve (#1747).
+      expect(run!.location).toBeNull();
       expect(run!.hares).toBeUndefined();
       expect(run!.locationUrl).toBeUndefined();
     });
@@ -272,11 +274,13 @@ describe("NorfolkH3Adapter", () => {
       expect(run!.hares).toBe("Woolly & Bagpuss");
     });
 
-    it("captures hares when venue spans multi-line free-text body (#1545)", () => {
+    it("captures hares when venue spans multi-line free-text body, dropping the 'Details to follow' qualifier (#1545/#1747)", () => {
       // Verbatim from issue #1545 (Run #2153). Venue is a two-line free-text
       // body ("Drayton area" + "Details to follow") with no postcode, then
       // a Hare(s): label on the next line. The hare extraction must not be
-      // dropped just because the venue body is informal.
+      // dropped just because the venue body is informal. Per #1747 the
+      // trailing "Details to follow" uncertainty qualifier is now stripped
+      // from the location so the geocoder sees just "Drayton area".
       const text = [
         "Wednesday 8th July 2026, 7pm",
         "Venue:",
@@ -289,12 +293,12 @@ describe("NorfolkH3Adapter", () => {
       const run = parseNorfolkRunBlock(text);
       expect(run).not.toBeNull();
       expect(run!.date).toBe("2026-07-08");
-      expect(run!.location).toContain("Drayton area");
-      expect(run!.location).toContain("Details to follow");
+      expect(run!.location).toBe("Drayton area");
+      expect(run!.location).not.toMatch(/Details to follow/i);
       expect(run!.hares).toBe("James & Custodian");
     });
 
-    it("captures hares for single-line T.B.A. venue (#1545 Run #2154)", () => {
+    it("captures hares for single-line T.B.A. venue and clears the location (#1545/#1747 Run #2154)", () => {
       const text = [
         "Wednesday 15th July 2026, 7pm",
         "Venue:",
@@ -306,6 +310,34 @@ describe("NorfolkH3Adapter", () => {
       const run = parseNorfolkRunBlock(text);
       expect(run).not.toBeNull();
       expect(run!.hares).toBe("Maddie Mc Madder");
+      // "T.B.A." is a pure uncertainty marker — the Venue: field was present
+      // but cleans to non-venue text, so emit an explicit clear (#1747).
+      expect(run!.location).toBeNull();
+    });
+
+    it("peels leading 'Maybe,' and trailing 'T.B.C' qualifiers but keeps the postcode (#1747 Run #2148)", () => {
+      const text = [
+        "Sunday 1st June 2026, 11am",
+        "Venue:",
+        "Maybe, The Maids Head,",
+        "85 Spixworth Road",
+        "Old Catton",
+        "Norwich",
+        "NR6 7NH",
+        "T.B.C.",
+        "Hare(s):",
+        "Woolly",
+      ].join("\n");
+
+      const run = parseNorfolkRunBlock(text);
+      expect(run).not.toBeNull();
+      expect(run!.location).toBe(
+        "The Maids Head, 85 Spixworth Road, Old Catton, Norwich, NR6 7NH",
+      );
+      expect(run!.location).not.toMatch(/maybe/i);
+      expect(run!.location).not.toMatch(/t\.b\.c/i);
+      // Postcode survives the trailing-qualifier strip → map pin still resolves.
+      expect(run!.locationUrl).toContain("NR6");
     });
 
     it("strips leading '?' prefix from haresText (#1546)", () => {
@@ -537,7 +569,8 @@ describe("NorfolkH3Adapter", () => {
       expect(run2145).toBeDefined();
       expect(run2145!.date).toBe("2026-05-13");
       expect(run2145!.startTime).toBe("19:00");
-      expect(run2145!.location).toBeUndefined();
+      // Placeholder Venue: → explicit clear (null), not preserve (#1747).
+      expect(run2145!.location).toBeNull();
       expect(run2145!.hares).toBeUndefined();
     });
 
@@ -600,7 +633,8 @@ describe("NorfolkH3Adapter", () => {
       expect(run2150!.hares).not.toMatch(/^\?/);
 
       const run2151 = result.events.find((e) => e.runNumber === 2151);
-      expect(run2151!.location).toBeUndefined();
+      // Placeholder Venue: → explicit clear (null), not preserve (#1747).
+      expect(run2151!.location).toBeNull();
       expect(run2151!.hares).toBeUndefined();
 
       const run2152 = result.events.find((e) => e.runNumber === 2152);

--- a/src/adapters/html-scraper/norfolk-h3.ts
+++ b/src/adapters/html-scraper/norfolk-h3.ts
@@ -33,6 +33,7 @@ import { generateStructureHash } from "@/pipeline/structure-hash";
 import {
   buildUrlVariantCandidates,
   chronoParseDate,
+  cleanLocationName,
   decodeEntities,
   extractUkPostcode,
   googleMapsSearchUrl,
@@ -115,7 +116,9 @@ export interface ParsedNorfolkRun {
   runNumber?: number;
   date?: string; // YYYY-MM-DD
   startTime?: string; // HH:MM (24-hour)
-  location?: string;
+  // `null` = the Venue: field was present but cleaned to non-venue text
+  // (T.B.A./CTA) → explicit clear at merge. `undefined` = no Venue: field.
+  location?: string | null;
   locationUrl?: string;
   hares?: string;
   notes?: string;
@@ -210,10 +213,18 @@ export function parseNorfolkRunBlock(text: string): ParsedNorfolkRun | null {
   if (venueMatch) {
     const venueText = joinFieldSegments(venueMatch[1]);
 
-    const venue = stripPlaceholder(venueText);
+    // Strip placeholders (the "???" / "TBD" family) first, then run the
+    // residual through the shared cleaner to peel the dotted "T.B.A./T.B.C.",
+    // leading "Maybe," and trailing "Details/updates to follow" uncertainty
+    // qualifiers the kennel writes into the venue block (#1747). Postcode
+    // extraction runs on the cleaned venue so a trailing "…NR6 7NH, T.B.C."
+    // still yields the NR6 7NH map pin.
+    const venue = cleanLocationName(stripPlaceholder(venueText));
+    // The Venue: field was present, so propagate the cleaner's result
+    // verbatim — `null` (placeholder/CTA) becomes an explicit clear at merge
+    // rather than silently preserving a stale address (#1747).
+    result.location = venue;
     if (venue) {
-      result.location = venue;
-
       const postcode = extractUkPostcode(venue);
       if (postcode) {
         result.locationUrl = googleMapsSearchUrl(postcode);

--- a/src/adapters/html-scraper/sh3-au.test.ts
+++ b/src/adapters/html-scraper/sh3-au.test.ts
@@ -65,6 +65,19 @@ describe("sh3-au parseSh3Paragraph", () => {
     expect(e!.hares).toBe("Larrikins Joint Run 2500");
   });
 
+  // #1731 — blank Start: lets the non-greedy capture spill into the trailing
+  // "CLICK HERE FOR MAP" anchor; the Hares value must NOT become the location.
+  it("yields no location when Start: is blank, keeping the Hares value out of locationName (#1731)", () => {
+    const text =
+      "Run #3078Date: 9th June 2026 @ 6:30pm TUESDAYHares: Larrikins Joint Run 2500Special Tshirt – order here https://form.jotform.com/261247879266067Start: CLICK HERE FOR MAPOn On:";
+    const e = parseSh3Paragraph(text, URL, REF);
+    expect(e).not.toBeNull();
+    // Start: label present but blank → explicit clear (null), so a venue that
+    // disappears between scrapes wipes the stale canonical value (#1731).
+    expect(e!.location).toBeNull();
+    expect(e!.hares).toBe("Larrikins Joint Run 2500");
+  });
+
   it("strips bare http URL from hares without preceding keyword (#1644)", () => {
     const text =
       "Run #3079Date: 16th JuneHares: Dingo https://example.com/signupStart: TBA";

--- a/src/adapters/html-scraper/sh3-au.ts
+++ b/src/adapters/html-scraper/sh3-au.ts
@@ -1,6 +1,12 @@
 import type { Source } from "@/generated/prisma/client";
 import type { ErrorDetails, RawEventData, ScrapeResult, SourceAdapter } from "../types";
-import { applyDateWindow, chronoParseDate, fetchHTMLPage } from "../utils";
+import {
+  applyDateWindow,
+  chronoParseDate,
+  cleanLocationName,
+  fetchHTMLPage,
+  stripClickHereForMap,
+} from "../utils";
 
 /**
  * Sydney H3 ("Posh Hash") — sh3.link
@@ -64,39 +70,9 @@ function captureLabel(text: string, re: RegExp): string | undefined {
  *      swallowed the valid city/state suffix after the link.
  * The replacement uses anchor-text-only stripping with whitespace + dangling
  * separator cleanup so address detail downstream of the link survives.
+ * `stripClickHereForMap` is shared via `../utils` (also used by
+ * `cleanLocationName`) so the procedural sentinel stripper lives in one place.
  */
-/**
- * Strip every "CLICK HERE FOR MAP" anchor-text occurrence (case-
- * insensitive, arbitrary whitespace between tokens) from `s`. False
- * matches of the leading word "click" (e.g. "click to enlarge") advance
- * the search past the false hit instead of terminating the loop, so
- * later valid sentinels in the same string are still stripped. Gemini
- * caught the original break-on-false logic in PR #1702.
- */
-function stripClickHereForMap(s: string): string {
-  const TOKENS = ["click", "here", "for", "map"];
-  let out = s;
-  let startIdx = 0;
-  while (startIdx < out.length) {
-    const lower = out.toLowerCase();
-    const idx = lower.indexOf("click", startIdx);
-    if (idx < 0) break;
-    let pos = idx;
-    let matched = true;
-    for (const word of TOKENS) {
-      while (pos < lower.length && /\s/.test(lower[pos])) pos++;
-      if (lower.slice(pos, pos + word.length) !== word) { matched = false; break; }
-      pos += word.length;
-    }
-    if (matched) {
-      out = out.slice(0, idx) + out.slice(pos);
-      startIdx = idx;
-    } else {
-      startIdx = idx + 1;
-    }
-  }
-  return out;
-}
 
 function cleanStart(raw: string | undefined): string | undefined {
   if (!raw) return undefined;
@@ -197,7 +173,17 @@ export function parseSh3Paragraph(
   if (!date) return null;
 
   const hares = cleanHares(captureLabel(text, HARES_RE));
-  const start = cleanStart(captureLabel(text, START_RE));
+  // Run the captured Start: value through the shared location cleaner so a
+  // blank Start: (which lets the non-greedy capture spill into the trailing
+  // "CLICK HERE FOR MAP" / next-label text) resolves to no location instead
+  // of leaking anchor text or a sibling field's value (#1731). When the
+  // Start: label IS present but cleans to nothing, keep the cleaner's `null`
+  // so merge explicitly clears a stale value; only emit `undefined` (preserve)
+  // when the run has no Start: label at all.
+  const startLabelPresent = /Start\s*:/i.test(text);
+  const start = startLabelPresent
+    ? cleanLocationName(cleanStart(captureLabel(text, START_RE)))
+    : undefined;
   const onOn = captureLabel(text, ON_ON_RE);
 
   return {

--- a/src/adapters/html-scraper/true-trail-h3.test.ts
+++ b/src/adapters/html-scraper/true-trail-h3.test.ts
@@ -184,4 +184,36 @@ describe("TrueTrailH3Adapter", () => {
     const unique = new Set(runNumbers);
     expect(runNumbers.length).toBe(unique.size);
   });
+
+  it("does not store a placeholder 'Hares: Sexy Hares Needed' line as the venue (#1730)", async () => {
+    // Run #175 before a venue is announced: the only post-date paragraph is a
+    // placeholder Hares: line. It must never fall through to the venue slot.
+    const PLACEHOLDER_HTML = `
+<div class="wp-block-group">
+<h2 class="wp-block-heading"><strong>#1</strong>75 &#8211; Trailer Trash Hash</h2>
+<p class="">July 2, 2026</p>
+<p class="">Hares: Sexy Hares Needed</p>
+<p class="">More Detrails to Cum!</p>
+<p class="has-text-align-left">Pack Gathers: 6:30<br>Hash Cash: $8</p>
+</div>`;
+    const { fetchHTMLPage } = await import("../utils");
+    const cheerio = await import("cheerio");
+    vi.mocked(fetchHTMLPage).mockResolvedValue({
+      ok: true,
+      html: PLACEHOLDER_HTML,
+      $: cheerio.load(PLACEHOLDER_HTML),
+      structureHash: "test-hash",
+      fetchDurationMs: 100,
+    });
+
+    const { TrueTrailH3Adapter } = await import("./true-trail-h3");
+    const adapter = new TrueTrailH3Adapter();
+    const source = { id: "test", url: "https://truetrailh3.com/", scrapeDays: 365 } as Source;
+
+    const result = await adapter.fetch(source);
+    const ev = result.events.find((e) => e.runNumber === 175);
+    expect(ev).toBeDefined();
+    expect(ev!.location).toBeUndefined();
+    expect(ev!.hares).toBeUndefined();
+  });
 });

--- a/src/adapters/html-scraper/true-trail-h3.ts
+++ b/src/adapters/html-scraper/true-trail-h3.ts
@@ -1,6 +1,6 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ParseError } from "../types";
-import { fetchHTMLPage, decodeEntities, chronoParseDate, buildDateWindow, stripPlaceholder } from "../utils";
+import { fetchHTMLPage, decodeEntities, chronoParseDate, buildDateWindow, cleanLocationName, stripPlaceholder } from "../utils";
 
 const KENNEL_TAG = "tth3-ab";
 const DEFAULT_START_TIME = "18:30";
@@ -133,9 +133,15 @@ export class TrueTrailH3Adapter implements SourceAdapter {
           }
         }
 
-        // Hares
-        const h = extractHares(text);
-        if (h) { hares = h; continue; }
+        // Hares — a labeled "Hares:" line is always consumed here, even when
+        // the value is a placeholder ("Sexy Hares Needed" → undefined). Without
+        // this the placeholder line fell through to the venue branch below and
+        // was stored verbatim as the location (#1730).
+        if (/^Hares?\s*:/i.test(text)) {
+          const h = extractHares(text);
+          if (h) hares = h;
+          continue;
+        }
 
         // If we have a date but no venue yet, this is likely the venue name
         if (date && !venueName && !streetAddress) {
@@ -178,11 +184,18 @@ export class TrueTrailH3Adapter implements SourceAdapter {
       const eventDate = new Date(date + "T12:00:00Z");
       if (eventDate < minDate || eventDate > maxDate) continue;
 
-      // Build location
+      // Build location and run it through the shared cleaner as a final guard
+      // against any labeled/anchor/placeholder text that slipped into the
+      // venue-name slot (#1730). When a venue slot WAS captured but cleans to
+      // non-venue text, keep the cleaner's `null` so merge clears the stale
+      // value; `undefined` only when no venue paragraph was present at all.
       const locationParts: string[] = [];
       if (venueName) locationParts.push(venueName);
       if (streetAddress) locationParts.push(streetAddress);
-      const location = locationParts.length > 0 ? locationParts.join(", ") : undefined;
+      const location =
+        locationParts.length > 0
+          ? cleanLocationName(locationParts.join(", "))
+          : undefined;
 
       events.push({
         date,

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -21,6 +21,8 @@ import {
   hasPlaceholderRunNumber,
   extractHashRunNumber,
   normalizeCostSigil,
+  cleanLocationName,
+  stripClickHereForMap,
 } from "./utils";
 import { validateSourceUrlWithDns } from "./ssrf-dns";
 
@@ -1022,5 +1024,99 @@ describe("normalizeCostSigil (#1670)", () => {
       const twice = normalizeCostSigil(once);
       expect(twice).toBe(once);
     }
+  });
+});
+
+describe("stripClickHereForMap", () => {
+  it.each([
+    ["Pennant HillsCLICK HERE FOR MAP", "Pennant Hills", "no word boundary before sentinel (#1650)"],
+    [
+      "Pennant Hills CLICK HERE FOR MAP, Pennant Hills, NSW",
+      "Pennant Hills , Pennant Hills, NSW",
+      "address suffix after the link survives",
+    ],
+    ["click to enlarge then CLICK HERE FOR MAP", "click to enlarge then ", "false 'click' hit skipped"],
+    ["7 Joffre St", "7 Joffre St", "no sentinel unchanged"],
+  ])("'%s' → '%s' (%s)", (input, expected) => {
+    expect(stripClickHereForMap(input)).toBe(expected);
+  });
+});
+
+describe("cleanLocationName", () => {
+  describe("false-positive guards (must NOT over-strip)", () => {
+    it.each([
+      ["TBC Park", "TBC Park", "bare-word TBC prefix is a real venue, not a dotted qualifier"],
+      ["The (Old) Mill", "The (Old) Mill", "interior parens that aren't '(Link)' survive"],
+      [
+        "Start: 7 Joffre St, Brookvale",
+        "7 Joffre St, Brookvale",
+        "Start: is a location label — strip prefix, keep address",
+      ],
+      [
+        "Parking Elsenburgerbos (Lange Kleiweg), Rijswijk",
+        "Parking Elsenburgerbos (Lange Kleiweg), Rijswijk",
+        "no trailing (Link) — interior parens untouched",
+      ],
+      ["Clint Green, Yaxham", "Clint Green, Yaxham", "plain real venue passes through"],
+      ["Maybes Diner", "Maybes Diner", "'Maybe' must be a whole token, not a prefix of 'Maybes'"],
+    ])("'%s' → '%s' (%s)", (input, expected) => {
+      expect(cleanLocationName(input)).toBe(expected);
+    });
+  });
+
+  describe("strips recoverable noise", () => {
+    it.each([
+      [
+        "Parking Elsenburgerbos (Lange Kleiweg), Rijswijk (Link)",
+        "Parking Elsenburgerbos (Lange Kleiweg), Rijswijk",
+        "#1729 trailing (Link) anchor",
+      ],
+      [
+        "Carpark 87 Winbourne Rd, Brookvale CLICK HERE FOR MAP",
+        "Carpark 87 Winbourne Rd, Brookvale",
+        "#1731 inline CLICK HERE FOR MAP",
+      ],
+      [
+        "Maybe, The Maids Head, 85 Spixworth Road, Old Catton, Norwich, NR6 7NH, T.B.C",
+        "The Maids Head, 85 Spixworth Road, Old Catton, Norwich, NR6 7NH",
+        "#2148 leading Maybe, + trailing T.B.C",
+      ],
+      ["T.B.A. Maybe Worstead", "Worstead", "#2151 peels both dotted T.B.A. and 'Maybe'"],
+      [
+        "Clint Green, Yaxham T.B.C., updates to follow",
+        "Clint Green, Yaxham",
+        "#2152 trailing T.B.C. + 'updates to follow'",
+      ],
+      ["Drayton area, Details to follow", "Drayton area", "#2153 trailing 'Details to follow'"],
+      ["Haveringland area, Details to follow", "Haveringland area", "#2157 trailing phrase"],
+      ["Station Voorburg 👣 under the viaduct", "Station Voorburg under the viaduct", "emoji stripped"],
+    ])("'%s' → '%s' (%s)", (input, expected) => {
+      expect(cleanLocationName(input)).toBe(expected);
+    });
+  });
+
+  describe("rejects non-venue values (→ null)", () => {
+    it.each([
+      ["Hares: Sexy Hares Needed", "#1730 hare-solicitation captured as location"],
+      ["Hare(s): Woolly", "labeled hare field"],
+      ["Map: here", "map-link label"],
+      ["On On: Brookvale Hotel", "on-after label"],
+      ["T.B.A", "#2154 standalone dotted qualifier"],
+      ["T.B.C.", "standalone dotted qualifier with dot"],
+      ["Maybe", "standalone Maybe"],
+      ["Contact Le Caniveau to set this run.", "#1749 hare-contact CTA"],
+      ["Hare wanted", "hares-needed CTA"],
+      ["???", "question-mark placeholder"],
+      ["TBD", "placeholder"],
+      ["", "empty string"],
+      ["   ", "whitespace only"],
+    ])("'%s' → null (%s)", (input) => {
+      expect(cleanLocationName(input)).toBeNull();
+    });
+
+    it("returns null for null/undefined input", () => {
+      expect(cleanLocationName(null)).toBeNull();
+      expect(cleanLocationName(undefined)).toBeNull();
+    });
   });
 });

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -1087,6 +1087,11 @@ describe("cleanLocationName", () => {
         "Clint Green, Yaxham",
         "#2152 trailing T.B.C. + 'updates to follow'",
       ],
+      [
+        "Clint Green, Yaxham T.B.C. / updates to follow",
+        "Clint Green, Yaxham",
+        "#2152 slash separator before trailing phrase (Codex P2)",
+      ],
       ["Drayton area, Details to follow", "Drayton area", "#2153 trailing 'Details to follow'"],
       ["Haveringland area, Details to follow", "Haveringland area", "#2157 trailing phrase"],
       ["Station Voorburg 👣 under the viaduct", "Station Voorburg under the viaduct", "emoji stripped"],

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -909,16 +909,59 @@ export function stripClickHereForMap(s: string): string {
 const NON_LOCATION_LABEL_RE = /^(?:hares?|hare\(s\)|on[\s-]?on|map)\s*:/i;
 const START_LABEL_RE = /^start\s*:\s*/i;
 
-// Trailing map-anchor text: "(Link)" or a bare " Link" suffix (#1729 Hague).
-const TRAILING_PAREN_LINK_RE = /\s*\(\s*link\s*\)\s*$/i;
-const TRAILING_BARE_LINK_RE = /\s+link\s*$/i;
+// Segment-separator characters. Includes "/" because Norfolk venue blocks use
+// " / " between the address and a trailing "updates to follow" / "T.B.C."
+// marker (#1747 / Codex P2) — without it the slash blocks further stripping.
+const LOCATION_SEPARATOR_CHARS = new Set([",", "/", " ", "\t", "\n", "\r", "\f", "\v"]);
+
+/** True when `ch` is a segment boundary for qualifier stripping (edge/separator). */
+function isQualifierBoundary(ch: string | undefined): boolean {
+  return ch === undefined || LOCATION_SEPARATOR_CHARS.has(ch);
+}
+
+/** Trim leading + trailing separator chars (",", "/", whitespace) procedurally. */
+function trimLocationSeparators(s: string): string {
+  let start = 0;
+  let end = s.length;
+  while (start < end && LOCATION_SEPARATOR_CHARS.has(s[start])) start++;
+  while (end > start && LOCATION_SEPARATOR_CHARS.has(s[end - 1])) end--;
+  return s.slice(start, end);
+}
+
+/** Trim trailing whitespace only (single-char check — no quantified regex). */
+function trimTrailingWhitespace(s: string): string {
+  let end = s.length;
+  while (end > 0 && /\s/.test(s[end - 1])) end--;
+  return s.slice(0, end);
+}
+
+/**
+ * Strip a trailing Google-Maps "(Link)" or bare " Link" anchor (#1729 / #1258).
+ * Procedural rather than a `\s*\(\s*link\s*\)\s*$` regex, which Sonar S5852
+ * flags as ReDoS-prone (memory `feedback_sonar_s5852_procedural_over_regex`).
+ */
+function stripTrailingLinkAnchor(input: string): string {
+  let s = trimTrailingWhitespace(input);
+  const lower = s.toLowerCase();
+  if (lower.endsWith("(link)")) {
+    s = s.slice(0, -"(link)".length);
+  } else if (
+    lower.endsWith("link") &&
+    (s.length === 4 || /\s/.test(s[s.length - 5]))
+  ) {
+    // Bare trailing "Link" only when it's a standalone word (preceded by
+    // whitespace or at the start) — "Funlink" / "uplink" survive.
+    s = s.slice(0, -"link".length);
+  }
+  return trimTrailingWhitespace(s);
+}
 
 // Uncertainty qualifiers the kennels write to flag "not finalized" — dotted
 // "T.B.A/B/C/D" forms plus a leading "Maybe" and trailing "… to follow"
 // phrases (#1747 Norfolk). Matched as whole tokens (must be bounded by a
-// space, comma, or string edge) so a bare-word venue like "TBC Park" or a
-// venue literally named "…Maybes…" is never bitten. Stripped procedurally to
-// keep Sonar S5843/S5852 happy (no `\s*`-adjacent-to-alternation).
+// separator or string edge) so a bare-word venue like "TBC Park" or a venue
+// literally named "…Maybes…" is never bitten. Stripped procedurally to keep
+// Sonar S5843/S5852 happy (no `\s*`-adjacent-to-alternation).
 const LOCATION_QUALIFIER_TOKENS = [
   "t.b.a.",
   "t.b.c.",
@@ -930,11 +973,6 @@ const LOCATION_QUALIFIER_TOKENS = [
 ];
 const LOCATION_TRAILING_PHRASES = ["details to follow", "updates to follow"];
 
-/** True when `ch` is a token boundary for qualifier stripping (edge/space/comma). */
-function isQualifierBoundary(ch: string | undefined): boolean {
-  return ch === undefined || ch === " " || ch === ",";
-}
-
 function stripLeadingQualifiers(input: string): string {
   let s = input;
   let changed = true;
@@ -943,7 +981,7 @@ function stripLeadingQualifiers(input: string): string {
     const lower = s.toLowerCase();
     for (const tok of LOCATION_QUALIFIER_TOKENS) {
       if (lower.startsWith(tok) && isQualifierBoundary(s[tok.length])) {
-        s = s.slice(tok.length).replace(/^[,\s]+/, "");
+        s = trimLocationSeparators(s.slice(tok.length));
         changed = true;
         break;
       }
@@ -961,7 +999,7 @@ function stripTrailingQualifiers(input: string): string {
     const tryStrip = (frag: string): boolean => {
       if (!lower.endsWith(frag)) return false;
       if (!isQualifierBoundary(s[s.length - frag.length - 1])) return false;
-      s = s.slice(0, s.length - frag.length).replace(/[,\s]+$/, "");
+      s = trimLocationSeparators(s.slice(0, s.length - frag.length));
       return true;
     };
     for (const phrase of LOCATION_TRAILING_PHRASES) {
@@ -1020,16 +1058,15 @@ export function cleanLocationName(raw: string | null | undefined): string | null
   s = stripClickHereForMap(s);
   s = stripUrls(s);
   s = s.replace(EMOJI_RE, "");
-  s = s.replace(TRAILING_PAREN_LINK_RE, "").replace(TRAILING_BARE_LINK_RE, "").trim();
+  s = stripTrailingLinkAnchor(s);
 
   // 4. Peel leading/trailing uncertainty qualifiers (dotted T.B.x / Maybe /
   //    "… to follow"). Bare-word prefixes ("TBC Park") are preserved.
   s = stripLeadingQualifiers(s);
   s = stripTrailingQualifiers(s);
 
-  // 5. Tidy separators + collapse internal whitespace.
-  s = s.replace(/\s{2,}/g, " ").trim();
-  s = s.replace(/^[,\s]+/, "").replace(/[,\s]+$/, "").trim();
+  // 5. Collapse internal whitespace + trim dangling separators.
+  s = trimLocationSeparators(s.replace(/\s{2,}/g, " "));
 
   // 6. Reject pure placeholder / CTA residuals.
   if (!s) return null;

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -849,6 +849,198 @@ export function stripPlaceholder(value: string | undefined | null): string | und
   return trimmed;
 }
 
+// ---------------------------------------------------------------------------
+// Location name cleaning — shared post-processor for HTML scrapers
+// (#1729 #1730 #1731 #1747 #1749). Adapters keep leaking non-venue text into
+// the location field: map-anchor text ("(Link)", "CLICK HERE FOR MAP"),
+// labeled-field values ("Hares: …"), uncertainty qualifiers ("T.B.A.",
+// "Maybe,", "Details to follow"), and hare-contact CTA copy ("Contact X to
+// set this run"). `cleanLocationName` strips the recoverable noise and
+// rejects (→ null) anything that isn't a real venue, composing the existing
+// placeholder/CTA infrastructure above.
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip every "CLICK HERE FOR MAP" anchor-text occurrence (case-insensitive,
+ * arbitrary whitespace between tokens) from `s`. False matches of the leading
+ * word "click" (e.g. "click to enlarge") advance the search past the false hit
+ * instead of terminating the loop, so later valid sentinels in the same string
+ * are still stripped (Gemini caught the original break-on-false logic in
+ * PR #1702). Implemented procedurally rather than with a `CLICK\s*HERE\s*FOR\s*MAP`
+ * regex — the per-token `\s*` runs trip Sonar S5852's ReDoS heuristic even
+ * though they're linear (memory `feedback_sonar_s5852_procedural_over_regex`).
+ */
+export function stripClickHereForMap(s: string): string {
+  const TOKENS = ["click", "here", "for", "map"];
+  let out = s;
+  // `lower` mirrors `out` and is only recomputed when `out` is mutated, not on
+  // every loop pass (non-match advances leave `out` unchanged).
+  let lower = out.toLowerCase();
+  let startIdx = 0;
+  while (startIdx < out.length) {
+    const idx = lower.indexOf("click", startIdx);
+    if (idx < 0) break;
+    let pos = idx;
+    let matched = true;
+    for (const word of TOKENS) {
+      while (pos < lower.length && /\s/.test(lower[pos])) pos++;
+      if (lower.slice(pos, pos + word.length) !== word) {
+        matched = false;
+        break;
+      }
+      pos += word.length;
+    }
+    if (matched) {
+      out = out.slice(0, idx) + out.slice(pos);
+      lower = out.toLowerCase();
+      startIdx = idx;
+    } else {
+      startIdx = idx + 1;
+    }
+  }
+  return out;
+}
+
+// Field labels that are NOT a location — a value that is entirely
+// "<label>: …" for one of these is rejected outright (#1730 "Hares: Sexy
+// Hares Needed", #1731 "Hares: …" captured when Start: was blank). "Start:"
+// is intentionally absent: it IS a location label, so its prefix is stripped
+// and the address kept (see cleanLocationName step 2).
+const NON_LOCATION_LABEL_RE = /^(?:hares?|hare\(s\)|on[\s-]?on|map)\s*:/i;
+const START_LABEL_RE = /^start\s*:\s*/i;
+
+// Trailing map-anchor text: "(Link)" or a bare " Link" suffix (#1729 Hague).
+const TRAILING_PAREN_LINK_RE = /\s*\(\s*link\s*\)\s*$/i;
+const TRAILING_BARE_LINK_RE = /\s+link\s*$/i;
+
+// Uncertainty qualifiers the kennels write to flag "not finalized" — dotted
+// "T.B.A/B/C/D" forms plus a leading "Maybe" and trailing "… to follow"
+// phrases (#1747 Norfolk). Matched as whole tokens (must be bounded by a
+// space, comma, or string edge) so a bare-word venue like "TBC Park" or a
+// venue literally named "…Maybes…" is never bitten. Stripped procedurally to
+// keep Sonar S5843/S5852 happy (no `\s*`-adjacent-to-alternation).
+const LOCATION_QUALIFIER_TOKENS = [
+  "t.b.a.",
+  "t.b.c.",
+  "t.b.d.",
+  "t.b.a",
+  "t.b.c",
+  "t.b.d",
+  "maybe",
+];
+const LOCATION_TRAILING_PHRASES = ["details to follow", "updates to follow"];
+
+/** True when `ch` is a token boundary for qualifier stripping (edge/space/comma). */
+function isQualifierBoundary(ch: string | undefined): boolean {
+  return ch === undefined || ch === " " || ch === ",";
+}
+
+function stripLeadingQualifiers(input: string): string {
+  let s = input;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const lower = s.toLowerCase();
+    for (const tok of LOCATION_QUALIFIER_TOKENS) {
+      if (lower.startsWith(tok) && isQualifierBoundary(s[tok.length])) {
+        s = s.slice(tok.length).replace(/^[,\s]+/, "");
+        changed = true;
+        break;
+      }
+    }
+  }
+  return s;
+}
+
+function stripTrailingQualifiers(input: string): string {
+  let s = input;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const lower = s.toLowerCase();
+    const tryStrip = (frag: string): boolean => {
+      if (!lower.endsWith(frag)) return false;
+      if (!isQualifierBoundary(s[s.length - frag.length - 1])) return false;
+      s = s.slice(0, s.length - frag.length).replace(/[,\s]+$/, "");
+      return true;
+    };
+    for (const phrase of LOCATION_TRAILING_PHRASES) {
+      if (tryStrip(phrase)) {
+        changed = true;
+        break;
+      }
+    }
+    if (changed) continue;
+    for (const tok of LOCATION_QUALIFIER_TOKENS) {
+      if (tok === "maybe") continue; // trailing "maybe" is not a marker
+      if (tryStrip(tok)) {
+        changed = true;
+        break;
+      }
+    }
+  }
+  return s;
+}
+
+/** The hare-contact CTA Bristol GREY emits when no hare has signed up (#1749). */
+function isContactToSetRunCta(lower: string): boolean {
+  return lower.startsWith("contact ") && lower.includes(" to set this run");
+}
+
+/**
+ * Clean a raw scraped location string into a real venue name, or return
+ * `null` when the value is not a location at all.
+ *
+ * IMPORTANT — preserve the `null`. The merge pipeline is tri-state on
+ * `location`: `undefined` = preserve existing, `null` = explicit clear, value
+ * = overwrite (merge.ts WS6 #1516). When the SOURCE PROVIDED a location field
+ * but it cleans to non-venue text (e.g. a venue that changed to "T.B.A." or a
+ * hare-contact CTA), the adapter must emit `location: null` so the stale
+ * canonical value is cleared — NOT `?? undefined`, which would silently
+ * preserve the old address forever. Only fall back to `undefined` when the
+ * source had no location field at all.
+ *
+ * Order matters: reject non-location labels first, then strip anchor/URL/emoji
+ * noise, then peel uncertainty qualifiers, then reject pure placeholder/CTA
+ * residuals. The rules are deliberately conservative and global (no per-kennel
+ * tuning) — the dotted "T.B.x" markers are universal hash phrasing.
+ */
+export function cleanLocationName(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  let s = raw.trim();
+  if (!s) return null;
+
+  // 1. Reject whole-value non-location labeled fields ("Hares: …", "Map: …").
+  if (NON_LOCATION_LABEL_RE.test(s)) return null;
+
+  // 2. "Start:" is a location label — drop the prefix, keep the address.
+  s = s.replace(START_LABEL_RE, "").trim();
+
+  // 3. Strip map-anchor text, URLs, and emoji.
+  s = stripClickHereForMap(s);
+  s = stripUrls(s);
+  s = s.replace(EMOJI_RE, "");
+  s = s.replace(TRAILING_PAREN_LINK_RE, "").replace(TRAILING_BARE_LINK_RE, "").trim();
+
+  // 4. Peel leading/trailing uncertainty qualifiers (dotted T.B.x / Maybe /
+  //    "… to follow"). Bare-word prefixes ("TBC Park") are preserved.
+  s = stripLeadingQualifiers(s);
+  s = stripTrailingQualifiers(s);
+
+  // 5. Tidy separators + collapse internal whitespace.
+  s = s.replace(/\s{2,}/g, " ").trim();
+  s = s.replace(/^[,\s]+/, "").replace(/[,\s]+$/, "").trim();
+
+  // 6. Reject pure placeholder / CTA residuals.
+  if (!s) return null;
+  if (isPlaceholder(s)) return null;
+  const lower = s.toLowerCase();
+  if (isContactToSetRunCta(lower)) return null;
+  if (CTA_EMBEDDED_PATTERNS.some((re) => re.test(s))) return null;
+
+  return s;
+}
+
 /**
  * Walk a chronologically-sorted run list and bump a date's year forward
  * until it strictly exceeds the previous row's date. Used when the source

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -947,7 +947,7 @@ function stripTrailingLinkAnchor(input: string): string {
     s = s.slice(0, -"(link)".length);
   } else if (
     lower.endsWith("link") &&
-    (s.length === 4 || /\s/.test(s[s.length - 5]))
+    (s.length === 4 || /\s/.test(s.at(-5) ?? ""))
   ) {
     // Bare trailing "Link" only when it's a standalone word (preceded by
     // whitespace or at the start) — "Funlink" / "uplink" survive.
@@ -972,6 +972,12 @@ const LOCATION_QUALIFIER_TOKENS = [
   "maybe",
 ];
 const LOCATION_TRAILING_PHRASES = ["details to follow", "updates to follow"];
+// Trailing-strip order: multi-word phrases first, then dotted markers. "maybe"
+// is excluded — a trailing "Maybe" is not an uncertainty marker.
+const LOCATION_TRAILING_FRAGMENTS = [
+  ...LOCATION_TRAILING_PHRASES,
+  ...LOCATION_QUALIFIER_TOKENS.filter((t) => t !== "maybe"),
+];
 
 function stripLeadingQualifiers(input: string): string {
   let s = input;
@@ -996,22 +1002,9 @@ function stripTrailingQualifiers(input: string): string {
   while (changed) {
     changed = false;
     const lower = s.toLowerCase();
-    const tryStrip = (frag: string): boolean => {
-      if (!lower.endsWith(frag)) return false;
-      if (!isQualifierBoundary(s[s.length - frag.length - 1])) return false;
-      s = trimLocationSeparators(s.slice(0, s.length - frag.length));
-      return true;
-    };
-    for (const phrase of LOCATION_TRAILING_PHRASES) {
-      if (tryStrip(phrase)) {
-        changed = true;
-        break;
-      }
-    }
-    if (changed) continue;
-    for (const tok of LOCATION_QUALIFIER_TOKENS) {
-      if (tok === "maybe") continue; // trailing "maybe" is not a marker
-      if (tryStrip(tok)) {
+    for (const frag of LOCATION_TRAILING_FRAGMENTS) {
+      if (lower.endsWith(frag) && isQualifierBoundary(s[s.length - frag.length - 1])) {
+        s = trimLocationSeparators(s.slice(0, s.length - frag.length));
         changed = true;
         break;
       }


### PR DESCRIPTION
## Summary

Five audit issues share one root cause: HTML scrapers persist non-venue text in `locationName` instead of stripping or rejecting it, breaking geocoding and surfacing editorial junk on event cards/maps. This adds a shared `cleanLocationName()` helper (`src/adapters/utils.ts`) that composes the existing placeholder/CTA infrastructure and handles four noise classes, then wires it into the affected adapters. Paired with the long-deferred GREY follow-up (#1217).

### Noise classes handled
| Class | Example | Issue |
|---|---|---|
| Map-anchor text | `… Rijswijk (Link)`, `… CLICK HERE FOR MAP` | #1729 #1731 |
| Labeled-field leakage | `Hares: Sexy Hares Needed` rejected; `Start: <addr>` keeps the address | #1730 #1731 |
| Uncertainty qualifiers | `T.B.A.`, leading `Maybe,`, trailing `Details/updates to follow` | #1747 |
| Hare-contact CTA | `Contact Le Caniveau to set this run` | #1749 |

### Tri-state correctness (Codex adversarial-review catch)
`cleanLocationName` returns `string | null`. Where the **source provided** a location field but it cleans to non-venue text, the adapters now propagate that `null` as an **explicit-clear** signal into the merge tri-state (`undefined` = preserve, `null` = clear, value = overwrite — the WS6 #1516 pattern). Coercing to `?? undefined` would have silently preserved the stale address forever on a venue→placeholder transition. Adapters emit `undefined` only when the source had no location field at all.

### Adapters wired
- **hague-h3** — replaces the inline Link/URL/emoji chain.
- **true-trail-h3** — also fixes a placeholder-`Hares:` line falling through to the venue slot (#1730).
- **sh3-au** — lifts the local `stripClickHereForMap` into the shared helper.
- **norfolk-h3** — `ParsedNorfolkRun.location` now `string | null`.
- **generic.ts** — *unchanged*: its config-driven `locationOmitIfMatches` already nulls GREY's CTA at scrape time. #1749/#1217 are stale-data cases.

### Stale-data cleanup
`scripts/cleanup-locationname-systemic.ts` (dry-run by default, `--apply` to commit) clears canonical `Event.locationName` ghosts the merge tri-state would otherwise preserve, nulls the sh3-au #3078 hares-value leak, and rewrites stale `GREY Trail` → `Bristol Greyhound H3 Trail` titles via the canonical `rewriteStaleDefaultTitle` helper (#1217 / #1184 — `GREY` is already an alias, so no seed/code change needed). **Run post-merge against prod** after the re-scrape (`DATABASE_URL` required).

## Live verification (per .claude/rules/live-verification.md)
Ran each fixed adapter against its live source:
- **Hague** → `Parking Elsenburgerbos (Lange Kleiweg), Rijswijk` — no `(Link)`, interior parens kept ✓
- **TTH3 #175** → `location` undefined, hares `Cums in Spurts` ✓
- **Sydney #3078** → `location` undefined, hares `Larrikins Joint Run 2500` ✓
- **Norfolk** → all 6 cleaned (#2148 `The Maids Head, … NR6 7NH`, #2151 `Worstead`, #2154 null); `???` runs still null ✓
- **GREY** → all upcoming events null location ✓

## Tests
`cleanLocationName` table with ≥5 false-positive guards (`TBC Park`, `The (Old) Mill`, `Start: 7 Joffre St`, interior parens, `Maybes Diner`) + reject cases; per-adapter affected-run fixtures; existing placeholder-venue tests updated to assert the explicit-clear `null`. `npm run lint && npx tsc --noEmit && npm test` (7745 passed) green. `/codex:adversarial-review` (1 finding, fixed) and `/simplify` run before opening.

Closes #1729
Closes #1730
Closes #1731
Closes #1747
Closes #1749
Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)