### PR TITLE
feat(admin): umbrella link/unlink + kennel re-attribution maintenance flows

### DIFF
--- a/src/app/admin/events/actions.test.ts
+++ b/src/app/admin/events/actions.test.ts
@@ -614,20 +614,20 @@ describe("linkChildToUmbrella", () => {
   it("returns error when child not found", async () => {
     mockEventFindUnique.mockResolvedValueOnce(null as never); // child
     mockEventFindUnique.mockResolvedValueOnce(umbrella as never); // umbrella
-    expect(await linkChildToUmbrella("c1", "u1")).toEqual({ error: "Child event not found" });
+    expect(await linkChildToUmbrella("c1", "u1")).toEqual({ error: "Event not found" });
   });
 
   it("returns error when umbrella not found", async () => {
     mockEventFindUnique.mockResolvedValueOnce(child as never);
     mockEventFindUnique.mockResolvedValueOnce(null as never);
-    expect(await linkChildToUmbrella("c1", "u1")).toEqual({ error: "Umbrella event not found" });
+    expect(await linkChildToUmbrella("c1", "u1")).toEqual({ error: "Series parent not found" });
   });
 
   it("rejects when the umbrella is itself a child", async () => {
     mockEventFindUnique.mockResolvedValueOnce(child as never);
     mockEventFindUnique.mockResolvedValueOnce({ ...umbrella, parentEventId: "grandparent" } as never);
     expect(await linkChildToUmbrella("c1", "u1")).toEqual({
-      error: "Umbrella is itself a child of another event",
+      error: "That event is itself part of another series",
     });
   });
 
@@ -636,7 +636,7 @@ describe("linkChildToUmbrella", () => {
     mockEventFindUnique.mockResolvedValueOnce(umbrella as never);
     const result = await linkChildToUmbrella("c1", "u1");
     expect(result).toEqual({
-      error: "This event is a series parent — detach its children before attaching it",
+      error: "This event is already a series parent — remove its days first",
     });
   });
 
@@ -653,7 +653,7 @@ describe("linkChildToUmbrella", () => {
     mockEventFindUnique.mockResolvedValueOnce(umbrella as never);
     const result = await linkChildToUmbrella("c1", "u1");
     expect(result).toEqual({
-      error: "Event is already linked to a different umbrella — unlink it first",
+      error: "Event is already in a different series — remove it from that one first",
     });
     expect(mockEventUpdate).not.toHaveBeenCalled();
   });
@@ -730,7 +730,7 @@ describe("unlinkChildFromUmbrella", () => {
   it("returns error when event is not linked", async () => {
     mockEventFindUnique.mockResolvedValueOnce({ ...linkedChild, parentEventId: null } as never);
     expect(await unlinkChildFromUmbrella("c1")).toEqual({
-      error: "Event is not linked to an umbrella",
+      error: "Event isn't part of a series",
     });
   });
 

--- a/src/app/admin/events/actions.test.ts
+++ b/src/app/admin/events/actions.test.ts
@@ -21,6 +21,15 @@ vi.mock("@/lib/db", () => {
     eventHare: { deleteMany: vi.fn() },
     attendance: { deleteMany: vi.fn() },
     kennelAttendance: { deleteMany: vi.fn() },
+    kennel: { findUnique: vi.fn() },
+    eventKennel: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+    },
     $executeRaw: vi.fn().mockResolvedValue(1),
     // $transaction supports both forms:
     //   - array: deleteEventsCascade pattern
@@ -52,6 +61,12 @@ import {
   deleteSelectedEvents,
   uncancelEvent,
   adminCancelEvent,
+  linkChildToUmbrella,
+  unlinkChildFromUmbrella,
+  searchEventsForUmbrella,
+  reattributeEventKennel,
+  addCoHostKennel,
+  removeCoHostKennel,
 } from "./actions";
 
 const mockAdminAuth = vi.mocked(getAdminUser);
@@ -59,6 +74,11 @@ const mockEventFindUnique = vi.mocked(prisma.event.findUnique);
 const mockEventFindMany = vi.mocked(prisma.event.findMany);
 const mockEventCount = vi.mocked(prisma.event.count);
 const mockEventUpdate = vi.mocked(prisma.event.update);
+const mockKennelFindUnique = vi.mocked(prisma.kennel.findUnique);
+const mockEkCreate = vi.mocked(prisma.eventKennel.create);
+const mockEkUpdate = vi.mocked(prisma.eventKennel.update);
+const mockEkDelete = vi.mocked(prisma.eventKennel.delete);
+const mockEkDeleteMany = vi.mocked(prisma.eventKennel.deleteMany);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -567,5 +587,408 @@ describe("uncancelEvent — extended for admin override", () => {
     };
     expect(updateArg.data.adminAuditLog).toHaveLength(3);
     expect(updateArg.data.adminAuditLog[2].action).toBe("uncancel");
+  });
+});
+
+describe("linkChildToUmbrella", () => {
+  const child = {
+    parentEventId: null,
+    isSeriesParent: false,
+    date: new Date("2026-06-07T12:00:00Z"),
+    adminAuditLog: null,
+    kennel: { shortName: "NYCH3", slug: "nych3" },
+  };
+  const umbrella = { parentEventId: null, isSeriesParent: false };
+
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await linkChildToUmbrella("c1", "u1")).toEqual({ error: "Not authorized" });
+  });
+
+  it("rejects linking an event to itself", async () => {
+    expect(await linkChildToUmbrella("e1", "e1")).toEqual({
+      error: "Cannot link an event to itself",
+    });
+  });
+
+  it("returns error when child not found", async () => {
+    mockEventFindUnique.mockResolvedValueOnce(null as never); // child
+    mockEventFindUnique.mockResolvedValueOnce(umbrella as never); // umbrella
+    expect(await linkChildToUmbrella("c1", "u1")).toEqual({ error: "Child event not found" });
+  });
+
+  it("returns error when umbrella not found", async () => {
+    mockEventFindUnique.mockResolvedValueOnce(child as never);
+    mockEventFindUnique.mockResolvedValueOnce(null as never);
+    expect(await linkChildToUmbrella("c1", "u1")).toEqual({ error: "Umbrella event not found" });
+  });
+
+  it("rejects when the umbrella is itself a child", async () => {
+    mockEventFindUnique.mockResolvedValueOnce(child as never);
+    mockEventFindUnique.mockResolvedValueOnce({ ...umbrella, parentEventId: "grandparent" } as never);
+    expect(await linkChildToUmbrella("c1", "u1")).toEqual({
+      error: "Umbrella is itself a child of another event",
+    });
+  });
+
+  it("rejects attaching a series parent as a child", async () => {
+    mockEventFindUnique.mockResolvedValueOnce({ ...child, isSeriesParent: true } as never);
+    mockEventFindUnique.mockResolvedValueOnce(umbrella as never);
+    const result = await linkChildToUmbrella("c1", "u1");
+    expect(result).toEqual({
+      error: "This event is a series parent — detach its children before attaching it",
+    });
+  });
+
+  it("is idempotent when already linked to this umbrella", async () => {
+    mockEventFindUnique.mockResolvedValueOnce({ ...child, parentEventId: "u1" } as never);
+    mockEventFindUnique.mockResolvedValueOnce(umbrella as never);
+    const result = await linkChildToUmbrella("c1", "u1");
+    expect(result).toMatchObject({ success: true, kennelName: "NYCH3" });
+    expect(mockEventUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects relinking a child already under a different umbrella", async () => {
+    mockEventFindUnique.mockResolvedValueOnce({ ...child, parentEventId: "other" } as never);
+    mockEventFindUnique.mockResolvedValueOnce(umbrella as never);
+    const result = await linkChildToUmbrella("c1", "u1");
+    expect(result).toEqual({
+      error: "Event is already linked to a different umbrella — unlink it first",
+    });
+    expect(mockEventUpdate).not.toHaveBeenCalled();
+  });
+
+  it("links child, promotes umbrella, and extends endDate to cover the child", async () => {
+    mockEventFindUnique.mockResolvedValueOnce(child as never); // child guard
+    mockEventFindUnique.mockResolvedValueOnce(umbrella as never); // umbrella guard
+    // syncUmbrellaEndDate re-reads the umbrella + its children:
+    mockEventFindUnique.mockResolvedValueOnce({ date: new Date("2026-06-05T12:00:00Z") } as never);
+    mockEventFindMany.mockResolvedValueOnce([{ date: new Date("2026-06-07T12:00:00Z") }] as never);
+    mockEventUpdate.mockResolvedValue({} as never);
+
+    const result = await linkChildToUmbrella("c1", "u1");
+    expect(result).toMatchObject({ success: true, kennelName: "NYCH3" });
+
+    const childUpdate = mockEventUpdate.mock.calls[0][0] as unknown as {
+      where: { id: string };
+      data: { parentEventId: string; adminAuditLog: Array<{ action: string; changes?: { parentEventId?: { old: unknown; new: unknown } } }> };
+    };
+    expect(childUpdate.where).toEqual({ id: "c1" });
+    expect(childUpdate.data.parentEventId).toBe("u1");
+    expect(childUpdate.data.adminAuditLog[0].action).toBe("link_series");
+    expect(childUpdate.data.adminAuditLog[0].changes?.parentEventId).toEqual({ old: null, new: "u1" });
+
+    // Second update promotes the umbrella.
+    expect(mockEventUpdate.mock.calls[1][0]).toEqual({
+      where: { id: "u1" },
+      data: { isSeriesParent: true },
+    });
+
+    // Third update (syncUmbrellaEndDate) extends the range to the child's date.
+    expect(mockEventUpdate.mock.calls[2][0]).toEqual({
+      where: { id: "u1" },
+      data: { endDate: new Date("2026-06-07T12:00:00Z") },
+    });
+  });
+
+  it("does not re-promote an umbrella that is already a series parent", async () => {
+    mockEventFindUnique.mockResolvedValueOnce(child as never); // child guard
+    mockEventFindUnique.mockResolvedValueOnce({ ...umbrella, isSeriesParent: true } as never); // umbrella guard
+    mockEventFindUnique.mockResolvedValueOnce({ date: new Date("2026-06-05T12:00:00Z") } as never); // sync read
+    mockEventFindMany.mockResolvedValueOnce([{ date: new Date("2026-06-07T12:00:00Z") }] as never);
+    mockEventUpdate.mockResolvedValue({} as never);
+
+    await linkChildToUmbrella("c1", "u1");
+
+    // child update + endDate sync, but NO isSeriesParent promotion update.
+    expect(mockEventUpdate).toHaveBeenCalledTimes(2);
+    const setsIsSeriesParent = mockEventUpdate.mock.calls.some(
+      (c) => (c[0] as { data?: { isSeriesParent?: boolean } }).data?.isSeriesParent === true,
+    );
+    expect(setsIsSeriesParent).toBe(false);
+  });
+});
+
+describe("unlinkChildFromUmbrella", () => {
+  const linkedChild = {
+    parentEventId: "u1",
+    date: new Date("2026-06-07T12:00:00Z"),
+    adminAuditLog: null,
+    kennel: { shortName: "NYCH3", slug: "nych3" },
+  };
+
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await unlinkChildFromUmbrella("c1")).toEqual({ error: "Not authorized" });
+  });
+
+  it("returns error when event not found", async () => {
+    mockEventFindUnique.mockResolvedValueOnce(null);
+    expect(await unlinkChildFromUmbrella("c1")).toEqual({ error: "Event not found" });
+  });
+
+  it("returns error when event is not linked", async () => {
+    mockEventFindUnique.mockResolvedValueOnce({ ...linkedChild, parentEventId: null } as never);
+    expect(await unlinkChildFromUmbrella("c1")).toEqual({
+      error: "Event is not linked to an umbrella",
+    });
+  });
+
+  it("clears parentEventId, appends an unlink_series audit entry, and resyncs the umbrella range", async () => {
+    mockEventFindUnique.mockResolvedValueOnce(linkedChild as never); // child guard
+    // syncUmbrellaEndDate re-reads the old umbrella + its remaining children:
+    mockEventFindUnique.mockResolvedValueOnce({ date: new Date("2026-06-05T12:00:00Z") } as never);
+    mockEventFindMany.mockResolvedValueOnce([] as never); // no children left
+    mockEventUpdate.mockResolvedValue({} as never);
+
+    const result = await unlinkChildFromUmbrella("c1");
+    expect(result).toMatchObject({ success: true, kennelName: "NYCH3" });
+
+    const updateArg = mockEventUpdate.mock.calls[0][0] as unknown as {
+      data: { parentEventId: null; adminAuditLog: Array<{ action: string; changes?: { parentEventId?: { old: unknown; new: unknown } } }> };
+    };
+    expect(updateArg.data.parentEventId).toBeNull();
+    expect(updateArg.data.adminAuditLog[0].action).toBe("unlink_series");
+    expect(updateArg.data.adminAuditLog[0].changes?.parentEventId).toEqual({ old: "u1", new: null });
+
+    // With no children left, the umbrella's endDate is cleared.
+    expect(mockEventUpdate.mock.calls[1][0]).toEqual({
+      where: { id: "u1" },
+      data: { endDate: null },
+    });
+  });
+});
+
+describe("searchEventsForUmbrella", () => {
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await searchEventsForUmbrella("five")).toEqual({ error: "Not authorized" });
+  });
+
+  it("returns empty list for short queries without querying", async () => {
+    const result = await searchEventsForUmbrella(" a ");
+    expect(result).toEqual({ success: true, events: [] });
+    expect(mockEventFindMany).not.toHaveBeenCalled();
+  });
+
+  it("maps matched events", async () => {
+    mockEventFindMany.mockResolvedValueOnce([
+      {
+        id: "u1",
+        date: new Date("2026-06-05T12:00:00Z"),
+        title: "5-Boro Campout",
+        isSeriesParent: true,
+        kennel: { shortName: "NYCH3" },
+      },
+    ] as never);
+
+    const result = await searchEventsForUmbrella("5-Boro", "c1");
+    expect(result).toEqual({
+      success: true,
+      events: [
+        {
+          id: "u1",
+          date: "2026-06-05T12:00:00.000Z",
+          kennelName: "NYCH3",
+          title: "5-Boro Campout",
+          isSeriesParent: true,
+        },
+      ],
+    });
+  });
+});
+
+describe("reattributeEventKennel", () => {
+  const newKennel = { id: "knl_new", shortName: "BRH3", slug: "brh3" };
+  const eventBase = {
+    kennelId: "knl_old",
+    date: new Date("2026-06-06T12:00:00Z"),
+    adminAuditLog: null,
+    kennel: { kennelCode: "nych3", shortName: "NYCH3", slug: "nych3" },
+    eventKennels: [{ kennelId: "knl_old" }],
+  };
+
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await reattributeEventKennel("e1", "brh3")).toEqual({ error: "Not authorized" });
+  });
+
+  it("returns error when target kennel not found", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(null);
+    expect(await reattributeEventKennel("e1", "ghost")).toEqual({
+      error: "Kennel not found: ghost",
+    });
+  });
+
+  it("returns error when event not found", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(newKennel as never);
+    mockEventFindUnique.mockResolvedValueOnce(null);
+    expect(await reattributeEventKennel("e1", "brh3")).toEqual({ error: "Event not found" });
+  });
+
+  it("returns error when event already attributed to that kennel", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(newKennel as never);
+    mockEventFindUnique.mockResolvedValueOnce({ ...eventBase, kennelId: "knl_new" } as never);
+    expect(await reattributeEventKennel("e1", "brh3")).toEqual({
+      error: "Event is already attributed to BRH3",
+    });
+  });
+
+  it("deletes old primary BEFORE creating the new primary, mirrors kennelId, audits", async () => {
+    const callOrder: string[] = [];
+    mockKennelFindUnique.mockResolvedValueOnce(newKennel as never);
+    mockEventFindUnique.mockResolvedValueOnce(eventBase as never);
+    mockEkDeleteMany.mockImplementationOnce((() => { callOrder.push("deleteMany"); return Promise.resolve({ count: 1 }); }) as never);
+    mockEkCreate.mockImplementationOnce((() => { callOrder.push("create"); return Promise.resolve({}); }) as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    const result = await reattributeEventKennel("e1", "brh3");
+    expect(result).toMatchObject({ success: true, oldKennelName: "NYCH3", newKennelName: "BRH3" });
+    expect(callOrder).toEqual(["deleteMany", "create"]);
+    expect(mockEkDeleteMany).toHaveBeenCalledWith({ where: { eventId: "e1", isPrimary: true } });
+    expect(mockEkCreate).toHaveBeenCalledWith({ data: { eventId: "e1", kennelId: "knl_new", isPrimary: true } });
+
+    const updateArg = mockEventUpdate.mock.calls[0][0] as unknown as {
+      data: { kennelId: string; adminAuditLog: Array<{ action: string; changes?: Record<string, { old: unknown; new: unknown }> }> };
+    };
+    expect(updateArg.data.kennelId).toBe("knl_new");
+    expect(updateArg.data.adminAuditLog[0].action).toBe("reattribute_kennel");
+    expect(updateArg.data.adminAuditLog[0].changes?.kennelId).toEqual({ old: "knl_old", new: "knl_new" });
+    expect(updateArg.data.adminAuditLog[0].changes?.kennelCode).toEqual({ old: "nych3", new: "brh3" });
+  });
+
+  it("promotes an existing co-host row instead of creating one", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(newKennel as never);
+    mockEventFindUnique.mockResolvedValueOnce({
+      ...eventBase,
+      eventKennels: [{ kennelId: "knl_old" }, { kennelId: "knl_new" }],
+    } as never);
+    mockEkDeleteMany.mockResolvedValueOnce({ count: 1 } as never);
+    mockEkUpdate.mockResolvedValueOnce({} as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    const result = await reattributeEventKennel("e1", "brh3");
+    expect(result).toMatchObject({ success: true });
+    expect(mockEkUpdate).toHaveBeenCalledWith({
+      where: { eventId_kennelId: { eventId: "e1", kennelId: "knl_new" } },
+      data: { isPrimary: true },
+    });
+    expect(mockEkCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("addCoHostKennel", () => {
+  const kennel = { id: "knl_co", shortName: "BRH3", slug: "brh3" };
+  const eventBase = {
+    date: new Date("2026-06-06T12:00:00Z"),
+    adminAuditLog: null,
+    kennel: { slug: "nych3" },
+    eventKennels: [{ kennelId: "knl_primary" }],
+  };
+
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await addCoHostKennel("e1", "brh3")).toEqual({ error: "Not authorized" });
+  });
+
+  it("returns error when kennel not found", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(null);
+    expect(await addCoHostKennel("e1", "ghost")).toEqual({ error: "Kennel not found: ghost" });
+  });
+
+  it("returns error when event not found", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(kennel as never);
+    mockEventFindUnique.mockResolvedValueOnce(null);
+    expect(await addCoHostKennel("e1", "brh3")).toEqual({ error: "Event not found" });
+  });
+
+  it("returns error when kennel already attributed", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(kennel as never);
+    mockEventFindUnique.mockResolvedValueOnce({
+      ...eventBase,
+      eventKennels: [{ kennelId: "knl_co" }],
+    } as never);
+    expect(await addCoHostKennel("e1", "brh3")).toEqual({
+      error: "BRH3 is already attributed to this event",
+    });
+  });
+
+  it("creates a non-primary EventKennel row and appends add_cohost audit", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(kennel as never);
+    mockEventFindUnique.mockResolvedValueOnce(eventBase as never);
+    mockEkCreate.mockResolvedValueOnce({} as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    const result = await addCoHostKennel("e1", "brh3");
+    expect(result).toMatchObject({ success: true, kennelName: "BRH3" });
+    expect(mockEkCreate).toHaveBeenCalledWith({
+      data: { eventId: "e1", kennelId: "knl_co", isPrimary: false },
+    });
+    const updateArg = mockEventUpdate.mock.calls[0][0] as unknown as {
+      data: { adminAuditLog: Array<{ action: string }> };
+    };
+    expect(updateArg.data.adminAuditLog[0].action).toBe("add_cohost");
+  });
+});
+
+describe("removeCoHostKennel", () => {
+  const kennel = { id: "knl_co", shortName: "BRH3", slug: "brh3" };
+  const eventBase = {
+    date: new Date("2026-06-06T12:00:00Z"),
+    adminAuditLog: null,
+    kennel: { slug: "nych3" },
+    eventKennels: [
+      { kennelId: "knl_primary", isPrimary: true },
+      { kennelId: "knl_co", isPrimary: false },
+    ],
+  };
+
+  it("returns error when not admin", async () => {
+    mockAdminAuth.mockResolvedValueOnce(null);
+    expect(await removeCoHostKennel("e1", "brh3")).toEqual({ error: "Not authorized" });
+  });
+
+  it("returns error when kennel not found", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(null);
+    expect(await removeCoHostKennel("e1", "ghost")).toEqual({ error: "Kennel not found: ghost" });
+  });
+
+  it("returns error when kennel is not attributed", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(kennel as never);
+    mockEventFindUnique.mockResolvedValueOnce({
+      ...eventBase,
+      eventKennels: [{ kennelId: "knl_primary", isPrimary: true }],
+    } as never);
+    expect(await removeCoHostKennel("e1", "brh3")).toEqual({
+      error: "BRH3 is not attributed to this event",
+    });
+  });
+
+  it("refuses to remove the primary kennel", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(kennel as never);
+    mockEventFindUnique.mockResolvedValueOnce({
+      ...eventBase,
+      eventKennels: [{ kennelId: "knl_co", isPrimary: true }],
+    } as never);
+    expect(await removeCoHostKennel("e1", "brh3")).toEqual({
+      error: "Cannot remove the primary kennel — use Change kennel to move it",
+    });
+  });
+
+  it("deletes the co-host row and appends remove_cohost audit", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce(kennel as never);
+    mockEventFindUnique.mockResolvedValueOnce(eventBase as never);
+    mockEkDelete.mockResolvedValueOnce({} as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    const result = await removeCoHostKennel("e1", "brh3");
+    expect(result).toMatchObject({ success: true, kennelName: "BRH3" });
+    expect(mockEkDelete).toHaveBeenCalledWith({
+      where: { eventId_kennelId: { eventId: "e1", kennelId: "knl_co" } },
+    });
+    const updateArg = mockEventUpdate.mock.calls[0][0] as unknown as {
+      data: { adminAuditLog: Array<{ action: string }> };
+    };
+    expect(updateArg.data.adminAuditLog[0].action).toBe("remove_cohost");
   });
 });

--- a/src/app/admin/events/actions.ts
+++ b/src/app/admin/events/actions.ts
@@ -600,8 +600,8 @@ export async function linkChildToUmbrella(
       }),
     ]);
 
-    if (!child) return { ok: false, error: "Child event not found" };
-    if (!umbrella) return { ok: false, error: "Umbrella event not found" };
+    if (!child) return { ok: false, error: "Event not found" };
+    if (!umbrella) return { ok: false, error: "Series parent not found" };
 
     // Already linked to this umbrella — idempotent success.
     if (child.parentEventId === umbrellaEventId) {
@@ -617,14 +617,14 @@ export async function linkChildToUmbrella(
     // Moving it would orphan the old umbrella's cached series view; force an
     // explicit unlink first so both umbrellas get revalidated.
     if (child.parentEventId !== null) {
-      return { ok: false, error: "Event is already linked to a different umbrella — unlink it first" };
+      return { ok: false, error: "Event is already in a different series — remove it from that one first" };
     }
 
     if (umbrella.parentEventId !== null) {
-      return { ok: false, error: "Umbrella is itself a child of another event" };
+      return { ok: false, error: "That event is itself part of another series" };
     }
     if (child.isSeriesParent) {
-      return { ok: false, error: "This event is a series parent — detach its children before attaching it" };
+      return { ok: false, error: "This event is already a series parent — remove its days first" };
     }
 
     await tx.event.update({
@@ -702,7 +702,7 @@ export async function unlinkChildFromUmbrella(
       },
     });
     if (!child) return { ok: false, error: "Event not found" };
-    if (child.parentEventId === null) return { ok: false, error: "Event is not linked to an umbrella" };
+    if (child.parentEventId === null) return { ok: false, error: "Event isn't part of a series" };
 
     const oldParentId = child.parentEventId;
     await tx.event.update({

--- a/src/app/admin/events/actions.ts
+++ b/src/app/admin/events/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/db";
+import type { Prisma } from "@/generated/prisma/client";
 import { getAdminUser } from "@/lib/auth";
 import type { ActionResult } from "@/lib/actions";
 import { revalidatePath, revalidateTag } from "next/cache";
@@ -30,6 +31,26 @@ function revalidateAfterCancelToggle(eventId: string, kennelSlug: string): void 
   revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   revalidatePath(`/hareline/${eventId}`);
   revalidatePath(`/kennels/${kennelSlug}`);
+}
+
+/** Revalidate every cache surface affected by a series-link or kennel-
+ *  attribution change: the admin list, the hareline list + tag, this event's
+ *  detail page, and each kennel page whose membership shifted (old + new, or
+ *  the host + co-host). Empty/duplicate slugs are de-duped and skipped. */
+function revalidateAfterAttribution(eventId: string, kennelSlugs: string[]): void {
+  revalidatePath("/admin/events");
+  revalidatePath("/hareline");
+  revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
+  revalidatePath(`/hareline/${eventId}`);
+  for (const slug of new Set(kennelSlugs.filter(Boolean))) {
+    revalidatePath(`/kennels/${slug}`);
+  }
+}
+
+/** Take a row-level lock on an Event for the rest of the surrounding tx, so a
+ *  concurrent admin mutation can't race the read-modify-write of its fields. */
+function lockEvent(tx: Prisma.TransactionClient, eventId: string) {
+  return tx.$executeRaw`SELECT id FROM "Event" WHERE id = ${eventId} FOR UPDATE`;
 }
 
 /**
@@ -264,7 +285,7 @@ export async function uncancelEvent(eventId: string): Promise<ActionResult<{ ken
   const result: TxResult = await prisma.$transaction(async (tx) => {
     // Row-level lock prevents two concurrent uncancel/cancel actions from
     // racing on the audit-log append. The lock is released on commit/rollback.
-    await tx.$executeRaw`SELECT id FROM "Event" WHERE id = ${eventId} FOR UPDATE`;
+    await lockEvent(tx, eventId);
 
     const event = await tx.event.findUnique({
       where: { id: eventId },
@@ -375,7 +396,7 @@ export async function adminCancelEvent(
   }
 
   const result: TxResult = await prisma.$transaction(async (tx) => {
-    await tx.$executeRaw`SELECT id FROM "Event" WHERE id = ${eventId} FOR UPDATE`;
+    await lockEvent(tx, eventId);
 
     const event = await tx.event.findUnique({
       where: { id: eventId },
@@ -495,4 +516,562 @@ function buildEventWhere(filters: {
   if (conditions.length === 0) return null;
 
   return { AND: conditions };
+}
+
+// ---------------------------------------------------------------------------
+// Umbrella series link/unlink (#1679)
+// ---------------------------------------------------------------------------
+
+/**
+ * Recompute an umbrella's `endDate` so the public series header — which renders
+ * `formatDateRange(event.date, event.endDate)` (see hareline/[eventId]/page.tsx)
+ * — always covers its current children. Sets `endDate` to the latest child
+ * date when a child extends beyond the umbrella's own date, otherwise null
+ * (single-day display). Call inside a tx with the umbrella row already locked.
+ *
+ * Manual link/unlink must maintain this because the merge pipeline's
+ * `linkMultiDaySeries` only sets parent/child pointers; endDate otherwise comes
+ * from the adapter. A re-scrape re-asserts any adapter-supplied endDate via
+ * `resolveEndDateUpdate`, so this never permanently fights a source-driven range.
+ */
+async function syncUmbrellaEndDate(
+  tx: Prisma.TransactionClient,
+  umbrellaId: string,
+): Promise<void> {
+  const [umbrella, children] = await Promise.all([
+    tx.event.findUnique({ where: { id: umbrellaId }, select: { date: true } }),
+    tx.event.findMany({ where: { parentEventId: umbrellaId }, select: { date: true } }),
+  ]);
+  if (!umbrella) return;
+  const latestChild = children.reduce<Date | null>(
+    (max, c) => (max === null || c.date > max ? c.date : max),
+    null,
+  );
+  const endDate =
+    latestChild !== null && latestChild > umbrella.date ? latestChild : null;
+  await tx.event.update({ where: { id: umbrellaId }, data: { endDate } });
+}
+
+/**
+ * Attach a standalone Event as a child of an umbrella (series-parent) Event by
+ * setting `parentEventId`. Promotes the umbrella to `isSeriesParent=true` if it
+ * isn't already (mirrors the merge pipeline's `linkMultiDaySeries`).
+ *
+ * Enforces a strict 2-level tree (parent → children): the umbrella may not
+ * itself be a child, and the child may not already be a series parent. That
+ * keeps cycles impossible and the UI grouping flat.
+ *
+ * Atomic: both rows are locked with `SELECT ... FOR UPDATE` ordered by id (so a
+ * concurrent link in the opposite direction can't deadlock), then mutated.
+ */
+export async function linkChildToUmbrella(
+  childEventId: string,
+  umbrellaEventId: string,
+): Promise<ActionResult<{ kennelName: string; date: string }>> {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  if (childEventId === umbrellaEventId) {
+    return { error: "Cannot link an event to itself" };
+  }
+
+  type R =
+    | { ok: true; kennelName: string; kennelSlug: string; date: string }
+    | { ok: false; error: string };
+  const result: R = await prisma.$transaction(async (tx) => {
+    // Lock both rows in a deterministic (id-sorted) order to avoid deadlock
+    // with a concurrent link running in the opposite direction.
+    await tx.$executeRaw`SELECT id FROM "Event" WHERE id IN (${childEventId}, ${umbrellaEventId}) ORDER BY id FOR UPDATE`;
+
+    const [child, umbrella] = await Promise.all([
+      tx.event.findUnique({
+        where: { id: childEventId },
+        select: {
+          parentEventId: true,
+          isSeriesParent: true,
+          date: true,
+          adminAuditLog: true,
+          kennel: { select: KENNEL_SELECT_FOR_OVERRIDE },
+        },
+      }),
+      tx.event.findUnique({
+        where: { id: umbrellaEventId },
+        select: { parentEventId: true, isSeriesParent: true },
+      }),
+    ]);
+
+    if (!child) return { ok: false, error: "Child event not found" };
+    if (!umbrella) return { ok: false, error: "Umbrella event not found" };
+
+    // Already linked to this umbrella — idempotent success.
+    if (child.parentEventId === umbrellaEventId) {
+      return {
+        ok: true,
+        kennelName: child.kennel.shortName,
+        kennelSlug: child.kennel.slug,
+        date: child.date.toISOString(),
+      };
+    }
+
+    // Already a child of a DIFFERENT umbrella: refuse to silently re-parent.
+    // Moving it would orphan the old umbrella's cached series view; force an
+    // explicit unlink first so both umbrellas get revalidated.
+    if (child.parentEventId !== null) {
+      return { ok: false, error: "Event is already linked to a different umbrella — unlink it first" };
+    }
+
+    if (umbrella.parentEventId !== null) {
+      return { ok: false, error: "Umbrella is itself a child of another event" };
+    }
+    if (child.isSeriesParent) {
+      return { ok: false, error: "This event is a series parent — detach its children before attaching it" };
+    }
+
+    await tx.event.update({
+      where: { id: childEventId },
+      data: {
+        parentEventId: umbrellaEventId,
+        adminAuditLog: appendAuditLog(child.adminAuditLog, {
+          action: "link_series",
+          timestamp: new Date().toISOString(),
+          userId: admin.clerkId,
+          changes: { parentEventId: { old: child.parentEventId, new: umbrellaEventId } },
+          details: { umbrellaEventId },
+        }),
+      },
+    });
+
+    if (!umbrella.isSeriesParent) {
+      await tx.event.update({
+        where: { id: umbrellaEventId },
+        data: { isSeriesParent: true },
+      });
+    }
+
+    // Keep the umbrella's date range covering the newly-linked child.
+    await syncUmbrellaEndDate(tx, umbrellaEventId);
+
+    return {
+      ok: true,
+      kennelName: child.kennel.shortName,
+      kennelSlug: child.kennel.slug,
+      date: child.date.toISOString(),
+    };
+  });
+
+  if (!result.ok) return { error: result.error };
+
+  console.log("[admin-audit] linkChildToUmbrella", JSON.stringify({
+    adminId: admin.id,
+    adminClerkId: admin.clerkId,
+    action: "link_series",
+    childEventId,
+    umbrellaEventId,
+    timestamp: new Date().toISOString(),
+  }));
+
+  revalidateAfterAttribution(childEventId, [result.kennelSlug]);
+  revalidatePath(`/hareline/${umbrellaEventId}`);
+  return { success: true, kennelName: result.kennelName, date: result.date };
+}
+
+/**
+ * Detach a child Event from its umbrella by clearing `parentEventId`. Does not
+ * auto-demote the umbrella's `isSeriesParent` flag (demote-parent is a separate
+ * concern, intentionally out of scope here).
+ */
+export async function unlinkChildFromUmbrella(
+  childEventId: string,
+): Promise<ActionResult<{ kennelName: string; date: string }>> {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  type R =
+    | { ok: true; kennelName: string; kennelSlug: string; date: string; oldParentId: string }
+    | { ok: false; error: string };
+  const result: R = await prisma.$transaction(async (tx) => {
+    await lockEvent(tx, childEventId);
+
+    const child = await tx.event.findUnique({
+      where: { id: childEventId },
+      select: {
+        parentEventId: true,
+        date: true,
+        adminAuditLog: true,
+        kennel: { select: KENNEL_SELECT_FOR_OVERRIDE },
+      },
+    });
+    if (!child) return { ok: false, error: "Event not found" };
+    if (child.parentEventId === null) return { ok: false, error: "Event is not linked to an umbrella" };
+
+    const oldParentId = child.parentEventId;
+    await tx.event.update({
+      where: { id: childEventId },
+      data: {
+        parentEventId: null,
+        adminAuditLog: appendAuditLog(child.adminAuditLog, {
+          action: "unlink_series",
+          timestamp: new Date().toISOString(),
+          userId: admin.clerkId,
+          changes: { parentEventId: { old: oldParentId, new: null } },
+        }),
+      },
+    });
+
+    // Shrink the old umbrella's date range to cover only its remaining
+    // children (lock it first — low-concurrency admin path, no deadlock risk
+    // vs. the pipeline which locks nothing here).
+    await lockEvent(tx, oldParentId);
+    await syncUmbrellaEndDate(tx, oldParentId);
+
+    return {
+      ok: true,
+      kennelName: child.kennel.shortName,
+      kennelSlug: child.kennel.slug,
+      date: child.date.toISOString(),
+      oldParentId,
+    };
+  });
+
+  if (!result.ok) return { error: result.error };
+
+  console.log("[admin-audit] unlinkChildFromUmbrella", JSON.stringify({
+    adminId: admin.id,
+    adminClerkId: admin.clerkId,
+    action: "unlink_series",
+    childEventId,
+    oldParentId: result.oldParentId,
+    timestamp: new Date().toISOString(),
+  }));
+
+  revalidateAfterAttribution(childEventId, [result.kennelSlug]);
+  revalidatePath(`/hareline/${result.oldParentId}`);
+  return { success: true, kennelName: result.kennelName, date: result.date };
+}
+
+/**
+ * Read-only search backing the "link to umbrella" picker. Matches `title` or
+ * `kennel.shortName` (case-insensitive contains), newest first, capped at 25.
+ * Returns an empty list for queries shorter than 2 chars.
+ */
+export async function searchEventsForUmbrella(
+  query: string,
+  excludeId?: string,
+): Promise<
+  | { success: true; events: { id: string; date: string; kennelName: string; title: string | null; isSeriesParent: boolean }[] }
+  | { error: string }
+> {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  const trimmed = query.trim();
+  if (trimmed.length < 2) return { success: true, events: [] };
+
+  const events = await prisma.event.findMany({
+    where: {
+      AND: [
+        excludeId ? { id: { not: excludeId } } : {},
+        {
+          OR: [
+            { title: { contains: trimmed, mode: "insensitive" } },
+            { kennel: { shortName: { contains: trimmed, mode: "insensitive" } } },
+          ],
+        },
+      ],
+    },
+    select: {
+      id: true,
+      date: true,
+      title: true,
+      isSeriesParent: true,
+      kennel: { select: { shortName: true } },
+    },
+    orderBy: { date: "desc" },
+    take: 25,
+  });
+
+  return {
+    success: true,
+    events: events.map((e) => ({
+      id: e.id,
+      date: e.date.toISOString(),
+      kennelName: e.kennel.shortName,
+      title: e.title,
+      isSeriesParent: e.isSeriesParent,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Kennel attribution (#1680)
+// ---------------------------------------------------------------------------
+
+/**
+ * Change an Event's PRIMARY kennel (a true move). Deletes the old primary
+ * `EventKennel` row, promotes/creates the new kennel's row as primary, and
+ * mirrors `Event.kennelId`. Any existing co-host rows are left untouched.
+ *
+ * The old primary is deleted BEFORE the new one is promoted/created — the
+ * partial unique index `EventKennel(eventId) WHERE isPrimary = true` rejects
+ * two primaries even transiently (same recipe as `deduplicateEventKennels`).
+ */
+export async function reattributeEventKennel(
+  eventId: string,
+  newKennelCode: string,
+): Promise<ActionResult<{ oldKennelName: string; newKennelName: string; date: string }>> {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  type R =
+    | {
+        ok: true;
+        oldKennelName: string;
+        oldKennelSlug: string;
+        newKennelName: string;
+        newKennelSlug: string;
+        date: string;
+      }
+    | { ok: false; error: string };
+  const result: R = await prisma.$transaction(async (tx) => {
+    await lockEvent(tx, eventId);
+
+    // The kennel + event reads are independent — run them together.
+    const [newKennel, event] = await Promise.all([
+      tx.kennel.findUnique({
+        where: { kennelCode: newKennelCode },
+        select: { id: true, shortName: true, slug: true },
+      }),
+      tx.event.findUnique({
+        where: { id: eventId },
+        select: {
+          kennelId: true,
+          date: true,
+          adminAuditLog: true,
+          kennel: { select: { kennelCode: true, shortName: true, slug: true } },
+          eventKennels: { select: { kennelId: true } },
+        },
+      }),
+    ]);
+    if (!newKennel) return { ok: false, error: `Kennel not found: ${newKennelCode}` };
+    if (!event) return { ok: false, error: "Event not found" };
+    if (event.kennelId === newKennel.id) {
+      return { ok: false, error: `Event is already attributed to ${newKennel.shortName}` };
+    }
+
+    const oldKennelId = event.kennelId;
+
+    // Delete the old primary first (see partial-unique-index note above).
+    await tx.eventKennel.deleteMany({ where: { eventId, isPrimary: true } });
+
+    const newAlreadyAttached = event.eventKennels.some((ek) => ek.kennelId === newKennel.id);
+    if (newAlreadyAttached) {
+      await tx.eventKennel.update({
+        where: { eventId_kennelId: { eventId, kennelId: newKennel.id } },
+        data: { isPrimary: true },
+      });
+    } else {
+      await tx.eventKennel.create({
+        data: { eventId, kennelId: newKennel.id, isPrimary: true },
+      });
+    }
+
+    await tx.event.update({
+      where: { id: eventId },
+      data: {
+        kennelId: newKennel.id,
+        adminAuditLog: appendAuditLog(event.adminAuditLog, {
+          action: "reattribute_kennel",
+          timestamp: new Date().toISOString(),
+          userId: admin.clerkId,
+          changes: {
+            kennelId: { old: oldKennelId, new: newKennel.id },
+            kennelCode: { old: event.kennel.kennelCode, new: newKennelCode },
+          },
+        }),
+      },
+    });
+
+    return {
+      ok: true,
+      oldKennelName: event.kennel.shortName,
+      oldKennelSlug: event.kennel.slug,
+      newKennelName: newKennel.shortName,
+      newKennelSlug: newKennel.slug,
+      date: event.date.toISOString(),
+    };
+  });
+
+  if (!result.ok) return { error: result.error };
+
+  console.log("[admin-audit] reattributeEventKennel", JSON.stringify({
+    adminId: admin.id,
+    adminClerkId: admin.clerkId,
+    action: "reattribute_kennel",
+    eventId,
+    newKennelCode,
+    timestamp: new Date().toISOString(),
+  }));
+
+  revalidateAfterAttribution(eventId, [result.oldKennelSlug, result.newKennelSlug]);
+  return {
+    success: true,
+    oldKennelName: result.oldKennelName,
+    newKennelName: result.newKennelName,
+    date: result.date,
+  };
+}
+
+/**
+ * Add a co-host kennel to an Event as a non-primary `EventKennel` row. Rejects
+ * kennels already attributed (primary or existing co-host).
+ */
+export async function addCoHostKennel(
+  eventId: string,
+  kennelCode: string,
+): Promise<ActionResult<{ kennelName: string; date: string }>> {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  type R =
+    | { ok: true; eventSlug: string; coHostName: string; coHostSlug: string; date: string }
+    | { ok: false; error: string };
+  const result: R = await prisma.$transaction(async (tx) => {
+    await lockEvent(tx, eventId);
+
+    const kennel = await tx.kennel.findUnique({
+      where: { kennelCode },
+      select: { id: true, shortName: true, slug: true },
+    });
+    if (!kennel) return { ok: false, error: `Kennel not found: ${kennelCode}` };
+
+    const event = await tx.event.findUnique({
+      where: { id: eventId },
+      select: {
+        date: true,
+        adminAuditLog: true,
+        kennel: { select: { slug: true } },
+        eventKennels: { select: { kennelId: true } },
+      },
+    });
+    if (!event) return { ok: false, error: "Event not found" };
+    if (event.eventKennels.some((ek) => ek.kennelId === kennel.id)) {
+      return { ok: false, error: `${kennel.shortName} is already attributed to this event` };
+    }
+
+    await tx.eventKennel.create({
+      data: { eventId, kennelId: kennel.id, isPrimary: false },
+    });
+    await tx.event.update({
+      where: { id: eventId },
+      data: {
+        adminAuditLog: appendAuditLog(event.adminAuditLog, {
+          action: "add_cohost",
+          timestamp: new Date().toISOString(),
+          userId: admin.clerkId,
+          details: { kennelCode, kennelId: kennel.id },
+        }),
+      },
+    });
+
+    return {
+      ok: true,
+      eventSlug: event.kennel.slug,
+      coHostName: kennel.shortName,
+      coHostSlug: kennel.slug,
+      date: event.date.toISOString(),
+    };
+  });
+
+  if (!result.ok) return { error: result.error };
+
+  console.log("[admin-audit] addCoHostKennel", JSON.stringify({
+    adminId: admin.id,
+    adminClerkId: admin.clerkId,
+    action: "add_cohost",
+    eventId,
+    kennelCode,
+    timestamp: new Date().toISOString(),
+  }));
+
+  revalidateAfterAttribution(eventId, [result.eventSlug, result.coHostSlug]);
+  return { success: true, kennelName: result.coHostName, date: result.date };
+}
+
+/**
+ * Remove a co-host kennel from an Event. Rejects removing the primary (use
+ * `reattributeEventKennel` to move the primary) or a kennel that isn't attached.
+ */
+export async function removeCoHostKennel(
+  eventId: string,
+  kennelCode: string,
+): Promise<ActionResult<{ kennelName: string; date: string }>> {
+  const admin = await getAdminUser();
+  if (!admin) return { error: "Not authorized" };
+
+  type R =
+    | { ok: true; eventSlug: string; coHostName: string; coHostSlug: string; date: string }
+    | { ok: false; error: string };
+  const result: R = await prisma.$transaction(async (tx) => {
+    await lockEvent(tx, eventId);
+
+    const kennel = await tx.kennel.findUnique({
+      where: { kennelCode },
+      select: { id: true, shortName: true, slug: true },
+    });
+    if (!kennel) return { ok: false, error: `Kennel not found: ${kennelCode}` };
+
+    const event = await tx.event.findUnique({
+      where: { id: eventId },
+      select: {
+        date: true,
+        adminAuditLog: true,
+        kennel: { select: { slug: true } },
+        eventKennels: { select: { kennelId: true, isPrimary: true } },
+      },
+    });
+    if (!event) return { ok: false, error: "Event not found" };
+
+    const row = event.eventKennels.find((ek) => ek.kennelId === kennel.id);
+    if (!row) return { ok: false, error: `${kennel.shortName} is not attributed to this event` };
+    if (row.isPrimary) {
+      return { ok: false, error: "Cannot remove the primary kennel — use Change kennel to move it" };
+    }
+
+    await tx.eventKennel.delete({
+      where: { eventId_kennelId: { eventId, kennelId: kennel.id } },
+    });
+    await tx.event.update({
+      where: { id: eventId },
+      data: {
+        adminAuditLog: appendAuditLog(event.adminAuditLog, {
+          action: "remove_cohost",
+          timestamp: new Date().toISOString(),
+          userId: admin.clerkId,
+          details: { kennelCode, kennelId: kennel.id },
+        }),
+      },
+    });
+
+    return {
+      ok: true,
+      eventSlug: event.kennel.slug,
+      coHostName: kennel.shortName,
+      coHostSlug: kennel.slug,
+      date: event.date.toISOString(),
+    };
+  });
+
+  if (!result.ok) return { error: result.error };
+
+  console.log("[admin-audit] removeCoHostKennel", JSON.stringify({
+    adminId: admin.id,
+    adminClerkId: admin.clerkId,
+    action: "remove_cohost",
+    eventId,
+    kennelCode,
+    timestamp: new Date().toISOString(),
+  }));
+
+  revalidateAfterAttribution(eventId, [result.eventSlug, result.coHostSlug]);
+  return { success: true, kennelName: result.coHostName, date: result.date };
 }

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -79,7 +79,14 @@ export default async function AdminEventsPage({ searchParams }: PageProps) {
     prisma.event.findMany({
       where,
       include: {
-        kennel: { select: { shortName: true, region: true } },
+        kennel: { select: { kennelCode: true, shortName: true, region: true } },
+        eventKennels: {
+          orderBy: { isPrimary: "desc" }, // primary first — UI relies on this order
+          select: {
+            isPrimary: true,
+            kennel: { select: { kennelCode: true, shortName: true } },
+          },
+        },
         rawEvents: {
           select: {
             id: true,
@@ -95,7 +102,7 @@ export default async function AdminEventsPage({ searchParams }: PageProps) {
     }),
     prisma.kennel.findMany({
       orderBy: { shortName: "asc" },
-      select: { id: true, shortName: true, fullName: true, region: true },
+      select: { id: true, kennelCode: true, shortName: true, fullName: true, region: true },
     }),
     prisma.source.findMany({
       orderBy: { name: "asc" },
@@ -110,25 +117,41 @@ export default async function AdminEventsPage({ searchParams }: PageProps) {
   const totalPages = Math.ceil(totalCount / pageSize);
 
   // Serialize dates for client component
-  const serializedEvents = events.map((e) => ({
-    id: e.id,
-    date: e.date.toISOString(),
-    kennelId: e.kennelId,
-    kennelName: e.kennel.shortName,
-    kennelRegion: e.kennel.region,
-    title: e.title,
-    runNumber: e.runNumber,
-    startTime: e.startTime,
-    status: e.status,
-    adminCancelledAt: e.adminCancelledAt?.toISOString() ?? null,
-    adminCancelledBy: e.adminCancelledBy,
-    adminCancellationReason: e.adminCancellationReason,
-    adminAuditLogCount: Array.isArray(e.adminAuditLog) ? e.adminAuditLog.length : 0,
-    sources: [...new Set(e.rawEvents.map((r) => r.source.name))],
-    rawEventCount: e.rawEvents.length,
-    attendanceCount: e._count.attendances,
-    hareCount: e._count.hares,
-  }));
+  const serializedEvents = events.map((e) => {
+    // Co-host list for the kennel-attribution dialog, primary-first (ordered by
+    // the query). Fall back to the Event.kennelId denorm if the join table
+    // somehow has no rows.
+    const kennels =
+      e.eventKennels.length > 0
+        ? e.eventKennels.map((ek) => ({
+            kennelCode: ek.kennel.kennelCode,
+            shortName: ek.kennel.shortName,
+            isPrimary: ek.isPrimary,
+          }))
+        : [{ kennelCode: e.kennel.kennelCode, shortName: e.kennel.shortName, isPrimary: true }];
+    return {
+      id: e.id,
+      date: e.date.toISOString(),
+      kennelId: e.kennelId,
+      kennelName: e.kennel.shortName,
+      kennelRegion: e.kennel.region,
+      title: e.title,
+      runNumber: e.runNumber,
+      startTime: e.startTime,
+      status: e.status,
+      parentEventId: e.parentEventId,
+      isSeriesParent: e.isSeriesParent,
+      kennels,
+      adminCancelledAt: e.adminCancelledAt?.toISOString() ?? null,
+      adminCancelledBy: e.adminCancelledBy,
+      adminCancellationReason: e.adminCancellationReason,
+      adminAuditLogCount: Array.isArray(e.adminAuditLog) ? e.adminAuditLog.length : 0,
+      sources: [...new Set(e.rawEvents.map((r) => r.source.name))],
+      rawEventCount: e.rawEvents.length,
+      attendanceCount: e._count.attendances,
+      hareCount: e._count.hares,
+    };
+  });
 
   const rangeStart = totalCount > 0 ? skip + 1 : 0;
   const rangeEnd = Math.min(skip + pageSize, totalCount);

--- a/src/components/admin/EventTable.tsx
+++ b/src/components/admin/EventTable.tsx
@@ -305,7 +305,7 @@ export function EventTable({
         toast.error(result.error);
         return;
       }
-      toast.success(`Unlinked ${result.kennelName} — ${formatDate(result.date)} from umbrella`);
+      toast.success(`Removed ${result.kennelName} — ${formatDate(result.date)} from its series`);
       router.refresh();
     });
   }
@@ -525,28 +525,36 @@ export function EventTable({
                         {event.kennelName}
                       </Badge>
                       {event.kennels.length > 1 && (
-                        <Badge variant="secondary" className="text-[10px]">
-                          +{event.kennels.length - 1}
-                        </Badge>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge variant="secondary" className="text-[10px]">
+                              +{event.kennels.length - 1}
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            {event.kennels.length - 1} co-host{event.kennels.length - 1 !== 1 ? "s" : ""}:{" "}
+                            {event.kennels.filter((k) => !k.isPrimary).map((k) => k.shortName).join(", ")}
+                          </TooltipContent>
+                        </Tooltip>
                       )}
                       {event.isSeriesParent && (
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <span aria-label="Series umbrella" className="text-muted-foreground">
+                            <span aria-label="Multi-day series parent" className="text-muted-foreground">
                               <Layers className="h-3.5 w-3.5" />
                             </span>
                           </TooltipTrigger>
-                          <TooltipContent side="bottom">Umbrella (series parent)</TooltipContent>
+                          <TooltipContent side="bottom">Multi-day series — parent</TooltipContent>
                         </Tooltip>
                       )}
                       {event.parentEventId && (
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <span aria-label="Series child" className="text-muted-foreground">
+                            <span aria-label="Day in a multi-day series" className="text-muted-foreground">
                               <Link2 className="h-3.5 w-3.5" />
                             </span>
                           </TooltipTrigger>
-                          <TooltipContent side="bottom">Child of an umbrella event</TooltipContent>
+                          <TooltipContent side="bottom">A day within a multi-day series</TooltipContent>
                         </Tooltip>
                       )}
                     </div>
@@ -653,18 +661,18 @@ export function EventTable({
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem onSelect={() => setAttributionEvent(event)}>
                             <Crown className="mr-2 h-3.5 w-3.5" />
-                            Kennel attribution…
+                            Edit kennels…
                           </DropdownMenuItem>
                           <DropdownMenuSeparator />
                           {event.parentEventId ? (
                             <DropdownMenuItem onSelect={() => handleUnlinkUmbrella(event)}>
                               <Link2Off className="mr-2 h-3.5 w-3.5" />
-                              Unlink from umbrella
+                              Remove from series
                             </DropdownMenuItem>
                           ) : (
                             <DropdownMenuItem onSelect={() => setSeriesLinkEvent(event)}>
                               <Layers className="mr-2 h-3.5 w-3.5" />
-                              Link to umbrella…
+                              Add to multi-day series…
                             </DropdownMenuItem>
                           )}
                         </DropdownMenuContent>

--- a/src/components/admin/EventTable.tsx
+++ b/src/components/admin/EventTable.tsx
@@ -670,7 +670,10 @@ export function EventTable({
                               Remove from series
                             </DropdownMenuItem>
                           ) : (
-                            <DropdownMenuItem onSelect={() => setSeriesLinkEvent(event)}>
+                            <DropdownMenuItem
+                              onSelect={() => setSeriesLinkEvent(event)}
+                              disabled={event.isSeriesParent}
+                            >
                               <Layers className="mr-2 h-3.5 w-3.5" />
                               Add to multi-day series…
                             </DropdownMenuItem>

--- a/src/components/admin/EventTable.tsx
+++ b/src/components/admin/EventTable.tsx
@@ -4,10 +4,17 @@
 import { useState, useEffect, useTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
-import { ArrowUp, ArrowDown, Lock } from "lucide-react";
+import { ArrowUp, ArrowDown, Lock, MoreHorizontal, Layers, Link2, Link2Off, Crown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -45,8 +52,11 @@ import {
   bulkDeleteEvents,
   previewBulkDelete,
   uncancelEvent,
+  unlinkChildFromUmbrella,
 } from "@/app/admin/events/actions";
 import { CancellationOverrideDialog } from "./CancellationOverrideDialog";
+import { KennelAttributionDialog } from "./KennelAttributionDialog";
+import { SeriesLinkDialog } from "./SeriesLinkDialog";
 
 interface EventData {
   id: string;
@@ -58,6 +68,12 @@ interface EventData {
   runNumber: number | null;
   startTime: string | null;
   status: string;
+  /** Set when this event is a child of an umbrella (series) event. */
+  parentEventId: string | null;
+  /** True when this event is an umbrella (series parent) with children. */
+  isSeriesParent: boolean;
+  /** All kennels attributed to this event, primary-first. */
+  kennels: { kennelCode: string; shortName: string; isPrimary: boolean }[];
   /** ISO 8601 timestamp; null when not admin-cancelled. */
   adminCancelledAt: string | null;
   /** Clerk userId of the admin who set the override (matches User.clerkId; not the local User.id). */
@@ -73,7 +89,7 @@ interface EventData {
 
 interface EventTableProps {
   events: EventData[];
-  kennels: { id: string; shortName: string; fullName: string; region: string }[];
+  kennels: { id: string; kennelCode: string; shortName: string; fullName: string; region: string }[];
   sources: { id: string; name: string }[];
   filters: {
     kennelId?: string;
@@ -197,6 +213,8 @@ export function EventTable({
     sampleEvents: { id: string; date: string; kennelName: string; title: string | null; attendanceCount: number }[];
   } | null>(null);
   const [cancelDialogEvent, setCancelDialogEvent] = useState<EventData | null>(null);
+  const [attributionEvent, setAttributionEvent] = useState<EventData | null>(null);
+  const [seriesLinkEvent, setSeriesLinkEvent] = useState<EventData | null>(null);
 
   // Clear selection when URL params change (page navigation, filter change)
   useEffect(() => {
@@ -276,6 +294,18 @@ export function EventTable({
         return;
       }
       toast.success(`Restored ${result.kennelName} — ${formatDate(result.date)}`);
+      router.refresh();
+    });
+  }
+
+  function handleUnlinkUmbrella(event: EventData) {
+    startTransition(async () => {
+      const result = await unlinkChildFromUmbrella(event.id);
+      if ("error" in result) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(`Unlinked ${result.kennelName} — ${formatDate(result.date)} from umbrella`);
       router.refresh();
     });
   }
@@ -490,9 +520,36 @@ export function EventTable({
                     {formatDate(event.date)}
                   </TableCell>
                   <TableCell>
-                    <Badge variant="outline" className="text-xs">
-                      {event.kennelName}
-                    </Badge>
+                    <div className="flex items-center gap-1">
+                      <Badge variant="outline" className="text-xs">
+                        {event.kennelName}
+                      </Badge>
+                      {event.kennels.length > 1 && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          +{event.kennels.length - 1}
+                        </Badge>
+                      )}
+                      {event.isSeriesParent && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span aria-label="Series umbrella" className="text-muted-foreground">
+                              <Layers className="h-3.5 w-3.5" />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">Umbrella (series parent)</TooltipContent>
+                        </Tooltip>
+                      )}
+                      {event.parentEventId && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span aria-label="Series child" className="text-muted-foreground">
+                              <Link2 className="h-3.5 w-3.5" />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">Child of an umbrella event</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
                   </TableCell>
                   <TableCell className="text-xs max-w-[200px] sm:max-w-[300px] truncate">
                     {event.title ? (
@@ -580,6 +637,38 @@ export function EventTable({
                       >
                         Delete
                       </Button>
+
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 w-7 p-0"
+                            disabled={isPending}
+                            aria-label="More actions"
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onSelect={() => setAttributionEvent(event)}>
+                            <Crown className="mr-2 h-3.5 w-3.5" />
+                            Kennel attribution…
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          {event.parentEventId ? (
+                            <DropdownMenuItem onSelect={() => handleUnlinkUmbrella(event)}>
+                              <Link2Off className="mr-2 h-3.5 w-3.5" />
+                              Unlink from umbrella
+                            </DropdownMenuItem>
+                          ) : (
+                            <DropdownMenuItem onSelect={() => setSeriesLinkEvent(event)}>
+                              <Layers className="mr-2 h-3.5 w-3.5" />
+                              Link to umbrella…
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                   </TableCell>
                 </TableRow>
               ))}
@@ -779,6 +868,41 @@ export function EventTable({
           open={cancelDialogEvent !== null}
           onOpenChange={(next) => {
             if (!next) setCancelDialogEvent(null);
+          }}
+        />
+
+        <KennelAttributionDialog
+          event={
+            attributionEvent
+              ? {
+                  id: attributionEvent.id,
+                  title: attributionEvent.title,
+                  date: attributionEvent.date,
+                  kennels: attributionEvent.kennels,
+                }
+              : null
+          }
+          kennels={kennels}
+          open={attributionEvent !== null}
+          onOpenChange={(next) => {
+            if (!next) setAttributionEvent(null);
+          }}
+        />
+
+        <SeriesLinkDialog
+          event={
+            seriesLinkEvent
+              ? {
+                  id: seriesLinkEvent.id,
+                  title: seriesLinkEvent.title,
+                  date: seriesLinkEvent.date,
+                  kennelName: seriesLinkEvent.kennelName,
+                }
+              : null
+          }
+          open={seriesLinkEvent !== null}
+          onOpenChange={(next) => {
+            if (!next) setSeriesLinkEvent(null);
           }}
         />
       </div>

--- a/src/components/admin/KennelAttributionDialog.tsx
+++ b/src/components/admin/KennelAttributionDialog.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Crown, Loader2, X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { KennelCombobox } from "./KennelCombobox";
+import {
+  reattributeEventKennel,
+  addCoHostKennel,
+  removeCoHostKennel,
+} from "@/app/admin/events/actions";
+import { formatDateLong } from "@/lib/format";
+import { toast } from "sonner";
+
+export interface EventKennelInfo {
+  readonly kennelCode: string;
+  readonly shortName: string;
+  readonly isPrimary: boolean;
+}
+
+interface KennelAttributionDialogProps {
+  readonly event: {
+    readonly id: string;
+    readonly title: string | null;
+    /** ISO 8601 date string. */
+    readonly date: string;
+    readonly kennels: readonly EventKennelInfo[];
+  } | null;
+  readonly kennels: readonly {
+    readonly kennelCode: string;
+    readonly shortName: string;
+    readonly fullName: string;
+  }[];
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Admin dialog for an event's kennel attribution (#1680). Supports three
+ * operations against the EventKennel join: change the PRIMARY kennel (a move
+ * that drops the old kennel), add a co-host, and remove a co-host. Each
+ * mutation closes the dialog and refreshes; reopen to chain another change.
+ */
+export function KennelAttributionDialog({
+  event,
+  kennels,
+  open,
+  onOpenChange,
+}: KennelAttributionDialogProps) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const eventKennels = event?.kennels ?? [];
+  const primary = eventKennels.find((k) => k.isPrimary);
+  const coHosts = eventKennels.filter((k) => !k.isPrimary);
+  const attachedCodes = eventKennels.map((k) => k.kennelCode);
+
+  // Generic runner: T is inferred per action, so each successMessage callback
+  // sees that action's exact success fields — no discriminated-union checks.
+  function runMutation<T>(
+    fn: () => Promise<({ success: true } & T) | { error: string }>,
+    successMessage: (r: T) => string,
+  ) {
+    startTransition(async () => {
+      const r = await fn();
+      if ("error" in r) {
+        toast.error(r.error);
+        return;
+      }
+      toast.success(successMessage(r));
+      onOpenChange(false);
+      router.refresh();
+    });
+  }
+
+  function handleChangePrimary(kennelCode: string) {
+    if (!event) return;
+    runMutation(
+      () => reattributeEventKennel(event.id, kennelCode),
+      (r) => `Moved ${r.oldKennelName} → ${r.newKennelName}`,
+    );
+  }
+
+  function handleAddCoHost(kennelCode: string) {
+    if (!event) return;
+    runMutation(
+      () => addCoHostKennel(event.id, kennelCode),
+      (r) => `Added co-host ${r.kennelName}`,
+    );
+  }
+
+  function handleRemoveCoHost(kennelCode: string) {
+    if (!event) return;
+    runMutation(
+      () => removeCoHostKennel(event.id, kennelCode),
+      (r) => `Removed co-host ${r.kennelName}`,
+    );
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (isPending) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Kennel attribution</DialogTitle>
+          <DialogDescription className="pt-1">
+            Change the primary kennel (a move — the old kennel is dropped), or
+            add and remove co-hosts. Each change is audit-logged.
+          </DialogDescription>
+        </DialogHeader>
+
+        {event && (
+          <div className="space-y-4">
+            <div className="rounded-lg border bg-muted/40 p-3 space-y-1">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="font-medium">
+                  {primary?.shortName ?? "—"}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {formatDateLong(event.date)}
+                </span>
+              </div>
+              {event.title && (
+                <p className="text-sm text-muted-foreground line-clamp-2">
+                  {event.title}
+                </p>
+              )}
+            </div>
+
+            {/* Change primary */}
+            <div className="space-y-1.5">
+              <Label className="flex items-center gap-1 text-xs">
+                <Crown className="h-3 w-3" /> Primary kennel
+              </Label>
+              <KennelCombobox
+                kennels={kennels}
+                value={primary?.kennelCode}
+                onSelect={handleChangePrimary}
+                disabled={isPending}
+                placeholder="Change primary kennel…"
+                excludeCodes={primary ? [primary.kennelCode] : []}
+              />
+            </div>
+
+            {/* Co-hosts */}
+            <div className="space-y-1.5">
+              <Label className="text-xs">Co-hosts</Label>
+              {coHosts.length === 0 ? (
+                <p className="text-xs text-muted-foreground">No co-hosts.</p>
+              ) : (
+                <div className="flex flex-wrap gap-1.5">
+                  {coHosts.map((c) => (
+                    <Badge
+                      key={c.kennelCode}
+                      variant="secondary"
+                      className="gap-1 pr-1 text-xs"
+                    >
+                      {c.shortName}
+                      <button
+                        type="button"
+                        aria-label={`Remove co-host ${c.shortName}`}
+                        disabled={isPending}
+                        onClick={() => handleRemoveCoHost(c.kennelCode)}
+                        className="rounded-sm p-0.5 hover:bg-muted-foreground/20 disabled:opacity-50"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              )}
+              <KennelCombobox
+                kennels={kennels}
+                onSelect={handleAddCoHost}
+                disabled={isPending}
+                placeholder="Add co-host…"
+                excludeCodes={attachedCodes}
+              />
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Working…
+              </>
+            ) : (
+              "Done"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/KennelAttributionDialog.tsx
+++ b/src/components/admin/KennelAttributionDialog.tsx
@@ -118,10 +118,10 @@ export function KennelAttributionDialog({
     >
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>Kennel attribution</DialogTitle>
+          <DialogTitle>Edit kennels</DialogTitle>
           <DialogDescription className="pt-1">
-            Change the primary kennel (a move — the old kennel is dropped), or
-            add and remove co-hosts. Each change is audit-logged.
+            The primary kennel is where this event shows up. Co-hosts also list
+            it on their pages. Every change here is recorded in the audit log.
           </DialogDescription>
         </DialogHeader>
 
@@ -156,6 +156,10 @@ export function KennelAttributionDialog({
                 placeholder="Change primary kennel…"
                 excludeCodes={primary ? [primary.kennelCode] : []}
               />
+              <p className="text-xs text-muted-foreground">
+                Picking another kennel moves this event there
+                {primary ? ` and removes ${primary.shortName}` : ""}.
+              </p>
             </div>
 
             {/* Co-hosts */}

--- a/src/components/admin/KennelCombobox.tsx
+++ b/src/components/admin/KennelCombobox.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type KennelComboboxOption = {
+  kennelCode: string;
+  shortName: string;
+  fullName: string;
+};
+
+interface KennelComboboxProps {
+  readonly kennels: readonly KennelComboboxOption[];
+  /** Currently selected kennelCode, if any. */
+  readonly value?: string;
+  readonly onSelect: (kennelCode: string) => void;
+  readonly placeholder?: string;
+  readonly disabled?: boolean;
+  /** kennelCodes to hide (e.g. kennels already attributed to the event). */
+  readonly excludeCodes?: readonly string[];
+}
+
+/**
+ * Searchable single-kennel picker (Popover + Command) keyed on `kennelCode`.
+ * Mirrors the RegionCombobox idiom. Used by the admin kennel-attribution dialog
+ * for both "change primary" and "add co-host".
+ */
+export function KennelCombobox({
+  kennels,
+  value,
+  onSelect,
+  placeholder = "Select kennel…",
+  disabled,
+  excludeCodes = [],
+}: KennelComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const exclude = new Set(excludeCodes);
+  const options = kennels.filter((k) => !exclude.has(k.kennelCode));
+  const selected = kennels.find((k) => k.kennelCode === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="h-8 w-full justify-between text-xs font-normal"
+        >
+          <span className="truncate">
+            {selected ? `${selected.shortName} — ${selected.fullName}` : placeholder}
+          </span>
+          <ChevronsUpDown className="ml-1 h-3 w-3 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search kennels…" className="h-8 text-xs" />
+          <CommandList>
+            <CommandEmpty>No kennel found.</CommandEmpty>
+            {options.map((k) => (
+              <CommandItem
+                key={k.kennelCode}
+                value={`${k.shortName} ${k.fullName} ${k.kennelCode}`}
+                onSelect={() => {
+                  onSelect(k.kennelCode);
+                  setOpen(false);
+                }}
+              >
+                <Check
+                  className={cn(
+                    "mr-2 h-3 w-3",
+                    value === k.kennelCode ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                <span className="text-xs font-medium">{k.shortName}</span>
+                <span className="ml-1 truncate text-xs text-muted-foreground">
+                  — {k.fullName}
+                </span>
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/admin/SeriesLinkDialog.tsx
+++ b/src/components/admin/SeriesLinkDialog.tsx
@@ -76,6 +76,7 @@ export function SeriesLinkDialog({
     const q = query.trim();
     if (q.length < 2) {
       setResults([]);
+      setSearching(false);
       return;
     }
     let cancelled = false;

--- a/src/components/admin/SeriesLinkDialog.tsx
+++ b/src/components/admin/SeriesLinkDialog.tsx
@@ -104,7 +104,7 @@ export function SeriesLinkDialog({
         toast.error(r.error);
         return;
       }
-      toast.success(`Linked ${r.kennelName} — ${formatDateLong(r.date)} to umbrella`);
+      toast.success(`Added ${r.kennelName} — ${formatDateLong(r.date)} to the series`);
       onOpenChange(false);
       router.refresh();
     });
@@ -127,16 +127,19 @@ export function SeriesLinkDialog({
             >
               <Layers className="h-3.5 w-3.5 text-muted-foreground" />
             </span>
-            <DialogTitle>Link to umbrella</DialogTitle>
+            <DialogTitle>Add to a multi-day series</DialogTitle>
           </div>
           <DialogDescription className="pt-2">
-            Search for the umbrella (series-parent) event to attach this event
-            under. The umbrella is promoted to a series parent automatically.
+            Pick the parent event for the series (the one that spans the whole
+            weekend or campout). The event below becomes a day within it.
           </DialogDescription>
         </DialogHeader>
 
         {event && (
           <div className="rounded-lg border bg-muted/40 p-3 space-y-1">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Adding this event
+            </p>
             <div className="flex items-baseline justify-between gap-3">
               <span className="font-medium">{event.kennelName}</span>
               <span className="text-sm text-muted-foreground">
@@ -183,7 +186,7 @@ export function SeriesLinkDialog({
                 <span className="truncate text-xs">{r.title || "Untitled"}</span>
                 {r.isSeriesParent && (
                   <Badge variant="secondary" className="ml-auto text-[10px]">
-                    umbrella
+                    existing series
                   </Badge>
                 )}
               </CommandItem>

--- a/src/components/admin/SeriesLinkDialog.tsx
+++ b/src/components/admin/SeriesLinkDialog.tsx
@@ -1,0 +1,202 @@
+"use client";
+/* eslint-disable react-hooks/set-state-in-effect -- debounced search resets + writes results inside effects; key-based remount adds no benefit for this single-instance dialog */
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Layers, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Badge } from "@/components/ui/badge";
+import {
+  searchEventsForUmbrella,
+  linkChildToUmbrella,
+} from "@/app/admin/events/actions";
+import { formatDateLong } from "@/lib/format";
+import { toast } from "sonner";
+
+interface UmbrellaCandidate {
+  id: string;
+  date: string;
+  kennelName: string;
+  title: string | null;
+  isSeriesParent: boolean;
+}
+
+interface SeriesLinkDialogProps {
+  readonly event: {
+    readonly id: string;
+    readonly title: string | null;
+    readonly date: string;
+    readonly kennelName: string;
+  } | null;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Admin dialog to attach an event as a child of an umbrella (series parent),
+ * #1679. Searches across all events (not just the current page) via the
+ * `searchEventsForUmbrella` server action, debounced. Picking a candidate calls
+ * `linkChildToUmbrella` and closes on success.
+ */
+export function SeriesLinkDialog({
+  event,
+  open,
+  onOpenChange,
+}: SeriesLinkDialogProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<UmbrellaCandidate[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  // Reset state when the dialog opens for a new event.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setResults([]);
+    }
+  }, [open, event?.id]);
+
+  // Debounced search.
+  useEffect(() => {
+    if (!open) return;
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      return;
+    }
+    let cancelled = false;
+    setSearching(true);
+    const handle = setTimeout(async () => {
+      const r = await searchEventsForUmbrella(q, event?.id);
+      if (cancelled) return;
+      setSearching(false);
+      if ("error" in r) {
+        toast.error(r.error);
+        return;
+      }
+      setResults(r.events);
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, open, event?.id]);
+
+  function handlePick(umbrellaId: string) {
+    if (!event) return;
+    startTransition(async () => {
+      const r = await linkChildToUmbrella(event.id, umbrellaId);
+      if ("error" in r) {
+        toast.error(r.error);
+        return;
+      }
+      toast.success(`Linked ${r.kennelName} — ${formatDateLong(r.date)} to umbrella`);
+      onOpenChange(false);
+      router.refresh();
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (isPending) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <span
+              aria-hidden
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md border bg-muted"
+            >
+              <Layers className="h-3.5 w-3.5 text-muted-foreground" />
+            </span>
+            <DialogTitle>Link to umbrella</DialogTitle>
+          </div>
+          <DialogDescription className="pt-2">
+            Search for the umbrella (series-parent) event to attach this event
+            under. The umbrella is promoted to a series parent automatically.
+          </DialogDescription>
+        </DialogHeader>
+
+        {event && (
+          <div className="rounded-lg border bg-muted/40 p-3 space-y-1">
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="font-medium">{event.kennelName}</span>
+              <span className="text-sm text-muted-foreground">
+                {formatDateLong(event.date)}
+              </span>
+            </div>
+            {event.title && (
+              <p className="text-sm text-muted-foreground line-clamp-2">
+                {event.title}
+              </p>
+            )}
+          </div>
+        )}
+
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search by title or kennel…"
+            value={query}
+            onValueChange={setQuery}
+            className="text-xs"
+          />
+          <CommandList>
+            <CommandEmpty>
+              {searching
+                ? "Searching…"
+                : query.trim().length < 2
+                  ? "Type at least 2 characters."
+                  : "No matching events."}
+            </CommandEmpty>
+            {results.map((r) => (
+              <CommandItem
+                key={r.id}
+                value={r.id}
+                disabled={isPending}
+                onSelect={() => handlePick(r.id)}
+                className="flex items-center gap-2"
+              >
+                <span className="text-xs text-muted-foreground whitespace-nowrap">
+                  {formatDateLong(r.date)}
+                </span>
+                <Badge variant="outline" className="text-xs">
+                  {r.kennelName}
+                </Badge>
+                <span className="truncate text-xs">{r.title || "Untitled"}</span>
+                {r.isSeriesParent && (
+                  <Badge variant="secondary" className="ml-auto text-[10px]">
+                    umbrella
+                  </Badge>
+                )}
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+
+        {isPending && (
+          <p className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden /> Linking…
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/misman/audit.ts
+++ b/src/lib/misman/audit.ts
@@ -16,7 +16,12 @@ export type AuditAction =
   | "import"
   | "hare_sync"
   | "cancel"
-  | "uncancel";
+  | "uncancel"
+  | "link_series"
+  | "unlink_series"
+  | "reattribute_kennel"
+  | "add_cohost"
+  | "remove_cohost";
 
 /** A single entry in the KennelAttendance audit log (stored as JSON array). */
 export interface AuditLogEntry {


### PR DESCRIPTION
## What

Two admin maintenance flows that let an admin fix series/kennel mis-classifications from the `/admin/events` UI in <30s — previously these required a SQL shell.

### Umbrella series link/unlink — Closes #1679
- **`linkChildToUmbrella(childEventId, umbrellaEventId)`** — sets `Event.parentEventId`, promotes the umbrella to `isSeriesParent`, and keeps the umbrella's `endDate` covering its current children (`syncUmbrellaEndDate`) so the public series-header date range stays correct. Enforces a strict 2-level tree (no grandparents/grandchildren) and **rejects relinking a child already under a *different* umbrella** (unlink-first), so the old umbrella's cached series view never silently orphans.
- **`unlinkChildFromUmbrella(childEventId)`** — clears `parentEventId` and resyncs the old umbrella's range from its remaining children.
- **`searchEventsForUmbrella(query, excludeId?)`** — read-only, admin-gated; backs a debounced cross-page search combobox.

### Kennel attribution — Closes #1680
- **`reattributeEventKennel(eventId, newKennelCode)`** — changes the primary kennel (a move): deletes the old primary `EventKennel` row **before** promoting/creating the new one (respects the partial unique index `EventKennel(eventId) WHERE isPrimary = true`), and mirrors `Event.kennelId`.
- **`addCoHostKennel` / `removeCoHostKennel`** — manage non-primary co-host rows; remove refuses the primary (use Change kennel instead).

### Cross-cutting
- All mutations are **`getAdminUser()`-gated**, run inside a `$transaction` with a `SELECT … FOR UPDATE` row lock (shared `lockEvent` helper), and **append to `Event.adminAuditLog`** (`appendAuditLog`, mirroring `adminCancelEvent`).
- **UI**: per-row "⋯" dropdown in `EventTable` opens a kennel-attribution dialog (combobox-driven change-primary / add / remove co-host) and an umbrella-link dialog; child/umbrella indicator badges + co-host count on the kennel cell.

## Notes
- **No fingerprint recomputation**: Events carry no fingerprint — fingerprints live on the immutable `RawEvent` and are independent of `kennelId`/`parentEventId`. The original task's "re-fingerprint" instruction does not apply.
- **No migration**: `EventKennel`, `Event.adminAuditLog`, `parentEventId`, `isSeriesParent`, `endDate` all already exist.
- **Out of scope** (issues' fuller "proposed shape", deferred): promote/demote series-parent shortcuts, swap-primary-with-co-host, a dedicated `/admin/events/[id]` page.

## Review
- `/codex:adversarial-review` → 2 findings, both fixed (stale-old-umbrella on relink; umbrella `endDate` maintenance on link/unlink).
- `/simplify` → applied `lockEvent` helper, parallelized independent reads, pushed primary-first ordering into SQL, generic `runMutation`. Skipped speculative cross-file refactors.

## Verification
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (7742 passed; 39 new unit tests covering permission/validation/success for all six actions).
- Full browser smoke deferred: `/admin/events` is Clerk-admin-gated (interactive OAuth) and a safe smoke needs a seeded local DB — not available in the automated session. Logic is covered by the new unit tests + the heavily-tested `adminCancelEvent` pattern they mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)