### PR TITLE
feat(backfill): Melbourne/NCH3/LBH historical backfills + nch3.com source

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3057,6 +3057,21 @@ export const SOURCES = [
       },
       kennelCodes: ["sdh3", "clh3-sd", "ljh3", "nch3-sd", "irh3-sd", "humpin-sd", "fmh3-sd", "hah3-sd", "mh4-sd", "drh3-sd"],
     },
+    // NCH3 official microsite — a single "current run" page (#1765). Richer
+    // than the SDH3 hareline for the live run (hares/location/cost/trail type)
+    // but it enumerates only ONE event, so `upcomingOnly: true` keeps reconcile
+    // from cancelling the many SDH3-sourced NCH3 events it can't see. NCH3 stays
+    // primarily tracked via "SDH3 Hareline"; this is a supplemental enrichment.
+    {
+      name: "NCH3 Official Microsite",
+      url: "https://nch3.com/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 7,
+      scrapeFreq: "weekly",
+      scrapeDays: 30,
+      config: { upcomingOnly: true },
+      kennelCodes: ["nch3-sd"],
+    },
     // ===== OHIO =====
     // --- Cleveland (Meetup) ---
     {

--- a/scripts/backfill-lbh-phx-history-completion.test.ts
+++ b/scripts/backfill-lbh-phx-history-completion.test.ts
@@ -16,13 +16,14 @@ const CDX = [
 describe("parseCdxRows", () => {
   const snaps = parseCdxRows(CDX);
 
-  it("keeps only real lbh-<N> slugs, deduped to the latest snapshot", () => {
+  it("keeps only real lbh-<N> slugs", () => {
     expect(snaps.map((s) => s.runNumber).sort((a, b) => a - b)).toEqual([511, 512, 637]);
   });
 
-  it("picks the latest timestamp per slug", () => {
+  it("carries all captures per slug, newest first", () => {
     const s512 = snaps.find((s) => s.runNumber === 512)!;
-    expect(s512.timestamp).toBe("20220220151554");
+    // both 200 captures preserved (no collapse), sorted newest→oldest
+    expect(s512.timestamps).toEqual(["20220220151554", "20220101000000"]);
   });
 
   it("derives the canonical phoenixhhh.org sourceUrl from the slug", () => {

--- a/scripts/backfill-lbh-phx-history-completion.test.ts
+++ b/scripts/backfill-lbh-phx-history-completion.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { parseCdxRows, extractBodyDate } from "./backfill-lbh-phx-history-completion";
+
+const CDX = [
+  "https://www.phoenixhhh.org/?event=lbh-511-krummy-wineburgers 20220405115701 200",
+  "https://www.phoenixhhh.org/?event=lbh-512-chi-chi-fucked-up-my-hambone 20220220151554 200",
+  // newer snapshot of the same slug — should win over the older one below
+  "https://www.phoenixhhh.org/?event=lbh-512-chi-chi-fucked-up-my-hambone 20220101000000 200",
+  "https://www.phoenixhhh.org/?event=lbh-637-its-all-coming-up-bi-holer 20230110120000 200",
+  // non-numbered / meeting slugs must be dropped
+  "https://www.phoenixhhh.org/?event=lbh-special-event 20220321154944 200",
+  "https://www.phoenixhhh.org/?event=lbh3-mm-meeting 20220326174511 200",
+  "https://www.phoenixhhh.org/?event=hump-d-hash-9 20220423053706 200",
+].join("\n");
+
+describe("parseCdxRows", () => {
+  const snaps = parseCdxRows(CDX);
+
+  it("keeps only real lbh-<N> slugs, deduped to the latest snapshot", () => {
+    expect(snaps.map((s) => s.runNumber).sort((a, b) => a - b)).toEqual([511, 512, 637]);
+  });
+
+  it("picks the latest timestamp per slug", () => {
+    const s512 = snaps.find((s) => s.runNumber === 512)!;
+    expect(s512.timestamp).toBe("20220220151554");
+  });
+
+  it("derives the canonical phoenixhhh.org sourceUrl from the slug", () => {
+    const s511 = snaps.find((s) => s.runNumber === 511)!;
+    expect(s511.original).toBe("https://www.phoenixhhh.org/?event=lbh-511-krummy-wineburgers");
+  });
+});
+
+describe("extractBodyDate", () => {
+  it("reads the first MM/DD/YYYY from entry-content as UTC-noon date", () => {
+    const html = `<article><div class="entry-content">
+      <p>Date(s) - Monday - 05/25/20266:30 pm - 9:30 pm Location Backyards</p></div></article>`;
+    expect(extractBodyDate(html)).toBe("2026-05-25");
+  });
+
+  it("returns null when no date is present (skip, never guess from snapshot ts)", () => {
+    expect(extractBodyDate(`<div class="entry-content">no date here</div>`)).toBeNull();
+  });
+
+  it("rejects an out-of-range month", () => {
+    expect(extractBodyDate(`<div class="entry-content">13/40/2026</div>`)).toBeNull();
+  });
+});

--- a/scripts/backfill-lbh-phx-history-completion.ts
+++ b/scripts/backfill-lbh-phx-history-completion.ts
@@ -1,0 +1,205 @@
+/**
+ * LBH-PHX (Phoenix Lost Boobs Hash) pre-2023 history completion — issue #1595.
+ *
+ * Context: the cycle-11 `backfill-lbh-phx-history.ts` recovered 2023-10 → today
+ * by walking phoenixhhh.org's Big Ass Calendar. Everything earlier is gone from
+ * the wp-events-manager database — pre-2023 calendar pages (re-confirmed live
+ * on 2026-05-29) return empty grids, and HashRego 404s for LBH. The only public
+ * trace of pre-2023 runs is the Internet Archive, which snapshotted a handful of
+ * individual `phoenixhhh.org/?event=lbh-NNN-…` detail pages.
+ *
+ * This script harvests those archived detail pages:
+ *   1. Query the Wayback CDX API for `?event=lbh-*` snapshots (HTTP 200 only).
+ *   2. Keep slugs of the form `lbh-<runNumber>-…` (drops `lbh-special-event`,
+ *      `lbh3-mm-meeting`, etc.), one snapshot per slug (latest).
+ *   3. Fetch each via the `…/web/<ts>id_/<url>` RAW form — `id_` returns the
+ *      UNREWRITTEN original HTML so the wp-events-manager template parses
+ *      cleanly (no injected Wayback banner/link-rewriting).
+ *   4. Run number comes from the SLUG; the event date is parsed from the page
+ *      body's `MM/DD/YYYY` (NEVER the CDX snapshot timestamp — that's the crawl
+ *      date). Rows with no parseable body date are skipped. Hares / location /
+ *      start time / cost reuse the exported `parseDetailPage` from the parent
+ *      script.
+ *
+ * Yield ceiling: the Archive holds only ~10-13 LBH detail pages (runs in the
+ * #511-517 and #637-639 ranges), so this recovers a small slice of the ~630
+ * missing pre-2023 runs. The bulk requires a WordPress admin CSV export from
+ * the LBH kennel (no public path). **Issue #1595 stays OPEN** after this runs.
+ *
+ * Bound to "Phoenix H3 Big Ass Calendar" (trust 8 HTML scraper — the corrected
+ * binding from `cleanup-lbh-misbound-rawevents.ts`; NOT the trust-7 ICS feed).
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-lbh-phx-history-completion.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-lbh-phx-history-completion.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import type { RawEventData } from "@/adapters/types";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { parseDetailPage } from "./backfill-lbh-phx-history";
+
+const SOURCE_NAME = "Phoenix H3 Big Ass Calendar";
+const KENNEL_TAG = "lbh-phx";
+const KENNEL_TIMEZONE = "America/Phoenix";
+const ORIGIN = "https://www.phoenixhhh.org";
+
+const CDX_URL =
+  "https://web.archive.org/cdx/search/cdx?url=phoenixhhh.org&matchType=domain" +
+  "&output=text&collapse=urlkey&fl=original,timestamp,statuscode" +
+  "&filter=urlkey:.*event%3Dlbh.*&filter=statuscode:200";
+
+const BATCH_SIZE = 3;
+const POLITENESS_DELAY_MS = 600;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchText(url: string, attempts = 3): Promise<string | null> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" },
+        signal: AbortSignal.timeout(45_000),
+      });
+      if (res.ok) return await res.text();
+      // 4xx won't improve on retry; bail. 5xx (Wayback overload) → retry.
+      if (res.status < 500) return null;
+    } catch {
+      // network/timeout — fall through to retry
+    }
+    if (i < attempts - 1) await sleep(POLITENESS_DELAY_MS * (i + 1));
+  }
+  return null;
+}
+
+interface Snapshot {
+  slug: string;
+  runNumber: number;
+  timestamp: string;
+  /** Original phoenixhhh.org URL (used as the canonical sourceUrl). */
+  original: string;
+}
+
+/** Parse CDX text rows into one latest snapshot per real `lbh-<N>` slug. */
+export function parseCdxRows(cdxText: string): Snapshot[] {
+  const bySlug = new Map<string, Snapshot>();
+  for (const line of cdxText.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [original, timestamp] = trimmed.split(/\s+/);
+    if (!original || !timestamp) continue;
+    const slugMatch = original.match(/[?&]event=([^&"'#]+)/i);
+    if (!slugMatch) continue;
+    const slug = slugMatch[1].toLowerCase();
+    // Only real numbered runs: `lbh-<digits>` (drops lbh-special-event,
+    // lbh3-mm-meeting, lbh3-…). Require the hyphen so "lbh3" can't match.
+    const runMatch = slug.match(/^lbh-(\d{1,4})(?:-|$)/);
+    if (!runMatch) continue;
+    const runNumber = Number.parseInt(runMatch[1], 10);
+    if (!Number.isFinite(runNumber) || runNumber <= 0) continue;
+    const prev = bySlug.get(slug);
+    if (!prev || timestamp > prev.timestamp) {
+      bySlug.set(slug, { slug, runNumber, timestamp, original: `${ORIGIN}/?event=${slug}` });
+    }
+  }
+  return [...bySlug.values()];
+}
+
+/**
+ * Extract the event date from an archived detail page body as `YYYY-MM-DD`
+ * (UTC noon). Reads the FIRST `MM/DD/YYYY` inside the entry-content — the
+ * wp-events-manager `Date(s) - Weekday - MM/DD/YYYYH:MM pm` line. Returns null
+ * when absent so the caller can skip the row rather than guess. Exported for
+ * unit testing.
+ */
+export function extractBodyDate(html: string): string | null {
+  const $ = cheerio.load(html);
+  const text =
+    $(".entry-content").first().text() ||
+    $("article").first().text() ||
+    $("main").text() ||
+    $("body").text();
+  const m = text.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+  if (!m) return null;
+  const month = Number.parseInt(m[1], 10);
+  const day = Number.parseInt(m[2], 10);
+  const year = Number.parseInt(m[3], 10);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0)).toISOString().slice(0, 10);
+}
+
+/** Best-effort event title from the archived page, with the `LBH #N:` prefix
+ *  stripped to match the live calendar walker's title format (so an overlapping
+ *  event's canonical title doesn't regress to the prefixed form on merge).
+ *  Falls back to undefined → merge synthesizes "Lost Boobs Hash Trail #N". */
+function extractTitle(html: string): string | undefined {
+  const $ = cheerio.load(html);
+  const raw = ($(".entry-title").first().text() || $("h1").first().text() || "").replace(/\s+/g, " ").trim();
+  if (!raw) return undefined;
+  const stripped = raw.replace(/^LBH\s*#?\s*\d+\s*[:\-–]?\s*/i, "").trim();
+  return stripped.length > 0 ? stripped : raw;
+}
+
+async function harvestSnapshot(snap: Snapshot): Promise<RawEventData | null> {
+  const rawUrl = `https://web.archive.org/web/${snap.timestamp}id_/${snap.original}`;
+  const html = await fetchText(rawUrl);
+  if (!html) {
+    console.warn(`  ✗ #${snap.runNumber}: snapshot fetch failed (${snap.slug})`);
+    return null;
+  }
+  const date = extractBodyDate(html);
+  if (!date) {
+    console.warn(`  ✗ #${snap.runNumber}: no body date found (${snap.slug}) — skipped`);
+    return null;
+  }
+  const detail = parseDetailPage(html);
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber: snap.runNumber,
+    title: extractTitle(html),
+    hares: detail.hares,
+    location: detail.location,
+    startTime: detail.startTime,
+    cost: detail.cost,
+    sourceUrl: snap.original,
+  };
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log("  Querying Wayback CDX for archived LBH detail pages...");
+  const cdx = await fetchText(CDX_URL);
+  if (!cdx) {
+    throw new Error("Wayback CDX query failed (no response after retries).");
+  }
+  const snapshots = parseCdxRows(cdx);
+  console.log(`  ${snapshots.length} archived lbh-<N> detail page(s) found.`);
+
+  const events: RawEventData[] = [];
+  for (let i = 0; i < snapshots.length; i += BATCH_SIZE) {
+    const batch = snapshots.slice(i, i + BATCH_SIZE);
+    const results = await Promise.allSettled(batch.map(harvestSnapshot));
+    for (const r of results) {
+      if (r.status === "fulfilled" && r.value) events.push(r.value);
+    }
+    await sleep(POLITENESS_DELAY_MS);
+  }
+  console.log(`  Recovered ${events.length} event(s) with a parseable body date.`);
+  return events;
+}
+
+if (process.argv[1]?.endsWith("backfill-lbh-phx-history-completion.ts")) {
+  runBackfillScript({
+    sourceName: SOURCE_NAME,
+    kennelTimezone: KENNEL_TIMEZONE,
+    label: "Harvesting Wayback-archived LBH detail pages (pre-2023 completion)",
+    fetchEvents,
+  }).catch((err: unknown) => {
+    console.error("FAILED:", err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/scripts/backfill-lbh-phx-history-completion.ts
+++ b/scripts/backfill-lbh-phx-history-completion.ts
@@ -105,12 +105,12 @@ export function parseCdxRows(cdxText: string): Snapshot[] {
     if (!trimmed) continue;
     const [original, timestamp] = trimmed.split(/\s+/);
     if (!original || !timestamp) continue;
-    const slugMatch = original.match(/[?&]event=([^&"'#]+)/i);
+    const slugMatch = /[?&]event=([^&"'#]+)/i.exec(original);
     if (!slugMatch) continue;
     const slug = slugMatch[1].toLowerCase();
     // Only real numbered runs: `lbh-<digits>` (drops lbh-special-event,
     // lbh3-mm-meeting, lbh3-…). Require the hyphen so "lbh3" can't match.
-    const runMatch = slug.match(/^lbh-(\d{1,4})(?:-|$)/);
+    const runMatch = /^lbh-(\d{1,4})(?:-|$)/.exec(slug);
     if (!runMatch) continue;
     const runNumber = Number.parseInt(runMatch[1], 10);
     if (!Number.isFinite(runNumber) || runNumber <= 0) continue;

--- a/scripts/backfill-lbh-phx-history-completion.ts
+++ b/scripts/backfill-lbh-phx-history-completion.ts
@@ -38,6 +38,7 @@
 import "dotenv/config";
 import * as cheerio from "cheerio";
 import type { RawEventData } from "@/adapters/types";
+import { safeFetch } from "@/adapters/safe-fetch";
 import { runBackfillScript } from "./lib/backfill-runner";
 import { parseDetailPage } from "./backfill-lbh-phx-history";
 
@@ -61,7 +62,10 @@ function sleep(ms: number): Promise<void> {
 async function fetchText(url: string, attempts = 3): Promise<string | null> {
   for (let i = 0; i < attempts; i++) {
     try {
-      const res = await fetch(url, {
+      // safeFetch (not bare fetch) applies the repo's SSRF URL validation —
+      // the Wayback URLs are built from CDX response data, so route them
+      // through the sanctioned client.
+      const res = await safeFetch(url, {
         headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" },
         signal: AbortSignal.timeout(45_000),
       });
@@ -129,7 +133,10 @@ export function extractBodyDate(html: string): string | null {
   const day = Number.parseInt(m[2], 10);
   const year = Number.parseInt(m[3], 10);
   if (month < 1 || month > 12 || day < 1 || day > 31) return null;
-  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0)).toISOString().slice(0, 10);
+  const d = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  // Reject overflow dates (e.g. 2/30 → Mar 2) — Date.UTC silently rolls over.
+  if (d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return null;
+  return d.toISOString().slice(0, 10);
 }
 
 /** Best-effort event title from the archived page, with the `LBH #N:` prefix
@@ -140,7 +147,15 @@ function extractTitle(html: string): string | undefined {
   const $ = cheerio.load(html);
   const raw = ($(".entry-title").first().text() || $("h1").first().text() || "").replace(/\s+/g, " ").trim();
   if (!raw) return undefined;
-  const stripped = raw.replace(/^LBH\s*#?\s*\d+\s*[:\-–]?\s*/i, "").trim();
+  // Strip an "LBH #N:" / "LBH# N -" prefix via single-quantifier passes rather
+  // than one `^LBH\s*#?\s*\d+\s*[:\-–]?\s*` regex (adjacent `\s*` trips S5852).
+  let t = raw;
+  if (/^lbh/i.test(t)) {
+    t = t.slice("lbh".length).replace(/^[\s#]+/, ""); // "LBH" + spaces/#
+    t = t.replace(/^\d+/, ""); // run number
+    t = t.replace(/^[\s:–-]+/, ""); // trailing separators
+  }
+  const stripped = t.trim();
   return stripped.length > 0 ? stripped : raw;
 }
 

--- a/scripts/backfill-lbh-phx-history-completion.ts
+++ b/scripts/backfill-lbh-phx-history-completion.ts
@@ -47,13 +47,19 @@ const KENNEL_TAG = "lbh-phx";
 const KENNEL_TIMEZONE = "America/Phoenix";
 const ORIGIN = "https://www.phoenixhhh.org";
 
+// No `collapse=urlkey`: we want EVERY 200 capture per event URL, not just the
+// first. A given LBH page was re-archived several times, and the newest capture
+// occasionally lacks the run details an earlier one preserved — harvestSnapshot
+// falls back across captures, so we must see them all (Codex P2 on #1805).
 const CDX_URL =
   "https://web.archive.org/cdx/search/cdx?url=phoenixhhh.org&matchType=domain" +
-  "&output=text&collapse=urlkey&fl=original,timestamp,statuscode" +
+  "&output=text&fl=original,timestamp,statuscode" +
   "&filter=urlkey:.*event%3Dlbh.*&filter=statuscode:200";
 
 const BATCH_SIZE = 3;
 const POLITENESS_DELAY_MS = 600;
+/** Max captures to try per slug before giving up (newest first). */
+const MAX_CAPTURES_PER_SLUG = 4;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -83,14 +89,17 @@ async function fetchText(url: string, attempts = 3): Promise<string | null> {
 interface Snapshot {
   slug: string;
   runNumber: number;
-  timestamp: string;
+  /** All archived 200-capture timestamps for this slug, newest first. */
+  timestamps: string[];
   /** Original phoenixhhh.org URL (used as the canonical sourceUrl). */
   original: string;
 }
 
-/** Parse CDX text rows into one latest snapshot per real `lbh-<N>` slug. */
+/** Parse CDX text rows into one snapshot per real `lbh-<N>` slug, carrying ALL
+ *  capture timestamps (newest first) so the harvester can fall back across
+ *  captures when the newest lacks the run details. */
 export function parseCdxRows(cdxText: string): Snapshot[] {
-  const bySlug = new Map<string, Snapshot>();
+  const bySlug = new Map<string, { runNumber: number; timestamps: Set<string> }>();
   for (const line of cdxText.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -105,12 +114,19 @@ export function parseCdxRows(cdxText: string): Snapshot[] {
     if (!runMatch) continue;
     const runNumber = Number.parseInt(runMatch[1], 10);
     if (!Number.isFinite(runNumber) || runNumber <= 0) continue;
-    const prev = bySlug.get(slug);
-    if (!prev || timestamp > prev.timestamp) {
-      bySlug.set(slug, { slug, runNumber, timestamp, original: `${ORIGIN}/?event=${slug}` });
+    let entry = bySlug.get(slug);
+    if (!entry) {
+      entry = { runNumber, timestamps: new Set() };
+      bySlug.set(slug, entry);
     }
+    entry.timestamps.add(timestamp);
   }
-  return [...bySlug.values()];
+  return [...bySlug.entries()].map(([slug, { runNumber, timestamps }]) => ({
+    slug,
+    runNumber,
+    timestamps: [...timestamps].sort((a, b) => b.localeCompare(a)),
+    original: `${ORIGIN}/?event=${slug}`,
+  }));
 }
 
 /**
@@ -160,29 +176,31 @@ function extractTitle(html: string): string | undefined {
 }
 
 async function harvestSnapshot(snap: Snapshot): Promise<RawEventData | null> {
-  const rawUrl = `https://web.archive.org/web/${snap.timestamp}id_/${snap.original}`;
-  const html = await fetchText(rawUrl);
-  if (!html) {
-    console.warn(`  ✗ #${snap.runNumber}: snapshot fetch failed (${snap.slug})`);
-    return null;
+  // Try captures newest→oldest until one yields a parseable body date — a thin
+  // or error-shaped capture no longer dead-ends the run when another capture
+  // carries the details (Codex P2 on #1805).
+  const candidates = snap.timestamps.slice(0, MAX_CAPTURES_PER_SLUG);
+  for (let i = 0; i < candidates.length; i++) {
+    if (i > 0) await sleep(POLITENESS_DELAY_MS);
+    const html = await fetchText(`https://web.archive.org/web/${candidates[i]}id_/${snap.original}`);
+    if (!html) continue;
+    const date = extractBodyDate(html);
+    if (!date) continue;
+    const detail = parseDetailPage(html);
+    return {
+      date,
+      kennelTags: [KENNEL_TAG],
+      runNumber: snap.runNumber,
+      title: extractTitle(html),
+      hares: detail.hares,
+      location: detail.location,
+      startTime: detail.startTime,
+      cost: detail.cost,
+      sourceUrl: snap.original,
+    };
   }
-  const date = extractBodyDate(html);
-  if (!date) {
-    console.warn(`  ✗ #${snap.runNumber}: no body date found (${snap.slug}) — skipped`);
-    return null;
-  }
-  const detail = parseDetailPage(html);
-  return {
-    date,
-    kennelTags: [KENNEL_TAG],
-    runNumber: snap.runNumber,
-    title: extractTitle(html),
-    hares: detail.hares,
-    location: detail.location,
-    startTime: detail.startTime,
-    cost: detail.cost,
-    sourceUrl: snap.original,
-  };
+  console.warn(`  ✗ #${snap.runNumber}: no capture with a parseable body date (${snap.slug}) — skipped`);
+  return null;
 }
 
 async function fetchEvents(): Promise<RawEventData[]> {

--- a/scripts/backfill-mel-bike-hash-history.ts
+++ b/scripts/backfill-mel-bike-hash-history.ts
@@ -20,11 +20,16 @@
 
 import { backfillMelMeetupKennel } from "./lib/mel-meetup-history-backfill";
 
-/** True for bike-hash titles: leading "Bike …" or a leading numbered "Ride #N". */
+/** True for bike-hash titles: leading "Bike …" or a leading numbered "Ride #N".
+ *  The "Ride #N" check is procedural (strip "ride", then leading spaces/#, then
+ *  require a digit) rather than `/^ride\s*#?\s*\d/` — the adjacent `\s*#?\s*`
+ *  quantifiers trip Sonar S5852's backtracking-shape check. */
 export function isBikeHashTitle(title: string): boolean {
   const t = title.trimStart();
   if (/^bike\b/i.test(t)) return true;
-  return /^ride\s*#?\s*\d/i.test(t);
+  if (!/^ride\b/i.test(t)) return false;
+  const rest = t.slice("ride".length).replace(/^[\s#]+/, "");
+  return rest.length > 0 && rest[0] >= "0" && rest[0] <= "9";
 }
 
 if (process.argv[1]?.endsWith("backfill-mel-bike-hash-history.ts")) {

--- a/scripts/backfill-mel-bike-hash-history.ts
+++ b/scripts/backfill-mel-bike-hash-history.ts
@@ -1,0 +1,39 @@
+/**
+ * One-shot historical backfill for Melbourne Bike Hash (#1752).
+ *
+ * HashTracks tracked only 4 bike-hash events (the recent `#132-#134` rows the
+ * live Meetup adapter caught while upcoming); the committed Meetup history
+ * batches carry ~48 bike-hash events back to 2021. This replays them through
+ * the merge pipeline. See `scripts/lib/mel-meetup-history-backfill.ts`.
+ *
+ * Matcher: bike-hash titles take several shapes the live source's
+ * `^\s*Bike\s+hash\b` pattern does NOT all catch —
+ *   "Bike hash ride #132", "Bike Hash#75", "Bike Ride #88"   (all start "Bike")
+ *   "Ride #130 New Year, Old Favourites"                      ("Ride #N" form)
+ * so we match a leading "Bike" OR a leading numbered "Ride #N".
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-mel-bike-hash-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-mel-bike-hash-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import { backfillMelMeetupKennel } from "./lib/mel-meetup-history-backfill";
+
+/** True for bike-hash titles: leading "Bike …" or a leading numbered "Ride #N". */
+export function isBikeHashTitle(title: string): boolean {
+  const t = title.trimStart();
+  if (/^bike\b/i.test(t)) return true;
+  return /^ride\s*#?\s*\d/i.test(t);
+}
+
+if (process.argv[1]?.endsWith("backfill-mel-bike-hash-history.ts")) {
+  backfillMelMeetupKennel({
+    kennelCode: "melbourne-bike-hash",
+    matcher: isBikeHashTitle,
+    label: "Replaying Melbourne New Moon Meetup batches for Bike Hash entries",
+  }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/backfill-mel-city-h3-history.ts
+++ b/scripts/backfill-mel-city-h3-history.ts
@@ -1,0 +1,38 @@
+/**
+ * One-shot historical backfill for Melbourne City H3 (#1755).
+ *
+ * HashTracks tracked only 1 city-hash event (the recent City Hash Beer
+ * Marathon the live adapter caught upcoming); the committed Meetup history
+ * batches carry ~19 City H3 events spanning 2023-2024. This replays them
+ * through the merge pipeline. See `scripts/lib/mel-meetup-history-backfill.ts`.
+ *
+ * Matcher: every City H3 title contains "City Hash" in some form —
+ *   "City Hash Run#43", "Melbourne City Hash 1st Anniversary Run",
+ *   "Beer Run# 26 from Melbourne City Hash"
+ * — so a case-insensitive "city hash" substring is the inclusive form (the
+ * live source's anchored `^\s*(?:Melbourne\s+)?City\s+Hash\b` misses the
+ * "Beer Run#.. from Melbourne City Hash" variant).
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-mel-city-h3-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-mel-city-h3-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import { backfillMelMeetupKennel } from "./lib/mel-meetup-history-backfill";
+
+/** True for City H3 titles: contains "city hash" (case-insensitive). */
+export function isCityHashTitle(title: string): boolean {
+  return /city\s*hash/i.test(title);
+}
+
+if (process.argv[1]?.endsWith("backfill-mel-city-h3-history.ts")) {
+  backfillMelMeetupKennel({
+    kennelCode: "melbourne-city-h3",
+    matcher: isCityHashTitle,
+    label: "Replaying Melbourne New Moon Meetup batches for City H3 entries",
+  }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/backfill-mel-meetup-history.test.ts
+++ b/scripts/backfill-mel-meetup-history.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { isBikeHashTitle } from "./backfill-mel-bike-hash-history";
+import { isCityHashTitle } from "./backfill-mel-city-h3-history";
+import {
+  buildKennelEvents,
+  isImportablePlaceholder,
+} from "./lib/mel-meetup-history-backfill";
+
+describe("isBikeHashTitle", () => {
+  it.each([
+    ["Bike hash ride #132", true],
+    ["Bike Hash#75 - Coochie Coo in Castlemaine", true],
+    ["Bike Ride #88 - Two Fat Ladies hash", true],
+    ["Ride #130 New Year, Old Favourites", true],
+    ["Ride #102 Poison Ivy plays naughts and crosses", true],
+    ["Melbourne New Moon #174- Maggot @ Docklands", false],
+    ["Run No. 115", false],
+    ["City Hash Run#43 (Race The Tram)", false],
+    ["Full Moon Run No. 250", false],
+    ["Delinquents HHH No.38", false],
+  ])("%s → %s", (title, expected) => {
+    expect(isBikeHashTitle(title)).toBe(expected);
+  });
+});
+
+describe("isCityHashTitle", () => {
+  it.each([
+    ["City Hash Run#43 (Race The Tram)", true],
+    ["Melbourne City Hash 1st Anniversary Run", true],
+    ["Beer Run# 26 from Melbourne City Hash", true],
+    ["Melbourne City Hash#33 (Run & Beer)", true],
+    ["Bike hash ride #132", false],
+    ["Run No. 115", false],
+    ["Melbourne New Moon #173- Quick Lay", false],
+  ])("%s → %s", (title, expected) => {
+    expect(isCityHashTitle(title)).toBe(expected);
+  });
+});
+
+describe("isImportablePlaceholder", () => {
+  it.each([
+    ["LBH POSTPONED until further notice", true],
+    ["Run #50 CANCELLED", true],
+    ["Run #51 - NEEDS A HARE", true],
+    ["Every Wednesday @ 6:30pm from tbd", true],
+    ["Bike hash ride #132", false],
+    ["City Hash Run#43", false],
+  ])("%s → %s", (title, expected) => {
+    expect(isImportablePlaceholder(title)).toBe(expected);
+  });
+});
+
+describe("buildKennelEvents", () => {
+  const rows = [
+    { title: "Bike hash ride #132", date: "2026-02-22", startTime: "12:00", location: "Sandringham Station", url: "https://m/1" },
+    { title: "Ride #130 New Year, Old Favourites", date: "2026-01-18", startTime: "12:00", location: "Kaiju Beer & Pizza", url: "https://m/2" },
+    { title: "City Hash Run#54", date: "2024-02-15", startTime: "18:30", location: "13 Mitford St", url: "https://m/3" },
+    { title: "Run No. 115", date: "2021-04-10", startTime: "15:00", location: "Urban Alley", url: "https://m/4" },
+    { title: "Bike Hash CANCELLED", date: "2025-01-01", url: "https://m/5" },
+    // duplicate URL of row 1 — should collapse
+    { title: "Bike hash ride #132", date: "2026-02-22", startTime: "12:00", location: "Sandringham Station", url: "https://m/1" },
+  ];
+
+  it("filters to bike-hash, extracts run numbers, dedupes by url, drops placeholders", () => {
+    const events = buildKennelEvents(rows, "melbourne-bike-hash", isBikeHashTitle);
+    expect(events.map((e) => e.title)).toEqual([
+      "Bike hash ride #132",
+      "Ride #130 New Year, Old Favourites",
+    ]);
+    expect(events[0]).toMatchObject({
+      date: "2026-02-22",
+      kennelTags: ["melbourne-bike-hash"],
+      runNumber: 132,
+      startTime: "12:00",
+      location: "Sandringham Station",
+      sourceUrl: "https://m/1",
+    });
+    expect(events[1].runNumber).toBe(130);
+  });
+
+  it("filters to city-h3 independently", () => {
+    const events = buildKennelEvents(rows, "melbourne-city-h3", isCityHashTitle);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ title: "City Hash Run#54", runNumber: 54, kennelTags: ["melbourne-city-h3"] });
+  });
+});

--- a/scripts/backfill-nch3-microsite-event.ts
+++ b/scripts/backfill-nch3-microsite-event.ts
@@ -21,8 +21,7 @@
  */
 
 import "dotenv/config";
-import type { Source } from "@/generated/prisma/client";
-import type { Prisma } from "@/generated/prisma/client";
+import type { Source, Prisma } from "@/generated/prisma/client";
 import { prisma } from "@/lib/db";
 import { NCH3Adapter } from "@/adapters/html-scraper/nch3";
 import { reportAndApplyBackfill } from "./lib/backfill-runner";

--- a/scripts/backfill-nch3-microsite-event.ts
+++ b/scripts/backfill-nch3-microsite-event.ts
@@ -1,0 +1,116 @@
+/**
+ * Bootstrap + populate the NCH3 Official Microsite source (#1765).
+ *
+ * The nch3.com microsite exposes ONE "current run" event richer than the SDH3
+ * hareline (hares / location / cost / trail type). This script:
+ *   1. Ensures the "NCH3 Official Microsite" Source row + its nch3-sd
+ *      SourceKennel link exist (idempotent upsert). The canonical definition
+ *      lives in `prisma/seed-data/sources.ts`; a later `prisma db seed`
+ *      reconciles this row by (name, type) with no duplicate.
+ *   2. Scrapes the live page via `NCH3Adapter` (this is the mandatory live
+ *      adapter verification per .claude/rules/live-verification.md).
+ *   3. Routes the (now-past) current run through the merge pipeline.
+ *
+ * Reconcile-safety: the seeded source carries `config.upcomingOnly: true`, so a
+ * single-event scrape never cancels the many SDH3-sourced NCH3 events.
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-nch3-microsite-event.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-nch3-microsite-event.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import type { Source } from "@/generated/prisma/client";
+import type { Prisma } from "@/generated/prisma/client";
+import { prisma } from "@/lib/db";
+import { NCH3Adapter } from "@/adapters/html-scraper/nch3";
+import { reportAndApplyBackfill } from "./lib/backfill-runner";
+import { SOURCES } from "@/../prisma/seed-data/sources";
+
+const SOURCE_NAME = "NCH3 Official Microsite";
+const KENNEL_TIMEZONE = "America/Los_Angeles";
+
+// Single source of truth: the canonical row lives in prisma/seed-data/sources.ts.
+// We bootstrap from that definition so the row this script creates can't drift
+// from what `prisma db seed` later reconciles by (name, type). Resolve via a
+// throwing helper so the type narrows to non-undefined inside the functions.
+function requireSeed() {
+  const seed = SOURCES.find((s) => s.name === SOURCE_NAME && s.type === "HTML_SCRAPER");
+  if (!seed) {
+    throw new Error(`Seed definition for "${SOURCE_NAME}" not found in prisma/seed-data/sources.ts`);
+  }
+  return seed;
+}
+const SEED = requireSeed();
+const SCRAPE_DAYS = SEED.scrapeDays ?? 30;
+
+/** Find the source, or (apply only) create it + link its kennels from the seed
+ *  definition. Dry-run returns a synthetic row sufficient for `adapter.fetch`
+ *  (which only reads url). */
+async function resolveSource(apply: boolean): Promise<Source> {
+  const existing = await prisma.source.findFirst({
+    where: { name: SOURCE_NAME, type: "HTML_SCRAPER" },
+  });
+  if (existing) return existing;
+
+  if (!apply) {
+    console.log("  (dry run) source not yet in DB — using synthetic row for the live fetch.");
+    return { name: SEED.name, url: SEED.url, type: SEED.type } as unknown as Source;
+  }
+
+  const created = await prisma.source.create({
+    data: {
+      name: SEED.name,
+      url: SEED.url,
+      type: SEED.type,
+      trustLevel: SEED.trustLevel,
+      scrapeFreq: SEED.scrapeFreq,
+      scrapeDays: SEED.scrapeDays,
+      config: SEED.config as Prisma.InputJsonValue,
+    },
+  });
+  for (const code of SEED.kennelCodes) {
+    const kennel = await prisma.kennel.findUnique({ where: { kennelCode: code }, select: { id: true } });
+    if (!kennel) throw new Error(`Kennel "${code}" not found — cannot link the new source.`);
+    await prisma.sourceKennel.upsert({
+      where: { sourceId_kennelId: { sourceId: created.id, kennelId: kennel.id } },
+      update: {},
+      create: { sourceId: created.id, kennelId: kennel.id },
+    });
+  }
+  console.log(`  + Created source "${SOURCE_NAME}" and linked ${SEED.kennelCodes.join(", ")}.`);
+  return created;
+}
+
+async function main(): Promise<void> {
+  const apply = process.env.BACKFILL_APPLY === "1";
+  console.log(`NCH3 microsite backfill: source="${SOURCE_NAME}"`);
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
+
+  try {
+    const source = await resolveSource(apply);
+
+    console.log(`\n[1/2] Scraping ${SEED.url} via NCH3Adapter...`);
+    const result = await new NCH3Adapter().fetch(source, { days: SCRAPE_DAYS });
+    if (result.errors && result.errors.length > 0) {
+      console.warn(`  Adapter errors: ${result.errors.join("; ")}`);
+    }
+    console.log(`  Adapter returned ${result.events.length} event(s).`);
+
+    console.log("\n[2/2] Reporting + applying...");
+    await reportAndApplyBackfill({
+      apply,
+      sourceName: SOURCE_NAME,
+      events: result.events,
+      kennelTimezone: KENNEL_TIMEZONE,
+    });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-nch3-microsite-event.ts
+++ b/scripts/backfill-nch3-microsite-event.ts
@@ -52,24 +52,30 @@ async function resolveSource(apply: boolean): Promise<Source> {
   const existing = await prisma.source.findFirst({
     where: { name: SOURCE_NAME, type: "HTML_SCRAPER" },
   });
-  if (existing) return existing;
 
   if (!apply) {
+    if (existing) return existing;
     console.log("  (dry run) source not yet in DB — using synthetic row for the live fetch.");
     return { name: SEED.name, url: SEED.url, type: SEED.type } as unknown as Source;
   }
 
-  const created = await prisma.source.create({
-    data: {
-      name: SEED.name,
-      url: SEED.url,
-      type: SEED.type,
-      trustLevel: SEED.trustLevel,
-      scrapeFreq: SEED.scrapeFreq,
-      scrapeDays: SEED.scrapeDays,
-      config: SEED.config as Prisma.InputJsonValue,
-    },
-  });
+  const source =
+    existing ??
+    (await prisma.source.create({
+      data: {
+        name: SEED.name,
+        url: SEED.url,
+        type: SEED.type,
+        trustLevel: SEED.trustLevel,
+        scrapeFreq: SEED.scrapeFreq,
+        scrapeDays: SEED.scrapeDays,
+        config: SEED.config as Prisma.InputJsonValue,
+      },
+    }));
+
+  // Always (re)ensure the kennel links via idempotent upsert — covers a prior
+  // partial run that created the source but crashed before linking, which would
+  // otherwise trip reportAndApplyBackfill's "no SourceKennel links" preflight.
   const kennels = await prisma.kennel.findMany({
     where: { kennelCode: { in: SEED.kennelCodes } },
     select: { id: true, kennelCode: true },
@@ -79,13 +85,13 @@ async function resolveSource(apply: boolean): Promise<Source> {
     const kennelId = kennelIdByCode.get(code);
     if (!kennelId) throw new Error(`Kennel "${code}" not found — cannot link the new source.`);
     await prisma.sourceKennel.upsert({
-      where: { sourceId_kennelId: { sourceId: created.id, kennelId } },
+      where: { sourceId_kennelId: { sourceId: source.id, kennelId } },
       update: {},
-      create: { sourceId: created.id, kennelId },
+      create: { sourceId: source.id, kennelId },
     });
   }
-  console.log(`  + Created source "${SOURCE_NAME}" and linked ${SEED.kennelCodes.join(", ")}.`);
-  return created;
+  console.log(`  ${existing ? "✓ Ensured" : "+ Created"} source "${SOURCE_NAME}" + linked ${SEED.kennelCodes.join(", ")}.`);
+  return source;
 }
 
 async function main(): Promise<void> {

--- a/scripts/backfill-nch3-microsite-event.ts
+++ b/scripts/backfill-nch3-microsite-event.ts
@@ -70,13 +70,18 @@ async function resolveSource(apply: boolean): Promise<Source> {
       config: SEED.config as Prisma.InputJsonValue,
     },
   });
+  const kennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: SEED.kennelCodes } },
+    select: { id: true, kennelCode: true },
+  });
+  const kennelIdByCode = new Map(kennels.map((k) => [k.kennelCode, k.id]));
   for (const code of SEED.kennelCodes) {
-    const kennel = await prisma.kennel.findUnique({ where: { kennelCode: code }, select: { id: true } });
-    if (!kennel) throw new Error(`Kennel "${code}" not found — cannot link the new source.`);
+    const kennelId = kennelIdByCode.get(code);
+    if (!kennelId) throw new Error(`Kennel "${code}" not found — cannot link the new source.`);
     await prisma.sourceKennel.upsert({
-      where: { sourceId_kennelId: { sourceId: created.id, kennelId: kennel.id } },
+      where: { sourceId_kennelId: { sourceId: created.id, kennelId } },
       update: {},
-      create: { sourceId: created.id, kennelId: kennel.id },
+      create: { sourceId: created.id, kennelId },
     });
   }
   console.log(`  + Created source "${SOURCE_NAME}" and linked ${SEED.kennelCodes.join(", ")}.`);

--- a/scripts/backfill-nch3-sd-history.ts
+++ b/scripts/backfill-nch3-sd-history.ts
@@ -1,0 +1,38 @@
+/**
+ * One-shot historical backfill for NCH3 / North County Hash (San Diego).
+ * Issue #1763.
+ *
+ * `https://sdh3.com/history.shtml` lists every SD-area hash back to Dec 2006.
+ * Filtering for `(North County)` gives ~984 events spanning 2006-12-09 →
+ * present. HashTracks tracked only 55 (date floor 2025-03-29) before this
+ * backfill — the live SDH3 hareline source can only see upcoming events.
+ *
+ * Strategy: delegated to `backfillSdh3HistoryKennel` (scripts/lib/sdh3-history-backfill.ts).
+ * Same pattern as backfill-mission-h4-history.ts (#1666) and backfill-irh3-history.ts (#1425).
+ *
+ * Why attribute to "SDH3 Hareline": that source already links nch3-sd (see
+ * prisma/seed-data/sources.ts kennelCodes array + kennelNameMap "North County"),
+ * so the merge pipeline's per-event source-kennel guard accepts the rows.
+ * Reconcile risk is zero — historical events are far outside the live reconcile
+ * window, so future live scrapes won't cancel them.
+ *
+ * Coverage limit: the history page only carries date + start time + title +
+ * kennel; hares / location / description / cost stay null on backfilled rows.
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-nch3-sd-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-nch3-sd-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import { backfillSdh3HistoryKennel } from "./lib/sdh3-history-backfill";
+
+backfillSdh3HistoryKennel({
+  kennelCode: "nch3-sd",
+  kennelDisplayName: "North County",
+  label: "Walking SDH3 history.shtml for North County entries",
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-cross-kennel-conflation.ts
+++ b/scripts/cleanup-cross-kennel-conflation.ts
@@ -46,6 +46,7 @@ import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { createScriptPool } from "./lib/db-pool";
 import { cascadeDeleteEvents } from "./lib/cascade-delete";
+import { reassignEventKennel } from "./lib/event-reassign";
 
 const APPLY = process.env.BACKFILL_APPLY === "1";
 
@@ -68,44 +69,6 @@ async function main() {
 }
 
 // ── #1556 GyNO H3 ────────────────────────────────────────────────────────
-
-/**
- * Reassign an Event from one primary kennel to another in a single transaction,
- * keeping the unique `(eventId, kennelId)` constraint on EventKennel safe.
- * If the target kennel already has an EventKennel row on this event (legitimate
- * co-host link), drop the source row instead of attempting an update that
- * would collide on the composite primary key.
- */
-async function reassignEventKennel(
-  prisma: PrismaClient,
-  eventId: string,
-  fromKennelId: string,
-  toKennelId: string,
-) {
-  const targetCoHost = await prisma.eventKennel.findUnique({
-    where: { eventId_kennelId: { eventId, kennelId: toKennelId } },
-  });
-  await prisma.$transaction([
-    prisma.event.update({ where: { id: eventId }, data: { kennelId: toKennelId } }),
-    targetCoHost
-      ? prisma.eventKennel.delete({ where: { eventId_kennelId: { eventId, kennelId: fromKennelId } } })
-      : prisma.eventKennel.updateMany({
-          where: { eventId, kennelId: fromKennelId },
-          data: { kennelId: toKennelId },
-        }),
-  ]);
-  if (targetCoHost) {
-    // The remaining row (the original co-host) now owns the kennel link.
-    // If it wasn't already marked primary, promote it so downstream queries
-    // that order by isPrimary surface the right kennel.
-    if (!targetCoHost.isPrimary) {
-      await prisma.eventKennel.update({
-        where: { eventId_kennelId: { eventId, kennelId: toKennelId } },
-        data: { isPrimary: true },
-      });
-    }
-  }
-}
 
 /** Build the diff of gynoh3 profile fields that still need patching. */
 function gynoProfilePatch(gyno: { fullName: string; founder: string | null; parentKennelCode: string | null }): Record<string, string> {

--- a/scripts/cleanup-mel-cross-kennel-conflation.ts
+++ b/scripts/cleanup-mel-cross-kennel-conflation.ts
@@ -36,7 +36,7 @@ import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { createScriptPool } from "./lib/db-pool";
 import { cascadeDeleteEvents } from "./lib/cascade-delete";
-import { reassignEventKennel, utcDayBounds } from "./lib/event-reassign";
+import { reassignEventKennel } from "./lib/event-reassign";
 import { isBikeHashTitle } from "./backfill-mel-bike-hash-history";
 import { isCityHashTitle } from "./backfill-mel-city-h3-history";
 
@@ -74,15 +74,21 @@ async function reassignTarget(
   console.log(`\n── ${kennelCode}: ${misrouted.length} misrouted ${DEFAULT_KENNEL} canonical(s) ──`);
   if (misrouted.length === 0) return;
 
+  // Bulk-fetch the target kennel's occupied days once (one query, not one per
+  // misrouted event). A day already held by the target means the misrouted copy
+  // is a duplicate to delete; otherwise reassign — and record the day so a
+  // second misrouted event on the same date becomes a delete-dup too.
+  const targetEvents = await prisma.event.findMany({
+    where: { kennelId: target.id, isCanonical: true },
+    select: { date: true },
+  });
+  const targetDays = new Set(targetEvents.map((ev) => isoDay(ev.date)));
+
   let reassigned = 0;
   let deleted = 0;
   for (const e of misrouted) {
     const iso = isoDay(e.date);
-    const { day, next } = utcDayBounds(iso);
-    const slotTaken = await prisma.event.findFirst({
-      where: { kennelId: target.id, date: { gte: day, lt: next }, isCanonical: true, id: { not: e.id } },
-      select: { id: true },
-    });
+    const slotTaken = targetDays.has(iso);
     const action = slotTaken ? "delete-dup" : "reassign";
     console.log(`  [${action}] ${iso} #${e.runNumber ?? "?"} "${e.title}"`);
     if (!APPLY) continue;
@@ -91,6 +97,7 @@ async function reassignTarget(
       deleted++;
     } else {
       await reassignEventKennel(prisma, e.id, mnmId, target.id);
+      targetDays.add(iso);
       reassigned++;
     }
   }

--- a/scripts/cleanup-mel-cross-kennel-conflation.ts
+++ b/scripts/cleanup-mel-cross-kennel-conflation.ts
@@ -1,0 +1,120 @@
+/**
+ * Reassign misrouted Melbourne sibling events off `mel-new-moon` (#1752, #1755).
+ *
+ * The "Melbourne New Moon Meetup" source hosts five sibling kennels. Its
+ * `kennelPatterns` routing was added AFTER years of history had already been
+ * scraped, so every pre-routing Bike Hash / City H3 event landed on the default
+ * `mel-new-moon` kennel. Dry-run probing on 2026-05-29 found 39 bike-titled and
+ * 19 city-titled canonicals sitting under mel-new-moon.
+ *
+ * The historical backfill can't simply INSERT those events from the Meetup JSON
+ * batches — that would fork a second canonical on the same date under a
+ * different kennel (cross-kennel conflation). The events already exist with full
+ * fidelity (the live adapter captured location/startTime); they're just under
+ * the wrong kennel. So the correct fix is to REASSIGN them, then let the
+ * backfill scripts insert only the genuinely-missing rows.
+ *
+ * For each mel-new-moon canonical whose title matches a sibling's matcher:
+ *   - if the target kennel already holds a canonical on that date → cascade-
+ *     delete the mel-new-moon duplicate (the target copy wins);
+ *   - else reassign the Event + its EventKennel to the target (slot-safe).
+ *
+ * Title-matching is the audit key (same matchers the backfill uses), so a
+ * legitimate same-day "New Moon Run" is never touched. Idempotent: a second run
+ * finds nothing left to move.
+ *
+ * Scope: only bike-hash + city-h3 (the two issues). Full Moon / Delinquents
+ * rows are also misrouted under mel-new-moon but belong to separate issues.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/cleanup-mel-cross-kennel-conflation.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/cleanup-mel-cross-kennel-conflation.ts
+ */
+
+import "dotenv/config";
+import { PrismaClient } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { createScriptPool } from "./lib/db-pool";
+import { cascadeDeleteEvents } from "./lib/cascade-delete";
+import { reassignEventKennel, utcDayBounds } from "./lib/event-reassign";
+import { isBikeHashTitle } from "./backfill-mel-bike-hash-history";
+import { isCityHashTitle } from "./backfill-mel-city-h3-history";
+
+const APPLY = process.env.BACKFILL_APPLY === "1";
+const DEFAULT_KENNEL = "mel-new-moon";
+
+const TARGETS: ReadonlyArray<{ kennelCode: string; matcher: (t: string) => boolean }> = [
+  { kennelCode: "melbourne-bike-hash", matcher: isBikeHashTitle },
+  { kennelCode: "melbourne-city-h3", matcher: isCityHashTitle },
+];
+
+function isoDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+async function reassignTarget(
+  prisma: PrismaClient,
+  mnmId: string,
+  kennelCode: string,
+  matcher: (t: string) => boolean,
+): Promise<void> {
+  const target = await prisma.kennel.findUnique({ where: { kennelCode }, select: { id: true } });
+  if (!target) {
+    console.warn(`  ⚠ kennel "${kennelCode}" not found — skipping.`);
+    return;
+  }
+
+  const candidates = await prisma.event.findMany({
+    where: { kennelId: mnmId, isCanonical: true },
+    select: { id: true, title: true, date: true, runNumber: true },
+    orderBy: { date: "asc" },
+  });
+  const misrouted = candidates.filter((e) => e.title != null && matcher(e.title));
+
+  console.log(`\n── ${kennelCode}: ${misrouted.length} misrouted ${DEFAULT_KENNEL} canonical(s) ──`);
+  if (misrouted.length === 0) return;
+
+  let reassigned = 0;
+  let deleted = 0;
+  for (const e of misrouted) {
+    const iso = isoDay(e.date);
+    const { day, next } = utcDayBounds(iso);
+    const slotTaken = await prisma.event.findFirst({
+      where: { kennelId: target.id, date: { gte: day, lt: next }, isCanonical: true, id: { not: e.id } },
+      select: { id: true },
+    });
+    const action = slotTaken ? "delete-dup" : "reassign";
+    console.log(`  [${action}] ${iso} #${e.runNumber ?? "?"} "${e.title}"`);
+    if (!APPLY) continue;
+    if (slotTaken) {
+      await cascadeDeleteEvents(prisma, [e.id]);
+      deleted++;
+    } else {
+      await reassignEventKennel(prisma, e.id, mnmId, target.id);
+      reassigned++;
+    }
+  }
+  if (APPLY) console.log(`  ↳ reassigned ${reassigned}, deleted ${deleted} duplicate(s).`);
+}
+
+async function main(): Promise<void> {
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+  console.log(`Mode: ${APPLY ? "APPLY (writes enabled)" : "DRY RUN"}`);
+  try {
+    const mnm = await prisma.kennel.findUnique({ where: { kennelCode: DEFAULT_KENNEL }, select: { id: true } });
+    if (!mnm) throw new Error(`Kennel "${DEFAULT_KENNEL}" not found.`);
+    for (const { kennelCode, matcher } of TARGETS) {
+      await reassignTarget(prisma, mnm.id, kennelCode, matcher);
+    }
+    console.log(`\nDone. ${APPLY ? "Changes committed." : "No changes — pass BACKFILL_APPLY=1 to apply."}`);
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lib/event-reassign.ts
+++ b/scripts/lib/event-reassign.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared slot-safe Event→kennel reassignment helper for one-shot cleanup
+ * scripts. Extracted so cross-kennel conflation fixers don't each carry their
+ * own copy of the EventKennel composite-PK-safe transaction (the subtle part
+ * is the co-host collision case).
+ */
+
+import type { PrismaClient } from "@/generated/prisma/client";
+
+/** UTC day window [start, nextDay) for an ISO `YYYY-MM-DD` date. */
+export function utcDayBounds(isoDate: string): { day: Date; next: Date } {
+  const day = new Date(`${isoDate}T00:00:00.000Z`);
+  const next = new Date(day);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return { day, next };
+}
+
+/**
+ * Reassign an Event from one primary kennel to another in a single transaction,
+ * keeping the unique `(eventId, kennelId)` constraint on EventKennel safe. If
+ * the target kennel already has an EventKennel row on this event (legitimate
+ * co-host link), drop the source row instead of an update that would collide on
+ * the composite primary key, then promote the surviving row to primary.
+ */
+export async function reassignEventKennel(
+  prisma: PrismaClient,
+  eventId: string,
+  fromKennelId: string,
+  toKennelId: string,
+): Promise<void> {
+  const targetCoHost = await prisma.eventKennel.findUnique({
+    where: { eventId_kennelId: { eventId, kennelId: toKennelId } },
+  });
+  await prisma.$transaction([
+    prisma.event.update({ where: { id: eventId }, data: { kennelId: toKennelId } }),
+    targetCoHost
+      ? prisma.eventKennel.delete({ where: { eventId_kennelId: { eventId, kennelId: fromKennelId } } })
+      : prisma.eventKennel.updateMany({
+          where: { eventId, kennelId: fromKennelId },
+          data: { kennelId: toKennelId },
+        }),
+  ]);
+  if (targetCoHost && !targetCoHost.isPrimary) {
+    await prisma.eventKennel.update({
+      where: { eventId_kennelId: { eventId, kennelId: toKennelId } },
+      data: { isPrimary: true },
+    });
+  }
+}

--- a/scripts/lib/mel-meetup-history-backfill.ts
+++ b/scripts/lib/mel-meetup-history-backfill.ts
@@ -1,0 +1,236 @@
+/**
+ * Shared one-shot historical backfill helper for kennels hosted on the
+ * "Melbourne New Moon Meetup" aggregator source (#1752, #1755).
+ *
+ * Why a one-shot from committed JSON rather than a wide-window live scrape:
+ * the Meetup public API the live adapter uses only exposes UPCOMING events —
+ * `/events/past/` redirects to login (see #1752/#1755 issue bodies). The
+ * historical rows were captured out-of-band via the Chrome history-scrape
+ * tool into `scripts/data/mel-new-moon-meetup-history-batch-*.json` (each a
+ * complete JSON array of `{title,date,startTime,location,url,attendees}`).
+ * This helper replays those committed batches through the merge pipeline,
+ * filtered to a single sibling kennel.
+ *
+ * Per-kennel scripts (bike-hash, city-h3) collapse to one call into this
+ * helper with their own `matcher`, sharing the read/filter/merge wiring.
+ *
+ * Why a per-kennel matcher (not the live source's `kennelPatterns`): the live
+ * config deliberately routes only `^\s*Bike\s+hash\b` to bike-hash and leaves
+ * the "Bike Ride #N" / "Ride #N" / "Beer Run#.. from Melbourne City Hash"
+ * variants to the default `mel-new-moon` ("to avoid eating legit run names").
+ * A dedicated historical backfill wants the inclusive form, so each wrapper
+ * supplies its own matcher. See the cross-kennel collision guard below for the
+ * safety implication.
+ *
+ * Idempotency: routes through `reportAndApplyBackfill` → `processRawEvents`
+ * which dedupes by `(sourceId, fingerprint)`. The canonical `(kennelId, date)`
+ * merge collapses re-imports of already-tracked events onto the existing
+ * canonical (no duplicate Event), so re-runs are safe.
+ */
+
+import "dotenv/config";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { prisma } from "@/lib/db";
+import { extractHashRunNumber } from "@/adapters/utils";
+import type { RawEventData } from "@/adapters/types";
+import { runBackfillScript } from "./backfill-runner";
+import { utcDayBounds } from "./event-reassign";
+
+const SOURCE_NAME = "Melbourne New Moon Meetup";
+const KENNEL_TIMEZONE = "Australia/Melbourne";
+const DEFAULT_KENNEL = "mel-new-moon";
+const BATCH_PREFIX = "mel-new-moon-meetup-history-batch-";
+const DATA_DIR = fileURLToPath(new URL("../data", import.meta.url));
+
+/** Shape of a single row in the committed batch JSON files. */
+interface MeetupHistoryRow {
+  title?: string;
+  date?: string; // YYYY-MM-DD
+  startTime?: string; // HH:MM
+  location?: string | null;
+  url?: string | null;
+  attendees?: number | null;
+}
+
+/**
+ * Placeholder titles that are not real completed events. Same shape as
+ * `import-meetup-history.ts` (POSTPONED / CANCELLED / NEEDS A HARE). Kept as a
+ * small literal alternation — no nested `\s*` quantifiers, so Sonar S5852 is
+ * clean.
+ */
+const PLACEHOLDER_TITLE_RE = /\bPOSTPONED\b|\bCANCEL(?:L?ED)\b|\bNEEDS?\s+(?:A\s+)?HARE\b/i;
+
+/**
+ * Recurring-template titles emitted by Meetup's series feature
+ * ("Every Wednesday @ 6:30pm from tbd"). The live adapter strips these via
+ * `cleanMeetupTitle`; this backfill reads raw batch JSON and bypasses that, so
+ * we guard explicitly. See `cleanup-mel-nm-historical-placeholders.ts`.
+ */
+function isTemplateTitle(title: string): boolean {
+  return /^every\b/i.test(title.trim());
+}
+
+export function isImportablePlaceholder(title: string): boolean {
+  return PLACEHOLDER_TITLE_RE.test(title) || isTemplateTitle(title);
+}
+
+/**
+ * Read every committed batch file as an independent JSON array and concatenate
+ * the rows. Each file is a complete `[...]`, so a plain `JSON.parse` per file
+ * is correct — no need for the concatenated-stream parser used by the stdin
+ * importer.
+ */
+export function readBatchRows(dataDir: string = DATA_DIR): MeetupHistoryRow[] {
+  const files = readdirSync(dataDir)
+    .filter((name) => name.startsWith(BATCH_PREFIX) && name.endsWith(".json"))
+    .sort((a, b) => {
+      const an = Number(a.match(/(\d+)\.json$/)?.[1] ?? 0);
+      const bn = Number(b.match(/(\d+)\.json$/)?.[1] ?? 0);
+      return an - bn;
+    });
+  if (files.length === 0) {
+    throw new Error(`No batch files matching "${BATCH_PREFIX}*.json" in ${dataDir}`);
+  }
+  const rows: MeetupHistoryRow[] = [];
+  for (const name of files) {
+    const parsed = JSON.parse(readFileSync(`${dataDir}/${name}`, "utf-8"));
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Batch file ${name} is not a JSON array.`);
+    }
+    rows.push(...parsed);
+  }
+  return rows;
+}
+
+/**
+ * Turn batch rows into `RawEventData` for a single kennel. Pure (no I/O) so the
+ * unit test can exercise the matcher + field mapping directly. Rows are kept
+ * only when `matcher(title)` is true and the title is not a placeholder/template.
+ * De-duped within the batch by `url` (the same Meetup event can appear in
+ * overlapping scrape windows).
+ */
+export function buildKennelEvents(
+  rows: readonly MeetupHistoryRow[],
+  kennelCode: string,
+  matcher: (title: string) => boolean,
+): RawEventData[] {
+  const seenUrls = new Set<string>();
+  const events: RawEventData[] = [];
+  for (const row of rows) {
+    const title = row.title?.trim();
+    if (!title || !row.date) continue;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(row.date)) continue;
+    if (!matcher(title)) continue;
+    if (isImportablePlaceholder(title)) continue;
+    if (row.url) {
+      if (seenUrls.has(row.url)) continue;
+      seenUrls.add(row.url);
+    }
+    events.push({
+      date: row.date,
+      kennelTags: [kennelCode],
+      title,
+      runNumber: extractHashRunNumber(title),
+      startTime: row.startTime || undefined,
+      location: row.location || undefined,
+      sourceUrl: row.url || undefined,
+    });
+  }
+  return events;
+}
+
+/**
+ * Detect the cross-kennel conflation hazard: an event the inclusive matcher
+ * routes to `kennelCode` may already exist as a canonical Event MISROUTED under
+ * the default `mel-new-moon` kennel (the live source's `kennelPatterns` were
+ * added after these historical rows were first scraped, so they all landed on
+ * the default). Re-importing under `kennelCode` would fork the canonical.
+ *
+ * A genuine collision is a `mel-new-moon` canonical on the date whose TITLE
+ * matches `matcher` (i.e. it's the misrouted sibling event itself) while the
+ * target kennel holds no canonical for that date. Title-matching is essential:
+ * a same-day "New Moon Run No. 144" alongside a separate City Hash is NOT a
+ * collision — that's two legitimate sibling events, and the City row should
+ * insert freely.
+ *
+ * READ-ONLY. Returns the colliding dates so the caller can fail loud and direct
+ * the operator to run `scripts/cleanup-mel-cross-kennel-conflation.ts` first.
+ */
+async function findCrossKennelCollisions(
+  events: readonly RawEventData[],
+  kennelCode: string,
+  matcher: (title: string) => boolean,
+): Promise<string[]> {
+  const target = await prisma.kennel.findUnique({ where: { kennelCode }, select: { id: true } });
+  const def = await prisma.kennel.findUnique({ where: { kennelCode: DEFAULT_KENNEL }, select: { id: true } });
+  if (!target || !def) return [];
+
+  const collisions: string[] = [];
+  for (const ev of events) {
+    const { day, next } = utcDayBounds(ev.date);
+    const onDefault = await prisma.event.findMany({
+      where: { kennelId: def.id, date: { gte: day, lt: next }, isCanonical: true },
+      select: { title: true },
+    });
+    // Only the misrouted-sibling case: a default-kennel canonical whose title
+    // matches this kennel's matcher.
+    const misrouted = onDefault.some((e) => e.title != null && matcher(e.title));
+    if (!misrouted) continue;
+    const onTarget = await prisma.event.findFirst({
+      where: { kennelId: target.id, date: { gte: day, lt: next }, isCanonical: true },
+      select: { id: true },
+    });
+    if (!onTarget) collisions.push(ev.date);
+  }
+  return collisions;
+}
+
+export interface MelBackfillParams {
+  kennelCode: string;
+  matcher: (title: string) => boolean;
+  /** Short label printed by the runner. */
+  label: string;
+}
+
+export async function backfillMelMeetupKennel(params: MelBackfillParams): Promise<void> {
+  const { kennelCode, matcher, label } = params;
+  // Delegate the apply/dry-run, logging, merge, and DB-lifecycle ceremony to
+  // the shared runner; the per-kennel work (read batches, filter, collision
+  // preflight) lives in fetchEvents. The outer finally disconnects the prisma
+  // singleton the collision probe opens — the runner only disconnects on the
+  // apply path, so the dry-run probe connection needs closing here. Calling
+  // $disconnect twice on apply is a harmless no-op.
+  try {
+    await runBackfillScript({
+      sourceName: SOURCE_NAME,
+      kennelTimezone: KENNEL_TIMEZONE,
+      label,
+      fetchEvents: async () => {
+        const rows = readBatchRows();
+        const events = buildKennelEvents(rows, kennelCode, matcher);
+        console.log(`  Read ${rows.length} batch rows → ${events.length} ${kennelCode} events after filter.`);
+
+        const collisions = await findCrossKennelCollisions(events, kennelCode, matcher);
+        if (collisions.length === 0) {
+          console.log(`  Cross-kennel collision probe: clean (no ${DEFAULT_KENNEL} forks).`);
+          return events;
+        }
+        console.warn(
+          `  ⚠ ${collisions.length} misrouted-sibling collision(s): a "${DEFAULT_KENNEL}" canonical ` +
+            `with a ${kennelCode}-matching title sits on these dates with no "${kennelCode}" counterpart:\n    ${collisions.join(", ")}`,
+        );
+        if (process.env.BACKFILL_APPLY === "1") {
+          throw new Error(
+            `Refusing to apply: ${collisions.length} date(s) would fork a canonical Event across ` +
+              `${DEFAULT_KENNEL} and ${kennelCode}. Run scripts/cleanup-mel-cross-kennel-conflation.ts ` +
+              `(BACKFILL_APPLY=1) to reassign the misrouted events first, then re-run this backfill.`,
+          );
+        }
+        return events;
+      },
+    });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/scripts/lib/mel-meetup-history-backfill.ts
+++ b/scripts/lib/mel-meetup-history-backfill.ts
@@ -98,7 +98,7 @@ export function readBatchRows(dataDir: string = DATA_DIR): MeetupHistoryRow[] {
   for (const name of files) {
     const parsed = JSON.parse(readFileSync(`${dataDir}/${name}`, "utf-8"));
     if (!Array.isArray(parsed)) {
-      throw new Error(`Batch file ${name} is not a JSON array.`);
+      throw new TypeError(`Batch file ${name} is not a JSON array.`);
     }
     rows.push(...parsed);
   }
@@ -172,7 +172,7 @@ async function findCrossKennelCollisions(
   // (two range queries, not 2×N) and check collisions in memory.
   const dates = events.map((e) => e.date).sort((a, b) => a.localeCompare(b));
   const { day: rangeStart } = utcDayBounds(dates[0]);
-  const { next: rangeEnd } = utcDayBounds(dates[dates.length - 1]);
+  const { next: rangeEnd } = utcDayBounds(dates.at(-1)!);
 
   const [defaultEvents, targetEvents] = await Promise.all([
     prisma.event.findMany({

--- a/scripts/lib/mel-meetup-history-backfill.ts
+++ b/scripts/lib/mel-meetup-history-backfill.ts
@@ -81,14 +81,16 @@ export function isImportablePlaceholder(title: string): boolean {
  * is correct — no need for the concatenated-stream parser used by the stdin
  * importer.
  */
+/** Numeric suffix of a batch filename, e.g. "...batch-7.json" → 7. Sliced
+ *  (not regex) to avoid Sonar S5852's backtracking-shape flag on `\d+\.json$`. */
+function batchNum(name: string): number {
+  return Number(name.slice(BATCH_PREFIX.length, -".json".length)) || 0;
+}
+
 export function readBatchRows(dataDir: string = DATA_DIR): MeetupHistoryRow[] {
   const files = readdirSync(dataDir)
     .filter((name) => name.startsWith(BATCH_PREFIX) && name.endsWith(".json"))
-    .sort((a, b) => {
-      const an = Number(a.match(/(\d+)\.json$/)?.[1] ?? 0);
-      const bn = Number(b.match(/(\d+)\.json$/)?.[1] ?? 0);
-      return an - bn;
-    });
+    .sort((a, b) => batchNum(a) - batchNum(b));
   if (files.length === 0) {
     throw new Error(`No batch files matching "${BATCH_PREFIX}*.json" in ${dataDir}`);
   }
@@ -164,26 +166,37 @@ async function findCrossKennelCollisions(
 ): Promise<string[]> {
   const target = await prisma.kennel.findUnique({ where: { kennelCode }, select: { id: true } });
   const def = await prisma.kennel.findUnique({ where: { kennelCode: DEFAULT_KENNEL }, select: { id: true } });
-  if (!target || !def) return [];
+  if (!target || !def || events.length === 0) return [];
 
-  const collisions: string[] = [];
-  for (const ev of events) {
-    const { day, next } = utcDayBounds(ev.date);
-    const onDefault = await prisma.event.findMany({
-      where: { kennelId: def.id, date: { gte: day, lt: next }, isCanonical: true },
-      select: { title: true },
-    });
-    // Only the misrouted-sibling case: a default-kennel canonical whose title
-    // matches this kennel's matcher.
-    const misrouted = onDefault.some((e) => e.title != null && matcher(e.title));
-    if (!misrouted) continue;
-    const onTarget = await prisma.event.findFirst({
-      where: { kennelId: target.id, date: { gte: day, lt: next }, isCanonical: true },
-      select: { id: true },
-    });
-    if (!onTarget) collisions.push(ev.date);
+  // Bulk-fetch both kennels' canonicals across the backfill's full date span
+  // (two range queries, not 2×N) and check collisions in memory.
+  const dates = events.map((e) => e.date).sort((a, b) => a.localeCompare(b));
+  const { day: rangeStart } = utcDayBounds(dates[0]);
+  const { next: rangeEnd } = utcDayBounds(dates[dates.length - 1]);
+
+  const [defaultEvents, targetEvents] = await Promise.all([
+    prisma.event.findMany({
+      where: { kennelId: def.id, date: { gte: rangeStart, lt: rangeEnd }, isCanonical: true },
+      select: { title: true, date: true },
+    }),
+    prisma.event.findMany({
+      where: { kennelId: target.id, date: { gte: rangeStart, lt: rangeEnd }, isCanonical: true },
+      select: { date: true },
+    }),
+  ]);
+
+  // Days where the default kennel holds a canonical whose title matches this
+  // kennel's matcher (the misrouted-sibling case).
+  const misroutedDays = new Set<string>();
+  for (const e of defaultEvents) {
+    if (e.title != null && matcher(e.title)) misroutedDays.add(e.date.toISOString().slice(0, 10));
   }
-  return collisions;
+  const targetDays = new Set(targetEvents.map((e) => e.date.toISOString().slice(0, 10)));
+
+  // A collision is a backfill row on a misrouted day with no target counterpart.
+  return events
+    .filter((ev) => misroutedDays.has(ev.date) && !targetDays.has(ev.date))
+    .map((ev) => ev.date);
 }
 
 export interface MelBackfillParams {

--- a/src/adapters/html-scraper/nch3.test.ts
+++ b/src/adapters/html-scraper/nch3.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { parseNCH3Page } from "./nch3";
+
+// Captured from https://nch3.com/ on 2026-05-29. The B / On-After "Google Map"
+// links are real HTML comments on the live page — kept here so the test proves
+// cheerio ignores them and the Location anchor is the one picked up.
+const FIXTURE = `<!DOCTYPE html><html><body>
+<div class="main">
+  <div class="page" id="mission">
+    <div class="content container">
+      <h2>Run Start for North County Hash</h2>
+      <div class="row">
+        <p class="col-xs-5 col-xs-offset-1 col-sm-5 col-sm-offset-1 col-md-5 col-md-offset-1 notes">
+          <strong>Run Number:</strong> 1920<br>
+          <strong>Saturday,</strong> 5/23/26 10:00am<br>
+          <strong>Name: </strong> Memorial Day Beach and Cliffs Run <br>
+          <strong>Hare(s):</strong> TNT, Comes and Goes, Acute Triangle, Good Tail and PPI<br>
+          <strong>Location: </strong> Eucalyptus Grove on the corner of Horizon Way (it makes a 90 degree turn) in La Jolla. Next to La Jolla Shores Drive.
+          <a href="https://maps.app.goo.gl/4Jcbn4fZ1FBABZpt6" >   Google Map</a> <br>
+          <strong>B: </strong> <!-- <a href="https://maps.app.goo.gl/iaUmms3HrVz5HWXX6" >   Google Map</a> --><br>
+          <strong>Run Fee: $</strong> $8 cash only<br>
+          <strong>Trail type: </strong>A to A<br>
+          <strong></strong>
+          <strong>Dog friendly: </strong>On In Only<br>
+          <strong>On After: </strong> <!-- <a href="https://maps.app.goo.gl/GcWGuigeLBtGdVeX7" >   Google Map</a> --><br>
+          <strong>Notes: </strong>Happy Memorial Day weekend! It is early this year. Let's celebrate by running the beaches and cliffs of our favorite nude beach.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+</body></html>`;
+
+describe("parseNCH3Page", () => {
+  const event = parseNCH3Page(FIXTURE);
+
+  it("parses the single current run with all fields", () => {
+    expect(event).not.toBeNull();
+    expect(event).toMatchObject({
+      date: "2026-05-23", // 5/23/26 → UTC noon
+      kennelTags: ["nch3-sd"],
+      runNumber: 1920,
+      title: "Memorial Day Beach and Cliffs Run",
+      hares: "TNT, Comes and Goes, Acute Triangle, Good Tail and PPI",
+      startTime: "10:00",
+      cost: "$8 cash only",
+      trailType: "A to A",
+      locationUrl: "https://maps.app.goo.gl/4Jcbn4fZ1FBABZpt6",
+    });
+  });
+
+  it("keeps the Location text but strips the trailing 'Google Map' anchor label", () => {
+    expect(event?.location).toBe(
+      "Eucalyptus Grove on the corner of Horizon Way (it makes a 90 degree turn) in La Jolla. Next to La Jolla Shores Drive.",
+    );
+  });
+
+  it("leaves dogFriendly undefined for the ambiguous 'On In Only' phrasing", () => {
+    expect(event?.dogFriendly).toBeUndefined();
+  });
+
+  it("captures the Notes blurb as description", () => {
+    expect(event?.description).toMatch(/^Happy Memorial Day weekend!/);
+  });
+
+  it("returns null when no date is present", () => {
+    expect(parseNCH3Page("<html><body><p class='notes'>no run scheduled</p></body></html>")).toBeNull();
+  });
+});

--- a/src/adapters/html-scraper/nch3.ts
+++ b/src/adapters/html-scraper/nch3.ts
@@ -1,0 +1,200 @@
+import * as cheerio from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import type {
+  SourceAdapter,
+  RawEventData,
+  ScrapeResult,
+  ErrorDetails,
+} from "../types";
+import { hasAnyErrors } from "../types";
+import { generateStructureHash } from "@/pipeline/structure-hash";
+import { filterEventsByWindow, parse12HourTime } from "../utils";
+import { safeFetch } from "../safe-fetch";
+
+/**
+ * North County Hash (NCH3) official microsite scraper — nch3.com (#1765).
+ *
+ * The site is a PHP/MySQL "current run" page: it always renders exactly ONE
+ * event (the latest row, `ORDER BY id DESC LIMIT 1`) inside a single
+ * `<p class="notes">` block of `<strong>Label:</strong> value<br>` pairs:
+ *
+ *   <strong>Run Number:</strong> 1920<br>
+ *   <strong>Saturday,</strong> 5/23/26 10:00am<br>     ← weekday label, date value
+ *   <strong>Name: </strong> Memorial Day Beach and Cliffs Run<br>
+ *   <strong>Hare(s):</strong> TNT, Comes and Goes, ...<br>
+ *   <strong>Location: </strong> Eucalyptus Grove ... <a href="https://maps...">Google Map</a><br>
+ *   <strong>Run Fee: $</strong> $8 cash only<br>
+ *   <strong>Trail type: </strong>A to A<br>
+ *   <strong>Dog friendly: </strong>On In Only<br>
+ *   <strong>Notes: </strong>Happy Memorial Day weekend! ...
+ *
+ * This is a SUPPLEMENTAL source: NCH3 is primarily tracked via the SDH3
+ * hareline (which carries richer enumeration). The microsite adds fields the
+ * hareline lacks (hares, location, cost, trail type) for the current run. The
+ * seed marks it `config.upcomingOnly: true` so reconcile never cancels the
+ * many SDH3-sourced NCH3 events this single-event page can't enumerate.
+ *
+ * Field labels are walked procedurally (not via `^Label:` regex) per
+ * `feedback_sonar_s5852_procedural_over_regex` — anchored label captures trip
+ * Sonar S5852's backtracking-shape check.
+ */
+
+const DEFAULT_URL = "https://nch3.com/";
+const KENNEL_TAG = "nch3-sd";
+
+/** Read the value after a `Label:` prefix from the flattened notes lines. */
+function readLine(lines: readonly string[], label: string): string | undefined {
+  const needle = `${label.toLowerCase()}:`;
+  for (const raw of lines) {
+    const line = raw.trimStart();
+    if (line.toLowerCase().startsWith(needle)) {
+      return line.slice(needle.length).trim();
+    }
+  }
+  return undefined;
+}
+
+/** Parse a US `M/D/YY` (or `M/D/YYYY`) date to a UTC-noon `YYYY-MM-DD` string. */
+function parseUsDate(text: string): string | undefined {
+  const m = text.match(/(\d{1,2})\/(\d{1,2})\/(\d{2,4})/);
+  if (!m) return undefined;
+  const month = Number.parseInt(m[1], 10);
+  const day = Number.parseInt(m[2], 10);
+  let year = Number.parseInt(m[3], 10);
+  if (year < 100) year += 2000;
+  if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
+  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0)).toISOString().slice(0, 10);
+}
+
+/** Conservative boolean: only commit on an unambiguous yes/no prefix. The
+ *  microsite's "On In Only" / "On Out Only" phrasings don't map to a boolean,
+ *  so they leave the field `undefined` (preserve-existing) rather than guess. */
+function parseDogFriendly(value: string | undefined): boolean | undefined {
+  if (!value) return undefined;
+  if (/^\s*yes\b/i.test(value)) return true;
+  if (/^\s*no\b/i.test(value)) return false;
+  return undefined;
+}
+
+/**
+ * Parse the single nch3.com event. Pure function (no I/O) so the unit test can
+ * exercise it against a captured fixture. Returns null when no date is found.
+ */
+export function parseNCH3Page(html: string, sourceUrl = DEFAULT_URL): RawEventData | null {
+  const $ = cheerio.load(html);
+  const $notes = $("p.notes").first();
+  const scope = $notes.length > 0 ? $notes : $("#mission");
+  if (scope.length === 0) return null;
+
+  // The Location row carries the only real <a> (the B / On-After maps are HTML
+  // comments, invisible to cheerio). Grab it before flattening to text.
+  const locationUrl = scope.find("a[href]").first().attr("href") || undefined;
+
+  // Flatten on <br> boundaries only. Replace <br> with a sentinel (not "\n")
+  // so the page's own source-native line breaks — e.g. between the Location
+  // text and its "Google Map" anchor — collapse to spaces within a field
+  // rather than splitting it into two lines.
+  const ROW_SEP = "\u0001";
+  scope.find("br").replaceWith(ROW_SEP);
+  const lines = scope
+    .text()
+    .split(ROW_SEP)
+    .map((l) => l.replace(/\s+/g, " ").trim())
+    .filter((l) => l.length > 0);
+
+  const fullText = lines.join("\n");
+  const date = parseUsDate(fullText);
+  if (!date) return null;
+
+  const timeMatch = fullText.match(/\d{1,2}:\d{2}\s*[ap]\.?m/i);
+  const startTime = timeMatch ? parse12HourTime(timeMatch[0]) ?? undefined : undefined;
+
+  const runNumRaw = readLine(lines, "Run Number");
+  const runNumber = runNumRaw ? Number.parseInt(runNumRaw.match(/\d+/)?.[0] ?? "", 10) : NaN;
+
+  const title = readLine(lines, "Name") || undefined;
+  const hares = readLine(lines, "Hare(s)") || undefined;
+
+  // Location value ends with the anchor text "Google Map" — strip it.
+  let location = readLine(lines, "Location") || undefined;
+  if (location) {
+    location = location.replace(/\s*google map\s*$/i, "").trim() || undefined;
+  }
+
+  // "Run Fee: $" → value is "$ $8 cash only"; drop the leading bare "$".
+  const feeRaw = readLine(lines, "Run Fee");
+  const cost = feeRaw ? feeRaw.replace(/^\$\s*/, "").trim() || undefined : undefined;
+
+  const trailType = readLine(lines, "Trail type") || undefined;
+  const dogFriendly = parseDogFriendly(readLine(lines, "Dog friendly"));
+  const description = readLine(lines, "Notes") || undefined;
+
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber: Number.isFinite(runNumber) && runNumber > 0 ? runNumber : undefined,
+    title,
+    hares,
+    location,
+    locationUrl,
+    startTime,
+    cost,
+    trailType,
+    dogFriendly,
+    description,
+    sourceUrl,
+  };
+}
+
+export class NCH3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    const url = source.url || DEFAULT_URL;
+    const errorDetails: ErrorDetails = {};
+
+    let html: string;
+    const fetchStart = Date.now();
+    try {
+      const response = await safeFetch(url, {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (!response.ok) {
+        const message = `HTTP ${response.status}: ${response.statusText}`;
+        errorDetails.fetch = [{ url, status: response.status, message }];
+        return { events: [], errors: [message], errorDetails };
+      }
+      html = await response.text();
+    } catch (err) {
+      const message = `Fetch failed: ${err}`;
+      errorDetails.fetch = [{ url, message }];
+      return { events: [], errors: [message], errorDetails };
+    }
+    const fetchDurationMs = Date.now() - fetchStart;
+
+    const structureHash = generateStructureHash(html);
+    const errors: string[] = [];
+    const events: RawEventData[] = [];
+
+    const event = parseNCH3Page(html, url);
+    if (!event) {
+      errors.push("Could not parse the current run from nch3.com (no date found).");
+    } else {
+      // Honor the scrape window so a stale current-run far outside the lookback
+      // doesn't resurface (defaults to 90d; seed uses 30d).
+      events.push(...filterEventsByWindow([event], options?.days ?? 90));
+    }
+
+    return {
+      events,
+      errors,
+      structureHash,
+      errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+      diagnosticContext: { eventsParsed: events.length, fetchDurationMs },
+    };
+  }
+}

--- a/src/adapters/html-scraper/nch3.ts
+++ b/src/adapters/html-scraper/nch3.ts
@@ -56,7 +56,7 @@ function readLine(lines: readonly string[], label: string): string | undefined {
 
 /** Parse a US `M/D/YY` (or `M/D/YYYY`) date to a UTC-noon `YYYY-MM-DD` string. */
 function parseUsDate(text: string): string | undefined {
-  const m = text.match(/(\d{1,2})\/(\d{1,2})\/(\d{2,4})/);
+  const m = /(\d{1,2})\/(\d{1,2})\/(\d{2,4})/.exec(text);
   if (!m) return undefined;
   const month = Number.parseInt(m[1], 10);
   const day = Number.parseInt(m[2], 10);
@@ -113,7 +113,7 @@ export function parseNCH3Page(html: string, sourceUrl = DEFAULT_URL): RawEventDa
   const startTime = timeMatch ? parse12HourTime(timeMatch[0]) ?? undefined : undefined;
 
   const runNumRaw = readLine(lines, "Run Number");
-  const runNumber = runNumRaw ? Number.parseInt(runNumRaw.match(/\d+/)?.[0] ?? "", 10) : NaN;
+  const runNumber = runNumRaw ? Number.parseInt(/\d+/.exec(runNumRaw)?.[0] ?? "", 10) : Number.NaN;
 
   const title = readLine(lines, "Name") || undefined;
   const hares = readLine(lines, "Hare(s)") || undefined;
@@ -189,12 +189,12 @@ export class NCH3Adapter implements SourceAdapter {
     const events: RawEventData[] = [];
 
     const event = parseNCH3Page(html, url);
-    if (!event) {
-      errors.push("Could not parse the current run from nch3.com (no date found).");
-    } else {
+    if (event) {
       // Honor the scrape window so a stale current-run far outside the lookback
       // doesn't resurface (defaults to 90d; seed uses 30d).
       events.push(...filterEventsByWindow([event], options?.days ?? 90));
+    } else {
+      errors.push("Could not parse the current run from nch3.com (no date found).");
     }
 
     return {

--- a/src/adapters/html-scraper/nch3.ts
+++ b/src/adapters/html-scraper/nch3.ts
@@ -63,7 +63,10 @@ function parseUsDate(text: string): string | undefined {
   let year = Number.parseInt(m[3], 10);
   if (year < 100) year += 2000;
   if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
-  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0)).toISOString().slice(0, 10);
+  const d = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  // Reject overflow dates (e.g. 2/30 → Mar 2) — Date.UTC silently rolls over.
+  if (d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return undefined;
+  return d.toISOString().slice(0, 10);
 }
 
 /** Conservative boolean: only commit on an unambiguous yes/no prefix. The
@@ -115,10 +118,15 @@ export function parseNCH3Page(html: string, sourceUrl = DEFAULT_URL): RawEventDa
   const title = readLine(lines, "Name") || undefined;
   const hares = readLine(lines, "Hare(s)") || undefined;
 
-  // Location value ends with the anchor text "Google Map" — strip it.
+  // Location value ends with the anchor text "Google Map" — strip it. Done
+  // procedurally (not a `\s*…\s*$` regex) to avoid Sonar S5852.
   let location = readLine(lines, "Location") || undefined;
   if (location) {
-    location = location.replace(/\s*google map\s*$/i, "").trim() || undefined;
+    const idx = location.toLowerCase().lastIndexOf("google map");
+    if (idx >= 0 && location.slice(idx + "google map".length).trim() === "") {
+      location = location.slice(0, idx).trim();
+    }
+    location = location || undefined;
   }
 
   // "Run Fee: $" → value is "$ $8 cash only"; drop the leading bare "$".

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -34,6 +34,7 @@ import { HockessinAdapter } from "./html-scraper/hockessin";
 import { RenegadeH3Adapter } from "./html-scraper/renegade-h3";
 import { SWH3Adapter } from "./html-scraper/swh3";
 import { SDH3Adapter } from "./html-scraper/sdh3";
+import { NCH3Adapter } from "./html-scraper/nch3";
 import { PhoenixHHHAdapter } from "./html-scraper/phoenixhhh";
 import { EdinburghH3Adapter } from "./html-scraper/edinburgh-h3";
 import { NorfolkH3Adapter } from "./html-scraper/norfolk-h3";
@@ -167,6 +168,7 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /hockessinhash\.org/i,     name: "HockessinAdapter",         factory: () => new HockessinAdapter() },
   { pattern: /renegadeh3\.com/i,       name: "RenegadeH3Adapter",        factory: () => new RenegadeH3Adapter() },
   { pattern: /swh3\.wordpress\.com/i, name: "SWH3Adapter",              factory: () => new SWH3Adapter() },
+  { pattern: /nch3\.com/i,            name: "NCH3Adapter",              factory: () => new NCH3Adapter() },
   { pattern: /sdh3\.com/i,            name: "SDH3Adapter",              factory: () => new SDH3Adapter() },
   { pattern: /phoenixhhh\.org/i,    name: "PhoenixHHHAdapter",        factory: () => new PhoenixHHHAdapter() },
   { pattern: /edinburghh3\.com/i,  name: "EdinburghH3Adapter",       factory: () => new EdinburghH3Adapter() },


### PR DESCRIPTION
## Summary

Quick Win bundle — 5 historical-coverage audit findings across 3 kennel clusters. All new code lives in `scripts/` plus one new `nch3.com` adapter + a seed/registry entry. Every backfill routes through `reportAndApplyBackfill` (idempotent, fingerprint dedup) and was verified end-to-end against prod.

| Issue | Kennel | Result |
|---|---|---|
| #1752 | melbourne-bike-hash | **4 → 39** canonical events |
| #1755 | melbourne-city-h3 | **1 → 20** |
| #1763 | nch3-sd | **~61 → 850** (history back to 2006) |
| #1765 | nch3-sd | official microsite run present + enriched; new source added |
| #1595 | lbh-phx | **113 → 119** (+6 pre-2023); **kept open** — see below |

## What each piece does

**Melbourne (#1752 / #1755) — reassign, then backfill.** The live "Melbourne New Moon Meetup" source's `kennelPatterns` were added *after* years of history were scraped, so **39 bike-titled + 19 city-titled events were misrouted under the default `mel-new-moon` kennel** (and 5 recent ones were duplicated across both). Inserting from the Meetup batches alone would have forked canonicals, so:
- `scripts/cleanup-mel-cross-kennel-conflation.ts` reassigns the misrouted events to their correct kennel (slot-safe, title-matched) and cascade-deletes the 5 duplicates.
- `scripts/backfill-mel-bike-hash-history.ts` / `backfill-mel-city-h3-history.ts` (thin wrappers over `scripts/lib/mel-meetup-history-backfill.ts`) then replay the committed `scripts/data/mel-new-moon-meetup-history-batch-*.json` (the Meetup public API is upcoming-only). A pre-apply cross-kennel probe **fails loud** if misrouted events still exist.
- Net: mel-new-moon 247 → 189; bike 4 → 39; city 1 → 20.

**NCH3 history (#1763).** `scripts/backfill-nch3-sd-history.ts` backfills 789 North County events from `sdh3.com/history.shtml` (back to 2006-12) via the shared `backfillSdh3HistoryKennel` helper. nch3-sd ~61 → 850.

**NCH3 microsite (#1765) — new source.** Added `nch3.com` as a low-trust `HTML_SCRAPER` source (`src/adapters/html-scraper/nch3.ts` + registry + seed). It's a single "current run" page, so `config.upcomingOnly: true` keeps reconcile from cancelling the SDH3-sourced NCH3 events it can't enumerate. `scripts/backfill-nch3-microsite-event.ts` bootstraps the source row + scrapes live (the mandatory live-verification). Run #1920 merged into the existing 2026-05-23 canonical, **enriching it with hares / location / cost ($8) / trail type (A to A)**.

**LBH-PHX (#1595) — partial, issue stays open.** Re-confirmed live: the wp-events-manager calendar DB is purged (pre-2023 pages return empty grids), HashRego 404s. The only public trace of pre-2023 runs is the Internet Archive, which has ~10 archived `?event=lbh-NNN` detail pages. `scripts/backfill-lbh-phx-history-completion.ts` harvests them via the Wayback CDX API (`id_` raw snapshots, run# from slug, **date from page body — never the snapshot timestamp**, fields via the parent script's exported `parseDetailPage`). Recovered 6 pre-2023 runs (#511–516). **The remaining ~600 pre-2023 runs need a WordPress admin CSV export (no public path), so #1595 is intentionally left open.**

## Verification (prod)

| Script | apply | re-run (idempotent) |
|---|---|---|
| cleanup-mel-cross-kennel-conflation | reassigned 35 bike + 18 city, deleted 5 dups | 0 misrouted |
| backfill-mel-bike-hash-history | created=0 updated=37 (probe clean) | skipped=37 |
| backfill-mel-city-h3-history | created=1 updated=18 | skipped=19 |
| backfill-nch3-sd-history | created=789 updated=63 | skipped=852 |
| backfill-nch3-microsite-event | updated=1 (enriched) | skipped=1 |
| backfill-lbh-phx-history-completion | created=6 | skipped=8 |

Spot-checks (3 oldest + 3 newest) confirmed per kennel. No same-(kennel,date) duplicates in the Melbourne kennels; the 3 nch3-sd same-day pairs are faithful SDH3 double-rows (e.g. "Hashover" 08:00 + 09:00, distinct source URLs), not backfill artifacts. mel-new-moon has 0 residual bike/city-titled events.

## Checks
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (23 pre-existing warnings, none in changed files)
- `npm test` — **7745 passed**, 0 failed (36 new tests across the 3 new test files)
- `/simplify` — applied: extracted `reassignEventKennel`/`utcDayBounds` to `scripts/lib/event-reassign.ts` (shared with the existing cleanup), delegated the mel lib to `runBackfillScript`, used `filterEventsByWindow` in the adapter, DRY'd the nch3 bootstrap config from `SOURCES`. Skipped: deep merge-pipeline cross-kennel guard (out of scope; tracked separately) and a one-shot N+1 micro-opt.
- `/codex:adversarial-review` — **could not run: Codex usage limit hit (resets ~1:45 PM).** Should be re-run before merge; the 4 code-simplifier agents provided interim adversarial coverage.

## Follow-ups
- **Prod seed required:** the new `NCH3 Official Microsite` source row needs `npx prisma db seed` in prod to reconcile (Vercel deploys schema, not seed data). The backfill script already bootstrapped the row in prod, so this is just to keep seed authoritative.
- **Melbourne live-routing gap:** the live source still routes `"Ride #N"` / `"Bike Ride #N"` to mel-new-moon. This PR fixes history only; a future `kennelPatterns` tweak would fix go-forward routing.
- `.claude/rules/active-sources.md` not regenerated (avoids conflicts with parallel source-adding sessions); sync via `/update-sources-rule` later.

Closes #1752
Closes #1755
Closes #1763
Closes #1765
Refs #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)