### PR TITLE
fix(onh3): broaden GCal run pattern + guard publish-date typos

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -5825,7 +5825,12 @@ export const SOURCES = [
       scrapeFreq: "every_6h",
       scrapeDays: 365,
       config: {
-        kennelPatterns: [[String.raw`Run\s*#?\s*\d{3,4}`, "onh3"]],
+        // ONH3's calendar titles runs inconsistently: "Run 1334 …", "ONH3 1328 …",
+        // and bare "1324 …". Anchor on a leading 3-4 digit run number with an
+        // optional "ONH3"/"Run" prefix so every run matches while non-run socials
+        // ("Pia visit …", "Year 3 trip meeting") stay unmatched and drop out.
+        // Single \s (not \s+) keeps it safe-regex2-clean — see kennel-patterns.ts.
+        kennelPatterns: [[String.raw`^(?:ONH3\s)?(?:Run\s)?#?\d{3,4}\b`, "onh3"]],
         defaultKennelTag: null,
       },
       kennelCodes: ["onh3"],

--- a/src/adapters/html-scraper/onh3.test.ts
+++ b/src/adapters/html-scraper/onh3.test.ts
@@ -11,10 +11,10 @@ import {
 
 type Post = Parameters<typeof postToEvent>[0];
 
-function post(title: string, contentHtml: string, id = 1): Post {
+function post(title: string, contentHtml: string, id = 1, publishDate = "2026-03-29T07:58:13"): Post {
   return {
     id,
-    date: "2026-03-29T07:58:13",
+    date: publishDate,
     link: `https://onh3.wordpress.com/post/${id}/`,
     title: { rendered: title },
     content: { rendered: contentHtml },
@@ -138,16 +138,17 @@ describe("postToEvent", () => {
   it("parses a 2019-era post with an abbreviated month", () => {
     const ev = postToEvent(
       post(
-        "Run 1068. Hare: Dodger. Venue: Hare&#8217;s hole.",
-        "<p>Monday’s run will be hosted by Dodger. Run: #1068 Date: 16 Mar 2019 " +
-          "Hare: Dodger Time: 5:45 PM (registration starts at 5PM) Venue: Hare’s hole, Peponi Gardens</p>",
-        289,
+        "Run 1019. Hare: Pounder. Venue: Wasp & Sprout.",
+        "<p>Monday’s run will be hosted by Pounder. Run: #1019 Date: 16 Mar 2019 " +
+          "Hare: Pounder Time: 5:45 PM (registration starts at 5PM) Venue: Wasp & Sprout, Loresho</p>",
+        191,
+        "2019-03-12T09:00:00", // genuine 2019 announcement (run is 4 days out) — not a typo
       ),
     )!;
     expect(ev.date).toBe("2019-03-16");
-    expect(ev.runNumber).toBe(1068);
-    expect(ev.hares).toBe("Dodger");
-    expect(ev.location).toBe("Hare’s hole, Peponi Gardens");
+    expect(ev.runNumber).toBe(1019);
+    expect(ev.hares).toBe("Pounder");
+    expect(ev.location).toBe("Wasp & Sprout, Loresho");
   });
 
   it("trims a sentence of directions off a verbose venue", () => {
@@ -161,6 +162,31 @@ describe("postToEvent", () => {
       ),
     )!;
     expect(ev.location).toBe("Community Cooker at the Planning House on Lower Kabete");
+  });
+
+  it("drops a run dated far before its publish date (source year typo, e.g. #1068)", () => {
+    // Published March 2020, but the body Date reads "16 Mar 2019" — a typo.
+    const ev = postToEvent(
+      post(
+        "Run 1068. Hare: Dodger.",
+        "<p>Run: #1068 Date: 16 Mar 2019 Hare: Dodger Venue: Hare’s hole</p>",
+        289,
+        "2020-03-14T10:00:00",
+      ),
+    );
+    expect(ev).toBeNull();
+  });
+
+  it("keeps a recap-hybrid run posted a few days after the run", () => {
+    const ev = postToEvent(
+      post(
+        "Run 1329 Peeping Clam’s Birthday hash",
+        "<p>Date: Monday, 20 April 2026</p><p>Hares: Peeping Clam</p><p>Venue: German Point</p>",
+        353,
+        "2026-04-22T12:00:00", // 2 days after the run — within grace
+      ),
+    )!;
+    expect(ev.date).toBe("2026-04-20");
   });
 
   it("returns null for a post with no parseable date (a social)", () => {

--- a/src/adapters/html-scraper/onh3.ts
+++ b/src/adapters/html-scraper/onh3.ts
@@ -28,6 +28,7 @@ const WPCOM_API = "https://public-api.wordpress.com/wp/v2/sites/onh3.wordpress.c
 const KENNEL_TAG = "onh3";
 const KENNEL_TIMEZONE = "Africa/Nairobi";
 const DEFAULT_START_TIME = "17:45"; // 5:45 PM per kennel convention (registration from 5:00 PM)
+const STALE_PUBLISH_GRACE_MS = 120 * 86_400_000; // drop announcements dated >120d before publish (typo guard)
 const PER_PAGE = 100; // WordPress.com REST max
 const MAX_PAGES = 5; // 5 × 100 = 500 posts; the blog currently holds ~34
 
@@ -179,6 +180,15 @@ export function postToEvent(post: WPComPost): RawEventData | null {
   const dateField = fields.get("date");
   const date = dateField ? parseTextDate(dateField) ?? parseNumericDate(dateField) : undefined;
   if (!date) return null;
+
+  // A run announcement dated far before its own publish date is a source typo
+  // (post #1068 was labeled "16 Mar 2019" but published in March 2020 for a 2020
+  // run). Drop it rather than emit a mis-dated duplicate. The 120-day grace keeps
+  // recap-hybrid posts that go up a few days after the run (e.g. #1329).
+  const publishMs = Date.parse(post.date);
+  if (Number.isFinite(publishMs) && Date.parse(`${date}T12:00:00Z`) < publishMs - STALE_PUBLISH_GRACE_MS) {
+    return null;
+  }
 
   const { runNumber: titleRun, theme } = parseOnh3Title(post.title.rendered);
   // Body fallback uses the shared "#NNN" parser on the "Run:" field ("Run: #1068").

--- a/src/adapters/html-scraper/onh3.ts
+++ b/src/adapters/html-scraper/onh3.ts
@@ -185,8 +185,11 @@ export function postToEvent(post: WPComPost): RawEventData | null {
   // (post #1068 was labeled "16 Mar 2019" but published in March 2020 for a 2020
   // run). Drop it rather than emit a mis-dated duplicate. The 120-day grace keeps
   // recap-hybrid posts that go up a few days after the run (e.g. #1329).
-  const publishMs = Date.parse(post.date);
-  if (Number.isFinite(publishMs) && Date.parse(`${date}T12:00:00Z`) < publishMs - STALE_PUBLISH_GRACE_MS) {
+  // Compare both at UTC midnight (date-only) so the result is independent of the
+  // server timezone — post.date carries no offset, so a raw Date.parse would be local.
+  const publishMs = Date.parse(`${post.date.slice(0, 10)}T00:00:00Z`);
+  const eventMs = Date.parse(`${date}T00:00:00Z`);
+  if (Number.isFinite(publishMs) && Number.isFinite(eventMs) && eventMs < publishMs - STALE_PUBLISH_GRACE_MS) {
     return null;
   }
 


### PR DESCRIPTION
Follow-up to the ONH3 onboarding ([#1802](https://github.com/johnrclem/hashtracks-web/pull/1802)), fixing two issues found during post-merge verification. Both are low-risk; the WP source already covered the affected data.

## 1. GCal `kennelPattern` was too strict
The ONH3 Google Calendar titles runs inconsistently — `Run 1334 …`, `ONH3 1328 …`, and bare `1324 …`. The original pattern `Run\s*#?\s*\d{3,4}` only matched the `Run NNNN` form, so 5 real runs came back `UNMATCHED` (ongoing alert noise; the WP table covered the data).

**Fix:** `^(?:ONH3\s)?(?:Run\s)?#?\d{3,4}\b` — anchors on a leading 3–4 digit run number with an optional `ONH3`/`Run` prefix. Verified it matches all 5 run formats and still skips non-run socials (`Pia visit …`, `Year 3 trip meeting`). Uses single `\s` (not `\s+`) to stay **safe-regex2-clean** (the `\s+` form failed `safe-regex2`, which `kennel-patterns.ts` requires).

## 2. Publish-date typo guard
ONH3 post #1068 was labeled `Date: 16 Mar 2019` but published in March 2020 for a 2020 run — a source typo that produced a **mis-dated ghost Event** at 2019-03-16 alongside the correct 2020-03-16 backfill row.

**Fix:** in `postToEvent`, drop a run announcement dated **>120 days before its own publish date** (`post.date`). A run is announced shortly before (or, for recap-hybrid posts, just after) it happens, so a date a year before publish is a typo. The 120-day grace keeps legitimate recap-hybrids like #1329 (posted 2 days after the run). Verified live: adapter events 40→39, the 1068 ghost no longer emitted.

## Checks
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (7888 passed, +3 new ONH3 tests)
- Live-verified both fixes against the production source.
- `/simplify` run: caught and fixed the regex ReDoS-shape regression (confirmed via `safe-regex2`).

## Post-merge steps
1. `npx prisma db seed` — updates the `ONH3 Google Calendar` source `config` (re-seed applies changed `config` per `ensureSources`).
2. Delete the stale ghost Event `cmpr5aj8e001w97hne6a3ito3` (run 1068, 2019-03-16) — the guard prevents it recurring.
3. Re-scrape both ONH3 sources so the GCal picks up the previously-unmatched runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)