### PR TITLE
feat: kennel-onboarding system

### DIFF
--- a/docs/kennel-onboarding/README.md
+++ b/docs/kennel-onboarding/README.md
@@ -1,0 +1,87 @@
+# Kennel Onboarding System
+
+A lightweight system to onboard **one new kennel per day**, researched right the first time, so
+kennels don't accumulate audit rework (missing logos, founded years, socials, historical data).
+
+## How it works (research → handoff → local Claude Code → PR)
+
+A **scheduled task in Cowork runs every morning at ~6 AM** and:
+
+1. Reads [`daily-onboarding-prompt.md`](daily-onboarding-prompt.md) — the operating manual that
+   merges the [source onboarding playbook](../source-onboarding-playbook.md) **and** every
+   completeness field the per-kennel deep dive (`src/lib/admin/deep-dive-prompt.ts`) normally
+   catches after the fact.
+2. Pulls the top `queued` kennel from [`target-queue.md`](target-queue.md).
+3. Dedups against **LIVE production data** (the `hashtracks.xyz` sitemap read via the Chrome MCP
+   — *not* the seed files, which are incomplete; the prod DB isn't reachable from the run's
+   sandbox), **verifies the source is live** (pulls a real event sample), and harvests full
+   metadata (logo, founded year, socials, hash cash, schedule, description, historical-backfill
+   availability, coord sanity, pagination depth, end times).
+4. Consults [`source-platform-notes.md`](source-platform-notes.md) for platform-specific gotchas
+   (Squarespace, Wix, WordPress.com, etc.) — and *appends* to it when something new is learned,
+   so the system gets smarter every run.
+5. Writes a complete **handoff file** to [`handoffs/`](handoffs/) — verified sample data,
+   ready-to-paste seed blocks, adapter plan, and a leading **`▶ FOR CLAUDE CODE`** directive that
+   makes the whole file self-executing.
+6. Updates the queue + [`run-log.md`](run-log.md), and **refills the queue to ~20** whenever it
+   drops to 5 or fewer (dynamic-source kennels only, deduped against the live sitemap).
+
+Then the last mile (implement → PR) happens via Claude Code. The handoff is the brief.
+
+**Default workflow — manual paste into a local Claude Code session:**
+
+```bash
+bash scripts/copy-newest-handoff.sh   # alias suggestion: `htn`
+```
+
+That copies the newest un-implemented, non-voided handoff to your clipboard (skipping any that
+already have an `onboard/<code>-*` branch on origin, so re-runs are idempotent). Paste into a
+fresh Claude Code session in `hashtracks-web`; its top directive drives branch → seed → adapter
+→ live-verify → tsc/lint/test → PR.
+
+**Why local?** HashTracks adapters routinely need NAS-only resources during live verification —
+the NAS `browserRender` service (Wix / Google Sites / SPA scraping) and the residential proxy
+sit behind your Tailscale network, reachable from your Mac but not from Anthropic's cloud. Local
+sessions hit them; cloud routines can't. Live debugging is also faster locally.
+
+## The files
+
+| File | What it is |
+|---|---|
+| `daily-onboarding-prompt.md` | The operating manual the daily Cowork run executes. Edit to change the workflow. |
+| `target-queue.md` | Ranked backlog. **Cooperatively editable** — reorder/add/strike rows anytime. |
+| `source-platform-notes.md` | Self-improving platform memory. Daily run consults + appends. Currently covers Squarespace, Wix, WordPress.com. |
+| `handoffs/<date>-<kennel>.md` | One complete onboarding package per run, with the `▶ FOR CLAUDE CODE` directive at the top. |
+| `run-log.md` | Append-only log of each run's outcome. |
+| `claude-code-routine.md` | **Parked** alternate — cloud-hosted Claude Code routine. See its top note. |
+
+## Cooperating with the queue
+
+It's a plain markdown table — edit it freely. Bump something to Rank 1 to onboard it next, add
+your own targets (include a verified dynamic source + confidence), or strike rows you don't want.
+The auto-refill only kicks in at ≤5 `queued` rows and only adds dynamic-data kennels deduped
+against the live sitemap.
+
+## Alternate implementation paths (parked)
+
+Both kept around in case the situation changes. Neither is the current default.
+
+**Claude Code routine (cloud) — parked.** A `/schedule` routine on Anthropic's infrastructure can
+implement the newest committed handoff and open a PR. Full setup in
+[`claude-code-routine.md`](claude-code-routine.md). Currently parked because cloud sessions can't
+reach NAS-only resources (`browserRender`, residential proxy) over Tailscale. Revisit if those
+are exposed publicly (e.g. via Cloudflare Tunnel) or if a kennel pipeline lands that doesn't need
+them.
+
+**Local launchd implementer — parked.** Headless `claude` CLI invoked by launchd on the MacMini,
+working in an isolated clone (`~/.hashtracks-onboard-bot`). Files at
+[`scripts/onboard-implement.sh`](../../scripts/onboard-implement.sh) +
+[`scripts/com.hashtracks.onboard-implement.plist`](../../scripts/com.hashtracks.onboard-implement.plist).
+Kept as a fallback when you want full hands-off local automation; current default is the manual
+paste workflow above since live-debugging beats unattended runs for new-adapter cases.
+
+## Changing the schedule
+
+The schedule lives in the Cowork scheduled task `onboard-daily-kennel` (runs ~6 AM daily). Ask
+Claude to change it (e.g. "move the daily kennel onboarding to 7 AM"). Note: scheduled tasks run
+only while the Claude desktop app is open; if it's closed at 6 AM, the task runs on next launch.

--- a/docs/kennel-onboarding/claude-code-routine.md
+++ b/docs/kennel-onboarding/claude-code-routine.md
@@ -1,0 +1,161 @@
+# Claude Code Routine — Auto-Implement Daily Handoff
+
+> **Currently parked.** John is running implementation in **local** Claude Code sessions
+> (manual paste — see [`README.md`](README.md)) because HashTracks adapters routinely need
+> NAS-only resources during live verification (`browserRender` for Wix/Google-Sites/SPA;
+> residential proxy) — both on Tailscale, unreachable from Anthropic's cloud routines.
+>
+> Revisit this doc if (a) those services get exposed publicly (e.g. via Cloudflare Tunnel) or
+> (b) a stretch of kennels lands that doesn't need them. The setup below is ready to use as-is.
+
+---
+
+The second half of the loop (handoff → PR) can run as a **Claude Code routine** — a cloud-hosted
+recurring task created via `/schedule` in any Claude Code session.
+
+## How the two halves would fit together
+
+1. **Cowork scheduled task (~6 AM)** — `onboard-daily-kennel` researches one kennel against the
+   live sitemap and writes a complete, verified handoff to `docs/kennel-onboarding/handoffs/`.
+2. **Bridge — commit + push the handoff to `main`.** Routines see only committed files (they
+   clone from GitHub). See [Bridging the handoff](#bridging-the-handoff) below.
+3. **Claude Code routine (~7 AM)** — picks up the newest handoff, follows its top "▶ FOR CLAUDE
+   CODE" directive, and opens a PR. You review and merge.
+
+## Create the routine
+
+In any Claude Code session in this repo, type `/schedule`, paste the prompt below as the
+routine's instructions, set the schedule to **daily at 7 AM in your timezone**, and confirm. You
+can also create/manage routines at <https://claude.ai/code/routines>. Pro plan limit is 5 routine
+runs/day; one daily run is well inside that.
+
+## The routine prompt (copy verbatim)
+
+```
+You are the HashTracks daily kennel onboarding implementer. A separate task writes a
+verified onboarding handoff into docs/kennel-onboarding/handoffs/ each morning. Your job
+is to implement the NEWEST handoff that hasn't been implemented yet, end-to-end, and open
+a PR. STOP after opening the PR — do not merge.
+
+STEPS:
+
+1. Refresh the repo.
+   - git fetch origin --prune
+   - git checkout main && git pull --ff-only
+   - eval "$(fnm env)"; fnm use 20
+   - npm ci   (if node_modules is missing)
+
+2. Pick today's handoff.
+   - Scan docs/kennel-onboarding/handoffs/*.md (skip README.md).
+   - Skip any file whose first 5 lines contain "VOID" (case-insensitive).
+   - Order by filename desc (newest YYYY-MM-DD- first).
+   - For each candidate, derive <code> from the filename (the part after the
+     YYYY-MM-DD- prefix, before .md). Check whether an implementation branch
+     already exists on origin:
+       git ls-remote --heads origin "onboard/<code>-*"
+     If any matching branch exists, that handoff was already implemented — skip it
+     and try the next.
+   - If no un-implemented handoff is found, print "nothing to do" and exit 0.
+
+3. Implement it. Open the chosen handoff file and follow its TOP "▶ FOR CLAUDE CODE"
+   directive exactly. The whole file is the brief. Required honors:
+   - Branch off clean main:  onboard/<code>-<YYYYMMDD>
+   - Apply the Ready-to-paste seed (kennel + alias + source; for "source-add" type,
+     don't duplicate the kennel — just add/repoint the source and enrich missing fields).
+   - If the handoff's Effort says "NEW adapter", build it per the parsing plan:
+     create src/adapters/<dir>/<name>.ts + <name>.test.ts and add the URL pattern to
+     htmlScrapersByUrl in src/adapters/registry.ts. If Effort says "config-only", the
+     adapter already exists — only the Source row + URL pattern (if applicable) changes.
+   - If the handoff says the region isn't seeded, add it to the region seed mirroring an
+     existing metro (METRO level under the right country, with centroid + timezone).
+   - npx prisma db seed
+   - Live-verify against the real source URL per .claude/rules/live-verification.md AND
+     the handoff's "feed HEAD-check" guidance. Resolve every item marked "⚠️ Claude
+     Code must confirm" (e.g. HEAD the feed URL — text/calendar for an .ics; if it's
+     text/html the export is gated off and you use the documented fallback). Events
+     non-empty + upcoming, dates UTC-noon, startTime "HH:MM", kennelTag resolves with no
+     unmatched.
+   - Honor the "Implementation gotchas" block at the bottom of the handoff:
+       * Rejecting upstream coords needs dropCachedCoords:true (not just undefined).
+       * On partial pagination failure, set kennelPageFetchErrors + kennelPagesStopReason.
+       * For historical-archive sources, set config.upcomingOnly:true (ONH3 pattern).
+       * Tests using vi.spyOn(globalThis,"fetch") need beforeEach(vi.restoreAllMocks).
+       * Keep functions under Sonar S3776 cognitive complexity ≤15 (extract helpers).
+       * Use known-safe regex patterns for Sonar S5852 (split combined regexes; use
+         (\S.*) instead of (.+)$; make optional groups truly optional).
+       * Self-host tokenized CDN logos to public/kennel-logos/<code>.<ext>.
+   - Consult docs/kennel-onboarding/source-platform-notes.md for platform-specific gotchas
+     before drafting parsing logic; if you learn a new platform-level lesson while
+     implementing, append it there.
+   - Include the historical backfill only if the handoff says it's worth it.
+   - npx tsc --noEmit && npm run lint && npm test
+     All three must pass. Fix what's red. Don't disable lint rules or skip tests.
+
+4. Open the PR.
+   - git push -u origin onboard/<code>-<YYYYMMDD>
+   - gh pr create --base main --title "Onboard <shortName> (<region>)" with a body that
+     includes:
+       * Source type + URL (and adapter: config-only vs new).
+       * Live-verification results: event count + date range + a sample event.
+       * Whether historical backfill is included + count.
+       * The deep-dive checklist from the handoff (showing nothing was deferred).
+       * A "Implements: docs/kennel-onboarding/handoffs/<handoff-filename>" line.
+   - STOP. Do NOT merge. Do NOT enable auto-merge.
+
+5. If you cannot complete safely (live-verify fails and the documented fallback also fails;
+   tests can't be made green in-run; ambiguous adapter plan): push what you have and open
+   a DRAFT PR titled "WIP: onboard <shortName>" explaining what blocked you. Do NOT
+   force-fix, guess, or skip live verification.
+
+NEVER:
+ - edit applied prisma migration files (author a new migration if needed),
+ - commit secrets (.env, .env.local),
+ - modify RawEvent records or anything outside the onboarding scope,
+ - merge the PR,
+ - touch unrelated files in the same PR.
+
+If anything here conflicts with the handoff file, the HANDOFF takes precedence (it carries
+source-specific detail this prompt cannot).
+```
+
+## Bridging the handoff
+
+Routines see only what's committed and pushed. Two options to surface the morning's handoff:
+
+**Option A — manual commit (simplest, 30 seconds/morning):**
+
+```bash
+cd ~/Developer/hashtracks-web
+git checkout main && git pull
+git add docs/kennel-onboarding/handoffs docs/kennel-onboarding/run-log.md docs/kennel-onboarding/target-queue.md
+git commit -m "handoff: $(ls -t docs/kennel-onboarding/handoffs/*.md | head -1 | xargs basename .md)"
+git push
+```
+
+**Option B — minimal launchd helper (fully hands-off):** a small `~6:30 AM` job that just
+commits + pushes new handoffs. Keep the helper one job, separate from the implementation work
+(which is now the routine's job).
+
+## Migrating from the local launchd implementer
+
+The `scripts/onboard-implement.sh` + `scripts/com.hashtracks.onboard-implement.plist` workflow
+in this repo is a parallel option that runs a full local implementation cycle. With a routine in
+place you can:
+
+```bash
+launchctl unload -w ~/Library/LaunchAgents/com.hashtracks.onboard-implement.plist
+rm ~/Library/LaunchAgents/com.hashtracks.onboard-implement.plist
+```
+
+…and leave the scripts in the repo as a fallback.
+
+## Why this design
+
+- **Cloud-hosted** → laptop power state and network don't matter; runs on Anthropic infra.
+- **Full autonomous permissions in the routine** → no `--dangerously-skip-permissions` debate;
+  no permission prompts to stall on.
+- **Clean isolation** → routine starts from a fresh GitHub checkout each run; no entanglement
+  with a dirty working tree.
+- **Stops at PR** → CI + your review remain the safety net before anything lands on `main`.
+- **Self-improving** → both the daily research prompt and the routine reference
+  `source-platform-notes.md`; new platform learnings accrue there over time.

--- a/docs/kennel-onboarding/daily-onboarding-prompt.md
+++ b/docs/kennel-onboarding/daily-onboarding-prompt.md
@@ -1,0 +1,416 @@
+# Daily Kennel Onboarding — Autonomous Research & Handoff Prompt
+
+> **Purpose:** Each morning, take **one new kennel** from the queue, research it exhaustively,
+> verify its data source is live, and produce a **complete, self-contained handoff file** that
+> Claude Code can execute in one shot to implement and open the PR.
+>
+> This run merges the entire [`source-onboarding-playbook.md`](../source-onboarding-playbook.md)
+> checklist **and** every completeness field the per-kennel deep dive
+> (`src/lib/admin/deep-dive-prompt.ts`) normally catches *after the fact* — logo, founded year,
+> socials, hash cash, schedule, description, source accuracy, historical backfill. Get it all on
+> day one so the kennel never needs audit rework.
+
+## Why handoff, not direct PR
+
+This task runs in a sandboxed environment that **can read the repo and write files, but cannot
+reliably perform git operations** (the repo mount is often parked on a feature branch with
+uncommitted work, and `.git/` writes are permission-blocked). So this run does **no git** — it
+does the research + verification + drafting, and writes a handoff file. **Claude Code**, running
+in a local terminal where git works and where the NAS / live DB are reachable, then implements it
+end-to-end through PR creation. The handoff file leads with a `▶ FOR CLAUDE CODE` directive so the
+whole file is the brief.
+
+**Do not** attempt `git checkout`/`branch`/`commit`/`push` in this run. **Do** write files
+(the handoff, queue updates, run log) — plain file writes work fine.
+
+---
+
+## Golden rules
+
+1. **One kennel per run.** Take the single top target from the queue. Do not batch.
+2. **Dynamic data only.** Never hand off a kennel whose only source is a static Facebook page,
+   Instagram, or flyer. The queue is pre-filtered — but re-confirm the source is live (Step 3).
+   If the top target has no working dynamic source, mark it `blocked` and move to the next.
+3. **Verify the source is live before writing the handoff.** Fetch the real source and extract a
+   sample of real, upcoming events. A handoff built on an unverified source is worthless.
+4. **Front-load the deep dive.** Capture logo, founded year, socials, hash cash, schedule,
+   description, historical-backfill availability, end-times, coord sanity, pagination depth
+   *now* — they go in the handoff.
+5. **The handoff must be complete and self-contained.** Claude Code should implement from it
+   without re-researching: exact seed blocks, adapter type + config (or scraper plan), collision
+   results, verified sample data, an Effort estimate, and the embedded Claude Code directive
+   at the top.
+
+---
+
+## Repo & environment
+
+- **Repo path:** `/Users/johnclem/Developer/hashtracks-web` (bash mount: `/sessions/*/mnt/hashtracks-web`).
+  Read freely; **write only** to `docs/kennel-onboarding/` (handoff, queue, run log).
+- **Node (for any read-only probes):** `eval "$(fnm env)" && fnm use 20` if needed. You will NOT
+  run `prisma db seed` or the full pipeline here — that happens in Claude Code.
+- **Queue:** [`target-queue.md`](target-queue.md)
+- **Handoffs:** `handoffs/<YYYY-MM-DD>-<kennelCode>.md` (create the dir if missing)
+- **Run log:** [`run-log.md`](run-log.md)
+- **Key references:** [`docs/source-onboarding-playbook.md`](../source-onboarding-playbook.md),
+  [`source-platform-notes.md`](source-platform-notes.md) (platform gotchas — consult AND append to),
+  [`prisma/seed-data/{kennels,aliases,sources}.ts`](../../prisma/seed-data),
+  [`src/adapters/registry.ts`](../../src/adapters/registry.ts),
+  [`src/adapters/types.ts`](../../src/adapters/types.ts),
+  [`.claude/rules/adapter-patterns.md`](../../.claude/rules/adapter-patterns.md),
+  [`.claude/rules/live-verification.md`](../../.claude/rules/live-verification.md)
+
+---
+
+## Step 1 — Pick today's target
+
+Open `target-queue.md`. Take the **top row whose Status is `queued`** (lowest Rank first). If
+none are `queued`, jump to **Step 8's refill logic**, refill, then pick the new #1. Mark the
+chosen row `in_progress` with today's date. Record shortName, full name, region, proposed source
+type + URL.
+
+## Step 2 — Deduplicate against LIVE production data (NOT the seed files)
+
+> ⚠️ **The seed files are NOT the source of truth for what's live.** Kennels get added directly
+> to the production DB via the admin UI / "Suggest a Kennel" (`Kennel.isManualEntry`), so the
+> live site has *more* kennels than `prisma/seed-data/` (e.g. ~412+ live vs ~349 seeded). A kennel
+> can be fully live — page, logo, source, events — yet absent from `seed-data/`. **Always dedup
+> against the live production data first.** This is the #1 cause of wasted onboarding work.
+
+**Tooling reality (important):** the prod DB is **not reachable** from this sandbox (Railway host
+isn't in the network allowlist — DNS fails). The kennel directory and region pages are
+**client-rendered** — a plain fetch returns only a region's *count* ("SG7 / 7 kennels"), **not**
+the kennel names. So the authoritative full list comes from the **sitemap via the Chrome MCP**:
+
+- **PRIMARY — read the live sitemap with the Chrome MCP (authoritative, confirmed working).** The
+  server-generated `https://www.hashtracks.xyz/sitemap.xml` lists every non-hidden kennel slug
+  (the plain fetch tool returns it as binary, so use Chrome). Steps:
+  1. `list_connected_browsers` → `select_browser` (the user runs "Personal Chrome on MacMini").
+  2. `tabs_context_mcp { createIfEmpty: true }` → `navigate` to `https://www.hashtracks.xyz/sitemap.xml`.
+  3. `javascript_tool` to extract the slug list, e.g.:
+     ```js
+     [...new Set(Array.from(document.body.innerText.matchAll(/https?:\/\/[^\s<]+/g))
+       .map(m=>m[0]).filter(u=>/\/kennels\//.test(u)&&!/\/kennels\/region\//.test(u))
+       .map(u=>u.split('/kennels/')[1].replace(/[#?].*$/,'').replace(/\/$/,'')).filter(Boolean))].sort()
+     ```
+  4. Check the candidate against this list by slug AND by scanning for region/name fragments
+     (slugs aren't always the obvious kebab — e.g. Singapore Harriets is `sg-harriets`, Miami
+     Valley is `mvh3-day`, HK Monday is `hk-h3`). If present ⇒ **already live**.
+- **FALLBACK (only if Chrome isn't connected at run time) — per-slug fetch + empty regions.**
+  Fetch `https://www.hashtracks.xyz/kennels/<slug>` for 2–3 slug variants; a page rendering the
+  kennel name + "Est." + events ⇒ live. And **prefer candidates whose region shows 0 kennels**
+  (`/kennels/region/<region-slug>` count) — there, "not live" is unambiguous. A slug miss only
+  rules out that one slug, so without the sitemap you cannot safely treat a saturated-region
+  candidate as new — skip it until the sitemap can confirm.
+
+**Secondary check — the seed files** (only to see whether a *source* / adapter config already
+exists in code for an already-live kennel):
+
+```bash
+grep -in "<shortName>\|<domain/calendar-id/slug>" prisma/seed-data/sources.ts prisma/seed-data/kennels.ts
+```
+
+Decision matrix:
+
+| Kennel live on the site? | A dynamic source already feeds it? | Action |
+|---|---|---|
+| No | — | **Full onboard handoff** (kennel + aliases + source). |
+| Yes | Yes (events are flowing from an equivalent source) | **Skip.** Mark row `done (already live)`, pick next `queued`. |
+| Yes | No / stale / only a static/Facebook source, and you found a real dynamic one | **Source-add handoff** — don't re-create the kennel; add/repoint the `Source`, link via `kennelCodes`, and enrich any missing kennel fields (logo/foundedYear/socials). Note as "source-add". |
+
+Repeat until you land on a kennel that is genuinely **not live**, or a live kennel that's
+genuinely **missing this dynamic source**. Only then proceed.
+
+## Step 3 — Verify the dynamic source is LIVE (mandatory before drafting)
+
+Fetch the source directly and **extract a real sample** of upcoming events. Capture the raw
+sample for the handoff. Use the right probe (playbook §1):
+
+- **Google Calendar:** `curl "https://www.googleapis.com/calendar/v3/calendars/{id}/events?key=$GOOGLE_CALENDAR_API_KEY&maxResults=5&timeMin=$(date -u +%Y-%m-%dT%H:%M:%SZ)"`
+- **iCal:** `curl -s "<ics url>" | head -120` — find upcoming `VEVENT`/`DTSTART`
+- **Meetup:** `curl -s "https://api.meetup.com/{group-urlname}/events"` — must list upcoming events
+- **WordPress:** `curl -s "<site>/wp-json/wp/v2/posts?per_page=5"` (or The Events Calendar: `/wp-json/tribe/events/v1/events`)
+- **WordPress.com hosted:** `curl -s "https://public-api.wordpress.com/wp/v2/sites/<host>/posts?per_page=5"` — see `source-platform-notes.md` → WordPress.com section
+- **Squarespace:** see `source-platform-notes.md` → Squarespace section (config-only via existing `SquarespaceEventsAdapter`)
+- **HTML:** `curl -s "<url>" | head -200` — locate the event list / structure
+- **Wix / Google Sites / SPA:** these need the NAS `browserRender()` service. See `source-platform-notes.md` → Wix section. If `BROWSER_RENDER_URL`/`BROWSER_RENDER_KEY` aren't available, document clearly and flag for Claude Code rather than guessing.
+
+**Consult [`source-platform-notes.md`](source-platform-notes.md)** for platform-specific checks
+(Wix, Squarespace, WordPress.com, etc.) before drafting — and **append to it** if you learn
+something new about a platform. It exists because confident-but-wrong source plans (e.g.
+"config-only iCal" when the export is tenant-gated off) cause real rework.
+
+**Don't claim a feed works until you've checked the *actual* URL the adapter will use.** Many
+platforms gate their clean feed behind a toggle. HEAD-check it:
+```bash
+curl -sI "<feed-url>" | grep -i content-type   # e.g. expect text/calendar for an .ics feed
+```
+If the content-type is wrong (e.g. `text/html` from an `?format=ical`), the feed is disabled —
+pick the working path (often a JSON/API endpoint) and say so. If you can't fetch it from the
+sandbox at all, flag `⚠️ Claude Code must confirm` (see verification reality below) — but if you
+*can* HEAD it, do.
+
+**When sampling a JSON/API source, also capture (these are detectable now and bite later if missed):**
+
+- **Pagination / true history depth.** Look for a `pagination`/`nextPage`/`offset`/`_links.next`
+  field. Page 1 is usually not the whole history. Report total reachable past events + how to
+  paginate — the adapter likely needs pagination (with a max-pages guard) from day 1.
+- **Default/garbage coordinates (silent corruption).** If events carry lat/lng, check for a
+  **default pin repeated across many events** or duplicate `map*`/`marker*` pairs (e.g.
+  Squarespace's Manhattan `40.7207559` default). Report "X of N events have unset/default pins" and
+  note the adapter must reject those coords **and** emit `dropCachedCoords: true` (clearing a coord
+  doesn't unset an already-stored bad one). This is the kind of thing that ships silently and only
+  gets caught when a kennel shows up on the wrong continent on the map.
+- **End times / multi-day.** If events carry an end timestamp, note it — same-day → `endTime`,
+  different-day → multi-day `endDate`. Don't discard it as "acceptable."
+
+**Verification reality (learned from live runs) — don't get stuck here.** In this sandbox,
+`web_fetch` renders **HTML pages fine**, but raw machine-readable bodies (`.ics`, `?format=json`,
+REST/API) on domains **outside the allowlist** usually fail (HTTP 403 `blocked-by-allowlist`, or
+returned as binary), and the Chrome MCP **auto-denies a brand-new domain** when no user is present
+to approve it (Chrome works for already-approved domains like `hashtracks.xyz`). So:
+
+- **Prove events exist from the HTML listing** (almost always fetchable) — that's enough to
+  confirm the source is live and to capture the sample.
+- When the machine-readable feed itself (the `.ics`/JSON/REST URL the adapter will use) can't be
+  fetched here, **record its exact URL and flag it `⚠️ Claude Code must confirm at build`** — do
+  **not** block or downgrade the handoff over it. Claude Code live-verifies the feed anyway (the
+  adapter rejects a bad body loudly).
+
+**Capture for the handoff:** event count seen, date range, and 3–5 sample events with whatever
+fields the source exposes (date, time, title, hares, location, description, run number).
+
+**If the source is genuinely dead / has no upcoming events** (HTML listing itself is empty/gone):
+mark the target `blocked` with the reason, fall back to the next `queued` target (return to
+Step 1). A feed you simply couldn't fetch from the sandbox is **not** "dead" — flag it instead.
+
+## Step 4 — Full metadata harvest (onboarding + deep-dive in one pass)
+
+Gather **all** of the following (cross-reference the kennel's site, the live source, and the two
+H3 directories — **HHH Genealogy** `genealogy.gotothehash.net` for aliases/lineage/first-run
+date, **Half-Mind.com** for schedule/hash cash/contacts; playbook §3):
+
+Kennel profile (maps to the `Kennel` model): `fullName`, `shortName`, `kennelCode`
+(lowercase, URL-safe, **permanent**), `region`, `country`, `aliases`, `website`, `facebookUrl`,
+`instagramHandle`, `twitterHandle`, `discordUrl`, `scheduleDayOfWeek`, `scheduleTime`,
+`scheduleFrequency`, `foundedYear`, `hashCash`/payment, `dogFriendly`, `walkerFriendly`,
+`description` (short "about us"), **`logoUrl`**, and lat/lng if easily found.
+
+- **`logoUrl` stability:** prefer a stable URL. If the only logo is a **tokenized/ephemeral CDN
+  URL** (e.g. `images.squarespace-cdn.com/.../<hash>/...`, signed S3, Wix `static.wixstatic.com/media/<hash>~mv2.<ext>`),
+  flag it `⚠️ self-host` — recommend Claude Code download it into `public/kennel-logos/<code>.<ext>`
+  and reference that path instead (these CDN URLs can rotate when the kennel re-uploads).
+- **Schedule with more than one pattern → suggest `scheduleRules`, not just `scheduleDayOfWeek`.**
+  If the kennel runs e.g. "weekly Wednesday + occasional Saturday," a single `scheduleDayOfWeek`
+  miscategorizes the rest in Travel Mode. Propose an RRULE array, e.g.:
+  ```ts
+  scheduleRules: [
+    { rrule: "FREQ=WEEKLY;BYDAY=WE", startTime: "18:30", label: "Primary" },
+    { rrule: "FREQ=MONTHLY;BYDAY=SA", startTime: "12:00", label: "Occasional Saturday" },
+  ]
+  ```
+
+Deep-dive completeness (resolve now, record in the handoff): which event fields the source
+exposes (hares/location/description/start time); **historical events** available (count + which
+fields + whether a one-shot DB insert could backfill them without changing the adapter — the
+preferred path; per the ONH3 pattern, split future-only into the adapter and past into a
+`scripts/backfill-<code>-history.ts` one-shot); aggregator cross-refs (Harrier Central / Hash
+Rego / hashruns.org); any secondary source worth adding; avoid stale placeholder titles like
+"`<shortName>` Trail".
+
+## Step 5 — Choose kennelCode + check collisions
+
+```bash
+grep -i '"<proposed-code>"' prisma/seed-data/kennels.ts prisma/seed-data/aliases.ts
+```
+
+If taken, add a region suffix (`lvh3-nv`, `mh3-tn`, `bh3-bkk`, `ah3-nz`, …). Watch the
+collision-prone abbreviations in playbook §2. Resolve before drafting seed data.
+
+## Step 6 — Draft the implementation (seed + adapter plan)
+
+Decide the adapter type, preferring **config-only** sources (no new code): Google Calendar,
+Sheets, iCal, Meetup, Hash Rego, Harrier Central, Static Schedule, and the config-driven
+`GenericHtmlAdapter`.
+
+**"Config-only" is a claim you must EARN — two conditions, both required:** (a) the specific feed
+the config points at is **verified working** (Step 3 HEAD/structure check — not assumed), AND (b)
+an adapter for that source type **already exists** in `src/adapters/registry.ts`. If either is
+false, this is **not** config-only — give a realistic effort estimate (e.g. "new ~300–500 LoC
+shared platform adapter + tests"), not "alternative HTML scrape config." (The SACH3 handoff said
+"config-only iCal"; the iCal export was gated off and it actually needed a new ~360-LoC
+`SquarespaceEventsAdapter` + tests across 4 PRs. Don't repeat that.) Put your **effort estimate**
+in the handoff so Claude Code and John aren't surprised.
+
+Produce:
+
+- **Ready-to-paste seed blocks** following the real shapes in `prisma/seed-data/` and playbook
+  §4/§9: the `Kennel` object (or, for source-add, *which existing kennel*), the `aliases` entry,
+  and the `Source` row with `type`, `trustLevel` (GCal/HashRego 8–9, Meetup/Sheets 7–8, iCal 6–7,
+  HTML 5–6), `scrapeFreq: "daily"`, adapter `config`, and **`kennelCodes`** (the source-kennel
+  guard — list every kennel the source feeds).
+- For a **new HTML scraper** (only if nothing else fits): a parsing plan — target URL, the
+  fetch method (`fetchHTMLPage` from `src/adapters/utils.ts` for static HTML; `browserRender`
+  from `src/lib/browser-render.ts` for JS-rendered sites — the canonical call in scrapers;
+  `fetchWordPressPosts`; `fetchBloggerPosts`), the CSS selectors / fields, date-format notes, a
+  captured HTML snippet for the test fixture **that mirrors the real DOM structure** (e.g. Wix
+  wraps blocks in `[data-testid="richTextElement"]` — a flat fixture passes tests then fails
+  live; see `source-platform-notes.md` → Wix), and the `htmlScrapersByUrl` registry entry to add.
+- Conventions to honor downstream: dates as **UTC noon**, `startTime` as `"HH:MM"` string,
+  `cuid()` IDs, longer kennel-resolver patterns before shorter ones.
+
+## Step 7 — Write the handoff file
+
+Create `docs/kennel-onboarding/handoffs/<YYYY-MM-DD>-<kennelCode>.md` with this structure:
+
+````markdown
+# Onboarding Handoff — <shortName> (<region>) — <YYYY-MM-DD>
+
+> ## ▶ FOR CLAUDE CODE — implement this entire file, end to end
+> You are being given this whole file. Do the full onboarding now, autonomously:
+> 1. Branch off a clean `main`: `onboard/<kennelCode>-<YYYYMMDD>`.
+> 2. Apply the **Ready-to-paste seed** below (kennel + alias + source; for a `source-add`, only
+>    add/repoint the source and enrich missing kennel fields — don't duplicate the kennel). If the
+>    region isn't seeded yet, add it as noted in **Adapter notes**.
+> 3. Implement/configure the adapter exactly as in **Adapter notes** (prefer the config-only path).
+> 4. `npx prisma db seed`, then **live-verify against the real source URL** per
+>    `.claude/rules/live-verification.md` — resolve every item flagged `⚠️ Claude Code must
+>    confirm` in **Live source verification** (e.g. confirm the `.ics`/feed returns a valid body;
+>    if it doesn't, use the documented fallback). Events non-empty + upcoming, dates UTC-noon,
+>    `startTime` "HH:MM", `kennelTag` resolves with no unmatched.
+> 5. Optional: the **Historical backfill** one-shot insert, only if marked worth it.
+> 6. `eval "$(fnm env)" && fnm use 20 && npx tsc --noEmit && npm run lint && npm test`.
+> 7. Commit and open a PR whose body carries the metadata, live-verification results, and the
+>    deep-dive checklist below. Follow `docs/source-onboarding-playbook.md` throughout.
+> Everything you need is in the sections that follow.
+
+## Summary
+- Type: <full onboard | source-add>
+- Adapter: <SOURCE_TYPE> (<config-only — adapter exists & feed verified | NEW adapter needed>)
+- Effort estimate: <config-only | new ~N LoC adapter + tests | small JSON/HTML scraper>
+- One-line: <what this adds and why it's high value>
+
+## Dedup result
+- Kennel in seed: <no | yes @ kennels.ts:LINE>
+- Source in seed: <no | yes @ sources.ts:LINE>
+- Live sitemap dedup: <confirmed NOT live — read via Chrome MCP, N slugs; no `<fragments>` slug>
+- Decision: <full onboard | source-add | skip-reason>
+- kennelCode: `<code>` (collision check: <clear | suffixed because …>)
+
+## Live source verification  ✅ / ⚠️ needs Claude Code to confirm
+- Source: <TYPE> — <url/id>  (feed HEAD-check: <content-type seen | couldn't fetch — flag>)
+- Events seen: <count>, date range <… to …>
+- Sample events:
+  1. <date> — <title> — hares <…> — <location> — <time>
+  2. …
+- History depth / pagination: <total reachable past events; how to paginate, or "single page">
+- Coord sanity: <coords clean | ⚠️ X of N have default/duplicate pins → adapter must reject + dropCachedCoords:true>
+- End times: <none | same-day endTime available | multi-day endDate present>
+- Notes: <JS-rendered/browserRender needed? auth? platform quirks? see source-platform-notes.md>
+
+## Kennel metadata (deep-dive complete)
+- fullName / shortName / region / country
+- aliases: [...]
+- website / facebook / instagram / twitter / discord
+- schedule: <day>, <time>, <frequency>  (+ scheduleRules: [...] if multi-pattern)
+- foundedYear / hashCash / dogFriendly / walkerFriendly
+- logoUrl: <stable URL | ⚠️ self-host to public/kennel-logos/<code>.<ext>>
+- description: "<short about-us>"
+- lat/lng: <if found>
+
+## Historical backfill
+- Available: <count or none> — fields: <date/title/hares/location/cost>
+- Plan: <one-shot insert script at scripts/backfill-<code>-history.ts | not worth it | none>
+  (per the ONH3 pattern: future-only via adapter, past via one-shot; set source `config.upcomingOnly: true`
+  if relevant to suppress stale-event reconciliation)
+
+## Ready-to-paste seed
+```ts
+// kennels.ts  (skip if source-add)
+{ kennelCode: "...", shortName: "...", fullName: "...", region: "...", country: "...", website: "...", ... }
+// aliases.ts
+"<code>": ["...", "..."],
+// sources.ts
+{ name: "...", url: "...", type: "..." as const, trustLevel: N, scrapeFreq: "daily", config: { ... }, kennelCodes: ["..."] }
+```
+
+## Adapter notes / new-scraper plan
+<config explanation, or full parsing plan + fixture snippet (mirror real DOM) + registry entry>
+
+## Deep-dive checklist (nothing deferred)
+- [x] logo (stable? else flag self-host)  [x] foundedYear  [x] socials  [x] schedule (+ scheduleRules if multi-pattern)  [x] hashCash
+- [x] description  [x] source live-verified (feed HEAD-checked)  [x] history depth/pagination assessed
+- [x] coord sanity checked  [x] end times noted  [x] kennelCode collision-checked  [x] kennelCodes (source guard) set
+
+## Implementation gotchas (for Claude Code — repo knowledge, not source knowledge)
+Carry these into the build; they've each caused a follow-up fix before:
+- **Rejecting upstream coords needs `dropCachedCoords: true`** — setting `latitude: undefined`
+  alone does NOT clear a coord already stored by the merge pipeline (a re-scrape keeps the bad pin).
+- **On partial pagination failure, set `kennelPageFetchErrors` + `kennelPagesStopReason`** — else
+  `scrape.ts` runs stale-event reconciliation against partial data and cancels valid events. A
+  non-empty `kennelPagesStopReason` suppresses stale-event reconciliation; only set it on a genuine
+  truncation (full page left unfetched / HTTP or fetch error).
+- **For historical-archive sources, set `config.upcomingOnly: true`** to restrict reconciliation
+  to future dates (ONH3 pattern — prevents false-cancelling the archived backfill once it ages
+  off the source's first page).
+- **Tests:** `vi.spyOn(globalThis, "fetch")` accumulates `.mock.calls` across `it()` blocks — add
+  `beforeEach(vi.restoreAllMocks)` for accurate per-test counts.
+- **Sonar S3776 cognitive complexity ≤ 15 — pre-plan helpers, don't inline.** Pagination, guard
+  logic, and field extraction blow past 15 fast. The adapter-notes code block in this handoff
+  should already show helpers extracted (e.g. `parseDateTimeLine`, `mergeLocation`,
+  `walkPagination`, `resolveEndDateOrTime`, `extractVenueCoords`). If they aren't, extract before
+  writing the body.
+- **Sonar S5852 (catastrophic regex backtracking) — use known-safe patterns.** Avoid `.+$`,
+  complex optional groups, and `\s*` before character classes. Safe substitutes:
+  - Split combined patterns (e.g. one date+time regex → two simple regexes + combine in code):
+    `DATE_RE = /(\d{1,2}\/\d{1,2}\/\d{2,4})/` ; `TIME_RE = /(\d{1,2}:\d{2}) ?(AM|PM)/i`
+  - Replace `(.+)$` with `(\S.*)$` (anchor a non-space first char to bound the greedy match):
+    `HARES_RE = /^Hares?:\s*(\S.*)$/i`
+  - Make optional title groups truly optional: `/^Hash\s*#(\d+)(?:\s*[-–]\s*(.+))?$/i`
+- **Self-host tokenized logos** into `public/kennel-logos/<code>.<ext>` rather than referencing an
+  ephemeral CDN URL.
+
+---
+
+_Implementation directive is at the top of this file (**▶ FOR CLAUDE CODE**). The whole file is
+the brief — no separate prompt needed._
+````
+
+Putting the directive at the **top** means the file works whether it's pasted into Claude Code or
+piped in whole by an automated runner.
+
+## Step 8 — Update the queue + run log; refill if low
+
+1. In `target-queue.md`, set the target's Status to `handed-off` (or `blocked` with reason / 
+   `done (already live)`), add the handoff file path + today's date.
+2. Append an entry to `run-log.md`: date, kennel, source type, outcome (handoff path / blocked),
+   events verified (count + range), historical backfill count, follow-ups.
+3. **Refill check:** count rows still `queued`. **If 5 or fewer remain, research and add new
+   targets to ~20**, ranked by (a) hashing popularity/activity and (b) reliability of a
+   *confirmed* dynamic source. **Dedup every candidate against LIVE production data** (the
+   sitemap / kennel directory / region pages / per-slug page check from Step 2 — NOT just the
+   seed files, which are incomplete). A kennel already live (even if absent from `seed-data/`)
+   must not be queued as new; a live kennel lacking a dynamic source is a valid "source-add"
+   target. Use web search + H3 directories (harriercentral.com / hashruns.org,
+   hashrego.com, half-mind.com, genealogy.gotothehash.net); for Meetup, confirm upcoming events.
+   **Prefer candidates whose region shows 0 live kennels** (dedup is unambiguous there); for a
+   candidate in an already-populated region, only queue it after a positive slug check or a
+   sitemap read proves it's not already live. Append rows with full columns + honest confidence.
+
+## Step 9 — Report
+
+Return a one-line summary: kennel, source type, adapter (config-only or new), handoff file path,
+events verified, and the backlog count remaining.
+
+---
+
+## Failure / edge handling
+
+- **Target already seeded (kennel + source)** → mark `done (already live)`, pick next.
+- **Existing kennel, missing source** → that's a valid source-add handoff, not a skip.
+- **Source dead / no upcoming events** → mark `blocked` with reason, pick next.
+- **Source is JS-rendered and browserRender isn't available in this shell** → still write the
+  handoff with everything you could gather, clearly flagging that Claude Code must pull/verify
+  the live sample. Mark the queue row `handed-off (needs live-verify)`.
+- Never attempt git operations in this run. Never write outside `docs/kennel-onboarding/`.
+- Never invent a logo/source URL — mark "none found / follow up" instead.

--- a/docs/kennel-onboarding/handoffs/2026-05-29-bali-hash-2.md
+++ b/docs/kennel-onboarding/handoffs/2026-05-29-bali-hash-2.md
@@ -1,0 +1,200 @@
+# Onboarding Handoff — Bali Hash House Harriers 2 (`bali-hash-2`)
+
+> **▶ FOR CLAUDE CODE:** Implement a **new single-kennel `HTML_SCRAPER` (Cheerio) adapter** for the Bali Hash 2 Ghost blog (`balihash2.com`), register it, add the kennel + source + region + alias seed blocks below, write unit tests against the saved fixture, **and live-verify against `https://balihash2.com/` per `.claude/rules/live-verification.md`** before opening the PR. This is **not** config-only — no generic Ghost adapter exists; model the new adapter on `src/adapters/html-scraper/hangover.ts` (Ghost/DigitalPress) and `src/adapters/html-scraper/ofh3.ts` (Blogspot trail posts). Branch suggestion: `onboard/bali-hash-2-20260529`. Optional bonus: a one-shot historical backfill script paginating `/page/N` (~1,747 runs of archive).
+
+---
+
+## 1. Kennel summary
+
+| Field | Value |
+|---|---|
+| **kennelCode** | `bali-hash-2` *(collision-checked — no `bali*` / `bh2` in `kennels.ts`)* |
+| **shortName** | `Bali Hash 2` |
+| **fullName** | `Bali Hash House Harriers 2` |
+| **region** | `Bali` (country `Indonesia`) — **new region, see §6** |
+| **country** | `Indonesia` |
+| **Website** | https://balihash2.com |
+| **Schedule** | **Weekly, Saturday, 4:00 PM** (15-min stagger: arrive 30 min early, hares away 4:00 PM). Occasionally 3:00 PM on individual runs (e.g. run #1739) — parse start time per-event, don't hardcode. |
+| **Hash cash** | Members Rp.100,000 · Non-drinkers Rp.50,000 · Visitors Rp.150,000 · Kids <15 Rp.10,000 *(verbatim from run posts; "Run with us 5 times and you become a member")* |
+| **Founded** | **~1977 (verify)** — sources conflict (1977 vs 1980). Bali Hash House Harriers (Hash 1) founded 1977 by Victor "Night Jar" Mason; Hash 2 split off shortly after. **Leave `foundedYear` out of the seed until confirmed** rather than guess. |
+| **Logo** | `https://balihash2.com/content/images/2024/09/logo.0c98adfa-1.png` — **content-hashed Ghost CDN URL (ephemeral, rotates on re-upload). SELF-HOST** → download to `public/kennel-logos/bali-hash-2.png` and set `logoUrl: "/kennel-logos/bali-hash-2.png"`. |
+| **Socials** | Facebook page https://www.facebook.com/BaliHash2 · FB group https://www.facebook.com/groups/balihash2/ · X/Twitter https://twitter.com/balihash2 |
+| **Description** | World-famous Bali kennel — one of two big Bali hashes ("a drinking club with a running problem"). Weekly Saturday-afternoon trails through rice paddies, temples and villages across Bali; runs start promptly at 4:00 PM. Run number ~1,747 as of May 2026. |
+| **Mismanagement (2026)** | Hash Master: Gritty Balls · Beer Master: Short Shaft · Hare Raiser: Skanky Toe · Hash Cash: Toilet Trasher · (full list captured in §5 detail-page sample — populate `gm` / `hareRaiser` on the kennel row). |
+| **Aggregator cross-refs** | None. Not on hashruns.org / Harrier Central / hashrego / Meetup. Sole dynamic source is the Ghost blog. Sibling kennel "Bali Hash House Harriers" (Hash 1, `bali-hash.club`) is a **separate future target**, not this one. |
+
+---
+
+## 2. Source — VERIFIED LIVE (2026-05-29)
+
+| | |
+|---|---|
+| **Source name** | `Bali Hash 2 Website` |
+| **Feed URL (adapter)** | `https://balihash2.com/` (home page) + per-post detail pages |
+| **Type** | `HTML_SCRAPER` (Cheerio — **server-rendered static HTML, no browser-render needed**) |
+| **Platform** | **Ghost 6.5** (`meta-generator: Ghost 6.5`) |
+| **HEAD / content-type** | `Content-Type: text/html; charset=utf-8` ✅ (listing + detail both render full content via plain fetch) |
+| **Events proven** | ✅ Home page lists ~12–22 recent "Next Run Map" posts. **Next run #1747 dated 30-May-26 (tomorrow) is live** — upcoming event confirmed, not all-past. |
+| **trustLevel** | `6` (primary, sole source for this kennel) |
+| **scrapeFreq** | `daily` |
+| **scrapeDays** | `90` |
+
+**What each post exposes** (home-page excerpt → enrich from detail page):
+- **Run number** — `#1747` in title + `Run: 1747` in body → `extractHashRunNumber`.
+- **Date** — `Date: 30-May-26` (also in title), format **`D-MMM-YY`** (hyphenated, single- or two-digit day).
+- **Start time** — `Our runs start promptly at: 4:00 PM` → `parse12HourTime` → `"16:00"`.
+- **Location** — `Location: Pura Pekemitan / Prajapati, Kediri, Tabanan` (free-text venue/village).
+- **GPS** *(detail page only)* — `GPS: -8.58350, 115.1270571` → real per-run coords → `latitude`/`longitude` + `locationUrl` via `googleMapsSearchUrl`.
+- **Hares** *(detail page only)* — `Hares: Exit/Re Entry & Popoff Monster`.
+- **Occasion** *(detail page only)* — usually the generic slogan `WE START TOGETHER - WE DRINK TOGETHER`; **not a per-run theme → do NOT use as title.**
+
+---
+
+## 3. Effort estimate
+
+**New adapter, ~250–350 LoC + ~120–180 LoC tests.** Cheerio listing parse + detail-page enrichment. Closely mirrors `hangover.ts` (Ghost) and `ofh3.ts` (single-kennel trail-post blog). No new infra, no AI, no browser-render, no proxy. Config-only is **not** possible (no generic Ghost adapter).
+
+Adapter shape:
+1. `safeFetch("https://balihash2.com/")` → `cheerio.load`.
+2. Select each post-card link `a[href*="/bali-hash-2-next-run-map-"]`; parse title + excerpt for run#, date, start time, location.
+3. Filter to the date window (`buildDateWindow(options?.days ?? 90)`); for surviving (esp. **future**) posts, `safeFetch` the detail page and enrich GPS / hares / occasion.
+4. Cap detail fetches (e.g. ≤ 10 most-recent/future) to bound request volume.
+5. Emit `RawEventData` with `kennelTags: ["bali-hash-2"]`, `runNumber`, `date` (UTC-noon), `startTime`, `location`, `latitude`/`longitude`, `hares`, leave `title` **undefined** (let `merge.ts` synthesize `Bali Hash 2 Trail #N`).
+
+---
+
+## 4. History depth / pagination
+
+- **Deep archive available.** Run numbers run to ~#1747 today; older posts paginate at `/page/2/`, `/page/3/`, … (Ghost default pagination; home "See all" → `/page/2`).
+- Recurring adapter should emit **future + recent** runs only (the live hareline). The ~1,747-run **archive is a one-shot backfill** (`scripts/backfill-bali-hash-2-history.ts`) — do **not** re-parse the whole archive every scrape (mirrors the ONH3 / Seletar history pattern). If you ship the backfill, set strict date partitioning (adapter `date >= today` window; backfill `< today`) so re-runs are safe.
+- If a backfill is **not** shipped this PR, that's fine — flag it as a follow-up; do not block the kennel launch on it.
+
+---
+
+## 5. Coord sanity (silent-corruption trap)
+
+- Per-run GPS coords are **real and vary per run** (e.g. #1747 `-8.58350, 115.1270571`; #1721 `-8.44142, …`) — good for the map.
+- **BUT** many home-page excerpts truncate GPS to `* GPS:` (empty) or `* GPS: -8.` — only the **detail page** has the full pair. Parse coords **from the detail page only**; when absent/partial, emit `latitude: undefined, longitude: undefined` (never `0,0` and never a region-default pin).
+- Reject obviously-bad pairs (e.g. identical default coords repeated across events, or `0,0`) and emit `dropCachedCoords: true` so a previously-cached good coord isn't left wired to a now-blank run.
+
+---
+
+## 6. End times
+
+- Posts publish **start time only** (`4:00 PM`, occasionally `3:00 PM`). **No end time and no multi-day events.** Set `startTime` per-event; leave `endTime` / `endDate` undefined. Single-day weekly runs only.
+
+---
+
+## 7. Implementation gotchas (READ BEFORE CODING)
+
+1. **Date format `D-MMM-YY` is hyphenated.** Normalize hyphens to spaces (`"30-May-26"` → `"30 May 26"`) **before** calling `chronoParseDate`. Use `chronoParseDate` (not raw `chrono.parseDate`) — it carries the `D MMM YY` fast-path that fixes the single-digit-day mis-parse (`"4-Apr-26"` must be 4 Apr, not year-fragment-as-day). Store as **UTC noon** (`Date.UTC(y, m-1, d, 12, 0, 0)`).
+2. **Duplicate / corrected reposts share a run number.** #1739 appears twice (4:00 PM and 3:00 PM); #1723 appears twice. **Dedupe by run number**, preferring the **most recently published** post (`meta-article:published_time` / the "Latest" ordering). Two posts with the same run# but different times would otherwise produce two fingerprints (`date|kennelTag|runNumber|title`) — collapse them first.
+3. **Run-number gaps are normal** (cancelled/unpublished weeks: #1743, #1734, #1727–1729 missing). Don't assume contiguous numbering.
+4. **Never let the slogan or hares become the title.** `Occasion:` is the generic club slogan; `Hares:` is hare names. Leave `title` undefined → `merge.ts` synthesizes `Bali Hash 2 Trail #N` via `friendlyKennelName`. (Same trap as Chiang Mai #1084.)
+5. **Honor `options.days`** — filter through `buildDateWindow(options?.days ?? 90)`; don't ignore it.
+6. **Sort multi-value fields** (hares) before `join(", ")` for idempotent fingerprints.
+7. **Validate payload shape at runtime** — a 200 with an unexpected body (Ghost error/empty) must NOT silently yield 0 events (the reconciler would cancel the live run). Bail loudly on an empty post list.
+8. **Self-host the logo** (§1) — the Ghost CDN URL is content-hashed and rotates.
+9. **Timezone = `Asia/Makassar` (WITA, UTC+8)** for Bali — relevant if you compose any UTC timestamps; `startTime` itself is a local `"HH:MM"` string.
+10. **Bali Hash 2 ≠ Bali Hash 1.** Don't conflate with `bali-hash.club` (the original 1977 Hash 1) — separate kennel, separate future onboarding.
+
+---
+
+## 8. Ready-to-paste seed blocks
+
+### 8a. Region — `src/lib/region.ts` (add Indonesia COUNTRY + Bali METRO; new country)
+```ts
+// ── Indonesia ──
+{
+  name: "Indonesia",
+  country: "Indonesia",
+  level: "COUNTRY",
+  timezone: "Asia/Jakarta",
+  abbrev: "ID",
+  colorClasses: "bg-rose-100 text-rose-700",
+  pinColor: "#e11d48",
+  centroidLat: -2.55,
+  centroidLng: 118.01,
+  aliases: ["ID", "Republic of Indonesia"],
+},
+{
+  name: "Bali",
+  country: "Indonesia",
+  timezone: "Asia/Makassar",
+  abbrev: "DPS",
+  colorClasses: "bg-rose-100 text-rose-700",
+  pinColor: "#e11d48",
+  centroidLat: -8.41,
+  centroidLng: 115.19,
+  aliases: ["Bali, Indonesia", "Denpasar", "Denpasar, Bali", "Bali, ID"],
+},
+```
+*(Verify `colorClasses`/`pinColor` aren't already assigned to a neighboring region; pick an unused palette slot if rose collides.)*
+
+### 8b. Kennel — `prisma/seed-data/kennels.ts`
+```ts
+// ===== INDONESIA =====
+{
+  kennelCode: "bali-hash-2", shortName: "Bali Hash 2", fullName: "Bali Hash House Harriers 2",
+  region: "Bali", country: "Indonesia",
+  website: "https://balihash2.com",
+  facebookUrl: "https://www.facebook.com/BaliHash2",
+  twitterHandle: "balihash2",
+  logoUrl: "/kennel-logos/bali-hash-2.png", // self-hosted — see handoff §1
+  scheduleDayOfWeek: "Saturday", scheduleTime: "4:00 PM", scheduleFrequency: "Weekly",
+  scheduleNotes: "Saturdays — arrive 30 min early to pay run fee; runs start promptly at 4:00 PM (occasionally 3:00 PM).",
+  hashCash: "Members Rp.100,000 / Non-drinkers Rp.50,000 / Visitors Rp.150,000 / Kids <15 Rp.10,000",
+  description: "World-famous Bali kennel — 'a drinking club with a running problem.' Weekly Saturday-afternoon trails through rice paddies, temples and villages across Bali. Runs start promptly at 4:00 PM; run number ~1,747 as of mid-2026.",
+  // foundedYear: TBD — sources conflict (1977 vs 1980); confirm before adding.
+  // gm: "Gritty Balls", hareRaiser: "Skanky Toe", // from 2026 mismanagement list — add if KennelSeed supports
+  latitude: -8.41, longitude: 115.19, // Bali centroid; per-event coords come from the adapter
+},
+```
+
+### 8c. Source — `prisma/seed-data/sources.ts`
+```ts
+// ===== INDONESIA =====
+{
+  name: "Bali Hash 2 Website",
+  url: "https://balihash2.com",
+  type: "HTML_SCRAPER" as const,
+  trustLevel: 6,
+  scrapeFreq: "daily",
+  scrapeDays: 90,
+  kennelCodes: ["bali-hash-2"],
+},
+```
+
+### 8d. Aliases — `prisma/seed-data/aliases.ts` (for kennel resolution)
+```ts
+{ kennelCode: "bali-hash-2", alias: "Bali Hash 2" },
+{ kennelCode: "bali-hash-2", alias: "Bali Hash House Harriers 2" },
+{ kennelCode: "bali-hash-2", alias: "BH2" },
+{ kennelCode: "bali-hash-2", alias: "Bali Hash 2 Next Run Map" },
+```
+
+---
+
+## 9. Adapter registration
+
+- New file: `src/adapters/html-scraper/bali-hash-2.ts` exporting a `SourceAdapter`.
+- Register in `src/adapters/registry.ts` — route this source to the new adapter (match by source `url`/`name` host `balihash2.com`, as the other single-kennel HTML scrapers do).
+- Test: `src/adapters/html-scraper/bali-hash-2.test.ts` — save the home-page HTML + one detail page as fixture constants; assert run# / UTC-noon date / `"16:00"` start time / location / GPS extraction / dedupe of the #1739 double-post / `title` left undefined.
+
+---
+
+## 10. Live-verification checklist (do before PR — `.claude/rules/live-verification.md`)
+- [ ] `fetch("https://balihash2.com/")` returns events; array non-empty.
+- [ ] Upcoming run present (#1747 / 30-May-26 or later); not all past.
+- [ ] `date` UTC-noon, valid; `startTime` `"HH:MM"`; `kennelTags: ["bali-hash-2"]`.
+- [ ] GPS parsed from detail page; varies per run; blank/partial → undefined (not 0,0).
+- [ ] #1739 / #1723 double-posts collapse to one event each.
+- [ ] Update the test fixture if live HTML drifted from this handoff's sample.
+
+---
+
+### Source verification log (2026-05-29)
+- `https://balihash2.com/` → `text/html`, Ghost 6.5, ~12–22 run posts listed; newest = run #1747 (30-May-26). ✅
+- `https://balihash2.com/bali-hash-2-next-run-map-1747-…-30-may-26/` → full detail: Run 1747, Date 30-May-26, 4:00 PM, Location Pura Pekemitan/Prajapati Kediri Tabanan, GPS -8.58350,115.1270571, Hares "Exit/Re Entry & Popoff Monster", run fees + 2026 mismanagement committee. ✅
+- `/page/2/` reachable → pagination confirmed for historical backfill. ✅
+- Dedup: no `bali*` / `bh2` kennelCode and no Indonesia/Bali region in seed files → genuinely new; not in 414-slug live sitemap. ✅

--- a/docs/kennel-onboarding/handoffs/README.md
+++ b/docs/kennel-onboarding/handoffs/README.md
@@ -1,0 +1,22 @@
+# Onboarding Handoffs
+
+The daily Cowork onboarding task writes one file here per run:
+`<YYYY-MM-DD>-<kennelCode>.md`.
+
+Each file is a complete, self-contained onboarding package — verified live source sample,
+full kennel metadata (logo, founded year, socials, hash cash, schedule, description),
+ready-to-paste seed blocks, adapter plan, historical-backfill assessment, end-time/coord/
+pagination notes, and an embedded **`▶ FOR CLAUDE CODE`** directive **at the top of the file**.
+
+## To implement one
+
+Run `bash scripts/copy-newest-handoff.sh` to copy the newest un-implemented, non-voided handoff
+to your clipboard, then paste the whole file as the first message into a fresh Claude Code
+session in `hashtracks-web`. The top directive drives implementation through PR.
+
+The copy helper skips:
+- the `README.md` you're reading
+- voided handoffs (any with `VOID` in the first ~5 lines)
+- handoffs whose `onboard/<code>-*` branch already exists on origin (i.e. already implemented)
+
+Once a handoff's PR is merged, you can delete the file (or leave it as a record).

--- a/docs/kennel-onboarding/run-log.md
+++ b/docs/kennel-onboarding/run-log.md
@@ -1,0 +1,57 @@
+# Kennel Onboarding — Run Log
+
+Append one entry per daily run (newest at top). Keep it terse.
+
+Format:
+```
+## YYYY-MM-DD — <shortName> (<region>)
+- Source: <TYPE> — <url/id>
+- Outcome: <PR #123 | branch onboard/... ready to push | blocked: reason>
+- Events verified: <count>, date range <…>
+- Historical backfill: <count or none>
+- Follow-ups: <anything deferred>
+```
+
+---
+
+## 2026-05-29 — Bali Hash 2 (Bali, Indonesia) 🇮🇩 first Indonesia kennel
+- Source: HTML_SCRAPER (Ghost 6.5 blog, Cheerio) — `https://balihash2.com/`
+- Outcome: **handed-off** → `docs/kennel-onboarding/handoffs/2026-05-29-bali-hash-2.md`. NEW adapter ~250–350 LoC mirroring `hangover.ts` (Ghost) + `ofh3.ts`. Branch suggestion: `onboard/bali-hash-2-20260529`.
+- Dedup: full onboard — kennel absent (no `bali*`/`bh2` in seed). kennelCode `bali-hash-2` (clear). World-famous kennel, run #1747+ as of May 2026.
+- Events verified: next run #1747 dated 2026-05-30 (tomorrow) live; home-page lists ~12-22 recent posts.
+- Historical backfill: optional one-shot script paginating `/page/N` (~1,747 archived runs).
+- Follow-ups: self-host Ghost CDN logo; verify foundedYear (1977 vs 1980 conflict — Codex says don't guess); after ship, add a Ghost section to `source-platform-notes.md`.
+
+## 2026-05-29 — ONH3 (Nairobi, KE) 🌍 first Africa kennel
+- Source: HTML_SCRAPER (WordPress.com REST API) — `public-api.wordpress.com/wp/v2/sites/onh3.wordpress.com/posts`
+- Outcome: **SHIPPED** → commits `685f2e0d` (`feat(onh3): onboard Original Nairobi H3 — HashTracks' first Africa kennel`) + `d5a10952` (`refactor(onh3): split history into one-shot backfill; adapter table = future-only`).
+- Adapter strategy: WordPress.com REST → future-only via adapter, past via one-shot `scripts/backfill-onh3-history.ts`. Source config `upcomingOnly: true` to suppress stale-event reconciliation on the aged archive.
+- WordPress.com platform notes appended to `source-platform-notes.md` (multi-year title format drift, Hash Trash recap split, hareline-table parser, pagination 400-as-end, `kennelPagesStopReason` semantics, etc.).
+- Follow-ups: 3-4 more WordPress.com kennels and the pattern can be factored into a shared `WordPressComAdapter` base class.
+
+## 2026-05-28 — BoiseH3 (Boise, ID)
+- Source: HTML_SCRAPER (static Cheerio, home-page parse) — `https://www.boiseh3.org/`
+- Outcome: **SHIPPED** → PR #1750 + #27793f98 (SonarCloud fix). New ~200-300 LoC `BoiseH3Adapter`. New Idaho region. Self-hosted logo.
+- Dedup: full onboard — kennel absent from seed AND from live sitemap (412 slugs read via Chrome MCP). kennelCode `boiseh3` (clear).
+- Events verified: **1 upcoming** from home-page static HTML — Run #1993 "Memorial Day Hash!" Mon 2026-05-25 6:40 PM. Home page is updated weekly; daily scrape captures every trail (fingerprint dedup handles repeats). `/events-3` Wix Events widget is JS-only and not used.
+- Historical backfill: **none** — site doesn't expose an archive.
+- Retro lessons folded into the system: Wix `richTextElement` traversal pattern, title-less heading regex, Sonar S5852 safe regexes, S3776 pre-planned helpers, `browserRender` (not `fetchBrowserRenderedPage`) as canonical call. Wix section appended to `source-platform-notes.md`.
+
+## 2026-05-27 — SACH3 (Sacramento, CA)
+- Source: Squarespace events JSON (NEW `SquarespaceEventsAdapter`, ~360 LoC) — `sach3.beer/events?format=json`
+- Outcome: **SHIPPED** → PRs #1742 (adapter) + #1745 (Manhattan-coord-pin rejection + `dropCachedCoords`) + #1746 (pagination, endTime, dropCachedCoords, reconciliation suppression, per-event try/catch, maxPages guard).
+- Final prod state: 54 events (handoff promised 38), 0 Manhattan coords, 51 with end-time ranges, 2 multi-day events, history back to 2025-09-03.
+- iCal plan was infeasible (Squarespace collection-level iCal export tenant-gated off) → built shared platform adapter. **Future Squarespace kennels are now config-only.**
+- Retro lessons folded into the system: Squarespace section in `source-platform-notes.md` (HEAD-check `?format=ical`, tenant-default coord trap, pagination, endDate/endTime). Daily prompt now requires JSON sampling to capture pagination + coord sanity + end times.
+
+## 2026-05-27 — LVHHH (Las Vegas, NV) — **VOIDED**
+- Source: ICAL_FEED (The Events Calendar) — `lvh3.org/events/category/trails/lvhhh/?ical=1`
+- Outcome: **VOID — Las Vegas H3 was already live in prod** (`las-vegas-h3`, code `LVUSA0`, est. 1990, sourced from lvh3.org via The Events Calendar REST API). Discovered after the handoff was generated. Handoff file marked VOID.
+- Lesson: dedup against `prisma/seed-data/` files is insufficient — must check the **live sitemap** because kennels can be added directly via the admin UI without seed entries. System now uses Chrome MCP sitemap as the primary dedup oracle.
+
+## 2026-05-27 — (no onboard) — ENVIRONMENT BLOCKED at Step 0
+- Target attempted: Rank 1 LVHHH (now known to be already-live).
+- Outcome: **blocked — could not start.** Repo on `admin-ui-redesign` with 123 uncommitted changes, `main` occupied by another worktree, `.git/` writes broken from the sandbox (stale locks owned by another uid).
+- Lesson: this triggered the redesign to a write-only handoff workflow (no git from sandbox). Subsequent runs from this date onward never attempt git.
+
+_(latest successful onboarding: ONH3 2026-05-29. Daily cadence is working.)_

--- a/docs/kennel-onboarding/target-queue.md
+++ b/docs/kennel-onboarding/target-queue.md
@@ -1,0 +1,83 @@
+# Kennel Onboarding — Target Queue
+
+Ranked backlog for the daily onboarding task. **Rank 1 = onboard next.** The daily run
+([`daily-onboarding-prompt.md`](daily-onboarding-prompt.md)) takes the top `queued` row each
+morning. When `queued` rows drop to **5 or fewer**, the run refills the list back to ~20.
+
+**Inclusion rule:** every entry must have a **confirmed/identified dynamic data source**
+(Google Calendar, iCal, Meetup w/ upcoming events, Harrier Central, Hash Rego, Google Sheets,
+or a scrapeable website). No Facebook-only / static-only kennels.
+
+**Dedup rule (see prompt Step 2) — against the LIVE sitemap, read via the Chrome MCP.** The seed
+files are incomplete (live site has 410+ kennel slugs in the sitemap vs ~349 in seed; kennels are
+added straight to prod via the admin UI), the prod DB isn't reachable from the run's sandbox, and
+the kennel directory is client-rendered. The authoritative oracle is `hashtracks.xyz/sitemap.xml`
+read through the Chrome MCP. **Slugs aren't always the obvious kebab** — scan for fragments
+(Singapore Harriets = `sg-harriets`, Miami Valley = `mvh3-day`, HK Monday = `hk-h3`, Brussels
+Manneke Piss = `bmph3`).
+
+**Status values:** `queued` · `in_progress` · `handed-off` · `blocked` · `done (already live)` · `source-add` · `verify-live-first` · `shipped`
+
+> Cooperative: John can reorder, add, or strike rows anytime. The daily run respects the current
+> top `queued` row.
+
+**Last sitemap audits via Chrome MCP:** 2026-05-27 (411 slugs) → 2026-05-28 (412 slugs) →
+2026-05-29 (ONH3 added, 413+). Re-confirm each row at handoff time per the prompt.
+
+## Active queue — all confirmed NOT live (sitemap-verified)
+
+| Rank | Kennel | Full name | Region | Best source type | Source URL / ID | Confidence | Live-dedup (sitemap) | Status | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| — | SACH3 | Sacramento Hash House Harriers | Sacramento, CA | Squarespace events JSON (NEW `SquarespaceEventsAdapter`) | `sach3.beer/events?format=json` (iCal export was gated OFF; sach3.com dead) | Shipped | n/a | **shipped** | **Live in prod (54 events).** PRs #1742 (adapter) + #1745/#1746 (coord-pin fix, pagination, endTime, dropCachedCoords). iCal plan was infeasible → needed ~360-LoC adapter. **Future Squarespace kennels are now config-only.** |
+| — | BoiseH3 | Boise Hash House Harriers | Boise, ID | HTML_SCRAPER (static Cheerio, home-page) | `https://www.boiseh3.org/` (Wix; `/events-3` widget is JS-rendered) | Shipped | sitemap-checked absent at handoff | **shipped** | **PR #1750.** New ~200–300 LoC `BoiseH3Adapter`, new Idaho region, self-hosted logo. Wix `richTextElement` traversal + S5852 safe regexes + title-less heading regex now captured in `source-platform-notes.md`. |
+| — | ONH3 | Original Nairobi Hash House Harriers | Nairobi, KE | HTML_SCRAPER (WordPress.com REST API) | `public-api.wordpress.com/wp/v2/sites/onh3.wordpress.com/posts` | Shipped | n/a | **shipped** | **🌍 HashTracks' first Africa kennel.** Commits `685f2e0d` (adapter) + `d5a10952` (history split). Future adapter = future-only via WordPress.com REST; past via one-shot `scripts/backfill-onh3-history.ts`; `config.upcomingOnly: true` suppresses stale-event reconciliation. WordPress.com section now lives in `source-platform-notes.md` — next WP.com kennel will be much faster. **Once 3–4 ship, factor a shared `WordPressComAdapter` base class.** |
+| — | Bali Hash 2 | Bali Hash House Harriers 2 | Bali, Indonesia | HTML_SCRAPER (Ghost blog, Cheerio) | `https://balihash2.com/` (Ghost 6.5, server-rendered) | High — handed off 2026-05-29; next run #1747 dated 2026-05-30 confirmed live | n/a | **handed-off** | `handoffs/2026-05-29-bali-hash-2.md`. NEW adapter ~250–350 LoC mirroring `hangover.ts` (Ghost) + `ofh3.ts` (single-kennel trail posts). World-famous Bali kennel, run #1747+. **🇮🇩 First Indonesia kennel.** Self-host the Ghost CDN logo. Optional one-shot historical backfill (~1,747 archived runs via `/page/N`). After ship, add a Ghost section to `source-platform-notes.md`. |
+| 1 | Paris H3 / SCHHH | Paris + Sans Clue Hash House Harriers | Paris, FR | HTML_SCRAPER (WordPress.com) | `parishash.wordpress.com/category/hash-schedule` (try public-api.wordpress.com REST) | Med — use WP blog, NOT Meetup (0 upcoming); reuse ONH3 patterns | no `paris*`/`sans-clue` slug | queued | Only mainland-EU row that's been #1 for a while. **WordPress.com — apply the ONH3 pattern from `source-platform-notes.md` (title drift, Hash Trash split, upcomingOnly).** |
+| 2 | Zürich H3 | Zurich Hash House Harriers | Zurich, CH | MEETUP (site directs to Meetup for locations) | site: `zh3.ch` → meetup slug TBD at build | Med — Thu + 1st Sat / 3rd Sun; confirm Meetup has upcoming at build | no `zurich*`/`zh3` slug (Codex 2026-05-28) | queued | From Codex 2026-05-28 rebalance. `zh3` kennelCode looks clear but confirm vs seed. |
+| 3 | Mauritius H3 | Mauritius Hash House Harriers | Mauritius (Indian Ocean) | HTML_SCRAPER | `https://www.mhash.com/category/hash-next-run/` | High — clean future run list through Dec 2026, every 2nd Sunday | no `mauritius*`/`mhash` slug | queued | From Codex 2026-05-28. Mind `mh3` collision (Memphis/Munich/Montreal) → use `mh3-mu` or `mauritiush3`. |
+| 4 | Mijas H3 | Mijas Hash House Harriers | Mijas / Costa del Sol, ES | HTML_SCRAPER | `https://www.mijash3.com/hareline` (+ `/run-directions`) | High — weekly Sunday, hareline through Jul 2026 | no `mijas*` slug | queued | From Codex 2026-05-28. Spain coverage. kennelCode `mijash3`. |
+| 5 | Winterthur & Schaffhausen H3 | Winterthur & Schaffhausen Hash House Harriers | Switzerland | MEETUP | `meetup.com/winterthur_schaffhausenhhh/` | High — monthly recurring future events (Jun 20 + Jul 18 2026) | no `wsh3`/`winterthur`/`schaffhausen` slug | queued | From Codex 2026-05-28. Second Switzerland kennel. kennelCode `wsh3` (or `wsh3-ch`). |
+| 6 | Hamburg H7 | Hamburg H7 | Hamburg, DE | HARRIER_CENTRAL | blog: `hamburghash.blogspot.com` → now on hashruns.org | Med — May 2026 post says next runs on Harrier Central; verify kennel slug on hashruns.org | no `hamburg*`/`h7` slug | queued | From Codex 2026-05-28. **Likely config-only** — `HarrierCentralAdapter` exists. kennelCode `hamburg-h7` (mind `h7` collision check). |
+| 7 | VH3 | Vancouver Hash House Harriers | Vancouver, BC | HTML_SCRAPER | `vanhash.com` / `vh3.ca/RecedingHareline.html` | Low-Med — verify which domain is live; may need browserRender | no `vancouver*` slug | queued | Biweekly Sat. |
+| 8 | Mexico City H3 | Hash House Harriers Mexico City | Mexico City, MX | MEETUP | `meetup.com/mexico-city-hash-house-harriers` (fallback mchhh.com/schedule) | Med — confirm Meetup has upcoming events | no `mexico*` slug | queued | Run #732+, biweekly Sat. |
+| 9 | AnchorageH3 | Anchorage Alaska Hash House Harriers | Anchorage, AK | HTML_SCRAPER (WordPress) | `anchoragealaskah3.com/category/event/` | Med — WP event feed; recency unverified | no `anchorage*`/`alaska*` slug | queued | Biweekly Sat year-round. Self-hosted WordPress (not .com) — check `/wp-json/wp/v2/posts`. |
+| 10 | Auckland H3 | Auckland Hash House Harriers | Auckland, NZ | HTML_SCRAPER | `aucklandhashhouseharriers.co.nz` | Low-Med — events exist; structure unverified | only `auckland-hussies` is live | queued | Mind `ah3` collision → `ah3-nz`. |
+| 11 | NSWHHH | North Shore Wanderers H3 | Sydney, AU | HTML_SCRAPER | `nswhhh.info` | Low — confirm dynamic run list at build | no `nsw*`/`wanderer*` slug (4 other Sydney kennels live) | queued | Weekly Mon 6:30pm. |
+| 12 | Bangkok Monday H3 | Bangkok Monday Hash House Harriers | Bangkok, TH | HTML_SCRAPER | `bangkokmondayhhh.com` | Low — structure unverified | no `bangkok*` slug | queued | Prefer over bangkokhhh.org (PDF-only hareline). |
+| 13 | KL Junior H3 | Kuala Lumpur Junior Hash House Harriers | Kuala Lumpur, MY | HTML_SCRAPER (scrapeable runs page) | `https://www.kljhhh.org/runs/` | Med — runs page with future hares confirmed | only `kl-full-moon` is live | queued | Monthly family hash (lower cadence). |
+
+## Leads — verify a live dynamic source before queueing
+
+Grep-confirmed absent from the live sitemap but need one more live check before promotion.
+
+- **B.I.T.CH H3** (Zurich, CH) — Meetup + run-list site; Tuesday hash. *Verify upcoming events live* before queueing.
+- **Kampala H3 / KH3** (Uganda) — weekly Monday; active social signals, 2026 7 Hills Run coverage. *Find a clean dynamic source (FB-only is rejected); maybe source-add if a Meetup or HC listing surfaces.*
+- **Brasilia H3** (Brazil) — Blogspot + AllEvents sample for Mar 2026 (`brasiliah3.blogspot.com`). *Needs confirmed future event after 2026-05-28 before promotion.*
+- **Asunción H3** (Paraguay) — WordPress run history through Apr 18, 2026 (`asuncionh3.wordpress.com/run-history/`). *No confirmed future run after 2026-05-28; re-check next time queue refills.*
+- **Santiago H3** (Chile) — strong Meetup group signal but visible events are past (`meetup.com/es-ES/santiago-hash-house-harriers/`). *Verify an upcoming event before queueing.*
+- **Guadalajara H3** (MX) — likely Meetup/HTML; source not yet confirmed.
+- **El Paso H3** (TX) — likely Meetup; confirm upcoming events.
+- **Tulsa / OKC H3** (OK) — likely Meetup; confirm a live source.
+
+## Removed — already live (authoritative sitemap check)
+
+Confirmed present in `hashtracks.xyz/sitemap.xml` — do **not** onboard:
+
+- **Las Vegas H3** (`las-vegas-h3`) — kennel + lvh3.org Events Calendar source both live. Handoff `2026-05-27-lvhhh.md` was **voided**.
+- **Wanchai H3** (`wanchai-h3`), **Sydney Larrikins** (`sydney-larrikins`).
+- **Dayton/Cincinnati cluster** — `dayton-h4`, `mvh3-day` (Miami Valley), `swot` (SW Ohio Trash), `queen-city-h4` all live. The daytonhhh.org iCal hub is already covered.
+- **HHHS / Father Hash** (`hhhs`), **Singapore Harriets** (`sg-harriets`).
+- **HK H3 Monday** (`hk-h3`), **Wellington Capital H3** (`capital-h3`).
+- **Brussels Manneke Piss H3** (`bmph3`) — flagged tempting because of Friendica/iCal but already live per Codex 2026-05-28 sitemap check.
+
+## Parking lot / rejected (no usable dynamic source)
+
+- **RenoH3** — HashRego renders "No Public Events"; renoh3.com timed out; blog stale (2009).
+- **LDSH3 (Salt Lake City)** — HashRego empty; site static; Meetup slug unverified.
+- **Dubai Desert H3** — calendar shows "No event found"; details only via WhatsApp/email.
+- **Bangkok H3 (bangkokhhh.org)** — hareline is a PDF only (Bangkok Monday kept instead).
+- **Christchurch H3** — events page lists only special weekends, not the weekly calendar.
+- **Spokane** — no clear kennel site or active Meetup surfaced.
+- **Barcelona H3** — Meetup page exists but only two 2024 past events visible; fails the dynamic-source rule (Codex 2026-05-28).
+- **Brazil Nuts São Paulo H3** — Google Site says activity moved to Facebook; Facebook-only unless a better source turns up (Codex 2026-05-28).
+- **Note on HashRego** — many kennels' HashRego pages render "No Public Events"; don't rely on it without confirming events are posted.

--- a/scripts/com.hashtracks.onboard-implement.plist
+++ b/scripts/com.hashtracks.onboard-implement.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd job: run the kennel onboarding auto-implementer every day at 07:00 local.
+
+  PARKED — current default workflow is manual paste via scripts/copy-newest-handoff.sh.
+  This launchd job is kept as a fallback.
+
+  Install:
+    1. Edit the path below if your repo isn't at ~/Developer/hashtracks-web.
+    2. cp scripts/com.hashtracks.onboard-implement.plist ~/Library/LaunchAgents/
+    3. launchctl load -w ~/Library/LaunchAgents/com.hashtracks.onboard-implement.plist
+  Disable:  launchctl unload -w ~/Library/LaunchAgents/com.hashtracks.onboard-implement.plist
+  Run now:  launchctl start com.hashtracks.onboard-implement
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.hashtracks.onboard-implement</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>$HOME/Developer/hashtracks-web/scripts/onboard-implement.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key><integer>7</integer>
+        <key>Minute</key><integer>0</integer>
+    </dict>
+
+    <!-- If the Mac is asleep at 7:00, run as soon as it wakes. -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/hashtracks-onboard-implement.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/hashtracks-onboard-implement.err</string>
+</dict>
+</plist>

--- a/scripts/copy-newest-handoff.sh
+++ b/scripts/copy-newest-handoff.sh
@@ -24,7 +24,6 @@ command -v pbcopy >/dev/null 2>&1 || { echo "pbcopy not found (macOS only)" >&2;
 target=""
 while IFS= read -r f; do
   base="$(basename "$f")"
-  [ "$base" = "README.md" ] && continue
   # Skip voided handoffs (the void marker is in the first ~5 lines)
   head -5 "$f" | grep -qi VOID && continue
   # Derive <code> from "YYYY-MM-DD-<code>.md"
@@ -34,7 +33,9 @@ while IFS= read -r f; do
     continue
   fi
   target="$f"; break
-done < <(ls -t "$HANDOFF_DIR"/*.md 2>/dev/null || true)
+# Glob is constrained to the YYYY-MM-DD-<code>.md format so README.md (and any future non-handoff
+# .md) never match.
+done < <(ls -t "$HANDOFF_DIR"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*.md 2>/dev/null || true)
 
 if [ -z "$target" ]; then
   echo "No un-implemented handoffs found."

--- a/scripts/copy-newest-handoff.sh
+++ b/scripts/copy-newest-handoff.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# copy-newest-handoff.sh — copy the newest un-implemented kennel onboarding handoff to the
+# macOS clipboard, so you can paste it as the first message into a fresh local Claude Code
+# session and let its "▶ FOR CLAUDE CODE" directive drive implementation → PR.
+#
+# "Un-implemented" = no `onboard/<code>-*` branch exists on origin yet (so re-runs are idempotent).
+# Voided handoffs (first 5 lines contain "VOID") are skipped.
+#
+# Usage:
+#   bash scripts/copy-newest-handoff.sh
+#
+# Suggested alias (drop in ~/.zshrc):
+#   alias htn='bash ~/Developer/hashtracks-web/scripts/copy-newest-handoff.sh'
+
+set -euo pipefail
+
+REPO="${HASHTRACKS_REPO:-$HOME/Developer/hashtracks-web}"
+HANDOFF_DIR="$REPO/docs/kennel-onboarding/handoffs"
+
+[ -d "$HANDOFF_DIR" ] || { echo "No handoffs dir: $HANDOFF_DIR" >&2; exit 1; }
+command -v pbcopy >/dev/null 2>&1 || { echo "pbcopy not found (macOS only)" >&2; exit 1; }
+
+target=""
+while IFS= read -r f; do
+  base="$(basename "$f")"
+  [ "$base" = "README.md" ] && continue
+  # Skip voided handoffs (the void marker is in the first ~5 lines)
+  head -5 "$f" | grep -qi VOID && continue
+  # Derive <code> from "YYYY-MM-DD-<code>.md"
+  code="$(echo "$base" | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}-(.+)\.md$/\1/')"
+  # If an implementation branch already exists on origin for this code, skip it
+  if (cd "$REPO" && git ls-remote --heads origin "onboard/${code}-*" 2>/dev/null | grep -q .); then
+    continue
+  fi
+  target="$f"; break
+done < <(ls -t "$HANDOFF_DIR"/*.md 2>/dev/null || true)
+
+if [ -z "$target" ]; then
+  echo "No un-implemented handoffs found."
+  exit 0
+fi
+
+pbcopy < "$target"
+bytes="$(wc -c < "$target" | tr -d ' ')"
+echo "Copied to clipboard: $(basename "$target") (${bytes} bytes)"
+echo "Open a fresh Claude Code session in $REPO and paste."

--- a/scripts/onboard-implement.sh
+++ b/scripts/onboard-implement.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# onboard-implement.sh — auto-implement the newest kennel onboarding handoff with Claude Code.
+#
+# **PARKED.** Current default workflow is manual paste via scripts/copy-newest-handoff.sh.
+# This script is kept as a fallback for fully-hands-off local automation if needed.
+#
+# Pairs with the Cowork "onboard-daily-kennel" research task: that task writes a handoff to
+# docs/kennel-onboarding/handoffs/<date>-<kennel>.md each morning (~6 AM). This script (run ~7 AM
+# via launchd) picks up the newest un-implemented, non-voided handoff and runs Claude Code headless
+# to branch → seed → configure adapter → live-verify → tsc/lint/test → open a PR, then STOP.
+#
+# It works in an ISOLATED clean clone of main (BOT_DIR) so it never touches your dev working tree.
+#
+# Prerequisites on this machine (one-time):
+#   - `claude` CLI installed and authenticated     (https://docs.claude.com/claude-code)
+#   - `gh` CLI installed and authenticated          (gh auth status)  — for opening the PR
+#   - Node via fnm with Node 20 available
+#   - The dev repo present with a working .env / .env.local (DATABASE_URL etc.) and an `origin` remote
+#
+# First time: run it by hand once and watch the log — `bash scripts/onboard-implement.sh`.
+
+set -euo pipefail
+
+# ---- config (override via env if needed) ----
+DEV_REPO="${HASHTRACKS_REPO:-$HOME/Developer/hashtracks-web}"
+BOT_DIR="${HASHTRACKS_BOT_DIR:-$HOME/.hashtracks-onboard-bot}"
+LOG="${HASHTRACKS_BOT_LOG:-$HOME/Library/Logs/hashtracks-onboard.log}"
+# Permission flags for headless Claude Code. Default lets it edit files and run shell/git/gh.
+# If it stalls waiting for approvals in the log, switch to: PERM_FLAGS="--dangerously-skip-permissions"
+PERM_FLAGS="${HASHTRACKS_PERM_FLAGS:---permission-mode acceptEdits --allowedTools Bash Edit Write Read Glob Grep WebFetch}"
+
+HANDOFF_DIR="$DEV_REPO/docs/kennel-onboarding/handoffs"
+DONE_LOG="$DEV_REPO/docs/kennel-onboarding/.implemented.log"
+
+mkdir -p "$(dirname "$LOG")"
+exec >>"$LOG" 2>&1
+echo "==================================================================="
+echo "=== $(date '+%Y-%m-%d %H:%M:%S')  onboard-implement run ==="
+
+# Make common tool paths available under launchd's minimal environment.
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/.fnm:$PATH"
+command -v fnm >/dev/null 2>&1 && eval "$(fnm env)" && fnm use 20 >/dev/null 2>&1 || true
+
+command -v claude >/dev/null 2>&1 || { echo "FATAL: 'claude' CLI not found in PATH"; exit 1; }
+command -v gh >/dev/null 2>&1 || echo "WARN: 'gh' not found — PR creation may fail"
+[ -d "$DEV_REPO/.git" ] || { echo "FATAL: dev repo not found at $DEV_REPO"; exit 1; }
+
+# ---- pick newest handoff: not README, not voided, not already implemented ----
+touch "$DONE_LOG"
+target=""
+while IFS= read -r f; do
+  base="$(basename "$f")"
+  [ "$base" = "README.md" ] && continue
+  if head -5 "$f" | grep -qi 'VOID'; then echo "skip (voided): $base"; continue; fi
+  if grep -qxF "$base" "$DONE_LOG"; then continue; fi
+  target="$f"; break
+done < <(ls -t "$HANDOFF_DIR"/*.md 2>/dev/null || true)
+
+if [ -z "$target" ]; then echo "Nothing to do — no new handoff."; exit 0; fi
+target_base="$(basename "$target")"
+echo "Implementing handoff: $target_base"
+
+# ---- refresh an isolated clean clone on origin/main ----
+if [ ! -d "$BOT_DIR/.git" ]; then
+  origin="$(git -C "$DEV_REPO" remote get-url origin)"
+  echo "Cloning $origin → $BOT_DIR"
+  git clone "$origin" "$BOT_DIR"
+fi
+git -C "$BOT_DIR" fetch origin --prune
+git -C "$BOT_DIR" checkout -f main
+git -C "$BOT_DIR" reset --hard origin/main
+git -C "$BOT_DIR" clean -fd
+
+# carry over secrets (gitignored) so prisma seed + live-verify can reach the DB
+cp "$DEV_REPO/.env" "$BOT_DIR/.env" 2>/dev/null || true
+cp "$DEV_REPO/.env.local" "$BOT_DIR/.env.local" 2>/dev/null || true
+
+# install deps if missing
+[ -d "$BOT_DIR/node_modules" ] || (cd "$BOT_DIR" && npm ci)
+
+# bring the handoff into the clone so it can be committed into the PR
+mkdir -p "$BOT_DIR/docs/kennel-onboarding/handoffs"
+cp "$target" "$BOT_DIR/docs/kennel-onboarding/handoffs/$target_base"
+
+# ---- run Claude Code headless, feeding the WHOLE handoff (its top directive drives the work) ----
+cd "$BOT_DIR"
+PROMPT="$(cat "$target")
+
+-----
+You are running UNATTENDED in an isolated clean clone of main. Implement the onboarding described
+in the file content above, following its '▶ FOR CLAUDE CODE' directive exactly. Open a PR with
+\`gh\` and then STOP — do NOT merge. Also \`git add\` the handoff file at
+docs/kennel-onboarding/handoffs/$target_base so it's part of the PR. If you cannot complete it
+(e.g. live source verification fails and the documented fallback also fails), open a DRAFT PR
+titled 'WIP: onboard ...' explaining what blocked you, rather than merging or leaving nothing."
+
+echo "--- claude -p starting ---"
+# shellcheck disable=SC2086
+claude -p "$PROMPT" $PERM_FLAGS || { echo "claude run exited non-zero for $target_base"; exit 1; }
+echo "--- claude -p finished ---"
+
+# ---- mark processed so the next run skips it ----
+echo "$target_base" >> "$DONE_LOG"
+echo "=== done: $target_base ==="

--- a/scripts/onboard-implement.sh
+++ b/scripts/onboard-implement.sh
@@ -31,7 +31,6 @@ LOG="${HASHTRACKS_BOT_LOG:-$HOME/Library/Logs/hashtracks-onboard.log}"
 PERM_FLAGS="${HASHTRACKS_PERM_FLAGS:---permission-mode acceptEdits --allowedTools Bash Edit Write Read Glob Grep WebFetch}"
 
 HANDOFF_DIR="$DEV_REPO/docs/kennel-onboarding/handoffs"
-DONE_LOG="$DEV_REPO/docs/kennel-onboarding/.implemented.log"
 
 mkdir -p "$(dirname "$LOG")"
 exec >>"$LOG" 2>&1
@@ -40,22 +39,30 @@ echo "=== $(date '+%Y-%m-%d %H:%M:%S')  onboard-implement run ==="
 
 # Make common tool paths available under launchd's minimal environment.
 export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/.fnm:$PATH"
-command -v fnm >/dev/null 2>&1 && eval "$(fnm env)" && fnm use 20 >/dev/null 2>&1 || true
+if command -v fnm >/dev/null 2>&1; then
+  eval "$(fnm env)"
+  fnm use 20 >/dev/null 2>&1 || true
+fi
 
 command -v claude >/dev/null 2>&1 || { echo "FATAL: 'claude' CLI not found in PATH"; exit 1; }
 command -v gh >/dev/null 2>&1 || echo "WARN: 'gh' not found — PR creation may fail"
 [ -d "$DEV_REPO/.git" ] || { echo "FATAL: dev repo not found at $DEV_REPO"; exit 1; }
 
-# ---- pick newest handoff: not README, not voided, not already implemented ----
-touch "$DONE_LOG"
+# ---- pick newest handoff: not voided, not already implemented ----
+# "Already implemented" = an onboard/<code>-* branch exists on origin — the same durable oracle
+# scripts/copy-newest-handoff.sh uses. No local state file, so the dev working tree stays clean.
+# The glob is constrained to the YYYY-MM-DD-<code>.md handoff format so README.md (and any future
+# non-handoff .md) never match.
 target=""
 while IFS= read -r f; do
   base="$(basename "$f")"
-  [ "$base" = "README.md" ] && continue
   if head -5 "$f" | grep -qi 'VOID'; then echo "skip (voided): $base"; continue; fi
-  if grep -qxF "$base" "$DONE_LOG"; then continue; fi
+  code="$(echo "$base" | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}-(.+)\.md$/\1/')"
+  if git -C "$DEV_REPO" ls-remote --heads origin "onboard/${code}-*" 2>/dev/null | grep -q .; then
+    echo "skip (branch exists): $base"; continue
+  fi
   target="$f"; break
-done < <(ls -t "$HANDOFF_DIR"/*.md 2>/dev/null || true)
+done < <(ls -t "$HANDOFF_DIR"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*.md 2>/dev/null || true)
 
 if [ -z "$target" ]; then echo "Nothing to do — no new handoff."; exit 0; fi
 target_base="$(basename "$target")"
@@ -65,6 +72,9 @@ echo "Implementing handoff: $target_base"
 if [ ! -d "$BOT_DIR/.git" ]; then
   origin="$(git -C "$DEV_REPO" remote get-url origin)"
   echo "Cloning $origin → $BOT_DIR"
+  # Clear any leftover non-git directory (e.g. an interrupted prior clone) so `git clone` doesn't
+  # fail with "destination path already exists and is not an empty directory".
+  rm -rf "$BOT_DIR"
   git clone "$origin" "$BOT_DIR"
 fi
 git -C "$BOT_DIR" fetch origin --prune
@@ -76,8 +86,10 @@ git -C "$BOT_DIR" clean -fd
 cp "$DEV_REPO/.env" "$BOT_DIR/.env" 2>/dev/null || true
 cp "$DEV_REPO/.env.local" "$BOT_DIR/.env.local" 2>/dev/null || true
 
-# install deps if missing
-[ -d "$BOT_DIR/node_modules" ] || (cd "$BOT_DIR" && npm ci)
+# install deps if missing OR if the lockfile changed since the last install (stale node_modules)
+if [ ! -d "$BOT_DIR/node_modules" ] || [ "$BOT_DIR/package-lock.json" -nt "$BOT_DIR/node_modules" ]; then
+  (cd "$BOT_DIR" && npm ci)
+fi
 
 # bring the handoff into the clone so it can be committed into the PR
 mkdir -p "$BOT_DIR/docs/kennel-onboarding/handoffs"
@@ -100,6 +112,6 @@ echo "--- claude -p starting ---"
 claude -p "$PROMPT" $PERM_FLAGS || { echo "claude run exited non-zero for $target_base"; exit 1; }
 echo "--- claude -p finished ---"
 
-# ---- mark processed so the next run skips it ----
-echo "$target_base" >> "$DONE_LOG"
+# Processed-state is durable via the onboard/<code>-* branch the run above pushes — the next
+# invocation's branch-existence check skips this handoff, so no local state file is needed.
 echo "=== done: $target_base ==="


### PR DESCRIPTION
Scaffolds the daily kennel onboarding loop alongside the already-merged source-platform-notes.md. Manual-paste workflow is the documented default; cloud routine + launchd implementer are committed parked. First handoff (Bali Hash 2) ships separately.