### PR TITLE
docs(kennel-onboarding): fold ONH3 retro fixes into prompt + Bali patch

### DIFF
--- a/docs/kennel-onboarding/daily-onboarding-prompt.md
+++ b/docs/kennel-onboarding/daily-onboarding-prompt.md
@@ -180,6 +180,24 @@ to approve it (Chrome works for already-approved domains like `hashtracks.xyz`).
 **Capture for the handoff:** event count seen, date range, and 3–5 sample events with whatever
 fields the source exposes (date, time, title, hares, location, description, run number).
 
+**🔴 Sample ≥3 posts across YEARS (not just the latest 3) for multi-year archives.** Format drift
+is the rule, not the exception. Real source data routinely mixes: full and abbreviated months
+("16 March 2026" vs "16 Mar 2019"), weekday-prefixed dates ("Monday, 20 April 2026"), per-block
+field layouts (each `Date:`/`Hare:`/`Venue:` in its own `<p>` or `<h5>`), embedded recap blocks
+*inside* run posts, standalone "Hash Trash Run N" recap *posts*, prose-format older entries
+vs `<table>`-format newer ones, and outright **source date typos** (a 2020 post may carry a 2019
+date label). Report every variant you see in the sample so the adapter is designed for the
+distribution, not the latest post. The ONH3 retro lists each of these specifically — start there.
+
+**Past + schedule sources → call the split at research time.** If the source carries both an
+archive (past runs) AND an advance schedule, recommend the **past/future split** in the handoff:
+- **Past → one-shot backfill** (`scripts/backfill-<code>-history.ts`), run once, never touched again.
+- **Future → adapter** with `config.upcomingOnly: true` so `reconcile.ts` doesn't false-cancel
+  aged-out archive rows.
+- **Report how far ahead the live feed actually reaches** (the ONH3 Google Calendar only covered
+  ~4 weeks while the WordPress.com archive went back to 2019). Past-only vs future-only vs both
+  matters for the adapter shape — don't conflate them.
+
 **If the source is genuinely dead / has no upcoming events** (HTML listing itself is empty/gone):
 mark the target `blocked` with the reason, fall back to the next `queued` target (return to
 Step 1). A feed you simply couldn't fetch from the sandbox is **not** "dead" — flag it instead.
@@ -200,6 +218,23 @@ Kennel profile (maps to the `Kennel` model): `fullName`, `shortName`, `kennelCod
   URL** (e.g. `images.squarespace-cdn.com/.../<hash>/...`, signed S3, Wix `static.wixstatic.com/media/<hash>~mv2.<ext>`),
   flag it `⚠️ self-host` — recommend Claude Code download it into `public/kennel-logos/<code>.<ext>`
   and reference that path instead (these CDN URLs can rotate when the kennel re-uploads).
+- **New country → 5-edit `src/lib/region.ts` checklist (NOT just COUNTRY + METRO).** Listing
+  only the seed records is the gap that bit ONH3 (Kenya was first Africa, missed
+  `COUNTRY_INFERENCE_RULES`, `inferCountry()` returned `"USA"` for Kenyan kennels, caught in CI).
+  Bali Hash 2 will hit the same gap if not pre-flagged. Every new country needs **all 5**:
+  1. **`REGION_SEED_DATA`** — COUNTRY record (timezone, ISO abbrev, centroid, color classes, pin
+     color, aliases) **+** METRO record under it.
+  2. **`STATE_GROUP_MAP`** — metro → group (use country name as the group for country→metro
+     countries; mirror the New Zealand / Singapore precedent).
+  3. **`COUNTRY_GROUP_MAP`** — wire **both** the country **and** every metro slug to the country
+     name (this is what `groupRegionsByCountry` consumes).
+  4. **`COUNTRY_CODE_TO_NAME`** — ISO code → country name (e.g. `"ID": "Indonesia"`).
+  5. **`COUNTRY_INFERENCE_RULES`** — regex → country (e.g. `/\bbali\b|\bindonesia\b/i` → "Indonesia").
+     **Without this, `inferCountry()` falls through to `"USA"`** for any text mentioning the new
+     country. THE one that bit ONH3 in CI; do not omit.
+  Also pick a **color palette consistent with the continent** for the COUNTRY + METRO records
+  (Africa = amber per Kenya precedent; pick a similarly-distinct Asia palette by scanning
+  existing Bangkok/Singapore/Tokyo entries rather than guessing).
 - **Schedule with more than one pattern → suggest `scheduleRules`, not just `scheduleDayOfWeek`.**
   If the kennel runs e.g. "weekly Wednesday + occasional Saturday," a single `scheduleDayOfWeek`
   miscategorizes the rest in Travel Mode. Propose an RRULE array, e.g.:
@@ -256,6 +291,19 @@ Produce:
   captured HTML snippet for the test fixture **that mirrors the real DOM structure** (e.g. Wix
   wraps blocks in `[data-testid="richTextElement"]` — a flat fixture passes tests then fails
   live; see `source-platform-notes.md` → Wix), and the `htmlScrapersByUrl` registry entry to add.
+- **Adapter code shown in the handoff is ILLUSTRATIVE — not authoritative.** Show the *shape*
+  (control flow, where each field comes from, helper extraction, pagination/coord/end-time
+  handling, S5852/S3776 boundaries) and name a **reference adapter** to mirror (e.g.
+  "model on `src/adapters/html-scraper/onh3.ts` for WP.com REST; `hangover.ts` for Ghost"). Do
+  **NOT** assert field names, function signatures, or import paths in the sketch as if they're
+  canonical — the ONH3 sketch invented `kennelTag` (real type is `kennelTags: string[]`),
+  invented `walkerFriendly` (not on `Kennel`), used raw `fetch()` (must be `safeFetch`),
+  hardcoded a `title` (`merge.ts` synthesizes when undefined), and set
+  `kennelPagesStopReason` in a way that would silently disable reconciliation. Include an
+  explicit **"⚠️ Claude Code must verify against current types"** stanza listing exactly what
+  to check (RawEventData/Kennel field names, `safeFetch` vs `fetch`, `kennelPagesStopReason`
+  semantics — set only on genuine truncation, e.g. a full page left unfetched / an HTTP or
+  fetch error; a non-empty string suppresses stale-event reconciliation in `scrape.ts`).
 - Conventions to honor downstream: dates as **UTC noon**, `startTime` as `"HH:MM"` string,
   `cuid()` IDs, longer kennel-resolver patterns before shorter ones.
 
@@ -336,6 +384,23 @@ Create `docs/kennel-onboarding/handoffs/<YYYY-MM-DD>-<kennelCode>.md` with this 
 
 ## Adapter notes / new-scraper plan
 <config explanation, or full parsing plan + fixture snippet (mirror real DOM) + registry entry>
+
+**⚠️ Claude Code: verify before writing real code.** Any code snippet below is illustrative; the
+authority is the live repo. Before writing the adapter, confirm against current types/imports:
+- `RawEventData` field names — `kennelTags` is `string[]` (NOT `kennelTag`); there is no
+  `walkerFriendly` field on `Kennel`; check the actual `prisma/schema.prisma` for unexpected
+  invented fields.
+- Imports — `safeFetch` from `@/adapters/safe-fetch` (NOT raw `fetch`); date/extract helpers from
+  `@/adapters/utils`; browser-render via `browserRender` from `@/lib/browser-render`.
+- `kennelPagesStopReason` — set ONLY on genuine truncation (a full page left unfetched / HTTP or
+  fetch error); a non-empty string suppresses stale-event reconciliation. Don't set it on a clean
+  pagination end (e.g. WP.com `page=N+1` returning 400 = expected end, leave it null).
+- `title` — leave `undefined` when no clean theme exists; `merge.ts` synthesizes
+  `"<KennelName> Trail #N"`. Never let a labeled-field fragment or hare name become the title.
+- For `kennelPatterns` (when this is a multi-kennel calendar/source): list the actual sampled
+  titles you're matching against AND keep regexes `safe-regex2`-clean — single `\s` (not stacked
+  `\s+`), no `(?:…\s+)?` optional groups stacked, no nested quantifiers. S5852 will reject the
+  obvious forms.
 
 ## Deep-dive checklist (nothing deferred)
 - [x] logo (stable? else flag self-host)  [x] foundedYear  [x] socials  [x] schedule (+ scheduleRules if multi-pattern)  [x] hashCash

--- a/docs/kennel-onboarding/daily-onboarding-prompt.md
+++ b/docs/kennel-onboarding/daily-onboarding-prompt.md
@@ -225,9 +225,12 @@ Kennel profile (maps to the `Kennel` model): `fullName`, `shortName`, `kennelCod
   1. **`REGION_SEED_DATA`** — COUNTRY record (timezone, ISO abbrev, centroid, color classes, pin
      color, aliases) **+** METRO record under it.
   2. **`STATE_GROUP_MAP`** — metro → group (use country name as the group for country→metro
-     countries; mirror the New Zealand / Singapore precedent).
-  3. **`COUNTRY_GROUP_MAP`** — wire **both** the country **and** every metro slug to the country
-     name (this is what `groupRegionsByCountry` consumes).
+     countries; mirror the New Zealand / Singapore precedent). **Keys are canonical region
+     display names, NOT lowercase slugs** — e.g. `"Bali": "Indonesia"` (cf. `"Nairobi": "Kenya"`).
+  3. **`COUNTRY_GROUP_MAP`** — wire **both** the country **and** every metro to the country
+     name (this is what `groupRegionsByCountry` consumes). Same key convention as item 2 —
+     canonical display names, not slugs — e.g. `"Indonesia": "Indonesia"` + `"Bali": "Indonesia"`
+     (cf. `"Bangkok": "Thailand"`).
   4. **`COUNTRY_CODE_TO_NAME`** — ISO code → country name (e.g. `"ID": "Indonesia"`).
   5. **`COUNTRY_INFERENCE_RULES`** — regex → country (e.g. `/\bbali\b|\bindonesia\b/i` → "Indonesia").
      **Without this, `inferCountry()` falls through to `"USA"`** for any text mentioning the new

--- a/docs/kennel-onboarding/handoff-retros/2026-05-29-onh3.md
+++ b/docs/kennel-onboarding/handoff-retros/2026-05-29-onh3.md
@@ -1,0 +1,161 @@
+# Cowork Handoff Retro — ONH3 (Original Nairobi H3) — 2026-05-29
+
+Feedback from the Claude Code implementation session for the `2026-05-29-onh3.md` handoff
+(the third successful Cowork research run). Goal: improve the **research prompt** so future
+handoffs need fewer mid-implementation corrections.
+
+**PRs produced:**
+- Onboarding: https://github.com/johnrclem/hashtracks-web/pull/1802 (merged)
+- Follow-up fixes: https://github.com/johnrclem/hashtracks-web/pull/1807 (merged)
+
+**Outcome:** First Africa kennel live at https://www.hashtracks.xyz/kennels/onh3 — 114 canonical
+events (2020→Dec 2026), 30 upcoming, WordPress.com REST adapter + 83-event AI-mapped historical
+backfill + secondary Google Calendar.
+
+---
+
+## What the handoff got RIGHT (keep doing)
+
+These saved real time and prevented bugs — preserve them in the prompt:
+
+1. **The `▶ FOR CLAUDE CODE` directive at the top** with branch name, scope, and "live-verify per
+   `.claude/rules/live-verification.md`." Drove the whole session cleanly.
+2. **Source-type identification + reference adapter to mirror** ("WordPress.com REST API, mirror
+   `SWH3Adapter`"). Correct and high-leverage.
+3. **Collision check** (`kennelCode: onh3` clear) — verified, accurate.
+4. **The embedded "Hash Trash" recap warning.** This was the single best catch in the handoff —
+   each ONH3 post bundles the *previous* run's recap, and without the warning the parser would
+   have harvested the wrong date. Flag this class of thing ("posts bundle prior-run recaps")
+   whenever sampled.
+5. **`DD/MM/YYYY` (UK/Kenyan) date-ordering** call-out — correct and easy to get wrong.
+6. **Logo self-host flag** (WordPress.com CDN path rotates) — correct, matches repo convention.
+7. **Pre-emptive SonarCloud notes** (S3776 cognitive complexity, S5852 ReDoS) — useful framing.
+8. **Metadata accuracy** (schedule, hash cash KSh 900, founded 2000, Facebook group) — all verified
+   correct against the live site.
+
+---
+
+## Handoff GAPS → research-prompt improvements (the actionable part)
+
+Each of these cost a correction during implementation. Grouped by whether it's a **research**
+fix (sample more / know the schema) or a **don't-overspecify** fix (the sketch was wrong; better to
+under-specify and let Claude Code write it).
+
+### A. Schema/contract details the sketch got wrong — *stop hand-writing the adapter sketch in this much detail*
+
+The handoff included a ~150-line adapter code sketch. Several details were wrong and had to be
+rewritten. **Recommendation: replace the full code sketch with a short "shape" spec** (fields to
+extract, reference adapter, pitfalls) and let Claude Code write the actual code against the live
+types. The wrong details were:
+
+1. **`kennelTag` (singular) → must be `kennelTags: ["onh3"]`** (required `string[]` per
+   `src/adapters/types.ts`). The sketch used a field that doesn't exist.
+2. **`walkerFriendly: true` in the kennel seed → field does not exist** on `KennelSeed`/schema
+   (only `dogFriendly`). The research invented a plausible-but-nonexistent field.
+3. **Raw `fetch()` → must be `safeFetch`** (SSRF guard). Convention the sketch missed.
+4. **Hardcoded `title: "ONH3 Run #N"` → should be `undefined`** so `merge.ts` synthesizes the
+   canonical title (repo rule: title fallback must never be a placeholder/hare name).
+5. **`kennelPagesStopReason` always set to a string → must be `null` on clean completion.** The
+   sketch's value would have *permanently disabled stale-event reconciliation* (`scrape.ts` treats
+   any non-empty value as "incomplete"). Subtle, high-impact.
+
+> **Prompt change:** Drop the literal code sketch. Instead emit: "Reference adapter: `swh3.ts`.
+> Emit `RawEventData` with `kennelTags: [code]`, `startTime` `"HH:MM"`, leave `title` undefined
+> unless a real per-run theme exists. Use `safeFetch`. For paginated sources, set
+> `kennelPagesStopReason` only on genuine truncation (see `hashrego`/`squarespace-events`)." Let
+> Claude Code read the current types/conventions rather than freezing them in a sketch that drifts.
+
+### B. New-country onboarding is a 5-edit checklist, not 2 — *research should enumerate all of them*
+
+The handoff listed the two `REGION_SEED_DATA` records (Kenya COUNTRY + Nairobi METRO) but **missed
+the other region wiring**, which surfaced as a real bug in CI review (`inferCountry("Nairobi")`
+returned "USA"). A new country requires updating, in `src/lib/region.ts`:
+- `REGION_SEED_DATA` (country + metro) ✅ handoff had this
+- `STATE_GROUP_MAP` (metro → group)
+- `COUNTRY_GROUP_MAP` (country **and** metro → country name)
+- `COUNTRY_CODE_TO_NAME` (ISO code → name)
+- `COUNTRY_INFERENCE_RULES` (regex → country) ← **the one that bit us**
+
+> **Prompt change:** Add a "New country/region checklist" the research must fill in when a kennel
+> introduces a new country: list all five maps with the exact tuples to add, following the New
+> Zealand/Singapore precedent (country→metro, no state-province). The `bali-hash-2.md` handoff
+> (new "Indonesia"/"Bali") will hit this exact gap — worth fixing before it's implemented.
+
+### C. Under-sampled body-format variety — *sample more posts, especially old ones*
+
+The handoff's date regex only handled full month names. Real ONH3 data had:
+- Abbreviated months (`16 Mar 2019`) and weekday prefixes (`Date: Monday, 20 April 2026`).
+- **Per-block-element field layout** — each `Date:`/`Hare:`/`Venue:` in its own `<p>`/`<h5>`, with
+  an unlabeled recap in following `<p>`s. The naive parse let `Venue:` swallow the whole recap;
+  fix needed newline-bounded field tokenizing.
+- **Standalone "Hash Trash" *posts*** (not just embedded blocks) — recaps titled "Hash Trash Run N"
+  that must be skipped.
+- **Prose-format older "Hareline" posts** (2020) vs `<table>` format (2025/2026) — same logical
+  content, two parsers.
+- A **source date typo** (post #1068 labeled "16 Mar 2019" but published 2020 for a 2020 run),
+  producing a mis-dated ghost event — required a publish-date sanity guard (#1807).
+
+> **Prompt change:** Have the research sample **≥3 posts across different years** (newest + a
+> 2–3-year-old one) and explicitly report: date formats seen, whether fields are inline vs
+> per-block, whether recaps appear as separate posts, and whether annual index/"hareline" posts
+> change format across years. Note any date that disagrees with the post's publish date.
+
+### D. History strategy + reconciliation interplay — *research should call the past/future split*
+
+The handoff suggested parsing the annual master table *in the adapter*. During implementation we
+split it: **adapter emits future rows only; past rows go to a one-shot AI-mapped backfill**; and the
+source needs **`config.upcomingOnly: true`** so reconciliation (which else cancels orphaned events
+within ±scrapeDays) doesn't false-cancel the archive. Also discovered: the secondary Google Calendar
+only published ~4 weeks ahead, so the table was the *sole* advance-schedule source — meaning you
+can't just drop table parsing.
+
+> **Prompt change:** When a source exposes both an archive and a forward schedule, the research
+> should recommend the **past→one-shot-backfill / future→adapter** split, flag `upcomingOnly: true`
+> when the source carries history, and check how far ahead each feed actually reaches (don't assume
+> a secondary calendar covers the full schedule). (The repo already prefers one-shot backfills for
+> history — `feedback_historical_backfill`.)
+
+### E. Secondary-source config precision — *verify title formats before writing the pattern*
+
+The handoff proposed a Google Calendar secondary source with a `kennelPatterns` regex
+`Run\s*#?\s*\d{3,4}`. In practice the calendar titled runs three ways (`Run 1334`, `ONH3 1328`,
+bare `1324`), so the pattern missed 5 of them, and my first broadened version
+(`(?:…\s+)?(?:…\s+)?`) **failed `safe-regex2`** (CI-blocking). Final: `^(?:ONH3\s)?(?:Run\s)?#?\d{3,4}\b`.
+
+> **Prompt change:** If proposing a `kennelPatterns` regex, the research should list the **actual
+> sampled title strings** it must match, and prefer single `\s` over `\s+` (the repo validates
+> kennelPatterns with `safe-regex2`; `\s+` in stacked optional groups is rejected).
+
+---
+
+## Implementation-side learnings (context for the loop, mostly NOT research-prompt changes)
+
+These are Claude-Code / repo-process notes — useful background, but not things the research prompt
+controls:
+
+- **CI bot gauntlet** is heavy: SonarCloud (S5852 ReDoS, S3776 complexity), **Codacy/Semgrep**
+  (`detect-non-literal-regexp` on `new RegExp(variable)` even with constant args; plus a false-
+  positive "unencoded HTML input" on a registry array line). Took several CI rounds. A single
+  `matchAll(literalRegex)` tokenizer beats per-key `new RegExp`.
+- **`main` is unprotected** — no required checks block merge; Codacy/SonarCloud are advisory.
+- **Append-heavy files conflict** (`registry.ts`, `seed-data/*`) when other onboardings land first;
+  expect a merge-resolution pass.
+- **Post-merge runbook** (manual): `npx prisma db seed` (additive; updates changed `Source.config`)
+  → one-shot backfill (`BACKFILL_ALLOW_SELF_SIGNED_CERT=1` for the Railway public proxy) → re-scrape.
+  Note: a normal scrape merges **only freshly-fetched events**, so a backfill that inserts RawEvents
+  directly must be merged explicitly (it won't ride along on a scrape unless the adapter re-emits).
+
+---
+
+## TL;DR for the research prompt
+
+1. **Stop emitting a full adapter code sketch** — emit a short shape spec + reference adapter +
+   pitfalls. The detailed sketch drifted from the real types (`kennelTags`, `safeFetch`,
+   `kennelPagesStopReason`, title-synthesis) and invented a field (`walkerFriendly`).
+2. **Add a "new country" checklist** covering all 5 region maps (incl. `COUNTRY_INFERENCE_RULES`).
+3. **Sample ≥3 posts across years** and report date-format variety, inline-vs-per-block layout,
+   standalone recap posts, format drift in annual index posts, and publish-date/run-date mismatches.
+4. **For archive+schedule sources**, recommend the past-backfill / future-adapter split +
+   `upcomingOnly: true`, and verify how far ahead each feed reaches.
+5. **For `kennelPatterns`**, list the real sampled titles to match and keep the regex `safe-regex2`-
+   clean (single `\s`, no stacked `(?:…\s+)?`).

--- a/docs/kennel-onboarding/handoffs/2026-05-29-bali-hash-2.md
+++ b/docs/kennel-onboarding/handoffs/2026-05-29-bali-hash-2.md
@@ -140,18 +140,20 @@ Adapter shape:
 },
 ```
 
-#### 8a.2 — `STATE_GROUP_MAP` (metro slug → group name)
+#### 8a.2 — `STATE_GROUP_MAP` (metro **display name** → group name)
 Indonesia is a country→metro country (no state-province intermediate), so the group name is the
-country itself. Mirror the Kenya / New Zealand / Singapore precedent:
+country itself. Keys are the **canonical region display names**, not lowercase slugs (mirror the
+existing `"Nairobi": "Kenya"` entry):
 ```ts
-"bali": "Indonesia",
+"Bali": "Indonesia",
 ```
 
-#### 8a.3 — `COUNTRY_GROUP_MAP` (country slug **AND** every metro slug → country name)
-**Both** keys are required — `groupRegionsByCountry()` consumes the metro mapping too:
+#### 8a.3 — `COUNTRY_GROUP_MAP` (country name **AND** every metro display name → country name)
+**Both** keys are required — `groupRegionsByCountry()` consumes the metro mapping too. As in 8a.2,
+key by canonical display name, not slug (e.g. existing `"Bangkok": "Thailand"`):
 ```ts
-"indonesia": "Indonesia",
-"bali": "Indonesia",
+"Indonesia": "Indonesia",
+"Bali": "Indonesia",
 ```
 
 #### 8a.4 — `COUNTRY_CODE_TO_NAME` (ISO code → name)

--- a/docs/kennel-onboarding/handoffs/2026-05-29-bali-hash-2.md
+++ b/docs/kennel-onboarding/handoffs/2026-05-29-bali-hash-2.md
@@ -102,7 +102,15 @@ Adapter shape:
 
 ## 8. Ready-to-paste seed blocks
 
-### 8a. Region — `src/lib/region.ts` (add Indonesia COUNTRY + Bali METRO; new country)
+### 8a. Region — `src/lib/region.ts` (**NEW COUNTRY = 5 EDITS, all required**)
+
+> ⚠️ **Updated 2026-05-29 per ONH3 retro.** A new country touches **5 places** in `region.ts`,
+> not just `REGION_SEED_DATA`. ONH3 (Kenya, first Africa) shipped missing
+> `COUNTRY_INFERENCE_RULES` and `inferCountry()` returned `"USA"` for Kenyan kennels — caught in
+> CI, fixed in PR #1807. Do not repeat that for Indonesia. Mirror the Kenya pattern in commit
+> `685f2e0d` (look for the `// ── Africa — Kenya ──` block and follow each step).
+
+#### 8a.1 — `REGION_SEED_DATA` (COUNTRY + METRO entries)
 ```ts
 // ── Indonesia ──
 {
@@ -111,6 +119,8 @@ Adapter shape:
   level: "COUNTRY",
   timezone: "Asia/Jakarta",
   abbrev: "ID",
+  // ⚠️ Pick an Asia-distinct palette — scan existing Bangkok/Singapore/Tokyo/HK entries before
+  // setting these; current values are a guess and likely collide with an existing Asia kennel.
   colorClasses: "bg-rose-100 text-rose-700",
   pinColor: "#e11d48",
   centroidLat: -2.55,
@@ -129,7 +139,39 @@ Adapter shape:
   aliases: ["Bali, Indonesia", "Denpasar", "Denpasar, Bali", "Bali, ID"],
 },
 ```
-*(Verify `colorClasses`/`pinColor` aren't already assigned to a neighboring region; pick an unused palette slot if rose collides.)*
+
+#### 8a.2 — `STATE_GROUP_MAP` (metro slug → group name)
+Indonesia is a country→metro country (no state-province intermediate), so the group name is the
+country itself. Mirror the Kenya / New Zealand / Singapore precedent:
+```ts
+"bali": "Indonesia",
+```
+
+#### 8a.3 — `COUNTRY_GROUP_MAP` (country slug **AND** every metro slug → country name)
+**Both** keys are required — `groupRegionsByCountry()` consumes the metro mapping too:
+```ts
+"indonesia": "Indonesia",
+"bali": "Indonesia",
+```
+
+#### 8a.4 — `COUNTRY_CODE_TO_NAME` (ISO code → name)
+```ts
+"ID": "Indonesia",
+```
+
+#### 8a.5 — `COUNTRY_INFERENCE_RULES` (regex → country)  ← **THE ONE THAT BIT ONH3**
+**Without this, `inferCountry()` falls through to `"USA"` for any text mentioning Bali or
+Indonesia.** This is the CI-blocker. Mirror the Kenya rule's shape (safe regex — single `\b`
+boundaries, alternation only, no nested groups):
+```ts
+[/\bbali\b|\bindonesia\b/i, "Indonesia"],
+```
+
+**Verify all 5 are present** before pushing. Grep the diff:
+```bash
+git diff src/lib/region.ts | grep -E "Indonesia|Bali|\"ID\":|inferCountry|COUNTRY_INFERENCE|COUNTRY_GROUP|STATE_GROUP|COUNTRY_CODE"
+```
+Expected: at least 6 hits (one per item above, plus the country-inference regex match).
 
 ### 8b. Kennel — `prisma/seed-data/kennels.ts`
 ```ts


### PR DESCRIPTION
See commit message. Source-of-truth retro is committed under `handoff-retros/` (outside `handoffs/` so the copy-newest helper skips it). Bali Hash 2 implementation can paste the updated handoff (re-run `scripts/copy-newest-handoff.sh` first) and won't hit the inferCountry gap that bit ONH3.