### PR TITLE
feat(hashcash): backfill structured Kennel.hashCash + surface Event.cost on card

### DIFF
--- a/prisma/migrations/20260530120000_fix_profile_round_15_hashcash/migration.sql
+++ b/prisma/migrations/20260530120000_fix_profile_round_15_hashcash/migration.sql
@@ -46,8 +46,8 @@ BEGIN
     END IF;
 
     UPDATE "Kennel"
-    SET "hashCash"  = COALESCE("hashCash", r.hash_cash),
-        "updatedAt" = NOW()
+    SET "hashCash"  = r.hash_cash,
+        "updatedAt" = NOW() AT TIME ZONE 'UTC'
     WHERE "kennelCode" = r.kennel_code
       AND "hashCash" IS NULL;
   END LOOP;

--- a/prisma/migrations/20260530120000_fix_profile_round_15_hashcash/migration.sql
+++ b/prisma/migrations/20260530120000_fix_profile_round_15_hashcash/migration.sql
@@ -1,0 +1,56 @@
+-- Profile Round 15 hash-cash backfill (#1504, #1571) — drain prose-captured
+-- hash cash values into the structured `Kennel.hashCash` slot.
+--
+-- The cycle-15 canonical decision (#1571) keeps `Kennel.hashCash` (kennel-level
+-- standard/headline) and `Event.cost` (per-event override) as a two-tier model —
+-- no schema change. This migration only backfills DATA. The matching seed
+-- headline values live in prisma/seed-data/kennels.ts; the prose detail stays in
+-- each kennel's `description` (carries tier / payment-method nuance the headline
+-- can't encode, e.g. "non piss-stop vs piss-stop", "pay-as-you-go at restaurants").
+--
+-- Why a migration and not just a seed update: `ensureKennelRecords`
+-- (prisma/seed.ts) only fills NULL profile fields on existing rows, and Vercel's
+-- build runs `migrate deploy` — not `prisma db seed`. Issuing the null-fills via
+-- COALESCE here pushes them to prod automatically (see memory:
+-- feedback_post_merge_seed_required.md). All 14 candidate slots were verified
+-- NULL in prod before authoring; motherh3 / mrhappy / mrh3 were already populated
+-- and are intentionally excluded.
+--
+-- Idempotency: COALESCE + `"hashCash" IS NULL` guard makes re-application a no-op
+-- on an already-corrected DB. A NOTICE surfaces missing-row situations on fresh /
+-- preview DBs.
+
+BEGIN;
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT * FROM (VALUES
+      ('garden-city-h3',   '$7 (at hare''s home)'),
+      ('capital-h3-nz',    '$2'),
+      ('geriatrix-h3',     '$2 / $4'),
+      ('auckland-hussies', '$15'),
+      ('hibiscus-h3',      'Free'),
+      ('mel-new-moon',     '$5'),
+      ('lbh-phx',          '$5'),
+      ('lds-h3',           '$5'),
+      ('lil',              '$20'),
+      ('lch3',             '$15 ladies / $20 men'),
+      ('madisonh3',        '$5')
+    ) AS t(kennel_code, hash_cash)
+  LOOP
+    IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = r.kennel_code) THEN  -- NOSONAR plsql:S1138
+      RAISE NOTICE 'Kennel "%" not found — UPDATE will no-op (run prisma db seed)', r.kennel_code;  -- NOSONAR plsql:S1192
+    END IF;
+
+    UPDATE "Kennel"
+    SET "hashCash"  = COALESCE("hashCash", r.hash_cash),
+        "updatedAt" = NOW()
+    WHERE "kennelCode" = r.kennel_code
+      AND "hashCash" IS NULL;
+  END LOOP;
+END $$;
+
+COMMIT;

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -93,6 +93,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Monthly",
       scheduleNotes: "Saturday near the full moon — LIRR-accessible starts. Check schedule for time.",
       foundedYear: 2012,
+      hashCash: "$20",
       description: "Long Island's LIRR-friendly hash kennel — part of the HashNYC umbrella. Trails start near a Long Island Rail Road station on full-moon Saturdays. Hash cash is $20.",
     },
     {
@@ -2425,6 +2426,7 @@ export const KENNELS: KennelSeed[] = [
       logoUrl: "/kennel-logos/lbh-phx.png",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       foundedYear: 2011,
+      hashCash: "$5",
       description: "Phoenix weekly Monday evening hash. Part of the phoenixhhh.org collective. Hash cash is $5.",
       latitude: 33.45, longitude: -112.07,
     },
@@ -3029,6 +3031,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Weekly",
       scheduleNotes: "5 PM summer (DST), 3 PM winter",
       foundedYear: 1977,
+      hashCash: "$5",
       description: "Madison's weekly Saturday hash since 1977. Run #2540+. Hash cash is $5.",
       latitude: 43.07, longitude: -89.40,
     },
@@ -3364,6 +3367,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleTime: "6:00 PM",
       scheduleNotes: "Weekly Friday evenings at 6 PM, mixed.",
       foundedYear: 1982,
+      hashCash: "$15 ladies / $20 men",
       description: "Singapore's Friday hash, running every Friday since 1982. Mixed kennel that runs 50+ weeks a year, with weekly trail announcements on lioncityhhh.com — including hare, run location, nearest MRT, bus routes, and the on-on venue. Hash cash is $15 for ladies, $20 for men.",
       latitude: 1.3, longitude: 103.83,
     },
@@ -3599,6 +3603,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleDayOfWeek: "Saturday", scheduleTime: "3:00 PM", scheduleFrequency: "Monthly",
       scheduleNotes: "Saturday nearest the new moon.",
       contactName: "John 0411 143744",
+      hashCash: "$5",
       description: "Melbourne New Moon HHH — Melbourne's city-runners new-moon kennel. A drinking club with a running problem: each run is a mystery fun run, with a known start but trail marks leading you somewhere unknown (beware false trails). Hash cash is $5 to cover the circle beers.",
       latitude: -37.8136, longitude: 144.9631,
     },
@@ -4142,6 +4147,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleTime: "6:00 PM",
       scheduleNotes: "Weekly Thursday evenings at 6 PM. Part of the Whoreman H3 umbrella.",
       foundedYear: 2011,
+      hashCash: "$5",
       description: "LDS H3 (Lotsa Damn Shiggy) — Salt Lake City's weekly Thursday evening hash. NOT a religious organization. Hash cash is $5.",
       latitude: 40.76, longitude: -111.89,
     },
@@ -4182,6 +4188,7 @@ export const KENNELS: KennelSeed[] = [
       region: "Christchurch, NZ", country: "New Zealand",
       website: "https://gardencityhash.co.nz",
       foundedYear: 1984,
+      hashCash: "$7 (at hare's home)",
       scheduleDayOfWeek: "Tuesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Tuesday evenings at 6:30 PM. Hareline (Receding Hareline) maintained on the homepage with run number, date, hares, and location.",
       description: "Founded 1984 when Christchurch H3 outgrew its single weekly slot. Garden City takes the Tuesday evening slot with a continuously maintained hareline and ~2,300+ runs to date.",
@@ -4192,6 +4199,7 @@ export const KENNELS: KennelSeed[] = [
       region: "Auckland, NZ", country: "New Zealand",
       website: "https://www.edmondsfamily.co.nz/community/hibiscus-hhh",
       foundedYear: 1987,
+      hashCash: "Free",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Monday evenings at 6:30 PM on Auckland's Hibiscus Coast (Orewa). Trail list posted as a public schedule.",
       description: "Hibiscus Coast hash kennel covering Orewa, Whangaparaoa, and the northern Auckland coast. Weekly Monday evening trails since 1987. No fees, no committee — an optional post-run meal and drinks are pay-as-you-go.",
@@ -4224,6 +4232,7 @@ export const KENNELS: KennelSeed[] = [
       facebookUrl: "https://www.facebook.com/AK.HASH.HARRIETS",
       contactEmail: "trailmaster@aucklandhussies.co.nz",
       foundedYear: 1978,
+      hashCash: "$15",
       scheduleDayOfWeek: "Tuesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Tuesday evenings at 6:30 PM. Run list posted on aucklandhussies.co.nz.",
       description: "Auckland's women-founded hash, established 1978. Weekly Tuesday evening trails across Auckland with a published run list. Mixed attendance though women-led. Hash cash is $15 when starting from home or a park (pay-as-you-go at restaurants and pubs), plus $5 for drinks.",
@@ -4235,12 +4244,15 @@ export const KENNELS: KennelSeed[] = [
       // prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql
       // because `ensureKennelRecords` only fills NULLs. Edits here must
       // update that migration (or author a follow-up) to reach prod.
+      // #1571 (round 15): hashCash null-fill is in the follow-up migration
+      // prisma/migrations/*_fix_profile_round_15_hashcash/migration.sql.
       kennelCode: "capital-h3-nz", shortName: "Capital H3", fullName: "Capital Hash House Harriers",
       region: "Wellington, NZ", country: "New Zealand",
       website: "https://www.sporty.co.nz/capitalh3",
       facebookUrl: "https://www.facebook.com/Capitalhhh/",
       logoUrl: "https://prodcdn.sporty.co.nz/cms/3076/logo.png",
       foundedYear: 1981,
+      hashCash: "$2",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Monday evenings at 6:30 PM unless otherwise noted. Run list maintained on the homepage notices panel with run number, date, location, and hare.",
       description: "Founded 2 February 1981 by Mad Max with an inaugural run from the Thorndon Tavern (briefly in recess Nov 1981 until re-erected Sept 1983). Weekly Monday evening trails across Wellington and the wider Hutt Valley. Hash cash is $2 per run; food and drinks at the on-on are BYO.",
@@ -4267,11 +4279,14 @@ export const KENNELS: KennelSeed[] = [
       // prisma/migrations/20260521210000_fix_nz_quick_win_profiles/migration.sql
       // because `ensureKennelRecords` only fills NULLs. Edits here must
       // update that migration (or author a follow-up) to reach prod.
+      // #1571 (round 15): hashCash null-fill is in the follow-up migration
+      // prisma/migrations/*_fix_profile_round_15_hashcash/migration.sql.
       kennelCode: "geriatrix-h3", shortName: "Geriatrix H3", fullName: "Port Nicholson Geriatrix Hash House Harriers",
       region: "Wellington, NZ", country: "New Zealand",
       website: "https://www.sporty.co.nz/geriatrixhhh",
       logoUrl: "https://prodcdn.sporty.co.nz/cms/5181/logo.gif",
       foundedYear: 1985,
+      hashCash: "$2 / $4",
       scheduleDayOfWeek: "Tuesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Tuesday evenings at 6:30 PM. Each run lists venue, hare, and a map link.",
       description: "Wellington's relaxed-pace Tuesday hash — \"the drinking club with a running problem,\" founded 24 September 1985. Shorter, accessible trails around Wellington and Lower Hutt. Hash cash is $2 (non piss-stop) or $4 (piss-stop) per run; home runs are $15–$20 (cashless, direct credit preferred).",

--- a/src/app/hareline/actions.test.ts
+++ b/src/app/hareline/actions.test.ts
@@ -161,7 +161,7 @@ describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
       eventKennels: [],
     });
     mockFindMany.mockResolvedValueOnce([
-      minimalEvent("umbrella", null, true),
+      { ...minimalEvent("umbrella", null, true), cost: "$7" },
       minimalEvent("sat-child", "umbrella", false),
       minimalEvent("sun-child", "umbrella", false),
       // Child whose parent is NOT in result (GGFM Friday case viewed from
@@ -176,5 +176,6 @@ describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
     expect(ids).toContain("ggfm-child"); // parent NOT in result → kept
     expect(ids).not.toContain("sat-child"); // parent IS in result → dropped
     expect(ids).not.toContain("sun-child"); // parent IS in result → dropped
+    expect(result.find((e) => e.id === "umbrella")?.cost).toBe("$7"); // cost flows through slim payload
   });
 });

--- a/src/app/hareline/actions.test.ts
+++ b/src/app/hareline/actions.test.ts
@@ -152,6 +152,7 @@ describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
       trailType: null,
       dogFriendly: null,
       prelube: null,
+      cost: null,
       isSeriesParent,
       parentEventId: parentId,
       endDate: null,

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -66,6 +66,9 @@ export interface HarelineListEvent {
   dogFriendly: boolean | null;
   /** #1316 — pre-event meetup venue/time, free-form. */
   prelube: string | null;
+  /** #1316 — per-event hash cash override (two-tier model, #1571). Null ⇒
+   *  inherit the kennel default. Surfaced on the card as a small chip (#1571). */
+  cost: string | null;
   /** #1560 — multi-day series + standalone date-range support. */
   isSeriesParent: boolean | null;
   parentEventId: string | null;
@@ -225,6 +228,7 @@ const fetchSlimEventsCached = unstable_cache(
         trailType: true,
         dogFriendly: true,
         prelube: true,
+        cost: true,
         // #1560 — multi-day series metadata + inline children list.
         isSeriesParent: true,
         parentEventId: true,
@@ -311,6 +315,7 @@ const fetchSlimEventsCached = unstable_cache(
       trailType: e.trailType,
       dogFriendly: e.dogFriendly,
       prelube: e.prelube,
+      cost: e.cost,
       isSeriesParent: e.isSeriesParent,
       parentEventId: e.parentEventId,
       endDate: e.endDate ? e.endDate.toISOString() : null,
@@ -403,7 +408,9 @@ export interface EventDetailFields {
   sourceUrl: string | null;
   locationStreet: string | null;
   locationAddress: string | null;
-  /** #1316 — Hash Cash. Detail-only because card has no room for a chip. */
+  /** #1316 — Hash Cash (per-event override). Also in the slim list payload
+   *  (#1571) so the card can show it; kept here for the brief window where the
+   *  list cache predates the field, and for detail-panel parity. */
   cost: string | null;
   eventLinks: { id: string; url: string; label: string }[];
   /**

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { MapPin, Clock, Footprints, Tent, ChevronDown } from "lucide-react";
+import { MapPin, Clock, Footprints, Tent, ChevronDown, Banknote } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
@@ -86,7 +86,8 @@ export type HarelineEvent = {
   dogFriendly?: boolean | null;
   /** #1316 — pre-event meetup venue/time, free-form. Heavy field; render only on detail. */
   prelube?: string | null;
-  /** #1316 — explicit `cost` column (free-form). Used to be smashed into `description`. */
+  /** #1316 — per-event hash cash override (free-form). #1571 — now surfaced on
+   *  the medium-density card as a small chip (slim list payload carries it). */
   cost?: string | null;
   // Heavy / on-demand fields — undefined until `getEventDetail` resolves.
   locationStreet?: string | null;
@@ -301,6 +302,7 @@ function buildAriaLabel(event: HarelineEvent, attendance?: AttendanceData | null
   // #1316 — surface card-visible structured fields to screen readers.
   if (event.trailType) parts.push(`Trail type ${event.trailType}`);
   if (event.dogFriendly === true) parts.push("dog friendly");
+  if (event.cost) parts.push(`${event.cost} hash cash`);
   if (attendance?.status === "INTENDING") parts.push("Going");
   if (attendance?.status === "CONFIRMED") parts.push("Checked in");
   return parts.join(", ");
@@ -797,7 +799,25 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
               </Tooltip>
             )}
 
-            {weather && (locationDisplay || event.haresText || trailLengthDisplay || event.difficulty != null || event.trailType || event.dogFriendly === true) && (
+            {/* #1571 — per-event hash cash. Surfaces only when the source set an
+                explicit `Event.cost` override; otherwise the card inherits the
+                kennel default shown on the kennel profile (two-tier model). */}
+            {event.cost && (locationDisplay || event.haresText || trailLengthDisplay || event.difficulty != null || event.trailType || event.dogFriendly === true) && (
+              <span className="text-muted-foreground/30" aria-hidden="true">&middot;</span>
+            )}
+            {event.cost && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="flex items-center gap-1 shrink-0 max-w-[110px]">
+                    <Banknote className="h-3 w-3 shrink-0" style={{ color: `${regionColor}90` }} />
+                    <span className="truncate tabular-nums">{event.cost}</span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{event.cost} hash cash</TooltipContent>
+              </Tooltip>
+            )}
+
+            {weather && (locationDisplay || event.haresText || trailLengthDisplay || event.difficulty != null || event.trailType || event.dogFriendly === true || event.cost) && (
               <span className="text-muted-foreground/30" aria-hidden="true">&middot;</span>
             )}
 


### PR DESCRIPTION
## What

Two-tier hash cash **data-fill + UI-completeness** pass. **No schema change** — `Kennel.hashCash` and `Event.cost` already exist. Per the cycle-15 canonical decision (#1571 pinned comment), both columns stay under a documented two-tier model:

- **`Kennel.hashCash`** — kennel-level standard/headline (kennel profile).
- **`Event.cost`** — per-event override; null ⇒ inherit the kennel default for display.

## Changes

**1. Backfill `Kennel.hashCash` (11 kennels)** — drain prose-captured values (folded into `description` during prior onboarding rounds) into the structured slot. Headline goes in `hashCash`; the tier / payment-method nuance stays in `description`.

| kennel | hashCash |
|---|---|
| garden-city-h3 | `$7 (at hare's home)` |
| capital-h3-nz | `$2` |
| geriatrix-h3 | `$2 / $4` |
| auckland-hussies | `$15` |
| hibiscus-h3 | `Free` |
| mel-new-moon | `$5` |
| lbh-phx, lds-h3, madisonh3 | `$5` |
| lil | `$20` |
| lch3 | `$15 ladies / $20 men` |

All 14 candidate slots were verified **NULL in prod** first; `motherh3` / `mrhappy` / `mrh3` were already populated and excluded.

**Reach-prod mechanism:** a **data-only** COALESCE null-fill migration (`20260530120000_fix_profile_round_15_hashcash`) — no `ALTER TABLE`, no new column. Mirrors `profile_round_13` so Vercel's `migrate deploy` reaches prod (`ensureKennelRecords` only fills NULLs and the seed isn't run on deploy). Idempotent (`"hashCash" IS NULL` guard).

**2. Surface `Event.cost` on the event card** — it was detail-only ("card has no room for a chip"); the slim list query didn't even fetch it. Threaded `cost` into the slim hareline payload (type + select + mapping) and rendered a small Banknote chip in the medium-density metadata strip + aria-label. Shows only when a per-event override is set; otherwise the card inherits the kennel default (shown on the kennel profile). Completes the loop for NYCH3 5-boro cost (#1792), Hump D (#1349), etc.

## Verification

- Migration applied to local dev DB → all 11 slots backfilled; `prisma db seed` clean.
- Dev spot-check: GCH3 kennel page shows "$7 (at hare's home) hash cash"; Hareline card shows the cost chip (e.g. Ithaca H3 `$50`).
- `npx tsc --noEmit` (0 errors), `npm run lint` (0 errors), `npm test` (7905 pass).
- `/codex:adversarial-review` + `/simplify` (4 agents) — clean.

## Notes

- The schema already existed; this is the data-fill + UI pass under the two-tier model, not a migration of the column shape.
- Out of scope (flagged separately): the unfiltered `/hareline` `unstable_cache` payload (~5272 events, ~4.77MB) already exceeds Next's 2MB cache limit and silently falls back to uncached — pre-existing, unaffected by the ~60KB `cost` addition.

Closes #1504
Closes #1571
