### PR TITLE
fix(nych3): HashNYC parse fixes, profile enrichment, archive backfill

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -72,6 +72,11 @@ export const KENNELS: KennelSeed[] = [
       logoUrl: "/kennel-logos/nych3.png",
       scheduleDayOfWeek: "Wednesday", scheduleTime: "7:00 PM", scheduleFrequency: "Weekly",
       hashCash: "$3",
+      foundedYear: 1984,
+      contactEmail: "hareraiser@hashnyc.com",
+      description:
+        "New York City's original hash, hashing every Wednesday since 1984. " +
+        "Hotline: +1-212-HASH-NYC (212.427.4692), option 3.",
       facebookUrl: "https://www.facebook.com/groups/nychash",
       instagramHandle: "nychashhouse",
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -173,7 +173,12 @@ export const SOURCES = [
       // "Receding Hareline (Next 30 Days)" — events fall off the page once they
       // pass, so the reconciler must not interpret that as a cancellation. (#1263)
       config: { upcomingOnly: true },
-      kennelCodes: ["nych3", "brh3", "nah3", "knick", "lil", "qbk", "si", "columbia", "harriettes-nyc", "ggfm", "nawwh3"],
+      // `drinking-practice-nyc` is the 12th kennel the parser routes to
+      // (KENNEL_PATTERNS in hashnyc.ts) — hashnyc.com publishes its events, so
+      // the source must be linked or the merge guard blocks them as
+      // SOURCE_KENNEL_MISMATCH (and the archive backfill would partial-fail on
+      // the ~24 historical Drinking Practice rows). (#1793 / Codex review)
+      kennelCodes: ["nych3", "brh3", "nah3", "knick", "lil", "qbk", "si", "columbia", "harriettes-nyc", "ggfm", "nawwh3", "drinking-practice-nyc"],
     },
     {
       name: "Boston Hash Calendar",

--- a/scripts/backfill-nych3-history.ts
+++ b/scripts/backfill-nych3-history.ts
@@ -69,5 +69,7 @@ runBackfillScript({
 }).catch((err) => {
   const message = err instanceof Error ? err.message : String(err);
   console.error("FAILED:", message);
-  process.exit(1);
+  // Set exitCode (not process.exit) so the event loop drains and the runner's
+  // `finally { await prisma.$disconnect() }` resolves before the process ends.
+  process.exitCode = 1;
 });

--- a/scripts/backfill-nych3-history.ts
+++ b/scripts/backfill-nych3-history.ts
@@ -1,0 +1,73 @@
+/**
+ * One-shot historical backfill for the HashNYC receding hareline archive.
+ *
+ * The live adapter only ingests the next/last `scrapeDays` window AND hard-floors
+ * at year 2016, so HashTracks coverage stops at NYCH3 #1669 (Jan 2016). The full
+ * archive at `?days=all&backwards=true` exposes ~4,400 rows back to ~1998
+ * (NYC #920–#2151 plus the sibling NYC kennels the source feeds), which would
+ * never reach canonical Events through normal scrapes. (#1793)
+ *
+ * Reuses the adapter's exported `parseRows` (with a lowered `minYear`) so field
+ * extraction stays in lockstep with the live adapter. The whole archive is
+ * inserted — the per-event source-kennel guard in the merge pipeline only admits
+ * the 11 kennels actually linked to the HashNYC source, so this is safe.
+ *
+ * Re-runnable: `reportAndApplyBackfill` routes through `processRawEvents`, which
+ * dedupes by fingerprint and partitions to `date < today` (dropping the future
+ * rows the combined archive table also contains).
+ *
+ * Prerequisite: run `npx prisma db seed` first so the HashNYC source is linked
+ * to all 12 kennels it feeds (incl. `drinking-practice-nyc`). Otherwise the
+ * ~24 archive Drinking Practice rows are blocked by the per-event source-kennel
+ * guard and the run reports FAILED (the OK rows still commit; re-running after
+ * the seed converges, since the merge dedupes by fingerprint).
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-nych3-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-nych3-history.ts
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { parseRows } from "@/adapters/html-scraper/hashnyc";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "HashNYC Website";
+const KENNEL_TIMEZONE = "America/New_York";
+const BASE_URL = "https://hashnyc.com";
+const ARCHIVE_URL = `${BASE_URL}/?days=all&backwards=true`;
+const MIN_YEAR = 1990; // archive goes back to ~1998; floor well below that
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const res = await safeFetch(ARCHIVE_URL, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" },
+  });
+  if (!res.ok) {
+    throw new Error(`Archive fetch failed: HTTP ${res.status} ${res.statusText}`);
+  }
+  const html = await res.text();
+  const $ = cheerio.load(html);
+  // The archive table carries BOTH classes: class="future_hashes past_hashes".
+  const rows = $("table.past_hashes tr");
+  if (rows.length === 0) {
+    throw new Error("No archive rows found — page structure may have changed.");
+  }
+  const { events, errors } = parseRows($, rows, BASE_URL, false, "past_hashes", MIN_YEAR);
+  if (errors.length > 0) {
+    console.warn(`  ${errors.length} row parse warnings (first 3): ${errors.slice(0, 3).join(" | ")}`);
+  }
+  return events;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Walking hashnyc.com receding-hareline archive (?days=all&backwards=true)",
+  fetchEvents,
+}).catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error("FAILED:", message);
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/hashnyc.test.ts
+++ b/src/adapters/html-scraper/hashnyc.test.ts
@@ -10,6 +10,8 @@ import {
   extractTitle,
   extractTime,
   extractHares,
+  extractCost,
+  isPlaceholderHare,
   parseDetailsCell,
   extractSourceUrl,
   parseRows,
@@ -385,6 +387,9 @@ describe("extractRawDesignation", () => {
   it("extracts LIL #147", () => {
     expect(extractRawDesignation("Bears!LIL #147Start: Your Mother's House")).toBe("LIL #147");
   });
+  it("extracts Special #254 (section label, not a kennel) (#1791)", () => {
+    expect(extractRawDesignation("Red Dress Run!Special #254Start: TBA")).toBe("Special #254");
+  });
   it("returns undefined when no designation found", () => {
     expect(extractRawDesignation("Just some random text")).toBeUndefined();
   });
@@ -440,6 +445,24 @@ describe("parseDetailsCell title format", () => {
     const $ = cheerio.load(html);
     const result = parseDetailsCell($, $("td").first());
     expect(result.title).toBe("7-11 C*ms to Queens! - Queens #248");
+  });
+
+  it("special-event title uses the Special label, not the raw kennelCode (#1791)", () => {
+    const html = `<table><tr><td><b>Red Dress Run!</b><br>Special #254<br>Start: TBA</td></tr></table>`;
+    const $ = cheerio.load(html);
+    const result = parseDetailsCell($, $("td").first());
+    expect(result.title).toBe("Red Dress Run! - Special #254");
+    expect(result.title).not.toContain("nych3");
+    expect(result.kennelTag).toBe("nych3");
+  });
+
+  it("titled special event with no recognizable designation drops to bare title (no kennelCode leak) (#1791)", () => {
+    // "Gala #N" is not a known designation; previously fell back to "nych3 #..".
+    const html = `<table><tr><td><b>Mystery Gala</b><br>Start: TBA</td></tr></table>`;
+    const $ = cheerio.load(html);
+    const result = parseDetailsCell($, $("td").first());
+    expect(result.title).toBe("Mystery Gala");
+    expect(result.title).not.toContain("nych3");
   });
 });
 
@@ -536,6 +559,80 @@ describe("parseRows", () => {
     const result = parseRows($, rows, "https://hashnyc.com", false);
     expect(result.events).toEqual([]);
     expect(result.parseErrors).toEqual([]);
+  });
+});
+
+// ── extractCost (#1792) ──
+
+describe("extractCost", () => {
+  const FIVE_BORO_CELL =
+    `<b>5-boro Pub Crawl</b><br>Special #252<br>Start: TBA<br>` +
+    `Three days. Five boroughs. Countless bad decisions. </br>` +
+    `Cost: Free / Pay as you go &#8212; no rego fee. You cover your own drinks and food at each stop. </br>` +
+    `What to bring: ID, cash/card, comfortable shoes.`;
+
+  it("extracts the Cost line, bounded at the next break", () => {
+    expect(extractCost(FIVE_BORO_CELL)).toBe(
+      "Free / Pay as you go — no rego fee. You cover your own drinks and food at each stop.",
+    );
+  });
+
+  it("returns undefined when there is no Cost label", () => {
+    expect(extractCost("NYC #2152<br>Start: The Library")).toBeUndefined();
+  });
+
+  it("is surfaced through parseDetailsCell", () => {
+    const $ = cheerio.load(`<table><tr><td>${FIVE_BORO_CELL}</td></tr></table>`);
+    const result = parseDetailsCell($, $("td").first());
+    expect(result.cost).toContain("Free / Pay as you go");
+  });
+});
+
+// ── isPlaceholderHare (#1790) ──
+
+describe("isPlaceholderHare", () => {
+  it.each([
+    ["flags the signup CTA", "Sign up to hare!", "nych3", true],
+    ["flags a bare kennel code used as a hare", "NYCH3", "nych3", true],
+    ["flags the archive Unknown placeholder", "Unknown", "nych3", true],
+    ["does not flag a real hare name", "Shitwrecked", "nych3", false],
+  ])("%s", (_label, hares, kennelTag, expected) => {
+    expect(isPlaceholderHare(hares as string, kennelTag as string)).toBe(expected);
+  });
+});
+
+// ── parseRows tri-state hares + minYear ──
+
+describe("parseRows hares + minYear", () => {
+  it("emits null (explicit clear) for a future signup-placeholder row (#1790)", () => {
+    const html = `<table class="future_hashes">
+      <tr><td>June 10 7:00 pm</td><td>NYC #2153</td><td>Sign up to hare!</td></tr>
+    </table>`;
+    const $ = cheerio.load(html);
+    const result = parseRows($, $("tr"), "https://hashnyc.com", true);
+    expect(result.events.length).toBe(1);
+    expect(result.events[0].hares).toBeNull();
+  });
+
+  it("keeps a real future hare value", () => {
+    const html = `<table class="future_hashes">
+      <tr><td>June 3 7:00 pm</td><td>NYC #2152</td><td>Shitwrecked</td></tr>
+    </table>`;
+    const $ = cheerio.load(html);
+    const result = parseRows($, $("tr"), "https://hashnyc.com", true);
+    expect(result.events[0].hares).toBe("Shitwrecked");
+  });
+
+  it("drops pre-floor years by default but keeps them with a lower minYear (#1793)", () => {
+    const html = `<table><tr id="2002may15">
+      <td>May 15 7:00 pm</td><td>NYC #939</td><td>Fluffy Lockerman</td>
+    </tr></table>`;
+    const $ = cheerio.load(html);
+    expect(parseRows($, $("tr"), "https://hashnyc.com", false).events.length).toBe(0);
+    const kept = parseRows($, $("tr"), "https://hashnyc.com", false, "past_hashes", 1990);
+    expect(kept.events.length).toBe(1);
+    expect(kept.events[0].date).toBe("2002-05-15");
+    expect(kept.events[0].runNumber).toBe(939);
   });
 });
 

--- a/src/adapters/html-scraper/hashnyc.ts
+++ b/src/adapters/html-scraper/hashnyc.ts
@@ -175,6 +175,10 @@ const RAW_DESIGNATION_PATTERNS: RegExp[] = [
   /\bLIL\b\s*#\s*\d+/i,
   /\bSI\b\s*#\s*\d+/i,
   /\bQueens\b\s*#\s*\d+/i,
+  // `Special #N` is a hashnyc.com SECTION label, not a kennel — preserve it
+  // verbatim so special-event titles read "Red Dress Run! - Special #254"
+  // rather than leaking the internal kennelCode "nych3 #254" (#1791).
+  /\bSpecial\b\s*#\s*\d+/i,
 ];
 
 export function extractRawDesignation(text: string): string | undefined {
@@ -301,6 +305,58 @@ interface ParsedDetails {
   location?: string;
   locationUrl?: string;
   description?: string;
+  cost?: string;
+}
+
+/**
+ * Extract a per-event cost from the details-cell prose. Some events (e.g. the
+ * NYCH3 5-boro Pub Crawl) carry a `Cost: …` line inside the description blob,
+ * bounded by a `<br>` / `</br>` or the next labelled line. (#1792)
+ *
+ * Uses several simple `.search()` probes + `Math.min` for the boundary instead
+ * of one alternation regex to stay clear of Sonar S5852/S5843 (ReDoS-shape).
+ */
+const COST_BOUNDARY_RES: RegExp[] = [
+  /<\/?br\b[^>]*>/i,
+  /What to bring:/i,
+  /Please rego/i,
+  /Transit:/i,
+];
+
+export function extractCost(cellHtml: string): string | undefined {
+  const label = /Cost:\s*/i.exec(cellHtml);
+  if (!label) return undefined;
+  let rest = cellHtml.slice(label.index + label[0].length);
+  const bounds = COST_BOUNDARY_RES
+    .map((re) => rest.search(re))
+    .filter((i) => i >= 0);
+  if (bounds.length > 0) rest = rest.slice(0, Math.min(...bounds));
+  const text = decodeHtmlEntities(rest).replaceAll(/\s+/g, " ").trim();
+  return text || undefined;
+}
+
+const HARE_SIGNUP_RE = /sign up to hare/i;
+const ARCHIVE_UNKNOWN_RE = /^unknown$/i;
+const NON_ALNUM_RE = /[^a-z0-9]/gi;
+const normalizeAlnum = (s: string) => s.replaceAll(NON_ALNUM_RE, "").toLowerCase();
+
+/** Archive rows occasionally carry the literal "Unknown" as a not-provided
+ *  placeholder across several fields (title / hares / location). (#1793) */
+function isArchiveUnknown(text: string): boolean {
+  return ARCHIVE_UNKNOWN_RE.test(text.trim());
+}
+
+/**
+ * A hare-cell value that is not a real hasher: the "Sign up to hare!" CTA, or a
+ * bare kennel code (e.g. "NYCH3" meaning "the kennel hares it"), or the archive
+ * "Unknown" placeholder. These must clear a previously-stored real hare rather
+ * than be preserved, so the adapter emits `null` (explicit clear) for them. (#1790)
+ */
+export function isPlaceholderHare(hares: string, kennelTag: string): boolean {
+  if (!hares) return false;
+  if (HARE_SIGNUP_RE.test(hares)) return true;
+  if (isArchiveUnknown(hares)) return true;
+  return normalizeAlnum(hares) === normalizeAlnum(kennelTag);
 }
 
 /** Word-bounded so "TBA Park" isn't a placeholder. */
@@ -325,6 +381,7 @@ function extractStartBlock(cellHtml: string): string {
  *  canonical token, otherwise collapse whitespace and dangling commas. */
 function normalizeLocationText(text: string): string | undefined {
   if (!text) return undefined;
+  if (isArchiveUnknown(text)) return undefined; // archive placeholder (#1793)
   const placeholder = LOCATION_PLACEHOLDER_RE.exec(text);
   if (placeholder) return placeholder[1].toUpperCase();
   return text.replaceAll(/\s+,/g, ",").replaceAll(/\s+/g, " ").trim(); // NOSONAR S5852 — single-quantifier `\s+` patterns, no alternation/nesting
@@ -442,7 +499,12 @@ export function parseDetailsCell(
   const boldTag = cell.find("b").first();
   if (boldTag.length) {
     const boldText = boldTag.text().trim();
-    if (boldText && !/^(Run|Trail|#)\s*\d+$/i.test(boldText) && boldText.length > 1) {
+    if (
+      boldText &&
+      !/^(Run|Trail|#)\s*\d+$/i.test(boldText) &&
+      !isArchiveUnknown(boldText) && // archive placeholder, not a real event name (#1793)
+      boldText.length > 1
+    ) {
       eventName = boldText;
     }
   }
@@ -450,8 +512,11 @@ export function parseDetailsCell(
   let title: string | undefined;
   const rawDesignation = extractRawDesignation(cellText);
   if (eventName) {
-    const designation = rawDesignation ?? (runNumber ? `${kennelTag} #${runNumber}` : kennelTag);
-    title = `${eventName} - ${designation}`;
+    // Only append a designation we can render from the source verbatim (e.g.
+    // "NYC #2142", "Special #254"); never fall back to the internal kennelCode
+    // ("nych3 #254") — that leaked into user-facing titles (#1791). The run
+    // number still lives in the dedicated runNumber field.
+    title = rawDesignation ? `${eventName} - ${rawDesignation}` : eventName;
   } else if (rawDesignation) {
     title = rawDesignation;
   } else {
@@ -462,6 +527,7 @@ export function parseDetailsCell(
   const { location, locationUrl } = extractLocationAndUrl(cellHtml, $, cell);
   const rawDescription = extractDescriptionFromCell($, cell, cellHtml, cellText);
   const description = cleanEventDescription(rawDescription, eventName);
+  const cost = extractCost(cellHtml);
 
   return {
     kennelTag,
@@ -471,6 +537,7 @@ export function parseDetailsCell(
     location,
     locationUrl,
     description,
+    cost,
   };
 }
 
@@ -489,6 +556,10 @@ export function parseRows(
   baseUrl: string,
   isFuture: boolean,
   section: string = isFuture ? "future_hashes" : "past_hashes",
+  // Floor year for the live adapter (HashTracks coverage starts 2016). The
+  // one-shot archive backfill passes a lower floor to ingest pre-2016 rows
+  // from `?days=all&backwards=true` (#1793).
+  minYear: number = 2016,
 ): { events: RawEventData[]; errors: string[]; parseErrors: ParseError[] } {
   const events: RawEventData[] = [];
   const errors: string[] = [];
@@ -517,7 +588,7 @@ export function parseRows(
         year = extractYear(rowId, dateCellHtml);
       }
 
-      if (!year || year < 2016) return;
+      if (!year || year < minYear) return;
 
       const monthDay = extractMonthDay(dateCellText);
       if (!monthDay) return;
@@ -546,9 +617,17 @@ export function parseRows(
         hares = extractHares($, row);
       }
 
-      // Filter out "Sign up to hare!" placeholder text
-      if (hares && /sign up to hare/i.test(hares)) {
-        hares = "N/A";
+      // Tri-state hares (#1790): a placeholder (signup CTA / bare kennel code /
+      // "Unknown") emits `null` so the merge CLEARS a previously-stored real
+      // hare when the slot reverts to a placeholder. A genuinely empty cell
+      // emits `undefined` so cross-source enrichment is preserved.
+      let haresOut: string | null | undefined;
+      if (isPlaceholderHare(hares, parsed.kennelTag)) {
+        haresOut = null;
+      } else if (hares && hares !== "N/A") {
+        haresOut = hares;
+      } else {
+        haresOut = undefined;
       }
 
       events.push({
@@ -557,10 +636,11 @@ export function parseRows(
         runNumber: parsed.runNumber,
         title: parsed.title,
         description: parsed.description,
-        hares: hares && hares !== "N/A" ? hares : undefined,
+        hares: haresOut,
         location: parsed.location,
         locationUrl: parsed.locationUrl,
         startTime,
+        cost: parsed.cost,
         sourceUrl,
       });
     } catch (err) {


### PR DESCRIPTION
Deep dive on the **NYCH3 flagship cluster** — five audit findings, all tracing to the **HashNYC Website** scraper (`hashnyc.com`, feeds 11→12 NYC kennels) plus the NYCH3 seed row. Every change was root-caused against the live source (`?days=90` future table + `?days=all&backwards=true` archive).

## What changed

**`src/adapters/html-scraper/hashnyc.ts`**
- **#1791 title leak** — `Special #N` is a hashnyc.com *section label*, not a kennel. Added it to `RAW_DESIGNATION_PATTERNS` so it's preserved verbatim, and dropped the `${kennelTag} #${runNumber}` fallback that leaked the raw lowercase kennelCode. Titles now read `Red Dress Run! - Special #254` / `5-boro Pub Crawl - Special #252`. Legitimate `NYC …` titles are not over-stripped.
- **#1790 stale hares** — `hares` already participates in the fingerprint, so real hare *changes* already re-merge. The actual bug: when a hare drops out the source reverts to the `Sign up to hare!` placeholder, which mapped to `undefined` = **preserve**, so the prior real hare never cleared. Now placeholders (signup CTA / bare kennel code / archive `Unknown`) emit `null` (explicit clear); genuinely-empty cells stay `undefined` (preserve enrichment).
- **#1792 cost** — `Event.cost` already exists (`schema.prisma:351`) and `merge.ts` already writes it. Adapter now extracts the `Cost:` line from the details-cell prose into `RawEventData.cost`. **No schema change.**
- **#1793 support** — parameterized the hard 2016 year floor (`minYear`, default unchanged) and drop literal `Unknown` archive placeholders.

**`scripts/backfill-nych3-history.ts`** (new, #1793) — one-shot backfill over the receding-hareline archive (~4,400 rows back to ~1998), reusing the adapter's `parseRows` and the idempotent `reportAndApplyBackfill` (partitions `date < today`, dedupes by fingerprint).

**`prisma/seed-data/sources.ts`** — linked `drinking-practice-nyc` (the parser's 12th kennel) to the HashNYC source so its events aren't blocked as `SOURCE_KENNEL_MISMATCH` and the archive backfill doesn't partial-fail on ~24 Drinking Practice rows (Codex adversarial-review catch).

**`prisma/seed-data/kennels.ts`** (#1789) — NYCH3 row gains `contactEmail`, `foundedYear: 1984`, and a user-facing `description` carrying the hotline (no phone field exists on the Kennel model). Logo already self-hosted.

## Verification
- **Live** (`hashnyc.com`): 0 title leaks, 16 placeholder hares cleared to `null`, cost populated on the 5-boro event.
- **Backfill dry-run**: 4,396 rows parsed, 1998-08-15 → 2026-05-29.
- `npx tsc --noEmit` 0 errors · `npm run lint` 0 errors · `npm test` 7,918 pass.
- `/codex:adversarial-review` (1 high finding, fixed) + `/simplify` run pre-PR.

## Manual post-merge steps
1. `npx prisma db seed` — lands the NYCH3 profile fields + the new `drinking-practice-nyc` SourceKennel link.
2. `BACKFILL_APPLY=1 npx tsx scripts/backfill-nych3-history.ts` — applies the archive history (run **after** the seed).

Closes #1789
Closes #1790
Closes #1791
Closes #1792
Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)