### PR TITLE
feat(pipeline): systemic silentlySkipPatterns phantom-event filter (#1739, #1783, #1786)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2731,22 +2731,17 @@ export const SOURCES = [
         // the source side. Opt in to the doubled-prefix strip so titles
         // like "MoA2H3 MoA2H3 Red Dress Run" surface as a single prefix.
         stripDoubledKennelPrefix: true,
-        // #1671 — the MoA2H3 calendar carries a handful of sister-kennel
+        // #1671 / #1739 — the MoA2H3 calendar carries a handful of sister-kennel
         // events (DeMon H3 inaugural trail Nov 2025; GLH3 HashMas Jan 2025).
-        // Without routing, the wide-window backfill would file them under
-        // moa2h3 and pollute the kennel page. Patterns route them to the
-        // sister codes — those codes are intentionally NOT added to
-        // `kennelCodes` here, so the source-kennel guard blocks the rows
-        // with `SOURCE_KENNEL_MISMATCH` alerts instead of creating duplicate
-        // Event records. The merge pipeline does NOT dedup by `(kennelId,
-        // date)` across sources (known travel-pipeline gap — Codex
-        // adversarial review on #1671), so listing the codes here would
-        // produce duplicates against the kennels' own GCal sources. The 3
-        // expected alerts during the backfill are the right surface: admin
-        // reviews and dismisses.
-        kennelPatterns: [
-          [String.raw`^DeMon\s*H?3?\b`, "demon-h3"],
-          [String.raw`^GLH3\b|^Greater\s+Lansing`, "glh3"],
+        // DeMon H3 and GLH3 each have their OWN Google Calendar source, so these
+        // rows are pure pollution here. The original fix routed them to the
+        // sister codes, which then fired recurring `SOURCE_KENNEL_MISMATCH`
+        // alerts every 6h (intentional but noisy). Drop them silently instead
+        // (#1739) — no alert, no duplicate Events against the sisters' own
+        // sources, no kennel-page pollution.
+        silentlySkipPatterns: [
+          { pattern: String.raw`^DeMon\s*H?3?\b` },
+          { pattern: String.raw`^GLH3\b|^Greater\s+Lansing` },
         ],
       },
       kennelCodes: ["moa2h3"],
@@ -4297,6 +4292,12 @@ export const SOURCES = [
         // a proper `dateTime` and bypass this fallback. See #536.
         includeAllDayEvents: true,
         defaultStartTime: "18:00",
+        // #1783 — `includeAllDayEvents` (above) also admits the kennel admin's
+        // personal all-day OOO blocks. "LYNNE OFF" surfaced on /hareline as a
+        // phantom Friday run (ABQ doesn't run Fridays). Drop it silently
+        // (#1739). Anchored exact-title match so it can never shadow a real
+        // trail; broaden only if other OOO variants appear in prod.
+        silentlySkipPatterns: [{ pattern: String.raw`^LYNNE\s+OFF$`, field: "title" }],
       },
       kennelCodes: ["abqh3"],
     },
@@ -5708,6 +5709,12 @@ export const SOURCES = [
         columns: { date: 1, location: 2, hares: 3 },
         kennelTagRules: { default: "hibiscus-h3" },
         startTimeRules: { default: "18:30" },
+        // #1786 — holiday rows carry a real date but a "no run" note in the
+        // Where column (e.g. "Kings B'day, no run , Yours"). These ingested as
+        // phantom runs with a map + weather. Drop any row whose location says
+        // "no run" (#1739). A venue is never literally "no run", so this is
+        // false-positive-safe; `\b` + `\s+` won't match "Norun St".
+        silentlySkipPatterns: [{ pattern: String.raw`\bno\s+run\b`, field: "location" }],
       },
       kennelCodes: ["hibiscus-h3"],
     },

--- a/scripts/cleanup-abq-admin-note.ts
+++ b/scripts/cleanup-abq-admin-note.ts
@@ -1,22 +1,11 @@
 /**
  * One-shot cleanup for the ABQ H3 "LYNNE OFF" phantom event (#1783).
  *
- * Background:
- *   ABQ H3's Google Calendar source opts into `includeAllDayEvents` (their
- *   Tuesday CLiT runs are entered as all-day blocks). That also admitted the
- *   kennel admin's personal all-day OOO block "LYNNE OFF", which surfaced on
- *   /hareline as a phantom Friday run. PR for #1739 adds a
- *   `silentlySkipPatterns` rule to the source so the row can never re-ingest;
- *   this script removes the already-persisted phantom Event + its RawEvent(s).
- *
- * Safety / idempotency:
- *   - Verifies the target Event still matches "LYNNE OFF" before deleting
- *     (refuses if the row drifted to something else).
- *   - Deletes the phantom RawEvent(s) outright (not unlink) so they cannot
- *     re-merge into a fresh phantom; canonical RawEvents are an audit trail but
- *     a personal OOO note is not legitimate scraped data.
- *   - No-op on re-run (Event already gone → reports clean, exit 0).
- *   - Dry run by default; set CLEANUP_APPLY=1 to mutate.
+ * ABQ H3's Google Calendar opts into `includeAllDayEvents` (their Tuesday CLiT
+ * runs are all-day blocks), which also admitted the kennel admin's personal
+ * all-day OOO block "LYNNE OFF" — surfaced on /hareline as a phantom Friday
+ * run. PR for #1739 adds a `silentlySkipPatterns` rule so the row can never
+ * re-ingest; this script removes the already-persisted phantom Event + raw.
  *
  * Usage:
  *   Dry run: npx tsx scripts/cleanup-abq-admin-note.ts
@@ -24,12 +13,9 @@
  */
 import "dotenv/config";
 import { prisma } from "@/lib/db";
+import { runPhantomCleanup } from "./lib/cleanup-phantom-event";
 
-const EVENT_ID = "cmpqmy3m9000b04joivvx6nt1";
-const SOURCE_NAME = "ABQ H3 Google Calendar";
 const EXPECTED_TITLE = "LYNNE OFF";
-
-const APPLY = process.env.CLEANUP_APPLY === "1";
 
 /** True when a RawEvent.rawData is the "LYNNE OFF" phantom. */
 function isPhantomRaw(rawData: unknown): boolean {
@@ -38,94 +24,19 @@ function isPhantomRaw(rawData: unknown): boolean {
   return typeof title === "string" && title.trim().toUpperCase() === EXPECTED_TITLE;
 }
 
-async function main(): Promise<void> {
-  const mode = APPLY ? "APPLY" : "DRY-RUN";
-  console.log(`[cleanup-abq] ${mode} — target Event ${EVENT_ID} ("${EXPECTED_TITLE}")`);
-
-  const source = await prisma.source.findFirst({ where: { name: SOURCE_NAME }, select: { id: true } });
-  if (!source) throw new Error(`Source not found: ${SOURCE_NAME}`);
-
-  const event = await prisma.event.findUnique({
-    where: { id: EVENT_ID },
-    select: { id: true, title: true, status: true },
-  });
-
-  // Delete ONLY the RawEvents linked to the target Event. We additionally scan
-  // the source for signature-matching rows that are NOT linked to this event
-  // and FAIL CLOSED if any exist (Codex adversarial review): deleting by
-  // signature alone could erase unrelated source/audit data. A stray match
-  // means something unexpected — surface it for a human rather than over-delete.
-  const sourceRaws = await prisma.rawEvent.findMany({
-    where: { sourceId: source.id },
-    select: { id: true, eventId: true, rawData: true },
-  });
-  const phantomRawIds = sourceRaws.filter((r) => r.eventId === EVENT_ID).map((r) => r.id);
-  const strayMatches = sourceRaws
-    .filter((r) => r.eventId !== EVENT_ID && isPhantomRaw(r.rawData))
-    .map((r) => r.id);
-  if (strayMatches.length > 0) {
-    throw new Error(
-      `Found ${strayMatches.length} "${EXPECTED_TITLE}" RawEvent(s) NOT linked to ${EVENT_ID}: ` +
-        `[${strayMatches.join(", ")}]. Refusing to delete unrelated source data — investigate manually.`,
-    );
-  }
-
-  if (!event && phantomRawIds.length === 0) {
-    console.log("[cleanup-abq] Nothing to do — phantom Event and RawEvents already removed.");
-    return;
-  }
-
-  if (event && event.title?.trim().toUpperCase() !== EXPECTED_TITLE) {
-    throw new Error(
-      `Refusing to delete: Event ${EVENT_ID} title is "${event.title}", expected "${EXPECTED_TITLE}". ` +
-        `The row may have drifted — investigate manually.`,
-    );
-  }
-
-  console.log(
-    `[cleanup-abq] Would delete: Event=${event ? `${event.id} (status ${event.status})` : "none"}, ` +
-      `RawEvents=${phantomRawIds.length} [${phantomRawIds.join(", ")}]`,
-  );
-
-  if (!APPLY) {
-    console.log("[cleanup-abq] DRY-RUN complete. Re-run with CLEANUP_APPLY=1 to delete.");
-    return;
-  }
-
-  await prisma.$transaction([
-    // Dependent records keyed on the Event (no onDelete cascade in schema).
-    prisma.eventHare.deleteMany({ where: { eventId: EVENT_ID } }),
-    prisma.attendance.deleteMany({ where: { eventId: EVENT_ID } }),
-    prisma.kennelAttendance.deleteMany({ where: { eventId: EVENT_ID } }),
-    // Defensive: orphan any child events that pointed at this one.
-    prisma.event.updateMany({ where: { parentEventId: EVENT_ID }, data: { parentEventId: null } }),
-    // Delete the phantom RawEvents (audit pollution — not legitimate data).
-    prisma.rawEvent.deleteMany({ where: { id: { in: phantomRawIds } } }),
-    // Delete the canonical Event (EventKennel + EventLink cascade in schema).
-    prisma.event.deleteMany({ where: { id: EVENT_ID } }),
-  ]);
-
-  // Post-delete orphan check.
-  const eventStill = await prisma.event.findUnique({ where: { id: EVENT_ID }, select: { id: true } });
-  const rawsStill = await prisma.rawEvent.count({ where: { id: { in: phantomRawIds } } });
-  if (eventStill || rawsStill > 0) {
-    throw new Error(`Post-delete check failed: event=${!!eventStill}, rawsRemaining=${rawsStill}`);
-  }
-
-  console.log(
-    "[cleanup-abq] " +
-      JSON.stringify({
-        action: "delete_phantom_event",
-        issue: 1783,
-        eventId: EVENT_ID,
-        rawEventsDeleted: phantomRawIds.length,
-        timestamp: new Date().toISOString(),
-      }),
-  );
-  console.log("[cleanup-abq] Done.");
-}
-
-main()
+runPhantomCleanup(
+  {
+    logPrefix: "cleanup-abq",
+    issue: 1783,
+    eventId: "cmpqmy3m9000b04joivvx6nt1",
+    sourceName: "ABQ H3 Google Calendar",
+    targetLabel: `"${EXPECTED_TITLE}"`,
+    isPhantomRaw,
+    verify: (e) => e.title?.trim().toUpperCase() === EXPECTED_TITLE,
+    describeDrift: (e) => `title is "${e.title}", expected "${EXPECTED_TITLE}"`,
+  },
+  process.env.CLEANUP_APPLY === "1",
+)
   .catch((err) => {
     console.error("[cleanup-abq] FAILED:", err);
     process.exitCode = 1;

--- a/scripts/cleanup-abq-admin-note.ts
+++ b/scripts/cleanup-abq-admin-note.ts
@@ -1,0 +1,133 @@
+/**
+ * One-shot cleanup for the ABQ H3 "LYNNE OFF" phantom event (#1783).
+ *
+ * Background:
+ *   ABQ H3's Google Calendar source opts into `includeAllDayEvents` (their
+ *   Tuesday CLiT runs are entered as all-day blocks). That also admitted the
+ *   kennel admin's personal all-day OOO block "LYNNE OFF", which surfaced on
+ *   /hareline as a phantom Friday run. PR for #1739 adds a
+ *   `silentlySkipPatterns` rule to the source so the row can never re-ingest;
+ *   this script removes the already-persisted phantom Event + its RawEvent(s).
+ *
+ * Safety / idempotency:
+ *   - Verifies the target Event still matches "LYNNE OFF" before deleting
+ *     (refuses if the row drifted to something else).
+ *   - Deletes the phantom RawEvent(s) outright (not unlink) so they cannot
+ *     re-merge into a fresh phantom; canonical RawEvents are an audit trail but
+ *     a personal OOO note is not legitimate scraped data.
+ *   - No-op on re-run (Event already gone → reports clean, exit 0).
+ *   - Dry run by default; set CLEANUP_APPLY=1 to mutate.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-abq-admin-note.ts
+ *   Apply:   CLEANUP_APPLY=1 npx tsx scripts/cleanup-abq-admin-note.ts
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const EVENT_ID = "cmpqmy3m9000b04joivvx6nt1";
+const SOURCE_NAME = "ABQ H3 Google Calendar";
+const EXPECTED_TITLE = "LYNNE OFF";
+
+const APPLY = process.env.CLEANUP_APPLY === "1";
+
+/** True when a RawEvent.rawData is the "LYNNE OFF" phantom. */
+function isPhantomRaw(rawData: unknown): boolean {
+  if (!rawData || typeof rawData !== "object") return false;
+  const title = (rawData as { title?: unknown }).title;
+  return typeof title === "string" && title.trim().toUpperCase() === EXPECTED_TITLE;
+}
+
+async function main(): Promise<void> {
+  const mode = APPLY ? "APPLY" : "DRY-RUN";
+  console.log(`[cleanup-abq] ${mode} — target Event ${EVENT_ID} ("${EXPECTED_TITLE}")`);
+
+  const source = await prisma.source.findFirst({ where: { name: SOURCE_NAME }, select: { id: true } });
+  if (!source) throw new Error(`Source not found: ${SOURCE_NAME}`);
+
+  const event = await prisma.event.findUnique({
+    where: { id: EVENT_ID },
+    select: { id: true, title: true, status: true },
+  });
+
+  // Delete ONLY the RawEvents linked to the target Event. We additionally scan
+  // the source for signature-matching rows that are NOT linked to this event
+  // and FAIL CLOSED if any exist (Codex adversarial review): deleting by
+  // signature alone could erase unrelated source/audit data. A stray match
+  // means something unexpected — surface it for a human rather than over-delete.
+  const sourceRaws = await prisma.rawEvent.findMany({
+    where: { sourceId: source.id },
+    select: { id: true, eventId: true, rawData: true },
+  });
+  const phantomRawIds = sourceRaws.filter((r) => r.eventId === EVENT_ID).map((r) => r.id);
+  const strayMatches = sourceRaws
+    .filter((r) => r.eventId !== EVENT_ID && isPhantomRaw(r.rawData))
+    .map((r) => r.id);
+  if (strayMatches.length > 0) {
+    throw new Error(
+      `Found ${strayMatches.length} "${EXPECTED_TITLE}" RawEvent(s) NOT linked to ${EVENT_ID}: ` +
+        `[${strayMatches.join(", ")}]. Refusing to delete unrelated source data — investigate manually.`,
+    );
+  }
+
+  if (!event && phantomRawIds.length === 0) {
+    console.log("[cleanup-abq] Nothing to do — phantom Event and RawEvents already removed.");
+    return;
+  }
+
+  if (event && event.title?.trim().toUpperCase() !== EXPECTED_TITLE) {
+    throw new Error(
+      `Refusing to delete: Event ${EVENT_ID} title is "${event.title}", expected "${EXPECTED_TITLE}". ` +
+        `The row may have drifted — investigate manually.`,
+    );
+  }
+
+  console.log(
+    `[cleanup-abq] Would delete: Event=${event ? `${event.id} (status ${event.status})` : "none"}, ` +
+      `RawEvents=${phantomRawIds.length} [${phantomRawIds.join(", ")}]`,
+  );
+
+  if (!APPLY) {
+    console.log("[cleanup-abq] DRY-RUN complete. Re-run with CLEANUP_APPLY=1 to delete.");
+    return;
+  }
+
+  await prisma.$transaction([
+    // Dependent records keyed on the Event (no onDelete cascade in schema).
+    prisma.eventHare.deleteMany({ where: { eventId: EVENT_ID } }),
+    prisma.attendance.deleteMany({ where: { eventId: EVENT_ID } }),
+    prisma.kennelAttendance.deleteMany({ where: { eventId: EVENT_ID } }),
+    // Defensive: orphan any child events that pointed at this one.
+    prisma.event.updateMany({ where: { parentEventId: EVENT_ID }, data: { parentEventId: null } }),
+    // Delete the phantom RawEvents (audit pollution — not legitimate data).
+    prisma.rawEvent.deleteMany({ where: { id: { in: phantomRawIds } } }),
+    // Delete the canonical Event (EventKennel + EventLink cascade in schema).
+    prisma.event.deleteMany({ where: { id: EVENT_ID } }),
+  ]);
+
+  // Post-delete orphan check.
+  const eventStill = await prisma.event.findUnique({ where: { id: EVENT_ID }, select: { id: true } });
+  const rawsStill = await prisma.rawEvent.count({ where: { id: { in: phantomRawIds } } });
+  if (eventStill || rawsStill > 0) {
+    throw new Error(`Post-delete check failed: event=${!!eventStill}, rawsRemaining=${rawsStill}`);
+  }
+
+  console.log(
+    "[cleanup-abq] " +
+      JSON.stringify({
+        action: "delete_phantom_event",
+        issue: 1783,
+        eventId: EVENT_ID,
+        rawEventsDeleted: phantomRawIds.length,
+        timestamp: new Date().toISOString(),
+      }),
+  );
+  console.log("[cleanup-abq] Done.");
+}
+
+main()
+  .catch((err) => {
+    console.error("[cleanup-abq] FAILED:", err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-hibiscus-no-run.ts
+++ b/scripts/cleanup-hibiscus-no-run.ts
@@ -1,0 +1,129 @@
+/**
+ * One-shot cleanup for the Hibiscus H3 "King's Birthday — no run" phantom
+ * event (#1786).
+ *
+ * Background:
+ *   Hibiscus H3's hareline Google Sheet carries holiday rows that have a real
+ *   date but a "no run" note in the Where column (e.g.
+ *   "Kings B'day, no run , Yours"). The GOOGLE_SHEETS adapter ingested this as
+ *   a real run with a map + weather. PR for #1739 adds a `silentlySkipPatterns`
+ *   rule (`\bno\s+run\b` on the location field) so such rows can never
+ *   re-ingest; this script removes the already-persisted phantom Event + its
+ *   RawEvent(s) (there are two — a re-scrape produced a duplicate raw).
+ *
+ * Safety / idempotency:
+ *   - Verifies the target Event's location still contains "no run" before
+ *     deleting (refuses if the row drifted).
+ *   - Deletes the phantom RawEvent(s) outright (not unlink) so they cannot
+ *     re-merge into a fresh phantom.
+ *   - No-op on re-run (Event already gone → reports clean, exit 0).
+ *   - Dry run by default; set CLEANUP_APPLY=1 to mutate.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-hibiscus-no-run.ts
+ *   Apply:   CLEANUP_APPLY=1 npx tsx scripts/cleanup-hibiscus-no-run.ts
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const EVENT_ID = "cmp9wo2nx001q04lam9go48hk";
+const SOURCE_NAME = "Hibiscus H3 Hareline Sheet";
+const NO_RUN_RE = /\bno\s+run\b/i;
+
+const APPLY = process.env.CLEANUP_APPLY === "1";
+
+/** True when a RawEvent.rawData is a "no run" holiday phantom (location note). */
+function isPhantomRaw(rawData: unknown): boolean {
+  if (!rawData || typeof rawData !== "object") return false;
+  const location = (rawData as { location?: unknown }).location;
+  return typeof location === "string" && NO_RUN_RE.test(location);
+}
+
+async function main(): Promise<void> {
+  const mode = APPLY ? "APPLY" : "DRY-RUN";
+  console.log(`[cleanup-hibiscus] ${mode} — target Event ${EVENT_ID} ("no run" holiday row)`);
+
+  const source = await prisma.source.findFirst({ where: { name: SOURCE_NAME }, select: { id: true } });
+  if (!source) throw new Error(`Source not found: ${SOURCE_NAME}`);
+
+  const event = await prisma.event.findUnique({
+    where: { id: EVENT_ID },
+    select: { id: true, locationName: true, status: true },
+  });
+
+  // Delete ONLY the RawEvents linked to the target Event. Scan the source for
+  // signature-matching rows that are NOT linked to this event and FAIL CLOSED
+  // if any exist (Codex adversarial review): a "no run" note could legitimately
+  // recur on a past/future Hibiscus row, and deleting by signature alone would
+  // erase unrelated source/audit data. Surface strays for a human instead.
+  const sourceRaws = await prisma.rawEvent.findMany({
+    where: { sourceId: source.id },
+    select: { id: true, eventId: true, rawData: true },
+  });
+  const phantomRawIds = sourceRaws.filter((r) => r.eventId === EVENT_ID).map((r) => r.id);
+  const strayMatches = sourceRaws
+    .filter((r) => r.eventId !== EVENT_ID && isPhantomRaw(r.rawData))
+    .map((r) => r.id);
+  if (strayMatches.length > 0) {
+    throw new Error(
+      `Found ${strayMatches.length} "no run" RawEvent(s) NOT linked to ${EVENT_ID}: ` +
+        `[${strayMatches.join(", ")}]. Refusing to delete unrelated source data — investigate manually.`,
+    );
+  }
+
+  if (!event && phantomRawIds.length === 0) {
+    console.log("[cleanup-hibiscus] Nothing to do — phantom Event and RawEvents already removed.");
+    return;
+  }
+
+  if (event && !(event.locationName && NO_RUN_RE.test(event.locationName))) {
+    throw new Error(
+      `Refusing to delete: Event ${EVENT_ID} locationName is "${event.locationName}", ` +
+        `expected it to contain "no run". The row may have drifted — investigate manually.`,
+    );
+  }
+
+  console.log(
+    `[cleanup-hibiscus] Would delete: Event=${event ? `${event.id} (status ${event.status})` : "none"}, ` +
+      `RawEvents=${phantomRawIds.length} [${phantomRawIds.join(", ")}]`,
+  );
+
+  if (!APPLY) {
+    console.log("[cleanup-hibiscus] DRY-RUN complete. Re-run with CLEANUP_APPLY=1 to delete.");
+    return;
+  }
+
+  await prisma.$transaction([
+    prisma.eventHare.deleteMany({ where: { eventId: EVENT_ID } }),
+    prisma.attendance.deleteMany({ where: { eventId: EVENT_ID } }),
+    prisma.kennelAttendance.deleteMany({ where: { eventId: EVENT_ID } }),
+    prisma.event.updateMany({ where: { parentEventId: EVENT_ID }, data: { parentEventId: null } }),
+    prisma.rawEvent.deleteMany({ where: { id: { in: phantomRawIds } } }),
+    prisma.event.deleteMany({ where: { id: EVENT_ID } }),
+  ]);
+
+  const eventStill = await prisma.event.findUnique({ where: { id: EVENT_ID }, select: { id: true } });
+  const rawsStill = await prisma.rawEvent.count({ where: { id: { in: phantomRawIds } } });
+  if (eventStill || rawsStill > 0) {
+    throw new Error(`Post-delete check failed: event=${!!eventStill}, rawsRemaining=${rawsStill}`);
+  }
+
+  console.log(
+    "[cleanup-hibiscus] " +
+      JSON.stringify({
+        action: "delete_phantom_event",
+        issue: 1786,
+        eventId: EVENT_ID,
+        rawEventsDeleted: phantomRawIds.length,
+        timestamp: new Date().toISOString(),
+      }),
+  );
+  console.log("[cleanup-hibiscus] Done.");
+}
+
+main()
+  .catch((err) => {
+    console.error("[cleanup-hibiscus] FAILED:", err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-hibiscus-no-run.ts
+++ b/scripts/cleanup-hibiscus-no-run.ts
@@ -2,22 +2,12 @@
  * One-shot cleanup for the Hibiscus H3 "King's Birthday — no run" phantom
  * event (#1786).
  *
- * Background:
- *   Hibiscus H3's hareline Google Sheet carries holiday rows that have a real
- *   date but a "no run" note in the Where column (e.g.
- *   "Kings B'day, no run , Yours"). The GOOGLE_SHEETS adapter ingested this as
- *   a real run with a map + weather. PR for #1739 adds a `silentlySkipPatterns`
- *   rule (`\bno\s+run\b` on the location field) so such rows can never
- *   re-ingest; this script removes the already-persisted phantom Event + its
- *   RawEvent(s) (there are two — a re-scrape produced a duplicate raw).
- *
- * Safety / idempotency:
- *   - Verifies the target Event's location still contains "no run" before
- *     deleting (refuses if the row drifted).
- *   - Deletes the phantom RawEvent(s) outright (not unlink) so they cannot
- *     re-merge into a fresh phantom.
- *   - No-op on re-run (Event already gone → reports clean, exit 0).
- *   - Dry run by default; set CLEANUP_APPLY=1 to mutate.
+ * Hibiscus H3's hareline Google Sheet carries holiday rows with a real date
+ * but a "no run" note in the Where column (e.g. "Kings B'day, no run , Yours").
+ * The GOOGLE_SHEETS adapter ingested this as a real run with a map + weather.
+ * PR for #1739 adds a `silentlySkipPatterns` rule (`\bno\s+run\b` on location)
+ * so such rows can never re-ingest; this script removes the already-persisted
+ * phantom Event + its RawEvent(s) (two — a re-scrape produced a duplicate raw).
  *
  * Usage:
  *   Dry run: npx tsx scripts/cleanup-hibiscus-no-run.ts
@@ -25,12 +15,9 @@
  */
 import "dotenv/config";
 import { prisma } from "@/lib/db";
+import { runPhantomCleanup } from "./lib/cleanup-phantom-event";
 
-const EVENT_ID = "cmp9wo2nx001q04lam9go48hk";
-const SOURCE_NAME = "Hibiscus H3 Hareline Sheet";
 const NO_RUN_RE = /\bno\s+run\b/i;
-
-const APPLY = process.env.CLEANUP_APPLY === "1";
 
 /** True when a RawEvent.rawData is a "no run" holiday phantom (location note). */
 function isPhantomRaw(rawData: unknown): boolean {
@@ -39,89 +26,19 @@ function isPhantomRaw(rawData: unknown): boolean {
   return typeof location === "string" && NO_RUN_RE.test(location);
 }
 
-async function main(): Promise<void> {
-  const mode = APPLY ? "APPLY" : "DRY-RUN";
-  console.log(`[cleanup-hibiscus] ${mode} — target Event ${EVENT_ID} ("no run" holiday row)`);
-
-  const source = await prisma.source.findFirst({ where: { name: SOURCE_NAME }, select: { id: true } });
-  if (!source) throw new Error(`Source not found: ${SOURCE_NAME}`);
-
-  const event = await prisma.event.findUnique({
-    where: { id: EVENT_ID },
-    select: { id: true, locationName: true, status: true },
-  });
-
-  // Delete ONLY the RawEvents linked to the target Event. Scan the source for
-  // signature-matching rows that are NOT linked to this event and FAIL CLOSED
-  // if any exist (Codex adversarial review): a "no run" note could legitimately
-  // recur on a past/future Hibiscus row, and deleting by signature alone would
-  // erase unrelated source/audit data. Surface strays for a human instead.
-  const sourceRaws = await prisma.rawEvent.findMany({
-    where: { sourceId: source.id },
-    select: { id: true, eventId: true, rawData: true },
-  });
-  const phantomRawIds = sourceRaws.filter((r) => r.eventId === EVENT_ID).map((r) => r.id);
-  const strayMatches = sourceRaws
-    .filter((r) => r.eventId !== EVENT_ID && isPhantomRaw(r.rawData))
-    .map((r) => r.id);
-  if (strayMatches.length > 0) {
-    throw new Error(
-      `Found ${strayMatches.length} "no run" RawEvent(s) NOT linked to ${EVENT_ID}: ` +
-        `[${strayMatches.join(", ")}]. Refusing to delete unrelated source data — investigate manually.`,
-    );
-  }
-
-  if (!event && phantomRawIds.length === 0) {
-    console.log("[cleanup-hibiscus] Nothing to do — phantom Event and RawEvents already removed.");
-    return;
-  }
-
-  if (event && !(event.locationName && NO_RUN_RE.test(event.locationName))) {
-    throw new Error(
-      `Refusing to delete: Event ${EVENT_ID} locationName is "${event.locationName}", ` +
-        `expected it to contain "no run". The row may have drifted — investigate manually.`,
-    );
-  }
-
-  console.log(
-    `[cleanup-hibiscus] Would delete: Event=${event ? `${event.id} (status ${event.status})` : "none"}, ` +
-      `RawEvents=${phantomRawIds.length} [${phantomRawIds.join(", ")}]`,
-  );
-
-  if (!APPLY) {
-    console.log("[cleanup-hibiscus] DRY-RUN complete. Re-run with CLEANUP_APPLY=1 to delete.");
-    return;
-  }
-
-  await prisma.$transaction([
-    prisma.eventHare.deleteMany({ where: { eventId: EVENT_ID } }),
-    prisma.attendance.deleteMany({ where: { eventId: EVENT_ID } }),
-    prisma.kennelAttendance.deleteMany({ where: { eventId: EVENT_ID } }),
-    prisma.event.updateMany({ where: { parentEventId: EVENT_ID }, data: { parentEventId: null } }),
-    prisma.rawEvent.deleteMany({ where: { id: { in: phantomRawIds } } }),
-    prisma.event.deleteMany({ where: { id: EVENT_ID } }),
-  ]);
-
-  const eventStill = await prisma.event.findUnique({ where: { id: EVENT_ID }, select: { id: true } });
-  const rawsStill = await prisma.rawEvent.count({ where: { id: { in: phantomRawIds } } });
-  if (eventStill || rawsStill > 0) {
-    throw new Error(`Post-delete check failed: event=${!!eventStill}, rawsRemaining=${rawsStill}`);
-  }
-
-  console.log(
-    "[cleanup-hibiscus] " +
-      JSON.stringify({
-        action: "delete_phantom_event",
-        issue: 1786,
-        eventId: EVENT_ID,
-        rawEventsDeleted: phantomRawIds.length,
-        timestamp: new Date().toISOString(),
-      }),
-  );
-  console.log("[cleanup-hibiscus] Done.");
-}
-
-main()
+runPhantomCleanup(
+  {
+    logPrefix: "cleanup-hibiscus",
+    issue: 1786,
+    eventId: "cmp9wo2nx001q04lam9go48hk",
+    sourceName: "Hibiscus H3 Hareline Sheet",
+    targetLabel: '"no run" holiday row',
+    isPhantomRaw,
+    verify: (e) => !!e.locationName && NO_RUN_RE.test(e.locationName),
+    describeDrift: (e) => `locationName is "${e.locationName}", expected it to contain "no run"`,
+  },
+  process.env.CLEANUP_APPLY === "1",
+)
   .catch((err) => {
     console.error("[cleanup-hibiscus] FAILED:", err);
     process.exitCode = 1;

--- a/scripts/lib/cleanup-phantom-event.ts
+++ b/scripts/lib/cleanup-phantom-event.ts
@@ -80,10 +80,8 @@ export async function runPhantomCleanup(cfg: PhantomCleanupConfig, apply: boolea
     );
   }
 
-  log(
-    `Would delete: Event=${event ? `${event.id} (status ${event.status})` : "none"}, ` +
-      `RawEvents=${phantomRawIds.length} [${phantomRawIds.join(", ")}]`,
-  );
+  const eventDesc = event ? `${event.id} (status ${event.status})` : "none";
+  log(`Would delete: Event=${eventDesc}, RawEvents=${phantomRawIds.length} [${phantomRawIds.join(", ")}]`);
   if (!apply) {
     log("DRY-RUN complete. Re-run with CLEANUP_APPLY=1 to delete.");
     return;

--- a/scripts/lib/cleanup-phantom-event.ts
+++ b/scripts/lib/cleanup-phantom-event.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared driver for one-shot phantom-event cleanups (#1739).
+ *
+ * Removes a single already-ingested phantom canonical Event plus its phantom
+ * RawEvent(s). Safety guarantees, identical across callers:
+ *   - Verifies the target Event still matches the expected signature before
+ *     deleting (refuses if the row drifted).
+ *   - Deletes ONLY RawEvents linked to the target Event. Scans the source for
+ *     signature-matching rows that are NOT linked and FAILS CLOSED if any
+ *     exist (Codex adversarial review) — deleting by signature alone could
+ *     erase unrelated source/audit data.
+ *   - Deletes phantom RawEvents outright (not unlink) so they cannot re-merge.
+ *   - No-op on re-run (Event already gone → reports clean, exit 0).
+ *   - Dry run unless `apply` is true.
+ */
+import { prisma } from "@/lib/db";
+
+/** Minimal Event projection passed to the per-caller verify/drift hooks. */
+export interface PhantomEvent {
+  id: string;
+  title: string | null;
+  locationName: string | null;
+  status: string;
+}
+
+export interface PhantomCleanupConfig {
+  /** Log prefix, e.g. "cleanup-abq". */
+  logPrefix: string;
+  /** GitHub issue number, surfaced in the audit line. */
+  issue: number;
+  /** Canonical Event id to remove. */
+  eventId: string;
+  /** Source name that owns the phantom RawEvents (provenance scope). */
+  sourceName: string;
+  /** Human label for logs, e.g. `"LYNNE OFF"`. */
+  targetLabel: string;
+  /** True when a RawEvent.rawData carries the phantom signature. */
+  isPhantomRaw: (rawData: unknown) => boolean;
+  /** True when the loaded Event still matches the expected phantom (drift guard). */
+  verify: (event: PhantomEvent) => boolean;
+  /** Drift detail for the refusal message when `verify` fails. */
+  describeDrift: (event: PhantomEvent) => string;
+}
+
+export async function runPhantomCleanup(cfg: PhantomCleanupConfig, apply: boolean): Promise<void> {
+  const log = (m: string) => console.log(`[${cfg.logPrefix}] ${m}`);
+  log(`${apply ? "APPLY" : "DRY-RUN"} — target Event ${cfg.eventId} (${cfg.targetLabel})`);
+
+  const source = await prisma.source.findFirst({ where: { name: cfg.sourceName }, select: { id: true } });
+  if (!source) throw new Error(`Source not found: ${cfg.sourceName}`);
+
+  const event = await prisma.event.findUnique({
+    where: { id: cfg.eventId },
+    select: { id: true, title: true, locationName: true, status: true },
+  });
+
+  const sourceRaws = await prisma.rawEvent.findMany({
+    where: { sourceId: source.id },
+    select: { id: true, eventId: true, rawData: true },
+  });
+  const phantomRawIds = sourceRaws.filter((r) => r.eventId === cfg.eventId).map((r) => r.id);
+  const strayMatches = sourceRaws
+    .filter((r) => r.eventId !== cfg.eventId && cfg.isPhantomRaw(r.rawData))
+    .map((r) => r.id);
+  if (strayMatches.length > 0) {
+    throw new Error(
+      `Found ${strayMatches.length} signature-matching RawEvent(s) NOT linked to ${cfg.eventId}: ` +
+        `[${strayMatches.join(", ")}]. Refusing to delete unrelated source data — investigate manually.`,
+    );
+  }
+
+  if (!event && phantomRawIds.length === 0) {
+    log("Nothing to do — phantom Event and RawEvents already removed.");
+    return;
+  }
+  if (event && !cfg.verify(event)) {
+    throw new Error(
+      `Refusing to delete: Event ${cfg.eventId} ${cfg.describeDrift(event)}. ` +
+        `The row may have drifted — investigate manually.`,
+    );
+  }
+
+  log(
+    `Would delete: Event=${event ? `${event.id} (status ${event.status})` : "none"}, ` +
+      `RawEvents=${phantomRawIds.length} [${phantomRawIds.join(", ")}]`,
+  );
+  if (!apply) {
+    log("DRY-RUN complete. Re-run with CLEANUP_APPLY=1 to delete.");
+    return;
+  }
+
+  await prisma.$transaction([
+    // Dependent records keyed on the Event (no onDelete cascade in schema).
+    prisma.eventHare.deleteMany({ where: { eventId: cfg.eventId } }),
+    prisma.attendance.deleteMany({ where: { eventId: cfg.eventId } }),
+    prisma.kennelAttendance.deleteMany({ where: { eventId: cfg.eventId } }),
+    // Defensive: orphan any child events that pointed at this one.
+    prisma.event.updateMany({ where: { parentEventId: cfg.eventId }, data: { parentEventId: null } }),
+    // Delete the phantom RawEvents (audit pollution — not legitimate data).
+    prisma.rawEvent.deleteMany({ where: { id: { in: phantomRawIds } } }),
+    // Delete the canonical Event (EventKennel + EventLink cascade in schema).
+    prisma.event.deleteMany({ where: { id: cfg.eventId } }),
+  ]);
+
+  const eventStill = await prisma.event.findUnique({ where: { id: cfg.eventId }, select: { id: true } });
+  const rawsStill = await prisma.rawEvent.count({ where: { id: { in: phantomRawIds } } });
+  if (eventStill || rawsStill > 0) {
+    throw new Error(`Post-delete check failed: event=${!!eventStill}, rawsRemaining=${rawsStill}`);
+  }
+
+  log(
+    JSON.stringify({
+      action: "delete_phantom_event",
+      issue: cfg.issue,
+      eventId: cfg.eventId,
+      rawEventsDeleted: phantomRawIds.length,
+      timestamp: new Date().toISOString(),
+    }),
+  );
+  log("Done.");
+}

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -6,6 +6,7 @@ import { matchKennelPatterns, matchCompiledKennelPatterns, compileKennelPatterns
 import { LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 import { parseDMSFromLocation } from "@/lib/geo";
 import { extractHares, PHONE_TRAILING_RE } from "../hare-extraction";
+import { MEDICAL_SKIP_RES } from "../skip-rules";
 
 /**
  * Default cap on the future-window passed to Google Calendar's `timeMax`. With
@@ -152,25 +153,13 @@ const PERSONAL_TITLE_PATTERNS: readonly RegExp[] = [
   /^\s*[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?\s+(?:training|practice|lesson|class|workout|tutoring|rehearsal)\b/,
 ];
 
-/**
- * Medical / telehealth appointment patterns (#1690 Houston PII).
- *
- * Kept separate from PERSONAL_TITLE_PATTERNS because a real contributor
- * adding their own medical appointment to a shared kennel calendar will
- * almost certainly type description text for themselves (clinic name,
- * prep notes). The PERSONAL_TITLE_PATTERNS gate (`hasStructuredField`)
- * treats any non-empty description as a hash signal — too permissive
- * for PII titles. These patterns ride a tighter gate: only runNumber
- * or hares can override (mirrors NON_HASH_DOMAIN_PATTERNS below).
- *
- * Patterns are narrow on purpose. A real hash titled "Sleep Study Trail"
- * with a hare assigned still passes thanks to the gate.
- */
-const MEDICAL_TITLE_PATTERNS: readonly RegExp[] = [
-  /^\s*sleep\s+study\b/i,
-  /^\s*(?:medical|telehealth|virtual)\s+(?:appointment|visit|consultation|consult)\b/i,
-  /\bremote\s+visit\b/i,
-];
+// Medical / telehealth appointment patterns (#1690 Houston PII) now live in
+// the shared `skip-rules` module as MEDICAL_SKIP_RES (#1739), so per-source
+// `silentlySkipPatterns` and this global heuristic share one definition. The
+// gate below is unchanged: kept separate from PERSONAL_TITLE_PATTERNS because a
+// real contributor adding their own medical appointment will type description
+// prose; only runNumber / hares / the literal "hash" override (a real
+// "Sleep Study Trail" with a hare still ingests).
 
 /**
  * Non-hash domain markers (#1426). Pairing a sport with a game/practice
@@ -1682,7 +1671,7 @@ export function buildRawEventFromGCalItem(
     runNumber === undefined &&
     !hares &&
     !HASH_KEYWORD_RE.test(summary) &&
-    MEDICAL_TITLE_PATTERNS.some((re) => re.test(summary) || re.test(strippedSummary))
+    MEDICAL_SKIP_RES.some((re) => re.test(summary) || re.test(strippedSummary))
   ) {
     return null;
   }

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -459,6 +459,41 @@ describe("MeetupAdapter", () => {
     ]);
   });
 
+  it("keeps run-numbered farewell/goodbye trails (#1739 negative fixture)", async () => {
+    // The retrofit gates the broad farewell words ("farewell"/"goodbye") with a
+    // hash-signal check, so a real departing-hasher "Farewell Run" / "Goodbye
+    // Trail" that carries a run number still ingests — only un-signalled
+    // platform-departure posts drop. Without the gate these would be dropped as
+    // false positives (the exact case .claude required a negative fixture for).
+    const html = buildMeetupHtml({
+      "Event:farewell": buildApolloEvent({
+        id: "fw1",
+        title: "Farewell Run Trail #42",
+        dateTime: "2026-06-10T18:00:00-04:00",
+        status: "ACTIVE",
+      }),
+      "Event:goodbye": buildApolloEvent({
+        id: "gb1",
+        title: "Goodbye Trail #138",
+        dateTime: "2026-06-12T18:00:00-04:00",
+        status: "ACTIVE",
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "narwhal-h3-group", kennelTag: "narwhal-h3" }),
+      { days: 365 },
+    );
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events.some((e) => /Farewell/i.test(e.title ?? ""))).toBe(true);
+    expect(result.events.some((e) => /Goodbye/i.test(e.title ?? ""))).toBe(true);
+    expect(result.diagnosticContext?.adminNoticeSkipped).toBe(0);
+  });
+
   it("parses events and assigns kennelTag", async () => {
     const html = buildMeetupHtml({
       "Event:1": buildApolloEvent(),

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -5,7 +5,7 @@ import { hasAnyErrors } from "../types";
 import { validateSourceConfig, stripHtmlTags, buildDateWindow, extractHashRunNumber, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { extractHares as extractHaresFromDescription } from "../hare-extraction";
-import { isAdminNoticeTitle } from "../facebook-hosted-events/constants";
+import { isPlatformDepartureTitle } from "../skip-rules";
 
 /** US state abbreviation → full name mapping (50 states + DC). */
 const US_STATE_ABBREV_TO_NAME: Record<string, string> = {
@@ -720,13 +720,14 @@ export class MeetupAdapter implements SourceAdapter {
           cancelledSkipped++;
           continue;
         }
-        // Drop admin-notice posts (kennel migration announcements, farewell
-        // posts). Same pattern set used by FACEBOOK_HOSTED_EVENTS (#1500 /
-        // PR #1527); Narwhal H3 surfaced the identical "Moving to a new
-        // website site - Last day in Meetup is March 10th" notice via the
-        // Meetup path (#1689). Patterns intentionally narrow — see
-        // ADMIN_NOTICE_PATTERNS docstring.
-        if (ev.title && isAdminNoticeTitle(ev.title)) {
+        // Drop platform-departure admin posts (kennel migration announcements,
+        // farewell posts). Narwhal H3 surfaced "Moving to a new website site -
+        // Last day in Meetup is March 10th" (#1689); Miami posted "...ARE
+        // LEAVING MEETUP" (#1728). Routed through the shared skip-rules matcher
+        // (#1739): the specific departure phrases drop unconditionally, while
+        // the broad farewell words ("farewell"/"goodbye") are now signal-gated
+        // so a real "Farewell Run Trail #42" still ingests.
+        if (ev.title && isPlatformDepartureTitle(ev.title)) {
           adminNoticeSkipped++;
           adminNoticeTitles.push(ev.title);
           continue;

--- a/src/adapters/skip-rules.test.ts
+++ b/src/adapters/skip-rules.test.ts
@@ -57,14 +57,13 @@ describe("matchSilentSkip — field targeting", () => {
     ["location", { location: "Kings B'day, no run , Yours" }],
     ["hares", { hares: "TBD admin note" }],
   ] as const)("matches on the %s field", (field, partial) => {
-    const pattern =
-      field === "title"
-        ? "^LYNNE OFF$"
-        : field === "description"
-          ? "new website"
-          : field === "location"
-            ? String.raw`\bno\s+run\b`
-            : "admin note";
+    const patternByField = {
+      title: "^LYNNE OFF$",
+      description: "new website",
+      location: String.raw`\bno\s+run\b`,
+      hares: "admin note",
+    } as const;
+    const pattern = patternByField[field];
     const rules = compileSilentSkipRules([{ pattern, field }]);
     const hit = matchSilentSkip(ev(partial), rules);
     expect(hit).toEqual({ field, pattern });

--- a/src/adapters/skip-rules.test.ts
+++ b/src/adapters/skip-rules.test.ts
@@ -1,0 +1,151 @@
+import {
+  compileSilentSkipRules,
+  matchSilentSkip,
+  titleHasHashSignal,
+  hasHashSignal,
+  isPlatformDepartureTitle,
+} from "./skip-rules";
+import type { RawEventData } from "./types";
+
+/** Minimal RawEventData builder for matcher tests. */
+function ev(partial: Partial<RawEventData>): RawEventData {
+  return { date: "2026-06-01", kennelTags: ["test-h3"], ...partial };
+}
+
+describe("compileSilentSkipRules", () => {
+  it("compiles a valid rule and defaults field to title", () => {
+    const [rule] = compileSilentSkipRules([{ pattern: "^LYNNE OFF$" }]);
+    expect(rule.field).toBe("title");
+    expect(rule.unlessHashSignal).toBe(false);
+    expect(rule.source).toBe("^LYNNE OFF$");
+    expect(rule.re.test("lynne off")).toBe(true); // case-insensitive
+  });
+
+  it.each([
+    ["null", null, 0],
+    ["non-array", { pattern: "x" }, 0],
+    ["empty array", [], 0],
+  ])("returns [] for %s config", (_label, raw, expected) => {
+    expect(compileSilentSkipRules(raw)).toHaveLength(expected);
+  });
+
+  it.each([
+    ["missing pattern", { field: "title" }],
+    ["empty pattern", { pattern: "" }],
+    ["non-string pattern", { pattern: 42 }],
+    ["invalid field", { pattern: "x", field: "venue" }],
+    ["invalid regex", { pattern: "(" }],
+    ["ReDoS-unsafe", { pattern: "(a+)+$" }],
+  ])("drops malformed rule: %s", (_label, badRule) => {
+    expect(compileSilentSkipRules([badRule])).toHaveLength(0);
+  });
+
+  it("keeps valid rules and drops malformed ones in the same array", () => {
+    const rules = compileSilentSkipRules([
+      { pattern: "good" },
+      { pattern: "(" },
+      { pattern: "also good", field: "location" },
+    ]);
+    expect(rules.map((r) => r.source)).toEqual(["good", "also good"]);
+  });
+});
+
+describe("matchSilentSkip — field targeting", () => {
+  it.each([
+    ["title", { title: "LYNNE OFF" }],
+    ["description", { description: "moving to a new website" }],
+    ["location", { location: "Kings B'day, no run , Yours" }],
+    ["hares", { hares: "TBD admin note" }],
+  ] as const)("matches on the %s field", (field, partial) => {
+    const pattern =
+      field === "title"
+        ? "^LYNNE OFF$"
+        : field === "description"
+          ? "new website"
+          : field === "location"
+            ? String.raw`\bno\s+run\b`
+            : "admin note";
+    const rules = compileSilentSkipRules([{ pattern, field }]);
+    const hit = matchSilentSkip(ev(partial), rules);
+    expect(hit).toEqual({ field, pattern });
+  });
+
+  it("returns null when nothing matches", () => {
+    const rules = compileSilentSkipRules([{ pattern: "^LYNNE OFF$" }]);
+    expect(matchSilentSkip(ev({ title: "Red Dress Run #42" }), rules)).toBeNull();
+  });
+
+  it("only tests the configured field, not others", () => {
+    // pattern targets location; a title hit must NOT drop the event
+    const rules = compileSilentSkipRules([{ pattern: "secret", field: "location" }]);
+    expect(matchSilentSkip(ev({ title: "secret trail", location: "Main St" }), rules)).toBeNull();
+  });
+});
+
+describe("matchSilentSkip — unlessHashSignal gate", () => {
+  const rules = compileSilentSkipRules([
+    { pattern: "sleep study", field: "title", unlessHashSignal: true },
+  ]);
+
+  it("drops a matching event with no hash signal", () => {
+    expect(matchSilentSkip(ev({ title: "Sleep Study" }), rules)).not.toBeNull();
+  });
+
+  it.each([
+    ["runNumber", { title: "Sleep Study", runNumber: 42 }],
+    ["hares", { title: "Sleep Study", hares: "Just Tom" }],
+    ["hash keyword in title", { title: "Sleep Study Hash" }],
+    ["#NN in title", { title: "Sleep Study Trail #7" }],
+  ])("is suppressed by a hash signal: %s", (_label, partial) => {
+    expect(matchSilentSkip(ev(partial), rules)).toBeNull();
+  });
+
+  it("unconditional rule (no gate) drops regardless of signal", () => {
+    const hard = compileSilentSkipRules([{ pattern: "sleep study", field: "title" }]);
+    expect(matchSilentSkip(ev({ title: "Sleep Study", runNumber: 42 }), hard)).not.toBeNull();
+  });
+});
+
+describe("hash-signal helpers", () => {
+  it.each([
+    ["plain title", "Red Dress Run", false],
+    ["hash keyword", "Full Moon Hash", true],
+    ["run number", "Trail #138", true],
+    ["empty", "", false],
+  ])("titleHasHashSignal(%s)", (_label, title, expected) => {
+    expect(titleHasHashSignal(title)).toBe(expected);
+  });
+
+  it("hasHashSignal reads runNumber/hares/title", () => {
+    expect(hasHashSignal({ title: "x", runNumber: 1 })).toBe(true);
+    expect(hasHashSignal({ title: "x", hares: "Tom" })).toBe(true);
+    expect(hasHashSignal({ title: "Hash" })).toBe(true);
+    expect(hasHashSignal({ title: "x", runNumber: null, hares: null })).toBe(false);
+  });
+});
+
+describe("isPlatformDepartureTitle (retrofit built-in)", () => {
+  it.each([
+    "Moving to a new website site - Last day in Meetup is March 10th",
+    "MIAMI HASH HOUSE HARRIERS ARE LEAVING MEETUP",
+    "Please use our new website",
+  ])("drops platform-departure post: %s", (title) => {
+    expect(isPlatformDepartureTitle(title)).toBe(true);
+  });
+
+  it.each([
+    "Farewell party for Just Departed",
+    "Goodbye and good riddance",
+  ])("drops un-signalled farewell post: %s", (title) => {
+    expect(isPlatformDepartureTitle(title)).toBe(true);
+  });
+
+  it.each([
+    "Farewell Run Trail #42", // run-numbered farewell = real trail
+    "Goodbye Trail #138",
+    "Leaving Las Vegas Trail #42", // bare "leaving" ≠ "leaving meetup"
+    "Red Dress Run #500",
+  ])("keeps legitimate hash event: %s", (title) => {
+    expect(isPlatformDepartureTitle(title)).toBe(false);
+  });
+});

--- a/src/adapters/skip-rules.ts
+++ b/src/adapters/skip-rules.ts
@@ -11,10 +11,11 @@
  *      existing call sites — same regex semantics as the old hard-coded
  *      one-offs, now centralized here.
  *
- * Pure leaf module: no DB / server-only imports, so client bundles that reach
- * `types.ts` never pull server code (memory: turbopack client-bundle leaks).
+ * Imported only by server-side adapters and the scrape pipeline — never by
+ * client components — so it can reuse the adapter `utils` helpers freely.
  */
 import isSafeRegex from "safe-regex2";
+import { compilePatterns } from "./utils";
 import type { RawEventData, SilentSkipRule } from "./types";
 
 type SkipField = NonNullable<SilentSkipRule["field"]>;
@@ -60,11 +61,10 @@ export function compileSilentSkipRules(raw: unknown): CompiledSkipRule[] {
       console.warn(`[skip-rules] dropping rule with invalid field "${field}"`);
       continue;
     }
-    let re: RegExp;
-    try {
-      // nosemgrep: detect-non-literal-regexp — config regex, ReDoS-guarded by isSafeRegex() below
-      re = new RegExp(rule.pattern, "i"); // NOSONAR
-    } catch {
+    // Compile via the shared helper so the (suppressed) dynamic-RegExp call
+    // lives in exactly one place (utils.ts). Malformed patterns yield [].
+    const [re] = compilePatterns([rule.pattern], "i");
+    if (!re) {
       console.warn(`[skip-rules] dropping rule with invalid regex "${rule.pattern}"`);
       continue;
     }
@@ -108,7 +108,7 @@ function fieldValue(ev: RawEventData, field: SkipField): string | null | undefin
   }
 }
 
-interface SkipMatch {
+export interface SkipMatch {
   field: SkipField;
   pattern: string;
 }

--- a/src/adapters/skip-rules.ts
+++ b/src/adapters/skip-rules.ts
@@ -1,0 +1,198 @@
+/**
+ * Systemic phantom-event skip mechanism (#1739).
+ *
+ * One shared matcher backs two consumers:
+ *   1. Per-source `Source.config.silentlySkipPatterns` (compiled + matched in
+ *      `src/pipeline/scrape.ts`, before events become RawEvents) — drops known
+ *      source pollution (admin notes, "no run" holiday rows, sister-kennel
+ *      events) with NO `SOURCE_KENNEL_MISMATCH` alert.
+ *   2. The global built-in rule sets below (medical / platform-departure /
+ *      farewell), consumed by `google-calendar` + `meetup` adapters at their
+ *      existing call sites — same regex semantics as the old hard-coded
+ *      one-offs, now centralized here.
+ *
+ * Pure leaf module: no DB / server-only imports, so client bundles that reach
+ * `types.ts` never pull server code (memory: turbopack client-bundle leaks).
+ */
+import isSafeRegex from "safe-regex2";
+import type { RawEventData, SilentSkipRule } from "./types";
+
+type SkipField = NonNullable<SilentSkipRule["field"]>;
+
+export interface CompiledSkipRule {
+  re: RegExp;
+  field: SkipField;
+  unlessHashSignal: boolean;
+  /** Original pattern string — surfaced in scrape diagnostics. */
+  source: string;
+}
+
+const VALID_FIELDS: ReadonlySet<string> = new Set([
+  "title",
+  "description",
+  "location",
+  "hares",
+]);
+
+const HASH_KEYWORD_RE = /\bhash\b/i;
+const TITLE_RUN_NUMBER_RE = /#\s?\d/;
+
+/**
+ * Compile per-source `silentlySkipPatterns` config (untrusted JSON). Validates
+ * shape and ReDoS-safety; silently drops malformed entries with a one-line
+ * warning rather than throwing, so a single bad rule never breaks a scrape.
+ */
+export function compileSilentSkipRules(raw: unknown): CompiledSkipRule[] {
+  if (raw == null) return [];
+  if (!Array.isArray(raw)) {
+    console.warn("[skip-rules] silentlySkipPatterns must be an array — ignoring");
+    return [];
+  }
+  const out: CompiledSkipRule[] = [];
+  for (const entry of raw) {
+    const rule = entry as Partial<SilentSkipRule> | null | undefined;
+    if (!rule || typeof rule.pattern !== "string" || rule.pattern.length === 0) {
+      console.warn("[skip-rules] dropping malformed silentlySkipPatterns entry (missing pattern)");
+      continue;
+    }
+    const field = rule.field ?? "title";
+    if (!VALID_FIELDS.has(field)) {
+      console.warn(`[skip-rules] dropping rule with invalid field "${field}"`);
+      continue;
+    }
+    let re: RegExp;
+    try {
+      // nosemgrep: detect-non-literal-regexp — config regex, ReDoS-guarded by isSafeRegex() below
+      re = new RegExp(rule.pattern, "i"); // NOSONAR
+    } catch {
+      console.warn(`[skip-rules] dropping rule with invalid regex "${rule.pattern}"`);
+      continue;
+    }
+    if (!isSafeRegex(re)) {
+      console.warn(`[skip-rules] dropping ReDoS-unsafe rule "${rule.pattern}"`);
+      continue;
+    }
+    out.push({
+      re,
+      field: field as SkipField,
+      unlessHashSignal: rule.unlessHashSignal === true,
+      source: rule.pattern,
+    });
+  }
+  return out;
+}
+
+/** Hash-confirming signal present in a title alone (word "hash" or a `#NN`). */
+export function titleHasHashSignal(title: string | null | undefined): boolean {
+  if (!title) return false;
+  return HASH_KEYWORD_RE.test(title) || TITLE_RUN_NUMBER_RE.test(title);
+}
+
+/** Hash-confirming signal on a (partial) event: real runNumber, hares, or title keyword. */
+export function hasHashSignal(
+  ev: Pick<RawEventData, "title" | "runNumber" | "hares">,
+): boolean {
+  return ev.runNumber != null || !!ev.hares || titleHasHashSignal(ev.title);
+}
+
+function fieldValue(ev: RawEventData, field: SkipField): string | null | undefined {
+  switch (field) {
+    case "title":
+      return ev.title;
+    case "description":
+      return ev.description;
+    case "location":
+      return ev.location;
+    case "hares":
+      return ev.hares;
+  }
+}
+
+interface SkipMatch {
+  field: SkipField;
+  pattern: string;
+}
+
+/**
+ * First rule (if any) that drops `ev`: the chosen field matches the regex and,
+ * for `unlessHashSignal` rules, no hash signal rescues it. The signal is
+ * computed lazily and at most once per event.
+ */
+export function matchSilentSkip(
+  ev: RawEventData,
+  rules: CompiledSkipRule[],
+): SkipMatch | null {
+  if (rules.length === 0) return null;
+  let signal: boolean | undefined;
+  for (const rule of rules) {
+    const value = fieldValue(ev, rule.field);
+    if (!value || !rule.re.test(value)) continue;
+    if (rule.unlessHashSignal) {
+      signal ??= hasHashSignal(ev);
+      if (signal) continue;
+    }
+    return { field: rule.field, pattern: rule.source };
+  }
+  return null;
+}
+
+// ───────────────────────── Global built-in rule sets ─────────────────────────
+// Trusted RegExp literals (not user input → no isSafeRegex gate needed).
+// Consumed by adapters at their existing call sites; behavior matches the
+// pre-#1739 hard-coded one-offs, except FAREWELL_RES is now signal-gated.
+
+/**
+ * Medical / telehealth appointment titles (#1690, cycle-13 Houston PII leak).
+ * Used by `google-calendar/adapter.ts` together with its explicit
+ * `runNumber === undefined && !hares && !/\bhash\b/i` gate, so a real
+ * "Sleep Study Trail" with a hare still ingests.
+ */
+export const MEDICAL_SKIP_RES: readonly RegExp[] = [
+  /^\s*sleep\s+study\b/i,
+  /^\s*(?:medical|telehealth|virtual)\s+(?:appointment|visit|consultation|consult)\b/i,
+  /\bremote\s+visit\b/i,
+];
+
+/**
+ * Platform-departure admin posts (#1689 Narwhal, #1728 Miami). Unconditional —
+ * no run number / location / hares rehabilitates a "we're leaving" notice.
+ * `leaving meetup` is narrow on purpose ("Leaving Las Vegas Trail" ingests).
+ * Consumed only via `isPlatformDepartureTitle` below.
+ *
+ * NOTE: `facebook-hosted-events/constants.ts` keeps a parallel
+ * `ADMIN_NOTICE_PATTERNS` copy (applied unconditionally, no farewell gate).
+ * Unifying FB onto this matcher is a deliberate follow-up — out of scope here.
+ */
+const PLATFORM_DEPARTURE_RES: readonly RegExp[] = [
+  /\bmoving\s+to\s+(?:a\s+)?new\s+(?:website|site|home|platform)\b/i,
+  /\blast\s+day\s+(?:in|on|at)\b/i,
+  /\bnew\s+website\b/i,
+  /\bleaving\s+meetup\b/i,
+  /\bplease\s+(?:use|visit|follow)\s+(?:our\s+)?new\b/i,
+];
+
+/**
+ * Broad farewell words. GATED by `titleHasHashSignal` (#1739): a real
+ * "Farewell Run Trail #42" / "Goodbye Trail #138" carries a run number and
+ * ingests, while a bare "Farewell, we're done" departure post (no number)
+ * drops. `RIP` stays case-sensitive — lowercase "rip" appears in real prose.
+ * Consumed only via `isPlatformDepartureTitle` below.
+ */
+const FAREWELL_RES: readonly RegExp[] = [
+  /\bfarewell\b/i,
+  /\bgoodbye\b/i,
+  /\bRIP\b/,
+  /\bdeprecated\b/i,
+];
+
+/**
+ * True when a Meetup/FB-style title is a platform-departure post, or an
+ * un-signalled farewell post. The single entry point adapters call to drop
+ * admin-notice events. Replaces the old unconditional `isAdminNoticeTitle`
+ * path for Meetup (FB keeps its own copy in `facebook-hosted-events`).
+ */
+export function isPlatformDepartureTitle(title: string): boolean {
+  if (PLATFORM_DEPARTURE_RES.some((re) => re.test(title))) return true;
+  if (FAREWELL_RES.some((re) => re.test(title)) && !titleHasHashSignal(title)) return true;
+  return false;
+}

--- a/src/adapters/skip-rules.ts
+++ b/src/adapters/skip-rules.ts
@@ -74,7 +74,7 @@ export function compileSilentSkipRules(raw: unknown): CompiledSkipRule[] {
     }
     out.push({
       re,
-      field: field as SkipField,
+      field,
       unlessHashSignal: rule.unlessHashSignal === true,
       source: rule.pattern,
     });

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -106,6 +106,30 @@ export interface RawEventData {
   dropCachedCoords?: boolean;
 }
 
+/**
+ * A single "silently skip" rule (#1739). Drops a matched event at the ingest
+ * boundary (`scrape.ts`, before it becomes a RawEvent) with no
+ * `SOURCE_KENNEL_MISMATCH` alert — for intentional, known source pollution
+ * (admin notes, "no run" holiday rows, platform-departure posts, sister-kennel
+ * events that have their own source). Per-source config lives in
+ * `Source.config.silentlySkipPatterns`. The same shape backs the global
+ * built-in rule sets in `skip-rules.ts` (medical / platform-departure /
+ * farewell) so config and adapter heuristics share one matcher.
+ */
+export interface SilentSkipRule {
+  /** Regex string; compiled case-insensitive. Must be ReDoS-safe. */
+  pattern: string;
+  /** Which RawEventData field to test. Default `"title"`. */
+  field?: "title" | "description" | "location" | "hares";
+  /**
+   * When true, the skip is suppressed if the event carries a hash-confirming
+   * signal (a real `runNumber`, `hares`, or the word "hash" in the title).
+   * Mirrors the MEDICAL_TITLE_PATTERNS gate so a real "Sleep Study Trail" with
+   * a hare still ingests. Default false (unconditional drop).
+   */
+  unlessHashSignal?: boolean;
+}
+
 /** Structured parse error with row-level context (Phase 2A) */
 export interface ParseError {
   row: number; // Which row in the source data failed

--- a/src/app/admin/sources/config-validation.test.ts
+++ b/src/app/admin/sources/config-validation.test.ts
@@ -176,6 +176,45 @@ describe("validateSourceConfig", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // silentlySkipPatterns validation (#1739 — object-array rules)
+  // ---------------------------------------------------------------------------
+
+  describe("silentlySkipPatterns validation", () => {
+    it("accepts valid rules across all source types", () => {
+      const config = {
+        silentlySkipPatterns: [
+          { pattern: "^LYNNE OFF$", field: "title" },
+          { pattern: String.raw`\bno\s+run\b`, field: "location" },
+          { pattern: "deprecated", unlessHashSignal: true },
+          { pattern: "^DeMon" }, // field defaults to title
+        ],
+        defaultKennelTag: "abqh3",
+      };
+      expect(validateSourceConfig("GOOGLE_CALENDAR", config)).toEqual([]);
+      expect(validateSourceConfig("MEETUP", { ...config, groupUrlname: "x", kennelTag: "y" })).toEqual([]);
+    });
+
+    it("rejects a non-array value", () => {
+      const errors = validateSourceConfig("GOOGLE_CALENDAR", { silentlySkipPatterns: "nope" });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("must be an array");
+    });
+
+    it.each([
+      [{ field: "title" }, "required non-empty string"],
+      [{ pattern: "" }, "required non-empty string"],
+      [{ pattern: "[broken(" }, "invalid regex"],
+      [{ pattern: "(x+x+)+y" }, "catastrophic backtracking"],
+      [{ pattern: "ok", field: "venue" }, "must be one of"],
+      [{ pattern: "ok", unlessHashSignal: "yes" }, "must be a boolean"],
+      ["not-an-object", 'must be an object with a "pattern" string'],
+    ])("rejects malformed rule %#", (rule, expectedMsg) => {
+      const errors = validateSourceConfig("GOOGLE_CALENDAR", { silentlySkipPatterns: [rule] });
+      expect(errors.some((e) => e.includes(expectedMsg))).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // titleHarePattern validation (single string, not array)
   // ---------------------------------------------------------------------------
 

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -162,6 +162,42 @@ function validatePatternArray(
   }
 }
 
+/** Valid `field` values for a silentlySkipPatterns rule (#1739). */
+const SILENT_SKIP_FIELDS = new Set(["title", "description", "location", "hares"]);
+
+/**
+ * Validate the cross-cutting `silentlySkipPatterns` config (#1739): an array of
+ * `{ pattern, field?, unlessHashSignal? }` rules. Each `pattern` must be a
+ * ReDoS-safe regex; `field` (when present) must be one of the supported event
+ * fields; `unlessHashSignal` (when present) must be boolean.
+ */
+function validateSilentlySkipPatterns(obj: Record<string, unknown>, errors: string[]): void {
+  if (!("silentlySkipPatterns" in obj) || obj.silentlySkipPatterns === undefined) return;
+  if (!Array.isArray(obj.silentlySkipPatterns)) {
+    errors.push("silentlySkipPatterns must be an array of { pattern, field?, unlessHashSignal? } rules");
+    return;
+  }
+  for (const [i, raw] of (obj.silentlySkipPatterns as unknown[]).entries()) {
+    const label = `silentlySkipPatterns[${i}]`;
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      errors.push(`${label}: must be an object with a "pattern" string`);
+      continue;
+    }
+    const rule = raw as Record<string, unknown>;
+    if (typeof rule.pattern !== "string" || rule.pattern.length === 0) {
+      errors.push(`${label}.pattern: required non-empty string`);
+    } else {
+      validateRegex(rule.pattern, `${label}.pattern`, errors);
+    }
+    if (rule.field !== undefined && (typeof rule.field !== "string" || !SILENT_SKIP_FIELDS.has(rule.field))) {
+      errors.push(`${label}.field: must be one of title | description | location | hares`);
+    }
+    if (rule.unlessHashSignal !== undefined && typeof rule.unlessHashSignal !== "boolean") {
+      errors.push(`${label}.unlessHashSignal: must be a boolean`);
+    }
+  }
+}
+
 /** Validate Google Sheets required fields. */
 function validateGoogleSheetsConfig(obj: Record<string, unknown>, errors: string[]): void {
   if (!obj.sheetId || typeof obj.sheetId !== "string") {
@@ -486,6 +522,7 @@ export function validateSourceConfig(
   validatePatternArray(obj, "costPatterns", errors);
   validatePatternArray(obj, "titleStripPatterns", errors);
   validatePatternArray(obj, "locationOmitIfMatches", errors, { rejectBroad: true });
+  validateSilentlySkipPatterns(obj, errors);
 
   // Single-pattern validation (titleHarePattern is a string, not an array)
   if ("titleHarePattern" in obj && obj.titleHarePattern !== undefined) {

--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -259,6 +259,66 @@ describe("scrapeSource", () => {
     expect(updateData.data.sampleSkipped).toEqual(sampleSkipped);
   });
 
+  // #1739 — silentlySkipPatterns drops known source pollution at the ingest
+  // boundary, before events become RawEvents and before the reconciler runs.
+  describe("silentlySkipPatterns", () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    afterEach(() => consoleWarnSpy.mockClear());
+
+    it("drops matched events before processRawEvents — no merge, no mismatch", async () => {
+      const skipSource = {
+        id: "src_skip", type: "GOOGLE_CALENDAR", url: "abqh3@group.calendar.google.com",
+        config: { silentlySkipPatterns: [{ pattern: "^LYNNE OFF$", field: "title" }] },
+      };
+      mockSourceFind.mockResolvedValueOnce(skipSource as never);
+      mockGetAdapter.mockReturnValueOnce({
+        type: "GOOGLE_CALENDAR",
+        fetch: vi.fn().mockResolvedValue({
+          events: [
+            { date: "2026-05-29", kennelTags: ["abqh3"], title: "LYNNE OFF" },
+            { date: "2026-05-30", kennelTags: ["abqh3"], title: "Red Dress Run #42" },
+          ],
+          errors: [],
+        }),
+      } as never);
+
+      await scrapeSource("src_skip");
+
+      // The merge pipeline only ever sees the real event — the phantom never
+      // becomes a RawEvent and so can never raise SOURCE_KENNEL_MISMATCH.
+      expect(mockProcessRaw).toHaveBeenCalledWith("src_skip", [
+        expect.objectContaining({ title: "Red Dress Run #42" }),
+      ]);
+      const merged = mockProcessRaw.mock.calls[0][1] as Array<{ title?: string }>;
+      expect(merged.some((e) => e.title === "LYNNE OFF")).toBe(false);
+    });
+
+    it("records a PII-safe silentlySkipped diagnostic (no raw location value)", async () => {
+      const skipSource = {
+        id: "src_skip2", type: "GOOGLE_SHEETS", url: "https://docs.google.com/sheet",
+        config: { silentlySkipPatterns: [{ pattern: String.raw`\bno\s+run\b`, field: "location" }] },
+      };
+      mockSourceFind.mockResolvedValueOnce(skipSource as never);
+      mockGetAdapter.mockReturnValueOnce({
+        type: "GOOGLE_SHEETS",
+        fetch: vi.fn().mockResolvedValue({
+          events: [{ date: "2026-06-01", kennelTags: ["hibiscus-h3"], location: "Kings B'day, no run , Yours" }],
+          errors: [],
+        }),
+      } as never);
+
+      await scrapeSource("src_skip2");
+
+      expect(mockProcessRaw).toHaveBeenCalledWith("src_skip2", []);
+      const updateData = mockLogUpdate.mock.calls[0][0] as { data: Record<string, unknown> };
+      const diag = updateData.data.diagnosticContext as { silentlySkipped: { skipped: number; samples: unknown[] } };
+      expect(diag.silentlySkipped.skipped).toBe(1);
+      expect(diag.silentlySkipped.samples[0]).toMatchObject({ field: "location", date: "2026-06-01" });
+      // PII hygiene: the raw location value is never serialized into diagnostics.
+      expect(JSON.stringify(diag.silentlySkipped)).not.toContain("Kings B'day");
+    });
+  });
+
   // Regression for #1053-1056. Both `after()` and `revalidateTag()` need a
   // Next.js request scope. When something (Vercel cold-start race, library
   // wrapping a Promise chain, etc.) breaks AsyncLocalStorage tracking they

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -13,6 +13,7 @@ import { autoFileIssuesForAlerts } from "./auto-issue";
 import { verifyResolvedAutoFixes } from "./verify-fixes";
 import { attemptAiRecovery, isAiRecoveryAvailable } from "@/lib/ai/parse-recovery";
 import { validateSourceUrl } from "@/adapters/utils";
+import { compileSilentSkipRules, matchSilentSkip } from "@/adapters/skip-rules";
 import { after } from "next/server";
 import { pingIndexNow } from "@/lib/indexnow";
 import { getCanonicalSiteUrl } from "@/lib/site-url";
@@ -136,6 +137,58 @@ function buildDiagnosticContext(
     };
   }
   return diagnosticContext;
+}
+
+/** Audit summary for a source's `silentlySkipPatterns` drops (#1739). */
+interface SilentSkipSummary {
+  skipped: number;
+  /** PII-safe samples: matched field + pattern + date (+ title only for title matches). */
+  samples: Array<{ field: string; pattern: string; date: string; title?: string }>;
+}
+
+/**
+ * Filter `scrapeResult.events` in place, dropping events matched by the
+ * source's configured `silentlySkipPatterns` (#1739). Mutating the array here —
+ * before `processRawEvents` and `reconcileStaleEvents` — means matched events
+ * never become RawEvents, never raise SOURCE_KENNEL_MISMATCH, and aren't seen
+ * as "removed from source" by the reconciler. Returns a PII-safe audit summary.
+ */
+function applySilentSkipPatterns(
+  source: { config: unknown; name: string },
+  scrapeResult: ScrapeResult,
+  sourceId: string,
+): SilentSkipSummary {
+  const rules = compileSilentSkipRules(
+    (source.config as Record<string, unknown> | null)?.silentlySkipPatterns,
+  );
+  if (rules.length === 0) return { skipped: 0, samples: [] };
+
+  const samples: SilentSkipSummary["samples"] = [];
+  let skipped = 0;
+  scrapeResult.events = scrapeResult.events.filter((ev) => {
+    const hit = matchSilentSkip(ev, rules);
+    if (!hit) return true;
+    skipped++;
+    if (samples.length < 5) {
+      // PII hygiene (memory: adapter PII filter): never log a raw location /
+      // hares value. Title is safe to surface; for other fields log only the
+      // matched field name + pattern.
+      samples.push({
+        field: hit.field,
+        pattern: hit.pattern,
+        date: ev.date,
+        ...(hit.field === "title" && ev.title ? { title: ev.title } : {}),
+      });
+    }
+    return false;
+  });
+
+  if (skipped > 0) {
+    console.warn(
+      `[scrape] silentlySkipPatterns dropped ${skipped} event(s) for source "${source.name}" (${sourceId})`,
+    );
+  }
+  return { skipped, samples };
 }
 
 /** Parameters for the ScrapeLog update after merge completes. */
@@ -414,6 +467,14 @@ export async function scrapeSource(
     // AI Recovery
     const aiRecovery = await runAiRecovery(scrapeResult, source.name);
 
+    // Silently drop known source pollution (#1739) — admin notes, "no run"
+    // holiday rows, sister-kennel events with their own source — BEFORE events
+    // become RawEvents and BEFORE the reconciler sees them. No
+    // SOURCE_KENNEL_MISMATCH alert is raised; the drops are audited in the
+    // scrape diagnostics below (PII-safe: field + title + date only, never the
+    // raw location/hares value).
+    const silentSkip = applySilentSkipPatterns(source, scrapeResult, sourceId);
+
     const fillRates = computeFillRates(scrapeResult.events);
 
     const mergeStart = Date.now();
@@ -475,6 +536,7 @@ export async function scrapeSource(
     diagnosticContext.scrapeDays = days;
     if (reconcileContext) diagnosticContext.reconciliation = reconcileContext;
     if (mergeResult.restored > 0) diagnosticContext.eventsRestored = mergeResult.restored;
+    if (silentSkip.skipped > 0) diagnosticContext.silentlySkipped = silentSkip;
 
     await updateScrapeLogWithResults({
       scrapeLogId: scrapeLog.id, startedAt, scrapeResult, mergeResult,


### PR DESCRIPTION
## What & why

Admin notes, "no run" holiday rows, and platform-departure announcements keep getting ingested as hash events. Cycle-13 (Houston PII) and cycle-14 (Miami #1728, Narwhal #1689) each patched this with a **one-off, hard-coded adapter regex**. This introduces **one systemic mechanism** and retrofits the one-offs onto it.

### Mechanism (#1739)
- `SilentSkipRule` type + shared matcher `src/adapters/skip-rules.ts`: field-targeted (`title`/`description`/`location`/`hares`) with an optional `unlessHashSignal` gate (a real `runNumber`/`hares`/"hash" rescues legit trails).
- Applied **centrally in `scrape.ts`** between `adapter.fetch()` and `processRawEvents()` — matched events never become RawEvents, never raise `SOURCE_KENNEL_MISMATCH`, and are invisible to the reconciler. `merge.ts` untouched.
- PII-safe audit trail in `ScrapeLog` diagnostics (field + title + date only — never raw `location`/`hares` values).
- ReDoS-safe config validation in `config-validation.ts`.

### Applied to fresh cases
- **ABQ H3** (#1783): admin OOO block `LYNNE OFF` (title match).
- **Hibiscus H3** (#1786): `no run` holiday rows (location match).
- **MoA2H3** (#1739's own example): sister-kennel events (DeMonH3/GLH3, which have their own sources) now drop silently instead of firing recurring `SOURCE_KENNEL_MISMATCH` alerts every 6h.

### Retrofit — behavior-preserving, kept global
- GCal medical filter (#1690 Houston) → shared `MEDICAL_SKIP_RES` (same gate, same dual summary/stripped-title check).
- Meetup admin-notice (#1689/#1728) → shared `PLATFORM_DEPARTURE_RES` (unconditional) + `FAREWELL_RES` (**now signal-gated**, so a real "Farewell Run Trail #42" / "Goodbye Trail #138" ingests — the one intentional, strictly-fewer-false-positives change). Existing fixtures stay green; **negative fixtures added**.

### Cleanup
Idempotent, **fail-closed** scripts (`scripts/cleanup-{abq-admin-note,hibiscus-no-run}.ts`) remove the two already-ingested phantom Events + their RawEvents. **Applied to prod**; re-runs are no-ops; prod re-verified clean (0 phantom events, 0 raws).

## Verification
- `npm run lint` (0 errors), `npx tsc --noEmit` (clean), `npm test` (**7954 passing**).
- **Live**: ran ABQ (GCal) + Hibiscus (Sheets) adapters against production with the new config — Hibiscus "no run" row dropped, 8 real events kept; ABQ 99 real events, **zero false-positive drops**.
- `/codex:adversarial-review` (found + fixed an over-delete in the cleanup scripts → scoped to event-linked raws + fail-closed on strays) and `/simplify` run before opening.

> Follow-up (out of scope): `facebook-hosted-events/constants.ts` keeps a parallel `ADMIN_NOTICE_PATTERNS` copy (applied unconditionally). Unifying FB onto this matcher is a clean follow-up; FB behavior is unchanged here.

Closes #1739
Closes #1783
Closes #1786

🤖 Generated with [Claude Code](https://claude.com/claude-code)