### PR TITLE
feat(kennels): Profile Round 15 — OC Hump, O2H3, NTKH4, NVHHH profile fields

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -873,7 +873,12 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "ochump", shortName: "OC Hump", fullName: "OC Hump Hash House Harriers", region: "Orange County, CA",
+      website: "http://www.hash.beer",
+      logoUrl: "https://hashboyh3.com/wp-content/uploads/2018/06/OC-Hump-Logo-150x150.jpg",
+      contactEmail: "dgleach2@gmail.com", contactName: "Balls Out for the Boyz",
+      founder: "Small Sandpiper", foundedYear: 1995, hashCash: "$6",
       scheduleDayOfWeek: "Wednesday", scheduleTime: "6:30 PM", scheduleFrequency: "Biweekly",
+      scheduleNotes: "Every other Wednesday at 6:30 PM in Orange County, with occasional Friday 6:30 PM trails and special runs.",
       description: "Orange County biweekly Wednesday evening hash.",
       latitude: 33.72, longitude: -117.83,
     },
@@ -1161,6 +1166,8 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "nvhhh", shortName: "NVHHH", fullName: "Nittany Valley Hash House Harriers", region: "State College, PA",
       website: "https://www.nvhhh.com/",
+      logoUrl: "https://nvhhh.com/images/nvhhh_logo.gif",
+      contactEmail: "hareraiser@nvhhh.com", twitterHandle: "nvhhh",
       scheduleDayOfWeek: "Monday", scheduleFrequency: "Weekly", scheduleTime: "6:30 PM",
       scheduleNotes: "Mondays 6:30 PM (summer); Sundays 3 PM (winter).",
       hashCash: "$5", foundedYear: 1990,
@@ -1725,7 +1732,7 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "o2h3", shortName: "O2H3", fullName: "Other Orlando Hash House Harriers", region: "Orlando, FL",
       website: "https://www.o2h3.net",
       facebookUrl: "https://www.facebook.com/OtherOrlandoH3/",
-      contactEmail: "hashcalendar@gmail.com",
+      contactEmail: "hashcalendar@gmail.com", hashCash: "$7",
       scheduleDayOfWeek: "Saturday", scheduleTime: "1:25 PM", scheduleFrequency: "Weekly",
       foundedYear: 1986,
       scheduleNotes: "Every Saturday afternoon + full moon evenings.",
@@ -2720,6 +2727,7 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "new-tokyo-katch", shortName: "NTKH4", fullName: "New Tokyo Katch the Hare Hash House Harriers", region: "Tokyo", country: "Japan",
       website: "https://newtokyohash.wixsite.com/newtokyokatchhash",
+      logoUrl: "https://static.wixstatic.com/media/74a0f6_85a0a91b884944e3a02710a8363dfeb8~mv2_d_1350_1435_s_2.jpeg/v1/fill/w_113,h_116,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/NTKH4_design.jpeg",
       scheduleFrequency: "Monthly",
       foundedYear: 1995,
       description: "Monthly Tokyo hash with a catch-the-hare format. Mix of regular runs, onsen runs, and annual overseas events.",

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -873,7 +873,7 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "ochump", shortName: "OC Hump", fullName: "OC Hump Hash House Harriers", region: "Orange County, CA",
-      website: "http://www.hash.beer",
+      website: "https://hash.beer",
       logoUrl: "https://hashboyh3.com/wp-content/uploads/2018/06/OC-Hump-Logo-150x150.jpg",
       contactEmail: "dgleach2@gmail.com", contactName: "Balls Out for the Boyz",
       founder: "Small Sandpiper", foundedYear: 1995, hashCash: "$6",


### PR DESCRIPTION
## Summary

Profile Round 15 — fills missing public-profile fields surfaced by `audit:chrome-kennel` **profile-bundle** findings for four kennels. Single-file change to `prisma/seed-data/kennels.ts`.

Seed merge is **fill-null-only** (`seed.ts:296-301`), so every value below was confirmed `null` in prod (queried live against Railway) and will actually propagate on the next `npx prisma db seed`.

### Filled

| Kennel | Fields added |
|---|---|
| **OC Hump** (`ochump`) | website `hash.beer`, logo, contactEmail, contactName `Balls Out for the Boyz`, founder `Small Sandpiper`, foundedYear `1995`, hashCash `$6`, scheduleNotes |
| **NVHHH** (`nvhhh`) | logo, hare-raiser contactEmail, twitterHandle `nvhhh` |
| **O2H3** (`o2h3`) | hashCash `$7` |
| **NTKH4** (`new-tokyo-katch`) | logo |

### Deferred / not-applicable (honest notes)

- **O2H3 logo** — the only available asset is a hotlink-protected Google Sites (`googleusercontent` `sitesv`) image that returns **403 cross-origin** and fails to render in-browser. Omitted rather than shipping a broken image; self-hosting is out of this PR's single-file scope. (An identical existing repo entry has the same broken behavior — pre-existing, untouched here.)
- **OC Hump** description prose + coordinate correction, **NVHHH** full-moon schedule + "second hash FREE" nuance, **O2H3/NTKH4** contact-page URLs — either already-populated (fill-null seed can't overwrite) or have no modeled `Kennel` field. Left for a follow-up.

### Dedup

#1798 and #1810 are both OC Hump profile-bundle findings (#1810 is the richer superset). Keeping the older #1798; **#1810 is closed as a duplicate** of #1798. This PR's edits cover both.

## Verification

- `npx prisma db seed` against local dev DB — clean; all targeted null fields filled (re-queried to confirm).
- Dev-server spot-check of `/kennels/oc-hump`, `/kennels/ntkh4`, `/kennels/nvhhh` — new fields render, logos load (OC Hump 150px, NTKH4 113px, NVHHH 165px).
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (280 files pass).
- `/simplify` — clean (4 agents, no findings). `/codex:adversarial-review` could not run (Codex usage limit, resets Jun 1); diff is data-only with no logic/regex/new code paths.

Closes #1798
Closes #1795
Closes #1794
Closes #1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)