### PR TITLE
fix(adapters): event-parse wave — run numbers, hares, all-day merge (5 issues)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1607,6 +1607,17 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "o2h3",
+        // #1796: O2H3 packs run number + a literal "Title:" label into the
+        // summary ("O2H3 #: 2340 Title: Grand Hash Ocoee 6: Hood Hustle",
+        // "O2H3# 2336 Green dress"). The `#:` colon form is parsed for the run
+        // number by the shared extractHashRunNumber; these patterns strip the
+        // leading kennel+number+label noise so the display title is just the
+        // theme. Char-class gaps ([\s#:]*) keep each pattern ReDoS-safe.
+        titleStripPatterns: [
+          String.raw`^O2H3[\s#:]*\d+[\s:]*`,
+          String.raw`^Title:\s*`,
+          String.raw`^[-\s]+`,
+        ],
       },
       kennelCodes: ["o2h3"],
     },
@@ -4445,6 +4456,10 @@ export const SOURCES = [
         // captures from that digit run to end-of-string.
         titleHarePattern: String.raw`^(.+?)\s+\d+\s+[A-Z]`,
         titleLocationPattern: String.raw`(\d+\s+.+?)\.?\s*$`,
+        // #1787: run number + theme live on an all-day "Run #2397 …"
+        // descriptor; start time + hare live on a same-date timed event
+        // ("3pm Scarlet"). Merge the pair into one event.
+        mergeAllDayRunDescriptor: true,
       },
       kennelCodes: ["capital-h3-au"],
     },

--- a/scripts/cleanup-mh3de-dup-events.ts
+++ b/scripts/cleanup-mh3de-dup-events.ts
@@ -1,0 +1,159 @@
+/**
+ * One-shot cleanup for the Munich H3 (mh3-de) duplicate / orphan canonical
+ * Events reported in #1784.
+ *
+ * Background:
+ *   The Munich shared GOOGLE_SHEETS source historically collapsed two
+ *   legitimate same-day MH3 runs (the Munich-area #938 and the Hashathon
+ *   co-host #939, both 20-Jun-26) onto one canonical row because the
+ *   pre-WS1 merge pipeline keyed canonical Events on (kennelId, date) alone.
+ *   WS1 added same-day double-header support (eventSignature keyed on
+ *   runNumber), so a re-scrape now yields #938 and #939 as two distinct rows.
+ *   A second artifact remained: an orphan #940 on 18-Jul-26. Its source row
+ *   (#941, "18-Jul-02") carries a year typo that parses to 2002 and is
+ *   filtered out of the scrape window, so the reconciler CANCELLED the row
+ *   but left it behind as a source-less phantom duplicating the real
+ *   4-Jul-26 #940.
+ *
+ * What this deletes (mh3-de only, narrow + verified):
+ *   1. ORPHANS — canonical Events with status=CANCELLED, ZERO backing
+ *      RawEvents, ZERO attendances, and no admin lock (adminCancelledAt null).
+ *      These have no source and cannot be re-created (the typo'd source row is
+ *      out of window). The 18-Jul-26 #940 phantom is the live instance.
+ *   2. TRUE DUPLICATES — if 2+ live (non-cancelled) Events still share the
+ *      same (date, runNumber), keep the best-supported one (most RawEvents,
+ *      then most attendances) and delete the rest, but ONLY when the
+ *      to-delete rows have ZERO attendances and no admin lock. As of the
+ *      pre-merge prod check the Jun-20 dup had already self-healed, so this
+ *      branch is defensive and a no-op on current prod.
+ *
+ * Canonical Events that still have RawEvents or attendances, or are
+ * admin-locked, are NEVER touched. EventKennel rows cascade on Event delete;
+ * EventLinks are removed explicitly first.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-mh3de-dup-events.ts
+ *   Apply:   CLEANUP_APPLY=1 npx tsx scripts/cleanup-mh3de-dup-events.ts
+ */
+
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const APPLY = process.env.CLEANUP_APPLY === "1";
+
+interface Candidate {
+  id: string;
+  date: string;
+  runNumber: number | null;
+  title: string | null;
+  reason: string;
+}
+
+async function main() {
+  const kennel = await prisma.kennel.findFirst({
+    where: { kennelCode: "mh3-de" },
+    select: { id: true, kennelCode: true, shortName: true },
+  });
+  if (!kennel) {
+    console.error("mh3-de kennel not found — aborting");
+    return;
+  }
+  console.log(`Kennel: ${kennel.shortName} (${kennel.kennelCode}) ${kennel.id}`);
+
+  const events = await prisma.event.findMany({
+    where: { kennelId: kennel.id },
+    select: {
+      id: true,
+      date: true,
+      runNumber: true,
+      title: true,
+      status: true,
+      adminCancelledAt: true,
+      rawEvents: { select: { id: true } },
+      attendances: { select: { id: true } },
+    },
+    orderBy: [{ date: "asc" }, { runNumber: "asc" }],
+  });
+
+  const isSafe = (e: (typeof events)[number]) =>
+    e.rawEvents.length === 0 && e.attendances.length === 0 && e.adminCancelledAt === null;
+
+  const toDelete: Candidate[] = [];
+
+  // 1. Orphans: cancelled, source-less, no attendances, unlocked.
+  for (const e of events) {
+    if (e.status === "CANCELLED" && isSafe(e)) {
+      toDelete.push({
+        id: e.id,
+        date: e.date.toISOString().slice(0, 10),
+        runNumber: e.runNumber,
+        title: e.title,
+        reason: "orphan (cancelled, 0 raws, 0 attns, unlocked)",
+      });
+    }
+  }
+
+  // 2. True duplicates among LIVE events sharing (date, runNumber).
+  const liveByKey = new Map<string, typeof events>();
+  for (const e of events) {
+    if (e.status === "CANCELLED" || e.runNumber == null) continue;
+    const key = `${e.date.toISOString().slice(0, 10)}#${e.runNumber}`;
+    let bucket = liveByKey.get(key);
+    if (!bucket) liveByKey.set(key, (bucket = []));
+    bucket.push(e);
+  }
+  const support = (e: (typeof events)[number]) => e.rawEvents.length * 1000 + e.attendances.length;
+  for (const [key, group] of liveByKey) {
+    if (group.length < 2) continue;
+    const ranked = [...group].sort((a, b) => support(b) - support(a));
+    const [keep, ...rest] = ranked;
+    console.log(`  duplicate group ${key}: keeping ${keep.id} (raws=${keep.rawEvents.length})`);
+    for (const e of rest) {
+      // Honor the same contract as the orphan branch: only delete a duplicate
+      // that is ALSO source-less (0 raws), attendance-free, and unlocked. A
+      // duplicate that still has backing RawEvents needs manual review — blind
+      // deletion would orphan its RawEvents and force a delete→regenerate churn.
+      if (isSafe(e)) {
+        toDelete.push({
+          id: e.id,
+          date: e.date.toISOString().slice(0, 10),
+          runNumber: e.runNumber,
+          title: e.title,
+          reason: `duplicate of ${keep.id} (lower support)`,
+        });
+      } else {
+        console.log(`    SKIP ${e.id} — has RawEvents, attendances, or admin lock; manual review`);
+      }
+    }
+  }
+
+  if (toDelete.length === 0) {
+    console.log("\nNothing to delete — prod is clean.");
+    return;
+  }
+
+  console.log(`\n${toDelete.length} canonical Event(s) flagged for deletion:`);
+  for (const c of toDelete) {
+    console.log(`  ${c.date}  #${c.runNumber}  ${JSON.stringify(c.title)}  — ${c.reason}  [${c.id}]`);
+  }
+
+  if (!APPLY) {
+    console.log("\nDRY RUN — set CLEANUP_APPLY=1 to delete.");
+    return;
+  }
+
+  const ids = toDelete.map((c) => c.id);
+  await prisma.$transaction(async (tx) => {
+    await tx.eventLink.deleteMany({ where: { eventId: { in: ids } } });
+    const del = await tx.event.deleteMany({ where: { id: { in: ids } } });
+    console.log(`\nDeleted ${del.count} Event(s) (EventKennel cascaded).`);
+  });
+
+  // Post-delete orphan check.
+  const remaining = await prisma.event.count({
+    where: { kennelId: kennel.id, status: "CANCELLED", rawEvents: { none: {} }, adminCancelledAt: null },
+  });
+  console.log(`Remaining source-less cancelled mh3-de Events: ${remaining}`);
+}
+
+main().then(() => prisma.$disconnect()).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/cleanup-mh3de-dup-events.ts
+++ b/scripts/cleanup-mh3de-dup-events.ts
@@ -169,4 +169,6 @@ async function main() {
   console.log(`Remaining source-less cancelled mh3-de Events: ${remaining}`);
 }
 
-main().then(() => prisma.$disconnect()).catch((e) => { console.error(e); process.exit(1); });
+main()
+  .catch((e) => { console.error(e); process.exitCode = 1; })
+  .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-mh3de-dup-events.ts
+++ b/scripts/cleanup-mh3de-dup-events.ts
@@ -49,6 +49,69 @@ interface Candidate {
   reason: string;
 }
 
+interface CleanupEvent {
+  id: string;
+  date: Date;
+  runNumber: number | null;
+  title: string | null;
+  status: string;
+  adminCancelledAt: Date | null;
+  rawEvents: { id: string }[];
+  attendances: { id: string }[];
+}
+
+/** An Event we may delete: source-less (0 raws), attendance-free, unlocked. */
+function isSafe(e: CleanupEvent): boolean {
+  return e.rawEvents.length === 0 && e.attendances.length === 0 && e.adminCancelledAt === null;
+}
+
+const candidate = (e: CleanupEvent, reason: string): Candidate => ({
+  id: e.id,
+  date: e.date.toISOString().slice(0, 10),
+  runNumber: e.runNumber,
+  title: e.title,
+  reason,
+});
+
+/** Cancelled, source-less, attendance-free, unlocked → safe to delete. */
+function findOrphans(events: CleanupEvent[]): Candidate[] {
+  return events
+    .filter((e) => e.status === "CANCELLED" && isSafe(e))
+    .map((e) => candidate(e, "orphan (cancelled, 0 raws, 0 attns, unlocked)"));
+}
+
+/**
+ * True duplicates among LIVE events sharing (date, runNumber): keep the
+ * best-supported row, delete the rest — but only when a to-delete row is ALSO
+ * `isSafe` (a duplicate with backing RawEvents needs manual review; blind
+ * deletion would orphan its raws and force a delete→regenerate churn).
+ */
+function findDuplicates(events: CleanupEvent[]): Candidate[] {
+  const liveByKey = new Map<string, CleanupEvent[]>();
+  for (const e of events) {
+    if (e.status === "CANCELLED" || e.runNumber == null) continue;
+    const key = `${e.date.toISOString().slice(0, 10)}#${e.runNumber}`;
+    let bucket = liveByKey.get(key);
+    if (!bucket) {
+      bucket = [];
+      liveByKey.set(key, bucket);
+    }
+    bucket.push(e);
+  }
+  const support = (e: CleanupEvent) => e.rawEvents.length * 1000 + e.attendances.length;
+  const out: Candidate[] = [];
+  for (const [key, group] of liveByKey) {
+    if (group.length < 2) continue;
+    const [keep, ...rest] = [...group].sort((a, b) => support(b) - support(a));
+    console.log(`  duplicate group ${key}: keeping ${keep.id} (raws=${keep.rawEvents.length})`);
+    for (const e of rest) {
+      if (isSafe(e)) out.push(candidate(e, `duplicate of ${keep.id} (lower support)`));
+      else console.log(`    SKIP ${e.id} — has RawEvents, attendances, or admin lock; manual review`);
+    }
+  }
+  return out;
+}
+
 async function main() {
   const kennel = await prisma.kennel.findFirst({
     where: { kennelCode: "mh3-de" },
@@ -75,57 +138,7 @@ async function main() {
     orderBy: [{ date: "asc" }, { runNumber: "asc" }],
   });
 
-  const isSafe = (e: (typeof events)[number]) =>
-    e.rawEvents.length === 0 && e.attendances.length === 0 && e.adminCancelledAt === null;
-
-  const toDelete: Candidate[] = [];
-
-  // 1. Orphans: cancelled, source-less, no attendances, unlocked.
-  for (const e of events) {
-    if (e.status === "CANCELLED" && isSafe(e)) {
-      toDelete.push({
-        id: e.id,
-        date: e.date.toISOString().slice(0, 10),
-        runNumber: e.runNumber,
-        title: e.title,
-        reason: "orphan (cancelled, 0 raws, 0 attns, unlocked)",
-      });
-    }
-  }
-
-  // 2. True duplicates among LIVE events sharing (date, runNumber).
-  const liveByKey = new Map<string, typeof events>();
-  for (const e of events) {
-    if (e.status === "CANCELLED" || e.runNumber == null) continue;
-    const key = `${e.date.toISOString().slice(0, 10)}#${e.runNumber}`;
-    let bucket = liveByKey.get(key);
-    if (!bucket) liveByKey.set(key, (bucket = []));
-    bucket.push(e);
-  }
-  const support = (e: (typeof events)[number]) => e.rawEvents.length * 1000 + e.attendances.length;
-  for (const [key, group] of liveByKey) {
-    if (group.length < 2) continue;
-    const ranked = [...group].sort((a, b) => support(b) - support(a));
-    const [keep, ...rest] = ranked;
-    console.log(`  duplicate group ${key}: keeping ${keep.id} (raws=${keep.rawEvents.length})`);
-    for (const e of rest) {
-      // Honor the same contract as the orphan branch: only delete a duplicate
-      // that is ALSO source-less (0 raws), attendance-free, and unlocked. A
-      // duplicate that still has backing RawEvents needs manual review — blind
-      // deletion would orphan its RawEvents and force a delete→regenerate churn.
-      if (isSafe(e)) {
-        toDelete.push({
-          id: e.id,
-          date: e.date.toISOString().slice(0, 10),
-          runNumber: e.runNumber,
-          title: e.title,
-          reason: `duplicate of ${keep.id} (lower support)`,
-        });
-      } else {
-        console.log(`    SKIP ${e.id} — has RawEvents, attendances, or admin lock; manual review`);
-      }
-    }
-  }
+  const toDelete: Candidate[] = [...findOrphans(events), ...findDuplicates(events)];
 
   if (toDelete.length === 0) {
     console.log("\nNothing to delete — prod is clean.");

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -1645,7 +1645,7 @@ describe("mergeAllDayRunDescriptor — Capital H3 descriptor↔timed merge (#178
     id?: string,
   ) =>
     buildRawEventFromGCalItem(
-      { summary, start, status: "confirmed", id, description } as never,
+      { summary, start, status: "confirmed", id, description },
       config,
       o,
     );
@@ -1741,7 +1741,7 @@ describe("mergeAllDayRunDescriptor — Capital H3 descriptor↔timed merge (#178
     const gcalIdMap = new WeakMap<RawEventData, string>();
     const plainConfig = { defaultKennelTag: "capital-h3-au" };
     const descriptor = buildRawEventFromGCalItem(
-      { summary: "Run #2397 Public Holiday - King's birthday", start: { date: "2026-06-08" }, status: "confirmed", id: "d6" } as never,
+      { summary: "Run #2397 Public Holiday - King's birthday", start: { date: "2026-06-08" }, status: "confirmed", id: "d6" },
       plainConfig,
       { allDayEventSet, gcalIdMap },
     );

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -15,6 +15,8 @@ import {
   normalizeGCalDescription,
   GoogleCalendarAdapter,
   dedupGCalEvents,
+  extractRunDescriptorTheme,
+  splitTimedSummaryHareLocation,
 } from "./adapter";
 import { compilePatterns } from "../utils";
 import type { RawEventData } from "../types";
@@ -1590,6 +1592,160 @@ describe("dedupGCalEvents — all-day vs timed collapse (#1199)", () => {
     );
     expect(allDayCollapsedCount).toBe(0);
     expect(deduped).toHaveLength(1);
+  });
+});
+
+describe("extractRunDescriptorTheme (#1787)", () => {
+  it.each<[string, string]>([
+    ["Run #2397 Public Holiday - King's birthday", "King's birthday"],
+    ["Run# 2396 Public Holiday - Reconciliation Day. ACT only", "Reconciliation Day. ACT only"],
+    ["Run #2395", ""],
+    ["Run #2398", ""],
+  ])("%j → %j", (input, expected) => {
+    expect(extractRunDescriptorTheme(input)).toBe(expected);
+  });
+});
+
+describe("splitTimedSummaryHareLocation (#1787)", () => {
+  it.each<[string, { hare: string; location?: string }]>([
+    ["Scarlet", { hare: "Scarlet" }],
+    ["Greasenipple - Park in Beagle Street Red Hill", { hare: "Greasenipple", location: "Park in Beagle Street Red Hill" }],
+    ["Hidden Flagon", { hare: "Hidden Flagon" }],
+  ])("%j", (input, expected) => {
+    expect(splitTimedSummaryHareLocation(input)).toEqual(expected);
+  });
+});
+
+describe("mergeAllDayRunDescriptor — Capital H3 descriptor↔timed merge (#1787)", () => {
+  // Mirrors the live Capital H3 config: run number + theme on an all-day
+  // "Run #N …" descriptor, start time + hare on a same-date timed event.
+  const config = {
+    defaultKennelTag: "capital-h3-au",
+    titleHarePattern: String.raw`^(.+?)\s+\d+\s+[A-Z]`,
+    titleLocationPattern: String.raw`(\d+\s+.+?)\.?\s*$`,
+    mergeAllDayRunDescriptor: true,
+  };
+  const opts = () => {
+    const allDayEventSet = new WeakSet<RawEventData>();
+    const gcalIdMap = new WeakMap<RawEventData, string>();
+    const summaryMap = new WeakMap<RawEventData, string>();
+    return {
+      allDayEventSet,
+      gcalIdMap,
+      summaryMap,
+      compiledTitleHarePatterns: compilePatterns([config.titleHarePattern], "i"),
+      compiledTitleLocationPatterns: compilePatterns([config.titleLocationPattern], "i"),
+    };
+  };
+  const build = (
+    summary: string,
+    start: { date: string } | { dateTime: string },
+    o: ReturnType<typeof opts>,
+    description?: string,
+    id?: string,
+  ) =>
+    buildRawEventFromGCalItem(
+      { summary, start, status: "confirmed", id, description } as never,
+      config,
+      o,
+    );
+
+  it("merges descriptor theme + run number into the timed sibling (hare from pristine summary, not a stray description)", () => {
+    const o = opts();
+    // The timed "Scarlet" event carries description "Public holiday" — the
+    // bare-title fallback would otherwise surface that as the title.
+    const descriptor = build("Run #2397 Public Holiday - King's birthday", { date: "2026-06-08" }, o, undefined, "d1");
+    const timed = build("Scarlet", { dateTime: "2026-06-08T15:00:00+10:00" }, o, "Public holiday", "t1");
+    const { events, runDescriptorMergedCount } = dedupGCalEvents(
+      [descriptor!, timed!],
+      o.gcalIdMap,
+      o.allDayEventSet,
+      true,
+      o.summaryMap,
+    );
+    expect(runDescriptorMergedCount).toBe(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      runNumber: 2397,
+      title: "King's birthday",
+      hares: "Scarlet",
+      startTime: "15:00",
+    });
+  });
+
+  it("splits 'Hare - Location' from the timed summary and keeps an empty-theme descriptor's run number", () => {
+    const o = opts();
+    const descriptor = build("Run #2395", { date: "2026-05-25" }, o, undefined, "d2");
+    const timed = build("Greasenipple - Park in Beagle Street Red Hill", { dateTime: "2026-05-25T18:00:00+10:00" }, o, undefined, "t2");
+    const { events } = dedupGCalEvents([descriptor!, timed!], o.gcalIdMap, o.allDayEventSet, true, o.summaryMap);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      runNumber: 2395,
+      hares: "Greasenipple",
+      location: "Park in Beagle Street Red Hill",
+      startTime: "18:00",
+    });
+    // Empty theme → title left undefined so merge.ts synthesizes the default.
+    expect(events[0].title).toBeUndefined();
+  });
+
+  it("strips the 'Public Holiday' boilerplate but keeps a trailing note (Run# no-space variant)", () => {
+    const o = opts();
+    const descriptor = build("Run# 2396 Public Holiday - Reconciliation Day. ACT only", { date: "2026-06-01" }, o, undefined, "d3");
+    const timed = build("Hidden Flagon", { dateTime: "2026-06-01T15:00:00+10:00" }, o, undefined, "t3");
+    const { events } = dedupGCalEvents([descriptor!, timed!], o.gcalIdMap, o.allDayEventSet, true, o.summaryMap);
+    expect(events[0]).toMatchObject({ runNumber: 2396, title: "Reconciliation Day. ACT only", hares: "Hidden Flagon" });
+  });
+
+  it("keeps a descriptor standalone when no timed sibling exists", () => {
+    const o = opts();
+    const descriptor = build("Run #2398", { date: "2026-06-15" }, o, undefined, "d4");
+    const { events, runDescriptorMergedCount } = dedupGCalEvents([descriptor!], o.gcalIdMap, o.allDayEventSet, true, o.summaryMap);
+    expect(runDescriptorMergedCount).toBe(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(2398);
+  });
+
+  it("merges the descriptor into the earliest timed sibling and leaves a second same-day timed event independent", () => {
+    const o = opts();
+    const descriptor = build("Run #2500", { date: "2026-08-01" }, o, undefined, "dd1");
+    const earlier = build("FirstHare", { dateTime: "2026-08-01T10:00:00+10:00" }, o, undefined, "tt1");
+    const later = build("SecondHare", { dateTime: "2026-08-01T18:00:00+10:00" }, o, undefined, "tt2");
+    const { events, runDescriptorMergedCount } = dedupGCalEvents(
+      [descriptor!, earlier!, later!],
+      o.gcalIdMap,
+      o.allDayEventSet,
+      true,
+      o.summaryMap,
+    );
+    expect(runDescriptorMergedCount).toBe(1);
+    expect(events).toHaveLength(2);
+    const merged = events.find((e) => e.startTime === "10:00")!;
+    const independent = events.find((e) => e.startTime === "18:00")!;
+    expect(merged).toMatchObject({ runNumber: 2500, hares: "FirstHare" });
+    // The second timed event keeps its own identity and does NOT inherit the run number.
+    expect(independent.runNumber).toBeUndefined();
+    expect(independent.hares ?? independent.title).toContain("SecondHare");
+  });
+
+  it("drops a non-run all-day campout (no run number) — over-admit guard", () => {
+    const o = opts();
+    const campout = build("Bike hash weekend away - Braidwood", { date: "2026-05-30" }, o, undefined, "d5");
+    expect(campout).toBeNull();
+  });
+
+  it("flag off: a run-numbered all-day descriptor is dropped as before (no admit, no merge)", () => {
+    // Same fixtures, but mergeAllDayRunDescriptor absent → all-day descriptor
+    // drops at the gate (no includeAllDayEvents) and only the timed survives.
+    const allDayEventSet = new WeakSet<RawEventData>();
+    const gcalIdMap = new WeakMap<RawEventData, string>();
+    const plainConfig = { defaultKennelTag: "capital-h3-au" };
+    const descriptor = buildRawEventFromGCalItem(
+      { summary: "Run #2397 Public Holiday - King's birthday", start: { date: "2026-06-08" }, status: "confirmed", id: "d6" } as never,
+      plainConfig,
+      { allDayEventSet, gcalIdMap },
+    );
+    expect(descriptor).toBeNull();
   });
 });
 
@@ -4607,6 +4763,28 @@ describe("buildRawEventFromGCalItem — jHav title suffix strip (#1429)", () => 
     ["colon suffix mixed-case", "Equi-Stava-Ganza: JHav Trail #2073", "Equi-Stava-Ganza", 2073],
     // No suffix → no strip, no false-positive.
     ["no suffix preserved verbatim", "If It Hurts, Sweetie, Be Sure To Tell Mommy", "If It Hurts, Sweetie, Be Sure To Tell Mommy", undefined],
+  ])("%s", (_, summary, expectedTitle, expectedRunNumber) => {
+    const event = buildRawEventFromGCalItem(testGCalEvent({ summary }), config, opts);
+    expect(event).not.toBeNull();
+    expect(event!.title).toBe(expectedTitle);
+    expect(event!.runNumber).toBe(expectedRunNumber);
+  });
+});
+
+describe("buildRawEventFromGCalItem — O2H3 #: colon run-number + title strip (#1796)", () => {
+  // Drive the test off the real seed config so the regression locks the
+  // shipped patterns. The `#:` colon form is parsed by the shared
+  // extractHashRunNumber ([\s:]* gap); titleStripPatterns drop the leading
+  // kennel+number+"Title:" label noise.
+  const seed = SOURCES.find((s) => s.name === "O2H3 Google Calendar");
+  const config = seed!.config as { defaultKennelTag: string; titleStripPatterns: string[] };
+  const opts = { compiledTitleStripPatterns: compilePatterns(config.titleStripPatterns, "i") };
+
+  it.each<[string, string, string, number | undefined]>([
+    ["colon + Title: label", "O2H3 #: 2340 Title: Grand Hash Ocoee 6: Hood Hustle", "Grand Hash Ocoee 6: Hood Hustle", 2340],
+    ["colon + dash prefix", "O2H3 #: 2335 -A Great Trail", "A Great Trail", 2335],
+    ["no-space hash", "O2H3# 2336 Green dress", "Green dress", 2336],
+    ["plain hash", "O2H3 #2355 Float Hash 2026", "Float Hash 2026", 2355],
   ])("%s", (_, summary, expectedTitle, expectedRunNumber) => {
     const event = buildRawEventFromGCalItem(testGCalEvent({ summary }), config, opts);
     expect(event).not.toBeNull();

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1879,12 +1879,12 @@ function isPlaceholderShell(e: RawEventData): boolean {
  * survives standalone (its numeric run number keeps `isPlaceholderShell` from
  * dropping it). Returns the surviving events plus the merge count.
  */
-function mergeRunDescriptorsIntoTimed(
+/** Index timed (non-all-day) events by `(kennelTag, date)`, earliest start
+ *  first (undefined last) — so a descriptor merges into the day's first run. */
+function indexTimedByKennelDate(
   events: RawEventData[],
   allDayEventSet: WeakSet<RawEventData>,
-  summaryMap?: WeakMap<RawEventData, string>,
-): { events: RawEventData[]; mergedCount: number } {
-  // Index timed events by (kennelTag, date); earliest start wins (undefined last).
+): Map<string, RawEventData[]> {
   const timedByKey = new Map<string, RawEventData[]>();
   for (const e of events) {
     if (allDayEventSet.has(e)) continue;
@@ -1896,25 +1896,39 @@ function mergeRunDescriptorsIntoTimed(
   for (const bucket of timedByKey.values()) {
     bucket.sort((a, b) => (a.startTime ?? "99:99").localeCompare(b.startTime ?? "99:99"));
   }
+  return timedByKey;
+}
 
+/** Copy a descriptor's run number + theme onto its timed sibling. Reads the
+ *  hare from the timed event's PRISTINE summary, not its post-pipeline title —
+ *  a stray `description` ("Public holiday") can override the title via the
+ *  bare-title fallback. Only fills fields the pipeline left empty, so the #1222
+ *  "hare + street address" titleHarePattern (which DOES populate hares) wins.
+ *  Empty theme → clears the title so merge.ts synthesizes "<Kennel> Trail #N". */
+function applyDescriptorToTimed(
+  descriptor: RawEventData,
+  timed: RawEventData,
+  summaryMap?: WeakMap<RawEventData, string>,
+): void {
+  const { hare, location } = splitTimedSummaryHareLocation(summaryMap?.get(timed) ?? timed.title ?? "");
+  if (!timed.hares && hare) timed.hares = hare;
+  if (!timed.location && location) timed.location = location;
+  timed.runNumber ??= descriptor.runNumber;
+  timed.title = descriptor.title ?? undefined;
+}
+
+function mergeRunDescriptorsIntoTimed(
+  events: RawEventData[],
+  allDayEventSet: WeakSet<RawEventData>,
+  summaryMap?: WeakMap<RawEventData, string>,
+): { events: RawEventData[]; mergedCount: number } {
+  const timedByKey = indexTimedByKennelDate(events, allDayEventSet);
   const descriptorsToRemove = new Set<RawEventData>();
   for (const descriptor of events) {
     if (!allDayEventSet.has(descriptor) || typeof descriptor.runNumber !== "number") continue;
     const timed = timedByKey.get(`${descriptor.kennelTags[0]}|${descriptor.date}`)?.[0];
     if (!timed) continue; // standalone descriptor survives
-    // Read the hare from the timed event's PRISTINE summary, not its
-    // post-pipeline title — a stray `description` ("Public holiday") can
-    // override the title via the bare-title fallback. Only fill fields the
-    // pipeline left empty so the #1222 "hare + street address" titleHarePattern
-    // (which DOES populate hares) is preserved.
-    const { hare, location } = splitTimedSummaryHareLocation(summaryMap?.get(timed) ?? timed.title ?? "");
-    if (!timed.hares && hare) timed.hares = hare;
-    if (!timed.location && location) timed.location = location;
-    // Adopt the descriptor's run number + theme. Empty theme → clear the
-    // (possibly description-corrupted) title so merge.ts synthesizes the
-    // default "<Kennel> Trail #N" rather than surfacing the hare/description.
-    timed.runNumber ??= descriptor.runNumber;
-    timed.title = descriptor.title ?? undefined;
+    applyDescriptorToTimed(descriptor, timed, summaryMap);
     descriptorsToRemove.add(descriptor);
   }
   const filtered = descriptorsToRemove.size ? events.filter((e) => !descriptorsToRemove.has(e)) : events;

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1869,6 +1869,55 @@ function isPlaceholderShell(e: RawEventData): boolean {
   return false;
 }
 
+/**
+ * #1787 Capital H3 pre-pass: merge each all-day run descriptor (run number +
+ * theme title) into its same-date timed sibling (start time + hare/location in
+ * the summary). A descriptor with no timed sibling is left untouched and
+ * survives standalone (its numeric run number keeps `isPlaceholderShell` from
+ * dropping it). Returns the surviving events plus the merge count.
+ */
+function mergeRunDescriptorsIntoTimed(
+  events: RawEventData[],
+  allDayEventSet: WeakSet<RawEventData>,
+  summaryMap?: WeakMap<RawEventData, string>,
+): { events: RawEventData[]; mergedCount: number } {
+  // Index timed events by (kennelTag, date); earliest start wins (undefined last).
+  const timedByKey = new Map<string, RawEventData[]>();
+  for (const e of events) {
+    if (allDayEventSet.has(e)) continue;
+    const key = `${e.kennelTags[0]}|${e.date}`;
+    const bucket = timedByKey.get(key);
+    if (bucket) bucket.push(e);
+    else timedByKey.set(key, [e]);
+  }
+  for (const bucket of timedByKey.values()) {
+    bucket.sort((a, b) => (a.startTime ?? "99:99").localeCompare(b.startTime ?? "99:99"));
+  }
+
+  const descriptorsToRemove = new Set<RawEventData>();
+  for (const descriptor of events) {
+    if (!allDayEventSet.has(descriptor) || typeof descriptor.runNumber !== "number") continue;
+    const timed = timedByKey.get(`${descriptor.kennelTags[0]}|${descriptor.date}`)?.[0];
+    if (!timed) continue; // standalone descriptor survives
+    // Read the hare from the timed event's PRISTINE summary, not its
+    // post-pipeline title — a stray `description` ("Public holiday") can
+    // override the title via the bare-title fallback. Only fill fields the
+    // pipeline left empty so the #1222 "hare + street address" titleHarePattern
+    // (which DOES populate hares) is preserved.
+    const { hare, location } = splitTimedSummaryHareLocation(summaryMap?.get(timed) ?? timed.title ?? "");
+    if (!timed.hares && hare) timed.hares = hare;
+    if (!timed.location && location) timed.location = location;
+    // Adopt the descriptor's run number + theme. Empty theme → clear the
+    // (possibly description-corrupted) title so merge.ts synthesizes the
+    // default "<Kennel> Trail #N" rather than surfacing the hare/description.
+    timed.runNumber ??= descriptor.runNumber;
+    timed.title = descriptor.title ?? undefined;
+    descriptorsToRemove.add(descriptor);
+  }
+  const filtered = descriptorsToRemove.size ? events.filter((e) => !descriptorsToRemove.has(e)) : events;
+  return { events: filtered, mergedCount: descriptorsToRemove.size };
+}
+
 export function dedupGCalEvents(
   events: RawEventData[],
   gcalIdMap: WeakMap<RawEventData, string>,
@@ -1877,48 +1926,11 @@ export function dedupGCalEvents(
   summaryMap?: WeakMap<RawEventData, string>,
 ): { events: RawEventData[]; compositeDedupedCount: number; allDayCollapsedCount: number; runDescriptorMergedCount: number } {
   let runDescriptorMergedCount = 0;
-  // #1787 Capital H3 pre-pass: merge an all-day run descriptor (run number +
-  // theme title) into its same-date timed sibling (start time + hare/location
-  // in the summary). Runs before the #1199 placeholder collapse. A descriptor
-  // with no timed sibling is left untouched and survives standalone (its
-  // numeric run number keeps isPlaceholderShell from dropping it).
+  // #1787: merge run descriptors before the #1199 placeholder collapse.
   if (mergeAllDayRunDescriptor) {
-    const timedByKey = new Map<string, RawEventData[]>();
-    for (const e of events) {
-      if (allDayEventSet.has(e)) continue;
-      const key = `${e.kennelTags[0]}|${e.date}`;
-      const bucket = timedByKey.get(key);
-      if (bucket) bucket.push(e);
-      else timedByKey.set(key, [e]);
-    }
-    // Earliest start wins when a date has multiple timed events (undefined last).
-    for (const bucket of timedByKey.values()) {
-      bucket.sort((a, b) => (a.startTime ?? "99:99").localeCompare(b.startTime ?? "99:99"));
-    }
-    const descriptorsToRemove = new Set<RawEventData>();
-    for (const descriptor of events) {
-      if (!allDayEventSet.has(descriptor) || typeof descriptor.runNumber !== "number") continue;
-      const timed = timedByKey.get(`${descriptor.kennelTags[0]}|${descriptor.date}`)?.[0];
-      if (!timed) continue; // standalone descriptor survives
-      // Read the hare from the timed event's PRISTINE summary, not its
-      // post-pipeline title — a stray `description` ("Public holiday") can
-      // override the title via the bare-title fallback. Only fill fields the
-      // pipeline left empty so the #1222 "hare + street address"
-      // titleHarePattern (which DOES populate hares) is preserved.
-      const rawSummary = summaryMap?.get(timed) ?? timed.title ?? "";
-      const { hare, location } = splitTimedSummaryHareLocation(rawSummary);
-      if (!timed.hares && hare) timed.hares = hare;
-      if (!timed.location && location) timed.location = location;
-      // Adopt the descriptor's run number, then its theme as the title — when
-      // the theme is empty (bare "Run #2398") clear the (possibly
-      // description-corrupted) title so merge.ts synthesizes "<Kennel> Trail
-      // #N" instead of showing the hare or stray description text.
-      if (timed.runNumber == null) timed.runNumber = descriptor.runNumber;
-      timed.title = descriptor.title ?? undefined;
-      descriptorsToRemove.add(descriptor);
-      runDescriptorMergedCount++;
-    }
-    if (descriptorsToRemove.size) events = events.filter((e) => !descriptorsToRemove.has(e));
+    const merged = mergeRunDescriptorsIntoTimed(events, allDayEventSet, summaryMap);
+    events = merged.events;
+    runDescriptorMergedCount = merged.mergedCount;
   }
 
   // #1199 pre-pass: drop placeholder all-day events when a timed sibling

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -109,6 +109,29 @@ function extractRunNumberFromDescription(
   return standaloneMatch ? Number.parseInt(standaloneMatch[1], 10) : undefined;
 }
 
+// #1787 Capital H3 — strip a leading "Run #NNNN" token plus a "Public
+// Holiday" boilerplate phrase from an all-day run descriptor, leaving just
+// the theme. Each regex uses a single char-class / `\s+` run with no
+// alternation adjacency, so Sonar S5852/S5843 read them as linear.
+const RUN_DESCRIPTOR_PREFIX_RE = /^\s*Run\b[\s#:]*\d+\s*/i;
+const PUBLIC_HOLIDAY_BOILERPLATE_RE = /\bPublic\s+Holiday\b/i;
+const DESCRIPTOR_EDGE_DELIMS_RE = /^[\s\-–—:.]+|[\s\-–—:.]+$/g;
+export function extractRunDescriptorTheme(summary: string): string {
+  let theme = summary.replace(RUN_DESCRIPTOR_PREFIX_RE, "");
+  theme = theme.replace(PUBLIC_HOLIDAY_BOILERPLATE_RE, "");
+  theme = theme.replace(DESCRIPTOR_EDGE_DELIMS_RE, "");
+  return theme.trim();
+}
+
+/** #1787 — split a Capital H3 timed-event summary into hare (+ optional
+ *  location). The summary is the hare name, optionally "Hare - Location".
+ *  Pure `indexOf`/`slice` (no regex) — ReDoS N/A. */
+export function splitTimedSummaryHareLocation(title: string): { hare: string; location?: string } {
+  const i = title.indexOf(" - ");
+  if (i < 0) return { hare: title.trim() };
+  return { hare: title.slice(0, i).trim(), location: title.slice(i + 3).trim() || undefined };
+}
+
 /** Strip the "Kennel: " or "Kennel #N: " prefix from a calendar summary to extract the event title. */
 export function extractTitle(summary: string): string {
   // Strip "Kennel: " or "Kennel #123: " prefix to get the event name
@@ -855,6 +878,23 @@ interface CalendarSourceConfig {
    * and re-scrape if the series ever goes live again.
    */
   suppressICalUids?: readonly string[];
+  /**
+   * #1787 Capital H3 (Canberra): this calendar publishes the run number (+ an
+   * optional theme) on an ALL-DAY descriptor event ("Run #2397 Public Holiday
+   * - King's birthday") and the start time / hares / location on a SEPARATE
+   * same-date TIMED event ("Scarlet", "Greasenipple - Park in Beagle St").
+   * When true:
+   *   1. an all-day event whose summary yields a run number is admitted even
+   *      without `includeAllDayEvents`, and its title is reduced to the theme;
+   *   2. in `dedupGCalEvents`, such a descriptor is merged into its same-date
+   *      (earliest-start) timed sibling — the descriptor contributes runNumber
+   *      + theme title, the timed event keeps its startTime and contributes
+   *      hares (+ location) parsed from its summary. Descriptors with no timed
+   *      sibling survive standalone (the run number still shows).
+   * All-day events with NO run number (campouts, "weekend away") keep their
+   * existing behavior (dropped unless `includeAllDayEvents`).
+   */
+  mergeAllDayRunDescriptor?: boolean;
   // Some calendars only populate the soonest-upcoming event's description, which
   // carries an inline schedule listing future dates and hares. After the scrape
   // finishes, back-fill `hares` on other events for the same kennelTag by
@@ -1133,6 +1173,11 @@ export interface BuildRawEventFromGCalItemOptions {
    *  `dedupGCalEvents` to drop placeholder all-day rows when a timed
    *  sibling exists for the same `(kennelTag, date)` (#1199 Giggity). */
   allDayEventSet?: WeakSet<RawEventData>;
+  /** Original decoded SUMMARY per built event. Used by the #1787 descriptor
+   *  merge to read a Capital H3 timed event's hare from its pristine summary
+   *  rather than the post-pipeline title (which a stray `description` can
+   *  override, e.g. summary "Scarlet" + description "Public holiday"). */
+  summaryMap?: WeakMap<RawEventData, string>;
 }
 
 /** Build a RawEventData from a single Google Calendar event item. Returns null if the item should be skipped. */
@@ -1152,6 +1197,7 @@ export function buildRawEventFromGCalItem(
     suppressedICalUidSet,
     gcalIdMap,
     allDayEventSet,
+    summaryMap,
   } = options;
   if (item.status === "cancelled") return null;
   // #1708: drop instances of dormant recurring series the kennel abandoned but
@@ -1176,7 +1222,17 @@ export function buildRawEventFromGCalItem(
   // so a carve-out would silently ingest unwanted all-day recurring instances on
   // sources that never opted in.
   const isAllDay = !!(item.start?.date && !item.start?.dateTime);
-  if (isAllDay && !sourceConfig?.includeAllDayEvents) return null;
+  if (isAllDay && !sourceConfig?.includeAllDayEvents) {
+    // #1787 Capital H3: admit an all-day run descriptor ("Run #2397 …") even
+    // without includeAllDayEvents so dedupGCalEvents can merge it into its
+    // same-date timed sibling. A descriptor is an all-day event whose summary
+    // yields a real run number; campouts / "weekend away" (no run number)
+    // still drop here.
+    const admitRunDescriptor =
+      sourceConfig?.mergeAllDayRunDescriptor === true &&
+      typeof extractRunNumber(decodeEntities(item.summary)) === "number";
+    if (!admitRunDescriptor) return null;
+  }
 
   const { dateISO, startTime } = extractDateTimeFromGCalItem(item.start, sourceConfig?.timezone);
   if (!dateISO) return null;
@@ -1710,13 +1766,21 @@ export function buildRawEventFromGCalItem(
     return null;
   }
 
+  // #1787: an admitted all-day run descriptor carries only the run number +
+  // a noisy "Public Holiday - <theme>" title. Reduce it to the theme so the
+  // dedup merge surfaces a clean title on the paired timed event (empty theme
+  // → undefined → merge.ts synthesizes the default "<Kennel> Trail #N").
+  const isRunDescriptor =
+    sourceConfig?.mergeAllDayRunDescriptor === true && isAllDay && typeof runNumber === "number";
+  const finalTitle = isRunDescriptor ? (extractRunDescriptorTheme(summary) || undefined) : title;
+
   const event: RawEventData = {
     date: dateISO,
     // Pass the full multi-kennel set (#1023): for single-tag patterns this
     // is `[primary]`; for array patterns it's the union of all matched kennels.
     kennelTags,
     runNumber,
-    title,
+    title: finalTitle,
     description: appendDescriptionSuffix(description, sourceConfig?.descriptionSuffix),
     hares,
     location: locationIsUrl ? undefined : location,
@@ -1731,6 +1795,7 @@ export function buildRawEventFromGCalItem(
   };
   if (gcalIdMap && item.id) gcalIdMap.set(event, item.id);
   if (allDayEventSet && isAllDay) allDayEventSet.add(event);
+  if (summaryMap) summaryMap.set(event, summary);
   return event;
 }
 
@@ -1808,7 +1873,54 @@ export function dedupGCalEvents(
   events: RawEventData[],
   gcalIdMap: WeakMap<RawEventData, string>,
   allDayEventSet: WeakSet<RawEventData>,
-): { events: RawEventData[]; compositeDedupedCount: number; allDayCollapsedCount: number } {
+  mergeAllDayRunDescriptor = false,
+  summaryMap?: WeakMap<RawEventData, string>,
+): { events: RawEventData[]; compositeDedupedCount: number; allDayCollapsedCount: number; runDescriptorMergedCount: number } {
+  let runDescriptorMergedCount = 0;
+  // #1787 Capital H3 pre-pass: merge an all-day run descriptor (run number +
+  // theme title) into its same-date timed sibling (start time + hare/location
+  // in the summary). Runs before the #1199 placeholder collapse. A descriptor
+  // with no timed sibling is left untouched and survives standalone (its
+  // numeric run number keeps isPlaceholderShell from dropping it).
+  if (mergeAllDayRunDescriptor) {
+    const timedByKey = new Map<string, RawEventData[]>();
+    for (const e of events) {
+      if (allDayEventSet.has(e)) continue;
+      const key = `${e.kennelTags[0]}|${e.date}`;
+      const bucket = timedByKey.get(key);
+      if (bucket) bucket.push(e);
+      else timedByKey.set(key, [e]);
+    }
+    // Earliest start wins when a date has multiple timed events (undefined last).
+    for (const bucket of timedByKey.values()) {
+      bucket.sort((a, b) => (a.startTime ?? "99:99").localeCompare(b.startTime ?? "99:99"));
+    }
+    const descriptorsToRemove = new Set<RawEventData>();
+    for (const descriptor of events) {
+      if (!allDayEventSet.has(descriptor) || typeof descriptor.runNumber !== "number") continue;
+      const timed = timedByKey.get(`${descriptor.kennelTags[0]}|${descriptor.date}`)?.[0];
+      if (!timed) continue; // standalone descriptor survives
+      // Read the hare from the timed event's PRISTINE summary, not its
+      // post-pipeline title — a stray `description` ("Public holiday") can
+      // override the title via the bare-title fallback. Only fill fields the
+      // pipeline left empty so the #1222 "hare + street address"
+      // titleHarePattern (which DOES populate hares) is preserved.
+      const rawSummary = summaryMap?.get(timed) ?? timed.title ?? "";
+      const { hare, location } = splitTimedSummaryHareLocation(rawSummary);
+      if (!timed.hares && hare) timed.hares = hare;
+      if (!timed.location && location) timed.location = location;
+      // Adopt the descriptor's run number, then its theme as the title — when
+      // the theme is empty (bare "Run #2398") clear the (possibly
+      // description-corrupted) title so merge.ts synthesizes "<Kennel> Trail
+      // #N" instead of showing the hare or stray description text.
+      if (timed.runNumber == null) timed.runNumber = descriptor.runNumber;
+      timed.title = descriptor.title ?? undefined;
+      descriptorsToRemove.add(descriptor);
+      runDescriptorMergedCount++;
+    }
+    if (descriptorsToRemove.size) events = events.filter((e) => !descriptorsToRemove.has(e));
+  }
+
   // #1199 pre-pass: drop placeholder all-day events when a timed sibling
   // exists for the same `(kennelTag, date)`. Sources with
   // `includeAllDayEvents: true` (WA Hash for CUNTh) admit both placeholder
@@ -1860,7 +1972,7 @@ export function dedupGCalEvents(
   // Skip the rebuild when nothing collapsed — saves an O(n) array copy on
   // the typical scrape where parallel-series duplicates don't exist.
   const result = compositeDedupedCount === 0 ? idDeduped : [...compositeMap.values()];
-  return { events: result, compositeDedupedCount, allDayCollapsedCount };
+  return { events: result, compositeDedupedCount, allDayCollapsedCount, runDescriptorMergedCount };
 }
 
 /** Google Calendar API v3 adapter. Fetches events from a public calendar and extracts kennel tags via configurable patterns. */
@@ -1899,6 +2011,11 @@ export class GoogleCalendarAdapter implements SourceAdapter {
     const compiled = compileSourceConfigPatterns(sourceConfig);
     const gcalIdMap = new WeakMap<RawEventData, string>();
     const allDayEventSet = new WeakSet<RawEventData>();
+    // Only the #1787 descriptor merge reads pristine summaries; skip the map
+    // entirely for the vast majority of sources that don't opt in.
+    const summaryMap = sourceConfig?.mergeAllDayRunDescriptor === true
+      ? new WeakMap<RawEventData, string>()
+      : undefined;
 
     const buildEvents = (items: GCalEvent[], filter?: (item: GCalEvent) => boolean): void => {
       let eventIndex = 0;
@@ -1908,7 +2025,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
           continue;
         }
         try {
-          const event = buildRawEventFromGCalItem(item, sourceConfig, { ...compiled, gcalIdMap, allDayEventSet });
+          const event = buildRawEventFromGCalItem(item, sourceConfig, { ...compiled, gcalIdMap, allDayEventSet, summaryMap });
           if (event) events.push(event);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -1974,7 +2091,8 @@ export class GoogleCalendarAdapter implements SourceAdapter {
 
     const hasErrorDetails = hasAnyErrors(errorDetails);
 
-    const { events: compositeDeduped, compositeDedupedCount, allDayCollapsedCount } = dedupGCalEvents(events, gcalIdMap, allDayEventSet);
+    const { events: compositeDeduped, compositeDedupedCount, allDayCollapsedCount, runDescriptorMergedCount } =
+      dedupGCalEvents(events, gcalIdMap, allDayEventSet, sourceConfig?.mergeAllDayRunDescriptor === true, summaryMap);
 
     return {
       events: compositeDeduped,
@@ -1988,6 +2106,7 @@ export class GoogleCalendarAdapter implements SourceAdapter {
         ...(exceptionsRecovered > 0 && { exceptionsRecovered }),
         ...(compositeDedupedCount > 0 && { compositeDeduped: compositeDedupedCount }),
         ...(allDayCollapsedCount > 0 && { allDayCollapsed: allDayCollapsedCount }),
+        ...(runDescriptorMergedCount > 0 && { runDescriptorMerged: runDescriptorMergedCount }),
       },
     };
   }

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1921,6 +1921,36 @@ function mergeRunDescriptorsIntoTimed(
   return { events: filtered, mergedCount: descriptorsToRemove.size };
 }
 
+/**
+ * #1199 pre-pass: drop placeholder all-day events when a timed sibling exists
+ * for the same `(kennelTag, date)`. Sources with `includeAllDayEvents: true`
+ * (WA Hash for CUNTh) admit both placeholder shells like "Giggity H3 #? (TBD)"
+ * and real timed runs; the merge pipeline collapses them into one canonical
+ * event by `(kennelId, date)`, so whichever survives this dedup wins. Prefer
+ * the timed one — but ONLY when the all-day event LOOKS like a placeholder. A
+ * real all-day event (campout, away weekend, RDR) sharing the date with a
+ * timed trail must survive so the merge pipeline can keep both via
+ * signature-based multi-event handling.
+ */
+function collapsePlaceholderAllDayEvents(
+  events: RawEventData[],
+  allDayEventSet: WeakSet<RawEventData>,
+): { events: RawEventData[]; collapsedCount: number } {
+  const timedKeys = new Set<string>();
+  for (const e of events) {
+    if (!allDayEventSet.has(e)) timedKeys.add(`${e.kennelTags[0]}|${e.date}`);
+  }
+  let collapsedCount = 0;
+  const filtered = events.filter((e) => {
+    const isCollapsible = allDayEventSet.has(e)
+      && timedKeys.has(`${e.kennelTags[0]}|${e.date}`)
+      && isPlaceholderShell(e);
+    if (isCollapsible) collapsedCount++;
+    return !isCollapsible;
+  });
+  return { events: filtered, collapsedCount };
+}
+
 export function dedupGCalEvents(
   events: RawEventData[],
   gcalIdMap: WeakMap<RawEventData, string>,
@@ -1936,34 +1966,9 @@ export function dedupGCalEvents(
     runDescriptorMergedCount = merged.mergedCount;
   }
 
-  // #1199 pre-pass: drop placeholder all-day events when a timed sibling
-  // exists for the same `(kennelTag, date)`. Sources with
-  // `includeAllDayEvents: true` (WA Hash for CUNTh) admit both placeholder
-  // shells like "Giggity H3 #? (TBD)" and real timed runs; the merge
-  // pipeline collapses them into one canonical event by `(kennelId, date)`,
-  // so whichever survives this dedup wins. Prefer the timed one — but ONLY
-  // when the all-day event LOOKS like a placeholder. A real all-day event
-  // (campout, away weekend, RDR) sharing the date with a timed trail must
-  // survive so the merge pipeline can keep both via signature-based
-  // multi-event handling. Placeholder evidence: missing run number AND
-  // (title contains `#?`, "TBD"/"TBA"/"TBC" placeholder marker, or
-  // hares/location are placeholder strings).
-  const timedKeys = new Set<string>();
-  for (const e of events) {
-    if (!allDayEventSet.has(e)) timedKeys.add(`${e.kennelTags[0]}|${e.date}`);
-  }
-  let allDayCollapsedCount = 0;
-  const timedFiltered = events.filter(e => {
-    if (
-      allDayEventSet.has(e)
-      && timedKeys.has(`${e.kennelTags[0]}|${e.date}`)
-      && isPlaceholderShell(e)
-    ) {
-      allDayCollapsedCount++;
-      return false;
-    }
-    return true;
-  });
+  const collapsed = collapsePlaceholderAllDayEvents(events, allDayEventSet);
+  const timedFiltered = collapsed.events;
+  const allDayCollapsedCount = collapsed.collapsedCount;
 
   const seen = new Set<string>();
   const idDeduped = timedFiltered.filter(e => {

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -115,11 +115,14 @@ function extractRunNumberFromDescription(
 // alternation adjacency, so Sonar S5852/S5843 read them as linear.
 const RUN_DESCRIPTOR_PREFIX_RE = /^\s*Run\b[\s#:]*\d+\s*/i;
 const PUBLIC_HOLIDAY_BOILERPLATE_RE = /\bPublic\s+Holiday\b/i;
-const DESCRIPTOR_EDGE_DELIMS_RE = /^[\s\-–—:.]+|[\s\-–—:.]+$/g;
+// Leading / trailing delimiters stripped as two separate anchored single
+// char-class passes — a combined `^X+|X+$` alternation trips Sonar S5852.
+const DESCRIPTOR_LEADING_DELIMS_RE = /^[\s\-–—:.]+/;
+const DESCRIPTOR_TRAILING_DELIMS_RE = /[\s\-–—:.]+$/;
 export function extractRunDescriptorTheme(summary: string): string {
   let theme = summary.replace(RUN_DESCRIPTOR_PREFIX_RE, "");
   theme = theme.replace(PUBLIC_HOLIDAY_BOILERPLATE_RE, "");
-  theme = theme.replace(DESCRIPTOR_EDGE_DELIMS_RE, "");
+  theme = theme.replace(DESCRIPTOR_LEADING_DELIMS_RE, "").replace(DESCRIPTOR_TRAILING_DELIMS_RE, "");
   return theme.trim();
 }
 

--- a/src/adapters/google-sheets/adapter.test.ts
+++ b/src/adapters/google-sheets/adapter.test.ts
@@ -1041,6 +1041,40 @@ describe("GoogleSheetsAdapter.fetch — groupFilter (#1542)", () => {
     expect(result.events.every((e) => e.kennelTags[0] === "mh3-de")).toBe(true);
   });
 
+  it("#1784 emits BOTH same-day MH3 runs (incl. 'MH3/ Hashathon' co-host) with distinct run numbers, skips siblings + date typos", async () => {
+    // Reproduces the live Munich sheet on the Jun-20 double-header day: a
+    // Munich-area MH3 run (#938) AND the Hashathon co-host run (#939, Group
+    // "MH3/ Hashathon") share one date. The tokenizer routes the co-host cell
+    // to mh3-de, so the adapter emits BOTH with distinct run numbers; WS1's
+    // merge same-day double-header support keeps them as two canonical events.
+    // The MFMH3 sibling is filtered out, and a date-typo row (18-Jul-02 →
+    // year 2002, far past) is dropped rather than producing a phantom.
+    const csv = [
+      "#,Date,Group,Start time,Hared by,Location,Notes",
+      `938,${testDateMDY},MH3,17:00,Loose Nutz & Motörmouth,,Munich-area trail`,
+      `939,${testDateMDY},MH3/ Hashathon,,Muddy Rucker,Gerlaser Forsthaus,Hashathon Weekend`,
+      `264,${testDateMDY},MFMH3,19:00,Moose Diver,Olympic Park,Full Moon sibling`,
+      `941,18-Jul-02,MH3,17:00,,,date typo → far past`,
+    ].join("\n");
+
+    mockedSafeFetch.mockResolvedValueOnce(mockFetchResponse(csv));
+
+    const config: GoogleSheetsConfig = {
+      sheetId: "munich",
+      csvUrl: "https://example.com/pub?output=csv",
+      columns: { runNumber: 0, date: 1, group: 2, startTime: 3, hares: 4, location: 5, description: 6 },
+      groupFilter: "MH3",
+      kennelTagRules: { default: "mh3-de" },
+    };
+    const adapter = new GoogleSheetsAdapter();
+    const result = await adapter.fetch(makeSource({ config: config as unknown as null }));
+
+    // Both Jun-20 MH3 runs survive with distinct run numbers; sibling + typo dropped.
+    expect(result.events.map((e) => e.runNumber).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([938, 939]);
+    expect(result.events.every((e) => e.kennelTags[0] === "mh3-de")).toBe(true);
+    expect(result.events.every((e) => e.date === result.events[0].date)).toBe(true);
+  });
+
   it("#1624 emits eventLabel: null on whole-token match so a stale prefix label clears (Codex review)", async () => {
     // A row that previously read "MH3 - Birthday" leaves a label on the
     // canonical Event. If the source reverts to plain "MH3", the adapter

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -194,6 +194,26 @@ describe("parseICalSummary", () => {
     expect(result.runNumber).toBe(2274);
     expect(result.title).toBe("Nice Trail");
   });
+
+  // Reading H3 (#1785)
+  it("keeps the theme after the run number (Reading #1202)", () => {
+    const result = parseICalSummary("RH3 #1202: Clowning Around Hash", [], "rh3");
+    expect(result.kennelTag).toBe("rh3");
+    expect(result.runNumber).toBe(1202);
+    expect(result.title).toBe("Clowning Around Hash");
+  });
+
+  it("rejects an unconfirmed-run placeholder and drops the bare marker title", () => {
+    const result = parseICalSummary("RH3: #120?", [], "rh3");
+    expect(result.runNumber).toBeUndefined();
+    expect(result.title).toBeUndefined();
+  });
+
+  it("strips a leading placeholder marker but keeps the theme", () => {
+    const result = parseICalSummary("RH3: #120? Kegs & Eggs", [], "rh3");
+    expect(result.runNumber).toBeUndefined();
+    expect(result.title).toBe("Kegs & Eggs");
+  });
 });
 
 describe("extractHaresFromDescription", () => {
@@ -203,6 +223,23 @@ describe("extractHaresFromDescription", () => {
 
   it("extracts multiple hares with &", () => {
     expect(extractHaresFromDescription("Hares: Alpha & Omega")).toBe("Alpha & Omega");
+  });
+
+  // Reading H3 (#1785) — clip hares at a standing "More details to cum"
+  // notice OR at the next inline field label (On-On / Hash Cash) when the
+  // kennel packs everything onto one DESCRIPTION line with no newline.
+  it.each<[string, string]>([
+    ["Hare: Sex Toys for Everyone More details to cum", "Sex Toys for Everyone"],
+    ["Hares: Dances with Whores More details to cum", "Dances with Whores"],
+    ["Hares: Decoy & More details to cum", "Decoy"],
+    ["Hare: Decoy More to come", "Decoy"],
+    // Live #1202: hares run straight into On-On: and Hash Cash: on one line.
+    [
+      "Hares: Sex Toys & Silence of the Goats On-On: Reading Regional Airport Hash Cash: $5 Note on out at 12pm",
+      "Sex Toys & Silence of the Goats",
+    ],
+  ])("clips the description trailer/fields from %j", (desc, expected) => {
+    expect(extractHaresFromDescription(desc)).toBe(expected);
   });
 
   it("handles ICS escaped newlines", () => {

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -176,11 +176,12 @@ function cleanHaresValue(value: string): string {
 }
 
 export function extractHaresFromDescription(description: string, customPatterns?: string[] | RegExp[]): string | undefined {
-  const patterns = customPatterns && customPatterns.length > 0
-    ? (typeof customPatterns[0] === "string"
+  let patterns: RegExp[] = HARE_PATTERNS;
+  if (customPatterns && customPatterns.length > 0) {
+    patterns = typeof customPatterns[0] === "string"
       ? compilePatterns(customPatterns as string[])
-      : customPatterns as RegExp[])
-    : HARE_PATTERNS;
+      : (customPatterns as RegExp[]);
+  }
   const hares = extractFieldFromDescription(description, patterns);
   return hares ? cleanHaresValue(hares) || undefined : undefined;
 }

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -166,8 +166,10 @@ const HARES_TRAILER_SEPARATORS_RE = /[\s&,;-]+$/;
 function cleanHaresValue(value: string): string {
   let cut = value.length;
   for (const re of HARES_FIELD_LABEL_RES) {
-    const m = re.exec(value);
-    if (m && m.index < cut) cut = m.index;
+    // `search` is stateless (no `lastIndex`) — safe even if a shared regex
+    // ever gains the global flag; we only need the match start index.
+    const index = value.search(re);
+    if (index >= 0 && index < cut) cut = index;
   }
   const lower = value.toLowerCase();
   for (const phrase of HARES_TRAILER_PHRASES) {

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -158,7 +158,9 @@ const HARES_TRAILER_PHRASES = [
   "more to come",
   "details to follow",
 ];
-const HARES_ON_ON_LABEL_RE = /On[\s-]?On\s*:.*$/i;
+// No `.*$` tail — cleanHaresValue only reads `.index` (the label start), and
+// the trailing `\s*:.*$` shape trips Sonar S5852.
+const HARES_ON_ON_LABEL_RE = /On[\s-]?On\s*:/i;
 const HARES_FIELD_LABEL_RES = [EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, HARES_ON_ON_LABEL_RE];
 const HARES_TRAILER_SEPARATORS_RE = /[\s&,;-]+$/;
 function cleanHaresValue(value: string): string {

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails, ParseError } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, compilePatterns, appendDescriptionSuffix, isPlaceholder } from "../utils";
+import { googleMapsSearchUrl, compilePatterns, appendDescriptionSuffix, isPlaceholder, extractHashRunNumber, hasPlaceholderRunNumber, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { enrichSFH3Events, markSFH3SeriesMembership } from "../html-scraper/sfh3-detail-enrichment";
 import { enrichBerlinH3Events } from "../html-scraper/berlin-h3-detail-enrichment";
@@ -65,9 +65,11 @@ export function parseICalSummary(
     kennelTag = defaultKennelTag ?? "UNKNOWN";
   }
 
-  // Extract run number: #1234 or #1234.56 or #1234A
-  const runMatch = summary.match(/#(\d+)/);
-  const runNumber = runMatch ? parseInt(runMatch[1], 10) : undefined;
+  // Extract run number via the shared helper: enforces the #1147 delimiter
+  // guard so an unconfirmed placeholder like Reading H3's "RH3: #120?"
+  // (#1785) rejects instead of parsing as a bogus 120, and accepts the
+  // fullwidth/`#:` colon variants for free.
+  const runNumber = extractHashRunNumber(summary);
 
   // Extract title: everything after "#{number}: " or "{kennel}: " or "{kennel} #{number}: "
   let title: string | undefined;
@@ -76,7 +78,11 @@ export function parseICalSummary(
     /^[A-Za-z0-9 .'-]+(?:\s*#[\d.A-Za-z]+)?:\s*(.+)$/,
   );
   if (titleMatch) {
-    title = titleMatch[1].trim() || undefined;
+    // Drop a leading unconfirmed-run placeholder ("#120?") that the kennel
+    // uses in place of a real run number (#1785): "RH3: #120? Kegs & Eggs" →
+    // "Kegs & Eggs"; a bare "RH3: #120?" → undefined so the caller can
+    // synthesize a default rather than surfacing the placeholder marker.
+    title = titleMatch[1].replace(/^#\d+\?+\s*/, "").trim() || undefined;
   }
 
   return { kennelTag, runNumber, title };
@@ -133,16 +139,50 @@ function extractFieldFromDescription(
  * Accepts pre-compiled RegExp[] or raw string[] (compiled on the fly for one-off use).
  * The adapter fetch() pre-compiles once per scrape for efficiency.
  */
-export function extractHaresFromDescription(description: string, customPatterns?: string[] | RegExp[]): string | undefined {
-  if (customPatterns && customPatterns.length > 0) {
-    const compiled = typeof customPatterns[0] === "string"
-      ? compilePatterns(customPatterns as string[])
-      : customPatterns as RegExp[];
-    if (compiled.length > 0) {
-      return extractFieldFromDescription(description, compiled);
-    }
+// Reading H3 (#1785) packs sibling fields onto the same DESCRIPTION line as
+// the hares, with no newline to terminate the `Hares:` capture: both
+// "Hares: Dances with Whores More details to cum" (a standing "details
+// coming later" notice) and "Hares: Sex Toys & Silence of the Goats On-On:
+// Reading Regional Airport Hash Cash: $5 …" (real fields running on). Clip the
+// captured hares at the earliest inline field-label boundary OR standing
+// trailer phrase, then drop any dangling separator.
+//
+// The field-label regexes are the shared set used by the GCal/HTML adapters;
+// On-On is Reading-specific and added locally. The trailer phrases are matched
+// procedurally (lowercase indexOf) to avoid the multi-`\s+` alternation shape
+// Sonar S5852 flags (memory: feedback_sonar_s5852_procedural_over_regex).
+const HARES_TRAILER_PHRASES = [
+  "more details to cum",
+  "more details to come",
+  "more details to follow",
+  "more to come",
+  "details to follow",
+];
+const HARES_ON_ON_LABEL_RE = /On[\s-]?On\s*:.*$/i;
+const HARES_FIELD_LABEL_RES = [EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, HARES_ON_ON_LABEL_RE];
+const HARES_TRAILER_SEPARATORS_RE = /[\s&,;-]+$/;
+function cleanHaresValue(value: string): string {
+  let cut = value.length;
+  for (const re of HARES_FIELD_LABEL_RES) {
+    const m = re.exec(value);
+    if (m && m.index < cut) cut = m.index;
   }
-  return extractFieldFromDescription(description, HARE_PATTERNS);
+  const lower = value.toLowerCase();
+  for (const phrase of HARES_TRAILER_PHRASES) {
+    const i = lower.indexOf(phrase);
+    if (i >= 0 && i < cut) cut = i;
+  }
+  return value.slice(0, cut).replace(HARES_TRAILER_SEPARATORS_RE, "").trim();
+}
+
+export function extractHaresFromDescription(description: string, customPatterns?: string[] | RegExp[]): string | undefined {
+  const patterns = customPatterns && customPatterns.length > 0
+    ? (typeof customPatterns[0] === "string"
+      ? compilePatterns(customPatterns as string[])
+      : customPatterns as RegExp[])
+    : HARE_PATTERNS;
+  const hares = extractFieldFromDescription(description, patterns);
+  return hares ? cleanHaresValue(hares) || undefined : undefined;
 }
 
 /**
@@ -479,7 +519,10 @@ function buildRawEventFromVEvent(
     date: dateStr,
     kennelTags: [parsed.kennelTag],
     runNumber,
-    title: parsed.title ?? summary,
+    // A summary that is only kennel + an unconfirmed-run placeholder
+    // ("RH3: #120?") has no real title — leave it undefined so the merge
+    // pipeline synthesizes a default rather than surfacing the marker (#1785).
+    title: parsed.title ?? (hasPlaceholderRunNumber(summary) ? undefined : summary),
     description: appendDescriptionSuffix(description?.substring(0, 2000) || undefined, config?.descriptionSuffix),
     hares,
     location,

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -943,6 +943,14 @@ describe("extractHashRunNumber", () => {
     ["ASCII with space", "FCH3 # 88", 88],
     ["ASCII with trailing colon", "BH3 #2781:", 2781],
     ["ASCII with comma delimiter", "Hash #100, hare needed", 100],
+    // O2H3 `#:` colon form (#1796) — `#`, optional space, colon, space, digits
+    ["O2H3 colon form", "O2H3 #: 2340 Title: Grand Hash Ocoee 6: Hood Hustle", 2340],
+    ["O2H3 colon dash form", "O2H3 #: 2335 -A Great Trail", 2335],
+    ["O2H3 no-space hash", "O2H3# 2336 Green dress", 2336],
+    ["O2H3 plain hash", "O2H3 #2355 Float Hash 2026", 2355],
+    // NVHHH spaced hash form (#1782)
+    ["NVHHH spaced hash", "NVHHH # 1882 Shh! It's a virgin lay", 1882],
+    ["NVHHH double-spaced hash", "NVHHH #  1882", 1882],
     // Fullwidth ＃ (U+FF03) — Japanese kennels
     ["fullwidth Kyoto", `Run＃132 Sunday June 25th "Bunter's North Side Trail!"`, 132],
     ["fullwidth with space", "＃55 trail", 55],

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -714,8 +714,13 @@ export function stripNonEnglishCountry(location: string): string {
  * variant (#1440). Shared by the Google Calendar summary path
  * (`extractRunNumber` in `google-calendar/adapter.ts`) and the Phoenix HHH
  * HTML scraper which preempts a stale-WordPress-slug fallback (#1211).
+ *
+ * The gap between the marker and the digits is `[\s:]*` so O2H3's `#: 2340`
+ * colon form parses (#1796) alongside the spaced `# 1882` and bare `#2355`
+ * variants. A single char-class quantifier (no `\s*`-adjacent alternation)
+ * keeps the pattern provably linear for Sonar S5852/S5843.
  */
-const HASH_RUN_NUMBER_RE = /[#＃]\s*(\d+)(?=$|[\s:\-–—,.()/])/;
+const HASH_RUN_NUMBER_RE = /[#＃][\s:]*(\d+)(?=$|[\s:\-–—,.()/])/;
 export function extractHashRunNumber(text: string | undefined): number | undefined {
   if (!text) return undefined;
   const m = HASH_RUN_NUMBER_RE.exec(text);


### PR DESCRIPTION
Quick Win bundle: 5 event-parse fixes across 5 adapters. Branched after WS1 (skip-rules retrofit + merge.ts same-day double-header support, both in `main`).

## Fixes

### #1796 — O2H3 nonstandard run numbers (`#:` colon form)
- Widened the **shared** `HASH_RUN_NUMBER_RE` gap from `\s*` to `[\s:]*` so `O2H3 #: 2340` parses (single char-class quantifier → ReDoS-safe; the `#30X?` placeholder guard is untouched).
- Added O2H3 `titleStripPatterns` to drop the `#: NNNN Title:` label noise → clean display title (`Grand Hash Ocoee 6: Hood Hustle`).

### #1782 — NVHHH spaced run number (`# 1882`)
- Already handled by the shared helper (the `\s*`/`[\s:]*` gap matches the space); the reported event was a stale **past** event (Mar 2025). Added a regression test to lock the behavior.

### #1785 — Reading H3 iCal (`title`, `haresText`)
- `parseICalSummary` now routes run-number extraction through the shared `extractHashRunNumber`, so the kennel's `#120?` "unconfirmed" placeholder rejects instead of storing a bogus `120`; a bare placeholder title is dropped so merge synthesizes a default.
- New `cleanHaresValue` clips hares at the earliest inline field label (`On-On:` / `Hash Cash:` / shared `EVENT_FIELD_LABEL_RE`) or a standing `More details to cum` trailer. Live-verified: the linked event now reads title `Clowning Around Hash`, hares `Sex Toys & Silence of the Goats`.

### #1784 — Munich MH3 GSheets dup #939 + orphan #940
- Regression test proves the adapter emits **both** same-day Jun-20 runs (#938 + #939, incl. the `MH3/ Hashathon` co-host cell) with distinct run numbers, skips the MFMH3 sibling, and drops the `18-Jul-02` date-typo row. The Jun-20 dup had already self-healed via WS1's merge double-header support.
- `scripts/cleanup-mh3de-dup-events.ts` (dry-run default) removed the stale source-less, cancelled Jul-18 orphan #940 from prod.

### #1787 — Capital H3 all-day descriptor ↔ timed merge (GCal)
- New per-source `mergeAllDayRunDescriptor` flag: admits an all-day `Run #N …` descriptor (carrying run number + theme) past the all-day gate and merges it into its same-date earliest-start timed sibling (which carries the start time + hare). The hare is read from the timed event's **pristine summary** (a stray `description: "Public holiday"` was overriding the title). Standalone descriptors survive; campouts (no run number) drop.
- Live-verified across 25 events: `#2397` → title `King's birthday`, hare `Scarlet`, 15:00.

## Verification
- Live-verified every affected source (Capital/NVHHH/O2H3 GCal, Reading localendar, Munich CSV).
- `npm run lint` (0 errors) · `npx tsc --noEmit` · `npm test` (8060 passing) all green.
- Adversarial review (Codex was rate-limited; substituted the code-reviewer agent) + `/simplify` run pre-PR; findings applied (cleanup-script contract tightened, `summaryMap` gated on the flag, hares-extraction branching collapsed, double-header hardening test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #1796
Closes #1785
Closes #1782
Closes #1784
Closes #1787
