### PR TITLE
feat(backfill): GCal history sweep — OC Hump, NVHHH, O2H3

### DIFF
--- a/scripts/backfill-nvhhh-history.ts
+++ b/scripts/backfill-nvhhh-history.ts
@@ -1,0 +1,35 @@
+/**
+ * One-shot historical backfill for NVHHH (Nittany Valley H3, kennel `nvhhh`).
+ * Issue #1781.
+ *
+ * The "Nittany Valley H3 Calendar" exposes older rows immediately before
+ * HashTracks' current historical floor (Mar 16 2025 / #1881). The recurring
+ * scrape's `scrapeDays: 365` window discards everything older than a year
+ * every run, so events like the Dec 29 2024 #1870 "First Last Hash of the
+ * Year" — and whatever the feed carries before that — never persist.
+ *
+ * Wide-window pull is safe — GOOGLE_CALENDAR is API-backed and reconcile only
+ * operates within its own window, so the older rows this writes stay stable
+ * across future scrapes (see scripts/lib/gcal-backfill.ts).
+ *
+ * Routing: defaultKennelTag is `nvhhh` (no kennelPatterns). Timezone is
+ * America/New_York (State College, PA) for the today-cutoff.
+ *
+ * Window: 6000 days ≈ 16.4 years — sized to capture whatever the feed holds;
+ * the GCal API returns only the events that exist, so over-sizing is harmless.
+ * The true archive depth is reported by the dry run.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-nvhhh-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-nvhhh-history.ts
+ *   Env:     GOOGLE_CALENDAR_API_KEY, DATABASE_URL
+ */
+
+import "dotenv/config";
+import { runGCalBackfill } from "./lib/gcal-backfill";
+
+runGCalBackfill({
+  sourceName: "Nittany Valley H3 Calendar",
+  days: 6000,
+  timezone: "America/New_York",
+});

--- a/scripts/backfill-o2h3-history.ts
+++ b/scripts/backfill-o2h3-history.ts
@@ -1,0 +1,43 @@
+/**
+ * One-shot historical backfill for O2H3 (Other Orlando H3, kennel `o2h3`).
+ *
+ * The "O2H3 Google Calendar" (hashcalendar@gmail.com) backs a kennel founded
+ * in 1986 with run numbers already past #2347, so a deep archive may exist
+ * behind the recurring scrape's `scrapeDays: 365` window. The dry run reports
+ * the true depth; if the feed only holds a year or two, this script recovers
+ * whatever exists (the GCal API returns only real events, so over-sizing the
+ * window is harmless).
+ *
+ * Wide-window pull is safe — GOOGLE_CALENDAR is API-backed and reconcile only
+ * operates within its own window, so the older rows this writes stay stable
+ * across future scrapes (see scripts/lib/gcal-backfill.ts).
+ *
+ * PARSER + CONFIG DEPENDENCY (#1796): O2H3 packs the run number and a literal
+ * "Title:" label into the summary ("O2H3 #: 2340 Title: ...", "O2H3# 2336").
+ * Correct extraction needs BOTH:
+ *   1. the rebased adapter — shared extractHashRunNumber now parses the `#:`
+ *      colon form (utils.ts gap widened to `[\s:]*`), AND
+ *   2. the O2H3 `titleStripPatterns` in Source.config, which the backfill
+ *      adapter reads from the PROD DB — so `npx prisma db seed` must have run
+ *      in prod before applying, or display titles keep the `#: NNNN Title:`
+ *      noise (run numbers extract regardless; only the title strip needs it).
+ * Backfilling against a stale adapter/config bakes durable, unrepairable
+ * historical rows that a later fix can't reach outside the scrape window —
+ * verify the dry-run samples show clean titles + numeric run numbers first.
+ *
+ * Window: 7500 days ≈ 20.5 years.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-o2h3-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-o2h3-history.ts
+ *   Env:     GOOGLE_CALENDAR_API_KEY, DATABASE_URL
+ */
+
+import "dotenv/config";
+import { runGCalBackfill } from "./lib/gcal-backfill";
+
+runGCalBackfill({
+  sourceName: "O2H3 Google Calendar",
+  days: 7500,
+  timezone: "America/New_York",
+});

--- a/scripts/backfill-oc-hump-history.ts
+++ b/scripts/backfill-oc-hump-history.ts
@@ -1,0 +1,31 @@
+/**
+ * One-shot historical backfill for OC Hump (kennel `ochump`). Issue #1809.
+ *
+ * The "OC Hump Google Calendar" enumerates a deep archive — the public feed
+ * carries 142 VEVENT entries spanning 2011-12-25 through 2026-07-22 — but the
+ * recurring scrape's `scrapeDays: 90` window discards everything older than ~3
+ * months every run, leaving HashTracks with only ~40 tracked events.
+ *
+ * Wide-window pull is safe — GOOGLE_CALENDAR is API-backed and reconcile only
+ * operates within its own window, so the older rows this writes stay stable
+ * across future scrapes (see scripts/lib/gcal-backfill.ts).
+ *
+ * Routing: defaultKennelTag is `ochump` (no kennelPatterns). Timezone is
+ * America/Los_Angeles (Orange County, CA) for the today-cutoff.
+ *
+ * Window: 6000 days ≈ 16.4 years — comfortably covers the 2011-12-25 floor.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-oc-hump-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-oc-hump-history.ts
+ *   Env:     GOOGLE_CALENDAR_API_KEY, DATABASE_URL
+ */
+
+import "dotenv/config";
+import { runGCalBackfill } from "./lib/gcal-backfill";
+
+runGCalBackfill({
+  sourceName: "OC Hump Google Calendar",
+  days: 6000,
+  timezone: "America/Los_Angeles",
+});


### PR DESCRIPTION
## What

Three one-shot wide-window Google Calendar historical backfills, each a thin wrapper over the shared `runGCalBackfill` helper (mirrors `scripts/backfill-noh3-history.ts`):

- `scripts/backfill-oc-hump-history.ts`
- `scripts/backfill-nvhhh-history.ts`
- `scripts/backfill-o2h3-history.ts`

## Why

The recurring per-source scrape uses a narrow symmetric window (OC Hump `scrapeDays: 90`, NVHHH/O2H3 `365`), so everything older than the window was discarded every run even though the GCal feeds enumerate a complete archive. A wide-window one-shot pull is safe — `GOOGLE_CALENDAR` is API-backed and the reconcile step only operates within its own window, so backfilled historical rows are stable across future scrapes. We deliberately did **not** bump `scrapeDays` in `sources.ts` (Path B); the one-shot script does the deep pull.

## Live verification (prod)

Idempotent re-run confirmed `created=0` (fingerprint stability):

| Kennel | Before | After | Recovered | Oldest | Merge result |
|---|---|---|---|---|---|
| OC Hump | 43 | 209 | +166 | 2012-04-04 | created=166 updated=16 blocked=0 errors=0 |
| NVHHH | 66 | 940 | +874 | 2009-12-31 | created=874 updated=13 blocked=0 errors=0 |
| O2H3 | 118 | 712 | +594 | 2011-01-01 | created=594 updated=36 blocked=0 errors=0 |

**Spot-checks (oldest / newest backfilled):**
- OC Hump: `2012-04-04 "OCH4 Head you said Head!!!!!!"` → `2026-05-27 "OC Hump Hash"`
- NVHHH: `2009-12-31 #7 "Blue Moon #7"`, `2010-01-02 #1127 "NVHHH #1127: Last First Hash of the Year"` → `2026-05-17 #1940 "Post Rothrock Challenge Trail"`
- O2H3: `2011-01-01 #1449 "Other Orlando H3 Trail #1449"` (empty source title → synthesized default) → `2026-05-30 #2347 "Blue Moon"`

**No merge duplicates.** Same-day multi-event groups were inspected and are legitimate double-headers — e.g. NVHHH `#1444 Run Cock Run` (18:30) + `Full Moon #251` (20:30), or O2H3 morning RDR hash + afternoon Red Dress pub crawl. Distinct fingerprints, correctly kept as separate canonical Events.

## O2H3 sequencing note

O2H3's calendar packs the run number + a literal `Title:` label into the summary (`O2H3 #: 2340 Title: ...`). Correct extraction depends on WS5's parse fix (#1796): the rebased `extractHashRunNumber` parses the `#:` colon form (`[\s:]*` gap) and the seeded O2H3 `titleStripPatterns` strip the label noise. This branch was rebased onto current `main` (the fix is present) and prod config is seeded — verified **0 title-noise across all 693 events**. O2H3 has no dedicated backfill issue (#1795 profile + #1796 parse already closed by WS5), so this just recovers its history.

## Checks

`npm run lint` (0 errors) · `npx tsc --noEmit` green · `npm test` 8084 passed. Independent adversarial review + `/simplify` pass: clean, ship as-is.

Closes #1809
Closes #1781

🤖 Generated with [Claude Code](https://claude.com/claude-code)