### PR TITLE
feat(seed): onboard WSH3 (Winterthur & Schaffhausen H3, Switzerland) via Meetup

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -355,6 +355,8 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
 
     // ===== SWITZERLAND =====
     "zh3": ["ZH3", "Zurich Hash House Harriers", "Zürich Hash House Harriers", "Zurich H3", "The Zurich Hash House Harriers"],
+    // Keyed "wsh3-ch" (NOT "wsh3" → Wandering Soul H3). Bare "WSH3" alias omitted (claimed).
+    "wsh3-ch": ["Winterthur & Schaffhausen Hash House Harriers", "Winterthur & Schaffhausen H3", "Winterthur Schaffhausen H3", "W&S H3", "WSH3 Switzerland"],
 
     // ===== LOUISIANA =====
     "noh3": ["NOH3", "New Orleans Hash", "New Orleans HHH", "New Orleans H3", "NOLA Hash"],

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1145,6 +1145,21 @@ export const KENNELS: KennelSeed[] = [
       description: "Zürich's English-speaking hash — 'a drinking club with a running problem.' Reformed in 1990, ZH3 lays a new flour trail around Zürich every Thursday evening, plus the first Saturday and third Sunday of each month, finishing with a beer circle. Walkers and runners of all abilities welcome; ~4–7 km trails.",
       latitude: 47.37, longitude: 8.54,
     },
+    {
+      // kennelCode is "wsh3-ch", NOT "wsh3" — bare "wsh3" is Wandering Soul H3
+      // (Birmingham, AL). Mirrors the swh3 → swh3-or country-suffix precedent.
+      kennelCode: "wsh3-ch", shortName: "WSH3", fullName: "Winterthur & Schaffhausen Hash House Harriers",
+      region: "Winterthur", country: "Switzerland",
+      hashCash: "CHF 5",
+      // Legacy flat fields kept for fallback only — scheduleRules below are authoritative.
+      scheduleDayOfWeek: "Saturday", scheduleTime: "2:00 PM", scheduleFrequency: "Monthly",
+      scheduleNotes: "Third Saturday of the month; meeting point varies around the Schaffhausen area, usually reachable by public transport. Location each month via Meetup.",
+      scheduleRules: [
+        { rrule: "FREQ=MONTHLY;BYDAY=3SA", startTime: "14:00", label: "3rd Saturday", displayOrder: 0 },
+      ],
+      description: "Winterthur & Schaffhausen's English-speaking hash — 'a drinking club with a running problem.' WSH3 lays a flour trail on the third Saturday of each month around the Winterthur and Schaffhausen area of northern Switzerland, usually meeting at a public-transport-accessible point near Schaffhausen, and finishes with an On-After at a local restaurant. Runners and walkers of all abilities welcome.",
+      latitude: 47.5, longitude: 8.72,
+    },
     // ===== PENNSYLVANIA (outside Philly) =====
     // --- Pittsburgh ---
     {

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3535,6 +3535,25 @@ export const SOURCES = [
       },
       kennelCodes: ["zh3"],
     },
+    {
+      // The queue originally proposed this Meetup; an onboarding handoff claimed
+      // it was dead and tried to pivot to a swisshash.ch Google Calendar — but
+      // swisshash.ch (and the kennel's stated schaffhausen-h3.com) are both
+      // NXDOMAIN, while this group is live (950 members, monthly hareline).
+      name: "Winterthur & Schaffhausen H3 Meetup",
+      url: "https://www.meetup.com/winterthur_schaffhausenhhh/",
+      type: "MEETUP" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 365, // monthly hareline runs ~12 events out; 90d would truncate
+      config: {
+        groupUrlname: "winterthur_schaffhausenhhh",
+        kennelTag: "wsh3-ch",
+        // extractRunNumber OFF — titles are free-form prose ("WSH3 Summer
+        // Solstice Trail", "WSH3 tbd"), no "#NNN" run numbers to extract.
+      },
+      kennelCodes: ["wsh3-ch"],
+    },
 
     // ===== NETHERLANDS =====
     {

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -3157,7 +3157,7 @@ const COUNTRY_INFERENCE_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   [/\b(japan|tokyo|osaka)\b/, "Japan"],
   [/\b(belgium|brussels|bruxelles|antwerp|ghent)\b/, "Belgium"],
   [/\b(spain|españa|espana|costa del sol|mijas|malaga|málaga|marbella|fuengirola|andalucia|andalucía|madrid|barcelona)\b/, "Spain"],
-  [/\b(switzerland|schweiz|suisse|svizzera|zurich|zürich|geneva|bern|basel)\b/, "Switzerland"],
+  [/\b(switzerland|schweiz|suisse|svizzera|zurich|zürich|geneva|bern|basel|winterthur|schaffhausen)\b/, "Switzerland"],
   [/\b(netherlands|amsterdam|rotterdam|den haag|the hague|holland)\b/, "Netherlands"],
   [/\b(denmark|copenhagen|københavn|aarhus)\b/, "Denmark"],
   [/\b(sweden|stockholm|göteborg|gothenburg|malmö)\b/, "Sweden"],

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -1779,6 +1779,17 @@ export const REGION_SEED_DATA: RegionSeedRecord[] = [
     centroidLng: 8.54,
     aliases: ["Zurich", "Zürich, Switzerland"],
   },
+  {
+    name: "Winterthur",
+    country: "Switzerland",
+    timezone: "Europe/Zurich",
+    abbrev: "WIN",
+    colorClasses: "bg-red-100 text-red-700",
+    pinColor: "#f87171",
+    centroidLat: 47.5,
+    centroidLng: 8.72,
+    aliases: ["Winterthur, Switzerland", "Schaffhausen"],
+  },
   // ── Louisiana ──
   {
     name: "Louisiana",
@@ -3394,6 +3405,7 @@ const STATE_GROUP_MAP: Record<string, string> = {
   "Oslo": "Norway",
   // Switzerland
   "Zürich": "Switzerland",
+  "Winterthur": "Switzerland",
   // Malaysia — Kuala Lumpur is a Federal Territory (state-equivalent),
   // NOT part of Selangor. Penang Island is a metro under Penang state.
   "Kuala Lumpur, MY": "Kuala Lumpur, MY",


### PR DESCRIPTION
## Summary

Onboards the **Winterthur & Schaffhausen Hash House Harriers** (WSH3) — an active Swiss kennel (950 Meetup members, ~monthly 3rd-Saturday hareline) — as kennelCode **`wsh3-ch`**. Switzerland's 2nd live kennel, after ZH3. Config-only: seed rows + region records, zero new adapter code.

## ⚠️ Source correction vs the onboarding handoff

The handoff brief instructed pivoting **away** from the "dead" Meetup to a `swisshash.ch` Google Calendar aggregator. **Live verification inverted both claims:**

| Brief claimed | Reality (verified 2026-05-30 via browser DNS/DOM) |
|---|---|
| Meetup group is dead (0 upcoming / 0 past) | **Live**: 950 members, **12 upcoming + 307 past** events |
| Real source = `swisshash.ch/hash-calendar/` GCal | **`swisshash.ch` is NXDOMAIN** — not registered. No calendar exists |
| Kennel website = swisshash.ch | Group lists `schaffhausen-h3.com` — **also NXDOMAIN** |

`dns.google` returns NXDOMAIN for both `swisshash.ch` and `schaffhausen-h3.com` (authority is the bare `.ch` TLD SOA — no records). The **Meetup group the queue originally proposed is the only live source**, so this onboards via the config-driven `MEETUP` adapter (same shape as the sibling ZH3 Meetup source).

## Changes
- **`prisma/seed-data/kennels.ts`** — WSH3 kennel. `kennelCode: "wsh3-ch"` (bare `wsh3` is **Wandering Soul H3, Birmingham AL** — `kennels.ts:3251`), mirrors the `swh3 → swh3-or` country-suffix precedent.
- **`prisma/seed-data/aliases.ts`** — `"wsh3-ch"` alias entry. Bare `"WSH3"` alias **omitted** (claimed by Wandering Soul).
- **`prisma/seed-data/sources.ts`** — `MEETUP` source (`groupUrlname: "winterthur_schaffhausenhhh"`, `kennelTag: "wsh3-ch"`, `scrapeDays: 365` to fit the ~17-month monthly hareline; `extractRunNumber` off — titles are free-form prose).
- **`src/lib/region.ts`** — Winterthur METRO + `STATE_GROUP_MAP` entry. Switzerland COUNTRY + Zürich METRO already shipped with ZH3.

## Metadata (Meetup About page — the authoritative source)
- **Schedule:** third Saturday of the month → `FREQ=MONTHLY;BYDAY=3SA`. (Brief's "alternating Thursday/Saturday" was wrong.)
- **Hash cash:** CHF 5. (Brief said CHF 10.)
- **Run numbers:** none — titles are "WSH3 Summer Solstice Trail", "WSH3 tbd". (Brief's "#412/#413/#414" was fiction.)
- **foundedYear / contactEmail / website:** **omitted** — their only source was the non-existent swisshash.ch, so unverified.

## Live verification (`MeetupAdapter.fetch`, days=365)
```
event count: 21        errors: []
distinct kennelTags: [ 'wsh3-ch' ]      contaminates bare 'wsh3'? false
date range: 2025-04-19 → 2027-05-15     upcoming (future): 12
startTime format: all valid HH:MM
sample: "WSH3 Summer Solstice Trail" 2026-06-20 17:00 @ Schaffhausen SBB → wsh3-ch
        "WSH3 tbd" 2026-07-18 14:00 @ Schaffhausen SBB → wsh3-ch
```
(`date` is emitted as `YYYY-MM-DD`; merge normalizes to UTC noon via `parseUtcNoonDate`.)

**Checks:** `tsc --noEmit` clean · `lint` 0 errors · **8084 tests pass** (incl. seed-validation suites). `/simplify` run — clean (mirrors ZH3 precedent).

## Deep-dive checklist
- [x] kennelCode collision-checked (`wsh3` taken → `wsh3-ch`) · bare `WSH3` alias omitted
- [x] source live-verified (Meetup live; swisshash.ch/schaffhausen-h3.com NXDOMAIN)
- [x] schedule (3rd-Sat scheduleRules) · [x] hashCash (CHF 5) · [x] description
- [x] region (Winterthur METRO + group map) · [x] coord sanity (Meetup, no per-event lat/lng)
- [~] logo / socials / foundedYear / email — none verifiable (sole source was a dead domain); **follow-up**
- [x] history depth assessed (Meetup carries 307 past; adapter pulls the window — no separate backfill needed)

## Post-merge runbook
`git checkout main && git pull` → verify files landed → `npx prisma db seed` → trigger a scrape from `/admin/sources` → spot-check the kennel page on hashtracks.xyz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)