### PR TITLE
fix(gcal): O-cluster A — location leaks, Oregon Kahuna misroute, OCHHH/Oregon profiles (6 issues)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -924,8 +924,8 @@ export const KENNELS: KennelSeed[] = [
     // Orange County
     {
       kennelCode: "ochhh", shortName: "OCHHH", fullName: "Orange County Hash House Harriers", region: "Orange County, CA",
-      scheduleDayOfWeek: "Saturday", scheduleTime: "10:00 AM", scheduleFrequency: "Monthly",
-      description: "Orange County monthly Saturday morning hash.",
+      scheduleDayOfWeek: "Saturday", scheduleTime: "10:00 AM", scheduleFrequency: "Biweekly",
+      description: "Orange County biweekly Saturday morning hash.",
       latitude: 33.72, longitude: -117.83,
     },
     {
@@ -2168,9 +2168,10 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "oh3", shortName: "Oregon H3", fullName: "Oregon Hash House Harriers",
       region: "Portland, OR",
       website: "https://www.oregonhhh.org/",
-      scheduleDayOfWeek: "Saturday", scheduleTime: "1:00 PM", scheduleFrequency: "Biweekly",
-      scheduleNotes: "Bi-weekly Saturdays plus full moon runs",
-      description: "Oregon's flagship kennel. Bi-weekly Saturday afternoon trails plus full moon evening runs in the Portland metro area.",
+      foundedYear: 1987,
+      scheduleDayOfWeek: "Saturday", scheduleTime: "1:00 PM", scheduleFrequency: "Biweekly + Full Moon",
+      scheduleNotes: "2nd & 4th Saturdays at 1pm plus Full Moon evening runs. Hotline 866-656-5477 for run info.",
+      description: "Founded 17 May 1987 by Wrong Way Corrigan — THE Mother Hash of Oregon. Biweekly Saturday afternoon trails plus Full Moon evening runs in the Portland metro area. Tyrant I and founder: Mark 'Wrong Way Corrigan' Cook.",
       latitude: 45.52, longitude: -122.68,
     },
     {

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2289,12 +2289,26 @@ export const SOURCES = [
           ["Cherry City|Cherry Cherry City", "cch3-or"],
         ],
         defaultKennelTag: "oh3",
-        // Drop N2H3 / NNH3 events that leak into this shared aggregator.
-        // N2H3 has its own No Name H3 Calendar source (trust 8), so skipping
-        // here avoids cross-kennel duplicates on the Oregon H3 hareline.
-        // Anchored so joint co-host titles with the local kennel stay put.
-        // Closes #584.
-        skipPatterns: ["^NNH3\\b", "^N2H3\\b", "^No Name\\b"],
+        // Drop sibling-kennel events that leak into this shared aggregator and
+        // already have their own dedicated calendar source, so they don't get
+        // dumped into the OH3 default bucket (cross-kennel misattribution):
+        //   - N2H3 / NNH3 → No Name H3 Calendar (trust 8). Closes #584.
+        //   - Kahuna / Ka3na / Katuna / Kah-Two-Na / Ka-Three-Na → Kahuna H3
+        //     Calendar (okh3, trust 8). The Oregon feed cross-posts Kahuna's
+        //     Monday runs ("Kahuna H3 #815 …", "Kahuna pick up hash!", etc.)
+        //     which were landing on oh3. #1867.
+        // Anchored so joint co-host titles led by the local kennel ("OH3 #1336
+        // / Kahuna combo") are NOT skipped — they stay on oh3.
+        skipPatterns: [
+          "^NNH3\\b",
+          "^N2H3\\b",
+          "^No Name\\b",
+          "^Kahuna\\b",
+          "^Ka3na\\b",
+          "^Katuna\\b",
+          "^Kah-Two-Na\\b",
+          "^Ka-Three-Na\\b",
+        ],
       },
       kennelCodes: ["oh3", "tgif", "cch3-or"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2300,14 +2300,14 @@ export const SOURCES = [
         // Anchored so joint co-host titles led by the local kennel ("OH3 #1336
         // / Kahuna combo") are NOT skipped — they stay on oh3.
         skipPatterns: [
-          "^NNH3\\b",
-          "^N2H3\\b",
-          "^No Name\\b",
-          "^Kahuna\\b",
-          "^Ka3na\\b",
-          "^Katuna\\b",
-          "^Kah-Two-Na\\b",
-          "^Ka-Three-Na\\b",
+          String.raw`^NNH3\b`,
+          String.raw`^N2H3\b`,
+          String.raw`^No Name\b`,
+          String.raw`^Kahuna\b`,
+          String.raw`^Ka3na\b`,
+          String.raw`^Katuna\b`,
+          String.raw`^Kah-Two-Na\b`,
+          String.raw`^Ka-Three-Na\b`,
         ],
       },
       kennelCodes: ["oh3", "tgif", "cch3-or"],

--- a/scripts/cleanup-oregon-kahuna-misroute.ts
+++ b/scripts/cleanup-oregon-kahuna-misroute.ts
@@ -1,0 +1,143 @@
+/**
+ * One-shot cleanup for the Oregon Hashing Calendar Kahuna/OKH3 misattribution
+ * reported in #1867.
+ *
+ * Background:
+ *   The shared Oregon Hashing Calendar (GOOGLE_CALENDAR) cross-posts Kahuna H3
+ *   (okh3) trails. Before PR (this change) the aggregate had no Kahuna routing
+ *   pattern, so every "Kahuna …" / "Kah-Two-Na" / "Ka-Three-Na" title fell
+ *   through to `defaultKennelTag: "oh3"` and landed on Oregon H3. okh3 has its
+ *   OWN dedicated calendar source, so the PR adds these prefixes to the Oregon
+ *   aggregate's `skipPatterns` (same precedent as No Name H3). Future scrapes
+ *   no longer create these rows on oh3.
+ *
+ *   This script repairs the already-ingested canonical Events. okh3's own
+ *   calendar does NOT cover these historical 2025 dates (verified), so they are
+ *   REASSIGNED to okh3 (not deleted) to preserve the kennel's history — per the
+ *   reassign-don't-insert precedent. A row is deleted only if okh3 already has a
+ *   confirmed event on the same date (a true duplicate).
+ *
+ * Why reassignment survives reconcile:
+ *   - The Oregon reconciler only considers events whose kennelId is in the
+ *     source's linked kennels (oh3/tgif/cch3-or). okh3 is intentionally NOT
+ *     linked, so reassigned okh3 events are invisible to it.
+ *   - The okh3 reconciler excludes events backed by RawEvents from other
+ *     sources; these are backed by the Oregon source, so it won't cancel them.
+ *
+ * Match by SIGNATURE, not hard-coded ids (a cron in the seed→cleanup gap may
+ * re-create rows under new ids; #1867 cleanup must stay idempotent).
+ *
+ * Targets (ALL conditions must hold):
+ *   - current primary kennel = oh3
+ *   - title matches an anchored Kahuna/okh3 prefix (the same skip patterns;
+ *     a leading-OH3 joint title like "OH3 Full Moon #1333 (Kahuna combo??)"
+ *     is therefore NEVER touched)
+ *   - zero attendances and no admin lock (adminCancelledAt null)
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-oregon-kahuna-misroute.ts
+ *   Apply:   CLEANUP_APPLY=1 npx tsx scripts/cleanup-oregon-kahuna-misroute.ts
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { reassignEventKennel } from "./lib/event-reassign";
+
+const APPLY = process.env.CLEANUP_APPLY === "1";
+
+// Anchored prefixes — mirror the Oregon source `skipPatterns` so the set of
+// reassigned events exactly matches the set the adapter now drops.
+const KAHUNA_PREFIX = /^(?:Kahuna|Ka3na|Katuna|Kah-Two-Na|Ka-Three-Na)\b/i;
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+async function main() {
+  const kennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: ["oh3", "okh3"] } },
+    select: { id: true, kennelCode: true },
+  });
+  const oh3 = kennels.find((k) => k.kennelCode === "oh3")?.id;
+  const okh3 = kennels.find((k) => k.kennelCode === "okh3")?.id;
+  if (!oh3 || !okh3) throw new Error("oh3/okh3 kennel ids not found");
+
+  // All oh3-primary events whose title starts with a Kahuna/okh3 prefix.
+  const candidates = await prisma.event.findMany({
+    where: {
+      kennelId: oh3,
+      OR: [
+        { title: { startsWith: "Kahuna", mode: "insensitive" } },
+        { title: { startsWith: "Ka3na", mode: "insensitive" } },
+        { title: { startsWith: "Katuna", mode: "insensitive" } },
+        { title: { startsWith: "Kah-Two-Na", mode: "insensitive" } },
+        { title: { startsWith: "Ka-Three-Na", mode: "insensitive" } },
+      ],
+    },
+    select: {
+      id: true, date: true, title: true, runNumber: true, status: true, adminCancelledAt: true,
+      eventKennels: { select: { kennelId: true, isPrimary: true } },
+      _count: { select: { attendances: true } },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  // Defense-in-depth: re-assert the anchored regex (DB startsWith is a coarse
+  // prefilter) and the safety guards.
+  const targets = candidates.filter(
+    (e) => e.title && KAHUNA_PREFIX.test(e.title) && e._count.attendances === 0 && !e.adminCancelledAt,
+  );
+  const skipped = candidates.filter((e) => !targets.includes(e));
+
+  console.log(`[cleanup] ${APPLY ? "APPLY" : "DRY-RUN"} — ${targets.length} reassignment target(s), ${skipped.length} skipped`);
+  for (const e of skipped) {
+    console.log(`  SKIP   ${isoDate(e.date)} "${e.title}" (att=${e._count.attendances}, adminLock=${!!e.adminCancelledAt})`);
+  }
+
+  let reassigned = 0;
+  let deletedDup = 0;
+  let skippedDependent = 0;
+  for (const e of targets) {
+    const dupOnOkh3 = await prisma.event.findFirst({
+      where: { kennelId: okh3, date: e.date, id: { not: e.id } },
+      select: { id: true, status: true },
+    });
+
+    if (dupOnOkh3) {
+      // Only an Event with no dependent rows can be hard-deleted: KennelAttendance
+      // and EventHare have RESTRICT FKs (no cascade), so delete() would throw.
+      const [kennelAtt, hares] = await Promise.all([
+        prisma.kennelAttendance.count({ where: { eventId: e.id } }),
+        prisma.eventHare.count({ where: { eventId: e.id } }),
+      ]);
+      if (kennelAtt > 0 || hares > 0) {
+        console.log(`  SKIP   ${isoDate(e.date)} "${e.title}" — dup of okh3 ${dupOnOkh3.id} but has dependent rows (kennelAtt=${kennelAtt}, hares=${hares}); needs manual merge`);
+        skippedDependent++;
+        continue;
+      }
+      console.log(`  DELETE ${isoDate(e.date)} "${e.title}" — duplicate of okh3 event ${dupOnOkh3.id}`);
+      if (APPLY) {
+        await prisma.$transaction([
+          prisma.eventLink.deleteMany({ where: { eventId: e.id } }),
+          prisma.event.delete({ where: { id: e.id } }), // EventKennel cascades
+        ]);
+      }
+      deletedDup++;
+      continue;
+    }
+
+    console.log(`  MOVE   ${isoDate(e.date)} "${e.title}" oh3 → okh3 (run=${e.runNumber ?? "—"}, status ${e.status}→CONFIRMED)`);
+    if (APPLY) {
+      // Shared composite-PK-safe swap (handles the okh3-already-co-host case);
+      // same helper the other cross-kennel conflation fixers use.
+      await reassignEventKennel(prisma, e.id, oh3, okh3);
+      if (e.status !== "CONFIRMED") {
+        await prisma.event.update({ where: { id: e.id }, data: { status: "CONFIRMED" } });
+      }
+    }
+    reassigned++;
+  }
+
+  console.log(`[cleanup] done — reassigned=${reassigned}, deletedDup=${deletedDup}, skippedDependent=${skippedDependent}${APPLY ? "" : " (dry-run, no writes)"}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/cleanup-oregon-kahuna-misroute.ts
+++ b/scripts/cleanup-oregon-kahuna-misroute.ts
@@ -52,6 +52,60 @@ function isoDate(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
+type CleanupOutcome = "reassigned" | "deletedDup" | "skippedDependent";
+
+interface TargetEvent {
+  id: string;
+  date: Date;
+  title: string | null;
+  runNumber: number | null;
+  status: string;
+}
+
+/**
+ * Process one misrouted oh3 Kahuna event: delete it if okh3 already has a
+ * same-date event (true dup, only when it carries no dependent rows), otherwise
+ * reassign it to okh3. Returns which branch ran (for the run tally).
+ */
+async function processTarget(e: TargetEvent, oh3: string, okh3: string): Promise<CleanupOutcome> {
+  const dupOnOkh3 = await prisma.event.findFirst({
+    where: { kennelId: okh3, date: e.date, id: { not: e.id } },
+    select: { id: true },
+  });
+
+  if (dupOnOkh3) {
+    // Only an Event with no dependent rows can be hard-deleted: KennelAttendance
+    // and EventHare have RESTRICT FKs (no cascade), so delete() would throw.
+    const [kennelAtt, hares] = await Promise.all([
+      prisma.kennelAttendance.count({ where: { eventId: e.id } }),
+      prisma.eventHare.count({ where: { eventId: e.id } }),
+    ]);
+    if (kennelAtt > 0 || hares > 0) {
+      console.log(`  SKIP   ${isoDate(e.date)} "${e.title}" — dup of okh3 ${dupOnOkh3.id} but has dependent rows (kennelAtt=${kennelAtt}, hares=${hares}); needs manual merge`);
+      return "skippedDependent";
+    }
+    console.log(`  DELETE ${isoDate(e.date)} "${e.title}" — duplicate of okh3 event ${dupOnOkh3.id}`);
+    if (APPLY) {
+      await prisma.$transaction([
+        prisma.eventLink.deleteMany({ where: { eventId: e.id } }),
+        prisma.event.delete({ where: { id: e.id } }), // EventKennel cascades
+      ]);
+    }
+    return "deletedDup";
+  }
+
+  console.log(`  MOVE   ${isoDate(e.date)} "${e.title}" oh3 → okh3 (run=${e.runNumber ?? "—"}, status ${e.status}→CONFIRMED)`);
+  if (APPLY) {
+    // Shared composite-PK-safe swap (handles the okh3-already-co-host case);
+    // same helper the other cross-kennel conflation fixers use.
+    await reassignEventKennel(prisma, e.id, oh3, okh3);
+    if (e.status !== "CONFIRMED") {
+      await prisma.event.update({ where: { id: e.id }, data: { status: "CONFIRMED" } });
+    }
+  }
+  return "reassigned";
+}
+
 async function main() {
   const kennels = await prisma.kennel.findMany({
     where: { kennelCode: { in: ["oh3", "okh3"] } },
@@ -93,51 +147,12 @@ async function main() {
     console.log(`  SKIP   ${isoDate(e.date)} "${e.title}" (att=${e._count.attendances}, adminLock=${!!e.adminCancelledAt})`);
   }
 
-  let reassigned = 0;
-  let deletedDup = 0;
-  let skippedDependent = 0;
+  const counts: Record<CleanupOutcome, number> = { reassigned: 0, deletedDup: 0, skippedDependent: 0 };
   for (const e of targets) {
-    const dupOnOkh3 = await prisma.event.findFirst({
-      where: { kennelId: okh3, date: e.date, id: { not: e.id } },
-      select: { id: true, status: true },
-    });
-
-    if (dupOnOkh3) {
-      // Only an Event with no dependent rows can be hard-deleted: KennelAttendance
-      // and EventHare have RESTRICT FKs (no cascade), so delete() would throw.
-      const [kennelAtt, hares] = await Promise.all([
-        prisma.kennelAttendance.count({ where: { eventId: e.id } }),
-        prisma.eventHare.count({ where: { eventId: e.id } }),
-      ]);
-      if (kennelAtt > 0 || hares > 0) {
-        console.log(`  SKIP   ${isoDate(e.date)} "${e.title}" — dup of okh3 ${dupOnOkh3.id} but has dependent rows (kennelAtt=${kennelAtt}, hares=${hares}); needs manual merge`);
-        skippedDependent++;
-        continue;
-      }
-      console.log(`  DELETE ${isoDate(e.date)} "${e.title}" — duplicate of okh3 event ${dupOnOkh3.id}`);
-      if (APPLY) {
-        await prisma.$transaction([
-          prisma.eventLink.deleteMany({ where: { eventId: e.id } }),
-          prisma.event.delete({ where: { id: e.id } }), // EventKennel cascades
-        ]);
-      }
-      deletedDup++;
-      continue;
-    }
-
-    console.log(`  MOVE   ${isoDate(e.date)} "${e.title}" oh3 → okh3 (run=${e.runNumber ?? "—"}, status ${e.status}→CONFIRMED)`);
-    if (APPLY) {
-      // Shared composite-PK-safe swap (handles the okh3-already-co-host case);
-      // same helper the other cross-kennel conflation fixers use.
-      await reassignEventKennel(prisma, e.id, oh3, okh3);
-      if (e.status !== "CONFIRMED") {
-        await prisma.event.update({ where: { id: e.id }, data: { status: "CONFIRMED" } });
-      }
-    }
-    reassigned++;
+    counts[await processTarget(e, oh3, okh3)]++;
   }
 
-  console.log(`[cleanup] done — reassigned=${reassigned}, deletedDup=${deletedDup}, skippedDependent=${skippedDependent}${APPLY ? "" : " (dry-run, no writes)"}`);
+  console.log(`[cleanup] done — reassigned=${counts.reassigned}, deletedDup=${counts.deletedDup}, skippedDependent=${counts.skippedDependent}${APPLY ? "" : " (dry-run, no writes)"}`);
 }
 
 main()

--- a/scripts/cleanup-oregon-kahuna-misroute.ts
+++ b/scripts/cleanup-oregon-kahuna-misroute.ts
@@ -140,4 +140,6 @@ async function main() {
   console.log(`[cleanup] done — reassigned=${reassigned}, deletedDup=${deletedDup}, skippedDependent=${skippedDependent}${APPLY ? "" : " (dry-run, no writes)"}`);
 }
 
-main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });
+main()
+  .catch((e) => { console.error(e); process.exitCode = 1; })
+  .finally(() => prisma.$disconnect());

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -190,6 +190,7 @@ describe("Oregon Hashing Calendar multi-kennel routing (#1023 step 4)", () => {
     "Kahuna pick up hash!",
     "Kahuna Revival #??? - Amazon.cum!",
     "Kah-Two-Na",
+    "Katuna: Hate Crime",
     "Ka-Three-Na H3 - Gayzelle",
   ])("skips Kahuna/okh3 cross-post %j", (summary) => {
     const result = buildRawEventFromGCalItem(

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -17,6 +17,7 @@ import {
   dedupGCalEvents,
   extractRunDescriptorTheme,
   splitTimedSummaryHareLocation,
+  stripGluedDescriptionEcho,
 } from "./adapter";
 import { compilePatterns } from "../utils";
 import type { RawEventData } from "../types";
@@ -176,6 +177,45 @@ describe("Oregon Hashing Calendar multi-kennel routing (#1023 step 4)", () => {
       config,
     );
     expect(result?.kennelTags).toEqual(["tgif"]);
+  });
+
+  // #1867 — Kahuna (okh3) cross-posts onto the Oregon aggregate but has its own
+  // dedicated calendar source, so it's dropped here via skipPatterns (same
+  // precedent as No Name H3). Compile the seed skip patterns and pass them in.
+  const skipCfg = oregonSource.config as { skipPatterns?: string[] };
+  const compiledSkipPatterns = compilePatterns(skipCfg.skipPatterns ?? [], "i");
+
+  it.each([
+    "Kahuna H3 #815 w/ Deaf Dick.",
+    "Kahuna pick up hash!",
+    "Kahuna Revival #??? - Amazon.cum!",
+    "Kah-Two-Na",
+    "Ka-Three-Na H3 - Gayzelle",
+  ])("skips Kahuna/okh3 cross-post %j", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2025-07-07T18:30:00-07:00" }, status: "confirmed" },
+      config,
+      { compiledSkipPatterns },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("does NOT skip a joint trail led by the local kennel (anchored)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "OH3 Full Moon #1336 / Kahuna Combo", start: { dateTime: "2025-06-11T18:30:00-07:00" }, status: "confirmed" },
+      config,
+      { compiledSkipPatterns },
+    );
+    expect(result?.kennelTags).toEqual(["oh3"]);
+  });
+
+  it("still routes the Cherry City + OH3 joint inaugural to both with skip patterns active", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Cherry City H3 #1 / OH3 # 1340", start: { dateTime: "2025-07-12T18:30:00-07:00" }, status: "confirmed" },
+      config,
+      { compiledSkipPatterns },
+    );
+    expect(result?.kennelTags).toEqual(["cch3-or", "oh3"]);
   });
 });
 
@@ -405,6 +445,148 @@ describe("buildRawEventFromGCalItem — placeholder summary promotion (#1761)", 
     );
     expect(result?.runNumber).toBe(449);
     expect(result?.title).toContain("Normal Run");
+  });
+});
+
+// ── #1843 — Maps-URL location with appended description text (OKH3/Kahuna) ──
+
+describe("buildRawEventFromGCalItem — Maps-URL location leak (#1843)", () => {
+  const config = { defaultKennelTag: "okh3", includeAllDayEvents: true };
+
+  it("clips a pre-built Maps URL when the description is appended after it", () => {
+    // The audit shape: LOCATION holds a Maps search URL and then a raw space +
+    // the run description (note the UNencoded '/' and spaces, proving it rode in
+    // as a URL value, not via mapsUrl() encoding).
+    const dirty =
+      "https://www.google.com/maps/search/?api=1&query=Burrito%20Azteca%2C%201942%20N%20Rosa%20Parks%20Way%2C%20Portland%2C%20OR%2097217%2C%20USA" +
+      " for Ka3Na/Morning Wood - Memorial Day Trail\nWho - We will be deflouring…";
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Ka3na/Morningwood Combo - Street Meat and Bottom Dollar",
+        start: { date: "2026-05-25" },
+        status: "confirmed",
+        location: dirty,
+        description: "Detrails for Ka3Na/Morning Wood - Memorial Day Trail",
+      },
+      config,
+    );
+    expect(result?.locationUrl).toBe(
+      "https://www.google.com/maps/search/?api=1&query=Burrito%20Azteca%2C%201942%20N%20Rosa%20Parks%20Way%2C%20Portland%2C%20OR%2097217%2C%20USA",
+    );
+    expect(result?.locationUrl).not.toMatch(/\s/);
+    // The leaked detrails must NOT survive on the URL.
+    expect(result?.locationUrl).not.toContain("Morning Wood");
+  });
+
+  it("does NOT truncate a hand-pasted coordinate Maps URL with a raw space", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Kahuna H3 - Coords",
+        start: { date: "2026-05-04" },
+        status: "confirmed",
+        // Raw space after the comma in a 'lat, lng' query — no prose follows,
+        // so the clip must leave the longitude intact.
+        location: "https://maps.google.com/?q=30.2, -97.7",
+      },
+      config,
+    );
+    expect(result?.locationUrl).toContain("-97.7");
+  });
+
+  it("leaves a clean plain-address location encoded normally", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Kahuna H3 - CherryNova",
+        start: { date: "2026-05-04" },
+        status: "confirmed",
+        location: "Mad Hanna, 6129 NE Fremont St, Portland, OR 97213, USA",
+      },
+      config,
+    );
+    expect(result?.location).toBe("Mad Hanna, 6129 NE Fremont St, Portland, OR 97213, USA");
+    expect(result?.locationUrl).toBe(
+      "https://www.google.com/maps/search/?api=1&query=Mad%20Hanna%2C%206129%20NE%20Fremont%20St%2C%20Portland%2C%20OR%2097213%2C%20USA",
+    );
+  });
+});
+
+// ── #1827 — venue glued to parking note from the description (Austin H3) ──
+
+describe("stripGluedDescriptionEcho (#1827)", () => {
+  it.each([
+    [
+      "strips the no-separator parking-note glue",
+      "Holiday Inn Austin-Town Lake by IHGUnder I35 by Holiday Inn Townlake",
+      "This is a woman only trail-Bring money and ID. Park under I35 by Holiday Inn Townlake.",
+      "Holiday Inn Austin-Town Lake by IHG",
+    ],
+    [
+      "keeps a venue fully echoed in the description (space-separated)",
+      "Memorial Park",
+      "Meet at Memorial Park, bring water",
+      "Memorial Park",
+    ],
+    [
+      "keeps a coincidental sub-token overlap (n│ear the river)",
+      "Smith Park near the river",
+      "head down near the river to find us",
+      "Smith Park near the river",
+    ],
+    [
+      "keeps a single lowercase-continuing word (West│in is not a glue)",
+      "Westin Hotel Conference Room",
+      "Registration is in Hotel Conference Room downstairs",
+      "Westin Hotel Conference Room",
+    ],
+    [
+      "no-op when the description is empty",
+      "Joe's Bar, 12 Main St",
+      "",
+      "Joe's Bar, 12 Main St",
+    ],
+    [
+      "leaves a clean address whose words appear in prose untouched",
+      "Lutz Tavern, 4639 SE Woodstock Blvd, Portland, OR 97206, USA",
+      "Ka-three-na H3 - Amazon Lutz Tavern - 4639 SE Woodstock Blvd.",
+      "Lutz Tavern, 4639 SE Woodstock Blvd, Portland, OR 97206, USA",
+    ],
+  ])("%s", (_label, location, description, expected) => {
+    expect(stripGluedDescriptionEcho(location, description)).toBe(expected);
+  });
+
+  it("cleans the location end-to-end through buildRawEventFromGCalItem", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "OTR Resurrection",
+        start: { date: "2026-05-30" },
+        status: "confirmed",
+        location: "Holiday Inn Austin-Town Lake by IHGUnder I35 by Holiday Inn Townlake",
+        description: "This is a woman only trail-Bring money and ID. Park under I35 by Holiday Inn Townlake.",
+      },
+      { defaultKennelTag: "ah3", includeAllDayEvents: true },
+    );
+    expect(result?.location).toBe("Holiday Inn Austin-Town Lake by IHG");
+  });
+});
+
+// ── #1819 — sibling title independence (OCHHH stale-title regression) ──
+
+describe("buildRawEventFromGCalItem — no cross-event title bleed (#1819)", () => {
+  const config = { defaultKennelTag: "ochhh", includeAllDayEvents: true };
+  // Distinct gcalIds + distinct summaries on adjacent dates: each event must
+  // keep its OWN title. The dedup path keys on `id:`, and `title` is not a
+  // merge key, so a sibling's title can never overwrite another's.
+  it.each([
+    ["2026-04-18", "Celebration of Life hash run for Jeff “Walking Small” Miner."],
+    ["2026-05-02", "OCHHH - Cum Shui & Howdy Do Me"],
+    ["2026-07-11", "OCHHH - MUM & Repo"],
+    ["2026-08-01", "OCHHH - Twatermelon"],
+  ])("keeps the %s title from its own summary", (date, summary) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { date }, status: "confirmed" },
+      config,
+    );
+    expect(result?.title).toBe(summary);
   });
 });
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -678,6 +678,63 @@ export function extractLocationFromDescription(description: string): string | un
 }
 
 /**
+ * #1827 — some kennel admins type the venue into the GCal LOCATION field and
+ * then paste a chunk of the run description (parking / navigation notes) right
+ * after it with NO separator, e.g.
+ *   location:    "Holiday Inn Austin-Town Lake by IHGUnder I35 by Holiday Inn Townlake"
+ *   description: "…Bring money and ID. Park under I35 by Holiday Inn Townlake."
+ * The trailing run ("Under I35 by Holiday Inn Townlake") is a verbatim echo of
+ * the description that got glued onto the venue mid-word ("IHG│Under"). Left
+ * intact it both leaks description text into the venue name and defeats
+ * geocoding.
+ *
+ * Strip the longest trailing slice of `location` that:
+ *   (a) begins at a GLUED-WORD boundary in the location: the char before the cut
+ *       is alphanumeric (no separator) AND the char at the cut is an UPPERCASE
+ *       letter. That's the fingerprint of the no-separator glue ("IHG│Under") —
+ *       a capitalised word jammed onto the venue. The uppercase requirement is
+ *       what keeps a single lowercase-continuing word intact: "Westin Hotel …"
+ *       would cut at "West│in", but 'i' is lowercase so it's rejected (likewise
+ *       "Eastman"→"East", "Northbound"→"North"); and
+ *   (b) appears in `description` at a WORD BOUNDARY (case-insensitive). The
+ *       boundary check on the description side rejects coincidental sub-token
+ *       matches: "Smith Park near the river" would otherwise cut at "n│ear the
+ *       river" because "ear the river" is a substring of "near the river", but
+ *       there that match is preceded by a word char, so it's discarded.
+ * Pure string ops — no regex over the input (ReDoS-safe, Sonar S5852/S5843).
+ */
+export function stripGluedDescriptionEcho(
+  location: string,
+  description: string | null | undefined,
+): string {
+  if (!location || !description) return location;
+  const locLower = location.toLowerCase();
+  const descLower = description.toLowerCase();
+  const isWordChar = (ch: string) => (ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9");
+  const isUpper = (ch: string) => ch >= "A" && ch <= "Z";
+  const echoesAtWordBoundary = (needle: string): boolean => {
+    let from = descLower.indexOf(needle);
+    while (from !== -1) {
+      if (from === 0 || !isWordChar(descLower[from - 1])) return true;
+      from = descLower.indexOf(needle, from + 1);
+    }
+    return false;
+  };
+  // Ascending i ⇒ the first qualifying cut is the LONGEST echoed suffix.
+  for (let i = 1; i < location.length; i++) {
+    if (!isWordChar(locLower[i - 1]) || !isUpper(location[i])) continue;
+    const candidate = locLower.slice(i);
+    if (candidate.length < 12) break; // remaining tails only get shorter
+    if (!echoesAtWordBoundary(candidate)) continue;
+    const removed = location.slice(i).trim();
+    if (removed.split(/\s+/).length < 2) return location;
+    const head = location.slice(0, i).trim();
+    return head.length >= 4 ? head : location;
+  }
+  return location;
+}
+
+/**
  * Extract a start time from the event description when `item.start.dateTime` yields no time.
  * Parses common label patterns (Pack Meet:, Circle:, Time:, Start:, When:, Chalk Talk:).
  *
@@ -1302,6 +1359,20 @@ export function buildRawEventFromGCalItem(
   // raw GCal location field. Trailing only — a bare "1 800 ..." in the middle
   // of a street fragment would otherwise be shredded.
   let location = item.location ? stripNonEnglishCountry(decodeEntities(item.location).trim()) : undefined;
+  // #1843 — some calendars (Kahuna/OKH3) paste a pre-built Google Maps URL into
+  // the LOCATION field and then append the run description after it. A
+  // well-formed URL contains no raw whitespace, so the run from the first
+  // whitespace char on is leaked description text — clip it before this value
+  // flows through to `locationUrl` (where `locationIsUrl` stores it verbatim).
+  // Only clip when the trailing run actually looks like prose (≥3 consecutive
+  // letters) so a hand-pasted coordinate URL with a raw space ("?q=30.2, -97.7")
+  // keeps its longitude rather than being truncated at the comma-space.
+  if (location && /^https?:\/\//i.test(location)) {
+    const wsIdx = location.search(/\s/);
+    if (wsIdx !== -1 && /[A-Za-z]{3,}/.test(location.slice(wsIdx))) {
+      location = location.slice(0, wsIdx).trim() || undefined;
+    }
+  }
   let latitude: number | undefined;
   let longitude: number | undefined;
   // When `item.location` is a coord-only string (decimal or DMS), parse it
@@ -1333,6 +1404,12 @@ export function buildRawEventFromGCalItem(
     location = undefined;
   }
   if (location && (isPlaceholder(location) || isNonAddressText(location))) location = undefined;
+  // #1827 — strip description text glued onto the venue without a separator
+  // (e.g. "…by IHGUnder I35 by Holiday Inn Townlake"). URLs are exempt — the
+  // #1843 clip above already handles the Maps-URL leak shape.
+  if (location && !/^https?:\/\//i.test(location)) {
+    location = stripGluedDescriptionEcho(location, rawDescription) || undefined;
+  }
   if (!location && rawDescription) {
     location = extractLocationFromDescription(rawDescription);
   }


### PR DESCRIPTION
## Summary

O-cluster A — Google Calendar family deep dive across **4 kennels / 6 issues**. All adapter work is confined to `src/adapters/google-calendar/adapter.ts`; every fix was **live-verified against the production calendars** (per `.claude/rules/live-verification.md`).

Investigation split the 6 issues into **adapter parse/extraction fixes** (ship + fixtures), **source routing**, **profile data**, and **stale-row cleanup** — three of the reported symptoms had already self-healed in prod via cron re-scrapes, so those ship as regression guards.

## Adapter fixes — `google-calendar/adapter.ts`

- **#1843 (OKH3/Kahuna) — Maps-URL location leak.** Some calendars paste a pre-built Google Maps URL into the `LOCATION` field and append the run description after it; `locationIsUrl` then stored the whole dirty string verbatim as `locationUrl`. A well-formed URL has no raw whitespace, so we clip at the first whitespace — but **only when prose (≥3 letters) follows**, so a hand-pasted `?q=30.2, -97.7` coordinate URL keeps its longitude.
- **#1827 (Austin) — venue glued to a parking note.** New `stripGluedDescriptionEcho()` strips a description echo concatenated onto the venue with no separator: `Holiday Inn Austin-Town Lake by IHGUnder I35 by Holiday Inn Townlake` → `Holiday Inn Austin-Town Lake by IHG`. It fires only at an **uppercase glued-word boundary** whose tail re-appears in the description **at a word boundary**, so a single word (`Westin`→`West`) and coincidental sub-token overlaps (`n│ear the river`) are left intact. Pure string ops — ReDoS-safe (Sonar S5852/S5843).
- **#1819 (OCHHH) — sibling title bleed.** The adapter processes each event independently (dedup keys on `gcalId`; `title` is not a merge key), so it **cannot** bleed a sibling's title. The reported 5/2 & 7/11 titles have already self-healed in prod. Shipped as a regression test.

## Source routing — `prisma/seed-data/sources.ts`

- **#1867 (Oregon aggregate).** Kahuna (okh3) cross-posts onto the shared Oregon Hashing Calendar but has its **own dedicated calendar source**, so it was landing in the `oh3` default bucket. Added `^Kahuna` / `^Ka3na` / `^Katuna` / `^Kah-Two-Na` / `^Ka-Three-Na` to `skipPatterns` (anchored) — same precedent as the existing No Name H3 skip. Leading-OH3 joint titles (`OH3 #1336 / Kahuna combo`) are preserved. CCH3 #1 already routes correctly via the existing array pattern.

## Profiles — `prisma/seed-data/kennels.ts`

- **#1818 OCHHH** — `scheduleFrequency` Monthly → Biweekly (+ description).
- **#1866 Oregon H3** — `foundedYear` 1987, `scheduleFrequency` "Biweekly + Full Moon", `scheduleNotes`, founder/Mother-Hash `description`.

## Cleanup — `scripts/cleanup-oregon-kahuna-misroute.ts`

Reassigns the **7 already-ingested Kahuna events** from `oh3` → `okh3` (okh3's own calendar covers none of those historical 2025 dates, so reassign — not delete). Signature-matched + idempotent, reuses the shared `reassignEventKennel` helper, FK-aware dup deletes. Dry-run by default; `CLEANUP_APPLY=1` to apply. Reassignment survives both reconcilers (okh3 isn't linked to the Oregon source; the okh3 reconciler excludes other-source-backed events). #1843 (0 prod leaks remain) and CCH3 #1 (already `cch3-or`-primary + CONFIRMED) had already self-healed.

## Verification

- Live-verified all 4 calendars via the real adapter before and after the fix.
- `npm run lint` (0 errors) · `npx tsc --noEmit` · `npm test` (**8105 passing**) all green.
- Cleanup script dry-run validated against prod (7 reassignments, 0 dups).
- Reviewed: built-in `/code-review` (high) adversarial pass + `/simplify` (Codex was rate-limited). Findings addressed: tightened the glue-strip to an uppercase boundary, guarded the URL clip against coordinate URLs, FK-aware dup deletes, and adopted the shared reassignment helper.

Closes #1818
Closes #1819
Closes #1827
Closes #1843
Closes #1866
Closes #1867

🤖 Generated with [Claude Code](https://claude.com/claude-code)