### PR TITLE
fix(kennels): harden Mijas/Bali/ONH3 — titles, hares, sub-letters, profiles

### DIFF
--- a/docs/kennel-onboarding/daily-onboarding-prompt.md
+++ b/docs/kennel-onboarding/daily-onboarding-prompt.md
@@ -500,6 +500,9 @@ authority is the live repo. Before writing the adapter, confirm against current 
 - [x] logo (stable? else flag self-host)  [x] foundedYear  [x] socials  [x] schedule (+ scheduleRules if multi-pattern)  [x] hashCash
 - [x] description  [x] source live-verified (feed HEAD-checked)  [x] history depth/pagination assessed
 - [x] coord sanity checked  [x] end times noted  [x] kennelCode collision-checked  [x] kennelCodes (source guard) set
+- [x] **per-run title** extracted when the source carries one (theme/venue/post title) — NOT left on the synthesized `<Kennel> Trail #N` default
+- [x] **hares** populated from hareline table columns AND trail-post "Hare(s):" lines
+- [x] **sub-letter run numbers** (`1999a`/`1999b`) handled as distinct events (see gotcha below)
 
 ## Implementation gotchas (for Claude Code — repo knowledge, not source knowledge)
 Carry these into the build; they've each caused a follow-up fix before:
@@ -552,6 +555,18 @@ Carry these into the build; they've each caused a follow-up fix before:
   - **No negated ternaries.** `a ? b : c` (NOT `!a ? c : b`) — Sonar S3358.
 - **Self-host tokenized logos** into `public/kennel-logos/<code>.<ext>` rather than referencing an
   ephemeral CDN URL.
+- **Don't ship a kennel stuck on the synthesized `<Kennel> Trail #N` title.** If the source carries
+  a per-run descriptor — a trail-post theme, a hareline `Venue` column, or a structured post title
+  (Ghost: `… - #N - <location> - D-MMM-YY`) — extract it into `title`. Fall back to the synthesized
+  default only when the source row genuinely has none. The audit flags this as `stale-default-title`
+  (Bali #1838, ONH3 #1862). Same rule for `hares`: hareline tables put it in a dedicated column and
+  trail posts in a leading `Hare(s):` line — promote both to `RawEventData.hares` (#1863).
+- **Sub-letter run numbers (`1999a` / `1999b`) must produce DISTINCT events.** Some kennels append
+  `a`/`b` when two trails share a base run number on different dates (Mijas #1848). Keep the base
+  integer in `runNumber` and emit the suffix as `eventLabel` — do NOT silently drop it. Dropping it
+  leaves both rows at `(sourceUrl, runNumber)`, and the merge same-sourceUrl date-correction
+  (`merge.ts`) then "moves" one onto the other's date, deleting a real event. The date-correction
+  probe co-matches on `eventLabel`, so an emitted label keeps the pair separate.
 
 ---
 

--- a/docs/kennel-onboarding/source-platform-notes.md
+++ b/docs/kennel-onboarding/source-platform-notes.md
@@ -84,6 +84,13 @@ Detection / gotchas for the content-page variant:
   undefined. Set `config.upcomingOnly: true` (a rolling hareline prunes old months → protects
   reconcile).
 - **Logo** is the usual tokenized `images.squarespace-cdn.com/.../<hash>/logo.<ext>` → self-host.
+- **Sub-letter run numbers** (`1999a`/`1999b`): when two trails share a base run number on different
+  dates (a Memorial Run squeezed in, an away-weekend split), keep the base integer in `runNumber`
+  and emit the suffix as **`eventLabel`** (`"a"`/`"b"`). Dropping the suffix collapses both rows to
+  `(sourceUrl, runNumber)`; since a content-page hareline emits a single fixed page `sourceUrl`, the
+  merge same-sourceUrl date-correction then "moves" one onto the other's date and deletes a real
+  event (Mijas #1848). The date-correction probe co-matches on `eventLabel`, so the label keeps them
+  distinct. `parseRunLabel` in `mijas-hash.ts` is the reference.
 
 #### 🔴 Third pattern — separate "Run Reports" / archive collection (learned from Mijas H3, 2026-05-30)
 
@@ -112,3 +119,25 @@ available"; the same site had `/run-reports` with **389 events back to 2005** (a
 - **`location` is tri-state in backfill.** `cleanLocationName()` returns `null` for "TBD" / unknown;
   preserve that null (don't coerce to empty string), so the merge pipeline can display "venue TBD"
   properly.
+
+---
+
+## Ghost blog — the run descriptor lives in the post TITLE (learned from Bali Hash 2, 2026-05-30)
+
+Ghost-hosted kennels (balihash2.com) publish one post per run with a **structured title**:
+`Bali Hash 2 Next Run Map - #NNNN - <location> - D-MMM-YY`. The home page lists ~12–22 recent
+posts as `article.gh-card` / `a.gh-card-link`; the detail page (`section.gh-content`) adds GPS,
+hares, and a per-tier fee table.
+
+- **Parse the title for the `title` field**, not just the run number. The middle `<location>`
+  segment is the source's own per-run descriptor — slice off the `…#NNNN - ` prefix and the trailing
+  ` - D-MMM-YY` date (index slicing + a date regex, no `.*?`/`\s*` shapes → Sonar S5852-safe).
+  Leaving it on the synthesized `<Kennel> Trail #N` default is the `stale-default-title` finding
+  (Bali #1838). `parseBaliTitle` in `bali-hash-2.ts` is the reference.
+- **The home page is recent-only** → set `config.upcomingOnly: true` and drive deep history from a
+  one-shot `scripts/backfill-<code>-history.ts` that walks `/page/N/` reusing the adapter's own
+  `parseListingCards`/`buildEvent` (no parser fork — the title fix lands in the backfill for free).
+- **Corrected reposts** get a `…-2` slug published later (higher on the reverse-chron listing);
+  dedupe by run number keeping the first DOM occurrence so the correction wins.
+- **`hashCash`** is a per-tier fee table in every post body, not a single value — capture verbatim
+  (`Members Rp.X / Non-drinkers Rp.Y / Visitors Rp.Z / Kids <15 Rp.W`).

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4327,6 +4327,7 @@ export const KENNELS: KennelSeed[] = [
       region: "Nairobi", country: "Kenya",
       website: "https://onh3.wordpress.com/",
       facebookUrl: "https://www.facebook.com/groups/onhhh/",
+      contactEmail: "onh3mismanagement@gmail.com",
       logoUrl: "/kennel-logos/onh3.jpg",
       foundedYear: 2000,
       scheduleDayOfWeek: "Monday", scheduleTime: "5:45 PM", scheduleFrequency: "Weekly",
@@ -4341,7 +4342,7 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "bali-hash-2", shortName: "Bali Hash 2", fullName: "Bali Hash House Harriers 2",
       region: "Bali", country: "Indonesia",
       website: "https://balihash2.com",
-      facebookUrl: "https://www.facebook.com/BaliHash2",
+      facebookUrl: "https://www.facebook.com/groups/balihash2/",
       twitterHandle: "balihash2",
       logoUrl: "/kennel-logos/bali-hash-2.png",
       gm: "Gritty Balls", hareRaiser: "Skanky Toe",
@@ -4364,7 +4365,7 @@ export const KENNELS: KennelSeed[] = [
       scheduleNotes:
         "Time varies seasonally (summer 'Short n Sweet' runs ~15:00; winter earlier). Originally Mondays at founding (1989), now Sundays.",
       facebookUrl: "https://www.facebook.com/groups/MijasHHH",
-      contactEmail: "5ksmh3@gmail.com",
+      contactEmail: "info@mijash3.com",
       foundedYear: 1989,
       description:
         "The Costa del Sol 'Burro Hash' — a drinking club with a running problem. Founded in 1989 by 'Flakey' (ex-Pattaya H3), Mijas HHH runs every Sunday across the hills and coast of Andalucía. 30+ years and 2000+ runs on.",

--- a/scripts/backfill-onh3-history.ts
+++ b/scripts/backfill-onh3-history.ts
@@ -34,6 +34,7 @@ import { PrismaClient, type Prisma } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { createScriptPool } from "./lib/db-pool";
 import { googleMapsSearchUrl } from "@/adapters/utils";
+import { composeVenueTitle } from "@/adapters/html-scraper/onh3";
 import { generateFingerprint } from "@/pipeline/fingerprint";
 import type { RawEventData } from "@/adapters/types";
 
@@ -143,6 +144,9 @@ function rowToEvent(row: HistoryRow): RawEventData {
     date: row.date,
     kennelTags: [KENNEL_TAG],
     runNumber: row.runNumber,
+    // Venue (+ area) title repaints the stale "ONH3 Trail #N" placeholder on
+    // re-run via the merge UPDATE path (#1862); shares the adapter helper.
+    title: composeVenueTitle(row.venue, row.area),
     hares: row.hares,
     location: row.venue,
     locationUrl: venueQuery ? googleMapsSearchUrl(`${venueQuery} Nairobi Kenya`) : undefined,

--- a/scripts/cleanup-cycle6-profile-overrides.ts
+++ b/scripts/cleanup-cycle6-profile-overrides.ts
@@ -1,17 +1,19 @@
 /**
  * One-off overrides for the cycle-6 profile bundle PR (#1380, #1392, #1393).
  *
- * Background: prisma/seed.ts performs a fill-only merge for existing kennels
- * — it never overwrites an already-populated column (seed.ts:298-303), and
- * `fullName` is set only at create time (seed.ts:265, not in PROFILE_FIELDS).
- *
- * This script applies the rewrites that can't be expressed in seed:
+ * Background: prisma/seed.ts performs a fill-only merge for existing kennels —
+ * it never overwrites an already-populated column (seed.ts:296-301), and
+ * `fullName` is set only at create time (not in PROFILE_FIELDS). This script
+ * applies the rewrites that can't be expressed in seed:
  *   - gynoh3.fullName  → "Gyrls Night Out Hash House Harriers"     (#1393)
  *   - gynoh3.description → expanded blurb with founding details    (#1393)
  *   - kimchi-h3.description → expanded blurb with Korean lineage   (#1380)
  *
- * Idempotent and safe to re-run. Default mode is DRY-RUN; pass --execute
- * to actually write to the DB.
+ * Each rewrite carries the EXPECTED current value (captured from the cycle-6 PR
+ * Step 0 prod-state query) so the runner refuses to overwrite admin curations
+ * applied between merge and execution.
+ *
+ * Idempotent and safe to re-run. Default mode is DRY-RUN; pass --execute to apply.
  *
  * Usage:
  *   eval "$(fnm env)" && fnm use 20
@@ -21,30 +23,9 @@
  */
 
 import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
+import { runProfileOverrides, type ProfileOverride } from "./lib/profile-override-runner";
 
-const EXECUTE = process.argv.includes("--execute");
-
-type OverrideField = "fullName" | "description";
-interface FieldRewrite {
-  expected: string;
-  target: string;
-}
-interface Override {
-  kennelCode: string;
-  rewrites: Partial<Record<OverrideField, FieldRewrite>>;
-}
-interface RewriteEvaluation {
-  updateData: Partial<Record<OverrideField, string>>;
-  driftSkip: boolean;
-}
-
-// Each rewrite carries the EXPECTED current value so the script refuses to
-// overwrite admin curations applied between merge and execution. `expected`
-// is captured from the prod-state query in cycle-6 PR Step 0 — see PR body.
-const OVERRIDES: Override[] = [
+const OVERRIDES: ProfileOverride[] = [
   {
     kennelCode: "gynoh3",
     rewrites: {
@@ -73,95 +54,10 @@ const OVERRIDES: Override[] = [
   },
 ];
 
-type KennelRow = { id: string; kennelCode: string; fullName: string; description: string | null };
-
-function evaluateRewrites(
-  kennel: KennelRow,
-  rewrites: Override["rewrites"],
-): RewriteEvaluation {
-  const updateData: Partial<Record<OverrideField, string>> = {};
-  let driftSkip = false;
-  for (const field of Object.keys(rewrites) as OverrideField[]) {
-    const { expected, target } = rewrites[field]!;
-    const current = kennel[field];
-    if (current === target) {
-      console.log(`  · ${kennel.kennelCode}.${field} already correct.`);
-    } else if (current === expected) {
-      updateData[field] = target;
-      console.log(`  ~ ${kennel.kennelCode}.${field}`);
-      console.log(`      current: ${JSON.stringify(current)}`);
-      console.log(`      target:  ${JSON.stringify(target)}`);
-    } else {
-      console.warn(`  ⚠ ${kennel.kennelCode}.${field} drifted from expected — refusing to overwrite.`);
-      console.warn(`      expected: ${JSON.stringify(expected)}`);
-      console.warn(`      current:  ${JSON.stringify(current)}`);
-      console.warn(`      target:   ${JSON.stringify(target)}`);
-      driftSkip = true;
-    }
-  }
-  return { updateData, driftSkip };
-}
-
-async function processOverride(
-  prisma: PrismaClient,
-  override: Override,
-): Promise<"updated" | "skipped-drift" | "noop" | "missing"> {
-  const kennel = await prisma.kennel.findUnique({
-    where: { kennelCode: override.kennelCode },
-    select: { id: true, kennelCode: true, fullName: true, description: true },
-  });
-  if (!kennel) {
-    console.error(`✗ Kennel "${override.kennelCode}" not found — skipping.`);
-    return "missing";
-  }
-
-  const { updateData, driftSkip } = evaluateRewrites(kennel, override.rewrites);
-  if (driftSkip) return "skipped-drift";
-  if (Object.keys(updateData).length === 0) return "noop";
-  if (!EXECUTE) return "updated";
-
-  await prisma.kennel.update({ where: { id: kennel.id }, data: updateData });
-  console.log(`  ✓ Updated ${kennel.kennelCode} (${Object.keys(updateData).join(", ")})`);
-  return "updated";
-}
-
-function summarize(plannedUpdates: number, skippedDueToDrift: number) {
-  if (skippedDueToDrift > 0) {
-    console.warn(`\n⚠ Skipped ${skippedDueToDrift} kennel(s) due to drift from expected values — review manually.`);
-  }
-  if (plannedUpdates === 0 && skippedDueToDrift === 0) {
-    console.log("\nNothing to do — all overrides already applied.");
-  } else if (plannedUpdates > 0 && !EXECUTE) {
-    console.log(`\nDry-run complete. ${plannedUpdates} kennel(s) would be updated. Re-run with --execute to apply.`);
-  } else if (plannedUpdates > 0) {
-    console.log(`\nApplied overrides to ${plannedUpdates} kennel(s).`);
-  }
-}
-
-async function main() {
-  const mode = EXECUTE ? "EXECUTE (will update DB)" : "DRY-RUN (read-only)";
-  console.log(`\n=== cleanup-cycle6-profile-overrides ===`);
-  console.log(`Mode: ${mode}\n`);
-
-  const pool = createScriptPool();
-  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
-
-  try {
-    let plannedUpdates = 0;
-    let skippedDueToDrift = 0;
-    for (const override of OVERRIDES) {
-      const outcome = await processOverride(prisma, override);
-      if (outcome === "updated") plannedUpdates++;
-      else if (outcome === "skipped-drift") skippedDueToDrift++;
-    }
-    summarize(plannedUpdates, skippedDueToDrift);
-  } finally {
-    await prisma.$disconnect();
-    await pool.end();
-  }
-}
-
-main().catch((err) => {
+runProfileOverrides(OVERRIDES, {
+  execute: process.argv.includes("--execute"),
+  scriptName: "cleanup-cycle6-profile-overrides",
+}).catch((err) => {
   console.error("\nFatal error:", err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/scripts/cleanup-new-kennel-profiles.ts
+++ b/scripts/cleanup-new-kennel-profiles.ts
@@ -1,0 +1,162 @@
+/**
+ * One-off profile overrides for the new-kennel hardening bundle (#1839, #1849).
+ *
+ * Background: prisma/seed.ts performs a fill-only merge for existing kennels —
+ * it never overwrites an already-populated column (seed.ts:296-301). These two
+ * fields are already non-null in prod with the wrong value, so the seed cannot
+ * correct them; this script applies the rewrites:
+ *   - bali-hash-2.facebookUrl → https://www.facebook.com/groups/balihash2/  (#1839)
+ *       (was the bare page handle /BaliHash2; the site only links the group)
+ *   - mijash3.contactEmail    → info@mijash3.com                            (#1849)
+ *       (was the 5ksmh3 hareraiser mailbox; info@ is the site's canonical inbox)
+ *
+ * Each rewrite carries the EXPECTED current value, so the script refuses to
+ * clobber an admin edit applied between merge and execution (drift guard).
+ *
+ * Idempotent and safe to re-run. Default mode is DRY-RUN; pass --execute to
+ * write to the DB.
+ *
+ * Usage:
+ *   eval "$(fnm env)" && fnm use 20
+ *   set -a && source .env && set +a
+ *   npx tsx scripts/cleanup-new-kennel-profiles.ts            # dry-run
+ *   npx tsx scripts/cleanup-new-kennel-profiles.ts --execute  # apply
+ */
+
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const EXECUTE = process.argv.includes("--execute");
+
+type OverrideField = "facebookUrl" | "contactEmail";
+interface FieldRewrite {
+  expected: string;
+  target: string;
+}
+interface Override {
+  kennelCode: string;
+  rewrites: Partial<Record<OverrideField, FieldRewrite>>;
+}
+
+// `expected` captured from the prod-state query at planning time (2026-05-30).
+const OVERRIDES: Override[] = [
+  {
+    kennelCode: "bali-hash-2",
+    rewrites: {
+      facebookUrl: {
+        expected: "https://www.facebook.com/BaliHash2",
+        target: "https://www.facebook.com/groups/balihash2/",
+      },
+    },
+  },
+  {
+    kennelCode: "mijash3",
+    rewrites: {
+      contactEmail: {
+        expected: "5ksmh3@gmail.com",
+        target: "info@mijash3.com",
+      },
+    },
+  },
+];
+
+type KennelRow = {
+  id: string;
+  kennelCode: string;
+  facebookUrl: string | null;
+  contactEmail: string | null;
+};
+
+interface RewriteEvaluation {
+  updateData: Partial<Record<OverrideField, string>>;
+  driftSkip: boolean;
+}
+
+function evaluateRewrites(kennel: KennelRow, rewrites: Override["rewrites"]): RewriteEvaluation {
+  const updateData: Partial<Record<OverrideField, string>> = {};
+  let driftSkip = false;
+  for (const field of Object.keys(rewrites) as OverrideField[]) {
+    const { expected, target } = rewrites[field]!;
+    const current = kennel[field];
+    if (current === target) {
+      console.log(`  · ${kennel.kennelCode}.${field} already correct.`);
+    } else if (current === expected) {
+      updateData[field] = target;
+      console.log(`  ~ ${kennel.kennelCode}.${field}`);
+      console.log(`      current: ${JSON.stringify(current)}`);
+      console.log(`      target:  ${JSON.stringify(target)}`);
+    } else {
+      console.warn(`  ⚠ ${kennel.kennelCode}.${field} drifted from expected — refusing to overwrite.`);
+      console.warn(`      expected: ${JSON.stringify(expected)}`);
+      console.warn(`      current:  ${JSON.stringify(current)}`);
+      console.warn(`      target:   ${JSON.stringify(target)}`);
+      driftSkip = true;
+    }
+  }
+  return { updateData, driftSkip };
+}
+
+async function processOverride(
+  prisma: PrismaClient,
+  override: Override,
+): Promise<"updated" | "skipped-drift" | "noop" | "missing"> {
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: override.kennelCode },
+    select: { id: true, kennelCode: true, facebookUrl: true, contactEmail: true },
+  });
+  if (!kennel) {
+    console.error(`✗ Kennel "${override.kennelCode}" not found — skipping.`);
+    return "missing";
+  }
+
+  const { updateData, driftSkip } = evaluateRewrites(kennel, override.rewrites);
+  if (driftSkip) return "skipped-drift";
+  if (Object.keys(updateData).length === 0) return "noop";
+  if (!EXECUTE) return "updated";
+
+  await prisma.kennel.update({ where: { id: kennel.id }, data: updateData });
+  console.log(`  ✓ Updated ${kennel.kennelCode} (${Object.keys(updateData).join(", ")})`);
+  return "updated";
+}
+
+function summarize(plannedUpdates: number, skippedDueToDrift: number) {
+  if (skippedDueToDrift > 0) {
+    console.warn(`\n⚠ Skipped ${skippedDueToDrift} kennel(s) due to drift from expected values — review manually.`);
+  }
+  if (plannedUpdates === 0 && skippedDueToDrift === 0) {
+    console.log("\nNothing to do — all overrides already applied.");
+  } else if (plannedUpdates > 0 && !EXECUTE) {
+    console.log(`\nDry-run complete. ${plannedUpdates} kennel(s) would be updated. Re-run with --execute to apply.`);
+  } else if (plannedUpdates > 0) {
+    console.log(`\nApplied overrides to ${plannedUpdates} kennel(s).`);
+  }
+}
+
+async function main() {
+  console.log(`\n=== cleanup-new-kennel-profiles ===`);
+  console.log(`Mode: ${EXECUTE ? "EXECUTE (will update DB)" : "DRY-RUN (read-only)"}\n`);
+
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+  try {
+    let plannedUpdates = 0;
+    let skippedDueToDrift = 0;
+    for (const override of OVERRIDES) {
+      const outcome = await processOverride(prisma, override);
+      if (outcome === "updated") plannedUpdates++;
+      else if (outcome === "skipped-drift") skippedDueToDrift++;
+    }
+    summarize(plannedUpdates, skippedDueToDrift);
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("\nFatal error:", err);
+  process.exit(1);
+});

--- a/scripts/cleanup-new-kennel-profiles.ts
+++ b/scripts/cleanup-new-kennel-profiles.ts
@@ -1,20 +1,14 @@
 /**
  * One-off profile overrides for the new-kennel hardening bundle (#1839, #1849).
  *
- * Background: prisma/seed.ts performs a fill-only merge for existing kennels —
- * it never overwrites an already-populated column (seed.ts:296-301). These two
- * fields are already non-null in prod with the wrong value, so the seed cannot
- * correct them; this script applies the rewrites:
+ * These two fields are already non-null in prod with the wrong value, so the
+ * fill-only seed merge can't correct them (see profile-override-runner.ts):
  *   - bali-hash-2.facebookUrl → https://www.facebook.com/groups/balihash2/  (#1839)
  *       (was the bare page handle /BaliHash2; the site only links the group)
  *   - mijash3.contactEmail    → info@mijash3.com                            (#1849)
  *       (was the 5ksmh3 hareraiser mailbox; info@ is the site's canonical inbox)
  *
- * Each rewrite carries the EXPECTED current value, so the script refuses to
- * clobber an admin edit applied between merge and execution (drift guard).
- *
- * Idempotent and safe to re-run. Default mode is DRY-RUN; pass --execute to
- * write to the DB.
+ * Idempotent and drift-guarded. Default mode is DRY-RUN; pass --execute to apply.
  *
  * Usage:
  *   eval "$(fnm env)" && fnm use 20
@@ -24,24 +18,10 @@
  */
 
 import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
-
-const EXECUTE = process.argv.includes("--execute");
-
-type OverrideField = "facebookUrl" | "contactEmail";
-interface FieldRewrite {
-  expected: string;
-  target: string;
-}
-interface Override {
-  kennelCode: string;
-  rewrites: Partial<Record<OverrideField, FieldRewrite>>;
-}
+import { runProfileOverrides, type ProfileOverride } from "./lib/profile-override-runner";
 
 // `expected` captured from the prod-state query at planning time (2026-05-30).
-const OVERRIDES: Override[] = [
+const OVERRIDES: ProfileOverride[] = [
   {
     kennelCode: "bali-hash-2",
     rewrites: {
@@ -62,101 +42,12 @@ const OVERRIDES: Override[] = [
   },
 ];
 
-type KennelRow = {
-  id: string;
-  kennelCode: string;
-  facebookUrl: string | null;
-  contactEmail: string | null;
-};
-
-interface RewriteEvaluation {
-  updateData: Partial<Record<OverrideField, string>>;
-  driftSkip: boolean;
-}
-
-function evaluateRewrites(kennel: KennelRow, rewrites: Override["rewrites"]): RewriteEvaluation {
-  const updateData: Partial<Record<OverrideField, string>> = {};
-  let driftSkip = false;
-  for (const field of Object.keys(rewrites) as OverrideField[]) {
-    const { expected, target } = rewrites[field]!;
-    const current = kennel[field];
-    if (current === target) {
-      console.log(`  · ${kennel.kennelCode}.${field} already correct.`);
-    } else if (current === expected) {
-      updateData[field] = target;
-      console.log(`  ~ ${kennel.kennelCode}.${field}`);
-      console.log(`      current: ${JSON.stringify(current)}`);
-      console.log(`      target:  ${JSON.stringify(target)}`);
-    } else {
-      console.warn(`  ⚠ ${kennel.kennelCode}.${field} drifted from expected — refusing to overwrite.`);
-      console.warn(`      expected: ${JSON.stringify(expected)}`);
-      console.warn(`      current:  ${JSON.stringify(current)}`);
-      console.warn(`      target:   ${JSON.stringify(target)}`);
-      driftSkip = true;
-    }
-  }
-  return { updateData, driftSkip };
-}
-
-async function processOverride(
-  prisma: PrismaClient,
-  override: Override,
-): Promise<"updated" | "skipped-drift" | "noop" | "missing"> {
-  const kennel = await prisma.kennel.findUnique({
-    where: { kennelCode: override.kennelCode },
-    select: { id: true, kennelCode: true, facebookUrl: true, contactEmail: true },
-  });
-  if (!kennel) {
-    console.error(`✗ Kennel "${override.kennelCode}" not found — skipping.`);
-    return "missing";
-  }
-
-  const { updateData, driftSkip } = evaluateRewrites(kennel, override.rewrites);
-  if (driftSkip) return "skipped-drift";
-  if (Object.keys(updateData).length === 0) return "noop";
-  if (!EXECUTE) return "updated";
-
-  await prisma.kennel.update({ where: { id: kennel.id }, data: updateData });
-  console.log(`  ✓ Updated ${kennel.kennelCode} (${Object.keys(updateData).join(", ")})`);
-  return "updated";
-}
-
-function summarize(plannedUpdates: number, skippedDueToDrift: number) {
-  if (skippedDueToDrift > 0) {
-    console.warn(`\n⚠ Skipped ${skippedDueToDrift} kennel(s) due to drift from expected values — review manually.`);
-  }
-  if (plannedUpdates === 0 && skippedDueToDrift === 0) {
-    console.log("\nNothing to do — all overrides already applied.");
-  } else if (plannedUpdates > 0 && !EXECUTE) {
-    console.log(`\nDry-run complete. ${plannedUpdates} kennel(s) would be updated. Re-run with --execute to apply.`);
-  } else if (plannedUpdates > 0) {
-    console.log(`\nApplied overrides to ${plannedUpdates} kennel(s).`);
-  }
-}
-
-async function main() {
-  console.log(`\n=== cleanup-new-kennel-profiles ===`);
-  console.log(`Mode: ${EXECUTE ? "EXECUTE (will update DB)" : "DRY-RUN (read-only)"}\n`);
-
-  const pool = createScriptPool();
-  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
-
-  try {
-    let plannedUpdates = 0;
-    let skippedDueToDrift = 0;
-    for (const override of OVERRIDES) {
-      const outcome = await processOverride(prisma, override);
-      if (outcome === "updated") plannedUpdates++;
-      else if (outcome === "skipped-drift") skippedDueToDrift++;
-    }
-    summarize(plannedUpdates, skippedDueToDrift);
-  } finally {
-    await prisma.$disconnect();
-    await pool.end();
-  }
-}
-
-main().catch((err) => {
+runProfileOverrides(OVERRIDES, {
+  execute: process.argv.includes("--execute"),
+  scriptName: "cleanup-new-kennel-profiles",
+}).catch((err) => {
   console.error("\nFatal error:", err);
-  process.exit(1);
+  // Set exitCode (not process.exit) so the runner's prisma.$disconnect()/pool.end()
+  // in its finally block drain cleanly before the process ends.
+  process.exitCode = 1;
 });

--- a/scripts/lib/profile-override-runner.ts
+++ b/scripts/lib/profile-override-runner.ts
@@ -1,0 +1,141 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient, type Prisma } from "@/generated/prisma/client";
+import { createScriptPool } from "./db-pool";
+
+/**
+ * Shared engine for one-shot kennel-profile override scripts.
+ *
+ * `prisma/seed.ts` does a fill-only merge for existing kennels — it never
+ * overwrites an already-populated column (seed.ts:296-301). When a field is
+ * already non-null in prod with the wrong value, the seed can't correct it, so
+ * a one-shot override script is the only path. Several such scripts ship over
+ * time (cycle-6 #1380/#1392/#1393, the new-kennel bundle #1839/#1849, …); this
+ * runner holds the shared dry-run / drift-guard / update boilerplate so each
+ * wrapper collapses to a list of overrides + one call — the same factoring as
+ * `backfill-runner.ts` (avoids the Sonar new-code duplication that ships when
+ * two near-identical wrappers land together).
+ *
+ * Each rewrite carries the EXPECTED current value, so the runner refuses to
+ * clobber an admin edit applied between merge and execution (drift guard).
+ * Idempotent: a field already at `target` is a no-op.
+ */
+
+export interface FieldRewrite {
+  /** The value the field is expected to currently hold (captured at authoring). */
+  expected: string;
+  /** The value to write. */
+  target: string;
+}
+
+export interface ProfileOverride {
+  kennelCode: string;
+  /** Map of Kennel column name → rewrite. */
+  rewrites: Record<string, FieldRewrite>;
+}
+
+export interface RunProfileOverridesOptions {
+  /** When false (default), prints the plan without writing. */
+  execute: boolean;
+  /** Script name printed in the header banner. */
+  scriptName: string;
+}
+
+type KennelRow = Record<string, unknown> & { id: string; kennelCode: string };
+
+interface RewriteEvaluation {
+  updateData: Record<string, string>;
+  driftSkip: boolean;
+}
+
+function evaluateRewrites(kennel: KennelRow, rewrites: ProfileOverride["rewrites"]): RewriteEvaluation {
+  const updateData: Record<string, string> = {};
+  let driftSkip = false;
+  for (const [field, { expected, target }] of Object.entries(rewrites)) {
+    const current = kennel[field];
+    if (current === target) {
+      console.log(`  · ${kennel.kennelCode}.${field} already correct.`);
+    } else if (current === expected) {
+      updateData[field] = target;
+      console.log(`  ~ ${kennel.kennelCode}.${field}`);
+      console.log(`      current: ${JSON.stringify(current)}`);
+      console.log(`      target:  ${JSON.stringify(target)}`);
+    } else {
+      console.warn(`  ⚠ ${kennel.kennelCode}.${field} drifted from expected — refusing to overwrite.`);
+      console.warn(`      expected: ${JSON.stringify(expected)}`);
+      console.warn(`      current:  ${JSON.stringify(current)}`);
+      console.warn(`      target:   ${JSON.stringify(target)}`);
+      driftSkip = true;
+    }
+  }
+  return { updateData, driftSkip };
+}
+
+async function processOverride(
+  prisma: PrismaClient,
+  override: ProfileOverride,
+  execute: boolean,
+): Promise<"updated" | "skipped-drift" | "noop" | "missing"> {
+  // Select only the columns this override touches (plus id/kennelCode), built
+  // dynamically so the runner stays field-agnostic across wrapper scripts.
+  const select = {
+    id: true,
+    kennelCode: true,
+    ...Object.fromEntries(Object.keys(override.rewrites).map((f) => [f, true])),
+  } as Prisma.KennelSelect;
+
+  const kennel = (await prisma.kennel.findUnique({
+    where: { kennelCode: override.kennelCode },
+    select,
+  })) as KennelRow | null;
+  if (!kennel) {
+    console.error(`✗ Kennel "${override.kennelCode}" not found — skipping.`);
+    return "missing";
+  }
+
+  const { updateData, driftSkip } = evaluateRewrites(kennel, override.rewrites);
+  if (driftSkip) return "skipped-drift";
+  if (Object.keys(updateData).length === 0) return "noop";
+  if (!execute) return "updated";
+
+  await prisma.kennel.update({ where: { id: kennel.id }, data: updateData });
+  console.log(`  ✓ Updated ${kennel.kennelCode} (${Object.keys(updateData).join(", ")})`);
+  return "updated";
+}
+
+function summarize(plannedUpdates: number, skippedDueToDrift: number, execute: boolean): void {
+  if (skippedDueToDrift > 0) {
+    console.warn(`\n⚠ Skipped ${skippedDueToDrift} kennel(s) due to drift from expected values — review manually.`);
+  }
+  if (plannedUpdates === 0 && skippedDueToDrift === 0) {
+    console.log("\nNothing to do — all overrides already applied.");
+  } else if (plannedUpdates > 0 && !execute) {
+    console.log(`\nDry-run complete. ${plannedUpdates} kennel(s) would be updated. Re-run with --execute to apply.`);
+  } else if (plannedUpdates > 0) {
+    console.log(`\nApplied overrides to ${plannedUpdates} kennel(s).`);
+  }
+}
+
+/** One-call entry point: prints mode, applies each override, summarizes. */
+export async function runProfileOverrides(
+  overrides: ProfileOverride[],
+  { execute, scriptName }: RunProfileOverridesOptions,
+): Promise<void> {
+  console.log(`\n=== ${scriptName} ===`);
+  console.log(`Mode: ${execute ? "EXECUTE (will update DB)" : "DRY-RUN (read-only)"}\n`);
+
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+  try {
+    let plannedUpdates = 0;
+    let skippedDueToDrift = 0;
+    for (const override of overrides) {
+      const outcome = await processOverride(prisma, override, execute);
+      if (outcome === "updated") plannedUpdates++;
+      else if (outcome === "skipped-drift") skippedDueToDrift++;
+    }
+    summarize(plannedUpdates, skippedDueToDrift, execute);
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}

--- a/src/adapters/html-scraper/bali-hash-2.test.ts
+++ b/src/adapters/html-scraper/bali-hash-2.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
 import {
   parseBaliDate,
+  parseBaliTitle,
   parseListingCards,
   parseDetailFields,
   dedupeByRunNumber,
@@ -110,6 +111,30 @@ describe("parseBaliDate", () => {
   });
 });
 
+describe("parseBaliTitle", () => {
+  it.each([
+    [
+      "Bali Hash 2 Next Run Map - #1747 - Pura Pekemitan / Prajapati, Kediri, Tabanan - 30-May-26",
+      "Pura Pekemitan / Prajapati, Kediri, Tabanan",
+    ],
+    [
+      "Bali Hash 2 Next Run Map - #1746 - Lapangan Sepak Bola Perean, Baturiti - 23-May-26",
+      "Lapangan Sepak Bola Perean, Baturiti",
+    ],
+    // Single-digit day in the trailing date is still stripped.
+    [
+      "Bali Hash 2 Next Run Map - #1739 - Lapangan Mamed, Sindu Wati, Sidemen - 4-Apr-26",
+      "Lapangan Mamed, Sindu Wati, Sidemen",
+    ],
+  ])("strips the prefix + trailing date from %s", (title, expected) => {
+    expect(parseBaliTitle(title)).toBe(expected);
+  });
+
+  it("returns undefined when the title carries no run-number token", () => {
+    expect(parseBaliTitle("Bali Hash 2 About Us")).toBeUndefined();
+  });
+});
+
 describe("parseListingCards", () => {
   const entries = parseListingCards(HOME_FIXTURE);
 
@@ -124,6 +149,7 @@ describe("parseListingCards", () => {
     expect(e.date).toBe("2026-05-30");
     expect(e.startTime).toBe("16:00");
     expect(e.location).toBe("Pura Pekemitan / Prajapati, Kediri, Tabanan");
+    expect(e.title).toBe("Pura Pekemitan / Prajapati, Kediri, Tabanan");
     expect(e.url).toBe(
       "https://balihash2.com/bali-hash-2-next-run-map-1747-pura-pekemitan-prajapati-kediri-tabanan-30-may-26/",
     );
@@ -196,8 +222,8 @@ describe("BaliHash2Adapter.fetch", () => {
     expect(run1747.latitude).toBeCloseTo(-8.5835, 4);
     expect(run1747.longitude).toBeCloseTo(115.1270571, 4);
     expect(run1747.hares).toBe("Exit/Re Entry & Popoff Monster");
-    // Title left undefined → merge.ts synthesizes "Bali Hash 2 Trail #N".
-    expect(run1747.title).toBeUndefined();
+    // Title parsed from the post title (#1838), not the synthesized placeholder.
+    expect(run1747.title).toBe("Pura Pekemitan / Prajapati, Kediri, Tabanan");
     expect(run1747.locationUrl).toContain("google.com/maps");
   });
 

--- a/src/adapters/html-scraper/bali-hash-2.ts
+++ b/src/adapters/html-scraper/bali-hash-2.ts
@@ -83,7 +83,7 @@ const TITLE_EDGE_CHARS = " \t\n-–—:";
  */
 export function parseBaliTitle(postTitle: string): string | undefined {
   const hash = /#\d+/.exec(postTitle);
-  if (!hash || hash.index === undefined) return undefined;
+  if (hash?.index === undefined) return undefined;
   let rest = postTitle.slice(hash.index + hash[0].length);
   // Drop the trailing ` - D-MMM-YY` date the source appends. Two guards so a
   // location containing a date-like token (e.g. "Pura 12-Marching-26 …") can't
@@ -118,7 +118,8 @@ export interface BaliDetailFields {
  *  chrono `D MMM YY` fast-path fires (avoids the single-digit-day mis-parse). */
 export function parseBaliDate(text: string): string | undefined {
   const m = RUN_DATE_RE.exec(text);
-  if (!m || !VALID_MONTHS.has(m[2].toLowerCase())) return undefined;
+  if (!m) return undefined;
+  if (!VALID_MONTHS.has(m[2].toLowerCase())) return undefined;
   const normalized = `${m[1]} ${m[2]} ${m[3]}`;
   return chronoParseDate(normalized, "en-US") ?? undefined;
 }

--- a/src/adapters/html-scraper/bali-hash-2.ts
+++ b/src/adapters/html-scraper/bali-hash-2.ts
@@ -85,9 +85,21 @@ export function parseBaliTitle(postTitle: string): string | undefined {
   const hash = /#\d+/.exec(postTitle);
   if (!hash || hash.index === undefined) return undefined;
   let rest = postTitle.slice(hash.index + hash[0].length);
-  // Drop the trailing ` - D-MMM-YY` date the source appends.
+  // Drop the trailing ` - D-MMM-YY` date the source appends. Two guards so a
+  // location containing a date-like token (e.g. "Pura 12-Marching-26 …") can't
+  // be wrongly truncated: (1) the matched month must be a real month
+  // (VALID_MONTHS — same check as parseBaliDate), and (2) the match must be the
+  // trailing token (nothing but separators after it), since the date is always
+  // last in the post title.
   const date = RUN_DATE_RE.exec(rest);
-  if (date && date.index !== undefined) rest = rest.slice(0, date.index);
+  if (
+    date &&
+    date.index !== undefined &&
+    VALID_MONTHS.has(date[2].toLowerCase()) &&
+    rest.slice(date.index + date[0].length).trim() === ""
+  ) {
+    rest = rest.slice(0, date.index);
+  }
   const cleaned = trimEdgeChars(rest, TITLE_EDGE_CHARS);
   return cleaned.length > 0 ? cleaned : undefined;
 }

--- a/src/adapters/html-scraper/bali-hash-2.ts
+++ b/src/adapters/html-scraper/bali-hash-2.ts
@@ -12,6 +12,7 @@ import {
   normalizeHaresField,
   parse12HourTime,
   stripHtmlTags,
+  trimEdgeChars,
 } from "../utils";
 
 /**
@@ -61,9 +62,34 @@ export interface BaliListingEntry {
   date?: string;
   startTime?: string;
   location?: string;
+  /** Run descriptor from the post title (the location name the source titles
+   *  the post with) — `undefined` when the title doesn't parse. See #1838. */
+  title?: string;
   url: string;
   /** DOM order on the listing (0 = newest, reverse-chronological). */
   domIndex: number;
+}
+
+/** Edge characters trimmed off a parsed title segment (separators + space). */
+const TITLE_EDGE_CHARS = " \t\n-–—:";
+
+/**
+ * Parse the descriptive run title from a post title of the form
+ *   `Bali Hash 2 Next Run Map - #NNNN - <location> - D-MMM-YY`
+ * Returns the `<location>` middle segment (the source's own per-run descriptor)
+ * or undefined. Without this the adapter discards the title and merge.ts
+ * synthesizes the placeholder "Bali Hash 2 Trail #N" (#1838). Implemented with
+ * index slicing + `RUN_DATE_RE` (no `.*?`/`\s*` alternation) to stay S5852-safe.
+ */
+export function parseBaliTitle(postTitle: string): string | undefined {
+  const hash = /#\d+/.exec(postTitle);
+  if (!hash || hash.index === undefined) return undefined;
+  let rest = postTitle.slice(hash.index + hash[0].length);
+  // Drop the trailing ` - D-MMM-YY` date the source appends.
+  const date = RUN_DATE_RE.exec(rest);
+  if (date && date.index !== undefined) rest = rest.slice(0, date.index);
+  const cleaned = trimEdgeChars(rest, TITLE_EDGE_CHARS);
+  return cleaned.length > 0 ? cleaned : undefined;
 }
 
 /** Detail-page enrichment fields. */
@@ -142,6 +168,7 @@ export function parseListingCards(html: string): BaliListingEntry[] {
       date: parseBaliDate(excerpt) ?? parseBaliDate(title),
       startTime: parseStartTime(excerpt),
       location: parseLocation(excerpt),
+      title: parseBaliTitle(title),
       url,
       domIndex: domIndex++,
     });
@@ -229,7 +256,9 @@ export function buildEvent(entry: BaliListingEntry, detail: BaliDetailFields | n
     date: entry.date!,
     kennelTags: [KENNEL_TAG],
     runNumber: entry.runNumber,
-    // title left undefined → merge.ts synthesizes "Bali Hash 2 Trail #N".
+    // Descriptor from the post title (#1838); undefined → merge.ts synthesizes
+    // "Bali Hash 2 Trail #N".
+    title: entry.title,
     startTime: detail?.startTime ?? entry.startTime,
     location,
     locationUrl: location ? googleMapsSearchUrl(location) : undefined,

--- a/src/adapters/html-scraper/mijas-hash.test.ts
+++ b/src/adapters/html-scraper/mijas-hash.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/adapters/safe-fetch", () => ({ safeFetch: vi.fn() }));
 import { safeFetch } from "@/adapters/safe-fetch";
 import {
   parseRunNumber,
+  parseRunLabel,
   parseHares,
   parseHarelineLine,
   MijasHashAdapter,
@@ -26,6 +27,22 @@ describe("parseRunNumber", () => {
   it("returns null for non-numeric token", () => {
     expect(parseRunNumber("Glampout")).toBeNull();
   });
+});
+
+describe("parseRunLabel", () => {
+  it.each([
+    ["1999a", "a"],
+    ["1999b", "b"],
+  ])("captures the sub-letter from %s -> %s", (token, expected) => {
+    expect(parseRunLabel(token)).toBe(expected);
+  });
+
+  it.each([["2020"], ["2000"], ["Glampout"]])(
+    "returns undefined for a label-less token (%s)",
+    (token) => {
+      expect(parseRunLabel(token)).toBeUndefined();
+    },
+  );
 });
 
 describe("parseHares", () => {
@@ -77,13 +94,22 @@ describe("parseHarelineLine", () => {
     expect(event!.title).toBe("Mummy's Boy Birthday Run");
   });
 
-  it("strips a/b away-weekend suffix from the run number", () => {
+  it("splits a/b sub-runs into distinct events via eventLabel (#1848)", () => {
     const a = parseHarelineLine("1999a - 04 January 2026 - Stiffanny & From Behind", REF);
     const b = parseHarelineLine("1999b - 11 January 2026 - Big Brother & Blanka Wanka", REF);
+    // Base run number is shared; the sub-letter rides on eventLabel so the merge
+    // same-sourceUrl date-correction can't collapse the two dated sub-runs.
     expect(a!.runNumber).toBe(1999);
+    expect(a!.eventLabel).toBe("a");
     expect(a!.date).toBe("2026-01-04");
     expect(b!.runNumber).toBe(1999);
-    expect(b!.date).toBe("2026-01-11"); // distinct date keeps the two days separate
+    expect(b!.eventLabel).toBe("b");
+    expect(b!.date).toBe("2026-01-11");
+  });
+
+  it("emits no eventLabel for a plain integer run number", () => {
+    const event = parseHarelineLine("2020 - 31 May 2026 - Shaggy & AguaSex - AGM Run", REF);
+    expect(event!.eventLabel).toBeUndefined();
   });
 
   it("parses the date from the line, not from order (Aug parses independently)", () => {

--- a/src/adapters/html-scraper/mijas-hash.ts
+++ b/src/adapters/html-scraper/mijas-hash.ts
@@ -38,12 +38,26 @@ const FIELD_DELIM_RE = /(?<=\s)-|-(?=\s)/;
 
 /**
  * Parse the leading run number, dropping any `a`/`b` away-weekend suffix
- * (e.g. `1999a`/`1999b` share base #1999; kennel+date dedup keeps the two
- * days distinct). Returns null when the segment isn't a run number.
+ * (e.g. `1999a`/`1999b` share base #1999). Returns null when the segment
+ * isn't a run number. The suffix is preserved separately via `parseRunLabel`
+ * and emitted as `eventLabel` so the two sub-runs stay distinct events.
  */
 export function parseRunNumber(token: string): number | null {
   const match = token.trim().match(/^(\d+)[ab]?\b/);
   return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Parse the `a`/`b` sub-letter that Mijas appends when two trails share a base
+ * run number on different dates (e.g. `1999a` Memorial Run + `1999b` the week
+ * after — issue #1848). Returned as `eventLabel`; without it both rows collapse
+ * to `(sourceUrl, runNumber=1999)` and the merge same-sourceUrl date-correction
+ * moves one onto the other's date, dropping a real event. Returns undefined for
+ * a plain integer run number.
+ */
+export function parseRunLabel(token: string): string | undefined {
+  const match = token.trim().match(/^\d+([ab])\b/);
+  return match ? match[1] : undefined;
 }
 
 /**
@@ -80,6 +94,7 @@ export function parseHarelineLine(
   if (!date) return null;
 
   const runNumber = parseRunNumber(trimmed);
+  const eventLabel = parseRunLabel(trimmed);
 
   const remainder = trimmed.slice(dateMatch.index + dateMatch[0].length);
   const tokens = remainder.split(FIELD_DELIM_RE).map((t) => t.trim());
@@ -91,6 +106,10 @@ export function parseHarelineLine(
     date,
     kennelTags: [KENNEL_TAG],
     runNumber: runNumber ?? undefined,
+    // `a`/`b` sub-letter (#1848). Distinguishes two same-run-number trails on
+    // different dates so the merge date-correction doesn't collapse them; only
+    // emitted when a suffix is present, so normal rows fingerprint unchanged.
+    eventLabel,
     // Leave title undefined when there's no real theme — merge.ts synthesizes
     // "Mijas H3 Trail #N". Never let a hare name become the title.
     title: theme.length > 0 ? theme : undefined,

--- a/src/adapters/html-scraper/mijas-hash.ts
+++ b/src/adapters/html-scraper/mijas-hash.ts
@@ -56,7 +56,7 @@ export function parseRunNumber(token: string): number | null {
  * a plain integer run number.
  */
 export function parseRunLabel(token: string): string | undefined {
-  const match = token.trim().match(/^\d+([ab])\b/);
+  const match = /^\d+([ab])\b/.exec(token.trim());
   return match ? match[1] : undefined;
 }
 

--- a/src/adapters/html-scraper/onh3.test.ts
+++ b/src/adapters/html-scraper/onh3.test.ts
@@ -5,6 +5,7 @@ import {
   parseLabeledFields,
   parseOnh3Title,
   deriveTheme,
+  composeVenueTitle,
   postToEvent,
   parseHarelineTable,
 } from "./onh3";
@@ -89,6 +90,25 @@ describe("parseOnh3Title / deriveTheme", () => {
   });
 });
 
+describe("composeVenueTitle", () => {
+  it("returns the venue alone when no area", () => {
+    expect(composeVenueTitle("Kingfisher")).toBe("Kingfisher");
+  });
+  it("appends a distinct area in parens", () => {
+    expect(composeVenueTitle("Kingfisher", "Westlands")).toBe("Kingfisher (Westlands)");
+  });
+  it("omits a duplicate area (case-insensitive)", () => {
+    expect(composeVenueTitle("Karen", "karen")).toBe("Karen");
+  });
+  it.each([
+    [undefined, "Westlands"],
+    [null, "Westlands"],
+    ["", "Westlands"],
+  ])("returns undefined with no venue (%s)", (venue, area) => {
+    expect(composeVenueTitle(venue, area)).toBeUndefined();
+  });
+});
+
 describe("postToEvent", () => {
   // Captured live 2026-05-29 from the WordPress.com REST API (run 1326 post).
   const RUN_1326 = post(
@@ -111,7 +131,9 @@ describe("postToEvent", () => {
     expect(ev.locationUrl).toMatch(/maps\.app\.goo\.gl/);
     expect(ev.startTime).toBe("17:45");
     expect(ev.kennelTags).toEqual(["onh3"]);
-    expect(ev.title).toBeUndefined(); // no theme → merge synthesizes the canonical title
+    // No theme on this title → fall back to the venue rather than the
+    // synthesized "ONH3 Trail #N" placeholder (#1862).
+    expect(ev.title).toBe("Spring Valley Oven Restaurant");
   });
 
   it("handles per-block fields and stops the venue before an unlabeled recap", () => {
@@ -213,12 +235,15 @@ describe("parseHarelineTable", () => {
       runNumber: 1340,
       hares: "Glossy",
       location: "Matteo’s Italian Restaurant",
+      title: "Matteo’s Italian Restaurant (Karen)", // venue (+ area) title (#1862)
       startTime: "17:45",
       kennelTags: ["onh3"],
     });
   });
 
-  it("includes a row dated exactly today", () => {
-    expect(parseHarelineTable(TABLE, "2026-01-05").map((e) => e.runNumber)).toContain(1314);
+  it("includes a row dated exactly today and extracts its Hare column (#1863)", () => {
+    const row = parseHarelineTable(TABLE, "2026-01-05").find((e) => e.runNumber === 1314);
+    expect(row).toBeDefined();
+    expect(row!.hares).toBe("STFU & Blown Fuse"); // Hare column promoted to haresText
   });
 });

--- a/src/adapters/html-scraper/onh3.ts
+++ b/src/adapters/html-scraper/onh3.ts
@@ -2,7 +2,7 @@ import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { stripHtmlTags, decodeEntities, googleMapsSearchUrl, MONTHS, extractHashRunNumber, stripPlaceholder } from "../utils";
+import { stripHtmlTags, decodeEntities, googleMapsSearchUrl, MONTHS, extractHashRunNumber, stripPlaceholder, trimEdgeChars } from "../utils";
 import { safeFetch } from "../safe-fetch";
 
 /**
@@ -125,15 +125,6 @@ export function parseOnh3Title(title: string): { runNumber?: number; theme?: str
 
 const THEME_EDGE_CHARS = " \t\n.-–|";
 
-/** Trim leading/trailing separator chars without a regex (ReDoS-safe). */
-function trimEdgeChars(s: string): string {
-  let lo = 0;
-  let hi = s.length;
-  while (lo < hi && THEME_EDGE_CHARS.includes(s[lo])) lo++;
-  while (hi > lo && THEME_EDGE_CHARS.includes(s[hi - 1])) hi--;
-  return s.slice(lo, hi);
-}
-
 /**
  * Derive a human theme from the title, or undefined. Leaving it undefined lets
  * merge.ts synthesize the canonical "ONH3 Trail #N" title (a theme must never
@@ -146,7 +137,7 @@ export function deriveTheme(title: string): string | undefined {
     .replace(RUN_NUMBER_RE, "");
   // Trim leading/trailing separators procedurally — a `^[…]+|[…]+$` regex trips
   // SonarCloud's ReDoS heuristic (S5852) even though it's linear here.
-  const cleaned = trimEdgeChars(stripped);
+  const cleaned = trimEdgeChars(stripped, THEME_EDGE_CHARS);
   if (cleaned.length === 0) return undefined;
   // A remainder carrying labeled fields ("Hare: …", "Venue: …") is not a theme.
   if (/\b(?:Hares?|Venue|Date|Location)\s*:/i.test(cleaned)) return undefined;
@@ -163,6 +154,23 @@ function cleanVenue(venue: string | undefined): string | undefined {
   if (!venue) return undefined;
   const period = venue.indexOf(". ");
   return period >= 15 ? venue.slice(0, period).trim() : venue;
+}
+
+/**
+ * Compose an event title from the venue (and optional area) when the source
+ * carries no theme — e.g. the Hareline table's Venue column. Without this,
+ * every hareline-sourced run falls back to the synthesized "ONH3 Trail #N"
+ * placeholder even though the venue is known (#1862). Returns undefined when
+ * there's no venue, so a truly bare row still synthesizes the default.
+ */
+export function composeVenueTitle(
+  venue: string | undefined | null,
+  area?: string | undefined | null,
+): string | undefined {
+  const v = venue?.trim();
+  if (!v) return undefined;
+  const a = area?.trim();
+  return a && a.toLowerCase() !== v.toLowerCase() ? `${v} (${a})` : v;
 }
 
 function flatten(html: string): string {
@@ -208,7 +216,9 @@ export function postToEvent(post: WPComPost): RawEventData | null {
     date,
     kennelTags: [KENNEL_TAG],
     runNumber,
-    title: theme,
+    // Real theme wins; otherwise fall back to the venue so a venue-only post
+    // gets a descriptive title instead of the synthesized "ONH3 Trail #N" (#1862).
+    title: theme ?? composeVenueTitle(venue),
     hares,
     location: venue,
     locationUrl,
@@ -249,6 +259,9 @@ export function parseHarelineTable(post: WPComPost, today: string): RawEventData
       date,
       kennelTags: [KENNEL_TAG],
       runNumber,
+      // Venue (+ area) title so hareline rows aren't stuck on the synthesized
+      // "ONH3 Trail #N" placeholder (#1862); undefined when the row has no venue.
+      title: composeVenueTitle(venue, area),
       hares,
       location: venue,
       locationUrl: venueQuery ? googleMapsSearchUrl(`${venueQuery} Nairobi Kenya`) : undefined,

--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -765,10 +765,17 @@ describe("PhoenixHHHAdapter.fetch — detail-fetch failures are visible", () => 
     `;
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    // First call: the month AJAX returns the list HTML.
-    fetchSpy.mockResolvedValueOnce(new Response(sampleAjaxResponse, { status: 200 }));
-    // Every detail-page fetch returns 503 (origin rate-limit / outage).
-    fetchSpy.mockImplementation(async () => new Response("Service Unavailable", { status: 503 }));
+    // Route by URL, not call order: month-list AJAX calls succeed (there are TWO
+    // when "today" is in the last days of a month — the date window spills into
+    // next month), and only the detail-page fetch (?event=…) returns 503. Keying
+    // on the URL keeps the surfaced error a detail-fetch failure regardless of
+    // the current date (an order-based mock flaked at month boundaries).
+    fetchSpy.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      return url.includes("?event=")
+        ? new Response("Service Unavailable", { status: 503 })
+        : new Response(sampleAjaxResponse, { status: 200 });
+    });
 
     const adapter = new PhoenixHHHAdapter();
     const source = {

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -941,6 +941,21 @@ function trimTrailingWhitespace(s: string): string {
 }
 
 /**
+ * Trim leading/trailing characters that appear in `edgeChars` from a string,
+ * procedurally. Used by adapters to strip separator/decoration chars off a
+ * parsed title or theme segment without an anchored `^[…]+|[…]+$` regex, which
+ * SonarCloud flags as a ReDoS shape (S5852) even when linear. `edgeChars` is the
+ * per-caller set (e.g. `" \t\n.-–|"` for theme text, `" \t\n-–—:"` for titles).
+ */
+export function trimEdgeChars(value: string, edgeChars: string): string {
+  let lo = 0;
+  let hi = value.length;
+  while (lo < hi && edgeChars.includes(value[lo])) lo++;
+  while (hi > lo && edgeChars.includes(value[hi - 1])) hi--;
+  return value.slice(lo, hi);
+}
+
+/**
  * Strip a trailing Google-Maps "(Link)" or bare " Link" anchor (#1729 / #1258).
  * Procedural rather than a `\s*\(\s*link\s*\)\s*$` regex, which Sonar S5852
  * flags as ReDoS-prone (memory `feedback_sonar_s5852_procedural_over_regex`).

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -4968,4 +4968,57 @@ describe("same-sourceUrl date-correction dedup (#1613 / #1648)", () => {
     );
     expect(phantomUpdate).toBeUndefined();
   });
+
+  it("Mijas-shape: distinct eventLabel prevents collapse of two same-run-number sub-runs (#1848)", async () => {
+    // 1999a (label "a") and 1999b (label "b") share a fixed hareline sourceUrl
+    // and base runNumber 1999 on dates 7d apart. The probe must filter on the
+    // incoming label so 1999a never date-corrects (moves) a 1999b canonical.
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([]); // cache prefetch empty
+    // Probe finds no candidate sharing label "a" (the only canonical is "b").
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(null);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_1999a"));
+
+    const result = await processRawEvents("src_mijas", [
+      buildRawEvent({
+        date: "2026-01-04",
+        kennelTags: ["mijash3"],
+        sourceUrl: "https://www.mijash3.com/hareline",
+        runNumber: 1999,
+        eventLabel: "a",
+      }),
+    ]);
+
+    // No collapse — 1999a is created as its own event.
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(0);
+    const probeWhere = (vi.mocked(prisma.event.findFirst).mock.calls[0][0] as {
+      where: { eventLabel: string | null; runNumber: number };
+    }).where;
+    expect(probeWhere.runNumber).toBe(1999);
+    expect(probeWhere.eventLabel).toBe("a"); // same-label only
+  });
+
+  it("non-regression: a label-less event probes eventLabel:null (matches existing canonicals)", async () => {
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([]);
+    mockEventFindMany.mockResolvedValueOnce([]);
+    vi.mocked(prisma.event.findFirst).mockResolvedValueOnce(buildCorrectionCandidate());
+    mockEventUpdate.mockResolvedValueOnce(eventRow("evt_phantom"));
+
+    await processRawEvents("src_sfh3_html", [
+      buildRawEvent({
+        date: "2026-05-09",
+        kennelTags: ["marinh3"],
+        sourceUrl: "https://www.sfh3.com/runs/6443",
+        runNumber: 291,
+        // no eventLabel
+      }),
+    ]);
+
+    const probeWhere = (vi.mocked(prisma.event.findFirst).mock.calls[0][0] as {
+      where: { eventLabel: string | null };
+    }).where;
+    expect(probeWhere.eventLabel).toBeNull(); // undefined → null preserves legacy match
+  });
 });

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1352,6 +1352,13 @@ async function upsertCanonicalEvent(
         sourceUrl: event.sourceUrl,
         eventKennels: { some: { kennelId } },
         runNumber: event.runNumber,
+        // #1848 — sub-letter discriminator. Mijas-style kennels reuse one base
+        // run number across two dated sub-runs (1999a / 1999b) on a fixed
+        // hareline `sourceUrl`. Without this, the second sub-run "date-corrects"
+        // (moves) the first's canonical instead of staying distinct. `?? null`
+        // keeps the normal case unchanged: label-less events (undefined → null)
+        // still match the existing label-less canonicals (#1613/#1648/#1643).
+        eventLabel: event.eventLabel ?? null,
         date: {
           gte: new Date(eventDate.getTime() - windowMs),
           lte: new Date(eventDate.getTime() + windowMs),


### PR DESCRIPTION
## New-kennel hardening — Mijas 🇪🇸 + Bali Hash 2 🇮🇩 + ONH3 🇰🇪

Closes 7 post-onboarding audit gaps for three cycle-14/15 kennels. Each issue was verified against **prod** (read-only psql) before coding — a few had partially self-healed, which scoped the work.

### Fixes

| Issue | Fix |
|---|---|
| **#1848** Mijas sub-letter dropped | Adapter emits `eventLabel` ("a"/"b") for `1999a`/`1999b` (base `runNumber` unchanged); the merge same-sourceUrl date-correction now co-matches on `eventLabel`. Root cause: both sub-runs shared the fixed hareline `sourceUrl` + base run number, so the second "date-corrected" (moved) the first's canonical instead of staying distinct. |
| **#1838** Bali stale titles (78/78) | Parse the descriptive title from the Ghost post title (`… - #N - <location> - D-MMM-YY`) instead of defaulting to `Bali Hash 2 Trail #N`. |
| **#1862** ONH3 stale titles (108) | `parseHarelineTable` + venue-only `postToEvent` now emit a `venue (area)` title; backfill emits it too so the 72 past stale-with-venue rows repaint on re-run. Venue-less rows correctly stay synthesized. |
| **#1863** ONH3 missing hares | Extraction already works (both adapter paths + backfill); prod self-healed 114→28 nulls and the remaining 28 are source-unassigned future rows. Added an explicit hareline-column regression test. |
| **#1864** ONH3 contactEmail | Seed-fill `onh3mismanagement@gmail.com` (null in prod). |
| **#1839** Bali profile | `hashCash` already correct; `facebookUrl` → `/groups/balihash2/` (one-shot cleanup — seed won't overwrite non-null). |
| **#1849** Mijas profile | `website` already set; `contactEmail` → `info@mijash3.com` per owner decision (one-shot cleanup). |

### Quality
- Extracted shared `trimEdgeChars(value, chars)` into `adapters/utils.ts` (dedups onh3 + bali edge-trim helpers) — `/simplify` reuse finding.
- Docs: title/hares/sub-letter lessons in `daily-onboarding-prompt.md`; new Ghost-blog platform note in `source-platform-notes.md`.

### Verification
- `npx tsc --noEmit` clean, `npm run lint` 0 errors, full suite green (8102 passed). CI: `test`, `SonarCloud` (0 new issues, 0% dup), and `Codacy` all pass. Also fixed a pre-existing, date-sensitive `phoenixhhh.test.ts` month-boundary flake (mock now routes by URL) that was surfacing on the May→June boundary.
- **Live-verified** all three adapters against production: Mijas emits both #1999a/#1999b with labels a/b; Bali 11/11 titles parsed; ONH3 per-post venue/theme titles populate (future hareline rows correctly blank where the source is unassigned).
- `/codex:adversarial-review` could **not** run this session — Codex hit its usage limit (resets Jun 1). `/simplify` ran (applied the `trimEdgeChars` dedup).

### Post-merge prod cleanup (operator steps)
Seed/data changes don't apply on Vercel deploy. After merge, with Node 20 + prod `DATABASE_URL`:
1. `npx prisma db seed` — fills ONH3 contactEmail.
2. `npx tsx scripts/cleanup-new-kennel-profiles.ts --execute` — Bali facebookUrl + Mijas email (drift-guarded).
3. `BACKFILL_APPLY=1 npx tsx scripts/backfill-{bali-hash-2,onh3,mijash3}-history.ts` — repaint stale titles via re-merge.
4. Re-scrape the 3 sources — creates Mijas #1999a + applies future titles.


### Closes
Closes #1848
Closes #1849
Closes #1838
Closes #1839
Closes #1862
Closes #1863
Closes #1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

