### PR TITLE
fix(test): pin clock in PhoenixHHH detail-fetch-failure test to avoid month-boundary flakiness

### DIFF
--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -745,8 +745,17 @@ describe("fetchEventDetail", () => {
 
 describe("PhoenixHHHAdapter.fetch — detail-fetch failures are visible", () => {
   it("records detail-fetch failures in errorDetails.fetch (bounded sample)", async () => {
-    // Build a fixture with TODAY's date so it falls inside the
-    // adapter's date window regardless of when the test runs.
+    // Pin the clock to a mid-month date (fake only `Date`, leaving real
+    // timers so the async fetch mocks still resolve). Near a month boundary
+    // the adapter issues a SECOND month-AJAX fetch for the next month, which
+    // the single mockResolvedValueOnce below doesn't cover — it would fall
+    // through to the 503 mockImplementation and surface a "Month N: HTTP 503"
+    // error as fetch[0] instead of the detail-fetch error this test asserts.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(Date.UTC(2026, 5, 15, 12, 0, 0)));
+
+    // Build a fixture with TODAY's (pinned) date so it falls inside the
+    // adapter's date window.
     const now = new Date();
     const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
     const dd = String(now.getUTCDate()).padStart(2, "0");
@@ -779,6 +788,7 @@ describe("PhoenixHHHAdapter.fetch — detail-fetch failures are visible", () => 
 
     const result = await adapter.fetch(source, { days: 1 });
     vi.restoreAllMocks();
+    vi.useRealTimers();
 
     // Events still parse (list-view fallback).
     expect(result.events.length).toBeGreaterThan(0);

--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -744,16 +744,22 @@ describe("fetchEventDetail", () => {
 // ── Detail-fetch failures surface in errorDetails (codex follow-up) ──
 
 describe("PhoenixHHHAdapter.fetch — detail-fetch failures are visible", () => {
-  it("records detail-fetch failures in errorDetails.fetch (bounded sample)", async () => {
-    // Pin the clock to a mid-month date (fake only `Date`, leaving real
-    // timers so the async fetch mocks still resolve). Near a month boundary
-    // the adapter issues a SECOND month-AJAX fetch for the next month, which
-    // the single mockResolvedValueOnce below doesn't cover — it would fall
-    // through to the 503 mockImplementation and surface a "Month N: HTTP 503"
-    // error as fetch[0] instead of the detail-fetch error this test asserts.
+  // Pin the clock to a mid-month date before each test (fake only `Date`,
+  // leaving real timers so async fetch mocks still resolve). Near a month
+  // boundary the adapter issues a SECOND month-AJAX fetch for the next month,
+  // which the single mockResolvedValueOnce below doesn't cover — it would fall
+  // through to the 503 mockImplementation and surface a "Month N: HTTP 503"
+  // error as fetch[0] instead of the detail-fetch error this test asserts.
+  // Cleanup in afterEach guarantees restoration even if a test throws.
+  beforeEach(() => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date(Date.UTC(2026, 5, 15, 12, 0, 0)));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
+  it("records detail-fetch failures in errorDetails.fetch (bounded sample)", async () => {
     // Build a fixture with TODAY's (pinned) date so it falls inside the
     // adapter's date window.
     const now = new Date();
@@ -788,7 +794,6 @@ describe("PhoenixHHHAdapter.fetch — detail-fetch failures are visible", () => 
 
     const result = await adapter.fetch(source, { days: 1 });
     vi.restoreAllMocks();
-    vi.useRealTimers();
 
     // Events still parse (list-view fallback).
     expect(result.events.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- Pins `Date` to June 15 (mid-month) in the `"records detail-fetch failures in errorDetails.fetch"` test using `vi.useFakeTimers({ toFake: ["Date"] })` + `vi.setSystemTime()`
- Only `Date` is faked — real async timers remain so `fetch` mocks resolve normally
- Restores with `vi.useRealTimers()` at teardown alongside the existing `vi.restoreAllMocks()`

## Problem

Near a month boundary the Phoenix HHH adapter issues a **second** month-AJAX fetch for the following month. The test only installed one `mockResolvedValueOnce` (for the current month), so that second call fell through to the `503 mockImplementation` and surfaced a `"Month N/YYYY: HTTP 503"` entry as `errorDetails.fetch[0]` instead of the expected detail-fetch error — causing the `/Detail fetch/i` assertion to fail.

This was a **pre-existing flake** (fails on a clean tree near a month boundary; independent of any unrelated adapter work).

## Test plan

- [x] `npx vitest run src/adapters/html-scraper/phoenixhhh.test.ts` → 56/56 passed
- [x] Date-stable: pinned clock means the result is independent of the real system clock

🤖 Generated with [Claude Code](https://claude.ai/claude-code)