### PR TITLE
fix(test): pin clock in date-sensitive adapter tests to prevent rollover rot

### DIFF
--- a/src/adapters/html-scraper/hangover.test.ts
+++ b/src/adapters/html-scraper/hangover.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseHangoverTitle,
   parseHangoverDate,
@@ -7,6 +7,19 @@ import {
   cleanHangoverLocation,
   HangoverAdapter,
 } from "./hangover";
+
+// Pin the clock so date-window-filtered fixtures don't rot. Adapter fetch()
+// filters events through a rolling ±days window (default 365), so fixtures with
+// a fixed past date silently age out once real time passes. Fake only Date
+// (not all timers) so awaited fetch/Ghost-API mocks still resolve. 2026-03-01
+// keeps every fixture date in window: [2025-03-01, 2027-03-01].
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-03-01T12:00:00.000Z"));
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("parseHangoverTitle", () => {
   it("parses standard title", () => {

--- a/src/adapters/html-scraper/ofh3.test.ts
+++ b/src/adapters/html-scraper/ofh3.test.ts
@@ -5,6 +5,19 @@ import * as bloggerApi from "../blogger-api";
 
 vi.mock("../blogger-api");
 
+// Pin the clock so date-window-filtered fixtures don't rot. Adapter fetch()
+// filters events through a rolling ±days window (default 365), so fixtures with
+// a fixed past date silently age out once real time passes. Fake only Date
+// (not all timers) so awaited fetch/blogger mocks still resolve. 2026-03-01
+// keeps every fixture date in window: [2025-03-01, 2027-03-01].
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-03-01T12:00:00.000Z"));
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 // Typed factory so tests can pass a partial Source without per-call
 // `as never` — Source has 14+ required fields the adapter never reads.
 function fakeSource(overrides: Partial<Source> & Pick<Source, "id" | "url">): Source {


### PR DESCRIPTION
## Problem

`src/adapters/html-scraper/ofh3.test.ts` started failing on **2026-06-01** with no code change — pure fixture rot.

Adapter `fetch()` methods filter events through a **rolling ±`days` window** (`filterEventsByWindow`, default `days = options?.days ?? source.scrapeDays ?? 365`). A test that builds a fixture with a fixed past calendar date and asserts the event survives `fetch()` silently breaks once real wall-clock time passes `fixtureDate + 365d`: the event is filtered out → `result.events` is empty → `expected [] to have a length of 1`.

The failing test: `OFH3Adapter title fallback > "extracts date from title when body has no When field"` (fixture event date `2025-06-01`, no `scrapeDays` override). `hangover.test.ts` carries the same latent rot in its 2025/2026 `.fetch()` fixtures (would break in ~2027).

## Fix

Pin the system clock to `2026-03-01T12:00:00.000Z` in a **file-level `beforeEach`/`afterEach`** in both files, so date-window filtering is deterministic regardless of when the suite runs. This matches the established house convention (`samurai-h3`, `enfield-hash`, `phoenixhhh`, `bali-hash-2`, et al.).

- **`toFake: ["Date"]`** (not bare `useFakeTimers()`) so awaited `fetch` / blogger / Ghost-API mocks still resolve — only `Date` is faked, not the timer/microtask queue.
- **`2026-03-01`** keeps every fixture date in window `[2025-03-01, 2027-03-01]` (ofh3: `2025-06-01`, `2026-02-08`, `2026-03-14`; hangover: `2025-12-07` … `2026-04-05`).
- Setup/teardown in `beforeEach`/`afterEach` (never inline) so `useRealTimers()` always runs even if an assertion throws.

**Test-only change — no production code touched.**

## Verification

- `npx vitest run` on both files: green (previously-failing test now passes).
- Full CI gate: `npx tsc --noEmit` clean, `npm run lint` 0 errors, `npm test` **8162 passed / 284 files**.
- `/simplify` (4 cleanup agents) and `/codex:adversarial-review` both ran — no findings; matches existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)