### PR TITLE
fix(h7): clean synthesized titles (friendlyKennelName mid-string + Hamburg H7 shortName)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2759,7 +2759,7 @@ export const KENNELS: KennelSeed[] = [
       latitude: 50.11, longitude: 8.68,
     },
     {
-      kennelCode: "h7", shortName: "H7", fullName: "Hansestadt Hamburg Hash House Harriers Hummel Hummel", region: "Hamburg", country: "Germany",
+      kennelCode: "h7", shortName: "Hamburg H7", fullName: "Hansestadt Hamburg Hash House Harriers Hummel Hummel", region: "Hamburg", country: "Germany",
       website: "https://hamburghash.blogspot.com/",
       facebookUrl: "https://www.facebook.com/groups/280388972016079",
       scheduleDayOfWeek: "Sunday", scheduleTime: "2:00 PM", scheduleFrequency: "Biweekly (1st & 3rd Sundays)",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -304,6 +304,21 @@ async function ensureKennelRecords(prisma: any, kennels: KennelSeed[], toSlugFn:
         if (kennel.slug && record.slug !== kennel.slug) {
           updates.slug = kennel.slug;
         }
+        // Propagate a shortName rename — the seed is the source of truth for it.
+        // The NULL-fill loop above only touches PROFILE_FIELDS, so without this a
+        // rename like "H7" → "Hamburg H7" (#1895) would never reach an existing
+        // row. Preserve the old value as an alias so resolution by the prior name
+        // survives; kennelCode is immutable and unaffected. (fullName is left
+        // alone deliberately — several rows carry admin-curated fullNames that
+        // diverge from seed and shouldn't be clobbered.)
+        if (kennel.shortName && record.shortName !== kennel.shortName) {
+          updates.shortName = kennel.shortName;
+          await prisma.kennelAlias.upsert({
+            where: { kennelId_alias: { kennelId: record.id, alias: record.shortName } },
+            update: {},
+            create: { kennelId: record.id, alias: record.shortName },
+          });
+        }
         if (Object.keys(updates).length > 0) {
           record = await prisma.kennel.update({
             where: { id: record.id },

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -2448,6 +2448,24 @@ describe("friendlyKennelName", () => {
     expect(friendlyKennelName("HHH", "Hash House Harriers")).toBe("HHH");
   });
 
+  // Mid-string "Hash House Harriers" (not just suffix) must still be stripped —
+  // the old suffix-only regex left these fully verbose. (H7 follow-up)
+  it.each([
+    // shortName, fullName, expected
+    ["RH3C", "Renegade Hash House Harriers Columbus", "Renegade Columbus H3"],
+    ["HHHS", "Hash House Harriers Singapore", "Singapore H3"],
+    ["SOH4", "Syracuse On-On-Dog-A Hash House Harriers & Harriettes", "Syracuse On-On-Dog-A H3"],
+    ["SLH3", "SLASH (South London Hash House Harriers)", "SLASH H3"],
+  ])("strips mid-string HHH: %s", (short, full, expected) => {
+    expect(friendlyKennelName(short, full as string)).toBe(expected);
+  });
+
+  it("returns the >4-char shortName verbatim for H7 (Hamburg H7), bypassing the verbose fullName", () => {
+    expect(
+      friendlyKennelName("Hamburg H7", "Hansestadt Hamburg Hash House Harriers Hummel Hummel"),
+    ).toBe("Hamburg H7");
+  });
+
   it("handles 'Hash House Harriers and Harriettes' suffix (DH4)", () => {
     expect(friendlyKennelName("DH4", "Dayton Hash House Harriers and Harriettes")).toBe("Dayton H3");
   });

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -2456,6 +2456,8 @@ describe("friendlyKennelName", () => {
     ["HHHS", "Hash House Harriers Singapore", "Singapore H3"],
     ["SOH4", "Syracuse On-On-Dog-A Hash House Harriers & Harriettes", "Syracuse On-On-Dog-A H3"],
     ["SLH3", "SLASH (South London Hash House Harriers)", "SLASH H3"],
+    // Single-t "Harriets" trailing co-name (Gemini review #1895).
+    ["LH4", "Hong Kong Ladies Hash House Harriers & Harriets", "Hong Kong Ladies H3"],
   ])("strips mid-string HHH: %s", (short, full, expected) => {
     expect(friendlyKennelName(short, full as string)).toBe(expected);
   });

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -190,12 +190,25 @@ export function sanitizeHares(hares: string | undefined | null): string | null {
 /**
  * Derive a user-friendly kennel name for default event titles.
  * For short/cryptic codes (≤4 chars), derives a readable name from fullName.
- * Strips "Hash House Harriers" suffix and appends "H3" when appropriate.
+ * Strips the "Hash House Harriers" token (wherever it sits, not just the
+ * suffix) and appends "H3" when appropriate. Mid-string strip matters for
+ * kennels whose name wraps the token, e.g. "Renegade Hash House Harriers
+ * Columbus", "Hash House Harriers Singapore", or "SLASH (South London Hash
+ * House Harriers)" — the old suffix-only strip left those fully verbose.
+ *
+ * Spaces are written as literal ` ?` (not `\s*`) around the alternation to
+ * keep the pattern ReDoS-linear (Sonar S5852).
  */
 export function friendlyKennelName(shortName: string, fullName: string | null): string {
   if (shortName.length > 4) return shortName;
   if (!fullName) return shortName;
-  const friendly = fullName.replace(/\s*Hash House Harriers?(?:\s+and\s+Harriettes?)?\s*$/i, "").trim();
+  const friendly = fullName
+    // Drop a parenthetical that wraps the token, e.g. "(South London Hash House Harriers)".
+    .replace(/\s*\([^)]*Hash House Harriers[^)]*\)/i, "")
+    // Strip the token itself + an optional trailing "and/& Harriettes".
+    .replace(/Hash House Harriers?(?: ?(?:and|&) ?Harriettes?)?/i, " ")
+    .replace(/\s+/g, " ")
+    .trim();
   if (!friendly || friendly === shortName) return shortName;
   const hadHHH = /Hash House Harriers?/i.test(fullName);
   return hadHHH ? `${friendly} H3` : friendly;

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -203,10 +203,13 @@ export function friendlyKennelName(shortName: string, fullName: string | null): 
   if (shortName.length > 4) return shortName;
   if (!fullName) return shortName;
   const friendly = fullName
-    // Drop a parenthetical that wraps the token, e.g. "(South London Hash House Harriers)".
-    .replace(/\s*\([^)]*Hash House Harriers[^)]*\)/i, "")
-    // Strip the token itself + an optional trailing "and/& Harriettes".
-    .replace(/Hash House Harriers?(?: ?(?:and|&) ?Harriettes?)?/i, " ")
+    // Drop a parenthetical that wraps the token, e.g. "(South London Hash House
+    // Harriers)". Single- and double-t Harriet(te)s spellings both occur.
+    .replace(/\s*\([^)]*Hash House Harri(?:ers?|ett?e?s?)[^)]*\)/i, "")
+    // Strip "Hash House Harriers" + an optional trailing "and/& Harriet(te)s".
+    // The standalone women's "Hash House Harriettes" name is intentionally left
+    // verbatim (it's not the standard HHH suffix) — see test below.
+    .replace(/Hash House Harriers?(?: ?(?:and|&) ?Harriett?e?s?)?/i, " ")
     .replace(/\s+/g, " ")
     .trim();
   if (!friendly || friendly === shortName) return shortName;


### PR DESCRIPTION
## Summary
Follow-up to #1886. H7's placeholder/untitled events synthesized as **"Hansestadt Hamburg Hash House Harriers Hummel Hummel H3 Trail #N"** — verbose and inconsistent with the HC source's "Hamburg H7 Trail #N". Two complementary fixes:

### A. `friendlyKennelName` strips "Hash House Harriers" mid-string (`src/pipeline/merge.ts`)
The old regex was suffix-anchored (`…$`), so it left the token intact when it sat mid-name. Now it strips the token wherever it appears (and drops a parenthetical that wraps it). Fixes **5 kennels** with shortName ≤4 + mid-string HHH:

| Kennel | Before | After |
| --- | --- | --- |
| renh3 | Renegade Hash House Harriers Columbus | **Renegade Columbus H3** |
| hhhs | Hash House Harriers Singapore | **Singapore H3** |
| slh3 | SLASH (South London Hash House Harriers) | **SLASH H3** |
| soh4 | Syracuse On-On-Dog-A HHH & Harriettes | **Syracuse On-On-Dog-A H3** |
| h7 | (see B) | (see B) |

Spaces written as literal ` ?` (not `\s*`) around the alternation to keep the pattern ReDoS-linear (Sonar S5852). Existing suffix cases (Galveston H3, Harrisburg-Hershey H3, Dayton H3, etc.) unchanged.

### B. h7 `shortName` "H7" → "Hamburg H7" (`prisma/seed-data/kennels.ts`)
`friendlyKennelName` returns the shortName verbatim when it's >4 chars, so this makes H7's titles **"Hamburg H7 Trail #N"** (matching the HC `defaultTitle`) and brands the kennel as "Hamburg H7". **A alone is not enough for H7** — `friendlyKennelName("H7", fullName)` still yields "Hansestadt Hamburg Hummel Hummel H3"; B short-circuits that. `"H7"` remains an alias and `kennelCode` (`h7`) is unchanged, so kennel resolution and HC's `kennelUniqueShortName: "H7"` filter are unaffected.

## Why both (re: an automated reviewer suggesting B is redundant)
A is the general root-cause fix (5 kennels); B is a deliberate display-identity choice (requested) that A cannot achieve for H7 on its own — verified: `friendlyKennelName("H7", …)` → "Hansestadt Hamburg Hummel Hummel H3", `friendlyKennelName("Hamburg H7", …)` → "Hamburg H7".

## Checks
`tsc` ✅ · `lint` ✅ (0 errors) · `npm test` ✅ (284 files, 8167 tests; +5 `friendlyKennelName` cases).

## Post-merge
1. `npx prisma db seed` (updates h7 shortName; auto-adds "H7" alias via rename safety).
2. One-shot title fix for the **111 already-merged H7 events** — their verbose titles were baked in at merge time and won't auto-rewrite (disabled archive source + fixed HC fingerprints don't re-merge). Replace the verbose prefix with "Hamburg H7" on those events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
