### PR TITLE
fix(ch4-dk): backfill runNumber from GCal titles + close CRH3/CH4 audit bundle

### DIFF
--- a/scripts/backfill-ch4-dk-run-numbers.test.ts
+++ b/scripts/backfill-ch4-dk-run-numbers.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { parseCh4TitleRunNumber, planRunNumberBackfill } from "./backfill-ch4-dk-run-numbers";
+
+describe("parseCh4TitleRunNumber", () => {
+  it.each([
+    ["CH4 376", 376],
+    ["CH4 #376", 376],
+    ["CH4 352 - Valby St - Deep and Smelly Penetration", 352],
+    ["CH4 360 ØB Ølbar - Codpiece, Oeuf, Calapso", 360],
+    ["ch4  #260  Gispert", 260],
+    // Reject — number not in the leading position (do not guess).
+    ["CH4 Full Moon - 315 - Meatloaf Memorial", null],
+    ["CH4 Full Moon 318", null],
+    ["CH4 run258", null],
+    ["CH4 - Flagpole", null],
+    ["", null],
+    [null, null],
+    [undefined, null],
+  ])("parses %p -> %p", (title, expected) => {
+    expect(parseCh4TitleRunNumber(title)).toBe(expected);
+  });
+});
+
+describe("planRunNumberBackfill", () => {
+  it("sets run numbers on unique, untaken NULL-runNumber events", () => {
+    const plan = planRunNumberBackfill([
+      { id: "a", title: "CH4 374", runNumber: null },
+      { id: "b", title: "CH4 375", runNumber: null },
+      { id: "c", title: "CH4 345 - already numbered", runNumber: 345 },
+    ]);
+    expect(plan.toSet).toEqual([
+      { id: "a", number: 374 },
+      { id: "b", number: 375 },
+    ]);
+    expect(plan.skippedCollisions).toEqual([]);
+    expect(plan.unparseable).toBe(0);
+  });
+
+  it("skips numbers that collide internally (the #352/#360 typo pairs)", () => {
+    const plan = planRunNumberBackfill([
+      { id: "a", title: "CH4 352 - Carlsberg", runNumber: null },
+      { id: "b", title: "CH4 352 - Valby", runNumber: null },
+      { id: "c", title: "CH4 360 ØB Ølbar", runNumber: null },
+      { id: "d", title: "CH4 360 - Sydhavn", runNumber: null },
+      { id: "e", title: "CH4 376", runNumber: null },
+    ]);
+    expect(plan.toSet).toEqual([{ id: "e", number: 376 }]);
+    expect(plan.skippedCollisions).toEqual([352, 360]);
+  });
+
+  it("skips a candidate already taken by a non-NULL event", () => {
+    const plan = planRunNumberBackfill([
+      { id: "a", title: "CH4 345 - dup of existing", runNumber: null },
+      { id: "b", title: "CH4 345 - the real one", runNumber: 345 },
+    ]);
+    expect(plan.toSet).toEqual([]);
+    expect(plan.skippedCollisions).toEqual([345]);
+  });
+
+  it("counts unparseable titles without setting them", () => {
+    const plan = planRunNumberBackfill([
+      { id: "a", title: "CH4 - Flagpole", runNumber: null },
+      { id: "b", title: "CH4 Full Moon 318", runNumber: null },
+      { id: "c", title: "CH4 377", runNumber: null },
+    ]);
+    expect(plan.toSet).toEqual([{ id: "c", number: 377 }]);
+    expect(plan.unparseable).toBe(2);
+    expect(plan.skippedCollisions).toEqual([]);
+  });
+});

--- a/scripts/backfill-ch4-dk-run-numbers.ts
+++ b/scripts/backfill-ch4-dk-run-numbers.ts
@@ -33,6 +33,7 @@
  */
 
 import "dotenv/config";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/generated/prisma/client";
@@ -41,26 +42,35 @@ import { createScriptPool } from "./lib/db-pool";
 const APPLY = process.argv.includes("--apply");
 const KENNEL_CODE = "ch4-dk";
 
-// Anchored: the run number must follow "CH4" directly (optionally a "#"). This
-// matches "CH4 376", "CH4 #376", "CH4 352 - …" but intentionally rejects
-// "CH4 Full Moon - 315", "CH4 run258" and "CH4 - Flagpole" — we do not guess
-// numbers that aren't in the canonical leading position.
-const RE_LEADING_RUN = /^\s*CH4\s*#?\s*(\d+)\b/i;
-
-/** Parse the leading "CH4 <NNN>" run number from an event title, or null. */
+/**
+ * Parse the leading "CH4 <NNN>" run number from an event title, or null.
+ *
+ * The number must follow "CH4" directly (optionally past a "#"): this matches
+ * "CH4 376", "CH4 #376", "CH4 352 - …" but intentionally rejects
+ * "CH4 Full Moon - 315", "CH4 run258" and "CH4 - Flagpole" — we do not guess
+ * numbers that aren't in the canonical leading position.
+ *
+ * Implemented with string ops + two trivially-linear regexes rather than one
+ * anchored pattern, to stay clear of Sonar S5852's ReDoS heuristic (which flags
+ * the "\s*#?\s*" quantifier bracketing even though it can't actually backtrack).
+ */
 export function parseCh4TitleRunNumber(title: string | null | undefined): number | null {
   if (!title) return null;
-  const m = RE_LEADING_RUN.exec(title);
-  return m ? Number.parseInt(m[1], 10) : null;
+  let rest = title.trimStart();
+  if (!/^ch4/i.test(rest)) return null;
+  rest = rest.slice(3).trimStart();
+  if (rest.startsWith("#")) rest = rest.slice(1).trimStart();
+  const m = /^\d+\b/.exec(rest);
+  return m ? Number.parseInt(m[0], 10) : null;
 }
 
-interface CanonicalEvent {
+export interface CanonicalEvent {
   id: string;
   title: string | null;
   runNumber: number | null;
 }
 
-interface BackfillPlan {
+export interface BackfillPlan {
   /** events whose runNumber will be set: { id, number } */
   toSet: { id: string; number: number }[];
   /** numbers skipped because they collide (internal dup or already taken) */
@@ -221,7 +231,8 @@ async function main() {
 }
 
 // Only auto-run when invoked directly (not when imported by the test file).
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+// Resolve argv[1] so a relative invocation (npx tsx scripts/…) still matches.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
   main().catch((err) => {
     console.error("\nFatal error:", err);
     process.exit(1);

--- a/scripts/backfill-ch4-dk-run-numbers.ts
+++ b/scripts/backfill-ch4-dk-run-numbers.ts
@@ -122,12 +122,84 @@ export function planRunNumberBackfill(events: CanonicalEvent[]): BackfillPlan {
   };
 }
 
+/**
+ * Where-fragment matching events where ch4-dk is the PRIMARY kennel.
+ * Event.runNumber is a single kennel-specific field shared across co-hosts, so
+ * writing it on a row where ch4-dk is only a secondary co-host would leak CH4
+ * numbering into another kennel's display. CH4 has no co-hosts today, but this
+ * keeps the script correct if that ever changes.
+ */
+function primaryScopeFor(kennelId: string) {
+  return {
+    kennelId,
+    eventKennels: { some: { kennelId, isPrimary: true } },
+  };
+}
+
+/**
+ * Apply the planned writes and verify the result. Each update is predicate-
+ * guarded (still a primary, canonical, NULL-runNumber row), so a row that
+ * drifted since the snapshot is safely skipped rather than overwritten.
+ */
+async function applyBackfill(
+  prisma: PrismaClient,
+  kennelId: string,
+  toSet: { id: string; number: number }[],
+): Promise<void> {
+  console.log(`\n⚠️  APPLY mode — writing in 3s. Ctrl-C to abort.`);
+  await new Promise((r) => setTimeout(r, 3000));
+
+  const scope = primaryScopeFor(kennelId);
+  let written = 0;
+  let drifted = 0;
+  for (const { id, number } of toSet) {
+    const { count } = await prisma.event.updateMany({
+      where: { id, isCanonical: true, runNumber: null, ...scope },
+      data: { runNumber: number },
+    });
+    if (count === 1) written++;
+    else drifted++;
+  }
+  console.log(`\nSet runNumber on ${written} events.`);
+  if (drifted > 0) {
+    console.log(`Skipped ${drifted} events that changed since the snapshot (not overwritten).`);
+  }
+
+  // Verify: max run number now reflects the real latest run, and no non-NULL dups.
+  const afterEvents = await prisma.event.findMany({
+    where: { isCanonical: true, runNumber: { not: null }, ...scope },
+    select: { runNumber: true },
+  });
+  const maxRun = afterEvents.reduce((m, e) => Math.max(m, e.runNumber ?? 0), 0);
+  const counts = new Map<number, number>();
+  for (const e of afterEvents) {
+    if (e.runNumber != null) counts.set(e.runNumber, (counts.get(e.runNumber) ?? 0) + 1);
+  }
+  const dupNumbers = [...counts.entries()].filter(([, c]) => c > 1).map(([n]) => n);
+  dupNumbers.sort((a, b) => a - b);
+
+  console.log(`Max runNumber (canonical): ${maxRun}`);
+  console.log(
+    `Non-NULL duplicate run numbers: ${dupNumbers.length}` +
+      (dupNumbers.length ? ` → #${dupNumbers.join(", #")}` : ""),
+  );
+  if (dupNumbers.length > 0) {
+    console.error(`\nERROR: backfill introduced duplicate run numbers — investigate.`);
+    process.exit(1);
+  }
+  if (drifted > 0) {
+    console.error(`\nERROR: ${drifted} planned writes drifted — re-run to retry the skipped rows.`);
+    process.exit(1);
+  }
+  console.log(`\nDone. ✓`);
+}
+
 async function main() {
   console.log(`\n=== backfill-ch4-dk-run-numbers ===`);
   console.log(`Mode: ${APPLY ? "APPLY (will write to DB)" : "DRY-RUN (read-only)"}`);
 
   const pool = createScriptPool();
-  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) } as never);
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
 
   try {
     const kennel = await prisma.kennel.findUnique({
@@ -139,18 +211,8 @@ async function main() {
       process.exit(1);
     }
 
-    // Scope strictly to events where ch4-dk is the PRIMARY kennel. Event.runNumber
-    // is a single kennel-specific field shared across co-hosts, so writing it on a
-    // row where ch4-dk is only a secondary co-host would leak CH4 numbering into
-    // another kennel's display. CH4 has no co-hosts today, but this keeps the
-    // script correct if that ever changes.
-    const primaryScope = {
-      kennelId: kennel.id,
-      eventKennels: { some: { kennelId: kennel.id, isPrimary: true } },
-    } as const;
-
     const events: CanonicalEvent[] = await prisma.event.findMany({
-      where: { isCanonical: true, ...primaryScope },
+      where: { isCanonical: true, ...primaryScopeFor(kennel.id) },
       select: { id: true, title: true, runNumber: true },
     });
 
@@ -170,60 +232,12 @@ async function main() {
       console.log("\nNothing to set — already backfilled.");
       return;
     }
-
     if (!APPLY) {
       console.log(`\nDry-run complete. Re-run with --apply to set ${plan.toSet.length} run numbers.`);
       return;
     }
 
-    console.log(`\n⚠️  APPLY mode — writing in 3s. Ctrl-C to abort.`);
-    await new Promise((r) => setTimeout(r, 3000));
-
-    // Predicate-guarded writes: each update only fires if the row is STILL a
-    // primary, canonical, NULL-runNumber ch4-dk event. If a scrape or manual
-    // repair changed it between the snapshot and now, count comes back 0 and we
-    // safely skip rather than overwrite a stale assumption (fail-closed).
-    let written = 0;
-    let drifted = 0;
-    for (const { id, number } of plan.toSet) {
-      const { count } = await prisma.event.updateMany({
-        where: { id, isCanonical: true, runNumber: null, ...primaryScope },
-        data: { runNumber: number },
-      });
-      if (count === 1) written++;
-      else drifted++;
-    }
-    console.log(`\nSet runNumber on ${written} events.`);
-    if (drifted > 0) {
-      console.log(`Skipped ${drifted} events that changed since the snapshot (not overwritten).`);
-    }
-
-    // Verify: max run number now reflects the real latest run, and no non-NULL dups.
-    const afterEvents = await prisma.event.findMany({
-      where: { isCanonical: true, runNumber: { not: null }, ...primaryScope },
-      select: { runNumber: true },
-    });
-    const maxRun = afterEvents.reduce((m, e) => Math.max(m, e.runNumber ?? 0), 0);
-    const counts = new Map<number, number>();
-    for (const e of afterEvents) {
-      if (e.runNumber != null) counts.set(e.runNumber, (counts.get(e.runNumber) ?? 0) + 1);
-    }
-    const dupNumbers = [...counts.entries()].filter(([, c]) => c > 1).map(([n]) => n);
-
-    console.log(`Max runNumber (canonical): ${maxRun}`);
-    console.log(
-      `Non-NULL duplicate run numbers: ${dupNumbers.length}` +
-        (dupNumbers.length ? ` → #${dupNumbers.sort((a, b) => a - b).join(", #")}` : ""),
-    );
-    if (dupNumbers.length > 0) {
-      console.error(`\nERROR: backfill introduced duplicate run numbers — investigate.`);
-      process.exit(1);
-    }
-    if (drifted > 0) {
-      console.error(`\nERROR: ${drifted} planned writes drifted — re-run to retry the skipped rows.`);
-      process.exit(1);
-    }
-    console.log(`\nDone. ✓`);
+    await applyBackfill(prisma, kennel.id, plan.toSet);
   } finally {
     await prisma.$disconnect();
     await pool.end();

--- a/scripts/backfill-ch4-dk-run-numbers.ts
+++ b/scripts/backfill-ch4-dk-run-numbers.ts
@@ -1,0 +1,229 @@
+/**
+ * One-shot runNumber backfill for ch4-dk (Copenhagen Howling H3) — closes #1049.
+ *
+ * The Google Calendar source (ch3.archive@gmail.com, owned by the GCal adapter)
+ * publishes CH4 runs with the run number in the SUMMARY ("CH4 376 - Venue - Theme")
+ * but never parses it into Event.runNumber, so 95+ canonical events sit with
+ * runNumber=NULL. The kennel page's "Latest Run" stat is
+ *   currentRunNumber = upcoming.find(runNumber != null) ?? past.find(runNumber != null)
+ * (src/app/kennels/[slug]/page.tsx) — with 346–376 all NULL it falls through to the
+ * last *numbered* event, #345, which is the stale value reported in #1049.
+ *
+ * This script parses the leading "CH4 <NNN>" from the title and writes it into
+ * Event.runNumber, scoped strictly to ch4-dk canonical events. It does NOT touch
+ * the GCal adapter, merge pipeline, or sibling kennels (ch3-dk / rdh3).
+ *
+ * Collision guard (must not re-introduce #1050): a candidate number is skipped if
+ * it appears more than once among the NULL-runNumber events, or already exists on a
+ * non-NULL canonical event. In prod the only internal collisions are #352 (×2) and
+ * #360 (×2) — four distinct real trails sharing a kennel-side GCal SUMMARY typo
+ * (different dates/venues/themes). They are deliberately left NULL and reported.
+ *
+ * Durability: a later GCal re-scrape emits runNumber=undefined, which the merge
+ * pipeline treats as "preserve existing", so the backfilled value persists. Each
+ * GCal event has a distinct sourceUrl, so distinct eventSignatures — setting
+ * runNumber cannot collapse distinct canonicals in recomputeCanonical().
+ *
+ * Usage:
+ *   eval "$(fnm env)" && fnm use 20
+ *   npx tsx scripts/backfill-ch4-dk-run-numbers.ts            # dry-run (default)
+ *   npx tsx scripts/backfill-ch4-dk-run-numbers.ts --apply    # actually write
+ *
+ * Idempotent: re-running finds fewer NULLs and still skips the typo collisions.
+ */
+
+import "dotenv/config";
+import { fileURLToPath } from "node:url";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const APPLY = process.argv.includes("--apply");
+const KENNEL_CODE = "ch4-dk";
+
+// Anchored: the run number must follow "CH4" directly (optionally a "#"). This
+// matches "CH4 376", "CH4 #376", "CH4 352 - …" but intentionally rejects
+// "CH4 Full Moon - 315", "CH4 run258" and "CH4 - Flagpole" — we do not guess
+// numbers that aren't in the canonical leading position.
+const RE_LEADING_RUN = /^\s*CH4\s*#?\s*(\d+)\b/i;
+
+/** Parse the leading "CH4 <NNN>" run number from an event title, or null. */
+export function parseCh4TitleRunNumber(title: string | null | undefined): number | null {
+  if (!title) return null;
+  const m = RE_LEADING_RUN.exec(title);
+  return m ? Number.parseInt(m[1], 10) : null;
+}
+
+interface CanonicalEvent {
+  id: string;
+  title: string | null;
+  runNumber: number | null;
+}
+
+interface BackfillPlan {
+  /** events whose runNumber will be set: { id, number } */
+  toSet: { id: string; number: number }[];
+  /** numbers skipped because they collide (internal dup or already taken) */
+  skippedCollisions: number[];
+  /** count of NULL-runNumber events whose title has no leading CH4 number */
+  unparseable: number;
+}
+
+/**
+ * Pure planner — decides which NULL-runNumber events get which number, applying
+ * the collision guard. Exported for unit testing.
+ */
+export function planRunNumberBackfill(events: CanonicalEvent[]): BackfillPlan {
+  const taken = new Set<number>();
+  for (const e of events) {
+    if (e.runNumber != null) taken.add(e.runNumber);
+  }
+
+  // Collect parseable candidates and tally their numbers to detect internal dups.
+  const candidateCounts = new Map<number, number>();
+  const candidates: { id: string; number: number }[] = [];
+  let unparseable = 0;
+  for (const e of events) {
+    if (e.runNumber != null) continue;
+    const number = parseCh4TitleRunNumber(e.title);
+    if (number == null) {
+      unparseable++;
+      continue;
+    }
+    candidateCounts.set(number, (candidateCounts.get(number) ?? 0) + 1);
+    candidates.push({ id: e.id, number });
+  }
+
+  // Skip any number that collides internally (appears >1×) or is already taken.
+  const toSet: { id: string; number: number }[] = [];
+  const skipped = new Set<number>();
+  for (const { id, number } of candidates) {
+    if ((candidateCounts.get(number) ?? 0) > 1 || taken.has(number)) {
+      skipped.add(number);
+      continue;
+    }
+    toSet.push({ id, number });
+  }
+
+  return {
+    toSet,
+    skippedCollisions: [...skipped].sort((a, b) => a - b),
+    unparseable,
+  };
+}
+
+async function main() {
+  console.log(`\n=== backfill-ch4-dk-run-numbers ===`);
+  console.log(`Mode: ${APPLY ? "APPLY (will write to DB)" : "DRY-RUN (read-only)"}`);
+
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) } as never);
+
+  try {
+    const kennel = await prisma.kennel.findUnique({
+      where: { kennelCode: KENNEL_CODE },
+      select: { id: true, shortName: true },
+    });
+    if (!kennel) {
+      console.error(`${KENNEL_CODE} kennel not found — aborting.`);
+      process.exit(1);
+    }
+
+    // Scope strictly to events where ch4-dk is the PRIMARY kennel. Event.runNumber
+    // is a single kennel-specific field shared across co-hosts, so writing it on a
+    // row where ch4-dk is only a secondary co-host would leak CH4 numbering into
+    // another kennel's display. CH4 has no co-hosts today, but this keeps the
+    // script correct if that ever changes.
+    const primaryScope = {
+      kennelId: kennel.id,
+      eventKennels: { some: { kennelId: kennel.id, isPrimary: true } },
+    } as const;
+
+    const events: CanonicalEvent[] = await prisma.event.findMany({
+      where: { isCanonical: true, ...primaryScope },
+      select: { id: true, title: true, runNumber: true },
+    });
+
+    const nullCount = events.filter((e) => e.runNumber == null).length;
+    const plan = planRunNumberBackfill(events);
+
+    console.log(`\nCanonical ${kennel.shortName} events: ${events.length}`);
+    console.log(`  NULL runNumber:        ${nullCount}`);
+    console.log(`  Will set runNumber on: ${plan.toSet.length}`);
+    console.log(
+      `  Skipped (collisions):  ${plan.skippedCollisions.length}` +
+        (plan.skippedCollisions.length ? ` → #${plan.skippedCollisions.join(", #")}` : ""),
+    );
+    console.log(`  Unparseable titles:    ${plan.unparseable}`);
+
+    if (plan.toSet.length === 0) {
+      console.log("\nNothing to set — already backfilled.");
+      return;
+    }
+
+    if (!APPLY) {
+      console.log(`\nDry-run complete. Re-run with --apply to set ${plan.toSet.length} run numbers.`);
+      return;
+    }
+
+    console.log(`\n⚠️  APPLY mode — writing in 3s. Ctrl-C to abort.`);
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // Predicate-guarded writes: each update only fires if the row is STILL a
+    // primary, canonical, NULL-runNumber ch4-dk event. If a scrape or manual
+    // repair changed it between the snapshot and now, count comes back 0 and we
+    // safely skip rather than overwrite a stale assumption (fail-closed).
+    let written = 0;
+    let drifted = 0;
+    for (const { id, number } of plan.toSet) {
+      const { count } = await prisma.event.updateMany({
+        where: { id, isCanonical: true, runNumber: null, ...primaryScope },
+        data: { runNumber: number },
+      });
+      if (count === 1) written++;
+      else drifted++;
+    }
+    console.log(`\nSet runNumber on ${written} events.`);
+    if (drifted > 0) {
+      console.log(`Skipped ${drifted} events that changed since the snapshot (not overwritten).`);
+    }
+
+    // Verify: max run number now reflects the real latest run, and no non-NULL dups.
+    const afterEvents = await prisma.event.findMany({
+      where: { isCanonical: true, runNumber: { not: null }, ...primaryScope },
+      select: { runNumber: true },
+    });
+    const maxRun = afterEvents.reduce((m, e) => Math.max(m, e.runNumber ?? 0), 0);
+    const counts = new Map<number, number>();
+    for (const e of afterEvents) {
+      if (e.runNumber != null) counts.set(e.runNumber, (counts.get(e.runNumber) ?? 0) + 1);
+    }
+    const dupNumbers = [...counts.entries()].filter(([, c]) => c > 1).map(([n]) => n);
+
+    console.log(`Max runNumber (canonical): ${maxRun}`);
+    console.log(
+      `Non-NULL duplicate run numbers: ${dupNumbers.length}` +
+        (dupNumbers.length ? ` → #${dupNumbers.sort((a, b) => a - b).join(", #")}` : ""),
+    );
+    if (dupNumbers.length > 0) {
+      console.error(`\nERROR: backfill introduced duplicate run numbers — investigate.`);
+      process.exit(1);
+    }
+    if (drifted > 0) {
+      console.error(`\nERROR: ${drifted} planned writes drifted — re-run to retry the skipped rows.`);
+      process.exit(1);
+    }
+    console.log(`\nDone. ✓`);
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+// Only auto-run when invoked directly (not when imported by the test file).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("\nFatal error:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Quick-Win bundle: CRH3 + Copenhagen Howling H3 (CH4) audit issues

Prod investigation showed most of this bundle was already landed in code/prod; the real remaining gap was CH4's `runNumber` column. One small, scoped change does the work.

### The fix — `scripts/backfill-ch4-dk-run-numbers.ts` (#1049)
The Copenhagen Howling H3 Google Calendar source publishes runs as `CH4 376 - Venue - Theme` but never parses the number into `Event.runNumber`, so 91 canonical events (346–376) sat with `runNumber=NULL`. The kennel page's "Latest Run" stat (`upcoming.find(runNumber!=null) ?? past.find(...)`) fell through to the last *numbered* event → stale **345**.

The script parses the leading `CH4 <NNN>` from the title into `runNumber`:
- **Primary-scoped** — only events where `ch4-dk` is the primary kennel (never co-host rows), so the shared `Event.runNumber` can't leak into another kennel.
- **Collision-guarded** — skips any number that appears >1× among NULLs or is already taken, leaving the #352/#360 typo pairs NULL (can't re-introduce #1050).
- **Predicate-guarded writes** — `updateMany` on still-NULL primary canonical rows; fails closed on drift.
- **Idempotent**, dry-run by default, `--apply` to write.

**Applied to prod & verified:** 91 set, max `runNumber` **376**, zero non-NULL duplicates, re-run shows 0 to set. `foundedYear=1995` was already set, so "Years Active" = 31 (the "14" was the null-`foundedYear` fallback, already fixed).

### Issues closed (the other three were already resolved in prod — verified, documented)
- **#1049** — fixed by this backfill (Latest Run now reflects the current run, not stale 345).
- **#1121** — CRH3 runs 211/213/214/216/218 already present in prod (backfill had run).
- **#1052** — `Copenhagen Howling H3 Runsheet` source already seeded, enabled, scraping (29 RawEvents, last success today).
- **#1050** — the `CH4 352`/`CH4 360` "duplicates" are **4 distinct real trails** (different dates, venues, themes, GCal event IDs); the shared number is a kennel-side Google Calendar SUMMARY typo, not duplicate rows. Per the no-delete-real-trails principle, both are preserved and the run-number column is left NULL on the pair (flagged, not deleted).

### Scope
Touches only the new script. Does **not** touch the GCal adapter, the Copenhagen GCal source, sibling kennels `ch3-dk`/`rdh3`, `merge.ts`, or `ch4-dk.ts`.

### Out of scope (flagged separately)
CRH3 has a separate duplicate **#220** (2026-03-26 vs 2026-03-28) — not part of these four issues; left for a follow-up.

### Verification
- `npm run lint` (0 errors), `npx tsc --noEmit`, `npm test` (8178 passed) all green.
- 16 unit tests for the pure planner (`parseCh4TitleRunNumber` + `planRunNumberBackfill`).
- `/codex:adversarial-review` (hardened co-host scope + write-time guard from its findings) and `/simplify` run before this PR.

Closes #1049
Closes #1121
Closes #1052
Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)