### PR TITLE
feat(hashstats): HashStats historical archive adapter (#1771)

### DIFF
--- a/.claude/rules/active-sources.md
+++ b/.claude/rules/active-sources.md
@@ -7,7 +7,7 @@ globs:
   - src/pipeline/**
 ---
 
-# Active Sources (342)
+# Active Sources (343)
 
 Last synced from `prisma/seed-data/sources.ts` via the `/update-sources-rule` skill.
 
@@ -85,8 +85,9 @@ Last synced from `prisma/seed-data/sources.ts` via the `/update-sources-rule` sk
 - **Chicago Hash Website** -> HTML_SCRAPER -> ch3
 - **Thirstday Hash Website** -> HTML_SCRAPER -> th3
 
-### Cincinnati, OH (4)
+### Cincinnati, OH (5)
 - **SCH4 Google Calendar** -> GOOGLE_CALENDAR -> sch4
+- **SCH4 HashStats** -> HTML_SCRAPER (HashStats archive) -> sch4
 - **QCH4 Google Calendar** -> GOOGLE_CALENDAR -> qch4
 - **LVH3 Google Calendar** -> GOOGLE_CALENDAR -> lvh3-cin
 - **Licking Valley H3 Facebook Hosted Events** -> FACEBOOK_HOSTED_EVENTS -> lvh3-cin

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3243,6 +3243,24 @@ export const SOURCES = [
       },
       kennelCodes: ["lvh3-cin"],
     },
+    // HashStats historical archive (proof kennel, #1771). Retrospective stats
+    // platform — completed hashes only, no upcoming events; supplemental to the
+    // GCal source above. Public hashingstats.com JSON: POST /SCH4/listhashes2
+    // returns the full 1995→present archive. Routed via the registry URL-matcher
+    // (HashStatsAdapter); kennelSlugMap maps kennelCode → external slug, so the
+    // same adapter can drive QCH4/SWOT/LVH3/SCH4BASH once those are onboarded.
+    {
+      name: "SCH4 HashStats",
+      url: "https://hashingstats.com/SCH4",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "weekly",
+      scrapeDays: 20000,
+      config: {
+        kennelSlugMap: { sch4: "SCH4" },
+      },
+      kennelCodes: ["sch4"],
+    },
     // --- Columbus (Renegade H3 website) ---
     {
       name: "Renegade H3 Website",

--- a/src/adapters/hashstats/adapter.test.ts
+++ b/src/adapters/hashstats/adapter.test.ts
@@ -108,6 +108,11 @@ describe("parseHashStatsDateTime", () => {
   ])("rejects %s (%s)", (input, _label) => {
     expect(parseHashStatsDateTime(input as string | undefined)).toBeNull();
   });
+
+  it("rejects non-string input (payload cast from unknown)", () => {
+    expect(parseHashStatsDateTime(20260521 as unknown)).toBeNull();
+    expect(parseHashStatsDateTime({} as unknown)).toBeNull();
+  });
 });
 
 describe("mapHashStatsRow", () => {
@@ -144,6 +149,11 @@ describe("mapHashStatsRow", () => {
   it("returns null for an unparseable EVENT_DATE", () => {
     const row: HashStatsRow = { ...SCH4_ROWS[0], EVENT_DATE: "garbage" };
     expect(mapHashStatsRow(row, "sch4", "https://hashingstats.com", "SCH4")).toBeNull();
+  });
+
+  it("returns null for a null / non-object row (aaData cast from unknown)", () => {
+    expect(mapHashStatsRow(null, "sch4", "https://hashingstats.com", "SCH4")).toBeNull();
+    expect(mapHashStatsRow(undefined, "sch4", "https://hashingstats.com", "SCH4")).toBeNull();
   });
 
   it("drops startTime for the midnight sentinel", () => {
@@ -243,6 +253,17 @@ describe("HashStatsAdapter.fetch", () => {
     expect(result.events).toHaveLength(1);
     expect(result.events[0].runNumber).toBe(1454);
     expect(result.errorDetails?.parse?.[0].error).toMatch(/unparseable EVENT_DATE/i);
+  });
+
+  it("skips a null row in aaData without aborting the kennel (no throw)", async () => {
+    const rows = [null, SCH4_ROWS[0]];
+    mockSafeFetch.mockResolvedValueOnce(jsonResponse({ aaData: rows }));
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(makeSource({ kennelSlugMap: { sch4: "SCH4" } }));
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].runNumber).toBe(1455);
+    expect(result.errorDetails?.parse?.length).toBeGreaterThan(0);
   });
 
   it("honors options.days — old events fall outside a narrow window", async () => {

--- a/src/adapters/hashstats/adapter.test.ts
+++ b/src/adapters/hashstats/adapter.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  HashStatsAdapter,
+  parseHashStatsDateTime,
+  mapHashStatsRow,
+  type HashStatsRow,
+} from "./adapter";
+import type { Source } from "@/generated/prisma/client";
+
+vi.mock("../safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+
+import { safeFetch } from "../safe-fetch";
+const mockSafeFetch = vi.mocked(safeFetch);
+
+/** Build a Response-like object whose .json() yields `{ aaData: rows }`. */
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function makeSource(config: unknown, scrapeDays = 20000): Source {
+  return {
+    id: "src-hashstats-1",
+    name: "SCH4 HashStats",
+    config,
+    url: "https://hashingstats.com/SCH4",
+    type: "HTML_SCRAPER",
+    scrapeDays,
+  } as unknown as Source;
+}
+
+// Real captured rows from POST https://hashingstats.com/SCH4/listhashes2
+const SCH4_ROWS: HashStatsRow[] = [
+  {
+    KENNEL_EVENT_NUMBER: "1455",
+    EVENT_LOCATION: "Smokin the Oak",
+    SPECIAL_EVENT_DESCRIPTION: "Monthly Hyper",
+    EVENT_DATE: "2026-05-21 19:00:00",
+    EVENT_CITY: "Cincinnati",
+    EVENT_STATE: "OH",
+    FORMATTED_ADDRESS: "3882 Paxton Ave, Cincinnati, OH 45209, USA",
+    HASY_KY: "2114",
+  },
+  {
+    KENNEL_EVENT_NUMBER: "1454",
+    EVENT_LOCATION: "Eclectic Northside",
+    SPECIAL_EVENT_DESCRIPTION: "HTS BDay Fun",
+    EVENT_DATE: "2026-05-09 16:00:00",
+    EVENT_CITY: "Cincinnati",
+    EVENT_STATE: "OH",
+    FORMATTED_ADDRESS: "4109 Hamilton Ave, Cincinnati, OH 45223, USA",
+    HASY_KY: "2113",
+  },
+];
+
+// Real captured rows from POST https://hashingstats.com/QCH4/listhashes2 —
+// note the "None" placeholder description on the oldest row.
+const QCH4_ROWS: HashStatsRow[] = [
+  {
+    KENNEL_EVENT_NUMBER: "2",
+    EVENT_LOCATION: "Fries Cafe",
+    SPECIAL_EVENT_DESCRIPTION: "None",
+    EVENT_DATE: "2017-06-27 19:00:00",
+    EVENT_CITY: "Cincinnati",
+    EVENT_STATE: "OH",
+    FORMATTED_ADDRESS: "3247 Jefferson Ave, Cincinnati, OH 45220, USA",
+    HASY_KY: "1389",
+  },
+  {
+    KENNEL_EVENT_NUMBER: "1",
+    EVENT_LOCATION: "Queen City Radio",
+    SPECIAL_EVENT_DESCRIPTION: "First QCH4 Hash",
+    EVENT_DATE: "2017-06-13 19:00:00",
+    EVENT_CITY: "Cincinnati",
+    EVENT_STATE: "OH",
+    FORMATTED_ADDRESS: "222 W 12th St, Cincinnati, OH 45202, USA",
+    HASY_KY: "1388",
+  },
+];
+
+beforeEach(() => {
+  mockSafeFetch.mockReset();
+});
+
+describe("parseHashStatsDateTime", () => {
+  it.each([
+    ["2026-05-21 19:00:00", { date: "2026-05-21", startTime: "19:00" }],
+    ["2017-06-13 19:00:00", { date: "2017-06-13", startTime: "19:00" }],
+    // midnight sentinel → no startTime
+    ["2020-01-01 00:00:00", { date: "2020-01-01" }],
+    // date-only string → no startTime
+    ["1999-12-31", { date: "1999-12-31" }],
+  ])("parses %s", (input, expected) => {
+    expect(parseHashStatsDateTime(input)).toEqual(expected);
+  });
+
+  it.each([
+    ["", "empty"],
+    [undefined, "undefined"],
+    ["not-a-date", "garbage"],
+    ["2026-02-30 12:00:00", "impossible day (Feb 30)"],
+    ["2026-13-01 12:00:00", "impossible month"],
+  ])("rejects %s (%s)", (input, _label) => {
+    expect(parseHashStatsDateTime(input as string | undefined)).toBeNull();
+  });
+});
+
+describe("mapHashStatsRow", () => {
+  it("maps a full SCH4 row", () => {
+    const ev = mapHashStatsRow(SCH4_ROWS[0], "sch4", "https://hashingstats.com", "SCH4");
+    expect(ev).toEqual({
+      date: "2026-05-21",
+      kennelTags: ["sch4"],
+      runNumber: 1455,
+      startTime: "19:00",
+      description: "Monthly Hyper",
+      location: "Smokin the Oak",
+      locationStreet: "3882 Paxton Ave, Cincinnati, OH 45209, USA",
+      sourceUrl: "https://hashingstats.com/SCH4/hashes/2114",
+    });
+  });
+
+  it("leaves title undefined so merge synthesizes the canonical title", () => {
+    const ev = mapHashStatsRow(SCH4_ROWS[0], "sch4", "https://hashingstats.com", "SCH4");
+    expect(ev?.title).toBeUndefined();
+  });
+
+  it('treats "None" description as no theme', () => {
+    const ev = mapHashStatsRow(QCH4_ROWS[0], "qch4", "https://hashingstats.com", "QCH4");
+    expect(ev?.description).toBeUndefined();
+  });
+
+  it("omits sourceUrl when HASY_KY is absent", () => {
+    const row: HashStatsRow = { ...SCH4_ROWS[0], HASY_KY: undefined };
+    const ev = mapHashStatsRow(row, "sch4", "https://hashingstats.com", "SCH4");
+    expect(ev?.sourceUrl).toBeUndefined();
+  });
+
+  it("returns null for an unparseable EVENT_DATE", () => {
+    const row: HashStatsRow = { ...SCH4_ROWS[0], EVENT_DATE: "garbage" };
+    expect(mapHashStatsRow(row, "sch4", "https://hashingstats.com", "SCH4")).toBeNull();
+  });
+
+  it("drops startTime for the midnight sentinel", () => {
+    const row: HashStatsRow = { ...SCH4_ROWS[0], EVENT_DATE: "2026-05-21 00:00:00" };
+    const ev = mapHashStatsRow(row, "sch4", "https://hashingstats.com", "SCH4");
+    expect(ev?.startTime).toBeUndefined();
+  });
+});
+
+describe("HashStatsAdapter.fetch", () => {
+  it("routes each kennel slug to the correct kennelTag", async () => {
+    mockSafeFetch
+      .mockResolvedValueOnce(jsonResponse({ aaData: SCH4_ROWS }))
+      .mockResolvedValueOnce(jsonResponse({ aaData: QCH4_ROWS }));
+
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(
+      makeSource({ kennelSlugMap: { sch4: "SCH4", qch4: "QCH4" } }),
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.events).toHaveLength(4);
+    expect(result.events.filter((e) => e.kennelTags[0] === "sch4")).toHaveLength(2);
+    expect(result.events.filter((e) => e.kennelTags[0] === "qch4")).toHaveLength(2);
+
+    // POSTs to the per-slug listhashes2 endpoint
+    expect(mockSafeFetch).toHaveBeenCalledWith(
+      "https://hashingstats.com/SCH4/listhashes2",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(mockSafeFetch).toHaveBeenCalledWith(
+      "https://hashingstats.com/QCH4/listhashes2",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("fails loud (no throw) when kennelSlugMap is missing", async () => {
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(makeSource({}));
+    expect(result.events).toEqual([]);
+    expect(result.errors[0]).toMatch(/kennelSlugMap is missing/i);
+    expect(mockSafeFetch).not.toHaveBeenCalled();
+  });
+
+  it("records a fetch error when aaData is not an array (auth HTML / error body)", async () => {
+    mockSafeFetch.mockResolvedValueOnce(jsonResponse({ error: "nope" }));
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(makeSource({ kennelSlugMap: { sch4: "SCH4" } }));
+
+    expect(result.events).toEqual([]);
+    expect(result.errorDetails?.fetch?.[0].message).toMatch(/missing aaData array/i);
+  });
+
+  it("fails loud on a server-capped partial archive (blocks reconcile)", async () => {
+    // iTotalRecords claims 1457 but only 2 rows came back → page was capped.
+    // Must error (so scrape.ts skips reconcile) and emit no partial events.
+    mockSafeFetch.mockResolvedValueOnce(
+      jsonResponse({ aaData: SCH4_ROWS, iTotalRecords: "1457" }),
+    );
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(makeSource({ kennelSlugMap: { sch4: "SCH4" } }));
+
+    expect(result.events).toEqual([]);
+    expect(result.errorDetails?.fetch?.[0].message).toMatch(/partial archive/i);
+  });
+
+  it("accepts a full archive when returned rows equal iTotalRecords", async () => {
+    mockSafeFetch.mockResolvedValueOnce(
+      jsonResponse({ aaData: SCH4_ROWS, iTotalRecords: String(SCH4_ROWS.length) }),
+    );
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(makeSource({ kennelSlugMap: { sch4: "SCH4" } }));
+
+    expect(result.errors).toEqual([]);
+    expect(result.events).toHaveLength(2);
+  });
+
+  it("records a fetch error on non-OK HTTP without throwing", async () => {
+    mockSafeFetch.mockResolvedValueOnce(jsonResponse({}, false, 503));
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(makeSource({ kennelSlugMap: { sch4: "SCH4" } }));
+
+    expect(result.events).toEqual([]);
+    expect(result.errorDetails?.fetch?.[0].status).toBe(503);
+  });
+
+  it("skips a bad-date row but still emits its siblings (fail-loud)", async () => {
+    const rows: HashStatsRow[] = [
+      { ...SCH4_ROWS[0], EVENT_DATE: "garbage", KENNEL_EVENT_NUMBER: "1455" },
+      SCH4_ROWS[1],
+    ];
+    mockSafeFetch.mockResolvedValueOnce(jsonResponse({ aaData: rows }));
+
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(makeSource({ kennelSlugMap: { sch4: "SCH4" } }));
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].runNumber).toBe(1454);
+    expect(result.errorDetails?.parse?.[0].error).toMatch(/unparseable EVENT_DATE/i);
+  });
+
+  it("honors options.days — old events fall outside a narrow window", async () => {
+    // QCH4 rows are from 2017; a ±30-day window around 2026-06-01 excludes them.
+    mockSafeFetch.mockResolvedValueOnce(jsonResponse({ aaData: QCH4_ROWS }));
+    const adapter = new HashStatsAdapter();
+    const result = await adapter.fetch(
+      makeSource({ kennelSlugMap: { qch4: "QCH4" } }),
+      { days: 30 },
+    );
+    expect(result.events).toEqual([]);
+    expect(result.diagnosticContext?.apiRowsReturned).toBe(2);
+  });
+
+  it("respects a configurable baseUrl override", async () => {
+    mockSafeFetch.mockResolvedValueOnce(jsonResponse({ aaData: SCH4_ROWS }));
+    const adapter = new HashStatsAdapter();
+    await adapter.fetch(
+      makeSource({ baseUrl: "https://hashingstats.com/", kennelSlugMap: { sch4: "SCH4" } }),
+    );
+    // Trailing slash on baseUrl is stripped before composing the URL.
+    expect(mockSafeFetch).toHaveBeenCalledWith(
+      "https://hashingstats.com/SCH4/listhashes2",
+      expect.anything(),
+    );
+  });
+});

--- a/src/adapters/hashstats/adapter.ts
+++ b/src/adapters/hashstats/adapter.ts
@@ -148,7 +148,7 @@ export function mapHashStatsRow(
     date: parsed.date,
     kennelTags: [kennelTag],
     // title omitted on purpose — merge.ts synthesizes "<Kennel> Trail #N".
-    ...(runNumber !== undefined ? { runNumber } : {}),
+    ...(runNumber ? { runNumber } : {}),
     ...(parsed.startTime ? { startTime: parsed.startTime } : {}),
     description: normalizeDescription(row.SPECIAL_EVENT_DESCRIPTION),
     location: cleanLocationName(row.EVENT_LOCATION),
@@ -159,6 +159,77 @@ export function mapHashStatsRow(
   };
 
   return raw;
+}
+
+/** A single fetch/parse error for one kennel slug. */
+type KennelFetchError = { url: string; status?: number; message: string };
+
+/** Discriminated result of fetching one kennel's archive. */
+type KennelArchiveResult =
+  | { ok: true; rows: HashStatsRow[] }
+  | { ok: false; error: KennelFetchError };
+
+/**
+ * Fetch + validate one kennel's full archive. Fails loud (returns an error
+ * result, never throws) on non-OK HTTP, a non-array `aaData` body, or a
+ * server-capped page — each of which must block reconcile rather than be
+ * mistaken for a complete (possibly empty) archive.
+ */
+async function fetchKennelArchive(
+  baseUrl: string,
+  externalSlug: string,
+): Promise<KennelArchiveResult> {
+  const url = `${baseUrl}/${encodeURIComponent(externalSlug)}/listhashes2`;
+  let rows: unknown;
+  let reportedTotal: number;
+  try {
+    const res = await safeFetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": USER_AGENT,
+      },
+      body: LIST_BODY,
+    });
+    if (!res.ok) {
+      return { ok: false, error: { url, status: res.status, message: `HashStats ${externalSlug}: HTTP ${res.status}` } };
+    }
+    const json = (await res.json()) as {
+      aaData?: unknown;
+      iTotalRecords?: unknown;
+      iTotalDisplayRecords?: unknown;
+    };
+    rows = json?.aaData;
+    reportedTotal = Number(json?.iTotalRecords ?? json?.iTotalDisplayRecords);
+  } catch (err) {
+    return {
+      ok: false,
+      error: { url, message: `HashStats ${externalSlug}: fetch error: ${err instanceof Error ? err.message : String(err)}` },
+    };
+  }
+
+  // Runtime shape guard — never trust the cast. A 200 with a non-array body
+  // (auth HTML, error JSON) must fail loud rather than silently yield 0 events,
+  // which would let the reconciler cancel live canonical events.
+  if (!Array.isArray(rows)) {
+    return { ok: false, error: { url, message: `HashStats ${externalSlug}: response missing aaData array` } };
+  }
+
+  // DataTables reports the true row count in iTotalRecords. We request the
+  // whole archive in one shot (length=100000); if the server caps the page and
+  // returns fewer rows than the total, treating it as the complete archive
+  // would let the reconciler CANCEL the missing historical events (this
+  // source's scrapeDays spans the full 1995→present window). Fail loud — an
+  // error blocks reconcile (scrape.ts gates on errors.length===0) — and skip
+  // the partial page rather than emit a half-archive. (#1771)
+  if (Number.isFinite(reportedTotal) && reportedTotal > rows.length) {
+    return {
+      ok: false,
+      error: { url, message: `HashStats ${externalSlug}: partial archive — got ${rows.length} of ${reportedTotal} rows (server-capped); skipping to avoid false reconcile cancellations` },
+    };
+  }
+
+  return { ok: true, rows: rows as HashStatsRow[] };
 }
 
 export class HashStatsAdapter implements SourceAdapter {
@@ -186,76 +257,26 @@ export class HashStatsAdapter implements SourceAdapter {
     let apiRowsReturned = 0;
 
     for (const [kennelTag, externalSlug] of entries) {
-      const url = `${baseUrl}/${encodeURIComponent(externalSlug)}/listhashes2`;
-      let rows: unknown;
-      let reportedTotal = Number.NaN;
-      try {
-        const res = await safeFetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "User-Agent": USER_AGENT,
-          },
-          body: LIST_BODY,
-        });
-        if (!res.ok) {
-          const msg = `HashStats ${externalSlug}: HTTP ${res.status}`;
-          fetchErrors.push({ url, status: res.status, message: msg });
-          errors.push(msg);
-          continue;
-        }
-        const json = (await res.json()) as {
-          aaData?: unknown;
-          iTotalRecords?: unknown;
-          iTotalDisplayRecords?: unknown;
-        };
-        rows = json?.aaData;
-        reportedTotal = Number(json?.iTotalRecords ?? json?.iTotalDisplayRecords);
-      } catch (err) {
-        const msg = `HashStats ${externalSlug}: fetch error: ${err instanceof Error ? err.message : String(err)}`;
-        fetchErrors.push({ url, message: msg });
-        errors.push(msg);
+      const result = await fetchKennelArchive(baseUrl, externalSlug);
+      if (!result.ok) {
+        fetchErrors.push(result.error);
+        errors.push(result.error.message);
         continue;
       }
 
-      // Runtime shape guard — never trust the cast. A 200 with a non-array
-      // body (auth HTML, error JSON) must fail loud rather than silently yield
-      // 0 events, which would let the reconciler cancel live canonical events.
-      if (!Array.isArray(rows)) {
-        const msg = `HashStats ${externalSlug}: response missing aaData array`;
-        fetchErrors.push({ url, message: msg });
-        errors.push(msg);
-        continue;
-      }
+      apiRowsReturned += result.rows.length;
 
-      // DataTables reports the true row count in iTotalRecords. We request the
-      // whole archive in one shot (length=100000); if the server caps the page
-      // and returns fewer rows than the total, treating it as the complete
-      // archive would let the reconciler CANCEL the missing historical events
-      // (this source's scrapeDays spans the full 1995→present window). Fail
-      // loud — an error blocks reconcile (scrape.ts gates on errors.length===0)
-      // — and skip the partial page rather than emit a half-archive. (#1771)
-      if (Number.isFinite(reportedTotal) && reportedTotal > rows.length) {
-        const msg = `HashStats ${externalSlug}: partial archive — got ${rows.length} of ${reportedTotal} rows (server-capped); skipping to avoid false reconcile cancellations`;
-        fetchErrors.push({ url, message: msg });
-        errors.push(msg);
-        continue;
-      }
-
-      apiRowsReturned += rows.length;
-
-      rows.forEach((rawRow, index) => {
-        const row = rawRow as HashStatsRow;
+      for (const [index, row] of result.rows.entries()) {
         const mapped = mapHashStatsRow(row, kennelTag, baseUrl, externalSlug);
         if (!mapped) {
           const ref = row?.KENNEL_EVENT_NUMBER ?? "?";
           const msg = `HashStats ${externalSlug}: skipped event #${ref} — unparseable EVENT_DATE "${row?.EVENT_DATE ?? ""}"`;
           parseErrors.push({ row: index, section: externalSlug, field: "date", error: msg });
           errors.push(msg);
-          return;
+          continue;
         }
         events.push(mapped);
-      });
+      }
     }
 
     if (fetchErrors.length) errorDetails.fetch = fetchErrors;

--- a/src/adapters/hashstats/adapter.ts
+++ b/src/adapters/hashstats/adapter.ts
@@ -1,0 +1,280 @@
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails, ParseError } from "../types";
+import { hasAnyErrors } from "../types";
+import { safeFetch } from "../safe-fetch";
+import { filterEventsByWindow, cleanLocationName } from "../utils";
+
+/**
+ * HashStats adapter — historical hash-event archive on the HashStats platform.
+ *
+ * HashStats (hashstats.org / hashingstats.com) is a multi-kennel *stats*
+ * platform: each kennel exposes its complete archive of **completed** hashes
+ * (with attendance counts) via a DataTables-style JSON endpoint:
+ *
+ *     POST {baseUrl}/{EXTERNAL_SLUG}/listhashes2
+ *       body: draw=1&start=0&length=<big>
+ *     → { aaData: [ { KENNEL_EVENT_NUMBER, EVENT_DATE, EVENT_LOCATION,
+ *                     SPECIAL_EVENT_DESCRIPTION, FORMATTED_ADDRESS, HASY_KY, ... } ] }
+ *
+ * A single large `length` returns the entire archive (no pagination needed).
+ *
+ * IMPORTANT — this is a *retrospective* source: every row is an event that has
+ * already happened. There is no upcoming-events surface. Seed it as a
+ * supplemental / historical-backfill source (trust ~6) behind any kennel's
+ * primary upcoming source (Google Calendar, etc.). See issue #1771.
+ *
+ * Routing: registered via the HTML_SCRAPER URL-matcher in registry.ts
+ * (`/hashingstats\.com/i`) — no new SourceType enum needed (precedent: SHITH3
+ * PHP REST API, Seletar JSON API). Kennel slugs are read directly from
+ * `source.config.kennelSlugMap`, so the pipeline injects nothing extra.
+ *
+ * Only the public `hashingstats.com` hosts serve JSON to logged-out clients.
+ * Other HashStats hosts (stats.daytonhhh.org, *.hashstats.org subdomains)
+ * redirect to `/auth` and are intentionally NOT supported here.
+ */
+
+const DEFAULT_BASE_URL = "https://hashingstats.com";
+
+/** Browser-y UA — the endpoint is public but rejects empty/odd user agents. */
+const USER_AGENT =
+  "Mozilla/5.0 (compatible; HashTracksBot/1.0; +https://hashtracks.com)";
+
+/** Request the full archive in one shot — the server returns all rows. */
+const LIST_BODY = "draw=1&start=0&length=100000";
+
+/** Single row from the `listhashes2` `aaData` array (fields we consume). */
+export interface HashStatsRow {
+  KENNEL_EVENT_NUMBER?: string;
+  EVENT_DATE?: string; // "YYYY-MM-DD HH:MM:SS"
+  EVENT_LOCATION?: string;
+  SPECIAL_EVENT_DESCRIPTION?: string;
+  EVENT_CITY?: string;
+  EVENT_STATE?: string;
+  FORMATTED_ADDRESS?: string;
+  HASY_KY?: string; // detail-page key
+}
+
+/** Config shape for HashStats sources stored in Source.config. */
+export interface HashStatsConfig {
+  /** Override the API host. Defaults to "https://hashingstats.com". */
+  baseUrl?: string;
+  /**
+   * Map of HashTracks kennelCode → HashStats external slug, e.g.
+   * `{ sch4: "SCH4" }`. One source row can drive many kennels off this map.
+   * Required and non-empty — a missing map fails loud (no silent 0 events).
+   */
+  kennelSlugMap?: Record<string, string>;
+}
+
+/**
+ * HashStats stores "no description" rows literally as "None". Treat that (and
+ * empty/whitespace) as "no theme" so it doesn't surface as event prose.
+ */
+function normalizeDescription(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed || /^none$/i.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+/**
+ * Parse HashStats `EVENT_DATE` ("2026-05-21 19:00:00") into a calendar date
+ * + optional start time. Validates the date is real (rejects 2026-02-30 etc.)
+ * Returns null when the date portion is missing/invalid so the caller can
+ * fail loud and skip the row rather than emitting a garbage date.
+ *
+ * `startTime` is dropped for the "00:00" midnight sentinel (HashStats uses it
+ * when no real start time was recorded).
+ */
+export function parseHashStatsDateTime(
+  raw: string | undefined,
+): { date: string; startTime?: string } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}))?/.exec((raw ?? "").trim());
+  if (!m) return null;
+
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+
+  // Round-trip through UTC noon to reject impossible dates (Feb 30, month 13).
+  const probe = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  if (
+    probe.getUTCFullYear() !== year ||
+    probe.getUTCMonth() !== month - 1 ||
+    probe.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  const date = `${m[1]}-${m[2]}-${m[3]}`;
+
+  let startTime: string | undefined;
+  if (m[4] != null && m[5] != null) {
+    const hh = Number(m[4]);
+    const mm = Number(m[5]);
+    if (hh >= 0 && hh <= 23 && mm >= 0 && mm <= 59 && !(hh === 0 && mm === 0)) {
+      startTime = `${m[4]}:${m[5]}`;
+    }
+  }
+
+  return startTime ? { date, startTime } : { date };
+}
+
+/**
+ * Map one HashStats row to RawEventData for a given kennel tag. Returns null
+ * when EVENT_DATE is unparseable (caller records a parse error and skips).
+ *
+ * Title is intentionally left undefined so the merge pipeline synthesizes the
+ * canonical "<KennelName> Trail #N" — the theme goes in `description` instead.
+ * Run number comes straight from the clean integer KENNEL_EVENT_NUMBER field
+ * (not extractHashRunNumber, which is for free-form `#NNN` text).
+ */
+export function mapHashStatsRow(
+  row: HashStatsRow,
+  kennelTag: string,
+  baseUrl: string,
+  externalSlug: string,
+): RawEventData | null {
+  const parsed = parseHashStatsDateTime(row.EVENT_DATE);
+  if (!parsed) return null;
+
+  const runNumberRaw = Number(row.KENNEL_EVENT_NUMBER);
+  const runNumber =
+    Number.isFinite(runNumberRaw) && runNumberRaw > 0 ? runNumberRaw : undefined;
+
+  const street = row.FORMATTED_ADDRESS?.trim();
+  const hasyKy = row.HASY_KY?.trim();
+
+  const raw: RawEventData = {
+    date: parsed.date,
+    kennelTags: [kennelTag],
+    // title omitted on purpose — merge.ts synthesizes "<Kennel> Trail #N".
+    ...(runNumber !== undefined ? { runNumber } : {}),
+    ...(parsed.startTime ? { startTime: parsed.startTime } : {}),
+    description: normalizeDescription(row.SPECIAL_EVENT_DESCRIPTION),
+    location: cleanLocationName(row.EVENT_LOCATION),
+    ...(street ? { locationStreet: street } : {}),
+    ...(hasyKy
+      ? { sourceUrl: `${baseUrl}/${encodeURIComponent(externalSlug)}/hashes/${hasyKy}` }
+      : {}),
+  };
+
+  return raw;
+}
+
+export class HashStatsAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    const config = (source.config ?? {}) as HashStatsConfig;
+    const events: RawEventData[] = [];
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+    const fetchErrors: NonNullable<ErrorDetails["fetch"]> = [];
+    const parseErrors: ParseError[] = [];
+    const fetchStart = Date.now();
+
+    const entries = Object.entries(config.kennelSlugMap ?? {});
+    if (entries.length === 0) {
+      const msg =
+        "HashStats: config.kennelSlugMap is missing or empty — cannot resolve external kennel slugs";
+      return { events: [], errors: [msg], errorDetails: { fetch: [{ message: msg }] } };
+    }
+
+    const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    const days = options?.days ?? source.scrapeDays ?? 365;
+
+    let apiRowsReturned = 0;
+
+    for (const [kennelTag, externalSlug] of entries) {
+      const url = `${baseUrl}/${encodeURIComponent(externalSlug)}/listhashes2`;
+      let rows: unknown;
+      let reportedTotal = Number.NaN;
+      try {
+        const res = await safeFetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": USER_AGENT,
+          },
+          body: LIST_BODY,
+        });
+        if (!res.ok) {
+          const msg = `HashStats ${externalSlug}: HTTP ${res.status}`;
+          fetchErrors.push({ url, status: res.status, message: msg });
+          errors.push(msg);
+          continue;
+        }
+        const json = (await res.json()) as {
+          aaData?: unknown;
+          iTotalRecords?: unknown;
+          iTotalDisplayRecords?: unknown;
+        };
+        rows = json?.aaData;
+        reportedTotal = Number(json?.iTotalRecords ?? json?.iTotalDisplayRecords);
+      } catch (err) {
+        const msg = `HashStats ${externalSlug}: fetch error: ${err instanceof Error ? err.message : String(err)}`;
+        fetchErrors.push({ url, message: msg });
+        errors.push(msg);
+        continue;
+      }
+
+      // Runtime shape guard — never trust the cast. A 200 with a non-array
+      // body (auth HTML, error JSON) must fail loud rather than silently yield
+      // 0 events, which would let the reconciler cancel live canonical events.
+      if (!Array.isArray(rows)) {
+        const msg = `HashStats ${externalSlug}: response missing aaData array`;
+        fetchErrors.push({ url, message: msg });
+        errors.push(msg);
+        continue;
+      }
+
+      // DataTables reports the true row count in iTotalRecords. We request the
+      // whole archive in one shot (length=100000); if the server caps the page
+      // and returns fewer rows than the total, treating it as the complete
+      // archive would let the reconciler CANCEL the missing historical events
+      // (this source's scrapeDays spans the full 1995→present window). Fail
+      // loud — an error blocks reconcile (scrape.ts gates on errors.length===0)
+      // — and skip the partial page rather than emit a half-archive. (#1771)
+      if (Number.isFinite(reportedTotal) && reportedTotal > rows.length) {
+        const msg = `HashStats ${externalSlug}: partial archive — got ${rows.length} of ${reportedTotal} rows (server-capped); skipping to avoid false reconcile cancellations`;
+        fetchErrors.push({ url, message: msg });
+        errors.push(msg);
+        continue;
+      }
+
+      apiRowsReturned += rows.length;
+
+      rows.forEach((rawRow, index) => {
+        const row = rawRow as HashStatsRow;
+        const mapped = mapHashStatsRow(row, kennelTag, baseUrl, externalSlug);
+        if (!mapped) {
+          const ref = row?.KENNEL_EVENT_NUMBER ?? "?";
+          const msg = `HashStats ${externalSlug}: skipped event #${ref} — unparseable EVENT_DATE "${row?.EVENT_DATE ?? ""}"`;
+          parseErrors.push({ row: index, section: externalSlug, field: "date", error: msg });
+          errors.push(msg);
+          return;
+        }
+        events.push(mapped);
+      });
+    }
+
+    if (fetchErrors.length) errorDetails.fetch = fetchErrors;
+    if (parseErrors.length) errorDetails.parse = parseErrors;
+
+    // Honor options.days via the shared window filter (events are mapped from
+    // the full archive above, then trimmed to the requested ±days window).
+    const windowedEvents = filterEventsByWindow(events, days);
+
+    return {
+      events: windowedEvents,
+      errors,
+      ...(hasAnyErrors(errorDetails) ? { errorDetails } : {}),
+      diagnosticContext: {
+        fetchDurationMs: Date.now() - fetchStart,
+        kennelsRequested: entries.length,
+        apiRowsReturned,
+        eventsEmitted: windowedEvents.length,
+      },
+    };
+  }
+}

--- a/src/adapters/hashstats/adapter.ts
+++ b/src/adapters/hashstats/adapter.ts
@@ -237,6 +237,45 @@ async function fetchKennelArchive(
   return { ok: true, rows: rows as HashStatsRow[] };
 }
 
+/**
+ * Map one kennel's rows to events with per-row isolation: a single malformed
+ * row (unparseable date, or an unexpected field type that throws downstream) is
+ * recorded as a parse error and skipped, never aborting the rest of the archive.
+ */
+function collectKennelEvents(
+  rows: HashStatsRow[],
+  kennelTag: string,
+  baseUrl: string,
+  externalSlug: string,
+): { events: RawEventData[]; parseErrors: ParseError[] } {
+  const events: RawEventData[] = [];
+  const parseErrors: ParseError[] = [];
+  rows.forEach((row, index) => {
+    try {
+      const mapped = mapHashStatsRow(row, kennelTag, baseUrl, externalSlug);
+      if (mapped) {
+        events.push(mapped);
+        return;
+      }
+      const ref = row?.KENNEL_EVENT_NUMBER ?? "?";
+      parseErrors.push({
+        row: index,
+        section: externalSlug,
+        field: "date",
+        error: `HashStats ${externalSlug}: skipped event #${ref} — unparseable EVENT_DATE "${row?.EVENT_DATE ?? ""}"`,
+      });
+    } catch (err) {
+      parseErrors.push({
+        row: index,
+        section: externalSlug,
+        field: "row",
+        error: `HashStats ${externalSlug}: failed to process row ${index}: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  });
+  return { events, parseErrors };
+}
+
 export class HashStatsAdapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
@@ -274,25 +313,11 @@ export class HashStatsAdapter implements SourceAdapter {
 
       apiRowsReturned += result.rows.length;
 
-      for (const [index, row] of result.rows.entries()) {
-        // Per-row isolation: a single malformed row (unparseable date, or an
-        // unexpected field type that throws downstream) is logged and skipped,
-        // never aborting the rest of the archive.
-        try {
-          const mapped = mapHashStatsRow(row, kennelTag, baseUrl, externalSlug);
-          if (!mapped) {
-            const ref = row?.KENNEL_EVENT_NUMBER ?? "?";
-            const msg = `HashStats ${externalSlug}: skipped event #${ref} — unparseable EVENT_DATE "${row?.EVENT_DATE ?? ""}"`;
-            parseErrors.push({ row: index, section: externalSlug, field: "date", error: msg });
-            errors.push(msg);
-            continue;
-          }
-          events.push(mapped);
-        } catch (err) {
-          const msg = `HashStats ${externalSlug}: failed to process row ${index}: ${err instanceof Error ? err.message : String(err)}`;
-          parseErrors.push({ row: index, section: externalSlug, field: "row", error: msg });
-          errors.push(msg);
-        }
+      const collected = collectKennelEvents(result.rows, kennelTag, baseUrl, externalSlug);
+      events.push(...collected.events);
+      for (const pe of collected.parseErrors) {
+        parseErrors.push(pe);
+        errors.push(pe.error);
       }
     }
 

--- a/src/adapters/hashstats/adapter.ts
+++ b/src/adapters/hashstats/adapter.ts
@@ -251,7 +251,9 @@ export class HashStatsAdapter implements SourceAdapter {
       return { events: [], errors: [msg], errorDetails: { fetch: [{ message: msg }] } };
     }
 
-    const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    // Strip trailing slashes procedurally (avoids a regex ReDoS hotspot).
+    let baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+    while (baseUrl.endsWith("/")) baseUrl = baseUrl.slice(0, -1);
     const days = options?.days ?? source.scrapeDays ?? 365;
 
     let apiRowsReturned = 0;

--- a/src/adapters/hashstats/adapter.ts
+++ b/src/adapters/hashstats/adapter.ts
@@ -86,9 +86,11 @@ function normalizeDescription(raw: string | undefined): string | undefined {
  * when no real start time was recorded).
  */
 export function parseHashStatsDateTime(
-  raw: string | undefined,
+  raw: unknown,
 ): { date: string; startTime?: string } | null {
-  const m = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}))?/.exec((raw ?? "").trim());
+  // The payload is cast from `unknown`, so a non-string EVENT_DATE is possible.
+  if (typeof raw !== "string") return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}))?/.exec(raw.trim());
   if (!m) return null;
 
   const year = Number(m[1]);
@@ -129,11 +131,14 @@ export function parseHashStatsDateTime(
  * (not extractHashRunNumber, which is for free-form `#NNN` text).
  */
 export function mapHashStatsRow(
-  row: HashStatsRow,
+  row: HashStatsRow | null | undefined,
   kennelTag: string,
   baseUrl: string,
   externalSlug: string,
 ): RawEventData | null {
+  // aaData is cast from `unknown` — a null / non-object element would otherwise
+  // throw on property access. Treat it as an unparseable row (caller logs + skips).
+  if (row == null || typeof row !== "object") return null;
   const parsed = parseHashStatsDateTime(row.EVENT_DATE);
   if (!parsed) return null;
 
@@ -251,8 +256,9 @@ export class HashStatsAdapter implements SourceAdapter {
       return { events: [], errors: [msg], errorDetails: { fetch: [{ message: msg }] } };
     }
 
+    // baseUrl comes from a config cast from `unknown`; tolerate a non-string.
     // Strip trailing slashes procedurally (avoids a regex ReDoS hotspot).
-    let baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+    let baseUrl = typeof config.baseUrl === "string" ? config.baseUrl : DEFAULT_BASE_URL;
     while (baseUrl.endsWith("/")) baseUrl = baseUrl.slice(0, -1);
     const days = options?.days ?? source.scrapeDays ?? 365;
 
@@ -269,15 +275,24 @@ export class HashStatsAdapter implements SourceAdapter {
       apiRowsReturned += result.rows.length;
 
       for (const [index, row] of result.rows.entries()) {
-        const mapped = mapHashStatsRow(row, kennelTag, baseUrl, externalSlug);
-        if (!mapped) {
-          const ref = row?.KENNEL_EVENT_NUMBER ?? "?";
-          const msg = `HashStats ${externalSlug}: skipped event #${ref} — unparseable EVENT_DATE "${row?.EVENT_DATE ?? ""}"`;
-          parseErrors.push({ row: index, section: externalSlug, field: "date", error: msg });
+        // Per-row isolation: a single malformed row (unparseable date, or an
+        // unexpected field type that throws downstream) is logged and skipped,
+        // never aborting the rest of the archive.
+        try {
+          const mapped = mapHashStatsRow(row, kennelTag, baseUrl, externalSlug);
+          if (!mapped) {
+            const ref = row?.KENNEL_EVENT_NUMBER ?? "?";
+            const msg = `HashStats ${externalSlug}: skipped event #${ref} — unparseable EVENT_DATE "${row?.EVENT_DATE ?? ""}"`;
+            parseErrors.push({ row: index, section: externalSlug, field: "date", error: msg });
+            errors.push(msg);
+            continue;
+          }
+          events.push(mapped);
+        } catch (err) {
+          const msg = `HashStats ${externalSlug}: failed to process row ${index}: ${err instanceof Error ? err.message : String(err)}`;
+          parseErrors.push({ row: index, section: externalSlug, field: "row", error: msg });
           errors.push(msg);
-          continue;
         }
-        events.push(mapped);
       }
     }
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -118,6 +118,7 @@ import { RssAdapter } from "./rss/adapter";
 import { StaticScheduleAdapter } from "./static-schedule/adapter";
 import { HarrierCentralAdapter } from "./harrier-central/adapter";
 import { FacebookHostedEventsAdapter } from "./facebook-hosted-events/adapter";
+import { HashStatsAdapter } from "./hashstats/adapter";
 
 const adapters: Partial<Record<SourceType, () => SourceAdapter>> = {
   HTML_SCRAPER: () => new HashNYCAdapter(), // default HTML scraper
@@ -280,6 +281,12 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   // additional kennels just add a URL pattern + a Source row with
   // `kennelTag` in config.
   { pattern: /sach3\.beer/i, name: "SquarespaceEventsAdapter", factory: () => new SquarespaceEventsAdapter() },
+  // HashStats — multi-kennel historical stats archive served as JSON over
+  // POST {host}/{SLUG}/listhashes2 (DataTables shape). JSON-over-HTML_SCRAPER,
+  // like SHITH3/Seletar. Kennel slugs come from config.kennelSlugMap, so one
+  // Source row can drive many kennels. Only public hashingstats.com hosts
+  // serve logged-out JSON; *.hashstats.org subdomains redirect to /auth. (#1771)
+  { pattern: /hashingstats\.com/i, name: "HashStatsAdapter", factory: () => new HashStatsAdapter() },
 ];
 
 /** URL-based routing for HTML_SCRAPER — derived from htmlScraperEntries (single source of truth). */

--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/lib/db", () => ({
     source: { findUnique: vi.fn(), update: vi.fn() },
     rawEvent: { deleteMany: vi.fn() },
     scrapeLog: { create: vi.fn(), update: vi.fn() },
+    sourceKennel: { findMany: vi.fn() },
   },
 }));
 
@@ -58,6 +59,7 @@ import { prisma } from "@/lib/db";
 import { getAdapter } from "@/adapters/registry";
 import { processRawEvents } from "./merge";
 import { analyzeHealth } from "./health";
+import { reconcileStaleEvents } from "./reconcile";
 import { scrapeSource } from "./scrape";
 import { revalidateTag } from "next/cache";
 import { after } from "next/server";
@@ -70,6 +72,8 @@ const mockLogUpdate = vi.mocked(prisma.scrapeLog.update);
 const mockGetAdapter = vi.mocked(getAdapter);
 const mockProcessRaw = vi.mocked(processRawEvents);
 const mockAnalyzeHealth = vi.mocked(analyzeHealth);
+const mockSourceKennelFind = vi.mocked(prisma.sourceKennel.findMany);
+const mockReconcile = vi.mocked(reconcileStaleEvents);
 
 const fakeSource = { id: "src_1", type: "HTML_SCRAPER", url: "https://test.com" };
 const fakeMergeResult = {
@@ -257,6 +261,73 @@ describe("scrapeSource", () => {
     const updateData = mockLogUpdate.mock.calls[0][0] as { data: Record<string, unknown> };
     expect(updateData.data.sampleBlocked).toEqual(sampleBlocked);
     expect(updateData.data.sampleSkipped).toEqual(sampleSkipped);
+  });
+
+  // #1771 — config-driven slug-map sources (HashStats) must scope reconcile to
+  // the kennels named in kennelSlugMap. Otherwise scrapedKennelIds stays
+  // undefined and reconcile evaluates every linked kennel, false-cancelling the
+  // sole-source events of a linked kennel the map omits.
+  describe("kennelSlugMap reconcile scoping", () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    afterEach(() => consoleWarnSpy.mockClear());
+
+    it("scopes reconcile to mapped kennels, excluding omitted linked kennels", async () => {
+      const slugMapSource = {
+        id: "src_hs", type: "HTML_SCRAPER", url: "https://hashingstats.com/SCH4",
+        config: { kennelSlugMap: { sch4: "SCH4" } },
+      };
+      mockSourceFind.mockResolvedValue(slugMapSource as never);
+      // The source is linked to TWO kennels but the map only covers sch4.
+      mockSourceKennelFind.mockResolvedValue([
+        { kennelId: "k_sch4", kennel: { kennelCode: "sch4" } },
+        { kennelId: "k_qch4", kennel: { kennelCode: "qch4" } },
+      ] as never);
+      mockGetAdapter.mockReturnValue({
+        type: "HTML_SCRAPER",
+        fetch: vi.fn().mockResolvedValue({
+          events: [{ date: "2026-02-14", kennelTags: ["sch4"] }],
+          errors: [],
+        }),
+      } as never);
+
+      await scrapeSource("src_hs");
+
+      expect(mockSourceKennelFind).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { sourceId: "src_hs" } }),
+      );
+      // reconcile scoped to ONLY the mapped kennel (k_sch4), never k_qch4.
+      expect(mockReconcile).toHaveBeenCalledWith(
+        "src_hs",
+        expect.any(Array),
+        expect.any(Number),
+        ["k_sch4"],
+        false,
+      );
+    });
+
+    it("fails closed (skips reconcile) when the map matches no linked SourceKennel", async () => {
+      const slugMapSource = {
+        id: "src_hs2", type: "HTML_SCRAPER", url: "https://hashingstats.com/SCH4",
+        config: { kennelSlugMap: { sch4: "SCH4" } },
+      };
+      mockSourceFind.mockResolvedValue(slugMapSource as never);
+      // Drift: the only linked kennel's code doesn't appear in the map.
+      mockSourceKennelFind.mockResolvedValue([
+        { kennelId: "k_other", kennel: { kennelCode: "qch4" } },
+      ] as never);
+      mockGetAdapter.mockReturnValue({
+        type: "HTML_SCRAPER",
+        fetch: vi.fn().mockResolvedValue({
+          events: [{ date: "2026-02-14", kennelTags: ["sch4"] }],
+          errors: [],
+        }),
+      } as never);
+
+      await scrapeSource("src_hs2");
+
+      // An empty scope must NOT reconcile (that would fall back to all linked).
+      expect(mockReconcile).not.toHaveBeenCalled();
+    });
   });
 
   // #1739 — silentlySkipPatterns drops known source pollution at the ingest

--- a/src/pipeline/scrape.test.ts
+++ b/src/pipeline/scrape.test.ts
@@ -288,7 +288,7 @@ describe("scrapeSource", () => {
           events: [{ date: "2026-02-14", kennelTags: ["sch4"] }],
           errors: [],
         }),
-      } as never);
+      });
 
       await scrapeSource("src_hs");
 
@@ -321,7 +321,7 @@ describe("scrapeSource", () => {
           events: [{ date: "2026-02-14", kennelTags: ["sch4"] }],
           errors: [],
         }),
-      } as never);
+      });
 
       await scrapeSource("src_hs2");
 

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -460,6 +460,43 @@ export async function scrapeSource(
       }
     }
 
+    // Config-driven slug-map sources (HashStats) scope their fetch to the
+    // kennels named in `config.kennelSlugMap`. Reconcile must be scoped the
+    // same way: without this, scrapedKennelIds stays undefined and reconcile
+    // evaluates EVERY linked kennel, so a map that omits a linked kennel would
+    // let reconcile false-cancel that kennel's sole-source events. HASHREGO is
+    // excluded explicitly (not just via `!scrapedKennelIds`) because its block
+    // above can legitimately leave scrapedKennelIds undefined — the
+    // zero-discoveries fallback path — so a HASHREGO source that also carried a
+    // kennelSlugMap must not fall through into this slug-map scoping. (#1771)
+    let slugMapScopeMismatch = false;
+    if (!scrapedKennelIds && source.type !== "HASHREGO") {
+      const slugMap = (source.config as { kennelSlugMap?: Record<string, string> } | null)
+        ?.kennelSlugMap;
+      if (slugMap && Object.keys(slugMap).length > 0) {
+        const mappedCodes = new Set(Object.keys(slugMap));
+        const sks = await prisma.sourceKennel.findMany({
+          where: { sourceId },
+          select: { kennelId: true, kennel: { select: { kennelCode: true } } },
+        });
+        scrapedKennelIds = sks
+          .filter((sk) => mappedCodes.has(sk.kennel.kennelCode))
+          .map((sk) => sk.kennelId);
+        // Fail closed on scope drift: if the map matched no linked SourceKennel
+        // (typo, missing link, stale seed), an EMPTY scrapedKennelIds would make
+        // reconcile fall back to ALL linked kennels (reconcile treats [] the same
+        // as undefined) — reopening the false-cancellation hazard. Block reconcile
+        // and surface it instead of silently reconciling everything. (#1771)
+        if (scrapedKennelIds.length === 0) {
+          slugMapScopeMismatch = true;
+          console.warn(
+            `[scrape] ${source.name}: kennelSlugMap matched no linked SourceKennel rows — ` +
+              `skipping reconcile to avoid false cancellations (check seed config/links)`,
+          );
+        }
+      }
+    }
+
     const fetchStart = Date.now();
     const scrapeResult = await adapter.fetch(source, { days, kennelSlugs });
     const fetchDurationMs = Date.now() - fetchStart;
@@ -495,7 +532,8 @@ export async function scrapeSource(
       scrapeResult.events.length > 0 &&
       scrapeResult.errors.length === 0 &&
       kennelPageErrors === 0 &&
-      !kennelPagesIncomplete
+      !kennelPagesIncomplete &&
+      !slugMapScopeMismatch
     ) {
       const upcomingOnly =
         (source.config as Record<string, unknown> | null)?.upcomingOnly === true;
@@ -535,6 +573,7 @@ export async function scrapeSource(
     const diagnosticContext = buildDiagnosticContext(scrapeResult.diagnosticContext, aiRecovery);
     diagnosticContext.scrapeDays = days;
     if (reconcileContext) diagnosticContext.reconciliation = reconcileContext;
+    if (slugMapScopeMismatch) diagnosticContext.slugMapScopeMismatch = true;
     if (mergeResult.restored > 0) diagnosticContext.eventsRestored = mergeResult.restored;
     if (silentSkip.skipped > 0) diagnosticContext.silentlySkipped = silentSkip;
 


### PR DESCRIPTION
## What

Adds a **HashStats** source adapter and onboards one proof kennel (SCH4).

HashStats (`hashingstats.com`) is a multi-kennel hash *stats* platform. Each kennel exposes its complete archive of **completed** hashes via a public DataTables JSON endpoint:

```
POST https://hashingstats.com/{SLUG}/listhashes2   body: draw=1&start=0&length=100000
→ { aaData: [ { KENNEL_EVENT_NUMBER, EVENT_DATE, EVENT_LOCATION,
                SPECIAL_EVENT_DESCRIPTION, FORMATTED_ADDRESS, HASY_KY, ... } ] }
```

A single large `length` returns the **entire archive** — no pagination, no auth, cron-safe.

## Research-spike finding (GATE: GO, with a caveat)

HashStats is **retrospective** — it records hashes that already happened (with attendance counts). There is **no upcoming-events surface** (verified: SCH4 = 1457 rows, 1995-09-15 → 2026-05-21, **zero future-dated**). So it's onboarded as a **supplemental / historical-backfill source (trust 6)** behind each kennel's primary upcoming source — exactly as issue #1771's acceptance criteria describe. Only public `hashingstats.com` hosts serve logged-out JSON; the `*.hashstats.org` / `stats.daytonhhh.org` hosts redirect to `/auth` and are deliberately excluded (follow-up to investigate).

## Design

- **No new `SourceType` / migration** — routed via the existing `HTML_SCRAPER` URL-matcher in `registry.ts` (`/hashingstats\.com/i`). Precedent: SHITH3 (PHP REST API) and Seletar (JSON API) are both JSON-over-`HTML_SCRAPER`.
- **`config.kennelSlugMap`** (kennelCode → external slug) lets one source drive many kennels. Read directly from `source.config`, so no `scrape.ts` slug-injection needed.

## Reconcile safety (fail-loud)

HashStats spans a ~31-year window, so a bad scrape must never trigger destructive reconciliation:

1. **Capped page guard** — if returned rows `< iTotalRecords`, the page was server-capped; push an error (blocks reconcile via the `errors.length === 0` gate) and skip the partial page rather than emit a half-archive.
2. **Reconcile scoping** — `scrape.ts` scopes reconcile to the `kennelSlugMap` kennels (generalizes the HASHREGO pattern). If the map matches **no** linked `SourceKennel` (config drift), it **fails closed** — skips reconcile and surfaces a diagnostic — because an empty scope would otherwise widen reconcile back to all linked kennels.

Both hazards were surfaced by `/codex:adversarial-review` and fixed + regression-tested.

## Proof kennel

**SCH4** (Sin City H4, Cincinnati) — already live with a Google Calendar primary; HashStats adds the full 1995→present archive. Live-verified end-to-end: **1457 events, 0 errors**, all `startTime` valid `HH:MM`, venue + street address populated.

## Tests / checks

- Fixture-backed adapter tests (24) from real captured payloads + reconcile-scoping tests in `scrape.test.ts`.
- `npm run lint && npx tsc --noEmit && npm test` — all green (8188 pass).

## Follow-ups (filed separately)

- Onboard remaining public HashStats kennels (QCH4, SWOT, LVH3, SCH4BASH) via the same adapter + config.
- Investigate auth-gated `*.hashstats.org` hosts (DH3, BH3, MVH3, ONINH3, RH3C, UNMASKEDH3).

Closes #1771

🤖 Generated with [Claude Code](https://claude.com/claude-code)