### PR TITLE
fix(adapters): parse-wave bundle — 5 adapter parse fixes + shared helpers

### DIFF
--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -3794,6 +3794,24 @@ describe("normalizeGCalDescription", () => {
     // No "Description:" label after Location:, so it is NOT the HC boilerplate pattern
     expect(result.description).toContain("Trail notes");
   });
+
+  it("collapses a body block pasted verbatim twice (#1889 Morgantown Run #136)", () => {
+    // Verbatim from the live morgantownh3@gmail.com calendar: the source entry
+    // duplicates the whole body block after the #724 boilerplate header.
+    const block = [
+      "All work and no play makes Jack a dull boy! Let's celebrate National Repeat Day!",
+      "",
+      "Time: June 3, 6 PM",
+      "Location TBA.",
+      "Hares: I Call the Shots and Attn: Ass Horse!",
+      "$5 Hash Cash.",
+    ].join("\n");
+    const raw = `Morgantown H3\nLocation: Genes Beer Garden\nDescription: ${block}\n\n${block}`;
+    const result = normalizeGCalDescription(raw);
+    expect(result.description).toBe(block);
+    // The duplicated copy is gone — "National Repeat Day" appears exactly once.
+    expect(result.description?.match(/National Repeat Day/g)).toHaveLength(1);
+  });
 });
 
 describe("buildRawEventFromGCalItem — trailing dash + defaultTitle (#756 Moooouston)", () => {

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber, normalizeCostSigil } from "../utils";
+import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, dedupeRepeatedDescription, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber, normalizeCostSigil } from "../utils";
 import { matchKennelPatterns, matchCompiledKennelPatterns, compileKennelPatterns, type KennelPattern, type CompiledKennelPattern } from "../kennel-patterns";
 import { LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 import { parseDMSFromLocation } from "@/lib/geo";
@@ -1165,6 +1165,10 @@ export function normalizeGCalDescription(rawDesc: string | undefined): { rawDesc
   // Strip Harrier Central auto-generated header from GCal-synced events:
   // "{KennelName}\nLocation: {venue}\nDescription: {actual text}" → "{actual text}"
   rawDescription = rawDescription.replace(/^[^\n]*\nLocation:[^\n]*\nDescription:\s*/i, "");
+  // Collapse a description whose body block is pasted verbatim twice (#1889
+  // Morgantown "National Repeat Day" — the source calendar entry duplicated the
+  // whole block). No-op for non-doubled descriptions.
+  rawDescription = dedupeRepeatedDescription(rawDescription) ?? rawDescription;
   const description = rawDescription
     ? rawDescription.replace(/[ \t]+/g, " ").trim().substring(0, 2000) || undefined
     : undefined;

--- a/src/adapters/html-scraper/geriatrix-h3.test.ts
+++ b/src/adapters/html-scraper/geriatrix-h3.test.ts
@@ -132,25 +132,31 @@ describe("GeriatrixH3Adapter.fetch", () => {
   });
 
   it("strips ' - Maybe' / ' - Memorial Run' venue qualifiers from location (#1880)", async () => {
-    // Verbatim venue strings from live sporty.co.nz Geriatrix hareline.
-    const fixture = `<!DOCTYPE html><html><body>
-      <div class="richtext-editor">
-        <p><span>09/06/2026</span></p>
-        <p>Venue: Victoria Tavern, Petone - Maybe.</p>
-        <p>Hare: Pohutukawa</p>
-        <p><br></p>
-        <p><span>16/06/2026</span></p>
-        <p>Venue: The Co-Op Whitby - Memorial Run</p>
-        <p>Hare: Slippery</p>
-      </div>
-    </body></html>`;
-    mockedBrowserRender.mockResolvedValue(fixture);
-    const adapter = new GeriatrixH3Adapter();
-    const result = await adapter.fetch(makeSource(), { days: 365 });
-    expect(result.errors).toEqual([]);
-    expect(result.events.length).toBe(2);
-    expect(result.events[0].location).toBe("Victoria Tavern, Petone");
-    expect(result.events[1].location).toBe("The Co-Op Whitby");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+    try {
+      // Verbatim venue strings from live sporty.co.nz Geriatrix hareline.
+      const fixture = `<!DOCTYPE html><html><body>
+        <div class="richtext-editor">
+          <p><span>09/06/2026</span></p>
+          <p>Venue: Victoria Tavern, Petone - Maybe.</p>
+          <p>Hare: Pohutukawa</p>
+          <p><br></p>
+          <p><span>16/06/2026</span></p>
+          <p>Venue: The Co-Op Whitby - Memorial Run</p>
+          <p>Hare: Slippery</p>
+        </div>
+      </body></html>`;
+      mockedBrowserRender.mockResolvedValue(fixture);
+      const adapter = new GeriatrixH3Adapter();
+      const result = await adapter.fetch(makeSource(), { days: 365 });
+      expect(result.errors).toEqual([]);
+      expect(result.events.length).toBe(2);
+      expect(result.events[0].location).toBe("Victoria Tavern, Petone");
+      expect(result.events[1].location).toBe("The Co-Op Whitby");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns the fetch failure when browserRender errors", async () => {

--- a/src/adapters/html-scraper/geriatrix-h3.test.ts
+++ b/src/adapters/html-scraper/geriatrix-h3.test.ts
@@ -132,25 +132,34 @@ describe("GeriatrixH3Adapter.fetch", () => {
   });
 
   it("strips ' - Maybe' / ' - Memorial Run' venue qualifiers from location (#1880)", async () => {
-    // Verbatim venue strings from live sporty.co.nz Geriatrix hareline.
-    const fixture = `<!DOCTYPE html><html><body>
-      <div class="richtext-editor">
-        <p><span>09/06/2026</span></p>
-        <p>Venue: Victoria Tavern, Petone - Maybe.</p>
-        <p>Hare: Pohutukawa</p>
-        <p><br></p>
-        <p><span>16/06/2026</span></p>
-        <p>Venue: The Co-Op Whitby - Memorial Run</p>
-        <p>Hare: Slippery</p>
-      </div>
-    </body></html>`;
-    mockedBrowserRender.mockResolvedValue(fixture);
-    const adapter = new GeriatrixH3Adapter();
-    const result = await adapter.fetch(makeSource(), { days: 365 });
-    expect(result.errors).toEqual([]);
-    expect(result.events.length).toBe(2);
-    expect(result.events[0].location).toBe("Victoria Tavern, Petone");
-    expect(result.events[1].location).toBe("The Co-Op Whitby");
+    // Freeze the clock so the hard-coded 2026 fixture dates stay inside the
+    // rolling date window as real time advances (fake only Date — browserRender
+    // is mocked, so no real timers are in play).
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+    try {
+      // Verbatim venue strings from live sporty.co.nz Geriatrix hareline.
+      const fixture = `<!DOCTYPE html><html><body>
+        <div class="richtext-editor">
+          <p><span>09/06/2026</span></p>
+          <p>Venue: Victoria Tavern, Petone - Maybe.</p>
+          <p>Hare: Pohutukawa</p>
+          <p><br></p>
+          <p><span>16/06/2026</span></p>
+          <p>Venue: The Co-Op Whitby - Memorial Run</p>
+          <p>Hare: Slippery</p>
+        </div>
+      </body></html>`;
+      mockedBrowserRender.mockResolvedValue(fixture);
+      const adapter = new GeriatrixH3Adapter();
+      const result = await adapter.fetch(makeSource(), { days: 365 });
+      expect(result.errors).toEqual([]);
+      expect(result.events.length).toBe(2);
+      expect(result.events[0].location).toBe("Victoria Tavern, Petone");
+      expect(result.events[1].location).toBe("The Co-Op Whitby");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns the fetch failure when browserRender errors", async () => {

--- a/src/adapters/html-scraper/geriatrix-h3.test.ts
+++ b/src/adapters/html-scraper/geriatrix-h3.test.ts
@@ -131,6 +131,28 @@ describe("GeriatrixH3Adapter.fetch", () => {
     expect(result.events[1].hares).toBe("Hey Baby");
   });
 
+  it("strips ' - Maybe' / ' - Memorial Run' venue qualifiers from location (#1880)", async () => {
+    // Verbatim venue strings from live sporty.co.nz Geriatrix hareline.
+    const fixture = `<!DOCTYPE html><html><body>
+      <div class="richtext-editor">
+        <p><span>09/06/2026</span></p>
+        <p>Venue: Victoria Tavern, Petone - Maybe.</p>
+        <p>Hare: Pohutukawa</p>
+        <p><br></p>
+        <p><span>16/06/2026</span></p>
+        <p>Venue: The Co-Op Whitby - Memorial Run</p>
+        <p>Hare: Slippery</p>
+      </div>
+    </body></html>`;
+    mockedBrowserRender.mockResolvedValue(fixture);
+    const adapter = new GeriatrixH3Adapter();
+    const result = await adapter.fetch(makeSource(), { days: 365 });
+    expect(result.errors).toEqual([]);
+    expect(result.events.length).toBe(2);
+    expect(result.events[0].location).toBe("Victoria Tavern, Petone");
+    expect(result.events[1].location).toBe("The Co-Op Whitby");
+  });
+
   it("returns the fetch failure when browserRender errors", async () => {
     mockedBrowserRender.mockRejectedValueOnce(new Error("502 challenge"));
     const adapter = new GeriatrixH3Adapter();

--- a/src/adapters/html-scraper/geriatrix-h3.ts
+++ b/src/adapters/html-scraper/geriatrix-h3.ts
@@ -169,7 +169,7 @@ export class GeriatrixH3Adapter implements SourceAdapter {
           // no Venue field (placeholder already normalised away), otherwise the
           // cleaner's value or `null` (explicit clear) for non-venue text.
           const location =
-            row.venue !== undefined ? cleanLocationName(row.venue) : undefined;
+            row.venue === undefined ? undefined : cleanLocationName(row.venue);
           events.push({
             date: row.date,
             kennelTags: [kennelTag],

--- a/src/adapters/html-scraper/geriatrix-h3.ts
+++ b/src/adapters/html-scraper/geriatrix-h3.ts
@@ -9,6 +9,7 @@ import { hasAnyErrors } from "../types";
 import {
   buildDateWindow,
   chronoParseDate,
+  cleanLocationName,
   configString,
   fetchBrowserRenderedPage,
   normalizeHaresField,
@@ -162,10 +163,17 @@ export class GeriatrixH3Adapter implements SourceAdapter {
       try {
         const eventDate = new Date(`${row.date}T12:00:00Z`);
         if (eventDate >= minDate && eventDate <= maxDate) {
+          // Run the venue through the shared cleaner — strips appended source
+          // qualifiers like " - Maybe" / " - Memorial Run" (#1880) plus emoji/
+          // URL noise. Preserve the merge tri-state: `undefined` when there was
+          // no Venue field (placeholder already normalised away), otherwise the
+          // cleaner's value or `null` (explicit clear) for non-venue text.
+          const location =
+            row.venue !== undefined ? cleanLocationName(row.venue) : undefined;
           events.push({
             date: row.date,
             kennelTags: [kennelTag],
-            location: row.venue,
+            location,
             locationUrl: row.mapUrl,
             hares: normalizeHaresField(row.hare),
             sourceUrl,

--- a/src/adapters/html-scraper/hague-h3.test.ts
+++ b/src/adapters/html-scraper/hague-h3.test.ts
@@ -156,6 +156,44 @@ Where: Some place`;
     expect(parseEventBlock(text, SOURCE_URL)).toBeNull();
   });
 
+  it("extracts the colon run number and the theme line after it (#1888)", () => {
+    // Verbatim from live haguehash.nl (Run #2423): the site uses the "Run:"
+    // colon form and puts the theme on its own line after the run number.
+    const text = `Run: 2423
+Rotte Dam Loop 10k
+When: Wednesday, June 3
+Time: 19:00 hr
+Where: Zwembad Hillegersberg, Rotterdam
+Link
+Hare: Ironic Maiden
+Cost: non-members EUR 7.00 for a single run (includes beer and snacks)
+Inquiries?
+Contact: mismanagement@haguehash.nl`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.runNumber).toBe(2423);
+    expect(event!.title).toBe("Hague H3 #2423 — Rotte Dam Loop 10k");
+    expect(event!.hares).toBe("Ironic Maiden");
+    expect(event!.location).toBe("Zwembad Hillegersberg, Rotterdam");
+  });
+
+  it("synthesizes a title when the colon run number has no theme line (#1888)", () => {
+    // Live Run #2422 — colon form, no separate theme line. The metadata line
+    // immediately after "Run: 2422" must NOT be promoted to a title.
+    const text = `Run: 2422
+When: Wednesday, May 27
+Time: 19:00 hr
+Where: Parking Elsenburgerbos (Lange Kleiweg), Rijswijk (Link)
+Hare: Balls on a Dyke`;
+
+    const event = parseEventBlock(text, SOURCE_URL);
+    expect(event).not.toBeNull();
+    expect(event!.runNumber).toBe(2422);
+    expect(event!.title).toBe("Hague H3 #2422");
+    expect(event!.location).toBe("Parking Elsenburgerbos (Lange Kleiweg), Rijswijk");
+  });
+
   it("captures parenthetical theme as title and strips emoji from location (#1258)", () => {
     // Verbatim from issue #1258 / live haguehash.nl source.
     const text = `Run 2419 (How Original Run)

--- a/src/adapters/html-scraper/hague-h3.ts
+++ b/src/adapters/html-scraper/hague-h3.ts
@@ -48,8 +48,13 @@ const DEFAULT_START_TIME = "14:00";
 
 // ── Regex patterns ──
 
-/** Match run number: "Run 2412" or "Run 2410 (50+% run)" */
-const RUN_NUMBER_RE = /Run\s+(\d{4})/;
+/**
+ * Match run number: "Run 2412", "Run 2410 (50+% run)", or the colon form the
+ * site switched to — "Run: 2423" (#1888). The `[:\s]+` separator accepts both
+ * the legacy space form and the colon form without a nested quantifier (Sonar
+ * S5852-safe).
+ */
+const RUN_NUMBER_RE = /Run[:\s]+(\d{4})/;
 
 /**
  * Match the parenthetical theme that frequently follows the run number on the
@@ -58,7 +63,7 @@ const RUN_NUMBER_RE = /Run\s+(\d{4})/;
  * The /i flag is intentional — "Run" is alphabetic, so case-insensitivity
  * makes the match resilient if the source ever switches to lowercase "run".
  */
-const RUN_TITLE_PARENTHETICAL_RE = /Run\s+\d{4}\s*\(([^)]+)\)/i;
+const RUN_TITLE_PARENTHETICAL_RE = /Run[:\s]+\d{4}\s*\(([^)]+)\)/i;
 
 /** Match date line: "When: Sunday, March 29" or "When: Sunday Februari 22th" */
 const WHEN_RE = /When:\s*(.+)/i;
@@ -71,6 +76,23 @@ const WHERE_RE = /Where:\s*(.+)/i;
 
 /** Match hares: "Hares: ...", "Hare: ...", or "Hare(s): ..." */
 const HARES_RE = /Hare(?:s|\(s\))?:\s*(.+)/i;
+
+/** Lines that are event metadata / boilerplate, not a run theme. Used to find
+ *  the theme line that follows the run-number line (#1888). */
+const STRUCTURAL_LINE_PREFIX_RE = /^(?:OnOn|Link|Cost:|Inquiries|Contact:)/i;
+
+/** True when `line` is a labeled metadata line, the run-number line, or
+ *  boilerplate — i.e. NOT a candidate run theme/title. */
+function isStructuralLine(line: string): boolean {
+  return (
+    RUN_NUMBER_RE.test(line) ||
+    WHEN_RE.test(line) ||
+    TIME_RE.test(line) ||
+    WHERE_RE.test(line) ||
+    HARES_RE.test(line) ||
+    STRUCTURAL_LINE_PREFIX_RE.test(line)
+  );
+}
 
 // ── Exported helpers (for unit testing) ──
 
@@ -161,8 +183,11 @@ export function parseEventBlock(
   }
 
   // Extract title: prefer the parenthetical theme on the run-number line
-  // ("Run 2419 (How Original Run)" → "How Original Run", #1258). Otherwise
-  // fall back to the first non-blank line preceding the Run line.
+  // ("Run 2419 (How Original Run)" → "How Original Run", #1258). Otherwise look
+  // for a theme line BEFORE the Run line ("Windmill Poker Run"), then — for the
+  // colon format where the theme sits on its own line AFTER the run number
+  // ("Run: 2423" ⏎ "Rotte Dam Loop 10k", #1888) — take the first non-structural
+  // line immediately following the Run line.
   let title: string | undefined;
   const parenMatch = RUN_TITLE_PARENTHETICAL_RE.exec(text);
   if (parenMatch) {
@@ -172,11 +197,22 @@ export function parseEventBlock(
     title = parenMatch[1].replace(/\s+/g, " ").trim() || undefined;
   } else {
     const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+    const runLineIdx = lines.findIndex((l) => RUN_NUMBER_RE.test(l));
+
+    // Title before the Run line (e.g. "Windmill Poker Run" preceding "Run NNNN").
     for (const line of lines) {
       if (RUN_NUMBER_RE.test(line) || /^When:/i.test(line)) break;
       if (line.length > 2 && !/^OnOn/i.test(line)) {
         title = line;
         break;
+      }
+    }
+
+    // Theme line on its own line after the Run line (#1888 colon format).
+    if (!title && runLineIdx >= 0) {
+      const next = lines[runLineIdx + 1];
+      if (next && next.length > 2 && !isStructuralLine(next)) {
+        title = next;
       }
     }
   }

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -294,6 +294,21 @@ describe("parseHarelineRow", () => {
     expect(result?.location).toBe("On Tap Sports Bar");
   });
 
+  it("clears location (null) when the anchor is venue-shaped but a placeholder (#1890 tri-state)", () => {
+    // "Details to follow" is not a CTA but cleans to a placeholder → emit an
+    // explicit null so the merge pipeline wipes any stale canonical location,
+    // rather than undefined (which would preserve it).
+    const dirHtml = `
+      <h2>Mystery Trail</h2>
+      <a href="https://www.google.com/maps/place/foo">
+        <font color="#cc0000">Details to follow</font>
+      </a>
+    `;
+    const cells = ["Mon June 29", "6:30 PM", "2105"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBeNull();
+  });
+
   it("does not surface a coordinate-only / On-After maps anchor as the venue (#1890 negative)", () => {
     // No body start-sentence and no address — a polluted anchor must NOT become
     // the location (it falls through to undefined rather than leaking coords).

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -308,6 +308,38 @@ describe("parseHarelineRow", () => {
     expect(result?.location).toBeUndefined();
   });
 
+  it("emits location=null (explicit clear) when anchor is non-CTA but cleans to placeholder", () => {
+    // Tri-state: a source that provided a location but it's non-venue text must
+    // emit null so the merge pipeline clears stale canonical location data, not
+    // undefined which would silently preserve it (merge.ts WS6 #1516).
+    const dirHtml = `
+      <h2>Mystery Trail</h2>
+      <a href="https://www.google.com/maps/place/foo">
+        <font color="#cc0000">Location TBD</font>
+      </a>
+    `;
+    const cells = ["Mon July 7", "6:30 PM", "2105"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBeNull();
+    expect(result?.locationUrl).toBeUndefined();
+  });
+
+  it("preserves venue when start-sentence references a numbered street ('at 5th Ave')", () => {
+    // atTime regex must not fire on "at 5th Ave" — the digit is a street number,
+    // not a time marker. Without this fix, "the lot at 5th Ave" would truncate
+    // to "the lot" (Gemini code-review fix).
+    const dirHtml = `
+      <h2>Test Trail</h2>
+      We'll be starting from the parking lot at 5th Ave
+      <a href="https://www.google.com/maps/place/foo">
+        <font color="#cc0000">Go to 41.631488, -71.571204</font>
+      </a>
+    `;
+    const cells = ["Mon July 14", "6:30 PM", "2106"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBe("parking lot at 5th Ave");
+  });
+
   it("normalizes H2 title with line breaks", () => {
     const cells = ["Mon March 23", "6:30 PM", "2091"];
     const result = parseHarelineRow(

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -244,6 +244,70 @@ describe("parseHarelineRow", () => {
     expect(result?.location).toBe("dog park at Melville Park, Portsmouth, RI");
   });
 
+  it("uses the 'starting from' sentence when the maps anchor is CTA/coords (#1890 Run #2101)", () => {
+    // Verbatim from live rih3.com: the maps-link anchor text is a CTA + raw
+    // coordinate dump + On-After venue, while the real start is in the body
+    // sentence. The maps href (correct pin) is kept.
+    const dirHtml = `
+      <p><h2>Shemale's Hash</h2>
+      Hope he doesn't send us down the rabbit hole again.
+      <br/>
+      We'll be starting from the Hopkins Hill Trailhead for Big River at 6:30pm
+      <br/><br/>
+      <a href="https://www.google.com/maps/place/Big+River+Hopkins+Hill+Area+Parking/@41.6322766,-71.5695437,1239m/data=foo" target="new"><br/>
+        <font color="#cc0000">You know the spot. Go to 41.631488, -71.571204
+        <br/>
+        On On at Tavern on the Hill????</font>
+      </a>
+    `;
+    const cells = ["Mon June 1", "6:30 PM", "2101"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBe("Hopkins Hill Trailhead for Big River");
+    expect(result?.locationUrl).toContain("Big+River+Hopkins+Hill");
+  });
+
+  it("preserves abbreviation periods in a start-sentence venue (St./Mt.) (#1890)", () => {
+    // Anchor is a coordinate dump → falls back to the start sentence. The venue
+    // must NOT be truncated at the "St." abbreviation period.
+    const dirHtml = `
+      <h2>Holy Trail</h2>
+      We'll be starting from St. Mary's Hall. On-On at the pub afterward.
+      <br/>
+      <a href="https://www.google.com/maps/place/foo">
+        <font color="#cc0000">Go to 41.631488, -71.571204</font>
+      </a>
+    `;
+    const cells = ["Mon June 22", "6:30 PM", "2104"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBe("St. Mary's Hall");
+  });
+
+  it("keeps a clean maps-anchor venue that merely begins with 'On' (#1890 negative)", () => {
+    const dirHtml = `
+      <h2>Test Run</h2>
+      <a href="https://www.google.com/maps/place/On+Tap">
+        <font color="#cc0000">On Tap Sports Bar</font>
+      </a>
+    `;
+    const cells = ["Mon June 8", "6:30 PM", "2102"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBe("On Tap Sports Bar");
+  });
+
+  it("does not surface a coordinate-only / On-After maps anchor as the venue (#1890 negative)", () => {
+    // No body start-sentence and no address — a polluted anchor must NOT become
+    // the location (it falls through to undefined rather than leaking coords).
+    const dirHtml = `
+      <h2>Mystery Trail</h2>
+      <a href="https://www.google.com/maps/place/foo">
+        <font color="#cc0000">Go to 41.631488, -71.571204 On On at Tavern on the Hill????</font>
+      </a>
+    `;
+    const cells = ["Mon June 15", "6:30 PM", "2103"];
+    const result = parseHarelineRow(cells, HARE_SINGLE, dirHtml, SOURCE_URL);
+    expect(result?.location).toBeUndefined();
+  });
+
   it("normalizes H2 title with line breaks", () => {
     const cells = ["Mon March 23", "6:30 PM", "2091"];
     const result = parseHarelineRow(

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -192,7 +192,9 @@ function firstSentencePeriod(s: string): number {
     if (dot < 0) return -1;
     const before = s.slice(0, dot);
     const lastToken = before.split(/[^A-Za-z]+/).pop() ?? "";
-    if (!VENUE_ABBREVS.has(lastToken.toLowerCase())) return dot;
+    // Single-letter tokens are middle initials (e.g. "F." in "John F. Kennedy") —
+    // never a sentence end. Abbreviations must be 2+ chars to match VENUE_ABBREVS.
+    if (lastToken.length > 1 && !VENUE_ABBREVS.has(lastToken.toLowerCase())) return dot;
     from = dot + 2;
   }
   return -1;
@@ -208,7 +210,9 @@ function cutAtVenueTerminator(s: string): string {
   if (dot >= 0) end = Math.min(end, dot);
   const nl = s.search(/[\n\r]/);
   if (nl >= 0) end = Math.min(end, nl);
-  const atTime = /\bat\s+\d/i.exec(s);
+  // Require a colon (HH:MM) or am/pm suffix so "at 5th Ave" / "at 123 Main St"
+  // are NOT treated as time markers and the street address is preserved.
+  const atTime = /\bat\s+\d{1,2}(?::\d{2}|\s*[ap]m)\b/i.exec(s);
   if (atTime) end = Math.min(end, atTime.index);
   return s.slice(0, end);
 }
@@ -248,7 +252,7 @@ function extractStartVenueFromBody(dir$: cheerio.CheerioAPI): string | undefined
 function resolveRih3Location(
   dir$: cheerio.CheerioAPI,
   mapsLink: cheerio.Cheerio<AnyNode>,
-): { location: string | undefined; locationUrl: string | undefined } {
+): { location: string | null | undefined; locationUrl: string | undefined } {
   const addressLocation = findAddressInBody(dir$);
   if (addressLocation) {
     return { location: addressLocation, locationUrl: undefined };
@@ -259,14 +263,20 @@ function resolveRih3Location(
   const anchorText = cleanMapsLinkText(mapsLink);
   if (anchorText && !isDirectionsCta(anchorText)) {
     const cleaned = cleanLocationName(anchorText);
-    if (cleaned) return { location: cleaned, locationUrl: href };
+    if (cleaned !== null) return { location: cleaned, locationUrl: href };
+    // Anchor passed the CTA filter but cleaned to null (placeholder/non-venue
+    // text). Emit explicit null so the merge pipeline clears any stale location;
+    // do not fall through to the start-sentence (that fallback is for absent/CTA
+    // anchors, not placeholder ones). Preserves tri-state semantics from merge.ts.
+    return { location: null, locationUrl: undefined };
   }
 
   // Anchor missing or polluted — fall back to the start-sentence venue.
   const startVenue = extractStartVenueFromBody(dir$);
   if (startVenue) {
     const cleaned = cleanLocationName(startVenue);
-    if (cleaned) return { location: cleaned, locationUrl: href };
+    if (cleaned !== null) return { location: cleaned, locationUrl: href };
+    return { location: null, locationUrl: undefined };
   }
 
   return { location: undefined, locationUrl: href };

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -28,6 +28,7 @@ import {
   parse12HourTime,
   isPlaceholder,
   stripHtmlTags,
+  cleanLocationName,
 } from "../utils";
 
 const DAY_PREFIX_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\.?\s+/i;
@@ -146,10 +147,104 @@ function cleanMapsLinkText(mapsLink: cheerio.Cheerio<AnyNode>): string | undefin
   return cleaned;
 }
 
-/** Resolve location + locationUrl from a RIH3 directions cell. Prefers the
- *  address-shaped sentence in the body over the maps-link anchor text (#1427);
- *  drops the maps URL when the address path wins because the first maps link
- *  often points at the wrong place (Julia's Trail Parking vs the actual start). */
+/** A raw decimal lat/long pair ("41.631488, -71.571204") dumped into the
+ *  Directions text — geocode anchor, not a venue name. */
+const COORD_PAIR_RE = /-?\d{1,3}\.\d{3,}\s*,\s*-?\d{1,3}\.\d{3,}/;
+
+/** Reject a maps-anchor "venue" that is actually CTA flavor copy, a raw
+ *  coordinate dump, or an On-After (On-On) venue rather than the start (#1890,
+ *  Run #2101: "You know the spot. Go to 41.631488, -71.571204 On On at Tavern
+ *  on the Hill????"). Gated on the standalone "On On"/"On-On" token so real
+ *  venues that merely begin with "On" ("On Tap Sports Bar") are preserved. */
+function isDirectionsCta(text: string): boolean {
+  if (text.toLowerCase().startsWith("you know the spot")) return true;
+  if (COORD_PAIR_RE.test(text)) return true;
+  return /\bon[\s-]?on\b/i.test(text);
+}
+
+/** "starting from / start at / meeting at …" lead-ins that introduce the real
+ *  meeting point in a RIH3 directions narrative. */
+const START_PHRASES = [
+  "starting from",
+  "starting at",
+  "start from",
+  "start at",
+  "starts from",
+  "starts at",
+  "meeting at",
+  "meet at",
+];
+
+/** Street/title abbreviations whose trailing "." is NOT a sentence end — so a
+ *  venue like "St. Mary's Hall" / "Mt. Hope Farm" / "Ft. Adams" isn't truncated
+ *  to "St" / "Mt" / "Ft". */
+const VENUE_ABBREVS = new Set([
+  "st", "rd", "ave", "mt", "dr", "ft", "blvd", "ln", "pl", "ste", "no", "jr", "sr", "pt",
+]);
+
+/** Index of the first sentence-ending "." (followed by a space) that is not part
+ *  of a known abbreviation, or -1. Procedural (no anchored `(\w+)$` capture) to
+ *  stay clear of Sonar's regex-complexity heuristics. */
+function firstSentencePeriod(s: string): number {
+  let from = 0;
+  while (from < s.length) {
+    const dot = s.indexOf(". ", from);
+    if (dot < 0) return -1;
+    const before = s.slice(0, dot);
+    const lastToken = before.split(/[^A-Za-z]+/).pop() ?? "";
+    if (!VENUE_ABBREVS.has(lastToken.toLowerCase())) return dot;
+    from = dot + 2;
+  }
+  return -1;
+}
+
+/** Trim a captured start-venue at the first sentence/time terminator: a
+ *  sentence-ending period (abbreviation periods preserved), a line break, or an
+ *  " at <digit>" time marker ("… at 6:30pm"). Procedural to keep clear of Sonar
+ *  S5852 (no `\s*`-adjacent alternation). */
+function cutAtVenueTerminator(s: string): string {
+  let end = s.length;
+  const dot = firstSentencePeriod(s);
+  if (dot >= 0) end = Math.min(end, dot);
+  const nl = s.search(/[\n\r]/);
+  if (nl >= 0) end = Math.min(end, nl);
+  const atTime = /\bat\s+\d/i.exec(s);
+  if (atTime) end = Math.min(end, atTime.index);
+  return s.slice(0, end);
+}
+
+/** Extract the start venue from a "(we'll be) starting from/at <venue>" sentence
+ *  in the directions body — the actual meeting point. Preferred over a CTA /
+ *  coordinate maps anchor (#1890). Operates on the body with <h2>/<a> removed so
+ *  the title and link anchor text don't bleed in. */
+function extractStartVenueFromBody(dir$: cheerio.CheerioAPI): string | undefined {
+  const body = dir$("body").clone();
+  body.find("h2").remove();
+  body.find("a").remove();
+  const text = body.text().replace(/\s+/g, " ").trim();
+  const lower = text.toLowerCase();
+  for (const phrase of START_PHRASES) {
+    const idx = lower.indexOf(phrase);
+    if (idx < 0) continue;
+    let rest = text.slice(idx + phrase.length).trimStart().replace(/^the\s+/i, "");
+    rest = cutAtVenueTerminator(rest).trim();
+    if (rest.length >= 4 && !PROSE_LEAD_RE.test(rest)) return rest;
+  }
+  return undefined;
+}
+
+/** Resolve location + locationUrl from a RIH3 directions cell.
+ *
+ *  Precedence:
+ *   1. Address-shaped sentence in the body ("… 2203 Boston Neck Rd, …, RI") —
+ *      drops the maps URL because the first maps link often points at the wrong
+ *      place (#1427).
+ *   2. The maps-link anchor text, when it reads like a venue — but reject CTA
+ *      flavor copy, raw coordinate dumps, and On-After venues (#1890).
+ *   3. The explicit "starting from <venue>" sentence — the real meeting point,
+ *      used when the anchor is unusable (Run #2101's anchor was the polluted
+ *      "You know the spot. Go to <coords> On On at …").
+ *  Every venue candidate is passed through the shared cleanLocationName. */
 function resolveRih3Location(
   dir$: cheerio.CheerioAPI,
   mapsLink: cheerio.Cheerio<AnyNode>,
@@ -158,10 +253,23 @@ function resolveRih3Location(
   if (addressLocation) {
     return { location: addressLocation, locationUrl: undefined };
   }
-  return {
-    location: cleanMapsLinkText(mapsLink),
-    locationUrl: mapsLink.length ? mapsLink.attr("href")?.trim() : undefined,
-  };
+
+  const href = mapsLink.length ? mapsLink.attr("href")?.trim() : undefined;
+
+  const anchorText = cleanMapsLinkText(mapsLink);
+  if (anchorText && !isDirectionsCta(anchorText)) {
+    const cleaned = cleanLocationName(anchorText);
+    if (cleaned) return { location: cleaned, locationUrl: href };
+  }
+
+  // Anchor missing or polluted — fall back to the start-sentence venue.
+  const startVenue = extractStartVenueFromBody(dir$);
+  if (startVenue) {
+    const cleaned = cleanLocationName(startVenue);
+    if (cleaned) return { location: cleaned, locationUrl: href };
+  }
+
+  return { location: undefined, locationUrl: href };
 }
 
 /**

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -179,12 +179,14 @@ const START_PHRASES = [
  *  venue like "St. Mary's Hall" / "Mt. Hope Farm" / "Ft. Adams" isn't truncated
  *  to "St" / "Mt" / "Ft". */
 const VENUE_ABBREVS = new Set([
-  "st", "rd", "ave", "mt", "dr", "ft", "blvd", "ln", "pl", "ste", "no", "jr", "sr", "pt",
+  "st", "rd", "ave", "mt", "dr", "ft", "blvd", "ln", "pl", "ste",
+  "no", "jr", "sr", "pt", "ct", "sq", "hwy", "rte",
 ]);
 
 /** Index of the first sentence-ending "." (followed by a space) that is not part
- *  of a known abbreviation, or -1. Procedural (no anchored `(\w+)$` capture) to
- *  stay clear of Sonar's regex-complexity heuristics. */
+ *  of a known abbreviation OR a single-letter middle initial ("John F. Kennedy
+ *  Blvd"), or -1. Procedural (no anchored `(\w+)$` capture) to stay clear of
+ *  Sonar's regex-complexity heuristics. */
 function firstSentencePeriod(s: string): number {
   let from = 0;
   while (from < s.length) {
@@ -192,7 +194,8 @@ function firstSentencePeriod(s: string): number {
     if (dot < 0) return -1;
     const before = s.slice(0, dot);
     const lastToken = before.split(/[^A-Za-z]+/).pop() ?? "";
-    if (!VENUE_ABBREVS.has(lastToken.toLowerCase())) return dot;
+    // Single letters are middle initials, not sentence ends.
+    if (lastToken.length > 1 && !VENUE_ABBREVS.has(lastToken.toLowerCase())) return dot;
     from = dot + 2;
   }
   return -1;
@@ -208,7 +211,10 @@ function cutAtVenueTerminator(s: string): string {
   if (dot >= 0) end = Math.min(end, dot);
   const nl = s.search(/[\n\r]/);
   if (nl >= 0) end = Math.min(end, nl);
-  const atTime = /\bat\s+\d/i.exec(s);
+  // Cut at an " at <time>" marker only when it's a real clock time (HH:MM or
+  // H[ap]m) — NOT "at 5th Avenue" / "at 123 Main St" (gemini review). `\s?`
+  // (bounded) rather than `\s*` keeps clear of Sonar S5852.
+  const atTime = /\bat\s+\d{1,2}(?::\d{2}|\s?[ap]\.?m)/i.exec(s);
   if (atTime) end = Math.min(end, atTime.index);
   return s.slice(0, end);
 }
@@ -248,7 +254,7 @@ function extractStartVenueFromBody(dir$: cheerio.CheerioAPI): string | undefined
 function resolveRih3Location(
   dir$: cheerio.CheerioAPI,
   mapsLink: cheerio.Cheerio<AnyNode>,
-): { location: string | undefined; locationUrl: string | undefined } {
+): { location: string | null | undefined; locationUrl: string | undefined } {
   const addressLocation = findAddressInBody(dir$);
   if (addressLocation) {
     return { location: addressLocation, locationUrl: undefined };
@@ -256,10 +262,18 @@ function resolveRih3Location(
 
   const href = mapsLink.length ? mapsLink.attr("href")?.trim() : undefined;
 
+  // Track whether a candidate provided venue-shaped text that cleaned away to a
+  // placeholder/non-venue (e.g. "Details to follow"). If so — and nothing else
+  // yields a real venue — emit `null` (explicit clear) so the merge tri-state
+  // wipes a stale canonical location, rather than `undefined` (preserve). Only
+  // when NO candidate had any text do we preserve via `undefined`.
+  let sawPlaceholder = false;
+
   const anchorText = cleanMapsLinkText(mapsLink);
   if (anchorText && !isDirectionsCta(anchorText)) {
     const cleaned = cleanLocationName(anchorText);
     if (cleaned) return { location: cleaned, locationUrl: href };
+    sawPlaceholder = true;
   }
 
   // Anchor missing or polluted — fall back to the start-sentence venue.
@@ -267,9 +281,10 @@ function resolveRih3Location(
   if (startVenue) {
     const cleaned = cleanLocationName(startVenue);
     if (cleaned) return { location: cleaned, locationUrl: href };
+    sawPlaceholder = true;
   }
 
-  return { location: undefined, locationUrl: href };
+  return { location: sawPlaceholder ? null : undefined, locationUrl: href };
 }
 
 /**

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -1290,3 +1290,83 @@ describe("coalesceEndpointDuplicates (unit, #1828)", () => {
     expect(coalesceEndpointDuplicates(only)).toHaveLength(1);
   });
 });
+
+// VEVENTs verbatim from the live Reading H3 Localendar feed
+// (localendar.com/public/readinghhh?style=X2). The upcoming runs are all the
+// "RH3: #120?" placeholder (run number not yet assigned); only past/numbered
+// runs carry a real "#NNNN".
+const READING_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//iCal4j 1.0//EN
+BEGIN:VEVENT
+UID:reading-1202@localendar.com
+DTSTART;TZID=America/New_York:20260531T120000
+SUMMARY:RH3 #1202: Clowning Around Hash
+DESCRIPTION:Hares: Sex Toys & Silence of the Goats On-On: Reading Regional Airport Hash Cash: $5 Note on out at 12pm Pre-lube at Klinger's by the Airport
+DTSTAMP:20260528T180347Z
+END:VEVENT
+BEGIN:VEVENT
+UID:reading-120a@localendar.com
+DTSTART;TZID=America/New_York:20260608T181500
+SUMMARY:RH3: #120?
+DESCRIPTION:Hare: Sex Toys for Everyone More details to cum
+DTSTAMP:20260516T003011Z
+END:VEVENT
+BEGIN:VEVENT
+UID:reading-120b@localendar.com
+DTSTART;TZID=America/New_York:20260920T120000
+SUMMARY:RH3: #120? Kegs & Eggs
+DESCRIPTION:Hares: Foot Fairy & Schmamazon Prime More details to cum
+DTSTAMP:20260516T004448Z
+END:VEVENT
+END:VCALENDAR`;
+
+function buildReadingSource(): Source {
+  return buildMockSource({
+    name: "Reading H3 Localendar",
+    url: "https://localendar.com/public/readinghhh?style=X2",
+    config: { defaultKennelTag: "rh3" },
+  });
+}
+
+describe("ICalAdapter — Reading H3 Localendar (#1883 placeholder run number)", () => {
+  let adapter: ICalAdapter;
+  beforeEach(() => {
+    adapter = new ICalAdapter();
+    vi.restoreAllMocks();
+  });
+
+  it("clears the run number for the 'RH3: #120?' placeholder (no stale 120)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(READING_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildReadingSource(), { days: 9999 });
+
+    const jun8 = result.events.find((e) => e.date === "2026-06-08");
+    expect(jun8).toBeDefined();
+    // Explicit null (not 120, not undefined) so the merge tri-state wipes the
+    // stale run number from a prior scrape.
+    expect(jun8!.runNumber).toBeNull();
+    // No theme + no venue in the source → both left for the merge synthesizer.
+    expect(jun8!.title).toBeUndefined();
+    expect(jun8!.location).toBeUndefined();
+  });
+
+  it("keeps the theme after a placeholder marker while still clearing the number", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(READING_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildReadingSource(), { days: 9999 });
+
+    const sep20 = result.events.find((e) => e.date === "2026-09-20");
+    expect(sep20).toBeDefined();
+    expect(sep20!.runNumber).toBeNull();
+    expect(sep20!.title).toBe("Kegs & Eggs");
+  });
+
+  it("parses a real numbered run with its theme and On-On venue", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(READING_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildReadingSource(), { days: 9999 });
+
+    const numbered = result.events.find((e) => e.runNumber === 1202);
+    expect(numbered).toBeDefined();
+    expect(numbered!.title).toBe("Clowning Around Hash");
+    expect(numbered!.location).toBe("Reading Regional Airport");
+  });
+});

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -23,6 +23,7 @@ import {
   normalizeCostSigil,
   cleanLocationName,
   stripClickHereForMap,
+  dedupeRepeatedDescription,
 } from "./utils";
 import { validateSourceUrlWithDns } from "./ssrf-dns";
 
@@ -1131,5 +1132,75 @@ describe("cleanLocationName", () => {
       expect(cleanLocationName(null)).toBeNull();
       expect(cleanLocationName(undefined)).toBeNull();
     });
+  });
+
+  describe("venue-qualifier dash-suffix (#1880 Geriatrix)", () => {
+    it.each([
+      [
+        "Victoria Tavern, Petone - Maybe.",
+        "Victoria Tavern, Petone",
+        "' - Maybe' uncertainty suffix (trailing period tolerated)",
+      ],
+      [
+        "The Co-Op Whitby - Memorial Run",
+        "The Co-Op Whitby",
+        "' - <X> Run' run-type descriptor suffix",
+      ],
+      [
+        "Lower Hutt Events Centre - Away Run",
+        "Lower Hutt Events Centre",
+        "another ' - <X> Run' descriptor",
+      ],
+    ])("strips: '%s' → '%s' (%s)", (input, expected) => {
+      expect(cleanLocationName(input)).toBe(expected);
+    });
+
+    it.each([
+      ["Memorial Hall", "Memorial Hall", "venue named like a descriptor — no dash separator"],
+      ["The Co-Op Whitby", "The Co-Op Whitby", "internal hyphen (no surrounding spaces) preserved"],
+      ["Bar - Restaurant", "Bar - Restaurant", "generic dash-suffix that isn't a qualifier preserved"],
+      ["Bear Run Tavern", "Bear Run Tavern", "interior 'Run' word without a dash preserved"],
+    ])("preserves: '%s' → '%s' (%s)", (input, expected) => {
+      expect(cleanLocationName(input)).toBe(expected);
+    });
+  });
+});
+
+describe("dedupeRepeatedDescription (#1889 Morgantown)", () => {
+  const REPEAT_BLOCK = [
+    "All work and no play makes Jack a dull boy! Let's celebrate National Repeat Day!",
+    "",
+    "Time: June 3, 6 PM",
+    "Location TBA.",
+    "Hares: I Call the Shots and Attn: Ass Horse!",
+    "$5 Hash Cash.",
+  ].join("\n");
+
+  it("collapses a body block pasted verbatim twice", () => {
+    const doubled = `${REPEAT_BLOCK}\n\n${REPEAT_BLOCK}`;
+    expect(dedupeRepeatedDescription(doubled)).toBe(REPEAT_BLOCK);
+  });
+
+  it("is idempotent on an already-deduped description", () => {
+    expect(dedupeRepeatedDescription(REPEAT_BLOCK)).toBe(REPEAT_BLOCK);
+  });
+
+  it("collapses a trailing-whitespace-only difference between copies", () => {
+    const doubled = `Hello world\n\nDetails here\n\nHello world\n\nDetails here `;
+    expect(dedupeRepeatedDescription(doubled)).toBe("Hello world\n\nDetails here");
+  });
+
+  it.each([
+    ["Single block, no repeat", "Single block, no repeat", "non-doubled single block"],
+    ["A\n\nB\n\nC", "A\n\nB\n\nC", "odd block count is never collapsed"],
+    ["A\n\nB\n\nA\n\nC", "A\n\nB\n\nA\n\nC", "even count but halves differ"],
+  ])("returns unchanged: %s (%s)", (input, expected) => {
+    expect(dedupeRepeatedDescription(input)).toBe(expected);
+  });
+
+  it("passes null/undefined/empty through untouched (tri-state)", () => {
+    expect(dedupeRepeatedDescription(null)).toBeNull();
+    expect(dedupeRepeatedDescription(undefined)).toBeUndefined();
+    expect(dedupeRepeatedDescription("")).toBe("");
   });
 });

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -1050,6 +1050,44 @@ function isContactToSetRunCta(lower: string): boolean {
   return lower.startsWith("contact ") && lower.includes(" to set this run");
 }
 
+// Venue-qualifier dash-suffixes (#1880). Organizers append a run-status or
+// run-type descriptor to the venue field with a " - " separator, e.g.
+// "Victoria Tavern, Petone - Maybe." (uncertainty flag) or "The Co-Op Whitby -
+// Memorial Run" (run-type descriptor). These degrade geocoding and aren't part
+// of the address. Only a SPACE-dash-SPACE separator counts, so a hyphenated
+// venue token like "Co-Op" (no surrounding spaces) is never bitten. The
+// qualifier must be a known uncertainty token ("maybe" / dotted T.B.x) or a
+// run-type descriptor (ends with the standalone word "run") — a generic
+// trailing segment like "- Restaurant" is preserved.
+const VENUE_QUALIFIER_DASHES = [" - ", " – ", " — "];
+
+function isVenueQualifierSuffix(suffix: string): boolean {
+  // Tolerate a trailing period the organizer leaves on the qualifier ("Maybe.").
+  const lower = suffix.replace(/\.+$/, "").trim().toLowerCase();
+  if (!lower) return false;
+  // LOCATION_QUALIFIER_TOKENS already includes "maybe" + the dotted T.B.x forms.
+  if (LOCATION_QUALIFIER_TOKENS.includes(lower)) return true;
+  return lower === "run" || lower.endsWith(" run");
+}
+
+function stripVenueQualifierSuffix(input: string): string {
+  let s = input;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const dash of VENUE_QUALIFIER_DASHES) {
+      const idx = s.lastIndexOf(dash);
+      if (idx < 0) continue;
+      if (isVenueQualifierSuffix(s.slice(idx + dash.length))) {
+        s = s.slice(0, idx).trim();
+        changed = true;
+        break;
+      }
+    }
+  }
+  return s;
+}
+
 /**
  * Clean a raw scraped location string into a real venue name, or return
  * `null` when the value is not a location at all.
@@ -1089,6 +1127,11 @@ export function cleanLocationName(raw: string | null | undefined): string | null
   //    "… to follow"). Bare-word prefixes ("TBC Park") are preserved.
   s = stripLeadingQualifiers(s);
   s = stripTrailingQualifiers(s);
+
+  // 4b. Strip a trailing " - <qualifier>" venue descriptor (#1880 Geriatrix:
+  //     "… - Maybe", "… - Memorial Run"). Space-dash-space only, so hyphenated
+  //     venue tokens ("Co-Op") and generic suffixes ("- Restaurant") survive.
+  s = stripVenueQualifierSuffix(s);
 
   // 5. Collapse internal whitespace + trim dangling separators.
   s = trimLocationSeparators(s.replace(/\s{2,}/g, " "));
@@ -1154,6 +1197,40 @@ export function appendDescriptionSuffix(
   const trimmedSuffix = suffix?.trim();
   if (!trimmedSuffix) return description ?? undefined;
   return description ? `${description}\n\n${trimmedSuffix}` : trimmedSuffix;
+}
+
+/**
+ * Collapse a description whose blank-line-separated blocks are the same
+ * sequence repeated twice back-to-back (#1889 Morgantown: a Google Calendar
+ * entry whose body block is pasted verbatim twice). Splits on blank lines into
+ * blocks; when there's an even number and the first half deep-equals the second
+ * half (whitespace-/case-insensitive), returns just the first half rejoined.
+ *
+ * Idempotent and conservative: any non-doubled description (odd block count, or
+ * halves that differ) is returned unchanged, so legitimately repetitive copy is
+ * never truncated. Tri-state preserving — passes `null`/`undefined`/empty
+ * through untouched so the merge pipeline's preserve/clear semantics hold.
+ */
+export function dedupeRepeatedDescription(
+  description: string | null | undefined,
+): string | null | undefined {
+  if (!description) return description;
+  const text = description.trim();
+  if (!text) return description;
+
+  const blocks = text
+    .split(/\n\s*\n/)
+    .map((b) => b.trim())
+    .filter((b) => b.length > 0);
+  if (blocks.length < 2 || blocks.length % 2 !== 0) return description;
+
+  const half = blocks.length / 2;
+  const norm = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
+  const isDoubled = blocks
+    .slice(0, half)
+    .every((b, i) => norm(b) === norm(blocks[half + i]));
+
+  return isDoubled ? blocks.slice(0, half).join("\n\n") : description;
 }
 
 /**

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -1063,7 +1063,11 @@ const VENUE_QUALIFIER_DASHES = [" - ", " – ", " — "];
 
 function isVenueQualifierSuffix(suffix: string): boolean {
   // Tolerate a trailing period the organizer leaves on the qualifier ("Maybe.").
-  const lower = suffix.replace(/\.+$/, "").trim().toLowerCase();
+  // Procedural trailing-dot strip (not `/\.+$/`) keeps clear of Sonar S5852's
+  // ReDoS heuristic, which flags the anchored `+` even though it's linear.
+  let trimmed = suffix.trim();
+  while (trimmed.endsWith(".")) trimmed = trimmed.slice(0, -1);
+  const lower = trimmed.trim().toLowerCase();
   if (!lower) return false;
   // LOCATION_QUALIFIER_TOKENS already includes "maybe" + the dotted T.B.x forms.
   if (LOCATION_QUALIFIER_TOKENS.includes(lower)) return true;


### PR DESCRIPTION
Quick-win bundle of single-adapter parse defects from `audit:chrome-event` alerts. Each fix is fixture-backed and **live-verified** against the named run.

## Fixes

| Issue | Adapter | Fix | Live-verified |
|---|---|---|---|
| #1888 | Hague H3 | Handle the `Run: NNNN` colon format (run number was being dropped) and promote the theme line *after* the run-number line to the title. | Run 2423 → `runNumber=2423`, title `Hague H3 #2423 — Rotte Dam Loop 10k` |
| #1890 | Rhode Island H3 | Stop mapping a CTA / raw-coordinate / On-After maps anchor to `locationName`; prefer the "starting from \<venue\>" sentence, route candidates through `cleanLocationName`. | Run #2101 → `Hopkins Hill Trailhead for Big River` (was `You know the spot. Go to 41.6…, On On at Tavern…`) |
| #1880 | Geriatrix H3 | Route the venue through `cleanLocationName` and strip appended `- Maybe` / `- Memorial Run` qualifier suffixes. | Jun 9 → `Victoria Tavern, Petone`; Jun 16 → `The Co-Op Whitby` |
| #1889 | Morgantown H3 | Collapse a Google Calendar description whose body block is pasted verbatim twice. | Run #136 → "National Repeat Day" appears once |
| #1883 | Reading H3 | Confirm the `RH3: #120?` placeholder emits `runNumber=null` (clears the stale `120`); themes + real numbers still parse. | Jun 8/22, Jul 4 → `runNumber=null` |

## Scope notes
- **#1889 root cause** is duplicated text in the **Google Calendar source data** (verified: the Harrier Central API returns no description field for Run #136). The fix is a shared `dedupeRepeatedDescription()` in `utils.ts` wired into `normalizeGCalDescription` — not the HARRIER_CENTRAL adapter.
- **#1883's run-number clear was already implemented** (placeholder → `null`); this PR adds the missing regression coverage and live-verifies the stale `120` now clears on re-scrape.

## Shared helpers (`src/adapters/utils.ts`)
- `cleanLocationName` gains a venue-qualifier dash-suffix step (` - Maybe` / ` - …Run`), space-dash-space only so hyphenated tokens like `Co-Op` are safe.
- new `dedupeRepeatedDescription` (idempotent, tri-state preserving).

Negative fixtures guard real venues: `Memorial Hall`, `The Co-Op Whitby`, `On Tap Sports Bar`, `St. Mary's Hall` (abbreviation periods preserved).

## Verification
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (8187 passed)
- All 5 runs live-verified against production sources (table above).
- `/code-review` (found + fixed an abbreviation-truncation bug in the rih3 fallback) + `/simplify` (removed one redundant check) run pre-PR.

Closes #1888
Closes #1890
Closes #1880
Closes #1889
Closes #1883

🤖 Generated with [Claude Code](https://claude.com/claude-code)