### PR TITLE
Wire schema-gap fields: Hump D + Iron Pussy + DCFMH3 (8 issues)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -877,30 +877,54 @@ export const SOURCES = [
       scrapeDays: 90,
       kennelCodes: ["h4"],
     },
-    // DC Full Moon Hash — anchor-mode lunar STATIC_SCHEDULE.
-    // DCFMH3 runs Friday/Saturday "near the full moon" rather than on the
-    // exact phase. `nearest` snaps each phase to the closest Saturday
-    // (forward on tie). Hash Rego covers individual registrations; this
-    // source provides forward-looking projections for Travel Mode + calendar.
+    // DC Full Moon Hash — Google Sites published annual schedule.
+    // DCFMH3 is a rotating umbrella: a different DC-area kennel hosts each
+    // monthly full-moon trail, and the source page publishes the moon name +
+    // host per date. The former STATIC_SCHEDULE (lunar) source only produced a
+    // generic "DCFMH3 Full Moon Run" placeholder title and drifted 1–3 days off
+    // the real dates (#1399); the DCFMH3Adapter parses the published schedule so
+    // titles + dates are source-faithful and the host rides as an EventKennel
+    // co-host where it maps to a seeded kennel (#1400). kennelCodes must include
+    // every host the parser can emit (HOST_KENNEL_PATTERNS in dcfmh3.ts) so the
+    // merge source-kennel guard doesn't reject co-hosts.
     {
-      name: "DCFMH3 Static Schedule (Lunar Anchor)",
-      url: "https://sites.google.com/site/dcfmh3/home",
-      type: "STATIC_SCHEDULE" as const,
+      name: "DCFMH3 Google Sites Calendar",
+      url: "https://sites.google.com/site/dcfmh3/home/dc-kennel-calendar",
+      type: "HTML_SCRAPER" as const,
       trustLevel: 5,
       scrapeFreq: "weekly",
       scrapeDays: 365,
       config: {
         kennelTag: "dcfmh3",
-        lunar: {
-          phase: "full",
-          timezone: "America/New_York",
-          anchorWeekday: "SA",
-          anchorRule: "nearest",
-        },
+        startTime: "18:30",
+        defaultLocation: "Washington, DC",
+        defaultDescription: "Monthly full-moon hash hosted by a rotating DC-area kennel. Check Hash Rego or the kennel website for hare and start details.",
+      },
+      kennelCodes: ["dcfmh3", "ewh3", "dch3", "dch4", "cch3", "mvh3", "fuh3", "h4"],
+    },
+    // Retired predecessor of the row above. Source identity in the seeder is
+    // (name, type), so the HTML_SCRAPER row above is a NEW source rather than an
+    // in-place migration of this STATIC_SCHEDULE one. Keep this row with
+    // `enabled: false` so a normal `prisma db seed` deterministically disables
+    // the old lunar generator (otherwise it stays enabled and keeps
+    // re-creating the "DCFMH3 Full Moon Run" placeholders the new scraper +
+    // cleanup script remove — Codex adversarial review). RawEvents/ScrapeLogs
+    // survive (soft-disable, not delete). Safe to remove once prod confirms it
+    // is disabled.
+    {
+      name: "DCFMH3 Static Schedule (Lunar Anchor)",
+      url: "https://sites.google.com/site/dcfmh3/home",
+      type: "STATIC_SCHEDULE" as const,
+      enabled: false,
+      trustLevel: 5,
+      scrapeFreq: "weekly",
+      scrapeDays: 365,
+      config: {
+        kennelTag: "dcfmh3",
+        lunar: { phase: "full", timezone: "America/New_York", anchorWeekday: "SA", anchorRule: "nearest" },
         startTime: "18:30",
         defaultTitle: "DCFMH3 Full Moon Run",
         defaultLocation: "Washington, DC",
-        defaultDescription: "Monthly full-moon hash, run on the Saturday nearest the full moon. Check Hash Rego or the kennel website for hare and start details.",
       },
       kennelCodes: ["dcfmh3"],
     },
@@ -2858,6 +2882,12 @@ export const SOURCES = [
           ["Dusk.*Down|FDTDD", "fdtdd"],
         ],
         defaultKennelTag: "wrong-way",
+        // Two-Tier Hash Cash (#1349): detail pages carry a `Hash Cash:` line on
+        // every event; promote it to Event.cost ONLY when it differs from these
+        // kennel standards. Hump D ($1) and LBH ($5) match their profile hashCash,
+        // so their per-event cost stays null. wrong-way/fdtdd have no seeded
+        // standard, so any cost on their pages surfaces verbatim.
+        kennelHashCash: { "hump-d": "$1", "lbh-phx": "$5" },
       },
       kennelCodes: ["lbh-phx", "hump-d", "wrong-way", "fdtdd"],
     },

--- a/scripts/cleanup-dcfmh3-placeholder-events.ts
+++ b/scripts/cleanup-dcfmh3-placeholder-events.ts
@@ -99,6 +99,7 @@ async function main() {
 main()
   .catch((err) => {
     console.error(err);
-    process.exit(1);
+    // Set exitCode (don't process.exit) so the .finally() disconnect still runs.
+    process.exitCode = 1;
   })
   .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-dcfmh3-placeholder-events.ts
+++ b/scripts/cleanup-dcfmh3-placeholder-events.ts
@@ -1,0 +1,104 @@
+/**
+ * One-shot cleanup for the stale DCFMH3 "DCFMH3 Full Moon Run" placeholder
+ * Events left behind when the source moved from STATIC_SCHEDULE (lunar anchor)
+ * to the Google Sites HTML scraper (#1399 / #1400).
+ *
+ * Background:
+ *   The old lunar source synthesized one event per month with the generic title
+ *   "DCFMH3 Full Moon Run" on a *drifted* date (the Saturday nearest the full
+ *   moon, 1–3 days off the published schedule). The new DCFMH3Adapter parses the
+ *   published Google Sites calendar, so it emits events with real moon/host
+ *   titles on the *correct* dates. Because the dates differ, the new events are
+ *   NEW canonical rows — the old placeholders are orphaned at the wrong dates and
+ *   would otherwise linger (cancelled-but-visible) on the kennel page.
+ *
+ *   This is the canonical-ghost cleanup that always accompanies a
+ *   fingerprint/date-changing parser swap (memory:
+ *   feedback_parser_fix_canonical_ghosts). Phuket (#1410/#1411) and Hump D
+ *   (#1348-#1350) need NO equivalent script — their dates are unchanged, so
+ *   merge's equal-trust update branch refreshes title/endTime/cost/dogFriendly
+ *   in place on the next scrape.
+ *
+ * Selection (intentionally narrow):
+ *   Events for the `dcfmh3` kennel whose title is EXACTLY the old placeholder
+ *   "DCFMH3 Full Moon Run". The new scraper never emits that string, so live
+ *   events are never matched. Events that have attendance check-ins are SKIPPED
+ *   (these synthetic placeholders shouldn't have any; bail loudly if they do).
+ *
+ * Run order (POST-merge — Vercel deploys schema but not seed data):
+ *   1. npx prisma db seed                       # flips the source to HTML_SCRAPER
+ *   2. re-scrape DCFMH3 (admin re-scrape / cron) # creates the real events
+ *   3. npx tsx scripts/cleanup-dcfmh3-placeholder-events.ts            # dry run
+ *   4. CLEANUP_APPLY=1 npx tsx scripts/cleanup-dcfmh3-placeholder-events.ts  # apply
+ */
+
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const KENNEL_CODE = "dcfmh3";
+export const PLACEHOLDER_TITLE = "DCFMH3 Full Moon Run";
+const APPLY = process.env.CLEANUP_APPLY === "1";
+
+async function main() {
+  const kennel = await prisma.kennel.findFirst({
+    where: { kennelCode: KENNEL_CODE },
+    select: { id: true },
+  });
+  if (!kennel) throw new Error(`Kennel ${KENNEL_CODE} not found`);
+
+  const placeholders = await prisma.event.findMany({
+    where: { kennelId: kennel.id, title: PLACEHOLDER_TITLE },
+    select: {
+      id: true,
+      date: true,
+      status: true,
+      _count: { select: { attendances: true } },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  console.log(`Found ${placeholders.length} "${PLACEHOLDER_TITLE}" events for ${KENNEL_CODE}.`);
+  if (placeholders.length === 0) return;
+
+  const withAttendance = placeholders.filter((e) => e._count.attendances > 0);
+  const deletable = placeholders.filter((e) => e._count.attendances === 0);
+
+  for (const e of placeholders) {
+    console.log(
+      `  ${e.date.toISOString().slice(0, 10)}  status=${e.status}  attendances=${e._count.attendances}` +
+        (e._count.attendances > 0 ? "  → SKIP (has check-ins)" : ""),
+    );
+  }
+  if (withAttendance.length > 0) {
+    console.warn(
+      `\n⚠️  ${withAttendance.length} placeholder event(s) have attendance check-ins and will NOT be deleted. ` +
+        `Investigate before forcing — a real check-in on a synthetic placeholder is unexpected.`,
+    );
+  }
+
+  if (!APPLY) {
+    console.log(`\nDry run. Would delete ${deletable.length} event(s) (+ their RawEvents/EventKennel rows).`);
+    console.log("Re-run with CLEANUP_APPLY=1 to apply.");
+    return;
+  }
+
+  const ids = deletable.map((e) => e.id);
+  const result = await prisma.$transaction(async (tx) => {
+    // Old lunar-synthesized RawEvents are dead once the source is HTML-scraped;
+    // delete them so a future merge can't re-materialize the placeholder, and so
+    // the Event delete doesn't trip the RawEvent.eventId FK.
+    const raws = await tx.rawEvent.deleteMany({ where: { eventId: { in: ids } } });
+    // EventKennel + EventLink cascade on Event delete (schema onDelete: Cascade).
+    const events = await tx.event.deleteMany({ where: { id: { in: ids } } });
+    return { raws: raws.count, events: events.count };
+  });
+
+  console.log(`\n✅ Deleted ${result.events} placeholder events and ${result.raws} orphaned RawEvents.`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/adapters/html-scraper/dcfmh3.test.ts
+++ b/src/adapters/html-scraper/dcfmh3.test.ts
@@ -1,0 +1,104 @@
+import { parseDCFMH3Schedule, detectHostKennel, DCFMH3Adapter } from "./dcfmh3";
+
+// Fixture mirrors the live Google Sites markup: each schedule entry is a
+// <p><span>…</span></p> line. Includes a <script> JSON island (must be ignored),
+// a duplicated "next trail" banner (dedup), and the real line shapes from #1399.
+const SAMPLE_HTML = `
+<html><head><title>DC Kennel Calendar</title></head><body>
+<script type="application/json">{"July 31, 2026: Full Buck Moon - DCH3":"noise"}</script>
+<div class="banner"><p dir="ltr"><span>Next Full Moon Trail</span></p>
+<p dir="ltr"><span>June 27, 2026: Full Strawberry Moon - Hangover</span></p></div>
+<div class="schedule">
+  <p dir="ltr"><span>2026 Schedule</span></p>
+  <p dir="ltr"><span>January 3, 2026: Smutty Crab H3</span></p>
+  <p dir="ltr"><span>February 6, 2026: Full Snow Moon - EWH3 Hash Olympdicks Trail</span></p>
+  <p dir="ltr"><span>March 6 - Worm Blood Moon OTH3</span></p>
+  <p dir="ltr"><span>April 3, 2026: Full Pink Moon - White House H3</span></p>
+  <p dir="ltr"><span>May 2, 2026: Full Flower Moon - Hillbilly H3</span></p>
+  <p dir="ltr"><span>June 6-14: &iexcl;Tour Duh Hash!</span></p>
+  <p dir="ltr"><span>June 27, 2026: Full Strawberry Moon - Hangover</span></p>
+  <p dir="ltr"><span>July 31, 2026: Full Buck Moon - DCH3</span></p>
+  <p dir="ltr"><span>August 28, 2026: Full Sturgeon Moon -Mount Vernon H3</span></p>
+  <p dir="ltr"><span>September 26, 2026: Full Harvest Moon - Charm City</span></p>
+  <p dir="ltr"><span>October 24, 2026: Full Hunter's Moon - DC Red Tent</span></p>
+  <p dir="ltr"><span>November 24, 2026: Super Beaver Moon - Fredericksburg Urban H3</span></p>
+  <p dir="ltr"><span>December 23, 2026: Super Cold Moon - DCH4</span></p>
+  <p dir="ltr"><span>Some unrelated paragraph about hashing.</span></p>
+</div>
+</body></html>`;
+
+describe("detectHostKennel (#1400)", () => {
+  it.each([
+    { title: "Full Buck Moon - DCH3", expected: "dch3" },
+    { title: "Full Snow Moon - EWH3 Hash Olympdicks Trail", expected: "ewh3" },
+    { title: "Super Cold Moon - DCH4", expected: "dch4" },
+    { title: "Full Sturgeon Moon -Mount Vernon H3", expected: "mvh3" },
+    { title: "Full Harvest Moon - Charm City", expected: "cch3" },
+    { title: "Super Beaver Moon - Fredericksburg Urban H3", expected: "fuh3" },
+    { title: "Full Strawberry Moon - Hangover", expected: "h4" },
+  ])("maps '$title' → $expected", ({ title, expected }) => {
+    expect(detectHostKennel(title)).toBe(expected);
+  });
+
+  it.each([
+    "Smutty Crab H3",
+    "Full Pink Moon - White House H3",
+    "Full Flower Moon - Hillbilly H3",
+    "Full Hunter's Moon - DC Red Tent",
+    "¡Tour Duh Hash!",
+  ])("returns undefined for unseeded host %s", (title) => {
+    expect(detectHostKennel(title)).toBeUndefined();
+  });
+
+  it("does not match DCH3 inside DCFMH3", () => {
+    expect(detectHostKennel("DCFMH3 Full Moon Run")).toBeUndefined();
+  });
+});
+
+describe("parseDCFMH3Schedule (#1399)", () => {
+  const entries = parseDCFMH3Schedule(SAMPLE_HTML, 2026);
+  const byTitleStarts = (s: string) => entries.find((e) => e.title.startsWith(s));
+
+  it("parses the published date verbatim (no lunar drift)", () => {
+    expect(byTitleStarts("Full Buck Moon")?.date).toBe("2026-07-31");
+    expect(byTitleStarts("Full Sturgeon Moon")?.date).toBe("2026-08-28");
+    expect(byTitleStarts("Super Cold Moon")?.date).toBe("2026-12-23");
+  });
+
+  it("uses the verbatim source title (moon name + host)", () => {
+    expect(byTitleStarts("Full Buck Moon")?.title).toBe("Full Buck Moon - DCH3");
+  });
+
+  it("handles the ' - ' separator + year-less row via fallback year", () => {
+    const worm = byTitleStarts("Worm Blood Moon");
+    expect(worm?.date).toBe("2026-03-06");
+    expect(worm?.title).toBe("Worm Blood Moon OTH3");
+  });
+
+  it("takes the start date of a date range (June 6-14)", () => {
+    const tour = entries.find((e) => e.title.includes("Tour Duh Hash"));
+    expect(tour?.date).toBe("2026-06-06");
+  });
+
+  it("dedups the repeated banner entry", () => {
+    const straw = entries.filter((e) => e.title === "Full Strawberry Moon - Hangover");
+    expect(straw).toHaveLength(1);
+  });
+
+  it("ignores non-schedule paragraphs, headings, and the script island", () => {
+    expect(entries.find((e) => e.title.includes("unrelated"))).toBeUndefined();
+    expect(entries.find((e) => e.title === "Schedule")).toBeUndefined();
+    expect(entries.find((e) => e.title === "Full Moon Trail")).toBeUndefined();
+  });
+
+  it("attaches host co-host codes where seeded", () => {
+    expect(byTitleStarts("Full Buck Moon")?.hostKennelCode).toBe("dch3");
+    expect(byTitleStarts("Smutty Crab")?.hostKennelCode).toBeUndefined();
+  });
+});
+
+describe("DCFMH3Adapter", () => {
+  it("has correct type", () => {
+    expect(new DCFMH3Adapter().type).toBe("HTML_SCRAPER");
+  });
+});

--- a/src/adapters/html-scraper/dcfmh3.test.ts
+++ b/src/adapters/html-scraper/dcfmh3.test.ts
@@ -75,9 +75,14 @@ describe("parseDCFMH3Schedule (#1399)", () => {
     expect(worm?.title).toBe("Worm Blood Moon OTH3");
   });
 
-  it("takes the start date of a date range (June 6-14)", () => {
+  it("emits a multi-day range (June 6-14) as one event with start + endDate", () => {
     const tour = entries.find((e) => e.title.includes("Tour Duh Hash"));
     expect(tour?.date).toBe("2026-06-06");
+    expect(tour?.endDate).toBe("2026-06-14");
+  });
+
+  it("leaves endDate undefined for single-day entries", () => {
+    expect(byTitleStarts("Full Buck Moon")?.endDate).toBeUndefined();
   });
 
   it("dedups the repeated banner entry", () => {

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -57,13 +57,13 @@ const MONTH_NAMES = new Set([
  * MONTH_NAMES in code — keeping the regex a literal (no `new RegExp` →
  * Codacy/Semgrep detect-non-literal-regexp) while avoiding a 12-branch month
  * alternation that would blow Sonar's regex-complexity cap (S5843). The range
- * uses spaceless `-` (source ranges are `6-14`); the separator class is just
- * `-`/`:` (the only separators the source uses — Sonar flagged the prior
- * en-dash variant as a duplicate dash, S5869); the title is captured with
- * `(.+)` and trimmed by the caller.
+ * uses spaceless `-` (source ranges are `6-14`); the separator is a `(?:-|:)`
+ * alternation rather than a `[…]` class (the only separators the source uses,
+ * and a non-class form sidesteps Sonar's char-class duplicate check S5869); the
+ * title is captured with `(.+)` and trimmed by the caller.
  */
 const SCHEDULE_LINE_RE =
-  /^([A-Za-z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*[-:](.+)$/i;
+  /^([A-Za-z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*(?:-|:)(.+)$/i;
 
 /**
  * Host kennel detection (#1400). Only seeded DC-area kennels are listed; the

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -141,9 +141,19 @@ export function parseDCFMH3Schedule(
   return entries;
 }
 
-/** Pick the year that appears in most dated lines, for year-less rows. */
+/**
+ * Pick the year for year-less rows ("March 6") from the years that appear on
+ * actual SCHEDULE rows — not every `20xx` in the page source (script islands and
+ * Google Sites boilerplate would otherwise outvote the real schedule year).
+ */
 function inferScheduleYear(html: string): number {
-  const years = [...html.matchAll(/\b(20\d{2})\b/g)].map((m) => Number.parseInt(m[1], 10));
+  const years = stripHtmlTags(html, "\n")
+    .split("\n")
+    .map((line) => SCHEDULE_LINE_RE.exec(line.trim()))
+    .filter((m): m is RegExpExecArray => m != null && MONTH_NAMES.has(m[1].toLowerCase()))
+    .map((m) => m[4]) // group 4 = explicit year, if present
+    .filter((y): y is string => Boolean(y))
+    .map((y) => Number.parseInt(y, 10));
   if (years.length === 0) return new Date().getUTCFullYear();
   const counts = new Map<number, number>();
   for (const y of years) counts.set(y, (counts.get(y) ?? 0) + 1);

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -57,12 +57,13 @@ const MONTH_NAMES = new Set([
  * MONTH_NAMES in code — keeping the regex a literal (no `new RegExp` →
  * Codacy/Semgrep detect-non-literal-regexp) while avoiding a 12-branch month
  * alternation that would blow Sonar's regex-complexity cap (S5843). The range
- * uses spaceless `-` (source ranges are `6-14`) and the separator class lists
- * `-` first as a literal (avoids the `[:–-]` range/duplicate flag, S5869); the
- * title is captured with `(.+)` and trimmed by the caller.
+ * uses spaceless `-` (source ranges are `6-14`); the separator class is just
+ * `-`/`:` (the only separators the source uses — Sonar flagged the prior
+ * en-dash variant as a duplicate dash, S5869); the title is captured with
+ * `(.+)` and trimmed by the caller.
  */
 const SCHEDULE_LINE_RE =
-  /^([A-Za-z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*[-:–](.+)$/i;
+  /^([A-Za-z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*[-:](.+)$/i;
 
 /**
  * Host kennel detection (#1400). Only seeded DC-area kennels are listed; the

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -50,7 +50,7 @@ const MONTHS =
  * end is consumed before the separator so `June 6-14: …` parses (start day wins).
  */
 const SCHEDULE_LINE_RE = new RegExp(
-  `^(${MONTHS})\\s+(\\d{1,2})(?:\\s*-\\s*\\d{1,2})?(?:,?\\s*(\\d{4}))?\\s*[:\\u2013-]\\s*(\\S.*)$`,
+  String.raw`^(${MONTHS})\s+(\d{1,2})(?:\s*-\s*\d{1,2})?(?:,?\s*(\d{4}))?\s*[:–-]\s*(\S.*)$`,
   "i",
 );
 

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -1,0 +1,187 @@
+import type { Source } from "@/generated/prisma/client";
+import type {
+  SourceAdapter,
+  RawEventData,
+  ScrapeResult,
+  ErrorDetails,
+} from "../types";
+import { hasAnyErrors } from "../types";
+import { applyDateWindow, chronoParseDate, fetchHTMLPage, stripHtmlTags } from "../utils";
+
+/**
+ * DC Full Moon Hash House Harriers (DCFMH3) Google Sites adapter.
+ *
+ * sites.google.com/site/dcfmh3/home/dc-kennel-calendar publishes a hand-maintained
+ * annual schedule where each monthly full-moon trail carries a distinct moon name
+ * AND a rotating host kennel — DCFMH3 is an umbrella that doesn't run its own
+ * trails; a different DC-area kennel hosts each month. Each entry is one
+ * `<p><span>` line, e.g.:
+ *
+ *   July 31, 2026: Full Buck Moon - DCH3
+ *   February 6, 2026: Full Snow Moon - EWH3 Hash Olympdicks Trail
+ *   January 3, 2026: Smutty Crab H3            (no moon name — host is the title)
+ *   March 6 - Worm Blood Moon                  (dash separator, no year)
+ *   June 6-14: ¡Tour Duh Hash!                 (date range — emit on start date)
+ *
+ * Replaces the former STATIC_SCHEDULE (lunar) source, which could only synthesize
+ * a generic placeholder title ("DCFMH3 Full Moon Run") and drifted 1–3 days off
+ * the published dates (#1399). Parsing the published schedule fixes both the
+ * titles and the dates, and surfaces the host kennel:
+ *   - #1399: title = the verbatim source text (moon name + host).
+ *   - #1400: when the host matches a seeded kennel, it is emitted as a secondary
+ *     co-host tag → merge writes an EventKennel co-host (#1023). Unseeded hosts
+ *     (Smutty Crab, White House, etc.) stay in the title only — no sourceless
+ *     kennel rows are created.
+ */
+
+interface DCFMH3Config {
+  kennelTag?: string; // primary kennel; defaults to "dcfmh3"
+  startTime?: string; // "HH:MM"; defaults to "18:30"
+  defaultLocation?: string;
+  defaultDescription?: string;
+}
+
+const MONTHS =
+  "January|February|March|April|May|June|July|August|September|October|November|December";
+
+/**
+ * One schedule line: `<Month> <Day>[-<Day2>][, <Year>] <sep> <title>` where the
+ * first `:` or ` - ` after the date opens the title. The optional `-<Day2>` range
+ * end is consumed before the separator so `June 6-14: …` parses (start day wins).
+ */
+const SCHEDULE_LINE_RE = new RegExp(
+  `^(${MONTHS})\\s+(\\d{1,2})(?:\\s*-\\s*\\d{1,2})?(?:,?\\s*(\\d{4}))?\\s*[:\\u2013-]\\s*(\\S.*)$`,
+  "i",
+);
+
+/**
+ * Host kennel detection (#1400). Only seeded DC-area kennels are listed; the
+ * matched kennelCode becomes a secondary co-host tag. Keep in sync with the
+ * DCFMH3 source's `kennelCodes` in prisma/seed-data/sources.ts (the merge
+ * source-kennel guard blocks tags the source isn't linked to). `\b…\b` boundaries
+ * keep DCH3 from matching DCH4 / DCFMH3.
+ */
+const HOST_KENNEL_PATTERNS: readonly [RegExp, string][] = [
+  [/\bEWH3\b/i, "ewh3"],
+  [/\bDCH4\b/i, "dch4"],
+  [/\bDCH3\b/i, "dch3"],
+  [/\bCharm City\b/i, "cch3"],
+  [/\bMount Vernon\b/i, "mvh3"],
+  [/\bFredericksburg Urban\b/i, "fuh3"],
+  [/\bHangover\b/i, "h4"],
+];
+
+/** Resolve a seeded host kennelCode from the event title, or undefined. */
+export function detectHostKennel(title: string): string | undefined {
+  for (const [re, code] of HOST_KENNEL_PATTERNS) {
+    if (re.test(title)) return code;
+  }
+  return undefined;
+}
+
+export interface ParsedScheduleEntry {
+  date: string; // YYYY-MM-DD
+  title: string;
+  hostKennelCode?: string;
+}
+
+/**
+ * Flatten the Google Sites HTML into one line per schedule paragraph, then parse
+ * each `<date>: <title>` entry. `fallbackYear` fills year-less rows ("March 6").
+ */
+export function parseDCFMH3Schedule(
+  html: string,
+  fallbackYear: number,
+): ParsedScheduleEntry[] {
+  // stripHtmlTags flattens each <p>/block to its own line, removes script/style,
+  // decodes entities, and collapses internal whitespace — one schedule entry per
+  // line, exactly what the per-line regex below needs. Non-schedule lines
+  // (headings, nav, the <title>) simply don't match SCHEDULE_LINE_RE.
+  const text = stripHtmlTags(html, "\n");
+
+  const seen = new Set<string>();
+  const entries: ParsedScheduleEntry[] = [];
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    const m = SCHEDULE_LINE_RE.exec(line);
+    if (!m) continue;
+    const [, month, day, year, rawTitle] = m;
+    const title = rawTitle.trim();
+    if (!title) continue;
+    const date = chronoParseDate(`${month} ${day}, ${year ?? fallbackYear}`, "en-US");
+    if (!date) continue;
+    // Dedup repeated lines (the page echoes a "next trail" banner up top).
+    const key = `${date}|${title}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    entries.push({ date, title, hostKennelCode: detectHostKennel(title) });
+  }
+  return entries;
+}
+
+/** Pick the year that appears in most dated lines, for year-less rows. */
+function inferScheduleYear(html: string): number {
+  const years = [...html.matchAll(/\b(20\d{2})\b/g)].map((m) => Number.parseInt(m[1], 10));
+  if (years.length === 0) return new Date().getUTCFullYear();
+  const counts = new Map<number, number>();
+  for (const y of years) counts.set(y, (counts.get(y) ?? 0) + 1);
+  return [...counts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+}
+
+export class DCFMH3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    const url = source.url || "https://sites.google.com/site/dcfmh3/home/dc-kennel-calendar";
+    const config = (source.config ?? {}) as DCFMH3Config;
+    const kennelTag = config.kennelTag ?? "dcfmh3";
+    const startTime = config.startTime ?? "18:30";
+
+    const page = await fetchHTMLPage(url);
+    if (!page.ok) return page.result;
+    const { html, structureHash, fetchDurationMs } = page;
+
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    const fallbackYear = inferScheduleYear(html);
+    const entries = parseDCFMH3Schedule(html, fallbackYear);
+
+    const events: RawEventData[] = entries.map((e) => ({
+      date: e.date,
+      // #1400: host kennel (when seeded) rides as a secondary co-host tag.
+      kennelTags: e.hostKennelCode ? [kennelTag, e.hostKennelCode] : [kennelTag],
+      title: e.title,
+      startTime,
+      location: config.defaultLocation,
+      description: config.defaultDescription,
+      sourceUrl: url,
+    }));
+
+    if (events.length === 0) {
+      errors.push("DCFMH3: zero schedule entries parsed from Google Sites calendar");
+      errorDetails.parse = [
+        { row: 0, section: "calendar", error: "No <date>: <title> lines matched", rawText: html.slice(0, 500) },
+      ];
+    }
+
+    const days = options?.days ?? source.scrapeDays ?? 365;
+    return applyDateWindow(
+      {
+        events,
+        errors,
+        structureHash,
+        errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+        diagnosticContext: {
+          url,
+          fetchMethod: "fetchHTMLPage",
+          entriesParsed: entries.length,
+          eventsWithHost: entries.filter((e) => e.hostKennelCode).length,
+          fallbackYear,
+          fetchDurationMs,
+        },
+      },
+      days,
+    );
+  }
+}

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -41,18 +41,25 @@ interface DCFMH3Config {
   defaultDescription?: string;
 }
 
+const MONTH_NAMES = new Set([
+  "january", "february", "march", "april", "may", "june",
+  "july", "august", "september", "october", "november", "december",
+]);
+
 /**
  * One schedule line: `<Month> <Day>[-<Day2>][, <Year>] <sep> <title>` where the
  * first `:` or ` - ` after the date opens the title. The optional `-<Day2>` range
  * end is captured so a multi-day entry (`June 6-14: ¡Tour Duh Hash!`) emits a
  * single Event with `endDate` set (a campout — NOT a per-day series split).
- * Groups: 1=month, 2=startDay, 3=endDay?, 4=year?, 5=title.
+ * Groups: 1=monthWord, 2=startDay, 3=endDay?, 4=year?, 5=title.
  *
- * Written as a literal (not `new RegExp(...)`) so Codacy/Semgrep's
- * detect-non-literal-regexp doesn't flag it — the month alternation is inlined.
+ * The leading word is matched generically (`[A-Za-z]+`) and validated against
+ * MONTH_NAMES in code — keeping the regex a literal (no `new RegExp` →
+ * Codacy/Semgrep detect-non-literal-regexp) while avoiding a 12-branch month
+ * alternation that would blow Sonar's regex-complexity cap (S5843).
  */
 const SCHEDULE_LINE_RE =
-  /^(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2})(?:\s*-\s*(\d{1,2}))?(?:,?\s*(\d{4}))?\s*[:–-]\s*(\S.*)$/i;
+  /^([A-Za-z]+)\s+(\d{1,2})(?:\s*-\s*(\d{1,2}))?(?:,?\s*(\d{4}))?\s*[:–-]\s*(\S.*)$/i;
 
 /**
  * Host kennel detection (#1400). Only seeded DC-area kennels are listed; the
@@ -107,6 +114,8 @@ export function parseDCFMH3Schedule(
     const m = SCHEDULE_LINE_RE.exec(line);
     if (!m) continue;
     const [, month, startDay, endDay, year, rawTitle] = m;
+    // The regex matches any leading word; only real month names are schedule rows.
+    if (!MONTH_NAMES.has(month.toLowerCase())) continue;
     const title = rawTitle.trim();
     if (!title) continue;
     const yr = year ?? fallbackYear;

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -47,10 +47,12 @@ const MONTHS =
 /**
  * One schedule line: `<Month> <Day>[-<Day2>][, <Year>] <sep> <title>` where the
  * first `:` or ` - ` after the date opens the title. The optional `-<Day2>` range
- * end is consumed before the separator so `June 6-14: …` parses (start day wins).
+ * end is captured so a multi-day entry (`June 6-14: ¡Tour Duh Hash!`) emits a
+ * single Event with `endDate` set (a campout — NOT a per-day series split).
+ * Groups: 1=month, 2=startDay, 3=endDay?, 4=year?, 5=title.
  */
 const SCHEDULE_LINE_RE = new RegExp(
-  String.raw`^(${MONTHS})\s+(\d{1,2})(?:\s*-\s*\d{1,2})?(?:,?\s*(\d{4}))?\s*[:–-]\s*(\S.*)$`,
+  String.raw`^(${MONTHS})\s+(\d{1,2})(?:\s*-\s*(\d{1,2}))?(?:,?\s*(\d{4}))?\s*[:–-]\s*(\S.*)$`,
   "i",
 );
 
@@ -80,7 +82,8 @@ export function detectHostKennel(title: string): string | undefined {
 }
 
 export interface ParsedScheduleEntry {
-  date: string; // YYYY-MM-DD
+  date: string; // YYYY-MM-DD (start)
+  endDate?: string; // YYYY-MM-DD, set only for multi-day ranges (campouts)
   title: string;
   hostKennelCode?: string;
 }
@@ -105,16 +108,23 @@ export function parseDCFMH3Schedule(
     const line = rawLine.trim();
     const m = SCHEDULE_LINE_RE.exec(line);
     if (!m) continue;
-    const [, month, day, year, rawTitle] = m;
+    const [, month, startDay, endDay, year, rawTitle] = m;
     const title = rawTitle.trim();
     if (!title) continue;
-    const date = chronoParseDate(`${month} ${day}, ${year ?? fallbackYear}`, "en-US");
+    const yr = year ?? fallbackYear;
+    const date = chronoParseDate(`${month} ${startDay}, ${yr}`, "en-US");
     if (!date) continue;
+    // Multi-day range ("June 6-14") → single Event spanning to endDate (campout),
+    // not a per-day series. Only when the end day is later in the same month.
+    let endDate: string | undefined;
+    if (endDay && Number.parseInt(endDay, 10) > Number.parseInt(startDay, 10)) {
+      endDate = chronoParseDate(`${month} ${endDay}, ${yr}`, "en-US") ?? undefined;
+    }
     // Dedup repeated lines (the page echoes a "next trail" banner up top).
     const key = `${date}|${title}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    entries.push({ date, title, hostKennelCode: detectHostKennel(title) });
+    entries.push({ date, endDate, title, hostKennelCode: detectHostKennel(title) });
   }
   return entries;
 }
@@ -149,6 +159,7 @@ export class DCFMH3Adapter implements SourceAdapter {
 
     const events: RawEventData[] = entries.map((e) => ({
       date: e.date,
+      ...(e.endDate ? { endDate: e.endDate } : {}),
       // #1400: host kennel (when seeded) rides as a secondary co-host tag.
       kennelTags: e.hostKennelCode ? [kennelTag, e.hostKennelCode] : [kennelTag],
       title: e.title,

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -57,13 +57,14 @@ const MONTH_NAMES = new Set([
  * MONTH_NAMES in code — keeping the regex a literal (no `new RegExp` →
  * Codacy/Semgrep detect-non-literal-regexp) while avoiding a 12-branch month
  * alternation that would blow Sonar's regex-complexity cap (S5843). The range
- * uses spaceless `-` (source ranges are `6-14`); the separator is a `(?:-|:)`
- * alternation rather than a `[…]` class (the only separators the source uses,
- * and a non-class form sidesteps Sonar's char-class duplicate check S5869); the
- * title is captured with `(.+)` and trimmed by the caller.
+ * uses spaceless `-` (source ranges are `6-14`); the separator is the char class
+ * `[-:]` — the two separators the source uses. Sonar wants a class here, not an
+ * alternation (S6035); `[-:]` has no duplicate so S5869 is satisfied too (the
+ * earlier S5869 was the en-dash variant `[-:–]`, where Sonar treats en-dash and
+ * hyphen as duplicate dashes). The title is captured with `(.+)` and trimmed.
  */
 const SCHEDULE_LINE_RE =
-  /^([A-Za-z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*(?:-|:)(.+)$/i;
+  /^([A-Za-z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*[-:](.+)$/i;
 
 /**
  * Host kennel detection (#1400). Only seeded DC-area kennels are listed; the

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -56,10 +56,13 @@ const MONTH_NAMES = new Set([
  * The leading word is matched generically (`[A-Za-z]+`) and validated against
  * MONTH_NAMES in code — keeping the regex a literal (no `new RegExp` →
  * Codacy/Semgrep detect-non-literal-regexp) while avoiding a 12-branch month
- * alternation that would blow Sonar's regex-complexity cap (S5843).
+ * alternation that would blow Sonar's regex-complexity cap (S5843). The range
+ * uses spaceless `-` (source ranges are `6-14`) and the separator class lists
+ * `-` first as a literal (avoids the `[:–-]` range/duplicate flag, S5869); the
+ * title is captured with `(.+)` and trimmed by the caller.
  */
 const SCHEDULE_LINE_RE =
-  /^([A-Za-z]+)\s+(\d{1,2})(?:\s*-\s*(\d{1,2}))?(?:,?\s*(\d{4}))?\s*[:–-]\s*(\S.*)$/i;
+  /^([A-Za-z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*[-:–](.+)$/i;
 
 /**
  * Host kennel detection (#1400). Only seeded DC-area kennels are listed; the

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -41,20 +41,18 @@ interface DCFMH3Config {
   defaultDescription?: string;
 }
 
-const MONTHS =
-  "January|February|March|April|May|June|July|August|September|October|November|December";
-
 /**
  * One schedule line: `<Month> <Day>[-<Day2>][, <Year>] <sep> <title>` where the
  * first `:` or ` - ` after the date opens the title. The optional `-<Day2>` range
  * end is captured so a multi-day entry (`June 6-14: ¡Tour Duh Hash!`) emits a
  * single Event with `endDate` set (a campout — NOT a per-day series split).
  * Groups: 1=month, 2=startDay, 3=endDay?, 4=year?, 5=title.
+ *
+ * Written as a literal (not `new RegExp(...)`) so Codacy/Semgrep's
+ * detect-non-literal-regexp doesn't flag it — the month alternation is inlined.
  */
-const SCHEDULE_LINE_RE = new RegExp(
-  String.raw`^(${MONTHS})\s+(\d{1,2})(?:\s*-\s*(\d{1,2}))?(?:,?\s*(\d{4}))?\s*[:–-]\s*(\S.*)$`,
-  "i",
-);
+const SCHEDULE_LINE_RE =
+  /^(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2})(?:\s*-\s*(\d{1,2}))?(?:,?\s*(\d{4}))?\s*[:–-]\s*(\S.*)$/i;
 
 /**
  * Host kennel detection (#1400). Only seeded DC-area kennels are listed; the

--- a/src/adapters/html-scraper/dcfmh3.ts
+++ b/src/adapters/html-scraper/dcfmh3.ts
@@ -58,13 +58,13 @@ const MONTH_NAMES = new Set([
  * Codacy/Semgrep detect-non-literal-regexp) while avoiding a 12-branch month
  * alternation that would blow Sonar's regex-complexity cap (S5843). The range
  * uses spaceless `-` (source ranges are `6-14`); the separator is the char class
- * `[-:]` — the two separators the source uses. Sonar wants a class here, not an
- * alternation (S6035); `[-:]` has no duplicate so S5869 is satisfied too (the
- * earlier S5869 was the en-dash variant `[-:–]`, where Sonar treats en-dash and
- * hyphen as duplicate dashes). The title is captured with `(.+)` and trimmed.
+ * `[-:]` (S6035 wants a class, not an alternation). The leading word uses
+ * `[A-Z]` (not `[A-Za-z]`) because the `i` flag already matches lowercase —
+ * `[A-Za-z]` under `/i` makes `a-z` a duplicate of `A-Z` (S5869). The title is
+ * captured with `(.+)` and trimmed.
  */
 const SCHEDULE_LINE_RE =
-  /^([A-Za-z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*[-:](.+)$/i;
+  /^([A-Z]+)\s+(\d{1,2})(?:-(\d{1,2}))?(?:,\s*(\d{4}))?\s*[-:](.+)$/i;
 
 /**
  * Host kennel detection (#1400). Only seeded DC-area kennels are listed; the

--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -7,6 +7,11 @@ import {
   PHOENIX_HARE_PATTERNS,
   PhoenixHHHAdapter,
   extractVenueFromDescription,
+  parseTimeRangeEnd,
+  extractHashCash,
+  extractDogFriendly,
+  cleanPhoenixDescription,
+  normalizePhoenixDetailBlock,
 } from "./phoenixhhh";
 import { extractHashRunNumber } from "../utils";
 import { extractHares } from "../hare-extraction";
@@ -225,6 +230,25 @@ describe("parseEventFromItem", () => {
     const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
 
     expect(event!.startTime).toBe("18:30");
+  });
+
+  it("extracts end time from the time range (#1348)", () => {
+    const $ = cheerio.load(SAMPLE_EVENT_WITH_IMAGE);
+    const $item = $(".em-item").first();
+    const compiled = makeCompiledPatterns(DEFAULT_CONFIG);
+    const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
+
+    expect(event!.endTime).toBe("21:30");
+  });
+
+  it("leaves endTime undefined when the time meta has no range (#1348)", () => {
+    const $ = cheerio.load(SAMPLE_EVENT_COMPACT_DATE);
+    const $item = $(".em-item").first();
+    const compiled = makeCompiledPatterns(DEFAULT_CONFIG);
+    const event = parseEventFromItem($item, $, DEFAULT_CONFIG, compiled);
+
+    expect(event!.startTime).toBe("18:30");
+    expect(event!.endTime).toBeUndefined();
   });
 
   it("extracts location", () => {
@@ -817,5 +841,114 @@ describe("PhoenixHHHAdapter.fetch — detail-fetch failures are visible", () => 
     ).toBe(true);
     expect(result.diagnosticContext?.detailFetchFailures).toBeGreaterThan(0);
     expect(result.diagnosticContext?.detailsFetched).toBe(0);
+  });
+});
+
+// ── #1348/#1349/#1350: detail-block field extraction ──
+
+// Verbatim Hump D detail-page key:value block from #1350 (5/6 Taco Bell Cantina).
+const HUMP_D_DETAIL_BLOCK = [
+  "Hares: TBD",
+  "Where: Taco Bell Cantina Tempe (423 S Mill)",
+  "When: 5/6/26",
+  "Time: Meet at 6:30 PM, Hares off at 6:45, Hounds to follow at 7:00.",
+  "Bring: Proper illumination (BRING a Headlamp, it gets dark so be safe), a whistle, low morals, and even lower expectations.",
+  "Things you probably won't need: A drinking vessel",
+  "Hash Cash: $1",
+  "Cash Needed on Trail:? Always good to bring a few dollars for bail",
+  "Dog friendly: Usually not on humps",
+  "On-After: Usually The Same Place We Started from",
+].join("\n");
+
+describe("parseTimeRangeEnd (#1348)", () => {
+  it.each([
+    { input: "6:30 pm - 9:30 pm", expected: "21:30" },
+    { input: "2:00 pm - 5:00 pm", expected: "17:00" },
+    { input: "6:30 pm – 8:30 pm", expected: "20:30" }, // en-dash
+  ])("parses end time from $input", ({ input, expected }) => {
+    expect(parseTimeRangeEnd(input)).toBe(expected);
+  });
+
+  it.each(["6:30 pm", "", "TBD"])("returns undefined when no range in %s", (input) => {
+    expect(parseTimeRangeEnd(input)).toBeUndefined();
+  });
+});
+
+// Live "mashed" variant (#1350 — some Hump D detail pages run every field onto
+// one line with NO separator). Verbatim shape from phoenixhhh.org 4/15 TAX DAY.
+const HUMP_D_MASHED_BLOCK =
+  "Hares: TBDWhere: Gracie’s Tax BarWhen: 4/15/26Time: Meet at 6:30 PM, Hares off at 6:45, Hounds to follow at 7:00." +
+  "Bring: Proper illumination (BRING a Headlamp), a whistle, low morals.Things you probably won’t need: A drinking vessel" +
+  "Hash Cash: $1Cash Needed on Trail:? Always good to bring a few dollars for bailDog friendly: Usually not on humps" +
+  "On-After: Usually The Same Place We Started fromDrink responsibly so you don’t need a designated driver";
+
+describe("normalizePhoenixDetailBlock (#1350 mashed single-line variant)", () => {
+  it("injects newlines before each label so mashed fields become parseable", () => {
+    const normalized = normalizePhoenixDetailBlock(HUMP_D_MASHED_BLOCK);
+    expect(extractHashCash(normalized)).toBe("$1");
+    expect(extractDogFriendly(normalized)).toBe(false);
+  });
+
+  it("does not match 'Time' inside 'Date/Time' (no false split)", () => {
+    expect(normalizePhoenixDetailBlock("Date/Time\nDate(s) - Wed")).toBe("Date/Time\nDate(s) - Wed");
+  });
+});
+
+describe("extractHashCash (#1349)", () => {
+  it("extracts the cash value from the detail block", () => {
+    expect(extractHashCash(HUMP_D_DETAIL_BLOCK)).toBe("$1");
+  });
+
+  it("returns undefined when no Hash Cash line", () => {
+    expect(extractHashCash("Hares: TBD\nWhere: Somewhere")).toBeUndefined();
+  });
+});
+
+describe("extractDogFriendly (#1350)", () => {
+  it.each([
+    { value: "Dog friendly: Usually not on humps", expected: false },
+    { value: "Dog friendly: No", expected: false },
+    { value: "Dog friendly: Yes, leashed", expected: true },
+    { value: "Dog friendly: Dogs welcome", expected: true },
+  ])("classifies '$value' → $expected", ({ value, expected }) => {
+    expect(extractDogFriendly(value)).toBe(expected);
+  });
+
+  it("classifies the full Hump D block as not dog-friendly", () => {
+    expect(extractDogFriendly(HUMP_D_DETAIL_BLOCK)).toBe(false);
+  });
+
+  it("returns undefined when the line is absent", () => {
+    expect(extractDogFriendly("Hares: TBD")).toBeUndefined();
+  });
+});
+
+describe("cleanPhoenixDescription (#1350)", () => {
+  it("drops Hash Cash + Dog friendly lines but keeps Bring / On-After / Cash Needed", () => {
+    const out = cleanPhoenixDescription(HUMP_D_DETAIL_BLOCK, {
+      stripHashCash: true,
+      stripDogFriendly: true,
+    });
+    expect(out).not.toContain("Hash Cash:");
+    expect(out).not.toContain("Dog friendly:");
+    // Fields with no schema home stay in the description.
+    expect(out).toContain("Bring: Proper illumination");
+    expect(out).toContain("On-After: Usually The Same Place");
+    expect(out).toContain("Cash Needed on Trail");
+  });
+
+  it("keeps the Dog friendly line when not classified", () => {
+    const out = cleanPhoenixDescription(HUMP_D_DETAIL_BLOCK, {
+      stripHashCash: true,
+      stripDogFriendly: false,
+    });
+    expect(out).toContain("Dog friendly:");
+    expect(out).not.toContain("Hash Cash:");
+  });
+
+  it("returns undefined when stripping leaves nothing", () => {
+    expect(
+      cleanPhoenixDescription("Hash Cash: $1", { stripHashCash: true, stripDogFriendly: false }),
+    ).toBeUndefined();
   });
 });

--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -918,8 +918,15 @@ describe("extractDogFriendly (#1350)", () => {
     expect(extractDogFriendly(HUMP_D_DETAIL_BLOCK)).toBe(false);
   });
 
-  it("returns undefined when the line is absent", () => {
+  it("returns undefined when the line is absent (preserve existing)", () => {
     expect(extractDogFriendly("Hares: TBD")).toBeUndefined();
+  });
+
+  it.each([
+    "Dog friendly: Depends on the hare",
+    "Dog friendly: Ask first",
+  ])("returns null (explicit clear) when present but unparseable: %s", (line) => {
+    expect(extractDogFriendly(line)).toBeNull();
   });
 });
 

--- a/src/adapters/html-scraper/phoenixhhh.test.ts
+++ b/src/adapters/html-scraper/phoenixhhh.test.ts
@@ -925,7 +925,9 @@ describe("extractDogFriendly (#1350)", () => {
   it.each([
     "Dog friendly: Depends on the hare",
     "Dog friendly: Ask first",
-  ])("returns null (explicit clear) when present but unparseable: %s", (line) => {
+    "Dog friendly:",
+    "Dog friendly:   ",
+  ])("returns null (explicit clear) when present but blank/unparseable: %s", (line) => {
     expect(extractDogFriendly(line)).toBeNull();
   });
 });

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -140,15 +140,19 @@ export function extractVenueFromDescription(description: string): string | undef
 // Some detail pages separate the labeled fields with `<p>` boundaries
 // ("Hash Cash: $1\n\nDog friendly: …"); others mash them onto a single line
 // with NO separator ("…vesselHash Cash: $1Cash Needed…Dog friendly: Usually
-// not on humpsOn-After: …"). Inject a newline before each known label so the
+// not on humpsOn-After: …"). Insert a newline before each known label so the
 // line-anchored extractors + description cleaner work uniformly on both shapes
-// (mirrors the FIELD_LABEL_SPLIT_RE approach in seven-hills-h3.ts). Each
-// alternative carries its own literal colon — no `\s*` adjacent to the
-// alternation, so Sonar S5852 (ReDoS) doesn't fire.
-const PHOENIX_LABEL_BOUNDARY_RE =
-  /(?=Hares:|Where:|When:|Time:|Bring:|Hash Cash:|Cash Needed on Trail:|Dog[ -]?friendly:|On[- ]?On:|On-After:|Things you probably won['’]t need:)/gi;
+// (mirrors the FIELD_LABEL_SPLIT_RE approach in seven-hills-h3.ts). The label
+// set is split across two regexes so neither trips Sonar's regex-complexity cap
+// (S5843, threshold 20); each alternative carries its own literal colon, so no
+// `\s*` sits adjacent to the alternation (S5852 ReDoS) either.
+const PHOENIX_LABELS_A_RE = /(Hares:|Where:|When:|Time:|Bring:|Hash Cash:)/gi;
+const PHOENIX_LABELS_B_RE =
+  /(Cash Needed on Trail:|Dog[ -]?friendly:|On[- ]?On:|On-After:|Things you probably won['’]t need:)/gi;
 export function normalizePhoenixDetailBlock(description: string): string {
-  return description.replaceAll(PHOENIX_LABEL_BOUNDARY_RE, "\n");
+  return description
+    .replaceAll(PHOENIX_LABELS_A_RE, "\n$1")
+    .replaceAll(PHOENIX_LABELS_B_RE, "\n$1");
 }
 
 /** "6:30 pm - 9:30 pm" → end time "21:30" (#1348). Returns undefined when the

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -177,20 +177,24 @@ function normalizeCash(value: string): string {
   return value.trim().toLowerCase().replaceAll(/\s+/g, "");
 }
 
-/** `Dog friendly: <value>` line → boolean (#1350). Returns undefined when the
- *  line is absent or the value is too hedged to classify (caller leaves the
- *  raw line in the description in that case). */
+/** `Dog friendly: <value>` line → tri-state (#1350), per the RawEventData
+ *  explicit-clear contract (atomic-bundle semantics, adapter-patterns.md):
+ *    - label absent              → undefined (no signal; preserve existing)
+ *    - value classifiable        → true / false
+ *    - label present, unparseable → null (clear any stale Event.dogFriendly) */
 const DOG_LINE_RE = /(?:^|\n)[ \t]*Dog[\s-]?friendly[ \t]*:[ \t]*([^\n]+)/i;
 const DOG_NO_RE = /\b(?:no|not|never|none)\b/i;
 const DOG_YES_RE = /\b(?:yes|welcome|welcomed|ok|okay|sure|allowed|leash|leashed|friendly|encouraged|always)\b/i;
-export function extractDogFriendly(description: string): boolean | undefined {
+export function extractDogFriendly(description: string): boolean | null | undefined {
   const m = DOG_LINE_RE.exec(description);
-  const value = m?.[1]?.trim();
-  if (!value) return undefined;
+  if (m == null) return undefined;
+  const value = m[1].trim();
   // Negative wins first — "Usually not on humps" must classify as false.
   if (DOG_NO_RE.test(value)) return false;
   if (DOG_YES_RE.test(value)) return true;
-  return undefined;
+  // Label present but the value is empty or too hedged to classify → explicit
+  // clear so a stale boolean from a prior scrape doesn't linger.
+  return null;
 }
 
 /** Strip lines now promoted to structured fields so they don't duplicate in
@@ -584,6 +588,8 @@ export class PhoenixHHHAdapter implements SourceAdapter {
       const normalized = normalizePhoenixDetailBlock(e.description);
       const rawCash = extractHashCash(normalized);
       const dog = extractDogFriendly(normalized);
+      // Tri-state: undefined = no label (preserve), null = unparseable (clear),
+      // boolean = classified. null/boolean both propagate to the merge contract.
       if (dog !== undefined) e.dogFriendly = dog;
       // Two-Tier: only persist a per-event cost when it differs from the
       // kennel's standard hash cash (#1349). Hump D ($1 == $1) → cost stays null.
@@ -593,7 +599,9 @@ export class PhoenixHHHAdapter implements SourceAdapter {
       }
       e.description = cleanPhoenixDescription(normalized, {
         stripHashCash: rawCash !== undefined,
-        stripDogFriendly: dog !== undefined,
+        // Keep the raw `Dog friendly:` line when it was unparseable (dog === null)
+        // so the hedged text stays visible; only strip once classified.
+        stripDogFriendly: typeof dog === "boolean",
       });
     }
 

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -23,6 +23,14 @@ interface PhoenixHHHConfig {
   kennelPatterns: [string, string][];
   defaultKennelTag: string;
   pageId?: number; // defaults to 21
+  /**
+   * Per-kennel standard hash cash (Two-Tier Hash Cash Model). Keyed by
+   * kennelCode. The detail page carries a `Hash Cash:` line on every event;
+   * we only promote it to `Event.cost` when it DIFFERS from the kennel's
+   * standard here (#1349). When it matches, the kennel-profile `hashCash`
+   * already covers it, so a per-event override would be redundant noise.
+   */
+  kennelHashCash?: Record<string, string>;
 }
 
 // ── Exported helpers (for unit testing) ──
@@ -117,6 +125,85 @@ export function extractVenueFromDescription(description: string): string | undef
     }
   }
   return undefined;
+}
+
+// ── #1348/#1349/#1350: structured field extraction from the detail block ──
+// The Big Ass Calendar event detail page carries a labeled key:value block,
+// e.g.:
+//   Time: Meet at 6:30 PM, Hares off at 6:45, Hounds to follow at 7:00.
+//   Bring: Proper illumination...
+//   Hash Cash: $1
+//   Dog friendly: Usually not on humps
+//   On-After: Usually The Same Place We Started from
+// The list-view time meta ("6:30 pm - 9:30 pm") is the reliable end-time source.
+
+// Some detail pages separate the labeled fields with `<p>` boundaries
+// ("Hash Cash: $1\n\nDog friendly: …"); others mash them onto a single line
+// with NO separator ("…vesselHash Cash: $1Cash Needed…Dog friendly: Usually
+// not on humpsOn-After: …"). Inject a newline before each known label so the
+// line-anchored extractors + description cleaner work uniformly on both shapes
+// (mirrors the FIELD_LABEL_SPLIT_RE approach in seven-hills-h3.ts). Each
+// alternative carries its own literal colon — no `\s*` adjacent to the
+// alternation, so Sonar S5852 (ReDoS) doesn't fire.
+const PHOENIX_LABEL_BOUNDARY_RE =
+  /(?=Hares:|Where:|When:|Time:|Bring:|Hash Cash:|Cash Needed on Trail:|Dog[ -]?friendly:|On[- ]?On:|On-After:|Things you probably won['’]t need:)/gi;
+export function normalizePhoenixDetailBlock(description: string): string {
+  return description.replaceAll(PHOENIX_LABEL_BOUNDARY_RE, "\n");
+}
+
+/** "6:30 pm - 9:30 pm" → end time "21:30" (#1348). Returns undefined when the
+ *  meta line has no range. `parse12HourTime` reads the first match, so slice
+ *  after the dash to grab the closing time. */
+export function parseTimeRangeEnd(timeText: string): string | undefined {
+  const m = /[-–—]\s*(.+)$/.exec(timeText);
+  return m ? parse12HourTime(m[1]) : undefined;
+}
+
+/** `Hash Cash: $1` → `$1` (#1349). Single labeled line; value to EOL. */
+const HASH_CASH_LINE_RE = /(?:^|\n)[ \t]*Hash[ \t]*Cash[ \t]*:[ \t]*([^\n]+)/i;
+export function extractHashCash(description: string): string | undefined {
+  const m = HASH_CASH_LINE_RE.exec(description);
+  const value = m?.[1]?.trim();
+  return value || undefined;
+}
+
+/** Normalize a hash-cash string for equality (`"$1 "` == `"$1"`). */
+function normalizeCash(value: string): string {
+  return value.trim().toLowerCase().replaceAll(/\s+/g, "");
+}
+
+/** `Dog friendly: <value>` line → boolean (#1350). Returns undefined when the
+ *  line is absent or the value is too hedged to classify (caller leaves the
+ *  raw line in the description in that case). */
+const DOG_LINE_RE = /(?:^|\n)[ \t]*Dog[\s-]?friendly[ \t]*:[ \t]*([^\n]+)/i;
+const DOG_NO_RE = /\b(?:no|not|never|none)\b/i;
+const DOG_YES_RE = /\b(?:yes|welcome|welcomed|ok|okay|sure|allowed|leash|leashed|friendly|encouraged|always)\b/i;
+export function extractDogFriendly(description: string): boolean | undefined {
+  const m = DOG_LINE_RE.exec(description);
+  const value = m?.[1]?.trim();
+  if (!value) return undefined;
+  // Negative wins first — "Usually not on humps" must classify as false.
+  if (DOG_NO_RE.test(value)) return false;
+  if (DOG_YES_RE.test(value)) return true;
+  return undefined;
+}
+
+/** Strip lines now promoted to structured fields so they don't duplicate in
+ *  the free-text description (#1350). `Hash Cash` is always dropped once seen
+ *  (it either became `Event.cost` or equals the kennel default); `Dog friendly`
+ *  is dropped only when we successfully classified it. */
+export function cleanPhoenixDescription(
+  description: string,
+  opts: { stripHashCash: boolean; stripDogFriendly: boolean },
+): string | undefined {
+  const kept = description.split("\n").filter((line) => {
+    const t = line.trim();
+    if (opts.stripHashCash && /^Hash[ \t]*Cash[ \t]*:/i.test(t)) return false;
+    if (opts.stripDogFriendly && /^Dog[\s-]?friendly[ \t]*:/i.test(t)) return false;
+    return true;
+  });
+  const out = kept.join("\n").replaceAll(/\n{3,}/g, "\n\n").trim();
+  return out || undefined;
 }
 
 /** Detail-page extraction result. Null fields mean "missing on the page"
@@ -229,9 +316,10 @@ export function parseEventFromItem(
     date = parsed;
   }
 
-  // Time extraction: "6:30 pm - 9:30 pm"
+  // Time extraction: "6:30 pm - 9:30 pm" → start + end (#1348)
   const timeText = $item.find(".em-item-meta-line.em-event-time").text().trim();
   const startTime = parse12HourTime(timeText);
+  const endTime = parseTimeRangeEnd(timeText);
 
   // Location — try link text first, fall back to plain text in meta line
   const locationMeta = $item.find(".em-item-meta-line.em-event-location");
@@ -287,6 +375,7 @@ export function parseEventFromItem(
     hares,
     location,
     startTime,
+    endTime,
     sourceUrl,
   };
 }
@@ -476,6 +565,31 @@ export class PhoenixHHHAdapter implements SourceAdapter {
         if (detail.description) batch[j].description = detail.description;
         if (detail.hares) batch[j].hares = detail.hares;
       }
+    }
+
+    // ── Structured field extraction from the (now detail-enriched) description ──
+    // cost (#1349), dogFriendly (#1350). Runs after detail enrichment so it
+    // reads the authoritative full body, and after kennel-tag re-resolution so
+    // the Two-Tier cost comparison uses the correct kennel default.
+    const kennelHashCash = config.kennelHashCash ?? {};
+    for (const e of allEvents) {
+      if (!e.description) continue;
+      // Normalize the two detail-block shapes (separated vs. single-line mashed)
+      // into one-label-per-line before extracting + cleaning.
+      const normalized = normalizePhoenixDetailBlock(e.description);
+      const rawCash = extractHashCash(normalized);
+      const dog = extractDogFriendly(normalized);
+      if (dog !== undefined) e.dogFriendly = dog;
+      // Two-Tier: only persist a per-event cost when it differs from the
+      // kennel's standard hash cash (#1349). Hump D ($1 == $1) → cost stays null.
+      const standard = kennelHashCash[e.kennelTags[0]];
+      if (rawCash && (!standard || normalizeCash(rawCash) !== normalizeCash(standard))) {
+        e.cost = rawCash;
+      }
+      e.description = cleanPhoenixDescription(normalized, {
+        stripHashCash: rawCash !== undefined,
+        stripDogFriendly: dog !== undefined,
+      });
     }
 
     if (allParseErrors.length > 0) {

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -182,7 +182,7 @@ function normalizeCash(value: string): string {
  *    - label absent              → undefined (no signal; preserve existing)
  *    - value classifiable        → true / false
  *    - label present, unparseable → null (clear any stale Event.dogFriendly) */
-const DOG_LINE_RE = /(?:^|\n)[ \t]*Dog[\s-]?friendly[ \t]*:[ \t]*([^\n]+)/i;
+const DOG_LINE_RE = /(?:^|\n)[ \t]*Dog[\s-]?friendly[ \t]*:[ \t]*([^\n]*)/i;
 const DOG_NO_RE = /\b(?:no|not|never|none)\b/i;
 const DOG_YES_RE = /\b(?:yes|welcome|welcomed|ok|okay|sure|allowed|leash|leashed|friendly|encouraged|always)\b/i;
 export function extractDogFriendly(description: string): boolean | null | undefined {
@@ -192,8 +192,8 @@ export function extractDogFriendly(description: string): boolean | null | undefi
   // Negative wins first — "Usually not on humps" must classify as false.
   if (DOG_NO_RE.test(value)) return false;
   if (DOG_YES_RE.test(value)) return true;
-  // Label present but the value is empty or too hedged to classify → explicit
-  // clear so a stale boolean from a prior scrape doesn't linger.
+  // Label present but the value is empty/blank or too hedged to classify →
+  // explicit clear so a stale boolean from a prior scrape doesn't linger.
   return null;
 }
 
@@ -591,11 +591,14 @@ export class PhoenixHHHAdapter implements SourceAdapter {
       // Tri-state: undefined = no label (preserve), null = unparseable (clear),
       // boolean = classified. null/boolean both propagate to the merge contract.
       if (dog !== undefined) e.dogFriendly = dog;
-      // Two-Tier: only persist a per-event cost when it differs from the
-      // kennel's standard hash cash (#1349). Hump D ($1 == $1) → cost stays null.
+      // Two-Tier (#1349): when the detail page shows a Hash Cash line, persist a
+      // per-event cost only if it DIFFERS from the kennel's standard; when it
+      // matches, emit null (explicit clear) so a stale per-event override is
+      // wiped on re-scrape rather than preserved. Hump D ($1 == $1) → null.
       const standard = kennelHashCash[e.kennelTags[0]];
-      if (rawCash && (!standard || normalizeCash(rawCash) !== normalizeCash(standard))) {
-        e.cost = rawCash;
+      if (rawCash !== undefined) {
+        e.cost =
+          standard && normalizeCash(rawCash) === normalizeCash(standard) ? null : rawCash;
       }
       e.description = cleanPhoenixDescription(normalized, {
         stripHashCash: rawCash !== undefined,

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -156,11 +156,12 @@ export function normalizePhoenixDetailBlock(description: string): string {
 }
 
 /** "6:30 pm - 9:30 pm" → end time "21:30" (#1348). Returns undefined when the
- *  meta line has no range. `parse12HourTime` reads the first match, so slice
- *  after the dash to grab the closing time. */
+ *  meta line has no range. Locate the dash with a quantifier-free char class
+ *  (no ReDoS surface — Sonar S5852), then let `parse12HourTime` pull the closing
+ *  time from the trailing slice. */
 export function parseTimeRangeEnd(timeText: string): string | undefined {
-  const m = /[-–—]\s*(.+)$/.exec(timeText);
-  return m ? parse12HourTime(m[1]) : undefined;
+  const dashIdx = timeText.search(/[-–—]/);
+  return dashIdx < 0 ? undefined : parse12HourTime(timeText.slice(dashIdx + 1));
 }
 
 /** `Hash Cash: $1` → `$1` (#1349). Single labeled line; value to EOL. */

--- a/src/adapters/html-scraper/phuket-hhh.test.ts
+++ b/src/adapters/html-scraper/phuket-hhh.test.ts
@@ -46,6 +46,59 @@ describe("parsePhuketRow", () => {
     expect(event!.startTime).toBe("16:00");
     expect(event!.hares).toContain("B.C.");
     expect(event!.hares).toContain("FUNGUS");
+    // #1410: source-faithful title from name + run columns, no synthesized "Trail".
+    expect(event!.title).toBe("PHHH 2062");
+  });
+
+  // ── #1410: source-faithful title (kennel name + run number, no "Trail" word) ──
+  it.each([
+    { rowClass: "ironpussy", name: "Iron Pussy", run: "265", expected: "Iron Pussy 265" },
+    { rowClass: "tinmen", name: "Tinmen", run: "451", expected: "Tinmen 451" },
+    { rowClass: "pooying", name: "Pooying", run: "414", expected: "Pooying 414" },
+  ])(
+    "(#1410) emits '$expected' title without a synthesized Trail suffix",
+    ({ rowClass, name, run, expected }) => {
+      const cells = ["13 May 2026 @ 16:00 PM", name, run, "", ""];
+      const event = parsePhuketRow(cells, rowClass, DEFAULT_KENNEL_MAP, sourceUrl);
+      expect(event!.title).toBe(expected);
+    },
+  );
+
+  it("(#1410) leaves title undefined when the name cell is blank", () => {
+    const cells = ["13 May 2026 @ 16:00 PM", "", "265", "", ""];
+    const event = parsePhuketRow(cells, "ironpussy", DEFAULT_KENNEL_MAP, sourceUrl);
+    expect(event!.title).toBeUndefined();
+  });
+
+  // ── #1411: recruitment CTA in the HARES column → explicit clear (null) ──
+  // null (not undefined) so the merge pipeline OVERWRITES stale haresText
+  // instead of preserving it (merge.ts: undefined = preserve, null = clear).
+  it.each([
+    "Want to hare? Contact the Runmaster",
+    "want to hare",
+    "Hare needed",
+    "Looking for a hare",
+  ])("(#1411) maps CTA-only hares cell %s → null (explicit clear)", (cta) => {
+    const cells = ["10 May 2026 @ 16:00 PM", "Iron Pussy", "265", cta, ""];
+    const event = parsePhuketRow(cells, "ironpussy", DEFAULT_KENNEL_MAP, sourceUrl);
+    expect(event!.hares).toBeNull();
+  });
+
+  it("(#1411) a genuinely blank hares cell stays undefined (preserve, not clear)", () => {
+    const cells = ["10 May 2026 @ 16:00 PM", "Iron Pussy", "265", "", ""];
+    const event = parsePhuketRow(cells, "ironpussy", DEFAULT_KENNEL_MAP, sourceUrl);
+    expect(event!.hares).toBeUndefined();
+  });
+
+  it.each([
+    { cell: "FUNGUS, LUCKY LEK, B.C.", expected: "B.C., FUNGUS, LUCKY LEK" },
+    { cell: "PAPER", expected: "PAPER" },
+    { cell: "Slippery When Wet", expected: "Slippery When Wet" },
+    { cell: "BUNNYKEN PIS\nLA LASAGNA", expected: "BUNNYKEN PIS, LA LASAGNA" },
+  ])("(#1411) keeps real hare names $cell", ({ cell, expected }) => {
+    const cells = ["10 May 2026 @ 16:00 PM", "Iron Pussy", "265", cell, ""];
+    const event = parsePhuketRow(cells, "ironpussy", DEFAULT_KENNEL_MAP, sourceUrl);
+    expect(event!.hares).toBe(expected);
   });
 
   it("parses a Pooying row", () => {

--- a/src/adapters/html-scraper/phuket-hhh.ts
+++ b/src/adapters/html-scraper/phuket-hhh.ts
@@ -157,7 +157,7 @@ export function parsePhuketRow(
   const kennelName = decodeEntities(cells[1] ?? "").trim();
   let title: string | undefined;
   if (kennelName) {
-    title = runNumber !== undefined ? `${kennelName} ${runNumber}` : kennelName;
+    title = runNumber === undefined ? kennelName : `${kennelName} ${runNumber}`;
   }
 
   // Hares column (#1327): one hare per <br>-delimited line; sort + comma-join

--- a/src/adapters/html-scraper/phuket-hhh.ts
+++ b/src/adapters/html-scraper/phuket-hhh.ts
@@ -4,6 +4,7 @@ import { hasAnyErrors } from "../types";
 import {
   applyDateWindow,
   chronoParseDate,
+  CTA_EMBEDDED_PATTERNS,
   decodeEntities,
   fetchHTMLPage,
   normalizeHaresField,
@@ -81,14 +82,36 @@ const PHUKET_DIRECTIONS_RE =
 /** Placeholder-only venue values that should resolve to undefined location. */
 const PHUKET_PLACEHOLDER_VENUE_RE = /^(?:location:\s*tbc|tbc|tbd)$/i;
 
-/** Hares cell → comma-joined sorted list (stable fingerprint per project rule). */
-function parsePhuketHares(cell: string | undefined): string | undefined {
-  if (!cell) return undefined;
-  const segments = splitCellSegments(cell);
-  if (segments.length === 0) return undefined;
-  return normalizeHaresField(
-    [...segments].sort((a, b) => a.localeCompare(b)).join(", "),
+/**
+ * Hare-recruitment CTA the source drops into the HARES column when no hare has
+ * signed up (#1411), e.g. "Want to hare? Contact the Runmaster". The shared
+ * `CTA_EMBEDDED_PATTERNS` cover the "hares needed / wanted" family; this adds the
+ * verb-form "want to hare" phrasing specific to this source.
+ */
+const PHUKET_HARE_CTA_RE = /\bwant\s+to\s+hare\b/i;
+
+/** True when a hares-cell segment is a recruitment CTA rather than a real hare name. */
+function isHareRecruitmentCta(segment: string): boolean {
+  return (
+    PHUKET_HARE_CTA_RE.test(segment) ||
+    CTA_EMBEDDED_PATTERNS.some((re) => re.test(segment))
   );
+}
+
+/** Hares cell → comma-joined sorted list (stable fingerprint per project rule).
+ *  Recruitment CTAs (#1411) are dropped. Tri-state per the merge contract
+ *  (RawEventData.hares — `null` overwrites stale haresText, `undefined` preserves):
+ *    - nullish / blank cell        → undefined (no signal; keep any existing value)
+ *    - cell that is ONLY a CTA     → null (explicit clear, so a previously stored
+ *                                    CTA / now-stale hare text is overwritten)
+ *    - real hare names present     → normalized list */
+function parsePhuketHares(cell: string | undefined): string | null | undefined {
+  if (!cell) return undefined;
+  const all = splitCellSegments(cell);
+  if (all.length === 0) return undefined;
+  const real = all.filter((s) => !isHareRecruitmentCta(s));
+  if (real.length === 0) return null;
+  return normalizeHaresField([...real].sort((a, b) => a.localeCompare(b)).join(", ")) ?? null;
 }
 
 /** Location cell → venue (first <br>-segment, directions stripped) + description (remaining segments). */
@@ -127,6 +150,16 @@ export function parsePhuketRow(
   const runNumberMatch = /(\d+)/.exec(cells[2] ?? "");
   const runNumber = runNumberMatch ? Number.parseInt(runNumberMatch[1], 10) : undefined;
 
+  // #1410: the source row carries the kennel name + run number ("Iron Pussy 265")
+  // and has no separate "Trail" word. Emit that source-faithful title explicitly so
+  // the merge pipeline does NOT synthesize its default "<Kennel> Trail #N" suffix.
+  // When the name cell is blank, leave title undefined and let merge fall back.
+  const kennelName = decodeEntities(cells[1] ?? "").trim();
+  let title: string | undefined;
+  if (kennelName) {
+    title = runNumber !== undefined ? `${kennelName} ${runNumber}` : kennelName;
+  }
+
   // Hares column (#1327): one hare per <br>-delimited line; sort + comma-join
   // for stable fingerprint per project rule.
   const hares = parsePhuketHares(cells[3]);
@@ -138,6 +171,7 @@ export function parsePhuketRow(
   return {
     date,
     kennelTags: [kennelTag],
+    title,
     runNumber,
     hares,
     location,

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -63,6 +63,7 @@ import { SamuraiH3Adapter } from "./html-scraper/samurai-h3";
 import { NewTokyoKatchAdapter } from "./html-scraper/new-tokyo-katch";
 import { Hayama4HAdapter } from "./html-scraper/hayama-4h";
 import { SevenHillsH3Adapter } from "./html-scraper/seven-hills-h3";
+import { DCFMH3Adapter } from "./html-scraper/dcfmh3";
 import { Oh3OttawaAdapter } from "./html-scraper/oh3-ottawa";
 import { CalgaryH3HomeAdapter } from "./html-scraper/calgary-h3-home";
 import { CalgaryH3ScribeAdapter } from "./html-scraper/calgary-h3-scribe";
@@ -195,6 +196,7 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /newtokyohash.*wixsite/i, name: "NewTokyoKatchAdapter", factory: () => new NewTokyoKatchAdapter() },
   { pattern: /sites\.google\.com\/site\/hayama4h/i, name: "Hayama4HAdapter", factory: () => new Hayama4HAdapter() },
   { pattern: /sites\.google\.com\/view\/7h4/i, name: "SevenHillsH3Adapter", factory: () => new SevenHillsH3Adapter() },
+  { pattern: /sites\.google\.com\/site\/dcfmh3/i, name: "DCFMH3Adapter", factory: () => new DCFMH3Adapter() },
   { pattern: /kansascityh3\.com/i, name: "KCH3Adapter", factory: () => new KCH3Adapter() },
   { pattern: /big-hump\.com/i, name: "BigHumpAdapter", factory: () => new BigHumpAdapter() },
   { pattern: /stlh3\.com/i, name: "StlH3Adapter", factory: () => new StlH3Adapter() },


### PR DESCRIPTION
Deep-dive schema-gap drain across 3 kennels / 3 non-GCal adapters. `Event.endTime`, `cost`, `dogFriendly` and the `EventKennel` co-host model already exist, so this is extraction/wiring — **no Prisma migration**.

## Hump D — `phoenixhhh.ts` (#1348 / #1349 / #1350)
- **endTime** parsed from the meta-line time range (`6:30 pm - 9:30 pm` → `21:30`).
- **cost** — Two-Tier Hash Cash: the `Hash Cash:` line is promoted to `Event.cost` only when it **differs** from the kennel's standard (threaded via a `kennelHashCash` config map). Hump D ($1 == kennel default) stays null; siblings without a seeded default surface verbatim.
- **dogFriendly** parsed to a boolean; **Bring / On-After / Cash Needed on Trail** have no schema home → folded cleanly into the description.
- Detail pages come in two markup variants (`\n\n`-separated and a fully **mashed** single line). A label-boundary normalizer (mirrors `seven-hills-h3.ts`) makes extraction work on both — the mashed variant was silently dropping every field before this.

## Iron Pussy / all Phuket kennels — `phuket-hhh.ts` (#1410 / #1411 / #1412)
- **#1410** emit a source-faithful title (`Iron Pussy 265`) so merge stops synthesizing a `Trail #N` suffix.
- **#1411** strip the `Want to hare? Contact the Runmaster` recruitment CTA from the hares column, emitting **`null`** (explicit clear per the merge contract) so a previously-stored CTA is overwritten — not preserved. Negative fixtures keep real hare names.
- **#1412** the `OnOn at <venue>` on-after has no Event field → kept cleanly in the description (documented schema-gap).

## DCFMH3 — new `dcfmh3.ts` Google Sites scraper (#1399 / #1400)
- Replaces the STATIC_SCHEDULE (lunar) source whose titles were the generic **"DCFMH3 Full Moon Run"** placeholder and whose dates drifted 1–3 days. The new scraper parses the published schedule → **real moon/host titles on the correct dates** (#1399).
- **#1400** the rotating host kennel rides as an **`EventKennel` co-host** (#1023) when it maps to a seeded kennel (ewh3, dch3, dch4, cch3, mvh3, fuh3, h4); unseeded hosts stay in the title only. **Decision: reuse EventKennel — no new schema column.**
- Legacy STATIC_SCHEDULE source kept as `enabled: false` so `prisma db seed` disables the old generator deterministically (its identity is `(name, type)`, so the new row can't migrate it in place).

## Verification
- All three adapters **live-verified** against production: Phuket (14 events, faithful titles, zero CTA leaks), Hump D (endTime + cost-suppressed + dogFriendly on both markup variants), DCFMH3 (13 events, correct dates, 7 co-host tags).
- Fixture-backed unit tests next to each adapter; `npm run lint`, `npx tsc --noEmit`, `npm test` (8217) all green.
- `/codex:adversarial-review` → **approve**; `/simplify` applied (reuse `stripHtmlTags`).

## Post-merge runbook (seed data — Vercel doesn't run `prisma db seed`)
1. `npx prisma db seed` — flips DCFMH3 to HTML_SCRAPER, disables the legacy lunar source, adds Phoenix `kennelHashCash`.
2. Re-scrape DCFMH3 + Phoenix + Phuket (Phuket/Hump D self-heal in place via merge's update branch; DCFMH3 creates new dated events).
3. `npx tsx scripts/cleanup-dcfmh3-placeholder-events.ts` (dry run), then `CLEANUP_APPLY=1 …` to remove the stale "DCFMH3 Full Moon Run" placeholder events.

Closes #1348
Closes #1349
Closes #1350
Closes #1410
Closes #1411
Closes #1412
Closes #1399
Closes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)