### PR TITLE
fix(gcal): systemic title/hare/theme/location extraction + GCal-routed fields (12 issues)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2869,6 +2869,13 @@ export const KENNELS: KennelSeed[] = [
       foundedYear: 1997,
       description: "Osaka hash kennel running in Japan's second-largest city and the Kansai region.",
       latitude: 34.69, longitude: 135.50,
+      // #1872 profile bundle (fields published on the kennel's site).
+      logoUrl: "https://kfmh3.github.io/Home/OsakaH3_Logo.png",
+      gm: "Ero Massage",
+      hareRaiser: "Blue Cherry Boy",
+      hashCash: "¥1,000",
+      scheduleFrequency: "Irregular",
+      scheduleNotes: "Runs are scheduled ad-hoc rather than on a fixed weekly slot; recent trails cluster on weekends. Check the kennel's site for the next run.",
     },
 
     // ── Belgium: Brussels ──

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -200,6 +200,11 @@ export const SOURCES = [
           ["Boston Moo[mn]|Full Moon|\\bMoo[mn]\\b", "bos-moon"],
           ["Boston H3|Boston Hash|BoH3|BH3", "boh3"],
         ],
+        // #1891: BH3 events carry a "BH3:" title prefix and stash the run
+        // number in the description ("BH #2805"). Strip the prefix; pull the
+        // run number from the description. (Same precedent as Morgantown #1726.)
+        titleStripPatterns: [String.raw`^BH3:\s*`],
+        runNumberPatterns: [String.raw`BH\s*#\s*(\d+)`],
       },
       kennelCodes: ["boh3", "bobbh3", "beantown", "bos-moon", "pink-taco", "zigzag", "e4b"],
     },
@@ -427,6 +432,13 @@ export const SOURCES = [
         includeAllDayEvents: true,
         defaultTitle: "EWH3 Trail",
         defaultStartTime: "18:45",
+        // #1892: summaries are "{theme} - {location}" (e.g. "Autism Speaks for
+        // Deities & Friends! - Dupont Circle"). Capture the post-dash location
+        // into locationName and strip it from the title. Deliberately NO
+        // titleHarePattern — the pre-dash text is a run theme, not hares.
+        // "… - Location TBD" is rejected by the adapter's placeholder-token
+        // guard (the "TBD" token), so it never becomes a location.
+        titleLocationPattern: String.raw`\s+-\s+(\S.*)$`,
       },
       kennelCodes: ["ewh3"],
     },
@@ -1475,7 +1487,16 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "every_6h",
       scrapeDays: 365,
-      config: { defaultKennelTag: "swh3" },
+      config: {
+        defaultKennelTag: "swh3",
+        // #1881: hare follows the LAST dash, with or without a run number:
+        // "SWH3 #1794 -Pukey", "SWH3- I Do Greek and Frau Farter",
+        // "SWH3- Bad Beer Hash- PITA" (→ PITA). Single-kennel source, so the
+        // un-anchored last-dash capture is safe; the looksLikeHareName gate
+        // rejects placeholder/kennel-code captures.
+        titleHarePattern: String.raw`-\s*([^-]+)$`,
+        defaultTitle: "SWH3 Trail",
+      },
       kennelCodes: ["swh3"],
     },
     {
@@ -2332,6 +2353,17 @@ export const SOURCES = [
           String.raw`^Kah-Two-Na\b`,
           String.raw`^Ka-Three-Na\b`,
         ],
+        // #1868: hares appear in the title suffix ("OH3 #1370 Boner Spur!",
+        // "OH3 #1366 w/ Mouthful") for events whose description has no "Who:"
+        // line (which DEFAULT_HARE_PATTERNS already handles). First pattern:
+        // "w/|with|featuring <hare>"; second: "OH3 #N <hare>". Char-class
+        // captures exclude "/" and "#" so co-host titles ("OH3 #1340 / Cherry
+        // City H3 #1") don't leak the sibling into hares; trailing "!" is
+        // absorbed by the span so the title cleans to "OH3 #N".
+        titleHarePattern: [
+          String.raw`(?:w/|with|featuring)\s+([^/#!]+)!*\s*$`,
+          String.raw`^OH3(?:\s+Full Moon)?\s*#\s*\d+\s+([^/#!]+)!*\s*$`,
+        ],
       },
       kennelCodes: ["oh3", "tgif", "cch3-or"],
     },
@@ -2530,6 +2562,14 @@ export const SOURCES = [
         // the all-day filter (#1021). strictKennelRouting bounds the blast radius —
         // anything not matching kennelPatterns is still discarded.
         includeAllDayEvents: true,
+        // #1406: HSWTF events whose summary is just the bare kennel code
+        // "HSWTFH3" fall through to a placeholder title. Map them to a real
+        // default and treat the bare code as a stale alias so the fallback
+        // fires. (#1407 — the "(2011)" year suffix on Analversary events is NOT
+        // a run number: extractHashRunNumber requires a "#", so it is already
+        // ignored; covered by a regression test.)
+        defaultTitles: { "hswtf-h3": "HSWTF Trail" },
+        staleTitleAliases: { "hswtf-h3": ["HSWTFH3"] },
       },
       kennelCodes: ["sh3-wa", "psh3", "nbh3-wa", "rch3-wa", "seamon-h3", "th3-wa", "ssh3-wa", "cunth3-wa", "taint-h3", "giggity-h3", "seh3-wa", "hswtf-h3", "leapyear-h3"],
     },
@@ -2759,6 +2799,14 @@ export const SOURCES = [
           ["\\bMH3\\b", "mh3-mn"]
         ],
         defaultKennelTag: "mh3-mn",
+        // #1884: title embeds the hare ("MH3 #1984 - B Knuckles") AND the
+        // description carries the canonical "Hare : Butt Knuckles" line. The
+        // description hare wins; alwaysStripTitleHareSpan still strips the
+        // "- B Knuckles" suffix off the title. Anchored to MH3+run so the
+        // shared T3H3 rows are untouched.
+        titleHarePattern: String.raw`^MH3\s*#?\s*\d+\s*-\s*(.+)$`,
+        alwaysStripTitleHareSpan: true,
+        defaultTitles: { "mh3-mn": "Minneapolis H3 Trail" },
       },
       kennelCodes: ["mh3-mn", "t3h3"],
     },

--- a/scripts/cleanup-ewh3-stale-theme-hares.ts
+++ b/scripts/cleanup-ewh3-stale-theme-hares.ts
@@ -1,0 +1,59 @@
+/**
+ * #1892 cleanup — null EWH3 canonical `haresText` that is actually the run
+ * THEME, not hares. The pre-#1227 Google Calendar adapter routed the pre-dash
+ * summary text ("Autism Speaks for Deities & Friends! - Dupont Circle") into
+ * haresText; the current adapter no longer does (no titleHarePattern for EWH3),
+ * but the merge pipeline preserves the stale value (undefined = keep).
+ *
+ * Precise + safe: only clears rows where `haresText` EQUALS the title or the
+ * title's pre-dash prefix (the theme). Legit hares supplied by sibling sources
+ * (Hash Rego / WordPress — "PSA & Haystack", "PhD and Tatas") differ from the
+ * title and are left untouched.
+ *
+ * Run AFTER the seed config + re-scrape have deployed (so a cron scrape in the
+ * gap doesn't re-add it). Dry-run by default:
+ *   set -a && source .env && set +a && npx tsx scripts/cleanup-ewh3-stale-theme-hares.ts
+ * Apply: append ` -- --apply`.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const APPLY = process.argv.includes("--apply");
+
+function isThemeHares(title: string | null, hares: string): boolean {
+  if (!title) return false;
+  const t = title.trim();
+  const h = hares.trim();
+  if (t === h) return true;
+  const dash = t.search(/\s+-\s+/);
+  if (dash !== -1 && t.slice(0, dash).trim() === h) return true;
+  return false;
+}
+
+async function main() {
+  const events = await prisma.event.findMany({
+    where: { eventKennels: { some: { kennel: { kennelCode: "ewh3" } } }, haresText: { not: null } },
+    select: { id: true, date: true, title: true, haresText: true },
+    orderBy: { date: "desc" },
+  });
+  const targets = events.filter((e) => e.haresText && isThemeHares(e.title, e.haresText));
+  console.log(`EWH3 events with haresText: ${events.length}; theme-as-hares to clear: ${targets.length}`);
+  for (const e of targets) {
+    console.log(`  ${e.date.toISOString().slice(0, 10)} title=${JSON.stringify(e.title)} hares=${JSON.stringify(e.haresText)}`);
+  }
+  if (!APPLY) {
+    console.log("\nDry run — re-run with ` -- --apply` to clear haresText on the above.");
+    await prisma.$disconnect();
+    return;
+  }
+  let cleared = 0;
+  for (const e of targets) {
+    await prisma.event.update({ where: { id: e.id }, data: { haresText: null } });
+    cleared++;
+  }
+  // Mirror into the structured EventHare rows if any were synthesized from the theme.
+  console.log(`\nCleared haresText on ${cleared} EWH3 events.`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/cleanup-ewh3-stale-theme-hares.ts
+++ b/scripts/cleanup-ewh3-stale-theme-hares.ts
@@ -25,9 +25,9 @@ function isThemeHares(title: string | null, hares: string): boolean {
   const t = title.trim();
   const h = hares.trim();
   if (t === h) return true;
-  const dash = t.search(/\s+-\s+/);
-  if (dash !== -1 && t.slice(0, dash).trim() === h) return true;
-  return false;
+  // pre-dash prefix (string op, not regex — avoids a Sonar ReDoS flag)
+  const dash = t.indexOf(" - ");
+  return dash !== -1 && t.slice(0, dash).trim() === h;
 }
 
 async function main() {
@@ -43,7 +43,6 @@ async function main() {
   }
   if (!APPLY) {
     console.log("\nDry run — re-run with ` -- --apply` to clear haresText on the above.");
-    await prisma.$disconnect();
     return;
   }
   let cleared = 0;
@@ -51,9 +50,9 @@ async function main() {
     await prisma.event.update({ where: { id: e.id }, data: { haresText: null } });
     cleared++;
   }
-  // Mirror into the structured EventHare rows if any were synthesized from the theme.
   console.log(`\nCleared haresText on ${cleared} EWH3 events.`);
-  await prisma.$disconnect();
 }
 
-main().catch((e) => { console.error(e); process.exit(1); });
+main()
+  .catch((e) => { console.error(e); process.exitCode = 1; })
+  .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-hswtf-placeholder-titles.ts
+++ b/scripts/cleanup-hswtf-placeholder-titles.ts
@@ -1,0 +1,69 @@
+/**
+ * #1406 cleanup — rewrite historical HSWTF (hswtf-h3) canonical titles that
+ * still carry the bare kennel-code placeholder "HSWTFH3…". These ~102 events
+ * (2013–2017) predate the WA Hash calendar's scrape window, so they will never
+ * re-scrape; the forward fix (defaultTitles + staleTitleAliases on the source)
+ * only helps future/in-window events.
+ *
+ * Rewrites by shape, deriving a real title where the source encoded one:
+ *   "HSWTFH3 #99 (99 problems…)"  → "99 problems…"            (theme in parens)
+ *   "HSWTFH3 #153"                → "HSWTF Trail #153"
+ *   "HSWTFH3# 62"                 → "HSWTF Trail #62"
+ *   "HSWTFH3 <free text>"         → "<free text>"
+ *   "HSWTFH3" / "HSWTFH3 #?"      → "HSWTF Trail"
+ *
+ * Dry-run by default:
+ *   set -a && source .env && set +a && npx tsx scripts/cleanup-hswtf-placeholder-titles.ts
+ * Apply: append ` -- --apply`.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const APPLY = process.argv.includes("--apply");
+const DEFAULT_TITLE = "HSWTF Trail";
+
+interface Rewrite { title: string; runNumber?: number }
+
+function rewriteTitle(raw: string): Rewrite | null {
+  const t = raw.trim();
+  // #N (theme) — theme wins as the title; keep the run number.
+  let m = /^HSWTFH3\s*#\s*(\d+)\s*\((.+)\)\s*$/.exec(t);
+  if (m) return { title: m[2].trim(), runNumber: Number.parseInt(m[1], 10) };
+  // bare #N (optionally with a space-before-or-after #) → "HSWTF Trail #N"
+  m = /^HSWTFH3\s*#?\s*(\d+)\s*$/.exec(t);
+  if (m) return { title: `${DEFAULT_TITLE} #${m[1]}`, runNumber: Number.parseInt(m[1], 10) };
+  // bare code or unknown-run placeholder → generic default
+  if (/^HSWTFH3\s*(?:#\s*\?+)?\s*$/.test(t)) return { title: DEFAULT_TITLE };
+  // "HSWTFH3 <free text>" (no leading #) → use the free text as the title
+  m = /^HSWTFH3\s+(?!#)(\S.*)$/.exec(t);
+  if (m) return { title: m[1].trim() };
+  return null; // leave anything unrecognized untouched
+}
+
+async function main() {
+  const events = await prisma.event.findMany({
+    where: { eventKennels: { some: { kennel: { kennelCode: "hswtf-h3" } } }, title: { contains: "HSWTFH3" } },
+    select: { id: true, date: true, title: true, runNumber: true },
+    orderBy: { date: "asc" },
+  });
+  console.log(`HSWTF events with 'HSWTFH3' in title: ${events.length}`);
+  let planned = 0, skipped = 0;
+  for (const e of events) {
+    const rw = rewriteTitle(e.title ?? "");
+    if (!rw || rw.title === e.title) { skipped++; continue; }
+    planned++;
+    const runNote = rw.runNumber && rw.runNumber !== e.runNumber ? ` run ${e.runNumber}→${rw.runNumber}` : "";
+    console.log(`  ${e.date.toISOString().slice(0, 10)} ${JSON.stringify(e.title)} → ${JSON.stringify(rw.title)}${runNote}`);
+    if (APPLY) {
+      await prisma.event.update({
+        where: { id: e.id },
+        data: { title: rw.title, ...(rw.runNumber && e.runNumber == null ? { runNumber: rw.runNumber } : {}) },
+      });
+    }
+  }
+  console.log(`\n${APPLY ? "Applied" : "Planned"}: ${planned}; unchanged: ${skipped}`);
+  if (!APPLY) console.log("Dry run — re-run with ` -- --apply` to write the above.");
+  await prisma.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/cleanup-hswtf-placeholder-titles.ts
+++ b/scripts/cleanup-hswtf-placeholder-titles.ts
@@ -26,17 +26,21 @@ interface Rewrite { title: string; runNumber?: number }
 
 function rewriteTitle(raw: string): Rewrite | null {
   const t = raw.trim();
-  // #N (theme) — theme wins as the title; keep the run number.
-  let m = /^HSWTFH3\s*#\s*(\d+)\s*\((.+)\)\s*$/.exec(t);
+  if (!t.startsWith("HSWTFH3")) return null;
+  // Strip the kennel-code prefix and work on the remainder with anchored
+  // regexes that use bounded char classes (no `(.+)` / doubled `\s+` — those
+  // shapes trip Sonar's ReDoS hotspot, S5852).
+  const rest = t.slice("HSWTFH3".length).trim();
+  // "#N (theme)" — theme wins as the title; keep the run number.
+  let m = /^#\s*(\d+)\s*\(([^)]+)\)$/.exec(rest);
   if (m) return { title: m[2].trim(), runNumber: Number.parseInt(m[1], 10) };
-  // bare #N (optionally with a space-before-or-after #) → "HSWTF Trail #N"
-  m = /^HSWTFH3\s*#?\s*(\d+)\s*$/.exec(t);
+  // "#N" (optionally a space after #) → "HSWTF Trail #N"
+  m = /^#\s*(\d+)$/.exec(rest);
   if (m) return { title: `${DEFAULT_TITLE} #${m[1]}`, runNumber: Number.parseInt(m[1], 10) };
-  // bare code or unknown-run placeholder → generic default
-  if (/^HSWTFH3\s*(?:#\s*\?+)?\s*$/.test(t)) return { title: DEFAULT_TITLE };
-  // "HSWTFH3 <free text>" (no leading #) → use the free text as the title
-  m = /^HSWTFH3\s+(?!#)(\S.*)$/.exec(t);
-  if (m) return { title: m[1].trim() };
+  // empty remainder or unknown-run placeholder ("#?", "#??") → generic default
+  if (rest === "" || /^#\s*\?+$/.test(rest)) return { title: DEFAULT_TITLE };
+  // free text not starting with "#" → use it verbatim as the title
+  if (!rest.startsWith("#")) return { title: rest };
   return null; // leave anything unrecognized untouched
 }
 
@@ -63,7 +67,8 @@ async function main() {
   }
   console.log(`\n${APPLY ? "Applied" : "Planned"}: ${planned}; unchanged: ${skipped}`);
   if (!APPLY) console.log("Dry run — re-run with ` -- --apply` to write the above.");
-  await prisma.$disconnect();
 }
 
-main().catch((e) => { console.error(e); process.exit(1); });
+main()
+  .catch((e) => { console.error(e); process.exitCode = 1; })
+  .finally(() => prisma.$disconnect());

--- a/scripts/live-verify-gcal-hare-theme-bundle.ts
+++ b/scripts/live-verify-gcal-hare-theme-bundle.ts
@@ -1,0 +1,169 @@
+/**
+ * Live verification for the systemic GCal title/hare/theme/location fixes
+ * (#1892 EWH3, #1881 SWH3, #1884 MH3-Mpls, #1882 Capital-AU, #1891 Boston,
+ * #1868 Oregon, #1873 Osaka, #1401 FCMH3 endTime, #1406/#1407 HSWTF).
+ *
+ * Run: `set -a && source .env && set +a && npx tsx scripts/live-verify-gcal-hare-theme-bundle.ts`
+ *
+ * Read-only — does not mutate the DB. Fetches live Google Calendar data through
+ * the real adapter + the seed config, prints samples, and counts regressions.
+ */
+import "dotenv/config";
+import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
+import type { RawEventData } from "@/adapters/types";
+import { SOURCES } from "../prisma/seed-data/sources";
+import type { Source } from "@/generated/prisma/client";
+
+interface Check {
+  label: string;
+  predicate: (e: RawEventData) => boolean;
+}
+interface Target {
+  sourceName: string;
+  describe: string;
+  /** Restrict to events for this kennel tag (multi-kennel calendars). */
+  kennelTag?: string;
+  checks: Check[];
+  summary?: (events: RawEventData[]) => string[];
+  sampleLimit?: number;
+}
+
+function fmt(e: RawEventData): string {
+  const time = e.startTime ?? "all-day";
+  const end = e.endTime ? `-${e.endTime}` : "";
+  return `[${e.date} ${time}${end}] run=${e.runNumber ?? "—"} title=${JSON.stringify((e.title ?? "").slice(0, 70))} hares=${JSON.stringify(e.hares ?? null)} loc=${JSON.stringify(e.location ?? null)}`;
+}
+
+// A run theme leaking into hares (the #1892 class). Heuristic for *reporting*
+// only — not used by the adapter.
+const THEME_IN_HARES_RE = /speaks|friends|trail$|annual|christmas|halloween|birthday/i;
+
+const TARGETS: Target[] = [
+  {
+    sourceName: "EWH3 Google Calendar",
+    describe: "#1892 — theme not in hares; '- Location' → locationName",
+    checks: [
+      { label: "theme-shaped hares", predicate: (e) => !!e.hares && THEME_IN_HARES_RE.test(e.hares) },
+      { label: "title still contains ' - '", predicate: (e) => !!e.title && / - /.test(e.title) && !!e.location },
+    ],
+    summary: (ev) => [`with hares: ${ev.filter((e) => e.hares).length}`, `with location: ${ev.filter((e) => e.location).length}`],
+    sampleLimit: 12,
+  },
+  {
+    sourceName: "SWH3 Google Calendar",
+    describe: "#1881 — hare after last dash extracted; run# kept",
+    // No hard predicate: events whose hare came from the description keep a
+    // theme-style title suffix ("SWH3#1588- AGM" / hares "Ex GM's"), which is
+    // correct. The hares fill-rate is the signal.
+    checks: [],
+    summary: (ev) => [`with hares: ${ev.filter((e) => e.hares).length}/${ev.length}`],
+    sampleLimit: 15,
+  },
+  {
+    sourceName: "Minneapolis H3 Calendar",
+    describe: "#1884 — hare from description; '- B Knuckles' stripped from title",
+    kennelTag: "mh3-mn",
+    checks: [
+      { label: "title contains ' - ' (un-stripped hare)", predicate: (e) => !!e.title && / - /.test(e.title) },
+    ],
+    summary: (ev) => [`with hares: ${ev.filter((e) => e.hares).length}/${ev.length}`],
+    sampleLimit: 12,
+  },
+  {
+    sourceName: "Capital Hash Calendar",
+    describe: "#1882 — no 'CH3'/'vacant' garbage hares/location",
+    checks: [
+      { label: "hares = CH3 / vacant", predicate: (e) => !!e.hares && /^(?:ch3|vacant)$/i.test(e.hares.trim()) },
+      { label: "location contains 'vacant'", predicate: (e) => !!e.location && /vacant/i.test(e.location) },
+    ],
+    sampleLimit: 12,
+  },
+  {
+    sourceName: "Boston Hash Calendar",
+    describe: "#1891 — 'BH3:' prefix stripped; run# from description",
+    kennelTag: "boh3",
+    checks: [
+      { label: "title still has 'BH3:' prefix", predicate: (e) => !!e.title && /^BH3:/i.test(e.title) },
+    ],
+    summary: (ev) => [`with runNumber: ${ev.filter((e) => e.runNumber).length}/${ev.length}`],
+    sampleLimit: 12,
+  },
+  {
+    sourceName: "Oregon Hashing Calendar",
+    describe: "#1868 — hares extracted from title/description",
+    kennelTag: "oh3",
+    checks: [
+      // Only flag genuine OH3-titled events; the Oregon aggregator also
+      // mis-defaults stray EH3/OKH3 rows to oh3 whose description hares may
+      // contain "w/" (a separate routing concern, out of scope here).
+      { label: "OH3-title hares leak '/' or '#'", predicate: (e) => !!e.hares && /[/#]/.test(e.hares) && /^OH3\b/i.test(e.title ?? "") },
+    ],
+    summary: (ev) => [`with hares: ${ev.filter((e) => e.hares).length}/${ev.length}`],
+    sampleLimit: 15,
+  },
+  {
+    sourceName: "Osaka H3 Google Calendar",
+    describe: "#1873 — hares from 'Hare:' description line",
+    checks: [],
+    summary: (ev) => [`with hares: ${ev.filter((e) => e.hares).length}/${ev.length}`],
+    sampleLimit: 12,
+  },
+  {
+    sourceName: "Chicagoland Hash Calendar",
+    describe: "#1401 — First Crack (fcmh3) endTime present",
+    kennelTag: "fcmh3",
+    checks: [],
+    summary: (ev) => [`with endTime: ${ev.filter((e) => e.endTime).length}/${ev.length}`],
+    sampleLimit: 10,
+  },
+  {
+    sourceName: "WA Hash Google Calendar",
+    describe: "#1406/#1407 — HSWTF: no 'HSWTFH3' title, no run=2011",
+    kennelTag: "hswtf-h3",
+    checks: [
+      { label: "placeholder title 'HSWTFH3'", predicate: (e) => e.title === "HSWTFH3" },
+      { label: "run number = 2011", predicate: (e) => e.runNumber === 2011 },
+    ],
+    sampleLimit: 15,
+  },
+];
+
+async function runTarget(adapter: GoogleCalendarAdapter, t: Target): Promise<number> {
+  const seedRow = SOURCES.find((s) => s.name === t.sourceName);
+  console.log(`\n## ${t.sourceName}\n   ${t.describe}`);
+  if (!seedRow) { console.log("   NOT FOUND IN SEED"); return 1; }
+  const source = {
+    id: "stub", name: seedRow.name, url: seedRow.url,
+    type: seedRow.type as Source["type"], enabled: true,
+    config: (seedRow as { config?: unknown }).config ?? null,
+  } as unknown as Source;
+  try {
+    const result = await adapter.fetch(source, { days: 1500 });
+    let events = result.events;
+    if (t.kennelTag) events = events.filter((e) => e.kennelTags?.includes(t.kennelTag!));
+    console.log(`   events: ${events.length}${t.kennelTag ? ` (filtered to ${t.kennelTag})` : ""}`);
+    for (const line of t.summary?.(events) ?? []) console.log(`   ${line}`);
+    let failed = 0;
+    for (const c of t.checks) {
+      const violators = events.filter(c.predicate);
+      console.log(`   ${c.label}: ${violators.length} (expect 0)`);
+      failed += violators.length;
+      for (const e of violators.slice(0, 5)) console.log(`     VIOLATION ${fmt(e)}`);
+    }
+    for (const e of events.slice(0, t.sampleLimit ?? 10)) console.log(`   ${fmt(e)}`);
+    return failed;
+  } catch (err) {
+    console.log(`   FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+async function main() {
+  if (!process.env.GOOGLE_CALENDAR_API_KEY) throw new Error("GOOGLE_CALENDAR_API_KEY not set — source .env first");
+  const adapter = new GoogleCalendarAdapter();
+  let failures = 0;
+  for (const t of TARGETS) failures += await runTarget(adapter, t);
+  console.log(failures === 0 ? "\n✓ All targets clean" : `\n✗ ${failures} regression(s)/fetch failure(s)`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/scripts/live-verify-gcal-hare-theme-bundle.ts
+++ b/scripts/live-verify-gcal-hare-theme-bundle.ts
@@ -141,7 +141,8 @@ async function runTarget(adapter: GoogleCalendarAdapter, t: Target): Promise<num
     const result = await adapter.fetch(source, { days: 1500 });
     let events = result.events;
     if (t.kennelTag) events = events.filter((e) => e.kennelTags?.includes(t.kennelTag!));
-    console.log(`   events: ${events.length}${t.kennelTag ? ` (filtered to ${t.kennelTag})` : ""}`);
+    const scope = t.kennelTag ? ` (filtered to ${t.kennelTag})` : "";
+    console.log(`   events: ${events.length}${scope}`);
     for (const line of t.summary?.(events) ?? []) console.log(`   ${line}`);
     let failed = 0;
     for (const c of t.checks) {

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -5106,7 +5106,7 @@ describe("SWH3 title-embedded hare (#1881)", () => {
 
 describe("MH3-Mpls title hare + alwaysStripTitleHareSpan (#1884)", () => {
   const config = {
-    kennelPatterns: [["\\bT3H3\\b|Twin Titties", "t3h3"], ["\\bMH3\\b", "mh3-mn"]] as [string, string][],
+    kennelPatterns: [[String.raw`\bT3H3\b|Twin Titties`, "t3h3"], [String.raw`\bMH3\b`, "mh3-mn"]] as [string, string][],
     defaultKennelTag: "mh3-mn",
     titleHarePattern: String.raw`^MH3\s*#?\s*\d+\s*-\s*(.+)$`,
     alwaysStripTitleHareSpan: true,

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -18,6 +18,7 @@ import {
   extractRunDescriptorTheme,
   splitTimedSummaryHareLocation,
   stripGluedDescriptionEcho,
+  looksLikeHareName,
 } from "./adapter";
 import { compilePatterns } from "../utils";
 import type { RawEventData } from "../types";
@@ -1409,13 +1410,15 @@ describe("titleHarePattern — hare extraction from summary", () => {
 
   it("classifies by match position, not hare-text coincidence", () => {
     // Regression: if hareText coincidentally equals a leading substring
-    // of the title, content-based startsWith() would misroute to the
-    // prefix branch and leave the "Hare:" label behind. Position-based
-    // classification (start === 0) routes to the mid-match branch.
+    // of the title ("Dusty #880 Hare: Dusty"), content-based startsWith()
+    // would misroute to the prefix branch and leave the "Hare:" label
+    // behind. Position-based classification (start === 0) routes to the
+    // mid-match branch. (Uses a real hash name, not the kennel code — the
+    // looksLikeHareName gate rejects bare kennel codes like "AH3", #1882.)
     const pattern = /Hare:\s+(.+?)(?:\s*$)/i;
     const result = buildRawEventFromGCalItem(
       testGCalEvent({
-        summary: "AH3 #880 Hare: AH3",
+        summary: "Dusty #880 Hare: Dusty",
         start: { dateTime: "2026-05-01T12:00:00-10:00" },
       }),
       {
@@ -1423,8 +1426,8 @@ describe("titleHarePattern — hare extraction from summary", () => {
         titleHarePattern: String.raw`Hare:\s+(.+?)(?:\s*$)`,
       }, { compiledTitleHarePatterns: [pattern] });
     expect(result).not.toBeNull();
-    expect(result!.hares).toBe("AH3");
-    expect(result!.title).toBe("AH3 #880");
+    expect(result!.hares).toBe("Dusty");
+    expect(result!.title).toBe("Dusty #880");
   });
 
   it("description hares take priority over title hares", () => {
@@ -5048,5 +5051,178 @@ describe("GoogleCalendarAdapter — composite-key dedup of duplicate series (#11
         fetchSpy.mockRestore();
       }
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Systemic title/hare/theme/location hygiene (deep-dive: #1892 #1881 #1884
+// #1882 #1868 #1407) — narrow looksLikeHareName gate + per-kennel config.
+// ---------------------------------------------------------------------------
+
+describe("looksLikeHareName — narrow hare-shape gate (#1882)", () => {
+  it.each([
+    ["", false],
+    ["vacant", false],
+    ["VACANT", false],
+    ["TBD", false],
+    ["TBA", false],
+    ["CH3", false],
+    ["SWH3", false],
+    ["MH3", false],
+    ["BH3", false],
+    // Real hash names — multi-word, &/and/comma-joined, 2-char — MUST pass:
+    ["Butt Knuckles", true],
+    ["Boner Spur", true],
+    ["Darkstar Porkestra", true],
+    ["Dead Woody and Pukey", true],
+    ["I Do Greek and Frau Farter", true],
+    ["Jaba the Slut & Stop, Drop, and Puke", true],
+    ["DJ", true],
+    ["MJ", true],
+    ["Pukey", true],
+  ])("looksLikeHareName(%j) === %s", (input, expected) => {
+    expect(looksLikeHareName(input)).toBe(expected);
+  });
+});
+
+describe("SWH3 title-embedded hare (#1881)", () => {
+  const config = { defaultKennelTag: "swh3", titleHarePattern: String.raw`-\s*([^-]+)$`, defaultTitle: "SWH3 Trail" };
+  const o = { compiledTitleHarePatterns: compilePatterns([config.titleHarePattern], "i") };
+  const build = (summary: string) =>
+    buildRawEventFromGCalItem({ summary, start: { dateTime: "2026-06-07T14:00:00-04:00" }, status: "confirmed" }, config, o);
+
+  it.each([
+    ["SWH3 #1794 -Pukey", "Pukey", 1794],
+    ["SWH3 #1780- Buki", "Buki", 1780],
+    ["SWH3- I Do Greek and Frau Farter", "I Do Greek and Frau Farter", undefined],
+    ["SWH3- Bad Beer Hash- PITA", "PITA", undefined],
+  ])("%j → hares %j, run %s", (summary, hares, run) => {
+    const e = build(summary)!;
+    expect(e.hares).toBe(hares);
+    expect(e.runNumber ?? undefined).toBe(run);
+    expect(e.title).not.toContain(`-${hares}`);
+  });
+});
+
+describe("MH3-Mpls title hare + alwaysStripTitleHareSpan (#1884)", () => {
+  const config = {
+    kennelPatterns: [["\\bT3H3\\b|Twin Titties", "t3h3"], ["\\bMH3\\b", "mh3-mn"]] as [string, string][],
+    defaultKennelTag: "mh3-mn",
+    titleHarePattern: String.raw`^MH3\s*#?\s*\d+\s*-\s*(.+)$`,
+    alwaysStripTitleHareSpan: true,
+    defaultTitles: { "mh3-mn": "Minneapolis H3 Trail" },
+  };
+  const o = { compiledTitleHarePatterns: compilePatterns([config.titleHarePattern], "i") };
+  const build = (summary: string, description?: string) =>
+    buildRawEventFromGCalItem({ summary, start: { dateTime: "2026-05-31T15:00:00-05:00" }, status: "confirmed", description }, config, o);
+
+  it("description 'Hare : Butt Knuckles' wins; title suffix stripped", () => {
+    const e = build("MH3 #1984 - B Knuckles", "Hare : Butt Knuckles\nTheme: 1984")!;
+    expect(e.hares).toBe("Butt Knuckles");
+    expect(e.title).toBe("Minneapolis H3 Trail #1984");
+  });
+
+  it("no description → hare taken from title suffix", () => {
+    const e = build("MH3 #1984 - B Knuckles")!;
+    expect(e.hares).toBe("B Knuckles");
+    expect(e.title).toBe("Minneapolis H3 Trail #1984");
+  });
+});
+
+describe("EWH3 theme stays out of hares; '- Location' → locationName (#1892)", () => {
+  const config = { defaultKennelTag: "ewh3", defaultTitle: "EWH3 Trail", titleLocationPattern: String.raw`\s+-\s+(\S.*)$` };
+  const o = { compiledTitleLocationPatterns: compilePatterns([config.titleLocationPattern], "i") };
+  const build = (summary: string) =>
+    buildRawEventFromGCalItem({ summary, start: { dateTime: "2026-06-04T18:45:00-04:00" }, status: "confirmed" }, config, o);
+
+  it("'{theme}! - {location}' → theme title, location extracted, hares null", () => {
+    const e = build("Autism Speaks for Deities & Friends! - Dupont Circle")!;
+    expect(e.hares ?? null).toBeNull();
+    expect(e.location).toBe("Dupont Circle");
+    expect(e.title).toBe("Autism Speaks for Deities & Friends!");
+  });
+
+  it("'{theme} - Location TBD' placeholder location not extracted", () => {
+    const e = build("Mystery Trail - Location TBD")!;
+    expect(e.location ?? null).toBeNull();
+    expect(e.hares ?? null).toBeNull();
+  });
+
+  it("real venue with a placeholder-vocabulary word is NOT dropped (Volunteer Park)", () => {
+    const e = build("Mystery Trail - Volunteer Park")!;
+    expect(e.location).toBe("Volunteer Park");
+    expect(e.title).toBe("Mystery Trail");
+  });
+});
+
+describe("Capital-AU placeholder slot yields no garbage (#1882)", () => {
+  const config = {
+    defaultKennelTag: "capital-h3-au",
+    titleHarePattern: String.raw`^(.+?)\s+\d+\s+[A-Z]`,
+    titleLocationPattern: String.raw`(\d+\s+.+?)\.?\s*$`,
+    mergeAllDayRunDescriptor: true,
+  };
+  const opts = () => ({
+    allDayEventSet: new WeakSet<RawEventData>(),
+    gcalIdMap: new WeakMap<RawEventData, string>(),
+    summaryMap: new WeakMap<RawEventData, string>(),
+    compiledTitleHarePatterns: compilePatterns([config.titleHarePattern], "i"),
+    compiledTitleLocationPatterns: compilePatterns([config.titleLocationPattern], "i"),
+  });
+
+  it("'Run #2398' + '6pm CH3 - vacant' merge → no hares/location garbage", () => {
+    const o = opts();
+    const descriptor = buildRawEventFromGCalItem({ summary: "Run #2398", start: { date: "2026-06-15" }, status: "confirmed", id: "d" }, config, o)!;
+    const timed = buildRawEventFromGCalItem({ summary: "6pm CH3 - vacant", start: { dateTime: "2026-06-15T18:00:00+10:00" }, status: "confirmed", id: "t" }, config, o)!;
+    const { events } = dedupGCalEvents([descriptor, timed], o.gcalIdMap, o.allDayEventSet, true, o.summaryMap);
+    expect(events).toHaveLength(1);
+    expect(events[0].runNumber).toBe(2398);
+    expect(events[0].hares ?? null).toBeNull();
+    expect(events[0].location ?? null).toBeNull();
+  });
+
+  it("'CH3 - vacant - Restaurant run' merge → location not set", () => {
+    const o = opts();
+    const descriptor = buildRawEventFromGCalItem({ summary: "Run #2409", start: { date: "2026-08-24" }, status: "confirmed", id: "d" }, config, o)!;
+    const timed = buildRawEventFromGCalItem({ summary: "6pm CH3 - vacant - Restaurant run", start: { dateTime: "2026-08-24T18:00:00+10:00" }, status: "confirmed", id: "t" }, config, o)!;
+    const { events } = dedupGCalEvents([descriptor, timed], o.gcalIdMap, o.allDayEventSet, true, o.summaryMap);
+    expect(events[0].location ?? null).toBeNull();
+  });
+});
+
+describe("Oregon title hare extraction (#1868)", () => {
+  const config = {
+    defaultKennelTag: "oh3",
+    titleHarePattern: [
+      String.raw`(?:w/|with|featuring)\s+([^/#!]+)!*\s*$`,
+      String.raw`^OH3(?:\s+Full Moon)?\s*#\s*\d+\s+([^/#!]+)!*\s*$`,
+    ],
+  };
+  const o = { compiledTitleHarePatterns: compilePatterns(config.titleHarePattern, "i") };
+  const build = (summary: string) =>
+    buildRawEventFromGCalItem({ summary, start: { dateTime: "2026-05-23T12:30:00-07:00" }, status: "confirmed" }, config, o);
+
+  it.each([
+    ["OH3 #1370 Boner Spur!", "Boner Spur"],
+    ["OH3 #1366 w/ Mouthful", "Mouthful"],
+    ["OH3 Full Moon #1365 / PH4 #???? w/ Darkstar Porkestra", "Darkstar Porkestra"],
+  ])("%j → hares %j", (summary, hares) => {
+    expect(build(summary)!.hares).toBe(hares);
+  });
+
+  it("co-host title 'OH3 # 1340 / Cherry City H3 #1' does not leak sibling into hares", () => {
+    const e = build("OH3 # 1340 / Cherry City H3 #1")!;
+    expect(e.hares ?? null).toBeNull();
+  });
+});
+
+describe("HSWTF run-number guard — parenthetical year is not a run number (#1407)", () => {
+  it("'HSWTF Analversary (2011)' → runNumber undefined", () => {
+    const e = buildRawEventFromGCalItem(
+      { summary: "HSWTF Analversary (2011)", start: { date: "2026-08-07" }, status: "confirmed" },
+      { defaultKennelTag: "hswtf-h3", includeAllDayEvents: true },
+      {},
+    )!;
+    expect(e.runNumber ?? undefined).toBeUndefined();
   });
 });

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -488,7 +488,7 @@ const MAX_HARE_PAREN_LENGTH = 40;
  * blanket all-caps reject: real 2-3-char hash names ("DJ", "MJ", "FBI") do NOT
  * end in H+digit and still pass the gate. See #1882 (Capital H3 "CH3 - vacant").
  */
-const BARE_KENNEL_CODE_RE = /^[A-Za-z][A-Za-z0-9]*H[0-9]$/;
+const BARE_KENNEL_CODE_RE = /^[A-Za-z][A-Za-z\d]*H\d$/;
 
 /**
  * Narrow reject-gate applied wherever the adapter routes *title-derived* text

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -482,6 +482,57 @@ const DATE_RANGE_PAREN_RE = /\b\d{1,2}\s*\/\s*\d{1,2}\b/;
 const MAX_HARE_PAREN_LENGTH = 40;
 
 /**
+ * A bare kennel-code token like "CH3", "SWH3", "MH3", "BH3" — the kennel's
+ * own abbreviation, never a hash name. Shape: starts with a letter, ends with
+ * "H<digit>" (the H3/H4/H5 hash-family marker). Deliberately tighter than a
+ * blanket all-caps reject: real 2-3-char hash names ("DJ", "MJ", "FBI") do NOT
+ * end in H+digit and still pass the gate. See #1882 (Capital H3 "CH3 - vacant").
+ */
+const BARE_KENNEL_CODE_RE = /^[A-Za-z][A-Za-z0-9]*H[0-9]$/;
+
+/**
+ * Narrow reject-gate applied wherever the adapter routes *title-derived* text
+ * into `haresText`. Rejects only what is unambiguously NOT a hash name:
+ * placeholders ("vacant", "TBD", "Hares Needed", …) and bare kennel-code
+ * tokens. It deliberately has NO fuzzy theme/word-count/punctuation heuristic —
+ * hash names are routinely multi-word, "&"/"and"/comma-joined, and exclamatory
+ * (e.g. "Jaba the Slut & Stop, Drop, and Puke", "Just the Tip!"), so any such
+ * heuristic would false-reject real names. Run themes that aren't hares (e.g.
+ * EWH3 "Autism Speaks for Deities & Friends!") are kept out of `haresText` by
+ * NOT configuring a `titleHarePattern` for that source, not by this gate.
+ *
+ * Not applied to description-derived hares (extractHares), which come from
+ * explicit "Hare:" labels already filtered in hare-extraction.ts.
+ */
+export function looksLikeHareName(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  if (isPlaceholder(t)) return false;
+  if (BARE_KENNEL_CODE_RE.test(t)) return false;
+  return true;
+}
+
+/**
+ * A "this slot has no real value" token — used per-token inside a location
+ * candidate. Deliberately NARROW (only vacancy markers), NOT the full
+ * `isPlaceholder` vocabulary: that set includes ordinary venue words like
+ * "volunteer"/"registration" which appear in real place names ("Volunteer
+ * Park"). See the Codex review note on #1882.
+ */
+const VACANCY_TOKEN_RE = /^(?:vacant|tbd|tba|tbc|n\/a)$/i;
+
+/**
+ * True when any dash/whitespace-delimited token of `text` is a vacancy marker.
+ * Rejects titleLocationPattern / merge captures like "3 - vacant" (#1882
+ * Capital H3: the `(\d+\s+.+)` address pattern grabs the "3" out of
+ * "CH3 - vacant") and "Location TBD" — which the anchored whole-string
+ * `isPlaceholder` check misses — without dropping real multi-word venues.
+ */
+function containsPlaceholderToken(text: string): boolean {
+  return text.split(/[\s–—-]+/).some((tok) => VACANCY_TOKEN_RE.test(tok));
+}
+
+/**
  * #1444 Larryville: detect "initials wordplay" parentheticals like
  * `LH3 #670 DP (dirtier pickle)` where the parenthetical is a punning
  * lowercase expansion of the uppercase token immediately preceding it.
@@ -895,6 +946,15 @@ interface CalendarSourceConfig {
    *  hit wins. The matched span is stripped from the title. Candidates that
    *  trip `isPlaceholder()` (e.g. "venue TBC") are rejected (#1222). */
   titleLocationPattern?: string | string[];
+  /**
+   * When true, the `titleHarePattern` span is stripped from the title even when
+   * the canonical hare came from the description (#1884 MH3-Mpls: title
+   * "MH3 #1984 - B Knuckles" + description "Hare : Butt Knuckles" — keep the
+   * description hare, but still strip the "- B Knuckles" suffix off the title).
+   * Default (off) preserves the description-priority-keeps-title contract for
+   * every other titleHarePattern kennel.
+   */
+  alwaysStripTitleHareSpan?: boolean;
   /**
    * Regex strings applied as `title.replace(re, "")` in sequence after hare
    * extraction and before the `defaultTitle` fallback. Compiled with `i`
@@ -1320,7 +1380,12 @@ export function buildRawEventFromGCalItem(
   // matched so the downstream title-cleanup block uses the same regex span.
   let haresFromTitle = false;
   let matchedTitleHarePattern: RegExp | undefined;
-  if (!hares && compiledTitleHarePatterns?.length) {
+  // Run the title-hare patterns when hares are still missing, OR when the source
+  // opts into `alwaysStripTitleHareSpan` (#1884 MH3-Mpls): there the canonical
+  // hare comes from the description's "Hare:" line, but the title still carries a
+  // "- HareName" suffix that must be stripped. In that mode we record the matched
+  // span for the title-cleanup block below WITHOUT overwriting the description hare.
+  if (compiledTitleHarePatterns?.length && (!hares || sourceConfig?.alwaysStripTitleHareSpan === true)) {
     for (const re of compiledTitleHarePatterns) {
       const titleMatch = re.exec(summary);
       if (titleMatch?.[1]) {
@@ -1332,9 +1397,14 @@ export function buildRawEventFromGCalItem(
           .replace(/^\s*[-–—:]+\s*|\s*[-–—:]+\s*$/g, "") // NOSONAR — anchored char-class alternation
           .trim();
         if (cleaned) {
-          hares = cleaned;
-          haresFromTitle = true;
+          // Record the span so the title-cleanup block strips it regardless.
           matchedTitleHarePattern = re;
+          // Assign hares only when none yet AND the capture looks like a hash
+          // name (not a placeholder / bare kennel code, #1882).
+          if (!hares && looksLikeHareName(cleaned)) {
+            hares = cleaned;
+            haresFromTitle = true;
+          }
           break;
         }
       }
@@ -1522,7 +1592,7 @@ export function buildRawEventFromGCalItem(
   // and suffix patterns (hares at end: "AH3 #1833 - Location - Hare Name").
   // The prior code assumed prefix-only and did title.slice(captureGroup.length),
   // which mangled titles when the capture group was at the end.
-  if (haresFromTitle && matchedTitleHarePattern) {
+  if (matchedTitleHarePattern && (haresFromTitle || sourceConfig?.alwaysStripTitleHareSpan === true)) {
     const titleMatch = matchedTitleHarePattern.exec(title);
     if (titleMatch && titleMatch[1]) {
       const hareText = titleMatch[1];
@@ -1576,7 +1646,7 @@ export function buildRawEventFromGCalItem(
       const locMatch = re.exec(title);
       if (locMatch?.[1]) {
         const candidate = locMatch[1].trim().replace(/[.,;:\s]+$/, "").trim(); // NOSONAR — anchored end-of-string char-class
-        if (candidate && !isPlaceholder(candidate)) {
+        if (candidate && !isPlaceholder(candidate) && !containsPlaceholderToken(candidate)) {
           location = candidate;
           title = (title.slice(0, locMatch.index) + title.slice(locMatch.index + locMatch[0].length))
             .replaceAll(/^\s*[-–—:]+\s*|\s*[-–—:]+\s*$/g, "") // NOSONAR — anchored char-class alternation, mirrors title-hare strip
@@ -1597,7 +1667,7 @@ export function buildRawEventFromGCalItem(
     if (wMatch) {
       const wHares = wMatch[1].trim();
       const wLocation = wMatch[2].trim();
-      if (!hares && !isPlaceholder(wHares)) hares = wHares;
+      if (!hares && looksLikeHareName(wHares)) hares = wHares;
       if (!location && !isPlaceholder(wLocation)) location = wLocation;
       title = title.slice(0, wMatch.index).trim();
     }
@@ -1627,6 +1697,7 @@ export function buildRawEventFromGCalItem(
     // expansion). Real hash names — Title Case, lowercase-multi-word,
     // mixed-case — still pass through.
     const isNameLike =
+      looksLikeHareName(inner) &&
       !NON_NAME_PAREN_RE.test(inner) &&
       !ACRONYM_PAREN_RE.test(inner) &&
       !isInitialsWordplay(title, inner, parenMatch.index);
@@ -1641,14 +1712,16 @@ export function buildRawEventFromGCalItem(
   // Dash-separated hare suffix: "Title - Hare(s): Name" (H5, OCHHH)
   const dashHareMatch = TITLE_DASH_HARE_RE.exec(title);
   if (dashHareMatch) {
-    if (!hares) hares = dashHareMatch[1].trim();
+    const dashHare = dashHareMatch[1].trim();
+    if (!hares && looksLikeHareName(dashHare)) hares = dashHare;
     title = title.slice(0, dashHareMatch.index).trim();
   }
 
   // "hared by Name" suffix: "Voodoo Trail #1032 hared by The Iceman" (Voodoo H3)
   const haredByMatch = TITLE_HARED_BY_RE.exec(title);
   if (haredByMatch) {
-    if (!hares) hares = haredByMatch[1].trim();
+    const haredBy = haredByMatch[1].trim();
+    if (!hares && looksLikeHareName(haredBy)) hares = haredBy;
     title = title.slice(0, haredByMatch.index).trim();
   }
 
@@ -1988,8 +2061,14 @@ function applyDescriptorToTimed(
   summaryMap?: WeakMap<RawEventData, string>,
 ): void {
   const { hare, location } = splitTimedSummaryHareLocation(summaryMap?.get(timed) ?? timed.title ?? "");
-  if (!timed.hares && hare) timed.hares = hare;
-  if (!timed.location && location) timed.location = location;
+  // A placeholder slot like "6pm CH3 - vacant" / "CH3 - vacant - Restaurant run"
+  // is an unfilled run: the location half is a placeholder, so neither the
+  // "hare" ("6pm CH3") nor the "location" ("vacant…") is real. Drop both (#1882).
+  const slotVacant = !!location && (isPlaceholder(location) || containsPlaceholderToken(location));
+  if (!slotVacant) {
+    if (!timed.hares && hare && looksLikeHareName(hare)) timed.hares = hare;
+    if (!timed.location && location) timed.location = location;
+  }
   timed.runNumber ??= descriptor.runNumber;
   timed.title = descriptor.title ?? undefined;
 }

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -23,6 +23,9 @@ const EXPECTED_GROUPS: ExpectedGroup[] = [
     table: [
       ["Hare: line", "Details\nHare: Mudflap\nON-IN: Some Bar", "Mudflap"],
       ["Hares: line", "Hares: Alice & Bob", "Alice & Bob"],
+      // #1884 MH3-Mpls — space before the colon ("Hare : Butt Knuckles").
+      ["'Hare :' space-before-colon", "Hare : Butt Knuckles\nTheme: 1984", "Butt Knuckles"],
+      ["'Hares :' space-before-colon", "Hares : Alice & Bob", "Alice & Bob"],
       ["'Hare & Co-Hares:' (Voodoo H3 format)", "Hare & Co-Hares: Steven with a D\nStart Address: 123 Main", "Steven with a D"],
       ["'Hare & Co-Hares:' multiple names", "Hare & Co-Hares: Whordini & Mudflap", "Whordini & Mudflap"],
       ["Who: line", "Who: Charlie", "Charlie"],

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -31,7 +31,7 @@ export const PHONE_TRAILING_RE = new RegExp(String.raw`\s*(?:${PHONE_NUMBER_RE.s
 /** Default hare extraction patterns for Google Calendar descriptions. */
 /* eslint-disable -- security/detect-unsafe-regex (Codacy ESLint plugin not loaded locally); patterns operate on trusted GCal description fields with bounded line slicing in extractHares */
 const DEFAULT_HARE_PATTERNS = [
-  /(?:^|\n)[ \t]*H{1,3}are(?:\s*&\s*Co-Hares?)?\(?s?\)?:[ \t]*(.*)/im,  // Hare:, Hares:, HHHares: (Asheville's "HHH" = Hash House Harriers convention)
+  /(?:^|\n)[ \t]*H{1,3}are(?:\s*&\s*Co-Hares?)?\(?s?\)?[ \t]*:[ \t]*(.*)/im,  // Hare:, Hares:, "Hare :" (space before colon, #1884 MH3-Mpls), HHHares: (Asheville's "HHH" = Hash House Harriers convention)
   // "WHO ARE THE HARES:" template variant — must match before the generic
   // "Who:" pattern so the full label prefix is consumed. Non-greedy capture
   // with a section-label lookahead terminator handles concatenated descriptions

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -780,7 +780,7 @@ export function hasPlaceholderRunNumber(text: string | undefined): boolean {
 // alternation and a single tail.
 const PLACEHOLDER_TBD_RE = /^(?:venue[\s-]+)?(?:tbd|tba|tbc)$/i;
 const PLACEHOLDER_OTHER_RE =
-  /^(?:n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|\?{1,3})$/i;
+  /^(?:n\/a|none|null|needed|required|registration|sign[\s\-_]*up!?|volunteer|vacant|\?{1,3})$/i;
 // "Hare(s) required(!?)" / "Hare(s) wanted" added in WS6 (#1521/#1523) —
 // Capital H3 was storing the hare-needed placeholder as the location.
 const PLACEHOLDER_HARES_NEEDED_RE = /^(?:hares?\s+(?:needed|required|wanted)|needs?\s+(?:a\s+)?hares?)\b[\s\S]*$/i;

--- a/src/app/admin/sources/config-validation.test.ts
+++ b/src/app/admin/sources/config-validation.test.ts
@@ -248,6 +248,50 @@ describe("validateSourceConfig", () => {
       expect(errors).toHaveLength(1);
       expect(errors[0]).toContain("must be a string");
     });
+
+    it("accepts an array of titleHarePattern strings (Stuttgart/Copenhagen shape)", () => {
+      expect(validateSourceConfig("GOOGLE_CALENDAR", {
+        titleHarePattern: [String.raw`^a(.+)$`, String.raw`^b(.+)$`],
+      })).toEqual([]);
+    });
+
+    it("rejects an array titleHarePattern with a non-string element", () => {
+      const errors = validateSourceConfig("GOOGLE_CALENDAR", {
+        titleHarePattern: ["ok", 123],
+      });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("titleHarePattern[1]");
+    });
+
+    it("rejects an array titleHarePattern with a ReDoS element", () => {
+      const errors = validateSourceConfig("GOOGLE_CALENDAR", {
+        titleHarePattern: ["(a+a+)+$"],
+      });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("catastrophic backtracking");
+    });
+  });
+
+  describe("titleLocationPattern validation", () => {
+    it("accepts a valid string titleLocationPattern", () => {
+      expect(validateSourceConfig("GOOGLE_CALENDAR", {
+        titleLocationPattern: String.raw`\s+-\s+(\S.*)$`,
+      })).toEqual([]);
+    });
+
+    it("accepts an array of titleLocationPattern strings", () => {
+      expect(validateSourceConfig("GOOGLE_CALENDAR", {
+        titleLocationPattern: [String.raw`\s+-\s+(\S.*)$`, String.raw`(\d+\s+.+)$`],
+      })).toEqual([]);
+    });
+
+    it("rejects an invalid regex titleLocationPattern", () => {
+      const errors = validateSourceConfig("GOOGLE_CALENDAR", {
+        titleLocationPattern: "[broken(",
+      });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("invalid regex");
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/app/admin/sources/config-validation.test.ts
+++ b/src/app/admin/sources/config-validation.test.ts
@@ -294,6 +294,18 @@ describe("validateSourceConfig", () => {
     });
   });
 
+  describe("alwaysStripTitleHareSpan validation", () => {
+    it("accepts a boolean", () => {
+      expect(validateSourceConfig("GOOGLE_CALENDAR", { alwaysStripTitleHareSpan: true })).toEqual([]);
+    });
+
+    it("rejects a non-boolean", () => {
+      const errors = validateSourceConfig("GOOGLE_CALENDAR", { alwaysStripTitleHareSpan: "yes" });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("must be a boolean");
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // harePatterns validation
   // ---------------------------------------------------------------------------

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -162,6 +162,28 @@ function validatePatternArray(
   }
 }
 
+/**
+ * Validate a field that accepts EITHER a single regex string OR an array of
+ * regex strings (titleHarePattern / titleLocationPattern). The adapter compiles
+ * both shapes via `compileMaybeArray`; the seed already ships arrays (Stuttgart,
+ * Copenhagen), so a string-only check here is a latent false-positive.
+ */
+function validateStringOrPatternArray(
+  obj: Record<string, unknown>,
+  fieldName: string,
+  errors: string[],
+): void {
+  if (!(fieldName in obj) || obj[fieldName] === undefined) return;
+  const value = obj[fieldName];
+  if (typeof value === "string") {
+    validateRegex(value, fieldName, errors);
+  } else if (Array.isArray(value)) {
+    validatePatternArray(obj, fieldName, errors); // reuse the array-of-regex validator
+  } else {
+    errors.push(`${fieldName} must be a string or an array of regex strings`);
+  }
+}
+
 /** Valid `field` values for a silentlySkipPatterns rule (#1739). */
 const SILENT_SKIP_FIELDS = new Set(["title", "description", "location", "hares"]);
 
@@ -524,14 +546,10 @@ export function validateSourceConfig(
   validatePatternArray(obj, "locationOmitIfMatches", errors, { rejectBroad: true });
   validateSilentlySkipPatterns(obj, errors);
 
-  // Single-pattern validation (titleHarePattern is a string, not an array)
-  if ("titleHarePattern" in obj && obj.titleHarePattern !== undefined) {
-    if (typeof obj.titleHarePattern !== "string") {
-      errors.push("titleHarePattern must be a string");
-    } else {
-      validateRegex(obj.titleHarePattern, "titleHarePattern", errors);
-    }
-  }
+  // titleHarePattern / titleLocationPattern accept string | string[] (the
+  // adapter compiles both shapes; seed data ships arrays).
+  validateStringOrPatternArray(obj, "titleHarePattern", errors);
+  validateStringOrPatternArray(obj, "titleLocationPattern", errors);
 
   // Type-specific validation
   runTypeValidator(type, obj, errors);

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -551,6 +551,12 @@ export function validateSourceConfig(
   validateStringOrPatternArray(obj, "titleHarePattern", errors);
   validateStringOrPatternArray(obj, "titleLocationPattern", errors);
 
+  if ("alwaysStripTitleHareSpan" in obj
+    && obj.alwaysStripTitleHareSpan !== undefined
+    && typeof obj.alwaysStripTitleHareSpan !== "boolean") {
+    errors.push("alwaysStripTitleHareSpan must be a boolean");
+  }
+
   // Type-specific validation
   runTypeValidator(type, obj, errors);
 


### PR DESCRIPTION
## Summary

Fixes the Google Calendar SUMMARY splitter **systemically** rather than with per-kennel band-aids (#1892 EWH3 was an explicit recurrence of #1127/PR #1227). Because kennel formats are contradictory — the text after the dash is a **location** for EWH3 but a **hare** for SWH3/MH3 — the core fix is a *narrow hare-shape reject-gate* applied at every title-derived hare-assignment site, plus thin config-driven per-kennel patterns. All changes are live-verified against the real calendars.

## Systemic adapter changes
- **`looksLikeHareName()` gate** — rejects only placeholders and bare kennel codes (e.g. "CH3"), deliberately *no* fuzzy theme/word-count/`!` heuristic (which would false-reject real hash names like "Jaba the Slut & Stop, Drop, and Puke"). Applied at: `titleHarePattern`, `" w/ "`, trailing-paren, `"- Hares:"`, `"hared by"`, and the descriptor-merge split.
- **`alwaysStripTitleHareSpan`** opt-in — strips the title's hare suffix even when the canonical hare comes from the description (#1884), without breaking the description-priority-keeps-title contract for other kennels.
- **`containsPlaceholderToken()` / `VACANCY_TOKEN_RE`** — narrow per-token guard for location captures like `"3 - vacant"` / `"Location TBD"` that anchored `isPlaceholder` misses, without dropping real venues ("Volunteer Park").
- `hare-extraction.ts`: accept `"Hare :"` (space before colon). `utils.ts`: `"vacant"` is a placeholder. `config-validation.ts`: `titleHarePattern`/`titleLocationPattern` accept `string | string[]` (the seed already ships arrays — fixes a latent false-positive).

## Per-kennel config
| Issue | Kennel | Change |
|---|---|---|
| #1892 | EWH3 | `titleLocationPattern` → `"… - Dupont Circle"` → locationName; no theme in hares |
| #1881 | SWH3 | last-dash hare pattern + `defaultTitle` |
| #1884 | MH3-Mpls | anchored hare pattern + `alwaysStripTitleHareSpan` + `defaultTitles` |
| #1891 | Boston | `titleStripPatterns` `BH3:` + `runNumberPatterns` `BH #N` |
| #1868 | Oregon | `w/`/`OH3 #N` hare patterns (co-host-safe) |
| #1401 | FCMH3 | endTime already wired end-to-end — **verified 61/61 live** |
| #1406/#1407 | HSWTF | `defaultTitles`+`staleTitleAliases`; "(2011)" guarded as not-a-run-number |

## Side-tasks
- **#1872** Osaka profile bundle (logoUrl/gm/hareRaiser/hashCash/schedule).
- **#1869** OH3 HashRego — **verified** the source keys on slug `OregonH3` (→ Oregon, HTTP 200), *not* the bare `OH3` that resolves to Okinawa. No leak; no change needed (the issue's premise was inverted).

## Stale-data cleanup (one-shot, dry-run default, run post-deploy)
- `cleanup-ewh3-stale-theme-hares.ts` — nulls theme-as-hares where `haresText == title` (the #1892 rows the merge preserves; 25 found, legit hares preserved).
- `cleanup-hswtf-placeholder-titles.ts` — rewrites 101 historical `"HSWTFH3…"` titles (#1406; predate the scrape window, cannot self-heal).
- **#1873** Osaka hares and **#1407** run=2011 already self-healed in prod (verified 10/10 hares, 0 run=2011) — no cleanup needed.

## Verification
- `npx tsc --noEmit` clean; `npm run lint` 0 errors; **8204 tests pass** (new regression + negative fixtures incl. `looksLikeHareName` gate, EWH3/SWH3/MH3/Capital/Oregon/HSWTF, config-validation array forms, `Hare :` extraction).
- Live: `scripts/live-verify-gcal-hare-theme-bundle.ts` — all targets clean (no theme/placeholder in hares, post-dash hares extracted, EWH3 location strip, FCMH3 endTime 61/61, HSWTF no `HSWTFH3`/run=2011).

Closes #1892
Closes #1884
Closes #1881
Closes #1882
Closes #1891
Closes #1868
Closes #1873
Closes #1872
Closes #1869
Closes #1401
Closes #1406
Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)