### PR TITLE
fix(merge): lower-trust enrichment backfills coords/map URL, not just venue name

### DIFF
--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -510,12 +510,11 @@ describe("processRawEvents", () => {
 
   it("higher-trust enrichment source writes coords onto a no-coords canonical event (NSWHHH dual-source)", async () => {
     // NSWHHH ships two sources: the hareline sheet (trust 7, no venue/coords)
-    // and the website (trust 8, venue + map coords). If the sheet's raw merges
-    // first, the canonical Event is created without coordinates. The website
-    // must OUT-trust the sheet so it takes the full-update path and writes
-    // lat/lng — the lower-trust enrichment branch backfills locationName but
-    // NOT locationAddress/latitude/longitude (merge.ts ~L1668), so a lower-trust
-    // website would have its map pin silently dropped (Codex adversarial review).
+    // and the website (trust 8, venue + map coords). When the higher-trust
+    // website merges, it takes the full-update path and writes lat/lng. (As of
+    // the enrichment-coords fix the lower-trust path also backfills coords — see
+    // the "lower-trust enrichment backfills coords" test below — but the
+    // higher-trust write is still exercised here.)
     mockSourceFind.mockResolvedValueOnce(sourceRow({
       trustLevel: 8,
       type: "HTML_SCRAPER",
@@ -550,6 +549,90 @@ describe("processRawEvents", () => {
     expect(data.locationAddress).toContain("maps.app.goo.gl");
     // locationName lands too (sanitizeLocation may trim street fragments).
     expect(data.locationName).toContain("Bay Road Reserve");
+  });
+
+  it("lower-trust enrichment backfills coords/map URL onto a coordless canonical event", async () => {
+    // The enrichment branch fills NULL canonical fields from a lower-trust source.
+    // Coords + map URL must enrich like locationName: a coord-bearing secondary
+    // (trust 5) should fill lat/lng/locationAddress when the higher-trust primary
+    // (trust 8) created the event without them — so dual-source kennels no longer
+    // have to make the coord source out-trust the other (the #1917 workaround).
+    mockSourceFind.mockResolvedValueOnce(sourceRow({
+      trustLevel: 5,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([{
+      id: "evt_coordless",
+      trustLevel: 8,
+      locationName: null,
+      locationAddress: null,
+      locationCity: null,
+      latitude: null,
+      longitude: null,
+    }] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_coordless"));
+
+    await processRawEvents("src_low", [buildRawEvent({
+      location: "Bay Road Reserve, Waverton",
+      locationUrl: "https://maps.app.goo.gl/iiY2q5avvkBvBchS6",
+      latitude: -33.837524,
+      longitude: 151.196929,
+    })]);
+
+    const update = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_coordless",
+    );
+    expect(update).toBeDefined();
+    const data = (update![0] as { data: Record<string, unknown> }).data;
+    expect(data).toHaveProperty("latitude", -33.837524);
+    expect(data).toHaveProperty("longitude", 151.196929);
+    expect(data.locationAddress).toContain("maps.app.goo.gl");
+    // reverseGeocode is mocked to null in this file → locationCity not asserted.
+  });
+
+  it("lower-trust enrichment does NOT overwrite existing coords / map URL", async () => {
+    // Fill-only: when the canonical Event already has coords (from a higher-trust
+    // source), a lower-trust source with *different* coords must not clobber them
+    // — but it may still fill a genuinely-null field (here, description).
+    mockSourceFind.mockResolvedValueOnce(sourceRow({
+      trustLevel: 5,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([{
+      id: "evt_hascoords",
+      trustLevel: 8,
+      locationName: "Existing Venue",
+      locationAddress: "https://maps.example.com/existing",
+      locationCity: "Sydney",
+      latitude: -10,
+      longitude: 20,
+      description: null,
+    }] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_hascoords"));
+
+    await processRawEvents("src_low", [buildRawEvent({
+      description: "A fresh write-up",
+      location: "Different Place",
+      locationUrl: "https://maps.app.goo.gl/different",
+      latitude: 51.5,
+      longitude: -0.12,
+    })]);
+
+    const update = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_hascoords",
+    );
+    expect(update).toBeDefined();
+    const data = (update![0] as { data: Record<string, unknown> }).data;
+    // The fillable null field is enriched...
+    expect(data).toHaveProperty("description", "A fresh write-up");
+    // ...but the existing higher-trust coords / map URL are NOT touched.
+    expect(data).not.toHaveProperty("latitude");
+    expect(data).not.toHaveProperty("longitude");
+    expect(data).not.toHaveProperty("locationAddress");
   });
 
   it("lower-trust enrichment recomposes dateUtc when backfilling startTime (#1654)", async () => {

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -635,6 +635,95 @@ describe("processRawEvents", () => {
     expect(data).not.toHaveProperty("locationAddress");
   });
 
+  it("does NOT backfill coords/map URL when the lower-trust venue differs from the existing name (#1919)", async () => {
+    // Venue-compatibility gate: a fuzzy/stale lower-trust match carrying a
+    // DIFFERENT venue must not pin its coords under the higher-trust venue name
+    // (silent map/name mismatch — Codex adversarial review). Coords are null
+    // here, so ONLY the venue gate can block the backfill.
+    mockSourceFind.mockResolvedValueOnce(sourceRow({
+      trustLevel: 5,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([{
+      id: "evt_named",
+      trustLevel: 8,
+      locationName: "Higher-Trust Venue",
+      locationAddress: null,
+      locationCity: null,
+      latitude: null,
+      longitude: null,
+      description: null,
+    }] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_named"));
+
+    await processRawEvents("src_low", [buildRawEvent({
+      description: "fresh writeup",
+      location: "A Totally Different Place",
+      locationUrl: "https://maps.app.goo.gl/different",
+      latitude: 51.5,
+      longitude: -0.12,
+    })]);
+
+    const update = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_named",
+    );
+    expect(update).toBeDefined();
+    const data = (update![0] as { data: Record<string, unknown> }).data;
+    // Other null fields still enrich...
+    expect(data).toHaveProperty("description", "fresh writeup");
+    // ...but the mismatched venue's coords / map URL are NOT attached, and the
+    // higher-trust venue name is left untouched.
+    expect(data).not.toHaveProperty("latitude");
+    expect(data).not.toHaveProperty("longitude");
+    expect(data).not.toHaveProperty("locationAddress");
+    expect(data).not.toHaveProperty("locationName");
+  });
+
+  it("resolves coords by geocoding the venue (not direct lat/lng) + fills map URL & locationCity", async () => {
+    // Exercises the resolveCoords path that derives coords from the venue string
+    // via geocodeAddress (not raw lat/lng), the map-URL backfill, and the
+    // reverse-geocode locationCity fill (CodeRabbit nitpick). Venue is null on
+    // the canonical → venue-compatible, so name + pin fill from this source.
+    // (extractCoordsFromMapsUrl is stubbed to null in this file, so the goo.gl
+    // URL yields no coords — coords must come from geocodeAddress.)
+    const { geocodeAddress, reverseGeocode } = await import("@/lib/geo");
+    vi.mocked(geocodeAddress).mockResolvedValueOnce({ lat: 51.5, lng: -0.12, formattedAddress: "London, UK" } as never);
+    vi.mocked(reverseGeocode).mockResolvedValueOnce("London");
+    mockSourceFind.mockResolvedValueOnce(sourceRow({
+      trustLevel: 5,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([{
+      id: "evt_urlcoords",
+      trustLevel: 8,
+      locationName: null,
+      locationAddress: null,
+      locationCity: null,
+      latitude: null,
+      longitude: null,
+    }] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_urlcoords"));
+
+    await processRawEvents("src_low", [buildRawEvent({
+      location: "Some Venue",
+      locationUrl: "https://maps.app.goo.gl/somewhere",
+    })]);
+
+    const update = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_urlcoords",
+    );
+    expect(update).toBeDefined();
+    const data = (update![0] as { data: Record<string, unknown> }).data;
+    expect(data).toHaveProperty("latitude", 51.5);
+    expect(data).toHaveProperty("longitude", -0.12);
+    expect(data.locationAddress).toContain("goo.gl");
+    expect(data).toHaveProperty("locationCity", "London");
+  });
+
   it("lower-trust enrichment recomposes dateUtc when backfilling startTime (#1654)", async () => {
     // SeaMon Trail #556 shape: higher-trust GSheets created the row without a
     // startTime (so dateUtc = eventDate = UTC noon). Lower-trust GCal later

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1692,6 +1692,44 @@ async function upsertCanonicalEvent(
       if (!existingEvent.locationStreet && event.locationStreet) {
         enrichData.locationStreet = event.locationStreet;
       }
+      // Coords + map URL enrich like locationName: a lower-trust source can carry
+      // the venue's pin when the higher-trust primary created the event with none.
+      // Fill-only — never overwrite an existing (higher-trust) coord. #1917 Codex
+      // review caught the asymmetry where the website source had to out-trust the
+      // sheet purely to dodge this gap; this lets enrichment carry the coords.
+      // Only resolve when the canonical lacks coords AND this source carries a
+      // coord signal (direct lat/lng, a maps URL, or a venue to geocode) — skip
+      // the otherwise no-op async call. `existingCoords` is omitted: the null
+      // guard means there's nothing cached to preserve.
+      const eventHasCoordSignal =
+        event.latitude != null || event.longitude != null || !!event.locationUrl || !!event.location;
+      if (existingEvent.latitude == null && existingEvent.longitude == null && eventHasCoordSignal) {
+        const coords = await resolveCoords(
+          event,
+          undefined,
+          ctx.shortUrlCache,
+          kennelData,
+          resolveRegionBias(event, kennelData.country),
+        );
+        if (coords.latitude != null && coords.longitude != null) {
+          enrichData.latitude = coords.latitude;
+          enrichData.longitude = coords.longitude;
+          // Reverse-geocode the city to match the full-update path: skip for
+          // canonical-location source types, and only when not already set.
+          if (!shouldSkipReverseGeocode(ctx.sourceType) && !existingEvent.locationCity) {
+            const city = suppressRedundantCity(
+              (enrichData.locationName as string | null | undefined) ?? existingEvent.locationName,
+              await reverseGeocode(coords.latitude, coords.longitude),
+            );
+            if (city) enrichData.locationCity = city;
+          }
+        }
+      }
+      // Map URL backfill — independent of coords (a source may carry a maps link
+      // the canonical lacks even when coords don't resolve). Fill-only.
+      if (!existingEvent.locationAddress && event.locationUrl) {
+        enrichData.locationAddress = sanitizeLocationUrl(event.locationUrl);
+      }
       if (!existingEvent.startTime && event.startTime) {
         enrichData.startTime = event.startTime;
         // #1654: keep dateUtc in sync with the newly-enriched startTime.

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1697,13 +1697,25 @@ async function upsertCanonicalEvent(
       // Fill-only — never overwrite an existing (higher-trust) coord. #1917 Codex
       // review caught the asymmetry where the website source had to out-trust the
       // sheet purely to dodge this gap; this lets enrichment carry the coords.
+      //
+      // Venue-compatibility gate (#1919 Codex review): only attach this source's
+      // coords/map URL when they won't contradict an EXISTING higher-trust venue
+      // name. Safe when the canonical has no venue yet (we're filling it from this
+      // same source just above, so name + pin agree by construction) OR when this
+      // source's venue matches the stored name. Otherwise a fuzzy/stale lower-trust
+      // match could pin a *different* venue's coords under a higher-trust venue
+      // name — a silent map/name mismatch. Strict equality is intentionally
+      // conservative: on any doubt we skip rather than risk a wrong pin.
+      const venueCompatible =
+        existingEvent.locationName == null ||
+        (event.location != null && sanitizeLocation(event.location) === existingEvent.locationName);
       // Only resolve when the canonical lacks coords AND this source carries a
       // coord signal (direct lat/lng, a maps URL, or a venue to geocode) — skip
       // the otherwise no-op async call. `existingCoords` is omitted: the null
       // guard means there's nothing cached to preserve.
       const eventHasCoordSignal =
         event.latitude != null || event.longitude != null || !!event.locationUrl || !!event.location;
-      if (existingEvent.latitude == null && existingEvent.longitude == null && eventHasCoordSignal) {
+      if (venueCompatible && existingEvent.latitude == null && existingEvent.longitude == null && eventHasCoordSignal) {
         const coords = await resolveCoords(
           event,
           undefined,
@@ -1726,8 +1738,9 @@ async function upsertCanonicalEvent(
         }
       }
       // Map URL backfill — independent of coords (a source may carry a maps link
-      // the canonical lacks even when coords don't resolve). Fill-only.
-      if (!existingEvent.locationAddress && event.locationUrl) {
+      // the canonical lacks even when coords don't resolve), but same venue gate:
+      // the URL is effectively the pin too, so don't attach a mismatched one.
+      if (venueCompatible && !existingEvent.locationAddress && event.locationUrl) {
         enrichData.locationAddress = sanitizeLocationUrl(event.locationUrl);
       }
       if (!existingEvent.startTime && event.startTime) {


### PR DESCRIPTION
## Summary
The merge pipeline's lower-trust enrichment branch (`src/pipeline/merge.ts`, the `else` of `if (ctx.trustLevel >= existingEvent.trustLevel)`) backfilled NULL canonical-Event fields from a lower-trust source — `description`, `eventLabel`, `haresText`, `locationName`, `locationStreet`, `startTime`, the trail-length bundle, `difficulty`, `trailType`, `dogFriendly`, `prelube`, `endDate` — but **not** `latitude`, `longitude`, or `locationAddress` (map URL).

That asymmetry meant a lower-trust source could fill a venue's **name** but its map **pin** was silently dropped: if a higher-trust source created an Event with no location and a lower-trust source carried the venue + coords, the event rendered without a map. A **Codex adversarial review** caught this during the NSWHHH onboarding ([#1917](https://github.com/johnrclem/hashtracks-web/pull/1917)), which worked around it by making the coord-bearing website source out-trust the sheet. This closes the general gap so dual-source kennels can rely on enrichment instead of trust-ordering gymnastics.

## Change
The enrichment branch now resolves coords and fills `latitude`/`longitude`/`locationAddress` (+ reverse-geocoded `locationCity`) when the canonical has them null:
- **Reuses** the same helpers the sibling full-update branch uses — `resolveCoords`, `shouldSkipReverseGeocode`, `reverseGeocode`, `suppressRedundantCity`, `sanitizeLocationUrl`.
- **Fill-only** — never overwrites a higher-trust source's coords (guarded on `latitude == null && longitude == null` / `!locationAddress`). The map-URL fill is independent of coords (a source may carry a maps link even when coords don't resolve).
- **Skips the async resolve** entirely unless the source carries a coord signal (direct lat/lng, a maps URL, or a venue to geocode); `existingCoords` is omitted from the call since the null-guard means there's nothing cached to preserve.
- `locationCity` mirrors the full-update reverse-geocode (skipped for canonical-location source types, only when null).

## Tests (`src/pipeline/merge.test.ts`)
- **Lower-trust source fills coords** on a coordless canonical Event → `latitude`/`longitude`/`locationAddress` land.
- **Lower-trust source does NOT overwrite** existing coords → only the genuinely-null field (`description`) is filled; lat/lng/`locationAddress` untouched.
- Updated the existing "NSWHHH dual-source" test's comment (the branch *does* backfill coords now).

## Verification
`npx tsc --noEmit` ✅ · `npm run lint` ✅ · `npm test` ✅ (8379 passed; 370 in merge.test.ts). `/simplify` ran (2 cleanups applied: omit the inert `existingCoords` object; add the coord-signal pre-guard).

Note: a deeper refactor — extracting a shared `deriveCoordCity` helper used by the full-update, enrichment, and create branches — was flagged by the review as a reasonable future cleanup but deliberately left out of this focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)