### PR TITLE
fix(adapters): Meetup hares-from-title (#1270) + Hash Rego cost (#1126); verify+guard self-healed #1242/#1244

### DIFF
--- a/src/adapters/google-sheets/adapter.test.ts
+++ b/src/adapters/google-sheets/adapter.test.ts
@@ -871,6 +871,81 @@ describe("GoogleSheetsAdapter.fetch — csvUrl", () => {
   });
 });
 
+// ── #1244 Kowloon H3 row alignment (off-by-one regression guard) ──
+//
+// The #1244 audit alleged the adapter pulled run N's hares/location/date from
+// row N+1. Code review proved the adapter reads every field from the same row
+// (buildEventFromSheetRow) and parseDate("10-May-26") → "2026-05-10" (no +1
+// shift); prod confirmed the canonical events self-healed (#2910 = TIMBITS /
+// Macau / May-10). This fixture locks in the exact Kowloon sheet shape — three
+// leading non-data rows ("hide me" / link / header), the real column layout,
+// CRLF line endings, and `extraHares` — so each run stays welded to its OWN
+// row's data and a future refactor can't reintroduce the drift.
+describe("GoogleSheetsAdapter.fetch — Kowloon row alignment (#1244)", () => {
+  beforeEach(() => {
+    vi.stubEnv("GOOGLE_CALENDAR_API_KEY", "test-key");
+    mockedSafeFetch.mockReset();
+  });
+
+  // D-Mon-YY (e.g. "10-May-26") for now + offset days, matching the live sheet.
+  const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  function dMonYY(offsetDays: number): string {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() + offsetDays);
+    return `${d.getUTCDate()}-${MONTHS[d.getUTCMonth()]}-${String(d.getUTCFullYear()).slice(2)}`;
+  }
+
+  const kowloonConfig = {
+    sheetId: "kowloon",
+    csvUrl: "https://docs.google.com/spreadsheets/d/e/XXX/pub?output=csv",
+    columns: { date: 1, runNumber: 2, hares: 3, extraHares: [4], location: 7, title: 6 },
+    kennelTagRules: { default: "kowloon-h3" },
+    startTimeRules: { default: "18:00" },
+  };
+
+  it("welds each run to its own row's hares/location/date (no off-by-one)", async () => {
+    const d1 = dMonYY(7);
+    const d2 = dMonYY(8); // adjacent day — the Sun/Mon shape from the issue
+    const d3 = dMonYY(14);
+    // Col layout: tag, Date, Run no., Hare1, Hare2, Scribles, Headline, Location
+    const csv = [
+      ",hide me,232,,,,,",
+      ",Link to Run Notice,,WWW.KOWLOONHASH.COM,,,,",
+      ",Date,Run no.,Hare1,Hare2,Scribles,Headline,Location",
+      `LH13,${d1},2910,TIMBITS,,SCRIBE,,Macau`,
+      `LH14,${d2},2911,INFLATADATE,,SCRIBE,,Wong Tai Sin`,
+      `LH15,${d3},2912,WHORES DRAWERS,SECOND HARE,SCRIBE,Family Run,Tin Wan`,
+    ].join("\r\n"); // CRLF, as Google's published CSV emits
+
+    mockedSafeFetch.mockResolvedValueOnce(mockFetchResponse(csv));
+
+    const adapter = new GoogleSheetsAdapter();
+    const source = makeSource({ config: kowloonConfig as unknown as null });
+    const result = await adapter.fetch(source);
+
+    // Only the 3 data rows produce events — the "hide me" / link / header rows
+    // fail date parsing and are skipped (no skipRows configured upstream).
+    expect(result.events).toHaveLength(3);
+
+    const r2910 = result.events.find((e) => e.runNumber === 2910)!;
+    expect(r2910.hares).toBe("TIMBITS");
+    expect(r2910.location).toBe("Macau");
+    expect(r2910.date).toBe(parseDate(d1)!);
+
+    const r2911 = result.events.find((e) => e.runNumber === 2911)!;
+    expect(r2911.hares).toBe("INFLATADATE");
+    expect(r2911.location).toBe("Wong Tai Sin");
+    expect(r2911.date).toBe(parseDate(d2)!);
+
+    const r2912 = result.events.find((e) => e.runNumber === 2912)!;
+    // extraHares (col 4) merges with hares (col 3), sorted for fingerprint stability.
+    expect(r2912.hares).toBe("SECOND HARE / WHORES DRAWERS");
+    expect(r2912.location).toBe("Tin Wan");
+    expect(r2912.title).toBe("Family Run");
+    expect(r2912.date).toBe(parseDate(d3)!);
+  });
+});
+
 // ── #1542 group_filter: shared multi-kennel sheets ──
 
 describe("normalizeGroupFilter (#1542)", () => {

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -9,6 +9,7 @@ import {
   parseDayHeaderSections,
   detectVenueWeekendEndDate,
   stripDoubledKennelPrefix,
+  type ParsedEvent,
 } from "./parser";
 import { HashRegoAdapter, apiToIndexEntry, normalizeHashRegoPrice } from "./adapter";
 import { HashRegoApiError, type HashRegoKennelEvent } from "./api";
@@ -810,6 +811,54 @@ describe("parseEventDetail — Strategy 1 NYE year rollover (#1630 review)", () 
     const parsed = parseEventDetail(NYE_RANGE_HTML, "nye-campout-2026", NYE_INDEX_ENTRY);
     expect(parsed.isMultiDay).toBe(true);
     expect(parsed.dates).toEqual(["2026-12-31", "2027-01-01"]);
+  });
+});
+
+// #1126 — Hash Rego publishes a per-event registration cost; splitToRawEvents
+// must propagate ParsedEvent.cost onto every emitted RawEventData so the merge
+// pipeline writes it to Event.cost.
+describe("splitToRawEvents — cost propagation (#1126)", () => {
+  function buildParsed(overrides: Partial<ParsedEvent> = {}): ParsedEvent {
+    return {
+      title: "EWH3 #1516: Bugs Bunny's Cream Pie",
+      dates: ["2026-04-30"],
+      startTimes: ["18:45"],
+      kennelSlug: "EWH3",
+      hostKennelName: "EWH3",
+      isMultiDay: false,
+      cost: "$10",
+      ...overrides,
+    };
+  }
+
+  it("single-day event carries cost (EWH3 #1516)", () => {
+    const events = splitToRawEvents(buildParsed(), "ewh3-1516");
+    expect(events).toHaveLength(1);
+    expect(events[0].cost).toBe("$10");
+  });
+
+  it("emits undefined cost when the source has none (additive — preserve existing)", () => {
+    const events = splitToRawEvents(buildParsed({ cost: undefined }), "ewh3-1516");
+    expect(events[0].cost).toBeUndefined();
+  });
+
+  it("multi-day series puts cost on the umbrella parent only, not each day", () => {
+    const parsed = buildParsed({
+      title: "EWH3 Campout",
+      dates: ["2026-05-01", "2026-05-02", "2026-05-03"],
+      startTimes: ["18:00", "10:00", "10:00"],
+      isMultiDay: true,
+      cost: "$85",
+    });
+    const events = splitToRawEvents(parsed, "ewh3-campout");
+    expect(events).toHaveLength(3);
+    // Day 1 doubles as the series parent — it carries the single registration fee.
+    const parent = events.find((e) => e.seriesParent);
+    expect(parent?.cost).toBe("$85");
+    // Child days do NOT repeat the fee (would read as "$85/day").
+    const children = events.filter((e) => !e.seriesParent);
+    expect(children).toHaveLength(2);
+    expect(children.every((e) => e.cost === undefined)).toBe(true);
   });
 });
 

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -817,19 +817,21 @@ describe("parseEventDetail — Strategy 1 NYE year rollover (#1630 review)", () 
 // #1126 — Hash Rego publishes a per-event registration cost; splitToRawEvents
 // must propagate ParsedEvent.cost onto every emitted RawEventData so the merge
 // pipeline writes it to Event.cost.
+function buildParsedHashRegoEvent(overrides: Partial<ParsedEvent> = {}): ParsedEvent {
+  return {
+    title: "EWH3 #1516: Bugs Bunny's Cream Pie",
+    dates: ["2026-04-30"],
+    startTimes: ["18:45"],
+    kennelSlug: "EWH3",
+    hostKennelName: "EWH3",
+    isMultiDay: false,
+    cost: "$10",
+    ...overrides,
+  };
+}
+
 describe("splitToRawEvents — cost propagation (#1126)", () => {
-  function buildParsed(overrides: Partial<ParsedEvent> = {}): ParsedEvent {
-    return {
-      title: "EWH3 #1516: Bugs Bunny's Cream Pie",
-      dates: ["2026-04-30"],
-      startTimes: ["18:45"],
-      kennelSlug: "EWH3",
-      hostKennelName: "EWH3",
-      isMultiDay: false,
-      cost: "$10",
-      ...overrides,
-    };
-  }
+  const buildParsed = buildParsedHashRegoEvent;
 
   it("single-day event carries cost (EWH3 #1516)", () => {
     const events = splitToRawEvents(buildParsed(), "ewh3-1516");

--- a/src/adapters/hashrego/adapter.ts
+++ b/src/adapters/hashrego/adapter.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types";
 import { hasAnyErrors } from "../types";
 import { safeFetch } from "../safe-fetch";
+import { normalizeCostSigil } from "../utils";
 import { generateStructureHash } from "@/pipeline/structure-hash";
 import {
   parseEventsIndex,
@@ -502,6 +503,10 @@ function createFromIndex(entry: IndexEntry): RawEventData[] {
       date,
       kennelTags: [entry.kennelSlug],
       title: entry.title,
+      // #1126 — preserve the index-table cost ("$10") even when the detail
+      // fetch fails and we fall back to the index row. Normalize for parity
+      // with the detail-page path (parser.ts strips markdown bullets / `$$`).
+      cost: entry.cost ? normalizeCostSigil(entry.cost) : undefined,
       startTime: time || undefined,
       sourceUrl: hashRegoUrl,
       externalLinks: [{ url: hashRegoUrl, label: "Hash Rego" }],

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -452,6 +452,10 @@ export function splitToRawEvents(
         kennelTags: [parsed.hostKennelName || parsed.kennelSlug],
         title: parsed.title,
         description: parsed.description,
+        // #1126 — Hash Rego publishes a per-event registration cost ("$10");
+        // surface it onto Event.cost (merge maps RawEventData.cost). undefined
+        // when the source has no cost (tri-state: preserve existing).
+        cost: parsed.cost,
         hares: parsed.hares,
         location: parsed.location,
         locationUrl: parsed.locationAddress || parsed.locationUrl,
@@ -512,6 +516,9 @@ export function splitToRawEvents(
       kennelTags: [perDayCode ?? hostKennelTag],
       title: childTitle,
       description: parsed.description,
+      // #1126 — cost is a single registration fee for the whole series, so it
+      // lives on the parent/umbrella row only, NOT repeated onto each day
+      // (which would read as "$N per day").
       hares: parsed.hares,
       location: parsed.location,
       locationUrl: parsed.locationAddress || parsed.locationUrl,
@@ -533,6 +540,7 @@ export function splitToRawEvents(
       kennelTags: [hostKennelTag],
       title: parsed.title,
       description: parsed.description,
+      cost: parsed.cost, // #1126 — umbrella registration cost on the parent
       sourceUrl: hashRegoUrl,
       externalLinks,
       seriesId,
@@ -550,6 +558,7 @@ export function splitToRawEvents(
         kennelTags: [hostKennelTag],
         title: parsed.title,
         description: parsed.description,
+        cost: parsed.cost, // #1126 — registration cost on the Day-1 parent
         hares: parsed.hares,
         location: parsed.location,
         locationUrl: parsed.locationAddress || parsed.locationUrl,

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -599,7 +599,9 @@ describe("ICalAdapter", () => {
   // them again. (The original empty canonical was a transient — the run was
   // scraped before the kennel filled in details; it self-healed on re-scrape.)
   it("extracts location/hares/description from a dedicated EBH3 VEVENT (#1242)", async () => {
-    const EBH3_ICS = `BEGIN:VCALENDAR
+    // String.raw so the RFC 5545 escapes (\, and \n) are written as single
+    // backslashes without TS double-escaping; node-ical unescapes them.
+    const EBH3_ICS = String.raw`BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:icalendar-ruby
 CALSCALE:GREGORIAN
@@ -607,8 +609,8 @@ BEGIN:VEVENT
 UID:com.sfh3.calendar.run-6493-2
 DTSTART;TZID=America/Los_Angeles:20260510T130000
 DTEND;TZID=America/Los_Angeles:20260510T160000
-DESCRIPTION:Hares: Butt Plug FRED\\, Worst Bottom Ever\\, Cosmic Pussy\\, Litt
- le Johnson\\n\\nDirections: Use your phone!\\n\\nPrelube: Triple Rock Brewery
+DESCRIPTION:Hares: Butt Plug FRED\, Worst Bottom Ever\, Cosmic Pussy\, Litt
+ le Johnson\n\nDirections: Use your phone!\n\nPrelube: Triple Rock Brewery
 GEO:37.873416;-122.2687553
 LOCATION:Triple Rock Brewery
 SUMMARY:EBH3 #1164: Motherless Child Hash

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -591,6 +591,49 @@ describe("ICalAdapter", () => {
     expect(descLoc!.hares).toBe("Test Runner");
   });
 
+  // #1242 — regression guard for the dedicated "East Bay H3 iCal Feed"
+  // (ebh3.com). The aggregator strips trail names from SUMMARY, but the
+  // kennel-owned subsite ICS carries LOCATION + a leading "Hares:" line +
+  // escaped commas. This is the exact #1164 VEVENT shape; assert the adapter
+  // extracts location/hares/description so a regression can't silently empty
+  // them again. (The original empty canonical was a transient — the run was
+  // scraped before the kennel filled in details; it self-healed on re-scrape.)
+  it("extracts location/hares/description from a dedicated EBH3 VEVENT (#1242)", async () => {
+    const EBH3_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:icalendar-ruby
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:com.sfh3.calendar.run-6493-2
+DTSTART;TZID=America/Los_Angeles:20260510T130000
+DTEND;TZID=America/Los_Angeles:20260510T160000
+DESCRIPTION:Hares: Butt Plug FRED\\, Worst Bottom Ever\\, Cosmic Pussy\\, Litt
+ le Johnson\\n\\nDirections: Use your phone!\\n\\nPrelube: Triple Rock Brewery
+GEO:37.873416;-122.2687553
+LOCATION:Triple Rock Brewery
+SUMMARY:EBH3 #1164: Motherless Child Hash
+URL;VALUE=URI:https://www.ebh3.com/runs/6493
+END:VEVENT
+END:VCALENDAR`;
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(EBH3_ICS, { status: 200 }),
+    );
+    const source = buildMockSource({
+      name: "East Bay H3 iCal Feed",
+      url: "https://www.ebh3.com/calendar.ics",
+      config: { kennelPatterns: [["^EBH3", "ebh3"]], defaultKennelTag: "ebh3" },
+    });
+    const result = await adapter.fetch(source, { days: 9999 });
+
+    const ebh3 = result.events.find((e) => e.runNumber === 1164);
+    expect(ebh3).toBeDefined();
+    expect(ebh3!.kennelTags[0]).toBe("ebh3");
+    expect(ebh3!.title).toBe("Motherless Child Hash");
+    expect(ebh3!.location).toBe("Triple Rock Brewery");
+    expect(ebh3!.hares).toBe("Butt Plug FRED, Worst Bottom Ever, Cosmic Pussy, Little Johnson");
+    expect(ebh3!.description).toContain("Directions: Use your phone!");
+  });
+
   it("returns diagnostic context", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(SAMPLE_ICS, { status: 200 }),

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1379,7 +1379,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
         // No description hares → title fallback must engage.
         description: "<p>Meet at the usual spot. On-after at the bar.</p>",
       };
-      const event = buildRawEventFromApollo(ev as never, emptyState, "feh3");
+      const event = buildRawEventFromApollo(ev, emptyState, "feh3");
       expect(event.hares).toBe("salty cliterature and this is Sharda white dress!!");
       // The "hare:" span is stripped out of the title so names don't appear twice.
       expect(event.title).toBe("Trail 2578");
@@ -1403,7 +1403,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
         dateTime: "2026-05-09T16:00:00-04:00",
         description: "<p>Just a regular trail with no hare info</p>",
       };
-      const event = buildRawEventFromApollo(ev as never, emptyState, "feh3");
+      const event = buildRawEventFromApollo(ev, emptyState, "feh3");
       expect(event.hares).toBeUndefined();
     });
 
@@ -1415,7 +1415,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
         dateTime: "2026-05-09T16:00:00-04:00",
         description: "<p>HARE: Description Hare</p>",
       };
-      const event = buildRawEventFromApollo(ev as never, emptyState, "feh3");
+      const event = buildRawEventFromApollo(ev, emptyState, "feh3");
       expect(event.hares).toBe("Description Hare");
     });
   });

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1366,6 +1366,60 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     expect(event.hares).toBeUndefined();
   });
 
+  // #1270 — FEH3 admins embed the hare line in the Meetup *title* and leave the
+  // description hare-less. The title fallback only fires when neither
+  // description path produced hares, so kennels that already work stay untouched.
+  describe("hares from title fallback (#1270)", () => {
+    it("extracts hares from a title with a hare: label and strips the span (FEH3 Trail 2578)", () => {
+      const ev = {
+        __typename: "Event",
+        id: "7",
+        title: "Trail 2578, hare: salty cliterature and this is Sharda white dress!!",
+        dateTime: "2026-05-09T16:00:00-04:00",
+        // No description hares → title fallback must engage.
+        description: "<p>Meet at the usual spot. On-after at the bar.</p>",
+      };
+      const event = buildRawEventFromApollo(ev as never, emptyState, "feh3");
+      expect(event.hares).toBe("salty cliterature and this is Sharda white dress!!");
+      // The "hare:" span is stripped out of the title so names don't appear twice.
+      expect(event.title).toBe("Trail 2578");
+    });
+
+    it.each([
+      // Other kennels' titles carry no hare: label → no change (additive guard).
+      ["SAVH3 Trail #1324!"],
+      ["BIBH3 Trail #246 - TITS HAVE EYES BDAY TRAIL"],
+      // CTA-shaped "Hares Needed" must NOT be mistaken for a hare label.
+      ["Trail 300 - Hares Needed - Claim This Trail!"],
+      // Themed title with a hyphen after "Hare" must NOT match (colon-only).
+      ["Welcome to the Hare-raising Halloween Hash"],
+      // Explicit "hare:" whose value is a CTA/placeholder → cleanAndFilterHares drops it.
+      ["Annual Red Dress, hare: needed badly"],
+    ])("does not invent hares from non-label title %s", (title) => {
+      const ev = {
+        __typename: "Event",
+        id: "8",
+        title,
+        dateTime: "2026-05-09T16:00:00-04:00",
+        description: "<p>Just a regular trail with no hare info</p>",
+      };
+      const event = buildRawEventFromApollo(ev as never, emptyState, "feh3");
+      expect(event.hares).toBeUndefined();
+    });
+
+    it("prefers description hares over the title (fallback not consulted)", () => {
+      const ev = {
+        __typename: "Event",
+        id: "9",
+        title: "Trail 99, hare: Title Hare",
+        dateTime: "2026-05-09T16:00:00-04:00",
+        description: "<p>HARE: Description Hare</p>",
+      };
+      const event = buildRawEventFromApollo(ev as never, emptyState, "feh3");
+      expect(event.hares).toBe("Description Hare");
+    });
+  });
+
   // #1617 — Mel-NM Meetup aggregator hosts events for 5 Melbourne kennels.
   // The seed config wires kennelPatterns to split them. Verify the routing
   // matches what `prisma/seed-data/sources.ts` ships.

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -487,6 +487,21 @@ export function cleanMeetupTitle(raw: string | null | undefined): string | undef
 // covers "Hare : BBQ". ReDoS-safe: `(\S.*)`, no `$` anchor, no nested quantifier.
 const TITLE_HARE_RE = /\bhares?\s*:\s*(\S.*)/i;
 
+/**
+ * #1270 — pull hares from a title's explicit "hare:" label and return both the
+ * hares and the title with that span removed (so names don't appear twice). The
+ * shared extractHares runs cleanAndFilterHares, which rejects CTA/placeholder
+ * values ("hare: needed"); the colon-only label avoids themed-title false
+ * positives ("Hare-raising"). Returns the title unchanged when no label matches.
+ */
+function extractTitleHares(title: string | undefined): { hares?: string; title?: string } {
+  if (!title) return { title };
+  const hares = extractHaresFromDescription(title, [TITLE_HARE_RE]);
+  if (!hares) return { title };
+  const m = TITLE_HARE_RE.exec(title);
+  return { hares, title: m ? title.slice(0, m.index) : title };
+}
+
 /** Build a RawEventData from an Apollo event entry. */
 export function buildRawEventFromApollo(
   ev: ApolloEvent,
@@ -525,27 +540,16 @@ export function buildRawEventFromApollo(
   // Try the colon-form helper first (matches DEFAULT_HARE_PATTERNS in
   // google-calendar/adapter.ts). Fall back to the Meetup-local dash-separator
   // pattern for kennels like CHH3 that always write "Hares - X". See #953.
-  let hares =
+  const descHares =
     (descForHares ? extractHaresFromDescription(descForHares) : undefined)
     ?? extractHaresFromMeetupDescription(descForHares);
 
   // Final fallback (#1270): some kennels (FEH3) embed the hare line directly in
-  // the Meetup *title* ("Trail 2578, hare: salty cliterature ...") and leave the
-  // description hare-less. Only when neither description path produced hares,
-  // run the shared extractHares against the title with the explicit colon
-  // label. Its cleanAndFilterHares rejects CTA/placeholder values ("hare:
-  // needed"); the colon-only label avoids themed-title false positives
-  // ("Hare-raising"). When it fires, strip the matched "hare:" span out of the
-  // title so the names don't appear twice (title + Hares field).
-  let titleForDisplay = ev.title;
-  if (!hares && ev.title) {
-    const titleHares = extractHaresFromDescription(ev.title, [TITLE_HARE_RE]);
-    if (titleHares) {
-      hares = titleHares;
-      const m = TITLE_HARE_RE.exec(ev.title);
-      if (m) titleForDisplay = ev.title.slice(0, m.index);
-    }
-  }
+  // the Meetup *title* and leave the description hare-less. Only consult the
+  // title when neither description path produced hares.
+  const fromTitle = descHares ? undefined : extractTitleHares(ev.title);
+  const hares = descHares ?? fromTitle?.hares;
+  const titleForDisplay = fromTitle?.title ?? ev.title;
   const cleanedDesc = cleanMeetupDescription(ev.description, state);
 
   return {

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -480,6 +480,13 @@ export function cleanMeetupTitle(raw: string | null | undefined): string | undef
   return t.replace(/[\s,:\-–—]+$/, "").trim() || undefined; // NOSONAR S5852 — single char class + `+` anchored to `$`, linear in input length
 }
 
+// #1270 — explicit "hare(s):" label for hares embedded in a Meetup *title*
+// (FEH3: "Trail 2578, hare: salty cliterature ..."). Colon-only on purpose: a
+// hyphen separator (as the description matcher allows) would misfire on themed
+// titles like "Hare-raising Halloween Hash". Optional space before the colon
+// covers "Hare : BBQ". ReDoS-safe: `(\S.*)`, no `$` anchor, no nested quantifier.
+const TITLE_HARE_RE = /\bhares?\s*:\s*(\S.*)/i;
+
 /** Build a RawEventData from an Apollo event entry. */
 export function buildRawEventFromApollo(
   ev: ApolloEvent,
@@ -518,15 +525,33 @@ export function buildRawEventFromApollo(
   // Try the colon-form helper first (matches DEFAULT_HARE_PATTERNS in
   // google-calendar/adapter.ts). Fall back to the Meetup-local dash-separator
   // pattern for kennels like CHH3 that always write "Hares - X". See #953.
-  const hares =
+  let hares =
     (descForHares ? extractHaresFromDescription(descForHares) : undefined)
     ?? extractHaresFromMeetupDescription(descForHares);
+
+  // Final fallback (#1270): some kennels (FEH3) embed the hare line directly in
+  // the Meetup *title* ("Trail 2578, hare: salty cliterature ...") and leave the
+  // description hare-less. Only when neither description path produced hares,
+  // run the shared extractHares against the title with the explicit colon
+  // label. Its cleanAndFilterHares rejects CTA/placeholder values ("hare:
+  // needed"); the colon-only label avoids themed-title false positives
+  // ("Hare-raising"). When it fires, strip the matched "hare:" span out of the
+  // title so the names don't appear twice (title + Hares field).
+  let titleForDisplay = ev.title;
+  if (!hares && ev.title) {
+    const titleHares = extractHaresFromDescription(ev.title, [TITLE_HARE_RE]);
+    if (titleHares) {
+      hares = titleHares;
+      const m = TITLE_HARE_RE.exec(ev.title);
+      if (m) titleForDisplay = ev.title.slice(0, m.index);
+    }
+  }
   const cleanedDesc = cleanMeetupDescription(ev.description, state);
 
   return {
     date,
     kennelTags: [resolvedKennelTag],
-    title: cleanMeetupTitle(ev.title),
+    title: cleanMeetupTitle(titleForDisplay),
     runNumber: extractRunNumber ? extractHashRunNumber(ev.title) : undefined,
     description: cleanedDesc,
     hares,


### PR DESCRIPTION
Quick-win bundle: 4 long-deferred audit issues across 4 shared BASE adapters. Investigation showed the bot's "adapter bug" framing held for 2 of them and was a **misdiagnosis** for the other 2 (which had self-healed in prod). Each adapter gets a fixture-backed regression guard; every change is additive and live-verified.

## #1270 — Fort Eustis H3 (Meetup): hares embedded in the title
FEH3 admins put the hare line in the Meetup **title** (`Trail 2578, hare: salty cliterature ...`) and leave the description hare-less, so `haresText` was empty.
- When neither description path yields hares, run the **shared `extractHares`** against the title with an explicit `hare(s):` colon label, then strip the matched span out of the title (names no longer appear twice).
- **Colon-only** on purpose: a hyphen separator would misfire on themed titles like `Hare-raising Halloween Hash`; `cleanAndFilterHares` additionally drops CTA/placeholder values (`hare: needed`). Mirrors the existing `google-calendar`/`ical` title-hare pattern.
- **Live-verified:** Trail 2578 → title `Trail 2578` + hares populated; Trail 2577 likewise; description-hare events unchanged.

## #1126 — EWH3 (Hash Rego): missing per-event cost
`ParsedEvent.cost` / the index-table cost were already parsed but never reached `RawEventData`. The merge already maps `RawEventData.cost → Event.cost` (no migration — `Event.cost` exists).
- Spread `cost` onto the single-day and multi-day **umbrella parent** rows; child days omit it (one registration fee, not `$N/day`). Index-fallback path normalizes via the shared `normalizeCostSigil`.
- **Live-verified:** EWH3 #1521 → `$10`, EWH3 Pub Crawl → `$45` (issue's #1516 has aged out of the 90-day window; identical extraction now applies to all 15 Hash Rego kennels).

## #1242 — East Bay H3 (iCal): **self-healed**
The dedicated ebh3.com VEVENT for #1164 already carries `LOCATION` + `DESCRIPTION` + a leading `Hares:` line, and the adapter extracts all three. **Prod confirms the canonical Event is now correct** (hares/location/description populated; the dedicated source is healthy with 41 RawEvents). The original empty state was a transient — #1164 was first scraped before the kennel filled in details (soonest events always are) and self-healed on re-scrape. Added a regression fixture (the real #1164 VEVENT shape) locking in rich extraction.

## #1244 — Kowloon H3 (Google Sheets): **self-healed**
`buildEventFromSheetRow` reads every field from the same row, and `parseDate("10-May-26") → 2026-05-10` (no +1 shift). **Prod confirms #2910 = TIMBITS / Macau / 10-May** (exactly the issue's "should be") with **0 `(kennel,date)` collisions** — the off-by-one is gone. Added a multi-row fixture (exact Kowloon layout: leading junk + header rows, CRLF, `extraHares`) proving each run stays welded to its own row.

> Note for the seed owner (out of scope here): the Kowloon source has no `skipRows`; the 3 leading non-data rows currently self-skip (their date cells fail parsing), but adding `skipRows: 3` would make that explicit.

## Verification
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (8393 passing)
- All 4 named runs live-verified against production sources.
- `/code-review` (high) + `/simplify` run; review findings (colon-only tightening, multi-day cost-on-parent-only, title-span strip) applied.

Closes #1270
Closes #1126
Closes #1242
Closes #1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)