### PR TITLE
feat(hashstats): onboard 4 public HashStats kennels (#1901) + auth-gated NO-GO (#1902)

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -67,6 +67,7 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "sch4": ["SCH4", "Sin City H4", "Sin City Hash", "Cincinnati Hash"],
     "qch4": ["QCH4", "QCH3", "Queen City H4", "Queen City Hash"],
     "lvh3-cin": ["LVH3", "Licking Valley H3", "Licking Valley Hash"],
+    "sch4bash": ["SCH4BASH", "Sin City Bike Hash", "Sin City Bike H3"],
     "cleh4": ["CleH4", "Cleveland H4", "Cleveland Hash", "Cleveland H3"],
     "rch3": ["RCH3", "Rubber City H3", "Rubber City Hash", "Akron Hash", "RCH3-OH"],
     "renh3": ["RH3", "Renegade H3", "Renegade Hash", "RH3 Columbus", "RH3C"],

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2660,7 +2660,7 @@ export const KENNELS: KennelSeed[] = [
       // HashStats archive (28 events, last run 2020-08-15) — currently dormant.
       kennelCode: "sch4bash", shortName: "Sin City Bike Hash", fullName: "Sin City Bike Hash", region: "Cincinnati, OH",
       description: "Cincinnati bike hash, sister kennel of Sin City H4. Currently dormant.",
-      latitude: 39.10, longitude: -84.51,
+      latitude: 39.1, longitude: -84.51,
     },
     // --- Cleveland ---
     {

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2655,6 +2655,13 @@ export const KENNELS: KennelSeed[] = [
       description: "Monthly hash in Cincinnati and Northern Kentucky. Never cancels for weather.",
       latitude: 39.10, longitude: -84.51,
     },
+    {
+      // Sister kennel of Sin City H4 (sch4). Sole source is the retrospective
+      // HashStats archive (28 events, last run 2020-08-15) — currently dormant.
+      kennelCode: "sch4bash", shortName: "Sin City Bike Hash", fullName: "Sin City Bike Hash", region: "Cincinnati, OH",
+      description: "Cincinnati bike hash, sister kennel of Sin City H4. Currently dormant.",
+      latitude: 39.10, longitude: -84.51,
+    },
     // --- Cleveland ---
     {
       kennelCode: "cleh4", shortName: "Cleveland H4", fullName: "Cleveland Hash House Harriers and Harriettes", region: "Cleveland, OH",

--- a/prisma/seed-data/sources.test.ts
+++ b/prisma/seed-data/sources.test.ts
@@ -65,4 +65,24 @@ describe("SOURCES seed data invariants (#817 regression guard)", () => {
     expect(cfg.rrule).toBe(rrule);
     expect(cfg.startTime).toBe(startTime);
   });
+
+  // #1901: HashStats (and any future config.kennelSlugMap source) routes its
+  // fetch by the map's kennelCode keys, and scrape.ts scopes reconcile to those
+  // same keys (#1771). If a mapped key is NOT a linked SourceKennel (i.e. not in
+  // the row's kennelCodes), the reconcile guard fails CLOSED — it skips reconcile
+  // entirely to avoid false cancellations. Lock the invariant at the seed layer
+  // so a typo'd slug-map key can never silently disable reconcile in prod.
+  it("every config.kennelSlugMap key is also in the source's kennelCodes", () => {
+    const offenders: string[] = [];
+    for (const s of SOURCES) {
+      const slugMap = (s.config as { kennelSlugMap?: Record<string, string> } | undefined)
+        ?.kennelSlugMap;
+      if (!slugMap) continue;
+      const codes = new Set(s.kennelCodes ?? []);
+      for (const key of Object.keys(slugMap)) {
+        if (!codes.has(key)) offenders.push(`${s.name}: kennelSlugMap key "${key}" not in kennelCodes`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
 });

--- a/prisma/seed-data/sources.test.ts
+++ b/prisma/seed-data/sources.test.ts
@@ -66,21 +66,32 @@ describe("SOURCES seed data invariants (#817 regression guard)", () => {
     expect(cfg.startTime).toBe(startTime);
   });
 
-  // #1901: HashStats (and any future config.kennelSlugMap source) routes its
-  // fetch by the map's kennelCode keys, and scrape.ts scopes reconcile to those
-  // same keys (#1771). If a mapped key is NOT a linked SourceKennel (i.e. not in
-  // the row's kennelCodes), the reconcile guard fails CLOSED — it skips reconcile
-  // entirely to avoid false cancellations. Lock the invariant at the seed layer
-  // so a typo'd slug-map key can never silently disable reconcile in prod.
-  it("every config.kennelSlugMap key is also in the source's kennelCodes", () => {
+  // #1901: kennelSlugMap (kennelCode → external slug) appears in two shapes:
+  //  - HashStats reads `config.kennelSlugMap` at runtime; scrape.ts scopes
+  //    reconcile to those keys (#1771).
+  //  - HASHREGO carries a TOP-LEVEL `kennelSlugMap` that seed.ts destructures
+  //    into SourceKennel.externalSlug rows (seed.ts ~375).
+  // Both require the slug-map key set to match kennelCodes EXACTLY:
+  //  - a key not in kennelCodes is an unlinked SourceKennel — HashStats reconcile
+  //    then fails closed (skips reconcile), and HASHREGO writes no externalSlug;
+  //  - a kennelCode not in the map is a linked kennel this source can never
+  //    scrape/match/reconcile (dead link).
+  // Lock the bidirectional invariant across BOTH locations so either drift fails
+  // the build, never prod.
+  it("every source's kennelSlugMap key set (config or top-level) exactly matches its kennelCodes", () => {
     const offenders: string[] = [];
     for (const s of SOURCES) {
-      const slugMap = (s.config as { kennelSlugMap?: Record<string, string> } | undefined)
-        ?.kennelSlugMap;
+      const slugMap =
+        (s.config as { kennelSlugMap?: Record<string, string> } | undefined)?.kennelSlugMap ??
+        (s as { kennelSlugMap?: Record<string, string> }).kennelSlugMap;
       if (!slugMap) continue;
       const codes = new Set(s.kennelCodes ?? []);
-      for (const key of Object.keys(slugMap)) {
+      const keys = new Set(Object.keys(slugMap));
+      for (const key of keys) {
         if (!codes.has(key)) offenders.push(`${s.name}: kennelSlugMap key "${key}" not in kennelCodes`);
+      }
+      for (const code of codes) {
+        if (!keys.has(code)) offenders.push(`${s.name}: kennelCodes entry "${code}" missing from kennelSlugMap`);
       }
     }
     expect(offenders).toEqual([]);

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3339,6 +3339,67 @@ export const SOURCES = [
       },
       kennelCodes: ["sch4"],
     },
+    // Remaining public hashingstats.com kennels (#1901). Per-kennel rows (not a
+    // single bundled multi-slug row) so a capped/failed fetch on one archive can't
+    // block reconcile for the others, and name↔url↔kennel provenance stays aligned.
+    // All trust 6 — historical-backfill secondaries behind each kennel's primary
+    // (QCH4/SWOT/LVH3 have GCal trust-7 primaries; SCH4BASH is sole-source/dormant).
+    // For every row kennelSlugMap keys === kennelCodes (reconcile fail-closed guard).
+    {
+      name: "QCH4 HashStats",
+      url: "https://hashingstats.com/QCH4",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "weekly",
+      scrapeDays: 20000,
+      config: {
+        kennelSlugMap: { qch4: "QCH4" },
+      },
+      kennelCodes: ["qch4"],
+    },
+    {
+      name: "SWOT HashStats",
+      url: "https://hashingstats.com/SWOT",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "weekly",
+      scrapeDays: 20000,
+      config: {
+        kennelSlugMap: { "swot-h3": "SWOT" },
+      },
+      kennelCodes: ["swot-h3"],
+    },
+    {
+      name: "LVH3 HashStats",
+      url: "https://hashingstats.com/LVH3",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "weekly",
+      scrapeDays: 20000,
+      config: {
+        kennelSlugMap: { "lvh3-cin": "LVH3" },
+      },
+      kennelCodes: ["lvh3-cin"],
+    },
+    {
+      // sch4bash (Sin City Bike Hash) is dormant and HashStats is its SOLE
+      // source. Reconcile is still safe: HashStats returns the COMPLETE archive
+      // every scrape, so its own canonical events are never missing/orphaned,
+      // and the adapter's capped-page guard blocks reconcile on any partial
+      // fetch. HashStats never emits future-dated rows, so if this kennel ever
+      // reactivates, add a live primary source (GCal/FB) — that restores
+      // another-source protection for upcoming events. (#1901 / Codex review)
+      name: "SCH4BASH HashStats",
+      url: "https://hashingstats.com/SCH4BASH",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "weekly",
+      scrapeDays: 20000,
+      config: {
+        kennelSlugMap: { sch4bash: "SCH4BASH" },
+      },
+      kennelCodes: ["sch4bash"],
+    },
     // --- Columbus (Renegade H3 website) ---
     {
       name: "Renegade H3 Website",


### PR DESCRIPTION
## What

Onboards the 4 remaining **public** `hashingstats.com` kennels onto the HashStats archive adapter (shipped in #1900, proof kennel SCH4), and records the **NO-GO** investigation result for the auth-gated hosts (#1902).

**Pure seed data** — `HashStatsAdapter` and the reconcile pipeline are unchanged.

### #1901 — 4 public kennels

| Slug | kennelCode | events | range | source role |
|---|---|---|---|---|
| QCH4 | `qch4` | 219 | 2017-06 → 2026-06 | trust-6 secondary (GCal trust-7 primary) |
| SWOT | `swot-h3` | 205 | 2002-01 → 2024-03 | trust-6 secondary (GCal trust-7 primary) |
| LVH3 | `lvh3-cin` | 179 | 2006-02 → 2021-09 | trust-6 secondary (GCal trust-7 primary) |
| SCH4BASH | `sch4bash` *(new kennel)* | 28 | 2013-10 → 2020-08 | sole source (dormant) |

- 3 kennels (`qch4`/`swot-h3`/`lvh3-cin`) already exist → reused, no dupes.
- `sch4bash` (Sin City Bike Hash, Cincinnati, sister of `sch4`) is newly created — dormant, but has a real source (28 archive events), so it satisfies the no-sourceless-kennels rule.

### Design

- **Per-kennel source rows**, each mirroring the existing `SCH4 HashStats` row (own name/url, single-entry `config.kennelSlugMap`, `kennelCodes`, trust 6, `scrapeDays: 20000`). Not a single bundled multi-slug row — HashStats endpoints are per-kennel anyway (one POST per slug regardless), so bundling buys nothing while coupling reconcile across kennels and forcing a rename of `SCH4 HashStats`. Per-kennel isolates a capped/failed fetch to its own reconcile scope and keeps name↔url↔kennel provenance aligned. `SCH4 HashStats` is untouched.
- **Reconcile fail-closed invariant** (#1771): for every row `kennelSlugMap` keys === `kennelCodes`. Locked by a new seed-invariant test that generalizes to **any** future `kennelSlugMap` source, so a typo'd slug-map key can never silently disable reconcile in prod.
- `sch4bash` reconcile safety is documented inline: HashStats returns the **complete** archive every scrape (its events are never orphaned) and the adapter's capped-page guard blocks reconcile on any partial fetch; HashStats never emits future-dated rows, so a live primary should be added if the kennel reactivates.

### #1902 — auth-gated hosts: **NO-GO**

All 6 auth-gated kennels (BH3, DH3, MVH3, ONINH3, RH3C, UNMASKEDH3 on `stats.daytonhhh.org` / `*.hashstats.org`) have **no public surface** — every path returns HTTP 403 or a JS `/auth` redirect, with both bot and browser UA + `Sec-Fetch-*` headers. browser-render would only render the same wall; no credential hacking is in scope. Several already have primary GCal/FB/HTML sources, so HashStats would be history-only backfill anyway. Documented + closed as blocked-pending-credentials: [#1902 comment](https://github.com/johnrclem/hashtracks-web/issues/1902#issuecomment-4612110446).

## Verification

- **Live-verified** each kennel via `HashStatsAdapter.fetch` against the live endpoints: 219 / 205 / 179 / 28 events, **0 errors**, all dates valid, all present `startTime` in `HH:MM`, run numbers populated.
- `npx tsc --noEmit` ✓ · `npm run lint` ✓ (0 errors) · `npm test` ✓ (289 files / 8382 tests).
- `/codex:adversarial-review` (1 P2 on dormant sole-source reconcile — addressed via inline doc; archive completeness + capped-page guard make false-cancel impossible in practice) + `/simplify` (clean) run pre-PR.

## Post-merge (manual — not applied by Vercel build)

`npx prisma db seed` against prod (creates `sch4bash`, the 4 source rows + their `SourceKennel` links + aliases), then trigger a scrape of the 4 new sources to backfill the archives.

Closes #1901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
