### PR TITLE
Dead/stale-source triage: 8 kennels, 10 issues

### DIFF
--- a/prisma/migrations/20260603075924_triage_hkfh3_rename_elah3_hide/migration.sql
+++ b/prisma/migrations/20260603075924_triage_hkfh3_rename_elah3_hide/migration.sql
@@ -1,0 +1,174 @@
+-- Dead/stale-source triage (#1373/#1374 HKFH3, #1358 Hebe, #1130 ELAH3,
+-- #1144/#1459 VTH3).
+--
+-- The seed files (prisma/seed-data/{kennels,sources,aliases}.ts) carry the
+-- same corrections so fresh DBs land identical data, but Vercel runs only
+-- `prisma migrate deploy` (never `prisma db seed`). Without this migration the
+-- only path to prod would be a manual seed — so the live `Source`/`Kennel`
+-- rows are converged here. Structure + idioms mirror
+-- 20260521020000_fix_se_asia_static_schedules (per-area DO block, NOTICE-not-
+-- RAISE on missing seed rows so a pre-seed deploy doesn't abort, `IS DISTINCT
+-- FROM` divergence guards + `COALESCE` so re-runs and admin edits are no-ops).
+--
+-- Two changes the seed genuinely cannot make on existing rows and that only
+-- this migration can apply:
+--   * Kennel.fullName — seed deliberately never updates fullName on existing
+--     rows (admin-curation guard, prisma/seed.ts).
+--   * Kennel.isHidden — not a seed PROFILE_FIELD; seed never writes it.
+--
+-- VTH3's stale "Future VTH3 Run" placeholder EVENTS are intentionally NOT
+-- deleted here — that cleanup ships as the post-merge one-shot
+-- scripts/cleanup-vth3-meetup-placeholders.ts (provenance-scoped, dry-run
+-- first). This migration only flips the dead Meetup source off so it stops
+-- generating new placeholders on the next scrape.
+
+BEGIN;
+
+-- ===== HKFH3 (#1373 / #1374): "Full House" → "Hong Kong Friday Hash" =====
+DO $$
+DECLARE
+  v_kennel_code  text := 'hkfh3';
+  v_source_name  text := 'HKFH3 Static Schedule';
+  v_source_type  text := 'STATIC_SCHEDULE';
+  v_old_fullname text := 'Hong Kong Full House Hash House Harriers';
+  v_new_fullname text := 'Hong Kong Friday Hash House Harriers';
+  v_new_url      text := 'https://www.facebook.com/groups/197105523127/';
+  v_new_descr    text := 'Monthly Friday evening trail. Check the HK Friday Hash Facebook group for run details and start location.';
+  v_facebook_url text := 'https://www.facebook.com/groups/197105523127/';
+  v_contact      text := 'HKFridayHash@gmail.com';
+  v_founder      text := 'Stash & Hopeless';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN
+    RAISE NOTICE 'Kennel "%" not found — updates will no-op (run prisma db seed)', v_kennel_code;
+  END IF;
+
+  -- Correct the long name only if still on the audited stale value (admin
+  -- curation to anything else is preserved).
+  UPDATE "Kennel"
+  SET "fullName" = v_new_fullname,
+      "updatedAt" = NOW() AT TIME ZONE 'UTC'
+  WHERE "kennelCode" = v_kennel_code
+    AND "fullName" = v_old_fullname;
+
+  -- Fill recoverable profile fields when still NULL (don't stomp admin edits).
+  UPDATE "Kennel"
+  SET "facebookUrl" = COALESCE("facebookUrl", v_facebook_url),
+      "contactEmail" = COALESCE("contactEmail", v_contact),
+      founder = COALESCE(founder, v_founder),
+      "updatedAt" = NOW() AT TIME ZONE 'UTC'
+  WHERE "kennelCode" = v_kennel_code
+    AND ("facebookUrl" IS NULL OR "contactEmail" IS NULL OR founder IS NULL);
+
+  -- Repoint the dead source URL + drop the "cadence uncertain" caveat.
+  UPDATE "Source"
+  SET url = v_new_url,
+      config = COALESCE(config, '{}'::jsonb) || jsonb_build_object('defaultDescription', v_new_descr),
+      "updatedAt" = NOW() AT TIME ZONE 'UTC'
+  WHERE name = v_source_name
+    AND type::text = v_source_type
+    AND (url IS DISTINCT FROM v_new_url OR config->>'defaultDescription' IS DISTINCT FROM v_new_descr);
+END $$;
+
+-- ===== Hebe H3 (#1358): dead Page handle → real FB group =====
+DO $$
+DECLARE
+  v_source_name text := 'Hebe H3 Static Schedule';
+  v_source_type text := 'STATIC_SCHEDULE';
+  v_new_url     text := 'https://www.facebook.com/groups/HebeH3';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Source" WHERE name = v_source_name AND type::text = v_source_type) THEN
+    RAISE NOTICE 'Source "%" not found — UPDATE will no-op (run prisma db seed)', v_source_name;
+  END IF;
+
+  UPDATE "Source"
+  SET url = v_new_url,
+      "updatedAt" = NOW() AT TIME ZONE 'UTC'
+  WHERE name = v_source_name
+    AND type::text = v_source_type
+    AND url IS DISTINCT FROM v_new_url;
+END $$;
+
+-- ===== ELAH3 (#1130): defunct/mis-registered — hide kennel + disable source =====
+DO $$
+DECLARE
+  v_kennel_code text := 'elah3';
+  v_source_name text := 'East LA H3 Google Calendar';
+  v_source_type text := 'GOOGLE_CALENDAR';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN
+    RAISE NOTICE 'Kennel "%" not found — update will no-op (run prisma db seed)', v_kennel_code;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM "Source" WHERE name = v_source_name AND type::text = v_source_type) THEN
+    RAISE NOTICE 'Source "%" not found — update will no-op (run prisma db seed)', v_source_name;
+  END IF;
+
+  -- Hide the kennel from the public directory + hareline (the only "source" is
+  -- one ex-member's personal travel calendar; no third-party trace exists).
+  UPDATE "Kennel"
+  SET "isHidden" = true,
+      "updatedAt" = NOW() AT TIME ZONE 'UTC'
+  WHERE "kennelCode" = v_kennel_code
+    AND "isHidden" = false;
+
+  -- Disable the source so we stop ingesting the personal-travel events.
+  UPDATE "Source"
+  SET enabled = false,
+      "updatedAt" = NOW() AT TIME ZONE 'UTC'
+  WHERE name = v_source_name
+    AND type::text = v_source_type
+    AND enabled = true;
+END $$;
+
+-- ===== VTH3 (#1144 / #1459): disable dead Meetup source =====
+DO $$
+DECLARE
+  v_source_name text := 'Von Tramp H3 Meetup';
+  v_source_type text := 'MEETUP';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Source" WHERE name = v_source_name AND type::text = v_source_type) THEN
+    RAISE NOTICE 'Source "%" not found — update will no-op (run prisma db seed)', v_source_name;
+  END IF;
+
+  -- Meetup group is gone ("Group not found"); disable so it stops generating
+  -- "Future VTH3 Run" placeholders. Existing placeholder events are removed
+  -- post-merge via scripts/cleanup-vth3-meetup-placeholders.ts. The FB Hosted
+  -- Events source for VTH3 stays enabled.
+  UPDATE "Source"
+  SET enabled = false,
+      "updatedAt" = NOW() AT TIME ZONE 'UTC'
+  WHERE name = v_source_name
+    AND type::text = v_source_type
+    AND enabled = true;
+END $$;
+
+-- Verify post-state. EXISTS predicates rather than SELECT...INTO: they no-op
+-- cleanly on a pre-seed DB (row absent) and don't assume a single matching row
+-- (Source is @@unique([name,type]) and kennelCode is unique, so a match is
+-- always ≤1, but EXISTS is the idiomatic shape for a "should be no rows left in
+-- the bad state" assertion).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "Kennel" WHERE "kennelCode" = 'hkfh3' AND "fullName" = 'Hong Kong Full House Hash House Harriers'
+  ) THEN
+    RAISE EXCEPTION 'hkfh3 fullName still has the stale "Full House" value after migration';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = 'elah3' AND "isHidden" = false) THEN
+    RAISE EXCEPTION 'elah3 isHidden is not true after migration';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "Source" WHERE name = 'East LA H3 Google Calendar' AND type::text = 'GOOGLE_CALENDAR' AND enabled = true
+  ) THEN
+    RAISE EXCEPTION 'ELAH3 Google Calendar source is still enabled after migration';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "Source" WHERE name = 'Von Tramp H3 Meetup' AND type::text = 'MEETUP' AND enabled = true
+  ) THEN
+    RAISE EXCEPTION 'VTH3 Meetup source is still enabled after migration';
+  END IF;
+END $$;
+
+COMMIT;

--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -493,7 +493,9 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "lsw-h3": ["LSW", "Little Sai Wan H3", "Little Sai Wan Hash", "LSW H3", "LSWH3"],
     "lh4-hk": ["Ladies H4", "HK Ladies H4", "Ladies Hash HK", "HKLH4", "Hong Kong Ladies Hash"],
     "kowloon-h3": ["Kowloon H3", "Kowloon Hash", "KH3", "Kowloon HHH"],
-    "hkfh3": ["HKFH3", "HK Full House", "Full House H3", "Hong Kong Full House Hash"],
+    // #1374: kennel is "Hong Kong Friday Hash"; the "Full House" entries are the
+    // old-name aliases kept for rename safety.
+    "hkfh3": ["HKFH3", "HK Friday Hash", "Hong Kong Friday Hash", "HK Full House", "Full House H3", "Hong Kong Full House Hash"],
     "fch3-hk": ["Free China H3", "Free China Hash", "FCH3 HK", "Free China HHH"],
     "hebe-h3": ["Hebe H3", "Hebe Hash", "Hebe HHH", "Hebe Haven Hash"],
     // Thailand

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3949,8 +3949,16 @@ export const KENNELS: KennelSeed[] = [
       latitude: 22.3200, longitude: 114.1700,
     },
     {
-      kennelCode: "hkfh3", shortName: "HKFH3", fullName: "Hong Kong Full House Hash House Harriers",
+      // #1374: "HKFH3" = Hong Kong Friday Hash (not "Full House"). This is the
+      // canonical name for fresh DBs (seed CREATE uses it); the existing prod
+      // row is renamed by the companion migration, since seed never updates
+      // fullName on existing rows. Profile fields below were NULL in prod and
+      // are filled by the migration (Vercel skips db seed).
+      kennelCode: "hkfh3", shortName: "HKFH3", fullName: "Hong Kong Friday Hash House Harriers",
       region: "Hong Kong", country: "Hong Kong",
+      facebookUrl: "https://www.facebook.com/groups/197105523127/",
+      contactEmail: "HKFridayHash@gmail.com",
+      founder: "Stash & Hopeless",
       scheduleDayOfWeek: "Friday", scheduleTime: "7:00 PM", scheduleFrequency: "Monthly",
       scheduleNotes: "At least monthly Friday evening trails around Hong Kong.",
       description: "Hong Kong's Friday hash. Runs at least monthly around Hong Kong.",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2268,6 +2268,12 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 180,
+      // #1144 / #1459: Meetup group migrated off the platform — the URL returns
+      // "Group not found" and the adapter only ever ingested a recurring
+      // "Future VTH3 Run" placeholder slot. Disabled; the FB Hosted Events
+      // source (below) carries real events. Existing placeholder Events are
+      // cleaned up post-merge via scripts/cleanup-vth3-meetup-placeholders.ts.
+      enabled: false,
       config: {
         groupUrlname: "vontramph3",
         kennelTag: "vth3",
@@ -3123,6 +3129,11 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "every_6h",
       scrapeDays: 90,
+      // #1130: kennel is defunct/mis-registered — the only "source" is one
+      // ex-member's personal calendar (Wisconsin travel notes, no real trails)
+      // and no third-party trace of ELAH3 exists. Kennel hidden via migration;
+      // source disabled so we stop pulling personal-travel events.
+      enabled: false,
       config: { defaultKennelTag: "elah3" },
       kennelCodes: ["elah3"],
     },
@@ -5126,7 +5137,9 @@ export const SOURCES = [
     // --- HKFH3 (STATIC_SCHEDULE) ---
     {
       name: "HKFH3 Static Schedule",
-      url: "https://www.facebook.com/hkfullhousehash",
+      // #1374: kennel is "Hong Kong Friday Hash" (HKFH3), not "Full House"; the
+      // old hkfullhousehash handle 404s. Working FB group ("HK Friday Hash").
+      url: "https://www.facebook.com/groups/197105523127/",
       type: "STATIC_SCHEDULE" as const,
       trustLevel: 3,
       scrapeFreq: "weekly",
@@ -5138,7 +5151,7 @@ export const SOURCES = [
         startTime: "19:00",
         defaultTitle: "HKFH3 Monthly Run",
         defaultLocation: "Hong Kong",
-        defaultDescription: "Monthly Friday evening trail (exact cadence uncertain — at least monthly per available evidence). Check Facebook for run details and start location.",
+        defaultDescription: "Monthly Friday evening trail. Check the HK Friday Hash Facebook group for run details and start location.",
       },
       kennelCodes: ["hkfh3"],
     },
@@ -5164,7 +5177,8 @@ export const SOURCES = [
     // --- Hebe H3 (STATIC_SCHEDULE) ---
     {
       name: "Hebe H3 Static Schedule",
-      url: "https://www.facebook.com/hebehash",
+      // #1358: old hebehash Page handle 404s; real presence is the FB group.
+      url: "https://www.facebook.com/groups/HebeH3",
       type: "STATIC_SCHEDULE" as const,
       trustLevel: 3,
       scrapeFreq: "weekly",

--- a/scripts/cleanup-vth3-meetup-placeholders.ts
+++ b/scripts/cleanup-vth3-meetup-placeholders.ts
@@ -1,0 +1,175 @@
+/**
+ * One-shot cleanup for the stale "Future VTH3 Run" placeholder Events left
+ * behind by the now-disabled Von Tramp H3 Meetup source (#1144 / #1459).
+ *
+ * Background:
+ *   Von Tramp migrated off Meetup — https://www.meetup.com/vontramph3/ returns
+ *   "Group not found". Before it died the group published real trails (the
+ *   "VTH3 Trail #NNN: …" events, which we keep), but its final state was a
+ *   single recurring placeholder slot titled "Future VTH3 Run — First and Third
+ *   Saturdays of the Month" (a/k/a "Future VTH3 Run"). The Meetup source is now
+ *   `enabled: false` in seed, so it will never be re-scraped — which means the
+ *   reconciler (only runs while scraping enabled sources) will never cancel
+ *   these placeholders. They would otherwise linger, future-dated, on the
+ *   public kennel page for months until their dates pass.
+ *
+ *   This is the canonical-ghost cleanup that accompanies retiring a source
+ *   (memory: feedback_parser_fix_canonical_ghosts). The kennel stays visible;
+ *   its real history (#079–#089 etc.) is untouched and the FB Hosted Events
+ *   source remains for future events (its checkpoint/IP limitation is tracked
+ *   in a separate follow-up).
+ *
+ * Selection (intentionally narrow):
+ *   Events for the `vth3` kennel whose title starts with "Future VTH3 Run"
+ *   AND whose RawEvents all trace to the retired Meetup source. Real trails are
+ *   titled "VTH3 Trail #NNN: …", so live events are never matched. Events with
+ *   human check-ins (user RSVP or misman) are SKIPPED. The actual delete goes
+ *   through the shared race-safe deleteLeakedEvent helper (FOR UPDATE lock +
+ *   delete-time required-empty checks), so a check-in that races in after the
+ *   snapshot rolls that event's delete back instead of destroying it.
+ *
+ * Run order (POST-merge — Vercel deploys schema/migration but not seed data):
+ *   1. npx prisma db seed                                       # disables the Meetup source
+ *   2. npx tsx scripts/cleanup-vth3-meetup-placeholders.ts      # dry run
+ *   3. CLEANUP_APPLY=1 npx tsx scripts/cleanup-vth3-meetup-placeholders.ts  # apply
+ */
+
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
+import {
+  deleteLeakedEvent,
+  DeleteSafetyViolationError,
+  ForeignRawSourceError,
+} from "./lib/delete-leaked-event";
+
+const KENNEL_CODE = "vth3";
+export const PLACEHOLDER_TITLE_PREFIX = "Future VTH3 Run";
+// Provenance guard: only events provably produced by THIS retired source are
+// deletable. The title prefix alone is not enough — a future FB/website import
+// or an admin edit could in theory reuse it, and this is a delete path.
+const MEETUP_SOURCE_NAME = "Von Tramp H3 Meetup";
+const APPLY = process.env.CLEANUP_APPLY === "1";
+
+async function main() {
+  const kennel = await prisma.kennel.findFirst({
+    where: { kennelCode: KENNEL_CODE },
+    select: { id: true },
+  });
+  if (!kennel) throw new Error(`Kennel ${KENNEL_CODE} not found`);
+
+  const meetupSource = await prisma.source.findFirst({
+    where: { name: MEETUP_SOURCE_NAME, type: "MEETUP" },
+    select: { id: true },
+  });
+  if (!meetupSource) throw new Error(`Source "${MEETUP_SOURCE_NAME}" (MEETUP) not found`);
+
+  const placeholders = await prisma.event.findMany({
+    where: { kennelId: kennel.id, title: { startsWith: PLACEHOLDER_TITLE_PREFIX } },
+    select: {
+      id: true,
+      date: true,
+      title: true,
+      status: true,
+      // Both human check-in tables (user RSVPs + misman records) are non-cascading
+      // and must never be auto-deleted; count both as a skip guard.
+      _count: { select: { attendances: true, kennelAttendances: true, hares: true } },
+      rawEvents: { select: { sourceId: true, source: { select: { name: true } } } },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  console.log(
+    `Found ${placeholders.length} "${PLACEHOLDER_TITLE_PREFIX}…" events for ${KENNEL_CODE}.`,
+  );
+  if (placeholders.length === 0) return;
+
+  // An event is deletable only if it has zero human-attributable rows — check-ins
+  // (user OR misman) AND hare credits (EventHare can carry a userId / MISMAN_SYNC
+  // attribution, so it's not always disposable scraper metadata) — AND every one
+  // of its RawEvents traces to the retired Meetup source (≥1 Meetup raw, no
+  // foreign raw, no zero-raw orphan). Anything else is reported and skipped.
+  const deletable: typeof placeholders = [];
+  for (const e of placeholders) {
+    const sources = [
+      ...new Set(e.rawEvents.map((r) => r.source?.name ?? "(no source)")),
+    ].join(", ");
+    const hasMeetupRaw = e.rawEvents.some((r) => r.sourceId === meetupSource.id);
+    const hasForeignRaw = e.rawEvents.some((r) => r.sourceId !== meetupSource.id);
+    const meetupOnly = hasMeetupRaw && !hasForeignRaw;
+    const checkIns = e._count.attendances + e._count.kennelAttendances;
+    const skipReason =
+      checkIns > 0
+        ? "SKIP (has check-ins)"
+        : e._count.hares > 0
+          ? "SKIP (has hare credits)"
+          : !meetupOnly
+            ? "SKIP (not Meetup-only provenance)"
+            : null;
+    if (!skipReason) deletable.push(e);
+    console.log(
+      `  ${e.date.toISOString().slice(0, 10)}  status=${e.status}  ` +
+        `checkIns=${checkIns}  hares=${e._count.hares}  sources=[${sources}]` +
+        (skipReason ? `  → ${skipReason}` : ""),
+    );
+  }
+
+  const skipped = placeholders.length - deletable.length;
+  if (skipped > 0) {
+    console.warn(
+      `\n⚠️  ${skipped} matched event(s) skipped (check-ins, hare credits, or non-Meetup provenance). ` +
+        `Any of those on a "${PLACEHOLDER_TITLE_PREFIX}" event is unexpected — investigate before forcing.`,
+    );
+  }
+
+  if (!APPLY) {
+    console.log(
+      `\nDry run. Would delete ${deletable.length} event(s) (+ their RawEvents/EventKennel rows).`,
+    );
+    console.log("Re-run with CLEANUP_APPLY=1 to apply.");
+    return;
+  }
+
+  // Hard-delete via the shared race-safe helper. Under a FOR UPDATE lock it
+  // re-checks, AT DELETE TIME, that (a) no hare credit or human check-in raced
+  // in (user RSVP or misman) and (b) no foreign-source RawEvent has merged onto
+  // the event since our snapshot (forbidForeignRawSourceId = the Meetup source).
+  // Any violation rolls that event's delete back and is reported, not destroyed.
+  // Hard-deleting the RawEvents (vs unlinking) keeps the placeholder from ever
+  // re-materializing.
+  let deleted = 0;
+  for (const e of deletable) {
+    try {
+      await deleteLeakedEvent(
+        prisma,
+        e.id,
+        ["hares", "attendances", "kennelAttendances"],
+        meetupSource.id,
+      );
+      deleted++;
+    } catch (err) {
+      if (err instanceof DeleteSafetyViolationError || err instanceof ForeignRawSourceError) {
+        console.warn(`  ⚠️  Skipped ${e.id} (${e.date.toISOString().slice(0, 10)}): ${err.message}`);
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  console.log(`\n✅ Deleted ${deleted} of ${deletable.length} placeholder event(s).`);
+
+  // The deleted placeholders are future-dated and may have been VTH3's cached
+  // MAX(date); recompute lastEventDate via the canonical backfill (matches the
+  // nightly audit predicate exactly — see reference_lasteventdate_recompute_symmetry)
+  // so VTH3's activity sort/badge can't keep ranking off deleted rows.
+  const refreshed = await backfillLastEventDates();
+  console.log(`Recomputed lastEventDate (${refreshed} kennel row(s) updated).`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    // Set exitCode (don't process.exit) so the .finally() disconnect still runs.
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-vth3-meetup-placeholders.ts
+++ b/scripts/cleanup-vth3-meetup-placeholders.ts
@@ -51,6 +51,66 @@ export const PLACEHOLDER_TITLE_PREFIX = "Future VTH3 Run";
 const MEETUP_SOURCE_NAME = "Von Tramp H3 Meetup";
 const APPLY = process.env.CLEANUP_APPLY === "1";
 
+function fetchPlaceholders(kennelId: string) {
+  return prisma.event.findMany({
+    where: { kennelId, title: { startsWith: PLACEHOLDER_TITLE_PREFIX } },
+    select: {
+      id: true,
+      date: true,
+      title: true,
+      status: true,
+      // Both human check-in tables (user RSVPs + misman records) are non-cascading
+      // and must never be auto-deleted; count both as a skip guard.
+      _count: { select: { attendances: true, kennelAttendances: true, hares: true } },
+      rawEvents: { select: { sourceId: true, source: { select: { name: true } } } },
+    },
+    orderBy: { date: "asc" },
+  });
+}
+type PlaceholderEvent = Awaited<ReturnType<typeof fetchPlaceholders>>[number];
+
+// Returns a human-readable skip reason, or null if the event is safe to
+// hard-delete. Deletable only when it has zero human-attributable rows —
+// check-ins (user OR misman) AND hare credits (EventHare can carry a userId /
+// MISMAN_SYNC attribution) — AND every RawEvent traces to the retired Meetup
+// source (≥1 Meetup raw, no foreign raw, no zero-raw orphan).
+function classifyPlaceholder(e: PlaceholderEvent, meetupSourceId: string): string | null {
+  if (e._count.attendances + e._count.kennelAttendances > 0) return "SKIP (has check-ins)";
+  if (e._count.hares > 0) return "SKIP (has hare credits)";
+  const meetupOnly =
+    e.rawEvents.length > 0 && e.rawEvents.every((r) => r.sourceId === meetupSourceId);
+  if (!meetupOnly) return "SKIP (not Meetup-only provenance)";
+  return null;
+}
+
+// Hard-delete via the shared race-safe helper. Under a FOR UPDATE lock it
+// re-checks, AT DELETE TIME, that (a) no hare credit or human check-in raced in
+// and (b) no foreign-source RawEvent has merged onto the event since our
+// snapshot (forbidForeignRawSourceId = the Meetup source). Any violation rolls
+// that event's delete back and is reported, not destroyed. Hard-deleting the
+// RawEvents (vs unlinking) keeps the placeholder from ever re-materializing.
+async function applyDeletes(events: PlaceholderEvent[], meetupSourceId: string): Promise<number> {
+  let deleted = 0;
+  for (const e of events) {
+    try {
+      await deleteLeakedEvent(
+        prisma,
+        e.id,
+        ["hares", "attendances", "kennelAttendances"],
+        meetupSourceId,
+      );
+      deleted++;
+    } catch (err) {
+      if (err instanceof DeleteSafetyViolationError || err instanceof ForeignRawSourceError) {
+        console.warn(`  ⚠️  Skipped ${e.id} (${e.date.toISOString().slice(0, 10)}): ${err.message}`);
+        continue;
+      }
+      throw err;
+    }
+  }
+  return deleted;
+}
+
 async function main() {
   const kennel = await prisma.kennel.findFirst({
     where: { kennelCode: KENNEL_CODE },
@@ -64,52 +124,23 @@ async function main() {
   });
   if (!meetupSource) throw new Error(`Source "${MEETUP_SOURCE_NAME}" (MEETUP) not found`);
 
-  const placeholders = await prisma.event.findMany({
-    where: { kennelId: kennel.id, title: { startsWith: PLACEHOLDER_TITLE_PREFIX } },
-    select: {
-      id: true,
-      date: true,
-      title: true,
-      status: true,
-      // Both human check-in tables (user RSVPs + misman records) are non-cascading
-      // and must never be auto-deleted; count both as a skip guard.
-      _count: { select: { attendances: true, kennelAttendances: true, hares: true } },
-      rawEvents: { select: { sourceId: true, source: { select: { name: true } } } },
-    },
-    orderBy: { date: "asc" },
-  });
-
+  const placeholders = await fetchPlaceholders(kennel.id);
   console.log(
     `Found ${placeholders.length} "${PLACEHOLDER_TITLE_PREFIX}…" events for ${KENNEL_CODE}.`,
   );
   if (placeholders.length === 0) return;
 
-  // An event is deletable only if it has zero human-attributable rows — check-ins
-  // (user OR misman) AND hare credits (EventHare can carry a userId / MISMAN_SYNC
-  // attribution, so it's not always disposable scraper metadata) — AND every one
-  // of its RawEvents traces to the retired Meetup source (≥1 Meetup raw, no
-  // foreign raw, no zero-raw orphan). Anything else is reported and skipped.
-  const deletable: typeof placeholders = [];
+  const deletable: PlaceholderEvent[] = [];
   for (const e of placeholders) {
     const sources = [
       ...new Set(e.rawEvents.map((r) => r.source?.name ?? "(no source)")),
     ].join(", ");
-    const hasMeetupRaw = e.rawEvents.some((r) => r.sourceId === meetupSource.id);
-    const hasForeignRaw = e.rawEvents.some((r) => r.sourceId !== meetupSource.id);
-    const meetupOnly = hasMeetupRaw && !hasForeignRaw;
-    const checkIns = e._count.attendances + e._count.kennelAttendances;
-    const skipReason =
-      checkIns > 0
-        ? "SKIP (has check-ins)"
-        : e._count.hares > 0
-          ? "SKIP (has hare credits)"
-          : !meetupOnly
-            ? "SKIP (not Meetup-only provenance)"
-            : null;
+    const skipReason = classifyPlaceholder(e, meetupSource.id);
     if (!skipReason) deletable.push(e);
     console.log(
       `  ${e.date.toISOString().slice(0, 10)}  status=${e.status}  ` +
-        `checkIns=${checkIns}  hares=${e._count.hares}  sources=[${sources}]` +
+        `checkIns=${e._count.attendances + e._count.kennelAttendances}  ` +
+        `hares=${e._count.hares}  sources=[${sources}]` +
         (skipReason ? `  → ${skipReason}` : ""),
     );
   }
@@ -130,32 +161,7 @@ async function main() {
     return;
   }
 
-  // Hard-delete via the shared race-safe helper. Under a FOR UPDATE lock it
-  // re-checks, AT DELETE TIME, that (a) no hare credit or human check-in raced
-  // in (user RSVP or misman) and (b) no foreign-source RawEvent has merged onto
-  // the event since our snapshot (forbidForeignRawSourceId = the Meetup source).
-  // Any violation rolls that event's delete back and is reported, not destroyed.
-  // Hard-deleting the RawEvents (vs unlinking) keeps the placeholder from ever
-  // re-materializing.
-  let deleted = 0;
-  for (const e of deletable) {
-    try {
-      await deleteLeakedEvent(
-        prisma,
-        e.id,
-        ["hares", "attendances", "kennelAttendances"],
-        meetupSource.id,
-      );
-      deleted++;
-    } catch (err) {
-      if (err instanceof DeleteSafetyViolationError || err instanceof ForeignRawSourceError) {
-        console.warn(`  ⚠️  Skipped ${e.id} (${e.date.toISOString().slice(0, 10)}): ${err.message}`);
-        continue;
-      }
-      throw err;
-    }
-  }
-
+  const deleted = await applyDeletes(deletable, meetupSource.id);
   console.log(`\n✅ Deleted ${deleted} of ${deletable.length} placeholder event(s).`);
 
   // The deleted placeholders are future-dated and may have been VTH3's cached

--- a/scripts/lib/delete-leaked-event.test.ts
+++ b/scripts/lib/delete-leaked-event.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { deleteLeakedEvent, DeleteSafetyViolationError } from "./delete-leaked-event";
+import {
+  deleteLeakedEvent,
+  DeleteSafetyViolationError,
+  ForeignRawSourceError,
+} from "./delete-leaked-event";
 import type { PrismaClient } from "@/generated/prisma/client";
 
 /**
@@ -18,7 +22,12 @@ type RelationCounts = {
   eventKennels?: number;
 };
 
-function buildPrisma(counts: RelationCounts, lockedRows: Array<{ id: string }> = [{ id: "evt_1" }]) {
+function buildPrisma(
+  counts: RelationCounts,
+  lockedRows: Array<{ id: string }> = [{ id: "evt_1" }],
+  /** When set, `rawEvent.findFirst` (the foreign-provenance probe) returns this. */
+  foreignRaw: { sourceId: string | null } | null = null,
+) {
   const eventDelete = vi.fn().mockResolvedValue({});
   const queryRaw = vi.fn().mockResolvedValue(lockedRows);
   const tx = {
@@ -28,7 +37,10 @@ function buildPrisma(counts: RelationCounts, lockedRows: Array<{ id: string }> =
     kennelAttendance: {
       deleteMany: vi.fn().mockResolvedValue({ count: counts.kennelAttendances ?? 0 }),
     },
-    rawEvent: { deleteMany: vi.fn().mockResolvedValue({ count: counts.rawEvents ?? 0 }) },
+    rawEvent: {
+      deleteMany: vi.fn().mockResolvedValue({ count: counts.rawEvents ?? 0 }),
+      findFirst: vi.fn().mockResolvedValue(foreignRaw),
+    },
     eventKennel: { deleteMany: vi.fn().mockResolvedValue({ count: counts.eventKennels ?? 0 }) },
     event: { delete: eventDelete },
   };
@@ -109,5 +121,24 @@ describe("deleteLeakedEvent safety invariant", () => {
     await deleteLeakedEvent(prisma, "evt_1", ["rawEvents"]);
     expect(eventDelete).not.toHaveBeenCalled();
     expect(tx.rawEvent.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("throws ForeignRawSourceError (and never deletes) when a foreign-source RawEvent is present", async () => {
+    // A different source merged onto the event after the caller's snapshot.
+    const { prisma, eventDelete, tx } = buildPrisma({}, [{ id: "evt_1" }], { sourceId: "src_other" });
+    await expect(
+      deleteLeakedEvent(prisma, "evt_1", ["attendances"], "src_meetup"),
+    ).rejects.toBeInstanceOf(ForeignRawSourceError);
+    expect(eventDelete).not.toHaveBeenCalled();
+    // The provenance probe must run under the lock, before any relation delete.
+    expect(tx.rawEvent.findFirst).toHaveBeenCalledTimes(1);
+    expect(tx.rawEvent.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("deletes when forbidForeignRawSourceId is set and no foreign RawEvent exists", async () => {
+    const { prisma, eventDelete, tx } = buildPrisma({ rawEvents: 2 }, [{ id: "evt_1" }], null);
+    await deleteLeakedEvent(prisma, "evt_1", ["attendances", "kennelAttendances"], "src_meetup");
+    expect(tx.rawEvent.findFirst).toHaveBeenCalledTimes(1);
+    expect(eventDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/scripts/lib/delete-leaked-event.test.ts
+++ b/scripts/lib/delete-leaked-event.test.ts
@@ -140,5 +140,10 @@ describe("deleteLeakedEvent safety invariant", () => {
     await deleteLeakedEvent(prisma, "evt_1", ["attendances", "kennelAttendances"], "src_meetup");
     expect(tx.rawEvent.findFirst).toHaveBeenCalledTimes(1);
     expect(eventDelete).toHaveBeenCalledTimes(1);
+    // The provenance probe must run before any relation delete, or a foreign
+    // RawEvent could be destroyed before the guard sees it.
+    expect(tx.rawEvent.findFirst.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.rawEvent.deleteMany.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/scripts/lib/delete-leaked-event.ts
+++ b/scripts/lib/delete-leaked-event.ts
@@ -44,10 +44,36 @@ export class DeleteSafetyViolationError extends Error {
   }
 }
 
+/**
+ * Thrown (rolling back the transaction) when `forbidForeignRawSourceId` is set
+ * and a RawEvent from a different source is attached to the Event at delete
+ * time. Checked AFTER the FOR UPDATE lock so a concurrent merge can't slip a
+ * foreign RawEvent in past the caller's provenance snapshot.
+ */
+export class ForeignRawSourceError extends Error {
+  constructor(
+    readonly eventId: string,
+    readonly foreignSourceId: string | null,
+  ) {
+    super(
+      `Refusing to delete Event ${eventId}: a RawEvent from a non-allowed source ` +
+        `(${foreignSourceId ?? "unknown"}) was present at delete time.`,
+    );
+    this.name = "ForeignRawSourceError";
+  }
+}
+
 export async function deleteLeakedEvent(
   prisma: PrismaClient,
   eventId: string,
   requireZeroCounts: RequireZeroCount[] = [],
+  /**
+   * When set, the delete proceeds only if every RawEvent on the Event belongs
+   * to this source id (no foreign-provenance RawEvent exists). Enforced under
+   * the row lock so it's race-proof — for provenance-scoped cleanups that must
+   * not hard-delete an event another source has since merged onto.
+   */
+  forbidForeignRawSourceId?: string,
 ): Promise<void> {
   const existing = await prisma.event.findUnique({
     where: { id: eventId },
@@ -85,6 +111,19 @@ export async function deleteLeakedEvent(
     if (locked.length === 0) {
       console.log(`Event ${eventId} vanished before lock — nothing to delete.`);
       return;
+    }
+
+    // Provenance guard (under the lock, before any delete): refuse if a
+    // RawEvent from a different source was attached after the caller's
+    // snapshot — i.e. another source has merged onto this event since.
+    if (forbidForeignRawSourceId) {
+      const foreign = await tx.rawEvent.findFirst({
+        where: { eventId, sourceId: { not: forbidForeignRawSourceId } },
+        select: { sourceId: true },
+      });
+      if (foreign) {
+        throw new ForeignRawSourceError(eventId, foreign.sourceId);
+      }
     }
 
     const hareDeleted = await tx.eventHare.deleteMany({ where: { eventId } });


### PR DESCRIPTION
Deep-dive triage of long-festering dead/stale-source audit issues. Each needed a **decision** (replace / mark-defunct / accept-and-document), not just a code fix. No adapter code changed — anything requiring an adapter build/extend was filed as a scoped follow-up and the interim state accepted.

## Resolutions

| Issue(s) | Kennel | Decision | What shipped |
|---|---|---|---|
| #1373 #1374 | HKFH3 | **Rename / replace** | fullName "Full House" → "Hong Kong Friday Hash" (migration — seed never updates existing fullName); repoint dead `hkfullhousehash` handle → working FB group; fill `facebookUrl`/`contactEmail`/`founder`; add "HK Friday Hash" aliases (old "Full House" aliases kept for rename safety) |
| #1358 | Hebe H3 | **Accept + fix URL** | dead `facebook.com/hebehash` Page → real `facebook.com/groups/HebeH3` |
| #1130 | ELAH3 | **Mark defunct** | `isHidden=true` (migration) + disable the ex-member personal-travel calendar source. Kennel preserved, not deleted |
| #1144 #1459 | VTH3 | **Replace-source (partial)** | disable dead Meetup source (404'd group); FB source stays; placeholder events cleaned post-merge (script below); rich website scraper → follow-up |
| #1262 | GSH3 | **Accept** | FB-primary + STATIC-fallback is the documented design; past-event gap → follow-up |
| #1318 | Hollyweird (h6) | **Accept + follow-up** | fix needs adapter code (`/past_hosted_events`) → follow-up |
| #1417 | Survivor | **Investigated → follow-up** | live check: FB serves a **checkpoint page (HTTP 200, 0 event nodes)** to datacenter IPs — not config-fixable → follow-up |
| #1512 | JB H3 | **Accept + document** | sole source is a login-walled FB STATIC_SCHEDULE; Sat 17:00 has no live provenance → schedule-verification follow-up |

## How it reaches prod

Vercel runs `prisma migrate deploy` but **not** `db seed`, so all prod-relevant data changes live in the companion data migration `20260603075824_triage_hkfh3_rename_elah3_hide` (NOTICE-not-RAISE on missing seed rows for fresh-DB safety; `IS DISTINCT FROM` / `COALESCE` idempotency; mirrors `fix_se_asia_static_schedules`). The seed files carry the same values so fresh DBs land identical data. Verified end-to-end against a local prod-copy DB (apply + re-seed idempotency + migration re-run no-op).

## Post-merge step (one, with your go-ahead)

`scripts/cleanup-vth3-meetup-placeholders.ts` removes the ~14 stale "Future VTH3 Run" placeholder Events orphaned by disabling the dead Meetup source (a disabled source is never re-scraped, so the reconciler never cancels them). Dry-run by default; `CLEANUP_APPLY=1` to apply. It selects only Meetup-only-provenance, check-in-free placeholders and deletes via the shared race-safe `deleteLeakedEvent` helper (extended here with an optional under-lock foreign-provenance guard + a `lastEventDate` recompute after deletion). Verified end-to-end locally (clean placeholder deleted; foreign-merged + check-in events survive).

## Follow-ups filed (adapter work, out of scope here)

- #1939 — FACEBOOK_HOSTED_EVENTS: datacenter-IP checkpoint → route via residential proxy (covers #1417, #1459 FB half)
- #1940 — FACEBOOK_HOSTED_EVENTS: ingest `/past_hosted_events` (covers #1318, #1262 past-event reversion)
- #1941 — VTH3 website HTML scraper for `vontramph3.com/hareline` (covers #1144 rich data)
- #1942 — JB H3 schedule verification (#1512)

## Checks
`npx tsc --noEmit` ✓ · `npm run lint` ✓ (0 errors) · `npm test` ✓ (8383 passing, +2 new helper tests) · `/simplify` + 7 rounds of `/codex:adversarial-review` (all real findings addressed; final round's two flags declined as schema-ruled-out false positives — `Source @@unique([name,type])` + `RawEvent.sourceId` NOT NULL).

Closes #1373
Closes #1374
Closes #1358
Closes #1318
Closes #1417
Closes #1130
Closes #1144
Closes #1459
Closes #1262
Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)