### PR TITLE
fix(kennels): alias EWH3 Hash Rego host display name so cost merges (#1126)

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -97,7 +97,11 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "dlh3": ["Duneland", "Duneland H3", "South Shore HHH"],
     "c2b3h4": ["C2B3H4", "C2B3", "Chicago Ballbusters", "Chicago Ballbuster H3", "Chicago BallBusters"],
     // DC / DMV area
-    "ewh3": ["Everyday is Wednesday", "Every Day is Wednesday"],
+    // "Everyday Is Wednesday H3" is the Host Kennel display name Hash Rego emits
+    // on EWH3 detail pages; without this alias the HASHREGO raws fail kennel
+    // resolution and never merge onto the EWH3 canonical (so the published cost
+    // never lands). See #1126.
+    "ewh3": ["Everyday is Wednesday", "Every Day is Wednesday", "Everyday Is Wednesday H3"],
     "shith3": ["SHIT H3", "S.H.I.T. H3", "So Happy It's Tuesday"],
     "cch3": ["Charm City", "Charm City Hash", "Charm City H3", "CCH3"],
     "w3h3": ["Wild and Wonderful Wednesday"],


### PR DESCRIPTION
Follow-up to #1931. Post-merge verification of #1931 showed the Hash Rego cost wiring works (raws now carry cost — 9/12 fresh raws, incl. EWH3 #1521 `$10`, Pub Crawl `$45`), **but the cost still doesn't reach the EWH3 canonical**. This PR fixes the remaining merge leg.

## Root cause (issue #1126 hypothesis 1)
The HASHREGO adapter tags EWH3 events with the detail-page Host Kennel **display name** `"Everyday Is Wednesday H3"`. That string matched **none** of ewh3's resolution keys:
- shortName `EWH3`, fullName `Everyday is Wednesday Hash House Harriers`
- aliases `Everyday is Wednesday`, `Every Day is Wednesday`

So the raws fail kennel resolution and never merge onto the EWH3 canonical (which is owned by EWH3 Google Calendar). Historically *all* Hash Rego EWH3 data was dropped this way; the cost just made it visible.

## Fix
Add `"Everyday Is Wednesday H3"` as an ewh3 alias. Since Hash Rego (trust 8) > EWH3 Google Calendar (trust 7) and `Event.cost` is null on the canonical, the resolved raw's merge-update field-fills the published cost.

## Audit (prod, live Hash Rego host display names)
Checked all 8 Hash Rego kennels with current events against the real resolver:
- ✅ resolve fine: Blooming Fools H3, White House H3, NYC HHH, Wandering Soul H3, Motown/Ann Arbor H3, `ggfm`
- ❌ **ewh3** — `"Everyday Is Wednesday H3"` → no match (this PR)
- ⚠️ **separate bug (NOT fixed here):** the Hash Rego `fch3-weekend-2026` event has display name `"Flour City Hash House Harriers"` (Rochester = `flour-city`) but the source's `FCH3` link points at kennelCode `fch3` = **Fog City H3 (San Francisco)**. That's a source-config mis-link / `FCH3` kennelCode collision (Fort Collins also uses `FCH3`), which needs careful handling in `sources.ts` — filed/flagged separately, not an alias fix.

## Takes effect
After merge: `npx prisma db seed` (adds the alias) + the next Hash Rego scrape → EWH3 cost field-fills onto the canonical. (Direct prod application was intentionally not done from this session.)

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)