### PR TITLE
fix(kennels): pin asu-h3 slug to asuncion-h3

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4570,6 +4570,9 @@ export const KENNELS: KennelSeed[] = [
     // Asunción city centroid; per-run start coords come from the adapter's embed-map parse.
     {
       kennelCode: "asu-h3", shortName: "Asunción H3", fullName: "Asunción Hash House Harriers",
+      // Pin the slug: toSlug("Asunción H3") drops the accented ó to a dash → "asunci-n-h3".
+      // Pin the clean, no-accent form so the URL is /kennels/asuncion-h3 (matches the aliases).
+      slug: "asuncion-h3",
       region: "Asunción", country: "Paraguay",
       website: "https://asuncionh3.wordpress.com/",
       instagramHandle: "asuncionh3",


### PR DESCRIPTION
## Summary

Follow-up to [#1944](https://github.com/johnrclem/hashtracks-web/pull/1944). The Asunción H3 kennel's slug was auto-derived as **`asunci-n-h3`** because `toSlug("Asunción H3")` replaces the accented `ó` (non-`[a-z0-9]`) with a dash. Pin it to the clean **`asuncion-h3`** so the page lives at `/kennels/asuncion-h3` (matching the `"Asuncion H3"` alias and the PR's stated URL).

Uses the seeder's existing explicit-`slug` override (precedent: `nah3`). **Prod is already corrected** — re-ran `npx prisma db seed` (a runbook-authorized step), which updated the slug via the override path (`~ Updated kennel: Asunción H3 (slug)`). This commit carries the pin so future re-seeds don't revert it to `asunci-n-h3`.

Verified in prod: slug `asuncion-h3`, 120 canonical events (2021-12-05 → 2026-05-30), 120/120 with coords.

## Note

`toSlug` has no accent transliteration, so any future accented-name kennel hits the same mangling. Pinning per-kennel is the established pattern; a general `toSlug` transliteration would change existing accented slugs on re-seed (URL churn), so it's intentionally not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)