### PR TITLE
fix(h7): clear standard-fee costs via explicit cost:null (Two-Tier follow-up to #1937)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4570,9 +4570,6 @@ export const KENNELS: KennelSeed[] = [
     // Asunción city centroid; per-run start coords come from the adapter's embed-map parse.
     {
       kennelCode: "asu-h3", shortName: "Asunción H3", fullName: "Asunción Hash House Harriers",
-      // Pin the slug: toSlug("Asunción H3") drops the accented ó to a dash → "asunci-n-h3".
-      // Pin the clean, no-accent form so the URL is /kennels/asuncion-h3 (matches the aliases).
-      slug: "asuncion-h3",
       region: "Asunción", country: "Paraguay",
       website: "https://asuncionh3.wordpress.com/",
       instagramHandle: "asuncionh3",

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4570,6 +4570,9 @@ export const KENNELS: KennelSeed[] = [
     // Asunción city centroid; per-run start coords come from the adapter's embed-map parse.
     {
       kennelCode: "asu-h3", shortName: "Asunción H3", fullName: "Asunción Hash House Harriers",
+      // Pin the slug: toSlug("Asunción H3") drops the accented ó to a dash → "asunci-n-h3".
+      // Pin the clean, no-accent form so the URL is /kennels/asuncion-h3 (matches the aliases).
+      slug: "asuncion-h3",
       region: "Asunción", country: "Paraguay",
       website: "https://asuncionh3.wordpress.com/",
       instagramHandle: "asuncionh3",

--- a/scripts/data/h7-history.json
+++ b/scripts/data/h7-history.json
@@ -9,7 +9,8 @@
   "locationUrl": "https://goo.gl/maps/8fF2nAWZshg8dmm1A",
   "startTime": "14:00",
   "description": "HHHi Halfminds, Our next run will be on Sunday August 1st in New Zealand Swamp, aka Kiwittsmoor.",
-  "sourceUrl": "https://hamburghash.blogspot.com/2021/07/hamburg-h7-run-in-kiwittsmoor-01082021.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2021/07/hamburg-h7-run-in-kiwittsmoor-01082021.html",
+  "cost": null
  },
  {
   "date": "2021-08-15",
@@ -21,7 +22,8 @@
   "locationUrl": "https://goo.gl/maps/TLpi9FfE4SHh5Vs4A",
   "startTime": "14:00",
   "description": "HHHello Halfminds, Next Hansestadt Hamburg Hash House Harriers Hummel Hummel run will be in Mümmelmannsberg. (And if you tell me how many M&Ns there are in that sentence, you'll get a free beer on Sunday!)",
-  "sourceUrl": "https://hamburghash.blogspot.com/2021/08/hamburg-h7-run-in-mummelmannsberg.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2021/08/hamburg-h7-run-in-mummelmannsberg.html",
+  "cost": null
  },
  {
   "date": "2021-09-19",
@@ -34,7 +36,8 @@
   "locationUrl": "https://goo.gl/maps/tXDehN331X51fsA18",
   "startTime": "14:00",
   "description": "HHHello Halfminds, Hope your brains are ready, because here is a shitload of info about the run in the very southern suburbs of Hamburg on Sunday:",
-  "sourceUrl": "https://hamburghash.blogspot.com/2021/09/hamburg-h7-run-594-in-bremen-september.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2021/09/hamburg-h7-run-594-in-bremen-september.html",
+  "cost": null
  },
  {
   "date": "2021-10-03",
@@ -47,7 +50,8 @@
   "locationUrl": "https://goo.gl/maps/vAuBKsZp5xYidrc27",
   "startTime": "14:00",
   "description": "What better activity could there be for Germany's National day than getting pissed? At least that's what our hares seems to be planning with the 2 drinkstops I've heard of... You guys better start practicing the proper way to drink Lütt ‘n Lütt !!",
-  "sourceUrl": "https://hamburghash.blogspot.com/2021/09/hamburg-h7-run-595-lut-n-lut-hash-run.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2021/09/hamburg-h7-run-595-lut-n-lut-hash-run.html",
+  "cost": null
  },
  {
   "date": "2021-10-17",
@@ -61,7 +65,8 @@
   "startTime": "14:00",
   "description": "HHHello Halfminds, Next run will take us oversees, exploring Hamburg's Hafencity and the new hash territory of Überseequartier. So my dear fellow Se(a)men, dig out your sailor costume, your pirate accessories, or the famous capitain's hat! We want you to cum (to the run) in your best maritime attire! Option B is to come dressed up as a d!ck... Your choice.",
   "sourceUrl": "https://hamburghash.blogspot.com/2021/10/hamburg-h7-run-596-seamen-hash-run.html",
-  "title": "Se(a)men Hash run"
+  "title": "Se(a)men Hash run",
+  "cost": null
  },
  {
   "date": "2021-11-07",
@@ -75,7 +80,8 @@
   "startTime": "14:00",
   "description": "HHHello Halfminds, Did you know that Friedrichsgabe was founded in 1820 by Danish King Frederik VI? Yes, the Danes are simply everywhere!! Let's see if we spot one on our next trail :",
   "sourceUrl": "https://hamburghash.blogspot.com/2021/10/hamburg-h7-hash-run-597-in.html",
-  "title": "Friedrichsgabe"
+  "title": "Friedrichsgabe",
+  "cost": null
  },
  {
   "date": "2021-11-21",
@@ -89,7 +95,8 @@
   "startTime": "14:00",
   "description": "HHHello Halfminds, For our next run, we hope that the liquid element will flow from the bottle down our throats rather than pour from the sky down over our heads... (Who said head?)",
   "sourceUrl": "https://hamburghash.blogspot.com/2021/11/hamburg-h7-hash-run-588-in-langenhorn.html",
-  "title": "Langenhorn Nord"
+  "title": "Langenhorn Nord",
+  "cost": null
  },
  {
   "date": "2021-12-05",
@@ -103,7 +110,8 @@
   "startTime": "14:00",
   "description": "HHHello Halfminds, Prof. Dr. Wouldn’t Chew Yes I Would invites you for a trip to the Riviera! Oh no, that’s too difficult with covid, so instead it will have to be Blankenese. The hare is somewhat half minded, but did mention there might be Belgian beer. And possibly some stairs. The hare has not checked the Weihnachtsmarkt Blankenese out yet, but according to their website there is a reduced but supposedly still ongoing Christmas market for the on-after. This may mean you cannot buy Christma...",
   "sourceUrl": "https://hamburghash.blogspot.com/2021/11/hamburg-h7-run-599-blank-it-with-chew.html",
-  "title": "Blank it with the Chew"
+  "title": "Blank it with the Chew",
+  "cost": null
  },
  {
   "date": "2021-12-19",
@@ -132,7 +140,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Hope Santa was good to you boys and girls... Although \"it's just a question of perspective\" would say Longshanks in one of his wise moments... (see event picture on Facebook). I'm so looking forward to 2022 --> twenty two two... tutu... get it?! a whole year of tutus' run ahead!!!! (add hysterical jumping up and down here). Anyway, for those that might be sober enough after whatever New Year's Eve party you might attend, here the details of our next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/04/hamburg-h7-new-years-run-601-jan-2nd.html",
-  "title": "New Year's Run – Barmbek"
+  "title": "New Year's Run – Barmbek",
+  "cost": null
  },
  {
   "date": "2022-01-16",
@@ -146,7 +155,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Hashy New Beer to all those who missed the New Year's run! Does everybody have their New Year's resolutions yet? Hope you guys are in shape, because our hares' resolution is to run a full marathon in September 2022... so they want to start training now!! (I know... serious racism going on there, right??) Here the details of our next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/01/hamburg-h7-run-602-jan-16th-2022.html",
-  "title": "Ohlsdorf"
+  "title": "Ohlsdorf",
+  "cost": null
  },
  {
   "date": "2022-02-06",
@@ -160,7 +170,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, After last run requiring 5 hares, with at least one of them being something in between a bitch and a pussy (true fact!), let's stop the nonsense for a while! Quality instead of quantity, that's what you are getting at our next trail! Here the details of next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/01/hamburg-h7-run-603-feb-6th-2022-klein.html",
-  "title": "Klein Flottbek"
+  "title": "Klein Flottbek",
+  "cost": null
  },
  {
   "date": "2022-02-20",
@@ -174,7 +185,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Next weekend, exceptionnaly for you, a run by the only H8 in the world!! Try and count it yourself if you don't believe me : Hansestadt Hamburg Harburg Hash House Harriers Hummel Hummel ! At last run, we were promised that the trail would be set by a blind dog... what could possibly go wrong??? Here the details of next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/02/hamburg-h7-run-604-feb-20th-2022-harburg.html",
-  "title": "Hamburg - Harburg"
+  "title": "Hamburg - Harburg",
+  "cost": null
  },
  {
   "date": "2022-03-06",
@@ -188,7 +200,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Next run is gonna be a killer! hahaha... well, the joke works for a French person, but not sure it's translates well into other languages... at least I'm happy about it! We will be on the road again Sunday, traveling north to Kiel, where a very cultural and maritime trail has been plotted by our local harriettes. Another occasion to show up in your best seamen or sailor costume! Here the details :",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/02/hamburg-h7-run-605-march-6th-2022-in.html",
-  "title": "Kiel"
+  "title": "Kiel",
+  "cost": null
  },
  {
   "date": "2022-03-20",
@@ -202,7 +215,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Next Sunday might be a very wet one... our hare has a reputation of setting his best trails under the rain... But this time he can blame the weather on the Irish, as we will be celabrating St Patrick's day! So wear green or your best Irish costume! Here the details :",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/03/hamburg-h7-run-606-march-20th-2022-st.html",
-  "title": "St Patrick's run"
+  "title": "St Patrick's run",
+  "cost": null
  },
  {
   "date": "2022-04-03",
@@ -216,7 +230,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, So, big changes... you were expecting a nice run on the waterside in Övelgönne next Sunday?? F#ck that! You are instead gonna gather in front of a Church in Harvestehude! Blame Corona for it (yes, the virus or the beer, as you please). Here the details :",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/03/hamburg-h7-run-607-april-3rd-2022.html",
-  "title": "Harvestehude Church run"
+  "title": "Harvestehude Church run",
+  "cost": null
  },
  {
   "date": "2022-04-17",
@@ -230,7 +245,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Are you ready for the Easter eggstravaganza? Our hare, (or is it an Easter bunny ?? ) has prepapared an eggscellent trail, with eggstremely well thought loops, checks and other eggsquisite tricks! Ok, enough bad egg's jokes, here the details :",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/04/hamburg-h7-run-608-april-17th-2022.html",
-  "title": "Easterbeer run"
+  "title": "Easterbeer run",
+  "cost": null
  },
  {
   "date": "2022-05-01",
@@ -244,7 +260,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Beware F-Hash-ion week is on again! Our guest co-hare for next run has a reputation of dressing up with the fanciest Hash-Tshirts ever (sic!), so if you want to be up to the standard, and make sure he feels welcome, wear your oldest, ugliest T-shirt next week. Yes, it's almost gonna be sexy... just like the number of this run... On a more serious note, we'll need Hares for June, July, August! Please volunteer! For the newbies, we are happy to help you and co-hare with you. Her...",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/04/hamburg-h7-run-609-may-1st-2022.html",
-  "title": "Wandsbekmarkt"
+  "title": "Wandsbekmarkt",
+  "cost": null
  },
  {
   "date": "2022-05-14",
@@ -258,7 +275,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Here comes another SOTE (South of the Elbe) run... but will it really start south of the river? It could also be a fantastic opportunity to run in 3 different Bundeslaender in 1 Hashtrail... but... should you trust the hares for that, when they are already trying to confuse the pack by setting a run on a Saturday!!??!! Still, here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/05/hamburg-h7-run-610-saturday-may-14th.html",
-  "title": "Lauenburg"
+  "title": "Lauenburg",
+  "cost": null
  },
  {
   "date": "2022-06-05",
@@ -272,7 +290,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, It's so hot right now in Hamburg, that our hares have found the perfect theme for next hashrun : naked!! Wait? What? no? Well, when one has no knickers and the other one is topless... what is left then??? And wondering if FKK is gonna show up for this one... ;-) Still, here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/05/hamburg-h7-run-611-sunday-june-5th-2022.html",
-  "title": "Bergedorf"
+  "title": "Bergedorf",
+  "cost": null
  },
  {
   "date": "2022-06-18",
@@ -286,7 +305,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Saturday is a hashing day! That's the new trend for Hamburg Hash it seems. We'll offer not one but 2 runs on Saturdays until the end of this month! One by our lovely killer harriettes to celebrate the start of the Kielerwoche (and to use that damn 9€ Ticket!) and the second one to welcome a mystery guest of honor. Stay tuned! Details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/06/hamburg-h7-run-612-saturday-june-18th.html",
-  "title": "Kieler Woche Hash"
+  "title": "Kieler Woche Hash",
+  "cost": null
  },
  {
   "date": "2022-07-03",
@@ -300,7 +320,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Let's say that Bundeslicker's plan to hare a Canoe trail went by the board. But I hope to offer you other possibilities to get wet next Sunday, with a more classic trail around Stadtpark and endless beers at the on-after by Landhaus Walter. Back to basics! Details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/06/hamburg-h7-run-613-saturday-june-25th.html",
-  "title": "Stadtpark"
+  "title": "Stadtpark",
+  "cost": null
  },
  {
   "date": "2022-07-17",
@@ -314,7 +335,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Don't let the name of the place fool you, there is no lake or sea at Meeschensee! You are welcome to run in your swimsuit or bikini though... A beautiful forest and a sneaky trail awaits you at this now traditional H7 run. Here the details for next hash trail:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/07/hamburg-h7-run-614-sunday-july-17th.html",
-  "title": "Meeschensee"
+  "title": "Meeschensee",
+  "cost": null
  },
  {
   "date": "2022-08-07",
@@ -328,7 +350,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, It seems not enough hashers went overboard last Saturday during the \"Paddle party\" on the Alster, although there was plenty alcohol involved I've heard... Anyway, our hare for next run intends to correct this, by setting a proper swimmstop on trail and accurately test if hashers need beer to float or not... Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/07/hamburg-h7-run-615-sunday-august-7th.html",
-  "title": "Mittlerer Landweg"
+  "title": "Mittlerer Landweg",
+  "cost": null
  },
  {
   "date": "2022-08-21",
@@ -342,7 +365,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, WE NEED HARES!! After that subtle subliminal message, back to the ground, or, more accurately back to the water. Yes, while France is burning and drying out to the last drop, it seems the Hamburg Hash finds it funny to get wet again and again. Bundeslicker is disorganizing a trail on the canals of Wilhelmsburg. Yes, holy harriette laying trail on water... Let's see how many mobilephones will die this time (you guys should know that technology on trail is bad...) Anyway, here t...",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/08/hamburg-h7-run-616-sunday-august-21st.html",
-  "title": "the Willy Wade"
+  "title": "the Willy Wade",
+  "cost": null
  },
  {
   "date": "2022-09-04",
@@ -356,7 +380,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Our hares for next run seem to have something to prove : after being recently defeated on the Alster and throw into the water by a danish harriette, they want to reconquer their lost pride and invade Danemark! Like Joan of Arc, a Virgin (hare) riding a Horse! [Insert epic music here] Maybe someone should tell them, that Altona doesn't belong to Danemark anymore since 1864... And here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/08/hamburg-h7-run-617-sunday-september-4th.html",
-  "title": "Invading Altona"
+  "title": "Invading Altona",
+  "cost": null
  },
  {
   "date": "2022-09-18",
@@ -370,7 +395,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Our lovely hare is pretty unlucky right now in a search for an internship (Anyone looking for a trainee/slave in Digital transformation management??) ... but that's good luck for us, as she has plenty time to scout, organise and lay trail!!! Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/09/hamburg-h7-run-618-sunday-september.html",
-  "title": "Schlump !"
+  "title": "Schlump !",
+  "cost": null
  },
  {
   "date": "2022-10-02",
@@ -384,7 +410,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfmind, I could make jokes about size, lenght or how long the trail is gonna be next week... but I'll spare you those, and will go straight to the point : there will be beer! Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/09/hamburg-h7-run-619-sunday-october-2nd.html",
-  "title": "Langenhorn Nord... a long and h*rny one"
+  "title": "Langenhorn Nord... a long and h*rny one",
+  "cost": null
  },
  {
   "date": "2022-10-16",
@@ -398,7 +425,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, It's never too late to have a happy childhood! That's why our hare on Sunday has set the meeting point on a local playground. So swing by! Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/10/hamburg-h7-run-620-sunday-october-16th.html",
-  "title": "Baumwall"
+  "title": "Baumwall",
+  "cost": null
  },
  {
   "date": "2022-11-06",
@@ -412,7 +440,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, How far is it to the moon? Is there beer over there? No idea, but our hare next week might know. In any case he promised us a trail full of nature, stars, and shiggy! And if you survive that, there will also be a private tour of the Bergedorf observatory, where you might see the moon... (whose i don't know though...) Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/10/hamburg-h7-run-621-sunday-november-6th.html",
-  "title": "To the moon and back - Sternwarte Bergedorf"
+  "title": "To the moon and back - Sternwarte Bergedorf",
+  "cost": null
  },
  {
   "date": "2022-11-20",
@@ -425,7 +454,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, What do you get if you add 622 + 40 + 69 ? No, it's not the winning number for the lottery or an exotic sex position. It's just our next hashtrail in Bremen! Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/11/hamburg-h7-run-622-sunday-november-20th.html",
-  "title": "Bremen"
+  "title": "Bremen",
+  "cost": null
  },
  {
   "date": "2022-12-04",
@@ -439,7 +469,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Hashers are known to be big kids. Well our next trail is gonna be set by an actual kid! Child labour?? Sure, but monitored by the proud father. (+ read a bit further down to register to Christmas run) Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/11/hamburg-h7-run-623-sunday-december-4th.html",
-  "title": "Hagendeel"
+  "title": "Hagendeel",
+  "cost": null
  },
  {
   "date": "2022-12-17",
@@ -453,7 +484,8 @@
   "startTime": "13:00",
   "description": "HHHi Halfminds, Have you written your letter to Santa yet? If not, don't bother, hashers are usually too naughty to get anything nice... What??! No, don't deny it, I already have a list of down-downs as long as a ballbreaker trail ready for next run. Here the details of the festivities, and please register if you intend to be there :",
   "sourceUrl": "https://hamburghash.blogspot.com/2022/12/hamburg-h7-run-624-saturday-december.html",
-  "title": "Christmas run"
+  "title": "Christmas run",
+  "cost": null
  },
  {
   "date": "2023-01-15",
@@ -467,7 +499,8 @@
   "startTime": "13:00",
   "description": "HHHi Halfminds, And Hashy New Beer! We have all been there, some serious hashing has created Black Holes in our memory, or even worse: Dark Matter in our souls! They’re definitely a large part of hashing, and this has inspired Wouldn’t Chew to tell her minions to organise a special exhibition on Black Holes, Antimatter (that’s when the R.A. tries to make it look like what they say matters) and the Universe as a whole. This exhibition in the Hamburger Museum der Arbeit is intended for all ages...",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/01/hamburg-h7-run-625-sunday-january-15th.html",
-  "title": "How it all started... in Barmbek"
+  "title": "How it all started... in Barmbek",
+  "cost": null
  },
  {
   "date": "2023-02-04",
@@ -481,7 +514,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Freeeeeee!!! After months and months of covering our faces in public transport, we will be officialy able to take our masks off in Hamburg HVV from February 1st. !! To celebrate this, will our hare take her top off as well??? Come and find out at the next hash!! (Please note : it takes place on a SATURDAY) Here the details:",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/01/hamburg-h7-run-626-saturday-february.html",
-  "title": "Klein Flottbek"
+  "title": "Klein Flottbek",
+  "cost": null
  },
  {
   "date": "2023-02-19",
@@ -495,7 +529,8 @@
   "startTime": "11:00",
   "description": "HHHi Halfminds, Balls, balls, balls! Yes, some of us love them. Small, big or oval-shaped... they are addicted to balls! That's why our hares next week have tried to combine the run and football. We will start trail at 11am, and then afterwards at 1pm go and watch the Hamburg HSV vs Bielefeld Football game at the stadium. (You will have to get your own tickets for that - read instructions below) Let's see how this is going to turn out... And before we get to the details, a short subtle messag...",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/02/hamburg-h7-run-627-sunday-february-19th.html",
-  "title": "The football run"
+  "title": "The football run",
+  "cost": null
  },
  {
   "date": "2023-03-05",
@@ -509,7 +544,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, The 7th Wilhelmsburg Winterlaufseries will take place on Sunday March 5th, starting at 9 am, you´ll be able to choose a running distance from 5km to 20km... Ok, enough bullshit and serious running... we all know, hashers will be too hangover on a Sunday morning to take part to this very racist event. But to confuse everybody, our hare next week will lay a trail from the exact same starting spot, just a few hours later. That´s gonna be interesting! Here the details:",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/02/hamburg-h7-run-628-sunday-march-5th.html",
-  "title": "Wilhelmsburg"
+  "title": "Wilhelmsburg",
+  "cost": null
  },
  {
   "date": "2023-03-19",
@@ -523,7 +559,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, This is the time of the year, when everybody is happy and everything turns green again! No!... I don´t mean spring... St Patrick´s Day of course!! Even if your hare has never been to Ireland (so says the legend...), we´ll try to find the treasure of the Leprechauns, gold hidden at the feet of a rainbow, or more realisticaly, find the path to that famous dark brew... Here the details:",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/03/hamburg-h7-run-629-sunday-march-19th.html",
-  "title": "St Patrick´s run"
+  "title": "St Patrick´s run",
+  "cost": null
  },
  {
   "date": "2023-04-02",
@@ -537,7 +574,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Whhaaaaat? You are not signed up for H7 30th birthdayParty yet?? Do so quickly, and join us in Bremen June 2-4 2023 : https://hamburghash.blogspot.com/p/hamburg-h7-30th-anniversary-june-2nd.html Talking about foolishness, our next trail will take place the day after April 1st, and we will celebrate dicks...! Yes, April 2nd is Saint Richard´s day... Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/03/hamburg-h7-run-630-sunday-april-2nd.html",
-  "title": "Elbgaustrasse"
+  "title": "Elbgaustrasse",
+  "cost": null
  },
  {
   "date": "2023-04-16",
@@ -551,7 +589,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, According to the tradition, next trail is supposed to be a very wet one, as our hare is renowned to (not) control the rain ... Anyway, let's get straight to the point (or is that shortcutting?). Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/04/hamburg-h7-run-631-sunday-april-16th.html",
-  "title": "Poppenbüttel"
+  "title": "Poppenbüttel",
+  "cost": null
  },
  {
   "date": "2023-05-21",
@@ -565,7 +604,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, The weather is getting hotter and hotter! And what a coincidence, one of our hare next Sunday is also a hot bitch... Come and check it out! Here the details for next run:",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/05/hamburg-h7-run-632-sunday-may-21st-2023.html",
-  "title": "Hudtwalckerstrasse"
+  "title": "Hudtwalckerstrasse",
+  "cost": null
  },
  {
   "date": "2023-06-03",
@@ -579,7 +619,8 @@
   "startTime": "13:00",
   "description": "HHHi Halfminds, In case you missed it, Hamburg Hash is turning 30! We are celebrating this with a full weekend of hashing in Bremen, including a pubcrawl on Friday night hared by Bundeslicker, a very nautical party on Saturday night and a hangover run on Sunday morning hared by Pant in the Country. But the main event will of course be the Saturday trail! Here are the details :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/05/hamburg-h7-30th-birthday-run-saturday.html",
-  "title": "H7 30th Birtday - saturday run #634"
+  "title": "H7 30th Birtday - saturday run #634",
+  "cost": null
  },
  {
   "date": "2023-06-18",
@@ -593,7 +634,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Hot, hot, hot ! No, I'm not talking about our hare next Sunday, but about the weather. It's gonna be Licken Sie Hole first official trail in Hamburg, and I'm sure she's planned a lot of scenic loops. Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/06/hamburg-h7-run-636-sunday-june-18th.html",
-  "title": "Tonndorf"
+  "title": "Tonndorf",
+  "cost": null
  },
  {
   "date": "2023-07-02",
@@ -607,7 +649,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, You better catch the right train to get to the next hashtrail, because according to the hare, at least one railway station is missing over there. Hope the hashmarkings will not vanish ... and the beer... what if it disappears as well ?!??!! Better drink it quickly then! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/06/hamburg-h7-run-637-sunday-july-2nd-2023.html",
-  "title": "The disappeared Railway Station run - Aumühle"
+  "title": "The disappeared Railway Station run - Aumühle",
+  "cost": null
  },
  {
   "date": "2023-07-16",
@@ -621,7 +664,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, It's hot! Let's go north and hide in the shade of the forest! Maybe we'll even find trail there... and beer! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/07/hhhi-halfminds-its-hot-lets-go-north.html",
-  "title": "Meeschensee"
+  "title": "Meeschensee",
+  "cost": null
  },
  {
   "date": "2023-08-20",
@@ -635,7 +679,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Some of us are still hashing away, in one of the plenty hash events that are taking place this summer all over Europe. But our local hares are here in Hamburg for you, and have organised what seems to be a trail full of horny deers (or am I lost in translation here??). Antlers... or whaterver you call those things on their head... Head? Who said head? Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/08/hamburg-h7-run-639-sunday-august-20th.html",
-  "title": "Buckhorn"
+  "title": "Buckhorn",
+  "cost": null
  },
  {
   "date": "2023-09-03",
@@ -649,7 +694,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, It seems some of us like to lick her hard... i mean, hard liqueur! Well, luckily, that's the kind of spirits you can get at Nordik (no pun intended here) distillery in Horneburg, where our hare has planned a tour after the run next Sunday. Rum, Gin, Whisky and other Schnapps, expect you if you find the true trail to Horneburg! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/08/hamburg-h7-run-640-sunday-september-3rd.html",
-  "title": "Horneburg - The distillery run"
+  "title": "Horneburg - The distillery run",
+  "cost": null
  },
  {
   "date": "2023-09-17",
@@ -663,7 +709,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Our newcommer Just Ibrahim has been quite eager to set his first ever trail. He is overprepared and overorganised... Let's see if all goes according to his plan... Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/09/hamburg-h7-run-641-sunday-september.html",
-  "title": "Langenhorn Nord"
+  "title": "Langenhorn Nord",
+  "cost": null
  },
  {
   "date": "2023-10-01",
@@ -677,7 +724,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, It's Oktoberfest season, and it smells like beer! If one does catch more flies with honey than vinegar, it seems you can catch a Berlin Hasher with Fishbrötchen and the perspective of a beertent full of loud sweety drunkheads. In any case, we are looking forward to our returning hare! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/09/hamburg-h7-run-642-sunday-october-1st.html",
-  "title": "Wandsbek Markt and Oktoberfest"
+  "title": "Wandsbek Markt and Oktoberfest",
+  "cost": null
  },
  {
   "date": "2023-10-15",
@@ -691,7 +739,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, I never thought I would write that about the hash, but after quantity, we might have quality... Yes, after Oktoberfest last week, our hares next week have promised a selection of their homebrewed beers! I just hope those beers will taste better than the hashnames of those brewing it... Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/10/hamburg-h7-run-643-sunday-october-15th.html",
-  "title": "Hittfeld Craftbeerfest"
+  "title": "Hittfeld Craftbeerfest",
+  "cost": null
  },
  {
   "date": "2023-11-05",
@@ -705,7 +754,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, you can´t write scrotum without scrum... that is my spelling homage to the New-Zealand rugby team, that came second ... in the worldcup finale yesterday... So if your Wellington Boots have dried since Flensburg last week, you might have to put them back on for our next trail in Wellies-büttel ! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/10/hamburg-h7-run-644-sunday-december-5th.html",
-  "title": "Wellington Boots -büttel"
+  "title": "Wellington Boots -büttel",
+  "cost": null
  },
  {
   "date": "2023-11-19",
@@ -719,7 +769,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Don't forget to sign-up for H7 Christmas' Run on Saturday December 16th 2023. I've heard our leadhare is already testing all the Glühwein spots in town, to make sure you get the best ones! But I bet you guys don't believe in Santa anymore, do you? Well, our hare next weekend has promised some dancing unicorns on trail... do you believe in that????!! Or did she mean Uni-Korn ? In any case, it sounds like a lot of strong alcool was involved in the planning (sic!) of that trail. ...",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/11/hamburg-h7-run-645-sunday-november-19th.html",
-  "title": "🦄The Dancing Unicorn run 🦄"
+  "title": "🦄The Dancing Unicorn run 🦄",
+  "cost": null
  },
  {
   "date": "2023-12-03",
@@ -733,7 +784,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, I know we promissed you fantastic creatures on trail last time, and all we saw instead of a unicorn was a wet hedgehog... But we'll keep hunting those mystical animals and we can now assure you, there will be a virgin hare on trail next Sunday! Even if she collided quite a lot recently at the CERN in Geneva, Just Sabine will set her first trail in Hamburg! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/11/hamburg-h7-run-646-sunday-december-3rd.html",
-  "title": "The vrgin hare run"
+  "title": "The vrgin hare run",
+  "cost": null
  },
  {
   "date": "2023-12-16",
@@ -747,7 +799,8 @@
   "startTime": "13:00",
   "description": "HHHi Halfminds, Fun fact we learned on our way to Denmark last week : the noun for a group of puffins, is a circus of puffins; for crows, it's called a murder of crows... But how would you call the group of international hares that will set our Christmas trail? Well... I've done some research ... \"The collective nouns for Hares are derived from the behavior of the animals. A husk is a group of hares that live in a thicket, a warren is a group of Hares that live in a warren, a band is a group ...",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/12/hamburg-h7-run-647-saturday-december.html",
-  "title": "🎄Christmas run 🎄"
+  "title": "🎄Christmas run 🎄",
+  "cost": null
  },
  {
   "date": "2024-01-07",
@@ -761,7 +814,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Thought about your new year's resolutions yet? How about haring a trail in 2024?? Rumor has it, quite a few hashers will enjoy the New Year celebrations tonight with bubbles and a view on the Elbe... Well, we'll stick with the Elbe for the first run of the year next Sunday! Wishing you all a hashy new beer!! Here the details :",
   "sourceUrl": "https://hamburghash.blogspot.com/2023/12/hamburg-h7-run-648-sunday-january-7th.html",
-  "title": "Elbbrücken"
+  "title": "Elbbrücken",
+  "cost": null
  },
  {
   "date": "2024-01-20",
@@ -774,7 +828,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Anyone still dreaming of completing a Dry January?? Well, even if our next trail in gonna end in milk (you´ll get the joke if you make it to the end of the run), there is little hope that your good resolution is gonna survive the Burns´ hash. This trail is held in celebration of the great Scottish poet Robert Burns, born 20th January 1759, and Burns' night or Burns' supper is a tradition that our 2 half Scottish hashers want to share with you. Don´t disappoint them... Here the...",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/01/hamburg-h7-run-649-saturday-january.html",
-  "title": "Burns´ Hash"
+  "title": "Burns´ Hash",
+  "cost": null
  },
  {
   "date": "2024-02-04",
@@ -788,7 +843,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Survived the Haggis Ok? Never wanna see a Horse in a \"kilt\" again?? Well, there will be more of those \"funny\" H7 special events this year. Cumming up are St Patrick's run in March, a 30 years hash birthday in April or a trip to Hell (goland) in June . But for the time being, we are keeping Hamburg hash SOTE (South of the Elbe), or kind of. Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/01/hamburg-h7-run-650-sunday-february-4th.html",
-  "title": "Veddel"
+  "title": "Veddel",
+  "cost": null
  },
  {
   "date": "2024-02-18",
@@ -802,7 +858,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, It´s cold, grey and wet ... (and no, it´s not the start of a necrophile joke). That´s why we are so happy it´s carnival season all over the world! to bring us joy, colors and fun! Of course that was the perfect excuse : our local Brazilian was voluntold to hare! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/02/hamburg-h7-run-651-sunday-february-18th.html",
-  "title": "Dehnhaide Carnival"
+  "title": "Dehnhaide Carnival",
+  "cost": null
  },
  {
   "date": "2024-03-03",
@@ -816,7 +873,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, This week´s hashtrash is gonna be short and painless (and no, I´m not gonna make any jokes about that) : Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/02/hamburg-h7-run-652-sunday-march-3rd.html",
-  "title": "Meiendorfer Weg"
+  "title": "Meiendorfer Weg",
+  "cost": null
  },
  {
   "date": "2024-03-16",
@@ -830,7 +888,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, We've witnessed a few weeks ago an attempt at scottish dances... Will those Sexy Legs be able to entertain us with some Irish dances this time? Or will the hare be too tired after setting the same trail 3 times in a row within 4 days? Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/03/hamburg-h7-run-653-saturday-march-16th.html",
-  "title": "St Patrick´s run"
+  "title": "St Patrick´s run",
+  "cost": null
  },
  {
   "date": "2024-04-06",
@@ -844,7 +903,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, When the pussy is away, the hashers will play... (or will celabrate a birthday?) Our dear Pork Sausage has been away in sunny Ghana for a long time now, and we still didn't have a housewarming party at his new place, maybe a too rough house? Well, as Perfect Mudder Sucker is turning 18 (for the second time), he decided to have a little run and birthday do there. Cake anyone? Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/03/hamburg-h7-run-654-saturday-april-6th.html",
-  "title": "\"When the pussy is away\" run - Rauhes Haus"
+  "title": "\"When the pussy is away\" run - Rauhes Haus",
+  "cost": null
  },
  {
   "date": "2024-04-21",
@@ -858,7 +918,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Since you all liked last week's cake so much, we'll go on with birthdays and special celebrations : This month, give or take a few weeks, Knickerless will have been hashing for 30 years, and Cruiser for 42 years!! Fun fact, they both started hashing in a French speaking country... (où est le papier?). This brings me to the joke of the day: Why does a Frenchman only have one egg for breakfast? Because it's un oeuf. More bad jokes and mispronounciation coming up next Sunday. Her...",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/04/hamburg-h7-run-655-sunday-april-21st.html",
-  "title": "30+42 years Hashing"
+  "title": "30+42 years Hashing",
+  "cost": null
  },
  {
   "date": "2024-05-05",
@@ -872,7 +933,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Everybody made it back home from last run? Or are there still some hashers lost in one of the S-Bahn replacement bus?? As we are now all mastering the ups and (down-)downs of Hamburg transport system, let's attack the regional trains! See how well that Metronom line to Bremen works! Talking about attacking, next hash will celebrate the Cinco de Mayo, an obsucre battle between French and Mexicans in Puebla in 1862, that is celebrated... only in the USA... Who cares? Any excuse ...",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/04/hamburg-h7-run-656-sunday-may-5th-2024.html",
-  "title": "Cinco de mayo - Bremen"
+  "title": "Cinco de mayo - Bremen",
+  "cost": null
  },
  {
   "date": "2024-05-19",
@@ -886,7 +948,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, After last weather and train drama, let's try again to cross the Elbe! Get those Sexy Shanks and Long legs out, and join the run and on after Bbq for a taste of summer! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/05/hamburg-h7-run-657-sunday-may-19th-2024.html",
-  "title": "Heimfeld BBQ"
+  "title": "Heimfeld BBQ",
+  "cost": null
  },
  {
   "date": "2024-05-31",
@@ -913,7 +976,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, The month of June is a month of away hashes for H7. After joining Toulouse H3 in Hell(goland) last weekend, our next trail will be a joint one with Berlin H3. Plus I´ve heard that some of the drinks might have come all the way from Finland. Who doesn´t like a good mingle?! Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/06/hamburg-h7-run-659-saturday-june-15th.html",
-  "title": "Schwerin"
+  "title": "Schwerin",
+  "cost": null
  },
  {
   "date": "2024-07-07",
@@ -927,7 +991,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, After a month in Hell (goland to Helsingor), it's nice to be back in Hamburg for the summer ... when does it start again? Is it over already? One good advice we got from our encounter with the birdswatchers in Helgoland : in summer, if you go running in the bushes, don't forget to check for tits! (or did i get lost in translation again??) Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/07/hamburg-h7-run-660-sunday-july-7th-2024.html",
-  "title": "Reinbek"
+  "title": "Reinbek",
+  "cost": null
  },
  {
   "date": "2024-07-21",
@@ -940,7 +1005,8 @@
   "locationUrl": "https://goo.gl/maps/LqL4SWmFbw4wQ2dw6",
   "startTime": "14:00",
   "description": "HHHi Halfminds, This is the time of the year when we celebrate Booze's birthday with the now traditional run in Meeschensee (where there is still no lake... but then, let them have cake!). Here the details for next run :",
-  "sourceUrl": "https://hamburghash.blogspot.com/2024/07/hamburg-h7-run-661-sunday-july-21st.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2024/07/hamburg-h7-run-661-sunday-july-21st.html",
+  "cost": null
  },
  {
   "date": "2024-08-03",
@@ -954,7 +1020,8 @@
   "startTime": "22:00",
   "description": "HHHi Halfminds, The hares promessed it will be dark, wet, cold with a lot of shiggy. You will suffer. But at the end of the tunnel, there will be light... I mean, beer!! Please note this run takes place at night. Here the details for next run :",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/07/hamburg-h7-run-662-saturday-august-3rd.html",
-  "title": "H7 Nightmare run"
+  "title": "H7 Nightmare run",
+  "cost": null
  },
  {
   "date": "2024-08-17",
@@ -968,7 +1035,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, This week we are celebrating the fact that everyone’s favourite movie “Princess Diaries 2 / Plötzlich Prinzessin 2: Royal Engagement” came out 20 years ago. And that H7 has been organising hash invasions to Bremen for 20 years! Our glorious hares UB69 and Dr Poor Nelly always put on an amazing trail. Also, it’s in Bremen! And there are rumors of a barbecue afterwards!",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/08/hamburg-h7-run-663-20-years-h7-hashing.html",
-  "title": "H7 20 years hashing in Bremen"
+  "title": "H7 20 years hashing in Bremen",
+  "cost": null
  },
  {
   "date": "2024-08-31",
@@ -982,7 +1050,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, The first run of September will be in August because that is how we roll at H7. We will be exploring the West (and shiggy)! Our hare Bitch Hiker promised that this is going to be a \"Taiwan-style\" run, so definitely expect some shiggy. Bring good shoes (High heels or sandals are not recommended) and consider bringing your bikini, because we can swim afterwards.",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/08/h7-run-664-saturday-august-31th-2024.html",
-  "title": "Taiwan style in Sülldorf"
+  "title": "Taiwan style in Sülldorf",
+  "cost": null
  },
  {
   "date": "2024-09-15",
@@ -996,7 +1065,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Next weekend, we will be venturing deep into Sleswig-Holstein. You will enjoy exploring a small town with a surprise. Our run starts from the train station at Reinfeld and is about 7.5 km long. A shorter hiking trail is also offered. At the end of the run, we do the circle at Hasher Just Scott in a hall or in the garden, depending on the weather.",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/09/h7-run-665-reinfeld.html",
-  "title": "Reinfeld"
+  "title": "Reinfeld",
+  "cost": null
  },
  {
   "date": "2024-10-06",
@@ -1008,7 +1078,8 @@
   "locationUrl": "https://maps.app.goo.gl/YLFvvToMf5MLAnRh6",
   "startTime": "14:00",
   "description": "HHHi Halfminds, Toppless Peddler is taking us to Niendorf, so who knows, we might get to head into Sleswig-Holstein twice in one month! Dress like a devil, as this is run 666! Or Sexy, as it is run 666!",
-  "sourceUrl": "https://hamburghash.blogspot.com/2024/09/hamburg-h7-run-666-sunday-october-6th.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2024/09/hamburg-h7-run-666-sunday-october-6th.html",
+  "cost": null
  },
  {
   "date": "2024-11-02",
@@ -1021,7 +1092,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds,On Saturday (!) 2 November, Sexy Legs and Just Brian will be haring a Halloween trail through the forests near Heimfeld, followed by a BBQ. Wear your best Halloween or BBQ outfit. The hare will pick us up at Heimfeld S Bahn, so be on time if you come by public transport (or just go directly to Sexy Leg's house instead).",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/10/hamburg-h7-run-667-saturday-november.html",
-  "title": "Heimfeld S Bahn - Heimfeld Halloween BBQ R*n"
+  "title": "Heimfeld S Bahn - Heimfeld Halloween BBQ R*n",
+  "cost": null
  },
  {
   "date": "2024-11-17",
@@ -1034,7 +1106,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, On Sunday 17 November we are exploring Altona! Our hare-du-jour is Longshanks (we are not worthy!).",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/11/hamburg-h7-run-668-sunday-17-november.html",
-  "title": "Altona"
+  "title": "Altona",
+  "cost": null
  },
  {
   "date": "2024-12-01",
@@ -1047,7 +1120,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, Who likes balls? Well, definitely the inhabitants of Wedel. They have a massive giant with balls and use it as the centerpiece of their Christmas market. Also, he has a sword to match his balls. So come check out those giant balls or swords. It is run 669, so obviously, that giant's family jewels need to be thoroughly inspected. And after that, enjoy some tasty warm drinks after a run through the technically-no-longer-Hamburg countryside. The hare confirmed that she will be ac...",
   "sourceUrl": "https://hamburghash.blogspot.com/2024/11/hamburg-h7-run-669-sunday-17-november.html",
-  "title": "Jingle Balls in Wedel"
+  "title": "Jingle Balls in Wedel",
+  "cost": null
  },
  {
   "date": "2024-12-15",
@@ -1059,7 +1133,8 @@
   "locationUrl": "https://maps.app.goo.gl/5BaNPy9ZWTy64JSE6",
   "startTime": "14:00",
   "description": "Santa Claus is coming to town... with his flight! Rudolph and the gang decided they deserved a well-earned break this year and have on holiday in Hamburg! Let’s make a stop to say “Moin” to his old friends (don’t be surprised if they’ve lost a few pounds), and then head to the airport to pick up Santa to the Christmas market. (Yes, we can never get enough of the Christmas markets and Glühwein in December!) Put on your Christmas outfit and your Christmas hat! Let's go confuse his reindeer and ...",
-  "sourceUrl": "https://hamburghash.blogspot.com/2024/12/hamburg-h7-run-670-sunday-15-december.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2024/12/hamburg-h7-run-670-sunday-15-december.html",
+  "cost": null
  },
  {
   "date": "2025-01-05",
@@ -1071,7 +1146,8 @@
   "locationUrl": "https://maps.app.goo.gl/CqUAYVmbF62NPk1G6",
   "startTime": "14:00",
   "description": "The first run of the new year will be by Knickerless. Considering the location and the hare, a good quess will be that there will be a short, walker friendly, trail and beer.",
-  "sourceUrl": "https://hamburghash.blogspot.com/2024/12/hamburg-h7-run-671-sunday-5-january-2pm.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2024/12/hamburg-h7-run-671-sunday-5-january-2pm.html",
+  "cost": null
  },
  {
   "date": "2025-01-18",
@@ -1084,7 +1160,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, On Saturday 18th January we are going Scottish, as it is Burns Night, when scots perform poems to their Haggis. There are rumors of Haggis at the Burns dinner, but anyway make sure you let Sexy Legs know if you are joining for dinner. Otherwise, you might end up like the Haggis below.",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/01/hamburg-h7-run-672-saturday-january.html",
-  "title": "Burns night"
+  "title": "Burns night",
+  "cost": null
  },
  {
   "date": "2025-02-01",
@@ -1098,7 +1175,8 @@
   "startTime": "14:00",
   "description": "HHHi Halfminds, On Saturday, 1st February, we celebrate the Chinese New Year with Bull's Eye in Wellingbüttel. It's the year of the snake. So, of course, you're welcome to dress like a snake. If that's too much, another tradition is to give red envelopes with money to your hasher friends. Organizational notice: could whoever wanted to hare the Carnival trail on 15-16 February contact the hare raiser? I forgot who said they would do it, and feel downdowns in my future.",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/01/hamburg-h7-run-673-saturday-february.html",
-  "title": "Chinese New Year with Bull's Eye"
+  "title": "Chinese New Year with Bull's Eye",
+  "cost": null
  },
  {
   "date": "2025-02-15",
@@ -1112,7 +1190,8 @@
   "startTime": "14:00",
   "description": "The second trail in February will be hared by hero last-minute hare Sexy Legs, with an on-after at Pant in the Country's place.",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/02/hamburg-h7-run-674-saturday-february.html",
-  "title": "Alsterdorf with Sexy legs"
+  "title": "Alsterdorf with Sexy legs",
+  "cost": null
  },
  {
   "date": "2025-03-01",
@@ -1125,7 +1204,8 @@
   "startTime": "14:00",
   "description": "Dear Half-minds, Titanic Seaman has thankfully decided to return from sunny warm Brazil and inspire us with some wonderful carnival spirit next weekend. Don’t forget to Brazilian wax for the on after Carnival party at Sexy Legs.",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/02/hamburg-h7-run-675-saturday-march-1st.html",
-  "title": "Brazillian Carnaval with Titanic Seaman"
+  "title": "Brazillian Carnaval with Titanic Seaman",
+  "cost": null
  },
  {
   "date": "2025-03-16",
@@ -1139,7 +1219,8 @@
   "startTime": "14:00",
   "description": "Be prepared from some Alster parkland riverside paths. The hare confirmed this will be an A to A run and explicitly would love to have a co-hare.",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/02/hamburg-h7-run-676-klein-borstel-u1.html",
-  "title": "Klein Borstel U1 with PMS"
+  "title": "Klein Borstel U1 with PMS",
+  "cost": null
  },
  {
   "date": "2025-04-05",
@@ -1151,7 +1232,8 @@
   "location": "Lübeck Hauptbahnhof",
   "startTime": "14:00",
   "description": "Come and check out Lübeck. The hare has promised a historic adventure run.",
-  "sourceUrl": "https://hamburghash.blogspot.com/2025/03/hamburg-h7-run-677-saturday-5-april.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2025/03/hamburg-h7-run-677-saturday-5-april.html",
+  "cost": null
  },
  {
   "date": "2025-04-20",
@@ -1164,7 +1246,8 @@
   "startTime": "14:00",
   "description": "It's easter!",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/04/hamburg-h7-run-678-sunday-20-april.html",
-  "title": "Easter with Knickerleas"
+  "title": "Easter with Knickerleas",
+  "cost": null
  },
  {
   "date": "2025-05-04",
@@ -1176,7 +1259,8 @@
   "location": "S bahn Klein Flottbek (S1)",
   "startTime": "14:00",
   "description": "Fresh from Katmandu, new arrival Horny Toddler will take us around Klein Flottbek. Be prepared for immoporn and Elbe-views.",
-  "sourceUrl": "https://hamburghash.blogspot.com/2025/04/hamburg-h7-run-679-sunday-4-may-klein.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2025/04/hamburg-h7-run-679-sunday-4-may-klein.html",
+  "cost": null
  },
  {
   "date": "2025-05-18",
@@ -1190,7 +1274,8 @@
   "startTime": "14:00",
   "description": "PMS chivalrously stepped up to replace our GM who has a family emergency.",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/05/hamburg-h7-run-680-sunday-18-may.html",
-  "title": "Hafengeburtstag at wouldn’t Chew"
+  "title": "Hafengeburtstag at wouldn’t Chew",
+  "cost": null
  },
  {
   "date": "2025-06-08",
@@ -1204,7 +1289,8 @@
   "startTime": "14:00",
   "description": "Bull's eye is taking us to Ohlstedt. Note the change of weekend to avoid GNH in Bad Tölz!",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/05/hamburg-h7-run-681-sunday-8-june.html",
-  "title": "H7 does Hafen City with PMS"
+  "title": "H7 does Hafen City with PMS",
+  "cost": null
  },
  {
   "date": "2025-07-19",
@@ -1216,7 +1302,9 @@
   "startTime": "15:00",
   "description": "Lace up your shoes and grab your finest orange gear, because on 12th July, we’re celebrating the Battle of the Boyne… erm Elbe… the only way hashers know how: One week late, with beer, and questionable decisions! WSH3 joins H7 for a raucous romp through Barmbek with hare Moose Diver and maybe even a surprise hare from Schaffhausen as we honor history with hilarity, hydration, and just a hint of heresy. Orangemen, Orangewomen, and all who enjoy a good trail followed by a down-down. This is you...",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/06/hamburg-h7-extra-run-in-collaboration.html",
-  "title": "WSH3 surprise co-H7"
+  "title": "WSH3 surprise co-H7",
+  "cost": null,
+  "runNumber": 686
  },
  {
   "date": "2025-08-03",
@@ -1228,7 +1316,8 @@
   "location": "Mittlerer Landweg (S2)",
   "startTime": "14:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/07/h7-run-687ish-sunday-3-august-2pm.html",
-  "title": "Drinking practice!"
+  "title": "Drinking practice!",
+  "cost": null
  },
  {
   "date": "2025-08-17",
@@ -1240,7 +1329,9 @@
   "locationUrl": "https://maps.app.goo.gl/WepWGqKPBx9VxGqq7",
   "startTime": "14:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/08/hamburg-h7-run-sunday-17-august-2pm.html",
-  "title": "Veddel"
+  "title": "Veddel",
+  "cost": null,
+  "runNumber": 688
  },
  {
   "date": "2025-09-07",
@@ -1252,7 +1343,8 @@
   "location": "Langenhorn Nord (U1)",
   "locationUrl": "https://maps.app.goo.gl/hWvSskvPucZoBFWV6",
   "startTime": "14:00",
-  "sourceUrl": "https://hamburghash.blogspot.com/2025/08/h7-run-689-langenhorn-nord-with-just.html"
+  "sourceUrl": "https://hamburghash.blogspot.com/2025/08/h7-run-689-langenhorn-nord-with-just.html",
+  "cost": null
  },
  {
   "date": "2025-09-21",
@@ -1265,7 +1357,8 @@
   "locationUrl": "https://maps.app.goo.gl/EcJbWdPiyhAatFth9",
   "startTime": "14:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/09/h7-run-690-sunday-21-september.html",
-  "title": "Meiendorfer Weg (U1), with Knickerless"
+  "title": "Meiendorfer Weg (U1), with Knickerless",
+  "cost": null
  },
  {
   "date": "2025-10-05",
@@ -1277,7 +1370,8 @@
   "location": "Hamburg Airport S-Bahn",
   "startTime": "14:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/09/h7-run-691-sunday-5-october-come-fly.html",
-  "title": "Come fly with Just Kim"
+  "title": "Come fly with Just Kim",
+  "cost": null
  },
  {
   "date": "2025-10-19",
@@ -1289,7 +1383,8 @@
   "location": "Wilhelmsburg S-Bahn",
   "startTime": "14:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/10/h7-run-692-sunday-19-october.html",
-  "title": "Wilhelmsburg with Longshanks"
+  "title": "Wilhelmsburg with Longshanks",
+  "cost": null
  },
  {
   "date": "2025-11-02",
@@ -1316,7 +1411,8 @@
   "locationUrl": "https://maps.app.goo.gl/wRbiv9XfBYfT8U6WA",
   "startTime": "14:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/11/hare-knickerless-where-s-bahn-sulldorf.html",
-  "title": "Alsterdorf with PitC and Horse"
+  "title": "Alsterdorf with PitC and Horse",
+  "cost": null
  },
  {
   "date": "2025-12-06",
@@ -1329,7 +1425,8 @@
   "locationUrl": "https://maps.app.goo.gl/8Z9DhY77bdzRaX9N6",
   "startTime": "14:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/11/blog-post.html",
-  "title": "Norderstedt Weihnachtsmarkt with Just Ewa and Sexy Legs"
+  "title": "Norderstedt Weihnachtsmarkt with Just Ewa and Sexy Legs",
+  "cost": null
  },
  {
   "date": "2025-12-20",
@@ -1339,7 +1436,8 @@
   "startTime": "12:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2025/11/a-very-h7-hashmas-christmas-run-and.html",
   "title": "A very H7 hashmas",
-  "cost": "10€"
+  "cost": "10€",
+  "runNumber": 696
  },
  {
   "date": "2026-02-01",
@@ -1352,7 +1450,8 @@
   "locationUrl": "https://maps.app.goo.gl/MBYB9hdJkVpoJow17",
   "startTime": "14:00",
   "sourceUrl": "https://hamburghash.blogspot.com/2026/01/h7-run-sunday-1-february-hagendeel-u2.html",
-  "title": "Knickerless"
+  "title": "Knickerless",
+  "cost": null
  },
  {
   "date": "2026-02-14",
@@ -1366,7 +1465,8 @@
   "description": "It's Chinese New Year and this year it is year of the Horse! Bull's Eye confirmed that this run is also Valentine's Day, and our GM confirms this is also Hamburg Run number 700. What's not to like, there will be romance, and red envelopes with goodies in them!",
   "sourceUrl": "https://hamburghash.blogspot.com/2026/02/h7-run-saturday-february-14th-chinese.html",
   "runNumber": 700,
-  "title": "Chinese New Year with Bulls Eye"
+  "title": "Chinese New Year with Bulls Eye",
+  "cost": null
  },
  {
   "date": "2026-03-01",
@@ -1380,7 +1480,8 @@
   "runNumber": 701,
   "sourceUrl": "https://www.hashruns.org/H7/701",
   "latitude": 53.54765638282494,
-  "longitude": 10.00077410319483
+  "longitude": 10.00077410319483,
+  "cost": null
  },
  {
   "date": "2026-03-15",
@@ -1394,7 +1495,8 @@
   "runNumber": 702,
   "sourceUrl": "https://www.hashruns.org/H7/702",
   "latitude": 53.62823068425758,
-  "longitude": 10.130904463735764
+  "longitude": 10.130904463735764,
+  "cost": null
  },
  {
   "date": "2026-04-05",
@@ -1406,7 +1508,8 @@
   "location": "Hudtwalckerstraße (U1)",
   "startTime": "14:00",
   "runNumber": 703,
-  "sourceUrl": "https://www.hashruns.org/H7/703"
+  "sourceUrl": "https://www.hashruns.org/H7/703",
+  "cost": null
  },
  {
   "date": "2026-04-19",
@@ -1420,7 +1523,8 @@
   "runNumber": 704,
   "sourceUrl": "https://www.hashruns.org/H7/704",
   "latitude": 53.553904776964444,
-  "longitude": 10.08440401516552
+  "longitude": 10.08440401516552,
+  "cost": null
  },
  {
   "date": "2026-05-03",
@@ -1434,7 +1538,8 @@
   "runNumber": 705,
   "sourceUrl": "https://www.hashruns.org/H7/705",
   "latitude": 53.594506170640045,
-  "longitude": 9.996485497024802
+  "longitude": 9.996485497024802,
+  "cost": null
  },
  {
   "date": "2026-05-17",
@@ -1445,6 +1550,7 @@
   "location": "U3 St Pauli",
   "startTime": "14:00",
   "runNumber": 706,
-  "sourceUrl": "https://www.hashruns.org/H7/706"
+  "sourceUrl": "https://www.hashruns.org/H7/706",
+  "cost": null
  }
 ]


### PR DESCRIPTION
Follow-up to #1937. During post-merge verification I found the H7 Two-Tier hash-cash cleanup didn't actually take effect: PR #1937 *omitted* the `cost` field on standard-fee (5€) rows of `scripts/data/h7-history.json`, and the merge pipeline treats `undefined` as **"preserve existing"** — so the ~77 pre-existing polluted `"5€ + prose"` costs were never cleared. Only the 4 genuine differentials landed.

## Fix
- Set explicit **`cost: null`** on all 103 standard rows so the merge UPDATE branch clears the column (`event.cost !== undefined` → `cost: null`).
- Recover run numbers for **#686 / #688 / #696** (matched by date + title to the Harrier Central archive) — rows the original Blogspot backfill left unnumbered (#696's missing run-number badge was noted in #1910).

## Applied to prod
Ran `BACKFILL_APPLY=1 npx tsx scripts/backfill-h7-history.ts` (updated=104). Verified prod now has **exactly 4** H7 events with cost — #600/#658/#696 = `10€`, #693 = `Free` — all others null. Proper Two-Tier: 5€ is the kennel default (`Kennel.hashCash`), so no per-event cost. This PR brings the committed JSON in line with the already-applied prod state; the backfill is idempotent on re-run.

Verified: `tsc`, `lint` (0 errors), JSON valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)