### PR TITLE
fix(seed): correct asu-h3 slug to asuncion-h3

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4570,6 +4570,7 @@ export const KENNELS: KennelSeed[] = [
     // Asunción city centroid; per-run start coords come from the adapter's embed-map parse.
     {
       kennelCode: "asu-h3", shortName: "Asunción H3", fullName: "Asunción Hash House Harriers",
+      slug: "asuncion-h3", // explicit: toSlug("Asunción H3") mangles the accented ó → "asunci-n-h3"
       region: "Asunción", country: "Paraguay",
       website: "https://asuncionh3.wordpress.com/",
       instagramHandle: "asuncionh3",


### PR DESCRIPTION
## What

The `asu-h3` kennel (Asunción H3, added in #1944) has no explicit `slug` in `prisma/seed-data/kennels.ts`, so the seed's auto-slug runs `toSlug("Asunción H3")` which drops the accented `ó` to a dash → slug `asunci-n-h3`. The kennel page should live at `/kennels/asuncion-h3` (matching its aliases).

This PR adds an explicit `slug: "asuncion-h3"` on the `asu-h3` row.

## Why a standalone PR

This 3-line fix was briefly staged in the shared main-repo git index and accidentally swept into an unrelated H7 PR (#1948). It was removed from that PR, so the fix currently lives nowhere committed — hence this small dedicated PR.

## Post-merge step

The kennel already exists in prod with the mangled slug. `ensureKennelProfiles` in `prisma/seed.ts` sets `updates.slug` whenever `record.slug !== kennel.slug`, so run `npx prisma db seed` against prod after merge to apply the corrected slug, then verify the page resolves at `/kennels/asuncion-h3`.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- Targeted tests pass: `seed-utils`, `kennel-utils`, `asuncion-h3` adapter (42 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)