### PR TITLE
feat(vth3): add Squarespace hareline as rich primary source

### DIFF
--- a/.claude/rules/active-sources.md
+++ b/.claude/rules/active-sources.md
@@ -1,5 +1,5 @@
 ---
-description: Active data sources catalog — 342 sources across 17 countries
+description: Active data sources catalog — 344 sources across 17 countries
 globs:
   - src/adapters/**
   - prisma/seed.ts

--- a/.claude/rules/active-sources.md
+++ b/.claude/rules/active-sources.md
@@ -7,11 +7,11 @@ globs:
   - src/pipeline/**
 ---
 
-# Active Sources (343)
+# Active Sources (344)
 
 Last synced from `prisma/seed-data/sources.ts` via the `/update-sources-rule` skill.
 
-## United States (214 sources)
+## United States (215 sources)
 
 ### Akron, OH (1)
 - **Rubber City H3 Meetup** -> MEETUP -> rch3
@@ -419,8 +419,9 @@ Last synced from `prisma/seed-data/sources.ts` via the `/update-sources-rule` sk
 - **Mr. Happy's H3 Google Calendar** -> GOOGLE_CALENDAR -> mrhappy
 - **Pedal Files Bash Google Calendar** -> GOOGLE_CALENDAR -> pedalfiles
 
-### Vermont (4)
+### Vermont (5)
 - **Von Tramp H3 Meetup** -> MEETUP -> vth3
+- **Von Tramp H3 Squarespace Events** -> HTML_SCRAPER -> vth3
 - **Burlington H3 Website Hareline** -> HTML_SCRAPER -> burlyh3
 - **Burlington H3 Facebook Hosted Events** -> FACEBOOK_HOSTED_EVENTS -> burlyh3
 - **Von Tramp H3 Facebook Hosted Events** -> FACEBOOK_HOSTED_EVENTS -> vth3

--- a/prisma/migrations/20260603143000_add_vth3_squarespace_source/migration.sql
+++ b/prisma/migrations/20260603143000_add_vth3_squarespace_source/migration.sql
@@ -1,0 +1,97 @@
+-- VTH3 rich primary source (#1941).
+--
+-- Von Tramp H3 (vth3) has no reliably-working source: its Meetup source is
+-- dead (#1144/#1459, disabled in 20260603075924_triage_hkfh3_rename_elah3_hide)
+-- and its Facebook Hosted Events source is blocked by the datacenter-IP
+-- checkpoint (#1939). The kennel's own Squarespace hareline
+-- (vontramph3.com/hareline) exposes the full archive via ?format=json and is
+-- parsed by the shared SquarespaceEventsAdapter.
+--
+-- The seed files (prisma/seed-data/sources.ts + registry.ts) carry the same
+-- Source so fresh DBs land identical data, but Vercel runs only
+-- `prisma migrate deploy` (never `prisma db seed`). Without this migration the
+-- new Source would never reach prod and the kennel would stay dark. Structure +
+-- idioms mirror 20260521020000_fix_se_asia_static_schedules (deterministic
+-- literal ids — no pgcrypto/gen_random_uuid; NOTICE-not-RAISE on a missing seed
+-- row so a pre-seed deploy doesn't abort; ON CONFLICT upsert so re-runs and an
+-- already-seeded row are no-ops; SourceKennel link resolved by (name,type) so
+-- it attaches correctly even when the Source pre-existed).
+
+BEGIN;
+
+-- ===== Insert/converge the VTH3 Squarespace source + kennel link =====
+DO $$
+DECLARE
+  v_source_id   text := 'mig_1941_vth3_squarespace';
+  v_sk_id       text := 'mig_1941_vth3_sk';
+  v_source_name text := 'Von Tramp H3 Squarespace Events';
+  v_source_url  text := 'https://www.vontramph3.com';
+  v_kennel_code text := 'vth3';
+  v_config      jsonb := jsonb_build_object('kennelTag', 'vth3', 'collectionPath', '/hareline');
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = v_kennel_code) THEN  -- NOSONAR plsql:S1138
+    RAISE NOTICE 'Kennel "%" not found — source link will no-op (run prisma db seed)', v_kennel_code;
+  END IF;
+
+  -- Upsert the Source on its (name, type) seed identity. ON CONFLICT keeps the
+  -- existing row's id (e.g. if a manual `prisma db seed` already created it) and
+  -- converges the config/trust/window onto the desired shape.
+  INSERT INTO "Source" (
+    id, name, url, type, config, "trustLevel", "scrapeFreq", "scrapeDays",
+    enabled, "healthStatus", "createdAt", "updatedAt"
+  )
+  VALUES (
+    v_source_id, v_source_name, v_source_url, 'HTML_SCRAPER'::"SourceType", v_config,
+    9, 'daily', 3650, true, 'UNKNOWN'::"SourceHealth", NOW(), NOW()
+  )
+  ON CONFLICT (name, type) DO UPDATE SET
+    url = EXCLUDED.url,
+    config = EXCLUDED.config,
+    "trustLevel" = EXCLUDED."trustLevel",
+    "scrapeFreq" = EXCLUDED."scrapeFreq",
+    "scrapeDays" = EXCLUDED."scrapeDays",
+    enabled = true,
+    "updatedAt" = NOW();
+
+  -- Link the source to vth3. Resolve sourceId by (name, type) rather than the
+  -- literal id so the link attaches to the surviving row even when the Source
+  -- pre-existed under a different id. No-op when the Kennel is absent.
+  INSERT INTO "SourceKennel" (id, "sourceId", "kennelId")
+  SELECT v_sk_id, s.id, k.id
+  FROM "Source" s, "Kennel" k
+  WHERE s.name = v_source_name
+    AND s.type = 'HTML_SCRAPER'::"SourceType"
+    AND k."kennelCode" = v_kennel_code
+  ON CONFLICT ("sourceId", "kennelId") DO NOTHING;
+END $$;
+
+-- ===== Verify post-state (no-ops cleanly on a pre-seed DB where vth3 absent) =====
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "Kennel" WHERE "kennelCode" = 'vth3') THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM "Source"
+      WHERE name = 'Von Tramp H3 Squarespace Events'
+        AND type = 'HTML_SCRAPER'::"SourceType"
+        AND enabled = true
+        AND "trustLevel" = 9
+        AND config->>'collectionPath' = '/hareline'
+    ) THEN
+      RAISE EXCEPTION 'VTH3 Squarespace source missing/misconfigured after migration';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM "SourceKennel" sk
+      JOIN "Source" s ON s.id = sk."sourceId"
+      JOIN "Kennel" k ON k.id = sk."kennelId"
+      WHERE s.name = 'Von Tramp H3 Squarespace Events'
+        AND s.type = 'HTML_SCRAPER'::"SourceType"
+        AND k."kennelCode" = 'vth3'
+    ) THEN
+      RAISE EXCEPTION 'VTH3 Squarespace source not linked to the vth3 kennel after migration';
+    END IF;
+  END IF;
+END $$;
+
+COMMIT;

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2358,6 +2358,27 @@ export const SOURCES = [
       },
       kennelCodes: ["vth3"],
     },
+    // #1941: VTH3's rich primary source. The Meetup source (above) is dead and
+    // the FB Hosted Events source is blocked by the datacenter-IP checkpoint
+    // (#1939), so the kennel's own Squarespace hareline carries real events.
+    // Parsed by the shared SquarespaceEventsAdapter via `?format=json`. The
+    // Events collection lives at `/hareline` — `collectionPath` overrides the
+    // adapter's default `/events` (a base URL of vontramph3.com + default would
+    // resolve to the wrong `/events` collection). trustLevel 9 makes this the
+    // authoritative source: its structured run#/title/street/coords/times/
+    // description win over the sparser FB source when FB unblocks (merge
+    // field-fill is trust-gated). Wide window captures the full ~113-event
+    // archive back to 2022 (4 pages, under the adapter's default maxPages 20).
+    {
+      name: "Von Tramp H3 Squarespace Events",
+      url: "https://www.vontramph3.com",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 9,
+      scrapeFreq: "daily",
+      scrapeDays: 3650,
+      config: { kennelTag: "vth3", collectionPath: "/hareline" },
+      kennelCodes: ["vth3"],
+    },
     {
       name: "Burlington H3 Website Hareline",
       url: "https://www.burlingtonh3.com/hareline",

--- a/scripts/verify-vth3-squarespace.ts
+++ b/scripts/verify-vth3-squarespace.ts
@@ -1,0 +1,75 @@
+/**
+ * One-shot live verification for the VTH3 Squarespace source (#1941).
+ * Runs the shared SquarespaceEventsAdapter against the live vontramph3.com
+ * hareline and asserts the parse is sane. Not part of CI — run manually:
+ *   eval "$(fnm env)" && fnm use 20 && npx tsx scripts/verify-vth3-squarespace.ts
+ */
+import "dotenv/config";
+import type { Source } from "@/generated/prisma/client";
+import { SquarespaceEventsAdapter } from "@/adapters/html-scraper/squarespace-events";
+
+const source = {
+  id: "verify-vth3",
+  name: "Von Tramp H3 Squarespace Events",
+  url: "https://www.vontramph3.com",
+  type: "HTML_SCRAPER",
+  config: { kennelTag: "vth3", collectionPath: "/hareline" },
+  trustLevel: 9,
+  scrapeFreq: "daily",
+  scrapeDays: 3650,
+  enabled: true,
+} as unknown as Source;
+
+async function main() {
+  const adapter = new SquarespaceEventsAdapter();
+  const result = await adapter.fetch(source, { days: 3650 });
+
+  const { events, errors, diagnosticContext } = result;
+  console.log("errors:", errors);
+  console.log("diagnosticContext:", JSON.stringify(diagnosticContext, null, 2));
+  console.log("event count:", events.length);
+
+  const dates = events.map((e) => e.date).sort((a, b) => a.localeCompare(b));
+  console.log("date range:", dates[0], "→", dates[dates.length - 1]);
+  const todayYmd = new Date().toISOString().slice(0, 10);
+  const future = events.filter((e) => e.date >= todayYmd);
+  console.log("future events:", future.length);
+
+  const withRun = events.filter((e) => typeof e.runNumber === "number");
+  console.log("events with runNumber:", withRun.length);
+
+  const sample = future.sort((a, b) => a.date.localeCompare(b.date))[0] ?? events[0];
+  console.log("\nsample (soonest upcoming):", JSON.stringify(sample, null, 2));
+
+  // Assertions
+  const fails: string[] = [];
+  if (errors.length) fails.push(`unexpected errors: ${errors.join("; ")}`);
+  if (events.length < 100) fails.push(`expected ~113 events, got ${events.length}`);
+  if (!events.every((e) => /^\d{4}-\d{2}-\d{2}$/.test(e.date)))
+    fails.push("some dates are not YYYY-MM-DD");
+  if (future.length < 1) fails.push("no future events");
+  if (withRun.length < events.length * 0.8)
+    fails.push(`too few runNumbers: ${withRun.length}/${events.length}`);
+  // Coords: at least one event should carry the real Burlington pin, not the
+  // Manhattan tenant-default (40.7207559) which extractVenueCoords must reject.
+  const burlington = events.filter(
+    (e) => typeof e.latitude === "number" && e.latitude > 44 && e.latitude < 45,
+  );
+  if (burlington.length < 1) fails.push("no events with Burlington coords (~44.x)");
+  const manhattanLeak = events.filter(
+    (e) => typeof e.latitude === "number" && Math.abs(e.latitude - 40.7207559) < 1e-4,
+  );
+  if (manhattanLeak.length > 0)
+    fails.push(`${manhattanLeak.length} events leaked Manhattan default coords`);
+
+  if (fails.length) {
+    console.error("\n❌ VERIFICATION FAILED:\n - " + fails.join("\n - "));
+    process.exit(1);
+  }
+  console.log("\n✅ VTH3 Squarespace verification passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/verify-vth3-squarespace.ts
+++ b/scripts/verify-vth3-squarespace.ts
@@ -29,8 +29,8 @@ async function main() {
   console.log("diagnosticContext:", JSON.stringify(diagnosticContext, null, 2));
   console.log("event count:", events.length);
 
-  const dates = events.map((e) => e.date).sort((a, b) => a.localeCompare(b));
-  console.log("date range:", dates[0], "→", dates[dates.length - 1]);
+  const dates = events.map((e) => e.date).toSorted((a, b) => a.localeCompare(b));
+  console.log("date range:", dates[0], "→", dates.at(-1));
   // Event dates are local to the site timezone (America/New_York). Compute
   // "today" in that same zone — a UTC `toISOString().slice(0,10)` rolls over
   // after ~8pm ET and would misclassify tonight's run as past, spuriously
@@ -44,7 +44,7 @@ async function main() {
   const withRun = events.filter((e) => typeof e.runNumber === "number");
   console.log("events with runNumber:", withRun.length);
 
-  const sample = future.sort((a, b) => a.date.localeCompare(b.date))[0] ?? events[0];
+  const sample = future.toSorted((a, b) => a.date.localeCompare(b.date))[0] ?? events[0];
   console.log("\nsample (soonest upcoming):", JSON.stringify(sample, null, 2));
 
   // Assertions

--- a/scripts/verify-vth3-squarespace.ts
+++ b/scripts/verify-vth3-squarespace.ts
@@ -31,7 +31,13 @@ async function main() {
 
   const dates = events.map((e) => e.date).sort((a, b) => a.localeCompare(b));
   console.log("date range:", dates[0], "→", dates[dates.length - 1]);
-  const todayYmd = new Date().toISOString().slice(0, 10);
+  // Event dates are local to the site timezone (America/New_York). Compute
+  // "today" in that same zone — a UTC `toISOString().slice(0,10)` rolls over
+  // after ~8pm ET and would misclassify tonight's run as past, spuriously
+  // failing the future-event assertion.
+  const todayYmd = new Date().toLocaleDateString("en-CA", {
+    timeZone: "America/New_York",
+  });
   const future = events.filter((e) => e.date >= todayYmd);
   console.log("future events:", future.length);
 

--- a/src/adapters/html-scraper/squarespace-events.test.ts
+++ b/src/adapters/html-scraper/squarespace-events.test.ts
@@ -1,6 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import {
   parseSquarespaceEvent,
+  resolveCollectionUrl,
   SquarespaceEventsAdapter,
   type SquarespaceEventsConfig,
 } from "./squarespace-events";
@@ -79,6 +80,33 @@ const NUMBERED_PAST_EVENT = {
   location: { addressTitle: "Johnson-Springview Park, Rocklin" },
   body: "",
 };
+
+describe("resolveCollectionUrl", () => {
+  it("appends a non-default collectionPath to a bare-domain base URL (VTH3 #1941)", () => {
+    // VTH3's Events collection lives at /hareline, not the adapter default
+    // /events. A bare-domain base URL + collectionPath must resolve to the
+    // hareline collection, never /events.
+    expect(resolveCollectionUrl("https://www.vontramph3.com", "/hareline")).toBe(
+      "https://www.vontramph3.com/hareline?format=json",
+    );
+  });
+
+  it("does not double-append when the base URL already includes the collection path", () => {
+    expect(
+      resolveCollectionUrl("https://www.vontramph3.com/hareline", "/hareline"),
+    ).toBe("https://www.vontramph3.com/hareline?format=json");
+    // Trailing slash on the base path is tolerated.
+    expect(
+      resolveCollectionUrl("https://www.vontramph3.com/hareline/", "/hareline"),
+    ).toBe("https://www.vontramph3.com/hareline?format=json");
+  });
+
+  it("falls back to the default /events collection (Sacramento)", () => {
+    expect(resolveCollectionUrl("https://sach3.beer", "/events")).toBe(
+      "https://sach3.beer/events?format=json",
+    );
+  });
+});
 
 describe("parseSquarespaceEvent", () => {
   it("converts epoch-ms startDate to local YYYY-MM-DD in the site timezone", () => {

--- a/src/adapters/html-scraper/squarespace-events.ts
+++ b/src/adapters/html-scraper/squarespace-events.ts
@@ -194,7 +194,7 @@ function trimTrailingSlashes(s: string): string {
  * path (e.g. a seed row that stores `https://example.com/events`), don't
  * double-append it. The collectionPath argument wins when present.
  */
-function resolveCollectionUrl(baseUrl: string, collectionPath: string): string {
+export function resolveCollectionUrl(baseUrl: string, collectionPath: string): string {
   const url = new URL(baseUrl);
   const basePath = trimTrailingSlashes(url.pathname);
   const cleanPath = collectionPath.startsWith("/")

--- a/src/adapters/registry.test.ts
+++ b/src/adapters/registry.test.ts
@@ -16,6 +16,7 @@ import { SlashHashAdapter } from "./html-scraper/slash-hash";
 import { EnfieldHashAdapter } from "./html-scraper/enfield-hash";
 import { SFH3Adapter } from "./html-scraper/sfh3";
 import { HHHSAdapter } from "./html-scraper/hhhs";
+import { SquarespaceEventsAdapter } from "./html-scraper/squarespace-events";
 import { RssAdapter } from "./rss/adapter";
 import { StaticScheduleAdapter } from "./static-schedule/adapter";
 
@@ -55,6 +56,14 @@ describe("getAdapter", () => {
   it("returns HHHSAdapter for hhhs.org.sg URL (not the HashNYCAdapter default)", () => {
     const adapter = getAdapter("HTML_SCRAPER", "https://www.hhhs.org.sg/hareline");
     expect(adapter).toBeInstanceOf(HHHSAdapter);
+    expect(adapter).not.toBeInstanceOf(HashNYCAdapter);
+  });
+
+  it("returns SquarespaceEventsAdapter for vontramph3.com (VTH3 #1941, not the default)", () => {
+    // Guards the new route from being silently darkened by a future import or
+    // ordering change — HTML_SCRAPER otherwise falls back to HashNYCAdapter.
+    const adapter = getAdapter("HTML_SCRAPER", "https://www.vontramph3.com");
+    expect(adapter).toBeInstanceOf(SquarespaceEventsAdapter);
     expect(adapter).not.toBeInstanceOf(HashNYCAdapter);
   });
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -289,6 +289,12 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   // additional kennels just add a URL pattern + a Source row with
   // `kennelTag` in config.
   { pattern: /sach3\.beer/i, name: "SquarespaceEventsAdapter", factory: () => new SquarespaceEventsAdapter() },
+  // ── Von Tramp H3 (Burlington, VT) ──
+  // VTH3 — same shared SquarespaceEventsAdapter. The kennel's own hareline
+  // lives at the `/hareline` collection (config.collectionPath), not the
+  // default `/events`. Seeded as the rich primary source while the FB Hosted
+  // Events source is blocked (#1939) and the Meetup source is dead (#1144/#1459).
+  { pattern: /vontramph3\.com/i, name: "SquarespaceEventsAdapter", factory: () => new SquarespaceEventsAdapter() },
   // HashStats — multi-kennel historical stats archive served as JSON over
   // POST {host}/{SLUG}/listhashes2 (DataTables shape). JSON-over-HTML_SCRAPER,
   // like SHITH3/Seletar. Kennel slugs come from config.kennelSlugMap, so one


### PR DESCRIPTION
## Context

Von Tramp H3 (VTH3, Burlington VT) had **no reliably-working event source**:
- Its **Meetup** source is dead ("Group not found") — disabled in the dead-source triage (#1144/#1459).
- Its **Facebook Hosted Events** source (trust 8) is blocked by the datacenter-IP checkpoint (#1939).

The kennel's own Squarespace site exposes a full, structured hareline at `vontramph3.com/hareline`. This adds it as VTH3's rich primary source.

## Approach — config-only reuse

The repo already has a generic `SquarespaceEventsAdapter` (used by Sacramento H3) that parses any Squarespace Events tenant via `?format=json`. VTH3's payload is an exact match, so **no new adapter/parser** is needed:

- **`registry.ts`** — route `vontramph3.com` → `SquarespaceEventsAdapter`.
- **`prisma/seed-data/sources.ts`** — new source row. `config.collectionPath: "/hareline"` overrides the adapter's default `/events` (the collection lives at `/hareline`). `trustLevel: 9` makes it authoritative so its structured run#/title/street/coords/times/description win over the sparser FB source when FB unblocks (merge field-fill is trust-gated). Wide `scrapeDays: 3650` captures the full archive.
- **Companion data migration** — INSERTs the Source + SourceKennel idempotently. Vercel runs `prisma migrate deploy` (never `db seed`), so a new Source needs a migration to reach prod. Mirrors the triage / se-asia migration idioms (deterministic ids, NOTICE-not-RAISE, `ON CONFLICT` upsert, link resolved by `(name,type)`).
- **Tests** — `export` + unit-test `resolveCollectionUrl` (the `/hareline` collection-path resolution + double-append guard); registry routing regression test so the new route can't be silently darkened.
- **`active-sources.md`** — Vermont 4 → 5.

## Verification

- **Live** (`scripts/verify-vth3-squarespace.ts`): **113 events** (7 upcoming + 106 past) back to **2022-01-08** across **4 pages**, EDT times, real Burlington coords (44.48 — no Manhattan tenant-default leak), **94 run numbers**, 0 errors.
- Migration applied + re-applied against the local dev DB (idempotent; exactly 1 source, linked to `vth3`).
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (8459 tests).
- `/simplify` + `/codex:adversarial-review` (the latter's P2 — missing registry test — is fixed here).

Closes #1941

🤖 Generated with [Claude Code](https://claude.com/claude-code)