### PR TITLE
feat(brasilia-h3): onboard Brasília H3 — HashTracks' first Brazil kennel

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -553,6 +553,8 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "bali-hash-2": ["Bali Hash 2", "Bali Hash House Harriers 2", "BH2", "Bali Hash 2 Next Run Map"],
     // Paraguay — first South American kennel (omit "ASS H3": collides with ass-h3 Atomic Shit Show)
     "asu-h3": ["Asunción H3", "Asuncion H3", "ASU H3", "ASUH3", "Asuncion Hash", "Asunción Hash House Harriers"],
+    // Brazil — first Brazil kennel ("BH3" omitted: globally taken by Boston/Buffalo/Bristol/Boulder)
+    "brasilia-h3": ["Brasilia H3", "Brasília H3", "Brasilia Hash", "Brasilia HHH"],
     // Spain — first Spain kennel ("MH3" alone collides with Memphis/Munich/Montreal)
     "mijash3": ["Mijas", "Mijas HHH", "MijasH3", "MH3 Spain", "Burro Hash", "Mijas Hash House Harriers"],
     // France — bare "PH3" omitted (collides with ph3-my/pattaya-h3); bare "SCH3" omitted (collides with sch3-atl/sch3-ca)

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4584,6 +4584,24 @@ export const KENNELS: KennelSeed[] = [
       latitude: -25.2637,
       longitude: -57.5759,
     },
+    // ===== BRAZIL =====
+    // First Brazil kennel — Brasília H3, hashing since 1989. shortName is the
+    // ASCII "Brasilia H3" (the kennel writes it without the accent) → toSlug =
+    // "brasilia-h3", clean, no accent-mangling, so no explicit slug override.
+    // scheduleTime/hashCash/logoUrl intentionally omitted — unverified, do not invent.
+    // latitude/longitude is the Brasília city centroid; runs carry no per-event coords.
+    {
+      kennelCode: "brasilia-h3", shortName: "Brasilia H3", fullName: "Brasilia Hash House Harriers",
+      region: "Brasília, Brazil", country: "Brazil",
+      website: "https://brasiliah3.blogspot.com",
+      facebookUrl: "https://www.facebook.com/BrasiliaHHH",
+      foundedYear: 1989,
+      scheduleDayOfWeek: "Sunday", scheduleFrequency: "Biweekly",
+      walkersWelcome: true,
+      description: "Brasília's hash kennel — running and walking 5–7 km trails around Brazil's capital since 1989, with biweekly Sunday runs that always end at the beer stop.",
+      latitude: -15.793,
+      longitude: -47.882,
+    },
     // ===== MEXICO =====
     // First Mexico kennel — Mexico City H3 ("CDMX H3"), hashing since Oct 1983.
     // foundedYear 1983 is the kennel founding (Mexico News Daily + Half-Mind), NOT the

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -6407,6 +6407,22 @@ export const SOURCES = [
       config: { upcomingOnly: true },
       kennelCodes: ["asu-h3"],
     },
+    // --- Brasília, Brazil (first Brazil kennel) ---
+    {
+      name: "Brasilia H3 Blogspot Trail Posts",
+      url: "https://brasiliah3.blogspot.com/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "daily",
+      scrapeDays: 90,
+      // Future-only adapter (fetches a recent ~25-post window via the Blogger
+      // API); the ~186-post archive back to Apr 2019 loads via the one-shot
+      // scripts/backfill-brasilia-h3-history.ts insert. upcomingOnly restricts
+      // reconciliation to future dates so the aged archive is never
+      // false-cancelled as posts roll off the recent window (reconcile.ts guard).
+      config: { upcomingOnly: true },
+      kennelCodes: ["brasilia-h3"],
+    },
 
     // ===== MEXICO =====
     // --- Mexico City, Mexico (first Mexico kennel) ---

--- a/scripts/backfill-brasilia-h3-history.ts
+++ b/scripts/backfill-brasilia-h3-history.ts
@@ -43,5 +43,7 @@ runBackfillScript({
   fetchEvents: async () => brasiliaHistory as RawEventData[],
 }).catch((err) => {
   console.error(err);
-  process.exit(1);
+  // Set exitCode (not process.exit) so the runner's Prisma disconnect / event
+  // loop can drain cleanly before the process terminates.
+  process.exitCode = 1;
 });

--- a/scripts/backfill-brasilia-h3-history.ts
+++ b/scripts/backfill-brasilia-h3-history.ts
@@ -1,0 +1,47 @@
+/**
+ * One-shot historical backfill for Brasilia H3 (brasilia-h3) — HashTracks'
+ * first Brazil kennel.
+ *
+ * The Brasilia H3 adapter (src/adapters/html-scraper/brasilia-h3.ts) fetches
+ * only a recent window of Blogspot posts, so the full archive (run #154
+ * 2019-04 → #338 2026-05) would never reach canonical Events on its own.
+ *
+ * The archive was extracted once (parsed via the adapter's exported
+ * `parseBrasiliaPost` over the live Blogger API feed) and frozen into
+ * `scripts/data/brasilia-h3-history.json` — committed as data, no parser, per
+ * the H7/Asunción lesson. The rows bind to the live "Brasilia H3 Blogspot
+ * Trail Posts" source (same sourceUrl the recurring adapter scrapes).
+ *
+ * Known source-data quirk: six date pairs collide (the kennel copy-pasted the
+ * previous run's date line into the next post — e.g. runs 194/195 both stamped
+ * "15th of November" 2020). The rows are stored faithfully; the merge pipeline
+ * collapses same (kennel, date) RawEvents into one canonical Event. N+339 is
+ * genuinely absent from the blog and is not synthesized.
+ *
+ * Re-runnable: the backfill runner dedupes by fingerprint and loads only past
+ * events (date < today in kennel timezone).
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-brasilia-h3-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-brasilia-h3-history.ts
+ *
+ * Requires the "Brasilia H3 Blogspot Trail Posts" source to exist (run
+ * `npx prisma db seed`).
+ */
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import type { RawEventData } from "@/adapters/types";
+import brasiliaHistory from "./data/brasilia-h3-history.json";
+
+const SOURCE_NAME = "Brasilia H3 Blogspot Trail Posts";
+const KENNEL_TIMEZONE = "America/Sao_Paulo";
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Loading curated Brasilia H3 Blogspot archive",
+  fetchEvents: async () => brasiliaHistory as RawEventData[],
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/data/brasilia-h3-history.json
+++ b/scripts/data/brasilia-h3-history.json
@@ -1,0 +1,1409 @@
+[
+  {
+    "date": "2019-04-21",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 154,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/04/blog-post_12.html"
+  },
+  {
+    "date": "2019-05-05",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 155,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/04/blog-post.html"
+  },
+  {
+    "date": "2019-05-19",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 156,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/05/blog-post.html"
+  },
+  {
+    "date": "2019-05-31",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 157,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/05/blog-post_20.html"
+  },
+  {
+    "date": "2019-06-16",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 160,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/06/blog-post.html"
+  },
+  {
+    "date": "2019-06-30",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 161,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/06/blog-post_24.html"
+  },
+  {
+    "date": "2019-07-14",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 162,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/07/blog-post.html"
+  },
+  {
+    "date": "2019-07-28",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 163,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/07/blog-post_20.html"
+  },
+  {
+    "date": "2019-08-11",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 164,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/08/blog-post.html"
+  },
+  {
+    "date": "2019-08-25",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 165,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/08/blog-post_18.html"
+  },
+  {
+    "date": "2019-09-08",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 166,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/08/blog-post_30.html"
+  },
+  {
+    "date": "2019-09-22",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 167,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/09/blog-post.html"
+  },
+  {
+    "date": "2019-10-06",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 168,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/10/blog-post.html"
+  },
+  {
+    "date": "2019-10-20",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 169,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/10/blog-post_10.html"
+  },
+  {
+    "date": "2019-11-03",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 170,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/10/blog-post_27.html"
+  },
+  {
+    "date": "2019-11-17",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 171,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/11/blog-post.html"
+  },
+  {
+    "date": "2019-12-01",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 172,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/11/blog-post_19.html"
+  },
+  {
+    "date": "2019-12-15",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 173,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/12/blog-post.html"
+  },
+  {
+    "date": "2019-12-29",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 174,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2019/12/blog-post_22.html"
+  },
+  {
+    "date": "2020-01-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 175,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/01/blog-post.html"
+  },
+  {
+    "date": "2020-01-26",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 176,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/01/blog-post_18.html"
+  },
+  {
+    "date": "2020-02-09",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 177,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/02/blog-post.html"
+  },
+  {
+    "date": "2020-02-23",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 178,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/02/blog-post_14.html"
+  },
+  {
+    "date": "2020-03-08",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 179,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/02/blog-post_29.html"
+  },
+  {
+    "date": "2020-05-03",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 180,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/04/blog-post.html"
+  },
+  {
+    "date": "2020-05-17",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 182,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/05/blog-post_19.html"
+  },
+  {
+    "date": "2020-05-17",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 181,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/05/blog-post.html"
+  },
+  {
+    "date": "2020-06-14",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 183,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/06/blog-post.html"
+  },
+  {
+    "date": "2020-06-28",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 184,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/06/blog-post_16.html"
+  },
+  {
+    "date": "2020-07-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 186,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/07/blog-post_16.html"
+  },
+  {
+    "date": "2020-07-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 185,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/07/blog-post.html"
+  },
+  {
+    "date": "2020-08-09",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 187,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/08/blog-post.html"
+  },
+  {
+    "date": "2020-08-23",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 188,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/08/blog-post_17.html"
+  },
+  {
+    "date": "2020-09-06",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 189,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/08/blog-post_31.html"
+  },
+  {
+    "date": "2020-09-20",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 190,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/09/blog-post.html"
+  },
+  {
+    "date": "2020-10-04",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 191,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/09/blog-post_25.html"
+  },
+  {
+    "date": "2020-10-18",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 192,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/10/blog-post.html"
+  },
+  {
+    "date": "2020-11-01",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 193,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/10/blog-post_23.html"
+  },
+  {
+    "date": "2020-11-15",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 195,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/11/blog-post_23.html"
+  },
+  {
+    "date": "2020-11-15",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 194,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/11/blog-post.html"
+  },
+  {
+    "date": "2020-12-13",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 196,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/12/blog-post.html"
+  },
+  {
+    "date": "2020-12-27",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 197,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/12/blog-post_20.html"
+  },
+  {
+    "date": "2021-01-10",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 198,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/01/blog-post.html"
+  },
+  {
+    "date": "2021-01-24",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 199,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/01/blog-post_15.html"
+  },
+  {
+    "date": "2021-02-07",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 200,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/01/blog-post_26.html"
+  },
+  {
+    "date": "2021-02-21",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 201,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/02/blog-post.html"
+  },
+  {
+    "date": "2021-03-07",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 202,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/02/blog-post_26.html"
+  },
+  {
+    "date": "2021-03-21",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 203,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/03/blog-post.html"
+  },
+  {
+    "date": "2021-04-04",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 204,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/03/blog-post_26.html"
+  },
+  {
+    "date": "2021-04-18",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 205,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/04/blog-post_12.html"
+  },
+  {
+    "date": "2021-05-02",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 206,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/04/blog-post_26.html"
+  },
+  {
+    "date": "2021-05-16",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 208,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/05/blog-post_23.html"
+  },
+  {
+    "date": "2021-05-16",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 207,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/05/blog-post.html"
+  },
+  {
+    "date": "2021-06-13",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 209,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/06/blog-post.html"
+  },
+  {
+    "date": "2021-06-27",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 210,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/06/blog-post_17.html"
+  },
+  {
+    "date": "2021-07-11",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 211,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/07/blog-post.html"
+  },
+  {
+    "date": "2021-07-25",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 212,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/07/blog-post_20.html"
+  },
+  {
+    "date": "2021-08-08",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 213,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/08/blog-post.html"
+  },
+  {
+    "date": "2021-08-22",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 214,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/08/blog-post_14.html"
+  },
+  {
+    "date": "2021-09-05",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 215,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/08/blog-post_29.html"
+  },
+  {
+    "date": "2021-09-19",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 216,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/09/blog-post.html"
+  },
+  {
+    "date": "2021-10-03",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 217,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/09/blog-post_23.html"
+  },
+  {
+    "date": "2021-10-17",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 218,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/10/blog-post.html"
+  },
+  {
+    "date": "2021-10-31",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 219,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/10/blog-post_21.html"
+  },
+  {
+    "date": "2021-11-14",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 220,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/11/blog-post.html"
+  },
+  {
+    "date": "2021-11-28",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 221,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/11/blog-post_21.html"
+  },
+  {
+    "date": "2021-12-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 222,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/12/blog-post.html"
+  },
+  {
+    "date": "2021-12-26",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 223,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/12/blog-post_19.html"
+  },
+  {
+    "date": "2022-01-09",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 224,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/01/blog-post.html"
+  },
+  {
+    "date": "2022-01-20",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 227,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/02/blog-post.html"
+  },
+  {
+    "date": "2022-01-23",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 226,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/01/blog-post_28.html"
+  },
+  {
+    "date": "2022-01-23",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 225,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/01/blog-post_15.html"
+  },
+  {
+    "date": "2022-03-06",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 228,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/02/blog-post_27.html"
+  },
+  {
+    "date": "2022-03-20",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 229,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/03/blog-post.html"
+  },
+  {
+    "date": "2022-04-03",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 230,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/03/blog-post_28.html"
+  },
+  {
+    "date": "2022-04-17",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 231,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/04/blog-post.html"
+  },
+  {
+    "date": "2022-05-01",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 232,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/04/blog-post_24.html"
+  },
+  {
+    "date": "2022-05-29",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 236,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/05/blog-post_22.html"
+  },
+  {
+    "date": "2022-06-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 237,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/06/blog-post.html"
+  },
+  {
+    "date": "2022-06-26",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 238,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/06/blog-post_19.html"
+  },
+  {
+    "date": "2022-07-10",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 239,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/07/blog-post.html"
+  },
+  {
+    "date": "2022-07-26",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 240,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/07/blog-post_15.html"
+  },
+  {
+    "date": "2022-08-07",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 241,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/07/blog-post_31.html"
+  },
+  {
+    "date": "2022-08-21",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 242,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/08/blog-post.html"
+  },
+  {
+    "date": "2022-09-04",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 243,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/08/blog-post_28.html"
+  },
+  {
+    "date": "2022-09-18",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 244,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/09/blog-post.html"
+  },
+  {
+    "date": "2022-10-02",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 245,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/09/blog-post_26.html"
+  },
+  {
+    "date": "2022-10-16",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 246,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/10/blog-post.html"
+  },
+  {
+    "date": "2022-10-30",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 247,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/10/blog-post_23.html"
+  },
+  {
+    "date": "2022-11-13",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 248,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/11/blog-post.html"
+  },
+  {
+    "date": "2022-11-27",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 249,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/11/blog-post_21.html"
+  },
+  {
+    "date": "2022-12-11",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 250,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/12/blog-post.html"
+  },
+  {
+    "date": "2023-01-09",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 251,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/01/blog-post.html"
+  },
+  {
+    "date": "2023-01-22",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 252,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/01/blog-post_15.html"
+  },
+  {
+    "date": "2023-02-05",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 252,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/01/blog-post_30.html"
+  },
+  {
+    "date": "2023-02-19",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 254,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/02/blog-post.html"
+  },
+  {
+    "date": "2023-03-05",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 256,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/03/blog-post.html"
+  },
+  {
+    "date": "2023-03-05",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 255,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/02/blog-post_26.html"
+  },
+  {
+    "date": "2023-04-05",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 257,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/03/blog-post_26.html"
+  },
+  {
+    "date": "2023-04-16",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 258,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/04/blog-post.html"
+  },
+  {
+    "date": "2023-04-30",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 259,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/04/blog-post_23.html"
+  },
+  {
+    "date": "2023-05-14",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 260,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/05/blog-post.html"
+  },
+  {
+    "date": "2023-05-28",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 261,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/05/blog-post_21.html"
+  },
+  {
+    "date": "2023-06-25",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 265,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/06/blog-post_18.html"
+  },
+  {
+    "date": "2023-07-09",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 266,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/07/blog-post.html"
+  },
+  {
+    "date": "2023-07-23",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 267,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/07/blog-post_16.html"
+  },
+  {
+    "date": "2023-08-06",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 268,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/07/blog-post_30.html"
+  },
+  {
+    "date": "2023-08-20",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 269,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/08/blog-post.html"
+  },
+  {
+    "date": "2023-09-03",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 270,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/08/blog-post_28.html"
+  },
+  {
+    "date": "2023-09-17",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 271,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/09/blog-post.html"
+  },
+  {
+    "date": "2023-10-01",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 272,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/09/blog-post_26.html"
+  },
+  {
+    "date": "2023-10-15",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 273,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/10/blog-post.html"
+  },
+  {
+    "date": "2023-10-29",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 274,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/10/blog-post_22.html"
+  },
+  {
+    "date": "2023-11-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 275,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/11/blog-post.html"
+  },
+  {
+    "date": "2023-11-26",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 276,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/11/blog-post_13.html"
+  },
+  {
+    "date": "2023-12-10",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 277,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/12/blog-post.html"
+  },
+  {
+    "date": "2024-01-07",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 278,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/12/blog-post_30.html"
+  },
+  {
+    "date": "2024-01-21",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 279,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/01/blog-post.html"
+  },
+  {
+    "date": "2024-02-04",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 280,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/01/blog-post_28.html"
+  },
+  {
+    "date": "2024-02-18",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 281,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/02/blog-post.html"
+  },
+  {
+    "date": "2024-03-03",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 282,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/02/blog-post_25.html"
+  },
+  {
+    "date": "2024-03-17",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 283,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/03/blog-post.html"
+  },
+  {
+    "date": "2024-03-31",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 284,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/03/blog-post_24.html"
+  },
+  {
+    "date": "2024-04-14",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 285,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/04/blog-post.html"
+  },
+  {
+    "date": "2024-04-28",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 286,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/04/blog-post_22.html"
+  },
+  {
+    "date": "2024-05-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 287,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/05/blog-post.html"
+  },
+  {
+    "date": "2024-05-26",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 288,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/05/blog-post_19.html"
+  },
+  {
+    "date": "2024-06-23",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 289,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/06/blog-post_17.html"
+  },
+  {
+    "date": "2024-07-07",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 290,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/07/blog-post.html"
+  },
+  {
+    "date": "2024-07-21",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 291,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/07/blog-post_14.html"
+  },
+  {
+    "date": "2024-08-04",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 292,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/07/blog-post_30.html"
+  },
+  {
+    "date": "2024-08-18",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 293,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/08/blog-post.html"
+  },
+  {
+    "date": "2024-09-01",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 294,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/08/blog-post_25.html"
+  },
+  {
+    "date": "2024-09-15",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 295,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/09/blog-post.html"
+  },
+  {
+    "date": "2024-09-29",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 296,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/09/blog-post_22.html"
+  },
+  {
+    "date": "2024-10-13",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 297,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/10/blog-post.html"
+  },
+  {
+    "date": "2024-10-27",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 298,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/10/blog-post_21.html"
+  },
+  {
+    "date": "2024-11-10",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 299,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/11/blog-post.html"
+  },
+  {
+    "date": "2024-11-24",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 300,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/11/hash-n300-300-hash-sunday-24th-of.html"
+  },
+  {
+    "date": "2024-12-08",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 301,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/12/hash-n301-mice-hash-sunday-8th-of.html"
+  },
+  {
+    "date": "2024-12-22",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 302,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/12/hash-n302-hashmas-sunday-22nd-of.html"
+  },
+  {
+    "date": "2025-01-05",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 303,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2024/12/hash-n303-new-year-sunday-5th-of.html"
+  },
+  {
+    "date": "2025-01-19",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 304,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/01/hash-n304-city-park-sunday-19th-of.html"
+  },
+  {
+    "date": "2025-02-02",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 305,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/01/hash-n305-virgin-hare-sunday-2nd-of.html"
+  },
+  {
+    "date": "2025-02-16",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 306,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/02/hash-n306-pontao-sunday-16th-of.html"
+  },
+  {
+    "date": "2025-03-02",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 307,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/02/hash-n307-carnaval-sunday-2nd-of-march.html"
+  },
+  {
+    "date": "2025-03-16",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 308,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/03/hash-n308-virgin-hare-sunday-16th-of.html"
+  },
+  {
+    "date": "2025-03-30",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 309,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/03/hash-n309-april-fools-day-sunday-30th.html"
+  },
+  {
+    "date": "2025-04-13",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 310,
+    "location": "Parking lot right in front of Parque das Garças (look for hungover",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/04/hash-n310-parque-das-garcas-sunday-13th.html"
+  },
+  {
+    "date": "2025-04-27",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 311,
+    "location": "Parking lot at",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/04/hash-n311-ruine-sunday-27th-of-april.html"
+  },
+  {
+    "date": "2025-05-11",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 312,
+    "location": "Parking lot at Centro Educacional Leonardo da",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/05/hash-n312-mothers-day-sunday-11th-of.html"
+  },
+  {
+    "date": "2025-05-25",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 313,
+    "location": "Parking lot at Borracharia",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/05/hash-n313-bush-sunday-25th-of-may-ah.html"
+  },
+  {
+    "date": "2025-06-22",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 317,
+    "location": "Parking lot",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/06/hash-n317-festa-junina-sunday-22nd-of.html"
+  },
+  {
+    "date": "2025-07-06",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 318,
+    "location": "Parque Bosque do Sudoeste (aka",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/07/hash-n318-independence-day-sunday-6th.html"
+  },
+  {
+    "date": "2025-07-20",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 319,
+    "location": "Praça da Persistência, Asa Sul",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/07/hash-n319-naming-sunday-20th-of-july.html"
+  },
+  {
+    "date": "2025-08-03",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 320,
+    "location": "SQS 305, bloco to be revealed like a reality show twist",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/07/hash-n320-leo-zodiac-sunday-3rd-of.html"
+  },
+  {
+    "date": "2025-08-17",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 321,
+    "location": "Parking lot, Praça dos Cristais,",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/08/hash-n321-farewell-sunday-17th-of.html"
+  },
+  {
+    "date": "2025-08-31",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 322,
+    "location": "Parking lot beside Concha Acústica",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/08/hash-n322-vila-planalto-sunday-31st-of.html"
+  },
+  {
+    "date": "2025-09-14",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 323,
+    "location": "Parque da 13,",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/09/hash-n323-lago-norte-sunday-14th-of.html"
+  },
+  {
+    "date": "2025-09-28",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 324,
+    "location": "Praça Índio Pataxó Galdino Jesus dos Santos, SHIGS 704 – Asa Sul",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/09/hash-n324-asa-sul-sunday-28th-of.html"
+  },
+  {
+    "date": "2025-10-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 325,
+    "location": "SQN 107, Bloco C",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/10/hash-n325-eixao-sunday-12th-of-october.html"
+  },
+  {
+    "date": "2025-11-09",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 326,
+    "location": "Parking lot behind",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/10/hash-n326-halloween-sunday-26th-of.html"
+  },
+  {
+    "date": "2025-11-23",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 327,
+    "location": "Parking Ecological",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/11/hash-n327dom-bosco-sunday-23rd-of.html"
+  },
+  {
+    "date": "2025-12-07",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 328,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/12/hash-n328-lago-sul-sunday-7th-of.html"
+  },
+  {
+    "date": "2025-12-21",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 329,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2025/12/hash-n329-hashmas-sunday-21st-of.html"
+  },
+  {
+    "date": "2026-01-18",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 330,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/01/hash-n330-new-year-sunday-18th-of.html"
+  },
+  {
+    "date": "2026-02-01",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 331,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/01/hash-n330-new-year-sunday-18th-of_27.html"
+  },
+  {
+    "date": "2026-02-15",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 332,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/02/hash-n332-carnaval-sunday-15th-of.html"
+  },
+  {
+    "date": "2026-03-01",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 333,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/02/hash-n333-city-park-sunday-1st-of-march.html"
+  },
+  {
+    "date": "2026-03-15",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 334,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/03/hash-n334-st.html"
+  },
+  {
+    "date": "2026-03-29",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 335,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/03/hash-n335-university-sunday-29th-of.html"
+  },
+  {
+    "date": "2026-04-12",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 336,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/04/hash-n336-asa-sul-sunday-12th-of-april.html"
+  },
+  {
+    "date": "2026-04-26",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 337,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/04/hash-n337-zoo-sunday-26th-of-april.html"
+  },
+  {
+    "date": "2026-05-10",
+    "kennelTags": [
+      "brasilia-h3"
+    ],
+    "runNumber": 338,
+    "sourceUrl": "https://brasiliah3.blogspot.com/2026/05/hash-n338-farewell-sunday-10th-of-may.html"
+  }
+]

--- a/scripts/data/brasilia-h3-history.json
+++ b/scripts/data/brasilia-h3-history.json
@@ -1324,6 +1324,7 @@
       "brasilia-h3"
     ],
     "runNumber": 328,
+    "location": "Parking lot of",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/12/hash-n328-lago-sul-sunday-7th-of.html"
   },
   {
@@ -1332,6 +1333,7 @@
       "brasilia-h3"
     ],
     "runNumber": 329,
+    "location": "SQN 203 – Bloco TBA (because planning is for other people)",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/12/hash-n329-hashmas-sunday-21st-of.html"
   },
   {
@@ -1340,6 +1342,7 @@
       "brasilia-h3"
     ],
     "runNumber": 330,
+    "location": "Praça da Persistência,SHCS EQS 112/113 – Asa Sul",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/01/hash-n330-new-year-sunday-18th-of.html"
   },
   {
@@ -1348,6 +1351,7 @@
       "brasilia-h3"
     ],
     "runNumber": 331,
+    "location": "Parking lot in front of Borracharia Lago Norte",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/01/hash-n330-new-year-sunday-18th-of_27.html"
   },
   {
@@ -1356,6 +1360,7 @@
       "brasilia-h3"
     ],
     "runNumber": 332,
+    "location": "Parking lot in front of Caixa Cultural Brasília",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/02/hash-n332-carnaval-sunday-15th-of.html"
   },
   {
@@ -1364,6 +1369,7 @@
       "brasilia-h3"
     ],
     "runNumber": 333,
+    "location": "Parking lot 9 in Parque da Cidade Sarah Kubitschek",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/02/hash-n333-city-park-sunday-1st-of-march.html"
   },
   {
@@ -1372,6 +1378,7 @@
       "brasilia-h3"
     ],
     "runNumber": 334,
+    "location": "Park at SQN216, Bloco B in Asa Norte",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/03/hash-n334-st.html"
   },
   {
@@ -1380,6 +1387,7 @@
       "brasilia-h3"
     ],
     "runNumber": 335,
+    "location": "Main parking lot at UNB – Asa Norte",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/03/hash-n335-university-sunday-29th-of.html"
   },
   {
@@ -1388,6 +1396,7 @@
       "brasilia-h3"
     ],
     "runNumber": 336,
+    "location": "SQS 406, Bloco K",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/04/hash-n336-asa-sul-sunday-12th-of-april.html"
   },
   {
@@ -1396,6 +1405,7 @@
       "brasilia-h3"
     ],
     "runNumber": 337,
+    "location": "Main gate at Brasília Zoo",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/04/hash-n337-zoo-sunday-26th-of-april.html"
   },
   {
@@ -1404,6 +1414,7 @@
       "brasilia-h3"
     ],
     "runNumber": 338,
+    "location": "Road entrance to SQN 306, Asa Norte — Wine Rack’s home turf.",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/05/hash-n338-farewell-sunday-10th-of-may.html"
   }
 ]

--- a/src/adapters/html-scraper/brasilia-h3.test.ts
+++ b/src/adapters/html-scraper/brasilia-h3.test.ts
@@ -42,10 +42,22 @@ describe("parseBrasiliaPost", () => {
     expect(parseBrasiliaPost(body, "2026-02-20T12:00:00-03:00", "https://brasiliah3.blogspot.com/x")).toBeNull();
   });
 
-  it("extracts a clean `Start:`-labelled venue", () => {
+  it("extracts a clean `Start:`-labelled venue (inline form)", () => {
     const body = "Hash N+300\nSunday, 12th of April\nStart: SQN 107, Bloco C\nBring beer money.";
     const parsed = parseBrasiliaPost(body, "2025-04-07T12:00:00-03:00", "https://brasiliah3.blogspot.com/x");
     expect(parsed?.location).toBe("SQN 107, Bloco C");
+  });
+
+  it("extracts a venue from a `📍 Start` heading with the venue on the next line", () => {
+    const body = "Hash N+335 \"University Hash\"\nSunday, 29th of March\n📍 Start\nSQS 406, Bloco K\n🏃 Runners\n6 km";
+    const parsed = parseBrasiliaPost(body, "2026-03-24T12:00:00-03:00", "https://brasiliah3.blogspot.com/x");
+    expect(parsed?.location).toBe("SQS 406, Bloco K");
+  });
+
+  it("does not treat mid-prose 'start at …' as a venue label", () => {
+    const body = "Hash N+334 \"Richard Hash\"\nSunday, 15th of March\nWe start at the park at SQN 216, Bloco B, at the far end of Asa Norte.";
+    const parsed = parseBrasiliaPost(body, "2026-03-10T12:00:00-03:00", "https://brasiliah3.blogspot.com/x");
+    expect(parsed?.location).toBeUndefined();
   });
 
   it("ignores a placeholder venue", () => {
@@ -126,6 +138,7 @@ describe("BrasiliaH3Adapter.fetch", () => {
       postsFound: 2,
       eventsParsed: 2,
     });
+    expect(result.diagnosticContext?.eventsParsed).toBe(2);
   });
 
   it("skips non-run posts (away-hash socials) without erroring", async () => {

--- a/src/adapters/html-scraper/brasilia-h3.test.ts
+++ b/src/adapters/html-scraper/brasilia-h3.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseBrasiliaPost, BrasiliaH3Adapter } from "./brasilia-h3";
+import { stripHtmlTags } from "../utils";
+import * as bloggerApi from "../blogger-api";
+
+vi.mock("../blogger-api");
+
+// Real N+340 post body (Praça dos Orixás Hash), trimmed. Titles are empty on
+// this blog, so the run number + date live in the body. Published 2026-06-02,
+// run on Sunday 7 June 2026.
+const N340_HTML = [
+  "<div>Hash N+340 \"Pra&#231;a dos Orix&#225;s Hash\"</div>",
+  "<div>Sunday, 7th of June</div>",
+  "<p>Welcome to Hash N+340: the lakeside edition.</p>",
+  "<p>This week we gather at Pra&#231;a dos Orix&#225;s.</p>",
+].join("");
+
+describe("parseBrasiliaPost", () => {
+  it("extracts run number and date from a post body (empty title, body-only)", () => {
+    const body = stripHtmlTags(N340_HTML, "\n");
+    const parsed = parseBrasiliaPost(body, "2026-06-02T17:29:24-03:00", "https://brasiliah3.blogspot.com/2026/06/n340.html");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.runNumber).toBe(340);
+    expect(parsed?.date).toBe("2026-06-07");
+    expect(parsed?.sourceUrl).toBe("https://brasiliah3.blogspot.com/2026/06/n340.html");
+    // No `Start:` label in this post → location stays undefined (merge geocodes prose).
+    expect(parsed?.location).toBeUndefined();
+  });
+
+  it("returns null for a non-run post (no `Hash N+NNN` heading)", () => {
+    const body = "Brasilia Hash House Harriers Weekend Away 2025\nFriday, 6th of June\nJoin us for the annual trip.";
+    expect(parseBrasiliaPost(body, "2025-05-26T12:00:00-03:00", "https://brasiliah3.blogspot.com/x")).toBeNull();
+  });
+
+  it("returns null when a run post has no parseable date line", () => {
+    const body = "Hash N+205\nNo date given this week, watch the group chat.";
+    expect(parseBrasiliaPost(body, "2021-09-01T12:00:00-03:00", "https://brasiliah3.blogspot.com/x")).toBeNull();
+  });
+
+  it("returns null for an impossible date (round-trip guard)", () => {
+    const body = "Hash N+500\nSunday, 31st of February";
+    expect(parseBrasiliaPost(body, "2026-02-20T12:00:00-03:00", "https://brasiliah3.blogspot.com/x")).toBeNull();
+  });
+
+  it("extracts a clean `Start:`-labelled venue", () => {
+    const body = "Hash N+300\nSunday, 12th of April\nStart: SQN 107, Bloco C\nBring beer money.";
+    const parsed = parseBrasiliaPost(body, "2025-04-07T12:00:00-03:00", "https://brasiliah3.blogspot.com/x");
+    expect(parsed?.location).toBe("SQN 107, Bloco C");
+  });
+
+  it("ignores a placeholder venue", () => {
+    const body = "Hash N+301\nSunday, 26th of April\nStart Location: TBD";
+    const parsed = parseBrasiliaPost(body, "2025-04-21T12:00:00-03:00", "https://brasiliah3.blogspot.com/x");
+    expect(parsed?.location).toBeUndefined();
+  });
+
+  // Year is absent from the date line; it is inferred as the year (pubY-1/pubY/pubY+1)
+  // that puts the run closest to the publish date. Covers announcement, Dec→Jan
+  // rollover, and recap-published-after-the-run cases.
+  it.each([
+    // label,             body date line,            published,                     expected date
+    ["announcement",      "Sunday, 7th of June",     "2026-06-02T17:29:24-03:00",   "2026-06-07"],
+    ["Dec→Jan rollover",  "Sunday, 3rd of January",  "2025-12-28T12:00:00-03:00",   "2026-01-03"],
+    ["recap after run",   "Friday, 20th of January", "2023-02-10T12:00:00-03:00",   "2023-01-20"],
+  ])("infers the year for the %s case", (_label, dateLine, published, expected) => {
+    const body = `Hash N+123 "Theme Hash"\n${dateLine}\nSome prose.`;
+    const parsed = parseBrasiliaPost(body, published, "https://brasiliah3.blogspot.com/x");
+    expect(parsed?.date).toBe(expected);
+  });
+});
+
+describe("BrasiliaH3Adapter.fetch", () => {
+  let adapter: BrasiliaH3Adapter;
+
+  beforeEach(() => {
+    adapter = new BrasiliaH3Adapter();
+    // Fix "now" so applyDateWindow(±90d) is deterministic (the API is mocked).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-04T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("parses run events from Blogger API posts", async () => {
+    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
+      posts: [
+        {
+          title: "",
+          content: N340_HTML,
+          url: "https://brasiliah3.blogspot.com/2026/06/n340.html",
+          published: "2026-06-02T17:29:24-03:00",
+        },
+        {
+          title: "",
+          content: "<div>Hash N+338 \"Farewell Hash\"</div><div>Sunday, 10th of May</div><p>Start: Road entrance to SQN 306, Asa Norte</p>",
+          url: "https://brasiliah3.blogspot.com/2026/05/n338.html",
+          published: "2026-05-05T15:42:00-03:00",
+        },
+      ],
+      blogId: "777",
+      fetchDurationMs: 120,
+    });
+
+    const result = await adapter.fetch({ id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays: 90 } as never);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0]).toMatchObject({
+      date: "2026-06-07",
+      kennelTags: ["brasilia-h3"],
+      runNumber: 340,
+    });
+    expect(result.events[0].title).toBeUndefined();
+    expect(result.events[1]).toMatchObject({
+      date: "2026-05-10",
+      kennelTags: ["brasilia-h3"],
+      runNumber: 338,
+      location: "Road entrance to SQN 306, Asa Norte",
+    });
+    expect(result.diagnosticContext).toMatchObject({
+      fetchMethod: "blogger-api",
+      blogId: "777",
+      postsFound: 2,
+      eventsParsed: 2,
+    });
+  });
+
+  it("skips non-run posts (away-hash socials) without erroring", async () => {
+    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
+      posts: [
+        {
+          title: "",
+          content: "<div>Hash N+340 \"Pra&#231;a dos Orix&#225;s Hash\"</div><div>Sunday, 7th of June</div>",
+          url: "https://brasiliah3.blogspot.com/2026/06/n340.html",
+          published: "2026-06-02T17:29:24-03:00",
+        },
+        {
+          title: "",
+          content: "<div>Yearly Weekend Away Hash 2026</div><div>Friday, 6th of June to Sunday 8th</div>",
+          url: "https://brasiliah3.blogspot.com/2026/05/away.html",
+          published: "2026-05-20T12:00:00-03:00",
+        },
+      ],
+      blogId: "777",
+      fetchDurationMs: 90,
+    });
+
+    const result = await adapter.fetch({ id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays: 90 } as never);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].runNumber).toBe(340);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("fails loud when posts are fetched but none parse as runs", async () => {
+    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
+      posts: [
+        {
+          title: "",
+          content: "<div>Some announcement with no run heading and no date.</div>",
+          url: "https://brasiliah3.blogspot.com/2026/06/x.html",
+          published: "2026-06-02T12:00:00-03:00",
+        },
+      ],
+      blogId: "777",
+      fetchDurationMs: 80,
+    });
+
+    const result = await adapter.fetch({ id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays: 90 } as never);
+    expect(result.events).toHaveLength(0);
+    expect(result.errors.some((e) => e.includes("parsed 0 run events"))).toBe(true);
+  });
+
+  it("surfaces a Blogger API error", async () => {
+    vi.mocked(bloggerApi.fetchBloggerPosts).mockResolvedValueOnce({
+      posts: [],
+      error: { message: "Missing GOOGLE_CALENDAR_API_KEY environment variable" },
+    });
+
+    const result = await adapter.fetch({ id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays: 90 } as never);
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toContain("Blogger API fetch failed");
+    expect(result.errorDetails?.fetch?.[0].message).toContain("Blogger API fetch failed");
+  });
+});

--- a/src/adapters/html-scraper/brasilia-h3.test.ts
+++ b/src/adapters/html-scraper/brasilia-h3.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Source } from "@/generated/prisma/client";
 import { parseBrasiliaPost, BrasiliaH3Adapter } from "./brasilia-h3";
 import { stripHtmlTags } from "../utils";
 import * as bloggerApi from "../blogger-api";
 
 vi.mock("../blogger-api");
+
+// The adapter only reads source.url + source.scrapeDays. A single typed cast
+// here keeps the fetch() call sites assertion-free (Sonar S4325).
+function brasiliaSource(scrapeDays = 90): Source {
+  return { id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays } as unknown as Source;
+}
 
 // Real N+340 post body (Praça dos Orixás Hash), trimmed. Titles are empty on
 // this blog, so the run number + date live in the body. Published 2026-06-02,
@@ -116,7 +123,7 @@ describe("BrasiliaH3Adapter.fetch", () => {
       fetchDurationMs: 120,
     });
 
-    const result = await adapter.fetch({ id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays: 90 } as never);
+    const result = await adapter.fetch(brasiliaSource());
 
     expect(result.errors).toHaveLength(0);
     expect(result.events).toHaveLength(2);
@@ -161,7 +168,7 @@ describe("BrasiliaH3Adapter.fetch", () => {
       fetchDurationMs: 90,
     });
 
-    const result = await adapter.fetch({ id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays: 90 } as never);
+    const result = await adapter.fetch(brasiliaSource());
     expect(result.events).toHaveLength(1);
     expect(result.events[0].runNumber).toBe(340);
     expect(result.errors).toHaveLength(0);
@@ -181,7 +188,7 @@ describe("BrasiliaH3Adapter.fetch", () => {
       fetchDurationMs: 80,
     });
 
-    const result = await adapter.fetch({ id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays: 90 } as never);
+    const result = await adapter.fetch(brasiliaSource());
     expect(result.events).toHaveLength(0);
     expect(result.errors.some((e) => e.includes("parsed 0 run events"))).toBe(true);
   });
@@ -192,7 +199,7 @@ describe("BrasiliaH3Adapter.fetch", () => {
       error: { message: "Missing GOOGLE_CALENDAR_API_KEY environment variable" },
     });
 
-    const result = await adapter.fetch({ id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays: 90 } as never);
+    const result = await adapter.fetch(brasiliaSource());
     expect(result.events).toHaveLength(0);
     expect(result.errors[0]).toContain("Blogger API fetch failed");
     expect(result.errorDetails?.fetch?.[0].message).toContain("Blogger API fetch failed");

--- a/src/adapters/html-scraper/brasilia-h3.ts
+++ b/src/adapters/html-scraper/brasilia-h3.ts
@@ -29,11 +29,13 @@ const DATE_RE = /(\d{1,2})(?:st|nd|rd|th)?\s+of\s+([A-Za-z]+)\b/;
  *    (the venue is on the same line; ~15% of posts)
  *  - heading-only form `📍 Start` / `Start` on its own line, with the venue on
  *    the NEXT line (the 📍 Start pattern used by recent posts, e.g. N+335)
- * Capture starts at a non-space char (Sonar S5852-safe). Posts with neither
+ * Capture starts at a non-space char. ` Location` is a literal (not `\s*Location`)
+ * and the colon is literal with no leading `\s*`, avoiding the adjacent-`\s*`
+ * quantifier shape Sonar S5852 flags as super-linear. Posts with neither form
  * leave `location` undefined (merge geocodes the kennel/region centroid).
  */
-const LOCATION_INLINE_RE = /^(?:📍\s*)?Start(?:\s*Location)?\s*:\s*(\S.*)/i;
-const LOCATION_HEADING_RE = /^(?:📍\s*)?Start(?:\s*Location)?\s*:?\s*$/i;
+const LOCATION_INLINE_RE = /^(?:📍\s*)?Start(?: Location)?:\s*(\S.*)/i;
+const LOCATION_HEADING_RE = /^(?:📍\s*)?Start(?: Location)?:?\s*$/i;
 
 const DEFAULT_BLOG_URL = "https://brasiliah3.blogspot.com/";
 

--- a/src/adapters/html-scraper/brasilia-h3.ts
+++ b/src/adapters/html-scraper/brasilia-h3.ts
@@ -1,0 +1,204 @@
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
+import { hasAnyErrors } from "../types";
+import { fetchBloggerPosts } from "../blogger-api";
+import { applyDateWindow, isPlaceholder, MONTHS, stripHtmlTags } from "../utils";
+
+/**
+ * Run heading: `Hash N+340 "Praça dos Orixás Hash"`. The kennel's post-reboot
+ * numbering uses an `N+` prefix; `runNumber` stores the bare integer (340).
+ * Posts without this marker (away-hash weekends, Hashmas/Earth-Day socials)
+ * are not runs and are skipped.
+ */
+const RUN_RE = /Hash\s+N\+(\d+)/i;
+
+/**
+ * In-body date line: `Sunday, 7th of June` — ordinal day + "of" + month name,
+ * with NO YEAR. No `/i` flag (Sonar S5869): in this source the month is always
+ * a capitalised English name (resolved through the English-only MONTHS map) and
+ * the ordinal suffix + "of" are lowercase, so the class never needs case-folding.
+ */
+const DATE_RE = /(\d{1,2})(?:st|nd|rd|th)?\s+of\s+([A-Za-z]+)/;
+
+/**
+ * Clean inline venue label: `Start: <venue>`, `Start Location: <venue>`, or
+ * `📍 Start: <venue>`. Capture starts at a non-space char (Sonar S5852-safe
+ * alternative to a leading `(.+)`) and runs to end of line. Only ~15% of posts
+ * carry this label; the rest leave `location` undefined (merge geocodes later).
+ */
+const LOCATION_RE = /(?:📍\s*)?Start(?:\s*Location)?\s*:\s*(\S.*)/i;
+
+const DEFAULT_BLOG_URL = "https://brasiliah3.blogspot.com/";
+
+/** Structured fields extracted from one Blogspot post body. */
+export interface ParsedBrasiliaPost {
+  runNumber: number;
+  date: string; // YYYY-MM-DD
+  location?: string;
+  sourceUrl: string;
+}
+
+/**
+ * The in-body date line carries no year. Pick the year (publishYear − 1,
+ * publishYear, or publishYear + 1) that places the run date closest to the
+ * post's publish date. This is more robust than a naive "use publishYear, add a
+ * year if the date is before publish" rule: it handles both the Dec→Jan
+ * announcement rollover AND recap posts published days-to-weeks after the run
+ * (a previous-run photo gallery is sometimes prepended, bumping publish later).
+ */
+function inferDateString(day: number, month: number, publishedIso: string): string | null {
+  const published = new Date(publishedIso);
+  if (Number.isNaN(published.getTime())) return null;
+
+  const pubYear = published.getUTCFullYear();
+  const pubMs = published.getTime();
+
+  let bestUtc: number | null = null;
+  let bestDiff = Number.POSITIVE_INFINITY;
+  for (const year of [pubYear - 1, pubYear, pubYear + 1]) {
+    const candidate = Date.UTC(year, month - 1, day, 12, 0, 0);
+    // Skip impossible dates that Date.UTC silently rolled over (e.g. "31st of
+    // February", or "29th of February" in a non-leap year) so a valid sibling
+    // year can still win the minimisation instead of being masked by a rolled
+    // candidate that happens to land closer to the publish date.
+    const resolved = new Date(candidate);
+    if (resolved.getUTCDate() !== day || resolved.getUTCMonth() !== month - 1) continue;
+    const diff = Math.abs(candidate - pubMs);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      bestUtc = candidate;
+    }
+  }
+  if (bestUtc === null) return null;
+  return new Date(bestUtc).toISOString().slice(0, 10);
+}
+
+/** Parse the `Dth of Month` date line and resolve its year from the publish date. */
+function parseRunDate(body: string, publishedIso: string): string | null {
+  const match = DATE_RE.exec(body);
+  if (!match) return null;
+  const day = Number.parseInt(match[1], 10);
+  const month = MONTHS[match[2].toLowerCase().slice(0, 3)];
+  if (!month || day < 1 || day > 31) return null;
+  return inferDateString(day, month, publishedIso);
+}
+
+/** Extract a clean venue from a `Start:`-labelled line, or undefined. */
+function parseLocation(body: string): string | undefined {
+  const match = LOCATION_RE.exec(body);
+  if (!match) return undefined;
+  const venue = match[1].trim();
+  if (!venue || isPlaceholder(venue)) return undefined;
+  return venue;
+}
+
+/**
+ * Parse a single Brasilia H3 Blogspot post body into structured fields.
+ *
+ * Post titles are empty on this blog — all run data lives in the flattened
+ * body HTML. A post is a run only if it carries a `Hash N+NNN` heading AND a
+ * parseable date line; otherwise it returns null (skipped). Hares are
+ * deliberately NOT extracted: this blog never uses an inline `Hares:` label,
+ * only buried jokey prose, so attempting it would risk field-bleed.
+ *
+ * Exported so the one-shot history backfill can reuse it as a throwaway
+ * extractor over the full Blogger archive (the backfill itself commits the
+ * curated JSON output, not this parser).
+ */
+export function parseBrasiliaPost(
+  body: string,
+  publishedIso: string,
+  url: string,
+): ParsedBrasiliaPost | null {
+  const runMatch = RUN_RE.exec(body);
+  if (!runMatch) return null;
+  const runNumber = Number.parseInt(runMatch[1], 10);
+  if (!Number.isFinite(runNumber)) return null;
+
+  // Anchor date + venue extraction to the text following the run heading. The
+  // canonical body is `Hash N+NNN ...\n<date line>\n... Start: <venue>`, so a
+  // prepended recap of a previous run cannot supply an earlier "Dth of Month"
+  // or "Start:" line that would otherwise win the first-match search.
+  const afterHeading = body.slice(runMatch.index);
+
+  const date = parseRunDate(afterHeading, publishedIso);
+  if (!date) return null;
+
+  return {
+    runNumber,
+    date,
+    location: parseLocation(afterHeading),
+    sourceUrl: url,
+  };
+}
+
+/**
+ * Brasilia H3 Blogspot Adapter (Brasília, Brazil — HashTracks' first Brazil
+ * kennel). Reads brasiliah3.blogspot.com trail announcements via the Blogger
+ * API v3 (keyed by GOOGLE_CALENDAR_API_KEY to bypass cloud-IP 403s).
+ *
+ * Each post is one biweekly Sunday run. Post titles are empty, so run number,
+ * date (year inferred from the publish date), and venue are parsed from the
+ * post body. Title is intentionally left undefined — the merge pipeline
+ * synthesizes "Brasilia H3 Trail #NNN". This adapter fetches a recent window
+ * only; the ~186-post archive back to 2019 loads via the one-shot backfill,
+ * and `Source.config.upcomingOnly` keeps reconciliation from cancelling it.
+ */
+export class BrasiliaH3Adapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    const baseUrl = source.url || DEFAULT_BLOG_URL;
+    const days = options?.days ?? source.scrapeDays ?? 90;
+
+    const bloggerResult = await fetchBloggerPosts(baseUrl, 25);
+
+    const events: RawEventData[] = [];
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    if (bloggerResult.error) {
+      const message = `Blogger API fetch failed: ${bloggerResult.error.message}`;
+      errors.push(message);
+      errorDetails.fetch = [{ url: baseUrl, status: bloggerResult.error.status, message }];
+      return { events, errors, errorDetails };
+    }
+
+    for (const post of bloggerResult.posts) {
+      const body = stripHtmlTags(post.content, "\n");
+      const parsed = parseBrasiliaPost(body, post.published, post.url);
+      if (!parsed) continue;
+      events.push({
+        date: parsed.date,
+        kennelTags: ["brasilia-h3"],
+        runNumber: parsed.runNumber,
+        location: parsed.location,
+        sourceUrl: parsed.sourceUrl,
+      });
+    }
+
+    // Fail-loud: a brand-new source has no fill-rate baseline, so a body-format
+    // drift that yields zero parses from a non-empty fetch must surface as an
+    // error rather than passing silently as "0 events this scrape".
+    if (events.length === 0 && bloggerResult.posts.length > 0) {
+      errors.push(
+        `Brasilia H3: fetched ${bloggerResult.posts.length} posts but parsed 0 run events — body format may have changed`,
+      );
+    }
+
+    const result: ScrapeResult = {
+      events,
+      errors,
+      errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+      diagnosticContext: {
+        fetchMethod: "blogger-api",
+        blogId: bloggerResult.blogId,
+        postsFound: bloggerResult.posts.length,
+        eventsParsed: events.length,
+        fetchDurationMs: bloggerResult.fetchDurationMs,
+      },
+    };
+
+    return applyDateWindow(result, days);
+  }
+}

--- a/src/adapters/html-scraper/brasilia-h3.ts
+++ b/src/adapters/html-scraper/brasilia-h3.ts
@@ -14,19 +14,26 @@ const RUN_RE = /Hash\s+N\+(\d+)/i;
 
 /**
  * In-body date line: `Sunday, 7th of June` — ordinal day + "of" + month name,
- * with NO YEAR. No `/i` flag (Sonar S5869): in this source the month is always
- * a capitalised English name (resolved through the English-only MONTHS map) and
- * the ordinal suffix + "of" are lowercase, so the class never needs case-folding.
+ * with NO YEAR. Trailing `\b` so the month group can't eat a glued token
+ * ("February14th"). No `/i` flag (Sonar S5869): in this source the month is
+ * always a capitalised English name (resolved through the English-only MONTHS
+ * map) and the ordinal suffix + "of" are lowercase, so the class never needs
+ * case-folding.
  */
-const DATE_RE = /(\d{1,2})(?:st|nd|rd|th)?\s+of\s+([A-Za-z]+)/;
+const DATE_RE = /(\d{1,2})(?:st|nd|rd|th)?\s+of\s+([A-Za-z]+)\b/;
 
 /**
- * Clean inline venue label: `Start: <venue>`, `Start Location: <venue>`, or
- * `📍 Start: <venue>`. Capture starts at a non-space char (Sonar S5852-safe
- * alternative to a leading `(.+)`) and runs to end of line. Only ~15% of posts
- * carry this label; the rest leave `location` undefined (merge geocodes later).
+ * Venue labels, matched per-line (both anchored to the whole line so prose like
+ * "start at the park…" — no colon — can never match):
+ *  - inline form `Start: <venue>` / `Start Location: <venue>` / `📍 Start: <venue>`
+ *    (the venue is on the same line; ~15% of posts)
+ *  - heading-only form `📍 Start` / `Start` on its own line, with the venue on
+ *    the NEXT line (the 📍 Start pattern used by recent posts, e.g. N+335)
+ * Capture starts at a non-space char (Sonar S5852-safe). Posts with neither
+ * leave `location` undefined (merge geocodes the kennel/region centroid).
  */
-const LOCATION_RE = /(?:📍\s*)?Start(?:\s*Location)?\s*:\s*(\S.*)/i;
+const LOCATION_INLINE_RE = /^(?:📍\s*)?Start(?:\s*Location)?\s*:\s*(\S.*)/i;
+const LOCATION_HEADING_RE = /^(?:📍\s*)?Start(?:\s*Location)?\s*:?\s*$/i;
 
 const DEFAULT_BLOG_URL = "https://brasiliah3.blogspot.com/";
 
@@ -83,13 +90,24 @@ function parseRunDate(body: string, publishedIso: string): string | null {
   return inferDateString(day, month, publishedIso);
 }
 
-/** Extract a clean venue from a `Start:`-labelled line, or undefined. */
-function parseLocation(body: string): string | undefined {
-  const match = LOCATION_RE.exec(body);
-  if (!match) return undefined;
-  const venue = match[1].trim();
+/** Trim a candidate venue, rejecting empty/placeholder text. */
+function cleanVenue(text: string): string | undefined {
+  const venue = text.trim();
   if (!venue || isPlaceholder(venue)) return undefined;
   return venue;
+}
+
+/** Extract a clean venue from a `Start`-labelled line (inline or heading), or undefined. */
+function parseLocation(body: string): string | undefined {
+  const lines = body.split("\n").map((line) => line.trim()).filter(Boolean);
+  for (let i = 0; i < lines.length; i++) {
+    const inline = LOCATION_INLINE_RE.exec(lines[i]);
+    if (inline) return cleanVenue(inline[1]);
+    if (LOCATION_HEADING_RE.test(lines[i]) && i + 1 < lines.length) {
+      return cleanVenue(lines[i + 1]);
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -151,6 +169,9 @@ export class BrasiliaH3Adapter implements SourceAdapter {
     const baseUrl = source.url || DEFAULT_BLOG_URL;
     const days = options?.days ?? source.scrapeDays ?? 90;
 
+    // 25 posts amply covers scrapeDays=90: at a biweekly cadence that's ~6-7
+    // runs plus the occasional social post per window. The full archive loads
+    // via the one-shot backfill, not this fetch — bump if scrapeDays grows.
     const bloggerResult = await fetchBloggerPosts(baseUrl, 25);
 
     const events: RawEventData[] = [];

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -29,6 +29,7 @@ import { DublinHashAdapter } from "./html-scraper/dublin-hash";
 import { BurlingtonHashAdapter } from "./html-scraper/burlington-hash";
 import { RIH3Adapter } from "./html-scraper/rih3";
 import { BrassMonkeyAdapter } from "./html-scraper/brass-monkey";
+import { BrasiliaH3Adapter } from "./html-scraper/brasilia-h3";
 import { DFWHashAdapter } from "./html-scraper/dfw-hash";
 import { SOH4Adapter } from "./html-scraper/soh4";
 import { HalveMeinAdapter } from "./html-scraper/halvemein";
@@ -172,6 +173,7 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /burlingtonh3\.com/i,          name: "BurlingtonHashAdapter",   factory: () => new BurlingtonHashAdapter() },
   { pattern: /rih3\.com/i,                 name: "RIH3Adapter",             factory: () => new RIH3Adapter() },
   { pattern: /teambrassmonkey\.blogspot/i, name: "BrassMonkeyAdapter",      factory: () => new BrassMonkeyAdapter() },
+  { pattern: /brasiliah3\.blogspot/i,      name: "BrasiliaH3Adapter",       factory: () => new BrasiliaH3Adapter() },
   { pattern: /dfwhhh\.org/i,              name: "DFWHashAdapter",           factory: () => new DFWHashAdapter() },
   { pattern: /soh4\.com/i,               name: "SOH4Adapter",              factory: () => new SOH4Adapter() },
   { pattern: /hmhhh\.com/i,              name: "HalveMeinAdapter",         factory: () => new HalveMeinAdapter() },

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -3014,6 +3014,32 @@ export const REGION_SEED_DATA: RegionSeedRecord[] = [
     centroidLng: -57.576,
     aliases: ["Asuncion", "Asunción, Paraguay"],
   },
+  // ── South America — Brazil (first Brazilian country; country → metro, no
+  // state-province intermediate, mirroring Paraguay). Emerald palette keeps it
+  // visually distinct from Paraguay's purple within South America. ──
+  {
+    name: "Brazil",
+    country: "Brazil",
+    level: "COUNTRY",
+    timezone: "America/Sao_Paulo",
+    abbrev: "BR",
+    colorClasses: "bg-emerald-200 text-emerald-800",
+    pinColor: "#059669",
+    centroidLat: -14.235,
+    centroidLng: -51.925,
+    aliases: ["BR"],
+  },
+  {
+    name: "Brasília",
+    country: "Brazil",
+    timezone: "America/Sao_Paulo",
+    abbrev: "BSB",
+    colorClasses: "bg-emerald-100 text-emerald-700",
+    pinColor: "#10b981",
+    centroidLat: -15.793,
+    centroidLng: -47.882,
+    aliases: ["Brasilia", "Brasília, Brazil"],
+  },
   // ── North America — Mexico (first Mexican country; country → metro, no
   // state-province intermediate, mirroring Kenya/Indonesia/Paraguay). Fuchsia
   // palette keeps it distinct from South-America purple and the US/Canada hues. ──
@@ -3259,6 +3285,7 @@ const COUNTRY_INFERENCE_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   [/\b(kenya|nairobi|mombasa|kisumu)\b/, "Kenya"],
   [/\b(bali|indonesia|denpasar)\b/, "Indonesia"],
   [/\b(paraguay|asuncion|asunción|luque)\b/, "Paraguay"],
+  [/\b(brazil|brasil|bras[ií]lia)\b/, "Brazil"],
   // Mexico — guard "New Mexico" (US state, Albuquerque) to USA BEFORE the Mexico rule
   // fires (first-match-wins), since \bmexico\b would otherwise match "New Mexico".
   [/\bnew mexico\b/, "USA"],
@@ -3545,6 +3572,8 @@ const STATE_GROUP_MAP: Record<string, string> = {
   "Bali": "Indonesia",
   // Paraguay — country → metro (no state-province intermediate)
   "Asunción": "Paraguay",
+  // Brazil — country → metro (no state-province intermediate)
+  "Brasília": "Brazil",
   // Mexico — country → metro (no state-province intermediate)
   "Mexico City": "Mexico",
 };
@@ -3720,6 +3749,9 @@ const COUNTRY_GROUP_MAP: Record<string, string> = {
   // Paraguay — both the country-level region and its metro map to "Paraguay"
   "Paraguay": "Paraguay",
   "Asunción": "Paraguay",
+  // Brazil — both the country-level region and its metro map to "Brazil"
+  "Brazil": "Brazil",
+  "Brasília": "Brazil",
   // Mexico — both the country-level region and its metro map to "Mexico"
   "Mexico": "Mexico",
   "Mexico City": "Mexico",
@@ -3779,6 +3811,7 @@ const COUNTRY_CODE_TO_NAME: Record<string, string> = {
   KE: "Kenya",
   ID: "Indonesia",
   PY: "Paraguay",
+  BR: "Brazil",
   MX: "Mexico",
 };
 

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -3027,7 +3027,7 @@ export const REGION_SEED_DATA: RegionSeedRecord[] = [
     pinColor: "#059669",
     centroidLat: -14.235,
     centroidLng: -51.925,
-    aliases: ["BR"],
+    aliases: ["BR", "Brasil"],
   },
   {
     name: "Brasília",


### PR DESCRIPTION
## Summary
Onboards **Brasília Hash House Harriers** (Brasília, Brazil — est. 1989), a biweekly Sunday run/walk and HashTracks' **first 🇧🇷 Brazil kennel**. The source is a structured Blogspot archive ([brasiliah3.blogspot.com](https://brasiliah3.blogspot.com)) whose **post titles are empty** — all run data lives in the post body — so this ships a new bespoke body-parsing adapter (not config-only, not title-based like Brass Monkey).

Implements the deep-dive handoff at `docs/kennel-onboarding/handoffs/2026-06-04-brasilia-h3.md`.

## What's included
- **New `BrasiliaH3Adapter`** (`src/adapters/html-scraper/brasilia-h3.ts`) — Blogger API v3 via `fetchBloggerPosts` (keyed by `GOOGLE_CALENDAR_API_KEY` to bypass cloud-IP 403s). Parses the `Hash N+NNN` run number and the year-less `Dth of Month` date line from the body.
  - **Year inference**: the date line carries no year, so the year is chosen from `{pubYear−1, pubYear, pubYear+1}` to land the date **closest to the post's publish date**. This is more robust than the handoff's naive "+1 year if before publish" rule, which mis-dated the many *recap posts published days-to-weeks after the run* (the photo-gallery case the handoff itself flagged). Each candidate is validated before minimising so an impossible date (e.g. 31 Feb) can't mask a valid sibling year.
  - Date + venue extraction is **anchored to the text after the run heading** so a prepended recap can't supply an earlier date/`Start:` line.
  - `title` left undefined (merge synthesizes `"Brasilia H3 Trail #NNN"`); **hares not extracted** (the blog never uses an inline `Hares:` label — only buried jokey prose — and 0/186 posts had one, so attempting it would risk field-bleed). **Fail-loud** if posts are fetched but zero parse as runs.
- **Region (first Brazil kennel)** — Brazil COUNTRY + Brasília METRO added to `REGION_SEED_DATA` plus the 4 dependent maps (`COUNTRY_INFERENCE_RULES`, `STATE_GROUP_MAP`, `COUNTRY_GROUP_MAP`, `COUNTRY_CODE_TO_NAME`), mirroring the Paraguay precedent. Emerald palette, `America/Sao_Paulo`.
- **Seed** — kennel `brasilia-h3`, aliases (`"BH3"` omitted — globally taken), and source **"Brasilia H3 Blogspot Trail Posts"** with `config.upcomingOnly: true` so `reconcile.ts` won't false-cancel the aged archive.
- **Historical backfill** — frozen 174-row archive (run #154 2019-04 → #338 2026-05) in `scripts/data/brasilia-h3-history.json` + a dumb loader (`scripts/backfill-brasilia-h3-history.ts`) using the shared `runBackfillScript`, bound to the live source row.

## Live verification ✅
Ran `BrasiliaH3Adapter.fetch()` against the live blog (keyed Blogger API, blogId `7471248430657737048`):
- **Upcoming N+340 "Praça dos Orixás Hash" / Sun 7 Jun 2026 present** ✅
- 8 in-window events, date range 2026-02-15 → 2026-06-07, all UTC-noon string dates
- All `kennelTags = ["brasilia-h3"]`, 0 unexpected, no errors
- `inferCountry("Brasília, Brazil")` and `inferCountry("Brasilia H3")` both → **Brazil**
- N+339 genuinely absent from the blog → **not synthesized** (faithful)

## Known source-data quirk (documented, not a parser bug)
Six date pairs collide because the kennel **copy-pasted the previous run's date line** into the next post (e.g. runs 194/195 both stamped "15th of November" 2020). The parser extracts faithfully; the merge pipeline collapses same-`(kennel, date)` RawEvents into one canonical Event. Not fabricated/corrected — a human can amend later.

## Checks
`npx tsc --noEmit` ✅ · `npm run lint` (0 errors) ✅ · `npm test` — **8471 passed** (13 new adapter tests covering run#/date/year-rollover/recap/empty-title-skip/impossible-date/location) ✅

Reviewed via high-effort `/code-review` (correctness + integration + cleanup angles); the three actionable findings (unanchored date/venue extraction, leap-day guard, dead `À-ÿ` class) are addressed in this PR.

## Post-merge runbook
1. `git checkout main && git pull`; verify `brasilia-h3.ts`, `backfill-brasilia-h3-history.ts`, `brasilia-h3-history.json` landed (squash-merge can drop a follow-up commit).
2. `npx prisma db seed` (additive — seeds kennel/alias/source + Brazil/Brasília regions).
3. Run `BACKFILL_APPLY=1 npx tsx scripts/backfill-brasilia-h3-history.ts`, then trigger a scrape from `/admin/sources`.
4. Spot-check `https://www.hashtracks.xyz/kennels/brasilia-h3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)