### PR TITLE
Show kennel logos on /kennels directory cards (#111)

### DIFF
--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -275,9 +275,11 @@ export default async function KennelDetailPage({
   // Region color for theming
   const regionColor = kennel.region ? getRegionColor(kennel.region) : "#6b7280";
 
-  // Initials for logo fallback
+  // Initials for logo fallback. Unicode-aware (\p{L}\p{N} + u flag) so accented
+  // / non-Latin kennel names (München, Montréal) keep correct initials instead
+  // of being stripped to ASCII. Mirrored in KennelCard's directory-card avatar.
   const initials = kennel.shortName
-    .replace(/[^A-Z0-9]/gi, "")
+    .replace(/[^\p{L}\p{N}]/gu, "")
     .slice(0, 3)
     .toUpperCase();
 

--- a/src/app/kennels/page.tsx
+++ b/src/app/kennels/page.tsx
@@ -50,6 +50,7 @@ export default async function KennelsPage() {
         country: true,
         latitude: true,
         longitude: true,
+        logoUrl: true,
         description: true,
         foundedYear: true,
         scheduleDayOfWeek: true,

--- a/src/app/kennels/region/[slug]/page.tsx
+++ b/src/app/kennels/region/[slug]/page.tsx
@@ -107,6 +107,7 @@ export default async function RegionPage({
         country: true,
         latitude: true,
         longitude: true,
+        logoUrl: true,
         description: true,
         foundedYear: true,
         scheduleDayOfWeek: true,

--- a/src/components/kennels/KennelCard.tsx
+++ b/src/components/kennels/KennelCard.tsx
@@ -13,6 +13,7 @@ export interface KennelCardData {
   country: string;
   latitude?: number | null;
   longitude?: number | null;
+  logoUrl?: string | null;
   description: string | null;
   foundedYear: number | null;
   scheduleDayOfWeek: string | null;
@@ -40,15 +41,35 @@ export function KennelCard({ kennel }: KennelCardProps) {
   return (
     <Link href={`/kennels/${kennel.slug}`}>
       <div className={`rounded-lg border bg-card p-4 transition-colors hover:border-primary/50 hover:shadow-sm h-full flex flex-col${!kennel.nextEvent ? " opacity-60" : ""}`}>
-        {/* Header: shortName + region badge */}
+        {/* Header: logo + shortName + region badge. Logo avatar mirrors the
+            profile-page hero (src/app/kennels/[slug]/page.tsx) at card scale;
+            initials are the null-logo fallback. */}
         <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
-            <h3 className="text-base font-bold leading-tight truncate" title={kennel.fullName}>
-              {kennel.shortName}
-            </h3>
-            <p className="text-sm text-muted-foreground truncate">
-              {kennel.fullName}
-            </p>
+          <div className="flex items-start gap-2.5 min-w-0">
+            {kennel.logoUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={kennel.logoUrl}
+                alt={`${kennel.shortName} logo`}
+                loading="lazy"
+                className="h-10 w-10 shrink-0 rounded-lg object-contain bg-white dark:bg-background ring-1 ring-border"
+              />
+            ) : (
+              <div
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-xs font-bold text-muted-foreground"
+                aria-hidden="true"
+              >
+                {kennel.shortName.replace(/[^A-Z0-9]/gi, "").slice(0, 3).toUpperCase()}
+              </div>
+            )}
+            <div className="min-w-0">
+              <h3 className="text-base font-bold leading-tight truncate" title={kennel.fullName}>
+                {kennel.shortName}
+              </h3>
+              <p className="text-sm text-muted-foreground truncate">
+                {kennel.fullName}
+              </p>
+            </div>
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
             <ActivityStatusBadge lastEventDate={kennel.lastEventDate} hasUpcomingEvent={!!kennel.nextEvent} />

--- a/src/components/kennels/KennelCard.tsx
+++ b/src/components/kennels/KennelCard.tsx
@@ -59,7 +59,7 @@ export function KennelCard({ kennel }: KennelCardProps) {
                 className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-xs font-bold text-muted-foreground"
                 aria-hidden="true"
               >
-                {kennel.shortName.replace(/[^A-Z0-9]/gi, "").slice(0, 3).toUpperCase()}
+                {kennel.shortName.replace(/[^\p{L}\p{N}]/gu, "").slice(0, 3).toUpperCase()}
               </div>
             )}
             <div className="min-w-0">


### PR DESCRIPTION
## What

Renders `Kennel.logoUrl` on the `/kennels` directory cards — a real user feature request (#111): *"Can there be a kennel logo next to the name of each hash? Like a visual image for each one?"*

The field already exists and is populated for ~33% of kennels (142/424), and the kennel **profile page** already renders it — this brings the same treatment to the directory list cards.

## How

- **`KennelCard.tsx`** — 40px rounded-square logo avatar at the left of the name row, mirroring the profile-page hero at card scale: `object-contain` (so varied crest/wordmark/mascot aspect ratios never clip), `loading="lazy"`, `alt` = kennel name. Adds `logoUrl?: string | null` to `KennelCardData`.
- **Null-logo fallback** — a muted-gray initials box, so every card keeps an aligned avatar and the grid stays even. Never a broken image for the (majority) logo-less kennels.
- **`kennels/page.tsx` + `kennels/region/[slug]/page.tsx`** — add `logoUrl: true` to the directory Prisma selects. `serializeKennelWithNext` spreads it onto `KennelCardData` automatically; no change needed in `kennel-directory.ts`.

UI-only; no schema/backend/adapter changes.

## Design decision

The null-logo fallback (muted-initials box vs. no avatar) was chosen from a live side-by-side render with real data and real logos. Muted-initials won because it keeps name blocks aligned across the grid — with ~67% of kennels logo-less, the no-avatar variant produced a ragged left edge.

## Verification

- `npx tsc --noEmit` ✅ &nbsp; `npm run lint` ✅ (0 errors) &nbsp; `npm test` ✅ (8381 passing)
- `/simplify` + correctness review (line-by-line + cross-file tracer) — clean; mirrors the established profile-page convention (lazy-load, alt text, `aria-hidden` fallback), optional field flows through with no consumer breakage.
- Rendered the exact card markup with real local logos + real logo-less kennels and visually confirmed both the logo and muted-fallback states. (Note: the headless preview browser can't complete Clerk's external dev-browser handshake, so the real authed `/kennels` route was verified via a faithful static render of the card markup rather than the live page.)

Closes #111