### PR TITLE
fix(merge): field-level enrich fill for cost + endTime (#1950)

### DIFF
--- a/src/pipeline/fingerprint.test.ts
+++ b/src/pipeline/fingerprint.test.ts
@@ -75,6 +75,30 @@ describe("generateFingerprint", () => {
     expect(generateFingerprint(baseline)).toBe(generateFingerprint(withExplicitUndefined));
   });
 
+  // #1950 stability guard — the lower-trust enrich branch now fills cost +
+  // endTime onto the canonical. Both fields already participate in the
+  // fingerprint (cost/endTime are WS6 tokens), so a RawEvent that newly carries
+  // them re-fingerprints and the canonical UPDATE persists the enriched value.
+  // These assert that wiring stays intact: distinct values fork the fingerprint,
+  // and a baseline event with neither field is unaffected (no re-merge churn).
+  it.each([
+    ["cost", { cost: "$10" } as const],
+    ["endTime", { endTime: "21:30" } as const],
+  ])("different %s values produce different fingerprints (#1950)", (_field, override) => {
+    const a = generateFingerprint(buildRawEvent());
+    const b = generateFingerprint(buildRawEvent(override));
+    expect(a).not.toBe(b);
+  });
+
+  it.each([
+    ["cost", { cost: undefined } as const],
+    ["endTime", { endTime: undefined } as const],
+  ])("%s=undefined leaves the baseline fingerprint unchanged (#1950)", (_field, override) => {
+    expect(generateFingerprint(buildRawEvent())).toBe(
+      generateFingerprint(buildRawEvent(override)),
+    );
+  });
+
   // #1624 — eventLabel must participate in the fingerprint so a label edit
   // (e.g. "Birthday" → "Pink Moon") re-fingerprints and the canonical UPDATE
   // fires; otherwise the dedup map silently swallows the new label.

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -635,6 +635,135 @@ describe("processRawEvents", () => {
     expect(data).not.toHaveProperty("locationAddress");
   });
 
+  // #1950 — endTime + cost were the last two enrichable fields the lower-trust
+  // enrich branch omitted (the higher-trust full-update branch always wrote
+  // them). A lower-trust co-covering source must fill them when the higher-trust
+  // owner left them NULL — EWH3 #1521: Hash Rego (trust 8) carried cost "$10"
+  // but the trust-9 WordPress source owned the canonical with cost=null, so the
+  // $10 never surfaced. Fill-only: a non-NULL canonical value is never clobbered.
+  it.each([
+    ["cost", { cost: "$10" } as const, "$10"],
+    ["endTime", { endTime: "21:30" } as const, "21:30"],
+  ])("lower-trust enrichment fills a NULL canonical %s (#1950)", async (field, override, expected) => {
+    mockSourceFind.mockResolvedValueOnce(sourceRow({
+      trustLevel: 5,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    // Higher-trust owner (trust 8) left cost + endTime NULL; source is trust 5.
+    mockEventFindMany.mockResolvedValueOnce([{
+      id: "evt_fill",
+      trustLevel: 8,
+      cost: null,
+      endTime: null,
+    }] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_fill"));
+
+    await processRawEvents("src_low", [buildRawEvent(override)]);
+
+    const update = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_fill",
+    );
+    expect(update).toBeDefined();
+    const data = (update![0] as { data: Record<string, unknown> }).data;
+    expect(data).toHaveProperty(field, expected);
+  });
+
+  it.each([
+    ["cost", { cost: "$10" } as const],
+    ["endTime", { endTime: "21:30" } as const],
+  ])("lower-trust enrichment does NOT override a non-NULL canonical %s (#1950)", async (field, override) => {
+    mockSourceFind.mockResolvedValueOnce(sourceRow({
+      trustLevel: 5,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    // Higher-trust owner (trust 8) already set cost + endTime; a NULL description
+    // guarantees the enrich update still fires so we can inspect its payload.
+    mockEventFindMany.mockResolvedValueOnce([{
+      id: "evt_keep",
+      trustLevel: 8,
+      cost: "$5",
+      endTime: "20:00",
+      description: null,
+    }] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_keep"));
+
+    await processRawEvents("src_low", [buildRawEvent(override)]);
+
+    const update = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_keep",
+    );
+    expect(update).toBeDefined();
+    const data = (update![0] as { data: Record<string, unknown> }).data;
+    // The fillable NULL field (description) enriches, proving the update fired...
+    expect(data).toHaveProperty("description");
+    // ...but the non-NULL higher-trust value is left untouched.
+    expect(data).not.toHaveProperty(field);
+  });
+
+  it("lower-trust enrichment does NOT clobber an earlier same-batch fill (#1950 shared-cache patch)", async () => {
+    // Two lower-trust raws in ONE batch both match the same canonical (shared
+    // runNumber + startTime → the matcher re-matches the second onto the first).
+    // The first fills cost+endTime onto the NULL canonical; the second carries
+    // DIFFERENT values. Without patching the shared per-batch cache after the
+    // enrich UPDATE, the second raw reads the stale pre-fill row and clobbers
+    // the value — patchSharedEventCaches keeps the fill-only invariant honest.
+    mockSourceFind.mockResolvedValue(sourceRow({
+      trustLevel: 5,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockFingerprint.mockReturnValueOnce("fp_a").mockReturnValueOnce("fp_b");
+    mockRawEventFind.mockResolvedValue(null);
+    // Higher-trust owner (trust 8) left cost + endTime NULL.
+    mockEventFindMany.mockResolvedValueOnce([{
+      id: "evt_batch",
+      trustLevel: 8,
+      cost: null,
+      endTime: null,
+      startTime: "14:00",
+      runNumber: 2100,
+      sourceUrl: "https://example.com/#past",
+      title: "Trail",
+      description: null,
+      parentEventId: null,
+      isSeriesParent: false,
+    }] as never);
+    // Echo each enrich UPDATE back as the merged row so the shared-cache patch
+    // carries the filled value into the second raw's match.
+    mockEventUpdate.mockImplementation(((args: unknown) => {
+      const { where, data } = args as { where: { id: string }; data: Record<string, unknown> };
+      return eventRow(where.id, {
+        trustLevel: 8,
+        startTime: "14:00",
+        runNumber: 2100,
+        sourceUrl: "https://example.com/#past",
+        title: "Trail",
+        parentEventId: null,
+        isSeriesParent: false,
+        cost: null,
+        endTime: null,
+        description: null,
+        ...data,
+      });
+    }) as never);
+
+    await processRawEvents("src_low", [
+      buildRawEvent({ date: "2026-03-08", runNumber: 2100, startTime: "14:00", cost: "$10", endTime: "21:30", sourceUrl: "https://example.com/#past" }),
+      buildRawEvent({ date: "2026-03-08", runNumber: 2100, startTime: "14:00", cost: "$20", endTime: "22:30", sourceUrl: "https://example.com/#future" }),
+    ]);
+
+    const costWrites = mockEventUpdate.mock.calls.map(
+      (c: unknown[]) => (c[0] as { data: { cost?: unknown } }).data.cost,
+    );
+    // The first raw fills $10; the second's $20 must never reach the DB.
+    expect(costWrites).toContain("$10");
+    expect(costWrites).not.toContain("$20");
+  });
+
   it("does NOT backfill coords/map URL when the lower-trust venue differs from the existing name (#1919)", async () => {
     // Venue-compatibility gate: a fuzzy/stale lower-trust match carrying a
     // DIFFERENT venue must not pin its coords under the higher-trust venue name

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -663,6 +663,29 @@ function invalidateKennelEventCache(kennelId: string, ctx: MergeContext): void {
   ctx.eventBatch.fuzzyPoolByKennel.delete(kennelId);
 }
 
+/** Patch an already-cached canonical row in the shared per-batch pools after an
+ *  in-place UPDATE whose `date` is unchanged. A later event in the same batch
+ *  matching this canonical must read post-update values, not stale ones —
+ *  otherwise a same-batch re-match re-evaluates its fill-gates against the
+ *  pre-update row (the higher-trust matcher's "stale match → spurious create"
+ *  regression; for the lower-trust enrich branch, clobbering an earlier fill —
+ *  #1950 Codex review). No-op when the row isn't in the cache (e.g. a freshly
+ *  date-corrected row already invalidated). */
+function patchSharedEventCaches(kennelId: string, updated: EventRow, ctx: MergeContext): void {
+  const sharedPool = ctx.eventBatch.sameDayByKennel.get(kennelId);
+  if (sharedPool) {
+    const si = sharedPool.findIndex(e => e.id === updated.id);
+    if (si !== -1) sharedPool[si] = updated;
+  }
+  if (updated.parentEventId == null && !updated.isSeriesParent) {
+    const fuzzyPool = ctx.eventBatch.fuzzyPoolByKennel.get(kennelId);
+    if (fuzzyPool) {
+      const fi = fuzzyPool.findIndex(e => e.id === updated.id);
+      if (fi !== -1) fuzzyPool[fi] = updated;
+    }
+  }
+}
+
 /**
  * Refresh dateUtc/timezone on a canonical Event for a processed duplicate.
  * Only updates if the source has sufficient trust and values differ.
@@ -1643,18 +1666,7 @@ async function upsertCanonicalEvent(
         // this canonical row sees post-update values, not stale ones —
         // skipping this leaks the same "stale match → spurious create"
         // regression a fresh DB findMany would have avoided pre-#1287.
-        const sharedPool = ctx.eventBatch.sameDayByKennel.get(kennelId);
-        if (sharedPool) {
-          const si = sharedPool.findIndex(e => e.id === updated.id);
-          if (si !== -1) sharedPool[si] = updated;
-        }
-        if (updated.parentEventId == null && !updated.isSeriesParent) {
-          const fuzzyPool = ctx.eventBatch.fuzzyPoolByKennel.get(kennelId);
-          if (fuzzyPool) {
-            const fi = fuzzyPool.findIndex(e => e.id === updated.id);
-            if (fi !== -1) fuzzyPool[fi] = updated;
-          }
-        }
+        patchSharedEventCaches(kennelId, updated, ctx);
       }
     }
 
@@ -1769,6 +1781,23 @@ async function upsertCanonicalEvent(
           enrichData.timezone = timezone;
         }
       }
+      // #1950 — endTime + cost enrich like every other nullable display field.
+      // The lower-trust enrich branch had silently omitted these two (they are
+      // the only enrichable fields the higher-trust full-update branch writes
+      // — endTime ~L1562, cost ~L1565 — that weren't mirrored here), so a
+      // lower-trust enrichment source's cost/end-time was dropped whenever a
+      // higher-trust source co-covered the date without those fields (EWH3
+      // #1521: Hash Rego $10 never surfaced because trust-9 WordPress owned the
+      // canonical with no cost). Fill-only — a lower-trust source never clears;
+      // the tri-state clear stays owned by the higher-trust branch. endTime is
+      // a plain display string with no dateUtc coupling (only startTime anchors
+      // dateUtc), so no recompose is needed.
+      if (!existingEvent.endTime && event.endTime) {
+        enrichData.endTime = event.endTime;
+      }
+      if (!existingEvent.cost && event.cost) {
+        enrichData.cost = event.cost;
+      }
       // #890 — fill the trail-length bundle when the canonical event has
       // it unset, so a higher-trust primary that lacks these fields
       // doesn't drop a lower-trust source's parsed values on the floor.
@@ -1814,6 +1843,13 @@ async function upsertCanonicalEvent(
         });
         const idx = sameDayEvents.findIndex(e => e.id === existingEvent.id);
         if (idx !== -1) sameDayEvents[idx] = enriched;
+        // Mirror the fresh row into the shared per-batch caches (date unchanged
+        // in the enrich branch — it never sets crossWindowMatch). Without this a
+        // later same-batch row that re-matches this canonical would read the
+        // stale pre-enrich row and re-fire the fill-gates, clobbering the value
+        // just filled (#1950 Codex review — same patch the higher-trust branch
+        // applies above via patchSharedEventCaches).
+        patchSharedEventCaches(kennelId, enriched, ctx);
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes the field-level trust-gating gap in `src/pipeline/merge.ts` reported in #1950.

The lower-trust **enrichment branch** in `upsertCanonicalEvent` already fills NULL canonical fields from a lower-trust co-covering source (description, hares, location, coords, startTime, trail-length, difficulty, …). It had silently omitted exactly **two** fields — `cost` and `endTime` — the only enrichable fields the higher-trust full-update branch writes that weren't mirrored here. So a lower-trust source's cost/end-time was dropped whenever a higher-trust source owned the canonical without those fields.

### Live evidence (prod, verified)
Canonical `cmlrh0fr3003u04jxkeqk0ewb` (EWH3 #1521, 2026-06-04): `cost=NULL`, trustLevel 9 (WordPress owns it, no cost). Linked Hash Rego raw (trust 8) carries `cost=$10` — never wrote because `cost` wasn't in the enrich branch. After this fix the next EWH3 merge fills `$10`.

## Changes
- **Enrich-branch fills** for `cost` + `endTime` — fill-only (`!existingEvent.X && event.X`), mirroring the ~13 sibling fills. The tri-state explicit-clear (`null`) stays owned by the higher-trust branch; `endTime` has no `dateUtc` coupling so no recompose.
- **`patchSharedEventCaches` helper** extracted from the higher-trust update branch and now called from the enrich branch too. The enrich UPDATE previously patched only the local `sameDayEvents` copy, not the shared per-batch pools — so a second same-batch row re-matching the canonical could clobber an earlier fill. (Caught by `/codex:adversarial-review`.)

## Tests
- `it.each` fill / no-override for `cost` + `endTime` (enrich branch).
- Same-batch **no-clobber** regression — verified to fail without the shared-cache patch.
- Fingerprint-participation guards for `cost`/`endTime`.
- Explicit-clear tri-state already covered by the existing #530 suite (untouched higher-trust branch).
- `npm run lint && npx tsc --noEmit && npm test` → green (8482 passing).

Post-deploy live-verify: re-scrape EWH3, re-query `cmlrh0fr3003u04jxkeqk0ewb` → expect `cost=$10`.

> Note: the sibling duplicate-event issues (#1976/#1984/#1962/#1967) are being resolved separately as not-reproducible — every "seed event ID" in those reports is actually that kennel's own `Kennel.id`, and prod has zero duplicates for those kennels.

Closes #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)