### PR TITLE
fix(audit): unfreeze /admin/audit dashboard — self-diagnosing sync staleness + recovery (#1958)

### DIFF
--- a/src/app/admin/audit/AuditSyncStatus.tsx
+++ b/src/app/admin/audit/AuditSyncStatus.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { AlertTriangle, CheckCircle2, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { formatRelativeTime } from "@/lib/format";
+import {
+  resyncAuditIssues,
+  type AuditSyncFreshness,
+  type ResyncAuditIssuesResult,
+} from "@/app/admin/audit/actions";
+
+/**
+ * Surfaces the freshness of the AuditIssue mirror that feeds every
+ * dashboard widget, and offers a one-click re-sync. The mirror is
+ * repopulated by a daily cron; when that cron fails (e.g. an expired
+ * GITHUB_TOKEN — #1958) the whole dashboard silently freezes. This
+ * banner converts that silent freeze into a loud, self-diagnosing
+ * signal and gives operators an immediate catch-up path.
+ */
+export function AuditSyncStatus({
+  freshness,
+}: {
+  /** Result of `getAuditSyncFreshness`; null when the probe itself failed. */
+  freshness: AuditSyncFreshness | null;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<ResyncAuditIssuesResult | null>(null);
+
+  function handleResync() {
+    setResult(null);
+    startTransition(async () => {
+      const res = await resyncAuditIssues();
+      setResult(res);
+      if (res.ok) router.refresh();
+    });
+  }
+
+  // The probe failing, an empty mirror, or an over-threshold age all
+  // warrant the loud treatment — the only "all clear" state is a recent
+  // successful sync.
+  const stale = freshness === null || freshness.stale;
+
+  const resyncControls = (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        variant={stale ? "default" : "outline"}
+        size="sm"
+        onClick={handleResync}
+        disabled={pending}
+        className="shrink-0"
+      >
+        <RefreshCw className={pending ? "animate-spin" : undefined} />
+        {pending ? "Syncing…" : "Re-sync now"}
+      </Button>
+      <ResyncFeedback result={result} />
+    </div>
+  );
+
+  if (!stale && freshness?.lastSyncAt) {
+    // Healthy: subtle one-liner with a quiet re-sync affordance.
+    return (
+      <div className="mb-4 flex items-center justify-between gap-3 text-sm text-muted-foreground">
+        <span className="flex items-center gap-2">
+          <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+          Audit mirror synced {formatRelativeTime(freshness.lastSyncAt)}.
+        </span>
+        {resyncControls}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/[0.08] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+          <div className="space-y-1 text-sm">
+            <p className="font-medium text-amber-700 dark:text-amber-400">
+              {stalenessHeadline(freshness)}
+            </p>
+            <p className="text-muted-foreground">
+              Every widget below reads from the GitHub audit mirror, which a
+              daily cron refreshes. The sync has not succeeded recently — most
+              likely an expired <code className="font-mono">GITHUB_TOKEN</code>.
+              Rotate the token in Vercel, then re-sync.
+            </p>
+          </div>
+        </div>
+        {resyncControls}
+      </div>
+    </div>
+  );
+}
+
+/** Inline success/error feedback for the last re-sync attempt. */
+function ResyncFeedback({ result }: { result: ResyncAuditIssuesResult | null }) {
+  if (!result) return null;
+  if (result.ok) {
+    const r = result.result;
+    const summary = `Synced ${r.scanned} issues (${r.opened} opened, ${r.closed} closed)`;
+    // A non-throwing sync can still skip individual issues (per-issue
+    // errors collected in result.errors — the cron treats this as 207,
+    // not 200). Surface it as a warning so "Synced" never implies a
+    // clean run when some issues were dropped.
+    if (r.errors.length > 0) {
+      return (
+        <span className="max-w-xs text-right text-xs text-amber-600 dark:text-amber-400">
+          {summary} — {r.errors.length} skipped; see server logs.
+        </span>
+      );
+    }
+    return (
+      <span className="text-right text-xs text-emerald-600 dark:text-emerald-400">
+        {summary}.
+      </span>
+    );
+  }
+  return (
+    <span className="max-w-xs text-right text-xs text-destructive">
+      Re-sync failed: {result.error}
+    </span>
+  );
+}
+
+/** Headline that quantifies how stale the mirror is. */
+function stalenessHeadline(freshness: AuditSyncFreshness | null): string {
+  if (freshness === null) {
+    return "Audit sync status unavailable.";
+  }
+  if (freshness.lastSyncAt === null || freshness.ageHours === null) {
+    return "Audit mirror has never been synced.";
+  }
+  const days = Math.floor(freshness.ageHours / 24);
+  const age =
+    days >= 1
+      ? `${days} day${days === 1 ? "" : "s"}`
+      : `${Math.floor(freshness.ageHours)}h`;
+  return `Audit dashboard data is ${age} stale (last synced ${formatRelativeTime(freshness.lastSyncAt)}).`;
+}

--- a/src/app/admin/audit/AuditSyncStatus.tsx
+++ b/src/app/admin/audit/AuditSyncStatus.tsx
@@ -21,10 +21,10 @@ import {
  */
 export function AuditSyncStatus({
   freshness,
-}: {
+}: Readonly<{
   /** Result of `getAuditSyncFreshness`; null when the probe itself failed. */
   freshness: AuditSyncFreshness | null;
-}) {
+}>) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [result, setResult] = useState<ResyncAuditIssuesResult | null>(null);
@@ -96,7 +96,7 @@ export function AuditSyncStatus({
 }
 
 /** Inline success/error feedback for the last re-sync attempt. */
-function ResyncFeedback({ result }: { result: ResyncAuditIssuesResult | null }) {
+function ResyncFeedback({ result }: Readonly<{ result: ResyncAuditIssuesResult | null }>) {
   if (!result) return null;
   if (result.ok) {
     const r = result.result;
@@ -134,9 +134,11 @@ function stalenessHeadline(freshness: AuditSyncFreshness | null): string {
     return "Audit mirror has never been synced.";
   }
   const days = Math.floor(freshness.ageHours / 24);
-  const age =
-    days >= 1
-      ? `${days} day${days === 1 ? "" : "s"}`
-      : `${Math.floor(freshness.ageHours)}h`;
+  let age: string;
+  if (days >= 1) {
+    age = `${days} day${days === 1 ? "" : "s"}`;
+  } else {
+    age = `${Math.floor(freshness.ageHours)}h`;
+  }
   return `Audit dashboard data is ${age} stale (last synced ${formatRelativeTime(freshness.lastSyncAt)}).`;
 }

--- a/src/app/admin/audit/actions.test.ts
+++ b/src/app/admin/audit/actions.test.ts
@@ -58,7 +58,7 @@ vi.mock("@/generated/prisma/client", () => ({
 
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
-import { syncAuditIssues } from "@/pipeline/audit-issue-sync";
+import { syncAuditIssues, type SyncResult } from "@/pipeline/audit-issue-sync";
 import { revalidatePath } from "next/cache";
 import { buildPrismaUniqueViolation } from "@/test/factories";
 import {
@@ -91,6 +91,14 @@ const mockSupDeleteMany = vi.mocked(prisma.auditSuppression.deleteMany);
 const mockIssueAggregate = vi.mocked(prisma.auditIssue.aggregate);
 const mockSync = vi.mocked(syncAuditIssues);
 const mockRevalidate = vi.mocked(revalidatePath);
+
+// getAuditSyncFreshness only reads `_max.syncedAt`, but Prisma's aggregate
+// return type also carries _count/_avg/_sum/_min. Build the minimal shape
+// the action uses and widen it once here rather than asserting per call.
+type AuditIssueAggregate = Awaited<ReturnType<typeof prisma.auditIssue.aggregate>>;
+function aggregateWithSyncedAt(syncedAt: Date | null): AuditIssueAggregate {
+  return { _max: { syncedAt } } as unknown as AuditIssueAggregate;
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -749,7 +757,7 @@ describe("getAuditSyncFreshness", () => {
     { label: "long-dead sync", hoursAgo: 240, stale: true },
   ])("marks a $label as stale=$stale", async ({ hoursAgo, stale }) => {
     const lastSyncAt = new Date(Date.now() - hoursAgo * 3_600_000);
-    mockIssueAggregate.mockResolvedValue({ _max: { syncedAt: lastSyncAt } } as never);
+    mockIssueAggregate.mockResolvedValue(aggregateWithSyncedAt(lastSyncAt));
 
     const result = await getAuditSyncFreshness();
 
@@ -759,7 +767,7 @@ describe("getAuditSyncFreshness", () => {
   });
 
   it("treats an empty mirror as stale with a null age", async () => {
-    mockIssueAggregate.mockResolvedValue({ _max: { syncedAt: null } } as never);
+    mockIssueAggregate.mockResolvedValue(aggregateWithSyncedAt(null));
     const result = await getAuditSyncFreshness();
     expect(result).toEqual({ lastSyncAt: null, ageHours: null, stale: true });
   });
@@ -772,7 +780,7 @@ describe("resyncAuditIssues", () => {
   });
 
   it("returns ok and revalidates the dashboard on a successful sync", async () => {
-    const syncResult = {
+    const syncResult: SyncResult = {
       scanned: 5,
       opened: 2,
       closed: 1,
@@ -781,7 +789,7 @@ describe("resyncAuditIssues", () => {
       delisted: 0,
       errors: [],
     };
-    mockSync.mockResolvedValue(syncResult as never);
+    mockSync.mockResolvedValue(syncResult);
 
     const result = await resyncAuditIssues();
 
@@ -811,7 +819,7 @@ describe("resyncAuditIssues", () => {
   });
 
   it("flags a partial sync (per-issue errors) without claiming a clean run", async () => {
-    const syncResult = {
+    const syncResult: SyncResult = {
       scanned: 10,
       opened: 3,
       closed: 1,
@@ -820,7 +828,7 @@ describe("resyncAuditIssues", () => {
       delisted: 0,
       errors: ["#42: multi-stream label conflict"],
     };
-    mockSync.mockResolvedValue(syncResult as never);
+    mockSync.mockResolvedValue(syncResult);
 
     const result = await resyncAuditIssues();
 

--- a/src/app/admin/audit/actions.test.ts
+++ b/src/app/admin/audit/actions.test.ts
@@ -20,8 +20,15 @@ vi.mock("@/lib/db", () => ({
     },
     auditIssue: {
       groupBy: vi.fn(),
+      aggregate: vi.fn(),
     },
   },
+}));
+vi.mock("@/pipeline/audit-issue-sync", () => ({
+  syncAuditIssues: vi.fn(),
+}));
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
 }));
 vi.mock("@/generated/prisma/client", () => ({
   Prisma: {
@@ -51,6 +58,8 @@ vi.mock("@/generated/prisma/client", () => ({
 
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
+import { syncAuditIssues } from "@/pipeline/audit-issue-sync";
+import { revalidatePath } from "next/cache";
 import { buildPrismaUniqueViolation } from "@/test/factories";
 import {
   getAuditTrends,
@@ -65,6 +74,8 @@ import {
   getCloseReasonRatiosByStream,
   getDeepDiveQueueToken,
   recordDeepDive,
+  getAuditSyncFreshness,
+  resyncAuditIssues,
 } from "./actions";
 import {
   computeQueueSnapshotId,
@@ -77,6 +88,9 @@ const mockLogFind = vi.mocked(prisma.auditLog.findMany);
 const mockSupFind = vi.mocked(prisma.auditSuppression.findMany);
 const mockSupCreate = vi.mocked(prisma.auditSuppression.create);
 const mockSupDeleteMany = vi.mocked(prisma.auditSuppression.deleteMany);
+const mockIssueAggregate = vi.mocked(prisma.auditIssue.aggregate);
+const mockSync = vi.mocked(syncAuditIssues);
+const mockRevalidate = vi.mocked(revalidatePath);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -715,5 +729,105 @@ describe("getCloseReasonRatiosByStream", () => {
     mockGroupBy.mockResolvedValue([] as never);
     const ratios = await getCloseReasonRatiosByStream(30);
     for (const r of ratios) expect(r.windowDays).toBe(30);
+  });
+});
+
+describe("getAuditSyncFreshness", () => {
+  it("rejects unauthenticated callers", async () => {
+    mockAdmin.mockResolvedValue(null);
+    await expect(getAuditSyncFreshness()).rejects.toThrow("Unauthorized");
+  });
+
+  // Threshold is SYNC_STALENESS_WARN_HOURS = 30 (daily cron + margin).
+  // lastSyncAt is derived from real `Date.now()` so the action's own
+  // `Date.now()` read lands a few ms later — ageHours is asserted with
+  // tolerance rather than faking the clock.
+  it.each([
+    { label: "recent sync", hoursAgo: 2, stale: false },
+    { label: "just inside the threshold", hoursAgo: 29, stale: false },
+    { label: "just past the threshold", hoursAgo: 31, stale: true },
+    { label: "long-dead sync", hoursAgo: 240, stale: true },
+  ])("marks a $label as stale=$stale", async ({ hoursAgo, stale }) => {
+    const lastSyncAt = new Date(Date.now() - hoursAgo * 3_600_000);
+    mockIssueAggregate.mockResolvedValue({ _max: { syncedAt: lastSyncAt } } as never);
+
+    const result = await getAuditSyncFreshness();
+
+    expect(result.lastSyncAt).toEqual(lastSyncAt);
+    expect(result.stale).toBe(stale);
+    expect(result.ageHours).toBeCloseTo(hoursAgo, 1);
+  });
+
+  it("treats an empty mirror as stale with a null age", async () => {
+    mockIssueAggregate.mockResolvedValue({ _max: { syncedAt: null } } as never);
+    const result = await getAuditSyncFreshness();
+    expect(result).toEqual({ lastSyncAt: null, ageHours: null, stale: true });
+  });
+});
+
+describe("resyncAuditIssues", () => {
+  it("rejects unauthenticated callers", async () => {
+    mockAdmin.mockResolvedValue(null);
+    await expect(resyncAuditIssues()).rejects.toThrow("Unauthorized");
+  });
+
+  it("returns ok and revalidates the dashboard on a successful sync", async () => {
+    const syncResult = {
+      scanned: 5,
+      opened: 2,
+      closed: 1,
+      reopened: 0,
+      relabeled: 0,
+      delisted: 0,
+      errors: [],
+    };
+    mockSync.mockResolvedValue(syncResult as never);
+
+    const result = await resyncAuditIssues();
+
+    expect(result).toEqual({ ok: true, result: syncResult });
+    expect(mockRevalidate).toHaveBeenCalledWith("/admin/audit");
+  });
+
+  it("sanitizes a GitHub error (drops the response body) and skips revalidation when the sync throws", async () => {
+    // fetchAllAuditIssues embeds GitHub's raw response body in the message;
+    // it must not reach the browser verbatim.
+    mockSync.mockRejectedValue(
+      new Error(
+        'GitHub API 401 on page 1: {"message":"Bad credentials","documentation_url":"https://..."}',
+      ),
+    );
+
+    const result = await resyncAuditIssues();
+
+    expect(result).toEqual({ ok: false, error: "GitHub API 401 on page 1" });
+    expect(mockRevalidate).not.toHaveBeenCalled();
+  });
+
+  it("passes through a non-GitHub error message (capped)", async () => {
+    mockSync.mockRejectedValue(new Error("GITHUB_TOKEN not set"));
+    const result = await resyncAuditIssues();
+    expect(result).toEqual({ ok: false, error: "GITHUB_TOKEN not set" });
+  });
+
+  it("flags a partial sync (per-issue errors) without claiming a clean run", async () => {
+    const syncResult = {
+      scanned: 10,
+      opened: 3,
+      closed: 1,
+      reopened: 0,
+      relabeled: 0,
+      delisted: 0,
+      errors: ["#42: multi-stream label conflict"],
+    };
+    mockSync.mockResolvedValue(syncResult as never);
+
+    const result = await resyncAuditIssues();
+
+    // Still ok:true (the sync ran) but errors[] is preserved so the UI can
+    // render the amber "partial" state rather than green success.
+    expect(result).toEqual({ ok: true, result: syncResult });
+    expect(result.ok && result.result.errors).toHaveLength(1);
+    expect(mockRevalidate).toHaveBeenCalledWith("/admin/audit");
   });
 });

--- a/src/app/admin/audit/actions.ts
+++ b/src/app/admin/audit/actions.ts
@@ -1,11 +1,13 @@
 "use server";
 
 import * as Sentry from "@sentry/nextjs";
+import { revalidatePath } from "next/cache";
 import { AuditStream, AuditIssueEventType } from "@/generated/prisma/client";
 import { isUniqueConstraintViolation } from "@/lib/prisma-errors";
 import { prisma } from "@/lib/db";
 import { getAdminUser } from "@/lib/auth";
 import { KNOWN_AUDIT_RULES, type AuditFinding } from "@/pipeline/audit-checks";
+import { syncAuditIssues, type SyncResult } from "@/pipeline/audit-issue-sync";
 import { DASHBOARD_STREAMS } from "@/lib/audit-stream-meta";
 import type {
   HarelinePromptInputs,
@@ -925,4 +927,94 @@ export async function getHarelinePromptInputs(): Promise<HarelinePromptInputs> {
   }));
 
   return { recentlyFixed, focusAreas };
+}
+
+// ── Sync freshness + manual re-sync (issue #1958) ───────────────────
+//
+// Every dashboard widget reads live from the AuditIssue / AuditIssueEvent
+// mirror, which a daily cron (`/api/cron/sync-audit-issues`, 12:30 UTC)
+// repopulates from GitHub. When that cron fails — e.g. an expired
+// GITHUB_TOKEN makes `fetchAllAuditIssues` throw a 401 before any write
+// (#1958) — the mirror silently freezes and the whole dashboard serves
+// stale snapshots with no visible signal. These two actions make the
+// freeze loud (freshness probe → banner) and one-click recoverable
+// (manual re-sync) without waiting for the next cron.
+
+/** Warn once the last sync write is older than this. Keep in step with
+ *  the cron cadence in `vercel.json` (`/api/cron/sync-audit-issues`,
+ *  `30 12 * * *` = daily 12:30 UTC): 24h interval + 6h slack for cron
+ *  jitter + render time, so a healthy daily cron never false-alarms but
+ *  a single missed run trips the banner. */
+const SYNC_STALENESS_WARN_HOURS = 30;
+
+export interface AuditSyncFreshness {
+  /** Timestamp of the most recent mirror write (max `AuditIssue.syncedAt`),
+   *  or null when the mirror is empty. `syncedAt` is `@updatedAt`, so the
+   *  full-pull sync bumps it across every row on each run — but the
+   *  recurrence-escalation / file-finding paths also write individual
+   *  rows. In practice both paths depend on a live GITHUB_TOKEN, so the
+   *  #1958 token-expiry freeze (sync throws before any write) still
+   *  surfaces here; a dedicated "last full sync" marker is a tracked
+   *  follow-up if finer accuracy is ever needed. */
+  lastSyncAt: Date | null;
+  /** Hours since `lastSyncAt`, or null when the mirror is empty. */
+  ageHours: number | null;
+  /** True when the mirror is older than the warn threshold, or empty. */
+  stale: boolean;
+}
+
+export async function getAuditSyncFreshness(): Promise<AuditSyncFreshness> {
+  await requireAdmin();
+  const agg = await prisma.auditIssue.aggregate({ _max: { syncedAt: true } });
+  const lastSyncAt = agg._max.syncedAt ?? null;
+  if (!lastSyncAt) {
+    // Empty mirror — treat as stale so a never-run sync is surfaced, not
+    // mistaken for a quiet-but-healthy day.
+    return { lastSyncAt: null, ageHours: null, stale: true };
+  }
+  const ageHours = (Date.now() - lastSyncAt.getTime()) / 3_600_000;
+  return { lastSyncAt, ageHours, stale: ageHours > SYNC_STALENESS_WARN_HOURS };
+}
+
+/** Discriminated result for the manual re-sync trigger. The error string
+ *  is surfaced verbatim in the UI so a 401 (dead token) is diagnosable
+ *  without a log dive. */
+export type ResyncAuditIssuesResult =
+  | { ok: true; result: SyncResult }
+  | { ok: false; error: string };
+
+/**
+ * Reduce a sync error to a short, body-free message safe to render in
+ * the browser. `fetchAllAuditIssues` embeds GitHub's raw response body
+ * (`await res.text()`) in its error — echoing that verbatim to the
+ * client would leak response headers/HTML. Keep the diagnostic
+ * `GitHub API <status> on page <n>` prefix and drop the body; cap any
+ * other message as a backstop. Full detail goes to Sentry.
+ */
+function sanitizeResyncError(message: string): string {
+  const githubPrefix = message.match(/^GitHub API \d+ on page \d+/);
+  if (githubPrefix) return githubPrefix[0];
+  return message.length > 200 ? `${message.slice(0, 200)}…` : message;
+}
+
+/**
+ * Manually run the GitHub→mirror sync from the dashboard. The operator's
+ * catch-up path after a sync outage (e.g. a rotated GITHUB_TOKEN) —
+ * avoids waiting for the next 12:30 UTC cron. Also a live diagnostic:
+ * while the token is invalid, the returned error surfaces `GitHub API
+ * 401` directly in the UI so the operator knows exactly what to fix.
+ * `result.errors` is preserved on success so the UI can distinguish a
+ * clean sync from a partial one (mirrors the cron's 207 semantics).
+ */
+export async function resyncAuditIssues(): Promise<ResyncAuditIssuesResult> {
+  await requireAdmin();
+  try {
+    const result = await syncAuditIssues();
+    revalidatePath("/admin/audit");
+    return { ok: true, result };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: "resyncAuditIssues" } });
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: sanitizeResyncError(message) };
+  }
 }

--- a/src/app/admin/audit/actions.ts
+++ b/src/app/admin/audit/actions.ts
@@ -991,8 +991,9 @@ export type ResyncAuditIssuesResult =
  * `GitHub API <status> on page <n>` prefix and drop the body; cap any
  * other message as a backstop. Full detail goes to Sentry.
  */
+const GITHUB_API_ERROR_PREFIX_RE = /^GitHub API \d+ on page \d+/;
 function sanitizeResyncError(message: string): string {
-  const githubPrefix = message.match(/^GitHub API \d+ on page \d+/);
+  const githubPrefix = GITHUB_API_ERROR_PREFIX_RE.exec(message);
   if (githubPrefix) return githubPrefix[0];
   return message.length > 200 ? `${message.slice(0, 200)}…` : message;
 }

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -19,6 +19,12 @@ import { AuditSyncStatus } from "./AuditSyncStatus";
 import { buildHarelinePrompt } from "@/lib/admin/hareline-prompt";
 import { mintQueueTokens } from "@/lib/queue-snapshot-token";
 
+// The "Re-sync now" server action (resyncAuditIssues) runs the full sync
+// on this route — GitHub fetch + a transaction up to SYNC_TX_TIMEOUT_MS
+// (120s). Lift the function budget above that (matching the sync cron) so
+// a manual catch-up of a large backlog isn't 504'd before Prisma finishes.
+export const maxDuration = 300;
+
 /** Build the daily hareline audit prompt at request time so the curated
  *  sections (recently-fixed, focus areas) reflect live data. Returns null on
  *  failure so the dashboard hides the copy button rather than rendering empty. */

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -11,9 +11,11 @@ import {
   getCloseReasonRatiosByStream,
   getRecentOpenIssues,
   getHarelinePromptInputs,
+  getAuditSyncFreshness,
 } from "./actions";
 import { KNOWN_AUDIT_RULES } from "@/pipeline/audit-checks";
 import { AuditDashboard } from "@/components/admin/AuditDashboard";
+import { AuditSyncStatus } from "./AuditSyncStatus";
 import { buildHarelinePrompt } from "@/lib/admin/hareline-prompt";
 import { mintQueueTokens } from "@/lib/queue-snapshot-token";
 
@@ -46,6 +48,7 @@ export default async function AuditPage() {
     streamOpenCountsResult,
     streamCloseReasonRatiosResult,
     recentOpenIssuesResult,
+    syncFreshnessResult,
   ] = await Promise.all([
     getAuditTrends().catch(() => []),
     getTopOffenders().catch(() => []),
@@ -66,6 +69,10 @@ export default async function AuditPage() {
     // hide schema skew / Prisma errors during rollout.
     getCloseReasonRatiosByStream().catch(() => null),
     getRecentOpenIssues().catch(() => []),
+    // `null` (not a fabricated "fresh" value) on failure so the banner
+    // renders the loud "status unavailable" state rather than masking a
+    // broken probe behind a false all-clear.
+    getAuditSyncFreshness().catch(() => null),
   ]);
 
   // Pre-mint a queue token per candidate at page render so the dialog
@@ -79,21 +86,24 @@ export default async function AuditPage() {
   );
 
   return (
-    <AuditDashboard
-      trends={trendsResult}
-      topOffenders={offendersResult}
-      recentRuns={runsResult}
-      suppressions={suppressionsResult}
-      kennels={kennels}
-      knownRules={[...KNOWN_AUDIT_RULES]}
-      deepDiveQueue={deepDiveQueueResult}
-      deepDiveCoverage={deepDiveCoverageResult}
-      deepDiveTokens={deepDiveTokens}
-      harelinePrompt={harelinePrompt}
-      streamTrends={streamTrendsResult}
-      streamOpenCounts={streamOpenCountsResult}
-      streamCloseReasonRatios={streamCloseReasonRatiosResult}
-      recentOpenIssues={recentOpenIssuesResult}
-    />
+    <>
+      <AuditSyncStatus freshness={syncFreshnessResult} />
+      <AuditDashboard
+        trends={trendsResult}
+        topOffenders={offendersResult}
+        recentRuns={runsResult}
+        suppressions={suppressionsResult}
+        kennels={kennels}
+        knownRules={[...KNOWN_AUDIT_RULES]}
+        deepDiveQueue={deepDiveQueueResult}
+        deepDiveCoverage={deepDiveCoverageResult}
+        deepDiveTokens={deepDiveTokens}
+        harelinePrompt={harelinePrompt}
+        streamTrends={streamTrendsResult}
+        streamOpenCounts={streamOpenCountsResult}
+        streamCloseReasonRatios={streamCloseReasonRatiosResult}
+        recentOpenIssues={recentOpenIssuesResult}
+      />
+    </>
   );
 }

--- a/src/app/api/cron/sync-audit-issues/route.ts
+++ b/src/app/api/cron/sync-audit-issues/route.ts
@@ -3,6 +3,13 @@ import { verifyCronAuth } from "@/lib/cron-auth";
 import { syncAuditIssues } from "@/pipeline/audit-issue-sync";
 import { syncKennelLabels, summarizeLabelSync } from "@/pipeline/kennel-label-sync";
 
+// The audit sync upserts the full corpus in one transaction (up to
+// SYNC_TX_TIMEOUT_MS = 120s) plus the GitHub fetch — a catch-up run after
+// an outage drains a large backlog in a single pass. Give the function
+// the same 300s budget as the scrape cron so the platform doesn't 504
+// before Prisma finishes (matches src/app/api/cron/scrape/[sourceId]).
+export const maxDuration = 300;
+
 /**
  * Daily sync of GitHub `audit`-labeled issues into the AuditIssue mirror.
  * Runs two phases in order:

--- a/src/pipeline/audit-issue-sync.ts
+++ b/src/pipeline/audit-issue-sync.ts
@@ -37,6 +37,17 @@ const FETCH_TIMEOUT_MS = 15_000;
 const PAGE_SIZE = 100;
 const MAX_PAGES = 20; // safety cap; ~2000 issues
 
+// The sync upserts the *entire* audit corpus in one advisory-locked
+// transaction (the lock is xact-scoped, so the work can't be split). At
+// ~950+ issues that's well past Prisma's 5 s interactive-transaction
+// default — and a catch-up run after an outage (e.g. a rotated
+// GITHUB_TOKEN draining a multi-hundred-issue backlog) is heavier still.
+// Without generous headroom the *first* sync after any gap times out with
+// P2028 and the mirror stays frozen (#1958). Bounded by MAX_PAGES*PAGE_SIZE
+// (~2000 issues) and well under Vercel's 300 s function limit.
+const SYNC_TX_TIMEOUT_MS = 120_000;
+const SYNC_TX_MAX_WAIT_MS = 15_000;
+
 /** Shape of a GitHub issue from the REST API (only the fields we use). */
 export interface GitHubIssue {
   number: number;
@@ -538,7 +549,7 @@ export async function syncAuditIssues(): Promise<SyncResult> {
       });
       result.delisted = staleIds.length;
     }
-  });
+  }, { maxWait: SYNC_TX_MAX_WAIT_MS, timeout: SYNC_TX_TIMEOUT_MS });
 
   console.log(
     `[audit-sync] scanned=${result.scanned} opened=${result.opened} closed=${result.closed} reopened=${result.reopened} relabeled=${result.relabeled} delisted=${result.delisted} errors=${result.errors.length}`,


### PR DESCRIPTION
## Problem

`/admin/audit` froze at **~2026-05-24**: the "Findings by stream" cards, the **OPENED vs CLOSED — 30 DAYS** chart, and **RECENT OPEN ISSUES** lists were all stale even though Chrome Deep Dive findings file daily (e.g. #1980–#1985 on 2026-06-04). New findings were still created on GitHub; only the dashboard view was frozen.

## Root cause (confirmed against prod)

Every dashboard widget reads **live** (no caching) from the `AuditIssue` / `AuditIssueEvent` mirror, which is repopulated by a daily cron — `vercel.json` → `/api/cron/sync-audit-issues` (`30 12 * * *`) → `syncAuditIssues()`. That sync does a full GitHub pull via `fetchAllAuditIssues(GITHUB_TOKEN)` and **throws on any non-200 before the DB transaction** (`audit-issue-sync.ts`).

Verified:
- The server `GITHUB_TOKEN` (classic `ghp_` PAT) returns **HTTP 401** — expired.
- `MAX(AuditIssue.syncedAt)` was `2026-05-25` → ~10 days stale; `MAX(AuditIssueEvent.occurredAt)` `2026-05-24`.
- GitHub had **954** audit issues vs **749** mirrored (~205 unmirrored).
- No code regression around 05-23/24 — the sync is months old.

So the PAT expired ~05-24, every nightly sync has 401'd since, and the mirror froze — with **zero visible signal** on the dashboard (same silent-token failure mode as #1494; the cron's 500 only showed in Vercel logs).

A **second latent failure** surfaced while running the catch-up: the full-corpus upsert runs in one advisory-locked transaction that exceeds Prisma's **5 s** interactive-transaction default once the corpus/backlog is large (`P2028`). This means rotating the token alone would **not** fix prod — the first post-rotation cron must drain the backlog in one transaction and would time out, staying frozen.

## Fix (all in `src/app/admin/audit/*`, + one pipeline durability line)

1. **`getAuditSyncFreshness()`** — probes `MAX(AuditIssue.syncedAt)` (the `@updatedAt` the full-pull bumps every run). Returns `{ lastSyncAt, ageHours, stale }`.
2. **`AuditSyncStatus.tsx`** (new banner above the dashboard) — healthy: a quiet "synced N ago"; stale (> **30h** = daily cron + margin) or probe-failed: a loud amber banner naming the likely expired `GITHUB_TOKEN`, plus a **"Re-sync now"** button.
3. **`resyncAuditIssues()`** — runs the sync on demand (operator catch-up after token rotation, no waiting for cron). Also a live diagnostic: a dead token surfaces `GitHub API 401` right in the UI. Errors are **Sentry-captured and sanitized** (GitHub response bodies stripped) before display; **partial syncs** (`errors[]`) render an amber "partial" state instead of green success (mirrors the cron's 207 semantics).
4. **`audit-issue-sync.ts`** — raise the `$transaction` timeout to **120 s** (maxWait 15 s) so the full pull + post-outage backlog drains without `P2028`. Bounded by `MAX_PAGES*PAGE_SIZE` (~2000 issues) and well under Vercel's 300 s function limit. The xact-scoped advisory lock means the work can't be split, so a longer timeout is the right-depth fix.

## Immediate unfreeze (done)

Ran the catch-up sync once against prod with a valid token (the exact operation the new button performs): `scanned=954 opened=205 closed=230 errors=0`. The dashboard is now live — verified via the actions' exact SQL:
- RECENT OPEN ISSUES now tops out at **#1985** (was #1646/#1639).
- Open-by-stream: AUTOMATED 5 / CHROME_EVENT 11 / CHROME_KENNEL 55 / UNKNOWN 6 (was the stale 3/19/74).
- Chart shows real opens/closes through 06-04 (e.g. 24 CHROME_KENNEL opened on 06-04) — no longer flat-lined from 05-23.

## ⚠️ Required operational follow-up (cannot be a code PR)

**Rotate `GITHUB_TOKEN` in Vercel (and local `.env`).** The expired PAT is still in prod, so the nightly cron will 401 again and the mirror will re-freeze within ~30h — at which point the new banner lights up. After rotating, the dashboard's "Re-sync now" will drain any backlog (now within the raised transaction budget).

## Out of scope / tracked follow-ups
- `syncedAt` is `@updatedAt`, so a recurrence-escalation / file-finding write *could* bump it without a successful full sync. Empirically it tracked this 10-day freeze exactly (both paths depend on a live token), so a dedicated "last full sync" marker (needs a migration) is a follow-up, documented inline.
- Hardening `syncAuditIssues()` with explicit 401 detection / telemetry (cf. #1494) — pipeline follow-up.

## Verification
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (8484 passed)
- New tests: freshness fresh/threshold/stale/empty (`it.each`); resync success + revalidate, sanitized-401 (body stripped), non-GitHub passthrough, partial-sync amber path.
- `/simplify` + `/codex:adversarial-review` run pre-PR; findings applied (error sanitization, partial-failure surfacing, control-block dedup, doc accuracy).

Closes #1958

🤖 Generated with [Claude Code](https://claude.com/claude-code)