### PR TITLE
fix(onboarding): Paris/MCH3/NSWHHH audit cleanup (7 issues)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3738,9 +3738,17 @@ export const KENNELS: KennelSeed[] = [
       website: "https://www.nswhhh.info/",
       facebookUrl: "https://www.facebook.com/nswhash.flash",
       logoUrl: "/kennel-logos/nswhhh.png",
+      // gm + contactEmail per nswhhh.info homepage/about-us ("Call the Grand
+      // Master: Lost Jewels (Darren)"; about-us mailto). (#1972)
+      gm: "Lost Jewels",
+      contactEmail: "darrenkelly1@hotmail.com",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Monday 6:30pm hash around Sydney's North Shore & surrounds. ~4–5 km walk / 6 km run, ~1 hour; non-competitive, walkers & runners welcome. First run free, then $5. Run details posted on nswhhh.info each week.",
       foundedYear: 2004,
+      // hashCash is the correct single-"$" form. The #1972 audit flagged a
+      // double-"$$5" artifact, but a prod query (2026-06-04) showed prod already
+      // holds "$5 (first run free)" — the one-shot override carries a
+      // drift-guarded no-op rewrite as a safety net. (#1972)
       hashCash: "$5 (first run free)",
       walkersWelcome: true,
       description: "North Shore Wanderers H3 (NSWHHH) is a non-competitive Sydney hash kennel founded in 2004, running every Monday at 6:30pm across Sydney's North Shore and surrounds. Walkers and runners welcome; first run free, then $5.",
@@ -4534,6 +4542,10 @@ export const KENNELS: KennelSeed[] = [
       scheduleTime: "2:00 PM",
       scheduleFrequency: "Biweekly",
       foundedYear: 1981,
+      // Jointly-held Grand Master per the 2026 sanscluehash.fr Misman page
+      // ("Grand Masters - Paris H3: Bearded Clam and Gasbag"). Joint Master
+      // (The Anarchist) and Hare Raisers ("Open!") are separate/vacant roles. (#1974)
+      gm: "Bearded Clam and Gasbag",
       hashCash: "5 €",
       walkersWelcome: true,
       description:
@@ -4558,8 +4570,12 @@ export const KENNELS: KennelSeed[] = [
       // rather than seeding an unverified year as canonical user-facing metadata.
       hashCash: "5 €",
       walkersWelcome: true,
+      // #1974: the "~1993" inference is Sans Clue's OWN founding year (25th
+      // birthday Apr 2018), not Paris H3's. The prior wording "Paris H3 (est.
+      // ~1993)" cross-wired it onto Paris H3 — which is the 1981 original.
+      // Reattributed here so the two records no longer contradict.
       description:
-        "Sister hash to Paris H3 (est. ~1993), running alternating Sundays around central Paris. A-to-B trails set by a hare, beer stops along the way, most trails walker-friendly. 'Sans Clue' = without a clue.",
+        "Sister hash to Paris H3 (France's original 1981 kennel), itself running alternating Sundays around central Paris since around 1993. A-to-B trails set by a hare, beer stops along the way, most trails walker-friendly. 'Sans Clue' = without a clue.",
       // Shared club image (parish3-schhh Meetup group) — no distinct Sans Clue logo found on sanscluehash.fr.
       logoUrl: "/kennel-logos/sans-clue-h3.jpg",
       latitude: 48.8566,
@@ -4607,6 +4623,9 @@ export const KENNELS: KennelSeed[] = [
     // foundedYear 1983 is the kennel founding (Mexico News Daily + Half-Mind), NOT the
     // Meetup group's 2022 creation date. latitude/longitude is the CDMX centroid; per-run
     // start coords come from the Meetup venue.lat/lng on each event.
+    // #1970: the Meetup About blurb says "since 1980"; reviewed and NOT adopted —
+    // the dual-sourced 1983 (Mexico News Daily + Half-Mind) is better-attributed,
+    // and foundedYear + description already agree at 1983 (no internal conflict).
     {
       kennelCode: "mch3",
       shortName: "Mexico City H3",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4927,7 +4927,10 @@ export const SOURCES = [
         // holiday"). They'd otherwise ingest as phantom runs. A hare is never
         // literally "no run", so this is false-positive-safe (#1739).
         silentlySkipPatterns: [{ pattern: String.raw`\bno\s+run\b`, field: "hares" }],
-        // No defaultTitle — let merge.ts synthesize "North Shore Wanderers H3 Trail #N".
+        // The sheet carries only date + run # + hare (no title column), so
+        // synthesize a source-anchored "Run #<N> w/ <hare>" title from the data
+        // we already capture, instead of a bare "… Trail #N" (#1973).
+        runHareTitle: true,
       },
       kennelCodes: ["nswhhh"],
     },
@@ -6369,6 +6372,13 @@ export const SOURCES = [
     // kennelPatterns; the group's weekly non-hash "Thursday Night Drinking Club"
     // socials (18 of 30 upcoming) are dropped pipeline-side before RawEvent
     // creation via silentlySkipPatterns (no SOURCE_KENNEL_MISMATCH alert).
+    //
+    // Umbrella structure (#1977 — documented, intentionally unmapped): the
+    // sanscluehash.fr site also lists (a) Paris Full Moon H3 — currently in
+    // hibernation per the Misman page, so no source until it announces a return
+    // (no-sourceless-kennels rule); and (b) the Thursday Night Drinking Club
+    // (TNDC) socials, which are NOT hash runs — they're dropped by the
+    // silentlySkipPatterns below and await a future social-event schema column.
     {
       name: "Paris & Sans Clue H3 Meetup",
       url: "https://www.meetup.com/parish3-schhh/events/",
@@ -6380,6 +6390,11 @@ export const SOURCES = [
         groupUrlname: "parish3-schhh",
         kennelTag: "paris-h3", // required fallback; rarely hit once skip + patterns apply
         upcomingOnly: true, // Meetup ages past events off its window — protects reconcile
+        // Both kennels stylize "Run" as "R*n" in every title (self-censorship),
+        // e.g. "Paris H3 R*n 1136 | TBD" (#1975). runNumberPrefix rewrites the
+        // literal "R*n" → "#" so the shared extractHashRunNumber helper parses it.
+        extractRunNumber: true,
+        runNumberPrefix: "R*n",
         kennelPatterns: [
           ["^Paris H3", "paris-h3"],
           ["^Sans Clue H3", "sans-clue-h3"],

--- a/scripts/backfill-mch3-history.ts
+++ b/scripts/backfill-mch3-history.ts
@@ -37,7 +37,10 @@ const KENNEL_TIMEZONE = "America/Mexico_City";
 const GROUP_URL = "https://www.meetup.com/mexico-city-hash-house-harriers/";
 
 interface FrozenRun {
-  runNumber: number;
+  // Optional: deep-archive thematic posts occasionally omit a "#NNN" / "Run #N"
+  // token in their title (e.g. a special event). Those rows still backfill
+  // (date + title + location), just without a runNumber.
+  runNumber?: number | null;
   date: string;
   startTime: string | null;
   endTime: string | null;
@@ -50,7 +53,7 @@ function toRawEvent(run: FrozenRun): RawEventData {
   return {
     date: run.date,
     kennelTags: ["mch3"],
-    runNumber: run.runNumber,
+    runNumber: run.runNumber ?? undefined,
     title: run.title,
     startTime: run.startTime ?? undefined,
     endTime: run.endTime ?? undefined,

--- a/scripts/backfill-nswhhh-history.ts
+++ b/scripts/backfill-nswhhh-history.ts
@@ -21,6 +21,7 @@ import "dotenv/config";
 import { runBackfillScript } from "./lib/backfill-runner";
 import { safeFetch } from "@/adapters/safe-fetch";
 import { parseCSV, parseDate } from "@/adapters/google-sheets/adapter";
+import { buildRunHareTitle } from "@/adapters/utils";
 import { todayInTimezone } from "@/lib/timezone";
 import type { RawEventData } from "@/adapters/types";
 
@@ -66,10 +67,15 @@ async function fetchArchive(): Promise<RawEventData[]> {
 
     const hares = row[COL.hares]?.trim() || undefined;
     const location = row[COL.location]?.trim() || undefined;
+    const runNumber = Number.parseInt(runCell, 10);
     events.push({
       date,
       kennelTags: ["nswhhh"],
-      runNumber: Number.parseInt(runCell, 10),
+      runNumber,
+      // Match the live GOOGLE_SHEETS source + HTML adapter title shape (#1973)
+      // so re-running this backfill re-titles the historical canonicals to
+      // "Run #<N> w/ <hare>" instead of the synthesized "… Trail #N".
+      title: buildRunHareTitle(runNumber, hares),
       hares,
       location,
       startTime: "18:30",

--- a/scripts/data/mch3-history.json
+++ b/scripts/data/mch3-history.json
@@ -1,12 +1,758 @@
 [
-  {"runNumber":756,"date":"2026-05-23","startTime":"13:30","endTime":"18:30","title":"HASH #756- SPRING HASH !","location":"HECOP San Angel - Metrobus la bombilla, Cerca del Monumento a Obregon","address":"Insurgentes Sur 2047 B. Col. San Angel Esq. Cracovia"},
-  {"runNumber":755,"date":"2026-04-25","startTime":"11:30","endTime":"18:30","title":"HASH #755- Cholula HASH !","location":"La Huerta Golf & Hotel","address":"Privada Juan Blanca 2501-A, Barrio de Sta Maria Xixitla, 72762 San Pedro Cholula, Pue."},
-  {"runNumber":754,"date":"2026-03-21","startTime":"13:30","endTime":"16:30","title":"HASH #754 - SPICY HASH !","location":"Plaza Morelia","address":"Circular de Morelia, Roma Nte., Cuauhtémoc, 06700 CDMX"},
-  {"runNumber":753,"date":"2026-02-21","startTime":"13:30","endTime":"16:30","title":"HASH #753 !","location":"Parque La Mexicana","address":"Paseo de los Arquitectos SN, Lomas de Santa Fe, Contadero, CDMX"},
-  {"runNumber":752,"date":"2026-01-31","startTime":"13:30","endTime":"16:30","title":"HASH #752 - First Hash of 2026!","location":"HECOP San Angel - Metrobus la bombilla","address":"Insurgentes Sur 2047 B. Col. San Angel"},
-  {"runNumber":750,"date":"2025-11-15","startTime":"11:30","endTime":null,"title":"HASH #750!","location":"Parque Ejidal San Nicolás Totolapan","address":null},
-  {"runNumber":749,"date":"2025-10-25","startTime":"13:30","endTime":null,"title":"Run #749 – Octuber 25th","location":"Monumento a la Revolución","address":null},
-  {"runNumber":748,"date":"2025-09-27","startTime":"13:30","endTime":null,"title":"Hash House Harriers Mexico City - Run #748","location":"Barril 23","address":null},
-  {"runNumber":747,"date":"2025-08-30","startTime":"13:30","endTime":null,"title":"Hash House Harriers Mexico City - Run #747","location":"Parque México","address":null},
-  {"runNumber":746,"date":"2025-07-26","startTime":"13:30","endTime":null,"title":"Hash House Harriers Mexico City - Run #746","location":"Erotika Polanco","address":null}
+  {
+    "runNumber": 756,
+    "date": "2026-05-23",
+    "startTime": "13:30",
+    "endTime": "18:30",
+    "title": "HASH #756- SPRING HASH !",
+    "location": "HECOP San Angel - Metrobus la bombilla, Cerca del Monumento a Obregon",
+    "address": "Insurgentes Sur 2047 B. Col. San Angel Esq. Cracovia"
+  },
+  {
+    "runNumber": 755,
+    "date": "2026-04-25",
+    "startTime": "11:30",
+    "endTime": "18:30",
+    "title": "HASH #755- Cholula HASH !",
+    "location": "La Huerta Golf & Hotel",
+    "address": "Privada Juan Blanca 2501-A, Barrio de Sta Maria Xixitla, 72762 San Pedro Cholula, Pue."
+  },
+  {
+    "runNumber": 754,
+    "date": "2026-03-21",
+    "startTime": "13:30",
+    "endTime": "16:30",
+    "title": "HASH #754 - SPICY HASH !",
+    "location": "Plaza Morelia",
+    "address": "Circular de Morelia, Roma Nte., Cuauhtémoc, 06700 CDMX"
+  },
+  {
+    "runNumber": 753,
+    "date": "2026-02-21",
+    "startTime": "13:30",
+    "endTime": "16:30",
+    "title": "HASH #753 !",
+    "location": "Parque La Mexicana",
+    "address": "Paseo de los Arquitectos SN, Lomas de Santa Fe, Contadero, CDMX"
+  },
+  {
+    "runNumber": 752,
+    "date": "2026-01-31",
+    "startTime": "13:30",
+    "endTime": "16:30",
+    "title": "HASH #752 - First Hash of 2026!",
+    "location": "HECOP San Angel - Metrobus la bombilla",
+    "address": "Insurgentes Sur 2047 B. Col. San Angel"
+  },
+  {
+    "runNumber": 750,
+    "date": "2025-11-15",
+    "startTime": "11:30",
+    "endTime": null,
+    "title": "HASH #750!",
+    "location": "Parque Ejidal San Nicolás Totolapan",
+    "address": null
+  },
+  {
+    "runNumber": 749,
+    "date": "2025-10-25",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Run #749 – Octuber 25th",
+    "location": "Monumento a la Revolución",
+    "address": null
+  },
+  {
+    "runNumber": 748,
+    "date": "2025-09-27",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #748",
+    "location": "Barril 23",
+    "address": null
+  },
+  {
+    "runNumber": 747,
+    "date": "2025-08-30",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #747",
+    "location": "Parque México",
+    "address": null
+  },
+  {
+    "runNumber": 746,
+    "date": "2025-07-26",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #746",
+    "location": "Erotika Polanco",
+    "address": null
+  },
+  {
+    "runNumber": 745,
+    "date": "2025-06-28",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #745 Chayanne’s Piss Off Farewell Hash!",
+    "location": "Metro Refineria, Mexico, MX",
+    "address": null
+  },
+  {
+    "runNumber": 744,
+    "date": "2025-05-17",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #744",
+    "location": "London Karaoke, Londres 169 Juárez, Cuauhtémoc, 06600 Ciudad de México, D.F.esquina florencias, México City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 741,
+    "date": "2025-05-03",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #741",
+    "location": "Parque Protasio Tagle, Calle Arenal, Chimalistac, Álvaro Obregón ,, Ciudad de México, MX",
+    "address": null
+  },
+  {
+    "runNumber": 742,
+    "date": "2025-04-05",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #742",
+    "location": "Vips Town Center El Rosario, Town Center El Rosario,Cultura Norte 1025, El Rosario, Azapotzalco 02100 Ciudad de México, México City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 742,
+    "date": "2025-03-22",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash #742: The Primavera Hash!",
+    "location": "metro auditorio, Mexico city, MX",
+    "address": null
+  },
+  {
+    "runNumber": 740,
+    "date": "2025-03-08",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash #740: International women's day!",
+    "location": "HASH #741, Av. Horacio 619, Polanco, Polanco IV Secc, Miguel Hidalgo, 11550 Ciudad de México, CDMX, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 739,
+    "date": "2025-02-22",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #739",
+    "location": "HASH #739, Cuauhtemoc 1017 03020, Narvarte Poniente, 03020 Ciudad de México, CDMX, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2025-02-08",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #7**",
+    "location": "metro auditorio, Mexico city, MX",
+    "address": null
+  },
+  {
+    "runNumber": 728,
+    "date": "2025-01-25",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #728",
+    "location": "Anil's place, calle Issac Newton 82 Polanco, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 737,
+    "date": "2025-01-11",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #737",
+    "location": "Lucy, Iztaccihuatl 26 #701, Cuauhtemoc ,, Mexico city, MX",
+    "address": null
+  },
+  {
+    "runNumber": 736,
+    "date": "2024-12-28",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #736",
+    "location": "metro auditorio, Mexico city, MX",
+    "address": null
+  },
+  {
+    "runNumber": 735,
+    "date": "2024-12-14",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #735",
+    "location": "metro auditorio, Mexico city, MX",
+    "address": null
+  },
+  {
+    "runNumber": 734,
+    "date": "2024-12-01",
+    "startTime": "11:30",
+    "endTime": null,
+    "title": "!! NASH HASH !! Hash House Harriers Mexico City - Run #734 - Recovery Brunch",
+    "location": "Brunch, Iztaccihuatl 41, Hipódromo, Cuauhtémoc, 06100 Ciudad de México, CDMX, Mexico city, MX",
+    "address": null
+  },
+  {
+    "runNumber": 734,
+    "date": "2024-11-30",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "!! NASH HASH !! Hash House Harriers Mexico City - Run #734",
+    "location": "The Duke of Lisbon, Calle Lisboa 15, Juárez, Cuauhtémoc, 06600 Ciudad de México, CDMX, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 734,
+    "date": "2024-11-29",
+    "startTime": "06:30",
+    "endTime": null,
+    "title": "!! NASH HASH Pub Crawl!! Hash House Harriers Mexico City - Run #734",
+    "location": "Shakesprick's, Higuera 22, apartment 15, La Concepción, Coyoacán, 04000 Ciudad de México, CDMX, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 733,
+    "date": "2024-11-16",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #733",
+    "location": "Kate's, 30 Gral Aureliano Riviera, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 732,
+    "date": "2024-11-02",
+    "startTime": "10:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #732",
+    "location": "Instituto Nacional de Pediatría, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 731,
+    "date": "2024-10-19",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #731",
+    "location": "Metro la raza, Vallejo Poniente, Gustavo A. Madero, La Raza, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 730,
+    "date": "2024-10-05",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #730",
+    "location": "Lucy, Iztaccihuatl 26 #701, Cuauhtemoc ,, Mexico city, MX",
+    "address": null
+  },
+  {
+    "runNumber": 729,
+    "date": "2024-09-21",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #729",
+    "location": "shakes, Higuera 22, La Concepción, Coyoacán, 04000 Ciudad de México, CDMX, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 728,
+    "date": "2024-09-07",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #728",
+    "location": "Chimalistac, Paseo del Río, Chimalistac, Álvaro Obregon,, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 727,
+    "date": "2024-08-24",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #727",
+    "location": "Libra 159, Prado Churubusco, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 725,
+    "date": "2024-08-24",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #725 - Mineral del Chico Hash",
+    "location": "Mineral del Chico, MX",
+    "address": null
+  },
+  {
+    "runNumber": 726,
+    "date": "2024-08-10",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #726",
+    "location": "Quintana Roo 93-8, Roma, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 725,
+    "date": "2024-07-27",
+    "startTime": "10:00",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #725 - Mineral del Chico Hash",
+    "location": "Mineral del Chico, MX",
+    "address": null
+  },
+  {
+    "runNumber": 725,
+    "date": "2024-07-27",
+    "startTime": "09:00",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #725 Outa town hash",
+    "location": "Mineral del Chico, MX",
+    "address": null
+  },
+  {
+    "runNumber": 724,
+    "date": "2024-07-13",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #724",
+    "location": "Goguinara // Canta bar london Karaoke, Genova #20 local 3 entre Hamburgo y Paseo de la Reforma // Londres #167 3er piso, México City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 723,
+    "date": "2024-06-29",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #723",
+    "location": "Metro Refinería, Ferrocarriles Nacionales de México Esquina, Ciudad de México, MX",
+    "address": null
+  },
+  {
+    "runNumber": 722,
+    "date": "2024-06-15",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #722",
+    "location": "Plaza San Jacinto, Pl. San Jacinto, Ciudad de México, MX",
+    "address": null
+  },
+  {
+    "runNumber": 721,
+    "date": "2024-06-01",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #721",
+    "location": "Metro Constituyentes., Parque Lira # 18., México City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 720,
+    "date": "2024-05-18",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #720",
+    "location": "Hash start, Etna 82, Los Alpes, Álvaro Obregón, 01010 Ciudad de México, CDMX, Mexico City, IA, MX",
+    "address": null
+  },
+  {
+    "runNumber": 719,
+    "date": "2024-05-04",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #719",
+    "location": "C. 14 Bis 1, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": 718,
+    "date": "2024-04-20",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #718",
+    "location": "Hash start, Etna 82, Los Alpes, Álvaro Obregón, 01010 Ciudad de México, CDMX, Mexico City, IA, MX",
+    "address": null
+  },
+  {
+    "runNumber": 717,
+    "date": "2024-04-06",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #717",
+    "location": "Parque Lincoln, Av. Emilio Castelar 163, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": 716,
+    "date": "2024-03-23",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #716",
+    "location": "Plaza San Jacinto, Pl. San Jacinto, Ciudad de México, MX",
+    "address": null
+  },
+  {
+    "runNumber": 715,
+    "date": "2024-03-09",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #715",
+    "location": "Americas Park, Av. Horacio Col, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": 714,
+    "date": "2024-02-24",
+    "startTime": "13:00",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #714",
+    "location": "Entrada a Bosque de tlalpan, Camino Sta. Teresa S / N, Ciudad de México, MX",
+    "address": null
+  },
+  {
+    "runNumber": 713,
+    "date": "2024-02-10",
+    "startTime": "10:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #713",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2024-02-03",
+    "startTime": "14:00",
+    "endTime": null,
+    "title": "Coyoacan Not a Full Moon Hash House Harriers, Run 1",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 712,
+    "date": "2024-01-27",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #712",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 711,
+    "date": "2024-01-13",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #711",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 709,
+    "date": "2023-12-16",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #709",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 708,
+    "date": "2023-12-02",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #708",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 707,
+    "date": "2023-11-18",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #707",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 706,
+    "date": "2023-11-04",
+    "startTime": "11:00",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #706",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 705,
+    "date": "2023-10-21",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #705 🎃 The Halloween Hash ☠️",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 704,
+    "date": "2023-10-07",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Run #704",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 703,
+    "date": "2023-09-23",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Hash #703",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 702,
+    "date": "2023-09-09",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Hash #702",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-08-25",
+    "startTime": "21:00",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - 700th Hidalgo Cowboy Hash",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 699,
+    "date": "2023-08-12",
+    "startTime": "15:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Hash #699",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 698,
+    "date": "2023-07-29",
+    "startTime": "14:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Hash #698",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": 697,
+    "date": "2023-07-15",
+    "startTime": "14:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Hash #697",
+    "location": "Parque Lincoln, Av. Emilio Castelar 163, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": 696,
+    "date": "2023-07-01",
+    "startTime": "14:30",
+    "endTime": null,
+    "title": "Hash House Harriers Mexico City - Hash #696",
+    "location": "Dre Coyoacan, Av. Miguel Ángel de Quevedo 992, Parque San Andrés,, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": 695,
+    "date": "2023-06-17",
+    "startTime": "10:30",
+    "endTime": null,
+    "title": "CDMX H3 - Hash #695: Father's Day Shitty Tie Hash",
+    "location": "Americas Park, Av. Horacio Col, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-06-03",
+    "startTime": "14:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Hash!",
+    "location": "Parque Lincoln, Av. Emilio Castelar 163, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": 693,
+    "date": "2023-05-20",
+    "startTime": "14:30",
+    "endTime": null,
+    "title": "CDMX H3 Hash # 693 - Coyoacan",
+    "location": "DRE Coyoacan, Av. Miguel Ángel de Quevedo 992, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-05-06",
+    "startTime": "14:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Hash!",
+    "location": "METROBÚS LA PALMA - LÍNEA 7, Av. P.º de la Reforma, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": 691,
+    "date": "2023-04-22",
+    "startTime": "10:00",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Hash # 691 - 😈 The Satanic Hash 😈",
+    "location": "C. 14 Bis 1, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-04-08",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers:Easter Vigil Hash!",
+    "location": "Location not specified yet",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-03-25",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: “Panama Mágico” Hash",
+    "location": "EKKO Hostel, Revolución de 1910 s/n, Tepoztlán, MO, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-03-11",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: “A Flash of Green” St Patrick’s Hash",
+    "location": "Preescolar Miguel Leon Portilla, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-02-25",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: “Musical Treasure Hunt” - San Rafael",
+    "location": "Guau Tap, C. Guillermo Prieto 45, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-02-11",
+    "startTime": "13:45",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Valentine’s Hash in Lomas - Virreyes",
+    "location": "Avenida Prado Norte 310, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-01-28",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Farewell Hash - Zeppelin and Missing in Action",
+    "location": "Minatitlan 10, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2023-01-14",
+    "startTime": "14:00",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Parque Tamayo Jan 14, 2023",
+    "location": "Monumento a Gandhi, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2022-12-17",
+    "startTime": "14:00",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Coyoacan- Sat Dec 17, 2022",
+    "location": "DRE Coyoacan, Av. Miguel Ángel de Quevedo 992, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2022-12-03",
+    "startTime": "11:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Reforma Social - Sat Dec 03, 2022",
+    "location": "Reforma Social, C. 14 Bis 1, Reforma Soc, Miguel Hidalgo, 11650 Ciudad de México, CDMX, Mexico City, AL, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2022-11-19",
+    "startTime": "09:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Hidalgo Ranch Hash - Sat Nov 19, 2022",
+    "location": "The Duke of Lisbon, Calle Lisboa 15, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2022-11-05",
+    "startTime": "11:00",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Ajusco Hash - Sat Nov 05, 2022",
+    "location": "El Abrevadero, Mexico City, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2022-10-22",
+    "startTime": "13:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Insurgentes Sur Hash - Sat Oct 22, 2022",
+    "location": "Metrobus Parque Hundido, Av. Insurgentes Sur, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2022-10-08",
+    "startTime": "14:00",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Col. Juarez Hash - Sat Oct 08, 2022",
+    "location": "Abraham González 19, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2022-09-24",
+    "startTime": "12:30",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Polanco Hash - Sat Sep 24, 2022",
+    "location": "Presa Salinillas 264, Ciudad de México, CD, MX",
+    "address": null
+  },
+  {
+    "runNumber": null,
+    "date": "2022-09-10",
+    "startTime": "14:00",
+    "endTime": null,
+    "title": "Mexico City Hash House Harriers: Polanco Hash - Sat Sep 10, 2022",
+    "location": "Av. Horacio 1104, Ciudad de México, CD, MX",
+    "address": null
+  }
 ]

--- a/scripts/fix-onboarding-profile-overrides.ts
+++ b/scripts/fix-onboarding-profile-overrides.ts
@@ -1,0 +1,64 @@
+/**
+ * One-off profile overrides for the Paris / NSWHHH onboarding-cleanup bundle
+ * (#1972, #1974).
+ *
+ * These fields are already non-null in prod, so the fill-only seed merge can't
+ * correct them (see profile-override-runner.ts):
+ *
+ *   - sans-clue-h3.description → reattribute the "~1993" founding inference to
+ *       Sans Clue itself instead of cross-wiring it onto Paris H3 (the 1981
+ *       original). The prior wording "Paris H3 (est. ~1993)" contradicted
+ *       Paris H3's own foundedYear/description. (#1974)
+ *   - nswhhh.hashCash → drift-guarded no-op: the #1972 audit flagged a "$$5"
+ *       double-dollar artifact, but a prod query (2026-06-04) showed prod
+ *       already holds the correct "$5 (first run free)". Kept here as a safety
+ *       net — the runner reports "already correct" when current === target, and
+ *       still corrects a "$$5" value if one ever reappears. (#1972)
+ *
+ * Idempotent and drift-guarded. Default mode is DRY-RUN; pass --execute to apply.
+ *
+ * Usage:
+ *   eval "$(fnm env)" && fnm use 20
+ *   set -a && source .env && set +a
+ *   npx tsx scripts/fix-onboarding-profile-overrides.ts            # dry-run
+ *   npx tsx scripts/fix-onboarding-profile-overrides.ts --execute  # apply
+ */
+
+import "dotenv/config";
+import { runProfileOverrides, type ProfileOverride } from "./lib/profile-override-runner";
+
+// `expected` captured from the prod-state query at authoring time (2026-06-04).
+const OVERRIDES: ProfileOverride[] = [
+  {
+    kennelCode: "sans-clue-h3",
+    rewrites: {
+      description: {
+        expected:
+          "Sister hash to Paris H3 (est. ~1993), running alternating Sundays around central Paris. A-to-B trails set by a hare, beer stops along the way, most trails walker-friendly. 'Sans Clue' = without a clue.",
+        target:
+          "Sister hash to Paris H3 (France's original 1981 kennel), itself running alternating Sundays around central Paris since around 1993. A-to-B trails set by a hare, beer stops along the way, most trails walker-friendly. 'Sans Clue' = without a clue.",
+      },
+    },
+  },
+  {
+    kennelCode: "nswhhh",
+    rewrites: {
+      hashCash: {
+        // Accept either the audit-reported "$$5" artifact or the already-correct
+        // value; current === target short-circuits to a no-op either way.
+        expected: ["$$5 (first run free)", "$5 (first run free)"],
+        target: "$5 (first run free)",
+      },
+    },
+  },
+];
+
+runProfileOverrides(OVERRIDES, {
+  execute: process.argv.includes("--execute"),
+  scriptName: "fix-onboarding-profile-overrides",
+}).catch((err) => {
+  console.error("\nFatal error:", err);
+  // Set exitCode (not process.exit) so the runner's prisma.$disconnect()/pool.end()
+  // in its finally block drain cleanly before the process ends.
+  process.exitCode = 1;
+});

--- a/src/adapters/google-sheets/adapter.test.ts
+++ b/src/adapters/google-sheets/adapter.test.ts
@@ -337,6 +337,52 @@ describe("buildEventFromSheetRow", () => {
     expect(event!.locationUrl).toBeUndefined();
   });
 
+  // #1973 NSWHHH: opt-in runHareTitle synthesizes "Run #<N> w/ <hares>" from
+  // the data we already capture, instead of merge.ts's bare "… Trail #N".
+  describe("runHareTitle (#1973)", () => {
+    const config = {
+      sheetId: "nswhhh",
+      columns: { date: 0, runNumber: 1, hares: 2 },
+      kennelTagRules: { default: "nswhhh" },
+      runHareTitle: true,
+    };
+
+    it("builds 'Run #<N> w/ <hare>' when hares present", () => {
+      const row = ["1-Jun-2026", "1066", "He'll Do"];
+      const event = buildEventFromSheetRow(row, config, "https://example.com", "2026-06-01");
+      expect(event!.title).toBe("Run #1066 w/ He'll Do");
+    });
+
+    it("falls back to 'Run #<N>' when the hare cell is empty", () => {
+      const row = ["1-Jun-2026", "933", ""];
+      const event = buildEventFromSheetRow(row, config, "https://example.com", "2026-06-01");
+      expect(event!.title).toBe("Run #933");
+    });
+
+    it("leaves title undefined (merge synthesizes default) when there's no run number", () => {
+      const noRunConfig = {
+        sheetId: "nswhhh",
+        columns: { date: 0, hares: 2 },
+        kennelTagRules: { default: "nswhhh" },
+        runHareTitle: true,
+      };
+      const row = ["1-Jun-2026", "", "He'll Do"];
+      const event = buildEventFromSheetRow(row, noRunConfig, "https://example.com", "2026-06-01");
+      expect(event!.title).toBeUndefined();
+    });
+
+    it("does not synthesize a title when runHareTitle is off (default)", () => {
+      const offConfig = {
+        sheetId: "nswhhh",
+        columns: { date: 0, runNumber: 1, hares: 2 },
+        kennelTagRules: { default: "nswhhh" },
+      };
+      const row = ["1-Jun-2026", "1066", "He'll Do"];
+      const event = buildEventFromSheetRow(row, offConfig, "https://example.com", "2026-06-01");
+      expect(event!.title).toBeUndefined();
+    });
+  });
+
   // #923 Munich H3: explicit startTime column overrides startTimeRules
   // inference. Empty / placeholder cells fall through to rules.
   describe("startTime column (#923)", () => {

--- a/src/adapters/google-sheets/adapter.ts
+++ b/src/adapters/google-sheets/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails, ParseError } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, validateSourceConfig, stripPlaceholder, parse12HourTime } from "../utils";
+import { googleMapsSearchUrl, validateSourceConfig, stripPlaceholder, parse12HourTime, buildRunHareTitle } from "../utils";
 import { safeFetch } from "../safe-fetch";
 
 /** Titles starting with these verbs are instructions/notes, not event names. */
@@ -116,6 +116,14 @@ export interface GoogleSheetsConfig {
   };
   /** Fallback title when title cell is empty/placeholder. Use with runNumber: "${defaultTitle} #${runNumber}" */
   defaultTitle?: string;
+  /**
+   * Opt-in: when the title cell is empty/absent, synthesize a source-anchored
+   * "Run #<N> w/ <hares>" title (falls back to "Run #<N>" when no hares) instead
+   * of letting merge.ts emit a bare "<Kennel> Trail #N". For harelines that
+   * carry only date + run # + hare (e.g. NSWHHH #1973). Takes precedence over
+   * `defaultTitle`. No-op when the row has no run number.
+   */
+  runHareTitle?: boolean;
   /** Rows to skip before the header row (title rows, notes). Default: 0 */
   skipRows?: number;
   /** Explicit Google Sheet tab gid (numeric). When set, uses export?format=csv&gid=X instead of gviz URL */
@@ -643,6 +651,12 @@ export function buildEventFromSheetRow(
 
   if (title && INSTRUCTION_TITLE_RE.test(title)) {
     title = undefined;
+  }
+
+  // Synthesize "Run #<N> w/ <hares>" when opted in and no title cell (#1973).
+  // Takes precedence over defaultTitle; no-op when the row lacks a run number.
+  if (!title && config.runHareTitle) {
+    title = buildRunHareTitle(resolved.runNumber, hares);
   }
 
   // Apply defaultTitle fallback when title is empty

--- a/src/adapters/html-scraper/nswhhh.test.ts
+++ b/src/adapters/html-scraper/nswhhh.test.ts
@@ -40,6 +40,7 @@ describe("parseNSWHHHPage", () => {
     expect(event).toMatchObject({
       date: "2026-06-01",
       runNumber: 1065,
+      title: "Run #1065 w/ Lost Jewels",
       hares: "Lost Jewels",
       location: "Bay Road Reserve, Bay Rd, Waverton",
       locationUrl: "https://maps.app.goo.gl/iiY2q5avvkBvBchS6",
@@ -47,6 +48,13 @@ describe("parseNSWHHHPage", () => {
       kennelTags: ["nswhhh"],
       sourceUrl: SOURCE_URL,
     });
+  });
+
+  it("synthesizes a 'Run #<N>' title (no hare) when the hare is a placeholder (#1973)", () => {
+    const html = FIXTURE.replace("<span>Hare: Lost Jewels</span>", "<span>Hare: Hare Wanted</span>");
+    const { event } = parseNSWHHHPage(html, SOURCE_URL);
+    expect(event?.hares).toBeNull();
+    expect(event?.title).toBe("Run #1065");
   });
 
   it("extracts coordinates from the embedded maps iframe (q= marker)", () => {

--- a/src/adapters/html-scraper/nswhhh.ts
+++ b/src/adapters/html-scraper/nswhhh.ts
@@ -1,7 +1,7 @@
 import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult } from "../types";
-import { fetchHTMLPage, chronoParseDate, extractHashRunNumber, formatAmPmTime, stripHtmlTags } from "../utils";
+import { fetchHTMLPage, chronoParseDate, extractHashRunNumber, formatAmPmTime, stripHtmlTags, buildRunHareTitle } from "../utils";
 import { extractCoordsFromMapsUrl } from "@/lib/geo";
 
 /**
@@ -158,6 +158,11 @@ export function parseNSWHHHPage(
       date,
       kennelTags: ["nswhhh"],
       runNumber,
+      // Source-anchored "Run #<N> w/ <hare>" title (#1973) — matches the
+      // GOOGLE_SHEETS source + backfill so the current-run event and the
+      // forward schedule share one title shape. Undefined when no run number,
+      // letting merge.ts synthesize the kennel-name default.
+      title: buildRunHareTitle(runNumber, hares),
       hares,
       location,
       locationUrl,

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1598,6 +1598,47 @@ describe("buildRawEventFromApollo — runNumber (#1562 Miami H3)", () => {
   });
 });
 
+// ── buildRawEventFromApollo — runNumberPrefix (#1975 Paris / Sans Clue) ──
+
+describe("buildRawEventFromApollo — runNumberPrefix (#1975 Paris/Sans Clue 'R*n')", () => {
+  const emptyState = {} as Record<string, Record<string, unknown>>;
+  // 6th positional arg is `runNumberPrefix` — the literal token a kennel uses
+  // instead of "#". Paris H3 + Sans Clue H3 self-censor "Run" as "R*n".
+  const OPT_IN = true;
+  const PREFIX = "R*n";
+
+  it.each([
+    ["Paris H3 R*n 1136 | TBD", 1136],
+    ["Sans Clue H3 R*n 1192 | TBD", 1192],
+    ["Paris H3 R*n 1134 | ✨ Eurovision! ✨", 1134],
+    ["Sans Clue H3 R*n 1196", 1196],
+  ])("extracts runNumber from %j by normalizing the R*n prefix", (title, expected) => {
+    const ev = { __typename: "Event", id: "rxn", title, dateTime: "2026-06-06T14:00:00+02:00" };
+    const event = buildRawEventFromApollo(ev, emptyState, "paris-h3", undefined, OPT_IN, PREFIX);
+    expect(event.runNumber).toBe(expected);
+  });
+
+  it("keeps the kennel's 'R*n' stylization in the display title", () => {
+    const ev = { __typename: "Event", id: "disp", title: "Paris H3 R*n 1136 | TBD", dateTime: "2026-06-06T14:00:00+02:00" };
+    const event = buildRawEventFromApollo(ev, emptyState, "paris-h3", undefined, OPT_IN, PREFIX);
+    expect(event.title).toBe("Paris H3 R*n 1136 | TBD");
+  });
+
+  it("leaves runNumber undefined when the prefix is configured but extraction is off", () => {
+    const ev = { __typename: "Event", id: "off", title: "Paris H3 R*n 1136 | TBD", dateTime: "2026-06-06T14:00:00+02:00" };
+    const event = buildRawEventFromApollo(ev, emptyState, "paris-h3", undefined, false, PREFIX);
+    expect(event.runNumber).toBeUndefined();
+  });
+
+  it("leaves runNumber undefined for an 'R*n' title when no prefix is configured (no regression)", () => {
+    // Without runNumberPrefix the shared helper only matches '#NNN', so the
+    // bare "R*n 1136" form yields nothing — exactly what other Meetup kennels see.
+    const ev = { __typename: "Event", id: "norm", title: "Paris H3 R*n 1136 | TBD", dateTime: "2026-06-06T14:00:00+02:00" };
+    const event = buildRawEventFromApollo(ev, emptyState, "paris-h3", undefined, OPT_IN);
+    expect(event.runNumber).toBeUndefined();
+  });
+});
+
 describe("extractHaresFromMeetupDescription (#953 CHH3 dash separator)", () => {
   it("captures 'Hares - X and Y' (plural, dash, ASCII hyphen)", () => {
     expect(extractHaresFromMeetupDescription("Hares - FAW and Just Jim\n\nGo see the rail yards"))

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -515,6 +515,24 @@ function extractTitleHares(title: string | undefined): { hares?: string; title?:
   return { hares, title: m ? title.slice(0, m.index) : title };
 }
 
+/**
+ * Resolve a run number from a Meetup title. Off unless `extractRunNumber` is
+ * opted in per source. When a kennel stylizes its run number with a literal
+ * prefix instead of "#" (e.g. Paris/Sans Clue "R*n", #1975), that prefix is
+ * rewritten to "#" first — a literal `String.replaceAll`, not regex, so a `*`
+ * in the token needs no escaping — and the shared `extractHashRunNumber` does
+ * the parsing. Returns undefined when extraction is off or no number is found.
+ */
+function resolveRunNumber(
+  title: string | undefined,
+  extractRunNumber: boolean,
+  runNumberPrefix: string | undefined,
+): number | undefined {
+  if (!extractRunNumber) return undefined;
+  const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
+  return extractHashRunNumber(normalized);
+}
+
 /** Build a RawEventData from an Apollo event entry. */
 export function buildRawEventFromApollo(
   ev: ApolloEvent,
@@ -566,19 +584,14 @@ export function buildRawEventFromApollo(
   const titleForDisplay = fromTitle?.title ?? ev.title;
   const cleanedDesc = cleanMeetupDescription(ev.description, state);
 
-  // Normalize a kennel's stylized run-number prefix (e.g. "R*n") to "#" so the
-  // shared extractHashRunNumber helper parses it (#1975). Literal string
-  // replace — not regex — so "R*n" needs no escaping. Display title is left
-  // untouched (it keeps the kennel's "R*n 1136" stylization).
-  const runNumberTitle = runNumberPrefix && ev.title
-    ? ev.title.replaceAll(runNumberPrefix, "#")
-    : ev.title;
-
   return {
     date,
     kennelTags: [resolvedKennelTag],
     title: cleanMeetupTitle(titleForDisplay),
-    runNumber: extractRunNumber ? extractHashRunNumber(runNumberTitle) : undefined,
+    // Run-number extraction (with optional "R*n"-style prefix normalization)
+    // lives in resolveRunNumber so this builder stays under the cognitive-
+    // complexity budget. Display title keeps the kennel's stylization.
+    runNumber: resolveRunNumber(ev.title, extractRunNumber, runNumberPrefix),
     description: cleanedDesc,
     hares,
     location: venueInfo.location,

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -79,6 +79,19 @@ export interface MeetupConfig {
    * conventions are unambiguous (e.g. always "Miami H3 Trail #NNNN").
    */
   extractRunNumber?: boolean;
+  /**
+   * Optional literal prefix a kennel stylizes its run number with instead of
+   * the standard `#`. When set (and `extractRunNumber` is true), every literal
+   * occurrence is rewritten to `#` before `extractHashRunNumber` runs, so the
+   * shared helper does the actual parsing (no per-kennel run-number regex).
+   *
+   * Paris H3 + Sans Clue H3 self-censor "Run" as "R*n" — titles read
+   * `Paris H3 R*n 1136 | TBD` (#1975). With `runNumberPrefix: "R*n"`, that
+   * normalizes to `Paris H3 # 1136 | TBD` → `extractHashRunNumber` → 1136.
+   * Matched as a plain string via `String.prototype.replaceAll` (literal, not
+   * regex), so a `*` in the token needs no escaping.
+   */
+  runNumberPrefix?: string;
 }
 
 /** Shape of an event entry in Meetup's __NEXT_DATA__ Apollo state. */
@@ -509,6 +522,7 @@ export function buildRawEventFromApollo(
   kennelTag: string,
   compiledPatterns?: [RegExp, string][],
   extractRunNumber = false,
+  runNumberPrefix?: string,
 ): RawEventData {
   const { date, startTime } = ev.dateTime
     ? extractDateTime(ev.dateTime)
@@ -552,11 +566,19 @@ export function buildRawEventFromApollo(
   const titleForDisplay = fromTitle?.title ?? ev.title;
   const cleanedDesc = cleanMeetupDescription(ev.description, state);
 
+  // Normalize a kennel's stylized run-number prefix (e.g. "R*n") to "#" so the
+  // shared extractHashRunNumber helper parses it (#1975). Literal string
+  // replace — not regex — so "R*n" needs no escaping. Display title is left
+  // untouched (it keeps the kennel's "R*n 1136" stylization).
+  const runNumberTitle = runNumberPrefix && ev.title
+    ? ev.title.replaceAll(runNumberPrefix, "#")
+    : ev.title;
+
   return {
     date,
     kennelTags: [resolvedKennelTag],
     title: cleanMeetupTitle(titleForDisplay),
-    runNumber: extractRunNumber ? extractHashRunNumber(ev.title) : undefined,
+    runNumber: extractRunNumber ? extractHashRunNumber(runNumberTitle) : undefined,
     description: cleanedDesc,
     hares,
     location: venueInfo.location,
@@ -765,7 +787,7 @@ export class MeetupAdapter implements SourceAdapter {
         // hydrated from persisted JSON, where any truthy value would pass
         // through unintentionally. Only literal `true` opts in.
         const shouldExtractRunNumber = config.extractRunNumber === true;
-        events.push(buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber));
+        events.push(buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix));
       } catch (err) {
         const msg = `Failed to parse event "${ev.id}": ${err instanceof Error ? err.message : String(err)}`;
         errors.push(msg);

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -20,6 +20,7 @@ import {
   applyWeekdayShift,
   hasPlaceholderRunNumber,
   extractHashRunNumber,
+  buildRunHareTitle,
   normalizeCostSigil,
   cleanLocationName,
   stripClickHereForMap,
@@ -966,6 +967,26 @@ describe("extractHashRunNumber", () => {
     ["undefined", undefined, undefined],
   ])("%s: %j → %p", (_, input, expected) => {
     expect(extractHashRunNumber(input)).toBe(expected);
+  });
+});
+
+describe("buildRunHareTitle (#1973 NSWHHH)", () => {
+  it("builds 'Run #<N> w/ <hares>' when hares present", () => {
+    expect(buildRunHareTitle(1066, "He'll Do")).toBe("Run #1066 w/ He'll Do");
+  });
+
+  it("falls back to 'Run #<N>' when hares is null/undefined/blank", () => {
+    expect(buildRunHareTitle(933, null)).toBe("Run #933");
+    expect(buildRunHareTitle(934, undefined)).toBe("Run #934");
+    expect(buildRunHareTitle(936, "   ")).toBe("Run #936");
+  });
+
+  it("trims surrounding whitespace from hares", () => {
+    expect(buildRunHareTitle(1092, "  Minnie Mouse  ")).toBe("Run #1092 w/ Minnie Mouse");
+  });
+
+  it("returns undefined when there's no run number (merge synthesizes the default)", () => {
+    expect(buildRunHareTitle(undefined, "He'll Do")).toBeUndefined();
   });
 });
 

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -988,6 +988,11 @@ describe("buildRunHareTitle (#1973 NSWHHH)", () => {
   it("returns undefined when there's no run number (merge synthesizes the default)", () => {
     expect(buildRunHareTitle(undefined, "He'll Do")).toBeUndefined();
   });
+
+  it("returns undefined for NaN (guards against an unguarded parseInt) rather than 'Run #NaN'", () => {
+    expect(buildRunHareTitle(Number.NaN, "He'll Do")).toBeUndefined();
+    expect(buildRunHareTitle(Number.parseInt("not-a-number", 10), null)).toBeUndefined();
+  });
 });
 
 // #1272/#1274/#1275 — placeholder-runNumber detection. Kennel admins use

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -742,6 +742,25 @@ export function extractHashRunNumber(text: string | undefined): number | undefin
 }
 
 /**
+ * Build a source-anchored "Run #<N> w/ <hares>" event title for kennels whose
+ * source carries only run-number + hare (no separate title column). Folds the
+ * hares we already capture into the title instead of leaving the merge pipeline
+ * to synthesize a bare "<Kennel> Trail #N" (NSWHHH #1973). Falls back to
+ * "Run #<N>" when hares are absent, and `undefined` when there's no run number
+ * (so merge.ts still synthesizes the kennel-name default). Shared by the
+ * GOOGLE_SHEETS adapter, the NSWHHH HTML adapter, and the NSWHHH backfill so all
+ * three emit identical titles (no title churn on the in-window overlap).
+ */
+export function buildRunHareTitle(
+  runNumber: number | undefined,
+  hares: string | null | undefined,
+): string | undefined {
+  if (runNumber == null) return undefined;
+  const h = hares?.trim();
+  return h ? `Run #${runNumber} w/ ${h}` : `Run #${runNumber}`;
+}
+
+/**
  * Detect placeholder run-number markers like `#25XX`, `#208X`, `#30X?`,
  * `#30TBD`, `#2784 TBA`, plus digit-free variants like `#TBD`, `#?`, `#X`
  * — "next run, number not yet assigned" (#1272/#1274/#1275). Callers

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -755,7 +755,10 @@ export function buildRunHareTitle(
   runNumber: number | undefined,
   hares: string | null | undefined,
 ): string | undefined {
-  if (runNumber == null) return undefined;
+  // `== null` covers null/undefined but NOT NaN (NaN == null is false), so a
+  // stray NaN would otherwise render "Run #NaN". Guard it explicitly — this is
+  // a shared helper and a future caller might pass an unguarded parseInt.
+  if (runNumber == null || Number.isNaN(runNumber)) return undefined;
   const h = hares?.trim();
   return h ? `Run #${runNumber} w/ ${h}` : `Run #${runNumber}`;
 }


### PR DESCRIPTION
Onboarding-cleanup bundle for three recently-added Meetup/Sheet kennels. No `merge.ts` / hare-extraction / audit changes (those are parallel sessions). The Paris admin-seed dups (#1976) are handled elsewhere — not touched here.

## Paris H3 / Sans Clue H3 (Meetup)

**Closes #1975** — `runNumber` was null on every stored event despite titles like `Paris H3 R*n 1136 | TBD` (the kennels self-censor "Run" as `R*n`). Added an opt-in `runNumberPrefix` config to `MeetupConfig`; `buildRawEventFromApollo` rewrites the literal prefix to `#` (literal `String.replaceAll`, no new regex) before the shared `extractHashRunNumber`. **Live-verified:** `Paris H3 R*n 1136` → 1136, Sans Clue 9/9; TNDC socials stay null and are dropped downstream; other Meetup kennels unaffected (opt-in).

**Closes #1977** — Documented the umbrella structure in the source comment: Paris Full Moon H3 is dormant (no source → no-sourceless-kennels rule) and TNDC is a social-event schema gap. No new kennels/sources.

**Closes #1974** — Added Paris H3 `gm` = `Bearded Clam and Gasbag`. Reworded the Sans Clue description so the `~1993` inference attaches to Sans Clue itself (its own 25th-birthday-Apr-2018 inference), not Paris H3 — which stays the better-sourced **1981** original. Resolves the cross-wired internal contradiction.

## Mexico City H3 (Meetup)

**Closes #1970** — Sourcing conflict reviewed: kept the dual-sourced `foundedYear` **1983** (Mexico News Daily + Half-Mind), NOT the Meetup-About "1980" blurb. `foundedYear` + description already agree at 1983 (no internal conflict). No data change; rationale documented in the seed comment.

**Closes #1971** — Expanded the curated `scripts/data/mch3-history.json` from 10 → **84 rows** via a Playwright archive scrape (`scrape-meetup-history.mjs`), runNumber parsed via `extractHashRunNumber`, the existing 10 rich rows preserved. Loader `runNumber` made optional for the 20 themed posts without a `#`. **Prod: 10 → 79 canonical events** (`backfill-mch3-history.ts`, `reportAndApplyBackfill`, `date < today`).

## North Shore Wanderers H3 (Sheet + website)

**Closes #1973** — All 187 events showed the synthesized `… Trail #N`. Added a shared `buildRunHareTitle()` to `utils.ts`, wired into the **adapter level** (Google Sheets opt-in `runHareTitle` config, the NSWHHH HTML adapter, and the backfill) → `Run #<N> w/ <hare>`. **Prod: all 189 events retitled, 0 `Trail #` remaining** (archive backfill re-titled 160; a forward-sheet + website re-merge handled 28; one transition-artifact event — a stale empty-title trust-8 website RawEvent outranking the sheet — got a guarded one-event correction).

**Closes #1972** — Added `gm` = `Lost Jewels` and `contactEmail`. The audit-flagged `$$5` hashCash was verified **already correct in prod** (`$5 (first run free)`) — the one-shot carries a drift-guarded no-op for it.

## Applied to prod
Backfills (MCH3 + NSWHHH), the `gm`/`contactEmail` fills, and the Sans Clue description override (`scripts/fix-onboarding-profile-overrides.ts`, `runProfileOverrides`) are already applied.

## Post-merge step
Run `npx prisma db seed` after deploy to sync the new `Source.config` keys (`extractRunNumber` + `runNumberPrefix` on Paris, `runHareTitle` on NSWHHH) — these need the deployed adapter code. Paris stored events backfill their `runNumber` on the next scrape afterward; the seed is fill-only for kennels so the already-applied profile data is untouched.

## Checks
`npm run lint && npx tsc --noEmit && npm test` green (8489 tests). `/simplify` + correctness review (3 angles) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)