### PR TITLE
fix(adapters): cross-kennel hare role-header family + Brasília/Asunción/Auckland cleanup

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4573,9 +4573,11 @@ export const KENNELS: KennelSeed[] = [
       slug: "asuncion-h3", // explicit: toSlug("Asunción H3") mangles the accented ó → "asunci-n-h3"
       region: "Asunción", country: "Paraguay",
       website: "https://asuncionh3.wordpress.com/",
+      facebookUrl: "https://www.facebook.com/groups/1254316384994089", // footer "Facebook" link (#1959)
       instagramHandle: "asuncionh3",
       logoUrl: "/kennel-logos/asu-h3.png",
       foundedYear: 2021,
+      gm: "Ban The Cock (Eric)", // contact page header (#1959)
       scheduleDayOfWeek: "Saturday", scheduleTime: "4:00 PM", scheduleFrequency: "Biweekly",
       scheduleNotes: "Biweekly Saturday run/walk; start time shifts seasonally (~13:30–17:30 meet, southern-hemisphere winter/summer). Each post lists the exact meet and trail-start time.",
       hashCash: "₲10,000 (PYG, cash only)",
@@ -4594,7 +4596,10 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "brasilia-h3", shortName: "Brasilia H3", fullName: "Brasilia Hash House Harriers",
       region: "Brasília, Brazil", country: "Brazil",
       website: "https://brasiliah3.blogspot.com",
-      facebookUrl: "https://www.facebook.com/BrasiliaHHH",
+      // Sidebar "Brasilia H3 Facebook Page" link points to the groups URL, not
+      // the page URL HT previously had (#1980). Seed merge is fill-null only, so
+      // the existing prod value is corrected by the one-shot in the backfill.
+      facebookUrl: "https://www.facebook.com/groups/BrasiliaH3",
       foundedYear: 1989,
       scheduleDayOfWeek: "Sunday", scheduleFrequency: "Biweekly",
       walkersWelcome: true,

--- a/scripts/backfill-audit-brasilia-asu-auckland.ts
+++ b/scripts/backfill-audit-brasilia-asu-auckland.ts
@@ -67,9 +67,11 @@ const FORWARD_SOURCES: { name: string; days: number }[] = [
 async function updateProfiles(): Promise<void> {
   console.log(`\n=== Pass 1: kennel profiles ===`);
   for (const patch of PROFILE_PATCHES) {
+    // Fetch the whole row (no select): a selective projection would make any
+    // future PROFILE_PATCHES field read back as undefined (== null), forcing a
+    // redundant fill-null write every run. The Kennel row is tiny.
     const kennel = await prisma.kennel.findUnique({
       where: { kennelCode: patch.kennelCode },
-      select: { id: true, facebookUrl: true, gm: true },
     });
     if (!kennel) {
       console.warn(`  ⚠ kennel ${patch.kennelCode} not found — skipping`);
@@ -94,24 +96,37 @@ async function updateProfiles(): Promise<void> {
 async function refreshForwardEvents(): Promise<void> {
   console.log(`\n=== Pass 2: forward event refresh (current/future) ===`);
   for (const { name, days } of FORWARD_SOURCES) {
-    const source = await prisma.source.findFirst({ where: { name } });
-    if (!source) {
-      console.warn(`  ⚠ source "${name}" not found — skipping`);
-      continue;
-    }
-    const adapter = getAdapter(source.type, source.url, source.config as Record<string, unknown> | null);
-    const result = await adapter.fetch(source, { days });
-    console.log(`  ${name}: fetched ${result.events.length} event(s)${result.errors.length ? ` (errors: ${result.errors.length})` : ""}`);
-    if (!APPLY) {
-      for (const e of result.events.slice(0, 5)) {
-        console.log(`     [dry] ${e.date} #${e.runNumber ?? "?"} title=${e.title ?? "—"} hares=${e.hares ?? "—"} loc=${e.location ?? "—"}`);
+    try {
+      // `name` is not unique — use findMany(take:2) + length check (mirrors
+      // mergeRawEventsForSource) so a duplicate fails loud instead of silently
+      // scraping whichever row findFirst happened to pick.
+      const sources = await prisma.source.findMany({ where: { name }, take: 2 });
+      if (sources.length === 0) {
+        console.warn(`  ⚠ source "${name}" not found — skipping`);
+        continue;
       }
-      continue;
+      if (sources.length > 1) {
+        throw new Error(`Multiple sources named "${name}" — refusing to guess which to scrape`);
+      }
+      const source = sources[0];
+      const adapter = getAdapter(source.type, source.url, source.config as Record<string, unknown> | null);
+      const result = await adapter.fetch(source, { days });
+      console.log(`  ${name}: fetched ${result.events.length} event(s)${result.errors.length ? ` (errors: ${result.errors.length})` : ""}`);
+      if (!APPLY) {
+        for (const e of result.events.slice(0, 5)) {
+          console.log(`     [dry] ${e.date} #${e.runNumber ?? "?"} title=${e.title ?? "—"} hares=${e.hares ?? "—"} loc=${e.location ?? "—"}`);
+        }
+        continue;
+      }
+      if (result.events.length === 0) continue;
+      const merged = await processRawEvents(source.id, result.events);
+      console.log(`     created=${merged.created} updated=${merged.updated} skipped=${merged.skipped} blocked=${merged.blocked} errors=${merged.eventErrors}`);
+      if (merged.blocked > 0) console.warn(`     ⚠ blocked tags: ${merged.blockedTags.join(", ")}`);
+    } catch (err) {
+      // Failure isolation: one source's adapter/network error shouldn't abort
+      // the refresh for the others.
+      console.error(`  ❌ ${name}: refresh failed —`, err);
     }
-    if (result.events.length === 0) continue;
-    const merged = await processRawEvents(source.id, result.events);
-    console.log(`     created=${merged.created} updated=${merged.updated} skipped=${merged.skipped} blocked=${merged.blocked} errors=${merged.eventErrors}`);
-    if (merged.blocked > 0) console.warn(`     ⚠ blocked tags: ${merged.blockedTags.join(", ")}`);
   }
 }
 

--- a/scripts/backfill-audit-brasilia-asu-auckland.ts
+++ b/scripts/backfill-audit-brasilia-asu-auckland.ts
@@ -77,14 +77,18 @@ async function updateProfiles(): Promise<void> {
       console.warn(`  ⚠ kennel ${patch.kennelCode} not found — skipping`);
       continue;
     }
-    const data: Record<string, string> = {};
+    // Build the update via Reflect.get + Object.fromEntries rather than dynamic
+    // `kennel[k]` / `data[k] = …` bracket notation — the latter trips the
+    // object-injection-sink lint on computed keys.
+    const updates: [string, string][] = [];
     for (const [k, v] of Object.entries(patch.fillNull ?? {})) {
-      if ((kennel as Record<string, unknown>)[k] == null) data[k] = v;
+      if (Reflect.get(kennel, k) == null) updates.push([k, v]);
     }
     for (const [k, v] of Object.entries(patch.overwrite ?? {})) {
-      if ((kennel as Record<string, unknown>)[k] !== v) data[k] = v;
+      if (Reflect.get(kennel, k) !== v) updates.push([k, v]);
     }
-    if (Object.keys(data).length === 0) {
+    const data = Object.fromEntries(updates);
+    if (updates.length === 0) {
       console.log(`  ${patch.kennelCode}: already correct, no change`);
       continue;
     }

--- a/scripts/backfill-audit-brasilia-asu-auckland.ts
+++ b/scripts/backfill-audit-brasilia-asu-auckland.ts
@@ -34,27 +34,9 @@ import { processRawEvents } from "@/pipeline/merge";
 
 const APPLY = process.argv.includes("--apply");
 
-interface ProfilePatch {
-  kennelCode: string;
-  /** Fields to set only when the current prod value is null (mirrors seed fill-null). */
-  fillNull?: Record<string, string>;
-  /** Fields to overwrite unconditionally (a known-wrong existing value). */
-  overwrite?: Record<string, string>;
-}
-
-const PROFILE_PATCHES: ProfilePatch[] = [
-  {
-    kennelCode: "asu-h3",
-    fillNull: {
-      facebookUrl: "https://www.facebook.com/groups/1254316384994089",
-      gm: "Ban The Cock (Eric)",
-    },
-  },
-  {
-    kennelCode: "brasilia-h3",
-    overwrite: { facebookUrl: "https://www.facebook.com/groups/BrasiliaH3" },
-  },
-];
+const ASU_FACEBOOK = "https://www.facebook.com/groups/1254316384994089";
+const ASU_GM = "Ban The Cock (Eric)";
+const BRASILIA_FACEBOOK = "https://www.facebook.com/groups/BrasiliaH3";
 
 // Source NAME → forward scrape window (days). Asunción is future-only with no
 // upcoming events today, so its fetch returns nothing — harmless.
@@ -64,36 +46,42 @@ const FORWARD_SOURCES: { name: string; days: number }[] = [
   { name: "Auckland H3 Website", days: 365 },
 ];
 
+/**
+ * Apply a kennel profile patch (only the keys present in `data` are written).
+ * Logs + writes only when there's an actual change. Explicit typed fields — no
+ * dynamic key access — so there's no object-injection sink to flag.
+ */
+async function applyProfile(kennelCode: string, data: Record<string, string>): Promise<void> {
+  if (Object.keys(data).length === 0) {
+    console.log(`  ${kennelCode}: already correct, no change`);
+    return;
+  }
+  console.log(`  ${kennelCode}: ${APPLY ? "updating" : "would update"} ${JSON.stringify(data)}`);
+  if (APPLY) await prisma.kennel.update({ where: { kennelCode }, data });
+}
+
 async function updateProfiles(): Promise<void> {
   console.log(`\n=== Pass 1: kennel profiles ===`);
-  for (const patch of PROFILE_PATCHES) {
-    // Fetch the whole row (no select): a selective projection would make any
-    // future PROFILE_PATCHES field read back as undefined (== null), forcing a
-    // redundant fill-null write every run. The Kennel row is tiny.
-    const kennel = await prisma.kennel.findUnique({
-      where: { kennelCode: patch.kennelCode },
-    });
-    if (!kennel) {
-      console.warn(`  ⚠ kennel ${patch.kennelCode} not found — skipping`);
-      continue;
-    }
-    // Build the update via Reflect.get + Object.fromEntries rather than dynamic
-    // `kennel[k]` / `data[k] = …` bracket notation — the latter trips the
-    // object-injection-sink lint on computed keys.
-    const updates: [string, string][] = [];
-    for (const [k, v] of Object.entries(patch.fillNull ?? {})) {
-      if (Reflect.get(kennel, k) == null) updates.push([k, v]);
-    }
-    for (const [k, v] of Object.entries(patch.overwrite ?? {})) {
-      if (Reflect.get(kennel, k) !== v) updates.push([k, v]);
-    }
-    const data = Object.fromEntries(updates);
-    if (updates.length === 0) {
-      console.log(`  ${patch.kennelCode}: already correct, no change`);
-      continue;
-    }
-    console.log(`  ${patch.kennelCode}: ${APPLY ? "updating" : "would update"} ${JSON.stringify(data)}`);
-    if (APPLY) await prisma.kennel.update({ where: { id: kennel.id }, data });
+
+  // asu-h3: fill facebookUrl + gm only when null (mirrors seed fill-null, #1959).
+  const asu = await prisma.kennel.findUnique({ where: { kennelCode: "asu-h3" } });
+  if (asu) {
+    const data: Record<string, string> = {};
+    if (asu.facebookUrl == null) data.facebookUrl = ASU_FACEBOOK;
+    if (asu.gm == null) data.gm = ASU_GM;
+    await applyProfile("asu-h3", data);
+  } else {
+    console.warn("  ⚠ kennel asu-h3 not found — skipping");
+  }
+
+  // brasilia-h3: overwrite the wrong facebookUrl (BrasiliaHHH → groups, #1980).
+  const bra = await prisma.kennel.findUnique({ where: { kennelCode: "brasilia-h3" } });
+  if (bra) {
+    const data: Record<string, string> = {};
+    if (bra.facebookUrl !== BRASILIA_FACEBOOK) data.facebookUrl = BRASILIA_FACEBOOK;
+    await applyProfile("brasilia-h3", data);
+  } else {
+    console.warn("  ⚠ kennel brasilia-h3 not found — skipping");
   }
 }
 

--- a/scripts/backfill-audit-brasilia-asu-auckland.ts
+++ b/scripts/backfill-audit-brasilia-asu-auckland.ts
@@ -119,22 +119,32 @@ async function refreshOneSource(name: string, days: number): Promise<void> {
 
 async function refreshForwardEvents(): Promise<void> {
   console.log(`\n=== Pass 2: forward event refresh (current/future) ===`);
+  const failed: string[] = [];
   for (const { name, days } of FORWARD_SOURCES) {
     try {
       await refreshOneSource(name, days);
     } catch (err) {
       // Failure isolation: one source's adapter/network error shouldn't abort
-      // the refresh for the others.
+      // the refresh for the others — but record it so the run still fails loud.
       console.error(`  ❌ ${name}: refresh failed —`, err);
+      failed.push(name);
     }
+  }
+  // Surface a partial refresh as a non-zero exit so automation sees it.
+  if (failed.length > 0) {
+    throw new Error(`Forward refresh failed for source(s): ${failed.join(", ")}`);
   }
 }
 
 async function main(): Promise<void> {
   console.log(APPLY ? "APPLY MODE — writing to DB" : "DRY RUN — no writes (pass --apply to write)");
-  await updateProfiles();
-  await refreshForwardEvents();
-  await prisma.$disconnect();
+  try {
+    await updateProfiles();
+    await refreshForwardEvents();
+  } finally {
+    // Always disconnect, even if a pass throws.
+    await prisma.$disconnect();
+  }
 }
 
 main().catch((err) => {

--- a/scripts/backfill-audit-brasilia-asu-auckland.ts
+++ b/scripts/backfill-audit-brasilia-asu-auckland.ts
@@ -1,0 +1,128 @@
+/**
+ * One-shot audit corrections for the Brasília / Asunción / Auckland cycle
+ * (#1959, #1980, #1981, #1982, #1983, #1960, #1964 — the current/future slice).
+ *
+ * Two passes:
+ *  1. Kennel profile fields the seed merge can't reach in prod:
+ *       - asu-h3: facebookUrl + gm (seed fill-null also works, but a full
+ *         `prisma db seed` would clobber sibling sessions' Source.config, so
+ *         touch only these rows).
+ *       - brasilia-h3: facebookUrl overwrite (BrasiliaHHH → groups/BrasiliaH3) —
+ *         a non-null change the fill-null seed merge would skip.
+ *  2. Forward refresh of CURRENT/FUTURE events for the three sources via the
+ *     live adapter + processRawEvents (NO reconcile → pure upsert, no cancels).
+ *     The PAST archives are handled by the per-kennel history backfills; this
+ *     pass updates the rolling/upcoming events (e.g. Brasília #340, Auckland's
+ *     upcoming list) with the new title/hares/location.
+ *
+ * PREREQUISITE for the PAST slice: title/hares/location are fingerprint inputs,
+ * so existing archive Events keep their old synthesized titles / null hares
+ * until the per-kennel history backfills are re-run with the regenerated JSON:
+ *   BACKFILL_APPLY=1 npx tsx scripts/backfill-brasilia-h3-history.ts
+ *   BACKFILL_APPLY=1 npx tsx scripts/backfill-asu-h3-history.ts
+ * (Regenerate the JSON first via scripts/generate-{brasilia,asu}-h3-history.ts.)
+ * This script only covers the current/future slice; run it after the backfills.
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-audit-brasilia-asu-auckland.ts
+ *   Apply:    npx tsx scripts/backfill-audit-brasilia-asu-auckland.ts --apply
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { getAdapter } from "@/adapters/registry";
+import { processRawEvents } from "@/pipeline/merge";
+
+const APPLY = process.argv.includes("--apply");
+
+interface ProfilePatch {
+  kennelCode: string;
+  /** Fields to set only when the current prod value is null (mirrors seed fill-null). */
+  fillNull?: Record<string, string>;
+  /** Fields to overwrite unconditionally (a known-wrong existing value). */
+  overwrite?: Record<string, string>;
+}
+
+const PROFILE_PATCHES: ProfilePatch[] = [
+  {
+    kennelCode: "asu-h3",
+    fillNull: {
+      facebookUrl: "https://www.facebook.com/groups/1254316384994089",
+      gm: "Ban The Cock (Eric)",
+    },
+  },
+  {
+    kennelCode: "brasilia-h3",
+    overwrite: { facebookUrl: "https://www.facebook.com/groups/BrasiliaH3" },
+  },
+];
+
+// Source NAME → forward scrape window (days). Asunción is future-only with no
+// upcoming events today, so its fetch returns nothing — harmless.
+const FORWARD_SOURCES: { name: string; days: number }[] = [
+  { name: "Brasilia H3 Blogspot Trail Posts", days: 120 },
+  { name: "Asunción H3 WordPress Run Posts", days: 120 },
+  { name: "Auckland H3 Website", days: 365 },
+];
+
+async function updateProfiles(): Promise<void> {
+  console.log(`\n=== Pass 1: kennel profiles ===`);
+  for (const patch of PROFILE_PATCHES) {
+    const kennel = await prisma.kennel.findUnique({
+      where: { kennelCode: patch.kennelCode },
+      select: { id: true, facebookUrl: true, gm: true },
+    });
+    if (!kennel) {
+      console.warn(`  ⚠ kennel ${patch.kennelCode} not found — skipping`);
+      continue;
+    }
+    const data: Record<string, string> = {};
+    for (const [k, v] of Object.entries(patch.fillNull ?? {})) {
+      if ((kennel as Record<string, unknown>)[k] == null) data[k] = v;
+    }
+    for (const [k, v] of Object.entries(patch.overwrite ?? {})) {
+      if ((kennel as Record<string, unknown>)[k] !== v) data[k] = v;
+    }
+    if (Object.keys(data).length === 0) {
+      console.log(`  ${patch.kennelCode}: already correct, no change`);
+      continue;
+    }
+    console.log(`  ${patch.kennelCode}: ${APPLY ? "updating" : "would update"} ${JSON.stringify(data)}`);
+    if (APPLY) await prisma.kennel.update({ where: { id: kennel.id }, data });
+  }
+}
+
+async function refreshForwardEvents(): Promise<void> {
+  console.log(`\n=== Pass 2: forward event refresh (current/future) ===`);
+  for (const { name, days } of FORWARD_SOURCES) {
+    const source = await prisma.source.findFirst({ where: { name } });
+    if (!source) {
+      console.warn(`  ⚠ source "${name}" not found — skipping`);
+      continue;
+    }
+    const adapter = getAdapter(source.type, source.url, source.config as Record<string, unknown> | null);
+    const result = await adapter.fetch(source, { days });
+    console.log(`  ${name}: fetched ${result.events.length} event(s)${result.errors.length ? ` (errors: ${result.errors.length})` : ""}`);
+    if (!APPLY) {
+      for (const e of result.events.slice(0, 5)) {
+        console.log(`     [dry] ${e.date} #${e.runNumber ?? "?"} title=${e.title ?? "—"} hares=${e.hares ?? "—"} loc=${e.location ?? "—"}`);
+      }
+      continue;
+    }
+    if (result.events.length === 0) continue;
+    const merged = await processRawEvents(source.id, result.events);
+    console.log(`     created=${merged.created} updated=${merged.updated} skipped=${merged.skipped} blocked=${merged.blocked} errors=${merged.eventErrors}`);
+    if (merged.blocked > 0) console.warn(`     ⚠ blocked tags: ${merged.blockedTags.join(", ")}`);
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(APPLY ? "APPLY MODE — writing to DB" : "DRY RUN — no writes (pass --apply to write)");
+  await updateProfiles();
+  await refreshForwardEvents();
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/backfill-audit-brasilia-asu-auckland.ts
+++ b/scripts/backfill-audit-brasilia-asu-auckland.ts
@@ -85,35 +85,43 @@ async function updateProfiles(): Promise<void> {
   }
 }
 
+/**
+ * Forward-refresh one source's current/future events. `name` is not unique, so
+ * use findMany(take:2) + length check (mirrors mergeRawEventsForSource) — a
+ * duplicate fails loud rather than silently scraping whichever row findFirst
+ * picked. Pure upsert via processRawEvents (no reconcile → no cancels).
+ */
+async function refreshOneSource(name: string, days: number): Promise<void> {
+  const sources = await prisma.source.findMany({ where: { name }, take: 2 });
+  if (sources.length === 0) {
+    console.warn(`  ⚠ source "${name}" not found — skipping`);
+    return;
+  }
+  if (sources.length > 1) {
+    throw new Error(`Multiple sources named "${name}" — refusing to guess which to scrape`);
+  }
+  const source = sources[0];
+  const adapter = getAdapter(source.type, source.url, source.config as Record<string, unknown> | null);
+  const result = await adapter.fetch(source, { days });
+  const errNote = result.errors.length ? ` (errors: ${result.errors.length})` : "";
+  console.log(`  ${name}: fetched ${result.events.length} event(s)${errNote}`);
+  if (!APPLY) {
+    for (const e of result.events.slice(0, 5)) {
+      console.log(`     [dry] ${e.date} #${e.runNumber ?? "?"} title=${e.title ?? "—"} hares=${e.hares ?? "—"} loc=${e.location ?? "—"}`);
+    }
+    return;
+  }
+  if (result.events.length === 0) return;
+  const merged = await processRawEvents(source.id, result.events);
+  console.log(`     created=${merged.created} updated=${merged.updated} skipped=${merged.skipped} blocked=${merged.blocked} errors=${merged.eventErrors}`);
+  if (merged.blocked > 0) console.warn(`     ⚠ blocked tags: ${merged.blockedTags.join(", ")}`);
+}
+
 async function refreshForwardEvents(): Promise<void> {
   console.log(`\n=== Pass 2: forward event refresh (current/future) ===`);
   for (const { name, days } of FORWARD_SOURCES) {
     try {
-      // `name` is not unique — use findMany(take:2) + length check (mirrors
-      // mergeRawEventsForSource) so a duplicate fails loud instead of silently
-      // scraping whichever row findFirst happened to pick.
-      const sources = await prisma.source.findMany({ where: { name }, take: 2 });
-      if (sources.length === 0) {
-        console.warn(`  ⚠ source "${name}" not found — skipping`);
-        continue;
-      }
-      if (sources.length > 1) {
-        throw new Error(`Multiple sources named "${name}" — refusing to guess which to scrape`);
-      }
-      const source = sources[0];
-      const adapter = getAdapter(source.type, source.url, source.config as Record<string, unknown> | null);
-      const result = await adapter.fetch(source, { days });
-      console.log(`  ${name}: fetched ${result.events.length} event(s)${result.errors.length ? ` (errors: ${result.errors.length})` : ""}`);
-      if (!APPLY) {
-        for (const e of result.events.slice(0, 5)) {
-          console.log(`     [dry] ${e.date} #${e.runNumber ?? "?"} title=${e.title ?? "—"} hares=${e.hares ?? "—"} loc=${e.location ?? "—"}`);
-        }
-        continue;
-      }
-      if (result.events.length === 0) continue;
-      const merged = await processRawEvents(source.id, result.events);
-      console.log(`     created=${merged.created} updated=${merged.updated} skipped=${merged.skipped} blocked=${merged.blocked} errors=${merged.eventErrors}`);
-      if (merged.blocked > 0) console.warn(`     ⚠ blocked tags: ${merged.blockedTags.join(", ")}`);
+      await refreshOneSource(name, days);
     } catch (err) {
       // Failure isolation: one source's adapter/network error shouldn't abort
       // the refresh for the others.

--- a/scripts/data/asu-h3-history.json
+++ b/scripts/data/asu-h3-history.json
@@ -5,6 +5,7 @@
       "asu-h3"
     ],
     "runNumber": 1,
+    "title": "Run #1",
     "hares": "Ma Bouche & Ban the Cock",
     "startTime": "16:00",
     "latitude": -25.23663263795628,
@@ -17,6 +18,7 @@
       "asu-h3"
     ],
     "runNumber": 2,
+    "title": "Run #2",
     "hares": "Ban the Cock",
     "location": "Plaza 1ro de Mayo, San Lorenzo; pin is where the shop is.",
     "cost": "20,000.- PYG (cash only).",
@@ -31,6 +33,7 @@
       "asu-h3"
     ],
     "runNumber": 3,
+    "title": "Run #3",
     "hares": "Ban the Cock",
     "location": "Edificio Malutin Lofts, end of cul-de-sac, only reachable from Malutin.",
     "cost": "20,000.- PYG (cash only). The money will cover drinks and snacks.",
@@ -45,6 +48,7 @@
       "asu-h3"
     ],
     "runNumber": 4,
+    "title": "Run #4",
     "hares": "Orificio",
     "location": "Nueva Colombia (1 hour drive from Asunción), field at calle Profesor Mendez Mendoza. Look for hashers.",
     "cost": "20,000.- PYG (cash only). The money will cover drinks and snacks.",
@@ -59,6 +63,7 @@
       "asu-h3"
     ],
     "runNumber": 5,
+    "title": "Run #5",
     "hares": "Ban the Cock",
     "location": "Edificio LIFE Villa Morra sobre Alberto de Souza, entre Zotti y Bogarin.",
     "cost": "20,000.- PYG (cash only). The money will cover drinks and snacks.",
@@ -73,6 +78,7 @@
       "asu-h3"
     ],
     "runNumber": 6,
+    "title": "Run #6",
     "hares": "Ban the Cock",
     "location": "El Café de Acá Textilia, Av. Gral. Máximo Santos 1030, Asunción.",
     "cost": "20,000.- PYG (cash only). The money will cover drinks and snacks.",
@@ -87,6 +93,7 @@
       "asu-h3"
     ],
     "runNumber": 7,
+    "title": "Run #7",
     "hares": "Ban the Cock",
     "location": "Plaza 1ro de Mayo, San Lorenzo.",
     "cost": "20,000.- PYG (cash only). The money will cover drinks and snacks.",
@@ -101,6 +108,7 @@
       "asu-h3"
     ],
     "runNumber": 8,
+    "title": "Run #8",
     "hares": "As you like it & Ban the Cock",
     "location": "Curda Gym (in front of the black hut that says CURDA & HEINEKEN), Calle Jasy, entre Cap. Domingo Antonio Ortiz y Cap. Elias Ayala, Asunción.",
     "cost": "15,000.- PYG (cash only). The money will cover drinks and snacks.",
@@ -115,6 +123,7 @@
       "asu-h3"
     ],
     "runNumber": 9,
+    "title": "Run #9",
     "hares": "Ban the Cock",
     "location": "Plaza Pedro Juan Caballero, opposite Casa Rica Los Laureles.",
     "cost": "15,000.- PYG (cash only). The money will cover drinks and snacks.",
@@ -129,6 +138,7 @@
       "asu-h3"
     ],
     "runNumber": 10,
+    "title": "Run #10",
     "hares": "Just Uğur & Ban the Cock",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
     "startTime": "15:00",
@@ -142,6 +152,7 @@
       "asu-h3"
     ],
     "runNumber": 11,
+    "title": "Run #11",
     "hares": "Ban the Cock",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
     "startTime": "15:00",
@@ -155,6 +166,7 @@
       "asu-h3"
     ],
     "runNumber": 12,
+    "title": "Run #12",
     "hares": "Ban the Cock",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
     "startTime": "15:00",
@@ -168,6 +180,7 @@
       "asu-h3"
     ],
     "runNumber": 13,
+    "title": "Run #13",
     "hares": "Ban the Cock",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
     "startTime": "15:00",
@@ -181,6 +194,7 @@
       "asu-h3"
     ],
     "runNumber": 14,
+    "title": "Run #14",
     "hares": "Just Laura & Just Carolina",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
     "startTime": "14:30",
@@ -194,6 +208,7 @@
       "asu-h3"
     ],
     "runNumber": 15,
+    "title": "Run #15",
     "hares": "Just Amydelle & Just Carolina",
     "cost": "see above.",
     "startTime": "14:00",
@@ -207,6 +222,7 @@
       "asu-h3"
     ],
     "runNumber": 16,
+    "title": "Run #16",
     "hares": "Trio: David, Amydelle, Carolina",
     "location": "Edificio Aurora, Caballero 223 c/ Eligio Ayala, depto. 21A",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -221,6 +237,7 @@
       "asu-h3"
     ],
     "runNumber": 17,
+    "title": "Run #17",
     "hares": "Ban the Cock & Double Dutch Mountain",
     "location": "Supermarket on the corner of 12 de Junio and República de Colombia in Isla Bogado (Luque).",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -235,6 +252,7 @@
       "asu-h3"
     ],
     "runNumber": 18,
+    "title": "Run #18",
     "hares": "Just Laura & Just Liz",
     "location": "Liz’ place, José del Rosario Miranda esquina Longino Santacruz",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -249,6 +267,7 @@
       "asu-h3"
     ],
     "runNumber": 19,
+    "title": "Run #19",
     "hares": "Ban the Cock & Double Dutch Mountain",
     "location": "F&A Resto in Lambaré (opposite la Despensa), Mayor Alfaro Ramos (between Los Alpes & Martiniano Ortiz)",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -263,6 +282,7 @@
       "asu-h3"
     ],
     "runNumber": 20,
+    "title": "Run #20",
     "hares": "Ban the Cock & Double Dutch Mountain",
     "location": "LomiToro’s in San Lorenzo, Aztecas c/ Rogelio Benitez.",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -277,6 +297,7 @@
       "asu-h3"
     ],
     "runNumber": 21,
+    "title": "Run #21",
     "hares": "Ban the Cock",
     "location": "Cemetery Flower Shop (Floreria) on the corner of Quesada & L. Fragnaud.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -291,6 +312,7 @@
       "asu-h3"
     ],
     "runNumber": 22,
+    "title": "Run #22",
     "hares": "Ban the Cock & Double Dutch Mountain",
     "location": "Palo Santo Brewing Co., 2nd Pub is opposite, Poros Brewing Co. (we stay at Poros until ca. 19:30).",
     "cost": "Pay as you go (food & drinks).",
@@ -305,6 +327,7 @@
       "asu-h3"
     ],
     "runNumber": 23,
+    "title": "Run #23",
     "hares": "Ban the Cock",
     "location": "Quinta Divino Niño Jesús in Luque.",
     "cost": "100,000.- Gs pp (incl. BBQ & all drinks)",
@@ -319,6 +342,7 @@
       "asu-h3"
     ],
     "runNumber": 24,
+    "title": "Run #24",
     "hares": "Ban the Cock & Double Dutch Mountain",
     "location": "Main entrance Cerro Ko’i.",
     "cost": "50,000.- Gs pp return trip.",
@@ -333,6 +357,7 @@
       "asu-h3"
     ],
     "runNumber": 25,
+    "title": "Run #25",
     "hares": "Ban the Cock",
     "location": "Edificio Malutin Loft, Villa Morra. Location can only be reached from Calle Malutin, enter cul-de-sac on the corner where the THREE Bar is, it’s at the end on the left side.",
     "cost": "5,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -347,6 +372,7 @@
       "asu-h3"
     ],
     "runNumber": 26,
+    "title": "Run #26",
     "hares": "Ban the Cock",
     "location": "Jardín Botánico, parking lot on the left after passing the main entrance.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -361,6 +387,7 @@
       "asu-h3"
     ],
     "runNumber": 27,
+    "title": "Run #27",
     "hares": "Ban the Cock",
     "location": "Gas station Energy-Laurelty, Ave. Gral. Eugenio A. Garay with Palo Santo (opposite the restaurant Araceli La Mexicana).",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -375,6 +402,7 @@
       "asu-h3"
     ],
     "runNumber": 28,
+    "title": "Run #28",
     "hares": "Ban the Cock",
     "location": "El Patio Resto-Bar, Epifanio Mendez Fleitas, corner of Cacique Lambare, Asunción.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -389,6 +417,7 @@
       "asu-h3"
     ],
     "runNumber": 29,
+    "title": "Run #29",
     "hares": "Christmas Carol and Long & Hard",
     "location": "Plaza Mburucuya",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -403,6 +432,7 @@
       "asu-h3"
     ],
     "runNumber": 30,
+    "title": "Run #30",
     "hares": "Ban the Cock",
     "location": "Lomiteria 24 de diciembre, Natalicio Talavera, San Lorenzo.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -417,6 +447,7 @@
       "asu-h3"
     ],
     "runNumber": 31,
+    "title": "Run #31",
     "hares": "Slumdog & Just Lisa",
     "location": "Quincho Resto Bar in Nanawa (Puerto Elsa) on the border with Argentina.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -431,6 +462,7 @@
       "asu-h3"
     ],
     "runNumber": 32,
+    "title": "Run #32",
     "hares": "Blind Pussy, Christmas Carol + Long & Hard",
     "location": "Sajonia Brewery Co. Cervecería, Alejo García 2589, Asunción.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -445,6 +477,7 @@
       "asu-h3"
     ],
     "runNumber": 33,
+    "title": "Run #33",
     "hares": "Silent G-Spot",
     "location": "Jardin Urbano, Luís Alberto de Herrera 2299 con Vice Pdte. Sanchez, Asunción",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and snacks in the circle.",
@@ -459,6 +492,7 @@
       "asu-h3"
     ],
     "runNumber": 34,
+    "title": "Run #34",
     "hares": "Just Andrea, Blind Pussy, and Just Daniel",
     "location": "Indigo Bar, Juan de Salazar 851, between Washington and Padre Cardozo.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks and special awards.",
@@ -473,6 +507,7 @@
       "asu-h3"
     ],
     "runNumber": 35,
+    "title": "Run #35",
     "hares": "As you like it, Just Silvia & Long and Hard.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle. Bring sunscreen, mosquito repellent, cash.",
     "startTime": "15:00",
@@ -486,6 +521,7 @@
       "asu-h3"
     ],
     "runNumber": 36,
+    "title": "Run #36",
     "hares": "Orificio",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle. Bring sunscreen, mosquito repellent, cash.",
     "startTime": "15:00",
@@ -499,6 +535,7 @@
       "asu-h3"
     ],
     "runNumber": 37,
+    "title": "Run #37",
     "hares": "Frosty Balls & Just Andrea",
     "location": "Parking Lot (Pin) on Denis Roa, close to Mariscal Antonio José Sucre.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle. Bring sunscreen, mosquito repellent, cash.",
@@ -513,6 +550,7 @@
       "asu-h3"
     ],
     "runNumber": 38,
+    "title": "Run #38",
     "hares": "Feliz & Bedsheets",
     "location": "Javorai, América 486 with Avda. España, Asunción.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle. Bring sunscreen, mosquito repellent, cash.",
@@ -527,6 +565,7 @@
       "asu-h3"
     ],
     "runNumber": 39,
+    "title": "Run #39",
     "cost": "10,000.- PYG (sólo en efectivo). El dinero servirá para cubrir las bebidas ‘down down’. Llevar repelente de mosquitos, dinero en efectivo.",
     "startTime": "15:00",
     "latitude": -25.28808851348442,
@@ -539,6 +578,7 @@
       "asu-h3"
     ],
     "runNumber": 40,
+    "title": "Run #40",
     "hares": "Ban the Cock",
     "location": "Hansel & Grettel, opposite Parroquia de Las Mercedes, Padre Egidio Cardozo between Intendentes Militares and Defensa Nacional.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -553,6 +593,7 @@
       "asu-h3"
     ],
     "runNumber": 41,
+    "title": "Run #41",
     "hares": "Frosty Balls, Dr. Cummm & Sugar Baby",
     "location": "Lomiteria Town & Owl, Carretera de López, Lambaré.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -567,6 +608,7 @@
       "asu-h3"
     ],
     "runNumber": 42,
+    "title": "Run #42",
     "hares": "The Village Idiot & Just John",
     "location": "Pizza Maui, Av. Acuña de Figueroa con Iturbe, Asunción",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -581,6 +623,7 @@
       "asu-h3"
     ],
     "runNumber": 43,
+    "title": "Run #43",
     "hares": "Dr. Cummm",
     "location": "Kilkenny, Carmelitas Bar Area",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -595,6 +638,7 @@
       "asu-h3"
     ],
     "runNumber": 44,
+    "title": "Run #44",
     "hares": "Long & Hard and Christmas Carol",
     "location": "American Bar Py, Atilio Peña Machain with Florida, Centro, Asunción",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -609,6 +653,7 @@
       "asu-h3"
     ],
     "runNumber": 45,
+    "title": "Run #45",
     "hares": "Slumdog & Just Denisse",
     "location": "Escuela Primer Presidente (Velazquez and Alvarenga, very near Slumdog’s house) in Asunción.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -623,6 +668,7 @@
       "asu-h3"
     ],
     "runNumber": 46,
+    "title": "Run #46",
     "hares": "Just Andrei & Orificio",
     "cost": "10,000.- PYG (sólo en efectivo). El dinero servirá para cubrir las bebidas ‘down down’. Llevar repelente de mosquitos, dinero en efectivo.",
     "startTime": "13:00",
@@ -636,6 +682,7 @@
       "asu-h3"
     ],
     "runNumber": 47,
+    "title": "Run #47",
     "hares": "Ban the Cock",
     "location": "Mercado Don Francisco, Coronel Martínez, Luque.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -650,6 +697,7 @@
       "asu-h3"
     ],
     "runNumber": 48,
+    "title": "Run #48",
     "hares": "As You Like It & Long and Hard",
     "location": "Plaza Asunción, Asunción.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -664,6 +712,7 @@
       "asu-h3"
     ],
     "runNumber": 49,
+    "title": "Run #49",
     "hares": "FAB & Slumdog",
     "location": "A (start) is at Gomería Betel.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -673,25 +722,12 @@
     "sourceUrl": "https://asuncionh3.wordpress.com/2023/10/16/run-49/"
   },
   {
-    "date": "2023-11-18",
-    "kennelTags": [
-      "asu-h3"
-    ],
-    "runNumber": 50,
-    "hares": "Ban the Cock & Double Dutch Mountain",
-    "location": "See above.",
-    "cost": "150,000 Gs, incl. bus trip, boat, all drinks (incl. drink stops), and BBQ.",
-    "startTime": "15:30",
-    "latitude": -25.287943951382363,
-    "longitude": -57.58042010142985,
-    "sourceUrl": "https://asuncionh3.wordpress.com/2023/10/16/run-50/"
-  },
-  {
     "date": "2023-11-16",
     "kennelTags": [
       "asu-h3"
     ],
     "runNumber": 51,
+    "title": "Run #51",
     "hares": "Ban the Cock & Double Dutch Mountain",
     "location": "Plaza Manuel Ortiz Guerrero y José Asunción Flores, opposite the female prison. Meet at the furthest north-west corner of the park, next to Sta. Rosa street.",
     "cost": "10,000.- Gs (cash only).",
@@ -706,6 +742,7 @@
       "asu-h3"
     ],
     "runNumber": 52,
+    "title": "Run #52",
     "hares": "Blind Pussy & Ban the Cock",
     "location": "Mahatma Gandhi monument on the Costanera de Asunción (beach).",
     "cost": "Circle included in rego-fee.",
@@ -715,11 +752,27 @@
     "sourceUrl": "https://asuncionh3.wordpress.com/2023/10/16/run-52/"
   },
   {
+    "date": "2023-11-18",
+    "kennelTags": [
+      "asu-h3"
+    ],
+    "runNumber": 50,
+    "title": "Run #50",
+    "hares": "Ban the Cock & Double Dutch Mountain",
+    "location": "See above.",
+    "cost": "150,000 Gs, incl. bus trip, boat, all drinks (incl. drink stops), and BBQ.",
+    "startTime": "15:30",
+    "latitude": -25.287943951382363,
+    "longitude": -57.58042010142985,
+    "sourceUrl": "https://asuncionh3.wordpress.com/2023/10/16/run-50/"
+  },
+  {
     "date": "2023-11-19",
     "kennelTags": [
       "asu-h3"
     ],
     "runNumber": 53,
+    "title": "Run #53",
     "hares": "Ban the Cock & Double Dutch Mountain.",
     "location": "See above.",
     "cost": "100,000 Gs, incl. bus trip, drink stops and circle drinks.",
@@ -734,6 +787,7 @@
       "asu-h3"
     ],
     "runNumber": 54,
+    "title": "Run #54",
     "hares": "Ban the Cock & DDM",
     "location": "Los Guaraníes Square/Playground, meet at north side (calle San Mateo) at the playground.",
     "cost": "10,000.- Gs (cash only).",
@@ -748,6 +802,7 @@
       "asu-h3"
     ],
     "runNumber": 55,
+    "title": "Run #55",
     "hares": "Christmas Carol and Long & Hard",
     "location": "on the corner of Avenida República Argentina with Alfredo Seiferheld, Asunción.",
     "startTime": "16:30",
@@ -761,6 +816,7 @@
       "asu-h3"
     ],
     "runNumber": 56,
+    "title": "Run #56",
     "hares": "Just Jackie and BtC",
     "location": "Malutin Loft Quincho, cul-de-sac Callejon Comandante Cardenas with Malutin (entre Lillo & Sucre). Enter the cul-de-sac where the THREE Bar & Lounge is, entrance is at the end on your left. Ask for Harma or Eric, Bloque B, Dept. 2C.",
     "cost": "FREE",
@@ -775,6 +831,7 @@
       "asu-h3"
     ],
     "runNumber": 57,
+    "title": "Run #57",
     "hares": "Ban the Cock",
     "location": "Despensa Buen Día in San Blas",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -789,6 +846,7 @@
       "asu-h3"
     ],
     "runNumber": 58,
+    "title": "Run #58",
     "hares": "Frosty Balls & Long and Hard",
     "location": "Plaza Zaragoza in Mariano Roque Alonso, Avenida Remanso with Zaragoza.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -803,6 +861,7 @@
       "asu-h3"
     ],
     "runNumber": 59,
+    "title": "Run #59",
     "hares": "PipiPupu & TVI",
     "location": "Plaza Carmen de Lara Castro",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -817,6 +876,7 @@
       "asu-h3"
     ],
     "runNumber": 60,
+    "title": "Run #60",
     "hares": "The Norwegian",
     "location": "Guasu Metropolitan Park.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -831,6 +891,7 @@
       "asu-h3"
     ],
     "runNumber": 61,
+    "title": "Run #61",
     "hares": "Christmas Carol and Long & Hard",
     "location": "Let’s meet at the Fruteria next to “El Asadito Arroyense”",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -845,6 +906,7 @@
       "asu-h3"
     ],
     "runNumber": 62,
+    "title": "Run #62",
     "hares": "Dr. Cummm & Sugar Baby",
     "location": "Nacion Sushi Bar",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -859,6 +921,7 @@
       "asu-h3"
     ],
     "runNumber": 63,
+    "title": "Run #63",
     "hares": "Blind Pussy & Frosty Balls",
     "location": "Yaguarón, Museo Dr. Francia",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -873,6 +936,7 @@
       "asu-h3"
     ],
     "runNumber": 64,
+    "title": "Run #64",
     "hares": "Bee on Top and Long & Hard",
     "location": "La Esquinita Bar, Tte. Jose Felix Lopez and Aztecas, San Pablo, Asunción.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -887,6 +951,7 @@
       "asu-h3"
     ],
     "runNumber": 65,
+    "title": "Run #65",
     "hares": "CC and Long & Hard",
     "location": "Edificio Nautilius, 25 de Mayo with Curupayty.",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -901,6 +966,7 @@
       "asu-h3"
     ],
     "runNumber": 66,
+    "title": "Run #66",
     "hares": "Sugar Baby and Just Lui",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
     "startTime": "13:15",
@@ -914,6 +980,7 @@
       "asu-h3"
     ],
     "runNumber": 67,
+    "title": "Run #67",
     "hares": "Bubbles & Ban the Cock",
     "location": "Mr. Boss, Victor Hugo 1746 (btw. Emilio Castelar and Cervantes Saavedra).",
     "cost": "10,000.- PYG (cash only). The money will cover down down drinks in the circle.",
@@ -928,6 +995,7 @@
       "asu-h3"
     ],
     "runNumber": 68,
+    "title": "Run #68",
     "hares": "Slumdog & Low Lay Lisa",
     "cost": "ca. 80,000.- PYG (cash only). The money will cover the bus and down down drinks in the circle.",
     "startTime": "12:30",
@@ -941,6 +1009,7 @@
       "asu-h3"
     ],
     "runNumber": 69,
+    "title": "Run #69",
     "hares": "Blind Pussy & Just Mariela",
     "location": "Mahatma Gandhi monument on the Costanera de Asunción (beach).",
     "cost": "10,000 Gs for the circle drinks.",
@@ -955,6 +1024,7 @@
       "asu-h3"
     ],
     "runNumber": 70,
+    "title": "Run #70",
     "hares": "Ban the Cock",
     "location": "Lomiteria 24 de diciembre, Natalicio Talavera, San Lorenzo.",
     "cost": "10,000 Gs for the circle drinks.",
@@ -969,6 +1039,7 @@
       "asu-h3"
     ],
     "runNumber": 71,
+    "title": "Run #71",
     "hares": "Long & Hard and Feliz",
     "location": "Gas Station – Copetrol in San Lorenzo, Ruta Departamental D027 with Calle Buenos Aires.",
     "cost": "25,000 Gs for the circle drinks and two drink stops.",
@@ -983,6 +1054,7 @@
       "asu-h3"
     ],
     "runNumber": 72,
+    "title": "Run #72",
     "hares": "Ban the Cock",
     "location": "Plaza Heroes Del Chaco, Avenida Santisima Trinidad, corner with Bodega “La Troya”.",
     "cost": "10,000 Gs for the circle drinks.",
@@ -997,6 +1069,7 @@
       "asu-h3"
     ],
     "runNumber": 73,
+    "title": "Run #73",
     "hares": "Uncut & Fartacus",
     "location": "Sinaloa Pizza & Mexican Food, Avenida José Félix Bogado with Campo Via, Asunción",
     "cost": "10,000 Gs for the circle drinks.",
@@ -1009,6 +1082,7 @@
       "asu-h3"
     ],
     "runNumber": 74,
+    "title": "Run #74",
     "hares": "Dr. Cummm",
     "location": "Residencia Irachet, between Santa Rosa de Lima and Constitución Nacional",
     "cost": "10,000 Gs for the circle drinks.",
@@ -1023,6 +1097,7 @@
       "asu-h3"
     ],
     "runNumber": 75,
+    "title": "Run #75",
     "hares": "Uncut and Long & Hard",
     "location": "El Comandante, Choferes del Chaco with Chaco Boreal, Asunción.",
     "cost": "10,000 Gs for the circle drinks.",
@@ -1037,6 +1112,7 @@
       "asu-h3"
     ],
     "runNumber": 76,
+    "title": "Run #76",
     "hares": "Blind Pussy & Just Mary",
     "location": "Far side of Heroes del Chaco Bridge.",
     "cost": "10,000 Gs for drink stops and circle drinks.",
@@ -1049,6 +1125,7 @@
       "asu-h3"
     ],
     "runNumber": 77,
+    "title": "Run #77",
     "hares": "Ban the Cock",
     "location": "Despensa Ña Berna, end of Cnel. Enrique García de Zuñiga, Asunción.",
     "cost": "0 Gs for drink stops and circle drinks.",
@@ -1063,6 +1140,7 @@
       "asu-h3"
     ],
     "runNumber": 78,
+    "title": "Run #78",
     "hares": "Uncut & Ban the Cock",
     "location": "Costanera Sur Gymnasium Area",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1077,6 +1155,7 @@
       "asu-h3"
     ],
     "runNumber": 79,
+    "title": "Run #79",
     "hares": "Long & Hard, Christmas Carol",
     "location": "Royal Container, Abdon Palacios with Mayor Alfredo Placita, Cd. del Este.",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1091,6 +1170,7 @@
       "asu-h3"
     ],
     "runNumber": 80,
+    "title": "Run #80",
     "hares": "Long & Hard",
     "location": "Saltos de Monday (entrance gate)",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1105,6 +1185,7 @@
       "asu-h3"
     ],
     "runNumber": 81,
+    "title": "Run #81",
     "hares": "Ban the Cock",
     "location": "Petrobras Station in Fernando de la Morra, meet at the small park in the back (see photo above).",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1119,6 +1200,7 @@
       "asu-h3"
     ],
     "runNumber": 82,
+    "title": "Run #82",
     "hares": "Long & Hard and Christmas Carol",
     "location": "Estacion de Servicio BR, Avenida Peru with Lomas Valentinas, Asunción.",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1133,6 +1215,7 @@
       "asu-h3"
     ],
     "runNumber": 83,
+    "title": "Run #83",
     "hares": "Uncut",
     "location": "Capilla de las Carmelitas Descalzas, Nuestra Señora del Carmen with San Rafael",
     "cost": "10,000.- Gs for the circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1147,6 +1230,7 @@
       "asu-h3"
     ],
     "runNumber": 84,
+    "title": "Run #84",
     "hares": "Ban the Cock",
     "location": "Barbakóa, Florida 1008 with Dr Pedro Ciancio, Jara, Asunción",
     "cost": "10,000.- Gs for the circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1161,6 +1245,7 @@
       "asu-h3"
     ],
     "runNumber": 85,
+    "title": "Run #85",
     "hares": "Ban the Cock & Faucet (partly)",
     "location": "All trails (M/L) start & end at Quinta “El Legendario” at 15:30.",
     "cost": "100,000.- Gs incl. all drinks & food at the quinta, swimming pool.",
@@ -1175,6 +1260,7 @@
       "asu-h3"
     ],
     "runNumber": 86,
+    "title": "Run #86",
     "hares": "Ban the Cock",
     "location": "ASUNCION sign",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1189,6 +1275,7 @@
       "asu-h3"
     ],
     "runNumber": 87,
+    "title": "Run #87",
     "hares": "The Norwegian",
     "location": "Biggie Express – Molas López",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1203,6 +1290,7 @@
       "asu-h3"
     ],
     "runNumber": 88,
+    "title": "Run #88",
     "hares": "Ban the Cock",
     "location": "Tronqui FC field in Luque. Picuiba & Yataity Cora.",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1217,6 +1305,7 @@
       "asu-h3"
     ],
     "runNumber": 89,
+    "title": "Run #89",
     "hares": "Rum & Coke",
     "location": "Pizzeria Kevin, Vicente Iturbe and José de Antequera y Castro, Ñemby.",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1231,6 +1320,7 @@
       "asu-h3"
     ],
     "runNumber": 90,
+    "title": "Run #90",
     "hares": "Uncut",
     "location": "Estatua De Las Residentas, Luque.",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1245,6 +1335,7 @@
       "asu-h3"
     ],
     "runNumber": 91,
+    "title": "Run #91",
     "hares": "Blind Pussy & Just Mary",
     "location": "Mahatma Gandhi monument on the Costanera de Asunción (beach).",
     "cost": "10,000.- Gs for circle drinks at the last drink stop, incl. snacks. Bring sunscreen, mosquito repellent, cash.",
@@ -1259,6 +1350,7 @@
       "asu-h3"
     ],
     "runNumber": 92,
+    "title": "Run #92",
     "hares": "Ban the Cock & Baboon",
     "startTime": "13:30",
     "latitude": -25.287379569623624,
@@ -1271,6 +1363,7 @@
       "asu-h3"
     ],
     "runNumber": 93,
+    "title": "Run #93",
     "hares": "Ban the Cock",
     "startTime": "13:30",
     "latitude": -25.287379569623624,
@@ -1283,6 +1376,7 @@
       "asu-h3"
     ],
     "runNumber": 94,
+    "title": "Run #94",
     "hares": "Ban the Cock",
     "location": "Gazebo Bar, Acosta Ñu 365 with San Bernardino, Lambaré.",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1297,6 +1391,7 @@
       "asu-h3"
     ],
     "runNumber": 95,
+    "title": "Run #95",
     "hares": "Uncut",
     "location": "Javorai Boggiani, Boggiani with R.I. 2 Ytororo, Asunción.",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1311,6 +1406,7 @@
       "asu-h3"
     ],
     "runNumber": 96,
+    "title": "Run #96",
     "hares": "Long and Hard & As You Like It",
     "location": "Medialunas Calentitas in Luque.",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1325,6 +1421,7 @@
       "asu-h3"
     ],
     "runNumber": 97,
+    "title": "Run #97",
     "hares": "Ban the Cock",
     "location": "Plaza Julio César Franco, corner of Capitán Figari and Rca. de Colombia, Asunción.",
     "cost": "10,000.- Gs for circle drinks.",
@@ -1339,6 +1436,7 @@
       "asu-h3"
     ],
     "runNumber": 98,
+    "title": "Run #98",
     "hares": "Blind Pussy and Just Mary",
     "location": "Bus stop on the D075 (Avda Primer Presidente).",
     "cost": "15,000.- Gs for circle drinks and the boat trip. Bring sunscreen, mosquito repellent, cash.",
@@ -1353,6 +1451,7 @@
       "asu-h3"
     ],
     "runNumber": 99,
+    "title": "Run #99",
     "hares": "As You Like It & Feliz",
     "location": "Lido Bar San Lorenzo",
     "cost": "10,000.- Gs for circle drinks and first private beer stop. Bring sunscreen, mosquito repellent, cash.",
@@ -1367,6 +1466,7 @@
       "asu-h3"
     ],
     "runNumber": 100,
+    "title": "Run #100",
     "hares": "Ban the Cock",
     "location": "Plaza Crispin Torres in Mora Kue, Luque.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1381,6 +1481,7 @@
       "asu-h3"
     ],
     "runNumber": 101,
+    "title": "Run #101",
     "hares": "Ban the Cock",
     "location": "BENTINO, Libertad (btw. Santa Lucía and Cristóbal Colón), San Lorenzo.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1395,6 +1496,7 @@
       "asu-h3"
     ],
     "runNumber": 102,
+    "title": "Run #102",
     "hares": "Ban the Cock",
     "location": "Lamora Burger, Andrés Barbero & Usher Rios, Fernando de la Mora.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1409,6 +1511,7 @@
       "asu-h3"
     ],
     "runNumber": 103,
+    "title": "Run #103",
     "hares": "Rum & Coke",
     "location": "Morphy Hamburguesas, Coronel Cabrera 554 (btw. Bertoni and 4 de Julio), Asunción.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1423,6 +1526,7 @@
       "asu-h3"
     ],
     "runNumber": 104,
+    "title": "Run #104",
     "hares": "Ban the Cock",
     "location": "Pyhare Pizzas, Luque, Felipe Gonzales & Washington.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash. Warm clothes for after the trail.",
@@ -1437,6 +1541,7 @@
       "asu-h3"
     ],
     "runNumber": 105,
+    "title": "Run #105",
     "hares": "The Norwegian",
     "location": "Biggie Express Molas Lopez, Asunción.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash. Warm clothes for after the trail.",
@@ -1451,6 +1556,7 @@
       "asu-h3"
     ],
     "runNumber": 106,
+    "title": "Run #106",
     "hares": "Blind Pussy & Just Mary",
     "location": "on Costanera at Entrance to Reserva de Banco San Miguel.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1465,6 +1571,7 @@
       "asu-h3"
     ],
     "runNumber": 107,
+    "title": "Run #107",
     "hares": "Just Rut & Just Fran",
     "location": "Cementerio Lambaré.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1479,6 +1586,7 @@
       "asu-h3"
     ],
     "runNumber": 108,
+    "title": "Run #108",
     "hares": "Long & Hard and As You Like It",
     "location": "Cafe next to Circo Hostel Bar.",
     "cost": "10,000.- Gs for circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1493,6 +1601,7 @@
       "asu-h3"
     ],
     "runNumber": 109,
+    "title": "Run #109",
     "hares": "Ban the Cock & Weeny Schnitzel",
     "location": "Quinta NR in Luque. Organise your own transport.",
     "cost": "100,000.- Gs for all drinks, food, and the quinta. Bring sunscreen, mosquito repellent, cash, swim gear, towel, change of clothes.",
@@ -1507,6 +1616,7 @@
       "asu-h3"
     ],
     "runNumber": 110,
+    "title": "Run #110",
     "hares": "Blind Pussy, Just Mary, Angry Pirate",
     "location": "Monumento de Hierro.",
     "cost": "10,000.- Gs for the circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1521,6 +1631,7 @@
       "asu-h3"
     ],
     "runNumber": 111,
+    "title": "Run #111",
     "hares": "DDM & Blind Pussy",
     "location": "Blind Pussy’s apartment, Ed. Aurora, Caballero 223 with Eligio Ayala, depto 21A",
     "cost": "10,000.- Gs for the circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1535,6 +1646,7 @@
       "asu-h3"
     ],
     "runNumber": 112,
+    "title": "Run #112",
     "hares": "Ban the Cock",
     "location": "Bodega LA TROYA, Avenida Santísima Trinidad and Vía Férrea, Asunción.",
     "cost": "10,000.- Gs for the circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1549,6 +1661,7 @@
       "asu-h3"
     ],
     "runNumber": 113,
+    "title": "Run #113",
     "hares": "The Addams Family",
     "location": "Biggie Express Pacheco.",
     "cost": "10,000.- Gs for the circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1563,6 +1676,7 @@
       "asu-h3"
     ],
     "runNumber": 114,
+    "title": "Run #114",
     "hares": "Uncut & Angry Pirate",
     "location": "❤️YO AMO ASU sign❤️on the Costanera.",
     "cost": "10,000.- Gs for the circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1577,6 +1691,7 @@
       "asu-h3"
     ],
     "runNumber": 115,
+    "title": "Run #115",
     "hares": "Christmas Carol & Dr. Cummm",
     "location": "Plaza Julio César Franco, barrio Pettirossi, Asunción",
     "cost": "10,000.- Gs for the circle drinks. Bring sunscreen, mosquito repellent, cash.",
@@ -1591,6 +1706,7 @@
       "asu-h3"
     ],
     "runNumber": 116,
+    "title": "Run #116",
     "hares": "Blind Pussy + mystery harriette(s)",
     "location": "Jardín Botánico parking lot. Point A.",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1605,6 +1721,7 @@
       "asu-h3"
     ],
     "runNumber": 117,
+    "title": "Run #117",
     "hares": "Dr. C. & As You Like It",
     "location": "La Cuadrita, Recoleta. Corner Alberto De Sousa con Cruz del Defensor.",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1619,6 +1736,7 @@
       "asu-h3"
     ],
     "runNumber": 118,
+    "title": "Run #118",
     "hares": "Joyful Elf & Just Gonzalo",
     "location": "Tatakua Alfajores, Avda. De Las Garzas and Concepción Leyes de Cháve. Close to the Costanera.",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1633,6 +1751,7 @@
       "asu-h3"
     ],
     "runNumber": 119,
+    "title": "Run #119",
     "hares": "The Norwegian",
     "location": "Biggie Express Molas López.",
     "cost": "10,000.- Gs for the circle drinks.",
@@ -1647,6 +1766,7 @@
       "asu-h3"
     ],
     "runNumber": 120,
+    "title": "Run #120",
     "hares": "Ban the Cock",
     "location": "Plaza Celsa Speratti, ASU H3 foundation stone",
     "cost": "Buy your own drinks at circle location (restaurant).",

--- a/scripts/data/brasilia-h3-history.json
+++ b/scripts/data/brasilia-h3-history.json
@@ -5,6 +5,7 @@
       "brasilia-h3"
     ],
     "runNumber": 154,
+    "title": "Hash N+154 - Easter Hash - Sunday, 21st of April",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/04/blog-post_12.html"
   },
   {
@@ -13,6 +14,7 @@
       "brasilia-h3"
     ],
     "runNumber": 155,
+    "title": "Hash N+155 - \"Monument Hash\" - Sunday, 5th of May",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/04/blog-post.html"
   },
   {
@@ -21,6 +23,7 @@
       "brasilia-h3"
     ],
     "runNumber": 156,
+    "title": "Hash N+156 - \"Virgin Hare Hash\" - Sunday, 19th of May",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/05/blog-post.html"
   },
   {
@@ -29,6 +32,7 @@
       "brasilia-h3"
     ],
     "runNumber": 157,
+    "title": "Hash N+157 & N+158 & N+159",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/05/blog-post_20.html"
   },
   {
@@ -37,6 +41,7 @@
       "brasilia-h3"
     ],
     "runNumber": 160,
+    "title": "Hash N+160 - \"Samba Hash\" - Sunday, 16th of June",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/06/blog-post.html"
   },
   {
@@ -45,6 +50,7 @@
       "brasilia-h3"
     ],
     "runNumber": 161,
+    "title": "Hash N+161 - \"Military Area Hash\" - Sunday, 30th of June",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/06/blog-post_24.html"
   },
   {
@@ -53,6 +59,7 @@
       "brasilia-h3"
     ],
     "runNumber": 162,
+    "title": "Hash N+162 - \"Bush Hash\" - Sunday, 14th of July",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/07/blog-post.html"
   },
   {
@@ -61,6 +68,7 @@
       "brasilia-h3"
     ],
     "runNumber": 163,
+    "title": "Hash N+163 - \"National Forest Hash\" - Sunday, 28th of July",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/07/blog-post_20.html"
   },
   {
@@ -69,6 +77,7 @@
       "brasilia-h3"
     ],
     "runNumber": 164,
+    "title": "Hash N+164 - \"Vila Planalto Hash\" - Sunday, 11th of August",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/08/blog-post.html"
   },
   {
@@ -77,6 +86,7 @@
       "brasilia-h3"
     ],
     "runNumber": 165,
+    "title": "Hash N+165 - \"Naming Hash\" - Sunday, 25th of August",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/08/blog-post_18.html"
   },
   {
@@ -85,6 +95,7 @@
       "brasilia-h3"
     ],
     "runNumber": 166,
+    "title": "Hash N+166 - \"Birthday Hash\" - Sunday, 8th of September",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/08/blog-post_30.html"
   },
   {
@@ -93,6 +104,7 @@
       "brasilia-h3"
     ],
     "runNumber": 167,
+    "title": "Hash N+167 - \"Africa Hash\" - Sunday, 22nd of September",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/09/blog-post.html"
   },
   {
@@ -101,6 +113,7 @@
       "brasilia-h3"
     ],
     "runNumber": 168,
+    "title": "Hash N+168 - \"Irish Hash\" - Sunday, 6th of October",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/10/blog-post.html"
   },
   {
@@ -109,6 +122,7 @@
       "brasilia-h3"
     ],
     "runNumber": 169,
+    "title": "Hash N+169 \"Surströmming Hash\" - Sunday, 20th of October",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/10/blog-post_10.html"
   },
   {
@@ -117,6 +131,7 @@
       "brasilia-h3"
     ],
     "runNumber": 170,
+    "title": "Hash N+170 \"Savannah Dry Hash\" - Sunday, 3rd of November",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/10/blog-post_27.html"
   },
   {
@@ -125,6 +140,7 @@
       "brasilia-h3"
     ],
     "runNumber": 171,
+    "title": "Hash N+171 \"Back to the Park\" - Sunday, 17th of November",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/11/blog-post.html"
   },
   {
@@ -133,6 +149,7 @@
       "brasilia-h3"
     ],
     "runNumber": 172,
+    "title": "Hash N+172 \"Virgin Hare Hash\" - Sunday, 1st of December",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/11/blog-post_19.html"
   },
   {
@@ -141,6 +158,7 @@
       "brasilia-h3"
     ],
     "runNumber": 173,
+    "title": "Hash N+173 \"Christmas Hash\" - Sunday, 15th of December",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/12/blog-post.html"
   },
   {
@@ -149,6 +167,7 @@
       "brasilia-h3"
     ],
     "runNumber": 174,
+    "title": "Hash N+174 \"Last In 2019\" - Sunday, 29th of December",
     "sourceUrl": "https://brasiliah3.blogspot.com/2019/12/blog-post_22.html"
   },
   {
@@ -157,6 +176,7 @@
       "brasilia-h3"
     ],
     "runNumber": 175,
+    "title": "Hash N+175 \"Welcome 2020\" - Sunday, 12th of January 2020",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/01/blog-post.html"
   },
   {
@@ -165,6 +185,7 @@
       "brasilia-h3"
     ],
     "runNumber": 176,
+    "title": "Hash N+176 \"Graffiti Hash\" - Sunday, 26th of January 2020",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/01/blog-post_18.html"
   },
   {
@@ -173,6 +194,7 @@
       "brasilia-h3"
     ],
     "runNumber": 177,
+    "title": "Hash N+177 \"Naming Hash\" - Sunday, 9th of February 2020",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/02/blog-post.html"
   },
   {
@@ -181,6 +203,7 @@
       "brasilia-h3"
     ],
     "runNumber": 178,
+    "title": "Hash N+178 \"Carnaval Hash\" - Sunday, 23rd of February",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/02/blog-post_14.html"
   },
   {
@@ -189,6 +212,7 @@
       "brasilia-h3"
     ],
     "runNumber": 179,
+    "title": "Hash N+179 \"Corona Hash\" - Sunday, 8th of March",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/02/blog-post_29.html"
   },
   {
@@ -197,6 +221,7 @@
       "brasilia-h3"
     ],
     "runNumber": 180,
+    "title": "Hash N+180 \"Social Distancing Hash\" - Sunday, 3rd of May",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/04/blog-post.html"
   },
   {
@@ -204,16 +229,18 @@
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 182,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2020/05/blog-post_19.html"
+    "runNumber": 181,
+    "title": "Hash N+181 \"Social Distancing Hash\" - Sunday, 17th of May",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/05/blog-post.html"
   },
   {
     "date": "2020-05-17",
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 181,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2020/05/blog-post.html"
+    "runNumber": 182,
+    "title": "Hash N+182 \"Social Distancing Hash 3\" - Sunday, 17th of May",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/05/blog-post_19.html"
   },
   {
     "date": "2020-06-14",
@@ -221,6 +248,7 @@
       "brasilia-h3"
     ],
     "runNumber": 183,
+    "title": "Hash N+183 \"Social Distancing Hash 4\" - Sunday, 14th of June",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/06/blog-post.html"
   },
   {
@@ -229,6 +257,7 @@
       "brasilia-h3"
     ],
     "runNumber": 184,
+    "title": "Hash N+184 \"Social Distancing Hash 5\" - Sunday, 28th of June",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/06/blog-post_16.html"
   },
   {
@@ -236,16 +265,18 @@
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 186,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2020/07/blog-post_16.html"
+    "runNumber": 185,
+    "title": "Hash N+185 \"Festa Junina Hash\" - Sunday, 12th of July",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/07/blog-post.html"
   },
   {
     "date": "2020-07-12",
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 185,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2020/07/blog-post.html"
+    "runNumber": 186,
+    "title": "Hash N+186 \"Buddha Hash\" - Sunday, 12th of July",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/07/blog-post_16.html"
   },
   {
     "date": "2020-08-09",
@@ -253,6 +284,7 @@
       "brasilia-h3"
     ],
     "runNumber": 187,
+    "title": "Hash N+187 \"Bush Hash\" - Sunday, 9th of August",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/08/blog-post.html"
   },
   {
@@ -261,6 +293,7 @@
       "brasilia-h3"
     ],
     "runNumber": 188,
+    "title": "Hash N+188 \"CL Final Hash\" - Sunday, 23rd of August",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/08/blog-post_17.html"
   },
   {
@@ -269,6 +302,7 @@
       "brasilia-h3"
     ],
     "runNumber": 189,
+    "title": "Hash N+189 \"Austrian Hash\" - Sunday, 6th of September",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/08/blog-post_31.html"
   },
   {
@@ -277,6 +311,7 @@
       "brasilia-h3"
     ],
     "runNumber": 190,
+    "title": "Hash N+190 \"City Hash\" - Sunday, 20th of September",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/09/blog-post.html"
   },
   {
@@ -285,6 +320,7 @@
       "brasilia-h3"
     ],
     "runNumber": 191,
+    "title": "Hash N+191 \"Oktoberfest Hash\" - Sunday, 4th of October",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/09/blog-post_25.html"
   },
   {
@@ -293,6 +329,7 @@
       "brasilia-h3"
     ],
     "runNumber": 192,
+    "title": "Hash N+192 \"Park Hash\" - Sunday, 18th of October",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/10/blog-post.html"
   },
   {
@@ -301,6 +338,7 @@
       "brasilia-h3"
     ],
     "runNumber": 193,
+    "title": "Hash N+193 \"Halloween Hash\" - Sunday, 1st of November",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/10/blog-post_23.html"
   },
   {
@@ -308,16 +346,18 @@
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 195,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2020/11/blog-post_23.html"
+    "runNumber": 194,
+    "title": "Hash N+194 \"FCV Hash\" - Sunday, 15th of November",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/11/blog-post.html"
   },
   {
     "date": "2020-11-15",
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 194,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2020/11/blog-post.html"
+    "runNumber": 195,
+    "title": "Hash N+195 \"4 Weeks to Xmas Hash\" Sunday, 15th of November",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2020/11/blog-post_23.html"
   },
   {
     "date": "2020-12-13",
@@ -325,6 +365,7 @@
       "brasilia-h3"
     ],
     "runNumber": 196,
+    "title": "Hash N+196 \"Santa Hash\" - Sunday, 13th of",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/12/blog-post.html"
   },
   {
@@ -333,6 +374,7 @@
       "brasilia-h3"
     ],
     "runNumber": 197,
+    "title": "Hash N+197 \"F#%k Off 2020 Hash\" Sunday, 27th",
     "sourceUrl": "https://brasiliah3.blogspot.com/2020/12/blog-post_20.html"
   },
   {
@@ -341,6 +383,7 @@
       "brasilia-h3"
     ],
     "runNumber": 198,
+    "title": "Hash N+198 \"New Year Hash\" Sunday, 10th",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/01/blog-post.html"
   },
   {
@@ -349,6 +392,7 @@
       "brasilia-h3"
     ],
     "runNumber": 199,
+    "title": "Hash N+199 \"Monument Hash\" Sunday, 24th",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/01/blog-post_15.html"
   },
   {
@@ -357,6 +401,7 @@
       "brasilia-h3"
     ],
     "runNumber": 200,
+    "title": "Hash N+200 \"Red Dress Run\" Sunday, 7th",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/01/blog-post_26.html"
   },
   {
@@ -365,6 +410,7 @@
       "brasilia-h3"
     ],
     "runNumber": 201,
+    "title": "Hash N+201 \"Inbred Fred Is Back\" Sunday, 21st",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/02/blog-post.html"
   },
   {
@@ -373,6 +419,7 @@
       "brasilia-h3"
     ],
     "runNumber": 202,
+    "title": "Hash N+202 \"Bootcamp Hash\" Sunday, 7th",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/02/blog-post_26.html"
   },
   {
@@ -381,6 +428,7 @@
       "brasilia-h3"
     ],
     "runNumber": 203,
+    "title": "Hash N+203 \"St Patrick's Day Hash\" Sunday, 21st of March",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/03/blog-post.html"
   },
   {
@@ -389,6 +437,7 @@
       "brasilia-h3"
     ],
     "runNumber": 204,
+    "title": "Hash N+204 \"Easter Hash\" Sunday, 4th of April",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/03/blog-post_26.html"
   },
   {
@@ -397,6 +446,7 @@
       "brasilia-h3"
     ],
     "runNumber": 205,
+    "title": "Hash N+205 \"Swedish Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/04/blog-post_12.html"
   },
   {
@@ -405,6 +455,7 @@
       "brasilia-h3"
     ],
     "runNumber": 206,
+    "title": "Hash N+206 \"Vila Planalto Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/04/blog-post_26.html"
   },
   {
@@ -412,16 +463,18 @@
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 208,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2021/05/blog-post_23.html"
+    "runNumber": 207,
+    "title": "Hash N+207 \"Bloco Hash\" - Sunday, 16th of May",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/05/blog-post.html"
   },
   {
     "date": "2021-05-16",
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 207,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2021/05/blog-post.html"
+    "runNumber": 208,
+    "title": "Hash N+208 \"Farewell Hash\" - Sunday, 16th of May",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2021/05/blog-post_23.html"
   },
   {
     "date": "2021-06-13",
@@ -429,6 +482,7 @@
       "brasilia-h3"
     ],
     "runNumber": 209,
+    "title": "Hash N+209 \"Monumental Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/06/blog-post.html"
   },
   {
@@ -437,6 +491,7 @@
       "brasilia-h3"
     ],
     "runNumber": 210,
+    "title": "Hash N+210 \"Hei da Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/06/blog-post_17.html"
   },
   {
@@ -445,6 +500,7 @@
       "brasilia-h3"
     ],
     "runNumber": 211,
+    "title": "Hash N+211 \"City Park Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/07/blog-post.html"
   },
   {
@@ -453,6 +509,7 @@
       "brasilia-h3"
     ],
     "runNumber": 212,
+    "title": "Hash N+212 \"Lago Norte Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/07/blog-post_20.html"
   },
   {
@@ -461,6 +518,7 @@
       "brasilia-h3"
     ],
     "runNumber": 213,
+    "title": "Hash N+213 \"Pretzel Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/08/blog-post.html"
   },
   {
@@ -469,6 +527,7 @@
       "brasilia-h3"
     ],
     "runNumber": 214,
+    "title": "Hash N+214 \"Horseshoe Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/08/blog-post_14.html"
   },
   {
@@ -477,6 +536,7 @@
       "brasilia-h3"
     ],
     "runNumber": 215,
+    "title": "Hash N+215 \"Canuck Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/08/blog-post_29.html"
   },
   {
@@ -485,6 +545,7 @@
       "brasilia-h3"
     ],
     "runNumber": 216,
+    "title": "Hash N+216 \"Babushka Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/09/blog-post.html"
   },
   {
@@ -493,6 +554,7 @@
       "brasilia-h3"
     ],
     "runNumber": 217,
+    "title": "Hash N+217 \"Cross Country Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/09/blog-post_23.html"
   },
   {
@@ -501,6 +563,7 @@
       "brasilia-h3"
     ],
     "runNumber": 218,
+    "title": "Hash N+218 \"Oktoberfest Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/10/blog-post.html"
   },
   {
@@ -509,6 +572,7 @@
       "brasilia-h3"
     ],
     "runNumber": 219,
+    "title": "Hash N+219 \"Halloween Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/10/blog-post_21.html"
   },
   {
@@ -517,6 +581,7 @@
       "brasilia-h3"
     ],
     "runNumber": 220,
+    "title": "Hash N+220 \"National Park Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/11/blog-post.html"
   },
   {
@@ -525,6 +590,7 @@
       "brasilia-h3"
     ],
     "runNumber": 221,
+    "title": "Hash N+221 \" Thanksgiving Hash\" - Sunday, 28th of November",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/11/blog-post_21.html"
   },
   {
@@ -533,6 +599,7 @@
       "brasilia-h3"
     ],
     "runNumber": 222,
+    "title": "Hash N+222 \" Hashmas Hash\" - Sunday, 12th of December",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/12/blog-post.html"
   },
   {
@@ -541,6 +608,7 @@
       "brasilia-h3"
     ],
     "runNumber": 223,
+    "title": "Hash N+223 \"FO 2021\" - Sunday, 26th of December",
     "sourceUrl": "https://brasiliah3.blogspot.com/2021/12/blog-post_19.html"
   },
   {
@@ -549,6 +617,7 @@
       "brasilia-h3"
     ],
     "runNumber": 224,
+    "title": "Hash N+224 \"New Year Hash\" - Sunday, 9th of January",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/01/blog-post.html"
   },
   {
@@ -557,6 +626,7 @@
       "brasilia-h3"
     ],
     "runNumber": 227,
+    "title": "Hash N+227 \"Bergfest Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/02/blog-post.html"
   },
   {
@@ -564,16 +634,18 @@
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 226,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2022/01/blog-post_28.html"
+    "runNumber": 225,
+    "title": "Hash N+225 \"Cross Country Hash\"",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/01/blog-post_15.html"
   },
   {
     "date": "2022-01-23",
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 225,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2022/01/blog-post_15.html"
+    "runNumber": 226,
+    "title": "Hash N+226 \"Bom Bosco Hash\"",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2022/01/blog-post_28.html"
   },
   {
     "date": "2022-03-06",
@@ -581,6 +653,7 @@
       "brasilia-h3"
     ],
     "runNumber": 228,
+    "title": "Hash N+228 \"Farewell Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/02/blog-post_27.html"
   },
   {
@@ -589,6 +662,7 @@
       "brasilia-h3"
     ],
     "runNumber": 229,
+    "title": "Hash N+229 \"St Patrick's Day Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/03/blog-post.html"
   },
   {
@@ -597,6 +671,7 @@
       "brasilia-h3"
     ],
     "runNumber": 230,
+    "title": "Hash N+230 \"Cemetery Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/03/blog-post_28.html"
   },
   {
@@ -605,6 +680,7 @@
       "brasilia-h3"
     ],
     "runNumber": 231,
+    "title": "Hash N+231 \"Easter Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/04/blog-post.html"
   },
   {
@@ -613,6 +689,7 @@
       "brasilia-h3"
     ],
     "runNumber": 232,
+    "title": "Hash N+232 \"May Day Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/04/blog-post_24.html"
   },
   {
@@ -621,6 +698,7 @@
       "brasilia-h3"
     ],
     "runNumber": 236,
+    "title": "Hash N+236 \"Festa Junina Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/05/blog-post_22.html"
   },
   {
@@ -629,6 +707,7 @@
       "brasilia-h3"
     ],
     "runNumber": 237,
+    "title": "Hash N+237 \"Farewell Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/06/blog-post.html"
   },
   {
@@ -637,6 +716,7 @@
       "brasilia-h3"
     ],
     "runNumber": 238,
+    "title": "Hash N+238 \"Military Sector Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/06/blog-post_19.html"
   },
   {
@@ -645,6 +725,7 @@
       "brasilia-h3"
     ],
     "runNumber": 239,
+    "title": "Hash N+239 \"University Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/07/blog-post.html"
   },
   {
@@ -653,6 +734,7 @@
       "brasilia-h3"
     ],
     "runNumber": 240,
+    "title": "Hash N+240 \"Lago Sul Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/07/blog-post_15.html"
   },
   {
@@ -661,6 +743,7 @@
       "brasilia-h3"
     ],
     "runNumber": 241,
+    "title": "Hash N+241 \"Italy Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/07/blog-post_31.html"
   },
   {
@@ -669,6 +752,7 @@
       "brasilia-h3"
     ],
     "runNumber": 242,
+    "title": "Hash N+242 \"Park Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/08/blog-post.html"
   },
   {
@@ -677,6 +761,7 @@
       "brasilia-h3"
     ],
     "runNumber": 243,
+    "title": "Hash N+243 \"Naming Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/08/blog-post_28.html"
   },
   {
@@ -685,6 +770,7 @@
       "brasilia-h3"
     ],
     "runNumber": 244,
+    "title": "Hash N+244 \"Patty Hearst Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/09/blog-post.html"
   },
   {
@@ -693,6 +779,7 @@
       "brasilia-h3"
     ],
     "runNumber": 245,
+    "title": "Hash N+245 \"Election Day Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/09/blog-post_26.html"
   },
   {
@@ -701,6 +788,7 @@
       "brasilia-h3"
     ],
     "runNumber": 246,
+    "title": "Hash N+246 \"Octoberfest Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/10/blog-post.html"
   },
   {
@@ -709,6 +797,7 @@
       "brasilia-h3"
     ],
     "runNumber": 247,
+    "title": "Hash N+247 \"Halloween Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/10/blog-post_23.html"
   },
   {
@@ -717,6 +806,7 @@
       "brasilia-h3"
     ],
     "runNumber": 248,
+    "title": "Hash N+248 \"Airmodel Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/11/blog-post.html"
   },
   {
@@ -725,6 +815,7 @@
       "brasilia-h3"
     ],
     "runNumber": 249,
+    "title": "Hash N+249 \"Thanksgiving Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/11/blog-post_21.html"
   },
   {
@@ -733,6 +824,7 @@
       "brasilia-h3"
     ],
     "runNumber": 250,
+    "title": "Hash N+250 \"Hashmas Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2022/12/blog-post.html"
   },
   {
@@ -741,6 +833,7 @@
       "brasilia-h3"
     ],
     "runNumber": 251,
+    "title": "Hash N+251 \"First Hash 2023\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/01/blog-post.html"
   },
   {
@@ -749,6 +842,7 @@
       "brasilia-h3"
     ],
     "runNumber": 252,
+    "title": "Hash N+252 \"Diplomatic Corps Hash 2023\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/01/blog-post_15.html"
   },
   {
@@ -757,6 +851,7 @@
       "brasilia-h3"
     ],
     "runNumber": 252,
+    "title": "Hash N+252 \"Pontao Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/01/blog-post_30.html"
   },
   {
@@ -765,6 +860,7 @@
       "brasilia-h3"
     ],
     "runNumber": 254,
+    "title": "Hash N+254 \"Carnival Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/02/blog-post.html"
   },
   {
@@ -772,16 +868,18 @@
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 256,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2023/03/blog-post.html"
+    "runNumber": 255,
+    "title": "Hash N+255 \"Naming Hash\"",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/02/blog-post_26.html"
   },
   {
     "date": "2023-03-05",
     "kennelTags": [
       "brasilia-h3"
     ],
-    "runNumber": 255,
-    "sourceUrl": "https://brasiliah3.blogspot.com/2023/02/blog-post_26.html"
+    "runNumber": 256,
+    "title": "Hash N+256 \"Casa do Piano Hash\"",
+    "sourceUrl": "https://brasiliah3.blogspot.com/2023/03/blog-post.html"
   },
   {
     "date": "2023-04-05",
@@ -789,6 +887,7 @@
       "brasilia-h3"
     ],
     "runNumber": 257,
+    "title": "Hash N+257 \"April Fools' Day Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/03/blog-post_26.html"
   },
   {
@@ -797,6 +896,7 @@
       "brasilia-h3"
     ],
     "runNumber": 258,
+    "title": "Hash N+258 \"Asa Sul Park Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/04/blog-post.html"
   },
   {
@@ -805,6 +905,7 @@
       "brasilia-h3"
     ],
     "runNumber": 259,
+    "title": "Hash N+259 \"Brasilia Zoo Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/04/blog-post_23.html"
   },
   {
@@ -813,6 +914,7 @@
       "brasilia-h3"
     ],
     "runNumber": 260,
+    "title": "Hash N+260 \"Virgin Hare Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/05/blog-post.html"
   },
   {
@@ -821,6 +923,7 @@
       "brasilia-h3"
     ],
     "runNumber": 261,
+    "title": "Hash N+261 \"Naming Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/05/blog-post_21.html"
   },
   {
@@ -829,6 +932,7 @@
       "brasilia-h3"
     ],
     "runNumber": 265,
+    "title": "Hash N+265 \"Naming Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/06/blog-post_18.html"
   },
   {
@@ -837,6 +941,7 @@
       "brasilia-h3"
     ],
     "runNumber": 266,
+    "title": "Hash N+266 \"Lake Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/07/blog-post.html"
   },
   {
@@ -845,6 +950,7 @@
       "brasilia-h3"
     ],
     "runNumber": 267,
+    "title": "Hash N+267 \"Music Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/07/blog-post_16.html"
   },
   {
@@ -853,6 +959,7 @@
       "brasilia-h3"
     ],
     "runNumber": 268,
+    "title": "Hash N+268 \"Bush Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/07/blog-post_30.html"
   },
   {
@@ -861,6 +968,7 @@
       "brasilia-h3"
     ],
     "runNumber": 269,
+    "title": "Hash N+269 \"Naming Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/08/blog-post.html"
   },
   {
@@ -869,6 +977,7 @@
       "brasilia-h3"
     ],
     "runNumber": 270,
+    "title": "Hash N+270 \"Park Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/08/blog-post_28.html"
   },
   {
@@ -877,6 +986,7 @@
       "brasilia-h3"
     ],
     "runNumber": 271,
+    "title": "Hash N+271 \"Park Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/09/blog-post.html"
   },
   {
@@ -885,6 +995,7 @@
       "brasilia-h3"
     ],
     "runNumber": 272,
+    "title": "Hash N+272 \"Cultural Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/09/blog-post_26.html"
   },
   {
@@ -893,6 +1004,7 @@
       "brasilia-h3"
     ],
     "runNumber": 273,
+    "title": "Hash N+273 \"Lago Norte Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/10/blog-post.html"
   },
   {
@@ -901,6 +1013,7 @@
       "brasilia-h3"
     ],
     "runNumber": 274,
+    "title": "Hash N+274 \"Farewell Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/10/blog-post_22.html"
   },
   {
@@ -909,6 +1022,7 @@
       "brasilia-h3"
     ],
     "runNumber": 275,
+    "title": "Hash N+275 \"India Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/11/blog-post.html"
   },
   {
@@ -917,6 +1031,7 @@
       "brasilia-h3"
     ],
     "runNumber": 276,
+    "title": "Hash N+276 \"Mr Brasilia Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/11/blog-post_13.html"
   },
   {
@@ -925,6 +1040,7 @@
       "brasilia-h3"
     ],
     "runNumber": 277,
+    "title": "Hash N+277 \"Christmas Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/12/blog-post.html"
   },
   {
@@ -933,6 +1049,7 @@
       "brasilia-h3"
     ],
     "runNumber": 278,
+    "title": "Hash N+278 \"Virgin Hares Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2023/12/blog-post_30.html"
   },
   {
@@ -941,6 +1058,7 @@
       "brasilia-h3"
     ],
     "runNumber": 279,
+    "title": "Hash N+279 \"Naming Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/01/blog-post.html"
   },
   {
@@ -949,6 +1067,7 @@
       "brasilia-h3"
     ],
     "runNumber": 280,
+    "title": "Hash N+280 \"Farewell Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/01/blog-post_28.html"
   },
   {
@@ -957,6 +1076,7 @@
       "brasilia-h3"
     ],
     "runNumber": 281,
+    "title": "Hash N+281 \"Apocalyptic Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/02/blog-post.html"
   },
   {
@@ -965,6 +1085,7 @@
       "brasilia-h3"
     ],
     "runNumber": 282,
+    "title": "Hash N+282 \"University Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/02/blog-post_25.html"
   },
   {
@@ -973,6 +1094,7 @@
       "brasilia-h3"
     ],
     "runNumber": 283,
+    "title": "Hash N+283 \"Farewell Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/03/blog-post.html"
   },
   {
@@ -981,6 +1103,7 @@
       "brasilia-h3"
     ],
     "runNumber": 284,
+    "title": "Hash N+284 \"Easter Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/03/blog-post_24.html"
   },
   {
@@ -989,6 +1112,7 @@
       "brasilia-h3"
     ],
     "runNumber": 285,
+    "title": "Hash N+285 \"Vila Planalto Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/04/blog-post.html"
   },
   {
@@ -997,6 +1121,7 @@
       "brasilia-h3"
     ],
     "runNumber": 286,
+    "title": "Hash N+286 \"Brasilia Center Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/04/blog-post_22.html"
   },
   {
@@ -1005,6 +1130,7 @@
       "brasilia-h3"
     ],
     "runNumber": 287,
+    "title": "Hash N+287 \"Countdown 2 Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/05/blog-post.html"
   },
   {
@@ -1013,6 +1139,7 @@
       "brasilia-h3"
     ],
     "runNumber": 288,
+    "title": "Hash N+288 \"Countdown 1 Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/05/blog-post_19.html"
   },
   {
@@ -1021,6 +1148,7 @@
       "brasilia-h3"
     ],
     "runNumber": 289,
+    "title": "Hash N+289 \"Burle Marx Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/06/blog-post_17.html"
   },
   {
@@ -1029,6 +1157,7 @@
       "brasilia-h3"
     ],
     "runNumber": 290,
+    "title": "Hash N+290 \"Infinu Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/07/blog-post.html"
   },
   {
@@ -1037,6 +1166,7 @@
       "brasilia-h3"
     ],
     "runNumber": 291,
+    "title": "Hash N+291 \"Virgin Hares Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/07/blog-post_14.html"
   },
   {
@@ -1045,6 +1175,7 @@
       "brasilia-h3"
     ],
     "runNumber": 292,
+    "title": "Hash N+292 \"She's Back Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/07/blog-post_30.html"
   },
   {
@@ -1053,6 +1184,7 @@
       "brasilia-h3"
     ],
     "runNumber": 293,
+    "title": "Hash N+293 \"Park Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/08/blog-post.html"
   },
   {
@@ -1061,6 +1193,7 @@
       "brasilia-h3"
     ],
     "runNumber": 294,
+    "title": "Hash N+294 \"Vila Planalto Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/08/blog-post_25.html"
   },
   {
@@ -1069,6 +1202,7 @@
       "brasilia-h3"
     ],
     "runNumber": 295,
+    "title": "Hash N+295 \"Eixo Rodoviario Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/09/blog-post.html"
   },
   {
@@ -1077,6 +1211,7 @@
       "brasilia-h3"
     ],
     "runNumber": 296,
+    "title": "Hash N+296 \"Iceland Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/09/blog-post_22.html"
   },
   {
@@ -1085,6 +1220,7 @@
       "brasilia-h3"
     ],
     "runNumber": 297,
+    "title": "Hash N+297 \"Oktoberfest Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/10/blog-post.html"
   },
   {
@@ -1093,6 +1229,7 @@
       "brasilia-h3"
     ],
     "runNumber": 298,
+    "title": "Hash N+298 \"Halloween Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/10/blog-post_21.html"
   },
   {
@@ -1101,6 +1238,7 @@
       "brasilia-h3"
     ],
     "runNumber": 299,
+    "title": "Hash N+299 \"Farewell Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/11/blog-post.html"
   },
   {
@@ -1109,6 +1247,7 @@
       "brasilia-h3"
     ],
     "runNumber": 300,
+    "title": "Hash N+300 \"The 300 Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/11/hash-n300-300-hash-sunday-24th-of.html"
   },
   {
@@ -1117,6 +1256,7 @@
       "brasilia-h3"
     ],
     "runNumber": 301,
+    "title": "Hash N+301 \"Mice Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/12/hash-n301-mice-hash-sunday-8th-of.html"
   },
   {
@@ -1125,6 +1265,7 @@
       "brasilia-h3"
     ],
     "runNumber": 302,
+    "title": "Hash N+302 \"Hashmas Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/12/hash-n302-hashmas-sunday-22nd-of.html"
   },
   {
@@ -1133,6 +1274,7 @@
       "brasilia-h3"
     ],
     "runNumber": 303,
+    "title": "Hash N+303 \"New Year Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2024/12/hash-n303-new-year-sunday-5th-of.html"
   },
   {
@@ -1141,6 +1283,7 @@
       "brasilia-h3"
     ],
     "runNumber": 304,
+    "title": "Hash N+304 \"City Park Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/01/hash-n304-city-park-sunday-19th-of.html"
   },
   {
@@ -1149,6 +1292,7 @@
       "brasilia-h3"
     ],
     "runNumber": 305,
+    "title": "Hash N+305 \"Virgin Hare Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/01/hash-n305-virgin-hare-sunday-2nd-of.html"
   },
   {
@@ -1157,6 +1301,7 @@
       "brasilia-h3"
     ],
     "runNumber": 306,
+    "title": "Hash N+306 \"Pontao Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/02/hash-n306-pontao-sunday-16th-of.html"
   },
   {
@@ -1165,6 +1310,7 @@
       "brasilia-h3"
     ],
     "runNumber": 307,
+    "title": "Hash N+307 \"Carnaval Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/02/hash-n307-carnaval-sunday-2nd-of-march.html"
   },
   {
@@ -1173,6 +1319,7 @@
       "brasilia-h3"
     ],
     "runNumber": 308,
+    "title": "Hash N+308 \"Virgin Hare Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/03/hash-n308-virgin-hare-sunday-16th-of.html"
   },
   {
@@ -1181,6 +1328,7 @@
       "brasilia-h3"
     ],
     "runNumber": 309,
+    "title": "Hash N+309 \"April Fools Day Hash\"",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/03/hash-n309-april-fools-day-sunday-30th.html"
   },
   {
@@ -1189,6 +1337,7 @@
       "brasilia-h3"
     ],
     "runNumber": 310,
+    "title": "Hash N+310 \"Parque das Garças Hash\"",
     "location": "Parking lot right in front of Parque das Garças (look for hungover",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/04/hash-n310-parque-das-garcas-sunday-13th.html"
   },
@@ -1198,6 +1347,7 @@
       "brasilia-h3"
     ],
     "runNumber": 311,
+    "title": "Hash N+311 \"Ruine Hash\"",
     "location": "Parking lot at",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/04/hash-n311-ruine-sunday-27th-of-april.html"
   },
@@ -1207,6 +1357,7 @@
       "brasilia-h3"
     ],
     "runNumber": 312,
+    "title": "Hash N+312 \"Mother's Day Hash\"",
     "location": "Parking lot at Centro Educacional Leonardo da",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/05/hash-n312-mothers-day-sunday-11th-of.html"
   },
@@ -1216,6 +1367,7 @@
       "brasilia-h3"
     ],
     "runNumber": 313,
+    "title": "Hash N+313 \"Bush Hash\"",
     "location": "Parking lot at Borracharia",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/05/hash-n313-bush-sunday-25th-of-may-ah.html"
   },
@@ -1225,6 +1377,7 @@
       "brasilia-h3"
     ],
     "runNumber": 317,
+    "title": "Hash N+317 \"Festa Junina Hash\"",
     "location": "Parking lot",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/06/hash-n317-festa-junina-sunday-22nd-of.html"
   },
@@ -1234,6 +1387,7 @@
       "brasilia-h3"
     ],
     "runNumber": 318,
+    "title": "Hash N+318 \"Independence Day Hash\"",
     "location": "Parque Bosque do Sudoeste (aka",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/07/hash-n318-independence-day-sunday-6th.html"
   },
@@ -1243,6 +1397,7 @@
       "brasilia-h3"
     ],
     "runNumber": 319,
+    "title": "Hash N+319 \"Naming Hash\"",
     "location": "Praça da Persistência, Asa Sul",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/07/hash-n319-naming-sunday-20th-of-july.html"
   },
@@ -1252,6 +1407,7 @@
       "brasilia-h3"
     ],
     "runNumber": 320,
+    "title": "Hash N+320 \"Leo Zodiac Hash\"",
     "location": "SQS 305, bloco to be revealed like a reality show twist",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/07/hash-n320-leo-zodiac-sunday-3rd-of.html"
   },
@@ -1261,6 +1417,7 @@
       "brasilia-h3"
     ],
     "runNumber": 321,
+    "title": "Hash N+321 \"Farewell Hash\"",
     "location": "Parking lot, Praça dos Cristais,",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/08/hash-n321-farewell-sunday-17th-of.html"
   },
@@ -1270,6 +1427,7 @@
       "brasilia-h3"
     ],
     "runNumber": 322,
+    "title": "Hash N+322 \"Vila Planalto Hash\"",
     "location": "Parking lot beside Concha Acústica",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/08/hash-n322-vila-planalto-sunday-31st-of.html"
   },
@@ -1279,6 +1437,7 @@
       "brasilia-h3"
     ],
     "runNumber": 323,
+    "title": "Hash N+323 \"Lago Norte Hash\"",
     "location": "Parque da 13,",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/09/hash-n323-lago-norte-sunday-14th-of.html"
   },
@@ -1288,6 +1447,7 @@
       "brasilia-h3"
     ],
     "runNumber": 324,
+    "title": "Hash N+324 \"Asa Sul Hash\"",
     "location": "Praça Índio Pataxó Galdino Jesus dos Santos, SHIGS 704 – Asa Sul",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/09/hash-n324-asa-sul-sunday-28th-of.html"
   },
@@ -1297,6 +1457,7 @@
       "brasilia-h3"
     ],
     "runNumber": 325,
+    "title": "Hash N+325 \"Eixao Hash\"",
     "location": "SQN 107, Bloco C",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/10/hash-n325-eixao-sunday-12th-of-october.html"
   },
@@ -1306,6 +1467,7 @@
       "brasilia-h3"
     ],
     "runNumber": 326,
+    "title": "Hash N+326 - 1\"Asa Norte Hash\"",
     "location": "Parking lot behind",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/10/hash-n326-halloween-sunday-26th-of.html"
   },
@@ -1315,6 +1477,7 @@
       "brasilia-h3"
     ],
     "runNumber": 327,
+    "title": "Hash N+327\"Dom Bosco Hash\"",
     "location": "Parking Ecological",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/11/hash-n327dom-bosco-sunday-23rd-of.html"
   },
@@ -1324,6 +1487,7 @@
       "brasilia-h3"
     ],
     "runNumber": 328,
+    "title": "Hash N+328 \"Lago Sul Hash\"",
     "location": "Parking lot of",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/12/hash-n328-lago-sul-sunday-7th-of.html"
   },
@@ -1333,6 +1497,7 @@
       "brasilia-h3"
     ],
     "runNumber": 329,
+    "title": "Hash N+329 \"Hashmas Hash\"",
     "location": "SQN 203 – Bloco TBA (because planning is for other people)",
     "sourceUrl": "https://brasiliah3.blogspot.com/2025/12/hash-n329-hashmas-sunday-21st-of.html"
   },
@@ -1342,6 +1507,7 @@
       "brasilia-h3"
     ],
     "runNumber": 330,
+    "title": "Hash N+330 \"New Year Hash\"",
     "location": "Praça da Persistência,SHCS EQS 112/113 – Asa Sul",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/01/hash-n330-new-year-sunday-18th-of.html"
   },
@@ -1351,6 +1517,7 @@
       "brasilia-h3"
     ],
     "runNumber": 331,
+    "title": "Hash N+331 \"Virgin Hare Hash\"",
     "location": "Parking lot in front of Borracharia Lago Norte",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/01/hash-n330-new-year-sunday-18th-of_27.html"
   },
@@ -1360,6 +1527,7 @@
       "brasilia-h3"
     ],
     "runNumber": 332,
+    "title": "Hash N+332 \"Carnaval Hash\"",
     "location": "Parking lot in front of Caixa Cultural Brasília",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/02/hash-n332-carnaval-sunday-15th-of.html"
   },
@@ -1369,6 +1537,7 @@
       "brasilia-h3"
     ],
     "runNumber": 333,
+    "title": "Hash N+333 \"City Park Hash\"",
     "location": "Parking lot 9 in Parque da Cidade Sarah Kubitschek",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/02/hash-n333-city-park-sunday-1st-of-march.html"
   },
@@ -1378,6 +1547,7 @@
       "brasilia-h3"
     ],
     "runNumber": 334,
+    "title": "Hash N+334 \"St. Patrick's Day Hash\"",
     "location": "Park at SQN216, Bloco B in Asa Norte",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/03/hash-n334-st.html"
   },
@@ -1387,6 +1557,7 @@
       "brasilia-h3"
     ],
     "runNumber": 335,
+    "title": "Hash N+335 \"University Hash\"",
     "location": "Main parking lot at UNB – Asa Norte",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/03/hash-n335-university-sunday-29th-of.html"
   },
@@ -1396,6 +1567,7 @@
       "brasilia-h3"
     ],
     "runNumber": 336,
+    "title": "Hash N+336 \"Asa Sul Hash\"",
     "location": "SQS 406, Bloco K",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/04/hash-n336-asa-sul-sunday-12th-of-april.html"
   },
@@ -1405,6 +1577,7 @@
       "brasilia-h3"
     ],
     "runNumber": 337,
+    "title": "Hash N+337 \"Zoo Hash\"",
     "location": "Main gate at Brasília Zoo",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/04/hash-n337-zoo-sunday-26th-of-april.html"
   },
@@ -1414,6 +1587,7 @@
       "brasilia-h3"
     ],
     "runNumber": 338,
+    "title": "Hash N+338 \"Farewell Hash\"",
     "location": "Road entrance to SQN 306, Asa Norte — Wine Rack’s home turf.",
     "sourceUrl": "https://brasiliah3.blogspot.com/2026/05/hash-n338-farewell-sunday-10th-of-may.html"
   }

--- a/scripts/generate-asu-h3-history.ts
+++ b/scripts/generate-asu-h3-history.ts
@@ -30,6 +30,13 @@ async function main(): Promise<void> {
     rows.push(ev);
   }
 
+  // Never overwrite the committed archive with an empty set (a fetch that
+  // returned but yielded nothing parseable). fetchAllRunPosts already throws on
+  // HTTP/site errors; this guards the parse-yield path.
+  if (rows.length === 0) {
+    throw new Error("Parsed 0 past rows — refusing to overwrite the committed archive");
+  }
+
   rows.sort((a, b) => a.date.localeCompare(b.date) || (a.runNumber ?? 0) - (b.runNumber ?? 0));
   writeFileSync(OUT, `${JSON.stringify(rows, null, 2)}\n`);
 

--- a/scripts/generate-asu-h3-history.ts
+++ b/scripts/generate-asu-h3-history.ts
@@ -1,0 +1,47 @@
+/**
+ * Regenerate `scripts/data/asu-h3-history.json` from the live WordPress.com REST
+ * feed using the adapter's exported `postToEvent`. Run once after a parser
+ * change (e.g. #1960/#1961 added the source title + shared-helper hares); commit
+ * the regenerated JSON. The recurring loader stays dumb (no parser).
+ *
+ * Archive = PAST events only (date < today in kennel tz) — the live adapter is
+ * future-only, so the committed archive holds the historical runs.
+ * No DB writes; this only rewrites the JSON file.
+ *
+ * Usage: npx tsx scripts/generate-asu-h3-history.ts
+ */
+import "dotenv/config";
+import { writeFileSync } from "node:fs";
+import { postToEvent, fetchAllRunPosts } from "@/adapters/html-scraper/asuncion-h3";
+import { todayInTimezone } from "@/lib/timezone";
+import type { RawEventData } from "@/adapters/types";
+
+const KENNEL_TIMEZONE = "America/Asuncion";
+const OUT = "scripts/data/asu-h3-history.json";
+
+async function main(): Promise<void> {
+  const posts = await fetchAllRunPosts();
+  const today = todayInTimezone(KENNEL_TIMEZONE);
+
+  const rows: RawEventData[] = [];
+  for (const post of posts) {
+    const ev = postToEvent(post);
+    if (!ev || ev.date >= today) continue;
+    rows.push(ev);
+  }
+
+  rows.sort((a, b) => a.date.localeCompare(b.date) || (a.runNumber ?? 0) - (b.runNumber ?? 0));
+  writeFileSync(OUT, `${JSON.stringify(rows, null, 2)}\n`);
+
+  const withTitle = rows.filter((r) => r.title).length;
+  const withHares = rows.filter((r) => r.hares).length;
+  console.log(`Posts fetched: ${posts.length}`);
+  console.log(`Wrote ${rows.length} past rows to ${OUT}`);
+  console.log(`  range: ${rows[0]?.date} (#${rows[0]?.runNumber}) → ${rows.at(-1)?.date} (#${rows.at(-1)?.runNumber})`);
+  console.log(`  title=${withTitle}/${rows.length}  hares=${withHares}/${rows.length}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/generate-brasilia-h3-history.ts
+++ b/scripts/generate-brasilia-h3-history.ts
@@ -43,6 +43,12 @@ async function main(): Promise<void> {
     });
   }
 
+  // Never overwrite the committed archive with an empty set. fetchBloggerPosts
+  // errors are already thrown above; this guards the parse-yield path.
+  if (rows.length === 0) {
+    throw new Error("Parsed 0 past rows — refusing to overwrite the committed archive");
+  }
+
   rows.sort((a, b) => a.date.localeCompare(b.date) || (a.runNumber ?? 0) - (b.runNumber ?? 0));
   writeFileSync(OUT, `${JSON.stringify(rows, null, 2)}\n`);
 

--- a/scripts/generate-brasilia-h3-history.ts
+++ b/scripts/generate-brasilia-h3-history.ts
@@ -1,0 +1,67 @@
+/**
+ * Regenerate `scripts/data/brasilia-h3-history.json` from the live Blogger
+ * archive using the adapter's exported `parseBrasiliaPost`. Run once after a
+ * parser change (e.g. #1981/#1982/#1983 added title + hares + prose location);
+ * commit the regenerated JSON. The recurring loader stays dumb (no parser).
+ *
+ * Archive = PAST events only (date < today in kennel tz) — the live adapter
+ * covers the current/future window, so the committed archive never drifts with
+ * upcoming runs. No DB writes; this only rewrites the JSON file.
+ *
+ * Usage: npx tsx scripts/generate-brasilia-h3-history.ts
+ */
+import "dotenv/config";
+import { writeFileSync } from "node:fs";
+import { fetchBloggerPosts } from "@/adapters/blogger-api";
+import { parseBrasiliaPost } from "@/adapters/html-scraper/brasilia-h3";
+import { stripHtmlTags } from "@/adapters/utils";
+import { todayInTimezone } from "@/lib/timezone";
+import type { RawEventData } from "@/adapters/types";
+
+const BLOG_URL = "https://brasiliah3.blogspot.com/";
+const KENNEL_TIMEZONE = "America/Sao_Paulo";
+const OUT = "scripts/data/brasilia-h3-history.json";
+
+async function main(): Promise<void> {
+  const res = await fetchBloggerPosts(BLOG_URL, 500);
+  if (res.error) throw new Error(`Blogger fetch failed: ${res.error.message}`);
+  const today = todayInTimezone(KENNEL_TIMEZONE);
+
+  const rows: RawEventData[] = [];
+  for (const post of res.posts) {
+    const body = stripHtmlTags(post.content, "\n");
+    const parsed = parseBrasiliaPost(body, post.published, post.url, post.title);
+    if (!parsed || parsed.date >= today) continue;
+    rows.push({
+      date: parsed.date,
+      kennelTags: ["brasilia-h3"],
+      runNumber: parsed.runNumber,
+      title: parsed.title,
+      hares: parsed.hares,
+      location: parsed.location,
+      sourceUrl: parsed.sourceUrl,
+    });
+  }
+
+  rows.sort((a, b) => a.date.localeCompare(b.date) || (a.runNumber ?? 0) - (b.runNumber ?? 0));
+  writeFileSync(OUT, `${JSON.stringify(rows, null, 2)}\n`);
+
+  const runs = rows.map((r) => r.runNumber ?? 0);
+  const withTitle = rows.filter((r) => r.title).length;
+  const withHares = rows.filter((r) => r.hares).length;
+  const withLoc = rows.filter((r) => r.location).length;
+  console.log(`Posts fetched: ${res.posts.length}`);
+  console.log(`Wrote ${rows.length} past rows to ${OUT}`);
+  console.log(`  range: ${rows[0]?.date} (#${runs[0]}) → ${rows.at(-1)?.date} (#${runs.at(-1)})`);
+  console.log(`  title=${withTitle}/${rows.length}  hares=${withHares}/${rows.length}  location=${withLoc}/${rows.length}`);
+  // Report run-number gaps so #1985 (missing #339 etc.) is visible at a glance.
+  const present = new Set(runs);
+  const gaps: number[] = [];
+  for (let n = Math.min(...runs); n <= Math.max(...runs); n++) if (!present.has(n)) gaps.push(n);
+  console.log(`  run-number gaps (${gaps.length}): ${gaps.join(", ") || "none"}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/generate-brasilia-h3-history.ts
+++ b/scripts/generate-brasilia-h3-history.ts
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
   rows.sort((a, b) => a.date.localeCompare(b.date) || (a.runNumber ?? 0) - (b.runNumber ?? 0));
   writeFileSync(OUT, `${JSON.stringify(rows, null, 2)}\n`);
 
-  const runs = rows.map((r) => r.runNumber ?? 0);
+  const runs = rows.map((r) => r.runNumber).filter((n): n is number => n != null);
   const withTitle = rows.filter((r) => r.title).length;
   const withHares = rows.filter((r) => r.hares).length;
   const withLoc = rows.filter((r) => r.location).length;
@@ -61,10 +61,16 @@ async function main(): Promise<void> {
   console.log(`  range: ${rows[0]?.date} (#${runs[0]}) → ${rows.at(-1)?.date} (#${runs.at(-1)})`);
   console.log(`  title=${withTitle}/${rows.length}  hares=${withHares}/${rows.length}  location=${withLoc}/${rows.length}`);
   // Report run-number gaps so #1985 (missing #339 etc.) is visible at a glance.
-  const present = new Set(runs);
-  const gaps: number[] = [];
-  for (let n = Math.min(...runs); n <= Math.max(...runs); n++) if (!present.has(n)) gaps.push(n);
-  console.log(`  run-number gaps (${gaps.length}): ${gaps.join(", ") || "none"}`);
+  // Only real run numbers count — coercing a missing one to 0 would fabricate a
+  // 0..min gap and bury the real diagnostic.
+  if (runs.length > 0) {
+    const present = new Set(runs);
+    const gaps: number[] = [];
+    for (let n = Math.min(...runs); n <= Math.max(...runs); n++) if (!present.has(n)) gaps.push(n);
+    console.log(`  run-number gaps (${gaps.length}): ${gaps.join(", ") || "none"}`);
+  } else {
+    console.log("  run-number gaps: unavailable (no parsed run numbers)");
+  }
 }
 
 main().catch((err) => {

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -167,6 +167,30 @@ const EXPECTED_GROUPS: ExpectedGroup[] = [
       ["case-insensitive", "Who Are The Hares: Leeroy", "Leeroy"],
     ],
   },
+  {
+    // #1981 Brasilia / 6th cross-kennel instance — role-header template family.
+    // Real shapes drawn from brasiliah3.blogspot.com (Blogger bodies) plus the
+    // "The Hares:" / "Perpetrator(s):" historical variants.
+    describe: "extractHares — role-header template family (#1981)",
+    template: "%s",
+    table: [
+      ["'The Hares:' inline", "The Hares: Sperm Bank", "Sperm Bank"],
+      ["'The Hare:' inline", "The Hare: Just One Guy", "Just One Guy"],
+      ["emoji-prefixed 'The Hares:'", "🐾 The Hares: Sperm Bank", "Sperm Bank"],
+      ["'The Hares:' header + next line", "The Hares:\nAlice & Bob", "Alice & Bob"],
+      ["'Perpetrator(s):' inline", "Perpetrator(s): Foo & Bar", "Foo & Bar"],
+      ["'Perpetrators:' plural inline", "Perpetrators: Baz", "Baz"],
+      ["'This week's perpetrator:' inline", "This week's perpetrator: Sperm Bank", "Sperm Bank"],
+      ["curly-apostrophe 'This week's perpetrator:'", "This week’s perpetrator: Spunk Bubble", "Spunk Bubble"],
+      [
+        // The exact current-post shape (after the adapter collapses blank lines):
+        // a "🐾 The Hare" banner, then the perpetrator header, then the name.
+        "Brasilia banner + 'This week's perpetrator:' header + name",
+        "🐾 The Hare\nThis week's perpetrator:\nSperm Bank",
+        "Sperm Bank",
+      ],
+    ],
+  },
 ];
 
 const UNDEFINED_GROUPS: UndefinedGroup[] = [
@@ -207,6 +231,14 @@ const UNDEFINED_GROUPS: UndefinedGroup[] = [
       ["mid-sentence 'Hares are Needed'", "Sign up now! Hares are Needed for July."],
       ["mid-sentence 'Hares are Welcome'", "Bring friends. Hares are Welcome to the pool party."],
       ["mid-sentence lowercase 'the hares are bringing'", "Tonight the hares are bringing dogs and friends."],
+      // #1981 role-header family — prose that mentions "hare"/"perpetrator" but
+      // is NOT a labeled hare line (no colon) must NOT promote. Regression guard
+      // for the new The-Hare / Perpetrator patterns.
+      ["prose 'the hare set a cracking trail'", "Last week the hare set a cracking trail through the park."],
+      ["prose 'thanks to the hare'", "Big thanks to the hare from last week."],
+      ["prose 'we chased the hares'", "We chased the hares through the park for hours."],
+      ["prose 'Perpetrators of' (no colon)", "Perpetrators of the great beer theft remain at large."],
+      ["banner 'The Hare' with no name (no colon)", "🐾 The Hare"],
     ],
   },
   {

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -50,6 +50,14 @@ const DEFAULT_HARE_PATTERNS = [
   // match lowercase). The lazy `.+?` plus a sentence-end lookahead bound the
   // capture so we stop at the next sentence terminator or newline.
   /(?:^|\n|(?<=[.!?]\s))[ \t]*[Hh]ares?\s+are\s+([A-Z*].+?)(?=[.!?](?:\s|$)|\n|$)/m,  // NOSONAR — bounded non-greedy, anchored to sentence/line end
+  // Role-header template family (#1981 Brasilia, 6th cross-kennel instance).
+  // Each REQUIRES a colon so prose ("the hare set a cracking trail") can never
+  // match; the leading [^\nA-Za-z]{0,4} tolerates an emoji/symbol banner prefix
+  // (e.g. "🐾 The Hares:"). Header-only forms (name on the next line) flow
+  // through collectContinuationLines exactly like the bare "Hares:" pattern.
+  /(?:^|\n)[^\nA-Za-z]{0,4}The\s+Hares?\b[ \t]*:[ \t]*(.*)/im,  // NOSONAR — "The Hare:" / "The Hares:" label variant
+  /(?:^|\n)[^\nA-Za-z]{0,4}Perpetrators?(?:\(s\))?[ \t]*:[ \t]*(.*)/im,  // NOSONAR — "Perpetrator(s):" hash-slang synonym for hare
+  /(?:^|\n)[^\nA-Za-z]{0,4}This\s+week['’]s\s+(?:perpetrator|hare)s?[ \t]*:[ \t]*(.*)/im,  // NOSONAR — "This week's perpetrator:" (straight + curly apostrophe)
 ];
 /* eslint-enable */
 
@@ -158,6 +166,12 @@ function isContinuationTerminator(line: string): boolean {
  * label-only headers — text after an inline hare is almost always free-form
  * description, not a co-hare. Caps line count and per-line length, and
  * rejects sentence-shaped lines.
+ *
+ * Only a SINGLE leading blank line is skipped (the `\n` immediately after the
+ * label). Sources that double-space the role-header from the name must collapse
+ * those blanks before calling extractHares — keeping the skip at one preserves
+ * the blank-line terminator for every other consumer (a label followed by two
+ * blanks then prose must NOT bleed that prose into hares).
  */
 function collectContinuationLines(normalized: string, match: RegExpExecArray): string {
   // eslint-disable-next-line -- @typescript-eslint/no-unnecessary-condition: defensive against engines where match.index can be undefined

--- a/src/adapters/html-scraper/asuncion-h3.test.ts
+++ b/src/adapters/html-scraper/asuncion-h3.test.ts
@@ -116,11 +116,6 @@ describe("postToEvent", () => {
     expect(ev!.title).toBe("Run #120");
   });
 
-  it("strips a trailing site-name suffix from the title if WP appends one", () => {
-    const ev = postToEvent(post("Run #118 – Asunción Hash House Harriers", RUN_120_HTML, 6311));
-    expect(ev!.title).toBe("Run #118");
-  });
-
   it.each([
     ["bare 'Hare:'", "Hare: Solo Hare", "Solo Hare"],
     ["plural 'Hares:'", "Hares: Alpha &amp; Beta", "Alpha & Beta"],

--- a/src/adapters/html-scraper/asuncion-h3.test.ts
+++ b/src/adapters/html-scraper/asuncion-h3.test.ts
@@ -111,9 +111,24 @@ describe("postToEvent", () => {
     expect(ev!.sourceUrl).toContain("asuncionh3.wordpress.com");
   });
 
-  it("never sets a title (merge.ts synthesizes 'Asunción H3 Trail #N')", () => {
+  it("sets the source post title verbatim ('Run #N', #1960)", () => {
     const ev = postToEvent(post("Run #120", RUN_120_HTML, 6313));
-    expect(ev!.title).toBeUndefined();
+    expect(ev!.title).toBe("Run #120");
+  });
+
+  it("strips a trailing site-name suffix from the title if WP appends one", () => {
+    const ev = postToEvent(post("Run #118 – Asunción Hash House Harriers", RUN_120_HTML, 6311));
+    expect(ev!.title).toBe("Run #118");
+  });
+
+  it.each([
+    ["bare 'Hare:'", "Hare: Solo Hare", "Solo Hare"],
+    ["plural 'Hares:'", "Hares: Alpha &amp; Beta", "Alpha & Beta"],
+    ["parenthesised 'Hare(s):'", "Hare(s): Ban the Cock", "Ban the Cock"],
+  ])("extracts hares via the shared helper for %s", (_label, hareLine, expected) => {
+    const html = `<h4>Run &amp; Walk #88</h4><p><strong>Saturday, 4 May 2024</strong><br>${hareLine}</p>`;
+    const ev = postToEvent(post("Run #88", html, 6088));
+    expect(ev!.hares).toBe(expected);
   });
 
   it("uses the in-body run date, not the post publish date (batch-posted runs)", () => {

--- a/src/adapters/html-scraper/asuncion-h3.ts
+++ b/src/adapters/html-scraper/asuncion-h3.ts
@@ -201,14 +201,14 @@ function runFromTitle(title: string): number | undefined {
   return m ? Number.parseInt(m[1], 10) : undefined;
 }
 
-// Defensive: strip a trailing site-name suffix if WP ever appends it to the
-// rendered post title (og:title is bare "Run #N", but <title> carries
-// " – Asunción Hash House Harriers"). Bounded literal, anchored to end.
-const TITLE_SUFFIX_RE = /\s*[–—-]\s*Asunci[oó]n Hash House Harriers\s*$/i;
-
-/** Source post title ("Run #120"), decoded + suffix-stripped, or undefined. */
+/**
+ * Source post title ("Run #120"), decoded + trimmed, or undefined. The WP REST
+ * `title.rendered` is the bare post title (the " – Asunción Hash House Harriers"
+ * site-name suffix only appears on the HTML `<title>` tag, never this field), so
+ * no suffix strip is needed.
+ */
 function cleanTitle(rendered: string): string | undefined {
-  const cleaned = decodeEntities(rendered).replace(TITLE_SUFFIX_RE, "").trim();
+  const cleaned = decodeEntities(rendered).trim();
   return cleaned.length > 0 ? cleaned : undefined;
 }
 

--- a/src/adapters/html-scraper/asuncion-h3.ts
+++ b/src/adapters/html-scraper/asuncion-h3.ts
@@ -252,14 +252,25 @@ function isRunPost(post: WPComPost): boolean {
  * params (per_page, _fields, the category-1 rule) have one source of truth.
  * Used by the one-shot history generator; the recurring fetch() below keeps its
  * own future-only loop with diagnostics.
+ *
+ * **Throws on a non-clean stop** (HTTP error, or a 400/404 on page 1 = site/API
+ * unavailable) so a transient failure can't make the generator overwrite the
+ * committed archive with an empty/partial set. Only a real end-of-pages — a
+ * `kind:"end"` past page 1, or a short/partial page — stops cleanly.
  */
 export async function fetchAllRunPosts(maxPages = MAX_PAGES + 2): Promise<WPComPost[]> {
   const all: WPComPost[] = [];
   for (let page = 1; page <= maxPages; page++) {
     const result = await fetchPostsPage(page);
-    if (result.kind !== "posts") break; // "end" or "error" → stop
+    if (result.kind === "error") {
+      throw new Error(`Asunción WP fetch failed on page ${page}: ${result.message}`);
+    }
+    if (result.kind === "end") {
+      if (page === 1) throw new Error("Asunción WP API returned 400/404 for page 1 (site/API unavailable)");
+      break; // clean end: a page past the last
+    }
     all.push(...result.posts.filter(isRunPost));
-    if (result.posts.length < PER_PAGE) break; // partial last page
+    if (result.posts.length < PER_PAGE) break; // partial last page — clean end
   }
   return all;
 }

--- a/src/adapters/html-scraper/asuncion-h3.ts
+++ b/src/adapters/html-scraper/asuncion-h3.ts
@@ -2,6 +2,7 @@ import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
 import { stripHtmlTags, decodeEntities } from "../utils";
+import { extractHares } from "../hare-extraction";
 import { safeFetch } from "../safe-fetch";
 import { isValidCoords } from "@/lib/geo";
 
@@ -45,7 +46,9 @@ const START_TIME_RE = /(\d{1,2}):(\d{2})[^\n\d]{0,8}(?:start|inicio)/i;
 const ANY_TIME_RE = /(\d{1,2}):(\d{2})/;
 // Per-line field labels (English column wins by document order). Bounded middles
 // (no unbounded quantifier next to ":") keep these out of the ReDoS heuristics.
-const HARE_LINE_RE = /^Hare\(s\)\s*:\s*(\S.*)$/i;
+// Hares are extracted via the shared extractHares helper (covers Hare:/Hares:/
+// Hare(s):, #1961) — the English column is first in document order so the
+// helper's first-match wins, matching the historical firstLineField behaviour.
 // Char classes use [A-Z …] (no a-z) because the /i flag already matches lowercase;
 // including both ranges trips Sonar S5869 (duplicate char class under case-insensitive).
 const START_LINE_RE = /^(?:Start|Location|Meeting point)[A-Z ()]{0,14}:\s*(\S.*)$/i;
@@ -71,7 +74,7 @@ const MONTH_MAP: Record<string, number> = {
   dec: 12, december: 12, diciembre: 12,
 };
 
-interface WPComPost {
+export interface WPComPost {
   id: number;
   date: string;
   link: string;
@@ -179,9 +182,10 @@ export function postToEvent(post: WPComPost): RawEventData | null {
     date,
     kennelTags: [KENNEL_TAG],
     runNumber,
-    // Title left undefined — titles are bare "Run #N"; merge.ts synthesizes
-    // "Asunción H3 Trail #N" (a title must never be a hare name or field fragment).
-    hares: firstLineField(lines, HARE_LINE_RE),
+    // #1960 — store the source post title ("Run #N") verbatim rather than
+    // letting merge synthesize the generic "Asunción H3 Trail #N".
+    title: cleanTitle(post.title.rendered),
+    hares: extractHares(text),
     location: firstLineField(lines, START_LINE_RE),
     cost: firstLineField(lines, COST_LINE_RE),
     startTime: parseStartTime(text),
@@ -195,6 +199,17 @@ export function postToEvent(post: WPComPost): RawEventData | null {
 function runFromTitle(title: string): number | undefined {
   const m = RUN_TITLE_RE.exec(title);
   return m ? Number.parseInt(m[1], 10) : undefined;
+}
+
+// Defensive: strip a trailing site-name suffix if WP ever appends it to the
+// rendered post title (og:title is bare "Run #N", but <title> carries
+// " – Asunción Hash House Harriers"). Bounded literal, anchored to end.
+const TITLE_SUFFIX_RE = /\s*[–—-]\s*Asunci[oó]n Hash House Harriers\s*$/i;
+
+/** Source post title ("Run #120"), decoded + suffix-stripped, or undefined. */
+function cleanTitle(rendered: string): string | undefined {
+  const cleaned = decodeEntities(rendered).replace(TITLE_SUFFIX_RE, "").trim();
+  return cleaned.length > 0 ? cleaned : undefined;
 }
 
 type PageResult =
@@ -229,6 +244,24 @@ async function fetchPostsPage(page: number): Promise<PageResult> {
  */
 function isRunPost(post: WPComPost): boolean {
   return RUN_TITLE_RE.test(post.title.rendered) && (post.categories?.includes(1) ?? true);
+}
+
+/**
+ * Fetch EVERY run post (all pages, not future-filtered), reusing the same
+ * pagination + run-filter as the recurring scrape so the WordPress.com request
+ * params (per_page, _fields, the category-1 rule) have one source of truth.
+ * Used by the one-shot history generator; the recurring fetch() below keeps its
+ * own future-only loop with diagnostics.
+ */
+export async function fetchAllRunPosts(maxPages = MAX_PAGES + 2): Promise<WPComPost[]> {
+  const all: WPComPost[] = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const result = await fetchPostsPage(page);
+    if (result.kind !== "posts") break; // "end" or "error" → stop
+    all.push(...result.posts.filter(isRunPost));
+    if (result.posts.length < PER_PAGE) break; // partial last page
+  }
+  return all;
 }
 
 /** Parse a page of posts into future-dated run events (the archive is backfilled separately). */

--- a/src/adapters/html-scraper/auckland-hash.test.ts
+++ b/src/adapters/html-scraper/auckland-hash.test.ts
@@ -46,6 +46,7 @@ describe("parseRunLine", () => {
     expect(event!.hares).toBe("Revs");
     expect(event!.location).toBe("29i James street, Glenfield");
     expect(event!.startTime).toBe("18:30");
+    expect(event!.title).toBe("Run w/ Revs");
   });
 
   it("keeps multi-word hares intact via the tab delimiter (no greedy split)", () => {
@@ -78,9 +79,9 @@ describe("parseRunLine", () => {
     expect(event!.title).toBeUndefined();
   });
 
-  it("leaves title undefined (merge synthesizes; no run numbers on this source)", () => {
+  it("synthesizes a 'Run w/ <Hare>' title from the hare; no run number (#1964)", () => {
     const event = parseRunLine("13-Jul-26\tLoose Change\t37 Waimoko Glen, Swanson", REF);
-    expect(event!.title).toBeUndefined();
+    expect(event!.title).toBe("Run w/ Loose Change");
     expect(event!.runNumber).toBeUndefined();
   });
 

--- a/src/adapters/html-scraper/auckland-hash.ts
+++ b/src/adapters/html-scraper/auckland-hash.ts
@@ -142,8 +142,11 @@ export function parseRunLine(
   return {
     date,
     kennelTags: [KENNEL_TAG],
-    // Leave title undefined — merge.ts synthesizes "Auckland H3 Trail". No run
-    // numbers exist on this source, so no runNumber is emitted.
+    // #1964 — the source has no per-event title or run number, so synthesize one
+    // from the hare ("Run w/ Loose Change"). When the hare is a placeholder
+    // ("Hare Wanted"), leave title undefined so merge falls back to the kennel
+    // default ("Auckland H3 Trail").
+    title: hares ? `Run w/ ${hares}` : undefined,
     hares,
     location,
     startTime: parseStartTime(venue),

--- a/src/adapters/html-scraper/brasilia-h3.test.ts
+++ b/src/adapters/html-scraper/brasilia-h3.test.ts
@@ -12,26 +12,56 @@ function brasiliaSource(scrapeDays = 90): Source {
   return { id: "test-bsb", url: "https://brasiliah3.blogspot.com/", scrapeDays } as unknown as Source;
 }
 
-// Real N+340 post body (Praça dos Orixás Hash), trimmed. Titles are empty on
-// this blog, so the run number + date live in the body. Published 2026-06-02,
-// run on Sunday 7 June 2026.
+// Real N+340 post body (Praça dos Orixás Hash), trimmed. The blog's run data
+// lives in the body: the heading line is the source title, the hare follows a
+// "🐾 The Hare / This week's perpetrator:" role-header (double-spaced in the
+// raw HTML — empty <p></p> reproduce the blank lines the adapter collapses),
+// and the venue is named only in the lede prose. Published 2026-06-02, run on
+// Sunday 7 June 2026.
 const N340_HTML = [
   "<div>Hash N+340 \"Pra&#231;a dos Orix&#225;s Hash\"</div>",
   "<div>Sunday, 7th of June</div>",
-  "<p>Welcome to Hash N+340: the lakeside edition.</p>",
-  "<p>This week we gather at Pra&#231;a dos Orix&#225;s.</p>",
+  "<p>🐾 The Hare</p>",
+  "<p></p>",
+  "<p></p>",
+  "<p>This week's perpetrator:</p>",
+  "<p></p>",
+  "<p></p>",
+  "<p>Sperm Bank</p>",
+  "<p></p>",
+  "<p>Sperm Bank has promised a beautiful lakeside trail with stunning views.</p>",
+  "<p>This week we gather at Pra&#231;a dos Orix&#225;s, where the lake meets the sky.</p>",
 ].join("");
 
 describe("parseBrasiliaPost", () => {
-  it("extracts run number and date from a post body (empty title, body-only)", () => {
+  it("extracts run number, date, source title, hares, and prose venue from a post body", () => {
     const body = stripHtmlTags(N340_HTML, "\n");
     const parsed = parseBrasiliaPost(body, "2026-06-02T17:29:24-03:00", "https://brasiliah3.blogspot.com/2026/06/n340.html");
     expect(parsed).not.toBeNull();
     expect(parsed?.runNumber).toBe(340);
     expect(parsed?.date).toBe("2026-06-07");
     expect(parsed?.sourceUrl).toBe("https://brasiliah3.blogspot.com/2026/06/n340.html");
-    // No `Start:` label in this post → location stays undefined (merge geocodes prose).
-    expect(parsed?.location).toBeUndefined();
+    // #1983 — the heading line is the source title (verbatim, with the theme).
+    expect(parsed?.title).toBe('Hash N+340 "Praça dos Orixás Hash"');
+    // #1981 — hare follows the "🐾 The Hare / This week's perpetrator:" header.
+    expect(parsed?.hares).toBe("Sperm Bank");
+    // #1982 — no `Start:` label, but the lede prose names the venue.
+    expect(parsed?.location).toBe("Praça dos Orixás");
+  });
+
+  it("prefers the body heading title even when the Blogger post title is set", () => {
+    const body = "Hash N+200 \"Mystery Hash\"\nSunday, 5th of May";
+    const parsed = parseBrasiliaPost(body, "2024-05-01T12:00:00-03:00", "https://brasiliah3.blogspot.com/x", "Some Blogger Title");
+    expect(parsed?.title).toBe('Hash N+200 "Mystery Hash"');
+  });
+
+  it.each([
+    ["inline 'The Hares:'", "Hash N+250\nSunday, 1st of June\nThe Hares: Alice & Bob", "Alice & Bob"],
+    ["inline 'Perpetrator(s):'", "Hash N+251\nSunday, 8th of June\nPerpetrator(s): Foghorn", "Foghorn"],
+    ["no hare line present", "Hash N+252\nSunday, 15th of June\nJust some prose about the weather.", undefined],
+  ])("extracts hares from %s", (_label, body, expected) => {
+    const parsed = parseBrasiliaPost(body, "2024-05-25T12:00:00-03:00", "https://brasiliah3.blogspot.com/x");
+    expect(parsed?.hares).toBe(expected);
   });
 
   it("returns null for a non-run post (no `Hash N+NNN` heading)", () => {
@@ -131,12 +161,15 @@ describe("BrasiliaH3Adapter.fetch", () => {
       date: "2026-06-07",
       kennelTags: ["brasilia-h3"],
       runNumber: 340,
+      title: 'Hash N+340 "Praça dos Orixás Hash"',
+      hares: "Sperm Bank",
+      location: "Praça dos Orixás",
     });
-    expect(result.events[0].title).toBeUndefined();
     expect(result.events[1]).toMatchObject({
       date: "2026-05-10",
       kennelTags: ["brasilia-h3"],
       runNumber: 338,
+      title: 'Hash N+338 "Farewell Hash"',
       location: "Road entrance to SQN 306, Asa Norte",
     });
     expect(result.diagnosticContext).toMatchObject({

--- a/src/adapters/html-scraper/brasilia-h3.ts
+++ b/src/adapters/html-scraper/brasilia-h3.ts
@@ -3,6 +3,7 @@ import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "..
 import { hasAnyErrors } from "../types";
 import { fetchBloggerPosts } from "../blogger-api";
 import { applyDateWindow, isPlaceholder, MONTHS, stripHtmlTags } from "../utils";
+import { extractHares } from "../hare-extraction";
 
 /**
  * Run heading: `Hash N+340 "Praça dos Orixás Hash"`. The kennel's post-reboot
@@ -37,12 +38,25 @@ const DATE_RE = /(\d{1,2})(?:st|nd|rd|th)?\s+of\s+([A-Za-z]+)\b/;
 const LOCATION_INLINE_RE = /^(?:📍\s*)?Start(?: Location)?:\s*(\S.*)/i;
 const LOCATION_HEADING_RE = /^(?:📍\s*)?Start(?: Location)?:?\s*$/i;
 
+/**
+ * Conservative prose-location fallback (#1982). Recent posts bury the meeting
+ * point in the lede prose ("This week we gather at Praça dos Orixás, where…")
+ * instead of a structured `Start:` line. Anchor on a gather/meet verb + "at"
+ * and capture a proper-noun place (capitalised initial — no /i, so the `[A-Z]`
+ * guard genuinely rejects "…meet at the park"). Bounded to the place phrase by
+ * stopping at the first comma/period/semicolon. Used ONLY when no structured
+ * `Start:` form matched; ambiguous lower-case prose stays undefined.
+ */
+const PROSE_LOCATION_RE = /\b(?:[Gg]ather|[Mm]eet)(?:ing)?\s+(?:this\s+week\s+)?at\s+([A-Z][^,.;(\n]{2,60})/; // NOSONAR — single bounded char-class capture (stops at , . ; ( newline), linear
+
 const DEFAULT_BLOG_URL = "https://brasiliah3.blogspot.com/";
 
 /** Structured fields extracted from one Blogspot post body. */
 export interface ParsedBrasiliaPost {
   runNumber: number;
   date: string; // YYYY-MM-DD
+  title?: string;
+  hares?: string;
   location?: string;
   sourceUrl: string;
 }
@@ -92,6 +106,26 @@ function parseRunDate(body: string, publishedIso: string): string | null {
   return inferDateString(day, month, publishedIso);
 }
 
+/**
+ * Collapse blank lines that immediately follow a label line (one ending in
+ * `:`). The blog double-spaces its role-header from the hare name
+ * ("This week's perpetrator:\n\n\nSperm Bank"); bringing the name adjacent lets
+ * the shared extractHares continuation pick it up. Blank lines elsewhere — in
+ * particular AFTER the name — are preserved, so trailing prose still terminates
+ * collection. Pure string ops (no regex quantifiers) to stay ReDoS-clear.
+ */
+function collapseBlankLinesAfterLabel(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    out.push(lines[i]);
+    if (lines[i].trimEnd().endsWith(":")) {
+      while (i + 1 < lines.length && lines[i + 1].trim() === "") i++;
+    }
+  }
+  return out.join("\n");
+}
+
 /** Trim a candidate venue, rejecting empty/placeholder text. */
 function cleanVenue(text: string): string | undefined {
   const venue = text.trim();
@@ -99,7 +133,11 @@ function cleanVenue(text: string): string | undefined {
   return venue;
 }
 
-/** Extract a clean venue from a `Start`-labelled line (inline or heading), or undefined. */
+/**
+ * Extract a clean venue: prefer a structured `Start`-labelled line (inline or
+ * heading), then fall back to the conservative prose pattern (#1982). Returns
+ * undefined when neither matches.
+ */
 function parseLocation(body: string): string | undefined {
   const lines = body.split("\n").map((line) => line.trim()).filter(Boolean);
   for (let i = 0; i < lines.length; i++) {
@@ -109,26 +147,33 @@ function parseLocation(body: string): string | undefined {
       return cleanVenue(lines[i + 1]);
     }
   }
+  const prose = PROSE_LOCATION_RE.exec(body);
+  if (prose) return cleanVenue(prose[1]);
   return undefined;
 }
 
 /**
  * Parse a single Brasilia H3 Blogspot post body into structured fields.
  *
- * Post titles are empty on this blog — all run data lives in the flattened
- * body HTML. A post is a run only if it carries a `Hash N+NNN` heading AND a
- * parseable date line; otherwise it returns null (skipped). Hares are
- * deliberately NOT extracted: this blog never uses an inline `Hares:` label,
- * only buried jokey prose, so attempting it would risk field-bleed.
+ * A post is a run only if it carries a `Hash N+NNN` heading AND a parseable
+ * date line; otherwise it returns null (skipped). The heading line itself is
+ * the source title (`Hash N+340 "Praça dos Orixás Hash"`, #1983) — captured
+ * verbatim rather than letting merge synthesize a generic "Trail #N". Hares are
+ * read from the role-header template the blog uses ("🐾 The Hare / This week's
+ * perpetrator: <name>", "The Hares:", "Perpetrator(s):") via the shared
+ * extractHares helper (#1981) — blank lines are collapsed first so the header→
+ * name continuation is adjacent.
  *
  * Exported so the one-shot history backfill can reuse it as a throwaway
  * extractor over the full Blogger archive (the backfill itself commits the
- * curated JSON output, not this parser).
+ * curated JSON output, not this parser). `postTitle` is the Blogger post title
+ * (often empty on this blog); the body heading line is preferred when present.
  */
 export function parseBrasiliaPost(
   body: string,
   publishedIso: string,
   url: string,
+  postTitle = "",
 ): ParsedBrasiliaPost | null {
   const runMatch = RUN_RE.exec(body);
   if (!runMatch) return null;
@@ -147,9 +192,26 @@ export function parseBrasiliaPost(
   return {
     runNumber,
     date,
+    title: parseTitle(afterHeading, postTitle),
+    // Collapse blanks between the role-header and the name so extractHares'
+    // continuation reaches it; the blank AFTER the name is preserved, so the
+    // surrounding jokey prose never bleeds in (#1981).
+    hares: extractHares(collapseBlankLinesAfterLabel(afterHeading)),
     location: parseLocation(afterHeading),
     sourceUrl: url,
   };
+}
+
+/**
+ * The run heading line is the source title (carries the quoted theme). Prefer
+ * it; fall back to the Blogger post title if the heading is somehow malformed.
+ * Length-guarded so a stray un-split body never becomes a runaway title.
+ */
+function parseTitle(afterHeading: string, postTitle: string): string | undefined {
+  const headingLine = afterHeading.split("\n")[0].trim();
+  if (headingLine.includes("N+") && headingLine.length <= 120) return headingLine;
+  const fallback = postTitle.trim();
+  return fallback.length > 0 && fallback.length <= 120 ? fallback : undefined;
 }
 
 /**
@@ -157,12 +219,12 @@ export function parseBrasiliaPost(
  * kennel). Reads brasiliah3.blogspot.com trail announcements via the Blogger
  * API v3 (keyed by GOOGLE_CALENDAR_API_KEY to bypass cloud-IP 403s).
  *
- * Each post is one biweekly Sunday run. Post titles are empty, so run number,
- * date (year inferred from the publish date), and venue are parsed from the
- * post body. Title is intentionally left undefined — the merge pipeline
- * synthesizes "Brasilia H3 Trail #NNN". This adapter fetches a recent window
- * only; the ~186-post archive back to 2019 loads via the one-shot backfill,
- * and `Source.config.upcomingOnly` keeps reconciliation from cancelling it.
+ * Each post is one biweekly Sunday run. Run number, date (year inferred from
+ * the publish date), title (the `Hash N+NNN "<theme>"` heading), hares (the
+ * blog's role-header template), and venue are parsed from the post body. This
+ * adapter fetches a recent window only; the full archive back to 2019 loads via
+ * the one-shot backfill, and `Source.config.upcomingOnly` keeps reconciliation
+ * from cancelling it.
  */
 export class BrasiliaH3Adapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
@@ -189,12 +251,14 @@ export class BrasiliaH3Adapter implements SourceAdapter {
 
     for (const post of bloggerResult.posts) {
       const body = stripHtmlTags(post.content, "\n");
-      const parsed = parseBrasiliaPost(body, post.published, post.url);
+      const parsed = parseBrasiliaPost(body, post.published, post.url, post.title);
       if (!parsed) continue;
       events.push({
         date: parsed.date,
         kennelTags: ["brasilia-h3"],
         runNumber: parsed.runNumber,
+        title: parsed.title,
+        hares: parsed.hares,
         location: parsed.location,
         sourceUrl: parsed.sourceUrl,
       });

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -181,7 +181,13 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /hockessinhash\.org/i,     name: "HockessinAdapter",         factory: () => new HockessinAdapter() },
   { pattern: /renegadeh3\.com/i,       name: "RenegadeH3Adapter",        factory: () => new RenegadeH3Adapter() },
   { pattern: /swh3\.wordpress\.com/i, name: "SWH3Adapter",              factory: () => new SWH3Adapter() },
-  { pattern: /onh3\.wordpress\.com/i, name: "ONH3Adapter",              factory: () => new ONH3Adapter() },
+  // `\b` anchor required: an unanchored `onh3\.wordpress\.com` matches the
+  // SUBSTRING inside `asunci‹onh3›.wordpress.com` (and `secessi‹onh3›…`), so it
+  // shadowed AsuncionH3Adapter — every Asunción cron scrape mis-routed to the
+  // Nairobi (ONH3) adapter and was silently dropped by the source-kennel guard.
+  // The boundary still matches ONH3's own `//onh3.wordpress.com`. (Same
+  // substring-collision class as #1869/#1968.)
+  { pattern: /\bonh3\.wordpress\.com/i, name: "ONH3Adapter",            factory: () => new ONH3Adapter() },
   { pattern: /asuncionh3\.wordpress\.com/i, name: "AsuncionH3Adapter",  factory: () => new AsuncionH3Adapter() },
   { pattern: /nch3\.com/i,            name: "NCH3Adapter",              factory: () => new NCH3Adapter() },
   { pattern: /sdh3\.com/i,            name: "SDH3Adapter",              factory: () => new SDH3Adapter() },


### PR DESCRIPTION
## Summary

The **6th instance** of the cross-kennel hare-extractor gap, plus per-kennel cleanup for the three new HTML-adapter kennels (Brasília, Asunción, Auckland). Prod was verified read-only first: most issues were already partially self-healed, so each item below records the real fix vs. the confirmed-state.

### Systemic hares helper (`src/adapters/hare-extraction.ts`)
Added the `<role-header>:\n<name>` template family to `DEFAULT_HARE_PATTERNS` (additive): **"The Hare(s):"**, **"Perpetrator(s):"**, **"This week's perpetrator:"**. Each requires a colon (prose like *"the hare set a trail"* can't match) and tolerates an emoji banner prefix. Comprehensive **positive + negative** fixtures; the shared `collectContinuationLines` was deliberately left at skip-**one**-blank so no existing consumer (gcal/meetup/phoenix/fb) changes behaviour — the double-spacing the blog uses is collapsed *inside the Brasília adapter only*.

### Adapters
- **brasilia-h3** — source title (`Hash N+NNN "<theme>"`), hares via the shared helper (label-local blank collapse so the header→name continuation is adjacent, prose never bleeds), conservative prose-location fallback. The historical archive is **prose-only for hares** (no labels), so only the recently-adopted label format extracts forward; this is a documented source limitation, not a parser miss.
- **asuncion-h3** — source title (`Run #N`); hares routed through `extractHares` (now covers `Hare:`/`Hares:`/`Hare(s):`), dropping the English-only `HARE_LINE_RE`.
- **auckland-hash** — `Run w/ <Hare>` titles; hares/location already correct.
- **registry** — anchored the ONH3 URL pattern (`\bonh3\.wordpress\.com`). Unanchored, it matched the substring inside `asunci‹onh3›.wordpress.com`, so every Asunción cron scrape mis-routed to the Nairobi (ONH3) adapter and was silently dropped by the source-kennel guard. Same substring-collision class as #1869/#1968.

### Seed + data
- `kennels.ts`: asu-h3 `facebookUrl`+`gm`; brasilia-h3 `facebookUrl` → `groups/BrasiliaH3`.
- Regenerated frozen archives (`scripts/data/{brasilia,asu}-h3-history.json`) + generator/audit scripts.

### Prod corrections applied + verified (Railway)
| Kennel | titles synth→ | hares null | location null |
|---|---|---|---|
| brasilia-h3 | 175 → **0** | 174 (archive prose-only) | 148 (`Start:`-labelled only; conservative) |
| asu-h3 | 120 → **0** | 1 (run #39 has no hare line in source) | 15 (source omits) |
| ah3-nz | 7 → **1** (one past event aged off the rolling list) | 0 ✓ | 2 (TBC + a source-malformed row) |

## Per-issue resolution

Closes #1981
Closes #1983
Closes #1982
Closes #1985
Closes #1980
Closes #1961
Closes #1960
Closes #1959
Closes #1965
Closes #1966
Closes #1963
Closes #1964
Closes #1968

- **#1981** Brasília hares — helper now extracts the role-header format forward (#340 → "Sperm Bank"). The 174 historical posts are free-prose with no hare label and are not safely recoverable (the original adapter deliberately skipped them; conservative approach confirmed).
- **#1983** Brasília titles — 174/174 archive + forward now carry the verbatim `Hash N+NNN "<theme>"` heading (synth titles 175→0).
- **#1982** Brasília location — `Start:` + conservative prose fallback; ambiguous prose left null per the conservative choice.
- **#1985** Brasília gap — #339 and the other gap runs have **no surviving blog post** (top runs jump 338→340), so they can't be inserted without fabricating data; all 174 available posts are loaded.
- **#1980** Brasília profile — `facebookUrl` corrected to the groups URL (foundedYear/day already correct).
- **#1961 / #1960** Asunción hares + titles — helper covers all `Hare:` variants (was 1 null, the run with no source hare line); titles set to `Run #N` (synth 120→0).
- **#1959** Asunción profile — `facebookUrl` + `gm` set.
- **#1965 / #1966** Auckland hares + location — already healed in prod (0 null hares; the 2 null locations are `Venue TBC` + a source-malformed row, both correct).
- **#1963** Auckland profile — already correct in prod (`foundedYear` 1970, `scheduleDay` Monday).
- **#1964** Auckland titles — `Run w/ <Hare>` synthesized for the active list.
- **#1968** Auckland Hash Rego — confirmed: Auckland is **not** on Hash Rego under any shortcode; `AH3` is Austin's. No config change; Austin intact.

## Verification
- `npx tsc --noEmit` ✓, `npm run lint` (0 errors) ✓, `npm test` (8495 passing) ✓
- Live-verified all three adapters against production sources; prod counts checked before/after.
- `/code-review` (high) + `/simplify` run pre-PR; findings addressed (confined the continuation change, removed a speculative export, tightened the prose-location boundary, de-duplicated the Asunción generator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)