### PR TITLE
Onboard Bangkok Monday H3 (bmh3-bkk) — adapter + 2002→2026 archive

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -513,6 +513,7 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "crh3": ["Chiang Rai H3", "Chiang Rai Hash", "CRH3", "Chiang Rai HHH"],
     "bkk-harriettes": ["BKK Harriettes", "Bangkok Harriettes", "Bangkok Harriettes H3", "Bangkok Harriets"],
     "bth3": ["BTH3", "Bangkok Thursday", "Bangkok Thursday Hash", "Bangkok Thursday H3"],
+    "bmh3-bkk": ["BMH3 Bangkok", "Bangkok Monday Hash House Harriers", "Bangkok Monday HHH", "Bangkok Monday Hash"],
     "bfmh3": ["BFMH3", "Bangkok Full Moon", "Bangkok Fullmoon", "Bangkok Full Moon Hash", "Bangkok Fullmoon H3"],
     "s2h3": ["S2H3", "Siam Sunday", "Siam Sunday Hash", "Siam Sunday H3"],
     "phhh": ["PHHH", "Phuket Hash", "Phuket HHH", "Phuket H3", "Phuket Saturday Hash"],

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -4137,6 +4137,19 @@ export const KENNELS: KennelSeed[] = [
       latitude: 13.76, longitude: 100.5,
     },
     {
+      kennelCode: "bmh3-bkk", shortName: "Bangkok Monday H3",
+      fullName: "Bangkok Monday Hash House Harriers",
+      region: "Bangkok", country: "Thailand",
+      website: "https://bangkokmondayhhh.com",
+      facebookUrl: "https://www.facebook.com/groups/376239262431489",
+      foundedYear: 1982,
+      scheduleDayOfWeek: "Monday", scheduleTime: "5:30 PM", scheduleFrequency: "Weekly",
+      hashCash: "฿250 men / ฿200 women (+฿50 non-members); ฿300 life membership",
+      description:
+        "Bangkok's Monday-night hash since 1982 — 7–8 km runs in a different spot around the city each week (usually the outskirts), followed by beers and a circle. Informal and visitor-friendly; Thai, foreign, resident, or visiting, all welcome.",
+      latitude: 13.7563, longitude: 100.5018,
+    },
+    {
       kennelCode: "bfmh3", shortName: "BFMH3", fullName: "Bangkok Full Moon Hash House Harriers",
       region: "Bangkok", country: "Thailand",
       website: "https://www.bangkokhash.com/fullmoon/index.php",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -5462,6 +5462,17 @@ export const SOURCES = [
       config: {},
       kennelCodes: ["bkk-harriettes"],
     },
+    // --- Bangkok Monday Hash (static HTML hareline) ---
+    {
+      name: "Bangkok Monday H3 Hareline",
+      url: "https://bangkokmondayhhh.com/FutureHares.html",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "daily",
+      scrapeDays: 365,
+      config: { upcomingOnly: true },
+      kennelCodes: ["bmh3-bkk"],
+    },
     // --- Bangkok Thursday Hash (Joomla + PHP API) ---
     {
       name: "Bangkok Thursday Hash",

--- a/scripts/backfill-bmh3-bkk-history.ts
+++ b/scripts/backfill-bmh3-bkk-history.ts
@@ -1,0 +1,40 @@
+/**
+ * One-shot historical backfill for Bangkok Monday H3 (bmh3-bkk).
+ *
+ * bangkokmondayhhh.com publishes a clean per-year run archive (Index2002.html …
+ * Index2026.html, ~1,185 runs #981→#2212). The recurring adapter only reads the
+ * forward hareline + homepage (config.upcomingOnly), so the 2002→2026 archive
+ * would never reach canonical Events.
+ *
+ * The archive was extracted once (throwaway walker over the year indexes, reusing
+ * the adapter's row parser) and frozen into `scripts/data/bmh3-bkk-history.json`.
+ * This loader just replays that curated dataset through the merge pipeline; rows
+ * bind to the "Bangkok Monday H3 Hareline" source for provenance.
+ *
+ * Re-runnable: `reportAndApplyBackfill` dedupes by fingerprint on every row, and
+ * partitions to strictly-past rows (date < today in Asia/Bangkok).
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-bmh3-bkk-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-bmh3-bkk-history.ts
+ *
+ * Requires the "Bangkok Monday H3 Hareline" source to exist (run
+ * `npx prisma db seed`).
+ */
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import type { RawEventData } from "@/adapters/types";
+import bmh3History from "./data/bmh3-bkk-history.json";
+
+const SOURCE_NAME = "Bangkok Monday H3 Hareline";
+const KENNEL_TIMEZONE = "Asia/Bangkok";
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Loading curated bangkokmondayhhh.com run archive (2002→2026)",
+  fetchEvents: async () => bmh3History as RawEventData[],
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/data/bmh3-bkk-history.json
+++ b/scripts/data/bmh3-bkk-history.json
@@ -1,0 +1,11852 @@
+[
+ {
+  "date": "2002-01-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 981,
+  "hares": "Vinai Seesar",
+  "location": "Just beyond the Hash Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-01-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 982,
+  "hares": "Bruce 'Hash Hash' Weeks",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-01-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 983,
+  "hares": "Faisal Mookerdum",
+  "location": "Yathika Restaurant, Ramindra Expressway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-01-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 984,
+  "hares": "Tom Ellefsen",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-02-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 985,
+  "hares": "Tim Daly",
+  "location": "Chatuchak Railway Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-02-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 986,
+  "hares": "George Morgan",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-02-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 987,
+  "hares": "Peter Laverick",
+  "location": "Baan Khieng Nam Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-02-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 988,
+  "hares": "John Hendrickson",
+  "location": "Wat Saimai Tai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-03-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 989,
+  "hares": "Pam Carter",
+  "location": "Ramintra, Wat Pra Ruang Prasit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-03-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 990,
+  "hares": "Lem Morgan",
+  "location": "Suan Somdej Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-03-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 991,
+  "hares": "Bo Eskesen",
+  "location": "Krungthep Kreeta Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-03-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 992,
+  "hares": "Neil Biggadike",
+  "location": "Wat Saeng Siritham",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-04-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 993,
+  "hares": "Finn Sorensen",
+  "location": "Khrua Tung Luang Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-04-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 994,
+  "hares": "John Courtney",
+  "location": "Near Rama IX Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-04-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 995,
+  "hares": "Frank Allum",
+  "location": "Khrua Tung Luang Restaurant Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-04-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 996,
+  "hares": "Graeme Bristol",
+  "location": "King Mongkut Technology University",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-04-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 997,
+  "hares": "Neil Hutchinson",
+  "location": "Muang Kaew golf course Bang Na-Trad highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-05-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 998,
+  "hares": "Mike Burgess",
+  "location": "Muang Kaew golf course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-05-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 999,
+  "hares": "Todd Wilkie",
+  "location": "Suan Koy Restaurant (Over Taksin Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-05-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1000,
+  "hares": "Bob Boulter/Tony Erswell",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-05-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1001,
+  "hares": "Marc Lavoie",
+  "location": "Piyavan Resort",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-06-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1002,
+  "hares": "Ian Slater",
+  "location": "Wat Molee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-06-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1003,
+  "hares": "Diane Furst",
+  "location": "Baan Khieng Nam Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-06-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1004,
+  "hares": "Derek Tavender",
+  "location": "A fish restaurant near Wat Bang Rak Noi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-06-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1005,
+  "hares": "Ed Rubesch",
+  "location": "Near Wat Saeng Siritham",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-07-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1006,
+  "hares": "Tom Sorensen",
+  "location": "Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-07-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1007,
+  "hares": "Ian Slater and Alastair",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-07-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1008,
+  "hares": "Bob Boulter",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-07-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1009,
+  "hares": "Tim Wienands",
+  "location": "Khrua Tung Luang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-07-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1010,
+  "hares": "Mike Rust",
+  "location": "Wat Prok, Sathorn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-08-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1011,
+  "hares": "It and Tim W",
+  "location": "Chaan May Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-08-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1012,
+  "hares": "Peter Laverick",
+  "location": "Baan Khieng Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-08-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1013,
+  "hares": "Christi Holleman",
+  "location": "Pakkret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-08-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1014,
+  "hares": "Andrew McPherson",
+  "location": "Wat Sak Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-09-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1015,
+  "hares": "Rod Turner",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-09-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1016,
+  "hares": "Teerachai Reinsubdee",
+  "location": "Sapan Nangklao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-09-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1017,
+  "hares": "Neil Biggadike",
+  "location": "Wat Tha It (over Nangklao Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-09-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1018,
+  "hares": "Narest Ratanapinanchai",
+  "location": "Bang Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-09-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1019,
+  "hares": "Bruce Weeks",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-10-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1020,
+  "hares": "Faisal Mookerdum",
+  "location": "Yathika Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-10-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1021,
+  "hares": "Tim Wienands",
+  "location": "Chonburi Motorway Chaan Maay Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-10-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1022,
+  "hares": "Mike Burgess",
+  "location": "Muang Kaew Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-10-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1023,
+  "hares": "AGPU Bo Eskasen and Marc Lavoie",
+  "location": "Noriega's Bar",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-11-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1024,
+  "hares": "Ed Rubesch",
+  "location": "Railway Park, Chatuchak",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-11-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1025,
+  "hares": "Piya Romyanond",
+  "location": "Romklao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-11-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1026,
+  "hares": "Khun Nit, It and Narest",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-11-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1027,
+  "hares": "Khun Som",
+  "location": "Muang Kaew Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-12-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1028,
+  "hares": "Tim Daly",
+  "location": "Hua Lamphong Station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-12-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1029,
+  "hares": "Vinai Seesar",
+  "location": "Wat Sai Ma Nua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-12-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1030,
+  "hares": "Tim Wienands",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-12-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1031,
+  "hares": "Vichai and Piya",
+  "location": "Ramintra Soi 6/2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2002-12-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1032,
+  "hares": "Diane and Steve Furst",
+  "location": "Baan Khieng Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-01-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1033,
+  "hares": "Frank Allum",
+  "location": "Khrua Tung Luang Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-01-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1034,
+  "hares": "Erik Ravn",
+  "location": "Just beyond the Nangklao Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-01-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1035,
+  "hares": "Tom Ellefsen",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-01-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1036,
+  "hares": "George Morgan",
+  "location": "Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-02-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1037,
+  "hares": "Graeme Bywater",
+  "location": "Bang Plee Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-02-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1038,
+  "hares": "Wichanee Charutas",
+  "location": "Wat Pra Ruang Prasit Ramindra",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-02-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1039,
+  "hares": "Roberto Guzman",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-02-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1040,
+  "hares": "Pam Carter",
+  "location": "Krungthep Kreeta Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-03-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1041,
+  "hares": "Bruce Weeks",
+  "location": "Noriegas, Silom Soi 4",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-03-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1042,
+  "hares": "Lem Morgan",
+  "location": "Suan Somdej, 'Ides of March' run",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-03-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1043,
+  "hares": "John Courtney",
+  "location": "Onnut/UdomSuk St Patrick's Day Run",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-03-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1044,
+  "hares": "Margarita Hernandez",
+  "location": "Pae Rong Floating Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-03-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1045,
+  "hares": "Bob Boulter",
+  "location": "Wat Sing Tong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-04-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1046,
+  "hares": "Christi Holleman",
+  "location": "Pakkret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-04-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1047,
+  "hares": "Andrew McPherson",
+  "location": "Wat Bang Khanun, Bang Kruay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-04-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1048,
+  "hares": "Teerachai",
+  "location": "Railway Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-04-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1049,
+  "hares": "Peter Laverick",
+  "location": "Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-05-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1050,
+  "hares": "Mike Burgess",
+  "location": "Muang Keow Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-05-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1051,
+  "hares": "Joost Zwagger",
+  "location": "Pakkret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-05-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1052,
+  "hares": "Lynda Sharpe",
+  "location": "Wat Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-05-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1053,
+  "hares": "Vichai S",
+  "location": "Bang Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-06-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1054,
+  "hares": "Ian Slater",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-06-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1055,
+  "hares": "Todd Wilkie",
+  "location": "Wat Champa",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-06-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1056,
+  "hares": "Mike Belew",
+  "location": "Noriegas Silom Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-06-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1057,
+  "hares": "Faisal M",
+  "location": "Ramindra Expressway Yathika Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-06-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1058,
+  "hares": "Graeme Bristol",
+  "location": "Pracha Utit Road (Over Rama 9 Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-07-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1059,
+  "hares": "Mike Rust",
+  "location": "Pracha Utit Road Soi 72 (Over Rama 9 Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-07-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1060,
+  "hares": "Marie Blond",
+  "location": "Wat Sing Tong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-07-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1061,
+  "hares": "Jumpstart",
+  "location": "Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-07-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1062,
+  "hares": "John Courtney",
+  "location": "Onnut Soi 66",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-08-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1063,
+  "hares": "John Sim",
+  "location": "Wat Saeng Siritham",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-08-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1064,
+  "hares": "Finn Sorensen",
+  "location": "Outer Ring Road Khrua Tung Luang Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-08-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1065,
+  "hares": "Alastair Atkinson",
+  "location": "Central Post Office Charoen Krung Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-08-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1066,
+  "hares": "Mike Rust",
+  "location": "Bulls Head Pub Sukhumvit Soi 33/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-09-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1067,
+  "hares": "Neil Biggadyke",
+  "location": "Wat Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-09-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1068,
+  "hares": "Rod Turner",
+  "location": "Pakkret Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-09-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1069,
+  "hares": "Maew Hutchinson",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-09-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1070,
+  "hares": "Clive Bryan",
+  "location": "Muang Keow Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-09-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1071,
+  "hares": "Mike Burgess and Som",
+  "location": "Bang Plee Par 3 Gold Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-10-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1072,
+  "hares": "Cengiz Ertuna",
+  "location": "Baan Suan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-10-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1073,
+  "hares": "Bo Eskesen",
+  "location": "Krungthep Kreeta Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-10-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1074,
+  "hares": "Brian Heath",
+  "location": "Unico Golf Course Krungthep Kreeta Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-10-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1075,
+  "hares": "Graeme Bywater",
+  "location": "Wat Keaw Pitak Soi Udomsuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-11-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1076,
+  "hares": "Narest",
+  "location": "Big C Car Park Nonthaburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-11-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1077,
+  "hares": "Tony 'Ambrose' Erswell",
+  "location": "Wat Banglane Charoen",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-11-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1078,
+  "hares": "Pam Carter",
+  "location": "Krungthep Kreeta Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-11-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1079,
+  "hares": "Tim Wienands",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-12-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1080,
+  "hares": "George Morgan",
+  "location": "Run Baan George Morgan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-12-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1081,
+  "hares": "Rod Turner",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-12-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1082,
+  "hares": "Mike Rust",
+  "location": "Wat Keh (over Rama 5 Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-12-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1083,
+  "hares": "Carlos TST and Ian Slater",
+  "location": "Outer Ring Road Khrua Tung Luang Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2003-12-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1084,
+  "hares": "Vichai Suphasomboon",
+  "location": "The Hash Bridge Saphan Nangklao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-01-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1085,
+  "hares": "Tim Wienands",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-01-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1086,
+  "hares": "Neil Biggadike",
+  "location": "Wat Yai Swang Arom (over the Hash Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-01-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1087,
+  "hares": "Tom Ellefsen",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-01-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1088,
+  "hares": "Steve Furst",
+  "location": "Wat Song Phlu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-02-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1089,
+  "hares": "George Morgan",
+  "location": "Ramkhamhaeng Soi 112",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-02-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1090,
+  "hares": "Vinai",
+  "location": "Saphan Nangklao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-02-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1091,
+  "hares": "Bob Boulter",
+  "location": "Wat Sing Tong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-02-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1092,
+  "hares": "Bruce Weeks",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-03-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1093,
+  "hares": "Lem Morgan",
+  "location": "Wat Khae Nai Bang Kruay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-03-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1094,
+  "hares": "Jeanine Souren",
+  "location": "Wat Sing Tong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-03-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1095,
+  "hares": "Bo Eskesen",
+  "location": "Unico Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-03-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1096,
+  "hares": "Lynda Sharp",
+  "location": "Wat Yai Swang Arom",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-03-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1097,
+  "hares": "Daeng Chuntong",
+  "location": "Bang Yai (Y-junction)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-04-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1098,
+  "hares": "Christi Hollerman",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-04-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1099,
+  "hares": "Andrew Murison",
+  "location": "Mopla Restaurant Bang Na-Trad Highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-04-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1100,
+  "hares": "Vinai",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-04-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1101,
+  "hares": "Andrew McPherson",
+  "location": "Wat Bang Khanun",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-05-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1102,
+  "hares": "Jason Cordray",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-05-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1103,
+  "hares": "Mike Burgess",
+  "location": "Ramkhanghaeng Soi 184",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-05-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1104,
+  "hares": "Joost Zwagger",
+  "location": "Pakkret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-05-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1105,
+  "hares": "Todd Wilkie",
+  "location": "Wat Pradu Taling Chan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-05-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1106,
+  "hares": "Pam Carter and Ian Slater",
+  "location": "Near Wat Saeng Siritham",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-06-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1107,
+  "hares": "Mike Belew (Mr Happy)",
+  "location": "Baan Suan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-06-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1108,
+  "hares": "Malinee K",
+  "location": "Wat Sanam Nuar Pakkret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-06-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1109,
+  "hares": "Wichanee",
+  "location": "Wat Pra Ruang Prasit Ramindra",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-06-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1110,
+  "hares": "Fizal Mookerdum",
+  "location": "Under the Hash Bridge Sapan Nangklao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-07-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1111,
+  "hares": "Rin Hoberhaus",
+  "location": "Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-07-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1112,
+  "hares": "Marie Blond",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-07-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1113,
+  "hares": "Jeff Reynolds",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-07-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1114,
+  "hares": "George Morgan",
+  "location": "Noriega's",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-08-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1115,
+  "hares": "Peter Laverick",
+  "location": "Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-08-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1116,
+  "hares": "Alastair Atkinson",
+  "location": "UNICO Golf course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-08-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1117,
+  "hares": "Rod Turner",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-08-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1118,
+  "hares": "Tim Wienands",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-08-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1119,
+  "hares": "Lem Morgan",
+  "location": "Wat Khae Nai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-09-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1120,
+  "hares": "Vichai 'Cool' Pechardkhao",
+  "location": "Suan Luang Park Soi Udomsuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-09-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1121,
+  "hares": "Brian Heath",
+  "location": "Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-09-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1122,
+  "hares": "Eric Ravn",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-09-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1123,
+  "hares": "Cengis Ertuna",
+  "location": "Baan Suan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-10-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1124,
+  "hares": "Bruce Marks",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-10-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1125,
+  "hares": "Tom Sorensen",
+  "location": "Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-10-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1126,
+  "hares": "Narest Ratanapinanchai",
+  "location": "Tha It 2km past the Hash Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-10-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1127,
+  "hares": "Frank Allum",
+  "location": "Wat Saphan (over Taksin Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-11-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1128,
+  "hares": "Khun Bussanee",
+  "location": "Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-11-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1129,
+  "hares": "Paul Loke/Peter Laverick",
+  "location": "Wat Bang Lane Charoen Bang Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-11-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1130,
+  "hares": "JMs Graeme Bywater and Peter Laverick",
+  "location": "Baan Khieng Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-11-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1131,
+  "hares": "Ex-GM George Morgan",
+  "location": "Baan Morgan Mooban Panya",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-11-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1132,
+  "hares": "Peter Laverick",
+  "location": "Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-12-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1133,
+  "hares": "Nid Parichard",
+  "location": "Outer Ring Road Hoffmann Haus",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-12-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1134,
+  "hares": "Mike Burgess",
+  "location": "Bang Plee Par 3 Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-12-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1135,
+  "hares": "Frank Allum",
+  "location": "Wat Saphan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2004-12-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1136,
+  "hares": "Graeme Bywater",
+  "location": "Mo Pla Restaurant Bang Na-Trad highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-01-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1137,
+  "hares": "George Bevington",
+  "location": "Wat Keaw Pitak Soi Udomsuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-01-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1138,
+  "hares": "Todd Wilkie",
+  "location": "Near Wat Pradu Over the Taksin Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-01-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1139,
+  "hares": "Marie Blond",
+  "location": "Wat Sing Tong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-01-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1140,
+  "hares": "Andrew 'NO NO' Murison",
+  "location": "Mopla Restaurant Bang Na Trad Highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-02-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1142,
+  "hares": "Bob 'Bullet' Boulter",
+  "location": "Wat Cherng Lane",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-02-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1143,
+  "hares": "Bruce Marks",
+  "location": "Muang Kaew Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-02-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1144,
+  "hares": "Pitak Chuntong",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-02-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1145,
+  "hares": "Lem Morgan",
+  "location": "Wat Khae Nai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-03-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1146,
+  "hares": "Bruce 'Hash Hash' Weeks",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-03-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1147,
+  "hares": "Tim 'Crash' Daly",
+  "location": "Sukhumvit Soi 103",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-03-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1148,
+  "hares": "Cenghis 'Disgusting' Ertuna",
+  "location": "Baan Suan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-03-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1149,
+  "hares": "Narest Ratanapin",
+  "location": "Wat Pracha Rangsan Bang Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-04-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1150,
+  "hares": "Roberto Guzman and Hotmix",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-04-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1151,
+  "hares": "Graeme 'Lenscap' Bywater",
+  "location": "Bang Plee Par 3 Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-04-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1152,
+  "hares": "Maew Hutchinson",
+  "location": "Khrua Sadet Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-04-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1153,
+  "hares": "Ian Slater and Cengis",
+  "location": "Baan Suan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-05-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1154,
+  "hares": "Matt Ryder",
+  "location": "Prakanong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-05-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1155,
+  "hares": "John Hawkins",
+  "location": "Sukhumvit Soi 10",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-05-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1156,
+  "hares": "Pam Carter",
+  "location": "Krungthep Kreetha Pond",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-05-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1157,
+  "hares": "Neil & Lynda",
+  "location": "Pathum Thani",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-05-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1158,
+  "hares": "Bo Eskesen",
+  "location": "Unico Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-06-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1159,
+  "hares": "Joost Zwagger",
+  "location": "Wat Cherng Lane",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-06-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1160,
+  "hares": "Vichai 'Cool'",
+  "location": "Soi Udomsuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-06-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1161,
+  "hares": "Neil Biggadike",
+  "location": "Wat Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-06-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1162,
+  "hares": "Andrew McPherson",
+  "location": "Wat Song Plu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-07-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1163,
+  "hares": "Bruce Weeks",
+  "location": "Baan Bruce Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-07-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1164,
+  "hares": "Kim Chaubert",
+  "location": "Chateau Chaubert Rama 9 Soi 37",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-07-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1165,
+  "hares": "Rod Turner",
+  "location": "Bang Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-07-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1166,
+  "hares": "George Morgan",
+  "location": "Baan George Moobaan Panya",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-08-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1167,
+  "hares": "Fizal Mookerdum",
+  "location": "Yathika Restaurant Ramindra Expressway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-08-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1168,
+  "hares": "Alastair Atkinson",
+  "location": "Unico Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-08-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1169,
+  "hares": "Vinai Seesar",
+  "location": "Moo Baan Rachapuek Rattana Tibet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-08-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1170,
+  "hares": "Paul Loke",
+  "location": "Chaeng Wattana Soi 13",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-08-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1171,
+  "hares": "May Wongsa",
+  "location": "Krungthep Kreeta Pond",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-09-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1172,
+  "hares": "Vichai 'The Senator'",
+  "location": "Luxurious Restaurant (over Rama 5 Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-09-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1173,
+  "hares": "Diane Furst",
+  "location": "Virgin Restaurant (over Rama 5 Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-09-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1174,
+  "hares": "Erik Ravn",
+  "location": "Moobaan Rachapuek Ratana Tibet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-09-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1175,
+  "hares": "Richard Ramsden",
+  "location": "Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-10-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1176,
+  "hares": "Mike and Som",
+  "location": "Im Pla Pao Restaurant (over Rama 5 Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-10-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1177,
+  "hares": "Tom Sorensen",
+  "location": "Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-10-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1178,
+  "hares": "Ching 'ABP'",
+  "location": "Sukhumvit Soi 34",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-10-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1179,
+  "hares": "Maarten Brusselers",
+  "location": "Romklao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-10-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1180,
+  "hares": "Bussanee 'It' Mungdee",
+  "location": "Lat Krabang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-11-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1181,
+  "hares": "Wichanee",
+  "location": "Wat Pra Ruang Prasit Ramindra",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-11-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1182,
+  "hares": "Peter Laverick",
+  "location": "Near Wat Khien Over Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-11-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1183,
+  "hares": "*** *** Alastair and Bruce",
+  "location": "San Ya Restaurant Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-11-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1184,
+  "hares": "Graeme 'Mini' Bristol",
+  "location": "Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-12-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1185,
+  "hares": "John McBirnie",
+  "location": "Chareon Krung Road Central Post Office",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-12-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1186,
+  "hares": "Tim Wienands",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-12-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1187,
+  "hares": "Jumpstart and Mudguard",
+  "location": "Wat Hua Kwu, Near the new airport",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2005-12-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1188,
+  "hares": "Steve Furst",
+  "location": "Maeprung Pra Pao Restaurant Over Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-01-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1189,
+  "hares": "Graeme Bywater",
+  "location": "Bang Plee Par 3 Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-01-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1190,
+  "hares": "Mike Burgess",
+  "location": "Wat Kaew Pitak",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-01-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1191,
+  "hares": "Andrew Murison",
+  "location": "Hua Pla Restaurant, Bang Na-Trad highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-01-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1192,
+  "hares": "Todd Wilkie",
+  "location": "Charan Sanit Wong Soi 13",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-01-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1193,
+  "hares": "Ian Slater",
+  "location": "Premier Entertainment Complex, Rama 9 Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-02-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1194,
+  "hares": "Frank Allum",
+  "location": "Near Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-02-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1195,
+  "hares": "Rod Turner",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-02-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1196,
+  "hares": "Cenghis Ertuna",
+  "location": "Baan Suan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-02-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1197,
+  "hares": "Pitak and Vinai",
+  "location": "Tim Daly's Palace",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-03-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1198,
+  "hares": "Bruce Weeks",
+  "location": "Baan Khieng Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-03-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1199,
+  "hares": "Malinee Kanchanapop",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-03-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1200,
+  "hares": "Lem and Cengis",
+  "location": "Near Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-03-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1201,
+  "hares": "Narest",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-04-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1202,
+  "hares": "Kim Chaubert",
+  "location": "Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-04-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1203,
+  "hares": "Tom Ellefsen",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-04-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1204,
+  "hares": "Maarten Brusselers",
+  "location": "Wat Thong Samrit, Lat Krabang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-04-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1205,
+  "hares": "Ching Wu",
+  "location": "Yok Krok Restaurant, Ratchapruek Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-05-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1206,
+  "hares": "Matt Ryder",
+  "location": "Town in Town",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-05-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1207,
+  "hares": "Rod Turner",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-05-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1208,
+  "hares": "Neil Biggadike",
+  "location": "Near Wat Yai/Wat Sing Tong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-05-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1209,
+  "hares": "Vichai Cool",
+  "location": "Udomsuk Soi 62",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-05-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1210,
+  "hares": "Joost Zwager",
+  "location": "Wat Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-06-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1211,
+  "hares": "Bob Boulter",
+  "location": "Klong Prapa",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-06-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1212,
+  "hares": "Wichanee",
+  "location": "Ban Suan Thong restaurant (beyond the Hash Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-06-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1213,
+  "hares": "Alastair Atkinson",
+  "location": "Unico Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-06-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1214,
+  "hares": "Tim Wienands",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-07-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1215,
+  "hares": "Graeme Bristol",
+  "location": "Pracha Utit Road, Thonburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-07-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1216,
+  "hares": "Teerachai",
+  "location": "Hash Bridge (Sapan Nangklao)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-07-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1217,
+  "hares": "Eric Ravn",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-07-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1218,
+  "hares": "George Morgan",
+  "location": "Noriega's bar, Silom Soi 4",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-07-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1219,
+  "hares": "Rod Turner",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-08-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1220,
+  "hares": "Vinai and Tim Daly",
+  "location": "Baan Suan Thong restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-08-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1221,
+  "hares": "Finn Sorensen",
+  "location": "Outer Ring Road - Hoffman Haus Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-08-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1222,
+  "hares": "Paul Loke",
+  "location": "Wat Toei, Pakkret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-08-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1223,
+  "hares": "Vichai Suphasomboon",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-09-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1224,
+  "hares": "Marie Blond",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-09-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1225,
+  "hares": "Mike and Som Burgess",
+  "location": "Muang Kaew Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-09-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1226,
+  "hares": "Diane Furst",
+  "location": "Bansuan Golf Driving Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-09-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1227,
+  "hares": "Nid Parichard",
+  "location": "Wat Kaew Pitak, Soi Udomsukk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-10-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1228,
+  "hares": "Lynda Sharp",
+  "location": "Beyond the Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-10-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1229,
+  "hares": "Christi Holleman and Sunee",
+  "location": "Wat Sing Tong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-10-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1230,
+  "hares": "Tom Sorensen",
+  "location": "Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-10-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1231,
+  "hares": "It and Vinai",
+  "location": "Nakhon Inn Road (over Rama 5 Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-10-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1232,
+  "hares": "Peter Laverick",
+  "location": "Nakhon Inn Road (over Rama 5 Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-11-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1233,
+  "hares": "Tim Wienands",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-11-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1234,
+  "hares": "Greg \"Tickler\" Cable",
+  "location": "Wat Sai, Bang Kruay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-11-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1235,
+  "hares": "JMs - run",
+  "location": "San Ya Restaurant, Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-11-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1236,
+  "hares": "Noah Shepherd",
+  "location": "Outer Ring Road, Unfinished Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-12-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1237,
+  "hares": "Rod Turner",
+  "location": "Bang Yai Y junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-12-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1238,
+  "hares": "Andrew Murison",
+  "location": "Hua Pla restaurant, Bang Na-Trad Highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-12-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1239,
+  "hares": "Todd Wilkie",
+  "location": "Wat Rang Bua, over Taksin Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2006-12-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1240,
+  "hares": "Mike Burgess",
+  "location": "Near Wat Kaew Pitak, Soi Udomsuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-01-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1241,
+  "hares": "Steve Furst",
+  "location": "Bansuan Golf Range, over Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-01-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1242,
+  "hares": "Vichai Cool and Piya",
+  "location": "Sri Nakarin, Country Villa",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-01-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1243,
+  "hares": "Ian Slater",
+  "location": "Assumption University, Ramkamhaeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-01-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1244,
+  "hares": "Matt Ryder",
+  "location": "Prakanong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-01-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1245,
+  "hares": "Cengis Ertuna",
+  "location": "Bang Kruay, Wat Sai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-02-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1246,
+  "hares": "Paul Loke",
+  "location": "Wat Sapan Sung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-02-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1247,
+  "hares": "Mike Rust and Frank Allum",
+  "location": "Wat Sapan, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-02-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1248,
+  "hares": "Narest",
+  "location": "Bansuan Golf Driving Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-02-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1249,
+  "hares": "Bruce Weeks",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-03-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1250,
+  "hares": "Marc Lavoie",
+  "location": "Sri Nakarin Klong Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-03-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1251,
+  "hares": "Pitak, Vinai and Stumbles",
+  "location": "BMH3 25 years old",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-03-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1252,
+  "hares": "Teerachai",
+  "location": "Hash Bridge (Saphan Pra Nang Klao)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-03-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1253,
+  "hares": "Joost Zwager",
+  "location": "Wat Pra Ruang Prasit, Ramindra",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-04-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1254,
+  "hares": "Maarten Brusselers",
+  "location": "Bang Namphueng Floating Market, Prapadaeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-04-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1255,
+  "hares": "Noah Shepherd",
+  "location": "Unfinished bridge, Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-04-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1256,
+  "hares": "Tim Wienands",
+  "location": "Over the Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-04-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1257,
+  "hares": "Piya",
+  "location": "Sri Nakarin, Moobaan Country Villa",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-04-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1258,
+  "hares": "Christi Holleman and Joost",
+  "location": "Klong Koi Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-05-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1259,
+  "hares": "Rod Turner and Vichai Cool",
+  "location": "Lan Suun Restaurant, Rangsit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-05-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1260,
+  "hares": "Ching Wu",
+  "location": "Wat Sapan, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-05-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1261,
+  "hares": "Neil Biggadike",
+  "location": "Unico Golf Course, Krunthep Kreeta Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-05-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1262,
+  "hares": "Bob Boulter",
+  "location": "Wat Sri Rat, Bang Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-06-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1263,
+  "hares": "Tom Ellefsen",
+  "location": "Sri Nakarin Klong Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-06-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1264,
+  "hares": "Alastair Atkinson",
+  "location": "Unico Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-06-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1265,
+  "hares": "Greg \"The Tickler\" Cable",
+  "location": "Deli Home Restaurant, Bang Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-06-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1266,
+  "hares": "Struan Robertson",
+  "location": "Spiceroads, Sukhumvit Soi 49/13",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-07-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1267,
+  "hares": "KC",
+  "location": "Sanya Restaurant, Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-07-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1268,
+  "hares": "Malinee Kanchanapop",
+  "location": "Baan Suan Golf Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-07-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1269,
+  "hares": "Geoff Reynolds",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-07-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1270,
+  "hares": "George Morgan",
+  "location": "Tokyo Joe's, Sukhumvit Soi 26",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-07-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1271,
+  "hares": "Lem Morgan",
+  "location": "Bo Gung Pao Restaurant, Bang Kruay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-08-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1272,
+  "hares": "Vichai The Senator",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-08-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1273,
+  "hares": "Rin \"Jumpstart\"",
+  "location": "Im Pla Pao Restaurant, Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-08-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1274,
+  "hares": "Capt'n Erik",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-08-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1275,
+  "hares": "Mike Rust and Sego",
+  "location": "Suksawat Soi 30",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-09-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1276,
+  "hares": "Marie Blond",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-09-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1277,
+  "hares": "Finn Sorensen",
+  "location": "Outer Ring Road, Hoffmann Haus",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-09-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1278,
+  "hares": "Mike Burgess",
+  "location": "Wat Kaew Pitak, Sukhumvit 103",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-09-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1279,
+  "hares": "Tim Daly",
+  "location": "Krua Klang Bung Restaurant, Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-10-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1280,
+  "hares": "Tom Sorensen",
+  "location": "Srinakarin/Onnut",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-10-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1281,
+  "hares": "Mike Burgess",
+  "location": "Wat Kaew Pitak, Sukhumvit 103",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-10-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1282,
+  "hares": "Diane Furst",
+  "location": "Sukhumvit Soi 23",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-10-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1283,
+  "hares": "Andrew Murison",
+  "location": "Hua Pla Restaurant, Bang Na-Trad Highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-10-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1284,
+  "hares": "Lynda Sharp",
+  "location": "Wat Mollee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-11-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1285,
+  "hares": "Todd Wilkie",
+  "location": "Soi Komate, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-11-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1286,
+  "hares": "Rod Turner",
+  "location": "Bang Yai Y-Junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-11-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1287,
+  "hares": "Joint Masters Paul \"KKB\" Loke and Bog Diver",
+  "location": "Ratchapreuk Road near Chaiyapruek Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-11-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1288,
+  "hares": "Ex GM No Good Boyo",
+  "location": "Tien Lai Restaurant, Nakorn Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-12-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1289,
+  "hares": "Ian \"AKM\" Slater",
+  "location": "Assumption University (ABAC), Ramkamhaeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-12-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1290,
+  "hares": "Steve \"Tastes Great\" Furst",
+  "location": "Rachapruek Rd just north of the Chaiyapruek Rd",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-12-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1291,
+  "hares": "Peter \"Maverick\" Laverick",
+  "location": "On Golden Pond, Krungtep Kreeta Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-12-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1292,
+  "hares": "Peter Haycocks",
+  "location": "Sukhumvit Soi 35",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2007-12-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1293,
+  "hares": "Mike \"Sugar Daddy\" B",
+  "location": "Noriegas, Silom Soi 4",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-01-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1294,
+  "hares": "It Shepherd",
+  "location": "Wat Kaew Pitak, Udomsuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-01-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1295,
+  "hares": "Rod Turner",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-01-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1296,
+  "hares": "Frank Allum",
+  "location": "Wat Bang Peung, over Rama 9 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-01-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1297,
+  "hares": "Narest R",
+  "location": "Nakon Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-02-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1298,
+  "hares": "Todd Wilkie",
+  "location": "Wat Samaragote, Taling Chan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-02-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1299,
+  "hares": "Na Rust",
+  "location": "Suan Koi Restaurant, Thonburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-02-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1300,
+  "hares": "Mike Rust",
+  "location": "Wat Laem, Industrial Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-02-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1301,
+  "hares": "Cengiz",
+  "location": "Baan Suan Restaurant, Bang Kruay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-03-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1302,
+  "hares": "Graeme Bristol",
+  "location": "King Mongkut's Institute of Technology Thonburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-03-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1303,
+  "hares": "Jeff Gay",
+  "location": "Bang Kruay Klong Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-03-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1304,
+  "hares": "Noah Shepherd",
+  "location": "Unfinished Bridge Homestay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-03-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1305,
+  "hares": "Tim Wienands",
+  "location": "Ratchapreuk Road near Chaiyapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-03-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1306,
+  "hares": "Jeff Gay",
+  "location": "Dairy Queen, Hash (PraNangklao) Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-04-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1307,
+  "hares": "Andrew Murison",
+  "location": "Tien Lai Restaurant, Nakon Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-04-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1308,
+  "hares": "Peter Laverick",
+  "location": "Wat Khien, Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-04-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1309,
+  "hares": "Kim Chaubert",
+  "location": "Chateau Chaubert, Rama 9 Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-04-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1310,
+  "hares": "Christi Holleman",
+  "location": "Ratchapreuk Road, Cho Ratchapreuk Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-05-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1311,
+  "hares": "Greg Cable",
+  "location": "Khun Buun Restaurant, Bang Kruai-Sai Noi Rd",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-05-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1312,
+  "hares": "Bob Boulter",
+  "location": "Tara Roung Rom Restaurant, Pakkret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-05-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1313,
+  "hares": "Lem Morgan",
+  "location": "Deli Home Restaurant, Bang Kruai-Sai Noi Rd",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-05-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1314,
+  "hares": "Sunee P",
+  "location": "Unfinished Bridge Homestay. Birthday run.",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-06-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1315,
+  "hares": "Kevin McGaffey and AKM",
+  "location": "Nonthaburi Pier",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-06-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1316,
+  "hares": "Neil Biggadike",
+  "location": "Hoffman Haus, Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-06-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1317,
+  "hares": "Joost Zwager",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-06-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1318,
+  "hares": "Malinee K",
+  "location": "Rama 9 Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-06-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1319,
+  "hares": "George Morgan",
+  "location": "Tokyo Joe, Sukhumvit Soi 26",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-07-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1320,
+  "hares": "Geoff Reynolds",
+  "location": "Klong Toei Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-07-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1321,
+  "hares": "Sego D and Eric C",
+  "location": "PM Riverside, Rama 3 Road, Bastille Day run",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-07-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1322,
+  "hares": "Tom Ellefsen",
+  "location": "Suksawat Road (far end)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-07-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1323,
+  "hares": "Erik R",
+  "location": "Unico Golf Course, Krungthep Kreeta Road.",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-08-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1324,
+  "hares": "Lem Morgan",
+  "location": "Deli Home Restaurant, Bang Kruay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-08-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1325,
+  "hares": "Rin H",
+  "location": "Sukhumvit Soi 56",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-08-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1326,
+  "hares": "Vichai (Senator)",
+  "location": "Golden Pond, Krungthep Kreeta Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-08-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1327,
+  "hares": "Marc Lavoie",
+  "location": "Suksawat Road (far end)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-09-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1328,
+  "hares": "Todd W",
+  "location": "Suan Bua Restaurant, Bang Kruay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-09-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1329,
+  "hares": "Simon K",
+  "location": "Wat Bung Nam Pung Nok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-09-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1330,
+  "hares": "Som Burgess",
+  "location": "Wat Kaew Pitak, Soi Udumsuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-09-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1331,
+  "hares": "Tim Daly",
+  "location": "Sri Nakarin Road, Klong Prawet Buri Rom",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-09-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1332,
+  "hares": "Tom Sorensen",
+  "location": "Sri Nakarin Road, Bang Na",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-10-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1333,
+  "hares": "Jeanine",
+  "location": "Ahun I Din Restaurant, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-10-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1334,
+  "hares": "Piyanoot Brusselers",
+  "location": "Outer Ring Road Homestay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-10-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1335,
+  "hares": "Diane Furst",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-10-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1336,
+  "hares": "John McBirnie",
+  "location": "Suksawat Road (far end)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-11-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1337,
+  "hares": "Lynda Sharp",
+  "location": "Tanon Tok, Rama 3 Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-11-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1338,
+  "hares": "- Joint Master",
+  "location": "Ahun I Din Restaurant, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-11-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1339,
+  "hares": "ex-GM Matt Ryder",
+  "location": "Ao Duern Restaurant, Outer Onnut",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-11-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1340,
+  "hares": "Vichai Cool and Piya",
+  "location": "Baan Dang Steakhouse, Romklao Soi 52",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-12-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1341,
+  "hares": "Ian Slater",
+  "location": "Mai Morn Restaurant, Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-12-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1342,
+  "hares": "Steve Furst and Kevin Mc",
+  "location": "Rama 5 Bridge (north side of road)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-12-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1343,
+  "hares": "Peter Laverick",
+  "location": "Rama 5 Bridge (south side of road)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-12-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1344,
+  "hares": "Peter Haycox",
+  "location": "Tara Roung Rom Restaurant, Pakkret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2008-12-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1345,
+  "hares": "Stefan Cassel",
+  "location": "Wat Chak Daeng, Prapadaeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-01-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1346,
+  "hares": "East Shepherd",
+  "location": "Ruan Chon Daw Restaurant Chalerm Prakiet Soi 55",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-01-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1347,
+  "hares": "Rod Turner",
+  "location": "Bang Yai, Wat Pikhun Ngoen car park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-01-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1348,
+  "hares": "Frank Allum",
+  "location": "Yok Krok Restaurant, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-01-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1349,
+  "hares": "Narest",
+  "location": "Moobaan Ratchapreuk Rattana Tibet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-02-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1350,
+  "hares": "Eric Corrnille",
+  "location": "Delawan Restaurant, Suksawat Soi 30",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-02-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1351,
+  "hares": "Mike Rust",
+  "location": "Wat Chok Lom, Nonthaburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-02-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1352,
+  "hares": "Andrew Murison",
+  "location": "Tien Lai restaurant, Nakon Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-02-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1353,
+  "hares": "Cenghis",
+  "location": "Wat Sai, Bang Kruay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-03-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1354,
+  "hares": "Kevin McGaffey",
+  "location": "Wat Bang Na",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-03-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1355,
+  "hares": "Noah Shepherd",
+  "location": "Term Taem Restauarant, Nong Chok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-03-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1356,
+  "hares": "Malinee Kanchanapop",
+  "location": "The Finished Bridge near Romklao Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-03-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1357,
+  "hares": "Tom Sorensen",
+  "location": "Bang Na/Sri Nakarin",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-03-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1358,
+  "hares": "Fred Ayris",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-04-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1359,
+  "hares": "Graham Bristol",
+  "location": "Yok Krok Restaurant, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-04-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1360,
+  "hares": "Mike Burgess",
+  "location": "Near Wat Keaw Pitak, Udomsuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-04-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1361,
+  "hares": "Geoff Reynolds",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-04-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1362,
+  "hares": "Christi Holleman",
+  "location": "Klong Pra Udom, near route 345",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-05-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1363,
+  "hares": "Greg Cable",
+  "location": "Ahun I Din Restaurant, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-05-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1364,
+  "hares": "Tim Wienands",
+  "location": "Homestay, near the Outer Ring Road (east)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-05-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1365,
+  "hares": "Peter Laverick",
+  "location": "Rama 5 Bridge, near Wat Khien",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-05-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1366,
+  "hares": "Lem Morgan",
+  "location": "Nakon Inn Road, Som Tam Yok Sot restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-06-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1367,
+  "hares": "Bruce Weeks",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-06-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1368,
+  "hares": "Neil Biggadyke",
+  "location": "Bang Yai, Wat Rat Prakhong Tham",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-06-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1369,
+  "hares": "Joost Zwager",
+  "location": "Sai Mai, Soi Chatu Chot",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-06-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1370,
+  "hares": "Bob Boulter",
+  "location": "Wat Yai Sawang Arom",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-06-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1371,
+  "hares": "George Morgan",
+  "location": "Patanakan Soi 32",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-07-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1372,
+  "hares": "Matt Ryder/Kevin Mc",
+  "location": "Phutta Bucha Soi 36",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-07-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1373,
+  "hares": "Sego D'herlincourt",
+  "location": "Taling Chan, In Pla Pao Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-07-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1374,
+  "hares": "Tom Ellefsen",
+  "location": "Suksawat Road, Wat Sa Khla",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-07-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1375,
+  "hares": "Peter Wallbank/AKM",
+  "location": "Railway Crossing near Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-08-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1376,
+  "hares": "Jeff Gay",
+  "location": "Nakon In Road, Ban Suan Golf Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-08-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1377,
+  "hares": "Vichai Cool",
+  "location": "Romklao Soi 52, Baan Dang Steakhouse",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-08-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1378,
+  "hares": "Simon Kitchen",
+  "location": "Sukhumvit Soi 56",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-08-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1379,
+  "hares": "John McBirnie",
+  "location": "Suksawat Road, Bu Lone Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-08-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1380,
+  "hares": "Clyde Albrecht/ Malinee",
+  "location": "Koh Kret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-09-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1381,
+  "hares": "Vichai and Vichai",
+  "location": "Mahachai Restaurant, Ramindra Expressway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-09-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1382,
+  "hares": "Som Burgess",
+  "location": "Near Wat Kaew Pitak, Udomsuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-09-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1383,
+  "hares": "Kevin McGaffey",
+  "location": "Rama 9 Road, Soi 19",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-09-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1384,
+  "hares": "Marc Lavoie",
+  "location": "Bang Pakong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-10-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1385,
+  "hares": "Kevin McG and Tickler",
+  "location": "Ratchapreuk Road, Ruaw Khao Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-10-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1386,
+  "hares": "Piyanoot Brusselers",
+  "location": "Chonburi Motorway, Krua Klang Bung Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-10-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1387,
+  "hares": "Diane Furst",
+  "location": "Phra Nang Klao Bridge, Chong Nam Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-10-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1388,
+  "hares": "Sunee Patcharapaisan",
+  "location": "Unfinished Bridge Homestay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-11-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1389,
+  "hares": "Kim Chaubert",
+  "location": "Rama 3 Road, Soi 44 ***Loy Kratong***",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-11-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1390,
+  "hares": "Lynda Sharp",
+  "location": "Rama 3 Road, Supalai Casa Riva, Tanon Tok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-11-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1391,
+  "hares": "Joint Masters",
+  "location": "Ratchapreuk Road, Ahun I Din Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-11-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1392,
+  "hares": "Ex GM Maarten Brusselers",
+  "location": "Chonburi Motorway, Krua Klang Bung restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-11-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1393,
+  "hares": "Peter Laverick",
+  "location": "Krungthep Kreeta Pond",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-12-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1394,
+  "hares": "Ian Slater",
+  "location": "Chonburi Motorway, Steak Baan Daeng restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-12-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1395,
+  "hares": "Stefan Cassel",
+  "location": "Bungsamran Fishing Park, Nawamin Soi 42",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-12-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1396,
+  "hares": "Lem Morgan",
+  "location": "Ruang Khao Restaurant, Ratchapreuk rd",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2009-12-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1397,
+  "hares": "KC Marchment",
+  "location": "Railway park Golf Driving Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2010-11-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1444,
+  "hares": "Vichai Senator",
+  "location": "Homestay near Outer Ring Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2010-11-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1445,
+  "hares": "Hank Graham",
+  "location": "Yok Krok Restaurant, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2010-12-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1446,
+  "hares": "Vichai Cool",
+  "location": "Lom Choi Restaurant, near Rose Garden, Sam Phran",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2010-12-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1447,
+  "hares": "John McBirnie",
+  "location": "Taling Chan, Jay Nok Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2010-12-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1448,
+  "hares": "Ian Slater",
+  "location": "Chonburi M'way, Steak Baan Deang Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2010-12-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1449,
+  "hares": "KC",
+  "location": "Prapadaeng, Wat Chak Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-01-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1450,
+  "hares": "Tinker and Short-Shorts",
+  "location": "Viphawadi Road, Soi 17",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-01-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1451,
+  "hares": "Jo van Aubel",
+  "location": "Wat Tha It",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-01-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1452,
+  "hares": "Lem Morgan",
+  "location": "Ruan Khao Restaurant, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-01-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1453,
+  "hares": "Rod Turner",
+  "location": "The Port. An A to B to C to D to E boat run",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-01-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1454,
+  "hares": "Malinee K",
+  "location": "Soi Ngam Dupli (Sathon/Rama 4 Roads)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-02-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1455,
+  "hares": "Jennifer Sloan",
+  "location": "Opposite Nonthaburi Pier",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-02-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1456,
+  "hares": "Frank Allum",
+  "location": "Sri Burapha Soi 11, Coca Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-02-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1457,
+  "hares": "Todd Wilkie",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-02-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1458,
+  "hares": "Mike Rust",
+  "location": "Tiwanon Road, Country Place Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-03-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1459,
+  "hares": "Cenghis",
+  "location": "Nakon Inn Road, Im Pla Pao restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-03-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1460,
+  "hares": "Noah Shepherd",
+  "location": "Romklao area, Pattana Chonnabot Soi 3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-03-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1461,
+  "hares": "Andrew Murison",
+  "location": "Nakon Inn Road, Ruan Sila Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-03-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1462,
+  "hares": "Terry 'Sheepshagger' J.",
+  "location": "Muang Thong Thani, Hot Shot Golf Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-04-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1463,
+  "hares": "Mike 'Sugar Daddy' B",
+  "location": "Chalerm Prakiet Soi 43",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-04-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1464,
+  "hares": "David K",
+  "location": "Muang Kaew Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-04-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1465,
+  "hares": "Clyde 'ABB' A",
+  "location": "Koh Kret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-04-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1466,
+  "hares": "Peter 'Hayter' H",
+  "location": "Sakuna Fishing Park, off Thepharak Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-05-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1467,
+  "hares": "Giles 'Mollester' C",
+  "location": "Phra Pradaeng, Wat Chak Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-05-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1468,
+  "hares": "Lynn 'Makin' Bacon' Y",
+  "location": "Taling Chan, Wat Siri Wattanaram",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-05-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1469,
+  "hares": "Steve 'Gringo' G",
+  "location": "Bang Kruay, Baan Suan Restauarant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-05-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1470,
+  "hares": "Narest",
+  "location": "Bang Yai Y Junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-05-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1471,
+  "hares": "Tim 'Joylide' W",
+  "location": "Koh Kret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-06-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1472,
+  "hares": "Eric 'Dunkin Donut' C",
+  "location": "Taling Chan, Suan Srikrung restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-06-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1473,
+  "hares": "Som 'Nonstop' B",
+  "location": "Muang Kaew Golf Course, Bang Na-Trat",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-06-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1474,
+  "hares": "Kevin 'Bruised Willy' McG",
+  "location": "Bang Kruay-Sai Noi Soi 15/2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-06-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1475,
+  "hares": "Bob 'Bullit' B",
+  "location": "Pakkret, Wat Toei - Boat run",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-07-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1476,
+  "hares": "Matt 'Canal Rapee' R",
+  "location": "Prapadaeng, near Wat Chak Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-07-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1477,
+  "hares": "George Morgan",
+  "location": "Pattanakan, Mooban Panya",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-07-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1478,
+  "hares": "Tony Erswell",
+  "location": "Bang Khae, Suk San Village",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-07-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1479,
+  "hares": "Teerachai Riensubdee",
+  "location": "Chatuchak, Railway Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-08-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1480,
+  "hares": "Jeff Gay",
+  "location": "Bang Kruai Bridge restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-08-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1481,
+  "hares": "Lorreta 'Whining Wino\" G",
+  "location": "Krua Khun Noi restaurant, Romklao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-08-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1482,
+  "hares": "Brenda \"Splat\" F",
+  "location": "Bang Kruai-Sai Noi Road, Soi 17",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-08-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1483,
+  "hares": "Id 'Eat Me' S",
+  "location": "Baan Eat Me, Pattanakan Soi 38",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-08-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1484,
+  "hares": "Ric 'Hand Job' J",
+  "location": "Soi Mahachai, Bang Na-Trat highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-09-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1485,
+  "hares": "Giles 'Molester' C",
+  "location": "Chalerm Prakiet Soi 47",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-09-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1486,
+  "hares": "Lynda 'No Meat' S",
+  "location": "Tanon Tok, Rama 3 Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-09-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1487,
+  "hares": "Greg 'Tickler' C",
+  "location": "Bang Kruay, Krua Sam Yai Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-09-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1488,
+  "hares": "Mark 'Thebathtian' L",
+  "location": "Bang Pakong Motorway Service Area",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-10-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1489,
+  "hares": "Tom 'Man Called Horse' S",
+  "location": "Srinakarin Road, Koh Yor Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-10-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1490,
+  "hares": "Peter 'Maverick' L",
+  "location": "Krungthep Kreetha Pond",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-10-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1491,
+  "hares": "Greg 'The Tickler' C",
+  "location": "Prapadaeng, Wat Chak Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-10-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1492,
+  "hares": "Maarten 'Bogdiver' B",
+  "location": "Khao Kiew Zoo, Chonburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-10-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1493,
+  "hares": "Tim 'Crash' D",
+  "location": "Soi Langsuan, Malinee's house",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-11-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1494,
+  "hares": "Neil 'Weedeater' B",
+  "location": "Chonburi Motorway, Soi 3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-11-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1495,
+  "hares": "JM Run",
+  "location": "Chonbuiri Motorway, Steak Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-11-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1496,
+  "hares": "ex GM's RUN",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-11-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1497,
+  "hares": "Piyanoot 'T Rex' B",
+  "location": "Chonburi Motorway, Soi 3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-12-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1498,
+  "hares": "Narest 'Nearest and Dearest'",
+  "location": "Moobaan Piboon, near Rama 7 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-12-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1499,
+  "hares": "Eric 'Drunken Donut' C and Osama 'Sexy Beast' R",
+  "location": "Prakanong, Soi Farmwattana",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-12-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1500,
+  "hares": "Noah '4x2' S and Eat Me",
+  "location": "Romklaoi, Krua Khun Noi 2 (Outer Ring, Chonnabot Pattana 3)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2011-12-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1501,
+  "hares": "KC 'Boobalube' M",
+  "location": "Wat Intharawat (a.k.a. Wat Pradu)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-01-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1502,
+  "hares": "Rin 'Jumpstart' H.",
+  "location": "Eight Plus Restaurant, Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-01-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1503,
+  "hares": "Ian 'AKM' S. and Bogdiver",
+  "location": "Bang Pakong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-01-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1504,
+  "hares": "Jennifer 'Late Coming Ball Slapper' S.",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-01-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1505,
+  "hares": "Joost 'Hashendale' Z.",
+  "location": "Ramindra, Wat Pra Ruang Prasit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-01-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1506,
+  "hares": "Hank 'Spank me' G.",
+  "location": "Romklao, Krua Khun Noi (Outer Ring, Chonnabot Pattana 3)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-02-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1507,
+  "hares": "Malinee 'Nibbles' K.",
+  "location": "Vipawadi Soi 17",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-02-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1508,
+  "hares": "Doug 'Deputy Dawg' A.",
+  "location": "Tueng Prik Tueng King Restaurant, Nakon Inn Road, Nonthaburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-02-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1509,
+  "hares": "Lem 'No Good Boyo' M.",
+  "location": "Krua Baan Jin Restaurant, Nakon Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-02-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1510,
+  "hares": "Detlev 'Shiny Helmet' S",
+  "location": "Sukhumvit Soi 64/2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-03-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1511,
+  "hares": "Jo 'Big Package' van A.",
+  "location": "Bang Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-03-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1512,
+  "hares": "Frank 'Noriega' A.",
+  "location": "30 years of the Bangkok Monday Hash. Sri Burapa Soi 1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-03-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1513,
+  "hares": "Todd 'Spinning Dwarf' W.",
+  "location": "Tha Nam Nonthaburi - Wat Bot Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-03-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1514,
+  "hares": "Mike 'Love Canal' R.",
+  "location": "Wat Yai Road, off Suksawat Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-04-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1515,
+  "hares": "Cengiz 'Disgusting' E.",
+  "location": "Nakon Inn Road, Im Pla Pao restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-04-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1516,
+  "hares": "Greg 'The Tickler' C.",
+  "location": "Nakon Inn Road, Cowboy restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-04-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1517,
+  "hares": "Giles 'Molester' C.",
+  "location": "Chalerm Prakiet Soi 47",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-04-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1518,
+  "hares": "Terry 'Sheepshagger' J.",
+  "location": "Nakon Inn Road, Cowboy restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-04-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1519,
+  "hares": "Clyde 'Adorable Blue Balls' A.",
+  "location": "Ko Kret",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-05-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1520,
+  "hares": "Goran 'Fawlty Towers' E.",
+  "location": "Romklao Soi 3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-05-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1521,
+  "hares": "Andrew 'No No' M..",
+  "location": "Nakon Inn Road, Cowboy restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-05-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1522,
+  "hares": "Peter 'Hayter' H.",
+  "location": "Sakuna Fishing Park, off Thepharak Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-05-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1523,
+  "hares": "Tom 'Pussy Virus' E.",
+  "location": "Suksawat, Tambon Na Kleua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-06-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1524,
+  "hares": "Vichai 'Cool' P.",
+  "location": "Romklao Soi 52",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-06-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1525,
+  "hares": "John 'Bad Boy Bubby' McB.",
+  "location": "Taling Chan, Wat Jampa",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-06-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1526,
+  "hares": "Tim 'Joylide' W.",
+  "location": "Outer Ring Road (east), Homestay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-06-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1527,
+  "hares": "Bruce 'Hash Hash' W.",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-07-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1528,
+  "hares": "Rod 'The Bug' T.",
+  "location": "Bang Yai Y-junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-07-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1529,
+  "hares": "Matt 'Canal Rapee' R.",
+  "location": "Wild Game Restaurant, Wat Praya Suren, Ramintra",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-07-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1530,
+  "hares": "Peter 'Maverick' L.",
+  "location": "Ramintra, near Wat Pra Ruang Prasit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-07-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1531,
+  "hares": "Kevin 'Bruised Willy' M.",
+  "location": "Baan Khun Nayok Restaurant, Bang Krachao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-07-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1532,
+  "hares": "George 'Of the Jungle' M.",
+  "location": "Onnut (near Sukhumvit Road)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-08-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1533,
+  "hares": "Tony 'Ambrose' E.",
+  "location": "Bang Khae, Suk San Village",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-08-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1534,
+  "hares": "Teerachai 'Pink Panther' R.",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-08-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1535,
+  "hares": "Jeff 'Bugs' G.",
+  "location": "Bansuan Golf Driving Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-08-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1536,
+  "hares": "Id 'Eat Me' S.",
+  "location": "Chonburi Motorway, Krua Klang Bueng Rest.",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-09-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1537,
+  "hares": "Brenda 'Splat' F.",
+  "location": "Suksawat Road Soi 26",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-09-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1538,
+  "hares": "Lorreta 'Whining Wino' G",
+  "location": "Romklao, Krua Khun Noi Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-09-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1539,
+  "hares": "Ainee '4 Nipples' W",
+  "location": "Sukhumvit Soi 101/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-09-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1540,
+  "hares": "Greg 'The Tickler' C",
+  "location": "Near Wat Chak Daeng, Petchahung Soi 10, Prapradaeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-10-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1541,
+  "hares": "Tom 'Man Called Horse' S.",
+  "location": "Restaurant Fai Kam, Near Central Bang Na",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-10-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1542,
+  "hares": "Steve 'Gringo' G.",
+  "location": "Bang Kruay, Baan Suan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-10-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1543,
+  "hares": "Mark 'Tebastian' L",
+  "location": "Bang Pli, Lom Thale Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-10-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1544,
+  "hares": "Nid 'Sizzler'",
+  "location": "Srinakarin Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-10-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1545,
+  "hares": "Bob 'Bullit' B.",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-11-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1546,
+  "hares": "Na 'Mrs Love Canal' R.",
+  "location": "Ramintra, near Wat Pra Ruang Prasit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-11-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1547,
+  "hares": "Tim 'Crash' D with help from friends",
+  "location": "Chatuchak, Railway Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-11-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1548,
+  "hares": "JMs",
+  "location": "Cowboy Restaurant, Nakon Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-11-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1549,
+  "hares": "ex GM The Senator",
+  "location": "Mueang Kaew Golf Course, Bang Na-Trad Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-12-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1550,
+  "hares": "Piya",
+  "location": "Chalerm Prakiet Soi 48",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-12-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1551,
+  "hares": "Kim 'Normal' C",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-12-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1552,
+  "hares": "Narest 'Nearest and Dearest' R",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-12-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1553,
+  "hares": "KC 'Boobalube' M",
+  "location": "Keereboon Restaurant, Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2012-12-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1554,
+  "hares": "Lem 'No Good Boyo' M and Kevin 'Bruised Willy\" M",
+  "location": "Yuan Yi Restaurant, Nonthaburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-01-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1555,
+  "hares": "Rin 'Jumpstart' H",
+  "location": "Bang Na, Wat Bang Na Nok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-01-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1556,
+  "hares": "Ian 'AKM' S.",
+  "location": "Steak Baan Daeng Restaurant, Chonburi motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-01-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1557,
+  "hares": "Detlev 'Shiny Helmet' S and Ainee",
+  "location": "Krungthep Kreeta Pond",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-01-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1558,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-02-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1559,
+  "hares": "Frank 'Noriega' A",
+  "location": "Krua Khun Noi Restaurant, Romklao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-02-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1560,
+  "hares": "Ainee 'Four Nipples' W",
+  "location": "Chalerm Prakiat Soi 47",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-02-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1561,
+  "hares": "Doug 'Deputy Dawg' A",
+  "location": "Tueng Prik Tueng King Restaurant Nakon Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-02-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1562,
+  "hares": "John 'Tinker' L",
+  "location": "Langsuan Soi 5",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-03-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1563,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nonthaburi, Suan Bua Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-03-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1564,
+  "hares": "Cengiz 'Disgusting' E",
+  "location": "Nakon Inn Road, Im Pla Pao Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-03-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1565,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Ratchapruek Road near Rattana Tibet Road Oon Eye Din Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-03-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1566,
+  "hares": "Peter 'Hayter Peacox' H",
+  "location": "Taling Chan, Baan Daolomdeun Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-04-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1567,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Petchaburi Road, Soi 32, near Chidlom",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-04-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1568,
+  "hares": "Neil 'Weedeater' B",
+  "location": "Supalai, Tanon Tok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-04-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1569,
+  "hares": "Vichai 'Cool' P",
+  "location": "Ton Khao DonTri opposite Chalermprakiet 55",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-04-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1570,
+  "hares": "Greg 'Tickler' C",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-04-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1571,
+  "hares": "Steve 'Gringo' G",
+  "location": "Bang Kruay, Baan Suan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-05-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1572,
+  "hares": "Nid 'Sizzler' P",
+  "location": "Sri Nakarin Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-05-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1573,
+  "hares": "Kevin 'Bruised Willy' M",
+  "location": "Bang Sue, Macam Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-05-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1574,
+  "hares": "Matt 'Canal Rappe' R",
+  "location": "Near Muang Kaew Golf Course, Bang Na-Trad Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-05-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1575,
+  "hares": "Rod 'The Bug' T",
+  "location": "Klong Toei Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-06-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1576,
+  "hares": "Mike 'Love Canal' R",
+  "location": "Romklao, Stolen Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-06-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1577,
+  "hares": "John 'Bad Boy Bubby' M",
+  "location": "Bang Plee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-06-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1578,
+  "hares": "Tim 'Joylide' W",
+  "location": "Krua 3 Yai, Ratchapreuk Road, Nonthaburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-06-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1579,
+  "hares": "Bruce 'Hash Hash' W",
+  "location": "Klong Toei Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-07-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1580,
+  "hares": "Clyde 'Adorable BB' A",
+  "location": "Wat Bang Na Nok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-07-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1581,
+  "hares": "Ichimura 'Bangcock'",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-07-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1582,
+  "hares": "Eric 'Drunken Donut' C",
+  "location": "Rama 3 Road, Soi 46 Bastille Day Run",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-07-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1583,
+  "hares": "It 'Eat Me' S",
+  "location": "Homestay, Outer Ring Road (East)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-07-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1584,
+  "hares": "Jo 'Big Package' van A",
+  "location": "Bang Yai bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-08-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1585,
+  "hares": "Peter 'Maverick' L",
+  "location": "Krungtep Kreeta swamp",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-08-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1586,
+  "hares": "Greg 'Tickler' C",
+  "location": "Wat Chak Daeng, Petchahung Soi 10, Prapadaeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-08-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1587,
+  "hares": "George 'of the Jungle' M",
+  "location": "Onnut Road Soi 65, Krua Khorat Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-08-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1588,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Suk San Village, Bang Khae",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-09-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1589,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Pakkret, Rama 4 Bridge (west side)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-09-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1590,
+  "hares": "Lem 'No Good Boyo' M and Cengiz 'Disgusting' E",
+  "location": "Im Pla Pao Restaurant, Nakon Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-09-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1591,
+  "hares": "Brenda 'Splat' F",
+  "location": "Krung Thonburi Road, near Taksin Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-09-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1592,
+  "hares": "Narest 'Nearest and Dearest'",
+  "location": "Rattana Thibet Road, Moobaan Ratchapreuk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-09-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1593,
+  "hares": "Bob 'Bullit' B",
+  "location": "Nonthaburi, Suan Bua Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-10-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1594,
+  "hares": "Noah '4x2' S",
+  "location": "Rice City, Outer Ring Road (east)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-10-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1595,
+  "hares": "Nick 'Leg Iron' Z",
+  "location": "Chalerm Prakiat Soi 55",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-10-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1596,
+  "hares": "Peter 'Maverick' L",
+  "location": "Krungtep Kreeta Swamp",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-10-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1597,
+  "hares": "Eric 'Dunkin Donut' C",
+  "location": "Hua Lampong Station Car Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-11-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1598,
+  "hares": "Greg 'The Tickler' C and Mike 'Love Canal' R",
+  "location": "Bang Kruay, Krua Sam Yai Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-11-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1599,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Nakon Inn Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-11-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1600,
+  "hares": "Jm's Fawlty Towers and Hashendale",
+  "location": "Ramindra, Steak Lao Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-11-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1601,
+  "hares": "Andrew 'NoNo' M",
+  "location": "Nakon Inn Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-12-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1602,
+  "hares": "Mike 'Love Canal' R and Peter 'Dripper' W",
+  "location": "Outer Ring Road (East), Rice City",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-12-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1603,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Suan Kanvela Restaurant, Kampaeng Phet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-12-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1604,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Krua Sam Yay Restaurant, Ratchapreuk Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-12-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1605,
+  "hares": "Rod 'The Bug' T",
+  "location": "Prapadaeng, Kumrapee Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2013-12-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1606,
+  "hares": "KC 'Boob-a-Lube' M",
+  "location": "Chalerm Prakiet Soi 55, Ruan Chon Daw Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-01-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1607,
+  "hares": "Ryn 'Jumpstart' H.",
+  "location": "Elvis restaurant between Sukhumvit Soi 89/1 and 91",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-01-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1608,
+  "hares": "Ian 'AKM' S. The Bangkok Shutdown Run",
+  "location": "Steak Baan Daeng restaurant, Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-01-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1609,
+  "hares": "Detlev 'Shiny Helmet' S.",
+  "location": "Wat Bang Na Nok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-01-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1610,
+  "hares": "John 'Tinker' L.",
+  "location": "Chatuchak, Railway Golf Driving Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-02-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1611,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Bang Sue",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-02-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1612,
+  "hares": "Frank 'Noriega' A.",
+  "location": "Bungsamran Fishing Park, Nawamin Soi 42",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-02-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1613,
+  "hares": "Todd 'Spinning Dwarf' W.",
+  "location": "Wun Wan Club, Near Bang Wa BTS Station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-02-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1614,
+  "hares": "Jeff 'Bugs' G and Greg 'Tickler' C",
+  "location": "Ban Suan Golf Range, off Nakon In Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-03-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1615,
+  "hares": "Cengiz 'Disgusting' E",
+  "location": "Implapao Restaurant, Nakon In Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-03-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1616,
+  "hares": "Noah '4x2' S.",
+  "location": "Outer Ring Road (east), Rice City",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-03-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1617,
+  "hares": "Peter 'Hayter Peacox' H. St Patrick's Day Run",
+  "location": "Taling Chan, Yok Krok Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-03-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1618,
+  "hares": "John 'McSwirly' M.",
+  "location": "Near Muang Kaew Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-03-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1619,
+  "hares": "Vichai 'Senator' S.",
+  "location": "Steak Baan Daeng, Chonburi Motorway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-04-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1620,
+  "hares": "Peter 'Maverick' L.",
+  "location": "Ramintra, near Wat Pra Ruang Prasit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-04-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1621,
+  "hares": "Matt 'Canal Rapee' R.",
+  "location": "Prakanong, Soi Phumichit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-04-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1622,
+  "hares": "Greg 'Tickler' C.",
+  "location": "Near Wat Chak Daeng, Petchahung Soi 10, Prapradaeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-04-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1623,
+  "hares": "Tom 'Pussy Virus' E.",
+  "location": "Near Suksawat Navy Base",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-05-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1624,
+  "hares": "Vichai 'Cool' P.",
+  "location": "Sukhumvit Soi 101/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-05-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1625,
+  "hares": "Nid 'Sizzler' P.",
+  "location": "Srinakarin Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-05-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1626,
+  "hares": "George 'of the Jungle' M.",
+  "location": "Chonburi Motorway, Steak Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-05-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1627,
+  "hares": "Tony 'Ambrose' E.",
+  "location": "Wutthakat BTS station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-06-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1628,
+  "hares": "Teerachai 'Pink Panther' R.",
+  "location": "Near Ngam Wong Wan Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-06-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1629,
+  "hares": "Goran 'Fawlty Towers' E.",
+  "location": "Krua Khun Noi 2, Patthana Chonabot 3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-06-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1630,
+  "hares": "Jeff 'Bugs' G.",
+  "location": "Bang Kruai-Sai Noi Road, Soi 16",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-06-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1631,
+  "hares": "East 'Eat Me' S.",
+  "location": "Krungtep Kreeta Road, Gai Yang Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-06-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1632,
+  "hares": "Bob 'Bullit' B and Mike 'Love Canal' R",
+  "location": "Suan Bua Restaurant, off Rattana Tibet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-07-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1633,
+  "hares": "Joost 'Hashendale' Z.",
+  "location": "Ramintra, near Wat Pra Ruang Prasit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-07-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1634,
+  "hares": "Eric 'Dunkin Donut' C. Bastille Day",
+  "location": "Phrapradaeng, Wat Kong Kaew",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-07-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1635,
+  "hares": "Bob 'Bullit' B",
+  "location": "Pakkred, Wat Sali Kho",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-07-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1636,
+  "hares": "Na R",
+  "location": "Elvis Restaurant, near Bangchak BTS station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-08-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1637,
+  "hares": "Vinai 'Oversexed' S",
+  "location": "Krua Baan Suan Restaurant, Rattana Tibet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-08-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1638,
+  "hares": "Ichimura-san 'Bangcock'",
+  "location": "Klong Toei Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-08-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1639,
+  "hares": "Piya 'Short Change' R and Sizzler",
+  "location": "Petronas Petrol Station, Chalerm Prakiat Soi 36",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-08-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1640,
+  "hares": "KC 'Boob-a-Lube' M.",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-09-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1641,
+  "hares": "Marc 'Manboobs' L",
+  "location": "Ekkamai Soi 23",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-09-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1642,
+  "hares": "Bruce 'Hash Hash' W",
+  "location": "Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-09-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1643,
+  "hares": "Kim 'Normal' C",
+  "location": "Klong Toei Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-09-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1644,
+  "hares": "Nick 'Leg iron' Z.",
+  "location": "Chatuchak, Railway Park golf driving range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-09-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1645,
+  "hares": "Maarten 'Bogdiver' B",
+  "location": "Bang Chalong, near Bang Na-Trad highway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-10-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1646,
+  "hares": "Vimol 'Chocolate Starfish' L.",
+  "location": "Chalerm Prakiat Soi 43",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-10-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1647,
+  "hares": "Andrew 'No No' M.",
+  "location": "Nakon Inn Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-10-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1648,
+  "hares": "Mike 'Love Canal' R.",
+  "location": "Rama 2 Road, Soi 33",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-10-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1649,
+  "hares": "Lem 'No Good Boyo' M. and Ian 'AKM' S",
+  "location": "Chonburi Motorway, Steak Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-11-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1650,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Nonthaburi, Tueng Prik King Restaurant, near Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-11-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1651,
+  "hares": "Ed 'Checkless' C and Frank 'Noriega' A",
+  "location": "Tub Chang Paintball and BB Kanchanapisek Road (east)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-11-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1652,
+  "hares": "Terry 'Sheepshagger' J and KC 'Boob-a-lube' M",
+  "location": "Pattanakan Soi 53, Chlorophyll Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-11-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1653,
+  "hares": "GM Emeritus Virginia Slim",
+  "location": "Rama 3 Soi 52, Ho Kitchen Seafood",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-12-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1654,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nonthaburi, Suan Bua Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-12-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1655,
+  "hares": "John 'Tinker' L",
+  "location": "Bang Na, Soi Muang Kaew",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-12-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1656,
+  "hares": "Detlev 'Shiny Helmet' S",
+  "location": "Wat Bang Na Nok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-12-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1657,
+  "hares": "Peter 'Hayter Peacox' H",
+  "location": "Taling Chan, Baan Daolomdeun Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2014-12-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1658,
+  "hares": "Vichai 'Senator' S and Porkfinder Farewell to 2014 run",
+  "location": "Krungthep Kreeta Road, Gaiyang Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-01-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1659,
+  "hares": "Rin 'Jumpstart' H",
+  "location": "Sukhumvit near Soi 89, Elvis Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-01-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1660,
+  "hares": "Noah '4x2' S",
+  "location": "Homestay, near Kanchanapisek (east)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-01-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1661,
+  "hares": "Brenda 'Splat' F",
+  "location": "Charoen Nakorn Soi 15 (near Sapan Taksin BTS)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-01-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1662,
+  "hares": "Ian 'AKM' S Australia Day Special",
+  "location": "Chonburi Motorway, Steak Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-02-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1663,
+  "hares": "John 'McSwirly' M",
+  "location": "The famous 3 way mosquito infested intersection 1.5km in from BangNaTrat",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-02-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1664,
+  "hares": "Cengiz 'Disgusting' E",
+  "location": "Cowboy Restaurant, near Nakon Inn Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-02-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1665,
+  "hares": "Peter 'Maverick' L",
+  "location": "Krungtep Kreeta Soi 31",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-02-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1666,
+  "hares": "Matt 'Canal Rappe' R",
+  "location": "Lat Krabang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-03-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1667,
+  "hares": "Kevin 'Bruised Willy' McG",
+  "location": "Bang Sue station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-03-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1668,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Talad Plu Betel Nut Market",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-03-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1669,
+  "hares": "Ed 'Checkless' C",
+  "location": "Tub Chang Paintball and BB Kanchanapisek Road (east)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-03-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1670,
+  "hares": "Vichai 'Cool' P",
+  "location": "Chalerm Prakiat Soi 46",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-03-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1671,
+  "hares": "Greg 'Tickler' C and Julien",
+  "location": "Near Wat Chak Daeng, Petchahung Soi 10, Prapradang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-04-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1672,
+  "hares": "Joost 'Hashendale' Z",
+  "location": "North Nonthaburi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-04-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1673,
+  "hares": "Roland 'Rawhide' P and Jim 'Virginia Slim' E",
+  "location": "Phra Athit Road, Venice Vanich Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-04-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1674,
+  "hares": "Alex 'Teeny' A",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-04-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1675,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Wat Bang Na Nok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-05-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1676,
+  "hares": "Jim 'Bimbo' E Terry 'Sheepshagger' J",
+  "location": "Sapan Kwai, Pradiphat Road, Soi 17",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-05-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1677,
+  "hares": "Na 'Mrs' R",
+  "location": "Onnut Soi 44",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-05-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1678,
+  "hares": "K.C. 'Boob a Lube' M",
+  "location": "Chatuchak, Railway Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-05-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1679,
+  "hares": "Eric 'Dunkin Donut' C",
+  "location": "Prapadaeng, Krua Baan Nayok Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-06-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1680,
+  "hares": "It 'Eat Me' S",
+  "location": "Krua Baan Plai Na Rom Klao Housing Project",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-06-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1681,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Chalerm Prakiat Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-06-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1682,
+  "hares": "Bruce 'Hash Hash' W",
+  "location": "Klong Toey Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-06-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1683,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Bang Sue, Ban Makarm Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-06-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1684,
+  "hares": "Marc 'Sebastian' L",
+  "location": "Ekkamai Soi 1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-07-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1685,
+  "hares": "Jeff 'Bugs' G",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-07-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1686,
+  "hares": "John 'LMMC' T",
+  "location": "Kanchanapisek Soi 44, Bung Maruay (behind Chalerm Prakiat Road)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-07-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1687,
+  "hares": "Andrew 'No No' M",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-07-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1688,
+  "hares": "Nid 'Sizzler' K",
+  "location": "Sri Nakarin Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-08-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1689,
+  "hares": "Mike 'Love Canal' R",
+  "location": "Samut Prakarn Sukhumvit South Soi 6",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-08-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1690,
+  "hares": "Ichimura 'Bangcock' T",
+  "location": "Rama 5 Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-08-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1691,
+  "hares": "Nick 'Leg Iron' Z",
+  "location": "Sukhumvit Soi 50",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-08-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1692,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "Taling Chan, Yok Krok Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-08-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1693,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-09-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1694,
+  "hares": "George 'of the Jungle' M",
+  "location": "Pickadaily, near Onnut Soi 37",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-09-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1695,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Kanchanapisek (East) Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-09-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1696,
+  "hares": "Greg 'Tickler' C",
+  "location": "Nonthaburi Bypass Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-09-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1697,
+  "hares": "Maarten 'Sir Bogdiver' B and T-Rex",
+  "location": "Chalerm Prakiat Soi 63",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-10-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1698,
+  "hares": "Piya 'Shortchange' R",
+  "location": "Chalerm Prakiat between near Soi 68",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-10-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1699,
+  "hares": "Will 'Pig Fokker' van S",
+  "location": "Homestay, Kanchanapisek (east)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-10-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1700,
+  "hares": "Sheepshagger and No Good Boyo",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-10-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1701,
+  "hares": "Kim 'Normal' C",
+  "location": "Chateau de Chaubert, Rama 9 Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-11-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1702,
+  "hares": "John 'Tinker' L",
+  "location": "Suan Kanvela Restaurant, Kamphaeng Phet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-11-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1703,
+  "hares": "Vichai 'Cool'",
+  "location": "Hua Lampong Station Car Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-11-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1704,
+  "hares": "Mike 'Love Canal' R/ Vichai 'Cool'",
+  "location": "Punnawithi Soi 28",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-11-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1705,
+  "hares": "Outgoing GM Bob 'Bullit' B",
+  "location": "Nonthaburi, Suan Bua Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-11-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1706,
+  "hares": "Cengiz 'Disgusting' E",
+  "location": "Nakon In Road, Im Pla Pao restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-12-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1707,
+  "hares": "Maarten 'Bogdiver' B",
+  "location": "Klong Dan. Krua Poo Yai Restaurant, on the seaside off Sukhumvit Road.",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-12-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1708,
+  "hares": "Rin 'Jumpstart' H",
+  "location": "Sukhumvit Soi 81",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-12-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1709,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Taling Chan, Im Pla Pao Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2015-12-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1710,
+  "hares": "Vichai 'Senator' S",
+  "location": "Krungthep Kreeta Gaiyang restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-01-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1711,
+  "hares": "Matt 'Canal Rapee' R",
+  "location": "Pra Samut Chedi, Suksawat Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-01-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1712,
+  "hares": "Noah '4x2' S",
+  "location": "Kanchanapisek (East) Rice City/Paintball Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-01-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1713,
+  "hares": "Vinai 'Over sexed' S",
+  "location": "Pra Nangklao Bridge (Hash Bridge)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-01-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1714,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Pra Samut Chedi, Suksawat Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-02-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1715,
+  "hares": "Peter 'Maverick' L",
+  "location": "Ramindra, Soi Wat Porn Pra Ruang Prasit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-02-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1716,
+  "hares": "Barry 'Knockout Neptune' M",
+  "location": "Pattanakarn Soi 25",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-02-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1717,
+  "hares": "John 'Tinker' L",
+  "location": "Kamphaeng Phet Road, Suan Kanvela Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-02-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1718,
+  "hares": "Mike 'Love Canal' R",
+  "location": "Theparak, Sakuna Fishing Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-02-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1719,
+  "hares": "It 'Eat Me' S",
+  "location": "Kanchanapisek (east), Homestay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-03-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1720,
+  "hares": "KC 'Boob-a-lube' M",
+  "location": "Bang Yai Y-junction, Morgan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-03-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1721,
+  "hares": "Nid 'Sizzler' K",
+  "location": "Chalerm Prakiat Soi 68",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-03-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1722,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Talad Plu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-03-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1723,
+  "hares": "Ed 'Checkless' C",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-04-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1724,
+  "hares": "John 'Bangkook' B",
+  "location": "Romklao, Pattana Chonnabot 3 Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-04-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1725,
+  "hares": "Nick 'Leg Iron' Z",
+  "location": "Krungthep Kreeta Rioad, Gai Yang Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-04-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1726,
+  "hares": "Frank 'Noriega' A",
+  "location": "Seri Thai Soi 38",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-04-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1727,
+  "hares": "Greg 'Tickler' C",
+  "location": "Near Wat Chak Daeng, Petchahung Soi 10",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-05-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1728,
+  "hares": "Maarten 'Sir Bogdiver' B",
+  "location": "Klong Dan (near Bang Na-Trad km25)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-05-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1729,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Nonthaburi, Suan Bua Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-05-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1730,
+  "hares": "Bob 'Bullit' B",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-05-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1731,
+  "hares": "Mrs Na",
+  "location": "Sukhumvit Soi 50",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-05-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1732,
+  "hares": "Neil 'Hags' H",
+  "location": "Chalerm Prakiat Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-06-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1733,
+  "hares": "Brenda 'Splat' F",
+  "location": "Krung Thonburi, Artist's Place",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-06-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1734,
+  "hares": "George 'Of the Jungle' M",
+  "location": "Patanakarn Road Soi 56",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-06-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1735,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Tiwanon Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-06-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1736,
+  "hares": "Vichai 'Cool' P",
+  "location": "Hua Lamphong station car park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-07-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1737,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "The Port - US Independence Day Run",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-07-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1738,
+  "hares": "Jeff 'Bugs' G",
+  "location": "Bang Kruai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-07-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1739,
+  "hares": "Peter 'Hater Peacox' H",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-07-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1740,
+  "hares": "Eric 'Drunken Donut' C",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-08-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1741,
+  "hares": "Andrew 'No No' M",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-08-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1742,
+  "hares": "Tim 'Crash' D",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-08-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1743,
+  "hares": "Brian 'Brain Health' H",
+  "location": "Krungthep Kreeta, Unico Golf Course",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-08-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1744,
+  "hares": "Tukta 'T-Rex' B",
+  "location": "Chalerm Prakiat Soi 63, Vietnamese Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-08-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1745,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-09-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1746,
+  "hares": "Ian 'AKM' S",
+  "location": "Chonburi M'way, Steak Baan Deang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-09-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1747,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-09-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1748,
+  "hares": "John 'Selfie Queen' T",
+  "location": "Chalerm Prakiat Soi 68",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-09-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1749,
+  "hares": "KC 'Boob-a-lube' M",
+  "location": "Bang Yai, Morgan Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-10-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1750,
+  "hares": "Greg 'Tickler' C",
+  "location": "Ratchapreuk Road TaKeing Keing Naam Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-10-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1751,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Hua Lamphong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-10-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1752,
+  "hares": "Bob 'Aunties Bitch' N",
+  "location": "Bang Wa, Wun Wan Club",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-10-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1753,
+  "hares": "Greg 'Tickler' C",
+  "location": "Ratchapreuk Road TaKeing Keing Naam Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-10-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1754,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Chalerm Prakiat Soi 63",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-11-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1755,
+  "hares": "Ed 'Checkless' C",
+  "location": "Kanchanapisek (East) Rice City/Paintball Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-11-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1756,
+  "hares": "Sizzler and Dunkin Donut",
+  "location": "Sri Nakarin Soi 49",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-11-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1757,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Krungthep Kreeta, Gai Yang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-11-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1758,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Talad Plu Market",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-12-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1759,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Hua Lamphong station car park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-12-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1760,
+  "hares": "Matt 'Canal Rappe' R",
+  "location": "Prakanong, Sukhumvit Plus 2 Condo",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-12-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1761,
+  "hares": "Bob 'Bullit' B",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2016-12-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1762,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Pra Samut Chedi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-01-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1763,
+  "hares": "Vichai 'Senator' S and Oversexed",
+  "location": "Krungthep Kreeta Gai Yang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-01-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1764,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nonthaburi, Suan Bua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-01-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1765,
+  "hares": "Peter 'Maverick' L",
+  "location": "Ramindra, Soi Wat, Porn Pra Ruang Prasit",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-01-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1766,
+  "hares": "John 'Tinker' L",
+  "location": "Kamphaeng Phet Road, Suan Kanvela",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-01-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1767,
+  "hares": "Noah '4x2' S",
+  "location": "Kanchanapisek Soi 12",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-02-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1768,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-02-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1769,
+  "hares": "Cengiz 'Disgusting' E",
+  "location": "Nakon In Road, Cowboy",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-02-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1770,
+  "hares": "Barry 'Knockout Neptune' M",
+  "location": "Pattanakarn Soi 25",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-02-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1771,
+  "hares": "Nid 'Sizzler' K",
+  "location": "Kanchanapisek, Krua Rim Tung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-03-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1772,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Talad Plu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-03-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1773,
+  "hares": "Greg 'Tickler' C",
+  "location": "Ratchapreuk Road, TaKeing Keing Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-03-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1774,
+  "hares": "Ed 'Checkless' C",
+  "location": "Samut Prakan, Naval Academy",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-03-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1775,
+  "hares": "Peter 'Hater Peacox' H",
+  "location": "Taling Chan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-04-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1776,
+  "hares": "Terry 'Sheep Shagger' J",
+  "location": "Krungthep Kreeta, Gai Yang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-04-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1777,
+  "hares": "KC 'Boob-a-Lube' M",
+  "location": "Ladprao Soi 26",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-04-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1778,
+  "hares": "Frank 'Noriega' A",
+  "location": "Seri Thai Soi 38",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-04-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1779,
+  "hares": "Kanchana 'Tom Yum Goong' M",
+  "location": "Wutthakat, Exit2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-05-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1780,
+  "hares": "Ian 'AKM' S",
+  "location": "Chonburi M'way, Steak Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-05-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1781,
+  "hares": "Mike 'Love Canal' R",
+  "location": "Lat Krabang Soi 5/3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-05-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1782,
+  "hares": "Neil 'Hags' H",
+  "location": "Krungthep Kreeta, Gai Yang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-05-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1783,
+  "hares": "Jeff 'Bugs' G",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-05-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1784,
+  "hares": "George 'Of the Jungle' M",
+  "location": "Patanakan Soi 25",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-06-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1785,
+  "hares": "Steve 'Gringo' G",
+  "location": "Nonthaburi Bypass",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-06-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1786,
+  "hares": "Vichai 'Cool' P",
+  "location": "Hua Lampong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-06-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1787,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "Ramkhamhaeng Soi 187/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-06-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1788,
+  "hares": "Tim 'Joylide' P",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-07-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1789,
+  "hares": "Bob 'Bull**it' B",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-07-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1790,
+  "hares": "Andrew 'No No' M",
+  "location": "Nakon In Road, Cowboy",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-07-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1791,
+  "hares": "Eric 'Dunkin Donut' C",
+  "location": "Wat Bang Na Nok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-07-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1792,
+  "hares": "John 'McSwirly Face' M",
+  "location": "Beyond Lat Krabang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-07-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1793,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Nonthaburi, Suan Bua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-08-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1794,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Nakon In, Cowboy",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-08-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1795,
+  "hares": "Peter 'Maverick' L",
+  "location": "Kanchanapisek (East), Homestay",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-08-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1796,
+  "hares": "It 'Eat Me' S",
+  "location": "Kanchanapisek (East), Krua Rim Tung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-08-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1797,
+  "hares": "Vinai 'Oversexed' S",
+  "location": "Pra Nangklao Bridge, Krua Mae Nong Nun",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-09-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1798,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Bang Sue, Baan Macam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-09-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1799,
+  "hares": "Clive 'Rabid Bitch' B",
+  "location": "Samrong, Sukhumvit Soi 117",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-09-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1800,
+  "hares": "Kim 'Normal' C",
+  "location": "Rama 3 Road, Soi 44",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-09-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1801,
+  "hares": "Tim 'Crash' D",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-10-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1802,
+  "hares": "Ya 'City Girl' C",
+  "location": "Lat Krabang, Mum Sabai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-10-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1803,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Nakon In Road, Cowboy",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-10-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1804,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-10-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1805,
+  "hares": "Mike 'Love Canal' R",
+  "location": "Onnut Soi 21/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-10-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1806,
+  "hares": "Vichai 'The Senator' S",
+  "location": "Krungthep Kreeta, Gai Yang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-11-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1807,
+  "hares": "John 'Tinker' L",
+  "location": "Bang Yai, Morgan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-11-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1808,
+  "hares": "Aunties Bitch and Boobalube",
+  "location": "Pattanakan Soi 53, Somtam Mueangthong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-11-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1809,
+  "hares": "ex-GM Peter 'Hayter Peacox' H",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-11-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1810,
+  "hares": "Mike 'Love Canal' R",
+  "location": "Samrong, Piap Return",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-12-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1811,
+  "hares": "Bob 'Aunties Bitch' N, Vinai 80 today!",
+  "location": "Taling Chan, Wat Intrawat (Wat Pradu)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-12-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1812,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Chonburi M'way, Steak Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-12-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1813,
+  "hares": "KC 'Boob-a-Lube' M",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2017-12-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1814,
+  "hares": "Andrew 'Agent Orange' McP",
+  "location": "Pra Samut Chedi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-01-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1815,
+  "hares": "Andrew 'No No' M",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-01-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1816,
+  "hares": "Barry 'Knockout Neptune' M",
+  "location": "Patanakan Soi 25",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-01-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1817,
+  "hares": "Frank 'Noriega' A",
+  "location": "Seri Thai Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-01-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1818,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Taling Chan, Suan Sri Krung Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-01-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1819,
+  "hares": "Noah '4x2' S",
+  "location": "Kanchanapisek (East), Krua Rim Tung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-02-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1820,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Klong Toei Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-02-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1821,
+  "hares": "Cengiz 'Disgusting' E",
+  "location": "Nakon In, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-02-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1822,
+  "hares": "Bruce 'Hash Hash' W",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-02-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1823,
+  "hares": "Chris 'Bushman' S",
+  "location": "Sathorn Road, Soi Suan Plu, Sub-Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-03-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1824,
+  "hares": "Steve 'Gringo' G",
+  "location": "Pattanakan Soi 25",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-03-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1825,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Chalerm Prakiat Soi 28",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-03-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1826,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Chonburi M'way, Steak Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-03-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1827,
+  "hares": "John 'Tinker' L",
+  "location": "Kamphaeng Phet Road, Suan Kanvela Resturant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-04-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1828,
+  "hares": "Jeff 'Bugs' G",
+  "location": "Bang Kruai Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-04-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1829,
+  "hares": "Ian 'AKM' S",
+  "location": "Chonburi Motorway, Steak Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-04-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1830,
+  "hares": "Chris 'Dutch Enhancer' H",
+  "location": "Sukhumvit Soi 50",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-04-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1831,
+  "hares": "Bob 'Bull**it' B",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-04-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1832,
+  "hares": "Greg 'The Tickler' C",
+  "location": "Ratchapreuk, TaKeing Keing Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-05-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1833,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Rattanakosin, The Giant Swing",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-05-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1834,
+  "hares": "Tim 'Joylide' W",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-05-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1835,
+  "hares": "Neil 'Hags' H",
+  "location": "Chonburi Motorway, Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-05-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1836,
+  "hares": "George 'Of the Jungle' M",
+  "location": "Onnut Market, Sukhumvit Soi 75/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-06-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1837,
+  "hares": "Ed 'Checkless' C",
+  "location": "Ramindra, Sukhaphiban 5",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-06-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1838,
+  "hares": "Vichai 'Cool' P",
+  "location": "Hua Lampong, station car park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-06-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1839,
+  "hares": "Kim 'Normal' C",
+  "location": "Rama 3 Road, Soi 44",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-06-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1840,
+  "hares": "Eric 'Dunkin Donut' C",
+  "location": "Wat Bang Na Nok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-07-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1841,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "Ramkhamhaeng Soi 127",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-07-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1842,
+  "hares": "John 'McSwirly Face' McB",
+  "location": "Samut Prakarn, near Ancient City",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-07-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1843,
+  "hares": "Shaggy & City Girl",
+  "location": "Lat Krabang, Mum Sabai Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-07-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1844,
+  "hares": "Louis 'Moonlight' H",
+  "location": "Petchahung Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-07-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1845,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-08-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1846,
+  "hares": "Roland 'Rawhide' P",
+  "location": "Nonthaburi, near Wat Molee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-08-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1847,
+  "hares": "Peter 'Hayter Peacox' H",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-08-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1848,
+  "hares": "It 'Eat Me' S",
+  "location": "Kanchanapisek, Krua Rim Tung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-08-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1849,
+  "hares": "‘Tom Yam’ Gung M",
+  "location": "Pattanakan Road near Chalerm Prakiat",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-09-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1850,
+  "hares": "Vinai 'Oversexed' S",
+  "location": "Nangklao Bridge, Krua Sam Yao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-09-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1851,
+  "hares": "Sherry 'Red Hot Lips' F",
+  "location": "Petchahung Soi 10",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-09-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1852,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Bang Sue, Baan Makham",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-09-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1853,
+  "hares": "Kevin 'Roger Me' M",
+  "location": "Samrong, Steak Baan Chan Suan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-10-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1854,
+  "hares": "Bruce 'Hash Hash' W",
+  "location": "Petchahung Road, IMF Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-10-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1855,
+  "hares": "Vichai 'Senator' S",
+  "location": "Kanchanapisek, Krua Rim Tung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-10-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1856,
+  "hares": "Andrew 'Agent Orange' M",
+  "location": "End of Suksawat Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-10-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1857,
+  "hares": "Jennifer 'LCBS' S",
+  "location": "Near Asok BTS, Bai Mai Ra Rerng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-10-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1858,
+  "hares": "Andrew 'No No' M",
+  "location": "Nakon In, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-11-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1859,
+  "hares": "Tim 'Crash' D",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-11-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1860,
+  "hares": "JMs - run",
+  "location": "Pattanakan/Chalerm Prakiat, Aroi Dee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-11-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1861,
+  "hares": "KC 'Boob-a-Lube' M",
+  "location": "Pattanakan Soi 53, Somtam Mueangthong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-11-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1862,
+  "hares": "Bob 'Auntie's Bitch' N",
+  "location": "Bang Na, Sampawut Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-12-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1863,
+  "hares": "Terry 'Sheepshagger' J",
+  "location": "Nakon In/Tiwanon, Korat Chicken",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-12-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1864,
+  "hares": "Frank 'Noriega' A",
+  "location": "Onnut Soi 37",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-12-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1865,
+  "hares": "Yuree 'Wiggler' S",
+  "location": "Tanon Tok, Good View Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-12-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1866,
+  "hares": "John 'Tinker' L",
+  "location": "Kampaeng Phet Road, Suan Kanvela Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2018-12-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1867,
+  "hares": "KC 'Boob-a-lube' M",
+  "location": "Rama 3 Road, Soi 47",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-01-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1868,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Kanchanapisek, Krua Rim Tung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-01-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1869,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nonthaburi, Baan Klong Om",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-01-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1870,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Chalerm Prakiat Road Soi 47",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-01-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1871,
+  "hares": "Peter 'Dripper' W",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-02-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1872,
+  "hares": "'Captain' Erik R",
+  "location": "Chonburi Motorway, Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-02-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1873,
+  "hares": "Andrew 'No No' M",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-02-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1874,
+  "hares": "Nid 'Sizzler' P",
+  "location": "Sri Nakarin Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-02-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1875,
+  "hares": "Tony 'Shaggy' S",
+  "location": "Lat Krabang Soi 3/3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-03-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1876,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Pratunam, Petchaburi Soi 32",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-03-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1877,
+  "hares": "Fred 'Sweetie' A",
+  "location": "Chatuchak Driving Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-03-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1878,
+  "hares": "Bob 'Bullit' B",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-03-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1879,
+  "hares": "'Tom Yum' Gung M",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-04-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1880,
+  "hares": "Andrew 'Agent Orange' M",
+  "location": "Pra Samut Chedi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-04-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1881,
+  "hares": "Ian 'AKM' S",
+  "location": "Chonburi Motorway Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-04-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1882,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "Samsen Soi 3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-04-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1883,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-04-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1884,
+  "hares": "Greg 'Tickler' C",
+  "location": "Nonthaburi, TaKeing Keing Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-05-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1885,
+  "hares": "Peter 'Hayter Peacox' H",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-05-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1886,
+  "hares": "Vichai 'Senator' S",
+  "location": "Chonburi M'way, Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-05-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1887,
+  "hares": "Mike 'Whoremonger' R",
+  "location": "Prapadaeng, Petchahung Soi 10",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-05-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1888,
+  "hares": "Vichai 'Cool' P",
+  "location": "Hua Lampong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-06-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1889,
+  "hares": "George 'of the Jungle' M",
+  "location": "Onnut Soi 37, Kung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-06-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1890,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Bang Sue, Baan Makham",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-06-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1891,
+  "hares": "Steve 'Gringo' G",
+  "location": "Ramindra, Sukhapiban 5, Chatu Chot 10",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-06-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1892,
+  "hares": "Noah '4x2' S",
+  "location": "Kanchanapisek, Krua Rim Tung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-07-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1893,
+  "hares": "Matt 'AR' R",
+  "location": "Ladprao, Sukhonthasawat Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-07-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1894,
+  "hares": "Eric 'Drunken Donut' C",
+  "location": "Bang Na, Sanpawut Road, Silawat Seafood",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-07-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1895,
+  "hares": "Peter 'Maverick' L",
+  "location": "Krungthep Kreeta, Baan Kong Rao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-07-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1896,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Talad Plu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-07-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1897,
+  "hares": "Mike 'Love Canal' R",
+  "location": "Samrong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-08-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1898,
+  "hares": "Simon 'Mudguard' K",
+  "location": "Prachachuen, Ratchadapisek Soi 27/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-08-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1899,
+  "hares": "Tim 'Crash' D",
+  "location": "Srinakarin Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-08-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1900,
+  "hares": "Woody 'Mongolian Crotch' T",
+  "location": "Samut Prakan Steak Baan Charn Suan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-08-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1901,
+  "hares": "Jeff 'Bugs' G",
+  "location": "Bang Kruay Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-09-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1902,
+  "hares": "Ian 'CoDpiece' P",
+  "location": "Onnut Soi 37",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-09-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1903,
+  "hares": "Paul 'Tamborine Man W",
+  "location": "Phayathai Station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-09-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1904,
+  "hares": "Vinai 'Oversexed' S",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-09-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1905,
+  "hares": "Kim 'Normal' C",
+  "location": "Rama 9 Road, Chateau Chaubert",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-09-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1906,
+  "hares": "Id 'Eat Me' S",
+  "location": "Pattanakan Soi 25",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-10-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1907,
+  "hares": "Mayli 'Hot Chili' S",
+  "location": "Srinakarin Soi 45",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-10-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1908,
+  "hares": "Louis 'Moonlight' H",
+  "location": "Viphavadee Soi 20",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-10-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1909,
+  "hares": "Tony 'Shaggy' S",
+  "location": "Sutthisan/Ratchadapisek",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-10-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1910,
+  "hares": "Roland 'Rawhide' P",
+  "location": "Nonthaburi, Wat Molee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-11-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1911,
+  "hares": "Senator and Rawhide",
+  "location": "Chonburi Motorway, Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-11-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1912,
+  "hares": "Ex-GM Checkless",
+  "location": "Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-11-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1913,
+  "hares": "Yuree 'Wiggler' S",
+  "location": "Tanon Tok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-11-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1914,
+  "hares": "KC 'Boob-a-lube' M",
+  "location": "Bang Wa",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-12-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1915,
+  "hares": "Frank 'Noriega' A",
+  "location": "Onnut Soi 37",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-12-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1916,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Samut Prakan, Bang Pu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-12-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1917,
+  "hares": "'Captain' Erik R",
+  "location": "Chonburi M'way, Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-12-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1918,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Baan Pussy Virus Yenakard Soi 2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2019-12-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1919,
+  "hares": "Michel 'Ibo Ibo' D",
+  "location": "Sukhumvit Soi 33 Yaek 5",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-01-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1920,
+  "hares": "Andrew 'No No' M",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-01-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1921,
+  "hares": "'Tom Yum' Gung M",
+  "location": "Pattanakarn Soi 53, Somtam Mueangthong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-01-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1922,
+  "hares": "Tony 'Shaggy' S",
+  "location": "Sutthisan, Zap Station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-01-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1923,
+  "hares": "Nid 'Sizzler' P",
+  "location": "Chonburi M'way, Baan Daeng",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-02-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1924,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nonthaburi, Rattana Thibet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-02-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1925,
+  "hares": "Peter 'Maverick' L",
+  "location": "Krungthep Kreeta, Baan Kong Rao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-02-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1926,
+  "hares": "John 'Tinker' L",
+  "location": "Dusit, Payap Pier",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-02-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1927,
+  "hares": "Peter 'Hater Peacox' H",
+  "location": "Taling Chan, Baan Daolomdeun",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-03-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1928,
+  "hares": "Bob 'Bullit' B",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-03-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1929,
+  "hares": "Bengt 'Khlong Dump' G",
+  "location": "Sukhumvit Soi 93",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-03-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1930,
+  "hares": "George 'of the Jungle' M",
+  "location": "Srinakarin Soi 44",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-06-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1931,
+  "hares": "Holden 'Eetan' L",
+  "location": "Pattanakan Soi 53",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-06-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1932,
+  "hares": "Mike 'Love Canal' R",
+  "location": "Praeksa",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-06-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1933,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Taling Chan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-07-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1934,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Bang Sue",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-07-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1935,
+  "hares": "Noah '4x2' S",
+  "location": "Pattanakarn 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-07-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1936,
+  "hares": "Steve 'Gringo' G",
+  "location": "Nonthaburi, Ricco Farm Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-07-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1937,
+  "hares": "Jeff 'Bugs' G",
+  "location": "Bang Yai, Krua Mu Bon",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-08-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1938,
+  "hares": "Eric 'Drunkin Donut' C",
+  "location": "Chinatown",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-08-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1939,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Onnut Soi 37, Kung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-08-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1940,
+  "hares": "Vichai 'Cool' P",
+  "location": "Klong San, Yok Yor",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-08-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1941,
+  "hares": "Jim 'Virginia Slim' E Birthday run",
+  "location": "Soi Pradit Manutham 23 Near Ramindra Expressway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-08-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1942,
+  "hares": "Ed 'Checkless' C",
+  "location": "Lat Krabang - Khrua Khun Noi 2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-09-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1943,
+  "hares": "Kevin 'Roger Me' M",
+  "location": "Near Bang O MRT",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-09-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1944,
+  "hares": "Bob 'Bullit' B",
+  "location": "Nakon In Road, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-09-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1945,
+  "hares": "Vinai 'Oversexed' S",
+  "location": "Krungthep Kreeta Soi 8 Gai Yang Sua Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-09-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1946,
+  "hares": "John 'Duke of Puke' G",
+  "location": "Sukhumvit Soi 8 Joylide Condo",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-10-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1947,
+  "hares": "Budsanee 'Eat Me' S",
+  "location": "Pattanakarn Soi 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-10-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1948,
+  "hares": "Ian 'Cod Piece' P",
+  "location": "off Pradit Manutham Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-10-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1949,
+  "hares": "Peter 'Penny Lame' C",
+  "location": "Paknam, Navy Academy",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-10-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1950,
+  "hares": "Vichai 'Senator' S",
+  "location": "Krungthep Kreeta Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-11-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1951,
+  "hares": "Gringo & No No",
+  "location": "Petchahung Soi 20, Baan Baan Bang Krajao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-11-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1952,
+  "hares": "Andrew 'No No' M",
+  "location": "Nakon In, Cowboy Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-11-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1953,
+  "hares": "Paul 'Tokyo Joe' E",
+  "location": "Chatuchak, Ratchadapisek Soi 52",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-11-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1954,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Baan Pussy Virus Yenakard Soi 2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-11-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1955,
+  "hares": "Peter 'Penny Lame' C",
+  "location": "Bang Na, Tanon Tang Rotfai Sai Kao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-12-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1956,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Sukhumvit Soi 50, Luea Suk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-12-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1957,
+  "hares": "Greg 'The Tickler' C",
+  "location": "Nonthaburi Bypass, Ricco Farms",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-12-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1958,
+  "hares": "Nid 'Sizzler' P",
+  "location": "Onnut Soi 37",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2020-12-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1959,
+  "hares": "KC 'Boobalube' M",
+  "location": "Ratburana, Wat Bang Phung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-01-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1960,
+  "hares": "Bengt 'Klong Dump' G",
+  "location": "Sri Nakarin Soi 41",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-01-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1961,
+  "hares": "'Tom Yum' Gung M",
+  "location": "Krungthep Kreeta Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-01-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1962,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-01-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1963,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "Petchahung Soi 49, IMF",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-02-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1964,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nonthaburi, Rattana Tibet Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-02-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1965,
+  "hares": "Peter 'Maverick' L",
+  "location": "Petchahung Soi 20, Baan Baan Bang Krajao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-02-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1966,
+  "hares": "Thananya 'Whippet Cream' C",
+  "location": "Kanchanapisek Soi 25, Homestay/Krangna",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-02-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1967,
+  "hares": "Peter 'Hayter Peacox' H",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-03-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1968,
+  "hares": "Bullit and No Good Boyo",
+  "location": "Bang Kruay, Pattana Gate St Davids Day run",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-03-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1969,
+  "hares": "Noah '4x2' S",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-03-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1970,
+  "hares": "George 'Of the Jungle' M",
+  "location": "Pattanakan Soi 53, Somtam Mueangthong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-03-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1971,
+  "hares": "Ed 'Checkless' C",
+  "location": "Ramindra, Chatu Chot 10",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-03-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1972,
+  "hares": "Frank 'Noriega' A",
+  "location": "Krungthep Kreeta Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-04-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1973,
+  "hares": "Tim 'Joylide' W",
+  "location": "Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-04-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1974,
+  "hares": "Bob 'Aunties Bitch' N",
+  "location": "Onnut Soi 80",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-04-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1975,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Petchahung Soi 20, Baan Baan Bang Krajao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-11-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1976,
+  "hares": "Greg 'The Tickler' C",
+  "location": "Ratchadapisek Soi 66",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-11-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1977,
+  "hares": "Andrew 'No No' M",
+  "location": "Ratburana Soi 22",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-11-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1978,
+  "hares": "Ed 'Checkless' C",
+  "location": "Ramindra ChatuChot 10, Uncle Chu's",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-11-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1979,
+  "hares": "Kevin 'Grannys Tits' C",
+  "location": "Taling Chan, Krua Jeed Jard",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-12-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1980,
+  "hares": "Eric 'Dunkin Donut' C",
+  "location": "Chinatown, Kaeng Hoi Khom",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-12-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1981,
+  "hares": "JM Codpiece",
+  "location": "Petchahung Soi 20, Baan Baan Bang Krajao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-12-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1982,
+  "hares": "Ex-GM Gringo",
+  "location": "Kanchanapisek Soi 25, Homestay/Klangna",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2021-12-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1983,
+  "hares": "Holden 'Eetan' L",
+  "location": "Bang Sue, Soi Rotfai 2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-01-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1984,
+  "hares": "Greg 'Tickler' C",
+  "location": "Nonthaburi, Takeing Keing Naam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-01-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1985,
+  "hares": "KC 'Boobalube' M",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-01-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1986,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Hua Chang, Taksura",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-01-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1987,
+  "hares": "Paul 'Tokyo Joe' E",
+  "location": "Ratchadapisek Soi 52, Lom Choi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-01-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1988,
+  "hares": "Peter 'Ladyboy' V",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-02-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1989,
+  "hares": "Bengt 'Klongdump' G",
+  "location": "Sri Nakarin Soi 41, Baan Noi Ling Khlong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-02-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1990,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "The Port",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-02-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1991,
+  "hares": "Stephen 'CiS' L",
+  "location": "Lat Krabang, Fish House",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-02-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1992,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nothaburi, Wat Bang Bua Tong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-03-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1993,
+  "hares": "Peter 'Maverick' L",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-03-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1994,
+  "hares": "Steve 'Gringo' G",
+  "location": "Chalerm Prakiat Soi 68",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-03-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1995,
+  "hares": "George 'of the Jungle' M",
+  "location": "Onnut Soi 65, Baan Suan 65",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-03-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1996,
+  "hares": "Bob 'Aunties Bitch' N",
+  "location": "Onnut Soi 55/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-04-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1997,
+  "hares": "Louis 'Moonlight' H",
+  "location": "Ruam Rudi Village",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-04-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1998,
+  "hares": "Greg 'Tickler' C",
+  "location": "Nonthaburi, TaKeing Keing Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-04-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 1999,
+  "hares": "Paul 'Tamborine Man' W",
+  "location": "Ratchathewi, Hua Chang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-04-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2000,
+  "hares": "Bullit & Tinker",
+  "location": "Nakon In Road, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-05-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2001,
+  "hares": "Eric 'Drunkin Donut' C",
+  "location": "Petchahung Soi 20, Baan Baan Bang Krachao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-05-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2002,
+  "hares": "Kevin 'Grannys Tits' C",
+  "location": "Taling Chan, The Junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-05-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2003,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Prakanong, Fongfab Laundry@Vistagarden",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-05-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2004,
+  "hares": "Tim 'Joylide' W",
+  "location": "Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-05-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2005,
+  "hares": "Noah '4x2' S",
+  "location": "Pattanakarn 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-06-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2006,
+  "hares": "Glen 'ThalidosKid' D",
+  "location": "Seri Thai Rd, Nang Talung Chomchan Seafood",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-06-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2007,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Talad Plu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-06-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2008,
+  "hares": "Holden 'Eetan' L",
+  "location": "Romklao, Chonnabot 3",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-06-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2009,
+  "hares": "Vichai 'Senator' S",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-07-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2010,
+  "hares": "Steve 'Gringo' G",
+  "location": "Ramindra, Chatu Chot 10",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-07-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2011,
+  "hares": "Patrick 'Dambuster' C",
+  "location": "Pahonyothin, Bang Bua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-07-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2012,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Ngam Wong Wan Soi 23",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-07-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2013,
+  "hares": "Svend 'Father Joseph' J",
+  "location": "Makkasan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-08-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2014,
+  "hares": "Tiradej 'Pork Finder' S",
+  "location": "Taling Chan, Prawnhub",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-08-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2015,
+  "hares": "Greg 'Tickler' C",
+  "location": "Ratchapreuk-Nonthaburi 1 Road, Big Boss",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-08-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2016,
+  "hares": "'Tom Yum' Gung M",
+  "location": "Bangsue, Mooban Rotfai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-08-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2017,
+  "hares": "Peter 'Ladyboy' V",
+  "location": "Ratchadapisek Soi 66",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-08-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2018,
+  "hares": "Id 'Eat Me' S",
+  "location": "Onnut Soi 37",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-09-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2019,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Hua Lampong Station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-09-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2020,
+  "hares": "Bengt 'Klongdump' G",
+  "location": "Bang Na, Plearn Por Dee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-09-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2021,
+  "hares": "John 'Tinker' L",
+  "location": "Bang Sue, Station Saep Nua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-09-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2022,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Pasicharoen, Moomsabai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-10-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2023,
+  "hares": "Tim 'Crash' D",
+  "location": "Chalerm Prakiet Soi 68, Krua Mum Suan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-10-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2024,
+  "hares": "Tim 'Joylide' W",
+  "location": "Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-10-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2025,
+  "hares": "George 'of the Jungle' M",
+  "location": "Srinakarin 44, Somtam Srinakarin",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-10-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2026,
+  "hares": "Holden 'Eetan' L",
+  "location": "Nonthaburi, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-10-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2027,
+  "hares": "Nid 'Sizzler' K Halloween Run",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-11-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2028,
+  "hares": "Granny's Tits and Checkless",
+  "location": "Taling Chan, The Junction",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-11-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2029,
+  "hares": "Ian 'Codpiece' P",
+  "location": "Onnut 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-11-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2030,
+  "hares": "Eric 'Drunken Donut' C",
+  "location": "Chinatown, Soi Phanumat",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-11-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2031,
+  "hares": "John 'Tinker' L",
+  "location": "Bang Yai, Fighting Shrimp",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-12-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2032,
+  "hares": "Steve 'Gringo' G",
+  "location": "Kanchanapisek, Klang Na (Homestay)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-12-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2033,
+  "hares": "Peter 'Maverick' L",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-12-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2034,
+  "hares": "Ed 'Checkless' C",
+  "location": "Chatu Chot 10, Uncle Chu's",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2022-12-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2035,
+  "hares": "Vichai 'Senator' S",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-01-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2036,
+  "hares": "Lili 'Slippery when Wet' C",
+  "location": "Chatuchak, Rot Fai Park, Thitaree",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-01-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2037,
+  "hares": "KC 'Boobalube' M",
+  "location": "Bang Sue, Station Saep Nua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-01-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2038,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Bang Na, Sanpawut Road, Silawat",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-01-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2039,
+  "hares": "Noah '4x2' S",
+  "location": "Pattanakan 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-01-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2040,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nonthaburi, Mooban Ratchapreuk Villa",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-02-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2041,
+  "hares": "Greg 'Tickler' C",
+  "location": "Nonthaburi, Takeing Keing Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-02-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2042,
+  "hares": "Bob 'Aunties Bitch' N",
+  "location": "Onnut 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-02-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2043,
+  "hares": "Peter 'Ladyboy' V",
+  "location": "Pahonyothin, Sena Nikom",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-02-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2044,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Romklao, Chonnabot 3, Jamaica Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-03-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2045,
+  "hares": "Id 'Eat Me' S",
+  "location": "Pattanakan Soi 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-03-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2046,
+  "hares": "George 'of the Jungle' M",
+  "location": "Krungthep Kreeta Soi 8, Gai Yang Sua Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-03-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2047,
+  "hares": "Capt'n Erik R",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-03-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2048,
+  "hares": "Bob 'Bullit' B",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-04-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2049,
+  "hares": "Svend 'Father Joseph' J",
+  "location": "Makkasan, Nikom Makkasan Road",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-04-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2050,
+  "hares": "Tiradej 'Porkfinder' S",
+  "location": "Taling Chan, Yok Krok",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-04-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2051,
+  "hares": "Tim 'Crash' D",
+  "location": "Onnut 37, not Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-04-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2052,
+  "hares": "John 'Tinker' L",
+  "location": "Ratchawat, near Laem Tong Restaurant",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-05-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2053,
+  "hares": "Nid 'Sizzler' P",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-05-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2054,
+  "hares": "Lili 'Slippery When Wet' C",
+  "location": "Sukhumvit Soi 74, Nachaleeti",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-05-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2055,
+  "hares": "Ian 'CoDPiece' P",
+  "location": "Bang Krachao, Baan Baan Bang Krachao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-05-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2056,
+  "hares": "'Tom Yum' Gung M",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-05-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2057,
+  "hares": "KC 'Boob-A-Lube' M",
+  "location": "Ratburana, Wat Bang Phung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-06-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2058,
+  "hares": "Tim 'Joylide' W",
+  "location": "Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-06-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2059,
+  "hares": "Bruce 'Hash Hash' W",
+  "location": "Bang Krachao, Lung Ooh",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-06-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2060,
+  "hares": "Bengt ‘Klong Dump’ G",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-06-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2061,
+  "hares": "Ryn 'Jumpstart' H",
+  "location": "Sukhumvit Soi 81, Sawadee Beer Garden",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-07-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2062,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "Nonthaburi, Sai Ma 7",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-07-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2063,
+  "hares": "Matthew C",
+  "location": "Bang Kruay, Zab Ozone",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-07-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2064,
+  "hares": "Greg 'Tickler' C",
+  "location": "Nonthaburi, Takeing Keing Nam",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-07-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2065,
+  "hares": "Su 'No Boyfriend'",
+  "location": "Mooban Panya",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-07-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2066,
+  "hares": "KC 'Boobalube' M",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-08-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2067,
+  "hares": "Vichai 'Senator' S",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-08-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2068,
+  "hares": "Stephen 'CiS' L",
+  "location": "Pattanakan 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-08-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2069,
+  "hares": "Peter 'Ladyboy' V",
+  "location": "Sena Nikom, Farm Sena",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-08-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2070,
+  "hares": "Tony 'Shaggy' S",
+  "location": "Minburi, Rim Lagoon",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-09-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2071,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Nonthaburi, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-09-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2072,
+  "hares": "Ian 'Codpiece' P",
+  "location": "Wang Thonglang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-09-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2073,
+  "hares": "Eric 'Drunken Donut' C",
+  "location": "Pratunam pier",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-09-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2074,
+  "hares": "Noah '4x2' S",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-10-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2075,
+  "hares": "Peter 'Maverick' L",
+  "location": "Pattanakarn Soi 93, Aroy Dee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-10-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2076,
+  "hares": "Ed 'Checkless' C",
+  "location": "Ramindra, Uncle Chu’s",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-10-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2077,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Pattanakan Soi 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-10-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2078,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Chinatown, Samphanthawong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-10-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2079,
+  "hares": "Kim 'Normal' C",
+  "location": "Rama 9 Road, Soi 39",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-11-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2080,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Bang Sue, Esan Lampluen",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-11-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2081,
+  "hares": "Bullit/Spinning Dwarf",
+  "location": "Nonthaburi, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-11-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2082,
+  "hares": "Georgia 'Always Cums Last' S",
+  "location": "Ratchathewi, Hua Chang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-11-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2083,
+  "hares": "Lily 'Slippery When Wet' C",
+  "location": "Nonthaburi, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-12-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2084,
+  "hares": "Ian 'Codpiece' P",
+  "location": "Sukhumvit Soi 81, New Beer Garden",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-12-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2085,
+  "hares": "Id 'Eat Me' S",
+  "location": "Pattanakan Soi 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-12-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2086,
+  "hares": "George 'of the Jungle' M",
+  "location": "Krungthep Kreeta Road, Dern Len Market",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2023-12-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2087,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "Sukhumvit Soi 13, Sethiwan Condo",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-01-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2088,
+  "hares": "Tim 'Joylide' W",
+  "location": "Sukhumvit Soi 8, Heritage Condo",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-01-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2089,
+  "hares": "Ibo Ibo and Noriega",
+  "location": "Thonglor Soi 21",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-01-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2090,
+  "hares": "Greg 'The Tickler' C",
+  "location": "Nonthaburi, Big Boss",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-01-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2091,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Bang Krachao, Baan Lung Ooh",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-01-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2092,
+  "hares": "Chris 'Wally' M",
+  "location": "Bang Sue, Esan Lampluen",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-02-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2093,
+  "hares": "KC 'Boobalube' M",
+  "location": "Taling Chan, Wat Pradu",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-02-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2094,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-02-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2095,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Nonthaburi, Chesada Bridge",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-02-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2096,
+  "hares": "Graeme 'Mini' B",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-03-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2097,
+  "hares": "Bob 'Aunties Bitch' N",
+  "location": "Chalerm Prakiet, Krua Mum Suan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-03-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2098,
+  "hares": "John 'Tinker' L",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-03-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2099,
+  "hares": "Peter 'Ladyboy' V",
+  "location": "Nonthaburi, near Royal Irrigation Department",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-03-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2100,
+  "hares": "Peter 'Maverick' L",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-04-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2101,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Yen Akard, Soi Prasat Suk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-04-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2102,
+  "hares": "Eric 'Drunken Donut' C",
+  "location": "Hua Lamphong station car park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-04-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2103,
+  "hares": "Tiradej 'Porkfinder' S",
+  "location": "Bangkok Noi, Erawan Park Avenue",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-04-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2104,
+  "hares": "Ed 'Checkless' C",
+  "location": "Kanchanapisek East, Klang Na (Homestay)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-04-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2105,
+  "hares": "Mike 'Drinks Like a Girl' C",
+  "location": "Sukhumvit Soi 23, Wind",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-05-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2106,
+  "hares": "Noah '4x2' S",
+  "location": "Onnut Soi 17",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-05-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2107,
+  "hares": "Bengt 'Klong Dump' G",
+  "location": "Seri Thai Soi 9, Lighthouse",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-05-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2108,
+  "hares": "Tony 'Shaggy' S",
+  "location": "Minburi, Kumklao Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-05-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2109,
+  "hares": "'Tom Yum' Gung M",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-06-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2110,
+  "hares": "The Nigerian",
+  "location": "Sukhumvit Soi 50, under the Expressway",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-06-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2111,
+  "hares": "Ian 'Codpiece' P",
+  "location": "Onnut 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-06-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2112,
+  "hares": "Vichai 'Senator' S",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-06-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2113,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Pasicharoen Panit Thon21, Moomsabai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-07-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2114,
+  "hares": "Id 'Eat Me' S",
+  "location": "Pattanakan 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-07-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2115,
+  "hares": "Yaya 'Angel' S",
+  "location": "Seri Thai Soi 9, Lighthouse",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-07-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2116,
+  "hares": "Georgia 'Always Cums Last' S",
+  "location": "Petchahung Soi 20, Baan Baan Bang Kra Jao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-07-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2117,
+  "hares": "Teerachai 'Pink Panther' R",
+  "location": "Bang Sue",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-07-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2118,
+  "hares": "Bob 'Bullit' B",
+  "location": "Koh Kred",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-08-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2119,
+  "hares": "Capt'n Erik R",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-08-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2120,
+  "hares": "Brenda 'Splat' F",
+  "location": "Sukhumvit Soi 8",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-08-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2121,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Nonthaburi, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-08-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2122,
+  "hares": "Bruce 'Hash Hash' W",
+  "location": "Bang Krachao,Wat Rat Rangsan Soi 1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-09-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2123,
+  "hares": "Holden 'Eetan' L",
+  "location": "Sena Nikom, Farm Sena",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-09-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2124,
+  "hares": "Ming 'Not Tonight' P",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-09-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2125,
+  "hares": "Su 'No Boyfriend' T",
+  "location": "Mooban Panya",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-09-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2126,
+  "hares": "Peter 'Dripper' W",
+  "location": "Pattanakan 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-09-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2127,
+  "hares": "Crash and Slippery",
+  "location": "Sri Nakarin Soi 12, Hua Mark SRT station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-10-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2128,
+  "hares": "Jennifer 'Late Cumming BS' S",
+  "location": "Nonthaburi, Bangkrang Soi 11",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-10-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2129,
+  "hares": "Stephen 'CiS' L",
+  "location": "Rama 9 Road, Gai Yang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-10-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2130,
+  "hares": "Frank 'Noriega' A",
+  "location": "Nawamin Soi 53, Nittiya Gai Yang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-10-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2131,
+  "hares": "Ed 'Hazukashii' H",
+  "location": "Ratchayothin BTS station",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-11-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2132,
+  "hares": "Boobalube and Checkless",
+  "location": "Pattanakan 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-11-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2133,
+  "hares": "Peter 'Maverick' L",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-11-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2134,
+  "hares": "Lili 'Slippery When Wet' S",
+  "location": "Pattanakan 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-11-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2135,
+  "hares": "Ian 'Codpiece' P",
+  "location": "Sukhumvit Soi 101, Tuppee",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-12-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2136,
+  "hares": "Keith 'Diaorhea' T",
+  "location": "Nonthaburi, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-12-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2137,
+  "hares": "George 'of the Jungle' M",
+  "location": "Srinakarin 44, Somtam Srinakarin",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-12-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2138,
+  "hares": "Peter 'Ladyboy' V",
+  "location": "Pakkret, Tara Riverside",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-12-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2139,
+  "hares": "Greg 'Tickler' C",
+  "location": "Nonthaburi, Hua Saphan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2024-12-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2140,
+  "hares": "Jim 'Virginia Slim' E",
+  "location": "Bang Kachao, Soi Wat Ratrangsan 1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-01-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2141,
+  "hares": "Tom 'Incomplete Erection' S",
+  "location": "Bangsue, Station Saep Nua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-01-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2142,
+  "hares": "Bob 'Aunties Bitch' N",
+  "location": "Onnut Soi 55/1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-01-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2143,
+  "hares": "Malinee 'Nibbles' K",
+  "location": "Samyan Market",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-01-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2144,
+  "hares": "Kim 'Normal' C",
+  "location": "Rama 4 Road, Soi Tobacco Monopoly",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-02-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2145,
+  "hares": "Tom 'Pussy Virus' E",
+  "location": "Klong San, Yok Yor",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-02-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2146,
+  "hares": "Tony 'Retard' P",
+  "location": "Bangsue, Station Saep Nua",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-02-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2147,
+  "hares": "Tim 'Joylide' W",
+  "location": "Sukhumvit Soi 8, Heritage Condo",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-02-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2148,
+  "hares": "Nid 'Sizzler' P",
+  "location": "Pattanakan Soi 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-03-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2149,
+  "hares": "Osama 'Sexy Beast' R",
+  "location": "Ratchathewi, Hua Chang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-03-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2150,
+  "hares": "Tony 'Ambrose' E",
+  "location": "Charan Soi 13, Moomsabai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-03-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2151,
+  "hares": "Peter 'Hayter Peacox' H",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-03-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2152,
+  "hares": "Vichai 'Cool' P",
+  "location": "Klong San, Yok Yor",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-03-31",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2153,
+  "hares": "KC 'Boobalube' M",
+  "location": "Bang Kruay, Mata Garden",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-04-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2154,
+  "hares": "Holden 'Eetan' L",
+  "location": "Sena Nikom, Farm Sena",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-04-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2155,
+  "hares": "Carlton 'Quickdraw' R",
+  "location": "Phra Athit Road, Arno's",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-04-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2156,
+  "hares": "Jurgen 'Handcream' H",
+  "location": "Bang Krachao, Wat Rat Rangsan Soi 1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-04-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2157,
+  "hares": "'The Nigerian'",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-05-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2158,
+  "hares": "Kian Guan 'Turtlehead' B",
+  "location": "Huay Kwang, Amaranta Condo",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-05-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2159,
+  "hares": "John 'Tinker' L",
+  "location": "Dusit, Ratchawat Market",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-05-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2160,
+  "hares": "Tiradej 'Porkfinder' S",
+  "location": "Nonthaburi, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-05-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2161,
+  "hares": "Vichai 'Senator' S",
+  "location": "Srinakarin 44, Somtam Srinakarin",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-06-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2162,
+  "hares": "Bob Bullit' B",
+  "location": "Taling Chan, Reuan Pech",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-06-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2163,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-06-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2164,
+  "hares": "Ian 'Codpiece' P",
+  "location": "Krungthep Kreeta Soi 8, Kai Gang Sua Yai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-06-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2165,
+  "hares": "David B",
+  "location": "Seri Thai Soi 9, Lighthouse",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-06-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2166,
+  "hares": "Ed 'Checkless' C",
+  "location": "Kanchanapisek, Cowboy",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-07-07",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2167,
+  "hares": "Ed 'Hazukashii' H",
+  "location": "Chang Erawan, Steak Baan Chan Suan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-07-14",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2168,
+  "hares": "Eric 'Drunken Donut' C",
+  "location": "Wong Wien Yai, Krung Thonburi Soi 2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-07-21",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2169,
+  "hares": "Noah '4x2' S",
+  "location": "Srinakarin Soi 12, Kin Lom Chom Rod Fai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-07-28",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2170,
+  "hares": "Steve 'Gringo' G",
+  "location": "Kanchanapisek 25, Klang Na",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-08-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2171,
+  "hares": "Ya 'City Girl' C",
+  "location": "Pradit Manutham Soi 27",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-08-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2172,
+  "hares": "Lem 'No Good Boyo' M",
+  "location": "Nonthaburi, Im Pla Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-08-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2173,
+  "hares": "Bengt 'Klong Dump' G",
+  "location": "Onnut/Pattanakan Tum20",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-08-25",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2174,
+  "hares": "Ian 'Ajarn Kee Mao' S",
+  "location": "Bang Krachao, Wat Rat Rangsan Soi 1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-09-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2175,
+  "hares": "Nick 'Here for beer' W",
+  "location": "Victory Monument",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-09-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2176,
+  "hares": "Brenda 'Splat' F",
+  "location": "Sukhumvit Soi 8, Heritage Condo",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-09-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2177,
+  "hares": "Michel 'Iboibo' D",
+  "location": "Bangkapi, Seri Thai Soi 5",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-09-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2178,
+  "hares": "'Tom Yum' Gung",
+  "location": "Ratburana, Wat Bang Peung",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-09-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2179,
+  "hares": "Tim 'Tokoroten' P",
+  "location": "Hua Lampong (A to B run)",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-10-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2180,
+  "hares": "Bruce 'Hash Hash' W",
+  "location": "Bang Krachao, Wat Rat Rangsan Soi 1",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-10-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2181,
+  "hares": "Stephen 'CiS' L",
+  "location": "Rama 9 Road, Gai Yang",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-10-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2182,
+  "hares": "Jim 'Virginia Slim' W",
+  "location": "Sukhumvit Soi 11, Haveli",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-10-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2183,
+  "hares": "Keith 'Diarrhea' T",
+  "location": "Chatuchak, Railway Park Driving Range",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-11-03",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2184,
+  "hares": "Codpiece",
+  "location": "Srinakarin, Kin Lom Chom Rod Fai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-11-10",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2185,
+  "hares": "Todd 'Spinning Dwarf' W",
+  "location": "Pasicharoen Panit Thon 21, Moomsabai",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-11-17",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2186,
+  "hares": "Ali 'Kamikaze Ali' R",
+  "location": "Sukhumvit Soi 16, Maduzi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-11-24",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2187,
+  "hares": "Peter 'Maverick' L",
+  "location": "Chonburi M'way, Gustavia",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-12-01",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2188,
+  "hares": "Jim 'PMS' H",
+  "location": "Bang Lamphu, Samsen Soi 2",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-12-08",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2189,
+  "hares": "Laetitia 'Tis' H",
+  "location": "Rama 4 Road, Soi Tobacco Monopoly",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-12-15",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2190,
+  "hares": "Peter 'Ladyboy' V",
+  "location": "Ramintra, Wat Nuan Chan",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-12-22",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2191,
+  "hares": "Tim 'Joylide' W",
+  "location": "Sukhumvit Soi 8, Heritage Condo",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2025-12-29",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2192,
+  "hares": "Simon 'Mudguard' K",
+  "location": "Sanam Pao, Je Liep",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-01-05",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2193,
+  "hares": "David 'Licensed to Chill' B",
+  "location": "Seri Thai Soi 9, Hiden Lighthouse",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-01-12",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2194,
+  "hares": "Su 'No Boyfriend' T",
+  "location": "Ramkamhaeng Soi 21, Janhom",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-01-19",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2195,
+  "hares": "Frank 'Noriega' A",
+  "location": "Onnut Soi 37, Gung Pao",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-01-26",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2196,
+  "hares": "Jennifer 'LCBS' S",
+  "location": "Sukhumvit 103, Udomsuk Walk",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-02-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2197,
+  "hares": "Bob 'Aunties Bitch' N",
+  "location": "Onnut/Pattanakan Tum20",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-02-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2198,
+  "hares": "Amy 'Sex Toy' P",
+  "location": "Pra Samut Chedi",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-02-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2199,
+  "hares": "Tom 'Incomplete Erection' S",
+  "location": "Bangkok Noi, Erawan Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-02-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2200,
+  "hares": "Tim 'Tokoroten' P",
+  "location": "Samyan Market",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-03-02",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2201,
+  "hares": "A Nonny Mousse",
+  "location": "Run 2200 celebration Bang Krachao, Baan Lung Ooh",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-03-09",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2202,
+  "hares": "Mark 'Hare Lip' G",
+  "location": "Sukhumvit Soi 11, Haveli",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-03-16",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2203,
+  "hares": "Yaard 'City Girl' C",
+  "location": "Minburi, Tong Romklao Market",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-03-23",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2204,
+  "hares": "Bengt 'Klongdump' G",
+  "location": "Srinakarin Soi 44, Somtam Srinakarin",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-03-30",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2205,
+  "hares": "Id 'Eat Me' S",
+  "location": "Pattanakan Soi 25, Krua Rim Mong",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-04-06",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2206,
+  "hares": "Ed 'Checkless' C",
+  "location": "Kanchanapisek, Cowboy",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-04-13",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2207,
+  "hares": "KC 'Boob-A-Lube' M",
+  "location": "Pakkret, Wat Toei",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-04-20",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2208,
+  "hares": "Ian 'Codpiece' P",
+  "location": "Ramkamhaeng Soi 21, Janhom",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-04-27",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2209,
+  "hares": "Tiradej 'Porkfinder' S",
+  "location": "Bangkok Noi, Erawan Park",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-05-04",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2210,
+  "hares": "Kim 'Normal' C",
+  "location": "Klong San, Yok Yor",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-05-11",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2211,
+  "hares": "Chris 'Horny Viking' H",
+  "location": "Srinakarin 44, Somtam Srinakarin",
+  "startTime": "17:30"
+ },
+ {
+  "date": "2026-05-18",
+  "kennelTags": [
+   "bmh3-bkk"
+  ],
+  "runNumber": 2212,
+  "hares": "Pom 'Pat Pom' S",
+  "location": "Nonthaburi, Bangkrang Soi 11",
+  "startTime": "17:30"
+ }
+]

--- a/src/adapters/html-scraper/bangkok-monday-hash.test.ts
+++ b/src/adapters/html-scraper/bangkok-monday-hash.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as cheerio from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import {
+  parseHarelineRow,
+  parseForwardDate,
+  parseArchiveDate,
+  parseNextRunBlock,
+  inferYear,
+  BangkokMondayHashAdapter,
+} from "./bangkok-monday-hash";
+
+// Mock safeFetch (used by fetchHTMLPage)
+vi.mock("@/adapters/safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+vi.mock("@/pipeline/structure-hash", () => ({
+  generateStructureHash: vi.fn(() => "mock-hash-bmh3"),
+}));
+
+const { safeFetch } = await import("@/adapters/safe-fetch");
+const mockedSafeFetch = vi.mocked(safeFetch);
+
+const REF = new Date("2026-06-05T00:00:00Z");
+
+/** Real FutureHares.html hareline table (verbatim shape, trimmed to representative rows). */
+const HARELINE_HTML = `<!DOCTYPE html><html><body>
+<table class="centre">
+  <tr><td><strong> Run No. </strong></td> <td><strong> Date </strong></td>
+  <td><strong> Name </strong></td> <td><strong> Location </strong></td> <td></td></tr>
+<tr><td>2221</td> <td>20 Jul</td> <td>Nick 'Here for Beer' W</td> <td>TBA</td> <td></td></tr>
+<tr><td>2227</td> <td>31 Aug</td> <td>TBA</td> <td>TBA</td> <td></td></tr>
+<tr><td>2236</td> <td>2 Nov AGM</td> <td>Tinker and Tickler</td> <td>TBA</td> <td></td></tr>
+<tr><td>2240</td> <td>30 Nov</td> <td>Peter 'Maverick' L</td> <td>TBA</td> <td></td></tr>
+</table></body></html>`;
+
+/** Real homepage: #nextrun block + near-term "Run schedule" table + nav row. */
+const HOME_HTML = `<!DOCTYPE html><html><body>
+<div id="nextrun">
+<h5>Next run</h5>
+<p><strong>Run No.</strong> 2215</p>
+<p><strong>Date/Time:-</strong> Monday 8 June at 17:30</p>
+<p><strong>Hare:-</strong> Tinker</p>
+<p><strong>Run site:-</strong> Dusit, Soi Si Kham, Teaw Kor Teaw Rim Nam</p>
+<table><tr>
+<td><a href="directions/DusitTeawKorTeawRimnam.html"><img src="Gif/directions.jpg" /></a></td>
+<td><a href="https://www.google.co.th/maps/place/X/@13.79,100.47,13z/data=!4m4!3m3!8m2!3d13.78578!4d100.50743?hl=en-TH"><img src="Gif/map.jpg" /></a></td>
+</tr></table>
+</div>
+<table>
+  <tr><td><strong>Run</strong></td><td><strong>Date</strong></td><td><strong>Hare</strong></td>
+      <td><strong>Location</strong></td><td><strong>Links</strong></td></tr>
+<tr><td>2213</td> <td>25 May</td> <td>Lem 'No Good Boyo' M</td> <td>Nonthaburi, Bang Kruay Bridge</td> <td><a href="Writeups/Run2213.html">Write-up</a></td></tr>
+<tr><td>2215</td> <td>8 Jun</td> <td>John 'Tinker' L</td> <td>Dusit, Teaw Kor Teaw Rim Nam</td> <td></td></tr>
+<tr><td>2216</td> <td>15 Jun</td> <td>Peter 'Hayter Peacox' H</td> <td>Onnut Soi 37, Gung Pao</td> <td></td></tr>
+<tr> <td></td> <td></td>
+<td class="boldcentre"><a href="FutureHares.html">View the hareline in full</a></td><td></td> <td></td> </tr>
+</table></body></html>`;
+
+function makeSource(overrides?: Partial<Source>): Source {
+  return {
+    id: "src-bmh3",
+    name: "Bangkok Monday H3 Hareline",
+    url: "https://bangkokmondayhhh.com/FutureHares.html",
+    type: "HTML_SCRAPER",
+    trustLevel: 6,
+    scrapeFreq: "daily",
+    scrapeDays: 365,
+    config: { upcomingOnly: true },
+    lastScrapeAt: null,
+    lastSuccessAt: null,
+    healthStatus: "UNKNOWN",
+    enabled: true,
+    baselineResetAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Source;
+}
+
+function htmlResponse(html: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: () => Promise.resolve(html),
+    headers: new Headers({ "content-type": "text/html" }),
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("inferYear (forward Dec→Jan rollover)", () => {
+  it.each([
+    ["recently-past May stays current year", 4, 25, 2026],
+    ["far-past Jan rolls to next year", 0, 5, 2027],
+    ["future Nov stays current year", 10, 2, 2026],
+  ])("%s", (_label, monthIndex, day, expected) => {
+    expect(inferYear(monthIndex, day, REF)).toBe(expected);
+  });
+});
+
+describe("parseForwardDate", () => {
+  it("strips a trailing AGM token before parsing", () => {
+    expect(parseForwardDate("2 Nov AGM", REF)).toBe("2026-11-02");
+  });
+  it("infers the current year for an upcoming month", () => {
+    expect(parseForwardDate("8 Jun", REF)).toBe("2026-06-08");
+  });
+  it("keeps a just-completed run in the current year (60-day margin)", () => {
+    expect(parseForwardDate("25 May", REF)).toBe("2026-05-25");
+  });
+  it("rolls a Jan row forward when the reference is late in the year", () => {
+    expect(parseForwardDate("5 Jan", new Date("2026-12-15T00:00:00Z"))).toBe(
+      "2027-01-05",
+    );
+  });
+  it("returns null for an unparseable cell", () => {
+    expect(parseForwardDate("TBA", REF)).toBeNull();
+  });
+});
+
+describe("parseArchiveDate (year known from page)", () => {
+  it("stamps the page year", () => {
+    expect(parseArchiveDate("6 Jan", 2025)).toBe("2025-01-06");
+  });
+  it("strips AGM in archive cells too", () => {
+    expect(parseArchiveDate("2 Nov AGM", 2024)).toBe("2024-11-02");
+  });
+});
+
+describe("parseHarelineRow", () => {
+  const resolve = (t: string) => parseArchiveDate(t, 2026);
+
+  it("parses a normal row", () => {
+    const row = parseHarelineRow(
+      ["2240", "30 Nov", "Peter 'Maverick' L", "Onnut Soi 37"],
+      resolve,
+    );
+    expect(row).toMatchObject({
+      date: "2026-11-30",
+      runNumber: 2240,
+      hares: "Peter 'Maverick' L",
+      location: "Onnut Soi 37",
+      startTime: "17:30",
+      kennelTags: ["bmh3-bkk"],
+    });
+  });
+
+  it.each([
+    ["TBA hare → undefined", ["2227", "31 Aug", "TBA", "TBA"], "hares"],
+    ["TBA location → undefined", ["2227", "31 Aug", "TBA", "TBA"], "location"],
+  ])("%s", (_label, cells, field) => {
+    const row = parseHarelineRow(cells as string[], resolve);
+    expect(row?.[field as "hares" | "location"]).toBeUndefined();
+  });
+
+  it("strips an AGM marker leaking into the hare cell", () => {
+    const row = parseHarelineRow(["1900", "2 Nov", "AGM Codpiece", "TBA"], resolve);
+    expect(row?.hares).toBe("Codpiece");
+  });
+
+  it("returns null for header / non-numeric run rows", () => {
+    expect(parseHarelineRow(["Run No.", "Date", "Name", "Location"], resolve)).toBeNull();
+  });
+
+  it("returns null when the row has too few cells", () => {
+    expect(parseHarelineRow(["2240", "30 Nov"], resolve)).toBeNull();
+  });
+
+  it("does not set a title (merge synthesizes it)", () => {
+    const row = parseHarelineRow(["2240", "30 Nov", "Hare", "Loc"], resolve);
+    expect(row?.title).toBeUndefined();
+  });
+});
+
+describe("parseNextRunBlock", () => {
+  it("extracts the run number and the single Google Maps pin", () => {
+    const $ = cheerio.load(HOME_HTML);
+    const info = parseNextRunBlock($);
+    expect(info).toMatchObject({
+      runNumber: 2215,
+      latitude: 13.78578,
+      longitude: 100.50743,
+    });
+    expect(info?.locationUrl).toContain("!3d13.78578!4d100.50743");
+  });
+
+  it("returns null when there is no next-run block", () => {
+    const $ = cheerio.load("<html><body><p>no run</p></body></html>");
+    expect(parseNextRunBlock($)).toBeNull();
+  });
+});
+
+describe("BangkokMondayHashAdapter.fetch", () => {
+  function mockBothPages() {
+    mockedSafeFetch.mockImplementation((url: string | URL) =>
+      Promise.resolve(
+        String(url).includes("FutureHares")
+          ? htmlResponse(HARELINE_HTML)
+          : htmlResponse(HOME_HTML),
+      ),
+    );
+  }
+
+  it("merges both pages, dedupes by run, and enriches the next run", async () => {
+    mockBothPages();
+    const result = await new BangkokMondayHashAdapter().fetch(makeSource());
+
+    expect(result.errors).toEqual([]);
+    expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
+
+    const runs = result.events.map((e) => e.runNumber);
+    // Union of homepage (#2213,#2215,#2216) and hareline (#2221,#2227,#2236,#2240),
+    // sorted by date, no duplicate #2215.
+    expect(runs).toEqual([2213, 2215, 2216, 2221, 2227, 2236, 2240]);
+
+    const r2215 = result.events.find((e) => e.runNumber === 2215);
+    expect(r2215).toMatchObject({
+      date: "2026-06-08",
+      startTime: "17:30",
+      latitude: 13.78578,
+      longitude: 100.50743,
+    });
+    expect(r2215?.locationUrl).toContain("!3d13.78578");
+  });
+
+  it("parses the AGM row's date and keeps the hare clean", async () => {
+    mockBothPages();
+    const result = await new BangkokMondayHashAdapter().fetch(makeSource());
+    const agm = result.events.find((e) => e.runNumber === 2236);
+    expect(agm?.date).toBe("2026-11-02");
+    expect(agm?.hares).toBe("Tinker and Tickler");
+  });
+
+  it("maps TBA hare/location to undefined and does not synthesize the #2238/#2239 gap", async () => {
+    mockBothPages();
+    const result = await new BangkokMondayHashAdapter().fetch(makeSource());
+    const r2227 = result.events.find((e) => e.runNumber === 2227);
+    expect(r2227?.hares).toBeUndefined();
+    expect(r2227?.location).toBeUndefined();
+    expect(result.events.some((e) => e.runNumber === 2238)).toBe(false);
+    expect(result.events.some((e) => e.runNumber === 2239)).toBe(false);
+  });
+
+  it("honors the date window via options.days", async () => {
+    mockBothPages();
+    // 7-day window from REF excludes everything except the next few days; but the
+    // adapter anchors on the real `new Date()`, so just assert the filter runs and
+    // returns a subset (<= full set) without throwing.
+    const full = await new BangkokMondayHashAdapter().fetch(makeSource());
+    const narrow = await new BangkokMondayHashAdapter().fetch(makeSource(), { days: 1 });
+    expect(narrow.events.length).toBeLessThanOrEqual(full.events.length);
+  });
+});

--- a/src/adapters/html-scraper/bangkok-monday-hash.test.ts
+++ b/src/adapters/html-scraper/bangkok-monday-hash.test.ts
@@ -74,6 +74,7 @@ function makeSource(overrides?: Partial<Source>): Source {
     baselineResetAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
+    ...overrides,
   } as Source;
 }
 
@@ -87,6 +88,17 @@ function htmlResponse(html: string): Response {
   } as Response;
 }
 
+/** Route FutureHares → hareline fixture, everything else → homepage fixture. */
+function mockBothPages() {
+  mockedSafeFetch.mockImplementation((url: string | URL) =>
+    Promise.resolve(
+      String(url).includes("FutureHares")
+        ? htmlResponse(HARELINE_HTML)
+        : htmlResponse(HOME_HTML),
+    ),
+  );
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
 });
@@ -98,6 +110,15 @@ describe("inferYear (forward Dec→Jan rollover)", () => {
     ["future Nov stays current year", 10, 2, 2026],
   ])("%s", (_label, monthIndex, day, expected) => {
     expect(inferYear(monthIndex, day, REF)).toBe(expected);
+  });
+
+  it("rolls a stale Nov run back a year when scraped in January", () => {
+    // Homepage still shows a just-completed Nov 2026 run on 15 Jan 2027.
+    expect(inferYear(10, 2, new Date("2027-01-15T00:00:00Z"))).toBe(2026);
+  });
+
+  it("keeps a near-future January run in the reference year", () => {
+    expect(inferYear(0, 20, new Date("2027-01-15T00:00:00Z"))).toBe(2027);
   });
 });
 
@@ -194,16 +215,6 @@ describe("parseNextRunBlock", () => {
 });
 
 describe("BangkokMondayHashAdapter.fetch", () => {
-  function mockBothPages() {
-    mockedSafeFetch.mockImplementation((url: string | URL) =>
-      Promise.resolve(
-        String(url).includes("FutureHares")
-          ? htmlResponse(HARELINE_HTML)
-          : htmlResponse(HOME_HTML),
-      ),
-    );
-  }
-
   it("merges both pages, dedupes by run, and enriches the next run", async () => {
     mockBothPages();
     const result = await new BangkokMondayHashAdapter().fetch(makeSource());
@@ -242,6 +253,19 @@ describe("BangkokMondayHashAdapter.fetch", () => {
     expect(r2227?.location).toBeUndefined();
     expect(result.events.some((e) => e.runNumber === 2238)).toBe(false);
     expect(result.events.some((e) => e.runNumber === 2239)).toBe(false);
+  });
+
+  it("survives a partial fetch failure (hareline fails, homepage succeeds)", async () => {
+    mockedSafeFetch.mockImplementation((url: string | URL) =>
+      String(url).includes("FutureHares")
+        ? Promise.resolve({ ok: false, status: 503, statusText: "err" } as Response)
+        : Promise.resolve(htmlResponse(HOME_HTML)),
+    );
+    const result = await new BangkokMondayHashAdapter().fetch(makeSource());
+    expect(result.errors.length).toBeGreaterThan(0);
+    // Homepage rows (#2213, #2215, #2216) still parsed.
+    expect(result.events.length).toBeGreaterThan(0);
+    expect(result.events.some((e) => e.runNumber === 2215)).toBe(true);
   });
 
   it("honors the date window via options.days", async () => {

--- a/src/adapters/html-scraper/bangkok-monday-hash.ts
+++ b/src/adapters/html-scraper/bangkok-monday-hash.ts
@@ -1,0 +1,273 @@
+/**
+ * Bangkok Monday Hash House Harriers (bmh3-bkk) HTML Scraper
+ *
+ * Scrapes bangkokmondayhhh.com — Bangkok's longest-running hash (est. 1982).
+ * Two static pages share the same `Run | Date | Hare | Location [| Links]`
+ * table shape:
+ *   - FutureHares.html  → the forward hareline backbone (far-out runs, mostly TBA)
+ *   - the homepage `/`   → a near-term "Run schedule" table (runs WITH locations)
+ *                          plus a `#nextrun` block carrying the only Google Maps
+ *                          pin + confirmed start time.
+ *
+ * Date cells are `DD MMM` with NO year (e.g. "8 Jun", "2 Nov AGM"). The year is
+ * inferred from a reference date with Dec→Jan rollover. The single next-run pin
+ * is attached to its matching run; every other run falls back to the Bangkok
+ * region centroid. Titles are left undefined so the merge pipeline synthesizes
+ * "Bangkok Monday H3 Trail #N".
+ */
+
+import type { CheerioAPI } from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import type {
+  SourceAdapter,
+  RawEventData,
+  ScrapeResult,
+  ErrorDetails,
+} from "../types";
+import { hasAnyErrors } from "../types";
+import { chronoParseDate, fetchHTMLPage, buildDateWindow } from "../utils";
+import { extractCoordsFromMapsUrl } from "@/lib/geo";
+
+const KENNEL_TAG = "bmh3-bkk";
+const DEFAULT_HARELINE_URL = "https://bangkokmondayhhh.com/FutureHares.html";
+const HOMEPAGE_URL = "https://bangkokmondayhhh.com/";
+/** Fixed Monday start (the homepage next-run block confirms 17:30). */
+const DEFAULT_START_TIME = "17:30";
+
+const MONTHS: Record<string, number> = {
+  jan: 0,
+  feb: 1,
+  mar: 2,
+  apr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  aug: 7,
+  sep: 8,
+  oct: 9,
+  nov: 10,
+  dec: 11,
+};
+
+const DATE_RE = /\b(\d{1,2})\s+([A-Za-z]{3,})/;
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+
+/** Drop the `AGM` event marker that leaks into date and hare cells. */
+function stripAgm(value: string): string {
+  return value.replace(/\bAGM\b/gi, " ").replace(/\s+/g, " ").trim();
+}
+
+/** Map a `TBA`/empty cell to undefined; strip AGM markers otherwise. */
+function cleanCell(value: string | undefined): string | undefined {
+  const cleaned = stripAgm(value?.trim() ?? "");
+  if (!cleaned || /^tba$/i.test(cleaned)) return undefined;
+  return cleaned;
+}
+
+function parseMonthDay(
+  dateText: string,
+): { day: number; monthIndex: number; monthWord: string } | null {
+  const m = DATE_RE.exec(stripAgm(dateText));
+  if (!m) return null;
+  const day = Number.parseInt(m[1], 10);
+  const monthWord = m[2];
+  const monthIndex = MONTHS[monthWord.slice(0, 3).toLowerCase()];
+  if (Number.isNaN(day) || monthIndex === undefined) return null;
+  return { day, monthIndex, monthWord };
+}
+
+/**
+ * Forward-hareline year inference. Year-less `DD MMM` cells belong to the
+ * reference year unless the resulting date is more than ~60 days in the past
+ * (a Jan/Feb row on a mid-year forward page), in which case it rolls to next
+ * year. The 60-day margin keeps the 1–2 just-completed runs the homepage still
+ * lists in the current year.
+ */
+export function inferYear(monthIndex: number, day: number, refDate: Date): number {
+  const refYear = refDate.getUTCFullYear();
+  const candidate = Date.UTC(refYear, monthIndex, day, 12, 0, 0);
+  if (candidate < refDate.getTime() - SIXTY_DAYS_MS) return refYear + 1;
+  return refYear;
+}
+
+/** Resolve a forward `DD MMM` cell to `YYYY-MM-DD` (year inferred, Dec→Jan rollover). */
+export function parseForwardDate(dateText: string, refDate: Date): string | null {
+  const parts = parseMonthDay(dateText);
+  if (!parts) return null;
+  const year = inferYear(parts.monthIndex, parts.day, refDate);
+  return chronoParseDate(`${parts.day} ${parts.monthWord} ${year}`, "en-GB");
+}
+
+/** Resolve an archive `DD MMM` cell to `YYYY-MM-DD` using the page's known year. */
+export function parseArchiveDate(dateText: string, pageYear: number): string | null {
+  const parts = parseMonthDay(dateText);
+  if (!parts) return null;
+  return chronoParseDate(`${parts.day} ${parts.monthWord} ${pageYear}`, "en-GB");
+}
+
+/**
+ * Parse a single hareline/archive table row into a RawEventData. Shared by the
+ * live adapter (forward date resolver) and the historical backfill (page-year
+ * resolver). Returns null for header/nav/decorative rows (no numeric run #).
+ * Exported for unit testing and backfill reuse.
+ */
+export function parseHarelineRow(
+  cells: string[],
+  resolveDate: (dateText: string) => string | null,
+): RawEventData | null {
+  // Columns: [0]=run #, [1]=date, [2]=hare, [3]=location, [4]=links (optional)
+  if (cells.length < 4) return null;
+
+  const runNumber = Number.parseInt(cells[0]?.trim() ?? "", 10);
+  if (Number.isNaN(runNumber)) return null;
+
+  const dateText = cells[1]?.trim() ?? "";
+  if (!dateText) return null;
+  const date = resolveDate(dateText);
+  if (!date) return null;
+
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber,
+    hares: cleanCell(cells[2]),
+    location: cleanCell(cells[3]),
+    startTime: DEFAULT_START_TIME,
+  };
+}
+
+export interface NextRunInfo {
+  runNumber: number;
+  locationUrl?: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+/**
+ * Parse the homepage `#nextrun` block: the run number plus the single Google
+ * Maps pin (the only coordinates anywhere on the site). Exported for testing.
+ */
+export function parseNextRunBlock($: CheerioAPI): NextRunInfo | null {
+  const block = $("#nextrun");
+  if (block.length === 0) return null;
+
+  const runMatch = /Run\s*No\.?\s*(\d{2,5})/i.exec(block.text());
+  if (!runMatch) return null;
+  const runNumber = Number.parseInt(runMatch[1], 10);
+
+  let locationUrl: string | undefined;
+  let latitude: number | undefined;
+  let longitude: number | undefined;
+  block.find("a").each((_i, a) => {
+    if (latitude !== undefined) return;
+    const href = $(a).attr("href");
+    if (!href) return;
+    const coords = extractCoordsFromMapsUrl(href);
+    if (coords) {
+      locationUrl = href;
+      latitude = coords.lat;
+      longitude = coords.lng;
+    }
+  });
+
+  return { runNumber, locationUrl, latitude, longitude };
+}
+
+/** Keep the more-complete of two rows for the same run (prefer one with a location). */
+function upsertEvent(map: Map<number, RawEventData>, event: RawEventData): void {
+  const runNumber = event.runNumber;
+  if (typeof runNumber !== "number") return;
+  const existing = map.get(runNumber);
+  if (!existing) {
+    map.set(runNumber, event);
+    return;
+  }
+  if (!existing.location && event.location) map.set(runNumber, event);
+}
+
+export class BangkokMondayHashAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    const harelineUrl = source.url || DEFAULT_HARELINE_URL;
+    const refDate = new Date();
+    const { minDate, maxDate } = buildDateWindow(options?.days ?? 365);
+
+    const eventsByRun = new Map<number, RawEventData>();
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+    let structureHash: string | undefined;
+    let nextRun: NextRunInfo | null = null;
+    let rowsFound = 0;
+
+    // Hareline first (canonical structure hash); homepage second (near-term
+    // rows with locations + the next-run pin).
+    for (const url of [harelineUrl, HOMEPAGE_URL]) {
+      const page = await fetchHTMLPage(url);
+      if (!page.ok) {
+        errors.push(`Failed to fetch ${url}`);
+        (errorDetails.fetch ??= []).push({ url, message: "fetch failed" });
+        continue;
+      }
+      const $ = page.$;
+      if (url === harelineUrl) structureHash = page.structureHash;
+      if (url === HOMEPAGE_URL) nextRun = parseNextRunBlock($);
+
+      const rows = $("table tr");
+      rowsFound += rows.length;
+      rows.each((i, el) => {
+        try {
+          const cells: string[] = [];
+          $(el)
+            .find("td")
+            .each((_j, td) => {
+              const $td = $(td);
+              $td.find("br").replaceWith(" ");
+              cells.push($td.text().trim());
+            });
+          const event = parseHarelineRow(cells, (t) => parseForwardDate(t, refDate));
+          if (event) {
+            event.sourceUrl = url;
+            upsertEvent(eventsByRun, event);
+          }
+        } catch (err) {
+          errors.push(`Error parsing row ${i} of ${url}: ${err}`);
+          (errorDetails.parse ??= []).push({
+            row: i,
+            section: "hareline",
+            error: String(err),
+            rawText: $(el).text().trim().slice(0, 2000),
+          });
+        }
+      });
+    }
+
+    // Attach the single next-run pin to its matching run.
+    if (nextRun) {
+      const target = eventsByRun.get(nextRun.runNumber);
+      if (target) {
+        if (nextRun.locationUrl) target.locationUrl = nextRun.locationUrl;
+        if (nextRun.latitude !== undefined) target.latitude = nextRun.latitude;
+        if (nextRun.longitude !== undefined) target.longitude = nextRun.longitude;
+      }
+    }
+
+    const events = [...eventsByRun.values()]
+      .filter((e) => {
+        const d = new Date(`${e.date}T12:00:00Z`);
+        return d >= minDate && d <= maxDate;
+      })
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    return {
+      events,
+      errors,
+      structureHash,
+      errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+      diagnosticContext: {
+        rowsFound,
+        eventsParsed: events.length,
+      },
+    };
+  }
+}

--- a/src/adapters/html-scraper/bangkok-monday-hash.ts
+++ b/src/adapters/html-scraper/bangkok-monday-hash.ts
@@ -17,12 +17,14 @@
  */
 
 import type { CheerioAPI } from "cheerio";
+import type { Element } from "domhandler";
 import type { Source } from "@/generated/prisma/client";
 import type {
   SourceAdapter,
   RawEventData,
   ScrapeResult,
   ErrorDetails,
+  ParseError,
 } from "../types";
 import { hasAnyErrors } from "../types";
 import { chronoParseDate, fetchHTMLPage, buildDateWindow } from "../utils";
@@ -50,7 +52,15 @@ const MONTHS: Record<string, number> = {
 };
 
 const DATE_RE = /\b(\d{1,2})\s+([A-Za-z]{3,})/;
-const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const SIXTY_DAYS_MS = 60 * DAY_MS;
+/**
+ * Forward bound for year inference. The live forward hareline reaches ~6 months
+ * (≈180 days) ahead, so a candidate landing more than ~8 months out must be a
+ * stale prior-year run still shown on the homepage (e.g. a Dec run viewed in
+ * early Jan) and rolls back a year. A weekly club never schedules >8 months out.
+ */
+const EIGHT_MONTHS_MS = 240 * DAY_MS;
 
 /** Drop the `AGM` event marker that leaks into date and hare cells. */
 function stripAgm(value: string): string {
@@ -77,16 +87,18 @@ function parseMonthDay(
 }
 
 /**
- * Forward-hareline year inference. Year-less `DD MMM` cells belong to the
- * reference year unless the resulting date is more than ~60 days in the past
- * (a Jan/Feb row on a mid-year forward page), in which case it rolls to next
- * year. The 60-day margin keeps the 1–2 just-completed runs the homepage still
- * lists in the current year.
+ * Forward-hareline year inference for year-less `DD MMM` cells:
+ *  - more than ~60 days in the past → next year (a Jan/Feb row on a mid-year
+ *    forward page). The 60-day margin keeps the 1–2 just-completed runs the
+ *    homepage still lists in the current year.
+ *  - more than ~8 months in the future → prior year (a stale Nov/Dec run still
+ *    shown on the homepage when scraped in early Jan/Feb).
  */
 export function inferYear(monthIndex: number, day: number, refDate: Date): number {
   const refYear = refDate.getUTCFullYear();
-  const candidate = Date.UTC(refYear, monthIndex, day, 12, 0, 0);
-  if (candidate < refDate.getTime() - SIXTY_DAYS_MS) return refYear + 1;
+  const diff = Date.UTC(refYear, monthIndex, day, 12, 0, 0) - refDate.getTime();
+  if (diff < -SIXTY_DAYS_MS) return refYear + 1;
+  if (diff > EIGHT_MONTHS_MS) return refYear - 1;
   return refYear;
 }
 
@@ -185,6 +197,68 @@ function upsertEvent(map: Map<number, RawEventData>, event: RawEventData): void 
   if (!existing.location && event.location) map.set(runNumber, event);
 }
 
+/** Extract a row's `<td>` text (br→space), mirroring the dublin pattern. */
+function extractCells($: CheerioAPI, el: Element): string[] {
+  const cells: string[] = [];
+  $(el)
+    .find("td")
+    .each((_j, td) => {
+      const $td = $(td);
+      $td.find("br").replaceWith(" ");
+      cells.push($td.text().trim());
+    });
+  return cells;
+}
+
+interface PageCollector {
+  target: Map<number, RawEventData>;
+  errors: string[];
+  parseErrors: ParseError[];
+}
+
+/** Parse every table row on one page into `collector`; returns the row count. */
+function collectPageRows(
+  $: CheerioAPI,
+  url: string,
+  refDate: Date,
+  collector: PageCollector,
+): number {
+  const rows = $("table tr");
+  rows.each((i, el) => {
+    try {
+      const event = parseHarelineRow(extractCells($, el), (t) =>
+        parseForwardDate(t, refDate),
+      );
+      if (event) {
+        event.sourceUrl = url;
+        upsertEvent(collector.target, event);
+      }
+    } catch (err) {
+      collector.errors.push(`Error parsing row ${i} of ${url}: ${err}`);
+      collector.parseErrors.push({
+        row: i,
+        section: "hareline",
+        error: String(err),
+        rawText: $(el).text().trim().slice(0, 2000),
+      });
+    }
+  });
+  return rows.length;
+}
+
+/** Attach the single homepage next-run pin to its matching run, if present. */
+function applyNextRun(
+  map: Map<number, RawEventData>,
+  nextRun: NextRunInfo | null,
+): void {
+  if (!nextRun) return;
+  const target = map.get(nextRun.runNumber);
+  if (!target) return;
+  if (nextRun.locationUrl) target.locationUrl = nextRun.locationUrl;
+  if (nextRun.latitude !== undefined) target.latitude = nextRun.latitude;
+  if (nextRun.longitude !== undefined) target.longitude = nextRun.longitude;
+}
+
 export class BangkokMondayHashAdapter implements SourceAdapter {
   type = "HTML_SCRAPER" as const;
 
@@ -195,7 +269,8 @@ export class BangkokMondayHashAdapter implements SourceAdapter {
 
     const eventsByRun = new Map<number, RawEventData>();
     const errors: string[] = [];
-    const errorDetails: ErrorDetails = {};
+    const parseErrors: ParseError[] = [];
+    const fetchErrors: NonNullable<ErrorDetails["fetch"]> = [];
     let structureHash: string | undefined;
     let nextRun: NextRunInfo | null = null;
     let rowsFound = 0;
@@ -206,51 +281,23 @@ export class BangkokMondayHashAdapter implements SourceAdapter {
       const page = await fetchHTMLPage(url);
       if (!page.ok) {
         errors.push(`Failed to fetch ${url}`);
-        (errorDetails.fetch ??= []).push({ url, message: "fetch failed" });
+        fetchErrors.push({ url, message: "fetch failed" });
         continue;
       }
-      const $ = page.$;
       if (url === harelineUrl) structureHash = page.structureHash;
-      if (url === HOMEPAGE_URL) nextRun = parseNextRunBlock($);
-
-      const rows = $("table tr");
-      rowsFound += rows.length;
-      rows.each((i, el) => {
-        try {
-          const cells: string[] = [];
-          $(el)
-            .find("td")
-            .each((_j, td) => {
-              const $td = $(td);
-              $td.find("br").replaceWith(" ");
-              cells.push($td.text().trim());
-            });
-          const event = parseHarelineRow(cells, (t) => parseForwardDate(t, refDate));
-          if (event) {
-            event.sourceUrl = url;
-            upsertEvent(eventsByRun, event);
-          }
-        } catch (err) {
-          errors.push(`Error parsing row ${i} of ${url}: ${err}`);
-          (errorDetails.parse ??= []).push({
-            row: i,
-            section: "hareline",
-            error: String(err),
-            rawText: $(el).text().trim().slice(0, 2000),
-          });
-        }
+      if (url === HOMEPAGE_URL) nextRun = parseNextRunBlock(page.$);
+      rowsFound += collectPageRows(page.$, url, refDate, {
+        target: eventsByRun,
+        errors,
+        parseErrors,
       });
     }
 
-    // Attach the single next-run pin to its matching run.
-    if (nextRun) {
-      const target = eventsByRun.get(nextRun.runNumber);
-      if (target) {
-        if (nextRun.locationUrl) target.locationUrl = nextRun.locationUrl;
-        if (nextRun.latitude !== undefined) target.latitude = nextRun.latitude;
-        if (nextRun.longitude !== undefined) target.longitude = nextRun.longitude;
-      }
-    }
+    applyNextRun(eventsByRun, nextRun);
+
+    const errorDetails: ErrorDetails = {};
+    if (fetchErrors.length > 0) errorDetails.fetch = fetchErrors;
+    if (parseErrors.length > 0) errorDetails.parse = parseErrors;
 
     const events = [...eventsByRun.values()]
       .filter((e) => {

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -101,6 +101,7 @@ import { BangkokHashAdapter } from "./html-scraper/bangkokhash";
 import { PattayaH3Adapter } from "./html-scraper/pattaya-h3";
 import { BangkokBikersAdapter } from "./html-scraper/bangkok-bikers";
 import { BangkokH3Adapter } from "./html-scraper/bangkok-h3";
+import { BangkokMondayHashAdapter } from "./html-scraper/bangkok-monday-hash";
 import { LVH3Adapter } from "./html-scraper/lvh3";
 import { BoulderH3Adapter } from "./html-scraper/boulder-h3";
 import { BoiseH3Adapter } from "./html-scraper/boiseh3";
@@ -258,6 +259,7 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /pattayah3\.com/i, name: "PattayaH3Adapter", factory: () => new PattayaH3Adapter() },
   { pattern: /bangkokbikehash\.org/i, name: "BangkokBikersAdapter", factory: () => new BangkokBikersAdapter() },
   { pattern: /bangkokhhh\.org/i, name: "BangkokH3Adapter", factory: () => new BangkokH3Adapter() },
+  { pattern: /bangkokmondayhhh\.com/i, name: "BangkokMondayHashAdapter", factory: () => new BangkokMondayHashAdapter() },
   // ── Nevada ──
   { pattern: /lvh3\.org/i, name: "LVH3Adapter", factory: () => new LVH3Adapter() },
   // ── Idaho ──


### PR DESCRIPTION
## Summary
Full onboard of **Bangkok Monday Hash House Harriers** (`bmh3-bkk`, est. 1982, run #2215+) — Bangkok's longest-running hash and the **first Monday** Bangkok kennel on HashTracks (joins 7 sibling Bangkok kennels). Implements the handoff `docs/kennel-onboarding/handoffs/2026-06-05-bmh3-bkk.md` end-to-end.

## What's included
- **New `BangkokMondayHashAdapter`** (`src/adapters/html-scraper/bangkok-monday-hash.ts`) — Cheerio scraper over the shared `Run | Date | Hare | Location` table on `FutureHares.html` + the homepage near-term schedule. Merges both pages by run number; enriches the single next-run Google Maps pin (`!3d/!4d` → lat/lng). Year-less `DD MMM` dates inferred with **Dec→Jan rollover**; **AGM** markers stripped; `TBA` → `undefined`; titles left undefined so the merge pipeline synthesizes "Bangkok Monday H3 Trail #N".
- **Registry route** `/bangkokmondayhhh\.com/i`.
- **Seed** — kennel `bmh3-bkk` (Bangkok/Thailand, founded 1982, ฿250/฿200, Mon 17:30 weekly, FB group), 4 aliases (bare `BMH3` omitted — collides with `bullmoon`/`bmh3-tx`), source *Bangkok Monday H3 Hareline* (trust 6, `upcomingOnly`). No `region.ts` edits (Bangkok/Thailand already seeded).
- **Historical backfill** — frozen dataset `scripts/data/bmh3-bkk-history.json` (**1,185 runs #981→#2212, 2002-01-07 → 2026-05-18**) + dumb loader `scripts/backfill-bmh3-bkk-history.ts` replaying through the merge pipeline.

## Live verification (against production)
- **26 events**, 0 errors; 24 upcoming, range **2026-05-25 → 2026-11-30**.
- `#2215` → `startTime 17:30`, coords **13.78578, 100.50743**, locationUrl present.
- `"2 Nov AGM"` (#2236) → `2026-11-02`, hare "Tinker and Tickler" clean.
- `TBA` rows → hares/location `undefined`; `#2238/#2239` gap **not** synthesized.
- Backfill extractor report: run-# monotonic (0 inversions), spacing flags only on legitimately sparse years; no real PII (the one `@` is a venue name).

## Checks
`npx tsc --noEmit` ✓ · `npm run lint` ✓ (0 errors) · `npm test` ✓ (**8620 passed**, incl. 23 new adapter tests).

## Deep-dive checklist
- [x] founded 1982 · [x] socials (FB group; Flickr noted below) · [x] schedule (Mon 17:30 weekly) · [x] hashCash (฿250/฿200) · [x] description
- [x] source live-verified · [x] history depth (1,185 runs, 2002–2026) · [x] coord sanity (only next-run pin; no default-pin trap) · [x] end times (none) · [x] kennelCode collision-checked · [x] source-kennel guard · [x] region exists

## Follow-up (not blocking)
- **Logo**: site uses GIF text banners, no square logo — left blank. Candidate: self-host the FB avatar or a header GIF to `public/kennel-logos/bmh3-bkk.<ext>` later.
- **Flickr**: the kennel has a public Flickr (`flickr.com/photos/56214060@N03/sets/`), but `KennelSeed` has no flickr field — dropped (would need a schema field to surface).

## Post-merge runbook
`git checkout main && git pull` → verify files landed → `npx prisma db seed` → `BACKFILL_APPLY=1 npx tsx scripts/backfill-bmh3-bkk-history.ts` → trigger a scrape from `/admin/sources` → spot-check `/kennels/bangkok-monday-h3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)