### PR TITLE
feat(facebook-hosted-events): per-event kennelPatterns routing (#1996)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -5758,13 +5758,18 @@ export const SOURCES = [
         pageHandle: "MemphisH3",
         timezone: "America/Chicago",
         upcomingOnly: true,
-        // #1954: the Memphis FB page hosts sister-kennel GyNO H3 events, which
-        // this adapter would hard-tag mh3-tn (no kennelPatterns support yet).
-        // GyNO already has its own GCal-fed `gynoh3` source, so drop the FB
-        // duplicate at the ingest boundary instead of mis-attributing it.
-        silentlySkipPatterns: [{ pattern: String.raw`\bGyNO\b`, field: "title" }],
+        // #1996: the Memphis FB page hosts sister-kennel GyNO H3 events. Route
+        // them to `gynoh3` (they dedup against GyNO's own GCal source by
+        // kennel+date in the merge pipeline) and everything else to `mh3-tn`.
+        // Replaces the #1954 silentlySkipPatterns drop-it workaround. Mirrors
+        // the Memphis GCal config's kennelPatterns.
+        kennelPatterns: [
+          [String.raw`\bGyNO\b`, "gynoh3"],
+          [String.raw`^MH3\b|Memphis`, "mh3-tn"],
+        ],
+        defaultKennelTag: "mh3-tn",
       },
-      kennelCodes: ["mh3-tn"],
+      kennelCodes: ["mh3-tn", "gynoh3"],
     },
     {
       name: "SOH4 Facebook Hosted Events",

--- a/src/adapters/facebook-hosted-events/adapter.test.ts
+++ b/src/adapters/facebook-hosted-events/adapter.test.ts
@@ -210,6 +210,41 @@ describe("FacebookHostedEventsAdapter — fetch", () => {
     });
   });
 
+  it("routes events per-config kennelPatterns (#1996)", async () => {
+    // One GyNO-named event on the Memphis page should route to gynoh3 via
+    // config.kennelPatterns rather than the source's own mh3-tn kennelTag —
+    // proving the adapter threads kennelPatterns/defaultKennelTag into the parser.
+    const listing =
+      `<script type="application/json">{"require":[["RelayPrefetchedStreamCache","next",[],[]]]}</script>` +
+      `<script type="application/json">{
+        "rich":{"__typename":"Event","id":"100000000000099","name":"GyNO H3 Harriette Happy Hour #12"},
+        "time":{"id":"100000000000099","start_timestamp":1778353200}
+      }</script>`;
+    // 1st fetch = listing tab; 2nd = the event's detail page (empty body → no
+    // description merge, no sleep since there's only one event).
+    mockedFetch
+      .mockResolvedValueOnce(htmlResponse(listing))
+      .mockResolvedValueOnce(htmlResponse("<html></html>"));
+    const adapter = new FacebookHostedEventsAdapter();
+    const result = await adapter.fetch(
+      makeSource({
+        kennelTag: "mh3-tn",
+        pageHandle: "MemphisH3",
+        timezone: "America/Chicago",
+        upcomingOnly: true,
+        kennelPatterns: [
+          [String.raw`\bGyNO\b`, "gynoh3"],
+          [String.raw`^MH3\b|Memphis`, "mh3-tn"],
+        ],
+        defaultKennelTag: "mh3-tn",
+      }),
+      { days: 365 },
+    );
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].kennelTags).toEqual(["gynoh3"]);
+    expect(result.events[0].title).toBe("GyNO H3 Harriette Happy Hour #12");
+  });
+
   it("populates diagnosticContext via applyDateWindow", async () => {
     mockedFetch.mockResolvedValueOnce(htmlResponse(FIXTURE_HTML));
     const adapter = new FacebookHostedEventsAdapter();

--- a/src/adapters/facebook-hosted-events/adapter.ts
+++ b/src/adapters/facebook-hosted-events/adapter.ts
@@ -29,6 +29,7 @@ import {
   extractFieldsFromFbDescription,
 } from "./parser";
 import { FB_PAGE_HANDLE_RE, isReservedFacebookHandle } from "./constants";
+import type { KennelPattern } from "../kennel-patterns";
 
 /**
  * Headers required to get a 200 from `/upcoming_hosted_events` logged out.
@@ -87,7 +88,11 @@ const DETAIL_FETCH_DELAY_MS = 200;
 
 /** Configuration shape for a FACEBOOK_HOSTED_EVENTS source. */
 export interface FacebookHostedEventsConfig {
-  /** Kennel shortName for all generated events (kennelCode). */
+  /**
+   * Default kennel shortName (kennelCode). Tags every event for a
+   * single-kennel source, and is the fallback for events matching no
+   * `kennelPatterns` entry (alongside `defaultKennelTag`).
+   */
   kennelTag: string;
   /**
    * Page handle — the part after `https://www.facebook.com/`. Restricted
@@ -110,12 +115,25 @@ export interface FacebookHostedEventsConfig {
    * runtime enforcement matches the admin-side `validateFacebookHostedEventsConfig`.
    */
   upcomingOnly: true;
+  /**
+   * Optional per-event kennel routing (#1996) for FB Pages that host a
+   * sister kennel's events. Each event's name is matched against these
+   * patterns via the shared `matchKennelPatterns` engine (same grammar
+   * GOOGLE_CALENDAR uses). Omit for single-kennel sources — every event is
+   * then tagged `kennelTag`, unchanged from pre-#1996 behavior.
+   */
+  kennelPatterns?: KennelPattern[];
+  /** Fallback kennelTag for events matching no `kennelPatterns` entry.
+   *  Defaults to `kennelTag`. No-op without `kennelPatterns`. */
+  defaultKennelTag?: string;
 }
 
 /**
- * Adapter for the FB Page hosted_events tab. Single-kennel-per-source for v1
- * — most FB Pages map 1:1 to a kennel. Multi-kennel routing via
- * `kennelPatterns` is a future extension.
+ * Adapter for the FB Page hosted_events tab. Most FB Pages map 1:1 to a
+ * kennel (just set `kennelTag`). Pages that host a sister kennel's events
+ * can route per-event via `config.kennelPatterns` (#1996), matched against
+ * each event name through the shared `matchKennelPatterns` engine — the same
+ * mechanism GOOGLE_CALENDAR uses.
  */
 export class FacebookHostedEventsAdapter implements SourceAdapter {
   type = "FACEBOOK_HOSTED_EVENTS" as const;
@@ -144,6 +162,9 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
     const parseResult = parseFacebookHostedEventsWithStats(html, {
       kennelTag: config.kennelTag,
       timezone: config.timezone,
+      // Optional routing — undefined when single-kennel, handled by the parser.
+      kennelPatterns: config.kennelPatterns,
+      defaultKennelTag: config.defaultKennelTag,
     });
     const allEvents = parseResult.events;
     const filteredCounts = parseResult.filtered;

--- a/src/adapters/facebook-hosted-events/parser.test.ts
+++ b/src/adapters/facebook-hosted-events/parser.test.ts
@@ -260,29 +260,30 @@ describe("parseFacebookHostedEvents — edge cases", () => {
   });
 });
 
-describe("parseFacebookHostedEvents — kennelPatterns routing (#1996)", () => {
-  // Build a minimal split-payload island (rich + time node sharing one id).
-  // Mirrors the documented FB SSR field surface used everywhere else here.
-  function island(id: string, name: string, startTs = 1778353200): string {
-    return `<script type="application/json">{
+// Build a minimal split-payload island (rich + time node sharing one id).
+// Mirrors the documented FB SSR field surface used everywhere else here.
+function fbRoutingIsland(id: string, name: string, startTs = 1778353200): string {
+  return `<script type="application/json">{
       "rich":{"__typename":"Event","id":"${id}","name":${JSON.stringify(name)}},
       "time":{"id":"${id}","start_timestamp":${startTs}}
     }</script>`;
-  }
+}
+
+function tagsByTitle(events: { title?: string; kennelTags: string[] }[]): Record<string, string[]> {
+  return Object.fromEntries(events.map((e) => [e.title ?? "", e.kennelTags]));
+}
+
+describe("parseFacebookHostedEvents — kennelPatterns routing (#1996)", () => {
   // Memphis FB page hosts both MH3's own trails and sister-kennel GyNO's.
   const MEMPHIS_PATTERNS: [string, string | string[]][] = [
     [String.raw`\bGyNO\b`, "gynoh3"],
     [String.raw`^MH3\b|Memphis`, "mh3-tn"],
   ];
 
-  function tagsByTitle(events: { title?: string; kennelTags: string[] }[]): Record<string, string[]> {
-    return Object.fromEntries(events.map((e) => [e.title ?? "", e.kennelTags]));
-  }
-
   it("routes each event to the right kennel via string-tuple patterns", () => {
     const html =
-      island("100000000000001", "GyNO H3 Harriette Happy Hour #12") +
-      island("100000000000002", "MH3 Trail #850");
+      fbRoutingIsland("100000000000001", "GyNO H3 Harriette Happy Hour #12") +
+      fbRoutingIsland("100000000000002", "MH3 Trail #850");
     const events = parseFacebookHostedEvents(html, {
       kennelTag: "mh3-tn",
       kennelPatterns: MEMPHIS_PATTERNS,
@@ -294,7 +295,7 @@ describe("parseFacebookHostedEvents — kennelPatterns routing (#1996)", () => {
   });
 
   it("falls back to defaultKennelTag when no pattern matches", () => {
-    const html = island("100000000000003", "Surprise Joint Trail #1");
+    const html = fbRoutingIsland("100000000000003", "Surprise Joint Trail #1");
     const [event] = parseFacebookHostedEvents(html, {
       kennelTag: "mh3-tn",
       kennelPatterns: MEMPHIS_PATTERNS,
@@ -304,7 +305,7 @@ describe("parseFacebookHostedEvents — kennelPatterns routing (#1996)", () => {
   });
 
   it("falls back to kennelTag when no pattern matches and defaultKennelTag is unset", () => {
-    const html = island("100000000000004", "Surprise Joint Trail #1");
+    const html = fbRoutingIsland("100000000000004", "Surprise Joint Trail #1");
     const [event] = parseFacebookHostedEvents(html, {
       kennelTag: "mh3-tn",
       kennelPatterns: MEMPHIS_PATTERNS,
@@ -313,7 +314,7 @@ describe("parseFacebookHostedEvents — kennelPatterns routing (#1996)", () => {
   });
 
   it("emits the co-host union for an array-tuple pattern (spec §2 D15)", () => {
-    const html = island("100000000000005", "MH3 x GyNO Joint Trail #1");
+    const html = fbRoutingIsland("100000000000005", "MH3 x GyNO Joint Trail #1");
     const [event] = parseFacebookHostedEvents(html, {
       kennelTag: "mh3-tn",
       kennelPatterns: [[String.raw`Joint`, ["mh3-tn", "gynoh3"]]],
@@ -323,13 +324,13 @@ describe("parseFacebookHostedEvents — kennelPatterns routing (#1996)", () => {
 
   it("is unchanged for single-kennel sources (no kennelPatterns → [kennelTag])", () => {
     const html =
-      island("100000000000006", "GyNO H3 Trail #1") + island("100000000000007", "MH3 Trail #2");
+      fbRoutingIsland("100000000000006", "GyNO H3 Trail #1") + fbRoutingIsland("100000000000007", "MH3 Trail #2");
     const events = parseFacebookHostedEvents(html, { kennelTag: "mh3-tn" });
     expect(events.map((e) => e.kennelTags)).toEqual([["mh3-tn"], ["mh3-tn"]]);
   });
 
   it("ignores an empty kennelPatterns array (single-kennel behavior)", () => {
-    const html = island("100000000000008", "GyNO H3 Trail #1");
+    const html = fbRoutingIsland("100000000000008", "GyNO H3 Trail #1");
     const [event] = parseFacebookHostedEvents(html, { kennelTag: "mh3-tn", kennelPatterns: [] });
     expect(event.kennelTags).toEqual(["mh3-tn"]);
   });

--- a/src/adapters/facebook-hosted-events/parser.test.ts
+++ b/src/adapters/facebook-hosted-events/parser.test.ts
@@ -260,6 +260,81 @@ describe("parseFacebookHostedEvents — edge cases", () => {
   });
 });
 
+describe("parseFacebookHostedEvents — kennelPatterns routing (#1996)", () => {
+  // Build a minimal split-payload island (rich + time node sharing one id).
+  // Mirrors the documented FB SSR field surface used everywhere else here.
+  function island(id: string, name: string, startTs = 1778353200): string {
+    return `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"${id}","name":${JSON.stringify(name)}},
+      "time":{"id":"${id}","start_timestamp":${startTs}}
+    }</script>`;
+  }
+  // Memphis FB page hosts both MH3's own trails and sister-kennel GyNO's.
+  const MEMPHIS_PATTERNS: [string, string | string[]][] = [
+    [String.raw`\bGyNO\b`, "gynoh3"],
+    [String.raw`^MH3\b|Memphis`, "mh3-tn"],
+  ];
+
+  function tagsByTitle(events: { title?: string; kennelTags: string[] }[]): Record<string, string[]> {
+    return Object.fromEntries(events.map((e) => [e.title ?? "", e.kennelTags]));
+  }
+
+  it("routes each event to the right kennel via string-tuple patterns", () => {
+    const html =
+      island("100000000000001", "GyNO H3 Harriette Happy Hour #12") +
+      island("100000000000002", "MH3 Trail #850");
+    const events = parseFacebookHostedEvents(html, {
+      kennelTag: "mh3-tn",
+      kennelPatterns: MEMPHIS_PATTERNS,
+      defaultKennelTag: "mh3-tn",
+    });
+    const tags = tagsByTitle(events);
+    expect(tags["GyNO H3 Harriette Happy Hour #12"]).toEqual(["gynoh3"]);
+    expect(tags["MH3 Trail #850"]).toEqual(["mh3-tn"]);
+  });
+
+  it("falls back to defaultKennelTag when no pattern matches", () => {
+    const html = island("100000000000003", "Surprise Joint Trail #1");
+    const [event] = parseFacebookHostedEvents(html, {
+      kennelTag: "mh3-tn",
+      kennelPatterns: MEMPHIS_PATTERNS,
+      defaultKennelTag: "mh3-tn",
+    });
+    expect(event.kennelTags).toEqual(["mh3-tn"]);
+  });
+
+  it("falls back to kennelTag when no pattern matches and defaultKennelTag is unset", () => {
+    const html = island("100000000000004", "Surprise Joint Trail #1");
+    const [event] = parseFacebookHostedEvents(html, {
+      kennelTag: "mh3-tn",
+      kennelPatterns: MEMPHIS_PATTERNS,
+    });
+    expect(event.kennelTags).toEqual(["mh3-tn"]);
+  });
+
+  it("emits the co-host union for an array-tuple pattern (spec §2 D15)", () => {
+    const html = island("100000000000005", "MH3 x GyNO Joint Trail #1");
+    const [event] = parseFacebookHostedEvents(html, {
+      kennelTag: "mh3-tn",
+      kennelPatterns: [[String.raw`Joint`, ["mh3-tn", "gynoh3"]]],
+    });
+    expect(event.kennelTags).toEqual(["mh3-tn", "gynoh3"]);
+  });
+
+  it("is unchanged for single-kennel sources (no kennelPatterns → [kennelTag])", () => {
+    const html =
+      island("100000000000006", "GyNO H3 Trail #1") + island("100000000000007", "MH3 Trail #2");
+    const events = parseFacebookHostedEvents(html, { kennelTag: "mh3-tn" });
+    expect(events.map((e) => e.kennelTags)).toEqual([["mh3-tn"], ["mh3-tn"]]);
+  });
+
+  it("ignores an empty kennelPatterns array (single-kennel behavior)", () => {
+    const html = island("100000000000008", "GyNO H3 Trail #1");
+    const [event] = parseFacebookHostedEvents(html, { kennelTag: "mh3-tn", kennelPatterns: [] });
+    expect(event.kennelTags).toEqual(["mh3-tn"]);
+  });
+});
+
 const DETAIL_FIXTURE = readFileSync(
   join(__dirname, "fixtures", "grand-strand-event-1012210268147290.html.fixture"),
   "utf-8",

--- a/src/adapters/facebook-hosted-events/parser.ts
+++ b/src/adapters/facebook-hosted-events/parser.ts
@@ -29,9 +29,20 @@ import { formatYmdInTimezone, formatTimeInZone, isValidTimezone } from "@/lib/ti
 import { FB_EVENT_ID_RE, isAdminNoticeTitle, isPlaceholderTitle } from "./constants";
 import { extractHashRunNumber, hasPlaceholderRunNumber } from "../utils";
 import { extractHares } from "../hare-extraction";
+import {
+  compileKennelPatterns,
+  matchCompiledKennelPatterns,
+  type KennelPattern,
+  type CompiledKennelPattern,
+} from "../kennel-patterns";
 
 export interface ParseFacebookOptions {
-  /** kennelTag (kennelCode) for all parsed events. */
+  /**
+   * Default kennelTag (kennelCode). Used for every event when no
+   * `kennelPatterns` are supplied (the single-kennel-per-source case), and
+   * as the fallback (alongside `defaultKennelTag`) for events that match no
+   * pattern when `kennelPatterns` are supplied.
+   */
   kennelTag: string;
   /**
    * IANA timezone for date/time interpretation. Defaults to UTC.
@@ -40,6 +51,45 @@ export interface ParseFacebookOptions {
    * the merge pipeline keys events by (kennelId, local-date).
    */
   timezone?: string;
+  /**
+   * Optional per-event routing for FB Pages that host multiple kennels'
+   * events (e.g. a page that lists a sister kennel's runs). Each event's
+   * name is matched against these patterns via the shared
+   * `matchCompiledKennelPatterns` engine — same grammar GOOGLE_CALENDAR uses
+   * (string tuple = most-specific-wins single kennel; array tuple = co-host
+   * union, spec §2 D15). Omit entirely for single-kennel sources; behavior
+   * is then identical to pre-#1996 (every event tagged `[kennelTag]`).
+   */
+  kennelPatterns?: KennelPattern[];
+  /**
+   * Fallback kennelTag for events that match no `kennelPatterns` entry.
+   * No-op without `kennelPatterns`. Defaults to `kennelTag` when unset.
+   */
+  defaultKennelTag?: string;
+}
+
+/** Resolves a parsed event title to its kennelTag(s). */
+type KennelTagResolver = (title: string) => string[];
+
+/**
+ * Build the per-event kennelTag resolver (#1996). With no compiled patterns
+ * this is the identity single-kennel mapping (`() => [kennelTag]`), so
+ * single-kennel sources are byte-for-byte unchanged. With patterns, each
+ * title routes via the shared engine, falling back to
+ * `defaultKennelTag ?? kennelTag` when nothing matches — mirrors the GCal
+ * adapter's `resolveKennelTagFromSummary` precedence.
+ */
+function buildKennelTagResolver(
+  kennelTag: string,
+  compiled: CompiledKennelPattern[] | null,
+  defaultKennelTag?: string,
+): KennelTagResolver {
+  if (!compiled || compiled.length === 0) return () => [kennelTag];
+  const fallback = defaultKennelTag ?? kennelTag;
+  return (title) => {
+    const matched = matchCompiledKennelPatterns(title, compiled);
+    return matched.length > 0 ? matched : [fallback];
+  };
 }
 
 /**
@@ -106,6 +156,14 @@ export function parseFacebookHostedEventsWithStats(
 ): ParseFacebookResult {
   const tz = options.timezone && isValidTimezone(options.timezone) ? options.timezone : "UTC";
 
+  // Compile kennelPatterns once per scrape (hot-path: O(patterns) per event,
+  // not per-event regex compilation). Null when single-kennel.
+  const compiled =
+    options.kennelPatterns && options.kennelPatterns.length > 0
+      ? compileKennelPatterns(options.kennelPatterns)
+      : null;
+  const resolveKennelTags = buildKennelTagResolver(options.kennelTag, compiled, options.defaultKennelTag);
+
   // Collect both halves of each event by id across all JSON islands.
   const byId = new Map<string, EventBag>();
   for (const json of extractJsonIslands(html)) {
@@ -117,7 +175,7 @@ export function parseFacebookHostedEventsWithStats(
   const events: RawEventData[] = [];
   const filtered = emptyFilteredCounts();
   for (const bag of byId.values()) {
-    const outcome = projectBag(bag, options.kennelTag, tz);
+    const outcome = projectBag(bag, resolveKennelTags, tz);
     if (outcome.kind === "event") {
       events.push(outcome.event);
     } else {
@@ -445,7 +503,7 @@ type BagOutcome =
 // adapter strip in `google-calendar/adapter.ts` (#756 / #1060).
 const TITLE_TRAILING_DELIMITER_RE = /\s*[-–—:]\s*$/; // NOSONAR — anchored end-of-string strip, single char class
 
-function projectBag(bag: EventBag, kennelTag: string, timezone: string): BagOutcome {
+function projectBag(bag: EventBag, resolveKennelTags: KennelTagResolver, timezone: string): BagOutcome {
   if (!bag.time || !bag.rich) return { kind: "rejected", reason: "missing-half" };
   if (bag.rich.is_canceled === true) return { kind: "rejected", reason: "cancelled" };
   // Inner `.trim()` is needed before the regex so the anchored `\s*$` strip
@@ -486,7 +544,7 @@ function projectBag(bag: EventBag, kennelTag: string, timezone: string): BagOutc
 
   const event: RawEventData = {
     date,
-    kennelTags: [kennelTag],
+    kennelTags: resolveKennelTags(title),
     title,
     startTime,
     sourceUrl: `https://www.facebook.com/events/${bag.id}/`,
@@ -513,9 +571,11 @@ function projectBag(bag: EventBag, kennelTag: string, timezone: string): BagOutc
   return { kind: "event", event };
 }
 
-/** Back-compat shim for the existing `facebookEventToRawEvent` external API. */
+/** Back-compat shim for the existing `facebookEventToRawEvent` external API.
+ *  The CIC pagination path is always single-kennel, so it resolves to a fixed
+ *  `[kennelTag]` regardless of title. */
 function bagToRawEvent(bag: EventBag, kennelTag: string, timezone: string): RawEventData | null {
-  const outcome = projectBag(bag, kennelTag, timezone);
+  const outcome = projectBag(bag, () => [kennelTag], timezone);
   return outcome.kind === "event" ? outcome.event : null;
 }
 

--- a/src/app/admin/sources/config-validation.ts
+++ b/src/app/admin/sources/config-validation.ts
@@ -53,7 +53,10 @@ function validateRegex(
  *
  * Add to this set when migrating an adapter to `matchKennelPatterns`.
  */
-const TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS = new Set(["GOOGLE_CALENDAR"]);
+const TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS = new Set([
+  "GOOGLE_CALENDAR",
+  "FACEBOOK_HOSTED_EVENTS", // #1996 — FB adapter routes per-event via matchKennelPatterns
+]);
 
 /** Per-entry tag-value validation for `validateKennelPatterns`. Extracted to
  *  keep the parent function's cognitive complexity below SonarCloud's


### PR DESCRIPTION
## What

Adds `kennelPatterns` per-event routing to the `FACEBOOK_HOSTED_EVENTS` adapter, reusing the shared `matchKennelPatterns` engine (the same mechanism `GOOGLE_CALENDAR` uses). A FB Page that hosts a sister kennel's events now routes each event to the right kennel by matching its name, with a `defaultKennelTag`/`kennelTag` fallback.

Previously the adapter hard-tagged every event with the source's single `config.kennelTag` — the Memphis H3 page hosts GyNO H3's events, which got mis-attributed to `mh3-tn`. The interim fix (#1995) was a blunt `silentlySkipPatterns` rule that *dropped* the GyNO event.

## Changes

- **parser.ts** — `ParseFacebookOptions` gains optional `kennelPatterns` / `defaultKennelTag`; patterns compiled once per scrape and threaded through `projectBag` via a resolver closure. Matching is against the event **name** (same field GCal matches). Single-kennel sources (no patterns) are byte-for-byte unchanged; the CIC `facebookEventToRawEvent` path stays single-tag.
- **adapter.ts** — forwards the two config fields to the parser; config interface + docs updated.
- **config-validation.ts** — `FACEBOOK_HOSTED_EVENTS` added to `TYPES_SUPPORTING_MULTI_KENNEL_PATTERNS` so array-tuple co-host configs validate (string tuples already validated for any type).
- **seed (Memphis FB source)** — routes `GyNO …` → `gynoh3`, everything else → `mh3-tn`, replacing the `silentlySkipPatterns` workaround; `gynoh3` linked via `kennelCodes` so the merge pipeline's source-kennel guard allows the routed events.

## Tests

Multi-kennel routing (string + array tuple), `defaultKennelTag`/`kennelTag` fallback precedence, and single-kennel-unchanged regressions at both parser and adapter level. Existing grand-strand / hollyweird fixture tests stay green (proves additivity). Full suite: 8648 passing.

`/codex:adversarial-review` → approve, no findings. `/simplify` → applied (removed an unnecessary conditional spread).

## ⚠️ Prod note

The Memphis seed change (new `gynoh3` SourceKennel link + config swap) reaches prod only via a **post-merge `npx prisma db seed` + re-scrape** — Vercel runs `migrate deploy`, not `db seed`. No historical cleanup needed: the prior workaround *dropped* GyNO events, so no mis-tagged `mh3-tn` GyNO rows exist to repair. After the seed re-run, GyNO FB events route to `gynoh3` and merge against GyNO's existing GCal events by kennel+date.

Closes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)