### PR TITLE
fix(dh4): resolve #2033 hares fill-rate alert (metric false-positive)

### DIFF
--- a/scripts/lib/reset-baseline.ts
+++ b/scripts/lib/reset-baseline.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared runner for one-shot `Source.baselineResetAt = NOW()` ops scripts.
+ *
+ * `baselineResetAt` is the documented escape hatch for code-led metric
+ * false-positives: when an adapter PR intentionally changes what it emits and
+ * trips a FIELD_FILL_DROP / EVENT_COUNT_ANOMALY alert, setting the boundary to
+ * NOW cuts the rolling baseline (see `prisma/schema.prisma` `baselineResetAt`
+ * and `src/pipeline/health.ts` `startedAt: { gte }`). Each incident gets its own
+ * thin wrapper that documents the verdict and calls this runner — the wrappers
+ * differ only in source identity + alert number, so the DB plumbing lives here.
+ *
+ * Behaviour (driven by `process.argv`):
+ *   (default)        dry run — print the source + current boundary, no write.
+ *   --apply          set baselineResetAt = NOW(), unless already set (idempotent
+ *                    no-op so a rerun can't move the boundary forward and discard
+ *                    re-accumulated post-fix scrape history).
+ *   --apply --force  set baselineResetAt = NOW() even if already set.
+ */
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient, type SourceType } from "@/generated/prisma/client";
+import { createScriptPool } from "./db-pool";
+
+export interface ResetBaselineOptions {
+  /** Exact `Source.name` (paired with `sourceType` for the unique key). */
+  sourceName: string;
+  /** `Source.type` — the other half of the `@@unique([name, type])` key. */
+  sourceType: SourceType;
+  /** Alert/issue number for the success log line (e.g. 2033). */
+  alertNumber: number;
+}
+
+export async function runBaselineReset({ sourceName, sourceType, alertNumber }: ResetBaselineOptions): Promise<void> {
+  const dryRun = !process.argv.includes("--apply");
+  const force = process.argv.includes("--force");
+
+  let pool: ReturnType<typeof createScriptPool> | undefined;
+  let prisma: PrismaClient | undefined;
+  try {
+    pool = createScriptPool();
+    prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+    console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
+
+    const source = await prisma.source.findUnique({
+      where: { name_type: { name: sourceName, type: sourceType } },
+      select: { id: true, name: true, url: true, baselineResetAt: true },
+    });
+
+    if (!source) {
+      console.error(`❌ Source "${sourceName}" not found.`);
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(`Source: ${source.name} (${source.id})`);
+    console.log(`  URL: ${source.url}`);
+    console.log(`  Current baselineResetAt: ${source.baselineResetAt?.toISOString() ?? "null"}`);
+
+    if (dryRun) {
+      console.log("\n(dry run) re-run with --apply to set baselineResetAt = NOW().");
+      return;
+    }
+
+    if (source.baselineResetAt && !force) {
+      console.log(
+        `\n⏭️  baselineResetAt already set (${source.baselineResetAt.toISOString()}) — no-op. ` +
+          "Re-run with --force to override.",
+      );
+      return;
+    }
+
+    const now = new Date();
+    await prisma.source.update({ where: { id: source.id }, data: { baselineResetAt: now } });
+    console.log(`\n✅ Set baselineResetAt = ${now.toISOString()} on "${sourceName}".`);
+    console.log(`   Alert #${alertNumber} will auto-resolve at the next scheduled scrape.`);
+  } finally {
+    await prisma?.$disconnect();
+    await pool?.end();
+  }
+}

--- a/scripts/reset-dh4-hares-baseline.ts
+++ b/scripts/reset-dh4-hares-baseline.ts
@@ -15,86 +15,30 @@
  * description `Hares:` label, never a title parenthetical, so the #2000 strip
  * cannot — and did not — nuke a real hare. 55% is the honest rate.
  *
- * This is a textbook `baselineResetAt` case (see `prisma/schema.prisma:217`
- * and `src/pipeline/health.ts:397-399`). Setting the boundary to NOW cuts the
- * rolling baseline so the next scrape sees no prior rows in window and the
- * FIELD_FILL_DROP comparison short-circuits. The baseline then re-accumulates
- * around the honest post-#2000 rate. We do NOT inject synthesized hare
- * fallbacks — `computeFillRates` runs on `RawEventData` pre-merge
- * (`src/pipeline/fill-rates.ts`), so padding it would permanently blind the
- * raw-layer metric to future real source regressions.
+ * Setting the boundary to NOW cuts the rolling baseline so the next scrape sees
+ * no prior rows in window and the FIELD_FILL_DROP comparison short-circuits; the
+ * baseline then re-accumulates around the honest post-#2000 rate. We do NOT
+ * inject synthesized hare fallbacks — `computeFillRates` runs on `RawEventData`
+ * pre-merge (`src/pipeline/fill-rates.ts`), so padding it would permanently
+ * blind the raw-layer metric to future real source regressions.
  *
  * Usage:
  *   npx tsx scripts/reset-dh4-hares-baseline.ts           # dry run (default)
  *   npx tsx scripts/reset-dh4-hares-baseline.ts --apply   # apply against prod
  *   npx tsx scripts/reset-dh4-hares-baseline.ts --apply --force  # re-set even if already set
  *
- * Idempotent: a plain `--apply` no-ops when `baselineResetAt` is already set, so
- * a rerun after the baseline has re-accumulated post-fix scrape history can't
- * move the boundary forward and discard that history. Use `--force` to override.
- *
  * Load env before running (tsx does not auto-load .env):
  *   set -a && source .env && set +a
  */
 import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient, SourceType } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
+import { SourceType } from "@/generated/prisma/client";
+import { runBaselineReset } from "./lib/reset-baseline";
 
-const dryRun = !process.argv.includes("--apply");
-const force = process.argv.includes("--force");
-const SOURCE_NAME = "DH4 Google Calendar";
-
-async function main() {
-  let pool: ReturnType<typeof createScriptPool> | undefined;
-  try {
-    pool = createScriptPool();
-    const adapter = new PrismaPg(pool);
-    const prisma = new PrismaClient({ adapter });
-
-    console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
-
-    const source = await prisma.source.findUnique({
-      where: { name_type: { name: SOURCE_NAME, type: SourceType.GOOGLE_CALENDAR } },
-      select: { id: true, name: true, url: true, baselineResetAt: true },
-    });
-
-    if (!source) {
-      console.error(`❌ Source "${SOURCE_NAME}" not found.`);
-      process.exitCode = 1;
-      return;
-    }
-
-    console.log(`Source: ${source.name} (${source.id})`);
-    console.log(`  URL: ${source.url}`);
-    console.log(`  Current baselineResetAt: ${source.baselineResetAt?.toISOString() ?? "null"}`);
-
-    if (dryRun) {
-      console.log("\n(dry run) re-run with --apply to set baselineResetAt = NOW().");
-      return;
-    }
-
-    if (source.baselineResetAt && !force) {
-      console.log(
-        `\n⏭️  baselineResetAt already set (${source.baselineResetAt.toISOString()}) — no-op. ` +
-          "Re-run with --force to override.",
-      );
-      return;
-    }
-
-    const now = new Date();
-    await prisma.source.update({
-      where: { id: source.id },
-      data: { baselineResetAt: now },
-    });
-    console.log(`\n✅ Set baselineResetAt = ${now.toISOString()} on "${SOURCE_NAME}".`);
-    console.log("   Alert #2033 will auto-resolve at the next scheduled scrape.");
-  } finally {
-    await pool?.end();
-  }
-}
-
-main().catch((err) => {
+runBaselineReset({
+  sourceName: "DH4 Google Calendar",
+  sourceType: SourceType.GOOGLE_CALENDAR,
+  alertNumber: 2033,
+}).catch((err) => {
   console.error(err);
   process.exitCode = 1;
 });

--- a/scripts/reset-dh4-hares-baseline.ts
+++ b/scripts/reset-dh4-hares-baseline.ts
@@ -1,0 +1,100 @@
+/**
+ * One-shot: set `Source.baselineResetAt = NOW()` on "DH4 Google Calendar" to
+ * resolve the FIELD_FILL_DROP hares alert (#2033).
+ *
+ * Verdict B — metric false-positive, NOT a real regression. PR #2032 (#2000)
+ * stopped promoting `(Run/Walk)`-style event-type parentheticals from the title
+ * into `haresText`. DH4's calendar titles future placeholder runs as
+ * `"DH4 #NNNN Hash Event (Run/Walk)"`; pre-#2000 each of those counted
+ * `"Run/Walk"` as a filled hare, inflating the rolling baseline to 91%.
+ *
+ * Prod evidence (80 most-recent DH4 RawEvents): 0 `(Run/Walk)` garbage remains;
+ * 44/80 = 55% carry real hare names ("Dah Gimp", "Noodle", …), all intact; the
+ * 36 nulls are genuine no-hare rows (future unannounced runs + non-trail social
+ * events like "Drinking Practice"). DH4's real hares come from the GCal
+ * description `Hares:` label, never a title parenthetical, so the #2000 strip
+ * cannot — and did not — nuke a real hare. 55% is the honest rate.
+ *
+ * This is a textbook `baselineResetAt` case (see `prisma/schema.prisma:217`
+ * and `src/pipeline/health.ts:397-399`). Setting the boundary to NOW cuts the
+ * rolling baseline so the next scrape sees no prior rows in window and the
+ * FIELD_FILL_DROP comparison short-circuits. The baseline then re-accumulates
+ * around the honest post-#2000 rate. We do NOT inject synthesized hare
+ * fallbacks — `computeFillRates` runs on `RawEventData` pre-merge
+ * (`src/pipeline/fill-rates.ts`), so padding it would permanently blind the
+ * raw-layer metric to future real source regressions.
+ *
+ * Usage:
+ *   npx tsx scripts/reset-dh4-hares-baseline.ts           # dry run (default)
+ *   npx tsx scripts/reset-dh4-hares-baseline.ts --apply   # apply against prod
+ *   npx tsx scripts/reset-dh4-hares-baseline.ts --apply --force  # re-set even if already set
+ *
+ * Idempotent: a plain `--apply` no-ops when `baselineResetAt` is already set, so
+ * a rerun after the baseline has re-accumulated post-fix scrape history can't
+ * move the boundary forward and discard that history. Use `--force` to override.
+ *
+ * Load env before running (tsx does not auto-load .env):
+ *   set -a && source .env && set +a
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient, SourceType } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const dryRun = !process.argv.includes("--apply");
+const force = process.argv.includes("--force");
+const SOURCE_NAME = "DH4 Google Calendar";
+
+async function main() {
+  let pool: ReturnType<typeof createScriptPool> | undefined;
+  try {
+    pool = createScriptPool();
+    const adapter = new PrismaPg(pool);
+    const prisma = new PrismaClient({ adapter });
+
+    console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
+
+    const source = await prisma.source.findUnique({
+      where: { name_type: { name: SOURCE_NAME, type: SourceType.GOOGLE_CALENDAR } },
+      select: { id: true, name: true, url: true, baselineResetAt: true },
+    });
+
+    if (!source) {
+      console.error(`❌ Source "${SOURCE_NAME}" not found.`);
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(`Source: ${source.name} (${source.id})`);
+    console.log(`  URL: ${source.url}`);
+    console.log(`  Current baselineResetAt: ${source.baselineResetAt?.toISOString() ?? "null"}`);
+
+    if (dryRun) {
+      console.log("\n(dry run) re-run with --apply to set baselineResetAt = NOW().");
+      return;
+    }
+
+    if (source.baselineResetAt && !force) {
+      console.log(
+        `\n⏭️  baselineResetAt already set (${source.baselineResetAt.toISOString()}) — no-op. ` +
+          "Re-run with --force to override.",
+      );
+      return;
+    }
+
+    const now = new Date();
+    await prisma.source.update({
+      where: { id: source.id },
+      data: { baselineResetAt: now },
+    });
+    console.log(`\n✅ Set baselineResetAt = ${now.toISOString()} on "${SOURCE_NAME}".`);
+    console.log("   Alert #2033 will auto-resolve at the next scheduled scrape.");
+  } finally {
+    await pool?.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/reset-ih3-title-baseline.ts
+++ b/scripts/reset-ih3-title-baseline.ts
@@ -9,69 +9,29 @@
  * `RawEventData.title` *before* merge — drops to 14%. User-visible `Event.title`
  * is unaffected.
  *
- * This is a textbook `baselineResetAt` case (see `prisma/schema.prisma:205-210`
- * and `src/pipeline/health.ts:397-399`). Setting the boundary to NOW cuts the
- * rolling baseline so the next scrape sees no prior rows in window and the
+ * This is a textbook `baselineResetAt` case (see `prisma/schema.prisma` and
+ * `src/pipeline/health.ts`). Setting the boundary to NOW cuts the rolling
+ * baseline so the next scrape sees no prior rows in window and the
  * FIELD_FILL_DROP comparison short-circuits. The baseline then re-accumulates
  * around the honest post-#1379 rate.
  *
  * Usage:
  *   npx tsx scripts/reset-ih3-title-baseline.ts           # dry run (default)
  *   npx tsx scripts/reset-ih3-title-baseline.ts --apply   # apply against prod
+ *   npx tsx scripts/reset-ih3-title-baseline.ts --apply --force  # re-set even if already set
  *
  * Load env before running (tsx does not auto-load .env):
  *   set -a && source .env && set +a
  */
 import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient, SourceType } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
+import { SourceType } from "@/generated/prisma/client";
+import { runBaselineReset } from "./lib/reset-baseline";
 
-const dryRun = !process.argv.includes("--apply");
-const SOURCE_NAME = "IH3 Website Hareline";
-
-async function main() {
-  let pool: ReturnType<typeof createScriptPool> | undefined;
-  try {
-    pool = createScriptPool();
-    const adapter = new PrismaPg(pool);
-    const prisma = new PrismaClient({ adapter });
-
-    console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "✏️  APPLYING changes\n");
-
-    const source = await prisma.source.findUnique({
-      where: { name_type: { name: SOURCE_NAME, type: SourceType.HTML_SCRAPER } },
-      select: { id: true, name: true, url: true, baselineResetAt: true },
-    });
-
-    if (!source) {
-      console.error(`❌ Source "${SOURCE_NAME}" not found.`);
-      process.exitCode = 1;
-      return;
-    }
-
-    console.log(`Source: ${source.name} (${source.id})`);
-    console.log(`  URL: ${source.url}`);
-    console.log(`  Current baselineResetAt: ${source.baselineResetAt?.toISOString() ?? "null"}`);
-
-    if (dryRun) {
-      console.log("\n(dry run) re-run with --apply to set baselineResetAt = NOW().");
-      return;
-    }
-
-    const now = new Date();
-    await prisma.source.update({
-      where: { id: source.id },
-      data: { baselineResetAt: now },
-    });
-    console.log(`\n✅ Set baselineResetAt = ${now.toISOString()} on "${SOURCE_NAME}".`);
-    console.log("   Alert #1385 will auto-resolve at the next scheduled scrape.");
-  } finally {
-    await pool?.end();
-  }
-}
-
-main().catch((err) => {
+runBaselineReset({
+  sourceName: "IH3 Website Hareline",
+  sourceType: SourceType.HTML_SCRAPER,
+  alertNumber: 1385,
+}).catch((err) => {
   console.error(err);
   process.exitCode = 1;
 });

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -5451,3 +5451,31 @@ describe("NOH3 titleLocationPattern — 'Start @ {address}' (#2022)", () => {
     expect(result!.title).toBe("Hash #1961");
   });
 });
+
+// ── #2033 — DH4 hares fill-rate regression was a metric false-positive ──
+// The #2000/#2032 `(Run/Walk)` strip dropped the DH4 hares fill rate 91% → 55%.
+// Verdict B (prod-verified): the old 91% was inflated by `"Run/Walk"` counted as
+// hares on placeholder rows; no REAL DH4 hare was lost. DH4's real hares come
+// from the GCal description `Hares:` label, never a title parenthetical — these
+// tests lock that boundary so a future over-broad strip can't regress them. The
+// alert itself is resolved out-of-band via `Source.baselineResetAt`, not adapter
+// changes (`scripts/reset-dh4-hares-baseline.ts`).
+describe("DH4 hares survive the event-type strip (#2033 verdict B)", () => {
+  it("keeps a real description-derived hare on a themed DH4 run", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "DH4 #1661 Blue Full Moon Hash", description: "Hares: Dah Gimp" }),
+      { defaultKennelTag: "dh4" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Dah Gimp");
+  });
+
+  it("leaves a placeholder '(Run/Walk)' DH4 row with no hares", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "DH4 #1663 Hash Event (Run/Walk)", description: "This event is currently being planned." }),
+      { defaultKennelTag: "dh4" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Verdict B — metric false-positive (garbage correctly removed)

Issue #2033 fired a `FIELD_FILL_DROP` alert: DH4 (Dayton H4) `GOOGLE_CALENDAR` hares fill rate dropped **91% → 55%** (36pp). The alert framed this as a regression and pointed at cycle-20's #2000 / PR #2032 GCal label-strip, which stopped promoting `(Run/Walk)`-style event-type parentheticals into `haresText`.

I pulled the live DH4 RawEvents from prod and compared stored `haresText` against each title. **The drop is a metric false-positive from an intentional change — no real hares were lost. 55% is the honest rate.**

### Evidence (80 most-recent DH4 RawEvents, prod)

| Signal | Finding |
|---|---|
| `(Run/Walk)` garbage in `haresText` | **0** remain — #2000 strip worked |
| Real hare names | **44/80 = 55%** intact ("Dah Gimp", "Noodle", "Nair and Toast", "Power Pack Twat and O-Ringer", …) |
| `null` hares | **36/80** — all genuine no-hare rows |

The 36 nulls break down as:
- Future placeholder runs titled `"DH4 #NNNN Hash Event"` where the hare isn't announced yet — **these are exactly the rows that pre-#2000 carried the `(Run/Walk)` suffix and got `haresText="Run/Walk"`**.
- Non-trail social events: `"Drinking Practice: …"`, `"… Volunteer Meeting"`, `"Extra Credit: …"` — legitimately have no hares.

DH4's real hares come from the GCal **description** (`Hares:` label), never a title parenthetical. The #2000 strip only targets `(Run/Walk)`-style combos and lowercase `(…trail)` themes — neither appears as a DH4 title hare — so it **cannot** have nuked a real DH4 hare, and the data confirms it didn't. Pre-#2000, the many `"DH4 #NNNN Hash Event (Run/Walk)"` placeholders each counted `"Run/Walk"` as a filled hare → inflated baseline to 91%.

## Resolution

This is the documented `baselineResetAt` escape hatch (`prisma/schema.prisma:217` + `src/pipeline/health.ts:397-399`) for code-led metric false-positives — **not** adapter changes, and **not** synthesized fallbacks (`computeFillRates` runs on `RawEventData` pre-merge in `src/pipeline/fill-rates.ts`, so padding it would permanently blind the raw-layer metric to future real source regressions).

- **`scripts/reset-dh4-hares-baseline.ts`** (new) — one-shot, dry-run by default, idempotent (no-ops if `baselineResetAt` already set; `--force` to override). Run with `--apply` post-merge.
- **`adapter.test.ts`** — 2 regression-lock tests: a real description-derived hare survives the strip; the `(Run/Walk)` placeholder yields no hares. **No adapter logic change.**

Because no extraction logic changes, no other GCal kennel can regress; #2032 already live-verified the strip against NOH3 / BAH3 / PGH / Perth.

## Checks
- `npx tsc --noEmit` ✓
- `npm run lint` — 0 errors ✓
- `npx vitest run src/adapters/google-calendar/adapter.test.ts` — 708 passed ✓
- Dry-run verified against prod: DH4 `cmmukn7wb001l4km910us6hxz`, current `baselineResetAt = null` ✓
- `/codex:adversarial-review` (idempotency guard added) + `/simplify` (clean) ✓

> Post-merge: run `npx tsx scripts/reset-dh4-hares-baseline.ts --apply` against prod → alert #2033 auto-resolves at the next scheduled DH4 scrape.

Closes #2033

🤖 Generated with [Claude Code](https://claude.com/claude-code)