### PR TITLE
fix(adapters): quick-win audit bundle — 9 issues across 8 adapters

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -701,6 +701,12 @@ export const SOURCES = [
         defaultKennelTag: "bogs-h3",
         defaultStartTime: "19:15",
         locationOmitIfMatches: BRISTOL_LOCATION_OMIT,
+        // Col 3 is "location + theme" — BOGS appends a day-name/theme to the
+        // venue ("T.B.A. World Orienteering Day", "World Brain Day Hare
+        // wanted"). Real venues always carry a UK postcode, so when none is
+        // present the cell is theme/CTA text, not a geocodable venue — clear it
+        // rather than letting it leak into locationName (#1259).
+        locationRequiresPostcode: true,
       },
       kennelCodes: ["bogs-h3"],
     },
@@ -789,12 +795,18 @@ export const SOURCES = [
       config: sfh3IcalConfig,
       kennelCodes: sfh3KennelCodes,
     },
-    // Bay Area HTML scraper (sfh3.com hareline — enrichment/fallback)
+    // Bay Area HTML scraper (sfh3.com hareline).
+    // trustLevel 9 (> the iCal feed's 8) so its richer "What"-column trail
+    // names win the canonical title. The kennels=all .ics SUMMARY strips trail
+    // names to a bare "GPH3 #1711" (no subsite exists for GPH3 — NXDOMAIN), so
+    // the hareline is the only source carrying e.g. "Just What You'd Expect From
+    // a Moron". This is the broader Option B of #1031 (the EBH3 fix used a
+    // kennel-owned subsite at trust 9; GPH3 has none) — see #1291.
     {
       name: "SFH3 MultiHash HTML Hareline",
       url: "https://www.sfh3.com/runs?kennels=all",
       type: "HTML_SCRAPER" as const,
-      trustLevel: 7,
+      trustLevel: 9,
       scrapeFreq: "daily",
       scrapeDays: 90,
       config: sfh3Config,

--- a/scripts/backfill-ch4dk-geocode-1256.ts
+++ b/scripts/backfill-ch4dk-geocode-1256.ts
@@ -28,7 +28,7 @@ import { runOneShot, findKennelId } from "./lib/one-shot";
 const KENNEL = { lat: 55.68, lng: 12.57 };
 const MAX_KM = 200;
 
-runOneShot(async ({ prisma, apply }) => {
+void runOneShot(async ({ prisma, apply }) => {
   const kennelId = await findKennelId(prisma, "ch4-dk");
   if (!kennelId) return;
 
@@ -44,7 +44,9 @@ runOneShot(async ({ prisma, apply }) => {
   for (const e of events) {
     try {
       // Prefer the fuller street address when present, else the venue name.
-      const address = e.locationStreet || e.locationName!;
+      // The query guarantees locationName is non-null; `|| ""` keeps the type
+      // `string` without a non-null assertion (geocodeAddress no-ops on "").
+      const address = e.locationStreet || e.locationName || "";
       const geo = await geocodeAddress(address, { regionBias: "dk" });
       if (!geo) {
         console.log(`  #${e.runNumber} ${e.id}: geocode null for ${JSON.stringify(address)} — skipping.`);

--- a/scripts/backfill-ch4dk-geocode-1256.ts
+++ b/scripts/backfill-ch4dk-geocode-1256.ts
@@ -13,6 +13,7 @@
  *   - Targets only ch4-dk events with a non-empty locationName and NULL coords.
  *   - Validates the geocode lands within ~200 km of the Copenhagen kennel
  *     centroid before writing (rejects a wild result, fail-loud).
+ *   - Per-event try/catch so one bad geocode/update doesn't abort the batch.
  *   - Idempotent: once coords are written the row no longer matches.
  *
  * Run (Railway proxy uses a self-signed cert):
@@ -20,47 +21,28 @@
  *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-ch4dk-geocode-1256.ts --apply
  *   Env:     DATABASE_URL, GOOGLE_CALENDAR_API_KEY
  */
-import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
 import { geocodeAddress, haversineDistance } from "@/lib/geo";
+import { runOneShot, findKennelId } from "./lib/one-shot";
 
 // Copenhagen kennel centroid — geocode results must land within this radius.
 const KENNEL = { lat: 55.68, lng: 12.57 };
 const MAX_KM = 200;
 
-async function main() {
-  const apply = process.argv.includes("--apply");
-  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+runOneShot(async ({ prisma, apply }) => {
+  const kennelId = await findKennelId(prisma, "ch4-dk");
+  if (!kennelId) return;
 
-  const pool = createScriptPool();
-  try {
-    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
-    const kennel = await prisma.kennel.findUnique({
-      where: { kennelCode: "ch4-dk" },
-      select: { id: true },
-    });
-    if (!kennel) {
-      console.log('Kennel "ch4-dk" not found — nothing to do.');
-      return;
-    }
+  const events = await prisma.event.findMany({
+    where: { kennelId, latitude: null, longitude: null, locationName: { not: null } },
+    select: { id: true, runNumber: true, locationName: true, locationStreet: true },
+    orderBy: { date: "asc" },
+  });
+  console.log(`Matched ${events.length} ch4-dk event(s) with a venue but no coords.`);
+  if (events.length === 0) return;
 
-    const events = await prisma.event.findMany({
-      where: {
-        kennelId: kennel.id,
-        latitude: null,
-        longitude: null,
-        locationName: { not: null },
-      },
-      select: { id: true, runNumber: true, locationName: true, locationStreet: true },
-      orderBy: { date: "asc" },
-    });
-    console.log(`Matched ${events.length} ch4-dk event(s) with a venue but no coords.`);
-    if (events.length === 0) return;
-
-    let written = 0;
-    for (const e of events) {
+  let written = 0;
+  for (const e of events) {
+    try {
       // Prefer the fuller street address when present, else the venue name.
       const address = e.locationStreet || e.locationName!;
       const geo = await geocodeAddress(address, { regionBias: "dk" });
@@ -75,21 +57,13 @@ async function main() {
           `(${dist.toFixed(0)}km from CPH; ${geo.formattedAddress ?? ""})${ok ? "" : "  ⚠️ >200km — refusing"}`,
       );
       if (ok && apply) {
-        await prisma.event.update({
-          where: { id: e.id },
-          data: { latitude: geo.lat, longitude: geo.lng },
-        });
+        await prisma.event.update({ where: { id: e.id }, data: { latitude: geo.lat, longitude: geo.lng } });
         written++;
       }
+    } catch (err) {
+      console.error(`  #${e.runNumber} ${e.id}: failed —`, err);
     }
-    if (apply) console.log(`\n✓ Wrote coords to ${written} event(s).`);
-    else console.log("\nRun with --apply to commit changes.");
-  } finally {
-    await pool.end();
   }
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
+  if (apply) console.log(`\n✓ Wrote coords to ${written} event(s).`);
+  else console.log("\nRun with --apply to commit changes.");
 });

--- a/scripts/backfill-ch4dk-geocode-1256.ts
+++ b/scripts/backfill-ch4dk-geocode-1256.ts
@@ -1,0 +1,95 @@
+/**
+ * One-shot geocode backfill for issue #1256 — CH4 (Copenhagen Howling H3).
+ *
+ * CH4 run #372 lists "Køge station" as the venue. The ch4-dk adapter extracts
+ * it correctly, but the canonical Event has NULL lat/lng, so the map renders
+ * the Copenhagen *region-centroid fallback* (~36 km north of Køge). The
+ * geocoder itself is correct — `geocodeAddress("Køge station")` resolves to
+ * Køge (55.458, 12.186) with and without a region bias (verified 2026-06-08).
+ * This is a coordinate-coverage gap, not a geocoder bug, so the fix is data,
+ * not code: geocode the CH4-dk events that have a venue but no coords.
+ *
+ * Self-verifying / safe:
+ *   - Targets only ch4-dk events with a non-empty locationName and NULL coords.
+ *   - Validates the geocode lands within ~200 km of the Copenhagen kennel
+ *     centroid before writing (rejects a wild result, fail-loud).
+ *   - Idempotent: once coords are written the row no longer matches.
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-ch4dk-geocode-1256.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-ch4dk-geocode-1256.ts --apply
+ *   Env:     DATABASE_URL, GOOGLE_CALENDAR_API_KEY
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+import { geocodeAddress, haversineDistance } from "@/lib/geo";
+
+// Copenhagen kennel centroid — geocode results must land within this radius.
+const KENNEL = { lat: 55.68, lng: 12.57 };
+const MAX_KM = 200;
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+
+  const pool = createScriptPool();
+  try {
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    const kennel = await prisma.kennel.findUnique({
+      where: { kennelCode: "ch4-dk" },
+      select: { id: true },
+    });
+    if (!kennel) {
+      console.log('Kennel "ch4-dk" not found — nothing to do.');
+      return;
+    }
+
+    const events = await prisma.event.findMany({
+      where: {
+        kennelId: kennel.id,
+        latitude: null,
+        longitude: null,
+        locationName: { not: null },
+      },
+      select: { id: true, runNumber: true, locationName: true, locationStreet: true },
+      orderBy: { date: "asc" },
+    });
+    console.log(`Matched ${events.length} ch4-dk event(s) with a venue but no coords.`);
+    if (events.length === 0) return;
+
+    let written = 0;
+    for (const e of events) {
+      // Prefer the fuller street address when present, else the venue name.
+      const address = e.locationStreet || e.locationName!;
+      const geo = await geocodeAddress(address, { regionBias: "dk" });
+      if (!geo) {
+        console.log(`  #${e.runNumber} ${e.id}: geocode null for ${JSON.stringify(address)} — skipping.`);
+        continue;
+      }
+      const dist = haversineDistance(geo.lat, geo.lng, KENNEL.lat, KENNEL.lng);
+      const ok = dist <= MAX_KM;
+      console.log(
+        `  #${e.runNumber} ${JSON.stringify(address)} → ${geo.lat.toFixed(4)},${geo.lng.toFixed(4)} ` +
+          `(${dist.toFixed(0)}km from CPH; ${geo.formattedAddress ?? ""})${ok ? "" : "  ⚠️ >200km — refusing"}`,
+      );
+      if (ok && apply) {
+        await prisma.event.update({
+          where: { id: e.id },
+          data: { latitude: geo.lat, longitude: geo.lng },
+        });
+        written++;
+      }
+    }
+    if (apply) console.log(`\n✓ Wrote coords to ${written} event(s).`);
+    else console.log("\nRun with --apply to commit changes.");
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/cleanup-bogs-location-leak-1259.ts
+++ b/scripts/cleanup-bogs-location-leak-1259.ts
@@ -33,7 +33,7 @@ runOneShot(async ({ prisma, apply }) => {
     orderBy: { date: "asc" },
   });
 
-  const leaks = events.filter((e) => !UK_POSTCODE_RE.test(e.locationName!));
+  const leaks = events.filter((e) => e.locationName != null && !UK_POSTCODE_RE.test(e.locationName));
   console.log(`bogs-h3 events with a locationName: ${events.length}; non-postcode leaks: ${leaks.length}`);
   for (const e of leaks) {
     console.log(`  CLEAR  #${e.runNumber} ${e.id}  ${JSON.stringify(e.locationName)} → null`);

--- a/scripts/cleanup-bogs-location-leak-1259.ts
+++ b/scripts/cleanup-bogs-location-leak-1259.ts
@@ -23,7 +23,7 @@ import { runOneShot, findKennelId } from "./lib/one-shot";
 // Same shape as UK_POSTCODE_RE in generic.ts.
 const UK_POSTCODE_RE = /[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}/i;
 
-runOneShot(async ({ prisma, apply }) => {
+void runOneShot(async ({ prisma, apply }) => {
   const kennelId = await findKennelId(prisma, "bogs-h3");
   if (!kennelId) return;
 

--- a/scripts/cleanup-bogs-location-leak-1259.ts
+++ b/scripts/cleanup-bogs-location-leak-1259.ts
@@ -18,66 +18,41 @@
  *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-bogs-location-leak-1259.ts
  *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-bogs-location-leak-1259.ts --apply
  */
-import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
+import { runOneShot, findKennelId } from "./lib/one-shot";
 
 // Same shape as UK_POSTCODE_RE in generic.ts.
 const UK_POSTCODE_RE = /[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}/i;
 
-async function main() {
-  const apply = process.argv.includes("--apply");
-  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+runOneShot(async ({ prisma, apply }) => {
+  const kennelId = await findKennelId(prisma, "bogs-h3");
+  if (!kennelId) return;
 
-  const pool = createScriptPool();
-  try {
-    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
-    const kennel = await prisma.kennel.findUnique({
-      where: { kennelCode: "bogs-h3" },
-      select: { id: true },
-    });
-    if (!kennel) {
-      console.log('Kennel "bogs-h3" not found — nothing to do.');
-      return;
-    }
+  const events = await prisma.event.findMany({
+    where: { kennelId, locationName: { not: null } },
+    select: { id: true, runNumber: true, locationName: true },
+    orderBy: { date: "asc" },
+  });
 
-    const events = await prisma.event.findMany({
-      where: { kennelId: kennel.id, locationName: { not: null } },
-      select: { id: true, runNumber: true, locationName: true },
-      orderBy: { date: "asc" },
-    });
-
-    const leaks = events.filter((e) => !UK_POSTCODE_RE.test(e.locationName!));
-    console.log(`bogs-h3 events with a locationName: ${events.length}; non-postcode leaks: ${leaks.length}`);
-    for (const e of leaks) {
-      console.log(`  CLEAR  #${e.runNumber} ${e.id}  ${JSON.stringify(e.locationName)} → null`);
-    }
-
-    if (apply && leaks.length > 0) {
-      for (const e of leaks) {
-        await prisma.event.update({
-          where: { id: e.id },
-          data: {
-            locationName: null,
-            locationStreet: null,
-            locationAddress: null,
-            locationCity: null,
-            latitude: null,
-            longitude: null,
-          },
-        });
-      }
-      console.log(`\n✓ Cleared location on ${leaks.length} event(s).`);
-    } else if (!apply) {
-      console.log("\nRun with --apply to commit changes.");
-    }
-  } finally {
-    await pool.end();
+  const leaks = events.filter((e) => !UK_POSTCODE_RE.test(e.locationName!));
+  console.log(`bogs-h3 events with a locationName: ${events.length}; non-postcode leaks: ${leaks.length}`);
+  for (const e of leaks) {
+    console.log(`  CLEAR  #${e.runNumber} ${e.id}  ${JSON.stringify(e.locationName)} → null`);
   }
-}
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
+  if (apply && leaks.length > 0) {
+    await prisma.event.updateMany({
+      where: { id: { in: leaks.map((e) => e.id) } },
+      data: {
+        locationName: null,
+        locationStreet: null,
+        locationAddress: null,
+        locationCity: null,
+        latitude: null,
+        longitude: null,
+      },
+    });
+    console.log(`\n✓ Cleared location on ${leaks.length} event(s).`);
+  } else if (!apply) {
+    console.log("\nRun with --apply to commit changes.");
+  }
 });

--- a/scripts/cleanup-bogs-location-leak-1259.ts
+++ b/scripts/cleanup-bogs-location-leak-1259.ts
@@ -1,0 +1,83 @@
+/**
+ * One-shot cleanup for issue #1259 — BOGS theme/CTA location leak.
+ *
+ * bogsruns.php column 3 is "location + theme". When the venue is TBA the cell
+ * is just a day-name/theme (± a "Hare wanted" CTA), e.g. "T.B.A. World
+ * Orienteering Day", "World Brain Day Hare wanted". These non-geocodable
+ * strings leaked into locationName because they carry no UK postcode to
+ * truncate at and don't match the exact-string omit patterns.
+ *
+ * The adapter fix in this PR (`locationRequiresPostcode` on the BOGS generic
+ * config) drops no-postcode cells going forward. This script clears the
+ * already-stored leaks: any bogs-h3 event whose locationName contains no UK
+ * postcode has its location fields nulled (real BOGS venues always carry one).
+ *
+ * Re-runnable: once locationName is null/postcoded the row no longer matches.
+ *
+ * Run:
+ *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-bogs-location-leak-1259.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-bogs-location-leak-1259.ts --apply
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+// Same shape as UK_POSTCODE_RE in generic.ts.
+const UK_POSTCODE_RE = /[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}/i;
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+
+  const pool = createScriptPool();
+  try {
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    const kennel = await prisma.kennel.findUnique({
+      where: { kennelCode: "bogs-h3" },
+      select: { id: true },
+    });
+    if (!kennel) {
+      console.log('Kennel "bogs-h3" not found — nothing to do.');
+      return;
+    }
+
+    const events = await prisma.event.findMany({
+      where: { kennelId: kennel.id, locationName: { not: null } },
+      select: { id: true, runNumber: true, locationName: true },
+      orderBy: { date: "asc" },
+    });
+
+    const leaks = events.filter((e) => !UK_POSTCODE_RE.test(e.locationName!));
+    console.log(`bogs-h3 events with a locationName: ${events.length}; non-postcode leaks: ${leaks.length}`);
+    for (const e of leaks) {
+      console.log(`  CLEAR  #${e.runNumber} ${e.id}  ${JSON.stringify(e.locationName)} → null`);
+    }
+
+    if (apply && leaks.length > 0) {
+      for (const e of leaks) {
+        await prisma.event.update({
+          where: { id: e.id },
+          data: {
+            locationName: null,
+            locationStreet: null,
+            locationAddress: null,
+            locationCity: null,
+            latitude: null,
+            longitude: null,
+          },
+        });
+      }
+      console.log(`\n✓ Cleared location on ${leaks.length} event(s).`);
+    } else if (!apply) {
+      console.log("\nRun with --apply to commit changes.");
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/cleanup-dch4-zombies-1074.ts
+++ b/scripts/cleanup-dch4-zombies-1074.ts
@@ -5,83 +5,60 @@
  * adapter previously defaulted the year to the *current* year, so an old
  * December run that resurfaced in a later post was stamped into a *future*
  * December (#2294 → 2026-12-20). That zombie outranked the real latest run
- * (#2310, May 2026) and drove the kennel's "Latest Run" header to 2294. A
- * second zombie (a null-runNumber Dec 23 row) showed the same shape.
+ * (#2310, May 2026) and drove the kennel's "Latest Run" header to 2294.
  *
  * The adapter fix in this PR (publish-date-anchored year inference,
- * `inferDch4Year`) stops new occurrences, but the existing zombies are future
- * rows the reconciler won't touch (HTML_SCRAPER reconcile against a wider
- * window would cancel legitimate past runs). This script removes them in place.
+ * `inferDch4Year`) stops new occurrences, but the existing zombie is a future
+ * row the reconciler won't touch (HTML_SCRAPER reconcile against a wider window
+ * would cancel legitimate past runs). This script removes it in place.
  *
  * Signature (re-runnable, not id-pinned): a future-dated DCH4 event whose run
  * number is absent OR <= the highest *past* run number. A genuine future run
  * always has a higher number than every past run, so this only ever matches
- * mis-dated rows.
+ * mis-dated rows. (Co-hosted events primary-owned by another kennel — e.g. the
+ * DCFMH3 "Super Cold Moon" full-moon trail — are scoped out by Event.kennelId.)
  *
  * Run:
  *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-dch4-zombies-1074.ts
  *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-dch4-zombies-1074.ts --apply
  */
-import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
 import { cascadeDeleteEvents } from "./lib/cascade-delete";
 import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
+import { runOneShot, findKennelId } from "./lib/one-shot";
 
-async function main() {
-  const apply = process.argv.includes("--apply");
-  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+runOneShot(async ({ prisma, apply }) => {
+  const kennelId = await findKennelId(prisma, "dch4");
+  if (!kennelId) return;
 
-  const pool = createScriptPool();
-  try {
-    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
-    const kennel = await prisma.kennel.findUnique({
-      where: { kennelCode: "dch4" },
-      select: { id: true },
-    });
-    if (!kennel) {
-      console.log('Kennel "dch4" not found — nothing to do.');
-      return;
-    }
+  const now = new Date();
+  // Highest run number among PAST events — a real future run must exceed it.
+  const pastAgg = await prisma.event.aggregate({
+    where: { kennelId, date: { lte: now }, runNumber: { not: null } },
+    _max: { runNumber: true },
+  });
+  const maxPastRun = pastAgg._max.runNumber ?? 0;
+  console.log(`Highest past DCH4 run number: #${maxPastRun}`);
 
-    const now = new Date();
-    // Highest run number among PAST events — a real future run must exceed it.
-    const pastAgg = await prisma.event.aggregate({
-      where: { kennelId: kennel.id, date: { lte: now }, runNumber: { not: null } },
-      _max: { runNumber: true },
-    });
-    const maxPastRun = pastAgg._max.runNumber ?? 0;
-    console.log(`Highest past DCH4 run number: #${maxPastRun}`);
+  const future = await prisma.event.findMany({
+    where: { kennelId, date: { gt: now } },
+    select: { id: true, runNumber: true, date: true, title: true },
+    orderBy: { date: "asc" },
+  });
 
-    const future = await prisma.event.findMany({
-      where: { kennelId: kennel.id, date: { gt: now } },
-      select: { id: true, runNumber: true, date: true, title: true },
-      orderBy: { date: "asc" },
-    });
-
-    const zombies = future.filter((e) => e.runNumber == null || e.runNumber <= maxPastRun);
-    console.log(`Future DCH4 events: ${future.length}; zombies (run# absent or <= #${maxPastRun}): ${zombies.length}`);
-    for (const e of zombies) {
-      console.log(
-        `  DELETE  ${e.id}  ${e.date.toISOString().slice(0, 10)}  run=${e.runNumber ?? "—"}  ${JSON.stringify(e.title)}`,
-      );
-    }
-
-    if (apply && zombies.length > 0) {
-      const deleted = await cascadeDeleteEvents(prisma, zombies.map((e) => e.id));
-      console.log(`\n✓ Deleted ${deleted} zombie event(s).`);
-      const touched = await backfillLastEventDates();
-      console.log(`✓ Recomputed lastEventDate for ${touched} kennel(s).`);
-    } else if (!apply) {
-      console.log("\nRun with --apply to commit changes.");
-    }
-  } finally {
-    await pool.end();
+  const zombies = future.filter((e) => e.runNumber == null || e.runNumber <= maxPastRun);
+  console.log(`Future DCH4 events: ${future.length}; zombies (run# absent or <= #${maxPastRun}): ${zombies.length}`);
+  for (const e of zombies) {
+    console.log(
+      `  DELETE  ${e.id}  ${e.date.toISOString().slice(0, 10)}  run=${e.runNumber ?? "—"}  ${JSON.stringify(e.title)}`,
+    );
   }
-}
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
+  if (apply && zombies.length > 0) {
+    const deleted = await cascadeDeleteEvents(prisma, zombies.map((e) => e.id));
+    console.log(`\n✓ Deleted ${deleted} zombie event(s).`);
+    const touched = await backfillLastEventDates();
+    console.log(`✓ Recomputed lastEventDate for ${touched} kennel(s).`);
+  } else if (!apply) {
+    console.log("\nRun with --apply to commit changes.");
+  }
 });

--- a/scripts/cleanup-dch4-zombies-1074.ts
+++ b/scripts/cleanup-dch4-zombies-1074.ts
@@ -12,11 +12,15 @@
  * row the reconciler won't touch (HTML_SCRAPER reconcile against a wider window
  * would cancel legitimate past runs). This script removes it in place.
  *
- * Signature (re-runnable, not id-pinned): a future-dated DCH4 event whose run
- * number is absent OR <= the highest *past* run number. A genuine future run
- * always has a higher number than every past run, so this only ever matches
- * mis-dated rows. (Co-hosted events primary-owned by another kennel — e.g. the
- * DCFMH3 "Super Cold Moon" full-moon trail — are scoped out by Event.kennelId.)
+ * Signature (re-runnable, not id-pinned): a future-dated DCH4 event with a
+ * run number <= the highest *past* run number. A genuine future WordPress run
+ * always has a higher number than every past run, so this only matches
+ * mis-dated rows. We require a non-null runNumber on purpose: the dch4.org
+ * WordPress title regex always yields one, whereas the Hash Rego source
+ * (seeded for dch4) emits run-number-less registrations/campouts — those are
+ * legitimate future events and must NOT be swept up (Codex review). Co-hosted
+ * events primary-owned by another kennel (e.g. the DCFMH3 "Super Cold Moon"
+ * full-moon trail) are already scoped out by Event.kennelId.
  *
  * Run:
  *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-dch4-zombies-1074.ts
@@ -45,8 +49,8 @@ runOneShot(async ({ prisma, apply }) => {
     orderBy: { date: "asc" },
   });
 
-  const zombies = future.filter((e) => e.runNumber == null || e.runNumber <= maxPastRun);
-  console.log(`Future DCH4 events: ${future.length}; zombies (run# absent or <= #${maxPastRun}): ${zombies.length}`);
+  const zombies = future.filter((e) => e.runNumber != null && e.runNumber <= maxPastRun);
+  console.log(`Future DCH4 events: ${future.length}; zombies (run# present and <= #${maxPastRun}): ${zombies.length}`);
   for (const e of zombies) {
     console.log(
       `  DELETE  ${e.id}  ${e.date.toISOString().slice(0, 10)}  run=${e.runNumber ?? "—"}  ${JSON.stringify(e.title)}`,

--- a/scripts/cleanup-dch4-zombies-1074.ts
+++ b/scripts/cleanup-dch4-zombies-1074.ts
@@ -30,7 +30,7 @@ import { cascadeDeleteEvents } from "./lib/cascade-delete";
 import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
 import { runOneShot, findKennelId } from "./lib/one-shot";
 
-runOneShot(async ({ prisma, apply }) => {
+void runOneShot(async ({ prisma, apply }) => {
   const kennelId = await findKennelId(prisma, "dch4");
   if (!kennelId) return;
 

--- a/scripts/cleanup-dch4-zombies-1074.ts
+++ b/scripts/cleanup-dch4-zombies-1074.ts
@@ -1,0 +1,87 @@
+/**
+ * One-shot cleanup for issue #1074 — DCH4 zombie upcoming events.
+ *
+ * DCH4 post titles often omit the year ("DCH4 Trail# 2294 - 12/20 @ 5pm"). The
+ * adapter previously defaulted the year to the *current* year, so an old
+ * December run that resurfaced in a later post was stamped into a *future*
+ * December (#2294 → 2026-12-20). That zombie outranked the real latest run
+ * (#2310, May 2026) and drove the kennel's "Latest Run" header to 2294. A
+ * second zombie (a null-runNumber Dec 23 row) showed the same shape.
+ *
+ * The adapter fix in this PR (publish-date-anchored year inference,
+ * `inferDch4Year`) stops new occurrences, but the existing zombies are future
+ * rows the reconciler won't touch (HTML_SCRAPER reconcile against a wider
+ * window would cancel legitimate past runs). This script removes them in place.
+ *
+ * Signature (re-runnable, not id-pinned): a future-dated DCH4 event whose run
+ * number is absent OR <= the highest *past* run number. A genuine future run
+ * always has a higher number than every past run, so this only ever matches
+ * mis-dated rows.
+ *
+ * Run:
+ *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-dch4-zombies-1074.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-dch4-zombies-1074.ts --apply
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+import { cascadeDeleteEvents } from "./lib/cascade-delete";
+import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+
+  const pool = createScriptPool();
+  try {
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    const kennel = await prisma.kennel.findUnique({
+      where: { kennelCode: "dch4" },
+      select: { id: true },
+    });
+    if (!kennel) {
+      console.log('Kennel "dch4" not found — nothing to do.');
+      return;
+    }
+
+    const now = new Date();
+    // Highest run number among PAST events — a real future run must exceed it.
+    const pastAgg = await prisma.event.aggregate({
+      where: { kennelId: kennel.id, date: { lte: now }, runNumber: { not: null } },
+      _max: { runNumber: true },
+    });
+    const maxPastRun = pastAgg._max.runNumber ?? 0;
+    console.log(`Highest past DCH4 run number: #${maxPastRun}`);
+
+    const future = await prisma.event.findMany({
+      where: { kennelId: kennel.id, date: { gt: now } },
+      select: { id: true, runNumber: true, date: true, title: true },
+      orderBy: { date: "asc" },
+    });
+
+    const zombies = future.filter((e) => e.runNumber == null || e.runNumber <= maxPastRun);
+    console.log(`Future DCH4 events: ${future.length}; zombies (run# absent or <= #${maxPastRun}): ${zombies.length}`);
+    for (const e of zombies) {
+      console.log(
+        `  DELETE  ${e.id}  ${e.date.toISOString().slice(0, 10)}  run=${e.runNumber ?? "—"}  ${JSON.stringify(e.title)}`,
+      );
+    }
+
+    if (apply && zombies.length > 0) {
+      const deleted = await cascadeDeleteEvents(prisma, zombies.map((e) => e.id));
+      console.log(`\n✓ Deleted ${deleted} zombie event(s).`);
+      const touched = await backfillLastEventDates();
+      console.log(`✓ Recomputed lastEventDate for ${touched} kennel(s).`);
+    } else if (!apply) {
+      console.log("\nRun with --apply to commit changes.");
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/cleanup-hkh3-duplicate-mondays-1284.ts
+++ b/scripts/cleanup-hkh3-duplicate-mondays-1284.ts
@@ -40,13 +40,21 @@ runOneShot(async ({ prisma, apply }) => {
   // Run numbers that appear on more than one distinct date = duplicated.
   const datesByRun = new Map<number, Set<string>>();
   for (const e of events) {
+    const run = e.runNumber;
+    if (run == null) continue; // the query excludes nulls; this narrows the type
     const day = e.date.toISOString().slice(0, 10);
-    (datesByRun.get(e.runNumber!) ?? datesByRun.set(e.runNumber!, new Set()).get(e.runNumber!)!).add(day);
+    let days = datesByRun.get(run);
+    if (!days) {
+      days = new Set();
+      datesByRun.set(run, days);
+    }
+    days.add(day);
   }
   const dupRuns = new Set([...datesByRun].filter(([, days]) => days.size > 1).map(([run]) => run));
-  const toReset = events.filter((e) => dupRuns.has(e.runNumber!));
+  const toReset = events.filter((e) => e.runNumber != null && dupRuns.has(e.runNumber));
 
-  console.log(`Duplicated run numbers: ${[...dupRuns].map((r) => `#${r}`).join(", ") || "(none)"}`);
+  const dupLabel = [...dupRuns].map((r) => "#" + r).join(", ") || "(none)";
+  console.log(`Duplicated run numbers: ${dupLabel}`);
   console.log(`Events to reset to generic placeholder: ${toReset.length}`);
   for (const e of toReset) {
     console.log(

--- a/scripts/cleanup-hkh3-duplicate-mondays-1284.ts
+++ b/scripts/cleanup-hkh3-duplicate-mondays-1284.ts
@@ -27,7 +27,7 @@ import { runOneShot, findKennelId } from "./lib/one-shot";
 const GENERIC_TITLE = "HK H3 Weekly Run";
 const GENERIC_LOCATION = "Hong Kong";
 
-runOneShot(async ({ prisma, apply }) => {
+void runOneShot(async ({ prisma, apply }) => {
   const kennelId = await findKennelId(prisma, "hkh3");
   if (!kennelId) return;
 

--- a/scripts/cleanup-hkh3-duplicate-mondays-1284.ts
+++ b/scripts/cleanup-hkh3-duplicate-mondays-1284.ts
@@ -1,0 +1,104 @@
+/**
+ * One-shot cleanup for issue #1284 — HK H3 duplicate-Monday enrichment.
+ *
+ * hkhash.com's homepage shows a single "Next H4 Run" block with no explicit
+ * date. The adapter dates it to the next Monday, but the homepage has been
+ * stale at "Run Number 2969" for weeks, so successive weekly scrapes stamped
+ * #2969 (+ "Hollywood Park Road") onto multiple consecutive Mondays (May 25,
+ * Jun 1, Jun 8) — a duplicate run number across several canonical events.
+ *
+ * The adapter fix in this PR (HK-timezone + 18:00 run-time aware
+ * `nextMondayOnOrAfter`) stops it from stamping an already-past Monday, but the
+ * existing duplicates must be reset. This reverts every hkh3 event whose run
+ * number is shared across ≥2 dates back to the generic STATIC_SCHEDULE
+ * placeholder, so the next scrape re-enriches only the single true upcoming
+ * Monday. (A non-updating homepage can still re-stamp a stale number — that's a
+ * documented source-freshness limitation.)
+ *
+ * Re-runnable: matches only run numbers that currently appear on >1 date.
+ *
+ * Run:
+ *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-hkh3-duplicate-mondays-1284.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-hkh3-duplicate-mondays-1284.ts --apply
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+// Generic STATIC_SCHEDULE placeholder values (observed on un-enriched Mondays).
+const GENERIC_TITLE = "HK H3 Weekly Run";
+const GENERIC_LOCATION = "Hong Kong";
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+
+  const pool = createScriptPool();
+  try {
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    const kennel = await prisma.kennel.findUnique({
+      where: { kennelCode: "hkh3" },
+      select: { id: true },
+    });
+    if (!kennel) {
+      console.log('Kennel "hkh3" not found — nothing to do.');
+      return;
+    }
+
+    const events = await prisma.event.findMany({
+      where: { kennelId: kennel.id, runNumber: { not: null } },
+      select: { id: true, runNumber: true, date: true, title: true, locationName: true },
+      orderBy: { date: "asc" },
+    });
+
+    // Run numbers that appear on more than one distinct date = duplicated.
+    const datesByRun = new Map<number, Set<string>>();
+    for (const e of events) {
+      const key = e.runNumber!;
+      const day = e.date.toISOString().slice(0, 10);
+      (datesByRun.get(key) ?? datesByRun.set(key, new Set()).get(key)!).add(day);
+    }
+    const dupRuns = new Set([...datesByRun].filter(([, days]) => days.size > 1).map(([run]) => run));
+    const toReset = events.filter((e) => dupRuns.has(e.runNumber!));
+
+    console.log(`Duplicated run numbers: ${[...dupRuns].map((r) => `#${r}`).join(", ") || "(none)"}`);
+    console.log(`Events to reset to generic placeholder: ${toReset.length}`);
+    for (const e of toReset) {
+      console.log(
+        `  RESET  ${e.id}  ${e.date.toISOString().slice(0, 10)}  #${e.runNumber}  ${JSON.stringify(e.title)} / ${JSON.stringify(e.locationName)}`,
+      );
+    }
+
+    if (apply && toReset.length > 0) {
+      for (const e of toReset) {
+        await prisma.event.update({
+          where: { id: e.id },
+          // Revert to the generic placeholder; null the enrichment-only fields
+          // so the next scrape re-fills the true upcoming Monday cleanly.
+          data: {
+            runNumber: null,
+            title: GENERIC_TITLE,
+            locationName: GENERIC_LOCATION,
+            locationStreet: null,
+            locationAddress: null,
+            locationCity: null,
+            latitude: null,
+            longitude: null,
+            description: null,
+          },
+        });
+      }
+      console.log(`\n✓ Reset ${toReset.length} event(s) to the generic placeholder.`);
+    } else if (!apply) {
+      console.log("\nRun with --apply to commit changes.");
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/cleanup-hkh3-duplicate-mondays-1284.ts
+++ b/scripts/cleanup-hkh3-duplicate-mondays-1284.ts
@@ -4,8 +4,8 @@
  * hkhash.com's homepage shows a single "Next H4 Run" block with no explicit
  * date. The adapter dates it to the next Monday, but the homepage has been
  * stale at "Run Number 2969" for weeks, so successive weekly scrapes stamped
- * #2969 (+ "Hollywood Park Road") onto multiple consecutive Mondays (May 25,
- * Jun 1, Jun 8) — a duplicate run number across several canonical events.
+ * #2969 (+ "Hollywood Park Road") onto multiple consecutive Mondays — a
+ * duplicate run number across several canonical events.
  *
  * The adapter fix in this PR (HK-timezone + 18:00 run-time aware
  * `nextMondayOnOrAfter`) stops it from stamping an already-past Monday, but the
@@ -21,84 +21,58 @@
  *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-hkh3-duplicate-mondays-1284.ts
  *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/cleanup-hkh3-duplicate-mondays-1284.ts --apply
  */
-import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
+import { runOneShot, findKennelId } from "./lib/one-shot";
 
 // Generic STATIC_SCHEDULE placeholder values (observed on un-enriched Mondays).
 const GENERIC_TITLE = "HK H3 Weekly Run";
 const GENERIC_LOCATION = "Hong Kong";
 
-async function main() {
-  const apply = process.argv.includes("--apply");
-  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+runOneShot(async ({ prisma, apply }) => {
+  const kennelId = await findKennelId(prisma, "hkh3");
+  if (!kennelId) return;
 
-  const pool = createScriptPool();
-  try {
-    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
-    const kennel = await prisma.kennel.findUnique({
-      where: { kennelCode: "hkh3" },
-      select: { id: true },
-    });
-    if (!kennel) {
-      console.log('Kennel "hkh3" not found — nothing to do.');
-      return;
-    }
+  const events = await prisma.event.findMany({
+    where: { kennelId, runNumber: { not: null } },
+    select: { id: true, runNumber: true, date: true, title: true, locationName: true },
+    orderBy: { date: "asc" },
+  });
 
-    const events = await prisma.event.findMany({
-      where: { kennelId: kennel.id, runNumber: { not: null } },
-      select: { id: true, runNumber: true, date: true, title: true, locationName: true },
-      orderBy: { date: "asc" },
-    });
-
-    // Run numbers that appear on more than one distinct date = duplicated.
-    const datesByRun = new Map<number, Set<string>>();
-    for (const e of events) {
-      const key = e.runNumber!;
-      const day = e.date.toISOString().slice(0, 10);
-      (datesByRun.get(key) ?? datesByRun.set(key, new Set()).get(key)!).add(day);
-    }
-    const dupRuns = new Set([...datesByRun].filter(([, days]) => days.size > 1).map(([run]) => run));
-    const toReset = events.filter((e) => dupRuns.has(e.runNumber!));
-
-    console.log(`Duplicated run numbers: ${[...dupRuns].map((r) => `#${r}`).join(", ") || "(none)"}`);
-    console.log(`Events to reset to generic placeholder: ${toReset.length}`);
-    for (const e of toReset) {
-      console.log(
-        `  RESET  ${e.id}  ${e.date.toISOString().slice(0, 10)}  #${e.runNumber}  ${JSON.stringify(e.title)} / ${JSON.stringify(e.locationName)}`,
-      );
-    }
-
-    if (apply && toReset.length > 0) {
-      for (const e of toReset) {
-        await prisma.event.update({
-          where: { id: e.id },
-          // Revert to the generic placeholder; null the enrichment-only fields
-          // so the next scrape re-fills the true upcoming Monday cleanly.
-          data: {
-            runNumber: null,
-            title: GENERIC_TITLE,
-            locationName: GENERIC_LOCATION,
-            locationStreet: null,
-            locationAddress: null,
-            locationCity: null,
-            latitude: null,
-            longitude: null,
-            description: null,
-          },
-        });
-      }
-      console.log(`\n✓ Reset ${toReset.length} event(s) to the generic placeholder.`);
-    } else if (!apply) {
-      console.log("\nRun with --apply to commit changes.");
-    }
-  } finally {
-    await pool.end();
+  // Run numbers that appear on more than one distinct date = duplicated.
+  const datesByRun = new Map<number, Set<string>>();
+  for (const e of events) {
+    const day = e.date.toISOString().slice(0, 10);
+    (datesByRun.get(e.runNumber!) ?? datesByRun.set(e.runNumber!, new Set()).get(e.runNumber!)!).add(day);
   }
-}
+  const dupRuns = new Set([...datesByRun].filter(([, days]) => days.size > 1).map(([run]) => run));
+  const toReset = events.filter((e) => dupRuns.has(e.runNumber!));
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
+  console.log(`Duplicated run numbers: ${[...dupRuns].map((r) => `#${r}`).join(", ") || "(none)"}`);
+  console.log(`Events to reset to generic placeholder: ${toReset.length}`);
+  for (const e of toReset) {
+    console.log(
+      `  RESET  ${e.id}  ${e.date.toISOString().slice(0, 10)}  #${e.runNumber}  ${JSON.stringify(e.title)} / ${JSON.stringify(e.locationName)}`,
+    );
+  }
+
+  if (apply && toReset.length > 0) {
+    await prisma.event.updateMany({
+      where: { id: { in: toReset.map((e) => e.id) } },
+      // Revert to the generic placeholder; null the enrichment-only fields so
+      // the next scrape re-fills the true upcoming Monday cleanly.
+      data: {
+        runNumber: null,
+        title: GENERIC_TITLE,
+        locationName: GENERIC_LOCATION,
+        locationStreet: null,
+        locationAddress: null,
+        locationCity: null,
+        latitude: null,
+        longitude: null,
+        description: null,
+      },
+    });
+    console.log(`\n✓ Reset ${toReset.length} event(s) to the generic placeholder.`);
+  } else if (!apply) {
+    console.log("\nRun with --apply to commit changes.");
+  }
 });

--- a/scripts/lib/one-shot.ts
+++ b/scripts/lib/one-shot.ts
@@ -1,0 +1,49 @@
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./db-pool";
+
+/**
+ * Shared scaffolding for one-shot maintenance scripts. Parses the `--apply`
+ * flag, logs the dry-run/apply banner, opens a script DB pool, runs `fn`, and
+ * always closes the pool (and sets a non-zero exit code on error). Keeps the
+ * per-script body focused on the actual query/filter/update logic so each
+ * script stays small and they don't duplicate boilerplate.
+ *
+ *   runOneShot(async ({ prisma, apply }) => { ... });
+ */
+export async function runOneShot(
+  fn: (ctx: { prisma: PrismaClient; apply: boolean }) => Promise<void>,
+): Promise<void> {
+  const apply = process.argv.includes("--apply");
+  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+  const pool = createScriptPool();
+  try {
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    await fn({ prisma, apply });
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+}
+
+/**
+ * Look up a kennel id by kennelCode. Logs and returns null when absent so the
+ * caller can bail with `if (!id) return;`.
+ */
+export async function findKennelId(
+  prisma: PrismaClient,
+  kennelCode: string,
+): Promise<string | null> {
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode },
+    select: { id: true },
+  });
+  if (!kennel) {
+    console.log(`Kennel "${kennelCode}" not found — nothing to do.`);
+    return null;
+  }
+  return kennel.id;
+}

--- a/scripts/patch-divah3-passion-pit-1178.ts
+++ b/scripts/patch-divah3-passion-pit-1178.ts
@@ -1,0 +1,72 @@
+/**
+ * One-shot patch for issue #1178 — DivaH3 Mar 13 2026 missing hares.
+ *
+ * The DivaH3 page labels the hare row "Hostess and hare: Passion Pit", which
+ * the EH3 adapter's hare matcher didn't recognize (it only matched "Hare(s):"),
+ * so the Friday March 13, 2026 event ("Divas jump into Spring a bit early")
+ * stored no hares. The adapter fix in this PR adds the hostess/host variants,
+ * but March 13 is now in the past and won't be re-scraped — this patches the
+ * stored row in place.
+ *
+ * Signature-pinned (re-runnable): kennel divah3-eh3, the March 13/14 2026 event
+ * with an empty haresText. Once haresText is set the row no longer matches.
+ *
+ * Run:
+ *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/patch-divah3-passion-pit-1178.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/patch-divah3-passion-pit-1178.ts --apply
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const HARE = "Passion Pit";
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+
+  const pool = createScriptPool();
+  try {
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    const kennel = await prisma.kennel.findUnique({
+      where: { kennelCode: "divah3-eh3" },
+      select: { id: true },
+    });
+    if (!kennel) {
+      console.log('Kennel "divah3-eh3" not found — nothing to do.');
+      return;
+    }
+
+    // The event is stored as UTC noon-ish for the Mar 13 local date; match the
+    // calendar window Mar 13–14 to be robust to the stored TZ offset.
+    const events = await prisma.event.findMany({
+      where: {
+        kennelId: kennel.id,
+        date: { gte: new Date("2026-03-13T00:00:00Z"), lt: new Date("2026-03-15T00:00:00Z") },
+        OR: [{ haresText: null }, { haresText: "" }],
+      },
+      select: { id: true, date: true, title: true, haresText: true },
+    });
+    console.log(`Matched ${events.length} DivaH3 event(s) with empty hares in the Mar 13 window.`);
+    for (const e of events) {
+      console.log(`  PATCH  ${e.id}  ${e.date.toISOString().slice(0, 10)}  ${JSON.stringify(e.title)}  haresText → ${JSON.stringify(HARE)}`);
+    }
+
+    if (apply && events.length > 0) {
+      for (const e of events) {
+        await prisma.event.update({ where: { id: e.id }, data: { haresText: HARE } });
+      }
+      console.log(`\n✓ Patched ${events.length} event(s).`);
+    } else if (!apply) {
+      console.log("\nRun with --apply to commit changes.");
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/patch-divah3-passion-pit-1178.ts
+++ b/scripts/patch-divah3-passion-pit-1178.ts
@@ -15,58 +15,36 @@
  *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/patch-divah3-passion-pit-1178.ts
  *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/patch-divah3-passion-pit-1178.ts --apply
  */
-import "dotenv/config";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/generated/prisma/client";
-import { createScriptPool } from "./lib/db-pool";
+import { runOneShot, findKennelId } from "./lib/one-shot";
 
 const HARE = "Passion Pit";
 
-async function main() {
-  const apply = process.argv.includes("--apply");
-  console.log(apply ? "✏️  APPLYING changes" : "🔍 DRY RUN — no changes will be made");
+runOneShot(async ({ prisma, apply }) => {
+  const kennelId = await findKennelId(prisma, "divah3-eh3");
+  if (!kennelId) return;
 
-  const pool = createScriptPool();
-  try {
-    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
-    const kennel = await prisma.kennel.findUnique({
-      where: { kennelCode: "divah3-eh3" },
-      select: { id: true },
-    });
-    if (!kennel) {
-      console.log('Kennel "divah3-eh3" not found — nothing to do.');
-      return;
-    }
-
-    // The event is stored as UTC noon-ish for the Mar 13 local date; match the
-    // calendar window Mar 13–14 to be robust to the stored TZ offset.
-    const events = await prisma.event.findMany({
-      where: {
-        kennelId: kennel.id,
-        date: { gte: new Date("2026-03-13T00:00:00Z"), lt: new Date("2026-03-15T00:00:00Z") },
-        OR: [{ haresText: null }, { haresText: "" }],
-      },
-      select: { id: true, date: true, title: true, haresText: true },
-    });
-    console.log(`Matched ${events.length} DivaH3 event(s) with empty hares in the Mar 13 window.`);
-    for (const e of events) {
-      console.log(`  PATCH  ${e.id}  ${e.date.toISOString().slice(0, 10)}  ${JSON.stringify(e.title)}  haresText → ${JSON.stringify(HARE)}`);
-    }
-
-    if (apply && events.length > 0) {
-      for (const e of events) {
-        await prisma.event.update({ where: { id: e.id }, data: { haresText: HARE } });
-      }
-      console.log(`\n✓ Patched ${events.length} event(s).`);
-    } else if (!apply) {
-      console.log("\nRun with --apply to commit changes.");
-    }
-  } finally {
-    await pool.end();
+  // The event is stored as UTC noon-ish for the Mar 13 local date; match the
+  // calendar window Mar 13–14 to be robust to the stored TZ offset.
+  const events = await prisma.event.findMany({
+    where: {
+      kennelId,
+      date: { gte: new Date("2026-03-13T00:00:00Z"), lt: new Date("2026-03-15T00:00:00Z") },
+      OR: [{ haresText: null }, { haresText: "" }],
+    },
+    select: { id: true, date: true, title: true },
+  });
+  console.log(`Matched ${events.length} DivaH3 event(s) with empty hares in the Mar 13 window.`);
+  for (const e of events) {
+    console.log(`  PATCH  ${e.id}  ${e.date.toISOString().slice(0, 10)}  ${JSON.stringify(e.title)}  haresText → ${JSON.stringify(HARE)}`);
   }
-}
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
+  if (apply && events.length > 0) {
+    await prisma.event.updateMany({
+      where: { id: { in: events.map((e) => e.id) } },
+      data: { haresText: HARE },
+    });
+    console.log(`\n✓ Patched ${events.length} event(s).`);
+  } else if (!apply) {
+    console.log("\nRun with --apply to commit changes.");
+  }
 });

--- a/scripts/patch-divah3-passion-pit-1178.ts
+++ b/scripts/patch-divah3-passion-pit-1178.ts
@@ -19,7 +19,7 @@ import { runOneShot, findKennelId } from "./lib/one-shot";
 
 const HARE = "Passion Pit";
 
-runOneShot(async ({ prisma, apply }) => {
+void runOneShot(async ({ prisma, apply }) => {
   const kennelId = await findKennelId(prisma, "divah3-eh3");
   if (!kennelId) return;
 

--- a/src/adapters/html-scraper/dch4.test.ts
+++ b/src/adapters/html-scraper/dch4.test.ts
@@ -6,8 +6,13 @@ import * as wordpressApi from "../wordpress-api";
 vi.mock("../wordpress-api");
 
 describe("parseDch4Title", () => {
+  // Representative publish dates for year-less titles (announcements post ~days
+  // before the run, so the publish month anchors the inferred year).
+  const febPub = new Date("2026-02-01T12:00:00Z");
+  const octPub = new Date("2026-10-01T12:00:00Z");
+
   it("parses standard title with 2-digit year", () => {
-    const result = parseDch4Title("DCH4 Trail# 2298 - 2/7/26 @ 2pm", 2026);
+    const result = parseDch4Title("DCH4 Trail# 2298 - 2/7/26 @ 2pm", febPub);
     expect(result).toEqual({
       runNumber: 2298,
       date: "2026-02-07",
@@ -16,8 +21,8 @@ describe("parseDch4Title", () => {
     });
   });
 
-  it("parses title without year (uses reference year)", () => {
-    const result = parseDch4Title("DCH4 Trail# 2299 - 2/14 @ 2pm", 2026);
+  it("parses title without year (infers from publish date)", () => {
+    const result = parseDch4Title("DCH4 Trail# 2299 - 2/14 @ 2pm", febPub);
     expect(result).toEqual({
       runNumber: 2299,
       date: "2026-02-14",
@@ -27,7 +32,7 @@ describe("parseDch4Title", () => {
   });
 
   it("parses title with theme suffix", () => {
-    const result = parseDch4Title("DCH4 Trail# 2224 - 2/17 @ 2pm - SWILL TEAM SIX!!", 2026);
+    const result = parseDch4Title("DCH4 Trail# 2224 - 2/17 @ 2pm - SWILL TEAM SIX!!", febPub);
     expect(result).toEqual({
       runNumber: 2224,
       date: "2026-02-17",
@@ -37,7 +42,7 @@ describe("parseDch4Title", () => {
   });
 
   it("parses title with 3pm summer time", () => {
-    const result = parseDch4Title("DCH4 Trail# 2243 - 8/24/24 @ 3pm", 2024);
+    const result = parseDch4Title("DCH4 Trail# 2243 - 8/24/24 @ 3pm", new Date("2024-08-01T12:00:00Z"));
     expect(result).toEqual({
       runNumber: 2243,
       date: "2024-08-24",
@@ -47,7 +52,7 @@ describe("parseDch4Title", () => {
   });
 
   it("parses title with 10am morning time", () => {
-    const result = parseDch4Title("DCH4 Trail# 1926 - 10/15 @ 10am", 2026);
+    const result = parseDch4Title("DCH4 Trail# 1926 - 10/15 @ 10am", octPub);
     expect(result).toEqual({
       runNumber: 1926,
       date: "2026-10-15",
@@ -56,9 +61,27 @@ describe("parseDch4Title", () => {
     });
   });
 
+  it("(#1074) a December run resurfacing in a Feb post resolves to the PRIOR December, not a future one", () => {
+    // The zombie: "DCH4 Trail# 2294 - 12/20 @ 5pm" posted 2026-02-22 was stamped
+    // 2026-12-20 (future) because the year defaulted to the current year. With
+    // publish-date inference it lands on 2025-12-20 (past), so it can't become a
+    // future zombie that outranks the real latest run (#2310).
+    const result = parseDch4Title("DCH4 Trail# 2294 - 12/20 @ 5pm", new Date("2026-02-22T12:00:00Z"));
+    expect(result).not.toBeNull();
+    expect(result!.runNumber).toBe(2294);
+    expect(result!.date).toBe("2025-12-20");
+  });
+
+  it("(#1074) a year-end run announced in late December rolls forward to January", () => {
+    // Closest-to-publish handles the rollover: a "1/4" run posted Dec 28 2026 is
+    // Jan 4 2027 (7 days later), not Jan 4 2026 (~358 days earlier).
+    const result = parseDch4Title("DCH4 Trail# 2400 - 1/4 @ 2pm", new Date("2026-12-28T12:00:00Z"));
+    expect(result!.date).toBe("2027-01-04");
+  });
+
   it("returns null for unparseable title", () => {
-    expect(parseDch4Title("Random post title", 2026)).toBeNull();
-    expect(parseDch4Title("Hash Trash Week 3", 2026)).toBeNull();
+    expect(parseDch4Title("Random post title", febPub)).toBeNull();
+    expect(parseDch4Title("Hash Trash Week 3", febPub)).toBeNull();
   });
 });
 

--- a/src/adapters/html-scraper/dch4.ts
+++ b/src/adapters/html-scraper/dch4.ts
@@ -6,6 +6,41 @@ import { fetchWordPressPosts } from "../wordpress-api";
 import { applyDateWindow } from "../utils";
 
 /**
+ * Infer the run year for a year-less DCH4 title from the post's publish date.
+ *
+ * DCH4 trail announcements are posted shortly before the run, so the run's
+ * M/D lands closest to the publish date. We pick the candidate year
+ * (pubY-1 / pubY / pubY+1) whose date is nearest the publish date, skipping
+ * rolled-over candidates (e.g. Feb 29 in a non-leap year). This is the fix for
+ * the #1074 zombie: an old December run that resurfaces in a later post was
+ * being stamped into a *future* December because the year defaulted to the
+ * current year. See reference_yearless_date_infer_closest_to_publish.
+ */
+export function inferDch4Year(month: number, day: number, publishDate: Date): number {
+  const pubMs = publishDate.getTime();
+  const pubY = publishDate.getUTCFullYear();
+  let best = pubY;
+  let bestDiff = Number.POSITIVE_INFINITY;
+  for (const y of [pubY - 1, pubY, pubY + 1]) {
+    const cand = new Date(Date.UTC(y, month - 1, day, 12, 0, 0));
+    // Skip rolled-over candidates (JS Date silently rolls invalid dates forward).
+    if (
+      cand.getUTCFullYear() !== y ||
+      cand.getUTCMonth() !== month - 1 ||
+      cand.getUTCDate() !== day
+    ) {
+      continue;
+    }
+    const diff = Math.abs(cand.getTime() - pubMs);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = y;
+    }
+  }
+  return best;
+}
+
+/**
  * Parse a DCH4 post title into structured fields.
  *
  * Standard format: "DCH4 Trail# 2299 - 2/14 @ 2pm"
@@ -13,8 +48,11 @@ import { applyDateWindow } from "../utils";
  *   "DCH4 Trail# 2298 - 2/7/26 @ 2pm"
  *   "DCH4 Trail# 2224 - 2/17 @ 2pm - SWILL TEAM SIX!!"
  *   "DCH4 Trail 1926: 10/15 10am MD Renaissance Festival"
+ *
+ * `publishDate` is the post's publish date (WordPress API `date`); year-less
+ * titles infer their year from it (see `inferDch4Year`).
  */
-export function parseDch4Title(title: string, referenceYear: number): {
+export function parseDch4Title(title: string, publishDate: Date): {
   runNumber?: number;
   date?: string;
   startTime?: string;
@@ -31,7 +69,7 @@ export function parseDch4Title(title: string, referenceYear: number): {
     const runNumber = parseInt(standard[1], 10);
     const month = parseInt(standard[2], 10);
     const day = parseInt(standard[3], 10);
-    let year = standard[4] ? parseInt(standard[4], 10) : referenceYear;
+    let year = standard[4] ? parseInt(standard[4], 10) : inferDch4Year(month, day, publishDate);
     if (year < 100) year += 2000;
 
     let hours = parseInt(standard[5], 10);
@@ -114,9 +152,9 @@ function processPost(
   bodyText: string,
   postUrl: string,
   baseUrl: string,
-  currentYear: number,
+  publishDate: Date,
 ): RawEventData | null {
-  const parsed = parseDch4Title(titleText, currentYear);
+  const parsed = parseDch4Title(titleText, publishDate);
   if (!parsed || !parsed.date) return null;
 
   const bodyFields = parseDch4Body(bodyText);
@@ -190,12 +228,15 @@ export class DCH4Adapter implements SourceAdapter {
     if (wpResult.error) return null;
 
     const events: RawEventData[] = [];
-    const currentYear = new Date().getFullYear();
 
     for (const post of wpResult.posts) {
       const $ = cheerio.load(post.content);
       const bodyText = $.text();
-      const event = processPost(post.title, bodyText, post.url, baseUrl, currentYear);
+      // Year-less titles infer their year from the post's publish date (#1074).
+      // Fall back to "now" if the API omitted/garbled the date.
+      const parsedDate = post.date ? new Date(post.date) : new Date();
+      const publishDate = Number.isNaN(parsedDate.getTime()) ? new Date() : parsedDate;
+      const event = processPost(post.title, bodyText, post.url, baseUrl, publishDate);
       if (event) events.push(event);
     }
 
@@ -239,7 +280,9 @@ export class DCH4Adapter implements SourceAdapter {
 
     const structureHash = generateStructureHash(html);
     const $ = cheerio.load(html);
-    const currentYear = new Date().getFullYear();
+    // HTML fallback exposes no per-post publish date; anchor year inference to
+    // "now". The WordPress API path (primary) carries real publish dates.
+    const publishDate = new Date();
 
     // Find all article post entries
     const articles = $("article.post, article.type-post, article[class*='post-'], .hentry").toArray();
@@ -255,7 +298,7 @@ export class DCH4Adapter implements SourceAdapter {
 
       const contentEl = article.find(".entry-content, .post-content").first();
       const bodyText = contentEl.text() || "";
-      const event = processPost(titleText, bodyText, postUrl, baseUrl, currentYear);
+      const event = processPost(titleText, bodyText, postUrl, baseUrl, publishDate);
       if (event) events.push(event);
     }
 

--- a/src/adapters/html-scraper/dch4.ts
+++ b/src/adapters/html-scraper/dch4.ts
@@ -69,7 +69,7 @@ export function parseDch4Title(title: string, publishDate: Date): {
     const runNumber = parseInt(standard[1], 10);
     const month = parseInt(standard[2], 10);
     const day = parseInt(standard[3], 10);
-    let year = standard[4] ? parseInt(standard[4], 10) : inferDch4Year(month, day, publishDate);
+    let year = standard[4] ? Number.parseInt(standard[4], 10) : inferDch4Year(month, day, publishDate);
     if (year < 100) year += 2000;
 
     let hours = parseInt(standard[5], 10);

--- a/src/adapters/html-scraper/eh3-edmonton.test.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.test.ts
@@ -243,6 +243,23 @@ describe("parseEh3EventBlock", () => {
       expect(result!.date).toBe("2026-03-13");
       expect(result!.hares).toBe("Lucky Diva");
     });
+
+    it("extracts hares from the 'Hostess and hare:' label (#1178)", () => {
+      // The live DivaH3 page (437) labels the hare row "Hostess and hare: …"
+      // rather than "Hare(s):" — verbatim from www.eh3.org/divah3/ run on
+      // Friday March 13, 2026. Without the hostess label the hare was dropped.
+      const lines = [
+        "Friday, March 13, 2026 – Divas jump into Spring a bit early",
+        "Location: 437 Butchart drive",
+        "Hostess and hare: Passion Pit",
+        "Time: Gather 6:30 pm. Stroll 7 pm. Run like a March hare if you wish.",
+      ];
+      const result = parseEh3EventBlock(lines, "divah3-eh3", "19:00");
+      expect(result).not.toBeNull();
+      expect(result!.title).toBe("Divas jump into Spring a bit early");
+      expect(result!.date).toBe("2026-03-13");
+      expect(result!.hares).toBe("Passion Pit");
+    });
   });
 
   describe("RASH (rash-eh3)", () => {

--- a/src/adapters/html-scraper/eh3-edmonton.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.ts
@@ -230,8 +230,10 @@ export function parseEh3EventBlock(
       }
     }
 
-    // Field extraction
-    const h = extractField(line, "Hares?", "Hare");
+    // Field extraction. DivaH3 (#1178) labels the hare row "Hostess and hare:"
+    // rather than "Hare(s):" — accept hostess/host variants so the hare isn't
+    // dropped. Order: try the explicit hare labels first, then the hostess forms.
+    const h = extractField(line, "Hares?", "Hare", "Hostess(?: and hare)?", "Host");
     if (h) { hares = h; continue; }
 
     // OSH3 (page 425) labels the meeting point "Address: …" rather than

--- a/src/adapters/html-scraper/generic-types.ts
+++ b/src/adapters/html-scraper/generic-types.ts
@@ -31,6 +31,7 @@ export interface GenericHtmlConfig {
   defaultKennelTag: string;
   dateLocale?: DateLocale;    // "en-US" | "en-GB" — defaults to "en-US"
   locationTruncateAfter?: "uk-postcode";  // truncate location at first UK postcode match
+  locationRequiresPostcode?: boolean;      // with locationTruncateAfter="uk-postcode": when NO postcode is present, clear the location (it's theme/CTA text, not a geocodable venue — BOGS col 3, #1259)
   locationOmitIfMatches?: string[];        // regex strings; trimmed location matching any pattern is dropped (TBA, "Contact X to set this run", etc.)
   defaultStartTime?: string;               // "HH:MM" fallback when page doesn't have per-event times
   defaultStartTimeByKennel?: Record<string, string>; // per-kennelTag "HH:MM" map; takes precedence over defaultStartTime when the row's kennelTag matches a key

--- a/src/adapters/html-scraper/generic.test.ts
+++ b/src/adapters/html-scraper/generic.test.ts
@@ -212,6 +212,37 @@ describe("parseEventRow", () => {
     expect(event?.location).toBe(fullLocation);
   });
 
+  // ── #1259: locationRequiresPostcode (BOGS theme/CTA leak) ──
+  describe("locationRequiresPostcode", () => {
+    const bogsConfig: GenericHtmlConfig = {
+      containerSelector: "table",
+      rowSelector: "tr",
+      columns: { date: "td:nth-child(1)", location: "td:nth-child(2)" },
+      defaultKennelTag: "bogs-h3",
+      dateLocale: "en-GB",
+      locationTruncateAfter: "uk-postcode",
+      locationRequiresPostcode: true,
+    };
+
+    function loc(text: string) {
+      const $ = cheerio.load(`<table><tr><td>25th June 2026</td><td>${text}</td></tr></table>`);
+      return parseEventRow($, $("tr").first(), bogsConfig, "https://example.com")?.location;
+    }
+
+    it("clears a no-postcode theme/CTA cell (null = explicit clear)", () => {
+      expect(loc("T.B.A. World Orienteering Day")).toBeNull();
+      expect(loc("World Brain Day Hare wanted")).toBeNull();
+      expect(loc("National Toilet Paper Day Hare wanted")).toBeNull();
+    });
+
+    it("keeps a real venue that carries a UK postcode (truncating trailing theme)", () => {
+      expect(loc("The Failand Inn, Failand BS8 3TU")).toBe("The Failand Inn, Failand BS8 3TU");
+      expect(loc("117 Old Park Road, Clevedon BS21 7EY. International No Diet Day")).toBe(
+        "117 Old Park Road, Clevedon BS21 7EY",
+      );
+    });
+  });
+
   it("uses defaultStartTime when no per-event time exists", () => {
     const html = `<table><tr><td>March 15, 2026</td></tr></table>`;
     const $t = cheerio.load(html);

--- a/src/adapters/html-scraper/generic.ts
+++ b/src/adapters/html-scraper/generic.ts
@@ -143,12 +143,19 @@ export function parseEventRow(
   const title = extractText($, $row, columns.title);
   const rawHares = extractText($, $row, columns.hares);
   const hares = rawHares && !CTA_HARES_RE.test(rawHares) ? rawHares : undefined;
-  let location = extractText($, $row, columns.location);
+  let location: string | null | undefined = extractText($, $row, columns.location);
   // UK postcode truncation: strip driving directions after postcode
   if (config.locationTruncateAfter === "uk-postcode" && location) {
     const postcodeMatch = UK_POSTCODE_RE.exec(location);
     if (postcodeMatch) {
       location = location.slice(0, postcodeMatch.index! + postcodeMatch[0].length).trim();
+    } else if (config.locationRequiresPostcode) {
+      // No postcode → the cell is theme/day-name/CTA text rather than a
+      // geocodable venue (e.g. BOGS col 3 "T.B.A. World Orienteering Day",
+      // "World Brain Day Hare wanted" — #1259). Real venues on these sources
+      // always carry a UK postcode, so clear it. `null` = explicit clear so a
+      // previously-stored venue is overwritten, not preserved.
+      location = null;
     }
   }
   // Drop placeholder/CTA location strings (e.g., "T.B.A.", "Contact X to set this run")

--- a/src/adapters/html-scraper/hkh3.test.ts
+++ b/src/adapters/html-scraper/hkh3.test.ts
@@ -40,6 +40,27 @@ describe("nextMondayOnOrAfter", () => {
     // 2026-04-30 (Thu) → 2026-05-04 (Mon)
     expect(nextMondayOnOrAfter(new Date(Date.UTC(2026, 3, 30)))).toBe("2026-05-04");
   });
+
+  // ── #1284: HK-timezone + 18:00 run-time awareness ──
+  it("(#1284) Monday before 18:00 HK → that Monday", () => {
+    // 09:00 UTC on Mon 2026-04-27 = 17:00 HK (run hasn't happened yet).
+    expect(nextMondayOnOrAfter(new Date(Date.UTC(2026, 3, 27, 9, 0)))).toBe("2026-04-27");
+  });
+
+  it("(#1284) Monday after 18:00 HK → next Monday (run already happened)", () => {
+    // 11:00 UTC on Mon 2026-04-27 = 19:00 HK — past the run, so roll forward.
+    expect(nextMondayOnOrAfter(new Date(Date.UTC(2026, 3, 27, 11, 0)))).toBe("2026-05-04");
+  });
+
+  it("(#1284) Monday exactly at 18:00 HK rolls forward", () => {
+    // 10:00 UTC on Mon 2026-04-27 = 18:00 HK (run start).
+    expect(nextMondayOnOrAfter(new Date(Date.UTC(2026, 3, 27, 10, 0)))).toBe("2026-05-04");
+  });
+
+  it("(#1284) Sunday-evening UTC that is already Monday in HK resolves to that HK Monday", () => {
+    // Sun 2026-05-03 17:00 UTC = Mon 2026-05-04 01:00 HK.
+    expect(nextMondayOnOrAfter(new Date(Date.UTC(2026, 4, 3, 17, 0)))).toBe("2026-05-04");
+  });
 });
 
 describe("parseHkh3Homepage", () => {

--- a/src/adapters/html-scraper/hkh3.ts
+++ b/src/adapters/html-scraper/hkh3.ts
@@ -35,25 +35,42 @@ import { generateStructureHash } from "@/pipeline/structure-hash";
 
 const KENNEL_TAG = "hkh3";
 const DEFAULT_START_TIME = "18:00";
+/** Hong Kong is UTC+8 year-round (no DST). */
+const HK_UTC_OFFSET_MS = 8 * 60 * 60 * 1000;
+/** The Monday run starts at 18:00 HK time. */
+const RUN_HOUR_HK = 18;
 
 /**
- * Compute the next Monday on-or-after `from` (UTC). If `from` is itself a
- * Monday, returns `from` — STATIC_SCHEDULE alignment relies on identical
- * Date selection so the two sources fingerprint to the same canonical event.
+ * Compute the upcoming Monday for the homepage's "Next H4 Run" block, resolved
+ * in **Hong Kong local time** (UTC+8). The kennel runs every Monday at 18:00 HK.
  *
- * Known edge case: a scrape that runs Monday evening after the 18:00 run will
- * still emit "today" rather than next Monday. The event becomes a (recently)
- * past event for ~6h until the next daily scrape rolls it forward. Acceptable
- * given the daily cadence; a clock-time check would couple the adapter to
- * server timezone semantics that aren't worth the complexity for this gap.
+ * Once the current Monday's 18:00 HK run has passed, we roll forward to the
+ * next Monday — so the scraped "Next" run never lands on an already-past
+ * Monday. This is the #1284 fix: previously a Monday-evening / mid-week scrape
+ * could stamp the run number onto a past Monday, and because the homepage's
+ * "Next H4 Run" block carries no explicit date, the same number ended up on two
+ * (or more) consecutive Mondays.
+ *
+ * STATIC_SCHEDULE alignment relies on this returning the same calendar Monday
+ * (HK wall-clock) the schedule generates, so the two sources fingerprint to the
+ * same canonical event.
+ *
+ * NOTE: a non-updating homepage (the run number stays stale for weeks) can
+ * still re-stamp the same number onto successive upcoming Mondays — that's a
+ * source-freshness limitation the adapter can't detect statelessly.
  */
 export function nextMondayOnOrAfter(from: Date): string {
-  const day = from.getUTCDay(); // 0 = Sun, 1 = Mon, ... 6 = Sat
-  const daysUntilMon = (1 - day + 7) % 7; // 0 if already Mon
+  // Shift into HK local time, then read the wall-clock via getUTC* accessors.
+  const hk = new Date(from.getTime() + HK_UTC_OFFSET_MS);
+  const day = hk.getUTCDay(); // 0 = Sun, 1 = Mon, ... 6 = Sat (HK weekday)
+  let daysUntilMon = (1 - day + 7) % 7; // 0 if HK-today is Monday
+  if (daysUntilMon === 0 && hk.getUTCHours() >= RUN_HOUR_HK) {
+    daysUntilMon = 7; // this Monday's 18:00 HK run already happened
+  }
   const mon = new Date(Date.UTC(
-    from.getUTCFullYear(),
-    from.getUTCMonth(),
-    from.getUTCDate() + daysUntilMon,
+    hk.getUTCFullYear(),
+    hk.getUTCMonth(),
+    hk.getUTCDate() + daysUntilMon,
   ));
   return `${mon.getUTCFullYear()}-${String(mon.getUTCMonth() + 1).padStart(2, "0")}-${String(mon.getUTCDate()).padStart(2, "0")}`;
 }

--- a/src/adapters/html-scraper/phuket-hhh.test.ts
+++ b/src/adapters/html-scraper/phuket-hhh.test.ts
@@ -155,7 +155,7 @@ describe("parsePhuketRow", () => {
     expect(event).toBeNull();
   });
 
-  it("handles TBC location", () => {
+  it("handles TBC location (#1240 — explicit clear via cleanLocationName)", () => {
     const cells = [
       "25 Apr 2026 @ 16:00 PM",
       "PHHH",
@@ -165,7 +165,50 @@ describe("parsePhuketRow", () => {
     ];
     const event = parsePhuketRow(cells, "saturday", DEFAULT_KENNEL_MAP, sourceUrl);
     expect(event).not.toBeNull();
-    expect(event!.location).toBeUndefined();
+    // null (not undefined) = explicit clear, so a previously-stored venue is
+    // overwritten when the source downgrades to "Location: Tbc".
+    expect(event!.location).toBeNull();
+  });
+
+  // ── #1240: live run 453/454 shapes (verified 2026-06-08) ──
+  it("(#1240) Tin Men run 453: first-line venue + delimited hares; CTA/bus → description", () => {
+    // Verbatim from www.phuket-hhh.com/hareline.php (run 453), <br> → \n.
+    const cells = [
+      "10 Jun 2026 @ 15:00 PM",
+      "Tinmen",
+      "453",
+      "WILMA\nFUNGUS\nINVISIBLE MAN\nTHUMB IN THE BUM (VH)",
+      [
+        "Patong area",
+        "OnOn: Round Tower (Wilma’s), Patong",
+        "More information and time schedules on: https://phuketh3.com/index.php",
+        "Bus: Bangtao 14:00  Kamala 14:30  Patong expat hotel 15:00",
+      ].join("\n"),
+    ];
+    const event = parsePhuketRow(cells, "tinmen", DEFAULT_KENNEL_MAP, sourceUrl);
+    expect(event).not.toBeNull();
+    expect(event!.kennelTags[0]).toBe("phuket-tinmen");
+    // Venue is just the first segment — no on-on/CTA/bus leakage.
+    expect(event!.location).toBe("Patong area");
+    expect(event!.location).not.toContain("OnOn");
+    expect(event!.location).not.toContain("Bus");
+    // Hares are delimited (sorted ascending), not run together.
+    expect(event!.hares).toBe("FUNGUS, INVISIBLE MAN, THUMB IN THE BUM (VH), WILMA");
+    expect(event!.description).toContain("OnOn: Round Tower");
+  });
+
+  it("(#1240) Tin Men run 454: 'Location: Tbc' clears; two hares stay delimited", () => {
+    const cells = [
+      "01 Jul 2026 @ 15:00 PM",
+      "Tinmen",
+      "454",
+      "B.C.\nBUTT-CYCLE",
+      "Location: Tbc",
+    ];
+    const event = parsePhuketRow(cells, "tinmen", DEFAULT_KENNEL_MAP, sourceUrl);
+    expect(event).not.toBeNull();
+    expect(event!.location).toBeNull();
+    expect(event!.hares).toBe("B.C., BUTT-CYCLE");
   });
 
   // ── #1327: Iron Pussy H3 — multi-row location cell mashing ──

--- a/src/adapters/html-scraper/phuket-hhh.ts
+++ b/src/adapters/html-scraper/phuket-hhh.ts
@@ -4,6 +4,7 @@ import { hasAnyErrors } from "../types";
 import {
   applyDateWindow,
   chronoParseDate,
+  cleanLocationName,
   CTA_EMBEDDED_PATTERNS,
   decodeEntities,
   fetchHTMLPage,
@@ -79,8 +80,10 @@ function splitCellSegments(raw: string): string[] {
 const PHUKET_DIRECTIONS_RE =
   /(?:Coming from|From the|Heading|Head toward|Turn (?:left|right)|Go past|Continue|Follow|The run|GPS\s*:)[\s\S]*/i;
 
-/** Placeholder-only venue values that should resolve to undefined location. */
-const PHUKET_PLACEHOLDER_VENUE_RE = /^(?:location:\s*tbc|tbc|tbd)$/i;
+/** The source occasionally labels the venue cell "Location: <venue>" — strip the
+ * leading label so the cleaner sees the bare venue (and so a "Location: Tbc"
+ * placeholder resolves to a clear, not a literal string). */
+const PHUKET_LOCATION_LABEL_RE = /^location\s*:\s*/i;
 
 /**
  * Hare-recruitment CTA the source drops into the HARES column when no hare has
@@ -114,17 +117,24 @@ function parsePhuketHares(cell: string | undefined): string | null | undefined {
   return normalizeHaresField([...real].sort((a, b) => a.localeCompare(b)).join(", ")) ?? null;
 }
 
-/** Location cell → venue (first <br>-segment, directions stripped) + description (remaining segments). */
+/** Location cell → venue (first <br>-segment, directions stripped) + description (remaining segments).
+ *  The venue is run through the shared `cleanLocationName` (#1240): it strips
+ *  CTA/URL/emoji residue and returns `null` for placeholder-only values
+ *  (TBC/TBD/"Location: Tbc"), which the merge pipeline treats as an explicit
+ *  clear. The remaining <br>-segments (OnOn / theme / bus schedule) go to the
+ *  description. */
 function parsePhuketLocationCell(cell: string | undefined): {
-  location?: string;
+  location?: string | null;
   description?: string;
 } {
   if (!cell) return {};
   const segments = splitCellSegments(cell);
   if (segments.length === 0) return {};
-  const venue = segments[0].replace(PHUKET_DIRECTIONS_RE, "").trim();
-  const location =
-    venue.length > 0 && !PHUKET_PLACEHOLDER_VENUE_RE.test(venue) ? venue : undefined;
+  const venueRaw = segments[0]
+    .replace(PHUKET_DIRECTIONS_RE, "")
+    .replace(PHUKET_LOCATION_LABEL_RE, "")
+    .trim();
+  const location = cleanLocationName(venueRaw);
   const rest = segments.slice(1).filter(Boolean);
   const description = rest.length > 0 ? rest.join("\n") : undefined;
   return { location, description };

--- a/src/adapters/html-scraper/sdh3.test.ts
+++ b/src/adapters/html-scraper/sdh3.test.ts
@@ -266,6 +266,28 @@ describe("parseEventFields", () => {
     expect(result.hares).toBe("Solo Runner");
   });
 
+  it("(#1069) extracts hare + multi-line Mexico address for the CLH3 Larrikins campout", () => {
+    // Verbatim from sdh3.com/hareline.shtml (Fri Jul 31, 2026), <br> → \n.
+    // Earlier this surfaced with no hares + a generic "CLH3 start location";
+    // the SDH3 hareline carries the real hare ("Larrikins MM") and a venue +
+    // multi-line foreign address that parseEventFields pulls through.
+    const text = [
+      "Larrikins Campout 2026 Mexican Mardi Gras",
+      "Hare(s): Larrikins MM",
+      "Address: Balneario Las Palmas",
+      "Carre. Libre Tijuana Km. 64 1/2, 22710 La Mision, B.C., Mexico",
+      "Map Link: https://maps.app.goo.gl/Nv5u9wpoDweA6nWJ7",
+      "Run Fee: $110",
+    ].join("\n");
+    const result = parseEventFields(text);
+    expect(result.hares).toBe("Larrikins MM");
+    expect(result.location).toBe("Balneario Las Palmas");
+    expect(result.locationStreet).toBe(
+      "Balneario Las Palmas, Carre. Libre Tijuana Km. 64 1/2, 22710 La Mision, B.C., Mexico",
+    );
+    expect(result.cost).toBe("$110");
+  });
+
   it("returns undefined for empty/no fields", () => {
     const result = parseEventFields("Just a title line with no labels");
     expect(result.hares).toBeUndefined();

--- a/src/adapters/html-scraper/sfh3.test.ts
+++ b/src/adapters/html-scraper/sfh3.test.ts
@@ -258,6 +258,33 @@ describe("parseHarelineRows", () => {
     expect(rows[2].kennelTag).toBe("Hand Pump Workday");
   });
 
+  it("(#1291) extracts the GPH3 trail name from unquoted class= attributes (live markup)", () => {
+    // The live sfh3.com/runs?kennels=all emits UNQUOTED class attributes
+    // (`<td class=kennel>`), verified 2026-06-08. The "What" column carries the
+    // trail name the kennels=all .ics SUMMARY strips — this is the title the
+    // higher-trust hareline source surfaces on the canonical event (#1291).
+    const html = `
+      <table><tbody>
+        <tr>
+          <td class=kennel>GPH3</td>
+          <td class=number><a href="/runs/6558">#1711</a></td>
+          <td class=time>Thu, Jun 11, 6:15 pm</td>
+          <td class=hare>Udder Moron</td>
+          <td class=location>San Francisco Lawn Bowling Club parking lot Golden Gate Park</td>
+          <td class=name>Just What You'd Expect From a Moron</td>
+        </tr>
+      </tbody></table>
+    `;
+    const rows = parseHarelineRows(html);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kennelTag: "GPH3",
+      runNumber: 1711,
+      title: "Just What You'd Expect From a Moron",
+      detailUrl: "/runs/6558",
+    });
+  });
+
   it("skips rows with fewer than 5 cells", () => {
     const html = `
       <table>


### PR DESCRIPTION
Quick-win bundle of 9 disjoint audit findings. Every named source was **live-verified** against production and every named event checked against the **prod DB** before and after. Reality diverged from several write-ups — findings below.

## Adapter / lib fixes

| Issue | Fix | Notes |
|---|---|---|
| #1178 DivaH3 | `eh3-edmonton.ts` hare matcher now accepts `Hostess and hare:` / `Host` | Real bug — hares were blank |
| #1240 Phuket | venue routed through shared `cleanLocationName` (+ `Location:` label strip) | Largely self-healed by #1327/#1410/#1411; hardened + live run 453/454 fixtures |
| #1069 CLH3 | fixture locking the campout hare (`Larrikins MM`) + multi-line Mexico address | Self-healed in prod; regression-locked |
| #1259 BOGS | opt-in `locationRequiresPostcode` on the generic adapter clears no-postcode theme/CTA cells | Real leak (9 events) |
| #1074 DCH4 | publish-date-anchored year inference (`inferDch4Year`, closest-to-publish) | Kills the future-zombie class |
| #1243 / #1284 HK H3 | HK-timezone + 18:00 run-time aware `nextMondayOnOrAfter` | Never stamps an already-past Monday |
| #1291 GPH3 | SFH3 HTML hareline trust 7→9 so its "What"-column trail names win | Same precedent as EBH3 #1031; the `.ics` SUMMARY strips trail names and GPH3 has no subsite |
| #1256 Køge | **no code change** — geocoder already resolves `Køge station`→Køge; event had null coords (Copenhagen centroid fallback) | Fixed via one-shot geocode backfill |

## One-shot scripts (run against prod this session — dry-run/`--apply`, re-runnable)

- `backfill-ch4dk-geocode-1256.ts` — geocoded 5 CH4-dk events; **#372 Køge station → 55.458, 12.186 (Køge ✓)**; sanity box refused a Norwich misgeocode + skipped TBA venues.
- `cleanup-dch4-zombies-1074.ts` — deleted the #2294 (Dec 20) zombie. (The "Dec 23" row from the issue is a **legitimate DCFMH3 "Super Cold Moon" full-moon co-host**, primary-owned by `dcfmh3` — correctly excluded.)
- `cleanup-hkh3-duplicate-mondays-1284.ts` — reset 6 Mondays carrying the stale #2969 to the generic placeholder.
- `cleanup-bogs-location-leak-1259.ts` — cleared 9 leaked theme/CTA `locationName`s.
- `patch-divah3-passion-pit-1178.ts` — patched the past Mar-13 event's hares to "Passion Pit".

## Known limitations (called out)

- **HK H3 stale source:** hkhash.com has shown the same `Run Number 2969` since ~May. The TZ fix stops past-Monday stamping, but a *non-updating* homepage can still re-stamp a stale number onto a future Monday (flagged by Codex adversarial review). A durable guard would need DB-aware adapter logic or merge/reconcile changes (`merge.ts` is off-limits, PR #2038) — deferred per the agreed scope (TZ anchor + cleanup).
- **GPH3** surfaces real trail names after the post-merge `npx prisma db seed` (applies the trust bump) + the next SFH3 scrape — the seed wasn't run from this worktree to avoid clobbering parallel sessions' `Source.config`.

## Verification
- `npx tsc --noEmit` clean; `npm run lint` 0 errors.
- `npm test`: all touched-adapter suites green. One **pre-existing, unrelated** failure (`atlanta-hash-board.test.ts`) — its fixture hardcodes March 2026 dates now aged out of the date window; that file is owned by another workstream and is not in this diff.
- `/codex:adversarial-review` + `/simplify` run pre-PR (HK limitation above is the one adversarial finding; diff otherwise clean).

Closes #1178
Closes #1240
Closes #1069
Closes #1259
Closes #1074
Closes #1243
Closes #1284
Closes #1291
Closes #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)