### PR TITLE
Coverage sweep: AH4 Wayback backfill + Giggity/LBH-PHX verification (4 issues)

### DIFF
--- a/scripts/backfill-ah4-wayback-history.test.ts
+++ b/scripts/backfill-ah4-wayback-history.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseViewtopicCdx,
+  waybackRawUrl,
+  extractTopicForumId,
+  extractTopicTitle,
+  hasExplicitEventDate,
+  buildAh4Event,
+} from "./backfill-ah4-wayback-history";
+
+const REF = new Date("2023-09-20T13:59:14+00:00");
+
+const CDX = [
+  // two captures of the same topic — the NEWER must win
+  "https://board.atlantahash.com/viewtopic.php?t=79 20240101000000 200",
+  "https://board.atlantahash.com/viewtopic.php?t=79&sid=abc 20251001120000 200",
+  "https://board.atlantahash.com/viewtopic.php?f=2&t=226 20250615000000 200",
+  // bare post permalinks (no t=) are dropped — they don't map to a topic opener
+  "https://board.atlantahash.com/viewtopic.php?p=332#p332 20250201000000 200",
+  "https://board.atlantahash.com/viewtopic.php?p=320 20250202000000 200",
+].join("\n");
+
+describe("parseViewtopicCdx", () => {
+  const snaps = parseViewtopicCdx(CDX);
+
+  it("collapses to one snapshot per distinct topic id, dropping p=-only rows", () => {
+    expect(snaps.map((s) => s.topicId)).toEqual(["79", "226"]);
+  });
+
+  it("keeps the newest capture per topic", () => {
+    const s79 = snaps.find((s) => s.topicId === "79")!;
+    expect(s79.timestamp).toBe("20251001120000");
+    expect(s79.original).toBe("https://board.atlantahash.com/viewtopic.php?t=79&sid=abc");
+  });
+});
+
+describe("waybackRawUrl", () => {
+  it("builds the id_ RAW (unrewritten) capture URL", () => {
+    expect(
+      waybackRawUrl("20251001120000", "https://board.atlantahash.com/viewtopic.php?t=79"),
+    ).toBe(
+      "https://web.archive.org/web/20251001120000id_/https://board.atlantahash.com/viewtopic.php?t=79",
+    );
+  });
+});
+
+/** Minimal phpBB topic page: breadcrumb microdata trail + jumpbox noise +
+ *  first post. `forumId` sets the deepest breadcrumb forum. */
+function topicHtml(opts: {
+  forumId: number;
+  title: string;
+  postId?: string;
+  datetime?: string;
+  body?: string;
+}): string {
+  const { forumId, title, postId = "120", datetime = "2023-09-20T13:59:14+00:00", body = "" } = opts;
+  return `<!DOCTYPE html><html><head><title>${title} - Atlanta Hash House Harriers</title></head><body>
+    <ul class="navbar">
+      <li><a itemprop="item" href="./index.php"><span itemprop="name">Board index</span></a></li>
+      <li><a itemprop="item" href="./viewforum.php?f=1&amp;sid=x"><span itemprop="name">Atlanta Area Hashes</span></a></li>
+      <li><a itemprop="item" href="./viewforum.php?f=${forumId}&amp;sid=x"><span itemprop="name">A Forum</span></a></li>
+    </ul>
+    <h2 class="topic-title"><a href="./viewtopic.php?t=99">${title}</a></h2>
+    <div id="p${postId}" class="post">
+      <div class="postbody">
+        <time datetime="${datetime}">then</time>
+        <div class="content">${body}</div>
+      </div>
+    </div>
+    <div class="jumpbox">
+      <a href="./viewforum.php?f=4&amp;sid=x" class="jumpbox-forum-link"><span>Pinelake Hash</span></a>
+      <a href="./viewforum.php?f=8&amp;sid=x" class="jumpbox-forum-link"><span>Moonlite</span></a>
+    </div>
+  </body></html>`;
+}
+
+describe("extractTopicForumId", () => {
+  it("reads the deepest breadcrumb forum, ignoring the jumpbox dropdown", () => {
+    expect(extractTopicForumId(topicHtml({ forumId: 2, title: "AH4 #2029" }))).toBe(2);
+    expect(extractTopicForumId(topicHtml({ forumId: 4, title: "Pinelake #1704" }))).toBe(4);
+  });
+
+  it("returns null when no breadcrumb forum link is present", () => {
+    expect(extractTopicForumId(`<div>no breadcrumbs here</div>`)).toBeNull();
+  });
+});
+
+describe("extractTopicTitle", () => {
+  it("reads the phpBB topic-title heading", () => {
+    expect(extractTopicTitle(topicHtml({ forumId: 2, title: "Saturday 9-23 AH4#2029 1:00 PM" }))).toBe(
+      "Saturday 9-23 AH4#2029 1:00 PM",
+    );
+  });
+});
+
+describe("hasExplicitEventDate", () => {
+  it("accepts a body 'Date:' line (step 1)", () => {
+    expect(hasExplicitEventDate("AH4 #2099", "Date: 09/23/2023\nKroger", REF)).toBe(true);
+  });
+
+  it("accepts a bare slash date in the body (step 1)", () => {
+    expect(hasExplicitEventDate("AH4 #2099", "meet at the usual 9/23/2023 spot", REF)).toBe(true);
+  });
+
+  it("accepts a date token in the title (step 2)", () => {
+    expect(hasExplicitEventDate("Saturday 9-23 AH4 #2099", "no date in body", REF)).toBe(true);
+  });
+
+  it("rejects a post with no date in title or body (would otherwise infer)", () => {
+    expect(hasExplicitEventDate("Cupid Undies Run", "On on at the usual spot. BYOB.", REF)).toBe(false);
+  });
+});
+
+describe("buildAh4Event", () => {
+  it("builds an AH4 event with the title run number, body date, and Atom-shape sourceUrl", () => {
+    const html = topicHtml({
+      forumId: 2,
+      title: "Start Info. Saturday AH4#2029 1:00 PM",
+      postId: "120",
+      body: "Date: 09/23/2023\nStart: Kroger 800 Glenwood Ave SE 30316\nTime: 1:00 PM\nHare: Hand-Tossed",
+    });
+    const ev = buildAh4Event(html);
+    expect(ev).not.toBeNull();
+    expect(ev!.date).toBe("2023-09-23");
+    expect(ev!.runNumber).toBe(2029);
+    expect(ev!.kennelTags).toEqual(["ah4"]);
+    expect(ev!.title).toBe("Start Info. Saturday AH4#2029 1:00 PM");
+    expect(ev!.sourceUrl).toBe("https://board.atlantahash.com/viewtopic.php?p=120#p120");
+  });
+
+  it("returns null for a non-AH4 (e.g. Pinelake f=4) topic", () => {
+    const html = topicHtml({
+      forumId: 4,
+      title: "Pinelake #1704",
+      body: "Date: 06/10/2023\nStart: Somewhere",
+    });
+    expect(buildAh4Event(html)).toBeNull();
+  });
+
+  it("returns null when the first post has no <time datetime> (refuse to fabricate a ref date)", () => {
+    const html = `<ul><li><a itemprop="item" href="./viewforum.php?f=2"><span itemprop="name">AH4</span></a></li></ul>
+      <h2 class="topic-title"><a>AH4 #2030</a></h2>
+      <div id="p1" class="post"><div class="content">Date: 10/07/2023</div></div>`;
+    expect(buildAh4Event(html)).toBeNull();
+  });
+
+  it("skips an AH4 post with a <time> but NO explicit date in title/body (no hash-day inference)", () => {
+    // Forum f=2, valid <time datetime>, but neither title nor body carries a
+    // date token — extractEventDate would otherwise infer "next Saturday after
+    // the post timestamp". The backfill must skip, not back-date (Codex review).
+    const html = topicHtml({
+      forumId: 2,
+      title: "AH4 #2099",
+      body: "On on at the usual spot. BYOB and bring $2 hash cash.",
+    });
+    expect(buildAh4Event(html)).toBeNull();
+  });
+});

--- a/scripts/backfill-ah4-wayback-history.ts
+++ b/scripts/backfill-ah4-wayback-history.ts
@@ -81,10 +81,13 @@ const BATCH_SIZE = 3;
 const POLITENESS_DELAY_MS = 600;
 const USER_AGENT = "Mozilla/5.0 (compatible; HashTracks-Backfill)";
 
+/** Resolve after `ms` milliseconds (politeness delay between Wayback hits). */
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** GET `url` via the SSRF-validated client, retrying 5xx/network errors with
+ *  backoff. Returns the body text, or null after `attempts` failures / on 4xx. */
 async function fetchText(url: string, attempts = 3): Promise<string | null> {
   for (let i = 0; i < attempts; i++) {
     try {
@@ -156,8 +159,8 @@ export function waybackRawUrl(timestamp: string, original: string): string {
  * `class="jumpbox-*"` and no `itemprop`, so it's excluded. Returns null when no
  * breadcrumb forum link is present. Exported for unit testing.
  */
-export function extractTopicForumId(html: string): number | null {
-  const $ = cheerio.load(html);
+export function extractTopicForumId(htmlOr$: string | cheerio.CheerioAPI): number | null {
+  const $ = typeof htmlOr$ === "string" ? cheerio.load(htmlOr$) : htmlOr$;
   let forumId: number | null = null;
   $('a[itemprop="item"]').each((_, el) => {
     const href = $(el).attr("href") ?? "";
@@ -167,9 +170,10 @@ export function extractTopicForumId(html: string): number | null {
   return forumId;
 }
 
-/** The topic title from the phpBB `<h2 class="topic-title">` heading. */
-export function extractTopicTitle(html: string): string | null {
-  const $ = cheerio.load(html);
+/** The topic title from the phpBB `<h2 class="topic-title">` heading. Accepts a
+ *  raw HTML string or an already-loaded Cheerio instance to avoid re-parsing. */
+export function extractTopicTitle(htmlOr$: string | cheerio.CheerioAPI): string | null {
+  const $ = typeof htmlOr$ === "string" ? cheerio.load(htmlOr$) : htmlOr$;
   const title =
     $("h2.topic-title a").first().text().trim() ||
     $("h2.topic-title").first().text().trim();
@@ -214,12 +218,17 @@ export function hasExplicitEventDate(title: string, body: string, refDate: Date)
  * Turn one archived AH4 topic page into a RawEventData, or null when it isn't
  * AH4, isn't a real topic, or has no EXPLICIT event date. The field-extraction
  * path mirrors the live forum-walker's `fetchTopicEvent` so backfill rows share
- * the recurring scrape's fingerprint surface.
+ * the recurring scrape's fingerprint surface. `preloaded$` lets `harvestTopic`
+ * reuse the page it already parsed for the forum check instead of re-loading.
  */
-export function buildAh4Event(html: string): RawEventData | null {
-  if (extractTopicForumId(html) !== AH4_FORUM_ID) return null;
+export function buildAh4Event(
+  html: string,
+  preloaded$?: cheerio.CheerioAPI,
+): RawEventData | null {
+  const $ = preloaded$ ?? cheerio.load(html);
+  if (extractTopicForumId($) !== AH4_FORUM_ID) return null;
 
-  const title = extractTopicTitle(html);
+  const title = extractTopicTitle($);
   if (!title || isReplyEntry(title)) return null;
 
   const bodyHtml = extractFirstPostHtml(html);
@@ -281,12 +290,14 @@ interface HarvestResult {
   event: RawEventData | null;
 }
 
+/** Fetch one archived topic and parse it. Parses the HTML ONCE and reuses that
+ *  Cheerio instance for the forum check + `buildAh4Event` (no redundant loads). */
 async function harvestTopic(snap: TopicSnapshot): Promise<HarvestResult> {
   const html = await fetchText(waybackRawUrl(snap.timestamp, snap.original));
   if (!html) return { isAh4: false, event: null };
-  const isAh4 = extractTopicForumId(html) === AH4_FORUM_ID;
-  if (!isAh4) return { isAh4: false, event: null };
-  return { isAh4: true, event: buildAh4Event(html) };
+  const $ = cheerio.load(html);
+  if (extractTopicForumId($) !== AH4_FORUM_ID) return { isAh4: false, event: null };
+  return { isAh4: true, event: buildAh4Event(html, $) };
 }
 
 interface HarvestSummary {
@@ -302,8 +313,14 @@ async function harvestAllTopics(snapshots: TopicSnapshot[]): Promise<HarvestSumm
   for (let i = 0; i < snapshots.length; i += BATCH_SIZE) {
     const batch = snapshots.slice(i, i + BATCH_SIZE);
     const results = await Promise.allSettled(batch.map(harvestTopic));
-    for (const r of results) {
-      if (r.status !== "fulfilled") continue;
+    for (let j = 0; j < results.length; j++) {
+      const r = results[j];
+      if (r.status === "rejected") {
+        // Surface transient fetch/parse crashes in the warning stream rather
+        // than silently undercounting (Gemini review).
+        console.warn(`  topic t=${batch[j].topicId}: harvest failed —`, r.reason);
+        continue;
+      }
       if (r.value.isAh4) ah4Topics++;
       if (r.value.event) events.push(r.value.event);
     }
@@ -321,6 +338,8 @@ function dumpEvents(events: RawEventData[]): void {
   }
 }
 
+/** Entry point handed to `runBackfillScript`: query CDX, harvest every AH4
+ *  topic, and return the explicit-date events for the merge pipeline. */
 async function fetchEvents(): Promise<RawEventData[]> {
   console.log("  Querying Wayback CDX for archived board.atlantahash.com topics...");
   const cdx = await fetchText(CDX_URL);

--- a/scripts/backfill-ah4-wayback-history.ts
+++ b/scripts/backfill-ah4-wayback-history.ts
@@ -202,11 +202,11 @@ export function hasExplicitEventDate(title: string, body: string, refDate: Date)
     }
   }
   // Step 2 — title date, after the same prefix/run-number stripping.
-  const normalized = title.replace(/·/g, "•");
+  const normalized = title.replaceAll("·", "•");
   const afterBullet = normalized.includes("•")
     ? normalized.split("•").pop()!.trim()
     : title;
-  const titleClean = afterBullet.replace(/#\d+/g, "").trim();
+  const titleClean = afterBullet.replaceAll(/#\d+/g, "").trim();
   return chronoParseDate(titleClean, "en-US", refDate, { forwardDate: true }) !== null;
 }
 
@@ -289,18 +289,14 @@ async function harvestTopic(snap: TopicSnapshot): Promise<HarvestResult> {
   return { isAh4: true, event: buildAh4Event(html) };
 }
 
-async function fetchEvents(): Promise<RawEventData[]> {
-  console.log("  Querying Wayback CDX for archived board.atlantahash.com topics...");
-  const cdx = await fetchText(CDX_URL);
-  if (!cdx) {
-    throw new Error("Wayback CDX query failed (no response after retries).");
-  }
-  const snapshots = parseViewtopicCdx(cdx);
-  console.log(
-    `  ${snapshots.length} distinct archived topic(s) across all forums — ` +
-      `filtering to AH4 (f=${AH4_FORUM_ID})...`,
-  );
+interface HarvestSummary {
+  events: RawEventData[];
+  /** Count of topics whose breadcrumb forum was AH4 (with or without a date). */
+  ah4Topics: number;
+}
 
+/** Fetch + parse every snapshot in politeness-delayed batches. */
+async function harvestAllTopics(snapshots: TopicSnapshot[]): Promise<HarvestSummary> {
   const events: RawEventData[] = [];
   let ah4Topics = 0;
   for (let i = 0; i < snapshots.length; i += BATCH_SIZE) {
@@ -313,17 +309,36 @@ async function fetchEvents(): Promise<RawEventData[]> {
     }
     await sleep(POLITENESS_DELAY_MS);
   }
+  return { events, ah4Topics };
+}
+
+/** BACKFILL_DUMP=1 prints every harvested row (date | #run | sourceUrl) — used
+ *  to diff a guarded run against what a prior run already wrote to prod. */
+function dumpEvents(events: RawEventData[]): void {
+  if (process.env.BACKFILL_DUMP !== "1") return;
+  for (const e of [...events].sort((a, b) => a.date.localeCompare(b.date))) {
+    console.log(`  DUMP ${e.date} | #${e.runNumber ?? "?"} | ${e.sourceUrl ?? "—"}`);
+  }
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log("  Querying Wayback CDX for archived board.atlantahash.com topics...");
+  const cdx = await fetchText(CDX_URL);
+  if (!cdx) {
+    throw new Error("Wayback CDX query failed (no response after retries).");
+  }
+  const snapshots = parseViewtopicCdx(cdx);
+  console.log(
+    `  ${snapshots.length} distinct archived topic(s) across all forums — ` +
+      `filtering to AH4 (f=${AH4_FORUM_ID})...`,
+  );
+
+  const { events, ah4Topics } = await harvestAllTopics(snapshots);
   console.log(
     `  ${ah4Topics} archived AH4 topic(s); recovered ${events.length} with an explicit body/title date ` +
       `(${ah4Topics - events.length} skipped — no explicit date / reply / no first post).`,
   );
-  // BACKFILL_DUMP=1 prints every harvested row (date | #run | sourceUrl) — used
-  // to diff a guarded run against what a prior run already wrote to prod.
-  if (process.env.BACKFILL_DUMP === "1") {
-    for (const e of [...events].sort((a, b) => a.date.localeCompare(b.date))) {
-      console.log(`  DUMP ${e.date} | #${e.runNumber ?? "?"} | ${e.sourceUrl ?? "—"}`);
-    }
-  }
+  dumpEvents(events);
   return events;
 }
 

--- a/scripts/backfill-ah4-wayback-history.ts
+++ b/scripts/backfill-ah4-wayback-history.ts
@@ -1,0 +1,340 @@
+/**
+ * AH4 (Atlanta H4, the original Saturday Atlanta kennel) historical backfill
+ * from the Internet Archive — issue #638.
+ *
+ * Context: the recurring `Atlanta Hash Board` HTML scraper read the phpBB forum
+ * at board.atlantahash.com (forum f=2 = "Atlanta Hash (Saturdays)" = AH4). That
+ * site went dark around 2025-10-16 (issue #633) — board.atlantahash.com AND
+ * atlantahash.com both time out, the Meetup group is dead, and HashRego carries
+ * only a profile + one 2026 weekend event. No live recurring source exists, so
+ * the only public trace of AH4's past trails is the Internet Archive, which
+ * individually crawled a subset of the board's `viewtopic.php` pages.
+ *
+ * This script harvests those archived topic pages:
+ *   1. Query the Wayback CDX API for every `board.atlantahash.com/viewtopic.php`
+ *      snapshot (HTTP 200 only). phpBB topic IDs are GLOBAL across all 9 forums,
+ *      so the CDX list mixes AH4 with Pinelake / Moonlite / etc.
+ *   2. Collapse to one capture per distinct topic id (`?t=<N>`), newest first.
+ *   3. Fetch each via the `…/web/<ts>id_/<url>` RAW form (`id_` returns the
+ *      UNREWRITTEN original HTML so the phpBB template parses cleanly).
+ *   4. Keep ONLY topics whose breadcrumb deepest forum is f=2 (AH4) — read from
+ *      the `<a itemprop="item" href="…viewforum.php?f=N">` microdata trail, NOT
+ *      the jumpbox dropdown (which lists every forum). This is how a Pinelake
+ *      topic (f=4) that happens to share the global id space is excluded.
+ *   5. Parse the first post with the SAME exported helpers the recurring adapter
+ *      + live forum-walker use (`extractEventDate` / `extractEventFields` /
+ *      `extractFirstPost*`), so backfill rows fingerprint-dedupe against any
+ *      future recurring scrape and the parser stays in lockstep. The event date
+ *      comes from the post body (NEVER the CDX crawl timestamp); rows with no
+ *      parseable date are skipped, never guessed.
+ *
+ * Yield: bounded by what the Archive crawled — far fewer than the ~94 live
+ * topics the board showed in Oct 2025 (Wayback snapshotted only page 1 of the
+ * index, twice, and a scattering of individual topics). This recovers whatever
+ * AH4 topic pages were archived; the remainder is gone with the site. Issue
+ * #633 (no live source) is documented separately and stays a follow-up.
+ *
+ * Bound to "Atlanta Hash Board" (the trust-7 HTML scraper the f=2 forum fed);
+ * `ah4` is already SourceKennel-linked, so the merge pipeline's source-kennel
+ * guard passes. `runBackfillScript` partitions to `date < today(America/
+ * New_York)` so a future live source (should the board return) still owns the
+ * forward window.
+ *
+ * Usage:
+ *   Dry run:   npx tsx scripts/backfill-ah4-wayback-history.ts
+ *   Apply:     BACKFILL_APPLY=1 npx tsx scripts/backfill-ah4-wayback-history.ts
+ *   Env:       DATABASE_URL
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import type { RawEventData } from "@/adapters/types";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { chronoParseDate, stripHtmlTags } from "@/adapters/utils";
+import {
+  extractEventDate,
+  extractEventFields,
+  isReplyEntry,
+} from "@/adapters/html-scraper/atlanta-hash-board";
+import {
+  extractFirstPostHtml,
+  extractFirstPostId,
+  extractFirstPostPublished,
+} from "@/lib/atlanta-forum-walker";
+import { runBackfillScript } from "./lib/backfill-runner";
+
+const SOURCE_NAME = "Atlanta Hash Board";
+const KENNEL_TAG = "ah4";
+const KENNEL_TIMEZONE = "America/New_York";
+const KENNEL_HASH_DAY = "Saturday";
+const ORIGIN = "https://board.atlantahash.com";
+/** phpBB forum id for "Atlanta Hash (Saturdays)" = AH4. */
+const AH4_FORUM_ID = 2;
+
+// Every 200 capture of every viewtopic page. No `collapse` here — we collapse
+// per-topic in parseViewtopicCdx (keeping the newest capture) ourselves.
+const CDX_URL =
+  "https://web.archive.org/cdx/search/cdx?url=board.atlantahash.com/viewtopic.php" +
+  "&matchType=prefix&output=text&fl=original,timestamp&filter=statuscode:200";
+
+const BATCH_SIZE = 3;
+const POLITENESS_DELAY_MS = 600;
+const USER_AGENT = "Mozilla/5.0 (compatible; HashTracks-Backfill)";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchText(url: string, attempts = 3): Promise<string | null> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      // safeFetch (not bare fetch) applies the repo's SSRF URL validation — the
+      // Wayback URLs are built from CDX response data, so route them through the
+      // sanctioned client (matches backfill-lbh-phx-history-completion.ts).
+      const res = await safeFetch(url, {
+        headers: { "User-Agent": USER_AGENT },
+        signal: AbortSignal.timeout(45_000),
+      });
+      if (res.ok) return await res.text();
+      // 4xx won't improve on retry; bail. 5xx (Wayback overload) → retry.
+      if (res.status < 500) return null;
+    } catch {
+      // network/timeout — fall through to retry
+    }
+    if (i < attempts - 1) await sleep(POLITENESS_DELAY_MS * (i + 1));
+  }
+  return null;
+}
+
+export interface TopicSnapshot {
+  topicId: string;
+  /** Newest archived 200-capture timestamp (YYYYMMDDhhmmss). */
+  timestamp: string;
+  /** Original board.atlantahash.com URL (used to build the `id_` raw URL). */
+  original: string;
+}
+
+/**
+ * Parse CDX text rows into one snapshot per distinct topic id (`?t=<N>`),
+ * carrying the NEWEST 200-capture. Rows without a `t=` parameter (bare `?p=`
+ * post permalinks, search links, etc.) are dropped — those don't map cleanly to
+ * a topic page and the `t=` captures already cover the topic openers. 14-digit
+ * Wayback timestamps sort lexicographically == chronologically, so a string
+ * compare picks the newest capture. Exported for unit testing.
+ */
+export function parseViewtopicCdx(cdxText: string): TopicSnapshot[] {
+  const byTopic = new Map<string, TopicSnapshot>();
+  for (const line of cdxText.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [original, timestamp] = trimmed.split(/\s+/);
+    if (!original || !timestamp) continue;
+    const topicMatch = /[?&]t=(\d+)/.exec(original);
+    if (!topicMatch) continue;
+    const topicId = topicMatch[1];
+    const existing = byTopic.get(topicId);
+    if (!existing || timestamp > existing.timestamp) {
+      byTopic.set(topicId, { topicId, timestamp, original });
+    }
+  }
+  // Stable ascending-by-id order so a re-run harvests in the same sequence.
+  return [...byTopic.values()].sort(
+    (a, b) => Number.parseInt(a.topicId, 10) - Number.parseInt(b.topicId, 10),
+  );
+}
+
+/** Build the Wayback `id_` RAW (unrewritten) URL for a capture. */
+export function waybackRawUrl(timestamp: string, original: string): string {
+  return `https://web.archive.org/web/${timestamp}id_/${original}`;
+}
+
+/**
+ * The topic's owning forum id, read from the deepest `<a itemprop="item">`
+ * breadcrumb link (phpBB renders `Board index ‹ Atlanta Area Hashes (f=1) ‹
+ * <Forum> (f=N)` as a microdata trail). The LAST such link is the topic's
+ * forum. The jumpbox dropdown also links every forum but uses
+ * `class="jumpbox-*"` and no `itemprop`, so it's excluded. Returns null when no
+ * breadcrumb forum link is present. Exported for unit testing.
+ */
+export function extractTopicForumId(html: string): number | null {
+  const $ = cheerio.load(html);
+  let forumId: number | null = null;
+  $('a[itemprop="item"]').each((_, el) => {
+    const href = $(el).attr("href") ?? "";
+    const m = /[?&]f=(\d+)/.exec(href);
+    if (m) forumId = Number.parseInt(m[1], 10);
+  });
+  return forumId;
+}
+
+/** The topic title from the phpBB `<h2 class="topic-title">` heading. */
+export function extractTopicTitle(html: string): string | null {
+  const $ = cheerio.load(html);
+  const title =
+    $("h2.topic-title a").first().text().trim() ||
+    $("h2.topic-title").first().text().trim();
+  return title || null;
+}
+
+/**
+ * True when the post carries an EXPLICIT event date that the shared
+ * `extractEventDate` would read from the body or title — i.e. NOT its
+ * hash-day inference fallback. This guard exists because the live recurring
+ * adapter deliberately infers "next Saturday after the post timestamp" for
+ * upcoming runs, but for a one-shot HISTORICAL import that inference would
+ * silently fabricate a date from the (crawl-time) post timestamp. We mirror
+ * `extractEventDate` steps 1-2 exactly — running the same `chronoParseDate`
+ * checks — so a date is accepted only when the same explicit branch the helper
+ * uses actually fires. Topics with only the inference fallback are skipped,
+ * never guessed.
+ */
+export function hasExplicitEventDate(title: string, body: string, refDate: Date): boolean {
+  // Step 1 — body "When/Date/Day:" line or a slash date, accepted only if
+  // chrono parses the captured value (matches extractEventDate's body loop).
+  const bodyPatterns = [
+    /(?:When|Date|Day)\s*:\s*([^\n<]*)(?:\n|<br|$)/i,
+    /(\d{1,2}\/\d{1,2}\/\d{2,4})/,
+  ];
+  for (const pattern of bodyPatterns) {
+    const match = pattern.exec(body);
+    if (match && chronoParseDate(match[1], "en-US", refDate, { forwardDate: true })) {
+      return true;
+    }
+  }
+  // Step 2 — title date, after the same prefix/run-number stripping.
+  const normalized = title.replace(/·/g, "•");
+  const afterBullet = normalized.includes("•")
+    ? normalized.split("•").pop()!.trim()
+    : title;
+  const titleClean = afterBullet.replace(/#\d+/g, "").trim();
+  return chronoParseDate(titleClean, "en-US", refDate, { forwardDate: true }) !== null;
+}
+
+/**
+ * Turn one archived AH4 topic page into a RawEventData, or null when it isn't
+ * AH4, isn't a real topic, or has no EXPLICIT event date. The field-extraction
+ * path mirrors the live forum-walker's `fetchTopicEvent` so backfill rows share
+ * the recurring scrape's fingerprint surface.
+ */
+export function buildAh4Event(html: string): RawEventData | null {
+  if (extractTopicForumId(html) !== AH4_FORUM_ID) return null;
+
+  const title = extractTopicTitle(html);
+  if (!title || isReplyEntry(title)) return null;
+
+  const bodyHtml = extractFirstPostHtml(html);
+  if (!bodyHtml) return null;
+
+  const published = extractFirstPostPublished(html);
+  if (!published) return null; // refuse to fabricate a reference date
+
+  // `stripHtmlTags(..., "\n")` — same as the live adapter — so the shared
+  // `extractEventFields` sees identical `\n`-delimited text and its label
+  // regexes (Hares:, Where:, Time:) keep matching.
+  const bodyText = stripHtmlTags(bodyHtml, "\n");
+
+  // Refuse the hash-day inference fallback: a historical import must skip a
+  // post that lacks an explicit date rather than back-date it to the Saturday
+  // after the crawl-time post timestamp (Codex adversarial review).
+  const refDate = new Date(published);
+  if (Number.isNaN(refDate.getTime())) return null;
+  if (!hasExplicitEventDate(title, bodyText, refDate)) return null;
+
+  const date = extractEventDate(title, bodyText, published, KENNEL_HASH_DAY);
+  if (!date) return null;
+
+  const $body = cheerio.load(bodyHtml);
+  const fields = extractEventFields(bodyHtml, bodyText, $body);
+
+  // Title-extracted run number takes precedence over body (matches the walker's
+  // #1587 ordering). Two-plus digits to avoid matching stray "#1" decorations.
+  const titleRunMatch = /#(\d{2,})/.exec(title);
+  const titleRunNumber = titleRunMatch
+    ? Number.parseInt(titleRunMatch[1], 10)
+    : undefined;
+
+  // Match the live adapter's Atom-feed sourceUrl shape so backfill rows
+  // fingerprint-dedupe against feed rows for any recent-past overlap window.
+  const postId = extractFirstPostId(html);
+  const sourceUrl = postId
+    ? `${ORIGIN}/viewtopic.php?p=${postId}#p${postId}`
+    : undefined;
+
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber: titleRunNumber ?? fields.runNumber,
+    title,
+    hares: fields.hares,
+    location: fields.location,
+    locationUrl: fields.locationUrl,
+    startTime: fields.startTime,
+    description: fields.description,
+    sourceUrl,
+  };
+}
+
+interface HarvestResult {
+  /** True when the topic's breadcrumb forum is AH4 (f=2). */
+  isAh4: boolean;
+  /** Parsed event, present only when the AH4 post had a parseable date. */
+  event: RawEventData | null;
+}
+
+async function harvestTopic(snap: TopicSnapshot): Promise<HarvestResult> {
+  const html = await fetchText(waybackRawUrl(snap.timestamp, snap.original));
+  if (!html) return { isAh4: false, event: null };
+  const isAh4 = extractTopicForumId(html) === AH4_FORUM_ID;
+  if (!isAh4) return { isAh4: false, event: null };
+  return { isAh4: true, event: buildAh4Event(html) };
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  console.log("  Querying Wayback CDX for archived board.atlantahash.com topics...");
+  const cdx = await fetchText(CDX_URL);
+  if (!cdx) {
+    throw new Error("Wayback CDX query failed (no response after retries).");
+  }
+  const snapshots = parseViewtopicCdx(cdx);
+  console.log(
+    `  ${snapshots.length} distinct archived topic(s) across all forums — ` +
+      `filtering to AH4 (f=${AH4_FORUM_ID})...`,
+  );
+
+  const events: RawEventData[] = [];
+  let ah4Topics = 0;
+  for (let i = 0; i < snapshots.length; i += BATCH_SIZE) {
+    const batch = snapshots.slice(i, i + BATCH_SIZE);
+    const results = await Promise.allSettled(batch.map(harvestTopic));
+    for (const r of results) {
+      if (r.status !== "fulfilled") continue;
+      if (r.value.isAh4) ah4Topics++;
+      if (r.value.event) events.push(r.value.event);
+    }
+    await sleep(POLITENESS_DELAY_MS);
+  }
+  console.log(
+    `  ${ah4Topics} archived AH4 topic(s); recovered ${events.length} with an explicit body/title date ` +
+      `(${ah4Topics - events.length} skipped — no explicit date / reply / no first post).`,
+  );
+  // BACKFILL_DUMP=1 prints every harvested row (date | #run | sourceUrl) — used
+  // to diff a guarded run against what a prior run already wrote to prod.
+  if (process.env.BACKFILL_DUMP === "1") {
+    for (const e of [...events].sort((a, b) => a.date.localeCompare(b.date))) {
+      console.log(`  DUMP ${e.date} | #${e.runNumber ?? "?"} | ${e.sourceUrl ?? "—"}`);
+    }
+  }
+  return events;
+}
+
+if (process.argv[1]?.endsWith("backfill-ah4-wayback-history.ts")) {
+  runBackfillScript({
+    sourceName: SOURCE_NAME,
+    kennelTimezone: KENNEL_TIMEZONE,
+    label: "Harvesting Wayback-archived AH4 forum topics (board.atlantahash.com is down)",
+    fetchEvents,
+  }).catch((err: unknown) => {
+    console.error("FAILED:", err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/scripts/cleanup-ah4-inferred-date-event.ts
+++ b/scripts/cleanup-ah4-inferred-date-event.ts
@@ -67,11 +67,22 @@ async function main() {
     return;
   }
 
-  const source = await prisma.source.findFirst({
+  // Resolve the source deterministically — `findFirst` could pick an arbitrary
+  // row if a legacy duplicate exists, weakening the provenance guard on this
+  // hard-delete. Require exactly one match (CodeRabbit review).
+  const sources = await prisma.source.findMany({
     where: { name: SOURCE_NAME },
     select: { id: true },
   });
-  if (!source) throw new Error(`Source "${SOURCE_NAME}" not found.`);
+  if (sources.length === 0) {
+    throw new Error(`Source "${SOURCE_NAME}" not found.`);
+  }
+  if (sources.length > 1) {
+    throw new Error(
+      `Multiple sources named "${SOURCE_NAME}" (${sources.length}) — aborting to avoid deleting against ambiguous provenance.`,
+    );
+  }
+  const source = sources[0];
 
   // requireZeroCounts guards user data (attendances); the Event's hares/raws
   // are hard-deleted. forbidForeignRawSourceId asserts only Atlanta Hash Board

--- a/scripts/cleanup-ah4-inferred-date-event.ts
+++ b/scripts/cleanup-ah4-inferred-date-event.ts
@@ -1,0 +1,93 @@
+/**
+ * One-shot cleanup for the single AH4 Event the FIRST apply of
+ * `scripts/backfill-ah4-wayback-history.ts` created with an INFERRED date.
+ *
+ * Background:
+ *   The first apply (14 rows) trusted `extractEventDate`, which falls back to
+ *   "next Saturday after the post timestamp" (`inferDateFromHashDay`) when a
+ *   post carries no explicit date. For a historical import that fabricates a
+ *   date from the crawl-time post stamp (Codex adversarial review). The script
+ *   now guards with `hasExplicitEventDate` and skips such rows, so a re-apply
+ *   yields 13. This removes the one already-written inferred row:
+ *
+ *     viewtopic.php?p=260#p260 — stored date 2024-02-10 (a back-dated guess).
+ *
+ * Safety:
+ *   HARD-deletes the Event AND its RawEvent (via {@link deleteLeakedEvent}) so
+ *   the inferred row can't be recreated by a stray re-merge of a `processed=
+ *   false` RawEvent. Refuses to proceed if the Event has any attendance data,
+ *   or if a RawEvent from a source other than "Atlanta Hash Board" is attached
+ *   (provenance guard). Idempotent — a no-op once the row is gone.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-ah4-inferred-date-event.ts
+ *   Apply:   CLEANUP_APPLY=1 npx tsx scripts/cleanup-ah4-inferred-date-event.ts
+ */
+
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { deleteLeakedEvent } from "./lib/delete-leaked-event";
+
+const SOURCE_NAME = "Atlanta Hash Board";
+const KENNEL_CODE = "ah4";
+const INFERRED_SOURCE_URL = "https://board.atlantahash.com/viewtopic.php?p=260#p260";
+
+async function main() {
+  const apply = process.env.CLEANUP_APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (will hard-delete)" : "DRY RUN (no writes)"}`);
+
+  const event = await prisma.event.findFirst({
+    where: {
+      sourceUrl: INFERRED_SOURCE_URL,
+      kennel: { kennelCode: KENNEL_CODE },
+    },
+    select: {
+      id: true,
+      date: true,
+      runNumber: true,
+      title: true,
+      _count: { select: { attendances: true, kennelAttendances: true } },
+    },
+  });
+
+  if (!event) {
+    console.log("No matching AH4 event found — already cleaned up. Nothing to do.");
+    return;
+  }
+
+  console.log(
+    `Target: ${event.id} | ${event.date.toISOString().slice(0, 10)} | #${event.runNumber ?? "?"} | ${event.title ?? "—"}`,
+  );
+  console.log(
+    `  attendances=${event._count.attendances} kennelAttendances=${event._count.kennelAttendances}`,
+  );
+
+  if (!apply) {
+    console.log("\nDry run complete. Re-run with CLEANUP_APPLY=1 to hard-delete.");
+    return;
+  }
+
+  const source = await prisma.source.findFirst({
+    where: { name: SOURCE_NAME },
+    select: { id: true },
+  });
+  if (!source) throw new Error(`Source "${SOURCE_NAME}" not found.`);
+
+  // requireZeroCounts guards user data (attendances); the Event's hares/raws
+  // are hard-deleted. forbidForeignRawSourceId asserts only Atlanta Hash Board
+  // raws are attached (provenance).
+  await deleteLeakedEvent(
+    prisma,
+    event.id,
+    ["attendances", "kennelAttendances"],
+    source.id,
+  );
+  console.log("Done.");
+}
+
+main()
+  .catch((err: unknown) => {
+    console.error("FAILED:", err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/adapters/html-scraper/atlanta-hash-board.test.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.test.ts
@@ -60,6 +60,63 @@ const SAMPLE_ATOM_FEED = `<?xml version="1.0" encoding="UTF-8"?>
   </entry>
 </feed>`;
 
+/**
+ * Build an Atom feed whose post dates are RECENT relative to the run, so the
+ * adapter's date-window filter (`buildDateWindow(days)`) never ages them out.
+ * The static `SAMPLE_ATOM_FEED` above pins absolute March-2026 dates — fine for
+ * the deterministic parse tests, but the window-filtered `fetch()` test must use
+ * dates relative to "now" or it goes red once wall-clock passes the 90-day mark
+ * (the fixtures silently aged out on 2026-06-08). Titles/bodies carry NO date
+ * token, so `extractEventDate` infers the next hash-day after the post date —
+ * always within the window.
+ */
+function isoDaysAgo(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString();
+}
+
+function buildRecentAtomFeed(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atlanta Hash Board - Atlanta Hash (Saturdays)</title>
+  <entry>
+    <title type="html"><![CDATA[Atlanta Hash (Saturdays) • Weekly Trail with Dr. PP & Big Bore]]></title>
+    <published>${isoDaysAgo(4)}</published>
+    <author><name><![CDATA[Headnurse]]></name></author>
+    <link href="https://board.atlantahash.com/viewtopic.php?p=1011#p1011"/>
+    <category term="Atlanta Hash (Saturdays)" label="Atlanta Hash (Saturdays)"/>
+    <content type="html"><![CDATA[
+      Hares: Dr PP &amp; Big Bore<br>
+      Start: Lake City, GA -- Parking lot off Main St<br>
+      Time: Gather 1:30 Hounds out at 2:00 PM<br>
+      Cost: $10 covers beer and food
+    ]]></content>
+  </entry>
+  <entry>
+    <title type="html"><![CDATA[Atlanta Hash (Saturdays) • Re: Last week's recap]]></title>
+    <published>${isoDaysAgo(5)}</published>
+    <author><name><![CDATA[SomeUser]]></name></author>
+    <link href="https://board.atlantahash.com/viewtopic.php?p=1010#p1010"/>
+    <category term="Atlanta Hash (Saturdays)" label="Atlanta Hash (Saturdays)"/>
+    <content type="html"><![CDATA[Great trail last week!]]></content>
+  </entry>
+  <entry>
+    <title type="html"><![CDATA[Moonlite H3 • Moonlite #1638 this week]]></title>
+    <published>${isoDaysAgo(4)}</published>
+    <author><name><![CDATA[LunarHare]]></name></author>
+    <link href="https://board.atlantahash.com/viewtopic.php?p=1012#p1012"/>
+    <category term="Moonlite H3" label="Moonlite H3"/>
+    <content type="html"><![CDATA[
+      Hares: Lunar Eclipse &amp; Stargazer<br>
+      Where: Piedmont Park, Atlanta<br>
+      Time: Meet at 6:30 PM, Trail at 7:00 PM<br>
+      Run #1638
+    ]]></content>
+  </entry>
+</feed>`;
+}
+
 // ── parseAtomFeed ──
 
 describe("parseAtomFeed", () => {
@@ -389,9 +446,11 @@ describe("AtlantaHashBoardAdapter", () => {
   });
 
   it("fetches and parses events from multiple forums", async () => {
+    // Recent (relative-to-now) post dates so the 90-day window filter doesn't
+    // age the fixtures out — see buildRecentAtomFeed.
     mockSafeFetch.mockResolvedValue(mockResponse({
       ok: true,
-      text: () => Promise.resolve(SAMPLE_ATOM_FEED),
+      text: () => Promise.resolve(buildRecentAtomFeed()),
     }));
 
     const adapter = new AtlantaHashBoardAdapter();


### PR DESCRIPTION
Quick-win coverage/backfill sweep across three piled-up historical-gap issues. Investigation found **two of the three already resolved** by prior cycles — the net-new code is the AH4 Wayback backfill.

## What changed (code)
- `scripts/backfill-ah4-wayback-history.ts` (+ test) — one-shot harvest of AH4 trails from the Internet Archive (`board.atlantahash.com` is dead). Wayback CDX → `id_` raw fetch → breadcrumb filter to phpBB forum f=2 → reuse the live forum-walker/adapter parsers → `runBackfillScript` (strict `date < today`). Guards against `extractEventDate`'s hash-day **inference** fallback (`hasExplicitEventDate`) so a historical import never back-dates a dateless post (Codex adversarial review).
- `scripts/cleanup-ah4-inferred-date-event.ts` — hard-deletes the one inferred row the first apply created ("Cupid Undies Run", 2024-02-10) before the guard was added.

## Per-issue outcomes (all verified against prod)
- **#638 AH4 historical gap** — no live source exists (board + atlantahash.com time out; Meetup dead; HashRego profile-only; FB group unusable). Recovered **13 archived AH4 trails** (2023-09 → 2025-08, #2029–#2320) from Wayback. AH4: 17 → **30 events**. Live-source follow-up: #2054.
- **#633 AH4 source down** — documented outage; source row **left enabled** (board has a long Wayback history, may return; auto-issue cooldown dampens alerts). Follow-up: #2054.
- **#1200 Giggity** — already backfilled by prior cycles (prod has **128 events, 2015→2027**, ≥ source's 126). Ran the prescribed wide one-shot rescrape (`backfill-gcal-history.ts --source "WA Hash Google Calendar"`, days=9999): recovered **0 additional Giggity** events, empirically confirming the window isn't the limiter — residual ≈ the separately-tracked same-day collision bug. (The wide pass also surfaced + I remediated 242 false-cancellations of pre-2022 `sh3-wa` events — restored, all older than the daily reconcile floor.)
- **#1595 LBH-PHX** — recoverable public history already in prod (**123 events back to #511/2021**); pre-2021 needs a WordPress admin export with no public path. Follow-up: #2053.

## Verification
- AH4 dry-run + apply against live Wayback; prod re-queried (AH4 30, Giggity 128, sh3-wa 1443 restored, lbh-phx 123).
- `npx tsc --noEmit`, `eslint`, `vitest run scripts/` all green (14 AH4 unit tests).
- `/codex:adversarial-review` (caught the inference-fallback bug, fixed) + `/simplify` (4 agents — code confirmed at right altitude).

Closes #638
Closes #633
Closes #1200
Closes #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)