### PR TITLE
test(adapters): de-bomb imminent hardcoded-fixture-date tests

### DIFF
--- a/src/adapters/html-scraper/dublin-hash.test.ts
+++ b/src/adapters/html-scraper/dublin-hash.test.ts
@@ -43,6 +43,29 @@ function mockFetchResponse(html: string) {
   } as Response);
 }
 
+// Build a date relative to "now" in both the parser's display format
+// ("D Month YYYY") and ISO ("YYYY-MM-DD"). The window-filter test below must
+// keep its "near-term" event inside buildDateWindow(90); pinning an absolute
+// date silently rots once the wall clock passes it (the same time-bomb that hit
+// atlanta-hash-board on 2026-06-08). Far-past/far-future rows can stay static —
+// 1990 and 2099 are outside ±90 days for any plausible run date.
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+function relativeDate(daysFromNow: number): { display: string; iso: string } {
+  const d = new Date();
+  d.setUTCHours(12, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + daysFromNow);
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return {
+    display: `${d.getUTCDate()} ${MONTH_NAMES[d.getUTCMonth()]} ${yyyy}`,
+    iso: `${yyyy}-${mm}-${dd}`,
+  };
+}
+
 describe("stripTruncatedPostalFragment", () => {
   it("strips trailing single-letter Dublin postal fragment", () => {
     expect(stripTruncatedPostalFragment("51 Bar, Haddington Rd, Dublin, D")).toBe(
@@ -265,7 +288,10 @@ describe("DublinHashAdapter", () => {
     });
 
     it("filters events outside the date window", async () => {
-      // Table with one far-future event (2099) and one near-term event (2026)
+      // Near-term date is relative to "now" so it never ages out of the
+      // ±90-day window (see relativeDate helper). Far-future (2099) and
+      // far-past (1990) rows stay static — always outside ±90 days.
+      const near = relativeDate(7);
       const html = `<html><body>
 <table>
   <tr><th>Day</th><th>Date</th><th>Time</th><th>Hash</th><th>Location</th><th>Hares</th><th>Notes</th></tr>
@@ -275,8 +301,8 @@ describe("DublinHashAdapter", () => {
     <td>Far Future Pub</td><td>FutureHare</td><td></td>
   </tr>
   <tr>
-    <td>Monday</td><td>16 March 2026</td><td>19:30</td>
-    <td><a href="/archive/2026-03-16-dublin-h3/">Dublin H3 #1668</a></td>
+    <td>Monday</td><td>${near.display}</td><td>19:30</td>
+    <td><a href="/archive/${near.iso}-dublin-h3/">Dublin H3 #1668</a></td>
     <td>Dalkey DART Station</td><td>Polly</td><td></td>
   </tr>
   <tr>
@@ -300,8 +326,8 @@ describe("DublinHashAdapter", () => {
       const pastEvent = result.events.find((e) => e.date === "1990-03-16");
       expect(pastEvent).toBeUndefined();
 
-      // Near-term event (2026) should be included
-      const currentEvent = result.events.find((e) => e.date === "2026-03-16");
+      // Near-term event should be included
+      const currentEvent = result.events.find((e) => e.date === near.iso);
       expect(currentEvent).toBeDefined();
       expect(currentEvent!.title).toBe("Dublin H3 #1668");
     });

--- a/src/adapters/html-scraper/sdh3.test.ts
+++ b/src/adapters/html-scraper/sdh3.test.ts
@@ -74,6 +74,37 @@ function mockFetchResponse(html: string, bytes?: Uint8Array) {
   mockedSafeFetch.mockResolvedValue(fakeResponse(html, bytes));
 }
 
+// Build a date relative to "now" in both the hareline display format
+// ("Weekday, Month D, YYYY") and ISO ("YYYY-MM-DD"). The date-window-filter
+// test must keep its "near-term" event inside buildDateWindow(90); pinning an
+// absolute date silently rots once the wall clock passes it (the time-bomb that
+// hit atlanta-hash-board on 2026-06-08). chrono parses the explicit numeric
+// date, so the weekday label is decorative — we still compute it correctly.
+const WEEKDAY_NAMES = [
+  "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+];
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+function relativeDate(daysFromNow: number): {
+  display: string;
+  iso: string;
+  compact: string;
+} {
+  const d = new Date();
+  d.setUTCHours(12, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + daysFromNow);
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return {
+    display: `${WEEKDAY_NAMES[d.getUTCDay()]}, ${MONTH_NAMES[d.getUTCMonth()]} ${d.getUTCDate()}, ${yyyy}`,
+    iso: `${yyyy}-${mm}-${dd}`,
+    compact: `${yyyy}${mm}${dd}`,
+  };
+}
+
 // ── Inline HTML fixtures ──
 
 const HARELINE_HTML = `<html><body>
@@ -542,7 +573,11 @@ describe("SDH3Adapter", () => {
     mockFetchResponse(HARELINE_HTML);
 
     const source = makeSource();
-    const result = await adapter.fetch(source, { days: 365 });
+    // All-time window: HARELINE_HTML carries fixed March-2026 dates (pinned by the
+    // parser-direct tests above), so a finite ±N-day window would age these out and
+    // redlight CI once the wall clock passes them. The window is incidental here —
+    // this test only asserts that parsing yields events.
+    const result = await adapter.fetch(source, { days: 36500 });
 
     expect(result.events.length).toBeGreaterThan(0);
     expect(result.structureHash).toBe("mock-hash-sdh3");
@@ -578,7 +613,9 @@ describe("SDH3Adapter", () => {
     } as Response);
 
     const source = makeSource();
-    const result = await adapter.fetch(source, { days: 365 });
+    // All-time window — see "fetches and parses hareline events": the fixture's
+    // fixed March-2026 dates must not age out of a finite window.
+    const result = await adapter.fetch(source, { days: 36500 });
     const sdh3Event = result.events.find((e) => e.kennelTags[0] === "sdh3");
     expect(sdh3Event?.description).toContain("🌮");
     expect(sdh3Event?.description).not.toContain("ðŸŒ®");
@@ -674,7 +711,9 @@ describe("SDH3Adapter", () => {
   });
 
   it("filters events by date window", async () => {
-    // Create events spanning a wide range — only those within the window should remain
+    // Near-term date is relative to "now" so it never ages out of the ±90-day
+    // window (see relativeDate helper). Far-future (2099) row stays static.
+    const near = relativeDate(7);
     const farFutureHareline = `<html><body>
 <dl>
   <dt class="hashEvent SDH3">
@@ -688,11 +727,11 @@ describe("SDH3Adapter", () => {
   </dt>
   <dt class="hashEvent SDH3">
     <span style="float:right;margin-right:5px;white-space:nowrap">
-      <a href="/e/event-20260320180000.shtml"><img src="/site_images/event.png"></a>
+      <a href="/e/event-${near.compact}180000.shtml"><img src="/site_images/event.png"></a>
       <a href="#">View Map</a>
     </span>
     <strong>San Diego H3</strong>
-    <span style="white-space:nowrap">Friday, March 20, 2026 6:00pm</span>
+    <span style="white-space:nowrap">${near.display} 6:00pm</span>
     <div><strong>Hare(s):</strong> Current Hare</div>
   </dt>
 </dl>
@@ -708,7 +747,7 @@ describe("SDH3Adapter", () => {
     expect(futureEvent).toBeUndefined();
 
     // Near-term event should be included
-    const currentEvent = result.events.find((e) => e.date === "2026-03-20");
+    const currentEvent = result.events.find((e) => e.date === near.iso);
     expect(currentEvent).toBeDefined();
   });
 });

--- a/src/adapters/html-scraper/squarespace-events.test.ts
+++ b/src/adapters/html-scraper/squarespace-events.test.ts
@@ -331,6 +331,18 @@ describe("SquarespaceEventsAdapter.fetch", () => {
   // history and any queued `mockResolvedValueOnce` responses.
   beforeEach(() => {
     vi.restoreAllMocks();
+    // Freeze "now" inside the fixtures' date span (2026-04-29 → 2026-07-10) so the
+    // adapter's ±days window (applyDateWindow) never ages the hardcoded fixture
+    // dates out and redlights CI — the same time-bomb that hit atlanta-hash-board
+    // on 2026-06-08. Every test here asserts events flow THROUGH the window (none
+    // test now-relative exclusion), so a fixed reference date is safe. Date-only
+    // faking keeps setTimeout real so the awaited fetch mocks still resolve.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("parses upcoming + past arrays into RawEvents", async () => {


### PR DESCRIPTION
## Summary

De-bombs the **imminent** sibling instances of the `atlanta-hash-board` time-bomb (fixed earlier in `53d19f11`): adapter `fetch()` tests that pin **absolute fixture dates** which age out of the adapter's relative `buildDateWindow`/`applyDateWindow` (±`days`) window, then assert events survive — redlighting CI for every PR once the wall clock passes them.

`atlanta-hash-board.test.ts` was already fixed; this PR handles the siblings detonating soonest.

## Changes

- **`dublin-hash.test.ts`** — the "filters events outside the date window" test pinned `16 March 2026` with `days:90` and asserted it was included (85 days old → fails ~June 14). Near-term row is now relative to `now` via a `relativeDate()` helper; the 2099/1990 rows stay static (always outside ±90).
- **`sdh3.test.ts`** — same ±90 bomb (`March 20, 2026` → ~June 18): made relative. Also widened the two `days:365` hareline fetch tests to an all-time window, since they reuse the date-pinned `HARELINE_HTML` parser fixture (which legitimately stays fixed for the parser-direct tests).
- **`squarespace-events.test.ts`** — densely coupled to fixed 2026 dates via `applyDateWindow`; froze the clock (Date-only) to `2026-06-01` in the fetch `describe`. No test there asserts now-relative exclusion, so a fixed reference date is safe and needs zero assertion changes. Date-only faking keeps `setTimeout` real so awaited fetch mocks still resolve.

## Verification

- All four files (incl. atlanta) pass now **and** with the clock advanced to `2027-06-09` — past every original detonation date.
- `npx tsc --noEmit` and `eslint` clean. Diff is test-only (3 files, +88/−11).

## Follow-up (not in this PR)

A clock-advanced sweep surfaced **~92 more tests across 32 adapter files** with the same pattern, detonating **2027–2028** (none imminent; meetup alone is 27). Catalogued with reproduction method and fix patterns in #2066 — left open intentionally as the backlog for that broader sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
