### PR TITLE
fix(gcal): C2H3 title from SUMMARY; suppress SH3 "#? (TBD)" placeholder

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1212,6 +1212,11 @@ export const SOURCES = [
         // slice misreads the UTC hour as local and trips event-improbable-time
         // on every Thursday run (#964 + 15 daily duplicates).
         timezone: "America/Chicago",
+        // #2046 — the SUMMARY is the title. Some C2H3 events pair a bare-code
+        // SUMMARY ("C2H3") with boilerplate marketing prose in DESCRIPTION;
+        // without this the generic description fallback surfaced that prose as
+        // the title.
+        summaryIsCanonicalTitle: true,
       },
       kennelCodes: ["c2h3"],
     },

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -19,9 +19,8 @@ import {
   splitTimedSummaryHareLocation,
   stripGluedDescriptionEcho,
   looksLikeHareName,
-  isThemelessPlaceholderTitle,
 } from "./adapter";
-import { compilePatterns } from "../utils";
+import { compilePatterns, isThemelessPlaceholderTitle } from "../utils";
 import type { RawEventData } from "../types";
 import { SOURCES } from "../../../prisma/seed-data/sources";
 
@@ -5532,6 +5531,9 @@ describe("summaryIsCanonicalTitle — title comes from SUMMARY, not DESCRIPTION 
 describe("isThemelessPlaceholderTitle (#2065)", () => {
   it.each([
     ["SH3 #? (TBD)", true],
+    // Separator before the placeholder theme (no paren) — must still be caught.
+    ["SH3 #? - TBD", true],
+    ["SH3 #?: TBD", true],
     ["SH3 #?", true],
     ["SH3 #? (TBA)", true],
     ["SH3 #? (Catholic School Girl)", false],

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -19,6 +19,7 @@ import {
   splitTimedSummaryHareLocation,
   stripGluedDescriptionEcho,
   looksLikeHareName,
+  isThemelessPlaceholderTitle,
 } from "./adapter";
 import { compilePatterns } from "../utils";
 import type { RawEventData } from "../types";
@@ -5477,5 +5478,92 @@ describe("DH4 hares survive the event-type strip (#2033 verdict B)", () => {
     );
     expect(result).not.toBeNull();
     expect(result!.hares).toBeUndefined();
+  });
+});
+
+// ── #2046 C2H3: summaryIsCanonicalTitle (title from SUMMARY, never description) ──
+
+describe("summaryIsCanonicalTitle — title comes from SUMMARY, not DESCRIPTION (#2046 C2H3)", () => {
+  const C2H3_BOILERPLATE =
+    "A fun way to get exercise, meet up with friends, and have some adult beverages and shenanigans.";
+
+  it("keeps the bare kennel-code SUMMARY instead of the boilerplate description", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "C2H3", description: C2H3_BOILERPLATE }),
+      { defaultKennelTag: "c2h3", summaryIsCanonicalTitle: true },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("C2H3");
+    expect(result!.title).not.toContain("A fun way");
+  });
+
+  it("regression: WITHOUT the flag the boilerplate description leaks as the title", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "C2H3", description: C2H3_BOILERPLATE }),
+      { defaultKennelTag: "c2h3" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toContain("A fun way");
+  });
+
+  it("leaves a real theme SUMMARY untouched under the flag", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "Cinco de Mayo May Trail", description: C2H3_BOILERPLATE }),
+      { defaultKennelTag: "c2h3", summaryIsCanonicalTitle: true },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Cinco de Mayo May Trail");
+  });
+
+  it("keeps a rich numbered SUMMARY (and its run number) under the flag", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "C2H3 - Trail #477", description: C2H3_BOILERPLATE }),
+      { defaultKennelTag: "c2h3", summaryIsCanonicalTitle: true },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toContain("Trail #477");
+    expect(result!.title).not.toContain("A fun way");
+    expect(result!.runNumber).toBe(477);
+  });
+});
+
+// ── #2065 SH3: themeless placeholder titles are nulled so a richer source wins ──
+
+describe("isThemelessPlaceholderTitle (#2065)", () => {
+  it.each([
+    ["SH3 #? (TBD)", true],
+    ["SH3 #?", true],
+    ["SH3 #? (TBA)", true],
+    ["SH3 #? (Catholic School Girl)", false],
+    ["NBH3/SH3 #?/#753 (Cross Dress Trail #25: Cunt and Cock Tease)", false],
+    // Real run number FIRST, placeholder last, no paren — must NOT be nulled.
+    ["SH3/NBH3 #753/#?", false],
+    ["TH3 #? (A Trail)", false],
+    ["SH3 #804 (OPERATION DICKCHEESE)", false],
+    ["Cinco de Mayo May Trail", false],
+  ])("%s → %s", (title, expected) => {
+    expect(isThemelessPlaceholderTitle(title)).toBe(expected);
+  });
+});
+
+describe("themeless placeholder titles are nulled in buildRawEventFromGCalItem (#2065 SH3)", () => {
+  it("nulls 'SH3 #? (TBD)' (title empty, runNumber cleared) so merge/secondary wins", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "SH3 #? (TBD)" }),
+      { defaultKennelTag: "sh3-wa" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title ?? "").toBe("");
+    expect(result!.runNumber).toBeNull();
+  });
+
+  it("does NOT null a real numbered event sharing the calendar (run number preserved)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "SH3 #804 (OPERATION DICKCHEESE)" }),
+      { defaultKennelTag: "sh3-wa" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("SH3 #804");
+    expect(result!.runNumber).toBe(804);
   });
 });

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -549,6 +549,50 @@ export function looksLikeHareName(text: string): boolean {
   return true;
 }
 
+/** The placeholder run token that follows a `#` marker: "?", "X"/"X?", or a
+ *  "TBD"/"TBA"/"TBC" word. Anchored at start (caller trims first) so there's no
+ *  `\s*`-adjacent alternation for Sonar S5852 to flag. */
+const PLACEHOLDER_RUN_TOKEN_RE = /^(?:X+\??|TB[ADC]|\?+)/i;
+/** Trailing "(...)" parenthetical, used as the theme slot of a title. Distinct
+ *  from TITLE_TRAILING_PAREN_RE (which requires non-empty `[^)]+`): here `[^)]*`
+ *  intentionally captures an empty "()" as an empty theme. */
+const TRAILING_PAREN_RE = /\(([^)]*)\)$/;
+
+/**
+ * #2065 — true when a title is a pure placeholder shell: it carries a
+ * placeholder run marker ("#?", "#TBD") AND its theme (the trailing
+ * parenthetical, else whatever follows the last `#` after stripping the
+ * placeholder run token) is empty or itself a placeholder. Used to null such
+ * titles so merge.ts synthesizes a default or a richer secondary source wins.
+ *
+ *   "SH3 #? (TBD)"                         → true   (theme "TBD" is a placeholder)
+ *   "SH3 #?"                               → true   (no theme)
+ *   "SH3 #? (Catholic School Girl)"        → false  (real theme)
+ *   "NBH3/SH3 #?/#753 (Cross Dress …)"     → false  (real theme)
+ *   "TH3 #? (A Trail)"                     → false  (non-placeholder theme; kept)
+ *
+ * ReDoS-safe: the parenthetical capture is a single negated class and the
+ * post-marker theme is sliced with lastIndexOf, not a `\s*`-adjacent alternation.
+ */
+export function isThemelessPlaceholderTitle(title: string): boolean {
+  const trimmed = title.trim();
+  if (!hasPlaceholderRunNumber(trimmed)) return false;
+  // A real "#NNN" anywhere means a co-host carries a genuine run number — keep it
+  // regardless of marker ordering ("SH3/NBH3 #753/#?" must NOT be nulled). Reuses
+  // the delimiter-guarded shared parser so "#30X?" stays a placeholder, not "30".
+  if (extractHashRunNumber(trimmed) !== undefined) return false;
+  const paren = TRAILING_PAREN_RE.exec(trimmed);
+  let theme: string;
+  if (paren) {
+    theme = paren[1].trim();
+  } else {
+    const hashIdx = trimmed.lastIndexOf("#");
+    const afterHash = hashIdx === -1 ? trimmed : trimmed.slice(hashIdx + 1);
+    theme = afterHash.replace(PLACEHOLDER_RUN_TOKEN_RE, "").trim();
+  }
+  return theme === "" || isPlaceholder(theme);
+}
+
 /**
  * A "this slot has no real value" token — used per-token inside a location
  * candidate. Deliberately NARROW (only vacancy markers), NOT the full
@@ -1095,6 +1139,18 @@ interface CalendarSourceConfig {
    * the only path to a usable title.
    */
   preferDefaultTitleOverDescription?: boolean;
+  /**
+   * When true, the calendar SUMMARY is the canonical title and the adapter
+   * NEVER falls back to the description for a title (#2046 C2H3). Some kennels
+   * put the bare kennel code in SUMMARY and boilerplate marketing prose in
+   * DESCRIPTION; the generic "summary == kennelTag → use description" fallback
+   * then surfaces the boilerplate. Setting this leaves the title as the
+   * stripped summary so merge.ts keeps it (or synthesizes "<Kennel> Trail #N"
+   * when it collapses to the bare code). Off by default — the description
+   * fallback is correct for the many calendars that genuinely encode the trail
+   * name there (4X2 H4 / Chicagoland).
+   */
+  summaryIsCanonicalTitle?: boolean;
 }
 
 /**
@@ -1571,7 +1627,12 @@ export function buildRawEventFromGCalItem(
   // When the flag is set AND a per-kennel `defaultTitles` (or generic
   // `defaultTitle`) is configured, skip the description fallback so the
   // existing defaultTitle path (line ~1311) wins instead.
-  if (titleMatchesKennelTag(title, kennelTag) && rawDescription) {
+  // `summaryIsCanonicalTitle` (#2046 C2H3): trust the SUMMARY and never derive
+  // a title from the description. C2H3's calendar pairs a bare-kennel-code
+  // SUMMARY ("C2H3") with boilerplate marketing prose in DESCRIPTION; both
+  // fallbacks below would otherwise surface that prose as the title.
+  const trustSummaryTitle = sourceConfig?.summaryIsCanonicalTitle === true;
+  if (!trustSummaryTitle && titleMatchesKennelTag(title, kennelTag) && rawDescription) {
     // Strict-boolean check on `preferDefaultTitleOverDescription`: the
     // config is hydrated from persisted JSON, where any truthy value
     // would otherwise opt in unintentionally (same convention as the
@@ -1588,7 +1649,7 @@ export function buildRawEventFromGCalItem(
   }
   // If title looks like a bare kennel code (2-10 alphanumeric chars, no spaces),
   // try extracting a better title from the description
-  if (/^[A-Za-z0-9]{2,10}$/.test(title) && rawDescription) {
+  if (!trustSummaryTitle && /^[A-Za-z0-9]{2,10}$/.test(title) && rawDescription) {
     const descTitle = titleFromDescription(rawDescription);
     if (descTitle) title = descTitle;
   }
@@ -1811,6 +1872,20 @@ export function buildRawEventFromGCalItem(
     for (const re of compiledTitleStripPatterns) {
       title = title.replace(re, "").trim();
     }
+  }
+
+  // #2065 SH3 — a placeholder-run-number title with no real theme ("SH3 #? (TBD)",
+  // or a bare "SH3 #?" left after a "(theme)" was extracted to hares above)
+  // carries zero information. Null it so the defaultTitle path below, merge.ts's
+  // "<Kennel> Trail #N" synthesis, or a richer secondary source (the SH3 hareline
+  // sheet's "#1011 Catholic School Girl") wins instead of a higher-trust
+  // placeholder. Runs AFTER hare/parenthetical extraction so the theme is
+  // preserved as hares when present; narrow by design — a placeholder marker that
+  // still wraps a real theme ("SH3 #? (Catholic School Girl)") or a co-host with a
+  // real number ("NBH3/SH3 #?/#753") is untouched. Empty title still reads as a
+  // shell for the all-day collapse (isPlaceholderShell), so dedup is unaffected.
+  if (promotedRunNumber === undefined && isThemelessPlaceholderTitle(title)) {
+    title = "";
   }
 
   // defaultTitle fallback runs last, after all branches that may reset title to kennelTag.

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, dedupeRepeatedDescription, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber, normalizeCostSigil, BARE_KENNEL_CODE_RE } from "../utils";
+import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, dedupeRepeatedDescription, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber, isThemelessPlaceholderTitle, normalizeCostSigil, BARE_KENNEL_CODE_RE } from "../utils";
 import { matchKennelPatterns, matchCompiledKennelPatterns, compileKennelPatterns, type KennelPattern, type CompiledKennelPattern } from "../kennel-patterns";
 import { LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 import { parseDMSFromLocation } from "@/lib/geo";
@@ -547,50 +547,6 @@ export function looksLikeHareName(text: string): boolean {
   if (isPlaceholder(t)) return false;
   if (BARE_KENNEL_CODE_RE.test(t)) return false;
   return true;
-}
-
-/** The placeholder run token that follows a `#` marker: "?", "X"/"X?", or a
- *  "TBD"/"TBA"/"TBC" word. Anchored at start (caller trims first) so there's no
- *  `\s*`-adjacent alternation for Sonar S5852 to flag. */
-const PLACEHOLDER_RUN_TOKEN_RE = /^(?:X+\??|TB[ADC]|\?+)/i;
-/** Trailing "(...)" parenthetical, used as the theme slot of a title. Distinct
- *  from TITLE_TRAILING_PAREN_RE (which requires non-empty `[^)]+`): here `[^)]*`
- *  intentionally captures an empty "()" as an empty theme. */
-const TRAILING_PAREN_RE = /\(([^)]*)\)$/;
-
-/**
- * #2065 — true when a title is a pure placeholder shell: it carries a
- * placeholder run marker ("#?", "#TBD") AND its theme (the trailing
- * parenthetical, else whatever follows the last `#` after stripping the
- * placeholder run token) is empty or itself a placeholder. Used to null such
- * titles so merge.ts synthesizes a default or a richer secondary source wins.
- *
- *   "SH3 #? (TBD)"                         → true   (theme "TBD" is a placeholder)
- *   "SH3 #?"                               → true   (no theme)
- *   "SH3 #? (Catholic School Girl)"        → false  (real theme)
- *   "NBH3/SH3 #?/#753 (Cross Dress …)"     → false  (real theme)
- *   "TH3 #? (A Trail)"                     → false  (non-placeholder theme; kept)
- *
- * ReDoS-safe: the parenthetical capture is a single negated class and the
- * post-marker theme is sliced with lastIndexOf, not a `\s*`-adjacent alternation.
- */
-export function isThemelessPlaceholderTitle(title: string): boolean {
-  const trimmed = title.trim();
-  if (!hasPlaceholderRunNumber(trimmed)) return false;
-  // A real "#NNN" anywhere means a co-host carries a genuine run number — keep it
-  // regardless of marker ordering ("SH3/NBH3 #753/#?" must NOT be nulled). Reuses
-  // the delimiter-guarded shared parser so "#30X?" stays a placeholder, not "30".
-  if (extractHashRunNumber(trimmed) !== undefined) return false;
-  const paren = TRAILING_PAREN_RE.exec(trimmed);
-  let theme: string;
-  if (paren) {
-    theme = paren[1].trim();
-  } else {
-    const hashIdx = trimmed.lastIndexOf("#");
-    const afterHash = hashIdx === -1 ? trimmed : trimmed.slice(hashIdx + 1);
-    theme = afterHash.replace(PLACEHOLDER_RUN_TOKEN_RE, "").trim();
-  }
-  return theme === "" || isPlaceholder(theme);
 }
 
 /**

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -872,7 +872,7 @@ const LEADING_CONNECTOR_RE = /^[\s:.\-–—/]+/;
 function trailingParenContent(s: string): string | null {
   if (!s.endsWith(")")) return null;
   const open = s.lastIndexOf("(", s.length - 1);
-  return open === -1 ? null : s.slice(open + 1, s.length - 1);
+  return open === -1 ? null : s.slice(open + 1, -1);
 }
 
 /**
@@ -900,12 +900,12 @@ export function isThemelessPlaceholderTitle(title: string): boolean {
   if (extractHashRunNumber(trimmed) !== undefined) return false;
   const paren = trailingParenContent(trimmed);
   let theme: string;
-  if (paren !== null) {
-    theme = paren;
-  } else {
+  if (paren === null) {
     const hashIdx = trimmed.lastIndexOf("#");
     const afterHash = hashIdx === -1 ? trimmed : trimmed.slice(hashIdx + 1);
     theme = afterHash.replace(LEADING_PLACEHOLDER_TOKEN_RE, "");
+  } else {
+    theme = paren;
   }
   theme = theme.replace(LEADING_CONNECTOR_RE, "").trim();
   return theme === "" || isPlaceholder(theme);

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -862,9 +862,18 @@ const LEADING_PLACEHOLDER_TOKEN_RE = /^(?:x{1,8}\?{0,3}|\?{1,4})/i;
 // Leading connector punctuation/whitespace left after the marker is stripped
 // (e.g. "? - TBD" → " - TBD" → "TBD"). Single char class — linear.
 const LEADING_CONNECTOR_RE = /^[\s:.\-–—/]+/;
-// Trailing "(...)" parenthetical theme slot; `[^)]*` intentionally also matches
-// an empty "()" as an empty theme.
-const TITLE_THEME_PAREN_RE = /\(([^)]*)\)$/;
+
+/**
+ * Content of a trailing "(...)" theme slot, or null when the title doesn't end
+ * in a parenthetical. Pure string ops (no regex) to avoid a Sonar S5852
+ * ReDoS false-positive on the equivalent `/\(([^)]*)\)$/`. An empty "()" yields
+ * an empty string (still a themeless slot).
+ */
+function trailingParenContent(s: string): string | null {
+  if (!s.endsWith(")")) return null;
+  const open = s.lastIndexOf("(", s.length - 1);
+  return open === -1 ? null : s.slice(open + 1, s.length - 1);
+}
 
 /**
  * True when a title is a pure placeholder shell: it carries a placeholder run
@@ -889,10 +898,10 @@ export function isThemelessPlaceholderTitle(title: string): boolean {
   // regardless of marker ordering. Reuses the delimiter-guarded shared parser so
   // an ambiguous "#30X?" stays a placeholder, not "30".
   if (extractHashRunNumber(trimmed) !== undefined) return false;
-  const paren = TITLE_THEME_PAREN_RE.exec(trimmed);
+  const paren = trailingParenContent(trimmed);
   let theme: string;
-  if (paren) {
-    theme = paren[1];
+  if (paren !== null) {
+    theme = paren;
   } else {
     const hashIdx = trimmed.lastIndexOf("#");
     const afterHash = hashIdx === -1 ? trimmed : trimmed.slice(hashIdx + 1);

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -853,6 +853,55 @@ export function isPlaceholder(value: string): boolean {
   return isPlaceholderText(value.trim());
 }
 
+// Placeholder run token immediately after a "#" marker — the non-word markers:
+// a bounded run of "X" (optionally with a trailing "?"), or a bounded run of
+// "?". Bounded quantifiers keep it linear (no Sonar S5852 ReDoS shape). The
+// "TBD"/"TBA"/"TBC" word markers don't need stripping here — isPlaceholder
+// catches them on the residual theme.
+const LEADING_PLACEHOLDER_TOKEN_RE = /^(?:x{1,8}\?{0,3}|\?{1,4})/i;
+// Leading connector punctuation/whitespace left after the marker is stripped
+// (e.g. "? - TBD" → " - TBD" → "TBD"). Single char class — linear.
+const LEADING_CONNECTOR_RE = /^[\s:.\-–—/]+/;
+// Trailing "(...)" parenthetical theme slot; `[^)]*` intentionally also matches
+// an empty "()" as an empty theme.
+const TITLE_THEME_PAREN_RE = /\(([^)]*)\)$/;
+
+/**
+ * True when a title is a pure placeholder shell: it carries a placeholder run
+ * marker ("#?", "#TBD") AND its theme (the trailing parenthetical, else whatever
+ * follows the last "#" after stripping the placeholder token + leading
+ * connectors) is empty or itself a placeholder. Used to null such titles so the
+ * merge pipeline synthesizes a "<Kennel> Trail #N" default or a richer secondary
+ * source wins (#2065).
+ *
+ *   "SH3 #? (TBD)"  / "SH3 #? - TBD" / "SH3 #?: TBD" / "SH3 #?"  → true
+ *   "SH3 #? (Catholic School Girl)"                              → false (real theme)
+ *   "NBH3/SH3 #?/#753 (…)"  / "SH3/NBH3 #753/#?"                 → false (real run #)
+ *   "TH3 #? (A Trail)"                                           → false (non-placeholder theme)
+ *
+ * ReDoS-safe: bounded/char-class regexes only; the post-marker theme is sliced
+ * with lastIndexOf, not a `\s*`-adjacent alternation.
+ */
+export function isThemelessPlaceholderTitle(title: string): boolean {
+  const trimmed = title.trim();
+  if (!hasPlaceholderRunNumber(trimmed)) return false;
+  // A real "#NNN" anywhere means a co-host carries a genuine run number — keep it
+  // regardless of marker ordering. Reuses the delimiter-guarded shared parser so
+  // an ambiguous "#30X?" stays a placeholder, not "30".
+  if (extractHashRunNumber(trimmed) !== undefined) return false;
+  const paren = TITLE_THEME_PAREN_RE.exec(trimmed);
+  let theme: string;
+  if (paren) {
+    theme = paren[1];
+  } else {
+    const hashIdx = trimmed.lastIndexOf("#");
+    const afterHash = hashIdx === -1 ? trimmed : trimmed.slice(hashIdx + 1);
+    theme = afterHash.replace(LEADING_PLACEHOLDER_TOKEN_RE, "");
+  }
+  theme = theme.replace(LEADING_CONNECTOR_RE, "").trim();
+  return theme === "" || isPlaceholder(theme);
+}
+
 /**
  * Read a string field off a Source's JSON `config`, falling back to the
  * provided default if the field is missing, non-string, or the config

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -49,7 +49,7 @@ import { prisma } from "@/lib/db";
 import { Prisma } from "@/generated/prisma/client";
 import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag } from "./kennel-resolver";
-import { processRawEvents, sanitizeTitle, sanitizeLocation, sanitizeHares, friendlyKennelName, rewriteStaleDefaultTitle, suppressRedundantCity, NON_ENGLISH_GEO_RE, completenessScore, pickCanonicalEventId, pickCanonicalEventIds, isAdminLocked } from "./merge";
+import { processRawEvents, sanitizeTitle, sanitizeLocation, sanitizeHares, friendlyKennelName, rewriteStaleDefaultTitle, resolveUpdatedTitle, suppressRedundantCity, NON_ENGLISH_GEO_RE, completenessScore, pickCanonicalEventId, pickCanonicalEventIds, isAdminLocked } from "./merge";
 
 const mockSourceFind = vi.mocked(prisma.source.findUnique);
 const _mockSourceUpdate = vi.mocked(prisma.source.update);
@@ -3020,6 +3020,35 @@ describe("rewriteStaleDefaultTitle", () => {
       expect(rewriteStaleDefaultTitle("KWH3 Trail", "kwh3", "Key West H3", "Key West Hash House Harriers"))
         .toBe("Key West H3 Trail");
     });
+  });
+});
+
+// ── resolveUpdatedTitle (#2065 — heal stale placeholder titles on update) ──
+
+describe("resolveUpdatedTitle", () => {
+  const sh3 = { kennelCode: "sh3-wa", shortName: "SH3", fullName: "Seattle Hash House Harriers", aliases: [] };
+
+  it("re-synthesizes the default when incoming is empty and existing is a stale placeholder", () => {
+    // The #2065 adapter clears "SH3 #? (TBD)" to "". On update the old logic
+    // preserved the stale placeholder via `?? existingEvent.title`; now it heals.
+    expect(resolveUpdatedTitle("", "SH3 #? (TBD)", sh3, null, "sh3-wa")).toBe("Seattle H3 Trail");
+    expect(resolveUpdatedTitle("", "SH3 #? (TBD)", sh3, 1011, "sh3-wa")).toBe("Seattle H3 Trail #1011");
+  });
+
+  it("preserves a real existing title when incoming is empty", () => {
+    expect(resolveUpdatedTitle("", "Catholic School Girl", sh3, 1011, "sh3-wa")).toBe("Catholic School Girl");
+  });
+
+  it("uses a real incoming title over the existing one", () => {
+    expect(resolveUpdatedTitle("Operation Dickcheese", "SH3 #? (TBD)", sh3, null, "sh3-wa")).toBe("Operation Dickcheese");
+  });
+
+  it("rewrites a stale kennelCode prefix on the incoming title", () => {
+    expect(resolveUpdatedTitle("sh3-wa Trail #5", null, sh3, 5, "sh3-wa")).toBe("Seattle H3 Trail #5");
+  });
+
+  it("synthesizes when both incoming and existing are absent", () => {
+    expect(resolveUpdatedTitle(undefined, null, sh3, 7, "sh3-wa")).toBe("Seattle H3 Trail #7");
   });
 });
 

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -8,7 +8,7 @@ import { composeUtcStart } from "@/lib/timezone";
 import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag, resolveKennelTags, clearResolverCache } from "./kennel-resolver";
 import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseGeocode, haversineDistance, parseDMSFromLocation, stripDMSFromLocation } from "@/lib/geo";
-import { isPlaceholder, decodeEntities, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "@/adapters/utils";
+import { isPlaceholder, isThemelessPlaceholderTitle, decodeEntities, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "@/adapters/utils";
 import { LOCATION_EMAIL_CTA_RE } from "./audit-checks";
 import { levenshtein } from "@/lib/fuzzy";
 import { createEventWithKennel } from "@/lib/event-write";
@@ -936,6 +936,42 @@ export function sanitizeTitle(title: string | undefined): string | null {
   return cleaned || null;
 }
 
+/** Minimal kennel display fields needed to synthesize a default title. */
+interface TitleKennelData {
+  kennelCode: string;
+  shortName: string;
+  fullName: string | null;
+  aliases: string[];
+}
+
+/**
+ * Resolve the title to write when updating an existing canonical Event.
+ *
+ * Priority: (1) a real incoming title; (2) the existing title — UNLESS it's a
+ * stale placeholder shell ("SH3 #? (TBD)") that a pre-#2065 scrape persisted, in
+ * which case we (3) re-synthesize the "<Kennel> Trail #N" default. Without (3) an
+ * incoming empty title (the #2065 adapter clears placeholder titles to "") would
+ * fall back to `existingEvent.title` and the stale placeholder would stick
+ * forever, since the lower-trust enrichment branch never backfills titles.
+ */
+export function resolveUpdatedTitle(
+  incomingTitle: string | undefined,
+  existingTitle: string | null,
+  kennelData: TitleKennelData,
+  runNumber: number | null | undefined,
+  fallbackTag: string,
+): string {
+  const incoming = sanitizeTitle(incomingTitle);
+  if (incoming) {
+    return rewriteStaleDefaultTitle(incoming, kennelData.kennelCode, kennelData.shortName, kennelData.fullName, kennelData.aliases);
+  }
+  if (existingTitle && !isThemelessPlaceholderTitle(existingTitle)) {
+    return rewriteStaleDefaultTitle(existingTitle, kennelData.kennelCode, kennelData.shortName, kennelData.fullName, kennelData.aliases);
+  }
+  const displayName = friendlyKennelName(kennelData.shortName, kennelData.fullName) || fallbackTag;
+  return runNumber ? `${displayName} Trail #${runNumber}` : `${displayName} Trail`;
+}
+
 /** Abbreviation map for address normalization (used by deduplicateAddressPrefix). */
 /** Pre-compiled address abbreviation patterns (avoids RegExp allocation per call). */
 const ADDR_PATTERNS = Object.entries({
@@ -1554,10 +1590,13 @@ async function upsertCanonicalEvent(
           ...(event.runNumber !== undefined
             ? { runNumber: event.runNumber }
             : {}),
-          title: (() => {
-            const nextTitle = sanitizeTitle(event.title) ?? existingEvent.title;
-            return nextTitle ? rewriteStaleDefaultTitle(nextTitle, kennelData.kennelCode, kennelData.shortName, kennelData.fullName, kennelData.aliases) : nextTitle;
-          })(),
+          title: resolveUpdatedTitle(
+            event.title,
+            existingEvent.title,
+            kennelData,
+            event.runNumber,
+            event.kennelTags[0],
+          ),
           // Preserve existing fields when source doesn't provide them (undefined)
           ...(event.description !== undefined
             ? { description: event.description ?? null }


### PR DESCRIPTION
## Summary

Two `GOOGLE_CALENDAR` title/source-mismatch audit findings, both rooted in the **Google Calendar adapter's title resolution** (one was mis-attributed to GOOGLE_SHEETS).

### #2046 — C2H3 (Corpus Christi)
The calendar pairs a bare-code `SUMMARY` (`"C2H3"`) with boilerplate marketing prose in `DESCRIPTION`. Because the summary normalizes to the kennelTag, the adapter fell back to the **description** for the title, surfacing the boilerplate.

**Fix:** a new opt-in `summaryIsCanonicalTitle` config flag that gates **both** description-title fallbacks in `buildRawEventFromGCalItem`; set on the C2H3 source. Title now comes from the SUMMARY (`"C2H3"` → merge keeps it; rich summaries like `Cinco de Mayo May Trail` are untouched). Off by default, so the ~200 calendars that legitimately encode the trail name in the description are unaffected.

### #2065 — Seattle H3 (`sh3-wa`)
SH3 is fed by the shared **WA Hash calendar** (trust 7) and the secondary **Seattle Hareline Sheet** (trust 5). For `2026-06-13` the calendar `SUMMARY` is a placeholder `"SH3 #? (TBD)"` while the sheet has the real `#1011 / "Catholic School Girl"`. The higher-trust placeholder won the merge and `sanitizeTitle` doesn't strip it, so the sheet's real title couldn't fill the (non-null) canonical title.

**Fix:** null "themeless placeholder" titles (placeholder run marker + empty/placeholder theme, **and** no real `#NNN` anywhere) so `merge.ts` synthesizes `<Kennel> Trail #N` or the richer secondary source wins. Narrow by design — real themes, and co-hosts carrying a real number (`SH3/NBH3 #753/#?`), are untouched. The null runs **after** hare extraction so a real `(theme)` survives as hares, and an empty title still reads as a shell for the all-day collapse (`isPlaceholderShell`), so dedup is unaffected. Verified via `merge.ts` that a higher-trust source whose title sanitizes to null never clobbers the sheet's real title.

## Verification
- **Live** (both calendars + the sheet): C2H3 no longer leaks boilerplate (101 events); **zero** SH3 `#?/TBD` titles remain (161 events); the `2026-06-13` SH3 event is nulled (`title:"", run:null`) so the sheet's `#1011 / Catholic School Girl` can win.
- `npm run lint` (0 errors), `npx tsc --noEmit`, `npm test` (8815 passed) all green.
- `/code-review` (high) + `/simplify`: confirmed correct & never-worse; applied robustness guard for real-number-first co-hosts and reused the shared `extractHashRunNumber` parser.

## De-bomb note
`google-calendar/adapter.test.ts` has **no genuine date-window time-bomb**: the window-sensitive `.fetch()` tests assert `timeMin`/`timeMax` against `Date.now()` dynamically, and the event-returning fetch tests return fixtures the adapter passes through without client-side date filtering (GCal trusts the API window, mocked). New tests are parse-level with static dates, which is correct.

## Out of scope (flagged separately)
The C2H3 calendar also carries `BALH3`/`CBH3` events, but the source has no `kennelPatterns`, so they all route to `c2h3` — pre-existing mis-attribution, not part of this title fix.

Closes #2046
Closes #2065

🤖 Generated with [Claude Code](https://claude.com/claude-code)