### PR TITLE
test(adapters): de-bomb latent time-bomb fixture-date tests (#2066)

### DIFF
--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   HarrierCentralAdapter,
   applyTitleFallback,
@@ -318,9 +318,16 @@ describe("generateAccessToken", () => {
 describe("HarrierCentralAdapter", () => {
   let adapter: HarrierCentralAdapter;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     vi.clearAllMocks();
     adapter = new HarrierCentralAdapter();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("has correct type", () => {

--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import {
@@ -306,8 +306,15 @@ describe("special events without Run №", () => {
 describe("AH3Adapter", () => {
   const adapter = new AH3Adapter();
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-01T12:00:00Z"));
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("fetches upcoming + previous pages and deduplicates by run number", async () => {

--- a/src/adapters/html-scraper/bangkok-monday-hash.test.ts
+++ b/src/adapters/html-scraper/bangkok-monday-hash.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import {
@@ -221,6 +221,15 @@ describe("parseNextRunBlock", () => {
 });
 
 describe("BangkokMondayHashAdapter.fetch", () => {
+  // Freeze the clock at the fixtures' era (REF) so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-05T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("merges both pages, dedupes by run, and enriches the next run", async () => {
     mockBothPages();
     const result = await new BangkokMondayHashAdapter().fetch(makeSource());

--- a/src/adapters/html-scraper/bfm.test.ts
+++ b/src/adapters/html-scraper/bfm.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { parseBfmDate, BFMAdapter, extractFunPart } from "./bfm";
 
 describe("parseBfmDate", () => {
@@ -48,7 +49,14 @@ const SAMPLE_HTML = `
 `;
 
 describe("BFMAdapter.fetch", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-01T12:00:00Z"));
+  });
+
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 

--- a/src/adapters/html-scraper/brass-monkey.test.ts
+++ b/src/adapters/html-scraper/brass-monkey.test.ts
@@ -138,12 +138,16 @@ describe("parseBrassMonkeyBody", () => {
 describe("BrassMonkeyAdapter.fetch (Blogger API path)", () => {
   let adapter: BrassMonkeyAdapter;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-01T12:00:00Z"));
     adapter = new BrassMonkeyAdapter();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("parses events from Blogger API posts", async () => {

--- a/src/adapters/html-scraper/brew-city-h3.test.ts
+++ b/src/adapters/html-scraper/brew-city-h3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
 import { parseDateTime, parseTitle, parseDetails, BrewCityH3Adapter } from "./brew-city-h3";
 
@@ -175,8 +175,15 @@ describe("parseDetails", () => {
 describe("BrewCityH3Adapter", () => {
   const adapter = new BrewCityH3Adapter();
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-01T12:00:00Z"));
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("parses events from Wix repeater HTML", async () => {

--- a/src/adapters/html-scraper/calgary-h3-home.test.ts
+++ b/src/adapters/html-scraper/calgary-h3-home.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as cheerio from "cheerio";
 import {
   parseCalgaryRunNumber,
@@ -93,8 +93,15 @@ describe("CalgaryH3HomeAdapter", () => {
     url: "https://home.onon.org/upcumming-runs",
   } as Parameters<typeof adapter.fetch>[0];
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("parses events from Events Manager HTML", async () => {

--- a/src/adapters/html-scraper/calgary-h3-scribe.test.ts
+++ b/src/adapters/html-scraper/calgary-h3-scribe.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseScribeTitle,
   parseScribeBody,
@@ -175,8 +175,15 @@ describe("CalgaryH3ScribeAdapter", () => {
     url: "https://scribe.onon.org/",
   } as Parameters<typeof adapter.fetch>[0];
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("returns events from WordPress API", async () => {

--- a/src/adapters/html-scraper/capital-h3.test.ts
+++ b/src/adapters/html-scraper/capital-h3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
 import { CapitalH3Adapter, parseCapitalRunLine } from "./capital-h3";
 
@@ -85,6 +85,16 @@ describe("parseCapitalRunLine", () => {
 });
 
 describe("CapitalH3Adapter.fetch", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   const FIXTURE = `<!DOCTYPE html><html><body>
     <div class="panel-body-text">
       <div id="notices-prevContent-242832">

--- a/src/adapters/html-scraper/chiangmai-hhh.test.ts
+++ b/src/adapters/html-scraper/chiangmai-hhh.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ChiangMaiHHHAdapter, parseChiangMaiLine } from "./chiangmai-hhh";
 import * as utils from "../utils";
 import * as cheerio from "cheerio";
@@ -9,6 +10,15 @@ const SOURCE_URL = "http://www.chiangmaihhh.com/ch3-hareline/";
 const CBH3_URL = "http://www.chiangmaihhh.com/cbh3-hareline/"; // NOSONAR
 
 describe("parseChiangMaiLine", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-01T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("parses CH3 format: 'Monday 6th April CH3 Run # 1631 Suckit'", () => {
     const event = parseChiangMaiLine(
       "Monday 6th April CH3  Run # 1631 Suckit",
@@ -202,7 +212,10 @@ describe("ChiangMaiHHHAdapter \u2014 year attribution from <b>Month YYYY</b> hea
 </div>
 `;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-01T12:00:00Z"));
     vi.spyOn(utils, "fetchHTMLPage").mockResolvedValue({
       ok: true,
       html: CBH3_FIXTURE,
@@ -214,6 +227,7 @@ describe("ChiangMaiHHHAdapter \u2014 year attribution from <b>Month YYYY</b> hea
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("stamps every event with year 2026, including July\u2013December", async () => {

--- a/src/adapters/html-scraper/city-hash.test.ts
+++ b/src/adapters/html-scraper/city-hash.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 import * as cheerio from "cheerio";
 import { parseMakesweatEvent, extractMakesweatId } from "./city-hash";
@@ -102,6 +102,16 @@ Pub - The Eagle</div>
 `;
 
 describe("parseMakesweatEvent", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   const $ = cheerio.load(SAMPLE_HTML);
   const cards = $(".ms_event");
 

--- a/src/adapters/html-scraper/dch4.test.ts
+++ b/src/adapters/html-scraper/dch4.test.ts
@@ -174,11 +174,15 @@ const SAMPLE_HTML = `
 describe("DCH4Adapter (WordPress API path)", () => {
   let adapter: DCH4Adapter;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     adapter = new DCH4Adapter();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-02-01T12:00:00Z"));
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -261,8 +265,11 @@ describe("DCH4Adapter (WordPress API path)", () => {
 describe("DCH4Adapter (HTML fallback path)", () => {
   let adapter: DCH4Adapter;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     adapter = new DCH4Adapter();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-02-01T12:00:00Z"));
     // Make WordPress API return error to trigger HTML fallback
     vi.mocked(wordpressApi.fetchWordPressPosts).mockResolvedValue({
       posts: [],
@@ -271,6 +278,7 @@ describe("DCH4Adapter (HTML fallback path)", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 

--- a/src/adapters/html-scraper/ewh3.test.ts
+++ b/src/adapters/html-scraper/ewh3.test.ts
@@ -177,12 +177,16 @@ const SAMPLE_HTML = `
 describe("EWH3Adapter (WordPress API path)", () => {
   let adapter: EWH3Adapter;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-02-01T12:00:00Z"));
     adapter = new EWH3Adapter();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("uses WordPress API when available and parses events", async () => {
@@ -266,7 +270,10 @@ describe("EWH3Adapter (WordPress API path)", () => {
 describe("EWH3Adapter (HTML fallback path)", () => {
   let adapter: EWH3Adapter;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-02-01T12:00:00Z"));
     adapter = new EWH3Adapter();
     // Make WordPress API return error to trigger HTML fallback
     vi.mocked(wordpressApi.fetchWordPressPosts).mockResolvedValue({
@@ -277,6 +284,7 @@ describe("EWH3Adapter (HTML fallback path)", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("falls back to HTML scrape and parses events", async () => {

--- a/src/adapters/html-scraper/hague-h3.test.ts
+++ b/src/adapters/html-scraper/hague-h3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import {
@@ -46,6 +46,16 @@ function makeSource(overrides?: Partial<Source>): Source {
 // ── Unit tests: parseEventBlock ──
 
 describe("parseEventBlock", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("parses a standard event block", () => {
     const text = `Run 2412
 When: Sunday, March 29

--- a/src/adapters/html-scraper/kch3.test.ts
+++ b/src/adapters/html-scraper/kch3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseKCH3Time,
   parseKCH3Body,
@@ -290,8 +290,15 @@ describe("KCH3Adapter", () => {
     url: "https://kansascityh3.com/",
   } as never;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("returns events from WordPress posts", async () => {

--- a/src/adapters/html-scraper/kj-harimau.test.ts
+++ b/src/adapters/html-scraper/kj-harimau.test.ts
@@ -137,11 +137,15 @@ Details at khhhkj.blogspot.com
 describe("KjHarimauAdapter.fetch dedup (#1446)", () => {
   let adapter: KjHarimauAdapter;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     adapter = new KjHarimauAdapter();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-01T12:00:00Z"));
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 

--- a/src/adapters/html-scraper/mijas-hash.test.ts
+++ b/src/adapters/html-scraper/mijas-hash.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // fetchHTMLPage (real) calls safeFetch, which does a DNS SSRF check — mock the
 // safe-fetch seam so the fetch() tests stay offline (matches atlanta-hash-board).
@@ -158,6 +158,16 @@ const SAMPLE_HTML = `
 `;
 
 describe("MijasHashAdapter.fetch", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("parses sample HTML, ignores nav <li>, and resolves all to mijash3", async () => {
     mockSafeFetch.mockResolvedValueOnce(
       new Response(SAMPLE_HTML, { status: 200 }),

--- a/src/adapters/html-scraper/miteri-hareline.test.ts
+++ b/src/adapters/html-scraper/miteri-hareline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import {
@@ -281,6 +281,15 @@ describe("parseNextRunPanel (GCH3 Next Run widget)", () => {
 });
 
 describe("MiteriHarelineAdapter.fetch (GCH3-style page)", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("emits a Next-Run-panel event ahead of the table (#1503)", async () => {
     const html = `<!DOCTYPE html><html><body>
       <div class="entry-content">
@@ -366,6 +375,15 @@ describe("MiteriHarelineAdapter.fetch (GCH3-style page)", () => {
 });
 
 describe("MiteriHarelineAdapter.fetch (GCH3-style page) — legacy", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns ordered RawEventData for visible runs and skips placeholders", async () => {
     const html = `<!DOCTYPE html><html><body>
       <div class="panel-grid">

--- a/src/adapters/html-scraper/mooloo-hhh.test.ts
+++ b/src/adapters/html-scraper/mooloo-hhh.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
 import { MoolooHhhAdapter, parseMoolooRunLine } from "./mooloo-hhh";
 
@@ -88,6 +88,16 @@ describe("parseMoolooRunLine", () => {
 });
 
 describe("MoolooHhhAdapter.fetch", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   const FIXTURE = `<!DOCTYPE html><html><body>
     <div class="panel-body-text">
       <p>UPCUMMING RUNS for Mooloo HHH roughly every 2nd Monday or whenever you feel like setting a trail..</p>

--- a/src/adapters/html-scraper/norfolk-h3.test.ts
+++ b/src/adapters/html-scraper/norfolk-h3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   extractRunNumber,
   parseNorfolkDate,
@@ -456,8 +456,15 @@ describe("NorfolkH3Adapter", () => {
   });
 
   describe("adapter integration", () => {
+    // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
     beforeEach(() => {
       vi.restoreAllMocks();
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-03-15T12:00:00Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
     });
 
     it("has correct type", () => {

--- a/src/adapters/html-scraper/och3.test.ts
+++ b/src/adapters/html-scraper/och3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseOCH3Date,
   extractDayOfWeek,
@@ -15,6 +15,15 @@ import * as cheerio from "cheerio";
 import type { RawEventData } from "../types";
 
 describe("parseOCH3Date", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-02-01T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("parses ordinal date with day name", () => {
     expect(parseOCH3Date("Sunday 22nd February 2026")).toBe("2026-02-22");
   });
@@ -484,6 +493,15 @@ describe("zero-width title prefix (#1814)", () => {
 });
 
 describe("OCH3Adapter.fetch", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-01T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("parses multiple upcoming runs from compact line block", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(SAMPLE_UPCOMING_RUNS_BLOCK_HTML, { status: 200 }))

--- a/src/adapters/html-scraper/oh3-ottawa.test.ts
+++ b/src/adapters/html-scraper/oh3-ottawa.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as cheerio from "cheerio";
 import {
   parseDetailedBlock,
@@ -205,8 +205,15 @@ describe("Oh3OttawaAdapter", () => {
     url: "https://docs.google.com/document/d/1jGyBUKxOYkxrZg8WVfpBYDP84fbacanoX_TJuyCmtAI/pub",
   } as Parameters<typeof adapter.fetch>[0];
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("parses detailed event blocks and planning-ahead lines", async () => {

--- a/src/adapters/html-scraper/stlh3.test.ts
+++ b/src/adapters/html-scraper/stlh3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseSubtitleTime,
   extractLocationFromMapsUrl,
@@ -150,8 +150,15 @@ describe("StlH3Adapter", () => {
     url: "https://www.stlh3.com/",
   } as never;
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-15T12:00:00Z"));
     vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("parses events from archive and detail pages", async () => {

--- a/src/adapters/html-scraper/true-trail-h3.test.ts
+++ b/src/adapters/html-scraper/true-trail-h3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { parseTrueTrailHeading, extractHares } from "./true-trail-h3";
 import type { Source } from "@/generated/prisma/client";
 
@@ -120,8 +120,11 @@ vi.mock("../utils", async () => {
 });
 
 describe("TrueTrailH3Adapter", () => {
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(async () => {
     vi.restoreAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-03-15T12:00:00Z"));
     const { fetchHTMLPage } = await import("../utils");
     const cheerio = await import("cheerio");
     vi.mocked(fetchHTMLPage).mockResolvedValue({
@@ -131,6 +134,10 @@ describe("TrueTrailH3Adapter", () => {
       structureHash: "test-hash",
       fetchDurationMs: 100,
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("parses events from fixture HTML", async () => {

--- a/src/adapters/html-scraper/voodoo-h3.test.ts
+++ b/src/adapters/html-scraper/voodoo-h3.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseVoodooTitle,
   parseVoodooBody,
@@ -240,8 +240,15 @@ describe("VoodooH3Adapter", () => {
     url: "https://www.voodoohash.com/",
   } as Parameters<typeof adapter.fetch>[0];
 
+  // Freeze the clock at the fixtures' era so the windowed/year-inferred assertions never age out (#2066).
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("returns events from WordPress API", async () => {

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ICalAdapter, parseICalSummary, extractHaresFromDescription, extractRunNumberFromDescription, extractLocationFromDescription, extractOnOnVenueFromDescription, extractCostFromDescription, extractMapsUrlFromDescription, coalesceEndpointDuplicates, paramValue } from "./adapter";
 import type { RawEventData } from "../types";
 import type { Source } from "@/generated/prisma/client";
@@ -547,6 +547,14 @@ describe("ICalAdapter", () => {
     vi.restoreAllMocks();
   });
 
+  // Safety net: several tests in this describe install fake timers inline
+  // (vi.useFakeTimers/setSystemTime) and restore at the end of the test body.
+  // Restore here too so a throwing assertion can't leak a frozen clock into
+  // subsequent tests (#2066).
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("has correct type", () => {
     expect(adapter.type).toBe("ICAL_FEED");
   });
@@ -822,6 +830,11 @@ END:VCALENDAR`;
     // reconciler would cancel everything in the gap as "missing from scrape"
     // — a critical data-loss risk during admin one-shot wide-window scrapes
     // (e.g. #1339 ICH3 historical recovery).
+    // Freeze the clock at the fixtures' era (2023 = ~3yr back, 2028 = ~2yr
+    // forward) so the ±1500-day window keeps both events inside it forever
+    // and the "3 years back" row never ages out of the past edge (#2066).
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
     const wideWindowIcs = `BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT

--- a/src/adapters/rss/adapter.test.ts
+++ b/src/adapters/rss/adapter.test.ts
@@ -125,14 +125,22 @@ describe("RssAdapter", () => {
     });
 
     it("preserves local date from non-UTC ISO timestamp (P1 regression)", async () => {
-      // "2026-02-22T00:30:00+10:00" = Feb 21 UTC — must stay Feb 22 (publisher's local day)
+      // A +10:00 timestamp at 00:30 local is the PRIOR day in UTC — the adapter
+      // must keep the publisher's LOCAL day. Build the fixture relative to now so
+      // it never ages out of the date window and red-lights CI in a future year (#2066).
+      const localDay = new Date();
+      localDay.setUTCDate(localDay.getUTCDate() + 5);
+      const yyyy = localDay.getUTCFullYear();
+      const mm = String(localDay.getUTCMonth() + 1).padStart(2, "0");
+      const dd = String(localDay.getUTCDate()).padStart(2, "0");
+      const localDate = `${yyyy}-${mm}-${dd}`;
       mockParseURL.mockResolvedValueOnce({
         title: "Feed",
-        items: [{ title: "Night trail", isoDate: "2026-02-22T00:30:00+10:00", link: "https://x.com/1" }],
+        items: [{ title: "Night trail", isoDate: `${localDate}T00:30:00+10:00`, link: "https://x.com/1" }],
       });
       const adapter = new RssAdapter();
       const result = await adapter.fetch(makeSource(), { days: 365 });
-      expect(result.events[0].date).toBe("2026-02-22");
+      expect(result.events[0].date).toBe(localDate);
     });
 
     it("falls back to pubDate when isoDate is absent", async () => {

--- a/src/adapters/rss/adapter.test.ts
+++ b/src/adapters/rss/adapter.test.ts
@@ -130,10 +130,7 @@ describe("RssAdapter", () => {
       // it never ages out of the date window and red-lights CI in a future year (#2066).
       const localDay = new Date();
       localDay.setUTCDate(localDay.getUTCDate() + 5);
-      const yyyy = localDay.getUTCFullYear();
-      const mm = String(localDay.getUTCMonth() + 1).padStart(2, "0");
-      const dd = String(localDay.getUTCDate()).padStart(2, "0");
-      const localDate = `${yyyy}-${mm}-${dd}`;
+      const localDate = localDay.toISOString().split("T")[0];
       mockParseURL.mockResolvedValueOnce({
         title: "Feed",
         items: [{ title: "Night trail", isoDate: `${localDate}T00:30:00+10:00`, link: "https://x.com/1" }],


### PR DESCRIPTION
## Summary

Sweeps the **latent** time-bomb adapter tests catalogued in #2066 (the ~92-test / 32-file backlog left after the imminent ones landed in #2069). These tests pin **hardcoded fixture dates** that age out of the adapter's relative date-window filter (or feed chrono's now-inferred year) while asserting events survive — green today, but they redline CI for **every open PR** once the wall clock passes them in **2027–2028**. Same defect class as the `atlanta-hash-board` bomb.

**TEST FILES ONLY — no adapter source changed.**

## Approach

Two sanctioned fixes (per #2066), picked per file:

- **Frozen clock (default, 26 files):** `vi.useFakeTimers({ toFake: ["Date"] })` + `vi.setSystemTime(<fixture era>)` in the failing `describe`'s `beforeEach`, with `afterEach(vi.useRealTimers())`. Date-only faking keeps `setTimeout` real so awaited fetch mocks resolve. The freeze date is pinned to **each file's own fixture era** (verified by re-running each file under a clock advanced to `2028-06-09`).
- **Relative-date rewrite (1 file):** `rss/adapter.test.ts` — its window fixtures are computed at **import time** via `Date.now()` (before any `beforeEach` can freeze), so the single bomb test's fixture was rewritten as `now + 5d` while preserving its `+10:00`/UTC-boundary semantics.
- **`ical/adapter.test.ts`** froze its one bomb test inline (matching the file's existing idiom) and added a **describe-level `afterEach(vi.useRealTimers())` leak-guard** so a throwing assertion can't leak a frozen clock into later tests (Codex review catch — also hardens the file's pre-existing inline-timer tests).

## Verification

- Every one of the **27 modified files passes at the real clock AND under a clock advanced to `2028-06-09`** (past every original detonation date).
- `npx tsc --noEmit` clean, `npm run lint` exit 0 (no new findings), full `npm test` green (**8800 passed**).
- `/codex:adversarial-review` (one finding, fixed — the ical leak-guard above) + `/simplify` (4 agents, no findings — the change uses the repo's established inline idiom; no shared freeze helper exists or is warranted).

## Files (27 de-bombed)

`harrier-central/adapter`, `rss/adapter`, `ical/adapter`, and html-scraper: `ah3`, `bangkok-monday-hash`, `bfm`, `brass-monkey`, `brew-city-h3`, `calgary-h3-home`, `calgary-h3-scribe`, `capital-h3`, `chiangmai-hhh`, `city-hash`, `dch4`, `ewh3`, `hague-h3`, `kch3`, `kj-harimau`, `mijas-hash`, `miteri-hareline`, `mooloo-hhh`, `norfolk-h3`, `och3`, `oh3-ottawa`, `stlh3`, `true-trail-h3`, `voodoo-h3`.

## Skipped — false positives (2 files, intentionally NOT modified)

#2066's list was generated by advancing the clock under fake timers, which **corrupts `Intl`/`composeUtcStart` timezone math** (`timezone.ts` passes `new Date()` as the date-fns reference). These two entries fail *only* under fake timers and pass at the real clock forever — they are **not** time-bombs:

- `html-scraper/adelaide-h3.test.ts` — the failing `adelaideWallClockToUnix` tests are a **pure function** of an explicit input string (no `now` dependency); a frozen clock would *break* them.
- `facebook-hosted-events/parser.test.ts` — the failing test projects a **fixed** FB timestamp through a timezone (asserts constant `2024-04-30`/`2024-05-01`); clock-independent.

Both verified green at the real clock.

## Excluded — owned by parallel sessions this cycle (NOT touched)

Per the workstream split, these 7 are de-bombed by other sessions:
`meetup/adapter.test.ts`, `html-scraper/gohash.test.ts`, `google-calendar/adapter.test.ts`, `html-scraper/atlanta-hash-board.test.ts`, `html-scraper/geriatrix-h3.test.ts`, `html-scraper/bruh3.test.ts`, `html-scraper/sh3-au.test.ts`.

Closes #2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)