### PR TITLE
fix(meetup): strip group-template boilerplate from event descriptions

### DIFF
--- a/scripts/cleanup-meetup-boilerplate-descriptions.ts
+++ b/scripts/cleanup-meetup-boilerplate-descriptions.ts
@@ -123,6 +123,26 @@ function describeUpdate(after: string | null): string {
   return `-> "${preview}"`;
 }
 
+/**
+ * Write each update independently. The script is idempotent (a re-run skips
+ * already-cleared rows via the provenance guard), so a single failing row is
+ * logged and the rest proceed rather than aborting the whole batch.
+ */
+async function applyUpdates(updates: Update[]): Promise<{ updated: number; failed: number }> {
+  let updated = 0;
+  let failed = 0;
+  for (const u of updates) {
+    try {
+      await prisma.event.update({ where: { id: u.id }, data: { description: u.after } });
+      updated++;
+    } catch (err) {
+      failed++;
+      console.error(`  FAILED ${u.kennelCode} ${u.id}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return { updated, failed };
+}
+
 async function main() {
   const meetupSources = await prisma.source.findMany({
     where: { type: "MEETUP" },
@@ -174,26 +194,13 @@ async function main() {
 
   // Do NOT mutate RawEvent.rawData (immutable audit trail). We only rewrite the
   // canonical UI value; the next in-window scrape re-applies the same strip.
-  // Each update is independent and the script is idempotent (a re-run skips
-  // already-cleared rows via the provenance guard), so a single failing row is
-  // logged and the rest proceed rather than aborting the whole batch.
-  let updated = 0;
-  let failed = 0;
-  if (APPLY) {
-    for (const u of updates) {
-      try {
-        await prisma.event.update({ where: { id: u.id }, data: { description: u.after } });
-        updated++;
-      } catch (err) {
-        failed++;
-        console.error(`  FAILED ${u.kennelCode} ${u.id}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
-  }
+  const { updated, failed } = APPLY
+    ? await applyUpdates(updates)
+    : { updated: updates.length, failed: 0 };
 
   const verb = APPLY ? "Updated" : "Would update";
-  console.log(`\n${verb} ${APPLY ? updated : updates.length} canonical Event.description value(s).`);
-  if (APPLY && failed > 0) console.log(`${failed} update(s) failed — re-run to retry (idempotent).`);
+  console.log(`\n${verb} ${updated} canonical Event.description value(s).`);
+  if (failed > 0) console.log(`${failed} update(s) failed — re-run to retry (idempotent).`);
   if (!APPLY) console.log("Dry-run only. Re-run with --apply to write changes.");
   await prisma.$disconnect();
 }

--- a/scripts/cleanup-meetup-boilerplate-descriptions.ts
+++ b/scripts/cleanup-meetup-boilerplate-descriptions.ts
@@ -55,6 +55,74 @@ const APPLY = process.argv.includes("--apply");
 const ALL = process.argv.includes("--all");
 const AFFECTED_KENNELS = new Set(["savh3", "hogtownh3", "mh3-ca"]);
 
+interface ProvEvent {
+  rawData: unknown;
+  event: { id: string; description: string | null; kennel: { kennelCode: string } | null } | null;
+}
+interface Update {
+  id: string;
+  kennelCode: string;
+  after: string | null;
+}
+
+/**
+ * Group provenance-matched events by kennel (eventId → description). An event is
+ * provenance-matched when its canonical description exactly equals a Meetup raw
+ * snapshot AND (unless `--all`) it belongs to an affected kennel. De-dupes to
+ * one record per event. Returns the grouping and the skipped-row count.
+ */
+function groupProvenancedByKennel(rawEvents: ProvEvent[]): {
+  byKennel: Map<string, Map<string, string>>;
+  skipped: number;
+} {
+  const byKennel = new Map<string, Map<string, string>>();
+  let skipped = 0;
+  for (const re of rawEvents) {
+    const description = re.event?.description ?? null;
+    const raw = re.rawData as { description?: unknown } | null;
+    const rawDescription = typeof raw?.description === "string" ? raw.description : null;
+    const kennelCode = re.event?.kennel?.kennelCode ?? "?";
+    const scoped = ALL || AFFECTED_KENNELS.has(kennelCode);
+    if (!re.event || description === null || description !== rawDescription || !scoped) {
+      skipped++;
+      continue;
+    }
+    let group = byKennel.get(kennelCode);
+    if (!group) {
+      group = new Map();
+      byKennel.set(kennelCode, group);
+    }
+    group.set(re.event.id, description);
+  }
+  return { byKennel, skipped };
+}
+
+/** Detect boilerplate per kennel and collect the events whose description changes. */
+function computeUpdates(byKennel: Map<string, Map<string, string>>): {
+  updates: Update[];
+  provenancedCount: number;
+} {
+  const updates: Update[] = [];
+  let provenancedCount = 0;
+  for (const [kennelCode, events] of byKennel) {
+    provenancedCount += events.size;
+    const boilerplateBlocks = detectBoilerplateBlocks([...events.values()]);
+    if (boilerplateBlocks.size === 0) continue;
+    for (const [id, description] of events) {
+      const after = stripBoilerplateBlocks(description, boilerplateBlocks);
+      if (after !== description) updates.push({ id, kennelCode, after });
+    }
+  }
+  return { updates, provenancedCount };
+}
+
+/** One-line preview of what an update would write. */
+function describeUpdate(after: string | null): string {
+  if (after === null) return "NULL";
+  const preview = after.length > 60 ? `${after.slice(0, 60)}...` : after;
+  return `-> "${preview}"`;
+}
+
 async function main() {
   const meetupSources = await prisma.source.findMany({
     where: { type: "MEETUP" },
@@ -72,8 +140,8 @@ async function main() {
   );
 
   // Canonical Events with a Meetup-provenance description, linked through
-  // RawEvent. An Event may have several Meetup RawEvents — we de-dupe to one
-  // record per Event below.
+  // RawEvent. An Event may have several Meetup RawEvents — de-duped to one
+  // record per Event in groupProvenancedByKennel.
   const rawEvents = await prisma.rawEvent.findMany({
     where: {
       sourceId: { in: meetupSources.map((s) => s.id) },
@@ -92,54 +160,11 @@ async function main() {
     },
   });
 
-  // Provenance-matched events grouped by kennel (eventId → description), so the
-  // block detector runs over one kennel's corpus at a time.
-  const byKennel = new Map<string, Map<string, string>>();
-  let skipped = 0;
-
-  for (const re of rawEvents) {
-    if (!re.event || re.event.description === null) {
-      skipped++;
-      continue;
-    }
-    const raw = re.rawData as { description?: unknown } | null;
-    const rawDescription = typeof raw?.description === "string" ? raw.description : null;
-    // Provenance: canonical Event.description must equal this Meetup raw's
-    // stored description.
-    if (rawDescription === null || re.event.description !== rawDescription) {
-      skipped++;
-      continue;
-    }
-    const kennelCode = re.event.kennel?.kennelCode ?? "?";
-    if (!ALL && !AFFECTED_KENNELS.has(kennelCode)) {
-      skipped++;
-      continue;
-    }
-    let group = byKennel.get(kennelCode);
-    if (!group) {
-      group = new Map();
-      byKennel.set(kennelCode, group);
-    }
-    group.set(re.event.id, re.event.description);
-  }
-
-  // For each kennel, detect boilerplate blocks across its descriptions and strip
-  // them from each event. Collect the resulting writes (null or shortened).
-  const updates: { id: string; kennelCode: string; after: string | null }[] = [];
-  let provenancedCount = 0;
-  for (const [kennelCode, events] of byKennel) {
-    provenancedCount += events.size;
-    const boilerplateBlocks = detectBoilerplateBlocks([...events.values()]);
-    if (boilerplateBlocks.size === 0) continue;
-    for (const [id, description] of events) {
-      const after = stripBoilerplateBlocks(description, boilerplateBlocks);
-      if (after !== description) updates.push({ id, kennelCode, after });
-    }
-  }
+  const { byKennel, skipped } = groupProvenancedByKennel(rawEvents);
+  const { updates, provenancedCount } = computeUpdates(byKennel);
 
   for (const u of updates) {
-    const what = u.after === null ? "NULL" : `-> "${u.after.slice(0, 60)}${u.after.length > 60 ? "..." : ""}"`;
-    console.log(`  ${u.kennelCode} ${u.id}: ${what}`);
+    console.log(`  ${u.kennelCode} ${u.id}: ${describeUpdate(u.after)}`);
   }
 
   console.log(
@@ -149,16 +174,14 @@ async function main() {
 
   // Do NOT mutate RawEvent.rawData (immutable audit trail). We only rewrite the
   // canonical UI value; the next in-window scrape re-applies the same strip.
-  let cleared = 0;
   if (APPLY) {
     for (const u of updates) {
       await prisma.event.update({ where: { id: u.id }, data: { description: u.after } });
-      cleared++;
     }
   }
 
   const verb = APPLY ? "Updated" : "Would update";
-  console.log(`\n${verb} ${APPLY ? cleared : updates.length} canonical Event.description value(s).`);
+  console.log(`\n${verb} ${updates.length} canonical Event.description value(s).`);
   if (!APPLY) console.log("Dry-run only. Re-run with --apply to write changes.");
   await prisma.$disconnect();
 }

--- a/scripts/cleanup-meetup-boilerplate-descriptions.ts
+++ b/scripts/cleanup-meetup-boilerplate-descriptions.ts
@@ -174,14 +174,26 @@ async function main() {
 
   // Do NOT mutate RawEvent.rawData (immutable audit trail). We only rewrite the
   // canonical UI value; the next in-window scrape re-applies the same strip.
+  // Each update is independent and the script is idempotent (a re-run skips
+  // already-cleared rows via the provenance guard), so a single failing row is
+  // logged and the rest proceed rather than aborting the whole batch.
+  let updated = 0;
+  let failed = 0;
   if (APPLY) {
     for (const u of updates) {
-      await prisma.event.update({ where: { id: u.id }, data: { description: u.after } });
+      try {
+        await prisma.event.update({ where: { id: u.id }, data: { description: u.after } });
+        updated++;
+      } catch (err) {
+        failed++;
+        console.error(`  FAILED ${u.kennelCode} ${u.id}: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
 
   const verb = APPLY ? "Updated" : "Would update";
-  console.log(`\n${verb} ${updates.length} canonical Event.description value(s).`);
+  console.log(`\n${verb} ${APPLY ? updated : updates.length} canonical Event.description value(s).`);
+  if (APPLY && failed > 0) console.log(`${failed} update(s) failed — re-run to retry (idempotent).`);
   if (!APPLY) console.log("Dry-run only. Re-run with --apply to write changes.");
   await prisma.$disconnect();
 }

--- a/scripts/cleanup-meetup-boilerplate-descriptions.ts
+++ b/scripts/cleanup-meetup-boilerplate-descriptions.ts
@@ -1,0 +1,170 @@
+/**
+ * One-shot cleanup for #2058/#2059/#2062: the Meetup adapter previously stored a
+ * kennel's standing recurring-event template (the group blurb Meetup applies to
+ * every occurrence) as each event's `description`, displacing run-specific
+ * notes. The adapter fix in this same PR detects the template structurally
+ * (paragraph blocks repeated verbatim across the group's events) and strips them
+ * going forward — but that only fires for events still inside the scrape window.
+ * Canonical Events that already stored the boilerplate and have aged out won't
+ * re-merge, so they keep the stale template until cleared here.
+ *
+ * Structural detection (mirrors the adapter — no keyword list):
+ *   - Scope to RawEvents from MEETUP-typed sources (only the Meetup adapter
+ *     contributes these descriptions).
+ *   - Provenance guard: only touch a canonical `Event.description` that EXACTLY
+ *     equals the Meetup `RawEvent.rawData.description` snapshot, so a
+ *     description merged from a different (e.g. higher-trust) adapter is never
+ *     touched.
+ *   - Per kennel, run the SAME paragraph-block detector the adapter uses
+ *     (`detectBoilerplateBlocks` / `stripBoilerplateBlocks`): a paragraph block
+ *     reused across >= 2 distinct events is template boilerplate and is removed.
+ *     A fully templated description collapses to null; a club blurb prepended to
+ *     a per-event stanza is partially stripped; a genuinely unique description
+ *     is left untouched.
+ *
+ * Blast-radius control: by default this only touches the kennels named in the
+ * incident (`AFFECTED_KENNELS`). The structural detector necessarily treats any
+ * paragraph a kennel reuses across >= 2 events as boilerplate, so running it
+ * over the entire Meetup corpus could strip a paragraph some other kennel
+ * legitimately repeats. Pass `--all` to opt into the full corpus only after
+ * reviewing a dry-run. Originals are always preserved in the immutable
+ * `RawEvent.rawData`, so a mistaken strip is recoverable.
+ *
+ * Runs in dry-run mode by default — pass `--apply` to write.
+ *   npx tsx scripts/cleanup-meetup-boilerplate-descriptions.ts            # preview affected kennels
+ *   npx tsx scripts/cleanup-meetup-boilerplate-descriptions.ts --apply    # write affected kennels
+ *   npx tsx scripts/cleanup-meetup-boilerplate-descriptions.ts --all      # preview entire Meetup corpus
+ *
+ * ORDERING (important):
+ *   1. Run `--apply` ONLY AFTER the adapter fix in this PR is deployed to prod.
+ *      For kennels whose canonical is owned by a higher-trust source (e.g.
+ *      Montreal mhhh.ca trust 9 > Meetup trust 7), the merge enrich branch is
+ *      fill-only (`if (!existing.description && event.description)`). If you
+ *      clear a description to null while the OLD adapter is still live, the next
+ *      cron re-emits the boilerplate and the fill branch puts it right back.
+ *   2. Run BEFORE any `force: true` re-scrape — force deletes the RawEvents that
+ *      carry the provenance link (see scripts/cleanup-lsw-stale-descriptions.ts).
+ */
+import "dotenv/config";
+import { prisma } from "../src/lib/db";
+import { detectBoilerplateBlocks, stripBoilerplateBlocks } from "../src/adapters/meetup/adapter";
+
+const APPLY = process.argv.includes("--apply");
+// Default scope: only the kennels named in #2058/#2059/#2062. `--all` opts into
+// the full Meetup corpus (review the dry-run first — see header).
+const ALL = process.argv.includes("--all");
+const AFFECTED_KENNELS = new Set(["savh3", "hogtownh3", "mh3-ca"]);
+
+async function main() {
+  const meetupSources = await prisma.source.findMany({
+    where: { type: "MEETUP" },
+    select: { id: true },
+  });
+  if (meetupSources.length === 0) {
+    console.log("No MEETUP sources found — nothing to scan.");
+    await prisma.$disconnect();
+    return;
+  }
+
+  console.log(
+    `Scanning ${meetupSources.length} MEETUP source(s) for group-template boilerplate ` +
+      `(scope: ${ALL ? "ALL kennels" : [...AFFECTED_KENNELS].join(", ")}).`,
+  );
+
+  // Canonical Events with a Meetup-provenance description, linked through
+  // RawEvent. An Event may have several Meetup RawEvents — we de-dupe to one
+  // record per Event below.
+  const rawEvents = await prisma.rawEvent.findMany({
+    where: {
+      sourceId: { in: meetupSources.map((s) => s.id) },
+      eventId: { not: null },
+      event: { description: { not: null } },
+    },
+    select: {
+      rawData: true,
+      event: {
+        select: {
+          id: true,
+          description: true,
+          kennel: { select: { kennelCode: true } },
+        },
+      },
+    },
+  });
+
+  // Provenance-matched events grouped by kennel (eventId → description), so the
+  // block detector runs over one kennel's corpus at a time.
+  const byKennel = new Map<string, Map<string, string>>();
+  let skipped = 0;
+
+  for (const re of rawEvents) {
+    if (!re.event || re.event.description === null) {
+      skipped++;
+      continue;
+    }
+    const raw = re.rawData as { description?: unknown } | null;
+    const rawDescription = typeof raw?.description === "string" ? raw.description : null;
+    // Provenance: canonical Event.description must equal this Meetup raw's
+    // stored description.
+    if (rawDescription === null || re.event.description !== rawDescription) {
+      skipped++;
+      continue;
+    }
+    const kennelCode = re.event.kennel?.kennelCode ?? "?";
+    if (!ALL && !AFFECTED_KENNELS.has(kennelCode)) {
+      skipped++;
+      continue;
+    }
+    let group = byKennel.get(kennelCode);
+    if (!group) {
+      group = new Map();
+      byKennel.set(kennelCode, group);
+    }
+    group.set(re.event.id, re.event.description);
+  }
+
+  // For each kennel, detect boilerplate blocks across its descriptions and strip
+  // them from each event. Collect the resulting writes (null or shortened).
+  const updates: { id: string; kennelCode: string; after: string | null }[] = [];
+  let provenancedCount = 0;
+  for (const [kennelCode, events] of byKennel) {
+    provenancedCount += events.size;
+    const boilerplateBlocks = detectBoilerplateBlocks([...events.values()]);
+    if (boilerplateBlocks.size === 0) continue;
+    for (const [id, description] of events) {
+      const after = stripBoilerplateBlocks(description, boilerplateBlocks);
+      if (after !== description) updates.push({ id, kennelCode, after });
+    }
+  }
+
+  for (const u of updates) {
+    const what = u.after === null ? "NULL" : `-> "${u.after.slice(0, 60)}${u.after.length > 60 ? "..." : ""}"`;
+    console.log(`  ${u.kennelCode} ${u.id}: ${what}`);
+  }
+
+  console.log(
+    `\nFound ${updates.length} canonical Event(s) carrying group-template boilerplate ` +
+      `across ${provenancedCount} provenance-matched Meetup event(s). (${skipped} rows skipped.)`,
+  );
+
+  // Do NOT mutate RawEvent.rawData (immutable audit trail). We only rewrite the
+  // canonical UI value; the next in-window scrape re-applies the same strip.
+  let cleared = 0;
+  if (APPLY) {
+    for (const u of updates) {
+      await prisma.event.update({ where: { id: u.id }, data: { description: u.after } });
+      cleared++;
+    }
+  }
+
+  const verb = APPLY ? "Updated" : "Would update";
+  console.log(`\n${verb} ${APPLY ? cleared : updates.length} canonical Event.description value(s).`);
+  if (!APPLY) console.log("Dry-run only. Re-run with --apply to write changes.");
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle } from "./adapter";
+import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle, detectBoilerplateBlocks, stripBoilerplateBlocks } from "./adapter";
+import { normalizeDescriptionKey } from "../utils";
 import type { Source } from "@/generated/prisma/client";
 
 vi.mock("../safe-fetch", () => ({
@@ -18,14 +19,38 @@ function makeSource(config: unknown): Source {
   } as unknown as Source;
 }
 
+// `.fetch()` tests filter events through buildDateWindow (symmetric ±days), so
+// static fixture dates eventually age out of the lower bound and turn main red
+// on a rolling calendar date (Memory: feedback_windowed_adapter_test_needs_relative_dates).
+// Use these now-relative helpers for any event a fetch test expects to survive
+// the window. Pure-parse tests (buildRawEventFromApollo, dedupByDate, etc.) keep
+// static dates — they never hit the window.
+function isoDaysFromNow(days: number, time = "18:00", offset = "-05:00"): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return `${d.toISOString().slice(0, 10)}T${time}:00${offset}`;
+}
+function dateDaysFromNow(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+// Shared near-future date for the default fixture so the date-asserting test can
+// recompute the expected value without re-deriving the offset.
+const DEFAULT_EVENT_DAYS = 10;
+// Shared near-future timestamp for the recurring-template / same-day dedup
+// enrichment fetch tests (template + customized occurrence must land on the
+// SAME calendar day for dedupByDate to collapse them).
+const ENRICH_DAY = isoDaysFromNow(20, "11:00", "-04:00");
+
 /** Build a minimal Apollo event object. */
 function buildApolloEvent(overrides: Record<string, unknown> = {}) {
   return {
     __typename: "Event",
     id: "313348941",
     title: "Trail #42 — Central Park",
-    dateTime: "2026-03-15T18:00:00-05:00",
-    endTime: "2026-03-15T21:00:00-05:00",
+    dateTime: isoDaysFromNow(DEFAULT_EVENT_DAYS, "18:00"),
+    endTime: isoDaysFromNow(DEFAULT_EVENT_DAYS, "21:00"),
     status: "ACTIVE",
     description: "<p>Join us for a fun trail!</p>",
     eventUrl: "https://www.meetup.com/test-hash/events/313348941/",
@@ -364,13 +389,13 @@ describe("MeetupAdapter", () => {
       "Event:cancelled": buildApolloEvent({
         id: "1235-cancelled",
         title: "Charlotte H3 Trail #1235 - Erections (Elections) & SOUP Cook off",
-        dateTime: "2026-01-10T14:00:00-05:00",
+        dateTime: isoDaysFromNow(20, "14:00"),
         status: "CANCELLED",
       }),
       "Event:active": buildApolloEvent({
         id: "1235-active",
         title: "Charlotte H3 Trail #1235 - An East Charlotte Snow Melt Trail!",
-        dateTime: "2026-02-07T14:00:00-05:00",
+        dateTime: isoDaysFromNow(30, "14:00"),
         status: "ACTIVE",
       }),
       "Venue:123": VENUE_ENTRY,
@@ -398,13 +423,13 @@ describe("MeetupAdapter", () => {
       "Event:admin": buildApolloEvent({
         id: "313638944",
         title: "Moving to a new website site - Last day in Meetup is March 10th",
-        dateTime: "2026-03-10T07:00:00-05:00",
+        dateTime: isoDaysFromNow(20, "07:00"),
         status: "ACTIVE",
       }),
       "Event:trail": buildApolloEvent({
         id: "real-trail",
         title: "Narwhal H3 #54 - Real Trail",
-        dateTime: "2026-03-08T13:00:00-05:00",
+        dateTime: isoDaysFromNow(25, "13:00"),
         status: "ACTIVE",
       }),
       "Venue:123": VENUE_ENTRY,
@@ -431,13 +456,13 @@ describe("MeetupAdapter", () => {
       "Event:departure": buildApolloEvent({
         id: "314543422",
         title: "MIAMI HASH HOUSE HARRIERS ARE LEAVING MEETUP",
-        dateTime: "2026-06-01T18:00:00-04:00",
+        dateTime: isoDaysFromNow(20, "18:00", "-04:00"),
         status: "ACTIVE",
       }),
       "Event:leavingLasVegas": buildApolloEvent({
         id: "real-trail",
         title: "Leaving Las Vegas Trail #42",
-        dateTime: "2026-06-03T18:00:00-04:00",
+        dateTime: isoDaysFromNow(25, "18:00", "-04:00"),
         status: "ACTIVE",
       }),
       "Venue:123": VENUE_ENTRY,
@@ -469,13 +494,13 @@ describe("MeetupAdapter", () => {
       "Event:farewell": buildApolloEvent({
         id: "fw1",
         title: "Farewell Run Trail #42",
-        dateTime: "2026-06-10T18:00:00-04:00",
+        dateTime: isoDaysFromNow(20, "18:00", "-04:00"),
         status: "ACTIVE",
       }),
       "Event:goodbye": buildApolloEvent({
         id: "gb1",
         title: "Goodbye Trail #138",
-        dateTime: "2026-06-12T18:00:00-04:00",
+        dateTime: isoDaysFromNow(25, "18:00", "-04:00"),
         status: "ACTIVE",
       }),
       "Venue:123": VENUE_ENTRY,
@@ -494,6 +519,167 @@ describe("MeetupAdapter", () => {
     expect(result.diagnosticContext?.adminNoticeSkipped).toBe(0);
   });
 
+  // ── #2058/#2059/#2062: group-template boilerplate leak ──
+  // Meetup stores a kennel's standing recurring-event template as EVERY
+  // occurrence's description, displacing run-specific notes. The structural
+  // signal is verbatim repetition across the group's events; genuine per-event
+  // notes appear once. Boilerplate → `description: null` (explicit clear);
+  // unique content survives untouched.
+
+  it("drops group-template boilerplate description repeated across events (#2058/#2059/#2062)", async () => {
+    // Montreal-style standing template reused verbatim on every occurrence.
+    const TEMPLATE =
+      "<p>Structure: This event will be a run/walk, followed by a social gathering with food and drinks. Don't Arrive Late! What Are The Hash House Harriers?</p>";
+    const html = buildMeetupHtml({
+      "Event:1683": buildApolloEvent({
+        id: "1683",
+        title: "MH3 Run #1683",
+        dateTime: isoDaysFromNow(20, "13:00"),
+        description: TEMPLATE,
+      }),
+      "Event:1684": buildApolloEvent({
+        id: "1684",
+        title: "MH3 Run #1684",
+        dateTime: isoDaysFromNow(27, "13:00"),
+        description: TEMPLATE,
+      }),
+      "Event:1685": buildApolloEvent({
+        id: "1685",
+        title: "MH3 Run #1685",
+        dateTime: isoDaysFromNow(34, "13:00"),
+        description: TEMPLATE,
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "montreal-hash-house-harriers", kennelTag: "mh3-ca" }),
+      { days: 365 },
+    );
+
+    expect(result.events).toHaveLength(3);
+    // Every event's boilerplate description is cleared to null (explicit clear,
+    // per merge.ts UPDATE contract — wipes the stored template).
+    for (const ev of result.events) {
+      expect(ev.description).toBeNull();
+    }
+    expect(result.diagnosticContext?.boilerplateDescriptionsDropped).toBe(3);
+  });
+
+  it("keeps a genuine per-event description while dropping the repeated template (negative fixture)", async () => {
+    const TEMPLATE =
+      "<p>Join us for our weekly hashing trail! Event details are posted by Thursday before trail. Savannah Hash House Harriers is a social running club.</p>";
+    const html = buildMeetupHtml({
+      // Two occurrences carry the standing template verbatim → boilerplate.
+      "Event:t1": buildApolloEvent({
+        id: "t1",
+        title: "Saturday Trail!",
+        dateTime: isoDaysFromNow(14, "15:00"),
+        description: TEMPLATE,
+      }),
+      "Event:t2": buildApolloEvent({
+        id: "t2",
+        title: "Saturday Trail!",
+        dateTime: isoDaysFromNow(21, "15:00"),
+        description: TEMPLATE,
+      }),
+      // One occurrence has real run-specific notes → must survive untouched.
+      "Event:real": buildApolloEvent({
+        id: "real",
+        title: "SAVH3 Trail #1324!",
+        dateTime: isoDaysFromNow(28, "15:00"),
+        description: "<p>Meet at Forsyth Park. Theme: pirates. On-after at the Rail Pub.</p>",
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "savannah-hash-house-harriers", kennelTag: "savh3" }),
+      { days: 365 },
+    );
+
+    expect(result.events).toHaveLength(3);
+    const real = result.events.find((e) => e.title === "SAVH3 Trail #1324!");
+    expect(real?.description).toBe(
+      "Meet at Forsyth Park. Theme: pirates. On-after at the Rail Pub.",
+    );
+    const templated = result.events.filter((e) => e.title === "Saturday Trail!");
+    expect(templated).toHaveLength(2);
+    for (const ev of templated) expect(ev.description).toBeNull();
+    expect(result.diagnosticContext?.boilerplateDescriptionsDropped).toBe(2);
+  });
+
+  it("keeps a one-off description that never repeats (no false positive)", async () => {
+    const html = buildMeetupHtml({
+      "Event:a": buildApolloEvent({
+        id: "a",
+        title: "Trail A",
+        dateTime: isoDaysFromNow(14, "18:00"),
+        description: "<p>Unique notes for trail A — bring a headlamp.</p>",
+      }),
+      "Event:b": buildApolloEvent({
+        id: "b",
+        title: "Trail B",
+        dateTime: isoDaysFromNow(21, "18:00"),
+        description: "<p>Different notes for trail B — wear costumes.</p>",
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events.every((e) => e.description !== null && e.description !== undefined)).toBe(true);
+    expect(result.diagnosticContext?.boilerplateDescriptionsDropped).toBe(0);
+  });
+
+  it("strips a shared club paragraph but keeps the per-event logistics stanza (#2059 Hogtown)", async () => {
+    // Hogtown prepends the same club blurb to a per-event Date/Cost stanza, so
+    // the WHOLE description differs per event but the club paragraph repeats.
+    const CLUB =
+      "Hogtown Hash House Harriers (HH3) is a Toronto social running and beer drinking group. New members welcome!";
+    const html = buildMeetupHtml({
+      "Event:h1": buildApolloEvent({
+        id: "h1",
+        title: "Thursday run/walk with HH3",
+        dateTime: isoDaysFromNow(14, "19:00", "-04:00"),
+        description: `${CLUB}\n\nDate / Time: Thursday @ 7pm. Start: Christie Pits. Cost: $10.`,
+      }),
+      "Event:h2": buildApolloEvent({
+        id: "h2",
+        title: "Saturday run/walk with HH3",
+        dateTime: isoDaysFromNow(23, "15:00", "-04:00"),
+        description: `${CLUB}\n\nDate / Time: Saturday @ 3pm. Start: High Park. Cost: $15.`,
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "meetup-group-pyrddkbc", kennelTag: "hogtownh3" }),
+      { days: 365 },
+    );
+
+    expect(result.events).toHaveLength(2);
+    const h1 = result.events.find((e) => e.title === "Thursday run/walk with HH3");
+    const h2 = result.events.find((e) => e.title === "Saturday run/walk with HH3");
+    // Club blurb removed; per-event logistics survive.
+    expect(h1?.description).toBe("Date / Time: Thursday @ 7pm. Start: Christie Pits. Cost: $10.");
+    expect(h2?.description).toBe("Date / Time: Saturday @ 3pm. Start: High Park. Cost: $15.");
+    expect(h1?.description).not.toContain("social running");
+    expect(result.diagnosticContext?.boilerplateDescriptionsDropped).toBe(2);
+  });
+
   it("parses events and assigns kennelTag", async () => {
     const html = buildMeetupHtml({
       "Event:1": buildApolloEvent(),
@@ -509,7 +695,7 @@ describe("MeetupAdapter", () => {
     expect(result.events.length).toBe(1);
     expect(result.events[0].kennelTags[0]).toBe("NYCH3");
     expect(result.events[0].title).toBe("Trail #42 — Central Park");
-    expect(result.events[0].date).toBe("2026-03-15");
+    expect(result.events[0].date).toBe(dateDaysFromNow(DEFAULT_EVENT_DAYS));
     expect(result.events[0].startTime).toBe("18:00");
     expect(result.events[0].endTime).toBe("21:00");
   });
@@ -824,8 +1010,8 @@ describe("MeetupAdapter", () => {
   });
 
   it("combines events from both upcoming and past pages", async () => {
-    const futureEvent = buildApolloEvent({ id: "future-1", title: "Upcoming Run", dateTime: "2026-03-20T18:00:00-05:00" });
-    const pastEvent = buildApolloEvent({ id: "past-1", title: "Past Run", dateTime: "2026-02-15T18:00:00-05:00" });
+    const futureEvent = buildApolloEvent({ id: "future-1", title: "Upcoming Run", dateTime: isoDaysFromNow(20) });
+    const pastEvent = buildApolloEvent({ id: "past-1", title: "Past Run", dateTime: isoDaysFromNow(-20) });
 
     const upcomingHtml = buildMeetupHtml({ "Event:future-1": futureEvent, "Venue:123": VENUE_ENTRY });
     const pastHtml = buildMeetupHtml({ "Event:past-1": pastEvent, "Venue:123": VENUE_ENTRY });
@@ -913,8 +1099,8 @@ describe("MeetupAdapter", () => {
   });
 
   it("includes per-page counts in diagnosticContext", async () => {
-    const futureEvent = buildApolloEvent({ id: "future-1", dateTime: "2026-03-20T18:00:00-05:00" });
-    const pastEvent = buildApolloEvent({ id: "past-1", dateTime: "2026-02-15T18:00:00-05:00" });
+    const futureEvent = buildApolloEvent({ id: "future-1", dateTime: isoDaysFromNow(20) });
+    const pastEvent = buildApolloEvent({ id: "past-1", dateTime: isoDaysFromNow(-20) });
 
     const upcomingHtml = buildMeetupHtml({ "Event:future-1": futureEvent, "Venue:123": VENUE_ENTRY });
     const pastHtml = buildMeetupHtml({ "Event:past-1": pastEvent, "Venue:123": VENUE_ENTRY });
@@ -932,8 +1118,8 @@ describe("MeetupAdapter", () => {
   });
 
   it("deduplicates template and customized occurrence on same date", async () => {
-    const template = buildRecurringTemplate({ dateTime: "2026-03-14T11:00:00-04:00" });
-    const customized = buildCustomizedOccurrence({ dateTime: "2026-03-14T11:00:00-04:00" });
+    const template = buildRecurringTemplate({ dateTime: ENRICH_DAY });
+    const customized = buildCustomizedOccurrence({ dateTime: ENRICH_DAY });
 
     const upcomingHtml = buildMeetupHtml({
       "Event:fpchvtyjcfbsb": template,
@@ -952,12 +1138,12 @@ describe("MeetupAdapter", () => {
   });
 
   it("enriches recurring event from detail page", async () => {
-    const template = buildRecurringTemplate({ dateTime: "2026-03-14T11:00:00-04:00" });
+    const template = buildRecurringTemplate({ dateTime: ENRICH_DAY });
     const detailEvent = buildApolloEvent({
       id: "fpchvtyjcfbsb",
       title: "SAVH3 Trail #1324 — Forsyth Park!",
       description: "<p>Detailed hare info and shiggy level</p>",
-      dateTime: "2026-03-14T11:00:00-04:00",
+      dateTime: ENRICH_DAY,
     });
 
     const upcomingHtml = buildMeetupHtml({
@@ -983,13 +1169,13 @@ describe("MeetupAdapter", () => {
   });
 
   it("does not enrich from detail page when event ID does not match", async () => {
-    const template = buildRecurringTemplate({ dateTime: "2026-03-14T11:00:00-04:00" });
+    const template = buildRecurringTemplate({ dateTime: ENRICH_DAY });
     // Detail page contains a different event ID — should NOT be used for enrichment
     const unrelatedEvent = buildApolloEvent({
       id: "unrelated-999",
       title: "Wrong Event Title",
       description: "<p>Wrong event data</p>",
-      dateTime: "2026-03-14T11:00:00-04:00",
+      dateTime: ENRICH_DAY,
     });
 
     const upcomingHtml = buildMeetupHtml({
@@ -1016,7 +1202,7 @@ describe("MeetupAdapter", () => {
   });
 
   it("falls back to list data when detail page fetch fails", async () => {
-    const template = buildRecurringTemplate({ dateTime: "2026-03-14T11:00:00-04:00" });
+    const template = buildRecurringTemplate({ dateTime: ENRICH_DAY });
 
     const upcomingHtml = buildMeetupHtml({
       "Event:fpchvtyjcfbsb": template,
@@ -1044,7 +1230,7 @@ describe("MeetupAdapter", () => {
   });
 
   it("skips detail page fetch for non-recurring events", async () => {
-    const normalEvent = buildApolloEvent({ dateTime: "2026-03-14T11:00:00-04:00" });
+    const normalEvent = buildApolloEvent({ dateTime: ENRICH_DAY });
 
     const upcomingHtml = buildMeetupHtml({
       "Event:1": normalEvent,
@@ -1165,8 +1351,8 @@ describe("MeetupAdapter", () => {
   });
 
   it("includes dedup and enrichment stats in diagnosticContext", async () => {
-    const template = buildRecurringTemplate({ dateTime: "2026-03-14T11:00:00-04:00" });
-    const customized = buildCustomizedOccurrence({ dateTime: "2026-03-14T11:00:00-04:00" });
+    const template = buildRecurringTemplate({ dateTime: ENRICH_DAY });
+    const customized = buildCustomizedOccurrence({ dateTime: ENRICH_DAY });
 
     const upcomingHtml = buildMeetupHtml({
       "Event:fpchvtyjcfbsb": template,
@@ -1243,10 +1429,124 @@ describe("dedupByDate", () => {
   });
 });
 
+// ── group-template boilerplate detection (#2058/#2059/#2062) ──
+
+describe("normalizeDescriptionKey", () => {
+  it("collapses whitespace and lowercases", () => {
+    expect(normalizeDescriptionKey("  Hello   World \n FOO ")).toBe("hello world foo");
+  });
+
+  it("matches templates that differ only in spacing/case", () => {
+    expect(normalizeDescriptionKey("Run/Walk\n\nThen Beer")).toBe(
+      normalizeDescriptionKey("run/walk then beer"),
+    );
+  });
+});
+
+describe("detectBoilerplateBlocks", () => {
+  it("returns empty set for an empty corpus", () => {
+    expect(detectBoilerplateBlocks([]).size).toBe(0);
+  });
+
+  it("returns empty set when every description is unique", () => {
+    const set = detectBoilerplateBlocks(["alpha notes", "beta notes", "gamma notes"]);
+    expect(set.size).toBe(0);
+  });
+
+  it("flags a whole single-block description that repeats across >= 2 events", () => {
+    const tmpl = "Structure / This event will be a run/walk";
+    const set = detectBoilerplateBlocks([tmpl, tmpl, "real per-event notes"]);
+    expect(set.has(normalizeDescriptionKey(tmpl))).toBe(true);
+    expect(set.has(normalizeDescriptionKey("real per-event notes"))).toBe(false);
+  });
+
+  it("flags a shared paragraph block even when the per-event tail differs (#2059)", () => {
+    const club = "Hogtown HH3 is a Toronto social running group.";
+    const a = `${club}\n\nDate: Fri June 12. Cost: $15.`;
+    const b = `${club}\n\nDate: Thu June 25. Cost: $10.`;
+    const set = detectBoilerplateBlocks([a, b]);
+    expect(set.has(normalizeDescriptionKey(club))).toBe(true);
+    // The per-event logistics stanzas differ → not boilerplate.
+    expect(set.has(normalizeDescriptionKey("Date: Fri June 12. Cost: $15."))).toBe(false);
+  });
+
+  it("ignores undefined and empty/whitespace-only descriptions (cannot be a template)", () => {
+    const set = detectBoilerplateBlocks([undefined, "   ", undefined, ""]);
+    expect(set.size).toBe(0);
+  });
+
+  it("does not self-promote a block a single event repeats internally", () => {
+    // One event with the same paragraph twice must NOT count as >= 2 events.
+    const set = detectBoilerplateBlocks(["dup para\n\ndup para", "other"]);
+    expect(set.size).toBe(0);
+  });
+});
+
+describe("stripBoilerplateBlocks", () => {
+  const club = "Hogtown HH3 is a Toronto social running group.";
+  const blocks = new Set([normalizeDescriptionKey(club)]);
+
+  it("returns null when every block is boilerplate", () => {
+    expect(stripBoilerplateBlocks(club, blocks)).toBeNull();
+  });
+
+  it("strips the boilerplate block and keeps the per-event tail", () => {
+    const desc = `${club}\n\nDate: Thu June 25. Cost: $10.`;
+    expect(stripBoilerplateBlocks(desc, blocks)).toBe("Date: Thu June 25. Cost: $10.");
+  });
+
+  it("returns the original string verbatim when nothing is boilerplate", () => {
+    const desc = "Real notes line 1\n\nReal notes line 2";
+    expect(stripBoilerplateBlocks(desc, blocks)).toBe(desc);
+  });
+});
+
 // ── buildRawEventFromApollo — kennelPatterns ──
 
 describe("buildRawEventFromApollo — kennelPatterns", () => {
   const emptyState = {} as Record<string, Record<string, unknown>>;
+
+  it("clears description to null when the whole description is boilerplate (#2058/#2059/#2062)", () => {
+    const ev = {
+      __typename: "Event",
+      id: "bp",
+      title: "MH3 Run #1683",
+      dateTime: "2026-04-01T18:30:00-04:00",
+      description: "<p>Structure / standing club template</p>",
+    };
+    const boilerplate = new Set([normalizeDescriptionKey("Structure / standing club template")]);
+    const event = buildRawEventFromApollo(ev as never, emptyState, "mh3-ca", undefined, false, undefined, boilerplate);
+    expect(event.description).toBeNull();
+  });
+
+  it("strips the boilerplate block but keeps the per-event tail (#2059 Hogtown)", () => {
+    // Real Meetup descriptions are markdown with literal blank-line paragraph
+    // breaks (the club blurb and the logistics stanza are separate paragraphs).
+    const club = "Hogtown HH3 is a Toronto social running group.";
+    const ev = {
+      __typename: "Event",
+      id: "ht",
+      title: "Thursday run",
+      dateTime: "2026-04-01T18:30:00-04:00",
+      description: `${club}\n\nDate: Thu. Cost: $10.`,
+    };
+    const boilerplate = new Set([normalizeDescriptionKey(club)]);
+    const event = buildRawEventFromApollo(ev as never, emptyState, "hogtownh3", undefined, false, undefined, boilerplate);
+    expect(event.description).toBe("Date: Thu. Cost: $10.");
+  });
+
+  it("keeps description untouched when no block is boilerplate", () => {
+    const ev = {
+      __typename: "Event",
+      id: "ok",
+      title: "MH3 Run #1683",
+      dateTime: "2026-04-01T18:30:00-04:00",
+      description: "<p>Real per-event notes: meet at the park</p>",
+    };
+    const boilerplate = new Set([normalizeDescriptionKey("some other template")]);
+    const event = buildRawEventFromApollo(ev as never, emptyState, "mh3-ca", undefined, false, undefined, boilerplate);
+    expect(event.description).toBe("Real per-event notes: meet at the park");
+  });
 
   it("suppresses endTime when end is on a different calendar day (overnight run)", () => {
     const ev = {

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1515,7 +1515,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       description: "<p>Structure / standing club template</p>",
     };
     const boilerplate = new Set([normalizeDescriptionKey("Structure / standing club template")]);
-    const event = buildRawEventFromApollo(ev as never, emptyState, "mh3-ca", undefined, false, undefined, boilerplate);
+    const event = buildRawEventFromApollo(ev, emptyState, "mh3-ca", undefined, false, undefined, boilerplate);
     expect(event.description).toBeNull();
   });
 
@@ -1531,7 +1531,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       description: `${club}\n\nDate: Thu. Cost: $10.`,
     };
     const boilerplate = new Set([normalizeDescriptionKey(club)]);
-    const event = buildRawEventFromApollo(ev as never, emptyState, "hogtownh3", undefined, false, undefined, boilerplate);
+    const event = buildRawEventFromApollo(ev, emptyState, "hogtownh3", undefined, false, undefined, boilerplate);
     expect(event.description).toBe("Date: Thu. Cost: $10.");
   });
 
@@ -1544,7 +1544,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       description: "<p>Real per-event notes: meet at the park</p>",
     };
     const boilerplate = new Set([normalizeDescriptionKey("some other template")]);
-    const event = buildRawEventFromApollo(ev as never, emptyState, "mh3-ca", undefined, false, undefined, boilerplate);
+    const event = buildRawEventFromApollo(ev, emptyState, "mh3-ca", undefined, false, undefined, boilerplate);
     expect(event.description).toBe("Real per-event notes: meet at the park");
   });
 

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1515,7 +1515,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       description: "<p>Structure / standing club template</p>",
     };
     const boilerplate = new Set([normalizeDescriptionKey("Structure / standing club template")]);
-    const event = buildRawEventFromApollo(ev, emptyState, "mh3-ca", undefined, false, undefined, boilerplate);
+    const event = buildRawEventFromApollo(ev, emptyState, "mh3-ca", undefined, false, undefined, { blocks: boilerplate });
     expect(event.description).toBeNull();
   });
 
@@ -1531,7 +1531,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       description: `${club}\n\nDate: Thu. Cost: $10.`,
     };
     const boilerplate = new Set([normalizeDescriptionKey(club)]);
-    const event = buildRawEventFromApollo(ev, emptyState, "hogtownh3", undefined, false, undefined, boilerplate);
+    const event = buildRawEventFromApollo(ev, emptyState, "hogtownh3", undefined, false, undefined, { blocks: boilerplate });
     expect(event.description).toBe("Date: Thu. Cost: $10.");
   });
 
@@ -1544,7 +1544,7 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
       description: "<p>Real per-event notes: meet at the park</p>",
     };
     const boilerplate = new Set([normalizeDescriptionKey("some other template")]);
-    const event = buildRawEventFromApollo(ev, emptyState, "mh3-ca", undefined, false, undefined, boilerplate);
+    const event = buildRawEventFromApollo(ev, emptyState, "mh3-ca", undefined, false, undefined, { blocks: boilerplate });
     expect(event.description).toBe("Real per-event notes: meet at the park");
   });
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -2,7 +2,7 @@ import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { validateSourceConfig, stripHtmlTags, buildDateWindow, extractHashRunNumber, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "../utils";
+import { validateSourceConfig, stripHtmlTags, buildDateWindow, extractHashRunNumber, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS, splitDescriptionBlocks, normalizeDescriptionKey } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { extractHares as extractHaresFromDescription } from "../hare-extraction";
 import { isPlatformDepartureTitle } from "../skip-rules";
@@ -362,6 +362,69 @@ function cleanMeetupDescription(
 }
 
 /**
+ * Detect group-template boilerplate structurally (#2058/#2059/#2062): Meetup
+ * stores a kennel's standing recurring-event template as part of *every*
+ * occurrence's description, displacing run-specific notes. The structural
+ * fingerprint of a template paragraph is that it appears verbatim across
+ * multiple events in a single fetch; genuine per-event notes appear once.
+ *
+ * Returns the set of normalized *paragraph-block* keys that occur in >= 2
+ * distinct events. Block granularity (not whole-string) is required because
+ * some kennels (Hogtown H3, #2059) prepend the standing club blurb to a
+ * per-event logistics stanza — the whole description differs per event, but the
+ * club paragraph repeats and must be stripped while the logistics stanza
+ * survives. Blocks are deduped within a single event so one event repeating a
+ * paragraph doesn't self-promote it to boilerplate. Empty/whitespace-only
+ * blocks carry no key and never count.
+ *
+ * Block boundary = blank line. `cleanMeetupDescription` strips HTML with a
+ * SPACE separator, so paragraph blocks survive only when the source carries
+ * literal markdown `\n\n` — which is how real Meetup descriptions arrive
+ * (verified live for all three incident kennels). A purely-HTML `<p>…</p><p>…</p>`
+ * description collapses to one block and degrades to whole-string matching: a
+ * fully-repeated template still nulls, only the partial club-blurb strip won't
+ * fire. That's a graceful degradation, not a silent failure of the core goal.
+ */
+export function detectBoilerplateBlocks(
+  cleanedDescriptions: (string | undefined)[],
+): Set<string> {
+  const counts = new Map<string, number>();
+  for (const desc of cleanedDescriptions) {
+    if (!desc) continue;
+    const seen = new Set<string>();
+    for (const block of splitDescriptionBlocks(desc)) {
+      const key = normalizeDescriptionKey(block);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  const boilerplate = new Set<string>();
+  for (const [key, count] of counts) {
+    if (count >= 2) boilerplate.add(key);
+  }
+  return boilerplate;
+}
+
+/**
+ * Remove boilerplate paragraph blocks from a cleaned description. Returns the
+ * surviving blocks rejoined with `\n\n`; `null` (explicit clear, per merge.ts
+ * UPDATE contract) when every block was boilerplate — that wipes a fully
+ * templated description (Savannah/Montreal). When NO block is boilerplate the
+ * original string is returned **verbatim** (not re-joined), so a genuine
+ * per-event description survives byte-for-byte untouched.
+ */
+export function stripBoilerplateBlocks(
+  desc: string,
+  boilerplateBlocks: Set<string>,
+): string | null {
+  const blocks = splitDescriptionBlocks(desc);
+  const kept = blocks.filter((b) => !boilerplateBlocks.has(normalizeDescriptionKey(b)));
+  if (kept.length === blocks.length) return desc;
+  return kept.length > 0 ? kept.join("\n\n") : null;
+}
+
+/**
  * Extract local date and time from an ISO 8601 dateTime string.
  * "2026-03-05T18:30:00-05:00" → { date: "2026-03-05", startTime: "18:30" }
  * Uses the local portion of the string (not UTC conversion).
@@ -582,6 +645,7 @@ export function buildRawEventFromApollo(
   compiledPatterns?: [RegExp, string][],
   extractRunNumber = false,
   runNumberPrefix?: string,
+  boilerplateBlocks?: Set<string>,
 ): RawEventData {
   const { date, startTime } = ev.dateTime
     ? extractDateTime(ev.dateTime)
@@ -605,6 +669,18 @@ export function buildRawEventFromApollo(
 
   const { hares, titleForDisplay } = resolveMeetupHares(ev.description, ev.title);
   const cleanedDesc = cleanMeetupDescription(ev.description, state);
+  // Group-template boilerplate (#2058/#2059/#2062): strip paragraph blocks the
+  // group reuses verbatim across >= 2 events (the standing recurring-event
+  // template), keeping any run-specific blocks. A fully templated description
+  // collapses to `null` (explicit clear, per merge.ts UPDATE contract) so the
+  // stored boilerplate is wiped; a description with no boilerplate is returned
+  // untouched. Hare extraction above still runs on the raw description — only
+  // the stored `description` field is affected. `boilerplateBlocks` is undefined
+  // when called outside fetch() (unit tests), preserving prior behavior.
+  const finalDesc =
+    cleanedDesc !== undefined && boilerplateBlocks
+      ? stripBoilerplateBlocks(cleanedDesc, boilerplateBlocks)
+      : cleanedDesc;
 
   return {
     date,
@@ -614,7 +690,7 @@ export function buildRawEventFromApollo(
     // lives in resolveRunNumber so this builder stays under the cognitive-
     // complexity budget. Display title keeps the kennel's stylization.
     runNumber: resolveRunNumber(ev.title, extractRunNumber, runNumberPrefix),
-    description: cleanedDesc,
+    description: finalDesc,
     hares,
     location: venueInfo.location,
     latitude: venueInfo.latitude,
@@ -785,9 +861,23 @@ export class MeetupAdapter implements SourceAdapter {
       errorDetails.parse = [{ row: 0, error: message }];
     }
 
+    // Detect group-template boilerplate structurally: a paragraph block the
+    // group reuses verbatim across >= 2 events is part of its standing
+    // recurring-event template, not run-specific notes (#2058/#2059/#2062).
+    // Computed once over the post-enrichment event set (index-aligned with
+    // allApolloEvents) so per-occurrence detail-page overrides are reflected.
+    // The pre-cleaned values back the per-event "was boilerplate stripped?"
+    // diagnostic below; the builder recomputes cleanMeetupDescription so both
+    // stay consistent.
+    const cleanedDescriptions = allApolloEvents.map((ev) =>
+      cleanMeetupDescription(ev.description, mergedState),
+    );
+    const boilerplateBlocks = detectBoilerplateBlocks(cleanedDescriptions);
+
     const compiledPatterns = compileKennelPatterns(config.kennelPatterns);
     let cancelledSkipped = 0;
     let adminNoticeSkipped = 0;
+    let boilerplateDescriptionsDropped = 0;
     // Collect the titles we drop as admin notices so admins can audit
     // false positives in the scrape diagnostics (#1728).
     const adminNoticeTitles: string[] = [];
@@ -822,7 +912,14 @@ export class MeetupAdapter implements SourceAdapter {
         // hydrated from persisted JSON, where any truthy value would pass
         // through unintentionally. Only literal `true` opts in.
         const shouldExtractRunNumber = config.extractRunNumber === true;
-        events.push(buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix));
+        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, boilerplateBlocks);
+        // Count events whose description had boilerplate removed (fully nulled
+        // or partially stripped) vs. its pre-strip cleaned value (index-aligned).
+        const cleanedBefore = cleanedDescriptions[i];
+        if (cleanedBefore !== undefined && rawEvent.description !== cleanedBefore) {
+          boilerplateDescriptionsDropped++;
+        }
+        events.push(rawEvent);
       } catch (err) {
         const msg = `Failed to parse event "${ev.id}": ${err instanceof Error ? err.message : String(err)}`;
         errors.push(msg);
@@ -846,6 +943,7 @@ export class MeetupAdapter implements SourceAdapter {
         cancelledSkipped,
         adminNoticeSkipped,
         adminNoticeTitles,
+        boilerplateDescriptionsDropped,
         detailPagesFetched,
         detailPagesEnriched,
       },

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -646,6 +646,11 @@ export function buildRawEventFromApollo(
   extractRunNumber = false,
   runNumberPrefix?: string,
   boilerplateBlocks?: Set<string>,
+  // Pre-cleaned description from fetch()'s detection pre-pass, wrapped so a
+  // legitimately-`undefined` cleaned value (event with no description) is
+  // distinguishable from "not supplied" (the wrapper is absent → recompute).
+  // Avoids a second heavy cleanMeetupDescription (cheerio) pass per event.
+  preCleaned?: { value: string | undefined },
 ): RawEventData {
   const { date, startTime } = ev.dateTime
     ? extractDateTime(ev.dateTime)
@@ -668,7 +673,7 @@ export function buildRawEventFromApollo(
   }
 
   const { hares, titleForDisplay } = resolveMeetupHares(ev.description, ev.title);
-  const cleanedDesc = cleanMeetupDescription(ev.description, state);
+  const cleanedDesc = preCleaned ? preCleaned.value : cleanMeetupDescription(ev.description, state);
   // Group-template boilerplate (#2058/#2059/#2062): strip paragraph blocks the
   // group reuses verbatim across >= 2 events (the standing recurring-event
   // template), keeping any run-specific blocks. A fully templated description
@@ -676,9 +681,10 @@ export function buildRawEventFromApollo(
   // stored boilerplate is wiped; a description with no boilerplate is returned
   // untouched. Hare extraction above still runs on the raw description — only
   // the stored `description` field is affected. `boilerplateBlocks` is undefined
-  // when called outside fetch() (unit tests), preserving prior behavior.
+  // (or empty) when called outside fetch() / with no detected template, so the
+  // strip is skipped entirely and prior behavior is preserved.
   const finalDesc =
-    cleanedDesc !== undefined && boilerplateBlocks
+    cleanedDesc !== undefined && boilerplateBlocks && boilerplateBlocks.size > 0
       ? stripBoilerplateBlocks(cleanedDesc, boilerplateBlocks)
       : cleanedDesc;
 
@@ -912,10 +918,12 @@ export class MeetupAdapter implements SourceAdapter {
         // hydrated from persisted JSON, where any truthy value would pass
         // through unintentionally. Only literal `true` opts in.
         const shouldExtractRunNumber = config.extractRunNumber === true;
-        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, boilerplateBlocks);
-        // Count events whose description had boilerplate removed (fully nulled
-        // or partially stripped) vs. its pre-strip cleaned value (index-aligned).
+        // Reuse the pre-pass cleaned value (index-aligned) so the builder
+        // doesn't re-run the heavy cleanMeetupDescription/cheerio parse.
         const cleanedBefore = cleanedDescriptions[i];
+        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, boilerplateBlocks, { value: cleanedBefore });
+        // Count events whose description had boilerplate removed (fully nulled
+        // or partially stripped) vs. its pre-strip cleaned value.
         if (cleanedBefore !== undefined && rawEvent.description !== cleanedBefore) {
           boilerplateDescriptionsDropped++;
         }

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -645,12 +645,13 @@ export function buildRawEventFromApollo(
   compiledPatterns?: [RegExp, string][],
   extractRunNumber = false,
   runNumberPrefix?: string,
-  boilerplateBlocks?: Set<string>,
-  // Pre-cleaned description from fetch()'s detection pre-pass, wrapped so a
-  // legitimately-`undefined` cleaned value (event with no description) is
-  // distinguishable from "not supplied" (the wrapper is absent → recompute).
-  // Avoids a second heavy cleanMeetupDescription (cheerio) pass per event.
-  preCleaned?: { value: string | undefined },
+  // Boilerplate-processing context from fetch()'s detection pre-pass. `blocks`
+  // are the group-template paragraph keys to strip. `preCleaned` carries the
+  // already-computed cleaned description (wrapped so a legitimately-`undefined`
+  // value is distinguishable from "not supplied" → recompute) to avoid a second
+  // heavy cleanMeetupDescription (cheerio) pass per event. Bundled into one
+  // object so the signature stays within the param-count budget.
+  boilerplate?: { blocks?: Set<string>; preCleaned?: { value: string | undefined } },
 ): RawEventData {
   const { date, startTime } = ev.dateTime
     ? extractDateTime(ev.dateTime)
@@ -673,19 +674,22 @@ export function buildRawEventFromApollo(
   }
 
   const { hares, titleForDisplay } = resolveMeetupHares(ev.description, ev.title);
-  const cleanedDesc = preCleaned ? preCleaned.value : cleanMeetupDescription(ev.description, state);
+  const cleanedDesc = boilerplate?.preCleaned
+    ? boilerplate.preCleaned.value
+    : cleanMeetupDescription(ev.description, state);
   // Group-template boilerplate (#2058/#2059/#2062): strip paragraph blocks the
   // group reuses verbatim across >= 2 events (the standing recurring-event
   // template), keeping any run-specific blocks. A fully templated description
   // collapses to `null` (explicit clear, per merge.ts UPDATE contract) so the
   // stored boilerplate is wiped; a description with no boilerplate is returned
   // untouched. Hare extraction above still runs on the raw description — only
-  // the stored `description` field is affected. `boilerplateBlocks` is undefined
-  // (or empty) when called outside fetch() / with no detected template, so the
-  // strip is skipped entirely and prior behavior is preserved.
+  // the stored `description` field is affected. `blocks` is undefined (or empty)
+  // when called outside fetch() / with no detected template, so the strip is
+  // skipped entirely and prior behavior is preserved.
+  const blocks = boilerplate?.blocks;
   const finalDesc =
-    cleanedDesc !== undefined && boilerplateBlocks && boilerplateBlocks.size > 0
-      ? stripBoilerplateBlocks(cleanedDesc, boilerplateBlocks)
+    cleanedDesc !== undefined && blocks && blocks.size > 0
+      ? stripBoilerplateBlocks(cleanedDesc, blocks)
       : cleanedDesc;
 
   return {
@@ -921,7 +925,7 @@ export class MeetupAdapter implements SourceAdapter {
         // Reuse the pre-pass cleaned value (index-aligned) so the builder
         // doesn't re-run the heavy cleanMeetupDescription/cheerio parse.
         const cleanedBefore = cleanedDescriptions[i];
-        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, boilerplateBlocks, { value: cleanedBefore });
+        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, { blocks: boilerplateBlocks, preCleaned: { value: cleanedBefore } });
         // Count events whose description had boilerplate removed (fully nulled
         // or partially stripped) vs. its pre-strip cleaned value.
         if (cleanedBefore !== undefined && rawEvent.description !== cleanedBefore) {

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -1236,6 +1236,28 @@ export function appendDescriptionSuffix(
 }
 
 /**
+ * Split a description into blank-line-delimited paragraph blocks (trimmed,
+ * empties dropped). Shared by `dedupeRepeatedDescription` and the Meetup
+ * boilerplate detector — both key off paragraph boundaries, so the split lives
+ * here to avoid drift between them.
+ */
+export function splitDescriptionBlocks(desc: string): string[] {
+  return desc
+    .split(/\n\s*\n/)
+    .map((b) => b.trim())
+    .filter((b) => b.length > 0);
+}
+
+/**
+ * Normalize a description (or block) for whitespace-/case-insensitive equality:
+ * collapse all whitespace runs to a single space, trim, lowercase. Used as a
+ * comparison key only — never stored.
+ */
+export function normalizeDescriptionKey(desc: string): string {
+  return desc.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+/**
  * Collapse a description whose blank-line-separated blocks are the same
  * sequence repeated twice back-to-back (#1889 Morgantown: a Google Calendar
  * entry whose body block is pasted verbatim twice). Splits on blank lines into
@@ -1254,17 +1276,13 @@ export function dedupeRepeatedDescription(
   const text = description.trim();
   if (!text) return description;
 
-  const blocks = text
-    .split(/\n\s*\n/)
-    .map((b) => b.trim())
-    .filter((b) => b.length > 0);
+  const blocks = splitDescriptionBlocks(text);
   if (blocks.length < 2 || blocks.length % 2 !== 0) return description;
 
   const half = blocks.length / 2;
-  const norm = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
   const isDoubled = blocks
     .slice(0, half)
-    .every((b, i) => norm(b) === norm(blocks[half + i]));
+    .every((b, i) => normalizeDescriptionKey(b) === normalizeDescriptionKey(blocks[half + i]));
 
   return isDoubled ? blocks.slice(0, half).join("\n\n") : description;
 }


### PR DESCRIPTION
## Problem

The MEETUP adapter stamps a kennel's **standing recurring-event template** onto every occurrence's `description`, displacing run-specific notes:

- **#2058 MH3 Montreal** — run #1692 shows the "Structure / Don't Arrive Late! / What Are The Hash House Harriers?…" template.
- **#2059 Hogtown H3** — TWAT #582 leads with "Hogtown Hash House Harriers (HH3) is a Toronto social running…" club blurb.
- **#2062 Savannah H3** — every "Saturday Trail!" shows "Join us for our weekly hashing trail! Event details are posted by Thursday…".

One root cause: `cleanMeetupDescription` stored the template verbatim.

## Fix — structural, not a keyword list

A paragraph block a group reuses **verbatim across ≥2 events in a single fetch** is its standing template; genuine per-event notes appear once.

- `detectBoilerplateBlocks` / `stripBoilerplateBlocks` run over the post-enrichment fetch set. A fully templated description collapses to `null` (explicit clear, per the `merge.ts` UPDATE contract); a club blurb prepended to a per-event logistics stanza is **partially** stripped; a unique description is returned **byte-for-byte untouched**.
- **Block** (not whole-string) granularity is required for Hogtown, whose club paragraph repeats while the per-event Date/Start/Cost stanza varies — whole-string never matched.
- Default-on for all Meetup sources: the signal is structural, so no per-source config. Hare extraction still reads the **raw** description (only the stored `description` field is affected).
- `description` is in the RawEvent fingerprint, so this triggers a one-time re-merge wave that UPDATEs existing canonicals (matched by kennel+date) — no ghost events.

## Live verification (all three groups, `days: 365`)

| Kennel | events | boilerplate removed | nulled | kept (real notes) |
|---|---|---|---|---|
| Savannah (savh3) | 40 | 35 | 30 | 10 |
| Hogtown (hogtownh3) | 11 | 10 (club blurb stripped, logistics kept) | 0 | 11 |
| MH3 Montreal (mh3-ca) | 13 | 13 | 8 | 5 |

Run #1692 → `null`; genuine per-event notes (REM-station trail, park run, "Join us at Jerry's Lounge…") survive untouched.

## Also in this PR

- **utils:** hoisted shared `splitDescriptionBlocks` + `normalizeDescriptionKey`; `dedupeRepeatedDescription` now reuses them (was a private byte-identical copy).
- **tests:** additive + negative fixtures (real per-event notes survive, Hogtown partial strip, no-false-positive); de-bombed the windowed `.fetch()` fixtures to now-relative dates (Memory: `feedback_windowed_adapter_test_needs_relative_dates`).
- **`scripts/cleanup-meetup-boilerplate-descriptions.ts`** — one-shot to clear **already-stored** boilerplate. Needed for trust-gated kennels (Montreal Meetup trust-7 < mhhh.ca trust-9 → forward emit hits the fill-only enrich branch and can't reach the merge clear path). Dry-run default; scoped to the 3 incident kennels (`--all` opts into the full corpus after review); provenance-guarded against `RawEvent.rawData` (immutable, so any strip is recoverable); idempotent. **Run after deploy, before any `force` re-scrape.**

## Checks

`npm run lint` ✅ · `npx tsc --noEmit` ✅ · `npm test` ✅ (8818 passing). Reviewed with `/codex:adversarial-review` (blast-radius hardening applied to the cleanup script) and `/simplify`.

Closes #2058
Closes #2059
Closes #2062

🤖 Generated with [Claude Code](https://claude.com/claude-code)