### PR TITLE
feat(kennels): Corpus Christi area routing — land on main (re-merge of #2087)

### DIFF
--- a/prisma/seed-data/aliases.ts
+++ b/prisma/seed-data/aliases.ts
@@ -177,6 +177,8 @@ export const KENNEL_ALIASES: Record<string, string[]> = {
     "yakh3": ["Yak Hash", "YAKH3", "YakH3", "DFW Yak Hash"],
     "sah3": ["San Antonio Hash", "San Antonio H3", "SAH3", "SA Hash"],
     "c2h3": ["Corpus Christi Hash", "Corpus Christi H3", "C2H3", "CC Hash"],
+    "balh3": ["Bay Area Larrikins", "Bay Area Larrikin", "BALH3", "BAL Hash"],
+    "cbh3-cc": ["Coastal Bend Hash", "Coastal Bend H3", "CBH3 Corpus Christi"],
     // Florida
     "mia-h3": ["Miami Hash", "Miami H3", "Dade H3", "MH3"],
     "wildcard-h3": ["Wildcard Hash", "FTL Wildcard", "Fort Lauderdale Wildcard"],

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1717,6 +1717,21 @@ export const KENNELS: KennelSeed[] = [
       description: "Bi-weekly Thursday-evening hash in Corpus Christi, with occasional Saturday runs.",
       latitude: 27.80, longitude: -97.40,
     },
+    // Bay Area Larrikins + Coastal Bend share the Corpus Christi area calendar
+    // (c2h3hash@gmail.com) and are routed off it via kennelPatterns. kennelCode
+    // "cbh3" is taken by Miami's Corned Beef Hash, so Coastal Bend uses "cbh3-cc".
+    {
+      kennelCode: "balh3", shortName: "BALH3", fullName: "Bay Area Larrikins Hash House Harriers", region: "Corpus Christi, TX",
+      scheduleTime: "6:30 PM",
+      hashCash: "$5",
+      description: "Bay Area Larrikins hash in the Corpus Christi, TX area.",
+      latitude: 27.80, longitude: -97.40,
+    },
+    {
+      kennelCode: "cbh3-cc", shortName: "Coastal Bend H3", fullName: "Coastal Bend Hash House Harriers", region: "Corpus Christi, TX",
+      description: "Coastal Bend hash in the Corpus Christi, TX area.",
+      latitude: 27.80, longitude: -97.40,
+    },
     // ===== FLORIDA =====
     // --- Miami / South Florida ---
     {

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -1725,12 +1725,12 @@ export const KENNELS: KennelSeed[] = [
       scheduleTime: "6:30 PM",
       hashCash: "$5",
       description: "Bay Area Larrikins hash in the Corpus Christi, TX area.",
-      latitude: 27.80, longitude: -97.40,
+      latitude: 27.8, longitude: -97.4,
     },
     {
       kennelCode: "cbh3-cc", shortName: "Coastal Bend H3", fullName: "Coastal Bend Hash House Harriers", region: "Corpus Christi, TX",
       description: "Coastal Bend hash in the Corpus Christi, TX area.",
-      latitude: 27.80, longitude: -97.40,
+      latitude: 27.8, longitude: -97.4,
     },
     // ===== FLORIDA =====
     // --- Miami / South Florida ---

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1207,7 +1207,23 @@ export const SOURCES = [
       scrapeFreq: "every_6h",
       scrapeDays: 365,
       config: {
+        // This is the shared Corpus Christi-area calendar: ~70% of its events
+        // are Bay Area Larrikins (BALH3) or Coastal Bend (CBH3) runs, not C2H3.
+        // Route each prefix to its own kennel; prefix-less themed trails fall to
+        // the C2H3 default (the calendar owner). Specific patterns precede
+        // generic. NOT strictKennelRouting: legit C2H3 trails are frequently
+        // posted without a kennel prefix ("Cinco de Mayo May Trail").
+        kennelPatterns: [
+          ["^BALH3\\b|Bay Area Larrikin", "balh3"],
+          ["^CBH3\\b", "cbh3-cc"],
+          ["^C2H3\\b|^Corpus Christi", "c2h3"],
+        ],
         defaultKennelTag: "c2h3",
+        // Coastal Bend (CBH3) posts ~all of its runs as all-day entries, so
+        // they're invisible without this. Trades in a handful of all-day
+        // personal/admin one-offs (routed to the C2H3 default), which is an
+        // acceptable cost for capturing the CBH3 kennel.
+        includeAllDayEvents: true,
         // Calendar feed publishes dateTime as UTC; without this the wall-clock
         // slice misreads the UTC hour as local and trips event-improbable-time
         // on every Thursday run (#964 + 15 daily duplicates).
@@ -1218,7 +1234,7 @@ export const SOURCES = [
         // the title.
         summaryIsCanonicalTitle: true,
       },
-      kennelCodes: ["c2h3"],
+      kennelCodes: ["c2h3", "balh3", "cbh3-cc"],
     },
     // ===== UPSTATE NEW YORK =====
     // --- Rochester (Google Calendar) ---

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1214,9 +1214,9 @@ export const SOURCES = [
         // generic. NOT strictKennelRouting: legit C2H3 trails are frequently
         // posted without a kennel prefix ("Cinco de Mayo May Trail").
         kennelPatterns: [
-          ["^BALH3\\b|Bay Area Larrikin", "balh3"],
-          ["^CBH3\\b", "cbh3-cc"],
-          ["^C2H3\\b|^Corpus Christi", "c2h3"],
+          [String.raw`^BALH3\b|^Bay Area Larrikin`, "balh3"],
+          [String.raw`^CBH3\b`, "cbh3-cc"],
+          [String.raw`^C2H3\b|^Corpus Christi`, "c2h3"],
         ],
         defaultKennelTag: "c2h3",
         // Coastal Bend (CBH3) posts ~all of its runs as all-day entries, so

--- a/scripts/cleanup-corpus-christi-misroute.ts
+++ b/scripts/cleanup-corpus-christi-misroute.ts
@@ -42,15 +42,19 @@ import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
 import type { Source } from "@/generated/prisma/client";
 import { deleteLeakedEvent } from "./lib/delete-leaked-event";
 
+interface Anchors {
+  c2h3Id: string;
+  source: Source;
+  /** kennelTag → kennel id, for the kennels we reassign INTO. */
+  targetByTag: Map<string, string>;
+}
+
 function utcDayBounds(date: Date): { gte: Date; lte: Date } {
   const d = date.toISOString().slice(0, 10);
   return { gte: new Date(`${d}T00:00:00.000Z`), lte: new Date(`${d}T23:59:59.999Z`) };
 }
 
-async function main() {
-  const apply = process.argv.includes("--apply");
-  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}`);
-
+async function loadAnchors(): Promise<Anchors | null> {
   const [c2h3, balh3, cbh3cc, source] = await Promise.all([
     prisma.kennel.findUnique({ where: { kennelCode: "c2h3" }, select: { id: true } }),
     prisma.kennel.findUnique({ where: { kennelCode: "balh3" }, select: { id: true } }),
@@ -60,56 +64,85 @@ async function main() {
   if (!c2h3 || !balh3 || !cbh3cc || !source) {
     console.error(`Missing anchor(s): c2h3=${!!c2h3} balh3=${!!balh3} cbh3-cc=${!!cbh3cc} source=${!!source}`);
     console.error("Run `npx prisma db seed` first so the new kennels + routing exist.");
-    process.exitCode = 1;
-    return;
+    return null;
   }
-  const targetByTag: Record<string, string> = { balh3: balh3.id, "cbh3-cc": cbh3cc.id };
+  return {
+    c2h3Id: c2h3.id,
+    source,
+    targetByTag: new Map([["balh3", balh3.id], ["cbh3-cc", cbh3cc.id]]),
+  };
+}
 
-  // Re-route the live calendar with the SEEDED config (same routing the scrape
-  // uses) → stable sourceUrl ⇒ correct kennelTag.
-  const res = await new GoogleCalendarAdapter().fetch(source as Source, { days: 3650 });
+/**
+ * Re-route the live calendar with the seeded config (the same routing the scrape
+ * uses) and map each stable sourceUrl → the kennelTag we reassign INTO. Throws on
+ * a failed/empty fetch so a bad API response can't be mistaken for "nothing to do".
+ */
+async function buildUrlToTagMap(source: Source, targetByTag: Map<string, string>): Promise<Map<string, string>> {
+  const res = await new GoogleCalendarAdapter().fetch(source, { days: 3650 });
+  if (res.errors.length > 0) {
+    throw new Error(`Calendar fetch returned errors; aborting: ${JSON.stringify(res.errors)}`);
+  }
+  if (res.events.length === 0) {
+    throw new Error("Calendar fetch returned zero events; aborting (likely a failed fetch, not an empty calendar).");
+  }
   const urlToTag = new Map<string, string>();
   for (const e of res.events) {
     const tag = e.kennelTags[0];
-    if (e.sourceUrl && (tag === "balh3" || tag === "cbh3-cc")) urlToTag.set(e.sourceUrl, tag);
+    if (e.sourceUrl && targetByTag.has(tag)) urlToTag.set(e.sourceUrl, tag);
   }
-  console.log(`Live re-route: ${urlToTag.size} sourceUrls map to balh3 / cbh3-cc`);
+  return urlToTag;
+}
 
+async function reassignEvents(anchors: Anchors, urlToTag: Map<string, string>, apply: boolean) {
+  const { c2h3Id, targetByTag } = anchors;
   const events = await prisma.event.findMany({
-    where: { kennelId: c2h3.id },
+    where: { kennelId: c2h3Id },
     select: { id: true, date: true, title: true, sourceUrl: true },
   });
   console.log(`c2h3 canonical events: ${events.length}`);
 
   let reassigned = 0, deleted = 0;
-  const byTag: Record<string, number> = { balh3: 0, "cbh3-cc": 0 };
+  const byTag = new Map<string, number>();
   for (const ev of events) {
-    if (!ev.sourceUrl) continue;
-    const tag = urlToTag.get(ev.sourceUrl);
-    if (!tag) continue; // stays c2h3 — real C2H3, noise, or outside the fetch window
-    const targetId = targetByTag[tag];
+    const tag = ev.sourceUrl ? urlToTag.get(ev.sourceUrl) : undefined;
+    const targetId = tag ? targetByTag.get(tag) : undefined;
+    if (!tag || !targetId) continue; // stays c2h3 — real C2H3, noise, or outside the window
+    const day = ev.date.toISOString().slice(0, 10);
     const { gte, lte } = utcDayBounds(ev.date);
     const existing = await prisma.event.findFirst({
       where: { kennelId: targetId, date: { gte, lte }, id: { not: ev.id } },
       select: { id: true },
     });
-
     if (existing) {
-      console.log(`  DELETE stale dup ${ev.id} (${ev.date.toISOString().slice(0, 10)} "${ev.title ?? ""}") — ${tag} ${existing.id} already canonical`);
+      console.log(`  DELETE stale dup ${ev.id} (${day} "${ev.title ?? ""}") — ${tag} ${existing.id} already canonical`);
       if (apply) await deleteLeakedEvent(prisma, ev.id, ["attendances", "kennelAttendances"]);
       deleted++;
     } else {
-      console.log(`  REASSIGN ${ev.id} (${ev.date.toISOString().slice(0, 10)} "${ev.title ?? ""}") c2h3 → ${tag}`);
+      console.log(`  REASSIGN ${ev.id} (${day} "${ev.title ?? ""}") c2h3 → ${tag}`);
       if (apply) {
-        await prisma.eventKennel.updateMany({ where: { eventId: ev.id, kennelId: c2h3.id }, data: { kennelId: targetId } });
+        await prisma.eventKennel.updateMany({ where: { eventId: ev.id, kennelId: c2h3Id }, data: { kennelId: targetId } });
         await prisma.event.update({ where: { id: ev.id }, data: { kennelId: targetId } });
       }
       reassigned++;
-      byTag[tag]++;
+      byTag.set(tag, (byTag.get(tag) ?? 0) + 1);
     }
   }
+  return { reassigned, deleted, byTag };
+}
 
-  console.log(`\n${apply ? "Applied" : "Would"}: reassign ${reassigned} (balh3 ${byTag.balh3}, cbh3-cc ${byTag["cbh3-cc"]}), delete ${deleted}`);
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}`);
+
+  const anchors = await loadAnchors();
+  if (!anchors) { process.exitCode = 1; return; }
+
+  const urlToTag = await buildUrlToTagMap(anchors.source, anchors.targetByTag);
+  console.log(`Live re-route: ${urlToTag.size} sourceUrls map to balh3 / cbh3-cc`);
+
+  const { reassigned, deleted, byTag } = await reassignEvents(anchors, urlToTag, apply);
+  console.log(`\n${apply ? "Applied" : "Would"}: reassign ${reassigned} (balh3 ${byTag.get("balh3") ?? 0}, cbh3-cc ${byTag.get("cbh3-cc") ?? 0}), delete ${deleted}`);
   if (apply && (reassigned > 0 || deleted > 0)) {
     const n = await backfillLastEventDates();
     console.log(`Recomputed lastEventDate for ${n} kennel(s).`);

--- a/scripts/cleanup-corpus-christi-misroute.ts
+++ b/scripts/cleanup-corpus-christi-misroute.ts
@@ -1,0 +1,121 @@
+/**
+ * One-shot cleanup for the Corpus Christi area calendar mis-attribution.
+ *
+ * Background:
+ *   "Corpus Christi H3 Calendar" (c2h3hash@gmail.com) is actually a shared
+ *   Corpus Christi-area calendar: ~70% of its events are Bay Area Larrikins
+ *   (BALH3 → `balh3`) or Coastal Bend (CBH3 → `cbh3-cc`) runs, not C2H3. With no
+ *   kennelPatterns, every event routed to `c2h3`, so ~233+ BALH3 trails landed
+ *   on the Corpus Christi H3 kennel page. The seed fix adds kennelPatterns +
+ *   includeAllDayEvents so future scrapes route correctly; this script reassigns
+ *   the already-mis-routed canonical Events off `c2h3`.
+ *
+ * Why re-route live instead of matching titles:
+ *   Bare-summary BALH3 events ("BALH3 -") had their title taken from the GCal
+ *   DESCRIPTION by the pre-#2046 fallback ("Who is the Hare: …" → "Who is the"),
+ *   so the canonical title is unreliable. Every c2h3 Event DOES carry a stable
+ *   `sourceUrl` (the GCal htmlLink), so we re-run the adapter with the seeded
+ *   config and map sourceUrl → correct kennelTag — the same routing the live
+ *   scrape will use. CBH3 events were all-day and never ingested, so none exist
+ *   under c2h3 to reassign (the scrape creates them fresh).
+ *
+ * Strategy (reassign, not delete — per the aggregator-misroute convention):
+ *   - For each c2h3 Event whose sourceUrl re-routes to balh3 / cbh3-cc:
+ *       · target has no Event that day → REASSIGN (Event.kennelId + its
+ *         EventKennel → target). The next scrape UPDATEs it in place and
+ *         refreshes the title (summaryIsCanonicalTitle).
+ *       · target already has that day (a scrape beat us) → the c2h3 row is a
+ *         stale dup → DELETE via the race-safe helper (zero attendances).
+ *   - Recompute lastEventDate for all kennels.
+ *
+ * Run AFTER `npx prisma db seed` (so balh3 / cbh3-cc + the kennelPatterns exist)
+ * and ideally BEFORE the next scrape (reassign-before-insert).
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-corpus-christi-misroute.ts
+ *   Apply:   npx tsx scripts/cleanup-corpus-christi-misroute.ts --apply
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
+import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
+import type { Source } from "@/generated/prisma/client";
+import { deleteLeakedEvent } from "./lib/delete-leaked-event";
+
+function utcDayBounds(date: Date): { gte: Date; lte: Date } {
+  const d = date.toISOString().slice(0, 10);
+  return { gte: new Date(`${d}T00:00:00.000Z`), lte: new Date(`${d}T23:59:59.999Z`) };
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}`);
+
+  const [c2h3, balh3, cbh3cc, source] = await Promise.all([
+    prisma.kennel.findUnique({ where: { kennelCode: "c2h3" }, select: { id: true } }),
+    prisma.kennel.findUnique({ where: { kennelCode: "balh3" }, select: { id: true } }),
+    prisma.kennel.findUnique({ where: { kennelCode: "cbh3-cc" }, select: { id: true } }),
+    prisma.source.findFirst({ where: { name: "Corpus Christi H3 Calendar" } }),
+  ]);
+  if (!c2h3 || !balh3 || !cbh3cc || !source) {
+    console.error(`Missing anchor(s): c2h3=${!!c2h3} balh3=${!!balh3} cbh3-cc=${!!cbh3cc} source=${!!source}`);
+    console.error("Run `npx prisma db seed` first so the new kennels + routing exist.");
+    process.exitCode = 1;
+    return;
+  }
+  const targetByTag: Record<string, string> = { balh3: balh3.id, "cbh3-cc": cbh3cc.id };
+
+  // Re-route the live calendar with the SEEDED config (same routing the scrape
+  // uses) → stable sourceUrl ⇒ correct kennelTag.
+  const res = await new GoogleCalendarAdapter().fetch(source as Source, { days: 3650 });
+  const urlToTag = new Map<string, string>();
+  for (const e of res.events) {
+    const tag = e.kennelTags[0];
+    if (e.sourceUrl && (tag === "balh3" || tag === "cbh3-cc")) urlToTag.set(e.sourceUrl, tag);
+  }
+  console.log(`Live re-route: ${urlToTag.size} sourceUrls map to balh3 / cbh3-cc`);
+
+  const events = await prisma.event.findMany({
+    where: { kennelId: c2h3.id },
+    select: { id: true, date: true, title: true, sourceUrl: true },
+  });
+  console.log(`c2h3 canonical events: ${events.length}`);
+
+  let reassigned = 0, deleted = 0;
+  const byTag: Record<string, number> = { balh3: 0, "cbh3-cc": 0 };
+  for (const ev of events) {
+    if (!ev.sourceUrl) continue;
+    const tag = urlToTag.get(ev.sourceUrl);
+    if (!tag) continue; // stays c2h3 — real C2H3, noise, or outside the fetch window
+    const targetId = targetByTag[tag];
+    const { gte, lte } = utcDayBounds(ev.date);
+    const existing = await prisma.event.findFirst({
+      where: { kennelId: targetId, date: { gte, lte }, id: { not: ev.id } },
+      select: { id: true },
+    });
+
+    if (existing) {
+      console.log(`  DELETE stale dup ${ev.id} (${ev.date.toISOString().slice(0, 10)} "${ev.title ?? ""}") — ${tag} ${existing.id} already canonical`);
+      if (apply) await deleteLeakedEvent(prisma, ev.id, ["attendances", "kennelAttendances"]);
+      deleted++;
+    } else {
+      console.log(`  REASSIGN ${ev.id} (${ev.date.toISOString().slice(0, 10)} "${ev.title ?? ""}") c2h3 → ${tag}`);
+      if (apply) {
+        await prisma.eventKennel.updateMany({ where: { eventId: ev.id, kennelId: c2h3.id }, data: { kennelId: targetId } });
+        await prisma.event.update({ where: { id: ev.id }, data: { kennelId: targetId } });
+      }
+      reassigned++;
+      byTag[tag]++;
+    }
+  }
+
+  console.log(`\n${apply ? "Applied" : "Would"}: reassign ${reassigned} (balh3 ${byTag.balh3}, cbh3-cc ${byTag["cbh3-cc"]}), delete ${deleted}`);
+  if (apply && (reassigned > 0 || deleted > 0)) {
+    const n = await backfillLastEventDates();
+    console.log(`Recomputed lastEventDate for ${n} kennel(s).`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => { console.error(err); process.exit(1); });

--- a/scripts/cleanup-corpus-christi-misroute.ts
+++ b/scripts/cleanup-corpus-christi-misroute.ts
@@ -149,8 +149,13 @@ async function reassignEvents(anchors: Anchors, routedByUrl: Map<string, RoutedE
     );
     console.log(`  REASSIGN ${ev.id} (${day}) c2h3 → ${routed.tag} | "${ev.title ?? ""}" → "${newTitle}"`);
     if (apply) {
-      await prisma.eventKennel.updateMany({ where: { eventId: ev.id, kennelId: anchors.c2h3Id }, data: { kennelId: target.id } });
-      await prisma.event.update({ where: { id: ev.id }, data: { kennelId: target.id, title: newTitle } });
+      // Atomic per-event: the EventKennel re-point and the Event.kennelId/title
+      // update must both land or neither, so a mid-failure can't leave the
+      // primary EventKennel on balh3 while Event.kennelId stays c2h3.
+      await prisma.$transaction([
+        prisma.eventKennel.updateMany({ where: { eventId: ev.id, kennelId: anchors.c2h3Id }, data: { kennelId: target.id } }),
+        prisma.event.update({ where: { id: ev.id }, data: { kennelId: target.id, title: newTitle } }),
+      ]);
     }
     reassigned++;
     byTag.set(routed.tag, (byTag.get(routed.tag) ?? 0) + 1);

--- a/scripts/cleanup-corpus-christi-misroute.ts
+++ b/scripts/cleanup-corpus-christi-misroute.ts
@@ -15,15 +15,18 @@
  *   DESCRIPTION by the pre-#2046 fallback ("Who is the Hare: …" → "Who is the"),
  *   so the canonical title is unreliable. Every c2h3 Event DOES carry a stable
  *   `sourceUrl` (the GCal htmlLink), so we re-run the adapter with the seeded
- *   config and map sourceUrl → correct kennelTag — the same routing the live
- *   scrape will use. CBH3 events were all-day and never ingested, so none exist
- *   under c2h3 to reassign (the scrape creates them fresh).
+ *   config and map sourceUrl → the routed event (kennelTag + fresh title + run
+ *   number) — the same routing the live scrape will use. CBH3 events were all-day
+ *   and never ingested, so none exist under c2h3 to reassign (the scrape creates
+ *   them fresh).
  *
  * Strategy (reassign, not delete — per the aggregator-misroute convention):
  *   - For each c2h3 Event whose sourceUrl re-routes to balh3 / cbh3-cc:
  *       · target has no Event that day → REASSIGN (Event.kennelId + its
- *         EventKennel → target). The next scrape UPDATEs it in place and
- *         refreshes the title (summaryIsCanonicalTitle).
+ *         EventKennel → target) AND refresh the title from the routed event.
+ *         The title refresh matters because historical rows older than the
+ *         source's `scrapeDays: 365` window are never revisited by the later
+ *         scrape, so their pre-#2046 junk titles would otherwise stick forever.
  *       · target already has that day (a scrape beat us) → the c2h3 row is a
  *         stale dup → DELETE via the race-safe helper (zero attendances).
  *   - Recompute lastEventDate for all kennels.
@@ -38,15 +41,30 @@
 import "dotenv/config";
 import { prisma } from "@/lib/db";
 import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
+import { resolveUpdatedTitle } from "@/pipeline/merge";
 import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
 import type { Source } from "@/generated/prisma/client";
 import { deleteLeakedEvent } from "./lib/delete-leaked-event";
 
+/** Kennel display fields needed to synthesize/rewrite a title on reassignment. */
+interface KennelMeta {
+  id: string;
+  kennelCode: string;
+  shortName: string;
+  fullName: string | null;
+}
+/** The routed view of a calendar event, keyed by its stable sourceUrl. */
+interface RoutedEvent {
+  tag: string;
+  title: string | undefined;
+  runNumber: number | null | undefined;
+}
+
 interface Anchors {
   c2h3Id: string;
   source: Source;
-  /** kennelTag → kennel id, for the kennels we reassign INTO. */
-  targetByTag: Map<string, string>;
+  /** kennelTag → metadata, for the kennels we reassign INTO. */
+  targetByTag: Map<string, KennelMeta>;
 }
 
 function utcDayBounds(date: Date): { gte: Date; lte: Date } {
@@ -55,10 +73,11 @@ function utcDayBounds(date: Date): { gte: Date; lte: Date } {
 }
 
 async function loadAnchors(): Promise<Anchors | null> {
+  const meta = { select: { id: true, kennelCode: true, shortName: true, fullName: true } };
   const [c2h3, balh3, cbh3cc, source] = await Promise.all([
     prisma.kennel.findUnique({ where: { kennelCode: "c2h3" }, select: { id: true } }),
-    prisma.kennel.findUnique({ where: { kennelCode: "balh3" }, select: { id: true } }),
-    prisma.kennel.findUnique({ where: { kennelCode: "cbh3-cc" }, select: { id: true } }),
+    prisma.kennel.findUnique({ where: { kennelCode: "balh3" }, ...meta }),
+    prisma.kennel.findUnique({ where: { kennelCode: "cbh3-cc" }, ...meta }),
     prisma.source.findFirst({ where: { name: "Corpus Christi H3 Calendar" } }),
   ]);
   if (!c2h3 || !balh3 || !cbh3cc || !source) {
@@ -69,16 +88,16 @@ async function loadAnchors(): Promise<Anchors | null> {
   return {
     c2h3Id: c2h3.id,
     source,
-    targetByTag: new Map([["balh3", balh3.id], ["cbh3-cc", cbh3cc.id]]),
+    targetByTag: new Map([["balh3", balh3], ["cbh3-cc", cbh3cc]]),
   };
 }
 
 /**
  * Re-route the live calendar with the seeded config (the same routing the scrape
- * uses) and map each stable sourceUrl → the kennelTag we reassign INTO. Throws on
- * a failed/empty fetch so a bad API response can't be mistaken for "nothing to do".
+ * uses) and map each stable sourceUrl → its routed event. Throws on a failed or
+ * empty fetch so a bad API response can't be mistaken for "nothing to do".
  */
-async function buildUrlToTagMap(source: Source, targetByTag: Map<string, string>): Promise<Map<string, string>> {
+async function buildRoutedMap(source: Source, targetByTag: Map<string, KennelMeta>): Promise<Map<string, RoutedEvent>> {
   const res = await new GoogleCalendarAdapter().fetch(source, { days: 3650 });
   if (res.errors.length > 0) {
     throw new Error(`Calendar fetch returned errors; aborting: ${JSON.stringify(res.errors)}`);
@@ -86,18 +105,17 @@ async function buildUrlToTagMap(source: Source, targetByTag: Map<string, string>
   if (res.events.length === 0) {
     throw new Error("Calendar fetch returned zero events; aborting (likely a failed fetch, not an empty calendar).");
   }
-  const urlToTag = new Map<string, string>();
+  const byUrl = new Map<string, RoutedEvent>();
   for (const e of res.events) {
     const tag = e.kennelTags[0];
-    if (e.sourceUrl && targetByTag.has(tag)) urlToTag.set(e.sourceUrl, tag);
+    if (e.sourceUrl && targetByTag.has(tag)) byUrl.set(e.sourceUrl, { tag, title: e.title, runNumber: e.runNumber });
   }
-  return urlToTag;
+  return byUrl;
 }
 
-async function reassignEvents(anchors: Anchors, urlToTag: Map<string, string>, apply: boolean) {
-  const { c2h3Id, targetByTag } = anchors;
+async function reassignEvents(anchors: Anchors, routedByUrl: Map<string, RoutedEvent>, apply: boolean) {
   const events = await prisma.event.findMany({
-    where: { kennelId: c2h3Id },
+    where: { kennelId: anchors.c2h3Id },
     select: { id: true, date: true, title: true, sourceUrl: true },
   });
   console.log(`c2h3 canonical events: ${events.length}`);
@@ -105,28 +123,37 @@ async function reassignEvents(anchors: Anchors, urlToTag: Map<string, string>, a
   let reassigned = 0, deleted = 0;
   const byTag = new Map<string, number>();
   for (const ev of events) {
-    const tag = ev.sourceUrl ? urlToTag.get(ev.sourceUrl) : undefined;
-    const targetId = tag ? targetByTag.get(tag) : undefined;
-    if (!tag || !targetId) continue; // stays c2h3 — real C2H3, noise, or outside the window
+    const routed = ev.sourceUrl ? routedByUrl.get(ev.sourceUrl) : undefined;
+    const target = routed ? anchors.targetByTag.get(routed.tag) : undefined;
+    if (!routed || !target) continue; // stays c2h3 — real C2H3, noise, or outside the window
     const day = ev.date.toISOString().slice(0, 10);
     const { gte, lte } = utcDayBounds(ev.date);
     const existing = await prisma.event.findFirst({
-      where: { kennelId: targetId, date: { gte, lte }, id: { not: ev.id } },
+      where: { kennelId: target.id, date: { gte, lte }, id: { not: ev.id } },
       select: { id: true },
     });
     if (existing) {
-      console.log(`  DELETE stale dup ${ev.id} (${day} "${ev.title ?? ""}") — ${tag} ${existing.id} already canonical`);
+      console.log(`  DELETE stale dup ${ev.id} (${day} "${ev.title ?? ""}") — ${routed.tag} ${existing.id} already canonical`);
       if (apply) await deleteLeakedEvent(prisma, ev.id, ["attendances", "kennelAttendances"]);
       deleted++;
-    } else {
-      console.log(`  REASSIGN ${ev.id} (${day} "${ev.title ?? ""}") c2h3 → ${tag}`);
-      if (apply) {
-        await prisma.eventKennel.updateMany({ where: { eventId: ev.id, kennelId: c2h3Id }, data: { kennelId: targetId } });
-        await prisma.event.update({ where: { id: ev.id }, data: { kennelId: targetId } });
-      }
-      reassigned++;
-      byTag.set(tag, (byTag.get(tag) ?? 0) + 1);
+      continue;
     }
+    // Refresh the title the same way a scrape+merge would (summaryIsCanonicalTitle
+    // titles are reliable; the stale description-derived junk is dropped).
+    const newTitle = resolveUpdatedTitle(
+      routed.title,
+      ev.title,
+      { kennelCode: target.kennelCode, shortName: target.shortName, fullName: target.fullName, aliases: [] },
+      routed.runNumber,
+      routed.tag,
+    );
+    console.log(`  REASSIGN ${ev.id} (${day}) c2h3 → ${routed.tag} | "${ev.title ?? ""}" → "${newTitle}"`);
+    if (apply) {
+      await prisma.eventKennel.updateMany({ where: { eventId: ev.id, kennelId: anchors.c2h3Id }, data: { kennelId: target.id } });
+      await prisma.event.update({ where: { id: ev.id }, data: { kennelId: target.id, title: newTitle } });
+    }
+    reassigned++;
+    byTag.set(routed.tag, (byTag.get(routed.tag) ?? 0) + 1);
   }
   return { reassigned, deleted, byTag };
 }
@@ -138,10 +165,10 @@ async function main() {
   const anchors = await loadAnchors();
   if (!anchors) { process.exitCode = 1; return; }
 
-  const urlToTag = await buildUrlToTagMap(anchors.source, anchors.targetByTag);
-  console.log(`Live re-route: ${urlToTag.size} sourceUrls map to balh3 / cbh3-cc`);
+  const routedByUrl = await buildRoutedMap(anchors.source, anchors.targetByTag);
+  console.log(`Live re-route: ${routedByUrl.size} sourceUrls map to balh3 / cbh3-cc`);
 
-  const { reassigned, deleted, byTag } = await reassignEvents(anchors, urlToTag, apply);
+  const { reassigned, deleted, byTag } = await reassignEvents(anchors, routedByUrl, apply);
   console.log(`\n${apply ? "Applied" : "Would"}: reassign ${reassigned} (balh3 ${byTag.get("balh3") ?? 0}, cbh3-cc ${byTag.get("cbh3-cc") ?? 0}), delete ${deleted}`);
   if (apply && (reassigned > 0 || deleted > 0)) {
     const n = await backfillLastEventDates();

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -63,6 +63,34 @@ describe("Boston Hash Calendar multi-kennel routing (#789)", () => {
   });
 });
 
+// ── Corpus Christi area multi-kennel routing via seed config (#2046 follow-up) ──
+
+describe("Corpus Christi area calendar multi-kennel routing", () => {
+  const ccSource = SOURCES.find((s) => s.name === "Corpus Christi H3 Calendar");
+  if (!ccSource?.config) throw new Error("Corpus Christi H3 Calendar seed config missing");
+  const config = ccSource.config as { kennelPatterns: [string, string][]; defaultKennelTag: string };
+
+  it.each([
+    // [summary, expected kennelTag, description]
+    ["BALH3 - Trail #988", "balh3", "Bay Area Larrikins prefixed"],
+    ['BALH3 - "The Great Gaspy" Hash', "balh3", "BALH3 themed"],
+    ["Bay Area Larrikin", "balh3", "Bay Area Larrikins full name"],
+    ["CBH3-4th Anal Bikini R*n", "cbh3-cc", "Coastal Bend (collision-safe code)"],
+    ["CBH3", "cbh3-cc", "bare CBH3"],
+    ["CBH3 - Cancelled", "cbh3-cc", "CBH3 with suffix"],
+    ["C2H3 Trail #485", "c2h3", "Corpus Christi prefixed"],
+    ["C2H3-#503", "c2h3", "C2H3 dash-number"],
+    ["Corpus Christi Hash house Harriers presents", "c2h3", "Corpus Christi full name"],
+    ["Cinco de Mayo May Trail", "c2h3", "prefix-less owner trail → default"],
+  ])("routes %j → %s (%s)", (summary, expectedTag) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-04-15T19:00:00-05:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe(expectedTag);
+  });
+});
+
 // ── Colorado H3 Aggregator multi-kennel routing via seed config (#850) ──
 
 describe("Colorado H3 Aggregator multi-kennel routing (#850)", () => {


### PR DESCRIPTION
## Why this PR exists

[#2087](https://github.com/johnrclem/hashtracks-web/pull/2087) was a **stacked** PR (base = #2077's branch `claude/quizzical-khayyam-982c19`). #2077 merged to `main` first, so when #2087 merged it landed on that now-orphaned branch — **its changes never reached `main`**. This re-lands exactly #2087's changes on `main` (the 3 commits cherry-picked onto current `origin/main`, so it does **not** revert any of the other work merged since).

Content is identical to the already-reviewed-and-green #2087:
- New kennels `balh3` (Bay Area Larrikins H3) + `cbh3-cc` (Coastal Bend H3) + aliases.
- `kennelPatterns` + `includeAllDayEvents` routing on the Corpus Christi calendar source.
- `it.each` routing fixtures.
- `scripts/cleanup-corpus-christi-misroute.ts` (reassign mis-routed events by stable `sourceUrl` + refresh stale titles via `resolveUpdatedTitle`).

## Verification
- Diff vs `main` is exactly the 5 #2087 files (243 insertions, 1 deletion) — no unrelated reverts.
- `tsc`, `lint`, gcal routing fixtures all green.
- Live re-route unchanged: balh3=369, cbh3-cc=75, c2h3=179.

## Post-merge runbook
1. `npx prisma db seed` (adds the kennels + updates the source config)
2. `npx tsx scripts/cleanup-corpus-christi-misroute.ts` (dry-run) → review → `--apply`
3. Trigger a scrape of the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)