### PR TITLE
fix(gcal): extraction hardening round 2 — 7 audit bugs

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -337,6 +337,12 @@ export const SOURCES = [
         // joint trail like "Philly H3 & BFM co-host" is still kept here.
         // Closes #582.
         skipPatterns: ["^Ben Franklin Mob H3\\b", "^BFM\\b"],
+        // #2099: the kennel posts marquee weekend runs (Green Dress Run, etc.)
+        // as all-day VEVENTs (DTSTART;VALUE=DATE). The adapter skips all-day
+        // events by default; opt in so their SUMMARY/LOCATION/DESCRIPTION are
+        // ingested instead of dropped. Single-kennel curated calendar — the
+        // imported-holiday filter already screens junk all-day rows.
+        includeAllDayEvents: true,
       },
       kennelCodes: ["philly-h3"],
     },
@@ -4956,10 +4962,19 @@ export const SOURCES = [
         kennelPatterns: [
           // Handles both spellings: correct "Knightvillian" (ian) and common misspelling "Knightvillain" (ain)
           ["Knightvill(ian|ain)", "knightvillian"],
+          // #2112: the kennel-code form "KVH3" (e.g. "KVH3 - Space Team
+          // Episode 2"). The generic "\bKV(?![A-Za-z])" below rejects it (the
+          // trailing "H" trips the negative lookahead), so it leaked to the
+          // default pormeh3. Most-specific-first.
+          ["\\bKVH3\\b", "knightvillian"],
           // Matches "KV", "KV484", "KV 478" but NOT "KVR", "Kevin", etc.
           // (\bKV not followed by another letter)
           ["\\bKV(?![A-Za-z])", "knightvillian"],
         ],
+        // #2112: "Kink and Pickle Falmouth Hash" is a sibling kennel with no
+        // HashTracks record (no sourceless kennels). Drop its events rather
+        // than letting them fall through to the default pormeh3 kennel.
+        skipPatterns: ["Kink and Pickle"],
       },
       kennelCodes: ["pormeh3", "knightvillian"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4966,7 +4966,7 @@ export const SOURCES = [
           // Episode 2"). The generic "\bKV(?![A-Za-z])" below rejects it (the
           // trailing "H" trips the negative lookahead), so it leaked to the
           // default pormeh3. Most-specific-first.
-          ["\\bKVH3\\b", "knightvillian"],
+          [String.raw`\bKVH3\b`, "knightvillian"],
           // Matches "KV", "KV484", "KV 478" but NOT "KVR", "Kevin", etc.
           // (\bKV not followed by another letter)
           ["\\bKV(?![A-Za-z])", "knightvillian"],

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -5815,4 +5815,15 @@ describe("Colorado Springs H3 Calendar — PPH4 description-hare preference (#21
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Slippery Nipple");
   });
+
+  it("runs the shared cleanAndFilterHares passes on the capture, e.g. trailing phone (#2122 review)", () => {
+    // The old subset-of-replaces did not strip phone numbers; cleanAndFilterHares
+    // truncates at a mid-string phone run, so the same-line tail can't persist.
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "PPH4 Some Trail", description: "Hare: Slug 2406185563 CALL for same day" }),
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Slug");
+  });
 });

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -417,6 +417,27 @@ describe("extractRunNumber", () => {
     expect(extractRunNumber("CUNTh 66ish Hiidea's Bday")).toBeUndefined();
   });
 
+  // #2089 PH4 (Portland Humpin') — the source embeds the run number as #NNNN in
+  // a handful of shapes; all must parse via the shared extractHashRunNumber path
+  // (incl. the bang-terminated form the read-only delimiter guard misses).
+  it.each([
+    ["PH4 #1315 - Gay!Gay!Gay! Hash!!!", 1315, "space after #"],
+    ["#1314 PH4 - Chubby Chaser", 1314, "leading #NNNN"],
+    ["PH4 #1283 Deaf Dick - Zombie Hash", 1283, "suffix word after #"],
+    ["PH4 - #1269! Can't Finish's XXX-MAS IN JULY", 1269, "bang-terminated #NNNN (#2089)"],
+    ["PH4 #1284/OH3 Full Moon Combo Trail", 1284, "slash-terminated #NNNN"],
+  ])("PH4 summary %j → run %i (%s)", (summary, expected) => {
+    expect(extractRunNumber(summary)).toBe(expected);
+  });
+
+  it("does not invent a run number for themed PH4 titles (no #)", () => {
+    expect(extractRunNumber("PH4 - Taco Flavored Pisses")).toBeUndefined();
+  });
+
+  it("bang normalization does not defeat the #30X? placeholder guard (#2089)", () => {
+    expect(extractRunNumber("FCH3 #30X?!: Frisky Whisk-her")).toBeNull();
+  });
+
   // Summary placeholder must beat description fallback (Codex adversarial
   // review #1297). A partial retitle (kennel admin updates the title to
   // `#30X?` but leaves the prior `BH3 #30` reference in the description)
@@ -1332,6 +1353,10 @@ describe("non-address location detection", () => {
     ["When: 5:69", "template-field text"],
     ["Hare: Bob McHash", "field label in location"],
     ["Cost: $5.00", "cost label in location"],
+    // #2081 Morgantown — kennel types this placeholder into the GCal LOCATION
+    // field instead of leaving it blank; any-case must be rejected.
+    ["No location provided", "literal placeholder phrase"],
+    ["NO LOCATION PROVIDED", "uppercase placeholder phrase"],
   ])("rejects non-address location %s (%s)", (location) => {
     const result = buildRawEventFromGCalItem(
       testGCalEvent({ description: "Some description", location }),
@@ -1339,6 +1364,17 @@ describe("non-address location detection", () => {
     );
     expect(result).not.toBeNull();
     expect(result!.location).toBeUndefined();
+  });
+
+  it.each([
+    ["Provided Park, 100 Main St", "venue containing the word 'provided'"],
+    ["No Name Saloon, Park City, UT", "venue starting with 'No'"],
+  ])("preserves real venue %j (#2081 anchored guard)", (location) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ description: "Some description", location }),
+      { defaultKennelTag: "test" },
+    );
+    expect(result!.location).toBe(location);
   });
 
   it("preserves normal address in location field", () => {
@@ -2183,6 +2219,46 @@ describe("buildRawEventFromGCalItem — all-day events", () => {
     );
     expect(result).not.toBeNull();
     expect(result!.startTime).toBeUndefined();
+  });
+
+  // #2099 Philly H3 — marquee weekend runs are posted as all-day VEVENTs. With
+  // includeAllDayEvents the same extractor must populate title/location/desc.
+  it("admits an all-day event and extracts SUMMARY/LOCATION/DESCRIPTION (#2099)", () => {
+    const phillySource = SOURCES.find((s) => s.name === "Philly H3 Google Calendar");
+    if (!phillySource?.config) throw new Error("Philly H3 Google Calendar seed config missing");
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "PHILLY GREEN DRESS RUN",
+        start: { date: "2026-03-14" },
+        end: { date: "2026-03-15" },
+        location: "Ruba, 416 Green St, Philadelphia, PA 19123, USA",
+        description: "It's GREEN DRESS WEEKEND 2026! For more info go to www.hashphilly.com",
+        status: "confirmed",
+      },
+      phillySource.config as Record<string, unknown>,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.kennelTags[0]).toBe("philly-h3");
+    expect(result!.title).toBe("PHILLY GREEN DRESS RUN");
+    expect(result!.location).toBe("Ruba, 416 Green St, Philadelphia, PA 19123, USA");
+    expect(result!.description).toContain("GREEN DRESS WEEKEND 2026");
+    expect(result!.startTime).toBeUndefined();
+    expect(result!.date).toBe("2026-03-14");
+  });
+
+  it("still drops the same all-day event when a source has not opted in (#2099)", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "PHILLY GREEN DRESS RUN",
+        start: { date: "2026-03-14" },
+        end: { date: "2026-03-15" },
+        location: "Ruba, 416 Green St, Philadelphia, PA 19123, USA",
+        description: "It's GREEN DRESS WEEKEND 2026!",
+        status: "confirmed",
+      },
+      { defaultKennelTag: "philly-h3" },
+    );
+    expect(result).toBeNull();
   });
 });
 
@@ -5595,5 +5671,148 @@ describe("themeless placeholder titles are nulled in buildRawEventFromGCalItem (
     expect(result).not.toBeNull();
     expect(result!.title).toBe("SH3 #804");
     expect(result!.runNumber).toBe(804);
+  });
+});
+
+// ── #2112 PorMEH3 — KVH3 / Kink-and-Pickle routing on the shared calendar ──
+
+describe("PorMe H3 Google Calendar — sister-kennel routing (#2112)", () => {
+  const pormeSource = SOURCES.find((s) => s.name === "PorMe H3 Google Calendar");
+  if (!pormeSource?.config) throw new Error("PorMe H3 Google Calendar seed config missing");
+  const config = pormeSource.config as { kennelPatterns: [string, string][]; skipPatterns?: string[] };
+
+  it.each([
+    ["KVH3 - Space Team Episode 2", "knightvillian", "KVH3 kennel-code form (#2112)"],
+    ["Knightvillain H3 #496 - Space Team!", "knightvillian", "full Knightvillain name"],
+    ["KV478 Onesies", "knightvillian", "bare KV + digits"],
+    ["PorMe H3 Hash Tutu on 22s", "pormeh3", "PorMe own event → default"],
+    ["PorMeH3 Kinks-giving", "pormeh3", "'Kinks-' must not trip the Kink-and-Pickle skip"],
+  ])("routes %j → %s (%s)", (summary, expectedTag) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-04-15T18:30:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe(expectedTag);
+  });
+
+  it("drops Kink and Pickle events (no HashTracks record) via skipPatterns (#2112)", () => {
+    const compiledSkipPatterns = compilePatterns(config.skipPatterns ?? [], "i");
+    const result = buildRawEventFromGCalItem(
+      { summary: "Kink and Pickle Falmouth Hash Placeholder", start: { dateTime: "2026-04-15T18:30:00-04:00" }, status: "confirmed" },
+      config,
+      { compiledSkipPatterns },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("does not skip a PorMe event whose title merely contains 'Kink' (#2112)", () => {
+    const compiledSkipPatterns = compilePatterns(config.skipPatterns ?? [], "i");
+    const result = buildRawEventFromGCalItem(
+      { summary: "PorMeH3 Kinks-giving", start: { dateTime: "2026-04-15T18:30:00-04:00" }, status: "confirmed" },
+      config,
+      { compiledSkipPatterns },
+    );
+    expect(result?.kennelTags[0]).toBe("pormeh3");
+  });
+});
+
+// ── #2091 PHH — title must NOT truncate at '&' (literal or entity) ──
+
+describe("Aloha H3 Google Calendar — PHH '&' title integrity (#2091)", () => {
+  const alohaSource = SOURCES.find((s) => s.name === "Aloha H3 Google Calendar");
+  if (!alohaSource?.config) throw new Error("Aloha H3 Google Calendar seed config missing");
+  const config = alohaSource.config as Record<string, unknown>;
+
+  it.each([
+    ["Open MisMan Meeting & Hump Night PHH - Ruby Tuesday Moanalua", "literal &"],
+    ["Open MisMan Meeting &amp; Hump Night PHH - Ruby Tuesday Moanalua", "HTML entity &amp;"],
+  ])("keeps the full title past the '&' (%s)", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-02-04T17:30:00-10:00", timeZone: "Pacific/Honolulu" }, status: "confirmed" },
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.kennelTags[0]).toBe("phh-hi");
+    // Decoded title carries the literal '&' and everything after it — no
+    // split-on-'&' truncation to "Open MisMan Meeting ".
+    expect(result!.title).toBe("Open MisMan Meeting & Hump Night PHH - Ruby Tuesday Moanalua");
+  });
+});
+
+// ── #2115 Houston — offset dateTime must keep PM; title is the SUMMARY ──
+
+describe("Houston Hash Calendar — evening startTime + SUMMARY title (#2115)", () => {
+  const houstonSource = SOURCES.find((s) => s.name === "Houston Hash Calendar");
+  if (!houstonSource?.config) throw new Error("Houston Hash Calendar seed config missing");
+  const config = houstonSource.config as Record<string, unknown>;
+
+  it("keeps a 4:15pm offset dateTime as 16:15 (no AM/PM flip) and uses the SUMMARY as title", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Running & Riding The Ho' - Memorial Park",
+        start: { dateTime: "2026-06-11T16:15:00-05:00" },
+        location: "https://maps.app.goo.gl/aBhVXbSyqd1vfNsY9",
+        status: "confirmed",
+      },
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.startTime).toBe("16:15");
+    expect(result!.title).toBe("Running & Riding The Ho' - Memorial Park");
+    // The goo.gl link routes to locationUrl for downstream geocoding; it must
+    // never become the display title/location.
+    expect(result!.location).toBeUndefined();
+  });
+});
+
+// ── #2122 PPH4 — hares come from the description 'Hare:' line, not the paren ──
+
+describe("Colorado Springs H3 Calendar — PPH4 description-hare preference (#2122)", () => {
+  const csSource = SOURCES.find((s) => s.name === "Colorado Springs H3 Calendar");
+  if (!csSource?.config) throw new Error("Colorado Springs H3 Calendar seed config missing");
+  const config = csSource.config as Record<string, unknown>;
+
+  it("prefers the mid-line 'Hare: NIPS' over the title parenthetical (#2122)", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "PPH4 Iron Girth #5 (Last Trail for the week)",
+        start: { dateTime: "2026-04-25T14:00:00-06:00" },
+        description: "P2H4\nIron Girth with your Hare: NIPS\nNo Girth's Birthday party\nBring: whistle, $5",
+        status: "confirmed",
+      },
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.kennelTags[0]).toBe("pph4");
+    expect(result!.runNumber).toBe(5);
+    expect(result!.hares).toBe("NIPS");
+    expect(result!.title).toContain("Iron Girth #5");
+  });
+
+  it("does not mistake a lowercase 'share:' for a hare label (#2122 negative)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "PPH4 Some Trail", description: "Come along and we share: cookies and beer" }),
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBeUndefined();
+  });
+
+  it("rejects a 'Hare: TBD' placeholder rather than storing it (#2122 negative)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "PPH4 Some Trail", description: "Iron Girth with your Hare: TBD" }),
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBeUndefined();
+  });
+
+  it("still promotes a real '(Hare Name)' parenthetical when the description has no Hare label (#2122 guard)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "PPH4 Trail (Slippery Nipple)", description: "Come run with us, bring water" }),
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.hares).toBe("Slippery Nipple");
   });
 });

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, dedupeRepeatedDescription, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber, isThemelessPlaceholderTitle, normalizeCostSigil, BARE_KENNEL_CODE_RE } from "../utils";
+import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, dedupeRepeatedDescription, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber, isThemelessPlaceholderTitle, normalizeCostSigil, BARE_KENNEL_CODE_RE } from "../utils";
 import { matchKennelPatterns, matchCompiledKennelPatterns, compileKennelPatterns, type KennelPattern, type CompiledKennelPattern } from "../kennel-patterns";
 import { LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 import { parseDMSFromLocation } from "@/lib/geo";
@@ -66,8 +66,15 @@ export function extractRunNumber(
 ): number | null | undefined {
   // 1. Check summary first (e.g., "Beantown #255: ...", "BH3: ... #2781", "Cunth # 40: ...").
   // Shared `extractHashRunNumber` enforces the delimiter guard (#1147) — "#30X?"
-  // rejects rather than parsing as 30.
-  const fromSummary = extractHashRunNumber(summary);
+  // rejects rather than parsing as 30. The fallback re-runs the same parser with
+  // "!" normalized to whitespace so a bang-terminated run number ("PH4 - #1269!",
+  // and the numerology "#1322 Centum!" titles) still parses — "!" isn't in the
+  // shared lookahead delimiter set (utils.ts is read-only) (#2089). Normalizing
+  // "!"→space only helps the lookahead; it can't manufacture a number where the
+  // first pass already saw a clean run, and "#30X?" still falls through to the
+  // placeholder check below.
+  const fromSummary = extractHashRunNumber(summary)
+    ?? (summary.includes("!") ? extractHashRunNumber(summary.replace(/!/g, " ")) : undefined);
   if (fromSummary !== undefined) return fromSummary;
 
   // 1b. Leading "Hash NNNN:" without the `#` (#2007 PGH H3). Colon-anchored
@@ -918,6 +925,31 @@ export function extractCostFromDescription(description: string): string | undefi
   return undefined;
 }
 
+/**
+ * Last-resort hare extraction for a mid-line `Hare: Name` label that the shared
+ * line-anchored `extractHares` patterns miss (#2122 PPH4 — description
+ * "Iron Girth with your Hare: NIPS"). Only used when description + title hare
+ * extraction yielded nothing; without it the title parenthetical
+ * ("(Last Trail for the week)") gets wrongly promoted to hares.
+ *
+ * Requires a literal capital `Hare`/`Hares` preceded by whitespace/`(`/start
+ * and a capture starting with an uppercase letter or `*`, so lowercase
+ * lookalikes ("…we share: cookies", "welfare: …") can't match. The capture is
+ * line-bounded, then truncated at any embedded field label / boilerplate marker
+ * and only returned when it still looks like a hash name.
+ */
+const INLINE_HARE_LABEL_RE = /(?:^|[\s(])Hares?\s*:\s*([A-Z*][^\n]*)/;
+export function extractInlineHareFromDescription(description: string): string | undefined {
+  const match = INLINE_HARE_LABEL_RE.exec(description);
+  if (!match?.[1]) return undefined;
+  const candidate = match[1]
+    .replace(EVENT_FIELD_LABEL_RE, "")
+    .replace(EVENT_FIELD_LABEL_UPPERCASE_RE, "")
+    .replace(HARE_BOILERPLATE_RE, "")
+    .trim();
+  return candidate && looksLikeHareName(candidate) ? candidate : undefined;
+}
+
 const mapsUrl = googleMapsSearchUrl;
 
 /** Instruction phrases that indicate a GCal location field is direction text. */
@@ -935,6 +967,10 @@ const NON_ADDRESS_LABEL_TRAIL_RE = /^(?:pack\s*meet|pre[\s-]?lube|trail\s*(?:typ
 const NON_ADDRESS_PAYMENT_RE = /^(?:venmo|pay\s*pal|cash\s*app|zelle)\b/i;
 /** Suffix phrase indicating the field is a placeholder like "DST start location". */
 const NON_ADDRESS_SUFFIX_RE = /\bstart\s+location\s*$/i;
+/** Literal "No location provided" placeholder some kennels type into the GCal
+ *  LOCATION field instead of leaving it blank (#2081 Morgantown). Anchored
+ *  whole-string so a real venue containing the word "provided" survives. */
+const NON_ADDRESS_NO_LOCATION_RE = /^no location provided$/i;
 
 /** Returns true if text starts with instruction phrasing rather than an address.
  *  Patterns are split across multiple small regexes so each stays under
@@ -947,7 +983,8 @@ function isNonAddressText(text: string): boolean {
     NON_ADDRESS_LABEL_CASH_RE.test(t) ||
     NON_ADDRESS_LABEL_TRAIL_RE.test(t) ||
     NON_ADDRESS_PAYMENT_RE.test(t) ||
-    NON_ADDRESS_SUFFIX_RE.test(t)
+    NON_ADDRESS_SUFFIX_RE.test(t) ||
+    NON_ADDRESS_NO_LOCATION_RE.test(t)
   );
 }
 
@@ -1430,6 +1467,13 @@ export function buildRawEventFromGCalItem(
   }
   const { rawDescription, description } = normalizeGCalDescription(item.description);
   let hares = rawDescription ? extractHares(rawDescription, compiledHarePatterns) : undefined;
+  // #2122 — fall back to a mid-line "Hare: Name" label that the line-anchored
+  // extractHares patterns miss (PPH4 "…with your Hare: NIPS"). Prefer this real
+  // description hare over the title parenthetical that would otherwise be
+  // promoted further below.
+  if (!hares && rawDescription) {
+    hares = extractInlineHareFromDescription(rawDescription);
+  }
   // Fall back to extracting hares from title when description has none. Try
   // each pattern in order; first capture-group hit wins. Track which pattern
   // matched so the downstream title-cleanup block uses the same regex span.

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1,11 +1,11 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, dedupeRepeatedDescription, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber, isThemelessPlaceholderTitle, normalizeCostSigil, BARE_KENNEL_CODE_RE } from "../utils";
+import { googleMapsSearchUrl, decodeEntities, stripHtmlTags, compilePatterns, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE, CTA_EMBEDDED_PATTERNS, appendDescriptionSuffix, dedupeRepeatedDescription, isPlaceholder, parse12HourTime, formatAmPmTime, stripNonEnglishCountry, extractHashRunNumber, hasPlaceholderRunNumber, isThemelessPlaceholderTitle, normalizeCostSigil, BARE_KENNEL_CODE_RE } from "../utils";
 import { matchKennelPatterns, matchCompiledKennelPatterns, compileKennelPatterns, type KennelPattern, type CompiledKennelPattern } from "../kennel-patterns";
 import { LOCATION_EMAIL_CTA_RE } from "@/pipeline/audit-checks";
 import { parseDMSFromLocation } from "@/lib/geo";
-import { extractHares, PHONE_TRAILING_RE } from "../hare-extraction";
+import { extractHares, PHONE_TRAILING_RE, cleanAndFilterHares } from "../hare-extraction";
 import { MEDICAL_SKIP_RES } from "../skip-rules";
 
 /**
@@ -74,7 +74,7 @@ export function extractRunNumber(
   // first pass already saw a clean run, and "#30X?" still falls through to the
   // placeholder check below.
   const fromSummary = extractHashRunNumber(summary)
-    ?? (summary.includes("!") ? extractHashRunNumber(summary.replace(/!/g, " ")) : undefined);
+    ?? (summary.includes("!") ? extractHashRunNumber(summary.replaceAll("!", " ")) : undefined);
   if (fromSummary !== undefined) return fromSummary;
 
   // 1b. Leading "Hash NNNN:" without the `#` (#2007 PGH H3). Colon-anchored
@@ -934,20 +934,21 @@ export function extractCostFromDescription(description: string): string | undefi
  *
  * Requires a literal capital `Hare`/`Hares` preceded by whitespace/`(`/start
  * and a capture starting with an uppercase letter or `*`, so lowercase
- * lookalikes ("…we share: cookies", "welfare: …") can't match. The capture is
- * line-bounded, then truncated at any embedded field label / boilerplate marker
- * and only returned when it still looks like a hash name.
+ * lookalikes ("…we share: cookies", "welfare: …") can't match. The line-bounded
+ * capture is run through the shared {@link cleanAndFilterHares} (phone strip,
+ * sentence-boundary truncation, conversational-tail strip, etc. — the same
+ * cleaner `extractHares` uses) so a same-line prose tail can't persist as a
+ * hare, then through `looksLikeHareName` as a final placeholder/kennel-code gate
+ * (cleanAndFilterHares passes "TBD" through; this rejects it). A null/undefined
+ * cleaner result means "no usable hare" → undefined.
  */
 const INLINE_HARE_LABEL_RE = /(?:^|[\s(])Hares?\s*:\s*([A-Z*][^\n]*)/;
 export function extractInlineHareFromDescription(description: string): string | undefined {
   const match = INLINE_HARE_LABEL_RE.exec(description);
   if (!match?.[1]) return undefined;
-  const candidate = match[1]
-    .replace(EVENT_FIELD_LABEL_RE, "")
-    .replace(EVENT_FIELD_LABEL_UPPERCASE_RE, "")
-    .replace(HARE_BOILERPLATE_RE, "")
-    .trim();
-  return candidate && looksLikeHareName(candidate) ? candidate : undefined;
+  const cleaned = cleanAndFilterHares(match[1]);
+  if (typeof cleaned !== "string" || !cleaned) return undefined;
+  return looksLikeHareName(cleaned) ? cleaned : undefined;
 }
 
 const mapsUrl = googleMapsSearchUrl;

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -211,8 +211,12 @@ function collectContinuationLines(normalized: string, match: RegExpExecArray): s
  * - `undefined` — no usable candidate, OR a low-confidence/ambiguous reject
  *   (generic "everyone", prose leak, date range, over-long text). "No signal"
  *   — the merge pipeline preserves any existing hare.
+ *
+ * Exported so adapters with a bespoke capture (e.g. the Google Calendar
+ * mid-line `Hare:` fallback, #2122) reuse this robust cleaner instead of
+ * re-implementing a weaker subset of its passes.
  */
-function cleanAndFilterHares(raw: string): string | null | undefined {
+export function cleanAndFilterHares(raw: string): string | null | undefined {
   let hares = raw
     .replace(LEADING_HARE_LABEL_RE, "")
     .trim()


### PR DESCRIPTION
GCal extraction hardening round 2. Owns `src/adapters/google-calendar/adapter.ts` (+ test) and the PorMEH3 / Morgantown / Philly config rows in `prisma/seed-data/sources.ts`. Each kennel was **live-verified** against the production Google Calendar API (raw dumps + running the current adapter inline), which split the seven issues into real current bugs vs already-self-healed historical data (audit snapshots of state the current adapter re-scrapes correctly).

## Real current bugs (code/config fix)

| Issue | Fix |
|---|---|
| #2122 PPH4 | Hares were pulled from the title parenthetical (`(Last Trail for the week)`) instead of the description `Hare: NIPS` line. `extractHares` only matches a **line-start** `Hare:`; added a GCal-local mid-line fallback `extractInlineHareFromDescription` so the real description hare wins and the parenthetical isn't promoted. Capital-`Hare` + capital-start capture rejects `share:`/`welfare:`; `looksLikeHareName` rejects placeholders. Live: `hares: "NIPS"` ✓ |
| #2081 Morgantown | Literal `"No location provided"` stored as `locationName`. Added anchored `NON_ADDRESS_NO_LOCATION_RE` to `isNonAddressText`; real venues containing "provided" survive. Live: 0 events with the placeholder ✓ |
| #2099 Philly | Marquee weekend runs (Green Dress Run) are all-day VEVENTs and were dropped. Added `includeAllDayEvents: true` to the Philly config; the same extractor then populates SUMMARY/LOCATION/DESCRIPTION. Live: Green Dress Run admitted with full fields ✓ |
| #2112 PorMEH3 | `KVH3` / `Kink and Pickle` leaked to the default kennel. Added a `\bKVH3\b` kennelPattern (the generic `\bKV(?![A-Za-z])` rejects the H3 suffix) + a `Kink and Pickle` skipPattern (sister kennel, no HashTracks record → drop). |
| #2089 PH4 | Bang-terminated run numbers (`#1269!`, `#1322 Centum!`) missed because the **read-only** `extractHashRunNumber` delimiter guard lacks `!`. Added a `summary.includes("!")`-guarded `"!"→space` fallback that reuses `extractHashRunNumber`. Space/slash forms already worked. |

## Confirmed self-healed (regression tests only)

| Issue | Finding |
|---|---|
| #2091 PHH | Current adapter emits the **full** `"Open MisMan Meeting & Hump Night PHH - …"` title — no `&` split (the truncation was historical). Tests cover both a literal `&` and the `&amp;` entity form. |
| #2115 Houston | Adapter emits `startTime: "16:15"` (offset `-05:00` preserved — no AM/PM flip) and the SUMMARY as title. The `"Fast Park"`/`"5:15 AM"` snapshot was historical; the wrong venue is a downstream geocode of the kennel's bad goo.gl link (out of adapter scope). |

In-window recurring PHH/Houston events self-heal on the next scrape. (~2024 out-of-window PHH one-offs would need a one-shot cleanup but are stale past events — not blocking.)

## Verification
- Live-verified every named kennel against the production calendar API.
- `npx tsc --noEmit` clean, `npm run lint` 0 errors, `npm test` 8889 passed.
- `/simplify` + correctness review pass applied (the only change taken: guard the `"!"` replace allocation with `summary.includes("!")`).

Closes #2122
Closes #2081
Closes #2099
Closes #2112
Closes #2089
Closes #2091
Closes #2115

🤖 Generated with [Claude Code](https://claude.com/claude-code)