### PR TITLE
feat(adapters): Occasion → title/description on PH3 + Bali Hash 2, backfill PH3 archive

### DIFF
--- a/scripts/backfill-ph3-my-history.ts
+++ b/scripts/backfill-ph3-my-history.ts
@@ -1,0 +1,82 @@
+/**
+ * One-shot historical backfill for Petaling H3 (`ph3-my`).
+ *
+ * The recurring `YiiHarelineAdapter` only fetches the last few pages of the
+ * ph3.org Yii GridView hareline each scrape (the upcoming/recent window). The
+ * source enumerates ~1,160 runs back to 2003 (#2085) across ~90 paginated
+ * pages. This walks every page, reuses the adapter's own parser
+ * (`parseYiiHarelinePage`, so there is no parser fork — the Occasion → title /
+ * description split from #2084 comes along for free), and routes the PAST slice
+ * through the shared backfill runner.
+ *
+ * `reportAndApplyBackfill` partitions strictly on `date < today-in-KL` so the
+ * recurring adapter (date >= today) and this backfill never overlap, and the
+ * merge pipeline dedupes by fingerprint — the script is safe to re-run. Because
+ * the merge UPDATE branch fires when a fingerprint changes, re-merging the
+ * in-window past rows also heals any stale placeholder titles (#2084).
+ *
+ * Usage:
+ *   Dry run:  BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-ph3-my-history.ts
+ *   Apply:    BACKFILL_APPLY=1 BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-ph3-my-history.ts
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import {
+  buildYiiPageUrl,
+  dedupeYiiEvents,
+  discoverMaxYiiPage,
+  parseYiiHarelinePage,
+  type YiiHarelineConfig,
+} from "@/adapters/html-scraper/yii-hareline";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Petaling H3 Hareline";
+const KENNEL_TIMEZONE = "Asia/Kuala_Lumpur";
+const BASE_URL = "https://ph3.org/index.php?r=site/hareline";
+const CONFIG: YiiHarelineConfig = { kennelTag: "ph3-my", startTime: "16:00" };
+
+const FETCH_HEADERS = { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)" };
+
+/** Fetch one hareline page; return parsed events + raw HTML (page 1's HTML is
+ *  needed to discover the pagination max). Pass the canonical BASE_URL (not the
+ *  per-page URL) to the parser so fingerprints match the recurring adapter. */
+async function fetchPage(pageNum: number): Promise<{ events: RawEventData[]; html: string }> {
+  const res = await safeFetch(buildYiiPageUrl(BASE_URL, pageNum), { headers: FETCH_HEADERS });
+  if (!res.ok) throw new Error(`Page ${pageNum}: HTTP ${res.status}`);
+  const html = await res.text();
+  return { events: parseYiiHarelinePage(cheerio.load(html), CONFIG, BASE_URL), html };
+}
+
+async function fetchAllPages(): Promise<RawEventData[]> {
+  const { events: page1Events, html } = await fetchPage(1);
+  const maxPage = discoverMaxYiiPage(html);
+  console.log(`  Discovered maxPage = ${maxPage} (page 1: ${page1Events.length} events)`);
+
+  const all: RawEventData[] = [...page1Events];
+  for (let p = 2; p <= maxPage; p++) {
+    const { events } = await fetchPage(p);
+    all.push(...events);
+    if (p % 10 === 0 || p === maxPage) {
+      console.log(`  page ${p}/${maxPage}: +${events.length} (total ${all.length})`);
+    }
+  }
+
+  // Dedupe (page tails can overlap if a row was added between fetches) using
+  // the same (runNumber|date) key as the recurring adapter, then sort by date.
+  const unique = dedupeYiiEvents(all);
+  unique.sort((a, b) => a.date.localeCompare(b.date));
+  return unique;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Walking Petaling H3 (ph3.org) Yii hareline archive",
+  fetchEvents: fetchAllPages,
+}).catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/adapters/html-scraper/bali-hash-2.test.ts
+++ b/src/adapters/html-scraper/bali-hash-2.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
 import {
   parseBaliDate,
-  parseBaliTitle,
   parseListingCards,
   parseDetailFields,
   dedupeByRunNumber,
+  buildEvent,
   BaliHash2Adapter,
 } from "./bali-hash-2";
 import * as safeFetchModule from "../safe-fetch";
@@ -79,6 +79,13 @@ const DETAIL_FIXTURE = `<!doctype html><html><body><article><section class="gh-c
 <hr><h1 id="run-fees">RUN FEES</h1><h2 id="visitors">VISITORS</h2><p><em>Run with us 5 times and you automatically become a member of Bali Hash 2</em></p>
 </section></article></body></html>`;
 
+/** A detail page whose `Occasion:` carries a real per-run theme (#2116, run
+ *  #1749 "Made in USSR") rather than the club slogan. */
+const THEMED_DETAIL_FIXTURE = `<!doctype html><html><body><article><section class="gh-content">
+<hr><p>Run: 1749<br>Date: 13-Jun-26<br>Our runs start promptly at: 4:00 PM.</p>
+<ul><li>Location: Pohen Hill Camp, Candikuning, Tabanan</li><li>GPS: <a href="x">-8.302931, 115.156899</a></li><li>Occasion: Made in USSR</li><li>Hares: Horny Rabbit, Sir Gay</li></ul>
+</section></article></body></html>`;
+
 /** Mock safeFetch to serve the home fixture for the listing URL and the detail
  *  fixture for everything else. */
 function mockFetch() {
@@ -111,30 +118,6 @@ describe("parseBaliDate", () => {
   });
 });
 
-describe("parseBaliTitle", () => {
-  it.each([
-    [
-      "Bali Hash 2 Next Run Map - #1747 - Pura Pekemitan / Prajapati, Kediri, Tabanan - 30-May-26",
-      "Pura Pekemitan / Prajapati, Kediri, Tabanan",
-    ],
-    [
-      "Bali Hash 2 Next Run Map - #1746 - Lapangan Sepak Bola Perean, Baturiti - 23-May-26",
-      "Lapangan Sepak Bola Perean, Baturiti",
-    ],
-    // Single-digit day in the trailing date is still stripped.
-    [
-      "Bali Hash 2 Next Run Map - #1739 - Lapangan Mamed, Sindu Wati, Sidemen - 4-Apr-26",
-      "Lapangan Mamed, Sindu Wati, Sidemen",
-    ],
-  ])("strips the prefix + trailing date from %s", (title, expected) => {
-    expect(parseBaliTitle(title)).toBe(expected);
-  });
-
-  it("returns undefined when the title carries no run-number token", () => {
-    expect(parseBaliTitle("Bali Hash 2 About Us")).toBeUndefined();
-  });
-});
-
 describe("parseListingCards", () => {
   const entries = parseListingCards(HOME_FIXTURE);
 
@@ -149,7 +132,6 @@ describe("parseListingCards", () => {
     expect(e.date).toBe("2026-05-30");
     expect(e.startTime).toBe("16:00");
     expect(e.location).toBe("Pura Pekemitan / Prajapati, Kediri, Tabanan");
-    expect(e.title).toBe("Pura Pekemitan / Prajapati, Kediri, Tabanan");
     expect(e.url).toBe(
       "https://balihash2.com/bali-hash-2-next-run-map-1747-pura-pekemitan-prajapati-kediri-tabanan-30-may-26/",
     );
@@ -189,6 +171,46 @@ describe("parseDetailFields", () => {
   it("parses the detail-page date", () => {
     expect(fields.date).toBe("2026-05-30");
   });
+
+  it("filters the club slogan out of the Occasion line (#2116)", () => {
+    // DETAIL_FIXTURE's Occasion is "WE START TOGETHER - WE DRINK TOGETHER".
+    expect(fields.occasion).toBeUndefined();
+  });
+
+  it("extracts a real per-run theme from the Occasion line (#2116)", () => {
+    const themed = parseDetailFields(THEMED_DETAIL_FIXTURE);
+    expect(themed.occasion).toBe("Made in USSR");
+    // Venue is NOT promoted to title — it stays in `location`.
+    expect(themed.location).toBe("Pohen Hill Camp, Candikuning, Tabanan");
+  });
+});
+
+describe("buildEvent", () => {
+  const entry = {
+    runNumber: 1749,
+    date: "2026-06-13",
+    location: "Pohen Hill Camp, Candikuning, Tabanan",
+    url: "https://balihash2.com/bali-hash-2-next-run-map-1749-x/",
+    domIndex: 0,
+  };
+
+  it("uses the Occasion theme as title and keeps the venue as location (#2116)", () => {
+    const event = buildEvent(entry, parseDetailFields(THEMED_DETAIL_FIXTURE));
+    expect(event.title).toBe("Made in USSR");
+    expect(event.location).toBe("Pohen Hill Camp, Candikuning, Tabanan");
+  });
+
+  it("leaves title undefined when there is no real Occasion (slogan/missing)", () => {
+    const event = buildEvent(entry, parseDetailFields(DETAIL_FIXTURE));
+    expect(event.title).toBeUndefined();
+    expect(event.location).toBe("Pura Pekemitan / Prajapati, Kediri, Tabanan");
+  });
+
+  it("leaves title undefined for a listing-only entry (no detail page)", () => {
+    const event = buildEvent(entry, null);
+    expect(event.title).toBeUndefined();
+    expect(event.location).toBe("Pohen Hill Camp, Candikuning, Tabanan");
+  });
 });
 
 describe("BaliHash2Adapter.fetch", () => {
@@ -206,7 +228,7 @@ describe("BaliHash2Adapter.fetch", () => {
     vi.restoreAllMocks();
   });
 
-  it("emits deduped events with detail-enriched coords and synthesized-able titles", async () => {
+  it("emits deduped events with detail-enriched coords and slogan-filtered titles", async () => {
     mockFetch();
     const result = await new BaliHash2Adapter().fetch(source);
 
@@ -222,8 +244,10 @@ describe("BaliHash2Adapter.fetch", () => {
     expect(run1747.latitude).toBeCloseTo(-8.5835, 4);
     expect(run1747.longitude).toBeCloseTo(115.1270571, 4);
     expect(run1747.hares).toBe("Exit/Re Entry & Popoff Monster");
-    // Title parsed from the post title (#1838), not the synthesized placeholder.
-    expect(run1747.title).toBe("Pura Pekemitan / Prajapati, Kediri, Tabanan");
+    // Occasion is the club slogan in the fixture → filtered → title undefined,
+    // so merge.ts synthesizes "Bali Hash 2 Trail #N". The venue is NOT the title.
+    expect(run1747.title).toBeUndefined();
+    expect(run1747.location).toBe("Pura Pekemitan / Prajapati, Kediri, Tabanan");
     expect(run1747.locationUrl).toContain("google.com/maps");
   });
 

--- a/src/adapters/html-scraper/bali-hash-2.ts
+++ b/src/adapters/html-scraper/bali-hash-2.ts
@@ -12,7 +12,6 @@ import {
   normalizeHaresField,
   parse12HourTime,
   stripHtmlTags,
-  trimEdgeChars,
 } from "../utils";
 
 /**
@@ -20,10 +19,12 @@ import {
  *
  * Each weekly run is a "Bali Hash 2 Next Run Map - #NNNN - <location> - D-MMM-YY"
  * post. The home-page listing card carries Run / Date / start time / Location in
- * its excerpt; the detail page additionally exposes `GPS:` coords and `Hares:`.
- * The `Occasion:` line is the club slogan ("WE START TOGETHER - WE DRINK
- * TOGETHER"), never a per-run theme, so it is deliberately ignored — titles are
- * left undefined for merge.ts to synthesize `Bali Hash 2 Trail #N`.
+ * its excerpt; the detail page additionally exposes `GPS:` coords, `Hares:`, and
+ * an `Occasion:` line. The `Occasion:` is the per-run theme ("Made in USSR") and
+ * is used as the event `title` (#2116). Some runs carry the club slogan
+ * ("WE START TOGETHER - WE DRINK TOGETHER") there instead — those are filtered
+ * out, leaving `title` undefined for merge.ts to synthesize `Bali Hash 2 Trail
+ * #N`. The location is NOT used as a title — it stays in `locationName` only.
  *
  * Parsing is split into pure exported helpers (`parseListingCards`,
  * `parseDetailFields`) so the one-shot history backfill
@@ -62,46 +63,9 @@ export interface BaliListingEntry {
   date?: string;
   startTime?: string;
   location?: string;
-  /** Run descriptor from the post title (the location name the source titles
-   *  the post with) — `undefined` when the title doesn't parse. See #1838. */
-  title?: string;
   url: string;
   /** DOM order on the listing (0 = newest, reverse-chronological). */
   domIndex: number;
-}
-
-/** Edge characters trimmed off a parsed title segment (separators + space). */
-const TITLE_EDGE_CHARS = " \t\n-–—:";
-
-/**
- * Parse the descriptive run title from a post title of the form
- *   `Bali Hash 2 Next Run Map - #NNNN - <location> - D-MMM-YY`
- * Returns the `<location>` middle segment (the source's own per-run descriptor)
- * or undefined. Without this the adapter discards the title and merge.ts
- * synthesizes the placeholder "Bali Hash 2 Trail #N" (#1838). Implemented with
- * index slicing + `RUN_DATE_RE` (no `.*?`/`\s*` alternation) to stay S5852-safe.
- */
-export function parseBaliTitle(postTitle: string): string | undefined {
-  const hash = /#\d+/.exec(postTitle);
-  if (hash?.index === undefined) return undefined;
-  let rest = postTitle.slice(hash.index + hash[0].length);
-  // Drop the trailing ` - D-MMM-YY` date the source appends. Two guards so a
-  // location containing a date-like token (e.g. "Pura 12-Marching-26 …") can't
-  // be wrongly truncated: (1) the matched month must be a real month
-  // (VALID_MONTHS — same check as parseBaliDate), and (2) the match must be the
-  // trailing token (nothing but separators after it), since the date is always
-  // last in the post title.
-  const date = RUN_DATE_RE.exec(rest);
-  if (
-    date &&
-    date.index !== undefined &&
-    VALID_MONTHS.has(date[2].toLowerCase()) &&
-    rest.slice(date.index + date[0].length).trim() === ""
-  ) {
-    rest = rest.slice(0, date.index);
-  }
-  const cleaned = trimEdgeChars(rest, TITLE_EDGE_CHARS);
-  return cleaned.length > 0 ? cleaned : undefined;
 }
 
 /** Detail-page enrichment fields. */
@@ -112,7 +76,14 @@ export interface BaliDetailFields {
   location?: string;
   startTime?: string;
   date?: string;
+  /** Per-run theme from the `Occasion:` line → event title (#2116). The club
+   *  slogan is filtered out, leaving this undefined. */
+  occasion?: string;
 }
+
+/** The club motto that appears on the `Occasion:` line of some posts — it is a
+ *  slogan, not a per-run theme, so it must never become a title (#2116). */
+const BALI_SLOGAN_RE = /we start together|we drink together/i;
 
 /** Parse `30-May-26` → `2026-05-30`. Normalizes hyphens to spaces so the
  *  chrono `D MMM YY` fast-path fires (avoids the single-digit-day mis-parse). */
@@ -181,7 +152,6 @@ export function parseListingCards(html: string): BaliListingEntry[] {
       date: parseBaliDate(excerpt) ?? parseBaliDate(title),
       startTime: parseStartTime(excerpt),
       location: parseLocation(excerpt),
-      title: parseBaliTitle(title),
       url,
       domIndex: domIndex++,
     });
@@ -214,6 +184,15 @@ export function parseDetailFields(html: string): BaliDetailFields {
   if (hareMatch) {
     const hares = normalizeHaresField(hareMatch[1].trim());
     if (hares) fields.hares = hares;
+  }
+
+  // Occasion → title (#2116). Skip the club slogan and any too-short fragment.
+  const occasionMatch = /Occasion:\s*([^\n]+)/i.exec(text);
+  if (occasionMatch) {
+    const occasion = occasionMatch[1].trim();
+    if (occasion.length >= 2 && !BALI_SLOGAN_RE.test(occasion)) {
+      fields.occasion = occasion;
+    }
   }
 
   const gps = /GPS:\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)/i.exec(text);
@@ -269,9 +248,11 @@ export function buildEvent(entry: BaliListingEntry, detail: BaliDetailFields | n
     date: entry.date!,
     kennelTags: [KENNEL_TAG],
     runNumber: entry.runNumber,
-    // Descriptor from the post title (#1838); undefined → merge.ts synthesizes
-    // "Bali Hash 2 Trail #N".
-    title: entry.title,
+    // Per-run theme from the detail page `Occasion:` line (#2116). Only the
+    // detail page carries it, so listing-only entries (beyond the detail-fetch
+    // cap, or no/slogan Occasion) leave this undefined → merge.ts synthesizes
+    // "Bali Hash 2 Trail #N". The venue is never used as a title.
+    title: detail?.occasion,
     startTime: detail?.startTime ?? entry.startTime,
     location,
     locationUrl: location ? googleMapsSearchUrl(location) : undefined,

--- a/src/adapters/html-scraper/yii-hareline.test.ts
+++ b/src/adapters/html-scraper/yii-hareline.test.ts
@@ -1,11 +1,16 @@
 import * as cheerio from "cheerio";
 import {
   buildYiiPageUrl,
+  dedupeYiiEvents,
+  discoverMaxYiiPage,
   extractMaxYiiPage,
+  extractTotalPagesFromSummary,
   parseYiiHarelineDate,
   parseYiiHarelinePage,
   parseYiiHarelineRow,
+  splitOccasion,
 } from "./yii-hareline";
+import type { RawEventData } from "../types";
 
 describe("parseYiiHarelineDate", () => {
   it("parses 04 Jan 2003", () => {
@@ -41,6 +46,82 @@ describe("extractMaxYiiPage", () => {
   });
 });
 
+describe("extractTotalPagesFromSummary", () => {
+  // Contract: called on PAGE 1, where the X-Y range is a full page so per-page
+  // is inferred correctly. (On a partial last page the inference would be off,
+  // but the adapter + backfill always pass page-1 HTML.)
+  it("computes pages from the 'Showing X-Y of TOTAL items' summary", () => {
+    // PH3: 13 per page, 1,160 items → 90 pages (links alone stop at 89, #2085).
+    expect(
+      extractTotalPagesFromSummary(`<div>Showing <b>1-13</b> of <b>1,160</b> items</div>`),
+    ).toBe(90);
+  });
+  it("handles a plain-text (un-bolded) summary", () => {
+    // 12 per page, 144 items → 12 pages (KL Full Moon scale).
+    expect(extractTotalPagesFromSummary(`Showing 1-12 of 144 items`)).toBe(12);
+  });
+  it("returns null when no summary present", () => {
+    expect(extractTotalPagesFromSummary("<html></html>")).toBeNull();
+  });
+});
+
+describe("discoverMaxYiiPage", () => {
+  it("takes the summary count when it exceeds the visible page links (#2085)", () => {
+    // Links top out at 89 but the summary says 90 pages.
+    const html = `<a href="?r=site/hareline&page=89">89</a>
+      <div>Showing <b>1-13</b> of <b>1,160</b> items</div>`;
+    expect(discoverMaxYiiPage(html)).toBe(90);
+  });
+  it("falls back to link scan when no summary is present", () => {
+    expect(discoverMaxYiiPage(`<a href="?page=14">14</a>`)).toBe(14);
+  });
+});
+
+describe("splitOccasion", () => {
+  it("returns {} for empty / whitespace", () => {
+    expect(splitOccasion(undefined)).toEqual({});
+    expect(splitOccasion("")).toEqual({});
+    expect(splitOccasion("   ")).toEqual({});
+  });
+
+  it.each([
+    // [occasion, expectedTitle] — short clean labels → title only, no description
+    ["Christmas Run", "Christmas Run"],
+    ["CNY Run", "CNY Run"],
+    ["Silver Centum Run", "Silver Centum Run"],
+    ["Merdeka Run", "Merdeka Run"],
+    ["New Year & Belated Birthday Run", "New Year & Belated Birthday Run"],
+    ["7-Eleven Run", "7-Eleven Run"], // bare hyphen (no spaces) is not a separator
+    ["St. George's Day", "St. George's Day"],
+    ["Interhowl / SHOT", "Interhowl / SHOT"], // KLFM — slash is not a separator
+    ["Mother's 80th preamble", "Mother's 80th preamble"], // KLFM
+  ])("treats %j as a pure label title", (occasion, expected) => {
+    expect(splitOccasion(occasion)).toEqual({ title: expected });
+  });
+
+  it.each([
+    // [occasion, expectedTitle] — prose/instructions: full string → description,
+    // leading clean label → title
+    ["Torchlight Run - Run Starts at 7pm!!!", "Torchlight Run"],
+    ["The X Run (Guest Fee Rm80 including On-On)", "The X Run"],
+    ["JM's Run - Run starts at 5:30pm - headtorch is mandatory!", "JM's Run"],
+    ["Outstation Run - there is NO LOCAL RUN this weekend", "Outstation Run"],
+  ])("splits rich occasion %j into title + description", (occasion, expectedTitle) => {
+    expect(splitOccasion(occasion)).toEqual({ title: expectedTitle, description: occasion });
+  });
+
+  it("leaves title undefined when the leading label is not clean (time-only)", () => {
+    const occ = "Run starts at 5:30pm - headtorch is mandatory!";
+    expect(splitOccasion(occ)).toEqual({ title: undefined, description: occ });
+  });
+
+  it("treats a >=60-char label-shaped cell as description only (no title)", () => {
+    const occ = "A very long single-clause occasion string that is well over sixty chars";
+    expect(occ.length).toBeGreaterThanOrEqual(60);
+    expect(splitOccasion(occ)).toEqual({ title: undefined, description: occ });
+  });
+});
+
 describe("parseYiiHarelineRow", () => {
   const config = {
     kennelTag: "ph3-my",
@@ -67,10 +148,35 @@ describe("parseYiiHarelineRow", () => {
     expect(event?.kennelTags[0]).toBe("ph3-my");
   });
 
-  it("extracts title from Occasion column", () => {
+  it("extracts a clean label Occasion into title (no description)", () => {
     const cells = ["2480", "18 Apr 2026", "Barry Sage", "Bukit Bayu", "St. George's Day"];
     const event = parseYiiHarelineRow(cells, config, "x");
     expect(event?.title).toBe("St. George's Day");
+    expect(event?.description).toBeUndefined();
+  });
+
+  it("routes a prose/instruction Occasion into description with a label title", () => {
+    const cells = ["2485", "23 May 2026", "Wim", "Somewhere", "Torchlight Run - Run Starts at 7pm!!!"];
+    const event = parseYiiHarelineRow(cells, config, "x");
+    expect(event?.title).toBe("Torchlight Run");
+    expect(event?.description).toBe("Torchlight Run - Run Starts at 7pm!!!");
+  });
+
+  it("leaves title + description undefined when Occasion is blank", () => {
+    const cells = ["2479", "11 Apr 2026", "Raymond Lai", "Pantai Remis", ""];
+    const event = parseYiiHarelineRow(cells, config, "x");
+    expect(event?.title).toBeUndefined();
+    expect(event?.description).toBeUndefined();
+  });
+
+  it("parses a KL Full Moon row (Occasion → title, additive)", () => {
+    const klfm = { kennelTag: "klfmh3", startTime: "18:00" };
+    const cells = ["144", "12 Sep 2026", "Cougar", "Kuala Lumpur", "Interhowl / SHOT"];
+    const event = parseYiiHarelineRow(cells, klfm, "https://klfullmoonhash.com/index.php?r=site/hareline");
+    expect(event?.runNumber).toBe(144);
+    expect(event?.kennelTags[0]).toBe("klfmh3");
+    expect(event?.title).toBe("Interhowl / SHOT");
+    expect(event?.description).toBeUndefined();
   });
 
   it("drops placeholder rows with run number 0", () => {
@@ -119,6 +225,21 @@ describe("parseYiiHarelinePage", () => {
     const events = parseYiiHarelinePage($, { kennelTag: "ph3-my" }, "https://ph3.org");
     expect(events).toHaveLength(2);
     expect(events.map((e) => e.runNumber)).toEqual([2479, 2480]);
+  });
+});
+
+describe("dedupeYiiEvents", () => {
+  const ev = (runNumber: number, date: string): RawEventData =>
+    ({ runNumber, date, kennelTags: ["ph3-my"] }) as RawEventData;
+
+  it("drops duplicate (runNumber, date) pairs, keeping the first", () => {
+    const out = dedupeYiiEvents([ev(2479, "2026-04-11"), ev(2479, "2026-04-11"), ev(2480, "2026-04-18")]);
+    expect(out.map((e) => e.runNumber)).toEqual([2479, 2480]);
+  });
+
+  it("keeps same run number on different dates (re-run / reschedule)", () => {
+    const out = dedupeYiiEvents([ev(2479, "2026-04-11"), ev(2479, "2026-04-18")]);
+    expect(out).toHaveLength(2);
   });
 });
 

--- a/src/adapters/html-scraper/yii-hareline.test.ts
+++ b/src/adapters/html-scraper/yii-hareline.test.ts
@@ -78,14 +78,21 @@ describe("discoverMaxYiiPage", () => {
 });
 
 describe("splitOccasion", () => {
-  it("returns {} for empty / whitespace", () => {
-    expect(splitOccasion(undefined)).toEqual({});
-    expect(splitOccasion("")).toEqual({});
-    expect(splitOccasion("   ")).toEqual({});
+  it("emits description:null for a blank cell when the column is PRESENT (clear stale)", () => {
+    // Column present but empty → explicit clear so a prior scrape's description
+    // can't linger after the source removes the Occasion.
+    expect(splitOccasion("")).toEqual({ title: undefined, description: null });
+    expect(splitOccasion("   ")).toEqual({ title: undefined, description: null });
+    expect(splitOccasion(undefined)).toEqual({ title: undefined, description: null });
+  });
+
+  it("emits description:undefined when the column is genuinely ABSENT (preserve)", () => {
+    expect(splitOccasion(undefined, false)).toEqual({ title: undefined, description: undefined });
+    expect(splitOccasion("", false)).toEqual({ title: undefined, description: undefined });
   });
 
   it.each([
-    // [occasion, expectedTitle] — short clean labels → title only, no description
+    // [occasion, expectedTitle] — short clean labels → title + description cleared
     ["Christmas Run", "Christmas Run"],
     ["CNY Run", "CNY Run"],
     ["Silver Centum Run", "Silver Centum Run"],
@@ -95,8 +102,9 @@ describe("splitOccasion", () => {
     ["St. George's Day", "St. George's Day"],
     ["Interhowl / SHOT", "Interhowl / SHOT"], // KLFM — slash is not a separator
     ["Mother's 80th preamble", "Mother's 80th preamble"], // KLFM
-  ])("treats %j as a pure label title", (occasion, expected) => {
-    expect(splitOccasion(occasion)).toEqual({ title: expected });
+  ])("treats %j as a pure label title (description cleared)", (occasion, expected) => {
+    // A clean label carries no prose, so description is cleared (null), not stale.
+    expect(splitOccasion(occasion)).toEqual({ title: expected, description: null });
   });
 
   it.each([
@@ -148,11 +156,12 @@ describe("parseYiiHarelineRow", () => {
     expect(event?.kennelTags[0]).toBe("ph3-my");
   });
 
-  it("extracts a clean label Occasion into title (no description)", () => {
+  it("extracts a clean label Occasion into title (description cleared to null)", () => {
     const cells = ["2480", "18 Apr 2026", "Barry Sage", "Bukit Bayu", "St. George's Day"];
     const event = parseYiiHarelineRow(cells, config, "x");
     expect(event?.title).toBe("St. George's Day");
-    expect(event?.description).toBeUndefined();
+    // Column present, no prose → explicit clear so stale descriptions don't linger.
+    expect(event?.description).toBeNull();
   });
 
   it("routes a prose/instruction Occasion into description with a label title", () => {
@@ -162,10 +171,17 @@ describe("parseYiiHarelineRow", () => {
     expect(event?.description).toBe("Torchlight Run - Run Starts at 7pm!!!");
   });
 
-  it("leaves title + description undefined when Occasion is blank", () => {
+  it("clears description (null) when the Occasion cell is blank but present", () => {
     const cells = ["2479", "11 Apr 2026", "Raymond Lai", "Pantai Remis", ""];
     const event = parseYiiHarelineRow(cells, config, "x");
     expect(event?.title).toBeUndefined();
+    expect(event?.description).toBeNull();
+  });
+
+  it("preserves description (undefined) when the row has no Occasion column at all", () => {
+    // Only 4 cells — index 4 (occasion) is absent, so preserve rather than clear.
+    const cells = ["2479", "11 Apr 2026", "Raymond Lai", "Pantai Remis"];
+    const event = parseYiiHarelineRow(cells, config, "x");
     expect(event?.description).toBeUndefined();
   });
 
@@ -176,7 +192,7 @@ describe("parseYiiHarelineRow", () => {
     expect(event?.runNumber).toBe(144);
     expect(event?.kennelTags[0]).toBe("klfmh3");
     expect(event?.title).toBe("Interhowl / SHOT");
-    expect(event?.description).toBeUndefined();
+    expect(event?.description).toBeNull();
   });
 
   it("drops placeholder rows with run number 0", () => {

--- a/src/adapters/html-scraper/yii-hareline.test.ts
+++ b/src/adapters/html-scraper/yii-hareline.test.ts
@@ -245,8 +245,11 @@ describe("parseYiiHarelinePage", () => {
 });
 
 describe("dedupeYiiEvents", () => {
-  const ev = (runNumber: number, date: string): RawEventData =>
-    ({ runNumber, date, kennelTags: ["ph3-my"] }) as RawEventData;
+  const ev = (runNumber: number, date: string): RawEventData => ({
+    runNumber,
+    date,
+    kennelTags: ["ph3-my"],
+  });
 
   it("drops duplicate (runNumber, date) pairs, keeping the first", () => {
     const out = dedupeYiiEvents([ev(2479, "2026-04-11"), ev(2479, "2026-04-11"), ev(2480, "2026-04-18")]);

--- a/src/adapters/html-scraper/yii-hareline.ts
+++ b/src/adapters/html-scraper/yii-hareline.ts
@@ -198,7 +198,7 @@ export function extractTotalPagesFromSummary(html: string): number | null {
   const text = stripHtmlTags(html);
   const m = /Showing\s+([\d,]+)\s*[-–]\s*([\d,]+)\s+of\s+([\d,]+)\s+items/i.exec(text);
   if (!m) return null;
-  const toNum = (s: string) => Number.parseInt(s.replace(/,/g, ""), 10);
+  const toNum = (s: string) => Number.parseInt(s.replaceAll(",", ""), 10);
   const from = toNum(m[1]);
   const to = toNum(m[2]);
   const total = toNum(m[3]);

--- a/src/adapters/html-scraper/yii-hareline.ts
+++ b/src/adapters/html-scraper/yii-hareline.ts
@@ -122,8 +122,12 @@ export function extractMaxYiiPage(html: string): number {
  * ugly multi-clause titles and never populated `description`.
  *
  * Heuristic:
- *   - A cell is "rich" (prose/instruction) if it contains a separator
- *     (` - `/` – `/` — `, `(`, or `!`) or is >= 60 chars.
+ *   - A cell is "rich" (prose/instruction) if it contains a separator — a
+ *     space-padded dash ("&nbsp;-&nbsp;", "&nbsp;–&nbsp;", "&nbsp;—&nbsp;"), an
+ *     opening paren "(", or "!" — or is >= 60 chars. (Comma is deliberately NOT
+ *     a separator: legit short titles routinely contain commas, e.g. "New Year,
+ *     Belated Birthday Run" and place names, so splitting on it would truncate
+ *     good titles.)
  *   - Not rich → the whole cell is a clean label → `{ title }`.
  *   - Rich → `{ description: <full cell>, title: <leading label if clean> }`.
  *     The leading label is the segment before the separator; it's only used as

--- a/src/adapters/html-scraper/yii-hareline.ts
+++ b/src/adapters/html-scraper/yii-hareline.ts
@@ -8,6 +8,7 @@ import {
   decodeEntities,
   fetchHTMLPage,
   MONTHS,
+  stripHtmlTags,
   validateSourceConfig,
 } from "../utils";
 
@@ -187,9 +188,10 @@ export function splitOccasion(
  * Exported for unit testing.
  */
 export function extractTotalPagesFromSummary(html: string): number | null {
-  // Strip tags first so the match is independent of the <b>…</b> markup Yii
-  // wraps the numbers in ("Showing <b>1-13</b> of <b>1,160</b> items").
-  const text = html.replace(/<[^>]+>/g, "");
+  // Strip tags via the shared cheerio-based helper (not a regex) so the match
+  // is independent of the <b>…</b> markup Yii wraps the numbers in
+  // ("Showing <b>1-13</b> of <b>1,160</b> items").
+  const text = stripHtmlTags(html);
   const m = /Showing\s+([\d,]+)\s*[-–]\s*([\d,]+)\s+of\s+([\d,]+)\s+items/i.exec(text);
   if (!m) return null;
   const toNum = (s: string) => Number.parseInt(s.replace(/,/g, ""), 10);

--- a/src/adapters/html-scraper/yii-hareline.ts
+++ b/src/adapters/html-scraper/yii-hareline.ts
@@ -130,6 +130,16 @@ export function extractMaxYiiPage(html: string): number {
  *     like `7:30`), otherwise title is left undefined and merge.ts synthesizes
  *     the "<Kennel> Trail #N" default.
  *
+ * **Tri-state `description` clear signal** (`columnPresent`): the merge pipeline
+ * treats `description: undefined` as "preserve existing" and `null` as "explicit
+ * clear" (see `feedback_backfill_clear_field_needs_explicit_null` + fingerprint
+ * tri-state). When the Occasion column is PRESENT on the row but yields no rich
+ * description (a clean label or a blank cell), we must emit `null` — otherwise a
+ * source edit from `"Torchlight Run - Run Starts at 7pm!!!"` to `"Torchlight
+ * Run"` (or a cleared cell) would update the title but leave the stale
+ * instruction text on the canonical Event forever. `undefined` is reserved for
+ * the genuinely-absent-column case (a row/columnMap with no Occasion at all).
+ *
  * Exported for unit testing.
  */
 const RICH_OCCASION_SEPARATOR = /\s[-–—]\s|\(|!/;
@@ -147,13 +157,19 @@ function isCleanLabel(s: string): boolean {
   );
 }
 
-export function splitOccasion(raw?: string): { title?: string; description?: string } {
+export function splitOccasion(
+  raw: string | undefined,
+  columnPresent = true,
+): { title?: string; description?: string | null } {
+  // No rich description from this cell → explicit-clear (null) when the column
+  // is present, preserve (undefined) only when the column is genuinely absent.
+  const emptyDescription = columnPresent ? null : undefined;
   const occ = raw?.trim();
-  if (!occ) return {};
+  if (!occ) return { title: undefined, description: emptyDescription };
 
   const sep = RICH_OCCASION_SEPARATOR.exec(occ);
   const isRich = sep !== null || occ.length >= 60;
-  if (!isRich) return { title: occ };
+  if (!isRich) return { title: occ, description: emptyDescription };
 
   const label = (sep ? occ.slice(0, sep.index) : occ).trim();
   return { title: isCleanLabel(label) ? label : undefined, description: occ };
@@ -239,8 +255,11 @@ export function parseYiiHarelineRow(
     : rawHare || undefined;
 
   const location = cells[cols.location]?.trim() || undefined;
+  // `columnPresent` distinguishes a blank Occasion cell (clear stale description)
+  // from a row that has no Occasion column at all (preserve) — see splitOccasion.
+  const occasionPresent = cols.occasion < cells.length;
   const occasion = cells[cols.occasion]?.trim() || undefined;
-  const { title, description } = splitOccasion(occasion);
+  const { title, description } = splitOccasion(occasion, occasionPresent);
 
   return {
     date,

--- a/src/adapters/html-scraper/yii-hareline.ts
+++ b/src/adapters/html-scraper/yii-hareline.ts
@@ -111,6 +111,102 @@ export function extractMaxYiiPage(html: string): number {
 }
 
 /**
+ * Split a hareline "Occasion" cell into title vs. description.
+ *
+ * The Occasion column mixes two kinds of content (#2084): short event labels
+ * ("Christmas Run", "CNY Run", "Silver Centum Run") that read as titles, and
+ * prose / instructions ("Torchlight Run - Run Starts at 7pm!!!", "JM's Run -
+ * headtorch is mandatory!", "The X Run (Guest Fee Rm80 including On-On)") that
+ * belong in the description. Dumping the whole string into `title` produced
+ * ugly multi-clause titles and never populated `description`.
+ *
+ * Heuristic:
+ *   - A cell is "rich" (prose/instruction) if it contains a separator
+ *     (` - `/` – `/` — `, `(`, or `!`) or is >= 60 chars.
+ *   - Not rich → the whole cell is a clean label → `{ title }`.
+ *   - Rich → `{ description: <full cell>, title: <leading label if clean> }`.
+ *     The leading label is the segment before the separator; it's only used as
+ *     a title when it passes `isCleanLabel` (2–50 chars, no `!`/`?`, no time
+ *     like `7:30`), otherwise title is left undefined and merge.ts synthesizes
+ *     the "<Kennel> Trail #N" default.
+ *
+ * Exported for unit testing.
+ */
+const RICH_OCCASION_SEPARATOR = /\s[-–—]\s|\(|!/;
+/** Sentence/instruction punctuation that disqualifies a string as a title. */
+const LABEL_REJECT_PUNCT = /[!?]/;
+/** A time like "7:30" — an instruction, not a title. */
+const LABEL_REJECT_TIME = /\d{1,2}:\d{2}/;
+
+function isCleanLabel(s: string): boolean {
+  return (
+    s.length >= 2 &&
+    s.length <= 50 &&
+    !LABEL_REJECT_PUNCT.test(s) &&
+    !LABEL_REJECT_TIME.test(s)
+  );
+}
+
+export function splitOccasion(raw?: string): { title?: string; description?: string } {
+  const occ = raw?.trim();
+  if (!occ) return {};
+
+  const sep = RICH_OCCASION_SEPARATOR.exec(occ);
+  const isRich = sep !== null || occ.length >= 60;
+  if (!isRich) return { title: occ };
+
+  const label = (sep ? occ.slice(0, sep.index) : occ).trim();
+  return { title: isCleanLabel(label) ? label : undefined, description: occ };
+}
+
+/**
+ * Recover the true total page count from Yii's "Showing X-Y of TOTAL items"
+ * summary. Yii's LinkPager only renders a windowed set of page links, so on a
+ * long hareline the visible `?page=N` links can stop one short of the real last
+ * page — PH3's page-1 links top out at 89 even though there are 90 pages, so
+ * runs 2498-2500 (page 90) were never fetched (#2085). Per-page = the size of a
+ * full page (Y - X + 1); pages = ceil(TOTAL / perPage). Returns null when the
+ * summary is absent or unparseable, so the caller falls back to the link scan.
+ *
+ * Exported for unit testing.
+ */
+export function extractTotalPagesFromSummary(html: string): number | null {
+  // Strip tags first so the match is independent of the <b>…</b> markup Yii
+  // wraps the numbers in ("Showing <b>1-13</b> of <b>1,160</b> items").
+  const text = html.replace(/<[^>]+>/g, "");
+  const m = /Showing\s+([\d,]+)\s*[-–]\s*([\d,]+)\s+of\s+([\d,]+)\s+items/i.exec(text);
+  if (!m) return null;
+  const toNum = (s: string) => Number.parseInt(s.replace(/,/g, ""), 10);
+  const from = toNum(m[1]);
+  const to = toNum(m[2]);
+  const total = toNum(m[3]);
+  // Self-enforce the page-1 contract: per-page is only inferable from a FULL
+  // page, and the only page guaranteed full is the first (`from === 1`). On a
+  // partial last page `to - from + 1` would be the remainder, badly inflating
+  // the page count — so bail to null and let the caller fall back to the link
+  // scan instead.
+  if (from !== 1) return null;
+  const perPage = to - from + 1;
+  if (!Number.isFinite(perPage) || perPage <= 0 || !Number.isFinite(total) || total <= 0) {
+    return null;
+  }
+  return Math.ceil(total / perPage);
+}
+
+/**
+ * Discover the true last page of a Yii hareline from page-1 HTML, taking the
+ * larger of the visible `?page=N` links and the item-count summary (the links
+ * alone can under-count — see `extractTotalPagesFromSummary`).
+ *
+ * Exported for unit testing + the historical backfill script.
+ */
+export function discoverMaxYiiPage(page1Html: string): number {
+  const fromLinks = extractMaxYiiPage(page1Html);
+  const fromSummary = extractTotalPagesFromSummary(page1Html) ?? 0;
+  return Math.max(fromLinks, fromSummary);
+}
+
+/**
  * Parse a single Yii hareline table row into a RawEventData. Returns null
  * when the row is a header row, an empty placeholder, or missing the
  * required run-number + date fields.
@@ -144,6 +240,7 @@ export function parseYiiHarelineRow(
 
   const location = cells[cols.location]?.trim() || undefined;
   const occasion = cells[cols.occasion]?.trim() || undefined;
+  const { title, description } = splitOccasion(occasion);
 
   return {
     date,
@@ -151,7 +248,8 @@ export function parseYiiHarelineRow(
     runNumber,
     hares,
     location,
-    title: occasion && occasion.length > 0 ? occasion : undefined,
+    title,
+    description,
     startTime: config.startTime,
     sourceUrl,
   };
@@ -183,6 +281,26 @@ export function parseYiiHarelinePage(
   });
 
   return events;
+}
+
+/**
+ * Dedupe parsed events by `(runNumber, date)` — runs are unique on that pair
+ * per the Yii schema. Adjacent page tails can overlap if the kennel adds a row
+ * between the page-1 discovery fetch and a later page fetch. Shared by the
+ * recurring adapter and the historical backfill so both dedupe identically.
+ *
+ * Exported for unit testing + the historical backfill script.
+ */
+export function dedupeYiiEvents(events: RawEventData[]): RawEventData[] {
+  const seen = new Set<string>();
+  const deduped: RawEventData[] = [];
+  for (const e of events) {
+    const key = `${e.runNumber ?? ""}|${e.date}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(e);
+  }
+  return deduped;
 }
 
 /**
@@ -223,7 +341,7 @@ export class YiiHarelineAdapter implements SourceAdapter {
     const page1 = await fetchHTMLPage(baseUrl);
     if (!page1.ok) return page1.result;
 
-    const maxPage = extractMaxYiiPage(page1.html);
+    const maxPage = discoverMaxYiiPage(page1.html);
     // Scale pages-to-fetch with the configured window. Yii GridView
     // pages default to 13 rows; weekly kennels produce ~1 run/week
     // so 180 days ≈ 26 runs ≈ 2 pages and 365 days ≈ 52 runs ≈ 4 pages.
@@ -265,17 +383,7 @@ export class YiiHarelineAdapter implements SourceAdapter {
       pagesFetched.push(pageNum);
     }
 
-    // Dedupe by (runNumber, date) — adjacent page tails can overlap if the
-    // kennel adds a row between the page-1 discovery fetch and the last-page
-    // fetch. Runs are unique on (runNumber + date) per Yii schema.
-    const seen = new Set<string>();
-    const deduped: RawEventData[] = [];
-    for (const e of allEvents) {
-      const key = `${e.runNumber ?? ""}|${e.date}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      deduped.push(e);
-    }
+    const deduped = dedupeYiiEvents(allEvents);
 
     return applyDateWindow(
       {


### PR DESCRIPTION
Quick Win bundle: extract the ignored **Occasion** column/field on two hareline adapters and backfill PH3's archive.

## #2084 — PH3 / KL Full Moon (`yii-hareline.ts`, shared adapter)
The adapter dumped the entire Occasion cell into `title` (ugly multi-clause titles) and never set `description`. New `splitOccasion()`:
- **Short labels → `title`** ("Christmas Run", "CNY Run", "Silver Centum Run", "Merdeka Run").
- **Prose/instructions → `title`-label + `description`** ("Torchlight Run" + "Torchlight Run - Run Starts at 7pm!!!"; "The X Run" + "(Guest Fee Rm80 including On-On)"; "Outstation Run" + full).

Additive and **KL Full Moon verified unchanged** (shared adapter).

## #2085 — PH3 coverage + full-archive backfill
- Root-caused the missing future runs: `extractMaxYiiPage` under-counted (Yii's LinkPager windows the page links → 89 of 90 pages), so runs **2498–2500 (page 90) were never fetched**. New `discoverMaxYiiPage()` also derives the count from the "Showing X-Y of N items" summary and takes the max. Adapter now reaches **2499 "Merdeka Run"**, **2500 "Silver Centum Run"**.
- `scripts/backfill-ph3-my-history.ts` walks the full ph3.org archive (1,160 runs back to 2003) via the shared parser + `runBackfillScript`, strict `date < today-in-KL` partition.
  - **Applied to prod:** `created=1106, updated=10, skipped=25, blocked=0, eventErrors=0`. Re-run idempotent (`created=0, skipped=1141`).

## #2116 — Bali Hash 2 (`bali-hash-2.ts`)
The adapter assumed `Occasion:` was always the club slogan and titled events with the **location** instead. Live-verified that's wrong (#1749 `Occasion: Made in USSR`). Now:
- Extract the detail-page `Occasion:` line as `title`; filter the club slogan.
- **Venue stays in `locationName`** — location is no longer used as a title. Removed the now-dead `parseBaliTitle`.

## Verification
- **Live-verified** all three sources via the adapters' `fetch()`: PH3 (35→ now reaches 2500), KL Full Moon (occasions intact, e.g. "Ball Breaker run" + "(20th edition)" desc), Bali #1749 `title="Made in USSR"` + venue in `location` + GPS present.
- `npm run lint` (0 errors), `npx tsc --noEmit` (clean), `npm test` (**8889 passing**).
- `/simplify` (hoisted regexes, self-enforced page-1 contract, shared `dedupeYiiEvents`) + adversarial `/code-review` (high) — no correctness findings.

### Notes (out of scope, not regressions)
- Existing Bali events titled with the venue (from #1838) that have **no** Occasion keep that venue title; #1749 (the issue's subject) heals via its Occasion on the next scrape. No Bali backfill run (task scoped to PH3).
- Did not touch `prisma/seed-data/kennels.ts` (WS6 owns PH3 logo #2086).

Closes #2084
Closes #2085
Closes #2116

🤖 Generated with [Claude Code](https://claude.com/claude-code)