### PR TITLE
fix(kch3): land location-quality fix on main (recover stranded #2132)

### DIFF
--- a/scripts/cleanup-kch3-junk-locations.test.ts
+++ b/scripts/cleanup-kch3-junk-locations.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+
+// classifyJunkEvents is pure, but the module imports prisma at top level — mock
+// it so importing here can't touch a real DB. (The entrypoint is argv-guarded.)
+vi.mock("@/lib/db", () => ({ prisma: {} }));
+
+import { classifyJunkEvents, type EventRow } from "./cleanup-kch3-junk-locations";
+
+const codeById = new Map([["k1", "kch3"]]);
+const row = (id: string, date: string, locationName: string | null): EventRow => ({
+  id,
+  date: new Date(`${date}T12:00:00Z`),
+  kennelId: "k1",
+  locationName,
+});
+
+describe("classifyJunkEvents", () => {
+  it("overwrites a junk value when the source post yields a real venue", () => {
+    const fresh = new Map([["kch3|2024-12-14", "7103 Harvard Ave, Raytown, MO"]]);
+    const { overwrite, nulled } = classifyJunkEvents([row("e1", "2024-12-14", "Hash Cash: $5")], codeById, fresh);
+    expect(nulled).toHaveLength(0);
+    expect(overwrite).toEqual([{ id: "e1", date: "2024-12-14", old: "Hash Cash: $5", fresh: "7103 Harvard Ave, Raytown, MO" }]);
+  });
+
+  it("nulls a junk value when the matching post has no location", () => {
+    const fresh = new Map<string, string | null>([["kch3|2019-06-22", null]]);
+    const { overwrite, nulled } = classifyJunkEvents([row("e2", "2019-06-22", "Time 3 p.m.")], codeById, fresh);
+    expect(overwrite).toHaveLength(0);
+    expect(nulled).toEqual([{ id: "e2", date: "2019-06-22", old: "Time 3 p.m.", fresh: null }]);
+  });
+
+  it("leaves a junk value untouched when there is NO matching source post (gemini #2136)", () => {
+    const fresh = new Map<string, string | null>(); // post not fetched / absent
+    const { overwrite, nulled } = classifyJunkEvents([row("e3", "2014-01-01", "Time 3 p.m.")], codeById, fresh);
+    expect(overwrite).toHaveLength(0);
+    expect(nulled).toHaveLength(0);
+  });
+
+  it("leaves a non-junk (real venue) value untouched even if it differs from fresh", () => {
+    const fresh = new Map([["kch3|2025-03-15", "Macken Park baseball fields"]]);
+    const { overwrite, nulled } = classifyJunkEvents(
+      [row("e4", "2025-03-15", "Macken Park (different wording)")],
+      codeById,
+      fresh,
+    );
+    expect(overwrite).toHaveLength(0);
+    expect(nulled).toHaveLength(0);
+  });
+});

--- a/scripts/cleanup-kch3-junk-locations.ts
+++ b/scripts/cleanup-kch3-junk-locations.ts
@@ -35,7 +35,7 @@ const KENNEL_CODES = ["kch3", "pnh3"];
 const JUNK_PATTERNS: RegExp[] = [
   /^(?:hash\s*cash|cost|time|meet\s*up|pack\s*(?:away|up|out))\b/i, // cost/time/meetup labels
   /^@\s/, // "@ Private Home:"
-  /^\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)\.?$/i, // bare time ("3 p.m.", "2:00pm")
+  /^\d{1,2}(?::\d{2})?\s?(?:a\.?m\.?|p\.?m\.?)\.?$/i, // bare time ("3 p.m.", "2:00pm")
   /!!|come dressed|bring your|going for gold/i, // theme prose
   /\bapproximately\b/i, // "… – approximately 5pm."
 ];
@@ -50,6 +50,12 @@ async function main() {
 
   // 1. Re-derive location from the live source with the fixed parser.
   const posts = await fetchAllWordPressPosts(BASE_URL, { perPage: 100, maxPages: 50 });
+  // Abort on an empty fetch: treating a failed/empty pull as "no source venues"
+  // would null every junk row (and overwrite none). fetchAllWordPressPosts
+  // throws on a real error; an empty array means the archive vanished, so stop.
+  if (posts.length === 0) {
+    throw new Error("KCH3 WordPress archive returned 0 posts — aborting to avoid nulling on a bad fetch.");
+  }
   const freshByKey = new Map<string, string | null>(); // `${kennelCode}|${YYYY-MM-DD}` → location
   for (const post of posts) {
     const ev = processKCH3Post(post.title, htmlToNewlineText(post.content), post.url, post.date);

--- a/scripts/cleanup-kch3-junk-locations.ts
+++ b/scripts/cleanup-kch3-junk-locations.ts
@@ -21,7 +21,7 @@
  */
 import "dotenv/config";
 import { prisma } from "@/lib/db";
-import { fetchAllWordPressPosts } from "@/adapters/wordpress-api";
+import { fetchAllWordPressPosts, type WordPressPost } from "@/adapters/wordpress-api";
 import { processKCH3Post } from "@/adapters/html-scraper/kch3";
 import { htmlToNewlineText } from "@/adapters/utils";
 
@@ -44,19 +44,22 @@ function isJunkLocation(value: string): boolean {
   return JUNK_PATTERNS.some((re) => re.test(value.trim()));
 }
 
-async function main() {
-  const apply = process.env.CLEANUP_APPLY === "1";
-  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}\n`);
+interface EventRow {
+  id: string;
+  date: Date;
+  kennelId: string;
+  locationName: string | null;
+}
+interface Change {
+  id: string;
+  date: string;
+  old: string;
+  fresh: string | null;
+}
 
-  // 1. Re-derive location from the live source with the fixed parser.
-  const posts = await fetchAllWordPressPosts(BASE_URL, { perPage: 100, maxPages: 50 });
-  // Abort on an empty fetch: treating a failed/empty pull as "no source venues"
-  // would null every junk row (and overwrite none). fetchAllWordPressPosts
-  // throws on a real error; an empty array means the archive vanished, so stop.
-  if (posts.length === 0) {
-    throw new Error("KCH3 WordPress archive returned 0 posts — aborting to avoid nulling on a bad fetch.");
-  }
-  const freshByKey = new Map<string, string | null>(); // `${kennelCode}|${YYYY-MM-DD}` → location
+/** Re-derive each post's location with the fixed parser, keyed by `${kennelCode}|${date}`. */
+function buildFreshLocationMap(posts: WordPressPost[]): Map<string, string | null> {
+  const freshByKey = new Map<string, string | null>();
   for (const post of posts) {
     const ev = processKCH3Post(post.title, htmlToNewlineText(post.content), post.url, post.date);
     if (!ev) continue;
@@ -65,6 +68,54 @@ async function main() {
     // Prefer a defined location if two posts collide on the same key.
     if (!freshByKey.has(key) || (loc && !freshByKey.get(key))) freshByKey.set(key, loc);
   }
+  return freshByKey;
+}
+
+/**
+ * Only ACT on stored values that match a junk pattern — a good (or cosmetically
+ * different) venue is left untouched, so we never churn or regress real data.
+ * For a junk value: overwrite with the re-parsed venue when one is recovered,
+ * else null it.
+ */
+function classifyJunkEvents(
+  events: EventRow[],
+  codeById: Map<string, string>,
+  freshByKey: Map<string, string | null>,
+): { overwrite: Change[]; nulled: Change[] } {
+  const overwrite: Change[] = [];
+  const nulled: Change[] = [];
+  for (const e of events) {
+    const old = e.locationName;
+    if (old == null || !isJunkLocation(old)) continue;
+    const dateStr = e.date.toISOString().slice(0, 10);
+    const fresh = freshByKey.get(`${codeById.get(e.kennelId)}|${dateStr}`) ?? null;
+    if (fresh === old) continue; // fresh is never junk, but guard anyway
+    (fresh ? overwrite : nulled).push({ id: e.id, date: dateStr, old, fresh });
+  }
+  return { overwrite, nulled };
+}
+
+function logSample(rows: Change[], withFresh: boolean): void {
+  for (const r of rows.slice(0, 30)) {
+    const extra = withFresh && r.fresh ? ` → ${JSON.stringify(r.fresh.slice(0, 60))}` : "";
+    console.log(`  ${r.date} ${JSON.stringify(r.old.slice(0, 70))}${extra}`);
+  }
+  if (rows.length > 30) console.log(`  …and ${rows.length - 30} more`);
+}
+
+async function main() {
+  const apply = process.env.CLEANUP_APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}\n`);
+
+  // 1. Re-derive location from the live source with the fixed parser. Abort on
+  //    an empty fetch: treating a failed/empty pull as "no source venues" would
+  //    null every junk row. fetchAllWordPressPosts throws on a real error; an
+  //    empty array means the archive vanished, so stop.
+  const posts = await fetchAllWordPressPosts(BASE_URL, { perPage: 100, maxPages: 50 });
+  if (posts.length === 0) {
+    throw new Error("KCH3 WordPress archive returned 0 posts — aborting to avoid nulling on a bad fetch.");
+  }
+  const freshByKey = buildFreshLocationMap(posts);
   console.log(`Re-derived ${freshByKey.size} (kennel|date) locations from ${posts.length} posts.\n`);
 
   // 2. Load every stored KCH3/PNH3 event location.
@@ -75,40 +126,15 @@ async function main() {
   const codeById = new Map(kennels.map((k) => [k.id, k.kennelCode]));
   const events = await prisma.event.findMany({
     where: { kennelId: { in: kennels.map((k) => k.id) }, locationName: { not: null } },
-    select: { id: true, date: true, kennelId: true, title: true, locationName: true },
+    select: { id: true, date: true, kennelId: true, locationName: true },
   });
 
-  // 3. Diff stored vs fresh — but only ACT on stored values that match a junk
-  //    pattern. A good (or cosmetically-different) venue is left untouched, so
-  //    we never churn or regress real data; we only fix the leaked theme/cost/
-  //    time/placeholder strings. For a junk value we overwrite with the
-  //    re-parsed venue when the fixed parser recovers one, else null it.
-  const overwrite: { id: string; date: string; old: string; fresh: string }[] = [];
-  const nulled: { id: string; date: string; old: string }[] = [];
-
-  for (const e of events) {
-    const old = e.locationName;
-    if (old == null || !isJunkLocation(old)) continue; // only touch junk
-    const code = codeById.get(e.kennelId);
-    const dateStr = e.date.toISOString().slice(0, 10);
-    const fresh = freshByKey.get(`${code}|${dateStr}`) ?? null;
-    if (fresh === old) continue; // shouldn't happen (fresh is never junk), but safe
-
-    if (fresh) overwrite.push({ id: e.id, date: dateStr, old, fresh });
-    else nulled.push({ id: e.id, date: dateStr, old });
-  }
-
-  const sample = <T extends { date: string; old: string }>(rows: T[], extra?: (r: T) => string) => {
-    for (const r of rows.slice(0, 30)) {
-      console.log(`  ${r.date} ${JSON.stringify(r.old.slice(0, 70))}${extra ? extra(r) : ""}`);
-    }
-    if (rows.length > 30) console.log(`  …and ${rows.length - 30} more`);
-  };
-
+  // 3. Classify + report.
+  const { overwrite, nulled } = classifyJunkEvents(events, codeById, freshByKey);
   console.log(`OVERWRITE junk → re-parsed venue: ${overwrite.length}`);
-  sample(overwrite, (r) => ` → ${JSON.stringify(r.fresh.slice(0, 60))}`);
+  logSample(overwrite, true);
   console.log(`\nNULL (junk, no venue recoverable from source): ${nulled.length}`);
-  sample(nulled);
+  logSample(nulled, false);
 
   if (!apply) {
     console.log("\nDry run complete. Re-run with CLEANUP_APPLY=1 to write.");
@@ -116,16 +142,10 @@ async function main() {
     return;
   }
 
-  let updated = 0;
-  for (const r of overwrite) {
+  for (const r of [...overwrite, ...nulled]) {
     await prisma.event.update({ where: { id: r.id }, data: { locationName: r.fresh } });
-    updated++;
   }
-  for (const r of nulled) {
-    await prisma.event.update({ where: { id: r.id }, data: { locationName: null } });
-    updated++;
-  }
-  console.log(`\nApplied: ${updated} events updated (${overwrite.length} overwritten, ${nulled.length} nulled).`);
+  console.log(`\nApplied: ${overwrite.length + nulled.length} events updated (${overwrite.length} overwritten, ${nulled.length} nulled).`);
   await prisma.$disconnect();
 }
 

--- a/scripts/cleanup-kch3-junk-locations.ts
+++ b/scripts/cleanup-kch3-junk-locations.ts
@@ -44,7 +44,7 @@ function isJunkLocation(value: string): boolean {
   return JUNK_PATTERNS.some((re) => re.test(value.trim()));
 }
 
-interface EventRow {
+export interface EventRow {
   id: string;
   date: Date;
   kennelId: string;
@@ -77,7 +77,7 @@ function buildFreshLocationMap(posts: WordPressPost[]): Map<string, string | nul
  * For a junk value: overwrite with the re-parsed venue when one is recovered,
  * else null it.
  */
-function classifyJunkEvents(
+export function classifyJunkEvents(
   events: EventRow[],
   codeById: Map<string, string>,
   freshByKey: Map<string, string | null>,
@@ -88,7 +88,13 @@ function classifyJunkEvents(
     const old = e.locationName;
     if (old == null || !isJunkLocation(old)) continue;
     const dateStr = e.date.toISOString().slice(0, 10);
-    const fresh = freshByKey.get(`${codeById.get(e.kennelId)}|${dateStr}`) ?? null;
+    const key = `${codeById.get(e.kennelId)}|${dateStr}`;
+    // No matching source post → leave untouched. Must check `.has()` before
+    // `.get() ?? null`, else an unfetched post (key absent → undefined → null)
+    // is indistinguishable from a fetched post with no location, and the junk
+    // row would be wrongly nulled (gemini, PR #2136).
+    if (!freshByKey.has(key)) continue;
+    const fresh = freshByKey.get(key) ?? null;
     if (fresh === old) continue; // fresh is never junk, but guard anyway
     (fresh ? overwrite : nulled).push({ id: e.id, date: dateStr, old, fresh });
   }
@@ -149,7 +155,11 @@ async function main() {
   await prisma.$disconnect();
 }
 
-main().catch((e) => {
-  console.error("FAILED:", e instanceof Error ? e.message : String(e));
-  process.exit(1);
-});
+// Guard the entrypoint so importing this module (e.g. from the unit test for
+// classifyJunkEvents) doesn't fire main() and hit the live DB.
+if (process.argv[1]?.endsWith("cleanup-kch3-junk-locations.ts")) {
+  main().catch((e) => {
+    console.error("FAILED:", e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  });
+}

--- a/scripts/cleanup-kch3-junk-locations.ts
+++ b/scripts/cleanup-kch3-junk-locations.ts
@@ -1,0 +1,129 @@
+/**
+ * One-shot re-clean for KCH3 + PNH3 event locationName junk (#2110 follow-up).
+ *
+ * The old `parseKCH3Body` Location/Start/Where regex was unanchored and let
+ * `\s*` span newlines, so it leaked theme/cost/time text into locationName
+ * (e.g. "Hash Cash: $5", "Time 3 p.m.", "@ Private Home:", "of the winter
+ * Olympics!!! Come dressed..."). The parser is fixed; this script re-derives
+ * each event's location from the live source with the FIXED parser and:
+ *   - overwrites the stored value when the re-parse yields a real venue (the
+ *     old value was a mis-captured fragment), or
+ *   - nulls it when the re-parse yields nothing AND the stored value matches a
+ *     junk pattern (cost/time/theme/placeholder/leading-dash). A stored value
+ *     that still looks like a real address is left untouched and reported, so
+ *     no good (or manually corrected) data is clobbered.
+ *
+ * Events with no matching source post are left untouched.
+ *
+ * Dry run:  npx tsx scripts/cleanup-kch3-junk-locations.ts
+ * Apply:    CLEANUP_APPLY=1 npx tsx scripts/cleanup-kch3-junk-locations.ts
+ * Env:      DATABASE_URL
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { fetchAllWordPressPosts } from "@/adapters/wordpress-api";
+import { processKCH3Post } from "@/adapters/html-scraper/kch3";
+import { htmlToNewlineText } from "@/adapters/utils";
+
+const BASE_URL = "https://kansascityh3.com/";
+const KENNEL_CODES = ["kch3", "pnh3"];
+
+// Patterns that mark a stored locationName as non-venue junk (gate for action).
+// Deliberately NOT a bare leading-dash: real venues are sometimes stored as
+// "– Wyandotte County Lake Park…" / "- Kelly's Westport Inn"; only the time/
+// cost/theme/placeholder fragments below are junk.
+const JUNK_PATTERNS: RegExp[] = [
+  /^(?:hash\s*cash|cost|time|meet\s*up|pack\s*(?:away|up|out))\b/i, // cost/time/meetup labels
+  /^@\s/, // "@ Private Home:"
+  /^\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)\.?$/i, // bare time ("3 p.m.", "2:00pm")
+  /!!|come dressed|bring your|going for gold/i, // theme prose
+  /\bapproximately\b/i, // "… – approximately 5pm."
+];
+
+function isJunkLocation(value: string): boolean {
+  return JUNK_PATTERNS.some((re) => re.test(value.trim()));
+}
+
+async function main() {
+  const apply = process.env.CLEANUP_APPLY === "1";
+  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}\n`);
+
+  // 1. Re-derive location from the live source with the fixed parser.
+  const posts = await fetchAllWordPressPosts(BASE_URL, { perPage: 100, maxPages: 50 });
+  const freshByKey = new Map<string, string | null>(); // `${kennelCode}|${YYYY-MM-DD}` → location
+  for (const post of posts) {
+    const ev = processKCH3Post(post.title, htmlToNewlineText(post.content), post.url, post.date);
+    if (!ev) continue;
+    const key = `${ev.kennelTags[0]}|${ev.date}`;
+    const loc = ev.location ?? null;
+    // Prefer a defined location if two posts collide on the same key.
+    if (!freshByKey.has(key) || (loc && !freshByKey.get(key))) freshByKey.set(key, loc);
+  }
+  console.log(`Re-derived ${freshByKey.size} (kennel|date) locations from ${posts.length} posts.\n`);
+
+  // 2. Load every stored KCH3/PNH3 event location.
+  const kennels = await prisma.kennel.findMany({
+    where: { kennelCode: { in: KENNEL_CODES } },
+    select: { id: true, kennelCode: true },
+  });
+  const codeById = new Map(kennels.map((k) => [k.id, k.kennelCode]));
+  const events = await prisma.event.findMany({
+    where: { kennelId: { in: kennels.map((k) => k.id) }, locationName: { not: null } },
+    select: { id: true, date: true, kennelId: true, title: true, locationName: true },
+  });
+
+  // 3. Diff stored vs fresh — but only ACT on stored values that match a junk
+  //    pattern. A good (or cosmetically-different) venue is left untouched, so
+  //    we never churn or regress real data; we only fix the leaked theme/cost/
+  //    time/placeholder strings. For a junk value we overwrite with the
+  //    re-parsed venue when the fixed parser recovers one, else null it.
+  const overwrite: { id: string; date: string; old: string; fresh: string }[] = [];
+  const nulled: { id: string; date: string; old: string }[] = [];
+
+  for (const e of events) {
+    const old = e.locationName;
+    if (old == null || !isJunkLocation(old)) continue; // only touch junk
+    const code = codeById.get(e.kennelId);
+    const dateStr = e.date.toISOString().slice(0, 10);
+    const fresh = freshByKey.get(`${code}|${dateStr}`) ?? null;
+    if (fresh === old) continue; // shouldn't happen (fresh is never junk), but safe
+
+    if (fresh) overwrite.push({ id: e.id, date: dateStr, old, fresh });
+    else nulled.push({ id: e.id, date: dateStr, old });
+  }
+
+  const sample = <T extends { date: string; old: string }>(rows: T[], extra?: (r: T) => string) => {
+    for (const r of rows.slice(0, 30)) {
+      console.log(`  ${r.date} ${JSON.stringify(r.old.slice(0, 70))}${extra ? extra(r) : ""}`);
+    }
+    if (rows.length > 30) console.log(`  …and ${rows.length - 30} more`);
+  };
+
+  console.log(`OVERWRITE junk → re-parsed venue: ${overwrite.length}`);
+  sample(overwrite, (r) => ` → ${JSON.stringify(r.fresh.slice(0, 60))}`);
+  console.log(`\nNULL (junk, no venue recoverable from source): ${nulled.length}`);
+  sample(nulled);
+
+  if (!apply) {
+    console.log("\nDry run complete. Re-run with CLEANUP_APPLY=1 to write.");
+    await prisma.$disconnect();
+    return;
+  }
+
+  let updated = 0;
+  for (const r of overwrite) {
+    await prisma.event.update({ where: { id: r.id }, data: { locationName: r.fresh } });
+    updated++;
+  }
+  for (const r of nulled) {
+    await prisma.event.update({ where: { id: r.id }, data: { locationName: null } });
+    updated++;
+  }
+  console.log(`\nApplied: ${updated} events updated (${overwrite.length} overwritten, ${nulled.length} nulled).`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error("FAILED:", e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/kch3.test.ts
+++ b/src/adapters/html-scraper/kch3.test.ts
@@ -154,7 +154,7 @@ Short-ish trail with possible Bar Audibles
     expect(parseKCH3Body(body).location).toBe("1601 N 98th St, Kansas City, KS 66111");
   });
 
-  it("does not let \\s* span a newline from a prose 'location' word into the next line (Chili: Hash Cash)", () => {
+  it("does not let whitespace span a newline from a prose 'location' word into the next line (Chili: Hash Cash)", () => {
     const body =
       "Meetup: 1:00 p.m.\n" +
       "Pack away shortly thereafter – shuttling to the trail start location\n" +

--- a/src/adapters/html-scraper/kch3.test.ts
+++ b/src/adapters/html-scraper/kch3.test.ts
@@ -172,6 +172,14 @@ Short-ish trail with possible Bar Audibles
     expect(parseKCH3Body("Start @ Private Home:\n3013 New Lawrence Rd").location).toBeUndefined();
     expect(parseKCH3Body("Start Time 3 p.m.\nHares: Naked Rider").location).toBeUndefined();
   });
+
+  it.each([
+    ["Location KC Bier Company 310 W 79th St, Kansas City, MO 64114", "KC Bier Company 310 W 79th St, Kansas City, MO 64114", "no-colon Location"],
+    ["Location Strang Hall 7313 W 80th St, Overland Park, KS 66204", "Strang Hall 7313 W 80th St, Overland Park, KS 66204", "no-colon Location"],
+    ["Start Location: Hidden Valley Park, 4029 Bellaire Ave, KC, MO", "Hidden Valley Park, 4029 Bellaire Ave, KC, MO", "Start Location: prefix"],
+  ])("captures the venue from '%s' (%s)", (body, expected) => {
+    expect(parseKCH3Body(body).location).toBe(expected);
+  });
 });
 
 describe("stripLeadingParenLabel", () => {

--- a/src/adapters/html-scraper/kch3.test.ts
+++ b/src/adapters/html-scraper/kch3.test.ts
@@ -134,6 +134,44 @@ Short-ish trail with possible Bar Audibles
       "Helen's J.A.D. – 2002 Armour Rd, North Kansas City, MO 64116",
     );
   });
+
+  // #2110 follow-up: the location label must only match at the start of a line,
+  // with its colon, capturing same-line text — never the bare word in prose or
+  // the next line's content.
+  it("does not capture theme prose containing the word 'start' (Olympic Trials leak)", () => {
+    const body =
+      "Meetup: 10:00 a.m. Just outside The Dub KC 105 W 9th St, Kansas City, MO 64105\n" +
+      "Hare(s): Black to the Cooter and HoMo\n" +
+      "The first PN trail of 2026 and just in time for the start of the winter Olympics!!! Come dressed as your favorite Olympian";
+    expect(parseKCH3Body(body).location).toBeUndefined();
+  });
+
+  it("prefers a real WHERE: line over a prose 'start' later in the body (Drinksgiving)", () => {
+    const body =
+      "Meetup 2pm / Pack away 2:30pm\n" +
+      "WHERE: 1601 N 98th St, Kansas City, KS 66111\n" +
+      "ON-AFTER continues at Casa de EZ Odor, a hop skip from trail start – approximately 5pm.";
+    expect(parseKCH3Body(body).location).toBe("1601 N 98th St, Kansas City, KS 66111");
+  });
+
+  it("does not let \\s* span a newline from a prose 'location' word into the next line (Chili: Hash Cash)", () => {
+    const body =
+      "Meetup: 1:00 p.m.\n" +
+      "Pack away shortly thereafter – shuttling to the trail start location\n" +
+      "Hash Cash: $5\n" +
+      "Location: 7103 Harvard Ave, Raytown, MO 64133";
+    expect(parseKCH3Body(body).location).toBe("7103 Harvard Ave, Raytown, MO 64133");
+  });
+
+  it("ignores a 'Start' line whose colon belongs to a time, not a label (Spock 5:00pm)", () => {
+    const body = "Start at Tuckers, hares away 5:00pm.\nHare: Spock";
+    expect(parseKCH3Body(body).location).toBeUndefined();
+  });
+
+  it("ignores 'Start @ Private Home:' / 'Start Time …' non-label lines", () => {
+    expect(parseKCH3Body("Start @ Private Home:\n3013 New Lawrence Rd").location).toBeUndefined();
+    expect(parseKCH3Body("Start Time 3 p.m.\nHares: Naked Rider").location).toBeUndefined();
+  });
 });
 
 describe("stripLeadingParenLabel", () => {

--- a/src/adapters/html-scraper/kch3.ts
+++ b/src/adapters/html-scraper/kch3.ts
@@ -120,11 +120,23 @@ export function parseKCH3Body(text: string): {
   const hareMatch = /Hares?\s*(?:\([^)]*\))?\s*:?\s*(.+?)(?=\n|$)/i.exec(text);
   const hares = hareMatch ? hareMatch[1].trim() : undefined;
 
-  // Location: "Location: Macken Park 1002 Clark Ferguson Dr..." or address at "Start:"
+  // Location: "Location: Macken Park…", "Location KC Bier Company…" (no colon),
+  // "Start Location: Hidden Valley Park…", or address at "Start:" / "Where:".
+  // Match each label only at the START of a line and capture same-line text.
+  // The old unanchored `:?\s*` form matched the bare word in prose (e.g. "just
+  // in time for the start of the winter Olympics") AND let `\s*` span the
+  // newline into the next line's cost/time text (#2110 follow-up).
+  //   - The Location label keeps an OPTIONAL colon (the site often writes
+  //     "Location <venue>" / "Location <venue>" with no colon) and accepts an
+  //     optional "Start " prefix; stripLeadingParenLabel still handles the
+  //     "Location (also prelube): venue" shape (#2019).
+  //   - Bare "Start" and "Where" REQUIRE the colon, which is what rejects
+  //     "Start Time 3 p.m." and "Start @ Private Home:" (address on the next
+  //     line) without swallowing them as a venue.
   const locMatch =
-    /Location:?\s*(.+?)(?=\n|$)/i.exec(text) ||
-    /Start:?\s*(.+?)(?=\n|$)/i.exec(text) ||
-    /Where:?\s*(.+?)(?=\n|$)/i.exec(text);
+    /^[ \t]*(?:Start[ \t]+)?Location[ \t]*:?[ \t]*(.+)$/im.exec(text) ||
+    /^[ \t]*Where[ \t]*:[ \t]*(.+)$/im.exec(text) ||
+    /^[ \t]*Start[ \t]*:[ \t]*(.+)$/im.exec(text);
   // Strip a parenthetical label that precedes the colon — e.g.
   // "Location (also prelube and on-after): Helen's J.A.D. ..." captures
   // "(also prelube and on-after): Helen's …"; drop the leading label so it

--- a/src/adapters/html-scraper/kch3.ts
+++ b/src/adapters/html-scraper/kch3.ts
@@ -133,10 +133,14 @@ export function parseKCH3Body(text: string): {
   //   - Bare "Start" and "Where" REQUIRE the colon, which is what rejects
   //     "Start Time 3 p.m." and "Start @ Private Home:" (address on the next
   //     line) without swallowing them as a venue.
+  // Capture starts at the first non-space (`\S`) so the leading `[ \t]*` and the
+  // value never overlap on whitespace, and the optional colon is wrapped as
+  // `(?::[ \t]*)?` rather than `:?[ \t]*` so two `[ \t]*` are never adjacent —
+  // both keep these clear of Sonar S5852 (ReDoS backtracking).
   const locMatch =
-    /^[ \t]*(?:Start[ \t]+)?Location[ \t]*:?[ \t]*(.+)$/im.exec(text) ||
-    /^[ \t]*Where[ \t]*:[ \t]*(.+)$/im.exec(text) ||
-    /^[ \t]*Start[ \t]*:[ \t]*(.+)$/im.exec(text);
+    /^[ \t]*(?:Start[ \t]+)?Location[ \t]*(?::[ \t]*)?(\S.*)$/im.exec(text) ||
+    /^[ \t]*Where:[ \t]*(\S.*)$/im.exec(text) ||
+    /^[ \t]*Start:[ \t]*(\S.*)$/im.exec(text);
   // Strip a parenthetical label that precedes the colon — e.g.
   // "Location (also prelube and on-after): Helen's J.A.D. ..." captures
   // "(also prelube and on-after): Helen's …"; drop the leading label so it

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -1148,6 +1148,11 @@ describe("cleanLocationName", () => {
       ["Hare wanted", "hares-needed CTA"],
       ["???", "question-mark placeholder"],
       ["TBD", "placeholder"],
+      ["Hash Cash: $5", "#2110 cost label captured as location"],
+      ["Cost: $10", "#2110 cost label"],
+      ["Time: 1400", "#2110 time label"],
+      ["Meetup: 2 p.m.", "#2110 meetup label"],
+      ["Pack away: 2:30 p.m.", "#2110 pack-away label"],
       ["", "empty string"],
       ["   ", "whitespace only"],
     ])("'%s' → null (%s)", (input) => {

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -1013,7 +1013,11 @@ export function stripClickHereForMap(s: string): string {
 // Hares Needed", #1731 "Hares: …" captured when Start: was blank). "Start:"
 // is intentionally absent: it IS a location label, so its prefix is stripped
 // and the address kept (see cleanLocationName step 2).
-const NON_LOCATION_LABEL_RE = /^(?:hares?|hare\(s\)|on[\s-]?on|map)\s*:/i;
+// Whole-value labels that are never a venue. Extended (#2110 follow-up) to drop
+// cost/time/meetup/pack-out label lines that a loose source parse can capture
+// into a location field — e.g. "Hash Cash: $5", "Time: 1400", "Meetup: 2 p.m.".
+const NON_LOCATION_LABEL_RE =
+  /^(?:hares?|hare\(s\)|on[\s-]?on|map|hash\s*cash|cost|meet\s*up|pack\s*(?:away|up|out)|time)\s*:/i;
 const START_LABEL_RE = /^start\s*:\s*/i;
 
 // Segment-separator characters. Includes "/" because Norfolk venue blocks use

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -1013,11 +1013,13 @@ export function stripClickHereForMap(s: string): string {
 // Hares Needed", #1731 "Hares: …" captured when Start: was blank). "Start:"
 // is intentionally absent: it IS a location label, so its prefix is stripped
 // and the address kept (see cleanLocationName step 2).
-// Whole-value labels that are never a venue. Extended (#2110 follow-up) to drop
-// cost/time/meetup/pack-out label lines that a loose source parse can capture
-// into a location field — e.g. "Hash Cash: $5", "Time: 1400", "Meetup: 2 p.m.".
-const NON_LOCATION_LABEL_RE =
-  /^(?:hares?|hare\(s\)|on[\s-]?on|map|hash\s*cash|cost|meet\s*up|pack\s*(?:away|up|out)|time)\s*:/i;
+// Whole-value labels that are never a venue. Split across two regexes (each
+// under Sonar S5843's complexity budget) and OR'd at the call site: the
+// original hare/on-on/map set, plus the cost/time/meetup/pack-out set added in
+// the #2110 follow-up ("Hash Cash: $5", "Time: 1400", "Meetup: 2 p.m.").
+const NON_LOCATION_LABEL_RE = /^(?:hares?|hare\(s\)|on[\s-]?on|map)\s*:/i;
+const NON_LOCATION_META_LABEL_RE =
+  /^(?:hash\s*cash|cost|meet\s*up|pack\s*(?:away|up|out)|time)\s*:/i;
 const START_LABEL_RE = /^start\s*:\s*/i;
 
 // Segment-separator characters. Includes "/" because Norfolk venue blocks use
@@ -1210,7 +1212,7 @@ export function cleanLocationName(raw: string | null | undefined): string | null
   if (!s) return null;
 
   // 1. Reject whole-value non-location labeled fields ("Hares: …", "Map: …").
-  if (NON_LOCATION_LABEL_RE.test(s)) return null;
+  if (NON_LOCATION_LABEL_RE.test(s) || NON_LOCATION_META_LABEL_RE.test(s)) return null;
 
   // 2. "Start:" is a location label — drop the prefix, keep the address.
   s = s.replace(START_LABEL_RE, "").trim();


### PR DESCRIPTION
**Recovery PR.** #2132 was merged into its stacked base `claude/keen-wilbur-bd5289` instead of `main` (the base was never retargeted after #2128 merged), so its three commits never reached `main`. This re-lands them on `main` via cherry-pick.

Without this, the prod **data** cleanup (11 KCH3/PNH3 events, already applied) is undone on the next scrape, because the **parser** fix isn't deployed.

## Commits (identical to the merged #2132)
- `fix(kch3): stop location parser leaking theme/cost/time text into locationName` — anchored Location/Start/Where regexes.
- `fix(kch3): de-ReDoS location regexes + harden cleanup (PR #2132 review)` — `\S.*` capture + `(?::[ \t]*)?`; cleanup aborts on empty fetch; bounded bare-time whitespace.
- `refactor: clear SonarCloud code smells on PR #2132` — split `NON_LOCATION_LABEL_RE` (S5843), extracted helpers from `main()` (S3776), reworded a test title (S7780).

Cherry-picked cleanly onto current `main` (no conflicts). `npx tsc --noEmit` clean, lint clean, **384 tests pass** (kch3 + utils + wordpress-api). All review feedback from #2132 (gemini + SonarCloud + Codex) was already addressed in these commits.

No `Closes #` — the underlying issues (#2110 etc.) closed via #2128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)