### PR TITLE
fix(gcal): PH4 all-day events + PHH "Pau Hana Hui" routing — wide backfills (#2088, #2093)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2589,6 +2589,11 @@ export const SOURCES = [
       config: {
         calendarId: "e42428cbbecf52a48618c36aa1654ec0186aa307eb6d608641ef3a9e5c243128@group.calendar.google.com",
         defaultKennelTag: "ph4",
+        // PH4 publishes ~half its runs as all-day events (55 of 101 VEVENTs:
+        // "PH4 #1291 - Bottom Dollar", "PH4 #1305 & OH3 Full Moon Combo", …).
+        // The GCal adapter drops all-day events by default, so without this the
+        // timed half is the only thing fetched — the root cause of #2088's gap.
+        includeAllDayEvents: true,
       },
       kennelCodes: ["ph4"],
     },
@@ -3163,9 +3168,14 @@ export const SOURCES = [
       config: {
         kennelPatterns: [
           // PHH must come before H5 (kennelPatterns resolve first-match-wins).
-          // Match only the kennel tag PHH — not "Pearl Harbor" as a location,
-          // since an AH3 run at Pearl Harbor would otherwise be misrouted.
-          [String.raw`\bPHH\b`, "phh-hi"],
+          // PHH (Pau Hana Hui) is the after-work social arm of Aloha H3. Its
+          // events carry EITHER the literal "PHH" token OR the full "Pau Hana
+          // Hui" name (the historical 2011→ archive titles are bare "Pau Hana
+          // Hui" with no PHH token — #2093). Match both; deliberately NOT bare
+          // "Pau Hana", which legit AH3 socials use generically ("Cinco de Mayo
+          // Pau Hana", "Karaoke … Pau Hana"). Also not "Pearl Harbor" as a
+          // location — an AH3 run at Pearl Harbor must not misroute here.
+          [String.raw`\bPHH\b|Pau Hana Hui`, "phh-hi"],
           ["\\bH5\\b|Honolulu H[45]", "h5-hi"],
         ],
         defaultKennelTag: "ah3-hi",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3175,7 +3175,11 @@ export const SOURCES = [
           // "Pau Hana", which legit AH3 socials use generically ("Cinco de Mayo
           // Pau Hana", "Karaoke … Pau Hana"). Also not "Pearl Harbor" as a
           // location — an AH3 run at Pearl Harbor must not misroute here.
-          [String.raw`\bPHH\b|Pau Hana Hui`, "phh-hi"],
+          // Trailing \b only on the "Pau Hana Hui" arm: it blocks suffix
+          // partial-matches (e.g. "Pau Hana Huipil") per review, but a LEADING
+          // \b is omitted on purpose — a real PHH title has a missing-space
+          // typo ("…ChristmasPau Hana Hui") that a leading boundary would drop.
+          [String.raw`\bPHH\b|Pau Hana Hui\b`, "phh-hi"],
           ["\\bH5\\b|Honolulu H[45]", "h5-hi"],
         ],
         defaultKennelTag: "ah3-hi",

--- a/scripts/backfill-gcal-history.ts
+++ b/scripts/backfill-gcal-history.ts
@@ -23,10 +23,30 @@
  *
  * Targets:
  *   - "Pedal Files Bash Google Calendar"  (2018-03 → present, ~56→130 events) — default
+ *   - "Portland Humpin' Hash Calendar"    (2024-10 → 2026-09, ~101 events, single-kennel ph4, #2088) — default
+ *   - "Aloha H3 Google Calendar"          (2011-12 → present, ~2,187 events, MULTI-kennel, #2093)    — default
  *   - "Pittsburgh Hash Calendar"          (2008-12 → present, ~900 events)    — GATED
  * PGH is gated OUT of the default run: pass it explicitly via --source, and only
  * AFTER WS1's PGH run-number parser fix is on main (#2009 caveat) — otherwise the
- * `Hash NNNN:` variants re-import malformed.
+ * `Hash NNNN:` variants re-import malformed. PH4 + Aloha are NOT gated: WS1's PH4
+ * run-number (#2089) and PHH "&"-truncation (#2091) fixes are already on main
+ * (PR #2126), so the historical rows parse correctly the first time.
+ *
+ * MULTI-KENNEL CAVEAT (Aloha H3 Google Calendar): this one source feeds THREE
+ * kennels — ah3-hi / h5-hi / phh-hi — via `config.kennelPatterns`. A wide pass
+ * re-fetches + re-routes ALL ~2,187 events and backfills all three kennels'
+ * history (you cannot fetch only PHH from a GCal); that is expected and benign.
+ * Per the PR #2055 caveat, a deep-history multi-kennel pass CAN cancel sibling
+ * events when the merge RE-ROUTES an event to a different kennel (the old slot
+ * orphans) or when GCal's far-past RRULE expansion is not reproducible run-to-
+ * run — the `cancelled > 0` warning below is the fail-loud guard. It is NOT
+ * automatically a regression: for #2093 the phh-hi pattern was widened to match
+ * "Pau Hana Hui", so a corrective re-scrape intentionally cancels the ~467 stale
+ * ah3-hi rows those events used to mis-route to. INVESTIGATE every cancellation
+ * before trusting OR restoring: confirm each cancelled row is a genuine re-route
+ * (a CONFIRMED counterpart now exists under the correct kennel) rather than a
+ * real orphan. Restore only true orphans (durable: deep-history rows predate the
+ * recurring now-365d reconcile floor, so the daily cron won't re-cancel them).
  *
  * Usage:
  *   eval "$(fnm env)" && fnm use 20
@@ -63,6 +83,8 @@ const BACKFILL_DAYS = 9999;
 // re-import the malformed `Hash NNNN:` variants the #2009 caveat warns about.
 const TARGETS: { name: string; gated: boolean }[] = [
   { name: "Pedal Files Bash Google Calendar", gated: false },
+  { name: "Portland Humpin' Hash Calendar", gated: false },
+  { name: "Aloha H3 Google Calendar", gated: false },
   { name: "Pittsburgh Hash Calendar", gated: true },
 ];
 


### PR DESCRIPTION
## Summary

Quick-win bundle for two `audit:chrome-kennel` coverage gaps. Both were filed as "widen the GCal window" but turned out to need a **source-config fix** — the wide-window one-shot (`scripts/backfill-gcal-history.ts`, `days=9999`) then pulls the history through the normal merge pipeline.

### #2088 — PH4 (Portland Humpin', single-kennel)
- **Root cause:** PH4 publishes **55 of 101** runs as all-day events ("PH4 #1291 - Bottom Dollar", "PH4 #1305 & OH3 Full Moon Combo", …). The GCal adapter drops all-day events by default, so only the timed half was ever fetched.
- **Fix:** `includeAllDayEvents: true` on the PH4 source config (the documented opt-in knob), + one-shot wide re-scrape.
- **Result:** **100 CONFIRMED** events, `2024-10-09 → 2026-09-02` (was 63, `2025-03 → 2026-08`). `cancelled=0`.

### #2093 — PHH (Pau Hana Hui, on the SHARED Aloha H3 calendar)
- **Root cause:** the `phh-hi` kennelPattern was `\bPHH\b`, matching only the literal "PHH" token. The historical 2011→ archive titles are bare **"Pau Hana Hui"** (no PHH token), so **467 events mis-routed to the default kennel `ah3-hi`**. The issue's "the filter is correct, no AH3 bleed-through" premise was wrong — the bleed was hiding in `ah3-hi`.
- **Fix:** widen the pattern to `\bPHH\b|Pau Hana Hui` — deliberately **not** bare "Pau Hana", which legit AH3 socials use generically ("Cinco de Mayo Pau Hana", "Karaoke … Pau Hana"). `kennelPatterns` ordering (PHH before H5) and the "Pearl Harbor" location guard are preserved.
- **Corrective re-scrape:** 470 `phh-hi` created, **469 stale `ah3-hi` cancelled** — every cancellation verified to have a CONFIRMED `phh-hi` counterpart on the same date (**0 true orphans**); 1 leftover duplicate cancelled to match.
- **Result:** `phh-hi` **526 CONFIRMED**, full `2011→2026` history (was 56). Siblings `ah3-hi`/`h5-hi` intact (`h5-hi` unchanged).

## Prod data
Prod `Source.config` was updated **surgically** (not via full `db seed`, to avoid clobbering parallel sessions per the concurrent-seed hazard) to match these seed values — so prod is already correct and a future `prisma db seed` is idempotent. The historical events were created by the one-shot wide passes; they fall outside the recurring ±365-day reconcile window, so the daily cron won't touch them.

## Verification
- Live source analysis (basic.ics): PH4 = 48 timed + 55 all-day; Aloha PHH = 452 timed + 16 all-day, with 467 bare-"Pau Hana Hui" titles confirmed mis-routed.
- Post-backfill prod queries: PH4 100 events / `cancelled=0`; `phh-hi` 526 events spanning 2011→2026; `ah3-hi` 0 residual "Pau Hana Hui"; orphan check 475/475 cancelled rows have a CONFIRMED `phh-hi` counterpart.
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (8929 passed).

## Notes
- No adapter edits (WS1 owns `google-calendar/adapter.ts`); WS1's #2089/#2091 parser fixes (PR #2126) are on main, so historical rows parse correctly.
- `scripts/backfill-gcal-history.ts`: PH4 + Aloha added as non-gated targets; doc updated to explain that `cancelled>0` is **expected** on a re-routing pass and to investigate every cancellation before restoring.

Closes #2088
Closes #2093

🤖 Generated with [Claude Code](https://claude.com/claude-code)