### PR TITLE
fix(gcal): drop Philly Green Dress agenda segments so the run surfaces (#2099 follow-up)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -336,7 +336,29 @@ export const SOURCES = [
         // the Philly hareline. Anchored to start-of-title so a hypothetical
         // joint trail like "Philly H3 & BFM co-host" is still kept here.
         // Closes #582.
-        skipPatterns: ["^Ben Franklin Mob H3\\b", "^BFM\\b"],
+        //
+        // #2099 follow-up: the Green Dress weekend is posted as the all-day
+        // "PHILLY GREEN DRESS RUN" umbrella event PLUS a string of timed agenda
+        // segments on the same date ("Event Check In", "Chalk Talk", "Trail",
+        // "Circle", "Dinner", "Dancing with DJ …", "Ruba After Hours"). Each of
+        // those segment titles occurs EXACTLY ONCE in the whole calendar (verified
+        // 2024–2027), so anchored whole-title skips drop the agenda noise without
+        // touching the recurring "Philly Hash" run (22×). With the segments gone,
+        // the all-day umbrella is the sole raw for that (kennel, date) so its real
+        // title + Ruba location surface instead of a null-title "Event Check In"
+        // collapse. Exact anchors (`^…$`) stop generic words like "Trail"/"Circle"
+        // from shadowing real run titles elsewhere.
+        skipPatterns: [
+          "^Ben Franklin Mob H3\\b",
+          "^BFM\\b",
+          "^Event Check In$",
+          "^Chalk Talk$",
+          "^Trail$",
+          "^Circle$",
+          "^Dinner$",
+          "^Dancing with DJ",
+          "^Ruba After Hours$",
+        ],
         // #2099: the kennel posts marquee weekend runs (Green Dress Run, etc.)
         // as all-day VEVENTs (DTSTART;VALUE=DATE). The adapter skips all-day
         // events by default; opt in so their SUMMARY/LOCATION/DESCRIPTION are

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -349,8 +349,8 @@ export const SOURCES = [
         // collapse. Exact anchors (`^…$`) stop generic words like "Trail"/"Circle"
         // from shadowing real run titles elsewhere.
         skipPatterns: [
-          "^Ben Franklin Mob H3\\b",
-          "^BFM\\b",
+          String.raw`^Ben Franklin Mob H3\b`,
+          String.raw`^BFM\b`,
           "^Event Check In$",
           "^Chalk Talk$",
           "^Trail$",

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -356,7 +356,7 @@ export const SOURCES = [
           "^Trail$",
           "^Circle$",
           "^Dinner$",
-          "^Dancing with DJ",
+          "^Dancing with DJ Trishylicious$",
           "^Ruba After Hours$",
         ],
         // #2099: the kennel posts marquee weekend runs (Green Dress Run, etc.)

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -2260,6 +2260,42 @@ describe("buildRawEventFromGCalItem — all-day events", () => {
     );
     expect(result).toBeNull();
   });
+
+  // #2099 follow-up: Green Dress weekend agenda segments are dropped so the
+  // all-day umbrella run is the sole event for that (kennel, date), while the
+  // recurring "Philly Hash" run is untouched.
+  it("skips Green Dress agenda segments but keeps the run + regular Philly Hash (#2099)", () => {
+    const phillySource = SOURCES.find((s) => s.name === "Philly H3 Google Calendar");
+    if (!phillySource?.config) throw new Error("Philly H3 Google Calendar seed config missing");
+    const config = phillySource.config as { skipPatterns?: string[] };
+    const compiledSkipPatterns = compilePatterns(config.skipPatterns ?? [], "i");
+
+    for (const seg of ["Event Check In", "Chalk Talk", "Trail", "Circle", "Dinner", "Dancing with DJ Trishylicious", "Ruba After Hours"]) {
+      const r = buildRawEventFromGCalItem(
+        { summary: seg, start: { dateTime: "2026-03-14T14:30:00-04:00" }, status: "confirmed" },
+        phillySource.config as Record<string, unknown>,
+        { compiledSkipPatterns },
+      );
+      expect(r, `agenda segment "${seg}" should be skipped`).toBeNull();
+    }
+
+    // The all-day umbrella run survives.
+    const gd = buildRawEventFromGCalItem(
+      { summary: "PHILLY GREEN DRESS RUN", start: { date: "2026-03-14" }, end: { date: "2026-03-15" }, location: "Ruba, 416 Green St, Philadelphia, PA 19123, USA", status: "confirmed" },
+      phillySource.config as Record<string, unknown>,
+      { compiledSkipPatterns },
+    );
+    expect(gd?.title).toBe("PHILLY GREEN DRESS RUN");
+    expect(gd?.location).toBe("Ruba, 416 Green St, Philadelphia, PA 19123, USA");
+
+    // The recurring weekly run is NOT shadowed by the anchored skips.
+    const regular = buildRawEventFromGCalItem(
+      { summary: "Philly Hash", start: { dateTime: "2026-04-25T15:00:00-04:00" }, status: "confirmed" },
+      phillySource.config as Record<string, unknown>,
+      { compiledSkipPatterns },
+    );
+    expect(regular?.kennelTags[0]).toBe("philly-h3");
+  });
 });
 
 // ── buildRawEventFromGCalItem — timezone-aware extraction (#964 / C2H3) ──


### PR DESCRIPTION
Follow-up to [#2126](https://github.com/johnrclem/hashtracks-web/pull/2126) / #2099.

## Problem

#2126 enabled `includeAllDayEvents` for the Philly H3 Google Calendar, so the all-day **"PHILLY GREEN DRESS RUN"** (2026-03-14, Ruba 416 Green St) is now ingested as a RawEvent. But the kennel posts the Green Dress weekend as the all-day umbrella event **plus ~7 timed agenda segments on the same date** — "Event Check In" (12:00), "Chalk Talk" (14:00), "Trail" (14:30), "Circle" (18:00), "Dinner" (19:00), "Dancing with DJ Trishylicious" (20:00), "Ruba After Hours" (22:00). The merge collapsed the all-day umbrella into the generic "Event Check In" canonical and kept a **stale null title + "Yards Brewing" location**, so the user-visible event was unchanged.

## Fix (source-config, in scope)

Add anchored whole-title `skipPatterns` for the agenda segments to the Philly config. Verified against the live Google Calendar API that **each segment title occurs exactly once across 2024–2027** (all on Green Dress day), while **"Philly Hash"** is the recurring weekly run (22×). So the skips drop the agenda noise without shadowing any real run. Exact `^…$` anchors keep generic words like "Trail"/"Circle" from matching real titles elsewhere.

With the segments gone, the all-day umbrella is the sole raw for that `(kennel, date)`, so its real title + Ruba location surface.

## Verification

- **Live adapter run** (post-change config): 2026-03-14 now yields **exactly 1 event** — `"PHILLY GREEN DRESS RUN"`, location `Ruba, 416 Green St, Philadelphia, PA 19123, USA`; all 32 regular `"Philly Hash"` runs untouched.
- New unit test asserts each agenda segment is skipped, the Green Dress umbrella survives with the right title/location, and "Philly Hash" still routes to philly-h3.
- `npx tsc --noEmit` clean, `npm run lint` 0 errors, `npm test` 8966 passed.

## Post-merge (config-only — Vercel does not seed)

1. `npx prisma db seed` from `origin/main` to push the new config.
2. Re-scrape Philly (`scrapeSource("cmljzsq0w001rvam99sw7zrx4", {})`).
3. The stale canonical event `cmlk1a1k` (null title / "Yards Brewing") then self-heals to "PHILLY GREEN DRESS RUN"; the old agenda-segment events get reconciled (CANCELLED). I'll handle this after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)