### PR TITLE
Quick-win bundle: kennel stats/logo, region ISR, providers, FilterBar a11y

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ logbook + kennel directory.
 - SENTRY_AUTH_TOKEN=     # Sentry auth token (build-time only, source map upload to Vercel)
 - SENTRY_ORG=            # Sentry organization slug (build-time)
 - SENTRY_PROJECT=        # Sentry project slug (build-time)
+- BLOB_READ_WRITE_TOKEN= # Vercel Blob store token — server-only, powers the kennel logo upload route (`/api/admin/kennels/logo/upload`, #1414). Without it the admin logo *URL* field still works; only the file-upload button is inert.
 - INDEXNOW_KEY=           # IndexNow API key (production only) — also served at /<key>.txt for ownership verification
 - BING_SITE_VERIFICATION= # Bing Webmaster Tools msvalidate.01 token (optional, fallback if not DNS-verified)
 - GOOGLE_SITE_VERIFICATION= # Google Search Console verification token (optional, fallback if not DNS-verified)

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,15 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["node-ical"],
+  images: {
+    // Kennel logos (#1301) come from open-ended third-party hosts — WordPress
+    // origins, assets.gohash.app, gravatar.com, Vercel Blob, etc. An enumerated
+    // allowlist would silently break every newly-added logo, so we allow any
+    // https origin through the optimizer (WebP/resize/lazy). Non-resolvable or
+    // http-only assets are caught by KennelLogo's onError → initials fallback
+    // (#1300). SVGs stay disabled (Next.js default) to avoid the XSS surface.
+    remotePatterns: [{ protocol: "https", hostname: "**" }],
+  },
   async redirects() {
     return [
       // Disambiguate /kennels/ah3 slug collision between Aloha H3 (HI) and Amsterdam H3 (NL)

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
+import { LOGO_REMOTE_PATTERNS } from "./src/lib/image-remote-patterns";
 
 const securityHeaders = [
   {
@@ -27,13 +28,11 @@ const securityHeaders = [
 const nextConfig: NextConfig = {
   serverExternalPackages: ["node-ical"],
   images: {
-    // Kennel logos (#1301) come from open-ended third-party hosts — WordPress
-    // origins, assets.gohash.app, gravatar.com, Vercel Blob, etc. An enumerated
-    // allowlist would silently break every newly-added logo, so we allow any
-    // https origin through the optimizer (WebP/resize/lazy). Non-resolvable or
-    // http-only assets are caught by KennelLogo's onError → initials fallback
-    // (#1300). SVGs stay disabled (Next.js default) to avoid the XSS surface.
-    remotePatterns: [{ protocol: "https", hostname: "**" }],
+    // FIRST-PARTY ONLY. The public `/_next/image` optimizer fetches whatever
+    // URL it's handed, so a wildcard host would expose an arbitrary-HTTPS
+    // fetch/resize proxy (SSRF + amplification). Third-party kennel logos
+    // render `unoptimized` in KennelLogo instead. See image-remote-patterns.ts.
+    remotePatterns: LOGO_REMOTE_PATTERNS,
   },
   async redirects() {
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@prisma/client": "^7.3.0",
         "@sentry/nextjs": "^10.47.0",
         "@upstash/qstash": "^2.9.0",
+        "@vercel/blob": "^2.4.0",
         "@vercel/speed-insights": "^1.3.1",
         "@vis.gl/react-google-maps": "^1.7.1",
         "cheerio": "^1.2.0",
@@ -8044,6 +8045,31 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@vercel/speed-insights": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.3.1.tgz",
@@ -8812,6 +8838,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -12581,6 +12625,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -12827,7 +12894,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
@@ -17424,6 +17490,18 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@prisma/client": "^7.3.0",
     "@sentry/nextjs": "^10.47.0",
     "@upstash/qstash": "^2.9.0",
+    "@vercel/blob": "^2.4.0",
     "@vercel/speed-insights": "^1.3.1",
     "@vis.gl/react-google-maps": "^1.7.1",
     "cheerio": "^1.2.0",

--- a/src/app/admin/kennels/actions.test.ts
+++ b/src/app/admin/kennels/actions.test.ts
@@ -462,7 +462,6 @@ describe("region ISR revalidation (#1461)", () => {
     fd.set("fullName", "Test Hash");
     fd.set("region", "NYC");
     fd.set("regionId", "region_1");
-
     await createKennel(fd);
     expect(mockRevalidatePath).toHaveBeenCalledWith(regionPath("NYC"));
   });

--- a/src/app/admin/kennels/actions.test.ts
+++ b/src/app/admin/kennels/actions.test.ts
@@ -28,10 +28,13 @@ vi.mock("next/cache", () => ({
 
 import { getAdminUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+import { regionNameToSlug, regionSlug } from "@/lib/region";
 import {
   createKennel,
   updateKennel,
   deleteKennel,
+  toggleKennelVisibility,
   assignMismanRole,
   revokeMismanRole,
   deduplicateEventKennels,
@@ -42,6 +45,9 @@ const mockKennelFindFirst = vi.mocked(prisma.kennel.findFirst);
 const mockKennelFindUnique = vi.mocked(prisma.kennel.findUnique);
 const mockKennelFindMany = vi.mocked(prisma.kennel.findMany);
 const mockKennelCreate = vi.mocked(prisma.kennel.create);
+const mockRevalidatePath = vi.mocked(revalidatePath);
+const regionPath = (name: string) =>
+  `/kennels/region/${regionNameToSlug(name) ?? regionSlug(name)}`;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -441,5 +447,71 @@ describe("revokeMismanRole", () => {
       where: { userId_kennelId: { userId: "u1", kennelId: "k1" } },
       data: { role: "MEMBER" },
     });
+  });
+});
+
+describe("region ISR revalidation (#1461)", () => {
+  it("createKennel busts the new region landing page", async () => {
+    mockKennelFindUnique
+      .mockResolvedValueOnce(null)  // kennelCode check
+      .mockResolvedValueOnce(null); // slug check
+    mockKennelFindFirst.mockResolvedValueOnce(null);
+    mockKennelCreate.mockResolvedValueOnce({} as never);
+    const fd = new FormData();
+    fd.set("shortName", "TestH3");
+    fd.set("fullName", "Test Hash");
+    fd.set("region", "NYC");
+    fd.set("regionId", "region_1");
+
+    await createKennel(fd);
+    expect(mockRevalidatePath).toHaveBeenCalledWith(regionPath("NYC"));
+  });
+
+  it("updateKennel busts BOTH the old and new region pages when a kennel moves", async () => {
+    vi.mocked(prisma.region.findUnique).mockResolvedValueOnce({ id: "region_1", name: "NYC" } as never);
+    mockKennelFindFirst
+      .mockResolvedValueOnce(null)  // slug check
+      .mockResolvedValueOnce(null); // shortName+region check
+    // current kennel lives in a different region (the move source)
+    mockKennelFindUnique.mockResolvedValueOnce({ shortName: "TestH3", region: "Boston, MA" } as never);
+    const fd = new FormData();
+    fd.set("shortName", "TestH3");
+    fd.set("fullName", "Test Hash");
+    fd.set("region", "NYC");
+    fd.set("regionId", "region_1");
+
+    const result = await updateKennel("k1", fd);
+    expect(result).toEqual({ success: true });
+    expect(mockRevalidatePath).toHaveBeenCalledWith(regionPath("NYC"));         // new region
+    expect(mockRevalidatePath).toHaveBeenCalledWith(regionPath("Boston, MA"));  // old region
+  });
+
+  it("deleteKennel busts the deleted kennel's region page", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce({
+      id: "k1",
+      kennelCode: "testh3",
+      region: "Chicago, IL",
+      _count: { events: 0, members: 0 },
+    } as never);
+    vi.mocked(prisma.eventKennel.count).mockResolvedValueOnce(0);
+    vi.mocked(prisma.kennelAttendance.count).mockResolvedValueOnce(0);
+
+    const result = await deleteKennel("k1");
+    expect(result).toEqual({ success: true });
+    expect(mockRevalidatePath).toHaveBeenCalledWith(regionPath("Chicago, IL"));
+  });
+
+  it("toggleKennelVisibility busts the kennel's region page", async () => {
+    mockKennelFindUnique.mockResolvedValueOnce({
+      isHidden: false,
+      shortName: "TestH3",
+      slug: "testh3",
+      region: "Boston, MA",
+    } as never);
+    vi.mocked(prisma.kennel.update).mockResolvedValueOnce({} as never);
+
+    const result = await toggleKennelVisibility("k1");
+    expect(result).toEqual({ success: true, isHidden: true });
+    expect(mockRevalidatePath).toHaveBeenCalledWith(regionPath("Boston, MA"));
   });
 });

--- a/src/app/admin/kennels/actions.ts
+++ b/src/app/admin/kennels/actions.ts
@@ -10,6 +10,7 @@ import { toSlug, toKennelCode } from "@/lib/kennel-utils";
 import { generateAliases } from "@/lib/auto-aliases";
 import { ensureKennelLabel, deleteKennelLabel } from "@/pipeline/kennel-label-sync";
 import { regionNameToSlug, regionSlug } from "@/lib/region";
+import { checkLogoUrl } from "@/lib/logo-url";
 
 /**
  * Bust the ISR-cached region landing page (`/kennels/region/[slug]`, which sets
@@ -83,20 +84,18 @@ function extractProfileFields(formData: FormData) {
  * must be a site-relative `/path` or a full `https://` URL — `http://` and other
  * schemes are rejected so the public profile (served over https) never shows a
  * mixed-content/broken logo. Returns an error message, or null when valid.
+ * Shares the underlying rule with the admin form via `checkLogoUrl`.
  */
 function validateLogoUrl(value: unknown): string | null {
-  if (typeof value !== "string" || value.length === 0) return null;
-  if (value.startsWith("/")) return null;
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return "Logo URL must be a full https:// URL or a site-relative /path";
+  if (typeof value !== "string") return null;
+  switch (checkLogoUrl(value)) {
+    case "ok":
+      return null;
+    case "unparseable":
+      return "Logo URL must be a full https:// URL or a site-relative /path";
+    default:
+      return "Logo URL must use https:// (http is blocked to avoid mixed-content warnings)";
   }
-  if (parsed.protocol !== "https:") {
-    return "Logo URL must use https:// (http is blocked to avoid mixed-content warnings)";
-  }
-  return null;
 }
 
 /** Resolve region name from regionId, falling back to the raw form value. */

--- a/src/app/admin/kennels/actions.ts
+++ b/src/app/admin/kennels/actions.ts
@@ -9,6 +9,18 @@ import { fuzzyMatch } from "@/lib/fuzzy";
 import { toSlug, toKennelCode } from "@/lib/kennel-utils";
 import { generateAliases } from "@/lib/auto-aliases";
 import { ensureKennelLabel, deleteKennelLabel } from "@/pipeline/kennel-label-sync";
+import { regionNameToSlug, regionSlug } from "@/lib/region";
+
+/**
+ * Bust the ISR-cached region landing page (`/kennels/region/[slug]`, which sets
+ * `revalidate = 3600`) for a kennel's region. Without this, creating, editing,
+ * hiding, deleting, or moving a kennel between regions left both region pages
+ * stale for up to an hour (#1461). No-op for a null/unknown region name.
+ */
+function revalidateRegion(name?: string | null) {
+  if (!name) return;
+  revalidatePath(`/kennels/region/${regionNameToSlug(name) ?? regionSlug(name)}`);
+}
 
 function extractProfileFields(formData: FormData) {
   const result: Record<string, string | number | boolean | null> = {};
@@ -64,6 +76,27 @@ function extractProfileFields(formData: FormData) {
   result.isHidden = formData.get("isHidden") === "true";
 
   return result;
+}
+
+/**
+ * Validate a kennel `logoUrl` (#1414). Empty is fine (cleared). Otherwise it
+ * must be a site-relative `/path` or a full `https://` URL — `http://` and other
+ * schemes are rejected so the public profile (served over https) never shows a
+ * mixed-content/broken logo. Returns an error message, or null when valid.
+ */
+function validateLogoUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  if (value.startsWith("/")) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return "Logo URL must be a full https:// URL or a site-relative /path";
+  }
+  if (parsed.protocol !== "https:") {
+    return "Logo URL must use https:// (http is blocked to avoid mixed-content warnings)";
+  }
+  return null;
 }
 
 /** Resolve region name from regionId, falling back to the raw form value. */
@@ -187,6 +220,8 @@ export async function createKennel(formData: FormData, force: boolean = false) {
   }
 
   const profileFields = extractProfileFields(formData);
+  const logoError = validateLogoUrl(profileFields.logoUrl);
+  if (logoError) return { error: logoError };
 
   // Parse kennel coordinates
   const latRaw = (formData.get("latitude") as string)?.trim();
@@ -227,6 +262,7 @@ export async function createKennel(formData: FormData, force: boolean = false) {
 
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
+  revalidateRegion(region);
   return { success: true };
 }
 
@@ -275,7 +311,7 @@ export async function updateKennel(kennelId: string, formData: FormData) {
   // If shortName changed, auto-add the old name as an alias so the resolver can still match it
   const current = await prisma.kennel.findUnique({
     where: { id: kennelId },
-    select: { shortName: true },
+    select: { shortName: true, region: true },
   });
 
   const newAliases = aliasesRaw
@@ -292,6 +328,8 @@ export async function updateKennel(kennelId: string, formData: FormData) {
   }
 
   const profileFields = extractProfileFields(formData);
+  const logoError = validateLogoUrl(profileFields.logoUrl);
+  if (logoError) return { error: logoError };
 
   // Parse kennel coordinates (only update if form provided values)
   const latRaw = (formData.get("latitude") as string)?.trim();
@@ -325,6 +363,9 @@ export async function updateKennel(kennelId: string, formData: FormData) {
 
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
+  // Bust both the new region page and — if the kennel moved — the old one (#1461).
+  revalidateRegion(region);
+  if (current?.region && current.region !== region) revalidateRegion(current.region);
   // Kennel display fields (shortName/fullName/slug/region/country) are
   // denormalized into the cached Hareline event list via a nested
   // `kennel` select, so any mutation here can leave stale labels/routes
@@ -423,6 +464,7 @@ export async function deleteKennel(kennelId: string) {
 
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
+  revalidateRegion(kennel.region);
   revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
   return { success: true };
 }
@@ -674,7 +716,7 @@ export async function mergeKennels(
 
   const targetKennel = await prisma.kennel.findUnique({
     where: { id: targetKennelId },
-    select: { id: true, shortName: true, slug: true },
+    select: { id: true, shortName: true, slug: true, region: true },
   });
 
   if (!sourceKennel) return { error: "Source kennel not found" };
@@ -812,6 +854,12 @@ export async function mergeKennels(
   revalidatePath("/admin/kennels");
   revalidatePath("/kennels");
   revalidatePath(`/kennels/${targetKennel.slug}`);
+  // The source kennel is deleted and its events move to the target — bust both
+  // region landing pages (#1461).
+  revalidateRegion(sourceKennel.region);
+  if (targetKennel.region && targetKennel.region !== sourceKennel.region) {
+    revalidateRegion(targetKennel.region);
+  }
   // Merge reassigns events to the target kennel, so their cached kennel
   // display fields (shortName/slug/region) go stale until tag bust.
   revalidateTag(HARELINE_EVENTS_TAG, { expire: 0 });
@@ -827,7 +875,7 @@ export async function toggleKennelVisibility(kennelId: string) {
 
   const kennel = await prisma.kennel.findUnique({
     where: { id: kennelId },
-    select: { isHidden: true, shortName: true, slug: true },
+    select: { isHidden: true, shortName: true, slug: true, region: true },
   });
   if (!kennel) return { error: "Kennel not found" };
 
@@ -849,6 +897,7 @@ export async function toggleKennelVisibility(kennelId: string) {
   revalidatePath("/admin/sources/coverage");
   revalidatePath("/kennels");
   revalidatePath(`/kennels/${kennel.slug}`);
+  revalidateRegion(kennel.region);
   revalidatePath("/hareline");
   revalidatePath("/misman");
   // Hareline's cached event list filters on `kennel.isHidden`; without a

--- a/src/app/api/admin/kennels/logo/upload/route.ts
+++ b/src/app/api/admin/kennels/logo/upload/route.ts
@@ -1,0 +1,45 @@
+import { handleUpload, type HandleUploadBody } from "@vercel/blob/client";
+import { NextResponse } from "next/server";
+import { getAdminUser } from "@/lib/auth";
+
+/**
+ * Client-upload token endpoint for kennel logos (#1414). The browser calls
+ * `upload()` from `@vercel/blob/client` against this route, which mints a
+ * scoped, short-lived upload token — the file streams directly to Vercel Blob,
+ * never through this function. Admin-gated inside `onBeforeGenerateToken`.
+ *
+ * Requires the `BLOB_READ_WRITE_TOKEN` env var (Vercel Blob store). Until that
+ * is provisioned the route returns 500 from `handleUpload`; the KennelForm
+ * degrades gracefully — admins can still paste an https Logo URL by hand.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = (await request.json()) as HandleUploadBody;
+
+  try {
+    const jsonResponse = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async () => {
+        const admin = await getAdminUser();
+        if (!admin) throw new Error("Not authorized");
+        return {
+          // No SVG — next/image can't optimize it (dangerouslyAllowSVG is off)
+          // and it carries an XSS surface. Raster only, 2 MB cap.
+          allowedContentTypes: ["image/png", "image/jpeg", "image/webp", "image/gif"],
+          maximumSizeInBytes: 2 * 1024 * 1024,
+          addRandomSuffix: true,
+        };
+      },
+      // The uploaded https URL is returned to the client, which writes it into
+      // the logoUrl field; persistence happens via the normal kennel mutation.
+      onUploadCompleted: async () => {},
+    });
+
+    return NextResponse.json(jsonResponse);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Upload failed" },
+      { status: 400 },
+    );
+  }
+}

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -12,6 +12,7 @@ import type { HarelineEvent } from "@/components/hareline/EventCard";
 import { MismanManagementSection } from "@/components/kennels/MismanManagementSection";
 import { QuickInfoCard } from "@/components/kennels/QuickInfoCard";
 import { KennelStats } from "@/components/kennels/KennelStats";
+import { KennelLogo } from "@/components/kennels/KennelLogo";
 import { TrailLocationMapClient } from "@/components/kennels/TrailLocationMapClient";
 import { EventTabs } from "@/components/kennels/EventTabs";
 import { RegionBadge } from "@/components/hareline/RegionBadge";
@@ -311,22 +312,23 @@ export default async function KennelDetailPage({
         }}
       >
         <div className="flex items-start gap-4 sm:gap-5">
-          {/* Logo or initials */}
-          {kennel.logoUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={kennel.logoUrl}
-              alt={`${kennel.shortName} logo`}
-              className="h-20 w-20 rounded-xl object-contain bg-white dark:bg-background ring-2 ring-white dark:ring-white/20 shadow-md sm:h-24 sm:w-24"
-            />
-          ) : (
-            <div
-              className="flex h-20 w-20 items-center justify-center rounded-xl text-xl font-bold text-white shadow-md ring-2 ring-white/80 dark:ring-white/20 sm:h-24 sm:w-24 sm:text-2xl"
-              style={{ backgroundColor: regionColor }}
-            >
-              {initials}
-            </div>
-          )}
+          {/* Logo (next/image, #1301) or initials fallback (#1300) */}
+          <KennelLogo
+            logoUrl={kennel.logoUrl}
+            alt={`${kennel.shortName} logo`}
+            width={96}
+            height={96}
+            loading="eager"
+            className="h-20 w-20 rounded-xl object-contain bg-white dark:bg-background ring-2 ring-white dark:ring-white/20 shadow-md sm:h-24 sm:w-24"
+            fallback={
+              <div
+                className="flex h-20 w-20 items-center justify-center rounded-xl text-xl font-bold text-white shadow-md ring-2 ring-white/80 dark:ring-white/20 sm:h-24 sm:w-24 sm:text-2xl"
+                style={{ backgroundColor: regionColor }}
+              >
+                {initials}
+              </div>
+            }
+          />
 
           <div className="min-w-0 flex-1">
             <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">

--- a/src/components/admin/KennelForm.tsx
+++ b/src/components/admin/KennelForm.tsx
@@ -182,6 +182,16 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
     const file = e.target.files?.[0];
     e.target.value = ""; // allow re-selecting the same file after an error
     if (!file) return;
+    // Validate client-side to match the route's onBeforeGenerateToken limits,
+    // so an oversized/wrong file fails instantly instead of round-tripping.
+    if (!["image/png", "image/jpeg", "image/webp", "image/gif"].includes(file.type)) {
+      toast.error("Logo must be a PNG, JPEG, WebP, or GIF image");
+      return;
+    }
+    if (file.size > 2 * 1024 * 1024) {
+      toast.error("Logo must be under 2 MB");
+      return;
+    }
     setUploadingLogo(true);
     try {
       // Streams directly to Vercel Blob; the route only mints a scoped token.
@@ -675,10 +685,13 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
                   <Input
                     id="logoUrl"
                     name="logoUrl"
-                    type="url"
+                    // Plain text (not type="url"): native URL validation rejects
+                    // the site-relative `/kennel-logos/*` paths the server allows
+                    // — the custom checkLogoUrl rule (+ warning below) governs.
+                    type="text"
                     value={logoUrl}
                     onChange={(e) => setLogoUrl(e.target.value)}
-                    placeholder="https://example.com/logo.png"
+                    placeholder="https://example.com/logo.png or /kennel-logos/foo.png"
                   />
                 </div>
                 <div className="flex items-center gap-2">

--- a/src/components/admin/KennelForm.tsx
+++ b/src/components/admin/KennelForm.tsx
@@ -21,6 +21,7 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { generateAliases } from "@/lib/auto-aliases";
+import { checkLogoUrl } from "@/lib/logo-url";
 import { GeocodeButton } from "./GeocodeButton";
 import { geocodeAction } from "@/app/admin/geocode-action";
 
@@ -64,26 +65,20 @@ function triStateDefault(value: boolean | null): string {
 }
 
 /**
- * Client-side mirror of the server `validateLogoUrl` (#1414) — surfaces a
- * warning before submit. Empty or `/relative` is fine; otherwise it must parse
- * as an https URL (http → mixed-content).
+ * Surfaces a logo-URL warning before submit (#1414). Shares the rule with the
+ * server action via `checkLogoUrl`; only the copy is form-specific.
  */
 function logoUrlWarning(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.startsWith("/")) return null;
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch {
-    return "Enter a full https:// URL or a site-relative /path";
+  switch (checkLogoUrl(value)) {
+    case "unparseable":
+      return "Enter a full https:// URL or a site-relative /path";
+    case "insecure-http":
+      return "Use https:// — http logos are blocked to avoid mixed-content warnings";
+    case "non-https":
+      return "Only https:// URLs are allowed";
+    default:
+      return null;
   }
-  if (parsed.protocol === "http:") {
-    return "Use https:// — http logos are blocked to avoid mixed-content warnings";
-  }
-  if (parsed.protocol !== "https:") {
-    return "Only https:// URLs are allowed";
-  }
-  return null;
 }
 
 /** Collapsible section used in the kennel form. */
@@ -169,6 +164,7 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
   const router = useRouter();
 
   const selectedRegion = regions.find((r) => r.id === selectedRegionId);
+  const logoWarning = logoUrlWarning(logoUrl);
 
   function addAlias() {
     const trimmed = aliasInput.trim();
@@ -713,9 +709,9 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
                     </Button>
                   )}
                 </div>
-                {logoUrlWarning(logoUrl) && (
+                {logoWarning && (
                   <p className="text-xs text-yellow-600 dark:text-yellow-500">
-                    {logoUrlWarning(logoUrl)}
+                    {logoWarning}
                   </p>
                 )}
               </div>

--- a/src/components/admin/KennelForm.tsx
+++ b/src/components/admin/KennelForm.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { upload } from "@vercel/blob/client";
 import { createKennel, updateKennel } from "@/app/admin/kennels/actions";
 import {
   Dialog,
@@ -60,6 +61,29 @@ function triStateDefault(value: boolean | null): string {
   if (value === true) return "true";
   if (value === false) return "false";
   return "";
+}
+
+/**
+ * Client-side mirror of the server `validateLogoUrl` (#1414) — surfaces a
+ * warning before submit. Empty or `/relative` is fine; otherwise it must parse
+ * as an https URL (http → mixed-content).
+ */
+function logoUrlWarning(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("/")) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return "Enter a full https:// URL or a site-relative /path";
+  }
+  if (parsed.protocol === "http:") {
+    return "Use https:// — http logos are blocked to avoid mixed-content warnings";
+  }
+  if (parsed.protocol !== "https:") {
+    return "Only https:// URLs are allowed";
+  }
+  return null;
 }
 
 /** Collapsible section used in the kennel form. */
@@ -137,8 +161,11 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
   const [pendingFormData, setPendingFormData] = useState<FormData | null>(null);
   const [selectedRegionId, setSelectedRegionId] = useState<string>(kennel?.regionId ?? "");
   const [isHidden, setIsHidden] = useState(kennel?.isHidden ?? false);
+  const [logoUrl, setLogoUrl] = useState(kennel?.logoUrl ?? "");
+  const [uploadingLogo, setUploadingLogo] = useState(false);
   const shortNameRef = useRef<HTMLInputElement>(null);
   const fullNameRef = useRef<HTMLInputElement>(null);
+  const logoFileRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
 
   const selectedRegion = regions.find((r) => r.id === selectedRegionId);
@@ -153,6 +180,26 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
 
   function removeAlias(alias: string) {
     setAliases(aliases.filter((a) => a !== alias));
+  }
+
+  async function handleLogoUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-selecting the same file after an error
+    if (!file) return;
+    setUploadingLogo(true);
+    try {
+      // Streams directly to Vercel Blob; the route only mints a scoped token.
+      const blob = await upload(file.name, file, {
+        access: "public",
+        handleUploadUrl: "/api/admin/kennels/logo/upload",
+      });
+      setLogoUrl(blob.url);
+      toast.success("Logo uploaded");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Logo upload failed");
+    } finally {
+      setUploadingLogo(false);
+    }
   }
 
   function handleGenerateAliases() {
@@ -235,6 +282,7 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
         setAliases(kennel?.aliases ?? []);
         setSelectedRegionId(kennel?.regionId ?? "");
         setIsHidden(kennel?.isHidden ?? false);
+        setLogoUrl(kennel?.logoUrl ?? "");
       }
     }}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
@@ -612,14 +660,64 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="logoUrl">Logo URL</Label>
-                <Input
-                  id="logoUrl"
-                  name="logoUrl"
-                  type="url"
-                  defaultValue={kennel?.logoUrl ?? ""}
-                  placeholder="https://example.com/logo.png"
-                />
+                <Label htmlFor="logoUrl">Logo</Label>
+                <div className="flex items-center gap-2">
+                  {logoUrl.trim() ? (
+                    // Live preview — a plain <img> (not next/image) so admins
+                    // see exactly what they pasted, including not-yet-valid URLs.
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={logoUrl}
+                      alt="Logo preview"
+                      className="h-10 w-10 shrink-0 rounded-md object-contain bg-white ring-1 ring-border"
+                    />
+                  ) : (
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted text-[10px] text-muted-foreground ring-1 ring-border">
+                      none
+                    </div>
+                  )}
+                  <Input
+                    id="logoUrl"
+                    name="logoUrl"
+                    type="url"
+                    value={logoUrl}
+                    onChange={(e) => setLogoUrl(e.target.value)}
+                    placeholder="https://example.com/logo.png"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={uploadingLogo}
+                    onClick={() => logoFileRef.current?.click()}
+                  >
+                    {uploadingLogo ? "Uploading…" : "Upload image"}
+                  </Button>
+                  <input
+                    ref={logoFileRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp,image/gif"
+                    className="hidden"
+                    onChange={handleLogoUpload}
+                  />
+                  {logoUrl.trim() && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setLogoUrl("")}
+                    >
+                      Clear
+                    </Button>
+                  )}
+                </div>
+                {logoUrlWarning(logoUrl) && (
+                  <p className="text-xs text-yellow-600 dark:text-yellow-500">
+                    {logoUrlWarning(logoUrl)}
+                  </p>
+                )}
               </div>
             </div>
             <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/kennels/KennelCard.tsx
+++ b/src/components/kennels/KennelCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { RegionBadge } from "@/components/hareline/RegionBadge";
 import { ActivityStatusBadge } from "@/components/kennels/ActivityStatusBadge";
+import { KennelLogo } from "@/components/kennels/KennelLogo";
 import { formatSchedule, formatDateShort, type ScheduleSlot } from "@/lib/format";
 
 export interface KennelCardData {
@@ -46,22 +47,21 @@ export function KennelCard({ kennel }: KennelCardProps) {
             initials are the null-logo fallback. */}
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-start gap-2.5 min-w-0">
-            {kennel.logoUrl ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={kennel.logoUrl}
-                alt={`${kennel.shortName} logo`}
-                loading="lazy"
-                className="h-10 w-10 shrink-0 rounded-lg object-contain bg-white dark:bg-background ring-1 ring-border"
-              />
-            ) : (
-              <div
-                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-xs font-bold text-muted-foreground"
-                aria-hidden="true"
-              >
-                {kennel.shortName.replace(/[^\p{L}\p{N}]/gu, "").slice(0, 3).toUpperCase()}
-              </div>
-            )}
+            <KennelLogo
+              logoUrl={kennel.logoUrl}
+              alt={`${kennel.shortName} logo`}
+              width={40}
+              height={40}
+              className="h-10 w-10 shrink-0 rounded-lg object-contain bg-white dark:bg-background ring-1 ring-border"
+              fallback={
+                <div
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-xs font-bold text-muted-foreground"
+                  aria-hidden="true"
+                >
+                  {kennel.shortName.replace(/[^\p{L}\p{N}]/gu, "").slice(0, 3).toUpperCase()}
+                </div>
+              }
+            />
             <div className="min-w-0">
               <h3 className="text-base font-bold leading-tight truncate" title={kennel.fullName}>
                 {kennel.shortName}

--- a/src/components/kennels/KennelLogo.tsx
+++ b/src/components/kennels/KennelLogo.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useState, type ReactNode } from "react";
+import { isOptimizableLogo } from "@/lib/image-remote-patterns";
 
 interface KennelLogoProps {
   /** Logo URL, or null/undefined when the kennel has no logo. */
@@ -25,6 +26,10 @@ interface KennelLogoProps {
  * load — a non-resolvable/404/http-only logo shows initials, never a broken
  * image icon (#1300). `onError` requires a client boundary, hence this small
  * client wrapper used by both the kennel hero and the directory card.
+ *
+ * Only first-party assets (local paths + Vercel Blob) go through the `/_next/
+ * image` optimizer; arbitrary third-party logos render `unoptimized` so the
+ * public optimizer is never used as a fetch proxy (see image-remote-patterns).
  */
 export function KennelLogo({
   logoUrl,
@@ -48,6 +53,7 @@ export function KennelLogo({
       width={width}
       height={height}
       loading={loading}
+      unoptimized={!isOptimizableLogo(logoUrl)}
       className={className}
       onError={() => setErrored(true)}
     />

--- a/src/components/kennels/KennelLogo.tsx
+++ b/src/components/kennels/KennelLogo.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Image from "next/image";
+import { useState, type ReactNode } from "react";
+
+interface KennelLogoProps {
+  /** Logo URL, or null/undefined when the kennel has no logo. */
+  logoUrl: string | null | undefined;
+  /** Accessible label, e.g. `${shortName} logo`. */
+  alt: string;
+  /** Intrinsic size hint for the optimizer — set to the largest rendered px. */
+  width: number;
+  height: number;
+  /** Sizing/rounding classes for the rendered <Image>. */
+  className?: string;
+  /** Whether to lazy-load (cards) or load eagerly (above-the-fold hero). */
+  loading?: "lazy" | "eager";
+  /** Rendered when there is no logo, or the image fails to load (#1300). */
+  fallback: ReactNode;
+}
+
+/**
+ * Renders a kennel logo via next/image (#1301) with a graceful fallback to the
+ * caller's initials placeholder when `logoUrl` is absent or the asset fails to
+ * load — a non-resolvable/404/http-only logo shows initials, never a broken
+ * image icon (#1300). `onError` requires a client boundary, hence this small
+ * client wrapper used by both the kennel hero and the directory card.
+ */
+export function KennelLogo({
+  logoUrl,
+  alt,
+  width,
+  height,
+  className,
+  loading = "lazy",
+  fallback,
+}: Readonly<KennelLogoProps>) {
+  const [errored, setErrored] = useState(false);
+
+  if (!logoUrl || errored) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <Image
+      src={logoUrl}
+      alt={alt}
+      width={width}
+      height={height}
+      loading={loading}
+      className={className}
+      onError={() => setErrored(true)}
+    />
+  );
+}

--- a/src/components/kennels/KennelStats.test.ts
+++ b/src/components/kennels/KennelStats.test.ts
@@ -1,0 +1,42 @@
+import { computeYearsActive } from "./KennelStats";
+
+// Use the real current year so the test never ages out (#1290 + relative-date rule).
+const CURRENT_YEAR = new Date().getUTCFullYear();
+const utcNoon = (year: number) =>
+  new Date(Date.UTC(year, 0, 1, 12, 0, 0)).toISOString();
+
+describe("computeYearsActive (#1290)", () => {
+  it("uses foundedYear as an exact (non-approximate) figure", () => {
+    const result = computeYearsActive(CURRENT_YEAR - 10, utcNoon(CURRENT_YEAR - 2));
+    expect(result).toEqual({
+      years: 10,
+      sinceYear: CURRENT_YEAR - 10,
+      approximate: false,
+    });
+  });
+
+  it("falls back to earliest known run as an approximate lower bound when foundedYear is null", () => {
+    const result = computeYearsActive(null, utcNoon(CURRENT_YEAR - 3));
+    expect(result).toEqual({
+      years: 3,
+      sinceYear: CURRENT_YEAR - 3,
+      approximate: true,
+    });
+  });
+
+  it("returns null when there is no founding year and no event history (tile suppressed)", () => {
+    expect(computeYearsActive(null, null)).toBeNull();
+    expect(computeYearsActive(undefined, null)).toBeNull();
+  });
+
+  it("returns 0 years when the only known run is the current year (renderer then suppresses)", () => {
+    const result = computeYearsActive(null, utcNoon(CURRENT_YEAR));
+    expect(result).toEqual({ years: 0, sinceYear: CURRENT_YEAR, approximate: true });
+  });
+
+  it("prefers foundedYear over event history when both are present", () => {
+    const result = computeYearsActive(CURRENT_YEAR - 25, utcNoon(CURRENT_YEAR - 1));
+    expect(result?.sinceYear).toBe(CURRENT_YEAR - 25);
+    expect(result?.approximate).toBe(false);
+  });
+});

--- a/src/components/kennels/KennelStats.test.ts
+++ b/src/components/kennels/KennelStats.test.ts
@@ -39,4 +39,17 @@ describe("computeYearsActive (#1290)", () => {
     expect(result?.sinceYear).toBe(CURRENT_YEAR - 25);
     expect(result?.approximate).toBe(false);
   });
+
+  it("is pure when given an explicit currentYear (deterministic, no clock dependency)", () => {
+    expect(computeYearsActive(1990, null, 2026)).toEqual({
+      years: 36,
+      sinceYear: 1990,
+      approximate: false,
+    });
+    expect(computeYearsActive(null, utcNoon(2020), 2026)).toEqual({
+      years: 6,
+      sinceYear: 2020,
+      approximate: true,
+    });
+  });
 });

--- a/src/components/kennels/KennelStats.tsx
+++ b/src/components/kennels/KennelStats.tsx
@@ -50,15 +50,40 @@ function formatLastRun(lastEventDate: string): string {
   });
 }
 
-function computeYearsActive(
+interface YearsActive {
+  /** Whole years between `sinceYear` and now. */
+  years: number;
+  /** First year we can attribute activity to (founding year, or earliest known run). */
+  sinceYear: number;
+  /**
+   * `true` when derived from the earliest *known* run rather than a real
+   * `foundedYear` — i.e. a lower bound, not an exact founding figure. The
+   * renderer surfaces this as a `title` hint so a kennel whose data only goes
+   * back one scrape ("Year Active: 1") doesn't masquerade as a one-year-old
+   * kennel. See #1290.
+   */
+  approximate: boolean;
+}
+
+/**
+ * Single source of truth for the Year(s) Active tile (#1290). Previously the
+ * two `foundedYear IS NULL` outcomes looked like distinct bugs — one rendered a
+ * bare "Year Active: 1" (event-derived), the other suppressed the tile (no
+ * data). They are one branch: prefer the real `foundedYear`; otherwise fall
+ * back to the earliest known run as an explicitly-`approximate` lower bound;
+ * otherwise return null so the tile is suppressed.
+ */
+export function computeYearsActive(
   foundedYear: number | null | undefined,
   oldestEventDate: string | null,
-): number | null {
+): YearsActive | null {
   const currentYear = new Date().getUTCFullYear();
-  if (foundedYear) return currentYear - foundedYear;
+  if (foundedYear) {
+    return { years: currentYear - foundedYear, sinceYear: foundedYear, approximate: false };
+  }
   if (oldestEventDate) {
     const year = new Date(oldestEventDate).getUTCFullYear();
-    return currentYear - year;
+    return { years: currentYear - year, sinceYear: year, approximate: true };
   }
   return null;
 }
@@ -85,6 +110,7 @@ export function KennelStats({
     icon: React.ReactNode;
     value: React.ReactNode;
     label: string;
+    hint?: string;
   }[] = [];
 
   if (currentRunNumber) {
@@ -102,11 +128,14 @@ export function KennelStats({
     });
   }
 
-  if (yearsActive !== null && yearsActive > 0) {
+  if (yearsActive !== null && yearsActive.years > 0) {
     stats.push({
       icon: <Clock className="h-5 w-5" />,
-      value: <AnimatedCounter target={yearsActive} />,
-      label: yearsActive === 1 ? "Year Active" : "Years Active",
+      value: <AnimatedCounter target={yearsActive.years} />,
+      label: yearsActive.years === 1 ? "Year Active" : "Years Active",
+      hint: yearsActive.approximate
+        ? `Since first known run in ${yearsActive.sinceYear}`
+        : undefined,
     });
   }
 
@@ -137,6 +166,7 @@ export function KennelStats({
       {stats.map((stat) => (
         <div
           key={stat.label}
+          title={stat.hint}
           className="rounded-xl border border-border/50 bg-card p-4 text-center"
         >
           <div

--- a/src/components/kennels/KennelStats.tsx
+++ b/src/components/kennels/KennelStats.tsx
@@ -76,8 +76,8 @@ interface YearsActive {
 export function computeYearsActive(
   foundedYear: number | null | undefined,
   oldestEventDate: string | null,
+  currentYear: number = new Date().getUTCFullYear(),
 ): YearsActive | null {
-  const currentYear = new Date().getUTCFullYear();
   if (foundedYear) {
     return { years: currentYear - foundedYear, sinceYear: foundedYear, approximate: false };
   }

--- a/src/components/kennels/KennelStats.tsx
+++ b/src/components/kennels/KennelStats.tsx
@@ -88,6 +88,13 @@ export function computeYearsActive(
   return null;
 }
 
+/** Tailwind grid-columns class for the stat tiles (1–3 tiles). */
+function statsGridClass(count: number): string {
+  if (count === 3) return "grid-cols-3";
+  if (count === 2) return "grid-cols-2";
+  return "grid-cols-1 max-w-[200px]";
+}
+
 export function KennelStats({
   currentRunNumber,
   totalEvents,
@@ -155,13 +162,7 @@ export function KennelStats({
 
   return (
     <div
-      className={`grid gap-3 ${
-        stats.length === 3
-          ? "grid-cols-3"
-          : stats.length === 2
-            ? "grid-cols-2"
-            : "grid-cols-1 max-w-[200px]"
-      }`}
+      className={`grid gap-3 ${statsGridClass(stats.length)}`}
     >
       {stats.map((stat) => (
         <div

--- a/src/components/providers/time-preference-provider.tsx
+++ b/src/components/providers/time-preference-provider.tsx
@@ -23,18 +23,27 @@ export function TimePreferenceProvider({
     const [isLoading, setIsLoading] = useState(false);
     // Last-write-wins guard for overlapping optimistic updates (#1139). Without
     // it, a slow PATCH that fails *after* a newer PATCH already succeeded would
-    // roll back to its own stale snapshot and clobber the user's confirmed
-    // choice. Persist the tracker across renders via a ref.
-    const trackerRef = useRef(createRequestTracker());
+    // roll back and clobber the user's confirmed choice. Lazy-init so the
+    // tracker is allocated once, not on every render.
+    const trackerRef = useRef<ReturnType<typeof createRequestTracker> | null>(null);
+    if (trackerRef.current === null) {
+        trackerRef.current = createRequestTracker();
+    }
+    // Last server-confirmed (or initial) preference — the safe rollback target
+    // when the latest in-flight update fails. Rolling back to a per-call
+    // optimistic snapshot could strand the UI on a value the server never
+    // accepted (e.g. A→B then B→C where both PATCHes fail).
+    const confirmedRef = useRef<TimeDisplayPref>(initialPreference);
 
     // Sync state if initialPreference changes (e.g. on navigation)
     useEffect(() => {
         setPreferenceState(initialPreference);
+        confirmedRef.current = initialPreference;
     }, [initialPreference]);
 
     const setPreference = async (newPref: TimeDisplayPref) => {
-        const previousPref = preference;
-        const requestId = trackerRef.current.begin();
+        const tracker = trackerRef.current!;
+        const requestId = tracker.begin();
         // Optimistic update
         setPreferenceState(newPref);
         setIsLoading(true);
@@ -49,17 +58,20 @@ export function TimePreferenceProvider({
             if (!res.ok) {
                 throw new Error("Failed to update preference");
             }
+            // Server accepted this value — it's now a safe rollback baseline.
+            confirmedRef.current = newPref;
         } catch (err) {
             console.error("Error setting time preference:", err);
             // Only roll back if this is still the latest intent — a stale
-            // failure must not overwrite a newer confirmed value.
-            if (trackerRef.current.isLatest(requestId)) {
-                setPreferenceState(previousPref);
+            // failure must not overwrite a newer confirmed value — and roll back
+            // to the last server-confirmed value, never an optimistic snapshot.
+            if (tracker.isLatest(requestId)) {
+                setPreferenceState(confirmedRef.current);
             }
         } finally {
             // Only the latest request owns the loading flag, so an early
             // completion doesn't clear the spinner for a still-pending newer one.
-            if (trackerRef.current.isLatest(requestId)) {
+            if (tracker.isLatest(requestId)) {
                 setIsLoading(false);
             }
         }

--- a/src/components/providers/time-preference-provider.tsx
+++ b/src/components/providers/time-preference-provider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode, useEffect } from "react";
+import { createContext, useContext, useState, useRef, ReactNode, useEffect } from "react";
 import type { TimeDisplayPref } from "@/generated/prisma/client";
+import { createRequestTracker } from "@/lib/request-tracker";
 
 interface TimePreferenceContextValue {
     preference: TimeDisplayPref;
@@ -20,6 +21,11 @@ export function TimePreferenceProvider({
 }) {
     const [preference, setPreferenceState] = useState<TimeDisplayPref>(initialPreference);
     const [isLoading, setIsLoading] = useState(false);
+    // Last-write-wins guard for overlapping optimistic updates (#1139). Without
+    // it, a slow PATCH that fails *after* a newer PATCH already succeeded would
+    // roll back to its own stale snapshot and clobber the user's confirmed
+    // choice. Persist the tracker across renders via a ref.
+    const trackerRef = useRef(createRequestTracker());
 
     // Sync state if initialPreference changes (e.g. on navigation)
     useEffect(() => {
@@ -28,6 +34,7 @@ export function TimePreferenceProvider({
 
     const setPreference = async (newPref: TimeDisplayPref) => {
         const previousPref = preference;
+        const requestId = trackerRef.current.begin();
         // Optimistic update
         setPreferenceState(newPref);
         setIsLoading(true);
@@ -44,9 +51,17 @@ export function TimePreferenceProvider({
             }
         } catch (err) {
             console.error("Error setting time preference:", err);
-            setPreferenceState(previousPref);
+            // Only roll back if this is still the latest intent — a stale
+            // failure must not overwrite a newer confirmed value.
+            if (trackerRef.current.isLatest(requestId)) {
+                setPreferenceState(previousPref);
+            }
         } finally {
-            setIsLoading(false);
+            // Only the latest request owns the loading flag, so an early
+            // completion doesn't clear the spinner for a still-pending newer one.
+            if (trackerRef.current.isLatest(requestId)) {
+                setIsLoading(false);
+            }
         }
     };
 

--- a/src/components/shared/ClearFilterButton.tsx
+++ b/src/components/shared/ClearFilterButton.tsx
@@ -1,27 +1,32 @@
 "use client";
 
 import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
 
-// Rendered inside parent <button> filter triggers — must stay a <span>
-// to avoid nested interactive elements (invalid HTML + hydration warnings).
-export function ClearFilterButton({ onClick, label }: Readonly<{ onClick: () => void; label: string }>) {
+// A real <button> rendered as a *sibling* of the filter trigger (never nested
+// inside it) — see the `relative inline-flex` chip wrappers at each call site.
+// Native button semantics give us correct keyboard handling (Enter/Space) for
+// free, so no role/tabIndex/onKeyDown is needed (#1140). `stopPropagation`
+// keeps a clear click from also toggling the adjacent popover trigger.
+export function ClearFilterButton({
+  onClick,
+  label,
+  className,
+}: Readonly<{ onClick: () => void; label: string; className?: string }>) {
   return (
-    <span
-      role="button"
-      tabIndex={0}
-      className="ml-1 rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      onClick={(e) => { e.stopPropagation(); onClick(); }}
-      onMouseDown={(e) => { e.preventDefault(); }}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          e.stopPropagation();
-          onClick();
-        }
+    <button
+      type="button"
+      className={cn(
+        "rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
       }}
       aria-label={label}
     >
       <X className="h-3 w-3" />
-    </span>
+    </button>
   );
 }

--- a/src/components/shared/ClearFilterButton.tsx
+++ b/src/components/shared/ClearFilterButton.tsx
@@ -22,6 +22,13 @@ export function ClearFilterButton({
       )}
       onClick={(e) => {
         e.stopPropagation();
+        // Clearing the filter unmounts this button; move focus back to the
+        // sibling trigger first so keyboard users aren't dumped on <body> (#1140).
+        const prev = e.currentTarget.previousElementSibling;
+        if (prev instanceof HTMLElement) {
+          const trigger = prev.tagName === "BUTTON" ? prev : prev.querySelector("button");
+          trigger?.focus();
+        }
         onClick();
       }}
       aria-label={label}

--- a/src/components/shared/DayOfWeekSelect.tsx
+++ b/src/components/shared/DayOfWeekSelect.tsx
@@ -25,23 +25,29 @@ interface DayOfWeekSelectProps {
 export function DayOfWeekSelect({ selectedDays, onDaysChange }: DayOfWeekSelectProps) {
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          variant={selectedDays.length > 0 ? "secondary" : "outline"}
-          size="sm"
-          className={`h-8 text-xs ${selectedDays.length > 0 ? "border-primary/50" : ""}`}
-        >
-          {selectedDays.length > 0 ? selectedDays.join(", ") : "Run Day"}
-          {selectedDays.length > 1 && (
-            <Badge variant="secondary" className="ml-1 text-xs">
-              {selectedDays.length}
-            </Badge>
-          )}
-          {selectedDays.length > 0 && (
-            <ClearFilterButton onClick={() => onDaysChange([])} label="Clear day filter" />
-          )}
-        </Button>
-      </PopoverTrigger>
+      <div className="relative inline-flex items-center">
+        <PopoverTrigger asChild>
+          <Button
+            variant={selectedDays.length > 0 ? "secondary" : "outline"}
+            size="sm"
+            className={`h-8 text-xs ${selectedDays.length > 0 ? "border-primary/50 pr-7" : ""}`}
+          >
+            {selectedDays.length > 0 ? selectedDays.join(", ") : "Run Day"}
+            {selectedDays.length > 1 && (
+              <Badge variant="secondary" className="ml-1 text-xs">
+                {selectedDays.length}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        {selectedDays.length > 0 && (
+          <ClearFilterButton
+            onClick={() => onDaysChange([])}
+            label="Clear day filter"
+            className="absolute right-1 top-1/2 -translate-y-1/2"
+          />
+        )}
+      </div>
       <PopoverContent className="w-44 p-0" align="start">
         <Command>
           <CommandList>

--- a/src/components/shared/FilterBar.tsx
+++ b/src/components/shared/FilterBar.tsx
@@ -193,31 +193,37 @@ export function FilterBar({
 
         {/* Region + Near Me + Filters button */}
         <div className="flex items-center gap-2">
-          <RegionFilterPopover
-            regions={regions}
-            selectedRegions={selectedRegions}
-            onRegionsChange={onRegionsChange}
-            enableCountryGrouping
-            trigger={
-              <Button
-                variant={selectedRegions.length > 0 ? "secondary" : "outline"}
-                size="sm"
-                className={`h-8 text-xs ${selectedRegions.length > 0 ? "border-primary/50" : ""}`}
-              >
-                {selectedRegions.length === 1
-                  ? regionDisplayName(selectedRegions[0])
-                  : "Region"}
-                {selectedRegions.length > 1 && (
-                  <Badge variant="secondary" className="ml-1 text-xs">
-                    {selectedRegions.length}
-                  </Badge>
-                )}
-                {selectedRegions.length > 0 && (
-                  <ClearFilterButton onClick={() => onRegionsChange([])} label="Clear region filter" />
-                )}
-              </Button>
-            }
-          />
+          <div className="relative inline-flex items-center">
+            <RegionFilterPopover
+              regions={regions}
+              selectedRegions={selectedRegions}
+              onRegionsChange={onRegionsChange}
+              enableCountryGrouping
+              trigger={
+                <Button
+                  variant={selectedRegions.length > 0 ? "secondary" : "outline"}
+                  size="sm"
+                  className={`h-8 text-xs ${selectedRegions.length > 0 ? "border-primary/50 pr-7" : ""}`}
+                >
+                  {selectedRegions.length === 1
+                    ? regionDisplayName(selectedRegions[0])
+                    : "Region"}
+                  {selectedRegions.length > 1 && (
+                    <Badge variant="secondary" className="ml-1 text-xs">
+                      {selectedRegions.length}
+                    </Badge>
+                  )}
+                </Button>
+              }
+            />
+            {selectedRegions.length > 0 && (
+              <ClearFilterButton
+                onClick={() => onRegionsChange([])}
+                label="Clear region filter"
+                className="absolute right-1 top-1/2 -translate-y-1/2"
+              />
+            )}
+          </div>
 
           <NearMeFilter
             nearMeDistance={nearMeDistance}
@@ -267,18 +273,24 @@ export function FilterBar({
             <>
               <div className="hidden sm:block w-px h-5 bg-border" />
               <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant={selectedFrequency ? "secondary" : "outline"}
-                    size="sm"
-                    className={`h-8 text-xs ${selectedFrequency ? "border-primary/50" : ""}`}
-                  >
-                    {selectedFrequency || "Frequency"}
-                    {selectedFrequency && (
-                      <ClearFilterButton onClick={() => onFrequencyChange?.("")} label="Clear frequency filter" />
-                    )}
-                  </Button>
-                </PopoverTrigger>
+                <div className="relative inline-flex items-center">
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant={selectedFrequency ? "secondary" : "outline"}
+                      size="sm"
+                      className={`h-8 text-xs ${selectedFrequency ? "border-primary/50 pr-7" : ""}`}
+                    >
+                      {selectedFrequency || "Frequency"}
+                    </Button>
+                  </PopoverTrigger>
+                  {selectedFrequency && (
+                    <ClearFilterButton
+                      onClick={() => onFrequencyChange?.("")}
+                      label="Clear frequency filter"
+                      className="absolute right-1 top-1/2 -translate-y-1/2"
+                    />
+                  )}
+                </div>
                 <PopoverContent className="w-44 p-0" align="start">
                   <Command>
                     <CommandList>
@@ -325,23 +337,29 @@ export function FilterBar({
             <>
               <div className="hidden sm:block w-px h-5 bg-border" />
               <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant={selectedKennels && selectedKennels.length > 0 ? "secondary" : "outline"}
-                    size="sm"
-                    className={`h-8 text-xs ${selectedKennels && selectedKennels.length > 0 ? "border-primary/50" : ""}`}
-                  >
-                    Kennel
-                    {selectedKennels && selectedKennels.length > 0 && (
-                      <Badge variant="secondary" className="ml-1 text-xs">
-                        {selectedKennels.length}
-                      </Badge>
-                    )}
-                    {selectedKennels && selectedKennels.length > 0 && (
-                      <ClearFilterButton onClick={() => onKennelsChange?.([])} label="Clear kennel filter" />
-                    )}
-                  </Button>
-                </PopoverTrigger>
+                <div className="relative inline-flex items-center">
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant={selectedKennels && selectedKennels.length > 0 ? "secondary" : "outline"}
+                      size="sm"
+                      className={`h-8 text-xs ${selectedKennels && selectedKennels.length > 0 ? "border-primary/50 pr-7" : ""}`}
+                    >
+                      Kennel
+                      {selectedKennels && selectedKennels.length > 0 && (
+                        <Badge variant="secondary" className="ml-1 text-xs">
+                          {selectedKennels.length}
+                        </Badge>
+                      )}
+                    </Button>
+                  </PopoverTrigger>
+                  {selectedKennels && selectedKennels.length > 0 && (
+                    <ClearFilterButton
+                      onClick={() => onKennelsChange?.([])}
+                      label="Clear kennel filter"
+                      className="absolute right-1 top-1/2 -translate-y-1/2"
+                    />
+                  )}
+                </div>
                 <PopoverContent className="w-72 p-0" align="start">
                   <Command>
                     <CommandInput placeholder="Search kennels..." />

--- a/src/lib/image-remote-patterns.test.ts
+++ b/src/lib/image-remote-patterns.test.ts
@@ -1,0 +1,48 @@
+import { LOGO_REMOTE_PATTERNS, isOptimizableLogo } from "./image-remote-patterns";
+
+describe("LOGO_REMOTE_PATTERNS (image optimizer allowlist)", () => {
+  it("never allows a global wildcard host (SSRF / proxy-amplification guard)", () => {
+    for (const pattern of LOGO_REMOTE_PATTERNS) {
+      expect(pattern.hostname).not.toBe("**");
+      expect(pattern.hostname).not.toBe("*");
+      // Every entry must be a concrete domain (a dot-bearing host), so the
+      // optimizer can only fetch from first-party origins.
+      expect(pattern.hostname).toContain(".");
+    }
+  });
+
+  it("only permits https origins", () => {
+    for (const pattern of LOGO_REMOTE_PATTERNS) {
+      expect(pattern.protocol).toBe("https");
+    }
+  });
+});
+
+describe("isOptimizableLogo (per-URL optimizer gate)", () => {
+  it("optimizes site-relative first-party assets", () => {
+    expect(isOptimizableLogo("/kennel-logos/qbk.png")).toBe(true);
+  });
+
+  it("optimizes Vercel Blob URLs (first-party upload destination)", () => {
+    expect(isOptimizableLogo("https://abc123.public.blob.vercel-storage.com/logo.png")).toBe(true);
+  });
+
+  it("does NOT optimize arbitrary third-party https hosts (rendered unoptimized instead)", () => {
+    expect(isOptimizableLogo("https://keywesthash.com/uploads/logo.jpg")).toBe(false);
+    expect(isOptimizableLogo("https://haguehash.nl/wp-content/uploads/logo.png")).toBe(false);
+  });
+
+  it("rejects a lookalike host that merely contains the Blob domain as a substring", () => {
+    expect(isOptimizableLogo("https://evil.public.blob.vercel-storage.com.attacker.test/x.png")).toBe(false);
+  });
+
+  it("rejects protocol-relative and non-https URLs", () => {
+    expect(isOptimizableLogo("//cdn.example.com/logo.png")).toBe(false);
+    expect(isOptimizableLogo("http://example.com/logo.png")).toBe(false);
+  });
+
+  it("rejects empty / unparseable values", () => {
+    expect(isOptimizableLogo("")).toBe(false);
+    expect(isOptimizableLogo("not a url")).toBe(false);
+  });
+});

--- a/src/lib/image-remote-patterns.ts
+++ b/src/lib/image-remote-patterns.ts
@@ -1,0 +1,48 @@
+/**
+ * Image-optimizer security boundary for kennel logos.
+ *
+ * Next's `/_next/image` optimizer is an UNAUTHENTICATED endpoint that fetches
+ * whatever remote URL it's handed. A wildcard `remotePatterns` (`hostname:
+ * "**"`) therefore turns the public deployment into an arbitrary-HTTPS
+ * fetch/resize proxy — an SSRF-probing and bandwidth/CPU-amplification surface
+ * (flagged by adversarial review on the #1301 logo change). So ONLY first-party
+ * origins are allowed through the optimizer:
+ *   - site-relative paths (`/kennel-logos/*`) — always first-party, need no
+ *     `remotePatterns` entry.
+ *   - Vercel Blob (`*.public.blob.vercel-storage.com`) — the #1414 upload
+ *     destination, content-type/size-gated at ingestion.
+ *
+ * Third-party kennel logos (arbitrary WordPress origins, gohash.app, etc.) are
+ * NOT proxied: `KennelLogo` renders them `unoptimized` (a direct browser→origin
+ * fetch, exactly like a plain <img>), keeping lazy-loading + the onError
+ * initials fallback without exposing the optimizer.
+ */
+
+export interface LogoRemotePattern {
+  protocol: "https";
+  hostname: string;
+}
+
+/** Hosts allowed through Next's image optimizer. First-party only. */
+export const LOGO_REMOTE_PATTERNS: LogoRemotePattern[] = [
+  { protocol: "https", hostname: "*.public.blob.vercel-storage.com" },
+];
+
+/**
+ * Whether a logo URL may be optimized via `/_next/image`. True only for
+ * first-party assets (site-relative paths and Vercel Blob); everything else
+ * must render `unoptimized` so the public optimizer never proxies it.
+ */
+export function isOptimizableLogo(url: string): boolean {
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  // Site-relative (but not protocol-relative `//host`) → first-party local asset.
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) return true;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === "https:" && parsed.hostname.endsWith(".public.blob.vercel-storage.com");
+}

--- a/src/lib/logo-url.test.ts
+++ b/src/lib/logo-url.test.ts
@@ -26,4 +26,9 @@ describe("checkLogoUrl (#1414 shared logo-url rule)", () => {
   it("flags unparseable values", () => {
     expect(checkLogoUrl("not a url")).toBe("unparseable");
   });
+
+  it("does not accept protocol-relative URLs as a site-relative path", () => {
+    // `//host` would resolve to http on an http page — must not pass as "ok".
+    expect(checkLogoUrl("//cdn.example.com/logo.png")).not.toBe("ok");
+  });
 });

--- a/src/lib/logo-url.test.ts
+++ b/src/lib/logo-url.test.ts
@@ -1,0 +1,29 @@
+import { checkLogoUrl } from "./logo-url";
+
+describe("checkLogoUrl (#1414 shared logo-url rule)", () => {
+  it("treats empty / whitespace as ok (cleared)", () => {
+    expect(checkLogoUrl("")).toBe("ok");
+    expect(checkLogoUrl("   ")).toBe("ok");
+  });
+
+  it("treats site-relative paths as ok", () => {
+    expect(checkLogoUrl("/kennel-logos/qbk.png")).toBe("ok");
+  });
+
+  it("accepts https URLs", () => {
+    expect(checkLogoUrl("https://example.com/logo.png")).toBe("ok");
+  });
+
+  it("flags http URLs as insecure (mixed content)", () => {
+    expect(checkLogoUrl("http://example.com/logo.png")).toBe("insecure-http");
+  });
+
+  it("flags other schemes as non-https", () => {
+    expect(checkLogoUrl("ftp://example.com/logo.png")).toBe("non-https");
+    expect(checkLogoUrl("data:image/png;base64,AAAA")).toBe("non-https");
+  });
+
+  it("flags unparseable values", () => {
+    expect(checkLogoUrl("not a url")).toBe("unparseable");
+  });
+});

--- a/src/lib/logo-url.ts
+++ b/src/lib/logo-url.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared kennel `logoUrl` validation rule (#1414).
+ *
+ * Both the server action (`createKennel`/`updateKennel`) and the admin form
+ * enforce the same rule — empty or a site-relative `/path` is fine, otherwise
+ * the value must parse as an `https` URL — but they surface different copy. The
+ * rule itself (the security-relevant part) lives here once so the two can't
+ * silently drift; each caller maps the returned code to its own message.
+ */
+export type LogoUrlCheck = "ok" | "unparseable" | "insecure-http" | "non-https";
+
+export function checkLogoUrl(value: string): LogoUrlCheck {
+  const trimmed = value.trim();
+  // Empty or site-relative (incl. protocol-relative `//`, matching the existing
+  // callers) is treated as valid here; emptiness is filtered upstream.
+  if (!trimmed || trimmed.startsWith("/")) return "ok";
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return "unparseable";
+  }
+  if (parsed.protocol === "https:") return "ok";
+  return parsed.protocol === "http:" ? "insecure-http" : "non-https";
+}

--- a/src/lib/logo-url.ts
+++ b/src/lib/logo-url.ts
@@ -11,9 +11,10 @@ export type LogoUrlCheck = "ok" | "unparseable" | "insecure-http" | "non-https";
 
 export function checkLogoUrl(value: string): LogoUrlCheck {
   const trimmed = value.trim();
-  // Empty or site-relative (incl. protocol-relative `//`, matching the existing
-  // callers) is treated as valid here; emptiness is filtered upstream.
-  if (!trimmed || trimmed.startsWith("/")) return "ok";
+  // Empty or a true site-relative path (`/foo`, not protocol-relative `//host`,
+  // which would resolve to http on an http page) is valid. This matches the
+  // optimizer gate in `isOptimizableLogo`. Emptiness is filtered upstream.
+  if (!trimmed || (trimmed.startsWith("/") && !trimmed.startsWith("//"))) return "ok";
   let parsed: URL;
   try {
     parsed = new URL(trimmed);

--- a/src/lib/request-tracker.test.ts
+++ b/src/lib/request-tracker.test.ts
@@ -1,0 +1,40 @@
+import { createRequestTracker } from "./request-tracker";
+
+describe("createRequestTracker (#1139)", () => {
+  it("mints monotonically increasing ids", () => {
+    const t = createRequestTracker();
+    expect(t.begin()).toBe(1);
+    expect(t.begin()).toBe(2);
+    expect(t.begin()).toBe(3);
+  });
+
+  it("treats only the most recently started request as latest", () => {
+    const t = createRequestTracker();
+    const first = t.begin();
+    const second = t.begin();
+    expect(t.isLatest(first)).toBe(false);
+    expect(t.isLatest(second)).toBe(true);
+  });
+
+  it("ignores a stale completion that resolves after a newer request (the A→B→C race)", () => {
+    const t = createRequestTracker();
+    // toggle A→B
+    const patch1 = t.begin();
+    // toggle B→C before patch1 resolves
+    const patch2 = t.begin();
+    // patch2 succeeds (latest) — its completion is authoritative
+    expect(t.isLatest(patch2)).toBe(true);
+    // patch1 fails late — it is NOT the latest, so its rollback must be skipped
+    expect(t.isLatest(patch1)).toBe(false);
+  });
+
+  it("each tracker instance is independent", () => {
+    const a = createRequestTracker();
+    const b = createRequestTracker();
+    a.begin();
+    a.begin();
+    const bId = b.begin();
+    expect(b.isLatest(bId)).toBe(true);
+    expect(a.isLatest(bId)).toBe(false);
+  });
+});

--- a/src/lib/request-tracker.ts
+++ b/src/lib/request-tracker.ts
@@ -1,0 +1,23 @@
+/**
+ * Tiny last-write-wins request tracker for optimistic UI updates.
+ *
+ * Each `begin()` mints a monotonically increasing id and records it as the
+ * latest in-flight intent. A completion (success or failure) can then ask
+ * `isLatest(id)` to decide whether it still represents the user's most recent
+ * choice — letting a stale, late-resolving request skip its rollback so it
+ * can't clobber a newer confirmed value. See #1139.
+ */
+export interface RequestTracker {
+  /** Mark a new request as the latest intent; returns its id. */
+  begin(): number;
+  /** True only if `id` is still the most recently started request. */
+  isLatest(id: number): boolean;
+}
+
+export function createRequestTracker(): RequestTracker {
+  let latest = 0;
+  return {
+    begin: () => ++latest,
+    isLatest: (id: number) => id === latest,
+  };
+}


### PR DESCRIPTION
Frontend + infra polish bundle (7 issues). No adapters / no `prisma/seed-data`.

Closes #1290
Closes #1300
Closes #1301
Closes #1414
Closes #1461
Closes #1139
Closes #1140

## What changed

**#1290 — Year-Active stat consolidation** (`KennelStats.tsx`)
`computeYearsActive` now returns `{ years, sinceYear, approximate }`, collapsing the two `foundedYear IS NULL` outcomes (the bare "Year Active: 1" vs. suppressed-tile variants) into one branch. When the value is event-derived rather than founding-based it's flagged `approximate` and the tile gets a `title="Since first known run in YYYY"` so a lower bound no longer masquerades as an exact founding figure. Unit-tested.

**#1301 + #1300 — logo rendering** (`KennelLogo.tsx`, kennel hero, `KennelCard`, `next.config.ts`)
New `KennelLogo` client wrapper renders logos via `next/image` and falls back to the existing initials placeholder when `logoUrl` is absent **or** the asset fails to load (`onError`) — no broken-image icon. Replaces two copies of the raw-`<img>` + initials markup.
**Security (adversarial-review fix):** the optimizer allowlist is **first-party only** (`LOGO_REMOTE_PATTERNS`: local paths + Vercel Blob). A wildcard `hostname: "**"` would have turned the public `/_next/image` endpoint into an arbitrary-HTTPS fetch/resize proxy (SSRF + amplification); arbitrary third-party logos now render `unoptimized` (direct browser fetch, no proxy). Regression-tested (`image-remote-patterns.test.ts`).

**#1414 — logoUrl admin path (both paths)** (`KennelForm.tsx`, `actions.ts`, new upload route)
- Hardening: controlled Logo field with a live preview thumbnail + inline `http://`/invalid warning; server rejects non-`https`/non-relative `logoUrl`. Rule shared via `src/lib/logo-url.ts` (`checkLogoUrl`) so server + client can't drift.
- Upload: `@vercel/blob` client-upload route (`/api/admin/kennels/logo/upload`, admin-gated, raster-only, 2 MB) + file picker that writes the returned Blob URL into the field.
> ⚠️ The Blob upload path ships **unverified** — it needs `BLOB_READ_WRITE_TOKEN` (documented in CLAUDE.md), which isn't provisioned, so it couldn't be exercised in preview. The URL field degrades gracefully without it.

**#1461 — region ISR invalidation** (`actions.ts`)
Every kennel mutation now busts `/kennels/region/[slug]` (the 1-hour-ISR region page) via a `revalidateRegion` helper — including **both** old and new region on a move (update) or merge. Verified by `actions.test.ts` assertions that `revalidatePath` fires with the region path for create/update(both)/delete/toggle.

**#1139 — TimePreferenceProvider single-flight** (`time-preference-provider.tsx`)
Last-write-wins guard (`createRequestTracker`) so a slow PATCH that fails *after* a newer one succeeded no longer rolls back to its stale snapshot and clobbers the confirmed value. Tracker unit-tested.

**#1140 — FilterBar clear affordance** (`ClearFilterButton`, `FilterBar`, `DayOfWeekSelect`)
`ClearFilterButton` is now a real `<button>` rendered as a **sibling** of the trigger (inside a `relative inline-flex` chip), not a `<span role="button">` nested inside the trigger `<button>` — removes the invalid nested-interactive-control at all 4 call sites.

## Verification
- `npx tsc --noEmit` (0 errors), `npm run lint` (0 errors), `npm test` (8993 pass) — all green.
- Server-render verified via the dev server: third-party logo renders `unoptimized` (0 `/_next/image`), the optimizer **rejects** arbitrary hosts (400, was 200 with the wildcard) and still serves local assets (200); Year-Active `title` hint renders; no-logo kennels show initials.
- `/codex:adversarial-review` (caught the optimizer-wildcard SSRF — fixed) and `/simplify` (deduped the logo-URL rule) run before this PR.

## Deferred (noted, out of scope)
- #1290 `foundedYear` backfill from About pages — touches seed data (WS6).
- #1300 logo **data harvesting** for non-WordPress hosts — logo *data* (WS6) + one-off scripts.
- Interaction/DOM tests for #1139 (two-toggle) and #1140 (Tab order) — repo has no jsdom/@testing-library/react; covered by pure-logic tests + structural correctness instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)