### PR TITLE
fix(bch3): Thursday timezone correctness via opt-in weekdayShift (#960/#1006/#1134)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -3362,11 +3362,11 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "bch3", shortName: "BCH3", fullName: "Brew City Hash House Harriers", region: "Milwaukee, WI",
       website: "https://www.brewcityh3.com",
       facebookUrl: "https://www.facebook.com/groups/BrewCityH3/",
-      scheduleDayOfWeek: "Friday", scheduleFrequency: "Weekly",
+      scheduleDayOfWeek: "Thursday", scheduleFrequency: "Weekly",
       hashCash: "$7-8",
       contactEmail: "Fido@BrewCityH3.com",
       logoUrl: "https://static.wixstatic.com/media/5b98c7_0b8ba7cdd4114a479765ea7e0d64d4ea~mv2.png/v1/fill/w_657,h_534,al_c/5b98c7_0b8ba7cdd4114a479765ea7e0d64d4ea~mv2.png",
-      description: "Milwaukee's weekly Friday evening hash. Trail #359+.",
+      description: "Milwaukee's weekly Thursday evening hash. Trail #359+.",
       latitude: 43.04, longitude: -87.91,
     },
 

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4726,6 +4726,16 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 365,
+      // BCH3 publishes Friday-midnight placeholders on Wix but actually runs
+      // Thursday 8 PM CDT (#960/#694). Remap Friday→Thursday at 20:00. No
+      // placeholderTime here: parseDateTime emits `undefined` (not "00:00") for
+      // the 12 AM placeholder, so a "00:00" gate would be inert. Instead the
+      // adapter gates the shift on a timeless (undefined startTime) row, so only
+      // the Friday-midnight placeholders move — a genuinely-timed Friday event
+      // stays put.
+      config: {
+        weekdayShift: { from: "Friday", to: "Thursday", defaultStartTime: "20:00" },
+      },
       kennelCodes: ["bch3"],
     },
 

--- a/src/adapters/html-scraper/brew-city-h3.test.ts
+++ b/src/adapters/html-scraper/brew-city-h3.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Source } from "@/generated/prisma/client";
+import { composeUtcStart, formatDateInZone } from "@/lib/timezone";
 import { parseDateTime, parseTitle, parseDetails, BrewCityH3Adapter } from "./brew-city-h3";
+
+/** BCH3's production weekdayShift config (Friday-published → Thursday-actual). */
+const BCH3_WEEKDAY_SHIFT = {
+  from: "Friday",
+  to: "Thursday",
+  defaultStartTime: "20:00",
+} as const;
 
 // Mock browserRender
 vi.mock("@/lib/browser-render", () => ({
@@ -78,6 +86,31 @@ describe("parseDateTime", () => {
     const result = parseDateTime("Thursday, April 30, 2026 AT 8 PM");
     expect(result.date).toBe("2026-04-30");
     expect(result.startTime).toBe("20:00");
+  });
+});
+
+// ── #960: timezone correctness — Thursday-evening must STAY Thursday ──
+// BCH3 runs Thursday 8 PM CDT (America/Chicago). The merge pipeline composes
+// the stored UTC start via composeUtcStart(date, startTime, timezone) and the
+// card re-composes + renders in the kennel's zone. This guards the round-trip:
+// the absolute instant rolls into the next UTC day, but rendered in
+// America/Chicago it is still Thursday. Uses the real composeUtcStart helper —
+// no hand-rolled tz math.
+describe("BCH3 timezone correctness (#960)", () => {
+  const BCH3_TZ = "America/Chicago";
+
+  it("Thursday 8 PM CDT composes to a UTC instant that still renders Thursday", () => {
+    // What the adapter emits for "Thursday, April 30, 2026 AT 8 PM".
+    const dateUtcNoon = new Date("2026-04-30T12:00:00Z");
+    const composed = composeUtcStart(dateUtcNoon, "20:00", BCH3_TZ);
+
+    expect(composed).not.toBeNull();
+    // 8 PM CDT (UTC-5) = 01:00 UTC the next calendar day — the day-roll #960
+    // reported. It is contained by the timezone, not lost.
+    expect(composed!.toISOString()).toBe("2026-05-01T01:00:00.000Z");
+    // Rendered back in BCH3's zone, the day is still Thursday April 30.
+    expect(formatDateInZone(composed!, BCH3_TZ, "EEEE")).toBe("Thursday");
+    expect(formatDateInZone(composed!, BCH3_TZ, "yyyy-MM-dd")).toBe("2026-04-30");
   });
 });
 
@@ -230,6 +263,66 @@ describe("BrewCityH3Adapter", () => {
     ]);
   });
 
+  it("does NOT shift when weekdayShift config is absent (#359 stays Friday)", async () => {
+    mockedBrowserRender.mockResolvedValue(buildTestHtml());
+
+    // makeSource() has config: null — the fixture's "Friday, April 3, 2026
+    // AT 12 AM" placeholder is left untouched.
+    const result = await adapter.fetch(makeSource());
+    const trail359 = result.events.find(e => e.runNumber === 359);
+    expect(trail359!.date).toBe("2026-04-03");
+    expect(trail359!.startTime).toBeUndefined();
+  });
+
+  it("applies weekdayShift: Friday-midnight placeholder → Thursday 20:00 (#1134)", async () => {
+    mockedBrowserRender.mockResolvedValue(buildTestHtml());
+
+    const result = await adapter.fetch(
+      makeSource({ config: { weekdayShift: BCH3_WEEKDAY_SHIFT } }),
+    );
+
+    // #359 published as "Friday, April 3, 2026 AT 12 AM" back-shifts one day to
+    // Thursday April 2 and gets the kennel's real 8 PM start.
+    const trail359 = result.events.find(e => e.runNumber === 359);
+    expect(trail359).toBeDefined();
+    expect(trail359!.date).toBe("2026-04-02");
+    expect(trail359!.startTime).toBe("20:00");
+  });
+
+  it("weekdayShift leaves a real non-Friday event unchanged (Saturday)", async () => {
+    mockedBrowserRender.mockResolvedValue(buildTestHtml());
+
+    const result = await adapter.fetch(
+      makeSource({ config: { weekdayShift: BCH3_WEEKDAY_SHIFT } }),
+    );
+
+    // "Easter Hash" is "Saturday, April 4, 2026 AT 7 PM" — weekday ≠ Friday, so
+    // the from:Friday gate doesn't fire. Date + time untouched.
+    const easterHash = result.events.find(e => e.title === "Easter Hash");
+    expect(easterHash).toBeDefined();
+    expect(easterHash!.date).toBe("2026-04-04");
+    expect(easterHash!.startTime).toBe("19:00");
+  });
+
+  it("weekdayShift does NOT touch a genuinely-timed Friday event (placeholder-only gate)", async () => {
+    // A real "Friday, April 10, 2026 AT 7 PM" event has a parsed startTime
+    // (19:00), not the 12 AM placeholder's undefined — so the gate skips it and
+    // it stays Friday 19:00 even under the from:Friday config. Guards against
+    // silently corrupting a legitimate Friday special trail.
+    mockedBrowserRender.mockResolvedValue(buildSingleEventHtml(
+      "Friday, April 10, 2026 AT 7 PM",
+      "BCH3 Trail #364: Friday Special",
+    ));
+
+    const result = await adapter.fetch(
+      makeSource({ config: { weekdayShift: BCH3_WEEKDAY_SHIFT } }),
+    );
+    const event = result.events.find(e => e.runNumber === 364);
+    expect(event).toBeDefined();
+    expect(event!.date).toBe("2026-04-10");
+    expect(event!.startTime).toBe("19:00");
+  });
+
   it("returns fetch error when browser render fails", async () => {
     mockedBrowserRender.mockRejectedValue(new Error("Browser render service not configured: set BROWSER_RENDER_URL and BROWSER_RENDER_KEY"));
 
@@ -248,6 +341,21 @@ describe("BrewCityH3Adapter", () => {
     expect(result.errors).toHaveLength(0);
   });
 });
+
+/** Build a minimal single-event Wix repeater item with a given date heading + title. */
+function buildSingleEventHtml(dateHeading: string, title: string): string {
+  return `<!DOCTYPE html><html><body>
+<div id="SITE_CONTAINER">
+  <div class="Exmq9">
+    <div role="listitem" class="_FiCX">
+      <div data-testid="richTextElement"><h6 class="font_6">${dateHeading}</h6></div>
+      <div data-testid="richTextElement"><h2 class="font_2">${title}</h2></div>
+      <div data-testid="richTextElement"><p class="font_7">\u{1F430} Hare: Solo Hare</p></div>
+    </div>
+  </div>
+</div>
+</body></html>`;
+}
 
 /** Build minimal Wix-like HTML for testing */
 function buildTestHtml(): string {

--- a/src/adapters/html-scraper/brew-city-h3.test.ts
+++ b/src/adapters/html-scraper/brew-city-h3.test.ts
@@ -287,6 +287,9 @@ describe("BrewCityH3Adapter", () => {
     expect(trail359).toBeDefined();
     expect(trail359!.date).toBe("2026-04-02");
     expect(trail359!.startTime).toBe("20:00");
+
+    // Only the Friday placeholder shifts; the Saturday event does not.
+    expect(result.diagnosticContext?.weekdayShifted).toBe(1);
   });
 
   it("weekdayShift leaves a real non-Friday event unchanged (Saturday)", async () => {

--- a/src/adapters/html-scraper/brew-city-h3.ts
+++ b/src/adapters/html-scraper/brew-city-h3.ts
@@ -4,9 +4,10 @@ import type {
   RawEventData,
   ScrapeResult,
   ErrorDetails,
+  SourceConfig,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { chronoParseDate, buildDateWindow, stripPlaceholder, fetchBrowserRenderedPage } from "../utils";
+import { applyWeekdayShift, chronoParseDate, buildDateWindow, stripPlaceholder, fetchBrowserRenderedPage } from "../utils";
 
 /**
  * Parse time from the Wix date heading, e.g. "Friday, April 3, 2026 AT 8 PM"
@@ -147,13 +148,18 @@ export class BrewCityH3Adapter implements SourceAdapter {
   ): Promise<ScrapeResult> {
     const calendarUrl = source.url || "https://www.brewcityh3.com/calendar";
 
-    // BCH3 is Wisconsin (Milwaukee) — America/Chicago. Wix renders calendar
-    // dates client-side via Intl.DateTimeFormat, so the rendering browser's
-    // timezone determines what string we see. Without this, Playwright's UTC
-    // default produced "Friday, May 1, AT 12 AM" for what the kennel
-    // authored as "Thursday, April 30, AT 8 PM CDT" — the date label was
-    // rounded forward across midnight UTC and the time degenerated to the
-    // 12 AM placeholder branch. See #960.
+    // Opt-in weekday remap (#1006/#1134). BCH3 publishes Friday-midnight
+    // placeholders on Wix but actually runs Thursday 8 PM CDT (#960/#694), so
+    // its source config sets `weekdayShift: { from: "Friday", to: "Thursday",
+    // defaultStartTime: "20:00" }`. Sources without the knob are unaffected.
+    const weekdayShift = (source.config as SourceConfig | null)?.weekdayShift;
+
+    // BCH3 is Wisconsin (Milwaukee) — America/Chicago. Render in the kennel's
+    // zone as a defensive hint, but note (live-verified #1134): this Wix page
+    // serves *literal* placeholder strings ("Friday, … AT 12 AM"), not
+    // client-rendered Intl.DateTimeFormat output, so timezoneId does NOT move
+    // the published day/time — the `weekdayShift` config above is what corrects
+    // Friday-midnight placeholders to the real Thursday 8 PM run. See #960/#1006.
     const page = await fetchBrowserRenderedPage(calendarUrl, {
       waitFor: '[role="listitem"]',
       timeout: 20000,
@@ -186,6 +192,19 @@ export class BrewCityH3Adapter implements SourceAdapter {
           ];
           return;
         }
+
+        // Remap the published weekday to the actual run weekday for placeholder
+        // rows only (#960/#1134). BCH3's Wix placeholders are the *timeless*
+        // "Friday … AT 12 AM" rows: parseDateTime collapses 12 AM to an
+        // `undefined` startTime, so after a successful date parse an undefined
+        // startTime IS the placeholder signal. Gating the shift on it means a
+        // genuinely-timed Friday event (e.g. "Friday … AT 7 PM" → "19:00") is
+        // trusted and left on Friday — never silently moved to Thursday. Throws
+        // on malformed config — caught by the per-item try/catch below.
+        const resolved =
+          weekdayShift && startTime === undefined
+            ? applyWeekdayShift(date, startTime, weekdayShift)
+            : { date, startTime };
 
         // 2. Title from h2 (skip header h2 elements outside repeater items)
         const titleText = $item.find("h2").first().text().trim();
@@ -241,14 +260,14 @@ export class BrewCityH3Adapter implements SourceAdapter {
             : undefined;
 
         const event: RawEventData = {
-          date,
+          date: resolved.date,
           kennelTags: ["bch3"],
           title,
           runNumber,
           hares: details.hares,
           location,
           locationStreet,
-          startTime,
+          startTime: resolved.startTime,
           description: details.description,
           sourceUrl: calendarUrl,
           externalLinks: externalLinks.length > 0 ? externalLinks : undefined,

--- a/src/adapters/html-scraper/brew-city-h3.ts
+++ b/src/adapters/html-scraper/brew-city-h3.ts
@@ -173,6 +173,7 @@ export class BrewCityH3Adapter implements SourceAdapter {
     const events: RawEventData[] = [];
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
+    let weekdayShifted = 0; // how many events the weekdayShift remapped (observability)
 
     // Each event is in a Wix repeater item (role="listitem")
     const listItems = $('[role="listitem"]');
@@ -204,7 +205,8 @@ export class BrewCityH3Adapter implements SourceAdapter {
         const resolved =
           weekdayShift && startTime === undefined
             ? applyWeekdayShift(date, startTime, weekdayShift)
-            : { date, startTime };
+            : { date, startTime, shifted: false };
+        if (resolved.shifted) weekdayShifted++;
 
         // 2. Title from h2 (skip header h2 elements outside repeater items)
         const titleText = $item.find("h2").first().text().trim();
@@ -314,6 +316,7 @@ export class BrewCityH3Adapter implements SourceAdapter {
       diagnosticContext: {
         listItemsFound: listItems.length,
         eventsParsed: dedupedEvents.length,
+        weekdayShifted,
         fetchDurationMs,
       },
     };

--- a/src/adapters/html-scraper/brew-city-h3.ts
+++ b/src/adapters/html-scraper/brew-city-h3.ts
@@ -7,7 +7,27 @@ import type {
   SourceConfig,
 } from "../types";
 import { hasAnyErrors } from "../types";
+import type { WeekdayShiftConfig } from "../utils";
 import { applyWeekdayShift, chronoParseDate, buildDateWindow, stripPlaceholder, fetchBrowserRenderedPage } from "../utils";
+
+/**
+ * Apply the configured weekday remap to a parsed (date, startTime) pair, gated
+ * on a *timeless* row. parseDateTime collapses the Wix 12 AM placeholder to an
+ * undefined startTime, so an undefined startTime after a successful date parse
+ * is the placeholder signal — a genuinely-timed Friday event ("19:00") is
+ * trusted and left untouched. Returns the resolved pair plus whether the shift
+ * fired (for diagnostics). See #960/#1006/#1134.
+ */
+function resolveWeekdayShift(
+  date: string,
+  startTime: string | undefined,
+  weekdayShift: WeekdayShiftConfig | undefined,
+): { date: string; startTime: string | undefined; shifted: boolean } {
+  if (weekdayShift && startTime === undefined) {
+    return applyWeekdayShift(date, startTime, weekdayShift);
+  }
+  return { date, startTime, shifted: false };
+}
 
 /**
  * Parse time from the Wix date heading, e.g. "Friday, April 3, 2026 AT 8 PM"
@@ -195,17 +215,9 @@ export class BrewCityH3Adapter implements SourceAdapter {
         }
 
         // Remap the published weekday to the actual run weekday for placeholder
-        // rows only (#960/#1134). BCH3's Wix placeholders are the *timeless*
-        // "Friday … AT 12 AM" rows: parseDateTime collapses 12 AM to an
-        // `undefined` startTime, so after a successful date parse an undefined
-        // startTime IS the placeholder signal. Gating the shift on it means a
-        // genuinely-timed Friday event (e.g. "Friday … AT 7 PM" → "19:00") is
-        // trusted and left on Friday — never silently moved to Thursday. Throws
-        // on malformed config — caught by the per-item try/catch below.
-        const resolved =
-          weekdayShift && startTime === undefined
-            ? applyWeekdayShift(date, startTime, weekdayShift)
-            : { date, startTime, shifted: false };
+        // rows only (#960/#1134) — see resolveWeekdayShift. Throws on malformed
+        // config, caught by the per-item try/catch below.
+        const resolved = resolveWeekdayShift(date, startTime, weekdayShift);
         if (resolved.shifted) weekdayShifted++;
 
         // 2. Title from h2 (skip header h2 elements outside repeater items)

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,4 +1,5 @@
 import type { SourceType, Source } from "@/generated/prisma/client";
+import type { WeekdayShiftConfig } from "./utils";
 
 /** Raw event data extracted from a source before kennel resolution or deduplication */
 export interface RawEventData {
@@ -104,6 +105,21 @@ export interface RawEventData {
    * since the adapter has no `locationUrl` to differ on (#957).
    */
   dropCachedCoords?: boolean;
+}
+
+/**
+ * Opt-in per-source config knobs read off `Source.config` (a JSON column).
+ * This is a partial, additive view — adapters read only the fields they
+ * support, so unrelated config keys (kennelPatterns, columns, etc.) coexist.
+ */
+export interface SourceConfig {
+  /**
+   * Remap a scraped occurrence from the weekday the source *publishes* to the
+   * weekday the kennel *actually* runs (#1006/#960). Consumed by the BCH3
+   * adapter via {@link applyWeekdayShift}; gated per-source — sources that
+   * don't set it are unaffected.
+   */
+  weekdayShift?: WeekdayShiftConfig;
 }
 
 /**


### PR DESCRIPTION
## What & why

Brew City H3 (Milwaukee) events were displaying on **Friday** when the kennel actually runs **Thursday 8 PM CDT**. BCH3's Wix calendar publishes timeless `"Friday … AT 12 AM"` placeholders, and the browser-render `timezoneId` hint does **not** fix it — the page serves *literal* text, not client-rendered datetimes. This wires the already-shipped `applyWeekdayShift` helper (#1123) into BCH3 behind an additive, opt-in source-config knob.

Closes #960
Closes #1006
Closes #1134

## Changes
- **`src/adapters/types.ts`** (#1006) — additive optional `SourceConfig.weekdayShift`, typed via the existing `WeekdayShiftConfig` (type-only import from `utils`). Sources that don't set it are unaffected.
- **`src/adapters/html-scraper/brew-city-h3.ts`** (#1134) — reads `source.config.weekdayShift` and applies `applyWeekdayShift` per event, **gated on a timeless (`undefined` startTime) row** so only the 12 AM placeholders move; a genuinely-timed Friday event is trusted and stays Friday.
- **`prisma/seed-data/sources.ts`** — BCH3 config `{ from: "Friday", to: "Thursday", defaultStartTime: "20:00" }`. No `placeholderTime`: `parseDateTime` emits `undefined` (not `"00:00"`) for the 12 AM placeholder, so a `"00:00"` gate would be inert — the adapter's undefined-startTime gate is the effective placeholder guard.
- **Tests** — `composeUtcStart` round-trip (Thursday 8 PM CDT → `2026-05-01T01:00Z`, still renders Thursday in `America/Chicago`); shift fires on the placeholder (Fri 12 AM → Thu 20:00); negative cases (Saturday one-off and a real timed-Friday event left untouched).

## Live verification
Ran the real adapter against `brewcityh3.com/calendar` via the NAS browser-render service:
- **Baseline (no config):** 26 events parsed as `Friday … (no time)` — confirming the literal-text root cause.
- **With config:** 33 events, **0 errors**; weekday distribution `{ Thu: 28, Sat: 4, Sun: 1 }` — all weekly trails at `20:00` on **Thursday**, with the Sat/Sun special events untouched and no over-shift to Wednesday.

## Checks
`npm run lint` (0 errors) · `npx tsc --noEmit` (clean) · `npm test` (8971 passed). Ran `/simplify` and `/codex:adversarial-review` — the latter caught that the original `from:Friday`-only gate would corrupt a future legitimately-timed Friday event; hardened to the placeholder-only gate + added the negative regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)