### PR TITLE
fix(gcal): polish round 3 — endTime display, MoA2H3 sisters, Princeton title, BJH3 tz, Aloha baseline

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -289,14 +289,12 @@ export const SOURCES = [
         kennelPatterns: [["^Regular Hash", "princeton-h3"], ["^MDL Hash", "princeton-h3"]],
         // null default so Summit/Rumson/other placeholders are skipped
         defaultKennelTag: null,
-        // #1934: every 2nd-Sunday event carries the standing schedule-description
-        // placeholder "Regular Hash Day, 2nd Sunday, detail cuming" as its title
-        // until the kennel posts run details. Substitute a clean default name so
-        // the event surfaces as a real run rather than a schedule blurb.
+        // #2125: the 2nd-Sunday SUMMARY "Regular Hash Day, 2nd Sunday, detail
+        // cuming" IS the intended run title (reverses #1934, which had treated
+        // it as a placeholder blurb and substituted a default). Prefer the real
+        // GCal SUMMARY (cf. #2046 C2H3). `defaultTitle` is retained only as a
+        // genuine-empty fallback; a non-empty SUMMARY no longer triggers it.
         defaultTitle: "Princeton H3 Hash",
-        staleTitleAliases: {
-          "princeton-h3": ["Regular Hash Day, 2nd Sunday, detail cuming"],
-        },
       },
       kennelCodes: ["princeton-h3"],
     },
@@ -1191,6 +1189,12 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "bjh3",
+        // #775 — BJH3 is El Paso, TX (Mountain Time). Pin the IANA zone so any
+        // timed event whose source DTSTART was authored in another zone is
+        // normalized to El Paso wall-clock at extraction (the "EPH3 Turkey Puke"
+        // event was created in Eastern and surfaced "2:00 PM EST"). All-day
+        // events carry no dateTime, so this is a no-op for them.
+        timezone: "America/Denver",
         // BJH3 publishes every run as an all-day event (no start times), so the
         // adapter must opt in or it drops all of them by default (adapter.ts:1349).
         includeAllDayEvents: true,
@@ -3039,25 +3043,25 @@ export const SOURCES = [
       // scrape route.
       scrapeDays: 800,
       config: {
+        // #1738 — most-specific-first: the MoA2H3 calendar carries a handful of
+        // sister-kennel events (DeMon H3 inaugural trail Nov 2025; GLH3 HashMas
+        // Jan 2025). Route them to the sister codes rather than silent-skipping
+        // (#1739). The sister codes are added to `kennelCodes` below so the merge
+        // source-kennel guard passes (no recurring `SOURCE_KENNEL_MISMATCH` — the
+        // #1739 noise that drove the original silent-skip). DeMon/GLH3 own sources
+        // stay at scrapeDays:90 and can't reach these historical dates, so no
+        // duplicate Events arise (the Codex #1719 dedup concern is moot here).
+        kennelPatterns: [
+          [String.raw`^DeMon\s*H?3?\b`, "demon-h3"],
+          [String.raw`^GLH3\b|^Greater\s+Lansing`, "glh3"],
+        ],
         defaultKennelTag: "moa2h3",
         // #1458 — kennel admins double-paste "MoA2H3" into event titles on
         // the source side. Opt in to the doubled-prefix strip so titles
         // like "MoA2H3 MoA2H3 Red Dress Run" surface as a single prefix.
         stripDoubledKennelPrefix: true,
-        // #1671 / #1739 — the MoA2H3 calendar carries a handful of sister-kennel
-        // events (DeMon H3 inaugural trail Nov 2025; GLH3 HashMas Jan 2025).
-        // DeMon H3 and GLH3 each have their OWN Google Calendar source, so these
-        // rows are pure pollution here. The original fix routed them to the
-        // sister codes, which then fired recurring `SOURCE_KENNEL_MISMATCH`
-        // alerts every 6h (intentional but noisy). Drop them silently instead
-        // (#1739) — no alert, no duplicate Events against the sisters' own
-        // sources, no kennel-page pollution.
-        silentlySkipPatterns: [
-          { pattern: String.raw`^DeMon\s*H?3?\b` },
-          { pattern: String.raw`^GLH3\b|^Greater\s+Lansing` },
-        ],
       },
-      kennelCodes: ["moa2h3"],
+      kennelCodes: ["moa2h3", "demon-h3", "glh3"],
     },
     {
       name: "DeMon H3 Google Calendar",

--- a/scripts/live-verify-gcal-round3.ts
+++ b/scripts/live-verify-gcal-round3.ts
@@ -1,0 +1,112 @@
+/**
+ * Live smoke for GCal polish round 3 (#2135 endTime, #2133 Aloha hares,
+ * #1738 MoA2H3 sisters, #775 BJH3 timezone, #2125 Princeton title).
+ * Hits each affected calendar's public API with the freshly-edited adapter +
+ * seed config and reports a verification digest per source.
+ *
+ * Run: `set -a && source /Users/johnclem/Developer/hashtracks-web/.env && set +a && npx tsx scripts/live-verify-gcal-round3.ts`
+ *
+ * Read-only — does not mutate the DB.
+ */
+import "dotenv/config";
+import { GoogleCalendarAdapter } from "@/adapters/google-calendar/adapter";
+import type { RawEventData } from "@/adapters/types";
+import { SOURCES } from "../prisma/seed-data/sources";
+import type { Source } from "@/generated/prisma/client";
+
+function pctHares(events: RawEventData[]): string {
+  if (events.length === 0) return "n/a (0 events)";
+  const withHares = events.filter((e) => !!e.hares).length;
+  return `${Math.round((withHares / events.length) * 100)}% (${withHares}/${events.length})`;
+}
+
+function tagCounts(events: RawEventData[]): Record<string, number> {
+  const m: Record<string, number> = {};
+  for (const e of events) {
+    const tag = e.kennelTags[0] ?? "(none)";
+    m[tag] = (m[tag] ?? 0) + 1;
+  }
+  return m;
+}
+
+async function fetchSource(adapter: GoogleCalendarAdapter, name: string, days: number) {
+  const seedRow = SOURCES.find((s) => s.name === name);
+  if (!seedRow) throw new Error(`${name} NOT FOUND IN SEED`);
+  const source = {
+    id: "stub",
+    name: seedRow.name,
+    url: seedRow.url,
+    type: seedRow.type as Source["type"],
+    enabled: true,
+    config: (seedRow as { config?: unknown }).config ?? null,
+  } as unknown as Source;
+  const result = await adapter.fetch(source, { days });
+  return { result, seedRow };
+}
+
+async function main() {
+  if (!process.env.GOOGLE_CALENDAR_API_KEY) {
+    throw new Error("GOOGLE_CALENDAR_API_KEY not set — source .env first");
+  }
+  const adapter = new GoogleCalendarAdapter();
+
+  // ── #2135 QCH4 endTime ──
+  console.log("\n## QCH4 Google Calendar — endTime from DTEND (#2135)");
+  {
+    const { result } = await fetchSource(adapter, "QCH4 Google Calendar", 365);
+    const withEnd = result.events.filter((e) => !!e.endTime);
+    console.log(`   events: ${result.events.length}; with endTime: ${withEnd.length}`);
+    for (const e of withEnd.slice(0, 5)) {
+      console.log(`   • ${e.date} ${e.startTime}–${e.endTime}  ${e.title ?? ""}`);
+    }
+  }
+
+  // ── #1738 MoA2H3 sister routing ──
+  console.log("\n## MoA2H3 Google Calendar — sister routing (#1738)");
+  {
+    const { result } = await fetchSource(adapter, "MoA2H3 Google Calendar", 800);
+    console.log(`   events: ${result.events.length}; tag counts: ${JSON.stringify(tagCounts(result.events))}`);
+    const sisters = result.events.filter((e) => ["demon-h3", "glh3"].includes(e.kennelTags[0] ?? ""));
+    for (const e of sisters) {
+      console.log(`   • ${e.date} → ${e.kennelTags[0]}  ${e.title ?? ""}`);
+    }
+  }
+
+  // ── #775 BJH3 timezone ──
+  console.log("\n## BJH3 Google Calendar — El Paso timezone (#775)");
+  {
+    const { result } = await fetchSource(adapter, "BJH3 Google Calendar", 730);
+    const timed = result.events.filter((e) => !!e.startTime);
+    console.log(`   events: ${result.events.length}; timed: ${timed.length}`);
+    for (const e of timed.slice(0, 8)) {
+      console.log(`   • ${e.date} ${e.startTime}${e.endTime ? `–${e.endTime}` : ""}  ${e.title ?? ""}`);
+    }
+    const turkey = result.events.find((e) => /turkey puke/i.test(e.title ?? ""));
+    console.log(`   Turkey Puke: ${turkey ? `${turkey.date} ${turkey.startTime} (expect ~12:00 MST)` : "not in window"}`);
+  }
+
+  // ── #2133 Aloha hares: recurring (365) vs wide (9999) fill rate ──
+  console.log("\n## Aloha H3 Google Calendar — hares fill rate (#2133)");
+  {
+    const recurring = await fetchSource(adapter, "Aloha H3 Google Calendar", 365);
+    console.log(`   recurring 365d hares fill: ${pctHares(recurring.result.events)}`);
+    const wide = await fetchSource(adapter, "Aloha H3 Google Calendar", 9999);
+    console.log(`   wide 9999d hares fill:     ${pctHares(wide.result.events)} (dilution check)`);
+    console.log(`   wide tag counts: ${JSON.stringify(tagCounts(wide.result.events))}`);
+  }
+
+  // ── #2125 Princeton title ──
+  console.log("\n## Princeton NJ Hash Calendar — title from SUMMARY (#2125)");
+  {
+    const { result } = await fetchSource(adapter, "Princeton NJ Hash Calendar", 365);
+    const princeton = result.events.filter((e) => e.kennelTags[0] === "princeton-h3");
+    console.log(`   princeton-h3 events: ${princeton.length}`);
+    for (const e of princeton.slice(0, 8)) {
+      console.log(`   • ${e.date} "${e.title ?? ""}"`);
+    }
+  }
+
+  console.log("\n✓ done");
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/scripts/live-verify-gcal-round3.ts
+++ b/scripts/live-verify-gcal-round3.ts
@@ -81,10 +81,12 @@ async function main() {
     const timed = result.events.filter((e) => !!e.startTime);
     console.log(`   events: ${result.events.length}; timed: ${timed.length}`);
     for (const e of timed.slice(0, 8)) {
-      console.log(`   • ${e.date} ${e.startTime}${e.endTime ? `–${e.endTime}` : ""}  ${e.title ?? ""}`);
+      const endPart = e.endTime ? `–${e.endTime}` : "";
+      console.log(`   • ${e.date} ${e.startTime}${endPart}  ${e.title ?? ""}`);
     }
     const turkey = result.events.find((e) => /turkey puke/i.test(e.title ?? ""));
-    console.log(`   Turkey Puke: ${turkey ? `${turkey.date} ${turkey.startTime} (expect ~12:00 MST)` : "not in window"}`);
+    const turkeyInfo = turkey ? `${turkey.date} ${turkey.startTime} (expect ~12:00 MST)` : "not in window";
+    console.log(`   Turkey Puke: ${turkeyInfo}`);
   }
 
   // ── #2133 Aloha hares: recurring (365) vs wide (9999) fill rate ──

--- a/scripts/live-verify-gcal-round3.ts
+++ b/scripts/live-verify-gcal-round3.ts
@@ -4,7 +4,7 @@
  * Hits each affected calendar's public API with the freshly-edited adapter +
  * seed config and reports a verification digest per source.
  *
- * Run: `set -a && source /Users/johnclem/Developer/hashtracks-web/.env && set +a && npx tsx scripts/live-verify-gcal-round3.ts`
+ * Run: `set -a && source .env && set +a && npx tsx scripts/live-verify-gcal-round3.ts`
  *
  * Read-only — does not mutate the DB.
  */
@@ -21,12 +21,14 @@ function pctHares(events: RawEventData[]): string {
 }
 
 function tagCounts(events: RawEventData[]): Record<string, number> {
-  const m: Record<string, number> = {};
+  // Map (not a plain object) avoids prototype-pollution / object-injection if a
+  // kennel tag is ever "__proto__"/"constructor" from an uncleaned GCal summary.
+  const m = new Map<string, number>();
   for (const e of events) {
     const tag = e.kennelTags[0] ?? "(none)";
-    m[tag] = (m[tag] ?? 0) + 1;
+    m.set(tag, (m.get(tag) ?? 0) + 1);
   }
-  return m;
+  return Object.fromEntries(m);
 }
 
 async function fetchSource(adapter: GoogleCalendarAdapter, name: string, days: number) {

--- a/scripts/reset-aloha-hares-baseline.ts
+++ b/scripts/reset-aloha-hares-baseline.ts
@@ -1,0 +1,47 @@
+/**
+ * One-shot: set `Source.baselineResetAt = NOW()` on "Aloha H3 Google Calendar"
+ * to resolve the FIELD_FILL_DROP hares alert (#2133, 71% → 15%, −56pp).
+ *
+ * Verdict: metric false-positive (dilution), NOT a real regression. Cycle-23's
+ * Aloha wide-window backfill (#2093, the PHH "Pau Hana Hui" routing widen) pulled
+ * the full 2011→present archive via a one-shot `days: 9999` pass. That single
+ * scrape recorded a fill rate over the entire archive — most historical events
+ * (esp. the bare "Pau Hana Hui" socials) carry no hares — which tripped the
+ * rolling-baseline FIELD_FILL_DROP comparison.
+ *
+ * Prod-fresh evidence (scripts/live-verify-gcal-round3.ts, this PR):
+ *   • recurring 365-day fetch  → hares fill 71% (99/139)  ← what the 6h cron sees
+ *   • wide 9999-day fetch      → hares fill 15% (384/2564) ← the #2093 dilution
+ * The recurring scrape — the only window that runs on a schedule — is healthy at
+ * 71%, exactly the pre-#2093 baseline. The 15% exists ONLY in the wide archive
+ * pass. So there is no extraction regression; the alert is an artifact of the
+ * one-shot backfill batch.
+ *
+ * Setting the boundary to NOW cuts the rolling baseline so the next scrape sees
+ * no prior rows in window and the FIELD_FILL_DROP comparison short-circuits; the
+ * baseline then re-accumulates around the honest recurring ~71% rate. We do NOT
+ * inject synthesized hare fallbacks — `computeFillRates` runs on `RawEventData`
+ * pre-merge (`src/pipeline/fill-rates.ts`), so padding it would permanently blind
+ * the raw-layer metric to future real source regressions — and we stay out of
+ * `hare-extraction.ts` entirely.
+ *
+ * Usage:
+ *   npx tsx scripts/reset-aloha-hares-baseline.ts                 # dry run (default)
+ *   npx tsx scripts/reset-aloha-hares-baseline.ts --apply         # apply against prod
+ *   npx tsx scripts/reset-aloha-hares-baseline.ts --apply --force # re-set even if already set
+ *
+ * Load env before running (tsx does not auto-load .env):
+ *   set -a && source .env && set +a
+ */
+import "dotenv/config";
+import { SourceType } from "@/generated/prisma/client";
+import { runBaselineReset } from "./lib/reset-baseline";
+
+runBaselineReset({
+  sourceName: "Aloha H3 Google Calendar",
+  sourceType: SourceType.GOOGLE_CALENDAR,
+  alertNumber: 2133,
+}).catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -196,7 +196,10 @@ describe("Princeton NJ Hash Calendar — title from SUMMARY (#2125, reverses #19
       },
       config,
     );
-    expect(result?.kennelTags[0]).not.toBe("princeton-h3");
+    // Passes through verbatim (not dropped, not rerouted to princeton-h3);
+    // downstream kennel resolution is what drops it.
+    expect(result).not.toBeNull();
+    expect(result!.kennelTags[0]).toBe("Summit H3 placeholder");
   });
 });
 

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -153,12 +153,12 @@ describe("Memphis H3 Google Calendar — GyNO routing (#1954)", () => {
 
 // ── Princeton NJ Hash Calendar — placeholder title substitution (#1934) ──
 
-describe("Princeton NJ Hash Calendar — placeholder title (#1934)", () => {
+describe("Princeton NJ Hash Calendar — title from SUMMARY (#2125, reverses #1934)", () => {
   const princetonSource = SOURCES.find((s) => s.name === "Princeton NJ Hash Calendar");
   if (!princetonSource?.config) throw new Error("Princeton NJ Hash Calendar seed config missing");
   const config = princetonSource.config as Parameters<typeof buildRawEventFromGCalItem>[1];
 
-  it("substitutes the standing schedule-description placeholder with the default title", () => {
+  it("surfaces the real GCal SUMMARY as the title (no staleTitleAliases substitution)", () => {
     const result = buildRawEventFromGCalItem(
       {
         summary: "Regular Hash Day, 2nd Sunday, detail cuming",
@@ -168,7 +168,94 @@ describe("Princeton NJ Hash Calendar — placeholder title (#1934)", () => {
       config,
     );
     expect(result?.kennelTags[0]).toBe("princeton-h3");
-    expect(result?.title).toBe("Princeton H3 Hash");
+    expect(result?.title).toBe("Regular Hash Day, 2nd Sunday, detail cuming");
+  });
+
+  it("still routes MDL Hash events to princeton-h3 with their own title", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "MDL Hash (4th Sunday except when it is 3rd Sunday or other)",
+        start: { dateTime: "2026-06-28T14:00:00-04:00" },
+        status: "confirmed",
+      },
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe("princeton-h3");
+    expect(result?.title).toContain("MDL Hash");
+  });
+
+  it("does not route unmatched Summit/Rumson placeholder events to princeton-h3 (defaultKennelTag: null)", () => {
+    // With kennelPatterns set + a null default, an unmatched summary passes
+    // through verbatim as its own tag (kennel resolution then drops it
+    // downstream — no Princeton attribution).
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "Summit H3 placeholder",
+        start: { dateTime: "2026-06-21T14:00:00-04:00" },
+        status: "confirmed",
+      },
+      config,
+    );
+    expect(result?.kennelTags[0]).not.toBe("princeton-h3");
+  });
+});
+
+// ── MoA2H3 Google Calendar sister-kennel routing (#1738) ──
+
+describe("MoA2H3 Google Calendar — sister-kennel routing (#1738)", () => {
+  const moaSource = SOURCES.find((s) => s.name === "MoA2H3 Google Calendar");
+  if (!moaSource?.config) throw new Error("MoA2H3 Google Calendar seed config missing");
+  const config = moaSource.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it.each([
+    // [summary, expected kennelTag, description]
+    ["DeMonH3 - Belle Isle Be Damned", "demon-h3", "DeMonH3 glued form"],
+    ["DeMonH3 Inaugural Trail", "demon-h3", "DeMonH3 inaugural"],
+    ["DeMon H3 Monday Run", "demon-h3", "DeMon H3 spaced form"],
+    ["GLH3 HashMas", "glh3", "GLH3 token"],
+    ["Greater Lansing H3 Holiday Trail", "glh3", "Greater Lansing full name"],
+    ["MoA2H3 Red Dress Run", "moa2h3", "host run falls through to default"],
+    ["MoA2H3 MoA2H3 Red Dress Run", "moa2h3", "doubled-prefix host run still routes to host"],
+  ])("routes %j → %s (%s)", (summary, expectedTag) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2025-11-24T18:30:00-05:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe(expectedTag);
+  });
+
+  it("links the sister kennels to the source so the merge guard passes (no SOURCE_KENNEL_MISMATCH)", () => {
+    expect(moaSource.kennelCodes).toEqual(
+      expect.arrayContaining(["moa2h3", "demon-h3", "glh3"]),
+    );
+  });
+});
+
+// ── BJH3 Google Calendar timezone normalization (#775) ──
+
+describe("BJH3 Google Calendar — El Paso (Mountain) timezone normalization (#775)", () => {
+  const bjSource = SOURCES.find((s) => s.name === "BJH3 Google Calendar");
+  if (!bjSource?.config) throw new Error("BJH3 Google Calendar seed config missing");
+  const config = bjSource.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it("pins the El Paso IANA zone in the seed config", () => {
+    expect((config as { timezone?: string }).timezone).toBe("America/Denver");
+  });
+
+  it("normalizes a UTC dateTime authored elsewhere to El Paso wall-clock (the Turkey Puke EST outlier)", () => {
+    // 2025-11-28 (MST, UTC-7): 19:00Z → 12:00 local; 21:00Z → 14:00 local.
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "EPH3 Turkey Puke Hash",
+        start: { dateTime: "2025-11-28T19:00:00Z" },
+        end: { dateTime: "2025-11-28T21:00:00Z" },
+        status: "confirmed",
+      },
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe("bjh3");
+    expect(result?.startTime).toBe("12:00");
+    expect(result?.endTime).toBe("14:00");
   });
 });
 

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -457,10 +457,13 @@ export default async function EventDetailPage({
                 )}
                 {event.startTime && (
                   <div>
-                    <dt className="text-sm font-medium text-muted-foreground">Start Time</dt>
+                    <dt className="text-sm font-medium text-muted-foreground">
+                      {event.endTime ? "Time" : "Start Time"}
+                    </dt>
                     <dd className="mt-0.5">
                       <EventTimeDisplay
                         startTime={event.startTime}
+                        endTime={event.endTime}
                         date={event.date.toISOString()}
                         timezone={event.timezone}
                       />

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -47,6 +47,9 @@ export interface HarelineListEvent {
   title: string | null;
   haresText: string | null;
   startTime: string | null;
+  /** #2135 — local end time "HH:MM" (same convention as startTime); null when
+   *  the source has no DTEND or the run wraps past midnight. */
+  endTime: string | null;
   locationName: string | null;
   locationCity: string | null;
   status: string;
@@ -249,6 +252,7 @@ const fetchSlimEventsCached = unstable_cache(
         eventLabel: true,
         haresText: true,
         startTime: true,
+        endTime: true,
         locationName: true,
         locationCity: true,
         status: true,
@@ -336,6 +340,7 @@ const fetchSlimEventsCached = unstable_cache(
       eventLabel: e.eventLabel,
       haresText: e.haresText,
       startTime: e.startTime,
+      endTime: e.endTime,
       locationName: e.locationName,
       locationCity: e.locationCity,
       status: e.status,

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -215,6 +215,7 @@ export default async function KennelDetailPage({
     eventLabel: e.eventLabel,
     haresText: e.haresText,
     startTime: e.startTime,
+    endTime: e.endTime,
     locationName: e.locationName,
     locationStreet: e.locationStreet,
     locationCity: e.locationCity,

--- a/src/components/hareline/EventCard.test.ts
+++ b/src/components/hareline/EventCard.test.ts
@@ -139,3 +139,43 @@ describe("EventCard time derivation — SeaMon stale-dateUtc regression (#1654)"
     expect(tzAbbrev).toBe("");
   });
 });
+
+describe("EventCard endTime range derivation (#2135)", () => {
+  const EDT = "America/New_York";
+  // QCH4 Run #220 — Jun 13 2026, 3:00–7:00 PM Eastern.
+  const QCH4_220 = {
+    date: "2026-06-13T12:00:00.000Z",
+    startTime: "15:00",
+    endTime: "19:00",
+    timezone: EDT,
+    dateUtc: new Date("2026-06-13T19:00:00.000Z"),
+  };
+
+  it("renders a start–end range in the event's zone", () => {
+    const { displayTimeStr, endTimeStr, tzAbbrev } = computeDisplayTime(QCH4_220, EDT);
+    expect(displayTimeStr).toBe("3:00 PM");
+    expect(endTimeStr).toBe("7:00 PM");
+    expect(tzAbbrev).toBe("EDT");
+  });
+
+  it("leaves endTimeStr null when there is no endTime (negative case)", () => {
+    const startOnly = { ...QCH4_220, endTime: null };
+    const { displayTimeStr, endTimeStr } = computeDisplayTime(startOnly, EDT);
+    expect(displayTimeStr).toBe("3:00 PM");
+    expect(endTimeStr).toBeNull();
+  });
+
+  it("does not render an endTime when the start time is absent", () => {
+    const endNoStart = { ...QCH4_220, startTime: null };
+    const { displayTimeStr, endTimeStr } = computeDisplayTime(endNoStart, EDT);
+    expect(displayTimeStr).toBeNull();
+    expect(endTimeStr).toBeNull();
+  });
+
+  it("formats endTime via plain HH:MM fallback when timezone is missing", () => {
+    const noTz = { ...QCH4_220, timezone: null, dateUtc: null };
+    const { displayTimeStr, endTimeStr } = computeDisplayTime(noTz, EDT);
+    expect(displayTimeStr).toBe("3:00 PM");
+    expect(endTimeStr).toBe("7:00 PM");
+  });
+});

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -306,7 +306,12 @@ function buildAriaLabel(event: HarelineEvent, attendance?: AttendanceData | null
   // (per claude[bot] PR #1566 review).
   parts.push(computeChipDate(event));
   if (event.runNumber) parts.push(`Run #${event.runNumber}`);
-  if (event.startTime) parts.push(formatTime(event.startTime));
+  // #2135 — voice the full start–end range so screen readers reach parity with
+  // the visually-rendered "3:00 PM – 7:00 PM".
+  if (event.startTime) {
+    const startStr = formatTime(event.startTime);
+    parts.push(event.endTime ? `${startStr} to ${formatTime(event.endTime)}` : startStr);
+  }
   // #1316 — surface card-visible structured fields to screen readers.
   if (event.trailType) parts.push(`Trail type ${event.trailType}`);
   if (event.dogFriendly === true) parts.push("dog friendly");

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -10,13 +10,13 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { formatTime, formatDateRange } from "@/lib/format";
+import { formatTime, formatTimeRange, formatDateRange } from "@/lib/format";
 import { AttendanceBadge } from "@/components/logbook/AttendanceBadge";
 import type { AttendanceData } from "@/components/logbook/CheckInButton";
 import { RegionBadge } from "./RegionBadge";
 import { useTimePreference } from "@/components/providers/time-preference-provider";
 import { getRegionColor } from "@/lib/region";
-import { composeUtcStart, formatTimeInZone, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
+import { composeUtcStart, formatTimeInZone, formatLocalTimeForDisplay, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
 import { useUnitsPreference } from "@/components/providers/units-preference-provider";
 import type { DailyWeather } from "@/lib/weather";
 import { getConditionEmoji, cToF } from "@/lib/weather-display";
@@ -69,6 +69,9 @@ export type HarelineEvent = {
   eventLabel?: string | null;
   haresText: string | null;
   startTime: string | null;
+  /** #2135 — local end time "HH:MM" (same convention as startTime); null when
+   *  the source has no DTEND or the run wraps past midnight. */
+  endTime?: string | null;
   locationName: string | null;
   locationCity: string | null;
   status: string;
@@ -194,9 +197,9 @@ export function computeChipDate(event: { date: string }): string {
  * renders.
  */
 export function computeDisplayTime(
-  event: { date: string; startTime: string | null; timezone: string | null; dateUtc: Date | null },
+  event: { date: string; startTime: string | null; endTime?: string | null; timezone: string | null; dateUtc: Date | null },
   displayTz: string,
-): { displayTimeStr: string | null; tzAbbrev: string } {
+): { displayTimeStr: string | null; endTimeStr: string | null; tzAbbrev: string } {
   const composedAnchor =
     event.startTime && event.timezone
       ? composeUtcStart(new Date(event.date), event.startTime, event.timezone)
@@ -208,8 +211,13 @@ export function computeDisplayTime(
   } else if (event.startTime) {
     displayTimeStr = formatTime(event.startTime);
   }
+  // #2135 — only render an end time alongside a shown start time.
+  const endTimeStr =
+    displayTimeStr && event.endTime
+      ? formatLocalTimeForDisplay(event.date, event.endTime, event.timezone, displayTz)
+      : null;
   const tzAbbrev = timeAnchor ? getTimezoneAbbreviation(timeAnchor, displayTz) : "";
-  return { displayTimeStr, tzAbbrev };
+  return { displayTimeStr, endTimeStr, tzAbbrev };
 }
 
 /**
@@ -358,7 +366,7 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
   const rangeDisplay = isMultiDay ? formatDateRange(event.date, event.endDate) : displayDateStr;
   const [seriesExpanded, setSeriesExpanded] = useState(false);
 
-  const { displayTimeStr, tzAbbrev } = computeDisplayTime(event, displayTz);
+  const { displayTimeStr, endTimeStr, tzAbbrev } = computeDisplayTime(event, displayTz);
 
   function handleClick() {
     // On desktop (lg+), select the event for the detail panel
@@ -520,7 +528,7 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
 
             {displayTimeStr && (
               <span className="flex items-center gap-1 text-xs font-semibold tabular-nums text-foreground/70" suppressHydrationWarning>
-                {displayTimeStr}
+                {formatTimeRange(displayTimeStr, endTimeStr)}
                 {tzAbbrev && <span className="text-[10px] font-medium opacity-60" suppressHydrationWarning>{tzAbbrev}</span>}
               </span>
             )}
@@ -699,7 +707,7 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
                 suppressHydrationWarning
               >
                 <Clock className="h-3 w-3 text-muted-foreground/40" />
-                <span className="text-sm font-bold tabular-nums text-foreground/85">{displayTimeStr}</span>
+                <span className="text-sm font-bold tabular-nums text-foreground/85">{formatTimeRange(displayTimeStr, endTimeStr)}</span>
                 {tzAbbrev && (
                   <span className="text-[10px] text-muted-foreground/40 font-semibold" suppressHydrationWarning>
                     {tzAbbrev}

--- a/src/components/hareline/EventDetailPanel.tsx
+++ b/src/components/hareline/EventDetailPanel.tsx
@@ -10,13 +10,14 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { formatTime, formatDateLong, formatDateRange, getLabelForUrl, stripMarkdown, stripUrlsFromText } from "@/lib/format";
+import { formatTimeRange, formatDateLong, formatDateRange, getLabelForUrl, stripMarkdown, stripUrlsFromText } from "@/lib/format";
 import { getFullLocationDisplay } from "@/lib/event-display";
 import type { HarelineEvent } from "./EventCard";
+import { computeDisplayTime } from "./EventCard";
 import { SeriesChildTimeline } from "./SeriesChildTimeline";
 import { ShiggyLevelFlames, TrailLengthLine, formatTrailLength } from "./TrailDifficulty";
 import { useTimePreference } from "@/components/providers/time-preference-provider";
-import { formatTimeInZone, getTimezoneAbbreviation, getBrowserTimezone } from "@/lib/timezone";
+import { getBrowserTimezone } from "@/lib/timezone";
 import { CheckInButton } from "@/components/logbook/CheckInButton";
 import type { AttendanceData } from "@/components/logbook/CheckInButton";
 import { CalendarExportButton } from "./CalendarExportButton";
@@ -78,13 +79,10 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
   // #1522). Time line below still uses `displayTz`. (#1502)
   const displayDateStr = computeHeadingDate(event);
 
-  const displayTimeStr = (event.dateUtc && event.startTime)
-    ? formatTimeInZone(event.dateUtc, displayTz)
-    : (event.startTime ? formatTime(event.startTime) : null);
-
-  const tzAbbrev = (event.dateUtc && event.startTime)
-    ? getTimezoneAbbreviation(event.dateUtc, displayTz)
-    : "";
+  // #2135 — reuse the card's canonical time derivation so the start anchor
+  // recomposes from startTime+timezone (#1654) and the start/end range share
+  // one anchor (avoids a stale-dateUtc start paired with a recomposed end).
+  const { displayTimeStr, endTimeStr, tzAbbrev } = computeDisplayTime(event, displayTz);
 
   const regionColor = event.kennel?.region ? getRegionColor(event.kennel.region) : "#6b7280";
   const trailLengthDisplay = formatTrailLength(event);
@@ -235,9 +233,9 @@ export function EventDetailPanel({ event, attendance, isAuthenticated, onDismiss
           )}
           {displayTimeStr && (
             <div>
-              <dt className="font-medium text-muted-foreground">Start Time</dt>
+              <dt className="font-medium text-muted-foreground">{endTimeStr ? "Time" : "Start Time"}</dt>
               <dd className="flex items-center gap-1" suppressHydrationWarning>
-                {displayTimeStr}
+                {formatTimeRange(displayTimeStr, endTimeStr)}
                 {tzAbbrev && <span className="text-xs font-medium opacity-70" suppressHydrationWarning>{tzAbbrev}</span>}
               </dd>
             </div>

--- a/src/components/hareline/EventTimeDisplay.tsx
+++ b/src/components/hareline/EventTimeDisplay.tsx
@@ -24,7 +24,7 @@ interface EventTimeDisplayProps {
  * Respects the user's time preference (event local vs. browser local).
  * Falls back to plain HH:MM AM/PM formatting if timezone data is unavailable.
  */
-export function EventTimeDisplay({ startTime, endTime, date, timezone }: EventTimeDisplayProps) {
+export function EventTimeDisplay({ startTime, endTime, date, timezone }: Readonly<EventTimeDisplayProps>) {
   const { preference } = useTimePreference();
   const isUserLocal = preference === "USER_LOCAL";
   const displayTz = isUserLocal ? getBrowserTimezone() : (timezone ?? null);

--- a/src/components/hareline/EventTimeDisplay.tsx
+++ b/src/components/hareline/EventTimeDisplay.tsx
@@ -4,24 +4,27 @@ import { useTimePreference } from "@/components/providers/time-preference-provid
 import {
   composeUtcStart,
   formatTimeInZone,
+  formatLocalTimeForDisplay,
   getTimezoneAbbreviation,
   getBrowserTimezone,
 } from "@/lib/timezone";
-import { formatTime } from "@/lib/format";
+import { formatTime, formatTimeRange } from "@/lib/format";
 
 interface EventTimeDisplayProps {
   startTime: string;
+  /** #2135 — local end time "HH:MM"; renders a "start – end" range when present. */
+  endTime?: string | null;
   /** ISO string of the event date (UTC noon, e.g. event.date.toISOString()) */
   date: string;
   timezone: string | null;
 }
 
 /**
- * Timezone-aware start time display for event detail pages.
+ * Timezone-aware start (and optional end) time display for event detail pages.
  * Respects the user's time preference (event local vs. browser local).
  * Falls back to plain HH:MM AM/PM formatting if timezone data is unavailable.
  */
-export function EventTimeDisplay({ startTime, date, timezone }: EventTimeDisplayProps) {
+export function EventTimeDisplay({ startTime, endTime, date, timezone }: EventTimeDisplayProps) {
   const { preference } = useTimePreference();
   const isUserLocal = preference === "USER_LOCAL";
   const displayTz = isUserLocal ? getBrowserTimezone() : (timezone ?? null);
@@ -31,12 +34,16 @@ export function EventTimeDisplay({ startTime, date, timezone }: EventTimeDisplay
   const displayTimeStr =
     dateUtc && displayTz ? formatTimeInZone(dateUtc, displayTz) : formatTime(startTime);
 
+  const endTimeStr = endTime
+    ? formatLocalTimeForDisplay(date, endTime, timezone, displayTz)
+    : null;
+
   const tzAbbrev =
     dateUtc && displayTz ? getTimezoneAbbreviation(dateUtc, displayTz) : "";
 
   return (
     <span suppressHydrationWarning>
-      {displayTimeStr}
+      {formatTimeRange(displayTimeStr, endTimeStr)}
       {tzAbbrev && (
         <span className="ml-1 text-sm text-muted-foreground">{tzAbbrev}</span>
       )}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -18,6 +18,16 @@ export function formatTime(time: string): string {
 }
 
 /**
+ * Render an already-formatted start time, optionally as a "start – end" range
+ * (#2135). Shared by the event card, detail panel, and full detail page so the
+ * range punctuation stays consistent. `end` is null/empty when the source has
+ * no end time.
+ */
+export function formatTimeRange(start: string, end: string | null): string {
+  return end ? `${start} – ${end}` : start;
+}
+
+/**
  * Parse "HH:MM" into minutes since midnight. Returns null if unparseable
  * or out of range. Promoted from src/lib/strava/match-score.ts so the
  * pipeline can share the same parser without depending on Strava.

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,5 +1,6 @@
 import { tz } from "@date-fns/tz";
 import { format, parse } from "date-fns";
+import { formatTime } from "@/lib/format";
 
 /**
  * Creates an exact global UTC Date representing the start time of an event.
@@ -56,6 +57,23 @@ export function formatTimeInZone(date: Date, timezone: string, fmt = "h:mm a"): 
     } catch {
         return format(date, fmt); // Fallback to system local if error
     }
+}
+
+/**
+ * Format a local "HH:MM" time for display in `displayTz`, anchored to the
+ * event's date. Composes an absolute instant from (date, time, eventTimezone)
+ * and renders it in `displayTz`; falls back to plain HH:MM AM/PM formatting
+ * when timezone data is unavailable. Shared by the card, detail panel, and full
+ * detail page so the start–end range renders consistently (#2135).
+ */
+export function formatLocalTimeForDisplay(
+    dateUtcNoon: string,
+    time: string,
+    eventTimezone: string | null,
+    displayTz: string | null,
+): string {
+    const composed = eventTimezone ? composeUtcStart(new Date(dateUtcNoon), time, eventTimezone) : null;
+    return composed && displayTz ? formatTimeInZone(composed, displayTz) : formatTime(time);
 }
 
 /**


### PR DESCRIPTION
Google-Calendar polish round 3 — 5 issues. Owns `src/adapters/google-calendar/adapter.ts` + its test and the GCal config rows for MoA2H3 / BJH3 / Princeton / QCH4 / Aloha.

## Fixes

### #2135 — QCH4 endTime not displayed
The adapter **already** extracts `endTime` from DTEND and stores it on `Event` (wired in #503/#504/#1401, tested) — it was simply never rendered. This wires it into the hareline serializers (`actions.ts`, kennel page, full detail page) and renders a **"start – end"** range in `EventCard`, `EventDetailPanel`, and `EventTimeDisplay`.
- New shared helpers: `formatLocalTimeForDisplay` (`timezone.ts`) + `formatTimeRange` (`format.ts`).
- **Additive**: the ~40 GCal sources without DTEND render exactly as before (live-verified a start-only event still shows "Start Time · 5:30 PM EDT").
- `EventDetailPanel` now reuses `EventCard.computeDisplayTime`, fixing a latent #1654 mismatch (start was anchored on stale `dateUtc` while the new end recomposed from `startTime+timezone`).
- Live proof (prod data): QCH4 #220 renders **"Time · 3:00 PM – 7:00 PM EDT"**.

### #1738 — MoA2H3 sister-kennel events not routed
The 3 DeMon/GLH3 events on the MoA2H3 calendar were silently skipped (#1739). Now routed via `kennelPatterns` to `demon-h3`/`glh3`, with both added to `kennelCodes` so the merge source-kennel guard passes (no `SOURCE_KENNEL_MISMATCH` refire). Sister sources stay at `scrapeDays:90`, so no duplicate Events. Live-verified: `{moa2h3:63, glh3:1, demon-h3:2}` — exactly the 3 issue events route correctly.

### #2125 — Princeton "Regular Hash" stale default title
Removed `staleTitleAliases` so the real GCal SUMMARY ("Regular Hash Day, 2nd Sunday, detail cuming") surfaces as the title (reverses the #1934 substitution per the user's newer request; cf. #2046 C2H3 precedent). Live-verified the real titles now appear.

### #775 — BJH3 "2:00 PM EST" (El Paso is Mountain)
Pinned `timezone:"America/Denver"` so any timed event authored in another zone normalizes to El Paso wall-clock. The reported "Turkey Puke" event has already self-healed in prod (stored `14:00` / `dateUtc 21:00Z` / `America/Denver` → renders **2:00 PM MST**); BJH3's region timezone is already Mountain, so the display is correct. The config hardens against recurrence of the cross-timezone authoring bug.

### #2133 — Aloha hares 71% → 15% (−56pp)
**Metric false-positive**, decided on evidence: the recurring 365-day scrape (what the 6h cron runs) is **71%** healthy; the 15% appears **only** in the #2093 one-shot wide-archive backfill (2,564 events, many historical hare-less "Pau Hana Hui" socials). Resolved via `Source.baselineResetAt` (`scripts/reset-aloha-hares-baseline.ts`), **not** an adapter change — `hare-extraction.ts` untouched, no synthesized fallbacks.

## Verification
- Live-verified all five against the production calendars (`scripts/live-verify-gcal-round3.ts`).
- `npm run lint` (0 errors), `npx tsc --noEmit`, and `npm test` (8982 passed) all green.
- `/codex` adversarial review (caught + fixed the EventDetailPanel anchor mismatch) and `/simplify` (extracted `formatTimeRange`) applied.

## Post-merge
- Run `npx tsx scripts/reset-aloha-hares-baseline.ts --apply` against prod (alert #2133 auto-resolves next scrape).
- Re-scrape MoA2H3 so the sisters surface on `/kennels/demon-h3` + `/kennels/glh3`, then resolve alert `cmpo55i120034h4hnpbcazghw`.

## Notes
- #2135's display touches WS2-owned files (`src/components/hareline/**`, kennel/detail pages) — user explicitly authorized crossing that boundary; edits kept minimal and additive.

Closes #2135
Closes #1738
Closes #2125
Closes #775
Closes #2133

🤖 Generated with [Claude Code](https://claude.com/claude-code)