### PR TITLE
fix(hashrego,hockessin): NFL-Draft per-day schedule tabs + SAH3 title + Hockessin dup-run# (#875, #1460, #1748)

### DIFF
--- a/scripts/heal-sah3-title.ts
+++ b/scripts/heal-sah3-title.ts
@@ -1,0 +1,93 @@
+/**
+ * One-shot HEAL for the San Antonio H3 stale title (#1460).
+ *
+ * SAH3's hashrego event was registered with a doubled kennel prefix, so its
+ * URL slug is "sah3-sah3-2026". A scrape taken BEFORE the kennel renamed the
+ * event (and before the #1669 doubled-prefix guard landed) captured the
+ * slug-shaped title "SAH3 SAH3 2026" onto the canonical Event.
+ *
+ * The adapter already reads the real title from og:title — the live page now
+ * serves "06/19 SAH3 Summer Campout 2026", which the parser strips to
+ * "SAH3 Summer Campout 2026". So the CODE is correct; only the already-persisted
+ * canonical row is stale. A future scrape would heal it, but we don't want to
+ * wait — this script repairs the persisted value in place.
+ *
+ * Safety:
+ *   - Drift guard: only updates Events whose title is the stale slug shape
+ *     ("SAH3 SAH3 …"); idempotent no-op (exit 0) once healed.
+ *   - Scoped to the SAH3 kennel (kennelCode "sah3") via EventKennel.
+ *   - Dry run unless HEAL_APPLY=1.
+ *   - Post-check verifies no stale titles remain.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/heal-sah3-title.ts
+ *   Apply:   HEAL_APPLY=1 npx tsx scripts/heal-sah3-title.ts
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+
+const LOG_PREFIX = "heal-sah3-title";
+const KENNEL_CODE = "sah3";
+const STALE_TITLE_PREFIX = "SAH3 SAH3";
+const HEALED_TITLE = "SAH3 Summer Campout 2026";
+
+const log = (m: string) => console.log(`[${LOG_PREFIX}] ${m}`);
+
+async function main(apply: boolean): Promise<void> {
+  log(`${apply ? "APPLY" : "DRY-RUN"} — heal stale "${STALE_TITLE_PREFIX} …" titles for kennel "${KENNEL_CODE}"`);
+
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: KENNEL_CODE },
+    select: { id: true },
+  });
+  if (!kennel) throw new Error(`Kennel not found: kennelCode="${KENNEL_CODE}"`);
+
+  // Events linked to SAH3 whose title is the stale slug shape.
+  const stale = await prisma.event.findMany({
+    where: {
+      title: { startsWith: STALE_TITLE_PREFIX },
+      eventKennels: { some: { kennelId: kennel.id } },
+    },
+    select: { id: true, title: true, dateUtc: true },
+  });
+
+  if (stale.length === 0) {
+    log("No stale titles found — already healed (no-op).");
+    return;
+  }
+
+  for (const e of stale) {
+    const day = e.dateUtc ? e.dateUtc.toISOString().slice(0, 10) : "no-date";
+    log(`  stale Event ${e.id} (${day}): "${e.title}" → "${HEALED_TITLE}"`);
+  }
+
+  if (!apply) {
+    log(`DRY-RUN — would update ${stale.length} Event(s). Re-run with HEAL_APPLY=1 to apply.`);
+    return;
+  }
+
+  const result = await prisma.event.updateMany({
+    where: {
+      id: { in: stale.map((e) => e.id) },
+      title: { startsWith: STALE_TITLE_PREFIX },
+    },
+    data: { title: HEALED_TITLE },
+  });
+  log(`Updated ${result.count} Event(s).`);
+
+  const remaining = await prisma.event.count({
+    where: {
+      title: { startsWith: STALE_TITLE_PREFIX },
+      eventKennels: { some: { kennelId: kennel.id } },
+    },
+  });
+  if (remaining !== 0) throw new Error(`Post-check failed: ${remaining} stale title(s) still present`);
+  log("Post-check OK — no stale titles remain.");
+}
+
+main(process.env.HEAL_APPLY === "1")
+  .catch((err) => {
+    console.error(`[${LOG_PREFIX}] FAILED:`, err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { load as cheerioLoad } from "cheerio";
 import {
   parseEventsIndex,
   parseKennelEventsPage,
@@ -7,6 +8,7 @@ import {
   parseEventDetail,
   splitToRawEvents,
   parseDayHeaderSections,
+  parseScheduleTabs,
   detectVenueWeekendEndDate,
   stripDoubledKennelPrefix,
   type ParsedEvent,
@@ -529,6 +531,39 @@ describe("parseEventDetail", () => {
   it("extracts kennel slug from sidebar link", () => {
     const parsed = parseEventDetail(SINGLE_DAY_HTML, "bfmh3-agm-2026", BFMH3_INDEX_ENTRY);
     expect(parsed.kennelSlug).toBe("BFMH3");
+  });
+
+  it("#1460: title comes from og:title, never the URL slug", () => {
+    // San Antonio H3's hashrego slug carries a doubled kennel prefix
+    // ("sah3-sah3-2026") because the event was registered with a doubled
+    // name. A naive slug→title-case would yield "SAH3 SAH3 2026". The adapter
+    // must instead read the real event title from og:title. The #1669
+    // doubled-prefix stripper is a NO-OP here because the real title's second
+    // token ("Summer") isn't a repeat of the kennel code.
+    const html = `
+<html>
+<head>
+  <title>SAH3 Summer Campout 2026</title>
+  <meta property="og:title" content="06/19 SAH3 Summer Campout 2026" />
+  <meta property="og:description" content='SAH3 Campout' />
+</head>
+<body>
+  <a href="/kennels/SAH3/">SAH3</a>
+</body>
+</html>`;
+    const entry = {
+      slug: "sah3-sah3-2026",
+      kennelSlug: "SAH3",
+      title: "SAH3 SAH3 2026", // slug-derived index title — must NOT win
+      startDate: "06/19/26",
+      startTime: "",
+      type: "Hash Campout",
+      cost: "",
+    };
+
+    const parsed = parseEventDetail(html, "sah3-sah3-2026", entry);
+    expect(parsed.title).toBe("SAH3 Summer Campout 2026");
+    expect(parsed.title).not.toContain("SAH3 SAH3");
   });
 
   it("extracts hares", () => {
@@ -1085,6 +1120,166 @@ Recovery day.' />
     expect(events[0].date).toBe("2026-06-26");
     // No duplicate Day 1 row.
     expect(events.filter((e) => e.date === "2026-06-26")).toHaveLength(1);
+  });
+});
+
+// #875 — PGH H3 NFL Draft Hash Weekend. Per-day venue/hares live in a
+// `div.schedule` tab block in the page BODY (one `.tab-pane` per weekday), NOT
+// in og:description (which carries only the umbrella blurb). Trimmed from the
+// live page (hashrego.com/events/nfl-draft-hash-weekend-spectacular-2026,
+// verified 2026-06-11), preserving the messy nested `<p><p><p>` markup.
+const NFL_DRAFT_HTML = `
+<html>
+<head>
+  <title>NFL Draft Hash Weekend Spectacular 2026</title>
+  <meta property="og:title" content="04/22 NFL Draft Hash Weekend Spectacular 2026" />
+  <meta property="og:description" content='The NFL draft is happening in Pittsburgh and all the kennels are coming together. Your rego includes all the events listed in the tabs below.' />
+</head>
+<body>
+  <a href="/kennels/PGH-H3/">PGH H3</a>
+  <div class="col-sm-6 schedule">
+    <h4 class="text-center"><strong>Schedule of Events</strong></h4>
+    <ul class="nav nav-tabs" role="tablist">
+      <li class="active"><a href="#schedule-tab-2895" role="tab" data-toggle="tab">Wednesday</a></li>
+      <li><a href="#schedule-tab-2896" role="tab" data-toggle="tab">Thursday</a></li>
+      <li><a href="#schedule-tab-2897" role="tab" data-toggle="tab">Friday</a></li>
+      <li><a href="#schedule-tab-2898" role="tab" data-toggle="tab">Saturday</a></li>
+      <li><a href="#schedule-tab-2899" role="tab" data-toggle="tab">Sunday</a></li>
+    </ul>
+    <div class="tab-content">
+      <div class="tab-pane active" id="schedule-tab-2895">
+        <p><p><p>Our Darkside H3 kennel will kick things off with a longer harder run. Trail $5 for those who didn't rego for the whole week.</p></p>
+        <p><p>When: 630pm gather 7pm on out<br />Where: Hop's Place<br />3037 Shadeland Ave, Pittsburgh, PA 15212<br />https://maps.app.goo.gl/cSPk3bJunnxN29Xu8</p><br /></p></p>
+      </div>
+      <div class="tab-pane" id="schedule-tab-2896">
+        <p><p><p>Pittsburgh Inebriated Thirsty Thursday (PITT) H3 will take us on a scenic jaunt. Trail $5 for those who didn't rego for the whole week.</p></p>
+        <p><p>When: 630pm gather 7pm on out<br />Where: Burghers at the Highline<br />46 S 4th St, Pittsburgh, PA 15219</p><br /></p></p>
+      </div>
+      <div class="tab-pane" id="schedule-tab-2897">
+        <p><p><p>Tn@ H3 our ladies and non-binary kennel will be hosting an all gender run. Trail $5 for those who didn't rego for the whole week.</p></p>
+        <p><p>When: 630pm gather 7pm on out<br />Where: Lorelei<br />124 S Highland Ave, Pittsburgh, PA 15206</p></p>
+        <p><p>After Party:<br />6391 Stanton Ave</p><br /></p></p>
+      </div>
+      <div class="tab-pane" id="schedule-tab-2898">
+        <p><p><p>PGH H3 the kennel you all know and love will be hosting a chaotic hash through the draft.</p></p>
+        <p><p>When: 630pm gather 7pm on out<br />Where: The YMR<br />631 Suismon St, Pittsburgh, PA 15212</p><br /></p></p>
+      </div>
+      <div class="tab-pane" id="schedule-tab-2899">
+        <p><p><p>Recovery brunch and farewells. Details on Discord.</p></p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>`;
+
+const NFL_DRAFT_INDEX_ENTRY = {
+  slug: "nfl-draft-hash-weekend-spectacular-2026",
+  kennelSlug: "PGH-H3",
+  title: "NFL Draft Hash Weekend Spectacular 2026",
+  startDate: "04/22/26", // Wednesday
+  startTime: "06:30 PM",
+  type: "Hash Weekend",
+  cost: "$85",
+};
+
+describe("parseScheduleTabs (#875)", () => {
+  it("extracts per-day venue / street / maps / hares from schedule tabs", () => {
+    const $ = cheerioLoad(NFL_DRAFT_HTML);
+    const tabs = parseScheduleTabs($);
+    expect(tabs.map((t) => t.weekday)).toEqual([
+      "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+    ]);
+    expect(tabs[0]).toMatchObject({
+      venue: "Hop's Place",
+      address: "3037 Shadeland Ave, Pittsburgh, PA 15212",
+      mapsUrl: "https://maps.app.goo.gl/cSPk3bJunnxN29Xu8",
+      startTime: "18:30",
+      hares: "Darkside H3",
+    });
+    // Parenthesized acronym immediately before the suffix wins ("(PITT) H3").
+    expect(tabs[1].hares).toBe("PITT H3");
+    expect(tabs[1].venue).toBe("Burghers at the Highline");
+    expect(tabs[1].mapsUrl).toBeUndefined();
+    // Special-char kennel token survives.
+    expect(tabs[2].hares).toBe("Tn@ H3");
+    expect(tabs[2].venue).toBe("Lorelei");
+    // First address after `Where:` wins — the After-Party line is ignored.
+    expect(tabs[2].address).toBe("124 S Highland Ave, Pittsburgh, PA 15206");
+    expect(tabs[3].hares).toBe("PGH H3");
+    expect(tabs[3].venue).toBe("The YMR");
+    // Sunday tab has no When/Where/H3 → all fields undefined (no leakage).
+    expect(tabs[4].venue).toBeUndefined();
+    expect(tabs[4].hares).toBeUndefined();
+  });
+});
+
+describe("parseEventDetail + splitToRawEvents — NFL Draft schedule tabs (#875)", () => {
+  it("derives the 5 consecutive dates by anchoring weekday tabs to the start date", () => {
+    const parsed = parseEventDetail(
+      NFL_DRAFT_HTML,
+      "nfl-draft-hash-weekend-spectacular-2026",
+      NFL_DRAFT_INDEX_ENTRY,
+    );
+    expect(parsed.isMultiDay).toBe(true);
+    expect(parsed.dates).toEqual([
+      "2026-04-22", "2026-04-23", "2026-04-24", "2026-04-25", "2026-04-26",
+    ]);
+    expect(parsed.endDate).toBe("2026-04-26");
+  });
+
+  it("emits a Day-1 parent + 4 children, each with its own venue/street/hares", () => {
+    const parsed = parseEventDetail(
+      NFL_DRAFT_HTML,
+      "nfl-draft-hash-weekend-spectacular-2026",
+      NFL_DRAFT_INDEX_ENTRY,
+    );
+    const events = splitToRawEvents(parsed, "nfl-draft-hash-weekend-spectacular-2026");
+    expect(events).toHaveLength(5);
+
+    // Day 1 (Wednesday) doubles as the series parent AND carries Wednesday's
+    // per-day venue/hares (#875) — not just the umbrella defaults.
+    expect(events[0].date).toBe("2026-04-22");
+    expect(events[0].seriesParent).toBe(true);
+    expect(events[0].endDate).toBe("2026-04-26");
+    expect(events[0].title).toBe("NFL Draft Hash Weekend Spectacular 2026");
+    expect(events[0].kennelTags).toEqual(["PGH-H3"]);
+    expect(events[0].location).toBe("Hop's Place");
+    expect(events[0].locationStreet).toBe("3037 Shadeland Ave, Pittsburgh, PA 15212");
+    expect(events[0].locationUrl).toBe("https://maps.app.goo.gl/cSPk3bJunnxN29Xu8");
+    expect(events[0].hares).toBe("Darkside H3");
+    expect(events[0].cost).toBe("$85"); // registration cost on the umbrella only
+
+    // Thursday child.
+    expect(events[1].date).toBe("2026-04-23");
+    expect(events[1].seriesParent).toBeUndefined();
+    expect(events[1].location).toBe("Burghers at the Highline");
+    expect(events[1].locationStreet).toBe("46 S 4th St, Pittsburgh, PA 15219");
+    expect(events[1].hares).toBe("PITT H3");
+    expect(events[1].kennelTags).toEqual(["PGH-H3"]); // host kennel — hares ≠ kennelTag
+    expect(events[1].cost).toBeUndefined(); // not repeated per day
+
+    // Friday + Saturday children.
+    expect(events[2].location).toBe("Lorelei");
+    expect(events[2].hares).toBe("Tn@ H3");
+    expect(events[3].location).toBe("The YMR");
+    expect(events[3].hares).toBe("PGH H3");
+
+    // Sunday child — sparse tab → falls back to whole-event (undefined here).
+    expect(events[4].date).toBe("2026-04-26");
+    expect(events[4].location).toBeUndefined();
+    expect(events[4].hares).toBeUndefined();
+  });
+
+  it("refuses the tab split when the first tab weekday ≠ the index start date", () => {
+    // Guard against a stale/shifted index date: if Day 0's weekday (Wednesday)
+    // doesn't match the indexed start date (here a Tuesday), anchoring the tabs
+    // would pair every day's venue/hares with the wrong date. The parser must
+    // bail to the single indexed event rather than publish misaligned data.
+    const entry = { ...NFL_DRAFT_INDEX_ENTRY, startDate: "04/21/26" }; // Tuesday
+    const parsed = parseEventDetail(NFL_DRAFT_HTML, NFL_DRAFT_INDEX_ENTRY.slug, entry);
+    expect(parsed.isMultiDay).toBe(false);
+    expect(parsed.dates).toEqual(["2026-04-21"]);
+    expect(parsed.perDayLocations).toBeUndefined();
   });
 });
 

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -1211,6 +1211,36 @@ describe("parseScheduleTabs (#875)", () => {
     expect(tabs[4].venue).toBeUndefined();
     expect(tabs[4].hares).toBeUndefined();
   });
+
+  it("takes the maps URL from the anchor href, skips a When: line after Where:, and handles hyphenated paren codes", () => {
+    // Edge cases flagged in review: (1) maps link wrapped in <a> (text-stripped
+    // → only the href survives); (2) `When:` follows `Where:` and carries a digit
+    // that must NOT be mistaken for the address; (3) a hyphenated kennel code in
+    // the paren-acronym position.
+    const html = `
+<div class="schedule">
+  <ul class="nav-tabs">
+    <li><a>Saturday</a></li>
+    <li><a>Sunday</a></li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane">
+      <p>The (D-Bag) H3 will host tonight.</p>
+      <p>Where: The Pub<br />When: 6:30 PM<br />100 Main St, Town, PA 19000<br /><a href="https://maps.app.goo.gl/abc123">Get Directions</a></p>
+    </div>
+    <div class="tab-pane">
+      <p>Recovery brunch.</p>
+    </div>
+  </div>
+</div>`;
+    const tabs = parseScheduleTabs(cheerioLoad(html));
+    expect(tabs[0]).toMatchObject({
+      venue: "The Pub",
+      address: "100 Main St, Town, PA 19000", // NOT "When: 6:30 PM"
+      mapsUrl: "https://maps.app.goo.gl/abc123", // from href, not body text
+      hares: "D-Bag H3", // hyphenated paren acronym
+    });
+  });
 });
 
 describe("parseEventDetail + splitToRawEvents — NFL Draft schedule tabs (#875)", () => {

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -1,7 +1,7 @@
 import * as cheerio from "cheerio";
 import isSafeRegex from "safe-regex2";
 import type { RawEventData } from "../types";
-import { normalizeCostSigil } from "../utils";
+import { normalizeCostSigil, parse12HourTime, stripHtmlTags } from "../utils";
 import { detectVenueWeekendEndDate } from "@/pipeline/venue-weekend";
 
 const BASE_URL = "https://hashrego.com";
@@ -61,6 +61,19 @@ export interface ParsedEvent {
    * `"${title} (Day N)"` for those days (the pre-E.1 behavior).
    */
   perDayTitles?: ReadonlyArray<string | undefined>;
+  /**
+   * Per-day venue / street-address / Google-Maps URL / hares, populated by the
+   * schedule-tab strategy (#875 — PGH H3 NFL Draft weekend). hashrego renders a
+   * per-day `Schedule of Events` tab block (`div.schedule .tab-pane`) whose
+   * venue + hares live in the page body, NOT in og:description. Aligned with
+   * `dates` by index; entries are `undefined` for days the tab didn't supply.
+   * `splitToRawEvents` falls back to the whole-event `location`/`hares` when a
+   * per-day entry is absent.
+   */
+  perDayLocations?: ReadonlyArray<string | undefined>;
+  perDayAddresses?: ReadonlyArray<string | undefined>;
+  perDayMapsUrls?: ReadonlyArray<string | undefined>;
+  perDayHares?: ReadonlyArray<string | undefined>;
 }
 
 /**
@@ -273,13 +286,23 @@ export function parseEventDetail(
   const locationAddress = descAddress || domLocation.address;
   const locationUrl = descLocationUrl || domLocation.mapsUrl;
 
-  // Parse dates from the description or index entry
-  const { dates, startTimes, isMultiDay, endDate, perDayKennelCodes, perDayTitles } = extractDates(
-    rawDescription,
-    indexEntry,
-    title,
-    kennelPatterns,
-  );
+  // Per-day `Schedule of Events` tabs from the page body (#875). Empty for the
+  // vast majority of events; only multi-day weekend pages carry them.
+  const scheduleTabs = parseScheduleTabs($);
+
+  // Parse dates from the description, schedule tabs, or index entry
+  const {
+    dates,
+    startTimes,
+    isMultiDay,
+    endDate,
+    perDayKennelCodes,
+    perDayTitles,
+    perDayLocations,
+    perDayAddresses,
+    perDayMapsUrls,
+    perDayHares,
+  } = extractDates(rawDescription, indexEntry, title, kennelPatterns, scheduleTabs);
 
   // Clean description: remove structured fields we already extracted
   const description = cleanDescription(rawDescription);
@@ -300,6 +323,10 @@ export function parseEventDetail(
     endDate,
     perDayKennelCodes,
     perDayTitles,
+    perDayLocations,
+    perDayAddresses,
+    perDayMapsUrls,
+    perDayHares,
   };
 }
 
@@ -426,6 +453,23 @@ function extractLocationFromDom(
 }
 
 /**
+ * Per-day location/hares for a multi-day row (#875). Prefers the schedule-tab
+ * per-day values when present, falling back to the whole-event values so events
+ * without per-day tabs (every existing multi-day kennel) behave identically.
+ */
+function perDayLocationFields(
+  parsed: ParsedEvent,
+  i: number,
+): { location?: string; locationStreet?: string; locationUrl?: string; hares?: string } {
+  return {
+    location: parsed.perDayLocations?.[i] ?? parsed.location,
+    locationStreet: parsed.perDayAddresses?.[i],
+    locationUrl: parsed.perDayMapsUrls?.[i] ?? (parsed.locationAddress || parsed.locationUrl),
+    hares: parsed.perDayHares?.[i] ?? parsed.hares,
+  };
+}
+
+/**
  * Split a parsed event into per-day RawEventData entries.
  * For single-day events, returns one entry.
  * For multi-day events, returns one per date with seriesId set.
@@ -511,6 +555,7 @@ export function splitToRawEvents(
     // fallback when the description had no parseable section title.
     const sectionTitle = parsed.perDayTitles?.[i];
     const childTitle = sectionTitle ?? `${parsed.title} (${dayLabel})`;
+    const { location, locationStreet, locationUrl, hares } = perDayLocationFields(parsed, i);
     return {
       date,
       kennelTags: [perDayCode ?? hostKennelTag],
@@ -519,9 +564,10 @@ export function splitToRawEvents(
       // #1126 — cost is a single registration fee for the whole series, so it
       // lives on the parent/umbrella row only, NOT repeated onto each day
       // (which would read as "$N per day").
-      hares: parsed.hares,
-      location: parsed.location,
-      locationUrl: parsed.locationAddress || parsed.locationUrl,
+      hares,
+      location,
+      ...(locationStreet ? { locationStreet } : {}),
+      locationUrl,
       startTime: parsed.startTimes[i] || parsed.startTimes[0] || undefined,
       sourceUrl: hashRegoUrl,
       externalLinks,
@@ -553,15 +599,20 @@ export function splitToRawEvents(
   // Shape (1): Day 1 doubles as parent (original PR B behavior).
   return parsed.dates.map((date, i) => {
     if (i === 0) {
+      // #875 — the Day-1 parent also carries that day's per-day venue/hares
+      // (e.g. NFL Draft Wednesday = Hop's Place / Darkside H3), not just the
+      // umbrella defaults.
+      const { location, locationStreet, locationUrl, hares } = perDayLocationFields(parsed, 0);
       return {
         date,
         kennelTags: [hostKennelTag],
         title: parsed.title,
         description: parsed.description,
         cost: parsed.cost, // #1126 — registration cost on the Day-1 parent
-        hares: parsed.hares,
-        location: parsed.location,
-        locationUrl: parsed.locationAddress || parsed.locationUrl,
+        hares,
+        location,
+        ...(locationStreet ? { locationStreet } : {}),
+        locationUrl,
         startTime: parsed.startTimes[0] || undefined,
         sourceUrl: hashRegoUrl,
         externalLinks,
@@ -670,10 +721,7 @@ function generateDatesInRange(startDate: Date, endDate: Date): string[] {
   const dates: string[] = [];
   const current = new Date(startDate);
   while (current <= endDate) {
-    const m = current.getUTCMonth() + 1;
-    const d = current.getUTCDate();
-    const y = current.getUTCFullYear();
-    dates.push(`${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`);
+    dates.push(isoUtcDate(current));
     current.setUTCDate(current.getUTCDate() + 1);
   }
   return dates;
@@ -1176,6 +1224,11 @@ type DateRangeResult = {
   perDayKennelCodes?: ReadonlyArray<string | undefined>;
   /** Per-day section-header titles (PR E.1). Aligned with `dates` by index. */
   perDayTitles?: ReadonlyArray<string | undefined>;
+  /** Per-day venue / address / maps URL / hares (#875 schedule tabs). */
+  perDayLocations?: ReadonlyArray<string | undefined>;
+  perDayAddresses?: ReadonlyArray<string | undefined>;
+  perDayMapsUrls?: ReadonlyArray<string | undefined>;
+  perDayHares?: ReadonlyArray<string | undefined>;
 };
 
 /** Try to parse a date range from the description and index entry. */
@@ -1236,16 +1289,243 @@ function parseDateRangeFromDescription(
 // adapter import `detectVenueWeekendEndDate` from `./parser`.
 export { detectVenueWeekendEndDate };
 
+// ── #875: per-day `Schedule of Events` tabs (PGH H3 NFL Draft weekend) ──
+//
+// Some multi-day hashrego events publish per-day venue/hares in a `div.schedule`
+// tab block in the PAGE BODY (one `.tab-pane` per weekday) rather than in
+// og:description. The umbrella og:description carries no dates or venues, so the
+// description-based strategies (1 & 2) return nothing. Strategy 3 below reads
+// these tabs, anchors each weekday label to the index start date, and emits a
+// per-day split. It is strictly additive: it only fires when Strategies 1 & 2
+// found nothing AND ≥2 weekday-labelled tabs exist.
+
+/** One day of a hashrego `Schedule of Events` tab block. */
+export interface ScheduleTab {
+  /** Weekday label from the tab nav (e.g. "Wednesday"). */
+  weekday: string;
+  venue?: string;
+  address?: string;
+  mapsUrl?: string;
+  /** "HH:MM" local start time parsed from the tab's `When:` line. */
+  startTime?: string;
+  /** Host kennel named in the tab prose, surfaced as the day's hares. */
+  hares?: string;
+}
+
+/** Weekday label → UTC day index (Sun=0). Mirrors `WEEKDAY_NAMES` coverage. */
+const WEEKDAY_DOW: ReadonlyMap<string, number> = new Map([
+  ["sun", 0], ["sunday", 0],
+  ["mon", 1], ["monday", 1],
+  ["tue", 2], ["tues", 2], ["tuesday", 2],
+  ["wed", 3], ["weds", 3], ["wednesday", 3],
+  ["thu", 4], ["thur", 4], ["thurs", 4], ["thursday", 4],
+  ["fri", 5], ["friday", 5],
+  ["sat", 6], ["saturday", 6],
+]);
+
+function weekdayLabelToDow(label: string): number | null {
+  return WEEKDAY_DOW.get(label.trim().toLowerCase()) ?? null;
+}
+
+function isoUtcDate(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  return `${y}-${String(m).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/**
+ * Parse a start time from a schedule-tab `When:` line. Mismanagement writes
+ * these free-form ("630pm gather 7pm on out", "6:30pm", "7 pm"), so try the
+ * shared colon-form parser first, then a procedural no-colon fallback. No
+ * nested-quantifier regex (keeps Sonar S5852 calm).
+ */
+function parseScheduleTime(line: string): string | undefined {
+  const colon = parse12HourTime(line);
+  if (colon) return colon;
+  const m = /\b(\d{1,2})(\d{2})?\s*(am|pm)\b/i.exec(line);
+  if (!m) return undefined;
+  let hours = Number.parseInt(m[1], 10);
+  const mins = m[2] ? Number.parseInt(m[2], 10) : 0;
+  if (hours > 12 || mins >= 60) return undefined;
+  const pm = m[3].toLowerCase() === "pm";
+  if (pm && hours !== 12) hours += 12;
+  if (!pm && hours === 12) hours = 0;
+  return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+}
+
+const MAPS_URL_RE = /maps\.app\.goo\.gl|maps\.google|google\.com\/maps|goo\.gl/i;
+
+/** Split a tab pane's inner HTML into trimmed, non-empty lines (br/p = breaks). */
+function scheduleTabLines(rawHtml: string): string[] {
+  // Reuse the shared HTML→text helper: it converts `<br>`/closing block tags to
+  // the separator, strips script/style, decodes entities, and trims — exactly
+  // the line model we want here.
+  return stripHtmlTags(rawHtml, "\n").split("\n").filter(Boolean);
+}
+
+/** Stopwords that bound the backward host-kennel scan in `extractScheduleTabHares`. */
+const HARE_PROSE_STOPWORDS: ReadonlySet<string> = new Set([
+  "our", "the", "a", "an", "with", "join", "this", "we", "your", "will", "is", "it",
+]);
+
+/**
+ * Conservatively extract the host kennel named in a tab's lead prose, to surface
+ * as that day's hares ("Our Darkside H3 kennel…" → "Darkside H3"; "…Thursday
+ * (PITT) H3…" → "PITT H3"). Returns undefined when no confident match — free
+ * prose is fuzzy, so we never leak a sentence into the hares field. Procedural
+ * (split on whitespace, scan backward from the H3/H4/HHH token) — no ReDoS.
+ */
+function extractScheduleTabHares(prose: string | undefined): string | undefined {
+  if (!prose) return undefined;
+  const tokens = prose.split(/\s+/).filter(Boolean);
+  let hIdx = -1;
+  let suffix = "";
+  for (let i = 0; i < tokens.length; i++) {
+    const bare = tokens[i].replace(/[^A-Za-z0-9@]/g, "").toUpperCase();
+    if (bare === "H3" || bare === "H4" || bare === "HHH") {
+      hIdx = i;
+      suffix = bare;
+      break;
+    }
+  }
+  if (hIdx <= 0) return undefined; // need a preceding name token
+  // A parenthesized acronym immediately before the suffix IS the kennel code.
+  const paren = /^\(([A-Za-z0-9@&]{2,})\)$/.exec(tokens[hIdx - 1]);
+  if (paren) return `${paren[1]} ${suffix}`;
+  // Otherwise collect up to 2 consecutive name-like tokens, stopping at a stopword.
+  const name: string[] = [];
+  for (let i = hIdx - 1; i >= 0 && name.length < 2; i--) {
+    const clean = tokens[i].replace(/^[^A-Za-z0-9@]+/, "").replace(/[^A-Za-z0-9@]+$/, "");
+    if (!clean || HARE_PROSE_STOPWORDS.has(clean.toLowerCase())) break;
+    const nameLike = /^[A-Z]/.test(clean) || /[@0-9]/.test(clean) || clean === clean.toUpperCase();
+    if (!nameLike) break;
+    name.unshift(clean);
+  }
+  return name.length > 0 ? `${name.join(" ")} ${suffix}` : undefined;
+}
+
+/** Extract structured fields from one tab pane's text lines. */
+function parseScheduleTabFields(lines: string[]): Omit<ScheduleTab, "weekday"> {
+  let venue: string | undefined;
+  let mapsUrl: string | undefined;
+  let startTime: string | undefined;
+  let whereIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (startTime === undefined && /^when\b/i.test(line)) startTime = parseScheduleTime(line);
+    if (whereIdx === -1 && /^where\b/i.test(line)) {
+      venue = line.replace(/^where\s*:?\s*/i, "").trim() || undefined;
+      whereIdx = i;
+    }
+    if (mapsUrl === undefined && MAPS_URL_RE.test(line)) mapsUrl = line;
+  }
+  // Address = first line after `Where:` that carries a street number and isn't a URL.
+  let address: string | undefined;
+  if (whereIdx >= 0) {
+    for (let i = whereIdx + 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (/^https?:\/\//i.test(line) || /^after\s+party/i.test(line)) continue;
+      if (/\d/.test(line)) {
+        address = line;
+        break;
+      }
+    }
+  }
+  return { venue, address, mapsUrl, startTime, hares: extractScheduleTabHares(lines[0]) };
+}
+
+/**
+ * Parse the per-day `Schedule of Events` tabs from a detail page. Returns the
+ * weekday-labelled days in document order. Empty unless ≥2 weekday tabs exist.
+ */
+export function parseScheduleTabs($: cheerio.CheerioAPI): ScheduleTab[] {
+  const sched = $(".schedule").first();
+  if (sched.length === 0) return [];
+  const labels: string[] = [];
+  sched.find(".nav-tabs li a").each((_i, a) => {
+    labels.push($(a).text().trim());
+  });
+  const panes = sched.find(".tab-content .tab-pane");
+  if (labels.length < 2 || panes.length === 0) return [];
+
+  const tabs: ScheduleTab[] = [];
+  panes.each((i, pane) => {
+    const label = labels[i];
+    if (!label || weekdayLabelToDow(label) === null) return;
+    const lines = scheduleTabLines($(pane).html() ?? "");
+    tabs.push({ weekday: label, ...parseScheduleTabFields(lines) });
+  });
+  // ≥2 weekday-labelled days required — single-day events / non-schedule blocks
+  // must not trip the multi-day path (keeps Strategy 3 additive).
+  return tabs.length >= 2 ? tabs : [];
+}
+
+/**
+ * Strategy 3 (#875): build a per-day date range from schedule tabs. Day 0 is
+ * anchored to the index start date (authoritative); each later day advances the
+ * cursor to the next date matching that tab's weekday label.
+ */
+function parseScheduleTabRange(
+  indexEntry: IndexEntry,
+  tabs: ScheduleTab[],
+): DateRangeResult | null {
+  const startDateStr = parseHashRegoDate(indexEntry.startDate);
+  if (!startDateStr) return null;
+
+  // Day 0 IS the index start date, so its weekday MUST match the first tab's
+  // label. If it doesn't, the index date is stale/shifted and anchoring the
+  // tabs to it would pair each day's venue/hares with the wrong date — bail to
+  // the single-day path rather than publish misaligned data (Codex review).
+  const startMs = Date.parse(`${startDateStr}T00:00:00Z`);
+  const firstDow = weekdayLabelToDow(tabs[0].weekday);
+  if (firstDow === null || firstDow !== new Date(startMs).getUTCDay()) return null;
+
+  const dates: string[] = [startDateStr];
+  let cursor = startMs + 86_400_000;
+  for (let i = 1; i < tabs.length; i++) {
+    const dow = weekdayLabelToDow(tabs[i].weekday);
+    if (dow === null) return null;
+    const d = new Date(cursor);
+    for (let guard = 0; guard < 7 && d.getUTCDay() !== dow; guard++) {
+      d.setUTCDate(d.getUTCDate() + 1);
+    }
+    if (d.getUTCDay() !== dow) return null;
+    dates.push(isoUtcDate(d));
+    cursor = d.getTime() + 86_400_000;
+  }
+
+  const firstTime = tabs.find((t) => t.startTime)?.startTime ?? "";
+  return {
+    dates,
+    startTimes: tabs.map((t) => t.startTime ?? firstTime),
+    isMultiDay: true,
+    endDate: dates.at(-1),
+    perDayLocations: tabs.map((t) => t.venue),
+    perDayAddresses: tabs.map((t) => t.address),
+    perDayMapsUrls: tabs.map((t) => t.mapsUrl),
+    perDayHares: tabs.map((t) => t.hares),
+  };
+}
+
 /** Extract dates and detect multi-day events */
 function extractDates(
   description: string,
   indexEntry?: IndexEntry,
   title?: string,
   kennelPatterns?: KennelPatternConfig,
+  scheduleTabs?: ScheduleTab[],
 ): DateRangeResult {
   if (indexEntry) {
     const rangeResult = parseDateRangeFromDescription(description, indexEntry, kennelPatterns);
     if (rangeResult) return rangeResult;
+
+    // Strategy 3 (#875): per-day schedule tabs in the page body. Only after the
+    // description-based strategies found nothing AND ≥2 weekday tabs exist.
+    if (scheduleTabs && scheduleTabs.length >= 2) {
+      const tabResult = parseScheduleTabRange(indexEntry, scheduleTabs);
+      if (tabResult) return tabResult;
+    }
 
     const date = parseHashRegoDate(indexEntry.startDate);
     const time = parseHashRegoTime(indexEntry.startTime);

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -1432,8 +1432,13 @@ function extractScheduleTabHares(prose: string | undefined): string | undefined 
   return name.length > 0 ? `${name.join(" ")} ${suffix}` : undefined;
 }
 
-/** Extract structured fields from one tab pane's text lines. */
-function parseScheduleTabFields(lines: string[]): Omit<ScheduleTab, "weekday"> {
+/** Lines that should never be read as a street address (URLs and labelled fields). */
+const NON_ADDRESS_LINE_RE = /^(?:https?:\/\/|after|when|where|cost|hares?|time|start)\b/i;
+
+/** Scan a tab's lines for the `When:` time, the `Where:` venue, and a maps URL. */
+function scanScheduleTabHeader(
+  lines: string[],
+): { venue?: string; mapsUrl?: string; startTime?: string; whereIdx: number } {
   let venue: string | undefined;
   let mapsUrl: string | undefined;
   let startTime: string | undefined;
@@ -1447,24 +1452,33 @@ function parseScheduleTabFields(lines: string[]): Omit<ScheduleTab, "weekday"> {
     }
     if (mapsUrl === undefined && MAPS_URL_RE.test(line)) mapsUrl = line;
   }
-  // Address = first line after `Where:` that carries a street number and isn't a
-  // URL or another labelled field. The label skip guards against a `When:`/`Cost:`
-  // line that happens to follow `Where:` and contains a digit (e.g. "When: 6:30").
-  let address: string | undefined;
-  if (whereIdx >= 0) {
-    for (let i = whereIdx + 1; i < lines.length; i++) {
-      const line = lines[i];
-      if (/^https?:\/\//i.test(line)) continue;
-      // Skip other labelled lines (After Party / When / Cost …) — no `\s+` in the
-      // alternation, to stay clear of Sonar S5852's ReDoS heuristic.
-      if (/^(?:after|when|where|cost|hares?|time|start)\b/i.test(line)) continue;
-      if (/\d/.test(line)) {
-        address = line;
-        break;
-      }
-    }
+  return { venue, mapsUrl, startTime, whereIdx };
+}
+
+/**
+ * First line after `Where:` that carries a street number and isn't a URL or
+ * another labelled field. The label skip guards against a `When:`/`Cost:` line
+ * that follows `Where:` and contains a digit (e.g. "When: 6:30").
+ */
+function findScheduleTabAddress(lines: string[], whereIdx: number): string | undefined {
+  if (whereIdx < 0) return undefined;
+  for (let i = whereIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!NON_ADDRESS_LINE_RE.test(line) && /\d/.test(line)) return line;
   }
-  return { venue, address, mapsUrl, startTime, hares: extractScheduleTabHares(lines[0]) };
+  return undefined;
+}
+
+/** Extract structured fields from one tab pane's text lines. */
+function parseScheduleTabFields(lines: string[]): Omit<ScheduleTab, "weekday"> {
+  const { venue, mapsUrl, startTime, whereIdx } = scanScheduleTabHeader(lines);
+  return {
+    venue,
+    address: findScheduleTabAddress(lines, whereIdx),
+    mapsUrl,
+    startTime,
+    hares: extractScheduleTabHares(lines[0]),
+  };
 }
 
 /**
@@ -1508,6 +1522,34 @@ export function parseScheduleTabs($: cheerio.CheerioAPI): ScheduleTab[] {
  * anchored to the index start date (authoritative); each later day advances the
  * cursor to the next date matching that tab's weekday label.
  */
+/** First UTC date ≥ `fromMs` whose day-of-week is `dow` (within a week), else null. */
+function nextUtcDateForDow(fromMs: number, dow: number): Date | null {
+  const d = new Date(fromMs);
+  for (let guard = 0; guard < 7 && d.getUTCDay() !== dow; guard++) {
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+  return d.getUTCDay() === dow ? d : null;
+}
+
+/**
+ * Build the per-day date list: day 0 is the anchor, each later day advances to
+ * the next date matching that tab's weekday. Returns null on any unmappable or
+ * unreachable weekday.
+ */
+function buildScheduleTabDates(startDateStr: string, startMs: number, tabs: ScheduleTab[]): string[] | null {
+  const dates: string[] = [startDateStr];
+  let cursor = startMs + 86_400_000;
+  for (let i = 1; i < tabs.length; i++) {
+    const dow = weekdayLabelToDow(tabs[i].weekday);
+    if (dow === null) return null;
+    const d = nextUtcDateForDow(cursor, dow);
+    if (!d) return null;
+    dates.push(isoUtcDate(d));
+    cursor = d.getTime() + 86_400_000;
+  }
+  return dates;
+}
+
 function parseScheduleTabRange(
   indexEntry: IndexEntry,
   tabs: ScheduleTab[],
@@ -1523,19 +1565,8 @@ function parseScheduleTabRange(
   const firstDow = weekdayLabelToDow(tabs[0].weekday);
   if (firstDow === null || firstDow !== new Date(startMs).getUTCDay()) return null;
 
-  const dates: string[] = [startDateStr];
-  let cursor = startMs + 86_400_000;
-  for (let i = 1; i < tabs.length; i++) {
-    const dow = weekdayLabelToDow(tabs[i].weekday);
-    if (dow === null) return null;
-    const d = new Date(cursor);
-    for (let guard = 0; guard < 7 && d.getUTCDay() !== dow; guard++) {
-      d.setUTCDate(d.getUTCDate() + 1);
-    }
-    if (d.getUTCDay() !== dow) return null;
-    dates.push(isoUtcDate(d));
-    cursor = d.getTime() + 86_400_000;
-  }
+  const dates = buildScheduleTabDates(startDateStr, startMs, tabs);
+  if (!dates) return null;
 
   const firstTime = tabs.find((t) => t.startTime)?.startTime ?? "";
   return {

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -1581,6 +1581,26 @@ function parseScheduleTabRange(
   };
 }
 
+const EMPTY_RANGE: DateRangeResult = { dates: [], startTimes: [], isMultiDay: false };
+
+/**
+ * Single-day fallback from the index entry. Applies the venue-weekend campout
+ * heuristic (#1560 PR C) so a single registration row can still carry an
+ * inclusive `endDate` (Madison-style "Jan 16 – 18" pill, no child expansion).
+ */
+function singleDayRange(description: string, indexEntry: IndexEntry, title?: string): DateRangeResult {
+  const date = parseHashRegoDate(indexEntry.startDate);
+  if (!date) return EMPTY_RANGE;
+  const time = parseHashRegoTime(indexEntry.startTime);
+  const endDate = detectVenueWeekendEndDate(description, title ?? "", date);
+  return {
+    dates: [date],
+    startTimes: time ? [time] : [],
+    isMultiDay: false,
+    ...(endDate ? { endDate } : {}),
+  };
+}
+
 /** Extract dates and detect multi-day events */
 function extractDates(
   description: string,
@@ -1589,36 +1609,19 @@ function extractDates(
   kennelPatterns?: KennelPatternConfig,
   scheduleTabs?: ScheduleTab[],
 ): DateRangeResult {
-  if (indexEntry) {
-    const rangeResult = parseDateRangeFromDescription(description, indexEntry, kennelPatterns);
-    if (rangeResult) return rangeResult;
+  if (!indexEntry) return EMPTY_RANGE;
 
-    // Strategy 3 (#875): per-day schedule tabs in the page body. Only after the
-    // description-based strategies found nothing AND ≥2 weekday tabs exist.
-    if (scheduleTabs && scheduleTabs.length >= 2) {
-      const tabResult = parseScheduleTabRange(indexEntry, scheduleTabs);
-      if (tabResult) return tabResult;
-    }
+  const rangeResult = parseDateRangeFromDescription(description, indexEntry, kennelPatterns);
+  if (rangeResult) return rangeResult;
 
-    const date = parseHashRegoDate(indexEntry.startDate);
-    const time = parseHashRegoTime(indexEntry.startTime);
-    if (date) {
-      // Try the venue-weekend campout heuristic (#1560 PR C) before
-      // committing to a single-day result. When it fires, the row stays
-      // single (no children) but carries an `endDate` so the UI renders
-      // a date-range pill — Madison-style "Jan 16 – 18" without the
-      // "+ N trails" expansion.
-      const endDate = detectVenueWeekendEndDate(description, title ?? "", date);
-      return {
-        dates: [date],
-        startTimes: time ? [time] : [],
-        isMultiDay: false,
-        ...(endDate ? { endDate } : {}),
-      };
-    }
+  // Strategy 3 (#875): per-day schedule tabs in the page body. Only after the
+  // description-based strategies found nothing AND ≥2 weekday tabs exist.
+  if (scheduleTabs && scheduleTabs.length >= 2) {
+    const tabResult = parseScheduleTabRange(indexEntry, scheduleTabs);
+    if (tabResult) return tabResult;
   }
 
-  return { dates: [], startTimes: [], isMultiDay: false };
+  return singleDayRange(description, indexEntry, title);
 }
 
 /** Extract year from "MM/DD/YY" format */

--- a/src/adapters/hashrego/parser.ts
+++ b/src/adapters/hashrego/parser.ts
@@ -461,10 +461,18 @@ function perDayLocationFields(
   parsed: ParsedEvent,
   i: number,
 ): { location?: string; locationStreet?: string; locationUrl?: string; hares?: string } {
+  const dayVenue = parsed.perDayLocations?.[i];
+  const dayStreet = parsed.perDayAddresses?.[i];
+  const dayMapsUrl = parsed.perDayMapsUrls?.[i];
+  // When the day has its OWN venue/street, do NOT inherit the umbrella's maps URL
+  // — that would pin this day's geocoding to a different venue (Codex P2). Use
+  // the day's own maps URL (or none, letting the street geocode). Only days with
+  // no per-day location at all fall back to the whole-event values.
+  const hasDayLocation = dayVenue !== undefined || dayStreet !== undefined;
   return {
-    location: parsed.perDayLocations?.[i] ?? parsed.location,
-    locationStreet: parsed.perDayAddresses?.[i],
-    locationUrl: parsed.perDayMapsUrls?.[i] ?? (parsed.locationAddress || parsed.locationUrl),
+    location: dayVenue ?? (hasDayLocation ? undefined : parsed.location),
+    locationStreet: dayStreet,
+    locationUrl: dayMapsUrl ?? (hasDayLocation ? undefined : (parsed.locationAddress || parsed.locationUrl)),
     hares: parsed.perDayHares?.[i] ?? parsed.hares,
   };
 }
@@ -567,7 +575,7 @@ export function splitToRawEvents(
       hares,
       location,
       ...(locationStreet ? { locationStreet } : {}),
-      locationUrl,
+      ...(locationUrl ? { locationUrl } : {}),
       startTime: parsed.startTimes[i] || parsed.startTimes[0] || undefined,
       sourceUrl: hashRegoUrl,
       externalLinks,
@@ -612,7 +620,7 @@ export function splitToRawEvents(
         hares,
         location,
         ...(locationStreet ? { locationStreet } : {}),
-        locationUrl,
+        ...(locationUrl ? { locationUrl } : {}),
         startTime: parsed.startTimes[0] || undefined,
         sourceUrl: hashRegoUrl,
         externalLinks,
@@ -1369,6 +1377,23 @@ const HARE_PROSE_STOPWORDS: ReadonlySet<string> = new Set([
   "our", "the", "a", "an", "with", "join", "this", "we", "your", "will", "is", "it",
 ]);
 
+/** Single-char name-token test (no quantifier — not a ReDoS shape). */
+const NAME_CHAR_RE = /[A-Za-z0-9@]/;
+
+/**
+ * Trim leading/trailing punctuation off a prose token ("Darkside," → "Darkside").
+ * Procedural rather than a `/[^…]+$/` regex — that anchored `+$` form trips
+ * Sonar S5852's ReDoS heuristic even though it's linear (cf. memory
+ * `feedback_sonar_s5852_false_positives`).
+ */
+function trimEdgePunctuation(token: string): string {
+  let start = 0;
+  let end = token.length;
+  while (start < end && !NAME_CHAR_RE.test(token[start])) start++;
+  while (end > start && !NAME_CHAR_RE.test(token[end - 1])) end--;
+  return token.slice(start, end);
+}
+
 /**
  * Conservatively extract the host kennel named in a tab's lead prose, to surface
  * as that day's hares ("Our Darkside H3 kennel…" → "Darkside H3"; "…Thursday
@@ -1391,12 +1416,14 @@ function extractScheduleTabHares(prose: string | undefined): string | undefined 
   }
   if (hIdx <= 0) return undefined; // need a preceding name token
   // A parenthesized acronym immediately before the suffix IS the kennel code.
-  const paren = /^\(([A-Za-z0-9@&]{2,})\)$/.exec(tokens[hIdx - 1]);
+  // Hyphen last in the class so it's a literal, not a range (kennel codes like
+  // "PGH-H3", "EW-H3" carry hyphens).
+  const paren = /^\(([A-Za-z0-9@&-]{2,})\)$/.exec(tokens[hIdx - 1]);
   if (paren) return `${paren[1]} ${suffix}`;
   // Otherwise collect up to 2 consecutive name-like tokens, stopping at a stopword.
   const name: string[] = [];
   for (let i = hIdx - 1; i >= 0 && name.length < 2; i--) {
-    const clean = tokens[i].replace(/^[^A-Za-z0-9@]+/, "").replace(/[^A-Za-z0-9@]+$/, "");
+    const clean = trimEdgePunctuation(tokens[i]);
     if (!clean || HARE_PROSE_STOPWORDS.has(clean.toLowerCase())) break;
     const nameLike = /^[A-Z]/.test(clean) || /[@0-9]/.test(clean) || clean === clean.toUpperCase();
     if (!nameLike) break;
@@ -1420,12 +1447,17 @@ function parseScheduleTabFields(lines: string[]): Omit<ScheduleTab, "weekday"> {
     }
     if (mapsUrl === undefined && MAPS_URL_RE.test(line)) mapsUrl = line;
   }
-  // Address = first line after `Where:` that carries a street number and isn't a URL.
+  // Address = first line after `Where:` that carries a street number and isn't a
+  // URL or another labelled field. The label skip guards against a `When:`/`Cost:`
+  // line that happens to follow `Where:` and contains a digit (e.g. "When: 6:30").
   let address: string | undefined;
   if (whereIdx >= 0) {
     for (let i = whereIdx + 1; i < lines.length; i++) {
       const line = lines[i];
-      if (/^https?:\/\//i.test(line) || /^after\s+party/i.test(line)) continue;
+      if (/^https?:\/\//i.test(line)) continue;
+      // Skip other labelled lines (After Party / When / Cost …) — no `\s+` in the
+      // alternation, to stay clear of Sonar S5852's ReDoS heuristic.
+      if (/^(?:after|when|where|cost|hares?|time|start)\b/i.test(line)) continue;
       if (/\d/.test(line)) {
         address = line;
         break;
@@ -1453,8 +1485,18 @@ export function parseScheduleTabs($: cheerio.CheerioAPI): ScheduleTab[] {
   panes.each((i, pane) => {
     const label = labels[i];
     if (!label || weekdayLabelToDow(label) === null) return;
-    const lines = scheduleTabLines($(pane).html() ?? "");
-    tabs.push({ weekday: label, ...parseScheduleTabFields(lines) });
+    const $pane = $(pane);
+    const fields = parseScheduleTabFields(scheduleTabLines($pane.html() ?? ""));
+    // Prefer the maps link straight off the anchor href — survives a future
+    // template change that wraps the URL in `<a>` (text-stripping would lose it)
+    // and avoids capturing trailing prose punctuation. Falls back to the
+    // text-scraped URL for the current bare-text markup.
+    const href = $pane
+      .find("a[href*='maps.app.goo.gl'], a[href*='maps.google'], a[href*='google.com/maps']")
+      .first()
+      .attr("href");
+    if (href) fields.mapsUrl = href;
+    tabs.push({ weekday: label, ...fields });
   });
   // ≥2 weekday-labelled days required — single-day events / non-schedule blocks
   // must not trip the multi-day path (keeps Strategy 3 additive).

--- a/src/adapters/html-scraper/hockessin.test.ts
+++ b/src/adapters/html-scraper/hockessin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseHockessinEvent } from "./hockessin";
+import { generateFingerprint } from "@/pipeline/fingerprint";
 
 describe("HockessinAdapter", () => {
   describe("parseHockessinEvent", () => {
@@ -171,6 +172,42 @@ describe("HockessinAdapter", () => {
       expect(event).not.toBeNull();
       expect(event!.title).toBeUndefined();
       expect(event!.hares).toBeUndefined();
+    });
+
+    it("#1748: a source-duplicated run number on two dates stays distinct", () => {
+      // Verbatim from hockessinhash.org on 2026-05-28: the kennel assigned the
+      // same run number (#1668) to two different Wednesday runs. The adapter
+      // faithfully scrapes both; distinctness is guaranteed downstream by the
+      // event date (the first field of the merge fingerprint), so the two never
+      // merge or collapse into one canonical Event. No renumbering — we don't
+      // fabricate data the source didn't provide.
+      const jun10 = parseHockessinEvent(
+        "Hash #1668: HARE(S) NEEDED?!",
+        "WEDNESDAY, June 10, 2026, 6:30pm, TBA",
+        "https://www.hockessinhash.org/",
+      );
+      const jun17 = parseHockessinEvent(
+        "Hash #1668: 7th Hole",
+        "WEDNESDAY, June 17, 2026, 6:30pm, TBA",
+        "https://www.hockessinhash.org/",
+      );
+
+      expect(jun10).not.toBeNull();
+      expect(jun17).not.toBeNull();
+
+      // Same (duplicated) run number, faithfully preserved on both.
+      expect(jun10!.runNumber).toBe(1668);
+      expect(jun17!.runNumber).toBe(1668);
+
+      // Distinct dates and hares keep them apart.
+      expect(jun10!.date).toBe("2026-06-10");
+      expect(jun17!.date).toBe("2026-06-17");
+      expect(jun10!.hares).toBe("HARE(S) NEEDED?!");
+      expect(jun17!.hares).toBe("7th Hole");
+
+      // The merge fingerprint differs (date is its first component), so the two
+      // RawEvents never dedup into one — this is the actual no-collapse guard.
+      expect(generateFingerprint(jun10!)).not.toBe(generateFingerprint(jun17!));
     });
   });
 });

--- a/src/adapters/html-scraper/hockessin.ts
+++ b/src/adapters/html-scraper/hockessin.ts
@@ -95,6 +95,11 @@ export function parseHockessinEvent(
   return {
     date,
     kennelTags: ["hockessin"],
+    // #1748 — the kennel sometimes assigns the SAME run number to two different
+    // dates (source data-entry error, e.g. #1668 on Jun 10 AND Jun 17 2026). We
+    // scrape it faithfully rather than renumbering; the two events stay distinct
+    // because `date` is the first field of the merge fingerprint, so they never
+    // collapse into one canonical Event.
     runNumber: !Number.isNaN(runNumber) ? runNumber : undefined,
     // Title is populated only when the source has a distinct theme separated
     // from the hares by " - " (#1493); the bare `Hash #N: <hares>` shape leaves


### PR DESCRIPTION
Quick-win bundle of 3 long-deferred parse issues. Investigation found two were already-correct in current code (data/self-heal) and one needed real new parsing — confirmed direction with the requester.

## #875 — PGH H3 NFL Draft weekend (the real work)
Per-day trail venue/hares live in HTML **schedule tabs** (`div.schedule .tab-pane`) in the page body, **not** in `og:description` (which carries only the umbrella blurb). Added a new **Strategy 3** to `extractDates`:
- `parseScheduleTabs($)` reads the weekday-labelled tabs → per-day venue, street address, maps URL, start time, and host-kennel-as-hares (e.g. "Our Darkside H3 kennel…" → `Darkside H3`).
- Anchors weekday labels to the index start date; **bails if Day-0's weekday ≠ the start date** (avoids pairing venues with wrong dates — caught in adversarial review).
- Threads new `perDay{Locations,Addresses,MapsUrls,Hares}` arrays through `splitToRawEvents` via the existing `seriesId`/parent multi-day convention.
- **Strictly additive:** only fires when Strategies 1 & 2 find nothing **and** ≥2 weekday tabs exist. Existing single-day and description-driven multi-day kennels are unaffected (regression tests included).

Live-verified against the production page → 5 children Apr 22–26, each with its own venue/street/hares.

## #1460 — SAH3 title (self-healed at source)
The adapter **already** sources the title from `og:title` (the real field), not the URL slug. The bad `"SAH3 SAH3 2026"` was a stale snapshot from before the kennel renamed the event (and before the `#1669` doubled-prefix guard). Added a regression test pinning the title to `og:title`, plus a one-shot prod heal (`scripts/heal-sah3-title.ts`) — **applied to prod: 1 row corrected** to `"SAH3 Summer Campout 2026"`.

## #1748 — Hockessin duplicate run #1668
The two events (Jun 10 / Jun 17 2026) are **already distinct** — different dates → different fingerprints (`date` is the first fingerprint field) → separate canonical Events (no `@@unique([kennelId,runNumber])`; canonical matching is same-day only). Faithful scrape, no renumbering. Added a regression test asserting distinct fingerprints + a code comment.

## Verification
- `npm run lint` (0 errors), `npx tsc --noEmit` (clean), `npm test` (8972 pass).
- Live-verified the NFL Draft + SAH3 pages against production.
- `/codex:adversarial-review` (1 high finding fixed: Day-0 weekday anchor guard) + `/simplify` (reused shared `stripHtmlTags`, deduped `isoUtcDate`).

Closes #875
Closes #1460
Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)