### PR TITLE
fix(gcal): #1738 follow-up — revert MoA2H3 Option B, let demon-h3/glh3 own their calendars

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3043,25 +3043,26 @@ export const SOURCES = [
       // scrape route.
       scrapeDays: 800,
       config: {
-        // #1738 — most-specific-first: the MoA2H3 calendar carries a handful of
-        // sister-kennel events (DeMon H3 inaugural trail Nov 2025; GLH3 HashMas
-        // Jan 2025). Route them to the sister codes rather than silent-skipping
-        // (#1739). The sister codes are added to `kennelCodes` below so the merge
-        // source-kennel guard passes (no recurring `SOURCE_KENNEL_MISMATCH` — the
-        // #1739 noise that drove the original silent-skip). DeMon/GLH3 own sources
-        // stay at scrapeDays:90 and can't reach these historical dates, so no
-        // duplicate Events arise (the Codex #1719 dedup concern is moot here).
-        kennelPatterns: [
-          [String.raw`^DeMon\s*H?3?\b`, "demon-h3"],
-          [String.raw`^GLH3\b|^Greater\s+Lansing`, "glh3"],
-        ],
         defaultKennelTag: "moa2h3",
         // #1458 — kennel admins double-paste "MoA2H3" into event titles on
         // the source side. Opt in to the doubled-prefix strip so titles
         // like "MoA2H3 MoA2H3 Red Dress Run" surface as a single prefix.
         stripDoubledKennelPrefix: true,
+        // #1739 / #1738 (reverted from #2152's Option B) — the MoA2H3 calendar
+        // carries a handful of sister-kennel events (DeMon H3 inaugural Nov 2025;
+        // GLH3 HashMas Jan 2025). DeMon H3 and GLH3 each have their OWN Google
+        // Calendar source whose archive DOES contain these events (verified:
+        // demonhashhouseharriers@gmail.com → 82 events to 2027, GLH3 → 169 events
+        // 2020→2027), so they're pure pollution here. Routing them through MoA2H3
+        // (Option B) made MoA2H3's reconcile own demon-h3/glh3 and cancel their
+        // own legitimate runs every 6h. Drop them silently instead; the sisters
+        // are surfaced by their OWN sources (scrapeDays bumped to 365 below).
+        silentlySkipPatterns: [
+          { pattern: String.raw`^DeMon\s*H?3?\b` },
+          { pattern: String.raw`^GLH3\b|^Greater\s+Lansing` },
+        ],
       },
-      kennelCodes: ["moa2h3", "demon-h3", "glh3"],
+      kennelCodes: ["moa2h3"],
     },
     {
       name: "DeMon H3 Google Calendar",
@@ -3069,7 +3070,11 @@ export const SOURCES = [
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "every_6h",
-      scrapeDays: 90,
+      // #1738 — 90 → 365 so the recurring scrape covers DeMon's full calendar
+      // (2025-11 inaugural → 2027-06), letting demon-h3 own its events from its
+      // OWN source rather than relying on MoA2H3 routing. 365 keeps reconcile's
+      // window aligned with the adapter's futureHorizonDays cap (no future gap).
+      scrapeDays: 365,
       config: {
         defaultKennelTag: "demon-h3",
         harePatterns: [String.raw`(?:^|\n)\s*WHO\s*\(?(?:hares?)?\)?\s*:?\s*(.+)`],
@@ -3082,7 +3087,9 @@ export const SOURCES = [
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "every_6h",
-      scrapeDays: 90,
+      // #1738 — 90 → 365 so the recurring scrape covers GLH3's ongoing calendar
+      // from its own source (deep 2020→2024 history backfilled out-of-band).
+      scrapeDays: 365,
       config: { defaultKennelTag: "glh3" },
       kennelCodes: ["glh3"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3058,8 +3058,8 @@ export const SOURCES = [
         // own legitimate runs every 6h. Drop them silently instead; the sisters
         // are surfaced by their OWN sources (scrapeDays bumped to 365 below).
         silentlySkipPatterns: [
-          { pattern: String.raw`^DeMon\s*H?3?\b` },
-          { pattern: String.raw`^GLH3\b|^Greater\s+Lansing` },
+          { pattern: String.raw`^DeMon\s*H?3?\b`, field: "title" },
+          { pattern: String.raw`^GLH3\b|^Greater\s+Lansing`, field: "title" },
         ],
       },
       kennelCodes: ["moa2h3"],

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -203,34 +203,40 @@ describe("Princeton NJ Hash Calendar — title from SUMMARY (#2125, reverses #19
   });
 });
 
-// ── MoA2H3 Google Calendar sister-kennel routing (#1738) ──
+// ── MoA2H3 Google Calendar sister-kennel handling (#1738, Option A) ──
 
-describe("MoA2H3 Google Calendar — sister-kennel routing (#1738)", () => {
+describe("MoA2H3 Google Calendar — sister kennels silently skipped, owned by their own sources (#1738)", () => {
   const moaSource = SOURCES.find((s) => s.name === "MoA2H3 Google Calendar");
   if (!moaSource?.config) throw new Error("MoA2H3 Google Calendar seed config missing");
-  const config = moaSource.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+  const config = moaSource.config as {
+    silentlySkipPatterns?: { pattern: string }[];
+    kennelPatterns?: unknown;
+    defaultKennelTag?: string;
+  };
 
-  it.each([
-    // [summary, expected kennelTag, description]
-    ["DeMonH3 - Belle Isle Be Damned", "demon-h3", "DeMonH3 glued form"],
-    ["DeMonH3 Inaugural Trail", "demon-h3", "DeMonH3 inaugural"],
-    ["DeMon H3 Monday Run", "demon-h3", "DeMon H3 spaced form"],
-    ["GLH3 HashMas", "glh3", "GLH3 token"],
-    ["Greater Lansing H3 Holiday Trail", "glh3", "Greater Lansing full name"],
-    ["MoA2H3 Red Dress Run", "moa2h3", "host run falls through to default"],
-    ["MoA2H3 MoA2H3 Red Dress Run", "moa2h3", "doubled-prefix host run still routes to host"],
-  ])("routes %j → %s (%s)", (summary, expectedTag) => {
-    const result = buildRawEventFromGCalItem(
-      { summary, start: { dateTime: "2025-11-24T18:30:00-05:00" }, status: "confirmed" },
-      config,
-    );
-    expect(result?.kennelTags[0]).toBe(expectedTag);
+  it("does NOT own demon-h3/glh3 — only moa2h3 in kennelCodes (no reconcile over sister kennels)", () => {
+    // Routing sisters through MoA2H3 (the reverted Option B) made its reconcile
+    // cancel demon-h3/glh3's own legitimate runs. They're silently skipped here
+    // and surfaced by their own sources instead.
+    expect(moaSource.kennelCodes).toEqual(["moa2h3"]);
+    expect(config.kennelPatterns).toBeUndefined();
   });
 
-  it("links the sister kennels to the source so the merge guard passes (no SOURCE_KENNEL_MISMATCH)", () => {
-    expect(moaSource.kennelCodes).toEqual(
-      expect.arrayContaining(["moa2h3", "demon-h3", "glh3"]),
-    );
+  it("silently skips the DeMon/GLH3 sister-event summaries", () => {
+    const patterns = (config.silentlySkipPatterns ?? []).map((p) => new RegExp(p.pattern));
+    const skips = (s: string) => patterns.some((re) => re.test(s));
+    expect(skips("DeMonH3 - Belle Isle Be Damned")).toBe(true);
+    expect(skips("DeMon H3 Monday Run")).toBe(true);
+    expect(skips("GLH3 HashMas")).toBe(true);
+    expect(skips("Greater Lansing H3 Holiday Trail")).toBe(true);
+    expect(skips("MoA2H3 Red Dress Run")).toBe(false);
+  });
+
+  it("bumps demon-h3 + glh3 scrapeDays to 365 so each owns its own calendar", () => {
+    for (const name of ["DeMon H3 Google Calendar", "GLH3 Google Calendar"]) {
+      const src = SOURCES.find((s) => s.name === name);
+      expect(src?.scrapeDays).toBe(365);
+    }
   });
 });
 

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -209,7 +209,7 @@ describe("MoA2H3 Google Calendar — sister kennels silently skipped, owned by t
   const moaSource = SOURCES.find((s) => s.name === "MoA2H3 Google Calendar");
   if (!moaSource?.config) throw new Error("MoA2H3 Google Calendar seed config missing");
   const config = moaSource.config as {
-    silentlySkipPatterns?: { pattern: string }[];
+    silentlySkipPatterns?: { pattern: string; field?: string }[];
     kennelPatterns?: unknown;
     defaultKennelTag?: string;
   };
@@ -223,6 +223,10 @@ describe("MoA2H3 Google Calendar — sister kennels silently skipped, owned by t
   });
 
   it("silently skips the DeMon/GLH3 sister-event summaries", () => {
+    // Field must target the title — a misconfig (e.g. "location") would let the
+    // sister summaries through and re-introduce SOURCE_KENNEL_MISMATCH noise.
+    expect(config.silentlySkipPatterns?.length).toBeGreaterThan(0);
+    expect(config.silentlySkipPatterns?.every((p) => (p.field ?? "title") === "title")).toBe(true);
     const patterns = (config.silentlySkipPatterns ?? []).map((p) => new RegExp(p.pattern));
     const skips = (s: string) => patterns.some((re) => re.test(s));
     expect(skips("DeMonH3 - Belle Isle Be Damned")).toBe(true);


### PR DESCRIPTION
Follow-up to #2152. **PR #2152's Option B for #1738 is architecturally wrong and is actively cancelling legitimate data in prod** — this reverts it to the issue's recommended Option A.

## What went wrong

#2152 routed the DeMon/GLH3 sister events through the MoA2H3 calendar and added `demon-h3`/`glh3` to MoA2H3's `kennelCodes`. Post-merge verification found:

1. **MoA2H3's reconcile now owns demon-h3/glh3** and cancels their own legitimate runs. A re-scrape cancelled **110 demon-h3 events**, and the every-6h cron re-cancels them after any restore.
2. **The issue's premise was wrong.** demon-h3's own calendar (`demonhashhouseharriers@gmail.com`) has **82 events → 2027** including the inaugural sisters, and glh3's has **169 events (2020→2027, incl. HashMas)**. Their sources just had `scrapeDays: 90`, so they weren't pulling the history. They don't need MoA2H3 to route anything.

## The fix (Option A — the issue's own recommendation)

- **MoA2H3** → silent-skip the sister summaries again (#1739); `kennelCodes` back to `["moa2h3"]` so its reconcile never scopes demon-h3/glh3.
- **demon-h3 + glh3** → `scrapeDays` 90 → 365 so each owns its full calendar from its **own** source. 365 keeps reconcile's window aligned with the adapter's `futureHorizonDays` cap (no future gap; per the wide-backfill memory).

The adapter test for #1738 is rewritten to assert the Option A config contract (silent-skip patterns, `kennelCodes == ["moa2h3"]`, no sister `kennelPatterns`, sister `scrapeDays == 365`).

## Verification
- `npm run lint`, `npx tsc --noEmit`, `npm test` (9043 passed) all green.
- demon-h3 / glh3 own-calendar contents verified live against their public GCal APIs.

## Prod state & post-merge
Prod was reverted to the safe silent-skip state during investigation, but **a `db seed` from main's Option-B seed re-applied Option B** (and the cron re-cancelled the 110) — manual reverts get clobbered until this PR merges. After merge:
1. Apply the seed to prod (silent-skip MoA2H3 + `scrapeDays=365` for demon-h3/glh3).
2. Restore the 110 cancelled demon-h3 events to CONFIRMED.
3. One-shot scrape demon-h3 (and glh3) so they re-own the sister events (multi-source).

Closes #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)