### PR TITLE
fix(travel): de-dupe same-date events in cadence inference

### DIFF
--- a/scripts/propose-rule-fixes.ts
+++ b/scripts/propose-rule-fixes.ts
@@ -85,12 +85,22 @@ function weekdayStats(dates: Date[]): { hist: number[]; dom: number; share: numb
   return { hist, dom, share: hist[dom] / total };
 }
 
-/** Median gap (days) between consecutive sorted dates → cadence label. */
+/**
+ * Median gap (days) between consecutive run DATES → cadence label.
+ *
+ * Collapses same-date events to distinct run days first. Many kennels publish
+ * two (or more) events per run day — Walkers @10:00 / Runners @11:00 pace
+ * splits, A-to-B legs, etc. (RDH3 does this on ~90% of its run days). Event
+ * dates are stored as UTC noon, so co-day rows share an identical getTime();
+ * without the dedupe they contribute 0-day gaps and a monthly kennel's median
+ * cadence collapses to "weekly" — the spurious "~0d median gap" anomaly.
+ * Cadence is a property of run days, not event rows.
+ */
 function cadenceOf(dates: Date[]): { medianGap: number; cadence: "weekly" | "biweekly" | "monthly" | "irregular" } {
-  if (dates.length < 2) return { medianGap: 0, cadence: "irregular" };
-  const sorted = [...dates].sort((a, b) => a.getTime() - b.getTime());
+  const distinct = [...new Set(dates.map((d) => d.getTime()))].sort((a, b) => a - b);
+  if (distinct.length < 2) return { medianGap: 0, cadence: "irregular" };
   const gaps: number[] = [];
-  for (let i = 1; i < sorted.length; i++) gaps.push((sorted[i].getTime() - sorted[i - 1].getTime()) / DAY_MS);
+  for (let i = 1; i < distinct.length; i++) gaps.push((distinct[i] - distinct[i - 1]) / DAY_MS);
   const g = median(gaps);
   let cadence: "weekly" | "biweekly" | "monthly" | "irregular";
   if (g <= 10) cadence = "weekly";


### PR DESCRIPTION
## Summary

Fixes a false-positive **\"~0d median gap\"** anomaly in `scripts/propose-rule-fixes.ts` that was surfaced during travel-mode rule-quality work (originally reported as an RDH3 dedup miss).

`cadenceOf()` measured the gap between consecutive event **rows**. Many kennels publish 2+ events per run day — Walkers @10:00 / Runners @11:00 pace splits, A-to-B legs. **RDH3 (Copenhagen) does this on 133 of 147 run days back to 2015.** Those co-day rows produced 0-day gaps, so the median gap for a monthly kennel collapsed to 0 and it was misclassified as `weekly`.

Cadence is a property of **run days**, not event rows. The fix de-dupes to distinct run days before computing gaps (event dates are stored as UTC noon, so co-day rows share an identical `getTime()`).

## Not a data defect

The investigation that led here confirmed the two RDH3 rows per day are a **legitimate Walkers/Runners double-header** — distinct Google Calendar events with different EIDs, start times, and titles (`…_20260510T080000Z` vs `…_20260510T090000Z`). The merge pipeline correctly keeps both canonical because `eventSignature` keys on `(startTime, sourceUrl, title)`. **No production data was changed** — collapsing either row would have deleted a real trail.

## Verification (read-only, against prod)

- RDH3: `medianGap=0 / weekly` → **`medianGap=28 / monthly`**
- **Zero** `~0d` anomalies remain anywhere in the regenerated output
- `tsc --noEmit` clean, `eslint` clean
- Codex adversarial review: **approve**, no material findings

## Follow-up (not in this PR)

`scripts/audit-travel-predictions.ts` may share the same per-row assumption in its census/backtest — not yet audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)