### PR TITLE
fix(rules): restore seasonal schedules for Summit, FH3, Beantown

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -266,10 +266,13 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "beantown", shortName: "Beantown", fullName: "Beantown City Hash House Harriers", region: "Boston, MA", hashCash: "$5", contactEmail: "HashCash@beantown.cityhash.org",
-      // Travel-prediction fix: previously dark (no rule). Independent history is ~weekly Sunday
-      // (recently shifted from Wednesday). Revisit if it reverts.
+      // Seasonal (corrected — a prior fix wrongly flattened this to year-round Sunday):
+      // summer Sundays (May–Sep), winter Wednesdays (Oct–Apr) per 2yr independent history.
       scheduleDayOfWeek: "Sunday", scheduleFrequency: "Weekly",
-      scheduleRules: [{ rrule: "FREQ=WEEKLY;BYDAY=SU" }],
+      scheduleRules: [
+        { rrule: "FREQ=WEEKLY;BYDAY=SU", label: "Summer", validFrom: "05-01", validUntil: "09-30", displayOrder: 0 },
+        { rrule: "FREQ=WEEKLY;BYDAY=WE", label: "Winter", validFrom: "10-01", validUntil: "04-30", displayOrder: 1 },
+      ],
     },
     {
       kennelCode: "bos-moon", shortName: "Boston Moon", fullName: "Boston Moon Hash House Harriers", region: "Boston, MA",
@@ -388,10 +391,14 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "summit", shortName: "Summit", fullName: "Summit Hash House Harriers", region: "North NJ",
       scheduleDayOfWeek: "Saturday", scheduleTime: "3:00 PM", scheduleFrequency: "Weekly",
-      // Travel-prediction fix: independent history is ~weekly Saturday year-round (23/24 recent
-      // runs); the old "summer Monday" note was stale. Was scheduleDayOfWeek "Monday".
-      scheduleRules: [{ rrule: "FREQ=WEEKLY;BYDAY=SA", startTime: "15:00" }],
-      scheduleNotes: "Saturdays, ~3 PM.",
+      // Seasonal (corrected — a prior fix wrongly flattened this to year-round Saturday):
+      // summer Mondays 7 PM (Jun–Aug), winter Saturdays 3 PM (Sep–May). 2yr independent history is
+      // Monday-dominant Jun–Aug, Saturday-dominant Sep–May.
+      scheduleRules: [
+        { rrule: "FREQ=WEEKLY;BYDAY=MO", startTime: "19:00", label: "Summer", validFrom: "06-01", validUntil: "08-31", displayOrder: 0 },
+        { rrule: "FREQ=WEEKLY;BYDAY=SA", startTime: "15:00", label: "Winter", validFrom: "09-01", validUntil: "05-31", displayOrder: 1 },
+      ],
+      scheduleNotes: "Summer: Mondays 7 PM (Jun–Aug). Winter: Saturdays 3 PM (Sep–May).",
     },
     {
       kennelCode: "sfm", shortName: "Summit Full Moon", fullName: "Summit Full Moon H3", region: "North NJ",
@@ -2900,10 +2907,13 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "fh3", shortName: "FH3", fullName: "Frankfurt Hash House Harriers", region: "Frankfurt", country: "Germany",
       website: "https://frankfurt-hash.de",
-      scheduleDayOfWeek: "Thursday", scheduleFrequency: "Weekly",
-      // Travel-prediction fix: schedule changed Sun(biweekly)→Thu(weekly) in summer 2026 per
-      // independent history (was scheduleDayOfWeek "Sunday", Biweekly). Revisit if it reverts in winter.
-      scheduleRules: [{ rrule: "FREQ=WEEKLY;BYDAY=TH" }],
+      scheduleDayOfWeek: "Sunday", scheduleFrequency: "Weekly",
+      // Seasonal (corrected — a prior fix wrongly flattened this to year-round Thursday):
+      // summer Thursdays (May–Aug), winter Sundays (Sep–Apr); weekly both seasons per 2yr history.
+      scheduleRules: [
+        { rrule: "FREQ=WEEKLY;BYDAY=TH", label: "Summer", validFrom: "05-01", validUntil: "08-31", displayOrder: 0 },
+        { rrule: "FREQ=WEEKLY;BYDAY=SU", startTime: "14:30", label: "Winter", validFrom: "09-01", validUntil: "04-30", displayOrder: 1 },
+      ],
       hashCash: "€5",
       description: "Frankfurt's biweekly Sunday afternoon hash. Run #2114+ and counting.",
       latitude: 50.11, longitude: 8.68,

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2915,7 +2915,7 @@ export const KENNELS: KennelSeed[] = [
         { rrule: "FREQ=WEEKLY;BYDAY=SU", startTime: "14:30", label: "Winter", validFrom: "09-01", validUntil: "04-30", displayOrder: 1 },
       ],
       hashCash: "€5",
-      description: "Frankfurt's biweekly Sunday afternoon hash. Run #2114+ and counting.",
+      description: "Frankfurt's weekly hash — summer Thursdays, winter Sunday afternoons. Run #2114+ and counting.",
       latitude: 50.11, longitude: 8.68,
     },
     {


### PR DESCRIPTION
## What & why

A prior travel-prediction fix ([#2154](https://github.com/johnrclem/hashtracks-web/pull/2154)) **flattened three genuinely seasonal kennels** into year-round rules. The change-detector there mistook a **seasonal day-switch** for a permanent schedule change (Summit's seed note literally said "summer Mondays / winter Saturdays" — I wrongly dismissed it as stale because the derivation window was all winter/spring).

2-year independent history confirms each switches weekday by season:

| Kennel | Summer | Winter |
|---|---|---|
| **Summit** | Mondays 7 PM (Jun–Aug) | Saturdays 3 PM (Sep–May) |
| **FH3** (Frankfurt) | Thursdays (May–Aug) | Sundays (Sep–Apr) |
| **Beantown** (Boston) | Sundays (May–Sep) | Wednesdays (Oct–Apr) |

Each is restored to a two-slot seasonal `scheduleRules[]` with `validFrom`/`validUntil`, so Travel Mode projects the correct weekday per season instead of mispredicting all summer.

## Verification

- `tsc` clean; backfill materializes 2 active HIGH rules per kennel on the local dev DB with the right season anchors.

## Post-merge (prod)

`npx tsx scripts/backfill-schedule-rules.ts --apply` (applied from this branch ahead of merge since it's a live mis-prediction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)