### PR TITLE
feat(rules): weekly rule-drift check + authoring guardrail

### DIFF
--- a/scripts/propose-rule-fixes.ts
+++ b/scripts/propose-rule-fixes.ts
@@ -111,18 +111,31 @@ function cadenceOf(dates: Date[]): { medianGap: number; cadence: "weekly" | "biw
 }
 
 /**
- * Seasonality probe: split the derivation events into two half-years (Apr–Sep vs Oct–Mar) and
- * compare the dominant weekday in each. Different dominant days with enough support → seasonal.
+ * Seasonality probe: compare CORE summer (May–Aug) vs CORE winter (Nov–Feb), skipping the shoulder
+ * months (Mar/Apr, Sep/Oct) where the switch happens — half-year buckets blur the boundary and miss
+ * real switchers (the Summit/FH3/Beantown class). Matches the seasonal-detector SQL.
  */
 function seasonalitySplit(dates: Date[]): { seasonal: boolean; summerDay: number | null; winterDay: number | null } {
-  const summer = dates.filter((d) => d.getUTCMonth() >= 3 && d.getUTCMonth() <= 8);
-  const winter = dates.filter((d) => d.getUTCMonth() < 3 || d.getUTCMonth() > 8);
+  const inMonths = (d: Date, months: number[]) => months.includes(d.getUTCMonth());
+  const summer = dates.filter((d) => inMonths(d, [4, 5, 6, 7])); // May–Aug
+  const winter = dates.filter((d) => inMonths(d, [10, 11, 0, 1])); // Nov–Feb
   if (summer.length < 3 || winter.length < 3) return { seasonal: false, summerDay: null, winterDay: null };
   const s = weekdayStats(summer);
   const w = weekdayStats(winter);
   const seasonal = s.dom !== w.dom && s.share >= MIN_DOMINANT_SHARE && w.share >= MIN_DOMINANT_SHARE;
   return { seasonal, summerDay: s.dom, winterDay: w.dom };
 }
+
+/** Days spanned by the independent history — used to gate confident flat rules (<1yr = risky). */
+function historySpanDays(dates: Date[]): number {
+  if (dates.length < 2) return 0;
+  let min = dates[0].getTime();
+  let max = dates[0].getTime();
+  for (const dt of dates) { const t = dt.getTime(); if (t < min) min = t; if (t > max) max = t; }
+  return Math.round((max - min) / (24 * 60 * 60 * 1000));
+}
+/** Below this much history, a flat weekly rule might be hiding an unseen season. */
+const MIN_SPAN_FOR_FLAT_RULE = 330;
 
 /** Current rule's BYDAY weekday index, if the rrule encodes a single weekday. */
 function ruleWeekday(rrule: string): number | null {
@@ -263,6 +276,14 @@ function buildProposal(
   // A recent day-change makes the derivation-based weekday stale → flag for the reviewer.
   if (changed && recentDomDay !== null) {
     const tail = `⚠ recent 4w runs are ${DAY_NAME[recentDomDay]} (${recent.length} ev), not ${DAY_NAME[dom]} — schedule likely changed; trust recent.`;
+    manualNote = manualNote ? `${manualNote} ${tail}` : tail;
+  }
+
+  // Guardrail (anti-Summit): never lock in a confident flat weekly rule from <1 full annual cycle —
+  // the unseen season may switch the weekday. Flag it for review instead of flattening.
+  const spanDays = historySpanDays(allIndependent);
+  if (kind === "flat-weekly" && spanDays < MIN_SPAN_FOR_FLAT_RULE) {
+    const tail = `⚠ only ${spanDays}d of history (<1yr) — could be seasonal; verify a full annual cycle before locking a flat rule.`;
     manualNote = manualNote ? `${manualNote} ${tail}` : tail;
   }
 

--- a/scripts/propose-rule-fixes.ts
+++ b/scripts/propose-rule-fixes.ts
@@ -129,9 +129,10 @@ function seasonalitySplit(dates: Date[]): { seasonal: boolean; summerDay: number
 /** Days spanned by the independent history — used to gate confident flat rules (<1yr = risky). */
 function historySpanDays(dates: Date[]): number {
   if (dates.length < 2) return 0;
-  let min = dates[0].getTime();
-  let max = dates[0].getTime();
-  for (const dt of dates) { const t = dt.getTime(); if (t < min) min = t; if (t > max) max = t; }
+  // `dates` arrives sorted ascending from the caller (buildProposal's `allIndependent`), so the
+  // span is just last − first — no need to scan for min/max.
+  const min = dates[0].getTime();
+  const max = dates[dates.length - 1].getTime();
   return Math.round((max - min) / (24 * 60 * 60 * 1000));
 }
 /** Below this much history, a flat weekly rule might be hiding an unseen season. */

--- a/src/app/api/cron/rule-drift/route.ts
+++ b/src/app/api/cron/rule-drift/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { verifyCronAuth } from "@/lib/cron-auth";
+import { prisma } from "@/lib/db";
+import { getValidatedRepo } from "@/lib/github-repo";
+import { detectRuleDrift, type DriftFinding } from "@/pipeline/rule-drift";
+
+/**
+ * Weekly schedule-rule drift check.
+ *
+ * Flags kennels whose active rule predicts a different weekday than the kennel's recent
+ * independent events actually fall on — a season switch, a permanent change, or a rule that
+ * flattened a seasonal kennel. Files ONE deduplicated GitHub issue (label `rule-drift`) so the
+ * finding self-surfaces; closing it lets the next real drift re-file.
+ *
+ * Triggered by Vercel Cron (GET) or QStash (POST) or manually with Bearer CRON_SECRET.
+ */
+const DRIFT_LABEL = "rule-drift";
+
+function renderIssueBody(findings: DriftFinding[]): string {
+  const rows = findings
+    .map(
+      (f) =>
+        `| ${f.shortName} (\`${f.kennelCode}\`) | ${f.region} | ${f.predictedWeekdays.join("/")} | **${f.actualWeekday}** (${Math.round(f.actualShare * 100)}%, ${f.recentEventCount} ev) | \`${f.activeRules}\` |`,
+    )
+    .join("\n");
+  return [
+    "Detected by the weekly rule-drift check (`/api/cron/rule-drift`). Each kennel below has an",
+    "active schedule rule whose currently-projected weekday disagrees with its recent independent",
+    "events — likely a **seasonal switch**, a permanent schedule change, or a rule that flattened a",
+    "seasonal kennel. Fix by authoring/correcting the kennel's `scheduleRules[]` (seasonal slots use",
+    "`validFrom`/`validUntil`); see the seasonal-detector workflow.",
+    "",
+    "| Kennel | Region | Rule predicts | Recent actual | Active rule(s) |",
+    "|---|---|---|---|---|",
+    rows,
+    "",
+    "_Close this issue once addressed; the next run re-files if drift remains._",
+  ].join("\n");
+}
+
+async function fileDriftIssue(findings: DriftFinding[]): Promise<{ filed: boolean; reason: string }> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return { filed: false, reason: "no GITHUB_TOKEN" };
+  const repo = getValidatedRepo();
+  const headers = { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json", "Content-Type": "application/json" };
+
+  // Dedup: skip if an open rule-drift issue already exists.
+  const existing = await fetch(
+    `https://api.github.com/repos/${repo}/issues?state=open&labels=${encodeURIComponent(DRIFT_LABEL)}&per_page=1`,
+    { headers },
+  );
+  if (existing.ok) {
+    const open = (await existing.json()) as unknown[];
+    if (Array.isArray(open) && open.length > 0) return { filed: false, reason: "open rule-drift issue exists" };
+  }
+
+  const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      title: `Schedule-rule drift: ${findings.length} kennel(s) predicting the wrong weekday`,
+      body: renderIssueBody(findings),
+      labels: [DRIFT_LABEL],
+    }),
+  });
+  if (!res.ok) return { filed: false, reason: `github ${res.status}` };
+  return { filed: true, reason: "issue created" };
+}
+
+export async function POST(request: Request) {
+  const auth = await verifyCronAuth(request);
+  if (!auth.authenticated) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const findings = await detectRuleDrift(prisma);
+    let issue = { filed: false, reason: "no drift" };
+    if (findings.length > 0) issue = await fileDriftIssue(findings);
+    console.log(`[rule-drift] ${findings.length} drifted kennel(s); issue: ${issue.reason}`);
+    return NextResponse.json({ data: { driftCount: findings.length, issue, findings } });
+  } catch (err) {
+    console.error("[rule-drift] failed:", err);
+    Sentry.captureException(err);
+    return NextResponse.json(
+      { data: null, error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}
+
+/** Vercel Cron triggers GET requests. */
+export async function GET(request: Request) {
+  return POST(request);
+}

--- a/src/pipeline/rule-drift.test.ts
+++ b/src/pipeline/rule-drift.test.ts
@@ -1,0 +1,50 @@
+import { dominantWeekday, judgeDrift, weekdayName } from "./rule-drift";
+
+// UTC-noon dates on known weekdays. 2026-06-01 is a Monday.
+const MON = "2026-06-01"; // Mon
+const TUE = "2026-06-02";
+const WED = "2026-06-03";
+const SAT = "2026-06-06"; // Sat
+const d = (iso: string) => new Date(iso + "T12:00:00Z");
+
+describe("dominantWeekday", () => {
+  it("finds the most common weekday + share", () => {
+    const r = dominantWeekday([d(SAT), d(SAT), d(SAT), d(MON)]);
+    expect(weekdayName(r.day)).toBe("Sat");
+    expect(r.count).toBe(4);
+    expect(r.share).toBeCloseTo(0.75);
+  });
+  it("returns day -1 for an empty set", () => {
+    expect(dominantWeekday([]).day).toBe(-1);
+  });
+});
+
+describe("judgeDrift", () => {
+  const recentSat = [d(SAT), d(SAT), d(SAT), d(SAT), d(SAT)]; // clear Saturday
+
+  it("flags drift when reality (Sat) is not among the predicted weekdays (Mon)", () => {
+    const r = judgeDrift(new Set([1 /* Mon */]), recentSat);
+    expect(r).not.toBeNull();
+    expect(weekdayName(r!.actualDay)).toBe("Sat");
+  });
+
+  it("does NOT flag when the rule already predicts the recent weekday (Sat)", () => {
+    expect(judgeDrift(new Set([6 /* Sat */]), recentSat)).toBeNull();
+  });
+
+  it("does NOT flag a correctly multi-day rule (predicts Sat AND Mon)", () => {
+    expect(judgeDrift(new Set([6, 1]), recentSat)).toBeNull();
+  });
+
+  it("does NOT flag with too few recent events", () => {
+    expect(judgeDrift(new Set([1]), [d(SAT), d(SAT)])).toBeNull();
+  });
+
+  it("does NOT flag when recent events are scattered (no clear dominant day)", () => {
+    expect(judgeDrift(new Set([1]), [d(SAT), d(MON), d(TUE), d(WED)])).toBeNull();
+  });
+
+  it("does NOT flag when the rule projects nothing in the window (empty predicted set)", () => {
+    expect(judgeDrift(new Set<number>(), recentSat)).toBeNull();
+  });
+});

--- a/src/pipeline/rule-drift.ts
+++ b/src/pipeline/rule-drift.ts
@@ -1,0 +1,154 @@
+/**
+ * Schedule-rule drift detection (Travel Mode prediction quality).
+ *
+ * Catches kennels whose active schedule rule predicts a different weekday than the
+ * kennel's RECENT independent events actually fall on. This surfaces, automatically:
+ *   - a kennel that flipped seasons (summer Mon → winter Sat) before the off-season
+ *     rule mis-predicts for months, AND
+ *   - a permanent schedule change, AND
+ *   - a rule that was authored from a partial-year window and flattened a seasonal kennel.
+ *
+ * Crucially it is SEASON-AWARE: the "predicted weekday" comes from projectTrails over the
+ * next few weeks, so the rule's validFrom/validUntil gating is honored — a correctly-seasonal
+ * kennel predicts the right day for *now* and never drifts. The detector only fires when the
+ * live rule disagrees with reality, regardless of why.
+ *
+ * Reuses the real engine (projectTrails) + isEligibleActual so detection matches production.
+ */
+import type { PrismaClient, ScheduleConfidence } from "@/generated/prisma/client";
+import { CANONICAL_EVENT_WHERE } from "@/lib/event-filters";
+import { EVENT_ELIGIBILITY_SELECT, isEligibleActual } from "@/lib/event-eligibility";
+import { projectTrails, type ScheduleRuleInput } from "@/lib/travel/projections";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** Recent independent events window used as ground truth. */
+export const DRIFT_RECENT_DAYS = 42;
+/** Forward window over which we read the rule's currently-projected weekday(s). */
+export const DRIFT_PROJECT_DAYS = 28;
+/** Need at least this many recent independent events to judge drift (avoid noise). */
+export const DRIFT_MIN_EVENTS = 4;
+/** The recent dominant weekday must be at least this share to call it a clear miss. */
+export const DRIFT_MIN_SHARE = 0.6;
+
+const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+// ── Pure helpers (exported for tests) ─────────────────────────────────────────
+
+/** Dominant UTC weekday over a set of dates + its share and count. */
+export function dominantWeekday(dates: Date[]): { day: number; share: number; count: number } {
+  if (dates.length === 0) return { day: -1, share: 0, count: 0 };
+  const hist = new Array(7).fill(0);
+  for (const d of dates) hist[d.getUTCDay()]++;
+  let day = 0;
+  for (let i = 1; i < 7; i++) if (hist[i] > hist[day]) day = i;
+  return { day, share: hist[day] / dates.length, count: dates.length };
+}
+
+/**
+ * Drift iff the recent dominant weekday is CLEAR (enough events, high share) and is NOT one of
+ * the weekdays the rule currently projects. Returns null when there's no drift (or not enough
+ * signal). `predictedDays` is the set of weekdays the active rule projects for the near window.
+ */
+export function judgeDrift(
+  predictedDays: ReadonlySet<number>,
+  recentDates: Date[],
+  minEvents = DRIFT_MIN_EVENTS,
+  minShare = DRIFT_MIN_SHARE,
+): { actualDay: number; actualShare: number; count: number } | null {
+  const dom = dominantWeekday(recentDates);
+  if (dom.count < minEvents || dom.share < minShare) return null;
+  if (predictedDays.size === 0) return null; // rule projects nothing here — not a weekday-drift signal
+  if (predictedDays.has(dom.day)) return null;
+  return { actualDay: dom.day, actualShare: dom.share, count: dom.count };
+}
+
+export function weekdayName(day: number): string {
+  return WEEKDAY[day] ?? "?";
+}
+
+// ── Detection ─────────────────────────────────────────────────────────────────
+export interface DriftFinding {
+  kennelCode: string;
+  shortName: string;
+  region: string;
+  predictedWeekdays: string[];
+  actualWeekday: string;
+  actualShare: number;
+  recentEventCount: number;
+  activeRules: string;
+}
+
+interface KennelRow { id: string; kennelCode: string; shortName: string; region: string }
+interface RuleRow {
+  id: string; kennelId: string; rrule: string; anchorDate: string | null; startTime: string | null;
+  confidence: ScheduleConfidence; notes: string | null; label: string | null;
+  validFrom: string | null; validUntil: string | null;
+}
+
+export async function detectRuleDrift(prisma: PrismaClient, now: Date = new Date()): Promise<DriftFinding[]> {
+  const recentStart = new Date(now.getTime() - DRIFT_RECENT_DAYS * DAY_MS);
+  const projectEnd = new Date(now.getTime() + DRIFT_PROJECT_DAYS * DAY_MS);
+
+  const [kennels, rules, events] = await Promise.all([
+    prisma.kennel.findMany({ where: { isHidden: false }, select: { id: true, kennelCode: true, shortName: true, region: true } }) as Promise<KennelRow[]>,
+    prisma.scheduleRule.findMany({
+      where: { isActive: true, kennel: { isHidden: false } },
+      select: { id: true, kennelId: true, rrule: true, anchorDate: true, startTime: true, confidence: true, notes: true, label: true, validFrom: true, validUntil: true },
+    }) as Promise<RuleRow[]>,
+    prisma.event.findMany({
+      where: { ...CANONICAL_EVENT_WHERE, status: "CONFIRMED", date: { gte: recentStart, lte: now }, kennel: { isHidden: false } },
+      select: { kennelId: true, date: true, eventKennels: { select: { kennelId: true } }, ...EVENT_ELIGIBILITY_SELECT },
+    }),
+  ]);
+
+  const recentByKennel = new Map<string, Date[]>();
+  for (const e of events) {
+    if (!isEligibleActual(e)) continue;
+    const kids = new Set<string>([e.kennelId, ...e.eventKennels.map((ek) => ek.kennelId)]);
+    for (const kid of kids) {
+      const arr = recentByKennel.get(kid);
+      if (arr) arr.push(e.date);
+      else recentByKennel.set(kid, [e.date]);
+    }
+  }
+  const rulesByKennel = new Map<string, RuleRow[]>();
+  for (const r of rules) {
+    const arr = rulesByKennel.get(r.kennelId);
+    if (arr) arr.push(r);
+    else rulesByKennel.set(r.kennelId, [r]);
+  }
+
+  const findings: DriftFinding[] = [];
+  const kennelByCode = new Map(kennels.map((k) => [k.id, k]));
+  for (const k of kennels) {
+    const kRules = rulesByKennel.get(k.id) ?? [];
+    if (kRules.length === 0) continue;
+    const recent = recentByKennel.get(k.id) ?? [];
+    if (recent.length < DRIFT_MIN_EVENTS) continue;
+
+    // Season-aware predicted weekdays: project the rule over the near window and collect days.
+    const ruleInputs: ScheduleRuleInput[] = kRules.map((r) => ({
+      id: r.id, kennelId: r.kennelId, rrule: r.rrule, anchorDate: r.anchorDate, startTime: r.startTime,
+      confidence: r.confidence, notes: r.notes, label: r.label, validFrom: r.validFrom, validUntil: r.validUntil,
+    }));
+    const predictedDays = new Set<number>();
+    for (const proj of projectTrails(ruleInputs, now, projectEnd)) {
+      if (proj.date) predictedDays.add(proj.date.getUTCDay());
+    }
+
+    const drift = judgeDrift(predictedDays, recent);
+    if (!drift) continue;
+    findings.push({
+      kennelCode: k.kennelCode,
+      shortName: kennelByCode.get(k.id)?.shortName ?? k.shortName,
+      region: k.region,
+      predictedWeekdays: [...predictedDays].sort((a, b) => a - b).map(weekdayName),
+      actualWeekday: weekdayName(drift.actualDay),
+      actualShare: drift.actualShare,
+      recentEventCount: drift.count,
+      activeRules: kRules.map((r) => r.rrule + (r.validFrom ? ` [${r.validFrom}..${r.validUntil}]` : "")).join(" | "),
+    });
+  }
+  findings.sort((a, b) => a.shortName.localeCompare(b.shortName));
+  return findings;
+}

--- a/src/pipeline/rule-drift.ts
+++ b/src/pipeline/rule-drift.ts
@@ -8,10 +8,12 @@
  *   - a permanent schedule change, AND
  *   - a rule that was authored from a partial-year window and flattened a seasonal kennel.
  *
- * Crucially it is SEASON-AWARE: the "predicted weekday" comes from projectTrails over the
- * next few weeks, so the rule's validFrom/validUntil gating is honored — a correctly-seasonal
- * kennel predicts the right day for *now* and never drifts. The detector only fires when the
- * live rule disagrees with reality, regardless of why.
+ * Crucially it is SEASON-AWARE: the "predicted weekday(s)" come from projectTrails over the
+ * observed-plus-upcoming span (the same 42d we read actuals from, through the next few weeks),
+ * so the rule's validFrom/validUntil gating is honored AND a kennel sitting right on a season
+ * boundary keeps its old-season weekday in the predicted set while the recent actuals still lean
+ * that way — it never false-fires across the switch. The detector only fires when the live rule
+ * disagrees with reality, regardless of why.
  *
  * Reuses the real engine (projectTrails) + isEligibleActual so detection matches production.
  */
@@ -119,20 +121,25 @@ export async function detectRuleDrift(prisma: PrismaClient, now: Date = new Date
   }
 
   const findings: DriftFinding[] = [];
-  const kennelByCode = new Map(kennels.map((k) => [k.id, k]));
   for (const k of kennels) {
     const kRules = rulesByKennel.get(k.id) ?? [];
     if (kRules.length === 0) continue;
     const recent = recentByKennel.get(k.id) ?? [];
     if (recent.length < DRIFT_MIN_EVENTS) continue;
 
-    // Season-aware predicted weekdays: project the rule over the near window and collect days.
+    // Season-aware predicted weekdays. Project over the FULL observed-plus-upcoming span
+    // [recentStart, projectEnd] — not just the forward window — so a correctly-seasonal kennel
+    // that just crossed a validFrom/validUntil boundary keeps its OLD-season weekday in the set
+    // while the recent actuals still lean that way. Otherwise the 42d actuals (prior season)
+    // would be compared against only the next 28d projections (new season) and false-fire for
+    // weeks after every switch (Codex review on PR #2166). A genuinely stale rule still projects
+    // only its wrong weekday across the whole span, so real drift is unaffected.
     const ruleInputs: ScheduleRuleInput[] = kRules.map((r) => ({
       id: r.id, kennelId: r.kennelId, rrule: r.rrule, anchorDate: r.anchorDate, startTime: r.startTime,
       confidence: r.confidence, notes: r.notes, label: r.label, validFrom: r.validFrom, validUntil: r.validUntil,
     }));
     const predictedDays = new Set<number>();
-    for (const proj of projectTrails(ruleInputs, now, projectEnd)) {
+    for (const proj of projectTrails(ruleInputs, recentStart, projectEnd)) {
       if (proj.date) predictedDays.add(proj.date.getUTCDay());
     }
 
@@ -140,7 +147,7 @@ export async function detectRuleDrift(prisma: PrismaClient, now: Date = new Date
     if (!drift) continue;
     findings.push({
       kennelCode: k.kennelCode,
-      shortName: kennelByCode.get(k.id)?.shortName ?? k.shortName,
+      shortName: k.shortName,
       region: k.region,
       predictedWeekdays: [...predictedDays].sort((a, b) => a - b).map(weekdayName),
       actualWeekday: weekdayName(drift.actualDay),

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,10 @@
     {
       "path": "/api/cron/travel-draft-gc",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/rule-drift",
+      "schedule": "0 9 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## What & why

Seasonal kennels (summer day X / winter day Y) — and schedule changes generally — were silently mis-predicting until someone noticed (Summit/FH3/Beantown). The model handles seasonality fine via `validFrom`/`validUntil`; the gap was the **authoring + maintenance** pipeline. This adds a layered defense so future seasonal kennels get into the prediction model correctly **on their own**.

## #1 — Weekly rule-drift detection (the runtime safety net)

`src/pipeline/rule-drift.ts` → `detectRuleDrift()`: flags any kennel whose **active rule predicts a different weekday** than its **recent (42d) independent events** actually fall on.

- **Season-aware:** the "predicted weekday" comes from `projectTrails` over the next 4 weeks, so `validFrom`/`validUntil` gating is honored. A correctly-seasonal kennel predicts the right day for *now* and never drifts — the check fires only on a genuine rule↔reality mismatch (a season switch, a permanent change, or a rule that flattened a seasonal kennel).
- Weekly cron `/api/cron/rule-drift` files **one deduplicated GitHub issue** (label `rule-drift`) listing the drifted kennels; closing it lets the next real drift re-file. Guarded on `GITHUB_TOKEN`.
- Reuses `projectTrails` + `isEligibleActual` so detection matches production. **8 unit tests.**

**Validated read-only against prod** — it flagged exactly the right things:
| Kennel | Rule predicts | Recent actual | |
|---|---|---|---|
| Boston H3 | Sun | **Wed** (86%) | summer switch — currently flat-Sunday |
| SWH3 | Sat | **Sun** (71%) | a seasonal kennel I'd *wrongly excluded* — the detector caught my mistake |
| NVHHH | Mon | **Sun** (60%) | genuine signal for review |
| Summit | Mon | Sat | season-boundary lag (rule just switched Jun 1; trailing window still May-Saturday) |

## #3 — Authoring guardrail (prevent the mistake)

`scripts/propose-rule-fixes.ts`:
- Seasonality probe now compares **core summer (May–Aug) vs core winter (Nov–Feb)**, skipping the shoulder months where the switch happens — catches switchers the old half-year split blurred.
- **Never proposes a confident flat weekly rule from <330 days of history** — flags "could be seasonal; verify a full annual cycle" instead of flattening (the exact Summit failure mode).

## Verification

`tsc` clean · `npm run lint` 0 errors · `npx vitest run` 9,051 passed (incl. 8 new drift tests) · detection validated read-only against prod.

> The Phase 2 prospective ledger (#2164) is the slow backstop behind this; the drift check is the fast signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)