### PR TITLE
fix(rule-drift): recover post-merge review fixes (dedup fallthrough, timeouts, guardrail)

### DIFF
--- a/scripts/propose-rule-fixes.ts
+++ b/scripts/propose-rule-fixes.ts
@@ -128,12 +128,12 @@ function seasonalitySplit(dates: Date[]): { seasonal: boolean; summerDay: number
 
 /** Days spanned by the independent history — used to gate confident flat rules (<1yr = risky). */
 function historySpanDays(dates: Date[]): number {
-  if (dates.length < 2) return 0;
   // `dates` arrives sorted ascending from the caller (buildProposal's `allIndependent`), so the
   // span is just last − first — no need to scan for min/max.
-  const min = dates[0].getTime();
-  const max = dates[dates.length - 1].getTime();
-  return Math.round((max - min) / (24 * 60 * 60 * 1000));
+  const first = dates[0];
+  const last = dates.at(-1);
+  if (!first || !last) return 0;
+  return Math.round((last.getTime() - first.getTime()) / (24 * 60 * 60 * 1000));
 }
 /** Below this much history, a flat weekly rule might be hiding an unseen season. */
 const MIN_SPAN_FOR_FLAT_RULE = 330;
@@ -391,7 +391,13 @@ async function run(prisma: PrismaClient): Promise<void> {
     },
   })) as RuleRow[];
 
-  const loadStart = addDays(today, -(DERIV_START_DAYS_AGO + 5));
+  // Load enough history that the flat-weekly span guardrail can actually be satisfied. The ~205d
+  // derivation window alone caps spanDays below MIN_SPAN_FOR_FLAT_RULE (330d), so every flat-weekly
+  // proposal would be flagged "<1yr" regardless of real history (CodeRabbit review on PR #2166).
+  // Extra-old events fall outside the derivation (28–200d) and holdout (0–28d) windows, so loading
+  // them only widens the span measurement — derivation/holdout are unaffected.
+  const requiredHistoryDays = Math.max(DERIV_START_DAYS_AGO + 5, MIN_SPAN_FOR_FLAT_RULE + HOLDOUT_DAYS);
+  const loadStart = addDays(today, -requiredHistoryDays);
   const events = await prisma.event.findMany({
     where: {
       ...CANONICAL_EVENT_WHERE,

--- a/src/app/api/cron/rule-drift/route.ts
+++ b/src/app/api/cron/rule-drift/route.ts
@@ -45,19 +45,20 @@ async function fileDriftIssue(findings: DriftFinding[]): Promise<{ filed: boolea
   const repo = getValidatedRepo();
   const headers = { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json", "Content-Type": "application/json" };
 
-  // Dedup: skip if an open rule-drift issue already exists.
+  // Dedup: skip if an open rule-drift issue already exists. Bail out (don't file) if the check
+  // itself fails — a transient non-2xx must NOT fall through to POSTing a possibly-duplicate issue.
   const existing = await fetch(
     `https://api.github.com/repos/${repo}/issues?state=open&labels=${encodeURIComponent(DRIFT_LABEL)}&per_page=1`,
-    { headers },
+    { headers, signal: AbortSignal.timeout(15_000) },
   );
-  if (existing.ok) {
-    const open = (await existing.json()) as unknown[];
-    if (Array.isArray(open) && open.length > 0) return { filed: false, reason: "open rule-drift issue exists" };
-  }
+  if (!existing.ok) return { filed: false, reason: `github dedup check failed: ${existing.status}` };
+  const open = (await existing.json()) as unknown[];
+  if (Array.isArray(open) && open.length > 0) return { filed: false, reason: "open rule-drift issue exists" };
 
   const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
     method: "POST",
     headers,
+    signal: AbortSignal.timeout(15_000),
     body: JSON.stringify({
       title: `Schedule-rule drift: ${findings.length} kennel(s) predicting the wrong weekday`,
       body: renderIssueBody(findings),

--- a/src/app/api/cron/rule-drift/route.ts
+++ b/src/app/api/cron/rule-drift/route.ts
@@ -45,28 +45,35 @@ async function fileDriftIssue(findings: DriftFinding[]): Promise<{ filed: boolea
   const repo = getValidatedRepo();
   const headers = { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json", "Content-Type": "application/json" };
 
-  // Dedup: skip if an open rule-drift issue already exists. Bail out (don't file) if the check
-  // itself fails — a transient non-2xx must NOT fall through to POSTing a possibly-duplicate issue.
-  const existing = await fetch(
-    `https://api.github.com/repos/${repo}/issues?state=open&labels=${encodeURIComponent(DRIFT_LABEL)}&per_page=1`,
-    { headers, signal: AbortSignal.timeout(15_000) },
-  );
-  if (!existing.ok) return { filed: false, reason: `github dedup check failed: ${existing.status}` };
-  const open = (await existing.json()) as unknown[];
-  if (Array.isArray(open) && open.length > 0) return { filed: false, reason: "open rule-drift issue exists" };
+  // A fetch timeout/abort REJECTS rather than returning a non-OK Response, so wrap the calls and
+  // convert any throw into a "don't file" reason — a transient GitHub error must degrade gracefully,
+  // not bubble up and 500 the cron (Codex review on PR #2169).
+  try {
+    // Dedup: skip if an open rule-drift issue already exists. Bail out (don't file) if the check
+    // itself fails — a transient non-2xx must NOT fall through to POSTing a possibly-duplicate issue.
+    const existing = await fetch(
+      `https://api.github.com/repos/${repo}/issues?state=open&labels=${encodeURIComponent(DRIFT_LABEL)}&per_page=1`,
+      { headers, signal: AbortSignal.timeout(15_000) },
+    );
+    if (!existing.ok) return { filed: false, reason: `github dedup check failed: ${existing.status}` };
+    const open = (await existing.json()) as unknown[];
+    if (Array.isArray(open) && open.length > 0) return { filed: false, reason: "open rule-drift issue exists" };
 
-  const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
-    method: "POST",
-    headers,
-    signal: AbortSignal.timeout(15_000),
-    body: JSON.stringify({
-      title: `Schedule-rule drift: ${findings.length} kennel(s) predicting the wrong weekday`,
-      body: renderIssueBody(findings),
-      labels: [DRIFT_LABEL],
-    }),
-  });
-  if (!res.ok) return { filed: false, reason: `github ${res.status}` };
-  return { filed: true, reason: "issue created" };
+    const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+      method: "POST",
+      headers,
+      signal: AbortSignal.timeout(15_000),
+      body: JSON.stringify({
+        title: `Schedule-rule drift: ${findings.length} kennel(s) predicting the wrong weekday`,
+        body: renderIssueBody(findings),
+        labels: [DRIFT_LABEL],
+      }),
+    });
+    if (!res.ok) return { filed: false, reason: `github ${res.status}` };
+    return { filed: true, reason: "issue created" };
+  } catch (err) {
+    return { filed: false, reason: `github request failed: ${err instanceof Error ? err.message : "unknown"}` };
+  }
 }
 
 export async function POST(request: Request) {

--- a/src/pipeline/rule-drift.test.ts
+++ b/src/pipeline/rule-drift.test.ts
@@ -7,6 +7,16 @@ const WED = "2026-06-03";
 const SAT = "2026-06-06"; // Sat
 const d = (iso: string) => new Date(iso + "T12:00:00Z");
 
+// Guard: every test below assumes these calendar weekdays. Fail fast if a constant is edited.
+describe("fixture sanity", () => {
+  it("date constants fall on their labelled weekdays", () => {
+    expect(d(MON).getUTCDay()).toBe(1);
+    expect(d(TUE).getUTCDay()).toBe(2);
+    expect(d(WED).getUTCDay()).toBe(3);
+    expect(d(SAT).getUTCDay()).toBe(6);
+  });
+});
+
 describe("dominantWeekday", () => {
   it("finds the most common weekday + share", () => {
     const r = dominantWeekday([d(SAT), d(SAT), d(SAT), d(MON)]);

--- a/src/pipeline/rule-drift.ts
+++ b/src/pipeline/rule-drift.ts
@@ -87,6 +87,74 @@ interface RuleRow {
   validFrom: string | null; validUntil: string | null;
 }
 
+/** Append `val` to the array at `key`, creating the bucket if absent. */
+function pushToMap<K, V>(map: Map<K, V[]>, key: K, val: V): void {
+  const arr = map.get(key);
+  if (arr) arr.push(val);
+  else map.set(key, [val]);
+}
+
+/** Group eligible (independent) event dates by every participating kennel. */
+function groupRecentEventDates<E extends { kennelId: string; date: Date; eventKennels: { kennelId: string }[] }>(
+  events: E[],
+  isEligible: (e: E) => boolean,
+): Map<string, Date[]> {
+  const map = new Map<string, Date[]>();
+  for (const e of events) {
+    if (!isEligible(e)) continue;
+    for (const kid of new Set<string>([e.kennelId, ...e.eventKennels.map((ek) => ek.kennelId)])) {
+      pushToMap(map, kid, e.date);
+    }
+  }
+  return map;
+}
+
+/** "[from..until]" season-window suffix for a rule (∞ for an open end); "" if year-round. */
+function formatRuleWindow(r: { validFrom: string | null; validUntil: string | null }): string {
+  if (!r.validFrom && !r.validUntil) return "";
+  return ` [${r.validFrom ?? "∞"}..${r.validUntil ?? "∞"}]`;
+}
+
+/**
+ * Drift finding for one kennel, or null if its active rules agree with reality.
+ *
+ * Season-aware predicted weekdays. Project over the FULL observed-plus-upcoming span
+ * [recentStart, projectEnd] — not just the forward window — so a correctly-seasonal kennel that
+ * just crossed a validFrom/validUntil boundary keeps its OLD-season weekday in the set while the
+ * recent actuals still lean that way. Otherwise the 42d actuals (prior season) would be compared
+ * against only the next 28d projections (new season) and false-fire for weeks after every switch
+ * (Codex review on PR #2166). A genuinely stale rule still projects only its wrong weekday across
+ * the whole span, so real drift is unaffected.
+ */
+function computeKennelDrift(
+  k: KennelRow,
+  kRules: RuleRow[],
+  recent: Date[],
+  recentStart: Date,
+  projectEnd: Date,
+): DriftFinding | null {
+  const ruleInputs: ScheduleRuleInput[] = kRules.map((r) => ({
+    id: r.id, kennelId: r.kennelId, rrule: r.rrule, anchorDate: r.anchorDate, startTime: r.startTime,
+    confidence: r.confidence, notes: r.notes, label: r.label, validFrom: r.validFrom, validUntil: r.validUntil,
+  }));
+  const predictedDays = new Set<number>();
+  for (const proj of projectTrails(ruleInputs, recentStart, projectEnd)) {
+    if (proj.date) predictedDays.add(proj.date.getUTCDay());
+  }
+  const drift = judgeDrift(predictedDays, recent);
+  if (!drift) return null;
+  return {
+    kennelCode: k.kennelCode,
+    shortName: k.shortName,
+    region: k.region,
+    predictedWeekdays: [...predictedDays].sort((a, b) => a - b).map(weekdayName),
+    actualWeekday: weekdayName(drift.actualDay),
+    actualShare: drift.actualShare,
+    recentEventCount: drift.count,
+    activeRules: kRules.map((r) => r.rrule + formatRuleWindow(r)).join(" | "),
+  };
+}
+
 export async function detectRuleDrift(prisma: PrismaClient, now: Date = new Date()): Promise<DriftFinding[]> {
   const recentStart = new Date(now.getTime() - DRIFT_RECENT_DAYS * DAY_MS);
   const projectEnd = new Date(now.getTime() + DRIFT_PROJECT_DAYS * DAY_MS);
@@ -103,22 +171,9 @@ export async function detectRuleDrift(prisma: PrismaClient, now: Date = new Date
     }),
   ]);
 
-  const recentByKennel = new Map<string, Date[]>();
-  for (const e of events) {
-    if (!isEligibleActual(e)) continue;
-    const kids = new Set<string>([e.kennelId, ...e.eventKennels.map((ek) => ek.kennelId)]);
-    for (const kid of kids) {
-      const arr = recentByKennel.get(kid);
-      if (arr) arr.push(e.date);
-      else recentByKennel.set(kid, [e.date]);
-    }
-  }
+  const recentByKennel = groupRecentEventDates(events, isEligibleActual);
   const rulesByKennel = new Map<string, RuleRow[]>();
-  for (const r of rules) {
-    const arr = rulesByKennel.get(r.kennelId);
-    if (arr) arr.push(r);
-    else rulesByKennel.set(r.kennelId, [r]);
-  }
+  for (const r of rules) pushToMap(rulesByKennel, r.kennelId, r);
 
   const findings: DriftFinding[] = [];
   for (const k of kennels) {
@@ -126,35 +181,8 @@ export async function detectRuleDrift(prisma: PrismaClient, now: Date = new Date
     if (kRules.length === 0) continue;
     const recent = recentByKennel.get(k.id) ?? [];
     if (recent.length < DRIFT_MIN_EVENTS) continue;
-
-    // Season-aware predicted weekdays. Project over the FULL observed-plus-upcoming span
-    // [recentStart, projectEnd] — not just the forward window — so a correctly-seasonal kennel
-    // that just crossed a validFrom/validUntil boundary keeps its OLD-season weekday in the set
-    // while the recent actuals still lean that way. Otherwise the 42d actuals (prior season)
-    // would be compared against only the next 28d projections (new season) and false-fire for
-    // weeks after every switch (Codex review on PR #2166). A genuinely stale rule still projects
-    // only its wrong weekday across the whole span, so real drift is unaffected.
-    const ruleInputs: ScheduleRuleInput[] = kRules.map((r) => ({
-      id: r.id, kennelId: r.kennelId, rrule: r.rrule, anchorDate: r.anchorDate, startTime: r.startTime,
-      confidence: r.confidence, notes: r.notes, label: r.label, validFrom: r.validFrom, validUntil: r.validUntil,
-    }));
-    const predictedDays = new Set<number>();
-    for (const proj of projectTrails(ruleInputs, recentStart, projectEnd)) {
-      if (proj.date) predictedDays.add(proj.date.getUTCDay());
-    }
-
-    const drift = judgeDrift(predictedDays, recent);
-    if (!drift) continue;
-    findings.push({
-      kennelCode: k.kennelCode,
-      shortName: k.shortName,
-      region: k.region,
-      predictedWeekdays: [...predictedDays].sort((a, b) => a - b).map(weekdayName),
-      actualWeekday: weekdayName(drift.actualDay),
-      actualShare: drift.actualShare,
-      recentEventCount: drift.count,
-      activeRules: kRules.map((r) => r.rrule + (r.validFrom ? ` [${r.validFrom}..${r.validUntil}]` : "")).join(" | "),
-    });
+    const finding = computeKennelDrift(k, kRules, recent, recentStart, projectEnd);
+    if (finding) findings.push(finding);
   }
   findings.sort((a, b) => a.shortName.localeCompare(b.shortName));
   return findings;


### PR DESCRIPTION
## Why this PR

These are the second-round review fixes for the rule-drift check that were pushed to `claude/rule-drift-check` **after** #2166's merge commit was already cut, so they never made it into `main`. Recovering them here.

Two are real bugs in code that's now live in prod:

- **`fileDriftIssue` dedup fallthrough** (`route.ts`) — if the dedup `GET` returned a non-2xx (rate limit / network blip), the code fell through and `POST`ed a new issue anyway, risking **duplicate `rule-drift` issues** from the now-live weekly cron. Now returns early on `!existing.ok`, and both GitHub fetches have a 15s `AbortSignal.timeout`.
- **Flat-weekly history guardrail always-on** (`propose-rule-fixes.ts`) — `loadStart` only reached ~205 days back, so `spanDays` could never hit the 330-day threshold and *every* flat-weekly proposal got the "<1yr history" warning. Widened the load to `max(205, 330+28)=358d`; extra-old events sit outside the derivation/holdout windows so only the span measurement changes.

Plus the SonarCloud + nit cleanups from that review round:
- `detectRuleDrift` cognitive complexity 25→<15 (extracted `groupRecentEventDates` / `computeKennelDrift` / `formatRuleWindow` / `pushToMap`).
- `historySpanDays` uses `dates.at(-1)` (Sonar S7755).
- `formatRuleWindow` fixes the `[from..null]` open-ended display → `∞`.
- Test asserts the fixture dates fall on their labelled weekdays.

All originally reviewed/approved on #2166 (CodeRabbit threads resolved, claude[bot] findings addressed). `tsc` + `eslint` clean; 9 rule-drift tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
