### PR TITLE
feat(rules): seasonal scheduleRules for 5 validated switchers (Boston, Copenhagen, Brew City, Canberra, Reading)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -255,6 +255,12 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "boh3", shortName: "Boston H3", fullName: "Boston Hash House Harriers", region: "Boston, MA",
       website: "https://bostonhash.com",
       scheduleDayOfWeek: "Sunday", scheduleTime: "2:30 PM", scheduleFrequency: "Weekly",
+      // Seasonal: summer Wednesdays (May–Oct), winter Sundays 2:30 PM (Nov–Apr) per 2yr history.
+      scheduleRules: [
+        { rrule: "FREQ=WEEKLY;BYDAY=WE", label: "Summer", validFrom: "05-01", validUntil: "10-31", displayOrder: 0 },
+        { rrule: "FREQ=WEEKLY;BYDAY=SU", startTime: "14:30", label: "Winter", validFrom: "11-01", validUntil: "04-30", displayOrder: 1 },
+      ],
+      scheduleNotes: "Summer: Wednesdays (May–Oct). Winter: Sundays 2:30 PM (Nov–Apr).",
       logoUrl: "/kennel-logos/boh3.jpg",
       contactEmail: "bostonhash@gmail.com",
     },
@@ -1363,6 +1369,11 @@ export const KENNELS: KennelSeed[] = [
       website: "https://readinghhh.blogspot.com/",
       scheduleDayOfWeek: "Monday", scheduleFrequency: "Weekly",
       scheduleNotes: "Mondays (summer); Sundays (winter).",
+      // Seasonal (matches the note + 2yr history): summer Mondays (Apr–Sep), winter Sundays (Oct–Mar).
+      scheduleRules: [
+        { rrule: "FREQ=WEEKLY;BYDAY=MO", label: "Summer", validFrom: "04-01", validUntil: "09-30", displayOrder: 0 },
+        { rrule: "FREQ=WEEKLY;BYDAY=SU", label: "Winter", validFrom: "10-01", validUntil: "03-31", displayOrder: 1 },
+      ],
       hashCash: "$6", foundedYear: 1990,
       description: "Weekly hash in Reading/Berks County with 1,194+ trails.",
       latitude: 40.34, longitude: -75.93,
@@ -3376,6 +3387,11 @@ export const KENNELS: KennelSeed[] = [
       hashCash: "50 DKK / run, 299 DKK / quarter (first run free)",
       scheduleFrequency: "Weekly",
       scheduleNotes: "Monday evenings (Apr-Sep), Saturday afternoons (Oct-Mar)",
+      // Seasonal (matches the note + 2yr history): summer Mondays (Apr–Sep), winter Saturdays (Oct–Mar).
+      scheduleRules: [
+        { rrule: "FREQ=WEEKLY;BYDAY=MO", label: "Summer", validFrom: "04-01", validUntil: "09-30", displayOrder: 0 },
+        { rrule: "FREQ=WEEKLY;BYDAY=SA", label: "Winter", validFrom: "10-01", validUntil: "03-31", displayOrder: 1 },
+      ],
       foundedYear: 1980,
       description: "Copenhagen's weekly hash — Monday evenings in summer, Saturday afternoons in winter. Runs from S-Tog stations around the city.",
       latitude: 55.68, longitude: 12.57,
@@ -3436,6 +3452,11 @@ export const KENNELS: KennelSeed[] = [
       website: "https://www.brewcityh3.com",
       facebookUrl: "https://www.facebook.com/groups/BrewCityH3/",
       scheduleDayOfWeek: "Thursday", scheduleFrequency: "Weekly",
+      // Seasonal: summer Thursdays (Jun–Oct), winter Fridays (Nov–May) per 2yr history.
+      scheduleRules: [
+        { rrule: "FREQ=WEEKLY;BYDAY=TH", label: "Summer", validFrom: "06-01", validUntil: "10-31", displayOrder: 0 },
+        { rrule: "FREQ=WEEKLY;BYDAY=FR", label: "Winter", validFrom: "11-01", validUntil: "05-31", displayOrder: 1 },
+      ],
       hashCash: "$7-8",
       contactEmail: "Fido@BrewCityH3.com",
       logoUrl: "https://static.wixstatic.com/media/5b98c7_0b8ba7cdd4114a479765ea7e0d64d4ea~mv2.png/v1/fill/w_657,h_534,al_c/5b98c7_0b8ba7cdd4114a479765ea7e0d64d4ea~mv2.png",
@@ -4013,7 +4034,12 @@ export const KENNELS: KennelSeed[] = [
       contactEmail: "capitalhash82@gmail.com",
       hashCash: "$10 AUD",
       scheduleDayOfWeek: "Monday", scheduleTime: "6:00 PM", scheduleFrequency: "Weekly",
-      scheduleNotes: "Weekly Monday evening runs. Schedule and trail details posted on capitalhash.com.",
+      scheduleNotes: "Mondays 6 PM most of the year; Sundays in the austral winter (May–Aug).",
+      // Seasonal (southern hemisphere): austral-winter Sundays (May–Aug), Mondays 6 PM otherwise (Sep–Apr).
+      scheduleRules: [
+        { rrule: "FREQ=WEEKLY;BYDAY=SU", label: "Austral winter", validFrom: "05-01", validUntil: "08-31", displayOrder: 0 },
+        { rrule: "FREQ=WEEKLY;BYDAY=MO", startTime: "18:00", label: "Austral summer", validFrom: "09-01", validUntil: "04-30", displayOrder: 1 },
+      ],
       foundedYear: 1982,
       description: "Canberra's senior hash kennel, meeting in and around the national capital and the Australian Capital Territory. Mixed kennel with weekly Monday evening runs.",
       latitude: -35.2809, longitude: 149.1300,

--- a/scripts/validate-seasonal-candidates.ts
+++ b/scripts/validate-seasonal-candidates.ts
@@ -1,0 +1,89 @@
+/**
+ * Read-only seasonal-switcher validation for candidate kennels (Travel Mode prediction quality).
+ *
+ * For each kennel code, pulls ~2yr of INDEPENDENT (non-STATIC_SCHEDULE) confirmed events from prod
+ * and reports the dominant weekday in CORE summer (May–Aug) vs CORE winter (Nov–Feb), skipping the
+ * shoulder months where the switch blurs. A clear summer≠winter dominant (both ≥60% share, ≥3 ev)
+ * confirms a seasonal switch worth a two-slot scheduleRules[].
+ *
+ * Usage: npx tsx scripts/validate-seasonal-candidates.ts <kennelCode> [<kennelCode> ...]
+ *   e.g. npx tsx scripts/validate-seasonal-candidates.ts boh3 ch3-dk swh3
+ *
+ * Run it on any kennel the weekly rule-drift check flags before authoring a seasonal
+ * scheduleRules[] — confirms the summer/winter weekday split with real data.
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+import { CANONICAL_EVENT_WHERE } from "@/lib/event-filters";
+import { EVENT_ELIGIBILITY_SELECT, isEligibleActual } from "@/lib/event-eligibility";
+
+const CANDIDATES = process.argv.slice(2);
+const DAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CORE_SUMMER = [4, 5, 6, 7]; // May–Aug
+const CORE_WINTER = [10, 11, 0, 1]; // Nov–Feb
+
+function dominant(dates: Date[]): { day: number; share: number; n: number } {
+  if (dates.length === 0) return { day: -1, share: 0, n: 0 };
+  const hist = new Array(7).fill(0);
+  for (const d of dates) hist[d.getUTCDay()]++;
+  let day = 0;
+  for (let i = 1; i < 7; i++) if (hist[i] > hist[day]) day = i;
+  return { day, share: hist[day] / dates.length, n: dates.length };
+}
+
+async function run(prisma: PrismaClient): Promise<void> {
+  const since = new Date(Date.now() - 730 * DAY_MS);
+  for (const code of CANDIDATES) {
+    const kennel = await prisma.kennel.findFirst({ where: { kennelCode: code }, select: { id: true, shortName: true } });
+    if (!kennel) {
+      console.log(`\n${code}: NOT FOUND`);
+      continue;
+    }
+    const events = await prisma.event.findMany({
+      where: {
+        ...CANONICAL_EVENT_WHERE,
+        status: "CONFIRMED",
+        date: { gte: since },
+        OR: [{ kennelId: kennel.id }, { eventKennels: { some: { kennelId: kennel.id } } }],
+      },
+      select: { date: true, ...EVENT_ELIGIBILITY_SELECT },
+      orderBy: { date: "asc" },
+    });
+    const indep = events.filter((e) => isEligibleActual(e)).map((e) => e.date);
+    const summer = indep.filter((d) => CORE_SUMMER.includes(d.getUTCMonth()));
+    const winter = indep.filter((d) => CORE_WINTER.includes(d.getUTCMonth()));
+    const s = dominant(summer);
+    const w = dominant(winter);
+    const seasonal = s.day !== w.day && s.share >= 0.6 && w.share >= 0.6 && s.n >= 3 && w.n >= 3;
+    const fmt = (x: { day: number; share: number; n: number }) =>
+      x.n === 0 ? "—" : `${DAY[x.day]} ${Math.round(x.share * 100)}% (${x.n}ev)`;
+    console.log(
+      `\n${code} (${kennel.shortName}) — ${indep.length} indep events / 2yr` +
+        `\n  core-summer: ${fmt(s)}   core-winter: ${fmt(w)}   → ${seasonal ? "SEASONAL ✓" : "not a clear switch"}`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  if (CANDIDATES.length === 0) {
+    console.error("Usage: npx tsx scripts/validate-seasonal-candidates.ts <kennelCode> [<kennelCode> ...]");
+    process.exitCode = 1;
+    return;
+  }
+  const pool = createScriptPool();
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+  try {
+    await run(prisma);
+  } finally {
+    await prisma.$disconnect().catch(() => undefined);
+    await pool.end().catch(() => undefined);
+  }
+}
+
+void main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

Two-slot seasonal `scheduleRules[]` (with `validFrom`/`validUntil`) for 5 kennels confirmed as genuine summer↔winter weekday switchers. Without these, each predicts a single flat weekday year-round and goes wrong for ~half the year in Travel Mode — and would be flagged by the new weekly rule-drift check once they cross a season boundary.

## Validation

Each was validated against **2 years of independent (non-STATIC_SCHEDULE) prod events** — dominant weekday in core-summer (May–Aug) vs core-winter (Nov–Feb):

| Kennel | Core-summer | Core-winter | Rule |
|---|---|---|---|
| boh3 (Boston H3) | Wed 85% | Sun 80% | summer WE (May–Oct) / winter SU 2:30pm (Nov–Apr) |
| ch3-dk (Copenhagen) | Mon 86% | Sat 77% | summer MO (Apr–Sep) / winter SA (Oct–Mar) |
| bch3 (Brew City) | Thu 86% | Fri 73% | summer TH (Jun–Oct) / winter FR (Nov–May) |
| capital-h3-au (Canberra) | Sun 61% | Mon 100% | austral-winter SU (May–Aug) / austral-summer MO 6pm (Sep–Apr) |
| rh3 (Reading) | Mon 50%¹ | Sun 80% | summer MO (Apr–Sep) / winter SU (Oct–Mar) |

¹ rh3's summer Monday share is softer (50%), but the Monday/Sunday seasonal split is documented on the kennel's own site and the winter signal is clear.

## Dropped after validation (not shipped)

- **tah3** — original note was "Wednesdays **and** Saturdays" (likely a twice-weekly kennel, not a seasonal switch); winter sample too thin (5 events) to confirm. Left unchanged.
- **swh3** — winter Saturday only 56% (below the 60% bar); borderline. The rule-drift check will keep surfacing it if its current rule is wrong.
- **nvhhh** — dominant **Sunday in both** seasons; not a switcher.

## Also

Adds `scripts/validate-seasonal-candidates.ts` — a read-only companion to `/api/cron/rule-drift`. Pass any flagged kennel codes (`npx tsx scripts/validate-seasonal-candidates.ts <code>...`) to confirm the season split before authoring a rule.

## Post-merge

Display fields are unchanged; `formatSchedule` prefers `scheduleRules` so the kennel pages and Travel Mode pick these up. Prod materialization (`backfill-schedule-rules --apply`) is a manual post-merge step — Vercel doesn't run it. (Seasonal-rule precedent: #2154/#2165.)

`tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
