### PR TITLE
feat(rules): seasonal monthly-ordinal scheduleRules for PSH3 (Puget Sound)

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2420,6 +2420,14 @@ export const KENNELS: KennelSeed[] = [
       website: "https://wh3.org", foundedYear: 1981,
       scheduleFrequency: "Biweekly",
       scheduleNotes: "Men's hash. 1st/3rd Saturday 10:30am (winter Nov-Mar), 1st/3rd Thursday 6:30pm (summer Apr-Oct)",
+      // Seasonal + monthly-ordinal (matches the note + 2yr history: summer Thu 82%, winter Sat 89%).
+      // 1st/3rd weekday → two ordinal rules per season; month ordinals self-anchor (no anchorDate).
+      scheduleRules: [
+        { rrule: "FREQ=MONTHLY;BYDAY=1TH", startTime: "18:30", label: "Summer", validFrom: "04-01", validUntil: "10-31", displayOrder: 0 },
+        { rrule: "FREQ=MONTHLY;BYDAY=3TH", startTime: "18:30", label: "Summer", validFrom: "04-01", validUntil: "10-31", displayOrder: 1 },
+        { rrule: "FREQ=MONTHLY;BYDAY=1SA", startTime: "10:30", label: "Winter", validFrom: "11-01", validUntil: "03-31", displayOrder: 2 },
+        { rrule: "FREQ=MONTHLY;BYDAY=3SA", startTime: "10:30", label: "Winter", validFrom: "11-01", validUntil: "03-31", displayOrder: 3 },
+      ],
       description: "Men's hash running biweekly across the Puget Sound region. Founded 1981, the oldest kennel in Washington state.",
       latitude: 47.50, longitude: -122.17,
     },


### PR DESCRIPTION
## What

Seasonal `scheduleRules[]` for **PSH3 (Puget Sound H3)** — the last deferred kennel from the seasonal-prediction pass. It was held back as "biweekly + seasonal," but it's actually **monthly-ordinal** (1st/3rd weekday), which is self-anchoring and projects cleanly.

Per its own seed note (and confirmed by 2yr of independent prod events):
- **Summer (Apr–Oct):** 1st & 3rd **Thursday** @ 6:30pm — events show Thu **82%**
- **Winter (Nov–Mar):** 1st & 3rd **Saturday** @ 10:30am — events show Sat **89%**

Authored as four `FREQ=MONTHLY;BYDAY=…` rules (`1TH`/`3TH` summer, `1SA`/`3SA` winter) with `validFrom`/`validUntil`. Month ordinals self-anchor, so no `anchorDate` is needed — cleaner and more robust than a rolling `INTERVAL=2`.

## Verified

`projectTrails` over the next 8 months produces exactly:
```
Jun–Oct: 1st/3rd Thu @18:30 (HIGH)  →  Nov–Jan: 1st/3rd Sat @10:30 (HIGH)
```
clean switch at the Nov 1 boundary. `FREQ=MONTHLY;BYDAY=<ordinal>` has wide precedent in the seed and is handled by the same `parseRRule`/`generateOccurrences` the engine already uses. `tsc` + `eslint` clean.

## Post-merge

Manual `backfill-schedule-rules.ts --apply` against prod to materialize (same step as #2171; Vercel skips it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
