### PR TITLE
docs: sync indexes + roadmap with Travel Mode prediction-quality system

### DIFF
--- a/.claude/rules/important-files.md
+++ b/.claude/rules/important-files.md
@@ -12,7 +12,7 @@ globs:
 # Important Files
 
 ## Core
-- `prisma/schema.prisma` — Full data model, 27 models + 20 enums (THE source of truth for types)
+- `prisma/schema.prisma` — Full data model, 38 models + 29 enums (THE source of truth for types)
 - `prisma/seed.ts` — 152 kennels, 481 aliases, 69 sources, 64 regions (first-class model with hierarchy)
 - `prisma.config.ts` — Prisma 7 config (datasource URL, seed command)
 - `src/lib/db.ts` — PrismaClient singleton (PrismaPg adapter + SSL)
@@ -79,6 +79,10 @@ globs:
 - `src/pipeline/verify-fixes.ts` — Post-merge fix verification (removes pending-verification label, posts confirmation comment)
 - `src/pipeline/html-analysis.ts` — Reusable HTML event analysis + Gemini column mapping (no auth, used by research pipeline)
 - `src/pipeline/source-research.ts` — Autonomous source research pipeline (URL discovery, classification, analysis, proposal persistence)
+- `src/pipeline/prediction-ledger.ts` — Travel Mode prospective prediction ledger (snapshot weekly + score matured HIT/MISS/PRECONFIRMED/UNOBSERVED, frozen-source)
+- `src/pipeline/rule-drift.ts` — Weekly season-aware schedule-rule drift detector (wrong-weekday → deduped GitHub issue)
+- `src/lib/travel/projections.ts` — Travel Mode projection engine (`projectTrails` + `scoreConfidence`, optional `now` for backtest)
+- `src/lib/event-eligibility.ts` — `isEligibleActual` / `EVENT_ELIGIBILITY_SELECT` (independent non-STATIC_SCHEDULE ground truth)
 
 ## Admin
 - `src/app/admin/alerts/actions.ts` — Alert repair actions (re-scrape, create alias/kennel, link kennel to source, file GitHub issue)
@@ -170,12 +174,14 @@ globs:
 - `src/components/admin/AnalyticsDashboard.tsx` — Dashboard UI: charts, stat cards, tables (community/engagement/operational)
 
 ## Infrastructure & CI
-- `vercel.json` — Vercel Cron config (triggers QStash dispatch at 6:00 AM UTC)
+- `vercel.json` — Vercel Cron config (QStash scrape dispatch 06:00 UTC; daily audit + audit-issue sync + travel-draft GC; weekly Mon prediction-ledger 08:00 + rule-drift 09:00 UTC)
 - `src/lib/qstash.ts` — QStash Client + Receiver singletons (Upstash fan-out queue)
 - `src/lib/cron-auth.ts` — Dual auth: QStash signature verification → Bearer CRON_SECRET fallback
 - `src/pipeline/schedule.ts` — Shared scheduling logic (shouldScrape, frequency intervals)
 - `src/app/api/cron/dispatch/route.ts` — Fan-out dispatcher: queries due sources, publishes QStash messages
 - `src/app/api/cron/scrape/[sourceId]/route.ts` — Per-source scrape endpoint (called by QStash)
+- `src/app/api/cron/prediction-ledger/route.ts` — Weekly prediction-ledger run (snapshot + score matured predictions)
+- `src/app/api/cron/rule-drift/route.ts` — Weekly rule-drift check (wrong-weekday → deduped GitHub issue)
 - `vitest.config.ts` — Test runner config (globals, path aliases)
 - `src/test/factories.ts` — Shared test data builders
 - `.github/workflows/ci.yml` — CI gate: type check, lint, tests on all PRs + push to main

--- a/.claude/rules/important-files.md
+++ b/.claude/rules/important-files.md
@@ -13,7 +13,7 @@ globs:
 
 ## Core
 - `prisma/schema.prisma` — Full data model, 38 models + 29 enums (THE source of truth for types)
-- `prisma/seed.ts` — 152 kennels, 481 aliases, 69 sources, 64 regions (first-class model with hierarchy)
+- `prisma/seed.ts` — ~465 kennels, ~2000 aliases, ~373 enabled sources (390 total), ~279 regions (first-class model with hierarchy)
 - `prisma.config.ts` — Prisma 7 config (datasource URL, seed command)
 - `src/lib/db.ts` — PrismaClient singleton (PrismaPg adapter + SSL)
 - `src/lib/auth.ts` — `getOrCreateUser()` + `getAdminUser()` + `getMismanUser()` + `getRosterGroupId()` (Clerk→DB sync + admin/misman role checks)
@@ -180,6 +180,9 @@ globs:
 - `src/pipeline/schedule.ts` — Shared scheduling logic (shouldScrape, frequency intervals)
 - `src/app/api/cron/dispatch/route.ts` — Fan-out dispatcher: queries due sources, publishes QStash messages
 - `src/app/api/cron/scrape/[sourceId]/route.ts` — Per-source scrape endpoint (called by QStash)
+- `src/app/api/cron/audit/route.ts` — Daily data-quality audit run
+- `src/app/api/cron/sync-audit-issues/route.ts` — Daily sync of the AuditIssue mirror with GitHub
+- `src/app/api/cron/travel-draft-gc/route.ts` — Daily garbage collection of expired travel drafts
 - `src/app/api/cron/prediction-ledger/route.ts` — Weekly prediction-ledger run (snapshot + score matured predictions)
 - `src/app/api/cron/rule-drift/route.ts` — Weekly rule-drift check (wrong-weekday → deduped GitHub issue)
 - `vitest.config.ts` — Test runner config (globals, path aliases)

--- a/.claude/rules/testing-coverage.md
+++ b/.claude/rules/testing-coverage.md
@@ -17,7 +17,7 @@ globs:
 
 ## Coverage Areas
 - **Adapters:** hashnyc, Google Calendar, Google Sheets, iCal, Blogger API, London scrapers (CityH3, WLH3, LH3, BarnesH3, OCH3, SLH3, EH3), Chicago (CH3, TH3), DC (EWH3, DCH4, OFH3, Hangover), SF Bay (SFH3), Philly (BFM, HashPhilly), Texas (Brass Monkey, DFW), Upstate NY (SOH4, Halve Mein, IH3), Hockessin, Northboro, Hash Rego, Meetup, WordPress API, GenericHtml, shared utils
-- **Pipeline:** merge dedup + trust levels + source-kennel guard, kennel resolution (4-stage), fingerprinting, scrape orchestration, health analysis + alerts, reconciliation, auto-issue filing, post-merge verification
+- **Pipeline:** merge dedup + trust levels + source-kennel guard, kennel resolution (4-stage), fingerprinting, scrape orchestration, health analysis + alerts, reconciliation, auto-issue filing, post-merge verification, prediction-ledger (band capture + outcome classification, frozen-source), rule-drift (dominant-weekday + season-aware drift judgement)
 - **AI:** Gemini wrapper (caching, rate-limits, grounding), parse recovery, HTML structure analysis
 - **Research:** source research pipeline, server actions, HTML analysis extraction
 - **Server actions:** logbook, profile, kennel subscriptions, admin CRUD, misman attendance/roster/history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ logbook + kennel directory.
 
 ## Important Files
 - `prisma/schema.prisma` — Full data model, 38 models + 29 enums (THE source of truth for types)
-- `prisma/seed.ts` — 430 kennels, 1660 aliases, 330 enabled sources (first-class model with hierarchy)
+- `prisma/seed.ts` — ~465 kennels, ~2000 aliases, ~373 enabled sources (390 total), ~279 regions (first-class model with hierarchy)
 - `prisma.config.ts` — Prisma 7 config (datasource URL, seed command)
 - `src/lib/db.ts` — PrismaClient singleton (PrismaPg adapter + SSL)
 - `src/lib/auth.ts` — `getOrCreateUser()` + `getAdminUser()` + `getMismanUser()` + `getRosterGroupId()` (Clerk→DB sync + admin/misman role checks)
@@ -249,6 +249,9 @@ logbook + kennel directory.
 - `src/pipeline/schedule.ts` — Shared scheduling logic (shouldScrape, frequency intervals)
 - `src/app/api/cron/dispatch/route.ts` — Fan-out dispatcher: queries due sources, publishes QStash messages
 - `src/app/api/cron/scrape/[sourceId]/route.ts` — Per-source scrape endpoint (called by QStash)
+- `src/app/api/cron/audit/route.ts` — Daily (12:00 UTC) data-quality audit run
+- `src/app/api/cron/sync-audit-issues/route.ts` — Daily (12:30 UTC) sync of the AuditIssue mirror with GitHub
+- `src/app/api/cron/travel-draft-gc/route.ts` — Daily (03:00 UTC) garbage collection of expired travel drafts
 - `src/app/api/cron/prediction-ledger/route.ts` — Weekly (Mon 08:00 UTC) prediction-ledger run (snapshot + score matured predictions)
 - `src/app/api/cron/rule-drift/route.ts` — Weekly (Mon 09:00 UTC) rule-drift check; files a deduped GitHub issue (label `rule-drift`) on wrong-weekday predictions
 - `vitest.config.ts` — Test runner config (globals, path aliases)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ logbook + kennel directory.
 ## Quick Commands
 - `npm run dev` — Start local dev server (http://localhost:3000)
 - `npm run build` — Production build
-- `npm test` — Run test suite (Vitest, 115 test files)
+- `npm test` — Run test suite (Vitest, 300+ test files)
 - `npx prisma studio` — Visual database browser
 - `npm run prisma -- db push` — Push schema changes to dev DB (**local only** — wrapper refuses to run against non-local hosts; Vercel runs `migrate deploy`)
 - `npm run prisma -- migrate dev --name <change>` — Author a new versioned migration (wrapper refuses to run against prod `DATABASE_URL`; review SQL before committing)
@@ -498,7 +498,7 @@ See `docs/roadmap.md` for implementation roadmap.
 ## Testing
 - **Framework:** Vitest with `globals: true` (no explicit imports needed)
 - **Config:** `vitest.config.ts` — path alias `@/` maps to `./src`
-- **Run:** `npm test` (115 test files)
+- **Run:** `npm test` (300+ test files)
 - **Factories:** `src/test/factories.ts` — shared builders (`buildRawEvent`, `buildCalendarEvent`, `mockUser`)
 - **Mocking pattern:** `vi.mock("@/lib/db")` + `vi.mocked(prisma.model.method)` with `as never` for partial returns
 - **Convention:** Test files live next to source files as `*.test.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ logbook + kennel directory.
 - GOOGLE_SITE_VERIFICATION= # Google Search Console verification token (optional, fallback if not DNS-verified)
 
 ## Important Files
-- `prisma/schema.prisma` — Full data model, 27 models + 20 enums (THE source of truth for types)
+- `prisma/schema.prisma` — Full data model, 38 models + 29 enums (THE source of truth for types)
 - `prisma/seed.ts` — 430 kennels, 1660 aliases, 330 enabled sources (first-class model with hierarchy)
 - `prisma.config.ts` — Prisma 7 config (datasource URL, seed command)
 - `src/lib/db.ts` — PrismaClient singleton (PrismaPg adapter + SSL)
@@ -162,6 +162,10 @@ logbook + kennel directory.
 - `src/pipeline/verify-fixes.ts` — Post-merge fix verification (removes pending-verification label, posts confirmation comment)
 - `src/pipeline/html-analysis.ts` — Reusable HTML event analysis + Gemini column mapping (no auth, used by research pipeline)
 - `src/pipeline/source-research.ts` — Autonomous source research pipeline (URL discovery, classification, analysis, proposal persistence)
+- `src/pipeline/prediction-ledger.ts` — Travel Mode prospective prediction ledger: snapshots forward HIGH/MEDIUM predictions weekly, scores matured ones HIT/MISS/PRECONFIRMED/UNOBSERVED against real events (frozen-source, drift-proof)
+- `src/pipeline/rule-drift.ts` — Weekly schedule-rule drift detector: flags kennels whose active rule projects a different weekday than recent independent events (season-aware via projectTrails); files one deduped GitHub issue
+- `src/lib/travel/projections.ts` — Travel Mode projection engine (`projectTrails` + `scoreConfidence`); `scoreConfidence` takes an optional `now` for backtesting
+- `src/lib/event-eligibility.ts` — `isEligibleActual`/`EVENT_ELIGIBILITY_SELECT`: a canonical CONFIRMED event backed by ≥1 non-STATIC_SCHEDULE RawEvent (independent ground truth for prediction scoring)
 - `src/app/admin/alerts/actions.ts` — Alert repair actions (re-scrape, create alias/kennel, link kennel to source, file GitHub issue)
 - `src/app/admin/regions/actions.ts` — Region CRUD, merge, AI suggestions (rule-based + Gemini), hierarchy validation
 - `src/app/admin/regions/page.tsx` — Admin region management page (RegionTable + RegionSuggestionsPanel)
@@ -239,12 +243,14 @@ logbook + kennel directory.
 - `src/app/admin/analytics/actions.ts` — Server actions for community health, user engagement, operational metrics
 - `src/app/admin/analytics/page.tsx` — Admin analytics dashboard (recharts)
 - `src/components/admin/AnalyticsDashboard.tsx` — Dashboard UI: charts, stat cards, tables (community/engagement/operational)
-- `vercel.json` — Vercel Cron config (triggers QStash dispatch at 6:00 AM UTC)
+- `vercel.json` — Vercel Cron config (QStash scrape dispatch 06:00 UTC; daily audit + audit-issue sync + travel-draft GC; weekly Mon prediction-ledger 08:00 + rule-drift 09:00 UTC)
 - `src/lib/qstash.ts` — QStash Client + Receiver singletons (Upstash fan-out queue)
 - `src/lib/cron-auth.ts` — Dual auth: QStash signature verification → Bearer CRON_SECRET fallback
 - `src/pipeline/schedule.ts` — Shared scheduling logic (shouldScrape, frequency intervals)
 - `src/app/api/cron/dispatch/route.ts` — Fan-out dispatcher: queries due sources, publishes QStash messages
 - `src/app/api/cron/scrape/[sourceId]/route.ts` — Per-source scrape endpoint (called by QStash)
+- `src/app/api/cron/prediction-ledger/route.ts` — Weekly (Mon 08:00 UTC) prediction-ledger run (snapshot + score matured predictions)
+- `src/app/api/cron/rule-drift/route.ts` — Weekly (Mon 09:00 UTC) rule-drift check; files a deduped GitHub issue (label `rule-drift`) on wrong-weekday predictions
 - `vitest.config.ts` — Test runner config (globals, path aliases)
 - `src/test/factories.ts` — Shared test data builders
 - `.github/workflows/ci.yml` — CI gate: type check, lint, tests on all PRs + push to main

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -437,7 +437,7 @@ See [config-driven-onboarding-plan.md](config-driven-onboarding-plan.md) for ful
 - [x] Config: `rrule`, `defaultTitle`, `defaultLocation`, `defaultStartTime`, `defaultKennelTag`
 - [x] Supports complex RRULE patterns (1st/3rd Sunday, every other Saturday, etc.)
 - [x] Moon-phase gap: lunar recurrence (full/new moon kennels) cannot be expressed as RRULE — added as kennel-only records
-- [ ] Seasonal schedule switching: many kennels change day/time seasonally (e.g., SAH3: Friday 6:30 PM summer / Sunday 3:30 PM winter) — needs RRULE enhancement or `seasonalSchedule` config with date ranges
+- [x] Seasonal schedule switching: kennels that change day/time by season author two-slot (or monthly-ordinal) `scheduleRules[]` with `validFrom`/`validUntil` MM-DD windows; `projectTrails` honors the active season. Shipped for ~9 kennels (Summit, FH3, Beantown, Boston, Copenhagen, Brew City, Canberra, Reading, PSH3). The weekly rule-drift cron self-surfaces new switchers.
 
 ### Meetup Adapter Live — COMPLETE
 - [x] 17+ live Meetup sources across FL, GA, SC, NY, VA, NC, VT, CT
@@ -536,7 +536,7 @@ See [config-driven-onboarding-plan.md](config-driven-onboarding-plan.md) for ful
 ### Current Stats
 - 290 kennels (with rich profiles), ~950 aliases, 185 sources, 137 regions (4 countries: US, UK, Ireland, Germany)
 - 9 live adapter types: STATIC_SCHEDULE, HTML_SCRAPER, GOOGLE_CALENDAR, MEETUP, ICAL_FEED, GOOGLE_SHEETS, HASHREGO, BLOGGER_API, RSS_ICAL
-- 27 models, 20 enums in Prisma schema
+- 38 models, 29 enums in Prisma schema
 - 128 test files
 
 ---
@@ -679,6 +679,17 @@ See "Source Onboarding Wizard" in What's Built section above. The wizard support
 - [ ] **Phase 7:** Saved trips dashboard (`/travel/saved` + SavedTripCard)
 - [ ] **Phase 8:** Public route registration + analytics events + sign-in banner
 - [ ] Pairs with Log Unlisted Run for runs found while traveling (separate effort)
+
+### Travel Mode prediction quality (SHIPPED)
+
+A layered system that measures and self-heals the confidence-scored projections that power Travel Mode (engine: `src/lib/travel/projections.ts`).
+
+- [x] **Evaluation harness** — `scripts/audit-travel-predictions.ts`: per-kennel × horizon coverage census + backtest precision/recall per confidence tier (excludes STATIC_SCHEDULE-generated events as circular). `scoreConfidence` gained an optional `now` for as-of-past backtesting.
+- [x] **Phase 1 rule fixes** — `scripts/propose-rule-fixes.ts` derives corrected rules from independent history (holds out the recent 4 weeks); fixed 25 kennels (biweekly anchors, weekday corrections).
+- [x] **Phase 2 prospective ledger** — `PredictionSnapshot` model + `src/pipeline/prediction-ledger.ts` + weekly cron: freezes forward HIGH/MEDIUM predictions at 180/90/30-day bands and scores them HIT/MISS/PRECONFIRMED/UNOBSERVED against real events as dates mature (frozen-source, drift-proof). Scorecard: `scripts/score-prediction-ledger.ts`. Precision accrues over weeks; recall is a deferred follow-up.
+- [x] **Rule-drift self-healing** — `src/pipeline/rule-drift.ts` + weekly cron flags kennels whose active rule projects a different weekday than recent independent events (season-aware) and files one deduped GitHub issue. Authoring guardrail in `propose-rule-fixes.ts` blocks confident flat rules derived from <1yr of history.
+- [x] **Seasonal scheduling** — see the checked "Seasonal schedule switching" item above; `scripts/validate-seasonal-candidates.ts` confirms a season split before authoring.
+- [ ] **Recall metric** in the ledger scorecard (deferred until cohorts mature, ~weeks out).
 
 ### Travel Mode follow-ups (deferred from polish passes)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -534,10 +534,10 @@ See [config-driven-onboarding-plan.md](config-driven-onboarding-plan.md) for ful
 - [x] Admin event deletion now properly cascades to orphaned RawEvent records
 
 ### Current Stats
-- 290 kennels (with rich profiles), ~950 aliases, 185 sources, 137 regions (4 countries: US, UK, Ireland, Germany)
-- 9 live adapter types: STATIC_SCHEDULE, HTML_SCRAPER, GOOGLE_CALENDAR, MEETUP, ICAL_FEED, GOOGLE_SHEETS, HASHREGO, BLOGGER_API, RSS_ICAL
+- ~465 kennels (with rich profiles), ~2000 aliases, ~373 enabled sources (390 total), ~279 regions across 31 countries
+- 9 live adapter types (enabled SourceTypes): HTML_SCRAPER, GOOGLE_CALENDAR, GOOGLE_SHEETS, ICAL_FEED, MEETUP, HASHREGO, HARRIER_CENTRAL, STATIC_SCHEDULE, FACEBOOK_HOSTED_EVENTS
 - 38 models, 29 enums in Prisma schema
-- 128 test files
+- 300+ test files
 
 ---
 

--- a/docs/self-healing-automation-plan.md
+++ b/docs/self-healing-automation-plan.md
@@ -493,6 +493,8 @@ The agent assigns a confidence score during triage. Score determines the action 
 | File | Role in Self-Healing |
 |------|---------------------|
 | `src/pipeline/health.ts` | Alert generation — triggers the loop |
+| `src/pipeline/rule-drift.ts` | Second producer: weekly schedule-rule drift detection (wrong-weekday predictions) → deduped GitHub issue (label `rule-drift`), independent of the alert/health path |
+| `src/app/api/cron/rule-drift/route.ts` | Weekly cron (Mon 09:00 UTC) that runs `detectRuleDrift` + files the issue |
 | `src/pipeline/scrape.ts` | Scrape orchestration — where auto-issue filing + verification hooks in |
 | `src/pipeline/auto-issue.ts` | Auto-file GitHub issues from alerts (rate limiting, cooldown, dedup) |
 | `src/pipeline/verify-fixes.ts` | Post-merge fix verification (removes pending-verification label on success) |


### PR DESCRIPTION
## What

Documentation-only sync for the shipped prediction-ledger / rule-drift / seasonal-rule work. No code changes.

- **CLAUDE.md** + **.claude/rules/important-files.md** (load-bearing, read every session): corrected schema count **27/20 → 38/29** (was stale from prior growth + new `PredictionSnapshot`/`PredictionOutcome`); expanded the `vercel.json` cron line; added `prediction-ledger.ts`, `rule-drift.ts`, `projections.ts`, `event-eligibility.ts`, and the two new cron routes.
- **roadmap.md**: checked off **Seasonal schedule switching** (shipped for ~9 kennels); fixed the model/enum stat; added a **Travel Mode prediction quality (SHIPPED)** section (harness → Phase 1 fixes → ledger → rule-drift self-healing → deferred recall).
- **self-healing-automation-plan.md**: listed `rule-drift.ts` as a second issue producer.
- **testing-coverage.md**: added the two new pipeline tests.

**Deliberately skipped:** the Travel Mode PRD/ERD (aspirational design docs with placeholder `uuid`/snake_case schema, not as-built) and the dated test-coverage snapshot — lower ROI than the as-built indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)