### PR TITLE
feat(admin): /admin/predictions dashboard — prediction ledger, rule-drift, rule coverage

### DIFF
--- a/prisma/migrations/20260612210000_add_rule_drift_snapshot/migration.sql
+++ b/prisma/migrations/20260612210000_add_rule_drift_snapshot/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "RuleDriftSnapshot" (
+    "id" TEXT NOT NULL,
+    "ranAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "driftCount" INTEGER NOT NULL,
+    "findings" JSONB NOT NULL,
+
+    CONSTRAINT "RuleDriftSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "RuleDriftSnapshot_ranAt_idx" ON "RuleDriftSnapshot"("ranAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1186,6 +1186,18 @@ model PredictionSnapshot {
   @@index([snapshotAt])
 }
 
+/// One row per rule-drift run (weekly cron or admin recompute): the season-aware
+/// schedule-rule drift findings as of `ranAt`. Read by /admin/predictions so the page
+/// never runs the heavy live sweep; written by /api/cron/rule-drift + the recompute action.
+model RuleDriftSnapshot {
+  id         String   @id @default(cuid())
+  ranAt      DateTime @default(now())
+  driftCount Int
+  findings   Json // DriftFinding[] from src/pipeline/rule-drift.ts
+
+  @@index([ranAt])
+}
+
 enum TravelSearchStatus {
   DRAFT    // Multi-dest trips auto-save as DRAFT once the user adds leg 2. Invisible
            // from /travel/saved; reachable by URL; converts to ACTIVE on explicit Save.

--- a/scripts/score-prediction-ledger.ts
+++ b/scripts/score-prediction-ledger.ts
@@ -20,46 +20,16 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/generated/prisma/client";
 import { createScriptPool } from "./lib/db-pool";
 import { utcNoon, fmtDate, pct, writeAuditReport } from "./lib/audit-shared";
-
-// Actual-days-out bins for precision (report by real horizon, not the nominal band).
-const DAYSOUT_BINS: { label: string; lo: number; hi: number }[] = [
-  { label: "0–45", lo: 0, hi: 45 },
-  { label: "46–120", lo: 46, hi: 120 },
-  { label: "121–200", lo: 121, hi: 200 },
-];
-
-type Outcome = "PENDING" | "HIT" | "MISS" | "PRECONFIRMED" | "UNOBSERVED";
-
-interface SnapRow {
-  confidence: "HIGH" | "MEDIUM";
-  horizonBucket: number;
-  daysOutAtSnapshot: number;
-  outcome: Outcome;
-  predictedDate: Date;
-}
-
-function binOf(daysOut: number): string {
-  return DAYSOUT_BINS.find((b) => daysOut >= b.lo && daysOut <= b.hi)?.label ?? "200+";
-}
-
-type Cell = { hit: number; miss: number };
-
-/** Precision cells keyed `${confidence}|${bin}`, over HIT/MISS rows only. */
-function buildPrecisionMap(snaps: SnapRow[]): Map<string, Cell> {
-  const precision = new Map<string, Cell>();
-  for (const s of snaps) {
-    if (s.outcome !== "HIT" && s.outcome !== "MISS") continue;
-    const key = `${s.confidence}|${binOf(s.daysOutAtSnapshot)}`;
-    const cell = precision.get(key) ?? { hit: 0, miss: 0 };
-    if (s.outcome === "HIT") cell.hit++;
-    else cell.miss++;
-    precision.set(key, cell);
-  }
-  return precision;
-}
+import {
+  DAYSOUT_BINS,
+  buildPrecisionMap,
+  tallyOutcomes,
+  firstMaturityDate,
+  type PrecisionCell,
+} from "@/lib/travel/ledger-scorecard";
 
 /** Render the Precision markdown section (placeholder until matured rows exist). */
-function renderPrecisionSection(scored: number, precision: Map<string, Cell>, firstMaturity: Date | null): string[] {
+function renderPrecisionSection(scored: number, precision: Map<string, PrecisionCell>, firstMaturity: Date | null): string[] {
   if (scored === 0) {
     return [
       "## Precision",
@@ -88,27 +58,21 @@ async function run(prisma: PrismaClient): Promise<void> {
   const today = utcNoon(new Date());
   console.log("📈 Prediction-ledger scorecard (read-only)\n");
 
-  const snaps = (await prisma.predictionSnapshot.findMany({
-    select: { confidence: true, horizonBucket: true, daysOutAtSnapshot: true, outcome: true, predictedDate: true },
-  })) as SnapRow[];
+  const snaps = await prisma.predictionSnapshot.findMany({
+    select: { confidence: true, daysOutAtSnapshot: true, outcome: true, predictedDate: true },
+  });
   const cohortWeeks = await prisma.predictionSnapshot.findMany({
     select: { snapshotAt: true }, orderBy: { snapshotAt: "asc" }, take: 1,
   });
 
-  const total = snaps.length;
-  const byOutcome: Record<Outcome, number> = { PENDING: 0, HIT: 0, MISS: 0, PRECONFIRMED: 0, UNOBSERVED: 0 };
-  for (const s of snaps) byOutcome[s.outcome]++;
+  const byOutcome = tallyOutcomes(snaps);
+  const total = byOutcome.total;
 
   // Precision per confidence × days-out bin (HIT/MISS only).
   const precision = buildPrecisionMap(snaps);
 
   // Pending maturity: earliest PENDING predictedDate = when the first scores arrive.
-  // reduce (not Math.min(...array)) — the pending set can grow large and the spread would
-  // risk a max-call-stack overflow (Gemini review on PR #2164).
-  const firstMaturity = snaps.reduce<Date | null>((earliest, s) => {
-    if (s.outcome !== "PENDING") return earliest;
-    return !earliest || s.predictedDate < earliest ? s.predictedDate : earliest;
-  }, null);
+  const firstMaturity = firstMaturityDate(snaps);
 
   // ── Render ──
   const date = fmtDate(today);

--- a/src/app/admin/predictions/actions.ts
+++ b/src/app/admin/predictions/actions.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import * as Sentry from "@sentry/nextjs";
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/db";
+import { getAdminUser } from "@/lib/auth";
+import { detectRuleDrift, writeRuleDriftSnapshot } from "@/pipeline/rule-drift";
+
+/** Server actions are POST endpoints anyone can hit — gate every one on admin (Codex review). */
+async function requireAdmin(): Promise<void> {
+  const admin = await getAdminUser();
+  if (!admin) throw new Error("Unauthorized");
+}
+
+const RECOMPUTE_TIMEOUT_MS = 25_000;
+
+export type RecomputeResult = { ok: true; driftCount: number } | { ok: false; error: string };
+
+/**
+ * Admin-only on-demand rule-drift recompute. Runs the heavy live sweep (bounded by a timeout so a
+ * slow query can't hang the request), persists a fresh `RuleDriftSnapshot`, and revalidates the
+ * page. Returns an explicit error result on failure — the caller MUST surface it (never a silent
+ * "no drift" green).
+ */
+export async function recomputeRuleDrift(): Promise<RecomputeResult> {
+  await requireAdmin();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const findings = await Promise.race([
+      detectRuleDrift(prisma),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("rule-drift recompute timed out")), RECOMPUTE_TIMEOUT_MS);
+      }),
+    ]);
+    await writeRuleDriftSnapshot(prisma, findings);
+    revalidatePath("/admin/predictions");
+    return { ok: true, driftCount: findings.length };
+  } catch (err) {
+    Sentry.captureException(err);
+    return { ok: false, error: err instanceof Error ? err.message : "Unknown error" };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/app/admin/predictions/data.ts
+++ b/src/app/admin/predictions/data.ts
@@ -1,0 +1,146 @@
+/**
+ * Read-only data loaders for /admin/predictions.
+ *
+ * These are PLAIN async functions (NOT `"use server"` actions) imported only by the
+ * admin-gated server component page — so they are never exposed as POST endpoints. The only
+ * `"use server"` entry point is the admin-guarded recompute in `actions.ts`. (Server actions
+ * are POST endpoints anyone can hit; read paths stay off that surface — Codex review.)
+ */
+import { prisma } from "@/lib/db";
+import type { DriftFinding } from "@/pipeline/rule-drift";
+import {
+  DAYSOUT_BINS,
+  buildPrecisionMap,
+  tallyOutcomes,
+  firstMaturityDate,
+  type OutcomeTally,
+} from "@/lib/travel/ledger-scorecard";
+
+// ── Ledger scorecard ────────────────────────────────────────────────────────
+export interface PrecisionCellView {
+  confidence: "HIGH" | "MEDIUM";
+  bin: string;
+  hit: number;
+  miss: number;
+  /** HIT / (HIT + MISS); null when no scored rows in the cell ("not matured", not zero). */
+  precision: number | null;
+}
+
+export interface LedgerScorecard {
+  total: number;
+  outcomes: OutcomeTally;
+  scored: number; // HIT + MISS
+  precision: PrecisionCellView[]; // full HIGH/MEDIUM × bin grid (for the heatmap)
+  firstMaturityISO: string | null;
+  firstSnapshotISO: string | null;
+  kennelsCovered: number;
+  confidenceSplit: { HIGH: number; MEDIUM: number };
+  weekly: { week: string; count: number }[]; // accumulation by snapshot week-start
+}
+
+/** UTC date (YYYY-MM-DD) of the Monday that starts `d`'s week. */
+function weekStart(d: Date): string {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dayNum = (date.getUTCDay() + 6) % 7; // Mon = 0
+  date.setUTCDate(date.getUTCDate() - dayNum);
+  return date.toISOString().slice(0, 10);
+}
+
+export async function loadLedgerScorecard(): Promise<LedgerScorecard> {
+  const snaps = await prisma.predictionSnapshot.findMany({
+    select: { confidence: true, daysOutAtSnapshot: true, outcome: true, predictedDate: true, snapshotAt: true, kennelId: true },
+  });
+
+  const outcomes = tallyOutcomes(snaps);
+  const precisionMap = buildPrecisionMap(snaps);
+  const precision: PrecisionCellView[] = [];
+  for (const confidence of ["HIGH", "MEDIUM"] as const) {
+    for (const b of DAYSOUT_BINS) {
+      const cell = precisionMap.get(`${confidence}|${b.label}`) ?? { hit: 0, miss: 0 };
+      const scored = cell.hit + cell.miss;
+      precision.push({ confidence, bin: b.label, hit: cell.hit, miss: cell.miss, precision: scored > 0 ? cell.hit / scored : null });
+    }
+  }
+
+  const firstMaturity = firstMaturityDate(snaps);
+  const firstSnapshot = snaps.reduce<Date | null>((e, s) => (!e || s.snapshotAt < e ? s.snapshotAt : e), null);
+  const confidenceSplit = { HIGH: 0, MEDIUM: 0 };
+  const weekCounts = new Map<string, number>();
+  for (const s of snaps) {
+    if (s.confidence === "HIGH" || s.confidence === "MEDIUM") confidenceSplit[s.confidence]++;
+    const w = weekStart(s.snapshotAt);
+    weekCounts.set(w, (weekCounts.get(w) ?? 0) + 1);
+  }
+  const weekly = [...weekCounts.entries()].sort((a, b) => a[0].localeCompare(b[0])).map(([week, count]) => ({ week, count }));
+
+  return {
+    total: outcomes.total,
+    outcomes,
+    scored: outcomes.HIT + outcomes.MISS,
+    precision,
+    firstMaturityISO: firstMaturity?.toISOString() ?? null,
+    firstSnapshotISO: firstSnapshot?.toISOString() ?? null,
+    kennelsCovered: new Set(snaps.map((s) => s.kennelId)).size,
+    confidenceSplit,
+    weekly,
+  };
+}
+
+// ── Rule-drift (latest persisted snapshot) ──────────────────────────────────
+export interface RuleDriftView {
+  ranAtISO: string | null;
+  findings: DriftFinding[];
+  everRun: boolean;
+}
+
+export async function loadRuleDriftSnapshot(): Promise<RuleDriftView> {
+  const latest = await prisma.ruleDriftSnapshot.findFirst({ orderBy: { ranAt: "desc" } });
+  if (!latest) return { ranAtISO: null, findings: [], everRun: false };
+  return {
+    ranAtISO: latest.ranAt.toISOString(),
+    findings: (latest.findings as unknown as DriftFinding[]) ?? [],
+    everRun: true,
+  };
+}
+
+// ── Schedule-rule coverage ──────────────────────────────────────────────────
+export interface RuleCoverage {
+  activeRules: number;
+  byConfidence: { HIGH: number; MEDIUM: number; LOW: number };
+  bySource: { source: string; count: number }[];
+  kennelsWithRule: number;
+  seasonalKennels: number;
+  darkKennels: number; // visible kennels with no active rule
+  totalVisibleKennels: number;
+}
+
+export async function loadRuleCoverage(): Promise<RuleCoverage> {
+  const activeVisible = { isActive: true, kennel: { isHidden: false } } as const;
+  const [byConf, bySrc, activeRules, withRule, seasonal, totalVisibleKennels] = await Promise.all([
+    prisma.scheduleRule.groupBy({ by: ["confidence"], where: activeVisible, _count: true }),
+    prisma.scheduleRule.groupBy({ by: ["source"], where: activeVisible, _count: true }),
+    prisma.scheduleRule.count({ where: activeVisible }),
+    prisma.scheduleRule.findMany({ where: activeVisible, select: { kennelId: true }, distinct: ["kennelId"] }),
+    prisma.scheduleRule.findMany({
+      where: { ...activeVisible, OR: [{ validFrom: { not: null } }, { validUntil: { not: null } }] },
+      select: { kennelId: true },
+      distinct: ["kennelId"],
+    }),
+    prisma.kennel.count({ where: { isHidden: false } }),
+  ]);
+
+  const byConfidence = { HIGH: 0, MEDIUM: 0, LOW: 0 };
+  for (const r of byConf) byConfidence[r.confidence] = r._count;
+  const bySource = bySrc.map((r) => ({ source: r.source, count: r._count })).sort((a, b) => b.count - a.count);
+  const kennelsWithRule = withRule.length;
+
+  return {
+    activeRules,
+    byConfidence,
+    bySource,
+    kennelsWithRule,
+    seasonalKennels: seasonal.length,
+    darkKennels: Math.max(0, totalVisibleKennels - kennelsWithRule),
+    totalVisibleKennels,
+  };
+}

--- a/src/app/admin/predictions/data.ts
+++ b/src/app/admin/predictions/data.ts
@@ -10,9 +10,7 @@ import { prisma } from "@/lib/db";
 import type { DriftFinding } from "@/pipeline/rule-drift";
 import {
   DAYSOUT_BINS,
-  buildPrecisionMap,
-  tallyOutcomes,
-  firstMaturityDate,
+  binOf,
   type OutcomeTally,
 } from "@/lib/travel/ledger-scorecard";
 
@@ -47,12 +45,40 @@ function weekStart(d: Date): string {
 }
 
 export async function loadLedgerScorecard(): Promise<LedgerScorecard> {
-  const snaps = await prisma.predictionSnapshot.findMany({
-    select: { confidence: true, daysOutAtSnapshot: true, outcome: true, predictedDate: true, snapshotAt: true, kennelId: true },
-  });
+  // Aggregate in the DB (not by fetching every row) — PredictionSnapshot grows ~weekly forever,
+  // so an in-memory tally would balloon and risk OOM in serverless (gemini review). The grouped
+  // results are bounded: outcomes (≤5), precision by confidence×daysOut×outcome (≤~800),
+  // confidence (≤3), and snapshots-by-snapshotAt (≈1 row per weekly cron run via createMany).
+  const [outcomeGroups, precisionGroups, earliestPending, earliestSnapshot, confidenceGroups, weeklyGroups, distinctKennels] =
+    await Promise.all([
+      prisma.predictionSnapshot.groupBy({ by: ["outcome"], _count: true }),
+      prisma.predictionSnapshot.groupBy({
+        by: ["confidence", "daysOutAtSnapshot", "outcome"],
+        where: { outcome: { in: ["HIT", "MISS"] } },
+        _count: true,
+      }),
+      prisma.predictionSnapshot.aggregate({ where: { outcome: "PENDING" }, _min: { predictedDate: true } }),
+      prisma.predictionSnapshot.aggregate({ _min: { snapshotAt: true } }),
+      prisma.predictionSnapshot.groupBy({ by: ["confidence"], _count: true }),
+      prisma.predictionSnapshot.groupBy({ by: ["snapshotAt"], _count: true }),
+      prisma.predictionSnapshot.findMany({ select: { kennelId: true }, distinct: ["kennelId"] }),
+    ]);
 
-  const outcomes = tallyOutcomes(snaps);
-  const precisionMap = buildPrecisionMap(snaps);
+  const outcomes: OutcomeTally = { PENDING: 0, HIT: 0, MISS: 0, PRECONFIRMED: 0, UNOBSERVED: 0, total: 0 };
+  for (const g of outcomeGroups) {
+    outcomes[g.outcome] = g._count;
+    outcomes.total += g._count;
+  }
+
+  const precisionMap = new Map<string, { hit: number; miss: number }>();
+  for (const g of precisionGroups) {
+    if (g.confidence !== "HIGH" && g.confidence !== "MEDIUM") continue;
+    const key = `${g.confidence}|${binOf(g.daysOutAtSnapshot)}`;
+    const cell = precisionMap.get(key) ?? { hit: 0, miss: 0 };
+    if (g.outcome === "HIT") cell.hit += g._count;
+    else cell.miss += g._count;
+    precisionMap.set(key, cell);
+  }
   const precision: PrecisionCellView[] = [];
   for (const confidence of ["HIGH", "MEDIUM"] as const) {
     for (const b of DAYSOUT_BINS) {
@@ -62,14 +88,15 @@ export async function loadLedgerScorecard(): Promise<LedgerScorecard> {
     }
   }
 
-  const firstMaturity = firstMaturityDate(snaps);
-  const firstSnapshot = snaps.reduce<Date | null>((e, s) => (!e || s.snapshotAt < e ? s.snapshotAt : e), null);
   const confidenceSplit = { HIGH: 0, MEDIUM: 0 };
+  for (const g of confidenceGroups) {
+    if (g.confidence === "HIGH" || g.confidence === "MEDIUM") confidenceSplit[g.confidence] = g._count;
+  }
+
   const weekCounts = new Map<string, number>();
-  for (const s of snaps) {
-    if (s.confidence === "HIGH" || s.confidence === "MEDIUM") confidenceSplit[s.confidence]++;
-    const w = weekStart(s.snapshotAt);
-    weekCounts.set(w, (weekCounts.get(w) ?? 0) + 1);
+  for (const g of weeklyGroups) {
+    const w = weekStart(g.snapshotAt);
+    weekCounts.set(w, (weekCounts.get(w) ?? 0) + g._count);
   }
   const weekly = [...weekCounts.entries()].sort((a, b) => a[0].localeCompare(b[0])).map(([week, count]) => ({ week, count }));
 
@@ -78,9 +105,9 @@ export async function loadLedgerScorecard(): Promise<LedgerScorecard> {
     outcomes,
     scored: outcomes.HIT + outcomes.MISS,
     precision,
-    firstMaturityISO: firstMaturity?.toISOString() ?? null,
-    firstSnapshotISO: firstSnapshot?.toISOString() ?? null,
-    kennelsCovered: new Set(snaps.map((s) => s.kennelId)).size,
+    firstMaturityISO: earliestPending._min.predictedDate?.toISOString() ?? null,
+    firstSnapshotISO: earliestSnapshot._min.snapshotAt?.toISOString() ?? null,
+    kennelsCovered: distinctKennels.length,
     confidenceSplit,
     weekly,
   };

--- a/src/app/admin/predictions/data.ts
+++ b/src/app/admin/predictions/data.ts
@@ -8,6 +8,7 @@
  */
 import { prisma } from "@/lib/db";
 import type { DriftFinding } from "@/pipeline/rule-drift";
+import type { PredictionOutcome, ScheduleConfidence } from "@/generated/prisma/client";
 import {
   DAYSOUT_BINS,
   binOf,
@@ -44,6 +45,58 @@ function weekStart(d: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+// — groupBy result processors (kept out of the loader to bound its cognitive complexity) —
+type OutcomeGroup = { outcome: PredictionOutcome; _count: number };
+type PrecisionGroup = { confidence: ScheduleConfidence; daysOutAtSnapshot: number; outcome: PredictionOutcome; _count: number };
+type ConfidenceGroup = { confidence: ScheduleConfidence; _count: number };
+type WeeklyGroup = { snapshotAt: Date; _count: number };
+
+function tallyOutcomeGroups(groups: OutcomeGroup[]): OutcomeTally {
+  const t: OutcomeTally = { PENDING: 0, HIT: 0, MISS: 0, PRECONFIRMED: 0, UNOBSERVED: 0, total: 0 };
+  for (const g of groups) {
+    t[g.outcome] = g._count;
+    t.total += g._count;
+  }
+  return t;
+}
+
+function precisionFromGroups(groups: PrecisionGroup[]): PrecisionCellView[] {
+  const map = new Map<string, { hit: number; miss: number }>();
+  for (const g of groups) {
+    if (g.confidence !== "HIGH" && g.confidence !== "MEDIUM") continue;
+    const cell = map.get(`${g.confidence}|${binOf(g.daysOutAtSnapshot)}`) ?? { hit: 0, miss: 0 };
+    if (g.outcome === "HIT") cell.hit += g._count;
+    else cell.miss += g._count;
+    map.set(`${g.confidence}|${binOf(g.daysOutAtSnapshot)}`, cell);
+  }
+  const out: PrecisionCellView[] = [];
+  for (const confidence of ["HIGH", "MEDIUM"] as const) {
+    for (const b of DAYSOUT_BINS) {
+      const cell = map.get(`${confidence}|${b.label}`) ?? { hit: 0, miss: 0 };
+      const scored = cell.hit + cell.miss;
+      out.push({ confidence, bin: b.label, hit: cell.hit, miss: cell.miss, precision: scored > 0 ? cell.hit / scored : null });
+    }
+  }
+  return out;
+}
+
+function splitConfidence(groups: ConfidenceGroup[]): { HIGH: number; MEDIUM: number } {
+  const split = { HIGH: 0, MEDIUM: 0 };
+  for (const g of groups) {
+    if (g.confidence === "HIGH" || g.confidence === "MEDIUM") split[g.confidence] = g._count;
+  }
+  return split;
+}
+
+function bucketWeekly(groups: WeeklyGroup[]): { week: string; count: number }[] {
+  const weekCounts = new Map<string, number>();
+  for (const g of groups) {
+    const w = weekStart(g.snapshotAt);
+    weekCounts.set(w, (weekCounts.get(w) ?? 0) + g._count);
+  }
+  return [...weekCounts.entries()].sort((a, b) => a[0].localeCompare(b[0])).map(([week, count]) => ({ week, count }));
+}
+
 export async function loadLedgerScorecard(): Promise<LedgerScorecard> {
   // Aggregate in the DB (not by fetching every row) — PredictionSnapshot grows ~weekly forever,
   // so an in-memory tally would balloon and risk OOM in serverless (gemini review). The grouped
@@ -64,52 +117,17 @@ export async function loadLedgerScorecard(): Promise<LedgerScorecard> {
       prisma.predictionSnapshot.findMany({ select: { kennelId: true }, distinct: ["kennelId"] }),
     ]);
 
-  const outcomes: OutcomeTally = { PENDING: 0, HIT: 0, MISS: 0, PRECONFIRMED: 0, UNOBSERVED: 0, total: 0 };
-  for (const g of outcomeGroups) {
-    outcomes[g.outcome] = g._count;
-    outcomes.total += g._count;
-  }
-
-  const precisionMap = new Map<string, { hit: number; miss: number }>();
-  for (const g of precisionGroups) {
-    if (g.confidence !== "HIGH" && g.confidence !== "MEDIUM") continue;
-    const key = `${g.confidence}|${binOf(g.daysOutAtSnapshot)}`;
-    const cell = precisionMap.get(key) ?? { hit: 0, miss: 0 };
-    if (g.outcome === "HIT") cell.hit += g._count;
-    else cell.miss += g._count;
-    precisionMap.set(key, cell);
-  }
-  const precision: PrecisionCellView[] = [];
-  for (const confidence of ["HIGH", "MEDIUM"] as const) {
-    for (const b of DAYSOUT_BINS) {
-      const cell = precisionMap.get(`${confidence}|${b.label}`) ?? { hit: 0, miss: 0 };
-      const scored = cell.hit + cell.miss;
-      precision.push({ confidence, bin: b.label, hit: cell.hit, miss: cell.miss, precision: scored > 0 ? cell.hit / scored : null });
-    }
-  }
-
-  const confidenceSplit = { HIGH: 0, MEDIUM: 0 };
-  for (const g of confidenceGroups) {
-    if (g.confidence === "HIGH" || g.confidence === "MEDIUM") confidenceSplit[g.confidence] = g._count;
-  }
-
-  const weekCounts = new Map<string, number>();
-  for (const g of weeklyGroups) {
-    const w = weekStart(g.snapshotAt);
-    weekCounts.set(w, (weekCounts.get(w) ?? 0) + g._count);
-  }
-  const weekly = [...weekCounts.entries()].sort((a, b) => a[0].localeCompare(b[0])).map(([week, count]) => ({ week, count }));
-
+  const outcomes = tallyOutcomeGroups(outcomeGroups);
   return {
     total: outcomes.total,
     outcomes,
     scored: outcomes.HIT + outcomes.MISS,
-    precision,
+    precision: precisionFromGroups(precisionGroups),
     firstMaturityISO: earliestPending._min.predictedDate?.toISOString() ?? null,
     firstSnapshotISO: earliestSnapshot._min.snapshotAt?.toISOString() ?? null,
     kennelsCovered: distinctKennels.length,
-    confidenceSplit,
-    weekly,
+    confidenceSplit: splitConfidence(confidenceGroups),
+    weekly: bucketWeekly(weeklyGroups),
   };
 }
 

--- a/src/app/admin/predictions/data.ts
+++ b/src/app/admin/predictions/data.ts
@@ -93,12 +93,17 @@ export interface RuleDriftView {
   everRun: boolean;
 }
 
+/** The findings JSON column is `DriftFinding[]`; guard against a non-array value defensively. */
+function asFindings(json: unknown): DriftFinding[] {
+  return Array.isArray(json) ? (json as DriftFinding[]) : [];
+}
+
 export async function loadRuleDriftSnapshot(): Promise<RuleDriftView> {
   const latest = await prisma.ruleDriftSnapshot.findFirst({ orderBy: { ranAt: "desc" } });
   if (!latest) return { ranAtISO: null, findings: [], everRun: false };
   return {
     ranAtISO: latest.ranAt.toISOString(),
-    findings: (latest.findings as unknown as DriftFinding[]) ?? [],
+    findings: asFindings(latest.findings),
     everRun: true,
   };
 }

--- a/src/app/admin/predictions/page.tsx
+++ b/src/app/admin/predictions/page.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { loadLedgerScorecard, loadRuleDriftSnapshot, loadRuleCoverage } from "./data";
 import { PredictionsDashboard } from "@/components/admin/PredictionsDashboard";
 
@@ -11,6 +12,11 @@ export default async function PredictionsPage() {
     loadRuleDriftSnapshot(),
     loadRuleCoverage(),
   ]);
+
+  // Don't let allSettled silently swallow a failing section — surface it for debugging.
+  if (ledger.status === "rejected") Sentry.captureException(ledger.reason);
+  if (drift.status === "rejected") Sentry.captureException(drift.reason);
+  if (coverage.status === "rejected") Sentry.captureException(coverage.reason);
 
   return (
     <PredictionsDashboard

--- a/src/app/admin/predictions/page.tsx
+++ b/src/app/admin/predictions/page.tsx
@@ -1,0 +1,22 @@
+import { loadLedgerScorecard, loadRuleDriftSnapshot, loadRuleCoverage } from "./data";
+import { PredictionsDashboard } from "@/components/admin/PredictionsDashboard";
+
+// Admin-gated by src/app/admin/layout.tsx (getAdminUser). The data loaders below are plain
+// async functions (not server actions), so they are never exposed as POST endpoints.
+export const dynamic = "force-dynamic";
+
+export default async function PredictionsPage() {
+  const [ledger, drift, coverage] = await Promise.allSettled([
+    loadLedgerScorecard(),
+    loadRuleDriftSnapshot(),
+    loadRuleCoverage(),
+  ]);
+
+  return (
+    <PredictionsDashboard
+      ledger={ledger.status === "fulfilled" ? { ok: true, data: ledger.value } : { ok: false }}
+      drift={drift.status === "fulfilled" ? { ok: true, data: drift.value } : { ok: false }}
+      coverage={coverage.status === "fulfilled" ? { ok: true, data: coverage.value } : { ok: false }}
+    />
+  );
+}

--- a/src/app/api/cron/rule-drift/route.ts
+++ b/src/app/api/cron/rule-drift/route.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { verifyCronAuth } from "@/lib/cron-auth";
 import { prisma } from "@/lib/db";
 import { getValidatedRepo } from "@/lib/github-repo";
-import { detectRuleDrift, type DriftFinding } from "@/pipeline/rule-drift";
+import { detectRuleDrift, writeRuleDriftSnapshot, type DriftFinding } from "@/pipeline/rule-drift";
 
 /**
  * Weekly schedule-rule drift check.
@@ -83,6 +83,9 @@ export async function POST(request: Request) {
   }
   try {
     const findings = await detectRuleDrift(prisma);
+    // Persist every run (even 0 drift) so /admin/predictions shows "last checked" + findings
+    // without re-running the heavy sweep on the page path.
+    await writeRuleDriftSnapshot(prisma, findings);
     let issue = { filed: false, reason: "no drift" };
     if (findings.length > 0) issue = await fileDriftIssue(findings);
     console.log(`[rule-drift] ${findings.length} drifted kennel(s); issue: ${issue.reason}`);

--- a/src/components/admin/AdminNavTabs.tsx
+++ b/src/components/admin/AdminNavTabs.tsx
@@ -16,6 +16,7 @@ import {
   Bell,
   BarChart3,
   ShieldCheck,
+  Target,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
@@ -42,6 +43,7 @@ export const TAB_ROUTES: TabRoute[] = [
   { value: "alerts", href: "/admin/alerts", label: "Alerts", icon: Bell, description: "Monitor source health alerts and take repair actions." },
   { value: "audit", href: "/admin/audit", label: "Audit", icon: ShieldCheck, description: "Daily data quality audit trends, top offenders, and suppressions." },
   { value: "analytics", href: "/admin/analytics", label: "Analytics", icon: BarChart3, description: "Community health, user engagement, and operational metrics." },
+  { value: "predictions", href: "/admin/predictions", label: "Predictions", icon: Target, description: "Travel Mode forward-prediction ledger, rule-drift findings, and schedule-rule coverage." },
 ];
 
 /** Map of tab value → badge count. Only tabs with count > 0 show a badge. */

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -18,7 +18,7 @@ const NAV_GROUPS = [
   },
   {
     label: "Operations",
-    tabs: ["alerts", "discovery", "research"],
+    tabs: ["alerts", "discovery", "research", "predictions"],
   },
   {
     label: "Access",

--- a/src/components/admin/PredictionsDashboard.tsx
+++ b/src/components/admin/PredictionsDashboard.tsx
@@ -54,7 +54,7 @@ function addDaysISO(iso: string, days: number): string {
   return new Date(new Date(iso).getTime() + days * DAY_MS).toISOString();
 }
 
-function ErrorCard({ what }: { what: string }) {
+function ErrorCard({ what }: Readonly<{ what: string }>) {
   return (
     <div className="rounded-xl border border-red-500/30 bg-red-500/[0.06] p-4 text-sm text-red-500">
       <AlertTriangle className="mb-1 inline h-4 w-4" /> Failed to load {what}.
@@ -69,7 +69,18 @@ const BANDS: { band: number; bin: string }[] = [
   { band: 180, bin: "121–200" },
 ];
 
-function MaturityTimeline({ ledger }: { ledger: LedgerScorecard }) {
+type BandStatus = "scoring" | "maturing" | "idle";
+function bandStatus(total: number, scored: boolean): BandStatus {
+  if (total === 0) return "idle";
+  return scored ? "scoring" : "maturing";
+}
+function bandMeta(status: BandStatus): { tone: string; label: string } {
+  if (status === "scoring") return { tone: "border-emerald-500/40 bg-emerald-500/[0.07] text-emerald-500", label: "Scoring" };
+  if (status === "maturing") return { tone: "border-amber-500/40 bg-amber-500/[0.07] text-amber-500", label: "Maturing" };
+  return { tone: "border-border/60 bg-muted/30 text-muted-foreground", label: "Not started" };
+}
+
+function MaturityTimeline({ ledger }: Readonly<{ ledger: LedgerScorecard }>) {
   const scoredBins = new Set(
     ledger.precision.filter((c) => c.hit + c.miss > 0).map((c) => c.bin),
   );
@@ -77,14 +88,8 @@ function MaturityTimeline({ ledger }: { ledger: LedgerScorecard }) {
     <div className="grid gap-3 sm:grid-cols-3">
       {BANDS.map(({ band, bin }) => {
         const eta = ledger.firstSnapshotISO ? addDaysISO(ledger.firstSnapshotISO, band) : null;
-        const status = ledger.total === 0 ? "idle" : scoredBins.has(bin) ? "scoring" : "maturing";
-        const tone =
-          status === "scoring"
-            ? "border-emerald-500/40 bg-emerald-500/[0.07] text-emerald-500"
-            : status === "maturing"
-              ? "border-amber-500/40 bg-amber-500/[0.07] text-amber-500"
-              : "border-border/60 bg-muted/30 text-muted-foreground";
-        const label = status === "scoring" ? "Scoring" : status === "maturing" ? "Maturing" : "Not started";
+        const status = bandStatus(ledger.total, scoredBins.has(bin));
+        const { tone, label } = bandMeta(status);
         return (
           <div key={band} className={`rounded-xl border p-4 transition-colors ${tone}`}>
             <div className="flex items-center justify-between">
@@ -113,7 +118,7 @@ function precisionBg(p: number | null): string {
   return `rgba(16, 185, 129, ${(0.08 + p * 0.5).toFixed(3)})`;
 }
 
-function PrecisionHeatmap({ ledger }: { ledger: LedgerScorecard }) {
+function PrecisionHeatmap({ ledger }: Readonly<{ ledger: LedgerScorecard }>) {
   const cell = (conf: "HIGH" | "MEDIUM", bin: string) =>
     ledger.precision.find((c) => c.confidence === conf && c.bin === bin);
   return (
@@ -160,7 +165,7 @@ function PrecisionHeatmap({ ledger }: { ledger: LedgerScorecard }) {
 }
 
 // ── Rule-drift section ───────────────────────────────────────────────────────
-function DriftSection({ drift }: { drift: RuleDriftView }) {
+function DriftSection({ drift }: Readonly<{ drift: RuleDriftView }>) {
   const [isPending, startTransition] = useTransition();
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
 
@@ -173,6 +178,53 @@ function DriftSection({ drift }: { drift: RuleDriftView }) {
   };
 
   const { findings, ranAtISO, everRun } = drift;
+
+  const body = () => {
+    if (!everRun) {
+      return (
+        <div className="rounded-xl border border-border/60 bg-muted/30 p-4 text-sm text-muted-foreground">
+          The weekly rule-drift check hasn&apos;t run yet — it runs Mondays, or use “Re-run now”.
+        </div>
+      );
+    }
+    if (findings.length === 0) {
+      return (
+        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/[0.06] p-4 text-sm text-emerald-600">
+          <CheckCircle className="mb-0.5 mr-1 inline h-4 w-4" /> No drift — every active rule agrees with recent reality.
+        </div>
+      );
+    }
+    return (
+      <div className="overflow-x-auto rounded-xl border border-border/50">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40 text-[11px] uppercase tracking-wider text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2 text-left">Kennel</th>
+              <th className="px-3 py-2 text-left">Region</th>
+              <th className="px-3 py-2 text-left">Rule predicts</th>
+              <th className="px-3 py-2 text-left">Recent actual</th>
+              <th className="px-3 py-2 text-left">Active rule(s)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {findings.map((f) => (
+              <tr key={f.kennelCode} className="border-t border-border/40 hover:bg-muted/20">
+                <td className="px-3 py-2 font-medium">{f.shortName} <span className="text-muted-foreground">({f.kennelCode})</span></td>
+                <td className="px-3 py-2 text-muted-foreground">{f.region}</td>
+                <td className="px-3 py-2">{f.predictedWeekdays.join("/")}</td>
+                <td className="px-3 py-2">
+                  <span className="font-semibold text-amber-600">{f.actualWeekday}</span>{" "}
+                  <span className="text-muted-foreground">({Math.round(f.actualShare * 100)}%, {f.recentEventCount} ev)</span>
+                </td>
+                <td className="px-3 py-2 font-mono text-xs text-muted-foreground">{f.activeRules}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
   return (
     <section className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -196,43 +248,7 @@ function DriftSection({ drift }: { drift: RuleDriftView }) {
         </div>
       )}
 
-      {!everRun ? (
-        <div className="rounded-xl border border-border/60 bg-muted/30 p-4 text-sm text-muted-foreground">
-          The weekly rule-drift check hasn&apos;t run yet — it runs Mondays, or use “Re-run now”.
-        </div>
-      ) : findings.length === 0 ? (
-        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/[0.06] p-4 text-sm text-emerald-600">
-          <CheckCircle className="mb-0.5 mr-1 inline h-4 w-4" /> No drift — every active rule agrees with recent reality.
-        </div>
-      ) : (
-        <div className="overflow-x-auto rounded-xl border border-border/50">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/40 text-[11px] uppercase tracking-wider text-muted-foreground">
-              <tr>
-                <th className="px-3 py-2 text-left">Kennel</th>
-                <th className="px-3 py-2 text-left">Region</th>
-                <th className="px-3 py-2 text-left">Rule predicts</th>
-                <th className="px-3 py-2 text-left">Recent actual</th>
-                <th className="px-3 py-2 text-left">Active rule(s)</th>
-              </tr>
-            </thead>
-            <tbody>
-              {findings.map((f) => (
-                <tr key={f.kennelCode} className="border-t border-border/40 hover:bg-muted/20">
-                  <td className="px-3 py-2 font-medium">{f.shortName} <span className="text-muted-foreground">({f.kennelCode})</span></td>
-                  <td className="px-3 py-2 text-muted-foreground">{f.region}</td>
-                  <td className="px-3 py-2">{f.predictedWeekdays.join("/")}</td>
-                  <td className="px-3 py-2">
-                    <span className="font-semibold text-amber-600">{f.actualWeekday}</span>{" "}
-                    <span className="text-muted-foreground">({Math.round(f.actualShare * 100)}%, {f.recentEventCount} ev)</span>
-                  </td>
-                  <td className="px-3 py-2 font-mono text-xs text-muted-foreground">{f.activeRules}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      {body()}
       <a
         href="https://github.com/johnrclem/hashtracks-web/issues?q=is%3Aissue+label%3Arule-drift"
         target="_blank"
@@ -246,7 +262,7 @@ function DriftSection({ drift }: { drift: RuleDriftView }) {
 }
 
 // ── Dashboard ────────────────────────────────────────────────────────────────
-export function PredictionsDashboard({ ledger, drift, coverage }: Props) {
+export function PredictionsDashboard({ ledger, drift, coverage }: Readonly<Props>) {
   return (
     <div className="space-y-10">
       <div>
@@ -259,9 +275,7 @@ export function PredictionsDashboard({ ledger, drift, coverage }: Props) {
       {/* ── Ledger ── */}
       <section className="space-y-5">
         <SectionHeader icon={Activity} title="Forward-prediction ledger" color="bg-blue-500/10 text-blue-500" />
-        {!ledger.ok ? (
-          <ErrorCard what="the prediction ledger" />
-        ) : (
+        {ledger.ok ? (
           <>
             <MaturityTimeline ledger={ledger.data} />
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
@@ -308,18 +322,18 @@ export function PredictionsDashboard({ ledger, drift, coverage }: Props) {
               </div>
             )}
           </>
+        ) : (
+          <ErrorCard what="the prediction ledger" />
         )}
       </section>
 
       {/* ── Rule-drift ── */}
-      {!drift.ok ? <ErrorCard what="rule-drift findings" /> : <DriftSection drift={drift.data} />}
+      {drift.ok ? <DriftSection drift={drift.data} /> : <ErrorCard what="rule-drift findings" />}
 
       {/* ── Coverage ── */}
       <section className="space-y-5">
         <SectionHeader icon={CalendarRange} title="Schedule-rule coverage" color="bg-purple-500/10 text-purple-500" />
-        {!coverage.ok ? (
-          <ErrorCard what="schedule-rule coverage" />
-        ) : (
+        {coverage.ok ? (
           <>
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
               <StatCard label="Active rules" value={coverage.data.activeRules} icon={Hash} color="purple" />
@@ -361,6 +375,8 @@ export function PredictionsDashboard({ ledger, drift, coverage }: Props) {
               </div>
             </div>
           </>
+        ) : (
+          <ErrorCard what="schedule-rule coverage" />
         )}
       </section>
     </div>

--- a/src/components/admin/PredictionsDashboard.tsx
+++ b/src/components/admin/PredictionsDashboard.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Target,
+  Activity,
+  CheckCircle,
+  XCircle,
+  Clock,
+  CircleSlash,
+  ShieldQuestion,
+  CalendarClock,
+  RefreshCw,
+  AlertTriangle,
+  Layers,
+  CalendarRange,
+  Hash,
+} from "lucide-react";
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { StatCard, SectionHeader } from "./dashboard-shared";
+import { recomputeRuleDrift } from "@/app/admin/predictions/actions";
+import type {
+  LedgerScorecard,
+  RuleDriftView,
+  RuleCoverage,
+} from "@/app/admin/predictions/data";
+
+type Loadable<T> = { ok: true; data: T } | { ok: false };
+
+interface Props {
+  ledger: Loadable<LedgerScorecard>;
+  drift: Loadable<RuleDriftView>;
+  coverage: Loadable<RuleCoverage>;
+}
+
+const DAY_MS = 86_400_000;
+
+/** Deterministic UTC date format (no hydration drift). */
+function fmtDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
+}
+function addDaysISO(iso: string, days: number): string {
+  return new Date(new Date(iso).getTime() + days * DAY_MS).toISOString();
+}
+
+function ErrorCard({ what }: { what: string }) {
+  return (
+    <div className="rounded-xl border border-red-500/30 bg-red-500/[0.06] p-4 text-sm text-red-500">
+      <AlertTriangle className="mb-1 inline h-4 w-4" /> Failed to load {what}.
+    </div>
+  );
+}
+
+// ── Horizon-maturity timeline (hero) ─────────────────────────────────────────
+const BANDS: { band: number; bin: string }[] = [
+  { band: 30, bin: "0–45" },
+  { band: 90, bin: "46–120" },
+  { band: 180, bin: "121–200" },
+];
+
+function MaturityTimeline({ ledger }: { ledger: LedgerScorecard }) {
+  const scoredBins = new Set(
+    ledger.precision.filter((c) => c.hit + c.miss > 0).map((c) => c.bin),
+  );
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      {BANDS.map(({ band, bin }) => {
+        const eta = ledger.firstSnapshotISO ? addDaysISO(ledger.firstSnapshotISO, band) : null;
+        const status = ledger.total === 0 ? "idle" : scoredBins.has(bin) ? "scoring" : "maturing";
+        const tone =
+          status === "scoring"
+            ? "border-emerald-500/40 bg-emerald-500/[0.07] text-emerald-500"
+            : status === "maturing"
+              ? "border-amber-500/40 bg-amber-500/[0.07] text-amber-500"
+              : "border-border/60 bg-muted/30 text-muted-foreground";
+        const label = status === "scoring" ? "Scoring" : status === "maturing" ? "Maturing" : "Not started";
+        return (
+          <div key={band} className={`rounded-xl border p-4 transition-colors ${tone}`}>
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold uppercase tracking-wider">{band}-day band</span>
+              <span className="text-[10px] font-medium uppercase tracking-wider">{label}</span>
+            </div>
+            <div className="mt-2 text-lg font-bold tracking-tight text-foreground">
+              {status === "scoring" ? "Scores in" : "First scores"}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {eta ? `~${fmtDate(eta)}` : "awaiting first snapshot"}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Precision heatmap ────────────────────────────────────────────────────────
+const BINS = ["0–45", "46–120", "121–200"] as const;
+
+function precisionBg(p: number | null): string {
+  if (p === null) return "transparent";
+  // single-hue emerald ramp; min 0.08 so even low precision reads as "has data"
+  return `rgba(16, 185, 129, ${(0.08 + p * 0.5).toFixed(3)})`;
+}
+
+function PrecisionHeatmap({ ledger }: { ledger: LedgerScorecard }) {
+  const cell = (conf: "HIGH" | "MEDIUM", bin: string) =>
+    ledger.precision.find((c) => c.confidence === conf && c.bin === bin);
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-separate border-spacing-1 text-sm">
+        <thead>
+          <tr className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            <th className="text-left font-medium">Confidence</th>
+            {BINS.map((b) => (
+              <th key={b} className="px-2 text-center font-medium">{b} days out</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {(["HIGH", "MEDIUM"] as const).map((conf) => (
+            <tr key={conf}>
+              <td className="py-1 pr-2 font-semibold">{conf}</td>
+              {BINS.map((bin) => {
+                const c = cell(conf, bin);
+                const p = c?.precision ?? null;
+                return (
+                  <td
+                    key={bin}
+                    className="rounded-md border border-border/40 px-2 py-2 text-center align-middle tabular-nums"
+                    style={{ backgroundColor: precisionBg(p) }}
+                  >
+                    {p === null ? (
+                      <span className="text-muted-foreground/60">—</span>
+                    ) : (
+                      <>
+                        <div className="font-bold">{Math.round(p * 100)}%</div>
+                        <div className="text-[10px] text-muted-foreground">{c!.hit}H / {c!.miss}M</div>
+                      </>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Rule-drift section ───────────────────────────────────────────────────────
+function DriftSection({ drift }: { drift: RuleDriftView }) {
+  const [isPending, startTransition] = useTransition();
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const onRecompute = () => {
+    setMsg(null);
+    startTransition(async () => {
+      const r = await recomputeRuleDrift();
+      setMsg(r.ok ? { ok: true, text: `Re-ran — ${r.driftCount} drifted kennel(s).` } : { ok: false, text: r.error });
+    });
+  };
+
+  const { findings, ranAtISO, everRun } = drift;
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <SectionHeader icon={Target} title="Rule-drift findings" color="bg-amber-500/10 text-amber-500" />
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {everRun && <span>last checked {fmtDate(ranAtISO)}</span>}
+          <button
+            onClick={onRecompute}
+            disabled={isPending}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2.5 py-1.5 font-medium text-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${isPending ? "animate-spin" : ""}`} />
+            {isPending ? "Re-running…" : "Re-run now"}
+          </button>
+        </div>
+      </div>
+
+      {msg && (
+        <div className={`rounded-md px-3 py-2 text-sm ${msg.ok ? "bg-emerald-500/10 text-emerald-600" : "bg-red-500/10 text-red-500"}`}>
+          {msg.text}
+        </div>
+      )}
+
+      {!everRun ? (
+        <div className="rounded-xl border border-border/60 bg-muted/30 p-4 text-sm text-muted-foreground">
+          The weekly rule-drift check hasn&apos;t run yet — it runs Mondays, or use “Re-run now”.
+        </div>
+      ) : findings.length === 0 ? (
+        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/[0.06] p-4 text-sm text-emerald-600">
+          <CheckCircle className="mb-0.5 mr-1 inline h-4 w-4" /> No drift — every active rule agrees with recent reality.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border/50">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-[11px] uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left">Kennel</th>
+                <th className="px-3 py-2 text-left">Region</th>
+                <th className="px-3 py-2 text-left">Rule predicts</th>
+                <th className="px-3 py-2 text-left">Recent actual</th>
+                <th className="px-3 py-2 text-left">Active rule(s)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {findings.map((f) => (
+                <tr key={f.kennelCode} className="border-t border-border/40 hover:bg-muted/20">
+                  <td className="px-3 py-2 font-medium">{f.shortName} <span className="text-muted-foreground">({f.kennelCode})</span></td>
+                  <td className="px-3 py-2 text-muted-foreground">{f.region}</td>
+                  <td className="px-3 py-2">{f.predictedWeekdays.join("/")}</td>
+                  <td className="px-3 py-2">
+                    <span className="font-semibold text-amber-600">{f.actualWeekday}</span>{" "}
+                    <span className="text-muted-foreground">({Math.round(f.actualShare * 100)}%, {f.recentEventCount} ev)</span>
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs text-muted-foreground">{f.activeRules}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <a
+        href="https://github.com/johnrclem/hashtracks-web/issues?q=is%3Aissue+label%3Arule-drift"
+        target="_blank"
+        rel="noreferrer"
+        className="inline-block text-xs text-muted-foreground underline hover:text-foreground"
+      >
+        View rule-drift issues on GitHub →
+      </a>
+    </section>
+  );
+}
+
+// ── Dashboard ────────────────────────────────────────────────────────────────
+export function PredictionsDashboard({ ledger, drift, coverage }: Props) {
+  return (
+    <div className="space-y-10">
+      <div>
+        <h1 className="text-xl font-bold tracking-tight">Prediction Quality</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Forward calibration of Travel Mode predictions, measured against reality as cohorts mature — plus live rule-drift and schedule-rule coverage.
+        </p>
+      </div>
+
+      {/* ── Ledger ── */}
+      <section className="space-y-5">
+        <SectionHeader icon={Activity} title="Forward-prediction ledger" color="bg-blue-500/10 text-blue-500" />
+        {!ledger.ok ? (
+          <ErrorCard what="the prediction ledger" />
+        ) : (
+          <>
+            <MaturityTimeline ledger={ledger.data} />
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+              <StatCard label="Snapshots" value={ledger.data.total} icon={Layers} color="blue" subtitle={`${ledger.data.kennelsCovered} kennels`} />
+              <StatCard label="Pending" value={ledger.data.outcomes.PENDING} icon={Clock} color="amber" />
+              <StatCard label="Hit" value={ledger.data.outcomes.HIT} icon={CheckCircle} color="emerald" />
+              <StatCard label="Miss" value={ledger.data.outcomes.MISS} icon={XCircle} color="red" />
+              <StatCard label="Preconfirmed" value={ledger.data.outcomes.PRECONFIRMED} icon={CircleSlash} color="teal" subtitle="excluded" />
+              <StatCard label="Unobserved" value={ledger.data.outcomes.UNOBSERVED} icon={ShieldQuestion} color="teal" subtitle="excluded" />
+            </div>
+
+            <div className="space-y-2">
+              <h3 className="text-sm font-semibold">Precision — HIT / (HIT + MISS), by confidence × actual days-out</h3>
+              {ledger.data.scored === 0 ? (
+                <div className="flex items-start gap-2 rounded-xl border border-blue-500/30 bg-blue-500/[0.06] p-4 text-sm text-blue-600">
+                  <CalendarClock className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    Still accumulating — no matured HIT/MISS rows yet.{" "}
+                    {ledger.data.firstMaturityISO
+                      ? <>First scores arrive ~<strong>{fmtDate(ledger.data.firstMaturityISO)}</strong> (earliest pending target date).</>
+                      : "Snapshots begin on the weekly Monday cron."}
+                  </span>
+                </div>
+              ) : (
+                <PrecisionHeatmap ledger={ledger.data} />
+              )}
+              <p className="text-xs text-muted-foreground">
+                PRECONFIRMED + UNOBSERVED are excluded. Recall is a deferred follow-up (computed from events vs snapshot coverage, not snapshot rows).
+              </p>
+            </div>
+
+            {ledger.data.weekly.length > 1 && (
+              <div className="h-56 rounded-xl border border-border/50 bg-card p-4">
+                <h3 className="mb-2 text-sm font-semibold">Snapshots accumulated per week</h3>
+                <ResponsiveContainer width="100%" height="85%">
+                  <LineChart data={ledger.data.weekly} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                    <XAxis dataKey="week" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
+                    <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} allowDecimals={false} />
+                    <Tooltip contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 8, fontSize: 12 }} />
+                    <Line type="monotone" dataKey="count" stroke="#3b82f6" strokeWidth={2} dot={false} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* ── Rule-drift ── */}
+      {!drift.ok ? <ErrorCard what="rule-drift findings" /> : <DriftSection drift={drift.data} />}
+
+      {/* ── Coverage ── */}
+      <section className="space-y-5">
+        <SectionHeader icon={CalendarRange} title="Schedule-rule coverage" color="bg-purple-500/10 text-purple-500" />
+        {!coverage.ok ? (
+          <ErrorCard what="schedule-rule coverage" />
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+              <StatCard label="Active rules" value={coverage.data.activeRules} icon={Hash} color="purple" />
+              <StatCard label="Kennels w/ rule" value={coverage.data.kennelsWithRule} icon={CheckCircle} color="emerald" subtitle={`of ${coverage.data.totalVisibleKennels} visible`} />
+              <StatCard label="Seasonal kennels" value={coverage.data.seasonalKennels} icon={CalendarRange} color="amber" />
+              <StatCard label="Dark kennels" value={coverage.data.darkKennels} icon={CircleSlash} color="red" subtitle="no active rule" />
+              <StatCard label="HIGH confidence" value={coverage.data.byConfidence.HIGH} icon={Target} color="blue" />
+            </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="h-56 rounded-xl border border-border/50 bg-card p-4">
+                <h3 className="mb-2 text-sm font-semibold">Active rules by confidence</h3>
+                <ResponsiveContainer width="100%" height="85%">
+                  <BarChart
+                    data={[
+                      { tier: "HIGH", count: coverage.data.byConfidence.HIGH },
+                      { tier: "MEDIUM", count: coverage.data.byConfidence.MEDIUM },
+                      { tier: "LOW", count: coverage.data.byConfidence.LOW },
+                    ]}
+                    margin={{ top: 4, right: 8, left: -16, bottom: 0 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                    <XAxis dataKey="tier" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
+                    <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} allowDecimals={false} />
+                    <Tooltip contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 8, fontSize: 12 }} />
+                    <Bar dataKey="count" fill="#8b5cf6" radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="rounded-xl border border-border/50 bg-card p-4">
+                <h3 className="mb-2 text-sm font-semibold">Active rules by source</h3>
+                <ul className="space-y-1.5 text-sm">
+                  {coverage.data.bySource.map((s) => (
+                    <li key={s.source} className="flex items-center justify-between">
+                      <span className="font-mono text-xs text-muted-foreground">{s.source}</span>
+                      <span className="font-semibold tabular-nums">{s.count}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/lib/travel/ledger-scorecard.test.ts
+++ b/src/lib/travel/ledger-scorecard.test.ts
@@ -1,0 +1,83 @@
+import {
+  binOf,
+  buildPrecisionMap,
+  tallyOutcomes,
+  firstMaturityDate,
+  type ScorecardSnap,
+} from "./ledger-scorecard";
+
+const snap = (o: Partial<ScorecardSnap>): ScorecardSnap => ({
+  confidence: "HIGH",
+  daysOutAtSnapshot: 30,
+  outcome: "PENDING",
+  ...o,
+});
+
+describe("binOf", () => {
+  it("maps days-out to the named bins, with a 200+ catch-all", () => {
+    expect(binOf(0)).toBe("0–45");
+    expect(binOf(45)).toBe("0–45");
+    expect(binOf(46)).toBe("46–120");
+    expect(binOf(120)).toBe("46–120");
+    expect(binOf(121)).toBe("121–200");
+    expect(binOf(200)).toBe("121–200");
+    expect(binOf(201)).toBe("200+");
+  });
+});
+
+describe("buildPrecisionMap", () => {
+  it("counts only HIT/MISS, keyed by confidence|bin", () => {
+    const m = buildPrecisionMap([
+      snap({ confidence: "HIGH", daysOutAtSnapshot: 10, outcome: "HIT" }),
+      snap({ confidence: "HIGH", daysOutAtSnapshot: 20, outcome: "HIT" }),
+      snap({ confidence: "HIGH", daysOutAtSnapshot: 40, outcome: "MISS" }),
+      snap({ confidence: "MEDIUM", daysOutAtSnapshot: 100, outcome: "HIT" }),
+    ]);
+    expect(m.get("HIGH|0–45")).toEqual({ hit: 2, miss: 1 });
+    expect(m.get("MEDIUM|46–120")).toEqual({ hit: 1, miss: 0 });
+  });
+
+  it("excludes PENDING / PRECONFIRMED / UNOBSERVED", () => {
+    const m = buildPrecisionMap([
+      snap({ outcome: "PENDING" }),
+      snap({ outcome: "PRECONFIRMED" }),
+      snap({ outcome: "UNOBSERVED" }),
+    ]);
+    expect(m.size).toBe(0);
+  });
+});
+
+describe("tallyOutcomes", () => {
+  it("counts each outcome plus a total", () => {
+    const t = tallyOutcomes([
+      { outcome: "PENDING" },
+      { outcome: "PENDING" },
+      { outcome: "HIT" },
+      { outcome: "MISS" },
+      { outcome: "PRECONFIRMED" },
+      { outcome: "UNOBSERVED" },
+    ]);
+    expect(t).toEqual({ PENDING: 2, HIT: 1, MISS: 1, PRECONFIRMED: 1, UNOBSERVED: 1, total: 6 });
+  });
+
+  it("is all-zero for an empty set", () => {
+    expect(tallyOutcomes([])).toEqual({ PENDING: 0, HIT: 0, MISS: 0, PRECONFIRMED: 0, UNOBSERVED: 0, total: 0 });
+  });
+});
+
+describe("firstMaturityDate", () => {
+  const d = (iso: string) => new Date(iso + "T12:00:00Z");
+
+  it("returns the earliest PENDING predictedDate, ignoring scored rows", () => {
+    const r = firstMaturityDate([
+      { outcome: "HIT", predictedDate: d("2026-06-01") }, // ignored (not PENDING)
+      { outcome: "PENDING", predictedDate: d("2026-08-15") },
+      { outcome: "PENDING", predictedDate: d("2026-07-20") }, // earliest pending
+    ]);
+    expect(r?.toISOString().slice(0, 10)).toBe("2026-07-20");
+  });
+
+  it("returns null when nothing is PENDING", () => {
+    expect(firstMaturityDate([{ outcome: "HIT", predictedDate: d("2026-06-01") }])).toBeNull();
+  });
+});

--- a/src/lib/travel/ledger-scorecard.ts
+++ b/src/lib/travel/ledger-scorecard.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure scorecard helpers for the Travel Mode prediction ledger.
+ *
+ * Shared by `scripts/score-prediction-ledger.ts` (CLI markdown report) and the
+ * `/admin/predictions` dashboard so both compute forward calibration IDENTICALLY from
+ * `PredictionSnapshot` rows. Precision = HIT / (HIT + MISS) per confidence × actual-days-out
+ * bin; PRECONFIRMED + UNOBSERVED are excluded (contamination / unobserved — not model signal).
+ * Recall is a deferred follow-up (needs matured cohorts; computed from events, not snapshot rows).
+ */
+import type { PredictionOutcome, ScheduleConfidence } from "@/generated/prisma/client";
+
+/** Actual-days-out bins for precision (report by real horizon, not the nominal band). */
+export const DAYSOUT_BINS: { label: string; lo: number; hi: number }[] = [
+  { label: "0–45", lo: 0, hi: 45 },
+  { label: "46–120", lo: 46, hi: 120 },
+  { label: "121–200", lo: 121, hi: 200 },
+];
+
+/** The days-out bin label a snapshot falls into (or "200+" beyond the named bins). */
+export function binOf(daysOut: number): string {
+  return DAYSOUT_BINS.find((b) => daysOut >= b.lo && daysOut <= b.hi)?.label ?? "200+";
+}
+
+/** Minimal snapshot shape the precision map needs. */
+export interface ScorecardSnap {
+  confidence: ScheduleConfidence; // HIGH | MEDIUM in practice (LOW is never snapshotted)
+  daysOutAtSnapshot: number;
+  outcome: PredictionOutcome;
+}
+
+export type PrecisionCell = { hit: number; miss: number };
+
+/** Precision cells keyed `${confidence}|${bin}`, over HIT/MISS rows only. */
+export function buildPrecisionMap(snaps: ScorecardSnap[]): Map<string, PrecisionCell> {
+  const precision = new Map<string, PrecisionCell>();
+  for (const s of snaps) {
+    if (s.outcome !== "HIT" && s.outcome !== "MISS") continue;
+    const key = `${s.confidence}|${binOf(s.daysOutAtSnapshot)}`;
+    const cell = precision.get(key) ?? { hit: 0, miss: 0 };
+    if (s.outcome === "HIT") cell.hit++;
+    else cell.miss++;
+    precision.set(key, cell);
+  }
+  return precision;
+}
+
+export type OutcomeTally = Record<PredictionOutcome, number> & { total: number };
+
+/** Count snapshots per outcome (+ total). */
+export function tallyOutcomes(snaps: { outcome: PredictionOutcome }[]): OutcomeTally {
+  const t: OutcomeTally = { PENDING: 0, HIT: 0, MISS: 0, PRECONFIRMED: 0, UNOBSERVED: 0, total: 0 };
+  for (const s of snaps) {
+    t[s.outcome]++;
+    t.total++;
+  }
+  return t;
+}
+
+/**
+ * Earliest PENDING predictedDate = when the first scores arrive. `reduce` (not `Math.min(...)`)
+ * because the pending set can grow large and the spread would risk a max-call-stack overflow.
+ */
+export function firstMaturityDate(snaps: { outcome: PredictionOutcome; predictedDate: Date }[]): Date | null {
+  return snaps.reduce<Date | null>((earliest, s) => {
+    if (s.outcome !== "PENDING") return earliest;
+    return !earliest || s.predictedDate < earliest ? s.predictedDate : earliest;
+  }, null);
+}

--- a/src/pipeline/rule-drift.ts
+++ b/src/pipeline/rule-drift.ts
@@ -17,7 +17,7 @@
  *
  * Reuses the real engine (projectTrails) + isEligibleActual so detection matches production.
  */
-import type { PrismaClient, ScheduleConfidence } from "@/generated/prisma/client";
+import type { Prisma, PrismaClient, ScheduleConfidence } from "@/generated/prisma/client";
 import { CANONICAL_EVENT_WHERE } from "@/lib/event-filters";
 import { EVENT_ELIGIBILITY_SELECT, isEligibleActual } from "@/lib/event-eligibility";
 import { projectTrails, type ScheduleRuleInput } from "@/lib/travel/projections";
@@ -186,4 +186,15 @@ export async function detectRuleDrift(prisma: PrismaClient, now: Date = new Date
   }
   findings.sort((a, b) => a.shortName.localeCompare(b.shortName));
   return findings;
+}
+
+/**
+ * Persist a drift run (findings + count + `ranAt`) so `/admin/predictions` can render it from a
+ * fast single-row read instead of re-running the heavy live sweep on the page path. Called by the
+ * weekly cron and the admin recompute action.
+ */
+export async function writeRuleDriftSnapshot(prisma: PrismaClient, findings: DriftFinding[]): Promise<void> {
+  await prisma.ruleDriftSnapshot.create({
+    data: { driftCount: findings.length, findings: findings as unknown as Prisma.InputJsonValue },
+  });
 }


### PR DESCRIPTION
## What

A dedicated **`/admin/predictions`** dashboard surfacing Travel Mode prediction health — the in-app view of the prediction-quality system (ledger + rule-drift + seasonal rules) that previously only existed as DB rows and GitHub issues.

Three sections:
- **Forward-prediction ledger** — outcome inventory (PENDING/HIT/MISS/PRECONFIRMED/UNOBSERVED), a **confidence × days-out precision heatmap**, a **horizon-maturity timeline** (30/90/180-day ETAs — answers "when do we get real numbers"), and a snapshot-accumulation chart. Reads `PredictionSnapshot`.
- **Rule-drift findings** — the latest persisted drift run + a "Re-run now" admin action, with distinct **no-drift / never-run / error** states. Links to the GitHub `rule-drift` label.
- **Schedule-rule coverage** — HIGH/MEDIUM/LOW split, kennels with rules, seasonal kennels, dark kennels, rules by source.

## How it matures (why now)

The ledger cron is already accruing — local prod-copy shows **797 PENDING** snapshots, first 30-day scores ~**Jul 8**, 90-day ~Sept, 180-day ~Dec. The drift + coverage sections are useful on day one; the precision heatmap fills in as cohorts mature (it'll empirically test the retrospective "HIGH < MEDIUM calibration inversion"). The page renders a designed "accumulating — first scores ~`<date>`" state until then.

## Review-driven design (Codex pass on the plan)

- **Auth boundary:** read paths are plain async loaders in `data.ts` (NOT `"use server"` → not POST endpoints); the only server action (`recomputeRuleDrift`) is `requireAdmin()`-guarded, timeout-bounded, and returns an explicit error result (never a silent green).
- **No heavy sweep on render:** `detectRuleDrift` (unbounded reads + per-kennel projection) is *not* run on the page path. New `RuleDriftSnapshot` model persists each weekly cron run; the page reads the latest row. The admin "Re-run now" recomputes on demand.
- Pure scorecard logic extracted to `src/lib/travel/ledger-scorecard.ts` (shared by the CLI scorecard + dashboard) with unit tests.

## Verification

`tsc` + `eslint` clean · 16 tests (7 new scorecard + 9 rule-drift) · `next build` compiles · migration applies to local dev DB (table/pkey/index correct) · all three loaders validated at runtime against a prod-copy DB (coverage `groupBy`/`distinct`, drift JSON round-trip, ledger 797 PENDING). Visual render is covered by the Vercel preview (the page is Clerk-admin-gated, so it can't be previewed headlessly).

**Post-merge:** migration applies automatically on the Vercel build. No manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
