### PR TITLE
fix(sources): point LRH3 STATIC_SCHEDULE urls at lrhash.com/contact (#1553)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4362,15 +4362,17 @@ export const SOURCES = [
     // in feedback_sourceless_kennels memory. Description fields link to their FB
     // page so users can check the actual trail location day-of.
     //
-    // The two records below share the same Facebook page but are kept as
-    // separate seed rows by their distinct `name` values — the seed upsert
-    // identity is `(name, type)` per `prisma/schema.prisma:221` and
-    // `prisma/seed.ts:364`. The `#sunday` / `#wednesday` URL fragments are
-    // only for human readability; identical names with different URLs would
-    // collapse to a single row on seed.
+    // The `url` fields point at the kennel's own contact page (publicly readable,
+    // no login wall) rather than the Facebook page, so an audit / manual cross-
+    // check / future-Claude verification pass can actually load the source (#1553).
+    // The two records below are kept as separate seed rows by their distinct
+    // `name` values — the seed upsert identity is `(name, type)` per
+    // `prisma/schema.prisma:221` and `prisma/seed.ts:364`. The `#sunday` /
+    // `#wednesday` URL fragments are only for human readability; identical names
+    // with different URLs would collapse to a single row on seed.
     {
       name: "Little Rock H3 Static Schedule (Sunday)",
-      url: "https://www.facebook.com/littlerockhashhouseharriers#sunday",
+      url: "https://lrhash.com/contact#sunday",
       type: "STATIC_SCHEDULE" as const,
       trustLevel: 3,
       scrapeFreq: "weekly",
@@ -4387,7 +4389,7 @@ export const SOURCES = [
     },
     {
       name: "Little Rock H3 Static Schedule (Wednesday)",
-      url: "https://www.facebook.com/littlerockhashhouseharriers#wednesday",
+      url: "https://lrhash.com/contact#wednesday",
       type: "STATIC_SCHEDULE" as const,
       trustLevel: 3,
       scrapeFreq: "weekly",


### PR DESCRIPTION
## Summary
Deferred follow-up to #1553 (source-owning side of the LRH3 profile bundle). Both Little Rock H3 `STATIC_SCHEDULE` source rows had their `url` pointing at the kennel's Facebook page, which gates anonymous viewers behind a login wall — unusable for an automated audit, a manual hasher cross-check, or a future verification pass.

## Change
`prisma/seed-data/sources.ts` — swap both `url` fields to the kennel's own contact page (preserving the disambiguating fragments):

| Row | Before | After |
|---|---|---|
| Little Rock H3 Static Schedule (Sunday) | `facebook.com/littlerockhashhouseharriers#sunday` | `https://lrhash.com/contact#sunday` |
| Little Rock H3 Static Schedule (Wednesday) | `facebook.com/littlerockhashhouseharriers#wednesday` | `https://lrhash.com/contact#wednesday` |

Comment block updated to explain the rationale.

## Why it's safe
- These are `STATIC_SCHEDULE` rows, so `url` is **not fetched** — it's the audit/verification target only. No change to event generation.
- `https://lrhash.com/contact` verified publicly reachable (HTTP 200, no auth).
- `defaultDescription` strings still reference the FB page, since that is genuinely where day-of trail locations are posted — kept intentionally.

## Notes
- #1553 is already CLOSED (the kennel-profile contact field shipped in PR #2155); this is the deferred source-row portion, so no `Closes` keyword.
- Prod impact is metadata-only and lands on the next `npx prisma db seed` — low priority since the `url` isn't fetched. Happy to run the prod seed if you'd like the stored value updated sooner.

## Verification
`npx tsc --noEmit`, `npm run lint` (0 errors), `npm test` (307 files, 9074 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)