### PR TITLE
fix(admin): guard ungated analytics server actions

### DIFF
--- a/src/app/admin/analytics/actions.ts
+++ b/src/app/admin/analytics/actions.ts
@@ -1,6 +1,9 @@
-"use server";
-
+// NOT a "use server" module: these loaders are imported only by the gated
+// analytics server-component page. Keeping them as plain server-side functions
+// (rather than server actions) means they are never POST endpoints a logged-out
+// caller could hit. `requireAdmin()` is a belt-and-suspenders guard.
 import { Prisma } from "@/generated/prisma/client";
+import { requireAdmin } from "@/lib/admin/require-admin";
 import { prisma } from "@/lib/db";
 
 export type TimePeriod = "7d" | "30d" | "90d" | "all";
@@ -42,6 +45,7 @@ export interface CommunityHealthMetrics {
 export async function getCommunityHealthMetrics(
   period: TimePeriod = "30d",
 ): Promise<CommunityHealthMetrics> {
+  await requireAdmin();
   const since = periodStart(period);
   const today = new Date();
   today.setUTCHours(12, 0, 0, 0);
@@ -144,6 +148,7 @@ export interface UserEngagementMetrics {
 }
 
 export async function getUserEngagementMetrics(): Promise<UserEngagementMetrics> {
+  await requireAdmin();
   const now = new Date();
   const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
   const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -232,6 +237,7 @@ export interface OperationalHealthMetrics {
 }
 
 export async function getOperationalHealthMetrics(): Promise<OperationalHealthMetrics> {
+  await requireAdmin();
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
   const [sourceHealthByRegion, scrapeSuccessRates, staleSources, totalEnabledSources, totalHealthySources] =

--- a/src/app/admin/analytics/page.test.ts
+++ b/src/app/admin/analytics/page.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──
+
+vi.mock("@/lib/admin/require-admin", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+// Stub the client dashboard so importing the page doesn't pull in recharts.
+vi.mock("@/components/admin/AnalyticsDashboard", () => ({
+  AnalyticsDashboard: () => null,
+}));
+
+// Stub the data loaders so a successful render never touches prisma, and so we
+// can assert they don't run when the admin guard rejects.
+vi.mock("./actions", () => ({
+  getCommunityHealthMetrics: vi.fn().mockResolvedValue({}),
+  getUserEngagementMetrics: vi.fn().mockResolvedValue({}),
+  getOperationalHealthMetrics: vi.fn().mockResolvedValue({}),
+}));
+
+import { requireAdmin } from "@/lib/admin/require-admin";
+import AnalyticsPage from "./page";
+import {
+  getCommunityHealthMetrics,
+  getUserEngagementMetrics,
+  getOperationalHealthMetrics,
+} from "./actions";
+
+const mockRequireAdmin = vi.mocked(requireAdmin);
+
+describe("AnalyticsPage auth boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails closed and visibly when the admin guard rejects — does not swallow auth into empty data", async () => {
+    mockRequireAdmin.mockRejectedValueOnce(new Error("Unauthorized"));
+
+    await expect(AnalyticsPage()).rejects.toThrow("Unauthorized");
+
+    // The guard runs before Promise.allSettled, so loaders never execute and the
+    // rejection can't be laundered into EMPTY_* dashboard data.
+    expect(getCommunityHealthMetrics).not.toHaveBeenCalled();
+    expect(getUserEngagementMetrics).not.toHaveBeenCalled();
+    expect(getOperationalHealthMetrics).not.toHaveBeenCalled();
+  });
+
+  it("renders for an authorized admin", async () => {
+    mockRequireAdmin.mockResolvedValueOnce({ id: "admin_1" } as never);
+
+    await expect(AnalyticsPage()).resolves.toBeDefined();
+    expect(getCommunityHealthMetrics).toHaveBeenCalled();
+  });
+});

--- a/src/app/admin/analytics/page.test.ts
+++ b/src/app/admin/analytics/page.test.ts
@@ -20,6 +20,7 @@ vi.mock("./actions", () => ({
 }));
 
 import { requireAdmin } from "@/lib/admin/require-admin";
+import { mockAdminUser } from "@/test/factories";
 import AnalyticsPage from "./page";
 import {
   getCommunityHealthMetrics,
@@ -47,7 +48,7 @@ describe("AnalyticsPage auth boundary", () => {
   });
 
   it("renders for an authorized admin", async () => {
-    mockRequireAdmin.mockResolvedValueOnce({ id: "admin_1" } as never);
+    mockRequireAdmin.mockResolvedValueOnce(mockAdminUser);
 
     await expect(AnalyticsPage()).resolves.toBeDefined();
     expect(getCommunityHealthMetrics).toHaveBeenCalled();

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -6,6 +6,7 @@ import {
   type UserEngagementMetrics,
   type OperationalHealthMetrics,
 } from "./actions";
+import { requireAdmin } from "@/lib/admin/require-admin";
 import { AnalyticsDashboard } from "@/components/admin/AnalyticsDashboard";
 
 const EMPTY_COMMUNITY: CommunityHealthMetrics = {
@@ -36,6 +37,14 @@ const EMPTY_OPERATIONAL: OperationalHealthMetrics = {
 };
 
 export default async function AnalyticsPage() {
+  // Fail closed AND visibly on auth: the loaders below run through
+  // Promise.allSettled (which degrades query failures to EMPTY_* so one slow
+  // query can't blank the whole dashboard). Guarding here keeps an auth failure
+  // from being laundered into legitimate-looking zeros if the /admin layout gate
+  // is ever bypassed. The per-loader requireAdmin() calls remain as defense in
+  // depth against the loaders being re-exposed as endpoints.
+  await requireAdmin();
+
   const [communityResult, engagementResult, operationalResult] =
     await Promise.allSettled([
       getCommunityHealthMetrics("30d"),

--- a/src/lib/admin/require-admin.test.ts
+++ b/src/lib/admin/require-admin.test.ts
@@ -17,7 +17,7 @@ describe("requireAdmin", () => {
   });
 
   it("returns the admin user when the caller is an admin", async () => {
-    vi.mocked(getAdminUser).mockResolvedValue(mockAdminUser as never);
+    vi.mocked(getAdminUser).mockResolvedValue(mockAdminUser);
     await expect(requireAdmin()).resolves.toBe(mockAdminUser);
   });
 });

--- a/src/lib/admin/require-admin.test.ts
+++ b/src/lib/admin/require-admin.test.ts
@@ -1,0 +1,23 @@
+import { getAdminUser } from "@/lib/auth";
+import { mockAdminUser } from "@/test/factories";
+import { requireAdmin } from "./require-admin";
+
+vi.mock("@/lib/auth", () => ({
+  getAdminUser: vi.fn(),
+}));
+
+describe("requireAdmin", () => {
+  beforeEach(() => {
+    vi.mocked(getAdminUser).mockReset();
+  });
+
+  it("throws Unauthorized when the caller is not an admin", async () => {
+    vi.mocked(getAdminUser).mockResolvedValue(null);
+    await expect(requireAdmin()).rejects.toThrow("Unauthorized");
+  });
+
+  it("returns the admin user when the caller is an admin", async () => {
+    vi.mocked(getAdminUser).mockResolvedValue(mockAdminUser as never);
+    await expect(requireAdmin()).resolves.toBe(mockAdminUser);
+  });
+});

--- a/src/lib/admin/require-admin.ts
+++ b/src/lib/admin/require-admin.ts
@@ -1,0 +1,16 @@
+import type { User } from "@/generated/prisma/client";
+import { getAdminUser } from "@/lib/auth";
+
+/**
+ * Admin guard for server-only code paths (`getAdminUser` reads Clerk's
+ * server-side session, so this is never importable from a client component).
+ * Server actions are POST endpoints anyone can hit, so page-level `/admin`
+ * gating does NOT protect them — call this first in any exported action that
+ * returns or mutates non-public data. Throws "Unauthorized" when the caller is
+ * not an admin; returns the admin User.
+ */
+export async function requireAdmin(): Promise<User> {
+  const admin = await getAdminUser();
+  if (!admin) throw new Error("Unauthorized");
+  return admin;
+}

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -99,6 +99,7 @@ export const mockUser = {
   hashName: null,
   nerdName: "Test User",
   bio: null,
+  timeDisplayPref: "EVENT_LOCAL" as const,
   createdAt: new Date("2026-01-01"),
   updatedAt: new Date("2026-01-01"),
 };


### PR DESCRIPTION
## Problem

`"use server"` functions compile to **POST endpoints that any unauthenticated caller can invoke directly** — the `/admin` layout's `getAdminUser()` page-gate does **not** protect them. (Discovered during the /admin/predictions build, PR #2177; Codex flagged the analytics actions as the precedent *not* to follow.)

## Audit result

Audited every `"use server"` module under `src/app/admin/**`. The codebase is overwhelmingly correct — 67 guarded exported actions across ~24 files (`audit/actions.ts`, `sources/*`, `events/*`, `kennels/*`, `regions/*`, `alerts/*`, `research/*`, `discovery/*`, `requests/*`, `roster-groups/*`, geocode/backfill) each call an admin guard as their first statement.

**Exactly one offender:** `src/app/admin/analytics/actions.ts`. Its three exported actions — `getCommunityHealthMetrics`, `getUserEngagementMetrics`, `getOperationalHealthMetrics` — had **no** auth check yet returned non-public data: user counts, attendance-derived active-user counts, subscription distribution, misman kennel counts, and source/scrape operational health. A logged-out user could POST to these and exfiltrate it.

## Fix (two parts)

1. **Drop `"use server"`** from `analytics/actions.ts` → the three loaders are no longer POST endpoints at all. They're imported **only** by `analytics/page.tsx` (a gated server component) via `Promise.allSettled` with `EMPTY_*` fallbacks, so they never needed to be remotely-invokable actions. This follows the `predictions/data.ts` safe-loader pattern (PR #2177). The client `AnalyticsDashboard` imports only `import type {...}`, which is erased at compile time — unaffected.
2. **Add `requireAdmin()`** (`src/lib/admin/require-admin.ts`) and call it first in each action as defense-in-depth. Mirrors the throwing `requireAdmin()` precedent already in `audit/actions.ts`.

Existing already-working guards (audit's local `requireAdmin`, inline `getAdminUser` checks) are intentionally left untouched to keep the PR focused; the shared helper is available for future adoption.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, none in changed files)
- `npm test` — **9079 pass**, incl. new `src/lib/admin/require-admin.test.ts` (throws "Unauthorized" for non-admin; returns the user for admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)