### PR TITLE
fix(adapters): RIH3 markup leak + DSMH3 bilingual fields + Hollyweird title prefix

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -6022,6 +6022,15 @@ export const SOURCES = [
         pageHandle: "HollyweirdH6",
         timezone: "America/New_York",
         upcomingOnly: true,
+        // #2158: the Page prefixes every event name with its full kennel name
+        // and appends a redundant trailing run marker ("~ aka: H6#311" in the
+        // current form; bare "~ H6#308" / "~ H6 #308" in older captures). Strip
+        // both from the stored title — the run number is still parsed from the
+        // pre-strip name, so the trailing strip never costs the runNumber.
+        titleStripPatterns: [
+          String.raw`^Hollyweird Hash House Harriers,?\s*`,
+          String.raw`\s*~\s*(?:aka:\s*)?H6\b.*$`,
+        ],
       },
       kennelCodes: ["h6"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -6029,7 +6029,7 @@ export const SOURCES = [
         // pre-strip name, so the trailing strip never costs the runNumber.
         titleStripPatterns: [
           String.raw`^Hollyweird Hash House Harriers,?\s*`,
-          String.raw`\s*~\s*(?:aka:\s*)?H6\b.*$`,
+          String.raw`\s*~\s*(?:aka:\s*)?H6\s*#\s*\d+\b.*$`,
         ],
       },
       kennelCodes: ["h6"],

--- a/src/adapters/facebook-hosted-events/adapter.ts
+++ b/src/adapters/facebook-hosted-events/adapter.ts
@@ -126,6 +126,15 @@ export interface FacebookHostedEventsConfig {
   /** Fallback kennelTag for events matching no `kennelPatterns` entry.
    *  Defaults to `kennelTag`. No-op without `kennelPatterns`. */
   defaultKennelTag?: string;
+  /**
+   * Optional per-source title strips (#2158) for Pages whose FB event names
+   * carry a fixed kennel-name prefix / templated suffix that isn't part of the
+   * actual title (e.g. Hollyweird's `Hollyweird Hash House Harriers, … ~ aka:
+   * H6#311`). Same grammar GOOGLE_CALENDAR uses; each pattern is `.replace()`-d
+   * out of the stored title. Applied after run-number extraction, so an embedded
+   * `H6#311` still yields a runNumber. Omit for sources without the issue.
+   */
+  titleStripPatterns?: string[];
 }
 
 /**
@@ -165,6 +174,7 @@ export class FacebookHostedEventsAdapter implements SourceAdapter {
       // Optional routing — undefined when single-kennel, handled by the parser.
       kennelPatterns: config.kennelPatterns,
       defaultKennelTag: config.defaultKennelTag,
+      titleStripPatterns: config.titleStripPatterns,
     });
     const allEvents = parseResult.events;
     const filteredCounts = parseResult.filtered;

--- a/src/adapters/facebook-hosted-events/parser.test.ts
+++ b/src/adapters/facebook-hosted-events/parser.test.ts
@@ -556,6 +556,50 @@ describe("bagToRawEvent — runNumber extraction (#1319)", () => {
   });
 });
 
+describe("title strip patterns (#2158)", () => {
+  // Hollyweird's seed config strips its self-prefixed kennel name and the
+  // redundant trailing run marker.
+  const HOLLYWEIRD_STRIPS = [
+    String.raw`^Hollyweird Hash House Harriers,?\s*`,
+    String.raw`\s*~\s*(?:aka:\s*)?H6\b.*$`,
+  ];
+
+  function rawFromTitleWithStrips(title: string, titleStripPatterns?: string[]) {
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":${JSON.stringify(title)}},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    return parseFacebookHostedEvents(html, { kennelTag: "h6", titleStripPatterns })[0];
+  }
+
+  it("strips the kennel-name prefix and trailing `~ aka: H6#NNN` (issue example)", () => {
+    const raw = rawFromTitleWithStrips(
+      "Hollyweird Hash House Harriers, HapPy Hour 4 Starlight Musical w/ WaCondom ForNever ~ aka: H6#311",
+      HOLLYWEIRD_STRIPS,
+    );
+    expect(raw.title).toBe("HapPy Hour 4 Starlight Musical w/ WaCondom ForNever");
+    // Run number still parsed from the pre-strip title.
+    expect(raw.runNumber).toBe(311);
+  });
+
+  it("strips the older space-form prefix and bare `~ H6#NNN` marker", () => {
+    const raw = rawFromTitleWithStrips(
+      "Hollyweird Hash House Harriers HapPy Hour w/ Shane Duncan Band ~ H6#308",
+      HOLLYWEIRD_STRIPS,
+    );
+    expect(raw.title).toBe("HapPy Hour w/ Shane Duncan Band");
+    expect(raw.runNumber).toBe(308);
+  });
+
+  it("leaves titles untouched when no titleStripPatterns are configured (additive)", () => {
+    const name =
+      "Hollyweird Hash House Harriers HapPy Hour w/ Shane Duncan Band ~ H6#308";
+    const raw = rawFromTitleWithStrips(name);
+    expect(raw.title).toBe(name);
+    expect(raw.runNumber).toBe(308);
+  });
+});
+
 describe("extractFieldsFromFbDescription (#1319)", () => {
   const MAY_15_DESCRIPTION = [
     "Hollyweird Hash House Harriers HapPy Hour ~ Boston Johnny's May's Birthday Party ~ H6#307",

--- a/src/adapters/facebook-hosted-events/parser.test.ts
+++ b/src/adapters/facebook-hosted-events/parser.test.ts
@@ -560,7 +560,7 @@ describe("bagToRawEvent — runNumber extraction (#1319)", () => {
 // redundant trailing run marker.
 const HOLLYWEIRD_STRIPS = [
   String.raw`^Hollyweird Hash House Harriers,?\s*`,
-  String.raw`\s*~\s*(?:aka:\s*)?H6\b.*$`,
+  String.raw`\s*~\s*(?:aka:\s*)?H6\s*#\s*\d+\b.*$`,
 ];
 
 function rawFromTitleWithStrips(title: string, titleStripPatterns?: string[]) {
@@ -597,6 +597,38 @@ describe("title strip patterns (#2158)", () => {
     const raw = rawFromTitleWithStrips(name);
     expect(raw.title).toBe(name);
     expect(raw.runNumber).toBe(308);
+  });
+
+  it("runs the placeholder filter on the STRIPPED title so a prefixed 'Test' is dropped", () => {
+    // Without normalizing before the filter, the prefix hides the placeholder
+    // and "Test" would persist. The event has no run number / location, so the
+    // stripped "Test" must be rejected as a placeholder (empty result).
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Hollyweird Hash House Harriers, Test"},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    const events = parseFacebookHostedEvents(html, {
+      kennelTag: "h6",
+      titleStripPatterns: HOLLYWEIRD_STRIPS,
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("routes kennelPatterns on the ORIGINAL title while stripping the display title", () => {
+    // Co-host routing must see the raw FB name; the stored title is still
+    // stripped, and the run number is parsed from the pre-strip suffix.
+    const html = `<script type="application/json">{
+      "rich":{"__typename":"Event","id":"123456789012345","name":"Hollyweird Hash House Harriers, GyNO Joint Trail ~ aka: H6#320"},
+      "time":{"id":"123456789012345","start_timestamp":1778353200}
+    }</script>`;
+    const [event] = parseFacebookHostedEvents(html, {
+      kennelTag: "h6",
+      kennelPatterns: [[String.raw`\bGyNO\b`, ["h6", "gynoh3"]]],
+      titleStripPatterns: HOLLYWEIRD_STRIPS,
+    });
+    expect(event.kennelTags).toEqual(["h6", "gynoh3"]);
+    expect(event.title).toBe("GyNO Joint Trail");
+    expect(event.runNumber).toBe(320);
   });
 });
 

--- a/src/adapters/facebook-hosted-events/parser.test.ts
+++ b/src/adapters/facebook-hosted-events/parser.test.ts
@@ -556,22 +556,22 @@ describe("bagToRawEvent — runNumber extraction (#1319)", () => {
   });
 });
 
+// Hollyweird's seed config strips its self-prefixed kennel name and the
+// redundant trailing run marker.
+const HOLLYWEIRD_STRIPS = [
+  String.raw`^Hollyweird Hash House Harriers,?\s*`,
+  String.raw`\s*~\s*(?:aka:\s*)?H6\b.*$`,
+];
+
+function rawFromTitleWithStrips(title: string, titleStripPatterns?: string[]) {
+  const html = `<script type="application/json">{
+    "rich":{"__typename":"Event","id":"123456789012345","name":${JSON.stringify(title)}},
+    "time":{"id":"123456789012345","start_timestamp":1778353200}
+  }</script>`;
+  return parseFacebookHostedEvents(html, { kennelTag: "h6", titleStripPatterns })[0];
+}
+
 describe("title strip patterns (#2158)", () => {
-  // Hollyweird's seed config strips its self-prefixed kennel name and the
-  // redundant trailing run marker.
-  const HOLLYWEIRD_STRIPS = [
-    String.raw`^Hollyweird Hash House Harriers,?\s*`,
-    String.raw`\s*~\s*(?:aka:\s*)?H6\b.*$`,
-  ];
-
-  function rawFromTitleWithStrips(title: string, titleStripPatterns?: string[]) {
-    const html = `<script type="application/json">{
-      "rich":{"__typename":"Event","id":"123456789012345","name":${JSON.stringify(title)}},
-      "time":{"id":"123456789012345","start_timestamp":1778353200}
-    }</script>`;
-    return parseFacebookHostedEvents(html, { kennelTag: "h6", titleStripPatterns })[0];
-  }
-
   it("strips the kennel-name prefix and trailing `~ aka: H6#NNN` (issue example)", () => {
     const raw = rawFromTitleWithStrips(
       "Hollyweird Hash House Harriers, HapPy Hour 4 Starlight Musical w/ WaCondom ForNever ~ aka: H6#311",

--- a/src/adapters/facebook-hosted-events/parser.ts
+++ b/src/adapters/facebook-hosted-events/parser.ts
@@ -530,22 +530,34 @@ function projectBag(
   if (bag.rich.is_canceled === true) return { kind: "rejected", reason: "cancelled" };
   // Inner `.trim()` is needed before the regex so the anchored `\s*$` strip
   // sees a delimiter at the end; the regex itself absorbs surrounding spaces.
-  const title = bag.rich.name?.trim().replace(TITLE_TRAILING_DELIMITER_RE, "") || undefined;
-  if (!title) return { kind: "rejected", reason: "no-title" };
+  const rawTitle = bag.rich.name?.trim().replace(TITLE_TRAILING_DELIMITER_RE, "") || undefined;
+  if (!rawTitle) return { kind: "rejected", reason: "no-title" };
   const ms = bag.time.start_timestamp * 1000;
   const instant = new Date(ms);
   if (Number.isNaN(instant.getTime())) return { kind: "rejected", reason: "invalid-time" };
 
+  // Normalize the STORED/display title up front (#2158): strip the kennel-name
+  // prefix / templated suffix so the content-quality filters below run against
+  // the real title — otherwise a prefixed placeholder ("Hollyweird … , Test")
+  // would slip past `isPlaceholderTitle` and persist as "Test". Run-number
+  // extraction and kennel routing deliberately stay on the RAW FB name (the run
+  // marker lives in the stripped suffix; routing keys on the original). Fall back
+  // to the raw title if a pattern empties it — stripping only improves, never
+  // drops. No-op when the source sets no `titleStripPatterns`.
+  let stripped = rawTitle;
+  for (const re of titleStripRes) stripped = stripped.replace(re, "").trim();
+  const displayTitle = stripped || rawTitle;
+
   // Admin-notice filter (#1500): titles like "Moving to a new website" are
   // Page-admin announcements, not trails. Drop unconditionally — no field
   // combo can rehabilitate a notice into a real run.
-  if (isAdminNoticeTitle(title)) return { kind: "rejected", reason: "admin-notice" };
+  if (isAdminNoticeTitle(displayTitle)) return { kind: "rejected", reason: "admin-notice" };
 
   const location = bag.rich.event_place?.contextual_name?.trim() || undefined;
   const lat = bag.rich.event_place?.location?.latitude;
   const lng = bag.rich.event_place?.location?.longitude;
-  const parsedRunNumber = extractHashRunNumber(title);
-  const placeholderRun = parsedRunNumber === undefined && hasPlaceholderRunNumber(title);
+  const parsedRunNumber = extractHashRunNumber(rawTitle);
+  const placeholderRun = parsedRunNumber === undefined && hasPlaceholderRunNumber(rawTitle);
 
   // Placeholder-event filter (#1497): single-word titles like "Test" with
   // no run number AND no location AND no parseable run marker. Hares come
@@ -553,7 +565,7 @@ function projectBag(
   // we deliberately don't require their absence — a real test event would
   // not have hares either.
   if (
-    isPlaceholderTitle(title) &&
+    isPlaceholderTitle(displayTitle) &&
     parsedRunNumber === undefined &&
     !placeholderRun &&
     !location
@@ -564,19 +576,9 @@ function projectBag(
   const date = formatYmdInTimezone(instant, timezone);
   const startTime = formatTimeInZone(instant, timezone, "HH:mm");
 
-  // Strip the kennel-name prefix / templated suffix from the STORED title only
-  // (#2158), after run-number extraction so an embedded `H6#311` already gave us
-  // the runNumber. Kennel routing still keys on the original FB name. Fall back
-  // to the original title if a pattern strips it to nothing — stripping must
-  // only ever improve the title, never drop an otherwise-valid event. No-op
-  // when the source sets no `titleStripPatterns`.
-  let stripped = title;
-  for (const re of titleStripRes) stripped = stripped.replace(re, "").trim();
-  const displayTitle = stripped || title;
-
   const event: RawEventData = {
     date,
-    kennelTags: resolveKennelTags(title),
+    kennelTags: resolveKennelTags(rawTitle),
     title: displayTitle,
     startTime,
     sourceUrl: `https://www.facebook.com/events/${bag.id}/`,

--- a/src/adapters/facebook-hosted-events/parser.ts
+++ b/src/adapters/facebook-hosted-events/parser.ts
@@ -27,7 +27,7 @@
 import type { RawEventData } from "../types";
 import { formatYmdInTimezone, formatTimeInZone, isValidTimezone } from "@/lib/timezone";
 import { FB_EVENT_ID_RE, isAdminNoticeTitle, isPlaceholderTitle } from "./constants";
-import { extractHashRunNumber, hasPlaceholderRunNumber } from "../utils";
+import { extractHashRunNumber, hasPlaceholderRunNumber, compilePatterns } from "../utils";
 import { extractHares } from "../hare-extraction";
 import {
   compileKennelPatterns,
@@ -66,6 +66,14 @@ export interface ParseFacebookOptions {
    * No-op without `kennelPatterns`. Defaults to `kennelTag` when unset.
    */
   defaultKennelTag?: string;
+  /**
+   * Per-source title strips (#2158) — same grammar the GOOGLE_CALENDAR adapter
+   * uses. Each pattern is `.replace()`-d out of the stored display title (e.g.
+   * a kennel that prefixes every FB event name with its full name). Applied
+   * AFTER run-number extraction so an embedded `H6#311` still yields a
+   * runNumber. Omit for sources without the issue — titles are then unchanged.
+   */
+  titleStripPatterns?: string[];
 }
 
 /** Resolves a parsed event title to its kennelTag(s). */
@@ -164,6 +172,15 @@ export function parseFacebookHostedEventsWithStats(
       : null;
   const resolveKennelTags = buildKennelTagResolver(options.kennelTag, compiled, options.defaultKennelTag);
 
+  // Compile per-source title strips once (#2158). Empty when unconfigured, so
+  // non-configured sources keep byte-identical titles. Case-insensitive only
+  // (no `m`/`g`) — same flags the GOOGLE_CALENDAR adapter uses, so `^`/`$`
+  // anchor the whole title, not individual lines of a multi-line FB name.
+  const titleStripRes =
+    options.titleStripPatterns && options.titleStripPatterns.length > 0
+      ? compilePatterns(options.titleStripPatterns, "i")
+      : [];
+
   // Collect both halves of each event by id across all JSON islands.
   const byId = new Map<string, EventBag>();
   for (const json of extractJsonIslands(html)) {
@@ -175,7 +192,7 @@ export function parseFacebookHostedEventsWithStats(
   const events: RawEventData[] = [];
   const filtered = emptyFilteredCounts();
   for (const bag of byId.values()) {
-    const outcome = projectBag(bag, resolveKennelTags, tz);
+    const outcome = projectBag(bag, resolveKennelTags, tz, titleStripRes);
     if (outcome.kind === "event") {
       events.push(outcome.event);
     } else {
@@ -503,7 +520,12 @@ type BagOutcome =
 // adapter strip in `google-calendar/adapter.ts` (#756 / #1060).
 const TITLE_TRAILING_DELIMITER_RE = /\s*[-–—:]\s*$/; // NOSONAR — anchored end-of-string strip, single char class
 
-function projectBag(bag: EventBag, resolveKennelTags: KennelTagResolver, timezone: string): BagOutcome {
+function projectBag(
+  bag: EventBag,
+  resolveKennelTags: KennelTagResolver,
+  timezone: string,
+  titleStripRes: RegExp[] = [],
+): BagOutcome {
   if (!bag.time || !bag.rich) return { kind: "rejected", reason: "missing-half" };
   if (bag.rich.is_canceled === true) return { kind: "rejected", reason: "cancelled" };
   // Inner `.trim()` is needed before the regex so the anchored `\s*$` strip
@@ -542,10 +564,20 @@ function projectBag(bag: EventBag, resolveKennelTags: KennelTagResolver, timezon
   const date = formatYmdInTimezone(instant, timezone);
   const startTime = formatTimeInZone(instant, timezone, "HH:mm");
 
+  // Strip the kennel-name prefix / templated suffix from the STORED title only
+  // (#2158), after run-number extraction so an embedded `H6#311` already gave us
+  // the runNumber. Kennel routing still keys on the original FB name. Fall back
+  // to the original title if a pattern strips it to nothing — stripping must
+  // only ever improve the title, never drop an otherwise-valid event. No-op
+  // when the source sets no `titleStripPatterns`.
+  let stripped = title;
+  for (const re of titleStripRes) stripped = stripped.replace(re, "").trim();
+  const displayTitle = stripped || title;
+
   const event: RawEventData = {
     date,
     kennelTags: resolveKennelTags(title),
-    title,
+    title: displayTitle,
     startTime,
     sourceUrl: `https://www.facebook.com/events/${bag.id}/`,
     externalLinks: [

--- a/src/adapters/html-scraper/rih3.test.ts
+++ b/src/adapters/html-scraper/rih3.test.ts
@@ -119,6 +119,20 @@ Basket says, "Check out the Receding Hareline..."
 <p><a href="https://www.facebook.com/groups/120140164667510">See the RIH3 facebook Page for updates</a></p>
 `;
 
+// #2141: the source hand-codes anchor markup ENTITY-ENCODED in the Directions
+// cell. cheerio decodes `&lt;a&gt;` into literal-text tags (not DOM elements),
+// so they survive `.text()` and dodge the real-anchor song-link removal. Mirrors
+// the two documented malformations: a doubled-quote `Songs/` link not wrapped in
+// `<p>` (#2103) and a mid-text `</a href>` closing tag (#2104).
+const DIRECTION_ENCODED_MARKUP = `
+<h2><strong>Encoded Markup Hash</strong></h2>
+<strong>
+Trail starts at the dirt lot singing Just Pat's tune&lt;/a href&gt; See the RIH3 facebook Page for updates.
+<br/><br/>
+&lt;a href="Songs/Favorites/irianjaya.txt"" target="new"&gt;His song of the Week: Irian Jaya
+</strong>
+`;
+
 // --- Tests ---
 
 describe("extractHares", () => {
@@ -460,6 +474,26 @@ describe("parseHarelineRow", () => {
 
     expect(result?.description).not.toContain("Santa Claus");
     expect(result?.description).not.toContain("Song of the Week");
+  });
+
+  it("strips entity-encoded anchor markup from description (#2141)", () => {
+    const cells = ["Mon June 15", "6:30 PM", "2103"];
+    const result = parseHarelineRow(
+      cells,
+      HARE_SINGLE,
+      DIRECTION_ENCODED_MARKUP,
+      SOURCE_URL,
+    );
+
+    // No raw tags / attributes leak through.
+    expect(result?.description).not.toContain("<");
+    expect(result?.description).not.toContain(">");
+    expect(result?.description).not.toContain("href");
+    expect(result?.description).not.toContain("/a ");
+    // Visible link text is preserved (issue: "keep visible link text, drop the tag").
+    expect(result?.description).toContain("singing Just Pat's tune");
+    expect(result?.description).toContain("See the RIH3 facebook Page for updates");
+    expect(result?.description).toContain("His song of the Week: Irian Jaya");
   });
 
   it("strips leading comma from description (Bug #3)", () => {

--- a/src/adapters/html-scraper/rih3.ts
+++ b/src/adapters/html-scraper/rih3.ts
@@ -366,9 +366,17 @@ export function parseHarelineRow(
     const text = $a.text().trim();
     $a.replaceWith(`${text} (${href})`);
   });
+  // The source hand-codes anchor markup ENTITY-ENCODED in the Directions cell
+  // (`&lt;a href="Songs/…"&gt;…&lt;/a href&gt;`). `cheerio.load()` decoded those
+  // entities into plain text nodes, so the literal tags survive `.text()` and the
+  // song-link removal above can't target them (#2141). A second pass through the
+  // shared `stripHtmlTags()` helper re-parses the now-literal `<a>`/`</a href>`
+  // fragments as real tags and drops them, keeping the visible link text.
   const description =
-    descRoot.text().replace(/\s+/g, " ").trim().replace(/^[,\s]+/, "") ||
-    undefined;
+    stripHtmlTags(descRoot.text())
+      .replace(/\s+/g, " ")
+      .trim()
+      .replace(/^[,\s]+/, "") || undefined;
 
   return {
     date,

--- a/src/adapters/html-scraper/victoria-h3.test.ts
+++ b/src/adapters/html-scraper/victoria-h3.test.ts
@@ -22,7 +22,11 @@ ${p("Hare: Goes Down Well")}
 ${p("Cost: $10 (includes two beverages, first timers free)")}
 ${p("On-afters: Little Thai Place Royal Oak")}
 ${p("Dark Side of the Moon Run #388")}
-${p("Friday June 12th at 7 pm")}
+${p("Course Dark Side of the Moon n° 388")}
+${p("Friday June 12th at 7 pm/Vendredi 12 juin à 19h")}
+${p("Location/Emplacement: Songhees Point Park - 45 Songhees Road off/hors de Tyee Road/Esquimalt Road")}
+${p("Hare/Lièvre & Host/Hôte: Mustapha & Turkish Delight")}
+${p("Cost/Prix: $7.00 +$ donation for dinner")}
 ${p("Next page")}
 ${p("VH3 #930")}
 ${p("Saturday, June 20, 2:30 pm Hares needed.")}
@@ -132,6 +136,16 @@ describe("VictoriaH3Adapter parser", () => {
     });
   });
 
+  it("extracts location + hares + cost from DSMH3 bilingual slash-labels (#2156)", () => {
+    const e = eventFor("dsmh3", 388);
+    expect(e?.location).toContain("Songhees Point Park");
+    expect(e?.hares).toBe("Mustapha, Turkish Delight");
+    expect(e?.cost).toBe("$7.00 +$ donation for dinner");
+    // Bilingual date line still parses (English half) → unchanged start time.
+    expect(e?.startTime).toBe("19:00");
+    expect(e?.date).toBe("2026-06-12");
+  });
+
   it("titles a bare run from its run number and flags placeholder hares as null (#2013)", () => {
     const e = eventFor("vh3", 930);
     expect(e?.title).toBe("Run #930");
@@ -140,7 +154,7 @@ describe("VictoriaH3Adapter parser", () => {
 
   it.each([
     { label: "dsmh3 schedule-only run → bare Run #", tag: "dsmh3", run: 383, title: "Run #383" },
-    { label: "dsmh3 schedule-only run → bare Run #", tag: "dsmh3", run: 388, title: "Run #388" },
+    { label: "dsmh3 schedule-only run → bare Run #", tag: "dsmh3", run: 387, title: "Run #387" },
   ])("emits a source-faithful title for $label (#2013)", ({ tag, run, title }) => {
     expect(eventFor(tag, run)?.title).toBe(title);
   });

--- a/src/adapters/html-scraper/victoria-h3.ts
+++ b/src/adapters/html-scraper/victoria-h3.ts
@@ -6,6 +6,7 @@ import {
   chronoParseDate,
   formatAmPmTime,
   normalizeHaresField,
+  cleanLocationName,
   applyDateWindow,
   buildRunHareTitle,
 } from "../utils";
@@ -106,13 +107,41 @@ const TBA_RE = /\b(?:TBA|TBD)\b/i;
 // just the "Hash #NNN " prefix and find the "(" via indexOf to avoid a
 // negated-char-class quantifier that trips Sonar S5852.
 const WRITEUP_HEAD_RE = /^Hash\s*#\s*(\d+)\s+/i;
-const WHERE_LABEL_RE = /^where\s*:/i;
-const HARE_LABEL_RE = /^hares?\s*:/i;
-const COST_LABEL_RE = /^(?:cost|hash cash)\s*:/i;
-const NOTE_LABEL_RE = /^(?:on-?afters?|note)\s*:/i;
 const SUBTITLE_RE = /^\(.*\)$/;
 const SECTION_BREAK_RE = /^(?:next page|back to)/i;
-const LABEL_VALUE_RE = /^[^:]*:\s*/;
+
+// Card-body fields are detected by their `Label: value` prefix. DSMH3 publishes
+// bilingual slash-labels (`Location/Emplacement:`, `Hare/Lièvre & Host/Hôte:`,
+// `Cost/Prix:`) the old English-only regexes never matched (#2156). We split on
+// the first colon and keyword-match the lowercased label via `startsWith` — no
+// complex bilingual alternation regex (Sonar S5852/S5843 safe), and a value like
+// "Thursday … 2:30 pm" matches no field keyword so it falls through to the date
+// parser, exactly as before.
+function isWhereLabel(label: string): boolean {
+  return (
+    label === "where" ||
+    label.startsWith("location") ||
+    label.startsWith("emplacement")
+  );
+}
+function isHareLabel(label: string): boolean {
+  return label.startsWith("hare") || label.startsWith("lièvre");
+}
+function isCostLabel(label: string): boolean {
+  return (
+    label.startsWith("cost") ||
+    label === "hash cash" ||
+    label.startsWith("prix") ||
+    label.startsWith("coût")
+  );
+}
+function isNoteLabel(label: string): boolean {
+  return (
+    label.startsWith("on-after") ||
+    label.startsWith("onafter") ||
+    label.startsWith("note")
+  );
+}
 
 const pad = (n: number) => String(n).padStart(2, "0");
 
@@ -279,15 +308,18 @@ function splitVenue(value: string): { location: string; street?: string } {
   return { location: value };
 }
 
-/** Apply a "Where:" value → location + street + optional maps URL. */
+/** Apply a "Where:" / "Location/Emplacement:" value → location + street + maps URL. */
 function applyWhereValue(
   card: CardData,
   value: string,
   venueUrlMap: Map<string, string>,
 ): void {
-  if (!value || TBA_RE.test(value)) return;
+  if (!value) return;
   const { location, street } = splitVenue(value);
-  card.location = location;
+  // Drop TBA/emoji/URL noise uniformly (also covers the old `TBA_RE` guard).
+  const cleaned = cleanLocationName(location);
+  if (!cleaned) return;
+  card.location = cleaned;
   card.locationStreet = street;
   const url = venueUrlMap.get(value);
   if (url) card.locationUrl = url;
@@ -328,17 +360,22 @@ function applyCardLine(
   line: string,
   venueUrlMap: Map<string, string>,
 ): void {
-  const value = () => line.replace(LABEL_VALUE_RE, "").trim();
-  if (WHERE_LABEL_RE.test(line)) {
-    applyWhereValue(card, value(), venueUrlMap);
-  } else if (HARE_LABEL_RE.test(line)) {
-    applyHareValue(card, value());
-  } else if (COST_LABEL_RE.test(line)) {
-    const cost = value();
-    if (cost) card.cost = cost;
-  } else if (NOTE_LABEL_RE.test(line)) {
-    const note = value();
-    if (note && !TBA_RE.test(note)) descParts.push(line);
+  // Split on the first colon → label + value. A label that matches a known
+  // field keyword routes the value; anything else (incl. label-less date lines
+  // whose only colon is in a time like "2:30 pm") falls through to the date/
+  // subtitle handling below.
+  const colonIdx = line.indexOf(":");
+  const label = colonIdx >= 0 ? line.slice(0, colonIdx).trim().toLowerCase() : "";
+  const value = colonIdx >= 0 ? line.slice(colonIdx + 1).trim() : "";
+
+  if (label && isWhereLabel(label)) {
+    applyWhereValue(card, value, venueUrlMap);
+  } else if (label && isHareLabel(label)) {
+    applyHareValue(card, value);
+  } else if (label && isCostLabel(label)) {
+    if (value) card.cost = value;
+  } else if (label && isNoteLabel(label)) {
+    if (value && !TBA_RE.test(value)) descParts.push(line);
   } else if (SUBTITLE_RE.test(line)) {
     descParts.push(line);
   } else {

--- a/src/adapters/html-scraper/victoria-h3.ts
+++ b/src/adapters/html-scraper/victoria-h3.ts
@@ -120,7 +120,7 @@ const SECTION_BREAK_RE = /^(?:next page|back to)/i;
 // single non-keyword token, so it falls through to the date parser as before.
 function getLabelTokens(label: string): string[] {
   return label
-    .replace(/\u00a0/g, " ")
+    .replaceAll("\u00a0", " ")
     .toLowerCase()
     .split(/[/&]/)
     .map((t) => t.trim());

--- a/src/adapters/html-scraper/victoria-h3.ts
+++ b/src/adapters/html-scraper/victoria-h3.ts
@@ -112,34 +112,45 @@ const SECTION_BREAK_RE = /^(?:next page|back to)/i;
 
 // Card-body fields are detected by their `Label: value` prefix. DSMH3 publishes
 // bilingual slash-labels (`Location/Emplacement:`, `Hare/Lièvre & Host/Hôte:`,
-// `Cost/Prix:`) the old English-only regexes never matched (#2156). We split on
-// the first colon and keyword-match the lowercased label via `startsWith` — no
-// complex bilingual alternation regex (Sonar S5852/S5843 safe), and a value like
-// "Thursday … 2:30 pm" matches no field keyword so it falls through to the date
-// parser, exactly as before.
+// `Cost/Prix:`) the old English-only regexes never matched (#2156). Rather than a
+// complex bilingual alternation regex (Sonar S5852/S5843), we tokenize the label
+// on `/` and `&` and keyword-match each token via `startsWith`. Tokenizing makes
+// the match order-independent (`Emplacement/Location` works too) and `&nbsp;`-safe
+// (HTML editors emit ` `). A value like "Thursday … 2:30 pm" tokenizes to a
+// single non-keyword token, so it falls through to the date parser as before.
+function getLabelTokens(label: string): string[] {
+  return label
+    .replace(/\u00a0/g, " ")
+    .toLowerCase()
+    .split(/[/&]/)
+    .map((t) => t.trim());
+}
 function isWhereLabel(label: string): boolean {
-  return (
-    label === "where" ||
-    label.startsWith("location") ||
-    label.startsWith("emplacement")
+  return getLabelTokens(label).some(
+    (t) => t === "where" || t.startsWith("location") || t.startsWith("emplacement"),
   );
 }
 function isHareLabel(label: string): boolean {
-  return label.startsWith("hare") || label.startsWith("lièvre");
+  return getLabelTokens(label).some(
+    (t) =>
+      t.startsWith("hare") ||
+      t.startsWith("lièvre") ||
+      t.startsWith("host") ||
+      t.startsWith("hôte"),
+  );
 }
 function isCostLabel(label: string): boolean {
-  return (
-    label.startsWith("cost") ||
-    label === "hash cash" ||
-    label.startsWith("prix") ||
-    label.startsWith("coût")
+  return getLabelTokens(label).some(
+    (t) =>
+      t.startsWith("cost") ||
+      t === "hash cash" ||
+      t.startsWith("prix") ||
+      t.startsWith("coût"),
   );
 }
 function isNoteLabel(label: string): boolean {
-  return (
-    label.startsWith("on-after") ||
-    label.startsWith("onafter") ||
-    label.startsWith("note")
+  return getLabelTokens(label).some(
+    (t) => t.startsWith("on-after") || t.startsWith("onafter") || t.startsWith("note"),
   );
 }
 
@@ -364,17 +375,20 @@ function applyCardLine(
   // field keyword routes the value; anything else (incl. label-less date lines
   // whose only colon is in a time like "2:30 pm") falls through to the date/
   // subtitle handling below.
+  // Empty label (no colon, or only a time colon) matches no keyword helper, so
+  // the chain falls through to the date/subtitle handling — no `label &&` guard
+  // needed (keeps cognitive complexity under the Sonar S3776 threshold).
   const colonIdx = line.indexOf(":");
-  const label = colonIdx >= 0 ? line.slice(0, colonIdx).trim().toLowerCase() : "";
+  const label = colonIdx >= 0 ? line.slice(0, colonIdx).trim() : "";
   const value = colonIdx >= 0 ? line.slice(colonIdx + 1).trim() : "";
 
-  if (label && isWhereLabel(label)) {
+  if (isWhereLabel(label)) {
     applyWhereValue(card, value, venueUrlMap);
-  } else if (label && isHareLabel(label)) {
+  } else if (isHareLabel(label)) {
     applyHareValue(card, value);
-  } else if (label && isCostLabel(label)) {
+  } else if (isCostLabel(label)) {
     if (value) card.cost = value;
-  } else if (label && isNoteLabel(label)) {
+  } else if (isNoteLabel(label)) {
     if (value && !TBA_RE.test(value)) descParts.push(line);
   } else if (SUBTITLE_RE.test(line)) {
     descParts.push(line);


### PR DESCRIPTION
Quick Win bundle — three independent HTML/FB parse-quality fixes, each in a distinct adapter. All additive, no schema changes, all live-verified.

## RIH3 markup leak — [#2141](https://github.com/johnrclem/hashtracks-web/issues/2141)
The source hand-codes anchor markup **entity-encoded** in the Directions cell (`&lt;a href="Songs/…"&gt;…&lt;/a href&gt;`). `cheerio.load()` decodes those entities into plain text nodes, so the literal tags survive `.text()` and the real-anchor song-link removal can't target them. Fix: route the description text through the shared `stripHtmlTags()` helper — a second cheerio pass that re-parses the now-literal `<a>`/`</a href>` fragments as tags and drops them, keeping visible link text.

## DSMH3 location/hares — [#2156](https://github.com/johnrclem/hashtracks-web/issues/2156)
The Victoria Gamma card parser only matched English `Where:`/`Hare:`/`Cost:` labels, so DSMH3's bilingual slash-labels (`Location/Emplacement:`, `Hare/Lièvre & Host/Hôte:`, `Cost/Prix:`) yielded `null` location/hares. Fix: replace the English-only regexes with a first-colon split + keyword `startsWith` matcher (Sonar-safe, handles both languages) and clean the venue via `cleanLocationName()`.

## Hollyweird title prefix — [#2158](https://github.com/johnrclem/hashtracks-web/issues/2158)
The FB Page prefixes every event name with its full kennel name and appends a redundant `~ aka: H6#NNN` run marker (`Hollyweird Hash House Harriers, <title> ~ aka: H6#311`). Fix: add config-driven `titleStripPatterns` to the `FACEBOOK_HOSTED_EVENTS` adapter (mirroring the `GOOGLE_CALENDAR` pattern), applied to the stored title **after** run-number extraction so the runNumber still parses. Additive — only the Hollyweird source sets it; every other FB kennel's titles are byte-identical.

## Verification
- **Live**: rih3.com/hareline.html → 0 markup leaks; vh3.ca → DSMH3 #388 now has `location="Songhees Point Park…"` + `hares="Mustapha, Turkish Delight"`; HollyweirdH6 FB → all 8 upcoming events de-prefixed, runNumbers preserved.
- `npm run lint` (0 errors), `npx tsc --noEmit` (clean for changed files), `npm test` (9118 passing).
- `/code-review high` surfaced 3 findings (whitespace regression, empty-title drop, regex-flag mismatch) — all fixed. `/simplify` reported clean.

Closes #2141
Closes #2156
Closes #2158

🤖 Generated with [Claude Code](https://claude.com/claude-code)