### PR TITLE
fix(adapters): CRH3 body date + Savannah run number (date-correctness)

### DIFF
--- a/src/adapters/html-scraper/crh3.test.ts
+++ b/src/adapters/html-scraper/crh3.test.ts
@@ -113,6 +113,32 @@ A to A flat trail - no hazards.
     expect(result.date).toBe("2026-03-28");
   });
 
+  // Real body from CRH3 #222 (live-verified 2026-06-14). The "🗓 Date -" line
+  // carries a "(next Saturday)" aside; passing the whole body to chrono made it
+  // resolve that relative phrase to the publish-week Saturday (Jun 13) instead
+  // of the literal Jun 20 — the #2161 bug.
+  const body222 = `🏃‍♂️Next Run  #222🏃‍♀️
+🗓 Date - Saturday 20 June 26 (next Saturday)
+▶️Hare: Get a Grip / Where's the paper
+📍Starting Location -Happy City Golf
+🕞EARLY TIME - 3 for 3:30 pm start.
+💲Price - All attendees 250 Baht.`;
+
+  it("parses the labelled '🗓 Date -' line, ignoring the '(next Saturday)' aside (#2161)", () => {
+    // Publish date is Jun 13 (a Saturday). The whole-body parse resolved
+    // "next Saturday" to Jun 13; isolating the date line yields the real Jun 20.
+    const result = parseCrh3Body(body222, "2026-06-13T18:00:00+07:00");
+    expect(result.date).toBe("2026-06-20");
+  });
+
+  it("infers the year on a year-less labelled Date line via forwardDate (#2161)", () => {
+    const body = `🏃‍♂️Next Run #223🏃‍♀️
+🗓 Date - Saturday 20 June (next Saturday)
+▶️Hare: Test`;
+    const result = parseCrh3Body(body, "2026-06-13T18:00:00+07:00");
+    expect(result.date).toBe("2026-06-20");
+  });
+
   it("returns undefined for freeform text without labels", () => {
     const body = "<p>Come join us for a great hash!</p>";
     const result = parseCrh3Body(body, "2025-02-01T00:00:00");
@@ -180,6 +206,27 @@ Saturday 28th Mar 26 (This coming Saturday)
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.event.date).toBe("2026-03-28");
+    }
+  });
+
+  it("uses the body's '🗓 Date -' line as the event date, not the publish date (#2161)", () => {
+    // Stored Jun 13 (publish-week Saturday) before the fix; body says Jun 20.
+    const result = parseCrh3Post({
+      title: "CRH3 #222 Saturday 20 June",
+      content: `🏃‍♂️Next Run  #222🏃‍♀️
+🗓 Date - Saturday 20 June 26 (next Saturday)
+▶️Hare: Get a Grip / Where's the paper
+📍Starting Location -Happy City Golf
+🕞EARLY TIME - 3 for 3:30 pm start.
+💲Price - All attendees 250 Baht.`,
+      url: "https://chiangraihhh.blogspot.com/2026/06/crh3-222-saturday-20-june.html",
+      published: "2026-06-13T18:00:00+07:00",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.event.date).toBe("2026-06-20");
+      expect(result.event.runNumber).toBe(222);
+      expect(result.event.startTime).toBe("15:30");
     }
   });
 

--- a/src/adapters/html-scraper/crh3.ts
+++ b/src/adapters/html-scraper/crh3.ts
@@ -129,12 +129,27 @@ export function parseCrh3Body(bodyHtml: string, publishDateIso: string): {
   const earlyLine = grab(String.raw`EARLY\s*TIME|Start(?:\s*Time)?|Time`);
   const startTime = parseStartTime(earlyLine);
 
-  // Strip URLs before chrono — Google Maps short-link base64 fragments
-  // contain digit sequences that chrono mis-parses as dates (verified
-  // live: #216 had `g_ep=EgoyMDI1MTExMi4w` decode to "20251112" and
-  // chrono picked Nov 16 instead of the title's Nov 22).
+  // Isolate the run-date line before chrono. The body's date sits on either a
+  // labelled "🗓 Date -" line (#2161) or a bare weekday-prefixed line
+  // ("Saturday 28th Mar 26", #220). Passing the WHOLE body to chrono makes it
+  // latch onto the "(next Saturday)" relative aside, which resolves to the
+  // publish-week Saturday — #2161 stored Jun 13 instead of the body's Jun 20.
+  // Strip the parenthetical aside for the same reason, then parse just that
+  // line. Fall back to the legacy whole-text parse only when no date line is
+  // found, so freeform posts still parse. URLs are stripped in the fallback —
+  // Google Maps short-link base64 fragments contain digit sequences chrono
+  // mis-parses as dates (verified live: #216 `g_ep=EgoyMDI1MTExMi4w` decoded
+  // to "20251112" and chrono picked Nov 16 instead of the title's Nov 22).
   const refDate = parsePublishDate(publishDateIso);
-  const date = chronoParseDate(stripUrls(text), "en-GB", refDate, { forwardDate: true }) ?? undefined;
+  const dateLine = grab("Date") ?? findWeekdayDateLine(text);
+  const cleanedDateLine = dateLine?.replaceAll(/\([^)]*\)/g, " ").trim();
+  const fromDateLine = cleanedDateLine
+    ? chronoParseDate(cleanedDateLine, "en-GB", refDate, { forwardDate: true })
+    : null;
+  const date =
+    fromDateLine ??
+    chronoParseDate(stripUrls(text), "en-GB", refDate, { forwardDate: true }) ??
+    undefined;
 
   const description = extractDescription(text);
 
@@ -196,6 +211,23 @@ function extractDescription(text: string): string | undefined {
   if (desc.length === 0) return undefined;
   const joined = desc.join(" ");
   return joined.length > 240 ? `${joined.slice(0, 239)}…` : joined;
+}
+
+/** A line beginning with a weekday name (full or abbreviated). CRH3 bodies
+ * put the run date on such a line ("Saturday 28th Mar 26"). */
+const WEEKDAY_LINE_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[a-z]*\b/i;
+
+/**
+ * Find the first body line that begins with a weekday name and also contains a
+ * digit — CRH3's bare run-date line ("Saturday 28th Mar 26"), used when there
+ * is no labelled "Date -" line (#220). Returns undefined when none matches.
+ */
+function findWeekdayDateLine(text: string): string | undefined {
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (WEEKDAY_LINE_RE.test(line) && /\d/.test(line)) return line;
+  }
+  return undefined;
 }
 
 /** A minimal Blogger post shape for parsePost. */

--- a/src/adapters/html-scraper/crh3.ts
+++ b/src/adapters/html-scraper/crh3.ts
@@ -142,7 +142,10 @@ export function parseCrh3Body(bodyHtml: string, publishDateIso: string): {
   // to "20251112" and chrono picked Nov 16 instead of the title's Nov 22).
   const refDate = parsePublishDate(publishDateIso);
   const dateLine = grab("Date") ?? findWeekdayDateLine(text);
-  const cleanedDateLine = dateLine?.replaceAll(/\([^)]*\)/g, " ").trim();
+  // Drop the trailing parenthetical aside ("(next Saturday)") — date tokens
+  // never contain "(", so truncating at the first "(" is safe and avoids a
+  // backtracking-prone regex (Sonar S5852).
+  const cleanedDateLine = dateLine?.split("(")[0].trim();
   const fromDateLine = cleanedDateLine
     ? chronoParseDate(cleanedDateLine, "en-GB", refDate, { forwardDate: true })
     : null;
@@ -213,19 +216,26 @@ function extractDescription(text: string): string | undefined {
   return joined.length > 240 ? `${joined.slice(0, 239)}…` : joined;
 }
 
-/** A line beginning with a weekday name (full or abbreviated). CRH3 bodies
- * put the run date on such a line ("Saturday 28th Mar 26"). */
-const WEEKDAY_LINE_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[a-z]*\b/i;
+/** Lowercased weekday names + 3-letter abbreviations. CRH3 bodies put the run
+ * date on a line whose first word is one of these ("Saturday 28th Mar 26"). */
+const WEEKDAYS = new Set([
+  "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+  "mon", "tue", "wed", "thu", "fri", "sat", "sun",
+]);
 
 /**
- * Find the first body line that begins with a weekday name and also contains a
- * digit — CRH3's bare run-date line ("Saturday 28th Mar 26"), used when there
- * is no labelled "Date -" line (#220). Returns undefined when none matches.
+ * Find the first body line whose first word is a weekday name and which also
+ * contains a digit — CRH3's bare run-date line ("Saturday 28th Mar 26"), used
+ * when there is no labelled "Date -" line (#220). Matching the whole first word
+ * against a Set (rather than a prefix regex) avoids false hits on words that
+ * merely start with a weekday prefix ("Mongrel", "Sunscreen") and keeps the
+ * scan ReDoS-free. Returns undefined when none matches.
  */
 function findWeekdayDateLine(text: string): string | undefined {
   for (const raw of text.split("\n")) {
     const line = raw.trim();
-    if (WEEKDAY_LINE_RE.test(line) && /\d/.test(line)) return line;
+    const firstWord = /^[A-Za-z]+/.exec(line)?.[0]?.toLowerCase();
+    if (firstWord && WEEKDAYS.has(firstWord) && /\d/.test(line)) return line;
   }
   return undefined;
 }

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle, detectBoilerplateBlocks, stripBoilerplateBlocks } from "./adapter";
+import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle, detectBoilerplateBlocks, stripBoilerplateBlocks, extractRunNumberFromMeetupDescription } from "./adapter";
 import { normalizeDescriptionKey } from "../utils";
 import type { Source } from "@/generated/prisma/client";
 
@@ -1951,6 +1951,85 @@ describe("buildRawEventFromApollo — runNumberPrefix (#1975 Paris/Sans Clue 'R*
     // bare "R*n 1136" form yields nothing — exactly what other Meetup kennels see.
     const ev = { __typename: "Event", id: "norm", title: "Paris H3 R*n 1136 | TBD", dateTime: "2026-06-06T14:00:00+02:00" };
     const event = buildRawEventFromApollo(ev, emptyState, "paris-h3", undefined, OPT_IN);
+    expect(event.runNumber).toBeUndefined();
+  });
+});
+
+// ── runNumber from description (#2167 Savannah H3) ──
+
+describe("extractRunNumberFromMeetupDescription (#2167 Savannah)", () => {
+  it.each([
+    ["Savannah H3 trail # 1338", 1338],
+    ["Savannah H3 Trail #: 1334", 1334],
+    ["What: Trail #1335", 1335],
+    ["Savannah H3 Trail #1333", 1333],
+  ])("extracts the run number from a 'Trail #N' description line: %j", (desc, expected) => {
+    expect(extractRunNumberFromMeetupDescription(desc)).toBe(expected);
+  });
+
+  it("tolerates Markdown bold around the trail line (Charlotte '**Trail # 1244**')", () => {
+    expect(extractRunNumberFromMeetupDescription("**Trail # 1244 - There's a Latta Animals Trail**")).toBe(1244);
+  });
+
+  it("finds the trail line inside a multi-line boilerplate description", () => {
+    const desc = "Savannah H3 trail # 1338\n\n**Structure**\n\nThis event will be a run/walk...";
+    expect(extractRunNumberFromMeetupDescription(desc)).toBe(1338);
+  });
+
+  it("returns undefined when no line pairs 'trail' with a number (boilerplate-only)", () => {
+    // Montreal's standing template mentions "trail" many times but carries no
+    // per-run number — must NOT promote a bogus value.
+    const desc = "Note that if a trail has been set, the hash WILL run it!\n\nOur runs usually have a split trail for walkers.";
+    expect(extractRunNumberFromMeetupDescription(desc)).toBeUndefined();
+  });
+
+  it("returns undefined for a stray '#3' not sharing a line with 'trail'", () => {
+    expect(extractRunNumberFromMeetupDescription("Meet at gate #3.\nBring water.")).toBeUndefined();
+  });
+
+  it.each([
+    // "trail" must be directly anchored to "#N" — substring/adjacency prose
+    // must NOT promote a number (Codex adversarial review).
+    "Meet at Trailhead gate #3",
+    "choose trail option #2",
+    "follow the trail, then find marker #5",
+  ])("returns undefined for non-run trail prose: %j", (desc) => {
+    expect(extractRunNumberFromMeetupDescription(desc)).toBeUndefined();
+  });
+
+  it("returns undefined for empty/undefined input", () => {
+    expect(extractRunNumberFromMeetupDescription(undefined)).toBeUndefined();
+    expect(extractRunNumberFromMeetupDescription("")).toBeUndefined();
+  });
+});
+
+describe("buildRawEventFromApollo — runNumber from description (#2167 Savannah)", () => {
+  const emptyState = {} as Record<string, Record<string, unknown>>;
+
+  it("extracts the run number from the description even with a generic title and extraction off", () => {
+    // Savannah's titles are the generic "Saturday Trail!"; the real number
+    // lives in the body. Default-on description extraction (trail-anchored)
+    // backfills it without the per-source opt-in title flag.
+    const ev = {
+      __typename: "Event",
+      id: "savh3",
+      title: "Saturday Trail!",
+      description: "Savannah H3 trail # 1338\n\nMeet at the park.",
+      dateTime: "2026-06-20T14:00:00-04:00",
+    };
+    const event = buildRawEventFromApollo(ev, emptyState, "savh3");
+    expect(event.runNumber).toBe(1338);
+  });
+
+  it("leaves runNumber undefined when the description has no trail-anchored number", () => {
+    const ev = {
+      __typename: "Event",
+      id: "tt",
+      title: "Thirsty Thursday / Drinking Practice",
+      description: "Join us for drinks! No run tonight.",
+      dateTime: "2026-06-18T18:30:00-04:00",
+    };
+    const event = buildRawEventFromApollo(ev, emptyState, "savh3");
     expect(event.runNumber).toBeUndefined();
   });
 });

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -629,12 +629,56 @@ function resolveMeetupHares(
  */
 function resolveRunNumber(
   title: string | undefined,
+  description: string | undefined,
   extractRunNumber: boolean,
   runNumberPrefix: string | undefined,
 ): number | undefined {
-  if (!extractRunNumber) return undefined;
-  const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
-  return extractHashRunNumber(normalized);
+  // Title extraction stays opt-in (#1562): free-form Meetup titles can promote
+  // non-hash tokens ("Pub Crawl #2") into a runNumber that then poisons
+  // fingerprinting. Only sources that confirm unambiguous title conventions
+  // set `extractRunNumber: true`.
+  if (extractRunNumber) {
+    const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
+    const fromTitle = extractHashRunNumber(normalized);
+    if (fromTitle !== undefined) return fromTitle;
+  }
+  // Description extraction is default-on but anchored to a "trail" line so it
+  // only fires on the hash-canonical "Trail #N" shape (#2167 Savannah, whose
+  // titles are generic "Saturday Trail!" and carry the number in the body).
+  // The per-line "trail" anchor keeps stray "#3" tokens in free prose from
+  // promoting a bogus run number; no parallel run-number regex.
+  return extractRunNumberFromMeetupDescription(description);
+}
+
+// Anchor for the hash-canonical "Trail #N" shape: the word "trail" (word
+// boundary — so "Trailhead" / "trailing" don't match) immediately followed by
+// "#" (whitespace allowed). This restricts description run-number extraction to
+// a real run-number label, NOT any line that merely contains "trail" — prose
+// like "Meet at Trailhead gate #3" or "choose trail option #2" must not promote
+// a bogus number (Codex review). The shared `extractHashRunNumber` still parses
+// the digits from the anchor position; this is only a locator, not a parser.
+// ReDoS-safe: single `\s*`, no alternation (Sonar S5852).
+const TRAIL_RUN_ANCHOR_RE = /\btrail\b\s*#/i; // NOSONAR S5852 — linear, no alternation
+
+/**
+ * Extract a hash run number from a Meetup event description. Scans each line for
+ * the "Trail #N" anchor (#2167 Savannah: "Savannah H3 trail # 1338",
+ * "Savannah H3 Trail #: 1334", "What: Trail #1335"; Charlotte's Markdown bold
+ * "**Trail # 1244**" matches too). Parses from the anchor onward via the shared
+ * `extractHashRunNumber` so a leading "#3" elsewhere on the line can't win.
+ * Returns undefined when no trail-anchored number is present.
+ */
+export function extractRunNumberFromMeetupDescription(
+  description: string | undefined,
+): number | undefined {
+  if (!description) return undefined;
+  for (const line of stripHtmlTags(description, "\n").split("\n")) {
+    const anchor = TRAIL_RUN_ANCHOR_RE.exec(line);
+    if (!anchor) continue;
+    const n = extractHashRunNumber(line.slice(anchor.index));
+    if (n !== undefined) return n;
+  }
+  return undefined;
 }
 
 /** Build a RawEventData from an Apollo event entry. */
@@ -699,7 +743,7 @@ export function buildRawEventFromApollo(
     // Run-number extraction (with optional "R*n"-style prefix normalization)
     // lives in resolveRunNumber so this builder stays under the cognitive-
     // complexity budget. Display title keeps the kennel's stylization.
-    runNumber: resolveRunNumber(ev.title, extractRunNumber, runNumberPrefix),
+    runNumber: resolveRunNumber(ev.title, ev.description, extractRunNumber, runNumberPrefix),
     description: finalDesc,
     hares,
     location: venueInfo.location,

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -629,7 +629,7 @@ function resolveMeetupHares(
  */
 function resolveRunNumber(
   title: string | undefined,
-  description: string | undefined,
+  description: string | null | undefined,
   extractRunNumber: boolean,
   runNumberPrefix: string | undefined,
 ): number | undefined {
@@ -667,9 +667,14 @@ const TRAIL_RUN_ANCHOR_RE = /\btrail\b\s*#/i; // NOSONAR S5852 — linear, no al
  * "**Trail # 1244**" matches too). Parses from the anchor onward via the shared
  * `extractHashRunNumber` so a leading "#3" elsewhere on the line can't win.
  * Returns undefined when no trail-anchored number is present.
+ *
+ * Callers pass the already-resolved, boilerplate-stripped description
+ * (`finalDesc`) — never a raw Apollo back-reference ("$44") and never a stale
+ * group-template block — so neither unresolved refs nor recycled template run
+ * numbers reach this parser (Codex/Gemini PR #2200 review).
  */
 export function extractRunNumberFromMeetupDescription(
-  description: string | undefined,
+  description: string | null | undefined,
 ): number | undefined {
   if (!description) return undefined;
   for (const line of stripHtmlTags(description, "\n").split("\n")) {
@@ -743,7 +748,10 @@ export function buildRawEventFromApollo(
     // Run-number extraction (with optional "R*n"-style prefix normalization)
     // lives in resolveRunNumber so this builder stays under the cognitive-
     // complexity budget. Display title keeps the kennel's stylization.
-    runNumber: resolveRunNumber(ev.title, ev.description, extractRunNumber, runNumberPrefix),
+    // Use finalDesc (Apollo-ref-resolved + boilerplate-stripped), not the raw
+    // ev.description, so a "$44" cache ref or a stale group-template "Trail #N"
+    // can't drive the run number (#2200 review).
+    runNumber: resolveRunNumber(ev.title, finalDesc, extractRunNumber, runNumberPrefix),
     description: finalDesc,
     hares,
     location: venueInfo.location,


### PR DESCRIPTION
## Summary
Quick-win date-correctness bundle (two adapter fixes; one issue self-resolved). All sources live-verified.

### #2161 — CRH3 stored the publish-week date instead of the body run-date
`parseCrh3Body` passed the **whole** post body to chrono, which latched onto the `(next Saturday)` relative aside and resolved it to the publish-week Saturday — run #222 stored `2026-06-13` instead of the body's `2026-06-20`. Empirically confirmed: whole-body → `2026-06-13`; isolated `"Saturday 20 June 26"` → `2026-06-20`; retaining the parenthetical reproduced the bug.

Fix: isolate the run-date line (labelled `🗓 Date -` line, or a bare weekday-prefixed line for the #220 shape), strip the parenthetical aside, and parse just that line; the whole-text parse stays as a fallback so freeform posts still parse.

**Live-verified** via `Crh3Adapter.fetch()`: #222 → `2026-06-20` (startTime 15:30); other runs unchanged (#220→03-28, #219→02-28, #216→11-22).

### #2167 — Savannah run number lives in the description, not the title
Savannah's Meetup titles are generic (`"Saturday Trail!"`); the real number is in the body (`Savannah H3 trail # 1338`). `resolveRunNumber` now falls back to a new `extractRunNumberFromMeetupDescription`, which anchors per-line on the `Trail #N` shape (word-boundary `trail` directly before `#`) and reuses the shared `extractHashRunNumber` (no parallel number regex). Title extraction stays opt-in (#1562). The tight anchor rejects prose false positives like `"Trailhead gate #3"` / `"choose trail option #2"` (Codex review).

**Live-verified** via `MeetupAdapter.fetch()`: Savannah Saturday trails → 1332–1338 (sequential); all Thursday drinking events → no run number. Cross-checked Charlotte (correct 1244/1245), Richmond/Asheville (none) — no false positives.

### #2187 — closed as self-resolved (no code change)
Live Meetup Apollo shows `dateTime="2026-06-21T13:00:00-04:00"` — the adapter already produces the correct Jun 21; the stored Jun 19 was stale post-reschedule data and prod has since self-healed (Jun 21 #1691 CONFIRMED, Jun 28 #1692 CONFIRMED, Jun 19 #1691 CANCELLED). Root cause is merge dedup-by-`(kennel,date)` on reschedule, outside the adapter's scope. [Diagnosis + closure on the issue](https://github.com/johnrclem/hashtracks-web/issues/2187#issuecomment-4702787251).

## Testing
- `npx tsc --noEmit` — clean (pre-existing `@vercel/blob` env gap unrelated to this change)
- `npm run lint` — clean on all 4 files
- `npm test` — full suite green (9127 passed); +14 new tests (CRH3 #222 regression + Savannah/false-positive cases)
- Live-verified both adapters against production sources

Closes #2161
Closes #2167

🤖 Generated with [Claude Code](https://claude.com/claude-code)