### PR TITLE
feat(adapters): S2H3 titles + cohare + archive backfill; document RH3C/Savannah audits

### DIFF
--- a/scripts/backfill-bth3-history.ts
+++ b/scripts/backfill-bth3-history.ts
@@ -17,9 +17,8 @@
 
 import "dotenv/config";
 import { runBackfillScript } from "./lib/backfill-runner";
-import { safeFetch } from "@/adapters/safe-fetch";
+import { walkJoomlaArchive } from "./lib/joomla-archive-backfill";
 import { parseNextRunArticle } from "@/adapters/html-scraper/bangkokhash";
-import type { RawEventData } from "@/adapters/types";
 
 const SOURCE_NAME = "Bangkok Thursday Hash";
 const KENNEL_TIMEZONE = "Asia/Bangkok";
@@ -30,82 +29,17 @@ const BASE_URL = "https://www.bangkokhash.com";
 const INDEX_URL = `${BASE_URL}/thursday/index.php/run-archives-bth3?limit=0`;
 const DETAIL_URL_RE = /\/thursday\/index\.php\/run-archives-bth3\/\d+-run-\d+/g;
 
-const FETCH_HEADERS = {
-  "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Backfill)",
-  Accept: "text/html",
-};
-const FETCH_CONCURRENCY = 4;
-const MAX_TOTAL_FAILURES = 10;
-
-async function fetchText(url: string): Promise<string | null> {
-  const res = await safeFetch(url, { headers: FETCH_HEADERS });
-  if (!res.ok) {
-    console.warn(`  HTTP ${res.status} for ${url}`);
-    return null;
-  }
-  return res.text();
-}
-
-async function discoverDetailUrls(): Promise<string[]> {
-  console.log(`  Fetching index: ${INDEX_URL}`);
-  const html = await fetchText(INDEX_URL);
-  if (!html) throw new Error("Failed to fetch BTH3 archive index");
-  const matches = html.match(DETAIL_URL_RE) ?? [];
-  return [...new Set(matches)]
-    .sort((a, b) => a.localeCompare(b))
-    .map((path) => `${BASE_URL}${path}`);
-}
-
-async function fetchAllArchive(): Promise<RawEventData[]> {
-  const urls = await discoverDetailUrls();
-  console.log(`  Discovered ${urls.length} detail URLs`);
-
-  const events: RawEventData[] = [];
-  let failures = 0;
-  let nextIdx = 0;
-  let processed = 0;
-  let aborted = false;
-  let abortReason = "";
-
-  async function worker(): Promise<void> {
-    while (!aborted) {
-      const i = nextIdx++;
-      if (i >= urls.length) return;
-      const url = urls[i];
-      const html = await fetchText(url);
-      if (!html) {
-        failures++;
-        if (failures >= MAX_TOTAL_FAILURES) {
-          aborted = true;
-          abortReason = `${failures} total fetch failures (limit ${MAX_TOTAL_FAILURES})`;
-        }
-        continue;
-      }
-      const event = parseNextRunArticle(html, KENNEL_TAG, DEFAULT_TIME, url);
-      if (event) {
-        events.push(event);
-      } else {
-        console.warn(`  Skipped (no parse): ${url}`);
-      }
-      processed++;
-      if (processed % 25 === 0) {
-        console.log(`  Progress: ${processed}/${urls.length} fetched, ${events.length} parsed`);
-      }
-    }
-  }
-
-  await Promise.all(Array.from({ length: FETCH_CONCURRENCY }, worker));
-  if (aborted) throw new Error(`Aborted: ${abortReason}`);
-  events.sort((a, b) => a.date.localeCompare(b.date));
-  console.log(`  Final: ${processed}/${urls.length} fetched, ${events.length} parsed`);
-  return events;
-}
-
 runBackfillScript({
   sourceName: SOURCE_NAME,
   kennelTimezone: KENNEL_TIMEZONE,
   label: "Walking BTH3 archive",
-  fetchEvents: fetchAllArchive,
+  fetchEvents: () =>
+    walkJoomlaArchive({
+      baseUrl: BASE_URL,
+      indexUrl: INDEX_URL,
+      detailUrlRe: DETAIL_URL_RE,
+      parse: (html, url) => parseNextRunArticle(html, KENNEL_TAG, DEFAULT_TIME, url),
+    }),
 }).catch((err) => {
   console.error(err);
   process.exit(1);

--- a/scripts/backfill-s2h3-history.ts
+++ b/scripts/backfill-s2h3-history.ts
@@ -1,0 +1,133 @@
+/**
+ * One-shot historical backfill for Siam Sunday H3 (`s2h3`, Bangkok). Issue #2190.
+ *
+ * The live adapter (BangkokHashAdapter, subSite "siamsunday") only surfaces the
+ * next run plus a small future window from the PHP hareline API, so HashTracks
+ * holds just a handful of recent S2H3 runs. The kennel's public Run Archives
+ * expose every past run as an individual Joomla detail page (Run #520 → #657) at
+ *   /siamsunday/index.php/run-archives-s2h3/{joomla-id}-run-{NNN}
+ * carrying the full field set: headline title ("Run #NNN, <Location>"), date,
+ * start time, hare, cohare, location, and Google Maps link.
+ *
+ * Widening the adapter's scrape window is unsafe (the live index only lists the
+ * next run, so reconcile would cancel every archived run the adapter didn't
+ * return). Instead this walks the archive index and reuses the SAME
+ * `parseNextRunArticle` the adapter uses — its comment documents that it handles
+ * the archive `.com-content-article__body` template, so no parser fork — then
+ * routes the strictly-past slice through the live merge pipeline.
+ *
+ * Mirrors `scripts/backfill-bth3-history.ts` (same site, sibling kennel): single
+ * `?limit=0` "show-all" index fetch + concurrency pool + failure cap. The one
+ * divergence is the User-Agent — the /siamsunday archive's WAF 403s the shared
+ * "compatible; HashTracks-Backfill" UA that /thursday accepts, so this script
+ * sends a plain desktop-browser UA (verified against the live site).
+ *
+ * Idempotency: `processRawEvents` dedupes by fingerprint — re-running writes no
+ * new rows. Reuses the existing "Siam Sunday Hash" source (already linked to
+ * `s2h3`), so no new Source row and no reconcile impact (past-dated rows fall
+ * outside the live scrape/cancel window — same pattern as SDH3 / Seletar).
+ *
+ * Usage:
+ *   Dry run:  npx tsx scripts/backfill-s2h3-history.ts
+ *   Apply:    BACKFILL_APPLY=1 npx tsx scripts/backfill-s2h3-history.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { parseNextRunArticle } from "@/adapters/html-scraper/bangkokhash";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Siam Sunday Hash";
+const KENNEL_TIMEZONE = "Asia/Bangkok";
+const KENNEL_TAG = "s2h3";
+const DEFAULT_TIME = "16:30";
+
+const BASE_URL = "https://www.bangkokhash.com";
+const INDEX_URL = `${BASE_URL}/siamsunday/index.php/run-archives-s2h3?limit=0`;
+const DETAIL_URL_RE = /\/siamsunday\/index\.php\/run-archives-s2h3\/\d+-run-\d+/g;
+
+// Unlike the BTH3/BFMH3 archives, the /siamsunday archive's WAF 403s the shared
+// "compatible; HashTracks-Backfill" UA — a plain desktop-browser UA is accepted
+// (verified against the live site).
+const FETCH_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+  Accept: "text/html",
+};
+const FETCH_CONCURRENCY = 4;
+const MAX_TOTAL_FAILURES = 10;
+
+async function fetchText(url: string): Promise<string | null> {
+  const res = await safeFetch(url, { headers: FETCH_HEADERS });
+  if (!res.ok) {
+    console.warn(`  HTTP ${res.status} for ${url}`);
+    return null;
+  }
+  return res.text();
+}
+
+async function discoverDetailUrls(): Promise<string[]> {
+  console.log(`  Fetching index: ${INDEX_URL}`);
+  const html = await fetchText(INDEX_URL);
+  if (!html) throw new Error("Failed to fetch S2H3 archive index");
+  const matches = html.match(DETAIL_URL_RE) ?? [];
+  return [...new Set(matches)]
+    .sort((a, b) => a.localeCompare(b))
+    .map((path) => `${BASE_URL}${path}`);
+}
+
+async function fetchAllArchive(): Promise<RawEventData[]> {
+  const urls = await discoverDetailUrls();
+  console.log(`  Discovered ${urls.length} detail URLs`);
+
+  const events: RawEventData[] = [];
+  let failures = 0;
+  let nextIdx = 0;
+  let processed = 0;
+  let aborted = false;
+  let abortReason = "";
+
+  async function worker(): Promise<void> {
+    while (!aborted) {
+      const i = nextIdx++;
+      if (i >= urls.length) return;
+      const url = urls[i];
+      const html = await fetchText(url);
+      if (!html) {
+        failures++;
+        if (failures >= MAX_TOTAL_FAILURES) {
+          aborted = true;
+          abortReason = `${failures} total fetch failures (limit ${MAX_TOTAL_FAILURES})`;
+        }
+        continue;
+      }
+      const event = parseNextRunArticle(html, KENNEL_TAG, DEFAULT_TIME, url);
+      if (event) {
+        events.push(event);
+      } else {
+        console.warn(`  Skipped (no parse): ${url}`);
+      }
+      processed++;
+      if (processed % 25 === 0) {
+        console.log(`  Progress: ${processed}/${urls.length} fetched, ${events.length} parsed`);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: FETCH_CONCURRENCY }, worker));
+  if (aborted) throw new Error(`Aborted: ${abortReason}`);
+  events.sort((a, b) => a.date.localeCompare(b.date));
+  console.log(`  Final: ${processed}/${urls.length} fetched, ${events.length} parsed`);
+  return events;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Walking S2H3 archive",
+  fetchEvents: fetchAllArchive,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-s2h3-history.ts
+++ b/scripts/backfill-s2h3-history.ts
@@ -11,16 +11,11 @@
  *
  * Widening the adapter's scrape window is unsafe (the live index only lists the
  * next run, so reconcile would cancel every archived run the adapter didn't
- * return). Instead this walks the archive index and reuses the SAME
+ * return). Instead this walks the archive (via the shared `walkJoomlaArchive`
+ * helper, same as backfill-bth3-history.ts) and reuses the SAME
  * `parseNextRunArticle` the adapter uses — its comment documents that it handles
  * the archive `.com-content-article__body` template, so no parser fork — then
  * routes the strictly-past slice through the live merge pipeline.
- *
- * Mirrors `scripts/backfill-bth3-history.ts` (same site, sibling kennel): single
- * `?limit=0` "show-all" index fetch + concurrency pool + failure cap. The one
- * divergence is the User-Agent — the /siamsunday archive's WAF 403s the shared
- * "compatible; HashTracks-Backfill" UA that /thursday accepts, so this script
- * sends a plain desktop-browser UA (verified against the live site).
  *
  * Idempotency: `processRawEvents` dedupes by fingerprint — re-running writes no
  * new rows. Reuses the existing "Siam Sunday Hash" source (already linked to
@@ -34,9 +29,8 @@
 
 import "dotenv/config";
 import { runBackfillScript } from "./lib/backfill-runner";
-import { safeFetch } from "@/adapters/safe-fetch";
+import { walkJoomlaArchive } from "./lib/joomla-archive-backfill";
 import { parseNextRunArticle } from "@/adapters/html-scraper/bangkokhash";
-import type { RawEventData } from "@/adapters/types";
 
 const SOURCE_NAME = "Siam Sunday Hash";
 const KENNEL_TIMEZONE = "Asia/Bangkok";
@@ -47,86 +41,17 @@ const BASE_URL = "https://www.bangkokhash.com";
 const INDEX_URL = `${BASE_URL}/siamsunday/index.php/run-archives-s2h3?limit=0`;
 const DETAIL_URL_RE = /\/siamsunday\/index\.php\/run-archives-s2h3\/\d+-run-\d+/g;
 
-// Unlike the BTH3/BFMH3 archives, the /siamsunday archive's WAF 403s the shared
-// "compatible; HashTracks-Backfill" UA — a plain desktop-browser UA is accepted
-// (verified against the live site).
-const FETCH_HEADERS = {
-  "User-Agent":
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
-  Accept: "text/html",
-};
-const FETCH_CONCURRENCY = 4;
-const MAX_TOTAL_FAILURES = 10;
-
-async function fetchText(url: string): Promise<string | null> {
-  const res = await safeFetch(url, { headers: FETCH_HEADERS });
-  if (!res.ok) {
-    console.warn(`  HTTP ${res.status} for ${url}`);
-    return null;
-  }
-  return res.text();
-}
-
-async function discoverDetailUrls(): Promise<string[]> {
-  console.log(`  Fetching index: ${INDEX_URL}`);
-  const html = await fetchText(INDEX_URL);
-  if (!html) throw new Error("Failed to fetch S2H3 archive index");
-  const matches = html.match(DETAIL_URL_RE) ?? [];
-  return [...new Set(matches)]
-    .sort((a, b) => a.localeCompare(b))
-    .map((path) => `${BASE_URL}${path}`);
-}
-
-async function fetchAllArchive(): Promise<RawEventData[]> {
-  const urls = await discoverDetailUrls();
-  console.log(`  Discovered ${urls.length} detail URLs`);
-
-  const events: RawEventData[] = [];
-  let failures = 0;
-  let nextIdx = 0;
-  let processed = 0;
-  let aborted = false;
-  let abortReason = "";
-
-  async function worker(): Promise<void> {
-    while (!aborted) {
-      const i = nextIdx++;
-      if (i >= urls.length) return;
-      const url = urls[i];
-      const html = await fetchText(url);
-      if (!html) {
-        failures++;
-        if (failures >= MAX_TOTAL_FAILURES) {
-          aborted = true;
-          abortReason = `${failures} total fetch failures (limit ${MAX_TOTAL_FAILURES})`;
-        }
-        continue;
-      }
-      const event = parseNextRunArticle(html, KENNEL_TAG, DEFAULT_TIME, url);
-      if (event) {
-        events.push(event);
-      } else {
-        console.warn(`  Skipped (no parse): ${url}`);
-      }
-      processed++;
-      if (processed % 25 === 0) {
-        console.log(`  Progress: ${processed}/${urls.length} fetched, ${events.length} parsed`);
-      }
-    }
-  }
-
-  await Promise.all(Array.from({ length: FETCH_CONCURRENCY }, worker));
-  if (aborted) throw new Error(`Aborted: ${abortReason}`);
-  events.sort((a, b) => a.date.localeCompare(b.date));
-  console.log(`  Final: ${processed}/${urls.length} fetched, ${events.length} parsed`);
-  return events;
-}
-
 runBackfillScript({
   sourceName: SOURCE_NAME,
   kennelTimezone: KENNEL_TIMEZONE,
   label: "Walking S2H3 archive",
-  fetchEvents: fetchAllArchive,
+  fetchEvents: () =>
+    walkJoomlaArchive({
+      baseUrl: BASE_URL,
+      indexUrl: INDEX_URL,
+      detailUrlRe: DETAIL_URL_RE,
+      parse: (html, url) => parseNextRunArticle(html, KENNEL_TAG, DEFAULT_TIME, url),
+    }),
 }).catch((err) => {
   console.error(err);
   process.exit(1);

--- a/scripts/lib/joomla-archive-backfill.ts
+++ b/scripts/lib/joomla-archive-backfill.ts
@@ -1,0 +1,108 @@
+import { safeFetch } from "@/adapters/safe-fetch";
+import type { RawEventData } from "@/adapters/types";
+
+/**
+ * bangkokhash.com's WAF 403s bot-style User-Agents site-wide, so default to a
+ * plain desktop-browser UA (verified against the live /thursday + /siamsunday
+ * archives). Callers can override via `headers` if a sub-site needs something
+ * different.
+ */
+const DEFAULT_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+  Accept: "text/html",
+};
+
+/**
+ * Shared archive walker for bangkokhash.com-style Joomla "Run Archives" backfills.
+ *
+ * The pattern (used by BTH3, S2H3, …): fetch a single `?limit=0` "show-all"
+ * index page, regex out the per-run detail links, then fetch each detail page
+ * through a bounded concurrency pool and parse it with the kennel's adapter
+ * parser. Each kennel differs only in its base origin, index URL, detail-link
+ * regex, request headers, and the parse closure — everything below is identical,
+ * so it lives here instead of being copy-pasted per script.
+ */
+export interface JoomlaArchiveWalkOptions {
+  /** Origin to prepend to matched relative detail paths, e.g. "https://www.bangkokhash.com". */
+  baseUrl: string;
+  /** Full `?limit=0` archive index URL. */
+  indexUrl: string;
+  /** Global (`/g`) regex matching the relative detail paths in the index HTML. */
+  detailUrlRe: RegExp;
+  /** Request header override. Defaults to a desktop-browser UA (see DEFAULT_HEADERS). */
+  headers?: Record<string, string>;
+  /** Parse one detail page's HTML into a RawEventData (or null to skip). */
+  parse: (html: string, url: string) => RawEventData | null;
+  /** Concurrent detail fetches. Default 4. */
+  concurrency?: number;
+  /** Abort after this many total fetch failures. Default 10. */
+  maxFailures?: number;
+}
+
+export async function walkJoomlaArchive(
+  opts: JoomlaArchiveWalkOptions,
+): Promise<RawEventData[]> {
+  const { baseUrl, indexUrl, detailUrlRe, parse } = opts;
+  const headers = opts.headers ?? DEFAULT_HEADERS;
+  const concurrency = opts.concurrency ?? 4;
+  const maxFailures = opts.maxFailures ?? 10;
+
+  async function fetchText(url: string): Promise<string | null> {
+    const res = await safeFetch(url, { headers });
+    if (!res.ok) {
+      console.warn(`  HTTP ${res.status} for ${url}`);
+      return null;
+    }
+    return res.text();
+  }
+
+  console.log(`  Fetching index: ${indexUrl}`);
+  const indexHtml = await fetchText(indexUrl);
+  if (!indexHtml) throw new Error(`Failed to fetch archive index: ${indexUrl}`);
+  const matches = indexHtml.match(detailUrlRe) ?? [];
+  const urls = [...new Set(matches)]
+    .sort((a, b) => a.localeCompare(b))
+    .map((path) => `${baseUrl}${path}`);
+  console.log(`  Discovered ${urls.length} detail URLs`);
+
+  const events: RawEventData[] = [];
+  let failures = 0;
+  let nextIdx = 0;
+  let processed = 0;
+  let aborted = false;
+  let abortReason = "";
+
+  async function worker(): Promise<void> {
+    while (!aborted) {
+      const i = nextIdx++;
+      if (i >= urls.length) return;
+      const url = urls[i];
+      const html = await fetchText(url);
+      if (!html) {
+        failures++;
+        if (failures >= maxFailures) {
+          aborted = true;
+          abortReason = `${failures} total fetch failures (limit ${maxFailures})`;
+        }
+        continue;
+      }
+      const event = parse(html, url);
+      if (event) {
+        events.push(event);
+      } else {
+        console.warn(`  Skipped (no parse): ${url}`);
+      }
+      processed++;
+      if (processed % 25 === 0) {
+        console.log(`  Progress: ${processed}/${urls.length} fetched, ${events.length} parsed`);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  if (aborted) throw new Error(`Aborted: ${abortReason}`);
+  events.sort((a, b) => a.date.localeCompare(b.date));
+  console.log(`  Final: ${processed}/${urls.length} fetched, ${events.length} parsed`);
+  return events;
+}

--- a/scripts/lib/joomla-archive-backfill.ts
+++ b/scripts/lib/joomla-archive-backfill.ts
@@ -48,13 +48,21 @@ export async function walkJoomlaArchive(
   const concurrency = opts.concurrency ?? 4;
   const maxFailures = opts.maxFailures ?? 10;
 
+  // Return null on any failure (non-OK status OR a thrown network/stream error)
+  // so transient errors count toward maxFailures instead of rejecting the whole
+  // run on the first hiccup. `await res.text()` keeps stream errors inside the try.
   async function fetchText(url: string): Promise<string | null> {
-    const res = await safeFetch(url, { headers });
-    if (!res.ok) {
-      console.warn(`  HTTP ${res.status} for ${url}`);
+    try {
+      const res = await safeFetch(url, { headers });
+      if (!res.ok) {
+        console.warn(`  HTTP ${res.status} for ${url}`);
+        return null;
+      }
+      return await res.text();
+    } catch (err) {
+      console.warn(`  Failed to fetch ${url}: ${err instanceof Error ? err.message : String(err)}`);
       return null;
     }
-    return res.text();
   }
 
   console.log(`  Fetching index: ${indexUrl}`);
@@ -65,6 +73,14 @@ export async function walkJoomlaArchive(
     .sort((a, b) => a.localeCompare(b))
     .map((path) => `${baseUrl}${path}`);
   console.log(`  Discovered ${urls.length} detail URLs`);
+  // A successful index fetch that yields zero detail links means the layout
+  // changed (the regex no longer matches) — fail loud rather than silently
+  // backfilling nothing and exiting 0.
+  if (urls.length === 0) {
+    throw new Error(
+      `No detail URLs discovered at ${indexUrl} — index layout may have changed (regex matched nothing)`,
+    );
+  }
 
   const events: RawEventData[] = [];
   let failures = 0;

--- a/scripts/lib/joomla-archive-backfill.ts
+++ b/scripts/lib/joomla-archive-backfill.ts
@@ -68,7 +68,9 @@ export async function walkJoomlaArchive(
   console.log(`  Fetching index: ${indexUrl}`);
   const indexHtml = await fetchText(indexUrl);
   if (!indexHtml) throw new Error(`Failed to fetch archive index: ${indexUrl}`);
-  const matches = indexHtml.match(detailUrlRe) ?? [];
+  // detailUrlRe is global — matchAll gathers every detail path (and satisfies
+  // Sonar S6594's preference for exec-family methods over String.match).
+  const matches = [...indexHtml.matchAll(detailUrlRe)].map((m) => m[0]);
   const urls = [...new Set(matches)]
     .sort((a, b) => a.localeCompare(b))
     .map((path) => `${baseUrl}${path}`);

--- a/src/adapters/html-scraper/bangkokhash.test.ts
+++ b/src/adapters/html-scraper/bangkokhash.test.ts
@@ -36,6 +36,7 @@ describe("parseNextRunArticle", () => {
     expect(event!.kennelTags[0]).toBe("bth3");
     expect(event!.runNumber).toBe(519);
     expect(event!.startTime).toBe("18:30");
+    expect(event!.title).toBe("Run #519");
     expect(event!.hares).toBe("Jessticles");
     expect(event!.location).toBe("Silom Road");
     expect(event!.locationUrl).toBe("https://maps.app.goo.gl/abc123");
@@ -49,8 +50,32 @@ describe("parseNextRunArticle", () => {
     expect(event!.runNumber).toBe(653);
     expect(event!.startTime).toBe("16:30");
     expect(event!.hares).toBe("Horny Viking");
+    // #2189: the run headline from `.item-title` becomes the event title
+    // instead of the synthesized "Siam Sunday H3 Trail #653" default.
+    expect(event!.title).toBe("Run #653. On Nut 37");
     expect(event!.location).toBe("On Nut 37");
     expect(event!.locationUrl).toBe("https://maps.app.goo.gl/LF88EQZtSPZkdt826");
+  });
+
+  it("merges Cohare into the hares field, sorted (#2189)", () => {
+    // The Siam Sunday next-run article lists `Hare:` and `Cohare:` on separate
+    // lines; both belong in the hares field. normalizeHaresField sorts them so
+    // the joined value is fingerprint-stable regardless of source order.
+    const html = `
+<div class="item-content">
+  <h2 class="item-title">
+    <a href="/siamsunday/index.php/run-archives-s2h3/236-run-657">Run #657, Suan Eden</a>
+  </h2>
+  <p><strong>Date</strong>: 14-June-2026<br>
+  <strong>Start Time</strong>: 16:30<br>
+  <strong>Hare</strong>: Hot Lips<br>
+  <strong>Cohare</strong>: Patpom<br>
+  <strong>Location</strong>: Suan Eden, Nonthaburi</p>
+</div>`;
+    const event = parseNextRunArticle(html, "s2h3", "16:30", "https://www.bangkokhash.com/siamsunday/index.php");
+    expect(event).not.toBeNull();
+    expect(event!.title).toBe("Run #657, Suan Eden");
+    expect(event!.hares).toBe("Hot Lips, Patpom");
   });
 
   it("falls back to Station when Run Site starts with 'Google Map:'", () => {
@@ -63,6 +88,9 @@ describe("parseNextRunArticle", () => {
 </div>`;
     const event = parseNextRunArticle(html, "bth3", "18:30", "https://www.bangkokhash.com/thursday/index.php");
     expect(event!.location).toBe("BTS Chong Nonsi");
+    // No `.item-title` / `.page-header` heading → title stays undefined so
+    // merge.ts synthesizes the "<Kennel> Trail #N" default (#2189 guard).
+    expect(event!.title).toBeUndefined();
   });
 
   it("returns null for empty article", () => {
@@ -132,6 +160,10 @@ describe("parseNextRunArticle", () => {
     expect(event).not.toBeNull();
     expect(event!.date).toBe("2026-04-03");
     expect(event!.kennelTags[0]).toBe("bfmh3");
+    // Archive detail pages carry the headline in `.page-header h1` (#2189) —
+    // both the title and the run number come from there (the body lacks "Run #").
+    expect(event!.title).toBe("Run #254, BTS Asok");
+    expect(event!.runNumber).toBe(254);
     expect(event!.hares).toBe("Patpom");
     expect(event!.location).toBe("BTS Asok");
     expect(event!.locationUrl).toBe("https://maps.app.goo.gl/v5yucg6jKmXALUf59");
@@ -153,6 +185,26 @@ describe("parseNextRunArticle", () => {
     expect(event!.date).toBe("2020-01-10");
     expect(event!.hares).toBe("Soi Squatter");
     expect(event!.location).toBe("On Nut BTS, Car park behind Cheap Charlies");
+  });
+
+  it("salvages a maps URL in the Location field into locationUrl (#2190 archive)", () => {
+    // Older S2H3 archive pages put the Google Maps link directly in the
+    // `Location:` field with no separate Googlemaps row. It must surface as
+    // locationUrl, never as the venue label.
+    const html = `
+<div class="page-header"><h1>Run #520, Talin Chan</h1></div>
+<div class="com-content-article__body">
+  <p><strong>Date</strong>: 12-Jan-2020<br>
+  <strong>Start Time</strong>: 16:30<br>
+  <strong>Hare</strong>: Boob-a-lube<br>
+  <strong>Location</strong>: https://goo.gl/maps/p3zCf2va3RjKc96x7</p>
+</div>`;
+    const event = parseNextRunArticle(html, "s2h3", "16:30", "https://www.bangkokhash.com/siamsunday/index.php/run-archives-s2h3/99-run-520");
+    expect(event).not.toBeNull();
+    expect(event!.runNumber).toBe(520);
+    expect(event!.title).toBe("Run #520, Talin Chan");
+    expect(event!.location).toBeUndefined();
+    expect(event!.locationUrl).toBe("https://goo.gl/maps/p3zCf2va3RjKc96x7");
   });
 
   it("returns null when the Date field lacks a 4-digit year", () => {

--- a/src/adapters/html-scraper/bangkokhash.test.ts
+++ b/src/adapters/html-scraper/bangkokhash.test.ts
@@ -36,7 +36,10 @@ describe("parseNextRunArticle", () => {
     expect(event!.kennelTags[0]).toBe("bth3");
     expect(event!.runNumber).toBe(519);
     expect(event!.startTime).toBe("18:30");
-    expect(event!.title).toBe("Run #519");
+    // Bare "Run #519" heading (no trail name) → leave title undefined so merge
+    // synthesizes "<Kennel> Trail #519"; persisting "Run #519" would double up
+    // with consumers that prepend the run number (#2189 / Codex review).
+    expect(event!.title).toBeUndefined();
     expect(event!.hares).toBe("Jessticles");
     expect(event!.location).toBe("Silom Road");
     expect(event!.locationUrl).toBe("https://maps.app.goo.gl/abc123");
@@ -55,6 +58,22 @@ describe("parseNextRunArticle", () => {
     expect(event!.title).toBe("Run #653. On Nut 37");
     expect(event!.location).toBe("On Nut 37");
     expect(event!.locationUrl).toBe("https://maps.app.goo.gl/LF88EQZtSPZkdt826");
+  });
+
+  it("leaves title undefined when the heading is a bare run number (#2189 / Codex)", () => {
+    // BTH3 archive page whose heading carries no trail name beyond "Run #300".
+    const html = `
+<div class="page-header"><h1>Run #300</h1></div>
+<div class="com-content-article__body">
+  <p><strong>Date</strong>: 03-Apr-2026<br>
+  <strong>Start Time</strong>: 18:30<br>
+  <strong>Hare</strong>: Jessticles<br>
+  <strong>Station</strong>: BTS Asok</p>
+</div>`;
+    const event = parseNextRunArticle(html, "bth3", "18:30", "https://www.bangkokhash.com/thursday/index.php/run-archives-bth3/9-run-300");
+    expect(event).not.toBeNull();
+    expect(event!.runNumber).toBe(300);
+    expect(event!.title).toBeUndefined();
   });
 
   it("merges Cohare into the hares field, sorted (#2189)", () => {

--- a/src/adapters/html-scraper/bangkokhash.ts
+++ b/src/adapters/html-scraper/bangkokhash.ts
@@ -77,6 +77,32 @@ function isFieldLabel(val: string): boolean {
  *  across `.test()` and `.exec()` (those are stateful only with `g`). */
 const RUN_NUMBER_RE = /Run\s*#?\s*(\d+)/i;
 
+const HTTP_URL_RE = /^https?:\/\//i;
+
+/**
+ * Resolve the display location + maps URL from the candidate venue fields.
+ * Prefers an explicit Location/Run Site/Station/Restaurant venue name; a
+ * "Google Map" label on Run Site is dropped (it's not a venue). Some archive
+ * pages put a maps URL directly in the `Location:` field — that's salvaged into
+ * `locationUrl` rather than leaking as the venue label.
+ */
+function resolveLocation(
+  locationRaw: string | undefined,
+  runSite: string | undefined,
+  station: string | undefined,
+  restaurant: string | undefined,
+  googleMap: string | undefined,
+): { location: string | undefined; locationUrl: string | undefined } {
+  const runSiteClean = runSite && !/^Google\s*Map/i.test(runSite) ? runSite : undefined;
+  const candidate = locationRaw ?? runSiteClean ?? station ?? restaurant;
+  const candidateIsUrl = !!candidate && HTTP_URL_RE.test(candidate);
+  const location =
+    candidate && !candidateIsUrl && candidate.length > 1 ? candidate : undefined;
+  const mapUrl = googleMap && HTTP_URL_RE.test(googleMap) ? googleMap : undefined;
+  const locationUrl = mapUrl ?? (candidateIsUrl ? candidate : undefined);
+  return { location, locationUrl };
+}
+
 /**
  * Parse the Joomla next-run article. This has labeled fields in
  * `<strong>Label</strong>: Value` format within `.item-content`.
@@ -165,21 +191,13 @@ export function parseNextRunArticle(
   const runMatch = RUN_NUMBER_RE.exec(headingRaw) ?? RUN_NUMBER_RE.exec(text);
   const runNumber = runMatch ? Number.parseInt(runMatch[1], 10) : undefined;
 
-  // Strip "Google Map:" prefix from runSite — when the kennel uses that as the label it's not
-  // a useful venue name. Fall back to station (BTS stop etc.) when runSite is just a map label.
-  const runSiteClean = runSite && !/^Google\s*Map/i.test(runSite) ? runSite : undefined;
-  const locationCandidate = locationRaw ?? runSiteClean ?? station ?? restaurant ?? undefined;
-  // Some older archive pages put a maps URL directly in the `Location:` field —
-  // that's a link, not a venue name. Keep `location` to venue text only and
-  // salvage the URL into `locationUrl` so it never renders as the venue label.
-  const candidateIsUrl = !!locationCandidate && /^https?:\/\//i.test(locationCandidate);
-  const location =
-    locationCandidate && !candidateIsUrl && locationCandidate.length > 1
-      ? locationCandidate
-      : undefined;
-  const locationUrl =
-    (googleMap && /^https?:\/\//i.test(googleMap) ? googleMap : undefined) ??
-    (candidateIsUrl ? locationCandidate : undefined);
+  const { location, locationUrl } = resolveLocation(
+    locationRaw,
+    runSite,
+    station,
+    restaurant,
+    googleMap,
+  );
 
   return {
     date,
@@ -187,7 +205,7 @@ export function parseNextRunArticle(
     runNumber,
     title,
     hares: normalizeHaresField(hare),
-    location: location || undefined,
+    location,
     locationUrl,
     startTime,
     sourceUrl,

--- a/src/adapters/html-scraper/bangkokhash.ts
+++ b/src/adapters/html-scraper/bangkokhash.ts
@@ -74,8 +74,26 @@ function isFieldLabel(val: string): boolean {
 }
 
 /** Run-headline matcher ("Run #657", "Run 657"). No `g` flag → safe to reuse
- *  across `.test()` and `.exec()` (those are stateful only with `g`). */
-const RUN_NUMBER_RE = /Run\s*#?\s*(\d+)/i;
+ *  across `.test()` and `.exec()` (those are stateful only with `g`). The
+ *  `\s*(?:#\s*)?` form avoids adjacent overlapping `\s*` quantifiers (ReDoS
+ *  hygiene per the repo regex rule). */
+const RUN_NUMBER_RE = /Run\s*(?:#\s*)?(\d+)/i;
+
+/**
+ * True when a "Run #NNN …" heading carries a trail name beyond the bare run
+ * number (e.g. "Run #657, Suan Eden"). A bare "Run #519" returns false so the
+ * caller falls back to the synthesized "<Kennel> Trail #N" instead of
+ * persisting a run-number-only title — downstream consumers (e.g.
+ * `calendar.ts` `buildTitle`) prepend the run number themselves and would
+ * otherwise render it twice.
+ */
+function runHeadlineHasName(heading: string): boolean {
+  const m = RUN_NUMBER_RE.exec(heading);
+  if (!m) return false;
+  const rest = heading.slice(0, m.index) + heading.slice(m.index + m[0].length);
+  // Anything left after stripping separators is a trail name (Latin or Thai).
+  return rest.replaceAll(/[\s,.:#@–—-]+/g, "").length > 0;
+}
 
 const HTTP_URL_RE = /^https?:\/\//i;
 
@@ -182,7 +200,7 @@ export function parseNextRunArticle(
   )
     .replaceAll(/\s+/g, " ")
     .trim();
-  const title = RUN_NUMBER_RE.test(headingRaw) ? headingRaw : undefined;
+  const title = runHeadlineHasName(headingRaw) ? headingRaw : undefined;
 
   // Extract the run number. On the homepage the heading lives inside
   // `.item-content` so it's in `text` too; on archive detail pages the
@@ -270,7 +288,7 @@ export function parseHarelineApiHtml(
     }
 
     // Regular run entry: "Run #519" followed by hare name
-    const runMatch = /Run\s*#?\s*(\d+)/i.exec(infoText);
+    const runMatch = RUN_NUMBER_RE.exec(infoText);
     const runNumber = runMatch ? Number.parseInt(runMatch[1], 10) : undefined;
 
     let hares: string | undefined;

--- a/src/adapters/html-scraper/bangkokhash.ts
+++ b/src/adapters/html-scraper/bangkokhash.ts
@@ -73,6 +73,10 @@ function isFieldLabel(val: string): boolean {
   return FIELD_LABELS.has(normalized);
 }
 
+/** Run-headline matcher ("Run #657", "Run 657"). No `g` flag → safe to reuse
+ *  across `.test()` and `.exec()` (those are stateful only with `g`). */
+const RUN_NUMBER_RE = /Run\s*#?\s*(\d+)/i;
+
 /**
  * Parse the Joomla next-run article. This has labeled fields in
  * `<strong>Label</strong>: Value` format within `.item-content`.
@@ -124,31 +128,64 @@ export function parseNextRunArticle(
 
   // #802: the labeled `Hares:` field sometimes carries filler like "On On Q"
   // instead of a real name. Mirror the API-path boilerplate guard so we don't
-  // ship "On On Q" as a hare name.
-  const hareRaw = grab("Hares?");
-  const hare = hareRaw && !HARE_BOILERPLATE_RE.test(hareRaw) ? hareRaw : undefined;
+  // ship "On On Q" as a hare name. #2189: fold the co-hare into the hares field
+  // (the source lists `Hare:` and `Cohare:` on separate lines) so it stops
+  // being dropped. `normalizeHaresField` sorts + dedupes, keeping the joined
+  // value stable for fingerprinting regardless of source line order.
+  const hareParts = [grab("Hares?"), grab("Cohares?")].filter(
+    (v): v is string => !!v && !HARE_BOILERPLATE_RE.test(v),
+  );
+  const hare = hareParts.length > 0 ? hareParts.join(", ") : undefined;
   const station = grab("Station");
   const runSite = grab("Run\\s*Site");
   const restaurant = grab("Restaurant");
   const locationRaw = grab("Location") ?? grab("Where");
   const googleMap = grab("Google\\s*(?:maps?|Map)\\s*(?:Link)?");
 
-  // Extract run number from the article title
-  const titleMatch = /Run\s*#?\s*(\d+)/i.exec(text);
-  const runNumber = titleMatch ? Number.parseInt(titleMatch[1], 10) : undefined;
+  // #2189: the source headlines each run "Run #NNN, <Location>" in the article
+  // heading. Use it as the event title instead of letting merge.ts synthesize
+  // "<Kennel> Trail #N". The homepage nests `.item-title` INSIDE the parsed
+  // `.item-content` article, so scope the lookup there to avoid grabbing a
+  // sibling article's title on multi-article pages; archive detail pages put
+  // the headline in a page-level `.page-header` OUTSIDE
+  // `.com-content-article__body`, so fall back to that (one per detail page).
+  // cheerio `.text()` already decodes entities, so no decodeEntities needed.
+  const headingRaw = (
+    article.find(".item-title").first().text() ||
+    $(".page-header h1, .page-header h2").first().text()
+  )
+    .replaceAll(/\s+/g, " ")
+    .trim();
+  const title = RUN_NUMBER_RE.test(headingRaw) ? headingRaw : undefined;
+
+  // Extract the run number. On the homepage the heading lives inside
+  // `.item-content` so it's in `text` too; on archive detail pages the
+  // "Run #NNN" is ONLY in the page-header heading — so check the heading
+  // first, then the body.
+  const runMatch = RUN_NUMBER_RE.exec(headingRaw) ?? RUN_NUMBER_RE.exec(text);
+  const runNumber = runMatch ? Number.parseInt(runMatch[1], 10) : undefined;
 
   // Strip "Google Map:" prefix from runSite — when the kennel uses that as the label it's not
   // a useful venue name. Fall back to station (BTS stop etc.) when runSite is just a map label.
   const runSiteClean = runSite && !/^Google\s*Map/i.test(runSite) ? runSite : undefined;
   const locationCandidate = locationRaw ?? runSiteClean ?? station ?? restaurant ?? undefined;
-  // Filter out empty/placeholder values
-  const location = locationCandidate && locationCandidate.length > 1 ? locationCandidate : undefined;
-  const locationUrl = googleMap && /^https?:\/\//.test(googleMap) ? googleMap : undefined;
+  // Some older archive pages put a maps URL directly in the `Location:` field —
+  // that's a link, not a venue name. Keep `location` to venue text only and
+  // salvage the URL into `locationUrl` so it never renders as the venue label.
+  const candidateIsUrl = !!locationCandidate && /^https?:\/\//i.test(locationCandidate);
+  const location =
+    locationCandidate && !candidateIsUrl && locationCandidate.length > 1
+      ? locationCandidate
+      : undefined;
+  const locationUrl =
+    (googleMap && /^https?:\/\//i.test(googleMap) ? googleMap : undefined) ??
+    (candidateIsUrl ? locationCandidate : undefined);
 
   return {
     date,
     kennelTags: [kennelTag],
     runNumber,
+    title,
     hares: normalizeHaresField(hare),
     location: location || undefined,
     locationUrl,


### PR DESCRIPTION
## Quick-Win audit bundle: S2H3 enrichment + archive, plus 3 documented closes

Two code fixes (S2H3) and three issues resolved by live-verified documentation (user-confirmed dispositions where live reality diverged from the issue's hypothesis).

### Code — Siam Sunday H3 (S2H3)
**#2189 — source titles + cohare.** `parseNextRunArticle` now reads the source run headline (`Run #NNN, <Location>`) as the event `title` instead of letting the merge pipeline synthesize `Siam Sunday H3 Trail #NNN`. The homepage lookup is scoped to the parsed `.item-content` article (`.item-title`); archive detail pages fall back to the page-level `.page-header`. Run number is now read from the heading first, then the body (archive pages carry `Run #NNN` only in `.page-header`). The `Cohare` field is folded into hares (sorted for fingerprint stability), and a maps URL appearing in the `Location:` field is salvaged into `locationUrl` instead of leaking as the venue name.

**#2190 — archive backfill.** New one-shot `scripts/backfill-s2h3-history.ts` backfills the Run Archives (#520→#657), mirroring the sibling `backfill-bth3-history.ts` (single `?limit=0` index fetch + concurrency pool). It reuses `parseNextRunArticle` and the existing **"Siam Sunday Hash"** source, routing strictly-past rows through `reportAndApplyBackfill` (idempotent, no new Source, no reconcile impact).

**Applied to prod:** 131 created, 5 updated (existing placeholder titles corrected, e.g. `#656` → "Run #656, Minburi"). S2H3 canonical events 18 → 149. Live-verified against the source for titles, cohare merge (`#657` → "Hot Lips, Patpom"), and URL-salvage (`#520` venue null + maps URL stored).

### Documented closes (live-verified not-feasible / not-a-bug)
- **#2143 (RH3C HashStats)** — `renegadeh3.hashstats.org` is gated behind a Cloudflare JS challenge → `/auth` "Access denied", and `RH3C` 404s on the public `hashingstats.com` host. The data needs credentials; no IP/UA/JS-render path reaches it. No source added (would be permanently broken).
- **#2168 (Savannah savh3.com)** — hand-coded static site, months stale (shows #1171–1174 while Meetup is on #1335), year-less dates. Kept Meetup-only; no HTML source added.
- **#2142 (RH3C #296/#297)** — both source rows have no date; HashTracks events require a date and dates must not be fabricated. The adapter already ingests dated rows correctly and will auto-ingest these once the source dates them.

### Verification
`npm run lint` ✓ · `npx tsc --noEmit` ✓ (only pre-existing `@vercel/blob` worktree-dep errors) · full test suite ✓ (312 files / 9115 tests) · adapter live-verified against 136 archive pages + homepage.

Closes #2189
Closes #2190
Closes #2168
Closes #2143
Closes #2142
