### PR TITLE
fix(gcal): RH3 leak, Reno Trail NNN: run number, RDH3 dangling hare label

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1464,7 +1464,18 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "every_6h",
       scrapeDays: 365,
-      config: { defaultKennelTag: "rvah3" },
+      // #2180 — this is the shared "Richmond, BIB, Titanic, Chain Gang H3"
+      // calendar. Without kennelPatterns every event routed to RH3, leaking
+      // sister-kennel runs (BIBH3, Chain Gang, TMFMH3) and a test entry
+      // ("FAKE HASH #12673") onto the RH3 page. RH3's own events consistently
+      // carry the "RH3" token; whitelist it and drop everything else via
+      // strictKennelRouting (returns null before kennelTag assignment, so no
+      // source-kennel-guard alerts). The sisters are served by the Meetup source.
+      config: {
+        defaultKennelTag: "rvah3",
+        kennelPatterns: [["\\b(?:RH3|RVAH3)\\b", "rvah3"]],
+        strictKennelRouting: true,
+      },
       kennelCodes: ["rvah3"],
     },
     {
@@ -4201,6 +4212,11 @@ export const SOURCES = [
           String.raw`[.]\s*Hare:\s*(.+)$`,
           String.raw`^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$`,
         ],
+        // #2146 — RDH3 TBA rows ("RDH3 XX Walkers. Hare: ") carry an empty hare,
+        // so titleHarePattern (which needs a non-empty capture) never fires and
+        // the dangling ". Hare:" label stays on the title. Strip it when no hare
+        // was extracted.
+        stripDanglingHareLabel: true,
       },
       kennelCodes: ["ch3-dk", "ch4-dk", "rdh3"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1473,7 +1473,7 @@ export const SOURCES = [
       // source-kennel-guard alerts). The sisters are served by the Meetup source.
       config: {
         defaultKennelTag: "rvah3",
-        kennelPatterns: [["\\b(?:RH3|RVAH3)\\b", "rvah3"]],
+        kennelPatterns: [[String.raw`\b(?:RH3|RVAH3)\b`, "rvah3"]],
         strictKennelRouting: true,
       },
       kennelCodes: ["rvah3"],

--- a/scripts/cleanup-rh3-calendar-leak.ts
+++ b/scripts/cleanup-rh3-calendar-leak.ts
@@ -54,6 +54,41 @@ const RVAH3 = "rvah3";
 /** RH3's own events carry this token; leaks (BIBH3/Chain Gang/TMFMH3/FAKE…) don't. */
 const RH3_TOKEN_RE = /\b(?:RH3|RVAH3)\b/i;
 
+interface LeakEvent {
+  id: string;
+  title: string | null;
+  date: Date;
+}
+
+/** Delete (or, in dry-run, count) one leaked event, classifying the keep-it
+ *  cases. Returns which bucket the event fell into. */
+async function processLeak(
+  ev: LeakEvent,
+  sourceId: string,
+  apply: boolean,
+): Promise<"deleted" | "keptForeign" | "keptUnsafe"> {
+  const label = `${ev.id} (${ev.date.toISOString().slice(0, 10)} "${ev.title ?? ""}")`;
+  if (!apply) {
+    console.log(`  WOULD DELETE ${label}`);
+    return "deleted";
+  }
+  try {
+    await deleteLeakedEvent(prisma, ev.id, ["attendances", "kennelAttendances"], sourceId);
+    console.log(`  DELETED ${label}`);
+    return "deleted";
+  } catch (err) {
+    if (err instanceof ForeignRawSourceError) {
+      console.log(`  KEPT (another source merged onto it) ${label}`);
+      return "keptForeign";
+    }
+    if (err instanceof DeleteSafetyViolationError) {
+      console.log(`  KEPT (has attendances/hares — review manually) ${label}`);
+      return "keptUnsafe";
+    }
+    throw err;
+  }
+}
+
 async function main() {
   const apply = process.argv.includes("--apply");
   console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}`);
@@ -82,37 +117,16 @@ async function main() {
   const leaks = events.filter((e) => !RH3_TOKEN_RE.test(e.title ?? ""));
   console.log(`Non-RH3 leaks to remove: ${leaks.length}`);
 
-  let deleted = 0, keptForeign = 0, keptUnsafe = 0;
+  const counts = { deleted: 0, keptForeign: 0, keptUnsafe: 0 };
   for (const ev of leaks) {
-    const day = ev.date.toISOString().slice(0, 10);
-    const label = `${ev.id} (${day} "${ev.title ?? ""}")`;
-    if (!apply) {
-      console.log(`  WOULD DELETE ${label}`);
-      deleted++;
-      continue;
-    }
-    try {
-      await deleteLeakedEvent(prisma, ev.id, ["attendances", "kennelAttendances"], source.id);
-      console.log(`  DELETED ${label}`);
-      deleted++;
-    } catch (err) {
-      if (err instanceof ForeignRawSourceError) {
-        console.log(`  KEPT (another source merged onto it) ${label}`);
-        keptForeign++;
-      } else if (err instanceof DeleteSafetyViolationError) {
-        console.log(`  KEPT (has attendances/hares — review manually) ${label}`);
-        keptUnsafe++;
-      } else {
-        throw err;
-      }
-    }
+    counts[await processLeak(ev, source.id, apply)]++;
   }
 
   console.log(
-    `\n${apply ? "Applied" : "Would"}: delete ${deleted}` +
-      (apply ? `, kept-foreign ${keptForeign}, kept-unsafe ${keptUnsafe}` : ""),
+    `\n${apply ? "Applied" : "Would"}: delete ${counts.deleted}` +
+      (apply ? `, kept-foreign ${counts.keptForeign}, kept-unsafe ${counts.keptUnsafe}` : ""),
   );
-  if (apply && deleted > 0) {
+  if (apply && counts.deleted > 0) {
     const n = await backfillLastEventDates();
     console.log(`Recomputed lastEventDate for ${n} kennel(s).`);
   }

--- a/scripts/cleanup-rh3-calendar-leak.ts
+++ b/scripts/cleanup-rh3-calendar-leak.ts
@@ -1,0 +1,126 @@
+/**
+ * One-shot cleanup for the Richmond H3 shared-calendar mis-attribution (#2180).
+ *
+ * Background:
+ *   "Richmond H3 Google Calendar"
+ *   (979d12b454…f90ae8@group.calendar.google.com) is actually the shared
+ *   "Richmond, BIB, Titanic, Chain Gang H3" calendar. With no `kennelPatterns`,
+ *   every event routed to `rvah3`, so sister-kennel runs (BIBH3, Belle Isle,
+ *   Chain Gang, TMFMH3, CHHH) and a test entry ("FAKE HASH #12673: Test Trail
+ *   101") landed on the Richmond H3 kennel page. The test event's #12673 also
+ *   polluted the "Latest Run" stat.
+ *
+ *   The seed fix adds `kennelPatterns: [["\\b(?:RH3|RVAH3)\\b", "rvah3"]]` +
+ *   `strictKennelRouting: true`, so future scrapes route only RH3-token titles
+ *   to rvah3 and drop the rest. RH3's real trails are served by the Meetup
+ *   source; the sisters by their own sources. This script removes the already-
+ *   ingested leaks (the forward fix doesn't touch them — the leaks predate the
+ *   forward scrape window and reconcile never revisits them).
+ *
+ * Strategy (delete, not reassign — the sisters aren't linked to this source):
+ *   - Find canonical `rvah3` Events that carry a RawEvent from this calendar
+ *     source AND whose title does NOT contain the RH3 / RVAH3 token (the same
+ *     whitelist the live config now enforces).
+ *   - Delete each via the race-safe helper with `forbidForeignRawSourceId` set
+ *     to this source's id: any Event a Meetup scrape has since merged onto
+ *     (foreign RawEvent present) is KEPT, not hard-deleted. Events with
+ *     attendances are also kept (logged for manual review).
+ *   - Recompute lastEventDate so the kennel header reflects the survivors.
+ *
+ * Title-match (not live re-route) is deliberate: it doesn't depend on the GCal
+ * fetch window, so it can't accidentally delete a legit *past* RH3 trail that a
+ * forward-only fetch wouldn't re-surface. Every legit RH3 event on this calendar
+ * carries "RH3" ("RH3 trail", "RH3 trail #1599 - …", "RH3 Medley of Mud #3");
+ * every leak does not — verified against the live calendar.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-rh3-calendar-leak.ts
+ *   Apply:   npx tsx scripts/cleanup-rh3-calendar-leak.ts --apply
+ *
+ * Run AFTER `npx prisma db seed` (so the new routing config is live) and ideally
+ * before the next scrape.
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
+import {
+  deleteLeakedEvent,
+  DeleteSafetyViolationError,
+  ForeignRawSourceError,
+} from "./lib/delete-leaked-event";
+
+const SOURCE_NAME = "Richmond H3 Google Calendar";
+const RVAH3 = "rvah3";
+/** RH3's own events carry this token; leaks (BIBH3/Chain Gang/TMFMH3/FAKE…) don't. */
+const RH3_TOKEN_RE = /\b(?:RH3|RVAH3)\b/i;
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}`);
+
+  const [kennel, source] = await Promise.all([
+    prisma.kennel.findUnique({ where: { kennelCode: RVAH3 }, select: { id: true } }),
+    prisma.source.findFirst({ where: { name: SOURCE_NAME }, select: { id: true } }),
+  ]);
+  if (!kennel || !source) {
+    console.error(`Missing anchor(s): rvah3=${!!kennel} source=${!!source}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // Canonical rvah3 events that have at least one RawEvent from this calendar.
+  const events = await prisma.event.findMany({
+    where: {
+      kennelId: kennel.id,
+      rawEvents: { some: { sourceId: source.id } },
+    },
+    select: { id: true, title: true, date: true },
+    orderBy: { date: "asc" },
+  });
+  console.log(`rvah3 events sourced (in part) from this calendar: ${events.length}`);
+
+  const leaks = events.filter((e) => !RH3_TOKEN_RE.test(e.title ?? ""));
+  console.log(`Non-RH3 leaks to remove: ${leaks.length}`);
+
+  let deleted = 0, keptForeign = 0, keptUnsafe = 0;
+  for (const ev of leaks) {
+    const day = ev.date.toISOString().slice(0, 10);
+    const label = `${ev.id} (${day} "${ev.title ?? ""}")`;
+    if (!apply) {
+      console.log(`  WOULD DELETE ${label}`);
+      deleted++;
+      continue;
+    }
+    try {
+      await deleteLeakedEvent(prisma, ev.id, ["attendances", "kennelAttendances"], source.id);
+      console.log(`  DELETED ${label}`);
+      deleted++;
+    } catch (err) {
+      if (err instanceof ForeignRawSourceError) {
+        console.log(`  KEPT (another source merged onto it) ${label}`);
+        keptForeign++;
+      } else if (err instanceof DeleteSafetyViolationError) {
+        console.log(`  KEPT (has attendances/hares — review manually) ${label}`);
+        keptUnsafe++;
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  console.log(
+    `\n${apply ? "Applied" : "Would"}: delete ${deleted}` +
+      (apply ? `, kept-foreign ${keptForeign}, kept-unsafe ${keptUnsafe}` : ""),
+  );
+  if (apply && deleted > 0) {
+    const n = await backfillLastEventDates();
+    console.log(`Recomputed lastEventDate for ${n} kennel(s).`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/cleanup-rh3-calendar-leak.ts
+++ b/scripts/cleanup-rh3-calendar-leak.ts
@@ -119,7 +119,9 @@ async function main() {
 }
 
 main()
-  .then(() => process.exit(0))
+  // Preserve any exit code main() set (e.g. 1 when an anchor is missing) instead
+  // of hard-coding 0 — otherwise a prerequisite failure would report success.
+  .then(() => process.exit(process.exitCode ?? 0))
   .catch((err) => {
     console.error(err);
     process.exit(1);

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -591,6 +591,12 @@ describe("extractRunNumber", () => {
     expect(extractRunNumber("A Queef-tastic trail")).toBeUndefined();
   });
 
+  it("does not mine a clock time as a 'Trail NNN' run number (#2184 codex)", () => {
+    // The colon here is an HH:MM separator, not the run-number delimiter.
+    expect(extractRunNumber("Trail 10:00 AM from the park")).toBeUndefined();
+    expect(extractRunNumber("Trail 11:30 meet at the bar")).toBeUndefined();
+  });
+
   it("bang normalization does not defeat the #30X? placeholder guard (#2089)", () => {
     expect(extractRunNumber("FCH3 #30X?!: Frisky Whisk-her")).toBeNull();
   });

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -244,6 +244,47 @@ describe("MoA2H3 Google Calendar — sister kennels silently skipped, owned by t
   });
 });
 
+// ── Richmond H3 Google Calendar — shared-calendar leak (#2180) ──
+
+describe("Richmond H3 Google Calendar — RH3-only whitelist (#2180)", () => {
+  const rvaSource = SOURCES.find((s) => s.name === "Richmond H3 Google Calendar");
+  if (!rvaSource?.config) throw new Error("Richmond H3 Google Calendar seed config missing");
+  const config = rvaSource.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it("only links rvah3 — sisters are served by the Meetup source", () => {
+    expect(rvaSource.kennelCodes).toEqual(["rvah3"]);
+    expect((config as { strictKennelRouting?: boolean }).strictKennelRouting).toBe(true);
+  });
+
+  it.each([
+    ["RH3 trail #1599 - You’re gonna die, we're following Tinder!", "RH3 trail w/ run number"],
+    ["RH3 trail", "bare RH3 trail"],
+    ["RH3 trail. Special start time.", "RH3 trail with note"],
+    ["RH3 Medley of Mud #3", "RH3 themed trail"],
+  ])("routes RH3 event %j → rvah3 (%s)", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-05-25T13:00:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe("rvah3");
+  });
+
+  it.each([
+    ["BIBH3: they're all food!", "Belle Isle Babes sister"],
+    ["BIB trail", "BIB sister"],
+    ["Chain Gang", "Chain Gang sister"],
+    ["TMFMH3", "Titanic Memorial FM sister"],
+    ["CHHH trail", "CHHH sister"],
+    ["FAKE HASH #12673: Test Trail 101", "test/junk entry polluting Latest Run"],
+  ])("drops non-RH3 event %j (%s)", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2025-10-26T21:00:00-04:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result).toBeNull();
+  });
+});
+
 // ── BJH3 Google Calendar timezone normalization (#775) ──
 
 describe("BJH3 Google Calendar — El Paso (Mountain) timezone normalization (#775)", () => {
@@ -532,6 +573,22 @@ describe("extractRunNumber", () => {
 
   it("does not invent a run number for themed PH4 titles (no #)", () => {
     expect(extractRunNumber("PH4 - Taco Flavored Pisses")).toBeUndefined();
+  });
+
+  // #2184 Reno H3 — dominant title form is "Trail NNN:" with no `#`. The `#`
+  // forms still resolve via extractHashRunNumber first.
+  it.each([
+    ["Trail 802: Sir Rubs a lot's short n sweet trail", 802, "Trail NNN:"],
+    ["Trail 796: Queef's Easter Trail", 796, "Trail NNN:"],
+    ["Trail #802: With the hash", 802, "Trail #NNN: (via # path)"],
+    ["Sloppy Trail #46 Kings Canyon", 46, "mid-title #NN (via # path)"],
+  ])("Reno summary %j → run %i (%s)", (summary, expected) => {
+    expect(extractRunNumber(summary)).toBe(expected);
+  });
+
+  it("does not match 'Trail' titles without a leading 'Trail NNN:' (#2184)", () => {
+    expect(extractRunNumber("Truckee trail with Beastie Ality & Bullshitwhistle")).toBeUndefined();
+    expect(extractRunNumber("A Queef-tastic trail")).toBeUndefined();
   });
 
   it("bang normalization does not defeat the #30X? placeholder guard (#2089)", () => {
@@ -1756,6 +1813,59 @@ describe("titleHarePattern array — multi-pattern fallback (#1208/#1209/#1221)"
     );
     expect(result).not.toBeNull();
     expect(result!.hares).toBe("Lust Jucie");
+  });
+
+  // #2146 — RDH3 TBA rows ("RDH3 XX Walkers. Hare: ") carry an empty hare, so
+  // the titleHarePattern (non-empty capture) never fires. stripDanglingHareLabel
+  // removes the dangling ". Hare:" label and leaves hares empty.
+  it.each([
+    ["RDH3 XX Walkers. Hare: ", "RDH3 XX Walkers", "Walkers TBA"],
+    ["RDH3 xx Runners. Hare: ", "RDH3 xx Runners", "Runners TBA"],
+  ])("Copenhagen: RDH3 empty-hare %j → title %j (%s)", (summary, expectedTitle) => {
+    const patterns = [
+      /[.]\s*Hare:\s*(.+)$/i, // NOSONAR — anchored, single capture, test fixture
+      /^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$/i, // NOSONAR — anchored, char-class delimited, test fixture
+    ];
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary, start: { dateTime: "2026-09-13T10:00:00+02:00" } }),
+      {
+        defaultKennelTag: "ch3-dk",
+        kennelPatterns: [["RDH3|Rabid", "rdh3"]],
+        stripDanglingHareLabel: true,
+      },
+      {
+        compiledTitleHarePatterns: patterns,
+        compiledKennelPatterns: [[/RDH3|Rabid/i, "rdh3"] as const],
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe(expectedTitle);
+    expect(result!.hares).toBeUndefined();
+  });
+
+  it("Copenhagen: stripDanglingHareLabel leaves filled-hare RDH3 titles intact (#2146)", () => {
+    const patterns = [
+      /[.]\s*Hare:\s*(.+)$/i, // NOSONAR — anchored, single capture, test fixture
+      /^CH3\s+\d+\s+-\s+[^-]+\s+-\s+(.+)$/i, // NOSONAR — anchored, char-class delimited, test fixture
+    ];
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "RDH3 136 Runners. Hare: Captain Shitshow",
+        start: { dateTime: "2026-06-14T11:00:00+02:00" },
+      }),
+      {
+        defaultKennelTag: "ch3-dk",
+        kennelPatterns: [["RDH3|Rabid", "rdh3"]],
+        stripDanglingHareLabel: true,
+      },
+      {
+        compiledTitleHarePatterns: patterns,
+        compiledKennelPatterns: [[/RDH3|Rabid/i, "rdh3"] as const],
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("RDH3 136 Runners");
+    expect(result!.hares).toBe("Captain Shitshow");
   });
 });
 

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -50,11 +50,14 @@ const LEADING_HASH_WORD_RE = /^Hash\s+(?:#\s*)?(\d{2,})\s*:/i;
  * the parser only saw the `#NN` shape, so every "Trail NNN" event extracted no
  * run number. Colon-anchored and start-anchored — the same tight shape as
  * LEADING_HASH_WORD_RE — so it stays additive across the ~40 GCal sources: only
- * a title that literally starts with "Trail NNN:" matches. The `#`-prefixed
- * variants ("Trail #802:", "Sloppy Trail #46") already resolve through the
- * shared `extractHashRunNumber` delimiter guard before this is reached.
+ * a title that literally starts with "Trail NNN:" matches. The trailing
+ * `(?!\d)` rejects a clock time ("Trail 10:00 AM …") — the colon there is a
+ * time separator, not the run-number delimiter — so the global pattern can't
+ * mine an hour as a run number. The `#`-prefixed variants ("Trail #802:",
+ * "Sloppy Trail #46") already resolve through the shared `extractHashRunNumber`
+ * delimiter guard before this is reached.
  */
-const LEADING_TRAIL_WORD_RE = /^Trail\s+(?:#\s*)?(\d{2,})\s*:/i;
+const LEADING_TRAIL_WORD_RE = /^Trail\s+(?:#\s*)?(\d{2,})\s*:(?!\d)/i;
 
 /** Run the capture-group-1 digits of a leading-word run-number regex (e.g.
  *  LEADING_HASH_WORD_RE / LEADING_TRAIL_WORD_RE) against `summary`, returning the

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -646,9 +646,10 @@ const TITLE_HARED_BY_RE = /\s+hared by\s+(.+)$/i;
  * Trailing dangling hare label with no name ("…Walkers. Hare:" / "…Walkers.
  * Hare") — stripped only under `stripDanglingHareLabel` when no hare was
  * extracted (#2146 RDH3). The leading `\.` is required so a title that simply
- * ends in the word "Hare" (no period separator) is never truncated. ReDoS-safe:
- * each `\s*` sits between literals, no alternation adjacency. */
-const TRAILING_EMPTY_HARE_LABEL_RE = /\s*\.\s*Hares?\s*:?\s*$/i;
+ * ends in the word "Hare" (no period separator) is never truncated.
+ * `(?::\s*)?` groups the colon+trailing-space as an atomic optional so the
+ * two `\s*` on either side of `:?` are never adjacent (fixes ReDoS S5852). */
+const TRAILING_EMPTY_HARE_LABEL_RE = /\s*\.\s*Hares?\s*(?::\s*)?$/i;
 /** Detect address-like titles (street number + road type + city) */
 const ADDRESS_AS_TITLE_RE = /^\d+\s+\w+.+?(?:Road|Rd|Street|St|Avenue|Ave|Drive|Dr|Boulevard|Blvd|Way|Lane|Ln|Court|Ct|Place|Pl|Parkway|Pkwy|Highway|Hwy),/i;
 /** Detect email addresses in titles (recruitment/placeholder summaries) */

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -45,6 +45,28 @@ const DEFAULT_RUN_NUMBER_PATTERNS = [
 const LEADING_HASH_WORD_RE = /^Hash\s+(?:#\s*)?(\d{2,})\s*:/i;
 
 /**
+ * Leading "Trail NNN:" run marker that omits the `#` (#2184 Reno H3 — "Trail
+ * 802: Sir Rubs a lot's short n sweet trail"). Reno's dominant title form, but
+ * the parser only saw the `#NN` shape, so every "Trail NNN" event extracted no
+ * run number. Colon-anchored and start-anchored — the same tight shape as
+ * LEADING_HASH_WORD_RE — so it stays additive across the ~40 GCal sources: only
+ * a title that literally starts with "Trail NNN:" matches. The `#`-prefixed
+ * variants ("Trail #802:", "Sloppy Trail #46") already resolve through the
+ * shared `extractHashRunNumber` delimiter guard before this is reached.
+ */
+const LEADING_TRAIL_WORD_RE = /^Trail\s+(?:#\s*)?(\d{2,})\s*:/i;
+
+/** Run the capture-group-1 digits of a leading-word run-number regex (e.g.
+ *  LEADING_HASH_WORD_RE / LEADING_TRAIL_WORD_RE) against `summary`, returning the
+ *  positive integer or `undefined`. */
+function matchLeadingWordRunNumber(re: RegExp, summary: string): number | undefined {
+  const m = re.exec(summary);
+  if (!m) return undefined;
+  const n = Number.parseInt(m[1], 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
  * Extract run number from summary (e.g. "#2781") or description.
  * Always checks summary first with `#(\d+)`. Then checks description with
  * custom patterns (if provided) or default patterns.
@@ -77,13 +99,13 @@ export function extractRunNumber(
     ?? (summary.includes("!") ? extractHashRunNumber(summary.replaceAll("!", " ")) : undefined);
   if (fromSummary !== undefined) return fromSummary;
 
-  // 1b. Leading "Hash NNNN:" without the `#` (#2007 PGH H3). Colon-anchored
-  // so a year-shaped digit run in prose can't false-match.
-  const leadingHashWord = LEADING_HASH_WORD_RE.exec(summary);
-  if (leadingHashWord) {
-    const n = Number.parseInt(leadingHashWord[1], 10);
-    if (Number.isFinite(n) && n > 0) return n;
-  }
+  // 1b/1c. Leading "<word> NNNN:" run markers that omit the `#`, colon-anchored
+  // so a year-shaped digit run in prose can't false-match: "Hash NNNN:" (#2007
+  // PGH H3) and "Trail NNN:" (#2184 Reno H3).
+  const fromLeadingWord =
+    matchLeadingWordRunNumber(LEADING_HASH_WORD_RE, summary)
+    ?? matchLeadingWordRunNumber(LEADING_TRAIL_WORD_RE, summary);
+  if (fromLeadingWord !== undefined) return fromLeadingWord;
 
   // 2. Summary placeholder takes precedence over description fallback. A
   // partial retitle (`#30: …` → `#30X?: …` while description still says
@@ -620,6 +642,13 @@ const TITLE_DASH_HARE_RE = /\s+-\s+Hares?:\s*(.+)$/i;
 const TITLE_DASH_LOCATION_TBD_RE = /^(.+?)\s+-\s+Location\s+(?:TBD|TBA|TBC)$/i;
 /** "hared by Name" suffix in title (Voodoo H3 format) */
 const TITLE_HARED_BY_RE = /\s+hared by\s+(.+)$/i;
+/**
+ * Trailing dangling hare label with no name ("…Walkers. Hare:" / "…Walkers.
+ * Hare") — stripped only under `stripDanglingHareLabel` when no hare was
+ * extracted (#2146 RDH3). The leading `\.` is required so a title that simply
+ * ends in the word "Hare" (no period separator) is never truncated. ReDoS-safe:
+ * each `\s*` sits between literals, no alternation adjacency. */
+const TRAILING_EMPTY_HARE_LABEL_RE = /\s*\.\s*Hares?\s*:?\s*$/i;
 /** Detect address-like titles (street number + road type + city) */
 const ADDRESS_AS_TITLE_RE = /^\d+\s+\w+.+?(?:Road|Rd|Street|St|Avenue|Ave|Drive|Dr|Boulevard|Blvd|Way|Lane|Ln|Court|Ct|Place|Pl|Parkway|Pkwy|Highway|Hwy),/i;
 /** Detect email addresses in titles (recruitment/placeholder summaries) */
@@ -1032,6 +1061,16 @@ interface CalendarSourceConfig {
    * every other titleHarePattern kennel.
    */
   alwaysStripTitleHareSpan?: boolean;
+  /**
+   * When true, strip a trailing dangling hare label ("…Walkers. Hare:" /
+   * "…Walkers. Hare") from the title when NO hare was extracted (#2146 RDH3:
+   * TBA rows are "RDH3 XX Walkers. Hare: " with an empty hare, so the
+   * `titleHarePattern` — which requires a non-empty capture — never fires and
+   * leaves the label behind). Opt-in per source; the strip requires a literal
+   * period before "Hare" so a title that genuinely ends in the word "Hare"
+   * isn't truncated.
+   */
+  stripDanglingHareLabel?: boolean;
   /**
    * Regex strings applied as `title.replace(re, "")` in sequence after hare
    * extraction and before the `defaultTitle` fallback. Compiled with `i`
@@ -1832,6 +1871,13 @@ export function buildRawEventFromGCalItem(
     const haredBy = haredByMatch[1].trim();
     if (!hares && looksLikeHareName(haredBy)) hares = haredBy;
     title = title.slice(0, haredByMatch.index).trim();
+  }
+
+  // #2146 RDH3 — TBA rows ("RDH3 XX Walkers. Hare: ") leave a dangling ". Hare:"
+  // label: the titleHarePattern requires a non-empty capture so it never fires.
+  // Strip the trailing label only when no hare was extracted (opt-in per source).
+  if (sourceConfig?.stripDanglingHareLabel && !hares) {
+    title = title.replace(TRAILING_EMPTY_HARE_LABEL_RE, "").trim();
   }
 
   // " - Location TBD" suffix: "<title> - Location TBD" (EWH3 placeholder events).

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -259,10 +259,16 @@ export default async function KennelDetailPage({
   // Stats — use unique date count for resilience against duplicate canonical events
   const uniqueDates = new Set(events.map(e => e.date.toISOString().split("T")[0]));
   const totalEvents = uniqueDates.size;
-  const currentRunNumber =
-    upcoming.find((e) => e.runNumber != null)?.runNumber ??
-    past.find((e) => e.runNumber != null)?.runNumber ??
-    null;
+  // "Latest Run" = highest run number among recent events (upcoming + the most
+  // recent past), so a low-numbered side-series ("Sloppy Trail #46") doesn't
+  // override the main sequence ("Trail 802") just by being the most recent date
+  // (#2184). Windowed to bound stale-outlier risk; CANCELLED events are already
+  // excluded by the events query above.
+  const RECENT_PAST_FOR_RUN = 12;
+  const recentRunNumbers = [...upcoming, ...past.slice(0, RECENT_PAST_FOR_RUN)]
+    .map((e) => e.runNumber)
+    .filter((n): n is number => n != null);
+  const currentRunNumber = recentRunNumbers.length ? Math.max(...recentRunNumbers) : null;
   const oldestEventDate = events.length > 0 ? events[0].date.toISOString() : null;
   const nextRunDate = upcoming.length > 0 ? upcoming[0].date : null;
 


### PR DESCRIPTION
Three independent Google-Calendar quick-win fixes, all **live-verified** against the production Calendar API (read-only fetch through the actual adapter).

## #2180 — RH3 shared-calendar leak
The "Richmond, BIB, Titanic, Chain Gang H3" calendar (`979d12b4…@group.calendar.google.com`) had no `kennelPatterns`, so **every** event routed to `rvah3` — leaking sister-kennel runs (BIBH3, Chain Gang, TMFMH3) and a junk test entry (`FAKE HASH #12673: Test Trail 101`, which also polluted the "Latest Run" stat).

- **Fix:** whitelist `kennelPatterns: [["\\b(?:RH3|RVAH3)\\b", "rvah3"]]` + `strictKennelRouting: true` on the Richmond source. RH3's own events all carry the `RH3` token; everything else is dropped before kennelTag assignment (no source-kennel-guard alerts). Sisters are served by the Meetup source.
- **Live-verified:** the calendar now emits 5 events, all `rvah3`, all genuine "RH3 trail…"; every leak drops.
- **Cleanup:** `scripts/cleanup-rh3-calendar-leak.ts` removes the already-ingested leaks via the race-safe `deleteLeakedEvent` helper (`forbidForeignRawSourceId` keeps any event a Meetup scrape merged onto). Dry-run by default; run with `--apply` post-merge after `npx prisma db seed`.

## #2184 — Reno "Trail NNN:" run number + Latest-Run stat
The parser only handled `#NN`; Reno's dominant form is `Trail NNN:` (e.g. `Trail 802: …`), which extracted nothing.

- **Parser:** add a colon-anchored `LEADING_TRAIL_WORD_RE`, mirroring the existing `LEADING_HASH_WORD_RE` (both folded into a shared `matchLeadingWordRunNumber` helper). Additive across all GCal sources; `#`-forms still resolve via `extractHashRunNumber` first.
- **Latest-Run derivation:** the kennel page picked the most-recent-*by-date* run number — the low-numbered `Sloppy Trail #46` side-series — instead of the main sequence. Switched to the highest run number among recent events (windowed; cancelled events already excluded). Reno now shows **802**, not 46.
- **Live-verified:** `Trail 796:`→796 … `Trail 802:`→802, `Sloppy Trail #46`→46.

## #2146 — RDH3 dangling ". Hare:" label
TBA rows are `RDH3 XX Walkers. Hare: ` (empty hare); `titleHarePattern` requires a non-empty capture so it never fires, leaving `. Hare:` on the title.

- **Fix:** opt-in `stripDanglingHareLabel` config knob (set on the Copenhagen source) strips the trailing label when no hare was extracted. The strip requires a literal period before "Hare" so a title genuinely ending in the word "Hare" is never truncated.
- **Live-verified:** all 20 TBA events now emit clean `RDH3 XX Walkers` / `RDH3 xx Runners`; no title contains a dangling `. Hare`. Filled rows are untouched.

## Verification
- `npm run lint` (0 errors), `npx tsc --noEmit` (clean), `npm test` (9132 passed).
- New unit tests for all three (real production summaries as fixtures).
- `/codex:adversarial-review`: approve, no material findings. `/simplify`: applied (deduped the two leading-word regex blocks).

## Notes
- Known limitation (out of scope): older dash-form Reno titles (`Trail 774 - …`) aren't captured by the colon-anchored matcher; they're historical and don't affect the reported "Latest Run" symptom.
- Does not touch `prisma/seed-data/kennels.ts` (separate workstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #2180
Closes #2184
Closes #2146
