### PR TITLE
feat(meetup): trail-anchored run-number extraction for Richmond H3 (rvah3)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1515,6 +1515,17 @@ export const SOURCES = [
       config: {
         groupUrlname: "richmond-hash-house-harriers",
         kennelTag: "rvah3",
+        // RH3 + its sisters title their trails "RH3 # 1704", "BIBH3 Trail #251",
+        // "Chain Gang Trail #42" — opt into run-number extraction so the kennel
+        // "Latest Run" stat populates. This is an aggregate feed that also carries
+        // non-trail socials ("Inter-Kennel Drinking Practice #15"), so anchor the
+        // extractor to trail context (a leading kennel-code token before "#", or
+        // "Trail #") via runNumberTitlePattern — the generic first-`#` parser
+        // would otherwise mint run #15 from the social, and runNumber feeds
+        // same-day merge identity, not just the stat. TMFMH3's "Trail 299" form
+        // (no `#`) stays null either way — no regression.
+        extractRunNumber: true,
+        runNumberTitlePattern: String.raw`(?:^\s*[A-Za-z0-9]{2,8}\s*#|\btrail\b\s*#)\s*(\d+)`,
         // Word-boundary patterns (not anchored) so prefixed Meetup titles like
         // "ANNUAL GENERAL MEEING: Chain Gang ... Trail #40" route correctly.
         // Closes #992. Alt names (Belle Isle, Titanic) included since the same

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1519,13 +1519,12 @@ export const SOURCES = [
         // "Chain Gang Trail #42" — opt into run-number extraction so the kennel
         // "Latest Run" stat populates. This is an aggregate feed that also carries
         // non-trail socials ("Inter-Kennel Drinking Practice #15"), so anchor the
-        // extractor to trail context (a leading kennel-code token before "#", or
-        // "Trail #") via runNumberTitlePattern — the generic first-`#` parser
-        // would otherwise mint run #15 from the social, and runNumber feeds
-        // same-day merge identity, not just the stat. TMFMH3's "Trail 299" form
-        // (no `#`) stays null either way — no regression.
+        // extractor to trail context (leading kennel-code token before "#", or
+        // "Trail #") — the generic first-`#` parser would otherwise mint run #15
+        // from the social, and runNumber feeds same-day merge identity, not just
+        // the stat. TMFMH3's "Trail 299" form (no `#`) stays null either way.
         extractRunNumber: true,
-        runNumberTitlePattern: String.raw`(?:^\s*[A-Za-z0-9]{2,8}\s*#|\btrail\b\s*#)\s*(\d+)`,
+        anchorTrailRunNumber: true,
         // Word-boundary patterns (not anchored) so prefixed Meetup titles like
         // "ANNUAL GENERAL MEEING: Chain Gang ... Trail #40" route correctly.
         // Closes #992. Alt names (Belle Isle, Titanic) included since the same

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle, detectBoilerplateBlocks, stripBoilerplateBlocks, extractRunNumberFromMeetupDescription } from "./adapter";
 import { normalizeDescriptionKey } from "../utils";
+import { SOURCES } from "../../../prisma/seed-data/sources";
 import type { Source } from "@/generated/prisma/client";
 
 vi.mock("../safe-fetch", () => ({
@@ -1911,6 +1912,59 @@ describe("buildRawEventFromApollo — runNumber (#1562 Miami H3)", () => {
     };
     const event = buildRawEventFromApollo(ev, emptyState, "mia-h3");
     expect(event.runNumber).toBeUndefined();
+  });
+});
+
+// ── buildRawEventFromApollo — runNumber (Richmond H3 + sisters) ──
+
+describe("buildRawEventFromApollo — runNumber (Richmond H3 rvah3, anchored)", () => {
+  const emptyState = {} as Record<string, Record<string, unknown>>;
+  const OPT_IN = true;
+  // The exact anchor Richmond's seed config ships: a leading kennel-code token
+  // before "#", or "Trail #". Excludes non-trail "#N" tokens.
+  const richmondCfg = (SOURCES.find((s) => s.name === "Richmond H3 Meetup")?.config ?? {}) as {
+    runNumberTitlePattern?: string;
+    extractRunNumber?: boolean;
+  };
+  const titleRe = new RegExp(richmondCfg.runNumberTitlePattern ?? "(?!)", "i");
+  const build = (title: string, tag: string) =>
+    buildRawEventFromApollo(
+      { __typename: "Event", id: title, title, dateTime: "2026-06-28T13:00:00-04:00" },
+      emptyState, tag, undefined, OPT_IN, undefined, { runNumberTitleRe: titleRe },
+    );
+
+  it.each([
+    ["RH3 # 1704 - Medley of Mud #3 I-Feel Tower, Biff!", 1704],
+    ["RH3 # 1700 NASA", 1700],
+    ["RH3 # 1703", 1703],
+    ["RH3 Trail #1696: Rock N Roll Don't Die Doh", 1696],
+    ["RH3 Trail # 1694: Gladiater", 1694],
+    // Anchor captures the "RH3 #" run number, not the trailing theme "#3"/"#2".
+    ["RH3 # 1702 - MEDLEY OF MUD #2 BananTa", 1702],
+  ])("extracts the RH3 trail run number from %j", (title, expected) => {
+    expect(build(title, "rvah3").runNumber).toBe(expected);
+  });
+
+  it("extracts sister-kennel run numbers (BIBH3 / Chain Gang)", () => {
+    expect(build("BIBH3 Trail #251 - DRAG RACE!!", "bibh3").runNumber).toBe(251);
+    expect(build("Chain Gang Trail #42", "chain-gang-hhh").runNumber).toBe(42);
+  });
+
+  it("does NOT mint a run number for the non-trail 'Drinking Practice #15' social", () => {
+    // The whole reason for the anchor: runNumber feeds same-day merge identity,
+    // so a non-trail "#15" must not become a canonical run number. Without the
+    // anchor the generic parser would grab 15 (asserted below).
+    expect(build("Inter-Kennel Drinking Practice #15 hosted by RH3!", "rvah3").runNumber).toBeUndefined();
+  });
+
+  it("the unanchored generic parser WOULD grab the bogus 15 — confirming the anchor is load-bearing", () => {
+    const ev = { __typename: "Event", id: "dp", title: "Inter-Kennel Drinking Practice #15 hosted by RH3!", dateTime: "2026-06-15T18:30:00-04:00" };
+    expect(buildRawEventFromApollo(ev, emptyState, "rvah3", undefined, OPT_IN).runNumber).toBe(15);
+  });
+
+  it("the Richmond H3 Meetup seed source opts in with a trail-anchored pattern", () => {
+    expect(richmondCfg.extractRunNumber).toBe(true);
+    expect(typeof richmondCfg.runNumberTitlePattern).toBe("string");
   });
 });
 

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1920,17 +1920,16 @@ describe("buildRawEventFromApollo — runNumber (#1562 Miami H3)", () => {
 describe("buildRawEventFromApollo — runNumber (Richmond H3 rvah3, anchored)", () => {
   const emptyState = {} as Record<string, Record<string, unknown>>;
   const OPT_IN = true;
-  // The exact anchor Richmond's seed config ships: a leading kennel-code token
-  // before "#", or "Trail #". Excludes non-trail "#N" tokens.
+  // Richmond opts into the trail-context anchor (a leading kennel-code token
+  // before "#", or "Trail #"); non-trail "#N" tokens are excluded.
   const richmondCfg = (SOURCES.find((s) => s.name === "Richmond H3 Meetup")?.config ?? {}) as {
-    runNumberTitlePattern?: string;
+    anchorTrailRunNumber?: boolean;
     extractRunNumber?: boolean;
   };
-  const titleRe = new RegExp(richmondCfg.runNumberTitlePattern ?? "(?!)", "i");
   const build = (title: string, tag: string) =>
     buildRawEventFromApollo(
       { __typename: "Event", id: title, title, dateTime: "2026-06-28T13:00:00-04:00" },
-      emptyState, tag, undefined, OPT_IN, undefined, { runNumberTitleRe: titleRe },
+      emptyState, tag, undefined, OPT_IN, undefined, { anchorTrail: true },
     );
 
   it.each([
@@ -1962,9 +1961,9 @@ describe("buildRawEventFromApollo — runNumber (Richmond H3 rvah3, anchored)", 
     expect(buildRawEventFromApollo(ev, emptyState, "rvah3", undefined, OPT_IN).runNumber).toBe(15);
   });
 
-  it("the Richmond H3 Meetup seed source opts in with a trail-anchored pattern", () => {
+  it("the Richmond H3 Meetup seed source opts in with the trail anchor", () => {
     expect(richmondCfg.extractRunNumber).toBe(true);
-    expect(typeof richmondCfg.runNumberTitlePattern).toBe("string");
+    expect(richmondCfg.anchorTrailRunNumber).toBe(true);
   });
 });
 

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1949,6 +1949,15 @@ describe("buildRawEventFromApollo — runNumber (Richmond H3 rvah3, anchored)", 
     expect(build("Chain Gang Trail #42", "chain-gang-hhh").runNumber).toBe(42);
   });
 
+  it.each([
+    "RH3 #1704TBD",   // placeholder suffix glued to digits
+    "RH3 Trail #30X?", // explicit unknown-run marker
+  ])("rejects placeholder/ambiguous run tokens via the shared delimiter guard: %j", (title) => {
+    // The anchor only locates the "#"; extractHashRunNumber parses the slice, so
+    // its delimiter guard still drops these (Codex PR #2207 review).
+    expect(build(title, "rvah3").runNumber).toBeUndefined();
+  });
+
   it("does NOT mint a run number for the non-trail 'Drinking Practice #15' social", () => {
     // The whole reason for the anchor: runNumber feeds same-day merge identity,
     // so a non-trail "#15" must not become a canonical run number. Without the

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -2,7 +2,6 @@ import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
-import isSafeRegex from "safe-regex2";
 import { validateSourceConfig, stripHtmlTags, buildDateWindow, extractHashRunNumber, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS, splitDescriptionBlocks, normalizeDescriptionKey } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { extractHares as extractHaresFromDescription } from "../hare-extraction";
@@ -94,19 +93,17 @@ export interface MeetupConfig {
    */
   runNumberPrefix?: string;
   /**
-   * Optional title run-number anchor for aggregate feeds. When set (and
-   * `extractRunNumber` is true), the run number is read from capture group 1 of
-   * this pattern instead of the generic first-`#NNN`. Lets a source that mixes
-   * trail titles with non-trail socials extract only anchored trail forms and
-   * skip stray "#N" tokens that would otherwise become a bogus runNumber — and
-   * runNumber participates in same-day matching / fuzzy dedup, not just the
-   * kennel-page stat. Richmond H3's feed carries "RH3 # 1704" / "BIBH3 Trail
-   * #251" trails alongside "Inter-Kennel Drinking Practice #15"; the anchor
-   * keeps the social from minting run #15. Compiled case-insensitively and
-   * validated for ReDoS safety; an unsafe/malformed pattern is ignored (falls
-   * back to the generic parser).
+   * Restrict title run-number extraction to trail context (requires
+   * `extractRunNumber`). When set, the number is read from `TITLE_TRAIL_RUN_RE`
+   * — a leading kennel-code token before "#", or "Trail #" — instead of the
+   * generic first-`#NNN`, then falls through to the description path on no
+   * match. For aggregate feeds that mix trail titles with non-trail socials:
+   * Richmond H3 carries "RH3 # 1704" / "BIBH3 Trail #251" trails alongside
+   * "Inter-Kennel Drinking Practice #15", and runNumber participates in same-day
+   * matching / fuzzy dedup (not just the kennel-page stat), so the social must
+   * not mint run #15.
    */
-  runNumberTitlePattern?: string;
+  anchorTrailRunNumber?: boolean;
 }
 
 /** Shape of an event entry in Meetup's __NEXT_DATA__ Apollo state. */
@@ -465,28 +462,13 @@ function compileKennelPatterns(
 }
 
 /**
- * Compile the optional per-source `runNumberTitlePattern`. Validated for ReDoS
- * safety (config can be admin-edited in the DB) and skipped if unsafe/malformed
- * so a bad pattern degrades to the generic parser rather than throwing.
- */
-function compileRunNumberTitlePattern(pattern?: string): RegExp | undefined {
-  if (!pattern) return undefined;
-  // isSafeRegex compiles the pattern internally, so a syntactically invalid
-  // string throws here too — keep the check inside the try so a malformed config
-  // degrades to the generic parser instead of crashing the fetch.
-  try {
-    // nosemgrep: detect-non-literal-regexp — protected by isSafeRegex() below
-    if (!isSafeRegex(pattern)) {
-      console.warn(`Unsafe runNumberTitlePattern skipped (ReDoS): "${pattern}"`);
-      return undefined;
-    }
-    // nosemgrep: detect-non-literal-regexp — validated ReDoS-safe immediately above
-    return new RegExp(pattern, "i");
-  } catch (e) {
-    console.warn(`Malformed runNumberTitlePattern skipped: "${pattern}"`, e);
-    return undefined;
-  }
-}
+ * Trail-context run-number anchor for aggregate Meetup feeds (opt in via
+ * `anchorTrailRunNumber`). Capture group 1 is the run number when it follows
+ * either a leading kennel-code token + "#" ("RH3 # 1704") or "Trail #"
+ * ("BIBH3 Trail #251"). A non-trail social ("Inter-Kennel Drinking Practice
+ * #15") matches neither, so it mints no run number. A module-level literal
+ * (not compiled from config) so it's ReDoS-safe by construction. */
+const TITLE_TRAIL_RUN_RE = /(?:^\s*[A-Za-z0-9]{2,8}\s*#|\btrail\b\s*#)\s*(\d+)/i; // NOSONAR S5852/S5843 — literal, bounded {2,8}, no overlapping quantifiers
 
 /**
  * Meetup-style hare-line fallback: scan the first few description lines for
@@ -667,20 +649,20 @@ function resolveMeetupHares(
  * the parsing. Returns undefined when extraction is off or no number is found.
  */
 /**
- * Extract a run number from a Meetup title. With `runNumberTitleRe` (aggregate
- * feeds) only a trail-context "#N" in capture group 1 counts — a no-match
- * returns undefined so the caller falls through to the description path rather
- * than the unanchored generic parser (the anchor is the whole point). Without
- * it, the generic `extractHashRunNumber` runs, after normalizing any
+ * Extract a run number from a Meetup title. With `anchorTrail` (aggregate feeds)
+ * only a trail-context "#N" (capture group 1 of `TITLE_TRAIL_RUN_RE`) counts — a
+ * no-match returns undefined so the caller falls through to the description path
+ * rather than the unanchored generic parser (the anchor is the whole point).
+ * Without it, the generic `extractHashRunNumber` runs, after normalizing any
  * `runNumberPrefix` ("R*n", #1975) to "#".
  */
 function runNumberFromTitle(
   title: string | undefined,
-  runNumberTitleRe: RegExp | undefined,
+  anchorTrail: boolean,
   runNumberPrefix: string | undefined,
 ): number | undefined {
-  if (runNumberTitleRe) {
-    const m = title ? runNumberTitleRe.exec(title) : null;
+  if (anchorTrail) {
+    const m = title ? TITLE_TRAIL_RUN_RE.exec(title) : null;
     if (!m?.[1]) return undefined;
     const n = Number.parseInt(m[1], 10);
     return Number.isFinite(n) && n > 0 ? n : undefined;
@@ -694,14 +676,14 @@ function resolveRunNumber(
   description: string | null | undefined,
   extractRunNumber: boolean,
   runNumberPrefix: string | undefined,
-  runNumberTitleRe?: RegExp,
+  anchorTrail = false,
 ): number | undefined {
   // Title extraction stays opt-in (#1562): free-form Meetup titles can promote
   // non-hash tokens ("Pub Crawl #2") into a runNumber that then poisons
   // fingerprinting. Only sources that confirm unambiguous title conventions
   // set `extractRunNumber: true`.
   if (extractRunNumber) {
-    const fromTitle = runNumberFromTitle(title, runNumberTitleRe, runNumberPrefix);
+    const fromTitle = runNumberFromTitle(title, anchorTrail, runNumberPrefix);
     if (fromTitle !== undefined) return fromTitle;
   }
   // Description extraction is default-on but anchored to a "trail" line so it
@@ -761,10 +743,9 @@ export function buildRawEventFromApollo(
   // and `preCleaned` carries the already-computed cleaned description (wrapped so
   // a legitimately-`undefined` value is distinguishable from "not supplied" →
   // recompute) to avoid a second heavy cleanMeetupDescription (cheerio) pass per
-  // event. `runNumberTitleRe` is the compiled per-source title run-number anchor
-  // (see `runNumberTitlePattern`), passed in pre-compiled so it isn't rebuilt per
-  // event.
-  opts?: { blocks?: Set<string>; preCleaned?: { value: string | undefined }; runNumberTitleRe?: RegExp },
+  // event. `anchorTrail` opts the title run-number extractor into the
+  // trail-context anchor (see `anchorTrailRunNumber`).
+  opts?: { blocks?: Set<string>; preCleaned?: { value: string | undefined }; anchorTrail?: boolean },
 ): RawEventData {
   const { date, startTime } = ev.dateTime
     ? extractDateTime(ev.dateTime)
@@ -815,7 +796,7 @@ export function buildRawEventFromApollo(
     // Use finalDesc (Apollo-ref-resolved + boilerplate-stripped), not the raw
     // ev.description, so a "$44" cache ref or a stale group-template "Trail #N"
     // can't drive the run number (#2200 review).
-    runNumber: resolveRunNumber(ev.title, finalDesc, extractRunNumber, runNumberPrefix, opts?.runNumberTitleRe),
+    runNumber: resolveRunNumber(ev.title, finalDesc, extractRunNumber, runNumberPrefix, opts?.anchorTrail),
     description: finalDesc,
     hares,
     location: venueInfo.location,
@@ -1001,7 +982,7 @@ export class MeetupAdapter implements SourceAdapter {
     const boilerplateBlocks = detectBoilerplateBlocks(cleanedDescriptions);
 
     const compiledPatterns = compileKennelPatterns(config.kennelPatterns);
-    const compiledRunNumberTitleRe = compileRunNumberTitlePattern(config.runNumberTitlePattern);
+    const anchorTrailRunNumber = config.anchorTrailRunNumber === true;
     let cancelledSkipped = 0;
     let adminNoticeSkipped = 0;
     let boilerplateDescriptionsDropped = 0;
@@ -1042,7 +1023,7 @@ export class MeetupAdapter implements SourceAdapter {
         // Reuse the pre-pass cleaned value (index-aligned) so the builder
         // doesn't re-run the heavy cleanMeetupDescription/cheerio parse.
         const cleanedBefore = cleanedDescriptions[i];
-        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, { blocks: boilerplateBlocks, preCleaned: { value: cleanedBefore }, runNumberTitleRe: compiledRunNumberTitleRe });
+        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, { blocks: boilerplateBlocks, preCleaned: { value: cleanedBefore }, anchorTrail: anchorTrailRunNumber });
         // Count events whose description had boilerplate removed (fully nulled
         // or partially stripped) vs. its pre-strip cleaned value.
         if (cleanedBefore !== undefined && rawEvent.description !== cleanedBefore) {

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -471,12 +471,15 @@ function compileKennelPatterns(
  */
 function compileRunNumberTitlePattern(pattern?: string): RegExp | undefined {
   if (!pattern) return undefined;
-  // nosemgrep: detect-non-literal-regexp — protected by isSafeRegex() below
-  if (!isSafeRegex(pattern)) {
-    console.warn(`Unsafe runNumberTitlePattern skipped (ReDoS): "${pattern}"`);
-    return undefined;
-  }
+  // isSafeRegex compiles the pattern internally, so a syntactically invalid
+  // string throws here too — keep the check inside the try so a malformed config
+  // degrades to the generic parser instead of crashing the fetch.
   try {
+    // nosemgrep: detect-non-literal-regexp — protected by isSafeRegex() below
+    if (!isSafeRegex(pattern)) {
+      console.warn(`Unsafe runNumberTitlePattern skipped (ReDoS): "${pattern}"`);
+      return undefined;
+    }
     // nosemgrep: detect-non-literal-regexp — validated ReDoS-safe immediately above
     return new RegExp(pattern, "i");
   } catch (e) {
@@ -663,6 +666,29 @@ function resolveMeetupHares(
  * in the token needs no escaping — and the shared `extractHashRunNumber` does
  * the parsing. Returns undefined when extraction is off or no number is found.
  */
+/**
+ * Extract a run number from a Meetup title. With `runNumberTitleRe` (aggregate
+ * feeds) only a trail-context "#N" in capture group 1 counts — a no-match
+ * returns undefined so the caller falls through to the description path rather
+ * than the unanchored generic parser (the anchor is the whole point). Without
+ * it, the generic `extractHashRunNumber` runs, after normalizing any
+ * `runNumberPrefix` ("R*n", #1975) to "#".
+ */
+function runNumberFromTitle(
+  title: string | undefined,
+  runNumberTitleRe: RegExp | undefined,
+  runNumberPrefix: string | undefined,
+): number | undefined {
+  if (runNumberTitleRe) {
+    const m = title ? runNumberTitleRe.exec(title) : null;
+    if (!m?.[1]) return undefined;
+    const n = Number.parseInt(m[1], 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  }
+  const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
+  return extractHashRunNumber(normalized);
+}
+
 function resolveRunNumber(
   title: string | undefined,
   description: string | null | undefined,
@@ -675,20 +701,8 @@ function resolveRunNumber(
   // fingerprinting. Only sources that confirm unambiguous title conventions
   // set `extractRunNumber: true`.
   if (extractRunNumber) {
-    if (runNumberTitleRe) {
-      // Anchored extraction (aggregate feeds): only a trail-context "#N" counts.
-      // On no-match we deliberately fall through to the description path rather
-      // than the unanchored generic parser — that anchor is the whole point.
-      const m = title ? runNumberTitleRe.exec(title) : null;
-      if (m?.[1]) {
-        const n = Number.parseInt(m[1], 10);
-        if (Number.isFinite(n) && n > 0) return n;
-      }
-    } else {
-      const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
-      const fromTitle = extractHashRunNumber(normalized);
-      if (fromTitle !== undefined) return fromTitle;
-    }
+    const fromTitle = runNumberFromTitle(title, runNumberTitleRe, runNumberPrefix);
+    if (fromTitle !== undefined) return fromTitle;
   }
   // Description extraction is default-on but anchored to a "trail" line so it
   // only fires on the hash-canonical "Trail #N" shape (#2167 Savannah, whose

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -2,6 +2,7 @@ import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
 import { hasAnyErrors } from "../types";
+import isSafeRegex from "safe-regex2";
 import { validateSourceConfig, stripHtmlTags, buildDateWindow, extractHashRunNumber, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS, splitDescriptionBlocks, normalizeDescriptionKey } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { extractHares as extractHaresFromDescription } from "../hare-extraction";
@@ -92,6 +93,20 @@ export interface MeetupConfig {
    * regex), so a `*` in the token needs no escaping.
    */
   runNumberPrefix?: string;
+  /**
+   * Optional title run-number anchor for aggregate feeds. When set (and
+   * `extractRunNumber` is true), the run number is read from capture group 1 of
+   * this pattern instead of the generic first-`#NNN`. Lets a source that mixes
+   * trail titles with non-trail socials extract only anchored trail forms and
+   * skip stray "#N" tokens that would otherwise become a bogus runNumber — and
+   * runNumber participates in same-day matching / fuzzy dedup, not just the
+   * kennel-page stat. Richmond H3's feed carries "RH3 # 1704" / "BIBH3 Trail
+   * #251" trails alongside "Inter-Kennel Drinking Practice #15"; the anchor
+   * keeps the social from minting run #15. Compiled case-insensitively and
+   * validated for ReDoS safety; an unsafe/malformed pattern is ignored (falls
+   * back to the generic parser).
+   */
+  runNumberTitlePattern?: string;
 }
 
 /** Shape of an event entry in Meetup's __NEXT_DATA__ Apollo state. */
@@ -450,6 +465,27 @@ function compileKennelPatterns(
 }
 
 /**
+ * Compile the optional per-source `runNumberTitlePattern`. Validated for ReDoS
+ * safety (config can be admin-edited in the DB) and skipped if unsafe/malformed
+ * so a bad pattern degrades to the generic parser rather than throwing.
+ */
+function compileRunNumberTitlePattern(pattern?: string): RegExp | undefined {
+  if (!pattern) return undefined;
+  // nosemgrep: detect-non-literal-regexp — protected by isSafeRegex() below
+  if (!isSafeRegex(pattern)) {
+    console.warn(`Unsafe runNumberTitlePattern skipped (ReDoS): "${pattern}"`);
+    return undefined;
+  }
+  try {
+    // nosemgrep: detect-non-literal-regexp — validated ReDoS-safe immediately above
+    return new RegExp(pattern, "i");
+  } catch (e) {
+    console.warn(`Malformed runNumberTitlePattern skipped: "${pattern}"`, e);
+    return undefined;
+  }
+}
+
+/**
  * Meetup-style hare-line fallback: scan the first few description lines for
  * `Hare(s)` followed by a colon or dash separator.
  *
@@ -632,15 +668,27 @@ function resolveRunNumber(
   description: string | null | undefined,
   extractRunNumber: boolean,
   runNumberPrefix: string | undefined,
+  runNumberTitleRe?: RegExp,
 ): number | undefined {
   // Title extraction stays opt-in (#1562): free-form Meetup titles can promote
   // non-hash tokens ("Pub Crawl #2") into a runNumber that then poisons
   // fingerprinting. Only sources that confirm unambiguous title conventions
   // set `extractRunNumber: true`.
   if (extractRunNumber) {
-    const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
-    const fromTitle = extractHashRunNumber(normalized);
-    if (fromTitle !== undefined) return fromTitle;
+    if (runNumberTitleRe) {
+      // Anchored extraction (aggregate feeds): only a trail-context "#N" counts.
+      // On no-match we deliberately fall through to the description path rather
+      // than the unanchored generic parser — that anchor is the whole point.
+      const m = title ? runNumberTitleRe.exec(title) : null;
+      if (m?.[1]) {
+        const n = Number.parseInt(m[1], 10);
+        if (Number.isFinite(n) && n > 0) return n;
+      }
+    } else {
+      const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
+      const fromTitle = extractHashRunNumber(normalized);
+      if (fromTitle !== undefined) return fromTitle;
+    }
   }
   // Description extraction is default-on but anchored to a "trail" line so it
   // only fires on the hash-canonical "Trail #N" shape (#2167 Savannah, whose
@@ -694,13 +742,15 @@ export function buildRawEventFromApollo(
   compiledPatterns?: [RegExp, string][],
   extractRunNumber = false,
   runNumberPrefix?: string,
-  // Boilerplate-processing context from fetch()'s detection pre-pass. `blocks`
-  // are the group-template paragraph keys to strip. `preCleaned` carries the
-  // already-computed cleaned description (wrapped so a legitimately-`undefined`
-  // value is distinguishable from "not supplied" → recompute) to avoid a second
-  // heavy cleanMeetupDescription (cheerio) pass per event. Bundled into one
-  // object so the signature stays within the param-count budget.
-  boilerplate?: { blocks?: Set<string>; preCleaned?: { value: string | undefined } },
+  // Per-fetch context, bundled into one object so the signature stays within the
+  // param-count budget. `blocks` are the group-template paragraph keys to strip
+  // and `preCleaned` carries the already-computed cleaned description (wrapped so
+  // a legitimately-`undefined` value is distinguishable from "not supplied" →
+  // recompute) to avoid a second heavy cleanMeetupDescription (cheerio) pass per
+  // event. `runNumberTitleRe` is the compiled per-source title run-number anchor
+  // (see `runNumberTitlePattern`), passed in pre-compiled so it isn't rebuilt per
+  // event.
+  opts?: { blocks?: Set<string>; preCleaned?: { value: string | undefined }; runNumberTitleRe?: RegExp },
 ): RawEventData {
   const { date, startTime } = ev.dateTime
     ? extractDateTime(ev.dateTime)
@@ -723,8 +773,8 @@ export function buildRawEventFromApollo(
   }
 
   const { hares, titleForDisplay } = resolveMeetupHares(ev.description, ev.title);
-  const cleanedDesc = boilerplate?.preCleaned
-    ? boilerplate.preCleaned.value
+  const cleanedDesc = opts?.preCleaned
+    ? opts.preCleaned.value
     : cleanMeetupDescription(ev.description, state);
   // Group-template boilerplate (#2058/#2059/#2062): strip paragraph blocks the
   // group reuses verbatim across >= 2 events (the standing recurring-event
@@ -735,7 +785,7 @@ export function buildRawEventFromApollo(
   // the stored `description` field is affected. `blocks` is undefined (or empty)
   // when called outside fetch() / with no detected template, so the strip is
   // skipped entirely and prior behavior is preserved.
-  const blocks = boilerplate?.blocks;
+  const blocks = opts?.blocks;
   const finalDesc =
     cleanedDesc !== undefined && blocks && blocks.size > 0
       ? stripBoilerplateBlocks(cleanedDesc, blocks)
@@ -751,7 +801,7 @@ export function buildRawEventFromApollo(
     // Use finalDesc (Apollo-ref-resolved + boilerplate-stripped), not the raw
     // ev.description, so a "$44" cache ref or a stale group-template "Trail #N"
     // can't drive the run number (#2200 review).
-    runNumber: resolveRunNumber(ev.title, finalDesc, extractRunNumber, runNumberPrefix),
+    runNumber: resolveRunNumber(ev.title, finalDesc, extractRunNumber, runNumberPrefix, opts?.runNumberTitleRe),
     description: finalDesc,
     hares,
     location: venueInfo.location,
@@ -937,6 +987,7 @@ export class MeetupAdapter implements SourceAdapter {
     const boilerplateBlocks = detectBoilerplateBlocks(cleanedDescriptions);
 
     const compiledPatterns = compileKennelPatterns(config.kennelPatterns);
+    const compiledRunNumberTitleRe = compileRunNumberTitlePattern(config.runNumberTitlePattern);
     let cancelledSkipped = 0;
     let adminNoticeSkipped = 0;
     let boilerplateDescriptionsDropped = 0;
@@ -977,7 +1028,7 @@ export class MeetupAdapter implements SourceAdapter {
         // Reuse the pre-pass cleaned value (index-aligned) so the builder
         // doesn't re-run the heavy cleanMeetupDescription/cheerio parse.
         const cleanedBefore = cleanedDescriptions[i];
-        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, { blocks: boilerplateBlocks, preCleaned: { value: cleanedBefore } });
+        const rawEvent = buildRawEventFromApollo(ev, mergedState, config.kennelTag, compiledPatterns, shouldExtractRunNumber, config.runNumberPrefix, { blocks: boilerplateBlocks, preCleaned: { value: cleanedBefore }, runNumberTitleRe: compiledRunNumberTitleRe });
         // Count events whose description had boilerplate removed (fully nulled
         // or partially stripped) vs. its pre-strip cleaned value.
         if (cleanedBefore !== undefined && rawEvent.description !== cleanedBefore) {

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -462,13 +462,17 @@ function compileKennelPatterns(
 }
 
 /**
- * Trail-context run-number anchor for aggregate Meetup feeds (opt in via
- * `anchorTrailRunNumber`). Capture group 1 is the run number when it follows
- * either a leading kennel-code token + "#" ("RH3 # 1704") or "Trail #"
- * ("BIBH3 Trail #251"). A non-trail social ("Inter-Kennel Drinking Practice
- * #15") matches neither, so it mints no run number. A module-level literal
- * (not compiled from config) so it's ReDoS-safe by construction. */
-const TITLE_TRAIL_RUN_RE = /(?:^\s*[A-Za-z0-9]{2,8}\s*#|\btrail\b\s*#)\s*(\d+)/i; // NOSONAR S5852/S5843 — literal, bounded {2,8}, no overlapping quantifiers
+ * Trail-context run-number *locator* for aggregate Meetup feeds (opt in via
+ * `anchorTrailRunNumber`). Matches the prefix up to and including the "#" when it
+ * follows either a leading kennel-code token ("RH3 # 1704") or "Trail #"
+ * ("BIBH3 Trail #251") — a non-trail social ("Inter-Kennel Drinking Practice
+ * #15") matches neither. Like the description path's TRAIL_RUN_ANCHOR_RE this is
+ * only a locator: the digits are parsed from the matched slice via the shared
+ * `extractHashRunNumber`, so its delimiter guard still rejects placeholder
+ * suffixes ("RH3 #1704TBD", "Trail #30X?") instead of minting a false run that
+ * would also pollute merge identity (Codex PR #2207 review). Module-level
+ * literal (not compiled from config) so it's ReDoS-safe by construction. */
+const TITLE_TRAIL_RUN_ANCHOR_RE = /(?:^\s*[A-Za-z0-9]{2,8}\s*#|\btrail\b\s*#)/i; // NOSONAR S5852/S5843 — literal, bounded {2,8}, no overlapping quantifiers
 
 /**
  * Meetup-style hare-line fallback: scan the first few description lines for
@@ -650,10 +654,12 @@ function resolveMeetupHares(
  */
 /**
  * Extract a run number from a Meetup title. With `anchorTrail` (aggregate feeds)
- * only a trail-context "#N" (capture group 1 of `TITLE_TRAIL_RUN_RE`) counts — a
- * no-match returns undefined so the caller falls through to the description path
- * rather than the unanchored generic parser (the anchor is the whole point).
- * Without it, the generic `extractHashRunNumber` runs, after normalizing any
+ * only a trail-context "#N" counts: the `TITLE_TRAIL_RUN_ANCHOR_RE` locator
+ * finds the trail "#", then the shared `extractHashRunNumber` parses the slice
+ * (keeping its delimiter/placeholder guard). A no-match returns undefined so the
+ * caller falls through to the description path rather than the unanchored generic
+ * parser (the anchor is the whole point). Without `anchorTrail`, the generic
+ * `extractHashRunNumber` runs over the whole title, after normalizing any
  * `runNumberPrefix` ("R*n", #1975) to "#".
  */
 function runNumberFromTitle(
@@ -662,10 +668,8 @@ function runNumberFromTitle(
   runNumberPrefix: string | undefined,
 ): number | undefined {
   if (anchorTrail) {
-    const m = title ? TITLE_TRAIL_RUN_RE.exec(title) : null;
-    if (!m?.[1]) return undefined;
-    const n = Number.parseInt(m[1], 10);
-    return Number.isFinite(n) && n > 0 ? n : undefined;
+    const anchor = title ? TITLE_TRAIL_RUN_ANCHOR_RE.exec(title) : null;
+    return anchor ? extractHashRunNumber(title!.slice(anchor.index)) : undefined;
   }
   const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
   return extractHashRunNumber(normalized);


### PR DESCRIPTION
## Problem
Richmond H3 (`rvah3`) shows no "Latest Run" on its kennel page even though its events clearly carry a run number. The events come from the **Richmond H3 Meetup** source, and the run number lives **only in the title** (`RH3 # 1704`, `RH3 Trail #1696`) — the description path finds nothing (verified 0/33). Meetup title run-number extraction is opt-in (`extractRunNumber`), deliberately off by default because free-form Meetup titles can promote non-trail `#N` tokens into a `runNumber`.

The Richmond feed is exactly that hazard: it's an aggregate of RH3 + sisters **plus** a recurring non-trail social, `Inter-Kennel Drinking Practice #15`. Naively enabling `extractRunNumber` would mint **bogus run #15** for that social — and `runNumber` participates in same-day matching / fuzzy dedup / event signatures (`src/pipeline/merge.ts`), not just the kennel-page stat. (Caught by adversarial review.)

## Fix
Add an optional per-source **`runNumberTitlePattern`** to the Meetup adapter:
- When set (and `extractRunNumber` is true), the run number is read from **capture group 1** of the anchor instead of the generic first-`#`; on no-match it falls through to the existing trail-anchored description path (never the unanchored generic parser).
- Compiled **once per fetch** and validated **ReDoS-safe** via `safe-regex2` (config can be admin-edited in the DB); unsafe/malformed patterns are skipped, degrading to the generic parser.
- Threaded through `buildRawEventFromApollo` via its existing per-fetch options bag (no new positional param — stays within the param-count budget).

Richmond opts in with an anchor matching a leading kennel-code token before `#`, or `Trail #`:
```
(?:^\s*[A-Za-z0-9]{2,8}\s*#|\btrail\b\s*#)\s*(\d+)
```

## Result (live-verified against the Meetup source)
| Title | runNumber |
|---|---|
| `RH3 # 1704 - Medley of Mud #3 …` | **1704** |
| `RH3 Trail #1696: …` | **1696** |
| `BIBH3 Trail #251 - DRAG RACE!!` | **251** |
| `Chain Gang Trail #42` | **42** |
| `TMFMH3 Trail 299: …` (no `#`) | — (unchanged) |
| `Inter-Kennel Drinking Practice #15 hosted by RH3!` | **— (excluded ✓)** |

27/33 events get correct run numbers, **0 bogus social run numbers**. The kennel-page "Latest Run" (recently changed to windowed `Math.max`) will now show **1704**. Bonus: sister kennels bibh3/chain-gang-hhh also populate correctly.

## Tests
- `buildRawEventFromApollo` unit tests for the RH3/sister trail forms (anchored), the social → `undefined`, a load-bearing assertion that the *unanchored* parser WOULD grab the bogus 15, and a seed-config guard (`extractRunNumber: true` + `runNumberTitlePattern` present).
- `npm run lint` clean, `npx tsc --noEmit` clean, `npm test` 9222 passed.
- `/simplify` + adversarial review run (this PR is the response to that review's finding on enabling the broad flag).

## Notes
- Follow-up to PR #2204 / issue #2180 (same kennel, **different source** — does not touch the Google Calendar adapter).
- Post-merge: `npx prisma db seed`; existing `rvah3` events backfill their NULL `runNumber` on the next scrape (merge enrich path fills NULL fields for in-window events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)