### PR TITLE
chore(sheets): drop no-op location:-1 from SeaMon + Leap Year configs

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2910,8 +2910,11 @@ export const SOURCES = [
       config: {
         sheetId: "12Ajped8oyheVayDmHs0d8glLVo23VOg8gRKCe4yQP-g",
         gid: 0,
+        // Layout: banner "SeaMon H3 Hareline"(0) → header(1) → data(2+), so
+        // skipRows:1 (one banner above the header) is correct. Columns are
+        // Run#(0) Date(1) Hare(s)(2) Theme/Name(3); no location column.
         skipRows: 1,
-        columns: { runNumber: 0, date: 1, hares: 2, title: 3, location: -1 },
+        columns: { runNumber: 0, date: 1, hares: 2, title: 3 },
         kennelTagRules: { default: "seamon-h3" },
       },
       kennelCodes: ["seamon-h3"],
@@ -2932,8 +2935,13 @@ export const SOURCES = [
       config: {
         sheetId: "anonymous",
         csvUrl: "https://docs.google.com/spreadsheets/d/e/2PACX-1vQ_z30ZkQNOwcAka4qU22bAGYIVjJFc5NyICst9OeUWPvi27lNK8ICkZllzLI0gjLwQDjVvlt3mMlDM/pub?output=csv",
+        // skipRows:2 is correct here (verified live): TWO banner rows sit above
+        // the header — "Leap Year H3 - Hareline"(0) + a "Leap years occur on…"
+        // description(1) → header(2) → data(3+). Unlike PSH3/Rain City (#2202),
+        // this is NOT the first-data-row-drop bug; do not lower it to 1.
+        // Columns: Run#(0) Date (Day)(1) Hare(s)(2) Theme?(3); no location column.
         skipRows: 2,
-        columns: { runNumber: 0, date: 1, hares: 2, title: 3, location: -1 },
+        columns: { runNumber: 0, date: 1, hares: 2, title: 3 },
         kennelTagRules: { default: "leapyear-h3" },
       },
       kennelCodes: ["leapyear-h3"],


### PR DESCRIPTION
## Summary

Follow-up audit to [#2202](https://github.com/johnrclem/hashtracks-web/pull/2202) (the PSH3/Rain City sheet fixes). Both Seattle hareline `GOOGLE_SHEETS` configs carried the same `location: -1` no-op; this drops it. **Live-verified both sheet layouts before touching `skipRows`** — and the verification changed the conclusion for Leap Year.

| Sheet | `skipRows` | Verdict |
|---|---|---|
| SeaMon | `1` | ✅ already correct — one banner row (`SeaMon H3 Hareline`) above the header |
| Leap Year | `2` | ✅ correct — **two** banner rows (`Leap Year H3 - Hareline` + a `"Leap years occur on…"` description) above the header |

So neither sheet had the first-data-row-drop bug that hit PSH3/Rain City (those had a single banner with `skipRows:2`). Leap Year legitimately needs `skipRows:2`; I added a comment so a future audit doesn't "fix" it down to 1. Leap Year is enabled and has real rows (#9–#16).

### Changes (config-only, no behavior change)
- **SeaMon** (`seamon-h3`): drop `location: -1`; document layout (`Run#0 Date1 Hare(s)2 Theme/Name3`).
- **Leap Year** (`leapyear-h3`): drop `location: -1`; keep `skipRows:2` with an explanatory comment; document layout (`Run#0 Date (Day)1 Hare(s)2 Theme?3`).

`row[-1]` already evaluates to `undefined` (identical to omitting the key), so adapter output is byte-for-byte unchanged.

### Verification
- Live-fetched both CSVs and counted banner rows above the header.
- `npx vitest run src/adapters/google-sheets/adapter.test.ts` ✓ (182) · `npx tsc --noEmit` ✓ · `npm run lint` ✓ · `npm test` ✓ (9213 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)