### PR TITLE
feat(merge): scrub mid-string phone/email PII from hares for every adapter

### DIFF
--- a/scripts/backfill-hare-pii-scrub.ts
+++ b/scripts/backfill-hare-pii-scrub.ts
@@ -1,0 +1,72 @@
+/**
+ * One-off full-history PII scrub of canonical Event.haresText (#2227 follow-up).
+ *
+ * The merge pipeline's `sanitizeHares` now strips phone numbers / emails embedded
+ * mid-string, so all FUTURE merges are protected. The daily audit's
+ * `selfHealSanitizers` also re-sanitizes the rolling −7d…+90d window. This script
+ * clears the historical backlog OUTSIDE that window in one shot.
+ *
+ * Scoped & safe:
+ *   - Only touches rows where `containsHarePii(haresText)` is true — non-PII hares
+ *     are never re-sanitized for unrelated reasons (no corpus churn).
+ *   - Computes the new value with the SAME `sanitizeHares` the pipeline uses.
+ *   - Optimistic-lock guard (`where: { id, haresText: <old> }`) so a concurrent
+ *     scrape can't be clobbered (mirrors selfHealSanitizers in audit-runner.ts).
+ *   - A null result clears the field (explicit clear).
+ *   - Idempotent: once scrubbed the row no longer matches `containsHarePii`.
+ *   - haresText is NOT part of the fingerprint, so rewriting it never disturbs dedup.
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: set -a && source .env && set +a && BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-hare-pii-scrub.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-hare-pii-scrub.ts --apply
+ *   Env:     DATABASE_URL
+ */
+import { containsHarePii } from "@/adapters/hare-pii";
+import { sanitizeHares } from "@/pipeline/merge";
+import { runOneShot } from "./lib/one-shot";
+
+const SAMPLE_LIMIT = 30;
+
+void runOneShot(async ({ prisma, apply }) => {
+  const events = await prisma.event.findMany({
+    where: { haresText: { not: null } },
+    select: { id: true, haresText: true },
+    orderBy: { date: "asc" },
+  });
+  console.log(`Scanned ${events.length} event(s) with a non-null haresText.`);
+
+  // haresText is non-null by the query above; narrow for the type checker.
+  const withPii = events.filter(
+    (e): e is { id: string; haresText: string } =>
+      e.haresText !== null && containsHarePii(e.haresText),
+  );
+  console.log(`${withPii.length} contain a phone number or email.`);
+  if (withPii.length === 0) return;
+
+  let changed = 0;
+  let cleared = 0;
+  let updated = 0;
+  let shown = 0;
+  for (const e of withPii) {
+    const next = sanitizeHares(e.haresText); // string | null
+    if (next === e.haresText) continue; // no-op (shouldn't happen for PII rows)
+    changed++;
+    if (next === null) cleared++;
+    if (shown < SAMPLE_LIMIT) {
+      console.log(`  ${e.id}: ${JSON.stringify(e.haresText)} → ${JSON.stringify(next)}`);
+      shown++;
+    }
+    if (apply) {
+      const res = await prisma.event.updateMany({
+        where: { id: e.id, haresText: e.haresText },
+        data: { haresText: next },
+      });
+      updated += res.count;
+    }
+  }
+
+  console.log(
+    `\n${changed} row(s) would change (${cleared} cleared to null).` +
+      (apply ? ` Applied ${updated} update(s).` : " Re-run with --apply to write."),
+  );
+});

--- a/src/adapters/hare-pii.test.ts
+++ b/src/adapters/hare-pii.test.ts
@@ -14,6 +14,10 @@ describe("scrubHarePii", () => {
     ["NA dashed", "Captain Hash 415-555-1212", "Captain Hash"],
     ["NA in parens, co-hare rescued", "Alice (415) 555-1212 & Bob", "Alice & Bob"],
     ["NA bare 10-digit", "Hares 4155551212", "Hares"],
+    // Parenthesized area code with NO separator after ")" — the audit's
+    // PHONE_NUMBER_RE misses this; PAREN_NA_PHONE_RE covers it (Codex #2248).
+    ["NA paren, no space after )", "Alice (415)555-1212", "Alice"],
+    ["NA paren, fully unseparated", "Alice (415)5551212", "Alice"],
     // Paren artifacts: the NA pattern's "\(?" eats the open paren, leaving a
     // dangling ")"; the email pattern leaves an empty "()". Both get tidied.
     ["orphan close paren (phone in parens)", "Just Jorge (973-760-5774)", "Just Jorge"],
@@ -51,6 +55,7 @@ describe("containsHarePii", () => {
     expect(containsHarePii("ASBO 010-2354-1741")).toBe(true);
     expect(containsHarePii("Captain Hash 415-555-1212")).toBe(true);
     expect(containsHarePii("Hares 4155551212")).toBe(true);
+    expect(containsHarePii("Alice (415)555-1212")).toBe(true);
     expect(containsHarePii("Slippery +44 7911 123456")).toBe(true);
     expect(containsHarePii("Hymen hymen@example.com")).toBe(true);
   });

--- a/src/adapters/hare-pii.test.ts
+++ b/src/adapters/hare-pii.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { scrubHarePii, containsHarePii } from "./hare-pii";
+
+describe("scrubHarePii", () => {
+  it.each([
+    // Korean — the original Seoul H3 cases (PR #2227), now handled by the
+    // generic +CC / Korean-domestic patterns. These must stay identical.
+    ["international +82 form", "Longfellow +82 10-9397-6199", "Longfellow"],
+    ["double-space +82 form", "EM Blank Space +82  10-7152-6362, EM Seoul Ultraman", "EM Blank Space, EM Seoul Ultraman"],
+    ["ampersand-joined", "EM Blank Space +82 10-7152-6362 & EM Seoul Ultraman", "EM Blank Space & EM Seoul Ultraman"],
+    ["domestic 010 form", "ASBO 010-2354-1741", "ASBO"],
+    ["email", "Hymen hymen@example.com", "Hymen"],
+    // North American (generalization)
+    ["NA dashed", "Captain Hash 415-555-1212", "Captain Hash"],
+    ["NA in parens, co-hare rescued", "Alice (415) 555-1212 & Bob", "Alice & Bob"],
+    ["NA bare 10-digit", "Hares 4155551212", "Hares"],
+    // Paren artifacts: the NA pattern's "\(?" eats the open paren, leaving a
+    // dangling ")"; the email pattern leaves an empty "()". Both get tidied.
+    ["orphan close paren (phone in parens)", "Just Jorge (973-760-5774)", "Just Jorge"],
+    ["orphan close paren mid-string", "The Tickler (089-813-0090) and Others", "The Tickler and Others"],
+    ["empty parens (email in parens)", "DJO (davehi@speakeasy.net)", "DJO"],
+    // Other international (generalization)
+    ["UK intl", "Slippery +44 7911 123456", "Slippery"],
+    ["German intl", "Hare +49 30 12345678", "Hare"],
+  ])("strips %s", (_label, input, expected) => {
+    expect(scrubHarePii(input)).toBe(expected);
+  });
+
+  it.each([
+    ["subway line + walk-time", "Jichuck station, line 3, exit 1 (10-15 min walk)"],
+    ["year range", "GM Over There (1995-1996) Memorial Run"],
+    ["run number + dollar amount", "Trail #500, raised $1500"],
+    ["distance range", "3-5 milers welcome"],
+    ["clock time", "6:30 start"],
+  ])("preserves false-positive %s", (_label, input) => {
+    expect(scrubHarePii(input)).toBe(input);
+  });
+
+  it("returns undefined when only PII remains", () => {
+    expect(scrubHarePii("+82 10-9397-6199")).toBeUndefined();
+    expect(scrubHarePii("415-555-1212")).toBeUndefined();
+    expect(scrubHarePii("")).toBeUndefined();
+    expect(scrubHarePii(null)).toBeUndefined();
+    expect(scrubHarePii(undefined)).toBeUndefined();
+  });
+});
+
+describe("containsHarePii", () => {
+  it("detects each PII shape", () => {
+    expect(containsHarePii("Longfellow +82 10-9397-6199")).toBe(true);
+    expect(containsHarePii("ASBO 010-2354-1741")).toBe(true);
+    expect(containsHarePii("Captain Hash 415-555-1212")).toBe(true);
+    expect(containsHarePii("Hares 4155551212")).toBe(true);
+    expect(containsHarePii("Slippery +44 7911 123456")).toBe(true);
+    expect(containsHarePii("Hymen hymen@example.com")).toBe(true);
+  });
+
+  it("does not flag legit content", () => {
+    expect(containsHarePii("GM Over There (1995-1996) Memorial Run")).toBe(false);
+    expect(containsHarePii("Jichuck station, line 3, exit 1 (10-15 min walk)")).toBe(false);
+    expect(containsHarePii("Trail #500, raised $1500")).toBe(false);
+    expect(containsHarePii("3-5 milers welcome")).toBe(false);
+    expect(containsHarePii("Mudflap & Trail Blazer")).toBe(false);
+  });
+
+  it("is deterministic across repeated calls on shared /g regexes (no lastIndex leak)", () => {
+    // Guards against a future refactor to RegExp.test on the module-level /g
+    // patterns, which would carry lastIndex between calls and flip results.
+    const value = "Captain Hash 415-555-1212";
+    expect(containsHarePii(value)).toBe(true);
+    expect(containsHarePii(value)).toBe(true);
+    // Mixing detect (.search) then scrub (.replace) must not desync either.
+    expect(scrubHarePii(value)).toBe("Captain Hash");
+    expect(containsHarePii(value)).toBe(true);
+  });
+});

--- a/src/adapters/hare-pii.ts
+++ b/src/adapters/hare-pii.ts
@@ -40,12 +40,21 @@ const DOMESTIC_MOBILE_RE = /\b01\d[-\s.]*\d{3,4}[-\s.]*\d{4}\b/g;
 // eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source is a hard-coded constant
 const NA_PHONE_GLOBAL_RE = new RegExp(PHONE_NUMBER_RE.source, "g"); // NOSONAR nosemgrep
 
-export { EMAIL_RE, INTL_PHONE_RE, DOMESTIC_MOBILE_RE, NA_PHONE_GLOBAL_RE };
+// Parenthesized area code with NO separator after the close paren, e.g.
+// "(415)555-1212" / "(415)5551212". The audit's PHONE_NUMBER_RE requires a
+// `[-.\s]` after the optional `\)?`, so it misses this common US shape — the
+// scrubber covers it as a superset (scrub ⊇ detect keeps selfHeal convergent).
+const PAREN_NA_PHONE_RE = /\(\d{3}\)[-.\s]?\d{3}[-.\s]?\d{4}(?!\d)/g;
 
+// NOTE: the individual regexes are intentionally NOT exported — only the
+// `containsHarePii` / `scrubHarePii` functions and `HARE_PII_RES` are public.
+// Exporting the live module-level `/g` objects would invite a caller to use
+// `.test()`/`.exec()` and trip the shared `lastIndex` non-determinism trap.
 export const HARE_PII_RES = [
   EMAIL_RE,
   INTL_PHONE_RE,
   NA_PHONE_GLOBAL_RE,
+  PAREN_NA_PHONE_RE,
   DOMESTIC_MOBILE_RE,
 ];
 

--- a/src/adapters/hare-pii.ts
+++ b/src/adapters/hare-pii.ts
@@ -1,0 +1,113 @@
+/**
+ * Generic PII scrubbing for hare fields, applied at ingest by the merge
+ * pipeline's `sanitizeHares` so EVERY adapter's `hares` output is protected —
+ * not just the source it was first discovered on (Seoul H3, PR #2227).
+ *
+ * Many sources list hare phone numbers (and occasionally emails) inline in the
+ * hare field, in domestic and international forms with inconsistent spacing.
+ * `sanitizeHares` only strips TRAILING logistics — not mid-string phones — so
+ * those leak into canonical, public-facing events without this scrubber.
+ *
+ * Lives in `src/adapters/` (next to `hare-extraction.ts`), NOT `utils.ts`,
+ * because it imports `PHONE_NUMBER_RE` from `@/pipeline/audit-checks`, which
+ * already imports from `utils.ts` — putting it in `utils.ts` would create an
+ * import cycle (same constraint hare-extraction.ts documents).
+ *
+ * Regex notes: patterns are kept as separate per-type LITERALS in an array (not
+ * one big alternation) so each stays under the Sonar S5843 complexity budget.
+ * The email uses `[\w-]+(?:\.[\w-]+)+` (the label class excludes `.`) so there's
+ * no backtracking ambiguity. The international pattern uses a DIGIT-count floor
+ * (≥8 digits total, E.164) rather than a char-count floor, so the hash "+1"
+ * plus-one convention ("+1 510 Crew") and short ranges ("+3-5 milers") can't be
+ * clipped. The Korean `01x` pattern is LOAD-BEARING: the North American
+ * `PHONE_NUMBER_RE` (3-3-4 or bare-10) does NOT match a Korean 3-4-4 number like
+ * `010-2354-1741`. Detection uses `String.search` (which ignores the global
+ * flag's `lastIndex`, unlike `RegExp.test`), so the global regexes are reused
+ * safely across the merge hot path.
+ */
+import { PHONE_NUMBER_RE } from "@/pipeline/audit-checks";
+
+const EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
+const INTL_PHONE_RE = /\+\d{1,3}[\s().-]*\d(?:[\s().-]*\d){6,13}/g;
+const DOMESTIC_MOBILE_RE = /\b01\d[-\s.]*\d{3,4}[-\s.]*\d{4}\b/g;
+
+// Reuse the audit's North American phone pattern as the single source of truth
+// so the scrubber removes exactly what `checkHareQuality`'s `hare-phone-number`
+// rule detects (otherwise `selfHealSanitizers` would re-flag forever). Needs the
+// global flag so `.replace` strips ALL occurrences. Mirrors the suppression on
+// hare-extraction.ts:28-30 — the source is a hard-coded constant from audit-checks.
+// nosemgrep: detect-non-literal-regexp -- source is a hard-coded constant from audit-checks
+// eslint-disable-next-line -- security/detect-non-literal-regexp + security-node/non-literal-reg-expr (Codacy ESLint plugins not loaded locally); source is a hard-coded constant
+const NA_PHONE_GLOBAL_RE = new RegExp(PHONE_NUMBER_RE.source, "g"); // NOSONAR nosemgrep
+
+export { EMAIL_RE, INTL_PHONE_RE, DOMESTIC_MOBILE_RE, NA_PHONE_GLOBAL_RE };
+
+export const HARE_PII_RES = [
+  EMAIL_RE,
+  INTL_PHONE_RE,
+  NA_PHONE_GLOBAL_RE,
+  DOMESTIC_MOBILE_RE,
+];
+
+/** True if the text contains a phone number or email. */
+export function containsHarePii(value: string): boolean {
+  return HARE_PII_RES.some((re) => value.search(re) !== -1);
+}
+
+/** Collapse internal whitespace runs and trim (no ReDoS-flagged regex). */
+function collapseSpaces(part: string): string {
+  return part.split(/\s+/).filter(Boolean).join(" ");
+}
+
+/**
+ * Tidy parenthesis artifacts left behind by PII removal so the common
+ * "Name (contact)" shape collapses to "Name":
+ *   - empty parens:   "DJO (a@b.com)" → "DJO ()" → "DJO"
+ *   - orphaned paren: the NA phone pattern's optional `\(?` eats a leading "(",
+ *     leaving a dangling ")" — "Just Jorge (973-760-5774)" → "Just Jorge )" → "Just Jorge"
+ * Balanced, non-empty parens (e.g. "(1995-1996)") are preserved. The orphan pass
+ * is a regex-free, surrogate-safe linear scan (no ReDoS surface).
+ */
+function stripParenArtifacts(input: string): string {
+  const withoutEmpty = input.replace(/\(\s*\)/g, "");
+  const chars = Array.from(withoutEmpty);
+  // Pass 1: drop unmatched ")" (no open paren still on the stack).
+  let depth = 0;
+  const kept: string[] = [];
+  for (const ch of chars) {
+    if (ch === ")") {
+      if (depth === 0) continue;
+      depth--;
+    } else if (ch === "(") {
+      depth++;
+    }
+    kept.push(ch);
+  }
+  // Pass 2: drop the `depth` still-unmatched "(" (scanning from the end).
+  for (let i = kept.length - 1; i >= 0 && depth > 0; i--) {
+    if (kept[i] === "(") {
+      kept.splice(i, 1);
+      depth--;
+    }
+  }
+  return kept.join("");
+}
+
+/**
+ * Remove phone/email PII and tidy the separators left behind, so
+ * "A +82 10-… & B" → "A & B" and "A +82 10-…, B" → "A, B". Comma/semicolon
+ * tokenisation keeps "A & B" intact while normalising spacing. Returns
+ * `undefined` when nothing meaningful remains.
+ */
+export function scrubHarePii(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  let stripped = value;
+  for (const re of HARE_PII_RES) stripped = stripped.replace(re, "");
+  stripped = stripParenArtifacts(stripped);
+  const cleaned = stripped
+    .split(/[,;]/)
+    .map(collapseSpaces)
+    .filter((part) => part.length > 0)
+    .join(", ");
+  return cleaned || undefined;
+}

--- a/src/adapters/html-scraper/sh3-pii.ts
+++ b/src/adapters/html-scraper/sh3-pii.ts
@@ -1,53 +1,12 @@
 /**
- * PII scrubbing for Seoul H3 hare fields.
+ * Seoul H3 hare PII scrubbing.
  *
- * The Seoul H3 source lists hare phone numbers (and occasionally emails) inline
- * in the hare field, in BOTH the domestic `010-XXXX-XXXX` and international
- * `+82 10-XXXX-XXXX` forms (with inconsistent spacing, e.g. a double space). The
- * merge pipeline's `sanitizeHares` only strips trailing logistics — NOT mid-string
- * phones — so both the live adapter and the frozen archive backfill scrub here.
- *
- * `containsHarePii` is exported so the regression test guarding
- * `scripts/data/sh3-kr-history.json` checks the exact patterns the scrubber removes.
- *
- * Regex notes: patterns are kept as separate per-type LITERALS (not `new RegExp`,
- * and not one big alternation) so each stays under the Sonar S5843 complexity
- * budget. The email uses `[\w-]+(?:\.[\w-]+)+` (the label class excludes `.`) so
- * there's no backtracking ambiguity. Each `[-\s.]*` is followed by a disjoint
- * required token (`\d`), keeping the phone patterns linear. The `01x` / `+82`
- * anchors spare false positives like "Line 1 (10-15 min walk)" and "1995-1996".
- * Detection uses `String.search` (which ignores the global flag's `lastIndex`,
- * unlike `RegExp.test`), so the global regexes are reused safely.
+ * The Korea-specific scrubber discovered on Seoul H3 (PR #2227) has been
+ * generalized into the shared `@/adapters/hare-pii` module and wired into the
+ * merge pipeline's `sanitizeHares`, so EVERY adapter's hares are now scrubbed at
+ * ingest. This file re-exports the shared functions to keep the Seoul adapter
+ * (`seoul-h3.ts` `parseEventBlock`) and the frozen-archive regression test
+ * (`scripts/backfill-sh3-kr-history.test.ts`) importing from a stable path —
+ * defense in depth with a single source of truth.
  */
-const EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
-const INTL_MOBILE_RE = /\+82[-\s]*1\d[-\s.]*\d{3,4}[-\s.]*\d{4}/g;
-const DOMESTIC_MOBILE_RE = /\b01\d[-\s.]*\d{3,4}[-\s.]*\d{4}\b/g;
-const PII_RES = [EMAIL_RE, INTL_MOBILE_RE, DOMESTIC_MOBILE_RE];
-
-/** True if the text contains a phone number or email (used by the regression test). */
-export function containsHarePii(value: string): boolean {
-  return PII_RES.some((re) => value.search(re) !== -1);
-}
-
-/** Collapse internal whitespace runs and trim (no ReDoS-flagged regex). */
-function collapseSpaces(part: string): string {
-  return part.split(/\s+/).filter(Boolean).join(" ");
-}
-
-/**
- * Remove phone/email PII and tidy the separators left behind, so
- * "A +82 10-… & B" → "A & B" and "A +82 10-…, B" → "A, B". Comma/semicolon
- * tokenisation keeps "A & B" intact while normalising spacing. Returns
- * `undefined` when nothing meaningful remains.
- */
-export function scrubHarePii(value: string | null | undefined): string | undefined {
-  if (!value) return undefined;
-  let stripped = value;
-  for (const re of PII_RES) stripped = stripped.replace(re, "");
-  const cleaned = stripped
-    .split(/[,;]/)
-    .map(collapseSpaces)
-    .filter((part) => part.length > 0)
-    .join(", ");
-  return cleaned || undefined;
-}
+export { scrubHarePii, containsHarePii } from "@/adapters/hare-pii";

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -2821,6 +2821,9 @@ describe("sanitizeHares", () => {
     // Co-hare after a mid-string phone is rescued — the boilerplate "(\\d{3})"
     // truncation would otherwise drop "Bob".
     expect(sanitizeHares("Alice (415) 555-1212 & Bob")).toBe("Alice & Bob");
+    // No separator after the area-code paren — covered by PAREN_NA_PHONE_RE
+    // (the audit's PHONE_NUMBER_RE misses it). Codex review on #2248.
+    expect(sanitizeHares("Captain Hash (415)555-1212")).toBe("Captain Hash");
   });
 
   it("strips an email embedded in the hare field", () => {

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -2802,6 +2802,50 @@ describe("sanitizeHares", () => {
   it("does not filter names containing 'sign' as substring", () => {
     expect(sanitizeHares("Stop Sign Steve")).toBe("Stop Sign Steve");
   });
+
+  // ── mid-string PII scrubbing (#2227, generalized to every adapter) ──
+
+  it("strips a mid-string international phone, keeping co-hares", () => {
+    expect(sanitizeHares("EM Blank Space +82 10-7152-6362, EM Seoul Ultraman")).toBe(
+      "EM Blank Space, EM Seoul Ultraman",
+    );
+    expect(sanitizeHares("Slippery +44 7911 123456")).toBe("Slippery");
+  });
+
+  it("strips a Korean domestic mobile from the hare field", () => {
+    expect(sanitizeHares("ASBO 010-2354-1741")).toBe("ASBO");
+  });
+
+  it("strips a North American phone (dashed and parenthesized)", () => {
+    expect(sanitizeHares("Captain Hash 415-555-1212")).toBe("Captain Hash");
+    // Co-hare after a mid-string phone is rescued — the boilerplate "(\\d{3})"
+    // truncation would otherwise drop "Bob".
+    expect(sanitizeHares("Alice (415) 555-1212 & Bob")).toBe("Alice & Bob");
+  });
+
+  it("strips an email embedded in the hare field", () => {
+    expect(sanitizeHares("Hymen hymen@example.com")).toBe("Hymen");
+  });
+
+  it("returns null when the hare field is only PII", () => {
+    expect(sanitizeHares("+82 10-9397-6199")).toBeNull();
+    expect(sanitizeHares("415-555-1212")).toBeNull();
+  });
+
+  it("leaves non-PII hares byte-identical — no separator normalization (gate)", () => {
+    // The containsHarePii gate means a hare with no phone/email never hits the
+    // scrub's tidy pass, so its separators (here a semicolon) survive unchanged.
+    // This is what keeps the corpus from churning on every merge.
+    expect(sanitizeHares("Just Tip; Slippery When Wet")).toBe("Just Tip; Slippery When Wet");
+    expect(sanitizeHares("Mudflap & Trail Blazer")).toBe("Mudflap & Trail Blazer");
+  });
+
+  it("does not strip legit numerics that look phone-ish (no false positives)", () => {
+    expect(sanitizeHares("GM Over There (1995-1996) Memorial Run")).toBe(
+      "GM Over There (1995-1996) Memorial Run",
+    );
+    expect(sanitizeHares("3-5 milers welcome")).toBe("3-5 milers welcome");
+  });
 });
 
 // ── friendlyKennelName ──

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -9,6 +9,7 @@ import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag, resolveKennelTags, clearResolverCache } from "./kennel-resolver";
 import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseGeocode, haversineDistance, parseDMSFromLocation, stripDMSFromLocation } from "@/lib/geo";
 import { isPlaceholder, isThemelessPlaceholderTitle, decodeEntities, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "@/adapters/utils";
+import { containsHarePii, scrubHarePii } from "@/adapters/hare-pii";
 import { LOCATION_EMAIL_CTA_RE } from "./audit-checks";
 import { levenshtein } from "@/lib/fuzzy";
 import { createEventWithKennel } from "@/lib/event-write";
@@ -167,6 +168,20 @@ export function sanitizeHares(hares: string | undefined | null): string | null {
 
   // Truncate at trailing logistics clauses (e.g., ", we are still taking applications...")
   h = h.replace(/,\s*(?:and we |we |still |also |please |but )\b.*/i, "").trim();
+
+  // Strip phone numbers / emails embedded mid-string so PII never reaches a
+  // canonical public event (#2227 — Seoul H3, generalized to every adapter).
+  // Gated on containsHarePii so non-PII hares pass through byte-identical (no
+  // separator normalization → no fingerprint/audit churn across the corpus).
+  // Runs before the boilerplate search so co-hares are rescued after a mid-string
+  // phone (e.g. "Alice (415) 555-1212 & Bob" → "Alice & Bob"), which the
+  // boilerplate `(\d{3})` truncation would otherwise drop. Sits after
+  // decodeEntities (in sanitizeRawFields) so HTML-encoded "+"/digits are seen decoded.
+  if (containsHarePii(h)) {
+    const scrubbed = scrubHarePii(h);
+    if (!scrubbed) return null;
+    h = scrubbed;
+  }
 
   // Truncate at boilerplate markers (description text leaked into hares).
   // If the whole value matches (idx === 0), drop it entirely — e.g. "On On Q"


### PR DESCRIPTION
## Context

The merge pipeline's `sanitizeHares` stripped only **trailing** logistics/boilerplate — it did **not** remove phone numbers or emails embedded mid-string in a hare line. Any source listing hare contacts inline therefore leaked PII into canonical, public-facing events. The Seoul H3 fix ([#2227](https://github.com/johnrclem/hashtracks-web/pull/2227)) was Korea-only and wired into a single adapter.

This generalizes phone/email scrubbing so **every adapter's `hares` is scrubbed at ingest**, and clears the existing prod backlog.

## Changes

- **New shared module** `src/adapters/hare-pii.ts` — `containsHarePii` / `scrubHarePii` / `HARE_PII_RES`, four anchored patterns kept as separate literals (Sonar S5843):
  - email
  - generic `+CC` international — digit-count floor `\+\d{1,3}[\s().-]*\d(?:[\s().-]*\d){6,13}` so the hash "+1" plus-one convention isn't clipped
  - global NA phone via `new RegExp(PHONE_NUMBER_RE.source, "g")` — single source of truth shared with the audit's `hare-phone-number` rule so `selfHealSanitizers` converges
  - Korean `\b01\d…` (load-bearing — NA's 3-3-4 / bare-10 doesn't match Korean 3-4-4)

  Detection uses `.search()` (avoids the `/g` `lastIndex` bug). `scrubHarePii` also has a regex-free paren-artifact cleanup so `"Just Jorge (973-760-5774)"` → `"Just Jorge"` instead of the dangling `"Just Jorge )"` the NA pattern's `\(?` would leave (balanced parens like `(1995-1996)` preserved).
- **Wired into `sanitizeHares`** — gated on `containsHarePii` so non-PII hares pass through **byte-identical** (no separator normalization → no fingerprint/audit churn). Runs before the boilerplate search so co-hares survive a mid-string phone (`"Alice (415) 555-1212 & Bob"` → `"Alice & Bob"`).
- **`sh3-pii.ts` reduced to a re-export shim** — Seoul adapter + its regression test unchanged (defense in depth, single source of truth).
- **One-off backfill** `scripts/backfill-hare-pii-scrub.ts` (dry-run default, `--apply` with optimistic-lock guard, scoped to PII-containing rows).

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (the `new RegExp` suppression mirrors `hare-extraction.ts`)
- `npm test` — **9291 passed, 0 failures** (new `hare-pii` suite, extended `sanitizeHares` block incl. a gate-preservation test, Seoul regression intact)
- Backfill against prod: dry-run found **30 / 34,976** rows with PII → reviewed → `--apply` wrote 30 → re-run confirms **0 remaining** (idempotent)

## Known, intentional gaps

Two conservative misses (prod-verified as the only ones), both rows still had their other PII stripped so neither re-triggers detection:
- leading-`0` national-without-`+` numbers — a pattern for them would false-positive on dotted dates like `07.08.2024`
- obfuscated `" at "` emails — too false-positive-prone to catch

🤖 Generated with [Claude Code](https://claude.com/claude-code)