### PR TITLE
fix(gcal): resolve six Google-Calendar field-extraction + coverage bugs

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2739,6 +2739,12 @@ export const SOURCES = [
       config: {
         calendarId: "0f125fcba18bfeca585fe7d3592c70159df9c97d620dfd68fd65a73fcd063d8c@group.calendar.google.com",
         defaultKennelTag: "salemh3",
+        // #2209: every future SalemH3 trail is published as an all-day
+        // (VALUE=DATE) event, so the default all-day filter dropped all of them
+        // (0 upcoming vs 39 in source). Admit all-day events, but drop the
+        // recurring "SalemH3 Placeholder (1st & 3rd Saturdays)" stubs.
+        includeAllDayEvents: true,
+        skipPatterns: ["SalemH3 Placeholder"],
       },
       kennelCodes: ["salemh3"],
     },
@@ -3069,6 +3075,12 @@ export const SOURCES = [
           ["^DIM", "dim-h3"],
         ],
         defaultKennelTag: "pph4",
+        // #2218: Kimchi's active recurring master is the bare placeholder
+        // "Kimchi #" (no run number / hares / location until the kennel fills in
+        // a per-week override). Substitute a readable trail name for the bare
+        // kennel-code/placeholder forms. Per-kennel keys leave pph4/dim-h3 alone.
+        defaultTitles: { "kimchi-h3": "Kimchi H3 Trail" },
+        staleTitleAliases: { "kimchi-h3": ["Kimchi #", "Kimchi"] },
       },
       kennelCodes: ["pph4", "kimchi-h3", "dim-h3"],
     },

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -6111,12 +6111,12 @@ describe("Thirstday H3 — empty 'Hares:' label must not capture next-line 'Note
 });
 
 describe('normalizeGCalDescription — Pandoc inline-math span $ restoration (#2217 LDS H3)', () => {
-  it('restores $ from a <span class="math inline"> \\( \\) cost artifact', () => {
+  it("restores $ from a Pandoc inline-math span cost artifact", () => {
     const { rawDescription, description } = normalizeGCalDescription(
-      'Hash cash: <span class="math inline">\\(5 (or \\)</span>1 and BYOB)',
+      String.raw`Hash cash: <span class="math inline">\(5 (or \)</span>1 and BYOB)`,
     );
     expect(rawDescription).toContain("$5 (or $1 and BYOB)");
-    expect(rawDescription).not.toContain("\\(");
+    expect(rawDescription).not.toContain(String.raw`\(`);
     expect(description).toContain("$5 (or $1 and BYOB)");
   });
 

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -6079,3 +6079,174 @@ describe("Colorado Springs H3 Calendar — PPH4 description-hare preference (#21
     expect(result!.hares).toBe("Slug");
   });
 });
+
+// ── Quick Win bundle: six GOOGLE_CALENDAR audit bugs ──────────────────────────
+
+describe("Thirstday H3 — empty 'Hares:' label must not capture next-line 'Notes:' (#2213)", () => {
+  const source = SOURCES.find((s) => s.name === "Chicagoland Hash Calendar");
+  if (!source?.config) throw new Error("Chicagoland Hash Calendar seed config missing");
+  const config = source.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it("yields no hare when the description is 'Hares: <br>Notes: <br>…'", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "Thirstday H3",
+        description:
+          'Hares: <br>Notes: <br><br><a href="http://www.chicagoth3.com/">http://www.chicagoth3.com/</a>',
+      }),
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe("th3");
+    expect(result?.hares).not.toBe("Notes:");
+    expect(result?.hares).toBeFalsy();
+  });
+
+  it("still captures a real same-line 'Hare: Name' (no #2122 regression)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary: "Thirstday H3", description: "Iron Girth with your Hare: NIPS" }),
+      config,
+    );
+    expect(result?.hares).toBe("NIPS");
+  });
+});
+
+describe('normalizeGCalDescription — Pandoc inline-math span $ restoration (#2217 LDS H3)', () => {
+  it('restores $ from a <span class="math inline"> \\( \\) cost artifact', () => {
+    const { rawDescription, description } = normalizeGCalDescription(
+      'Hash cash: <span class="math inline">\\(5 (or \\)</span>1 and BYOB)',
+    );
+    expect(rawDescription).toContain("$5 (or $1 and BYOB)");
+    expect(rawDescription).not.toContain("\\(");
+    expect(description).toContain("$5 (or $1 and BYOB)");
+  });
+
+  it("leaves descriptions without the math-span marker untouched", () => {
+    const { rawDescription } = normalizeGCalDescription("Meet at 6pm, $5 hash cash");
+    expect(rawDescription).toBe("Meet at 6pm, $5 hash cash");
+  });
+});
+
+describe("SEH3 — '(special location)' qualifier is not a hare (#2235)", () => {
+  const source = SOURCES.find((s) => s.name === "WA Hash Google Calendar");
+  if (!source?.config) throw new Error("WA Hash Google Calendar seed config missing");
+  const config = source.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it("strips '(special location)' from the title and leaves hares empty", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "South End H3 Happy Hour (special location)",
+        location: "8505 S 124th St, Seattle, WA 98178, USA",
+        start: { dateTime: "2026-06-25T17:00:00-07:00" },
+      }),
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe("seh3-wa");
+    expect(result?.hares).not.toBe("special location");
+    expect(result?.hares).toBeFalsy();
+    expect(result?.title).toBe("South End H3 Happy Hour");
+  });
+
+  it("still promotes a real trailing '(Hare Name)' (no paren-hare regression)", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "South End H3 Happy Hour (Just Bob)",
+        start: { dateTime: "2026-06-25T17:00:00-07:00" },
+      }),
+      config,
+    );
+    expect(result?.hares).toBe("Just Bob");
+  });
+});
+
+describe("Larryville H3 — location identical to title is dropped (#2231)", () => {
+  const source = SOURCES.find((s) => s.name === "Larryville H3 Google Calendar");
+  if (!source?.config) throw new Error("Larryville H3 Google Calendar seed config missing");
+  const config = source.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it("drops a location that is a verbatim copy of the title", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "Juneteenth parade downtown",
+        location: "Juneteenth parade downtown",
+        start: { dateTime: "2026-06-20T14:00:00-05:00" },
+      }),
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe("lh3-ks");
+    expect(result?.title).toBe("Juneteenth parade downtown");
+    expect(result?.location).toBeUndefined();
+  });
+
+  it("keeps a real address location", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "LH3 #687 - Dumpster Diving",
+        location: "The Wheel, 507 W 14th St, Lawrence, KS 66044, USA",
+        start: { dateTime: "2026-06-27T14:00:00-05:00" },
+      }),
+      config,
+    );
+    expect(result?.location).toContain("507 W 14th St");
+  });
+});
+
+describe("Kimchi — bare 'Kimchi #' placeholder gets a readable default title (#2218)", () => {
+  const source = SOURCES.find((s) => s.name === "Colorado Springs H3 Calendar");
+  if (!source?.config) throw new Error("Colorado Springs H3 Calendar seed config missing");
+  const config = source.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it.each([
+    ["Kimchi #", "Kimchi H3 Trail", "bare placeholder master"],
+    ["Kimchi", "Kimchi H3 Trail", "bare kennel name"],
+    ["Kimchi #606", "Kimchi H3 Trail #606", "bare numbered run"],
+  ])("title %j → %j (%s)", (summary, expectedTitle) => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({ summary, start: { dateTime: "2026-06-20T14:00:00-06:00" } }),
+      config,
+    );
+    expect(result?.kennelTags[0]).toBe("kimchi-h3");
+    expect(result?.title).toBe(expectedTitle);
+  });
+
+  it("leaves a themed Kimchi title untouched", () => {
+    const result = buildRawEventFromGCalItem(
+      testGCalEvent({
+        summary: "Kimchi #608: Kentucky Derby Hash",
+        start: { dateTime: "2026-06-20T14:00:00-06:00" },
+      }),
+      config,
+    );
+    expect(result?.title).toBe("Kimchi #608: Kentucky Derby Hash");
+  });
+});
+
+describe("Salem H3 — all-day events admitted, placeholder stubs skipped (#2209)", () => {
+  const source = SOURCES.find((s) => s.name === "Salem H3 Calendar");
+  if (!source?.config) throw new Error("Salem H3 Calendar seed config missing");
+  const config = source.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+  const skipOpts = { compiledSkipPatterns: compilePatterns(config?.skipPatterns ?? [], "i") };
+
+  it("admits an all-day named trail", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "🌤️SalemH3 Solstice Hash", start: { date: "2026-06-20" }, status: "confirmed" },
+      config,
+      skipOpts,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.kennelTags[0]).toBe("salemh3");
+    expect(result?.date).toBe("2026-06-20");
+  });
+
+  it("skips the recurring 'SalemH3 Placeholder' stubs", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "🐇SalemH3 Placeholder (1st & 3rd Saturdays)",
+        start: { date: "2026-07-04" },
+        status: "confirmed",
+      },
+      config,
+      skipOpts,
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -557,6 +557,11 @@ function isEventTypeOrThemeParen(inner: string): boolean {
 // reliable signal — real hare names never contain slash-separated date
 // tokens. Mirrors the same DATE_RANGE_RE in hare-extraction.ts.
 const DATE_RANGE_PAREN_RE = /\b\d{1,2}\s*\/\s*\d{1,2}\b/;
+// #2235 SEH3: a trailing parenthetical venue qualifier — "(special location)",
+// "(new location)", "(location TBD)" — is a location note, never a hare name.
+// Treated as instructional so it's stripped from the title and never promoted
+// to hares. Joins the same global reject family as NON_NAME / ACRONYM / etc.
+const LOCATION_QUALIFIER_PAREN_RE = /\blocation\b/i;
 const MAX_HARE_PAREN_LENGTH = 40;
 
 /**
@@ -975,7 +980,11 @@ export function extractCostFromDescription(description: string): string | undefi
  * (cleanAndFilterHares passes "TBD" through; this rejects it). A null/undefined
  * cleaner result means "no usable hare" → undefined.
  */
-const INLINE_HARE_LABEL_RE = /(?:^|[\s(])Hares?\s*:\s*([A-Z*][^\n]*)/;
+// #2213 Thirstday — `[ \t]*` (not `\s*`) after the label so an empty `Hares:`
+// label can't let the post-colon whitespace match cross a newline and capture
+// the NEXT line's label (`Hares: \nNotes:` → "Notes:"). This is a mid-line
+// `Hare: Name` extractor by design, so same-line whitespace is correct.
+const INLINE_HARE_LABEL_RE = /(?:^|[\s(])Hares?[ \t]*:[ \t]*([A-Z*][^\n]*)/;
 export function extractInlineHareFromDescription(description: string): string | undefined {
   const match = INLINE_HARE_LABEL_RE.exec(description);
   if (!match?.[1]) return undefined;
@@ -1352,6 +1361,15 @@ function extractDateTimeFromGCalItem(
 export function normalizeGCalDescription(rawDesc: string | undefined): { rawDescription: string | undefined; description: string | undefined } {
   if (!rawDesc) return { rawDescription: undefined, description: undefined };
   let rawDescription = stripHtmlTags(decodeEntities(rawDesc), "\n");
+  // #2217 LDS H3 — some kennels paste cost text copied from a Markdown/MathJax
+  // page where "$5 (or $1…" was rendered as a Pandoc inline-math span
+  // (<span class="math inline">\(5 (or \)</span>1…). After tag-stripping, the
+  // LaTeX \( / \) delimiters survive as garbled cost. Restore them to $. Gated
+  // on the span marker so unaffected descriptions are untouched; plain-string
+  // replaceAll keeps it off the Sonar regex radar.
+  if (rawDesc.includes("math inline")) {
+    rawDescription = rawDescription.replaceAll("\\(", "$").replaceAll("\\)", "$");
+  }
   // Strip mailto: link artifacts: "text (mailto:email)" → "text"
   rawDescription = rawDescription.replace(/\s*\(mailto:[^)]+\)/g, "");
   // Strip Harrier Central auto-generated header from GCal-synced events:
@@ -1842,6 +1860,7 @@ export function buildRawEventFromGCalItem(
       inner.length > MAX_HARE_PAREN_LENGTH ||
       INSTRUCTIONAL_PAREN_RE.test(inner) ||
       DATE_RANGE_PAREN_RE.test(inner) ||
+      LOCATION_QUALIFIER_PAREN_RE.test(inner) ||
       isEventTypeOrThemeParen(inner);
     // #1444 — three independent reject checks. NON_NAME catches descriptive
     // and status words; ACRONYM catches CTAs/units; isInitialsWordplay
@@ -2099,6 +2118,14 @@ export function buildRawEventFromGCalItem(
   const isRunDescriptor =
     sourceConfig?.mergeAllDayRunDescriptor === true && isAllDay && typeof runNumber === "number";
   const finalTitle = isRunDescriptor ? (extractRunDescriptorTheme(summary) || undefined) : title;
+
+  // #2231 Larryville — a venue is never a verbatim copy of the event title.
+  // Some kennels paste the event name into the GCal LOCATION field instead of an
+  // address ("Juneteenth parade downtown" in both summary and location); drop
+  // the duplicate so it doesn't masquerade as a geocodable location.
+  if (location && finalTitle && location.trim().toLowerCase() === finalTitle.trim().toLowerCase()) {
+    location = undefined;
+  }
 
   const event: RawEventData = {
     date: dateISO,

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -1368,7 +1368,7 @@ export function normalizeGCalDescription(rawDesc: string | undefined): { rawDesc
   // on the span marker so unaffected descriptions are untouched; plain-string
   // replaceAll keeps it off the Sonar regex radar.
   if (rawDesc.includes("math inline")) {
-    rawDescription = rawDescription.replaceAll("\\(", "$").replaceAll("\\)", "$");
+    rawDescription = rawDescription.replaceAll(String.raw`\(`, "$").replaceAll(String.raw`\)`, "$");
   }
   // Strip mailto: link artifacts: "text (mailto:email)" → "text"
   rawDescription = rawDescription.replace(/\s*\(mailto:[^)]+\)/g, "");
@@ -2123,7 +2123,7 @@ export function buildRawEventFromGCalItem(
   // Some kennels paste the event name into the GCal LOCATION field instead of an
   // address ("Juneteenth parade downtown" in both summary and location); drop
   // the duplicate so it doesn't masquerade as a geocodable location.
-  if (location && finalTitle && location.trim().toLowerCase() === finalTitle.trim().toLowerCase()) {
+  if (location && location.trim().toLowerCase() === finalTitle?.trim().toLowerCase()) {
     location = undefined;
   }
 


### PR DESCRIPTION
Quick Win bundle — six GOOGLE_CALENDAR bugs that all share one adapter
(`src/adapters/google-calendar/adapter.ts`) and per-source config in
`prisma/seed-data/sources.ts`. Each root cause was confirmed against the
calendar's **live iCal feed**, and every fix was **live-verified** by running
the real adapter against the live calendars.

## Fixes

**Adapter (narrow, generic invariant fixes)**
- **#2213 Thirstday** — `INLINE_HARE_LABEL_RE` now uses `[ \t]*` (not `\s*`) after the label, so an empty `Hares:` can't let the match cross a newline and capture the next line's `Notes:`. Same-line `Hare: Name` (#2122) still matches.
- **#2217 LDS** — `normalizeGCalDescription` unescapes in-source Pandoc inline-math spans (`<span class="math inline">\(5 (or \)…`) back to `$5 (or $1…`, gated on the `math inline` marker.
- **#2235 SEH3** — a trailing `(…location…)` parenthetical is treated as instructional, so `(special location)` is stripped from the title instead of being promoted to **Hares**.
- **#2231 Larryville** — drop a location that is a verbatim copy of the title.

**Per-source config**
- **#2209 Salem** — `includeAllDayEvents: true` + `skipPatterns: ["SalemH3 Placeholder"]`. Every future SalemH3 trail is published as an all-day `VALUE=DATE` event and was being dropped (0 upcoming vs 39 in source); the recurring placeholder stubs are filtered.
- **#2218 Kimchi** — per-kennel `defaultTitles`/`staleTitleAliases` so the bare recurring placeholder master `Kimchi #` renders as `Kimchi H3 Trail`.

## Documented as source data entry (no code fix)
- Duplicate `LDS #679` on two dates — the source itself has two events numbered #679; the kennel forgot to increment. Merge dedups on kennel+date, so distinct dates don't collide; fabricating run numbers would be wrong.
- The bare `Kimchi #` master — the kennel fills in run#/hares/location per-week via RECURRENCE-ID overrides later; the null fields are genuinely source-empty.

## Live verification (real adapter vs live calendars)
| Issue | Result |
|---|---|
| Kimchi | 26 upcoming → all `Kimchi H3 Trail` (was `Kimchi #`) |
| Thirstday | 52 upcoming → hares `null` (was `Notes:`) |
| LDS #680 | cost `$5 (or $1 and BYOB)`; 0 garbled `\(` across 67 events |
| SEH3 | no `special location` hare |
| Salem | 15 future named all-day events; 0 `Placeholder` stubs |
| Larryville | Jun 20 location dropped; 0 title==location |

**No sibling-kennel regressions on shared calendars:** ch3=53, sh3-wa=361, pph4=26.

## Tests / CI
- Added regression tests for all six in `adapter.test.ts`.
- `npx tsc --noEmit` clean · `npm run lint` 0 errors · `npm test` **9276 passed / 0 failed**.

Closes #2209
Closes #2213
Closes #2217
Closes #2218
Closes #2231
Closes #2235

🤖 Generated with [Claude Code](https://claude.com/claude-code)