### PR TITLE
fix(merge): collapse cross-source duplicate events (#2233)

### DIFF
--- a/scripts/cleanup-cross-source-placeholder-dupes.ts
+++ b/scripts/cleanup-cross-source-placeholder-dupes.ts
@@ -163,6 +163,96 @@ function isStub(e: EventRow, meta: TitleMeta): boolean {
 }
 
 interface GroupResult { merged: number; healed: number; keptSeparate: number; skippedDelete: number; }
+interface Heal { title?: string; hares?: string }
+
+/** Survivor rank: run-numbered (2) beats a real row (1) beats a content-free stub (0). */
+function survivorScore(e: EventRow, meta: TitleMeta): number {
+  if (e.runNumber != null) return 2;
+  return isStub(e, meta) ? 0 : 1;
+}
+
+/** The actual trail anchor: highest rank, then most complete, then oldest. */
+function pickSurvivor(group: EventRow[], meta: TitleMeta): EventRow {
+  return [...group].sort((a, b) =>
+    survivorScore(b, meta) - survivorScore(a, meta)
+    || completeness(b) - completeness(a)
+    || a.createdAt.getTime() - b.createdAt.getTime(),
+  )[0];
+}
+
+/** Title/hares to write onto the survivor when it currently holds a stub/default. */
+async function planHeal(survivor: EventRow, meta: TitleMeta, kennelCode: string): Promise<Heal> {
+  const { title: bestTitle, hares: bestHares } = await bestThemeFromRaws([survivor.id], meta);
+  const stubby = isReplaceableDefaultTitle(survivor.title, meta) || normalizeThemeTitle(survivor.title, meta) === "";
+  let title: string | undefined;
+  if (bestTitle && stubby) {
+    const next = resolveUpdatedTitle(bestTitle, survivor.title, meta, survivor.runNumber, kennelCode);
+    if (next !== survivor.title) title = next;
+  }
+  // Run hares through the same sanitizer the merge pipeline uses — drops
+  // placeholders ("TBD") and scrubs PII so the heal can't leak either.
+  const hares = survivor.haresText || !bestHares ? undefined : (sanitizeHares(bestHares) ?? undefined);
+  return { title, hares };
+}
+
+/** Split the group's non-survivor rows: a row folds in ONLY when it is the same
+ *  trail (content-free stub, SAME run number, or EXACT normalized-theme match);
+ *  everything else is a genuinely distinct event left as its own card. */
+function classifyGroup(group: EventRow[], survivor: EventRow, effectiveTheme: string, meta: TitleMeta) {
+  const merges: EventRow[] = [];
+  const keep: EventRow[] = [];
+  for (const e of group) {
+    if (e.id === survivor.id) continue;
+    const sameRun = survivor.runNumber != null && e.runNumber === survivor.runNumber;
+    const themeMatch = effectiveTheme !== "" && normalizeThemeTitle(e.title, meta) === effectiveTheme;
+    if (isStub(e, meta) || sameRun || themeMatch) merges.push(e);
+    else keep.push(e);
+  }
+  return { merges, keep };
+}
+
+/** `"Title A", "Title B"` — avoids nested template literals in log lines. */
+function titleList(rows: EventRow[]): string {
+  return rows.map((r) => `"${r.title ?? ""}"`).join(", ");
+}
+
+/** Re-point a loser's RawEvents / EventLinks / co-host EventKennels onto the
+ *  survivor, then race-safe-delete it. Returns whether the delete succeeded. */
+async function foldLoserIntoSurvivor(survivorId: string, loserId: string): Promise<boolean> {
+  await prisma.rawEvent.updateMany({ where: { eventId: loserId }, data: { eventId: survivorId } });
+
+  const survivorUrls = new Set(
+    (await prisma.eventLink.findMany({ where: { eventId: survivorId }, select: { url: true } })).map((l) => l.url),
+  );
+  const loserLinks = await prisma.eventLink.findMany({ where: { eventId: loserId }, select: { id: true, url: true } });
+  for (const link of loserLinks) {
+    if (survivorUrls.has(link.url)) continue;
+    await prisma.eventLink.update({ where: { id: link.id }, data: { eventId: survivorId } });
+    survivorUrls.add(link.url);
+  }
+
+  const survivorKennelIds = new Set(
+    (await prisma.eventKennel.findMany({ where: { eventId: survivorId }, select: { kennelId: true } })).map((k) => k.kennelId),
+  );
+  const loserSecondaries = await prisma.eventKennel.findMany({
+    where: { eventId: loserId, isPrimary: false },
+    select: { kennelId: true },
+  });
+  for (const ek of loserSecondaries) {
+    if (survivorKennelIds.has(ek.kennelId)) continue;
+    await prisma.eventKennel.create({ data: { eventId: survivorId, kennelId: ek.kennelId, isPrimary: false } });
+    survivorKennelIds.add(ek.kennelId);
+  }
+
+  // Race-safe: throws if hares/attendance/raws sneak in after the re-point above.
+  try {
+    await deleteLeakedEvent(prisma, loserId, ["hares", "attendances", "kennelAttendances", "rawEvents"]);
+    return true;
+  } catch (err) {
+    console.error(`      ⚠️  refused to delete loser ${loserId} — left intact:`, (err as Error).message);
+    return false;
+  }
+}
 
 async function collapseGroup(
   kennel: KennelMeta,
@@ -171,110 +261,39 @@ async function collapseGroup(
   apply: boolean,
   res: GroupResult,
 ): Promise<void> {
-  const titleMeta: TitleMeta = { kennelCode: kennel.kennelCode, shortName: kennel.shortName, fullName: kennel.fullName, aliases: kennel.aliases };
+  const meta: TitleMeta = { kennelCode: kennel.kennelCode, shortName: kennel.shortName, fullName: kennel.fullName, aliases: kennel.aliases };
+  const survivor = pickSurvivor(group, meta);
+  if (!survivor) return; // unreachable (group.length > 1) — guards the sort()[0] access
 
-  // SURVIVOR: prefer run-numbered, then a real (non-stub) row, then completeness,
-  // then oldest — the actual trail anchor for this date.
-  const survivor = [...group].sort((a, b) =>
-    (b.runNumber != null ? 1 : 0) - (a.runNumber != null ? 1 : 0)
-    || (isStub(a, titleMeta) ? 1 : 0) - (isStub(b, titleMeta) ? 1 : 0)
-    || completeness(b) - completeness(a)
-    || a.createdAt.getTime() - b.createdAt.getTime(),
-  )[0];
+  const heal = await planHeal(survivor, meta, kennel.kennelCode);
+  const effectiveTheme = normalizeThemeTitle(heal.title ?? survivor.title, meta);
+  const { merges, keep } = classifyGroup(group, survivor, effectiveTheme, meta);
 
-  // HEAL the survivor's title from its OWN raws when it holds a stub/default.
-  const { title: bestTitle, hares: bestHares } = await bestThemeFromRaws([survivor.id], titleMeta);
-  let healedTitle: string | undefined;
-  const survivorTitleIsStubby =
-    isReplaceableDefaultTitle(survivor.title, titleMeta) || normalizeThemeTitle(survivor.title, titleMeta) === "";
-  if (bestTitle && survivorTitleIsStubby) {
-    const next = resolveUpdatedTitle(bestTitle, survivor.title, titleMeta, survivor.runNumber, kennel.kennelCode);
-    if (next !== survivor.title) healedTitle = next;
-  }
-  // Run hares through the same sanitizer the merge pipeline uses — drops
-  // placeholders ("TBD") and scrubs PII so the heal can't leak either.
-  const healedHares = !survivor.haresText && bestHares ? (sanitizeHares(bestHares) ?? undefined) : undefined;
-
-  // A loser folds in ONLY if it is unmistakably the same trail: a content-free
-  // stub, the SAME run number, or an EXACT normalized-theme match. Everything
-  // else is a genuinely distinct event on the same date and is left as its own card.
-  const effectiveTheme = normalizeThemeTitle(healedTitle ?? survivor.title, titleMeta);
-  const merges: EventRow[] = [];
-  const keep: EventRow[] = [];
-  for (const e of group) {
-    if (e.id === survivor.id) continue;
-    const sameRun = survivor.runNumber != null && e.runNumber === survivor.runNumber;
-    const themeMatch = effectiveTheme !== "" && normalizeThemeTitle(e.title, titleMeta) === effectiveTheme;
-    if (isStub(e, titleMeta) || sameRun || themeMatch) merges.push(e);
-    else keep.push(e);
-  }
-
-  if (merges.length === 0) {
-    res.keptSeparate += keep.length;
-    return; // nothing collapses on this date (all rows distinct)
-  }
+  res.keptSeparate += keep.length;
+  if (merges.length === 0) return; // nothing collapses on this date (all rows distinct)
 
   console.log(
     `  MERGE ${kennel.kennelCode} ${day}: keep ${survivor.id} ` +
-      `(#${survivor.runNumber ?? "—"} "${survivor.title ?? ""}") ← ${merges.length} loser(s): ` +
-      merges.map((l) => `"${l.title ?? ""}"`).join(", "),
+      `(#${survivor.runNumber ?? "—"} "${survivor.title ?? ""}") ← ${merges.length} loser(s): ${titleList(merges)}`,
   );
-  if (keep.length > 0) console.log(`      keep separate: ${keep.map((k) => `"${k.title ?? ""}"`).join(", ")}`);
-  if (healedTitle) console.log(`      heal title: "${survivor.title ?? ""}" → "${healedTitle}"`);
-  if (healedHares) console.log(`      heal hares: → "${healedHares}"`);
+  if (keep.length > 0) console.log(`      keep separate: ${titleList(keep)}`);
+  if (heal.title) console.log(`      heal title: "${survivor.title ?? ""}" → "${heal.title}"`);
+  if (heal.hares) console.log(`      heal hares: → "${heal.hares}"`);
 
-  res.keptSeparate += keep.length;
   if (!apply) {
     res.merged += merges.length;
-    if (healedTitle || healedHares) res.healed++;
+    if (heal.title || heal.hares) res.healed++;
     return;
   }
 
-  const loserIds = merges.map((l) => l.id);
-
-  // 1. Re-point loser RawEvents onto the survivor (preserve the audit trail).
-  await prisma.rawEvent.updateMany({ where: { eventId: { in: loserIds } }, data: { eventId: survivor.id } });
-
-  // 2. Move loser EventLinks (dedup by url; remaining dup-url links cascade on delete).
-  const survivorUrls = new Set(
-    (await prisma.eventLink.findMany({ where: { eventId: survivor.id }, select: { url: true } })).map((l) => l.url),
-  );
-  const loserLinks = await prisma.eventLink.findMany({ where: { eventId: { in: loserIds } }, select: { id: true, url: true } });
-  for (const link of loserLinks) {
-    if (survivorUrls.has(link.url)) continue;
-    await prisma.eventLink.update({ where: { id: link.id }, data: { eventId: survivor.id } });
-    survivorUrls.add(link.url);
+  for (const loser of merges) {
+    if (await foldLoserIntoSurvivor(survivor.id, loser.id)) res.merged++;
+    else res.skippedDelete++;
   }
 
-  // 3. Move loser SECONDARY EventKennels (co-hosts) that the survivor lacks.
-  const survivorKennelIds = new Set(
-    (await prisma.eventKennel.findMany({ where: { eventId: survivor.id }, select: { kennelId: true } })).map((k) => k.kennelId),
-  );
-  const loserSecondaries = await prisma.eventKennel.findMany({
-    where: { eventId: { in: loserIds }, isPrimary: false },
-    select: { kennelId: true },
-  });
-  for (const ek of loserSecondaries) {
-    if (survivorKennelIds.has(ek.kennelId)) continue;
-    await prisma.eventKennel.create({ data: { eventId: survivor.id, kennelId: ek.kennelId, isPrimary: false } });
-    survivorKennelIds.add(ek.kennelId);
-  }
-
-  // 4. Delete the now-zero-raw losers (race-safe; throws if hares/attendance/raws sneak in).
-  for (const loserId of loserIds) {
-    try {
-      await deleteLeakedEvent(prisma, loserId, ["hares", "attendances", "kennelAttendances", "rawEvents"]);
-      res.merged++;
-    } catch (err) {
-      console.error(`      ⚠️  refused to delete loser ${loserId} — left intact:`, (err as Error).message);
-      res.skippedDelete++;
-    }
-  }
-
-  // 5. Heal the survivor's clobbered/stub title + missing hares.
   const healData: Record<string, unknown> = {};
-  if (healedTitle) healData.title = healedTitle;
-  if (healedHares) healData.haresText = healedHares;
+  if (heal.title) healData.title = heal.title;
+  if (heal.hares) healData.haresText = heal.hares;
   if (Object.keys(healData).length > 0) {
     await prisma.event.update({ where: { id: survivor.id }, data: healData });
     res.healed++;
@@ -304,18 +323,20 @@ async function main() {
       list.push(e);
       byDay.set(d, list);
     }
-    for (const [day, group] of [...byDay.entries()].sort()) {
+    const days = [...byDay.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+    for (const [day, group] of days) {
       if (group.length <= 1) continue;
       dupeGroups++;
       await collapseGroup(kennel, day, group, apply, res);
     }
   }
 
+  const verb = apply ? "Applied" : "Would apply";
+  const refused = res.skippedDelete ? `, ${res.skippedDelete} delete(s) refused by safety guard` : "";
   console.log(
-    `\n${apply ? "Applied" : "Would apply"}: ${dupeGroups} multi-row date-group(s) → ` +
+    `\n${verb}: ${dupeGroups} multi-row date-group(s) → ` +
       `${res.merged} stub/same-trail row(s) merged, ${res.healed} survivor title/hares heal(s), ` +
-      `${res.keptSeparate} distinct event(s) kept separate` +
-      (res.skippedDelete ? `, ${res.skippedDelete} delete(s) refused by safety guard` : ""),
+      `${res.keptSeparate} distinct event(s) kept separate${refused}`,
   );
 
   if (apply && res.merged > 0) {

--- a/scripts/cleanup-cross-source-placeholder-dupes.ts
+++ b/scripts/cleanup-cross-source-placeholder-dupes.ts
@@ -1,0 +1,329 @@
+/**
+ * One-shot cleanup for #2233 — cross-source duplicate events.
+ *
+ * Background:
+ *   Kennels fed by BOTH a GOOGLE_CALENDAR and a GOOGLE_SHEETS source accumulated
+ *   2–3 canonical Events per trail date. The calendar published content-free
+ *   stubs ("SH3 #?", "Seattle H3 Trail", empty summaries) and kennel-prefixed
+ *   themed entries ("SH3/NBH3 Gender Blender") that never merged with the sheet's
+ *   numbered/themed run, and a higher-trust stub title sometimes clobbered the
+ *   real theme on the run it DID merge into. The merge-pipeline fix (#2233)
+ *   prevents NEW duplicates, but existing RawEvents have stable fingerprints and
+ *   are never reprocessed — so the already-forked canonicals need a one-shot
+ *   collapse.
+ *
+ * Strategy (merge-in-place, NOT delete-and-rebuild — preserves Event ids):
+ *   Scope = kennels with both a GOOGLE_CALENDAR and a GOOGLE_SHEETS source.
+ *   ⚠️ These calendars are SHARED regional calendars: many same-date rows are
+ *   GENUINELY DISTINCT events mis-attributed to the host kennel (other kennels'
+ *   runs, holidays, memorials, social "hashy hour" notes). So the collapse
+ *   mirrors the forward Tier B/C semantics EXACTLY and is conservative — it only
+ *   folds a row into the survivor when that row is unmistakably the same trail:
+ *   a content-free STUB, the SAME run number, or an EXACT normalized-theme match.
+ *   Any row with a distinct real title is LEFT as its own card.
+ *
+ *   For each (kennel, UTC-date) group of >1 canonical, non-cancelled, non-series
+ *   Event:
+ *     1. SURVIVOR = run-numbered first, then non-stub, then most complete, then
+ *        oldest.
+ *     2. HEAL the survivor's title from its OWN RawEvents (sheet-preferred real
+ *        theme) when it currently holds a stub/default — undoes the title-clobber
+ *        so the surviving card shows run # + real theme; backfill hares too.
+ *     3. A loser MERGES into the survivor only if it is a content-free STUB, OR
+ *        carries the SAME run number, OR its normalized theme EXACTLY equals the
+ *        (healed) survivor theme. Otherwise it is KEPT SEPARATE.
+ *     4. Merge = re-point loser RawEvents onto the survivor (keep the audit
+ *        trail), move loser EventLinks (dedup by url) + secondary EventKennels,
+ *        then delete the now-zero-raw losers via the race-safe `deleteLeakedEvent`
+ *        (requireZeroCounts: hares/attendances/kennelAttendances/rawEvents — any
+ *        stray row rolls the delete back, so this is fail-safe).
+ *   Recompute Kennel.lastEventDate at the end.
+ *
+ * Safety: a distinct real event is never merged (only stubs / same-run /
+ * exact-theme). Groups with attendance / hares on any merged row are additionally
+ * protected by `deleteLeakedEvent`'s requireZeroCounts guard (the delete throws
+ * and that loser is logged + left intact).
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/cleanup-cross-source-placeholder-dupes.ts
+ *   Apply:   npx tsx scripts/cleanup-cross-source-placeholder-dupes.ts --apply
+ *   Limit:   add a kennelCode to scope to one kennel, e.g. `... --apply sh3-wa`
+ */
+import "dotenv/config";
+import { prisma } from "@/lib/db";
+import { backfillLastEventDates } from "@/pipeline/backfill-last-event";
+import { isReplaceableDefaultTitle, normalizeThemeTitle, resolveUpdatedTitle, sanitizeHares } from "@/pipeline/merge";
+import { deleteLeakedEvent } from "./lib/delete-leaked-event";
+
+interface KennelMeta {
+  id: string;
+  kennelCode: string;
+  shortName: string;
+  fullName: string | null;
+  aliases: string[];
+}
+
+const EVENT_SELECT = {
+  id: true,
+  date: true,
+  runNumber: true,
+  title: true,
+  haresText: true,
+  locationName: true,
+  locationAddress: true,
+  description: true,
+  startTime: true,
+  cost: true,
+  createdAt: true,
+} as const;
+type EventRow = {
+  id: string;
+  date: Date;
+  runNumber: number | null;
+  title: string | null;
+  haresText: string | null;
+  locationName: string | null;
+  locationAddress: string | null;
+  description: string | null;
+  startTime: string | null;
+  cost: string | null;
+  createdAt: Date;
+};
+
+/** Count of populated display fields — the survivor tie-break (mirrors merge's completeness intent). */
+function completeness(e: EventRow): number {
+  return [e.runNumber, e.haresText, e.locationName, e.locationAddress, e.description, e.startTime, e.cost]
+    .filter((v) => v != null && v !== "").length;
+}
+
+/** Kennels fed by BOTH a GOOGLE_CALENDAR and a GOOGLE_SHEETS source. */
+async function calendarSheetKennels(only?: string): Promise<KennelMeta[]> {
+  const links = await prisma.sourceKennel.findMany({
+    select: { kennelId: true, source: { select: { type: true } } },
+  });
+  const typesByKennel = new Map<string, Set<string>>();
+  for (const l of links) {
+    const set = typesByKennel.get(l.kennelId) ?? new Set<string>();
+    set.add(l.source.type);
+    typesByKennel.set(l.kennelId, set);
+  }
+  const ids = [...typesByKennel.entries()]
+    .filter(([, t]) => t.has("GOOGLE_CALENDAR") && t.has("GOOGLE_SHEETS"))
+    .map(([id]) => id);
+  if (ids.length === 0) return [];
+  const kennels = await prisma.kennel.findMany({
+    where: { id: { in: ids }, ...(only ? { kennelCode: only } : {}) },
+    select: { id: true, kennelCode: true, shortName: true, fullName: true, aliases: { select: { alias: true } } },
+  });
+  return kennels.map((k) => ({
+    id: k.id,
+    kennelCode: k.kennelCode,
+    shortName: k.shortName,
+    fullName: k.fullName,
+    aliases: k.aliases.map((a) => a.alias),
+  }));
+}
+
+type TitleMeta = { kennelCode: string; shortName: string; fullName: string | null; aliases: string[] };
+
+/** Best real-theme title + hares among a set of RawEvents (sheet-preferred). */
+async function bestThemeFromRaws(
+  eventIds: string[],
+  titleMeta: TitleMeta,
+): Promise<{ title?: string; hares?: string }> {
+  if (eventIds.length === 0) return {};
+  const raws = await prisma.rawEvent.findMany({
+    where: { eventId: { in: eventIds } },
+    select: { rawData: true, source: { select: { type: true } } },
+  });
+  let title: string | undefined;
+  let titleIsSheet = false;
+  let hares: string | undefined;
+  for (const r of raws) {
+    const data = r.rawData as { title?: unknown; hares?: unknown } | null;
+    const isSheet = r.source.type === "GOOGLE_SHEETS";
+    const t = typeof data?.title === "string" ? data.title.trim() : "";
+    if (t && !isReplaceableDefaultTitle(t, titleMeta) && normalizeThemeTitle(t, titleMeta) !== ""
+        && (title === undefined || (isSheet && !titleIsSheet))) {
+      title = t;
+      titleIsSheet = isSheet;
+    }
+    const h = typeof data?.hares === "string" ? data.hares.trim() : "";
+    if (h && (hares === undefined || isSheet)) hares = h;
+  }
+  return { title, hares };
+}
+
+/** A content-free placeholder: no run number, no hares, and a title that is a
+ *  replaceable default OR normalizes to no theme at all ("SH3", "SH3 #?"). */
+function isStub(e: EventRow, meta: TitleMeta): boolean {
+  return e.runNumber == null
+    && !e.haresText
+    && (isReplaceableDefaultTitle(e.title, meta) || normalizeThemeTitle(e.title, meta) === "");
+}
+
+interface GroupResult { merged: number; healed: number; keptSeparate: number; skippedDelete: number; }
+
+async function collapseGroup(
+  kennel: KennelMeta,
+  day: string,
+  group: EventRow[],
+  apply: boolean,
+  res: GroupResult,
+): Promise<void> {
+  const titleMeta: TitleMeta = { kennelCode: kennel.kennelCode, shortName: kennel.shortName, fullName: kennel.fullName, aliases: kennel.aliases };
+
+  // SURVIVOR: prefer run-numbered, then a real (non-stub) row, then completeness,
+  // then oldest — the actual trail anchor for this date.
+  const survivor = [...group].sort((a, b) =>
+    (b.runNumber != null ? 1 : 0) - (a.runNumber != null ? 1 : 0)
+    || (isStub(a, titleMeta) ? 1 : 0) - (isStub(b, titleMeta) ? 1 : 0)
+    || completeness(b) - completeness(a)
+    || a.createdAt.getTime() - b.createdAt.getTime(),
+  )[0];
+
+  // HEAL the survivor's title from its OWN raws when it holds a stub/default.
+  const { title: bestTitle, hares: bestHares } = await bestThemeFromRaws([survivor.id], titleMeta);
+  let healedTitle: string | undefined;
+  const survivorTitleIsStubby =
+    isReplaceableDefaultTitle(survivor.title, titleMeta) || normalizeThemeTitle(survivor.title, titleMeta) === "";
+  if (bestTitle && survivorTitleIsStubby) {
+    const next = resolveUpdatedTitle(bestTitle, survivor.title, titleMeta, survivor.runNumber, kennel.kennelCode);
+    if (next !== survivor.title) healedTitle = next;
+  }
+  // Run hares through the same sanitizer the merge pipeline uses — drops
+  // placeholders ("TBD") and scrubs PII so the heal can't leak either.
+  const healedHares = !survivor.haresText && bestHares ? (sanitizeHares(bestHares) ?? undefined) : undefined;
+
+  // A loser folds in ONLY if it is unmistakably the same trail: a content-free
+  // stub, the SAME run number, or an EXACT normalized-theme match. Everything
+  // else is a genuinely distinct event on the same date and is left as its own card.
+  const effectiveTheme = normalizeThemeTitle(healedTitle ?? survivor.title, titleMeta);
+  const merges: EventRow[] = [];
+  const keep: EventRow[] = [];
+  for (const e of group) {
+    if (e.id === survivor.id) continue;
+    const sameRun = survivor.runNumber != null && e.runNumber === survivor.runNumber;
+    const themeMatch = effectiveTheme !== "" && normalizeThemeTitle(e.title, titleMeta) === effectiveTheme;
+    if (isStub(e, titleMeta) || sameRun || themeMatch) merges.push(e);
+    else keep.push(e);
+  }
+
+  if (merges.length === 0) {
+    res.keptSeparate += keep.length;
+    return; // nothing collapses on this date (all rows distinct)
+  }
+
+  console.log(
+    `  MERGE ${kennel.kennelCode} ${day}: keep ${survivor.id} ` +
+      `(#${survivor.runNumber ?? "—"} "${survivor.title ?? ""}") ← ${merges.length} loser(s): ` +
+      merges.map((l) => `"${l.title ?? ""}"`).join(", "),
+  );
+  if (keep.length > 0) console.log(`      keep separate: ${keep.map((k) => `"${k.title ?? ""}"`).join(", ")}`);
+  if (healedTitle) console.log(`      heal title: "${survivor.title ?? ""}" → "${healedTitle}"`);
+  if (healedHares) console.log(`      heal hares: → "${healedHares}"`);
+
+  res.keptSeparate += keep.length;
+  if (!apply) {
+    res.merged += merges.length;
+    if (healedTitle || healedHares) res.healed++;
+    return;
+  }
+
+  const loserIds = merges.map((l) => l.id);
+
+  // 1. Re-point loser RawEvents onto the survivor (preserve the audit trail).
+  await prisma.rawEvent.updateMany({ where: { eventId: { in: loserIds } }, data: { eventId: survivor.id } });
+
+  // 2. Move loser EventLinks (dedup by url; remaining dup-url links cascade on delete).
+  const survivorUrls = new Set(
+    (await prisma.eventLink.findMany({ where: { eventId: survivor.id }, select: { url: true } })).map((l) => l.url),
+  );
+  const loserLinks = await prisma.eventLink.findMany({ where: { eventId: { in: loserIds } }, select: { id: true, url: true } });
+  for (const link of loserLinks) {
+    if (survivorUrls.has(link.url)) continue;
+    await prisma.eventLink.update({ where: { id: link.id }, data: { eventId: survivor.id } });
+    survivorUrls.add(link.url);
+  }
+
+  // 3. Move loser SECONDARY EventKennels (co-hosts) that the survivor lacks.
+  const survivorKennelIds = new Set(
+    (await prisma.eventKennel.findMany({ where: { eventId: survivor.id }, select: { kennelId: true } })).map((k) => k.kennelId),
+  );
+  const loserSecondaries = await prisma.eventKennel.findMany({
+    where: { eventId: { in: loserIds }, isPrimary: false },
+    select: { kennelId: true },
+  });
+  for (const ek of loserSecondaries) {
+    if (survivorKennelIds.has(ek.kennelId)) continue;
+    await prisma.eventKennel.create({ data: { eventId: survivor.id, kennelId: ek.kennelId, isPrimary: false } });
+    survivorKennelIds.add(ek.kennelId);
+  }
+
+  // 4. Delete the now-zero-raw losers (race-safe; throws if hares/attendance/raws sneak in).
+  for (const loserId of loserIds) {
+    try {
+      await deleteLeakedEvent(prisma, loserId, ["hares", "attendances", "kennelAttendances", "rawEvents"]);
+      res.merged++;
+    } catch (err) {
+      console.error(`      ⚠️  refused to delete loser ${loserId} — left intact:`, (err as Error).message);
+      res.skippedDelete++;
+    }
+  }
+
+  // 5. Heal the survivor's clobbered/stub title + missing hares.
+  const healData: Record<string, unknown> = {};
+  if (healedTitle) healData.title = healedTitle;
+  if (healedHares) healData.haresText = healedHares;
+  if (Object.keys(healData).length > 0) {
+    await prisma.event.update({ where: { id: survivor.id }, data: healData });
+    res.healed++;
+  }
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const only = process.argv.slice(2).find((a) => a !== "--apply");
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}${only ? ` (kennel ${only})` : ""}`);
+
+  const kennels = await calendarSheetKennels(only);
+  console.log(`Calendar+sheet kennels in scope: ${kennels.map((k) => k.kennelCode).join(", ") || "(none)"}`);
+
+  const res: GroupResult = { merged: 0, healed: 0, keptSeparate: 0, skippedDelete: 0 };
+  let dupeGroups = 0;
+
+  for (const kennel of kennels) {
+    const events = await prisma.event.findMany({
+      where: { kennelId: kennel.id, isCanonical: true, status: { not: "CANCELLED" }, parentEventId: null, isSeriesParent: false },
+      select: EVENT_SELECT,
+    });
+    const byDay = new Map<string, EventRow[]>();
+    for (const e of events) {
+      const d = e.date.toISOString().slice(0, 10);
+      const list = byDay.get(d) ?? [];
+      list.push(e);
+      byDay.set(d, list);
+    }
+    for (const [day, group] of [...byDay.entries()].sort()) {
+      if (group.length <= 1) continue;
+      dupeGroups++;
+      await collapseGroup(kennel, day, group, apply, res);
+    }
+  }
+
+  console.log(
+    `\n${apply ? "Applied" : "Would apply"}: ${dupeGroups} multi-row date-group(s) → ` +
+      `${res.merged} stub/same-trail row(s) merged, ${res.healed} survivor title/hares heal(s), ` +
+      `${res.keptSeparate} distinct event(s) kept separate` +
+      (res.skippedDelete ? `, ${res.skippedDelete} delete(s) refused by safety guard` : ""),
+  );
+
+  if (apply && res.merged > 0) {
+    const n = await backfillLastEventDates();
+    console.log(`Recomputed lastEventDate for ${n} kennel(s).`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => { console.error(err); process.exit(1); });

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -5651,6 +5651,15 @@ describe("normalizeThemeTitle (#2233)", () => {
     // The synthesized default normalizes to itself (Tier B, not C, handles it).
     expect(normalizeThemeTitle("Seattle H3 Trail", sh3)).toBe("seattle h3 trail");
   });
+
+  it("does NOT strip a leading ordinal token (starts with a digit, not a kennel code)", () => {
+    // Kennel codes start with a letter; ordinals start with a digit. Stripping
+    // "2nd"/"3rd" would let distinct "Nth Annual" events collapse (claude review).
+    expect(normalizeThemeTitle("2nd Annual Red Dress Run", sh3)).toBe("2nd annual red dress run");
+    expect(normalizeThemeTitle("3rd Annual Red Dress Run", sh3)).not.toBe(
+      normalizeThemeTitle("2nd Annual Red Dress Run", sh3),
+    );
+  });
 });
 
 describe("cross-source same-day merge (#2233)", () => {
@@ -5667,7 +5676,7 @@ describe("cross-source same-day merge (#2233)", () => {
       country: "United States",
       regionRef: null,
       aliases: [],
-    } as never);
+    } as unknown as Awaited<ReturnType<typeof prisma.kennel.findUnique>>);
   });
 
   it("Tier B: absorbs a content-free calendar stub into the same-day numbered run", async () => {
@@ -5773,6 +5782,30 @@ describe("cross-source same-day merge (#2233)", () => {
       buildRawEvent({ kennelTags: ["sh3-wa"], runNumber: 940, title: "Third Trail", hares: "Q", location: undefined, startTime: undefined, sourceUrl: "https://sheet" }),
     ]);
 
+    expect(result.created).toBe(1);
+    expect(mockEventCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("Tier C does NOT merge a same-theme sibling that carries a conflicting run number", async () => {
+    // Recurring "Red Dress Run": existing #939 vs incoming #940 share a normalized
+    // theme but are distinct runs. The run-number conflict guard must keep them
+    // split — without it, Tier C would weld #940 onto #939 and a higher/equal-trust
+    // update could overwrite #939's run number (Codex review on #2233).
+    mockSourceFind.mockResolvedValue(sourceRow({
+      trustLevel: 5, type: "GOOGLE_SHEETS", kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_939", trustLevel: 5, runNumber: 939, title: "SH3 Red Dress Run", haresText: null, sourceUrl: "https://cal", status: "CONFIRMED", createdAt: new Date("2026-01-01") },
+      { id: "evt_other", trustLevel: 5, runNumber: 7, title: "Some Other Trail", haresText: "Q", sourceUrl: "https://cal2", status: "CONFIRMED", createdAt: new Date("2026-01-02") },
+    ] as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_940"));
+
+    const result = await processRawEvents("src_sheet", [
+      buildRawEvent({ kennelTags: ["sh3-wa"], runNumber: 940, title: "Red Dress Run", hares: undefined, location: undefined, startTime: undefined, sourceUrl: "https://sheet" }),
+    ]);
+
+    // #940 must create its own canonical, not merge onto #939.
     expect(result.created).toBe(1);
     expect(mockEventCreate).toHaveBeenCalledTimes(1);
   });

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -49,7 +49,7 @@ import { prisma } from "@/lib/db";
 import { Prisma } from "@/generated/prisma/client";
 import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag } from "./kennel-resolver";
-import { processRawEvents, sanitizeTitle, sanitizeLocation, sanitizeHares, friendlyKennelName, rewriteStaleDefaultTitle, resolveUpdatedTitle, isReplaceableDefaultTitle, suppressRedundantCity, NON_ENGLISH_GEO_RE, completenessScore, pickCanonicalEventId, pickCanonicalEventIds, isAdminLocked } from "./merge";
+import { processRawEvents, sanitizeTitle, sanitizeLocation, sanitizeHares, friendlyKennelName, rewriteStaleDefaultTitle, resolveUpdatedTitle, isReplaceableDefaultTitle, normalizeThemeTitle, suppressRedundantCity, NON_ENGLISH_GEO_RE, completenessScore, pickCanonicalEventId, pickCanonicalEventIds, isAdminLocked } from "./merge";
 
 const mockSourceFind = vi.mocked(prisma.source.findUnique);
 const _mockSourceUpdate = vi.mocked(prisma.source.update);
@@ -3100,6 +3100,20 @@ describe("resolveUpdatedTitle", () => {
   it("synthesizes when both incoming and existing are absent", () => {
     expect(resolveUpdatedTitle(undefined, null, sh3, 7, "sh3-wa")).toBe("Seattle H3 Trail #7");
   });
+
+  // #2233 — a higher-trust source's placeholder title must NOT clobber a real
+  // theme already on the canonical. The WA Hash Google Calendar (trust 7) emits
+  // "SH3 #?" / "Seattle H3 Trail" stubs on the same date as the sheet's themed
+  // run; pre-fix the stub took the full-update branch and overwrote the theme.
+  it("does not let a themeless placeholder incoming clobber a real existing title", () => {
+    expect(resolveUpdatedTitle("SH3 #?", "Gender Blender", sh3, 1020, "sh3-wa")).toBe("Gender Blender");
+    expect(resolveUpdatedTitle("SH3 #? (TBD)", "Hashmas", sh3, 1025, "sh3-wa")).toBe("Hashmas");
+  });
+
+  it("does not let a synthesized-default incoming clobber a real existing title", () => {
+    expect(resolveUpdatedTitle("Seattle H3 Trail", "Gender Blender", sh3, 1020, "sh3-wa")).toBe("Gender Blender");
+    expect(resolveUpdatedTitle("sh3-wa Trail #1020", "Gender Blender", sh3, 1020, "sh3-wa")).toBe("Gender Blender");
+  });
 });
 
 // ── sanitizeLocation ──
@@ -5599,6 +5613,168 @@ describe("lower-trust enrichment title/runNumber backfill (#2130 / #2145)", () =
     expect(data).not.toHaveProperty("title");
     // runNumber already present on the canonical → not backfilled.
     expect(data).not.toHaveProperty("runNumber");
+  });
+});
+
+// ── #2233 — cross-source duplicate events. A kennel fed by BOTH a calendar and
+// a hareline sheet got 2–3 cards per Saturday: the calendar's content-free stubs
+// ("SH3 #?", "Seattle H3 Trail") and kennel-prefixed themed entries
+// ("SH3/NBH3 Gender Blender") never merged with the sheet's numbered themed run.
+describe("normalizeThemeTitle (#2233)", () => {
+  const sh3 = { kennelCode: "sh3-wa", shortName: "SH3", fullName: "Seattle Hash House Harriers", aliases: [] };
+
+  it("returns the bare lowercased theme for a plain title", () => {
+    expect(normalizeThemeTitle("Gender Blender", sh3)).toBe("gender blender");
+  });
+
+  it("strips a leading kennel-code prefix", () => {
+    expect(normalizeThemeTitle("SH3 Hashmas", sh3)).toBe("hashmas");
+    expect(normalizeThemeTitle("SH3 Red Dress Run", sh3)).toBe("red dress run");
+  });
+
+  it("strips a leading co-host kennel-code run", () => {
+    // "NBH3" is a different kennel (co-host); the digit-bearing code-token
+    // heuristic strips it even though it isn't one of sh3-wa's identifiers.
+    expect(normalizeThemeTitle("SH3/NBH3 Gender Blender", sh3)).toBe("gender blender");
+  });
+
+  it("returns '' for content-free stubs (placeholder tier owns them)", () => {
+    expect(normalizeThemeTitle("SH3 #? (TBD)", sh3)).toBe("");
+    expect(normalizeThemeTitle("SH3 #?", sh3)).toBe("");
+    expect(normalizeThemeTitle("", sh3)).toBe("");
+    expect(normalizeThemeTitle(null, sh3)).toBe("");
+  });
+
+  it("does NOT strip a plain leading theme word that merely looks capitalized", () => {
+    // "Gender" has no digit and isn't a known identifier → never a kennel code.
+    expect(normalizeThemeTitle("Gender Blender", sh3)).toBe("gender blender");
+    // The synthesized default normalizes to itself (Tier B, not C, handles it).
+    expect(normalizeThemeTitle("Seattle H3 Trail", sh3)).toBe("seattle h3 trail");
+  });
+});
+
+describe("cross-source same-day merge (#2233)", () => {
+  // resolveKennelData reads prisma.kennel.findUnique; the Seattle identity makes
+  // isReplaceableDefaultTitle recognize the synthesized "Seattle H3 Trail" default.
+  beforeEach(() => {
+    vi.mocked(prisma.kennel.findUnique).mockResolvedValue({
+      kennelCode: "sh3-wa",
+      shortName: "SH3",
+      fullName: "Seattle Hash House Harriers",
+      region: "Seattle, WA",
+      latitude: null,
+      longitude: null,
+      country: "United States",
+      regionRef: null,
+      aliases: [],
+    } as never);
+  });
+
+  it("Tier B: absorbs a content-free calendar stub into the same-day numbered run", async () => {
+    // Calendar (trust 7) publishes a generic "SH3 #? (TBD)" stub AND a themed
+    // special; the sheet (trust 5) carries the real numbered run. The stub must
+    // merge into the run, not survive as its own card — and must NOT clobber the
+    // run's theme (Fix A).
+    mockSourceFind.mockResolvedValue(sourceRow({
+      trustLevel: 7, type: "GOOGLE_CALENDAR", kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_run", trustLevel: 5, runNumber: 1020, title: "Gender Blender", haresText: "NB H3", sourceUrl: "https://sheet", status: "CONFIRMED", createdAt: new Date("2026-01-01") },
+      { id: "evt_special", trustLevel: 7, runNumber: null, title: "SH3/NBH3 Gender Blender", haresText: null, sourceUrl: "https://cal/special", status: "CONFIRMED", createdAt: new Date("2026-01-02") },
+    ] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_run"));
+
+    const result = await processRawEvents("src_cal", [
+      buildRawEvent({ kennelTags: ["sh3-wa"], runNumber: undefined, title: "SH3 #? (TBD)", hares: undefined, location: undefined, startTime: undefined, sourceUrl: "https://cal/stub" }),
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(mockEventCreate).not.toHaveBeenCalled();
+    const call = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_run",
+    );
+    expect(call).toBeDefined();
+    const data = (call![0] as { data: Record<string, unknown> }).data;
+    expect(data.title).toBe("Gender Blender"); // stub did not clobber the theme
+    // The stub's URL is recorded as an EventLink on the run.
+    expect(vi.mocked(prisma.eventLink.createMany)).toHaveBeenCalled();
+  });
+
+  it("Tier B: works regardless of order — sheet run incoming absorbs an existing calendar stub", async () => {
+    // Reverse order: the calendar stub canonical exists first; the sheet's
+    // numbered themed run arrives and must absorb the stub rather than fork.
+    mockSourceFind.mockResolvedValue(sourceRow({
+      trustLevel: 5, type: "GOOGLE_SHEETS", kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_stub", trustLevel: 7, runNumber: null, title: "Seattle H3 Trail", haresText: null, sourceUrl: "https://cal/stub", status: "CONFIRMED", createdAt: new Date("2026-01-01") },
+      { id: "evt_special", trustLevel: 7, runNumber: null, title: "SH3 Red Dress Run", haresText: null, sourceUrl: "https://cal/special", status: "CONFIRMED", createdAt: new Date("2026-01-02") },
+    ] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_stub"));
+
+    const result = await processRawEvents("src_sheet", [
+      buildRawEvent({ kennelTags: ["sh3-wa"], runNumber: 1028, title: "Erections", hares: "HFU", sourceUrl: "https://sheet", startTime: undefined }),
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(mockEventCreate).not.toHaveBeenCalled();
+    // The real run merged into the stub canonical (evt_stub), backfilling title +
+    // run number via the lower-trust enrich branch (#2130 / #2145).
+    const call = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_stub",
+    );
+    expect(call).toBeDefined();
+    const data = (call![0] as { data: Record<string, unknown> }).data;
+    expect(data.title).toBe("Erections");
+    expect(data.runNumber).toBe(1028);
+  });
+
+  it("Tier C: merges a kennel-prefixed themed calendar entry into the sheet run by normalized theme", async () => {
+    // Calendar "SH3 Hashmas" ↔ sheet "Hashmas" #1025 are the same trail; they
+    // collapse to one card once the kennel-code prefix is normalized away.
+    mockSourceFind.mockResolvedValue(sourceRow({
+      trustLevel: 7, type: "GOOGLE_CALENDAR", kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_run", trustLevel: 5, runNumber: 1025, title: "Hashmas", haresText: null, sourceUrl: "https://sheet", status: "CONFIRMED", createdAt: new Date("2026-01-01") },
+      { id: "evt_stub", trustLevel: 7, runNumber: null, title: "Seattle H3 Trail", haresText: null, sourceUrl: "https://cal/stub", status: "CONFIRMED", createdAt: new Date("2026-01-02") },
+    ] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_run"));
+
+    const result = await processRawEvents("src_cal", [
+      buildRawEvent({ kennelTags: ["sh3-wa"], runNumber: undefined, title: "SH3 Hashmas", hares: undefined, location: undefined, startTime: undefined, sourceUrl: "https://cal/hashmas" }),
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(mockEventCreate).not.toHaveBeenCalled();
+    expect(mockEventUpdate.mock.calls.some(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_run",
+    )).toBe(true);
+  });
+
+  it("does NOT merge a genuine distinct same-day run (no placeholder, no theme match)", async () => {
+    // Three real runs on one Saturday: the new #940 shares neither a theme nor a
+    // run number with #938/#939, and none is a content-free placeholder — so it
+    // must create its own canonical (Tier B/C must not weld real runs together).
+    mockSourceFind.mockResolvedValue(sourceRow({
+      trustLevel: 5, type: "GOOGLE_SHEETS", kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_938", trustLevel: 5, runNumber: 938, title: "Trail A", haresText: "Y", sourceUrl: "https://sheet", status: "CONFIRMED", createdAt: new Date("2026-01-01") },
+      { id: "evt_939", trustLevel: 5, runNumber: 939, title: "Trail B", haresText: "Z", sourceUrl: "https://sheet", status: "CONFIRMED", createdAt: new Date("2026-01-02") },
+    ] as never);
+    mockEventCreate.mockResolvedValueOnce(eventRow("evt_940"));
+
+    const result = await processRawEvents("src_sheet", [
+      buildRawEvent({ kennelTags: ["sh3-wa"], runNumber: 940, title: "Third Trail", hares: "Q", location: undefined, startTime: undefined, sourceUrl: "https://sheet" }),
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(mockEventCreate).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1032,27 +1032,22 @@ export function isReplaceableDefaultTitle(
 }
 
 /**
- * Leading kennel-code / placeholder-marker token at the start of a title.
- * Bounded length, single char class — ReDoS-safe (no nested quantifiers).
- */
-const LEADING_TITLE_TOKEN_RE = /^[\s/&,+]*(?:and\s+)?([A-Za-z0-9#?.'-]{1,12})/i;
-
-/**
  * Normalize a title to its bare "theme" for cross-source same-day matching
- * (#2233). Strips a leading run of co-hosting kennel-code tokens (`SH3`,
- * `SH3/NBH3`) and placeholder run markers (`#?`), then lowercases + collapses
- * whitespace. Returns `""` for content-free stubs so the normalized-theme match
- * tier never welds two unrelated placeholders together — stubs are handled by
- * the placeholder-absorption tier instead.
+ * (#2233). Drops a leading run of co-hosting kennel-code tokens (`SH3`,
+ * `SH3/NBH3`), the connector word "and", and placeholder run markers (`#?`),
+ * then lowercases. Returns `""` for content-free stubs so the normalized-theme
+ * match tier never welds two unrelated placeholders together — stubs are handled
+ * by the placeholder-absorption tier instead.
  *
- *   "Gender Blender"           → "gender blender"
- *   "SH3 Hashmas"              → "hashmas"
- *   "SH3/NBH3 Gender Blender"  → "gender blender"   (co-host prefix stripped)
- *   "SH3 #? (TBD)" / "SH3 #?"  → ""                 (stub)
+ *   "Gender Blender"            → "gender blender"
+ *   "SH3 Hashmas"               → "hashmas"
+ *   "SH3/NBH3 Gender Blender"   → "gender blender"            (co-host prefix stripped)
+ *   "SH3 #? (TBD)" / "SH3 #?"   → ""                          (stub)
  *   "SH3 (Catholic School Girl)" → "catholic school girl"
+ *   "2nd Annual Red Dress Run"  → "2nd annual red dress run"  (ordinal NOT a code)
  *
- * Deterministic, ReDoS-safe: one bounded leading-token regex applied in a loop
- * with monotonic progress (`rest` strictly shrinks; capped iterations).
+ * Tokenized with plain string splits (no `\s*`-adjacent alternation) so it can't
+ * regress into a ReDoS shape.
  */
 export function normalizeThemeTitle(
   title: string | null,
@@ -1065,23 +1060,26 @@ export function normalizeThemeTitle(
       .filter((s): s is string => !!s)
       .map((s) => s.toLowerCase()),
   );
-  // A leading token is strippable when it's one of this kennel's known
-  // identifiers, a code-shaped token carrying a digit (SH3, NBH3 — never a
-  // plain word like "Gender"), or a "#…" run marker.
+  // A leading token is strippable when it's the connector "and", one of this
+  // kennel's known identifiers, a "#…" run marker, or a kennel-code-shaped token
+  // — starts with a LETTER and carries a digit ("SH3"/"NBH3" yes; the ordinal
+  // "2nd" no, since it starts with a digit; a plain word like "Gender" no).
   const isStrippable = (token: string): boolean => {
-    if (known.has(token.toLowerCase())) return true;
+    const lower = token.toLowerCase();
+    if (lower === "and") return true;
+    if (known.has(lower)) return true;
     if (token.startsWith("#")) return true;
-    return /\d/.test(token) && /^[A-Za-z0-9]{2,8}$/.test(token);
+    return token.length <= 8 && /^[A-Za-z]/.test(token) && /\d/.test(token) && /^[A-Za-z0-9]+$/.test(token);
   };
-  let rest = sanitized;
-  for (let guard = 0; guard < 8; guard++) {
-    const m = LEADING_TITLE_TOKEN_RE.exec(rest);
-    if (!m || !isStrippable(m[1])) break;
-    rest = rest.slice(m[0].length);
-  }
-  const theme = rest
-    .replace(/^[\s:.\-–—/()]+/, "")
-    .replace(/[\s)(]+$/, "")
+  // Split on whitespace + co-host separators, then drop leading kennel/marker
+  // tokens. `(...)`-wrapped themes keep their inner words once the prefix is gone.
+  const tokens = sanitized.split(/[\s/&,+]+/).filter(Boolean);
+  let i = 0;
+  while (i < tokens.length && isStrippable(tokens[i])) i++;
+  const theme = tokens
+    .slice(i)
+    .join(" ")
+    .replace(/[()]/g, " ")
     .replace(/\s{2,}/g, " ")
     .trim();
   if (!theme || isPlaceholder(theme)) return "";
@@ -1539,13 +1537,22 @@ async function upsertCanonicalEvent(
     ? sameDayEvents.filter((e) => !batchMatched.has(e.id))
     : sameDayEvents;
   if (!existingEvent && !event.seriesId && crossSourceSiblings.length > 0) {
+    // A same-themed sibling that carries a CONFLICTING runNumber or startTime is
+    // a distinct event, not a duplicate — e.g. a recurring "Red Dress Run" where
+    // #939 and #940 share a theme. Reject those so Tier C never welds two real
+    // runs together or lets an equal/higher-trust update overwrite the sibling's
+    // run number (Codex review on #2233).
+    const conflictsWithIncoming = (e: (typeof sameDayEvents)[number]): boolean =>
+      (e.runNumber != null && event.runNumber != null && e.runNumber !== event.runNumber)
+      || (e.startTime != null && event.startTime != null && e.startTime !== event.startTime);
+
     // Tier C — normalized theme equality. Strip the kennel-code prefix from both
     // sides ("SH3 Hashmas" ⇄ "Hashmas") and merge on an exact, unique theme
     // match. Stubs normalize to "" and are skipped here (Tier B owns them).
     const incomingTheme = normalizeThemeTitle(event.title ?? null, kennelData);
     if (incomingTheme) {
       const themeMatches = crossSourceSiblings.filter(
-        (e) => normalizeThemeTitle(e.title, kennelData) === incomingTheme,
+        (e) => normalizeThemeTitle(e.title, kennelData) === incomingTheme && !conflictsWithIncoming(e),
       );
       if (themeMatches.length === 1) existingEvent = themeMatches[0];
     }

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -962,12 +962,21 @@ interface TitleKennelData {
 /**
  * Resolve the title to write when updating an existing canonical Event.
  *
- * Priority: (1) a real incoming title; (2) the existing title — UNLESS it's a
+ * Priority: (1) a *real* incoming title; (2) the existing title — UNLESS it's a
  * stale placeholder shell ("SH3 #? (TBD)") that a pre-#2065 scrape persisted, in
  * which case we (3) re-synthesize the "<Kennel> Trail #N" default. Without (3) an
  * incoming empty title (the #2065 adapter clears placeholder titles to "") would
  * fall back to `existingEvent.title` and the stale placeholder would stick
  * forever, since the lower-trust enrichment branch never backfills titles.
+ *
+ * #2233 — the incoming title is only allowed to *overwrite* when it's a real,
+ * human-authored theme (`!isReplaceableDefaultTitle`). The WA Hash Google
+ * Calendar out-trusts the hareline sheet and emits content-free stubs
+ * ("SH3 #?", synthesized "Seattle H3 Trail") on the same date as the sheet's
+ * themed run; without this gate the higher-trust stub takes the full-update
+ * branch and clobbers the real theme ("Gender Blender" → "SH3 #?"). A stub
+ * incoming now falls through to preserve the existing real title (or synthesize
+ * the default when the existing is itself a placeholder).
  */
 export function resolveUpdatedTitle(
   incomingTitle: string | undefined,
@@ -977,7 +986,7 @@ export function resolveUpdatedTitle(
   fallbackTag: string,
 ): string {
   const incoming = sanitizeTitle(incomingTitle);
-  if (incoming) {
+  if (incoming && !isReplaceableDefaultTitle(incoming, kennelData)) {
     return rewriteStaleDefaultTitle(incoming, kennelData.kennelCode, kennelData.shortName, kennelData.fullName, kennelData.aliases);
   }
   if (existingTitle && !isThemelessPlaceholderTitle(existingTitle)) {
@@ -1020,6 +1029,63 @@ export function isReplaceableDefaultTitle(
   // trailing " #<run>" is a no-op on the bare default, so this one comparison
   // covers both.
   return normalized.replace(/\s+#\d+$/, "") === base;
+}
+
+/**
+ * Leading kennel-code / placeholder-marker token at the start of a title.
+ * Bounded length, single char class — ReDoS-safe (no nested quantifiers).
+ */
+const LEADING_TITLE_TOKEN_RE = /^[\s/&,+]*(?:and\s+)?([A-Za-z0-9#?.'-]{1,12})/i;
+
+/**
+ * Normalize a title to its bare "theme" for cross-source same-day matching
+ * (#2233). Strips a leading run of co-hosting kennel-code tokens (`SH3`,
+ * `SH3/NBH3`) and placeholder run markers (`#?`), then lowercases + collapses
+ * whitespace. Returns `""` for content-free stubs so the normalized-theme match
+ * tier never welds two unrelated placeholders together — stubs are handled by
+ * the placeholder-absorption tier instead.
+ *
+ *   "Gender Blender"           → "gender blender"
+ *   "SH3 Hashmas"              → "hashmas"
+ *   "SH3/NBH3 Gender Blender"  → "gender blender"   (co-host prefix stripped)
+ *   "SH3 #? (TBD)" / "SH3 #?"  → ""                 (stub)
+ *   "SH3 (Catholic School Girl)" → "catholic school girl"
+ *
+ * Deterministic, ReDoS-safe: one bounded leading-token regex applied in a loop
+ * with monotonic progress (`rest` strictly shrinks; capped iterations).
+ */
+export function normalizeThemeTitle(
+  title: string | null,
+  kennelData: TitleKennelData,
+): string {
+  const sanitized = sanitizeTitle(title ?? undefined);
+  if (!sanitized) return "";
+  const known = new Set(
+    [kennelData.kennelCode, kennelData.shortName, ...kennelData.aliases]
+      .filter((s): s is string => !!s)
+      .map((s) => s.toLowerCase()),
+  );
+  // A leading token is strippable when it's one of this kennel's known
+  // identifiers, a code-shaped token carrying a digit (SH3, NBH3 — never a
+  // plain word like "Gender"), or a "#…" run marker.
+  const isStrippable = (token: string): boolean => {
+    if (known.has(token.toLowerCase())) return true;
+    if (token.startsWith("#")) return true;
+    return /\d/.test(token) && /^[A-Za-z0-9]{2,8}$/.test(token);
+  };
+  let rest = sanitized;
+  for (let guard = 0; guard < 8; guard++) {
+    const m = LEADING_TITLE_TOKEN_RE.exec(rest);
+    if (!m || !isStrippable(m[1])) break;
+    rest = rest.slice(m[0].length);
+  }
+  const theme = rest
+    .replace(/^[\s:.\-–—/()]+/, "")
+    .replace(/[\s)(]+$/, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+  if (!theme || isPlaceholder(theme)) return "";
+  return theme.toLowerCase();
 }
 
 /** Abbreviation map for address normalization (used by deduplicateAddressPrefix). */
@@ -1376,6 +1442,11 @@ async function upsertCanonicalEvent(
   await ensureKennelEventCache(kennelId, ctx);
   const sameDayEvents = getSameDayEvents(kennelId, eventDate, ctx);
 
+  // Resolved up-front (cheap, per-batch cached) so the cross-source match tiers
+  // below (#2233) can use the kennel's identifiers + default-title shape to
+  // recognise content-free placeholder rows.
+  const kennelData = await resolveKennelData(kennelId, ctx);
+
   // Match strategy:
   // 1. Zero existing → create new
   // 2. Exactly one → match unless already matched in this batch (double-header)
@@ -1443,6 +1514,65 @@ async function upsertCanonicalEvent(
     if (!existingEvent && urlMatches.length > 1
         && event.runNumber == null && !event.startTime && !event.title) {
       existingEvent = urlMatches[0];
+    }
+  }
+
+  // #2233 — cross-source same-day reconciliation. The WA Hash Google Calendar
+  // publishes the regular run as several content-free stubs ("SH3 #?",
+  // "SH3 #? (TBD)", an empty summary → synthesized "Seattle H3 Trail") AND a
+  // themed entry that re-prefixes the kennel code ("SH3/NBH3 Gender Blender"),
+  // while the hareline sheet carries the numbered/themed run. None of the signal
+  // tiers above connect these to the real run (different sourceUrl, no
+  // runNumber/startTime on the stub, kennel-prefixed titles), so without these
+  // two fallback tiers they survive as duplicate cards. Both tiers are strict:
+  // they only fire on a UNIQUE match, leaving genuine same-day double-headers
+  // (two real runs, distinct themes/run numbers) untouched.
+  //
+  // Scope: only PRE-EXISTING canonicals — siblings NOT created/matched earlier in
+  // THIS batch — are eligible. A same-batch double-header (one source emitting two
+  // runs on a date) already cleared the Case-2 reject above; re-merging it here
+  // would undo that. So we operate on cross-batch siblings (prior scrapes / other
+  // sources), which is exactly the cross-source duplicate class this targets.
+  // Series events are skipped (they're matched by seriesId, like the fuzzy probe).
+  const batchMatched = ctx.batchMatchedEvents.get(batchKey);
+  const crossSourceSiblings = batchMatched
+    ? sameDayEvents.filter((e) => !batchMatched.has(e.id))
+    : sameDayEvents;
+  if (!existingEvent && !event.seriesId && crossSourceSiblings.length > 0) {
+    // Tier C — normalized theme equality. Strip the kennel-code prefix from both
+    // sides ("SH3 Hashmas" ⇄ "Hashmas") and merge on an exact, unique theme
+    // match. Stubs normalize to "" and are skipped here (Tier B owns them).
+    const incomingTheme = normalizeThemeTitle(event.title ?? null, kennelData);
+    if (incomingTheme) {
+      const themeMatches = crossSourceSiblings.filter(
+        (e) => normalizeThemeTitle(e.title, kennelData) === incomingTheme,
+      );
+      if (themeMatches.length === 1) existingEvent = themeMatches[0];
+    }
+
+    // Tier B — content-free placeholder absorption. A placeholder carries no
+    // runNumber, no hares, and a default/themeless title; a "real" row has a
+    // runNumber or a genuine title. A stub never stands as its own card beside
+    // the real run.
+    if (!existingEvent) {
+      const rowIsPlaceholder = (e: (typeof sameDayEvents)[number]): boolean =>
+        e.runNumber == null && !e.haresText && isReplaceableDefaultTitle(e.title, kennelData);
+      const incomingIsPlaceholder =
+        event.runNumber == null
+        && !sanitizeHares(event.hares)
+        && isReplaceableDefaultTitle(sanitizeTitle(event.title), kennelData);
+      if (incomingIsPlaceholder) {
+        // Incoming stub → merge into the unique real sibling (prefer the
+        // run-numbered one; fall back to a sole real row).
+        const reals = crossSourceSiblings.filter((e) => !rowIsPlaceholder(e));
+        const numbered = reals.filter((e) => e.runNumber != null);
+        if (numbered.length === 1) existingEvent = numbered[0];
+        else if (reals.length === 1) existingEvent = reals[0];
+      } else {
+        // Incoming real run → absorb the unique content-free placeholder sibling.
+        const placeholders = crossSourceSiblings.filter(rowIsPlaceholder);
+        if (placeholders.length === 1) existingEvent = placeholders[0];
+      }
     }
   }
 
@@ -1537,7 +1667,6 @@ async function upsertCanonicalEvent(
     }
   }
 
-  const kennelData = await resolveKennelData(kennelId, ctx);
   const region = kennelData.region;
 
   const timezone = regionTimezone(region);

--- a/src/pipeline/reconcile.test.ts
+++ b/src/pipeline/reconcile.test.ts
@@ -99,6 +99,31 @@ describe("reconcileStaleEvents", () => {
     expect(mockEventUpdateMany).not.toHaveBeenCalled();
   });
 
+  it("#2233 — a merged calendar+sheet canonical survives when one source stops emitting it", async () => {
+    // After the cross-source merge fix, a calendar stub and a sheet run collapse
+    // onto ONE canonical carrying RawEvents from BOTH sources. When the CALENDAR
+    // source's scrape no longer lists that date, reconcile sees the canonical as
+    // orphaned for the calendar — but the sheet RawEvent keeps it alive. (Without
+    // the multi-source guard a dedup change could false-cancel the shared event.)
+    const calendarScrape = [
+      buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3"] }),
+    ];
+
+    mockEventFindMany.mockResolvedValueOnce([
+      mockEvent("evt_present", "kennel_1", "2026-02-14"),
+      mockEvent("evt_merged", "kennel_1", "2026-02-21"), // calendar dropped this date
+    ] as never);
+
+    // evt_merged still has a RawEvent from the hareline sheet source.
+    mockRawEventGroupBy.mockResolvedValueOnce([{ eventId: "evt_merged" }] as never);
+
+    const result = await reconcileStaleEvents("src_calendar", calendarScrape, 90);
+
+    expect(result.cancelled).toBe(0);
+    expect(result.multiSourcePreserved).toBe(1);
+    expect(mockEventUpdateMany).not.toHaveBeenCalled();
+  });
+
   it("does not cancel events that match scraped dates", async () => {
     const scrapedEvents = [
       buildRawEvent({ date: "2026-02-14", kennelTags: ["BoBBH3" ]}),


### PR DESCRIPTION
Closes #2233

## Problem
Kennels fed by **both** a `GOOGLE_CALENDAR` and a `GOOGLE_SHEETS` source (Seattle H3, SeaMon) showed **2–3 cards per trail**. The calendar (a shared regional calendar) publishes each run as several content-free stubs (`SH3 #?`, `SH3 #? (TBD)`, empty → `Seattle H3 Trail`) plus a kennel-prefixed themed entry (`SH3/NBH3 Gender Blender`); none merged with the sheet's numbered run. Worse, a higher-trust calendar stub that *did* merge **clobbered the real theme** (`Gender Blender` → `SH3 #?`).

Root cause: the fingerprint is per-source (correctly), and the canonical selector keys stub vs run under different signatures — so the same-day match logic in `upsertCanonicalEvent` never connected them. **No fingerprint/schema change needed.**

## Fix (`src/pipeline/merge.ts`)
- **A — no title clobber:** `resolveUpdatedTitle` only overwrites with a *real* incoming title (`!isReplaceableDefaultTitle`); a stub/synthesized-default never overwrites a real theme.
- **B — stub absorption:** a new cross-source same-day match tier folds a content-free stub (no run#, no hares, default/themeless title) into the real run, and vice-versa.
- **C — normalized-theme merge:** new `normalizeThemeTitle` collapses `SH3/NBH3 Gender Blender` ⇄ `Gender Blender` on exact normalized-theme equality.
- Tiers B/C are scoped to **pre-existing (cross-batch) siblings**, so genuine same-source double-headers (Munich `#938`/`#939`) stay split. Series events are skipped.

## Tests
- `merge.test.ts`: clobber guard, cross-source merge (both orders), normalized-theme merge, distinct double-header stays split, `normalizeThemeTitle` units.
- `reconcile.test.ts`: a merged calendar+sheet canonical is preserved when one source stops emitting it (multi-source guard).
- Full gate green: `tsc` 0 errors, `lint` 0 errors, full suite passing.

## Existing-data cleanup (already run against prod)
`scripts/cleanup-cross-source-placeholder-dupes.ts` (dry-run-reviewed, then applied) — merge-in-place, race-safe deletes, **conservative**: only stubs / same-run# / exact-theme rows fold in.
- **18** stub/same-trail rows merged, **4** clobbered titles healed, **73 genuinely-distinct events kept intact** (the shared calendar attributes many non-host events — other kennels' runs, holidays, memorials — to the host kennel; those are never merged), **0 attendance / 0 hares** touched.
- Verified on prod: Jul 11 → `#1013 Alpacalypse`, Oct 24 → `#1020 Gender Blender`, Jan 9 → `#1025 Hashmas` — each now **one card** (were 2–3). Two future themed near-dups (Feb 27, Mar 27) are intentionally left split because their two cards carry different real titles — consistent with the issue's "kept distinct" caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)