### PR TITLE
fix(scrapers): clear 7 consecutive-failure alerts (#2241–#2247)

### DIFF
--- a/infra/proxy-relay/server.js
+++ b/infra/proxy-relay/server.js
@@ -44,6 +44,14 @@ const FORWARDED_HEADERS = [
   "etag",
 ];
 
+// Headers dropped when a redirect crosses to a different origin, so caller
+// credentials can't leak to an untrusted host (lowercase for case-insensitive match).
+const SENSITIVE_REDIRECT_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+]);
+
 /**
  * Check if a hostname resolves to a private/reserved IP range.
  * Blocks SSRF through the proxy.
@@ -139,9 +147,23 @@ function fetchUrl(targetUrl, method, headers, body, redirectCount) {
         res.statusCode < 400 &&
         res.headers.location
       ) {
-        const nextUrl = new URL(res.headers.location, targetUrl).toString();
+        const nextParsed = new URL(res.headers.location, targetUrl);
         res.resume(); // drain response
-        return resolve(fetchUrl(nextUrl, method, headers, body, redirectCount + 1));
+        // Strip sensitive headers when the redirect crosses to a different
+        // origin, so a redirect to an untrusted host can't exfiltrate
+        // caller-supplied credentials.
+        let nextHeaders = headers;
+        if (nextParsed.origin !== parsed.origin) {
+          nextHeaders = { ...headers };
+          for (const k of Object.keys(nextHeaders)) {
+            if (SENSITIVE_REDIRECT_HEADERS.has(k.toLowerCase())) {
+              delete nextHeaders[k];
+            }
+          }
+        }
+        return resolve(
+          fetchUrl(nextParsed.toString(), method, nextHeaders, body, redirectCount + 1),
+        );
       }
 
       const chunks = [];

--- a/infra/proxy-relay/server.js
+++ b/infra/proxy-relay/server.js
@@ -86,9 +86,12 @@ function isPrivateTarget(hostname) {
 
 /**
  * Fetch a URL using Node built-in http/https, following redirects.
+ * `body` (optional string) is sent for POST/PUT/etc. requests — adapters
+ * that proxy a POST (e.g. Bangkok's PHP hareline API) need their request
+ * body forwarded to the upstream.
  * Returns { statusCode, headers, body (Buffer) }.
  */
-function fetchUrl(targetUrl, method, headers, redirectCount) {
+function fetchUrl(targetUrl, method, headers, body, redirectCount) {
   return new Promise((resolve, reject) => {
     if (redirectCount > MAX_REDIRECTS) {
       return reject(new Error(`Too many redirects (>${MAX_REDIRECTS})`));
@@ -112,9 +115,20 @@ function fetchUrl(targetUrl, method, headers, redirectCount) {
     }
 
     const client = parsed.protocol === "https:" ? https : http;
+    const mergedHeaders = { ...DEFAULT_HEADERS, ...headers };
+    const hasBody = typeof body === "string" && body.length > 0;
+    if (hasBody) {
+      // Recompute Content-Length and send unchunked — PHP/nginx endpoints
+      // often reject chunked transfer-encoding on POST. Strip any caller-
+      // supplied content-length (any case) so we don't emit a duplicate.
+      for (const k of Object.keys(mergedHeaders)) {
+        if (k.toLowerCase() === "content-length") delete mergedHeaders[k];
+      }
+      mergedHeaders["Content-Length"] = Buffer.byteLength(body);
+    }
     const options = {
       method: method || "GET",
-      headers: { ...DEFAULT_HEADERS, ...headers },
+      headers: mergedHeaders,
       timeout: REQUEST_TIMEOUT_MS,
     };
 
@@ -127,7 +141,7 @@ function fetchUrl(targetUrl, method, headers, redirectCount) {
       ) {
         const nextUrl = new URL(res.headers.location, targetUrl).toString();
         res.resume(); // drain response
-        return resolve(fetchUrl(nextUrl, method, headers, redirectCount + 1));
+        return resolve(fetchUrl(nextUrl, method, headers, body, redirectCount + 1));
       }
 
       const chunks = [];
@@ -157,6 +171,7 @@ function fetchUrl(targetUrl, method, headers, redirectCount) {
       reject(new Error(`Request timed out after ${REQUEST_TIMEOUT_MS}ms`));
     });
     req.on("error", reject);
+    if (hasBody) req.write(body);
     req.end();
   });
 }
@@ -225,16 +240,19 @@ const server = http.createServer(async (req, res) => {
       return jsonResponse(res, 400, { error: "Invalid JSON body" });
     }
 
-    const { url, method, headers } = parsed;
+    const { url, method, headers, body } = parsed;
     if (!url || typeof url !== "string") {
       return jsonResponse(res, 400, { error: "Missing or invalid 'url' field" });
+    }
+    if (body !== undefined && typeof body !== "string") {
+      return jsonResponse(res, 400, { error: "'body' field must be a string" });
     }
 
     console.log(
       `[${new Date().toISOString()}] Proxying ${method || "GET"} ${url}`,
     );
 
-    const result = await fetchUrl(url, method || "GET", headers || {}, 0);
+    const result = await fetchUrl(url, method || "GET", headers || {}, body, 0);
 
     // Forward select response headers
     const responseHeaders = {};

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3194,7 +3194,12 @@ export const SOURCES = [
       type: "HTML_SCRAPER" as const,
       trustLevel: 8,
       scrapeFreq: "daily",
-      scrapeDays: 365,
+      // #2242: each month page is an ~30s AJAX POST; the old ±365d window meant
+      // ~25 sequential month fetches that blew the 120s cron budget and timed
+      // out. The adapter now fetches forward-only (capped at maxForwardMonths,
+      // default 3); 90d keeps the event-retention window aligned with that. The
+      // iCal feed source remains primary — this calendar is enrichment.
+      scrapeDays: 90,
       config: {
         kennelPatterns: [
           ["^LBH\\b|Lost Boobs", "lbh-phx"],
@@ -4658,10 +4663,13 @@ export const SOURCES = [
       kennelCodes: ["ph3-my"],
     },
 
-    // 3. KL Full Moon H3 — Yii Framework hareline (same shape as PH3)
+    // 3. KL Full Moon H3 — migrated off Yii to the goHash.app platform (#2241).
+    // The old /index.php?r=site/hareline route now 404s; the relaunched site
+    // SSRs window.__INITIAL_STATE__ at /hareline/upcoming (shared GoHash adapter,
+    // same platform as Penang H3 / Harriets Penang).
     {
       name: "KL Full Moon H3 Hareline",
-      url: "https://klfullmoonhash.com/index.php?r=site/hareline",
+      url: "https://www.klfullmoonhash.com",
       type: "HTML_SCRAPER" as const,
       trustLevel: 7,
       scrapeFreq: "daily",
@@ -4669,6 +4677,7 @@ export const SOURCES = [
       config: {
         kennelTag: "klfmh3",
         startTime: "18:00",
+        harelinePath: "/hareline/upcoming",
       },
       kennelCodes: ["klfmh3"],
     },

--- a/src/adapters/html-scraper/bangkokhash.ts
+++ b/src/adapters/html-scraper/bangkokhash.ts
@@ -43,6 +43,12 @@ import {
  *   { "subSite": "thursday", "hashClub": "BTH3", "apiBase": "/H222k3" }
  */
 
+// bangkokhash.com's WAF 403s the default "HashTracks-Scraper" UA (#2247/#2245),
+// even via the residential proxy — it only allows a normal browser UA. Mirror
+// the UA the enfield/norfolk proxied adapters use.
+const BROWSER_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
 interface BangkokHashConfig {
   subSite: string;     // "thursday" | "fullmoon" | "siamsunday"
   hashClub: string;    // "BTH3" | "BFMH3" | "S2H3"
@@ -340,8 +346,16 @@ export class BangkokHashAdapter implements SourceAdapter {
     let structureHash: string | undefined;
     let fetchDurationMs = 0;
 
+    // bangkokhash.com 403s Vercel's datacenter IP (#2247 / #2245), so both the
+    // main Joomla page and the PHP hareline API must egress through the NAS
+    // residential proxy. The PHP API is a POST whose JSON body the proxy now
+    // forwards (residential-proxy body support added alongside this fix).
+
     // 1. Fetch the main Joomla page for the next run article
-    const page = await fetchHTMLPage(baseUrl);
+    const page = await fetchHTMLPage(baseUrl, {
+      useResidentialProxy: true,
+      userAgent: BROWSER_UA,
+    });
     if (page.ok) {
       structureHash = page.structureHash;
       fetchDurationMs = page.fetchDurationMs;
@@ -359,8 +373,12 @@ export class BangkokHashAdapter implements SourceAdapter {
       const apiStart = Date.now();
       const response = await safeFetch(apiUrl, {
         method: "POST",
-        headers: { "Content-Type": "application/json; charset=UTF-8" },
+        headers: {
+          "Content-Type": "application/json; charset=UTF-8",
+          "User-Agent": BROWSER_UA,
+        },
         body: JSON.stringify({ usewamp: 0, hashclub: hashClub, viewoption: "0" }),
+        useResidentialProxy: true,
       });
       const apiDurationMs = Date.now() - apiStart;
 

--- a/src/adapters/html-scraper/chicago-shared.ts
+++ b/src/adapters/html-scraper/chicago-shared.ts
@@ -46,12 +46,18 @@ export function parseTimeString(text: string): string | null {
   return null;
 }
 
-/** Fetch a URL and return its HTML text, or an error detail. */
+/** Fetch a URL and return its HTML text, or an error detail.
+ *
+ * chicagohash.org + chicagoth3.com sit behind Cloudflare, which 403s Vercel's
+ * datacenter IP (#2244 / #2246). Route through the NAS residential proxy so the
+ * request egresses from a residential IP. The pages are plain server-rendered
+ * WordPress HTML (no JS challenge), so a proxied GET is sufficient. */
 export async function fetchAndParseHtmlPage(url: string): Promise<{ html: string; error?: never } | { html?: never; error: { url: string; status?: number; message: string } }> {
   try {
     const response = await safeFetch(url, {
       headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
       signal: AbortSignal.timeout(30_000),
+      useResidentialProxy: true,
     });
     if (!response.ok) {
       return { error: { url, status: response.status, message: `HTTP ${response.status}: ${response.statusText}` } };

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -24,6 +24,14 @@ interface PhoenixHHHConfig {
   defaultKennelTag: string;
   pageId?: number; // defaults to 21
   /**
+   * Max number of forward calendar months to fetch per scrape (default 3).
+   * Each month page is an ~30s AJAX POST, so fetching the full ±365d window
+   * (~25 months) blew the 120s cron budget and timed out (#2242). The fetch is
+   * forward-only (past months never change); the date window still bounds which
+   * parsed events are kept.
+   */
+  maxForwardMonths?: number;
+  /**
    * Per-kennel standard hash cash (Two-Tier Hash Cash Model). Keyed by
    * kennelCode. The detail page carries a `Hash Cash:` line on every event;
    * we only promote it to `Event.cost` when it DIFFERS from the kennel's
@@ -415,11 +423,23 @@ export class PhoenixHHHAdapter implements SourceAdapter {
       config.kennelPatterns[i][1],
     ]);
 
-    // Calculate month range from date window
-    const startMonth = minDate.getUTCMonth() + 1;
-    const startYear = minDate.getUTCFullYear();
-    const endMonth = maxDate.getUTCMonth() + 1;
-    const endYear = maxDate.getUTCFullYear();
+    // Calculate the FETCH month range. Forward-only: past calendar months never
+    // change, and re-fetching ~12 of them every day (each an ~30s AJAX POST)
+    // blew the 120s cron budget and timed out (#2242). Start at the current
+    // month and cap the span via `maxForwardMonths` (default 3), never going
+    // past the date window's natural end. The [minDate, maxDate] window from
+    // buildDateWindow still governs which parsed events are KEPT below.
+    const now = new Date();
+    const startMonth = now.getUTCMonth() + 1;
+    const startYear = now.getUTCFullYear();
+
+    const maxForwardMonths = Math.max(1, config.maxForwardMonths ?? 3);
+    const startIndex = startYear * 12 + (startMonth - 1);
+    const capEndIndex = startIndex + (maxForwardMonths - 1);
+    const windowEndIndex = maxDate.getUTCFullYear() * 12 + maxDate.getUTCMonth();
+    const endIndex = Math.min(capEndIndex, windowEndIndex);
+    const endYear = Math.floor(endIndex / 12);
+    const endMonth = (endIndex % 12) + 1;
 
     const allEvents: RawEventData[] = [];
     const seenKeys = new Set<string>(); // dedup month boundary spillover

--- a/src/adapters/html-scraper/phoenixhhh.ts
+++ b/src/adapters/html-scraper/phoenixhhh.ts
@@ -24,11 +24,11 @@ interface PhoenixHHHConfig {
   defaultKennelTag: string;
   pageId?: number; // defaults to 21
   /**
-   * Max number of forward calendar months to fetch per scrape (default 3).
-   * Each month page is an ~30s AJAX POST, so fetching the full ±365d window
-   * (~25 months) blew the 120s cron budget and timed out (#2242). The fetch is
-   * forward-only (past months never change); the date window still bounds which
-   * parsed events are kept.
+   * Max number of forward calendar months to fetch per scrape (default 4 —
+   * covers a 90-day `scrapeDays` window, which spans up to four calendar
+   * months). Fetching the full ±365d window (~25 months) blew the 120s cron
+   * budget and timed out (#2242). The fetch is forward-only (past months never
+   * change); the date window still bounds which parsed events are kept.
    */
   maxForwardMonths?: number;
   /**
@@ -424,16 +424,25 @@ export class PhoenixHHHAdapter implements SourceAdapter {
     ]);
 
     // Calculate the FETCH month range. Forward-only: past calendar months never
-    // change, and re-fetching ~12 of them every day (each an ~30s AJAX POST)
-    // blew the 120s cron budget and timed out (#2242). Start at the current
-    // month and cap the span via `maxForwardMonths` (default 3), never going
-    // past the date window's natural end. The [minDate, maxDate] window from
-    // buildDateWindow still governs which parsed events are KEPT below.
+    // change, and re-fetching ~12 of them every day (each a slow AJAX POST) blew
+    // the 120s cron budget and timed out (#2242). Start at the current month and
+    // cap the span via `maxForwardMonths` (default 4), never going past the date
+    // window's natural end. The default of 4 covers a 90-day `scrapeDays` window,
+    // which spans up to four calendar months (e.g. Jun 18 → Sep 16) — a 3-month
+    // cap dropped the last partial month's events. The [minDate, maxDate] window
+    // from buildDateWindow still governs which parsed events are KEPT below.
     const now = new Date();
     const startMonth = now.getUTCMonth() + 1;
     const startYear = now.getUTCFullYear();
 
-    const maxForwardMonths = Math.max(1, config.maxForwardMonths ?? 3);
+    // Defensive parse: a misconfigured non-numeric `maxForwardMonths` must not
+    // NaN-poison the index math and silently skip the whole loop.
+    const rawMax =
+      typeof config.maxForwardMonths === "number"
+        ? config.maxForwardMonths
+        : Number(config.maxForwardMonths);
+    const maxForwardMonths =
+      Number.isFinite(rawMax) && rawMax >= 1 ? Math.floor(rawMax) : 4;
     const startIndex = startYear * 12 + (startMonth - 1);
     const capEndIndex = startIndex + (maxForwardMonths - 1);
     const windowEndIndex = maxDate.getUTCFullYear() * 12 + maxDate.getUTCMonth();

--- a/src/adapters/html-scraper/soh4.ts
+++ b/src/adapters/html-scraper/soh4.ts
@@ -207,12 +207,17 @@ export class SOH4Adapter implements SourceAdapter {
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
 
-    // Phase 1: Fetch RSS feed
+    // Phase 1: Fetch RSS feed.
+    // soh4.com sits behind Cloudflare, which 403s Vercel's datacenter IP
+    // (#2243). Route the feed + every trail page through the NAS residential
+    // proxy so requests egress from a residential IP. Both endpoints are plain
+    // server-rendered XML/HTML (no JS challenge), so proxied GETs suffice.
     const fetchStart = Date.now();
     let rssResponse: Response;
     try {
       rssResponse = await safeFetch(feedUrl, {
         headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+        useResidentialProxy: true,
       });
     } catch (err) {
       const message = `Fetch failed: ${err}`;
@@ -240,6 +245,7 @@ export class SOH4Adapter implements SourceAdapter {
           const trailUrl = item.url.endsWith("/") ? item.url : `${item.url}/`;
           const response = await safeFetch(trailUrl, {
             headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+            useResidentialProxy: true,
           });
           if (!response.ok) {
             throw new Error(`HTTP ${response.status} for ${trailUrl}`);

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -242,7 +242,11 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   // ── Malaysia (Phase 1: KL + Penang founder pack) ──
   { pattern: /motherhash\.org/i, name: "MotherHashAdapter", factory: () => new MotherHashAdapter() },
   { pattern: /ph3\.org/i, name: "YiiHarelineAdapter", factory: () => new YiiHarelineAdapter() },
-  { pattern: /klfullmoonhash\.com/i, name: "YiiHarelineAdapter", factory: () => new YiiHarelineAdapter() },
+  // KL Full Moon migrated off Yii to the goHash.app platform (#2241) — the old
+  // /index.php?r=site/hareline route now 404s. The relaunched site SSRs
+  // window.__INITIAL_STATE__ at /hareline/upcoming, so it shares the GoHash
+  // adapter with Penang H3 / Harriets Penang. (Petaling H3 stays on Yii.)
+  { pattern: /klfullmoonhash\.com/i, name: "GoHashAdapter", factory: () => new GoHashAdapter() },
   { pattern: /kljhhh\.org/i, name: "KljH3Adapter", factory: () => new KljH3Adapter() },
   { pattern: /penanghash3\.org/i, name: "GoHashAdapter", factory: () => new GoHashAdapter() },
   { pattern: /hashhouseharrietspenang\.com/i, name: "GoHashAdapter", factory: () => new GoHashAdapter() },

--- a/src/adapters/safe-fetch.test.ts
+++ b/src/adapters/safe-fetch.test.ts
@@ -56,3 +56,56 @@ describe("safeFetch direct-fetch timeout", () => {
     expect(second).toBe(first); // same object reused across the chain
   });
 });
+
+describe("safeFetch residential-proxy body forwarding", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  const prevUrl = process.env.RESIDENTIAL_PROXY_URL;
+  const prevKey = process.env.RESIDENTIAL_PROXY_KEY;
+
+  beforeEach(() => {
+    process.env.RESIDENTIAL_PROXY_URL = "https://proxy.example";
+    process.env.RESIDENTIAL_PROXY_KEY = "k".repeat(32);
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.RESIDENTIAL_PROXY_URL = prevUrl;
+    process.env.RESIDENTIAL_PROXY_KEY = prevKey;
+  });
+
+  function proxyPayload(): { url: string; method: string; headers: Record<string, string>; body?: string } {
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    return JSON.parse(init?.body as string);
+  }
+
+  it("forwards a string POST body to the proxy (e.g. Bangkok's PHP hareline API)", async () => {
+    await safeFetch("https://bangkokhash.com/api", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: '{"hashclub":"BTH3"}',
+      useResidentialProxy: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://proxy.example/proxy",
+      expect.anything(),
+    );
+    const payload = proxyPayload();
+    expect(payload.method).toBe("POST");
+    expect(payload.url).toBe("https://bangkokhash.com/api");
+    expect(payload.body).toBe('{"hashclub":"BTH3"}');
+  });
+
+  it("omits body for a proxied GET (no regression for body-less requests)", async () => {
+    await safeFetch("https://bangkokhash.com/page", {
+      useResidentialProxy: true,
+    });
+
+    const payload = proxyPayload();
+    expect(payload.method).toBe("GET");
+    expect(payload).not.toHaveProperty("body");
+  });
+});

--- a/src/adapters/safe-fetch.ts
+++ b/src/adapters/safe-fetch.ts
@@ -60,17 +60,30 @@ export async function safeFetch(
       );
     } else {
       const headerRecord = headersToRecord(init.headers);
+      // Forward the request body so proxied POSTs work (e.g. Bangkok's PHP
+      // hareline API needs its JSON body). Only string bodies are forwarded —
+      // the JSON envelope can't carry Blob/FormData/stream bodies, and every
+      // adapter that proxies a POST already serializes to a string.
+      const proxyPayload: {
+        url: string;
+        method: string;
+        headers: Record<string, string>;
+        body?: string;
+      } = {
+        url,
+        method: init.method || "GET",
+        headers: headerRecord,
+      };
+      if (typeof init.body === "string") {
+        proxyPayload.body = init.body;
+      }
       const proxyResponse = await fetch(`${proxyUrl}/proxy`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "X-Proxy-Key": proxyKey,
         },
-        body: JSON.stringify({
-          url,
-          method: init.method || "GET",
-          headers: headerRecord,
-        }),
+        body: JSON.stringify(proxyPayload),
         signal: init.signal ?? AbortSignal.timeout(45_000), // caller can override; default = 30s proxy + 15s tunnel
       });
 

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -628,12 +628,23 @@ export type FetchHTMLResult = FetchHTMLSuccess | FetchHTMLError;
 /**
  * Fetch a URL, validate via safeFetch, compute structureHash, and load Cheerio.
  * Returns a discriminated union: check `result.ok` before accessing fields.
+ *
+ * Pass `useResidentialProxy: true` to egress through the NAS residential proxy
+ * for datacenter-IP-blocked domains (e.g. bangkokhash.com 403s Vercel — #2247).
+ * Pass `userAgent` to override the default "HashTracks-Scraper" UA — some WAFs
+ * (e.g. bangkokhash.com) 403 the bot UA but allow a normal browser UA.
  */
-export async function fetchHTMLPage(url: string): Promise<FetchHTMLResult> {
+export async function fetchHTMLPage(
+  url: string,
+  options?: { useResidentialProxy?: boolean; userAgent?: string },
+): Promise<FetchHTMLResult> {
   const fetchStart = Date.now();
   try {
     const response = await safeFetch(url, {
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+      headers: {
+        "User-Agent": options?.userAgent ?? "Mozilla/5.0 (compatible; HashTracks-Scraper)",
+      },
+      useResidentialProxy: options?.useResidentialProxy,
     });
     if (!response.ok) {
       const message = `HTTP ${response.status}: ${response.statusText}`;


### PR DESCRIPTION
## Summary

Seven `severity:critical` `consecutive-failures` alerts. All were **Vercel-datacenter-IP-specific** (403 / timeout / 404): from a dev box every site returns 200, so parsing is verified locally and the fix is the **egress** (residential proxy / repoint / window cap). A scrape is marked `FAILED` on *any* non-empty `errors[]`, so every fetch must complete cleanly.

| Issue | Source | Root cause | Fix |
|---|---|---|---|
| #2241 | KL Full Moon | 404 — migrated Yii → **goHash.app** | Repoint registry + seed to `GoHashAdapter` (`/hareline/upcoming`). Petaling (`ph3.org`) stays on Yii. |
| #2244 | Chicago Hash | Cloudflare datacenter-IP 403 | `useResidentialProxy` on the shared chicago fetch |
| #2246 | Thirstday (TH3) | Cloudflare datacenter-IP 403 | same shared fix |
| #2243 | SOH4 | Cloudflare 403 | `useResidentialProxy` on RSS + trail fetches |
| #2247 | Bangkok Thursday | datacenter-IP 403 + WAF UA block + POST hareline | residential proxy + browser UA + proxy **body-forwarding** |
| #2245 | Bangkok Full Moon | same | same shared adapter |
| #2242 | Phoenix Big Ass Cal | ~25 sequential ~30s month-POSTs blew the 120s cron | forward-only fetch, `maxForwardMonths` cap (3), `scrapeDays` 365→90 |

## Notable changes
- **Residential proxy now forwards string POST bodies** (`src/adapters/safe-fetch.ts` + `infra/proxy-relay/server.js`) — required for Bangkok's PHP hareline API (returns 16 KB only *with* the body; 310 bytes without). Additive; existing proxied GETs unchanged.
- **`fetchHTMLPage` gains a `userAgent` override** — bangkokhash.com's WAF 403s the default `HashTracks-Scraper` UA even via a residential IP; Bangkok now sends a browser UA.
- **Phoenix** fetch is now forward-only with a month cap (config `maxForwardMonths`), fixing the cron timeout.

## Verification
- Each adapter's `fetch()` run against the **live** sites; proxy-routed ones exercised through a locally-run `proxy-relay` (full egress path). Live results, all `errors: 0`: KL 6, Chicago 12, TH3 33, SOH4 2, Bangkok Thursday 29, Bangkok Full Moon 7, Phoenix 22 events in **41s** (was timing out).
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (9264 passed; incl. new `safe-fetch` body-forward tests + shared yii-hareline/gohash suites).
- **Patched `proxy-relay` already deployed to the NAS** and confirmed forwarding bodies end-to-end (200, 16 KB) — so this PR can ship anytime.

## Notes
- **Siam Sunday** (third sub-site of the shared Bangkok adapter, *not* one of these 7) has a **source-side 500** on its hareline API (`/H220j/…ViewHL_Server.php`, reproduced with plain curl). This change *improves* it (main-page next-run now parses) but it stays partially failing until the site fixes its endpoint.

Closes #2241
Closes #2242
Closes #2243
Closes #2244
Closes #2245
Closes #2246
Closes #2247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
