### PR TITLE
fix(adapters): HC + Meetup boilerplate/window fixes (#2220 #2194 #2228 #2195)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -6948,6 +6948,12 @@ export const SOURCES = [
         // literal "R*n" → "#" so the shared extractHashRunNumber helper parses it.
         extractRunNumber: true,
         runNumberPrefix: "R*n",
+        // Both kennels publish the same emoji-structured run template
+        // ("🐰 Hares: TBD / 👣 Trail / 💶 Hash Cash: 5 €") verbatim on every
+        // event; the default boilerplate-block stripper would treat it as a
+        // standing club template and leave only a title-echo (#2228). Keep the
+        // full description body for these sibling kennels.
+        keepRepeatedDescription: true,
         kennelPatterns: [
           ["^Paris H3", "paris-h3"],
           ["^Sans Clue H3", "sans-clue-h3"],

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -245,6 +245,36 @@ describe("applyTitleFallback (#1166)", () => {
     );
     expect(applyTitleFallback("Hashmas Eve", 2590, config)).toBe("Hashmas Eve");
   });
+
+  // #2194 — Shanghai H3's eventName carries a dangling " |" when a title
+  // subfield is blank. Strip trailing |/-/: separators (the #756/#1060 family).
+  it("strips a dangling trailing pipe separator (#2194 Shanghai H3)", () => {
+    expect(
+      applyTitleFallback(
+        "26th All China Nash Hash + 40th Shanghai Hash House Harriers Anniversary |",
+        0,
+        { defaultTitle: "Shanghai H3" },
+      ),
+    ).toBe("26th All China Nash Hash + 40th Shanghai Hash House Harriers Anniversary");
+  });
+
+  it("strips trailing dash/colon and surrounding whitespace too (#756/#1060)", () => {
+    expect(applyTitleFallback("Trail Name -", 100, {})).toBe("Trail Name");
+    expect(applyTitleFallback("Trail Name : ", 100, {})).toBe("Trail Name");
+    expect(applyTitleFallback("Trail Name  |  ", 100, {})).toBe("Trail Name");
+  });
+
+  it("preserves terminal !/? — they are not separators", () => {
+    expect(applyTitleFallback("Saturday Trail!", 100, {})).toBe("Saturday Trail!");
+    expect(applyTitleFallback("Why?", 100, {})).toBe("Why?");
+  });
+
+  it("treats a separators-only eventName as stale (synthesizes when possible)", () => {
+    const config = { defaultTitle: "Shanghai H3" };
+    expect(applyTitleFallback(" | ", 42, config)).toBe("Shanghai H3 #42");
+    // eventNumber 0 (social) can't synthesize → undefined (UI run-number fallback)
+    expect(applyTitleFallback(" | ", 0, config)).toBeUndefined();
+  });
 });
 
 describe("hcGeocodeFailed", () => {
@@ -372,6 +402,33 @@ describe("HarrierCentralAdapter", () => {
       expect(result.events).toHaveLength(1);
       expect(result.events[0].hares).toBeUndefined();
       expect(result.events[0].location).toBeUndefined();
+    });
+
+    it("strips the HC 'Placeholder user for visitors / virgins' boilerplate hare (#2220 Lisbon)", async () => {
+      // Lisbon H3 run #1017: HC appends a system placeholder entry after the
+      // real hare. Only "Depth Charge" should survive.
+      mockApiResponse([
+        buildHCEvent({
+          hares: "Depth Charge , Placeholder user for visitors / virgins for Lisbon H3",
+        }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "lh3-pt" }));
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].hares).toBe("Depth Charge");
+    });
+
+    it("returns undefined hares when only the placeholder entry is present (#2220)", async () => {
+      mockApiResponse([
+        buildHCEvent({ hares: "Placeholder user for visitors / virgins for Lisbon H3" }),
+      ]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "lh3-pt" }));
+      expect(result.events[0].hares).toBeUndefined();
+    });
+
+    it("keeps ordinary multi-hare lists intact (no placeholder)", async () => {
+      mockApiResponse([buildHCEvent({ hares: "Alice, Bob" })]);
+      const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
+      expect(result.events[0].hares).toBe("Alice, Bob");
     });
 
     it("nulls hares (but keeps location) when the source pasted the same value into both slots (#521)", async () => {

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -269,6 +269,15 @@ describe("applyTitleFallback (#1166)", () => {
     expect(applyTitleFallback("Why?", 100, {})).toBe("Why?");
   });
 
+  it("only strips TRAILING separators — a mid-title comma/colon survives", () => {
+    // Guards the comma in the separator class: a meaningful mid-title comma
+    // (not the trailing char) must not be truncated.
+    expect(applyTitleFallback("Trail Name, Special Edition", 100, {})).toBe(
+      "Trail Name, Special Edition",
+    );
+    expect(applyTitleFallback("Run #5: The Sequel", 100, {})).toBe("Run #5: The Sequel");
+  });
+
   it("treats a separators-only eventName as stale (synthesizes when possible)", () => {
     const config = { defaultTitle: "Shanghai H3" };
     expect(applyTitleFallback(" | ", 42, config)).toBe("Shanghai H3 #42");

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -157,7 +157,7 @@ export class HarrierCentralAdapter implements SourceAdapter {
       const timeMatch = hcEvent.eventStartDatetime.match(/T(\d{2}:\d{2})/);
       const startTime = timeMatch ? timeMatch[1] : undefined;
 
-      let hares = stripTba(hcEvent.hares);
+      let hares = stripPlaceholderHares(hcEvent.hares);
       const location = composeHcLocation(
         hcEvent.locationOneLineDesc,
         hcEvent.resolvableLocation,
@@ -246,6 +246,29 @@ export class HarrierCentralAdapter implements SourceAdapter {
 function stripTba(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed && !/^tba$/i.test(trimmed) ? trimmed : undefined;
+}
+
+// Harrier Central appends a system entry — "Placeholder user for visitors /
+// virgins for <KennelName>" — to the comma-joined hares string for kennels that
+// pre-create biweekly slots (Lisbon H3 #1017, #2220). It is not a real hare and
+// must not leak into haresText. Split the comma-joined value, drop placeholder
+// entries, and rejoin; returns undefined when nothing real remains.
+const PLACEHOLDER_HARE_RE = /\bplaceholder user\b/i;
+function stripPlaceholderHares(value: string | undefined): string | undefined {
+  const trimmed = stripTba(value);
+  if (!trimmed) return undefined;
+  // Fast path: no placeholder present → return the trimmed value byte-for-byte
+  // (identical to the old stripTba behavior). Re-joining unconditionally would
+  // normalize comma spacing ("A,B" → "A, B") and re-fingerprint every HC
+  // multi-hare event on the first post-deploy scrape (hares is in the RawEvent
+  // fingerprint — see pipeline/fingerprint.ts). Only the rare placeholder case
+  // pays the split/rejoin.
+  if (!PLACEHOLDER_HARE_RE.test(trimmed)) return trimmed;
+  const kept = trimmed
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s && !PLACEHOLDER_HARE_RE.test(s));
+  return kept.length ? kept.join(", ") : undefined;
 }
 
 // Placeholder location strings that HC surfaces when a kennel hasn't set a real
@@ -395,12 +418,22 @@ export function hcGeocodeFailed(
  * eventName; this lets the source seed a fixed list of placeholder strings
  * to substitute without touching adapter code each time a new one appears.
  */
+// Trim trailing separators a source occasionally leaves when a title subfield is
+// blank: "…Anniversary |" (Shanghai H3 #2194), the trailing-dash (#756) and
+// trailing-colon (#1060) family. Single char class + `+` anchored to `$` →
+// linear in input length. Terminal-only: titles ending in "!"/"?" are untouched.
+const TITLE_SEPARATOR_TAIL_RE = /[\s|,:–—-]+$/; // NOSONAR S5852 — single char class anchored to `$`, no alternation
+function stripTrailingTitleSeparators(value: string | undefined): string | undefined {
+  if (!value) return value;
+  return value.replace(TITLE_SEPARATOR_TAIL_RE, "").trim() || undefined;
+}
+
 export function applyTitleFallback(
   eventName: string | undefined,
   eventNumber: number | undefined | null,
   config: HarrierCentralConfig,
 ): string | undefined {
-  const trimmed = eventName?.trim();
+  const trimmed = stripTrailingTitleSeparators(eventName);
   const aliases = config.staleTitleAliases;
   const isStale =
     !trimmed ||

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -643,6 +643,74 @@ describe("MeetupAdapter", () => {
     expect(result.diagnosticContext?.boilerplateDescriptionsDropped).toBe(0);
   });
 
+  // ── #2228: keepRepeatedDescription opt-out ──
+  // Paris H3 / Sans Clue H3 publish the SAME emoji run template on every event;
+  // the default detector would strip it as boilerplate and leave only a
+  // title-echo. With the opt-out, the full body is kept verbatim.
+  it("keeps repeated template descriptions when keepRepeatedDescription is set (#2228 Sans Clue)", async () => {
+    const TEMPLATE =
+      "🐰 Hares: TBD\n👣 Trail: A-to-B trail, no bag drop\n💶 Hash Cash: 5 €";
+    const html = buildMeetupHtml({
+      "Event:1193": buildApolloEvent({
+        id: "1193",
+        title: "Sans Clue H3 R*n 1193 | TBD",
+        dateTime: isoDaysFromNow(14, "14:00", "+02:00"),
+        description: `**Sans Clue H3 R\\*n 1193 \\| TBD**\n\n${TEMPLATE}`,
+      }),
+      "Event:1194": buildApolloEvent({
+        id: "1194",
+        title: "Sans Clue H3 R*n 1194 | TBD",
+        dateTime: isoDaysFromNow(28, "14:00", "+02:00"),
+        description: `**Sans Clue H3 R\\*n 1194 \\| TBD**\n\n${TEMPLATE}`,
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "parish3-schhh", kennelTag: "sans-clue-h3", keepRepeatedDescription: true }),
+      { days: 365 },
+    );
+
+    expect(result.events).toHaveLength(2);
+    // The full emoji body survives (not stripped to a title-echo).
+    for (const ev of result.events) {
+      expect(ev.description).toContain("Hash Cash: 5 €");
+      expect(ev.description).toContain("Hares: TBD");
+    }
+    expect(result.diagnosticContext?.boilerplateDescriptionsDropped).toBe(0);
+  });
+
+  it("still strips repeated boilerplate when keepRepeatedDescription is absent (default unchanged)", async () => {
+    const TEMPLATE = "🐰 Hares: TBD\n👣 Trail: A-to-B trail\n💶 Hash Cash: 5 €";
+    const html = buildMeetupHtml({
+      "Event:x1": buildApolloEvent({
+        id: "x1",
+        title: "Run #1",
+        dateTime: isoDaysFromNow(14, "14:00"),
+        description: TEMPLATE,
+      }),
+      "Event:x2": buildApolloEvent({
+        id: "x2",
+        title: "Run #2",
+        dateTime: isoDaysFromNow(28, "14:00"),
+        description: TEMPLATE,
+      }),
+      "Venue:123": VENUE_ENTRY,
+    });
+    mockHtmlResponse(html);
+
+    const adapter = new MeetupAdapter();
+    const result = await adapter.fetch(
+      makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
+      { days: 365 },
+    );
+    expect(result.events).toHaveLength(2);
+    for (const ev of result.events) expect(ev.description).toBeNull();
+    expect(result.diagnosticContext?.boilerplateDescriptionsDropped).toBe(2);
+  });
+
   it("strips a shared club paragraph but keeps the per-event logistics stanza (#2059 Hogtown)", async () => {
     // Hogtown prepends the same club blurb to a per-event Date/Cost stanza, so
     // the WHOLE description differs per event but the club paragraph repeats.
@@ -883,7 +951,7 @@ describe("MeetupAdapter", () => {
     expect(result.events[0].description).toBeUndefined();
   });
 
-  it("filters events outside the lookback window", async () => {
+  it("keeps far-future upcoming events beyond the forward window (#2195 Rubber City)", async () => {
     const futureDate = new Date(Date.now() + 200 * 24 * 60 * 60 * 1000);
     const futureIso = futureDate.toISOString().slice(0, 19) + "-05:00";
 
@@ -904,9 +972,10 @@ describe("MeetupAdapter", () => {
       makeSource({ groupUrlname: "test-hash", kennelTag: "NYCH3" }),
       { days: 90 },
     );
-    // far-future event is >90 days out and should be excluded
-    expect(result.events).toHaveLength(1);
-    expect(result.events[0].title).toBe("Trail #42 — Central Park");
+    // The far-future (200-day) upcoming event is NO LONGER clipped by maxDate —
+    // the upcoming feed is self-bounding and reconcile-safe (#2195).
+    expect(result.events).toHaveLength(2);
+    expect(result.events.map((e) => e.title)).toContain("Far Future Run");
   });
 
   it("skips events without dateTime", async () => {
@@ -1295,21 +1364,22 @@ describe("MeetupAdapter", () => {
     expect(result.errorDetails).toBeUndefined();
   });
 
-  it("past events exempt from minDate but upcoming still filtered by full window", async () => {
-    const veryOldDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
-    const veryOldIso = veryOldDate.toISOString().slice(0, 19) + "-05:00";
-    const farFutureDate = new Date(Date.now() + 200 * 24 * 60 * 60 * 1000);
-    const farFutureIso = farFutureDate.toISOString().slice(0, 19) + "-05:00";
-    const nearFutureDate = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
-    const nearFutureIso = nearFutureDate.toISOString().slice(0, 19) + "-05:00";
+  it("past exempt from minDate; upcoming exempt from maxDate but keeps its minDate floor (#2195)", async () => {
+    const veryOldIso = new Date(Date.now() - 365 * 86_400_000).toISOString().slice(0, 19) + "-05:00";
+    const farFutureIso = new Date(Date.now() + 200 * 86_400_000).toISOString().slice(0, 19) + "-05:00";
+    const nearFutureIso = new Date(Date.now() + 10 * 86_400_000).toISOString().slice(0, 19) + "-05:00";
 
     const pastEvent = buildApolloEvent({ id: "past-365", title: "Year Old Event", dateTime: veryOldIso });
     const farFutureEvent = buildApolloEvent({ id: "far-future", title: "Far Future", dateTime: farFutureIso, eventUrl: "https://www.meetup.com/test-hash/events/far-future/" });
     const nearFutureEvent = buildApolloEvent({ id: "near-future", title: "Near Future", dateTime: nearFutureIso, eventUrl: "https://www.meetup.com/test-hash/events/near-future/" });
+    // Contrived: a deep-past event surfaced on the UPCOMING page — must be
+    // dropped by the upcoming-side minDate floor (the one bound still enforced).
+    const stalePastUpcoming = buildApolloEvent({ id: "stale-up", title: "Stale Upcoming", dateTime: veryOldIso, eventUrl: "https://www.meetup.com/test-hash/events/stale-up/" });
 
     const upcomingHtml = buildMeetupHtml({
       "Event:far-future": farFutureEvent,
       "Event:near-future": nearFutureEvent,
+      "Event:stale-up": stalePastUpcoming,
       "Venue:123": VENUE_ENTRY,
     });
     const pastHtml = buildMeetupHtml({
@@ -1325,10 +1395,11 @@ describe("MeetupAdapter", () => {
       { days: 90 },
     );
     const titles = result.events.map((e) => e.title);
-    expect(titles).toContain("Year Old Event");  // past: exempt from minDate
-    expect(titles).toContain("Near Future");      // upcoming: within 90-day window
-    expect(titles).not.toContain("Far Future");   // upcoming: beyond maxDate
-    expect(result.events).toHaveLength(2);
+    expect(titles).toContain("Year Old Event");  // past page: exempt from minDate
+    expect(titles).toContain("Near Future");      // upcoming: within window
+    expect(titles).toContain("Far Future");       // upcoming: beyond maxDate, now KEPT (#2195)
+    expect(titles).not.toContain("Stale Upcoming"); // upcoming: below minDate floor → dropped
+    expect(result.events).toHaveLength(3);
   });
 
   it("maxDate still applies to past events (sanity check)", async () => {

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -952,8 +952,7 @@ describe("MeetupAdapter", () => {
   });
 
   it("keeps far-future upcoming events beyond the forward window (#2195 Rubber City)", async () => {
-    const futureDate = new Date(Date.now() + 200 * 24 * 60 * 60 * 1000);
-    const futureIso = futureDate.toISOString().slice(0, 19) + "-05:00";
+    const futureIso = isoDaysFromNow(200);
 
     const html = buildMeetupHtml({
       "Event:1": buildApolloEvent(),
@@ -1365,9 +1364,9 @@ describe("MeetupAdapter", () => {
   });
 
   it("past exempt from minDate; upcoming exempt from maxDate but keeps its minDate floor (#2195)", async () => {
-    const veryOldIso = new Date(Date.now() - 365 * 86_400_000).toISOString().slice(0, 19) + "-05:00";
-    const farFutureIso = new Date(Date.now() + 200 * 86_400_000).toISOString().slice(0, 19) + "-05:00";
-    const nearFutureIso = new Date(Date.now() + 10 * 86_400_000).toISOString().slice(0, 19) + "-05:00";
+    const veryOldIso = isoDaysFromNow(-365);
+    const farFutureIso = isoDaysFromNow(200);
+    const nearFutureIso = isoDaysFromNow(10);
 
     const pastEvent = buildApolloEvent({ id: "past-365", title: "Year Old Event", dateTime: veryOldIso });
     const farFutureEvent = buildApolloEvent({ id: "far-future", title: "Far Future", dateTime: farFutureIso, eventUrl: "https://www.meetup.com/test-hash/events/far-future/" });

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -104,6 +104,18 @@ export interface MeetupConfig {
    * not mint run #15.
    */
   anchorTrailRunNumber?: boolean;
+  /**
+   * Opt out of the structural boilerplate-block stripping (#2058/#2059/#2062).
+   * The default detector treats any paragraph block that repeats verbatim across
+   * >= 2 events as a standing club template and strips it. That misfires when a
+   * kennel's genuine per-event body IS a shared run template — Paris H3 +
+   * Sans Clue H3 (#2228) publish the same emoji-structured stanza
+   * ("🐰 Hares: TBD / 👣 Trail / 💶 Hash Cash: 5 €") on every event, so the
+   * detector strips the whole body and leaves only a title-echo. Set this on
+   * those sources so the full description is kept. Off (default) for everyone
+   * else — Savannah/Hogtown/Montreal still get their generic blurbs stripped.
+   */
+  keepRepeatedDescription?: boolean;
 }
 
 /** Shape of an event entry in Meetup's __NEXT_DATA__ Apollo state. */
@@ -956,7 +968,14 @@ export class MeetupAdapter implements SourceAdapter {
       if (!ev.dateTime) return true; // keep for downstream skip
       const d = new Date(ev.dateTime);
       if (pastOnlyIds.has(ev.id)) return d <= maxDate;
-      return d >= minDate && d <= maxDate;
+      // Upcoming-page events: keep ALL scheduled future runs. Clipping the future
+      // side (maxDate) silently dropped far-future events (#2195 Rubber City: 22
+      // scheduled through Dec 31, only ~12 within the 90-day window survived). The
+      // upcoming feed is self-bounding (only events the kennel created), and
+      // returning the full set every scrape keeps reconcile consistent so the
+      // far-future rows are never re-cancelled. Keep the minDate floor to drop a
+      // stale upcoming row dated in the deep past.
+      return d >= minDate;
     });
 
     // Enrich recurring events with detail page data (mutates in-place)
@@ -983,7 +1002,13 @@ export class MeetupAdapter implements SourceAdapter {
     const cleanedDescriptions = allApolloEvents.map((ev) =>
       cleanMeetupDescription(ev.description, mergedState),
     );
-    const boilerplateBlocks = detectBoilerplateBlocks(cleanedDescriptions);
+    // Strict-boolean opt-out (#2228): kennels whose real per-event body is a
+    // shared run template (Paris/Sans Clue) skip boilerplate stripping entirely,
+    // so the full description survives instead of collapsing to a title-echo.
+    const boilerplateBlocks =
+      config.keepRepeatedDescription === true
+        ? new Set<string>()
+        : detectBoilerplateBlocks(cleanedDescriptions);
 
     const compiledPatterns = compileKennelPatterns(config.kennelPatterns);
     const anchorTrailRunNumber = config.anchorTrailRunNumber === true;


### PR DESCRIPTION
## Summary

Quick-win bundle of four REST-API adapter defects (Harrier Central + Meetup), each **live-verified** against its production source.

| Issue | Kennel | Before | After (verified live) |
|---|---|---|---|
| #2220 | Lisbon H3 | `Depth Charge , Placeholder user for visitors / virgins for Lisbon H3` | `Depth Charge` |
| #2194 | Shanghai H3 | `…Anniversary \|` | `…Anniversary` |
| #2228 | Sans Clue H3 (+ Paris H3) | description = title-echo | full body (`🐰 Hares` / `💶 Hash Cash: 5 €`) |
| #2195 | Rubber City H3 | 12 events, stops Sep 3 | **22 events, Jun 18 → Dec 31** |

## What changed

**#2220 — `src/adapters/harrier-central/adapter.ts`**
HC appends a system `"Placeholder user for visitors / virgins for <Kennel>"` entry to the comma-joined hares string. New `stripPlaceholderHares()` filters it out. It fast-paths the no-placeholder case to return the value byte-identical to the old `stripTba` path, so it never re-fingerprints existing HC multi-hare events (`hares` is in the RawEvent fingerprint).

**#2194 — `src/adapters/harrier-central/adapter.ts`**
The API's `eventName` itself carries a trailing ` |`. `applyTitleFallback` now strips trailing `|`/`-`/`:` separators before the staleness check (the #756 / #1060 trailing-separator family). General to all HC sources; `!`/`?` terminators preserved.

**#2228 — `src/adapters/meetup/adapter.ts` + seed**
Paris H3 and Sans Clue H3 publish the *same* emoji run template on every event, so `detectBoilerplateBlocks` flagged the whole body as boilerplate and stripped it, leaving only a markdown echo of the title. New per-source `keepRepeatedDescription` opt-out skips boilerplate stripping; set on the "Paris & Sans Clue H3 Meetup" source. Savannah/Hogtown/Montreal (the kennels the stripper was built for) are unaffected. Hares extraction is unchanged.

**#2195 — `src/adapters/meetup/adapter.ts`**
The upcoming page's Apollo state already contains all 22 future events; the cause was the 90-day `maxDate` forward clip (not pagination, as the issue hypothesized). Upcoming-page events are now exempt from `maxDate`, mirroring the existing past-page `minDate` exemption. Reconcile-safe: its cancellation window is `now ± days`, so far-future rows sit outside it and are never re-cancelled (verified in `reconcile.ts`).

## Testing

- `npx tsc --noEmit` ✅, `npm run lint` ✅ (0 errors), `npm test` ✅ (9352 passed)
- New unit tests for all four fixes; two stale Meetup window tests updated to the new upcoming-exempt-from-maxDate contract.
- Live-verified each adapter's real `fetch()` against production (Lisbon/Shanghai HC API; Rubber City + Paris/Sans Clue Meetup pages).

## Deploy note

The `keepRepeatedDescription` seed flag is config — Vercel runs `migrate deploy`, **not** `db seed`, so a manual `npx prisma db seed` from synced `main` is needed post-merge for the Paris/Sans Clue source config to take effect.

Closes #2220
Closes #2194
Closes #2228
Closes #2195

🤖 Generated with [Claude Code](https://claude.com/claude-code)