### PR TITLE
fix(sources): set upcomingOnly on Seletar H3 PWA to protect backfilled history

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4767,6 +4767,15 @@ export const SOURCES = [
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 90,
+      config: {
+        // The adapter fetches UPCOMING_SQL (hl_datetime >= CURDATE()), so it is
+        // future-only. Without upcomingOnly the reconciler would cancel
+        // sole-source CONFIRMED past events inside the now±90d window that the
+        // live scrape never re-emits — including the ~13 recent rows from the
+        // 1980→present historical backfill (#2238). Restrict cancellation to
+        // FUTURE dates, the correct posture for a future-only adapter.
+        upcomingOnly: true,
+      },
       kennelCodes: ["seletar-h3"],
     },
 


### PR DESCRIPTION
## What

Adds `config: { upcomingOnly: true }` to the **Seletar H3 PWA** source in `prisma/seed-data/sources.ts`.

## Why

`Seletar H3 PWA` is the **sole** source for the `seletar-h3` kennel, and its adapter is **future-only** — the recurring scrape queries `UPCOMING_SQL` (`hl_datetime >= CURDATE()`, [`seletar-h3.ts`](src/adapters/html-scraper/seletar-h3.ts)). The source has `scrapeDays: 90` and previously no `config`.

The reconciler ([`reconcile.ts`](src/pipeline/reconcile.ts)) cancels sole-source CONFIRMED events inside its window that the live scrape doesn't re-emit. With no `upcomingOnly` flag that window is `now − 90d … future`, so it covers the recent past. [apps#2238](https://github.com/johnrclem/hashtracks-web/pull/2238) just one-shot-inserted ~2,084 canonical historical Events (1980→present); ~13 of them fall in the last 90 days and would be **CANCELLED** on the next daily Seletar scrape.

`upcomingOnly: true` makes the reconciler set `timeMin = now` (`reconcile.ts:144-147`), restricting cancellation to **future** dates — the correct posture for a future-only adapter, mirroring the existing `HHHS Penang` source pattern.

## Verified premises
- `reconcile.ts:144-147` — `upcomingOnly` → `timeMin = now`; past events untouched.
- `seletar-h3.ts:63,244` — recurring path is future-only (`UPCOMING_SQL`).
- `seed.ts:407-408` — `db seed` upserts `Source.config` when it differs.

## Checks
- `npx tsc --noEmit` → clean
- `npm run lint` → 0 errors (pre-existing warnings only, none in `sources.ts`)
- `npm test` → 318 files / 9343 tests passed

## ⚠️ Post-merge manual step
Vercel runs `prisma migrate deploy`, **not** `db seed`, so `Source.config` won't update automatically. After merge:
1. Sync local main (`git pull --ff-only`).
2. Run `npx prisma db seed` against prod (Node 20).
3. Verify the `Seletar H3 PWA` source `config` has `upcomingOnly: true`, and that recent `seletar-h3` events stay CONFIRMED (not CANCELLED) after the next daily scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)