### PR TITLE
fix(adapters): stop field-extraction leaks in Google Sheets + iCal (#2237, #2214, #2216)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -909,6 +909,9 @@ export const SOURCES = [
         // #2175: a `#TBD` placeholder run with a junk 03:02 DTSTART trips the
         // event-improbable-time audit — clear the throwaway time.
         dropImprobablePlaceholderTime: true,
+        // #2216: titleHarePattern extracts the "~ <hares>" suffix into haresText
+        // but left it in the title too. Strip the matched suffix from the title.
+        stripTitleHareSuffix: true,
       },
       kennelCodes: ["cch3"],
     },
@@ -2874,7 +2877,12 @@ export const SOURCES = [
       name: "Puget Sound H3 Hareline Sheet",
       url: "https://docs.google.com/spreadsheets/d/1XTN-ivc5NClSt4Z1HVYf0ddEzF3aXcnd1ZH0JFpLXm4",
       type: "GOOGLE_SHEETS" as const,
-      trustLevel: 5,
+      // #2214: trust 7 (= WA Hash GCal) so the dedicated hareline is authoritative
+      // for its own kennel. At trust 5 the aggregator GCal out-trusted the sheet,
+      // forcing the sheet through the merge enrich branch (fill-NULL-only) — so a
+      // stale `haresText` (the col-3 "Thursday" left by a pre-#2130 mapping) could
+      // never be overwritten by the sheet's real col-4 hares.
+      trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 365,
       config: {

--- a/scripts/backfill-cch3-title-2216.ts
+++ b/scripts/backfill-cch3-title-2216.ts
@@ -1,0 +1,72 @@
+/**
+ * One-shot canonical backfill for Charm City H3 titles with an embedded
+ * "~ <hares>" suffix (#2216).
+ *
+ * Why this is needed: the iCal adapter now strips the titleHarePattern "~ <hares>"
+ * suffix from the title (opt-in `stripTitleHareSuffix`, set on the CCH3 source).
+ * That fixes NEW raws and self-heals events whose stripped title is a real theme,
+ * but `resolveUpdatedTitle` (merge.ts #2233) PRESERVES an existing non-placeholder
+ * title — so a leaked title like "CCH3# TBD~ MoreMen Pukes Tonight" sticks even
+ * after the adapter emits the clean "CCH3# TBD".
+ *
+ * This script clears that residual directly. It STICKS because `title` is not part
+ * of the RawEvent fingerprint, so rewriting it never disturbs dedup.
+ *
+ * Scoped & safe: UPCOMING cch3 events only (the live window where the "~" separator
+ * always introduces hares — past CCH3 events used "~" for themes too, so they are
+ * deliberately left untouched), and only when the captured "~" suffix exactly
+ * equals the stored haresText (proving it's the hare suffix, not an incidental
+ * tilde). Optimistic value guard on UPDATE; idempotent (a re-run matches 0 rows).
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: DATABASE_URL=... BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-cch3-title-2216.ts
+ *   Apply:   DATABASE_URL=... BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-cch3-title-2216.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+
+// Mirrors the CCH3 source's titleHarePattern ("~\s*(.+)$"): capture everything
+// after the first tilde so the comparison matches the adapter's extraction.
+const TILDE_SUFFIX_RE = /~\s*(.+)$/;
+
+void runOneShot(async ({ prisma, apply }) => {
+  const events = await prisma.event.findMany({
+    where: {
+      title: { contains: "~" },
+      haresText: { not: null },
+      dateUtc: { gte: new Date() }, // upcoming only — see scope note above
+      eventKennels: { some: { kennel: { kennelCode: "cch3" } } },
+    },
+    select: { id: true, title: true, haresText: true, dateUtc: true },
+    orderBy: { date: "asc" },
+  });
+
+  const leaked = events.flatMap((e) => {
+    const title = e.title;
+    if (!title) return [];
+    const m = TILDE_SUFFIX_RE.exec(title);
+    if (!m || m[1].trim() !== (e.haresText ?? "").trim()) return [];
+    // Fall back to the synthesized default if stripping leaves nothing (none of
+    // the known leaks do, but stay safe rather than write an empty title).
+    const newTitle = title.replace(TILDE_SUFFIX_RE, "").trim() || "Charm City H3 Trail";
+    return [{ id: e.id, oldTitle: title, newTitle, dateUtc: e.dateUtc }];
+  });
+
+  console.log(`\n#2216 CCH3 title "~ <hares>" suffix → stripped: ${leaked.length} event(s)`);
+
+  let updated = 0;
+  for (const e of leaked) {
+    const date = e.dateUtc?.toISOString().slice(0, 10) ?? "?";
+    console.log(`   - ${date}: "${e.oldTitle}" → "${e.newTitle}"`);
+
+    if (apply) {
+      const res = await prisma.event.updateMany({
+        where: { id: e.id, title: e.oldTitle },
+        data: { title: e.newTitle },
+      });
+      updated += res.count;
+    }
+  }
+
+  if (apply && leaked.length) console.log(`   ✏️  updated ${updated}`);
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/scripts/backfill-cch3-title-2216.ts
+++ b/scripts/backfill-cch3-title-2216.ts
@@ -24,9 +24,21 @@
  */
 import { runOneShot } from "./lib/one-shot";
 
-// Mirrors the CCH3 source's titleHarePattern ("~\s*(.+)$"): capture everything
-// after the first tilde so the comparison matches the adapter's extraction.
-const TILDE_SUFFIX_RE = /~\s*(.+)$/;
+/**
+ * Mirror the CCH3 source's titleHarePattern ("~\s*(.+)$") with plain string ops
+ * (no regex — avoids the ReDoS hotspot, per the repo's `\s*`-adjacent guidance):
+ * split on the FIRST tilde, the trimmed remainder is the hare suffix. Returns the
+ * cleaned title only when that suffix equals `haresText` (proving it's the hare
+ * suffix, not an incidental tilde); otherwise null (leave untouched).
+ */
+function strippedTitle(title: string, haresText: string): string | null {
+  const idx = title.indexOf("~");
+  if (idx < 0) return null;
+  if (title.slice(idx + 1).trim() !== haresText.trim()) return null;
+  // Fall back to the synthesized default if stripping leaves nothing (none of the
+  // known leaks do, but stay safe rather than write an empty title).
+  return title.slice(0, idx).trim() || "Charm City H3 Trail";
+}
 
 void runOneShot(async ({ prisma, apply }) => {
   const events = await prisma.event.findMany({
@@ -41,14 +53,9 @@ void runOneShot(async ({ prisma, apply }) => {
   });
 
   const leaked = events.flatMap((e) => {
-    const title = e.title;
-    if (!title) return [];
-    const m = TILDE_SUFFIX_RE.exec(title);
-    if (!m || m[1].trim() !== (e.haresText ?? "").trim()) return [];
-    // Fall back to the synthesized default if stripping leaves nothing (none of
-    // the known leaks do, but stay safe rather than write an empty title).
-    const newTitle = title.replace(TILDE_SUFFIX_RE, "").trim() || "Charm City H3 Trail";
-    return [{ id: e.id, oldTitle: title, newTitle, dateUtc: e.dateUtc }];
+    const newTitle = e.title && e.haresText ? strippedTitle(e.title, e.haresText) : null;
+    if (e.title == null || newTitle == null) return [];
+    return [{ id: e.id, oldTitle: e.title, newTitle, dateUtc: e.dateUtc }];
   });
 
   console.log(`\n#2216 CCH3 title "~ <hares>" suffix → stripped: ${leaked.length} event(s)`);

--- a/scripts/backfill-psh3-hares-2214.ts
+++ b/scripts/backfill-psh3-hares-2214.ts
@@ -55,11 +55,10 @@ void runOneShot(async ({ prisma, apply }) => {
 
   console.log(`\n#2214 PSH3 haresText weekday leak → correct hares: ${events.length} event(s)`);
 
-  let cleared = 0;
-  let corrected = 0;
+  // Plan: each weekday-leak event → the correct hares from its latest sheet raw
+  // (the col-4 value, or null when the sheet row has no hares).
+  const plan = [];
   for (const e of events) {
-    // Latest PSH3-sheet raw linked to this canonical event carries the correct
-    // col-4 hares (or no hares at all, in which case the weekday is just wrong).
     const raw = await prisma.rawEvent.findFirst({
       where: { eventId: e.id, sourceId: source.id },
       orderBy: { scrapedAt: "desc" },
@@ -67,24 +66,28 @@ void runOneShot(async ({ prisma, apply }) => {
     });
     const rawHares = (raw?.rawData as { hares?: unknown } | null)?.hares;
     const fixed = sanitizeHares(typeof rawHares === "string" ? rawHares : null); // string | null
-
     const date = e.dateUtc?.toISOString().slice(0, 10) ?? "?";
-    console.log(`   - #${e.runNumber ?? "?"} ${date}: "${e.haresText}" → ${fixed === null ? "null" : `"${fixed}"`}`);
+    plan.push({ id: e.id, runNumber: e.runNumber, oldHares: e.haresText, fixed, date });
+  }
 
-    if (apply) {
-      // Optimistic guard: only rewrite while the stale weekday is still present.
-      const res = await prisma.event.updateMany({
-        where: { id: e.id, haresText: e.haresText },
-        data: { haresText: fixed },
-      });
-      if (res.count) {
-        if (fixed === null) cleared += res.count;
-        else corrected += res.count;
-      }
-    }
+  for (const p of plan) {
+    const target = p.fixed === null ? "null" : JSON.stringify(p.fixed);
+    console.log(`   - #${p.runNumber ?? "?"} ${p.date}: "${p.oldHares}" → ${target}`);
   }
 
   if (apply) {
+    let corrected = 0;
+    let cleared = 0;
+    for (const p of plan) {
+      // Optimistic guard: only rewrite while the stale weekday is still present.
+      const res = await prisma.event.updateMany({
+        where: { id: p.id, haresText: p.oldHares },
+        data: { haresText: p.fixed },
+      });
+      if (!res.count) continue;
+      if (p.fixed === null) cleared += res.count;
+      else corrected += res.count;
+    }
     console.log(`   ✏️  corrected ${corrected}, cleared ${cleared}`);
   }
   console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);

--- a/scripts/backfill-psh3-hares-2214.ts
+++ b/scripts/backfill-psh3-hares-2214.ts
@@ -1,0 +1,91 @@
+/**
+ * One-shot canonical backfill for PSH3 stale `haresText` (#2214).
+ *
+ * Why this is needed: PR #2202 corrected the PSH3 Google Sheets column mapping
+ * (hares = col 4 "Hare(s)", was the col 3 "Day" column) and #2214 bumps the
+ * sheet to trustLevel 7. But the already-stored canonical events still carry the
+ * pre-#2130 leak — `haresText` = the weekday name ("Thursday"/"Saturday"/…) — and
+ * a plain re-scrape does NOT fix them:
+ *   - The current sheet RawEvent already carries the CORRECT col-4 hares, so its
+ *     fingerprint is unchanged → the dedup table skips it → the merge UPDATE
+ *     never fires.
+ *   - Before the trust bump the sheet (trust 5) was out-trusted by the WA Hash
+ *     GCal (trust 7), so it only hit the merge ENRICH branch (fill-NULL-only),
+ *     which can never overwrite the non-null stale "Thursday".
+ *
+ * This script copies the correct hares from the most-recent PSH3 sheet RawEvent
+ * linked to each affected event (sanitized exactly as the merge would), or clears
+ * it to null when the sheet has no hares. It STICKS: haresText is not part of the
+ * RawEvent fingerprint, so rewriting it never disturbs dedup, and going forward
+ * the trust-7 sheet owns the field via the full-update branch.
+ *
+ * Scoped & safe: only psh3 events whose haresText is a bare weekday name (the
+ * Day-column leak signature — never a real hash name), optimistic value guard on
+ * UPDATE, idempotent (a re-run matches 0 rows).
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: DATABASE_URL=... BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-psh3-hares-2214.ts
+ *   Apply:   DATABASE_URL=... BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-psh3-hares-2214.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+import { sanitizeHares } from "@/pipeline/merge";
+
+const WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+const PSH3_SHEET_NAME = "Puget Sound H3 Hareline Sheet";
+
+void runOneShot(async ({ prisma, apply }) => {
+  const source = await prisma.source.findFirst({
+    where: { name: PSH3_SHEET_NAME },
+    select: { id: true },
+  });
+  if (!source) {
+    console.log(`Source "${PSH3_SHEET_NAME}" not found — nothing to do.`);
+    return;
+  }
+
+  // psh3 events whose haresText is a bare weekday — the col-3 "Day" leak.
+  const events = await prisma.event.findMany({
+    where: {
+      haresText: { in: WEEKDAYS },
+      eventKennels: { some: { kennel: { kennelCode: "psh3" } } },
+    },
+    select: { id: true, runNumber: true, haresText: true, dateUtc: true },
+    orderBy: { date: "asc" },
+  });
+
+  console.log(`\n#2214 PSH3 haresText weekday leak → correct hares: ${events.length} event(s)`);
+
+  let cleared = 0;
+  let corrected = 0;
+  for (const e of events) {
+    // Latest PSH3-sheet raw linked to this canonical event carries the correct
+    // col-4 hares (or no hares at all, in which case the weekday is just wrong).
+    const raw = await prisma.rawEvent.findFirst({
+      where: { eventId: e.id, sourceId: source.id },
+      orderBy: { scrapedAt: "desc" },
+      select: { rawData: true },
+    });
+    const rawHares = (raw?.rawData as { hares?: unknown } | null)?.hares;
+    const fixed = sanitizeHares(typeof rawHares === "string" ? rawHares : null); // string | null
+
+    const date = e.dateUtc?.toISOString().slice(0, 10) ?? "?";
+    console.log(`   - #${e.runNumber ?? "?"} ${date}: "${e.haresText}" → ${fixed === null ? "null" : `"${fixed}"`}`);
+
+    if (apply) {
+      // Optimistic guard: only rewrite while the stale weekday is still present.
+      const res = await prisma.event.updateMany({
+        where: { id: e.id, haresText: e.haresText },
+        data: { haresText: fixed },
+      });
+      if (res.count) {
+        if (fixed === null) cleared += res.count;
+        else corrected += res.count;
+      }
+    }
+  }
+
+  if (apply) {
+    console.log(`   ✏️  corrected ${corrected}, cleared ${cleared}`);
+  }
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/scripts/backfill-sekkong-blank-clear-2237.ts
+++ b/scripts/backfill-sekkong-blank-clear-2237.ts
@@ -29,6 +29,35 @@ import { runOneShot } from "./lib/one-shot";
 
 const SEKKONG_SHEET_NAME = "Sek Kong H3 Hareline Sheet";
 
+type SekEvent = {
+  id: string;
+  runNumber: number | null;
+  haresText: string | null;
+  description: string | null;
+  dateUtc: Date | null;
+};
+
+/** Decide which fields are stale (canonical holds a value the current sheet raw
+ *  no longer carries). A missing raw clears nothing — the row is left alone. */
+function planClears(e: SekEvent, rawData: unknown): { clearHares: boolean; clearDesc: boolean } {
+  const data = rawData as { hares?: unknown; description?: unknown } | null;
+  const rawHasHares = typeof data?.hares === "string" && data.hares.trim() !== "";
+  const rawHasDesc = typeof data?.description === "string" && data.description.trim() !== "";
+  return {
+    clearHares: e.haresText != null && !rawHasHares,
+    clearDesc: e.description != null && !rawHasDesc,
+  };
+}
+
+/** Single-template log line (no nested template literals). */
+function describeClears(e: SekEvent, clearHares: boolean, clearDesc: boolean): string {
+  const date = e.dateUtc?.toISOString().slice(0, 10) ?? "?";
+  const parts: string[] = [];
+  if (clearHares) parts.push(`hares "${e.haresText}" → null`);
+  if (clearDesc) parts.push(`desc "${(e.description ?? "").slice(0, 30)}…" → null`);
+  return `   - #${e.runNumber ?? "?"} ${date}: ${parts.join(" | ")}`;
+}
+
 void runOneShot(async ({ prisma, apply }) => {
   const source = await prisma.source.findFirst({
     where: { name: SEKKONG_SHEET_NAME },
@@ -49,10 +78,8 @@ void runOneShot(async ({ prisma, apply }) => {
     orderBy: { date: "asc" },
   });
 
-  let haresCleared = 0;
-  let descCleared = 0;
-  const leaks: string[] = [];
-
+  // Plan the clears: compare each canonical event against its latest sheet raw.
+  const plan = [];
   for (const e of events) {
     const raw = await prisma.rawEvent.findFirst({
       where: { eventId: e.id, sourceId: source.id },
@@ -60,39 +87,41 @@ void runOneShot(async ({ prisma, apply }) => {
       select: { rawData: true },
     });
     if (!raw) continue; // no sheet raw linked — leave alone
-    const data = raw.rawData as { hares?: unknown; description?: unknown } | null;
-    const rawHasHares = typeof data?.hares === "string" && data.hares.trim() !== "";
-    const rawHasDesc = typeof data?.description === "string" && data.description.trim() !== "";
-
-    const clearHares = e.haresText != null && !rawHasHares;
-    const clearDesc = e.description != null && !rawHasDesc;
+    const { clearHares, clearDesc } = planClears(e, raw.rawData);
     if (!clearHares && !clearDesc) continue;
+    plan.push({
+      id: e.id,
+      oldHares: e.haresText,
+      oldDesc: e.description,
+      clearHares,
+      clearDesc,
+      line: describeClears(e, clearHares, clearDesc),
+    });
+  }
 
-    const date = e.dateUtc?.toISOString().slice(0, 10) ?? "?";
-    leaks.push(
-      `   - #${e.runNumber ?? "?"} ${date}: ${clearHares ? `hares "${e.haresText}" → null` : ""}${clearHares && clearDesc ? " | " : ""}${clearDesc ? `desc "${(e.description ?? "").slice(0, 30)}…" → null` : ""}`,
-    );
+  console.log(`\n#2237 Sek Kong stale hares/description from blanked source rows: ${plan.length} event(s)`);
+  plan.forEach((p) => console.log(p.line));
 
-    if (apply) {
-      if (clearHares) {
+  if (apply) {
+    let haresCleared = 0;
+    let descCleared = 0;
+    for (const p of plan) {
+      if (p.clearHares) {
         const res = await prisma.event.updateMany({
-          where: { id: e.id, haresText: e.haresText },
+          where: { id: p.id, haresText: p.oldHares },
           data: { haresText: null },
         });
         haresCleared += res.count;
       }
-      if (clearDesc) {
+      if (p.clearDesc) {
         const res = await prisma.event.updateMany({
-          where: { id: e.id, description: e.description },
+          where: { id: p.id, description: p.oldDesc },
           data: { description: null },
         });
         descCleared += res.count;
       }
     }
+    console.log(`   ✏️  cleared ${haresCleared} hares, ${descCleared} description`);
   }
-
-  console.log(`\n#2237 Sek Kong stale hares/description from blanked source rows: ${leaks.length} event(s)`);
-  leaks.forEach((l) => console.log(l));
-  if (apply) console.log(`   ✏️  cleared ${haresCleared} hares, ${descCleared} description`);
   console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
 });

--- a/scripts/backfill-sekkong-blank-clear-2237.ts
+++ b/scripts/backfill-sekkong-blank-clear-2237.ts
@@ -1,0 +1,98 @@
+/**
+ * One-shot canonical backfill for Sek Kong H3 stale hares/description leaked
+ * from a since-blanked source row (#2237).
+ *
+ * Why this is needed: the google-sheets adapter now emits `null` (explicit clear)
+ * for a blank/placeholder cell in a configured column, which self-heals on the
+ * next scrape after deploy (the null re-fingerprints the raw → merge full-update
+ * clears the field). This script applies that same correction to the ALREADY
+ * stored canonical events immediately, so the leak (#2501 carrying #2500's
+ * "GM + Committee" / "2,500th Run" after its own row went blank) is fixed now
+ * rather than waiting for the deploy + next daily scrape.
+ *
+ * Mechanism: Sek Kong has a single source (the hareline sheet, trust 7). For each
+ * canonical event, the most-recent sheet RawEvent reflects the current sheet row.
+ * Where that raw carries NO hares/description (the row is blank) but the canonical
+ * still holds a value, the value is stale → clear it to null. Events whose raw
+ * still carries the value are left untouched (e.g. #2500 keeps "GM + Committee").
+ *
+ * Safe & idempotent: only clears (never invents), optimistic value guard on
+ * UPDATE, single-source kennel so there is no cross-source value to preserve, and
+ * the cleared null STICKS (haresText/description are not part of the fingerprint;
+ * the deployed adapter's `undefined` for a blank cell preserves the null).
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: DATABASE_URL=... BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-sekkong-blank-clear-2237.ts
+ *   Apply:   DATABASE_URL=... BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-sekkong-blank-clear-2237.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+
+const SEKKONG_SHEET_NAME = "Sek Kong H3 Hareline Sheet";
+
+void runOneShot(async ({ prisma, apply }) => {
+  const source = await prisma.source.findFirst({
+    where: { name: SEKKONG_SHEET_NAME },
+    select: { id: true },
+  });
+  if (!source) {
+    console.log(`Source "${SEKKONG_SHEET_NAME}" not found — nothing to do.`);
+    return;
+  }
+
+  // Canonical events that still hold a hares or description value.
+  const events = await prisma.event.findMany({
+    where: {
+      eventKennels: { some: { kennel: { kennelCode: "sekkong-h3" } } },
+      OR: [{ haresText: { not: null } }, { description: { not: null } }],
+    },
+    select: { id: true, runNumber: true, haresText: true, description: true, dateUtc: true },
+    orderBy: { date: "asc" },
+  });
+
+  let haresCleared = 0;
+  let descCleared = 0;
+  const leaks: string[] = [];
+
+  for (const e of events) {
+    const raw = await prisma.rawEvent.findFirst({
+      where: { eventId: e.id, sourceId: source.id },
+      orderBy: { scrapedAt: "desc" },
+      select: { rawData: true },
+    });
+    if (!raw) continue; // no sheet raw linked — leave alone
+    const data = raw.rawData as { hares?: unknown; description?: unknown } | null;
+    const rawHasHares = typeof data?.hares === "string" && data.hares.trim() !== "";
+    const rawHasDesc = typeof data?.description === "string" && data.description.trim() !== "";
+
+    const clearHares = e.haresText != null && !rawHasHares;
+    const clearDesc = e.description != null && !rawHasDesc;
+    if (!clearHares && !clearDesc) continue;
+
+    const date = e.dateUtc?.toISOString().slice(0, 10) ?? "?";
+    leaks.push(
+      `   - #${e.runNumber ?? "?"} ${date}: ${clearHares ? `hares "${e.haresText}" → null` : ""}${clearHares && clearDesc ? " | " : ""}${clearDesc ? `desc "${(e.description ?? "").slice(0, 30)}…" → null` : ""}`,
+    );
+
+    if (apply) {
+      if (clearHares) {
+        const res = await prisma.event.updateMany({
+          where: { id: e.id, haresText: e.haresText },
+          data: { haresText: null },
+        });
+        haresCleared += res.count;
+      }
+      if (clearDesc) {
+        const res = await prisma.event.updateMany({
+          where: { id: e.id, description: e.description },
+          data: { description: null },
+        });
+        descCleared += res.count;
+      }
+    }
+  }
+
+  console.log(`\n#2237 Sek Kong stale hares/description from blanked source rows: ${leaks.length} event(s)`);
+  leaks.forEach((l) => console.log(l));
+  if (apply) console.log(`   ✏️  cleared ${haresCleared} hares, ${descCleared} description`);
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/scripts/sync-source-config-2214-2216.ts
+++ b/scripts/sync-source-config-2214-2216.ts
@@ -1,0 +1,71 @@
+/**
+ * Targeted prod Source.config sync for #2214 + #2216.
+ *
+ * Vercel runs `prisma migrate deploy`, NOT `prisma db seed`, so edits to
+ * `prisma/seed-data/sources.ts` never reach the prod `Source` rows on merge.
+ * A full `db seed` would full-overwrite every Source.config and clobber other
+ * concurrent source edits, so this script updates ONLY the two rows this change
+ * owns, merging keys into the existing config rather than replacing it:
+ *
+ *   - #2214 Puget Sound H3 Hareline Sheet → trustLevel 7 (was 5), so the
+ *     dedicated hareline out-trusts the WA Hash aggregator GCal and its real
+ *     hares win the merge full-update branch going forward.
+ *   - #2216 Charm City H3 iCal Feed → config.stripTitleHareSuffix = true, so the
+ *     adapter strips the "~ <hares>" suffix from the title on every scrape.
+ *     (No-op until the adapter code that reads the flag is deployed.)
+ *
+ * Idempotent: re-running matches the desired state and reports "already set".
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: DATABASE_URL=... BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/sync-source-config-2214-2216.ts
+ *   Apply:   DATABASE_URL=... BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/sync-source-config-2214-2216.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+
+void runOneShot(async ({ prisma, apply }) => {
+  // ── #2214 PSH3 trustLevel 5 → 7 ──────────────────────────────────────────
+  {
+    const s = await prisma.source.findFirst({
+      where: { name: "Puget Sound H3 Hareline Sheet" },
+      select: { id: true, trustLevel: true },
+    });
+    if (!s) {
+      console.log(`\n#2214: "Puget Sound H3 Hareline Sheet" not found.`);
+    } else if (s.trustLevel === 7) {
+      console.log(`\n#2214 PSH3 trustLevel already 7 — no change.`);
+    } else {
+      console.log(`\n#2214 PSH3 trustLevel ${s.trustLevel} → 7`);
+      if (apply) {
+        await prisma.source.update({ where: { id: s.id }, data: { trustLevel: 7 } });
+        console.log(`   ✏️  updated`);
+      }
+    }
+  }
+
+  // ── #2216 CCH3 config.stripTitleHareSuffix = true (merge, don't replace) ──
+  {
+    const s = await prisma.source.findFirst({
+      where: { name: "Charm City H3 iCal Feed" },
+      select: { id: true, config: true },
+    });
+    if (!s) {
+      console.log(`\n#2216: "Charm City H3 iCal Feed" not found.`);
+    } else {
+      const config = (s.config ?? {}) as Record<string, unknown>;
+      if (config.stripTitleHareSuffix === true) {
+        console.log(`\n#2216 CCH3 stripTitleHareSuffix already true — no change.`);
+      } else {
+        console.log(`\n#2216 CCH3 config += stripTitleHareSuffix: true`);
+        if (apply) {
+          await prisma.source.update({
+            where: { id: s.id },
+            data: { config: { ...config, stripTitleHareSuffix: true } },
+          });
+          console.log(`   ✏️  updated`);
+        }
+      }
+    }
+  }
+
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/scripts/sync-source-config-2214-2216.ts
+++ b/scripts/sync-source-config-2214-2216.ts
@@ -48,9 +48,7 @@ void runOneShot(async ({ prisma, apply }) => {
       where: { name: "Charm City H3 iCal Feed" },
       select: { id: true, config: true },
     });
-    if (!s) {
-      console.log(`\n#2216: "Charm City H3 iCal Feed" not found.`);
-    } else {
+    if (s) {
       const config = (s.config ?? {}) as Record<string, unknown>;
       if (config.stripTitleHareSuffix === true) {
         console.log(`\n#2216 CCH3 stripTitleHareSuffix already true — no change.`);
@@ -64,6 +62,8 @@ void runOneShot(async ({ prisma, apply }) => {
           console.log(`   ✏️  updated`);
         }
       }
+    } else {
+      console.log(`\n#2216: "Charm City H3 iCal Feed" not found.`);
     }
   }
 

--- a/src/adapters/google-sheets/adapter.test.ts
+++ b/src/adapters/google-sheets/adapter.test.ts
@@ -242,13 +242,32 @@ describe("buildEventFromSheetRow", () => {
     expect(event!.title).toBeUndefined();
   });
 
-  it("strips TBD hares and location", () => {
+  it("strips TBD hares and location to null (configured cols → explicit clear, #2237)", () => {
     const row = ["100", "3/11/26", "tbd", "TBA", "Real Title"];
     const event = buildEventFromSheetRow(row, baseConfig, "https://example.com", "2026-03-11");
     expect(event).not.toBeNull();
-    expect(event!.hares).toBeUndefined();
-    expect(event!.location).toBeUndefined();
+    // #2237: a blank/placeholder cell in a CONFIGURED column emits `null`
+    // (explicit clear) so the merge pipeline scrubs a stale value rather than
+    // preserving it. (`undefined` is reserved for unconfigured columns.)
+    expect(event!.hares).toBeNull();
+    expect(event!.location).toBeNull();
     expect(event!.title).toBe("Real Title");
+  });
+
+  it("emits null for a blank configured description column (#2237)", () => {
+    // Sek Kong #2501 scenario: a present row whose Hares/Location/Notes cells
+    // are blank must clear those fields, not inherit the neighbouring row's.
+    const config = {
+      sheetId: "sekkong",
+      columns: { runNumber: 0, date: 2, hares: 3, location: 4, description: 5 },
+      kennelTagRules: { default: "sekkong-h3" },
+    } as GoogleSheetsConfig;
+    const row = ["2501", "Sun.", "20-Dec-2026", "", "", ""];
+    const event = buildEventFromSheetRow(row, config, "https://example.com", "2026-12-20")!;
+    expect(event.runNumber).toBe(2501);
+    expect(event.hares).toBeNull();
+    expect(event.location).toBeNull();
+    expect(event.description).toBeNull();
   });
 
   it("emits runNumber: undefined when columns.runNumber is not configured (Hibiscus pattern)", () => {
@@ -468,18 +487,19 @@ describe("buildEventFromSheetRow", () => {
       kennelTagRules: { default: "okissme-h3" },
     };
 
-    it("location only → location populated, locationStreet undefined", () => {
+    it("location only → location populated, locationStreet null (configured-blank, #2237)", () => {
       const row = ["53", "5/22/26", "Fire in the Hole", "Orlando", ""];
       const event = buildEventFromSheetRow(row, okConfig, "https://example.com", "2026-05-22");
       expect(event!.location).toBe("Orlando");
-      expect(event!.locationStreet).toBeUndefined();
+      // address column is configured but blank → explicit clear (#2237).
+      expect(event!.locationStreet).toBeNull();
       expect(event!.locationUrl).toContain("Orlando");
     });
 
-    it("address only → locationStreet populated, location undefined", () => {
+    it("address only → locationStreet populated, location null (configured-blank, #2237)", () => {
       const row = ["52", "5/15/26", "Slip", "", "West Oaks Mall-West, Ocoee, FL 34761"];
       const event = buildEventFromSheetRow(row, okConfig, "https://example.com", "2026-05-15");
-      expect(event!.location).toBeUndefined();
+      expect(event!.location).toBeNull();
       expect(event!.locationStreet).toBe("West Oaks Mall-West, Ocoee, FL 34761");
       // googleMapsSearchUrl percent-encodes the query, so spaces → %20.
       expect(event!.locationUrl).toContain("West%20Oaks%20Mall-West");
@@ -495,19 +515,19 @@ describe("buildEventFromSheetRow", () => {
       expect(event!.locationUrl).toContain("Orlando%2C%20123%20Lake%20Eola%20Dr");
     });
 
-    it("both blank → both undefined, no maps URL", () => {
+    it("both blank → both null (configured cols), no maps URL", () => {
       const row = ["55", "6/5/26", "Hare", "", ""];
       const event = buildEventFromSheetRow(row, okConfig, "https://example.com", "2026-06-05");
-      expect(event!.location).toBeUndefined();
-      expect(event!.locationStreet).toBeUndefined();
+      expect(event!.location).toBeNull();
+      expect(event!.locationStreet).toBeNull();
       expect(event!.locationUrl).toBeUndefined();
     });
 
-    it("address column strips TBD/TBA placeholders", () => {
+    it("address column strips TBD/TBA placeholders to null", () => {
       const row = ["56", "6/12/26", "Hare", "Orlando", "TBD"];
       const event = buildEventFromSheetRow(row, okConfig, "https://example.com", "2026-06-12");
       expect(event!.location).toBe("Orlando");
-      expect(event!.locationStreet).toBeUndefined();
+      expect(event!.locationStreet).toBeNull();
     });
   });
 
@@ -632,7 +652,7 @@ describe("buildEventFromSheetRow", () => {
     expect(event!.hares).toBe("TIMBITS");
   });
 
-  it("returns undefined hares when both primary and extra cells empty", () => {
+  it("returns null hares when both primary and extra cells empty (configured col → clear, #2237)", () => {
     const config = {
       sheetId: "test",
       columns: { runNumber: 0, date: 1, hares: 2, extraHares: [3], location: 4, title: 5 },
@@ -641,7 +661,7 @@ describe("buildEventFromSheetRow", () => {
     const row = ["102", "3/25/26", "", "", "", ""];
     const event = buildEventFromSheetRow(row, config as GoogleSheetsConfig, "https://example.com", "2026-03-25");
     expect(event).not.toBeNull();
-    expect(event!.hares).toBeUndefined();
+    expect(event!.hares).toBeNull();
   });
 
   it("strips placeholder values from extraHares cells", () => {
@@ -1042,8 +1062,10 @@ describe("GoogleSheetsAdapter.fetch — Munich row alignment, two runs/date (#21
     expect(r938.hares).toBe("Loose Nutz & Motörmouth");
     expect(r938.startTime).toBe("17:00");
     // The whole point of #2157: a blank Location cell must NOT borrow the
-    // neighbouring row's value.
-    expect(r938.location).toBeUndefined();
+    // neighbouring row's value. Post-#2237 a configured-but-blank Location
+    // emits `null` (explicit clear) rather than `undefined` — still not the
+    // borrowed value, and now also scrubs any stale canonical venue.
+    expect(r938.location).toBeNull();
     expect(r938.date).toBe(parseDate(dSame)!);
 
     const r939 = result.events.find((e) => e.runNumber === 939)!;

--- a/src/adapters/google-sheets/adapter.ts
+++ b/src/adapters/google-sheets/adapter.ts
@@ -593,17 +593,23 @@ function resolveKennelTagFromSheetRow(
 function resolveLocationFields(
   row: string[],
   config: GoogleSheetsConfig,
-): { location: string | undefined; locationStreet: string | undefined; locationUrl: string | undefined } {
+): { location: string | null | undefined; locationStreet: string | null | undefined; locationUrl: string | undefined } {
   const locationIdx = config.columns.location;
-  let location = locationIdx == null ? undefined : stripPlaceholder(row[locationIdx]);
+  // A configured-but-blank location cell emits an explicit `null` (clear stale
+  // venue) rather than `undefined` (preserve): a row that loses its venue
+  // between scrapes must scrub the canonical `locationName`, not inherit the
+  // previous value (#2237). An UNCONFIGURED column stays `undefined` so a
+  // sibling source can still enrich it (#1579).
+  let location = locationIdx == null ? undefined : (stripPlaceholder(row[locationIdx]) ?? null);
   // Drop all-lowercase single-token "city shorthand" values (e.g. "sheperdstown")
-  // that aren't real venue names. The merge pipeline still has the kennel's
-  // region/country bias for geocoding. See #893.
+  // that aren't real venue names. This is a "don't use as venue but don't clear"
+  // signal, so leave it `undefined` (preserve) — the merge pipeline still has the
+  // kennel's region/country bias for geocoding. See #893.
   if (location && isCityShorthand(location)) location = undefined;
   const addressIdx = config.columns.address;
   const locationStreet = addressIdx == null
     ? undefined
-    : stripPlaceholder(row[addressIdx]);
+    : (stripPlaceholder(row[addressIdx]) ?? null);
   const mapsQuery = location && locationStreet
     ? `${location}, ${locationStreet}`
     : (locationStreet || location);
@@ -633,15 +639,19 @@ export function buildEventFromSheetRow(
   const resolved = resolveKennelTagFromSheetRow(row, config);
   if (!resolved) return null;
 
-  // Strip placeholder values (TBD, TBA, N/A, etc.)
+  // Strip placeholder values (TBD, TBA, N/A, etc.). The hares column is always
+  // configured, so a blank/placeholder cell emits an explicit `null` (clear)
+  // rather than `undefined` (preserve): a row that loses its hares between
+  // scrapes must scrub the stale canonical `haresText`, not inherit the
+  // neighbouring row's value (the Sek Kong #2501 leak, #2237).
   const primaryHare = stripPlaceholder(row[config.columns.hares]);
   const extraHareCols = config.columns.extraHares ?? [];
   const hares = extraHareCols.length === 0
-    ? primaryHare
+    ? (primaryHare ?? null)
     : (() => {
         const all = [primaryHare, ...extraHareCols.map((idx) => stripPlaceholder(row[idx]))]
           .filter((h): h is string => Boolean(h));
-        if (all.length === 0) return undefined;
+        if (all.length === 0) return null;
         // Deterministic sort so column-order changes don't churn fingerprints.
         all.sort((a, b) => a.localeCompare(b));
         return all.join(" / ");
@@ -669,9 +679,12 @@ export function buildEventFromSheetRow(
   const writeUp = config.columns.description != null
     ? row[config.columns.description]?.trim()
     : undefined;
-  const description = writeUp
-    ? writeUp.substring(0, 2000) || undefined
-    : undefined;
+  // Configured-but-blank description emits an explicit `null` (clear) so a row
+  // that drops its notes between scrapes scrubs the stale canonical value
+  // instead of preserving it (#2237). Unconfigured column stays `undefined`.
+  const description = config.columns.description == null
+    ? undefined
+    : (writeUp ? (writeUp.substring(0, 2000) || null) : null);
   // #923: prefer an explicit startTime cell when configured, fall back to
   // day-of-week inference. Cell may be "HH:MM", "H:MM am/pm", or empty/TBD.
   const startTimeCell = config.columns.startTime == null ? undefined : row[config.columns.startTime];

--- a/src/adapters/google-sheets/adapter.ts
+++ b/src/adapters/google-sheets/adapter.ts
@@ -620,6 +620,33 @@ function resolveLocationFields(
   };
 }
 
+/** Resolve the merged hares string for a sheet row. The hares column is always
+ *  configured, so a blank/placeholder cell yields an explicit `null` (clear),
+ *  never `undefined` — a row that loses its hares must scrub the stale canonical
+ *  `haresText`, not inherit the neighbouring row's value (#2237). */
+function resolveHares(row: string[], config: GoogleSheetsConfig): string | null {
+  const primaryHare = stripPlaceholder(row[config.columns.hares]);
+  const extraHareCols = config.columns.extraHares ?? [];
+  if (extraHareCols.length === 0) return primaryHare ?? null;
+  const all = [primaryHare, ...extraHareCols.map((idx) => stripPlaceholder(row[idx]))]
+    .filter((h): h is string => Boolean(h));
+  if (all.length === 0) return null;
+  // Deterministic sort so column-order changes don't churn fingerprints.
+  all.sort((a, b) => a.localeCompare(b));
+  return all.join(" / ");
+}
+
+/** Resolve the description for a sheet row. Tri-state: an unconfigured column →
+ *  `undefined` (preserve existing); a configured-but-blank cell → `null` (clear
+ *  the stale canonical value, #2237); otherwise the trimmed cell capped at 2000
+ *  chars. */
+function resolveDescription(row: string[], config: GoogleSheetsConfig): string | null | undefined {
+  if (config.columns.description == null) return undefined;
+  const writeUp = row[config.columns.description]?.trim();
+  if (!writeUp) return null;
+  return writeUp.substring(0, 2000) || null;
+}
+
 /** Build a RawEventData from a sheet row. Returns null if the row should be skipped.
  *
  * `eventLabel` (#1624) is surfaced by `processRows` when the Group cell matched
@@ -639,23 +666,7 @@ export function buildEventFromSheetRow(
   const resolved = resolveKennelTagFromSheetRow(row, config);
   if (!resolved) return null;
 
-  // Strip placeholder values (TBD, TBA, N/A, etc.). The hares column is always
-  // configured, so a blank/placeholder cell emits an explicit `null` (clear)
-  // rather than `undefined` (preserve): a row that loses its hares between
-  // scrapes must scrub the stale canonical `haresText`, not inherit the
-  // neighbouring row's value (the Sek Kong #2501 leak, #2237).
-  const primaryHare = stripPlaceholder(row[config.columns.hares]);
-  const extraHareCols = config.columns.extraHares ?? [];
-  const hares = extraHareCols.length === 0
-    ? (primaryHare ?? null)
-    : (() => {
-        const all = [primaryHare, ...extraHareCols.map((idx) => stripPlaceholder(row[idx]))]
-          .filter((h): h is string => Boolean(h));
-        if (all.length === 0) return null;
-        // Deterministic sort so column-order changes don't churn fingerprints.
-        all.sort((a, b) => a.localeCompare(b));
-        return all.join(" / ");
-      })();
+  const hares = resolveHares(row, config);
   const { location, locationStreet, locationUrl } = resolveLocationFields(row, config);
   let title = config.columns.title != null ? stripPlaceholder(row[config.columns.title]) : undefined;
 
@@ -676,15 +687,7 @@ export function buildEventFromSheetRow(
       : config.defaultTitle;
   }
 
-  const writeUp = config.columns.description != null
-    ? row[config.columns.description]?.trim()
-    : undefined;
-  // Configured-but-blank description emits an explicit `null` (clear) so a row
-  // that drops its notes between scrapes scrubs the stale canonical value
-  // instead of preserving it (#2237). Unconfigured column stays `undefined`.
-  const description = config.columns.description == null
-    ? undefined
-    : (writeUp ? (writeUp.substring(0, 2000) || null) : null);
+  const description = resolveDescription(row, config);
   // #923: prefer an explicit startTime cell when configured, fall back to
   // day-of-week inference. Cell may be "HH:MM", "H:MM am/pm", or empty/TBD.
   const startTimeCell = config.columns.startTime == null ? undefined : row[config.columns.startTime];

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -1093,6 +1093,10 @@ END:VCALENDAR`;
     const phantom = result.events.find((e) => e.runNumber === 2927);
     expect(phantom).toBeDefined();
     expect(phantom!.hares).toBe("Phantom");
+    // #2216 regression guard: Perth's titleHarePattern is a FULL-LINE match, so
+    // stripping it would blank the whole title. Perth does NOT opt into
+    // stripTitleHareSuffix, so the title is left intact (the strip never runs).
+    expect(phantom!.title).toBeTruthy();
 
     const noSpaceDash = result.events.find((e) => e.runNumber === 2931);
     expect(noSpaceDash).toBeDefined();
@@ -1761,6 +1765,18 @@ DTSTART;TZID=America/New_York:20260911T030200
 SUMMARY:CCH3 #TBD- A phone Gerbile  and. around the world in 80 lays
 DTSTAMP:20260201T000000Z
 END:VEVENT
+BEGIN:VEVENT
+UID:ai1ec-1601@charmcityh3.com
+DTSTART;TZID=America/New_York:20260822T160000
+SUMMARY:CCH3# TBD~ MoreMen Pukes Tonight
+DTSTAMP:20260201T000000Z
+END:VEVENT
+BEGIN:VEVENT
+UID:ai1ec-1602@charmcityh3.com
+DTSTART;TZID=America/New_York:20260808T160000
+SUMMARY:CCH3 Trail TBD ~ Paint the Goat and Spewart Little
+DTSTAMP:20260201T000000Z
+END:VEVENT
 END:VCALENDAR`;
 
 function buildCharmCitySource(): Source {
@@ -1780,6 +1796,7 @@ function buildCharmCitySource(): Source {
       ],
       cleanDescriptionLocation: true,
       dropImprobablePlaceholderTime: true,
+      stripTitleHareSuffix: true,
     },
   });
 }
@@ -1875,6 +1892,55 @@ END:VCALENDAR`;
     // venue (tri-state), NOT undefined (which would preserve a prior venue).
     expect(e!.location).toBeNull();
     expect(e!.hares).toBe("Just Someone");
+  });
+
+  // #2216 — titleHarePattern pulls the "~ <hares>" suffix into haresText, but
+  // it was left embedded in the title too. stripTitleHareSuffix removes it.
+  it("strips the '~ <hares>' suffix from the title (#2216, kennel-prefixed)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(CHARM_CITY_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildCharmCitySource(), { days: 9999 });
+
+    const e = result.events.find((x) => x.date === "2026-08-22");
+    expect(e).toBeDefined();
+    expect(e!.hares).toBe("MoreMen Pukes Tonight");
+    // The hares must NOT also appear in the title, and the "~" separator is gone.
+    expect(e!.title).toBe("CCH3# TBD");
+  });
+
+  it("strips the '~ <hares>' suffix from a 'Trail #' kennel title (#2216, live shape)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(CHARM_CITY_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildCharmCitySource(), { days: 9999 });
+
+    const e = result.events.find((x) => x.date === "2026-08-08");
+    expect(e).toBeDefined();
+    expect(e!.hares).toBe("Paint the Goat and Spewart Little");
+    expect(e!.title).toBe("CCH3 Trail TBD");
+  });
+
+  it("does NOT strip the title when hares come from the DESCRIPTION, not the summary (negative)", async () => {
+    // The Brewery Bike Tour event's hares live in the DESCRIPTION ("Hares~ …"),
+    // so hareFromTitle is false and the SUMMARY title is left untouched even
+    // though stripTitleHareSuffix is on.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(CHARM_CITY_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildCharmCitySource(), { days: 9999 });
+
+    const e = result.events.find((x) => x.date === "2026-09-07");
+    expect(e!.hares).toBe("Facial Profiling and Just Mike");
+    expect(e!.title).toBe("CCH3 Brewery Bike Tour");
+  });
+
+  it("leaves the '~ <hares>' suffix in the title when stripTitleHareSuffix is off (opt-in guard)", async () => {
+    // Other titleHarePattern feeds must be untouched: without the opt-in flag the
+    // suffix stays in the title (the pre-#2216 behaviour), while hares are still
+    // extracted.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(CHARM_CITY_ICS, { status: 200 }));
+    const source = buildCharmCitySource();
+    (source.config as Record<string, unknown>).stripTitleHareSuffix = false;
+    const result = await adapter.fetch(source, { days: 9999 });
+
+    const e = result.events.find((x) => x.date === "2026-08-22");
+    expect(e!.hares).toBe("MoreMen Pukes Tonight");
+    expect(e!.title).toContain("MoreMen Pukes Tonight");
   });
 });
 

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -25,6 +25,7 @@ export interface ICalSourceConfig {
   keepNonKennelTitlePrefix?: boolean;  // #1955: only strip a "Prefix:" from the SUMMARY title when the prefix identifies the kennel (run marker or matching tag); keep event-type prefixes like "Hash Lunch:". Off by default — most feeds (e.g. the Reading regional Localendar) use full kennel-name prefixes that SHOULD be stripped.
   coalesceEndpointDuplicates?: boolean; // collapse a same-date all-day /events/{n} VEVENT into its timed /runs/{m} twin, enriching hares/description/etc. — Oslo H3 publishes each run on both endpoints (#1828)
   rejectTitleHareThemeSuffix?: boolean; // #2004 Perth: drop a titleHarePattern capture that ends in an event-type word ("West Coast 4 seasons run") — it's a trail theme, not a hare. Opt-in so it never touches other titleHarePattern sources whose hares can legitimately end in such words.
+  stripTitleHareSuffix?: boolean;      // #2216 Charm City: after extracting hares from the SUMMARY via titleHarePattern, remove the matched suffix (e.g. "~ <hares>") from the resolved title so hare names don't appear in both `title` and `haresText`. Opt-in (and gated on hareFromTitle) — full-line titleHarePattern sources (Perth's "^Run N - hares") would blank the whole title, and a rejected theme suffix must keep its title intact.
   titleStripPrefixAliases?: string[];  // #2148 Reading / #2160 ICH3: kennel-label variants ("RH3"/"ReadingH3", "ICH3") to strip from the START of the resolved title together with an immediately-following run marker ("#1203:", "# 60"). Opt-in per source — the run number is already extracted into its own field, so the prefix is pure noise. See stripTitleKennelRunPrefix.
   cleanDescriptionLocation?: boolean;  // #2159 Charm City: run a DESCRIPTION-derived location (not the VEVENT LOCATION field) through cleanLocationName — strips URLs/labels/CTA residue and rejects placeholders. Opt-in so feeds whose On-On venue path already emits clean names are untouched.
   dropImprobablePlaceholderTime?: boolean; // #2175 Charm City: clear startTime/endTime when a `#TBD`-style placeholder run also carries a junk late-night DTSTART (23:00–03:59) — the hare entered a throwaway time before the trail was scheduled. Opt-in so a legitimately late/early-morning trail on another feed that still uses a placeholder run number keeps its time.
@@ -713,6 +714,18 @@ function buildRawEventFromVEvent(
   // source bakes into the title ("RH3: #1203:", "ICH3# 60"). Opt-in per source.
   if (title && config?.titleStripPrefixAliases?.length) {
     title = stripTitleKennelRunPrefix(title, config.titleStripPrefixAliases);
+  }
+  // #2216 Charm City — when the hare was pulled from the SUMMARY via
+  // `titleHarePattern`, the matched "~ <hares>" suffix is still embedded in the
+  // title ("CCH3# TBD~ MoreMen Pukes Tonight"). Strip it so the hares don't
+  // appear in both `title` and `haresText`. Opt-in (`stripTitleHareSuffix`):
+  // CCH3's pattern is a suffix match, but full-line patterns (Perth's
+  // "^Run N - hares") would blank the entire title, so other sources are left
+  // untouched. Also gated on `hareFromTitle`, so a rejected theme suffix
+  // (rejectTitleHareThemeSuffix) keeps its full title. Empty remainder falls
+  // back to `undefined` so merge synthesizes "<Kennel> Trail #N".
+  if (config?.stripTitleHareSuffix && hareFromTitle && title && compiledTitleHarePattern) {
+    title = title.replace(compiledTitleHarePattern, "").trim() || undefined;
   }
   // #2160 hard rule — the title must NEVER be the hare name. When the hare was
   // pulled from the SUMMARY (titleHarePattern) and the stripped title is just


### PR DESCRIPTION
Quick-win bundle: three shared-adapter field-extraction leaks. Each issue had a **forward fix** (adapter/config) and **stale canonical data** the merge pipeline preserves; targeted, idempotent one-shot backfills clear the backlog. All three live-verified against their live sources, with sibling kennels confirmed regression-free.

## Fixes

### #2237 Sek Kong — blank source cell inheriting the prior row (`src/adapters/google-sheets/adapter.ts`)
A blank/placeholder cell in a **configured** column now emits `null` (explicit clear) instead of `undefined` (preserve), so a row that loses its hares/notes/venue scrubs the stale canonical value instead of inheriting the neighbour's. Unconfigured columns still emit `undefined` (preserves cross-source enrichment). The `null` also re-fingerprints the raw → self-heals on the next scrape.
- Live: Sek Kong #2501 (blank row) now emits `hares=null, description=null, location=null`; #2500 keeps its real `GM + Committee`.

### #2216 Charm City — hares left in the title (`src/adapters/ical/adapter.ts`)
After `titleHarePattern` extracts the `~ <hares>` suffix into `haresText`, the suffix is stripped from the title. Opt-in `stripTitleHareSuffix` (enabled on the CCH3 source), gated on `hareFromTitle` — opt-in because full-line patterns (Perth's `^Run N - hares`) would otherwise blank the entire title; gating on `hareFromTitle` keeps a rejected theme suffix intact.
- Live: Aug 8 → title `"Charm City H3 Trail TBD"` + hares `"Paint the Goat and Spewart Little"`; Aug 22 → title `"CCH3# TBD"` + hares `"MoreMen Pukes Tonight"`.

### #2214 PSH3 — `haresText="Thursday"` (`prisma/seed-data/sources.ts`)
The column mapping was **already correct** (PR #2202: `hares:4, title:5`). The stale `haresText="Thursday"` (the col-3 Day value from a pre-#2130 mapping) was stuck because the sheet (trust 5) was out-trusted by the WA Hash aggregator GCal (trust 7) and only hit the merge **enrich branch** (fill-NULL-only). Bumped the PSH3 Hareline Sheet to **trust 7** so its real hares win the full-update branch going forward.
- Live: #1228 emits `hares="Where's  & Corn on the Cock"` (col 4), `title="West Seattle"` (col 5).

## Backfills (applied to prod, idempotent — re-runs match 0)
- `scripts/backfill-psh3-hares-2214.ts` — 22 events: weekday → correct col-4 hares (13) or `null` where the sheet has no hare yet (9)
- `scripts/backfill-cch3-title-2216.ts` — 2 upcoming events: strip `~ <hares>` from title (scoped to upcoming; past CCH3 used `~` for themes too)
- `scripts/backfill-sekkong-blank-clear-2237.ts` — #2501: clear the leaked `GM + Committee` / `2,500th Run`
- `scripts/sync-source-config-2214-2216.ts` — targeted prod `Source.config` sync (PSH3 trust 7 + CCH3 `stripTitleHareSuffix`). Vercel runs `migrate deploy`, not `db seed`, and a full seed would clobber other concurrent source edits, so only these two rows are touched (config keys merged, not replaced). **Already applied to prod.**

## Verification
- Live-verified both adapters against live sources + siblings (Munich, Seattle, Berlin, Iron City) — **0 errors**.
- Prod canonical confirmed fixed (0 PSH3 weekday-leaks remain; CCH3 titles have no `~`; Sek Kong #2501 cleared).
- `npx tsc --noEmit` ✓ · `npm run lint` ✓ (0 errors) · `npm test` ✓ (9348 passed).

Closes #2237
Closes #2214
Closes #2216

🤖 Generated with [Claude Code](https://claude.com/claude-code)