### PR TITLE
chore(audit): clear recurring improbable-time + description-dropped backlog (9 issues)

### DIFF
--- a/scripts/suppress-soco-improbable-time.ts
+++ b/scripts/suppress-soco-improbable-time.ts
@@ -1,0 +1,63 @@
+/**
+ * One-shot: suppress the `event-improbable-time` audit finding for SoCo (soco-h3).
+ *
+ * Why: SoCo is fed solely by the Atlanta Hash Board scraper (board.atlantahash.com),
+ * which is dead — see #2054. The audit flags a future event with a `03:48` start
+ * (a stale parse artifact), but there is no live recurring source to re-scrape and
+ * correct it, so the finding can never self-resolve via a fresh scrape. This is the
+ * documented, reviewable form of the "Suppress" remediation path for the recurring
+ * escalation #2060 (base issues #1893/#1914/#1935/#1956). Mirrors the existing
+ * precedent row AuditSuppression(kwh3, event-improbable-time) from #461.
+ *
+ * Idempotent: upserts on the (kennelCode, rule) composite unique, so it is safe to
+ * re-run. Adding an AuditSuppression row is NOT a schema migration, but it must be
+ * run against prod to take effect (Vercel never runs scripts/). Suppressions are
+ * consumed by loadSuppressions()/isSuppressed() in src/pipeline/audit-runner.ts.
+ *
+ * Usage (worktree has no .env — supply DATABASE_URL from the main repo):
+ *   DATABASE_URL=... npx tsx scripts/suppress-soco-improbable-time.ts
+ *
+ * Remove this suppression if/when a live recurring SoCo source is onboarded (#2054).
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const KENNEL_CODE = "soco-h3";
+const RULE = "event-improbable-time";
+const REASON =
+  "SoCo's only source is the Atlanta Hash Board scraper (board.atlantahash.com), " +
+  "which is dead — see #2054. The flagged 03:48 start is a stale parse artifact on " +
+  "an un-rescrapeable event with no live source to correct it. Remove this " +
+  "suppression if a live recurring SoCo source is onboarded.";
+const CREATED_BY = "script:suppress-soco-improbable-time (#2060)";
+
+async function main(): Promise<void> {
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  const row = await prisma.auditSuppression.upsert({
+    where: { kennelCode_rule: { kennelCode: KENNEL_CODE, rule: RULE } },
+    update: { reason: REASON, createdBy: CREATED_BY },
+    create: { kennelCode: KENNEL_CODE, rule: RULE, reason: REASON, createdBy: CREATED_BY },
+    select: { id: true, kennelCode: true, rule: true, reason: true, createdBy: true, createdAt: true },
+  });
+
+  console.log("✅ AuditSuppression upserted:");
+  console.log(`   id:         ${row.id}`);
+  console.log(`   kennelCode: ${row.kennelCode}`);
+  console.log(`   rule:       ${row.rule}`);
+  console.log(`   createdBy:  ${row.createdBy}`);
+  console.log(`   createdAt:  ${row.createdAt.toISOString()}`);
+  console.log(`   reason:     ${row.reason}`);
+
+  await prisma.$disconnect();
+  pool.end();
+}
+
+void main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Clears the recurring audit-finding backlog. Each finding was diagnosed against **prod data + the live source** before acting (no blanket-suppression). The only code artifact is one idempotent suppression script — the rest were diagnosed as source-genuine or already self-healed.

## Resolutions

| Issue(s) | Kennel | Diagnosis | Action |
|---|---|---|---|
| #1893 #1914 #1935 #1956 #2060 | **SoCo** (`soco-h3`) | Only source (Atlanta Hash Board) is **dead** (#2054); flagged `03:48` is a stale, un-rescrapeable parse artifact | **Suppressed** + closed all 5 |
| #1384 | **C2H3** (`c2h3`) | Already fixed — canonical + raws now `16:30`; source carries `timezone: America/Chicago` | Closed (already-resolved) |
| #2061 | **HK H3** (`hkh3`) | **Self-healed** — flagged event aged out of the −7d window; prod scan shows **0** in-window dropped-description events anywhere; merge applies descriptions correctly | Closed (self-healed) |
| #2001 #2117 | **Capital H3** (`capital-h3-au`) | Live GCal genuinely lists `2026-07-19T03:00:00+10:00` (3 AM Sydney, embedded offset) — a one-off kennel data-entry error among otherwise-normal times; adapter extraction is correct | Documented, **left open** to age out (~2026-07-19); deliberately not suppressed to keep the audit sensitive to future timezone bugs |

## Why no pipeline/adapter code changes
`audit-checks.ts`, `audit-runner.ts`, `merge.ts`, `google-calendar/adapter.ts`, and `hkh3.ts` are all behaving correctly. The flagged times were either source-genuine (Capital H3, live-verified via Calendar API) or already self-resolved (C2H3, HK H3). A current full-window prod scan confirms the entire live `event-improbable-time` scope is two events (Capital H3 + SoCo) and the live `description-dropped` scope is zero.

## This PR adds
- `scripts/suppress-soco-improbable-time.ts` — committed, idempotent one-shot that upserts `AuditSuppression(soco-h3, event-improbable-time)`, mirroring the existing `kwh3` precedent (#461). **Already run against prod** (suppressions live in the DB; Vercel never runs `scripts/`). Re-running is a no-op.

## Notes
- Adding an `AuditSuppression` row is **not** a schema migration.
- `audit-filer.ts` has no closed-issue cooldown, so closing Capital H3 while its finding persists in-window would re-file new issues — hence those two are documented + left open rather than closed.
- Remove the SoCo suppression if/when a live recurring source is onboarded (#2054).

## Verification
- `npx tsc --noEmit` ✓ · `npm run lint` ✓ (0 errors; script clean) · `npm test` ✓ (318 files / 9343 tests)
- Prod `AuditSuppression`: `kwh3` (untouched) + new `soco-h3` row confirmed; script idempotent across two runs.
- Issue states: 7 closed with rationale, 2 (Capital H3) commented + intentionally open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)