### PR TITLE
fix(admin-audit): persist deep-dive completions reliably + fail loud (#2261)

### DIFF
--- a/src/app/admin/audit/actions.test.ts
+++ b/src/app/admin/audit/actions.test.ts
@@ -4,6 +4,7 @@ vi.mock("@/lib/auth", () => ({ getAdminUser: vi.fn() }));
 vi.mock("@/lib/db", () => ({
   prisma: {
     auditLog: {
+      findFirst: vi.fn(),
       findMany: vi.fn(),
       groupBy: vi.fn(),
       create: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock("@/lib/db", () => ({
     },
     kennel: {
       findMany: vi.fn(),
+      findUnique: vi.fn(),
       count: vi.fn(),
     },
     auditIssue: {
@@ -74,6 +76,8 @@ import {
   getCloseReasonRatiosByStream,
   getDeepDiveQueueToken,
   recordDeepDive,
+  recordDeepDiveManual,
+  lookupKennelForDeepDive,
   getAuditSyncFreshness,
   resyncAuditIssues,
 } from "./actions";
@@ -384,12 +388,16 @@ describe("getDeepDiveCoverage", () => {
 
 describe("recordDeepDive", () => {
   const mockLogCreate = vi.mocked(prisma.auditLog.create);
+  const mockLogFindFirst = vi.mocked(prisma.auditLog.findFirst);
   const mockKennelFind = vi.mocked(prisma.kennel.findMany);
   const mockLogGroupBy = vi.mocked(prisma.auditLog.groupBy);
 
   const ORIGINAL_SECRET = process.env.AUDIT_QUEUE_TOKEN_SECRET;
   beforeEach(() => {
     process.env.AUDIT_QUEUE_TOKEN_SECRET = "test-secret-for-queue-tokens";
+    // No prior dive by default — the idempotency guard finds nothing
+    // and the create path runs. Replay tests override this.
+    mockLogFindFirst.mockResolvedValue(null as never);
     // Default queue: a stable list with NYCH3 present so the
     // happy-path test can mint and verify a real token. Tests that
     // exercise removed/changed-snapshot paths override.
@@ -512,10 +520,16 @@ describe("recordDeepDive", () => {
     expect(mockLogCreate).not.toHaveBeenCalled();
   });
 
-  it("returns queueChanged when the snapshot diverges (409-shape)", async () => {
-    // Token was minted with snapshot of [nych3, agnews], but the
-    // queue now also has philly-h3 added. NYCH3 still present, so
-    // we want a refresh-and-retry rather than a hard error.
+  it("persists the dive when the rest of the queue churned but the kennel is still present (#2261 — no false queueChanged)", async () => {
+    // Token was minted with snapshot of [nych3, agnews]; by submit
+    // time the live queue also has philly-h3 (a daily cron ingest or
+    // a parallel admin shifted the top-20). NYCH3 is still in the
+    // queue and the token is cryptographically bound to it, so the
+    // credit is unambiguous — the dive MUST persist rather than
+    // silently no-op. The full-queue snapshot adds no misattribution
+    // safety beyond the kennelCode binding, so its divergence here is
+    // benign.
+    mockLogCreate.mockResolvedValue({ id: "log_churn" } as never);
     mockKennelFind.mockResolvedValue([
       {
         kennelCode: "nych3",
@@ -548,7 +562,35 @@ describe("recordDeepDive", () => {
       summary: "test",
       queueToken: freshToken("nych3"),
     });
-    expect(result).toEqual({ ok: false, error: "queueChanged" });
+    expect(result).toEqual({ ok: true, id: "log_churn" });
+    expect(mockLogCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "KENNEL_DEEP_DIVE",
+          kennelCode: "nych3",
+          findingsCount: 1,
+        }),
+      }),
+    );
+  });
+
+  it("rejects an expired token as invalidToken (no row written)", async () => {
+    // The page-render-minted token is good for QUEUE_TOKEN_TTL_MS; an
+    // idle dashboard whose token aged out before submit must fail
+    // closed, not silently no-op. Snapshot + kennel are otherwise
+    // valid, so `expired` is the only failing dimension.
+    const expiredToken = signQueueToken({
+      kennelCode: "nych3",
+      queueSnapshotId: computeQueueSnapshotId(["nych3", "agnews"]),
+      expiresAt: Date.now() - 1_000,
+    });
+    const result = await recordDeepDive({
+      kennelCode: "nych3",
+      findingsCount: 1,
+      summary: "test",
+      queueToken: expiredToken,
+    });
+    expect(result).toEqual({ ok: false, error: "invalidToken" });
     expect(mockLogCreate).not.toHaveBeenCalled();
   });
 
@@ -571,6 +613,159 @@ describe("recordDeepDive", () => {
         }),
       }),
     );
+  });
+
+  it("is idempotent: replaying the same valid token returns the existing row without writing a duplicate (#2261 Codex review)", async () => {
+    // A KENNEL_DEEP_DIVE row for nych3 already exists at/after this
+    // token's mint time — i.e. a prior submit with the same token
+    // already succeeded. A retry / double-submit / replayed payload
+    // must NOT create a second row (which would corrupt audit history
+    // and advance lastDeepDiveAt without a real second review).
+    mockLogFindFirst.mockResolvedValue({ id: "log_first" } as never);
+    const result = await recordDeepDive({
+      kennelCode: "nych3",
+      findingsCount: 1,
+      summary: "replayed submit",
+      queueToken: freshToken("nych3"),
+    });
+    expect(result).toEqual({ ok: true, id: "log_first" });
+    expect(mockLogCreate).not.toHaveBeenCalled();
+    // The dedupe is scoped to this kennel and bounded by the token's
+    // mint window (derived from expiresAt − TTL), not "any dive ever".
+    expect(mockLogFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          type: "KENNEL_DEEP_DIVE",
+          kennelCode: "nych3",
+          createdAt: expect.objectContaining({ gte: expect.any(Date) }),
+        }),
+      }),
+    );
+  });
+});
+
+describe("recordDeepDiveManual", () => {
+  const mockLogCreate = vi.mocked(prisma.auditLog.create);
+  const mockKennelFindUnique = vi.mocked(prisma.kennel.findUnique);
+
+  beforeEach(() => {
+    mockKennelFindUnique.mockResolvedValue({ shortName: "SFFMH3" } as never);
+    mockLogCreate.mockResolvedValue({ id: "log_manual" } as never);
+  });
+
+  it("requires admin", async () => {
+    mockAdmin.mockResolvedValue(null);
+    await expect(
+      recordDeepDiveManual({
+        kennelCode: "sffmh3",
+        findingsCount: 1,
+        summary: "manual backfill",
+      }),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects an empty kennelCode", async () => {
+    await expect(
+      recordDeepDiveManual({
+        kennelCode: "   ",
+        findingsCount: 1,
+        summary: "manual backfill",
+      }),
+    ).rejects.toThrow("kennelCode is required");
+  });
+
+  it("rejects a negative findings count", async () => {
+    await expect(
+      recordDeepDiveManual({
+        kennelCode: "sffmh3",
+        findingsCount: -1,
+        summary: "manual backfill",
+      }),
+    ).rejects.toThrow("findingsCount must be ≥ 0");
+  });
+
+  it("fails loud with kennelNotFound when the code doesn't resolve (no row written)", async () => {
+    mockKennelFindUnique.mockResolvedValue(null as never);
+    const result = await recordDeepDiveManual({
+      kennelCode: "does-not-exist",
+      findingsCount: 1,
+      summary: "manual backfill",
+    });
+    expect(result).toEqual({ ok: false, error: "kennelNotFound" });
+    expect(mockLogCreate).not.toHaveBeenCalled();
+  });
+
+  it("writes a KENNEL_DEEP_DIVE row (marked manual) for the explicit kennel — #2261 SFFMH3 backfill", async () => {
+    const result = await recordDeepDiveManual({
+      kennelCode: "sffmh3",
+      findingsCount: 1,
+      summary: "historical FMH3 events backfill (ref #2260)",
+    });
+    expect(result).toEqual({ ok: true, id: "log_manual", shortName: "SFFMH3" });
+    expect(mockKennelFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { kennelCode: "sffmh3" } }),
+    );
+    expect(mockLogCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "KENNEL_DEEP_DIVE",
+          kennelCode: "sffmh3",
+          findingsCount: 1,
+          issuesFiled: 1,
+          summary: { note: "historical FMH3 events backfill (ref #2260)", manual: true },
+        }),
+      }),
+    );
+  });
+
+  it("trims a padded kennelCode before lookup and write", async () => {
+    await recordDeepDiveManual({
+      kennelCode: "  sffmh3  ",
+      findingsCount: 0,
+      summary: "x",
+    });
+    expect(mockKennelFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { kennelCode: "sffmh3" } }),
+    );
+    expect(mockLogCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ kennelCode: "sffmh3" }),
+      }),
+    );
+  });
+});
+
+describe("lookupKennelForDeepDive", () => {
+  const mockKennelFindUnique = vi.mocked(prisma.kennel.findUnique);
+
+  it("requires admin", async () => {
+    mockAdmin.mockResolvedValue(null);
+    await expect(lookupKennelForDeepDive("sffmh3")).rejects.toThrow(
+      "Unauthorized",
+    );
+  });
+
+  it("returns the kennel identity for the echo confirmation", async () => {
+    mockKennelFindUnique.mockResolvedValue({
+      kennelCode: "sffmh3",
+      shortName: "SFFMH3",
+      region: "San Francisco, CA",
+    } as never);
+    const result = await lookupKennelForDeepDive("  sffmh3 ");
+    expect(result).toEqual({
+      kennelCode: "sffmh3",
+      shortName: "SFFMH3",
+      region: "San Francisco, CA",
+    });
+    expect(mockKennelFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { kennelCode: "sffmh3" } }),
+    );
+  });
+
+  it("returns null for an unknown / empty kennelCode", async () => {
+    expect(await lookupKennelForDeepDive("   ")).toBeNull();
+    mockKennelFindUnique.mockResolvedValue(null as never);
+    expect(await lookupKennelForDeepDive("nope")).toBeNull();
   });
 });
 

--- a/src/app/admin/audit/actions.ts
+++ b/src/app/admin/audit/actions.ts
@@ -19,6 +19,7 @@ import {
   computeQueueTokenExpiresAt,
   signQueueToken,
   verifyQueueToken,
+  QUEUE_TOKEN_TTL_MS,
 } from "@/lib/queue-snapshot-token";
 
 /** All audit dashboard actions are admin-only — server actions are POST endpoints anyone can hit. */
@@ -538,14 +539,24 @@ export type RecordDeepDiveResult =
       ok: false;
       error:
         | "invalidToken" // tampered, expired, or mismatched kennel
-        | "queueChanged" // kennel still in queue but snapshot diverged
         | "kennelGone"; // kennel no longer in queue
     };
 
 /** Record that a deep dive has been completed for a kennel. Requires
  *  a valid queue token from `getDeepDiveQueueToken` so a queue change
  *  between dialog-open and submit can't misattribute the credit
- *  (issue #1160). */
+ *  (issue #1160).
+ *
+ *  The anti-misattribution guarantee is the signed `kennelCode`
+ *  binding: the token cryptographically pins which kennel gets credit,
+ *  we verify `token.kennelCode === input.kennelCode`, and the row is
+ *  written with `input.kennelCode`. We do NOT additionally gate on a
+ *  full-queue snapshot match: a benign churn of the *other* top-20
+ *  kennels (a daily cron ingest, a parallel admin) between dialog-open
+ *  and submit can't change which kennel is credited, so rejecting it
+ *  only stranded legitimate completions as a silent no-op (#2261). The
+ *  snapshot id stays in the signed payload as tamper-proofing but no
+ *  longer blocks the write. */
 export async function recordDeepDive(input: {
   kennelCode: string;
   findingsCount: number;
@@ -568,16 +579,38 @@ export async function recordDeepDive(input: {
     return { ok: false, error: "invalidToken" };
   }
 
-  // Recompute snapshot from the live queue and decide. Use the
+  // The kennel must still be a current deep-dive target. Use the
   // lightweight kennelCode-only query to match what the token mint
-  // path captured.
+  // path captured. (Full-queue snapshot equality is intentionally NOT
+  // enforced here — see the doc comment above.)
   const liveCodes = await getDeepDiveQueueKennelCodes();
   if (!liveCodes.includes(input.kennelCode)) {
     return { ok: false, error: "kennelGone" };
   }
-  const liveSnapshot = computeQueueSnapshotId(liveCodes);
-  if (liveSnapshot !== verification.payload.queueSnapshotId) {
-    return { ok: false, error: "queueChanged" };
+
+  // Idempotent token consumption (Codex adversarial review, #2261).
+  // A signed token represents ONE dialog-open completion. Without the
+  // old snapshot gate, a still-valid token could otherwise be replayed
+  // (network retry, React double-fire, double-click) to write duplicate
+  // KENNEL_DEEP_DIVE rows — corrupting history and advancing
+  // lastDeepDiveAt without a real second review. If a row for this
+  // kennel already exists at or after this token was minted, the same
+  // completion already landed: return it instead of writing again.
+  // mintedAt is derived from expiresAt — both mint paths
+  // (getDeepDiveQueueToken, mintQueueTokens) use the default TTL, so
+  // `expiresAt - QUEUE_TOKEN_TTL_MS` is exactly the mint time.
+  const mintedAt = new Date(verification.payload.expiresAt - QUEUE_TOKEN_TTL_MS);
+  const existing = await prisma.auditLog.findFirst({
+    where: {
+      type: "KENNEL_DEEP_DIVE",
+      kennelCode: input.kennelCode,
+      createdAt: { gte: mintedAt },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+  });
+  if (existing) {
+    return { ok: true, id: existing.id };
   }
 
   const log = await prisma.auditLog.create({
@@ -594,6 +627,75 @@ export async function recordDeepDive(input: {
     select: { id: true },
   });
   return { ok: true, id: log.id };
+}
+
+/** Resolve a kennelCode to its display identity so the manual
+ *  deep-dive dialog can echo the kennel ("SFFMH3 — San Francisco, CA")
+ *  for last-chance confirmation before a write. Returns null when no
+ *  kennel matches. Admin-only. */
+export async function lookupKennelForDeepDive(
+  kennelCode: string,
+): Promise<{ kennelCode: string; shortName: string; region: string } | null> {
+  await requireAdmin();
+  const trimmed = kennelCode.trim();
+  if (!trimmed) return null;
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: trimmed },
+    select: { kennelCode: true, shortName: true, region: true },
+  });
+  return kennel ?? null;
+}
+
+/** Result shape for `recordDeepDiveManual`. */
+export type RecordDeepDiveManualResult =
+  | { ok: true; id: string; shortName: string }
+  | { ok: false; error: "kennelNotFound" };
+
+/** Admin-only manual backfill for a deep-dive completion the normal
+ *  token-bound flow missed — e.g. #2261, where a benign queue churn
+ *  stranded the SFFMH3 completion as a silent no-op.
+ *
+ *  Unlike `recordDeepDive`, this takes an EXPLICIT kennelCode and no
+ *  queue token. The #1160 anti-misattribution property is preserved a
+ *  different way: the caller supplies (and the dialog echoes back) the
+ *  exact kennelCode, so there is no position-based dropdown index that
+ *  can go stale between selection and submit. Fails loud with
+ *  `kennelNotFound` rather than writing a dangling row. */
+export async function recordDeepDiveManual(input: {
+  kennelCode: string;
+  findingsCount: number;
+  summary: string;
+}): Promise<RecordDeepDiveManualResult> {
+  await requireAdmin();
+  const kennelCode = input.kennelCode.trim();
+  if (!kennelCode) throw new Error("kennelCode is required");
+  if (input.findingsCount < 0) throw new Error("findingsCount must be ≥ 0");
+
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode },
+    select: { shortName: true },
+  });
+  if (!kennel) {
+    return { ok: false, error: "kennelNotFound" };
+  }
+
+  const log = await prisma.auditLog.create({
+    data: {
+      type: "KENNEL_DEEP_DIVE",
+      kennelCode,
+      eventsScanned: 0,
+      findingsCount: input.findingsCount,
+      groupsCount: 0,
+      issuesFiled: input.findingsCount,
+      findings: [],
+      // `manual: true` marks the provenance so a backfilled completion
+      // is distinguishable from a normal token-bound one in the row's
+      // JSON summary (useful when auditing #2261 cleanup later).
+      summary: { note: input.summary, manual: true },
+    },
+    select: { id: true },
+  });
+  return { ok: true, id: log.id, shortName: kennel.shortName };
 }
 
 // ── Stream Trends (audit-issue mirror) ──────────────────────────────

--- a/src/components/admin/AuditDashboard.tsx
+++ b/src/components/admin/AuditDashboard.tsx
@@ -32,6 +32,8 @@ import {
   getSuppressionImpact,
   getDeepDiveQueueToken,
   recordDeepDive,
+  recordDeepDiveManual,
+  lookupKennelForDeepDive,
   type TrendPoint,
   type TopOffender,
   type RecentRun,
@@ -888,6 +890,7 @@ function DeepDiveCard({
 }) {
   const [selectedCode, setSelectedCode] = useState(queue[0]?.kennelCode ?? "");
   const [completeOpen, setCompleteOpen] = useState(false);
+  const [manualOpen, setManualOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
@@ -975,12 +978,24 @@ function DeepDiveCard({
             <span className="font-mono tabular-nums">{coverage.total}</span> active kennels (
             {coverage.percent}%)
           </div>
-          {coverage.projectedFullCycleDate && (
-            <div>
-              Full cycle by{" "}
-              <span className="font-mono tabular-nums">{coverage.projectedFullCycleDate}</span>
-            </div>
-          )}
+          <div className="flex items-center gap-3">
+            {coverage.projectedFullCycleDate && (
+              <span>
+                Full cycle by{" "}
+                <span className="font-mono tabular-nums">{coverage.projectedFullCycleDate}</span>
+              </span>
+            )}
+            {/* Escape hatch for a deep dive the normal token-bound flow
+                missed (e.g. #2261). Records an explicit, echoed kennel —
+                no position-based dropdown to go stale (#1160). */}
+            <button
+              type="button"
+              className="underline underline-offset-2 hover:text-foreground"
+              onClick={() => setManualOpen(true)}
+            >
+              Manually record a deep dive
+            </button>
+          </div>
         </div>
       </div>
 
@@ -1065,7 +1080,216 @@ function DeepDiveCard({
           onCompleted();
         }}
       />
+
+      <ManualDeepDiveDialog
+        open={manualOpen}
+        onOpenChange={setManualOpen}
+        defaultKennelCode={currentKennel.kennelCode}
+        onCompleted={() => {
+          setManualOpen(false);
+          onCompleted();
+        }}
+      />
     </>
+  );
+}
+
+/**
+ * Manual deep-dive backfill dialog. For a completion the normal
+ * token-bound flow missed (e.g. #2261, where benign queue churn
+ * stranded the SFFMH3 completion). The operator types/confirms an
+ * explicit kennelCode, looks it up, and the dialog ECHOES the resolved
+ * kennel ("SFFMH3 — San Francisco, CA") before any write — preserving
+ * the #1160 anti-misattribution property without a queue token, since
+ * there's no position-based dropdown index that can go stale. The
+ * "Record" button stays disabled until the echoed kennel matches the
+ * current input, so what's confirmed is exactly what's written.
+ */
+function ManualDeepDiveDialog({
+  open,
+  onOpenChange,
+  defaultKennelCode,
+  onCompleted,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  defaultKennelCode: string;
+  onCompleted: () => void;
+}) {
+  const [kennelCode, setKennelCode] = useState(defaultKennelCode);
+  const [resolved, setResolved] = useState<{
+    kennelCode: string;
+    shortName: string;
+    region: string;
+  } | null>(null);
+  const [findingsCount, setFindingsCount] = useState(0);
+  const [summary, setSummary] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [looking, setLooking] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  // Reset to a clean slate each time the dialog opens, seeded with the
+  // currently-selected queue kennel for convenience.
+  useEffect(() => {
+    if (!open) return;
+    setKennelCode(defaultKennelCode);
+    setResolved(null);
+    setFindingsCount(0);
+    setSummary("");
+    setError(null);
+    setLooking(false);
+  }, [open, defaultKennelCode]);
+
+  const trimmedCode = kennelCode.trim();
+  // The echo is only valid while the input still matches what we
+  // resolved — editing the code after a lookup invalidates the echo so
+  // the operator can't confirm one kennel and submit another.
+  const echoValid = resolved !== null && resolved.kennelCode === trimmedCode;
+
+  async function handleLookup() {
+    setError(null);
+    setResolved(null);
+    if (!trimmedCode) {
+      setError("Enter a kennelCode to look up.");
+      return;
+    }
+    setLooking(true);
+    try {
+      const result = await lookupKennelForDeepDive(trimmedCode);
+      if (!result) {
+        setError(`No kennel found for code “${trimmedCode}”.`);
+        return;
+      }
+      setResolved(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Lookup failed.");
+    } finally {
+      setLooking(false);
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!echoValid || !resolved) {
+      setError("Look up and confirm the kennel before recording.");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        const result = await recordDeepDiveManual({
+          kennelCode: resolved.kennelCode,
+          findingsCount,
+          summary: summary.trim() || "(manual backfill — no notes)",
+        });
+        if (result.ok) {
+          onCompleted();
+          return;
+        }
+        // kennelNotFound (raced deletion) or any future error value —
+        // surface it; never swallow.
+        setError(
+          result.error === "kennelNotFound"
+            ? `${resolved.shortName} no longer exists. Nothing was saved.`
+            : `Could not record the deep dive (${String(result.error)}). Nothing was saved.`,
+        );
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to record deep dive",
+        );
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Manually record a deep dive</DialogTitle>
+          <DialogDescription>
+            Backfill a completion the normal flow missed. Look up the
+            kennel by its code, confirm the echoed name, then record.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="manual-dd-code">Kennel code</Label>
+            <div className="flex gap-2">
+              <Input
+                id="manual-dd-code"
+                value={kennelCode}
+                onChange={(e) => {
+                  setKennelCode(e.target.value);
+                  setResolved(null);
+                }}
+                placeholder="e.g. sffmh3"
+                data-kennel-code={trimmedCode}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleLookup}
+                disabled={looking || !trimmedCode}
+              >
+                {looking ? "Looking…" : "Look up"}
+              </Button>
+            </div>
+          </div>
+          {echoValid && resolved && (
+            <div className="rounded-md border border-border/50 bg-accent/30 px-3 py-2 text-sm">
+              Will record:{" "}
+              <strong data-kennel-code={resolved.kennelCode}>
+                {resolved.shortName}
+              </strong>{" "}
+              <span className="text-xs text-muted-foreground">
+                ({resolved.region})
+              </span>
+            </div>
+          )}
+          <div className="space-y-1.5">
+            <Label htmlFor="manual-dd-findings">Findings filed</Label>
+            <Input
+              id="manual-dd-findings"
+              type="number"
+              min={0}
+              value={findingsCount}
+              onChange={(e) =>
+                setFindingsCount(Math.max(0, Number(e.target.value)))
+              }
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="manual-dd-summary">One-line summary</Label>
+            <Textarea
+              id="manual-dd-summary"
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+              rows={2}
+              placeholder='e.g. "historical FMH3 events backfill (ref #2260)"'
+            />
+          </div>
+          {error && <div className="text-xs text-destructive">{error}</div>}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={pending || !echoValid}>
+              {pending
+                ? "Saving…"
+                : echoValid && resolved
+                  ? `Record ${resolved.shortName}`
+                  : "Record deep dive"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -1213,39 +1437,36 @@ function DeepDiveCompleteDialog({
           onCompleted();
           return;
         }
-        if (result.error === "queueChanged") {
-          // Refresh the token + show a one-shot warning. If the
-          // operator submits again with the fresh token and the
-          // queue still matches, it'll succeed. On refetch
-          // failure, refetchToken has already set its own error
-          // (kennelGone) — don't overwrite it (Gemini PR #1203).
+        // Every failure mode must surface a clear, persistent message —
+        // a silent {ok:false} is exactly the #2261 no-op. The server no
+        // longer rejects benign full-queue churn (it relies on the
+        // signed kennelCode binding for anti-misattribution), so the
+        // remaining failures are genuine and actionable.
+        if (result.error === "kennelGone") {
+          setError(
+            `${dialogKennel.shortName} is no longer an active deep-dive target. Cancel and refresh; if it still needs recording, use “Manually record a deep dive”.`,
+          );
+          return;
+        }
+        if (result.error === "invalidToken") {
+          // Session expired or tampered. Refetch in-place — the
+          // page-render-minted token expires after QUEUE_TOKEN_TTL_MS,
+          // and an idle dashboard would otherwise need a full refresh.
+          // On success prompt one explicit re-submit with the fresh
+          // token; on failure, refetchToken already set its own error.
           const fresh = await refetchToken();
           if (fresh) {
             setError(
-              "The deep-dive queue was edited by someone else. Confirm by submitting again.",
+              "Submission token expired — refreshed automatically. Submit again to confirm.",
             );
           }
           return;
         }
-        if (result.error === "kennelGone") {
-          setError(
-            `${dialogKennel.shortName} was removed from the queue. Cancel and refresh the page.`,
-          );
-          return;
-        }
-        // invalidToken: session expired or tampered. Try refetching
-        // in-place — the page-render-minted prefetched token expires
-        // after QUEUE_TOKEN_TTL_MS, and an idle dashboard would
-        // otherwise need a full refresh to recover. If the refetch
-        // succeeds, prompt the operator to submit again with the
-        // fresh token. If it fails, refetchToken already set its
-        // own error.
-        const fresh = await refetchToken();
-        if (fresh) {
-          setError(
-            "Submission token expired — refreshed automatically. Submit again to confirm.",
-          );
-        }
+        // Catch-all: an error value this dialog doesn't recognize (a new
+        // server branch, etc.). Never swallow it.
+        setError(
+          `Could not record the deep dive (${String(result.error)}). Nothing was saved — try again or use “Manually record a deep dive”.`,
+        );
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to record deep dive");
       }


### PR DESCRIPTION
Fixes #2261.

## Problem
On `/admin/audit` → Kennel Deep Dive, marking **SFFMH3** complete silently no-op'd: after reload the kennel was still queued, coverage unchanged (307/383), **no `AuditLog` row written**, and the operator got no actionable signal. This is the silent-non-registration class tracked in #1160.

## Root cause
The deep-dive queue *and* its integrity snapshot are both capped at the top **20** kennels (`DEEP_DIVE_QUEUE_DEFAULT_LIMIT = 20`). On submit, `recordDeepDive` re-hashed the **entire** live top-20 and rejected with `queueChanged` if *any* kennel in that set had shifted — even though credit is already cryptographically pinned to the frozen `kennelCode`. On a live dashboard (daily 06:00 UTC cron ingest, parallel admin sessions, a 10-min token TTL spanning the operator's #2260 research) the top-20 churns routinely, so the single submit returned `{ok:false, error:"queueChanged"}` and the dialog printed *"…submit again to confirm"* — which the #1160 runbook forbids, stranding the dive as a permanent no-op. The snapshot-equality gate added **no** misattribution safety beyond the `kennelCode` binding.

**Not misattributed (Goal #1):** confirmed by read-only prod query — zero `KENNEL_DEEP_DIVE` rows for `sffmh3` and no stray credit elsewhere at the incident time. A row can only ever land for the verified, token-bound kennelCode.

## Fix
**Server (`src/app/admin/audit/actions.ts`)**
- Drop the `queueChanged` snapshot-equality rejection. Kept intact: token signature/expiry validation, the `kennelCode` binding (the real #1160 guard), and the `kennelGone` eligibility check. A legitimately-bound single submit now persists through benign queue churn.
- **Idempotent token consumption** (from the Codex adversarial review): a `KENNEL_DEEP_DIVE` row written at/after the token's mint time short-circuits to that row, so a retry / double-submit / replayed payload can't write duplicate rows or falsely advance `lastDeepDiveAt`. Closes #1160 ask #5. (Mint time derived as `expiresAt − QUEUE_TOKEN_TTL_MS`; no token-format change.)
- Add admin-only `recordDeepDiveManual` + `lookupKennelForDeepDive` for backfilling a missed completion (explicit, echoed kennelCode, no token) — deliberately in app code, not `scripts/**`.

**Client (`src/components/admin/AuditDashboard.tsx`)**
- `handleSubmit` now surfaces **every** failure loudly (exhaustive switch + catch-all); no silent `{ok:false}`.
- New *"Manually record a deep dive"* dialog that echoes the resolved kennel (`SFFMH3 — San Francisco, CA`) and keeps **Record** disabled until the echo matches the typed code — preserving the anti-misattribution property without a queue token.

## Recording the missed SFFMH3 dive
Open `/admin/audit` → "Manually record a deep dive", enter `sffmh3`, look up (confirms *SFFMH3 — San Francisco, CA*), set findings = 1, summary referencing #2260, Record. (The prod write is left to the operator as an outward-facing action.)

## Tests
- Failing→passing reproduction: queue-change-between-open-and-submit now persists (previously proved the no-op).
- Added coverage: expired token, `kennelGone`, **idempotent replay**, and the manual action (admin guard, negative findings, `kennelNotFound`, happy path, echo lookup).
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (**9448 passed**).

## Scope
Touches only `src/app/admin/audit/actions.ts`, its test, and `src/components/admin/AuditDashboard.tsx`. No `scripts/**`, `prisma/**` (incl. `schema.prisma`), or profile/hareline/logbook changes — no schema change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)