### PR TITLE
feat(adapters): emit existing-schema fields the sources already expose (#2222 #2229 #1511 #1365 #1354 #1046 #766)

### DIFF
--- a/scripts/backfill-bfm-766.ts
+++ b/scripts/backfill-bfm-766.ts
@@ -1,0 +1,65 @@
+/**
+ * One-shot canonical backfill for #766 — BFM "Bring:" list + chalk-talk timing.
+ *
+ * The adapter now folds the "Bring:" checklist and the gather/chalk-talk "When:"
+ * line into the description. Because `description` is NOT part of the RawEvent
+ * fingerprint, a plain re-scrape emits a same-fingerprint raw that the merge
+ * dedupes/skips — so the current-trail canonical event never gains the new lines.
+ *
+ * BFM's site only exposes the CURRENT trail's rich block (past trails roll off),
+ * so this script patches the live current-trail event: it re-runs the adapter,
+ * and if the fresh description carries a "Bring:" or chalk-talk line the stored
+ * description lacks, writes the fuller (superset) description onto the matching
+ * canonical event by run number.
+ *
+ * Safe & idempotent: only updates when the fresh description adds the new content
+ * AND differs from the stored value (optimistic updateMany guard); re-run → 0.
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-bfm-766.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-bfm-766.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+import { BFMAdapter } from "@/adapters/html-scraper/bfm";
+import type { Source } from "@/generated/prisma/client";
+
+/** True when a description carries the #766 additions (Bring list / chalk-talk). */
+function hasNewContent(s: string | null | undefined): boolean {
+  return !!s && (/^Bring:/im.test(s) || /chalk\s*talk/i.test(s));
+}
+
+void runOneShot(async ({ prisma, apply }) => {
+  const src = { id: "backfill", url: "https://benfranklinmob.com", config: {} } as unknown as Source;
+  const result = await new BFMAdapter().fetch(src, { days: 60 });
+  // Current-trail events carry a runNumber + a description; upcoming-hares don't.
+  const fresh = result.events.filter((e) => e.runNumber != null && hasNewContent(e.description));
+  console.log(`Live BFM: ${result.events.length} events, ${fresh.length} current-trail event(s) with #766 content`);
+
+  let updated = 0;
+  for (const e of fresh) {
+    const canon = await prisma.event.findFirst({
+      where: { runNumber: e.runNumber, eventKennels: { some: { kennel: { kennelCode: "bfm" } } } },
+      select: { id: true, title: true, description: true },
+    });
+    if (!canon) {
+      console.log(`   (no canonical bfm event for run #${e.runNumber} yet — skipping)`);
+      continue;
+    }
+    if (hasNewContent(canon.description)) {
+      console.log(`   run #${e.runNumber} already has #766 content — skipping`);
+      continue;
+    }
+    if (canon.description === e.description) continue;
+    console.log(`   - run #${e.runNumber} ${canon.title}: add Bring/chalk-talk lines`);
+    if (apply) {
+      const r = await prisma.event.updateMany({
+        where: { id: canon.id, description: canon.description },
+        data: { description: e.description },
+      });
+      updated += r.count;
+    }
+  }
+
+  if (apply) console.log(`   ✏️  updated ${updated}`);
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/scripts/backfill-eh3-scribe-1046.ts
+++ b/scripts/backfill-eh3-scribe-1046.ts
@@ -1,0 +1,69 @@
+/**
+ * One-shot canonical backfill for #1046 — EH3 (Edmonton family) Scribe fold.
+ *
+ * The adapter now folds a "Scribe: <name>" credit into the description. Because
+ * `description` is NOT part of the RawEvent fingerprint, a plain re-scrape emits
+ * a same-fingerprint raw that the merge dedupes/skips — so existing canonical
+ * events never gain the scribe line ("re-scrape won't fix existing canonical").
+ *
+ * This script re-runs the EH3 adapter live, and for any event whose fresh
+ * description now carries a "Scribe:" line, writes that fuller description onto
+ * the matching canonical event (by kennel + date) when the stored description
+ * lacks a scribe. The fresh description is a superset (On On + Scribe + notes),
+ * so this only ever adds information.
+ *
+ * Safe & idempotent: only updates events whose stored description lacks
+ * "Scribe:" (optimistic updateMany guard on the old value); a re-run updates 0.
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-eh3-scribe-1046.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-eh3-scribe-1046.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+import { Eh3EdmontonAdapter } from "@/adapters/html-scraper/eh3-edmonton";
+import type { Source } from "@/generated/prisma/client";
+
+const EH3_KENNELS = ["eh3-ab", "osh3-ab", "efmh3", "bash-eh3", "snash-eh3", "divah3-eh3", "rash-eh3"];
+const SAMPLE = 12;
+
+void runOneShot(async ({ prisma, apply }) => {
+  // 1) Fresh descriptions from the live source.
+  const src = { id: "backfill", url: "https://www.eh3.org", scrapeDays: 365, config: {} } as unknown as Source;
+  const result = await new Eh3EdmontonAdapter().fetch(src, { days: 365 });
+  const liveByKey = new Map<string, string>();
+  for (const e of result.events) {
+    if (!e.description || !/Scribe:/i.test(e.description)) continue;
+    for (const tag of e.kennelTags) liveByKey.set(`${tag}|${e.date}`, e.description);
+  }
+  console.log(`Live source: ${result.events.length} events, ${liveByKey.size} carry a Scribe line`);
+
+  // 2) Match against canonical events lacking a scribe in their description.
+  let updated = 0;
+  const samples: string[] = [];
+  for (const code of EH3_KENNELS) {
+    const events = await prisma.event.findMany({
+      where: { eventKennels: { some: { kennel: { kennelCode: code } } } },
+      select: { id: true, date: true, title: true, description: true },
+    });
+    for (const e of events) {
+      const key = `${code}|${e.date.toISOString().slice(0, 10)}`;
+      const live = liveByKey.get(key);
+      if (!live) continue; // no fresh scribe-bearing description for this date
+      if (e.description && /Scribe:/i.test(e.description)) continue; // already has one
+      if (e.description === live) continue; // already correct
+      if (samples.length < SAMPLE) samples.push(`   - ${code} ${key.split("|")[1]}  ${e.title}`);
+      if (apply) {
+        const r = await prisma.event.updateMany({
+          where: { id: e.id, description: e.description },
+          data: { description: live },
+        });
+        updated += r.count;
+      }
+    }
+  }
+
+  console.log(`#1046 EH3 Scribe fold: ${samples.length}${apply ? "" : "+"} event(s) to patch`);
+  samples.forEach((s) => console.log(s));
+  if (apply) console.log(`   ✏️  updated ${updated}`);
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/scripts/backfill-indyh3-detail-1354.ts
+++ b/scripts/backfill-indyh3-detail-1354.ts
@@ -1,0 +1,100 @@
+/**
+ * One-shot canonical backfill for #1354 — IndyScent detail fold + trail length.
+ *
+ * The adapter now folds the rich `/hashes/<slug>/` detail body into `description`
+ * and lifts a clean mileage token into the trail-length bundle. A plain re-scrape
+ * only repairs events in the forward window (which are mostly skeleton placeholders
+ * with no body). Past fleshed-out events created before the fix have `description`
+ * NULL, but their detail pages are still live — so this script re-fetches each
+ * IndyScent/THICC canonical event's detail page through the SAME parseIndyDetail
+ * and fills description / trail length where the page provides them.
+ *
+ * Safe & idempotent: fill-only (optimistic updateMany guard on null); a re-run
+ * only re-touches events whose detail page still yields nothing (skeletons).
+ * description / trailLength are NOT in the RawEvent fingerprint, so this never
+ * disturbs dedup, and the merge preserves the values going forward.
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-indyh3-detail-1354.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-indyh3-detail-1354.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { parseIndyDetail } from "@/adapters/html-scraper/indyh3";
+
+const KENNELS = ["indyh3", "thicch3"];
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const SAMPLE = 12;
+
+void runOneShot(async ({ prisma, apply }) => {
+  const events = await prisma.event.findMany({
+    where: {
+      sourceUrl: { contains: "/hashes/" },
+      OR: [{ description: null }, { trailLengthText: null }],
+      eventKennels: { some: { kennel: { kennelCode: { in: KENNELS } } } },
+    },
+    select: { id: true, title: true, sourceUrl: true, description: true, trailLengthText: true },
+    orderBy: { date: "asc" },
+  });
+  console.log(`#1354 IndyScent detail backfill: ${events.length} candidate event(s) with a /hashes/ URL`);
+
+  let descUpdated = 0;
+  let trailUpdated = 0;
+  let fetched = 0;
+  let fetchErrors = 0;
+  const samples: string[] = [];
+
+  for (const e of events) {
+    const url = e.sourceUrl as string;
+    let html: string;
+    try {
+      const res = await safeFetch(url, { headers: { "User-Agent": UA, Accept: "text/html" } });
+      if (!res.ok) {
+        fetchErrors++;
+        continue;
+      }
+      html = await res.text();
+      fetched++;
+    } catch {
+      fetchErrors++;
+      continue;
+    }
+
+    const detail = parseIndyDetail(html);
+    const willDesc = e.description == null && !!detail.description;
+    const willTrail = e.trailLengthText == null && !!detail.trailLengthText;
+    if (!willDesc && !willTrail) continue;
+    if (samples.length < SAMPLE) {
+      samples.push(
+        `   - ${e.title}: ${willDesc ? `desc(${detail.description!.length}c) ` : ""}${willTrail ? `trail="${detail.trailLengthText}"` : ""}`,
+      );
+    }
+
+    if (apply) {
+      if (willDesc) {
+        const r = await prisma.event.updateMany({
+          where: { id: e.id, description: null },
+          data: { description: detail.description },
+        });
+        descUpdated += r.count;
+      }
+      if (willTrail) {
+        const r = await prisma.event.updateMany({
+          where: { id: e.id, trailLengthText: null },
+          data: {
+            trailLengthText: detail.trailLengthText,
+            trailLengthMinMiles: detail.trailLengthMinMiles ?? null,
+            trailLengthMaxMiles: detail.trailLengthMaxMiles ?? null,
+          },
+        });
+        trailUpdated += r.count;
+      }
+    }
+  }
+
+  console.log(`fetched ${fetched}, fetch errors ${fetchErrors}`);
+  samples.forEach((s) => console.log(s));
+  if (apply) console.log(`   ✏️  description updated ${descUpdated}, trail length updated ${trailUpdated}`);
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/scripts/backfill-meetup-cost-trailtype-2229.ts
+++ b/scripts/backfill-meetup-cost-trailtype-2229.ts
@@ -1,0 +1,82 @@
+/**
+ * One-shot canonical backfill for #2229 — Meetup cost + trailType.
+ *
+ * The adapter now lifts "Hash Cash:"/"Cost:" → cost and "Trail:"/"Trail type:"
+ * → trailType for every MEETUP source. A plain re-scrape only repairs events
+ * still in the source's forward window; historical Meetup events carry the
+ * structured labels in their already-stored (cleaned) `description` but have
+ * `cost`/`trailType` NULL. This script re-runs the SAME exported extractors over
+ * those stored descriptions and fills the typed fields.
+ *
+ * Scope: canonical events fed by a MEETUP-type source (rawEvents.some.source.type)
+ * with a non-null description and at least one of cost/trailType still null.
+ *
+ * Safe & idempotent: each field is filled only when currently null (optimistic
+ * updateMany guard); a re-run updates 0. cost/trailType are NOT in the RawEvent
+ * fingerprint, so this never disturbs dedup, and the merge preserves the values.
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-meetup-cost-trailtype-2229.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-meetup-cost-trailtype-2229.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+import { extractMeetupCost, extractMeetupTrailType } from "@/adapters/meetup/adapter";
+
+const SAMPLE = 12;
+
+void runOneShot(async ({ prisma, apply }) => {
+  const candidates = await prisma.event.findMany({
+    where: {
+      description: { not: null },
+      OR: [{ cost: null }, { trailType: null }],
+      rawEvents: { some: { source: { type: "MEETUP" } } },
+    },
+    select: { id: true, title: true, description: true, cost: true, trailType: true },
+    orderBy: { date: "asc" },
+  });
+
+  const plan = candidates
+    .map((e) => ({
+      id: e.id,
+      title: e.title,
+      newCost: e.cost == null ? extractMeetupCost(e.description ?? undefined) : undefined,
+      newTrailType:
+        e.trailType == null ? extractMeetupTrailType(e.description ?? undefined) : undefined,
+    }))
+    .filter((p) => p.newCost || p.newTrailType);
+
+  const costCount = plan.filter((p) => p.newCost).length;
+  const trailCount = plan.filter((p) => p.newTrailType).length;
+  console.log(
+    `\n#2229 Meetup cost+trailType: ${plan.length} event(s) to patch (${costCount} cost, ${trailCount} trailType) of ${candidates.length} MEETUP candidates`,
+  );
+  plan
+    .slice(0, SAMPLE)
+    .forEach((p) =>
+      console.log(`   - ${p.title}: cost=${JSON.stringify(p.newCost)} trailType=${JSON.stringify(p.newTrailType)}`),
+    );
+
+  if (apply) {
+    let costUpdated = 0;
+    let trailUpdated = 0;
+    for (const p of plan) {
+      if (p.newCost) {
+        const res = await prisma.event.updateMany({
+          where: { id: p.id, cost: null },
+          data: { cost: p.newCost },
+        });
+        costUpdated += res.count;
+      }
+      if (p.newTrailType) {
+        const res = await prisma.event.updateMany({
+          where: { id: p.id, trailType: null },
+          data: { trailType: p.newTrailType },
+        });
+        trailUpdated += res.count;
+      }
+    }
+    console.log(`   ✏️  cost updated ${costUpdated}, trailType updated ${trailUpdated}`);
+  }
+
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/scripts/backfill-samurai-cost-2222.ts
+++ b/scripts/backfill-samurai-cost-2222.ts
@@ -1,0 +1,66 @@
+/**
+ * One-shot canonical backfill for #2222 — Samurai H3 Fee → cost.
+ *
+ * Why this is needed: the adapter now emits the "Fee" column as the typed
+ * `cost` field, but a plain re-scrape only fixes events still in the source's
+ * forward window. Historical Samurai events created before the fix have the fee
+ * embedded only in their `description` ("…\nFee: 500jpy (BYO)\n…") with
+ * `cost = NULL`. This script lifts the Fee line into `cost` for those rows.
+ *
+ * Safe & idempotent: scoped to the samurai-h3 kennel, only touches rows where
+ * `cost IS NULL`, uses an optimistic guard (updateMany WHERE cost: null), and a
+ * re-run matches 0 rows. `cost` is NOT part of the RawEvent fingerprint, so this
+ * never disturbs dedup, and the merge pipeline preserves the value going forward.
+ *
+ * Run (Railway proxy uses a self-signed cert):
+ *   Dry-run: BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-samurai-cost-2222.ts
+ *   Apply:   BACKFILL_ALLOW_SELF_SIGNED_CERT=1 npx tsx scripts/backfill-samurai-cost-2222.ts --apply
+ */
+import { runOneShot } from "./lib/one-shot";
+
+const SAMPLE = 10;
+
+/** Pull the value from a "Fee: …" line in the folded description, if present. */
+function extractFee(description: string | null): string | undefined {
+  if (!description) return undefined;
+  for (const line of description.split("\n")) {
+    const m = /^Fee:\s*(.+)$/.exec(line.trim());
+    if (m && m[1].trim()) return m[1].trim();
+  }
+  return undefined;
+}
+
+void runOneShot(async ({ prisma, apply }) => {
+  const candidates = await prisma.event.findMany({
+    where: {
+      cost: null,
+      description: { contains: "Fee:" },
+      eventKennels: { some: { kennel: { kennelCode: "samurai-h3" } } },
+    },
+    select: { id: true, title: true, description: true },
+    orderBy: { date: "asc" },
+  });
+
+  const plan = candidates
+    .map((e) => ({ id: e.id, title: e.title, fee: extractFee(e.description) }))
+    .filter((p): p is { id: string; title: string | null; fee: string } => !!p.fee);
+
+  console.log(
+    `\n#2222 Samurai H3 Fee → cost: ${plan.length} event(s) (of ${candidates.length} with a "Fee:" line and null cost)`,
+  );
+  plan.slice(0, SAMPLE).forEach((p) => console.log(`   - ${p.title}: cost="${p.fee}"`));
+
+  if (apply) {
+    let n = 0;
+    for (const p of plan) {
+      const res = await prisma.event.updateMany({
+        where: { id: p.id, cost: null },
+        data: { cost: p.fee },
+      });
+      n += res.count;
+    }
+    console.log(`   ✏️  updated ${n}`);
+  }
+
+  console.log(`\n${apply ? "Applied." : "Dry run complete — re-run with --apply to write."}`);
+});

--- a/src/adapters/html-scraper/bfm.test.ts
+++ b/src/adapters/html-scraper/bfm.test.ts
@@ -161,6 +161,58 @@ describe("BFMAdapter.fetch", () => {
     expect(current!.description).not.toMatch(/Upcoming/i);
   });
 
+  it("#766: folds Bring list + chalk-talk timing into the description", async () => {
+    const html = `
+      <html><body>
+      <h2>Trail #1166: The Fruit Hash</h2>
+      <p>When: Thursday, 6/25 at 7:00 PM gather, 7:30 PM chalk talk</p>
+      <p>Where: Paine's Park</p>
+      <p>Bring: Cranium lamp, $10 hash cash</p>
+      <p>Hare: Bananass</p>
+      <p>The Fun Part: Join Bananass for his eponymous yearly fruit hash. Trail will be A-A.</p>
+      <h3>Upcoming Hares</h3>
+      <p>July 2 – CUNTsultant</p>
+      </body></html>
+    `;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(html, { status: 200 }))
+      .mockResolvedValueOnce(new Response("<html><body></body></html>", { status: 200 }));
+
+    const adapter = new BFMAdapter();
+    const result = await adapter.fetch({ id: "test", url: "https://benfranklinmob.com" } as never);
+    const current = result.events.find((e) => e.runNumber === 1166);
+    expect(current).toBeDefined();
+    // Start time still parsed from the gather time.
+    expect(current!.startTime).toBe("19:00");
+    // Bring list + chalk-talk split folded in, Fun Part preserved.
+    expect(current!.description).toContain("Bring: Cranium lamp, $10 hash cash");
+    expect(current!.description).toContain("7:30 PM chalk talk");
+    expect(current!.description).toContain("eponymous yearly fruit hash");
+  });
+
+  it("#766: a plain gather-only When line is NOT folded (no chalk talk → typed time only)", async () => {
+    const html = `
+      <html><body>
+      <h2>Trail #1167: Plain Trail</h2>
+      <p>When: Thursday, 7/2 at 7:00 PM gather</p>
+      <p>Where: Some Park</p>
+      <p>Bring: ID and hash cash</p>
+      <p>Hare: Someone</p>
+      </body></html>
+    `;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(html, { status: 200 }))
+      .mockResolvedValueOnce(new Response("<html><body></body></html>", { status: 200 }));
+
+    const adapter = new BFMAdapter();
+    const result = await adapter.fetch({ id: "test", url: "https://benfranklinmob.com" } as never);
+    const current = result.events.find((e) => e.runNumber === 1167);
+    expect(current).toBeDefined();
+    // Bring is still folded, but the plain "When:" line is not (just the start time).
+    expect(current!.description).toBe("Bring: ID and hash cash");
+    expect(current!.description).not.toContain("When:");
+  });
+
   it("leaves description undefined when Fun Part section is absent", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(SAMPLE_HTML, { status: 200 }))

--- a/src/adapters/html-scraper/bfm.ts
+++ b/src/adapters/html-scraper/bfm.ts
@@ -119,7 +119,19 @@ function scrapeCurrentTrail(
 
   const location = whereText ?? undefined;
   const hares = hareText ?? undefined;
-  const description = extractFunPart(bodyText.slice(trailMatch.index));
+  // #766: fold the "Bring:" checklist and the gather/chalk-talk timing into the
+  // description alongside the existing "The Fun Part:" prose. Neither has a typed
+  // home. The "When:" line is folded only when it carries a chalk-talk time
+  // (BFM's "7:00 PM gather, 7:30 PM chalk talk" convention) — that two-time split
+  // is the nuance the typed date/startTime can't express; a plain "7:00 PM
+  // gather" line is just the start time and is left out to avoid noise.
+  const bringText = extractBfmField(bodyText, /Bring:\s*/i);
+  const funPart = extractFunPart(bodyText.slice(trailMatch.index));
+  const descParts: string[] = [];
+  if (whenText && /chalk/i.test(whenText)) descParts.push(`When: ${whenText}`);
+  if (bringText) descParts.push(`Bring: ${bringText}`);
+  if (funPart) descParts.push(funPart);
+  const description = descParts.length > 0 ? descParts.join("\n\n") : undefined;
 
   let locationUrl: string | undefined;
   $("a[href]").each((_i, el) => {

--- a/src/adapters/html-scraper/eh3-edmonton.test.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.test.ts
@@ -84,6 +84,23 @@ describe("parseEh3EventBlock", () => {
       expect(result!.description).toContain("Hash Hold: Cherry Poppins");
     });
 
+    it("folds a Scribe credit into the description (#1046)", () => {
+      // Mirrors live EH3 Run #1857 (verified 2026-06-22).
+      const lines = [
+        "EH3 Run # 1857 Monday Jun 29 – 1st Whack Off Memorial Run",
+        "Hares: Free Woody, Gobble Me and PissUp",
+        "Scribe: Rearendee",
+        "Location: Old Alberta Museum parking lot – 12845 102 Ave NW",
+        "On On: Rosario's 11715 108Ave Nw",
+      ];
+      const result = parseEh3EventBlock(lines, "eh3-ab", "18:30");
+      expect(result).not.toBeNull();
+      // Scribe is not a hare and not a typed column — it folds into description.
+      expect(result!.hares).toBe("Free Woody, Gobble Me and PissUp");
+      expect(result!.description).toContain("Scribe: Rearendee");
+      expect(result!.description).toContain("On On: Rosario's");
+    });
+
     it("emits 'EH3 Run #NNNN' title for untitled numbered runs (#1044)", () => {
       const lines = [
         "EH3 Run # 1847 Monday April 20",

--- a/src/adapters/html-scraper/eh3-edmonton.ts
+++ b/src/adapters/html-scraper/eh3-edmonton.ts
@@ -236,6 +236,10 @@ export function parseEh3EventBlock(
     const h = extractField(line, "Hares?", "Hare", "Hostess(?: and hare)?", "Host");
     if (h) { hares = h; continue; }
 
+    // Scribe credit (#1046) — no typed column, so fold into the description.
+    const scribe = extractField(line, "Scribe");
+    if (scribe) { descParts.push(`Scribe: ${scribe}`); continue; }
+
     // OSH3 (page 425) labels the meeting point "Address: …" rather than
     // "Location:"/"Start:" (#1899). Only the OSH3 page uses "Address:" — the
     // other six EH3 pages use "Location"/"Start", so this is purely additive.

--- a/src/adapters/html-scraper/indyh3.test.ts
+++ b/src/adapters/html-scraper/indyh3.test.ts
@@ -224,4 +224,70 @@ describe("parseIndyDetail", () => {
     const result = parseIndyDetail(html);
     expect(result.location).toBe("Canonical address");
   });
+
+  // ── #1354 detail fold + trail length ──
+  it("folds the body into description and lifts a mileage token to trail length", () => {
+    const result = parseIndyDetail(sampleDetailHtml);
+    expect(result.trailLengthText).toBe("~3.69mi");
+    expect(result.trailLengthMinMiles).toBeCloseTo(3.69);
+    expect(result.trailLengthMaxMiles).toBeCloseTo(3.69);
+    expect(result.description).toContain("Trail: ~3.69mi");
+    // Jokey Shiggy value stays in the description — never forced into difficulty.
+    expect(result.description).toContain("Shiggy level: 0.69");
+  });
+
+  it("folds the div-based body, stripping byline + chrome + inline script", () => {
+    // Mirrors the current live X/Cornerstone layout (hash-1126, 2026-06-22).
+    const html = `
+      <article class="ht_hash_event">
+        <h1>Hash #1126: HAH Hash – 2026</h1>
+        <p>by <a href="#">Did We Fuck?</a> · March 27, 2026</p>
+        <div><strong>📅 Date:</strong> Saturday, May 23, 2026</div>
+        <div><strong>🐇 Hares:</strong> 13&quot; Cocktower</div>
+        <div><a href="#">🗺️ Get Directions</a></div>
+        <div>Trail will traverse through human shiggy. Wear redneck attire! (Note: Not historically a K9-friendly trail.)</div>
+        <div><strong>How?</strong> In the greatest redneck attire!</div>
+        <div><strong>Where?</strong> Leonard Park – Speedway, Indiana</div>
+        <div>ON-AFTER!</div>
+        <div>There is an On-After at Tosser&#8217;s place.</div>
+        <div><a href="#">Share</a></div>
+        <script>var x = "ran 3 miles of junk";</script>
+      </article>`;
+    const result = parseIndyDetail(html);
+    expect(result.location).toBe("Leonard Park – Speedway, Indiana");
+    expect(result.description).toContain("Trail will traverse through human shiggy");
+    expect(result.description).toContain("ON-AFTER!");
+    expect(result.description).toContain("There is an On-After at Tosser’s place.");
+    // K9/dog status preserved in prose (not promoted to a typed field).
+    expect(result.description).toContain("Not historically a K9-friendly trail");
+    // Byline, chrome links, title echo, and inline script are excluded.
+    expect(result.description).not.toContain("Did We Fuck?");
+    expect(result.description).not.toContain("Get Directions");
+    expect(result.description).not.toContain("Share");
+    expect(result.description).not.toContain("Hash #1126:");
+    expect(result.description).not.toContain("var x");
+    // The "3 miles" in the stripped <script> must NOT become a trail length.
+    expect(result.trailLengthText).toBeUndefined();
+  });
+
+  it("parses a mileage range and rejects implausible distances", () => {
+    const range = parseIndyDetail(`<div>Trail: 3-5 miles of shiggy</div>`);
+    expect(range.trailLengthText).toBe("3-5 miles");
+    expect(range.trailLengthMinMiles).toBe(3);
+    expect(range.trailLengthMaxMiles).toBe(5);
+    // 50 miles is implausible for a trail (> 15) — not promoted.
+    expect(parseIndyDetail(`<div>We have run 50 miles total this year</div>`).trailLengthText).toBeUndefined();
+  });
+
+  it("returns no description for a skeleton event (only filtered metadata)", () => {
+    const html = `
+      <article class="ht_hash_event">
+        <h1>Hash #1130: NASH Hash</h1>
+        <p>by Someone · March 27, 2026</p>
+        <div><strong>📅 Date:</strong> Thursday, July 2, 2026</div>
+        <div><strong>⏰ Time:</strong> 6:30 PM</div>
+        <div><strong>🐇 Hares:</strong> TBD</div>
+      </article>`;
+    expect(parseIndyDetail(html).description).toBeUndefined();
+  });
 });

--- a/src/adapters/html-scraper/indyh3.ts
+++ b/src/adapters/html-scraper/indyh3.ts
@@ -164,7 +164,95 @@ export function parseIndyCard(
 // time on some detail pages, not a location (Codex review on PR #1335).
 const LOCATION_LABEL_RE = /^(?:Start\s+Location|Where)\s*[?:]?$/i;
 
-export function parseIndyDetail(html: string): { location?: string } {
+// #1354 detail-fold helpers. The detail page (X/Cornerstone theme) carries a
+// rich event body — narrative blurb, "What?/When?/Who?/How?/Where?" fields, and
+// an "ON-AFTER!" section — none of which the list page exposes. We fold that body
+// into `description` (duplicate of list-page date/hares is acceptable — preserve
+// the source's look/feel) and only lift a clean mileage token into the typed
+// trail-length bundle. The jokey "Shiggy"/dog-status content stays in the
+// description rather than being forced into the difficulty/dogFriendly columns.
+const DETAIL_TITLE_LINE_RE = /^Hash\s*#?\d+\s*:/i; // list-page title echo
+const DETAIL_META_EMOJI_RE = /^(?:📅|⏰|🐇|🗺️)/; // Date/Time/Hares/Directions rows
+const DETAIL_START_LOCATION_LABEL_RE = /^Start\s+Location:?$/i; // empty label row
+const DETAIL_CHROME_LINE_RE = /^(?:share|add to calendar|get directions)$/i;
+
+// Plausible trail-length tokens embedded in prose ("~3.69mi", "3 miles",
+// "3-5 miles"). Single `\s*` runs, no alternation-adjacent quantifiers (Sonar).
+const TRAIL_MILEAGE_RANGE_RE = /(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)\s*mi(?:le|les)?\b/i;
+const TRAIL_MILEAGE_RE = /~?(\d+(?:\.\d+)?)\s*mi(?:le|les)?\b/i;
+
+/** Lift the rich detail-page body into a folded description, excluding the
+ *  list-page title echo, emoji metadata rows, the empty "Start Location:" label,
+ *  the byline (the only `<p>`), and action chrome (Get Directions / Add to
+ *  Calendar / Share). Returns undefined for skeleton events with no body. */
+function extractIndyDescription($: cheerio.CheerioAPI): string | undefined {
+  const $scope = $(".ht_hash_event").first();
+  const scope = $scope.length ? $scope : $("body");
+  // cheerio's .text() includes <script>/<style> bodies (the X theme inlines a
+  // Sharrre share widget + a Leaflet map init), so strip them first or the
+  // description fills with JavaScript. Then surgically drop the byline
+  // ("by <author> · <date>") — only `<p>`s that start with "by", so content
+  // `<p>` blocks (the older layout puts Trail/Shiggy lines in a `<p>`) survive —
+  // and the action links (Get Directions / Add to Calendar / Share).
+  scope.find("script, style, noscript").remove();
+  scope.find("p").each((_i, el) => {
+    if (/^\s*by\b/i.test($(el).text())) $(el).remove();
+  });
+  scope.find("a, button").each((_i, el) => {
+    if (/get directions|add to calendar|share/i.test($(el).text())) $(el).remove();
+  });
+  const withBreaks = (scope.html() ?? "").replace(/<(?:br|\/p|\/div|\/h[1-6]|\/li)[^>]*>/gi, "\n");
+  const lines = cheerio
+    .load(withBreaks)
+    .root()
+    .text()
+    .split("\n")
+    .map((l) => decodeEntities(l).replace(/\s+/g, " ").trim())
+    .filter(Boolean)
+    .filter(
+      (l) =>
+        !DETAIL_TITLE_LINE_RE.test(l) &&
+        !DETAIL_META_EMOJI_RE.test(l) &&
+        !DETAIL_START_LOCATION_LABEL_RE.test(l) &&
+        !DETAIL_CHROME_LINE_RE.test(l),
+    );
+  const desc = lines.join("\n").trim();
+  return desc || undefined;
+}
+
+/** Extract a plausible trail length (1–15 mi) from the detail body. Returns the
+ *  verbatim token plus parsed min/max (equal for a fixed distance). No token →
+ *  empty object (merge preserves any existing value). */
+function extractIndyTrailLength(
+  text: string,
+): { trailLengthText?: string; trailLengthMinMiles?: number; trailLengthMaxMiles?: number } {
+  const range = TRAIL_MILEAGE_RANGE_RE.exec(text);
+  if (range) {
+    const min = Number.parseFloat(range[1]);
+    const max = Number.parseFloat(range[2]);
+    if (min >= 1 && max <= 15 && min <= max) {
+      return { trailLengthText: range[0].trim(), trailLengthMinMiles: min, trailLengthMaxMiles: max };
+    }
+  }
+  const fixed = TRAIL_MILEAGE_RE.exec(text);
+  if (fixed) {
+    const n = Number.parseFloat(fixed[1]);
+    if (n >= 1 && n <= 15) {
+      return { trailLengthText: fixed[0].trim(), trailLengthMinMiles: n, trailLengthMaxMiles: n };
+    }
+  }
+  return {};
+}
+
+export interface IndyDetail {
+  location?: string;
+  description?: string;
+  trailLengthText?: string;
+  trailLengthMinMiles?: number;
+  trailLengthMaxMiles?: number;
+}
+
+export function parseIndyDetail(html: string): IndyDetail {
   const $ = cheerio.load(html);
   let preferred: string | undefined; // value behind "Start Location" — wins
   let fallback: string | undefined; // value behind "Where?"
@@ -185,7 +273,10 @@ export function parseIndyDetail(html: string): { location?: string } {
     }
   });
 
-  return { location: preferred ?? fallback };
+  const description = extractIndyDescription($);
+  const trail = description ? extractIndyTrailLength(description) : {};
+
+  return { location: preferred ?? fallback, description, ...trail };
 }
 
 async function fetchDetailHtml(
@@ -231,10 +322,26 @@ async function enrichWithDetails(
       }
       try {
         const detail = parseIndyDetail(r.value.html);
-        if (detail.location) {
+        let didEnrich = false;
+        // Only fill location when the list page didn't supply one (don't clobber).
+        if (detail.location && !event.location) {
           event.location = detail.location;
-          enriched++;
+          didEnrich = true;
         }
+        // Fold the rich detail body into description (#1354). List page carries
+        // no description, so this is fill-only.
+        if (detail.description && !event.description) {
+          event.description = detail.description;
+          didEnrich = true;
+        }
+        // Lift a clean mileage token into the typed trail-length bundle (#1354).
+        if (detail.trailLengthText) {
+          event.trailLengthText = detail.trailLengthText;
+          event.trailLengthMinMiles = detail.trailLengthMinMiles;
+          event.trailLengthMaxMiles = detail.trailLengthMaxMiles;
+          didEnrich = true;
+        }
+        if (didEnrich) enriched++;
       } catch (err) {
         errors.push(`Detail parse error for ${url}: ${err}`);
         errorDetails.parse = [
@@ -346,13 +453,12 @@ export class IndyH3Adapter implements SourceAdapter {
       return d >= minDate && d <= maxDate;
     });
 
-    // The list page omits start location; follow each event's /hashes/<slug>/
-    // URL and copy the parsed location onto the RawEventData (#1302).
+    // Follow each event's /hashes/<slug>/ detail URL. The detail page supplies
+    // the start location the list page omits (#1302) AND the rich event body +
+    // trail length we fold/lift in (#1354), so we enrich every event with a
+    // detail URL — not just the location-less ones.
     const detailEnrichable = events.filter(
-      (e) =>
-        !e.location &&
-        typeof e.sourceUrl === "string" &&
-        /\/hashes\//i.test(e.sourceUrl),
+      (e) => typeof e.sourceUrl === "string" && /\/hashes\//i.test(e.sourceUrl),
     );
     const { fetched: detailFetched, enriched: detailEnriched } =
       await enrichWithDetails(detailEnrichable, errors, errorDetails);

--- a/src/adapters/html-scraper/kampong-h3.test.ts
+++ b/src/adapters/html-scraper/kampong-h3.test.ts
@@ -253,6 +253,29 @@ describe("KampongH3Adapter — Next Run detail fold (#1365)", () => {
     expect(run305!.description).toContain("Bus: 77, 156, 970");
     expect(run305!.description).toContain("Limited parking - please park in side streets.");
   });
+
+  it("collects directions published as a <ul>/<li> list (gemini review)", async () => {
+    const html = `<!DOCTYPE html><html><body>
+<h1>Next Run<br>Run 306</h1>
+<h2>Date: Saturday, 16<sup>th</sup> January 2027<br>Run starts 5:30PM</h2>
+<h2>Run site: Some Park</h2>
+<ul>
+  <li>Nearest MRT: Botanic Gardens (CC19)</li>
+  <li>Bus: 7, 105, 123</li>
+</ul>
+<h2><a id="Hareline">Hare Line</a></h2>
+<table>
+<tr><th>Run</th><th>Date</th></tr>
+<tr><td>306</td><td>16 January 2027 - Test Hare</td></tr>
+</table>
+</body></html>`;
+    mockFetchResponse(html);
+    const result = await new KampongH3Adapter().fetch(makeSource());
+    const run306 = result.events.find((e) => e.runNumber === 306);
+    expect(run306).toBeDefined();
+    expect(run306!.description).toContain("Nearest MRT: Botanic Gardens (CC19)");
+    expect(run306!.description).toContain("Bus: 7, 105, 123");
+  });
 });
 
 describe("KampongH3Adapter.fetch", () => {

--- a/src/adapters/html-scraper/kampong-h3.test.ts
+++ b/src/adapters/html-scraper/kampong-h3.test.ts
@@ -5,6 +5,7 @@ import {
   KampongH3Adapter,
   parseKampongNextRun,
   parseKampongArchiveTable,
+  extractKampongDetails,
 } from "./kampong-h3";
 
 vi.mock("@/adapters/safe-fetch", () => ({
@@ -174,6 +175,83 @@ describe("parseKampongArchiveTable", () => {
     expect(out.skipped).toEqual([
       { runNumber: 18, cellText: "February 2001 - SOIXANTE NEUF and PONTIANAK", reason: "no-leading-date" },
     ]);
+  });
+});
+
+describe("extractKampongDetails (#1365)", () => {
+  it("folds MRT/bus directions + parking and lifts hash cash to cost", () => {
+    const blocks = [
+      "Limited parking - please park in side streets.",
+      "Nearest MRT: Bukit Timah (DT7) and King Albert Park (DT6)",
+      "Bus: 77, 156, 970",
+      "Hash Cash: S$20",
+    ];
+    const d = extractKampongDetails(blocks);
+    expect(d.directions).toEqual([
+      "Nearest MRT: Bukit Timah (DT7) and King Albert Park (DT6)",
+      "Bus: 77, 156, 970",
+    ]);
+    expect(d.parking).toBe("Limited parking - please park in side streets.");
+    expect(d.cost).toBe("S$20");
+  });
+
+  it("ignores standing membership / guest-fee / club boilerplate", () => {
+    const blocks = [
+      "The Kampong HHH runs once a month on the 3rd Saturday.",
+      "Membership fees (including insurance) are S$130 per year for women and S$190 per year for men.",
+      "Guest fees for non-members are normally S$20 for women and S$25 for men.",
+      "Contact us at kampong@hash.org.sg",
+    ];
+    expect(extractKampongDetails(blocks)).toEqual({ directions: [] });
+  });
+
+  it("skips a long promo paragraph that merely mentions parking", () => {
+    const longParking = `Parking ${"x".repeat(200)}`; // exceeds DETAIL_LINE_MAX
+    expect(extractKampongDetails([longParking]).parking).toBeUndefined();
+  });
+
+  it("keeps only the first parking line", () => {
+    const d = extractKampongDetails(["Limited parking here", "More parking there"]);
+    expect(d.parking).toBe("Limited parking here");
+  });
+});
+
+describe("KampongH3Adapter — Next Run detail fold (#1365)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-12-01T00:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("folds parking + MRT/bus into description, lifts hash cash to cost, keeps location clean", async () => {
+    const html = `<!DOCTYPE html><html><body>
+<h1>Next Run<br>Run 305</h1>
+<h2>Date: Saturday, 16<sup>th</sup> January 2027<br>Run starts 5:30PM</h2>
+<h2>Hares: Test Hare</h2>
+<h2>Run site: Some Park</h2>
+<p>Limited parking - please park in side streets.</p>
+<p>Nearest MRT: Bukit Timah (DT7)</p>
+<p>Bus: 77, 156, 970</p>
+<p>Hash Cash: S$20</p>
+<h2>On On: The Red Lantern</h2>
+<h2><a id="Hareline">Hare Line</a></h2>
+<table>
+<tr><th>Run</th><th>Date</th></tr>
+<tr><td>305</td><td>16 January 2027 - Test Hare</td></tr>
+</table>
+</body></html>`;
+    mockFetchResponse(html);
+    const result = await new KampongH3Adapter().fetch(makeSource());
+    const run305 = result.events.find((e) => e.runNumber === 305);
+    expect(run305).toBeDefined();
+    expect(run305!.cost).toBe("S$20");
+    expect(run305!.location).toBe("Some Park"); // parking/MRT prose must NOT leak into location
+    expect(run305!.description).toContain("On On: The Red Lantern");
+    expect(run305!.description).toContain("Nearest MRT: Bukit Timah (DT7)");
+    expect(run305!.description).toContain("Bus: 77, 156, 970");
+    expect(run305!.description).toContain("Limited parking - please park in side streets.");
   });
 });
 

--- a/src/adapters/html-scraper/kampong-h3.ts
+++ b/src/adapters/html-scraper/kampong-h3.ts
@@ -332,7 +332,9 @@ function collectNextRunDetailBlocks($: CheerioAPI): string[] {
     const tag = cur.prop("tagName")?.toLowerCase();
     if (tag === "p" || tag === "li") {
       pushText(cur.text());
-    } else if (tag === "div") {
+    } else if (tag === "div" || tag === "ul" || tag === "ol") {
+      // Descend into container/list siblings so directions published as a
+      // <ul>/<ol> list (or wrapped in a <div>) survive as individual blocks.
       const inner = cur.find("p, li");
       if (inner.length > 0) inner.each((_, p) => pushText($(p).text()));
       else pushText(cur.text());

--- a/src/adapters/html-scraper/kampong-h3.ts
+++ b/src/adapters/html-scraper/kampong-h3.ts
@@ -43,6 +43,18 @@ export interface KampongFields {
   onAfter?: string;
 }
 
+/**
+ * Per-run logistics the source publishes in `<p>`/`<div>` blocks below the
+ * `<h2>` header (deliberately kept out of `location` — see
+ * collectNextRunHeaderText). MRT/bus + parking fold into the description; a
+ * cleanly-labelled "Hash Cash" amount becomes the typed `cost` (#1365).
+ */
+export interface KampongDetails {
+  directions: string[]; // verbatim "Nearest MRT: …" / "Bus: …" lines
+  parking?: string; // verbatim "Limited parking …" line
+  cost?: string; // value after a "Hash Cash:" label
+}
+
 // `\s` already includes NBSP and all Unicode whitespace runs in JS regex.
 const NORMALIZE_WS_RE = /\s+/g;
 const RUN_NUMBER_RE = /Run\s+(\d{1,4})/i;
@@ -134,6 +146,43 @@ export function parseKampongNextRun(rawText: string): KampongFields {
   }
 
   return result;
+}
+
+// Per-run logistics labels (#1365). Anchored / single-class quantifiers keep
+// them clear of Sonar's ReDoS heuristics. Lines longer than DETAIL_LINE_MAX are
+// treated as boilerplate/promo prose and skipped — the labelled logistics lines
+// the source publishes are short ("Nearest MRT: …", "Bus: 77, 156, 970").
+const DIRECTIONS_LINE_RE = /^(?:nearest\s+)?(?:mrt|bus)\b/i;
+const PARKING_LINE_RE = /\bparking\b/i;
+const HASH_CASH_RE = /hash ?cash[:\s]+(.+)/i;
+const DETAIL_LINE_MAX = 120;
+
+/**
+ * Extract per-run logistics from the Next Run detail blocks (the `<p>`/`<div>`
+ * prose below the `<h2>` header). Only short, clearly-labelled lines are
+ * promoted — MRT/bus + parking fold into the description; a "Hash Cash:" amount
+ * becomes the typed cost. The standing membership/guest-fee/club boilerplate on
+ * the homepage is left untouched (it carries none of these labels and the long
+ * promo paragraphs exceed DETAIL_LINE_MAX). Exported for unit testing.
+ */
+export function extractKampongDetails(blocks: string[]): KampongDetails {
+  const directions: string[] = [];
+  let parking: string | undefined;
+  let cost: string | undefined;
+  for (const block of blocks) {
+    if (block.length > DETAIL_LINE_MAX) continue;
+    const hc = HASH_CASH_RE.exec(block);
+    if (hc) {
+      if (!cost && hc[1].trim()) cost = hc[1].trim();
+      continue;
+    }
+    if (DIRECTIONS_LINE_RE.test(block)) {
+      directions.push(block);
+    } else if (PARKING_LINE_RE.test(block) && !parking) {
+      parking = block;
+    }
+  }
+  return { directions, parking, cost };
 }
 
 export interface KampongArchiveRow {
@@ -257,6 +306,42 @@ function collectNextRunHeaderText($: CheerioAPI): string | null {
   return parts.filter(Boolean).join(" | ");
 }
 
+/**
+ * Collect the Next Run "detail" prose — the `<p>`/`<div>` siblings between the
+ * `<h1>Next Run…</h1>` heading and the Hareline anchor. Unlike
+ * collectNextRunHeaderText (which walks only `<h2>` so MRT/bus/parking prose
+ * can't leak into `location`), this captures those blocks so the labelled
+ * logistics lines can be folded into the description / cost. A `<div>` wrapper
+ * is descended into so nested `<p>`/`<li>` lines survive as individual blocks.
+ */
+function collectNextRunDetailBlocks($: CheerioAPI): string[] {
+  const h1 = $("h1")
+    .filter((_, el) => NEXT_RUN_HEADING_RE.test($(el).text()))
+    .first();
+  if (h1.length === 0) return [];
+
+  const blocks: string[] = [];
+  const pushText = (raw: string) => {
+    const txt = raw.replaceAll(NORMALIZE_WS_RE, " ").trim();
+    if (txt) blocks.push(txt);
+  };
+
+  let cur = h1.next();
+  while (cur.length > 0) {
+    if (cur.find("a#Hareline").length > 0) break;
+    const tag = cur.prop("tagName")?.toLowerCase();
+    if (tag === "p" || tag === "li") {
+      pushText(cur.text());
+    } else if (tag === "div") {
+      const inner = cur.find("p, li");
+      if (inner.length > 0) inner.each((_, p) => pushText($(p).text()));
+      else pushText(cur.text());
+    }
+    cur = cur.next();
+  }
+  return blocks;
+}
+
 function buildNextRunEvent($: CheerioAPI, sourceUrl: string): {
   event?: RawEventData;
   fields?: KampongFields;
@@ -267,7 +352,16 @@ function buildNextRunEvent($: CheerioAPI, sourceUrl: string): {
   const fields = parseKampongNextRun(headerText);
   if (!fields.date) return { error: "Could not parse date from Next Run block", fields };
 
-  const description = fields.onAfter ? `On On: ${fields.onAfter}` : undefined;
+  // Fold per-run logistics (MRT/bus directions, parking) into the description
+  // and lift a labelled hash-cash amount into the typed cost (#1365). Append
+  // only — the existing "On On:" line is preserved, and nothing is stripped.
+  const details = extractKampongDetails(collectNextRunDetailBlocks($));
+  const descParts: string[] = [];
+  if (fields.onAfter) descParts.push(`On On: ${fields.onAfter}`);
+  descParts.push(...details.directions);
+  if (details.parking) descParts.push(details.parking);
+  const description = descParts.length > 0 ? descParts.join("\n") : undefined;
+
   const event: RawEventData = {
     date: fields.date,
     startTime: fields.startTime,
@@ -276,6 +370,7 @@ function buildNextRunEvent($: CheerioAPI, sourceUrl: string): {
     title: fields.runNumber ? `Kampong H3 Run ${fields.runNumber}` : "Kampong H3 Monthly Run",
     hares: fields.hares,
     location: fields.location,
+    cost: details.cost,
     description,
     sourceUrl,
   };

--- a/src/adapters/html-scraper/samurai-h3.test.ts
+++ b/src/adapters/html-scraper/samurai-h3.test.ts
@@ -227,6 +227,10 @@ describe("SamuraiH3Adapter", () => {
       expect(run123!.title).toBe("Samurai H3 #123");
       expect(run123!.kennelTags[0]).toBe("samurai-h3");
       expect(run123!.hares).toBe("Hashimoto, Sake Bomb");
+      // #2222: Fee column surfaces as the typed `cost` field…
+      expect(run123!.cost).toBe("1500 yen");
+      // …and is intentionally still present in the description (duplicate OK).
+      expect(run123!.description).toContain("Fee: 1500 yen");
 
       const run124 = result.events.find((e) => e.runNumber === 124);
       expect(run124).toBeDefined();

--- a/src/adapters/html-scraper/samurai-h3.ts
+++ b/src/adapters/html-scraper/samurai-h3.ts
@@ -202,6 +202,10 @@ function buildRawEvent(parsed: ParsedSamuraiRun, sourceUrl: string): RawEventDat
 
   const descParts: string[] = [];
   if (parsed.train) descParts.push(`Train: ${parsed.train}`);
+  // Fee is now emitted as the typed `cost` field (#2222). We intentionally keep
+  // it in the description too — the source presents Fee inline with Train/Note,
+  // and duplicating it preserves the table's look/feel while giving the UI a
+  // structured cost chip.
   if (parsed.fee) descParts.push(`Fee: ${parsed.fee}`);
   if (parsed.note) descParts.push(`Note: ${parsed.note}`);
 
@@ -213,6 +217,9 @@ function buildRawEvent(parsed: ParsedSamuraiRun, sourceUrl: string): RawEventDat
     hares: parsed.hares,
     location: parsed.location,
     startTime: parsed.startTime,
+    // Typed cost from the "Fee" column (#2222). `undefined` when the column is
+    // empty so the merge pipeline preserves any previously stored value.
+    cost: parsed.fee,
     sourceUrl,
     description: descParts.length > 0 ? descParts.join("\n") : undefined,
   };

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle, detectBoilerplateBlocks, stripBoilerplateBlocks, extractRunNumberFromMeetupDescription } from "./adapter";
+import { MeetupAdapter, extractApolloEvents, resolveVenue, isNumericId, dedupByDate, stripTrailingState, deduplicateWords, isStateFullName, buildRawEventFromApollo, extractHaresFromMeetupDescription, cleanMeetupTitle, detectBoilerplateBlocks, stripBoilerplateBlocks, extractRunNumberFromMeetupDescription, extractMeetupCost, extractMeetupTrailType } from "./adapter";
 import { normalizeDescriptionKey } from "../utils";
 import { SOURCES } from "../../../prisma/seed-data/sources";
 import type { Source } from "@/generated/prisma/client";
@@ -1630,6 +1630,83 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     const event = buildRawEventFromApollo(ev as never, emptyState, "rvah3");
     expect(event.startTime).toBe("22:00");
     expect(event.endTime).toBeUndefined();
+  });
+
+  // ── #2229 cost + trailType extraction (Paris H3 / Sans Clue H3) ──
+  it("emits typed cost + trailType from emoji-labelled body, keeping the prose", () => {
+    const ev = {
+      __typename: "Event",
+      id: "paris",
+      title: "Paris H3 R*n 1140 | TBD",
+      dateTime: "2026-08-08T18:30:00+02:00",
+      description:
+        "🐰 Hares: TBD\n👣 Trail: A-to-B trail, no bag drop\n💶 Hash Cash: 5 € (Hash cash is collected to keep our club active.)",
+    };
+    const event = buildRawEventFromApollo(ev as never, emptyState, "paris-h3");
+    // Parenthetical boilerplate stripped from the cost chip…
+    expect(event.cost).toBe("5 €");
+    expect(event.trailType).toBe("A-to-B trail, no bag drop");
+    // …but the full labelled text is still present in the description (duplicate OK).
+    expect(event.description).toContain("Hash Cash: 5 €");
+    expect(event.description).toContain("👣 Trail: A-to-B trail, no bag drop");
+  });
+
+  it("leaves cost/trailType undefined when the body has no such labels", () => {
+    const ev = {
+      __typename: "Event",
+      id: "plain",
+      title: "Saturday Trail!",
+      dateTime: "2026-04-01T10:00:00-04:00",
+      description: "Just show up and run. Meet at the trailhead.",
+    };
+    const event = buildRawEventFromApollo(ev as never, emptyState, "rvah3");
+    expect(event.cost).toBeUndefined();
+    expect(event.trailType).toBeUndefined();
+  });
+
+  describe("extractMeetupCost / extractMeetupTrailType (#2229)", () => {
+  it("strips a leading emoji and a trailing parenthetical from cost", () => {
+    expect(extractMeetupCost("💶 Hash Cash: 10 € (cash to the hare)")).toBe("10 €");
+    expect(extractMeetupCost("Cost: $10")).toBe("$10");
+  });
+
+  it("keeps a short cost qualifier when there is no parenthetical", () => {
+    expect(extractMeetupCost("Hash Cash: $5 cash / $10 card")).toBe("$5 cash / $10 card");
+  });
+
+  it("matches Trail and Trail type labels", () => {
+    expect(extractMeetupTrailType("👣 Trail: A-to-A’ trail, no bag drop")).toBe(
+      "A-to-A’ trail, no bag drop",
+    );
+    expect(extractMeetupTrailType("Trail type: Live hare")).toBe("Live hare");
+  });
+
+  it("returns undefined for an unlabelled body", () => {
+    expect(extractMeetupCost("no structured fields here")).toBeUndefined();
+    expect(extractMeetupTrailType("no structured fields here")).toBeUndefined();
+    expect(extractMeetupCost(undefined)).toBeUndefined();
+  });
+
+  it("does not promote a mid-sentence 'cost'/'trail' mention to a typed field", () => {
+    expect(extractMeetupCost("There is no cost: just bring yourself")).toBeUndefined();
+    expect(extractMeetupTrailType("Meet at the trailhead by the lake")).toBeUndefined();
+  });
+
+  it("rejects a monetary value mis-filed under a Trail label (#2229 Narwhal)", () => {
+    expect(extractMeetupTrailType("Trail: $6.69")).toBeUndefined();
+  });
+
+  it("rejects a prose paragraph filed under Trail Type (Charlotte/Miami)", () => {
+    const prose =
+      "Trail Type: Man I been cooped up in the house for weeks and we need to hash, so this will be fun!";
+    expect(extractMeetupTrailType(prose)).toBeUndefined();
+  });
+
+  it("still accepts a short layout descriptor with a mileage note", () => {
+    expect(extractMeetupTrailType("**Trail Type: Pavement! Approx 3.6 miles**")).toBe(
+      "Pavement! Approx 3.6 miles",
+    );
+  });
   });
 
   it("routes event to matched kennel pattern", () => {

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -1696,6 +1696,22 @@ describe("buildRawEventFromApollo — kennelPatterns", () => {
     expect(extractMeetupTrailType("Trail: $6.69")).toBeUndefined();
   });
 
+  it("matches a bold-label form and rejects non-Latin currency (gemini review)", () => {
+    // "**Cost**: $10" — bold on the label word, colon outside the bold.
+    expect(extractMeetupCost("**Cost**: $10")).toBe("$10");
+    expect(extractMeetupCost("**Hash Cash**: 5 €")).toBe("5 €");
+    // Global adapter: a yen amount mis-filed under "Trail:" must not become a trail type.
+    expect(extractMeetupTrailType("Trail: ¥1000")).toBeUndefined();
+    expect(extractMeetupTrailType("**Trail Type**: A to B")).toBe("A to B");
+  });
+
+  it("rejects a value that bled into adjacent markdown (AVL #855)", () => {
+    // "**Cost**: $40…*INCLUDES*: ..." → "$40…*INCLUDES*:" after ** strip — not clean.
+    expect(extractMeetupCost("**Cost**: $40…*INCLUDES*: rego, beer, food")).toBeUndefined();
+    // A clean value next to it still extracts.
+    expect(extractMeetupCost("**Cost**: $8")).toBe("$8");
+  });
+
   it("rejects a prose paragraph filed under Trail Type (Charlotte/Miami)", () => {
     const prose =
       "Trail Type: Man I been cooped up in the house for weeks and we need to hash, so this will be fun!";

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -767,10 +767,12 @@ function firstLabeledValue(
 ): string | undefined {
   if (!desc) return undefined;
   for (const rawLine of desc.split("\n")) {
-    const line = rawLine.replace(/^[^A-Za-z]+/, "");
+    // Strip markdown bold FIRST so a "**Label**:" form (bold on the label word,
+    // colon outside the bold) still anchors, then drop the leading emoji/space.
+    const line = rawLine.replace(/\*\*/g, "").replace(/^[^A-Za-z]+/, "");
     const m = labelRe.exec(line);
     if (m) {
-      const v = m[1].replace(/\*\*/g, "").trim();
+      const v = m[1].trim();
       if (v) return v;
     }
   }
@@ -786,14 +788,27 @@ function stripTrailingParenthetical(s: string): string {
   return stripped || s.trim();
 }
 
+/** Reject a value that carries structural remnants of a line where the field
+ *  bled into adjacent markdown content — a stray "*" (single markdown marker),
+ *  an ellipsis, or a trailing ":" (a following label leaking in). Stripping
+ *  "**" can merge a bold label with the next bold segment on the same source
+ *  line (AVL H3 #855: "Cost: $40…*INCLUDES*:"); such values aren't a clean
+ *  mapping, so we leave them in the description only. No clean cost/trail type
+ *  ("$8", "5 €", "A to B") trips this. */
+function looksBledTogether(v: string): boolean {
+  return v.includes("*") || v.includes("…") || v.endsWith(":");
+}
+
 /** Extract a typed cost from a Meetup description ("Hash Cash:"/"Cost:" label).
  *  Runaway-guard: a "Cost:" label that introduces a whole prose paragraph
- *  (> 100 chars after parenthetical trim) is rejected as not-a-cost. */
+ *  (> 100 chars after parenthetical trim) or a bled-together markdown line is
+ *  rejected as not-a-cost. */
 export function extractMeetupCost(desc: string | undefined): string | undefined {
   const raw = firstLabeledValue(desc, MEETUP_COST_LABEL_RE);
   if (!raw) return undefined;
   const cost = stripTrailingParenthetical(raw);
-  return cost.length <= 100 ? cost : undefined;
+  if (cost.length > 100 || looksBledTogether(cost)) return undefined;
+  return cost;
 }
 
 /** Extract a typed trail type from a Meetup description ("Trail:"/"Trail type:").
@@ -805,7 +820,10 @@ export function extractMeetupTrailType(desc: string | undefined): string | undef
   const raw = firstLabeledValue(desc, MEETUP_TRAIL_TYPE_LABEL_RE);
   if (!raw) return undefined;
   if (raw.length > 50) return undefined;
-  if (/[$€£]/.test(raw)) return undefined;
+  // Reject monetary amounts mis-filed under a "Trail:" label, including
+  // non-Latin currency symbols (this adapter is global): $ € £ ¥ ₩ ₹ ₽ ₪ ₫ ฿ ₱.
+  if (/[$€£¥₩₹₽₪₫฿₱]/.test(raw)) return undefined;
+  if (looksBledTogether(raw)) return undefined;
   return raw;
 }
 

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -746,6 +746,69 @@ export function extractRunNumberFromMeetupDescription(
   return undefined;
 }
 
+// #2229: structured field labels many hash kennels embed in their Meetup body.
+// Anchored at the start of a line AFTER leading emoji/markdown/space are stripped
+// procedurally (see firstLabeledValue), so the patterns themselves stay simple +
+// ReDoS-safe (single `\s*` runs, no nested quantifiers under an alternation).
+//   "💶 Hash Cash: 5 € (…)"            -> cost
+//   "👣 Trail: A-to-B trail, no bag drop" -> trailType
+const MEETUP_COST_LABEL_RE = /^(?:hash ?cash|cost)\s*:\s*(.+)$/i;
+const MEETUP_TRAIL_TYPE_LABEL_RE = /^trail(?: type)?\s*:\s*(.+)$/i;
+
+/**
+ * Scan a (resolved, HTML-stripped) description line-by-line for a field label.
+ * Leading non-letters (emoji prefixes like "💶"/"👣", markdown "**", whitespace)
+ * are stripped before matching so the label can be anchored at `^`. Returns the
+ * first non-empty captured value with markdown bold removed, else undefined.
+ */
+function firstLabeledValue(
+  desc: string | undefined,
+  labelRe: RegExp,
+): string | undefined {
+  if (!desc) return undefined;
+  for (const rawLine of desc.split("\n")) {
+    const line = rawLine.replace(/^[^A-Za-z]+/, "");
+    const m = labelRe.exec(line);
+    if (m) {
+      const v = m[1].replace(/\*\*/g, "").trim();
+      if (v) return v;
+    }
+  }
+  return undefined;
+}
+
+/** Drop a trailing parenthetical so a cost chip stays tight ("5 € (Hash cash is
+ *  collected…)" → "5 €"). The full text survives verbatim in `description`, so
+ *  no information is lost. Falls back to the trimmed original if stripping would
+ *  empty the value (the whole value was a parenthetical). */
+function stripTrailingParenthetical(s: string): string {
+  const stripped = s.replace(/\s*\([^)]*\)\s*$/, "").trim();
+  return stripped || s.trim();
+}
+
+/** Extract a typed cost from a Meetup description ("Hash Cash:"/"Cost:" label).
+ *  Runaway-guard: a "Cost:" label that introduces a whole prose paragraph
+ *  (> 100 chars after parenthetical trim) is rejected as not-a-cost. */
+export function extractMeetupCost(desc: string | undefined): string | undefined {
+  const raw = firstLabeledValue(desc, MEETUP_COST_LABEL_RE);
+  if (!raw) return undefined;
+  const cost = stripTrailingParenthetical(raw);
+  return cost.length <= 100 ? cost : undefined;
+}
+
+/** Extract a typed trail type from a Meetup description ("Trail:"/"Trail type:").
+ *  A trail TYPE is a short layout descriptor ("A to B", "Live Hare", "Pavement").
+ *  Reject (a) monetary amounts some kennels mis-file under a "Trail:" label
+ *  ("Trail: $6.69") and (b) prose paragraphs (> 50 chars) — both stay captured in
+ *  the description, we just don't promote them to the typed field. */
+export function extractMeetupTrailType(desc: string | undefined): string | undefined {
+  const raw = firstLabeledValue(desc, MEETUP_TRAIL_TYPE_LABEL_RE);
+  if (!raw) return undefined;
+  if (raw.length > 50) return undefined;
+  if (/[$€£]/.test(raw)) return undefined;
+  return raw;
+}
+
 /** Build a RawEventData from an Apollo event entry. */
 export function buildRawEventFromApollo(
   ev: ApolloEvent,
@@ -802,6 +865,15 @@ export function buildRawEventFromApollo(
       ? stripBoilerplateBlocks(cleanedDesc, blocks)
       : cleanedDesc;
 
+  // #2229: lift the structured "Hash Cash"/"Cost" and "Trail"/"Trail type"
+  // labels into typed fields. Read from cleanedDesc (the resolved description
+  // BEFORE boilerplate stripping) so a templated Hash-Cash line — which is a
+  // perfectly valid recurring cost — still yields a value even when the block is
+  // stripped from the stored prose. The text also remains in `description`
+  // (duplicate is fine). undefined when no label is present → merge preserves.
+  const cost = extractMeetupCost(cleanedDesc);
+  const trailType = extractMeetupTrailType(cleanedDesc);
+
   return {
     date,
     kennelTags: [resolvedKennelTag],
@@ -815,6 +887,8 @@ export function buildRawEventFromApollo(
     runNumber: resolveRunNumber(ev.title, finalDesc, extractRunNumber, runNumberPrefix, opts?.anchorTrail),
     description: finalDesc,
     hares,
+    cost,
+    trailType,
     location: venueInfo.location,
     latitude: venueInfo.latitude,
     longitude: venueInfo.longitude,


### PR DESCRIPTION
## What & why

A bundle of issues originally filed as *"schema gap → routes to PRD"*, but the `Event` schema + merge pipeline + UI have since caught up (`cost`, `trailType`, `difficulty`, `trailLength*`, `dogFriendly`, `locationUrl`→`locationAddress`, free-form `description`). The remaining gap was purely in the **adapters** — each source already exposes the data, the adapter just wasn't emitting it. This PR makes each adapter emit the typed field it can map cleanly, and **folds** the rest (on-after, theme/attire, what-to-bring, scribe, transit/parking) into `description`. **No schema columns added.**

### Maintainer guidance applied throughout
> Pull out only data elements we're **sure** map cleanly to a typed field. Duplicate info in `description` is fine. Don't over-clean / don't risk removing useful info — keep the source's look/feel.

So typed extraction is conservative (high-precision, label-anchored, guarded), and folds preserve source content even where it duplicates a typed field.

## Per-issue

| Issue | Kennel | Change | Backfill (prod, idempotent) |
|---|---|---|---|
| #2222 | Samurai H3 | "Fee" column → typed `cost` (kept in description too) | 24 events: Fee→cost (pure-DB) |
| #2229 | Meetup (fleet-wide) | "Hash Cash"/"Cost" → `cost`, "Trail"/"Trail type" → `trailType` | 92 `cost` + 33 `trailType` (pure-DB) |
| #1511 | Geriatrix H3 | **already resolved** — adapter emits `locationUrl`, merge maps → `locationAddress`; verified live + prod (7/7 venue events have it) | none needed (0 backlog) |
| #1365 | Kampong H3 | fold MRT/bus + parking into description; "Hash Cash" → `cost` | none needed (0 recoverable backlog) |
| #1354 | IndyScent H3 | fold detail-page body into description; lift mileage token → `trailLength*` | 9 descriptions + 3 trail lengths |
| #1046 | EH3 (Edmonton) | fold "Scribe:" credit into description | 1 event |
| #766 | BFM | fold "Bring:" list + chalk-talk timing into description | 1 event |

## Deliberate deviations (worth a look)
- **#2222 Samurai:** the issue said "stop folding Fee into description" — per maintainer guidance we instead **keep** Fee in the description *and* emit `cost` (duplicate is fine; preserves the table look/feel).
- **#1354 IndyScent:** the source's `difficulty` (Shiggy) values are jokes (e.g. `0.69`, outside 1–5) and dog status is buried narrative, so these are **intentionally left in the folded description** rather than forced into typed `difficulty`/`dogFriendly`. Only a clean mileage token is typed.
- **#1511 Geriatrix:** no code/backfill — the adapter has emitted `locationUrl` since its first commit and prod already carries the goo.gl URLs in `locationAddress`. Closing as already-implemented.

## Backfill note
Several folds write to `description`, which is **not** part of the RawEvent fingerprint — so a plain re-scrape dedup-skips and never updates existing canonical events ("re-scrape won't fix existing canonical"). Each backfill therefore patches existing events directly (counts verified against prod, all idempotent on re-run). Where there was no recoverable backlog (#1365 Kampong, #1511 Geriatrix), no backfill was shipped — confirmed empirically against prod rather than assumed.

## Stretch (deferred, left open)
- **#1353** (IndyScent richer detail pages) — detail fetching already existed and is now folded for existing events; only the past-archive crawl remains.
- **#1131** (BTH3 archive enrichment) — not started.

## Verification
- Every adapter verified against its **live** production source (per `.claude/rules/live-verification.md`).
- Unit tests added/updated for each adapter (new field emission, atomic-null/guard cases, layout robustness).
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (0 errors) · full `vitest` suite ✅ (321 files, 9459 tests).

Closes #2222
Closes #2229
Closes #1511
Closes #1365
Closes #1354
Closes #1046
Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)