### PR TITLE
Include misman-recorded attendees in the public roster (opt-in, privacy-gated)

### DIFF
--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -205,47 +205,47 @@ export default async function EventDetailPage({
   //   - misman-recorded (KennelAttendance), but ONLY when the roster entry is
   //     linked to a registered User via a CONFIRMED link. An unlinked roster
   //     name has no account and never had a way to opt in, so it's never shown.
-  const rosterAttendees = showRoster
-    ? await prisma.attendance.findMany({
-        where: { eventId, status: "CONFIRMED", user: { attendanceVisibility: "PUBLIC" } },
-        select: {
-          userId: true,
-          user: {
-            select: { hashName: true, avatarUrl: true, clerkImageUrl: true, hideClerkImage: true },
+  // Both queries are independent — run them in parallel (one round-trip).
+  const [rosterAttendees, mismanAttendees] = showRoster
+    ? await Promise.all([
+        prisma.attendance.findMany({
+          where: { eventId, status: "CONFIRMED", user: { attendanceVisibility: "PUBLIC" } },
+          select: {
+            userId: true,
+            user: {
+              select: { hashName: true, avatarUrl: true, clerkImageUrl: true, hideClerkImage: true },
+            },
           },
-        },
-      })
-    : [];
-
-  const mismanAttendees = showRoster
-    ? await prisma.kennelAttendance.findMany({
-        where: {
-          eventId,
-          kennelHasher: {
-            userLink: { status: "CONFIRMED", user: { attendanceVisibility: "PUBLIC" } },
+        }),
+        prisma.kennelAttendance.findMany({
+          where: {
+            eventId,
+            kennelHasher: {
+              userLink: { status: "CONFIRMED", user: { attendanceVisibility: "PUBLIC" } },
+            },
           },
-        },
-        select: {
-          kennelHasher: {
-            select: {
-              userLink: {
-                select: {
-                  user: {
-                    select: {
-                      id: true,
-                      hashName: true,
-                      avatarUrl: true,
-                      clerkImageUrl: true,
-                      hideClerkImage: true,
+          select: {
+            kennelHasher: {
+              select: {
+                userLink: {
+                  select: {
+                    user: {
+                      select: {
+                        id: true,
+                        hashName: true,
+                        avatarUrl: true,
+                        clerkImageUrl: true,
+                        hideClerkImage: true,
+                      },
                     },
                   },
                 },
               },
             },
           },
-        },
-      })
-    : [];
+        }),
+      ])
+    : [[], []];
 
   const rosterEntries = showRoster
     ? assemblePastEventRoster({

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -221,7 +221,16 @@ export default async function EventDetailPage({
           where: {
             eventId,
             kennelHasher: {
-              userLink: { status: "CONFIRMED", user: { attendanceVisibility: "PUBLIC" } },
+              userLink: {
+                status: "CONFIRMED",
+                user: {
+                  attendanceVisibility: "PUBLIC",
+                  // Exclude anyone who explicitly declined this misman record
+                  // ("I wasn't there") — declineMismanAttendance writes a
+                  // DECLINED Attendance, which must suppress the public listing.
+                  attendances: { none: { eventId, status: "DECLINED" } },
+                },
+              },
             },
           },
           select: {

--- a/src/app/hareline/[eventId]/page.tsx
+++ b/src/app/hareline/[eventId]/page.tsx
@@ -199,7 +199,12 @@ export default async function EventDetailPage({
   );
   const showRoster = event.date.getTime() < todayNoonMs && !event.isSeriesParent;
 
-  // Only opted-in (PUBLIC) hashers who checked in; hares are always shown.
+  // Only opted-in (PUBLIC) hashers are listed; hares are always shown.
+  // Two attribution sources, both gated on the user's own PUBLIC visibility:
+  //   - self check-ins (Attendance — always tied to a User)
+  //   - misman-recorded (KennelAttendance), but ONLY when the roster entry is
+  //     linked to a registered User via a CONFIRMED link. An unlinked roster
+  //     name has no account and never had a way to opt in, so it's never shown.
   const rosterAttendees = showRoster
     ? await prisma.attendance.findMany({
         where: { eventId, status: "CONFIRMED", user: { attendanceVisibility: "PUBLIC" } },
@@ -212,15 +217,57 @@ export default async function EventDetailPage({
       })
     : [];
 
+  const mismanAttendees = showRoster
+    ? await prisma.kennelAttendance.findMany({
+        where: {
+          eventId,
+          kennelHasher: {
+            userLink: { status: "CONFIRMED", user: { attendanceVisibility: "PUBLIC" } },
+          },
+        },
+        select: {
+          kennelHasher: {
+            select: {
+              userLink: {
+                select: {
+                  user: {
+                    select: {
+                      id: true,
+                      hashName: true,
+                      avatarUrl: true,
+                      clerkImageUrl: true,
+                      hideClerkImage: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    : [];
+
   const rosterEntries = showRoster
     ? assemblePastEventRoster({
-        attendees: rosterAttendees.map((a) => ({
-          userId: a.userId,
-          hashName: a.user.hashName,
-          avatarUrl: a.user.avatarUrl,
-          clerkImageUrl: a.user.clerkImageUrl,
-          hideClerkImage: a.user.hideClerkImage,
-        })),
+        attendees: [
+          ...rosterAttendees.map((a) => ({
+            userId: a.userId,
+            hashName: a.user.hashName,
+            avatarUrl: a.user.avatarUrl,
+            clerkImageUrl: a.user.clerkImageUrl,
+            hideClerkImage: a.user.hideClerkImage,
+          })),
+          ...mismanAttendees
+            .map((ka) => ka.kennelHasher.userLink?.user)
+            .filter((u): u is NonNullable<typeof u> => u != null)
+            .map((u) => ({
+              userId: u.id,
+              hashName: u.hashName,
+              avatarUrl: u.avatarUrl,
+              clerkImageUrl: u.clerkImageUrl,
+              hideClerkImage: u.hideClerkImage,
+            })),
+        ],
         hares: event.hares.map((h) => ({
           userId: h.userId,
           hareName: h.hareName,

--- a/src/lib/roster.test.ts
+++ b/src/lib/roster.test.ts
@@ -45,6 +45,21 @@ describe("assemblePastEventRoster", () => {
     expect(roster[0].hareRole).toBe("CO_HARE");
   });
 
+  it("dedupes attendees by userId (same user from two sources appears once)", () => {
+    // Self check-in (Attendance) + misman-recorded (KennelAttendance) resolve to
+    // the same user — concatenated by the caller, deduped here.
+    const roster = assemblePastEventRoster({
+      attendees: [
+        { userId: "u1", hashName: "Mudflap", avatarUrl: null, clerkImageUrl: null },
+        { userId: "u1", hashName: "Mudflap", avatarUrl: null, clerkImageUrl: null },
+      ],
+      hares: [],
+    });
+    expect(roster).toHaveLength(1);
+    expect(roster[0].userId).toBe("u1");
+    expect(roster[0].isHare).toBe(false);
+  });
+
   it("dedupes: a user who both hared and checked in appears once, as a hare", () => {
     const roster = assemblePastEventRoster({
       attendees: [{ userId: "u1", hashName: "Trailblazer", avatarUrl: null, clerkImageUrl: null }],

--- a/src/lib/roster.ts
+++ b/src/lib/roster.ts
@@ -54,8 +54,13 @@ export function assemblePastEventRoster(input: {
     });
   }
 
+  // Attendees may arrive from more than one source (self check-in + misman-
+  // recorded), so dedup by userId here too — not just against hares.
+  const seenAttendee = new Set<string>();
   for (const att of input.attendees) {
     if (hareUserIds.has(att.userId)) continue; // hare credit already covers them
+    if (seenAttendee.has(att.userId)) continue;
+    seenAttendee.add(att.userId);
     entries.push({
       key: `u:${att.userId}`,
       userId: att.userId,


### PR DESCRIPTION
## What & why

Follow-up to the [#110](https://github.com/johnrclem/hashtracks-web/issues/110) "Who was there" roster (Codex's P2 from [#2277](https://github.com/johnrclem/hashtracks-web/pull/2277)).

Attendance entered through the **misman tool** writes `KennelAttendance` rows, not `Attendance` rows — so misman-tracked kennels' attendees were missing from the public roster. This includes them, without breaking the #110 opt-in privacy promise.

## Privacy model (the key decision)

A `KennelAttendance` is listed **only** when its `KennelHasher` is linked to a registered `User` via a **CONFIRMED** `KennelHasherLink` **and** that user opted **PUBLIC**. The person's own visibility preference governs regardless of who recorded the attendance.

**Unlinked roster names are never shown** — they have no account and never had a way to opt in. This is the only interpretation consistent with #110.

## Changes
- `assemblePastEventRoster` now dedups attendees by `userId` (not just against hares), so the self check-in + misman sources can be safely concatenated. (TDD: RED→GREEN.)
- Event page adds a `KennelAttendance` query gated on `userLink.status = CONFIRMED` + `user.attendanceVisibility = PUBLIC`, merged into the attendee list.

No schema change.

## Testing
- `tsc` clean, lint 0 errors, full suite green (9512 tests; +1 new roster dedup test).
- **Verified live** (local server render) against a real past event with a controlled scenario:
  - CONFIRMED-linked **PUBLIC** user with only a misman record (no self check-in) → **appears** in the roster.
  - Same user flipped to **PRIVATE** → **dropped**.
  - Link set to **SUGGESTED** (not CONFIRMED) → **dropped**.
  - Self check-in + hare paths still render and dedup correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)