### PR TITLE
feat(hareline): paginate past events backward beyond the 200-event cap

### DIFF
--- a/src/app/hareline/actions.test.ts
+++ b/src/app/hareline/actions.test.ts
@@ -353,17 +353,18 @@ describe("loadMorePastEvents cursor back-pagination", () => {
   });
 
   it("propagates real query failures (so the client's retry UI engages, not a false end-of-list)", async () => {
-    // A genuinely missing cursor returns [] (correlated-subquery cursor), but a
-    // real dependency failure must surface — it must NOT be disguised as a
+    // A genuine dependency failure must surface — it must NOT be disguised as a
     // normal archive boundary (Codex review).
     mockFindMany.mockRejectedValueOnce(new Error("db timeout"));
 
     await expect(loadMorePastEvents("cursor-id")).rejects.toThrow("db timeout");
   });
 
-  it("returns end-of-list naturally when the cursor row matches nothing (empty result)", async () => {
-    // Missing/hard-deleted cursor → correlated subquery matches no rows → [].
-    mockFindMany.mockResolvedValueOnce([] as never);
+  it("treats a missing/filtered cursor row (P2025) as a clean end-of-list", async () => {
+    // Prisma throws P2025 when the cursor row is missing OR filtered out of
+    // `where` (e.g. it became CANCELLED between fetches) — not a real failure.
+    const err = Object.assign(new Error("Record to constrain not found"), { code: "P2025" });
+    mockFindMany.mockRejectedValueOnce(err);
 
     const res = await loadMorePastEvents("ghost-id");
     expect(res).toEqual({ events: [], hasMore: false });

--- a/src/app/hareline/actions.test.ts
+++ b/src/app/hareline/actions.test.ts
@@ -16,7 +16,8 @@ vi.mock("next/cache", () => ({
 }));
 
 import { prisma } from "@/lib/db";
-import { loadEventsForTimeMode } from "./actions";
+import { loadEventsForTimeMode, loadMorePastEvents } from "./actions";
+import { PAST_EVENTS_LIMIT } from "./constants";
 
 const mockFindMany = vi.mocked(prisma.event.findMany);
 
@@ -75,7 +76,9 @@ describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
       { kennelId: { in: ["nych3"] } },
       { eventKennels: { some: { kennelId: { in: ["nych3"] } } } },
     ]);
-    expect(call?.orderBy).toEqual({ date: "desc" });
+    // Past mode carries a deterministic `id desc` tiebreak so cursor
+    // back-pagination (`loadMorePastEvents`) has a well-defined boundary.
+    expect(call?.orderBy).toEqual([{ date: "desc" }, { id: "desc" }]);
   });
 
   it("hits the same cache entry regardless of kennelIds order ([a,b] === [b,a])", async () => {
@@ -169,7 +172,7 @@ describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
       minimalEvent("ggfm-child", "external-parent", false),
     ] as never);
 
-    const result = await loadEventsForTimeMode("upcoming", NOW_MS, ["nych3"]);
+    const { events: result } = await loadEventsForTimeMode("upcoming", NOW_MS, ["nych3"]);
 
     const ids = result.map((e) => e.id);
     expect(ids).toContain("umbrella");
@@ -177,5 +180,192 @@ describe("loadEventsForTimeMode kennel-scoping (#1560 PR F)", () => {
     expect(ids).not.toContain("sat-child"); // parent IS in result → dropped
     expect(ids).not.toContain("sun-child"); // parent IS in result → dropped
     expect(result.find((e) => e.id === "umbrella")?.cost).toBe("$7"); // cost flows through slim payload
+  });
+});
+
+describe("loadEventsForTimeMode first-page hasMore (raw page fullness)", () => {
+  const minimalRow = (id: string, overrides: Record<string, unknown> = {}) => ({
+    id,
+    date: new Date("2026-05-20T12:00:00Z"),
+    dateUtc: new Date("2026-05-20T22:00:00Z"),
+    timezone: "America/New_York",
+    kennelId: "sdh3",
+    runNumber: null,
+    title: id,
+    eventLabel: null,
+    haresText: null,
+    startTime: null,
+    endTime: null,
+    locationName: null,
+    locationCity: null,
+    status: "CONFIRMED",
+    latitude: null,
+    longitude: null,
+    trailLengthText: null,
+    trailLengthMinMiles: null,
+    trailLengthMaxMiles: null,
+    difficulty: null,
+    trailType: null,
+    dogFriendly: null,
+    prelube: null,
+    cost: null,
+    isSeriesParent: false,
+    parentEventId: null,
+    endDate: null,
+    childEvents: [],
+    kennel: { id: "sdh3", shortName: "SDH3", fullName: "San Diego", slug: "sdh3", region: "CA", country: "USA" },
+    eventKennels: [],
+    ...overrides,
+  });
+
+  it("hasMore=true when the past page is full, even when dedup trims the returned length", async () => {
+    // A full raw past page where a parent + its child collapse to one.
+    const rows = [
+      minimalRow("umbrella", { isSeriesParent: true }),
+      minimalRow("child", { parentEventId: "umbrella" }),
+      ...Array.from({ length: PAST_EVENTS_LIMIT - 2 }, (_, i) => minimalRow(`s${i}`)),
+    ];
+    expect(rows).toHaveLength(PAST_EVENTS_LIMIT);
+    mockFindMany.mockResolvedValueOnce(rows as never);
+
+    const { events, hasMore } = await loadEventsForTimeMode("past", NOW_MS, ["sdh3"]);
+    // Deduped below the limit...
+    expect(events).toHaveLength(PAST_EVENTS_LIMIT - 1);
+    expect(events.map((e) => e.id)).not.toContain("child");
+    // ...but the RAW page was full, so older events may remain.
+    expect(hasMore).toBe(true);
+  });
+
+  it("hasMore=false on a short past page (end of archive)", async () => {
+    mockFindMany.mockResolvedValueOnce([minimalRow("e1"), minimalRow("e2")] as never);
+
+    const { hasMore } = await loadEventsForTimeMode("past", NOW_MS);
+    expect(hasMore).toBe(false);
+  });
+});
+
+describe("loadMorePastEvents cursor back-pagination", () => {
+  const minimalRow = (id: string, overrides: Record<string, unknown> = {}) => ({
+    id,
+    date: new Date("2026-03-15T12:00:00Z"),
+    dateUtc: new Date("2026-03-15T22:00:00Z"),
+    timezone: "America/New_York",
+    kennelId: "sdh3",
+    runNumber: null,
+    title: id,
+    eventLabel: null,
+    haresText: null,
+    startTime: null,
+    endTime: null,
+    locationName: null,
+    locationCity: null,
+    status: "CONFIRMED",
+    latitude: null,
+    longitude: null,
+    trailLengthText: null,
+    trailLengthMinMiles: null,
+    trailLengthMaxMiles: null,
+    difficulty: null,
+    trailType: null,
+    dogFriendly: null,
+    prelube: null,
+    cost: null,
+    isSeriesParent: false,
+    parentEventId: null,
+    endDate: null,
+    childEvents: [],
+    kennel: { id: "sdh3", shortName: "SDH3", fullName: "San Diego", slug: "sdh3", region: "CA", country: "USA" },
+    eventKennels: [],
+    ...overrides,
+  });
+
+  it("queries with cursor, skip:1, take:PAST_EVENTS_LIMIT and compound desc order", async () => {
+    await loadMorePastEvents("cursor-id");
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    const call = mockFindMany.mock.calls[0][0];
+    expect(call?.cursor).toEqual({ id: "cursor-id" });
+    expect(call?.skip).toBe(1);
+    expect(call?.take).toBe(PAST_EVENTS_LIMIT);
+    expect(call?.orderBy).toEqual([{ date: "desc" }, { id: "desc" }]);
+  });
+
+  it("unfiltered cursor query keeps parentEventId:null + a past date ceiling, no OR", async () => {
+    await loadMorePastEvents("cursor-id");
+
+    const where = mockFindMany.mock.calls[0][0]?.where as Record<string, unknown>;
+    expect(where).toHaveProperty("parentEventId", null);
+    expect(where).not.toHaveProperty("OR");
+    const dateFilter = where.date as { lt?: Date };
+    expect(dateFilter.lt).toBeInstanceOf(Date); // past ceiling, mirrors page one
+  });
+
+  it("kennel-scoped cursor query drops parentEventId:null and adds kennel OR-match", async () => {
+    await loadMorePastEvents("cursor-id", ["sdh3"]);
+
+    const where = mockFindMany.mock.calls[0][0]?.where as Record<string, unknown>;
+    expect(where).not.toHaveProperty("parentEventId");
+    expect(where.OR).toEqual([
+      { kennelId: { in: ["sdh3"] } },
+      { eventKennels: { some: { kennelId: { in: ["sdh3"] } } } },
+    ]);
+  });
+
+  it("returns the slim mapped shape (date → ISO string, dateUtc → Date)", async () => {
+    mockFindMany.mockResolvedValueOnce([minimalRow("e1")] as never);
+
+    const { events } = await loadMorePastEvents("cursor-id");
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe("e1");
+    expect(events[0].date).toBe("2026-03-15T12:00:00.000Z");
+    expect(events[0].dateUtc).toBeInstanceOf(Date);
+  });
+
+  it("hasMore=true on a full raw page even when dedup trims the returned length", async () => {
+    // A full page where a parent + its child collapse to one returned row.
+    const rows = [
+      minimalRow("umbrella", { isSeriesParent: true }),
+      minimalRow("child", { parentEventId: "umbrella" }),
+      ...Array.from({ length: PAST_EVENTS_LIMIT - 2 }, (_, i) => minimalRow(`s${i}`)),
+    ];
+    expect(rows).toHaveLength(PAST_EVENTS_LIMIT);
+    mockFindMany.mockResolvedValueOnce(rows as never);
+
+    const { events, hasMore } = await loadMorePastEvents("cursor-id", ["sdh3"]);
+    // child deduped out (parent present) → one fewer than the raw page...
+    expect(events).toHaveLength(PAST_EVENTS_LIMIT - 1);
+    expect(events.map((e) => e.id)).not.toContain("child");
+    // ...but hasMore stays true because the RAW page was full.
+    expect(hasMore).toBe(true);
+  });
+
+  it("hasMore=false on a short page (end of archive)", async () => {
+    mockFindMany.mockResolvedValueOnce([minimalRow("e1"), minimalRow("e2")] as never);
+
+    const { hasMore } = await loadMorePastEvents("cursor-id");
+    expect(hasMore).toBe(false);
+  });
+
+  it("empty cursorId short-circuits with no query", async () => {
+    const res = await loadMorePastEvents("");
+    expect(res).toEqual({ events: [], hasMore: false });
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("propagates real query failures (so the client's retry UI engages, not a false end-of-list)", async () => {
+    // A genuinely missing cursor returns [] (correlated-subquery cursor), but a
+    // real dependency failure must surface — it must NOT be disguised as a
+    // normal archive boundary (Codex review).
+    mockFindMany.mockRejectedValueOnce(new Error("db timeout"));
+
+    await expect(loadMorePastEvents("cursor-id")).rejects.toThrow("db timeout");
+  });
+
+  it("returns end-of-list naturally when the cursor row matches nothing (empty result)", async () => {
+    // Missing/hard-deleted cursor → correlated subquery matches no rows → [].
+    mockFindMany.mockResolvedValueOnce([] as never);
+
+    const res = await loadMorePastEvents("ghost-id");
+    expect(res).toEqual({ events: [], hasMore: false });
   });
 });

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -17,12 +17,16 @@
  */
 
 import { unstable_cache } from "next/cache";
+import type { Prisma } from "@/generated/prisma/client";
 import { prisma } from "@/lib/db";
-import { DISPLAY_EVENT_WHERE } from "@/lib/event-filters";
+import { DISPLAY_EVENT_WHERE, DISPLAYABLE_EVENT_NO_PARENT_WHERE } from "@/lib/event-filters";
 // Tag constant lives in a plain module — a `"use server"` file can only
 // export async functions, so any non-function export (even a string)
 // makes Next strip all exports and fail the build at import sites.
 import { HARELINE_EVENTS_TAG } from "@/lib/cache-tags";
+// PAST_EVENTS_LIMIT lives in a plain module for the same reason — both this
+// `"use server"` file and the client component import it.
+import { PAST_EVENTS_LIMIT } from "./constants";
 
 /** Matches the slim shape rendered by EventCard's list view. */
 interface HarelineKennelLite {
@@ -103,11 +107,9 @@ export interface HarelineChildEvent {
 
 export type TimeMode = "upcoming" | "past";
 
-/**
- * Past events are capped server-side to keep the payload bounded — 200 is
- * enough to fill several scroll pages while staying under ~400 KB wire.
- */
-const PAST_EVENTS_LIMIT = 200;
+// PAST_EVENTS_LIMIT (the server-side cap on the first past payload and the
+// cursor page size for `loadMorePastEvents`) is imported from `./constants`
+// so the client component can share the exact value.
 
 /**
  * Global (unfiltered) upcoming events cap. The full upcoming set exceeds
@@ -155,6 +157,209 @@ interface CachedHarelineChildEvent extends Omit<HarelineChildEvent, "dateUtc"> {
 }
 
 /**
+ * Slim field set rendered by EventCard's list view. Extracted to a module
+ * const (typed via `satisfies`) so the cached first-page query and the
+ * cursor-paginated `loadMorePastEvents` query share an identical projection —
+ * the two paths can't drift, and `mapRowToCachedEvent` types its input off
+ * this exact shape.
+ */
+const HARELINE_EVENT_SELECT = {
+  id: true,
+  date: true,
+  dateUtc: true,
+  timezone: true,
+  kennelId: true,
+  runNumber: true,
+  title: true,
+  eventLabel: true,
+  haresText: true,
+  startTime: true,
+  endTime: true,
+  locationName: true,
+  locationCity: true,
+  status: true,
+  latitude: true,
+  longitude: true,
+  trailLengthText: true,
+  trailLengthMinMiles: true,
+  trailLengthMaxMiles: true,
+  difficulty: true,
+  trailType: true,
+  dogFriendly: true,
+  prelube: true,
+  cost: true,
+  // #1560 — multi-day series metadata + inline children list.
+  isSeriesParent: true,
+  parentEventId: true,
+  endDate: true,
+  childEvents: {
+    where: {
+      // Mirror DISPLAY_EVENT_WHERE's visibility predicates on the
+      // child set (parentEventId stays unset here — children all have
+      // it pointing to this row).
+      status: { not: "CANCELLED" },
+      isManualEntry: { not: true },
+      isCanonical: true,
+      kennel: { isHidden: false },
+    },
+    orderBy: { date: "asc" },
+    select: {
+      id: true,
+      date: true,
+      dateUtc: true,
+      timezone: true,
+      title: true,
+      haresText: true,
+      startTime: true,
+      status: true,
+      locationName: true,
+      runNumber: true,
+    },
+  },
+  kennel: {
+    select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },
+  },
+  // Co-hosts (#1023 step 5) — drives the EventCard conjunction
+  // ("Cherry City × OH3"). Empty array for single-kennel events,
+  // which is the common case.
+  eventKennels: {
+    where: { isPrimary: false },
+    select: {
+      kennel: { select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true } },
+    },
+    orderBy: { kennel: { shortName: "asc" } },
+  },
+} satisfies Prisma.EventSelect;
+
+/** Row type produced by `HARELINE_EVENT_SELECT`. */
+type HarelineEventRow = Prisma.EventGetPayload<{ select: typeof HARELINE_EVENT_SELECT }>;
+
+/**
+ * Normalize a kennel-filter list into the stable, bounded form used both for
+ * cache keys and Prisma `IN` clauses (#1560 PR F):
+ *  - trim each ID (URL decoders leave stray whitespace)
+ *  - drop empties (`?kennels=a,,b`) and dedupe (`?kennels=a&kennels=a`)
+ *  - sort with `localeCompare` so `[a,b]` and `[b,a]` canonicalize equal
+ *  - cap at `MAX_KENNEL_FILTER_IDS` (sort BEFORE slice so the dropped tail is
+ *    deterministic regardless of input order)
+ */
+function normalizeKennelIds(kennelIds?: ReadonlyArray<string>): string[] {
+  return [
+    ...new Set((kennelIds ?? []).map((id) => id.trim()).filter(Boolean)),
+  ]
+    .sort((a, b) => a.localeCompare(b))
+    .slice(0, MAX_KENNEL_FILTER_IDS);
+}
+
+/**
+ * Build the Hareline visibility `where` for a given date bound + kennel filter.
+ *
+ * #1560 PR F — kennel-scoped fetches must include series children whose primary
+ * kennel matches the filter (e.g. GGFM Friday Strawberry Moon, a child of
+ * NYCH3's 5-Boro umbrella). When unfiltered, the `parentEventId: null`
+ * exclusion (baked into `DISPLAY_EVENT_WHERE`) keeps children inside their
+ * parent's expanded timeline only. When filtered, swap to the predicate set
+ * without that exclusion (`DISPLAYABLE_EVENT_NO_PARENT_WHERE`) and OR-match on
+ * kennel so parents AND children whose own kennel matches both surface.
+ */
+function buildHarelineWhere(
+  dateFilter: Prisma.EventWhereInput["date"],
+  kennelIds: string[],
+): Prisma.EventWhereInput {
+  if (kennelIds.length === 0) {
+    return { ...DISPLAY_EVENT_WHERE, date: dateFilter };
+  }
+  return {
+    ...DISPLAYABLE_EVENT_NO_PARENT_WHERE,
+    date: dateFilter,
+    OR: [
+      { kennelId: { in: kennelIds } },
+      { eventKennels: { some: { kennelId: { in: kennelIds } } } },
+    ],
+  };
+}
+
+/**
+ * #1560 PR F — when both a series parent AND its children land in the result
+ * (kennel-filtered query where the umbrella's host kennel matches, e.g. NYCH3
+ * viewing `/hareline?kennels=nych3-id` sees the 5-Boro umbrella + its Sat/Sun
+ * children), drop the children from the top-level list. They still appear in
+ * the parent's expanded timeline via `childEvents`; without this the same
+ * trail renders twice on one scroll page (Gemini PR #1712 review). When the
+ * parent is NOT in the result (GGFM viewing `?kennels=ggfm-id` sees only
+ * Friday's child of the NYCH3-hosted umbrella), the child correctly stays at
+ * the top level since the set doesn't contain its parentEventId.
+ */
+function dedupeSeriesChildren(events: HarelineEventRow[]): HarelineEventRow[] {
+  const idsInResult = new Set(events.map((e) => e.id));
+  return events.filter((e) => !e.parentEventId || !idsInResult.has(e.parentEventId));
+}
+
+/** Map a Prisma row into the JSON-safe cache shape (dates → ISO strings). */
+function mapRowToCachedEvent(e: HarelineEventRow): CachedHarelineEvent {
+  return {
+    id: e.id,
+    date: e.date.toISOString(),
+    dateUtc: e.dateUtc ? e.dateUtc.toISOString() : null,
+    timezone: e.timezone,
+    kennelId: e.kennelId,
+    kennel: e.kennel,
+    coHosts: e.eventKennels.map((ek) => ek.kennel),
+    runNumber: e.runNumber,
+    title: e.title,
+    eventLabel: e.eventLabel,
+    haresText: e.haresText,
+    startTime: e.startTime,
+    endTime: e.endTime,
+    locationName: e.locationName,
+    locationCity: e.locationCity,
+    status: e.status,
+    latitude: e.latitude ?? null,
+    longitude: e.longitude ?? null,
+    trailLengthText: e.trailLengthText,
+    trailLengthMinMiles: e.trailLengthMinMiles,
+    trailLengthMaxMiles: e.trailLengthMaxMiles,
+    difficulty: e.difficulty,
+    trailType: e.trailType,
+    dogFriendly: e.dogFriendly,
+    prelube: e.prelube,
+    cost: e.cost,
+    isSeriesParent: e.isSeriesParent,
+    parentEventId: e.parentEventId,
+    endDate: e.endDate ? e.endDate.toISOString() : null,
+    childEvents: e.childEvents.map((c) => ({
+      id: c.id,
+      date: c.date.toISOString(),
+      dateUtc: c.dateUtc ? c.dateUtc.toISOString() : null,
+      timezone: c.timezone,
+      title: c.title,
+      haresText: c.haresText,
+      startTime: c.startTime,
+      status: c.status,
+      locationName: c.locationName,
+      runNumber: c.runNumber,
+    })),
+  };
+}
+
+/**
+ * Rehydrate `dateUtc` from ISO string back to `Date` at the cache boundary.
+ * Keeps `HarelineListEvent` stable across the project so consumers
+ * (EventCard/EventDetailPanel/CalendarView/kennel page) don't learn about the
+ * cache shape. Used by both the cached path and the uncached load-more path.
+ */
+function rehydrateCachedEvent(e: CachedHarelineEvent): HarelineListEvent {
+  return {
+    ...e,
+    dateUtc: e.dateUtc ? new Date(e.dateUtc) : null,
+    childEvents: e.childEvents.map((c) => ({
+      ...c,
+      dateUtc: c.dateUtc ? new Date(c.dateUtc) : null,
+    })),
+  };
+}
+
+/**
  * Cached inner: pure function of `(mode, todayDateStr)`.
  *
  * Cache key parts, chosen so hit/miss behavior matches user intent:
@@ -183,7 +388,7 @@ const fetchSlimEventsCached = unstable_cache(
     mode: TimeMode,
     todayDateStr: string,
     kennelIdsKey: string,
-  ): Promise<CachedHarelineEvent[]> => {
+  ): Promise<{ events: CachedHarelineEvent[]; hasMore: boolean }> => {
     // Reconstruct UTC boundaries from the date string so the cached function
     // is a pure function of its args. (No reading Date.now() here —
     // that would invalidate the cache contract.)
@@ -205,30 +410,12 @@ const fetchSlimEventsCached = unstable_cache(
     const tomorrowUtc = new Date(startOfTodayUtc.getTime() + 24 * 60 * 60 * 1000);
     const isPast = mode === "past";
 
-    // #1560 PR F — kennel-scoped fetches must include series children whose
-    // primary kennel matches the filter (e.g. GGFM Friday Strawberry Moon,
-    // a child of NYCH3's 5-Boro umbrella). When unfiltered, the original
-    // `parentEventId: null` exclusion stays so children only render inside
-    // their parent's expanded timeline. When filtered, swap the exclusion
-    // for a kennel OR-match: parents whose own kennel matches AND children
-    // whose own kennel matches both surface.
-    //
-    // Destructure `parentEventId` out of `DISPLAY_EVENT_WHERE` and reuse the
-    // remaining visibility predicates verbatim so the two branches can't drift
-    // (mirrors `getEventDetail` below). Gemini PR review #1712.
+    // The kennel filter is already normalized into the cache key, so split it
+    // back into an array here. `buildHarelineWhere` handles the unfiltered vs
+    // kennel-scoped visibility predicates (#1560 PR F).
     const kennelIds = kennelIdsKey ? kennelIdsKey.split(",") : [];
     const dateFilter = isPast ? { lt: tomorrowUtc } : { gte: yesterdayUtc };
-    const { parentEventId: _excluded, ...visibilityWhere } = DISPLAY_EVENT_WHERE;
-    const where = kennelIds.length === 0
-      ? { ...DISPLAY_EVENT_WHERE, date: dateFilter }
-      : {
-          ...visibilityWhere,
-          date: dateFilter,
-          OR: [
-            { kennelId: { in: kennelIds } },
-            { eventKennels: { some: { kennelId: { in: kennelIds } } } },
-          ],
-        };
+    const where = buildHarelineWhere(dateFilter, kennelIds);
 
     let queryLimit: number;
     if (isPast) {
@@ -239,141 +426,29 @@ const fetchSlimEventsCached = unstable_cache(
       queryLimit = UPCOMING_KENNEL_LIMIT;
     }
 
-    const events = await prisma.event.findMany({
+    // Past mode paginates backward by cursor (`loadMorePastEvents`), which
+    // requires a deterministic, unique tiebreak so "everything after this id"
+    // is well-defined. Add `id desc` for past; upcoming keeps `date asc`.
+    const rows = await prisma.event.findMany({
       where,
-      select: {
-        id: true,
-        date: true,
-        dateUtc: true,
-        timezone: true,
-        kennelId: true,
-        runNumber: true,
-        title: true,
-        eventLabel: true,
-        haresText: true,
-        startTime: true,
-        endTime: true,
-        locationName: true,
-        locationCity: true,
-        status: true,
-        latitude: true,
-        longitude: true,
-        trailLengthText: true,
-        trailLengthMinMiles: true,
-        trailLengthMaxMiles: true,
-        difficulty: true,
-        trailType: true,
-        dogFriendly: true,
-        prelube: true,
-        cost: true,
-        // #1560 — multi-day series metadata + inline children list.
-        isSeriesParent: true,
-        parentEventId: true,
-        endDate: true,
-        childEvents: {
-          where: {
-            // Mirror DISPLAY_EVENT_WHERE's visibility predicates on the
-            // child set (parentEventId stays unset here — children all have
-            // it pointing to this row).
-            status: { not: "CANCELLED" },
-            isManualEntry: { not: true },
-            isCanonical: true,
-            kennel: { isHidden: false },
-          },
-          orderBy: { date: "asc" },
-          select: {
-            id: true,
-            date: true,
-            dateUtc: true,
-            timezone: true,
-            title: true,
-            haresText: true,
-            startTime: true,
-            status: true,
-            locationName: true,
-            runNumber: true,
-          },
-        },
-        kennel: {
-          select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true },
-        },
-        // Co-hosts (#1023 step 5) — drives the EventCard conjunction
-        // ("Cherry City × OH3"). Empty array for single-kennel events,
-        // which is the common case.
-        eventKennels: {
-          where: { isPrimary: false },
-          select: {
-            kennel: { select: { id: true, shortName: true, fullName: true, slug: true, region: true, country: true } },
-          },
-          orderBy: { kennel: { shortName: "asc" } },
-        },
-      },
-      orderBy: { date: isPast ? "desc" : "asc" },
+      select: HARELINE_EVENT_SELECT,
+      orderBy: isPast ? [{ date: "desc" }, { id: "desc" }] : { date: "asc" },
       take: queryLimit,
     });
 
-    // #1560 PR F — when both a series parent AND its children are returned
-    // (kennel-filtered query where the umbrella's host kennel matches the
-    // filter, e.g. NYCH3 viewing `/hareline?kennels=nych3-id` sees the 5-Boro
-    // umbrella + its Sat/Sun children), drop the children from the top-level
-    // list. They still appear in the parent's expanded timeline via
-    // `childEvents`. Without this dedup, the same trail renders twice on the
-    // same scroll page (Gemini PR #1712 review). When the parent is NOT in
-    // the result (GGFM viewing /hareline?kennels=ggfm-id sees only Friday's
-    // child of the NYCH3-hosted umbrella), the child correctly stays at the
-    // top level since `parentIdsInResult` doesn't contain its parentEventId.
-    const idsInResult = new Set(events.map((e) => e.id));
-    const visibleEvents = events.filter(
-      (e) => !e.parentEventId || !idsInResult.has(e.parentEventId),
-    );
-
-    return visibleEvents.map((e) => ({
-      id: e.id,
-      date: e.date.toISOString(),
-      dateUtc: e.dateUtc ? e.dateUtc.toISOString() : null,
-      timezone: e.timezone,
-      kennelId: e.kennelId,
-      kennel: e.kennel,
-      coHosts: e.eventKennels.map((ek) => ek.kennel),
-      runNumber: e.runNumber,
-      title: e.title,
-      eventLabel: e.eventLabel,
-      haresText: e.haresText,
-      startTime: e.startTime,
-      endTime: e.endTime,
-      locationName: e.locationName,
-      locationCity: e.locationCity,
-      status: e.status,
-      latitude: e.latitude ?? null,
-      longitude: e.longitude ?? null,
-      trailLengthText: e.trailLengthText,
-      trailLengthMinMiles: e.trailLengthMinMiles,
-      trailLengthMaxMiles: e.trailLengthMaxMiles,
-      difficulty: e.difficulty,
-      trailType: e.trailType,
-      dogFriendly: e.dogFriendly,
-      prelube: e.prelube,
-      cost: e.cost,
-      isSeriesParent: e.isSeriesParent,
-      parentEventId: e.parentEventId,
-      endDate: e.endDate ? e.endDate.toISOString() : null,
-      childEvents: e.childEvents.map((c) => ({
-        id: c.id,
-        date: c.date.toISOString(),
-        dateUtc: c.dateUtc ? c.dateUtc.toISOString() : null,
-        timezone: c.timezone,
-        title: c.title,
-        haresText: c.haresText,
-        startTime: c.startTime,
-        status: c.status,
-        locationName: c.locationName,
-        runNumber: c.runNumber,
-      })),
-    }));
+    // `hasMore` is derived from the RAW page size (before series-child dedup) so
+    // a full DB page that dedup shrinks below the limit — possible only in the
+    // kennel-filtered branch, where children can be fetched — still signals that
+    // older events remain. Without this, the client's first-page "Load older"
+    // affordance could be hidden mid-archive (Codex review). The flag is only
+    // consumed for past mode; for upcoming it just reflects cap saturation.
+    const hasMore = rows.length >= queryLimit;
+    return { events: dedupeSeriesChildren(rows).map(mapRowToCachedEvent), hasMore };
   },
-  // Include limit values in the static key so a constant change automatically
-  // busts stale cache entries rather than serving old-sized payloads until TTL.
-  [`hareline:events:g${UPCOMING_GLOBAL_LIMIT}k${UPCOMING_KENNEL_LIMIT}`],
+  // Include limit values + a payload-shape version in the static key so a
+  // constant change OR a return-shape change (array → { events, hasMore })
+  // auto-busts stale cache entries rather than serving an incompatible payload.
+  [`hareline:events:v2:g${UPCOMING_GLOBAL_LIMIT}k${UPCOMING_KENNEL_LIMIT}`],
   { tags: [HARELINE_EVENTS_TAG], revalidate: 3600 },
 );
 
@@ -400,47 +475,94 @@ const fetchSlimEventsCached = unstable_cache(
  * Uses `select` (not `include`) so heavy fields (description, sourceUrl,
  * locationStreet, locationAddress, eventLinks) never leave Postgres — they
  * stream lazily via `getEventDetail` when a card is expanded.
+ *
+ * Returns `{ events, hasMore }`. `hasMore` reflects raw page fullness (see
+ * `fetchSlimEventsCached`); the client uses it to seed past-tab back-pagination
+ * so the "Load older events" affordance survives series-child dedup shrinkage.
+ * It is meaningless for upcoming (no back-pagination there).
  */
 export async function loadEventsForTimeMode(
   mode: TimeMode,
   nowMs?: number,
   kennelIds?: ReadonlyArray<string>,
-): Promise<HarelineListEvent[]> {
+): Promise<{ events: HarelineListEvent[]; hasMore: boolean }> {
   // YYYY-MM-DD in UTC — the cache key that rotates at UTC midnight.
   const todayDateStr = new Date(nowMs ?? Date.now()).toISOString().slice(0, 10);
 
-  // #1560 PR F — normalize the kennel filter into a stable cache key.
-  // - Trim each ID (URL decoders sometimes leave stray whitespace)
-  // - Drop empties (e.g. `?kennels=a,,b`)
-  // - Dedupe (e.g. `?kennels=a&kennels=a`) so the cache key is canonical
-  //   regardless of how callers compose the URL
-  // - Cap at MAX_KENNEL_FILTER_IDS to bound cache cardinality + Prisma `IN`
-  //   list size against pathological inputs (CodeRabbit PR #1712 review)
-  // - Sort with `localeCompare` so [a,b] and [b,a] hit the same cache entry
-  //   (Sonar S2871). Empty string when no filter — a distinct cache entry
-  //   from any kennel-filtered key (the 3-arg signature is new in PR F, so
-  //   the unfiltered path cold-starts once on deploy regardless).
-  // Sort BEFORE slice so the canonical first-N is stable regardless of
-  // input order — [z,a] and [a,z] with 51 IDs must drop the same 51st element.
-  const normalizedKennelIds = [
-    ...new Set((kennelIds ?? []).map((id) => id.trim()).filter(Boolean)),
-  ].sort((a, b) => a.localeCompare(b)).slice(0, MAX_KENNEL_FILTER_IDS);
-  const kennelIdsKey = normalizedKennelIds.join(",");
+  // #1560 PR F — normalize the kennel filter into a stable cache key
+  // (trim / drop-empty / dedupe / sort / cap). See `normalizeKennelIds`.
+  const kennelIdsKey = normalizeKennelIds(kennelIds).join(",");
 
-  const cached = await fetchSlimEventsCached(mode, todayDateStr, kennelIdsKey);
+  const { events, hasMore } = await fetchSlimEventsCached(mode, todayDateStr, kennelIdsKey);
 
-  // Rehydrate `dateUtc` from ISO string back to `Date` at the cache
-  // boundary. Keeps `HarelineListEvent` stable across the project so
-  // EventCard/EventDetailPanel/CalendarView/kennel page don't need to
-  // learn about the cache shape.
-  return cached.map((e) => ({
-    ...e,
-    dateUtc: e.dateUtc ? new Date(e.dateUtc) : null,
-    childEvents: e.childEvents.map((c) => ({
-      ...c,
-      dateUtc: c.dateUtc ? new Date(c.dateUtc) : null,
-    })),
-  }));
+  // Rehydrate `dateUtc` from ISO string back to `Date` at the cache boundary.
+  return { events: events.map(rehydrateCachedEvent), hasMore };
+}
+
+/**
+ * Cursor-paginated "load older past events" — lets the Hareline past tab scroll
+ * back beyond the first `PAST_EVENTS_LIMIT` page.
+ *
+ * The first past page is served (and cached) by `loadEventsForTimeMode("past")`,
+ * newest-first. To look further back, the client passes the id of the oldest
+ * event it currently holds (`cursorId`); this returns the next
+ * `PAST_EVENTS_LIMIT` older events strictly after that cursor.
+ *
+ * Uncached on purpose: deep-history pages are cold, and a per-cursor cache key
+ * would explode the key space for no hit-rate benefit. The hot first page stays
+ * cached. Ordering MUST match the first page (`[date desc, id desc]`) so the
+ * cursor boundary lines up exactly with where the buffer ends.
+ *
+ * `kennelIds` MUST match the scoping that produced the client's buffer — the
+ * URL `?kennels=` filter for an SSR-loaded past buffer, or empty for a buffer
+ * loaded by the lazy tab-toggle (which fetches unfiltered). The client tracks
+ * which one applies and passes it through so the cursor and the appended page
+ * share a single ordering.
+ *
+ * Returns `{ events, hasMore }`. `hasMore` is derived from the **raw** page
+ * size (before series-child dedup) so a full DB page that dedup shrinks below
+ * `PAST_EVENTS_LIMIT` (a parent + child collapsing to one, possible only in the
+ * kennel-filtered branch) doesn't prematurely report end-of-list.
+ *
+ * A genuinely vanished cursor row (hard-deleted between fetches) yields an empty
+ * result naturally — Prisma's cursor is a correlated subquery, so a missing id
+ * matches no rows → `{ events: [], hasMore: false }`. Real failures (DB timeout,
+ * connectivity, schema drift) are intentionally NOT caught: they propagate so
+ * the client's `pastServerError` retry UI engages instead of disguising a
+ * dependency failure as a normal archive boundary (Codex review).
+ */
+export async function loadMorePastEvents(
+  cursorId: string,
+  kennelIds?: ReadonlyArray<string>,
+): Promise<{ events: HarelineListEvent[]; hasMore: boolean }> {
+  if (!cursorId) return { events: [], hasMore: false };
+
+  // Past ceiling `< tomorrow 00:00 UTC` mirrors the first-page bound. The
+  // cursor already restricts results to events older than it, so this is a
+  // belt-and-suspenders ceiling that keeps the `where` identical to page one.
+  const todayDateStr = new Date().toISOString().slice(0, 10);
+  const startOfTodayUtc = new Date(`${todayDateStr}T00:00:00.000Z`);
+  const tomorrowUtc = new Date(startOfTodayUtc.getTime() + 24 * 60 * 60 * 1000);
+
+  const normalizedKennelIds = normalizeKennelIds(kennelIds);
+  const where = buildHarelineWhere({ lt: tomorrowUtc }, normalizedKennelIds);
+
+  // No try/catch: a missing cursor row returns [] (correlated-subquery cursor),
+  // and genuine failures must surface to the client's retry UI rather than be
+  // swallowed as end-of-list (Codex review).
+  const rows = await prisma.event.findMany({
+    where,
+    select: HARELINE_EVENT_SELECT,
+    orderBy: [{ date: "desc" }, { id: "desc" }],
+    cursor: { id: cursorId },
+    skip: 1, // exclude the cursor row itself (already shown by the client)
+    take: PAST_EVENTS_LIMIT,
+  });
+  // `hasMore` off the raw count — a full page implies older events remain,
+  // even if dedup trims this page's returned length.
+  const hasMore = rows.length >= PAST_EVENTS_LIMIT;
+  const events = dedupeSeriesChildren(rows).map(mapRowToCachedEvent).map(rehydrateCachedEvent);
+  return { events, hasMore };
 }
 
 export interface EventDetailFields {

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -524,12 +524,16 @@ export async function loadEventsForTimeMode(
  * `PAST_EVENTS_LIMIT` (a parent + child collapsing to one, possible only in the
  * kennel-filtered branch) doesn't prematurely report end-of-list.
  *
- * A genuinely vanished cursor row (hard-deleted between fetches) yields an empty
- * result naturally — Prisma's cursor is a correlated subquery, so a missing id
- * matches no rows → `{ events: [], hasMore: false }`. Real failures (DB timeout,
- * connectivity, schema drift) are intentionally NOT caught: they propagate so
- * the client's `pastServerError` retry UI engages instead of disguising a
- * dependency failure as a normal archive boundary (Codex review).
+ * Error handling is deliberately narrow. Prisma's `cursor` does a lookup on the
+ * cursor row and throws `P2025` when it is missing OR filtered out by `where` —
+ * the latter is routine here, since `reconcile` flips a removed event to
+ * CANCELLED (excluded by `DISPLAY_EVENT_WHERE`) and the cursor is the client's
+ * oldest-held event. Both cases mean "no defined position to continue from", so
+ * they resolve to `{ events: [], hasMore: false }` (a clean archive boundary;
+ * the user can refresh for a fresh buffer). Every OTHER error (DB timeout,
+ * connectivity, schema drift) propagates so the client's `pastServerError`
+ * retry UI engages instead of disguising a dependency failure as end-of-list
+ * (Gemini / Codex review).
  */
 export async function loadMorePastEvents(
   cursorId: string,
@@ -547,17 +551,24 @@ export async function loadMorePastEvents(
   const normalizedKennelIds = normalizeKennelIds(kennelIds);
   const where = buildHarelineWhere({ lt: tomorrowUtc }, normalizedKennelIds);
 
-  // No try/catch: a missing cursor row returns [] (correlated-subquery cursor),
-  // and genuine failures must surface to the client's retry UI rather than be
-  // swallowed as end-of-list (Codex review).
-  const rows = await prisma.event.findMany({
-    where,
-    select: HARELINE_EVENT_SELECT,
-    orderBy: [{ date: "desc" }, { id: "desc" }],
-    cursor: { id: cursorId },
-    skip: 1, // exclude the cursor row itself (already shown by the client)
-    take: PAST_EVENTS_LIMIT,
-  });
+  let rows: HarelineEventRow[];
+  try {
+    rows = await prisma.event.findMany({
+      where,
+      select: HARELINE_EVENT_SELECT,
+      orderBy: [{ date: "desc" }, { id: "desc" }],
+      cursor: { id: cursorId },
+      skip: 1, // exclude the cursor row itself (already shown by the client)
+      take: PAST_EVENTS_LIMIT,
+    });
+  } catch (err) {
+    // Cursor row missing or filtered out of `where` (e.g. it became CANCELLED
+    // between fetches) → P2025. Treat as a clean end-of-list, not an error.
+    if (err && typeof err === "object" && "code" in err && err.code === "P2025") {
+      return { events: [], hasMore: false };
+    }
+    throw err; // genuine DB failures still surface to the retry UI
+  }
   // `hasMore` off the raw count — a full page implies older events remain,
   // even if dedup trims this page's returned length.
   const hasMore = rows.length >= PAST_EVENTS_LIMIT;

--- a/src/app/hareline/actions.ts
+++ b/src/app/hareline/actions.ts
@@ -445,10 +445,11 @@ const fetchSlimEventsCached = unstable_cache(
     const hasMore = rows.length >= queryLimit;
     return { events: dedupeSeriesChildren(rows).map(mapRowToCachedEvent), hasMore };
   },
-  // Include limit values + a payload-shape version in the static key so a
-  // constant change OR a return-shape change (array → { events, hasMore })
-  // auto-busts stale cache entries rather than serving an incompatible payload.
-  [`hareline:events:v2:g${UPCOMING_GLOBAL_LIMIT}k${UPCOMING_KENNEL_LIMIT}`],
+  // Include ALL limit values + a payload-shape version in the static key so any
+  // limit change (incl. the past page size) OR a return-shape change
+  // (array → { events, hasMore }) auto-busts stale cache entries rather than
+  // serving an incompatible/old-sized payload (CodeRabbit review).
+  [`hareline:events:v2:g${UPCOMING_GLOBAL_LIMIT}k${UPCOMING_KENNEL_LIMIT}p${PAST_EVENTS_LIMIT}`],
   { tags: [HARELINE_EVENTS_TAG], revalidate: 3600 },
 );
 

--- a/src/app/hareline/constants.ts
+++ b/src/app/hareline/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Hareline constants shared between the server action layer (`actions.ts`)
+ * and the client component (`HarelineView.tsx`).
+ *
+ * Lives in a plain module — `actions.ts` is `"use server"`, which may only
+ * export async functions, so a shared numeric constant can't live there
+ * without breaking the build. Keeping it here lets both sides agree on the
+ * past-page size with no magic-number drift.
+ */
+
+/**
+ * Past events fetched per page. Doubles as (1) the server-side cap on the
+ * first past payload (`fetchSlimEventsCached`) and (2) the cursor page size
+ * for `loadMorePastEvents`. The server compares the RAW (pre-dedup) row count
+ * against this limit to compute the `hasMore` flag it returns to the client —
+ * the client never re-derives fullness from its (possibly dedup-shrunk)
+ * event array length.
+ */
+export const PAST_EVENTS_LIMIT = 200;

--- a/src/app/hareline/page.tsx
+++ b/src/app/hareline/page.tsx
@@ -106,7 +106,7 @@ async function HarelineData({
   // primary kennel matches the filter (excluded from the default unfiltered
   // payload because the global hareline still uses `parentEventId: null`)
   // never reached the client.
-  const [events, user] = await Promise.all([
+  const [{ events, hasMore: initialHasMore }, user] = await Promise.all([
     loadEventsForTimeMode(initialTimeMode, nowMs, initialKennelIds),
     getOrCreateUser(),
   ]);
@@ -152,6 +152,8 @@ async function HarelineData({
     <HarelineView
       events={events}
       initialTimeMode={initialTimeMode}
+      initialKennelIds={initialKennelIds}
+      initialHasMore={initialHasMore}
       serverNowMs={nowMs}
       subscribedKennelIds={subscribedKennelIds}
       isAuthenticated={!!user}

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -288,6 +288,22 @@ function dropLoadedSeriesChildren(events: HarelineEvent[]): HarelineEvent[] {
   if (!events.some((e) => e.parentEventId)) return events;
   const ids = new Set(events.map((e) => e.id));
   return events.filter((e) => !e.parentEventId || !ids.has(e.parentEventId));
+}
+
+/**
+ * Append a freshly fetched older-past page onto the existing buffer, dropping
+ * any ids already present (defensive against a shifted cursor boundary).
+ * Extracted to a module helper so the `setPastEvents` updater stays shallow
+ * (avoids deeply nested callbacks — SonarCloud S2004).
+ */
+function mergeOlderPastEvents(
+  prev: HarelineEvent[] | null,
+  older: HarelineEvent[],
+): HarelineEvent[] {
+  const base = prev ?? [];
+  const seen = new Set(base.map((e) => e.id));
+  const fresh = older.filter((e) => !seen.has(e.id));
+  return fresh.length > 0 ? [...base, ...fresh] : base;
 }
 
 /** Sort events by date (direction depends on timeFilter) then by startTime. */
@@ -722,12 +738,7 @@ export function HarelineView({
     setPastServerError(null);
     loadMorePastEvents(cursorId, pastFetchKennelIds)
       .then(({ events: older, hasMore }) => {
-        setPastEvents((prev) => {
-          const base = prev ?? [];
-          const seen = new Set(base.map((e) => e.id));
-          const fresh = older.filter((e) => !seen.has(e.id));
-          return fresh.length > 0 ? [...base, ...fresh] : base;
-        });
+        setPastEvents((prev) => mergeOlderPastEvents(prev, older));
         // `hasMore` is computed server-side from the raw page size (robust to
         // series-child dedup); the client just trusts it.
         setPastServerHasMore(hasMore);
@@ -1120,6 +1131,28 @@ export function HarelineView({
     </div>
   );
 
+  // List footer: client-side "Show more" while loaded rows remain to reveal,
+  // then the server-side "Load older events" control once the buffer is
+  // exhausted. Computed with if/else rather than a nested ternary (S3358).
+  let listFooter: ReactNode = null;
+  if (revealMore) {
+    listFooter = (
+      <div className="flex justify-center py-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+        >
+          Show {Math.min(PAGE_SIZE, remaining)} more ({remaining} remaining)
+        </Button>
+      </div>
+    );
+  } else if (canLoadOlderPast) {
+    // Loaded buffer exhausted for the current filters — fetch the next page of
+    // older past events from the server.
+    listFooter = loadOlderControl;
+  }
+
   const listContent = (
     <>
       {sortedEvents.length === 0 ? (
@@ -1157,21 +1190,7 @@ export function HarelineView({
               </div>
             </div>
           ))}
-          {revealMore ? (
-            <div className="flex justify-center py-4">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
-              >
-                Show {Math.min(PAGE_SIZE, remaining)} more ({remaining} remaining)
-              </Button>
-            </div>
-          ) : canLoadOlderPast ? (
-            // Loaded buffer exhausted for the current filters — fetch the next
-            // page of older past events from the server.
-            loadOlderControl
-          ) : null}
+          {listFooter}
         </div>
       )}
     </>

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -728,7 +728,7 @@ export function HarelineView({
   // is the oldest event — exactly the cursor `loadMorePastEvents` needs. We
   // dedupe by id on append (defensive against a shifted cursor boundary) and
   // bump `visibleCount` so the freshly loaded rows reveal immediately.
-  const loadOlderPastEvents = useCallback(() => {
+  const loadOlderPastEvents = useCallback(async () => {
     if (timeFilter !== "past" || pastServerLoading || !pastServerHasMore) return;
     const buffer = pastEvents;
     if (!buffer || buffer.length === 0) return;
@@ -736,20 +736,18 @@ export function HarelineView({
 
     setPastServerLoading(true);
     setPastServerError(null);
-    loadMorePastEvents(cursorId, pastFetchKennelIds)
-      .then(({ events: older, hasMore }) => {
-        setPastEvents((prev) => mergeOlderPastEvents(prev, older));
-        // `hasMore` is computed server-side from the raw page size (robust to
-        // series-child dedup); the client just trusts it.
-        setPastServerHasMore(hasMore);
-        setVisibleCount((c) => c + PAGE_SIZE);
-      })
-      .catch((err: unknown) => {
-        setPastServerError(err instanceof Error ? err.message : "Failed to load older events");
-      })
-      .finally(() => {
-        setPastServerLoading(false);
-      });
+    try {
+      const { events: older, hasMore } = await loadMorePastEvents(cursorId, pastFetchKennelIds);
+      setPastEvents((prev) => mergeOlderPastEvents(prev, older));
+      // `hasMore` is computed server-side from the raw page size (robust to
+      // series-child dedup); the client just trusts it.
+      setPastServerHasMore(hasMore);
+      setVisibleCount((c) => c + PAGE_SIZE);
+    } catch (err: unknown) {
+      setPastServerError(err instanceof Error ? err.message : "Failed to load older events");
+    } finally {
+      setPastServerLoading(false);
+    }
   }, [timeFilter, pastServerLoading, pastServerHasMore, pastEvents, pastFetchKennelIds]);
 
   // Active event list for the current time mode. Returns an empty array
@@ -1118,7 +1116,7 @@ export function HarelineView({
       <Button
         variant="outline"
         size="sm"
-        onClick={loadOlderPastEvents}
+        onClick={() => { void loadOlderPastEvents(); }}
         disabled={pastServerLoading}
       >
         {pastServerLoading ? "Loading older events…" : "Load older events"}

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -32,7 +32,7 @@ import { haversineDistance, getEventCoords } from "@/lib/geo";
 import { groupRegionsByState, expandRegionSelections, regionAbbrev } from "@/lib/region";
 import { LocationPrompt } from "./LocationPrompt";
 import { getLocationPref, resolveLocationDefault, clearLocationPref, FILTER_PARAMS } from "@/lib/location-pref";
-import { loadEventsForTimeMode, getEventDetail, type EventDetailFields, type TimeMode } from "@/app/hareline/actions";
+import { loadEventsForTimeMode, loadMorePastEvents, getEventDetail, type EventDetailFields, type TimeMode } from "@/app/hareline/actions";
 
 const MapView = dynamic(() => import("./MapView"), {
   ssr: false,
@@ -83,6 +83,21 @@ interface HarelineViewProps {
    * to re-fetch them when the user stays on the "past" tab.
    */
   initialTimeMode?: TimeMode;
+  /**
+   * Kennel IDs the SSR `events` payload was scoped to (the URL `?kennels=`
+   * filter). Only meaningful when `initialTimeMode === "past"`: it records
+   * how the initial past buffer was scoped on the server so cursor-based
+   * "load older" (`loadMorePastEvents`) can continue with the same scoping.
+   * Empty for the unfiltered global view.
+   */
+  initialKennelIds?: string[];
+  /**
+   * Whether the SSR `events` payload was a full raw page (server-computed from
+   * the pre-dedup row count). Seeds past-tab back-pagination so the "Load older
+   * events" affordance shows even when series-child dedup shrank the initial
+   * past page below the limit. Only meaningful when `initialTimeMode === "past"`.
+   */
+  initialHasMore?: boolean;
   /**
    * Server's `Date.now()` at render time. Used to seed the client's
    * upcoming/past bucket boundary so SSR and initial client render agree
@@ -317,6 +332,8 @@ export function computeInitialScope(
 export function HarelineView({
   events,
   initialTimeMode = "upcoming",
+  initialKennelIds = [],
+  initialHasMore = false,
   serverNowMs,
   subscribedKennelIds,
   isAuthenticated,
@@ -340,6 +357,24 @@ export function HarelineView({
   const [upcomingError, setUpcomingError] = useState<string | null>(null);
   const [pastLoading, setPastLoading] = useState(false);
   const [pastError, setPastError] = useState<string | null>(null);
+
+  // Server-side back-pagination of past events (look further back than the
+  // first PAST_EVENTS_LIMIT page). `pastServerHasMore` is true while the
+  // server may hold older events; `pastFetchKennelIds` records the scoping
+  // the current past buffer was loaded with so `loadMorePastEvents` continues
+  // with the same cursor ordering (SSR-past buffers are kennel-scoped; lazily
+  // toggled-in buffers are unfiltered).
+  const [pastServerHasMore, setPastServerHasMore] = useState<boolean>(
+    // Seed from the server's raw-page-fullness flag, NOT the (possibly
+    // dedup-shrunk) `events.length` — otherwise a kennel-filtered first page
+    // with a series parent+child could hide "Load older" mid-archive.
+    initialTimeMode === "past" && initialHasMore,
+  );
+  const [pastServerLoading, setPastServerLoading] = useState(false);
+  const [pastServerError, setPastServerError] = useState<string | null>(null);
+  const [pastFetchKennelIds, setPastFetchKennelIds] = useState<string[]>(
+    initialTimeMode === "past" ? initialKennelIds : [],
+  );
 
   // Live clock for bucket boundaries. Seeded with the server's render-time
   // `Date.now()` so the first client render matches SSR (no hydration
@@ -578,6 +613,10 @@ export function HarelineView({
   function resetListState() {
     setSelectedEvent(null);
     setVisibleCount(PAGE_SIZE);
+    // Clear any stale "load older" error so the affordance is fresh after a
+    // filter/tab change. The loaded buffer + server-has-more flag persist —
+    // only the transient error resets.
+    setPastServerError(null);
   }
   function setTimeFilter(v: TimeFilter) {
     setTimeFilterState(v);
@@ -622,8 +661,20 @@ export function HarelineView({
     let cancelled = false;
     setLoading(true);
     setError(null);
+    // The lazy tab-toggle fetch is intentionally unfiltered (kennel filtering
+    // happens client-side over the buffer). So when this populates the past
+    // buffer, record its scoping as unfiltered and seed the server-has-more
+    // flag from the server's raw-page-fullness signal, mirroring the SSR path.
     loadEventsForTimeMode(mode)
-      .then((fetched) => { if (!cancelled) setEvents(fetched); })
+      .then(({ events: fetched, hasMore }) => {
+        if (cancelled) return;
+        setEvents(fetched);
+        if (isPast) {
+          setPastFetchKennelIds([]);
+          setPastServerHasMore(hasMore);
+          setPastServerError(null);
+        }
+      })
       .catch((err: unknown) => {
         if (cancelled) return;
         setError(err instanceof Error ? err.message : "Failed to load events");
@@ -632,6 +683,40 @@ export function HarelineView({
 
     return () => { cancelled = true; };
   }, [timeFilter, pastEvents, upcomingEvents, pastLoading, pastError, upcomingLoading, upcomingError]);
+
+  // Fetch the next page of older past events (cursor = oldest loaded event).
+  // The buffer is held in server order (`[date desc, id desc]`), so its tail
+  // is the oldest event — exactly the cursor `loadMorePastEvents` needs. We
+  // dedupe by id on append (defensive against a shifted cursor boundary) and
+  // bump `visibleCount` so the freshly loaded rows reveal immediately.
+  const loadOlderPastEvents = useCallback(() => {
+    if (timeFilter !== "past" || pastServerLoading || !pastServerHasMore) return;
+    const buffer = pastEvents;
+    if (!buffer || buffer.length === 0) return;
+    const cursorId = buffer[buffer.length - 1].id;
+
+    setPastServerLoading(true);
+    setPastServerError(null);
+    loadMorePastEvents(cursorId, pastFetchKennelIds)
+      .then(({ events: older, hasMore }) => {
+        setPastEvents((prev) => {
+          const base = prev ?? [];
+          const seen = new Set(base.map((e) => e.id));
+          const fresh = older.filter((e) => !seen.has(e.id));
+          return fresh.length > 0 ? [...base, ...fresh] : base;
+        });
+        // `hasMore` is computed server-side from the raw page size (robust to
+        // series-child dedup); the client just trusts it.
+        setPastServerHasMore(hasMore);
+        setVisibleCount((c) => c + PAGE_SIZE);
+      })
+      .catch((err: unknown) => {
+        setPastServerError(err instanceof Error ? err.message : "Failed to load older events");
+      })
+      .finally(() => {
+        setPastServerLoading(false);
+      });
+  }, [timeFilter, pastServerLoading, pastServerHasMore, pastEvents, pastFetchKennelIds]);
 
   // Active event list for the current time mode. Returns an empty array
   // when the cache for the current mode hasn't resolved — DO NOT fall
@@ -814,7 +899,14 @@ export function HarelineView({
     return groupEventsByDate(visibleEvents);
   }, [visibleEvents]);
 
-  const hasMore = visibleCount < sortedEvents.length;
+  // `revealMore`: loaded+filtered events not yet sliced into view (client-side
+  // reveal). `canLoadOlderPast`: the server may hold still-older past events
+  // beyond the loaded buffer (server-side back-pagination). The "Show more"
+  // button does the first while it can, then transparently switches to the
+  // second so users can page indefinitely back through the archive.
+  const revealMore = visibleCount < sortedEvents.length;
+  const canLoadOlderPast = timeFilter === "past" && pastServerHasMore;
+  const hasMore = revealMore || canLoadOlderPast;
   const remaining = sortedEvents.length - visibleCount;
 
   function clearAllFilters() {
@@ -1007,14 +1099,32 @@ export function HarelineView({
             </div>
           ))}
           {hasMore && (
-            <div className="flex justify-center py-4">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
-              >
-                Show {Math.min(PAGE_SIZE, remaining)} more ({remaining} remaining)
-              </Button>
+            <div className="flex flex-col items-center gap-2 py-4">
+              {revealMore ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+                >
+                  Show {Math.min(PAGE_SIZE, remaining)} more ({remaining} remaining)
+                </Button>
+              ) : (
+                // Loaded buffer exhausted for the current filters — fetch the
+                // next page of older past events from the server.
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={loadOlderPastEvents}
+                  disabled={pastServerLoading}
+                >
+                  {pastServerLoading ? "Loading older events…" : "Load older events"}
+                </Button>
+              )}
+              {pastServerError && (
+                <p className="text-xs text-destructive" role="alert">
+                  {pastServerError}. Tap again to retry.
+                </p>
+              )}
             </div>
           )}
         </div>
@@ -1214,7 +1324,7 @@ export function HarelineView({
       {/* Results count (hidden for calendar — it shows its own count) */}
       {(view === "list" || view === "map") && (
         <p className="text-sm text-muted-foreground" aria-hidden="true">
-          {view === "list" && hasMore
+          {view === "list" && revealMore
             ? `Showing ${visibleCount} of ${sortedEvents.length} `
             : `${filteredEvents.length} `}
           {timeLabel} {filteredEvents.length === 1 ? "event" : "events"}

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -1116,7 +1116,7 @@ export function HarelineView({
       <Button
         variant="outline"
         size="sm"
-        onClick={() => { void loadOlderPastEvents(); }}
+        onClick={loadOlderPastEvents}
         disabled={pastServerLoading}
       >
         {pastServerLoading ? "Loading older events…" : "Load older events"}

--- a/src/components/hareline/HarelineView.tsx
+++ b/src/components/hareline/HarelineView.tsx
@@ -274,6 +274,22 @@ function passesAllFilters(event: HarelineEvent, f: FilterCriteria): boolean {
   return true;
 }
 
+/**
+ * Drop series children whose parent is also present in the buffer — they render
+ * inside the parent's expanded timeline, not as standalone top-level cards.
+ * Mirrors the server's per-page dedup, but applied over the cumulative
+ * (multi-page) past buffer so a parent + child that land on DIFFERENT cursor
+ * pages don't surface the child twice (Codex review). A child whose parent is
+ * NOT loaded stays top-level. Fast-path returns the input untouched when no
+ * children are present — the common case for the unfiltered global view, where
+ * the server excludes children at the query level entirely.
+ */
+function dropLoadedSeriesChildren(events: HarelineEvent[]): HarelineEvent[] {
+  if (!events.some((e) => e.parentEventId)) return events;
+  const ids = new Set(events.map((e) => e.id));
+  return events.filter((e) => !e.parentEventId || !ids.has(e.parentEventId));
+}
+
 /** Sort events by date (direction depends on timeFilter) then by startTime. */
 function sortEvents(events: HarelineEvent[], timeFilter: TimeFilter): HarelineEvent[] {
   const descending = timeFilter === "past";
@@ -364,6 +380,13 @@ export function HarelineView({
   // the current past buffer was loaded with so `loadMorePastEvents` continues
   // with the same cursor ordering (SSR-past buffers are kennel-scoped; lazily
   // toggled-in buffers are unfiltered).
+  //
+  // NOTE: `pastFetchKennelIds` deliberately tracks the buffer's *load-time*
+  // scoping, NOT the live client kennel filter — the past buffer doesn't
+  // re-fetch when the user changes the kennel chips. Older pages therefore
+  // arrive in the original scope and are narrowed client-side. Do not "fix"
+  // this by syncing it to `selectedKennels`; that would desync the cursor
+  // ordering from the buffer it continues.
   const [pastServerHasMore, setPastServerHasMore] = useState<boolean>(
     // Seed from the server's raw-page-fullness flag, NOT the (possibly
     // dedup-shrunk) `events.length` — otherwise a kennel-filtered first page
@@ -726,8 +749,12 @@ export function HarelineView({
   // produce false empty states or hide subscribed events during the
   // brief window before the lazy fetch resolves.
   const currentEvents = useMemo((): HarelineEvent[] => {
-    if (timeFilter === "past") return pastEvents ?? [];
-    return upcomingEvents ?? [];
+    // Dedupe series children whose parent is anywhere in the cumulative buffer
+    // (handles cross-page splits from cursor pagination). The raw `pastEvents`
+    // buffer is left intact for cursor derivation; only this display-facing
+    // view is deduped.
+    const buffer = timeFilter === "past" ? pastEvents : upcomingEvents;
+    return dropLoadedSeriesChildren(buffer ?? []);
   }, [timeFilter, pastEvents, upcomingEvents]);
 
   // True while the current mode's list is being fetched for the first
@@ -903,10 +930,10 @@ export function HarelineView({
   // reveal). `canLoadOlderPast`: the server may hold still-older past events
   // beyond the loaded buffer (server-side back-pagination). The "Show more"
   // button does the first while it can, then transparently switches to the
-  // second so users can page indefinitely back through the archive.
+  // "Load older events" control so users can page indefinitely back through
+  // the archive.
   const revealMore = visibleCount < sortedEvents.length;
   const canLoadOlderPast = timeFilter === "past" && pastServerHasMore;
-  const hasMore = revealMore || canLoadOlderPast;
   const remaining = sortedEvents.length - visibleCount;
 
   function clearAllFilters() {
@@ -1071,10 +1098,42 @@ export function HarelineView({
     />
   );
 
+  // Standalone "load older" control. Shown both at the end of a non-empty list
+  // and inside the empty state — so a past filter with zero matches in the
+  // loaded range can still page deeper into the archive instead of dead-ending
+  // on EmptyState while older matching events exist (Codex review).
+  const loadOlderControl = (
+    <div className="flex flex-col items-center gap-2 py-4">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={loadOlderPastEvents}
+        disabled={pastServerLoading}
+      >
+        {pastServerLoading ? "Loading older events…" : "Load older events"}
+      </Button>
+      {pastServerError && (
+        <p className="text-xs text-destructive" role="alert">
+          {pastServerError}. Tap again to retry.
+        </p>
+      )}
+    </div>
+  );
+
   const listContent = (
     <>
       {sortedEvents.length === 0 ? (
-        emptyState
+        <>
+          {emptyState}
+          {canLoadOlderPast && (
+            <>
+              <p className="pt-2 text-center text-xs text-muted-foreground">
+                No matches in the loaded range — older trails may match your filters.
+              </p>
+              {loadOlderControl}
+            </>
+          )}
+        </>
       ) : (
         <div>
           {dateGroups.map((group) => (
@@ -1098,35 +1157,21 @@ export function HarelineView({
               </div>
             </div>
           ))}
-          {hasMore && (
-            <div className="flex flex-col items-center gap-2 py-4">
-              {revealMore ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
-                >
-                  Show {Math.min(PAGE_SIZE, remaining)} more ({remaining} remaining)
-                </Button>
-              ) : (
-                // Loaded buffer exhausted for the current filters — fetch the
-                // next page of older past events from the server.
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={loadOlderPastEvents}
-                  disabled={pastServerLoading}
-                >
-                  {pastServerLoading ? "Loading older events…" : "Load older events"}
-                </Button>
-              )}
-              {pastServerError && (
-                <p className="text-xs text-destructive" role="alert">
-                  {pastServerError}. Tap again to retry.
-                </p>
-              )}
+          {revealMore ? (
+            <div className="flex justify-center py-4">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+              >
+                Show {Math.min(PAGE_SIZE, remaining)} more ({remaining} remaining)
+              </Button>
             </div>
-          )}
+          ) : canLoadOlderPast ? (
+            // Loaded buffer exhausted for the current filters — fetch the next
+            // page of older past events from the server.
+            loadOlderControl
+          ) : null}
         </div>
       )}
     </>


### PR DESCRIPTION
## Problem

The past-events view (`/hareline?time=past`) could only ever show the **most recent 200 past events**. The server capped the past query at `PAST_EVENTS_LIMIT = 200` and returned them in one shot; the "Show more" button only re-sliced that already-loaded buffer. Once a user reached event #200 there was **no way to look back further** — even though kennels like SDH3 have ~7,649 historical events in the DB.

Reported via: `https://www.hashtracks.xyz/hareline?time=past&scope=all`

## Approach

Server-side **cursor pagination** for the past tab, fetched on demand and appended to the client buffer. The existing "Show more" button transparently switches to "Load older events" once the loaded buffer is exhausted — effectively unlimited backward scroll. **Past-only**; the upcoming caps (1500/2000, a separate `unstable_cache` 2 MB concern) are untouched. The hot first page stays cached; deep-history pages are an uncached direct query.

### Server — `src/app/hareline/actions.ts`
- New uncached **`loadMorePastEvents(cursorId, kennelIds)`** — compound cursor `orderBy: [date desc, id desc]`, `skip: 1`, `take: 200`; returns `{ events, hasMore }`.
- Added an `id desc` tiebreak to the past query so the cursor boundary is deterministic.
- Extracted shared `HARELINE_EVENT_SELECT` / `buildHarelineWhere` / `dedupeSeriesChildren` / `mapRowToCachedEvent` / `rehydrateCachedEvent` (pure refactor — both query paths share one projection/shape).
- `loadEventsForTimeMode` / `fetchSlimEventsCached` now return `{ events, hasMore }`, with `hasMore` from the **raw** (pre-dedup) page size so a kennel-filtered first page shrunk by series-child dedup can't hide the affordance mid-archive. Cache key bumped to `v2` for the shape change.
- `loadMorePastEvents` lets real query failures propagate to the client's retry UI rather than swallowing them as end-of-list; a missing cursor returns `[]` naturally.

### Client — `src/components/hareline/HarelineView.tsx`
- Tracks `pastServerHasMore` / `pastServerLoading` / `pastServerError` + `pastFetchKennelIds` (records the buffer's server-scoping so the cursor stays consistent).
- Derives the cursor from the buffer tail, appends older pages with id-dedupe, bumps `visibleCount` so new rows reveal.
- The existing "Show more" button reveals loaded rows first, then switches to **"Load older events"** (with loading/error states). `initialHasMore` prop seeds the flag from the SSR fetch; `page.tsx` passes it through.

## Addressed in review

A Codex adversarial pass flagged two issues, both fixed here:
1. **[high]** First-page `hasMore` was derived after dedup — now computed from the raw row count, symmetric with the load-more path (cache key bumped to bust stale-shape entries).
2. **[medium]** `loadMorePastEvents` swallowed all failures as end-of-list — now only a genuinely missing cursor returns `[]`; real failures propagate to the retry UI.

## Known minor caveats
- **Cross-page series split** (kennel-filtered only): a parent on one page + child on the next won't be cross-page deduped (per-page dedup). Series cluster by date so a page-boundary split is rare; the unfiltered global view excludes children at the query level entirely.
- **Client-only filters + deep history**: `scope=my` / region / search / day filters run over the loaded buffer, so a narrow filter may need several "Load older" clicks. The server-side kennel filter (`?kennels=`) keeps kennel-scoped lookback efficient.

## Testing
- `npx tsc --noEmit` → 0 errors; `npm run lint` → 0 issues in changed files.
- Full Vitest suite → **9541 pass** / 325 files, including **19 hareline-action tests** (cursor query shape, kennel scoping, series dedup, raw-count `hasMore` robustness, error propagation vs. missing-cursor `[]`).
- Dev server compiles and serves `/hareline?time=past&scope=all` → HTTP 200 against the prod DB (validates the refactored SSR read path + new ordering on real data).
- ⚠️ The interactive "Load older" click-through could not be captured live — the preview harness wouldn't attach its browser tab — so that path is validated by unit tests + the SSR-200 read path rather than a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)