### PR TITLE
fix(travel): dedupe redundant cadence predictions + clean multi-day series rendering

### DIFF
--- a/src/components/travel/ConfirmedCard.tsx
+++ b/src/components/travel/ConfirmedCard.tsx
@@ -10,6 +10,7 @@ import {
   MapPin,
   Users,
   CornerDownRight,
+  CalendarRange,
 } from "lucide-react";
 import { getConditionEmoji, cToF } from "@/lib/weather-display";
 import { formatDistanceWithWalk } from "@/lib/travel/format";
@@ -67,6 +68,7 @@ interface ConfirmedCardProps {
       precipProbability: number;
     } | null;
     attendance: { status: string; participationLevel: string } | null;
+    seriesParentTitle?: string | null;
   };
 }
 
@@ -167,6 +169,16 @@ export function ConfirmedCard({ result }: ConfirmedCardProps) {
             )}
           </div>
         </div>
+
+        {/* Series tie: this leg belongs to a multi-day event (parent umbrella
+            is hidden in Travel Mode) — surface the connection so adjacent legs
+            read as one event rather than near-duplicate cards. */}
+        {result.seriesParentTitle && (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground/70">
+            <CalendarRange className="h-3 w-3 flex-shrink-0" />
+            <span className="truncate">Part of: {result.seriesParentTitle}</span>
+          </div>
+        )}
 
         {/* Row 2: attribution (kennel · region · run#) + source icons */}
         <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground/80">

--- a/src/lib/travel/projections.test.ts
+++ b/src/lib/travel/projections.test.ts
@@ -316,7 +316,7 @@ describe("deduplicateAgainstConfirmed", () => {
     expect(result.find((r) => r.kennelId === "k2")).toBeDefined();
   });
 
-  it("keeps null-date projections (possible activity) even if kennel has confirmed events", () => {
+  it("suppresses null-date cadence projections when the kennel has a confirmed event", () => {
     const projections = [
       { kennelId: "k1", date: null, confidence: "low" as const, startTime: null, scheduleRuleId: "r1", explanation: "", evidenceWindow: "" },
     ];
@@ -325,7 +325,22 @@ describe("deduplicateAgainstConfirmed", () => {
     ];
 
     const result = deduplicateAgainstConfirmed(projections, confirmed);
-    expect(result).toHaveLength(1); // null-date should survive
+    // The concrete confirmed run makes the vague "usually runs" hint redundant
+    // (GGFM full-moon possible vs the confirmed Strawberry Moon GGFM run).
+    expect(result).toHaveLength(0);
+  });
+
+  it("keeps null-date cadence projections when the kennel has no confirmed event", () => {
+    const projections = [
+      { kennelId: "k1", date: null, confidence: "low" as const, startTime: null, scheduleRuleId: "r1", explanation: "", evidenceWindow: "" },
+    ];
+    // Confirmed events exist for a DIFFERENT kennel only.
+    const confirmedOtherKennel: ConfirmedEventRef[] = [
+      { kennelId: "k2", date: utcNoon("2026-04-05") },
+    ];
+    expect(deduplicateAgainstConfirmed(projections, confirmedOtherKennel)).toHaveLength(1);
+    // ...and survives when there are no confirmed events at all.
+    expect(deduplicateAgainstConfirmed(projections, [])).toHaveLength(1);
   });
 
   it("handles empty confirmed events array", () => {

--- a/src/lib/travel/projections.ts
+++ b/src/lib/travel/projections.ts
@@ -324,12 +324,19 @@ export function scoreConfidence(
 
 /**
  * Remove projected trails where a CONFIRMED event already exists for the
- * same kennel + date (+ startTime when available).
+ * same kennel.
  *
- * Strategy: when BOTH the confirmed event and the projection have a startTime,
- * use (kennelId, date, startTime) so a confirmed afternoon run doesn't suppress
- * a projected evening run. When either side lacks a startTime, fall back to
- * (kennelId, date) — conservative, since we can't distinguish time slots.
+ * Two granularities:
+ *   - DATED projections (HIGH/MEDIUM, and LOW projections that carry a date):
+ *     dedup by (kennelId, date, startTime) when BOTH sides have a startTime —
+ *     so a confirmed afternoon run doesn't suppress a projected evening run —
+ *     falling back to (kennelId, date) when either side lacks a startTime.
+ *   - CADENCE projections (`date: null` — e.g. "Full moon schedule",
+ *     biweekly/monthly sentinels): these are a vague "this kennel usually
+ *     runs" hint with no specific occurrence, so suppress them whenever the
+ *     kennel has ANY confirmed event in the window. A concrete confirmed run
+ *     makes the hint redundant (e.g. a confirmed Strawberry Moon GGFM run
+ *     should hide the "GGFM — Full moon schedule" possible).
  *
  * Only deduplicates against events with status=CONFIRMED (not TENTATIVE).
  */
@@ -340,7 +347,11 @@ export function deduplicateAgainstConfirmed(
   // Two key sets: one with startTime for precise matching, one date-only for fallback
   const confirmedWithTime = new Set<string>();
   const confirmedDateOnly = new Set<string>();
+  // Kennel-level set: any kennel with ≥1 confirmed event in the window, used to
+  // suppress its dateless cadence projections.
+  const confirmedKennelIds = new Set<string>();
   for (const evt of confirmedEvents) {
+    confirmedKennelIds.add(evt.kennelId);
     const dateKey = evt.date.toISOString().slice(0, 10);
     if (evt.startTime) {
       confirmedWithTime.add(`${evt.kennelId}:${dateKey}:${evt.startTime}`);
@@ -351,7 +362,9 @@ export function deduplicateAgainstConfirmed(
   }
 
   return projections.filter((proj) => {
-    if (!proj.date) return true;
+    // Cadence sentinel (no specific date): redundant once the kennel has a
+    // concrete confirmed run anywhere in the window.
+    if (!proj.date) return !confirmedKennelIds.has(proj.kennelId);
     const dateKey = proj.date.toISOString().slice(0, 10);
     const kennelDate = `${proj.kennelId}:${dateKey}`;
 

--- a/src/lib/travel/projections.ts
+++ b/src/lib/travel/projections.ts
@@ -57,6 +57,10 @@ export interface KennelContext {
 }
 
 export interface ConfirmedEventRef {
+  /** The kennel the confirmed event renders under. May be a CO-HOST pivot
+   *  kennel (set by the caller via `matchedNearbyKennelIds` in search.ts),
+   *  not necessarily the event's primary `kennelId` — so dedup suppresses
+   *  projections for the kennel the card actually shows under. */
   kennelId: string;
   date: Date; // UTC noon
   startTime?: string | null;

--- a/src/lib/travel/search.test.ts
+++ b/src/lib/travel/search.test.ts
@@ -59,6 +59,12 @@ interface MockEvent {
   status: string;
   kennel: { latitude: number | null; longitude: number | null } | null;
   eventLinks: { url: string; label: string }[];
+  /** Multi-day series linkage. A child leg sets `parentEventId`; a series
+   *  parent sets `isSeriesParent`. Used to exercise the bare-umbrella filter
+   *  (synthetic detail-less parent vs real promoted leg) + the
+   *  `parentEvent.title` series tie. */
+  parentEventId?: string | null;
+  isSeriesParent?: boolean;
 }
 
 interface MockScheduleRule {
@@ -112,15 +118,24 @@ function createMockPrisma(
           filtered = filtered.filter((e: MockEvent) => e.date <= where.date.lte);
         }
         // Production includes `eventKennels: { select: { kennelId: true } }`
-        // so the result-builder can pivot to the matching co-host. Mirror
-        // that in the mock by attaching the kennel-set on each row.
+        // so the result-builder can pivot to the matching co-host,
+        // `parentEvent: { select: { title: true } }` for the series tie, and
+        // `_count: { select: { childEvents: true } }` for the bare-umbrella
+        // filter. Mirror all three on each returned row.
         return Promise.resolve(
           filtered.map((e) => ({
             ...e,
+            isSeriesParent: e.isSeriesParent ?? false,
             eventKennels: [
               { kennelId: e.kennelId },
               ...(e.coHostKennelIds ?? []).map((id) => ({ kennelId: id })),
             ],
+            parentEvent: e.parentEventId
+              ? { title: events.find((p) => p.id === e.parentEventId)?.title ?? null }
+              : null,
+            _count: {
+              childEvents: events.filter((c) => c.parentEventId === e.id).length,
+            },
           })),
         );
       }),
@@ -239,9 +254,116 @@ describe("executeTravelSearch", () => {
     expect(result.confirmed[0].kennelName).toBe("Atlanta H3");
     expect(result.confirmed[0].distanceTier).toBe("nearby");
     expect(result.emptyState).toBe("none"); // has confirmed results
+    // A normal (non-series) event carries no series tie.
+    expect(result.confirmed[0].seriesParentTitle).toBeNull();
     // broaderRadiusKm must be undefined on primary-only searches or
     // TripSummary will render the "routing revised" expanded-radius UI.
     expect(result.destinations[0].broaderRadiusKm).toBeUndefined();
+  });
+
+  it("hides bare (detail-less) series umbrellas and ties child legs to the series", async () => {
+    // Mirrors the "5-boro Pub Crawl" bug: the umbrella parent has no per-day
+    // detail and must not render as a bare card; only the dated child leg shows,
+    // tagged "Part of: <series>".
+    const seriesParent: MockEvent = {
+      ...testEvent,
+      id: "e-series-parent",
+      title: "5-boro Pub Crawl 2026",
+      runNumber: null,
+      startTime: null,
+      haresText: null,
+      locationName: null,
+      isSeriesParent: true,
+      date: utcNoon("2026-04-18"),
+    };
+    const seriesChild: MockEvent = {
+      ...testEvent,
+      id: "e-series-child",
+      title: "5-boro Pub Crawl - Special #252",
+      runNumber: 252,
+      date: utcNoon("2026-04-19"),
+      parentEventId: "e-series-parent",
+    };
+    const prisma = createMockPrisma([testKennel], [seriesParent, seriesChild], []);
+    const result = await executeTravelSearch(prisma, baseParams);
+
+    // Bare umbrella dropped; only the dated child leg renders.
+    expect(result.confirmed).toHaveLength(1);
+    expect(result.confirmed[0].eventId).toBe("e-series-child");
+    expect(result.confirmed[0].seriesParentTitle).toBe("5-boro Pub Crawl 2026");
+  });
+
+  it("keeps a real dated leg that the merge promoted to series parent", async () => {
+    // Regression guard (Codex finding): the merge can make the EARLIEST real
+    // leg the series parent (Hash Rego "earliest by date wins"). It has
+    // children but also carries per-day detail, so it must NOT be hidden — a
+    // blunt `childEvents: { none: {} }` filter would delete this day-1 leg.
+    const realLegParent: MockEvent = {
+      ...testEvent,
+      id: "e-realleg-parent",
+      title: "Weekender Day 1",
+      runNumber: 900,
+      startTime: "10:00", // has per-day detail → real leg, not a bare umbrella
+      haresText: "Just Pat",
+      locationName: "Day 1 Park",
+      isSeriesParent: true,
+      date: utcNoon("2026-04-18"),
+    };
+    const realLegChild: MockEvent = {
+      ...testEvent,
+      id: "e-realleg-child",
+      title: "Weekender Day 2",
+      runNumber: 901,
+      date: utcNoon("2026-04-19"),
+      parentEventId: "e-realleg-parent",
+    };
+    const prisma = createMockPrisma([testKennel], [realLegParent, realLegChild], []);
+    const result = await executeTravelSearch(prisma, baseParams);
+
+    // Both legs render; neither is dropped.
+    expect(result.confirmed).toHaveLength(2);
+    expect(result.confirmed.map((r) => r.eventId).sort()).toEqual([
+      "e-realleg-child",
+      "e-realleg-parent",
+    ]);
+  });
+
+  it("suppresses a cadence possible for a co-hosted confirmed event (pivot kennel)", async () => {
+    // Confirmed event's PRIMARY kennel is far (London); the nearby kennel is a
+    // co-host. The confirmed card renders under the co-host, so the co-host's
+    // dateless cadence projection must be suppressed even though it is not the
+    // event's primary kennelId.
+    const londonKennel: MockKennel = {
+      ...testKennel,
+      id: "k-london",
+      slug: "london-h3",
+      shortName: "London H3",
+      latitude: 51.5,
+      longitude: -0.13,
+    };
+    const coHostEvent: MockEvent = {
+      ...testEvent,
+      id: "e-cohost-confirmed",
+      kennelId: "k-london", // primary far from Atlanta
+      coHostKennelIds: ["k-atl"], // co-host in range
+    };
+    // A LOW/cadence rule for the Atlanta co-host → dateless "possible".
+    const cadenceRule: MockScheduleRule = {
+      ...testRule,
+      id: "r-cadence",
+      kennelId: "k-atl",
+      rrule: "FREQ=MONTHLY;BYDAY=1FR",
+      confidence: "LOW",
+      notes: "Full moon schedule",
+    };
+    const prisma = createMockPrisma([testKennel, londonKennel], [coHostEvent], [cadenceRule]);
+    const result = await executeTravelSearch(prisma, baseParams);
+
+    // Confirmed renders under the Atlanta co-host…
+    expect(result.confirmed).toHaveLength(1);
+    expect(result.confirmed[0].kennelId).toBe("k-atl");
+    // …and the co-host's vague cadence "possible" is deduped away.
+    expect(result.possible.some((p) => p.kennelId === "k-atl")).toBe(false);
   });
 
   it("pivots co-host events onto the matching nearby kennel (#1023 step 5)", async () => {

--- a/src/lib/travel/search.test.ts
+++ b/src/lib/travel/search.test.ts
@@ -120,8 +120,8 @@ function createMockPrisma(
         // Production includes `eventKennels: { select: { kennelId: true } }`
         // so the result-builder can pivot to the matching co-host,
         // `parentEvent: { select: { title: true } }` for the series tie, and
-        // `_count: { select: { childEvents: true } }` for the bare-umbrella
-        // filter. Mirror all three on each returned row.
+        // `childEvents: { select: { date: true } }` for the synthetic-umbrella
+        // filter (a parent shares its date with a child). Mirror all three.
         return Promise.resolve(
           filtered.map((e) => ({
             ...e,
@@ -133,9 +133,9 @@ function createMockPrisma(
             parentEvent: e.parentEventId
               ? { title: events.find((p) => p.id === e.parentEventId)?.title ?? null }
               : null,
-            _count: {
-              childEvents: events.filter((c) => c.parentEventId === e.id).length,
-            },
+            childEvents: events
+              .filter((c) => c.parentEventId === e.id)
+              .map((c) => ({ date: c.date })),
           })),
         );
       }),
@@ -261,14 +261,15 @@ describe("executeTravelSearch", () => {
     expect(result.destinations[0].broaderRadiusKm).toBeUndefined();
   });
 
-  it("hides bare (detail-less) series umbrellas and ties child legs to the series", async () => {
-    // Mirrors the "5-boro Pub Crawl" bug: the umbrella parent has no per-day
-    // detail and must not render as a bare card; only the dated child leg shows,
-    // tagged "Part of: <series>".
-    const seriesParent: MockEvent = {
+  it("hides a synthetic umbrella that overlays a same-day child, tying legs to the series", async () => {
+    // SFH3-style explicit umbrella: an EXTRA detail-less parent row that shares
+    // its date with a real same-day child (merge.ts: "an umbrella + a same-day
+    // child both fall on the same day"). The umbrella must not render as a bare
+    // card; the real same-day child + later children show, tagged "Part of".
+    const umbrella: MockEvent = {
       ...testEvent,
-      id: "e-series-parent",
-      title: "5-boro Pub Crawl 2026",
+      id: "e-umbrella",
+      title: "Bay 2 Blackout 2026",
       runNumber: null,
       startTime: null,
       haresText: null,
@@ -276,34 +277,78 @@ describe("executeTravelSearch", () => {
       isSeriesParent: true,
       date: utcNoon("2026-04-18"),
     };
-    const seriesChild: MockEvent = {
+    const sameDayChild: MockEvent = {
       ...testEvent,
-      id: "e-series-child",
-      title: "5-boro Pub Crawl - Special #252",
-      runNumber: 252,
-      date: utcNoon("2026-04-19"),
-      parentEventId: "e-series-parent",
+      id: "e-umbrella-day1",
+      title: "Bay 2 Blackout - Day 1",
+      runNumber: 1,
+      date: utcNoon("2026-04-18"), // same date as the umbrella → synthetic signal
+      parentEventId: "e-umbrella",
     };
-    const prisma = createMockPrisma([testKennel], [seriesParent, seriesChild], []);
+    const day2Child: MockEvent = {
+      ...testEvent,
+      id: "e-umbrella-day2",
+      title: "Bay 2 Blackout - Day 2",
+      runNumber: 2,
+      date: utcNoon("2026-04-19"),
+      parentEventId: "e-umbrella",
+    };
+    const prisma = createMockPrisma([testKennel], [umbrella, sameDayChild, day2Child], []);
     const result = await executeTravelSearch(prisma, baseParams);
 
-    // Bare umbrella dropped; only the dated child leg renders.
-    expect(result.confirmed).toHaveLength(1);
-    expect(result.confirmed[0].eventId).toBe("e-series-child");
-    expect(result.confirmed[0].seriesParentTitle).toBe("5-boro Pub Crawl 2026");
+    // Umbrella dropped; both real child legs render, tied to the series.
+    expect(result.confirmed.map((r) => r.eventId).sort()).toEqual([
+      "e-umbrella-day1",
+      "e-umbrella-day2",
+    ]);
+    expect(result.confirmed.every((r) => r.seriesParentTitle === "Bay 2 Blackout 2026")).toBe(true);
   });
 
-  it("keeps a real dated leg that the merge promoted to series parent", async () => {
-    // Regression guard (Codex finding): the merge can make the EARLIEST real
-    // leg the series parent (Hash Rego "earliest by date wins"). It has
-    // children but also carries per-day detail, so it must NOT be hidden — a
-    // blunt `childEvents: { none: {} }` filter would delete this day-1 leg.
+  it("keeps a SPARSE promoted day-1 leg of a consecutive cluster (no same-day child)", async () => {
+    // Regression guard (Codex P2 on PR #2305): same-title-cluster.ts promotes
+    // the EARLIEST real trail of a consecutive cluster to series parent, keeping
+    // its title verbatim. That day-1 leg is often sparse (title + date only) but
+    // is a REAL trail — a content-only filter would delete it. It shares its
+    // date with NO child (children are later distinct days), so it must survive.
+    const sparseParent: MockEvent = {
+      ...testEvent,
+      id: "e-cluster-day1",
+      title: "Belgian Nash Hash 2026",
+      runNumber: null,
+      startTime: null, // sparse: no per-day detail at all
+      haresText: null,
+      locationName: null,
+      isSeriesParent: true,
+      date: utcNoon("2026-04-18"),
+    };
+    const day2: MockEvent = {
+      ...testEvent,
+      id: "e-cluster-day2",
+      title: "Belgian Nash Hash 2026 Pub Crawl",
+      runNumber: null,
+      date: utcNoon("2026-04-19"),
+      parentEventId: "e-cluster-day1",
+    };
+    const prisma = createMockPrisma([testKennel], [sparseParent, day2], []);
+    const result = await executeTravelSearch(prisma, baseParams);
+
+    // Sparse day-1 leg is preserved; both days render.
+    expect(result.confirmed.map((r) => r.eventId).sort()).toEqual([
+      "e-cluster-day1",
+      "e-cluster-day2",
+    ]);
+  });
+
+  it("keeps a real dated leg (with detail) that the merge promoted to series parent", async () => {
+    // The merge can make the EARLIEST real leg the series parent (Hash Rego
+    // "earliest by date wins"). It has children but carries per-day detail and
+    // a unique date, so it must NOT be hidden.
     const realLegParent: MockEvent = {
       ...testEvent,
       id: "e-realleg-parent",
       title: "Weekender Day 1",
       runNumber: 900,
-      startTime: "10:00", // has per-day detail → real leg, not a bare umbrella
+      startTime: "10:00", // has per-day detail → real leg
       haresText: "Just Pat",
       locationName: "Day 1 Park",
       isSeriesParent: true,

--- a/src/lib/travel/search.ts
+++ b/src/lib/travel/search.ts
@@ -425,30 +425,44 @@ function matchedNearbyKennelIds(
 }
 
 /**
- * A synthetic, detail-less multi-day series umbrella: a series parent WITH
- * children that carries no per-day detail (no time / hares / venue). These must
- * not render as bare cards beside their real legs in Travel Mode. A real day-1
- * leg the merge promoted to parent (Hash Rego "earliest by date wins") carries
- * detail and is NOT a bare umbrella; standalone umbrellas have no children.
+ * A SYNTHETIC, detail-less multi-day series umbrella that must not render as a
+ * bare card beside its real legs in Travel Mode.
+ *
+ * The distinguishing signal is NOT "is a series parent with no detail" — the
+ * merge promotes a REAL trail to series parent in two ways (`merge.ts`
+ * earliest-by-date Hash Rego fallback, and `same-title-cluster.ts` which
+ * promotes the earliest day of a same-title consecutive cluster, keeping its
+ * title verbatim). Those promoted legs are real days and are frequently sparse
+ * (title + date only), so a content-only check would delete them (Codex P2 on
+ * PR #2305).
+ *
+ * A genuinely synthetic umbrella (SFH3-style explicit `seriesParent`) is an
+ * EXTRA row that overlays a real same-day child — `merge.ts` notes "an umbrella
+ * + a same-day child both fall on the same day". A promoted real leg occupies a
+ * date no child shares (consecutive distinct days). So we hide a parent only
+ * when it is content-less AND a child shares its date — preserving sparse
+ * promoted day-1 legs while still dropping the redundant SFH3 umbrella. A
+ * content-rich same-day parent (e.g. a morning trail with an evening child) is
+ * also preserved.
+ *
  * Travel-local on purpose — the Hareline deliberately shows umbrellas (their
  * expandable "weekend at a glance"), the opposite of what Travel wants.
  */
-function isBareSeriesUmbrella(event: {
+function isSyntheticSeriesUmbrella(event: {
   isSeriesParent: boolean;
-  _count: { childEvents: number };
+  date: Date;
+  childEvents: { date: Date }[];
   startTime: string | null;
   haresText: string | null;
   locationName: string | null;
   locationStreet: string | null;
 }): boolean {
-  return (
-    event.isSeriesParent &&
-    event._count.childEvents > 0 &&
-    !event.startTime &&
-    !event.haresText &&
-    !event.locationName &&
-    !event.locationStreet
-  );
+  if (!event.isSeriesParent) return false;
+  const contentLess =
+    !event.startTime && !event.haresText && !event.locationName && !event.locationStreet;
+  if (!contentLess) return false;
+  const dayKey = event.date.toISOString().slice(0, 10);
+  return event.childEvents.some((c) => c.date.toISOString().slice(0, 10) === dayKey);
 }
 
 async function runStopSearch(
@@ -552,13 +566,12 @@ async function runStopSearch(
         // Series tie: a child leg surfaces its parent's title as
         // "Part of: <series>" so the legs read as one multi-day event.
         parentEvent: { select: { title: true } },
-        // Child count drives the bare-umbrella filter below. We must NOT use a
-        // blunt `childEvents: { none: {} }` WHERE clause: the merge pipeline can
-        // promote a REAL dated leg to series parent (Hash Rego "earliest by date
-        // wins", merge.ts) — that parent has children but carries genuine per-day
-        // detail and must still render. Only the synthetic, detail-less umbrella
-        // (SFH3-style explicit `seriesParent`) should be hidden.
-        _count: { select: { childEvents: true } },
+        // Child dates drive the synthetic-umbrella filter below (see
+        // isSyntheticSeriesUmbrella). We must NOT use a blunt
+        // `childEvents: { none: {} }` WHERE clause: the merge promotes REAL
+        // trails to series parent (merge.ts earliest-by-date; same-title-cluster.ts
+        // earliest-of-cluster) — those legs have children but must still render.
+        childEvents: { select: { date: true } },
       },
       orderBy: { date: "asc" },
       take: CONFIRMED_EVENT_ROW_CAP,
@@ -612,6 +625,9 @@ async function runStopSearch(
   // kennel its card actually renders under (not just the primary).
   const confirmedRefs = confirmedEvents.flatMap((e) => {
     const matchedNearby = matchedNearbyKennelIds(e.eventKennels, nearbyIdsSet);
+    // `matchedNearby` is non-empty in practice (the query requires an
+    // `eventKennels` member in `nearbyIds`); the `[e.kennelId]` fallback is
+    // defensive against a future query change that relaxes that guarantee.
     const refKennelIds = matchedNearby.length > 0 ? matchedNearby : [e.kennelId];
     return refKennelIds.map((kennelId) => ({
       kennelId,
@@ -642,10 +658,10 @@ async function runStopSearch(
   // multi-stop search shares one bounded MAX_WEATHER_API_CALLS batch.
   const weatherInputs: WeatherInput[] = [];
 
-  // Step 12: Drop synthetic, detail-less multi-day series umbrellas so they
-  // don't render as bare cards beside their real legs (see isBareSeriesUmbrella).
+  // Step 12: Drop synthetic multi-day series umbrellas so they don't render as
+  // bare cards beside their real legs (see isSyntheticSeriesUmbrella).
   const displayConfirmedEvents = confirmedEvents.filter(
-    (event) => !isBareSeriesUmbrella(event),
+    (event) => !isSyntheticSeriesUmbrella(event),
   );
 
   // Step 13: Assign distance tiers + build result objects

--- a/src/lib/travel/search.ts
+++ b/src/lib/travel/search.ts
@@ -113,6 +113,10 @@ export interface ConfirmedResult extends DestinationTag {
   distanceTier: DistanceTier;
   sourceLinks: SourceLink[];
   weather: DailyWeather | null;
+  /** Title of this leg's multi-day series parent, when the row is a child
+   *  leg — rendered as "Part of: <series>" so legs read as one event.
+   *  Null for normal events and standalone umbrellas. */
+  seriesParentTitle: string | null;
 }
 
 export interface LikelyResult extends DestinationTag {
@@ -406,6 +410,47 @@ interface StopOutcome {
   weatherInputs: WeatherInput[];
 }
 
+/**
+ * The nearby kennel(s) a confirmed event renders under, in row order (first =
+ * the display pivot). A co-hosted event's primary `kennelId` may sit outside
+ * the search radius while a co-host is in range, so Travel pivots metadata —
+ * and dedup keys — onto the matching nearby kennel(s). Shared by the dedup-ref
+ * builder and the result builder so the pivot contract lives in one place.
+ */
+function matchedNearbyKennelIds(
+  eventKennels: { kennelId: string }[],
+  nearbyIdsSet: Set<string>,
+): string[] {
+  return eventKennels.map((ek) => ek.kennelId).filter((id) => nearbyIdsSet.has(id));
+}
+
+/**
+ * A synthetic, detail-less multi-day series umbrella: a series parent WITH
+ * children that carries no per-day detail (no time / hares / venue). These must
+ * not render as bare cards beside their real legs in Travel Mode. A real day-1
+ * leg the merge promoted to parent (Hash Rego "earliest by date wins") carries
+ * detail and is NOT a bare umbrella; standalone umbrellas have no children.
+ * Travel-local on purpose — the Hareline deliberately shows umbrellas (their
+ * expandable "weekend at a glance"), the opposite of what Travel wants.
+ */
+function isBareSeriesUmbrella(event: {
+  isSeriesParent: boolean;
+  _count: { childEvents: number };
+  startTime: string | null;
+  haresText: string | null;
+  locationName: string | null;
+  locationStreet: string | null;
+}): boolean {
+  return (
+    event.isSeriesParent &&
+    event._count.childEvents > 0 &&
+    !event.startTime &&
+    !event.haresText &&
+    !event.locationName &&
+    !event.locationStreet
+  );
+}
+
 async function runStopSearch(
   prisma: PrismaClient,
   stop: DestinationParams,
@@ -479,6 +524,7 @@ async function runStopSearch(
 
   const runPipelineFor = async (kennels: NearbyKennel[]) => {
     const nearbyIds = kennels.map((k) => k.id);
+    const nearbyIdsSet = new Set(nearbyIds);
     const kennelMap = new Map(kennels.map((k) => [k.id, k]));
 
     // Steps 3–5 + 8: Three independent DB queries run in parallel (saves ~2 round-trips)
@@ -503,6 +549,16 @@ async function runStopSearch(
       include: {
         eventLinks: { select: { url: true, label: true } },
         eventKennels: { select: { kennelId: true } },
+        // Series tie: a child leg surfaces its parent's title as
+        // "Part of: <series>" so the legs read as one multi-day event.
+        parentEvent: { select: { title: true } },
+        // Child count drives the bare-umbrella filter below. We must NOT use a
+        // blunt `childEvents: { none: {} }` WHERE clause: the merge pipeline can
+        // promote a REAL dated leg to series parent (Hash Rego "earliest by date
+        // wins", merge.ts) — that parent has children but carries genuine per-day
+        // detail and must still render. Only the synthetic, detail-less umbrella
+        // (SFH3-style explicit `seriesParent`) should be hidden.
+        _count: { select: { childEvents: true } },
       },
       orderBy: { date: "asc" },
       take: CONFIRMED_EVENT_ROW_CAP,
@@ -548,12 +604,21 @@ async function runStopSearch(
   // close to the 90-day window the scoring function expects)
   const scoredProjections = scoreProjections(projections, kennelMap, scheduleRules, evidenceEvents);
 
-  // Step 9: Deduplicate projections against confirmed events
-  const confirmedRefs = confirmedEvents.map((e) => ({
-    kennelId: e.kennelId,
-    date: e.date,
-    startTime: e.startTime,
-  }));
+  // Step 9: Deduplicate projections against confirmed events.
+  // A confirmed event renders under whichever NEARBY kennel matched (the
+  // pivot below), which may be a co-host rather than the event's primary
+  // `kennelId`. Key the dedup refs off the same matched-nearby kennels so a
+  // co-hosted confirmed event suppresses dated + cadence projections for the
+  // kennel its card actually renders under (not just the primary).
+  const confirmedRefs = confirmedEvents.flatMap((e) => {
+    const matchedNearby = matchedNearbyKennelIds(e.eventKennels, nearbyIdsSet);
+    const refKennelIds = matchedNearby.length > 0 ? matchedNearby : [e.kennelId];
+    return refKennelIds.map((kennelId) => ({
+      kennelId,
+      date: e.date,
+      startTime: e.startTime,
+    }));
+  });
   const dedupedProjections = deduplicateAgainstConfirmed(scoredProjections, confirmedRefs);
   const horizonFilteredProjections = filterProjectionsByHorizon(dedupedProjections, horizonTier);
 
@@ -577,17 +642,22 @@ async function runStopSearch(
   // multi-stop search shares one bounded MAX_WEATHER_API_CALLS batch.
   const weatherInputs: WeatherInput[] = [];
 
+  // Step 12: Drop synthetic, detail-less multi-day series umbrellas so they
+  // don't render as bare cards beside their real legs (see isBareSeriesUmbrella).
+  const displayConfirmedEvents = confirmedEvents.filter(
+    (event) => !isBareSeriesUmbrella(event),
+  );
+
   // Step 13: Assign distance tiers + build result objects
   // #1023 step 5: when an event matches because a CO-HOST kennel is in
   // `nearbyIds` (the primary `event.kennelId` may not be), pivot the
   // result's kennel metadata onto that nearby kennel — otherwise we'd
   // emit empty kennelSlug/kennelName/distance for the user's intended
   // destination kennel.
-  const nearbyIdsSet = new Set(nearbyIds);
-  const confirmedResults: ConfirmedResult[] = confirmedEvents.map((event) => {
+  const confirmedResults: ConfirmedResult[] = displayConfirmedEvents.map((event) => {
     const pivotKennelId = nearbyIdsSet.has(event.kennelId)
       ? event.kennelId
-      : (event.eventKennels.find((ek) => nearbyIdsSet.has(ek.kennelId))?.kennelId ?? event.kennelId);
+      : (matchedNearbyKennelIds(event.eventKennels, nearbyIdsSet)[0] ?? event.kennelId);
     const kennel = kennelMap.get(pivotKennelId);
     const eventLat = event.latitude ?? kennel?.latitude;
     const eventLng = event.longitude ?? kennel?.longitude;
@@ -628,6 +698,7 @@ async function runStopSearch(
       distanceTier: distanceTier(distanceKm),
       sourceLinks: buildSourceLinks(kennel, event.eventLinks, event.sourceUrl),
       weather: null,
+      seriesParentTitle: event.parentEvent?.title ?? null,
     };
   });
 


### PR DESCRIPTION
## What & why

Two data-integrity bugs in Travel Mode that surfaced as confusing cards (reported on a DCA → PHL → JFK trip).

### 1. Redundant cadence "possible" alongside a confirmed run
`deduplicateAgainstConfirmed` short-circuited dateless cadence projections (`if (!proj.date) return true`), so a kennel with a confirmed event still showed a vague "usually runs" possible — e.g. **GGFM full-moon** next to the confirmed **Strawberry Moon GGFM** run — and inflated the "Include possible (N)" count. A cadence sentinel is now suppressed when its kennel has any confirmed event in the window. Dedup refs are keyed off the **matched-nearby (co-host pivot) kennel**, so co-hosted confirmations dedupe correctly too — closing a pre-existing gap that also affected dated projections.

### 2. Multi-day series umbrellas rendered as bare cards
Travel's confirmed query used `CANONICAL_EVENT_WHERE` (no series filter), so a synthetic series-parent umbrella leaked in as a **detail-less card** beside its real legs (the "5-boro Pub Crawl 2026" garble). Travel now hides only **synthetic, detail-less** umbrellas (series parent with children and no per-day time/hares/venue). A **real** day-1 leg the merge promoted to parent (Hash Rego "earliest by date wins") keeps its detail and still renders. Each child leg shows a muted **"Part of: &lt;series&gt;"** tie so the legs read as one event.

## Notes
- The bare-umbrella test is a content-less heuristic (no schema migration) — chosen deliberately over a persisted flag.
- Reviewed adversarially (Codex), which caught a regression in the first pass: a blunt `childEvents: { none: {} }` filter would have deleted real promoted day-1 legs. Replaced with the content-aware predicate + a regression-guard test. The co-host dedup gap was fixed in the same pass.
- `/simplify` pass extracted two shared helpers (`matchedNearbyKennelIds`, `isBareSeriesUmbrella`) to lock the co-host-pivot contract in one place.

## Tests
- `npx tsc --noEmit` clean, `npm run lint` 0 errors, full travel suite **231 tests** pass.
- New coverage: GGFM-style cadence dedup, bare-umbrella hidden + series tie, **real promoted leg kept**, and **co-host cadence suppression**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)