### PR TITLE
fix(directory): surface CADENCE sentinel weekday + frequency in kennel filters

### DIFF
--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -635,6 +635,58 @@ describe("collectKennelWeekdays", () => {
   it("returns empty array when nothing is populated", () => {
     expect(collectKennelWeekdays({})).toEqual([]);
   });
+
+  it("includes the weekday from a LOW CADENCE sentinel (#2310 follow-up)", () => {
+    expect(
+      collectKennelWeekdays({
+        scheduleRules: [{ rrule: "CADENCE=WEEKLY;BYDAY=SU" }],
+      }),
+    ).toEqual(["Sunday"]);
+  });
+
+  it("unions a dated MEDIUM rule with a LOW CADENCE sentinel (Desert H3 mixed cadence)", () => {
+    expect(
+      collectKennelWeekdays({
+        scheduleRules: [
+          { rrule: "FREQ=WEEKLY;BYDAY=MO" },
+          { rrule: "CADENCE=WEEKLY;BYDAY=SU" },
+        ],
+      }),
+    ).toEqual(["Monday", "Sunday"]);
+  });
+
+  it("matches BIWEEKLY/MONTHLY CADENCE sentinels too", () => {
+    expect(
+      collectKennelWeekdays({
+        scheduleRules: [{ rrule: "CADENCE=BIWEEKLY;BYDAY=TH" }],
+      }),
+    ).toEqual(["Thursday"]);
+  });
+
+  it("ignores the FREQ=LUNAR sentinel (no BYDAY)", () => {
+    expect(
+      collectKennelWeekdays({
+        scheduleRules: [{ rrule: "FREQ=LUNAR" }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("rejects a multi-day CADENCE sentinel (BYDAY=SA,SU) for lockstep", () => {
+    expect(
+      collectKennelWeekdays({
+        scheduleRules: [{ rrule: "CADENCE=WEEKLY;BYDAY=SA,SU" }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("deduplicates when the flat field equals a CADENCE sentinel weekday", () => {
+    expect(
+      collectKennelWeekdays({
+        scheduleDayOfWeek: "Sunday",
+        scheduleRules: [{ rrule: "CADENCE=WEEKLY;BYDAY=SU" }],
+      }),
+    ).toEqual(["Sunday"]);
+  });
 });
 
 describe("collectKennelFrequencies", () => {
@@ -681,5 +733,41 @@ describe("collectKennelFrequencies", () => {
 
   it("returns empty array when nothing is populated", () => {
     expect(collectKennelFrequencies({})).toEqual([]);
+  });
+
+  it("derives a frequency from a CADENCE sentinel so it stays in lockstep with the day facet (#2310)", () => {
+    expect(
+      collectKennelFrequencies({ scheduleRules: [{ rrule: "CADENCE=WEEKLY;BYDAY=SU" }] }),
+    ).toEqual(["Weekly"]);
+  });
+
+  it("maps each CADENCE keyword to its FilterBar frequency label", () => {
+    expect(
+      collectKennelFrequencies({ scheduleRules: [{ rrule: "CADENCE=BIWEEKLY;BYDAY=TH" }] }),
+    ).toEqual(["Biweekly"]);
+    expect(
+      collectKennelFrequencies({ scheduleRules: [{ rrule: "CADENCE=MONTHLY;BYDAY=SA" }] }),
+    ).toEqual(["Monthly"]);
+  });
+
+  it("ignores the FREQ=LUNAR sentinel (no cadence keyword)", () => {
+    expect(
+      collectKennelFrequencies({ scheduleRules: [{ rrule: "FREQ=LUNAR" }] }),
+    ).toEqual([]);
+  });
+});
+
+describe("CADENCE sentinel day + frequency stay in lockstep (#2310 adversarial-review)", () => {
+  // A sentinel-only kennel whose Saturday activity is monthly must pass BOTH the
+  // "Saturday" day filter and the "Monthly" frequency filter — otherwise
+  // "Saturday + Monthly" would drop a kennel that "Saturday" alone includes.
+  const sentinelOnlyKennel = { scheduleRules: [{ rrule: "CADENCE=MONTHLY;BYDAY=SA" }] };
+
+  it("contributes Saturday to the day facet", () => {
+    expect(collectKennelWeekdays(sentinelOnlyKennel)).toEqual(["Saturday"]);
+  });
+
+  it("contributes Monthly to the frequency facet", () => {
+    expect(collectKennelFrequencies(sentinelOnlyKennel)).toEqual(["Monthly"]);
   });
 });

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -663,6 +663,19 @@ describe("collectKennelWeekdays", () => {
     ).toEqual(["Thursday"]);
   });
 
+  it("matches monthly nth-weekday CADENCE sentinels (e.g. 1SA, -1FR)", () => {
+    expect(
+      collectKennelWeekdays({
+        scheduleRules: [{ rrule: "CADENCE=MONTHLY;BYDAY=1SA" }],
+      }),
+    ).toEqual(["Saturday"]);
+    expect(
+      collectKennelWeekdays({
+        scheduleRules: [{ rrule: "CADENCE=MONTHLY;BYDAY=-1FR" }],
+      }),
+    ).toEqual(["Friday"]);
+  });
+
   it("ignores the FREQ=LUNAR sentinel (no BYDAY)", () => {
     expect(
       collectKennelWeekdays({

--- a/src/lib/schedule-season.ts
+++ b/src/lib/schedule-season.ts
@@ -280,9 +280,14 @@ function parseCadenceSentinel(
 ): { frequency: string; dayName: string | null } | null {
   const cadence = /^CADENCE=(WEEKLY|BIWEEKLY|MONTHLY)\b/.exec(rrule);
   if (!cadence) return null;
-  const byDay = /BYDAY=([A-Z,]+)/.exec(rrule);
-  // length !== 2 rejects multi-day "SA,SU"; unknown tokens fall through to null.
-  const dayName = byDay && byDay[1].length === 2 ? RRULE_DAY_TO_NAME[byDay[1]] ?? null : null;
+  // Capture the BYDAY value up to the next param, then accept an optional
+  // nth-weekday ordinal prefix (e.g. "1SA", "-1FR" on monthly sentinels) before
+  // the 2-letter token. The `$` anchor rejects multi-day values ("SA,SU"); an
+  // unrecognized token falls through to null — keeping the single-weekday
+  // lockstep the parsed path enforces.
+  const byDay = /BYDAY=([^;]+)/.exec(rrule);
+  const token = byDay ? /^(-?\d+)?([A-Z]{2})$/.exec(byDay[1]) : null;
+  const dayName = token ? RRULE_DAY_TO_NAME[token[2]] ?? null : null;
   return { frequency: CADENCE_TO_FREQUENCY[cadence[1]], dayName };
 }
 

--- a/src/lib/schedule-season.ts
+++ b/src/lib/schedule-season.ts
@@ -28,6 +28,27 @@ export const WEEKDAY_NAMES = [
 ] as const;
 
 /**
+ * RRULE 2-char BYDAY token → weekday name. Mirrors the private map in
+ * `@/lib/travel/projections.ts`; duplicated here deliberately because
+ * projections.ts imports from this module, so importing it back would create a
+ * circular dependency. Used to surface CADENCE sentinel weekdays (see
+ * `extractSentinelWeekday`).
+ */
+const RRULE_DAY_TO_NAME: Record<string, string> = {
+  SU: "Sunday", MO: "Monday", TU: "Tuesday", WE: "Wednesday",
+  TH: "Thursday", FR: "Friday", SA: "Saturday",
+};
+
+/**
+ * CADENCE sentinel keyword → FilterBar frequency label. Keeps the sentinel
+ * frequency facet aligned with the parsed-rule path (`FREQ=WEEKLY` interval 1/2 →
+ * Weekly/Biweekly, `FREQ=MONTHLY` → Monthly).
+ */
+const CADENCE_TO_FREQUENCY: Record<string, string> = {
+  WEEKLY: "Weekly", BIWEEKLY: "Biweekly", MONTHLY: "Monthly",
+};
+
+/**
  * One schedule slot for display. Built from a `Kennel.scheduleRules` row when
  * present; the legacy flat fields collapse to a single ScheduleSlot when not.
  */
@@ -214,6 +235,13 @@ function formatMonthRange(from: MonthDay | null, until: MonthDay | null): string
  * Rejects multi-day BYDAY (`BYDAY=SA,SU`) so it stays in lockstep with
  * `formatSchedule`'s RRULE renderer — only single-weekday slots round-trip
  * through the UI.
+ *
+ * Also includes the weekday from LOW-confidence `CADENCE=…` sentinels (#2310
+ * follow-up). These aren't RFC-5545 parseable, so `safeParseRrule` returns null,
+ * but they encode a real occasional weekday the kennel runs (e.g. Desert H3's
+ * occasional Sunday) — so they should still surface in the directory/region
+ * weekday facets. See `parseCadenceSentinel` (whose frequency half keeps
+ * `collectKennelFrequencies` in lockstep with this facet).
  */
 export function collectKennelWeekdays(k: {
   scheduleDayOfWeek?: string | null;
@@ -223,14 +251,48 @@ export function collectKennelWeekdays(k: {
   if (k.scheduleDayOfWeek) days.add(k.scheduleDayOfWeek);
   for (const rule of k.scheduleRules ?? []) {
     const parsed = safeParseRrule(rule.rrule);
-    if (parsed?.byDay) days.add(WEEKDAY_NAMES[parsed.byDay.day]);
+    if (parsed?.byDay) {
+      days.add(WEEKDAY_NAMES[parsed.byDay.day]);
+      continue;
+    }
+    const sentinelDay = parseCadenceSentinel(rule.rrule)?.dayName;
+    if (sentinelDay) days.add(sentinelDay);
   }
   return [...days];
 }
 
 /**
+ * Parse a LOW-confidence CADENCE sentinel
+ * (`CADENCE=WEEKLY|BIWEEKLY|MONTHLY;BYDAY=XX`) into the weekday + frequency it
+ * encodes. These aren't RFC-5545 parseable (no FREQ), so `parseRRule` rejects
+ * them — but they encode real occasional activity that BOTH the directory day
+ * filter AND the frequency filter should see, so the two facets stay in lockstep
+ * (#2310 follow-up; without symmetric handling a kennel could match the "Sunday"
+ * day filter yet be dropped by "Sunday + Weekly").
+ *
+ * Returns null for non-sentinels (incl. `FREQ=LUNAR`). `dayName` is null for
+ * multi-day BYDAY (kept in lockstep with the single-weekday parsed path) or an
+ * unrecognized token; `frequency` mirrors the parsed-rule path, which derives a
+ * frequency label independent of BYDAY.
+ */
+function parseCadenceSentinel(
+  rrule: string,
+): { frequency: string; dayName: string | null } | null {
+  const cadence = /^CADENCE=(WEEKLY|BIWEEKLY|MONTHLY)\b/.exec(rrule);
+  if (!cadence) return null;
+  const byDay = /BYDAY=([A-Z,]+)/.exec(rrule);
+  // length !== 2 rejects multi-day "SA,SU"; unknown tokens fall through to null.
+  const dayName = byDay && byDay[1].length === 2 ? RRULE_DAY_TO_NAME[byDay[1]] ?? null : null;
+  return { frequency: CADENCE_TO_FREQUENCY[cadence[1]], dayName };
+}
+
+/**
  * Derive legacy-style frequency labels (Weekly / Biweekly / Monthly) this
  * kennel matches, considering both `scheduleFrequency` and any `scheduleRules`.
+ *
+ * Includes LOW-confidence `CADENCE=…` sentinels (#2310 follow-up) so the
+ * frequency facet stays symmetric with `collectKennelWeekdays`'s day facet —
+ * see `parseCadenceSentinel`.
  */
 export function collectKennelFrequencies(k: {
   scheduleFrequency?: string | null;
@@ -240,7 +302,11 @@ export function collectKennelFrequencies(k: {
   if (k.scheduleFrequency) labels.add(k.scheduleFrequency);
   for (const rule of k.scheduleRules ?? []) {
     const parsed = safeParseRrule(rule.rrule);
-    if (!parsed) continue;
+    if (!parsed) {
+      const sentinel = parseCadenceSentinel(rule.rrule);
+      if (sentinel) labels.add(sentinel.frequency);
+      continue;
+    }
     if (parsed.freq === "WEEKLY") {
       // Map only interval=1 → Weekly and interval=2 → Biweekly. Higher
       // intervals (triweekly, quadweekly, etc.) aren't part of the


### PR DESCRIPTION
## Context

PR #2310 (mixed per-weekday cadence prediction) introduced LOW-confidence `CADENCE=…` sentinel schedule rules — non-RFC-5545 strings like `CADENCE=WEEKLY;BYDAY=SU` that encode a weekday a kennel *occasionally* runs but that are never projected as specific dates. Concrete case: **Desert H3** (`dh3-ae`) carries a MEDIUM dated `FREQ=WEEKLY;BYDAY=MO` rule plus a LOW `CADENCE=WEEKLY;BYDAY=SU` sentinel.

Codex flagged (review on #2310) that `collectKennelWeekdays` in `src/lib/schedule-season.ts` derives weekday facets **only** from `parseRRule`, which throws on sentinels. So Desert H3 never appeared under the directory "runs on Sunday" filter, and the Dubai region intro prose omitted Sundays — even though the kennel genuinely sometimes runs Sundays.

## What changed

The directory **day** filter and **frequency** filter are ANDed, so handling sentinels on only one side is worse than not at all: a kennel could match "Sunday" yet be dropped by "Sunday + Weekly". This makes both facets see sentinels, symmetrically.

- New shared `parseCadenceSentinel(rrule)` → `{ frequency, dayName }`, consumed by both `collectKennelWeekdays` (`.dayName`) and `collectKennelFrequencies` (`.frequency`).
- `CADENCE_TO_FREQUENCY` maps `WEEKLY`/`BIWEEKLY`/`MONTHLY` → the FilterBar `Weekly`/`Biweekly`/`Monthly` labels.
- Helper is defined **locally** rather than importing `extractDayFromSentinel` from `src/lib/travel/projections.ts` — that module imports *from* `schedule-season.ts`, so importing back would be a circular dependency.
- Rejects multi-day BYDAY for the day facet (lockstep with the parsed-rule path); ignores `FREQ=LUNAR` (no cadence/day).
- No schema/migration/seed change — the `dh3-ae` sentinel rule already shipped in #2310. The two consumers (`KennelDirectory.tsx`, `kennels/region/[slug]/page.tsx`) pick up the extra days/frequencies automatically.

Decision context: surfacing sentinel weekdays in the hard facet is a recall-over-precision call for a discovery surface; the uncertainty is still conveyed in Travel Mode ("possible activity") and the kennel-page rule label ("Sunday afternoon (cooler months)").

## Testing

`src/lib/format.test.ts` — extended both describe blocks:
- Day facet: lone sentinel, Desert H3 mixed (`["Monday","Sunday"]`), BIWEEKLY sentinel, `FREQ=LUNAR` ignored, multi-day rejected, flat-field dedup.
- Frequency facet: sentinel cadence derivation, each keyword's label, `FREQ=LUNAR` ignored.
- Dedicated lockstep block: a `CADENCE=MONTHLY;BYDAY=SA` kennel passes **both** the Saturday day facet and the Monthly frequency facet.

Verified locally: affected test file **134 passed**, `npx tsc --noEmit` clean, `npx eslint` clean. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)