### PR TITLE
docs: correct NEXT_PUBLIC_APP_URL example to production domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ logbook + kennel directory.
 - GITHUB_TOKEN=           # GitHub PAT with repo scope (for filing issues from alerts, user feedback, auto-issue dedup + rate limiting)
 - STRAVA_CLIENT_ID=      # Strava OAuth app client ID
 - STRAVA_CLIENT_SECRET=  # Strava OAuth app client secret
-- NEXT_PUBLIC_APP_URL=    # Base URL for invite links (e.g., https://hashtracks.com)
+- NEXT_PUBLIC_APP_URL=    # Base URL for invite links (production: https://www.hashtracks.xyz)
 - RESIDENTIAL_PROXY_URL=  # NAS residential proxy URL (for WAF-blocked scrape targets)
 - RESIDENTIAL_PROXY_KEY=  # API key for residential proxy auth
 - BROWSER_RENDER_URL=    # NAS browser render service URL (for JS-rendered sites + iframe extraction via frameUrl)


### PR DESCRIPTION
## What

CLAUDE.md listed the app base URL example as `https://hashtracks.com`, but that domain is **parked** (302 → hugedomains.com). The live app is served from **hashtracks.xyz** — the production deploy emits `https://www.hashtracks.xyz` as its canonical / `og:url` base, and Clerk runs on `clerk.hashtracks.xyz`.

Updated the `NEXT_PUBLIC_APP_URL` example comment to the real production domain. (The actual env var in Vercel is already correct — this only fixes the stale doc example.)

```diff
-- NEXT_PUBLIC_APP_URL=    # Base URL for invite links (e.g., https://hashtracks.com)
+- NEXT_PUBLIC_APP_URL=    # Base URL for invite links (production: https://www.hashtracks.xyz)
```

Doc-only change; no code or behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)