### PR TITLE
fix(adapters): shared-adapter parse/window/attribution bugs (audit cluster)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -785,6 +785,21 @@ export const SOURCES = [
           String.raw`Hare:?\s+(.+?)(?:(?=[-\u2013\u2014]\s*\S)|\s*$)`,
           String.raw`^DST\s*#?\s*\d*\s*-\s*(.+)$`,
         ],
+        // #2349: SH3 frequently omits the "#" ("SH3 871 Anni Tua", "SH3 879
+        // Lone Thrills") so the shared #-parser misses the run number. Pull it
+        // from the summary (anchored to the SH3 prefix so a digit in a theme
+        // can't false-match). Events that DO carry "#" ("SH3 #859") are already
+        // handled by the shared parser before this runs.
+        summaryRunNumberPatterns: [String.raw`^SH3\s*#?\s*(\d{2,4})\b`],
+        // #2349 / #2351: strip the redundant "SH3 [#] NNN" / "FM #NNN -" run
+        // prefix that leaks into the title (the run number is already in its own
+        // field). Leaves the theme ("Fit Squirter", "Photo Bleibt") or an empty
+        // title that the default/merge synthesis fills. DST is intentionally
+        // omitted \u2014 its post-dash text is the hare (titleHarePattern handles it).
+        titleStripPatterns: [
+          String.raw`^SH3\s*#?\s*\d+\s*-?\s*`,
+          String.raw`^FM\s*#?\s*\d+\s*-?\s*`,
+        ],
       },
       kennelCodes: ["sh3-de", "dst-h3", "fm-stgt", "super-h3"],
     },
@@ -3419,7 +3434,11 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "every_6h",
       scrapeDays: 90,
-      config: { defaultKennelTag: "sch3-ca" },
+      // #2388: the Wharf-to-Barf weekend (#1424–#1426, multi-day) is published as
+      // all-day events, which the adapter drops by default. Surf City publishes
+      // regular weekly trails with explicit times, so these all-day rows are
+      // genuine special events to admit, not noise.
+      config: { defaultKennelTag: "sch3-ca", includeAllDayEvents: true },
       kennelCodes: ["sch3-ca"],
     },
     // --- Sacramento (HTML_SCRAPER, Squarespace events ?format=json) ---
@@ -3487,7 +3506,12 @@ export const SOURCES = [
       type: "GOOGLE_CALENDAR" as const,
       trustLevel: 7,
       scrapeFreq: "every_6h",
-      scrapeDays: 90,
+      // #2382: the GCal future window is min(scrapeDays, futureHorizonDays), so
+      // scrapeDays:90 silently capped the FORWARD horizon at 90 days and dropped
+      // SUPH3's late-2026 trails (the calendar carries events out to Dec 2026).
+      // 365 restores the full forward window (and ~1yr of recent history); deeper
+      // 2023–2024 backfill is tracked separately.
+      scrapeDays: 365,
       config: { defaultKennelTag: "suph3" },
       kennelCodes: ["suph3"],
     },
@@ -4419,11 +4443,18 @@ export const SOURCES = [
       scrapeFreq: "daily",
       scrapeDays: 365,
       config: {
+        // #2355: hash.se publishes one shared feed for the whole Stockholm scene
+        // (SUH3 Sunday, SAH3 Saturday, plus BASH, SPOR&DIC, LYH3, SMH3,
+        // Cocktails@3, Absolut, Harriettes specials…). We only track SUH3 + SAH3;
+        // every real run of those two is prefix-tagged ("SUH3 #1667", "SAH3
+        // #1017: …"), so anchor the patterns and drop the defaultKennelTag.
+        // strictKennelRouting then SKIPS the untracked series instead of welding
+        // them onto SUH3. Reconcile-safe: all real SUH3/SAH3 events still match.
         kennelPatterns: [
-          ["SUH3", "suh3"],
-          ["SAH3", "sah3-se"],
+          ["^SUH3\\b", "suh3"],
+          ["^SAH3\\b", "sah3-se"],
         ],
-        defaultKennelTag: "suh3",
+        strictKennelRouting: true,
       },
       kennelCodes: ["suh3", "sah3-se"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -790,15 +790,15 @@ export const SOURCES = [
         // from the summary (anchored to the SH3 prefix so a digit in a theme
         // can't false-match). Events that DO carry "#" ("SH3 #859") are already
         // handled by the shared parser before this runs.
-        summaryRunNumberPatterns: [String.raw`^SH3\s*#?\s*(\d{2,4})\b`],
+        summaryRunNumberPatterns: [String.raw`^SH3\s*(?:#\s*)?(\d{2,4})\b`],
         // #2349 / #2351: strip the redundant "SH3 [#] NNN" / "FM #NNN -" run
         // prefix that leaks into the title (the run number is already in its own
         // field). Leaves the theme ("Fit Squirter", "Photo Bleibt") or an empty
         // title that the default/merge synthesis fills. DST is intentionally
         // omitted \u2014 its post-dash text is the hare (titleHarePattern handles it).
         titleStripPatterns: [
-          String.raw`^SH3\s*#?\s*\d+\s*-?\s*`,
-          String.raw`^FM\s*#?\s*\d+\s*-?\s*`,
+          String.raw`^SH3\s*(?:#\s*)?\d+\s*(?:-\s*)?`,
+          String.raw`^FM\s*(?:#\s*)?\d+\s*(?:-\s*)?`,
         ],
       },
       kennelCodes: ["sh3-de", "dst-h3", "fm-stgt", "super-h3"],

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -498,6 +498,25 @@ describe("extractRunNumber", () => {
     ).toBeUndefined();
   });
 
+  // #2349 Stuttgart SH3 — summaryRunNumberPatterns (4th arg) pull the run number
+  // from the SUMMARY when "#" is omitted.
+  it.each([
+    ["SH3 871 Anni Tua", 871],
+    ["SH3 879  Lone Thrills", 879],
+    ["SH3 873", 873],
+  ])("extracts a no-# summary run number via summaryRunNumberPatterns: %j", (summary, expected) => {
+    expect(extractRunNumber(summary, undefined, undefined, [String.raw`^SH3\s*#?\s*(\d{2,4})\b`])).toBe(expected);
+  });
+
+  it("the shared #-parser still wins over summaryRunNumberPatterns", () => {
+    // "SH3 #859" — the "#" form is parsed first; the summary pattern is never reached.
+    expect(extractRunNumber("SH3 #859 Fit Squirter", undefined, undefined, [String.raw`^SH3\s*#?\s*(\d{2,4})\b`])).toBe(859);
+  });
+
+  it("summaryRunNumberPatterns are anchored — a digit in a non-SH3 theme is ignored", () => {
+    expect(extractRunNumber("SUGAR H3 - Bye Bye 39", undefined, undefined, [String.raw`^SH3\s*#?\s*(\d{2,4})\b`])).toBeUndefined();
+  });
+
   // #1009 Bushman H3: source description starts "What: Bushman HHH No. 251" —
   // matched by per-source `runNumberPatterns` config in the Chicagoland Hash
   // Calendar entry. Also handles the bare "Bushman No. 251" variant.
@@ -6248,5 +6267,79 @@ describe("Salem H3 — all-day events admitted, placeholder stubs skipped (#2209
       skipOpts,
     );
     expect(result).toBeNull();
+  });
+});
+
+// ── #2349 / #2351 Stuttgart SH3 / FM run-prefix leak + no-# run number ──
+
+describe("Stuttgart SH3/FM run-prefix strip + summary run number (#2349/#2351)", () => {
+  // Inline-compiled equivalents of the seed config's summaryRunNumberPatterns +
+  // titleStripPatterns (the production fetch path compiles these from config and
+  // passes them in the options bag).
+  const opts = {
+    compiledSummaryRunNumberPatterns: [/^SH3\s*#?\s*(\d{2,4})\b/i],
+    compiledTitleStripPatterns: [/^SH3\s*#?\s*\d+\s*-?\s*/i, /^FM\s*#?\s*\d+\s*-?\s*/i],
+  };
+  const config = { defaultKennelTag: "sh3-de" };
+  const build = (summary: string) =>
+    buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-04-15T19:00:00+02:00" }, status: "confirmed" },
+      config,
+      opts,
+    );
+
+  it.each([
+    // [summary, expected runNumber, expected title]
+    ["SH3 #859 Fit Squirter", 859, "Fit Squirter"],   // "#" form: shared parser + prefix strip
+    ["SH3 871 Anni Tua", 871, "Anni Tua"],             // no-# form: summary pattern + prefix strip
+    ["SH3 # 874", 874, undefined],                     // bare run → title cleared → default/merge synth
+  ])("strips the SH3 prefix and extracts the run from %j", (summary, run, title) => {
+    const r = build(summary);
+    expect(r?.runNumber).toBe(run);
+    expect(r?.title || undefined).toBe(title);
+  });
+
+  it("strips the FM run prefix, keeping the theme (#2351)", () => {
+    const r = build("FM #179 - Motel Six");
+    expect(r?.runNumber).toBe(179);
+    expect(r?.title).toBe("Motel Six");
+  });
+
+  it("the Stuttgart seed source carries the run/strip config", () => {
+    const cfg = (SOURCES.find((s) => s.name === "Stuttgart H3 Google Calendar")?.config ?? {}) as {
+      summaryRunNumberPatterns?: string[];
+      titleStripPatterns?: string[];
+    };
+    expect(cfg.summaryRunNumberPatterns?.length).toBeGreaterThan(0);
+    expect(cfg.titleStripPatterns?.length).toBeGreaterThan(0);
+  });
+});
+
+// ── #2388 Surf City admits all-day events (Wharf to Barf weekend) ──
+
+describe("Surf City all-day events (#2388)", () => {
+  it("the Surf City seed source opts into all-day events", () => {
+    const cfg = (SOURCES.find((s) => s.name === "Surf City H3 Google Calendar")?.config ?? {}) as {
+      includeAllDayEvents?: boolean;
+    };
+    expect(cfg.includeAllDayEvents).toBe(true);
+  });
+
+  it("admits an all-day event when includeAllDayEvents is set", () => {
+    const r = buildRawEventFromGCalItem(
+      { summary: "Surf City Hash 1424 - Wharf to Barf Pub Crawl", start: { date: "2026-07-24" }, status: "confirmed" },
+      { defaultKennelTag: "sch3-ca", includeAllDayEvents: true },
+    );
+    expect(r).not.toBeNull();
+    expect(r?.date).toBe("2026-07-24");
+    expect(r?.startTime).toBeUndefined();
+  });
+
+  it("still drops the all-day event without the opt-in (regression guard)", () => {
+    const r = buildRawEventFromGCalItem(
+      { summary: "Surf City Hash 1424 - Wharf to Barf Pub Crawl", start: { date: "2026-07-24" }, status: "confirmed" },
+      { defaultKennelTag: "sch3-ca" },
+    );
+    expect(r).toBeNull();
   });
 });

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -505,16 +505,16 @@ describe("extractRunNumber", () => {
     ["SH3 879  Lone Thrills", 879],
     ["SH3 873", 873],
   ])("extracts a no-# summary run number via summaryRunNumberPatterns: %j", (summary, expected) => {
-    expect(extractRunNumber(summary, undefined, undefined, [String.raw`^SH3\s*#?\s*(\d{2,4})\b`])).toBe(expected);
+    expect(extractRunNumber(summary, undefined, undefined, [String.raw`^SH3\s*(?:#\s*)?(\d{2,4})\b`])).toBe(expected);
   });
 
   it("the shared #-parser still wins over summaryRunNumberPatterns", () => {
     // "SH3 #859" — the "#" form is parsed first; the summary pattern is never reached.
-    expect(extractRunNumber("SH3 #859 Fit Squirter", undefined, undefined, [String.raw`^SH3\s*#?\s*(\d{2,4})\b`])).toBe(859);
+    expect(extractRunNumber("SH3 #859 Fit Squirter", undefined, undefined, [String.raw`^SH3\s*(?:#\s*)?(\d{2,4})\b`])).toBe(859);
   });
 
   it("summaryRunNumberPatterns are anchored — a digit in a non-SH3 theme is ignored", () => {
-    expect(extractRunNumber("SUGAR H3 - Bye Bye 39", undefined, undefined, [String.raw`^SH3\s*#?\s*(\d{2,4})\b`])).toBeUndefined();
+    expect(extractRunNumber("SUGAR H3 - Bye Bye 39", undefined, undefined, [String.raw`^SH3\s*(?:#\s*)?(\d{2,4})\b`])).toBeUndefined();
   });
 
   // #1009 Bushman H3: source description starts "What: Bushman HHH No. 251" —
@@ -6277,8 +6277,8 @@ describe("Stuttgart SH3/FM run-prefix strip + summary run number (#2349/#2351)",
   // titleStripPatterns (the production fetch path compiles these from config and
   // passes them in the options bag).
   const opts = {
-    compiledSummaryRunNumberPatterns: [/^SH3\s*#?\s*(\d{2,4})\b/i],
-    compiledTitleStripPatterns: [/^SH3\s*#?\s*\d+\s*-?\s*/i, /^FM\s*#?\s*\d+\s*-?\s*/i],
+    compiledSummaryRunNumberPatterns: [/^SH3\s*(?:#\s*)?(\d{2,4})\b/i],
+    compiledTitleStripPatterns: [/^SH3\s*(?:#\s*)?\d+\s*(?:-\s*)?/i, /^FM\s*(?:#\s*)?\d+\s*(?:-\s*)?/i],
   };
   const config = { defaultKennelTag: "sh3-de" };
   const build = (summary: string) =>

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -88,6 +88,7 @@ export function extractRunNumber(
   summary: string,
   description?: string,
   customPatterns?: string[] | RegExp[],
+  summaryPatterns?: string[] | RegExp[],
 ): number | null | undefined {
   // 1. Check summary first (e.g., "Beantown #255: ...", "BH3: ... #2781", "Cunth # 40: ...").
   // Shared `extractHashRunNumber` enforces the delimiter guard (#1147) — "#30X?"
@@ -101,6 +102,14 @@ export function extractRunNumber(
   const fromSummary = extractHashRunNumber(summary)
     ?? (summary.includes("!") ? extractHashRunNumber(summary.replaceAll("!", " ")) : undefined);
   if (fromSummary !== undefined) return fromSummary;
+
+  // 1a. Per-source SUMMARY run-number patterns (#2349 Stuttgart "SH3 871"): only
+  // reached when the shared `#`-delimited parser found nothing, so a `#`-style
+  // number always wins. Anchored, capture-group patterns from source config.
+  if (summaryPatterns?.length) {
+    const fromSummaryPattern = extractRunNumberFromDescription(summary, summaryPatterns);
+    if (fromSummaryPattern !== undefined) return fromSummaryPattern;
+  }
 
   // 1b/1c. Leading "<word> NNNN:" run markers that omit the `#`, colon-anchored
   // so a year-shaped digit run in prose can't false-match: "Hash NNNN:" (#2007
@@ -1055,6 +1064,12 @@ interface CalendarSourceConfig {
   skipPatterns?: string[];              // regex strings — skip events whose summary matches
   harePatterns?: string[];              // regex strings to extract hares from descriptions
   runNumberPatterns?: string[];         // regex strings to extract run numbers from descriptions
+  /** #2349 Stuttgart SH3: regex(es) (capture group = digits) to pull a run
+   *  number from the SUMMARY when it omits the `#` ("SH3 871", "SH3 879 Lone
+   *  Thrills"). Distinct from `runNumberPatterns` (description-only) — these
+   *  scan the summary, tried only after the shared `#`-delimited parser misses.
+   *  Anchor them (`^SH3\s*#?\s*(\d{2,4})`) so a digit run in a theme can't win. */
+  summaryRunNumberPatterns?: string[];
   /** Regex(es) to extract hare names from summary when description has none.
    *  Accepts a single pattern string or an array tried in order — first
    *  capture-group hit wins (#1208 DST + Stuttgart SH3 share a source;
@@ -1428,6 +1443,7 @@ function parseCalendarSourceConfig(config: unknown): CalendarSourceConfig | null
 export interface BuildRawEventFromGCalItemOptions {
   compiledHarePatterns?: RegExp[];
   compiledRunNumberPatterns?: RegExp[];
+  compiledSummaryRunNumberPatterns?: RegExp[];
   compiledSkipPatterns?: RegExp[];
   compiledTitleHarePatterns?: RegExp[];
   compiledTitleLocationPatterns?: RegExp[];
@@ -1463,6 +1479,7 @@ export function buildRawEventFromGCalItem(
   const {
     compiledHarePatterns,
     compiledRunNumberPatterns,
+    compiledSummaryRunNumberPatterns,
     compiledSkipPatterns,
     compiledTitleHarePatterns,
     compiledTitleLocationPatterns,
@@ -2027,7 +2044,7 @@ export function buildRawEventFromGCalItem(
   // #1761 — a run number promoted from a placeholder summary's description
   // header overrides the cleared placeholder (extractRunNumber returns null
   // for "#?"). Otherwise fall back to the normal summary/description scan.
-  const runNumber = promotedRunNumber ?? extractRunNumber(summary, rawDescription, compiledRunNumberPatterns);
+  const runNumber = promotedRunNumber ?? extractRunNumber(summary, rawDescription, compiledRunNumberPatterns, compiledSummaryRunNumberPatterns);
 
   // #1426 — sport-domain title (e.g. "Lansing Crisis Rugby Game") with no
   // hash-confirming signal. Three signals override: runNumber, hares, or
@@ -2178,6 +2195,9 @@ function compileSourceConfigPatterns(sourceConfig: CalendarSourceConfig | null) 
       : undefined,
     compiledRunNumberPatterns: sourceConfig?.runNumberPatterns?.length
       ? compilePatterns(sourceConfig.runNumberPatterns)
+      : undefined,
+    compiledSummaryRunNumberPatterns: sourceConfig?.summaryRunNumberPatterns?.length
+      ? compilePatterns(sourceConfig.summaryRunNumberPatterns, "i")
       : undefined,
     compiledSkipPatterns: sourceConfig?.skipPatterns?.length
       ? compilePatterns(sourceConfig.skipPatterns, "i")

--- a/src/adapters/hare-extraction.test.ts
+++ b/src/adapters/hare-extraction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractHares } from "./hare-extraction";
+import { extractHares, cleanAndFilterHares } from "./hare-extraction";
 
 type ExpectedRow = readonly [label: string, desc: string, expected: string];
 type UndefinedRow = readonly [label: string, desc: string];
@@ -478,5 +478,27 @@ describe("extractHares — Co-Hare merge + annotation strip (#1212 GLH3)", () =>
     { name: "unrelated description text — primary only", desc: "Hare: Alice\nLocation: 123 Main St", expected: "Alice" },
   ])("$name", ({ desc, expected }) => {
     expect(extractHares(desc)).toBe(expected);
+  });
+});
+
+// ── cleanAndFilterHares — hash ROLE-label strip (#2368 StumpH3) ──
+
+describe("cleanAndFilterHares — role labels (#2368 StumpH3)", () => {
+  it.each([
+    ["Hare-Deaf Dick. Jedi-Premature Evacuation", "Deaf Dick, Premature Evacuation"],
+    ["Hare- Just Jessie", "Just Jessie"],
+    ["Hares- I'm Gonna Cum and Cum Squadron, Jedi- I'm Gonna Cum", "I'm Gonna Cum and Cum Squadron, I'm Gonna Cum"],
+    ["Hare-Big Shitter Jedi-I'm Gonna Cum", "Big Shitter, I'm Gonna Cum"],
+    ["Hare and Jedi: Mouthful.", "Mouthful"],
+    ["Hare/Jedi double doody: RPM", "RPM"],
+    ["Knotty By Nature. Jedi: Just Val", "Knotty By Nature, Just Val"],
+    ["Hared by Purdy Mouth, the W.T.F.", "Purdy Mouth, the W.T.F"],
+  ])("strips role labels: %j → %j", (raw, expected) => {
+    expect(cleanAndFilterHares(raw)).toBe(expected);
+  });
+
+  it("leaves a plain hare name untouched (no labels)", () => {
+    expect(cleanAndFilterHares("Khuming Rouge")).toBe("Khuming Rouge");
+    expect(cleanAndFilterHares("Mudflap & Trail Blazer")).toBe("Mudflap & Trail Blazer");
   });
 });

--- a/src/adapters/hare-extraction.ts
+++ b/src/adapters/hare-extraction.ts
@@ -106,6 +106,32 @@ const DATE_RANGE_RE = /\b\d{1,2}\s*\/\s*\d{1,2}\b/;
 // can capture the label along with the value. Strip a residual
 // "Hares:/Hare:/Who:/Sweep:/Hare Raiser:" prefix so it never surfaces.
 const LEADING_HARE_LABEL_RE = /^(?:hares?|who|sweep|hare\s*raiser)\s*:\s*/i; // NOSONAR — anchored, bounded literal alternation
+// #2368 StumpH3 — descriptions wrap the hashers in hash ROLE labels with a dash
+// OR colon: "Hare-Deaf Dick. Jedi-Premature Evacuation", "Hares- A and B, Jedi-
+// C", plus the combined "Hare and Jedi:" / "Hare/Jedi double doody:" forms. The
+// labels are roles, not names. Strip the combined + leading labels, and turn a
+// mid-string role label into a comma so the two co-hares read as one list:
+// "Hare-Deaf Dick. Jedi-Premature Evacuation" → "Deaf Dick, Premature Evacuation".
+// Gate: does the value carry any hash role label at all? Non-global (no lastIndex
+// state) so the fast-path test is stable. When it misses, stripHareRoleLabels is
+// a byte-identical no-op — preserving fingerprint stability for the ~all hares
+// that have no role label (no separator/punctuation normalization → no churn).
+const HAS_ROLE_LABEL_RE = /\b(?:hares?\s*[-:]|jedi\s*[-:]|hared\s+by|hare\s*(?:and|\/)\s*jedi)/i; // NOSONAR S5852 — single quantifiers, char class
+const COMBINED_HARE_JEDI_LABEL_RE = /\bhare\s*(?:and|\/)\s*jedi\b[^:]{0,30}:\s*/gi; // NOSONAR S5852 — bounded {0,30}, single quantifiers
+const LEADING_ROLE_LABEL_RE = /^\s*(?:hares?\s*[-:]|hared\s+by)\s*/i; // NOSONAR S5852 — anchored, single quantifiers
+const JEDI_ROLE_LABEL_RE = /[\s.,/]*\bjedi\s*[-:]\s*/gi; // NOSONAR S5852 — single quantifiers, char class not alternation
+const MID_HARE_ROLE_LABEL_RE = /[\s.,/]+hares?\s*[-:]\s*/gi; // NOSONAR S5852 — leading separator required, single quantifiers
+function stripHareRoleLabels(value: string): string {
+  if (!HAS_ROLE_LABEL_RE.test(value)) return value;
+  return value
+    .replace(COMBINED_HARE_JEDI_LABEL_RE, "")
+    .replace(LEADING_ROLE_LABEL_RE, "")
+    .replace(JEDI_ROLE_LABEL_RE, ", ")
+    .replace(MID_HARE_ROLE_LABEL_RE, ", ")
+    .replace(/^[\s,]+/, "")
+    .replace(/[\s,.]+$/, "")
+    .trim();
+}
 // #2008 PGH H3 — a bare kennel code ("Who: PGHH3") is the kennel name, never a
 // hash name. Rejected via the shared BARE_KENNEL_CODE_RE (imported from utils).
 // #2008 PGH H3 row 4 — a conversational "…and you, of course" tail is not part
@@ -217,7 +243,7 @@ function collectContinuationLines(normalized: string, match: RegExpExecArray): s
  * re-implementing a weaker subset of its passes.
  */
 export function cleanAndFilterHares(raw: string): string | null | undefined {
-  let hares = raw
+  let hares = stripHareRoleLabels(raw)
     .replace(LEADING_HARE_LABEL_RE, "")
     .trim()
     .replace(ASTERISK_TAIL_RE, "")

--- a/src/adapters/harrier-central/adapter.test.ts
+++ b/src/adapters/harrier-central/adapter.test.ts
@@ -179,6 +179,21 @@ describe("composeHcLocation", () => {
   ])("drops placeholder sentinel from location: %s", (_label, place, resolvable, cityCountry) => {
     expect(composeHcLocation(place, resolvable, cityCountry)).toBeUndefined();
   });
+
+  // #2376 Bandung: the kennel pastes the run title into HC's venue field. Strip
+  // the "[code] Run <digits> at|:" prefix so only the venue text survives.
+  it.each([
+    ["BHHH2 Run 2288 at Gd. Abadi, Lembang", "Gd. Abadi, Lembang"],
+    ["BHHH2 Run 2292: Gd. BHHH2, Panorama, Lembang", "Gd. BHHH2, Panorama, Lembang"],
+    ["Run 2298 at Gd. BHHH2", "Gd. BHHH2"],
+  ])("strips a run-title prefix from the location: %s", (place, expected) => {
+    // resolvable is a coords-only sentinel, so output is the stripped place verbatim.
+    expect(composeHcLocation(place, "35.713, 139.704")).toBe(expected);
+  });
+
+  it("leaves a real venue that merely contains the word 'Run' untouched", () => {
+    expect(composeHcLocation("Run River Cafe, 5 Mill St", "35.713, 139.704")).toBe("Run River Cafe, 5 Mill St");
+  });
 });
 
 describe("applyTitleFallback (#1166)", () => {
@@ -467,6 +482,49 @@ describe("HarrierCentralAdapter", () => {
       const result = await adapter.fetch(makeSource({ defaultKennelTag: "tokyo-h3" }));
       expect(result.events[0].hares).toBe("Blue Job");
       expect(result.events[0].location).toBe("Nishiogikubo");
+    });
+
+    it("nulls a single-word neighborhood hare that equals the raw venue (#2408 Tokyo #2591)", async () => {
+      // Source pasted the neighborhood into hares, title AND venue. The composed
+      // location is "Azabujuban, Tokyo, Japan" (city appended), which the
+      // substring/address-signal check misses — the raw-place match catches it.
+      mockApiResponse([
+        buildHCEvent({
+          eventNumber: 2591,
+          eventName: "Azabujuban",
+          hares: "Azabujuban",
+          locationOneLineDesc: "Azabujuban",
+          resolvableLocation: "Azabujuban",
+          eventCityAndCountry: "Tokyo, Japan",
+        }),
+      ]);
+      const result = await adapter.fetch(
+        makeSource({ defaultKennelTag: "tokyo-h3", defaultTitle: "Tokyo H3 Trail" }),
+      );
+      expect(result.events[0].hares).toBeUndefined();
+      expect(result.events[0].location).toBe("Azabujuban, Tokyo, Japan");
+      // Title also equalled the venue → synthesized default.
+      expect(result.events[0].title).toBe("Tokyo H3 Trail #2591");
+    });
+
+    it("re-synthesizes the title when it byte-equals the hares, keeping the hare (#2409 Tokyo #2583)", async () => {
+      // Source stored the hare's hash name "Back Door Hoe" as BOTH title and hares.
+      mockApiResponse([
+        buildHCEvent({
+          eventNumber: 2583,
+          eventName: "Back Door Hoe",
+          hares: "Back Door Hoe",
+          locationOneLineDesc: "Shibuya St. C2 exit",
+          resolvableLocation: "35.659, 139.700",
+          eventCityAndCountry: "Tokyo, Japan",
+        }),
+      ]);
+      const result = await adapter.fetch(
+        makeSource({ defaultKennelTag: "tokyo-h3", defaultTitle: "Tokyo H3 Trail" }),
+      );
+      expect(result.events[0].title).toBe("Tokyo H3 Trail #2583");
+      expect(result.events[0].hares).toBe("Back Door Hoe");
+      expect(result.events[0].location).toBe("Shibuya St. C2 exit");
     });
 
     it("nulls hares when address-shaped haresText is a prefix of location (#1642)", async () => {

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -3,7 +3,7 @@ import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "..
 import { hasAnyErrors } from "../types";
 import { generateAccessToken, PUBLIC_HASHER_ID } from "./token";
 import { safeFetch } from "../safe-fetch";
-import { buildDateWindow } from "../utils";
+import { buildDateWindow, eqTrimLc } from "../utils";
 
 const API_URL = "https://harriercentralpublicapi.azurewebsites.net/api/PortalApi/";
 
@@ -181,6 +181,13 @@ export class HarrierCentralAdapter implements SourceAdapter {
       if (hares && location && haresLooksLikeLocation(hares, location)) {
         hares = undefined;
       }
+      // #2408 Tokyo #2591: the hare slot byte-equals the raw venue/neighborhood
+      // ("Azabujuban"). The composed-location check above misses it (a single
+      // word with no address signals isn't caught once ", Tokyo, Japan" is
+      // appended), so compare against the raw place text too.
+      if (hares && haresEqualsRawPlace(hares, hcEvent.locationOneLineDesc, hcEvent.resolvableLocation)) {
+        hares = undefined;
+      }
 
       // When HC's geocoder fails it returns the placeName verbatim as
       // resolvableLocation and falls back to a region-default lat/lng (e.g.
@@ -199,10 +206,26 @@ export class HarrierCentralAdapter implements SourceAdapter {
       // (#706, #725). The REST API still serves the UUIDs so scrapes succeed,
       // but the user-facing detail page is dead. Event detail pages fall back
       // to the kennel website / other EventLinks when sourceUrl is null.
+      let title = applyTitleFallback(hcEvent.eventName, hcEvent.eventNumber, config);
+      // #2409 Tokyo #2583: the source stored the hare's hash name ("Back Door
+      // Hoe") as BOTH the title and the hares field; #2591 stored the
+      // neighborhood ("Azabujuban") as both title and venue. A title that
+      // byte-equals the hares or the raw venue is never a real run title —
+      // re-route through the stale-title fallback ("<defaultTitle> #N", or
+      // undefined → merge synthesizes "<Kennel> Trail #N"). hares is kept.
+      if (
+        title &&
+        (eqTrimLc(title, hares) ||
+          eqTrimLc(title, hcEvent.locationOneLineDesc) ||
+          eqTrimLc(title, hcEvent.resolvableLocation))
+      ) {
+        title = staleTitleFallback(hcEvent.eventNumber, config);
+      }
+
       const raw: RawEventData = {
         date: dateStr,
         kennelTags: [kennelTag],
-        title: applyTitleFallback(hcEvent.eventName, hcEvent.eventNumber, config),
+        title,
         // Socials / "drinking practices" come back as eventNumber=0. Map that
         // sentinel to null (explicit clear) and positive values to the number;
         // anything else stays undefined so the merge UPDATE path preserves an
@@ -428,6 +451,33 @@ function stripTrailingTitleSeparators(value: string | undefined): string | undef
   return value.replace(TITLE_SEPARATOR_TAIL_RE, "").trim() || undefined;
 }
 
+/**
+ * #2408 Tokyo #2591: the source pasted the neighborhood/station name into the
+ * hares slot, byte-equal to the raw venue ("Azabujuban" in hares, title AND
+ * location). `haresLooksLikeLocation` compares against the *composed* location
+ * ("Azabujuban, Tokyo, Japan"), which a bare single-word place doesn't trip (no
+ * address signals). Catch the exact-match-to-raw-place case here.
+ */
+function haresEqualsRawPlace(
+  hares: string,
+  placeName: string | undefined,
+  resolvable: string | undefined,
+): boolean {
+  return eqTrimLc(hares, placeName) || eqTrimLc(hares, resolvable);
+}
+
+/** Stale-title fallback — "<defaultTitle> #N" when configured, else undefined.
+ *  Shared by applyTitleFallback and the #2409 title-equals-hares/place guard. */
+function staleTitleFallback(
+  eventNumber: number | undefined | null,
+  config: HarrierCentralConfig,
+): string | undefined {
+  if (config.defaultTitle && typeof eventNumber === "number" && eventNumber > 0) {
+    return `${config.defaultTitle} #${eventNumber}`;
+  }
+  return undefined;
+}
+
 export function applyTitleFallback(
   eventName: string | undefined,
   eventNumber: number | undefined | null,
@@ -441,10 +491,7 @@ export function applyTitleFallback(
 
   if (!isStale) return trimmed || undefined;
 
-  if (config.defaultTitle && typeof eventNumber === "number" && eventNumber > 0) {
-    return `${config.defaultTitle} #${eventNumber}`;
-  }
-  return undefined;
+  return staleTitleFallback(eventNumber, config);
 }
 
 /**
@@ -466,6 +513,19 @@ export function applyTitleFallback(
  * "JR Keihintohoku line, Akabane station, North Exit" to the correct city
  * instead of falling back to a region-default pin (#1167).
  */
+// #2376 Bandung: some kennels paste the run title into HC's free-text venue
+// field ("BHHH2 Run 2288 at Gd. Abadi, Lembang", "BHHH2 Run 2292: Gd. BHHH2,
+// Panorama, Lembang") — sometimes with a WRONG run number glued on (#2298 stored
+// "Run 2292" on run #2298). Strip a leading "[code] Run <digits> at|:" prefix so
+// only the venue remains. Only fires when the place literally starts with that
+// shape, so a real venue is untouched. ReDoS-safe: no `\s*` adjacent to the
+// at/colon alternation.
+const RUN_TITLE_LOCATION_PREFIX_RE = /^(?:\S+\s+)?run\s+\d+(?:\s+at\b|:)\s*/i; // NOSONAR S5852/S5843 — bounded, single quantifiers, no overlapping alternation
+function stripRunTitleLocationPrefix(place: string | undefined): string | undefined {
+  if (!place) return place;
+  return place.replace(RUN_TITLE_LOCATION_PREFIX_RE, "").trim() || place;
+}
+
 export function composeHcLocation(
   placeName: string | undefined,
   resolvable: string | undefined,
@@ -475,7 +535,7 @@ export function composeHcLocation(
   // so a non-venue never reaches event.location — otherwise the merge path
   // stores it verbatim and the geocoder treats it as meaningless text (the
   // Lisbon H3 case). Leaving it undefined lets the event render unlocated.
-  const place = stripPlaceholderLocation(placeName);
+  const place = stripRunTitleLocationPrefix(stripPlaceholderLocation(placeName));
   const full = stripPlaceholderLocation(resolvable);
 
   // resolvableLocation is a bare coordinate pair for venues Harrier Central

--- a/src/adapters/harrier-central/adapter.ts
+++ b/src/adapters/harrier-central/adapter.ts
@@ -523,7 +523,10 @@ export function applyTitleFallback(
 const RUN_TITLE_LOCATION_PREFIX_RE = /^(?:\S+\s+)?run\s+\d+(?:\s+at\b|:)\s*/i; // NOSONAR S5852/S5843 — bounded, single quantifiers, no overlapping alternation
 function stripRunTitleLocationPrefix(place: string | undefined): string | undefined {
   if (!place) return place;
-  return place.replace(RUN_TITLE_LOCATION_PREFIX_RE, "").trim() || place;
+  // When the venue was ONLY the run-title prefix (nothing after it), return
+  // undefined rather than the original bad string — composeHcLocation then falls
+  // back to the resolvable address instead of storing "Run 2288 at".
+  return place.replace(RUN_TITLE_LOCATION_PREFIX_RE, "").trim() || undefined;
 }
 
 export function composeHcLocation(

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -245,6 +245,16 @@ describe("parseICalSummary", () => {
     const kept = parseICalSummary("Lehigh Valley HHH: Mayfair Hash", [], "rh3", true);
     expect(kept.title).toBeUndefined();
   });
+
+  // #2355 — matchedPattern signals an explicit pattern hit (vs a default fallback)
+  // so strictKennelRouting can drop untracked series on a shared feed.
+  it("reports matchedPattern true on an explicit kennelPattern hit", () => {
+    expect(parseICalSummary("SFH3 #2285: X", patterns).matchedPattern).toBe(true);
+  });
+
+  it("reports matchedPattern false when falling back to defaultKennelTag", () => {
+    expect(parseICalSummary("BASH #38: Malibog's Beerthday", patterns, "suh3").matchedPattern).toBe(false);
+  });
 });
 
 describe("stripTitleKennelRunPrefix (#2148 Reading / #2160 ICH3)", () => {
@@ -2026,5 +2036,124 @@ describe("ICalAdapter — Iron City (ICH3) title prefix strip (#2160)", () => {
     // No aliases → verbatim summary title, no hare extracted.
     expect(e!.title).toBe("ICH3# 60 Plea Barkin");
     expect(e!.hares).toBeUndefined();
+  });
+
+  // #2355 Stockholm HHH — strictKennelRouting drops untracked series instead of
+  // welding them onto the (now removed) defaultKennelTag.
+  it("skips events matching no kennelPattern when strictKennelRouting is set", async () => {
+    const stockholmIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Test//EN",
+      "BEGIN:VEVENT",
+      "UID:suh3-1667",
+      "DTSTART;TZID=Europe/Stockholm:20260705T140000",
+      "SUMMARY:SUH3 #1667",
+      "DTSTAMP:20260201T000000Z",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:sah3-1017",
+      "DTSTART;TZID=Europe/Stockholm:20260711T140000",
+      "SUMMARY:SAH3 #1017",
+      "DTSTAMP:20260201T000000Z",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:bash-38",
+      "DTSTART;TZID=Europe/Stockholm:20260708T180000",
+      "SUMMARY:BASH #38: Malibog's Beerthday",
+      "DTSTAMP:20260201T000000Z",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:spordic-100",
+      "DTSTART;TZID=Europe/Stockholm:20260709T180000",
+      "SUMMARY:SPOR&DIC #100",
+      "DTSTAMP:20260201T000000Z",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(stockholmIcs, { status: 200 }));
+
+    const source = buildMockSource({
+      name: "Stockholm HHH iCal Feed",
+      url: "https://www.hash.se/calendar.ics",
+      config: {
+        kennelPatterns: [
+          ["^SUH3\\b", "suh3"],
+          ["^SAH3\\b", "sah3-se"],
+        ],
+        strictKennelRouting: true,
+      },
+    });
+    const result = await adapter.fetch(source, { days: 9999 });
+
+    expect(result.events.map((e) => e.kennelTags[0]).sort()).toEqual(["sah3-se", "suh3"]);
+    // The untracked series must NOT be welded onto suh3.
+    expect(result.events.some((e) => e.runNumber === 38)).toBe(false);
+    expect(result.events.some((e) => e.runNumber === 100)).toBe(false);
+  });
+
+  // #2312 Phoenix LBH — an empty "Where:" label in the DESCRIPTION must not bleed
+  // the next field's line ("Why: Monday is a hashing day") into the location.
+  it("does not capture the next field line when the Where: label is empty", async () => {
+    const lbhIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Test//EN",
+      "BEGIN:VEVENT",
+      "UID:lbh-751",
+      "DTSTART;TZID=America/Phoenix:20260706T183000",
+      "SUMMARY:LBH #751",
+      String.raw`DESCRIPTION:Hare(s): You?\n\nWho: 21+\n\nWhere:\n\n\nWhy: Monday is a hashing day\n\nWhen: Monday\, 7/6/2026`,
+      "DTSTAMP:20260201T000000Z",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(lbhIcs, { status: 200 }));
+
+    const source = buildMockSource({
+      name: "Phoenix H3 Events",
+      url: "https://www.phoenixhhh.org/?plugin=events-manager&page=events.ics",
+      config: { defaultKennelTag: "lbh-phx" },
+    });
+    const result = await adapter.fetch(source, { days: 9999 });
+
+    const lbh = result.events.find((e) => e.runNumber === 751);
+    expect(lbh).toBeDefined();
+    expect(lbh!.location).toBeFalsy();
+  });
+
+  // #2316 Oslo — the title must never be the venue. "OH3: Ommen" + LOCATION "Ommen"
+  // drops the title so merge synthesizes "<Kennel> Trail".
+  it("drops a title that byte-equals the location", async () => {
+    const osloIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Test//EN",
+      "BEGIN:VEVENT",
+      "UID:run-28373",
+      "DTSTART;TZID=Europe/Stockholm:20260704T143000",
+      "DESCRIPTION:Hare: Altar Boy",
+      "LOCATION:Ommen",
+      "SUMMARY:OH3: Ommen",
+      "DTSTAMP:20260201T000000Z",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(osloIcs, { status: 200 }));
+
+    const source = buildMockSource({
+      name: "Oslo H3 iCal Feed",
+      url: "https://www.oh3.no/calendar.ics",
+      config: { defaultKennelTag: "oh3-no" },
+    });
+    const result = await adapter.fetch(source, { days: 9999 });
+
+    const e = result.events.find((x) => x.kennelTags[0] === "oh3-no");
+    expect(e).toBeDefined();
+    expect(e!.location).toBe("Ommen");
+    expect(e!.title).toBeUndefined();
   });
 });

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails, ParseError } from "../types";
 import { hasAnyErrors } from "../types";
-import { googleMapsSearchUrl, compilePatterns, appendDescriptionSuffix, isPlaceholder, extractHashRunNumber, hasPlaceholderRunNumber, cleanLocationName, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE } from "../utils";
+import { googleMapsSearchUrl, compilePatterns, appendDescriptionSuffix, isPlaceholder, extractHashRunNumber, hasPlaceholderRunNumber, cleanLocationName, eqTrimLc, EVENT_FIELD_LABEL_RE, EVENT_FIELD_LABEL_UPPERCASE_RE } from "../utils";
 import { safeFetch } from "../safe-fetch";
 import { enrichSFH3Events, markSFH3SeriesMembership } from "../html-scraper/sfh3-detail-enrichment";
 import { enrichBerlinH3Events } from "../html-scraper/berlin-h3-detail-enrichment";
@@ -12,6 +12,7 @@ import type { VEvent, ParameterValue, DateWithTimeZone } from "node-ical";
 export interface ICalSourceConfig {
   kennelPatterns?: [string, string][]; // [[regex, kennelTag], ...] — same as Google Calendar
   defaultKennelTag?: string;           // fallback for unrecognized events
+  strictKennelRouting?: boolean;       // #2355 Stockholm HHH: a shared multi-series feed (SUH3, SAH3, BASH, SPOR&DIC, LYH3…) where only some series are tracked. When set, an event whose SUMMARY matches NO kennelPattern is SKIPPED rather than falling through to defaultKennelTag — otherwise every untracked series welds onto the default kennel. Reconcile-safe: every real tracked-series event still matches its own pattern. Mirrors Google Calendar's strictKennelRouting.
   skipPatterns?: string[];             // SUMMARY patterns to skip (e.g., "Hand Pump Workday")
   harePatterns?: string[];             // regex strings to extract hares from descriptions
   runNumberPatterns?: string[];        // regex strings to extract run numbers from descriptions
@@ -56,7 +57,7 @@ export function parseICalSummary(
   kennelPatterns?: [string, string][],
   defaultKennelTag?: string,
   keepNonKennelTitlePrefix = false,
-): { kennelTag: string; runNumber?: number; title?: string } {
+): { kennelTag: string; runNumber?: number; title?: string; matchedPattern: boolean } {
   let kennelTag: string | undefined;
   // Match against config patterns
   if (kennelPatterns) {
@@ -69,6 +70,10 @@ export function parseICalSummary(
     }
   }
 
+  // matchedPattern tells the caller whether an explicit kennelPattern hit (vs a
+  // defaultKennelTag fallback) — strictKennelRouting uses it to drop untracked
+  // series on shared feeds (#2355).
+  const matchedPattern = kennelTag != null;
   if (!kennelTag) {
     kennelTag = defaultKennelTag ?? "UNKNOWN";
   }
@@ -114,7 +119,7 @@ export function parseICalSummary(
     }
   }
 
-  return { kennelTag, runNumber, title };
+  return { kennelTag, runNumber, title, matchedPattern };
 }
 
 /** Normalize a kennel token for loose comparison: lowercase, drop everything
@@ -197,10 +202,6 @@ export function stripTitleKennelRunPrefix(
   return s.trim() || undefined;
 }
 
-/** Loose equality for the #2160 title-is-hare check: trimmed, case-insensitive. */
-function titleEqualsHare(title: string, hares: string): boolean {
-  return title.trim().toLowerCase() === hares.trim().toLowerCase();
-}
 
 // #2175 Charm City: a `#TBD` placeholder VEVENT carries a junk DTSTART time
 // (03:02) — the audit's `event-improbable-time` window is 23:00–04:00. Used
@@ -218,10 +219,16 @@ const HARE_PATTERNS = [
   /(?:^|\n)\s*Hares?:\s*([^\n]+)/im,
   /(?:^|\n)\s*Hare\(s\):\s*([^\n]+)/im,
 ];
+// #2312 Phoenix LBH: the whitespace AFTER the label must be horizontal-only
+// (`[^\S\n]*`, not `\s*`). Events Manager emits an empty venue as
+// "Where:\n\n\nWhy: Monday is a hashing day" — a `\s*` after "Where:" greedily
+// eats the blank lines and the capture grabs the *next* field's line ("Why:
+// Monday is a hashing day"). Horizontal-only whitespace stops at the newline, so
+// an empty label yields no capture and the venue stays unset.
 const LOCATION_PATTERNS = [
-  /(?:^|\n)\s*Where:\s*([^\n]+)/im,
-  /(?:^|\n)\s*Location:\s*([^\n]+)/im,
-  /(?:^|\n)\s*Start(?:ing)?\s*(?:Location)?:\s*([^\n]+)/im,
+  /(?:^|\n)\s*Where:[^\S\n]*([^\n]+)/im,
+  /(?:^|\n)\s*Location:[^\S\n]*([^\n]+)/im,
+  /(?:^|\n)\s*Start(?:ing)?\s*(?:Location)?:[^\S\n]*([^\n]+)/im,
 ];
 const COST_PATTERNS = [
   /(?:^|\n)\s*Hash\s*Cash:\s*([^\n]+)/im,
@@ -596,6 +603,11 @@ function buildRawEventFromVEvent(
     config?.keepNonKennelTitlePrefix,
   );
 
+  // #2355 Stockholm HHH: on a shared multi-series feed, an event matching no
+  // kennelPattern must be dropped, not routed to defaultKennelTag — otherwise
+  // every untracked series (BASH, SPOR&DIC, LYH3…) welds onto SUH3.
+  if (config?.strictKennelRouting && !parsed.matchedPattern) return null;
+
   // Computed once and reused across the run-number, junk-time, and title
   // branches below (the summary doesn't change within this event).
   const hasPlaceholderRun = hasPlaceholderRunNumber(summary);
@@ -731,7 +743,13 @@ function buildRawEventFromVEvent(
   // pulled from the SUMMARY (titleHarePattern) and the stripped title is just
   // that hare (ICH3 "ICH3# 60 Plea Barkin" → title "Plea Barkin" == hare), drop
   // the title so merge synthesizes "<Kennel> Trail #N" instead.
-  if (hareFromTitle && title && hares && titleEqualsHare(title, hares)) {
+  if (hareFromTitle && title && hares && eqTrimLc(title, hares)) {
+    title = undefined;
+  }
+  // #2316 hard rule — the title must NEVER be the venue. Oslo "OH3: Ommen" has
+  // title "Ommen" == location "Ommen"; drop the title so merge synthesizes the
+  // default and the venue still renders from `location`.
+  if (title && location && eqTrimLc(title, location)) {
     title = undefined;
   }
 

--- a/src/adapters/meetup/adapter.test.ts
+++ b/src/adapters/meetup/adapter.test.ts
@@ -2112,6 +2112,23 @@ describe("buildRawEventFromApollo — runNumber (Richmond H3 rvah3, anchored)", 
     expect(build("Chain Gang Trail #42", "chain-gang-hhh").runNumber).toBe(42);
   });
 
+  // #2414 TMFMH3 — "Trail <N>" with NO "#". The "#"-anchored locator misses, so
+  // the no-"#" fallback parses the number that follows "Trail".
+  it.each([
+    ["TMFMH3 Trail 299: Squishberries And Cream Strawberry Moon", 299],
+    ["TMFMH3 Trail 298", 298],
+  ])("extracts the no-# 'Trail N' run number from %j", (title, expected) => {
+    expect(build(title, "tmfmh3").runNumber).toBe(expected);
+  });
+
+  it.each([
+    "Trail option 2 starts at the gate",   // intervening word
+    "A-to-B trail, 5 miles tonight",       // punctuation after 'trail'
+    "Bring your best trail to 2026 vibes", // 'trail to <year>' — no immediate digit
+  ])("does NOT mint a no-# run number from non-run 'trail' prose: %j", (title) => {
+    expect(build(title, "tmfmh3").runNumber).toBeUndefined();
+  });
+
   it.each([
     "RH3 #1704TBD",   // placeholder suffix glued to digits
     "RH3 Trail #30X?", // explicit unknown-run marker

--- a/src/adapters/meetup/adapter.ts
+++ b/src/adapters/meetup/adapter.ts
@@ -487,6 +487,15 @@ function compileKennelPatterns(
 const TITLE_TRAIL_RUN_ANCHOR_RE = /(?:^\s*[A-Za-z0-9]{2,8}\s*#|\btrail\b\s*#)/i; // NOSONAR S5852/S5843 — literal, bounded {2,8}, no overlapping quantifiers
 
 /**
+ * #2414 TMFMH3: a no-`#` "Trail <N>" run number ("TMFMH3 Trail 299: Squishberries
+ * And Cream Strawberry Moon"). Only consulted (under `anchorTrailRunNumber`) when
+ * the `#`-anchored locator above finds nothing, so a `#`-style run still wins.
+ * The digits must sit immediately after the word "trail" + whitespace — "trail
+ * option 2" / "trail, 5 miles" / "trail to 2026" don't match (intervening word or
+ * punctuation). Module-level literal, ReDoS-safe: single capture, bounded {1,6}. */
+const TITLE_TRAIL_RUN_NOHASH_RE = /\btrail\s+(\d{1,6})\b/i; // NOSONAR S5852 — literal, single bounded quantifier, no alternation
+
+/**
  * Meetup-style hare-line fallback: scan the first few description lines for
  * `Hare(s)` followed by a colon or dash separator.
  *
@@ -681,7 +690,15 @@ function runNumberFromTitle(
 ): number | undefined {
   if (anchorTrail) {
     const anchor = title ? TITLE_TRAIL_RUN_ANCHOR_RE.exec(title) : null;
-    return anchor ? extractHashRunNumber(title!.slice(anchor.index)) : undefined;
+    if (anchor) return extractHashRunNumber(title!.slice(anchor.index));
+    // #2414: fall back to the no-"#" "Trail <N>" form (TMFMH3) — only after the
+    // "#"-anchored form misses, so a "#"-style run number still takes precedence.
+    const noHash = title ? TITLE_TRAIL_RUN_NOHASH_RE.exec(title) : null;
+    if (noHash) {
+      const n = Number.parseInt(noHash[1], 10);
+      if (n > 0) return n;
+    }
+    return undefined;
   }
   const normalized = runNumberPrefix && title ? title.replaceAll(runNumberPrefix, "#") : title;
   return extractHashRunNumber(normalized);

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -1431,3 +1431,12 @@ export async function fetchBrowserRenderedPage(
     return { ok: false, result: { events: [], errors: [message], errorDetails } };
   }
 }
+
+/**
+ * Trimmed, case-insensitive equality; false when either side is empty/nullish.
+ * Shared by the "title/hares must never equal X" guards across adapters
+ * (HC #2408/#2409, iCal #2160/#2316).
+ */
+export function eqTrimLc(a: string | undefined | null, b: string | undefined | null): boolean {
+  return !!a && !!b && a.trim().toLowerCase() === b.trim().toLowerCase();
+}

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -49,7 +49,7 @@ import { prisma } from "@/lib/db";
 import { Prisma } from "@/generated/prisma/client";
 import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag } from "./kennel-resolver";
-import { processRawEvents, sanitizeTitle, sanitizeLocation, sanitizeHares, friendlyKennelName, rewriteStaleDefaultTitle, resolveUpdatedTitle, isReplaceableDefaultTitle, normalizeThemeTitle, suppressRedundantCity, NON_ENGLISH_GEO_RE, completenessScore, pickCanonicalEventId, pickCanonicalEventIds, isAdminLocked } from "./merge";
+import { processRawEvents, sanitizeTitle, sanitizeLocation, sanitizeHares, friendlyKennelName, rewriteStaleDefaultTitle, resolveUpdatedTitle, isReplaceableDefaultTitle, normalizeThemeTitle, suppressRedundantCity, NON_ENGLISH_GEO_RE, completenessScore, pickCanonicalEventId, pickCanonicalEventIds, isAdminLocked, isImplausibleEndTime } from "./merge";
 
 const mockSourceFind = vi.mocked(prisma.source.findUnique);
 const _mockSourceUpdate = vi.mocked(prisma.source.update);
@@ -2268,6 +2268,27 @@ describe("time/cost field clearing on update (#530)", () => {
     expect(updateCall.data.endTime).toBeNull();
   });
 
+  // #2395 — an implausibly-inverted incoming endTime is bad source data: it must
+  // be treated as no-signal (skip the write), NOT written as a bad range AND NOT
+  // clearing an existing valid endTime (Codex adversarial review).
+  it("preserves an existing valid endTime when the incoming endTime is implausibly inverted", async () => {
+    mockRawEventFind.mockResolvedValueOnce(null);
+    mockEventFindMany.mockResolvedValueOnce([
+      { id: "evt_1", trustLevel: 5, startTime: "13:30", endTime: "16:00" },
+    ] as never);
+    mockEventUpdate.mockResolvedValueOnce({} as never);
+
+    // Incoming 13:30 → 09:00 is a >12h inverted span (SWH3 #1791 shape).
+    await processRawEvents("src_1", [
+      buildRawEvent({ startTime: "13:30", endTime: "09:00" }),
+    ]);
+
+    const updateCall = mockEventUpdate.mock.calls[0][0] as { data: Record<string, unknown> };
+    // The bad end is neither stored nor cleared — the field is left untouched so
+    // the existing valid "16:00" survives.
+    expect(updateCall.data).not.toHaveProperty("endTime");
+  });
+
   // cost
   it("preserves existing cost when new source has undefined cost", async () => {
     mockRawEventFind.mockResolvedValueOnce(null);
@@ -2484,6 +2505,15 @@ describe("sanitizeTitle", () => {
     expect(sanitizeTitle("The Pre-Saint Patrick's Day Trail")).toBe("The Pre-Saint Patrick's Day Trail");
   });
 
+  // #2393 Tacoma H3 — a "TH3 #653" whose run number was pulled out can leave a
+  // dangling "TH3 #". Strip the orphan "#" but keep a real "#653".
+  it("strips a trailing orphan '#' (#2393)", () => {
+    expect(sanitizeTitle("TH3 #")).toBe("TH3");
+    expect(sanitizeTitle("TH3 # ")).toBe("TH3");
+    expect(sanitizeTitle("TH3 #653")).toBe("TH3 #653");
+    expect(sanitizeTitle("C# Jam Session")).toBe("C# Jam Session");
+  });
+
   it("returns null for 'hares needed' admin text", () => {
     expect(sanitizeTitle("Hares needed! Email the Hare Razor")).toBeNull();
   });
@@ -2667,6 +2697,15 @@ describe("sanitizeHares", () => {
     expect(sanitizeHares("Needed")).toBeNull();
   });
 
+  // #2392 Tacoma H3 — a bare 4-digit year ("1987") leaked from the
+  // "TH3 Analversary (1987)" title parenthetical is never a hare.
+  it("returns null for a bare 4-digit year (#2392)", () => {
+    expect(sanitizeHares("1987")).toBeNull();
+    expect(sanitizeHares("2011")).toBeNull();
+    // A year embedded in a real name is preserved.
+    expect(sanitizeHares("Class of 1987")).toBe("Class of 1987");
+  });
+
   it("returns null for hare-needed phrasings ('Hare required!', 'Hares wanted') — WS6 #1521/#1523", () => {
     // Capital H3 emits "Hare required!" for unstaffed runs. Without WS6, this
     // text persisted in `haresText` because sanitizeHares didn't recognize it
@@ -2848,6 +2887,30 @@ describe("sanitizeHares", () => {
       "GM Over There (1995-1996) Memorial Run",
     );
     expect(sanitizeHares("3-5 milers welcome")).toBe("3-5 milers welcome");
+  });
+});
+
+// ── isImplausibleEndTime (#2395) ──
+
+describe("isImplausibleEndTime", () => {
+  it("rejects an inverted afternoon→morning range (SWH3 #1791)", () => {
+    expect(isImplausibleEndTime("13:30", "09:00")).toBe(true);
+  });
+
+  it("keeps a normal forward range", () => {
+    expect(isImplausibleEndTime("13:30", "16:00")).toBe(false);
+    expect(isImplausibleEndTime("18:30", "21:00")).toBe(false);
+  });
+
+  it("preserves a genuine short cross-midnight overnight trail", () => {
+    expect(isImplausibleEndTime("22:00", "01:00")).toBe(false);
+    expect(isImplausibleEndTime("23:30", "00:30")).toBe(false);
+  });
+
+  it("returns false when either time is missing or unparseable", () => {
+    expect(isImplausibleEndTime(undefined, "09:00")).toBe(false);
+    expect(isImplausibleEndTime("13:30", null)).toBe(false);
+    expect(isImplausibleEndTime("13:30", "garbage")).toBe(false);
   });
 });
 

--- a/src/pipeline/merge.test.ts
+++ b/src/pipeline/merge.test.ts
@@ -707,6 +707,38 @@ describe("processRawEvents", () => {
     expect(data).not.toHaveProperty(field);
   });
 
+  // #2395 / Codex review — when a lower-trust source backfills BOTH a missing
+  // startTime and an endTime in one pass, the endTime guard must screen against
+  // the just-enriched start (13:30), not the still-null existing start. An
+  // inverted 13:30 → 09:00 pair must be rejected for endTime while startTime fills.
+  it("rejects an enriched endTime that inverts the same-pass enriched startTime (#2395)", async () => {
+    mockSourceFind.mockResolvedValueOnce(sourceRow({
+      trustLevel: 5,
+      type: "HTML_SCRAPER",
+      kennels: [{ kennelId: "kennel_1" }],
+    }));
+    mockRawEventFind.mockResolvedValueOnce(null);
+    // Higher-trust owner left BOTH startTime and endTime NULL.
+    mockEventFindMany.mockResolvedValueOnce([{
+      id: "evt_inv",
+      trustLevel: 8,
+      startTime: null,
+      endTime: null,
+    }] as never);
+    mockEventUpdate.mockResolvedValue(eventRow("evt_inv"));
+
+    await processRawEvents("src_low", [buildRawEvent({ startTime: "13:30", endTime: "09:00" })]);
+
+    const update = mockEventUpdate.mock.calls.find(
+      (c: unknown[]) => (c[0] as { where: { id: string } }).where.id === "evt_inv",
+    );
+    expect(update).toBeDefined();
+    const data = (update![0] as { data: Record<string, unknown> }).data;
+    // startTime backfills, but the inverted endTime is rejected.
+    expect(data).toHaveProperty("startTime", "13:30");
+    expect(data).not.toHaveProperty("endTime");
+  });
+
   it("lower-trust enrichment does NOT clobber an earlier same-batch fill (#1950 shared-cache patch)", async () => {
     // Two lower-trust raws in ONE batch both match the same canonical (shared
     // runNumber + startTime → the matcher re-matches the second onto the first).

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -2106,7 +2106,13 @@ async function upsertCanonicalEvent(
       // the tri-state clear stays owned by the higher-trust branch. endTime is
       // a plain display string with no dateUtc coupling (only startTime anchors
       // dateUtc), so no recompose is needed.
-      if (!existingEvent.endTime && event.endTime && !isImplausibleEndTime(existingEvent.startTime, event.endTime)) {
+      // #2395 / Codex review — screen the incoming endTime against the start that
+      // will actually be persisted: the start enriched just above (when the
+      // existing one was null), else the existing one. Using existingEvent.startTime
+      // alone misses an inverted pair when THIS pass also backfills startTime
+      // (e.g. a lower-trust source filling both 13:30 + 09:00).
+      const enrichEffectiveStart = (enrichData.startTime as string | undefined) ?? existingEvent.startTime;
+      if (!existingEvent.endTime && event.endTime && !isImplausibleEndTime(enrichEffectiveStart, event.endTime)) {
         enrichData.endTime = event.endTime;
       }
       if (!existingEvent.cost && event.cost) {

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -163,6 +163,10 @@ export function sanitizeHares(hares: string | undefined | null): string | null {
   // Reject single-character values (no real hash name is 1 char — likely a scraping artifact)
   if (h.length === 1) return null;
 
+  // #2392 Tacoma H3 — a bare 4-digit year leaked from an "… Analversary (1987)"
+  // title parenthetical is never a hare name. Reject as an explicit clear.
+  if (/^(?:19|20)\d{2}$/.test(h)) return null;
+
   // Strip "Hare is " / "Hare: " prefix (some calendars embed the label in the value)
   h = h.replace(/^Hares?\s+(?:is|are|=)\s+/i, "").trim();
 
@@ -942,6 +946,11 @@ export function sanitizeTitle(title: string | undefined): string | null {
   // google-calendar/adapter.ts (#756/#1060) but applied universally for
   // adapters that don't pre-strip.
   cleaned = cleaned.replace(/[\s,:\-–—]+$/, "").trim(); // NOSONAR S5852 — single char class + `+` anchored to `$`, linear in input length
+  // #2393 Tacoma H3 — a "TH3 #653" summary whose run number was pulled into its
+  // own field can leave a dangling "#" once the digits are gone ("TH3 #"). Strip
+  // a trailing orphan "#" (same artifact family as the dash/colon strip above);
+  // a real "#653" still ends in a digit, so this only fires on the bare marker.
+  cleaned = cleaned.replace(/\s*#\s*$/, "").trim(); // NOSONAR S5852 — anchored to `$`, single quantifiers
   // Collapse multiple spaces from stripping and trim
   cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
   // Strip embedded email addresses
@@ -1347,6 +1356,28 @@ function timeDiffMinutes(a: string, b: string): number {
   const bv = timeToMinutes(b);
   if (av == null || bv == null) return Infinity;
   return Math.abs(av - bv);
+}
+
+/**
+ * #2395 SWH3 #1791 — an `endTime` that lands implausibly *before* `startTime`
+ * is a cross-source merge artifact (WordPress 1:30 PM start paired with a stray
+ * 9:00 AM end from a co-dated GCal row → "1:30 PM – 9:00 AM"). startTime and
+ * endTime can come from different sources (the lower-trust enrich + the update
+ * tri-state both write endTime independently of startTime), so the pair must be
+ * validated where it's joined. A genuine overnight trail (22:00 → 01:00) is
+ * preserved; only an inverted span longer than 12h is rejected as bogus.
+ */
+export function isImplausibleEndTime(
+  startTime: string | null | undefined,
+  endTime: string | null | undefined,
+): boolean {
+  if (!startTime || !endTime) return false;
+  const s = timeToMinutes(startTime);
+  const e = timeToMinutes(endTime);
+  if (s == null || e == null) return false;
+  if (e >= s) return false; // forward same-day range — always fine
+  // end < start: legitimate only as a short cross-midnight overnight trail.
+  return (e + 1440) - s > 12 * 60;
 }
 
 
@@ -1789,6 +1820,15 @@ async function upsertCanonicalEvent(
         locationStreetUpdate = { locationStreet: null };
       }
 
+      // #2395 — endTime can arrive from a different source than the effective
+      // startTime (incoming start, or the preserved existing start). A bogus
+      // inverted end ("1:30 PM – 9:00 AM") is bad source data, so treat it as
+      // no-signal: skip the write entirely (below) so it neither stores the bad
+      // value NOR clears an existing valid endTime. A genuine clear (incoming
+      // `null`, which is not "implausible") still flows through.
+      const effectiveStartTime = event.startTime !== undefined ? event.startTime : existingEvent.startTime;
+      const skipInvertedEndTime = isImplausibleEndTime(effectiveStartTime, event.endTime);
+
       const updated = await prisma.event.update({
         where: { id: existingEvent.id },
         data: {
@@ -1834,7 +1874,7 @@ async function upsertCanonicalEvent(
           ...(event.startTime !== undefined
             ? { startTime: event.startTime ?? null }
             : {}),
-          ...(event.endTime !== undefined
+          ...(event.endTime !== undefined && !skipInvertedEndTime
             ? { endTime: event.endTime ?? null }
             : {}),
           ...(event.cost !== undefined
@@ -2066,7 +2106,7 @@ async function upsertCanonicalEvent(
       // the tri-state clear stays owned by the higher-trust branch. endTime is
       // a plain display string with no dateUtc coupling (only startTime anchors
       // dateUtc), so no recompose is needed.
-      if (!existingEvent.endTime && event.endTime) {
+      if (!existingEvent.endTime && event.endTime && !isImplausibleEndTime(existingEvent.startTime, event.endTime)) {
         enrichData.endTime = event.endTime;
       }
       if (!existingEvent.cost && event.cost) {
@@ -2173,7 +2213,9 @@ async function upsertCanonicalEvent(
       locationStreet: event.locationStreet ?? null,
       locationAddress: sanitizeLocationUrl(event.locationUrl),
       startTime: event.startTime,
-      endTime: event.endTime,
+      // #2395 — defensive on create too: a single source emitting an inverted
+      // 1:30 PM → 9:00 AM span is bogus; store the start, drop the bad end.
+      endTime: isImplausibleEndTime(event.startTime, event.endTime) ? null : event.endTime,
       cost: event.cost,
       trailLengthText: event.trailLengthText,
       trailLengthMinMiles: event.trailLengthMinMiles,


### PR DESCRIPTION
Fixes a cluster of audit issues that read as per-kennel bugs but actually live in the **shared** multi-kennel adapters (Google Calendar, iCal, Meetup, Harrier Central) and the `merge.ts` / `hare-extraction.ts` hygiene helpers. Because these files are touched by every kennel they serve, all fixes land together. **Every fix was verified against the live source** (event count + date range + a sample event with the corrected field); see per-issue notes below.

## iCal (`src/adapters/ical/adapter.ts`)
- **#2355** — `strictKennelRouting`: on a shared multi-series feed (Stockholm hash.se carries SUH3/SAH3/BASH/SPOR&DIC/LYH3…), an event matching no `kennelPattern` is now skipped instead of falling through to `defaultKennelTag`. *Live: 41 events, kennels = only `suh3,sah3-se`.*
- **#2312** — an empty `Where:` label no longer bleeds the next description line into `location` (horizontal-whitespace-only after labels). *Live: Phoenix LBH #751/#752 `location` now empty, not "Why: Monday is a hashing day".*
- **#2316** — drop a title that byte-equals the location (Oslo "OH3: Ommen" + `LOCATION:Ommen`). *Live: title dropped, venue preserved.*

## Meetup (`src/adapters/meetup/adapter.ts`)
- **#2414** — extract a no-`#` "Trail NNN" run number under `anchorTrailRunNumber`. *Live: TMFMH3 runs 298–304 now populated.*

## Harrier Central (`src/adapters/harrier-central/adapter.ts`)
- **#2408** — null a hare that byte-equals the raw venue/neighborhood (Tokyo "Azabujuban"). *Live: #2591 hare cleared.*
- **#2409** — re-synthesize a title that byte-equals the hares/venue, keeping the hare ("Back Door Hoe").
- **#2376** — strip a `<code> Run NNNN at|:` run-title prefix from `composeHcLocation` (Bandung).

## Google Calendar (`src/adapters/google-calendar/adapter.ts`)
- **#2349 / #2351** — new `summaryRunNumberPatterns` knob + `titleStripPatterns` strip the redundant `SH3 [#] NNN` / `FM #NNN -` prefix and extract no-`#` run numbers (Stuttgart). *Live: "SH3 871 Anni Tua" → run 871/"Anni Tua"; "FM #179 - Motel Six" → "Motel Six".*
- **#2388** — `includeAllDayEvents` for Surf City. *Live: 38→41 events, Wharf-to-Barf #1424–#1426 recovered.*
- **#2382** — SUPH3 `scrapeDays` 90→365. The GCal forward window is `min(scrapeDays, futureHorizonDays)`, so 90 silently capped the future at 90 days. *Live: future now reaches 2026-12-12.*

## merge / hare-extraction
- **#2368** — strip hash role labels (`Hare-`/`Hares-`/`Jedi-`/`Hare and Jedi:`) from hares in the shared `cleanAndFilterHares` (StumpH3). *Live: "Hare-Deaf Dick. Jedi-Premature Evacuation" → "Deaf Dick, Premature Evacuation" across 16/16 samples.*
- **#2395** — drop an implausibly-inverted endTime (>12h inverted span); treated as **no-signal** so it never stores the bad range nor clears an existing valid endTime (per adversarial review).
- **#2393** — strip a trailing orphan `#` in `sanitizeTitle`.
- **#2392** — reject a bare 4-digit year in `sanitizeHares`.
- shared `eqTrimLc` helper in `utils.ts` (dedup of the title/hares-equality guards across iCal + HC).

## Not adapter bugs / handoffs (verified, no code change here)
- **#2407** Tokyo 7:15 AM — raw HC API stores `07:15:00` (source data entry). **#2377** Bandung run# — source typo, badge is authoritative. **#2410** — the synthesized default title is correct. **#2405** Taiwan endTime — raw `getEvents` payload has no end field. **#2403** Riyadh — Supabase source data (`html-scraper`).
- **#2392/#2393 stored rows** + deep historical gaps in **#2394/#2369/#2344** + SUPH3 pre-2025 history are **stale-canonical / backfill** work for the historical-backfill workstream — the shared code is now correct going forward.

## Verification
`npx tsc --noEmit` clean · `npm run lint` 0 errors · **9724 tests pass** (full suite) · `/simplify` (4-agent reuse/simplification/efficiency/altitude pass) applied · Codex adversarial review addressed (inverted-endTime now preserves valid existing values, with a regression test).

> ⚠️ `sources.ts` config edits (Stockholm/Stuttgart/Surf City/SUPH3) need a manual `npx prisma db seed` from synced main on prod — Vercel build skips `db seed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)