### PR TITLE
fix(audit+kennels): GitHub-search dedup gate + 5 admin/kennel UI bugs

### DIFF
--- a/scripts/fix-comma-slugs.ts
+++ b/scripts/fix-comma-slugs.ts
@@ -1,0 +1,108 @@
+/**
+ * One-shot data repair for issue #2308 — kennel slugs that contain characters
+ * outside the URL-safe `[a-z0-9-]` set (the trigger was `slut-h3` whose slug
+ * was the literal `sl,ut-discovery`). A comma in a slug makes the
+ * `/kennels/<slug>` route 404 (the comma in the path never resolves to the
+ * stored value), so the kennel's public page is unreachable and every card
+ * linking via `kennel.slug` emits a dead href.
+ *
+ * `toSlug` (src/lib/kennel-utils.ts) already normalizes commas to "-", so this
+ * is stale data predating the current generator. The script re-slugifies every
+ * offending row to a unique `toSlug(shortName)`, disambiguating with a numeric
+ * suffix on the rare collision.
+ *
+ * NOT a `backfill-*.ts` (those are owned by another workstream); this is a
+ * scoped slug repair. Idempotent / re-runnable — rows that already have a clean
+ * slug are skipped.
+ *
+ *   tsx scripts/fix-comma-slugs.ts          # dry-run (default)
+ *   tsx scripts/fix-comma-slugs.ts --apply  # write changes
+ *
+ * Per memory `reference_script_railway_tls_self_signed.md` — set
+ * BACKFILL_ALLOW_SELF_SIGNED_CERT=1 when pointing at the Railway public proxy.
+ * Per `feedback_script_env_loading.md` — `import "dotenv/config"` because tsx
+ * doesn't auto-load .env.
+ */
+import "dotenv/config";
+import { createScriptPool } from "./lib/db-pool";
+import { toSlug } from "@/lib/kennel-utils";
+
+/** A slug is clean iff it's a non-empty run of lowercase alphanumerics + hyphens. */
+const CLEAN_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+interface KennelRow {
+  id: string;
+  kennelCode: string;
+  shortName: string;
+  slug: string;
+}
+
+/**
+ * Pick a unique slug for `shortName`, starting from `toSlug(shortName)` and
+ * appending `-2`, `-3`, … until it doesn't collide with a slug already taken.
+ * `taken` is mutated so a batch of repairs in one run can't collide with each
+ * other.
+ */
+function uniqueSlug(shortName: string, taken: Set<string>): string {
+  const base = toSlug(shortName) || "kennel";
+  let candidate = base;
+  let n = 2;
+  while (taken.has(candidate)) {
+    candidate = `${base}-${n}`;
+    n += 1;
+  }
+  taken.add(candidate);
+  return candidate;
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const pool = createScriptPool();
+
+  try {
+    const { rows } = await pool.query<KennelRow>(
+      `SELECT id, "kennelCode", "shortName", slug FROM "Kennel"`,
+    );
+
+    const taken = new Set(rows.map((r) => r.slug));
+    const offenders = rows.filter((r) => !CLEAN_SLUG_RE.test(r.slug));
+
+    if (offenders.length === 0) {
+      console.log("[fix-comma-slugs] No malformed slugs found — nothing to do.");
+      return;
+    }
+
+    console.log(
+      `[fix-comma-slugs] ${offenders.length} kennel(s) with malformed slugs${apply ? "" : " (dry-run)"}:`,
+    );
+
+    for (const k of offenders) {
+      // Free the old slug before picking a replacement so a row can re-take its
+      // own normalized form without a needless `-2` suffix.
+      taken.delete(k.slug);
+      const newSlug = uniqueSlug(k.shortName, taken);
+      console.log(
+        `  ${k.kennelCode} (${k.shortName}): "${k.slug}" -> "${newSlug}"`,
+      );
+      if (apply) {
+        await pool.query(`UPDATE "Kennel" SET slug = $1 WHERE id = $2`, [
+          newSlug,
+          k.id,
+        ]);
+      }
+    }
+
+    console.log(
+      apply
+        ? `[fix-comma-slugs] Applied ${offenders.length} update(s).`
+        : `[fix-comma-slugs] Dry-run complete. Re-run with --apply to write.`,
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("[fix-comma-slugs] Failed:", err);
+  process.exitCode = 1;
+});

--- a/src/app/admin/audit/actions.test.ts
+++ b/src/app/admin/audit/actions.test.ts
@@ -390,6 +390,7 @@ describe("recordDeepDive", () => {
   const mockLogCreate = vi.mocked(prisma.auditLog.create);
   const mockLogFindFirst = vi.mocked(prisma.auditLog.findFirst);
   const mockKennelFind = vi.mocked(prisma.kennel.findMany);
+  const mockKennelFindUnique = vi.mocked(prisma.kennel.findUnique);
   const mockLogGroupBy = vi.mocked(prisma.auditLog.groupBy);
 
   const ORIGINAL_SECRET = process.env.AUDIT_QUEUE_TOKEN_SECRET;
@@ -398,9 +399,13 @@ describe("recordDeepDive", () => {
     // No prior dive by default — the idempotency guard finds nothing
     // and the create path runs. Replay tests override this.
     mockLogFindFirst.mockResolvedValue(null as never);
-    // Default queue: a stable list with NYCH3 present so the
-    // happy-path test can mint and verify a real token. Tests that
-    // exercise removed/changed-snapshot paths override.
+    // The kennel exists by default — the #2282 gate is now an existence
+    // check, not top-20 queue membership. The "kennel no longer exists"
+    // test overrides this to null.
+    mockKennelFindUnique.mockResolvedValue({ id: "k_nych3" } as never);
+    // Default queue (used by getDeepDiveQueueToken on the mint side). The
+    // submit-side gate no longer reads this, so a churned/removed list here
+    // is benign — see the #2282 test below.
     mockKennelFind.mockResolvedValue([
       {
         kennelCode: "nych3",
@@ -497,19 +502,11 @@ describe("recordDeepDive", () => {
     expect(mockLogCreate).not.toHaveBeenCalled();
   });
 
-  it("returns kennelGone when the kennel is no longer in the queue (410-shape)", async () => {
-    // Token was minted when NYCH3 was in the queue. Now NYCH3 has
-    // been removed (e.g. another admin already marked it complete).
-    mockKennelFind.mockResolvedValue([
-      {
-        kennelCode: "agnews",
-        shortName: "AGNEWS",
-        slug: "agnews",
-        region: "Atlanta, GA",
-        sources: [],
-        _count: { events: 3 },
-      },
-    ] as never);
+  it("returns kennelGone when the kennel no longer exists (410-shape)", async () => {
+    // Token was minted for NYCH3, but the kennel record has since been
+    // deleted/merged. The existence check fails closed rather than writing a
+    // dangling KENNEL_DEEP_DIVE row.
+    mockKennelFindUnique.mockResolvedValue(null as never);
     const result = await recordDeepDive({
       kennelCode: "nych3",
       findingsCount: 1,
@@ -518,6 +515,34 @@ describe("recordDeepDive", () => {
     });
     expect(result).toEqual({ ok: false, error: "kennelGone" });
     expect(mockLogCreate).not.toHaveBeenCalled();
+  });
+
+  it("persists the dive when the kennel dropped out of the displayed top-20 queue but still exists (#2282)", async () => {
+    // The #2282 regression: Fool Moon H3 was a valid never-dived target at
+    // dialog-open but a benign queue churn pushed it past the displayed
+    // top-20 window by submit time. The old gate re-checked top-20 membership
+    // and returned kennelGone — a silent no-op. The kennel still EXISTS, the
+    // token is bound to it, so the completion MUST persist.
+    mockLogCreate.mockResolvedValue({ id: "log_2282" } as never);
+    // Simulate the submit-side mint-queue no longer containing nych3.
+    mockKennelFind.mockResolvedValue([] as never);
+    // ...but the kennel record itself is alive.
+    mockKennelFindUnique.mockResolvedValue({ id: "k_nych3" } as never);
+    const result = await recordDeepDive({
+      kennelCode: "nych3",
+      findingsCount: 1,
+      summary: "boundary kennel completion",
+      queueToken: freshToken("nych3"),
+    });
+    expect(result).toEqual({ ok: true, id: "log_2282" });
+    expect(mockLogCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "KENNEL_DEEP_DIVE",
+          kennelCode: "nych3",
+        }),
+      }),
+    );
   });
 
   it("persists the dive when the rest of the queue churned but the kennel is still present (#2261 — no false queueChanged)", async () => {

--- a/src/app/admin/audit/actions.ts
+++ b/src/app/admin/audit/actions.ts
@@ -587,12 +587,21 @@ export async function recordDeepDive(input: {
     return { ok: false, error: "invalidToken" };
   }
 
-  // The kennel must still be a current deep-dive target. Use the
-  // lightweight kennelCode-only query to match what the token mint
-  // path captured. (Full-queue snapshot equality is intentionally NOT
-  // enforced here — see the doc comment above.)
-  const liveCodes = await getDeepDiveQueueKennelCodes();
-  if (!liveCodes.includes(input.kennelCode)) {
+  // The kennel must still exist. We deliberately do NOT re-check live
+  // top-20 deep-dive-queue membership here (#2282): a benign churn of the
+  // *other* queued kennels (a daily ingest, a parallel admin, a kennel
+  // ranked at the #20 boundary) between dialog-open and submit could drop
+  // this kennel out of the displayed window while it remains a perfectly
+  // valid dive target — and rejecting the write then stranded a legitimate
+  // completion as a silent no-op (the same churn-fragility #2261 removed for
+  // the snapshot gate, reintroduced as a position gate). The signed
+  // kennelCode binding already supplies the anti-misattribution guarantee,
+  // so an existence check is sufficient — matching `recordDeepDiveManual`.
+  const kennel = await prisma.kennel.findUnique({
+    where: { kennelCode: input.kennelCode },
+    select: { id: true },
+  });
+  if (!kennel) {
     return { ok: false, error: "kennelGone" };
   }
 
@@ -634,6 +643,9 @@ export async function recordDeepDive(input: {
     },
     select: { id: true },
   });
+  // Refresh the dashboard so the completed kennel leaves the never-dived queue
+  // and coverage advances without a hard reload (#2282).
+  revalidatePath("/admin/audit");
   return { ok: true, id: log.id };
 }
 
@@ -703,6 +715,7 @@ export async function recordDeepDiveManual(input: {
     },
     select: { id: true },
   });
+  revalidatePath("/admin/audit");
   return { ok: true, id: log.id, shortName: kennel.shortName };
 }
 

--- a/src/app/admin/kennels/page.tsx
+++ b/src/app/admin/kennels/page.tsx
@@ -30,6 +30,7 @@ export default async function AdminKennelsPage() {
 
   const serialized = kennels.map((k) => ({
     id: k.id,
+    slug: k.slug,
     shortName: k.shortName,
     fullName: k.fullName,
     region: k.region,

--- a/src/app/api/audit/file-finding/route.test.ts
+++ b/src/app/api/audit/file-finding/route.test.ts
@@ -349,10 +349,14 @@ describe("POST /api/audit/file-finding", () => {
     expect(json.action).toBe("created");
     expect(json.issueNumber).toBe(77);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const url = String(fetchMock.mock.calls[0][0]);
+    // The GitHub-search dedup gate GETs the kennel-labelled open issues before
+    // the create POST, so locate the create call by method rather than index.
+    const createCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as { method?: string } | undefined)?.method === "POST",
+    )!;
+    const url = String(createCall[0]);
     expect(url).toContain("/issues");
-    const init = fetchMock.mock.calls[0][1] as { body: string };
+    const init = createCall[1] as { body: string };
     const requestBody = JSON.parse(init.body) as {
       title: string;
       body: string;
@@ -495,9 +499,12 @@ describe("POST /api/audit/file-finding", () => {
 
     expect(mockFindIssue).not.toHaveBeenCalled();
     // Body should NOT contain a canonical block since the rule isn't
-    // fingerprintable (registry returned undefined).
-    const init = fetchMock.mock.calls[0][1] as { body: string };
-    const reqBody = JSON.parse(init.body) as { body: string };
+    // fingerprintable (registry returned undefined). Locate the create POST —
+    // the GitHub-search dedup gate GETs first.
+    const createCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as { method?: string } | undefined)?.method === "POST",
+    )!;
+    const reqBody = JSON.parse((createCall[1] as { body: string }).body) as { body: string };
     expect(reqBody.body).not.toContain("<!-- audit-canonical:");
   });
 });

--- a/src/app/api/audit/file-finding/route.ts
+++ b/src/app/api/audit/file-finding/route.ts
@@ -55,6 +55,7 @@ import {
   ALERT_LABEL,
   STREAM_LABELS,
   kennelLabel,
+  isValidKennelCode,
 } from "@/lib/audit-labels";
 import { AuditStream } from "@/generated/prisma/client";
 import {
@@ -242,6 +243,7 @@ function errorMessageFor(reason: FilerErrorReason): string {
     case "comment-failed-strict":
     case "comment-failed-bridging":
     case "comment-failed-coarse":
+    case "comment-failed-github":
       return "GitHub comment failed; refusing to fork a duplicate issue";
     case "db-update-failed":
       return "Filing-mirror DB update failed after successful GitHub comment; retry is safe";
@@ -375,6 +377,57 @@ function buildApiActions(): FilerActions {
         console.error(`${LOG_PREFIX} postComment fetch threw:`, err);
         reportAuditFilerFailure("chrome", "postComment", { error: err, issueNumber });
         return false;
+      }
+    },
+    listOpenIssuesByKennel: async (kennelCode) => {
+      const token = process.env.GITHUB_TOKEN;
+      if (!token) {
+        console.error(`${LOG_PREFIX} listOpenIssuesByKennel: GITHUB_TOKEN not set`);
+        reportAuditFilerFailure("chrome", "createIssue", {
+          error: "GITHUB_TOKEN not set (listOpenIssuesByKennel)",
+        });
+        return [];
+      }
+      if (!isValidKennelCode(kennelCode)) return [];
+      const repo = getValidatedRepo();
+      try {
+        // SSRF-safe: URL constructor anchors the request to api.github.com.
+        const url = new URL(`/repos/${repo}/issues`, "https://api.github.com");
+        url.searchParams.set("state", "open");
+        url.searchParams.set("labels", `${AUDIT_LABEL},${kennelLabel(kennelCode)}`);
+        url.searchParams.set("per_page", "100");
+        const res = await fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+          },
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+        if (!res.ok) {
+          const errBody = await safeErrorBody(res);
+          console.error(
+            `${LOG_PREFIX} listOpenIssuesByKennel GitHub API ${res.status}: ${errBody}`,
+          );
+          return [];
+        }
+        const issues = (await res.json()) as Array<{
+          number: number;
+          html_url: string;
+          title: string;
+          body: string | null;
+          pull_request?: unknown;
+        }>;
+        return issues
+          .filter((i) => !i.pull_request)
+          .map((i) => ({
+            number: i.number,
+            htmlUrl: i.html_url,
+            title: i.title,
+            body: i.body ?? "",
+          }));
+      } catch (err) {
+        console.error(`${LOG_PREFIX} listOpenIssuesByKennel fetch threw:`, err);
+        return [];
       }
     },
   };

--- a/src/app/kennels/[slug]/page.tsx
+++ b/src/app/kennels/[slug]/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { prisma } from "@/lib/db";
+import { toSlug } from "@/lib/kennel-utils";
 import { formatSchedule, stripMarkdown } from "@/lib/format";
 import { SCHEDULE_RULES_SELECT } from "@/lib/schedule-season";
 import { getOrCreateUser } from "@/lib/auth";
@@ -21,6 +22,25 @@ import { FadeInSection } from "@/components/home/HeroAnimations";
 import { buildKennelJsonLd, buildBreadcrumbJsonLd, safeJsonLd } from "@/lib/seo";
 import { getCanonicalSiteUrl } from "@/lib/site-url";
 import { ShareButton } from "@/components/shared/ShareButton";
+
+/**
+ * When an incoming slug doesn't resolve directly, normalize it the same way
+ * `toSlug` builds slugs from short names and look the kennel up under that
+ * canonical form. Catches legacy/malformed slugs — most importantly ones with a
+ * comma or other char outside `[a-z0-9-]` that the route can't otherwise match
+ * (#2308 `sl,ut-discovery` → `sl-ut-discovery`). Returns the canonical slug to
+ * redirect to, or null when no normalization helps. `toSlug` is idempotent on a
+ * clean slug, so this is a no-op for the common path.
+ */
+async function resolveCanonicalKennelSlug(slug: string): Promise<string | null> {
+  const normalized = toSlug(slug);
+  if (!normalized || normalized === slug) return null;
+  const match = await prisma.kennel.findUnique({
+    where: { slug: normalized },
+    select: { slug: true, isHidden: true },
+  });
+  return match && !match.isHidden ? match.slug : null;
+}
 
 export async function generateMetadata({
   params,
@@ -82,7 +102,14 @@ export default async function KennelDetailPage({
     },
   });
 
-  if (!kennel || kennel.isHidden) notFound();
+  if (!kennel) {
+    // Legacy / malformed slug (e.g. a comma-containing slug, #2308) — redirect
+    // to the canonical normalized slug if one resolves, else 404.
+    const canonical = await resolveCanonicalKennelSlug(slug);
+    if (canonical) redirect(`/kennels/${canonical}`);
+    notFound();
+  }
+  if (kennel.isHidden) notFound();
 
   const baseUrl = getCanonicalSiteUrl();
   const kennelJsonLd = buildKennelJsonLd({
@@ -259,13 +286,16 @@ export default async function KennelDetailPage({
   // Stats — use unique date count for resilience against duplicate canonical events
   const uniqueDates = new Set(events.map(e => e.date.toISOString().split("T")[0]));
   const totalEvents = uniqueDates.size;
-  // "Latest Run" = highest run number among recent events (upcoming + the most
-  // recent past), so a low-numbered side-series ("Sloppy Trail #46") doesn't
-  // override the main sequence ("Trail 802") just by being the most recent date
-  // (#2184). Windowed to bound stale-outlier risk; CANCELLED events are already
-  // excluded by the events query above.
+  // "Latest Run" = highest run number among the most recent COMPLETED runs
+  // (date < today). Past-only on purpose (#2385): kennels like T3H3 pre-populate
+  // weekly placeholders far into the future (e.g. "#500 - Hare TBD" in 2027), so
+  // including `upcoming` made Math.max report a run that hasn't happened. Taking
+  // the max over a recent-past window still preserves the #2184 intent — a
+  // low-numbered side-series ("Sloppy Trail #46") can't override the main
+  // sequence ("Trail 802") just by being the most recent date. CANCELLED events
+  // are already excluded by the events query above.
   const RECENT_PAST_FOR_RUN = 12;
-  const recentRunNumbers = [...upcoming, ...past.slice(0, RECENT_PAST_FOR_RUN)]
+  const recentRunNumbers = past.slice(0, RECENT_PAST_FOR_RUN)
     .map((e) => e.runNumber)
     .filter((n): n is number => n != null);
   const currentRunNumber = recentRunNumbers.length ? Math.max(...recentRunNumbers) : null;

--- a/src/components/admin/KennelForm.tsx
+++ b/src/components/admin/KennelForm.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
 import { upload } from "@vercel/blob/client";
 import { createKennel, updateKennel } from "@/app/admin/kennels/actions";
 import {
@@ -803,7 +803,21 @@ export function KennelForm({ kennel, regions, trigger }: Readonly<KennelFormProp
             </div>
           </FormSection>
 
-            <div className="flex justify-end gap-2 pt-2">
+            <div className="flex items-center justify-end gap-2 pt-2">
+              {/* Edit-mode only: jump to the live public page to verify a
+                  profile change (e.g. a new logo) without recalling the URL (#2396). */}
+              {kennel && (
+                <Button type="button" variant="ghost" size="sm" className="mr-auto" asChild>
+                  <a
+                    href={`/kennels/${kennel.slug}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    View public page
+                    <ExternalLink className="ml-1.5 size-3.5" />
+                  </a>
+                </Button>
+              )}
               <Button
                 type="button"
                 variant="outline"

--- a/src/components/admin/KennelTable.tsx
+++ b/src/components/admin/KennelTable.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { deleteKennel, toggleKennelVisibility } from "@/app/admin/kennels/actions";
-import { MoreHorizontal, Eye, EyeOff, AlertTriangle } from "lucide-react";
+import { MoreHorizontal, Eye, EyeOff, AlertTriangle, ExternalLink } from "lucide-react";
 import {
   Table,
   TableBody,
@@ -209,6 +209,17 @@ function KennelRow({ kennel, regions }: { kennel: Kennel; regions: RegionOption[
       <TableCell className="hidden sm:table-cell text-center">{kennel._count.aliases}</TableCell>
       <TableCell className="text-right">
         <div className="flex justify-end gap-2">
+          <Button size="sm" variant="ghost" className="h-8 w-8 p-0" asChild>
+            <a
+              href={`/kennels/${kennel.slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="View public page"
+              aria-label={`View public page for ${kennel.shortName}`}
+            >
+              <ExternalLink className="size-4" />
+            </a>
+          </Button>
           <KennelForm
             kennel={kennel}
             regions={regions}

--- a/src/components/admin/kennel-data-types.ts
+++ b/src/components/admin/kennel-data-types.ts
@@ -5,6 +5,8 @@
  */
 export type AdminKennelData = {
   id: string;
+  /** URL slug for the public kennel page (`/kennels/<slug>`). #2396 */
+  slug: string;
   shortName: string;
   fullName: string;
   region: string;

--- a/src/lib/audit-canonical.test.ts
+++ b/src/lib/audit-canonical.test.ts
@@ -2,6 +2,8 @@ import {
   emitCanonicalBlock,
   parseCanonicalBlock,
   buildCanonicalBlock,
+  emitIdentityMarker,
+  parseAuditIdentity,
   CANONICAL_SCHEMA_VERSION,
   type CanonicalBlock,
 } from "./audit-canonical";
@@ -180,5 +182,73 @@ describe("parseCanonicalBlock", () => {
       emitCanonicalBlock({ ...SAMPLE, kennelCode: "different-kennel" }),
     ].join("\n");
     expect(parseCanonicalBlock(body)?.kennelCode).toBe("nych3");
+  });
+});
+
+describe("identity marker (#2308 dedup hardening)", () => {
+  const IDENTITY = {
+    stream: "CHROME_KENNEL" as const,
+    kennelCode: "bombay-h3",
+    ruleSlug: "stale-placeholder-titles",
+  };
+
+  it("round-trips emit → parse losslessly", () => {
+    const marker = emitIdentityMarker(IDENTITY);
+    expect(marker.startsWith("<!-- audit-identity:")).toBe(true);
+    expect(marker.endsWith("-->")).toBe(true);
+    expect(parseAuditIdentity(marker)).toEqual(IDENTITY);
+  });
+
+  it("extracts the identity when surrounded by other markdown", () => {
+    const body = ["## Finding", "Some prose.", emitIdentityMarker(IDENTITY)].join("\n");
+    expect(parseAuditIdentity(body)).toEqual(IDENTITY);
+  });
+
+  it("escapes `-->` so the comment envelope can't be terminated early", () => {
+    const marker = emitIdentityMarker({ ...IDENTITY, kennelCode: "weird-->code" });
+    expect(marker.split("-->")).toHaveLength(2);
+    expect(parseAuditIdentity(marker)?.kennelCode).toBe("weird-->code");
+  });
+
+  it("falls back to the canonical block when no identity marker is present", () => {
+    // Issues filed before the identity marker existed only carry the canonical
+    // block (fingerprintable rules). The gate must still recover their identity.
+    const body = `prose\n\n${emitCanonicalBlock(SAMPLE)}`;
+    expect(parseAuditIdentity(body)).toEqual({
+      stream: SAMPLE.stream,
+      kennelCode: SAMPLE.kennelCode,
+      ruleSlug: SAMPLE.ruleSlug,
+    });
+  });
+
+  it("prefers the identity marker over the canonical block when both are present", () => {
+    const body = [
+      emitCanonicalBlock(SAMPLE), // kennelCode nych3 / hare-url
+      emitIdentityMarker(IDENTITY), // kennelCode bombay-h3 / stale-placeholder-titles
+    ].join("\n");
+    expect(parseAuditIdentity(body)).toEqual(IDENTITY);
+  });
+
+  it("returns null when the body carries neither marker nor canonical block", () => {
+    expect(parseAuditIdentity("just markdown")).toBeNull();
+    expect(parseAuditIdentity(null)).toBeNull();
+    expect(parseAuditIdentity(undefined)).toBeNull();
+    expect(parseAuditIdentity("")).toBeNull();
+  });
+
+  it("fails closed on a malformed identity payload", () => {
+    expect(parseAuditIdentity("<!-- audit-identity: { not json } -->")).toBeNull();
+  });
+
+  it("fails closed on a schema-version mismatch", () => {
+    const future =
+      '<!-- audit-identity: {"v":99,"stream":"AUTOMATED","kennelCode":"nych3","ruleSlug":"hare-url"} -->';
+    expect(parseAuditIdentity(future)).toBeNull();
+  });
+
+  it("fails closed when stream is not a known AuditStream value", () => {
+    const bad =
+      '<!-- audit-identity: {"v":1,"stream":"NOPE","kennelCode":"nych3","ruleSlug":"hare-url"} -->';
+    expect(parseAuditIdentity(bad)).toBeNull();
   });
 });

--- a/src/lib/audit-canonical.ts
+++ b/src/lib/audit-canonical.ts
@@ -127,14 +127,116 @@ function isCanonicalBlock(value: unknown): value is CanonicalBlock {
   const v = value as Record<string, unknown>;
   return (
     v.v === CANONICAL_SCHEMA_VERSION &&
-    (v.stream === "AUTOMATED" ||
-      v.stream === "CHROME_EVENT" ||
-      v.stream === "CHROME_KENNEL" ||
-      v.stream === "UNKNOWN") &&
+    isAuditStreamValue(v.stream) &&
     typeof v.kennelCode === "string" &&
     typeof v.ruleSlug === "string" &&
     typeof v.ruleVersion === "number" &&
     typeof v.semanticHash === "string" &&
     typeof v.fingerprint === "string"
   );
+}
+
+function isAuditStreamValue(value: unknown): value is AuditStream {
+  return (
+    value === "AUTOMATED" ||
+    value === "CHROME_EVENT" ||
+    value === "CHROME_KENNEL" ||
+    value === "UNKNOWN"
+  );
+}
+
+// ── Dedup identity marker (issue #2308 dedup hardening) ────────────────
+//
+// The canonical block above is only emitted for *fingerprintable* rules. But
+// chrome-kennel findings frequently use non-fingerprintable rules AND carry
+// free-form, agent-authored titles, so neither the fingerprint nor the title
+// gives the filer a stable way to recognize an already-open issue across runs.
+// That let a re-file fork a duplicate even when the same (kennel, rule) issue
+// was already open (#2425≡#2421, #2296≡#2260).
+//
+// The identity marker is a tiny, ALWAYS-emitted block carrying just the dedup
+// identity — (stream, kennelCode, ruleSlug) — which is independent of which
+// sample events a given run happened to pick. The GitHub-search dedup gate in
+// `audit-filer.ts` reads it back out of open issue bodies to match a re-file to
+// its existing issue, with no dependence on the local mirror's freshness.
+
+/** Schema version of the identity-marker payload. */
+export const IDENTITY_SCHEMA_VERSION = 1;
+
+const IDENTITY_PREFIX = "<!-- audit-identity:";
+
+/** The stable dedup identity of an audit finding — sample-event-independent. */
+export interface AuditIdentity {
+  stream: AuditStream;
+  kennelCode: string;
+  ruleSlug: string;
+}
+
+interface IdentityPayload extends AuditIdentity {
+  v: number;
+}
+
+/**
+ * Emit the always-on identity marker for an audit-issue body. Pure function;
+ * uses the same `-->`-escaping defense as `emitCanonicalBlock` so a payload
+ * field can't terminate the comment envelope early.
+ */
+export function emitIdentityMarker(identity: AuditIdentity): string {
+  const payload: IdentityPayload = { v: IDENTITY_SCHEMA_VERSION, ...identity };
+  const json = JSON.stringify(payload).replaceAll("-->", "--&gt;");
+  return `${IDENTITY_PREFIX} ${json} ${SUFFIX}`;
+}
+
+function parseIdentityMarker(body: string): AuditIdentity | null {
+  const start = body.indexOf(IDENTITY_PREFIX);
+  if (start === -1) return null;
+  const end = body.indexOf(SUFFIX, start + IDENTITY_PREFIX.length);
+  if (end === -1) return null;
+  const json = body.slice(start + IDENTITY_PREFIX.length, end).trim().replaceAll("--&gt;", "-->");
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (!isIdentityPayload(parsed)) return null;
+    return {
+      stream: parsed.stream,
+      kennelCode: parsed.kennelCode,
+      ruleSlug: parsed.ruleSlug,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isIdentityPayload(value: unknown): value is IdentityPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.v === IDENTITY_SCHEMA_VERSION &&
+    isAuditStreamValue(v.stream) &&
+    typeof v.kennelCode === "string" &&
+    typeof v.ruleSlug === "string"
+  );
+}
+
+/**
+ * Extract the dedup identity from an audit-issue body. Reads the explicit
+ * identity marker first, then falls back to the canonical block (which already
+ * carries stream + kennelCode + ruleSlug) so issues filed before the identity
+ * marker existed still match on the fingerprintable path. Returns null when the
+ * body carries neither (fails closed — the gate then treats it as no-match).
+ */
+export function parseAuditIdentity(
+  body: string | null | undefined,
+): AuditIdentity | null {
+  if (!body) return null;
+  const marker = parseIdentityMarker(body);
+  if (marker) return marker;
+  const canonical = parseCanonicalBlock(body);
+  if (canonical) {
+    return {
+      stream: canonical.stream,
+      kennelCode: canonical.kennelCode,
+      ruleSlug: canonical.ruleSlug,
+    };
+  }
+  return null;
 }

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -333,6 +333,22 @@ describe("formatSchedule", () => {
       ).toBe("Mondays at 6:00 PM / Mondays at 7:00 PM");
     });
 
+    it("drops a day-less sentinel-RRULE slot instead of rendering a bare 'at <time>' fragment (#2373 t3h3-nz)", () => {
+      // t3h3-nz has two ScheduleRule rows: a real STATIC_SCHEDULE rule
+      // (FREQ=MONTHLY;BYDAY=2TH → "2nd Thursday") and a CADENCE=… sentinel
+      // (Pass-2 backfill) that describeRruleDay can't summarize. The sentinel
+      // must NOT render as a standalone "at 6:30 PM" fragment appended after
+      // the real rule.
+      expect(
+        formatSchedule({
+          scheduleRules: [
+            { rrule: "FREQ=MONTHLY;BYDAY=2TH", startTime: "18:30", displayOrder: 0 },
+            { rrule: "CADENCE=MONTHLY;BYDAY=TH", startTime: "18:30", displayOrder: 1 },
+          ],
+        }),
+      ).toBe("2nd Thursday at 6:30 PM");
+    });
+
     it("falls through to flat fields when scheduleRules is an empty array", () => {
       expect(
         formatSchedule({

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -330,7 +330,16 @@ function formatScheduleRules(rules: ScheduleSlot[]): string | null {
 function formatScheduleSlot(slot: ScheduleSlot): string | null {
   const dayLabel = describeRruleDay(slot.rrule);
   const timeText = slot.startTime ? formatTime(slot.startTime) : null;
-  const head = [dayLabel, timeText ? `at ${timeText}` : null].filter(Boolean).join(" ");
+  // A slot whose RRULE has no describable weekday (e.g. a `CADENCE=…` or
+  // `FREQ=LUNAR` sentinel rule that Pass-2 backfill emits alongside a real
+  // rule) must NOT contribute a bare "at <time>" fragment — that produced the
+  // "2nd Thursday at 6:30 PM / at 6:30 PM" double-render in #2373. Without a
+  // day the time isn't independently meaningful here (the legacy flat-field
+  // path handles a bare time separately), so suppress the head and fall back
+  // to a season hint if the slot has one, else drop the slot entirely.
+  const head = dayLabel
+    ? [dayLabel, timeText ? `at ${timeText}` : null].filter(Boolean).join(" ")
+    : null;
   const seasonHint = formatSeasonHint(slot.label, slot.validFrom, slot.validUntil);
   if (!head && !seasonHint) return null;
   if (head && seasonHint) return `${head} (${seasonHint})`;

--- a/src/pipeline/audit-draft-promoter.test.ts
+++ b/src/pipeline/audit-draft-promoter.test.ts
@@ -10,7 +10,11 @@ vi.mock("@/lib/db", () => ({
 }));
 vi.mock("@/pipeline/audit-filer", () => ({ fileAuditFinding: vi.fn() }));
 vi.mock("@/pipeline/audit-issue", () => ({
-  buildCronActions: vi.fn(() => ({ createIssue: vi.fn(), postComment: vi.fn() })),
+  buildCronActions: vi.fn(() => ({
+    createIssue: vi.fn(),
+    postComment: vi.fn(),
+    listOpenIssuesByKennel: vi.fn().mockResolvedValue([]),
+  })),
 }));
 vi.mock("@/pipeline/audit-runner", () => ({ loadSuppressions: vi.fn() }));
 // Deterministic fingerprint per (kennel, rule) so same-finding siblings collide.

--- a/src/pipeline/audit-draft-promoter.ts
+++ b/src/pipeline/audit-draft-promoter.ts
@@ -260,7 +260,7 @@ async function promoteOneDraft(
 interface DraftOutcomeFields {
   issueNumber?: number;
   issueUrl?: string;
-  filerTier?: "strict" | "bridging" | "coarse";
+  filerTier?: "strict" | "bridging" | "coarse" | "github-search";
   errorReason?: string;
 }
 

--- a/src/pipeline/audit-filer.test.ts
+++ b/src/pipeline/audit-filer.test.ts
@@ -42,6 +42,7 @@ import {
   type FilerActions,
 } from "./audit-filer";
 import { AuditStream } from "@/generated/prisma/client";
+import { emitIdentityMarker } from "@/lib/audit-canonical";
 
 const mockFindFirst = vi.mocked(prisma.auditIssue.findFirst);
 const mockFindUnique = vi.mocked(prisma.auditIssue.findUnique);
@@ -56,6 +57,9 @@ function buildActions(overrides: Partial<FilerActions> = {}): FilerActions {
       htmlUrl: "https://github.com/x/y/issues/999",
     }),
     postComment: vi.fn().mockResolvedValue(true),
+    // Default: no open issues for the kennel → the GitHub-search dedup gate
+    // misses and the create path runs. Gate tests override this.
+    listOpenIssuesByKennel: vi.fn().mockResolvedValue([]),
     ...overrides,
   };
 }
@@ -548,7 +552,11 @@ describe("fileAuditFinding — recurrence escalation", () => {
       htmlUrl: "https://github.com/x/y/issues/555",
     });
     const postComment = vi.fn().mockResolvedValue(true);
-    const actions: FilerActions = { createIssue, postComment };
+    const actions: FilerActions = {
+      createIssue,
+      postComment,
+      listOpenIssuesByKennel: vi.fn().mockResolvedValue([]),
+    };
 
     const out = await fileAuditFinding(BASE_INPUT, actions);
     if (out.action !== "recurred") throw new Error("expected recurred");
@@ -737,7 +745,11 @@ describe("fileAuditFinding — recurrence escalation", () => {
       htmlUrl: "https://github.com/x/y/issues/777",
     });
     const postComment = vi.fn().mockResolvedValue(true);
-    const actions: FilerActions = { createIssue, postComment };
+    const actions: FilerActions = {
+      createIssue,
+      postComment,
+      listOpenIssuesByKennel: vi.fn().mockResolvedValue([]),
+    };
 
     const out = await fileAuditFinding(BASE_INPUT, actions);
     if (out.action !== "recurred") throw new Error("expected recurred");
@@ -760,6 +772,7 @@ describe("fileAuditFinding — recurrence escalation", () => {
         htmlUrl: "https://github.com/x/y/issues/777",
       }),
       postComment,
+      listOpenIssuesByKennel: vi.fn().mockResolvedValue([]),
     };
 
     const out = await fileAuditFinding(BASE_INPUT, actions);
@@ -1150,5 +1163,140 @@ describe("fileAuditFinding — coarse-dedup tier (non-fingerprintable rules)", (
     expect(mockFindMany).toHaveBeenCalledTimes(1);
     const callArgs = mockFindMany.mock.calls[0][0] as { where: Record<string, unknown> };
     expect(callArgs.where).not.toHaveProperty("stream");
+  });
+});
+
+describe("fileAuditFinding — GitHub-search dedup gate (#2308)", () => {
+  beforeEach(() => {
+    // All mirror tiers miss by default so the cascade reaches the gate.
+    mockFindFirst.mockResolvedValue(null as never);
+    mockFindMany.mockResolvedValue([] as never);
+  });
+
+  it("dedups against an open GitHub issue carrying a matching identity marker when the mirror missed", async () => {
+    // The stale-mirror / free-form-title case: coarse-dedup found nothing in
+    // the mirror, but an open issue for this kennel already covers the same
+    // (stream, kennelCode, ruleSlug). The gate must comment-and-recur, never
+    // fork a duplicate.
+    const candidateBody = `Bombay H3 placeholder titles…\n\n${emitIdentityMarker(
+      {
+        stream: COARSE_INPUT.stream,
+        kennelCode: COARSE_INPUT.kennelCode,
+        ruleSlug: COARSE_INPUT.ruleSlug,
+      },
+    )}`;
+    const actions = buildActions({
+      listOpenIssuesByKennel: vi.fn().mockResolvedValue([
+        {
+          number: 964,
+          htmlUrl: "https://github.com/x/y/issues/964",
+          title: "C2H3 — some free-form chrome title that won't match by text",
+          body: candidateBody,
+        },
+      ]),
+    });
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+
+    expect(out).toMatchObject({
+      action: "recurred",
+      issueNumber: 964,
+      htmlUrl: "https://github.com/x/y/issues/964",
+      tier: "github-search",
+    });
+    expect(actions.createIssue).not.toHaveBeenCalled();
+    expect(actions.postComment).toHaveBeenCalledWith(
+      964,
+      expect.stringContaining("Still recurring"),
+    );
+  });
+
+  it("matches a marker-less candidate by exact title (transition before every issue carries a marker)", async () => {
+    // #2425≡#2421 shape: two identical-title chrome findings, the open one
+    // filed before the identity marker existed (no marker in its body).
+    const input = {
+      ...COARSE_INPUT,
+      title: "Bombay H3 — Stale placeholder titles across all events (#627–#631)",
+    };
+    const actions = buildActions({
+      listOpenIssuesByKennel: vi.fn().mockResolvedValue([
+        {
+          number: 2421,
+          htmlUrl: "https://github.com/x/y/issues/2421",
+          title: input.title,
+          body: "free-form chrome body, no identity marker",
+        },
+      ]),
+    });
+
+    const out = await fileAuditFinding(input, actions);
+
+    expect(out).toMatchObject({ action: "recurred", issueNumber: 2421, tier: "github-search" });
+    expect(actions.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("is stream-scoped — an AUTOMATED issue does not absorb a CHROME_KENNEL finding for the same kennel + rule", async () => {
+    const input = { ...COARSE_INPUT, stream: AuditStream.CHROME_KENNEL };
+    const candidateBody = emitIdentityMarker({
+      stream: AuditStream.AUTOMATED, // different stream
+      kennelCode: COARSE_INPUT.kennelCode,
+      ruleSlug: COARSE_INPUT.ruleSlug,
+    });
+    const actions = buildActions({
+      listOpenIssuesByKennel: vi.fn().mockResolvedValue([
+        {
+          number: 964,
+          htmlUrl: "https://github.com/x/y/issues/964",
+          title: "different title",
+          body: candidateBody,
+        },
+      ]),
+    });
+
+    const out = await fileAuditFinding(input, actions);
+
+    // No identity match (stream differs) and no title match → fresh create.
+    expect(out.action).toBe("created");
+    expect(actions.createIssue).toHaveBeenCalled();
+  });
+
+  it("surfaces comment-failed-github (not a duplicate) when the recur comment fails on a gate hit", async () => {
+    const candidateBody = emitIdentityMarker({
+      stream: COARSE_INPUT.stream,
+      kennelCode: COARSE_INPUT.kennelCode,
+      ruleSlug: COARSE_INPUT.ruleSlug,
+    });
+    const actions = buildActions({
+      postComment: vi.fn().mockResolvedValue(false),
+      listOpenIssuesByKennel: vi.fn().mockResolvedValue([
+        {
+          number: 964,
+          htmlUrl: "https://github.com/x/y/issues/964",
+          title: "x",
+          body: candidateBody,
+        },
+      ]),
+    });
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+
+    expect(out).toEqual({
+      action: "error",
+      reason: "comment-failed-github",
+      existingIssueNumber: 964,
+    });
+    expect(actions.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("embeds the always-on identity marker on a fresh create so future re-files can match", async () => {
+    const actions = buildActions(); // listOpenIssuesByKennel → [] (gate miss)
+
+    const out = await fileAuditFinding(COARSE_INPUT, actions);
+
+    expect(out.action).toBe("created");
+    const createCall = vi.mocked(actions.createIssue).mock.calls[0][0];
+    expect(createCall.body).toContain("<!-- audit-identity:");
+    expect(createCall.body).toContain('"kennelCode":"c2h3"');
+    expect(createCall.body).toContain('"ruleSlug":"hare-cta-text"');
   });
 });

--- a/src/pipeline/audit-filer.ts
+++ b/src/pipeline/audit-filer.ts
@@ -65,6 +65,8 @@ import { prisma } from "@/lib/db";
 import {
   buildCanonicalBlock,
   emitCanonicalBlock,
+  emitIdentityMarker,
+  parseAuditIdentity,
 } from "@/lib/audit-canonical";
 import { toIsoDateString } from "@/lib/date";
 import {
@@ -127,7 +129,7 @@ export type FileFindingOutcome =
       issueNumber: number;
       htmlUrl: string;
       recurrenceCount: number;
-      tier: "strict" | "bridging" | "coarse";
+      tier: "strict" | "bridging" | "coarse" | "github-search";
       /** Set when this recur crossed the escalation threshold and a
        *  meta-issue was filed (or had previously been filed for this
        *  base lifecycle). Lets callers surface a link to the meta in
@@ -148,6 +150,7 @@ export type FilerErrorReason =
   | "comment-failed-strict"
   | "comment-failed-bridging"
   | "comment-failed-coarse"
+  | "comment-failed-github"
   | "create-failed"
   | "db-update-failed";
 
@@ -169,6 +172,18 @@ export interface FilerActions {
   }) => Promise<{ number: number; htmlUrl: string } | null>;
   /** Returns true on successful 2xx comment, false on any failure. */
   postComment: (issueNumber: number, body: string) => Promise<boolean>;
+  /**
+   * List OPEN audit issues carrying the `kennel:<code>` label, with their
+   * bodies, for the final GitHub-search dedup gate. Returns `[]` on any failure
+   * (missing token, invalid code, network/HTTP error) so a list failure can
+   * never block filing — the gate just falls through to create. The body is
+   * needed so the gate can read the embedded dedup identity marker.
+   */
+  listOpenIssuesByKennel: (
+    kennelCode: string,
+  ) => Promise<
+    Array<{ number: number; htmlUrl: string; title: string; body: string }>
+  >;
 }
 
 /**
@@ -784,6 +799,64 @@ async function tryCoarseDedup(
 }
 
 /**
+ * Final, mirror-independent dedup gate: search OPEN GitHub issues carrying this
+ * finding's `kennel:<code>` label and match a re-file to an already-open issue
+ * by its embedded dedup identity (stream, kennelCode, ruleSlug) — falling back
+ * to exact-title equality for issues filed before the identity marker existed.
+ *
+ * Runs only after the mirror-backed tiers (strict/bridging/coarse) all miss, so
+ * it catches the cases those tiers structurally can't: a stale/delayed mirror
+ * (the issue is open on GitHub but not yet mirrored) and non-fingerprintable
+ * chrome findings with free-form titles (no fingerprint, no parseable
+ * title-slug). Returns the recurred outcome on a hit, an error on comment
+ * failure, or null to fall through to a fresh create.
+ *
+ * `recurrenceCount` is reported as 0 on this path: we deliberately do NOT touch
+ * the mirror row's counter here (the row may not be mirrored yet, and the whole
+ * point of the gate is to avoid trusting the mirror). The next sync reconciles
+ * the open issue into the mirror; subsequent recurrences then increment
+ * normally via the strict/coarse tiers.
+ */
+async function tryGitHubSearchDedup(
+  input: FileFindingInput,
+  actions: FilerActions,
+): Promise<FileFindingOutcome | null> {
+  const candidates = await actions.listOpenIssuesByKennel(input.kennelCode);
+  if (candidates.length === 0) return null;
+
+  const match = candidates.find((issue) => {
+    // Exact-title match catches marker-less identical-title re-files (the
+    // #2425≡#2421 shape) during the transition before every open issue carries
+    // an identity marker.
+    if (issue.title === input.title) return true;
+    const identity = parseAuditIdentity(issue.body);
+    return (
+      identity !== null &&
+      identity.stream === input.stream &&
+      identity.kennelCode === input.kennelCode &&
+      identity.ruleSlug === input.ruleSlug
+    );
+  });
+  if (!match) return null;
+
+  const ok = await actions.postComment(match.number, formatRecurComment(input));
+  if (!ok) {
+    return {
+      action: "error",
+      reason: "comment-failed-github",
+      existingIssueNumber: match.number,
+    };
+  }
+  return {
+    action: "recurred",
+    issueNumber: match.number,
+    htmlUrl: match.htmlUrl,
+    recurrenceCount: 0,
+    tier: "github-search",
+  };
+}
+
+/**
  * File an audit finding through the dedup cascade.
  *   - Fingerprintable (canonical !== null): strict → bridging → create.
  *   - Non-fingerprintable (canonical === null): coarse-dedup → create.
@@ -791,6 +864,10 @@ async function tryCoarseDedup(
  * Coarse-dedup is gated to the canonical-null branch on purpose:
  * bridging already handles the (kennelCode, ruleSlug) match for
  * fingerprintable rules and additionally backfills the fingerprint.
+ *
+ * Before any fresh create — for BOTH branches — a final GitHub-search dedup
+ * gate (`tryGitHubSearchDedup`) checks the live open issues for the kennel, so
+ * a stale mirror or a free-form chrome title can't fork a duplicate (#2308).
  */
 export async function fileAuditFinding(
   input: FileFindingInput,
@@ -815,13 +892,24 @@ export async function fileAuditFinding(
     if (coarse) return coarse;
   }
 
+  // Final mirror-independent gate before creating fresh.
+  const gitHubDedup = await tryGitHubSearchDedup(input, actions);
+  if (gitHubDedup) return gitHubDedup;
+
   // Embedding the canonical block on fresh creates lets the next
   // sync round populate AuditIssue.fingerprint without a registry
   // round-trip; the bridging tier above is the safety net for rows
-  // that were created before this PR.
+  // that were created before this PR. The identity marker is ALWAYS
+  // embedded (even for non-fingerprintable rules) so the GitHub-search
+  // gate can recognize a future re-file regardless of title drift.
+  const identityMarker = emitIdentityMarker({
+    stream: input.stream,
+    kennelCode: input.kennelCode,
+    ruleSlug: input.ruleSlug,
+  });
   const finalBody = canonical
-    ? `${input.bodyMarkdown}\n\n${emitCanonicalBlock(canonical)}`
-    : input.bodyMarkdown;
+    ? `${input.bodyMarkdown}\n\n${emitCanonicalBlock(canonical)}\n${identityMarker}`
+    : `${input.bodyMarkdown}\n\n${identityMarker}`;
   const created = await actions.createIssue({
     title: input.title,
     body: finalBody,

--- a/src/pipeline/audit-issue.test.ts
+++ b/src/pipeline/audit-issue.test.ts
@@ -112,13 +112,16 @@ describe("fileAuditIssues", () => {
 
     const result = await fileAuditIssues([buildGroup()]);
     expect(result).toEqual(["https://github.com/test/42"]);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // The GitHub-search dedup gate issues a GET before the create POST, so
+    // locate the create call by method rather than by index.
+    const createCall = mockFetch.mock.calls.find(
+      (c) => (c[1] as { method?: string } | undefined)?.method === "POST",
+    )!;
     // fetch now receives a URL object (the cron path's
     // tainted-URL Codacy fix); stringify before assertion.
-    const url = String(mockFetch.mock.calls[0][0]);
+    const url = String(createCall[0]);
     expect(url).toContain("/issues");
-    const init = mockFetch.mock.calls[0][1] as { method: string };
-    expect(init.method).toBe("POST");
+    expect((createCall[1] as { method: string }).method).toBe("POST");
   });
 
   it("falls back to GitHub API and still creates issues when mirror query fails", async () => {
@@ -129,7 +132,12 @@ describe("fileAuditIssues", () => {
         ok: true,
         json: async () => [],
       })
-      // Second call: create issue
+      // Second call: GitHub-search dedup gate (no open issues for the kennel)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      // Third call: create issue
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ html_url: "https://github.com/test/1", number: 1 }),
@@ -137,8 +145,8 @@ describe("fileAuditIssues", () => {
 
     const result = await fileAuditIssues([buildGroup()]);
     expect(result).toEqual(["https://github.com/test/1"]);
-    // First fetch = GH API fallback for titles, second = issue creation
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // titles fallback + dedup-gate list + issue creation.
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
   it("falls back to GitHub API when mirror is stale", async () => {
@@ -146,6 +154,11 @@ describe("fileAuditIssues", () => {
     const staleDate = new Date(Date.now() - 26 * 60 * 60 * 1000);
     mockAggregate.mockResolvedValue({ _max: { syncedAt: staleDate } });
     mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      // GitHub-search dedup gate (no open issues for the kennel).
       .mockResolvedValueOnce({
         ok: true,
         json: async () => [],
@@ -166,7 +179,8 @@ describe("fileAuditIssues", () => {
     // create. The mirror-bypass invariant is observed via mockAggregate
     // returning a stale date and the GH API receiving the title fetch.
     expect(mockAggregate).toHaveBeenCalled();
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // titles fallback + dedup-gate list + issue creation.
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
   it("embeds the canonical block for fingerprintable rules", async () => {
@@ -181,7 +195,10 @@ describe("fileAuditIssues", () => {
 
     await fileAuditIssues([buildGroup({ rule: "hare-url", category: "hares" })]);
 
-    const fetchCall = mockFetch.mock.calls[0];
+    // Locate the create POST (the GitHub-search dedup gate GETs first).
+    const fetchCall = mockFetch.mock.calls.find(
+      (c) => (c[1] as { method?: string } | undefined)?.method === "POST",
+    )!;
     const requestBody = JSON.parse(fetchCall[1].body) as { body: string };
     expect(requestBody.body).toContain("<!-- audit-canonical:");
     expect(requestBody.body).toContain('"stream":"AUTOMATED"');
@@ -199,7 +216,10 @@ describe("fileAuditIssues", () => {
 
     await fileAuditIssues([buildGroup({ rule: "hare-cta-text", category: "hares" })]);
 
-    const fetchCall = mockFetch.mock.calls[0];
+    // Locate the create POST (the GitHub-search dedup gate GETs first).
+    const fetchCall = mockFetch.mock.calls.find(
+      (c) => (c[1] as { method?: string } | undefined)?.method === "POST",
+    )!;
     const requestBody = JSON.parse(fetchCall[1].body) as { body: string };
     expect(requestBody.body).not.toContain("<!-- audit-canonical:");
   });
@@ -276,10 +296,17 @@ describe("fileAuditIssues", () => {
 
   it("caps issues at MAX_ISSUES_PER_RUN (3)", async () => {
     let issueNum = 1;
-    mockFetch.mockImplementation(async () => ({
-      ok: true,
-      json: async () => ({ html_url: `https://github.com/test/${issueNum}`, number: issueNum++ }),
-    }));
+    // URL-aware: the GitHub-search dedup gate GETs the kennel-labelled list
+    // (return none) before each create POST.
+    mockFetch.mockImplementation(async (input: unknown, init?: { method?: string }) => {
+      if (init?.method !== "POST") {
+        return { ok: true, json: async () => [] };
+      }
+      return {
+        ok: true,
+        json: async () => ({ html_url: `https://github.com/test/${issueNum}`, number: issueNum++ }),
+      };
+    });
 
     const groups = Array.from({ length: 5 }, (_, i) =>
       buildGroup({ kennelCode: `k${i}`, kennelShortName: `K${i}H3` }),
@@ -287,6 +314,11 @@ describe("fileAuditIssues", () => {
 
     const result = await fileAuditIssues(groups);
     expect(result).toHaveLength(3);
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    // Only 3 create POSTs despite 5 groups (MAX_ISSUES_PER_RUN). The dedup-gate
+    // GETs aren't create calls.
+    const createCalls = mockFetch.mock.calls.filter(
+      (c) => (c[1] as { method?: string } | undefined)?.method === "POST",
+    );
+    expect(createCalls).toHaveLength(3);
   });
 });

--- a/src/pipeline/audit-issue.ts
+++ b/src/pipeline/audit-issue.ts
@@ -26,6 +26,7 @@ import {
   ALERT_LABEL,
   STREAM_LABELS,
   kennelLabel,
+  isValidKennelCode,
 } from "@/lib/audit-labels";
 import { prisma } from "@/lib/db";
 import { AUDIT_STREAM } from "@/lib/audit-stream-meta";
@@ -147,6 +148,59 @@ export function buildCronActions(): FilerActions {
         console.error("[audit-issue] Comment threw:", err);
         reportAuditFilerFailure("cron", "postComment", { error: err, issueNumber });
         return false;
+      }
+    },
+    listOpenIssuesByKennel: async (kennelCode) => {
+      const token = process.env.GITHUB_TOKEN;
+      if (!token) {
+        reportAuditFilerFailure("cron", "createIssue", {
+          error: "GITHUB_TOKEN not set (listOpenIssuesByKennel)",
+        });
+        return [];
+      }
+      // The kennelCode is interpolated into the `labels` query param; reject
+      // anything that isn't GitHub-label-safe so the gate never builds a
+      // malformed query (also matches the kennel labels actually filed).
+      if (!isValidKennelCode(kennelCode)) return [];
+      const repo = getValidatedRepo();
+      try {
+        // SSRF-safe: URL constructor anchors the request to api.github.com.
+        const url = new URL(`/repos/${repo}/issues`, "https://api.github.com");
+        url.searchParams.set("state", "open");
+        url.searchParams.set("labels", `${AUDIT_LABEL},${kennelLabel(kennelCode)}`);
+        url.searchParams.set("per_page", "100");
+        const res = await fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+          },
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+        if (!res.ok) {
+          console.error(
+            `[audit-issue] listOpenIssuesByKennel ${res.status} for ${kennelCode}`,
+          );
+          return [];
+        }
+        const issues = (await res.json()) as Array<{
+          number: number;
+          html_url: string;
+          title: string;
+          body: string | null;
+          pull_request?: unknown;
+        }>;
+        // The /issues endpoint returns PRs too — drop them.
+        return issues
+          .filter((i) => !i.pull_request)
+          .map((i) => ({
+            number: i.number,
+            htmlUrl: i.html_url,
+            title: i.title,
+            body: i.body ?? "",
+          }));
+      } catch (err) {
+        console.error("[audit-issue] listOpenIssuesByKennel threw:", err);
+        return [];
       }
     },
   };


### PR DESCRIPTION
Quick Win bundle: harden the audit-issue filer against duplicate GitHub issues, fix five admin/kennel UI bugs, and triage the duplicate/no-op backlog.

## Task 1 — Audit dedup hardening (the crux)
**Root cause:** dedup leaned entirely on the local `AuditIssue` mirror + title format. Chrome-kennel findings use **free-form, agent-authored titles** and often **non-fingerprintable rules**, so neither strict, bridging, nor coarse tiers could match an already-open issue — a re-file forked a duplicate (#2425≡#2421 same-day; #2296≡#2260 cross-run). The fingerprint was already sample-event-independent; the *title* was the unstable input, so we stop relying on it.

- **Always-on identity marker** (`emitIdentityMarker` / `parseAuditIdentity` in `audit-canonical.ts`) embeds `(stream, kennelCode, ruleSlug)` in every filed issue body — independent of which sample events a run picks.
- **Final GitHub-search dedup gate** in `fileAuditFinding`: after the mirror tiers miss, list OPEN issues by `kennel:<code>` label and match by identity marker (with an exact-title fallback for issues filed before the marker existed). **Mirror-independent**, so a stale/delayed sync cron can't fork a dup, and free-form titles no longer escape dedup.
- New `listOpenIssuesByKennel` FilerAction in both cron (`audit-issue.ts`) and API (`file-finding/route.ts`) envelopes; new outcome `tier: "github-search"` + `comment-failed-github` reason plumbed through the route + promoter.
- 14 new tests (gate hit via marker, exact-title fallback, stream-scoping, comment-failure, marker round-trip + canonical-block fallback).

## Tasks 2–6 — admin/kennel UI bugs
- **#2282** — `recordDeepDive` "Mark complete" silently no-op'd: it re-checked fragile **top-20 queue membership** and returned `kennelGone` on benign churn. Now gates on kennel **existence** (matching `recordDeepDiveManual`; re-applies the #2261 lesson) + `revalidatePath`. Updated unit tests.
- **#2396** — added a "View public page ↗" link to admin Kennels **row actions** and the **edit modal** (slug plumbed through `serialized` + `AdminKennelData`).
- **#2308** — kennel pages 404'd on slugs with route-breaking chars. `scripts/fix-comma-slugs.ts` re-slugified **8** affected kennels in prod (`sl,ut-discovery` → `sl-ut-discovery`, etc.; 0 malformed slugs remain) + a normalize/redirect fallback in the route for legacy links.
- **#2385** — "Latest Run" took `MAX(runNumber)` including future placeholders. Now computed from **past events only** (t3h3 shows 463, not the 2027 #500 placeholder).
- **#2373** — schedule label double-rendered (`2nd Thursday at 6:30 PM / at 6:30 PM`) from a day-less `CADENCE=…` sentinel rule. `formatScheduleSlot` now suppresses day-less bare-time fragments.

## Task 7 — Triage
Closed #2425, #2322, #2296, #2324 as duplicates (kept the lower/older original, with explanatory comments); added `wontfix` + a one-line comment to #2380 and #2371 (source-side quirks, explicitly not bugs). #2318/#2321 were already closed.

## Verification
- `npx tsc --noEmit` clean; `npm run lint` 0 errors; full suite **9695 tests passing** (331 files).
- Public-page fixes verified live via curl + DB (t3h3-nz single schedule label; t3h3 Latest Run = 463; `/kennels/sl-ut-discovery` 200).

## Reviewer notes
- **#2324/#2323** aren't byte-identical (location-missing vs hares-missing) but share one root cause (Desert H3 adapter doesn't scrape per-event detail pages); consolidated #2324 into #2323 per the task, noted in the close comment.
- The #2308 **redirect fallback** couldn't be HTTP-verified locally — the worktree dev server streams `200` for `notFound()`/`redirect()`. It uses the standard Next `redirect()` pattern that resolves on Vercel; the load-bearing **data** fix is confirmed.
- `scripts/fix-comma-slugs.ts` was already **run against prod** this session (idempotent / re-runnable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)