### PR TITLE
fix(desert-hash): don't take a title/theme-led detail line as the venue

### DIFF
--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -184,6 +184,54 @@ describe("parseEventSection — DOM-based event parsing", () => {
   });
 });
 
+// ── #2311: teaser-banner conflation (current ah3.nl markup, no <p id>) ──
+
+describe("parseEventSection — teaser/run-block binding (#2311)", () => {
+  // A section that over-collects a teaser block (its own date + venue, NO
+  // "Run №") followed by the real numbered run, with NO <p id> (current markup).
+  const SECTION_HTML = `<div class="sec"><div>
+    <p><font size=5><b>We Have A Run Tomorrow &#8211; Just Another BirthDay Party</b></font></p>
+    <p>by <b>Dick In The Dyke</b><br/>
+    <b>Saturday 27 June, 2026</b> at <b>17:00</b> hrs<br/>
+    <b>Her Place</b><br/>24 Seranggracht, Amsterdam, 1019 PM</p>
+    <p><font size=5><b>Bubbles &#038; Beers</b></font></p>
+    <p>Run № <b>1486</b> by <b>Middle Spoon &#038; Off The Rails</b><br/>
+    <b>Sunday 28 June, 2026</b> at <b>15:00</b> hrs<br/>
+    <b>Rooseveltlaan 164, Amsterdam</b></p>
+  </div></div>`;
+
+  it("does NOT let the teaser block borrow the next run's number + hares", () => {
+    const $ = cheerio.load(SECTION_HTML);
+    const event = parseEventSection($("div.sec"), $, SOURCE_URL);
+    expect(event).not.toBeNull();
+    // Teaser owns the FIRST date/venue; it has no Run № of its own → undefined.
+    expect(event!.runNumber).toBeUndefined();
+    expect(event!.date).toBe("2026-06-27");
+    expect(event!.startTime).toBe("17:00");
+    expect(event!.location).toBe("Her Place");
+    expect(event!.hares).toBeUndefined(); // must NOT be "Middle Spoon..."
+    // Teaser banner prefix stripped from the title.
+    expect(event!.title).toBe("Just Another BirthDay Party");
+  });
+
+  it("binds title/location/start-time to the Run № block when the section starts with it", () => {
+    const RUN_HTML = `<div class="sec"><div>
+      <p><font size=5><b>Bubbles &#038; Beers</b></font></p>
+      <p>Run № <b>1486</b> by <b>Middle Spoon &#038; Off The Rails</b><br/>
+      <b>Sunday 28 June, 2026</b> at <b>15:00</b> hrs<br/>
+      <b>Rooseveltlaan 164, Amsterdam</b></p>
+    </div></div>`;
+    const $ = cheerio.load(RUN_HTML);
+    const event = parseEventSection($("div.sec"), $, SOURCE_URL);
+    expect(event!.runNumber).toBe(1486);
+    expect(event!.title).toBe("AH3 #1486 — Bubbles & Beers");
+    expect(event!.date).toBe("2026-06-28");
+    expect(event!.startTime).toBe("15:00");
+    expect(event!.location).toBe("Rooseveltlaan 164, Amsterdam");
+    expect(event!.hares).toBe("Middle Spoon & Off The Rails");
+  });
+});
+
 // ── extractEventsFromDOM ──
 
 describe("extractEventsFromDOM", () => {

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -56,6 +56,27 @@ const DATE_TIME_RE =
  *  (Bag Drop, BeerMeister, Hash Cash, On After) not event description. */
 const GOOD_TO_KNOW_RE = /___good_to_know/i;
 
+/** Imminent-run teaser banner prefix ("We Have A Run Tomorrow – …") that the
+ *  editors prepend to the next run's name. Stripped so the event keeps its real
+ *  title rather than the banner (#2311). */
+const TEASER_BANNER_RE = /^We Have A Run\b[^–—\-]*[–—-]\s*/i;
+
+/**
+ * The run-name heading line of a block: the first pre-date line that is neither
+ * the "Run №" line nor a "by <hares>" line. Used when the page omits the
+ * `<p id="NNNN">` title element (current ah3.nl markup), so the title comes
+ * from the same block as the run number rather than a sibling banner (#2311).
+ */
+function pickHeadingTitle(preDateLines: string[]): string | undefined {
+  for (const l of preDateLines) {
+    if (/^Run\s*[№#]/i.test(l)) continue;
+    if (/^by\s+/i.test(l)) continue;
+    if (l.length < 3) continue;
+    return l;
+  }
+  return undefined;
+}
+
 // ── Exported helpers (for unit testing) ──
 
 /**
@@ -88,8 +109,20 @@ export function parseEventSection(
   const sectionHtml = $section.toArray().map((n) => $.html(n)).join("");
   const text = stripHtmlTags(sectionHtml, "\n").replaceAll("\u00a0", " ");
 
-  // ── Run number + hares from "Run №" line ──
-  const runMatch = RUN_NUMBER_RE.exec(text);
+  // Split into lines once; the extractors below are line-anchored. The live
+  // DOM nests each run in wrapping <div>s, so the <hr>-sibling walk
+  // over-collects into the following runs. The first DATE_TIME line marks the
+  // end of THIS block's header — everything the parser binds to this event
+  // (run number, hares, title heading) lives at or above it (#2311).
+  const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+  const dateLineIdx = lines.findIndex((l) => DATE_TIME_RE.test(l));
+
+  // ── Run number + hares from the "Run №" line that PRECEDES this block's
+  // date. Scoping to the pre-date lines stops a teaser block (its own date +
+  // venue but NO "Run №") from borrowing the next block's run number + hares
+  // out of the over-collected section text (#2311).
+  const preDateLines = dateLineIdx >= 0 ? lines.slice(0, dateLineIdx) : lines;
+  const runMatch = RUN_NUMBER_RE.exec(preDateLines.join("\n"));
   let runNumber: number | undefined;
   let hares: string | undefined;
   if (runMatch) {
@@ -131,11 +164,9 @@ export function parseEventSection(
   const startTime = `${hours.padStart(2, "0")}:${minutes}`;
 
   // ── Location: first bold text after the date line ──
-  const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
   let location: string | undefined;
   let locationStreet: string | undefined;
 
-  const dateLineIdx = lines.findIndex((l) => DATE_TIME_RE.test(l));
   if (dateLineIdx >= 0) {
     const venueLine = lines[dateLineIdx + 1];
     if (venueLine && !/Map\s*$/.test(venueLine) && !/Let us know/.test(venueLine)) {
@@ -165,7 +196,13 @@ export function parseEventSection(
   const goodToKnowIdx = lines.findIndex((l) => GOOD_TO_KNOW_RE.test(l));
   const descStartIdx = dateLineIdx >= 0 ? dateLineIdx + 1 : -1;
   if (descStartIdx > 0) {
-    const descEndIdx = goodToKnowIdx > descStartIdx ? goodToKnowIdx : lines.length;
+    // Bound the description at the next block boundary too — the next run's
+    // "Run №" or date line — so an over-collected section doesn't fold the
+    // following events' prose into this one's description (#2311).
+    const nextRunIdx = lines.findIndex((l, i) => i > descStartIdx && RUN_NUMBER_RE.test(l));
+    const nextDateIdx = lines.findIndex((l, i) => i > descStartIdx && DATE_TIME_RE.test(l));
+    const bounds = [goodToKnowIdx, nextRunIdx, nextDateIdx].filter((x) => x > descStartIdx);
+    const descEndIdx = bounds.length > 0 ? Math.min(...bounds) : lines.length;
     const descLines = lines.slice(descStartIdx, descEndIdx).filter((l) => {
       // Skip venue name (already captured as location)
       if (location && l === location) return false;
@@ -192,10 +229,17 @@ export function parseEventSection(
   }
 
   // ── Build event title ──
-  const eventTitle = title
+  // Prefer the <p id> title (legacy markup); fall back to the block's heading
+  // line (current markup omits <p id>). Strip the imminent-run teaser banner so
+  // the title is the run name, not "We Have A Run Tomorrow – …" (#2311).
+  const rawTitle = title ?? pickHeadingTitle(preDateLines);
+  const cleanTitle = rawTitle
+    ? rawTitle.replace(TEASER_BANNER_RE, "").trim() || rawTitle
+    : undefined;
+  const eventTitle = cleanTitle
     ? runNumber
-      ? `AH3 #${runNumber} — ${title}`
-      : title
+      ? `AH3 #${runNumber} — ${cleanTitle}`
+      : cleanTitle
     : runNumber
       ? `AH3 #${runNumber}`
       : undefined;

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -198,10 +198,16 @@ export function parseEventSection(
   if (descStartIdx > 0) {
     // Bound the description at the next block boundary too — the next run's
     // "Run №" or date line — so an over-collected section doesn't fold the
-    // following events' prose into this one's description (#2311).
+    // following events' prose into this one's description (#2311). The next run's
+    // HEADING sits one line ABOVE its "Run №" line, so also stop at `nextRunIdx
+    // - 1` to keep that heading ("Bubbles & Beers") out of this description
+    // (CodeRabbit review).
     const nextRunIdx = lines.findIndex((l, i) => i > descStartIdx && RUN_NUMBER_RE.test(l));
+    const nextRunHeadingIdx = nextRunIdx > descStartIdx ? nextRunIdx - 1 : -1;
     const nextDateIdx = lines.findIndex((l, i) => i > descStartIdx && DATE_TIME_RE.test(l));
-    const bounds = [goodToKnowIdx, nextRunIdx, nextDateIdx].filter((x) => x > descStartIdx);
+    const bounds = [goodToKnowIdx, nextRunHeadingIdx, nextRunIdx, nextDateIdx].filter(
+      (x) => x > descStartIdx,
+    );
     const descEndIdx = bounds.length > 0 ? Math.min(...bounds) : lines.length;
     const descLines = lines.slice(descStartIdx, descEndIdx).filter((l) => {
       // Skip venue name (already captured as location)

--- a/src/adapters/html-scraper/bombay-hash.test.ts
+++ b/src/adapters/html-scraper/bombay-hash.test.ts
@@ -15,20 +15,26 @@ const FIXTURE = `
     <div class="wp-block-spectra-container">
       <h3><span>🍻🏃‍♂️🏃‍♀️ MUMBAI HASH HOUSE HARRIERS 🏃‍♀️🏃‍♂️🍻🐾 RUN #631 🐾</span></h3>
     </div>
-    <p>“No One Gets Left Behind… Unless You’re the Hare!” 😂🐇📅 Date: Sunday, 28th June 2026🕘 Time: 9:30 AM Sharp (Hash Time… 😜)📍 Venue: Shivaji Park Gymkhana</p>
+    <p class="has-text-color">“No One Gets Left Behind… Unless You’re the Hare!” 😂🐇📅 Date: Sunday, 28th June 2026🕘 Time: 9:30 AM Sharp (Hash Time… 😜)📍 Venue: Shivaji Park Gymkhana</p>
     <p>🐇 HARES: ???🤔 Looking for brave volunteers… 🤪🍺💰 REGO: ✅ INR 250 till Friday, 26th June❌ Procrastinators Pay: INR 400 after that! 💸😂</p>
   </div>
   <div class="spectra-is-root-container alignfull">
     <div class="wp-block-spectra-container">
       <h3><span>🏃‍♂️🔥 BOMBAY HASH HOUSE HARRIERS 🔥🏃‍♀️🎉🍻 RUN #630 🍻🎉</span></h3>
     </div>
-    <p>⚠️ THIS IS NOT JUST ANOTHER RUN ⚠️📅 DATE: Sunday, 31st May 2026🕘 TIME: 9:30 AM📍 VENUE:🍻 SOCIAL – NESCO Gate 3, Goregaon East🕤 details🥃 REGO: ₹2100 🥃Completed 5 Trails since January 2026? Your rego is ONLY ₹1600</p>
+    <p class="has-text-color">⚠️ THIS IS NOT JUST ANOTHER RUN ⚠️📅 DATE: Sunday, 31st May 2026🕘 TIME: 9:30 AM📍 VENUE:🍻 SOCIAL – NESCO Gate 3, Goregaon East🕤 details🥃 REGO: ₹2100 🥃Completed 5 Trails since January 2026? Your rego is ONLY ₹1600</p>
+  </div>
+  <div class="spectra-is-root-container alignfull">
+    <div class="wp-block-spectra-container">
+      <h3><span>🐾🍺 BOMBAY HASH HOUSE HARRIERS 🍺🐾 BH3 RUN #629</span></h3>
+    </div>
+    <p class="has-text-color">🔥 THE MADHNESS MAYHEM RUN 🔥✅ Attendance is STRONGLY ENCOURAGED❌ Excuses are COMPLETE NONSENSE 😈 You will still say “mast tha!” after 😜🔥 Rao Bungalow Madh Marve Road Opp. Almeida Picnic Cottage 📅 Sunday, 26th April 2026⏰ 9:30 AM sharp</p>
   </div>
   <div class="spectra-is-root-container alignfull">
     <div class="wp-block-spectra-container">
       <h2><span>🚨 BOMBAY HASH RUN #628 🚨</span></h2>
     </div>
-    <p>Oi you filthy, beer-loving legends 🍻 this time we invade Malad ka concrete jungle 🌆</p>
+    <p class="has-text-color">Oi you filthy, beer-loving legends 🍻 this time we invade Malad ka concrete jungle 🌆 expect running like confused chickens and getting hopelessly lost</p>
     <p>📅 Sunday, 29 March 2026⏰ Assembly: 09:30 AM sharp-ish (Hash time 😏)📍 Pop Tate’s, Malad West💰 Damage: ₹250 per drunk runner 🍻📲 Pay via GPay/Paytm: 9320031565 (Shailesh Shah)⚠️ Register BEFORE Friday (27th)</p>
   </div>
   <div class="spectra-is-root-container alignfull">
@@ -45,15 +51,16 @@ describe("parseBombayHashPage", () => {
   const byRun = new Map(result.events.map((e) => [e.runNumber, e]));
 
   it("parses every run block keyed on heading text, not tag level", () => {
-    expect(result.blockCount).toBe(4); // 3 dated runs + 1 drift heading
+    expect(result.blockCount).toBe(5); // 4 dated runs + 1 drift heading
     expect(result.events.map((e) => e.runNumber).sort((a, b) => Number(a) - Number(b))).toEqual([
-      628, 630, 631,
+      628, 629, 630, 631,
     ]);
   });
 
   it("extracts year-bearing dates as UTC-noon YYYY-MM-DD (no inference)", () => {
     expect(byRun.get(631)?.date).toBe("2026-06-28");
     expect(byRun.get(630)?.date).toBe("2026-05-31");
+    expect(byRun.get(629)?.date).toBe("2026-04-26");
     expect(byRun.get(628)?.date).toBe("2026-03-29"); // weekday-prefixed, "29 March 2026"
   });
 
@@ -62,17 +69,30 @@ describe("parseBombayHashPage", () => {
     expect(byRun.get(628)?.startTime).toBe("09:30"); // ⏰ Assembly:
   });
 
-  it("tags every event with the kennel code and leaves title undefined", () => {
+  it("tags every event with the kennel code", () => {
     for (const e of result.events) {
       expect(e.kennelTags).toEqual(["bombay-h3"]);
-      expect(e.title).toBeUndefined(); // merge synthesizes "Bombay H3 Trail #N"
     }
+  });
+
+  it("extracts the run headline as the title, dropping emoji/CTA/prose (#2421/#2425)", () => {
+    expect(byRun.get(629)?.title).toBe("THE MADHNESS MAYHEM RUN");
+    expect(byRun.get(630)?.title).toBe("THIS IS NOT JUST ANOTHER RUN"); // ⚠ wrappers stripped
+    expect(byRun.get(631)?.title).toBe("No One Gets Left Behind… Unless You’re the Hare!");
+    // #628 leads with prose (no clean headline) → undefined so merge synthesizes
+    // "Bombay H3 Trail #628".
+    expect(byRun.get(628)?.title).toBeUndefined();
   });
 
   it("extracts the venue and strips a 🍻-prefixed/labeled value", () => {
     expect(byRun.get(631)?.location).toBe("Shivaji Park Gymkhana");
     expect(byRun.get(628)?.location).toBe("Pop Tate’s, Malad West");
     expect(byRun.get(630)?.location).toContain("NESCO Gate 3"); // leading 🍻 stripped
+  });
+
+  it("recovers the venue from text before 📅 when the 📍 marker is absent (#2422)", () => {
+    // Run #629 has no 📍 — the venue sits before the date marker.
+    expect(byRun.get(629)?.location).toBe("Rao Bungalow Madh Marve Road Opp. Almeida Picnic Cottage");
   });
 
   it("clears placeholder hares (label present) but preserves absent ones", () => {

--- a/src/adapters/html-scraper/bombay-hash.test.ts
+++ b/src/adapters/html-scraper/bombay-hash.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseBombayHashPage } from "./bombay-hash";
+import { parseBombayHashPage, parseTitle } from "./bombay-hash";
 
 // Faithful slice of the bombayhash.org SSR home page. Each run is a Spectra
 // "root container" whose heading sits one level deeper than the body paragraphs,
@@ -118,5 +118,35 @@ describe("parseBombayHashPage", () => {
     const drift = result.parseErrors.find((p) => /#999/.test(p.error));
     expect(drift).toBeDefined();
     expect(drift?.field).toBe("date");
+  });
+});
+
+describe("parseTitle", () => {
+  it("returns the clean headline before a CTA emoji", () => {
+    expect(parseTitle("🔥 THE MADHNESS MAYHEM RUN 🔥✅ Attendance is STRONGLY ENCOURAGED")).toBe(
+      "THE MADHNESS MAYHEM RUN",
+    );
+  });
+
+  it("returns undefined when the terminator is at index 0 (paragraph is pure CTA)", () => {
+    // Prior to the fix (term.index > 0), this returned the full string instead
+    // of slicing to 0 → an empty string that correctly falls through to undefined.
+    expect(parseTitle("✅ Attendance / ❌ Excuses")).toBeUndefined();
+    expect(parseTitle("📅 Date: Sunday, 28th June 2026")).toBeUndefined();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(parseTitle(undefined)).toBeUndefined();
+  });
+
+  it("strips ⚠ emoji wrappers without treating ⚠ as a terminator", () => {
+    expect(parseTitle("⚠️ THIS IS NOT JUST ANOTHER RUN ⚠️📅 DATE: Sunday")).toBe(
+      "THIS IS NOT JUST ANOTHER RUN",
+    );
+  });
+
+  it("returns undefined for a too-short or placeholder result", () => {
+    expect(parseTitle("AB")).toBeUndefined();
+    expect(parseTitle("TBA")).toBeUndefined();
   });
 });

--- a/src/adapters/html-scraper/bombay-hash.ts
+++ b/src/adapters/html-scraper/bombay-hash.ts
@@ -196,7 +196,7 @@ export function parseTitle(headlineText: string | undefined): string | undefined
   if (!headlineText) return undefined;
   const normalized = normalize(headlineText);
   const term = TITLE_TERMINATOR_RE.exec(normalized);
-  const head = term && term.index > 0 ? normalized.slice(0, term.index) : normalized;
+  const head = term ? normalized.slice(0, term.index) : normalized;
   const title = trimEdgeChars(normalize(head.replace(EMOJI_RE, " ")), TITLE_EDGE_CHARS);
   if (title.length < 3 || title.length > 70) return undefined;
   if (isPlaceholder(title)) return undefined;

--- a/src/adapters/html-scraper/bombay-hash.ts
+++ b/src/adapters/html-scraper/bombay-hash.ts
@@ -196,7 +196,10 @@ export function parseTitle(headlineText: string | undefined): string | undefined
   if (!headlineText) return undefined;
   const normalized = normalize(headlineText);
   const term = TITLE_TERMINATOR_RE.exec(normalized);
-  const head = term && term.index > 0 ? normalized.slice(0, term.index) : normalized;
+  // Slice at the terminator wherever it lands: a block that LEADS with a CTA /
+  // field marker (terminator at index 0) has no headline, so the slice yields
+  // "" → the length guard below returns undefined → synthesized default title.
+  const head = term ? normalized.slice(0, term.index) : normalized;
   const title = trimEdgeChars(normalize(head.replace(EMOJI_RE, " ")), TITLE_EDGE_CHARS);
   if (title.length < 3 || title.length > 70) return undefined;
   if (isPlaceholder(title)) return undefined;

--- a/src/adapters/html-scraper/bombay-hash.ts
+++ b/src/adapters/html-scraper/bombay-hash.ts
@@ -9,6 +9,8 @@ import {
   formatAmPmTime,
   chronoParseDate,
   isPlaceholder,
+  EMOJI_RE,
+  trimEdgeChars,
 } from "../utils";
 import { scrubHarePii } from "../hare-pii";
 
@@ -53,9 +55,19 @@ const LEADING_DECORATION_RE = /^[^\p{L}\p{N}]+/u;
 // isPlaceholder() helper; empty values fall through to the length guard below.
 const HARES_LABEL_RE = /\bhares?\s*:/i;
 
+// The run's headline lives at the START of its body paragraph
+// (`p.has-text-color`), e.g. "🔥 THE MADHNESS MAYHEM RUN 🔥" before the
+// "✅ Attendance / ❌ Excuses" CTA block. These markers terminate the headline
+// (✅/❌/😱/💀 are CTA; 📅/🕘/📍/🐇/⏰/🤔 are field markers). ⚠ is deliberately
+// EXCLUDED — it WRAPS some headlines ("⚠️ THIS IS NOT JUST ANOTHER RUN ⚠️").
+const TITLE_TERMINATOR_RE = /[✅❌😱💀📅🕘📍🐇⏰🤔]|\bAttendance\b|\bExcuses\b/u;
+const TITLE_EDGE_CHARS = " \"'“”‘’-–—:.";
+
 interface RunBlock {
   runNumber: number;
   text: string;
+  /** First body paragraph (`p.has-text-color`) — the run's headline source. */
+  headlineText?: string;
   rawHeading: string;
   row: number;
 }
@@ -87,6 +99,7 @@ function collectRunBlocks($: CheerioAPI): RunBlock[] {
     // Climb to the block container that holds this run's dated body.
     let node = $(el).parent();
     let blockText: string | null = null;
+    let headlineText: string | undefined;
     for (let depth = 0; depth < 6 && node.length > 0; depth++) {
       const tag = (node[0] as Element).tagName?.toLowerCase();
       const cls = node.attr("class") ?? "";
@@ -97,6 +110,8 @@ function collectRunBlocks($: CheerioAPI): RunBlock[] {
       const nodeText = node.text(); // recursive subtree concat — compute once
       if (DATE_RE.test(nodeText)) {
         blockText = nodeText;
+        // The run's headline is the first colored body paragraph in this block.
+        headlineText = node.find("p.has-text-color").first().text() || undefined;
         break;
       }
       node = node.parent();
@@ -105,7 +120,7 @@ function collectRunBlocks($: CheerioAPI): RunBlock[] {
     seen.add(runNumber);
     // No dated ancestor → record the run with the heading text only; date
     // parsing below fails loud (per-run drift), it is NOT silently dropped.
-    blocks.push({ runNumber, text: normalize(blockText ?? heading), rawHeading: heading, row });
+    blocks.push({ runNumber, text: normalize(blockText ?? heading), headlineText, rawHeading: heading, row });
   });
 
   return blocks;
@@ -128,7 +143,7 @@ function parseTime(text: string): string | undefined {
   return formatAmPmTime(hour, minute, m[3]);
 }
 
-function parseVenue(text: string): string | undefined {
+function parseVenueFromPin(text: string): string | undefined {
   const pin = text.indexOf("📍");
   if (pin < 0) return undefined;
   // Drop the "Venue:" label, then strip leading decoration (emoji/dashes) so a
@@ -142,6 +157,50 @@ function parseVenue(text: string): string | undefined {
   // it terminates before the 💰/📲 rego markers, but belt-and-suspenders).
   const cleaned = scrubHarePii(rest);
   return cleaned && cleaned.length >= 3 ? cleaned : undefined;
+}
+
+/**
+ * Fallback venue extraction for runs that omit the 📍 marker (run #629): the
+ * venue sits as plain text immediately before the 📅 Date marker, after the
+ * prose's trailing emoji ("…mast tha!" after 😜🔥 Rao Bungalow Madh Marve Road
+ * … 📅 Sunday …"). Take the run of text between the last emoji before 📅 and 📅.
+ */
+function parseVenueBeforeDate(text: string): string | undefined {
+  const dateIdx = text.indexOf("📅");
+  if (dateIdx <= 0) return undefined;
+  const before = text.slice(0, dateIdx);
+  let lastEmojiEnd = 0;
+  for (const m of before.matchAll(EMOJI_RE)) {
+    lastEmojiEnd = (m.index ?? 0) + m[0].length;
+  }
+  let venue = before.slice(lastEmojiEnd).replace(VENUE_LABEL_RE, "");
+  venue = venue.replace(LEADING_DECORATION_RE, "").trim();
+  const cleaned = scrubHarePii(venue);
+  // Guard against grabbing prose: require a plausible venue length.
+  if (!cleaned || cleaned.length < 5 || cleaned.length > 80) return undefined;
+  return cleaned;
+}
+
+function parseVenue(text: string): string | undefined {
+  return parseVenueFromPin(text) ?? parseVenueBeforeDate(text);
+}
+
+/**
+ * Extract a clean run headline from the first body paragraph (#2421/#2425).
+ * The headline is the leading phrase before the "✅ Attendance / ❌ Excuses"
+ * CTA or any field marker; emoji + wrapping quotes are stripped. Returns
+ * undefined for prose-led blocks (no clean headline) or placeholders so merge
+ * synthesizes the "Bombay H3 Trail #N" default rather than storing garbage.
+ */
+export function parseTitle(headlineText: string | undefined): string | undefined {
+  if (!headlineText) return undefined;
+  const normalized = normalize(headlineText);
+  const term = TITLE_TERMINATOR_RE.exec(normalized);
+  const head = term && term.index > 0 ? normalized.slice(0, term.index) : normalized;
+  const title = trimEdgeChars(normalize(head.replace(EMOJI_RE, " ")), TITLE_EDGE_CHARS);
+  if (title.length < 3 || title.length > 70) return undefined;
+  if (isPlaceholder(title)) return undefined;
+  return title;
 }
 
 // Tri-state return: `undefined` = HARES field ABSENT (preserve any existing
@@ -201,7 +260,9 @@ export function parseBombayHashPage(html: string): {
       date,
       kennelTags: [KENNEL_TAG],
       runNumber: block.runNumber,
-      // title left undefined → merge synthesizes "Bombay H3 Trail #N".
+      // Real headline when one is cleanly extractable; else undefined → merge
+      // synthesizes "Bombay H3 Trail #N" (#2421/#2425).
+      title: parseTitle(block.headlineText),
       startTime: parseTime(block.text),
       location: parseVenue(block.text),
       hares: parseHares(block.text),

--- a/src/adapters/html-scraper/desert-hash.test.ts
+++ b/src/adapters/html-scraper/desert-hash.test.ts
@@ -386,16 +386,41 @@ describe("DesertHashAdapter.fetch", () => {
     // errors[] empty → status SUCCESS, reconcile of the healthy listing runs.
     expect(result.errors).toHaveLength(0);
     expect(call).toBeGreaterThan(2); // listing + at least one detail attempt
-    // …but the all-detail-failure is recorded in errorDetails for the audit pipeline.
-    expect(result.errorDetails?.parse?.some((p) => /enrichment failed for all/.test(p.error))).toBe(true);
+    // …but the all-detail-failure is recorded in errorDetails for the audit pipeline,
+    // both as the systemic summary AND the structured per-fetch failure records.
+    expect(result.errorDetails?.parse?.some((p) => /produced no fields for all/.test(p.error))).toBe(true);
+    expect(result.errorDetails?.fetch?.length).toBeGreaterThan(0);
     expect(result.diagnosticContext?.detailFetchFailures).toBeGreaterThan(0);
+  });
+
+  it("surfaces systemic loss when detail pages 200-OK but parse to nothing (markup drift)", async () => {
+    // Every detail fetch returns a 200 page with NO detail markup (parses to {}):
+    // detailFetchFailures stays 0, but detailsEnriched === 0 → still flagged.
+    mockedSafeFetch.mockImplementation((url: string) => {
+      const u = String(url);
+      const html = u.includes("page_id=5152")
+        ? HARELINE_HTML
+        : u.includes("mec-events=")
+          ? "<html><body><div>no detail markup here</div></body></html>"
+          : HOME_HTML;
+      return Promise.resolve({
+        ok: true, status: 200, statusText: "OK",
+        text: () => Promise.resolve(html), headers: new Headers(),
+      } as Response);
+    });
+    const result = await new DesertHashAdapter().fetch(makeSource(), { days: 40000 });
+    expect(result.events.length).toBeGreaterThan(0);
+    expect(result.errors).toHaveLength(0); // reconcile not suppressed
+    expect(result.diagnosticContext?.detailFetchFailures).toBe(0); // no HTTP failures
+    expect(result.diagnosticContext?.detailsEnriched).toBe(0);
+    expect(result.errorDetails?.parse?.some((p) => /produced no fields for all/.test(p.error))).toBe(true);
   });
 
   it("does not flag systemic failure when detail enrichment succeeds", async () => {
     mockSurfacesWithDetails(HOME_HTML, HARELINE_HTML, { "dh3-run-2457": DETAIL_VENUE });
     const result = await new DesertHashAdapter().fetch(makeSource(), { days: 40000 });
     expect(result.errors).toHaveLength(0);
-    expect(result.errorDetails?.parse?.some((p) => /enrichment failed for all/.test(p.error)))
+    expect(result.errorDetails?.parse?.some((p) => /produced no fields for all/.test(p.error)))
       .toBeFalsy();
   });
 

--- a/src/adapters/html-scraper/desert-hash.test.ts
+++ b/src/adapters/html-scraper/desert-hash.test.ts
@@ -9,6 +9,7 @@ import {
   parseTimeRange,
   parseMonthDay,
   isoDate,
+  parseDetailPage,
 } from "./desert-hash";
 import * as cheerio from "cheerio";
 
@@ -81,6 +82,65 @@ function agendaDay(day: string, agendaDate: string, start: string, end: string, 
 
 function monthDivider(yyyymm: string, label: string): string {
   return `<div class="mec-month-divider" data-toggle-divider="mec-toggle-${yyyymm}-mec1"><h5>${label}</h5><i class="mec-sl-arrow-down"></i></div>`;
+}
+
+/** One MEC run detail page — faithful to the live organizer + description + gmap markup. */
+function detailPage(opts: { hares?: string[]; bodyHtml: string; lat?: string; lng?: string }): string {
+  const organizer = opts.hares?.length
+    ? `<div class="mec-event-meta"><div class="mec-single-event-organizer">
+         <div class="mec-events-single-section-title">Hare(s)</div>
+         ${opts.hares.map((h) => `<dd class="mec-organizer"><i class="mec-sl-people"></i><span class="mec-meta-label">${h}</span></dd>`).join("")}
+         <dd class="mec-organizer-tel"><i class="mec-sl-phone"></i><span class="mec-meta-label">Phone</span><a href="tel:+971 56 770 2627">+971 56 770 2627</a></dd>
+       </div></div>`
+    : "";
+  const gmap = opts.lat && opts.lng
+    ? `<div class="mec-events-meta-group mec-events-meta-group-gmap"><script>
+         p1 = jQuery("#m").mecGoogleMaps({ latitude: "${opts.lat}", longitude: "${opts.lng}", autoinit: true, zoom: 15 });
+       </script></div>`
+    : "";
+  return `<html><body>${organizer}${gmap}
+    <div class="mec-single-event-description mec-events-content ">${opts.bodyHtml}</div>
+  </body></html>`;
+}
+
+// 2456-style: structured location (coords present) → venue-first body.
+const DETAIL_VENUE = detailPage({
+  hares: ["Thighs Wide Open"],
+  lat: "25.054545",
+  lng: "55.207260",
+  bodyHtml: `<p>Goose Island Tap House, JVC</p>
+    <p><a href="https://maps.app.goo.gl/x1MbEGtWCutGho2B7">Google Map Link</a></p>`,
+});
+
+// 2455-style: no coords → body is free-form notes; phone present but must be skipped.
+const DETAIL_NOTES = detailPage({
+  hares: ["Dyke"],
+  bodyHtml: `<p>Note: This is a Sunday run, there will be no hash on the Monday immediately following.</p>
+    <p><a href="https://maps.app.goo.gl/RK2tAK8tNURUcS3a8?g_st=iwb">Google Map Link</a></p>
+    <p>Park in the car park and walk a few mins down the hill to the circle site.</p>
+    <p><a href="https://www.deserthash.org/wp-content/uploads/2025/09/alqudracycle.jpeg"><img src="x" alt="" /></a></p>`,
+});
+
+/** Route base→home, page_id=5152→hareline, and any `mec-events=<slug>`→detail HTML. */
+function mockSurfacesWithDetails(homeHtml: string, hareHtml: string, details: Record<string, string>) {
+  mockedSafeFetch.mockImplementation((url: string) => {
+    const u = String(url);
+    let html = homeHtml;
+    if (u.includes("page_id=5152")) {
+      html = hareHtml;
+    } else {
+      for (const [slug, h] of Object.entries(details)) {
+        if (u.includes(slug)) { html = h; break; }
+      }
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: () => Promise.resolve(html),
+      headers: new Headers({ "content-type": "text/html" }),
+    } as Response);
+  });
 }
 
 // Home: the upcoming DH3 run + a Moonshine card + an Interhash one-off (both must be filtered out).
@@ -232,6 +292,37 @@ describe("parseHareLine", () => {
   });
 });
 
+// ── Detail-page parser ─────────────────────────────────────────────────────────
+
+describe("parseDetailPage", () => {
+  it("extracts hares, venue, maps link, and coords when MEC carries a location", () => {
+    const d = parseDetailPage(DETAIL_VENUE);
+    expect(d.hares).toBe("Thighs Wide Open");
+    expect(d.location).toBe("Goose Island Tap House, JVC");
+    expect(d.locationUrl).toContain("maps.app.goo.gl");
+    expect(d.latitude).toBeCloseTo(25.054545);
+    expect(d.longitude).toBeCloseTo(55.20726);
+    // Venue-only body → no leftover notes.
+    expect(d.description).toBeUndefined();
+  });
+
+  it("treats a coord-less body as free-form notes (no venue) and never reads the phone", () => {
+    const d = parseDetailPage(DETAIL_NOTES);
+    expect(d.hares).toBe("Dyke");
+    expect(d.location).toBeUndefined(); // no coords → first paragraph is a note, not a venue
+    expect(d.description).toContain("Park in the car park");
+    expect(d.description).toContain("Sunday run");
+    expect(d.description).not.toContain("+971"); // contact phone is PII, never scraped
+    expect(d.description).not.toMatch(/Google Map Link/); // maps anchor stripped from notes
+    expect(d.locationUrl).toContain("maps.app.goo.gl");
+    expect(d.latitude).toBeUndefined();
+  });
+
+  it("returns {} for a listing page with no detail markup", () => {
+    expect(parseDetailPage(HOME_HTML)).toEqual({});
+  });
+});
+
 // ── Adapter integration (fetch) ────────────────────────────────────────────────
 
 describe("DesertHashAdapter.fetch", () => {
@@ -245,6 +336,67 @@ describe("DesertHashAdapter.fetch", () => {
     expect(runs).toEqual([2440, 2452, 2456, 2457]); // upcoming + 3 deduped/filtered recent
     expect(result.errors).toHaveLength(0);
     expect(result.events.every((e) => e.kennelTags[0] === "dh3-ae")).toBe(true);
+  });
+
+  it("enriches the upcoming run with detail-page hares / venue / maps / coords", async () => {
+    mockSurfacesWithDetails(HOME_HTML, HARELINE_HTML, { "dh3-run-2457": DETAIL_VENUE });
+    const result = await new DesertHashAdapter().fetch(makeSource(), { days: 40000 });
+    const e = result.events.find((ev) => ev.runNumber === 2457);
+    expect(e?.hares).toBe("Thighs Wide Open");
+    expect(e?.location).toBe("Goose Island Tap House, JVC");
+    expect(e?.locationUrl).toContain("maps.app.goo.gl");
+    expect(e?.latitude).toBeCloseTo(25.054545);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("captures coord-less notes as description and never leaks the phone", async () => {
+    mockSurfacesWithDetails(HOME_HTML, HARELINE_HTML, { "dh3-run-2457": DETAIL_NOTES });
+    const result = await new DesertHashAdapter().fetch(makeSource(), { days: 40000 });
+    const e = result.events.find((ev) => ev.runNumber === 2457);
+    expect(e?.hares).toBe("Dyke");
+    expect(e?.description).toContain("Park in the car park");
+    expect(e?.location).toBeUndefined();
+    expect(e?.description).not.toContain("+971");
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("survives a detail-page fetch failure without failing the scrape, but surfaces systemic loss", async () => {
+    // Detail fetches 503 while listing surfaces succeed → events still returned,
+    // just un-enriched; reconcile must NOT be suppressed (errors[] stays empty),
+    // but the total enrichment loss is surfaced via errorDetails (Codex review).
+    let call = 0;
+    mockedSafeFetch.mockImplementation((url: string) => {
+      const u = String(url);
+      const isListing = u === "https://www.deserthash.org/" || u.includes("page_id=5152");
+      call++;
+      if (isListing) {
+        const html = u.includes("page_id=5152") ? HARELINE_HTML : HOME_HTML;
+        return Promise.resolve({
+          ok: true, status: 200, statusText: "OK",
+          text: () => Promise.resolve(html), headers: new Headers(),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false, status: 503, statusText: "Service Unavailable",
+        text: () => Promise.resolve(""), headers: new Headers(),
+      } as Response);
+    });
+    const result = await new DesertHashAdapter().fetch(makeSource(), { days: 40000 });
+    expect(result.events.length).toBeGreaterThan(0);
+    // errors[] empty → status SUCCESS, reconcile of the healthy listing runs.
+    expect(result.errors).toHaveLength(0);
+    expect(call).toBeGreaterThan(2); // listing + at least one detail attempt
+    // …but the all-detail-failure is recorded in errorDetails for the audit pipeline.
+    expect(result.errorDetails?.parse?.some((p) => /enrichment failed for all/.test(p.error))).toBe(true);
+    expect(result.diagnosticContext?.detailFetchFailures).toBeGreaterThan(0);
+  });
+
+  it("does not flag systemic failure when detail enrichment succeeds", async () => {
+    mockSurfacesWithDetails(HOME_HTML, HARELINE_HTML, { "dh3-run-2457": DETAIL_VENUE });
+    const result = await new DesertHashAdapter().fetch(makeSource(), { days: 40000 });
+    expect(result.errors).toHaveLength(0);
+    expect(result.errorDetails?.parse?.some((p) => /enrichment failed for all/.test(p.error)))
+      .toBeFalsy();
   });
 
   it("fail-loud guard: 0 DH3 runs parsed → errors[]", async () => {

--- a/src/adapters/html-scraper/desert-hash.test.ts
+++ b/src/adapters/html-scraper/desert-hash.test.ts
@@ -132,6 +132,15 @@ const DETAIL_TITLE_LED = detailPage({
     <p><a href="https://maps.app.goo.gl/n3E9JHNFbHn29JBP8">Google Maps Link</a></p>`,
 });
 
+// A verbose but explicitly-labelled venue ("Location: …") must be captured even
+// though it exceeds the bare-line length guard.
+const DETAIL_LABELLED = detailPage({
+  hares: ["Just Balls"],
+  bodyHtml: `<p>Note: This is a Sunday run, there will be no hash on the Monday.</p>
+    <p>Location: Meet in Car Park P5 at the back of the Trade Centre building, Dubai</p>
+    <p><a href="https://maps.app.goo.gl/abc123">Google Maps Link</a></p>`,
+});
+
 /** Route base→home, page_id=5152→hareline, and any `mec-events=<slug>`→detail HTML. */
 function mockSurfacesWithDetails(homeHtml: string, hareHtml: string, details: Record<string, string>) {
   mockedSafeFetch.mockImplementation((url: string) => {
@@ -326,6 +335,12 @@ describe("parseDetailPage", () => {
     expect(d.locationUrl).toContain("maps.app.goo.gl"); // map pin still captured
     expect(d.description).toContain("Desert Shenanigans");
     expect(d.description).toContain("Truck Stop on Emirates Rd");
+  });
+
+  it("captures an explicit 'Location:'-labelled venue even when verbose, skipping the Note line", () => {
+    const d = parseDetailPage(DETAIL_LABELLED);
+    expect(d.location).toBe("Meet in Car Park P5 at the back of the Trade Centre building, Dubai");
+    expect(d.hares).toBe("Just Balls");
   });
 
   it("treats a coord-less body as free-form notes (no venue) and never reads the phone", () => {

--- a/src/adapters/html-scraper/desert-hash.test.ts
+++ b/src/adapters/html-scraper/desert-hash.test.ts
@@ -121,6 +121,17 @@ const DETAIL_NOTES = detailPage({
     <p><a href="https://www.deserthash.org/wp-content/uploads/2025/09/alqudracycle.jpeg"><img src="x" alt="" /></a></p>`,
 });
 
+// 2452-style: coords present BUT the body leads with a decorative title/theme
+// line (not a venue) — the lead line must NOT be taken as the location.
+const DETAIL_TITLE_LED = detailPage({
+  hares: ["Slow Crack Whore"],
+  lat: "25.106101",
+  lng: "55.300000",
+  bodyHtml: `<p>DH3 Run #2452 – Desert Shenanigans 🏜️🍻</p>
+    <p>This Sunday from the Truck Stop on Emirates Rd into the half desert.</p>
+    <p><a href="https://maps.app.goo.gl/n3E9JHNFbHn29JBP8">Google Maps Link</a></p>`,
+});
+
 /** Route base→home, page_id=5152→hareline, and any `mec-events=<slug>`→detail HTML. */
 function mockSurfacesWithDetails(homeHtml: string, hareHtml: string, details: Record<string, string>) {
   mockedSafeFetch.mockImplementation((url: string) => {
@@ -304,6 +315,17 @@ describe("parseDetailPage", () => {
     expect(d.longitude).toBeCloseTo(55.20726);
     // Venue-only body → no leftover notes.
     expect(d.description).toBeUndefined();
+  });
+
+  it("does NOT take a title/theme-led body line as the venue, even with coords present", () => {
+    const d = parseDetailPage(DETAIL_TITLE_LED);
+    expect(d.hares).toBe("Slow Crack Whore");
+    expect(d.latitude).toBeCloseTo(25.106101);
+    // The lead "DH3 Run #2452 – Desert Shenanigans 🏜️🍻" is a title, not a venue.
+    expect(d.location).toBeUndefined();
+    expect(d.locationUrl).toContain("maps.app.goo.gl"); // map pin still captured
+    expect(d.description).toContain("Desert Shenanigans");
+    expect(d.description).toContain("Truck Stop on Emirates Rd");
   });
 
   it("treats a coord-less body as free-form notes (no venue) and never reads the phone", () => {

--- a/src/adapters/html-scraper/desert-hash.ts
+++ b/src/adapters/html-scraper/desert-hash.ts
@@ -294,6 +294,17 @@ function collapseWs(s: string): string {
   return s.replace(/\s+/g, " ").trim();
 }
 
+// A lead description line is only trusted as the venue when it reads like one:
+// short, with no run-number / "DH3" title marker and no embedded calendar date
+// (those signal a decorative title or a dated blurb, not a gathering spot).
+const VENUE_TITLE_MARKER_RE = /\bDH3\b|\bRun\s*#?\s*\d/i;
+const VENUE_DATE_MARKER_RE =
+  /\b\d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/i;
+function looksLikeVenue(line: string): boolean {
+  if (line.length > 60) return false;
+  return !VENUE_TITLE_MARKER_RE.test(line) && !VENUE_DATE_MARKER_RE.test(line);
+}
+
 /**
  * Extract the event's coordinates from the gmap widget's `mecGoogleMaps({…})`
  * init block. Returns {} when either component is missing/non-finite, or when
@@ -364,8 +375,14 @@ export function parseDetailPage(html: string): DesertDetail {
       if ($maps.length > 0 && text === collapseWs($maps.text())) return;
       contentParas.push(text);
     });
-    // First body line is the venue only when MEC supplied structured coords.
-    if (coords.latitude != null && contentParas.length > 0) {
+    // First body line is the venue only when MEC supplied structured coords AND
+    // that line actually looks like a venue. Some runs lead their body with a
+    // decorative TITLE/theme ("DH3 Run #2452 – Desert Shenanigans 🏜️🍻") or a
+    // dated blurb ("The Qudra Lake Trail & BBQ – Sunday 19 April …") rather than
+    // a bare venue, and treating those as the location is worse than leaving it
+    // to the maps link + coords (a wrong venue is worse than none). When the
+    // lead line isn't venue-like it stays in the description.
+    if (coords.latitude != null && contentParas.length > 0 && looksLikeVenue(contentParas[0])) {
       detail.location = contentParas.shift();
     }
     const body = contentParas.join("\n").trim();

--- a/src/adapters/html-scraper/desert-hash.ts
+++ b/src/adapters/html-scraper/desert-hash.ts
@@ -294,15 +294,34 @@ function collapseWs(s: string): string {
   return s.replace(/\s+/g, " ").trim();
 }
 
-// A lead description line is only trusted as the venue when it reads like one:
-// short, with no run-number / "DH3" title marker and no embedded calendar date
-// (those signal a decorative title or a dated blurb, not a gathering spot).
+// An explicitly-labelled venue line ("Location: …" / "Location is …") is the
+// most reliable signal — the text after the label IS the gathering spot, even
+// when it's verbose. Captured ahead of the first-line heuristic below.
+const VENUE_LABEL_RE = /^location\s*(?:is|:)\s*(.+)/i;
+
+// When there's no label, the lead description line is only trusted as the venue
+// when it reads like one: short, not a notes/blurb prefix, with no run-number /
+// "DH3" title marker and no embedded calendar date (those signal a decorative
+// title or dated prose, not a gathering spot).
 const VENUE_TITLE_MARKER_RE = /\bDH3\b|\bRun\s*#?\s*\d/i;
 const VENUE_DATE_MARKER_RE =
   /\b\d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/i;
+const NON_VENUE_PREFIX_RE = /^(?:note|promises?|this\s+sunday|join|come)\b/i;
 function looksLikeVenue(line: string): boolean {
-  if (line.length > 60) return false;
+  if (line.length > 60 || NON_VENUE_PREFIX_RE.test(line)) return false;
   return !VENUE_TITLE_MARKER_RE.test(line) && !VENUE_DATE_MARKER_RE.test(line);
+}
+
+/** A "Location: <venue>"-labelled line's venue text, if any paragraph carries one. */
+function labelledVenue(paras: string[]): string | undefined {
+  for (const p of paras) {
+    const m = VENUE_LABEL_RE.exec(p);
+    if (m) {
+      const v = m[1].trim();
+      if (v) return v;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -375,14 +394,17 @@ export function parseDetailPage(html: string): DesertDetail {
       if ($maps.length > 0 && text === collapseWs($maps.text())) return;
       contentParas.push(text);
     });
-    // First body line is the venue only when MEC supplied structured coords AND
-    // that line actually looks like a venue. Some runs lead their body with a
-    // decorative TITLE/theme ("DH3 Run #2452 – Desert Shenanigans 🏜️🍻") or a
-    // dated blurb ("The Qudra Lake Trail & BBQ – Sunday 19 April …") rather than
-    // a bare venue, and treating those as the location is worse than leaving it
-    // to the maps link + coords (a wrong venue is worse than none). When the
-    // lead line isn't venue-like it stays in the description.
-    if (coords.latitude != null && contentParas.length > 0 && looksLikeVenue(contentParas[0])) {
+    // Venue resolution, most-reliable first:
+    //  1. an explicit "Location: …" label anywhere in the body, else
+    //  2. the lead line when coords are present AND it looks like a venue.
+    // Some runs lead with a decorative TITLE/theme ("DH3 Run #2452 – Desert
+    // Shenanigans 🏜️🍻"), a dated blurb, or a "Note: …" — treating those as the
+    // location is worse than leaving it to the maps link + coords. When neither
+    // path yields a venue the lines stay in the description.
+    const labelled = labelledVenue(contentParas);
+    if (labelled) {
+      detail.location = labelled;
+    } else if (coords.latitude != null && contentParas.length > 0 && looksLikeVenue(contentParas[0])) {
       detail.location = contentParas.shift();
     }
     const body = contentParas.join("\n").trim();

--- a/src/adapters/html-scraper/desert-hash.ts
+++ b/src/adapters/html-scraper/desert-hash.ts
@@ -66,8 +66,36 @@ const TOGGLE_YEAR_RE = /mec-toggle-(\d{4})\d{2}/;
 const YEAR_RE = /(20\d{2})/;
 
 // ── Detail-page enrichment (issues #2323-#2326) ──────────────────────────────
-// A Google-Maps link in the run-notes body, in any of the host forms MEC emits.
-const MAPS_URL_RE = /maps\.app\.goo\.gl|google\.[a-z.]+\/maps|goo\.gl\/maps|maps\.google/i;
+// Validate a run-notes anchor as a Google Maps link by HOSTNAME, not substring
+// — a hostile href that merely contains "maps.app.goo.gl" in a path/query must
+// not be persisted as `locationUrl` (CodeRabbit review). Label-based google
+// check so "google" must be the registrable-domain label (google.evil.com is
+// rejected), mirroring the stlh3 host allowlist.
+function isGoogleHostLabel(host: string): boolean {
+  const labels = host.split(".");
+  const n = labels.length;
+  if (n >= 2 && labels[n - 2] === "google") return true;
+  return (
+    n >= 3 &&
+    labels[n - 3] === "google" &&
+    labels[n - 1].length === 2 &&
+    labels[n - 2].length <= 3
+  );
+}
+function isMapsUrl(href: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(href);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") return false;
+  const host = u.hostname.toLowerCase();
+  if (host === "maps.app.goo.gl" || host === "maps.google.com") return true;
+  const path = u.pathname.toLowerCase();
+  if (host === "goo.gl") return path.startsWith("/maps");
+  return isGoogleHostLabel(host) && path.startsWith("/maps");
+}
 // The event's coordinates, embedded in the gmap widget's `mecGoogleMaps({…})`
 // init block. Only present when MEC carries a structured location.
 const DETAIL_LAT_RE = /latitude:\s*"(-?\d+(?:\.\d+)?)"/;
@@ -329,7 +357,7 @@ export function parseDetailPage(html: string): DesertDetail {
       if (!text) return; // image-only / empty paragraph
       const $maps = $p
         .find("a[href]")
-        .filter((_j, a) => MAPS_URL_RE.test($(a).attr("href") ?? ""))
+        .filter((_j, a) => isMapsUrl($(a).attr("href") ?? ""))
         .first();
       if ($maps.length > 0 && !detail.locationUrl) detail.locationUrl = $maps.attr("href");
       // A paragraph that is ONLY a maps anchor ("Google Map Link") is not content.
@@ -449,21 +477,28 @@ export class DesertHashAdapter implements SourceAdapter {
       detailsEnriched: 0,
       detailFetchFailures: 0,
     };
-    await this.enrichWithDetails(windowed.events, detailDiag);
+    // Per-detail fetch/parse failures are preserved here (structured, for the
+    // audit pipeline) but deliberately kept OUT of `errors[]`.
+    const detailErrors: ErrorDetails = windowed.errorDetails ?? {};
+    await this.enrichWithDetails(windowed.events, detailDiag, detailErrors);
     windowed.diagnosticContext = { ...windowed.diagnosticContext, ...detailDiag };
 
-    // Surface SYSTEMIC enrichment failure (every detail fetch failed) so the
-    // health/audit pipeline can flag a detail-page block or markup drift — but
-    // via `errorDetails` only, NOT `errors[]`, so the healthy listing still
-    // reconciles instead of leaving stale runs uncancelled (Codex review).
-    if (detailDiag.detailTargets > 0 && detailDiag.detailFetchFailures === detailDiag.detailTargets) {
+    // Surface SYSTEMIC enrichment loss — every in-window run came back with ZERO
+    // enriched fields, whether the detail fetch failed OR the page returned 200
+    // but parsed to {} under MEC markup drift (gating on `detailsEnriched === 0`
+    // catches both; `detailFetchFailures === detailTargets` would miss the
+    // parse-empty drift — Codex/CodeRabbit review). `errorDetails` only, NOT
+    // `errors[]`, so the healthy listing still reconciles instead of leaving
+    // stale runs uncancelled.
+    if (detailDiag.detailTargets > 0 && detailDiag.detailsEnriched === 0) {
       const message =
-        `Desert H3: detail-page enrichment failed for all ${detailDiag.detailTargets} in-window runs ` +
-        `(hares/venue/notes unavailable — detail-page block or MEC markup drift?)`;
-      const ed: ErrorDetails = windowed.errorDetails ?? {};
-      (ed.parse ??= []).push({ row: -1, section: "detail", error: message });
-      windowed.errorDetails = ed;
+        `Desert H3: detail-page enrichment produced no fields for all ${detailDiag.detailTargets} ` +
+        `in-window runs (hares/venue/notes unavailable — detail-page block or MEC markup drift?)`;
+      const parseErrors = detailErrors.parse ?? [];
+      parseErrors.push({ row: -1, section: "detail", error: message });
+      detailErrors.parse = parseErrors;
     }
+    if (hasAnyErrors(detailErrors)) windowed.errorDetails = detailErrors;
 
     return windowed;
   }
@@ -472,6 +507,7 @@ export class DesertHashAdapter implements SourceAdapter {
   private async enrichWithDetails(
     events: RawEventData[],
     diagnostics: DetailDiagnostics,
+    errorDetails: ErrorDetails,
   ): Promise<void> {
     const targets = events
       .filter((e) => e.sourceUrl?.includes("mec-events="))
@@ -481,19 +517,25 @@ export class DesertHashAdapter implements SourceAdapter {
     for (let i = 0; i < targets.length; i += DETAIL_FETCH_CONCURRENCY) {
       const batch = targets.slice(i, i + DETAIL_FETCH_CONCURRENCY);
       // Sequential by design: bounded batches keep the fan-out polite.
-      await Promise.all(batch.map((e) => this.enrichOne(e, diagnostics)));
+      await Promise.all(batch.map((e) => this.enrichOne(e, diagnostics, errorDetails)));
     }
   }
 
   private async enrichOne(
     e: RawEventData,
     diagnostics: DetailDiagnostics,
+    errorDetails: ErrorDetails,
   ): Promise<void> {
     const url = e.sourceUrl;
     if (!url) return;
     const page = await fetchHTMLPage(url);
     if (!page.ok) {
       diagnostics.detailFetchFailures++;
+      // Preserve the structured fetch failure (url/status/message) for audits.
+      const fetchErrs = page.result.errorDetails?.fetch;
+      errorDetails.fetch ??= [];
+      if (fetchErrs && fetchErrs.length > 0) errorDetails.fetch.push(...fetchErrs);
+      else errorDetails.fetch.push({ url, message: page.result.errors[0] ?? "Detail fetch failed" });
       return;
     }
     try {
@@ -509,8 +551,14 @@ export class DesertHashAdapter implements SourceAdapter {
         enriched = true;
       }
       if (enriched) diagnostics.detailsEnriched++;
-    } catch {
+    } catch (err) {
       diagnostics.detailFetchFailures++;
+      errorDetails.parse ??= [];
+      errorDetails.parse.push({
+        row: e.runNumber ?? -1,
+        section: "detail",
+        error: `Detail parse failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
     }
   }
 }

--- a/src/adapters/html-scraper/desert-hash.ts
+++ b/src/adapters/html-scraper/desert-hash.ts
@@ -26,9 +26,11 @@
  * `dh3-ae`. Numbered runs that happen to be virtual ("… – The War Edition –
  * ONLINE") are real DH3 runs and are kept (with their trailing theme as title).
  *
- * No per-event venue/hares/coords are published for current-era runs (they are
- * distributed off-site via WhatsApp), and the per-run contact-hare phone number
- * is PII and deliberately NOT scraped.
+ * Each run also has a DETAIL page (?mec-events=dh3-run-NNNN) that publishes the
+ * hare(s), the venue + Google Maps link, optional lat/lng, and a free-form
+ * run-notes body. fetch() follows the in-window runs' detail links and enriches
+ * each event with those fields (see `parseDetailPage`). The per-run contact-hare
+ * phone number is PII and is deliberately NOT scraped.
  */
 
 import type { Source } from "@/generated/prisma/client";
@@ -62,6 +64,25 @@ const TIME_RE = /(\d{1,2}):(\d{2})/;
 const DMY_RE = /(\d{1,2})\/(\d{1,2})\/(\d{4})/;
 const TOGGLE_YEAR_RE = /mec-toggle-(\d{4})\d{2}/;
 const YEAR_RE = /(20\d{2})/;
+
+// ── Detail-page enrichment (issues #2323-#2326) ──────────────────────────────
+// A Google-Maps link in the run-notes body, in any of the host forms MEC emits.
+const MAPS_URL_RE = /maps\.app\.goo\.gl|google\.[a-z.]+\/maps|goo\.gl\/maps|maps\.google/i;
+// The event's coordinates, embedded in the gmap widget's `mecGoogleMaps({…})`
+// init block. Only present when MEC carries a structured location.
+const DETAIL_LAT_RE = /latitude:\s*"(-?\d+(?:\.\d+)?)"/;
+const DETAIL_LNG_RE = /longitude:\s*"(-?\d+(?:\.\d+)?)"/;
+// Bound the detail-page fan-out: enrich only the in-window runs, batched +
+// capped so a future MEC format change can't trigger hundreds of fetches.
+const DETAIL_FETCH_CONCURRENCY = 4;
+const MAX_DETAIL_FETCHES = 60;
+
+/** Per-run detail-enrichment tallies (surfaced in diagnosticContext). */
+interface DetailDiagnostics {
+  detailTargets: number;
+  detailsEnriched: number;
+  detailFetchFailures: number;
+}
 
 // ---------------------------------------------------------------------------
 // Pure parse helpers (exported for unit testing)
@@ -227,6 +248,105 @@ export function parseHareLine($: cheerio.CheerioAPI): RawEventData[] {
   return [...byRun.values()];
 }
 
+// ---------------------------------------------------------------------------
+// Detail-page parse (per-run hares / venue / maps / notes / coords)
+// ---------------------------------------------------------------------------
+
+export interface DesertDetail {
+  hares?: string;
+  location?: string;
+  locationUrl?: string;
+  description?: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+/** Collapse internal whitespace runs to single spaces and trim. */
+function collapseWs(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Extract the event's coordinates from the gmap widget's `mecGoogleMaps({…})`
+ * init block. Returns {} when either component is missing/non-finite, or when
+ * both are 0 (MEC's no-location placeholder marker).
+ */
+function parseDetailCoords(html: string): { latitude?: number; longitude?: number } {
+  const lat = DETAIL_LAT_RE.exec(html);
+  const lng = DETAIL_LNG_RE.exec(html);
+  if (!lat || !lng) return {};
+  const latitude = Number.parseFloat(lat[1]);
+  const longitude = Number.parseFloat(lng[1]);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return {};
+  if (latitude === 0 && longitude === 0) return {};
+  return { latitude, longitude };
+}
+
+/**
+ * Parse a run's MEC detail page into the enrichment fields the listing surfaces
+ * lack. The body (`.mec-single-event-description`) is free-form: some runs lead
+ * with the venue line (2456 "Goose Island Tap House, JVC"), others lead with a
+ * note ("Note: this is a Sunday run …"). Coordinates are only emitted when MEC
+ * carries a *structured* location, so their presence is the signal that the
+ * first body paragraph is a trustworthy venue; without coords the body is
+ * treated as notes only and no venue text is fabricated.
+ *
+ * The contact-hare phone number lives in a separate `dd.mec-organizer-tel` and
+ * is PII — it is never read here.
+ */
+export function parseDetailPage(html: string): DesertDetail {
+  const $ = cheerio.load(html);
+  const detail: DesertDetail = {};
+
+  // Hares — the organizer section titled "Hare(s)". Names sit in
+  // `dd.mec-organizer .mec-meta-label` (the phone's `dd.mec-organizer-tel` is a
+  // distinct class and is not matched here).
+  const hareNames: string[] = [];
+  $(".mec-single-event-organizer").each((_i, sec) => {
+    const $sec = $(sec);
+    const title = $sec.find(".mec-events-single-section-title").first().text().toLowerCase();
+    if (!title.includes("hare")) return;
+    $sec.find("dd.mec-organizer .mec-meta-label").each((_j, el) => {
+      const name = collapseWs($(el).text());
+      if (name && !/^phone$/i.test(name)) hareNames.push(name);
+    });
+  });
+  if (hareNames.length > 0) detail.hares = hareNames.join(", ");
+
+  const coords = parseDetailCoords(html);
+  if (coords.latitude != null && coords.longitude != null) {
+    detail.latitude = coords.latitude;
+    detail.longitude = coords.longitude;
+  }
+
+  // Venue / Maps link / notes from the free-form description body.
+  const $desc = $(".mec-single-event-description").first();
+  if ($desc.length > 0) {
+    const contentParas: string[] = [];
+    $desc.find("p").each((_i, p) => {
+      const $p = $(p);
+      const text = collapseWs($p.text());
+      if (!text) return; // image-only / empty paragraph
+      const $maps = $p
+        .find("a[href]")
+        .filter((_j, a) => MAPS_URL_RE.test($(a).attr("href") ?? ""))
+        .first();
+      if ($maps.length > 0 && !detail.locationUrl) detail.locationUrl = $maps.attr("href");
+      // A paragraph that is ONLY a maps anchor ("Google Map Link") is not content.
+      if ($maps.length > 0 && text === collapseWs($maps.text())) return;
+      contentParas.push(text);
+    });
+    // First body line is the venue only when MEC supplied structured coords.
+    if (coords.latitude != null && contentParas.length > 0) {
+      detail.location = contentParas.shift();
+    }
+    const body = contentParas.join("\n").trim();
+    if (body) detail.description = body;
+  }
+
+  return detail;
+}
+
 /**
  * Merge one fetched surface into `byRun`, recording fetch/parse errors. Returns
  * the page's structureHash + fetch duration (0 for a failed fetch). Extracted
@@ -313,6 +433,84 @@ export class DesertHashAdapter implements SourceAdapter {
       },
     };
 
-    return applyDateWindow(result, options?.days ?? source.scrapeDays ?? DEFAULT_SCRAPE_DAYS);
+    const windowed = applyDateWindow(
+      result,
+      options?.days ?? source.scrapeDays ?? DEFAULT_SCRAPE_DAYS,
+    );
+
+    // Enrich the in-window runs with detail-page hares / venue / maps / notes /
+    // coords (issues #2323-#2326). Best-effort: an individual detail fetch/parse
+    // failure is recorded in diagnostics but never pushed to `errors[]`, so it
+    // can't turn a successful listing scrape into a FAILED run (which would skip
+    // reconcile of genuinely-removed runs — the listing surfaces still produced
+    // valid date/run#/time for every event).
+    const detailDiag: DetailDiagnostics = {
+      detailTargets: 0,
+      detailsEnriched: 0,
+      detailFetchFailures: 0,
+    };
+    await this.enrichWithDetails(windowed.events, detailDiag);
+    windowed.diagnosticContext = { ...windowed.diagnosticContext, ...detailDiag };
+
+    // Surface SYSTEMIC enrichment failure (every detail fetch failed) so the
+    // health/audit pipeline can flag a detail-page block or markup drift — but
+    // via `errorDetails` only, NOT `errors[]`, so the healthy listing still
+    // reconciles instead of leaving stale runs uncancelled (Codex review).
+    if (detailDiag.detailTargets > 0 && detailDiag.detailFetchFailures === detailDiag.detailTargets) {
+      const message =
+        `Desert H3: detail-page enrichment failed for all ${detailDiag.detailTargets} in-window runs ` +
+        `(hares/venue/notes unavailable — detail-page block or MEC markup drift?)`;
+      const ed: ErrorDetails = windowed.errorDetails ?? {};
+      (ed.parse ??= []).push({ row: -1, section: "detail", error: message });
+      windowed.errorDetails = ed;
+    }
+
+    return windowed;
+  }
+
+  /** Follow each in-window run's detail link and merge enrichment fields. */
+  private async enrichWithDetails(
+    events: RawEventData[],
+    diagnostics: DetailDiagnostics,
+  ): Promise<void> {
+    const targets = events
+      .filter((e) => e.sourceUrl?.includes("mec-events="))
+      .slice(0, MAX_DETAIL_FETCHES);
+    diagnostics.detailTargets = targets.length;
+
+    for (let i = 0; i < targets.length; i += DETAIL_FETCH_CONCURRENCY) {
+      const batch = targets.slice(i, i + DETAIL_FETCH_CONCURRENCY);
+      // Sequential by design: bounded batches keep the fan-out polite.
+      await Promise.all(batch.map((e) => this.enrichOne(e, diagnostics)));
+    }
+  }
+
+  private async enrichOne(
+    e: RawEventData,
+    diagnostics: DetailDiagnostics,
+  ): Promise<void> {
+    const url = e.sourceUrl;
+    if (!url) return;
+    const page = await fetchHTMLPage(url);
+    if (!page.ok) {
+      diagnostics.detailFetchFailures++;
+      return;
+    }
+    try {
+      const d = parseDetailPage(page.html);
+      let enriched = false;
+      if (d.hares) { e.hares = d.hares; enriched = true; }
+      if (d.location) { e.location = d.location; enriched = true; }
+      if (d.locationUrl) { e.locationUrl = d.locationUrl; enriched = true; }
+      if (d.description) { e.description = d.description; enriched = true; }
+      if (d.latitude != null && d.longitude != null) {
+        e.latitude = d.latitude;
+        e.longitude = d.longitude;
+        enriched = true;
+      }
+      if (enriched) diagnostics.detailsEnriched++;
+    } catch {
+      diagnostics.detailFetchFailures++;
+    }
   }
 }

--- a/src/adapters/html-scraper/sh3-au.test.ts
+++ b/src/adapters/html-scraper/sh3-au.test.ts
@@ -60,6 +60,15 @@ describe("sh3-au parseSh3Paragraph", () => {
     ).toBeUndefined();
   });
 
+  it("tolerates a 'Start :' label with whitespace before the colon", () => {
+    const e = parseSh3Paragraph(
+      "Run #3092 Date: 6th July @ 6:30 pm Hares: X Start : Park On On : Pub", URL, REF,
+    );
+    expect(e!.location).toBe("Park");
+    expect(e!.startTime).toBe("18:30");
+    expect(e!.description).toBe("Pub");
+  });
+
   it("strips a leading 'Posh –' nickname prefix from hares (#2363)", () => {
     const e = parseSh3Paragraph(
       "Run #3093 Date: 20th July Hares: Posh – Beep Beep & Ferret Start: Park", URL, REF,

--- a/src/adapters/html-scraper/sh3-au.test.ts
+++ b/src/adapters/html-scraper/sh3-au.test.ts
@@ -28,6 +28,59 @@ describe("sh3-au parseSh3Paragraph", () => {
     expect(e!.description).toBeUndefined();
   });
 
+  // Live format (#2360/#2361/#2362): "On On :" carries a space before the
+  // colon, the Date cell ends with "@ 6:30pm", and the Start field runs into
+  // "CLICK HERE FOR MAP" before the On-On.
+  it("handles the live 'On On :' / '@ time' shape: start time, clean location, On-On description", () => {
+    const text =
+      "Run #3081 Date: 29th June 2026 @ 6:30pm Hares: Beep Beep & Ferret Start: Gordon Station Carpark, off Park Rd, Gordon CLICK HERE FOR MAP On On : Greengate Hotel, Cnr Greengate Rd & Pacific Hwy";
+    const e = parseSh3Paragraph(text, URL, REF);
+    expect(e).not.toBeNull();
+    expect(e!.runNumber).toBe(3081);
+    expect(e!.startTime).toBe("18:30");
+    expect(e!.hares).toBe("Beep Beep & Ferret");
+    // CTA stripped AND On-On no longer leaks into the location.
+    expect(e!.location).toBe("Gordon Station Carpark, off Park Rd, Gordon");
+    expect(e!.location).not.toMatch(/CLICK HERE/i);
+    expect(e!.location).not.toMatch(/Greengate/);
+    // On-On captured into description despite the "On On :" space-colon.
+    expect(e!.description).toBe("Greengate Hotel, Cnr Greengate Rd & Pacific Hwy");
+  });
+
+  it("parses '@ 6:30 pm' and bare '@ 7pm' start times from the Date cell (#2361)", () => {
+    expect(
+      parseSh3Paragraph("Run #3090 Date: 6th July @ 6:30 pm Hares: X Start: Park", URL, REF)!.startTime,
+    ).toBe("18:30");
+    expect(
+      parseSh3Paragraph("Run #3091 Date: 6th July @ 7pm Hares: X Start: Park", URL, REF)!.startTime,
+    ).toBe("19:00");
+    // No "@ time" → no start time emitted.
+    expect(
+      parseSh3Paragraph("Run #3092 Date: 6th July Hares: X Start: Park", URL, REF)!.startTime,
+    ).toBeUndefined();
+  });
+
+  it("strips a leading 'Posh –' nickname prefix from hares (#2363)", () => {
+    const e = parseSh3Paragraph(
+      "Run #3093 Date: 20th July Hares: Posh – Beep Beep & Ferret Start: Park", URL, REF,
+    );
+    expect(e!.hares).toBe("Beep Beep & Ferret");
+    // A hare literally named "Posh" (no separator) survives.
+    expect(
+      parseSh3Paragraph("Run #3094 Date: 20th July Hares: Posh Start: Park", URL, REF)!.hares,
+    ).toBe("Posh");
+  });
+
+  it("yields empty hares (not the Start value) when an un-hared run reads 'Hares: Start:' (#2360)", () => {
+    const text =
+      "Run #3082 Date: 6th July @ 6:30 pm Hares: Start: CLICK HERE FOR MAP On On :";
+    const e = parseSh3Paragraph(text, URL, REF);
+    expect(e).not.toBeNull();
+    expect(e!.hares).toBeUndefined();
+    expect(e!.location).toBeNull();
+    expect(e!.startTime).toBe("18:30");
+  });
+
   it("returns null when Run # is missing", () => {
     expect(parseSh3Paragraph("Next Few Weeks", URL, REF)).toBeNull();
   });

--- a/src/adapters/html-scraper/sh3-au.ts
+++ b/src/adapters/html-scraper/sh3-au.ts
@@ -5,6 +5,7 @@ import {
   chronoParseDate,
   cleanLocationName,
   fetchHTMLPage,
+  formatAmPmTime,
   stripClickHereForMap,
 } from "../utils";
 
@@ -46,11 +47,36 @@ const SOURCE_URL_DEFAULT = "https://www.sh3.link/?page_id=9470";
  * the next known label anchor so the parser remains robust when the
  * WordPress innerText collapses every labeled field onto a single line.
  */
-const NEXT_LABEL = /(?=Run\s*#|Date:|Hares?:|Start:|On\s*On:|$)/i.source;
-const DATE_RE = new RegExp(`Date:\\s*(.+?)\\s*${NEXT_LABEL}`, "i");
-const HARES_RE = new RegExp(`Hares?:\\s*(.+?)\\s*${NEXT_LABEL}`, "i");
-const START_RE = new RegExp(`Start:\\s*(.+?)\\s*${NEXT_LABEL}`, "i");
-const ON_ON_RE = new RegExp(`On\\s*On:\\s*(.+?)\\s*${NEXT_LABEL}`, "i");
+// Each label tolerates whitespace before its colon — the live page writes
+// "On On :" (and occasionally "Start :") with a space, which the old
+// colon-tight patterns missed. When "On On :" failed to match, the Start
+// capture spilled to end-of-string, leaking the On-On venue + CTA into the
+// location and dropping the On-On entirely (#2360 / #2362).
+// Captures use `(.*?)` (zero-or-more) so an empty field whose next label sits
+// immediately after it — e.g. "Hares: Start:" on an un-hared future run —
+// captures "" and stops, instead of `(.+?)` skipping past the adjacent label
+// and swallowing the following field's value (#2360).
+const NEXT_LABEL = /(?=Run\s*#|Date\s*:|Hares?\s*:|Start\s*:|On\s*On\s*:|$)/i.source;
+const DATE_RE = new RegExp(`Date\\s*:\\s*(.*?)\\s*${NEXT_LABEL}`, "i");
+const HARES_RE = new RegExp(`Hares?\\s*:\\s*(.*?)\\s*${NEXT_LABEL}`, "i");
+const START_RE = new RegExp(`Start\\s*:\\s*(.*?)\\s*${NEXT_LABEL}`, "i");
+const ON_ON_RE = new RegExp(`On\\s*On\\s*:\\s*(.*?)\\s*${NEXT_LABEL}`, "i");
+
+/**
+ * Parse the start time the editors append to the Date cell as "@ 6:30pm" /
+ * "@ 6:30 pm" / "@ 6pm" (#2361). Returns "HH:MM" or undefined when absent or
+ * out of range. chrono parses the date and ignores this "@ time" suffix, so it
+ * has to be recovered separately.
+ */
+const SH3_AT_TIME_RE = /@\s*(\d{1,2})(?::(\d{2}))?\s*([ap]m)/i;
+function parseStartTimeFromDate(dateField: string): string | undefined {
+  const m = SH3_AT_TIME_RE.exec(dateField);
+  if (!m) return undefined;
+  const h = Number.parseInt(m[1], 10);
+  const min = m[2] ? Number.parseInt(m[2], 10) : 0;
+  if (h < 1 || h > 12 || min > 59) return undefined;
+  return formatAmPmTime(h, min, m[3]);
+}
 
 function captureLabel(text: string, re: RegExp): string | undefined {
   const m = re.exec(text);
@@ -141,14 +167,21 @@ const TRAILING_PUNCT = new Set(["-", "–", "—", " "]);
 // trail-setters, so there are no real hares to recover — drop the whole field.
 const JOINT_RUN_RE = /\bjoint\s+run\b/i;
 
+// "Posh –" / "Posh -" / "Posh:" / "Posh Hash –" lead-in some scribes prefix to
+// the hare line ("Posh" is the kennel's nickname, not a hare). Stripped only
+// when a separator + more content follows, so a hare literally named "Posh"
+// survives (#2363).
+const POSH_PREFIX_RE = /^posh(?:\s+hash)?\s*[-–—:]\s*(?=\S)/i;
+
 function cleanHares(raw: string | undefined): string | null | undefined {
   if (!raw) return undefined;
   // Recognized non-hare content → null (explicit clear), so a stale hare stored
   // for this run from an earlier scrape is wiped rather than preserved. The
   // merge tri-state reads undefined as "keep existing", null as "clear" (#2056).
   if (JOINT_RUN_RE.test(raw)) return null;
-  const cutoff = findFirstPromoIndex(raw);
-  let cleaned = (cutoff !== -1 ? raw.slice(0, cutoff) : raw).trimEnd();
+  const deprefixed = raw.replace(POSH_PREFIX_RE, "");
+  const cutoff = findFirstPromoIndex(deprefixed);
+  let cleaned = (cutoff !== -1 ? deprefixed.slice(0, cutoff) : deprefixed).trimEnd();
   // Collapse trailing punctuation left behind by truncation (en-dash, hyphen).
   while (cleaned.length > 0 && TRAILING_PUNCT.has(cleaned[cleaned.length - 1])) {
     cleaned = cleaned.slice(0, -1).trimEnd();
@@ -182,6 +215,7 @@ export function parseSh3Paragraph(
   const date = chronoParseDate(dateField, "en-GB", referenceDate, { forwardDate: true });
   if (!date) return null;
 
+  const startTime = parseStartTimeFromDate(dateField);
   const hares = cleanHares(captureLabel(text, HARES_RE));
   // Run the captured Start: value through the shared location cleaner so a
   // blank Start: (which lets the non-greedy capture spill into the trailing
@@ -201,6 +235,7 @@ export function parseSh3Paragraph(
     kennelTags: [KENNEL_TAG],
     runNumber,
     hares,
+    startTime,
     location: start,
     description: onOn,
     sourceUrl,

--- a/src/adapters/html-scraper/sh3-au.ts
+++ b/src/adapters/html-scraper/sh3-au.ts
@@ -56,11 +56,17 @@ const SOURCE_URL_DEFAULT = "https://www.sh3.link/?page_id=9470";
 // immediately after it — e.g. "Hares: Start:" on an un-hared future run —
 // captures "" and stops, instead of `(.+?)` skipping past the adjacent label
 // and swallowing the following field's value (#2360).
-const NEXT_LABEL = /(?=Run\s*#|Date\s*:|Hares?\s*:|Start\s*:|On\s*On\s*:|$)/i.source;
-const DATE_RE = new RegExp(`Date\\s*:\\s*(.*?)\\s*${NEXT_LABEL}`, "i");
-const HARES_RE = new RegExp(`Hares?\\s*:\\s*(.*?)\\s*${NEXT_LABEL}`, "i");
-const START_RE = new RegExp(`Start\\s*:\\s*(.*?)\\s*${NEXT_LABEL}`, "i");
-const ON_ON_RE = new RegExp(`On\\s*On\\s*:\\s*(.*?)\\s*${NEXT_LABEL}`, "i");
+//
+// The "next label" boundary lookahead is inlined into each LITERAL regex below
+// rather than composed via `new RegExp(...)`, so Codacy's detect-non-literal
+// -regexp can see the pattern is fully controlled (the interpolated form is a
+// flagged sink even though the input is a module constant). NOSONAR S5852: the
+// lazy capture + boundary lookahead is the same bounded shape the other HTML
+// scrapers use (e.g. chicago-hash).
+const DATE_RE = /Date\s*:\s*(.*?)\s*(?=Run\s*#|Date\s*:|Hares?\s*:|Start\s*:|On\s*On\s*:|$)/i; // NOSONAR S5852
+const HARES_RE = /Hares?\s*:\s*(.*?)\s*(?=Run\s*#|Date\s*:|Hares?\s*:|Start\s*:|On\s*On\s*:|$)/i; // NOSONAR S5852
+const START_RE = /Start\s*:\s*(.*?)\s*(?=Run\s*#|Date\s*:|Hares?\s*:|Start\s*:|On\s*On\s*:|$)/i; // NOSONAR S5852
+const ON_ON_RE = /On\s*On\s*:\s*(.*?)\s*(?=Run\s*#|Date\s*:|Hares?\s*:|Start\s*:|On\s*On\s*:|$)/i; // NOSONAR S5852
 
 /**
  * Parse the start time the editors append to the Date cell as "@ 6:30pm" /

--- a/src/adapters/html-scraper/shith3.test.ts
+++ b/src/adapters/html-scraper/shith3.test.ts
@@ -184,6 +184,25 @@ describe("buildEventFromDetail", () => {
     expect(event.hares).toBeUndefined();
   });
 
+  it("falls back to harestr when the hares array is empty", () => {
+    const detail = { ...baseDetail, hares: [], harestr: "Solo Hare" };
+    const event = buildEventFromDetail(detail, baseListing);
+    expect(event.hares).toBe("Solo Hare");
+  });
+
+  it("recovers hares from the TIDBIT body when array + harestr are empty (#2284)", () => {
+    // Real shape from lookup_id 10071 (Trail #1212): hares only in the TIDBIT.
+    const detail = {
+      ...baseDetail,
+      hares: [],
+      harestr: null,
+      TIDBIT:
+        "<div>WE LOVE RESTON<br><br>Hares:  Horse with No Name, Just Balaji, Dog with 69 Names <br><br>Runners: 4.69 miles<br><br>Prelube: Kalypsos</div>",
+    };
+    const event = buildEventFromDetail(detail, baseListing);
+    expect(event.hares).toBe("Horse with No Name, Just Balaji, Dog with 69 Names");
+  });
+
   it("falls back to ADDRESS when LOCATION is missing", () => {
     const detail = { ...baseDetail, LOCATION: undefined, ADDRESS: "123 Main St" };
     const event = buildEventFromDetail(detail, baseListing);

--- a/src/adapters/html-scraper/shith3.ts
+++ b/src/adapters/html-scraper/shith3.ts
@@ -21,6 +21,9 @@ export interface DetailItem {
   LOCATION?: string;
   hashdate?: string;
   hares?: string[];
+  /** Free-text hare string the API actually returns (often null — the hares
+   *  are then only in the TIDBIT body, see #2284). */
+  harestr?: string | null;
   TIDBIT?: string;
   ONONON?: string;
   NOTES?: string;
@@ -103,6 +106,23 @@ function parseDistances(notes: string): string | undefined {
 }
 
 /**
+ * Recover the hares from the body text when the structured fields are empty.
+ * SHITH3's API frequently returns an empty `hares` array + null `harestr`, with
+ * the real hares only in the TIDBIT body, e.g. "…Hares: Horse with No Name,
+ * Just Balaji…" (#2284). cleanHtml turns the `<br>`s into newlines, so the line
+ * is isolated and `[^\n]+` captures just the names.
+ */
+export function extractHaresFromBody(detail: DetailItem): string | undefined {
+  for (const src of [detail.TIDBIT, detail.NOTES]) {
+    if (!src) continue;
+    const m = /Hares?\s*:\s*([^\n]+)/i.exec(cleanHtml(src));
+    const hares = m?.[1]?.trim();
+    if (hares) return hares;
+  }
+  return undefined;
+}
+
+/**
  * Build a full RawEventData from a detail API response + listing item.
  * Detail fields take precedence; listing provides start time.
  */
@@ -111,9 +131,15 @@ export function buildEventFromDetail(detail: DetailItem, listing: ListingItem): 
   if (!date) throw new Error(`No date for event ${listing.lookup_id}`);
 
   const runNumber = detail.TRAIL ? parseInt(detail.TRAIL, 10) : undefined;
-  const hares = detail.hares && detail.hares.length > 0
+  // Prefer the structured `hares` array, then the `harestr` field, then the
+  // body fallback — the array + harestr are usually empty/null (#2284).
+  const haresFromArray = detail.hares && detail.hares.length > 0
     ? detail.hares.join(", ")
     : undefined;
+  const haresFromStr = typeof detail.harestr === "string" && detail.harestr.trim()
+    ? detail.harestr.trim()
+    : undefined;
+  const hares = haresFromArray ?? haresFromStr ?? extractHaresFromBody(detail);
   const location = detail.LOCATION || detail.ADDRESS || undefined;
 
   let locationUrl: string | undefined;

--- a/src/adapters/html-scraper/soh4.test.ts
+++ b/src/adapters/html-scraper/soh4.test.ts
@@ -1,5 +1,31 @@
-import { describe, it, expect } from "vitest";
-import { parseTrailPageHtml, parseRssItems, extractTrailNumber } from "./soh4";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Source } from "@/generated/prisma/client";
+import { SOH4Adapter, parseTrailPageHtml, parseRssItems, extractTrailNumber } from "./soh4";
+
+vi.mock("@/adapters/safe-fetch", () => ({ safeFetch: vi.fn() }));
+vi.mock("@/pipeline/structure-hash", () => ({
+  generateStructureHash: vi.fn(() => "mock-hash-soh4"),
+}));
+
+const { safeFetch } = await import("@/adapters/safe-fetch");
+const mockedSafeFetch = vi.mocked(safeFetch);
+
+function soh4Source(): Source {
+  return {
+    id: "src-soh4",
+    name: "SOH4 Website",
+    url: "https://www.soh4.com/trails/feed/",
+    type: "HTML_SCRAPER",
+    trustLevel: 6,
+    scrapeFreq: "daily",
+    scrapeDays: 365,
+    config: {},
+    isActive: true,
+    lastScrapedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as Source;
+}
 
 // ── HTML fixtures ──
 
@@ -7,7 +33,7 @@ import { parseTrailPageHtml, parseRssItems, extractTrailNumber } from "./soh4";
 const COMPLETE_TRAIL_HTML = `<html><body>
 <div class="em-item em-item-single em-event em-event-single em-event-617">
   <h1>Trail #822: Spring Flours</h1>
-  <h4>Saturday - March 21, 2026 - 2:09 pm</h4>
+  <h4>Saturday - March 21, 2026 - 2:09 pm - 5:09 pm</h4>
   <p>March weather has been at times both warm enough to start us thinking
   spring flowers and STRAWBERRY(s) but then cold enough for snow's return to
   crush our spirits to ZERO. Cum to Geddes and encourage Mother Nature to bring
@@ -92,6 +118,22 @@ describe("parseTrailPageHtml", () => {
   it("parses 'AKA' start time format (hash humor)", () => {
     const result = parseTrailPageHtml(COMPLETE_TRAIL_HTML);
     expect(result.startTime).toBe("14:09");
+  });
+
+  it("extracts the end time from the date line (#2329)", () => {
+    const result = parseTrailPageHtml(COMPLETE_TRAIL_HTML);
+    expect(result.endTime).toBe("17:09");
+  });
+
+  it("falls back to the date-line time when the labeled field is absent (#2328)", () => {
+    const html = `<div class="em-event-single">
+      <h1>Trail #840: Early Bird</h1>
+      <h4>Monday - June 8, 2026 - 11:00 am - 1:00 pm</h4>
+      <p><strong>Hares:</strong> Early Riser </br></p>
+    </div>`;
+    const result = parseTrailPageHtml(html);
+    expect(result.startTime).toBe("11:00");
+    expect(result.endTime).toBe("13:00");
   });
 
   it("parses standard start time", () => {
@@ -223,5 +265,52 @@ describe("extractTrailNumber", () => {
 
   it("returns undefined for non-trail URL", () => {
     expect(extractTrailNumber("https://www.soh4.com/about/")).toBeUndefined();
+  });
+});
+
+// ── SOH4Adapter.fetch (title placeholder + endTime/cost routing) ──
+
+describe("SOH4Adapter.fetch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function mockFeedAndTrails(items: Array<{ url: string; html: string }>) {
+    const rss = `<?xml version="1.0"?><rss><channel>${items
+      .map((i) => `<item><title>Trail</title><link>${i.url}</link></item>`)
+      .join("")}</channel></rss>`;
+    mockedSafeFetch.mockImplementation((url: string) => {
+      const u = String(url);
+      let html = rss;
+      if (u.includes("/feed/")) {
+        html = rss;
+      } else {
+        const hit = items.find((i) => u.startsWith(i.url));
+        html = hit ? hit.html : "";
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: () => Promise.resolve(html),
+        headers: new Headers({ "content-type": "text/html" }),
+      } as Response);
+    });
+  }
+
+  it("populates endTime + cost on Event fields, not in description (#2329)", async () => {
+    mockFeedAndTrails([{ url: "https://www.soh4.com/trails/822/", html: COMPLETE_TRAIL_HTML }]);
+    const result = await new SOH4Adapter().fetch(soh4Source());
+    const e = result.events.find((ev) => ev.runNumber === 822);
+    expect(e?.startTime).toBe("14:09");
+    expect(e?.endTime).toBe("17:09");
+    expect(e?.cost).toBe("$7 (Virgins/first timers are free!)");
+    expect(e?.description).not.toContain("Hash Cash");
+    expect(e?.title).toBe("Spring Flours");
+  });
+
+  it("synthesizes the default title when the source title is a placeholder (#2327)", async () => {
+    mockFeedAndTrails([{ url: "https://www.soh4.com/trails/825/", html: TBD_TRAIL_HTML }]);
+    const result = await new SOH4Adapter().fetch(soh4Source());
+    const e = result.events.find((ev) => ev.runNumber === 825);
+    expect(e?.title).toBe("SOH4 Trail #825"); // not "TBD"
   });
 });

--- a/src/adapters/html-scraper/soh4.ts
+++ b/src/adapters/html-scraper/soh4.ts
@@ -31,6 +31,7 @@ export function parseTrailPageHtml(html: string): {
   title?: string;
   date?: string;
   startTime?: string;
+  endTime?: string;
   description?: string;
   location?: string;
   locationUrl?: string;
@@ -90,6 +91,12 @@ export function parseTrailPageHtml(html: string): {
   // other dates, so we target the specific SOH4 date format and stop before
   // labels, the trail list, or the calendar section.
   let date: string | undefined;
+  // The SOH4 date line is "DayOfWeek - Month DD, YYYY - H:MM pm[ - H:MM pm]".
+  // The trailing time(s) are the *clean* real start/end (the labeled "Start
+  // Time" field carries a joke value like "1:69PM"), so capture them here as a
+  // reliable source for #2328 (start fallback) and #2329 (end time).
+  let dateLineStart: string | undefined;
+  let dateLineEnd: string | undefined;
   const descParagraphs: string[] = [];
   container.find("h1, h2, h3, h4, p").each((_i, el) => {
     const pText = decodeEntities($(el).text().replace(/\s+/g, " ").trim());
@@ -97,6 +104,11 @@ export function parseTrailPageHtml(html: string): {
     const dateMatch = !date ? DATE_LINE_RE.exec(pText) : null;
     if (dateMatch) {
       date = chronoParseDate(dateMatch[1], "en-US") ?? undefined;
+      const times = [...pText.matchAll(/(\d{1,2}:\d{2}\s*[ap]m)/gi)]
+        .map((m) => parse12HourTime(m[1]))
+        .filter((t): t is string => Boolean(t));
+      if (times[0]) dateLineStart = times[0];
+      if (times[1]) dateLineEnd = times[1];
       return; // skip date <p> from description
     }
     // Stop at structured labels, upcumming trails list, or calendar widget
@@ -125,6 +137,11 @@ export function parseTrailPageHtml(html: string): {
       startTime = parse12HourTime(timeText);
     }
   }
+  // Fall back to the clean date-line time when the labeled field is missing or
+  // unparseable — without this, an early-start trail loses its time and merge
+  // applies the kennel's default 6:09 PM (#2328).
+  if (!startTime) startTime = dateLineStart;
+  const endTime = dateLineEnd;
   // Clean description
   if (description) {
     description = description
@@ -145,6 +162,7 @@ export function parseTrailPageHtml(html: string): {
     title: rawTitle,
     date,
     startTime,
+    endTime,
     description,
     location: location && !isPlaceholder(location) ? location : undefined,
     locationUrl: location && !isPlaceholder(location) ? locationUrl : undefined,
@@ -290,12 +308,17 @@ export class SOH4Adapter implements SourceAdapter {
           if (title) {
             title = title.replace(/^Trail\s*#?\d+\s*[-–:]\s*/i, "").trim() || undefined;
           }
+          // An unannounced trail's heading is literally "Trail #NNN: TBD" — drop
+          // the placeholder so merge synthesizes "<Kennel> Trail #N" instead of
+          // storing "TBD" as the title (#2327).
+          if (title && isPlaceholder(title)) title = undefined;
 
-          // Build description with extra metadata
+          // Build description with extra prose metadata. Cost (Hash Cash) and the
+          // end time now live in their own Event columns (#2329), so they are no
+          // longer folded into the description text.
           const descParts: string[] = [];
           if (fields.description) descParts.push(fields.description);
           if (fields.theme) descParts.push(`Theme: ${fields.theme}`);
-          if (fields.hashCash) descParts.push(`Hash Cash: ${fields.hashCash}`);
           if (fields.onAfter) descParts.push(`On-After: ${fields.onAfter}`);
 
           const event: RawEventData = {
@@ -308,6 +331,8 @@ export class SOH4Adapter implements SourceAdapter {
             locationUrl: fields.locationUrl,
             hares: fields.hares,
             startTime: fields.startTime,
+            endTime: fields.endTime,
+            cost: fields.hashCash,
             sourceUrl: trailUrl,
           };
 

--- a/src/adapters/html-scraper/stlh3.test.ts
+++ b/src/adapters/html-scraper/stlh3.test.ts
@@ -102,6 +102,15 @@ describe("extractLocationFromMapsUrl", () => {
     const html = `<a href="javascript:share.google/x">Google Map</a>`;
     expect(findMapsLink(html)).toBeUndefined();
   });
+
+  it("rejects hosts where 'google' is not the registrable domain", () => {
+    // Subdomain-injection bypasses must NOT be treated as Google hosts.
+    expect(findMapsLink(`<a href="https://google.evil.com/maps/place/X/">m</a>`)).toBeUndefined();
+    expect(findMapsLink(`<a href="https://evil.google.attacker.com/maps">m</a>`)).toBeUndefined();
+    // Genuine Google hosts still pass.
+    expect(findMapsLink(`<a href="https://www.google.co.uk/maps/place/Big+Ben/">m</a>`)?.href)
+      .toContain("google.co.uk");
+  });
 });
 
 describe("cleanPostTitle (#808)", () => {

--- a/src/adapters/html-scraper/stlh3.test.ts
+++ b/src/adapters/html-scraper/stlh3.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseSubtitleTime,
   extractLocationFromMapsUrl,
+  findMapsLink,
   parseTitleDate,
   cleanPostTitle,
   StlH3Adapter,
@@ -73,6 +74,33 @@ describe("extractLocationFromMapsUrl", () => {
   it("returns undefined for short link text", () => {
     const html = `<a href="https://www.google.com/maps?q=x">Map</a>`;
     expect(extractLocationFromMapsUrl(html)).toBeUndefined();
+  });
+
+  it("extracts the address from a maps ?daddr= query (#2338)", () => {
+    const html = `<a href="http://google.com/maps?um=1&daddr=2200+W+Port+Plaza+Dr,+St.+Louis,+MO+63146">Google Map</a>`;
+    expect(extractLocationFromMapsUrl(html)).toBe(
+      "2200 W Port Plaza Dr, St. Louis, MO 63146",
+    );
+  });
+
+  it("returns undefined for a bare share.google shortlink (needs async resolve)", () => {
+    // No inline venue — the sync helper can't resolve the redirect, so the
+    // adapter's fetch() path handles it.
+    const html = `<a href="https://share.google/B9WpajhNuORHjuQ5L">Google Map</a>`;
+    expect(extractLocationFromMapsUrl(html)).toBeUndefined();
+  });
+
+  it("rejects a hostile href that only CONTAINS a maps host as a substring (Codex review)", () => {
+    // evil.example merely embeds "share.google" in a query param — must not be
+    // treated as a maps link, persisted, or followed.
+    const html = `<a href="https://evil.example/?next=share.google/foo">Google Map</a>`;
+    expect(findMapsLink(html)).toBeUndefined();
+    expect(extractLocationFromMapsUrl(html)).toBeUndefined();
+  });
+
+  it("rejects a non-http(s) maps-shaped href", () => {
+    const html = `<a href="javascript:share.google/x">Google Map</a>`;
+    expect(findMapsLink(html)).toBeUndefined();
   });
 });
 
@@ -238,6 +266,64 @@ describe("StlH3Adapter", () => {
     expect(result.events[0].startTime).toBe("14:00");
     expect(result.events[0].location).toBe("Tower Grove Park");
     // Should NOT have fetched detail since body_html was present
+    expect(safeFetchModule.safeFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves a share.google shortlink to recover the venue (#2338)", async () => {
+    const archiveResponse = {
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue([
+        {
+          title: "Upcumming Hash: Sunday Mar 22nd 2026",
+          subtitle: "Meet @ 5PM",
+          slug: "upcumming-hash-sunday-mar-22nd-2026",
+          post_date: "2026-03-21T10:00:00Z",
+          canonical_url: "https://www.stlh3.com/p/upcumming-hash-sunday-mar-22nd-2026",
+          body_html: '<a href="https://share.google/B9WpajhNuORHjuQ5L">Google Map</a>',
+        },
+      ]),
+    };
+    // The shortlink resolution call returns a response whose .url is the final
+    // google.com/search?q= destination.
+    const resolveResponse = {
+      ok: true,
+      status: 200,
+      url: "https://www.google.com/search?q=Whitecliff+Park&kgmid=/g/11g6q30mfm",
+    };
+
+    vi.mocked(safeFetchModule.safeFetch)
+      .mockResolvedValueOnce(archiveResponse as never)
+      .mockResolvedValueOnce(resolveResponse as never);
+
+    const result = await adapter.fetch(mockSource);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].location).toBe("Whitecliff Park");
+    expect(result.events[0].locationUrl).toBe("https://share.google/B9WpajhNuORHjuQ5L");
+  });
+
+  it("does not store or fetch a hostile body link as a location (Codex review)", async () => {
+    const archiveResponse = {
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue([
+        {
+          title: "Upcumming Hash: Sunday Mar 22nd 2026",
+          subtitle: "Meet @ 5PM",
+          slug: "evil",
+          post_date: "2026-03-21T10:00:00Z",
+          canonical_url: "https://www.stlh3.com/p/evil",
+          body_html: '<a href="https://evil.example/?next=share.google/foo">Google Map</a>',
+        },
+      ]),
+    };
+    vi.mocked(safeFetchModule.safeFetch).mockResolvedValueOnce(archiveResponse as never);
+
+    const result = await adapter.fetch(mockSource);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].location).toBeUndefined();
+    expect(result.events[0].locationUrl).toBeUndefined();
+    // Only the archive listing was fetched — no resolve fetch to evil.example.
     expect(safeFetchModule.safeFetch).toHaveBeenCalledTimes(1);
   });
 

--- a/src/adapters/html-scraper/stlh3.ts
+++ b/src/adapters/html-scraper/stlh3.ts
@@ -62,40 +62,151 @@ export function parseSubtitleTime(subtitle?: string | null): string {
   return `${hours.toString().padStart(2, "0")}:${minutes}`;
 }
 
+// Google-owned shortlink hosts whose venue can only be recovered by following
+// the redirect (#2338). `goo.gl`/`maps.app.goo.gl` are Maps short URLs;
+// `share.google` is Google's share shim that lands on a `google.*/search?q=`.
+const MAPS_SHORTLINK_HOSTS = new Set(["share.google", "goo.gl", "maps.app.goo.gl"]);
+// Any `google.<tld>` host (google.com, www.google.com, maps.google.com,
+// google.co.uk, …) — the direct `/maps/...` + resolved `/search?q=` surfaces.
+const GOOGLE_HOST_RE = /^(?:[a-z0-9-]+\.)*google(?:\.[a-z]{2,})+$/;
+const MAPS_DIR_RE = /\/maps\/dir\/\/([^/@?]+)/i;
+const MAPS_PLACE_RE = /\/maps\/place\/([^/@?]+)/i;
+// A coordinate-only / numeric query value ("38.6,-90.2") that is not a venue.
+const COORDS_ONLY_RE = /^[-\d.,\s]+$/;
+// Generic map anchor labels that carry no venue ("Google Map", "Directions").
+const GENERIC_MAP_LABEL_RE = /^(?:google\s*map|view\s*map|map|directions?|location)s?$/i;
+
 /**
- * Extract location from Google Maps URLs in body HTML.
+ * The validated lowercase hostname of an http(s) URL, or undefined when the
+ * href is unparseable / non-HTTP. Used to gate maps-link detection on the
+ * actual HOST rather than a substring match — a hostile body link like
+ * `https://evil.example/?next=share.google/x` must NOT be treated as a maps
+ * link, persisted as `locationUrl`, or followed as a shortlink (Codex review).
+ */
+function httpHost(href: string): string | undefined {
+  let u: URL;
+  try {
+    u = new URL(href);
+  } catch {
+    return undefined;
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") return undefined;
+  return u.hostname.toLowerCase();
+}
+
+/** A trustworthy Google Maps / share host (allowlisted by hostname). */
+function isMapsHost(href: string): boolean {
+  const host = httpHost(href);
+  if (!host) return false;
+  return MAPS_SHORTLINK_HOSTS.has(host) || GOOGLE_HOST_RE.test(host);
+}
+
+/** A Google shortlink host whose venue can only be recovered by following the redirect. */
+function isMapsShortlink(href: string): boolean {
+  const host = httpHost(href);
+  return host !== undefined && MAPS_SHORTLINK_HOSTS.has(host);
+}
+
+/** Decode a `+`-delimited Google Maps path/param segment to plain text. */
+function decodeMapsSegment(s: string): string {
+  try {
+    return decodeURIComponent(s.replace(/\+/g, " ")).trim();
+  } catch {
+    return s.replace(/\+/g, " ").trim();
+  }
+}
+
+/** Venue from the path forms `/maps/dir//VENUE` or `/maps/place/VENUE`. */
+function parseVenueFromMapsPath(url: string): string | undefined {
+  const dir = MAPS_DIR_RE.exec(url);
+  if (dir) return decodeMapsSegment(dir[1]);
+  const place = MAPS_PLACE_RE.exec(url);
+  if (place) return decodeMapsSegment(place[1]);
+  return undefined;
+}
+
+/** Venue from the query forms `?daddr=…`, `?q=…`, or `?destination=…`. */
+function parseVenueFromMapsQuery(url: string): string | undefined {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return undefined;
+  }
+  const raw =
+    u.searchParams.get("daddr") ??
+    u.searchParams.get("q") ??
+    u.searchParams.get("destination");
+  if (!raw) return undefined;
+  const v = decodeMapsSegment(raw);
+  // Reject coordinate-only or too-short values ("x", "38.6,-90.2").
+  if (v.length <= 3 || COORDS_ONLY_RE.test(v)) return undefined;
+  return v;
+}
+
+/** A descriptive anchor label, rejecting generic "Google Map" / "Directions" text. */
+function realLinkText(text: string): string | undefined {
+  const t = text.trim();
+  if (t.length <= 3) return undefined;
+  if (GENERIC_MAP_LABEL_RE.test(t)) return undefined;
+  return t;
+}
+
+/**
+ * The first anchor whose HOST is an allowlisted Google Maps / share host, with
+ * its href + visible text. Host-gated (not substring-matched) so untrusted post
+ * HTML can't smuggle a hostile href through a `share.google` query fragment.
+ */
+export function findMapsLink(bodyHtml: string): { href: string; text: string } | undefined {
+  const $ = cheerio.load(bodyHtml);
+  const a = $("a[href]")
+    .filter((_i, el) => isMapsHost($(el).attr("href") ?? ""))
+    .first();
+  if (!a.length) return undefined;
+  return { href: a.attr("href") ?? "", text: a.text().trim() };
+}
+
+/**
+ * Extract a venue/location string from the first Google-Maps link in body HTML.
  *
- * Pattern: google.com/maps/dir//VenueName+Address/@lat,lng
- * The part after /dir// and before /@ is the venue name/address (URL-encoded with +).
- *
- * Also matches: google.com/maps/place/VenueName+Address/
+ * Precedence: structured path (`/dir//`, `/place/`) → descriptive link text →
+ * query param (`daddr`/`q`/`destination`). Shortlinks (`share.google`,
+ * `goo.gl`, `maps.app.goo.gl`) carry no inline venue and need the async
+ * `fetch()` path's redirect resolution — this sync helper returns undefined for
+ * them (the adapter then resolves + re-parses). #2338.
  */
 export function extractLocationFromMapsUrl(
   bodyHtml: string,
 ): string | undefined {
-  const $ = cheerio.load(bodyHtml);
+  const link = findMapsLink(bodyHtml);
+  if (!link) return undefined;
+  return (
+    parseVenueFromMapsPath(link.href) ??
+    realLinkText(link.text) ??
+    parseVenueFromMapsQuery(link.href)
+  );
+}
 
-  // Find Google Maps links
-  const mapsLinks = $('a[href*="google.com/maps"]');
-  if (!mapsLinks.length) return undefined;
-
-  const href = mapsLinks.first().attr("href") ?? "";
-
-  // Pattern 1: /maps/dir//VenueName+Address/@lat,lng
-  const dirMatch = /\/maps\/dir\/\/([^/@]+)/i.exec(href);
-  if (dirMatch) {
-    return decodeURIComponent(dirMatch[1].replace(/\+/g, " ")).trim();
+/**
+ * Follow a Google Maps shortlink (share.google / goo.gl / maps.app.goo.gl) to
+ * its resolved destination URL. `safeFetch` follows redirects manually with
+ * per-hop SSRF re-validation; the final response's `.url` is the resolved
+ * target (e.g. `google.com/search?q=Whitecliff+Park`). Returns undefined on any
+ * failure so a dead shortlink never breaks the scrape.
+ */
+async function resolveMapsShortlink(url: string): Promise<string | undefined> {
+  try {
+    const res = await safeFetch(url, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+      },
+    });
+    const finalUrl = res.url;
+    return finalUrl && finalUrl !== url ? finalUrl : undefined;
+  } catch {
+    return undefined;
   }
-
-  // Pattern 2: /maps/place/VenueName+Address/
-  const placeMatch = /\/maps\/place\/([^/@]+)/i.exec(href);
-  if (placeMatch) {
-    return decodeURIComponent(placeMatch[1].replace(/\+/g, " ")).trim();
-  }
-
-  // Fallback: link text
-  const linkText = mapsLinks.first().text().trim();
-  return linkText && linkText.length > 3 ? linkText : undefined;
 }
 
 /**
@@ -261,8 +372,23 @@ export class StlH3Adapter implements SourceAdapter {
           }
         }
 
+        let locationUrl: string | undefined;
         if (bodyHtml) {
-          location = extractLocationFromMapsUrl(bodyHtml);
+          const link = findMapsLink(bodyHtml);
+          if (link) {
+            locationUrl = link.href;
+            location = parseVenueFromMapsPath(link.href);
+            // Shortlinks (share.google etc.) hide the venue behind a redirect —
+            // resolve once and re-parse the destination URL (#2338).
+            if (!location && isMapsShortlink(link.href)) {
+              const resolved = await resolveMapsShortlink(link.href);
+              if (resolved) {
+                location =
+                  parseVenueFromMapsPath(resolved) ?? parseVenueFromMapsQuery(resolved);
+              }
+            }
+            location ??= realLinkText(link.text) ?? parseVenueFromMapsQuery(link.href);
+          }
         }
 
         events.push({
@@ -270,6 +396,7 @@ export class StlH3Adapter implements SourceAdapter {
           kennelTags: ["stlh3"],
           title: cleanPostTitle(post.title),
           location,
+          locationUrl,
           startTime,
           sourceUrl: post.canonical_url || `${baseUrl}/p/${post.slug}`,
         });

--- a/src/adapters/html-scraper/stlh3.ts
+++ b/src/adapters/html-scraper/stlh3.ts
@@ -97,13 +97,13 @@ const COORDS_ONLY_RE = /^[-\d.,\s]+$/;
 const GENERIC_MAP_LABEL_RE = /^(?:google\s*map|view\s*map|map|directions?|location)s?$/i;
 
 /**
- * The validated lowercase hostname of an http(s) URL, or undefined when the
- * href is unparseable / non-HTTP. Used to gate maps-link detection on the
- * actual HOST rather than a substring match — a hostile body link like
- * `https://evil.example/?next=share.google/x` must NOT be treated as a maps
- * link, persisted as `locationUrl`, or followed as a shortlink (Codex review).
+ * The parsed http(s) URL, or undefined when unparseable / non-HTTP. Used to
+ * gate maps-link detection on the actual HOST (+ path) rather than a substring
+ * match — a hostile body link like `https://evil.example/?next=share.google/x`
+ * must NOT be treated as a maps link, persisted as `locationUrl`, or followed
+ * as a shortlink (Codex review).
  */
-function httpHost(href: string): string | undefined {
+function httpUrl(href: string): URL | undefined {
   let u: URL;
   try {
     u = new URL(href);
@@ -111,14 +111,33 @@ function httpHost(href: string): string | undefined {
     return undefined;
   }
   if (u.protocol !== "https:" && u.protocol !== "http:") return undefined;
-  return u.hostname.toLowerCase();
+  return u;
 }
 
-/** A trustworthy Google Maps / share host (allowlisted by hostname). */
+function httpHost(href: string): string | undefined {
+  return httpUrl(href)?.hostname.toLowerCase();
+}
+
+/**
+ * A trustworthy Google Maps / share link. Shortlink hosts (share.google etc.)
+ * pass on host alone (they're resolved later); direct Google hosts must ALSO
+ * point at a Maps/search SURFACE (`/maps…` or `/search?q=`), so a generic
+ * `google.com/<anything>` link can't be persisted as a location (CodeRabbit
+ * review). The same predicate re-validates a resolved shortlink before parsing.
+ */
 function isMapsHost(href: string): boolean {
-  const host = httpHost(href);
-  if (!host) return false;
-  return MAPS_SHORTLINK_HOSTS.has(host) || isGoogleHost(host);
+  const u = httpUrl(href);
+  if (!u) return false;
+  const host = u.hostname.toLowerCase();
+  if (MAPS_SHORTLINK_HOSTS.has(host)) return true;
+  if (!isGoogleHost(host)) return false;
+  const path = u.pathname.toLowerCase();
+  return (
+    host.startsWith("maps.google.") ||
+    path === "/maps" ||
+    path.startsWith("/maps/") ||
+    (path === "/search" && u.searchParams.has("q"))
+  );
 }
 
 /** A Google shortlink host whose venue can only be recovered by following the redirect. */
@@ -399,10 +418,11 @@ export class StlH3Adapter implements SourceAdapter {
             locationUrl = link.href;
             location = parseVenueFromMapsPath(link.href);
             // Shortlinks (share.google etc.) hide the venue behind a redirect —
-            // resolve once and re-parse the destination URL (#2338).
+            // resolve once, re-validate the destination is still a Maps/search
+            // surface, then parse it (#2338; CodeRabbit review).
             if (!location && isMapsShortlink(link.href)) {
               const resolved = await resolveMapsShortlink(link.href);
-              if (resolved) {
+              if (resolved && isMapsHost(resolved)) {
                 location =
                   parseVenueFromMapsPath(resolved) ?? parseVenueFromMapsQuery(resolved);
               }

--- a/src/adapters/html-scraper/stlh3.ts
+++ b/src/adapters/html-scraper/stlh3.ts
@@ -66,9 +66,29 @@ export function parseSubtitleTime(subtitle?: string | null): string {
 // the redirect (#2338). `goo.gl`/`maps.app.goo.gl` are Maps short URLs;
 // `share.google` is Google's share shim that lands on a `google.*/search?q=`.
 const MAPS_SHORTLINK_HOSTS = new Set(["share.google", "goo.gl", "maps.app.goo.gl"]);
-// Any `google.<tld>` host (google.com, www.google.com, maps.google.com,
-// google.co.uk, …) — the direct `/maps/...` + resolved `/search?q=` surfaces.
-const GOOGLE_HOST_RE = /^(?:[a-z0-9-]+\.)*google(?:\.[a-z]{2,})+$/;
+
+/**
+ * True when `host` is (a subdomain of) a Google registrable domain —
+ * `google.com`, `www.google.com`, `maps.google.com`, `google.co.uk`, etc.
+ * Label-based (not a regex) so it can't be ReDoS-flagged and, crucially, so
+ * "google" must be the registrable-domain label: `google.evil.com` and
+ * `evil.google.attacker.com` are correctly REJECTED (the substring/loose-regex
+ * forms would let them through — Codex/Codacy review).
+ */
+function isGoogleHost(host: string): boolean {
+  const labels = host.split(".");
+  const n = labels.length;
+  if (n < 2) return false;
+  // google.<tld>  /  *.google.<tld>   (google.com, www.google.com)
+  if (labels[n - 2] === "google") return true;
+  // google.<2-letter-sld>.<2-letter-cctld>  (google.co.uk, www.google.co.uk)
+  return (
+    n >= 3 &&
+    labels[n - 3] === "google" &&
+    labels[n - 1].length === 2 &&
+    labels[n - 2].length <= 3
+  );
+}
 const MAPS_DIR_RE = /\/maps\/dir\/\/([^/@?]+)/i;
 const MAPS_PLACE_RE = /\/maps\/place\/([^/@?]+)/i;
 // A coordinate-only / numeric query value ("38.6,-90.2") that is not a venue.
@@ -98,7 +118,7 @@ function httpHost(href: string): string | undefined {
 function isMapsHost(href: string): boolean {
   const host = httpHost(href);
   if (!host) return false;
-  return MAPS_SHORTLINK_HOSTS.has(host) || GOOGLE_HOST_RE.test(host);
+  return MAPS_SHORTLINK_HOSTS.has(host) || isGoogleHost(host);
 }
 
 /** A Google shortlink host whose venue can only be recovered by following the redirect. */

--- a/src/adapters/html-scraper/sumo-h3.test.ts
+++ b/src/adapters/html-scraper/sumo-h3.test.ts
@@ -173,6 +173,32 @@ describe("SumoH3Adapter", () => {
       expect(result).toBeNull();
     });
 
+    it("overrides the 2:00 pm default with a 'HH:MMstart' time in the description (#2379)", () => {
+      const cells = [
+        "1059(click here)",
+        "21 Jun ",
+        "Father's Day Special 11:00start!!",
+        "Okutama",
+        "JR Ome Line",
+        "Lost in Translation",
+      ];
+      const result = parseHarelineRow(cells, 1059, sourceUrl, ref);
+      expect(result?.startTime).toBe("11:00");
+    });
+
+    it("keeps the 2:00 pm default when no 'start'-anchored time is present", () => {
+      const cells = [
+        "1060(click here)",
+        "28 Jun ",
+        "Meet at gate 2 then run", // incidental number must NOT fire
+        "Tokyo",
+        "JR",
+        "Some Hare",
+      ];
+      const result = parseHarelineRow(cells, 1060, sourceUrl, ref);
+      expect(result?.startTime).toBe("14:00");
+    });
+
     it("returns null for fewer than 6 cells", () => {
       const result = parseHarelineRow(
         ["1038", "05 Apr"],

--- a/src/adapters/html-scraper/sumo-h3.ts
+++ b/src/adapters/html-scraper/sumo-h3.ts
@@ -29,6 +29,28 @@ import {
   isPlaceholder,
 } from "../utils";
 
+const DEFAULT_START_TIME = "14:00"; // Site default: "Sumo Hashers meet every Sunday at 2:00 pm"
+
+/**
+ * Recover a non-default start time when the event description tightly anchors a
+ * time to the word "start" — e.g. "11:00start!!", "10:30 start" (#2379). The
+ * "start" anchor (only `\s*` between it and the time, no am/pm) keeps this
+ * conservative: incidental numbers elsewhere in the prose never fire. Bare
+ * times are taken at face value (Sumo's early starts are morning times).
+ * Returns undefined when no anchored time is present, leaving the caller to use
+ * the 2:00 pm default.
+ */
+const SUMO_START_RE = /\b(\d{1,2}):(\d{2})\s*start\b/i;
+export function parseStartFromDescription(desc: string | undefined): string | undefined {
+  if (!desc) return undefined;
+  const m = SUMO_START_RE.exec(desc);
+  if (!m) return undefined;
+  const h = Number.parseInt(m[1], 10);
+  const min = Number.parseInt(m[2], 10);
+  if (h > 23 || min > 59) return undefined;
+  return `${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
+}
+
 /** Parse "DD Mon" into "YYYY-MM-DD" using current (or reference) year. */
 export function parseSumoDate(
   text: string,
@@ -92,6 +114,9 @@ export function parseHarelineRow(
   // Build description from event description field (if not placeholder)
   const description = isPlaceholderDesc ? undefined : descText;
 
+  // A description-embedded "HH:MMstart" overrides the 2:00 pm default (#2379).
+  const startTime = parseStartFromDescription(descText) ?? DEFAULT_START_TIME;
+
   return {
     date,
     kennelTags: ["sumo-h3"],
@@ -99,7 +124,7 @@ export function parseHarelineRow(
     runNumber,
     hares,
     location: station,
-    startTime: "14:00", // Default per site: "Sumo Hashers meet every Sunday at 2:00 pm"
+    startTime,
     sourceUrl,
     description,
   };

--- a/src/adapters/html-scraper/taipei-hash.test.ts
+++ b/src/adapters/html-scraper/taipei-hash.test.ts
@@ -127,12 +127,24 @@ describe("parseTaipeiHash", () => {
     expect(current.kennelTags).toEqual(["taipei-h3"]);
     expect(current.title).toBeUndefined(); // merge.ts synthesizes "Taipei H3 Trail #N"
     expect(current.hares).toBe("Engels Adolf Medina Ruiz 2nd Man In");
-    expect(current.location).toBe("猴硐 Houtong");
+    // Precise 集合地點 (meeting point) + English place, with the district in
+    // parens (#2399).
+    expect(current.location).toBe(
+      "猴硐里活動中心 Houtong Village Activity Center (猴硐 Houtong)",
+    );
     expect(current.locationUrl).toBe("https://maps.app.goo.gl/VtWk5MTYusyPA2P48");
     // No phone digits leak into any hare field.
     for (const e of events) {
       expect(e.hares ?? "").not.toMatch(/\d{6,}/);
     }
+  });
+
+  it("captures the 集合地點 meeting point even without an English Place span (#2399)", () => {
+    const $ = cheerio.load(FIXTURE);
+    const { events } = parseTaipeiHash($, "https://www.taipeihash.com.tw/run_site.php", REF);
+    const byRun = new Map(events.map((e) => [e.runNumber, e]));
+    // #2780: marks cell is just "集合地點：<a>📍大華農路六分福德宮</a>" (no Place span).
+    expect(byRun.get(2780)?.location).toBe("大華農路六分福德宮 (平溪 Pingxi)");
   });
 
   it("rejects a non-Maps / non-https locationUrl", () => {

--- a/src/adapters/html-scraper/taipei-hash.ts
+++ b/src/adapters/html-scraper/taipei-hash.ts
@@ -9,7 +9,7 @@ import type {
   ParseError,
 } from "../types";
 import { hasAnyErrors } from "../types";
-import { fetchHTMLPage, filterEventsByWindow, normalizeHaresField } from "../utils";
+import { fetchHTMLPage, filterEventsByWindow, normalizeHaresField, EMOJI_RE } from "../utils";
 
 // Taipei Hash House Harriers (台北捷兔) — Taiwan's oldest hash (founded 1973).
 // Static Cheerio scrape of the server-rendered PHP hareline at
@@ -33,6 +33,10 @@ const NOON_HOUR = 12;
 
 const DATE_RE = /(\d{1,2})\/(\d{1,2})/; // MM/DD — ignores any trailing event tag
 const RUN_RE = /(\d+)/;
+// 集合地點 (meeting-point) label + its English "Place：" counterpart, stripped
+// off the assembly-point anchor text (#2399).
+const MEETING_POINT_LABEL_RE = /^\s*集合地點\s*[:：]\s*/;
+const PLACE_LABEL_RE = /^\s*Place\s*[:：]\s*/i;
 // Strip a trailing phone number if the dedicated <span class="phone"> was absent
 // (markup-drift fallback). Single char class, bounded — ReDoS-safe.
 const PHONE_RE = /0\d[\d\s-]{6,15}/g;
@@ -111,6 +115,45 @@ function parseMapsUrl(marksCell: Cheerio<Element>): string | undefined {
   }
 }
 
+/**
+ * The specific meeting/assembly point (集合地點) from the 記號起點 cell (#2399).
+ * The cell carries the flour-start address AND a maps-linked assembly point —
+ * "集合地點： <a>📍萬壽橋 橋下休息區</a> <span class="english">Place：Wanshou
+ * Bridge Rest Area</span>" — which is where hashers actually gather and is more
+ * precise than the 地點/Run Site district. We return the anchor's Chinese text
+ * (📍 stripped) plus the trailing English "Place：…", matching the bilingual
+ * "中文 English" shape of the district cell.
+ */
+function parseMeetingPoint(marksCell: Cheerio<Element>): string | undefined {
+  const anchor = marksCell.find(MAPS_HREF).first();
+  if (anchor.length === 0) return undefined;
+  const zh = anchor
+    .text()
+    .replace(EMOJI_RE, " ")
+    .replace(MEETING_POINT_LABEL_RE, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  const enSpan = anchor.nextAll("span.english").first();
+  const en = enSpan.length > 0
+    ? enSpan.text().replace(PLACE_LABEL_RE, "").replace(/\s+/g, " ").trim()
+    : "";
+  const combined = [zh, en].filter(Boolean).join(" ").trim();
+  return combined.length >= 2 ? combined : undefined;
+}
+
+/**
+ * Combine the precise meeting point with the district context. When both are
+ * present: "<meeting point> (<district>)". Falls back to whichever exists
+ * (district-only is the pre-#2399 behavior when no assembly link is published).
+ */
+function buildLocation(
+  district: string | undefined,
+  meetingPoint: string | undefined,
+): string | undefined {
+  if (meetingPoint && district) return `${meetingPoint} (${district})`;
+  return meetingPoint ?? district;
+}
+
 /** Round-trip-validated UTC-noon ms for a given year, or null if impossible. */
 function utcNoonMs(year: number, month: number, day: number): number | null {
   const ms = Date.UTC(year, month - 1, day, NOON_HOUR, 0, 0);
@@ -177,7 +220,9 @@ function parseRows(
           runNumber,
           startTime: START_TIME,
           hares: parseHares(tds.eq(2)),
-          location: cellText(tds.eq(3)) || undefined,
+          // Prefer the precise 集合地點 (meeting point) from the marks cell;
+          // keep the 地點/Run Site district as parenthetical context (#2399).
+          location: buildLocation(cellText(tds.eq(3)) || undefined, parseMeetingPoint(tds.eq(4))),
           locationUrl: parseMapsUrl(tds.eq(4)),
           sourceUrl,
         },


### PR DESCRIPTION
## What

Post-merge prod verification of #2450 surfaced a regression in the Desert H3 detail-page enrichment. The MEC detail body is free-form prose, and the `coords present → first body paragraph is the venue` heuristic mis-stored non-venue lead lines as `locationName`. A prod scan found two failure modes across ~17 events:

- **Bogus venues**: decorative titles/themes and notes stored as the venue — e.g. `"DH3 Run #2452 – Desert Shenanigans 🏜️🍻"`, `"The Qudra Lake Trail & BBQ – Sunday 19 April …"`, `"Note: This is a Sunday run …"`.
- **Real venues dropped**: verbose but explicitly-labelled venues — `"Location: Meet in Car Park P5 …"`, `"Location is Rocks Villa, Dubai Internet City …"`.

## Fix

Resolve the venue most-reliable-first:
1. An explicit **`Location:` / `Location is`** labelled line anywhere in the body → captured verbatim (no length cap).
2. Else the **lead line** only when coords are present *and* it `looksLikeVenue` — now rejecting run-number/`DH3` titles, embedded dates, `Note:`/`Promises:`/`Join`/`Come`/`This Sunday` prose prefixes, and >60-char lines.

When neither yields a venue, the location is left to the maps link + coordinates and the lines stay in the `description`.

## Verification

- `tsc` ✅ · `lint` ✅ (0 errors) · desert suite ✅ (32 tests).
- Live-verified against production detail pages:
  - `#2434` → "Park anywhere at the front of the Trade Centre Apartments…" (labelled venue kept)
  - `#2430` → "Rocks Villa, Dubai Internet City…" (labelled venue kept)
  - `#2452` (title), `#2447` (dated theme), `#2449` ("Note: …") → no bogus venue, map pin retained via `locationUrl`
  - `#2456` → "Goose Island Tap House, JVC" (clean venue kept)

Once merged, a Desert re-scrape clears the ~17 stale `locationName` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)