### PR TITLE
fix(adapters): post-merge review follow-ups (desert venue, stlh3 res.ok, sumo PM)

### DIFF
--- a/src/adapters/html-scraper/desert-hash.test.ts
+++ b/src/adapters/html-scraper/desert-hash.test.ts
@@ -352,10 +352,13 @@ describe("parseDetailPage", () => {
     expect(d.location).toBe("10 Market Street, Junction Mall, JVC");
   });
 
-  it("captures an explicit 'Location:'-labelled venue even when verbose, skipping the Note line", () => {
+  it("captures an explicit 'Location:'-labelled venue (verbose) without repeating it in the description", () => {
     const d = parseDetailPage(DETAIL_LABELLED);
     expect(d.location).toBe("Meet in Car Park P5 at the back of the Trade Centre building, Dubai");
     expect(d.hares).toBe("Just Balls");
+    // The labelled line is spliced out of the body, so it isn't duplicated.
+    expect(d.description ?? "").not.toContain("Car Park P5");
+    expect(d.description).toContain("Sunday run"); // the Note line remains
   });
 
   it("treats a coord-less body as free-form notes (no venue) and never reads the phone", () => {

--- a/src/adapters/html-scraper/desert-hash.test.ts
+++ b/src/adapters/html-scraper/desert-hash.test.ts
@@ -121,6 +121,36 @@ const DETAIL_NOTES = detailPage({
     <p><a href="https://www.deserthash.org/wp-content/uploads/2025/09/alqudracycle.jpeg"><img src="x" alt="" /></a></p>`,
 });
 
+// 2452-style: coords present BUT the body leads with a decorative title/theme
+// line (not a venue) — the lead line must NOT be taken as the location.
+const DETAIL_TITLE_LED = detailPage({
+  hares: ["Slow Crack Whore"],
+  lat: "25.106101",
+  lng: "55.300000",
+  bodyHtml: `<p>DH3 Run #2452 – Desert Shenanigans 🏜️🍻</p>
+    <p>This Sunday from the Truck Stop on Emirates Rd into the half desert.</p>
+    <p><a href="https://maps.app.goo.gl/n3E9JHNFbHn29JBP8">Google Maps Link</a></p>`,
+});
+
+// A verbose but explicitly-labelled venue ("Location: …") must be captured even
+// though it exceeds the bare-line length guard.
+const DETAIL_LABELLED = detailPage({
+  hares: ["Just Balls"],
+  bodyHtml: `<p>Note: This is a Sunday run, there will be no hash on the Monday.</p>
+    <p>Location: Meet in Car Park P5 at the back of the Trade Centre building, Dubai</p>
+    <p><a href="https://maps.app.goo.gl/abc123">Google Maps Link</a></p>`,
+});
+
+// A real venue whose words start with a 3-letter month prefix ("Market" → mar,
+// "Junction" → jun) must NOT be rejected as a date by the lead-line guard.
+const DETAIL_MONTHISH_VENUE = detailPage({
+  hares: ["Just Balls"],
+  lat: "25.1",
+  lng: "55.2",
+  bodyHtml: `<p>10 Market Street, Junction Mall, JVC</p>
+    <p><a href="https://maps.app.goo.gl/zzz">Google Map Link</a></p>`,
+});
+
 /** Route base→home, page_id=5152→hareline, and any `mec-events=<slug>`→detail HTML. */
 function mockSurfacesWithDetails(homeHtml: string, hareHtml: string, details: Record<string, string>) {
   mockedSafeFetch.mockImplementation((url: string) => {
@@ -304,6 +334,28 @@ describe("parseDetailPage", () => {
     expect(d.longitude).toBeCloseTo(55.20726);
     // Venue-only body → no leftover notes.
     expect(d.description).toBeUndefined();
+  });
+
+  it("does NOT take a title/theme-led body line as the venue, even with coords present", () => {
+    const d = parseDetailPage(DETAIL_TITLE_LED);
+    expect(d.hares).toBe("Slow Crack Whore");
+    expect(d.latitude).toBeCloseTo(25.106101);
+    // The lead "DH3 Run #2452 – Desert Shenanigans 🏜️🍻" is a title, not a venue.
+    expect(d.location).toBeUndefined();
+    expect(d.locationUrl).toContain("maps.app.goo.gl"); // map pin still captured
+    expect(d.description).toContain("Desert Shenanigans");
+    expect(d.description).toContain("Truck Stop on Emirates Rd");
+  });
+
+  it("does not reject a venue whose words start with a month prefix (Market/Junction)", () => {
+    const d = parseDetailPage(DETAIL_MONTHISH_VENUE);
+    expect(d.location).toBe("10 Market Street, Junction Mall, JVC");
+  });
+
+  it("captures an explicit 'Location:'-labelled venue even when verbose, skipping the Note line", () => {
+    const d = parseDetailPage(DETAIL_LABELLED);
+    expect(d.location).toBe("Meet in Car Park P5 at the back of the Trade Centre building, Dubai");
+    expect(d.hares).toBe("Just Balls");
   });
 
   it("treats a coord-less body as free-form notes (no venue) and never reads the phone", () => {

--- a/src/adapters/html-scraper/desert-hash.ts
+++ b/src/adapters/html-scraper/desert-hash.ts
@@ -303,24 +303,40 @@ const VENUE_LABEL_RE = /^location\s*(?:is|:)\s*(.+)/i;
 // when it reads like one: short, not a notes/blurb prefix, with no run-number /
 // "DH3" title marker and no embedded calendar date (those signal a decorative
 // title or dated prose, not a gathering spot).
-const VENUE_TITLE_MARKER_RE = /\bDH3\b|\bRun\s*#?\s*\d/i;
-// "<day> <month>" — month bounded by `\b` + full-name suffixes so a venue like
-// "10 Market Street" / "4 Junction Road" isn't misread as a date (Gemini review).
-const VENUE_DATE_MARKER_RE =
-  /\b\d{1,2}\s+(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sept?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b/i;
+const VENUE_TITLE_MARKER_RE = /\bDH3\b|\bRun\s*(?:#\s*)?\d/i;
 const NON_VENUE_PREFIX_RE = /^(?:note|promises?|this\s+sunday|join|come)\b/i;
-function looksLikeVenue(line: string): boolean {
-  if (line.length > 60 || NON_VENUE_PREFIX_RE.test(line)) return false;
-  return !VENUE_TITLE_MARKER_RE.test(line) && !VENUE_DATE_MARKER_RE.test(line);
+
+// Month names (abbrev + full) as a Set, matched against the word that follows a
+// "<day>" number via a SIMPLE regex. This is far under SonarCloud's regex
+// complexity budget (S5843) vs a 12-way alternation with optional suffixes, and
+// still avoids the "10 Market Street" false positive (Market ∉ MONTH_WORDS) —
+// see memory feedback_codacy_non_literal_regexp / Set-over-complex-regex.
+const MONTH_WORDS = new Set([
+  "jan", "january", "feb", "february", "mar", "march", "apr", "april",
+  "may", "jun", "june", "jul", "july", "aug", "august",
+  "sep", "sept", "september", "oct", "october", "nov", "november", "dec", "december",
+]);
+const DAY_NUMBER_WORD_RE = /\b\d{1,2}\s+([a-z]+)/gi;
+/** True when the line embeds a "<day> <month>" calendar date (a dated blurb, not a venue). */
+function hasEmbeddedDate(line: string): boolean {
+  for (const m of line.matchAll(DAY_NUMBER_WORD_RE)) {
+    if (MONTH_WORDS.has(m[1].toLowerCase())) return true;
+  }
+  return false;
 }
 
-/** A "Location: <venue>"-labelled line's venue text, if any paragraph carries one. */
-function labelledVenue(paras: string[]): string | undefined {
-  for (const p of paras) {
-    const m = VENUE_LABEL_RE.exec(p);
+function looksLikeVenue(line: string): boolean {
+  if (line.length > 60 || NON_VENUE_PREFIX_RE.test(line)) return false;
+  return !VENUE_TITLE_MARKER_RE.test(line) && !hasEmbeddedDate(line);
+}
+
+/** A "Location: <venue>"-labelled line's venue text + its index, if any. */
+function findLabelledVenue(paras: string[]): { venue: string; index: number } | undefined {
+  for (let i = 0; i < paras.length; i++) {
+    const m = VENUE_LABEL_RE.exec(paras[i]);
     if (m) {
       const v = m[1].trim();
-      if (v) return v;
+      if (v) return { venue: v, index: i };
     }
   }
   return undefined;
@@ -403,9 +419,10 @@ export function parseDetailPage(html: string): DesertDetail {
     // Shenanigans 🏜️🍻"), a dated blurb, or a "Note: …" — treating those as the
     // location is worse than leaving it to the maps link + coords. When neither
     // path yields a venue the lines stay in the description.
-    const labelled = labelledVenue(contentParas);
+    const labelled = findLabelledVenue(contentParas);
     if (labelled) {
-      detail.location = labelled;
+      detail.location = labelled.venue;
+      contentParas.splice(labelled.index, 1); // don't repeat the venue line in the description
     } else if (coords.latitude != null && contentParas.length > 0 && looksLikeVenue(contentParas[0])) {
       detail.location = contentParas.shift();
     }

--- a/src/adapters/html-scraper/desert-hash.ts
+++ b/src/adapters/html-scraper/desert-hash.ts
@@ -294,6 +294,38 @@ function collapseWs(s: string): string {
   return s.replace(/\s+/g, " ").trim();
 }
 
+// An explicitly-labelled venue line ("Location: …" / "Location is …") is the
+// most reliable signal — the text after the label IS the gathering spot, even
+// when it's verbose. Captured ahead of the first-line heuristic below.
+const VENUE_LABEL_RE = /^location\s*(?:is|:)\s*(.+)/i;
+
+// When there's no label, the lead description line is only trusted as the venue
+// when it reads like one: short, not a notes/blurb prefix, with no run-number /
+// "DH3" title marker and no embedded calendar date (those signal a decorative
+// title or dated prose, not a gathering spot).
+const VENUE_TITLE_MARKER_RE = /\bDH3\b|\bRun\s*#?\s*\d/i;
+// "<day> <month>" — month bounded by `\b` + full-name suffixes so a venue like
+// "10 Market Street" / "4 Junction Road" isn't misread as a date (Gemini review).
+const VENUE_DATE_MARKER_RE =
+  /\b\d{1,2}\s+(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sept?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b/i;
+const NON_VENUE_PREFIX_RE = /^(?:note|promises?|this\s+sunday|join|come)\b/i;
+function looksLikeVenue(line: string): boolean {
+  if (line.length > 60 || NON_VENUE_PREFIX_RE.test(line)) return false;
+  return !VENUE_TITLE_MARKER_RE.test(line) && !VENUE_DATE_MARKER_RE.test(line);
+}
+
+/** A "Location: <venue>"-labelled line's venue text, if any paragraph carries one. */
+function labelledVenue(paras: string[]): string | undefined {
+  for (const p of paras) {
+    const m = VENUE_LABEL_RE.exec(p);
+    if (m) {
+      const v = m[1].trim();
+      if (v) return v;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Extract the event's coordinates from the gmap widget's `mecGoogleMaps({…})`
  * init block. Returns {} when either component is missing/non-finite, or when
@@ -364,8 +396,17 @@ export function parseDetailPage(html: string): DesertDetail {
       if ($maps.length > 0 && text === collapseWs($maps.text())) return;
       contentParas.push(text);
     });
-    // First body line is the venue only when MEC supplied structured coords.
-    if (coords.latitude != null && contentParas.length > 0) {
+    // Venue resolution, most-reliable first:
+    //  1. an explicit "Location: …" label anywhere in the body, else
+    //  2. the lead line when coords are present AND it looks like a venue.
+    // Some runs lead with a decorative TITLE/theme ("DH3 Run #2452 – Desert
+    // Shenanigans 🏜️🍻"), a dated blurb, or a "Note: …" — treating those as the
+    // location is worse than leaving it to the maps link + coords. When neither
+    // path yields a venue the lines stay in the description.
+    const labelled = labelledVenue(contentParas);
+    if (labelled) {
+      detail.location = labelled;
+    } else if (coords.latitude != null && contentParas.length > 0 && looksLikeVenue(contentParas[0])) {
       detail.location = contentParas.shift();
     }
     const body = contentParas.join("\n").trim();

--- a/src/adapters/html-scraper/stlh3.test.ts
+++ b/src/adapters/html-scraper/stlh3.test.ts
@@ -311,6 +311,33 @@ describe("StlH3Adapter", () => {
     expect(result.events[0].locationUrl).toBe("https://share.google/B9WpajhNuORHjuQ5L");
   });
 
+  it("ignores a shortlink resolution that returns a non-2xx response (Gemini review)", async () => {
+    const archiveResponse = {
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue([
+        {
+          title: "Upcumming Hash: Sunday Mar 22nd 2026",
+          subtitle: "Meet @ 5PM",
+          slug: "dead-link",
+          post_date: "2026-03-21T10:00:00Z",
+          canonical_url: "https://www.stlh3.com/p/dead-link",
+          body_html: '<a href="https://share.google/DeadLink">Google Map</a>',
+        },
+      ]),
+    };
+    // Dead shortlink → 404 whose .url is an error page; must not become a location.
+    const resolveResponse = { ok: false, status: 404, url: "https://share.google/error" };
+    vi.mocked(safeFetchModule.safeFetch)
+      .mockResolvedValueOnce(archiveResponse as never)
+      .mockResolvedValueOnce(resolveResponse as never);
+
+    const result = await adapter.fetch(mockSource);
+    expect(result.events[0].location).toBeUndefined();
+    // The (validated) shortlink href is still stored as the clickable map URL.
+    expect(result.events[0].locationUrl).toBe("https://share.google/DeadLink");
+  });
+
   it("does not store or fetch a hostile body link as a location (Codex review)", async () => {
     const archiveResponse = {
       ok: true,

--- a/src/adapters/html-scraper/stlh3.ts
+++ b/src/adapters/html-scraper/stlh3.ts
@@ -241,6 +241,9 @@ async function resolveMapsShortlink(url: string): Promise<string | undefined> {
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
       },
     });
+    // A failed redirect (404/503) can still expose an error-page `.url`; only
+    // trust the resolved URL on a 2xx (Gemini review).
+    if (!res.ok) return undefined;
     const finalUrl = res.url;
     return finalUrl && finalUrl !== url ? finalUrl : undefined;
   } catch {

--- a/src/adapters/html-scraper/sumo-h3.test.ts
+++ b/src/adapters/html-scraper/sumo-h3.test.ts
@@ -183,7 +183,20 @@ describe("SumoH3Adapter", () => {
         "Lost in Translation",
       ];
       const result = parseHarelineRow(cells, 1059, sourceUrl, ref);
-      expect(result?.startTime).toBe("11:00");
+      expect(result?.startTime).toBe("11:00"); // 11 stays AM (morning special)
+    });
+
+    it("treats a 1–6 'HH:MMstart' as PM for the afternoon hash (12-hour fallback)", () => {
+      const cells = [
+        "1061(click here)",
+        "5 Jul ",
+        "Special early 2:00start", // afternoon → 14:00, not 02:00
+        "Okutama",
+        "JR Ome Line",
+        "Some Hare",
+      ];
+      const result = parseHarelineRow(cells, 1061, sourceUrl, ref);
+      expect(result?.startTime).toBe("14:00");
     });
 
     it("keeps the 2:00 pm default when no 'start'-anchored time is present", () => {

--- a/src/adapters/html-scraper/sumo-h3.ts
+++ b/src/adapters/html-scraper/sumo-h3.ts
@@ -35,8 +35,11 @@ const DEFAULT_START_TIME = "14:00"; // Site default: "Sumo Hashers meet every Su
  * Recover a non-default start time when the event description tightly anchors a
  * time to the word "start" — e.g. "11:00start!!", "10:30 start" (#2379). The
  * "start" anchor (only `\s*` between it and the time, no am/pm) keeps this
- * conservative: incidental numbers elsewhere in the prose never fire. Bare
- * times are taken at face value (Sumo's early starts are morning times).
+ * conservative: incidental numbers elsewhere in the prose never fire.
+ *
+ * These are bare 12-hour clock times. Sumo is an afternoon hash (2:00 pm
+ * default), so an hour of 1–6 means PM (a "2:00start" is 14:00, not 02:00),
+ * while 7–12 stay as written (morning specials / noon) — Gemini review.
  * Returns undefined when no anchored time is present, leaving the caller to use
  * the 2:00 pm default.
  */
@@ -45,9 +48,10 @@ export function parseStartFromDescription(desc: string | undefined): string | un
   if (!desc) return undefined;
   const m = SUMO_START_RE.exec(desc);
   if (!m) return undefined;
-  const h = Number.parseInt(m[1], 10);
+  let h = Number.parseInt(m[1], 10);
   const min = Number.parseInt(m[2], 10);
   if (h > 23 || min > 59) return undefined;
+  if (h >= 1 && h <= 6) h += 12; // afternoon-hash 12-hour fallback
   return `${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
 }
 


### PR DESCRIPTION
Follow-ups to #2450 surfaced during post-merge **prod verification** + Gemini review. (Replaces #2459, which had a stale base that re-showed the whole #2450 diff and conflicted.)

## desert-hash — detail-page venue heuristic
Prod verification of #2450 found the `coords → first body line is the venue` rule storing non-venue lead lines as `locationName` (titles like `"DH3 Run #2452 – Desert Shenanigans 🏜️🍻"`, `"Note: …"`) while dropping verbose-but-real `Location:`-labelled venues.

- Prefer an explicit **`Location:` / `Location is`** labelled line (verbatim, no length cap); else the lead line only when coords are present **and** it `looksLikeVenue`.
- `looksLikeVenue` rejects DH3/run-number titles, embedded calendar dates, note/blurb prefixes (`Note`/`Promises`/`Join`/`Come`/`This Sunday`), and >60-char prose.
- **Gemini:** the date marker now bounds the month with `\b` + full-name suffixes, so a venue like `"10 Market Street"` / `"4 Junction Road"` is **not** misread as a date.

## stlh3 (Gemini)
`resolveMapsShortlink` returns `undefined` on a non-2xx response (a 404/503 error-page `.url` must not become a location).

## sumo-h3 (Gemini)
`parseStartFromDescription` treats a 1–6 `"HH:MMstart"` as PM for the afternoon hash: `"2:00start"` → `14:00`; 7–12 stay as written; `"11:00start"` (#2379) unchanged.

## Verification
- `tsc` ✅ · `lint` ✅ (0 errors) · desert/stlh3/sumo suites ✅ (88 tests).
- Live-verified against production Desert detail pages: `#2434`/`#2430` keep their labelled venues; `#2452`/`#2447` (title/dated) and `#2449` (`Note:`) yield no bogus venue (map pin retained via `locationUrl`); `#2456` "Goose Island Tap House, JVC" kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)