### PR TITLE
feat(backfill): WS4 historical backfills — Colombo, Tidewater, HC (Tokyo/Taiwan/SG), SFH3 archive, Sumo

### DIFF
--- a/scripts/backfill-colombo-harriettes-history.ts
+++ b/scripts/backfill-colombo-harriettes-history.ts
@@ -1,88 +1,110 @@
 /**
- * One-shot backfill for Colombo Harriettes (colombo-harriettes) Run #2223.
+ * One-shot historical backfill for Colombo Harriettes (colombo-harriettes).
  *
- * The Colombo Harriettes site (hashcolombo.com) SSRs a single "Next run" block
- * and keeps no on-site archive, so the recurring ColomboHarriettesAdapter only
- * ever sees the current run. At onboarding the site was in its between-postings
- * placeholder state ("We will announce soon"), so the kennel page would be empty
- * until the committee posts the next Saturday and the first scrape after that
- * picks it up.
+ * The recurring ColomboHarriettesAdapter scrapes hashcolombo.com, which SSRs
+ * only the single current "Next run" block — so the live scrape can never see
+ * the kennel's back-catalogue (HashTracks held just Run #2223). The site's
+ * backing API, however, exposes the FULL run archive with structured fields:
  *
- * This script seeds the one concrete recent run documented during onboarding —
- * Run #2223 (Sat 2026-06-20, KK's Crib, Ratmalana, 17:00) — so the page shows a
- * real run immediately. It is a PAST event, which is safe: the source carries
- * `config.upcomingOnly: true`, so reconcile clamps its cancellation window to
- * the future and never cancels this row. `title` is left undefined → merge
- * synthesizes "Colombo Harriettes Trail #2223". Coordinates are left to the
- * merge pipeline's geocoder (the documented sample's map embed coords weren't
- * captured; the street address resolves Ratmalana).
+ *   GET https://api2.hashcolombo.com/noauth/runs
+ *     → JSON array, run-level fields: run_number, run_date (YYYY-MM-DD),
+ *       starting_time (HH:MM, varies per run), run_name (theme, often empty),
+ *       run_site_name (venue), address (street), plus member/participant/income
+ *       arrays that are PII and are deliberately NOT read here.
  *
- * Calls `processRawEvents` inline (like backfill-chain-gang-trail-40.ts) so the
- * RawEvent is promoted to a canonical Event now; it dedups by fingerprint, so
- * re-running is safe.
+ * As of the audit (#2285) the feed carried 125 runs (#2099 → #2223, spanning
+ * 2023 → 2026-06-20). This script pulls them all and routes the past slice
+ * through the merge pipeline so canonical Events are created inline.
+ *
+ * Field mapping mirrors the live adapter's conventions:
+ *   - title  = run_name when present, else undefined → merge synthesizes
+ *     "Colombo Harriettes Trail #N" (the feed has no hares field).
+ *   - location = run_site_name (venue), locationStreet = address.
+ *   - startTime kept verbatim per row (the feed stores 24h HH:MM; quirky values
+ *     like a 05:00 entry are preserved faithfully, not "corrected").
+ *
+ * Safe + re-runnable: the source carries `config.upcomingOnly: true`, so
+ * reconcile clamps its cancellation window to the future and never cancels
+ * these past rows; `reportAndApplyBackfill` only loads `date < today` and
+ * `processRawEvents` dedupes by fingerprint, so re-running is a no-op.
  *
  * Usage:
  *   Dry run: npx tsx scripts/backfill-colombo-harriettes-history.ts
  *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-colombo-harriettes-history.ts
+ *
+ * Requires the "Colombo Harriettes Website" source to exist (run `prisma db seed`).
  */
 
 import "dotenv/config";
-import { prisma } from "@/lib/db";
-import { processRawEvents } from "@/pipeline/merge";
+import { runBackfillScript } from "./lib/backfill-runner";
 import type { RawEventData } from "@/adapters/types";
 
 const SOURCE_NAME = "Colombo Harriettes Website";
+const KENNEL_TIMEZONE = "Asia/Colombo";
+const KENNEL_TAG = "colombo-harriettes";
+const API_URL = "https://api2.hashcolombo.com/noauth/runs";
 
-const HISTORY: RawEventData[] = [
-  {
-    date: "2026-06-20", // Saturday
-    kennelTags: ["colombo-harriettes"],
-    runNumber: 2223,
-    // title undefined → merge synthesizes "Colombo Harriettes Trail #2223".
-    startTime: "17:00",
-    location: "KK's Crib",
-    locationStreet: "No.5, 1st Cross Street, Kandawala Road, Ratmalana",
-    sourceUrl: "https://hashcolombo.com/",
-  },
-];
-
-async function main() {
-  const apply = process.env.BACKFILL_APPLY === "1";
-  console.log(`Mode: ${apply ? "APPLY (will write to DB)" : "DRY RUN (no writes)"}`);
-
-  for (const ev of HISTORY) {
-    console.log(`  ${ev.date} #${ev.runNumber} | ${ev.location} | start=${ev.startTime}`);
-  }
-
-  if (!apply) {
-    console.log("\nDry run complete. Re-run with BACKFILL_APPLY=1 to write to DB.");
-    return;
-  }
-
-  try {
-    const sources = await prisma.source.findMany({
-      where: { name: SOURCE_NAME },
-      select: { id: true },
-    });
-    if (sources.length === 0) throw new Error(`Source "${SOURCE_NAME}" not found in DB. Run prisma db seed first.`);
-    if (sources.length > 1) {
-      throw new Error(`Multiple sources named "${SOURCE_NAME}" found (${sources.length}). Aborting.`);
-    }
-
-    console.log("\nDelegating to merge pipeline...");
-    const merge = await processRawEvents(sources[0].id, HISTORY);
-    console.log(
-      `Done. created=${merge.created} updated=${merge.updated} skipped=${merge.skipped} ` +
-        `unmatched=${merge.unmatched.length} blocked=${merge.blocked} errors=${merge.eventErrors}`,
-    );
-    if (merge.unmatched.length > 0) console.log(`  Unmatched tags: ${merge.unmatched.join(", ")}`);
-    if (merge.blocked > 0) console.log(`  Blocked tags: ${merge.blockedTags.join(", ")}`);
-  } finally {
-    await prisma.$disconnect();
-  }
+/** Run-level fields read from the noauth/runs feed. Participant/member/income
+ * arrays exist on each row but are PII and intentionally omitted. */
+interface ColomboRun {
+  run_number?: number;
+  run_date?: string; // "YYYY-MM-DD"
+  starting_time?: string; // "HH:MM"
+  run_name?: string; // theme / event name (often empty)
+  run_site_name?: string; // venue name
+  address?: string; // street address
 }
 
-main().catch((err) => {
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_RE = /^\d{1,2}:\d{2}$/;
+
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const res = await fetch(API_URL, {
+    headers: { "User-Agent": "Mozilla/5.0 (HashTracks historical backfill)" },
+  });
+  if (!res.ok) throw new Error(`Colombo API returned HTTP ${res.status}`);
+  const data: unknown = await res.json();
+  if (!Array.isArray(data)) {
+    throw new Error("Colombo API: expected a JSON array of runs");
+  }
+
+  const events: RawEventData[] = [];
+  for (const row of data as ColomboRun[]) {
+    const date = clean(row.run_date);
+    if (!date || !DATE_RE.test(date)) continue;
+    if (typeof row.run_number !== "number" || row.run_number <= 0) continue;
+
+    const startTimeRaw = clean(row.starting_time);
+    const startTime = startTimeRaw && TIME_RE.test(startTimeRaw) ? startTimeRaw : undefined;
+
+    events.push({
+      date,
+      kennelTags: [KENNEL_TAG],
+      runNumber: row.run_number,
+      // run_name → title when present; otherwise merge synthesizes the default.
+      title: clean(row.run_name),
+      startTime,
+      location: clean(row.run_site_name),
+      locationStreet: clean(row.address),
+      sourceUrl: "https://hashcolombo.com/",
+    });
+  }
+
+  events.sort((a, b) => a.date.localeCompare(b.date));
+  return events;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Fetching Colombo Harriettes full run archive (api2.hashcolombo.com/noauth/runs)",
+  fetchEvents,
+}).catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/scripts/backfill-colombo-harriettes-history.ts
+++ b/scripts/backfill-colombo-harriettes-history.ts
@@ -71,8 +71,7 @@ function normalizeTime(raw: string | undefined): string | undefined {
 }
 
 function clean(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
+  return value?.trim() || undefined;
 }
 
 async function fetchEvents(): Promise<RawEventData[]> {
@@ -82,7 +81,7 @@ async function fetchEvents(): Promise<RawEventData[]> {
   if (!res.ok) throw new Error(`Colombo API returned HTTP ${res.status}`);
   const data: unknown = await res.json();
   if (!Array.isArray(data)) {
-    throw new Error("Colombo API: expected a JSON array of runs");
+    throw new TypeError("Colombo API: expected a JSON array of runs");
   }
 
   const events: RawEventData[] = [];

--- a/scripts/backfill-colombo-harriettes-history.ts
+++ b/scripts/backfill-colombo-harriettes-history.ts
@@ -37,6 +37,7 @@
 
 import "dotenv/config";
 import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
 import type { RawEventData } from "@/adapters/types";
 
 const SOURCE_NAME = "Colombo Harriettes Website";
@@ -64,7 +65,7 @@ function clean(value: string | undefined): string | undefined {
 }
 
 async function fetchEvents(): Promise<RawEventData[]> {
-  const res = await fetch(API_URL, {
+  const res = await safeFetch(API_URL, {
     headers: { "User-Agent": "Mozilla/5.0 (HashTracks historical backfill)" },
   });
   if (!res.ok) throw new Error(`Colombo API returned HTTP ${res.status}`);
@@ -77,10 +78,13 @@ async function fetchEvents(): Promise<RawEventData[]> {
   for (const row of data as ColomboRun[]) {
     const date = clean(row.run_date);
     if (!date || !DATE_RE.test(date)) continue;
-    if (typeof row.run_number !== "number" || row.run_number <= 0) continue;
+    // Number.isInteger guards the integer runNumber column against NaN/float.
+    if (!Number.isInteger(row.run_number) || (row.run_number as number) <= 0) continue;
 
+    // Pad single-digit hours so startTime is always zero-padded "HH:MM".
     const startTimeRaw = clean(row.starting_time);
-    const startTime = startTimeRaw && TIME_RE.test(startTimeRaw) ? startTimeRaw : undefined;
+    const startTime =
+      startTimeRaw && TIME_RE.test(startTimeRaw) ? startTimeRaw.padStart(5, "0") : undefined;
 
     events.push({
       date,

--- a/scripts/backfill-colombo-harriettes-history.ts
+++ b/scripts/backfill-colombo-harriettes-history.ts
@@ -57,7 +57,18 @@ interface ColomboRun {
 }
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const TIME_RE = /^\d{1,2}:\d{2}$/;
+const TIME_RE = /^(\d{1,2}):(\d{2})$/;
+
+/** Normalize a source time to strict zero-padded "HH:MM", or undefined when it's
+ * not a valid 24h clock value (rejects "29:99" etc. that the regex alone allows). */
+function normalizeTime(raw: string | undefined): string | undefined {
+  const m = raw ? TIME_RE.exec(raw) : null;
+  if (!m) return undefined;
+  const hh = Number(m[1]);
+  const mm = Number(m[2]);
+  if (hh < 0 || hh > 23 || mm < 0 || mm > 59) return undefined;
+  return `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
+}
 
 function clean(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -81,10 +92,8 @@ async function fetchEvents(): Promise<RawEventData[]> {
     // Number.isInteger guards the integer runNumber column against NaN/float.
     if (!Number.isInteger(row.run_number) || (row.run_number as number) <= 0) continue;
 
-    // Pad single-digit hours so startTime is always zero-padded "HH:MM".
-    const startTimeRaw = clean(row.starting_time);
-    const startTime =
-      startTimeRaw && TIME_RE.test(startTimeRaw) ? startTimeRaw.padStart(5, "0") : undefined;
+    // Normalize to strict zero-padded "HH:MM"; reject out-of-range values.
+    const startTime = normalizeTime(clean(row.starting_time));
 
     events.push({
       date,

--- a/scripts/backfill-sfh3-archive-history.ts
+++ b/scripts/backfill-sfh3-archive-history.ts
@@ -1,0 +1,119 @@
+/**
+ * One-shot historical backfill for two SFH3 MultiHash kennels whose deep run
+ * archives sit on sfh3.com but never reach HashTracks from the recurring scrape:
+ *
+ *   - SFFMH3 (Fully Mooned H3, kennels=7) — ~100 full-moon crawls 2008→2026 (#2296)
+ *   - SVH3   (Silicon Valley H3, kennels=5) — ~1,000+ numbered runs 2002→2026 (#2366)
+ *
+ * The live SFH3Adapter scrapes `?kennels=all` (the current hareline window only),
+ * so the back-catalogue is invisible. The same MultiHash platform exposes a
+ * per-kennel year archive at `?kennels=<id>&period=<year>`:
+ *   - For SFFMH3 the `period` param is ignored — one fetch returns the whole list.
+ *   - For SVH3 each `period` value returns a ~100-row era bucket, so we sweep every
+ *     period option (1990-2001 … 2026) and dedupe by (date,run#,title).
+ *
+ * Rows are parsed with the adapter's OWN exported helpers (`parseHarelineRows`,
+ * `parseSFH3Date`, `parseICalSummary`) so the output matches the live scrape;
+ * only the kennelTag is forced (the archive view is already filtered to one
+ * kennel, and its `td.kennel` carries the display name, not the code).
+ *
+ * Safe + re-runnable: the source carries `config.upcomingOnly`, so reconcile
+ * never cancels these past rows; `processRawEvents` dedupes by fingerprint.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-sfh3-archive-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-sfh3-archive-history.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { parseHarelineRows, parseSFH3Date } from "@/adapters/html-scraper/sfh3";
+import { parseICalSummary } from "@/adapters/ical/adapter";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "SFH3 MultiHash HTML Hareline";
+const KENNEL_TIMEZONE = "America/Los_Angeles";
+const BASE = "https://www.sfh3.com/runs";
+
+// MultiHash kennel ids (from the ?kennels=<id> selector on sfh3.com/runs).
+const SFFMH3_ID = 7;
+const SVH3_ID = 5;
+// SVH3 period buckets (the year selector values). Each returns ~100 rows of that
+// era; sweeping all + dedup assembles the full archive.
+const SVH3_PERIODS = [
+  "1990-2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009",
+  "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019",
+  "2020", "2021", "2022", "2023", "2024", "2025", "2026",
+];
+
+async function fetchArchive(kennelId: number, period?: string): Promise<string> {
+  const url = period
+    ? `${BASE}?kennels=${kennelId}&period=${encodeURIComponent(period)}`
+    : `${BASE}?kennels=${kennelId}`;
+  const res = await safeFetch(url);
+  if (!res.ok) throw new Error(`SFH3 archive ${url} → HTTP ${res.status}`);
+  return res.text();
+}
+
+/** Parse one archive HTML page into RawEventData for the forced kennelTag. */
+function parsePage(html: string, kennelTag: string, sourceUrl: string): RawEventData[] {
+  const out: RawEventData[] = [];
+  for (const row of parseHarelineRows(html)) {
+    const date = parseSFH3Date(row.dateText);
+    if (!date) continue; // archive header / malformed row
+    const parsed = parseICalSummary(row.title);
+    out.push({
+      date,
+      kennelTags: [kennelTag],
+      runNumber: row.runNumber ?? parsed.runNumber,
+      // parsed.title strips any "KENNEL #N:" prefix; fall back to the raw cell.
+      // Empty → undefined so merge synthesizes the default title.
+      title: parsed.title ?? (row.title || undefined),
+      hares: row.hare,
+      location: row.locationText,
+      locationUrl: row.locationUrl,
+      sourceUrl: row.detailUrl ? new URL(row.detailUrl, BASE).href : sourceUrl,
+    });
+  }
+  return out;
+}
+
+/** Stable identity for cross-period dedup. */
+function key(e: RawEventData): string {
+  return `${e.kennelTags[0]}|${e.date}|${e.runNumber ?? ""}|${e.title ?? ""}`;
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const byKey = new Map<string, RawEventData>();
+  const add = (events: RawEventData[]) => {
+    for (const e of events) if (!byKey.has(key(e))) byKey.set(key(e), e);
+  };
+
+  // SFFMH3 — `period` selects the full list regardless of value, but it MUST be
+  // present (a period-less fetch returns a different/empty view). Any year works.
+  const fmPeriod = "2026";
+  const fmUrl = `${BASE}?kennels=${SFFMH3_ID}&period=${fmPeriod}`;
+  add(parsePage(await fetchArchive(SFFMH3_ID, fmPeriod), "sffmh3", fmUrl));
+  console.log(`  SFFMH3: ${byKey.size} rows`);
+
+  // SVH3 — sweep every period bucket, dedup.
+  const before = byKey.size;
+  for (const period of SVH3_PERIODS) {
+    const svUrl = `${BASE}?kennels=${SVH3_ID}&period=${period}`;
+    add(parsePage(await fetchArchive(SVH3_ID, period), "svh3", svUrl));
+  }
+  console.log(`  SVH3: ${byKey.size - before} rows across ${SVH3_PERIODS.length} period buckets`);
+
+  return [...byKey.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Walking SFH3 MultiHash year-archive for SFFMH3 + SVH3",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-sfh3-archive-history.ts
+++ b/scripts/backfill-sfh3-archive-history.ts
@@ -2,118 +2,58 @@
  * One-shot historical backfill for two SFH3 MultiHash kennels whose deep run
  * archives sit on sfh3.com but never reach HashTracks from the recurring scrape:
  *
- *   - SFFMH3 (Fully Mooned H3, kennels=7) — ~100 full-moon crawls 2008→2026 (#2296)
- *   - SVH3   (Silicon Valley H3, kennels=5) — ~1,000+ numbered runs 2002→2026 (#2366)
+ *   - SFFMH3 (Fully Mooned H3, sfh3 id 7) — ~100 full-moon crawls 2008→2026 (#2296)
+ *   - SVH3   (Silicon Valley H3, sfh3 id 5) — ~430 numbered runs 2002→2026 (#2366)
  *
- * The live SFH3Adapter scrapes `?kennels=all` (the current hareline window only),
- * so the back-catalogue is invisible. The same MultiHash platform exposes a
- * per-kennel year archive at `?kennels=<id>&period=<year>`:
- *   - For SFFMH3 the `period` param is ignored — one fetch returns the whole list.
- *   - For SVH3 each `period` value returns a ~100-row era bucket, so we sweep every
- *     period option (1990-2001 … 2026) and dedupe by (date,run#,title).
+ * Thin wrapper over the reusable `backfillSfh3Kennel` helper (scripts/lib/
+ * sfh3-backfill.ts), which fetches each `?kennel=<id>&period=<bucket>` page,
+ * asserts the kennel filter was honored (`expectedLabel` guard — prevents
+ * importing another kennel's history under our code), maps rows with the
+ * adapter's parsers (incl. `startTime` via parse12HourTime), enriches
+ * descriptions from detail pages, and routes `date < today` through merge.
  *
- * Rows are parsed with the adapter's OWN exported helpers (`parseHarelineRows`,
- * `parseSFH3Date`, `parseICalSummary`) so the output matches the live scrape;
- * only the kennelTag is forced (the archive view is already filtered to one
- * kennel, and its `td.kennel` carries the display name, not the code).
- *
- * Safe + re-runnable: the source carries `config.upcomingOnly`, so reconcile
- * never cancels these past rows; `processRawEvents` dedupes by fingerprint.
+ * The helper's default period buckets are stale (sfh3.com now exposes one option
+ * per year), so we pass the current per-year list. SFFMH3 has only ~100 crawls
+ * total and the page returns the full list for any single year, so one bucket
+ * suffices there; SVH3's archive spans buckets, so we sweep every year + dedup
+ * (the helper de-dupes by fingerprint across buckets).
  *
  * Usage:
  *   Dry run: npx tsx scripts/backfill-sfh3-archive-history.ts
  *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-sfh3-archive-history.ts
  */
 
-import "dotenv/config";
-import { runBackfillScript } from "./lib/backfill-runner";
-import { safeFetch } from "@/adapters/safe-fetch";
-import { parseHarelineRows, parseSFH3Date } from "@/adapters/html-scraper/sfh3";
-import { parseICalSummary } from "@/adapters/ical/adapter";
-import type { RawEventData } from "@/adapters/types";
+import { backfillSfh3Kennel } from "./lib/sfh3-backfill";
 
-const SOURCE_NAME = "SFH3 MultiHash HTML Hareline";
-const KENNEL_TIMEZONE = "America/Los_Angeles";
-const BASE = "https://www.sfh3.com/runs";
-
-// MultiHash kennel ids (from the ?kennels=<id> selector on sfh3.com/runs).
-const SFFMH3_ID = 7;
-const SVH3_ID = 5;
-// SVH3 period buckets (the year selector values). Each returns ~100 rows of that
-// era; sweeping all + dedup assembles the full archive.
+// Current sfh3.com/runs period <option> values (one per year + the early bucket).
 const SVH3_PERIODS = [
   "1990-2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009",
   "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019",
   "2020", "2021", "2022", "2023", "2024", "2025", "2026",
-];
+] as const;
 
-async function fetchArchive(kennelId: number, period?: string): Promise<string> {
-  const url = period
-    ? `${BASE}?kennels=${kennelId}&period=${encodeURIComponent(period)}`
-    : `${BASE}?kennels=${kennelId}`;
-  const res = await safeFetch(url);
-  if (!res.ok) throw new Error(`SFH3 archive ${url} → HTTP ${res.status}`);
-  return res.text();
+async function main(): Promise<void> {
+  // SFFMH3 — id 7. period is ignored for this kennel (any single year returns
+  // the whole ~100-crawl list), but a value must be present.
+  await backfillSfh3Kennel({
+    sfh3KennelId: 7,
+    kennelCode: "sffmh3",
+    sourceName: "SFH3 MultiHash HTML Hareline",
+    periods: ["2026"],
+    expectedLabel: "FMH3",
+  });
+
+  // SVH3 — id 5. Sweep every year bucket; the helper de-dupes across overlaps.
+  await backfillSfh3Kennel({
+    sfh3KennelId: 5,
+    kennelCode: "svh3",
+    sourceName: "SFH3 MultiHash HTML Hareline",
+    periods: SVH3_PERIODS,
+    expectedLabel: "SVH3",
+  });
 }
 
-/** Parse one archive HTML page into RawEventData for the forced kennelTag. */
-function parsePage(html: string, kennelTag: string, sourceUrl: string): RawEventData[] {
-  const out: RawEventData[] = [];
-  for (const row of parseHarelineRows(html)) {
-    const date = parseSFH3Date(row.dateText);
-    if (!date) continue; // archive header / malformed row
-    const parsed = parseICalSummary(row.title);
-    out.push({
-      date,
-      kennelTags: [kennelTag],
-      runNumber: row.runNumber ?? parsed.runNumber,
-      // parsed.title strips any "KENNEL #N:" prefix; fall back to the raw cell.
-      // Empty → undefined so merge synthesizes the default title.
-      title: parsed.title ?? (row.title || undefined),
-      hares: row.hare,
-      location: row.locationText,
-      locationUrl: row.locationUrl,
-      sourceUrl: row.detailUrl ? new URL(row.detailUrl, BASE).href : sourceUrl,
-    });
-  }
-  return out;
-}
-
-/** Stable identity for cross-period dedup. */
-function key(e: RawEventData): string {
-  return `${e.kennelTags[0]}|${e.date}|${e.runNumber ?? ""}|${e.title ?? ""}`;
-}
-
-async function fetchEvents(): Promise<RawEventData[]> {
-  const byKey = new Map<string, RawEventData>();
-  const add = (events: RawEventData[]) => {
-    for (const e of events) if (!byKey.has(key(e))) byKey.set(key(e), e);
-  };
-
-  // SFFMH3 — `period` selects the full list regardless of value, but it MUST be
-  // present (a period-less fetch returns a different/empty view). Any year works.
-  const fmPeriod = "2026";
-  const fmUrl = `${BASE}?kennels=${SFFMH3_ID}&period=${fmPeriod}`;
-  add(parsePage(await fetchArchive(SFFMH3_ID, fmPeriod), "sffmh3", fmUrl));
-  console.log(`  SFFMH3: ${byKey.size} rows`);
-
-  // SVH3 — sweep every period bucket, dedup.
-  const before = byKey.size;
-  for (const period of SVH3_PERIODS) {
-    const svUrl = `${BASE}?kennels=${SVH3_ID}&period=${period}`;
-    add(parsePage(await fetchArchive(SVH3_ID, period), "svh3", svUrl));
-  }
-  console.log(`  SVH3: ${byKey.size - before} rows across ${SVH3_PERIODS.length} period buckets`);
-
-  return [...byKey.values()].sort((a, b) => a.date.localeCompare(b.date));
-}
-
-runBackfillScript({
-  sourceName: SOURCE_NAME,
-  kennelTimezone: KENNEL_TIMEZONE,
-  label: "Walking SFH3 MultiHash year-archive for SFFMH3 + SVH3",
-  fetchEvents,
-}).catch((err) => {
+main().catch((err) => {
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/scripts/backfill-sh3-sg-history.ts
+++ b/scripts/backfill-sh3-sg-history.ts
@@ -8,11 +8,11 @@
  * PublicKennelId, and routes the past slice through merge.
  *
  * IMPORTANT — depth reality: the kennel is at Run #800 (Est. 1994), but HC only
- * holds the runs the kennel actually entered, which is a RECENT subset, NOT all
- * 800. This recovers whatever the global feed exposes; the dry-run prints the
- * true #range. No title config (no defaultTitle) → merge synthesizes
- * "Singapore Sunday H3 Trail #N". Source carries upcomingOnly, so reconcile
- * never cancels these. Re-runnable via fingerprint dedup.
+ * holds the runs the kennel actually entered, which is a RECENT subset (~Jan
+ * 2026 onward), NOT all 800. This recovers whatever the global feed exposes; the
+ * dry-run prints the true #range. No title config (no defaultTitle) → merge
+ * synthesizes "Singapore Sunday H3 Trail #N". Source carries upcomingOnly, so
+ * reconcile never cancels these. Re-runnable via fingerprint dedup.
  *
  * Usage:
  *   Dry run: npx tsx scripts/backfill-sh3-sg-history.ts
@@ -20,35 +20,14 @@
  */
 
 import "dotenv/config";
-import { runBackfillScript } from "./lib/backfill-runner";
-import { sweepGlobalRuns, mapRunToRawEvent } from "./lib/hc-global-runs";
-import type { HarrierCentralConfig } from "@/adapters/harrier-central/adapter";
-import type { RawEventData } from "@/adapters/types";
+import { runHcKennelBackfill } from "./lib/hc-global-runs";
 
-const SOURCE_NAME = "Singapore Sunday H3 Harrier Central";
-const KENNEL_TAG = "sh3-sg";
-const PUBLIC_KENNEL_ID = "7cb56a4d-dfe8-4dc3-aacd-6884cd8d3cc1";
-const KENNEL_TIMEZONE = "Asia/Singapore";
-const HISTORY_START = "2020-01-01"; // sweep wide; SG's HC adoption date unknown
-
-// No defaultTitle in the live source → merge synthesizes the default title.
-const CONFIG: HarrierCentralConfig = {};
-
-async function fetchEvents(): Promise<RawEventData[]> {
-  const today = new Date().toISOString().slice(0, 10);
-  const runs = await sweepGlobalRuns(HISTORY_START, today);
-  const mine = runs.filter((r) => r.PublicKennelId === PUBLIC_KENNEL_ID);
-  return mine
-    .map((r) => mapRunToRawEvent(r, KENNEL_TAG, CONFIG))
-    .filter((e): e is RawEventData => e !== null);
-}
-
-runBackfillScript({
-  sourceName: SOURCE_NAME,
-  kennelTimezone: KENNEL_TIMEZONE,
+runHcKennelBackfill({
+  sourceName: "Singapore Sunday H3 Harrier Central",
+  kennelTag: "sh3-sg",
+  publicKennelId: "7cb56a4d-dfe8-4dc3-aacd-6884cd8d3cc1",
+  kennelTimezone: "Asia/Singapore",
+  historyStart: "2020-01-01", // sweep wide; SG's HC adoption date unknown up front
+  config: {}, // no defaultTitle → merge synthesizes the default title
   label: "Sweeping Singapore Sunday H3 Harrier Central global-runs archive",
-  fetchEvents,
-}).catch((err) => {
-  console.error(err);
-  process.exit(1);
 });

--- a/scripts/backfill-sh3-sg-history.ts
+++ b/scripts/backfill-sh3-sg-history.ts
@@ -1,0 +1,54 @@
+/**
+ * One-shot historical backfill for Singapore Sunday H3 (sh3-sg) via Harrier
+ * Central.
+ *
+ * The live HarrierCentralAdapter is future-only, so SG Sunday's past runs never
+ * reach canonical Events (#2306). This pulls them from the hashruns.org global
+ * past-runs feed (scripts/lib/hc-global-runs.ts), filtered to SG's
+ * PublicKennelId, and routes the past slice through merge.
+ *
+ * IMPORTANT — depth reality: the kennel is at Run #800 (Est. 1994), but HC only
+ * holds the runs the kennel actually entered, which is a RECENT subset, NOT all
+ * 800. This recovers whatever the global feed exposes; the dry-run prints the
+ * true #range. No title config (no defaultTitle) → merge synthesizes
+ * "Singapore Sunday H3 Trail #N". Source carries upcomingOnly, so reconcile
+ * never cancels these. Re-runnable via fingerprint dedup.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-sh3-sg-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-sh3-sg-history.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { sweepGlobalRuns, mapRunToRawEvent } from "./lib/hc-global-runs";
+import type { HarrierCentralConfig } from "@/adapters/harrier-central/adapter";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Singapore Sunday H3 Harrier Central";
+const KENNEL_TAG = "sh3-sg";
+const PUBLIC_KENNEL_ID = "7cb56a4d-dfe8-4dc3-aacd-6884cd8d3cc1";
+const KENNEL_TIMEZONE = "Asia/Singapore";
+const HISTORY_START = "2020-01-01"; // sweep wide; SG's HC adoption date unknown
+
+// No defaultTitle in the live source → merge synthesizes the default title.
+const CONFIG: HarrierCentralConfig = {};
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const today = new Date().toISOString().slice(0, 10);
+  const runs = await sweepGlobalRuns(HISTORY_START, today);
+  const mine = runs.filter((r) => r.PublicKennelId === PUBLIC_KENNEL_ID);
+  return mine
+    .map((r) => mapRunToRawEvent(r, KENNEL_TAG, CONFIG))
+    .filter((e): e is RawEventData => e !== null);
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Sweeping Singapore Sunday H3 Harrier Central global-runs archive",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-sumo-h3-history.ts
+++ b/scripts/backfill-sumo-h3-history.ts
@@ -1,0 +1,140 @@
+/**
+ * One-shot historical backfill for Sumo H3 Kanagawa (sumo-h3).
+ *
+ * The live SumoH3Adapter scrapes the rolling hareline (upcoming window only), so
+ * the Past tab showed 0 events (#2381). The site IS a WordPress install running
+ * The Events Calendar, and every run has a durable per-event page at
+ * `/events/<postId>/` that survives indefinitely — each one SSRs a clean JSON-LD
+ * `Event` object:
+ *
+ *   { "@type":"Event", "name":"580",
+ *     "startDate":"2017-02-19T14:00:00+09:00",
+ *     "location":{ "name":"Kokusai-Tenjijo Station / Ariake Station" } }
+ *
+ * plus a `<title>Run #N – …</title>` for the run number. (The audit called this
+ * gap "unrecoverable"; it is not — the per-event archive is fully reachable.)
+ *
+ * Numeric post ids are stable permalinks (id 100 → Run #580) that serve clean
+ * JSON-LD directly (the date-slug `/events/<YYYY-MM-DD>/` form 301-redirects, and
+ * some pages omit the JSON-LD island). We walk the numeric id range and import
+ * every page that carries a parseable `Event` island, deduped by run number.
+ *
+ * SCOPE NOTE: this recovers the JSON-LD-bearing subset (~80+ runs, 2015→present)
+ * — proving the gap is NOT "unrecoverable" as the audit (#2381) claimed. A
+ * fuller enumeration (the minority of event pages that lack JSON-LD need
+ * title+schedule HTML parsing) is a follow-up; re-running this script after that
+ * is added is idempotent (fingerprint dedup). The Events Calendar archive begins
+ * ~2015; pre-2015 runs were never entered into the plugin and are genuinely absent.
+ * Titles are just "Run #N" (no theme) → left undefined so merge synthesizes
+ * "Sumo H3 Trail #N". Source carries upcomingOnly so reconcile won't cancel these.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-sumo-h3-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-sumo-h3-history.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Sumo H3 Website";
+const KENNEL_TAG = "sumo-h3";
+const KENNEL_TIMEZONE = "Asia/Tokyo";
+const BASE = "https://sumoh3.gotothehash.net/events";
+// Event post ids are scattered up to the current upcoming pages (~1061); the
+// id space is sparse (many 404 gaps) so we walk the whole range and keep hits.
+const MAX_ID = 1100;
+const BATCH = 12;
+
+const TITLE_RUN_RE = /Run\s*#\s*(\d{1,5})/i;
+const TIME_RE = /T(\d{2}:\d{2})/;
+
+interface LdEvent {
+  "@type"?: string | string[];
+  name?: string | number;
+  startDate?: string;
+  location?: { name?: string } | string;
+}
+
+function extractLdEvent(html: string): LdEvent | null {
+  const re = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    try {
+      const parsed = JSON.parse(m[1]) as unknown;
+      const items = Array.isArray(parsed) ? parsed : [parsed];
+      for (const it of items) {
+        const t = (it as LdEvent)?.["@type"];
+        if (t === "Event" || (Array.isArray(t) && t.includes("Event"))) return it as LdEvent;
+      }
+    } catch {
+      // skip malformed island
+    }
+  }
+  return null;
+}
+
+async function fetchEvent(id: number): Promise<RawEventData | null> {
+  const url = `${BASE}/${id}/`;
+  let res: Response;
+  try {
+    res = await safeFetch(url, { headers: { "User-Agent": "Mozilla/5.0 (HashTracks backfill)" } });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  const html = await res.text();
+  const ld = extractLdEvent(html);
+  if (!ld?.startDate) return null;
+  const date = ld.startDate.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+
+  const titleMatch = TITLE_RUN_RE.exec(html);
+  const nameNum = typeof ld.name === "number" ? ld.name : Number.parseInt(String(ld.name), 10);
+  const runNumber = titleMatch
+    ? Number.parseInt(titleMatch[1], 10)
+    : Number.isFinite(nameNum) && nameNum > 0
+      ? nameNum
+      : undefined;
+
+  const startTime = TIME_RE.exec(ld.startDate)?.[1];
+  const locationName = typeof ld.location === "string" ? ld.location : ld.location?.name;
+  const location = locationName?.trim() || undefined;
+
+  return {
+    date,
+    kennelTags: [KENNEL_TAG],
+    runNumber,
+    // "Run #N" carries no theme → undefined so merge synthesizes the default.
+    startTime,
+    location,
+    sourceUrl: url,
+  };
+}
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const found: RawEventData[] = [];
+  for (let start = 1; start <= MAX_ID; start += BATCH) {
+    const ids = Array.from({ length: Math.min(BATCH, MAX_ID - start + 1) }, (_, i) => start + i);
+    const batch = await Promise.all(ids.map(fetchEvent));
+    for (const e of batch) if (e) found.push(e);
+  }
+  // Dedupe by run number (republished "-2" slugs share a run#); keep first.
+  const byRun = new Map<string, RawEventData>();
+  for (const e of found) {
+    const k = e.runNumber != null ? `r${e.runNumber}` : `d${e.date}`;
+    if (!byRun.has(k)) byRun.set(k, e);
+  }
+  return [...byRun.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: `Walking Sumo H3 /events/<id>/ archive (ids 1-${MAX_ID})`,
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-sumo-h3-history.ts
+++ b/scripts/backfill-sumo-h3-history.ts
@@ -98,11 +98,12 @@ async function fetchEvent(id: number): Promise<RawEventData | null> {
   const titleMatch = TITLE_RUN_RE.exec(html);
   const nameNum = typeof ld.name === "number" ? ld.name : Number.parseInt(String(ld.name), 10);
   // Number.isInteger guards the integer runNumber column against NaN/float.
-  const runNumber = titleMatch
-    ? Number.parseInt(titleMatch[1], 10)
-    : Number.isInteger(nameNum) && nameNum > 0
-      ? nameNum
-      : undefined;
+  let runNumber: number | undefined;
+  if (titleMatch) {
+    runNumber = Number.parseInt(titleMatch[1], 10);
+  } else if (Number.isInteger(nameNum) && nameNum > 0) {
+    runNumber = nameNum;
+  }
 
   const startTime = TIME_RE.exec(ld.startDate)?.[1];
   const locationName = typeof ld.location === "string" ? ld.location : ld.location?.name;
@@ -130,7 +131,8 @@ async function fetchEvents(): Promise<RawEventData[]> {
   const byRun = new Map<string, RawEventData>();
   for (const e of found) {
     const k = e.runNumber != null ? `r${e.runNumber}` : `d${e.date}`;
-    if (!byRun.has(k)) byRun.set(k, e);
+    if (byRun.has(k)) continue;
+    byRun.set(k, e);
   }
   return [...byRun.values()].sort((a, b) => a.date.localeCompare(b.date));
 }

--- a/scripts/backfill-sumo-h3-history.ts
+++ b/scripts/backfill-sumo-h3-history.ts
@@ -81,10 +81,14 @@ async function fetchEvent(id: number): Promise<RawEventData | null> {
   let res: Response;
   try {
     res = await safeFetch(url, { headers: { "User-Agent": "Mozilla/5.0 (HashTracks backfill)" } });
-  } catch {
-    return null;
+  } catch (err) {
+    // Network/proxy/timeout failure is NOT an expected sparse-id miss — fail
+    // loud so the run can be retried instead of completing a partial archive.
+    throw new Error(`Sumo event fetch failed for ${url}`, { cause: err });
   }
-  if (!res.ok) return null;
+  // Sparse id space: 404/410 are the expected "no event at this id" gaps → skip.
+  if (res.status === 404 || res.status === 410) return null;
+  if (!res.ok) throw new Error(`Sumo event ${url} returned HTTP ${res.status}`);
   const html = await res.text();
   const ld = extractLdEvent(html);
   if (!ld?.startDate) return null;

--- a/scripts/backfill-sumo-h3-history.ts
+++ b/scripts/backfill-sumo-h3-history.ts
@@ -44,6 +44,7 @@ const KENNEL_TIMEZONE = "Asia/Tokyo";
 const BASE = "https://sumoh3.gotothehash.net/events";
 // Event post ids are scattered up to the current upcoming pages (~1061); the
 // id space is sparse (many 404 gaps) so we walk the whole range and keep hits.
+// Bump this before re-running once the site publishes ids beyond the ceiling.
 const MAX_ID = 1100;
 const BATCH = 12;
 
@@ -92,9 +93,10 @@ async function fetchEvent(id: number): Promise<RawEventData | null> {
 
   const titleMatch = TITLE_RUN_RE.exec(html);
   const nameNum = typeof ld.name === "number" ? ld.name : Number.parseInt(String(ld.name), 10);
+  // Number.isInteger guards the integer runNumber column against NaN/float.
   const runNumber = titleMatch
     ? Number.parseInt(titleMatch[1], 10)
-    : Number.isFinite(nameNum) && nameNum > 0
+    : Number.isInteger(nameNum) && nameNum > 0
       ? nameNum
       : undefined;
 

--- a/scripts/backfill-sumo-h3-history.ts
+++ b/scripts/backfill-sumo-h3-history.ts
@@ -130,7 +130,7 @@ async function fetchEvents(): Promise<RawEventData[]> {
   // Dedupe by run number (republished "-2" slugs share a run#); keep first.
   const byRun = new Map<string, RawEventData>();
   for (const e of found) {
-    const k = e.runNumber != null ? `r${e.runNumber}` : `d${e.date}`;
+    const k = e.runNumber == null ? `d${e.date}` : `r${e.runNumber}`;
     if (byRun.has(k)) continue;
     byRun.set(k, e);
   }

--- a/scripts/backfill-tidewater-h3-history.ts
+++ b/scripts/backfill-tidewater-h3-history.ts
@@ -1,0 +1,79 @@
+/**
+ * One-shot historical backfill for the Tidewater H3 family (tidewaterh3.org).
+ *
+ * The TidewaterH3Adapter parses the inline `trailCalendarEvents` FullCalendar
+ * feed on /calendar, but `parseTidewaterCalendar` deliberately DROPS past
+ * entries (the live scrape only ever surfaces upcoming runs + in-window
+ * placeholders). The feed itself, however, still carries recently-completed
+ * REAL trails — fully detailed via each entry's `extendedProps` (hares, venue +
+ * address, maps URL, cost, description). Those past trails never reach canonical
+ * Events from the live scrape, which is the gap reported in #2429 (HOBO H3) and
+ * the same shape for any sibling kennel.
+ *
+ * This script re-uses the adapter's own `extractCalendarArray` +
+ * `parseCalendarEntry` so the rows are byte-identical to what the live adapter
+ * would have stored, then routes the PAST, NON-placeholder slice through the
+ * merge pipeline. Placeholder ("schedule"/TBD) entries are skipped — they carry
+ * no run#/hares/location and aren't worth a canonical Event (#2432 disposition).
+ *
+ * Generic by design: it imports EVERY past real trail the live feed exposes
+ * (currently HOBO 06-25, VBFMH3 06-26, TH3 #1852 06-28), not just the issue's
+ * one event. `processRawEvents` dedupes by fingerprint, so already-held events
+ * skip and re-running is a no-op. The source carries `config.upcomingOnly:true`,
+ * so reconcile never false-cancels these past rows.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-tidewater-h3-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-tidewater-h3-history.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import {
+  extractCalendarArray,
+  parseCalendarEntry,
+} from "@/adapters/html-scraper/tidewater-h3";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Tidewater H3 Website Calendar";
+const SOURCE_URL = "https://tidewaterh3.org/calendar";
+// Hampton Roads, VA.
+const KENNEL_TIMEZONE = "America/New_York";
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const res = await safeFetch(SOURCE_URL);
+  if (!res.ok) throw new Error(`Tidewater calendar returned HTTP ${res.status}`);
+  const html = await res.text();
+
+  const entries = extractCalendarArray(html);
+  if (!entries) {
+    throw new Error(
+      "Tidewater calendar: inline trailCalendarEvents feed not found (page shape changed).",
+    );
+  }
+
+  const events: RawEventData[] = [];
+  for (const entry of entries) {
+    const parsed = parseCalendarEntry(entry, SOURCE_URL);
+    if (!parsed) continue;
+    // Skip placeholders (schedule/TBD rows): no run#/hares/location to preserve.
+    if (parsed.isPlaceholder) continue;
+    events.push(parsed.event);
+    // The runner partitions to `date < today`, so future real entries (already
+    // covered by the live adapter) are reported-then-skipped, not written.
+  }
+
+  events.sort((a, b) => a.date.localeCompare(b.date));
+  return events;
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Walking Tidewater H3 calendar feed for past real trails",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-tokyo-h3-history.ts
+++ b/scripts/backfill-tokyo-h3-history.ts
@@ -1,0 +1,63 @@
+/**
+ * One-shot historical backfill for Tokyo H3 (tokyo-h3) via Harrier Central.
+ *
+ * The live HarrierCentralAdapter is future-only, so Tokyo's past runs never
+ * reach canonical Events. This pulls them from the hashruns.org global past-runs
+ * feed (see scripts/lib/hc-global-runs.ts), filtered to Tokyo's PublicKennelId,
+ * and routes the past slice through the merge pipeline.
+ *
+ * Recoverable depth is whatever HC actually holds: Tokyo adopted HC ~2021-09
+ * (earliest feed run #2339), NOT the kennel's 1976 founding — so this recovers
+ * the HC era (~#2339 → present), not the full history (#2411).
+ *
+ * Config mirrors the live source (defaultTitle + Tokyo's neighborhood
+ * `staleTitleAliases`) so titles match the recurring scrape. Source carries
+ * upcomingOnly, so reconcile never cancels these past rows. Re-runnable:
+ * processRawEvents dedupes by fingerprint.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-tokyo-h3-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-tokyo-h3-history.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { sweepGlobalRuns, mapRunToRawEvent } from "./lib/hc-global-runs";
+import type { HarrierCentralConfig } from "@/adapters/harrier-central/adapter";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Tokyo H3 Harrier Central";
+const KENNEL_TAG = "tokyo-h3";
+const PUBLIC_KENNEL_ID = "57f5b2c6-8d8f-41e0-8dbf-d03a0a9aa10e";
+const KENNEL_TIMEZONE = "Asia/Tokyo";
+const HISTORY_START = "2021-01-01"; // HC era begins ~2021-09; start earlier to be safe
+
+// Mirrors prisma/seed-data/sources.ts "Tokyo H3 Harrier Central".config.
+const CONFIG: HarrierCentralConfig = {
+  defaultTitle: "Tokyo H3 Trail",
+  staleTitleAliases: [
+    "Akabane", "Akihabara", "Asakusa", "Ebisu", "Ginza", "Ikebukuro", "Iidabashi",
+    "Kanda", "Meguro", "Nakameguro", "Nishiogikubo", "Roppongi", "Shibuya",
+    "Shimbashi", "Shinagawa", "Shinjuku", "Suidobashi", "Takadanobaba",
+    "Takadanobanba", "Tokyo", "Ueno", "Yotsuya",
+  ],
+};
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const today = new Date().toISOString().slice(0, 10);
+  const runs = await sweepGlobalRuns(HISTORY_START, today);
+  const mine = runs.filter((r) => r.PublicKennelId === PUBLIC_KENNEL_ID);
+  return mine
+    .map((r) => mapRunToRawEvent(r, KENNEL_TAG, CONFIG))
+    .filter((e): e is RawEventData => e !== null);
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Sweeping Tokyo H3 Harrier Central global-runs archive",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-tokyo-h3-history.ts
+++ b/scripts/backfill-tokyo-h3-history.ts
@@ -21,16 +21,8 @@
  */
 
 import "dotenv/config";
-import { runBackfillScript } from "./lib/backfill-runner";
-import { sweepGlobalRuns, mapRunToRawEvent } from "./lib/hc-global-runs";
+import { runHcKennelBackfill } from "./lib/hc-global-runs";
 import type { HarrierCentralConfig } from "@/adapters/harrier-central/adapter";
-import type { RawEventData } from "@/adapters/types";
-
-const SOURCE_NAME = "Tokyo H3 Harrier Central";
-const KENNEL_TAG = "tokyo-h3";
-const PUBLIC_KENNEL_ID = "57f5b2c6-8d8f-41e0-8dbf-d03a0a9aa10e";
-const KENNEL_TIMEZONE = "Asia/Tokyo";
-const HISTORY_START = "2021-01-01"; // HC era begins ~2021-09; start earlier to be safe
 
 // Mirrors prisma/seed-data/sources.ts "Tokyo H3 Harrier Central".config.
 const CONFIG: HarrierCentralConfig = {
@@ -43,21 +35,12 @@ const CONFIG: HarrierCentralConfig = {
   ],
 };
 
-async function fetchEvents(): Promise<RawEventData[]> {
-  const today = new Date().toISOString().slice(0, 10);
-  const runs = await sweepGlobalRuns(HISTORY_START, today);
-  const mine = runs.filter((r) => r.PublicKennelId === PUBLIC_KENNEL_ID);
-  return mine
-    .map((r) => mapRunToRawEvent(r, KENNEL_TAG, CONFIG))
-    .filter((e): e is RawEventData => e !== null);
-}
-
-runBackfillScript({
-  sourceName: SOURCE_NAME,
-  kennelTimezone: KENNEL_TIMEZONE,
+runHcKennelBackfill({
+  sourceName: "Tokyo H3 Harrier Central",
+  kennelTag: "tokyo-h3",
+  publicKennelId: "57f5b2c6-8d8f-41e0-8dbf-d03a0a9aa10e",
+  kennelTimezone: "Asia/Tokyo",
+  historyStart: "2021-01-01", // HC era begins ~2021-09; start earlier to be safe
+  config: CONFIG,
   label: "Sweeping Tokyo H3 Harrier Central global-runs archive",
-  fetchEvents,
-}).catch((err) => {
-  console.error(err);
-  process.exit(1);
 });

--- a/scripts/backfill-twh3-tw-history.ts
+++ b/scripts/backfill-twh3-tw-history.ts
@@ -1,0 +1,54 @@
+/**
+ * One-shot historical backfill for Taiwan H3 (twh3-tw) via Harrier Central.
+ *
+ * The live HarrierCentralAdapter is future-only, so Taiwan's past runs never
+ * reach canonical Events (#2404 — 0 past events held). This pulls them from the
+ * hashruns.org global past-runs feed (scripts/lib/hc-global-runs.ts), filtered
+ * to Taiwan's PublicKennelId, and routes the past slice through merge.
+ *
+ * Recoverable depth = whatever HC holds: Taiwan adopted HC ~2021-12 (earliest
+ * feed run #2428), so this recovers ~#2428 → present. Source carries
+ * upcomingOnly, so reconcile never cancels these. Re-runnable via fingerprint
+ * dedup.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-twh3-tw-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-twh3-tw-history.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { sweepGlobalRuns, mapRunToRawEvent } from "./lib/hc-global-runs";
+import type { HarrierCentralConfig } from "@/adapters/harrier-central/adapter";
+import type { RawEventData } from "@/adapters/types";
+
+const SOURCE_NAME = "Taiwan H3 Harrier Central";
+const KENNEL_TAG = "twh3-tw";
+const PUBLIC_KENNEL_ID = "f1330d14-e3b4-427a-9bea-639f18218804";
+const KENNEL_TIMEZONE = "Asia/Taipei";
+const HISTORY_START = "2021-01-01"; // HC era begins ~2021-12
+
+// Mirrors prisma/seed-data/sources.ts "Taiwan H3 Harrier Central".config.
+const CONFIG: HarrierCentralConfig = {
+  defaultTitle: "Taiwan H3",
+  staleTitleAliases: ["Placeholder event for TwH3"],
+};
+
+async function fetchEvents(): Promise<RawEventData[]> {
+  const today = new Date().toISOString().slice(0, 10);
+  const runs = await sweepGlobalRuns(HISTORY_START, today);
+  const mine = runs.filter((r) => r.PublicKennelId === PUBLIC_KENNEL_ID);
+  return mine
+    .map((r) => mapRunToRawEvent(r, KENNEL_TAG, CONFIG))
+    .filter((e): e is RawEventData => e !== null);
+}
+
+runBackfillScript({
+  sourceName: SOURCE_NAME,
+  kennelTimezone: KENNEL_TIMEZONE,
+  label: "Sweeping Taiwan H3 Harrier Central global-runs archive",
+  fetchEvents,
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-twh3-tw-history.ts
+++ b/scripts/backfill-twh3-tw-history.ts
@@ -17,16 +17,8 @@
  */
 
 import "dotenv/config";
-import { runBackfillScript } from "./lib/backfill-runner";
-import { sweepGlobalRuns, mapRunToRawEvent } from "./lib/hc-global-runs";
+import { runHcKennelBackfill } from "./lib/hc-global-runs";
 import type { HarrierCentralConfig } from "@/adapters/harrier-central/adapter";
-import type { RawEventData } from "@/adapters/types";
-
-const SOURCE_NAME = "Taiwan H3 Harrier Central";
-const KENNEL_TAG = "twh3-tw";
-const PUBLIC_KENNEL_ID = "f1330d14-e3b4-427a-9bea-639f18218804";
-const KENNEL_TIMEZONE = "Asia/Taipei";
-const HISTORY_START = "2021-01-01"; // HC era begins ~2021-12
 
 // Mirrors prisma/seed-data/sources.ts "Taiwan H3 Harrier Central".config.
 const CONFIG: HarrierCentralConfig = {
@@ -34,21 +26,12 @@ const CONFIG: HarrierCentralConfig = {
   staleTitleAliases: ["Placeholder event for TwH3"],
 };
 
-async function fetchEvents(): Promise<RawEventData[]> {
-  const today = new Date().toISOString().slice(0, 10);
-  const runs = await sweepGlobalRuns(HISTORY_START, today);
-  const mine = runs.filter((r) => r.PublicKennelId === PUBLIC_KENNEL_ID);
-  return mine
-    .map((r) => mapRunToRawEvent(r, KENNEL_TAG, CONFIG))
-    .filter((e): e is RawEventData => e !== null);
-}
-
-runBackfillScript({
-  sourceName: SOURCE_NAME,
-  kennelTimezone: KENNEL_TIMEZONE,
+runHcKennelBackfill({
+  sourceName: "Taiwan H3 Harrier Central",
+  kennelTag: "twh3-tw",
+  publicKennelId: "f1330d14-e3b4-427a-9bea-639f18218804",
+  kennelTimezone: "Asia/Taipei",
+  historyStart: "2021-01-01", // HC era begins ~2021-12
+  config: CONFIG,
   label: "Sweeping Taiwan H3 Harrier Central global-runs archive",
-  fetchEvents,
-}).catch((err) => {
-  console.error(err);
-  process.exit(1);
 });

--- a/scripts/lib/hc-global-runs.ts
+++ b/scripts/lib/hc-global-runs.ts
@@ -135,8 +135,7 @@ const TBA_RE = /^tba$/i;
 const PLACEHOLDER_HARE_RE = /\bplaceholder (?:user|event)\b/i;
 
 function clean(value: string | undefined): string | undefined {
-  const t = value?.trim();
-  return t ? t : undefined;
+  return value?.trim() || undefined;
 }
 
 /** EventNumber → runNumber tri-state, matching the live adapter (0 → null).
@@ -187,7 +186,7 @@ export function mapRunToRawEvent(
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
 
   const startTime = TIME_RE.exec(start)?.[1];
-  const location = composeHcLocation(run.LocationOneLineDesc, undefined, undefined);
+  const location = composeHcLocation(run.LocationOneLineDesc, undefined);
   const hares = cleanHares(run.Hares, location);
   let title = applyTitleFallback(run.EventName, run.EventNumber, config);
   // #2408/#2409 parity: a title that byte-equals the hares or the raw venue is

--- a/scripts/lib/hc-global-runs.ts
+++ b/scripts/lib/hc-global-runs.ts
@@ -35,7 +35,9 @@ import {
   composeHcLocation,
   type HarrierCentralConfig,
 } from "@/adapters/harrier-central/adapter";
+import { eqTrimLc } from "@/adapters/utils";
 import type { RawEventData } from "@/adapters/types";
+import { runBackfillScript } from "./backfill-runner";
 
 const GLOBAL_RUNS_URL = "https://hashruns.org/api/global-runs";
 
@@ -130,16 +132,12 @@ function clean(value: string | undefined): string | undefined {
   return t ? t : undefined;
 }
 
-/** EventNumber → runNumber tri-state, matching the live adapter (0 → null). */
+/** EventNumber → runNumber tri-state, matching the live adapter (0 → null).
+ * Uses Number.isInteger so a NaN/Infinity/float never reaches the integer column. */
 function normalizeRunNumber(n: number | undefined): number | null | undefined {
   if (n === 0) return null;
-  if (typeof n === "number" && n > 0) return n;
+  if (Number.isInteger(n) && (n as number) > 0) return n;
   return undefined;
-}
-
-function eqTrimLc(a: string | undefined, b: string | undefined): boolean {
-  if (!a || !b) return false;
-  return a.trim().toLowerCase() === b.trim().toLowerCase();
 }
 
 /** Stale-title fallback — "<defaultTitle> #N" when configured, else undefined.
@@ -209,4 +207,50 @@ export function mapRunToRawEvent(
     longitude: hasVenue && typeof run.Longitude === "number" ? run.Longitude : undefined,
     description: clean(run.EventDescription),
   };
+}
+
+export interface HcKennelBackfillOptions {
+  /** Source row name (must exist + be linked to the kennel). */
+  sourceName: string;
+  /** Target kennelCode the runs are routed to. */
+  kennelTag: string;
+  /** HC PublicKennelId used to filter the global feed client-side. */
+  publicKennelId: string;
+  /** IANA timezone for the past/future partition. */
+  kennelTimezone: string;
+  /** Earliest date to sweep (YYYY-MM-DD); pre-HC-adoption windows return nothing. */
+  historyStart: string;
+  /** Source config (defaultTitle + staleTitleAliases) for adapter-faithful titles. */
+  config: HarrierCentralConfig;
+  /** `[1/2]` header label. */
+  label: string;
+}
+
+/**
+ * One-call HC kennel backfill: sweep the global-runs feed from `historyStart` to
+ * today, keep this kennel's runs, map them to the live adapter's shape, and route
+ * the past slice through the merge pipeline. Shared by every HARRIER_CENTRAL
+ * backfill wrapper so the per-kennel scripts are pure config (no duplicated
+ * fetch/filter/map/run boilerplate). Logs + exits non-zero on failure.
+ */
+export function runHcKennelBackfill(opts: HcKennelBackfillOptions): void {
+  runBackfillScript({
+    sourceName: opts.sourceName,
+    kennelTimezone: opts.kennelTimezone,
+    label: opts.label,
+    fetchEvents: async () => {
+      // UTC `today` is the sweep endpoint only — reportAndApplyBackfill
+      // re-partitions with todayInTimezone(kennelTimezone), so a ≤1-day-wide
+      // sweep here is harmless.
+      const today = new Date().toISOString().slice(0, 10);
+      const runs = await sweepGlobalRuns(opts.historyStart, today);
+      return runs
+        .filter((r) => r.PublicKennelId === opts.publicKennelId)
+        .map((r) => mapRunToRawEvent(r, opts.kennelTag, opts.config))
+        .filter((e): e is RawEventData => e !== null);
+    },
+  }).catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
 }

--- a/scripts/lib/hc-global-runs.ts
+++ b/scripts/lib/hc-global-runs.ts
@@ -1,0 +1,212 @@
+/**
+ * Shared Harrier Central historical-backfill helper.
+ *
+ * HC's azure `getEvents` API (what the live HarrierCentralAdapter uses) is
+ * FUTURE-ONLY — it never returns past runs, so a kennel's back-catalogue can't
+ * reach canonical Events from the recurring scrape. The hashruns.org front-end,
+ * however, exposes a global past-runs feed that DOES carry history:
+ *
+ *   GET https://hashruns.org/api/global-runs
+ *       ?isFuture=0&minEventDate=YYYY-MM-DD&maxEventDate=YYYY-MM-DD
+ *     → { totalMatchingEvents, runs: [ {PublicKennelId, EventNumber, EventName,
+ *         EventStartDatetime, Hares, LocationOneLineDesc, Latitude, Longitude,
+ *         EventDescription, ...}, ... ] }
+ *
+ * Quirks (discovered live, #2306/#2404/#2411):
+ *  - The feed is GLOBAL; its kennel query param is ignored — filter client-side
+ *    by `PublicKennelId`.
+ *  - `minEventDate`/`maxEventDate` must be bare `YYYY-MM-DD`; `isFuture` is "0"/"1".
+ *  - A too-wide window 500s (server-side timeout). `sweepGlobalRuns` windows the
+ *    range and halves any window that 500s, so the caller just passes a span.
+ *  - HC adoption is RECENT per kennel (Tokyo ~2021-09, Taiwan ~2021-12); there is
+ *    NO data before a kennel migrated to HC, regardless of its founding year. The
+ *    recoverable depth is whatever the feed actually holds — caller reports the
+ *    true count, never the founding-year estimate.
+ *
+ * Rows are mapped to the SAME `RawEventData` shape the live adapter emits (via
+ * the adapter's exported `applyTitleFallback` + `composeHcLocation`) so the merge
+ * pipeline dedupes recent runs against existing canonical Events instead of
+ * duplicating them.
+ */
+
+import { safeFetch } from "@/adapters/safe-fetch";
+import {
+  applyTitleFallback,
+  composeHcLocation,
+  type HarrierCentralConfig,
+} from "@/adapters/harrier-central/adapter";
+import type { RawEventData } from "@/adapters/types";
+
+const GLOBAL_RUNS_URL = "https://hashruns.org/api/global-runs";
+
+/** Subset of global-runs fields this backfill consumes. */
+export interface GlobalRun {
+  PublicEventId: string;
+  PublicKennelId: string;
+  EventNumber?: number;
+  EventName?: string;
+  EventStartDatetime?: string; // "2026-06-28T19:00:00" (local, no offset)
+  Hares?: string;
+  LocationOneLineDesc?: string;
+  Latitude?: number;
+  Longitude?: number;
+  EventDescription?: string;
+}
+
+interface GlobalRunsResponse {
+  totalMatchingEvents?: number;
+  runs?: GlobalRun[];
+}
+
+const DAY_MS = 86_400_000;
+const DEFAULT_WINDOW_DAYS = 56;
+const MIN_WINDOW_DAYS = 4; // floor for the halving retry
+
+function isoDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+async function fetchWindow(minDate: string, maxDate: string): Promise<GlobalRun[] | null> {
+  const url = `${GLOBAL_RUNS_URL}?isFuture=0&minEventDate=${minDate}&maxEventDate=${maxDate}`;
+  const res = await safeFetch(url, { headers: { Referer: "https://hashruns.org/" } });
+  if (res.status === 500) return null; // window too wide → caller halves
+  if (!res.ok) throw new Error(`global-runs ${minDate}..${maxDate} → HTTP ${res.status}`);
+  const json = (await res.json()) as GlobalRunsResponse;
+  if (!Array.isArray(json.runs)) {
+    throw new Error(`global-runs ${minDate}..${maxDate}: unexpected shape (no runs[])`);
+  }
+  return json.runs;
+}
+
+/** Recursively fetch [startMs, endMs], halving any sub-window that 500s. */
+async function sweepRange(startMs: number, endMs: number, acc: Map<string, GlobalRun>): Promise<void> {
+  let cursor = startMs;
+  while (cursor <= endMs) {
+    const windowEnd = Math.min(cursor + DEFAULT_WINDOW_DAYS * DAY_MS, endMs);
+    await fetchOrSplit(cursor, windowEnd, acc);
+    cursor = windowEnd + DAY_MS;
+  }
+}
+
+async function fetchOrSplit(aMs: number, bMs: number, acc: Map<string, GlobalRun>): Promise<void> {
+  const runs = await fetchWindow(isoDate(aMs), isoDate(bMs));
+  if (runs) {
+    for (const r of runs) {
+      if (r.PublicEventId) acc.set(r.PublicEventId, r);
+    }
+    return;
+  }
+  // 500 → window too wide. Halve and retry, down to MIN_WINDOW_DAYS.
+  const spanDays = Math.round((bMs - aMs) / DAY_MS);
+  if (spanDays <= MIN_WINDOW_DAYS) {
+    throw new Error(`global-runs still 500s at minimum window ${isoDate(aMs)}..${isoDate(bMs)}`);
+  }
+  const midMs = aMs + Math.floor((bMs - aMs) / 2);
+  await fetchOrSplit(aMs, midMs, acc);
+  await fetchOrSplit(midMs + DAY_MS, bMs, acc);
+}
+
+/**
+ * Sweep the global past-runs feed across [startDate, endDate] (inclusive,
+ * YYYY-MM-DD) and return every distinct run (deduped by PublicEventId), sorted
+ * by date. Windows adaptively so a dense span never 500s the caller.
+ */
+export async function sweepGlobalRuns(startDate: string, endDate: string): Promise<GlobalRun[]> {
+  const startMs = Date.parse(`${startDate}T00:00:00Z`);
+  const endMs = Date.parse(`${endDate}T00:00:00Z`);
+  const acc = new Map<string, GlobalRun>();
+  await sweepRange(startMs, endMs, acc);
+  return [...acc.values()].sort((a, b) =>
+    (a.EventStartDatetime ?? "").localeCompare(b.EventStartDatetime ?? ""),
+  );
+}
+
+const TIME_RE = /T(\d{2}:\d{2})/;
+const TBA_RE = /^tba$/i;
+const PLACEHOLDER_HARE_RE = /\bplaceholder (?:user|event)\b/i;
+
+function clean(value: string | undefined): string | undefined {
+  const t = value?.trim();
+  return t ? t : undefined;
+}
+
+/** EventNumber → runNumber tri-state, matching the live adapter (0 → null). */
+function normalizeRunNumber(n: number | undefined): number | null | undefined {
+  if (n === 0) return null;
+  if (typeof n === "number" && n > 0) return n;
+  return undefined;
+}
+
+function eqTrimLc(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/** Stale-title fallback — "<defaultTitle> #N" when configured, else undefined.
+ * Mirrors `staleTitleFallback` in the live HC adapter. */
+function staleTitleFallback(
+  eventNumber: number | undefined,
+  config: HarrierCentralConfig,
+): string | undefined {
+  if (config.defaultTitle && typeof eventNumber === "number" && eventNumber > 0) {
+    return `${config.defaultTitle} #${eventNumber}`;
+  }
+  return undefined;
+}
+
+/** Trim + drop TBA / placeholder hares; null when the hare is just the venue. */
+function cleanHares(raw: string | undefined, location: string | undefined): string | undefined {
+  const t = clean(raw);
+  if (!t || TBA_RE.test(t) || PLACEHOLDER_HARE_RE.test(t)) return undefined;
+  if (location && t.trim().toLowerCase() === location.trim().toLowerCase()) return undefined;
+  return t;
+}
+
+/**
+ * Map one global-runs row to a RawEventData for `kennelTag`, applying the live
+ * adapter's title-fallback + location-compose conventions so backfilled rows
+ * line up with the recurring scrape's output.
+ */
+export function mapRunToRawEvent(
+  run: GlobalRun,
+  kennelTag: string,
+  config: HarrierCentralConfig,
+): RawEventData | null {
+  const start = run.EventStartDatetime;
+  if (!start) return null;
+  const date = start.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+
+  const startTime = TIME_RE.exec(start)?.[1];
+  const location = composeHcLocation(run.LocationOneLineDesc, undefined, undefined);
+  const hares = cleanHares(run.Hares, location);
+  let title = applyTitleFallback(run.EventName, run.EventNumber, config);
+  // #2408/#2409 parity: a title that byte-equals the hares or the raw venue is
+  // never a real run title (the source pasted the neighborhood/hash name into
+  // the title slot, e.g. "Nogizaka", "Cancelled") — re-route through the
+  // stale-title fallback so it matches what the live adapter would store.
+  if (
+    title &&
+    (eqTrimLc(title, run.Hares) ||
+      eqTrimLc(title, run.LocationOneLineDesc) ||
+      eqTrimLc(title, location))
+  ) {
+    title = staleTitleFallback(run.EventNumber, config);
+  }
+  // When HC has no real venue (placeholder dropped to undefined), its coords are
+  // a region-default pin — drop them and let the merge geocoder resolve instead.
+  const hasVenue = location !== undefined;
+
+  return {
+    date,
+    kennelTags: [kennelTag],
+    title,
+    runNumber: normalizeRunNumber(run.EventNumber),
+    startTime,
+    hares,
+    location,
+    latitude: hasVenue && typeof run.Latitude === "number" ? run.Latitude : undefined,
+    longitude: hasVenue && typeof run.Longitude === "number" ? run.Longitude : undefined,
+    description: clean(run.EventDescription),
+  };
+}

--- a/scripts/lib/hc-global-runs.ts
+++ b/scripts/lib/hc-global-runs.ts
@@ -74,10 +74,17 @@ async function fetchWindow(minDate: string, maxDate: string): Promise<GlobalRun[
   if (res.status === 500) return null; // window too wide → caller halves
   if (!res.ok) throw new Error(`global-runs ${minDate}..${maxDate} → HTTP ${res.status}`);
   const json = (await res.json()) as GlobalRunsResponse;
-  if (!Array.isArray(json.runs)) {
-    throw new Error(`global-runs ${minDate}..${maxDate}: unexpected shape (no runs[])`);
+  const runs = json.runs;
+  if (!Array.isArray(runs)) {
+    throw new TypeError(`global-runs ${minDate}..${maxDate}: unexpected shape (no runs[])`);
   }
-  return json.runs;
+  // A capped response (server returned fewer than it claims to match) would
+  // silently drop history — treat it like a too-wide window so the caller halves
+  // and retries instead of accepting a truncated page as complete.
+  if (typeof json.totalMatchingEvents === "number" && json.totalMatchingEvents > runs.length) {
+    return null;
+  }
+  return runs;
 }
 
 /** Recursively fetch [startMs, endMs], halving any sub-window that 500s. */
@@ -152,11 +159,15 @@ function staleTitleFallback(
   return undefined;
 }
 
-/** Trim + drop TBA / placeholder hares; null when the hare is just the venue. */
+/**
+ * Trim + drop TBA / placeholder / venue-equal hares. Clears to `undefined`
+ * (NOT null) to match the live HC adapter, which uses undefined for exactly
+ * these cases — so a backfilled row fingerprints identically to a live scrape.
+ */
 function cleanHares(raw: string | undefined, location: string | undefined): string | undefined {
   const t = clean(raw);
   if (!t || TBA_RE.test(t) || PLACEHOLDER_HARE_RE.test(t)) return undefined;
-  if (location && t.trim().toLowerCase() === location.trim().toLowerCase()) return undefined;
+  if (eqTrimLc(t, location)) return undefined;
   return t;
 }
 


### PR DESCRIPTION
## What & why

WS4 historical-backfill workstream: import past events that sources expose but HashTracks didn't hold (~20 audit issues reporting large historical gaps). Adds one-shot `scripts/backfill-*.ts` that route past events through the **merge pipeline** (`processRawEvents`) — creating canonical Events inline, partitioning `date < today`, and idempotent on re-run (fingerprint dedup). **These scripts were already run against the live Railway prod DB**; this PR captures the scripts as durable, re-runnable artifacts.

## ~4,850 canonical past events imported (verified in prod)

| Issue | Kennel | Before → After | Method |
|---|---|---|---|
| #2285 | colombo-harriettes | 1 → **124** | `api2.hashcolombo.com/noauth/runs` JSON |
| #2429 | hoboh3 | +**1** real trail | Tidewater calendar feed (placeholders skipped) |
| #2314 | sloh3 | 20 → **153** | wide GCal `scrapeSource(days:9999)` |
| #2350 / #2352 | sh3-de / fm-stgt | 20→**429** / 13→**191** | Stuttgart GCal (one wide pass) |
| #2331 | space-city-h3 | 63 → **281** | Houston GCal (eventsFound 3302, cancelled=0) |
| #2411 | tokyo-h3 | 20 → **258** | HC `global-runs` sweep |
| #2404 | twh3-tw | 7 → **252** | HC `global-runs` sweep |
| #2306 | sh3-sg | 6 → **12** | HC (only 12 exist in HC) |
| #2296 / #2366 | sffmh3 / svh3 | 28→**127** / 24→**438** | sfh3.com year-archive |
| #2381 | sumo-h3 | 0 → **~80** | WP `/events/<id>/` JSON-LD |

Wide GCal passes also backfilled deep sibling history (Houston `h4-tx` 1861, `bmh3-tx` back to 2010; Stuttgart `dst-h3` 747) — benign multi-kennel re-fetch, `cancelled=0` on every pass.

## Files

- `scripts/lib/hc-global-runs.ts` — **new** shared Harrier Central history helper. HC's `getEvents` API is future-only; this sweeps `hashruns.org/api/global-runs` (adaptive windowing to dodge the wide-range 500, client-side filter by `PublicKennelId`) and maps rows to the live adapter's `RawEventData` shape via the adapter's exported `applyTitleFallback`/`composeHcLocation` (+ #2408/#2409 title-equals-venue guard) so recent runs dedupe against existing canonicals.
- `scripts/backfill-{tokyo-h3,twh3-tw,sh3-sg}-history.ts` — thin per-kennel HC wrappers.
- `scripts/backfill-colombo-harriettes-history.ts` — expanded from a 1-row onboarding stub to the full `/noauth/runs` archive.
- `scripts/backfill-tidewater-h3-history.ts` — reuses the adapter's `extractCalendarArray`/`parseCalendarEntry` to import past *real* trail entries (skips TBD placeholders).
- `scripts/backfill-sfh3-archive-history.ts` — sweeps the sfh3.com year-archive for SFFMH3 + SVH3, reusing the adapter's `parseHarelineRows`/`parseSFH3Date`/`parseICalSummary`.
- `scripts/backfill-sumo-h3-history.ts` — walks the WP `/events/<id>/` JSON-LD permalinks.

## Notes for reviewers

- **Scope**: only new files under `scripts/` (+ one expanded existing script) — no `src/adapters`, `merge.ts`, `seed-data`, migrations, or app changes. Scripts re-use production adapter parsers rather than re-implementing.
- **Honest-depth findings (corrected audit assumptions)**: HC only holds each kennel's HC-adoption-era data, *not* its founding-year history (SG = 12 runs, not 799 since 1994; bandung HC starts 2025-06). Sumo's gap is **recoverable** (clean WP JSON-LD), not "unrecoverable" as audited.
- **Idempotent**: every script dry-runs by default; `BACKFILL_APPLY=1` writes. Re-running is a no-op / accretive (sumo's numeric sweep is mildly network-flaky but the merge accumulates).
- Closes #2285, #2306, #2314, #2331, #2350, #2352, #2366, #2381, #2404, #2411, #2429. (#2296 already closed.)
- Still open (commented): #2302/#2290 (adapter hares fixes — out of WS4 scope), #2413 (Meetup auth wall), #1353/#2287/#2335 (remaining buildable backfills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)