### PR TITLE
fix(sonarcloud): resolve pre-existing credential-leak false positives + http NOSONAR

### DIFF
--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -2150,7 +2150,7 @@ export const KENNELS: KennelSeed[] = [
       // residential connections. Point the public website at the HTTP root, which is
       // the canonical reachable surface for end users (plain <a href> HTTP links carry
       // no mixed-content risk). The board source is tracked separately in #2054.
-      website: "http://atlantahash.com",
+      website: "http://atlantahash.com", // NOSONAR — see #1416 above: HTTPS hangs from every network tested; HTTP is the reachable surface
       scheduleDayOfWeek: "Saturday", scheduleTime: "1:00 PM", scheduleFrequency: "Weekly",
       hashCash: "$10", foundedYear: 1978,
       contactEmail: "info@atlantahash.com",


### PR DESCRIPTION
## What & why

`main`'s SonarCloud Quality Gate has been failing ("D Security Rating on New Code") since before PR #2462 merged — pre-existing, unrelated to that or any other recent merge. Traced and resolved the two findings behind it.

## 5 CRITICAL findings — verified false positives, not code changes

`tssecurity:S8689` ("confidential data leaking in logs") flagged 5 unrelated, months-old scripts:
- `scripts/cleanup-nbh3-misyeared.ts:28`
- `scripts/cleanup-sdh3-description-labels.ts:58`
- `scripts/cleanup-stale-schedule-rules.ts:155`
- `scripts/dedup-rawevent-fingerprint.ts:105`
- `scripts/backfill-historical-co-hosts.ts:55`

All 5 share the identical pattern: `new URL(process.env.DATABASE_URL).host` (or `.hostname`), logged so an operator can confirm the target environment before a destructive DB write — a deliberate safety practice.

Verified empirically that `.host`/`.hostname` structurally exclude the username/password per the WHATWG URL spec:
```
$ node -e 'console.log(new URL("postgresql://user:pass@host:port/db").host)'
host:port   # no credential
```
Only `.href`, `.toString()`, `.username`, `.password` carry the credential — none of the 5 call sites use those. SonarQube's taint model taints every property of a `URL` object once it's constructed from a "credential source" string, without recognizing `.host`/`.hostname` as a safe sub-extraction. Rewriting already-safe, deliberately-informative code to dodge this limitation would make it worse (an operator confirming the target host before a DELETE is exactly the safety net you want).

Marked all 5 `FALSE-POSITIVE` in SonarCloud with a verification comment via the REST API (the `mcp__sonarqube__markIssue(s)FalsePositive` MCP tool has a parameter-naming bug — `issue`/`issue_key`/`issue_keys` all rejected; fell back to `api/issues/do_transition` + `add_comment`). **User-authorized after review** — this is a project-dashboard action, not a code change, so it's called out explicitly here.

## 1 MINOR finding — NOSONAR, not a blind protocol swap

`typescript:S5332` (http→https) on Atlanta H4's `website` field (`prisma/seed-data/kennels.ts:2153`). The existing comment (from #1416) documents that `https://board.atlantahash.com` hangs from every network tested (cloud egress + NAS) but reportedly loads over HTTP on residential connections — HTTP was the deliberate choice.

Re-verified live: both `http://` and `https://atlantahash.com` currently timeout identically from this cloud environment (can't independently confirm or refute the residential-HTTP claim from here). Rather than blindly flip the protocol against a documented, deliberate decision, added a same-line `// NOSONAR` comment matching the codebase's existing convention for this exact situation (`dfwhhh.org`, `cspringsh3.com` use the identical pattern) — confirmed those two don't appear as open OR resolved SonarCloud issues at all, meaning the scanner respects the pragma at analysis time.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- Confirmed all 5 issues now show `issueStatus: FALSE_POSITIVE` on SonarCloud
- No functional code changed (0 lines of actual logic touched — 5 SonarCloud dashboard mutations + 1 comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)