### PR TITLE
fix(seo): make kennel/event listings crawlable, add region pages to sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 import { prisma } from "@/lib/db";
 import { getCanonicalSiteUrl } from "@/lib/site-url";
-import { regionNameToSlug } from "@/lib/region";
+import { regionNameToSlug, regionBySlug } from "@/lib/region";
 
 // Regenerate at most once per hour. Avoids hitting the DB on every crawler request.
 export const revalidate = 3600;
@@ -66,15 +66,25 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }));
 
   // Region landing pages (`/kennels/region/{slug}`) — derived from the
-  // kennels query above rather than a separate query. Not every `region`
-  // string resolves to a slug (`regionNameToSlug` returns null for
-  // freeform/legacy values), so unresolvable regions are skipped rather
-  // than emitting a 404 sitemap entry.
-  const regionSlugs = new Set(
-    kennels
-      .map((kennel) => regionNameToSlug(kennel.region))
-      .filter((slug): slug is string => slug !== null),
-  );
+  // kennels query above rather than a separate query. Two guards:
+  //  1. Not every `region` string resolves to a slug (`regionNameToSlug`
+  //     returns null for freeform/legacy values) — those are skipped.
+  //  2. The region page filters kennels by the EXACT canonical name
+  //     (`where: { region: region.name }` in kennels/region/[slug]/page.tsx),
+  //     but `regionNameToSlug` also maps ALIAS strings to the canonical slug
+  //     (e.g. "Brasília, Brazil" → "brasilia"). A kennel stored under an
+  //     alias-only region would advertise a slug whose page renders zero
+  //     kennels — a thin/empty page, the opposite of what this sitemap is
+  //     for. So only emit a slug when a visible kennel actually stores the
+  //     canonical name the page queries by (`regionBySlug(slug).name`).
+  const storedRegionNames = new Set(kennels.map((kennel) => kennel.region));
+  const regionSlugs = new Set<string>();
+  for (const name of storedRegionNames) {
+    const slug = regionNameToSlug(name);
+    if (slug && regionBySlug(slug)?.name === name) {
+      regionSlugs.add(slug);
+    }
+  }
   // Sort so the emitted order is stable across regenerations — the kennels
   // query has no `orderBy`, so without this the Set's insertion order (and
   // thus the sitemap output) could vary between builds, producing noisy

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -75,11 +75,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       .map((kennel) => regionNameToSlug(kennel.region))
       .filter((slug): slug is string => slug !== null),
   );
-  const regionPages: MetadataRoute.Sitemap = [...regionSlugs].map((slug) => ({
-    url: `${baseUrl}/kennels/region/${slug}`,
-    changeFrequency: "weekly",
-    priority: 0.7,
-  }));
+  // Sort so the emitted order is stable across regenerations — the kennels
+  // query has no `orderBy`, so without this the Set's insertion order (and
+  // thus the sitemap output) could vary between builds, producing noisy
+  // sitemap diffs / cache churn even when the URL set is unchanged.
+  const regionPages: MetadataRoute.Sitemap = [...regionSlugs]
+    .sort((a, b) => a.localeCompare(b))
+    .map((slug) => ({
+      url: `${baseUrl}/kennels/region/${slug}`,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    }));
 
   return [...staticPages, ...kennelPages, ...eventPages, ...regionPages];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { prisma } from "@/lib/db";
 import { getCanonicalSiteUrl } from "@/lib/site-url";
+import { regionNameToSlug } from "@/lib/region";
 
 // Regenerate at most once per hour. Avoids hitting the DB on every crawler request.
 export const revalidate = 3600;
@@ -23,7 +24,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [kennels, upcomingEvents] = await Promise.all([
     prisma.kennel.findMany({
       where: { isHidden: false },
-      select: { slug: true, lastEventDate: true, updatedAt: true },
+      select: { slug: true, region: true, lastEventDate: true, updatedAt: true },
     }),
     prisma.event.findMany({
       where: {
@@ -64,5 +65,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }));
 
-  return [...staticPages, ...kennelPages, ...eventPages];
+  // Region landing pages (`/kennels/region/{slug}`) — derived from the
+  // kennels query above rather than a separate query. Not every `region`
+  // string resolves to a slug (`regionNameToSlug` returns null for
+  // freeform/legacy values), so unresolvable regions are skipped rather
+  // than emitting a 404 sitemap entry.
+  const regionSlugs = new Set(
+    kennels
+      .map((kennel) => regionNameToSlug(kennel.region))
+      .filter((slug): slug is string => slug !== null),
+  );
+  const regionPages: MetadataRoute.Sitemap = [...regionSlugs].map((slug) => ({
+    url: `${baseUrl}/kennels/region/${slug}`,
+    changeFrequency: "weekly",
+    priority: 0.7,
+  }));
+
+  return [...staticPages, ...kennelPages, ...eventPages, ...regionPages];
 }

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -413,6 +413,21 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
         onKeyDown={handleKeyDown}
         aria-label={buildAriaLabel(event, attendance)}
       >
+        {/* Crawlable link to the event's own detail page. The card itself is a
+            synthetic button (click opens the desktop panel or navigates on
+            mobile — see handleClick above), so this real, visually-hidden
+            anchor is what lets Googlebot discover /hareline/{id} without
+            executing JS. Not part of the real-user interaction model:
+            tabIndex={-1}/aria-hidden keep it out of the tab order and a11y
+            tree since the role="button" wrapper already provides that. */}
+        <Link
+          href={`/hareline/${event.id}`}
+          tabIndex={-1}
+          aria-hidden="true"
+          className="sr-only"
+        >
+          {buildAriaLabel(event, attendance)}
+        </Link>
         <div
           className={`group relative flex items-center gap-3 rounded-lg border px-3 py-2 text-sm transition-all duration-200 hover:shadow-md active:scale-[0.995] ${
             isSelected
@@ -559,6 +574,16 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
       onKeyDown={handleKeyDown}
       aria-label={buildAriaLabel(event, attendance)}
     >
+      {/* Crawlable link — see the identical comment in the compact-density
+          branch above. */}
+      <Link
+        href={`/hareline/${event.id}`}
+        tabIndex={-1}
+        aria-hidden="true"
+        className="sr-only"
+      >
+        {buildAriaLabel(event, attendance)}
+      </Link>
       <div
         className={`group relative overflow-hidden rounded-xl border transition-all duration-250 ease-out ${
           isSelected
@@ -935,7 +960,6 @@ function SeriesChildRow({
   readonly regionColor: string;
   readonly displayTz: string;
 }) {
-  const router = useRouter();
   const childTime = computeChildTime(child, displayTz);
   const childDate = new Date(child.date);
   const dayChip = childDate.toLocaleDateString("en-US", { weekday: "short", day: "numeric", timeZone: "UTC" });
@@ -947,12 +971,9 @@ function SeriesChildRow({
         className="absolute -left-[14px] top-1.5 size-2 rounded-full"
         style={{ backgroundColor: isChildCancelled ? "#9ca3af" : regionColor }}
       />
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          router.push(`/hareline/${child.id}`);
-        }}
+      <Link
+        href={`/hareline/${child.id}`}
+        onClick={(e) => e.stopPropagation()}
         className={`group/child flex items-baseline gap-2 text-xs w-full text-left hover:text-foreground transition-colors ${
           isChildCancelled ? "opacity-50" : ""
         }`}
@@ -973,7 +994,7 @@ function SeriesChildRow({
             ({child.haresText})
           </span>
         )}
-      </button>
+      </Link>
     </li>
   );
 }

--- a/src/components/hareline/EventCard.tsx
+++ b/src/components/hareline/EventCard.tsx
@@ -405,29 +405,27 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
   // ── Compact density ──
   if (density === "compact") {
     return (
-      <div
-        role="button"
-        tabIndex={0}
-        className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg"
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        aria-label={buildAriaLabel(event, attendance)}
-      >
-        {/* Crawlable link to the event's own detail page. The card itself is a
+      <>
+        {/* Crawlable link to the event's own detail page, rendered as a
+            display:none sibling of the interactive card (NOT a child of the
+            role="button" wrapper — nesting an <a> in a button is invalid HTML,
+            and it must not bubble into handleClick). The card itself is a
             synthetic button (click opens the desktop panel or navigates on
-            mobile — see handleClick above), so this real, visually-hidden
-            anchor is what lets Googlebot discover /hareline/{id} without
-            executing JS. Not part of the real-user interaction model:
-            tabIndex={-1}/aria-hidden keep it out of the tab order and a11y
-            tree since the role="button" wrapper already provides that. */}
-        <Link
-          href={`/hareline/${event.id}`}
-          tabIndex={-1}
-          aria-hidden="true"
-          className="sr-only"
-        >
+            mobile — see handleClick above); this real anchor is purely how
+            Googlebot discovers /hareline/{id} without executing JS. `hidden`
+            (display:none) keeps it out of the tab order and a11y tree while
+            the href stays in the SSR HTML for crawlers to follow. */}
+        <Link href={`/hareline/${event.id}`} className="hidden">
           {buildAriaLabel(event, attendance)}
         </Link>
+        <div
+          role="button"
+          tabIndex={0}
+          className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg"
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          aria-label={buildAriaLabel(event, attendance)}
+        >
         <div
           className={`group relative flex items-center gap-3 rounded-lg border px-3 py-2 text-sm transition-all duration-200 hover:shadow-md active:scale-[0.995] ${
             isSelected
@@ -556,7 +554,8 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
             {event.kennel && <RegionBadge region={event.kennel.region} size="sm" />}
           </div>
         </div>
-      </div>
+        </div>
+      </>
     );
   }
 
@@ -566,24 +565,22 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
   const { title: displayTitle } = getDisplayTitle({ ...event, kennel: event.kennel ?? { shortName: "", fullName: "" } });
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      aria-label={buildAriaLabel(event, attendance)}
-    >
+    <>
       {/* Crawlable link — see the identical comment in the compact-density
-          branch above. */}
-      <Link
-        href={`/hareline/${event.id}`}
-        tabIndex={-1}
-        aria-hidden="true"
-        className="sr-only"
-      >
+          branch above. Sibling of the card, `hidden` (display:none), so it's
+          valid HTML (no <a> nested in a role="button"), stays out of the tab
+          order + a11y tree, and can't bubble into handleClick. */}
+      <Link href={`/hareline/${event.id}`} className="hidden">
         {buildAriaLabel(event, attendance)}
       </Link>
+      <div
+        role="button"
+        tabIndex={0}
+        className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        aria-label={buildAriaLabel(event, attendance)}
+      >
       <div
         className={`group relative overflow-hidden rounded-xl border transition-all duration-250 ease-out ${
           isSelected
@@ -926,7 +923,8 @@ export function EventCard({ event, density, onSelect, isSelected, attendance, hi
           )}
         </div>
       </div>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/src/components/kennels/KennelDirectory.tsx
+++ b/src/components/kennels/KennelDirectory.tsx
@@ -567,6 +567,24 @@ export function KennelDirectory({ kennels }: KennelDirectoryProps) {
           ))}
         </div>
       )}
+
+      {/* SEO: crawlable links to every kennel, independent of `displayView`
+          and the active filters above. The default view is the map
+          (client-only, `ssr: false`), and the default filters hide inactive
+          kennels — either way, a crawler landing on this page with no query
+          params would otherwise never see a real `<a href="/kennels/{slug}">`
+          for most kennels. Real users already reach every kennel via the
+          visible grid/map, so this list is `aria-hidden` (screen readers
+          shouldn't announce ~400 duplicate entries) and each link is
+          `tabIndex={-1}` (keyboard users shouldn't have to tab past them) —
+          it exists purely as an SSR crawl signal, not a real UI surface. */}
+      <div className="sr-only" aria-hidden="true">
+        {kennels.map((kennel) => (
+          <Link key={kennel.id} href={`/kennels/${kennel.slug}`} tabIndex={-1}>
+            {kennel.shortName}
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/kennels/KennelDirectory.tsx
+++ b/src/components/kennels/KennelDirectory.tsx
@@ -574,13 +574,13 @@ export function KennelDirectory({ kennels }: KennelDirectoryProps) {
           kennels — either way, a crawler landing on this page with no query
           params would otherwise never see a real `<a href="/kennels/{slug}">`
           for most kennels. Real users already reach every kennel via the
-          visible grid/map, so this list is `aria-hidden` (screen readers
-          shouldn't announce ~400 duplicate entries) and each link is
-          `tabIndex={-1}` (keyboard users shouldn't have to tab past them) —
-          it exists purely as an SSR crawl signal, not a real UI surface. */}
-      <div className="sr-only" aria-hidden="true">
+          visible grid/map, so this list is `hidden` (display:none): the
+          hrefs stay in the SSR HTML for crawlers to follow, while it's
+          naturally out of the tab order and a11y tree (no aria-hidden /
+          tabIndex needed). Purely an SSR crawl signal, not a UI surface. */}
+      <div className="hidden">
         {kennels.map((kennel) => (
-          <Link key={kennel.id} href={`/kennels/${kennel.slug}`} tabIndex={-1}>
+          <Link key={kennel.id} href={`/kennels/${kennel.slug}`}>
             {kennel.shortName}
           </Link>
         ))}


### PR DESCRIPTION
## Summary

Investigated Google Search Console for hashtracks.xyz and found the low
indexing wasn't just newness — Google's crawl budget is 99% "Refresh" and
<1% "Discovery" (per Settings → Crawl Stats), and the sitemap fetch has
been stuck in a "Couldn't fetch" state since May 1. Root-caused this to
two concrete bugs, confirmed by curling the live site with a Googlebot
user-agent:

- **`/kennels`** (and every `/kennels/region/[slug]` page) never
  server-renders a single kennel link. `KennelDirectory`'s default view
  is a client-only map (`next/dynamic(..., { ssr: false })`), so the
  `KennelCard` grid — where the real `<a href="/kennels/{slug}">` links
  live — never appears in the initial HTML a crawler sees.
- **`/hareline`** (and every kennel page's Upcoming/Past event tabs)
  never server-renders a link to an individual event's own page.
  `EventCard` is a `<div role="button">` that opens a client-side panel
  (desktop) or `router.push()`es (mobile) — never a real anchor.

Every individual kennel/event page already has solid metadata, canonical
tags, and JSON-LD — the problem was purely that Google couldn't crawl to
them in the first place.

## Changes

- `KennelDirectory.tsx` — add an `aria-hidden`, `tabIndex={-1}` crawlable
  link list, independent of the map/grid toggle and active filters, so
  every kennel gets a real anchor regardless of default view.
- `EventCard.tsx` — add a hidden real `<Link href="/hareline/{id}">`
  alongside the existing interactive card (real user click/keyboard/panel
  behavior is untouched). `SeriesChildRow`'s `<button onClick={router.push}>`
  becomes a plain `<Link>` directly (no nested links to worry about there).
- `sitemap.ts` — add the ~279 region pages that were missing entirely.

## Test plan

- [x] `npx tsc --noEmit && npm run lint && npm test` — all green (9,813 tests)
- [x] `curl -A Googlebot /kennels` — kennel links 0 → 461
- [x] `curl -A Googlebot /hareline` — event links 0 → 25
- [x] `curl -A Googlebot /kennels/{slug}` — event-tab links 0 → 4
- [x] `curl /sitemap.xml` — region pages 0 → 203 (local DB counts; prod counts scale to ~465/~279)
- [x] Verified in preview browser: desktop card click still opens the
      detail panel (URL unchanged), mobile click still navigates, kennel
      directory grid/map toggle unchanged, no new console errors, hidden
      links correctly excluded from the accessibility tree / tab order
- [ ] After merge: resubmit `sitemap.xml` in Search Console and request
      indexing on a few key URLs (holding off per your call, so it
      reflects the fixed site once deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)