### PR TITLE
feat(atlanta): route board.atlantahash.com scrape through a VPN proxy egress (#2054)

### DIFF
--- a/infra/proxy-relay/README.md
+++ b/infra/proxy-relay/README.md
@@ -70,6 +70,67 @@ Add to Vercel dashboard (Settings → Environment Variables):
 - `RESIDENTIAL_PROXY_URL` = `https://proxy.hashtracks.xyz`
 - `RESIDENTIAL_PROXY_KEY` = the `PROXY_API_KEY` value from the NAS `.env`
 
+## VPN Egress (Atlanta board — #2054)
+
+`board.atlantahash.com` sits behind OVH's anti-DDoS firewall, which drops **both**
+Vercel (datacenter) **and** the home residential range — so the residential relay
+above cannot reach it. Diagnosed live: home Spectrum ✗, Vercel ✗, NAS ✗; but
+cellular ✓, work WiFi ✓, home WiFi + ExpressVPN ✓ (IP/ASN-based block). The fix
+is a second relay whose traffic egresses through a **VPN exit** (ExpressVPN's exit
+is confirmed to reach the board). The app opts a source in via
+`config.egress: "vpn"` → `safeFetch({ egress: "vpn" })` → `VPN_PROXY_URL`.
+
+The `proxy-relay-vpn` service in `docker-compose.yml` implements this by **reusing
+the existing standalone `gluetun` container** (the one that already carries the
+torrent stack's ExpressVPN tunnel) via `network_mode: container:gluetun` — the
+same pattern qbittorrent uses. No second tunnel, no duplicate creds. Because the
+relay lives inside gluetun's network namespace, its `:3101` is reached at
+**gluetun's** address, not via a compose service name.
+
+### Setup
+
+1. **.env** (NAS `/volume1/docker/proxy-relay/.env`) — add only:
+   ```
+   VPN_PROXY_API_KEY=<openssl rand -hex 32>
+   ```
+   (No VPN creds here — they already live on the standalone gluetun container.)
+
+2. **Revive gluetun with the relay port published**, so the relay (sharing its
+   netns) is reachable from the host. The existing gluetun is stopped and does
+   NOT publish 3101 — add a `3101:3101` port mapping when you bring it back
+   (Container Manager → gluetun → Port Settings, or recreate with `-p 3101:3101`),
+   then start it.
+
+3. **Go/no-go gate** — confirm the VPN exit actually reaches the board BEFORE
+   enabling the source (this is the one unproven link):
+   ```bash
+   ssh nas-tailscale "/volume1/@appstore/ContainerManager/usr/bin/docker exec gluetun \
+     wget -qO- --timeout=15 'https://board.atlantahash.com/app.php/feed/forum/2' | head"
+   #   → expect XML starting with <feed ...>. If it times out, rotate the gluetun
+   #     SERVER_COUNTRIES / SERVER_CITIES to a different US exit and retry.
+   ```
+
+4. **Deploy the relay** (gluetun must already be running — `container:gluetun`
+   requires it):
+   ```bash
+   scp -O infra/proxy-relay/{docker-compose.yml,server.js,Dockerfile,README.md} \
+       nas-tailscale:/volume1/docker/proxy-relay/
+   ssh nas-tailscale "cd /volume1/docker/proxy-relay && \
+     /volume1/@appstore/ContainerManager/usr/bin/docker compose up -d --build proxy-relay-vpn"
+   ```
+
+5. **Cloudflare Tunnel** — add a public hostname `proxy-vpn.hashtracks.xyz` →
+   `http://<NAS-LAN-IP>:3101` (the relay is in gluetun's netns on the default
+   bridge, so target the host-published port — NOT a compose service name).
+
+6. **Vercel env** — add:
+   - `VPN_PROXY_URL` = `https://proxy-vpn.hashtracks.xyz`
+   - `VPN_PROXY_KEY` = the `VPN_PROXY_API_KEY` value from the NAS `.env`
+
+7. **Enable** — the `Atlanta Hash Board` source already has `config.egress: "vpn"`
+   (seed). Re-seed prod + trigger a scrape:
+   `POST /api/cron/scrape/{atlantaSourceId}` (`Authorization: Bearer $CRON_SECRET`).
+
 ## Security
 
 1. Timing-safe API key auth (`crypto.timingSafeEqual`, 256-bit random key)

--- a/infra/proxy-relay/docker-compose.yml
+++ b/infra/proxy-relay/docker-compose.yml
@@ -28,6 +28,35 @@ services:
         max-size: "5m"
         max-file: "3"
 
+  # --- VPN egress (for board.atlantahash.com / OVH anti-DDoS, #2054) ---
+  # Same zero-dep relay as `proxy-relay`, but its network is routed through the
+  # EXISTING standalone `gluetun` container (the one that already carries the
+  # torrent stack's ExpressVPN tunnel) via `network_mode: container:gluetun`.
+  # So it egresses from the VPN exit IP with no second tunnel. The app reaches
+  # it via VPN_PROXY_URL (→ safeFetch egress:"vpn").
+  #
+  # Prereqs (see README "VPN Egress"):
+  #   1. Revive the standalone gluetun container first (it's stopped) — this
+  #      compose does NOT manage it, so `depends_on` can't reference it.
+  #   2. Because proxy-relay-vpn shares gluetun's netns (not this compose's
+  #      network), publish 3101 on the gluetun container to the host and point
+  #      the Cloudflare tunnel ingress `proxy-vpn.hashtracks.xyz` at the NAS
+  #      host/LAN IP:3101 — NOT at a compose service name.
+  proxy-relay-vpn:
+    build: .
+    container_name: proxy-relay-vpn
+    restart: unless-stopped
+    network_mode: "container:gluetun" # reuse the standalone ExpressVPN tunnel
+    environment:
+      - PROXY_API_KEY=${VPN_PROXY_API_KEY}
+      - PORT=3101
+    mem_limit: 64m
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "3"
+
   cloudflared:
     image: cloudflare/cloudflared:latest
     container_name: cloudflared

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1981,6 +1981,11 @@ export const SOURCES = [
         // posts scroll off as new posts arrive. Reconciler must skip past
         // events. (#1263)
         upcomingOnly: true,
+        // board.atlantahash.com sits behind OVH's anti-DDoS firewall, which
+        // drops both Vercel (datacenter) and the home residential range — so
+        // the residential relay can't reach it. Route via the VPN-relay egress
+        // (VPN_PROXY_URL/KEY → NAS proxy-relay-vpn → gluetun/ExpressVPN). (#2054)
+        egress: "vpn",
         forums: {
           "2": { kennelTag: "ah4", hashDay: "Saturday" },
           "4": { kennelTag: "ph3-atl", hashDay: "Saturday" },

--- a/src/adapters/html-scraper/atlanta-hash-board.test.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.test.ts
@@ -535,33 +535,47 @@ describe("AtlantaHashBoardAdapter", () => {
     await expect(adapter.fetch(source)).rejects.toThrow("source.config is null");
   });
 
-  // Per-source useResidentialProxy flag — origin WAF blocks cloud-egress IPs (#633);
-  // adapter forwards the flag to safeFetch when the source row opts in, else defaults false.
+  // Per-source proxy egress — board.atlantahash.com is behind OVH anti-DDoS that
+  // blocks datacenter AND the home residential range, so it needs the VPN egress
+  // (#2054). The adapter forwards config.egress + config.useResidentialProxy RAW;
+  // safeFetch owns precedence + the legacy-alias resolution (covered in
+  // safe-fetch.test.ts). Here we only assert the adapter plumbs both through.
   it.each([
-    { configValue: true, expectedForwarded: true, label: "true forwards through" },
-    { configValue: undefined, expectedForwarded: false, label: "undefined defaults to false" },
-  ])("useResidentialProxy: $label", async ({ configValue, expectedForwarded }) => {
+    { config: {}, egress: undefined, proxy: undefined, label: "no proxy config" },
+    { config: { useResidentialProxy: true }, egress: undefined, proxy: true, label: "useResidentialProxy:true forwarded raw" },
+    { config: { useResidentialProxy: false }, egress: undefined, proxy: false, label: "useResidentialProxy:false forwarded raw" },
+    { config: { egress: "residential" }, egress: "residential", proxy: undefined, label: 'egress:"residential"' },
+    { config: { egress: "vpn" }, egress: "vpn", proxy: undefined, label: 'egress:"vpn"' },
+    { config: { egress: "vpn", useResidentialProxy: true }, egress: "vpn", proxy: true, label: "both forwarded raw" },
+  ])("forwards proxy config to safeFetch: $label", async ({ config: extra, egress, proxy }) => {
     mockSafeFetch.mockResolvedValue(mockResponse({
       ok: true,
       text: () => Promise.resolve(SAMPLE_ATOM_FEED),
     }));
 
     const adapter = new AtlantaHashBoardAdapter();
-    const config: Record<string, unknown> = {
-      forums: { "2": { kennelTag: "ah4", hashDay: "Saturday" } },
-    };
-    if (configValue !== undefined) config.useResidentialProxy = configValue;
     const source = {
       id: "test-source",
       url: "https://board.atlantahash.com",
-      config,
+      config: { forums: { "2": { kennelTag: "ah4", hashDay: "Saturday" } }, ...extra },
     } as never;
 
     await adapter.fetch(source);
 
     expect(mockSafeFetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ useResidentialProxy: expectedForwarded }),
+      expect.objectContaining({ egress, useResidentialProxy: proxy }),
     );
+  });
+
+  it("rejects an invalid egress value", async () => {
+    const adapter = new AtlantaHashBoardAdapter();
+    const source = {
+      id: "test-source",
+      url: "https://board.atlantahash.com",
+      config: { forums: { "2": { kennelTag: "ah4", hashDay: "Saturday" } }, egress: "carrier" },
+    } as never;
+
+    await expect(adapter.fetch(source)).rejects.toThrow(/config\.egress must be/);
   });
 });

--- a/src/adapters/html-scraper/atlanta-hash-board.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.ts
@@ -12,7 +12,7 @@
 import * as cheerio from "cheerio";
 import type { Source } from "@/generated/prisma/client";
 import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails, ParseError } from "../types";
-import { safeFetch } from "../safe-fetch";
+import { safeFetch, type ProxyEgress } from "../safe-fetch";
 import { parse12HourTime, validateSourceConfig, decodeEntities, stripHtmlTags, chronoParseDate, buildDateWindow, cleanLocationName } from "../utils";
 
 // ── Config shape ──
@@ -29,8 +29,17 @@ interface AtlantaHashBoardConfig {
    * cloud-egress IPs entirely; this flag opts a source into proxy routing.
    * Not a guaranteed bypass — some residential IPs (including the NAS at
    * times) are also blocked. (#633)
+   * @deprecated Prefer `egress`; retained as a back-compat alias for
+   * `egress: "residential"`.
    */
   useResidentialProxy?: boolean;
+  /**
+   * Proxy-relay egress for feed fetches. board.atlantahash.com sits behind
+   * OVH's anti-DDoS firewall, which drops BOTH Vercel and the home residential
+   * range (so "residential" is insufficient) but lets a VPN exit through — set
+   * `egress: "vpn"` to route via the VPN-relay (#2054). Omit for direct fetch.
+   */
+  egress?: ProxyEgress;
 }
 
 // ── Atom feed types ──
@@ -447,13 +456,23 @@ export class AtlantaHashBoardAdapter implements SourceAdapter {
     );
 
     const baseUrl = source.url || "https://board.atlantahash.com";
-    const rawProxyFlag = config.useResidentialProxy;
-    if (rawProxyFlag !== undefined && typeof rawProxyFlag !== "boolean") {
+    const useResidentialProxy = config.useResidentialProxy;
+    if (
+      useResidentialProxy !== undefined &&
+      typeof useResidentialProxy !== "boolean"
+    ) {
       throw new Error(
-        `AtlantaHashBoardAdapter: config.useResidentialProxy must be a boolean, got ${typeof rawProxyFlag}`,
+        `AtlantaHashBoardAdapter: config.useResidentialProxy must be a boolean, got ${typeof useResidentialProxy}`,
       );
     }
-    const useResidentialProxy = rawProxyFlag ?? false;
+    const egress = config.egress;
+    if (egress !== undefined && egress !== "residential" && egress !== "vpn") {
+      throw new Error(
+        `AtlantaHashBoardAdapter: config.egress must be "residential" | "vpn", got ${JSON.stringify(egress)}`,
+      );
+    }
+    // Forward both raw; safeFetch resolves precedence + the legacy alias
+    // (explicit egress fails closed; useResidentialProxy falls back).
     const { minDate, maxDate } = buildDateWindow(options?.days);
 
     const allEvents: RawEventData[] = [];
@@ -471,6 +490,7 @@ export class AtlantaHashBoardAdapter implements SourceAdapter {
         try {
           const response = await safeFetch(feedUrl, {
             headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracks-Scraper)" },
+            egress,
             useResidentialProxy,
           });
           if (!response.ok) {

--- a/src/adapters/html-scraper/atlanta-hash-board.ts
+++ b/src/adapters/html-scraper/atlanta-hash-board.ts
@@ -28,9 +28,7 @@ interface AtlantaHashBoardConfig {
    * Route fetches through the NAS residential proxy. The origin WAF blocks
    * cloud-egress IPs entirely; this flag opts a source into proxy routing.
    * Not a guaranteed bypass — some residential IPs (including the NAS at
-   * times) are also blocked. (#633)
-   * @deprecated Prefer `egress`; retained as a back-compat alias for
-   * `egress: "residential"`.
+   * times) are also blocked. (#633) Convenience alias for `egress: "residential"`.
    */
   useResidentialProxy?: boolean;
   /**

--- a/src/adapters/safe-fetch.test.ts
+++ b/src/adapters/safe-fetch.test.ts
@@ -109,3 +109,91 @@ describe("safeFetch residential-proxy body forwarding", () => {
     expect(payload).not.toHaveProperty("body");
   });
 });
+
+describe("safeFetch egress selection (residential vs vpn)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  const prev = {
+    resUrl: process.env.RESIDENTIAL_PROXY_URL,
+    resKey: process.env.RESIDENTIAL_PROXY_KEY,
+    vpnUrl: process.env.VPN_PROXY_URL,
+    vpnKey: process.env.VPN_PROXY_KEY,
+  };
+
+  beforeEach(() => {
+    process.env.RESIDENTIAL_PROXY_URL = "https://residential.example";
+    process.env.RESIDENTIAL_PROXY_KEY = "r".repeat(32);
+    process.env.VPN_PROXY_URL = "https://vpn.example";
+    process.env.VPN_PROXY_KEY = "v".repeat(32);
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.RESIDENTIAL_PROXY_URL = prev.resUrl;
+    process.env.RESIDENTIAL_PROXY_KEY = prev.resKey;
+    process.env.VPN_PROXY_URL = prev.vpnUrl;
+    process.env.VPN_PROXY_KEY = prev.vpnKey;
+  });
+
+  function targetUrl(): string {
+    return fetchSpy.mock.calls[0]?.[0] as string;
+  }
+  function proxyKeyHeader(): string | undefined {
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    return (init?.headers as Record<string, string> | undefined)?.["X-Proxy-Key"];
+  }
+
+  it('routes egress:"vpn" through the VPN relay', async () => {
+    await safeFetch("https://board.atlantahash.com/feed", { egress: "vpn" });
+
+    expect(targetUrl()).toBe("https://vpn.example/proxy");
+    expect(proxyKeyHeader()).toBe("v".repeat(32));
+  });
+
+  it('routes egress:"residential" through the residential relay', async () => {
+    await safeFetch("https://example.com/feed", { egress: "residential" });
+
+    expect(targetUrl()).toBe("https://residential.example/proxy");
+    expect(proxyKeyHeader()).toBe("r".repeat(32));
+  });
+
+  it("treats useResidentialProxy:true as the residential alias", async () => {
+    await safeFetch("https://example.com/feed", { useResidentialProxy: true });
+
+    expect(targetUrl()).toBe("https://residential.example/proxy");
+  });
+
+  it("lets egress take precedence over the useResidentialProxy alias", async () => {
+    await safeFetch("https://board.atlantahash.com/feed", {
+      egress: "vpn",
+      useResidentialProxy: true,
+    });
+
+    expect(targetUrl()).toBe("https://vpn.example/proxy");
+  });
+
+  it("fails closed when an explicit vpn egress is requested but its env is unset", async () => {
+    delete process.env.VPN_PROXY_URL;
+    delete process.env.VPN_PROXY_KEY;
+
+    await expect(
+      safeFetch("https://board.atlantahash.com/feed", { egress: "vpn" }),
+    ).rejects.toThrow(/VPN_PROXY_URL\/KEY not configured/);
+    // Must NOT silently fall back to a direct fetch of the known-blocked origin.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("legacy useResidentialProxy still falls back to a direct fetch when env is unset", async () => {
+    delete process.env.RESIDENTIAL_PROXY_URL;
+    delete process.env.RESIDENTIAL_PROXY_KEY;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await safeFetch("https://example.com/feed", { useResidentialProxy: true });
+
+    // Legacy alias keeps its graceful dev fallback: direct fetch to the target URL.
+    expect(targetUrl()).toBe("https://example.com/feed");
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/adapters/safe-fetch.ts
+++ b/src/adapters/safe-fetch.ts
@@ -14,9 +14,32 @@ export { validateSourceUrl } from "./utils";
 
 const MAX_REDIRECTS = 5;
 
+/**
+ * Which NAS proxy-relay egress to route a request through instead of fetching
+ * directly from the app's own (datacenter) IP:
+ *  - "residential" — the NAS's home residential IP (`RESIDENTIAL_PROXY_URL/KEY`).
+ *    For origins that block datacenter IPs but allow residential ones.
+ *  - "vpn" — a VPN-routed relay egress (`VPN_PROXY_URL/KEY`). For origins that
+ *    block BOTH datacenter and the home residential range — e.g. OVH's
+ *    anti-DDoS firewall on board.atlantahash.com, which drops Vercel and the
+ *    home Spectrum IP alike but lets a VPN exit through (#2054).
+ */
+export type ProxyEgress = "residential" | "vpn";
+
 export interface SafeFetchOptions extends RequestInit {
-  /** Route through NAS residential proxy. Use for WAF-blocked domains. */
+  /**
+   * Route through the NAS residential proxy. Use for WAF-blocked domains.
+   * @deprecated Prefer `egress: "residential"`; kept as a back-compat alias.
+   */
   useResidentialProxy?: boolean;
+  /**
+   * Route through a named NAS proxy-relay egress. Takes precedence over
+   * `useResidentialProxy`. Fails CLOSED (throws) when the corresponding proxy
+   * env vars are unset — an explicit egress must not silently degrade to a
+   * direct fetch, because the caller depends on that specific exit (e.g. the
+   * origin blocks direct datacenter traffic).
+   */
+  egress?: ProxyEgress;
 }
 
 /**
@@ -43,20 +66,65 @@ function headersToRecord(
   return { ...headers };
 }
 
+/**
+ * Resolve the proxy-relay endpoint + auth key for a named egress. Both the
+ * residential and VPN egresses speak the same `/proxy` JSON envelope; they only
+ * differ in which NAS relay (and therefore which outbound IP) handles the request.
+ */
+function resolveProxyEgress(egress: ProxyEgress): {
+  proxyUrl: string | undefined;
+  proxyKey: string | undefined;
+  envLabel: string;
+} {
+  switch (egress) {
+    case "vpn":
+      return {
+        proxyUrl: process.env.VPN_PROXY_URL,
+        proxyKey: process.env.VPN_PROXY_KEY,
+        envLabel: "VPN_PROXY_URL/KEY",
+      };
+    case "residential":
+      return {
+        proxyUrl: process.env.RESIDENTIAL_PROXY_URL,
+        proxyKey: process.env.RESIDENTIAL_PROXY_KEY,
+        envLabel: "RESIDENTIAL_PROXY_URL/KEY",
+      };
+    default: {
+      // Exhaustiveness guard: a new ProxyEgress value fails to compile here
+      // rather than silently resolving to the residential defaults.
+      const unknown: never = egress;
+      throw new Error(`Unknown proxy egress: ${String(unknown)}`);
+    }
+  }
+}
+
 export async function safeFetch(
   url: string,
   init?: SafeFetchOptions,
 ): Promise<Response> {
-  // Residential proxy path
-  if (init?.useResidentialProxy) {
+  // Proxy-relay egress path. An explicit `egress` wins and fails CLOSED when its
+  // env vars are missing (the caller depends on that exit — e.g. Atlanta's origin
+  // blocks direct datacenter traffic, so a silent direct fetch would just hammer
+  // the known-bad path). `useResidentialProxy` is the legacy alias and keeps a
+  // graceful direct-fetch fallback so dev environments (no proxy env) work unchanged.
+  const explicitEgress = init?.egress;
+  const egress: ProxyEgress | undefined =
+    explicitEgress ?? (init?.useResidentialProxy ? "residential" : undefined);
+  // `egress` can only be set when `init` is defined; the `&& init` restores that
+  // narrowing for TS inside the block (init.headers/method/body/signal below).
+  if (egress && init) {
     await validateSourceUrlWithDns(url); // Defense-in-depth: validate even when proxying
 
-    const proxyUrl = process.env.RESIDENTIAL_PROXY_URL;
-    const proxyKey = process.env.RESIDENTIAL_PROXY_KEY;
+    const { proxyUrl, proxyKey, envLabel } = resolveProxyEgress(egress);
 
     if (!proxyUrl || !proxyKey) {
+      if (explicitEgress) {
+        throw new Error(
+          `safeFetch: egress "${egress}" requested but ${envLabel} not configured — refusing to fall back to a direct fetch`,
+        );
+      }
       console.warn(
-        "Residential proxy requested but RESIDENTIAL_PROXY_URL/KEY not set — falling back to direct fetch",
+        `Residential proxy requested but ${envLabel} not set — falling back to direct fetch`,
       );
     } else {
       const headerRecord = headersToRecord(init.headers);
@@ -90,7 +158,7 @@ export async function safeFetch(
       if (!proxyResponse.ok) {
         const body = await proxyResponse.text();
         throw new Error(
-          `Residential proxy error (${proxyResponse.status}): ${body}`,
+          `${egress} proxy error (${proxyResponse.status}): ${body}`,
         );
       }
 

--- a/src/adapters/safe-fetch.ts
+++ b/src/adapters/safe-fetch.ts
@@ -28,8 +28,9 @@ export type ProxyEgress = "residential" | "vpn";
 
 export interface SafeFetchOptions extends RequestInit {
   /**
-   * Route through the NAS residential proxy. Use for WAF-blocked domains.
-   * @deprecated Prefer `egress: "residential"`; kept as a back-compat alias.
+   * Route through the NAS residential proxy (for WAF-blocked domains).
+   * Convenience alias for `egress: "residential"`; an explicit `egress` takes
+   * precedence when both are set.
    */
   useResidentialProxy?: boolean;
   /**

--- a/src/adapters/safe-fetch.ts
+++ b/src/adapters/safe-fetch.ts
@@ -112,8 +112,12 @@ export async function safeFetch(
     explicitEgress ?? (init?.useResidentialProxy ? "residential" : undefined);
   // `egress` can only be set when `init` is defined; the `&& init` restores that
   // narrowing for TS inside the block (init.headers/method/body/signal below).
+  // Track whether the URL was already DNS-validated here so the direct-fetch
+  // fallback (legacy alias + no proxy env) doesn't redundantly re-resolve it.
+  let urlValidated = false;
   if (egress && init) {
     await validateSourceUrlWithDns(url); // Defense-in-depth: validate even when proxying
+    urlValidated = true;
 
     const { proxyUrl, proxyKey, envLabel } = resolveProxyEgress(egress);
 
@@ -166,8 +170,11 @@ export async function safeFetch(
     }
   }
 
-  // Direct fetch path (default)
-  await validateSourceUrlWithDns(url);
+  // Direct fetch path (default). Skip re-validation if the proxy branch already
+  // DNS-validated this URL (legacy-alias fallback with no proxy env configured).
+  if (!urlValidated) {
+    await validateSourceUrlWithDns(url);
+  }
   let currentUrl = url;
   let redirectCount = 0;
 


### PR DESCRIPTION
## What
Routes the **Atlanta Hash Board** scrape (9 ATL kennels: `ah4, ph3-atl, bsh3, sobh3, whh3, mlh4, duffh3, sluth3, soco-h3`) through a **VPN proxy egress** so it can reach `board.atlantahash.com`.

## Why
`board.atlantahash.com` sits behind OVH's anti-DDoS firewall, which **IP-blocks both Vercel (datacenter) and the home residential range** (diagnosed live: direct ✗, home/NAS ✗, ExpressVPN exit ✓). The existing NAS residential proxy shares the blocked home IP, so a VPN-routed egress is required. Fixes the long-standing "board is down / unreachable" state.

## Changes
- **`safeFetch`** (`src/adapters/safe-fetch.ts`): new `egress: "residential" | "vpn"` option → `RESIDENTIAL_PROXY_*` vs `VPN_PROXY_*` relays. `useResidentialProxy` retained as a back-compat **alias** (no behavior change for existing callers). An **explicit** `egress` **fails closed** (throws) when its env vars are missing — no silent fallback to the known-blocked direct path — while the legacy alias keeps its dev fallback. Resolver is exhaustiveness-checked.
- **Atlanta adapter** (`atlanta-hash-board.ts`): validates + forwards `config.egress` / `config.useResidentialProxy` raw; `safeFetch` owns resolution.
- **Seed** (`prisma/seed-data/sources.ts`): Atlanta Hash Board source → `egress: "vpn"`.
- **Infra** (`infra/proxy-relay/`): `proxy-relay-vpn` container routed through the existing standalone `gluetun` (ExpressVPN) tunnel via `network_mode: container:gluetun`; README setup + validation steps.

## Verification
- `npx tsc --noEmit` clean · **66 unit tests pass** · `eslint` clean.
- **End-to-end (live):** `POST https://proxy-vpn.hashtracks.xyz/proxy` with the board feed URL returned the live **Atlanta Hash House Harriers** Atom feed through the ExpressVPN exit.

## Post-merge steps (owner)
Vercel runs migrations, not the seed, so after deploy:
1. Set Vercel env `VPN_PROXY_URL` + `VPN_PROXY_KEY` (Cloudflare hostname + NAS relay already live).
2. Apply `egress: "vpn"` to the Atlanta `Source.config` in prod (targeted update).
3. Trigger `POST /api/cron/scrape/{atlantaSourceId}` and confirm events flow for the 9 kennels.

Closes #2054

🤖 Generated with [Claude Code](https://claude.com/claude-code)
