### PR TITLE
feat(sources): onboard SG Harriets official hareline (#2299)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4826,6 +4826,9 @@ export const SOURCES = [
         defaultStartTime: "18:00", // Wed 6pm, matches the static schedule
         maxPastDays: 7,
         maxFutureDays: 120,
+        // Forward-only rolling hareline — past runs fall off the page, so the
+        // reconciler must not cancel them when they disappear from the scrape.
+        upcomingOnly: true,
       },
       kennelCodes: ["sgharriets"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -4800,6 +4800,35 @@ export const SOURCES = [
       },
       kennelCodes: ["sgharriets"],
     },
+    // --- SG Harriets official hareline (#2299) ---
+    // singaporeharriets.com/hareline exposes per-run number + hares the FB
+    // STATIC_SCHEDULE above can't. Higher trust so the real run#/hares/title
+    // enrich the generic Wednesday placeholders; the static schedule stays for
+    // forward Wednesday coverage beyond the (short) hareline window.
+    {
+      name: "SG Harriets Hareline",
+      url: "https://www.singaporeharriets.com/hareline/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "daily",
+      scrapeDays: 90,
+      config: {
+        // Clean semantic rows: .shhh-hareline-run-row > run-date/number/hares.
+        containerSelector: "body",
+        rowSelector: ".shhh-hareline-run-row",
+        columns: {
+          date: ".shhh-hareline-run-date", // "1 July 2026"
+          runNumber: ".shhh-hareline-run-number", // "Run #2663" -> 2663
+          hares: ".shhh-hareline-run-hares", // "Zipp, Big Head & Gypsy"
+        },
+        defaultKennelTag: "sgharriets",
+        dateLocale: "en-GB", // D Month YYYY
+        defaultStartTime: "18:00", // Wed 6pm, matches the static schedule
+        maxPastDays: 7,
+        maxFutureDays: 120,
+      },
+      kennelCodes: ["sgharriets"],
+    },
 
     // 6. Hash House Horrors — children's hash, WordPress.com Public API hareline page
     {


### PR DESCRIPTION
## What
Batch 2 (part 1) — onboard the **SG Harriets** official hareline (#2299) as a config-only GenericHtml source.

## Why
`sgharriets` currently has only a Facebook `STATIC_SCHEDULE` that synthesizes generic "Singapore Harriets Wednesday Run" placeholders (no run number, no hares). The kennel's official site publishes a structured hareline with run numbers + named hares.

## Change
Added an `HTML_SCRAPER` source using the existing `GenericHtmlAdapter` — **no new code**, clean semantic `.shhh-hareline-run-row` markup:
- `date` → `.shhh-hareline-run-date` ("1 July 2026", en-GB)
- `runNumber` → `.shhh-hareline-run-number` ("Run #2663" → 2663)
- `hares` → `.shhh-hareline-run-hares`
- trust 6 (above the static's 3) so real run#/hares/title enrich the Wednesday placeholders; the static schedule stays for forward coverage beyond the (short) hareline window; both use Wed 18:00.

## Verified live
Ran `GenericHtmlAdapter` against the live page: **8 events (#2663–#2670), 0 errors**, all `sgharriets`, Wed 18:00, hares extracted (open/unhared runs correctly empty).

`tsc --noEmit` clean · seed-data tests pass (12) · lint clean.

## Post-merge
Vercel deploys migrations, not seed → after merge: targeted create of the source + SourceKennel link, then a scrape to hydrate (same as Batch 1).

Closes #2299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
