### PR TITLE
chore(backfill): recover White House H3 historical hareline 2016-2023 (#2481)

### DIFF
--- a/scripts/backfill-wh4-history.ts
+++ b/scripts/backfill-wh4-history.ts
@@ -31,7 +31,7 @@ const SHEET =
   "2PACX-1vSydTV1S3AL9iUCrZKfzd7r9PCXSjx8wep3GWwuRAaA4THOpHrSgP-VGb87ICMWPe3iFM9WdNIyGh4K";
 const HISTORICAL_CSV = `https://docs.google.com/spreadsheets/d/e/${SHEET}/pub?gid=377767908&single=true&output=csv`;
 
-void runBackfillScript({
+runBackfillScript({
   sourceName: "White House H3 Hareline",
   kennelTimezone: "America/New_York",
   label: "Fetching WH4 historical hareline tab (gid=377767908)",
@@ -57,4 +57,7 @@ void runBackfillScript({
     }
     return res.events;
   },
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
 });

--- a/scripts/backfill-wh4-history.ts
+++ b/scripts/backfill-wh4-history.ts
@@ -3,9 +3,9 @@
  *
  * The live "White House H3 Hareline" GOOGLE_SHEETS source reads the sheet's
  * "Upcoming Trails" tab (gid=163010917 = the 2026 season). The same published
- * sheet has a separate historical tab (gid=377767908) with ~82 older runs
- * (2019 + 2022 + 2023, run# 1880–2101, gappy — no 2020/2021). Those pre-2026
- * runs are on a tab the live source never reads, so they need a one-shot.
+ * sheet has a separate historical tab (gid=377767908) with ~297 older runs
+ * (2016–2023, run# 1717–2101, gappy — no 2021, and 2024–25 absent). Those
+ * pre-2026 runs are on a tab the live source never reads, so they need a one-shot.
  *
  * Reuses GoogleSheetsAdapter for parsing (same column layout as the live tab),
  * binds to the "White House H3 Hareline" source for correct provenance, and
@@ -13,7 +13,7 @@
  * created in one pass; idempotent; strict date<today partition so it never
  * collides with the live 2026 source).
  *
- * The deeper archive (1987→2019, run #1–#1879) + the 2024–25 gap are not on the
+ * The deeper archive (1987→2016, run #1–#1716) + the 2024–25 gap are not on the
  * sheet — recoverable only from the kennel's own records (cf. #2053).
  *
  * Usage:

--- a/scripts/backfill-wh4-history.ts
+++ b/scripts/backfill-wh4-history.ts
@@ -49,7 +49,12 @@ void runBackfillScript({
       },
     } as unknown as Source;
     const res = await new GoogleSheetsAdapter().fetch(source, { days: 9999 });
-    if (res.errors.length > 0) console.warn("  adapter errors:", res.errors);
+    // Fail loud: a fetch/parse failure returns errors alongside a partial or
+    // empty event set — abort rather than silently backfilling an incomplete
+    // slice as if it were the whole archive.
+    if (res.errors.length > 0) {
+      throw new Error(`GoogleSheetsAdapter failed: ${res.errors.join("; ")}`);
+    }
     return res.events;
   },
 });

--- a/scripts/backfill-wh4-history.ts
+++ b/scripts/backfill-wh4-history.ts
@@ -1,0 +1,55 @@
+/**
+ * One-shot historical backfill for White House H3 (wh4), issue #2481.
+ *
+ * The live "White House H3 Hareline" GOOGLE_SHEETS source reads the sheet's
+ * "Upcoming Trails" tab (gid=163010917 = the 2026 season). The same published
+ * sheet has a separate historical tab (gid=377767908) with ~82 older runs
+ * (2019 + 2022 + 2023, run# 1880–2101, gappy — no 2020/2021). Those pre-2026
+ * runs are on a tab the live source never reads, so they need a one-shot.
+ *
+ * Reuses GoogleSheetsAdapter for parsing (same column layout as the live tab),
+ * binds to the "White House H3 Hareline" source for correct provenance, and
+ * routes through reportAndApplyBackfill → processRawEvents (canonical Events
+ * created in one pass; idempotent; strict date<today partition so it never
+ * collides with the live 2026 source).
+ *
+ * The deeper archive (1987→2019, run #1–#1879) + the 2024–25 gap are not on the
+ * sheet — recoverable only from the kennel's own records (cf. #2053).
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-wh4-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-wh4-history.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { GoogleSheetsAdapter } from "@/adapters/google-sheets/adapter";
+import type { RawEventData } from "@/adapters/types";
+import type { Source } from "@/generated/prisma/client";
+
+const SHEET =
+  "2PACX-1vSydTV1S3AL9iUCrZKfzd7r9PCXSjx8wep3GWwuRAaA4THOpHrSgP-VGb87ICMWPe3iFM9WdNIyGh4K";
+const HISTORICAL_CSV = `https://docs.google.com/spreadsheets/d/e/${SHEET}/pub?gid=377767908&single=true&output=csv`;
+
+void runBackfillScript({
+  sourceName: "White House H3 Hareline",
+  kennelTimezone: "America/New_York",
+  label: "Fetching WH4 historical hareline tab (gid=377767908)",
+  fetchEvents: async (): Promise<RawEventData[]> => {
+    const source = {
+      id: "backfill-wh4-hist",
+      name: "White House H3 Hareline",
+      type: "GOOGLE_SHEETS",
+      url: "https://whitehousehash.com/hareline",
+      config: {
+        sheetId: "anonymous",
+        csvUrl: HISTORICAL_CSV,
+        columns: { runNumber: 0, date: 1, title: 2, location: 3, hares: 4 },
+        kennelTagRules: { default: "wh4" },
+      },
+    } as unknown as Source;
+    const res = await new GoogleSheetsAdapter().fetch(source, { days: 9999 });
+    if (res.errors.length > 0) console.warn("  adapter errors:", res.errors);
+    return res.events;
+  },
+});


### PR DESCRIPTION
## What
One-shot historical backfill for **White House H3** (wh4) — recovers **297 past runs (2016–2023)** from the sheet's historical tab. Follow-up to Batch 1's live source (#2481, PR #2489).

## Why
The live `White House H3 Hareline` GOOGLE_SHEETS source reads only the "Upcoming Trails" tab (2026 season). The same published sheet has a separate historical tab (`gid=377767908`) with older runs the live source never reads.

## How
`scripts/backfill-wh4-history.ts` reuses `GoogleSheetsAdapter` to parse the historical tab (same column layout), binds to the **"White House H3 Hareline"** source (correct provenance), and routes through `reportAndApplyBackfill` → `processRawEvents` — canonical Events created in one pass, idempotent via fingerprint, strict `date < today` partition so it never collides with the live 2026 source.

## Applied to prod
```
created=297 updated=0 skipped=0 blocked=0 eventErrors=0
```
Verified by year: 2016(9) · 2017(61) · 2018(61) · 2019(59) · 2020(13) · 2022(37) · 2023(57), run# 1717–2101. Sample: `#1717 2016-11-06 "The Babysitter's Club"`, `#2101 2023-12-31 "NYE Pub Crawl"`.

## Scope / limits
Gaps **not** on the sheet (kennel-records-only, cf. #2053): **2021**, **2024–25**, and the deep archive **pre-2016** (runs #1–#1716, back to 1987).

Refs #2481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
