### PR TITLE
feat(geo): viewport-bias geocoding to the kennel's metro

### DIFF
--- a/src/lib/geo.test.ts
+++ b/src/lib/geo.test.ts
@@ -1,4 +1,4 @@
-import { extractCoordsFromMapsUrl, getEventCoords, getRegionColor, DEFAULT_PIN_COLOR, haversineDistance, geocodeAddress, reverseGeocode, cityFromTimezone, resolveShortMapsUrl, parseDMSFromLocation, stripDMSFromLocation } from "./geo";
+import { extractCoordsFromMapsUrl, getEventCoords, getRegionColor, DEFAULT_PIN_COLOR, haversineDistance, geocodeAddress, boundingBoxFromCenter, GEOCODE_VIEWPORT_DELTA_DEG, reverseGeocode, cityFromTimezone, resolveShortMapsUrl, parseDMSFromLocation, stripDMSFromLocation } from "./geo";
 
 describe("extractCoordsFromMapsUrl", () => {
   it("parses @lat,lng,zoom path segment", () => {
@@ -288,6 +288,23 @@ describe("geocodeAddress", () => {
     expect(fetchSpy).toHaveBeenCalledOnce();
     const calledUrl = fetchSpy.mock.calls[0][0] as string;
     expect(calledUrl).toContain("&bounds=38.4,-77.5|39.4,-76.5");
+  });
+
+  describe("boundingBoxFromCenter", () => {
+    it("builds a symmetric SW|NE box around the center using the default delta", () => {
+      expect(boundingBoxFromCenter(38.9, -77.0)).toEqual({
+        swLat: 38.9 - GEOCODE_VIEWPORT_DELTA_DEG,
+        swLng: -77.0 - GEOCODE_VIEWPORT_DELTA_DEG,
+        neLat: 38.9 + GEOCODE_VIEWPORT_DELTA_DEG,
+        neLng: -77.0 + GEOCODE_VIEWPORT_DELTA_DEG,
+      });
+    });
+
+    it("honors an explicit half-width", () => {
+      expect(boundingBoxFromCenter(10, 20, 1)).toEqual({
+        swLat: 9, swLng: 19, neLat: 11, neLng: 21,
+      });
+    });
   });
 
   it("does not include &region= when no options provided (backward compatible)", async () => {

--- a/src/lib/geo.test.ts
+++ b/src/lib/geo.test.ts
@@ -305,6 +305,21 @@ describe("geocodeAddress", () => {
         swLat: 9, swLng: 19, neLat: 11, neLng: 21,
       });
     });
+
+    it("returns undefined for non-finite inputs", () => {
+      expect(boundingBoxFromCenter(Number.NaN, -77.0)).toBeUndefined();
+      expect(boundingBoxFromCenter(38.9, Number.POSITIVE_INFINITY)).toBeUndefined();
+      expect(boundingBoxFromCenter(38.9, -77.0, Number.NaN)).toBeUndefined();
+    });
+
+    it("clamps corners to valid lat/lng ranges near the poles/antimeridian", () => {
+      expect(boundingBoxFromCenter(89.8, 179.8)).toEqual({
+        swLat: 89.8 - GEOCODE_VIEWPORT_DELTA_DEG,
+        swLng: 179.8 - GEOCODE_VIEWPORT_DELTA_DEG,
+        neLat: 90,
+        neLng: 180,
+      });
+    });
   });
 
   it("does not include &region= when no options provided (backward compatible)", async () => {

--- a/src/lib/geo.test.ts
+++ b/src/lib/geo.test.ts
@@ -274,6 +274,22 @@ describe("geocodeAddress", () => {
     expect(calledUrl).toContain("&region=us");
   });
 
+  it("appends &bounds= (SW|NE viewport) when bounds option is provided", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: "OK",
+        results: [{ geometry: { location: { lat: 38.9, lng: -77.0 } } }],
+      }),
+    } as Response);
+    await geocodeAddress("Union Station", {
+      bounds: { swLat: 38.4, swLng: -77.5, neLat: 39.4, neLng: -76.5 },
+    });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const calledUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("&bounds=38.4,-77.5|39.4,-76.5");
+  });
+
   it("does not include &region= when no options provided (backward compatible)", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
       ok: true,

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -214,18 +214,25 @@ export const GEOCODE_VIEWPORT_DELTA_DEG = 0.5;
 
 /**
  * Build a SW|NE viewport box centered on a point, for `geocodeAddress`'s
- * `bounds` option (soft-biases results toward the local area).
+ * `bounds` option (soft-biases results toward the local area). Returns
+ * `undefined` for non-finite inputs (NaN/Infinity) so a junk center silently
+ * drops the bias rather than emitting a malformed `&bounds=` param. Corners are
+ * clamped to valid lat/lng ranges (a center near a pole/antimeridian would
+ * otherwise overflow ±90/±180 and be rejected by the Geocoding API).
  */
 export function boundingBoxFromCenter(
   centerLat: number,
   centerLng: number,
   halfWidthDeg: number = GEOCODE_VIEWPORT_DELTA_DEG,
-): { swLat: number; swLng: number; neLat: number; neLng: number } {
+): { swLat: number; swLng: number; neLat: number; neLng: number } | undefined {
+  if (!Number.isFinite(centerLat) || !Number.isFinite(centerLng) || !Number.isFinite(halfWidthDeg)) {
+    return undefined;
+  }
   return {
-    swLat: centerLat - halfWidthDeg,
-    swLng: centerLng - halfWidthDeg,
-    neLat: centerLat + halfWidthDeg,
-    neLng: centerLng + halfWidthDeg,
+    swLat: Math.max(-90, centerLat - halfWidthDeg),
+    swLng: Math.max(-180, centerLng - halfWidthDeg),
+    neLat: Math.min(90, centerLat + halfWidthDeg),
+    neLng: Math.min(180, centerLng + halfWidthDeg),
   };
 }
 

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -206,6 +206,30 @@ export function getEventCoordsFromRegionData(
 const GOOGLE_GEOCODE_BASE = "https://maps.googleapis.com/maps/api/geocode/json";
 
 /**
+ * Half-width (degrees) of the geocoding viewport bias box. ~0.5° ≈ 55km — wide
+ * enough to cover a metro + its suburbs, tight enough to prefer the local
+ * landmark over a same-named place in another city.
+ */
+export const GEOCODE_VIEWPORT_DELTA_DEG = 0.5;
+
+/**
+ * Build a SW|NE viewport box centered on a point, for `geocodeAddress`'s
+ * `bounds` option (soft-biases results toward the local area).
+ */
+export function boundingBoxFromCenter(
+  centerLat: number,
+  centerLng: number,
+  halfWidthDeg: number = GEOCODE_VIEWPORT_DELTA_DEG,
+): { swLat: number; swLng: number; neLat: number; neLng: number } {
+  return {
+    swLat: centerLat - halfWidthDeg,
+    swLng: centerLng - halfWidthDeg,
+    neLat: centerLat + halfWidthDeg,
+    neLng: centerLng + halfWidthDeg,
+  };
+}
+
+/**
  * Geocode a text address using the Google Maps Geocoding API.
  * Returns the first result's coordinates, or null on failure.
  * Uses GOOGLE_CALENDAR_API_KEY (server-only, no HTTP referrer restrictions).

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -212,7 +212,17 @@ const GOOGLE_GEOCODE_BASE = "https://maps.googleapis.com/maps/api/geocode/json";
  */
 export async function geocodeAddress(
   address: string,
-  options?: { regionBias?: string },
+  options?: {
+    regionBias?: string;
+    /**
+     * Viewport (SW|NE corners) to soft-bias results toward. `region` only
+     * disambiguates by country; `bounds` disambiguates *within* a country so
+     * terse local landmarks ("Union Station", "Clarendon") resolve to the
+     * kennel's metro instead of a same-named place elsewhere. Soft bias — Google
+     * still returns better out-of-viewport matches, so legit suburbs survive.
+     */
+    bounds?: { swLat: number; swLng: number; neLat: number; neLng: number };
+  },
 ): Promise<{ lat: number; lng: number; formattedAddress?: string } | null> {
   const apiKey = process.env.GOOGLE_CALENDAR_API_KEY;
   if (!apiKey || !address.trim()) return null;
@@ -221,6 +231,10 @@ export async function geocodeAddress(
     let url = `${GOOGLE_GEOCODE_BASE}?address=${encodeURIComponent(address)}&language=en&key=${apiKey}`;
     if (options?.regionBias) {
       url += `&region=${encodeURIComponent(options.regionBias)}`;
+    }
+    if (options?.bounds) {
+      const b = options.bounds;
+      url += `&bounds=${b.swLat},${b.swLng}|${b.neLat},${b.neLng}`;
     }
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1245,6 +1245,11 @@ function sanitizeLocationUrl(url: string | undefined): string | null {
 /** Detect non-English geographic terms in a location string (e.g., French "État de New York"). */
 export const NON_ENGLISH_GEO_RE = /\b(?:États?[ -]Unis|État de|Bundesland|Straße|Vereinigte Staaten|Provincia de|Comunidad de|Préfecture)\b/i;
 
+// Half-width (degrees) of the viewport used to soft-bias geocoding toward the
+// kennel's metro. ~0.5° ≈ 55km — big enough to cover a metro + its suburbs,
+// tight enough to prefer the local landmark over a same-named place elsewhere.
+const GEOCODE_VIEWPORT_DELTA_DEG = 0.5;
+
 async function resolveCoords(
   event: RawEventData,
   existingCoords?: { latitude: number | null; longitude: number | null; locationAddress: string | null },
@@ -1288,17 +1293,31 @@ async function resolveCoords(
   }
 
   if (event.location) {
-    const geocoded = await geocodeAddress(event.location, regionBias ? { regionBias } : undefined);
+    // Bias point = kennel coords, else the region centroid. Used both to
+    // viewport-bias the geocode toward the kennel's metro (so terse local
+    // landmarks like "Union Station" resolve to the right city) and to validate
+    // the result below. Skip the viewport bias for `countryOverride` events
+    // (deliberate far-away trips) so we don't drag an overseas venue home.
+    const biasLat = kennelCoords?.latitude ?? kennelCoords?.regionCentroidLat;
+    const biasLng = kennelCoords?.longitude ?? kennelCoords?.regionCentroidLng;
+    const bounds =
+      event.countryOverride === undefined && biasLat != null && biasLng != null
+        ? {
+            swLat: biasLat - GEOCODE_VIEWPORT_DELTA_DEG,
+            swLng: biasLng - GEOCODE_VIEWPORT_DELTA_DEG,
+            neLat: biasLat + GEOCODE_VIEWPORT_DELTA_DEG,
+            neLng: biasLng + GEOCODE_VIEWPORT_DELTA_DEG,
+          }
+        : undefined;
+    const geocoded = await geocodeAddress(event.location, { regionBias, bounds });
     if (geocoded) {
       // Validate geocoded result against kennel coords or region centroid (if available)
       // Skip geocode if result is >200km from reference point — likely wrong city/state.
       // Adapters set `countryOverride` on per-event overseas trips (e.g. NTKH4 annual
       // Taoyuan run) to opt out of the kennel-proximity check, which would otherwise
       // reject the correct far-away pin.
-      const valLat = kennelCoords?.latitude ?? kennelCoords?.regionCentroidLat;
-      const valLng = kennelCoords?.longitude ?? kennelCoords?.regionCentroidLng;
-      if (valLat != null && valLng != null && event.countryOverride === undefined) {
-        const dist = haversineDistance(geocoded.lat, geocoded.lng, valLat, valLng);
+      if (biasLat != null && biasLng != null && event.countryOverride === undefined) {
+        const dist = haversineDistance(geocoded.lat, geocoded.lng, biasLat, biasLng);
         if (dist > 200) {
           console.warn(`Geocode validation: "${event.location}" resolved ${dist.toFixed(0)}km from kennel — skipping`);
           return {};

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -1293,12 +1293,19 @@ async function resolveCoords(
     // as local: viewport-bias the geocode toward it (so terse landmarks like
     // "Union Station" resolve to the right city) AND validate the result against
     // it below. The object form keeps the non-null lat/lng available in both spots.
-    const biasLat = kennelCoords?.latitude ?? kennelCoords?.regionCentroidLat;
-    const biasLng = kennelCoords?.longitude ?? kennelCoords?.regionCentroidLng;
-    const biasCenter =
-      event.countryOverride === undefined && biasLat != null && biasLng != null
-        ? { lat: biasLat, lng: biasLng }
+    // Pair lat+lng from the SAME source — kennel latitude/longitude are separately
+    // nullable, so mixing a real kennel lat with a region-centroid lng (or vice
+    // versa) would fabricate a nonsensical center that also self-validates below.
+    const kennelPoint =
+      kennelCoords?.latitude != null && kennelCoords?.longitude != null
+        ? { lat: kennelCoords.latitude, lng: kennelCoords.longitude }
         : null;
+    const centroidPoint =
+      kennelCoords?.regionCentroidLat != null && kennelCoords?.regionCentroidLng != null
+        ? { lat: kennelCoords.regionCentroidLat, lng: kennelCoords.regionCentroidLng }
+        : null;
+    const biasCenter =
+      event.countryOverride === undefined ? (kennelPoint ?? centroidPoint) : null;
     const geocoded = await geocodeAddress(event.location, {
       regionBias,
       bounds: biasCenter ? boundingBoxFromCenter(biasCenter.lat, biasCenter.lng) : undefined,

--- a/src/pipeline/merge.ts
+++ b/src/pipeline/merge.ts
@@ -7,7 +7,7 @@ import { regionTimezone, getLabelForUrl, stripUrlsFromText, timeToMinutes } from
 import { composeUtcStart } from "@/lib/timezone";
 import { generateFingerprint } from "./fingerprint";
 import { resolveKennelTag, resolveKennelTags, clearResolverCache } from "./kennel-resolver";
-import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseGeocode, haversineDistance, parseDMSFromLocation, stripDMSFromLocation } from "@/lib/geo";
+import { extractCoordsFromMapsUrl, geocodeAddress, resolveShortMapsUrl, reverseGeocode, haversineDistance, boundingBoxFromCenter, parseDMSFromLocation, stripDMSFromLocation } from "@/lib/geo";
 import { isPlaceholder, isThemelessPlaceholderTitle, decodeEntities, HARE_BOILERPLATE_RE, CTA_EMBEDDED_PATTERNS } from "@/adapters/utils";
 import { containsHarePii, scrubHarePii } from "@/adapters/hare-pii";
 import { LOCATION_EMAIL_CTA_RE } from "./audit-checks";
@@ -1245,11 +1245,6 @@ function sanitizeLocationUrl(url: string | undefined): string | null {
 /** Detect non-English geographic terms in a location string (e.g., French "État de New York"). */
 export const NON_ENGLISH_GEO_RE = /\b(?:États?[ -]Unis|État de|Bundesland|Straße|Vereinigte Staaten|Provincia de|Comunidad de|Préfecture)\b/i;
 
-// Half-width (degrees) of the viewport used to soft-bias geocoding toward the
-// kennel's metro. ~0.5° ≈ 55km — big enough to cover a metro + its suburbs,
-// tight enough to prefer the local landmark over a same-named place elsewhere.
-const GEOCODE_VIEWPORT_DELTA_DEG = 0.5;
-
 async function resolveCoords(
   event: RawEventData,
   existingCoords?: { latitude: number | null; longitude: number | null; locationAddress: string | null },
@@ -1293,31 +1288,27 @@ async function resolveCoords(
   }
 
   if (event.location) {
-    // Bias point = kennel coords, else the region centroid. Used both to
-    // viewport-bias the geocode toward the kennel's metro (so terse local
-    // landmarks like "Union Station" resolve to the right city) and to validate
-    // the result below. Skip the viewport bias for `countryOverride` events
-    // (deliberate far-away trips) so we don't drag an overseas venue home.
+    // Bias point = kennel coords, else the region centroid. When we have one and
+    // this isn't a deliberate far-away trip (`countryOverride`), treat the event
+    // as local: viewport-bias the geocode toward it (so terse landmarks like
+    // "Union Station" resolve to the right city) AND validate the result against
+    // it below. The object form keeps the non-null lat/lng available in both spots.
     const biasLat = kennelCoords?.latitude ?? kennelCoords?.regionCentroidLat;
     const biasLng = kennelCoords?.longitude ?? kennelCoords?.regionCentroidLng;
-    const bounds =
+    const biasCenter =
       event.countryOverride === undefined && biasLat != null && biasLng != null
-        ? {
-            swLat: biasLat - GEOCODE_VIEWPORT_DELTA_DEG,
-            swLng: biasLng - GEOCODE_VIEWPORT_DELTA_DEG,
-            neLat: biasLat + GEOCODE_VIEWPORT_DELTA_DEG,
-            neLng: biasLng + GEOCODE_VIEWPORT_DELTA_DEG,
-          }
-        : undefined;
-    const geocoded = await geocodeAddress(event.location, { regionBias, bounds });
+        ? { lat: biasLat, lng: biasLng }
+        : null;
+    const geocoded = await geocodeAddress(event.location, {
+      regionBias,
+      bounds: biasCenter ? boundingBoxFromCenter(biasCenter.lat, biasCenter.lng) : undefined,
+    });
     if (geocoded) {
-      // Validate geocoded result against kennel coords or region centroid (if available)
-      // Skip geocode if result is >200km from reference point — likely wrong city/state.
-      // Adapters set `countryOverride` on per-event overseas trips (e.g. NTKH4 annual
-      // Taoyuan run) to opt out of the kennel-proximity check, which would otherwise
-      // reject the correct far-away pin.
-      if (biasLat != null && biasLng != null && event.countryOverride === undefined) {
-        const dist = haversineDistance(geocoded.lat, geocoded.lng, biasLat, biasLng);
+      // Validate against the bias point: skip the geocode if it resolved >200km
+      // away — likely the wrong city/state. (countryOverride trips have no bias
+      // point, so they're never rejected here — e.g. NTKH4's annual Taoyuan run.)
+      if (biasCenter) {
+        const dist = haversineDistance(geocoded.lat, geocoded.lng, biasCenter.lat, biasCenter.lng);
         if (dist > 200) {
           console.warn(`Geocode validation: "${event.location}" resolved ${dist.toFixed(0)}km from kennel — skipping`);
           return {};


### PR DESCRIPTION
## What
Viewport-bias geocoding toward the kennel's metro so terse local landmarks ("Union Station", "Clarendon", "RI Metro") resolve to the right city.

## Why
`geocodeAddress` only applied Google's `region=` (country) bias, which can't disambiguate *within* a country — so "Union Station" resolved to a prominent same-named place elsewhere (LA/Denver), and the >200km kennel-proximity guard then dropped it. Result: DC-metro events lost their map pins (surfaced by the WH4 backfill's geocode-skip warnings).

## Change
- `src/lib/geo.ts`: `geocodeAddress` gains a `bounds` (SW|NE viewport) option → `&bounds=`. New `boundingBoxFromCenter(lat, lng, halfWidthDeg=0.5)` helper + exported `GEOCODE_VIEWPORT_DELTA_DEG`.
- `src/pipeline/merge.ts` `resolveCoords`: derives a `biasCenter` (kennel coords ?? region centroid) and passes `boundingBoxFromCenter(...)` as bounds. **Soft** bias — legit suburbs (Arlington/Bethesda) still resolve, and the existing >200km guard stays as backstop.
- **Gated on `countryOverride`**: deliberate far-away trips (e.g. NTKH4's annual Taoyuan run) get no bias, so we don't drag an overseas venue back to the home metro.

## Verification
- New unit tests: `geocodeAddress` appends `&bounds=`; `boundingBoxFromCenter` builds the box. `tsc` clean · **491 geo+merge tests pass** · lint clean.
- Ran `/simplify` (4 agents): moved box-building to the geo layer + deduped the bias condition; efficiency + reuse were clean.

## Post-merge
Re-geocode the already-created WH4 events (which kept location text but no pins) to backfill map pins; benefits every kennel with terse local landmark names going forward.
