### PR TITLE
feat(tribe): shared TribeEventsAdapter + Sydney Larrikins special events (#2391)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -5528,6 +5528,29 @@ export const SOURCES = [
       kennelCodes: ["larrikins-au"],
     },
     {
+      // The kennel's special / milestone events (Larrikin Long Lunch,
+      // Friday-the-13th runs, milestone #2500, interstate campouts) live in a
+      // "The Events Calendar" (Tribe) install on the same site — separate from
+      // the weekly numbered-trail table the URL-routed LarrikinsAdapter reads
+      // (#2391). Config-routed to the shared TribeEventsAdapter (registry.ts)
+      // so both sources coexist on sydney.larrikins.org. The Tribe REST API is a
+      // complete-window feed, so a wide pull is safe. Forward-only (start_date
+      // defaults to today) → `upcomingOnly` so a passed one-off freezes instead
+      // of being cancelled by reconcile when it drops off the upcoming list.
+      name: "Sydney Larrikins Special Events",
+      url: "https://sydney.larrikins.org",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 400,
+      config: {
+        tribeEvents: true,
+        kennelTag: "larrikins-au",
+        upcomingOnly: true,
+      },
+      kennelCodes: ["larrikins-au"],
+    },
+    {
       name: "Sydney Thirsty H3 Upcoming Runs",
       url: "https://www.sth3.org/upcoming-runs",
       type: "HTML_SCRAPER" as const,

--- a/scripts/backfill-larrikins-specials.ts
+++ b/scripts/backfill-larrikins-specials.ts
@@ -42,10 +42,11 @@ runBackfillScript({
       config: { tribeEvents: true, kennelTag: "larrikins-au", startDate: "2026-01-01" },
     } as unknown as Source;
     const res = await new TribeEventsAdapter().fetch(source, { days: 9999 });
-    // Fail loud on a fetch/parse failure (errorDetails.fetch is the fatal path;
-    // the benign skippedCount soft-signal in res.errors is not fatal) — abort
-    // rather than backfilling an empty/partial slice as if it were complete.
-    if (res.errorDetails?.fetch?.length) {
+    // Fail loud on ANY error — for a one-shot backfill completeness is the whole
+    // point, so a fetch failure, a maxEvents truncation (capReached → errors[]),
+    // or skipped/un-normalizable rows all mean an incomplete slice and must abort
+    // rather than backfill a partial slice as if it were the full archive.
+    if (res.errors.length > 0) {
       throw new Error(`TribeEventsAdapter failed: ${res.errors.join("; ")}`);
     }
     return res.events; // runner keeps only date < today (drops the future City 2 Surf)

--- a/scripts/backfill-larrikins-specials.ts
+++ b/scripts/backfill-larrikins-specials.ts
@@ -1,0 +1,56 @@
+/**
+ * One-shot historical backfill for Sydney Larrikins special events (#2391).
+ *
+ * The live "Sydney Larrikins Special Events" source (TRIBE_EVENTS via the shared
+ * TribeEventsAdapter) reads the kennel's "The Events Calendar" install with
+ * start_date defaulting to today — so it only ever ingests UPCOMING specials
+ * (paired with upcomingOnly reconcile). The 6 special / milestone events the
+ * kennel has already run this year (Larrikin Long Lunch, two Friday-the-13th
+ * runs, Noosa 50th, AGPU, milestone #2500 — Feb–Jun 2026) are already in the
+ * past, so they need a one-shot.
+ *
+ * Reuses TribeEventsAdapter with a past `startDate` (same mapping as the live
+ * source), binds to the "Sydney Larrikins Special Events" source for correct
+ * provenance, and routes through reportAndApplyBackfill → processRawEvents
+ * (canonical Events in one pass; idempotent; strict date<today partition so it
+ * never collides with the live upcoming source, which owns dates >= today).
+ *
+ * The weekly numbered-trail back-catalog (#1–#2501) is NOT enumerable anywhere
+ * on the site — only these special events are.
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-larrikins-specials.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-larrikins-specials.ts
+ */
+
+import "dotenv/config";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { TribeEventsAdapter } from "@/adapters/html-scraper/tribe-events-adapter";
+import type { RawEventData } from "@/adapters/types";
+import type { Source } from "@/generated/prisma/client";
+
+runBackfillScript({
+  sourceName: "Sydney Larrikins Special Events",
+  kennelTimezone: "Australia/Sydney",
+  label: "Fetching Sydney Larrikins Tribe special events (start_date=2026-01-01)",
+  fetchEvents: async (): Promise<RawEventData[]> => {
+    const source = {
+      id: "backfill-larrikins-specials",
+      name: "Sydney Larrikins Special Events",
+      type: "HTML_SCRAPER",
+      url: "https://sydney.larrikins.org",
+      config: { tribeEvents: true, kennelTag: "larrikins-au", startDate: "2026-01-01" },
+    } as unknown as Source;
+    const res = await new TribeEventsAdapter().fetch(source, { days: 9999 });
+    // Fail loud on a fetch/parse failure (errorDetails.fetch is the fatal path;
+    // the benign skippedCount soft-signal in res.errors is not fatal) — abort
+    // rather than backfilling an empty/partial slice as if it were complete.
+    if (res.errorDetails?.fetch?.length) {
+      throw new Error(`TribeEventsAdapter failed: ${res.errors.join("; ")}`);
+    }
+    return res.events; // runner keeps only date < today (drops the future City 2 Surf)
+  },
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/adapters/html-scraper/tribe-events-adapter.test.ts
+++ b/src/adapters/html-scraper/tribe-events-adapter.test.ts
@@ -1,0 +1,174 @@
+import { TribeEventsAdapter, isTribeEventsConfig } from "./tribe-events-adapter";
+import type { Source } from "@/generated/prisma/client";
+
+vi.mock("@/adapters/safe-fetch", () => ({ safeFetch: vi.fn() }));
+const { safeFetch } = await import("@/adapters/safe-fetch");
+const mockedSafeFetch = vi.mocked(safeFetch);
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+/** Date N days from now, "YYYY-MM-DD" — keeps windowed assertions from aging out. */
+function isoDate(offsetDays: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+/** start_date_details from a YYYY-MM-DD + HH:MM. */
+function details(date: string, hour: string, minutes: string) {
+  return { year: date.slice(0, 4), month: date.slice(5, 7), day: date.slice(8, 10), hour, minutes };
+}
+
+function mkSource(config: unknown): Source {
+  return {
+    id: "s1", name: "Larrikins Specials", url: "https://sydney.larrikins.org",
+    type: "HTML_SCRAPER", config,
+  } as unknown as Source;
+}
+
+beforeEach(() => mockedSafeFetch.mockReset());
+
+describe("isTribeEventsConfig", () => {
+  it("accepts { tribeEvents: true, kennelTag }", () => {
+    expect(isTribeEventsConfig({ tribeEvents: true, kennelTag: "larrikins-au" })).toBe(true);
+  });
+  it("rejects a missing discriminator, empty/absent kennelTag, and non-objects", () => {
+    expect(isTribeEventsConfig({ kennelTag: "x" })).toBe(false);
+    expect(isTribeEventsConfig({ tribeEvents: true })).toBe(false);
+    expect(isTribeEventsConfig({ tribeEvents: true, kennelTag: "" })).toBe(false);
+    expect(isTribeEventsConfig(null)).toBe(false);
+    expect(isTribeEventsConfig("nope")).toBe(false);
+  });
+});
+
+describe("TribeEventsAdapter.fetch", () => {
+  it("errors on a non-Tribe config without hitting the network", async () => {
+    const res = await new TribeEventsAdapter().fetch(mkSource({ foo: 1 }));
+    expect(res.events).toEqual([]);
+    expect(res.errors[0]).toMatch(/tribeEvents/);
+    expect(mockedSafeFetch).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on a forward-only config missing upcomingOnly (no network call)", async () => {
+    // No startDate → forward-only; without upcomingOnly, reconcile would cancel
+    // past sole-source events. Must refuse rather than silently succeed.
+    const res = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au" }), { days: 400 },
+    );
+    expect(res.events).toEqual([]);
+    expect(res.errors[0]).toMatch(/upcomingOnly/);
+    expect(mockedSafeFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows a config with an explicit startDate even without upcomingOnly (backfill exemption)", async () => {
+    const d = isoDate(-30);
+    mockedSafeFetch.mockResolvedValue(jsonResponse({
+      events: [{ id: 9, title: "Past Special", start_date: `${d} 12:00:00` }],
+      total: 1, total_pages: 1,
+    }));
+    const res = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", startDate: "2026-01-01" }), { days: 9999 },
+    );
+    expect(mockedSafeFetch).toHaveBeenCalled();
+    expect(res.errors).toEqual([]);
+    expect(res.events).toHaveLength(1);
+  });
+
+  it("pushes a truncation error when the maxEvents cap is hit (blocks reconcile)", async () => {
+    const d = isoDate(4);
+    mockedSafeFetch.mockResolvedValue(jsonResponse({
+      events: [
+        { id: 10, title: "One", start_date: `${d} 10:00:00` },
+        { id: 11, title: "Two", start_date: `${d} 11:00:00` },
+      ],
+      total: 2, total_pages: 1,
+    }));
+    const res = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", upcomingOnly: true, maxEvents: 1 }), { days: 400 },
+    );
+    expect(res.events).toHaveLength(1);
+    expect(res.errors.some((e) => /truncated at maxEvents=1/.test(e))).toBe(true);
+  });
+
+  it("maps events to RawEventData (kennelTag, date, time, decoded title, cleaned location)", async () => {
+    const d = isoDate(10);
+    mockedSafeFetch.mockResolvedValue(jsonResponse({
+      events: [{
+        id: 1, title: "Larrikin Long Lunch",
+        url: "https://sydney.larrikins.org/event/lll/",
+        start_date: `${d} 13:30:00`, start_date_details: details(d, "13", "30"),
+        venue: { venue: "Sydney Fish Markets", address: "1 Bridge Rd,", city: "Glebe" },
+        all_day: false,
+      }],
+      total: 1, total_pages: 1,
+    }));
+    const res = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", upcomingOnly: true }), { days: 400 },
+    );
+    expect(res.errors).toEqual([]);
+    expect(res.events).toHaveLength(1);
+    expect(res.events[0]).toMatchObject({
+      date: d, startTime: "13:30", kennelTags: ["larrikins-au"],
+      title: "Larrikin Long Lunch", location: "1 Bridge Rd, Glebe",
+      sourceUrl: "https://sydney.larrikins.org/event/lll/",
+    });
+  });
+
+  it("filters out events beyond the date window", async () => {
+    const far = isoDate(9000);
+    mockedSafeFetch.mockResolvedValue(jsonResponse({
+      events: [{ id: 2, title: "Way Future", start_date: `${far} 10:00:00` }],
+      total: 1, total_pages: 1,
+    }));
+    const res = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", upcomingOnly: true }), { days: 30 },
+    );
+    expect(res.events).toEqual([]);
+  });
+
+  it("drops the meaningless all-day 00:00 time, or uses defaultStartTime when set", async () => {
+    const d = isoDate(5);
+    const body = {
+      events: [{ id: 3, title: "Campout", start_date_details: details(d, "00", "00"), all_day: true }],
+      total: 1, total_pages: 1,
+    };
+    mockedSafeFetch.mockResolvedValue(jsonResponse(body));
+    const noDefault = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", upcomingOnly: true }), { days: 400 },
+    );
+    expect(noDefault.events[0].startTime).toBeUndefined();
+
+    mockedSafeFetch.mockResolvedValue(jsonResponse(body));
+    const withDefault = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", upcomingOnly: true, defaultStartTime: "18:30" }), { days: 400 },
+    );
+    expect(withDefault.events[0].startTime).toBe("18:30");
+  });
+
+  it("surfaces skippedCount as a soft error (schema-drift signal)", async () => {
+    const d = isoDate(3);
+    mockedSafeFetch.mockResolvedValue(jsonResponse({
+      events: [
+        { id: 4, title: "Good", start_date: `${d} 12:00:00` },
+        { id: 5, start_date: `${d} 12:00:00` }, // no title → skipped by normalizeTribeEvent
+      ],
+      total: 2, total_pages: 1,
+    }));
+    const res = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", upcomingOnly: true }), { days: 400 },
+    );
+    expect(res.events).toHaveLength(1);
+    expect(res.errors.some((e) => /Skipped 1\/2/.test(e))).toBe(true);
+  });
+
+  it("propagates a fetch HTTP error into errorDetails", async () => {
+    mockedSafeFetch.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as unknown as Response);
+    const res = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", upcomingOnly: true }),
+    );
+    expect(res.events).toEqual([]);
+    expect(res.errorDetails?.fetch?.[0].status).toBe(500);
+  });
+});

--- a/src/adapters/html-scraper/tribe-events-adapter.test.ts
+++ b/src/adapters/html-scraper/tribe-events-adapter.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TribeEventsAdapter, isTribeEventsConfig } from "./tribe-events-adapter";
 import type { Source } from "@/generated/prisma/client";
 

--- a/src/adapters/html-scraper/tribe-events-adapter.test.ts
+++ b/src/adapters/html-scraper/tribe-events-adapter.test.ts
@@ -116,6 +116,24 @@ describe("TribeEventsAdapter.fetch", () => {
     });
   });
 
+  it("carries a multi-day span through as RawEventData.endDate", async () => {
+    const d = isoDate(20);
+    const end = isoDate(22);
+    mockedSafeFetch.mockResolvedValue(jsonResponse({
+      events: [{
+        id: 7, title: "Campout Weekend",
+        start_date: `${d} 17:00:00`, start_date_details: details(d, "17", "00"),
+        end_date: `${end} 12:00:00`,
+        end_date_details: { year: end.slice(0, 4), month: end.slice(5, 7), day: end.slice(8, 10) },
+      }],
+      total: 1, total_pages: 1,
+    }));
+    const res = await new TribeEventsAdapter().fetch(
+      mkSource({ tribeEvents: true, kennelTag: "larrikins-au", upcomingOnly: true }), { days: 400 },
+    );
+    expect(res.events[0]).toMatchObject({ date: d, endDate: end });
+  });
+
   it("filters out events beyond the date window", async () => {
     const far = isoDate(9000);
     mockedSafeFetch.mockResolvedValue(jsonResponse({

--- a/src/adapters/html-scraper/tribe-events-adapter.ts
+++ b/src/adapters/html-scraper/tribe-events-adapter.ts
@@ -91,6 +91,9 @@ export class TribeEventsAdapter implements SourceAdapter {
       if (asDate < minDate || asDate > maxDate) continue;
       events.push({
         date: e.date,
+        // Multi-day span (campout weekend) — undefined for single-day events,
+        // which merge.ts treats as "no endDate" (its gated-spread convention).
+        endDate: e.endDate,
         // All-day events carry a meaningless 00:00 from the API; drop it (or use
         // the configured fallback) so the card doesn't render "midnight".
         startTime: e.allDay ? config.defaultStartTime : (e.startTime ?? config.defaultStartTime),

--- a/src/adapters/html-scraper/tribe-events-adapter.ts
+++ b/src/adapters/html-scraper/tribe-events-adapter.ts
@@ -1,0 +1,137 @@
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
+import { hasAnyErrors } from "../types";
+import { buildDateWindow } from "../utils";
+import { fetchTribeEvents } from "../tribe-events";
+
+/**
+ * Config-driven adapter for "The Events Calendar" (Tribe) REST sites.
+ *
+ * The Tribe REST utility (`fetchTribeEvents`) is already used by a bespoke
+ * per-kennel adapter (ChooChooH3). This shared adapter generalizes that: any
+ * WordPress kennel running the plugin onboards with a config block, no new
+ * adapter file. It is dispatched by CONFIG, not URL (see `getAdapter`), so it
+ * can coexist with another adapter on the same host — Sydney Larrikins already
+ * has a URL-routed weekly HTML scraper on `sydney.larrikins.org`, and its Tribe
+ * "special events" feed lives at the same host root. (#2391)
+ */
+export interface TribeEventsConfig {
+  /** Discriminator: routes an HTML_SCRAPER source to this adapter by config. */
+  tribeEvents: true;
+  /** Kennel shortName/code to assign all events to. */
+  kennelTag: string;
+  /**
+   * Earliest event date to request, "YYYY-MM-DD". Omit for the live source
+   * (defaults to today → upcoming only, which pairs with `upcomingOnly` reconcile
+   * so past specials freeze instead of being cancelled). Set to a past date only
+   * for a one-shot historical backfill.
+   */
+  startDate?: string;
+  /** Fallback "HH:MM" when the API reports an all-day event (no meaningful time). */
+  defaultStartTime?: string;
+  /** Defensive cap on total events returned. */
+  maxEvents?: number;
+  /**
+   * Read by the reconcile step (scrape.ts), NOT this adapter — documented here
+   * so the source's config shape is discoverable in one place. Forward-only
+   * special-events feeds set this so a passed one-off isn't cancelled when it
+   * drops out of the upcoming window.
+   */
+  upcomingOnly?: boolean;
+}
+
+/** True when a source config opts into the shared Tribe adapter. */
+export function isTribeEventsConfig(config: unknown): config is TribeEventsConfig {
+  if (!config || typeof config !== "object") return false;
+  const c = config as Record<string, unknown>;
+  return c.tribeEvents === true && typeof c.kennelTag === "string" && c.kennelTag.length > 0;
+}
+
+export class TribeEventsAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    if (!isTribeEventsConfig(source.config)) {
+      const message = "TribeEventsAdapter: config must set { tribeEvents: true, kennelTag: string }";
+      return { events: [], errors: [message], errorDetails: { fetch: [{ message }] } };
+    }
+    const config = source.config;
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    // Fail closed: with no explicit startDate the API request defaults to today,
+    // so the feed is forward-only. Reconcile would then cancel past sole-source
+    // events that aged out of the upcoming list unless the source is marked
+    // `upcomingOnly` (scrape.ts clamps reconcile to the future for those). Refuse
+    // to run rather than silently drive a destructive reconcile — a forward-only
+    // source MUST opt in, and a future onboarding of this shared adapter can't
+    // forget it. A one-shot backfill sets an explicit startDate and is exempt
+    // (it routes through processRawEvents, not the live reconcile path). (#2391)
+    if (config.startDate === undefined && config.upcomingOnly !== true) {
+      const message =
+        "TribeEventsAdapter: a forward-only feed (no startDate) requires config.upcomingOnly:true so reconcile cannot cancel past events";
+      return { events: [], errors: [message], errorDetails: { fetch: [{ url: source.url, message }] } };
+    }
+
+    const result = await fetchTribeEvents(source.url, {
+      perPage: 50,
+      maxEvents: config.maxEvents ?? 200,
+      startDate: config.startDate,
+    });
+    if (result.error) {
+      errorDetails.fetch = [{ url: source.url, status: result.error.status, message: result.error.message }];
+      return { events: [], errors: [result.error.message], errorDetails };
+    }
+
+    const { minDate, maxDate } = buildDateWindow(options?.days ?? 180);
+
+    const events: RawEventData[] = [];
+    for (const e of result.events) {
+      const asDate = new Date(`${e.date}T12:00:00Z`);
+      if (asDate < minDate || asDate > maxDate) continue;
+      events.push({
+        date: e.date,
+        // All-day events carry a meaningless 00:00 from the API; drop it (or use
+        // the configured fallback) so the card doesn't render "midnight".
+        startTime: e.allDay ? config.defaultStartTime : (e.startTime ?? config.defaultStartTime),
+        kennelTags: [config.kennelTag],
+        title: e.title,
+        description: e.description,
+        location: e.location || e.venue,
+        cost: e.cost,
+        sourceUrl: e.url ?? source.url,
+      });
+    }
+
+    // Surface silent schema drift (e.g. a plugin upgrade renaming fields →
+    // everything skipped) as a soft error so health monitoring catches it.
+    if (result.skippedCount > 0) {
+      errors.push(
+        `Skipped ${result.skippedCount}/${result.rawCount} tribe events (missing title or date — possible schema change)`,
+      );
+    }
+
+    // A truncated fetch (upstream has more events than maxEvents) MUST block
+    // reconcile — an empty errors[] would let scrape.ts reconcile against an
+    // incomplete set and cancel valid events beyond the cap. scrape.ts gates
+    // reconcile on errors.length === 0, so pushing an error is the block. (#2391)
+    if (result.capReached) {
+      errors.push(
+        `Tribe fetch truncated at maxEvents=${config.maxEvents ?? 200} — results incomplete; reconcile skipped to avoid cancelling un-fetched events`,
+      );
+    }
+
+    return {
+      events,
+      errors,
+      errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+      diagnosticContext: {
+        kennelTag: config.kennelTag,
+        rawCount: result.rawCount,
+        eventsInWindow: events.length,
+        skippedCount: result.skippedCount,
+        fetchDurationMs: result.fetchDurationMs,
+      },
+    };
+  }
+}

--- a/src/adapters/registry.test.ts
+++ b/src/adapters/registry.test.ts
@@ -17,10 +17,31 @@ import { EnfieldHashAdapter } from "./html-scraper/enfield-hash";
 import { SFH3Adapter } from "./html-scraper/sfh3";
 import { HHHSAdapter } from "./html-scraper/hhhs";
 import { SquarespaceEventsAdapter } from "./html-scraper/squarespace-events";
+import { TribeEventsAdapter } from "./html-scraper/tribe-events-adapter";
+import { LarrikinsAdapter } from "./html-scraper/larrikins";
 import { RssAdapter } from "./rss/adapter";
 import { StaticScheduleAdapter } from "./static-schedule/adapter";
 
 describe("getAdapter", () => {
+  it("routes a Tribe-config HTML_SCRAPER source to TribeEventsAdapter (config wins over URL)", () => {
+    // Same host as the URL-routed LarrikinsAdapter — the config discriminator
+    // must take priority so the two sources coexist on sydney.larrikins.org (#2391).
+    const adapter = getAdapter("HTML_SCRAPER", "https://sydney.larrikins.org", {
+      tribeEvents: true,
+      kennelTag: "larrikins-au",
+    });
+    expect(adapter).toBeInstanceOf(TribeEventsAdapter);
+  });
+
+  it("keeps the URL-routed LarrikinsAdapter when no Tribe config is present", () => {
+    const adapter = getAdapter(
+      "HTML_SCRAPER",
+      "https://sydney.larrikins.org/sydney-south-habour-hhh-tuesday-beers/upcoming-larrikin-runs/",
+    );
+    expect(adapter).toBeInstanceOf(LarrikinsAdapter);
+    expect(adapter).not.toBeInstanceOf(TribeEventsAdapter);
+  });
+
   it("returns HashNYCAdapter for HTML_SCRAPER (default)", () => {
     expect(getAdapter("HTML_SCRAPER")).toBeInstanceOf(HashNYCAdapter);
   });

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -133,6 +133,7 @@ import { GeriatrixH3Adapter } from "./html-scraper/geriatrix-h3";
 import { HogtownAdapter } from "./html-scraper/hogtown";
 import { MhhhCaAdapter } from "./html-scraper/mhhh-ca";
 import { SquarespaceEventsAdapter } from "./html-scraper/squarespace-events";
+import { TribeEventsAdapter, isTribeEventsConfig } from "./html-scraper/tribe-events-adapter";
 import { GoogleCalendarAdapter } from "./google-calendar/adapter";
 import { GoogleSheetsAdapter } from "./google-sheets/adapter";
 import { ICalAdapter } from "./ical/adapter";
@@ -409,6 +410,14 @@ export function getAdapter(
   sourceUrl?: string,
   sourceConfig?: Record<string, unknown> | null,
 ): SourceAdapter {
+  // Config-routed Tribe ("The Events Calendar") sources take priority over URL
+  // routing: the shared TribeEventsAdapter is dispatched by config so it can
+  // coexist with a URL-routed adapter on the same host (Sydney Larrikins has a
+  // weekly HTML scraper AND a Tribe specials feed on sydney.larrikins.org). (#2391)
+  if (sourceType === "HTML_SCRAPER" && isTribeEventsConfig(sourceConfig)) {
+    return new TribeEventsAdapter();
+  }
+
   // For HTML scrapers, check URL-based routing first (named adapters take priority)
   if (sourceType === "HTML_SCRAPER" && sourceUrl) {
     for (const [pattern, factory] of htmlScrapersByUrl) {

--- a/src/adapters/tribe-events.test.ts
+++ b/src/adapters/tribe-events.test.ts
@@ -74,6 +74,28 @@ describe("normalizeTribeEvent", () => {
     expect(out?.location).toBe("1 Bridge Rd, Glebe");
   });
 
+  it("sets endDate for a multi-day span (campout weekend)", () => {
+    const out = normalizeTribeEvent({
+      title: "Interstate Campout",
+      start_date: "2026-04-04 17:00:00",
+      start_date_details: { year: "2026", month: "04", day: "04", hour: "17", minutes: "00" },
+      end_date: "2026-04-06 12:00:00",
+      end_date_details: { year: "2026", month: "04", day: "06" },
+    });
+    expect(out?.date).toBe("2026-04-04");
+    expect(out?.endDate).toBe("2026-04-06");
+  });
+
+  it("omits endDate for a same-day event (end_date only carries the closing time)", () => {
+    const out = normalizeTribeEvent({
+      title: "Long Lunch",
+      start_date: "2026-02-06 13:30:00",
+      end_date: "2026-02-06 17:00:00",
+      end_date_details: { year: "2026", month: "02", day: "06" },
+    });
+    expect(out?.endDate).toBeUndefined();
+  });
+
   it("preserves the allDay flag", () => {
     const out = normalizeTribeEvent({
       title: "All-day event",

--- a/src/adapters/tribe-events.test.ts
+++ b/src/adapters/tribe-events.test.ts
@@ -64,6 +64,16 @@ describe("normalizeTribeEvent", () => {
     expect(out?.location).toBe("Chattanooga");
   });
 
+  it("trims a trailing comma off the address so parts don't double up", () => {
+    const out = normalizeTribeEvent({
+      title: "Long Lunch",
+      start_date: "2026-02-06 13:30:00",
+      // Sydney Larrikins' Tribe install stores the street with a dangling comma.
+      venue: { venue: "Sydney Fish Markets", address: "1 Bridge Rd,", city: "Glebe" },
+    });
+    expect(out?.location).toBe("1 Bridge Rd, Glebe");
+  });
+
   it("preserves the allDay flag", () => {
     const out = normalizeTribeEvent({
       title: "All-day event",

--- a/src/adapters/tribe-events.ts
+++ b/src/adapters/tribe-events.ts
@@ -42,6 +42,12 @@ interface TribeEventRaw {
     hour: string;
     minutes: string;
   };
+  end_date?: string; // "YYYY-MM-DD HH:MM:SS" — only the date part is used
+  end_date_details?: {
+    year: string;
+    month: string;
+    day: string;
+  };
   timezone?: string;
   categories?: TribeEventCategoryRaw[];
   venue?: TribeEventVenueRaw | TribeEventVenueRaw[];
@@ -63,6 +69,8 @@ export interface TribeEvent {
   url?: string;
   date: string; // "YYYY-MM-DD"
   startTime?: string; // "HH:MM" (24h)
+  /** Last day (YYYY-MM-DD) for a MULTI-DAY event; omitted when single-day. */
+  endDate?: string;
   timezone?: string;
   categorySlugs: string[];
   venue?: string;
@@ -129,6 +137,21 @@ export function parseTribeStartDate(
   return null;
 }
 
+/**
+ * Parse just the end DATE (YYYY-MM-DD) from a raw tribe event, preferring
+ * `end_date_details` and falling back to the `end_date` string. Time-of-day is
+ * intentionally ignored — a multi-day event is defined by its calendar span, not
+ * its closing time. Returns null when no end date can be derived.
+ */
+export function parseTribeEndDate(raw: TribeEventRaw): string | null {
+  const details = raw.end_date_details;
+  if (details?.year && details.month && details.day) {
+    return `${details.year}-${details.month.padStart(2, "0")}-${details.day.padStart(2, "0")}`;
+  }
+  const m = raw.end_date ? /^(\d{4})-(\d{2})-(\d{2})/.exec(raw.end_date) : null;
+  return m ? `${m[1]}-${m[2]}-${m[3]}` : null;
+}
+
 /** Normalize a single raw tribe event into our shape. Returns null if required fields are missing. */
 export function normalizeTribeEvent(raw: TribeEventRaw): TribeEvent | null {
   const parsed = parseTribeStartDate(raw);
@@ -151,6 +174,12 @@ export function normalizeTribeEvent(raw: TribeEventRaw): TribeEvent | null {
     .filter((s): s is string => Boolean(s));
   const location = addressParts.length ? addressParts.join(", ") : undefined;
 
+  // Multi-day span only (e.g. an interstate campout weekend). Same-day events —
+  // the norm for Tribe, where end_date just carries the closing time — omit
+  // endDate, matching the RawEventData "single-day events omit endDate" contract.
+  const endDateParsed = parseTribeEndDate(raw);
+  const endDate = endDateParsed && endDateParsed > parsed.date ? endDateParsed : undefined;
+
   return {
     id: raw.id,
     title,
@@ -158,6 +187,7 @@ export function normalizeTribeEvent(raw: TribeEventRaw): TribeEvent | null {
     url: raw.url,
     date: parsed.date,
     startTime: parsed.startTime,
+    endDate,
     timezone: raw.timezone,
     categorySlugs,
     venue,

--- a/src/adapters/tribe-events.ts
+++ b/src/adapters/tribe-events.ts
@@ -92,6 +92,13 @@ export interface FetchTribeEventsResult {
   rawCount: number;
   /** Count of normalized events excluded by `categorySlugs` filter. */
   categoryFilteredCount: number;
+  /**
+   * True when paging stopped because the `maxEvents` cap was hit — the result
+   * is TRUNCATED (more events exist upstream). Callers driving reconcile must
+   * treat this as a hard incomplete signal, else stale-event reconciliation
+   * could cancel valid events that were never fetched.
+   */
+  capReached: boolean;
 }
 
 /**
@@ -136,7 +143,12 @@ export function normalizeTribeEvent(raw: TribeEventRaw): TribeEvent | null {
 
   const venueRaw = Array.isArray(raw.venue) ? raw.venue[0] : raw.venue;
   const venue = venueRaw?.venue?.trim() || undefined;
-  const addressParts = [venueRaw?.address, venueRaw?.city].filter(Boolean);
+  // Trim a trailing comma off each part before joining — some sites store the
+  // street with a dangling "," (e.g. "1 Bridge Rd,") which would otherwise
+  // double up as "1 Bridge Rd,, Glebe".
+  const addressParts = [venueRaw?.address, venueRaw?.city]
+    .map((s) => s?.trim().replace(/,\s*$/, "").trim())
+    .filter((s): s is string => Boolean(s));
   const location = addressParts.length ? addressParts.join(", ") : undefined;
 
   return {
@@ -183,6 +195,7 @@ export async function fetchTribeEvents(
   let rawCount = 0;
   let skippedCount = 0;
   let categoryFilteredCount = 0;
+  let capReached = false;
   let page = 1;
 
   while (true) {
@@ -203,6 +216,7 @@ export async function fetchTribeEvents(
         rawCount,
         skippedCount,
         categoryFilteredCount,
+      capReached,
         error: { message: `Fetch error: ${err instanceof Error ? err.message : String(err)}` },
         fetchDurationMs: Date.now() - fetchStart,
       };
@@ -216,6 +230,7 @@ export async function fetchTribeEvents(
         rawCount,
         skippedCount,
         categoryFilteredCount,
+      capReached,
         error: { message: `HTTP ${res.status} from ${urlString}`, status: res.status },
         fetchDurationMs: Date.now() - fetchStart,
       };
@@ -230,6 +245,7 @@ export async function fetchTribeEvents(
         rawCount,
         skippedCount,
         categoryFilteredCount,
+      capReached,
         error: {
           message: `Invalid JSON from ${urlString}: ${err instanceof Error ? err.message : String(err)}`,
         },
@@ -258,7 +274,10 @@ export async function fetchTribeEvents(
         break;
       }
     }
-    if (reachedCap) break;
+    if (reachedCap) {
+      capReached = true;
+      break;
+    }
 
     // Keep paging until we get a short/empty response or a 404 — don't trust
     // total_pages to bound us (some plugin versions omit it).
@@ -271,6 +290,7 @@ export async function fetchTribeEvents(
     rawCount,
     skippedCount,
     categoryFilteredCount,
+    capReached,
     fetchDurationMs: Date.now() - fetchStart,
   };
 }


### PR DESCRIPTION
## What

Onboards **Sydney Larrikins** special/milestone events (#2391) and, in doing so, generalizes Tribe (**"The Events Calendar"**) support into a reusable adapter.

The kennel runs two event sources on the same site: the weekly numbered-trail table (already scraped by the URL-routed `LarrikinsAdapter`) and a separate **Tribe REST feed** at `/wp-json/tribe/events/v1/events` carrying special events (Long Lunch, Friday-the-13th runs, milestone #2500, interstate campouts). Only the Tribe feed is cleanly enumerable, so its events can be onboarded + backfilled.

## How

- **New shared `TribeEventsAdapter`** (config-driven, `HTML_SCRAPER`-typed) wrapping the existing `fetchTribeEvents` utility — reusable for any Tribe/WordPress kennel via a config block, no new adapter file. (The existing bespoke `ChooChooH3Adapter` also uses `fetchTribeEvents`; migrating it onto this shared adapter is a clean **follow-up**, out of scope here.)
- **Config-based dispatch runs BEFORE URL routing** in the registry, so the Tribe source coexists with the weekly `LarrikinsAdapter` on the same host (`sydney.larrikins.org`) without a URL collision — same pattern as the existing `isGenericHtmlConfig` branch.
- **New "Sydney Larrikins Special Events" source** — `upcomingOnly` (forward-only: the API defaults `start_date` to today, so a passed one-off freezes instead of being cancelled by reconcile).
- **`normalizeTribeEvent` fix**: trim a trailing comma off the address (source stores `1 Bridge Rd,` → was rendering `1 Bridge Rd,, Glebe`). Also benefits ChooChooH3.
- **One-shot backfill** for the 6 past 2026 specials (Feb–Jun), strict `date < today` partition via `reportAndApplyBackfill → processRawEvents`.

## Fail-closed reconcile guards (from the Codex adversarial review)

- A **forward-only Tribe config missing `upcomingOnly: true`** is now **refused at runtime** — otherwise reconcile would cancel past sole-source events that aged out of the upcoming list. The seed row can't be the only guard for a shared adapter. (A one-shot backfill sets an explicit `startDate` and is exempt — it doesn't touch the live reconcile path.)
- `fetchTribeEvents` now reports **`capReached`**; the adapter turns a `maxEvents` truncation into a hard error so `scrape.ts` (which gates reconcile on `errors.length === 0`) **skips reconcile** rather than cancelling un-fetched events beyond the cap.

## Verification

- **Live-verified** against the real API: upcoming path returns *City 2 Surf 2026* (a 7th special not in the issue — proof the live source has ongoing value beyond the one-shot); backfill path returns all 7 with decoded titles (`Noosa Larrikin's 50th`, `AGPU – 2026`), correct times, and cleaned venues.
- `npx tsc --noEmit`, `npm run lint`, `npm test` — **all green** (9846 tests; +11 for the new adapter incl. the fail-closed + cap-truncation guards, +2 registry collision-avoidance cases).
- Pre-PR `/simplify` (removed two speculative config knobs) + `/codex:adversarial-review` (both findings fixed above).

## Post-merge (manual)

1. `npx prisma db seed` — creates the new source + `SourceKennel` link.
2. Trigger the live source scrape (`POST /api/cron/scrape/{id}`) → hydrates the upcoming *City 2 Surf* special.
3. Run `BACKFILL_APPLY=1 npx tsx scripts/backfill-larrikins-specials.ts` → the 6 past 2026 specials.

Closes #2391

🤖 Generated with [Claude Code](https://claude.com/claude-code)