### PR TITLE
chore(db): add ScrapeLog retention GC — keep 30 most-recent per source

### DIFF
--- a/src/app/api/cron/scrape-log-gc/route.ts
+++ b/src/app/api/cron/scrape-log-gc/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { verifyCronAuth } from "@/lib/cron-auth";
+import { runScrapeLogGc } from "@/pipeline/scrape-log-gc";
+
+/**
+ * Daily GC for ScrapeLog retention — keeps the most-recent
+ * SCRAPE_LOG_KEEP_PER_SOURCE logs per source and deletes the rest.
+ *
+ * Every scrape writes a ScrapeLog (src/pipeline/scrape.ts); without retention the
+ * table grows unbounded and bloats the DB volume. Health analysis only needs the
+ * last few per source, so old logs are pure churn (see src/pipeline/scrape-log-gc.ts).
+ *
+ * Triggered by Vercel Cron (GET) or QStash (POST) or manually with Bearer CRON_SECRET.
+ */
+export async function POST(request: Request) {
+  const auth = await verifyCronAuth(request);
+  if (!auth.authenticated) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runScrapeLogGc();
+    console.log(
+      `[scrape-log-gc] deleted ${result.deleted} logs in ${result.batches} batch(es), keeping ${result.keptPerSource} per source`,
+    );
+    return NextResponse.json({
+      data: {
+        deleted: result.deleted,
+        keptPerSource: result.keptPerSource,
+        batches: result.batches,
+      },
+    });
+  } catch (err) {
+    console.error("[scrape-log-gc] failed:", err);
+    Sentry.captureException(err);
+    return NextResponse.json(
+      { data: null, error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}
+
+/** Vercel Cron triggers GET requests. */
+export async function GET(request: Request) {
+  return POST(request);
+}

--- a/src/app/api/cron/scrape-log-gc/route.ts
+++ b/src/app/api/cron/scrape-log-gc/route.ts
@@ -5,7 +5,9 @@ import { runScrapeLogGc } from "@/pipeline/scrape-log-gc";
 
 /**
  * Daily GC for ScrapeLog retention — keeps the most-recent
- * SCRAPE_LOG_KEEP_PER_SOURCE logs per source and deletes the rest.
+ * SCRAPE_LOG_KEEP_PER_SOURCE logs per source (plus a SCRAPE_LOG_KEEP_SUCCESS_PER_SOURCE
+ * SUCCESS-only floor so a long outage can't wipe a source's health baseline) and
+ * deletes the rest.
  *
  * Every scrape writes a ScrapeLog (src/pipeline/scrape.ts); without retention the
  * table grows unbounded and bloats the DB volume. Health analysis only needs the
@@ -22,12 +24,13 @@ export async function POST(request: Request) {
   try {
     const result = await runScrapeLogGc();
     console.log(
-      `[scrape-log-gc] deleted ${result.deleted} logs in ${result.batches} batch(es), keeping ${result.keptPerSource} per source`,
+      `[scrape-log-gc] deleted ${result.deleted} logs in ${result.batches} batch(es), keeping ${result.keptPerSource} per source (+ ${result.keptSuccessPerSource} SUCCESS floor)`,
     );
     return NextResponse.json({
       data: {
         deleted: result.deleted,
         keptPerSource: result.keptPerSource,
+        keptSuccessPerSource: result.keptSuccessPerSource,
         batches: result.batches,
       },
     });

--- a/src/pipeline/scrape-log-gc.test.ts
+++ b/src/pipeline/scrape-log-gc.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { prisma } from "@/lib/db";
-import {
-  runScrapeLogGc,
-  SCRAPE_LOG_KEEP_PER_SOURCE,
-  SCRAPE_LOG_GC_BATCH_SIZE,
-} from "./scrape-log-gc";
+import { runScrapeLogGc, SCRAPE_LOG_KEEP_PER_SOURCE } from "./scrape-log-gc";
 
 vi.mock("@/lib/db", () => ({
-  prisma: { $executeRaw: vi.fn() },
+  prisma: {
+    $queryRaw: vi.fn(),
+    scrapeLog: { deleteMany: vi.fn() },
+  },
 }));
+
+function ids(n: number): Array<{ id: string }> {
+  return Array.from({ length: n }, (_, i) => ({ id: `log-${i}` }));
+}
 
 describe("runScrapeLogGc", () => {
   beforeEach(() => {
@@ -16,43 +19,62 @@ describe("runScrapeLogGc", () => {
   });
 
   it("deletes in a single batch when fewer than batchSize rows are surplus", async () => {
-    vi.mocked(prisma.$executeRaw).mockResolvedValueOnce(5 as never);
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce(ids(5) as never);
+    vi.mocked(prisma.scrapeLog.deleteMany).mockResolvedValueOnce({ count: 5 } as never);
+
     const r = await runScrapeLogGc();
     expect(r.deleted).toBe(5);
     expect(r.batches).toBe(1);
     expect(r.keptPerSource).toBe(SCRAPE_LOG_KEEP_PER_SOURCE);
-    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(prisma.scrapeLog.deleteMany).toHaveBeenCalledTimes(1);
   });
 
-  it("loops in batches until a short batch signals completion", async () => {
-    vi.mocked(prisma.$executeRaw)
-      .mockResolvedValueOnce(100 as never)
-      .mockResolvedValueOnce(100 as never)
-      .mockResolvedValueOnce(42 as never);
+  it("ranks the surplus set ONCE regardless of how many delete batches follow", async () => {
+    // 242 surplus rows at batchSize=100 → 3 delete batches, but the ranking
+    // query (the expensive full-table sort) must run exactly once.
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce(ids(242) as never);
+    vi.mocked(prisma.scrapeLog.deleteMany)
+      .mockResolvedValueOnce({ count: 100 } as never)
+      .mockResolvedValueOnce({ count: 100 } as never)
+      .mockResolvedValueOnce({ count: 42 } as never);
+
     const r = await runScrapeLogGc(30, 100);
     expect(r.deleted).toBe(242);
     expect(r.batches).toBe(3);
-    expect(prisma.$executeRaw).toHaveBeenCalledTimes(3);
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(prisma.scrapeLog.deleteMany).toHaveBeenCalledTimes(3);
   });
 
-  it("stops after a single empty batch", async () => {
-    vi.mocked(prisma.$executeRaw).mockResolvedValueOnce(0 as never);
+  it("does nothing when there is no surplus", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([] as never);
+
     const r = await runScrapeLogGc();
     expect(r.deleted).toBe(0);
-    expect(r.batches).toBe(1);
-    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(r.batches).toBe(0);
+    expect(prisma.scrapeLog.deleteMany).not.toHaveBeenCalled();
   });
 
-  it("keeps the most-recent N per source via a partitioned row_number delete", async () => {
-    vi.mocked(prisma.$executeRaw).mockResolvedValueOnce(0 as never);
+  it("ranks by source via a partitioned row_number query", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([] as never);
     await runScrapeLogGc();
-    const call = vi.mocked(prisma.$executeRaw).mock.calls[0];
+
+    const call = vi.mocked(prisma.$queryRaw).mock.calls[0];
     // Tagged-template call shape: [TemplateStringsArray, ...interpolatedValues]
     const sql = (call[0] as unknown as string[]).join("?");
     expect(sql).toContain("row_number()");
     expect(sql).toContain('PARTITION BY "sourceId" ORDER BY "startedAt" DESC');
     expect(sql).toContain("rn >");
-    // The two interpolated params are keepPerSource then batchSize.
-    expect(call.slice(1)).toEqual([SCRAPE_LOG_KEEP_PER_SOURCE, SCRAPE_LOG_GC_BATCH_SIZE]);
+    expect(call.slice(1)).toEqual([SCRAPE_LOG_KEEP_PER_SOURCE]);
+  });
+
+  it("deletes surplus ids via indexed PK lookups, not a re-ranked query", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce(ids(3) as never);
+    vi.mocked(prisma.scrapeLog.deleteMany).mockResolvedValueOnce({ count: 3 } as never);
+
+    await runScrapeLogGc();
+    expect(prisma.scrapeLog.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["log-0", "log-1", "log-2"] } },
+    });
   });
 });

--- a/src/pipeline/scrape-log-gc.test.ts
+++ b/src/pipeline/scrape-log-gc.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prisma } from "@/lib/db";
+import {
+  runScrapeLogGc,
+  SCRAPE_LOG_KEEP_PER_SOURCE,
+  SCRAPE_LOG_GC_BATCH_SIZE,
+} from "./scrape-log-gc";
+
+vi.mock("@/lib/db", () => ({
+  prisma: { $executeRaw: vi.fn() },
+}));
+
+describe("runScrapeLogGc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes in a single batch when fewer than batchSize rows are surplus", async () => {
+    vi.mocked(prisma.$executeRaw).mockResolvedValueOnce(5 as never);
+    const r = await runScrapeLogGc();
+    expect(r.deleted).toBe(5);
+    expect(r.batches).toBe(1);
+    expect(r.keptPerSource).toBe(SCRAPE_LOG_KEEP_PER_SOURCE);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("loops in batches until a short batch signals completion", async () => {
+    vi.mocked(prisma.$executeRaw)
+      .mockResolvedValueOnce(100 as never)
+      .mockResolvedValueOnce(100 as never)
+      .mockResolvedValueOnce(42 as never);
+    const r = await runScrapeLogGc(30, 100);
+    expect(r.deleted).toBe(242);
+    expect(r.batches).toBe(3);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops after a single empty batch", async () => {
+    vi.mocked(prisma.$executeRaw).mockResolvedValueOnce(0 as never);
+    const r = await runScrapeLogGc();
+    expect(r.deleted).toBe(0);
+    expect(r.batches).toBe(1);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the most-recent N per source via a partitioned row_number delete", async () => {
+    vi.mocked(prisma.$executeRaw).mockResolvedValueOnce(0 as never);
+    await runScrapeLogGc();
+    const call = vi.mocked(prisma.$executeRaw).mock.calls[0];
+    // Tagged-template call shape: [TemplateStringsArray, ...interpolatedValues]
+    const sql = (call[0] as unknown as string[]).join("?");
+    expect(sql).toContain("row_number()");
+    expect(sql).toContain('PARTITION BY "sourceId" ORDER BY "startedAt" DESC');
+    expect(sql).toContain("rn >");
+    // The two interpolated params are keepPerSource then batchSize.
+    expect(call.slice(1)).toEqual([SCRAPE_LOG_KEEP_PER_SOURCE, SCRAPE_LOG_GC_BATCH_SIZE]);
+  });
+});

--- a/src/pipeline/scrape-log-gc.test.ts
+++ b/src/pipeline/scrape-log-gc.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { prisma } from "@/lib/db";
-import { runScrapeLogGc, SCRAPE_LOG_KEEP_PER_SOURCE } from "./scrape-log-gc";
+import {
+  runScrapeLogGc,
+  SCRAPE_LOG_KEEP_PER_SOURCE,
+  SCRAPE_LOG_KEEP_SUCCESS_PER_SOURCE,
+} from "./scrape-log-gc";
 
 vi.mock("@/lib/db", () => ({
   prisma: {
@@ -26,6 +30,7 @@ describe("runScrapeLogGc", () => {
     expect(r.deleted).toBe(5);
     expect(r.batches).toBe(1);
     expect(r.keptPerSource).toBe(SCRAPE_LOG_KEEP_PER_SOURCE);
+    expect(r.keptSuccessPerSource).toBe(SCRAPE_LOG_KEEP_SUCCESS_PER_SOURCE);
     expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
     expect(prisma.scrapeLog.deleteMany).toHaveBeenCalledTimes(1);
   });
@@ -39,7 +44,7 @@ describe("runScrapeLogGc", () => {
       .mockResolvedValueOnce({ count: 100 } as never)
       .mockResolvedValueOnce({ count: 42 } as never);
 
-    const r = await runScrapeLogGc(30, 100);
+    const r = await runScrapeLogGc(30, 10, 100);
     expect(r.deleted).toBe(242);
     expect(r.batches).toBe(3);
     expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
@@ -55,7 +60,7 @@ describe("runScrapeLogGc", () => {
     expect(prisma.scrapeLog.deleteMany).not.toHaveBeenCalled();
   });
 
-  it("ranks by source via a partitioned row_number query", async () => {
+  it("ranks by source (any status) AND by source+SUCCESS via two window functions", async () => {
     vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([] as never);
     await runScrapeLogGc();
 
@@ -64,8 +69,11 @@ describe("runScrapeLogGc", () => {
     const sql = (call[0] as unknown as string[]).join("?");
     expect(sql).toContain("row_number()");
     expect(sql).toContain('PARTITION BY "sourceId" ORDER BY "startedAt" DESC');
-    expect(sql).toContain("rn >");
-    expect(call.slice(1)).toEqual([SCRAPE_LOG_KEEP_PER_SOURCE]);
+    expect(sql).toContain('PARTITION BY "sourceId", ("status" = \'SUCCESS\')');
+    expect(sql).toContain("overall_rn >");
+    expect(sql).toContain("status_rn >");
+    // The two interpolated params are keepPerSource then keepSuccessPerSource.
+    expect(call.slice(1)).toEqual([SCRAPE_LOG_KEEP_PER_SOURCE, SCRAPE_LOG_KEEP_SUCCESS_PER_SOURCE]);
   });
 
   it("deletes surplus ids via indexed PK lookups, not a re-ranked query", async () => {
@@ -76,5 +84,28 @@ describe("runScrapeLogGc", () => {
     expect(prisma.scrapeLog.deleteMany).toHaveBeenCalledWith({
       where: { id: { in: ["log-0", "log-1", "log-2"] } },
     });
+  });
+
+  // Regression test for the scenario found in review on PR #2529: a source
+  // with a long outage (many consecutive non-SUCCESS scrapes since its last
+  // SUCCESS) must not have its SUCCESS history wiped by the overall quota
+  // alone — health.ts's baseline would go empty and silently stop detecting
+  // regressions / auto-resolve stale trend alerts. The predicate shape below
+  // was manually verified against a real Postgres instance (synthetic
+  // ScrapeLog rows: 1 SUCCESS + 35 FAILED for one source) — the SUCCESS row
+  // survives despite an overall rank of 36 because its status-specific rank
+  // is 1. This unit test pins that predicate shape (AND of two independent
+  // conditions) so a future edit can't silently collapse it back to a single
+  // combined rank.
+  it("protects SUCCESS rows via a status-specific quota independent of the overall quota", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([] as never);
+    await runScrapeLogGc();
+
+    const call = vi.mocked(prisma.$queryRaw).mock.calls[0];
+    const sql = (call[0] as unknown as string[]).join("?");
+    // A row is surplus only when it fails BOTH the overall AND the
+    // status-specific check — i.e. an AND of two independent conditions, not
+    // a single combined rank.
+    expect(sql).toMatch(/overall_rn > [\s\S]*AND[\s\S]*\([\s\S]*status <> 'SUCCESS'[\s\S]*OR[\s\S]*status_rn > [\s\S]*\)/);
   });
 });

--- a/src/pipeline/scrape-log-gc.ts
+++ b/src/pipeline/scrape-log-gc.ts
@@ -1,0 +1,70 @@
+import { prisma } from "@/lib/db";
+
+/**
+ * ScrapeLog retention GC — keep the N most-recent ScrapeLogs per source.
+ *
+ * Every source scrape writes one ScrapeLog row (src/pipeline/scrape.ts), so the
+ * table grows unbounded (~1 row/source/day from the dispatch cron, plus manual
+ * admin scrapes). Left ungoverned it reached 54k rows / 59 MB and contributed to
+ * a Railway volume-full outage. Nothing needs deep history: health analysis reads
+ * only the last 10 SUCCESS + last 3 any per source (src/pipeline/health.ts), so a
+ * per-source retention of 30 keeps every baseline with wide margin.
+ *
+ * Safe to run anytime: `Alert.scrapeLogId` is `ON DELETE SET NULL`
+ * (prisma/migrations baseline `Alert_scrapeLogId_fkey`), so deleting an old
+ * ScrapeLog referenced by an Alert simply nulls the Alert's link — the Alert row
+ * survives. No other table references ScrapeLog.
+ */
+export const SCRAPE_LOG_KEEP_PER_SOURCE = 30;
+
+/**
+ * Rows deleted per statement. The delete is batched (rather than one ~40k-row
+ * statement) so each transaction's WAL burst stays small — important when the GC
+ * is unblocking a near-full disk, where a single huge delete can itself fail to
+ * extend WAL.
+ */
+export const SCRAPE_LOG_GC_BATCH_SIZE = 2000;
+
+/** Backstop so a mis-sized batch can never loop forever. */
+const MAX_BATCHES = 1000;
+
+export interface ScrapeLogGcResult {
+  deleted: number;
+  keptPerSource: number;
+  batches: number;
+}
+
+/**
+ * Delete all but the `SCRAPE_LOG_KEEP_PER_SOURCE` most-recent ScrapeLogs per
+ * source (ordered by `startedAt` desc), in batches of `SCRAPE_LOG_GC_BATCH_SIZE`.
+ * Returns the total rows deleted.
+ */
+export async function runScrapeLogGc(
+  keepPerSource: number = SCRAPE_LOG_KEEP_PER_SOURCE,
+  batchSize: number = SCRAPE_LOG_GC_BATCH_SIZE,
+): Promise<ScrapeLogGcResult> {
+  let deleted = 0;
+  let batches = 0;
+
+  for (let i = 0; i < MAX_BATCHES; i++) {
+    // row_number() partitions by source, newest first; anything ranked beyond
+    // `keepPerSource` is surplus. LIMIT bounds each statement's WAL footprint.
+    const n = await prisma.$executeRaw`
+      DELETE FROM "ScrapeLog"
+      WHERE "id" IN (
+        SELECT "id" FROM (
+          SELECT "id", row_number() OVER (
+            PARTITION BY "sourceId" ORDER BY "startedAt" DESC
+          ) AS rn
+          FROM "ScrapeLog"
+        ) ranked
+        WHERE ranked.rn > ${keepPerSource}
+        LIMIT ${batchSize}
+      )`;
+    deleted += n;
+    batches++;
+    if (n < batchSize) break; // last (or empty) batch
+  }
+
+  return { deleted, keptPerSource: keepPerSource, batches };
+}

--- a/src/pipeline/scrape-log-gc.ts
+++ b/src/pipeline/scrape-log-gc.ts
@@ -18,15 +18,12 @@ import { prisma } from "@/lib/db";
 export const SCRAPE_LOG_KEEP_PER_SOURCE = 30;
 
 /**
- * Rows deleted per statement. The delete is batched (rather than one ~40k-row
- * statement) so each transaction's WAL burst stays small — important when the GC
- * is unblocking a near-full disk, where a single huge delete can itself fail to
- * extend WAL.
+ * Rows deleted per `deleteMany` call. Batched (rather than one huge IN-list
+ * statement) so each transaction's WAL burst stays small — important when the
+ * GC is unblocking a near-full disk, where a single huge delete can itself
+ * fail to extend WAL.
  */
 export const SCRAPE_LOG_GC_BATCH_SIZE = 2000;
-
-/** Backstop so a mis-sized batch can never loop forever. */
-const MAX_BATCHES = 1000;
 
 export interface ScrapeLogGcResult {
   deleted: number;
@@ -38,32 +35,34 @@ export interface ScrapeLogGcResult {
  * Delete all but the `SCRAPE_LOG_KEEP_PER_SOURCE` most-recent ScrapeLogs per
  * source (ordered by `startedAt` desc), in batches of `SCRAPE_LOG_GC_BATCH_SIZE`.
  * Returns the total rows deleted.
+ *
+ * The surplus-row `row_number()` ranking runs ONCE (a single full sort of
+ * ScrapeLog), not once per batch — re-running that window function inside a
+ * delete loop would sort the whole table again on every iteration (O(batches
+ * × N log N) instead of O(N log N)), which is exactly the wrong tradeoff on a
+ * disk that's already under pressure. The resulting ids are then deleted via
+ * plain indexed-PK `deleteMany` batches.
  */
 export async function runScrapeLogGc(
   keepPerSource: number = SCRAPE_LOG_KEEP_PER_SOURCE,
   batchSize: number = SCRAPE_LOG_GC_BATCH_SIZE,
 ): Promise<ScrapeLogGcResult> {
+  const surplus = await prisma.$queryRaw<Array<{ id: string }>>`
+    SELECT "id" FROM (
+      SELECT "id", row_number() OVER (
+        PARTITION BY "sourceId" ORDER BY "startedAt" DESC
+      ) AS rn
+      FROM "ScrapeLog"
+    ) ranked
+    WHERE ranked.rn > ${keepPerSource}`;
+
   let deleted = 0;
   let batches = 0;
-
-  for (let i = 0; i < MAX_BATCHES; i++) {
-    // row_number() partitions by source, newest first; anything ranked beyond
-    // `keepPerSource` is surplus. LIMIT bounds each statement's WAL footprint.
-    const n = await prisma.$executeRaw`
-      DELETE FROM "ScrapeLog"
-      WHERE "id" IN (
-        SELECT "id" FROM (
-          SELECT "id", row_number() OVER (
-            PARTITION BY "sourceId" ORDER BY "startedAt" DESC
-          ) AS rn
-          FROM "ScrapeLog"
-        ) ranked
-        WHERE ranked.rn > ${keepPerSource}
-        LIMIT ${batchSize}
-      )`;
-    deleted += n;
+  for (let i = 0; i < surplus.length; i += batchSize) {
+    const ids = surplus.slice(i, i + batchSize).map((r) => r.id);
+    const { count } = await prisma.scrapeLog.deleteMany({ where: { id: { in: ids } } });
+    deleted += count;
     batches++;
-    if (n < batchSize) break; // last (or empty) batch
   }
 
   return { deleted, keptPerSource: keepPerSource, batches };

--- a/src/pipeline/scrape-log-gc.ts
+++ b/src/pipeline/scrape-log-gc.ts
@@ -1,14 +1,28 @@
 import { prisma } from "@/lib/db";
 
 /**
- * ScrapeLog retention GC — keep the N most-recent ScrapeLogs per source.
+ * ScrapeLog retention GC — keep the N most-recent ScrapeLogs per source
+ * (any status), PLUS the M most-recent SUCCESS ScrapeLogs per source.
  *
  * Every source scrape writes one ScrapeLog row (src/pipeline/scrape.ts), so the
  * table grows unbounded (~1 row/source/day from the dispatch cron, plus manual
  * admin scrapes). Left ungoverned it reached 54k rows / 59 MB and contributed to
- * a Railway volume-full outage. Nothing needs deep history: health analysis reads
- * only the last 10 SUCCESS + last 3 any per source (src/pipeline/health.ts), so a
- * per-source retention of 30 keeps every baseline with wide margin.
+ * a Railway volume-full outage.
+ *
+ * The success-quota exists alongside the overall quota, not instead of it:
+ * health.ts's baseline query filters `status: "SUCCESS"` and takes the last 10,
+ * independent of how many non-SUCCESS rows sit more recently. A source with a
+ * long outage (>SCRAPE_LOG_KEEP_PER_SOURCE consecutive FAILED/RUNNING scrapes
+ * since its last SUCCESS) would have every SUCCESS row rank beyond the overall
+ * cutoff and get deleted — wiping the baseline entirely. health.ts registers
+ * EVENT_COUNT_ANOMALY/FIELD_FILL_DROP/STRUCTURE_CHANGE/UNMATCHED_TAGS as
+ * "checked" on every successful scrape regardless of baseline size, but only
+ * runs the actual detection `if (recentSuccessful.length > 0)` — an empty
+ * baseline means the check silently no-ops AND any pre-existing trend alerts of
+ * those types auto-resolve (no current alert exists to keep them open). That's
+ * a real regression-detection gap, not just wasted history (found in review on
+ * PR #2529 — a source can recover from an outage with a live bug and the first
+ * scrape after recovery won't catch it).
  *
  * Safe to run anytime: `Alert.scrapeLogId` is `ON DELETE SET NULL`
  * (prisma/migrations baseline `Alert_scrapeLogId_fkey`), so deleting an old
@@ -16,6 +30,13 @@ import { prisma } from "@/lib/db";
  * survives. No other table references ScrapeLog.
  */
 export const SCRAPE_LOG_KEEP_PER_SOURCE = 30;
+
+/**
+ * SUCCESS-only retention floor. health.ts reads exactly the last 10 SUCCESS
+ * rows per source for its trend baseline (src/pipeline/health.ts ~L401), so
+ * this must be >= 10 regardless of how the overall quota above is tuned.
+ */
+export const SCRAPE_LOG_KEEP_SUCCESS_PER_SOURCE = 10;
 
 /**
  * Rows deleted per `deleteMany` call. Batched (rather than one huge IN-list
@@ -28,33 +49,41 @@ export const SCRAPE_LOG_GC_BATCH_SIZE = 2000;
 export interface ScrapeLogGcResult {
   deleted: number;
   keptPerSource: number;
+  keptSuccessPerSource: number;
   batches: number;
 }
 
 /**
- * Delete all but the `SCRAPE_LOG_KEEP_PER_SOURCE` most-recent ScrapeLogs per
- * source (ordered by `startedAt` desc), in batches of `SCRAPE_LOG_GC_BATCH_SIZE`.
- * Returns the total rows deleted.
+ * Delete every ScrapeLog EXCEPT: the `keepPerSource` most-recent rows per
+ * source (any status), and the `keepSuccessPerSource` most-recent SUCCESS rows
+ * per source — whichever set is larger wins per row. Deletes run in batches of
+ * `batchSize`. Returns the total rows deleted.
  *
- * The surplus-row `row_number()` ranking runs ONCE (a single full sort of
- * ScrapeLog), not once per batch — re-running that window function inside a
- * delete loop would sort the whole table again on every iteration (O(batches
- * × N log N) instead of O(N log N)), which is exactly the wrong tradeoff on a
- * disk that's already under pressure. The resulting ids are then deleted via
- * plain indexed-PK `deleteMany` batches.
+ * The surplus-row ranking runs ONCE (two window functions over a single sort
+ * of ScrapeLog), not once per batch — re-running that inside a delete loop
+ * would sort the whole table again on every iteration (O(batches × N log N)
+ * instead of O(N log N)), which is exactly the wrong tradeoff on a disk that's
+ * already under pressure. The resulting ids are then deleted via plain
+ * indexed-PK `deleteMany` batches.
  */
 export async function runScrapeLogGc(
   keepPerSource: number = SCRAPE_LOG_KEEP_PER_SOURCE,
+  keepSuccessPerSource: number = SCRAPE_LOG_KEEP_SUCCESS_PER_SOURCE,
   batchSize: number = SCRAPE_LOG_GC_BATCH_SIZE,
 ): Promise<ScrapeLogGcResult> {
   const surplus = await prisma.$queryRaw<Array<{ id: string }>>`
     SELECT "id" FROM (
-      SELECT "id", row_number() OVER (
-        PARTITION BY "sourceId" ORDER BY "startedAt" DESC
-      ) AS rn
+      SELECT "id", "status",
+        row_number() OVER (
+          PARTITION BY "sourceId" ORDER BY "startedAt" DESC
+        ) AS overall_rn,
+        row_number() OVER (
+          PARTITION BY "sourceId", ("status" = 'SUCCESS') ORDER BY "startedAt" DESC
+        ) AS status_rn
       FROM "ScrapeLog"
     ) ranked
-    WHERE ranked.rn > ${keepPerSource}`;
+    WHERE ranked.overall_rn > ${keepPerSource}
+      AND (ranked.status <> 'SUCCESS' OR ranked.status_rn > ${keepSuccessPerSource})`;
 
   let deleted = 0;
   let batches = 0;
@@ -65,5 +94,5 @@ export async function runScrapeLogGc(
     batches++;
   }
 
-  return { deleted, keptPerSource: keepPerSource, batches };
+  return { deleted, keptPerSource: keepPerSource, keptSuccessPerSource: keepSuccessPerSource, batches };
 }

--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,10 @@
       "schedule": "0 3 * * *"
     },
     {
+      "path": "/api/cron/scrape-log-gc",
+      "schedule": "30 3 * * *"
+    },
+    {
       "path": "/api/cron/prediction-ledger",
       "schedule": "0 8 * * 1"
     },


### PR DESCRIPTION
## Summary
Adds a daily GC that keeps the **30 most-recent `ScrapeLog` rows per source** and deletes the rest.

**Context:** applying the HC-batch-10 post-merge runbook surfaced a **prod-wide outage** — the Railway Postgres volume is full (`No space left on device` on every write). ScrapeLog is the largest pure-churn table (59 MB / 54k rows — every scrape writes one, unbounded) with no existing retention. This PR is the durable fix; the disk itself still needs to be expanded and the backlog cleared (tracked separately, ops-side).

## Why 30 per source is safe
`health.ts` (`checkEventCountAnomaly`, `checkFieldFillDrops`, etc.) only ever reads the **last 10 SUCCESS + last 3 any** ScrapeLogs per source to build its rolling baseline. 30 leaves 3x margin.

## Why this is safe to run against the FK graph
`Alert.scrapeLogId` → `ScrapeLog` is `ON DELETE SET NULL` (verified in the baseline migration: `Alert_scrapeLogId_fkey ... ON DELETE SET NULL`). Deleting an old, Alert-referenced ScrapeLog just nulls the Alert's link — the Alert row survives untouched. No other table references ScrapeLog, so no manual FK handling is needed.

## Implementation
- `src/pipeline/scrape-log-gc.ts` — `runScrapeLogGc()`: a partitioned `row_number() OVER (PARTITION BY "sourceId" ORDER BY "startedAt" DESC)` delete, keeping rank ≤ 30. **Batched at 2000 rows/statement** (not one giant delete) so the WAL burst per transaction stays small — deliberately, since the GC's first production run is clearing a ~40k-row backlog on a disk that's already tight.
- `src/app/api/cron/scrape-log-gc/route.ts` + `vercel.json` (`30 3 * * *`, right after `travel-draft-gc` at `0 3 * * *`) — mirrors the existing `travel-draft-gc` GC pattern exactly (`verifyCronAuth`, Sentry capture on failure, `GET` delegates to `POST` for Vercel Cron).
- `scrape-log-gc.test.ts` — batch looping/termination behavior + asserts the SQL shape (partition/order/threshold).

## Checks
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (22 pre-existing warnings, unrelated `travel/` components)
- `npm test` — **9836 passed**, 0 failures

## Post-merge (ops, separate from this PR)
1. Expand the Railway Postgres volume (primary unblock — even `DELETE`/WAL can fail on a truly-full disk).
2. Once deployed, run the GC once to clear the backlog: `POST https://www.hashtracks.xyz/api/cron/scrape-log-gc` with `Bearer $CRON_SECRET`.
3. `VACUUM (FULL) "ScrapeLog";` via `psql` to return the reclaimed pages to the OS (plain `DELETE`+autovacuum won't shrink the file).
4. Re-trigger the 4 HC-batch-10 sources whose upcoming-event writes failed mid-outage (toulouse, tnth3, dafth3, beerspoke) to finish that batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)