### PR TITLE
feat(upstate): onboard /new-events-1 specials + backfill receding hareline (#2420)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2488,6 +2488,30 @@ export const SOURCES = [
       kennelCodes: ["uh3"],
     },
     {
+      // Themed special events (multi-day campouts, dress-run weekends) live in
+      // the /new-events-1 Squarespace events collection — richer than the
+      // recurring STATIC_SCHEDULE placeholders above. The shared
+      // SquarespaceEventsAdapter reads both `upcoming` and `past`; `upcomingOnly`
+      // keeps reconcile future-clamped so a recently-past special isn't cancelled
+      // when Squarespace rotates it out of `past`. This source is FORWARD-ONLY:
+      // ALL historical data — the two known Sep-2024 specials AND the static
+      // /receding-hareline archive (#122–#334, 2008–2016) — is loaded by the
+      // one-shot backfill, so the live window stays a normal forward horizon
+      // rather than reaching years back. (#2420)
+      name: "Upstate H3 Website",
+      url: "https://www.upstatehashers.com",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 6,
+      scrapeFreq: "weekly",
+      scrapeDays: 365,
+      config: {
+        kennelTag: "uh3",
+        collectionPath: "/new-events-1",
+        upcomingOnly: true,
+      },
+      kennelCodes: ["uh3"],
+    },
+    {
       name: "GOTH3 Static Schedule",
       url: "https://gothh3.com/",
       type: "STATIC_SCHEDULE" as const,

--- a/scripts/backfill-upstate-h3-history.test.ts
+++ b/scripts/backfill-upstate-h3-history.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { parseRecedingHareline } from "./backfill-upstate-h3-history";
+
+// Mirrors the real Squarespace summary markup: each run is an <a> whose text is
+// "M/D/YY #NNN Title", and every run renders twice (thumbnail link + title link).
+const FIXTURE = `
+<div class="summary-item">
+  <a class="summary-thumbnail-container" href="/122-red-dress-2008">
+    <img src="x.jpg">
+    2/17/08 #122 Red Dress 2008
+  </a>
+  <a class="summary-title-link" href="/122-red-dress-2008">
+    2/17/08 #122 Red Dress 2008
+  </a>
+</div>
+<h2>2008 Photos</h2>
+<div class="summary-item">
+  <a class="summary-title-link" href="/123-cant-wait">
+    3/2/08 #123 Can't Wait Til Summer Hash
+  </a>
+</div>
+<div class="summary-item">
+  <a class="summary-title-link" href="/334-lbd">
+    5/22/16 #334 Little Black Dress
+  </a>
+</div>
+<a href="/about">About Us</a>
+`;
+
+describe("parseRecedingHareline", () => {
+  it("parses M/D/YY #NNN Title rows into RawEventData (UTC-noon date string, run#, title)", () => {
+    const events = parseRecedingHareline(FIXTURE);
+    expect(events).toEqual([
+      { date: "2008-02-17", runNumber: 122, title: "Red Dress 2008", kennelTags: ["uh3"] },
+      { date: "2008-03-02", runNumber: 123, title: "Can't Wait Til Summer Hash", kennelTags: ["uh3"] },
+      { date: "2016-05-22", runNumber: 334, title: "Little Black Dress", kennelTags: ["uh3"] },
+    ]);
+  });
+
+  it("dedups the twice-rendered run (thumbnail + title link) by run number", () => {
+    const events = parseRecedingHareline(FIXTURE);
+    expect(events.filter((e) => e.runNumber === 122)).toHaveLength(1);
+  });
+
+  it("ignores non-run links and section headers", () => {
+    const events = parseRecedingHareline(FIXTURE);
+    expect(events.every((e) => typeof e.runNumber === "number")).toBe(true);
+    expect(events.map((e) => e.title)).not.toContain("About Us");
+  });
+
+  it("maps two-digit years to 2008–2016 (20YY)", () => {
+    const events = parseRecedingHareline(FIXTURE);
+    expect(events[0].date.startsWith("2008-")).toBe(true);
+    expect(events[2].date.startsWith("2016-")).toBe(true);
+  });
+});

--- a/scripts/backfill-upstate-h3-history.ts
+++ b/scripts/backfill-upstate-h3-history.ts
@@ -40,8 +40,11 @@ import type { Source } from "@/generated/prisma/client";
 const SITE_URL = "https://www.upstatehashers.com";
 const HARELINE_URL = `${SITE_URL}/receding-hareline`;
 
-/** Verbatim summary-link text: "M/D/YY #NNN Title". */
-const ROW_RE = /^(\d{1,2})\/(\d{1,2})\/(\d{2})\s+#(\d{2,3})\s+(.+)$/;
+/** Verbatim summary-link text: "M/D/YY #NNN Title". The title capture is
+ *  `(\S.*)` (not `.+`): requiring a non-space first char makes the `\s+` before
+ *  it a deterministic boundary, so the match is linear — no backtracking
+ *  (Sonar S8786). Text is single-spaced + trimmed before matching. */
+const ROW_RE = /^(\d{1,2})\/(\d{1,2})\/(\d{2})\s+#(\d{2,3})\s+(\S.*)$/;
 
 /**
  * Parse the receding-hareline HTML into one RawEventData per run. Each run is an

--- a/scripts/backfill-upstate-h3-history.ts
+++ b/scripts/backfill-upstate-h3-history.ts
@@ -29,6 +29,7 @@
  */
 
 import "dotenv/config";
+import { pathToFileURL } from "node:url";
 import * as cheerio from "cheerio";
 import { runBackfillScript } from "./lib/backfill-runner";
 import { safeFetch } from "@/adapters/safe-fetch";
@@ -75,7 +76,7 @@ export function parseRecedingHareline(html: string): RawEventData[] {
   return [...byRun.values()].sort((a, b) => (a.runNumber ?? 0) - (b.runNumber ?? 0));
 }
 
-const isMain = import.meta.url === new URL(`file://${process.argv[1]}`).href;
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   runBackfillScript({
     sourceName: "Upstate H3 Website",

--- a/scripts/backfill-upstate-h3-history.ts
+++ b/scripts/backfill-upstate-h3-history.ts
@@ -1,0 +1,121 @@
+/**
+ * One-shot historical backfill for Upstate H3 (uh3), issue #2420.
+ *
+ * The kennel's static "receding hareline" page
+ * (https://www.upstatehashers.com/receding-hareline) documents named historical
+ * runs #122 (Feb 2008) → #334 (May 2016) — 88 titled runs, gappy, unmaintained
+ * past 2016 (the kennel is now ~#700). Each run is a Squarespace summary link
+ * whose text is verbatim "M/D/YY #NNN Title" (rendered twice per run — thumbnail
+ * + title — so we dedup by run number). None are in HashTracks.
+ *
+ * These predate the STATIC_SCHEDULE source's recurring placeholders and carry
+ * real run numbers + titles, so there's no collision.
+ *
+ * This one-shot also owns ALL of the kennel's historical special events: it
+ * pulls the /new-events-1 Squarespace collection (multi-day dress-run weekends /
+ * campouts) via the shared SquarespaceEventsAdapter with a wide window, so the
+ * two known Sep-2024 specials land here too. The live "Upstate H3 Website"
+ * source stays forward-only (all historical data belongs to this backfill).
+ *
+ * Binds to the "Upstate H3 Website" source for provenance, routes through
+ * reportAndApplyBackfill → processRawEvents (canonical Events in one pass;
+ * idempotent; strict date<today partition — every row is past, so a future
+ * special returned by the Squarespace feed is dropped here and left to the
+ * live source).
+ *
+ * Usage:
+ *   Dry run: npx tsx scripts/backfill-upstate-h3-history.ts
+ *   Apply:   BACKFILL_APPLY=1 npx tsx scripts/backfill-upstate-h3-history.ts
+ */
+
+import "dotenv/config";
+import * as cheerio from "cheerio";
+import { runBackfillScript } from "./lib/backfill-runner";
+import { safeFetch } from "@/adapters/safe-fetch";
+import { SquarespaceEventsAdapter } from "@/adapters/html-scraper/squarespace-events";
+import { toIsoDateString } from "@/lib/date";
+import type { RawEventData } from "@/adapters/types";
+import type { Source } from "@/generated/prisma/client";
+
+const SITE_URL = "https://www.upstatehashers.com";
+const HARELINE_URL = `${SITE_URL}/receding-hareline`;
+
+/** Verbatim summary-link text: "M/D/YY #NNN Title". */
+const ROW_RE = /^(\d{1,2})\/(\d{1,2})\/(\d{2})\s+#(\d{2,3})\s+(.+)$/;
+
+/**
+ * Parse the receding-hareline HTML into one RawEventData per run. Each run is an
+ * `<a>` whose text is "M/D/YY #NNN Title"; Squarespace renders two links per run
+ * (thumbnail + title), so we dedup by run number (first wins). Two-digit years
+ * are all 2008–2016 → 20YY.
+ */
+export function parseRecedingHareline(html: string): RawEventData[] {
+  const $ = cheerio.load(html);
+  const byRun = new Map<number, RawEventData>();
+  $("a").each((_i, el) => {
+    const text = $(el).text().replace(/\s+/g, " ").trim();
+    const m = ROW_RE.exec(text);
+    if (!m) return;
+    const [, mo, day, yy, num, title] = m;
+    const runNumber = Number.parseInt(num, 10);
+    if (byRun.has(runNumber)) return;
+    // toIsoDateString normalizes the loose "2008-2-17" form to "2008-02-17" and
+    // validates — keeping the canonical UTC-noon date key in sync with merge.
+    const date = toIsoDateString(`${2000 + Number.parseInt(yy, 10)}-${mo}-${day}`);
+    byRun.set(runNumber, {
+      date,
+      runNumber,
+      title: title.trim(),
+      kennelTags: ["uh3"],
+    });
+  });
+  return [...byRun.values()].sort((a, b) => (a.runNumber ?? 0) - (b.runNumber ?? 0));
+}
+
+const isMain = import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+  runBackfillScript({
+    sourceName: "Upstate H3 Website",
+    kennelTimezone: "America/New_York",
+    label: "Fetching Upstate H3 receding hareline (#122–#334)",
+    fetchEvents: async (): Promise<RawEventData[]> => {
+      // 1. Historical hareline (#122–#334) from the static page.
+      const res = await safeFetch(HARELINE_URL, {
+        headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracksBackfill/1.0)" },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${HARELINE_URL}`);
+      const hareline = parseRecedingHareline(await res.text());
+      // Fail loud on a structural change — expect ~88 runs; a near-empty parse
+      // means the page markup rotated and we'd otherwise backfill nothing.
+      if (hareline.length < 60) {
+        throw new Error(`Only ${hareline.length} runs parsed (expected ~88) — page structure may have changed`);
+      }
+
+      // 2. Named special events from the /new-events-1 Squarespace collection —
+      //    same adapter the live source uses, but a wide window here reaches the
+      //    older past specials. The runner's date<today partition drops any
+      //    future one (the live source owns those).
+      const specialsSource = {
+        id: "backfill-upstate-specials",
+        name: "Upstate H3 Website",
+        type: "HTML_SCRAPER",
+        url: SITE_URL,
+        config: { kennelTag: "uh3", collectionPath: "/new-events-1" },
+      } as unknown as Source;
+      const specials = await new SquarespaceEventsAdapter().fetch(specialsSource, { days: 9999 });
+      // Fail closed on ANY adapter error — not just fetch. The Squarespace adapter
+      // also reports malformed JSON / missing upcoming|past shape through errors[],
+      // and this one-shot exclusively owns the historical specials, so a partial
+      // specials fetch must abort rather than silently backfill hareline-only.
+      // (Codex review; same completeness rule as the WH4/Larrikins backfills.)
+      if (specials.errors.length > 0) {
+        throw new Error(`Squarespace specials fetch failed: ${specials.errors.join("; ")}`);
+      }
+
+      return [...hareline, ...specials.events];
+    },
+  }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -381,6 +381,13 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   // default `/events`. Seeded as the rich primary source while the FB Hosted
   // Events source is blocked (#1939) and the Meetup source is dead (#1144/#1459).
   { pattern: /vontramph3\.com/i, name: "SquarespaceEventsAdapter", factory: () => new SquarespaceEventsAdapter() },
+  // ── Upstate H3 (Greenville, SC) ──
+  // UH3 — same shared SquarespaceEventsAdapter against the `/new-events-1`
+  // events collection (config.collectionPath). Carries the kennel's themed
+  // special events (multi-day campouts, dress runs); the recurring cadence
+  // stays on the STATIC_SCHEDULE source. The static `/receding-hareline`
+  // archive (#122–#334, 2008–2016) is a one-shot, not a scrape target (#2420).
+  { pattern: /upstatehashers\.com/i, name: "SquarespaceEventsAdapter", factory: () => new SquarespaceEventsAdapter() },
   // HashStats — multi-kennel historical stats archive served as JSON over
   // POST {host}/{SLUG}/listhashes2 (DataTables shape). JSON-over-HTML_SCRAPER,
   // like SHITH3/Seletar. Kennel slugs come from config.kennelSlugMap, so one


### PR DESCRIPTION
## What

Closes the Upstate H3 (Greenville, SC) source coverage gap (#2420). The kennel had only a STATIC_SCHEDULE source generating generic recurring placeholders; two richer sources on the kennel site were untracked.

## How

- **Live specials source** — `/new-events-1` is a Squarespace events collection carrying themed special events (multi-day dress-run weekends, campouts). New **"Upstate H3 Website"** source reuses the shared `SquarespaceEventsAdapter` (registered via an `upstatehashers.com` URL pattern, same as the existing `sach3.beer` / `vontramph3.com` entries). It's **forward-only** (`scrapeDays: 365`, `upcomingOnly`) — all historical data belongs to the one-shot, so the live window stays a normal forward horizon.
- **Historical one-shot** (`scripts/backfill-upstate-h3-history.ts`) — owns *all* of the kennel's history:
  - `/receding-hareline`: a static archive of **88 named runs #122 (Feb 2008) → #334 (May 2016)**. Each run is a Squarespace summary link whose text is verbatim `M/D/YY #NNN Title` (rendered twice → dedup by run#). Parsed via cheerio; dates normalized through the canonical `toIsoDateString`.
  - The **2 known Sep-2024 specials** (Vagangry's 50th, Yellow Dress Weekend — both multi-day), pulled via the same `SquarespaceEventsAdapter` with a wide window. The runner's `date < today` partition drops any future special (the live source owns those).

No collision with the STATIC_SCHEDULE placeholders (those are recent + numberless; these are 2008–2016 with real run numbers).

## Verification

- **Live-verified**: adapter returns the 2 multi-day past specials (`2024-09-13→15`, `2024-09-06→08`); the parser returns all **88 runs #122–#334** with correct dates/titles; combined fetch = **90 events**.
- `npx tsc --noEmit`, `npm run lint`, `npm test` — green (9859 tests; +4 parser tests, +2 registry collision cases already covered).
- Pre-PR `/simplify` (adopted `toIsoDateString`; made the live source forward-only per the altitude review) + `/codex:adversarial-review` (fixed: the specials fetch now fails closed on **any** adapter error, so a partial specials fetch can't silently backfill hareline-only).

## Post-merge (manual)

1. `npx prisma db seed` — creates the "Upstate H3 Website" source + `SourceKennel` link. (Or targeted create, per the usual pattern.)
2. `BACKFILL_APPLY=1 npx tsx scripts/backfill-upstate-h3-history.ts` — the 88 historical runs + 2 specials.
3. Trigger the live source scrape → catches future specials as UH3 posts them.

Closes #2420

🤖 Generated with [Claude Code](https://claude.com/claude-code)