### PR TITLE
feat(bfm): onboard BFM special-events page (marquee annual events) (#765)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -376,6 +376,24 @@ export const SOURCES = [
       kennelCodes: ["bfm"],
     },
     {
+      // BFM's marquee annual events (Train Hash, Mayor's Cup, Fearadelphia
+      // campout, Marathon Beer Check, AGM) live on a separate WordPress.com page,
+      // NOT the weekly-Thursday-runs scraper above (#765). Routed to
+      // BfmSpecialEventsAdapter via the more-specific /bfm-special-events/ URL
+      // pattern (registry). `upcomingOnly` — the page shows just-passed events
+      // until the kennel resets them, so reconcile must stay future-clamped. Wide
+      // scrapeDays so a recently-past special (e.g. the June Train Hash) still
+      // ingests without the far-future AGM being clipped.
+      name: "BFM Special Events",
+      url: "https://benfranklinmob.com/bfm-special-events/",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 365,
+      config: { upcomingOnly: true },
+      kennelCodes: ["bfm"],
+    },
+    {
       name: "Philly H3 Website",
       url: "https://hashphilly.com/nexthash/",
       type: "HTML_SCRAPER" as const,

--- a/src/adapters/html-scraper/bfm-special-events.test.ts
+++ b/src/adapters/html-scraper/bfm-special-events.test.ts
@@ -53,6 +53,14 @@ describe("parseBfmDate", () => {
   it("omits endDate when the range end is not after the start", () => {
     expect(parseBfmDate("2026 Date: August 8th")).toEqual({ date: "2026-08-08", endDate: undefined });
   });
+
+  it("does not mistake a trailing month + 4-digit year for an end date", () => {
+    // "August 2026" must NOT be read as "August 20" (a bogus endDate).
+    expect(parseBfmDate("2026 Date: Saturday, August 8th, August 2026")).toEqual({
+      date: "2026-08-08",
+      endDate: undefined,
+    });
+  });
 });
 
 const FIXTURE = `

--- a/src/adapters/html-scraper/bfm-special-events.test.ts
+++ b/src/adapters/html-scraper/bfm-special-events.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { parseBfmDate, parseBfmSpecialEvents } from "./bfm-special-events";
+
+describe("parseBfmDate", () => {
+  it("parses a single 'YYYY Date: Weekday, Month Dayth' line", () => {
+    expect(parseBfmDate("2026 Date: Saturday, August 8th (Information Here)")).toEqual({
+      date: "2026-08-08",
+      endDate: undefined,
+    });
+  });
+
+  it("parses a multi-day range into date + endDate", () => {
+    expect(parseBfmDate("2026 Date: Thursday, October 1st – Sunday, October 4th (Rego Here)")).toEqual({
+      date: "2026-10-01",
+      endDate: "2026-10-04",
+    });
+  });
+
+  it("trusts the 'YYYY Date:' prefix year over a conflicting trailing year (AGM typo)", () => {
+    // Source reads "2027 Date: Thursday, February 4th, 2026" — the prefix is
+    // authoritative (Feb 4 2027 is the Thursday the text names).
+    expect(parseBfmDate("2027 Date: Thursday, February 4th, 2026")).toEqual({
+      date: "2027-02-04",
+      endDate: undefined,
+    });
+  });
+
+  it("ignores the weekday word and only treats month names as months", () => {
+    // "Sunday" must not be mistaken for a month; "November 22nd" is the date.
+    expect(parseBfmDate("2026 Date: Sunday, November 22nd")).toEqual({
+      date: "2026-11-22",
+      endDate: undefined,
+    });
+  });
+
+  it("returns null for 'No Current Date' and text without a YYYY Date: prefix", () => {
+    expect(parseBfmDate("No Current Date")).toBeNull();
+    expect(parseBfmDate("Join us for a great time")).toBeNull();
+  });
+
+  it("fails closed on an impossible day rather than rolling it to another month", () => {
+    // A "February 31st" typo must NOT silently normalize to March 3.
+    expect(parseBfmDate("2026 Date: Saturday, February 31st")).toBeNull();
+    expect(parseBfmDate("2026 Date: Thursday, April 31st")).toBeNull();
+    expect(parseBfmDate("2026 Date: November 32nd")).toBeNull();
+  });
+
+  it("respects leap years (Feb 29 valid in 2028, rejected in 2026)", () => {
+    expect(parseBfmDate("2028 Date: Tuesday, February 29th")).toEqual({ date: "2028-02-29", endDate: undefined });
+    expect(parseBfmDate("2026 Date: Sunday, February 29th")).toBeNull();
+  });
+
+  it("omits endDate when the range end is not after the start", () => {
+    expect(parseBfmDate("2026 Date: August 8th")).toEqual({ date: "2026-08-08", endDate: undefined });
+  });
+});
+
+const FIXTURE = `
+<div class="entry-content">
+  <p class="has-medium-font-size wp-block-paragraph"><strong>Mayor’s Cup</strong></p>
+  <p class="wp-block-paragraph">2026 Date: Saturday, August 8th (<a href="#">Information Here</a>)</p>
+  <p class="has-medium-font-size wp-block-paragraph"><strong>Fearadelphia</strong></p>
+  <p class="wp-block-paragraph">2026 Date: Thursday, October 1st – Sunday, October 4th (Rego Here)</p>
+  <p class="has-medium-font-size wp-block-paragraph"><strong>LVH3+BFM Campout</strong></p>
+  <p class="wp-block-paragraph">No Current Date</p>
+  <p class="has-medium-font-size wp-block-paragraph"><strong>AGM</strong></p>
+  <p class="wp-block-paragraph">2027 Date: Thursday, February 4th, 2026</p>
+</div>
+`;
+
+describe("parseBfmSpecialEvents", () => {
+  it("emits one event per titled section with a parseable date, skipping 'No Current Date'", () => {
+    const events = parseBfmSpecialEvents(FIXTURE);
+    expect(events).toEqual([
+      { date: "2026-08-08", endDate: undefined, title: "Mayor’s Cup", kennelTags: ["bfm"] },
+      { date: "2026-10-01", endDate: "2026-10-04", title: "Fearadelphia", kennelTags: ["bfm"] },
+      { date: "2027-02-04", endDate: undefined, title: "AGM", kennelTags: ["bfm"] },
+    ]);
+  });
+
+  it("does not emit the dateless campout", () => {
+    const titles = parseBfmSpecialEvents(FIXTURE).map((e) => e.title);
+    expect(titles).not.toContain("LVH3+BFM Campout");
+  });
+});

--- a/src/adapters/html-scraper/bfm-special-events.ts
+++ b/src/adapters/html-scraper/bfm-special-events.ts
@@ -1,0 +1,118 @@
+import * as cheerio from "cheerio";
+import type { Source } from "@/generated/prisma/client";
+import type { SourceAdapter, RawEventData, ScrapeResult, ErrorDetails } from "../types";
+import { hasAnyErrors } from "../types";
+import { filterEventsByWindow, MONTHS } from "../utils";
+import { safeFetch } from "../safe-fetch";
+import { toIsoDateString } from "@/lib/date";
+
+/**
+ * Ben Franklin Mob H3 (Philadelphia) marquee/special-events adapter (#765).
+ *
+ * benfranklinmob.com/bfm-special-events/ is a WordPress.com page listing the
+ * kennel's annual special events (Train Hash, Mayor's Cup, Fearadelphia campout,
+ * Marathon Beer Check, AGM, …) — SEPARATE from the weekly Thursday runs the
+ * URL-routed BFMAdapter reads. Each event is a bold "medium font" heading
+ * paragraph followed by a "YYYY Date: <Weekday>, <Month> <Day>[ – <Weekday>,
+ * <Month> <Day>]" paragraph (or "No Current Date").
+ *
+ * Registered under a MORE-SPECIFIC url pattern than the generic benfranklinmob
+ * entry so the two coexist. The source is `upcomingOnly` — the page carries both
+ * just-passed and future events, so reconcile must be future-clamped or a passed
+ * special (still shown on the page until the kennel updates it) would be
+ * cancelled the moment its date flips to "No Current Date".
+ */
+
+const KENNEL_TAG = "bfm";
+
+/** Leading "YYYY Date:" prefix — the authoritative year (a trailing ", YYYY" in
+ *  the prose is sometimes a typo, e.g. the AGM's "2027 Date: … 2026"). */
+const YEAR_PREFIX_RE = /^\s*(\d{4})\s+Date\s*:/i;
+/** `<word> <day>[st|nd|rd|th]` pairs; the word is filtered through MONTHS so the
+ *  weekday ("Thursday") is ignored and only real month names count. Simple shape
+ *  (no month alternation, single `\s+`, tiny ordinal group) — ReDoS-safe. */
+const WORD_DAY_RE = /([a-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?/gi;
+
+/** Parse "YYYY Date: Weekday, Month Day[ – Weekday, Month Day]" → start (+ end
+ *  for a multi-day span). Returns null for "No Current Date" / unparseable. */
+export function parseBfmDate(dateText: string): { date: string; endDate?: string } | null {
+  const ym = YEAR_PREFIX_RE.exec(dateText);
+  if (!ym) return null;
+  const year = ym[1];
+  const monthDays: Array<{ month: number; day: number }> = [];
+  for (const m of dateText.slice(ym[0].length).matchAll(WORD_DAY_RE)) {
+    const month = MONTHS[m[1].toLowerCase()];
+    if (month) monthDays.push({ month, day: Number.parseInt(m[2], 10) });
+  }
+  if (monthDays.length === 0) return null;
+  // toIsoDateString normalizes overflow (a "February 31st" typo would silently
+  // roll to March 3), so round-trip: reject a day that landed on a different
+  // month/day than the source stated — a source typo fails closed (skip) rather
+  // than publishing a materially wrong marquee date. (Codex review)
+  const iso = (md: { month: number; day: number }): string | null => {
+    const s = toIsoDateString(`${year}-${md.month}-${md.day}`);
+    const [, mm, dd] = s.split("-");
+    return Number(mm) === md.month && Number(dd) === md.day ? s : null;
+  };
+  const date = iso(monthDays[0]);
+  if (!date) return null;
+  const end = monthDays.length > 1 ? iso(monthDays[monthDays.length - 1]) : null;
+  return { date, endDate: end && end > date ? end : undefined };
+}
+
+/** Parse the special-events page: each bold medium-font paragraph is an event
+ *  title; the next paragraph carries its date. Skips titles with no parseable
+ *  date ("No Current Date"). */
+export function parseBfmSpecialEvents(html: string): RawEventData[] {
+  const $ = cheerio.load(html);
+  const events: RawEventData[] = [];
+  $("p.has-medium-font-size").each((_i, el) => {
+    const title = $(el).find("strong").text().replace(/\s+/g, " ").trim();
+    if (!title) return;
+    const dateText = $(el).nextAll("p").first().text().replace(/\s+/g, " ").trim();
+    const parsed = parseBfmDate(dateText);
+    if (!parsed) return;
+    events.push({ date: parsed.date, endDate: parsed.endDate, title, kennelTags: [KENNEL_TAG] });
+  });
+  return events;
+}
+
+export class BfmSpecialEventsAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(source: Source, options?: { days?: number }): Promise<ScrapeResult> {
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    let res: Response;
+    try {
+      res = await safeFetch(source.url, { headers: { "User-Agent": "Mozilla/5.0 (compatible; HashTracksBot/1.0)" } });
+    } catch (err) {
+      const message = `Failed to fetch BFM special events: ${err instanceof Error ? err.message : String(err)}`;
+      return { events: [], errors: [message], errorDetails: { fetch: [{ url: source.url, message }] } };
+    }
+    if (!res.ok) {
+      const message = `BFM special-events page error ${res.status}`;
+      return { events: [], errors: [message], errorDetails: { fetch: [{ url: source.url, status: res.status, message }] } };
+    }
+
+    const parsed = parseBfmSpecialEvents(await res.text());
+    // Structural guard: the page always lists several marquee events. Zero
+    // parsed means the WordPress theme/markup changed — surface it (blocks
+    // reconcile via the errors[] gate) rather than silently cancelling events.
+    if (parsed.length === 0) {
+      const message = "No BFM special events parsed — page structure may have changed";
+      errors.push(message);
+      errorDetails.parse = [{ row: 0, error: message }];
+    }
+
+    const events = filterEventsByWindow(parsed, options?.days ?? 365);
+
+    return {
+      events,
+      errors,
+      errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+      diagnosticContext: { eventsParsed: parsed.length, eventsInWindow: events.length },
+    };
+  }
+}

--- a/src/adapters/html-scraper/bfm-special-events.ts
+++ b/src/adapters/html-scraper/bfm-special-events.ts
@@ -31,8 +31,10 @@ const YEAR_PREFIX_RE = /^\s*(\d{4})\s+Date\s*:/i;
 /** `<word> <day>[st|nd|rd|th]` pairs; the word is filtered through MONTHS so the
  *  weekday ("Thursday") is ignored and only real month names count. The word is
  *  bounded `{3,9}` (every month + weekday name fits, "may"–"september") so the
- *  quantifier is linear — no super-linear backtracking (Sonar S8786). */
-const WORD_DAY_RE = /([a-z]{3,9})\s+(\d{1,2})(?:st|nd|rd|th)?/gi;
+ *  quantifier is linear — no super-linear backtracking (Sonar S8786). The `(?!\d)`
+ *  stops the day from swallowing the first 2 digits of a 4-digit year, so a
+ *  trailing "Month YYYY" (e.g. "August 2026") is NOT read as "August 20". */
+const WORD_DAY_RE = /([a-z]{3,9})\s+(\d{1,2})(?!\d)(?:st|nd|rd|th)?/gi;
 
 /** Parse "YYYY Date: Weekday, Month Day[ – Weekday, Month Day]" → start (+ end
  *  for a multi-day span). Returns null for "No Current Date" / unparseable. */
@@ -69,9 +71,13 @@ export function parseBfmSpecialEvents(html: string): RawEventData[] {
   const $ = cheerio.load(html);
   const events: RawEventData[] = [];
   $("p.has-medium-font-size").each((_i, el) => {
-    const title = $(el).find("strong").text().replace(/\s+/g, " ").trim();
+    // Prefer the bold title, but fall back to the paragraph text if a title
+    // isn't wrapped in <strong> (CSS-styled / un-bolded).
+    const title = ($(el).find("strong").text() || $(el).text()).replace(/\s+/g, " ").trim();
     if (!title) return;
-    const dateText = $(el).nextAll("p").first().text().replace(/\s+/g, " ").trim();
+    // Only look for the date WITHIN this event's section (up to the next title
+    // paragraph) so an event with no date can't borrow the next event's date.
+    const dateText = $(el).nextUntil("p.has-medium-font-size", "p").first().text().replace(/\s+/g, " ").trim();
     const parsed = parseBfmDate(dateText);
     if (!parsed) return;
     events.push({ date: parsed.date, endDate: parsed.endDate, title, kennelTags: [KENNEL_TAG] });

--- a/src/adapters/html-scraper/bfm-special-events.ts
+++ b/src/adapters/html-scraper/bfm-special-events.ts
@@ -29,9 +29,10 @@ const KENNEL_TAG = "bfm";
  *  the prose is sometimes a typo, e.g. the AGM's "2027 Date: … 2026"). */
 const YEAR_PREFIX_RE = /^\s*(\d{4})\s+Date\s*:/i;
 /** `<word> <day>[st|nd|rd|th]` pairs; the word is filtered through MONTHS so the
- *  weekday ("Thursday") is ignored and only real month names count. Simple shape
- *  (no month alternation, single `\s+`, tiny ordinal group) — ReDoS-safe. */
-const WORD_DAY_RE = /([a-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?/gi;
+ *  weekday ("Thursday") is ignored and only real month names count. The word is
+ *  bounded `{3,9}` (every month + weekday name fits, "may"–"september") so the
+ *  quantifier is linear — no super-linear backtracking (Sonar S8786). */
+const WORD_DAY_RE = /([a-z]{3,9})\s+(\d{1,2})(?:st|nd|rd|th)?/gi;
 
 /** Parse "YYYY Date: Weekday, Month Day[ – Weekday, Month Day]" → start (+ end
  *  for a multi-day span). Returns null for "No Current Date" / unparseable. */
@@ -56,7 +57,8 @@ export function parseBfmDate(dateText: string): { date: string; endDate?: string
   };
   const date = iso(monthDays[0]);
   if (!date) return null;
-  const end = monthDays.length > 1 ? iso(monthDays[monthDays.length - 1]) : null;
+  const last = monthDays.at(-1);
+  const end = monthDays.length > 1 && last ? iso(last) : null;
   return { date, endDate: end && end > date ? end : undefined };
 }
 

--- a/src/adapters/registry.test.ts
+++ b/src/adapters/registry.test.ts
@@ -3,6 +3,7 @@ import { getAdapter } from "./registry";
 import { GenericHtmlAdapter } from "./html-scraper/generic";
 import { HashNYCAdapter } from "./html-scraper/hashnyc";
 import { BFMAdapter } from "./html-scraper/bfm";
+import { BfmSpecialEventsAdapter } from "./html-scraper/bfm-special-events";
 import { HashPhillyAdapter } from "./html-scraper/hashphilly";
 import { GoogleCalendarAdapter } from "./google-calendar/adapter";
 import { GoogleSheetsAdapter } from "./google-sheets/adapter";
@@ -52,6 +53,12 @@ describe("getAdapter", () => {
 
   it("returns BFMAdapter for benfranklinmob.com URL", () => {
     expect(getAdapter("HTML_SCRAPER", "https://benfranklinmob.com")).toBeInstanceOf(BFMAdapter);
+  });
+
+  it("routes the /bfm-special-events/ page to BfmSpecialEventsAdapter (more-specific wins)", () => {
+    const adapter = getAdapter("HTML_SCRAPER", "https://benfranklinmob.com/bfm-special-events/");
+    expect(adapter).toBeInstanceOf(BfmSpecialEventsAdapter);
+    expect(adapter).not.toBeInstanceOf(BFMAdapter);
   });
 
   it("returns HashPhillyAdapter for hashphilly.com URL", () => {

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import type { SourceAdapter } from "./types";
 import { GenericHtmlAdapter, isGenericHtmlConfig } from "./html-scraper/generic";
 import { HashNYCAdapter } from "./html-scraper/hashnyc";
 import { BFMAdapter } from "./html-scraper/bfm";
+import { BfmSpecialEventsAdapter } from "./html-scraper/bfm-special-events";
 import { HashPhillyAdapter } from "./html-scraper/hashphilly";
 import { CityHashAdapter } from "./html-scraper/city-hash";
 import { WestLondonHashAdapter } from "./html-scraper/west-london-hash";
@@ -167,6 +168,10 @@ interface HtmlScraperEntry {
 }
 
 const htmlScraperEntries: HtmlScraperEntry[] = [
+  // MORE-SPECIFIC first: the /bfm-special-events/ page is a separate WordPress.com
+  // page (marquee annual events) with its own parser; the generic benfranklinmob
+  // entry below handles the weekly Thursday runs. (#765)
+  { pattern: /benfranklinmob\.com\/bfm-special-events/i, name: "BfmSpecialEventsAdapter", factory: () => new BfmSpecialEventsAdapter() },
   { pattern: /benfranklinmob/i,          name: "BFMAdapter",          factory: () => new BFMAdapter() },
   { pattern: /hashphilly/i,              name: "HashPhillyAdapter",   factory: () => new HashPhillyAdapter() },
   { pattern: /makesweat\.com\/cityhash/i, name: "CityHashAdapter",     factory: () => new CityHashAdapter() },


### PR DESCRIPTION
## What

Onboards Ben Franklin Mob H3's marquee annual events (#765) — Train Hash, Mayor's Cup, Fearadelphia campout, Marathon Beer Check, AGM — from `benfranklinmob.com/bfm-special-events/`. None appeared on HashTracks; they're separate from the weekly Thursday runs.

## How

- **New `BfmSpecialEventsAdapter`** parses the WordPress.com page: each bold "medium font" heading paragraph is an event title; the next paragraph carries its `YYYY Date: Weekday, Month Day[ – Weekday, Month Day]` line (or "No Current Date" → skipped).
  - The **`YYYY Date:` prefix is the authoritative year** — resolves the AGM's `2027 Date: … 2026` typo → Feb 4 2027 (correctly a Thursday).
  - **Multi-day ranges → `endDate`** (Fearadelphia, Oct 1–4).
  - Month scan filters words through the shared `MONTHS` map so weekday names ("Thursday") aren't mistaken for months.
  - **Fails closed on impossible dates** — a "February 31st" typo round-trips against `toIsoDateString` and is rejected (skipped) rather than silently rolling to March 3 (per Codex review; leap years handled).
- **Registered under a more-specific `/bfm-special-events/` URL pattern before the generic `benfranklinmob` entry** so it coexists with the weekly-runs `BFMAdapter` on one host (same SLASH-before-London precedent).
- **New "BFM Special Events" source**, `upcomingOnly` + wide `scrapeDays` — the page shows just-passed events until the kennel resets them, so reconcile stays future-clamped; a recently-past special (June Train Hash) still ingests. All events live on the one page → **no one-shot needed**.

## Verification

- **Live-verified**: 6 events parse — Train Hash (past), The Number Run, Mayor's Cup, Fearadelphia (multi-day), Marathon Beer Check, AGM 2027; the dateless campout is skipped.
- `npx tsc --noEmit`, `npm run lint`, `npm test` — green (**9870 tests**; +10 parser/registry).
- Pre-PR `/simplify` (reused shared `MONTHS` + `filterEventsByWindow`; altitude/efficiency clean) + `/codex:adversarial-review` (added fail-closed date validation + impossible-date/leap-year tests).

## Post-merge (manual)

1. Targeted create of the "BFM Special Events" source + `SourceKennel` link (per usual pattern; not a full seed).
2. Trigger the scrape → all 6 marquee events hydrate (past Train Hash protected by `upcomingOnly`; future ones flow normally).

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)