### PR TITLE
feat(ical): maps.app.goo.gl support + documented deferred HashNYC iCal cutover

### DIFF
--- a/.claude/rules/documentation-index.md
+++ b/.claude/rules/documentation-index.md
@@ -17,5 +17,6 @@ globs:
 - `docs/test-coverage-analysis.md` -- Test coverage gap analysis and priorities
 - `docs/self-healing-automation-plan.md` -- Self-healing automation loop architecture, confidence scoring, roadmap
 - `docs/residential-proxy-spec.md` -- Architecture and deployment guide for residential proxy
+- `docs/hashnyc-ical-cutover.md` -- DEFERRED cutover: HashNYC HTML scraper -> iCal feed (ready-to-apply seed + migration; resume when hashnyc.com re-launches the .ics)
 - `infra/proxy-relay/` -- NAS-deployed residential proxy (Cloudflare Tunnel + Node.js forwarder)
 - `infra/browser-render/` -- NAS-hosted Playwright rendering service (Dockerfile + server.js)

--- a/docs/hashnyc-ical-cutover.md
+++ b/docs/hashnyc-ical-cutover.md
@@ -1,0 +1,196 @@
+# HashNYC: HTML scraper → iCal feed cutover (DEFERRED)
+
+**Status:** Ready to apply, on hold. hashnyc.com relaunched a new WordPress site in
+mid-2026 that published a clean iCal feed, but as of 2026-07-04 the site **reverted
+to the old HTML layout** and the `.ics` endpoint 404s. The current bespoke
+`HashNYCAdapter` (`src/adapters/html-scraper/hashnyc.ts`) still works against the old
+site and must stay enabled. Resume this cutover when they re-launch and the feed is
+live again.
+
+**Trigger to resume:** `curl -sSL https://hashnyc.com/public/hareline.ics` returns a
+`BEGIN:VCALENDAR` body (not a WordPress 404 page) with upcoming `VEVENT`s.
+
+## Why iCal over patching the HTML scraper
+
+The relaunched feed is far better structured than scraping HTML — kennel is a reliable
+`SUMMARY` prefix, hares + hash cash sit in `DESCRIPTION`, venue is a first-class
+`LOCATION`, and Google Maps pins arrive as `maps.app.goo.gl` links. The shared
+`ICalAdapter` already handles all of it via config (`kennelPatterns`, default hare /
+cost extraction, `LOCATION` → venue). No new adapter code is needed — it's a config
+swap plus a retirement migration.
+
+Live feed sample captured at session start (2026-07-03), when the endpoint was up:
+
+```
+SUMMARY:NYCH3 #2153
+LOCATION:Malt & Mold, 362 Second Ave
+DESCRIPTION:Hares: Cheeky Bastard, Just Elizabeth\nHash Cash: $3\nMap: https://maps.app.goo.gl/…
+```
+
+The live fetch returned **53 events (2026-05 → 2026-12), 0 errors, 0 unrouted**, split
+nych3 21 / brh3 16 / ggfm 7 / lil 5 / nah3 3 / qbk 1.
+
+## Already merged with this work (do NOT redo)
+
+The shared iCal adapter improvements landed independently and are safe/general:
+
+- `src/adapters/ical/adapter.ts` — `MAPS_URL_PATTERN` recognizes `maps.app.goo.gl`;
+  a maps-shaped `URL:` property routes to `locationUrl` (preferred over the
+  name-search fallback) instead of leaking into `sourceUrl`.
+- `src/adapters/ical/adapter.test.ts` — the `describe("ICalAdapter — HashNYC …")`
+  block: fixture-based regression coverage for the multi-kennel routing (incl. the
+  nawwh3-vs-nah3 ordering) and the map-link support. It runs today and passes.
+
+## To resume the cutover — 2 changes
+
+### 1. Seed: swap the HashNYC source to ICAL_FEED + add a disabled legacy entry
+
+In `prisma/seed-data/sources.ts`, replace the single HTML_SCRAPER "HashNYC Website"
+entry with these two (identity is `(name, type)`, so they're distinct rows):
+
+```ts
+{
+  name: "HashNYC Website",
+  url: "https://hashnyc.com/public/hareline.ics",
+  type: "ICAL_FEED" as const,
+  trustLevel: 8,
+  scrapeFreq: "daily",
+  scrapeDays: 365,
+  config: {
+    upcomingOnly: true, // forward hareline; receding events aren't cancellations (#1263)
+    // Ported from the old adapter's KENNEL_PATTERNS, anchored to SUMMARY start,
+    // most-specific first (first match wins): "Queens Black Knights" before
+    // generic "Queens"; "NAWW" (nawwh3) distinct from "New Amsterdam" (nah3).
+    kennelPatterns: [
+      ["^Knickerbocker\\b|^Knick\\b", "knick"],
+      ["^Queens Black Knights\\b|^QBK\\b", "qbk"],
+      ["^NAWW(?:H3)?\\b", "nawwh3"],
+      ["^New Amsterdam\\b|^NAH3\\b|^NASS\\b", "nah3"],
+      ["^Long Island(?:\\s+Lunatics)?\\b|^LIL\\b", "lil"],
+      ["^Staten Island\\b|^SI\\b", "si"],
+      ["^Drinking Practice\\b", "drinking-practice-nyc"],
+      ["^Brooklyn(?:\\s+H3)?\\b|^BrH3\\b|^BKH3\\b", "brh3"],
+      ["^Harriettes\\b", "harriettes-nyc"],
+      ["^Columbia\\b", "columbia"],
+      ["^GGFM\\b", "ggfm"],
+      ["^Queens\\b", "qbk"],
+      ["^NYC(?:H3)?\\b", "nych3"],
+    ],
+    defaultKennelTag: "nych3",
+  },
+  kennelCodes: ["nych3", "brh3", "nah3", "knick", "lil", "qbk", "si", "columbia", "harriettes-nyc", "ggfm", "nawwh3", "drinking-practice-nyc"],
+},
+{
+  // Retired legacy HTML scraper — kept disabled so re-seeds hold it disabled and it
+  // isn't flagged as a stale source (seed identity is (name, type)).
+  name: "HashNYC Website",
+  url: "https://hashnyc.com",
+  type: "HTML_SCRAPER" as const,
+  enabled: false,
+  trustLevel: 8,
+  scrapeFreq: "daily",
+  scrapeDays: 365,
+  config: { upcomingOnly: true },
+  kennelCodes: ["nych3", "brh3", "nah3", "knick", "lil", "qbk", "si", "columbia", "harriettes-nyc", "ggfm", "nawwh3", "drinking-practice-nyc"],
+},
+```
+
+Keep `src/adapters/html-scraper/hashnyc.ts` — it's still the default HTML_SCRAPER
+fallback in `src/adapters/registry.ts` (`HTML_SCRAPER: () => new HashNYCAdapter()`).
+
+### 2. Companion migration: ATOMIC provision + retire (create a new timestamped dir)
+
+Vercel runs `prisma migrate deploy`, never `db seed`, so the migration must both
+**create** the replacement ICAL_FEED row + its SourceKennel links **and** disable the
+old HTML_SCRAPER row in one transaction — otherwise the deploy disables the working
+HTML source and leaves hashnyc with no enabled source until an operator runs the seed.
+(This gap was caught by an adversarial review; the fix mirrors
+`prisma/migrations/20260622120100_onboard_fool_moon_h3_644/`.)
+
+Create `prisma/migrations/<new-ts>_cutover_hashnyc_html_to_ical/migration.sql`:
+
+```sql
+BEGIN;
+
+-- 1. Provision the replacement ICAL_FEED source (create if absent; leave any
+--    existing / seed-converged row untouched). Config mirrors the seed row.
+--    JSONB escaping note: write "\\b" in the SQL literal → jsonb stores "\b"
+--    (backslash+b, a regex word boundary), NOT a JSON backspace. Verified via
+--    DB→config::text→JSON.parse→RegExp round-trip (word boundary, no 0x08).
+INSERT INTO "Source" (
+  id, name, url, type, config, "trustLevel", "scrapeFreq", "scrapeDays",
+  enabled, "createdAt", "updatedAt"
+)
+VALUES (
+  'src_hashnyc_ical_relaunch',
+  'HashNYC Website',
+  'https://hashnyc.com/public/hareline.ics',
+  'ICAL_FEED'::"SourceType",
+  '{
+    "upcomingOnly": true,
+    "kennelPatterns": [
+      ["^Knickerbocker\\b|^Knick\\b", "knick"],
+      ["^Queens Black Knights\\b|^QBK\\b", "qbk"],
+      ["^NAWW(?:H3)?\\b", "nawwh3"],
+      ["^New Amsterdam\\b|^NAH3\\b|^NASS\\b", "nah3"],
+      ["^Long Island(?:\\s+Lunatics)?\\b|^LIL\\b", "lil"],
+      ["^Staten Island\\b|^SI\\b", "si"],
+      ["^Drinking Practice\\b", "drinking-practice-nyc"],
+      ["^Brooklyn(?:\\s+H3)?\\b|^BrH3\\b|^BKH3\\b", "brh3"],
+      ["^Harriettes\\b", "harriettes-nyc"],
+      ["^Columbia\\b", "columbia"],
+      ["^GGFM\\b", "ggfm"],
+      ["^Queens\\b", "qbk"],
+      ["^NYC(?:H3)?\\b", "nych3"]
+    ],
+    "defaultKennelTag": "nych3"
+  }'::jsonb,
+  8, 'daily', 365, true,
+  NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC'
+)
+ON CONFLICT (name, type) DO NOTHING;
+
+-- 2. Link the 12 kennels the feed routes to (merge source-kennel guard).
+INSERT INTO "SourceKennel" (id, "sourceId", "kennelId")
+SELECT 'sk_hashnyc_ical_' || k."kennelCode", s.id, k.id
+FROM "Source" s
+JOIN "Kennel" k ON k."kennelCode" = ANY (ARRAY[
+  'nych3', 'brh3', 'nah3', 'knick', 'lil', 'qbk', 'si', 'columbia',
+  'harriettes-nyc', 'ggfm', 'nawwh3', 'drinking-practice-nyc'
+])
+WHERE s.name = 'HashNYC Website' AND s.type::text = 'ICAL_FEED'
+ON CONFLICT ("sourceId", "kennelId") DO NOTHING;
+
+-- 3. Retire the legacy HTML_SCRAPER row (only while still enabled → idempotent).
+UPDATE "Source"
+SET enabled = false, "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE name = 'HashNYC Website' AND type::text = 'HTML_SCRAPER' AND enabled = true;
+
+COMMIT;
+```
+
+(The full authored version also RAISE NOTICEs when the ICAL row / a kennel link /
+the legacy row is missing — nice-to-have, not required. See git history of this branch
+for the annotated copy if needed.)
+
+## Post-resume validation (all passed on 2026-07-03 dry run)
+
+1. `npm test src/adapters/ical/adapter.test.ts` — HashNYC block green.
+2. Live: build a `Source` from the config and run `new ICalAdapter().fetch(source)` —
+   confirm non-empty, 0 unrouted, hares/cost/location/run# populated, `maps.app.goo.gl`
+   → `locationUrl` (0 leaking into `sourceUrl`). (8 of the 53 events had a map pin.)
+3. Apply the migration to the local prod-copy DB (`.claude/rules/local-dev-db.md`):
+   confirm it creates 1 source + 12 links, disables the old row, and is idempotent on
+   re-run (`INSERT 0 0`). All verified during the original work.
+4. `npx tsc --noEmit && npm run lint && npm test`.
+
+## Notes / decisions from the original work
+
+- **Titles:** plain `NYCH3 #2150` (no colon) keeps the summary as the title — same as
+  every other iCal source (e.g. SFH3 `GPH3 #1700`); colon events get clean titles
+  ("Cold Moon"). Accepted as-is by the owner.
+- **Existing canonical Events** (kennel+date keyed) are enriched/re-merged by the iCal
+  source, not duplicated; old immutable RawEvents from the HTML source stay as audit.
+- **Seed identity is `(name, type)`** and the stale-source reconcile is opt-in
+  (`SEED_RECONCILE_DISABLE`), which is why the migration — not the seed — is what
+  actually retires the old row in prod.

--- a/src/adapters/hashrego/adapter.test.ts
+++ b/src/adapters/hashrego/adapter.test.ts
@@ -2420,10 +2420,14 @@ describe("HashRegoAdapter", () => {
     // how we prove the 9 good Step 2b rows actually emit events end-to-end.
     fetchSpy.mockImplementation(async () => new Response("", { status: 404 }));
 
+    // Future-relative date so the row stays inside the fetch's forward window and
+    // the test never ages out (a hardcoded past date silently drops all 9 rows and
+    // fails on kennelPageEventsFound). ~30 days ahead is well within `days: 365`.
+    const goodStart = `${new Date(Date.now() + 30 * 86_400_000).toISOString().slice(0, 10)}T19:00:00-04:00`;
     const rows: HashRegoKennelEvent[] = Array.from({ length: 10 }, (_, i) =>
       buildApiRow({
         slug: `nych3-row-${i}`,
-        start_time: i === 4 ? "garbage" : "2026-06-27T19:00:00-04:00",
+        start_time: i === 4 ? "garbage" : goodStart,
       }),
     );
     mockedFetchKennelEvents.mockResolvedValueOnce(rows);

--- a/src/adapters/ical/adapter.test.ts
+++ b/src/adapters/ical/adapter.test.ts
@@ -1498,6 +1498,195 @@ function buildOh3Source(): Source {
   });
 }
 
+// hashnyc.com's 2026 relaunch published a structured iCal feed
+// (https://hashnyc.com/public/hareline.ics). The source cutover from the bespoke
+// HTML scraper to the shared ICalAdapter is DEFERRED — the site reverted to the
+// old HTML layout and the .ics 404s for now (see docs/hashnyc-ical-cutover.md for
+// the ready-to-apply seed + migration to resume when they re-launch). This block
+// stays as forward-looking coverage: it guards the shared adapter's multi-kennel
+// routing (incl. the nawwh3-vs-nah3 ordering) and the maps.app.goo.gl locationUrl
+// support that landed with this work. Fixture mirrors the live feed's real VEVENT
+// shapes (SUMMARY "<kennel> #<run>[: <title>]", "Hares:"/"Hash Cash:" in
+// DESCRIPTION, venue in LOCATION).
+const HASHNYC_ICS = [
+  "BEGIN:VCALENDAR",
+  "VERSION:2.0",
+  "PRODID:-//hashnyc.com//hash-attendance//EN",
+  "CALSCALE:GREGORIAN",
+  "X-WR-TIMEZONE:America/New_York",
+  // NYCH3 #2153 — full field set (hares, hash cash, escaped-comma venue)
+  "BEGIN:VEVENT",
+  "UID:ab8995b7#2153@hashnyc.com",
+  "DTSTART;TZID=America/New_York:20260610T190000",
+  "DURATION:PT2H",
+  "SUMMARY:NYCH3 #2153",
+  "LOCATION:Malt & Mold\\, 362 Second Ave",
+  "DESCRIPTION:Hares: Cheeky Bastard\\, Just Elizabeth\\nHash Cash: $3\\nMap: https://maps.app.goo.gl/nyc2153",
+  "DTSTAMP:20260601T000000Z",
+  "END:VEVENT",
+  // Brooklyn H3 #1185 — full-name prefix with " H3"
+  "BEGIN:VEVENT",
+  "UID:817c90a6#1185@hashnyc.com",
+  "DTSTART;TZID=America/New_York:20260622T190000",
+  "DURATION:PT2H",
+  "SUMMARY:Brooklyn H3 #1185",
+  "LOCATION:Hinterlands Bar\\, 739 Church Ave",
+  "DESCRIPTION:Hash Cash: $3",
+  "DTSTAMP:20260601T000000Z",
+  "END:VEVENT",
+  // GGFM #441: Cold Moon — run number + colon title
+  "BEGIN:VEVENT",
+  "UID:ggfm#441@hashnyc.com",
+  "DTSTART;TZID=America/New_York:20261221T190000",
+  "DURATION:PT2H",
+  "SUMMARY:GGFM #441: Cold Moon",
+  "DESCRIPTION:Hash Cash: $3",
+  "DTSTAMP:20260601T000000Z",
+  "END:VEVENT",
+  // LIL #149 — apostrophe in colon title
+  "BEGIN:VEVENT",
+  "UID:lil#149@hashnyc.com",
+  "DTSTART;TZID=America/New_York:20260620T140000",
+  "DURATION:PT2H",
+  "SUMMARY:LIL #149: Fluffy's Long Beach Adventure",
+  "LOCATION:Long Beach train station",
+  "DTSTAMP:20260601T000000Z",
+  "END:VEVENT",
+  // NAH3 #391 — must route to nah3, NOT nawwh3
+  "BEGIN:VEVENT",
+  "UID:nah3#391@hashnyc.com",
+  "DTSTART;TZID=America/New_York:20260614T140000",
+  "DURATION:PT2H",
+  "SUMMARY:NAH3 #391",
+  "URL:https://maps.app.goo.gl/nah3391",
+  "DTSTAMP:20260601T000000Z",
+  "END:VEVENT",
+  // NAWW #12 — synthetic: proves the nawwh3 pattern precedes New Amsterdam/NAH3
+  "BEGIN:VEVENT",
+  "UID:naww#12@hashnyc.com",
+  "DTSTART;TZID=America/New_York:20260701T190000",
+  "DURATION:PT2H",
+  "SUMMARY:NAWW #12: Winter Wednesday",
+  "DTSTAMP:20260601T000000Z",
+  "END:VEVENT",
+  // Queens #249 — generic "Queens" routes to qbk (not shadowed, not NYCH3)
+  "BEGIN:VEVENT",
+  "UID:queens#249@hashnyc.com",
+  "DTSTART;TZID=America/New_York:20260702T190000",
+  "DURATION:PT2H",
+  "SUMMARY:Queens #249: 7-11 C*ms to Queens!",
+  "DTSTAMP:20260601T000000Z",
+  "END:VEVENT",
+  // NYCH3 Beer Mile — special event, no run #, no colon → title stays undefined
+  "BEGIN:VEVENT",
+  "UID:nych3-beermile@hashnyc.com",
+  "DTSTART;TZID=America/New_York:20261024T170000",
+  "DURATION:PT2H",
+  "SUMMARY:NYCH3 Beer Mile",
+  "DTSTAMP:20260601T000000Z",
+  "END:VEVENT",
+  "END:VCALENDAR",
+].join("\r\n");
+
+const HASHNYC_KENNEL_PATTERNS: [string, string][] = [
+  ["^Knickerbocker\\b|^Knick\\b", "knick"],
+  ["^Queens Black Knights\\b|^QBK\\b", "qbk"],
+  ["^NAWW(?:H3)?\\b", "nawwh3"],
+  ["^New Amsterdam\\b|^NAH3\\b|^NASS\\b", "nah3"],
+  ["^Long Island(?:\\s+Lunatics)?\\b|^LIL\\b", "lil"],
+  ["^Staten Island\\b|^SI\\b", "si"],
+  ["^Drinking Practice\\b", "drinking-practice-nyc"],
+  ["^Brooklyn(?:\\s+H3)?\\b|^BrH3\\b|^BKH3\\b", "brh3"],
+  ["^Harriettes\\b", "harriettes-nyc"],
+  ["^Columbia\\b", "columbia"],
+  ["^GGFM\\b", "ggfm"],
+  ["^Queens\\b", "qbk"],
+  ["^NYC(?:H3)?\\b", "nych3"],
+];
+
+function buildHashNycSource(): Source {
+  return buildMockSource({
+    name: "HashNYC Website",
+    url: "https://hashnyc.com/public/hareline.ics",
+    config: {
+      upcomingOnly: true,
+      kennelPatterns: HASHNYC_KENNEL_PATTERNS,
+      defaultKennelTag: "nych3",
+    },
+  });
+}
+
+describe("ICalAdapter — HashNYC (relaunch iCal migration)", () => {
+  let adapter: ICalAdapter;
+  beforeEach(() => {
+    adapter = new ICalAdapter();
+    vi.restoreAllMocks();
+  });
+
+  it("routes every SUMMARY prefix to the correct kennel code", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(HASHNYC_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildHashNycSource(), { days: 9999 });
+
+    expect(result.errors).toHaveLength(0);
+    const byTag = (tag: string) => result.events.filter((e) => e.kennelTags[0] === tag);
+
+    expect(byTag("nych3").map((e) => e.runNumber).sort()).toEqual([2153, undefined]);
+    expect(byTag("brh3")[0]?.runNumber).toBe(1185);
+    expect(byTag("ggfm")[0]?.runNumber).toBe(441);
+    expect(byTag("lil")[0]?.runNumber).toBe(149);
+    // NAWW routes to nawwh3, NAH3 routes to nah3 — the ordering split holds
+    expect(byTag("nawwh3")[0]?.runNumber).toBe(12);
+    expect(byTag("nah3")[0]?.runNumber).toBe(391);
+    // generic "Queens" → qbk (not NYCH3 default, not shadowed)
+    expect(byTag("qbk")[0]?.runNumber).toBe(249);
+    // no event should fall through to the UNKNOWN sentinel
+    expect(result.events.every((e) => e.kennelTags[0] !== "UNKNOWN")).toBe(true);
+  });
+
+  it("extracts hares, hash cash, and venue from a full NYCH3 VEVENT", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(HASHNYC_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildHashNycSource(), { days: 9999 });
+
+    const nych3 = result.events.find((e) => e.runNumber === 2153);
+    expect(nych3).toBeDefined();
+    expect(nych3!.kennelTags[0]).toBe("nych3");
+    expect(nych3!.date).toBe("2026-06-10");
+    expect(nych3!.startTime).toBe("19:00");
+    expect(nych3!.hares).toBe("Cheeky Bastard, Just Elizabeth");
+    expect(nych3!.cost).toBe("$3");
+    expect(nych3!.location).toBe("Malt & Mold, 362 Second Ave");
+    // The DESCRIPTION "Map:" line (a maps.app.goo.gl share link) → locationUrl
+    expect(nych3!.locationUrl).toBe("https://maps.app.goo.gl/nyc2153");
+  });
+
+  it("routes a maps-shaped URL property to locationUrl, not sourceUrl", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(HASHNYC_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildHashNycSource(), { days: 9999 });
+
+    // NAH3 #391 has no DESCRIPTION Map: line — the map pin comes from the
+    // maps.app.goo.gl URL property, which must NOT leak into sourceUrl.
+    const nah3 = result.events.find((e) => e.runNumber === 391);
+    expect(nah3!.locationUrl).toBe("https://maps.app.goo.gl/nah3391");
+    expect(nah3!.sourceUrl).toBeUndefined();
+  });
+
+  it("keeps colon titles but never leaks the kennel prefix", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(HASHNYC_ICS, { status: 200 }));
+    const result = await adapter.fetch(buildHashNycSource(), { days: 9999 });
+
+    expect(result.events.find((e) => e.runNumber === 441)!.title).toBe("Cold Moon");
+    expect(result.events.find((e) => e.runNumber === 149)!.title).toBe("Fluffy's Long Beach Adventure");
+    expect(result.events.find((e) => e.runNumber === 249)!.title).toBe("7-11 C*ms to Queens!");
+    // Colon-less, run-less special event: kennel resolves and the full SUMMARY
+    // is kept as the title (same behavior as the all-day "Bay 2 Blackout 2026"
+    // case) — there is no run number for the merge synthesizer to build from.
+    const beerMile = result.events.find((e) => e.date === "2026-10-24");
+    expect(beerMile!.kennelTags[0]).toBe("nych3");
+    expect(beerMile!.runNumber).toBeUndefined();
+    expect(beerMile!.title).toBe("NYCH3 Beer Mile");
+  });
+});
+
 describe("ICalAdapter — Oslo H3 (#1824 placeholder, #1828 endpoint coalesce)", () => {
   let adapter: ICalAdapter;
   beforeEach(() => {

--- a/src/adapters/ical/adapter.ts
+++ b/src/adapters/ical/adapter.ts
@@ -237,8 +237,12 @@ const COST_PATTERNS = [
 // ("West Coast 4 seasons run") is a trail theme, not a hare. "hash"/"trail" are
 // deliberately omitted so legit names like "Captain Hash" pass.
 const TITLE_HARE_THEME_SUFFIX_RE = /\b(?:run|walk|jog|ride|bike|hike)$/i;
+// `maps.app.goo.gl` is the modern Google Maps share-link host (hashnyc.com's
+// iCal feed emits these in both the DESCRIPTION "Map:" line and the URL
+// property); `goo.gl/maps` is the legacy short form. Both recognized so the
+// map pin surfaces as locationUrl.
 const MAPS_URL_PATTERN =
-  /https?:\/\/(?:www\.)?(?:google\.com\/maps|maps\.google\.com|goo\.gl\/maps)\S*/i;
+  /https?:\/\/(?:www\.)?(?:google\.com\/maps|maps\.google\.com|maps\.app\.goo\.gl|goo\.gl\/maps)\S*/i;
 
 /** Normalize ICS escape sequences in a description string. */
 function normalizeIcsDescription(description: string): string {
@@ -560,11 +564,18 @@ function parseIcsCalendar(
   }
 }
 
-/** Resolve a locationUrl from GEO field, description Maps URL, or location name search. */
+/**
+ * Resolve a locationUrl from GEO field, description Maps URL, a maps-shaped
+ * event URL property, or a location-name search — most precise first. An exact
+ * map pin (`eventMapUrl`, e.g. hashnyc's `URL:https://maps.app.goo.gl/…`) beats
+ * the name-search fallback, which is why it's threaded through here rather than
+ * left in `sourceUrl`.
+ */
 function resolveLocationUrl(
   geo: VEvent["geo"],
   location: string | undefined,
   description: string | undefined,
+  eventMapUrl?: string,
 ): string | undefined {
   if (geo) {
     const { lat, lon } = geo;
@@ -576,6 +587,7 @@ function resolveLocationUrl(
     const descUrl = extractMapsUrlFromDescription(description);
     if (descUrl) return descUrl;
   }
+  if (eventMapUrl) return eventMapUrl;
   if (location) return mapsUrl(location);
   return undefined;
 }
@@ -682,7 +694,18 @@ function buildRawEventFromVEvent(
     }
   }
 
-  const locationUrl = resolveLocationUrl(vevent.geo, location ?? undefined, description);
+  // A URL property that is itself a Google Maps link (hashnyc.com's feed) is a
+  // map pin, not an event page — route it to locationUrl and keep it out of
+  // sourceUrl. Real event-page URLs (EBH3 `URL:https://www.ebh3.com/runs/…`)
+  // don't match, so their sourceUrl behavior is unchanged.
+  const eventUrl = paramValue(vevent.url) ?? undefined;
+  const eventUrlIsMap = eventUrl ? MAPS_URL_PATTERN.test(eventUrl) : false;
+  const locationUrl = resolveLocationUrl(
+    vevent.geo,
+    location ?? undefined,
+    description,
+    eventUrlIsMap ? eventUrl : undefined,
+  );
 
   // Run number: prefer the shared `#`-delimited summary extraction (parsed),
   // then custom patterns.
@@ -765,7 +788,7 @@ function buildRawEventFromVEvent(
     startTime,
     endTime,
     cost,
-    sourceUrl: paramValue(vevent.url) ?? undefined,
+    sourceUrl: eventUrlIsMap ? undefined : eventUrl,
     endDate,
   };
 }


### PR DESCRIPTION
## Context

hashnyc.com relaunched with a new site that publishes a clean structured iCal feed (`https://hashnyc.com/public/hareline.ics`), which would let us retire the bespoke `HashNYCAdapter` HTML scraper. During this work the site **reverted to the old HTML layout** (the `.ics` now 404s), so the **source cutover is deferred** — the old HTML scraper keeps running untouched — and only the safe, general adapter improvements land now. The full, verified cutover recipe is documented to resume when they re-launch.

## What's in this PR

**Shared iCal adapter — `maps.app.goo.gl` support** (`src/adapters/ical/adapter.ts`)
- `MAPS_URL_PATTERN` now recognizes the modern `maps.app.goo.gl` share-link host.
- A maps-shaped `URL:` property routes to `locationUrl` (preferred over the imprecise name-search fallback) instead of leaking into `sourceUrl`. Real event-page URLs (e.g. EBH3's `ebh3.com/runs/…`) don't match, so they're unaffected. General improvement — benefits any iCal feed.

**Forward-looking test coverage** (`src/adapters/ical/adapter.test.ts`)
- A `HashNYC` describe block with a fixture mirroring the real feed: guards the multi-kennel routing (incl. the tricky `nawwh3`-vs-`nah3` ordering) and the new map-link support. Runs and passes today; annotated as coverage for the deferred cutover.

**Deferred cutover docs** (`docs/hashnyc-ical-cutover.md`, indexed)
- Trigger condition, exact seed entries, and the **atomic** provision-and-retire migration (create new ICAL_FEED source + 12 SourceKennel links + disable old row in one transaction — no deploy-time gap). Verified end-to-end against a local prod-copy DB (applies, idempotent, correct routing incl. the JSONB `\b`-escaping round-trip). The atomic design came out of an adversarial review that caught the "disable without provisioning" gap.

**Drive-by fix** (`src/adapters/hashrego/adapter.test.ts`)
- An unrelated, pre-existing test failure: a hardcoded `2026-06-27` fixture date aged out of the forward scrape window (fails on clean `main` as of 2026-07-04). Made the row date relative to now so it can't age out again.

## Verification
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors (22 pre-existing warnings)
- `npm test` — 334 files, 9,859 tests pass
- iCal adapter live-verified against the feed while it was up (53 events, 0 unrouted, 8 with `maps.app.goo.gl` pins, 0 leaking into `sourceUrl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)