### PR TITLE
fix(sources): Amsterdam URL + seasonal/low-baseline alert suppression + FB proxy flags

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2588,6 +2588,9 @@ export const SOURCES = [
         kennelTag: "gsh3",
         pageHandle: "GrandStrandHashing",
         timezone: "America/New_York",
+        // #1939/#2561: FB serves a datacenter-IP checkpoint wall to this Page from
+        // Vercel — fetch via residential proxy first (skips the wasted direct hit).
+        useResidentialProxy: true,
         upcomingOnly: true,
         includePastEvents: true, // #1940: backfill rich title/venue from /past_hosted_events (reconcile-safe under upcomingOnly)
       },
@@ -4473,7 +4476,8 @@ export const SOURCES = [
     // ===== NETHERLANDS =====
     {
       name: "Amsterdam H3 Website",
-      url: "https://ah3.nl/nextruns/",
+      // Site renamed the upcoming page /nextruns/ → /nextrun/ (#2564: old path 404s).
+      url: "https://ah3.nl/nextrun/",
       type: "HTML_SCRAPER" as const,
       trustLevel: 7,
       scrapeFreq: "daily",
@@ -6590,6 +6594,9 @@ export const SOURCES = [
         kennelTag: "soh4",
         pageHandle: "soh4onon",
         timezone: "America/New_York",
+        // #1939/#2556: FB serves a datacenter-IP checkpoint wall to this Page from
+        // Vercel — fetch via residential proxy first (skips the wasted direct hit).
+        useResidentialProxy: true,
         upcomingOnly: true,
         includePastEvents: true, // #1940: backfill rich title/venue from /past_hosted_events (reconcile-safe under upcomingOnly)
       },
@@ -6622,6 +6629,9 @@ export const SOURCES = [
         kennelTag: "dh4",
         pageHandle: "DaytonHash",
         timezone: "America/New_York",
+        // #1939/#2559: FB serves a datacenter-IP checkpoint wall to this Page from
+        // Vercel — fetch via residential proxy first (skips the wasted direct hit).
+        useResidentialProxy: true,
         upcomingOnly: true,
         includePastEvents: true, // #1940: backfill rich title/venue from /past_hosted_events (reconcile-safe under upcomingOnly)
       },

--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -393,6 +393,20 @@ describe("AH3Adapter", () => {
     expect(run1475).toHaveLength(1);
   });
 
+  it.each([
+    { url: "https://ah3.nl/nextrun/", label: "current /nextrun/" },
+    { url: "https://ah3.nl/nextruns/", label: "legacy /nextruns/" },
+  ])("derives previousUrl → /previous/ from $label when config.previousUrl is unset", async ({ url }) => {
+    // Fallback path (no config.previousUrl). The derivation regex must be
+    // anchored + plural-aware so the legacy `/nextruns/` doesn't yield
+    // `/previous/s/` (#2573 review).
+    mockFetchResponses("<html><body></body></html>", "<html><body></body></html>");
+    await adapter.fetch(makeSource({ url, config: {} }));
+    const requestedUrls = mockedSafeFetch.mock.calls.map((c) => c[0]);
+    expect(requestedUrls[0]).toBe(url); // upcoming fetched first
+    expect(requestedUrls[1]).toBe("https://ah3.nl/previous/"); // derived previous
+  });
+
   it("handles fetch failure on upcoming page", async () => {
     mockedSafeFetch.mockResolvedValueOnce({
       ok: false,

--- a/src/adapters/html-scraper/ah3.test.ts
+++ b/src/adapters/html-scraper/ah3.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/pipeline/structure-hash", () => ({
 const { safeFetch } = await import("@/adapters/safe-fetch");
 const mockedSafeFetch = vi.mocked(safeFetch);
 
-const SOURCE_URL = "https://ah3.nl/nextruns/";
+const SOURCE_URL = "https://ah3.nl/nextrun/";
 const PREVIOUS_URL = "https://ah3.nl/previous/";
 
 function makeSource(overrides?: Partial<Source>): Source {
@@ -60,7 +60,7 @@ function mockFetchResponses(upcomingHtml: string, previousHtml: string) {
   });
 }
 
-// Real HTML fixture — mirrors the structure of ah3.nl/nextruns/
+// Real HTML fixture — mirrors the structure of ah3.nl/nextrun/
 const FIXTURE_HTML = `<html><body><div class="entry-content">
 <style>mark { background-color: lightgrey; color: black; }</style>
 <hr class="wp-block-separator"/>

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -431,7 +431,10 @@ export class AH3Adapter implements SourceAdapter {
     const config = (source.config ?? {}) as Record<string, unknown>;
     const previousUrl =
       (config.previousUrl as string) ??
-      upcomingUrl.replace(/nextrun\/?/, "previous/");
+      // Anchored + plural-aware so a legacy `/nextruns/` URL also derives
+      // `/previous/` (an unanchored `/nextrun\/?/` would leave the stray `s`
+      // → `/previous/s/`). Only the trailing segment is rewritten.
+      upcomingUrl.replace(/nextruns?\/?$/, "previous/");
 
     const allEvents: RawEventData[] = [];
     const allErrors: string[] = [];

--- a/src/adapters/html-scraper/ah3.ts
+++ b/src/adapters/html-scraper/ah3.ts
@@ -2,7 +2,7 @@
  * Amsterdam Hash House Harriers (AH3) Website Adapter
  *
  * Scrapes ah3.nl for hash events from two pages:
- *   1. /nextruns/  — upcoming events
+ *   1. /nextrun/   — upcoming events
  *   2. /previous/  — historical/past events
  *
  * DOM-based parsing: each event sits between consecutive `<hr>` elements
@@ -426,12 +426,12 @@ export class AH3Adapter implements SourceAdapter {
     source: Source,
     options?: { days?: number },
   ): Promise<ScrapeResult> {
-    const upcomingUrl = source.url || "https://ah3.nl/nextruns/";
+    const upcomingUrl = source.url || "https://ah3.nl/nextrun/";
     const days = options?.days ?? source.scrapeDays ?? 365;
     const config = (source.config ?? {}) as Record<string, unknown>;
     const previousUrl =
       (config.previousUrl as string) ??
-      upcomingUrl.replace(/nextruns\/?/, "previous/");
+      upcomingUrl.replace(/nextrun\/?/, "previous/");
 
     const allEvents: RawEventData[] = [];
     const allErrors: string[] = [];

--- a/src/adapters/static-schedule/adapter.ts
+++ b/src/adapters/static-schedule/adapter.ts
@@ -416,6 +416,9 @@ export class StaticScheduleAdapter implements SourceAdapter {
           windowStart: window.start.toISOString(),
           windowEnd: window.end.toISOString(),
           note: "off-season: window does not overlap any BYMONTH month",
+          // Health-check signal: this empty scrape is expected (seasonal dormancy),
+          // so the zero-event anomaly alert is suppressed (#2557).
+          expectedZero: true,
         },
       };
     }

--- a/src/pipeline/health.test.ts
+++ b/src/pipeline/health.test.ts
@@ -74,6 +74,46 @@ describe("analyzeHealth", () => {
     expect(result.alerts.some(a => a.type === "EVENT_COUNT_ANOMALY")).toBe(true);
   });
 
+  it("suppresses zero-event anomaly when adapter declares expectedZero (#2557)", async () => {
+    // Seasonal STATIC_SCHEDULE off-season window: 0 events is expected, not a break.
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      eventsFound: 0,
+      expectedZero: true,
+    }));
+    expect(result.alerts.find(a => a.type === "EVENT_COUNT_ANOMALY")).toBeUndefined();
+    // Still marked checked so any stale prior alert auto-resolves.
+    expect(result.checkedTypes).toContain("EVENT_COUNT_ANOMALY");
+  });
+
+  it("suppresses zero-event anomaly for very-low-baseline sources (#2560/#2563)", async () => {
+    // A future-only feed (e.g. Harrier Central) averaging ~1 event legitimately
+    // has empty forward windows between runs — dormancy, not a scraper break.
+    mockScrapeLogFind.mockReset();
+    mockScrapeLogFind
+      .mockResolvedValueOnce(
+        baselineEntries.map(e => ({ ...e, eventsFound: 1 })) as never,
+      )
+      .mockResolvedValueOnce([] as never);
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      eventsFound: 0,
+    }));
+    expect(result.alerts.find(a => a.type === "EVENT_COUNT_ANOMALY")).toBeUndefined();
+  });
+
+  it("still fires zero-event anomaly for healthy-baseline sources", async () => {
+    // Guard against over-suppression: an 8-event source dropping to 0 is a real break.
+    mockScrapeLogFind.mockReset();
+    mockScrapeLogFind
+      .mockResolvedValueOnce(
+        baselineEntries.map(e => ({ ...e, eventsFound: 8 })) as never,
+      )
+      .mockResolvedValueOnce([] as never);
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      eventsFound: 0,
+    }));
+    expect(result.alerts.some(a => a.type === "EVENT_COUNT_ANOMALY")).toBe(true);
+  });
+
   it("generates UNMATCHED_TAGS for novel tags", async () => {
     const result = await analyzeHealth("src_1", "log_1", baseInput({
       unmatchedTags: ["NewKennel"],

--- a/src/pipeline/health.test.ts
+++ b/src/pipeline/health.test.ts
@@ -85,9 +85,25 @@ describe("analyzeHealth", () => {
     expect(result.checkedTypes).toContain("EVENT_COUNT_ANOMALY");
   });
 
+  it("also suppresses FIELD_FILL_DROP on a benign expected-empty scrape (#2557)", async () => {
+    // Off-season scrape: 0 events → computeFillRates([]) is all-zero. That must
+    // NOT fire FIELD_FILL_DROP against the in-season baseline (title 100% etc.) —
+    // the whole benign-empty scrape is skipped, not just the count anomaly.
+    const result = await analyzeHealth("src_1", "log_1", baseInput({
+      eventsFound: 0,
+      expectedZero: true,
+      fillRates: { title: 0, location: 0, hares: 0, startTime: 0, runNumber: 0 },
+    }));
+    expect(result.alerts.find(a => a.type === "EVENT_COUNT_ANOMALY")).toBeUndefined();
+    expect(result.alerts.find(a => a.type === "FIELD_FILL_DROP")).toBeUndefined();
+    // Still marked checked so any stale prior alert auto-resolves.
+    expect(result.checkedTypes).toContain("FIELD_FILL_DROP");
+  });
+
   it("suppresses zero-event anomaly for very-low-baseline sources (#2560/#2563)", async () => {
     // A future-only feed (e.g. Harrier Central) averaging ~1 event legitimately
     // has empty forward windows between runs — dormancy, not a scraper break.
+    // Its all-zero fill rates must not fire FIELD_FILL_DROP either.
     mockScrapeLogFind.mockReset();
     mockScrapeLogFind
       .mockResolvedValueOnce(
@@ -96,8 +112,10 @@ describe("analyzeHealth", () => {
       .mockResolvedValueOnce([] as never);
     const result = await analyzeHealth("src_1", "log_1", baseInput({
       eventsFound: 0,
+      fillRates: { title: 0, location: 0, hares: 0, startTime: 0, runNumber: 0 },
     }));
     expect(result.alerts.find(a => a.type === "EVENT_COUNT_ANOMALY")).toBeUndefined();
+    expect(result.alerts.find(a => a.type === "FIELD_FILL_DROP")).toBeUndefined();
   });
 
   it("still fires zero-event anomaly for healthy-baseline sources", async () => {

--- a/src/pipeline/health.ts
+++ b/src/pipeline/health.ts
@@ -48,6 +48,8 @@ interface AnalyzeInput {
   currentConfigHash?: string;
   /** Optional manual baseline boundary (`Source.baselineResetAt`). Health checks ignore scrape rows older than this when computing rolling averages. Use after a code-led adapter improvement that doesn't change `Source.config`. */
   baselineResetAt?: Date;
+  /** Adapter-declared "an empty scrape is expected this run" signal (e.g. a seasonal STATIC_SCHEDULE whose forward window doesn't overlap any active month). Suppresses the zero-event anomaly alert so off-season dormancy doesn't file recurring false-positives (#2557). */
+  expectedZero?: boolean;
 }
 
 /** Type alias for the shape of recent scrape log rows used across checks. */
@@ -102,6 +104,18 @@ function checkEventCountAnomaly(
   const avgEvents =
     recentSuccessful.reduce((sum, l) => sum + l.eventsFound, 0) /
     recentSuccessful.length;
+
+  // Adapter declared this empty scrape expected (e.g. seasonal off-season window).
+  // Not a break — skip the anomaly entirely (#2557).
+  if (input.expectedZero) return null;
+
+  // Very-low-baseline sources (future-only feeds like Harrier Central for a lunar
+  // or low-volume kennel) legitimately have empty forward windows between runs.
+  // A drop from a rolling average of ~1 to 0 is dormancy, not a scraper break —
+  // suppress the CRITICAL zero-event alert rather than filing a recurring
+  // false-positive (#2560, #2563). The >50%-drop WARNING branch below (gated on
+  // avgEvents > 5) is unaffected.
+  if (input.eventsFound === 0 && Math.round(avgEvents) <= 1) return null;
 
   const aiNote = input.aiRecovery
     ? ` AI recovery: ${input.aiRecovery.succeeded}/${input.aiRecovery.attempted} parse errors recovered.${input.aiRecovery.failed > 0 ? ` ${input.aiRecovery.failed} could not be recovered — may need code changes.` : ""}`

--- a/src/pipeline/health.ts
+++ b/src/pipeline/health.ts
@@ -96,6 +96,26 @@ function checkConsecutiveFailures(
   };
 }
 
+/**
+ * A zero-event scrape that is *expected*, not a break — so the event-dependent
+ * trend checks (event-count anomaly, field-fill drop, structure change) must all
+ * be skipped. Two causes:
+ *   - the adapter declared it (`expectedZero`, e.g. a seasonal STATIC_SCHEDULE
+ *     whose forward window doesn't overlap any active month) — #2557; or
+ *   - the source is a very-low-baseline future-only feed (Harrier Central for a
+ *     lunar/low-volume kennel) that legitimately has empty windows between runs,
+ *     i.e. its rolling average rounds to ≤1 — #2560/#2563.
+ * Suppressing only the count anomaly (and not field-fill) would still leave the
+ * source degraded/noisy: `computeFillRates([])` is all-zero, so `checkFieldFillDrops`
+ * would compare 0% against the in-season baseline and fire WARNINGs every scrape.
+ * The >50%-drop count WARNING (gated `avgEvents > 5`) never applies here since the
+ * baseline is ≤1 or the scrape is adapter-declared empty.
+ */
+function isBenignEmptyScrape(input: AnalyzeInput, avgEvents: number): boolean {
+  if (input.eventsFound !== 0) return false;
+  return input.expectedZero === true || Math.round(avgEvents) <= 1;
+}
+
 /** Alert if event count dropped >50% vs rolling average, or hit zero. */
 function checkEventCountAnomaly(
   input: AnalyzeInput,
@@ -104,18 +124,6 @@ function checkEventCountAnomaly(
   const avgEvents =
     recentSuccessful.reduce((sum, l) => sum + l.eventsFound, 0) /
     recentSuccessful.length;
-
-  // Adapter declared this empty scrape expected (e.g. seasonal off-season window).
-  // Not a break — skip the anomaly entirely (#2557).
-  if (input.expectedZero) return null;
-
-  // Very-low-baseline sources (future-only feeds like Harrier Central for a lunar
-  // or low-volume kennel) legitimately have empty forward windows between runs.
-  // A drop from a rolling average of ~1 to 0 is dormancy, not a scraper break —
-  // suppress the CRITICAL zero-event alert rather than filing a recurring
-  // false-positive (#2560, #2563). The >50%-drop WARNING branch below (gated on
-  // avgEvents > 5) is unaffected.
-  if (input.eventsFound === 0 && Math.round(avgEvents) <= 1) return null;
 
   const aiNote = input.aiRecovery
     ? ` AI recovery: ${input.aiRecovery.succeeded}/${input.aiRecovery.attempted} parse errors recovered.${input.aiRecovery.failed > 0 ? ` ${input.aiRecovery.failed} could not be recovered — may need code changes.` : ""}`
@@ -470,13 +478,23 @@ export async function analyzeHealth(
     checkedTypes.add("UNMATCHED_TAGS");
 
     if (recentSuccessful.length > 0) {
-      const countAlert = checkEventCountAnomaly(input, recentSuccessful);
-      if (countAlert) alerts.push(countAlert);
+      const avgEvents =
+        recentSuccessful.reduce((sum, l) => sum + l.eventsFound, 0) /
+        recentSuccessful.length;
+      // On a benign expected-empty scrape (seasonal off-season / low-baseline
+      // dormancy) the event-dependent trend checks compare an all-zero current
+      // state against an in-season baseline and fire false positives. Skip them
+      // as a group (#2557/#2560/#2563) — still registered in checkedTypes above,
+      // so any stale prior alert still auto-resolves.
+      if (!isBenignEmptyScrape(input, avgEvents)) {
+        const countAlert = checkEventCountAnomaly(input, recentSuccessful);
+        if (countAlert) alerts.push(countAlert);
 
-      alerts.push(...checkFieldFillDrops(input, recentSuccessful));
+        alerts.push(...checkFieldFillDrops(input, recentSuccessful));
 
-      const structureAlert = await checkStructuralChange(sourceId, input, recentSuccessful);
-      if (structureAlert) alerts.push(structureAlert);
+        const structureAlert = await checkStructuralChange(sourceId, input, recentSuccessful);
+        if (structureAlert) alerts.push(structureAlert);
+      }
 
       const unmatchedAlert = checkUnmatchedTags(input, recentSuccessful);
       if (unmatchedAlert) alerts.push(unmatchedAlert);

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -598,6 +598,9 @@ export async function scrapeSource(
       cancelledCount,
       reconcileEvaluated,
       reconcileSuppressedKennels,
+      // Adapter-declared expected-empty scrape (e.g. seasonal STATIC_SCHEDULE
+      // off-season window) — suppresses the zero-event anomaly alert (#2557).
+      expectedZero: scrapeResult.diagnosticContext?.expectedZero === true,
       ...regimeContext,
     });
 


### PR DESCRIPTION
Batch of low-risk config + health fixes from the 2026-07-05/06 source-health alert triage. Three separate concerns, all config/health-layer (no adapter-parser rewrites).

## Amsterdam H3 — URL moved (Closes #2564)
Site renamed the upcoming page `/nextruns/` → `/nextrun/` (old path now 404s). Updates seed URL, adapter fallback default, the `previousUrl`-derivation regex, and the test fixture constant.

**Live-verified** against `https://ah3.nl/nextrun/`: 53 events parsed, 0 errors, valid future dates (2026-07-19 …), run numbers, HH:MM times, hares, locations.

## Seasonal off-season false-positive (Closes #2557)
`Budapest H3 Static Schedule (Winter Sundays)` correctly generates 0 events in July (summer) — its Summer companion is active — but fired a CRITICAL zero-event alert every scrape. The STATIC_SCHEDULE adapter already detects off-season; it now emits `expectedZero: true` in `diagnosticContext`, `scrape.ts` threads it into the health input, and `checkEventCountAnomaly` skips the alert when set.

## Low-baseline dormancy false-positive (Closes #2560, Closes #2563)
`Moonshine H3 Dubai` and `Bandung H3` (Harrier Central, future-only feeds, baseline avg 1) legitimately have empty forward windows between runs. Suppress the CRITICAL zero-event alert when the rolling average rounds to ≤1. The >50%-drop WARNING branch (gated `avgEvents > 5`) is unaffected.

## FB soft-block cluster (proxy mitigation; monitoring #2561/#2556/#2559)
Grand Strand, SOH4, and Dayton H4 FB Hosted Events hit the FB datacenter-IP checkpoint (HTTP 200 + valid SSR envelope + 0 event nodes). Added `useResidentialProxy: true` to match Von Tramp/Survivor. This is the cheap mitigation — a proper block-*detection* fix (the soft-block slips past `looksLikeFbBlock`) needs a Vercel/proxy-side HTML capture and is tracked separately; those issues stay **open** to monitor.

## Tests
4 new `health.test.ts` cases: `expectedZero` suppresses; avg≈1 suppresses; avg=8 still fires (over-suppression guard). `tsc --noEmit` + lint clean; health / scrape / static-schedule / ah3 suites green.

## Post-merge
Targeted prod writes (not full seed): Amsterdam `Source.url`; 3 FB `Source.config`. Then re-scrape Amsterdam and confirm SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)