### PR TITLE
fix(victoria-h3): follow Gamma leaf-class change so runs parse again (#2555)

### DIFF
--- a/src/adapters/html-scraper/victoria-h3.test.ts
+++ b/src/adapters/html-scraper/victoria-h3.test.ts
@@ -3,12 +3,13 @@ import { parseVictoriaH3Page } from "./victoria-h3";
 
 const SOURCE_URL = "https://vh3.ca/";
 
-// Faithful to the live Gamma markup: every text block is wrapped in a
-// `data-node-view-content-inner="paragraph"` node-view div, and venue links are
-// `maps.app.goo.gl` anchors whose text is the venue (verified against the real
-// 2026-06-04 capture of vh3.ca).
+// Faithful to the live Gamma markup: every text block is a leaf
+// `<p class="gml-paragraph__content">` inside a `gml-paragraph block-paragraph`
+// wrapper (verified against the 2026-07-05 capture of vh3.ca — Gamma dropped the
+// older `data-node-view-content-inner="paragraph"` attribute, #2555). Venue links
+// are `maps.app.goo.gl` anchors whose text is the venue.
 const p = (inner: string) =>
-  `<div data-node-view-content-inner="paragraph" style="whitespace:inherit">${inner}</div>`;
+  `<div contentEditable="false" class="gml-paragraph block-paragraph"><p class="gml-paragraph__content" dir="auto">${inner}</p></div>`;
 const mapLink = (venue: string, url: string) =>
   `<a class="chakra-text link css-0" rel="noopener nofollow" href="${url}"><span>${venue}</span></a>`;
 

--- a/src/adapters/html-scraper/victoria-h3.ts
+++ b/src/adapters/html-scraper/victoria-h3.ts
@@ -27,9 +27,9 @@ import {
  *
  * Gamma wraps every block in deeply nested divs, so a whole-document `.text()`
  * stack-overflows (domutils recursion). Instead we select the leaf text-block
- * node-view wrappers and read each one's (shallow) text, keying entirely on
- * visible content — the same content-keyed strategy the Wix/Google-Sites
- * scrapers use.
+ * elements (`p.gml-paragraph__content`) and read each one's (shallow) text,
+ * keying entirely on visible content — the same content-keyed strategy the
+ * Wix/Google-Sites scrapers use.
  *
  * Maps venues are `maps.app.goo.gl` shortlinks (no extractable lat/lng), so
  * coords are left undefined and the merge pipeline falls back to the Victoria, BC
@@ -81,10 +81,17 @@ function fragmentUrl(anchor: string, baseUrl: string): string {
   return `${baseUrl.split("#")[0]}#${anchor}`;
 }
 
-// Gamma renders each text block inside a node-view content wrapper. Selecting
-// these leaves and reading their text avoids a full-document `.text()`.
-const TEXT_BLOCK_SELECTOR =
-  '[data-node-view-content-inner="paragraph"],[data-node-view-content-inner="heading"],[data-node-view-content-inner="title"]';
+// Gamma renders each text block as a leaf `<p class="gml-paragraph__content">`
+// (headings included — they're paragraphs with a bold run, not <h*>). Selecting
+// these leaves and reading each one's shallow text avoids a full-document
+// `.text()`. NOTE (#2555): Gamma dropped the older
+// `data-node-view-content-inner="paragraph"|"title"` attributes — the run lines
+// now live only in `gml-paragraph__content`, so the previous attribute selector
+// matched nothing and every kennel parsed 0 runs. We key on the leaf content
+// class; `.gml-heading__content` is kept as a forward-compatible fallback in
+// case Gamma reintroduces a distinct heading leaf. Both are leaves, so there is
+// no ancestor/child double-count (and the parse passes dedupe by run key anyway).
+const TEXT_BLOCK_SELECTOR = "p.gml-paragraph__content,.gml-heading__content";
 
 // A schedule-list run line carries its date inline, and the remainder after the
 // run number starts (after an optional colon) with a weekday: "VH3 #918:


### PR DESCRIPTION
## Problem (Closes #2555)
`vh3.ca` (a Gamma-platform SSR page hosting VH3, DSMH3, and VK9H3) was live with a full season of runs, but the adapter parsed **0 runs for all three kennels** → fail-loud error → 4 consecutive scrape failures.

Root cause: Gamma changed its markup. The linearizer keyed on `data-node-view-content-inner="paragraph"|"title"`, which **no longer exist**; `="heading"` now matches only noisy ancestor containers. Every run line (schedule lists + "Up Cumming" cards) now renders as a leaf `<p class="gml-paragraph__content">`, so the old selector matched nothing.

## Fix
Key the linearizer on the leaf content class: `p.gml-paragraph__content,.gml-heading__content`. Both are leaves (no ancestor/child double-count), and the parse passes already dedupe by run key. `.gml-heading__content` is a forward-compat fallback (0 present today) in case Gamma reintroduces a distinct heading leaf.

## Live verification
Ran `parseVictoriaH3Page` against the current `vh3.ca` capture: **48 events, 0 errors, all three kennels** (vh3:27, dsmh3:12, vk9h3:9). Spot-checked: VH3 #932 Sat Jul 18 14:30, DSMH3 #389 Jul 17 19:00, VK9H3 #75 Aug 3 — dates/times/run numbers all correct.

## Tests
Fixture `p()` helper updated to the current leaf markup (2026-07-05 capture). Full suite (27) green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)