### PR TITLE
fix(google-calendar): GCal correctness bundle + improbable-time triage

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3290,7 +3290,7 @@ export const SOURCES = [
         // events; skip the all-day "Travel Hash: <city>" trip announcements that
         // would otherwise flood the mh3-mn default.
         includeAllDayEvents: true,
-        skipPatterns: [String.raw`^Travel [Hh]ash`],
+        skipPatterns: ["^Travel [Hh]ash"],
         // #1884: title embeds the hare ("MH3 #1984 - B Knuckles") AND the
         // description carries the canonical "Hare : Butt Knuckles" line. The
         // description hare wins; alwaysStripTitleHareSpan still strips the
@@ -6530,7 +6530,7 @@ export const SOURCES = [
           // Whoreman umbrella events (campouts, RDRs, specials). Unanchored so
           // mid-title mentions ("… a Whoreman Campout", "CC Celebration Of Life
           // WH3 #1096") route explicitly rather than falling to the default.
-          ["\\bWH3\\b", "wasatch-h3"],
+          [String.raw`\bWH3\b`, "wasatch-h3"],
           ["[Ww]horeman", "wasatch-h3"],
         ],
         // #2461: Whoreman is the SLC umbrella hosted by Wasatch H3. Community

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -1757,6 +1757,12 @@ export const SOURCES = [
       scrapeDays: 365,
       config: {
         defaultKennelTag: "swh3",
+        // #2394: ~200 SWH3 runs (Bike Hash, Geezer trails, Hare Raising Party,
+        // XXXMas Market, etc.) are published as all-day (VALUE=DATE) events,
+        // which the default filter dropped. Admit them so upcoming specials
+        // ingest. (~440 older-than-365d historical events are recovered by a
+        // one-shot wide re-scrape, not a permanent scrapeDays bump.)
+        includeAllDayEvents: true,
         // #1881: hare follows the LAST dash, with or without a run number:
         // "SWH3 #1794 -Pukey", "SWH3- I Do Greek and Frau Farter",
         // "SWH3- Bad Beer Hash- PITA" (→ PITA). Single-kennel source, so the
@@ -2894,6 +2900,11 @@ export const SOURCES = [
       config: {
         calendarId: "898ddb527b83d7944c788bfbdb4074be5ee3c5ddf380acbdb206abd2861d6dc2@group.calendar.google.com",
         defaultKennelTag: "swh3-or",
+        // #2344: run #140 "Pick Up Hash" is published as an all-day event and
+        // was dropped by the default filter. Admit all-day events. (Run #130
+        // sits >365d back and is recovered by a bounded one-shot re-scrape that
+        // stops short of the bogus 2018-04-07 placeholder rows.)
+        includeAllDayEvents: true,
       },
       kennelCodes: ["swh3-or"],
     },
@@ -3274,6 +3285,12 @@ export const SOURCES = [
           ["\\bMH3\\b", "mh3-mn"]
         ],
         defaultKennelTag: "mh3-mn",
+        // #2384: T3H3 off-cadence specials (Pink Dress weekends, Hot Mess) are
+        // published as multi-day all-day events and were dropped. Admit all-day
+        // events; skip the all-day "Travel Hash: <city>" trip announcements that
+        // would otherwise flood the mh3-mn default.
+        includeAllDayEvents: true,
+        skipPatterns: [String.raw`^Travel [Hh]ash`],
         // #1884: title embeds the hare ("MH3 #1984 - B Knuckles") AND the
         // description carries the canonical "Hare : Butt Knuckles" line. The
         // description hare wins; alwaysStripTitleHareSpan still strips the
@@ -3478,10 +3495,15 @@ export const SOURCES = [
           // typo ("…ChristmasPau Hana Hui") that a leading boundary would drop.
           [String.raw`\bPHH\b|Pau Hana Hui\b`, "phh-hi"],
           ["\\bH5\\b|Honolulu H[45]", "h5-hi"],
-          // #644: Fool Moon H3 full-moon trails ("Fool Moon H3 #409") have their own
-          // run numbering and kennel page; route them off the ah3-hi default. Distinct
-          // from PHH / H5, so order vs. those doesn't matter.
-          ["Fool Moon", "fool-moon-h3"],
+          // #644 / #2281: Fool Moon H3 (aka Hawaii Full Moon H3 / HFMH3) full-moon
+          // trails have their own run numbering + kennel page. Titles are wildly
+          // inconsistent across years — "Fool Moon H3 #409", "Hawaii Full Moon H3
+          // Run #380", "Hawai'i Full Moon H3", "HFMH3 Run #300", "Full Moon Hash",
+          // "Full Moon #410" — so match the kennel signatures, NOT bare "Full
+          // Moon" (which AH3 socials use as a theme word). Ordered AFTER PHH/H5 so
+          // their co-hosted full-moon events ("PHH - Full Moon H3", "Pau Hana Hui
+          // Frisky Full Moon") keep first-match priority.
+          [String.raw`Fool Moon|HFMH3|Hawai.i Full Moon|Full Moon H[34]|Full Moon Hash|Full Moon Run|Full Moon #\s*\d`, "fool-moon-h3"],
         ],
         defaultKennelTag: "ah3-hi",
         // Upcoming AH3 events encode hares in the title as the last
@@ -4642,6 +4664,13 @@ export const SOURCES = [
       config: {
         calendarId: "voodoohash@gmail.com",
         defaultKennelTag: "voodoo-h3",
+        // #2442: titles arrive as "Voodoo Trail #NNNN hared by <hares>" (stripped
+        // by the global TITLE_HARED_BY_RE) OR the bare "Voodoo Trail #1044 by
+        // <hares>" variant the global strip misses. Hares already come from the
+        // description body, so strip the trailing " by <hares>" span off the
+        // title. Runs after the global "hared by" strip; scoped to Voodoo, whose
+        // titles reliably end in the hare attribution.
+        titleStripPatterns: [String.raw`\s+by\s+.+$`],
       },
       kennelCodes: ["voodoo-h3"],
     },
@@ -6494,13 +6523,18 @@ export const SOURCES = [
           ["^SLOSH", "slosh-h3"],
           // Match both "SL, UT" and escaped "SL\\, UT" from Google Calendar
           ["^SL[,\\\\]+\\s*UT", "slut-h3"],
-          // Whoreman umbrella events (campouts, RDRs, specials)
-          ["^WH3", "wasatch-h3"],
-          ["^[Ww]horeman", "wasatch-h3"],
+          // Whoreman umbrella events (campouts, RDRs, specials). Unanchored so
+          // mid-title mentions ("… a Whoreman Campout", "CC Celebration Of Life
+          // WH3 #1096") route explicitly rather than falling to the default.
+          ["\\bWH3\\b", "wasatch-h3"],
+          ["[Ww]horeman", "wasatch-h3"],
         ],
-        // null default — unmatched events are skipped rather than
-        // silently misrouted to wasatch-h3
-        defaultKennelTag: null,
+        // #2461: Whoreman is the SLC umbrella hosted by Wasatch H3. Community
+        // specials on this calendar (campouts, dress runs, Missionary Position
+        // Bashes, "easter trail", "World Peace Through Beer") match no kennel
+        // prefix; with a null default each leaked as its own UNMATCHED_TAG.
+        // Route unmatched events to the host kennel instead.
+        defaultKennelTag: "wasatch-h3",
         // #796: Wasatch titles arrive as bare "wasatch #1144" — substitute a
         // readable trail name when the adapter matches the kennel-code-only
         // pattern. Per-kennel keys so lds/slosh/slut keep pattern routing.

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -3503,7 +3503,7 @@ export const SOURCES = [
           // Moon" (which AH3 socials use as a theme word). Ordered AFTER PHH/H5 so
           // their co-hosted full-moon events ("PHH - Full Moon H3", "Pau Hana Hui
           // Frisky Full Moon") keep first-match priority.
-          [String.raw`Fool Moon|HFMH3|Hawai.i Full Moon|Full Moon H[34]|Full Moon Hash|Full Moon Run|Full Moon #\s*\d`, "fool-moon-h3"],
+          [String.raw`Fool Moon|HFMH3|Hawai.i Full Moon|Full Moon (?:H[34]|Hash|Run|#\s*\d)`, "fool-moon-h3"],
         ],
         defaultKennelTag: "ah3-hi",
         // Upcoming AH3 events encode hares in the title as the last
@@ -4669,7 +4669,11 @@ export const SOURCES = [
         // <hares>" variant the global strip misses. Hares already come from the
         // description body, so strip the trailing " by <hares>" span off the
         // title. Runs after the global "hared by" strip; scoped to Voodoo, whose
-        // titles reliably end in the hare attribution.
+        // titles reliably end in the hare attribution. Deliberately strips
+        // everything after " by " (no "by (?!the|a)" lookahead): Voodoo hare
+        // names can start with an article — e.g. "The Iceman" — so excluding
+        // "the/a/an" would leak those. Live-verified: 0 over-strips across 36
+        // events.
         titleStripPatterns: [String.raw`\s+by\s+.+$`],
       },
       kennelCodes: ["voodoo-h3"],

--- a/scripts/suppress-improbable-time-gcal-hc-bundle.ts
+++ b/scripts/suppress-improbable-time-gcal-hc-bundle.ts
@@ -69,7 +69,9 @@ async function main(): Promise<void> {
   for (const { kennelCode, reason } of TARGETS) {
     const row = await prisma.auditSuppression.upsert({
       where: { kennelCode_rule: { kennelCode, rule: RULE } },
-      update: { reason, createdBy: CREATED_BY },
+      // Refresh only `reason` on rerun; keep `createdBy` on the create path so a
+      // pre-existing suppression retains its original creator provenance.
+      update: { reason },
       create: { kennelCode, rule: RULE, reason, createdBy: CREATED_BY },
       select: { id: true, kennelCode: true, rule: true, createdAt: true },
     });

--- a/scripts/suppress-improbable-time-gcal-hc-bundle.ts
+++ b/scripts/suppress-improbable-time-gcal-hc-bundle.ts
@@ -1,0 +1,86 @@
+/**
+ * One-shot: suppress the `event-improbable-time` audit finding for four kennels
+ * whose flagged late-night / early-morning start times are GENUINE source data,
+ * not an adapter bug. Resolves audit issues #2542 (Salem), #2295 + escalation
+ * #2455 (Flour City), #2537 (Toulouse), #2531 (Aberdeen).
+ *
+ * Why (each confirmed by live verification, 2026-07-07):
+ *  - GCal sources raw-slice the API `dateTime` string only when no `timezone`
+ *    config is set; a Z-slice bug would push every evening event into the
+ *    22:00–01:00 band. Live histograms disprove that:
+ *      • Salem (salemh3):     timed events cluster 11:00–15:00 (+ all-day); 0 improbable.
+ *      • Flour City (flour-city): 42 events at 18:00, 17 at 13:00; 0 improbable.
+ *    The originally-flagged events were one-off odd entries (e.g. Flour City's
+ *    "3:33" gag trail) that have since aged out — the adapter stores correct
+ *    local times, so there is nothing to fix in code.
+ *  - Harrier Central verbatim-slices HC's naive LOCAL time (Tokyo, UTC+9, is
+ *    correct with the same slice). Aberdeen's live feed is a MIX of 19:00 (9)
+ *    and 23:00 (5) — a uniform TZ bug cannot produce both, so the 23:00 runs
+ *    are genuine values in HC's data. Same for Toulouse's 02:30. Un-fixable
+ *    from our side (upstream data-entry), so the finding can never self-resolve.
+ *
+ * Precedent: AuditSuppression(kwh3, event-improbable-time) #461,
+ * AuditSuppression(soco-h3, …) #2060.
+ *
+ * Idempotent: upserts on (kennelCode, rule). Adding a row is NOT a schema
+ * migration but MUST run against prod to take effect (Vercel never runs
+ * scripts/). Consumed by loadSuppressions()/isSuppressed() in
+ * src/pipeline/audit-runner.ts.
+ *
+ * Usage (worktree has no .env — supply DATABASE_URL from the main repo):
+ *   DATABASE_URL=... npx tsx scripts/suppress-improbable-time-gcal-hc-bundle.ts
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import { createScriptPool } from "./lib/db-pool";
+
+const RULE = "event-improbable-time";
+const CREATED_BY = "script:suppress-improbable-time-gcal-hc-bundle (#2542/#2295/#2455/#2537/#2531)";
+
+const TARGETS: Array<{ kennelCode: string; reason: string }> = [
+  {
+    kennelCode: "salemh3",
+    reason:
+      "GCal source. Live verification (2026-07-07) shows timed events cluster 11:00–15:00 with 0 improbable-hour events; a Z-slice bug would push evening events to 22:00–01:00. The flagged 23:00 event was a one-off entry that has aged out. Adapter stores correct local time. #2542.",
+  },
+  {
+    kennelCode: "flour-city",
+    reason:
+      "GCal source. Live verification (2026-07-07): 42 events at 18:00, 17 at 13:00, 0 improbable-hour events. The flagged 03:33 'El Farge2' entry is a genuine one-off gag time, not a Z-slice bug. Adapter stores correct Eastern local time. #2295 / escalation #2455.",
+  },
+  {
+    kennelCode: "aberdeen-h3",
+    reason:
+      "Harrier Central source. Live verification (2026-07-07): feed is a mix of 19:00 (9 events) and 23:00 (5 events) — a uniform timezone bug cannot produce both, so the 23:00 runs are genuine values in HC's data (upstream data entry). Adapter verbatim-slices HC's naive local time (correct, proven by Tokyo). #2531.",
+  },
+  {
+    kennelCode: "toulouse-h3",
+    reason:
+      "Harrier Central source. The flagged 02:30 start is a genuine value in HC's data; the adapter verbatim-slices HC's naive local time (correct, proven by Tokyo, UTC+9). Un-fixable from our side (upstream data entry). #2537.",
+  },
+];
+
+async function main(): Promise<void> {
+  const pool = createScriptPool();
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  for (const { kennelCode, reason } of TARGETS) {
+    const row = await prisma.auditSuppression.upsert({
+      where: { kennelCode_rule: { kennelCode, rule: RULE } },
+      update: { reason, createdBy: CREATED_BY },
+      create: { kennelCode, rule: RULE, reason, createdBy: CREATED_BY },
+      select: { id: true, kennelCode: true, rule: true, createdAt: true },
+    });
+    console.log(`✅ suppressed ${row.kennelCode} / ${row.rule} (id=${row.id}, ${row.createdAt.toISOString()})`);
+  }
+
+  await prisma.$disconnect();
+  pool.end();
+}
+
+void main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -446,6 +446,165 @@ describe("resolveKennelTagFromSummary with no config", () => {
   });
 });
 
+// ── #2461 Whoreman — unmatched community specials route to the host kennel ──
+
+describe("Whoreman H3 — unmatched community specials route to wasatch-h3 (#2461)", () => {
+  const src = SOURCES.find((s) => s.name === "Whoreman H3 Calendar");
+  if (!src?.config) throw new Error("Whoreman H3 Calendar seed config missing");
+  const config = src.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it.each([
+    "White Trash American Penis - a Whoreman Campout",
+    "easter trail",
+    "World Peace Through Beer",
+    "Missionary Position Bash #67",
+    "CC Celebration Of Life    WH3 #1096",
+    "Two Pumps 7th ANAuaL Leggings Trail",
+  ])("routes unmatched Whoreman-calendar special %j to wasatch-h3", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-08-15T18:00:00-06:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual(["wasatch-h3"]);
+  });
+
+  it.each([
+    ["LDSH3 # 634", "lds-h3"],
+    ["SLOSH Trail #5", "slosh-h3"],
+    ["SL,UT-D #177 - Buck Moon", "slut-h3"],
+    ["wasatch#1152", "wasatch-h3"],
+  ])("still routes the kennel-prefixed title %j to %s", (summary, tag) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-08-15T18:00:00-06:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual([tag]);
+  });
+});
+
+// ── #2281 Aloha — "Full Moon" title variants route to fool-moon-h3 ──
+
+describe("Aloha H3 — Full Moon title variants route to fool-moon-h3 (#2281)", () => {
+  const src = SOURCES.find((s) => s.name === "Aloha H3 Google Calendar");
+  if (!src?.config) throw new Error("Aloha H3 Google Calendar seed config missing");
+  const config = src.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+
+  it.each([
+    "Hawaii Full Moon H3 Run #380 - The Full Hunter Moon Hash",
+    "Hawai‘i Full Moon H3 Run #381 - The Full Beaver Moon Hash",
+    "Hawaii Full Moon Hash #329 - The Christmas Full Moon Hash",
+    "Hawaii Full Moon Run #319 - The March New Moon Hash",
+    "Full Moon Hash ",
+    "Full Moon #410",
+    "HFMH3 Run #300",
+    "Fool Moon H3 #409",
+  ])("routes %j to fool-moon-h3", (summary) => {
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { dateTime: "2026-05-31T18:30:00-10:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual(["fool-moon-h3"]);
+  });
+
+  it("keeps PHH-prefixed co-hosted full-moon events on phh-hi (PHH ordered first)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "PHH - Full Moon H3 - First Trail of the Year", start: { dateTime: "2026-01-03T18:30:00-10:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual(["phh-hi"]);
+  });
+
+  it("keeps Pau Hana Hui socials on phh-hi even when they mention full moon", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Pau Hana Hui Frisky Full Moon", start: { dateTime: "2026-02-13T17:00:00-10:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual(["phh-hi"]);
+  });
+
+  it("does not misroute a plain AH3 run to fool-moon-h3", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "AH3 #1833 - Ala Moana - Some Hare", start: { dateTime: "2026-03-01T16:00:00-10:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.kennelTags).toEqual(["ah3-hi"]);
+  });
+});
+
+// ── #2442 Voodoo — bare " by <hares>" suffix stripped from the title ──
+
+describe("Voodoo H3 — bare 'by' hare suffix stripped from title (#2442)", () => {
+  const src = SOURCES.find((s) => s.name === "Voodoo H3 Google Calendar");
+  if (!src?.config) throw new Error("Voodoo H3 Google Calendar seed config missing");
+  const config = src.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+  const cfg = src.config as { titleStripPatterns?: string[] };
+  const compiledTitleStripPatterns = compilePatterns(cfg.titleStripPatterns ?? [], "i");
+
+  it("strips the bare ' by <hares>' variant (#1044)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Voodoo Trail #1044 by YMBJ", start: { dateTime: "2026-07-10T19:00:00-05:00" }, status: "confirmed" },
+      config,
+      { compiledTitleStripPatterns },
+    );
+    expect(result?.title).toBe("Voodoo Trail #1044");
+  });
+
+  it("still strips the 'hared by <hares>' variant (regression, global TITLE_HARED_BY_RE)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Voodoo Trail #1045 hared by Tits Don't Fit", start: { dateTime: "2026-07-17T19:00:00-05:00" }, status: "confirmed" },
+      config,
+      { compiledTitleStripPatterns },
+    );
+    expect(result?.title).toBe("Voodoo Trail #1045");
+  });
+});
+
+// ── #2384/#2394/#2344 — all-day admission for the affected sources ──
+
+describe("Minneapolis H3 — all-day T3H3 specials admitted, travel-hash skipped (#2384)", () => {
+  const src = SOURCES.find((s) => s.name === "Minneapolis H3 Calendar");
+  if (!src?.config) throw new Error("Minneapolis H3 Calendar seed config missing");
+  const config = src.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+  const cfg = src.config as { skipPatterns?: string[] };
+  const compiledSkipPatterns = compilePatterns(cfg.skipPatterns ?? [], "i");
+
+  it("admits the all-day 'T3H3 Pink Dress!' special and routes it to t3h3", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "T3H3 Pink Dress!", start: { date: "2026-10-02" }, status: "confirmed" },
+      config,
+      { compiledSkipPatterns },
+    );
+    expect(result).not.toBeNull();
+    expect(result?.kennelTags).toEqual(["t3h3"]);
+  });
+
+  it("skips all-day 'Travel Hash: <city>' trip announcements", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "Travel Hash: NOLA RDR", start: { date: "2026-08-07" }, status: "confirmed" },
+      config,
+      { compiledSkipPatterns },
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("SWH3 sources — all-day events admitted (#2394 Raleigh, #2344 Portland)", () => {
+  it.each([
+    ["SWH3 Google Calendar", "SWH3 Bike Hash- Scrub Jay", "2026-09-05", "swh3"],
+    ["SWH3 Calendar", "SWH3 #140 - Pick Up Hash", "2025-11-15", "swh3-or"],
+  ])("%s admits an all-day event and routes to %s", (name, summary, date, tag) => {
+    const src = SOURCES.find((s) => s.name === name);
+    if (!src?.config) throw new Error(`${name} seed config missing`);
+    const config = src.config as Parameters<typeof buildRawEventFromGCalItem>[1];
+    const result = buildRawEventFromGCalItem(
+      { summary, start: { date }, status: "confirmed" },
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.kennelTags).toEqual([tag]);
+  });
+});
+
 // ── extractRunNumber ──
 
 describe("extractRunNumber", () => {

--- a/src/adapters/html-scraper/vindobona-h3.test.ts
+++ b/src/adapters/html-scraper/vindobona-h3.test.ts
@@ -112,22 +112,22 @@ describe("parseFutureRow", () => {
     [
       "Hash # routes to vindobona-h3 with a clean run number",
       ["2026-06-08", "Hash #2363", "Miss Piss", ""],
-      { date: "2026-06-08", kennel: "vindobona-h3", runNumber: 2363, hares: "Miss Piss" },
+      { date: "2026-06-08", kennel: "vindobona-h3", runNumber: 2363, hares: "Miss Piss", title: undefined },
     ],
     [
-      "FMH # routes to vienna-fmh3 and rejects the trailing-? run number",
+      "FMH # routes to vienna-fmh3, rejects the trailing-? run number, promotes the comment to title (#2440)",
       ["2026-08-01", "FMH #30?", "Casting Couch", "Full Moon run"],
-      { date: "2026-08-01", kennel: "vienna-fmh3", runNumber: undefined, hares: "Casting Couch" },
+      { date: "2026-08-01", kennel: "vienna-fmh3", runNumber: undefined, hares: "Casting Couch", title: "Full Moon run" },
     ],
     [
-      "Hash #23?? keeps the dated event but drops the unfinalized run number",
+      "Hash #23?? keeps the dated event, drops the run number, promotes the comment to title (#2440)",
       ["2026-12-13", "Hash #23??", "Oh Fardolena & Whoppa", "Finlandia run"],
-      { date: "2026-12-13", kennel: "vindobona-h3", runNumber: undefined, hares: "Oh Fardolena & Whoppa" },
+      { date: "2026-12-13", kennel: "vindobona-h3", runNumber: undefined, hares: "Oh Fardolena & Whoppa", title: "Finlandia run" },
     ],
     [
       "blank hares cell maps to undefined",
       ["2026-07-06", "Hash #2367", "", ""],
-      { date: "2026-07-06", kennel: "vindobona-h3", runNumber: 2367, hares: undefined },
+      { date: "2026-07-06", kennel: "vindobona-h3", runNumber: 2367, hares: undefined, title: undefined },
     ],
   ])("%s", (_label, cells, expected) => {
     const ev = parseFutureRow(cells);
@@ -136,8 +136,34 @@ describe("parseFutureRow", () => {
     expect(ev?.kennelTags).toEqual([expected.kennel]);
     expect(ev?.runNumber).toBe(expected.runNumber);
     expect(ev?.hares).toBe(expected.hares);
-    // Titles are always synthesized downstream — never set by the adapter.
+    // #2440: a numbered run leaves title undefined (merge synthesizes "#N"); an
+    // unfinalized run (no run number) promotes the Comments note to the title.
+    expect(ev?.title).toBe(expected.title);
+  });
+
+  it("#2440: promotes the real futureruns comment to the title for an unfinalized FMH run", () => {
+    const ev = parseFutureRow([
+      "2026-08-01",
+      "FMH #30?",
+      "Casting Couch",
+      "Summer afternoon Full Moon run, Gruess di a Gott Wirt",
+    ]);
+    expect(ev?.title).toBe("Summer afternoon Full Moon run, Gruess di a Gott Wirt");
+    // Description still carries the note too.
+    expect(ev?.description).toBe("Summer afternoon Full Moon run, Gruess di a Gott Wirt");
+  });
+
+  it("#2440: an unfinalized run with no comment leaves title undefined (merge synthesizes the placeholder)", () => {
+    const ev = parseFutureRow(["2026-08-01", "FMH #31?", "Casting Couch", ""]);
+    expect(ev?.runNumber).toBeUndefined();
     expect(ev?.title).toBeUndefined();
+  });
+
+  it("#2440: a promoted comment longer than the cap is truncated with an ellipsis", () => {
+    const longComment = "A".repeat(200);
+    const ev = parseFutureRow(["2026-08-01", "FMH #32?", "Hare", longComment]);
+    expect(ev?.title).toBe(`${"A".repeat(120)}…`);
+    expect(ev?.description).toBe(longComment);
   });
 
   it("collapses doubled whitespace in the hares cell", () => {

--- a/src/adapters/html-scraper/vindobona-h3.ts
+++ b/src/adapters/html-scraper/vindobona-h3.ts
@@ -51,6 +51,21 @@ function cleanText(value: string | undefined): string | undefined {
   return cleaned.length > 0 ? cleaned : undefined;
 }
 
+/** Max characters for a comment promoted to a title (#2440). */
+const MAX_TITLE_LEN = 120;
+
+/**
+ * #2440: promote the Comments note to a title for unfinalized runs (a label
+ * like "FMH #30?" yields no run number, so merge would emit the bare
+ * "<Kennel> Trail" placeholder). Truncated so an over-long note stays tidy.
+ */
+function titleFromComment(comment: string | undefined): string | undefined {
+  if (!comment) return undefined;
+  return comment.length > MAX_TITLE_LEN
+    ? `${comment.slice(0, MAX_TITLE_LEN).trimEnd()}…`
+    : comment;
+}
+
 /** Route a run label to its kennel by prefix; null for header/decorative rows. */
 function routeKennel(label: string): string | null {
   const upper = label.toUpperCase();
@@ -88,14 +103,20 @@ export function parseFutureRow(cells: string[]): RawEventData | null {
 
   // extractHashRunNumber rejects trailing-`?` tokens (#30?, #23??) → undefined,
   // so the dated event still emits and merge synthesizes "<Kennel> Trail #N".
+  const runNumber = extractHashRunNumber(label);
+  // The Comments column is a free-form note (run type / theme / sometimes a
+  // town). It is NOT a reliable venue, so it feeds description, never location.
+  const description = cleanText(cells[3]);
   return {
     date,
     kennelTags: [kennelTag],
-    runNumber: extractHashRunNumber(label),
+    runNumber,
     hares: cleanText(cells[2]),
-    // The Comments column is a free-form note (run type / theme / sometimes a
-    // town). It is NOT a reliable venue, so it feeds description, never location.
-    description: cleanText(cells[3]),
+    // #2440: an unfinalized run has no run number, so merge would fall back to
+    // the bare "<Kennel> Trail" placeholder. Promote the Comments note to the
+    // title. Numbered runs keep the synthesized "<Kennel> Trail #N".
+    title: runNumber === undefined ? titleFromComment(description) : undefined,
+    description,
   };
 }
 

--- a/src/adapters/html-scraper/vindobona-h3.ts
+++ b/src/adapters/html-scraper/vindobona-h3.ts
@@ -61,8 +61,11 @@ const MAX_TITLE_LEN = 120;
  */
 function titleFromComment(comment: string | undefined): string | undefined {
   if (!comment) return undefined;
-  return comment.length > MAX_TITLE_LEN
-    ? `${comment.slice(0, MAX_TITLE_LEN).trimEnd()}…`
+  // Slice by code points (Array.from) so a trailing emoji surrogate pair isn't
+  // split into a malformed character — hash comments often carry emoji.
+  const chars = Array.from(comment);
+  return chars.length > MAX_TITLE_LEN
+    ? `${chars.slice(0, MAX_TITLE_LEN).join("").trimEnd()}…`
     : comment;
 }
 


### PR DESCRIPTION
Quick-win bundle on the shared Google Calendar adapter. Every root cause was confirmed against the **live ICS feed / live adapter run**, not just fixtures. Fixes are per-source config where possible; adapter code touched only where genuinely needed (Vindobona).

## Title / hare leaks
- **#2442 Voodoo H3** — titles come as `Voodoo Trail #NNNN hared by <hares>` (stripped by the global `TITLE_HARED_BY_RE`) **or** the bare `… #1044 by YMBJ` variant the global strip misses. Added a scoped `titleStripPatterns` on Voodoo that runs *after* the global strip. Live: 0 titles still end in " by X".
- **#2440 Vienna FMH3** (Vindobona HTML adapter) — `parseFutureRow` never set `title`, so an unfinalized run (`FMH #30?` → no run number) fell back to the bare `Vienna FMH3 Trail` placeholder. Now promotes the Comments note to the title when there's no run number.

## Kennel routing / coverage
- **#2461 Whoreman** — `defaultKennelTag: null` made every unmatched community special (campouts, dress runs, Missionary Position Bashes, "easter trail") leak as its own `UNMATCHED_TAG`. Set default to the host kennel `wasatch-h3` + unanchored the Whoreman/WH3 patterns. Live: **0 unmatched tags**.
- **#2281 Aloha Fool Moon** — the `fool-moon-h3` pattern matched only literal "Fool Moon", but the real titles say "Hawaii Full Moon H3", "HFMH3", "Full Moon Hash", "Full Moon #410", … so ~76 events mis-routed to `ah3-hi`. Widened to the kennel signatures (ordered after PHH/H5 so co-hosts keep priority). Live: **fool-moon-h3 1 → 42**, PHH unaffected.
- **#2394 SWH3 Raleigh / #2344 SWH3-or / #2384 T3H3 Minneapolis** — the missing specials are published as **all-day** events (SWH3 Bike Hash / Geezer / Hare-Raising Party; SWH3-or #140 "Pick Up Hash"; "T3H3 Pink Dress!" weekend). Added `includeAllDayEvents: true`; Minneapolis also `skipPatterns` the all-day "Travel Hash: <city>" trip announcements. Live: all specials now admitted; no travel-hash noise.

## Improbable-time audits — triaged as FALSE POSITIVES (no code fix)
Confirmed via live histograms that these are **genuine source data**, not Z-slice bugs:
- **#2542 Salem** / **#2295 + #2455 Flour City** (GCal) — timed events cluster at normal hours (Flour City: 42 @ 18:00; Salem: 11:00–15:00); 0 improbable-hour events. A Z-slice bug would push evenings to 22:00–01:00. Flagged events were one-off odd entries that aged out.
- **#2537 Toulouse** / **#2531 Aberdeen** (Harrier Central) — HC verbatim-slices its naive **local** time (Tokyo, UTC+9, is correct with the same slice). Aberdeen's live feed **mixes 19:00 and 23:00**, which a uniform timezone bug can't produce → the 23:00 runs are genuine values in HC's data.

Added `scripts/suppress-improbable-time-gcal-hc-bundle.ts` (idempotent AuditSuppression upsert for the 4 kennels, mirroring the kwh3 #461 / soco #2060 precedent).

## Tests / checks
Regression tests added for every case (`adapter.test.ts`, `vindobona-h3.test.ts`). `npx tsc --noEmit`, `npm run lint`, and the full suite (**9918 tests**) all green.

## Post-merge prod ops (I run these with go-ahead — not auto-closing the issues)
Vercel deploys code, not `Source.config`, so these take effect only after:
1. Surgically apply the new `Source.config` to prod (jsonb, per-source — not a full `db seed`) for Whoreman, Aloha, Voodoo, Minneapolis, SWH3 Raleigh, SWH3-or.
2. Re-scrapes: Aloha wide **re-route** (fool-moon-h3, expect reconcile cancellations of stale ah3-hi rows); SWH3 Raleigh wide backfill (~440 historical); SWH3-or **bounded** backfill (~600d, recovers #130, stops short of the bogus 2018-04-07 rows).
3. Run `scripts/suppress-improbable-time-gcal-hc-bundle.ts` against prod, then close #2542/#2295/#2455/#2537/#2531.
4. **#2534 BAH3** — no live GCal source (removed iCal); correct/clean the orphan canonical in prod, then close.

Addresses #2442 #2440 #2461 #2281 #2394 #2344 #2384 #2542 #2295 #2455 #2537 #2531 #2534 (closed manually after the prod ops above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)