### PR TITLE
fix(google-calendar): BAH3 — strip hare names from event title (#2534)

### DIFF
--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -978,7 +978,28 @@ export const SOURCES = [
       },
       kennelCodes: ["cch3"],
     },
-    // BAH3 iCal Feed — REMOVED: all-in-one-event-calendar plugin gone, endpoint returns HTML. Never successfully scraped.
+    // BAH3 iCal Feed — REMOVED: all-in-one-event-calendar plugin gone, endpoint
+    // returns HTML. BAH3 is now fed by the kennel's public Google Calendar.
+    {
+      name: "Baltimore Annapolis GCal",
+      url: "cee16fd6817286546f6b8e999e4b473d33aa1fd42f14f0d71969e994c05c22c1@group.calendar.google.com",
+      type: "GOOGLE_CALENDAR" as const,
+      trustLevel: 7,
+      scrapeFreq: "every_6h",
+      scrapeDays: 365,
+      config: {
+        defaultKennelTag: "bah3",
+        // #2534: the kennel puts the HARE names in the event SUMMARY
+        // ("BAH3 #2034 - Dud, G-Spotify, Chia Head") — the real run name lives
+        // in the description body. Extract the post-dash span and strip it from
+        // the title (the hares themselves come from the description "Hares:"
+        // line), leaving a clean "BAH3 [Trail] #N" instead of a hare list.
+        // Mirrors the MH3-Mpls alwaysStripTitleHareSpan fix.
+        titleHarePattern: String.raw`[-–—]\s*(.+)$`,
+        alwaysStripTitleHareSpan: true,
+      },
+      kennelCodes: ["bah3"],
+    },
     // DC / DMV area — HTML scraper sources
     {
       name: "EWH3 WordPress Trail News",

--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -6502,3 +6502,40 @@ describe("Surf City all-day events (#2388)", () => {
     expect(r).toBeNull();
   });
 });
+
+// ── #2534 BAH3 — hare names in the summary stripped out of the title ──
+
+describe("Baltimore Annapolis GCal — hare names stripped from title (#2534)", () => {
+  const src = SOURCES.find((s) => s.name === "Baltimore Annapolis GCal");
+  if (!src?.config) throw new Error("Baltimore Annapolis GCal seed config missing");
+  const config = src.config as Parameters<typeof buildRawEventFromGCalItem>[1] & { titleHarePattern: string };
+  const compiledTitleHarePatterns = compilePatterns([config.titleHarePattern], "i");
+
+  it("strips the post-dash hare span; hares come from the description Hares: line", () => {
+    const result = buildRawEventFromGCalItem(
+      {
+        summary: "BAH3 #2034 - Dud, G-Spotify, Chia Head",
+        description: "BAH3 Trail #2034 – Red, White, and Blue (Balls)\nHares: Chia Head, G-Spotify, Dude w/o the e\nStart: 7:00 PM",
+        start: { dateTime: "2026-07-05T19:00:00-04:00" },
+        status: "confirmed",
+      },
+      config,
+      { compiledTitleHarePatterns },
+    );
+    expect(result?.kennelTags).toEqual(["bah3"]);
+    // Title must NOT be the hare list any more.
+    expect(result?.title ?? "").not.toMatch(/Chia Head|G-Spotify|Dud/);
+    // Hares are preserved from the description.
+    expect(result?.hares).toContain("Chia Head");
+  });
+
+  it("keeps a dash-less BAH3 tour title intact (no over-strip)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "TOUR DUH HASH: MVH3", start: { dateTime: "2026-08-01T14:00:00-04:00" }, status: "confirmed" },
+      config,
+      { compiledTitleHarePatterns },
+    );
+    expect(result?.kennelTags).toEqual(["bah3"]);
+    expect(result?.title).toBe("TOUR DUH HASH: MVH3");
+  });
+});


### PR DESCRIPTION
Follow-up to #2607 (from its prod-ops verification, which corrected the diagnosis).

## What #2534 actually is
The audit filed #2534 as "BAH3 GOOGLE_CALENDAR sets title to hare names". During #2607's prod ops I found the backing source is **"Baltimore Annapolis GCal"** (a live, enabled `GOOGLE_CALENDAR` feeding `bah3`) — **which existed only in the prod DB, not the committed seed** (added directly, no git history). So it was neither an orphan nor covered by #2607. This PR brings it under version control and fixes the title bug.

## The bug + fix
The kennel puts the **hare names in the event summary** (`"BAH3 #2034 - Dud, G-Spotify, Chia Head"`); the real run name lives in the description (`"BAH3 Trail #2034 – Red, White, and Blue (Balls)"`). The adapter used the full summary as the title → hares leaked into the title.

Fix = the MH3-Mpls pattern: `titleHarePattern: [-–—]\s*(.+)$` + `alwaysStripTitleHareSpan: true`. The post-dash span is stripped from the title; the hares themselves still come from the description "Hares:" line. Result: a clean `"BAH3 [Trail] #N"` with hares in the hares field.

## Verification
Live-verified the config against the source (401-day window, 91 events): **0 hare-laden or empty titles** — every title is a clean `BAH3 [Trail] #N` (or an intact dash-less tour title like `"TOUR DUH HASH: MVH3"`), with hares correctly separated. Regression tests added (`adapter.test.ts`). `npx tsc --noEmit`, `npm run lint`, and the full suite pass.

## Post-merge
Vercel deploys code, not `Source.config`, so after merge I'll surgically apply the config to the prod source and re-scrape to fix existing canonicals, then close #2534.

Addresses #2534 (closed manually after the post-merge prod apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)