### PR TITLE
fix(google-calendar): emit endDate for multi-day all-day events

### DIFF
--- a/src/adapters/google-calendar/adapter.test.ts
+++ b/src/adapters/google-calendar/adapter.test.ts
@@ -6539,3 +6539,45 @@ describe("Baltimore Annapolis GCal — hare names stripped from title (#2534)", 
     expect(result?.title).toBe("TOUR DUH HASH: MVH3");
   });
 });
+
+// ── Multi-day all-day events → inclusive endDate (Codex follow-up on #2607) ──
+
+describe("buildRawEventFromGCalItem — multi-day all-day endDate", () => {
+  const config = { defaultKennelTag: "t3h3", includeAllDayEvents: true };
+
+  it("emits an inclusive endDate for a multi-day all-day event (GCal DTEND is exclusive)", () => {
+    // "T3H3 Pink Dress!" weekend: DTSTART;VALUE=DATE:20261002 / DTEND;VALUE=DATE:20261005.
+    const result = buildRawEventFromGCalItem(
+      { summary: "T3H3 Pink Dress!", start: { date: "2026-10-02" }, end: { date: "2026-10-05" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.date).toBe("2026-10-02");
+    expect(result?.endDate).toBe("2026-10-04"); // 2026-10-05 exclusive − 1 day
+  });
+
+  it("does NOT emit endDate for a single-day all-day event (regression guard)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "T3H3 One-Day Special", start: { date: "2026-10-02" }, end: { date: "2026-10-03" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.date).toBe("2026-10-02");
+    expect(result?.endDate).toBeUndefined();
+  });
+
+  it("does NOT emit endDate for an all-day event with no end", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "T3H3 No-End", start: { date: "2026-10-02" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.endDate).toBeUndefined();
+  });
+
+  it("does NOT emit endDate for a timed event that crosses midnight (overnight run, not multi-day)", () => {
+    const result = buildRawEventFromGCalItem(
+      { summary: "T3H3 #500", start: { dateTime: "2026-10-02T20:00:00-05:00" }, end: { dateTime: "2026-10-03T01:00:00-05:00" }, status: "confirmed" },
+      config,
+    );
+    expect(result?.date).toBe("2026-10-02");
+    expect(result?.endDate).toBeUndefined();
+  });
+});

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -2150,8 +2150,10 @@ export function buildRawEventFromGCalItem(
   // events that merely cross midnight (overnight runs) are single-day events
   // with a late end, NOT multi-day campouts — the `isAllDay` guard excludes them.
   let endDate: string | undefined;
-  if (isAllDay && item.end?.date) {
-    const startMs = Date.parse(`${dateISO}T00:00:00Z`);
+  if (isAllDay && item.start?.date && item.end?.date) {
+    // Use the raw all-day date strings (guaranteed YYYY-MM-DD) rather than the
+    // derived `dateISO`, so the parse can't break if `dateISO`'s shape changes.
+    const startMs = Date.parse(`${item.start.date}T00:00:00Z`);
     const endMs = Date.parse(`${item.end.date}T00:00:00Z`);
     if (endMs - startMs > 86_400_000) {
       endDate = new Date(endMs - 86_400_000).toISOString().slice(0, 10);

--- a/src/adapters/google-calendar/adapter.ts
+++ b/src/adapters/google-calendar/adapter.ts
@@ -2144,6 +2144,20 @@ export function buildRawEventFromGCalItem(
     location = undefined;
   }
 
+  // Multi-day ALL-DAY events (#1560 parity with the iCal adapter): a GCal
+  // all-day DTEND is EXCLUSIVE (the day after the last day), so the inclusive
+  // last day is DTEND − 1. Emit only when genuinely multi-day (> 1 day); timed
+  // events that merely cross midnight (overnight runs) are single-day events
+  // with a late end, NOT multi-day campouts — the `isAllDay` guard excludes them.
+  let endDate: string | undefined;
+  if (isAllDay && item.end?.date) {
+    const startMs = Date.parse(`${dateISO}T00:00:00Z`);
+    const endMs = Date.parse(`${item.end.date}T00:00:00Z`);
+    if (endMs - startMs > 86_400_000) {
+      endDate = new Date(endMs - 86_400_000).toISOString().slice(0, 10);
+    }
+  }
+
   const event: RawEventData = {
     date: dateISO,
     // Pass the full multi-kennel set (#1023): for single-tag patterns this
@@ -2160,6 +2174,9 @@ export function buildRawEventFromGCalItem(
     startTime: resolvedStartTime,
     // endTime is HH:MM only, so cross-date end timestamps (overnight runs) are dropped.
     endTime: endParts && endParts.dateISO === dateISO ? endParts.startTime : undefined,
+    // Gated so single-day events never emit endDate — keeps their fingerprint
+    // stable (fingerprint.ts only tokenizes endDate when present).
+    ...(endDate ? { endDate } : {}),
     cost,
     sourceUrl: item.htmlLink,
   };


### PR DESCRIPTION
Follow-up to Codex's P2 review comment on #2607.

## Problem
Once a source sets `includeAllDayEvents: true`, the GCal adapter admits multi-day all-day events (e.g. **"T3H3 Pink Dress!"** spanning `DTSTART;VALUE=DATE:20261002` → `DTEND;VALUE=DATE:20261005`) but stores only `date` from `item.start.date` and **discards `item.end.date`** — so they render as a single day on the start date instead of a span. Affects all 15 `includeAllDayEvents` sources.

## Fix (adapter-only)
In `buildRawEventFromGCalItem`, derive an **inclusive** `endDate` from `item.end.date` — a GCal all-day `DTEND` is *exclusive* (the day after the last day), so `endDate = end − 1 day` — and emit it via a gated spread, **only when genuinely multi-day** (`> 1 day`). Timed events that merely cross midnight (overnight runs) are excluded by the `isAllDay` guard — they're single-day events with a late end, not campouts. Mirrors the iCal adapter (`ical/adapter.ts`, #1560), which handles the identical exclusive-DTEND convention.

Nothing downstream needed changing — it was all already wired:
- **Merge**: `resolveEndDateUpdate` (`merge.ts`) writes `endDate` tri-state; the venue-weekend heuristic is gated on `!event.endDate`.
- **Fingerprint**: tokenizes `endDate` **only when present**, so single-day events don't re-fingerprint.
- **UI**: `EventCard`/`EventDetailPanel` already render `formatDateRange(event.date, event.endDate)` when `endDate` differs from `date`.

## Verification
- **CI**: `tsc` + `lint` + full suite (**9965 tests**) green — confirms no single-day regression across the 15 all-day sources.
- **Live** (Minneapolis calendar): 5/231 events carry `endDate`, all genuine multi-day weekends — **"T3H3 Pink Dress!" → 2026-10-02 → 2026-10-04**, "Twin Titties Pink Dress", "Destination Hash - Wisconsin Dells", etc.; **0 events with `endDate <= date`**; the 226 single-day events correctly have none.
- New regression tests: multi-day all-day (inclusive endDate), single-day all-day (none), no-`end` (none), timed-overnight (none).

## Post-merge (needs go-ahead)
New scrapes emit `endDate` automatically; existing canonicals need a one-shot re-scrape of the 15 `includeAllDayEvents` sources to backfill it. Since only `endDate` changes (same kennel+date), merge updates in place — no re-route/cancellation.

Scope: GCal adapter + its test only. Does not touch the STATIC_SCHEDULE / `seriesId` multi-day split path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)