### PR TITLE
fix(logos): serve self-hosted .avif kennel logos (Clerk matcher skip-list)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -44,7 +44,11 @@ export const config = {
     // self-hosted under `public/` MUST be added to this alternation or requests
     // for it run through Clerk instead of the static CDN and 404 (the file exists
     // but never resolves) — that's why `.avif` kennel logos 404'd until added here.
-    String.raw`/((?!_next|[^?]*\.(?:html?|css|js(?!on)|jpe?g|webp|avif|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|xml|txt)).*)`,
+    // `[.]` matches a literal dot without a backslash escape — a plain string
+    // literal (required: Next statically analyzes this middleware matcher at
+    // build time, so no String.raw/template expressions here) that also avoids
+    // the escaped-backslash smell.
+    "/((?!_next|[^?]*[.](?:html?|css|js(?!on)|jpe?g|webp|avif|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|xml|txt)).*)",
     // Always run for API routes
     "/(api|trpc)(.*)",
   ],

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -40,8 +40,11 @@ export const proxy = clerkMiddleware(async (auth, request) => {
 
 export const config = {
   matcher: [
-    // Skip Next.js internals and static files
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|xml|txt)).*)",
+    // Skip Next.js internals and static files. NOTE: any NEW static extension
+    // self-hosted under `public/` MUST be added to this alternation or requests
+    // for it run through Clerk instead of the static CDN and 404 (the file exists
+    // but never resolves) — that's why `.avif` kennel logos 404'd until added here.
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|avif|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|xml|txt)).*)",
     // Always run for API routes
     "/(api|trpc)(.*)",
   ],

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -44,7 +44,7 @@ export const config = {
     // self-hosted under `public/` MUST be added to this alternation or requests
     // for it run through Clerk instead of the static CDN and 404 (the file exists
     // but never resolves) — that's why `.avif` kennel logos 404'd until added here.
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|avif|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|xml|txt)).*)",
+    String.raw`/((?!_next|[^?]*\.(?:html?|css|js(?!on)|jpe?g|webp|avif|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|xml|txt)).*)`,
     // Always run for API routes
     "/(api|trpc)(.*)",
   ],


### PR DESCRIPTION
## Problem

Every self-hosted `.avif` kennel logo 404s in production (`hashtracks.xyz`) — both the direct path `/kennel-logos/<name>.avif` **and** the optimizer path `/_next/image?url=%2Fkennel-logos%2F<name>.avif` — while `.png`/`.jpg`/`.webp` logos serve 200. `KennelLogo.tsx` falls back to initials (#1300), so affected kennels show initials instead of their real logo — cosmetic but wrong. The files are valid and committed to git (real `ftypavif` magic bytes, not LFS pointers).

## Root cause

The Clerk middleware matcher in `src/proxy.ts` has a negative-lookahead skip-list of static extensions that bypass middleware and get served straight from the static CDN. It listed **every** served image format (`png`, `jpe?g`, `webp`, `svg`, `gif`, `ico`) **except `avif`**. So:

- `/kennel-logos/a3h.png` → matches skip-list → middleware skipped → CDN serves it → **200** ✓
- `/kennel-logos/krashh3.avif` → not in skip-list → runs through `clerkMiddleware`, never resolves the `public/` asset → **404**
- `/_next/image?url=…krashh3.avif` → optimizer fetches its source URL server-side, hits the same blocked 404 → **404**

All three observed behaviors are explained by the one missing token. Same bug class as the earlier extensionless-metadata-route 404 (paths not covered by the skip-list run through Clerk and get blocked).

`next.config.ts` (no `images.formats` override) and `vercel.json` (crons only) are both clean — this is **not** a Vercel-platform / build-output / format problem, so no data change is needed.

## Fix

One line: add `avif` to the skip-list alternation. Strictly additive — avif now bypasses Clerk exactly like `png`; it can only make avif *more* served, never less. No seed change, no migration, no prod DB re-point, no file conversion.

Fixes all 6 current self-hosted avif logos and any future ones at once:

| kennelCode | shortName | file |
|---|---|---|
| `krashh3` | KRASH H3 (Kaiserslautern, DE) | `krashh3.avif` |
| `h2fmh3` | Hua Hin Full Moon H3 (TH) | `h2fmh3.avif` |
| `psh3-th` | Pranburi H3 (TH) | `psh3-th.avif` |
| `toulouse-h3` | Toulouse H3 (FR) | `toulouse-h3.avif` |
| `bnh3` | Brazil Nuts H3 (São Paulo, BR) | `bnh3.avif` |
| `beerh3` | BEER H3 (Belgrade) | `beerh3.avif` |

## Verification

**Locally (`next dev`), after the fix:**
- `/kennel-logos/krashh3.avif` → `200 image/avif` (size 118183 = exact git blob), was 404
- `/kennel-logos/toulouse-h3.avif` → `200 image/avif`
- optimizer `/_next/image?url=%2Fkennel-logos%2Fkrashh3.avif&w=256&q=75` → `200`
- `.png` sanity → still `200` (regex change didn't break the existing skip)
- kennel page server HTML emits the avif optimizer `srcset` (the real logo, not initials)

`npx tsc --noEmit` passes; `eslint src/proxy.ts` clean.

**Post-merge (after Vercel deploy):** curl the 6 URLs → expect `200 image/avif`, and confirm a kennel page (e.g. `/kennels/krash-h3`) renders the real logo instead of initials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)