### PR TITLE
feat(mgh4,w3h3-ga): onboard shared mgh4.com next-hash HTML source

### DIFF
--- a/docs/kennel-research/static-only-audit.md
+++ b/docs/kennel-research/static-only-audit.md
@@ -83,8 +83,8 @@ Action: **ONBOARD** (build the found source) · **KEEP** (static, no better opti
 | Kota Kinabalu, MY | KK H3 | `kk-h3` | UNCONFIRMED | NONE — Facebook-only | VERIFY / KEEP |
 | Kuching, MY | Kuching H3 | `kuching-h3` | **ACTIVE** (scene won Interhash 2028 bid, Jun 2026) | NONE — Facebook-only | KEEP |
 | Little Rock, AR | Little Rock H3 | `lrh3` | **ACTIVE** (Green Dress wknd Mar 2026) | NONE — `lrhash.com` static, weekly hareline on FB only | KEEP |
-| Macon, GA | MGH4 | `mgh4` | **DORMANT** (last run Jul 19 2025) | **HTML** — `mgh4.com/page/next-hash` — MED (verified live) | ONBOARD (shared w/ w3h3-ga) |
-| Macon, GA | W3H3 | `w3h3-ga` | **DORMANT** (last run Oct 29 2025) | **HTML** — `mgh4.com/page/next-hash` — MED (verified live) | ONBOARD (shared w/ mgh4) |
+| Macon, GA | MGH4 | `mgh4` | **DORMANT** (last run Jul 19 2025) | **HTML** — `mgh4.com/page/next-hash` — MED (verified live) | **ONBOARDED** (shared adapter; static kept) |
+| Macon, GA | W3H3 | `w3h3-ga` | **DORMANT** (last run Oct 29 2025) | **HTML** — `mgh4.com/page/next-hash` — MED (verified live) | **ONBOARDED** (shared adapter; static kept) |
 | Miami, FL | Palm Beach H3 | `pbh3` | **DORMANT** (last public 2023; site → FB) | NONE — Facebook-only | VERIFY / KEEP |
 | Miami, FL | Wildcard H3 | `wildcard-h3` | UNCONFIRMED | NONE — Facebook-only | VERIFY / KEEP |
 | New Jersey | Rumson | `rumson` | **ACTIVE** (2,500th run Feb/Mar 2026) | NONE — FB-only (RunSignUp for annual events only) | KEEP |
@@ -107,13 +107,15 @@ Action: **ONBOARD** (build the found source) · **KEEP** (static, no better opti
    static source was **disabled** rather than kept as a fallback (the blog is
    authoritative). Seeded as a trust-7 HTML_SCRAPER.
 
-2. **MGH4 (`mgh4`) + W3H3 (`w3h3-ga`) — one HTML adapter on `mgh4.com` — MED.**
-   `https://mgh4.com/page/next-hash` (and `/page/hareline`) is a BlogEngine.NET page
-   carrying dated runs for **both** Macon kennels with time + location. One config-driven
-   or bespoke HTML scraper feeds both. **Caveat:** the site itself says "we are having
-   trouble getting people to hare trails" and the latest posted runs are stale
-   (MGH4 Jul 2025, W3H3 Oct 2025) — onboard, but expect thin/dormant output; keep the
-   static fallback beneath it.
+2. **MGH4 (`mgh4`) + W3H3 (`w3h3-ga`) — one HTML adapter on `mgh4.com` — MED. ✅ DONE.**
+   `https://mgh4.com/page/next-hash` (BlogEngine.NET) carries the current/next run for
+   **both** Macon kennels as prose paragraphs (kennel label + date + hares + location +
+   times). `MaconHashAdapter` parses both, routing by the leading label. Seeded as one
+   trust-7 source linked to both kennels. **Caveat:** the site says "we are having trouble
+   getting people to hare trails" and the latest runs are stale (MGH4 Jul 2025, W3H3 Oct
+   2025) — output is thin/dormant. Because the page has no future events, it can't phantom
+   against the static placeholders, so **both static rows stay enabled** as the
+   forward-looking backbone (unlike GATR, whose static was disabled).
 
 3. ~~**Budapest H3 (`budapest-h3`) — self-hosted WordPress.**~~ **Ruled out (2026-07-10).**
    `budapesthashhouseharriers.org` has **no DNS at all** — no A record, no NS record —

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2317,6 +2317,21 @@ export const SOURCES = [
       kennelCodes: ["w3h3-ga"],
     },
     {
+      // One HTML page (mgh4.com/page/next-hash) carries the current/next run for
+      // BOTH Macon kennels (#static-only-audit): real date/location/time/hares.
+      // Enrichment above the two STATIC_SCHEDULE rows above — trust 7 so real
+      // runs win on merge. The page is low-activity (often stale) and has no
+      // future events today, so it can't phantom against the static placeholders;
+      // both static rows stay enabled as the forward-looking backbone.
+      name: "MGH4 & W3H3 Next Hash",
+      url: "https://mgh4.com/page/next-hash",
+      type: "HTML_SCRAPER" as const,
+      trustLevel: 7,
+      scrapeFreq: "daily",
+      scrapeDays: 90,
+      kennelCodes: ["mgh4", "w3h3-ga"],
+    },
+    {
       name: "CVH3 Static Schedule",
       url: "https://www.facebook.com/groups/cvh3columbus",
       type: "STATIC_SCHEDULE" as const,

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -2329,6 +2329,10 @@ export const SOURCES = [
       trustLevel: 7,
       scrapeFreq: "daily",
       scrapeDays: 90,
+      // Single current/next-hash page: once the site advances from run A to B,
+      // A stops appearing. upcomingOnly clamps reconcile to the future so a
+      // recently-past off-cadence Macon trail (only carried here) isn't cancelled.
+      config: { upcomingOnly: true },
       kennelCodes: ["mgh4", "w3h3-ga"],
     },
     {

--- a/src/adapters/html-scraper/macon-hash.test.ts
+++ b/src/adapters/html-scraper/macon-hash.test.ts
@@ -31,8 +31,13 @@ describe("parseMaconLocation", () => {
     expect(parseMaconLocation("starting at Washington Park, Macon. In at 6")).toBe(
       "Washington Park, Macon",
     );
-    expect(parseMaconLocation("Meet at 5650 Arkwright Rd. Congregate")).toBe(
+    expect(parseMaconLocation("Meet at 5650 Arkwright Rd. Congregate at 1:30")).toBe(
       "5650 Arkwright Rd",
+    );
+  });
+  it("does not truncate a mid-string abbreviation (St. / Rd.)", () => {
+    expect(parseMaconLocation("Meet at St. Andrews Park. In at 6")).toBe(
+      "St. Andrews Park",
     );
   });
 });
@@ -41,6 +46,11 @@ describe("parseMaconHares", () => {
   it("reads 'X is laying' and a leading possessive", () => {
     expect(parseMaconHares("Weedeater is laying a trail")).toBe("Weedeater");
     expect(parseMaconHares("Weedeater's birthday trail")).toBe("Weedeater");
+  });
+  it("captures a multi-hare list before 'are laying'", () => {
+    expect(parseMaconHares("Weedeater and Hash Trash are laying a trail")).toBe(
+      "Weedeater and Hash Trash",
+    );
   });
 });
 

--- a/src/adapters/html-scraper/macon-hash.test.ts
+++ b/src/adapters/html-scraper/macon-hash.test.ts
@@ -1,10 +1,27 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import * as cheerio from "cheerio";
 import {
   parseMaconEntry,
   parseMaconTime,
   parseMaconLocation,
   parseMaconHares,
+  MaconHashAdapter,
 } from "./macon-hash";
+import { fetchHTMLPage } from "../utils";
+import type { Source } from "@/generated/prisma/client";
+
+// Keep every real util helper; only stub the network fetch.
+vi.mock("../utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils")>();
+  return { ...actual, fetchHTMLPage: vi.fn() };
+});
+
+const SOURCE = {
+  id: "s",
+  name: "MGH4 & W3H3 Next Hash",
+  url: "https://mgh4.com/page/next-hash",
+  type: "HTML_SCRAPER",
+} as unknown as Source;
 
 const SRC = "https://mgh4.com/page/next-hash";
 
@@ -39,6 +56,10 @@ describe("parseMaconLocation", () => {
     expect(parseMaconLocation("Meet at St. Andrews Park. In at 6")).toBe(
       "St. Andrews Park",
     );
+  });
+  it("returns null for a placeholder phrase (clear stale venue) and undefined when absent", () => {
+    expect(parseMaconLocation("Meet at TBA. In at 6")).toBeNull();
+    expect(parseMaconLocation("Weedeater is laying a trail")).toBeUndefined();
   });
 });
 
@@ -82,5 +103,51 @@ describe("parseMaconEntry", () => {
 
   it("returns null for a labeled paragraph with no parseable date", () => {
     expect(parseMaconEntry("W3H3 hareline: when we have hares", SRC)).toBeNull();
+  });
+});
+
+describe("MaconHashAdapter.fetch", () => {
+  const okPage = (html: string) => ({
+    ok: true as const,
+    html,
+    $: cheerio.load(html),
+    structureHash: "hash123",
+    fetchDurationMs: 5,
+  });
+
+  it("parses run paragraphs and ignores the intro, reporting diagnostics", async () => {
+    const html = `
+      <p>Note: we are having trouble getting hares.</p>
+      <p><strong>W3H3 Wednesday, October 29, 2025,</strong> Weedeater is laying a trail starting at Washington Park, Macon. In at 6:30, out at 7.</p>
+      <p><strong>MGH4, Saturday, July 19, 2025.</strong> Meet at 5650 Arkwright Rd. Congregate at 1:30, out at 2.</p>`;
+    vi.mocked(fetchHTMLPage).mockResolvedValue(okPage(html));
+
+    const res = await new MaconHashAdapter().fetch(SOURCE);
+
+    expect(res.errors).toEqual([]);
+    expect(res.events).toHaveLength(2);
+    expect(res.events.map((e) => e.kennelTags[0])).toEqual(["w3h3-ga", "mgh4"]);
+    expect(res.diagnosticContext).toMatchObject({
+      fetchMethod: "cheerio",
+      paragraphs: 3,
+      eventsParsed: 2,
+    });
+  });
+
+  it("returns the fetch failure result when the page fetch fails", async () => {
+    const failure = {
+      ok: false as const,
+      result: {
+        events: [],
+        errors: ["fetch boom"],
+        errorDetails: {},
+        diagnosticContext: { fetchMethod: "cheerio" },
+      },
+    };
+    vi.mocked(fetchHTMLPage).mockResolvedValue(failure);
+
+    const res = await new MaconHashAdapter().fetch(SOURCE);
+    expect(res).toBe(failure.result);
+    expect(res.errors).toEqual(["fetch boom"]);
   });
 });

--- a/src/adapters/html-scraper/macon-hash.test.ts
+++ b/src/adapters/html-scraper/macon-hash.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMaconEntry,
+  parseMaconTime,
+  parseMaconLocation,
+  parseMaconHares,
+} from "./macon-hash";
+
+const SRC = "https://mgh4.com/page/next-hash";
+
+// Real paragraph text as cheerio's .text() yields it (NBSP =  ).
+const W3H3_TEXT =
+  "W3H3 Wednesday,  October 29, 2025, Weedeater is laying a trail starting at Washington Park, Macon.  In at 6:30, out at 7.  Bring the usual stuff.  ";
+const MGH4_TEXT =
+  "MGH4, Saturday, July 19, 2025.  Weedeater's birthday trail.  Meet at 5650 Arkwright Rd.  Congregate at 1:30, out at 2.  Bring a chair and a bathing suit.";
+const INTRO_TEXT =
+  "Note: We are having trouble getting people to hare trails. The second someone steps up, the details will be posted here, so please check back often.";
+
+describe("parseMaconTime", () => {
+  it("prefers pack-off (out at) over gather and PM-normalizes", () => {
+    expect(parseMaconTime("In at 6:30, out at 7")).toBe("19:00");
+    expect(parseMaconTime("Congregate at 1:30, out at 2")).toBe("14:00");
+  });
+  it("falls back to gather time when there is no out time", () => {
+    expect(parseMaconTime("In at 6:30. Bring stuff.")).toBe("18:30");
+  });
+});
+
+describe("parseMaconLocation", () => {
+  it("extracts the place after starting-at / meet-at", () => {
+    expect(parseMaconLocation("starting at Washington Park, Macon. In at 6")).toBe(
+      "Washington Park, Macon",
+    );
+    expect(parseMaconLocation("Meet at 5650 Arkwright Rd. Congregate")).toBe(
+      "5650 Arkwright Rd",
+    );
+  });
+});
+
+describe("parseMaconHares", () => {
+  it("reads 'X is laying' and a leading possessive", () => {
+    expect(parseMaconHares("Weedeater is laying a trail")).toBe("Weedeater");
+    expect(parseMaconHares("Weedeater's birthday trail")).toBe("Weedeater");
+  });
+});
+
+describe("parseMaconEntry", () => {
+  it("routes a W3H3 paragraph to w3h3-ga with full fields", () => {
+    expect(parseMaconEntry(W3H3_TEXT, SRC)).toMatchObject({
+      date: "2025-10-29",
+      kennelTags: ["w3h3-ga"],
+      startTime: "19:00",
+      location: "Washington Park, Macon",
+      hares: "Weedeater",
+      sourceUrl: SRC,
+    });
+  });
+
+  it("routes an MGH4 paragraph to mgh4 with full fields", () => {
+    expect(parseMaconEntry(MGH4_TEXT, SRC)).toMatchObject({
+      date: "2025-07-19",
+      kennelTags: ["mgh4"],
+      startTime: "14:00",
+      location: "5650 Arkwright Rd",
+      hares: "Weedeater",
+    });
+  });
+
+  it("returns null for the non-run intro paragraph", () => {
+    expect(parseMaconEntry(INTRO_TEXT, SRC)).toBeNull();
+  });
+
+  it("returns null for a labeled paragraph with no parseable date", () => {
+    expect(parseMaconEntry("W3H3 hareline: when we have hares", SRC)).toBeNull();
+  });
+});

--- a/src/adapters/html-scraper/macon-hash.ts
+++ b/src/adapters/html-scraper/macon-hash.ts
@@ -1,0 +1,162 @@
+import type { Source } from "@/generated/prisma/client";
+import type {
+  SourceAdapter,
+  RawEventData,
+  ScrapeResult,
+  ErrorDetails,
+} from "../types";
+import { hasAnyErrors } from "../types";
+import {
+  chronoParseDate,
+  fetchHTMLPage,
+  googleMapsSearchUrl,
+  isPlaceholder,
+} from "../utils";
+
+/**
+ * Macon, GA hash adapter — one HTML source (mgh4.com) feeds BOTH kennels.
+ *
+ * The `/page/next-hash` page (BlogEngine.NET) lists the current/next run for
+ * MGH4 (Middle Georgia Hash, Saturdays) and W3H3 (Wednesdays) as prose
+ * paragraphs, each led by a bold "KENNEL Weekday, Month DD, YYYY" then the
+ * hares / start location / times. Example:
+ *   "W3H3 Wednesday, October 29, 2025, Weedeater is laying a trail starting at
+ *    Washington Park, Macon. In at 6:30, out at 7."
+ *   "MGH4, Saturday, July 19, 2025. Weedeater's birthday trail. Meet at 5650
+ *    Arkwright Rd. Congregate at 1:30, out at 2."
+ *
+ * This is an enrichment source above the two kennels' STATIC_SCHEDULE rows: the
+ * page carries only the imminent run per kennel (often stale — the kennel is
+ * low-activity), so we emit whatever dated entries are present rather than
+ * window-filtering them away. It has no future events today, so it can't
+ * collide with (or phantom against) the static placeholders.
+ */
+
+const NEXT_HASH_URL = "https://mgh4.com/page/next-hash";
+
+/** Map the leading bold kennel label to its kennelCode. */
+function kennelTagFor(label: string): string | undefined {
+  const up = label.toUpperCase();
+  if (up === "MGH4") return "mgh4";
+  if (up === "W3H3") return "w3h3-ga";
+  return undefined;
+}
+
+const DATE_RE =
+  /(?:(?:Sun|Mon|Tues?|Wed(?:nes)?|Thur?s?|Fri|Satur?)[a-z]*,?\s+)?((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4})/i;
+
+/**
+ * Extract a start time from the prose. Prefers the pack-off ("out at N"), then
+ * the gather ("in at" / "congregate at"). Macon runs are afternoon/evening, so
+ * a bare hour below noon is treated as PM (7 → 19:00, 2 → 14:00).
+ */
+export function parseMaconTime(text: string): string | undefined {
+  const out = /\bout\s+at\s+(\d{1,2})(?::(\d{2}))?/i.exec(text);
+  const gather = /(?:\bin\s+at|congregate\s+at)\s+(\d{1,2})(?::(\d{2}))?/i.exec(text);
+  const m = out ?? gather;
+  if (!m) return undefined;
+  let hour = parseInt(m[1], 10);
+  const min = m[2] ?? "00";
+  if (hour < 12) hour += 12; // afternoon/evening hash assumption
+  if (hour > 23) return undefined;
+  return `${String(hour).padStart(2, "0")}:${min}`;
+}
+
+/** Extract the start location after "starting at" / "meet at" / "start at". */
+export function parseMaconLocation(text: string): string | undefined {
+  const m = /(?:starting at|start at|meet at)\s+([^.]+?)(?:\.|$)/i.exec(text);
+  if (!m) return undefined;
+  const loc = m[1].replace(/\s+/g, " ").trim();
+  return loc && !isPlaceholder(loc) ? loc : undefined;
+}
+
+/** Best-effort hare name: "X is laying" or a leading possessive "X's …". */
+export function parseMaconHares(text: string): string | undefined {
+  const laying = /\b([A-Z][a-zA-Z]+)\s+(?:is|are)\s+(?:laying|haring|setting)/.exec(text);
+  if (laying) return laying[1];
+  const poss = /\b([A-Z][a-zA-Z]+)'s\s+\w/.exec(text);
+  return poss ? poss[1] : undefined;
+}
+
+/** Parse one next-hash paragraph into a RawEventData (null if not a run line). */
+export function parseMaconEntry(
+  rawText: string,
+  sourceUrl: string,
+): RawEventData | null {
+  // Normalize NBSPs and collapse whitespace.
+  const text = rawText.replace(/ /g, " ").replace(/\s+/g, " ").trim();
+
+  const labelMatch = /^(MGH4|W3H3)\b/i.exec(text);
+  if (!labelMatch) return null;
+  const kennelTag = kennelTagFor(labelMatch[1]);
+  if (!kennelTag) return null;
+
+  const dateMatch = DATE_RE.exec(text);
+  if (!dateMatch) return null;
+  const date = chronoParseDate(dateMatch[1], "en-US");
+  if (!date) return null;
+
+  const location = parseMaconLocation(text);
+
+  return {
+    date,
+    kennelTags: [kennelTag],
+    startTime: parseMaconTime(text),
+    location,
+    locationUrl: location ? googleMapsSearchUrl(location) : undefined,
+    hares: parseMaconHares(text),
+    sourceUrl,
+  };
+}
+
+/**
+ * Macon (MGH4 + W3H3) next-hash adapter.
+ */
+export class MaconHashAdapter implements SourceAdapter {
+  type = "HTML_SCRAPER" as const;
+
+  async fetch(
+    source: Source,
+    _options?: { days?: number },
+  ): Promise<ScrapeResult> {
+    const sourceUrl = source.url || NEXT_HASH_URL;
+
+    const page = await fetchHTMLPage(sourceUrl);
+    if (!page.ok) return page.result;
+    const { $, fetchDurationMs } = page;
+
+    const events: RawEventData[] = [];
+    const errors: string[] = [];
+    const errorDetails: ErrorDetails = {};
+
+    const paragraphs = $("p").toArray();
+    for (let i = 0; i < paragraphs.length; i++) {
+      const rawText = $(paragraphs[i]).text();
+      try {
+        const event = parseMaconEntry(rawText, sourceUrl);
+        if (event) events.push(event);
+      } catch (err) {
+        errors.push(`Error parsing paragraph ${i}: ${err}`);
+        const parse = (errorDetails.parse ??= []);
+        parse.push({
+          row: i,
+          section: "next-hash",
+          error: String(err),
+          rawText: rawText.trim().slice(0, 2000),
+        });
+      }
+    }
+
+    return {
+      events,
+      errors,
+      errorDetails: hasAnyErrors(errorDetails) ? errorDetails : undefined,
+      diagnosticContext: {
+        fetchMethod: "cheerio",
+        paragraphs: paragraphs.length,
+        eventsParsed: events.length,
+        fetchDurationMs,
+      },
+    };
+  }
+}

--- a/src/adapters/html-scraper/macon-hash.ts
+++ b/src/adapters/html-scraper/macon-hash.ts
@@ -42,8 +42,11 @@ function kennelTagFor(label: string): string | undefined {
   return undefined;
 }
 
-const DATE_RE =
-  /(?:(?:Sun|Mon|Tues?|Wed(?:nes)?|Thur?s?|Fri|Satur?)[a-z]*,?\s+)?((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4})/i;
+// A capitalized month word + day + year, e.g. "October 29, 2025" / "Jul. 19, 2025".
+// chronoParseDate validates the actual month name, so we don't need an explicit
+// month/weekday alternation here (keeps the pattern well under Sonar's complexity
+// budget and avoids catastrophic backtracking).
+const DATE_RE = /[A-Z][a-z]{2,8}\.?\s+\d{1,2},?\s+\d{4}/;
 
 /**
  * Extract a start time from the prose. Prefers the pack-off ("out at N"), then
@@ -55,7 +58,7 @@ export function parseMaconTime(text: string): string | undefined {
   const gather = /(?:\bin\s+at|congregate\s+at)\s+(\d{1,2})(?::(\d{2}))?/i.exec(text);
   const m = out ?? gather;
   if (!m) return undefined;
-  let hour = parseInt(m[1], 10);
+  let hour = Number.parseInt(m[1], 10);
   const min = m[2] ?? "00";
   if (hour < 12) hour += 12; // afternoon/evening hash assumption
   if (hour > 23) return undefined;
@@ -64,9 +67,11 @@ export function parseMaconTime(text: string): string | undefined {
 
 /** Extract the start location after "starting at" / "meet at" / "start at". */
 export function parseMaconLocation(text: string): string | undefined {
-  const m = /(?:starting at|start at|meet at)\s+([^.]+?)(?:\.|$)/i.exec(text);
+  // `[^.]+` is greedy and can't match a period, so it stops at the first "." or
+  // end of string with no backtracking — no lazy `+?`/`$` alternation needed.
+  const m = /(?:start(?:ing)? at|meet at)\s+([^.]+)/i.exec(text);
   if (!m) return undefined;
-  const loc = m[1].replace(/\s+/g, " ").trim();
+  const loc = m[1].replaceAll(/\s+/g, " ").trim();
   return loc && !isPlaceholder(loc) ? loc : undefined;
 }
 
@@ -83,8 +88,8 @@ export function parseMaconEntry(
   rawText: string,
   sourceUrl: string,
 ): RawEventData | null {
-  // Normalize NBSPs and collapse whitespace.
-  const text = rawText.replace(/ /g, " ").replace(/\s+/g, " ").trim();
+  // Collapse all whitespace (incl. the page’s &nbsp; runs — \s matches U+00A0).
+  const text = rawText.replaceAll(/\s+/g, " ").trim();
 
   const labelMatch = /^(MGH4|W3H3)\b/i.exec(text);
   if (!labelMatch) return null;
@@ -93,7 +98,7 @@ export function parseMaconEntry(
 
   const dateMatch = DATE_RE.exec(text);
   if (!dateMatch) return null;
-  const date = chronoParseDate(dateMatch[1], "en-US");
+  const date = chronoParseDate(dateMatch[0], "en-US");
   if (!date) return null;
 
   const location = parseMaconLocation(text);

--- a/src/adapters/html-scraper/macon-hash.ts
+++ b/src/adapters/html-scraper/macon-hash.ts
@@ -76,8 +76,13 @@ const LOCATION_BOUNDARIES = [
   "on on",
 ];
 
-/** Extract the start location after "starting at" / "meet at" / "start at". */
-export function parseMaconLocation(text: string): string | undefined {
+/**
+ * Extract the start location after "starting at" / "meet at" / "start at".
+ * Returns `undefined` when there's no location phrase at all (no signal —
+ * merge preserves the existing value), and `null` when a phrase is present but
+ * resolves to a placeholder ("TBA"/"TBD"), so a stale venue/pin gets cleared.
+ */
+export function parseMaconLocation(text: string): string | null | undefined {
   const m = /(?:start(?:ing)? at|meet at)\s+(\S.*)/i.exec(text);
   if (!m) return undefined;
   const rest = m[1];
@@ -96,7 +101,7 @@ export function parseMaconLocation(text: string): string | undefined {
     .trim()
     .replace(/[.,;]+$/, "")
     .trim();
-  return loc && !isPlaceholder(loc) ? loc : undefined;
+  return loc && !isPlaceholder(loc) ? loc : null;
 }
 
 // Trailing run of Capitalized words (joined by space / "and" / "&" / comma),

--- a/src/adapters/html-scraper/macon-hash.ts
+++ b/src/adapters/html-scraper/macon-hash.ts
@@ -83,9 +83,11 @@ const LOCATION_BOUNDARIES = [
  * resolves to a placeholder ("TBA"/"TBD"), so a stale venue/pin gets cleared.
  */
 export function parseMaconLocation(text: string): string | null | undefined {
-  const m = /(?:start(?:ing)? at|meet at)\s+(\S.*)/i.exec(text);
-  if (!m) return undefined;
-  const rest = m[1];
+  // Find the "meet at" / "starting at" marker, then slice the rest procedurally
+  // (a capturing `\s+(.*)` would be a super-linear backtracking shape).
+  const marker = /(?:start(?:ing)? at|meet at)\s/i.exec(text);
+  if (!marker) return undefined;
+  const rest = text.slice(marker.index + marker[0].length).trimStart();
   const lower = rest.toLowerCase();
   // Cut at the first trailing boilerplate boundary rather than the first period,
   // so mid-string abbreviations ("St." / "Rd.") aren't truncated.
@@ -104,25 +106,34 @@ export function parseMaconLocation(text: string): string | null | undefined {
   return loc && !isPlaceholder(loc) ? loc : null;
 }
 
-// Trailing run of Capitalized words (joined by space / "and" / "&" / comma),
-// anchored at $. Bounded ({0,6}) and using char classes (not overlapping \s
-// quantifiers) so it can't backtrack catastrophically.
-const HARE_RUN_RE =
-  /(?:[A-Z][a-zA-Z]+)(?:[ ,&]+(?:and\s+)?[A-Z][a-zA-Z]+){0,6}$/;
+const HARE_VERB_RE = /\b(?:is|are)\s+(?:laying|haring|setting)\b/i;
+const NAME_TOKEN_RE = /^[A-Z][a-zA-Z]+$/;
 
 /**
  * Best-effort hare name(s): the run of names before "is/are laying|haring|setting",
  * or a leading possessive "X's …". Handles single, multi-word, and multi-hare
- * lists ("Weedeater and Hash Trash").
+ * lists ("Weedeater and Hash Trash"). Scans tokens backward (no complex regex)
+ * so there's no catastrophic-backtracking surface.
  */
 export function parseMaconHares(text: string): string | undefined {
-  const verb = /\b(?:is|are)\s+(?:laying|haring|setting)\b/i.exec(text);
+  const verb = HARE_VERB_RE.exec(text);
   if (verb) {
-    const before = text.slice(0, verb.index).trimEnd();
-    const run = HARE_RUN_RE.exec(before);
-    if (run) return run[0].replaceAll(/\s+/g, " ").trim();
+    const before = text.slice(0, verb.index).trim();
+    const tokens = before.split(/\s+/);
+    const names: string[] = [];
+    for (let i = tokens.length - 1; i >= 0; i--) {
+      const bare = tokens[i].replace(/,$/, "");
+      if (NAME_TOKEN_RE.test(bare)) {
+        names.unshift(bare);
+      } else if ((bare === "and" || bare === "&") && names.length > 0) {
+        names.unshift(bare);
+      } else {
+        break;
+      }
+    }
+    if (names.length > 0) return names.join(" ");
   }
-  const poss = /\b([A-Z][a-zA-Z]+)'s\s+\w/.exec(text);
+  const poss = /\b([A-Z][a-zA-Z]+)'s\s/.exec(text);
   return poss ? poss[1] : undefined;
 }
 

--- a/src/adapters/html-scraper/macon-hash.ts
+++ b/src/adapters/html-scraper/macon-hash.ts
@@ -65,20 +65,58 @@ export function parseMaconTime(text: string): string | undefined {
   return `${String(hour).padStart(2, "0")}:${min}`;
 }
 
+/** Boilerplate that follows the start location in the prose (times, "bring", on-after). */
+const LOCATION_BOUNDARIES = [
+  "in at",
+  "out at",
+  "congregate at",
+  "bring",
+  "pack off",
+  "on-on",
+  "on on",
+];
+
 /** Extract the start location after "starting at" / "meet at" / "start at". */
 export function parseMaconLocation(text: string): string | undefined {
-  // `[^.]+` is greedy and can't match a period, so it stops at the first "." or
-  // end of string with no backtracking — no lazy `+?`/`$` alternation needed.
-  const m = /(?:start(?:ing)? at|meet at)\s+([^.]+)/i.exec(text);
+  const m = /(?:start(?:ing)? at|meet at)\s+(\S.*)/i.exec(text);
   if (!m) return undefined;
-  const loc = m[1].replaceAll(/\s+/g, " ").trim();
+  const rest = m[1];
+  const lower = rest.toLowerCase();
+  // Cut at the first trailing boilerplate boundary rather than the first period,
+  // so mid-string abbreviations ("St." / "Rd.") aren't truncated.
+  let end = rest.length;
+  for (const b of LOCATION_BOUNDARIES) {
+    const idx = lower.indexOf(b);
+    if (idx !== -1 && idx < end) end = idx;
+  }
+  // Drop only trailing sentence punctuation (keeps a mid-string "St."/"Rd.").
+  const loc = rest
+    .slice(0, end)
+    .replaceAll(/\s+/g, " ")
+    .trim()
+    .replace(/[.,;]+$/, "")
+    .trim();
   return loc && !isPlaceholder(loc) ? loc : undefined;
 }
 
-/** Best-effort hare name: "X is laying" or a leading possessive "X's …". */
+// Trailing run of Capitalized words (joined by space / "and" / "&" / comma),
+// anchored at $. Bounded ({0,6}) and using char classes (not overlapping \s
+// quantifiers) so it can't backtrack catastrophically.
+const HARE_RUN_RE =
+  /(?:[A-Z][a-zA-Z]+)(?:[ ,&]+(?:and\s+)?[A-Z][a-zA-Z]+){0,6}$/;
+
+/**
+ * Best-effort hare name(s): the run of names before "is/are laying|haring|setting",
+ * or a leading possessive "X's …". Handles single, multi-word, and multi-hare
+ * lists ("Weedeater and Hash Trash").
+ */
 export function parseMaconHares(text: string): string | undefined {
-  const laying = /\b([A-Z][a-zA-Z]+)\s+(?:is|are)\s+(?:laying|haring|setting)/.exec(text);
-  if (laying) return laying[1];
+  const verb = /\b(?:is|are)\s+(?:laying|haring|setting)\b/i.exec(text);
+  if (verb) {
+    const before = text.slice(0, verb.index).trimEnd();
+    const run = HARE_RUN_RE.exec(before);
+    if (run) return run[0].replaceAll(/\s+/g, " ").trim();
+  }
   const poss = /\b([A-Z][a-zA-Z]+)'s\s+\w/.exec(text);
   return poss ? poss[1] : undefined;
 }

--- a/src/adapters/html-scraper/macon-hash.ts
+++ b/src/adapters/html-scraper/macon-hash.ts
@@ -97,12 +97,12 @@ export function parseMaconLocation(text: string): string | null | undefined {
     if (idx !== -1 && idx < end) end = idx;
   }
   // Drop only trailing sentence punctuation (keeps a mid-string "St."/"Rd.").
-  const loc = rest
-    .slice(0, end)
-    .replaceAll(/\s+/g, " ")
-    .trim()
-    .replace(/[.,;]+$/, "")
-    .trim();
+  // Done procedurally so there's no regex for the analyzer to flag.
+  let loc = rest.slice(0, end).replaceAll(/\s+/g, " ").trim();
+  while (loc.length > 0 && ".,;".includes(loc.charAt(loc.length - 1))) {
+    loc = loc.slice(0, -1);
+  }
+  loc = loc.trim();
   return loc && !isPlaceholder(loc) ? loc : null;
 }
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -43,6 +43,7 @@ import { HockessinAdapter } from "./html-scraper/hockessin";
 import { RenegadeH3Adapter } from "./html-scraper/renegade-h3";
 import { SWH3Adapter } from "./html-scraper/swh3";
 import { GATRH3Adapter } from "./html-scraper/gatrh3";
+import { MaconHashAdapter } from "./html-scraper/macon-hash";
 import { ONH3Adapter } from "./html-scraper/onh3";
 import { AsuncionH3Adapter } from "./html-scraper/asuncion-h3";
 import { SDH3Adapter } from "./html-scraper/sdh3";
@@ -227,6 +228,7 @@ const htmlScraperEntries: HtmlScraperEntry[] = [
   { pattern: /renegadeh3\.com/i,       name: "RenegadeH3Adapter",        factory: () => new RenegadeH3Adapter() },
   { pattern: /swh3\.wordpress\.com/i, name: "SWH3Adapter",              factory: () => new SWH3Adapter() },
   { pattern: /gatrh3\.wordpress\.com/i, name: "GATRH3Adapter",           factory: () => new GATRH3Adapter() },
+  { pattern: /mgh4\.com/i,             name: "MaconHashAdapter",         factory: () => new MaconHashAdapter() },
   // `\b` anchor required: an unanchored `onh3\.wordpress\.com` matches the
   // SUBSTRING inside `asunci‹onh3›.wordpress.com` (and `secessi‹onh3›…`), so it
   // shadowed AsuncionH3Adapter — every Asunción cron scrape mis-routed to the


### PR DESCRIPTION
## Summary

Onboards the two Macon, GA kennels — **MGH4** (Middle Georgia Hash) and **W3H3** — which were `STATIC_SCHEDULE`-only. This is onboarding-queue item #2 from the static-only audit (#2645).

`mgh4.com/page/next-hash` publishes the current/next run for **both** kennels as prose paragraphs, each led by a bold `KENNEL Weekday, Month DD, YYYY` then hares / start location / times.

## Changes
- **`MaconHashAdapter`** (Cheerio) — one source, both kennels: each `<p>` is routed by its leading `MGH4`/`W3H3` label. Registered on the `mgh4.com` URL pattern.
- **Seed:** one trust-7 `HTML_SCRAPER` source ("MGH4 & W3H3 Next Hash") linked to both `kennelCodes` `["mgh4","w3h3-ga"]`, above the existing static rows.
- Time parsing prefers pack-off (`out at N`) over gather and PM-normalizes (afternoon/evening hash); location from `starting at`/`meet at`; hares best-effort from `X is laying`/possessive.

### Why the static rows stay enabled (unlike GATR in #2645)
The next-hash page carries only **past** runs today (no future dates), so it can't collide with — or phantom against — the static placeholders. The static rows remain the forward-looking backbone; this HTML source enriches real dates and will supersede the placeholder on any future date the kennel actually posts.

### Live verification
Ran the adapter against the live page: **2 events, 0 errors** —
- W3H3 → `2025-10-29`, 19:00, Washington Park, Macon
- MGH4 → `2025-07-19`, 14:00, 5650 Arkwright Rd

**Caveat:** the site itself notes it's "having trouble getting people to hare trails" — output is thin/dormant until the kennel resumes posting.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 340 files, 9990 tests pass
- [x] Live-verified adapter against the production page (8 unit tests use real markup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)