### PR TITLE
fix(hebe-h3,jb-h3): correct static schedules from verification pass

### DIFF
--- a/prisma/seed-data/sources.test.ts
+++ b/prisma/seed-data/sources.test.ts
@@ -56,6 +56,8 @@ describe("SOURCES seed data invariants (#817 regression guard)", () => {
     { name: "Kluang H3 Static Schedule", tag: "kluang-h3", rrule: "FREQ=WEEKLY;BYDAY=WE", startTime: "18:00", issue: 1431 },
     { name: "Kuching H3 Static Schedule", tag: "kuching-h3", rrule: "FREQ=WEEKLY;BYDAY=TU", startTime: "17:30", issue: 1535 },
     { name: "KK H3 Static Schedule", tag: "kk-h3", rrule: "FREQ=WEEKLY;BYDAY=MO", startTime: "16:30", issue: 1537 },
+    // static-only-audit: JB H3 corrected SA→WE (FB run dates all Wednesdays; original JBHHH).
+    { name: "JB H3 Static Schedule", tag: "jb-h3", rrule: "FREQ=WEEKLY;BYDAY=WE", startTime: "17:00", issue: 0 },
   ])("(#$issue) $name emits $rrule @ $startTime, not Saturday @ 17:00", ({ name, tag, rrule, startTime }) => {
     const src = SOURCES.find((s) => s.name === name);
     expect(src).toBeDefined();

--- a/prisma/seed-data/sources.test.ts
+++ b/prisma/seed-data/sources.test.ts
@@ -56,8 +56,8 @@ describe("SOURCES seed data invariants (#817 regression guard)", () => {
     { name: "Kluang H3 Static Schedule", tag: "kluang-h3", rrule: "FREQ=WEEKLY;BYDAY=WE", startTime: "18:00", issue: 1431 },
     { name: "Kuching H3 Static Schedule", tag: "kuching-h3", rrule: "FREQ=WEEKLY;BYDAY=TU", startTime: "17:30", issue: 1535 },
     { name: "KK H3 Static Schedule", tag: "kk-h3", rrule: "FREQ=WEEKLY;BYDAY=MO", startTime: "16:30", issue: 1537 },
-    // static-only-audit: JB H3 corrected SA→WE (FB run dates all Wednesdays; original JBHHH).
-    { name: "JB H3 Static Schedule", tag: "jb-h3", rrule: "FREQ=WEEKLY;BYDAY=WE", startTime: "17:00", issue: 0 },
+    // #1942: JB H3 corrected SA→WE (FB run dates all Wednesdays; original JBHHH).
+    { name: "JB H3 Static Schedule", tag: "jb-h3", rrule: "FREQ=WEEKLY;BYDAY=WE", startTime: "17:00", issue: 1942 },
   ])("(#$issue) $name emits $rrule @ $startTime, not Saturday @ 17:00", ({ name, tag, rrule, startTime }) => {
     const src = SOURCES.find((s) => s.name === name);
     expect(src).toBeDefined();

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -5946,10 +5946,11 @@ export const SOURCES = [
       kennelCodes: ["ipoh-h3"],
     },
     {
-      // #1942: Saturday 17:00 is UNVERIFIED — facebook.com/tjbhhh is login-walled and
-      // no reachable Malaysian directory confirms the current cadence. Conflicting
-      // historical evidence (a 2010 circular + colahhh.blogspot.com) says Wednesday.
-      // Kept as documented in triage PR #1512 until a Johor-area hasher confirms.
+      // #static-only-audit: corrected to WEDNESDAY, confirming the Wednesday
+      // suspicion #1942/#1512 flagged. facebook.com/tjbhhh run dates 29-Oct-2025,
+      // 12-Nov-2025 and 13-May-2026 all fall on Wednesdays (this is the original
+      // JBHHH, Johor's oldest kennel — not a Saturday "JB City Hash"). Evening
+      // start time kept as a placeholder pending a precise time from a member.
       name: "JB H3 Static Schedule",
       url: "https://www.facebook.com/tjbhhh",
       type: "STATIC_SCHEDULE" as const,
@@ -5958,11 +5959,11 @@ export const SOURCES = [
       scrapeDays: 90,
       config: {
         kennelTag: "jb-h3",
-        rrule: "FREQ=WEEKLY;BYDAY=SA",
+        rrule: "FREQ=WEEKLY;BYDAY=WE",
         startTime: "17:00",
         defaultTitle: "JB H3 Weekly Run",
         defaultLocation: "Johor Bahru, Johor, Malaysia",
-        defaultDescription: "Weekly Saturday evening trail. Founded 1969, the oldest hash kennel in Johor. See Facebook page at facebook.com/tjbhhh for trail details.",
+        defaultDescription: "Weekly Wednesday evening trail. Founded 1969, the oldest hash kennel in Johor (original JBHHH). See Facebook page at facebook.com/tjbhhh for trail details.",
       },
       kennelCodes: ["jb-h3"],
     },
@@ -6228,10 +6229,13 @@ export const SOURCES = [
       scrapeDays: 90,
       config: {
         kennelTag: "hebe-h3",
-        // #1388 / #1390: canonical 1st-Saturday RRULE (was misleading BYSETPOS=3;
-        // parser silently ignored it and emitted 1st Saturdays anyway). No event-
-        // date change.
-        rrule: "FREQ=MONTHLY;BYDAY=1SA",
+        // #static-only-audit: restore the 3rd-Saturday intent. The original config
+        // was BYSETPOS=3 (3rd Sat); a parser bug ignored it and #1388/#1390
+        // "canonicalized" to 1SA to match the buggy 1st-Sat emission (not because
+        // 1st was verified). The china.hash.cn/hkmacao directory and the 2026 FB
+        // Activity check both confirm a live monthly Saturday at 15:00, and 3rd-Sat
+        // matches the original author intent.
+        rrule: "FREQ=MONTHLY;BYDAY=3SA",
         startTime: "15:00",
         defaultTitle: "Hebe H3 Monthly Run",
         defaultLocation: "Sai Kung, Hong Kong",


### PR DESCRIPTION
## Summary

Two well-grounded `STATIC_SCHEDULE` day corrections surfaced by the static-only audit's Facebook/web verification pass (#2645, #2647).

### `hebe-h3`: 1st Saturday → **3rd Saturday**
The current `BYDAY=1SA` isn't a verified choice — the seed comment shows the *original* config was `BYSETPOS=3` (3rd Sat), and a parser bug made #1388/#1390 "canonicalize" to `1SA` just to match the buggy 1st-Sat emission. The `china.hash.cn/hkmacao` directory **and** the 2026 FB Activity check both confirm a live monthly Saturday at 15:00, and 3rd-Sat restores the original author intent. (Time already 15:00 — unchanged.)

### `jb-h3`: weekly Saturday → **weekly Wednesday**
Confirms the Wednesday suspicion #1942/#1512 already flagged ("kept as Saturday until a Johor-area hasher confirms"). `facebook.com/tjbhhh` run dates **29-Oct-2025, 12-Nov-2025, 13-May-2026 all fall on Wednesdays** — this is the original JBHHH (Johor's oldest kennel), not a Saturday "JB City Hash." Added to the SE-Asia weekly-day regression guard so it can't silently revert.

## Deliberately NOT changed
- **`hkfh3`** — the exact week (2nd vs 3rd Friday) can't be pinned from available evidence, and changing it reverses a *deliberate* original 1st-Friday. Left as-is pending one member's confirmation of the exact Friday.
- **`kk-h3`** — a Friday signal exists but it reverses the test-guarded Monday (#1537) and multiple KK kennels muddy the identity. Held.

## ⚠️ Post-merge step required
`STATIC_SCHEDULE` config is **not** applied by Vercel deploys (seed isn't run in prod). After merge, a targeted prod `Source.config` UPDATE for these two sources + a re-scrape is needed, then reconcile clears the old-date placeholder events (hebe 1st-Sat, jb Saturday). Happy to run that.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] seed-data tests pass (jb-h3 added to the day-regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)