### PR TITLE
fix(seed): guard prisma/seed.ts main() behind an entry-point check

### DIFF
--- a/docs/kennel-onboarding/handoffs/retros/2026-07-15-hc-batch-6-retro.md
+++ b/docs/kennel-onboarding/handoffs/retros/2026-07-15-hc-batch-6-retro.md
@@ -208,6 +208,30 @@ await applyUpserts(prisma, planned);                 // NOT runScheduleRuleBackf
    one to the HC config would let live + backfill share a single rule. Blast radius today is one
    kennel, so this is a follow-up, not a blocker.
 
+## Post-merge incident — importing `prisma/seed.ts` auto-runs the FULL seed
+
+The post-merge runbook says "targeted `seedKennels`". Reusing the *real* tested `seedKennels` means
+importing it — but **`prisma/seed.ts` has an unguarded top-level `main().catch()`**, so
+`import { seedKennels } from "./prisma/seed"` fired the entire full seed as an import side effect,
+running concurrently with the scoped call against prod. The tell was a string of misleading `P2002`
+"unique on (name)" errors on region names that didn't exist (two racing `create`s) — which looked like
+a driver / prepared-statement bug and cost real time to chase before the double `main()` was spotted.
+
+The scoped one-shot's `process.exit(0)` killed the runaway `main()` right after region creation, so the
+damage was near-zero (only the 6 batch kennels touched; no other configs; `deactivateStaleRules` never
+ran). But the trap is real and will recur.
+
+> **Fix (shipped as a follow-up PR):** add the entry-point guard `scripts/backfill-schedule-rules.ts`
+> already uses — `const entryPoint = (process.argv[1] ?? "").replace(/\\/g,"/"); if
+> (entryPoint.endsWith("/seed.ts")) main()...` — so importing `prisma/seed.ts` is inert and only
+> `npx prisma db seed` / direct exec runs it.
+>
+> **Rule for the runbook:** a scoped post-merge seed must **never** `import` from `prisma/seed.ts`.
+> Write self-contained upserts against the `@/lib/db` singleton, and for scoped Pass 3 import from the
+> already-guarded `scripts/backfill-schedule-rules.ts` (`runKennelSeedPass` + `applyUpserts`). Read the
+> prod `DATABASE_URL` from the **main repo** `.env` (the worktree's may point at the local dev DB) and
+> pass it explicitly with a host guard.
+
 ## TL;DR for the research prompt + platform notes
 
 1. **🔴 Commit the daily run's output.** Six kennels were invisible for six days because their handoffs

--- a/docs/kennel-onboarding/handoffs/retros/2026-07-15-hc-batch-6-retro.md
+++ b/docs/kennel-onboarding/handoffs/retros/2026-07-15-hc-batch-6-retro.md
@@ -222,7 +222,7 @@ damage was near-zero (only the 6 batch kennels touched; no other configs; `deact
 ran). But the trap is real and will recur.
 
 > **Fix ([PR #2655](https://github.com/johnrclem/hashtracks-web/pull/2655)):** add the entry-point guard `scripts/backfill-schedule-rules.ts`
-> already uses — `const entryPoint = (process.argv[1] ?? "").replace(/\\/g,"/"); if
+> already uses — `const entryPoint = (process.argv[1] ?? "").replaceAll("\\","/"); if
 > (entryPoint.endsWith("/seed.ts")) main()...` — so importing `prisma/seed.ts` is inert and only
 > `npx prisma db seed` / direct exec runs it.
 >

--- a/docs/kennel-onboarding/handoffs/retros/2026-07-15-hc-batch-6-retro.md
+++ b/docs/kennel-onboarding/handoffs/retros/2026-07-15-hc-batch-6-retro.md
@@ -221,7 +221,7 @@ The scoped one-shot's `process.exit(0)` killed the runaway `main()` right after 
 damage was near-zero (only the 6 batch kennels touched; no other configs; `deactivateStaleRules` never
 ran). But the trap is real and will recur.
 
-> **Fix (shipped as a follow-up PR):** add the entry-point guard `scripts/backfill-schedule-rules.ts`
+> **Fix ([PR #2655](https://github.com/johnrclem/hashtracks-web/pull/2655)):** add the entry-point guard `scripts/backfill-schedule-rules.ts`
 > already uses — `const entryPoint = (process.argv[1] ?? "").replace(/\\/g,"/"); if
 > (entryPoint.endsWith("/seed.ts")) main()...` — so importing `prisma/seed.ts` is inert and only
 > `npx prisma db seed` / direct exec runs it.

--- a/docs/kennel-onboarding/run-log.md
+++ b/docs/kennel-onboarding/run-log.md
@@ -12,6 +12,30 @@ Format:
 - Follow-ups: <anything deferred>
 ```
 
+> **✅ POST-MERGE LIVE (2026-07-16, all prod-verified) — HC BATCH-6.** [PR #2654](https://github.com/johnrclem/hashtracks-web/pull/2654)
+> merged (`71d5ca1f`); all 6 kennels live: **rio-h3 3 · poznan-h3 3 · divahhh 9 · steel-city-h3 1 ·
+> manchester-h3 3 · douliu-h3 31** canonical events (46 backfill + 4 live), **0 cancelled on every
+> source** (the `upcomingOnly` reconcile contract held), correct region badges, all 6 `/kennels/*` +
+> all 6 `/kennel-logos/*` serve 200. Scoped **Pass 3** created the 4 `scheduleRules` (mh3-gb 3 ·
+> douliu-h3 1) via `runKennelSeedPass` + `applyUpserts` (Taoyuan precedent — NOT the global
+> `runScheduleRuleBackfill`). Steel City & Manchester shipped **live-only** (0 backfill); the other 4
+> are backfill + 0-upcoming (recently-active, expected). Divahhh landed **9** — the same-day #39/#40
+> Walkers/Runners collapse guard held in the real merge (both survived, not 8).
+>
+> 🔴 **Incident during the post-merge seed — importing `prisma/seed.ts` auto-runs the FULL seed.** The
+> scoped-seed one-shot `import`ed `seedKennels` from `prisma/seed.ts`, whose **unguarded top-level
+> `main().catch()`** fired the entire full seed as an import side effect, running **concurrently** with
+> the scoped call against prod. That concurrency (two racing `region.create`s) produced misleading
+> `P2002` "unique on (name)" errors on names that didn't exist — not a driver bug, self-inflicted. The
+> one-shot's `process.exit(0)` then killed the runaway `main()` **very early, right after region
+> creation**, so the blast radius was near-zero: only the 6 batch kennels were touched (no other kennel
+> profile overwritten), **zero** other source configs changed (the 17 other sources touched in the hour
+> were all routine scrape-cron), and `deactivateStaleRules` never ran (schedule rules 447→451 = only the
+> +4 mine, 78 inactive unchanged). **Fix follow-up: [PR #TBD] adds an entry-point guard to
+> `prisma/seed.ts`** so importing it is inert (mirrors `scripts/backfill-schedule-rules.ts`). Lesson:
+> never `import` from `prisma/seed.ts` in a one-shot; write self-contained upserts, or import from the
+> entry-point-guarded `scripts/backfill-schedule-rules.ts` for scoped Pass 3.
+
 > **2026-07-15 — HC BATCH-6 SHIPPED (Rio · Poznan · Divahhh · Steel City · Manchester · Douliu).** The
 > six config-only `HARRIER_CENTRAL` handoffs from the 2026-07-10→15 daily runs — **generated but never
 > implemented** — were built in **one batch PR** (hc-batch-4 #2622 / hc-batch-10 #2526 precedent). Zero

--- a/docs/kennel-onboarding/run-log.md
+++ b/docs/kennel-onboarding/run-log.md
@@ -31,7 +31,7 @@ Format:
 > creation**, so the blast radius was near-zero: only the 6 batch kennels were touched (no other kennel
 > profile overwritten), **zero** other source configs changed (the 17 other sources touched in the hour
 > were all routine scrape-cron), and `deactivateStaleRules` never ran (schedule rules 447→451 = only the
-> +4 mine, 78 inactive unchanged). **Fix follow-up: [PR #TBD] adds an entry-point guard to
+> +4 mine, 78 inactive unchanged). **Fix follow-up: [PR #2655](https://github.com/johnrclem/hashtracks-web/pull/2655) adds an entry-point guard to
 > `prisma/seed.ts`** so importing it is inert (mirrors `scripts/backfill-schedule-rules.ts`). Lesson:
 > never `import` from `prisma/seed.ts` in a one-shot; write self-contained upserts, or import from the
 > entry-point-guarded `scripts/backfill-schedule-rules.ts` for scoped Pass 3.

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -764,7 +764,17 @@ async function main() {
   await prisma.$disconnect();
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+// Only run the full seed when this file is executed directly (via the Prisma
+// seed command `npx tsx prisma/seed.ts`), NOT when it is imported. Without this
+// guard, any `import { seedKennels, toSlug } from "./prisma/seed"` — e.g. a
+// scoped post-merge one-shot reusing seedKennels — silently fires the ENTIRE
+// full seed as an import side effect (overwriting every kennel/source + running
+// the global schedule-rule backfill). tsx sets process.argv[1] to the absolute
+// path of the invoked script. Mirrors the guard in scripts/backfill-schedule-rules.ts.
+const entryPoint = (process.argv[1] ?? "").replace(/\\/g, "/");
+if (entryPoint.endsWith("/seed.ts") || entryPoint.endsWith("prisma/seed.ts")) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -771,7 +771,7 @@ async function main() {
 // full seed as an import side effect (overwriting every kennel/source + running
 // the global schedule-rule backfill). tsx sets process.argv[1] to the absolute
 // path of the invoked script. Mirrors the guard in scripts/backfill-schedule-rules.ts.
-const entryPoint = (process.argv[1] ?? "").replace(/\\/g, "/");
+const entryPoint = (process.argv[1] ?? "").replaceAll("\\", "/");
 if (entryPoint.endsWith("/seed.ts") || entryPoint.endsWith("prisma/seed.ts")) {
   main().catch((e) => {
     console.error(e);


### PR DESCRIPTION
## The bug

`prisma/seed.ts` ends with an **unguarded top-level `main().catch(...)`**. So *any* `import { seedKennels, toSlug } from "./prisma/seed"` fires the **entire full seed** as an import side effect — `seedKennels` over all ~515 kennels + ~443 sources (overwriting profile fields + source config) **plus** the global `runScheduleRuleBackfill` (which runs `deactivateStaleRules`). This is exactly the full seed the post-merge runbook forbids (barbados #2471).

## How it bit us

During the hc-batch-6 post-merge ([#2654](https://github.com/johnrclem/hashtracks-web/pull/2654)), a scoped-seed one-shot imported `seedKennels` to reuse it with filtered arrays — and unknowingly ran a **full seed concurrently** against prod. The tell was a run of misleading `P2002` "unique constraint on (name)" errors on region names that **didn't exist** — two racing `region.create()`s from the two `main()`s. It looked like a driver / prepared-statement bug and cost real time to chase before the double `main()` was spotted.

Blast radius stayed **near-zero** only by luck: the one-shot's `process.exit(0)` killed the runaway `main()` right after region creation, before the table-wide overwrite stages. Verified against prod afterward — only the 6 batch kennels touched, zero other source configs changed, `deactivateStaleRules` never ran.

## The fix

Guard `main()` behind the same entry-point check `scripts/backfill-schedule-rules.ts` **already uses**, so importing `seed.ts` is inert and only `npx prisma db seed` / direct `npx tsx prisma/seed.ts` runs it:

```ts
const entryPoint = (process.argv[1] ?? "").replace(/\\/g, "/");
if (entryPoint.endsWith("/seed.ts") || entryPoint.endsWith("prisma/seed.ts")) {
  main().catch((e) => { console.error(e); process.exit(1); });
}
```

The Prisma seed command is `npx tsx prisma/seed.ts` (`prisma.config.ts`), so `process.argv[1]` is the absolute path ending `/seed.ts` — the guard passes for direct execution.

## Verification

- **Import is now inert:** `import { seedKennels, toSlug } from "./prisma/seed"` runs no seed output / no DB connection; `toSlug` still exports (`seedKennels` remains intentionally un-exported).
- **Direct execution still works:** `npx tsx prisma/seed.ts` against the local dev DB runs the full seed to `Seed complete!`.
- `npx tsc --noEmit` → 0 errors · `npm run lint` → 0 errors (22 pre-existing warnings, none here) · `npm test` → **9998 passed**.
- No file in the repo imports `prisma/seed` expecting the `main()` side effect (grep-confirmed).

## Docs (in this PR)

- `run-log.md`: **POST-MERGE LIVE** record for hc-batch-6 (6 kennels live, 46 backfill events, 0 cancelled on every source, scoped Pass 3) + the seed.ts import incident.
- `2026-07-15-hc-batch-6-retro.md`: a post-merge-incident section documenting the trap, the fix, and the runbook rule (never `import` from `prisma/seed.ts`; use self-contained upserts or the guarded `scripts/backfill-schedule-rules.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)